### PR TITLE
Use sized operator delete for TOwnedCellVec

### DIFF
--- a/ydb/core/scheme/scheme_tablecell.cpp
+++ b/ydb/core/scheme/scheme_tablecell.cpp
@@ -112,8 +112,11 @@ namespace {
 
 } // namespace
 
-void TOwnedCellVec::TData::operator delete(void* mem) noexcept {
-    ::free(mem);
+void TOwnedCellVec::TData::operator delete(TData* data, std::destroying_delete_t) noexcept {
+    void* ptr = data;
+    size_t size = data->DataSize;
+    data->~TData();
+    ::operator delete(ptr, size);
 }
 
 TOwnedCellVec::TInit TOwnedCellVec::Allocate(TOwnedCellVec::TCellVec cells) {
@@ -124,7 +127,6 @@ TOwnedCellVec::TInit TOwnedCellVec::Allocate(TOwnedCellVec::TCellVec cells) {
         return TInit{
             TCellVec(),
             nullptr,
-            0,
         };
     }
 
@@ -136,7 +138,7 @@ TOwnedCellVec::TInit TOwnedCellVec::Allocate(TOwnedCellVec::TCellVec cells) {
         }
     }
 
-    void* mem = ::malloc(size);
+    void* mem = ::operator new(size);
     if (Y_UNLIKELY(!mem)) {
         throw std::bad_alloc();
     }
@@ -165,8 +167,7 @@ TOwnedCellVec::TInit TOwnedCellVec::Allocate(TOwnedCellVec::TCellVec cells) {
 
     return TInit {
         cellvec,
-        new (mem) TData(),
-        size,
+        new (mem) TData(size),
     };
 }
 
@@ -176,7 +177,6 @@ TOwnedCellVec::TInit TOwnedCellVec::AllocateFromSerialized(std::string_view data
         return TInit{
             TCellVec(),
             nullptr,
-            0,
         };
     }
 
@@ -192,7 +192,6 @@ TOwnedCellVec::TInit TOwnedCellVec::AllocateFromSerialized(std::string_view data
         return TInit{
             TCellVec(),
             nullptr,
-            0,
         };
     }
 
@@ -210,7 +209,7 @@ TOwnedCellVec::TInit TOwnedCellVec::AllocateFromSerialized(std::string_view data
         }
     }
 
-    void* mem = ::malloc(size);
+    void* mem = ::operator new(size);
     if (Y_UNLIKELY(!mem)) {
         throw std::bad_alloc();
     }
@@ -245,8 +244,7 @@ TOwnedCellVec::TInit TOwnedCellVec::AllocateFromSerialized(std::string_view data
 
     return TInit {
         cellvec,
-        new (mem) TData(),
-        size,
+        new (mem) TData(size),
     };
 }
 

--- a/ydb/core/scheme/scheme_tablecell.h
+++ b/ydb/core/scheme/scheme_tablecell.h
@@ -420,21 +420,23 @@ private:
 
     class TData : public TAtomicRefCount<TData> {
     public:
-        TData() = default;
+        const size_t DataSize;
 
-        void operator delete(void* mem) noexcept;
+        explicit TData(size_t size)
+            : DataSize(size)
+        {}
+
+        void operator delete(TData* data, std::destroying_delete_t) noexcept;
     };
 
     struct TInit {
         TCellVec Cells;
         TIntrusivePtr<TData> Data;
-        size_t DataSize;
     };
 
     TOwnedCellVec(TInit init) noexcept
         : TCellVec(std::move(init.Cells))
         , Data(std::move(init.Data))
-        , DataSize_(init.DataSize)
     { }
 
     static TInit Allocate(TCellVec cells);
@@ -448,7 +450,6 @@ private:
 public:
     TOwnedCellVec() noexcept
         : TCellVec()
-        , DataSize_(0)
     { }
 
     explicit TOwnedCellVec(TCellVec cells)
@@ -466,22 +467,18 @@ public:
     TOwnedCellVec(const TOwnedCellVec& rhs) noexcept
         : TCellVec(rhs)
         , Data(rhs.Data)
-        , DataSize_(rhs.DataSize_)
     { }
 
     TOwnedCellVec(TOwnedCellVec&& rhs) noexcept
         : TCellVec(rhs)
         , Data(std::move(rhs.Data))
-        , DataSize_(rhs.DataSize_)
     {
         rhs.CellVec() = { };
-        rhs.DataSize_ = 0;
     }
 
     TOwnedCellVec& operator=(const TOwnedCellVec& rhs) noexcept {
         if (Y_LIKELY(this != &rhs)) {
             Data = rhs.Data;
-            DataSize_ = rhs.DataSize_;
             CellVec() = rhs;
         }
 
@@ -491,22 +488,19 @@ public:
     TOwnedCellVec& operator=(TOwnedCellVec&& rhs) noexcept {
         if (Y_LIKELY(this != &rhs)) {
             Data = std::move(rhs.Data);
-            DataSize_ = rhs.DataSize_;
             CellVec() = rhs;
             rhs.CellVec() = { };
-            rhs.DataSize_ = 0;
         }
 
         return *this;
     }
 
     size_t DataSize() const {
-        return DataSize_;
+        return Data ? Data->DataSize : 0;
     }
 
 private:
     TIntrusivePtr<TData> Data;
-    size_t DataSize_;
 };
 
 static_assert(std::is_nothrow_destructible_v<TOwnedCellVec>, "Expected TOwnedCellVec to be nothrow destructible");

--- a/ydb/core/scheme/scheme_tablecell_ut.cpp
+++ b/ydb/core/scheme/scheme_tablecell_ut.cpp
@@ -95,7 +95,7 @@ Y_UNIT_TEST_SUITE(Scheme) {
         UNIT_ASSERT_VALUES_EQUAL(twoLargeCells[0].AsBuf(), TStringBuf("zyxwvutsrqponmlkjihgfedcba987654321"));
         UNIT_ASSERT_VALUES_EQUAL(twoLargeCells[1].AsBuf(), TStringBuf("ZYXWVUTSRQPONMLKJIHGFEDCBA987654321"));
         // Ensure cell data is aligned (36 bytes per cell instead of 35)
-        UNIT_ASSERT_VALUES_EQUAL(twoLargeCells.DataSize(), 8 + sizeof(TCell) * 2 + 36 * 2);
+        UNIT_ASSERT_VALUES_EQUAL(twoLargeCells.DataSize(), 16 + sizeof(TCell) * 2 + 36 * 2);
         UNIT_ASSERT_VALUES_EQUAL(uintptr_t(twoLargeCells[0].Data()) & 3, 0);
         UNIT_ASSERT_VALUES_EQUAL(uintptr_t(twoLargeCells[1].Data()) & 3, 0);
     }


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of changes introduced in this PR -->

...

### Changelog category <!-- remove all except one -->

* Not for changelog (changelog entry is not required)

### Additional information

It was pointed out that `TOwnedCellVec` could use sized operator delete, since we use c++20 anyway, and this could be a bit more efficient. To make that work use a custom destroying delete operator.