### PR TITLE
Remove MemoryLimit from TCMallocControls

### DIFF
--- a/ydb/core/mon_alloc/tcmalloc.cpp
+++ b/ydb/core/mon_alloc/tcmalloc.cpp
@@ -582,7 +582,6 @@ class TTcMallocMonitor : public IAllocMonitor {
 
         TControlWrapper ProfileSamplingRate;
         TControlWrapper GuardedSamplingRate;
-        TControlWrapper MemoryLimit;
         TControlWrapper PageCacheTargetSize;
         TControlWrapper PageCacheReleaseRate;
 
@@ -591,8 +590,6 @@ class TTcMallocMonitor : public IAllocMonitor {
                 64 << 10, MaxSamplingRate)
             , GuardedSamplingRate(MaxSamplingRate,
                 64 << 10, MaxSamplingRate)
-            , MemoryLimit(0,
-                0, std::numeric_limits<i64>::max())
             , PageCacheTargetSize(DefaultPageCacheTargetSize,
                 0, MaxPageCacheTargetSize)
             , PageCacheReleaseRate(DefaultPageCacheReleaseRate,
@@ -602,7 +599,6 @@ class TTcMallocMonitor : public IAllocMonitor {
         void Register(TIntrusivePtr<TControlBoard> icb) {
             icb->RegisterSharedControl(ProfileSamplingRate, "TCMallocControls.ProfileSamplingRate");
             icb->RegisterSharedControl(GuardedSamplingRate, "TCMallocControls.GuardedSamplingRate");
-            icb->RegisterSharedControl(MemoryLimit, "TCMallocControls.MemoryLimit");
             icb->RegisterSharedControl(PageCacheTargetSize, "TCMallocControls.PageCacheTargetSize");
             icb->RegisterSharedControl(PageCacheReleaseRate, "TCMallocControls.PageCacheReleaseRate");
         }
@@ -660,12 +656,6 @@ private:
             tcmalloc::MallocExtension::ActivateGuardedSampling();
         }
         tcmalloc::MallocExtension::SetGuardedSamplingRate(Controls.GuardedSamplingRate);
-
-        tcmalloc::MallocExtension::MemoryLimit limit;
-        limit.hard = false;
-        limit.limit = Controls.MemoryLimit ?
-            (size_t)Controls.MemoryLimit : std::numeric_limits<size_t>::max();
-        tcmalloc::MallocExtension::SetMemoryLimit(limit);
     }
 
     void ReleaseMemoryIfNecessary(TDuration interval) {

--- a/ydb/core/protos/config.proto
+++ b/ydb/core/protos/config.proto
@@ -1290,11 +1290,9 @@ message TImmediateControlsConfig {
             MinValue: 65536,
             MaxValue: 4294967296,
             DefaultValue: 4294967296 }];
-        optional uint64 MemoryLimit = 3 [(ControlOptions) = {
-            Description: "Make a best effort attempt to prevent more than limit bytes of memory from being allocated by the system.",
-            MinValue: 0,
-            MaxValue: 9223372036854775807,
-            DefaultValue: 0 }];
+
+        reserved 3; // was MemoryLimit
+
         optional uint64 PageCacheTargetSize = 4 [(ControlOptions) = {
             Description: "Page Cache Target Size.",
             MinValue: 0,


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of changes introduced in this PR -->

This control from Immediate Control Board was interfering with tcmalloc's default memory soft limit from MemoryController - since I found no way to combine both I have to remove the control.

### Changelog category <!-- remove all except one -->

* New feature