### PR TITLE
24-3: Fix disabled use virtual addressing option for import from S3 (#9162)

### DIFF
--- a/ydb/core/kqp/ut/federated_query/s3/s3_recipe_ut_helpers.cpp
+++ b/ydb/core/kqp/ut/federated_query/s3/s3_recipe_ut_helpers.cpp
@@ -1,146 +1,18 @@
 #include "s3_recipe_ut_helpers.h"
 
 #include <ydb/library/yql/providers/s3/actors/yql_s3_actors_factory_impl.h>
-#include <library/cpp/testing/hook/hook.h>
-
-#include <util/string/builder.h>
-
-#include <aws/core/Aws.h>
-
-Y_TEST_HOOK_BEFORE_RUN(InitAwsAPI) {
-    Aws::InitAPI(Aws::SDKOptions());
-}
-
-Y_TEST_HOOK_AFTER_RUN(ShutdownAwsAPI) {
-    Aws::ShutdownAPI(Aws::SDKOptions());
-}
 
 namespace NTestUtils {
 
-    extern const TString TEST_SCHEMA = R"(["StructType";[["key";["DataType";"Utf8";];];["value";["DataType";"Utf8";];];];])";
+using std::shared_ptr;
+using namespace NKikimr::NKqp;
 
-    extern const TString TEST_SCHEMA_IDS = R"(["StructType";[["key";["DataType";"Utf8";];];];])";
+const TString TEST_SCHEMA = R"(["StructType";[["key";["DataType";"Utf8";];];["value";["DataType";"Utf8";];];];])";
+const TString TEST_SCHEMA_IDS = R"(["StructType";[["key";["DataType";"Utf8";];];];])";
 
-    std::shared_ptr<NKikimr::NKqp::TKikimrRunner> MakeKikimrRunner(std::optional<NKikimrConfig::TAppConfig> appConfig, const TString& domainRoot) {
-        return NKikimr::NKqp::NFederatedQueryTest::MakeKikimrRunner(true, nullptr, nullptr, appConfig, NYql::NDq::CreateS3ActorsFactory(), domainRoot);
-    }
+shared_ptr<TKikimrRunner> MakeKikimrRunner(std::optional<NKikimrConfig::TAppConfig> appConfig, const TString& domainRoot)
+{
+    return NFederatedQueryTest::MakeKikimrRunner(true, nullptr, nullptr, appConfig, NYql::NDq::CreateS3ActorsFactory(), domainRoot);
+}
 
-    Aws::S3::S3Client MakeS3Client() {
-        Aws::Client::ClientConfiguration s3ClientConfig;
-        s3ClientConfig.endpointOverride = GetEnv("S3_ENDPOINT");
-        s3ClientConfig.scheme = Aws::Http::Scheme::HTTP;
-        return Aws::S3::S3Client(
-            std::make_shared<Aws::Auth::AnonymousAWSCredentialsProvider>(),
-            s3ClientConfig,
-            Aws::Client::AWSAuthV4Signer::PayloadSigningPolicy::Never,
-            /*useVirtualAddressing=*/true);
-    }
-
-    void CreateBucket(const TString& bucket, Aws::S3::S3Client& s3Client) {
-        Aws::S3::Model::CreateBucketRequest req;
-        req.SetBucket(bucket);
-        req.SetACL(Aws::S3::Model::BucketCannedACL::public_read_write);
-        const Aws::S3::Model::CreateBucketOutcome result = s3Client.CreateBucket(req);
-        UNIT_ASSERT_C(result.IsSuccess(), "Error creating bucket \"" << bucket << "\": " << result.GetError().GetExceptionName() << ": " << result.GetError().GetMessage());
-    }
-
-    void CreateBucket(const TString& bucket) {
-        Aws::S3::S3Client s3Client = MakeS3Client();
-
-        CreateBucket(bucket, s3Client);
-    }
-
-    void UploadObject(const TString& bucket, const TString& object, const TStringBuf& content, Aws::S3::S3Client& s3Client) {
-        Aws::S3::Model::PutObjectRequest req;
-        req.WithBucket(bucket).WithKey(object);
-
-        auto inputStream = std::make_shared<std::stringstream>();
-        *inputStream << content;
-        req.SetBody(inputStream);
-        const Aws::S3::Model::PutObjectOutcome result = s3Client.PutObject(req);
-        UNIT_ASSERT_C(result.IsSuccess(), "Error uploading object \"" << object << "\" to a bucket \"" << bucket << "\": " << result.GetError().GetExceptionName() << ": " << result.GetError().GetMessage());
-    }
-
-    void UploadObject(const TString& bucket, const TString& object, const TStringBuf& content) {
-        Aws::S3::S3Client s3Client = MakeS3Client();
-
-        UploadObject(bucket, object, content, s3Client);
-    }
-
-    void CreateBucketWithObject(const TString& bucket, const TString& object, const TStringBuf& content, Aws::S3::S3Client& s3Client) {
-        CreateBucket(bucket, s3Client);
-        UploadObject(bucket, object, content, s3Client);
-    }
-
-    void CreateBucketWithObject(const TString& bucket, const TString& object, const TStringBuf& content) {
-        Aws::S3::S3Client s3Client = MakeS3Client();
-
-        CreateBucketWithObject(bucket, object, content, s3Client);
-    }
-
-    TString GetObject(const TString& bucket, const TString& object, Aws::S3::S3Client& s3Client) {
-        Aws::S3::Model::GetObjectRequest req;
-        req.WithBucket(bucket).WithKey(object);
-
-        Aws::S3::Model::GetObjectOutcome outcome = s3Client.GetObject(req);
-        UNIT_ASSERT(outcome.IsSuccess());
-        Aws::S3::Model::GetObjectResult& result = outcome.GetResult();
-        std::istreambuf_iterator<char> eos;
-        std::string objContent(std::istreambuf_iterator<char>(result.GetBody()), eos);
-        Cerr << "Got object content from \"" << bucket << "." << object << "\"\n"
-             << objContent << Endl;
-        return objContent;
-    }
-
-    TString GetObject(const TString& bucket, const TString& object) {
-        Aws::S3::S3Client s3Client = MakeS3Client();
-
-        return GetObject(bucket, object, s3Client);
-    }
-
-    std::vector<TString> GetObjectKeys(const TString& bucket, Aws::S3::S3Client& s3Client) {
-        Aws::S3::Model::ListObjectsRequest listReq;
-        listReq.WithBucket(bucket);
-
-        Aws::S3::Model::ListObjectsOutcome outcome = s3Client.ListObjects(listReq);
-        UNIT_ASSERT(outcome.IsSuccess());
-
-        std::vector<TString> keys;
-        for (auto& obj : outcome.GetResult().GetContents()) {
-            keys.push_back(TString(obj.GetKey()));
-            Cerr << "Found S3 object: \"" << obj.GetKey() << "\"" << Endl;
-        }
-        return keys;
-    }
-
-    std::vector<TString> GetObjectKeys(const TString& bucket) {
-        Aws::S3::S3Client s3Client = MakeS3Client();
-
-        return GetObjectKeys(bucket, s3Client);
-    }
-
-    TString GetAllObjects(const TString& bucket, TStringBuf separator, Aws::S3::S3Client& s3Client) {
-        std::vector<TString> keys = GetObjectKeys(bucket, s3Client);
-        TString result;
-        bool firstObject = true;
-        for (const TString& key : keys) {
-            result += GetObject(bucket, key, s3Client);
-            if (!firstObject) {
-                result += separator;
-            }
-            firstObject = false;
-        }
-        return result;
-    }
-
-    TString GetAllObjects(const TString& bucket, TStringBuf separator) {
-        Aws::S3::S3Client s3Client = MakeS3Client();
-
-        return GetAllObjects(bucket, separator, s3Client);
-    }
-
-    TString GetBucketLocation(const TStringBuf bucket) {
-        return TStringBuilder() << GetEnv("S3_ENDPOINT") << '/' << bucket << '/';
-    }
-
-} // namespace NTestUtils
+}

