### PR TITLE
Faster tests teardown (add enable_drain_on_shutdown=False)

### DIFF
--- a/ydb/tests/library/harness/kikimr_config.py
+++ b/ydb/tests/library/harness/kikimr_config.py
@@ -263,6 +263,9 @@ class KikimrConfigGenerator(object):
             self.yaml_config["table_service_config"]["enable_kqp_data_query_stream_lookup"] = False
 
         self.yaml_config["feature_flags"]["enable_public_api_external_blobs"] = enable_public_api_external_blobs
+
+        # for faster shutdown: there is no reason to wait while tablets are drained before whole cluster is stopping
+        self.yaml_config["feature_flags"]["enable_drain_on_shutdown"] = False
         for extra_feature_flag in extra_feature_flags:
             self.yaml_config["feature_flags"][extra_feature_flag] = True
         if enable_alter_database_create_hive_first:


### PR DESCRIPTION
Preventing loop from 
https://github.com/ydb-platform/ydb/blob/2b752b4d32e1161d4fb2c61af38b1594d4e85a9a/ydb/core/driver_lib/run/run.cpp#L1816
On shutdown 

In tests it is meaningless to wait drain because whole cluster is stopping 

Before change (from https://github.com/ydb-platform/ydb/pull/13026 )
https://storage.yandexcloud.net/ydb-gh-logs/ydb-platform/ydb/PR-check/12502259622/ya-x86-64/try_1/test_bloat/tree_map.html
<img width="2037" alt="image" src="https://github.com/user-attachments/assets/0e184486-2538-4a02-a4ea-be3d01214058" />


After change 
https://storage.yandexcloud.net/ydb-gh-logs/ydb-platform/ydb/PR-check/12502252680/ya-x86-64/try_1/test_bloat/tree_map.html
<img width="2039" alt="image" src="https://github.com/user-attachments/assets/fe36ef33-4696-4010-9e66-982add67fc7b" />


Total time (relwithdebinfo)
47k -> 41k

For asan 
34k -> 31k
