### PR TITLE
mute and unmute

### DIFF
--- a/.github/config/muted_ya.txt
+++ b/.github/config/muted_ya.txt
@@ -1,5 +1,9 @@
 ydb/apps/ydb/ut YdbWorkloadTopic.Full_Statistics_UseTx
+ydb/apps/ydb/ut YdbWorkloadTransferTopicToTable.Clean_Without_Init
+ydb/apps/ydb/ut YdbWorkloadTransferTopicToTable.Default_Init_Clean
+ydb/apps/ydb/ut YdbWorkloadTransferTopicToTable.Default_Run
 ydb/core/blobstorage/dsproxy/ut TBlobStorageProxySequenceTest.TestBlock42PutWithChangingSlowDisk
+ydb/core/blobstorage/dsproxy/ut TDSProxyPutTest.TestBlock42PutStatusErrorWith_1_2_VdiskErrors
 ydb/core/blobstorage/dsproxy/ut_fat TBlobStorageProxyTest.TestBatchedPutRequestDoesNotContainAHugeBlob
 ydb/core/blobstorage/ut_blobstorage/ut_huge HugeBlobOnlineSizeChange.Compaction
 ydb/core/blobstorage/ut_blobstorage/ut_huge [*/*] chunk chunk
@@ -21,7 +25,6 @@ ydb/core/keyvalue/ut_trace TKeyValueTracingTest.WriteSmall
 ydb/core/kqp/ut/cost KqpCost.OlapWriteRow
 ydb/core/kqp/ut/data_integrity KqpDataIntegrityTrails.Select
 ydb/core/kqp/ut/data_integrity KqpDataIntegrityTrails.UpsertEvWrite
-ydb/core/kqp/ut/data_integrity KqpDataIntegrityTrails.UpsertViaLegacyScripting-Streaming
 ydb/core/kqp/ut/olap KqpDecimalColumnShard.TestAggregation
 ydb/core/kqp/ut/olap KqpDecimalColumnShard.TestFilterCompare
 ydb/core/kqp/ut/olap KqpOlapBlobsSharing.BlobsSharingSplit1_1
@@ -43,14 +46,10 @@ ydb/core/kqp/ut/olap KqpOlapBlobsSharing.MultipleSplitsWithRestartsWhenWait
 ydb/core/kqp/ut/olap KqpOlapBlobsSharing.TableReshardingConsistency64
 ydb/core/kqp/ut/olap KqpOlapBlobsSharing.TableReshardingModuloN
 ydb/core/kqp/ut/olap KqpOlapBlobsSharing.UpsertWhileSplitTest
-ydb/core/kqp/ut/olap KqpOlapTiering.Eviction
 ydb/core/kqp/ut/olap KqpOlapWrite.TierDraftsGCWithRestart
 ydb/core/kqp/ut/olap [*/*] chunk chunk
 ydb/core/kqp/ut/query KqpAnalyze.AnalyzeTable+ColumnStore
-ydb/core/kqp/ut/query KqpLimits.QueryExecTimeoutCancel
 ydb/core/kqp/ut/query KqpStats.SysViewClientLost
-ydb/core/kqp/ut/tx KqpSnapshotIsolation.TConflictWrite*
-ydb/core/kqp/ut/tx KqpSnapshotIsolation.TConflictRead*
 ydb/core/kqp/ut/scan KqpRequestContext.TraceIdInErrorMessage
 ydb/core/kqp/ut/scheme KqpOlapScheme.TenThousandColumns
 ydb/core/kqp/ut/scheme KqpScheme.AlterAsyncReplication