--- a/ydb/core/kqp/ut/federated_query/s3/s3_recipe_ut_helpers.h
+++ b/ydb/core/kqp/ut/federated_query/s3/s3_recipe_ut_helpers.h
@@ -2,55 +2,21 @@
 
 #include <ydb/core/kqp/ut/common/kqp_ut_common.h>
 #include <ydb/core/kqp/ut/federated_query/common/common.h>
-#include <library/cpp/testing/unittest/registar.h>
-
-#include <util/generic/strbuf.h>
-#include <util/generic/string.h>
-#include <util/system/env.h>
-
-#include <aws/core/auth/AWSCredentialsProvider.h>
-#include <aws/core/Aws.h>
-#include <aws/s3/model/CreateBucketRequest.h>
-#include <aws/s3/model/GetObjectRequest.h>
-#include <aws/s3/model/ListObjectsRequest.h>
-#include <aws/s3/model/PutObjectRequest.h>
-#include <aws/s3/S3Client.h>
+#include <ydb/library/testlib/s3_recipe_helper/s3_recipe_helper.h>
 
 namespace NTestUtils {
 
-    constexpr TStringBuf TEST_CONTENT =
-        R"({"key": "1", "value": "trololo"}
-           {"key": "2", "value": "hello world"})"sv;
+constexpr TStringBuf TEST_CONTENT =
+    R"({"key": "1", "value": "trololo"}
+       {"key": "2", "value": "hello world"})"sv;
 
