### PR TITLE
Fix an observer use-after-free in a datashard test

### DIFF
--- a/ydb/core/tx/datashard/datashard_ut_kqp_errors.cpp
+++ b/ydb/core/tx/datashard/datashard_ut_kqp_errors.cpp
@@ -233,7 +233,7 @@ void TestProposeResultLost(TTestActorRuntime& runtime, TActorId client, const TS
     TActorId executer;
     ui32 droppedEvents = 0;
 
-    runtime.SetObserverFunc([&](TAutoPtr<IEventHandle>& ev) {
+    auto prev = runtime.SetObserverFunc([&](TAutoPtr<IEventHandle>& ev) {
         if (ev->GetTypeRewrite() == TEvPipeCache::TEvForward::EventType) {
             auto* fe = ev.Get()->Get<TEvPipeCache::TEvForward>();
             if (fe->Ev->Type() == TEvDataShard::TEvProposeTransaction::EventType) {
@@ -266,6 +266,8 @@ void TestProposeResultLost(TTestActorRuntime& runtime, TActorId client, const TS
     auto& record = ev->Get()->Record;
     // Cerr << record.DebugString() << Endl;
     fn(record);
+
+    runtime.SetObserverFunc(prev);
 }
 
 Y_UNIT_TEST(ProposeResultLost_RwTx) {


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of changes introduced in this PR -->

...

### Changelog category <!-- remove all except one -->

* Not for changelog (changelog entry is not required)

### Additional information

...