@@ -63,6 +62,7 @@ ydb/core/persqueue/ut TPQTest.TestReadAndDeleteConsumer
 ydb/core/persqueue/ut [*/*] chunk chunk
 ydb/core/quoter/ut QuoterWithKesusTest.PrefetchCoefficient
 ydb/core/tablet_flat/ut TSharedPageCache.Compaction_BTreeIndex
+ydb/core/tablet_flat/ut TSharedPageCache.ThreeLeveledLRU
 ydb/core/tx/datashard/ut_incremental_backup IncrementalBackup.ComplexRestoreBackupCollection+WithIncremental
 ydb/core/tx/schemeshard/ut_move_reboots TSchemeShardMoveRebootsTest.WithData
 ydb/core/tx/schemeshard/ut_move_reboots TSchemeShardMoveRebootsTest.WithDataAndPersistentPartitionStats
@@ -78,7 +78,6 @@ ydb/library/actors/http/ut sole chunk chunk
 ydb/library/actors/http/ut sole+chunk+chunk
 ydb/library/actors/interconnect/ut_huge_cluster HugeCluster.AllToAll
 ydb/library/actors/interconnect/ut_huge_cluster sole chunk chunk
-ydb/library/yql/providers/generic/connector/tests/datasource/ydb test.py.test_select_positive[column_selection_col2_COL1_HTTP-dqrun]
 ydb/public/sdk/cpp/client/ydb_topic/ut [*/*] chunk chunk
 ydb/public/sdk/cpp/client/ydb_topic/ut [*/*]+chunk+chunk
 ydb/services/datastreams/ut DataStreams.TestPutRecordsCornerCases
@@ -93,6 +92,7 @@ ydb/services/ydb/table_split_ut [*/*] chunk chunk
 ydb/services/ydb/ut YdbLogStore.AlterLogTable
 ydb/tests/fq/control_plane_storage [*/*] chunk chunk
 ydb/tests/fq/control_plane_storage [*/*]+chunk+chunk
+ydb/tests/fq/generic/analytics sole chunk chunk
 ydb/tests/fq/generic/analytics test_join.py.TestJoinAnalytics.test_simple[v1-2-fq_client0-mvp_external_ydb_endpoint0]
 ydb/tests/fq/generic/streaming sole chunk chunk
 ydb/tests/fq/generic/streaming test_join.py.TestJoinStreaming.test_simple[v1-fq_client0-mvp_external_ydb_endpoint0]
@@ -126,7 +126,6 @@ ydb/tests/fq/yds test_select_limit_db_id.py.TestSelectLimitWithDbId.test_select_
 ydb/tests/fq/yds test_yds_bindings.py.TestBindings.test_yds_insert[v1]
 ydb/tests/fq/yt/kqp_yt_file/part18 test.py.test[pg-join_brackets2-default.txt]
 ydb/tests/functional/hive test_drain.py.TestHive.test_drain_on_stop
-ydb/tests/functional/kqp/kqp_query_session KqpQuerySession.NoLocalAttach
 ydb/tests/functional/rename [test_rename.py */*] chunk chunk
 ydb/tests/functional/serializable sole chunk chunk
 ydb/tests/functional/serializable test.py.test_local

--- a/.github/config/muted_ya.txt
+++ b/.github/config/muted_ya.txt
@@ -80,6 +80,7 @@ ydb/library/actors/http/ut sole chunk chunk
 ydb/library/actors/http/ut sole+chunk+chunk
 ydb/library/actors/interconnect/ut_huge_cluster HugeCluster.AllToAll
 ydb/library/actors/interconnect/ut_huge_cluster sole chunk chunk
+ydb/library/yql/providers/generic/connector/tests/datasource/ydb test.py.test_select_positive[column_selection_col2_COL1_HTTP-dqrun]
 ydb/public/sdk/cpp/client/ydb_topic/ut [*/*] chunk chunk
 ydb/public/sdk/cpp/client/ydb_topic/ut [*/*]+chunk+chunk
 ydb/services/datastreams/ut DataStreams.TestPutRecordsCornerCases

--- a/.github/config/muted_ya.txt
+++ b/.github/config/muted_ya.txt
@@ -50,6 +50,8 @@ ydb/core/kqp/ut/olap KqpOlapWrite.TierDraftsGCWithRestart
 ydb/core/kqp/ut/olap [*/*] chunk chunk
 ydb/core/kqp/ut/query KqpAnalyze.AnalyzeTable+ColumnStore
 ydb/core/kqp/ut/query KqpStats.SysViewClientLost