-    constexpr TStringBuf TEST_CONTENT_KEYS =
-        R"({"key": "1"}
-           {"key": "3"})"sv;
+constexpr TStringBuf TEST_CONTENT_KEYS =
+    R"({"key": "1"}
+       {"key": "3"})"sv;
 
-    extern const TString TEST_SCHEMA;
-    extern const TString TEST_SCHEMA_IDS;
+extern const TString TEST_SCHEMA;
+extern const TString TEST_SCHEMA_IDS;
 
-    std::shared_ptr<NKikimr::NKqp::TKikimrRunner> MakeKikimrRunner(std::optional<NKikimrConfig::TAppConfig> appConfig = std::nullopt, const TString& domainRoot = "Root");
-
-    Aws::S3::S3Client MakeS3Client();
-
-    void CreateBucket(const TString& bucket, Aws::S3::S3Client& s3Client);
-    void CreateBucket(const TString& bucket);
-
-    void UploadObject(const TString& bucket, const TString& object, const TStringBuf& content, Aws::S3::S3Client& s3Client);
-    void UploadObject(const TString& bucket, const TString& object, const TStringBuf& content);
-
-    void CreateBucketWithObject(const TString& bucket, const TString& object, const TStringBuf& content, Aws::S3::S3Client& s3Client);
-    void CreateBucketWithObject(const TString& bucket, const TString& object, const TStringBuf& content);
-
-    TString GetObject(const TString& bucket, const TString& object, Aws::S3::S3Client& s3Client);
-    TString GetObject(const TString& bucket, const TString& object);
-
-    std::vector<TString> GetObjectKeys(const TString& bucket, Aws::S3::S3Client& s3Client);
-    std::vector<TString> GetObjectKeys(const TString& bucket);
-
-    TString GetAllObjects(const TString& bucket, TStringBuf separator, Aws::S3::S3Client& s3Client);
-    TString GetAllObjects(const TString& bucket, TStringBuf separator = {});
-
-    TString GetBucketLocation(const TStringBuf bucket);
+std::shared_ptr<NKikimr::NKqp::TKikimrRunner> MakeKikimrRunner(std::optional<NKikimrConfig::TAppConfig> appConfig = std::nullopt, const TString& domainRoot = "Root");
 
 } // namespace NTestUtils

--- a/ydb/core/kqp/ut/federated_query/s3/ya.make
+++ b/ydb/core/kqp/ut/federated_query/s3/ya.make
@@ -22,6 +22,7 @@ PEERDIR(
     ydb/core/kqp/ut/federated_query/common
     ydb/library/yql/providers/s3/actors
     ydb/library/yql/sql/pg_dummy
+    ydb/library/testlib/s3_recipe_helper
     ydb/public/sdk/cpp/client/ydb_types/operation
 )
 

--- a/ydb/core/wrappers/s3_storage_config.cpp
+++ b/ydb/core/wrappers/s3_storage_config.cpp
@@ -171,6 +171,7 @@ IExternalStorageOperator::TPtr TS3ExternalStorageConfig::DoConstructStorageOpera
 TS3ExternalStorageConfig::TS3ExternalStorageConfig(const Ydb::Import::ImportFromS3Settings& settings)
     : Config(ConfigFromSettings(settings))
     , Credentials(CredentialsFromSettings(settings))
+    , UseVirtualAddressing(!settings.disable_virtual_addressing())
 {
     Bucket = settings.bucket();
 }
@@ -178,6 +179,7 @@ TS3ExternalStorageConfig::TS3ExternalStorageConfig(const Ydb::Import::ImportFrom
 TS3ExternalStorageConfig::TS3ExternalStorageConfig(const Ydb::Export::ExportToS3Settings& settings)
     : Config(ConfigFromSettings(settings))
     , Credentials(CredentialsFromSettings(settings))
+    , UseVirtualAddressing(!settings.disable_virtual_addressing())
 {
     Bucket = settings.bucket();
 }

--- a/ydb/library/testlib/s3_recipe_helper/s3_recipe_helper.cpp
+++ b/ydb/library/testlib/s3_recipe_helper/s3_recipe_helper.cpp
@@ -1,0 +1,137 @@
+#include "s3_recipe_helper.h"
+
+#include <library/cpp/testing/hook/hook.h>
+
+#include <util/string/builder.h>
+
+#include <aws/core/Aws.h>
+
+Y_TEST_HOOK_BEFORE_RUN(InitAwsAPI) {
+    Aws::InitAPI(Aws::SDKOptions());
+}
+
+Y_TEST_HOOK_AFTER_RUN(ShutdownAwsAPI) {
+    Aws::ShutdownAPI(Aws::SDKOptions());
+}
+
+namespace NTestUtils {
+
+    Aws::S3::S3Client MakeS3Client() {
+        Aws::Client::ClientConfiguration s3ClientConfig;
+        s3ClientConfig.endpointOverride = GetEnv("S3_ENDPOINT");
+        s3ClientConfig.scheme = Aws::Http::Scheme::HTTP;
+        return Aws::S3::S3Client(
+            std::make_shared<Aws::Auth::AnonymousAWSCredentialsProvider>(),
+            s3ClientConfig,
+            Aws::Client::AWSAuthV4Signer::PayloadSigningPolicy::Never,
+            /*useVirtualAddressing=*/true);
+    }
+
+    void CreateBucket(const TString& bucket, Aws::S3::S3Client& s3Client) {
+        Aws::S3::Model::CreateBucketRequest req;
+        req.SetBucket(bucket);
+        req.SetACL(Aws::S3::Model::BucketCannedACL::public_read_write);
+        const Aws::S3::Model::CreateBucketOutcome result = s3Client.CreateBucket(req);
+        UNIT_ASSERT_C(result.IsSuccess(), "Error creating bucket \"" << bucket << "\": " << result.GetError().GetExceptionName() << ": " << result.GetError().GetMessage());
+    }
+
+    void CreateBucket(const TString& bucket) {
+        Aws::S3::S3Client s3Client = MakeS3Client();
+
+        CreateBucket(bucket, s3Client);
+    }
+
+    void UploadObject(const TString& bucket, const TString& object, const TStringBuf& content, Aws::S3::S3Client& s3Client) {
+        Aws::S3::Model::PutObjectRequest req;
+        req.WithBucket(bucket).WithKey(object);
+
+        auto inputStream = std::make_shared<std::stringstream>();
+        *inputStream << content;
+        req.SetBody(inputStream);
+        const Aws::S3::Model::PutObjectOutcome result = s3Client.PutObject(req);
+        UNIT_ASSERT_C(result.IsSuccess(), "Error uploading object \"" << object << "\" to a bucket \"" << bucket << "\": " << result.GetError().GetExceptionName() << ": " << result.GetError().GetMessage());
+    }
+
+    void UploadObject(const TString& bucket, const TString& object, const TStringBuf& content) {
+        Aws::S3::S3Client s3Client = MakeS3Client();
+
+        UploadObject(bucket, object, content, s3Client);
+    }
+
+    void CreateBucketWithObject(const TString& bucket, const TString& object, const TStringBuf& content, Aws::S3::S3Client& s3Client) {
+        CreateBucket(bucket, s3Client);
+        UploadObject(bucket, object, content, s3Client);
+    }
+
+    void CreateBucketWithObject(const TString& bucket, const TString& object, const TStringBuf& content) {
+        Aws::S3::S3Client s3Client = MakeS3Client();
+
+        CreateBucketWithObject(bucket, object, content, s3Client);
+    }
+
+    TString GetObject(const TString& bucket, const TString& object, Aws::S3::S3Client& s3Client) {
+        Aws::S3::Model::GetObjectRequest req;
+        req.WithBucket(bucket).WithKey(object);
+
+        Aws::S3::Model::GetObjectOutcome outcome = s3Client.GetObject(req);
+        UNIT_ASSERT(outcome.IsSuccess());
+        Aws::S3::Model::GetObjectResult& result = outcome.GetResult();
+        std::istreambuf_iterator<char> eos;
+        std::string objContent(std::istreambuf_iterator<char>(result.GetBody()), eos);
+        Cerr << "Got object content from \"" << bucket << "." << object << "\"\n"
+             << objContent << Endl;
+        return objContent;
+    }
+
+    TString GetObject(const TString& bucket, const TString& object) {
+        Aws::S3::S3Client s3Client = MakeS3Client();
+
+        return GetObject(bucket, object, s3Client);
+    }
+
+    std::vector<TString> GetObjectKeys(const TString& bucket, Aws::S3::S3Client& s3Client) {
+        Aws::S3::Model::ListObjectsRequest listReq;
+        listReq.WithBucket(bucket);
+
+        Aws::S3::Model::ListObjectsOutcome outcome = s3Client.ListObjects(listReq);
+        UNIT_ASSERT(outcome.IsSuccess());
+
+        std::vector<TString> keys;
+        for (auto& obj : outcome.GetResult().GetContents()) {
+            keys.push_back(TString(obj.GetKey()));
+            Cerr << "Found S3 object: \"" << obj.GetKey() << "\"" << Endl;
+        }
+        return keys;
+    }
+
+    std::vector<TString> GetObjectKeys(const TString& bucket) {
+        Aws::S3::S3Client s3Client = MakeS3Client();
+
+        return GetObjectKeys(bucket, s3Client);
+    }
+
+    TString GetAllObjects(const TString& bucket, TStringBuf separator, Aws::S3::S3Client& s3Client) {
+        std::vector<TString> keys = GetObjectKeys(bucket, s3Client);
+        TString result;
+        bool firstObject = true;
+        for (const TString& key : keys) {
+            result += GetObject(bucket, key, s3Client);
+            if (!firstObject) {
+                result += separator;
+            }
+            firstObject = false;
+        }
+        return result;
+    }
+
+    TString GetAllObjects(const TString& bucket, TStringBuf separator) {
+        Aws::S3::S3Client s3Client = MakeS3Client();
+
+        return GetAllObjects(bucket, separator, s3Client);
+    }
+
+    TString GetBucketLocation(const TStringBuf bucket) {
+        return TStringBuilder() << GetEnv("S3_ENDPOINT") << '/' << bucket << '/';
+    }
+
+} // namespace NTestUtils

--- a/ydb/library/testlib/s3_recipe_helper/s3_recipe_helper.h
+++ b/ydb/library/testlib/s3_recipe_helper/s3_recipe_helper.h
@@ -1,0 +1,40 @@
+#pragma once
+
+#include <library/cpp/testing/unittest/registar.h>
+
+#include <util/generic/strbuf.h>
+#include <util/generic/string.h>
+#include <util/system/env.h>
+
+#include <aws/core/auth/AWSCredentialsProvider.h>
+#include <aws/core/Aws.h>
+#include <aws/s3/model/CreateBucketRequest.h>
+#include <aws/s3/model/GetObjectRequest.h>
+#include <aws/s3/model/ListObjectsRequest.h>
+#include <aws/s3/model/PutObjectRequest.h>
+#include <aws/s3/S3Client.h>
+
+namespace NTestUtils {
+    Aws::S3::S3Client MakeS3Client();
+
+    void CreateBucket(const TString& bucket, Aws::S3::S3Client& s3Client);
+    void CreateBucket(const TString& bucket);
+
+    void UploadObject(const TString& bucket, const TString& object, const TStringBuf& content, Aws::S3::S3Client& s3Client);
+    void UploadObject(const TString& bucket, const TString& object, const TStringBuf& content);
+
+    void CreateBucketWithObject(const TString& bucket, const TString& object, const TStringBuf& content, Aws::S3::S3Client& s3Client);
+    void CreateBucketWithObject(const TString& bucket, const TString& object, const TStringBuf& content);
+
+    TString GetObject(const TString& bucket, const TString& object, Aws::S3::S3Client& s3Client);
+    TString GetObject(const TString& bucket, const TString& object);
+
+    std::vector<TString> GetObjectKeys(const TString& bucket, Aws::S3::S3Client& s3Client);
+    std::vector<TString> GetObjectKeys(const TString& bucket);
+
+    TString GetAllObjects(const TString& bucket, TStringBuf separator, Aws::S3::S3Client& s3Client);
+    TString GetAllObjects(const TString& bucket, TStringBuf separator = {});
+
+    TString GetBucketLocation(const TStringBuf bucket);
+
+} // namespace NTestUtils

--- a/ydb/library/testlib/s3_recipe_helper/ya.make
+++ b/ydb/library/testlib/s3_recipe_helper/ya.make
@@ -1,0 +1,11 @@
+LIBRARY()
+
+SRCS(
+    s3_recipe_helper.cpp
+)
+
+PEERDIR(
+    contrib/libs/aws-sdk-cpp/aws-cpp-sdk-s3
+)
+
+END()

--- a/ydb/public/lib/ydb_cli/commands/ydb_service_import.cpp
+++ b/ydb/public/lib/ydb_cli/commands/ydb_service_import.cpp
@@ -128,6 +128,7 @@ int TCommandImportFromS3::Run(TConfig& config) {
     settings.Bucket(AwsBucket);
     settings.AccessKey(AwsAccessKey);
     settings.SecretKey(AwsSecretKey);
+    settings.UseVirtualAddressing(UseVirtualAddressing);
 
     if (Description) {
         settings.Description(Description);

--- a/ydb/public/lib/ydb_cli/common/aws.cpp
+++ b/ydb/public/lib/ydb_cli/common/aws.cpp
@@ -70,12 +70,13 @@ public:
         } else {
             throw TMisuseException() << "\"" << settings.Scheme_ << "\" scheme type is not supported";
         }
+        config.useVirtualAddressing = settings.UseVirtualAddressing_;
 
         Client = std::make_unique<Aws::S3::S3Client>(
             Aws::Auth::AWSCredentials(settings.AccessKey_, settings.SecretKey_),
             config,
             Aws::Client::AWSAuthV4Signer::PayloadSigningPolicy::Never,
-            true);
+            settings.UseVirtualAddressing_);
     }
 
     TListS3Result ListObjectKeys(const TString& prefix, const std::optional<TString>& token) override {

--- a/ydb/tests/functional/backup/s3_path_style/s3_path_style_backup_ut.cpp
+++ b/ydb/tests/functional/backup/s3_path_style/s3_path_style_backup_ut.cpp
@@ -1,0 +1,110 @@
+#include <ydb/public/sdk/cpp/client/ydb_driver/driver.h>
+#include <ydb/public/sdk/cpp/client/ydb_export/export.h>
+#include <ydb/public/sdk/cpp/client/ydb_import/import.h>
+#include <ydb/public/sdk/cpp/client/ydb_operation/operation.h>
+#include <ydb/public/sdk/cpp/client/ydb_table/table.h>
+#include <ydb/library/testlib/s3_recipe_helper/s3_recipe_helper.h>
+
+#include <library/cpp/testing/unittest/registar.h>
+#include <util/system/env.h>
+
+using namespace NYdb;
+using namespace NYdb::NTable;
+
+namespace {
+    template<typename TOp>
+    void WaitOp(TMaybe<TOperation>& op, NOperation::TOperationClient& opClient) {
+        int attempt = 20;
+        while (--attempt) {
+            op = opClient.Get<TOp>(op->Id()).GetValueSync();
+            if (op->Ready()) {
+                break;
+            } 
+            Sleep(TDuration::Seconds(1));
+        }
+        UNIT_ASSERT_C(attempt, "Unable to wait completion of backup");
+    }
+}
+
+Y_UNIT_TEST_SUITE(S3PathStyleBackup)
+{
+    Y_UNIT_TEST(DisableVirtualAddressing)
+    {
+        TString connectionString = GetEnv("YDB_ENDPOINT") + "/?database=" + GetEnv("YDB_DATABASE");
+        auto config = TDriverConfig(connectionString);
+        auto driver = TDriver(config);
+        auto tableClient = TTableClient(driver);
+        auto session = tableClient.GetSession().GetValueSync().GetSession();
+
+        {
+            auto res = session.ExecuteSchemeQuery(R"(
+                CREATE TABLE `/local/Table` (
+                    Key Uint32,
+                    PRIMARY KEY (Key)
+                );
+            )").GetValueSync();
+            UNIT_ASSERT_C(res.IsSuccess(), res.GetIssues().ToString());
+        }
+
+        Aws::Client::ClientConfiguration s3ClientConfig;
+        s3ClientConfig.endpointOverride = GetEnv("S3_ENDPOINT");
+        s3ClientConfig.scheme = Aws::Http::Scheme::HTTP;
+        auto s3Client = Aws::S3::S3Client(
+            std::make_shared<Aws::Auth::AnonymousAWSCredentialsProvider>(),
+            s3ClientConfig,
+            Aws::Client::AWSAuthV4Signer::PayloadSigningPolicy::Never,
+            false
+        );
+        const TString bucketName = "my-bucket";
+        NTestUtils::CreateBucket(bucketName, s3Client);
+
+        auto fillS3Settings = [bucketName](auto& settings) {
+            settings.Endpoint(GetEnv("S3_ENDPOINT"));
+            settings.Bucket(bucketName);
+            settings.AccessKey("minio");
+            settings.SecretKey("minio123");
+            settings.UseVirtualAddressing(false);
+        };
+
+        {
+            NExport::TExportToS3Settings settings;
+            fillS3Settings(settings);
+
+            settings.AppendItem({"/local/Table", "Table"});
+
+            auto exportClient = NExport::TExportClient(driver);
+            auto operationClient = NOperation::TOperationClient(driver);
+
+            const auto backupOp = exportClient.ExportToS3(settings).GetValueSync();
+
+            if (backupOp.Ready()) {
+                UNIT_ASSERT_C(backupOp.Status().IsSuccess(), backupOp.Status().GetIssues().ToString());
+            } else {
+                TMaybe<TOperation> op = backupOp;
+                WaitOp<NExport::TExportToS3Response>(op, operationClient);
+                UNIT_ASSERT_C(op->Status().IsSuccess(), op->Status().GetIssues().ToString());
+            }
+        }
+
+        {
+            NImport::TImportFromS3Settings settings;
+            fillS3Settings(settings);
+
+            settings.AppendItem({"Table", "/local/Restored"});
+
+            auto importClient = NImport::TImportClient(driver);
+            auto operationClient = NOperation::TOperationClient(driver);
+
+            const auto restoreOp = importClient.ImportFromS3(settings).GetValueSync();
+
+            if (restoreOp.Ready()) {
+                UNIT_ASSERT_C(restoreOp.Status().IsSuccess(), restoreOp.Status().GetIssues().ToString());
+            } else {
+                TMaybe<TOperation> op = restoreOp;
+                WaitOp<NImport::TImportFromS3Response>(op, operationClient);
+                UNIT_ASSERT_C(op->Status().IsSuccess(), op->Status().GetIssues().ToString());
+            }
+        }
+    }
+}
+

--- a/ydb/tests/functional/backup/s3_path_style/ya.make
+++ b/ydb/tests/functional/backup/s3_path_style/ya.make
@@ -1,0 +1,29 @@
+UNITTEST()
+
+ENV(S3_IGNORE_SUBDOMAIN_BUCKETNAME=true)
+ENV(YDB_USE_IN_MEMORY_PDISKS=true)
+
+ENV(YDB_ERASURE=block_4-2)
+
+PEERDIR(
+    ydb/library/testlib/s3_recipe_helper
+    ydb/public/sdk/cpp/client/ydb_export
+    ydb/public/sdk/cpp/client/ydb_table
+    ydb/public/sdk/cpp/client/ydb_operation
+    ydb/public/sdk/cpp/client/draft
+)
+
+SRCS(
+    s3_path_style_backup_ut.cpp
+)
+
+INCLUDE(${ARCADIA_ROOT}/ydb/public/tools/ydb_recipe/recipe.inc)
+INCLUDE(${ARCADIA_ROOT}/ydb/tests/tools/s3_recipe/recipe.inc)
+
+SIZE(MEDIUM)
+
+IF (SANITIZER_TYPE)
+    REQUIREMENTS(ram:16)
+ENDIF()
+
+END()

--- a/ydb/tests/functional/backup/ya.make
+++ b/ydb/tests/functional/backup/ya.make
@@ -1,0 +1,3 @@
+RECURSE(
+    s3_path_style
+)

--- a/ydb/tests/functional/ya.make
+++ b/ydb/tests/functional/ya.make
@@ -2,6 +2,7 @@ RECURSE(
     api
     audit
     autoconfig
+    backup
     blobstorage
     canonical
     clickbench


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of changes introduced in this PR -->

Fix disabled use virtual addressing option for import from S3

### Changelog category <!-- remove all except one -->

* Bugfix 

### Additional information

This fix allows import tables from S3 using path style addressing model