+ydb/core/kqp/ut/tx KqpSnapshotIsolation.TConflictWrite*
+ydb/core/kqp/ut/tx KqpSnapshotIsolation.TConflictRead*
 ydb/core/kqp/ut/scan KqpRequestContext.TraceIdInErrorMessage
 ydb/core/kqp/ut/scheme KqpOlapScheme.TenThousandColumns
 ydb/core/kqp/ut/scheme KqpScheme.AlterAsyncReplication


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of changes introduced in this PR -->
**Muted stable : 3**

ydb/core/kqp/ut/data_integrity KqpDataIntegrityTrails.UpsertViaLegacyScripting-Streaming # owner TEAM:@ydb-platform/qp success_rate 100%, state Muted Stable days in state 14
ydb/core/kqp/ut/query KqpLimits.QueryExecTimeoutCancel # owner TEAM:@ydb-platform/qp success_rate 100%, state Muted Stable days in state 14
ydb/tests/functional/kqp/kqp_query_session KqpQuerySession.NoLocalAttach # owner Unknown success_rate 100%, state Muted Stable days in state 14

**Deleted : 1**
ydb/core/kqp/ut/olap KqpOlapTiering.Eviction # owner TEAM:@ydb-platform/qp success_rate 0%, state no_runs days in state 19

**Flaky tests : 6**

Created issue 'Mute ydb/core/blobstorage/dsproxy/ut/TDSProxyPutTest.TestBlock42PutStatusErrorWith_1_2_VdiskErrors' for TEAM:@ydb-platform/storage, url https://github.com/ydb-platform/ydb/issues/12942
Created issue 'Mute ydb/core/tablet_flat/ut/TSharedPageCache.ThreeLeveledLRU' for TEAM:@ydb-platform/datashard, url https://github.com/ydb-platform/ydb/issues/12943
Created issue 'Mute ydb/apps/ydb/ut 3 tests' for TEAM:@ydb-platform/appteam, url https://github.com/ydb-platform/ydb/issues/12944
Created issue 'Mute ydb/tests/fq/generic/analytics/sole chunk chunk' for TEAM:@ydb-platform/fq, url https://github.com/ydb-platform/ydb/issues/12945

ydb/apps/ydb/ut YdbWorkloadTransferTopicToTable.Clean_Without_Init # owner TEAM:@ydb-platform/appteam success_rate 72%, state Flaky, days in state 7, pass_count 24, fail count 9
ydb/apps/ydb/ut YdbWorkloadTransferTopicToTable.Default_Init_Clean # owner TEAM:@ydb-platform/appteam success_rate 72%, state Flaky, days in state 7, pass_count 24, fail count 9
ydb/apps/ydb/ut YdbWorkloadTransferTopicToTable.Default_Run # owner TEAM:@ydb-platform/appteam success_rate 72%, state Flaky, days in state 7, pass_count 24, fail count 9
ydb/core/blobstorage/dsproxy/ut TDSProxyPutTest.TestBlock42PutStatusErrorWith_1_2_VdiskErrors # owner TEAM:@ydb-platform/storage success_rate 83%, state Flaky, days in state 2, pass_count 20, fail count 4
ydb/core/tablet_flat/ut TSharedPageCache.ThreeLeveledLRU # owner TEAM:@ydb-platform/datashard success_rate 67%, state Flaky, days in state 1, pass_count 19, fail count 9
ydb/tests/fq/generic/analytics sole chunk chunk # owner TEAM:@ydb-platform/fq success_rate 45%, state Flaky, days in state 14, pass_count 22, fail count 26

### Changelog category <!-- remove all except one -->


* Not for changelog (changelog entry is not required)

### Additional information

...
