### PR TITLE
Vector Index leftovers

### DIFF
--- a/ydb/core/kqp/opt/logical/kqp_opt_log_indexes.cpp
+++ b/ydb/core/kqp/opt/logical/kqp_opt_log_indexes.cpp
@@ -423,18 +423,6 @@ TExprBase DoRewriteTopSortOverKMeansTree(
     auto postingColumns = BuildKeyColumnsList(*postingTableDesc, pos, ctx, tableDesc.Metadata->KeyColumnNames);
     const auto& mainColumns = read.Columns();
 
-    auto mapArg = Build<TCoArgument>(ctx, pos)
-        .Name("mapArg")
-    .Done();
-    TVector<TExprBase> mapMembers{
-        Build<TCoNameValueTuple>(ctx, pos)
-            .Name().Build(NTableIndex::NTableVectorKmeansTreeIndex::ParentColumn)
-            .Value<TCoMember>().Struct(mapArg)
-                .Name().Build(NTableIndex::NTableVectorKmeansTreeIndex::IdColumn)
-            .Build()
-        .Done()
-    };
-
     // TODO(mbkkt) How to inline construction of these constants to construction of readLevel0?
     auto fromValues = ctx.Builder(pos)
         .Callable("Uint32").Atom(0, "0", TNodeFlags::Default).Seal()
@@ -447,21 +435,6 @@ TExprBase DoRewriteTopSortOverKMeansTree(
     auto count = ctx.Builder(pos)
         .Callable("Uint64").Atom(0, "2", TNodeFlags::Default).Seal()
     .Build();
-
-    // TODO(mbkkt) Is it best way to do `SELECT FROM levelTable WHERE first_pk_column = 0`?
-    auto readLevel0 = Build<TKqlReadTable>(ctx, pos)
-        .Table(levelTable)
-        .Range<TKqlKeyRange>()
-            .From<TKqlKeyInc>()
-                .Add(fromValues)
-            .Build()
-            .To<TKqlKeyExc>()
-                .Add(toValues)
-            .Build()
-        .Build()
-        .Columns(levelColumns)
-        .Settings(read.Settings())
-    .Done();
 
     auto levelLambda = [&] {
         const auto oldArgNodes = lambdaArgs.Children();
@@ -514,29 +487,71 @@ TExprBase DoRewriteTopSortOverKMeansTree(
             ctx.ReplaceNodes(TExprNode::TListType{apply.Ptr()}, replaces));
     }();
 
-    auto topLevel0 = Build<TCoTop>(ctx, pos)
-        .Input(readLevel0)
-        // TODO(mbkkt) how to construct our own lambda?
-        //  Maybe good idea is construct lambda with knn udf and two member access as arguments
-        //   and then replace one of them to argument without access to indexed field...
-        .KeySelectorLambda(levelLambda)
-        .SortDirections(top.SortDirections())
-        .Count(count)
-    .Done();
+    ui32 level = 1;
+    auto levels = std::get<NKikimrKqp::TVectorIndexKmeansTreeDescription>(indexDesc.SpecializedIndexDescription)
+        .settings().levels();
+    Y_ENSURE(level <= levels);
 
-    auto mapLevel0 = Build<TCoMap>(ctx, pos)
-        .Input(topLevel0)
-        .Lambda()
-            .Args({mapArg})
-            .Body<TCoAsStruct>().Add(mapMembers).Build()
+    // TODO(mbkkt) Is it best way to do `SELECT FROM levelTable WHERE first_pk_column = 0`?
+    auto readLevel = Build<TKqlReadTable>(ctx, pos)
+        .Table(levelTable)
+        .Range<TKqlKeyRange>()
+            .From<TKqlKeyInc>()
+                .Add(fromValues)
+            .Build()
+            .To<TKqlKeyExc>()
+                .Add(toValues)
+            .Build()
         .Build()
-    .Done();
+        .Columns(levelColumns)
+        .Settings(read.Settings())
+    .Done().Ptr();
 
+    for (;; ++level) {
+        readLevel = Build<TCoTop>(ctx, pos)
+            .Input(readLevel)
+            .KeySelectorLambda(levelLambda)
+            .SortDirections(top.SortDirections())
+            .Count(count)
+        .Done().Ptr();
+
+        auto mapArg = Build<TCoArgument>(ctx, pos)
+            .Name("mapArg")
+        .Done();
+        TVector<TExprBase> mapMembers{
+            Build<TCoNameValueTuple>(ctx, pos)
+                .Name().Build(NTableIndex::NTableVectorKmeansTreeIndex::ParentColumn)
+                .Value<TCoMember>().Struct(mapArg)
+                    .Name().Build(NTableIndex::NTableVectorKmeansTreeIndex::IdColumn)
+                .Build()
+            .Done()
+        };
+
+        readLevel = Build<TCoMap>(ctx, pos)
+            .Input(readLevel)
+            .Lambda()
+                .Args({mapArg})
+                .Body<TCoAsStruct>().Add(mapMembers).Build()
+            .Build()
+        .Done().Ptr();
+
+        if (level == levels) {
+            break;
+        }
+
+        readLevel = Build<TKqlLookupTable>(ctx, pos)
+            .Table(levelTable)
+            .LookupKeys(readLevel)
+            .Columns(levelColumns)
+        .Done().Ptr();
+    }
+
+    // TODO(mbkkt) handle covered index columns
     auto postingRead = Build<TKqlLookupTable>(ctx, pos)
         .Table(postingTable)
-        .LookupKeys(mapLevel0)
+        .LookupKeys(readLevel)
         .Columns(postingColumns)
-    .Done();
+    .Done().Ptr();
 
     auto mainRead = Build<TKqlLookupTable>(ctx, pos)
         .Table(mainTable)
@@ -551,15 +566,15 @@ TExprBase DoRewriteTopSortOverKMeansTree(
         .Done().Ptr();
     }
 
-    auto mainTop = Build<TCoTopBase>(ctx, top.Pos())
+    mainRead = Build<TCoTopBase>(ctx, top.Pos())
         .CallableName(top.Ref().Content())
         .Input(mainRead)
         .KeySelectorLambda(ctx.DeepCopyLambda(top.KeySelectorLambda().Ref()))
         .SortDirections(top.SortDirections())
         .Count(top.Count())
-    .Done();
+    .Done().Ptr();
 
-    return mainTop;
+    return TExprBase{mainRead};
 }
 
 } // namespace

--- a/ydb/core/kqp/ut/indexes/kqp_indexes_ut.cpp
+++ b/ydb/core/kqp/ut/indexes/kqp_indexes_ut.cpp
@@ -2279,7 +2279,7 @@ Y_UNIT_TEST_SUITE(KqpIndexes) {
         return session;
     }
 
-    Y_UNIT_TEST(VectorIndexOrderByCosineDistance) {
+    Y_UNIT_TEST(VectorIndexOrderByCosineDistanceLevel1) {
         NKikimrConfig::TFeatureFlags featureFlags;
         featureFlags.SetEnableVectorIndex(true);
         auto setting = NKikimrKqp::TKqpSetting();
@@ -2307,7 +2307,7 @@ Y_UNIT_TEST_SUITE(KqpIndexes) {
         DoPositiveQueriesVectorIndexOrderByCosine(session);
     }
 
-    Y_UNIT_TEST(VectorIndexOrderByCosineSimilarity) {
+    Y_UNIT_TEST(VectorIndexOrderByCosineSimilarityLevel1) {
         NKikimrConfig::TFeatureFlags featureFlags;
         featureFlags.SetEnableVectorIndex(true);
         auto setting = NKikimrKqp::TKqpSetting();
@@ -2335,7 +2335,7 @@ Y_UNIT_TEST_SUITE(KqpIndexes) {
         DoPositiveQueriesVectorIndexOrderByCosine(session);
     }
 
-    Y_UNIT_TEST(VectorIndexOrderByCosineDistanceNullable) {
+    Y_UNIT_TEST(VectorIndexOrderByCosineDistanceNullableLevel1) {
         NKikimrConfig::TFeatureFlags featureFlags;
         featureFlags.SetEnableVectorIndex(true);
         auto setting = NKikimrKqp::TKqpSetting();
@@ -2363,7 +2363,7 @@ Y_UNIT_TEST_SUITE(KqpIndexes) {
         DoPositiveQueriesVectorIndexOrderByCosine(session);
     }
 
-    Y_UNIT_TEST(VectorIndexOrderByCosineSimilarityNullable) {
+    Y_UNIT_TEST(VectorIndexOrderByCosineSimilarityNullableLevel1) {
         NKikimrConfig::TFeatureFlags featureFlags;
         featureFlags.SetEnableVectorIndex(true);
         auto setting = NKikimrKqp::TKqpSetting();
@@ -2381,6 +2381,118 @@ Y_UNIT_TEST_SUITE(KqpIndexes) {
                     GLOBAL USING vector_kmeans_tree
                     ON (emb)
                     WITH (similarity=cosine, vector_type="uint8", vector_dimension=2, levels=1, clusters=2);
+            )"));
+
+            auto result = session.ExecuteSchemeQuery(createIndex)
+                          .ExtractValueSync();
+
+            UNIT_ASSERT_C(result.IsSuccess(), result.GetIssues().ToString());
+        }
+        DoPositiveQueriesVectorIndexOrderByCosine(session);
+    }
+
+    Y_UNIT_TEST(VectorIndexOrderByCosineDistanceLevel2) {
+        NKikimrConfig::TFeatureFlags featureFlags;
+        featureFlags.SetEnableVectorIndex(true);
+        auto setting = NKikimrKqp::TKqpSetting();
+        auto serverSettings = TKikimrSettings()
+            .SetFeatureFlags(featureFlags)
+            .SetKqpSettings({setting});
+
+        TKikimrRunner kikimr(serverSettings);
+        auto db = kikimr.GetTableClient();
+        auto session = DoCreateTableForVectorIndex(db, false);
+        {
+            const TString createIndex(Q_(R"(
+                ALTER TABLE `/Root/TestTable`
+                    ADD INDEX index
+                    GLOBAL USING vector_kmeans_tree
+                    ON (emb)
+                    WITH (distance=cosine, vector_type="uint8", vector_dimension=2, levels=2, clusters=2);
+            )"));
+
+            auto result = session.ExecuteSchemeQuery(createIndex)
+                          .ExtractValueSync();
+
+            UNIT_ASSERT_C(result.IsSuccess(), result.GetIssues().ToString());
+        }
+        DoPositiveQueriesVectorIndexOrderByCosine(session);
+    }
+
+    Y_UNIT_TEST(VectorIndexOrderByCosineSimilarityLevel2) {
+        NKikimrConfig::TFeatureFlags featureFlags;
+        featureFlags.SetEnableVectorIndex(true);
+        auto setting = NKikimrKqp::TKqpSetting();
+        auto serverSettings = TKikimrSettings()
+            .SetFeatureFlags(featureFlags)
+            .SetKqpSettings({setting});
+
+        TKikimrRunner kikimr(serverSettings);
+        auto db = kikimr.GetTableClient();
+        auto session = DoCreateTableForVectorIndex(db, false);
+        {
+            const TString createIndex(Q_(R"(
+                ALTER TABLE `/Root/TestTable`
+                    ADD INDEX index
+                    GLOBAL USING vector_kmeans_tree
+                    ON (emb)
+                    WITH (similarity=cosine, vector_type="uint8", vector_dimension=2, levels=2, clusters=2);
+            )"));
+
+            auto result = session.ExecuteSchemeQuery(createIndex)
+                          .ExtractValueSync();
+
+            UNIT_ASSERT_C(result.IsSuccess(), result.GetIssues().ToString());
+        }
+        DoPositiveQueriesVectorIndexOrderByCosine(session);
+    }
+
+    Y_UNIT_TEST(VectorIndexOrderByCosineDistanceNullableLevel2) {
+        NKikimrConfig::TFeatureFlags featureFlags;
+        featureFlags.SetEnableVectorIndex(true);
+        auto setting = NKikimrKqp::TKqpSetting();
+        auto serverSettings = TKikimrSettings()
+            .SetFeatureFlags(featureFlags)
+            .SetKqpSettings({setting});
+
+        TKikimrRunner kikimr(serverSettings);
+        auto db = kikimr.GetTableClient();
+        auto session = DoCreateTableForVectorIndex(db, true);
+        {
+            const TString createIndex(Q_(R"(
+                ALTER TABLE `/Root/TestTable`
+                    ADD INDEX index
+                    GLOBAL USING vector_kmeans_tree
+                    ON (emb)
+                    WITH (distance=cosine, vector_type="uint8", vector_dimension=2, levels=2, clusters=2);
+            )"));
+
+            auto result = session.ExecuteSchemeQuery(createIndex)
+                          .ExtractValueSync();
+
+            UNIT_ASSERT_C(result.IsSuccess(), result.GetIssues().ToString());
+        }
+        DoPositiveQueriesVectorIndexOrderByCosine(session);
+    }
+
+    Y_UNIT_TEST(VectorIndexOrderByCosineSimilarityNullableLevel2) {
+        NKikimrConfig::TFeatureFlags featureFlags;
+        featureFlags.SetEnableVectorIndex(true);
+        auto setting = NKikimrKqp::TKqpSetting();
+        auto serverSettings = TKikimrSettings()
+            .SetFeatureFlags(featureFlags)
+            .SetKqpSettings({setting});
+
+        TKikimrRunner kikimr(serverSettings);
+        auto db = kikimr.GetTableClient();
+        auto session = DoCreateTableForVectorIndex(db, true);
+        {
+            const TString createIndex(Q_(R"(
+                ALTER TABLE `/Root/TestTable`
+                    ADD INDEX index
+                    GLOBAL USING vector_kmeans_tree
+                    ON (emb)
+                    WITH (similarity=cosine, vector_type="uint8", vector_dimension=2, levels=2, clusters=2);
             )"));
 
             auto result = session.ExecuteSchemeQuery(createIndex)

--- a/ydb/core/kqp/ut/indexes/kqp_indexes_ut.cpp
+++ b/ydb/core/kqp/ut/indexes/kqp_indexes_ut.cpp
@@ -2326,6 +2326,20 @@ Y_UNIT_TEST_SUITE(KqpIndexes) {
 
             UNIT_ASSERT_C(result.IsSuccess(), result.GetIssues().ToString());
         }
+        {
+            auto result = session.DescribeTable("/Root/TestTable").ExtractValueSync();
+            UNIT_ASSERT_VALUES_EQUAL(result.GetStatus(), NYdb::EStatus::SUCCESS);
+            const auto& indexes = result.GetTableDescription().GetIndexDescriptions();
+            UNIT_ASSERT_EQUAL(indexes.size(), 1);
+            UNIT_ASSERT_EQUAL(indexes[0].GetIndexName(), "index");
+            UNIT_ASSERT_EQUAL(indexes[0].GetIndexColumns(), TVector<TString>{"emb"});
+            const auto& settings = std::get<TKMeansTreeSettings>(indexes[0].GetVectorIndexSettings());
+            UNIT_ASSERT_EQUAL(settings.Settings.Metric, NYdb::NTable::TVectorIndexSettings::EMetric::CosineDistance);
+            UNIT_ASSERT_EQUAL(settings.Settings.VectorType, NYdb::NTable::TVectorIndexSettings::EVectorType::Uint8);
+            UNIT_ASSERT_EQUAL(settings.Settings.VectorDimension, 2);
+            UNIT_ASSERT_EQUAL(settings.Levels, 1);
+            UNIT_ASSERT_EQUAL(settings.Clusters, 2);
+        }
         DoPositiveQueriesVectorIndexOrderByCosine(session);
     }
 
@@ -2353,6 +2367,20 @@ Y_UNIT_TEST_SUITE(KqpIndexes) {
                           .ExtractValueSync();
 
             UNIT_ASSERT_C(result.IsSuccess(), result.GetIssues().ToString());
+        }
+        {
+            auto result = session.DescribeTable("/Root/TestTable").ExtractValueSync();
+            UNIT_ASSERT_VALUES_EQUAL(result.GetStatus(), NYdb::EStatus::SUCCESS);
+            const auto& indexes = result.GetTableDescription().GetIndexDescriptions();
+            UNIT_ASSERT_EQUAL(indexes.size(), 1);
+            UNIT_ASSERT_EQUAL(indexes[0].GetIndexName(), "index");
+            UNIT_ASSERT_EQUAL(indexes[0].GetIndexColumns(), TVector<TString>{"emb"});
+            const auto& settings = std::get<TKMeansTreeSettings>(indexes[0].GetVectorIndexSettings());
+            UNIT_ASSERT_EQUAL(settings.Settings.Metric, NYdb::NTable::TVectorIndexSettings::EMetric::CosineSimilarity);
+            UNIT_ASSERT_EQUAL(settings.Settings.VectorType, NYdb::NTable::TVectorIndexSettings::EVectorType::Uint8);
+            UNIT_ASSERT_EQUAL(settings.Settings.VectorDimension, 2);
+            UNIT_ASSERT_EQUAL(settings.Levels, 1);
+            UNIT_ASSERT_EQUAL(settings.Clusters, 2);
         }
         DoPositiveQueriesVectorIndexOrderByCosine(session);
     }
@@ -2382,6 +2410,20 @@ Y_UNIT_TEST_SUITE(KqpIndexes) {
 
             UNIT_ASSERT_C(result.IsSuccess(), result.GetIssues().ToString());
         }
+        {
+            auto result = session.DescribeTable("/Root/TestTable").ExtractValueSync();
+            UNIT_ASSERT_VALUES_EQUAL(result.GetStatus(), NYdb::EStatus::SUCCESS);
+            const auto& indexes = result.GetTableDescription().GetIndexDescriptions();
+            UNIT_ASSERT_EQUAL(indexes.size(), 1);
+            UNIT_ASSERT_EQUAL(indexes[0].GetIndexName(), "index");
+            UNIT_ASSERT_EQUAL(indexes[0].GetIndexColumns(), TVector<TString>{"emb"});
+            const auto& settings = std::get<TKMeansTreeSettings>(indexes[0].GetVectorIndexSettings());
+            UNIT_ASSERT_EQUAL(settings.Settings.Metric, NYdb::NTable::TVectorIndexSettings::EMetric::CosineDistance);
+            UNIT_ASSERT_EQUAL(settings.Settings.VectorType, NYdb::NTable::TVectorIndexSettings::EVectorType::Uint8);
+            UNIT_ASSERT_EQUAL(settings.Settings.VectorDimension, 2);
+            UNIT_ASSERT_EQUAL(settings.Levels, 1);
+            UNIT_ASSERT_EQUAL(settings.Clusters, 2);
+        }
         DoPositiveQueriesVectorIndexOrderByCosine(session);
     }
 
@@ -2409,6 +2451,20 @@ Y_UNIT_TEST_SUITE(KqpIndexes) {
                           .ExtractValueSync();
 
             UNIT_ASSERT_C(result.IsSuccess(), result.GetIssues().ToString());
+        }
+        {
+            auto result = session.DescribeTable("/Root/TestTable").ExtractValueSync();
+            UNIT_ASSERT_VALUES_EQUAL(result.GetStatus(), NYdb::EStatus::SUCCESS);
+            const auto& indexes = result.GetTableDescription().GetIndexDescriptions();
+            UNIT_ASSERT_EQUAL(indexes.size(), 1);
+            UNIT_ASSERT_EQUAL(indexes[0].GetIndexName(), "index");
+            UNIT_ASSERT_EQUAL(indexes[0].GetIndexColumns(), TVector<TString>{"emb"});
+            const auto& settings = std::get<TKMeansTreeSettings>(indexes[0].GetVectorIndexSettings());
+            UNIT_ASSERT_EQUAL(settings.Settings.Metric, NYdb::NTable::TVectorIndexSettings::EMetric::CosineSimilarity);
+            UNIT_ASSERT_EQUAL(settings.Settings.VectorType, NYdb::NTable::TVectorIndexSettings::EVectorType::Uint8);
+            UNIT_ASSERT_EQUAL(settings.Settings.VectorDimension, 2);
+            UNIT_ASSERT_EQUAL(settings.Levels, 1);
+            UNIT_ASSERT_EQUAL(settings.Clusters, 2);
         }
         DoPositiveQueriesVectorIndexOrderByCosine(session);
     }
@@ -2438,6 +2494,20 @@ Y_UNIT_TEST_SUITE(KqpIndexes) {
 
             UNIT_ASSERT_C(result.IsSuccess(), result.GetIssues().ToString());
         }
+        {
+            auto result = session.DescribeTable("/Root/TestTable").ExtractValueSync();
+            UNIT_ASSERT_VALUES_EQUAL(result.GetStatus(), NYdb::EStatus::SUCCESS);
+            const auto& indexes = result.GetTableDescription().GetIndexDescriptions();
+            UNIT_ASSERT_EQUAL(indexes.size(), 1);
+            UNIT_ASSERT_EQUAL(indexes[0].GetIndexName(), "index");
+            UNIT_ASSERT_EQUAL(indexes[0].GetIndexColumns(), TVector<TString>{"emb"});
+            const auto& settings = std::get<TKMeansTreeSettings>(indexes[0].GetVectorIndexSettings());
+            UNIT_ASSERT_EQUAL(settings.Settings.Metric, NYdb::NTable::TVectorIndexSettings::EMetric::CosineDistance);
+            UNIT_ASSERT_EQUAL(settings.Settings.VectorType, NYdb::NTable::TVectorIndexSettings::EVectorType::Uint8);
+            UNIT_ASSERT_EQUAL(settings.Settings.VectorDimension, 2);
+            UNIT_ASSERT_EQUAL(settings.Levels, 2);
+            UNIT_ASSERT_EQUAL(settings.Clusters, 2);
+        }
         DoPositiveQueriesVectorIndexOrderByCosine(session);
     }
 
@@ -2465,6 +2535,20 @@ Y_UNIT_TEST_SUITE(KqpIndexes) {
                           .ExtractValueSync();
 
             UNIT_ASSERT_C(result.IsSuccess(), result.GetIssues().ToString());
+        }
+        {
+            auto result = session.DescribeTable("/Root/TestTable").ExtractValueSync();
+            UNIT_ASSERT_VALUES_EQUAL(result.GetStatus(), NYdb::EStatus::SUCCESS);
+            const auto& indexes = result.GetTableDescription().GetIndexDescriptions();
+            UNIT_ASSERT_EQUAL(indexes.size(), 1);
+            UNIT_ASSERT_EQUAL(indexes[0].GetIndexName(), "index");
+            UNIT_ASSERT_EQUAL(indexes[0].GetIndexColumns(), TVector<TString>{"emb"});
+            const auto& settings = std::get<TKMeansTreeSettings>(indexes[0].GetVectorIndexSettings());
+            UNIT_ASSERT_EQUAL(settings.Settings.Metric, NYdb::NTable::TVectorIndexSettings::EMetric::CosineSimilarity);
+            UNIT_ASSERT_EQUAL(settings.Settings.VectorType, NYdb::NTable::TVectorIndexSettings::EVectorType::Uint8);
+            UNIT_ASSERT_EQUAL(settings.Settings.VectorDimension, 2);
+            UNIT_ASSERT_EQUAL(settings.Levels, 2);
+            UNIT_ASSERT_EQUAL(settings.Clusters, 2);
         }
         DoPositiveQueriesVectorIndexOrderByCosine(session);
     }
@@ -2494,6 +2578,20 @@ Y_UNIT_TEST_SUITE(KqpIndexes) {
 
             UNIT_ASSERT_C(result.IsSuccess(), result.GetIssues().ToString());
         }
+        {
+            auto result = session.DescribeTable("/Root/TestTable").ExtractValueSync();
+            UNIT_ASSERT_VALUES_EQUAL(result.GetStatus(), NYdb::EStatus::SUCCESS);
+            const auto& indexes = result.GetTableDescription().GetIndexDescriptions();
+            UNIT_ASSERT_EQUAL(indexes.size(), 1);
+            UNIT_ASSERT_EQUAL(indexes[0].GetIndexName(), "index");
+            UNIT_ASSERT_EQUAL(indexes[0].GetIndexColumns(), TVector<TString>{"emb"});
+            const auto& settings = std::get<TKMeansTreeSettings>(indexes[0].GetVectorIndexSettings());
+            UNIT_ASSERT_EQUAL(settings.Settings.Metric, NYdb::NTable::TVectorIndexSettings::EMetric::CosineDistance);
+            UNIT_ASSERT_EQUAL(settings.Settings.VectorType, NYdb::NTable::TVectorIndexSettings::EVectorType::Uint8);
+            UNIT_ASSERT_EQUAL(settings.Settings.VectorDimension, 2);
+            UNIT_ASSERT_EQUAL(settings.Levels, 2);
+            UNIT_ASSERT_EQUAL(settings.Clusters, 2);
+        }
         DoPositiveQueriesVectorIndexOrderByCosine(session);
     }
 
@@ -2521,6 +2619,20 @@ Y_UNIT_TEST_SUITE(KqpIndexes) {
                           .ExtractValueSync();
 
             UNIT_ASSERT_C(result.IsSuccess(), result.GetIssues().ToString());
+        }
+        {
+            auto result = session.DescribeTable("/Root/TestTable").ExtractValueSync();
+            UNIT_ASSERT_VALUES_EQUAL(result.GetStatus(), NYdb::EStatus::SUCCESS);
+            const auto& indexes = result.GetTableDescription().GetIndexDescriptions();
+            UNIT_ASSERT_EQUAL(indexes.size(), 1);
+            UNIT_ASSERT_EQUAL(indexes[0].GetIndexName(), "index");
+            UNIT_ASSERT_EQUAL(indexes[0].GetIndexColumns(), TVector<TString>{"emb"});
+            const auto& settings = std::get<TKMeansTreeSettings>(indexes[0].GetVectorIndexSettings());
+            UNIT_ASSERT_EQUAL(settings.Settings.Metric, NYdb::NTable::TVectorIndexSettings::EMetric::CosineSimilarity);
+            UNIT_ASSERT_EQUAL(settings.Settings.VectorType, NYdb::NTable::TVectorIndexSettings::EVectorType::Uint8);
+            UNIT_ASSERT_EQUAL(settings.Settings.VectorDimension, 2);
+            UNIT_ASSERT_EQUAL(settings.Levels, 2);
+            UNIT_ASSERT_EQUAL(settings.Clusters, 2);
         }
         DoPositiveQueriesVectorIndexOrderByCosine(session);
     }

--- a/ydb/core/protos/tx_datashard.proto
+++ b/ydb/core/protos/tx_datashard.proto
@@ -1548,8 +1548,9 @@ message TEvLocalKMeansRequest {
     optional uint32 NeedsRounds = 14;
 
     // id of parent cluster
-    optional uint32 Parent = 15;
-    // [Child ... Child + K) ids reserved for this kmeans clusters
+    optional uint32 ParentFrom = 15;
+    optional uint32 ParentTo = 21;
+    // [Child ... Child + K * (ParentFrom - ParentTo + 1)) ids reserved for this kmeans clusters
     optional uint32 Child = 16;
 
     optional string LevelName = 17;

--- a/ydb/core/tx/datashard/build_index.cpp
+++ b/ydb/core/tx/datashard/build_index.cpp
@@ -561,7 +561,9 @@ void TDataShard::HandleSafe(TEvDataShard::TEvBuildIndexCreateRequest::TPtr& ev, 
             return;
         }
 
-        CancelScan(userTable.LocalTid, recCard->ScanId);
+        for (auto scanId : recCard->ScanIds) {
+            CancelScan(userTable.LocalTid, scanId);
+        }
         ScanManager.Drop(buildIndexId);
     }
 
@@ -629,9 +631,7 @@ void TDataShard::HandleSafe(TEvDataShard::TEvBuildIndexCreateRequest::TPtr& ev, 
                                   0,
                                   scanOpts);
 
-    TScanRecord recCard = {scanId, seqNo};
-
-    ScanManager.Set(buildIndexId, recCard);
+    ScanManager.Set(buildIndexId, seqNo).push_back(scanId);
 }
 
 }

--- a/ydb/core/tx/datashard/datashard_ut_local_kmeans.cpp
+++ b/ydb/core/tx/datashard/datashard_ut_local_kmeans.cpp
@@ -69,7 +69,8 @@ Y_UNIT_TEST_SUITE (TTxDataShardLocalKMeansScan) {
             rec.SetDoneRounds(0);
             rec.SetNeedsRounds(3);
 
-            rec.SetParent(0);
+            rec.SetParentFrom(0);
+            rec.SetParentTo(0);
             rec.SetChild(1);
 
             if (rec.HasEmbeddingColumn()) {
@@ -133,7 +134,8 @@ Y_UNIT_TEST_SUITE (TTxDataShardLocalKMeansScan) {
                 rec.SetDoneRounds(0);
                 rec.SetNeedsRounds(300);
 
-                rec.SetParent(parent);
+                rec.SetParentFrom(parent);
+                rec.SetParentTo(parent);
                 rec.SetChild(parent + 1);
 
                 rec.SetEmbeddingColumn("embedding");

--- a/ydb/core/tx/datashard/finalize_build_index_unit.cpp
+++ b/ydb/core/tx/datashard/finalize_build_index_unit.cpp
@@ -67,7 +67,9 @@ public:
         Y_ABORT_UNLESS(step != 0);
 
         if (const auto* record = DataShard.GetScanManager().Get(params.GetBuildIndexId())) {
-            DataShard.CancelScan(tableInfo->LocalTid, record->ScanId);
+            for (auto scanId : record->ScanIds) {
+                DataShard.CancelScan(tableInfo->LocalTid, scanId);
+            }
             DataShard.GetScanManager().Drop(params.GetBuildIndexId());
         }
 

--- a/ydb/core/tx/datashard/kmeans_helper.h
+++ b/ydb/core/tx/datashard/kmeans_helper.h
@@ -15,10 +15,11 @@
 
 #include <span>
 
-#define LOG_T(stream) LOG_TRACE_S(*TlsActivationContext, NKikimrServices::TX_DATASHARD, stream)
-#define LOG_D(stream) LOG_DEBUG_S(*TlsActivationContext, NKikimrServices::TX_DATASHARD, stream)
-#define LOG_N(stream) LOG_NOTICE_S(*TlsActivationContext, NKikimrServices::TX_DATASHARD, stream)
-#define LOG_E(stream) LOG_ERROR_S(*TlsActivationContext, NKikimrServices::TX_DATASHARD, stream)
+// TODO(mbkkt) BUILD_INDEX_DATASHARD
+#define LOG_T(stream) LOG_TRACE_S (*TlsActivationContext, NKikimrServices::BUILD_INDEX, stream)
+#define LOG_D(stream) LOG_DEBUG_S (*TlsActivationContext, NKikimrServices::BUILD_INDEX, stream)
+#define LOG_N(stream) LOG_NOTICE_S(*TlsActivationContext, NKikimrServices::BUILD_INDEX, stream)
+#define LOG_E(stream) LOG_ERROR_S (*TlsActivationContext, NKikimrServices::BUILD_INDEX, stream)
 
 namespace NKikimr::NDataShard::NKMeans {
 
@@ -56,7 +57,7 @@ template <typename T>
 struct TMetric {
     using TCoord = T;
     // TODO(mbkkt) maybe compute floating sum in double? Needs benchmark
-    using TSum = std::conditional_t<std::is_floating_point_v<T>, T, int64_t>;
+    using TSum = std::conditional_t<std::is_floating_point_v<T>, T, i64>;
 
     ui32 Dimensions = 0;
 
@@ -218,13 +219,13 @@ MakeUploadTypes(const TUserTable& table, NKikimrTxDataShard::TEvLocalKMeansReque
 void MakeScan(auto& record, const auto& createScan, const auto& badRequest)
 {
     if (!record.HasEmbeddingColumn()) {
-        badRequest(TStringBuilder() << "Should be specified embedding column");
+        badRequest("Should be specified embedding column");
         return;
     }
 
     const auto& settings = record.GetSettings();
     if (settings.vector_dimension() < 1) {
-        badRequest(TStringBuilder() << "Dimension of vector should be at least one");
+        badRequest("Dimension of vector should be at least one");
         return;
     }
 

--- a/ydb/core/tx/datashard/local_kmeans.cpp
+++ b/ydb/core/tx/datashard/local_kmeans.cpp
@@ -22,6 +22,42 @@
 namespace NKikimr::NDataShard {
 using namespace NKMeans;
 
+class TResult {
+public:
+    explicit TResult(const TActorId& responseActorId, TAutoPtr<TEvDataShard::TEvLocalKMeansResponse> response)
+        : ResponseActorId{responseActorId}
+        , Response{std::move(response)} {
+            Y_ASSERT(Response);
+        }
+
+    void SizeAdd(i64 size) {
+        if (size != 0) {
+            std::lock_guard lock{Mutex};
+            Size += size;
+        }
+    }
+
+    template<typename Func>
+    void Send(const TActorContext& ctx, Func&& func) {
+        std::unique_lock lock{Mutex};
+        if (Size <= 0) {
+            return;
+        }
+        if (func(Response->Record) && --Size > 0) {
+            return;
+        }
+        Size = 0;
+        lock.unlock();
+        ctx.Send(ResponseActorId, std::move(Response));
+    }
+
+private:
+    std::mutex Mutex;
+    i64 Size = 1;
+    TActorId ResponseActorId;
+    TAutoPtr<TEvDataShard::TEvLocalKMeansResponse> Response;
+};
+
 // This scan needed to run local (not distributed) kmeans.
 // We have this local stage because we construct kmeans tree from top to bottom.
 // And bottom kmeans can be constructed completely locally in datashards to avoid extra communication.
@@ -64,6 +100,8 @@ protected:
     IDriver* Driver = nullptr;
 
     TLead Lead;
+
+    ui64 BuildId = 0;
 
     ui64 ReadRows = 0;
     ui64 ReadBytes = 0;
@@ -110,9 +148,7 @@ protected:
     ui64 UploadRows = 0;
     ui64 UploadBytes = 0;
 
-    // Response
-    TActorId ResponseActorId;
-    TAutoPtr<TEvDataShard::TEvLocalKMeansResponse> Response;
+    std::shared_ptr<TResult> Result;
 
 public:
     static constexpr NKikimrServices::TActivity::EType ActorActivityType()
@@ -120,22 +156,22 @@ public:
         return NKikimrServices::TActivity::LOCAL_KMEANS_SCAN_ACTOR;
     }
 
-    TLocalKMeansScanBase(const TUserTable& table, TLead&& lead,
-                         const NKikimrTxDataShard::TEvLocalKMeansRequest& request, const TActorId& responseActorId,
-                         TAutoPtr<TEvDataShard::TEvLocalKMeansResponse>&& response)
+    TLocalKMeansScanBase(ui64 buildId, const TUserTable& table, TLead&& lead, ui32 parent, ui32 child,
+                         const NKikimrTxDataShard::TEvLocalKMeansRequest& request,
+                         std::shared_ptr<TResult> result)
         : TActor{&TThis::StateWork}
-        , Parent{request.GetParent()}
-        , Child{request.GetChild()}
+        , Parent{parent}
+        , Child{child}
         , MaxRounds{request.GetNeedsRounds() - request.GetDoneRounds()}
         , K{request.GetK()}
         , State{request.GetState()}
         , UploadState{request.GetUpload()}
         , Lead{std::move(lead)}
+        , BuildId{buildId}
         , Rng{request.GetSeed()}
         , TargetTable{request.GetLevelName()}
         , NextTable{request.GetPostingName()}
-        , ResponseActorId{responseActorId}
-        , Response{std::move(response)}
+        , Result{std::move(result)}
     {
         const auto& embedding = request.GetEmbeddingColumn();
         const auto& data = request.GetDataColumns();
@@ -171,20 +207,23 @@ public:
             Uploader = {};
         }
 
-        auto& record = Response->Record;
-        record.SetReadRows(ReadRows);
-        record.SetReadBytes(ReadBytes);
-        record.SetUploadRows(UploadRows);
-        record.SetUploadBytes(UploadBytes);
-        if (abort != EAbort::None) {
-            record.SetStatus(NKikimrIndexBuilder::EBuildStatus::ABORTED);
-        } else if (UploadStatus.IsSuccess()) {
-            record.SetStatus(NKikimrIndexBuilder::EBuildStatus::DONE);
-        } else {
-            record.SetStatus(NKikimrIndexBuilder::EBuildStatus::BUILD_ERROR);
-        }
-        NYql::IssuesToMessage(UploadStatus.Issues, record.MutableIssues());
-        Send(ResponseActorId, Response.Release());
+        Result->Send(TActivationContext::AsActorContext(), [&] (NKikimrTxDataShard::TEvLocalKMeansResponse& response) {
+            response.SetReadRows(ReadRows);
+            response.SetReadBytes(ReadBytes);
+            response.SetUploadRows(UploadRows);
+            response.SetUploadBytes(UploadBytes);
+            NYql::IssuesToMessage(UploadStatus.Issues, response.MutableIssues());
+            if (abort != EAbort::None) {
+                response.SetStatus(NKikimrIndexBuilder::EBuildStatus::ABORTED);
+                return false;
+            } else if (UploadStatus.IsSuccess()) {
+                response.SetStatus(NKikimrIndexBuilder::EBuildStatus::DONE);
+                return true;
+            } else {
+                response.SetStatus(NKikimrIndexBuilder::EBuildStatus::BUILD_ERROR);
+                return false;
+            }
+        });
 
         Driver = nullptr;
         this->PassAway();
@@ -198,13 +237,9 @@ public:
 
     TString Debug() const
     {
-        auto builder = TStringBuilder() << " TLocalKMeansScan";
-        if (Response) {
-            auto& r = Response->Record;
-            builder << " Id: " << r.GetId();
-        }
-        return builder << " State: " << State << " Round: " << Round << " MaxRounds: " << MaxRounds
-                       << " ReadBuf size: " << ReadBuf.Size() << " WriteBuf size: " << WriteBuf.Size() << " ";
+        return TStringBuilder() << " TLocalKMeansScan Id: " << BuildId
+            << " State: " << State << " Round: " << Round << " MaxRounds: " << MaxRounds
+            << " ReadBuf size: " << ReadBuf.Size() << " WriteBuf size: " << WriteBuf.Size() << " ";
     }
 
     EScan PageFault() noexcept final
@@ -346,9 +381,9 @@ class TLocalKMeansScan final: public TLocalKMeansScanBase, private TCalculation<
     std::vector<TAggregatedCluster> AggregatedClusters;
 
 public:
-    TLocalKMeansScan(const TUserTable& table, TLead&& lead, NKikimrTxDataShard::TEvLocalKMeansRequest& request,
-                     const TActorId& responseActorId, TAutoPtr<TEvDataShard::TEvLocalKMeansResponse>&& response)
-        : TLocalKMeansScanBase{table, std::move(lead), request, responseActorId, std::move(response)}
+    TLocalKMeansScan(ui64 buildId, const TUserTable& table, TLead&& lead, ui32 parent, ui32 child, NKikimrTxDataShard::TEvLocalKMeansRequest& request,
+                     std::shared_ptr<TResult> result)
+        : TLocalKMeansScanBase{buildId, table, std::move(lead), parent, child, request, std::move(result)}
     {
         this->Dimensions = request.GetSettings().vector_dimension();
     }
@@ -613,9 +648,9 @@ void TDataShard::Handle(TEvDataShard::TEvLocalKMeansRequest::TPtr& ev, const TAc
 
 void TDataShard::HandleSafe(TEvDataShard::TEvLocalKMeansRequest::TPtr& ev, const TActorContext& ctx)
 {
-    auto& record = ev->Get()->Record;
-    const bool needsSnapshot = record.HasSnapshotStep() || record.HasSnapshotTxId();
-    TRowVersion rowVersion(record.GetSnapshotStep(), record.GetSnapshotTxId());
+    auto& request = ev->Get()->Record;
+    const bool needsSnapshot = request.HasSnapshotStep() || request.HasSnapshotTxId();
+    TRowVersion rowVersion(request.GetSnapshotStep(), request.GetSnapshotTxId());
     if (!needsSnapshot) {
         rowVersion = GetMvccTxVersion(EMvccTxMode::ReadOnly);
     }
@@ -625,30 +660,38 @@ void TDataShard::HandleSafe(TEvDataShard::TEvLocalKMeansRequest::TPtr& ev, const
         VolatileTxManager.AttachWaitingSnapshotEvent(rowVersion, std::unique_ptr<IEventHandle>(ev.Release()));
         return;
     }
-    const ui64 id = record.GetId();
+    const ui64 id = request.GetId();
 
     auto response = MakeHolder<TEvDataShard::TEvLocalKMeansResponse>();
     response->Record.SetId(id);
     response->Record.SetTabletId(TabletID());
 
-    TScanRecord::TSeqNo seqNo = {record.GetSeqNoGeneration(), record.GetSeqNoRound()};
+    TScanRecord::TSeqNo seqNo = {request.GetSeqNoGeneration(), request.GetSeqNoRound()};
     response->Record.SetRequestSeqNoGeneration(seqNo.Generation);
     response->Record.SetRequestSeqNoRound(seqNo.Round);
+    auto result = std::make_shared<TResult>(ev->Sender, std::move(response));
+    ui32 localTid = 0;
+    TScanRecord::TScanIds scanIds;
 
     auto badRequest = [&](const TString& error) {
-        response->Record.SetStatus(NKikimrIndexBuilder::EBuildStatus::BAD_REQUEST);
-        auto issue = response->Record.AddIssues();
-        issue->set_severity(NYql::TSeverityIds::S_ERROR);
-        issue->set_message(error);
-        ctx.Send(ev->Sender, std::move(response));
+        for (auto scanId : scanIds) {
+            CancelScan(localTid, scanId);
+        }
+        result->Send(ctx, [&] (NKikimrTxDataShard::TEvLocalKMeansResponse& response) {
+            response.SetStatus(NKikimrIndexBuilder::EBuildStatus::BAD_REQUEST);
+            auto issue = response.AddIssues();
+            issue->set_severity(NYql::TSeverityIds::S_ERROR);
+            issue->set_message(error);
+            return false;
+        });
     };
 
-    if (const ui64 shardId = record.GetTabletId(); shardId != TabletID()) {
+    if (const ui64 shardId = request.GetTabletId(); shardId != TabletID()) {
         badRequest(TStringBuilder() << "Wrong shard " << shardId << " this is " << TabletID());
         return;
     }
 
-    const auto pathId = TPathId::FromProto(record.GetPathId());
+    const auto pathId = TPathId::FromProto(request.GetPathId());
     const auto* userTableIt = GetUserTables().FindPtr(pathId.LocalPathId);
     if (!userTableIt) {
         badRequest(TStringBuilder() << "Unknown table id: " << pathId.LocalPathId);
@@ -663,16 +706,13 @@ void TDataShard::HandleSafe(TEvDataShard::TEvLocalKMeansRequest::TPtr& ev, const
             return;
         }
 
-        CancelScan(userTable.LocalTid, recCard->ScanId);
+        for (auto scanId : recCard->ScanIds) {
+            CancelScan(userTable.LocalTid, scanId);
+        }
         ScanManager.Drop(id);
     }
 
-    TCell from, to;
-    const auto range = CreateRangeFrom(userTable, record.GetParent(), from, to);
-    if (range.IsEmptyRange(userTable.KeyColumnTypes)) {
-        badRequest(TStringBuilder() << " requested range doesn't intersect with table range");
-        return;
-    }
+    localTid = userTable.LocalTid;
 
     const TSnapshotKey snapshotKey(pathId, rowVersion.Step, rowVersion.TxId);
     if (needsSnapshot && !SnapshotManager.FindAvailable(snapshotKey)) {
@@ -687,28 +727,54 @@ void TDataShard::HandleSafe(TEvDataShard::TEvLocalKMeansRequest::TPtr& ev, const
         return;
     }
 
-    if (record.GetK() < 2) {
-        badRequest(TStringBuilder() << "Should be requested partition on at least two rows");
+    if (request.GetK() < 2) {
+        badRequest("Should be requested partition on at least two rows");
         return;
     }
 
-    TAutoPtr<NTable::IScan> scan;
-    auto createScan = [&]<typename T> {
-        scan = new TLocalKMeansScan<T>{
-            userTable, CreateLeadFrom(range), record, ev->Sender, std::move(response),
+    const auto parentFrom = request.GetParentFrom();
+    const auto parentTo = request.GetParentTo();
+    if (parentFrom > parentTo) {
+        badRequest("Parent from should be less or equal to parent to");
+        return;
+    }
+    const i64 expectedSize = parentTo - parentFrom + 1;
+    result->SizeAdd(expectedSize);
+
+    for (auto parent = parentFrom; parent <= parentTo; ++parent) {
+        TCell from, to;
+        const auto range = CreateRangeFrom(userTable, parent, from, to);
+        if (range.IsEmptyRange(userTable.KeyColumnTypes)) {
+            continue;
+        }
+
+        TAutoPtr<NTable::IScan> scan;
+        auto createScan = [&]<typename T> {
+            scan = new TLocalKMeansScan<T>{
+                request.GetId(), userTable,
+                CreateLeadFrom(range), parent, request.GetChild() + request.GetK() * (parent - parentFrom),
+                request, result,
+            };
         };
-    };
-    MakeScan(record, createScan, badRequest);
-    if (!scan) {
-        return;
+        MakeScan(request, createScan, badRequest);
+        if (!scan) {
+            return;
+        }
+
+        TScanOptions scanOpts;
+        scanOpts.SetSnapshotRowVersion(rowVersion);
+        scanOpts.SetResourceBroker("build_index", 10); // TODO(mbkkt) Should be different group?
+        const auto scanId = QueueScan(userTable.LocalTid, std::move(scan), 0, scanOpts);
+        scanIds.push_back(scanId);
     }
 
-    TScanOptions scanOpts;
-    scanOpts.SetSnapshotRowVersion(rowVersion);
-    scanOpts.SetResourceBroker("build_index", 10); // TODO(mbkkt) Should be different group?
-    const auto scanId = QueueScan(userTable.LocalTid, std::move(scan), 0, scanOpts);
-    TScanRecord recCard = {scanId, seqNo};
-    ScanManager.Set(id, recCard);
+    if (scanIds.empty()) {
+        badRequest("Requested range doesn't intersect with table range");
+        return;
+    }
+    result->SizeAdd(static_cast<i64>(scanIds.size()) - expectedSize);
+    result->Send(ctx, [] (auto&) { return true; });  // decrement extra one
+    ScanManager.Set(id, seqNo) = std::move(scanIds);
 }
 
 }

--- a/ydb/core/tx/datashard/reshuffle_kmeans.cpp
+++ b/ydb/core/tx/datashard/reshuffle_kmeans.cpp
@@ -38,6 +38,8 @@ protected:
 
     TLead Lead;
 
+    ui64 BuildId = 0;
+
     ui64 ReadRows = 0;
     ui64 ReadBytes = 0;
 
@@ -86,6 +88,7 @@ public:
         , K{static_cast<ui32>(request.ClustersSize())}
         , UploadState{request.GetUpload()}
         , Lead{std::move(lead)}
+        , BuildId{request.GetId()}
         , Clusters{request.GetClusters().begin(), request.GetClusters().end()}
         , TargetTable{request.GetPostingName()}
         , ResponseActorId{responseActorId}
@@ -103,7 +106,7 @@ public:
     TInitialState Prepare(IDriver* driver, TIntrusiveConstPtr<TScheme>) noexcept final
     {
         TActivationContext::AsActorContext().RegisterWithSameMailbox(this);
-        LOG_T("Prepare " << Debug());
+        LOG_D("Prepare " << Debug());
 
         Driver = driver;
         return {EScan::Feed, {}};
@@ -111,7 +114,7 @@ public:
 
     EScan Seek(TLead& lead, ui64 seq) noexcept final
     {
-        LOG_T("Seek " << Debug());
+        LOG_D("Seek " << Debug());
         if (seq == 0) {
             lead = std::move(Lead);
             lead.SetTags(UploadScan);
@@ -133,7 +136,7 @@ public:
 
     TAutoPtr<IDestructable> Finish(EAbort abort) noexcept final
     {
-        LOG_T("Finish " << Debug());
+        LOG_D("Finish " << Debug());
 
         if (Uploader) {
             Send(Uploader, new TEvents::TEvPoison);
@@ -167,13 +170,9 @@ public:
 
     TString Debug() const
     {
-        auto builder = TStringBuilder() << " TReshuffleKMeansScan";
-        if (Response) {
-            auto& r = Response->Record;
-            builder << " Id: " << r.GetId();
-        }
-        return builder << " Upload: " << UploadState << " ReadBuf size: " << ReadBuf.Size()
-                       << " WriteBuf size: " << WriteBuf.Size() << " ";
+        return TStringBuilder() << " TReshuffleKMeansScan Id: " << BuildId << " Parent: " << Parent << " Child: " << Child
+            << " Target: " << TargetTable << " K: " << K << " Clusters: " << Clusters.size()
+            << " ReadBuf size: " << ReadBuf.Size() << " WriteBuf size: " << WriteBuf.Size() << " ";
     }
 
     EScan PageFault() noexcept final
@@ -211,7 +210,7 @@ protected:
 
     void Handle(TEvTxUserProxy::TEvUploadRowsResponse::TPtr& ev)
     {
-        LOG_T("Handle TEvUploadRowsResponse " << Debug() << " Uploader: " << Uploader.ToString()
+        LOG_D("Handle TEvUploadRowsResponse " << Debug() << " Uploader: " << Uploader.ToString()
                                               << " ev->Sender: " << ev->Sender.ToString());
 
         if (Uploader) {
@@ -286,6 +285,7 @@ public:
         : TReshuffleKMeansScanBase{table, std::move(lead), request, responseActorId, std::move(response)}
     {
         this->Dimensions = request.GetSettings().vector_dimension();
+        LOG_D("Create " << Debug());
     }
 
     EScan Feed(TArrayRef<const TCell> key, const TRow& row) noexcept final
@@ -406,6 +406,7 @@ void TDataShard::HandleSafe(TEvDataShard::TEvReshuffleKMeansRequest::TPtr& ev, c
         issue->set_severity(NYql::TSeverityIds::S_ERROR);
         issue->set_message(error);
         ctx.Send(ev->Sender, std::move(response));
+        response.Reset();
     };
 
     if (const ui64 shardId = record.GetTabletId(); shardId != TabletID()) {
@@ -455,7 +456,7 @@ void TDataShard::HandleSafe(TEvDataShard::TEvReshuffleKMeansRequest::TPtr& ev, c
     }
 
     if (record.ClustersSize() < 1) {
-        badRequest(TStringBuilder() << "Should be requested at least single cluster");
+        badRequest("Should be requested at least single cluster");
         return;
     }
 
@@ -467,6 +468,7 @@ void TDataShard::HandleSafe(TEvDataShard::TEvReshuffleKMeansRequest::TPtr& ev, c
     };
     MakeScan(record, createScan, badRequest);
     if (!scan) {
+        Y_ASSERT(!response);
         return;
     }
 

--- a/ydb/core/tx/datashard/reshuffle_kmeans.cpp
+++ b/ydb/core/tx/datashard/reshuffle_kmeans.cpp
@@ -428,7 +428,9 @@ void TDataShard::HandleSafe(TEvDataShard::TEvReshuffleKMeansRequest::TPtr& ev, c
             return;
         }
 
-        CancelScan(userTable.LocalTid, recCard->ScanId);
+        for (auto scanId : recCard->ScanIds) {
+            CancelScan(userTable.LocalTid, scanId);
+        }
         ScanManager.Drop(id);
     }
 
@@ -472,8 +474,7 @@ void TDataShard::HandleSafe(TEvDataShard::TEvReshuffleKMeansRequest::TPtr& ev, c
     scanOpts.SetSnapshotRowVersion(rowVersion);
     scanOpts.SetResourceBroker("build_index", 10); // TODO(mbkkt) Should be different group?
     const auto scanId = QueueScan(userTable.LocalTid, std::move(scan), 0, scanOpts);
-    TScanRecord recCard = {scanId, seqNo};
-    ScanManager.Set(id, recCard);
+    ScanManager.Set(id, seqNo).push_back(scanId);
 }
 
 }

--- a/ydb/core/tx/datashard/sample_k.cpp
+++ b/ydb/core/tx/datashard/sample_k.cpp
@@ -1,4 +1,5 @@
 #include "datashard_impl.h"
+#include "kmeans_helper.h"
 #include "range_ops.h"
 #include "scan_common.h"
 #include "upload_stats.h"
@@ -18,9 +19,6 @@
 
 #include <util/generic/algorithm.h>
 #include <util/string/builder.h>
-
-#define LOG_T(stream) LOG_TRACE_S(*TlsActivationContext, NKikimrServices::TX_DATASHARD, stream)
-#define LOG_E(stream) LOG_ERROR_S(*TlsActivationContext, NKikimrServices::TX_DATASHARD, stream)
 
 namespace NKikimr::NDataShard {
 
@@ -43,6 +41,8 @@ protected:
         bool operator==(const TProbability&) const noexcept = default;
         auto operator<=>(const TProbability&) const noexcept = default;
     };
+
+    ui64 BuildId = 0;
 
     ui64 ReadRows = 0;
     ui64 ReadBytes = 0;
@@ -77,9 +77,11 @@ public:
         , TableRange(tableInfo.Range)
         , RequestedRange(range)
         , K(k)
+        , BuildId(Response->Record.GetId())
         , MaxProbability(maxProbability)
         , Rng(seed) {
         Y_ASSERT(MaxProbability != 0);
+        LOG_D("Create " << Debug());
     }
 
     ~TSampleKScan() final = default;
@@ -87,7 +89,7 @@ public:
     TInitialState Prepare(IDriver* driver, TIntrusiveConstPtr<TScheme>) noexcept final {
         TActivationContext::AsActorContext().RegisterWithSameMailbox(this);
 
-        LOG_T("Prepare " << Debug());
+        LOG_D("Prepare " << Debug());
 
         Driver = driver;
 
@@ -96,7 +98,7 @@ public:
 
     EScan Seek(TLead& lead, ui64 seq) noexcept final {
         Y_ABORT_UNLESS(seq == 0);
-        LOG_T("Seek " << Debug());
+        LOG_D("Seek " << Debug());
 
         auto scanRange = Intersect(KeyTypes, RequestedRange.ToTableRange(), TableRange.ToTableRange());
 
@@ -155,7 +157,7 @@ public:
         } else {
             Response->Record.SetStatus(NKikimrIndexBuilder::EBuildStatus::ABORTED);
         }
-        LOG_T("Finish " << Debug());
+        LOG_D("Finish " << Debug());
         Send(ResponseActorId, Response.Release());
         Driver = nullptr;
         PassAway();
@@ -171,15 +173,8 @@ public:
     }
 
     TString Debug() const {
-        if (!Response) {
-            return "empty TSampleKScan";
-        }
-        auto& rec = Response->Record;
-        return TStringBuilder() << "TSampleKScan:"
-                                << "id: " << rec.GetId()
-                                << ", shard: " << rec.GetTabletId()
-                                << ", generation: " << rec.GetRequestSeqNoGeneration()
-                                << ", round: " << rec.GetRequestSeqNoRound();
+        return TStringBuilder() << " TSampleKScan Id: " << BuildId
+            << " K: " << K << " Clusters: " << MaxRows.size() << " ";
     }
 
 private:
@@ -322,12 +317,12 @@ void TDataShard::HandleSafe(TEvDataShard::TEvSampleKRequest::TPtr& ev, const TAc
     }
 
     if (record.GetK() < 1) {
-        badRequest(TStringBuilder() << "Should be requested at least single row");
+        badRequest("Should be requested at least single row");
         return;
     }
 
     if (record.ColumnsSize() < 1) {
-        badRequest(TStringBuilder() << "Should be requested at least single column");
+        badRequest("Should be requested at least single column");
         return;
     }
 

--- a/ydb/core/tx/datashard/sample_k.cpp
+++ b/ydb/core/tx/datashard/sample_k.cpp
@@ -287,7 +287,9 @@ void TDataShard::HandleSafe(TEvDataShard::TEvSampleKRequest::TPtr& ev, const TAc
             return;
         }
 
-        CancelScan(userTable.LocalTid, recCard->ScanId);
+        for (auto scanId : recCard->ScanIds) {
+            CancelScan(userTable.LocalTid, scanId);
+        }
         ScanManager.Drop(id);
     }
 
@@ -346,8 +348,7 @@ void TDataShard::HandleSafe(TEvDataShard::TEvSampleKRequest::TPtr& ev, const TAc
                                   0,
                                   scanOpts);
 
-    TScanRecord recCard = {scanId, seqNo};
-    ScanManager.Set(id, recCard);
+    ScanManager.Set(id, seqNo).push_back(scanId);
 }
 
 }

--- a/ydb/core/tx/datashard/scan_common.h
+++ b/ydb/core/tx/datashard/scan_common.h
@@ -21,9 +21,10 @@ struct TScanRecord {
         bool operator==(const TSeqNo& x) const noexcept = default;
         auto operator<=>(const TSeqNo& x) const noexcept = default;
     };
+    using TScanIds = std::vector<ui64>;
 
-    ui64 ScanId = 0;
     TSeqNo SeqNo;
+    TScanIds ScanIds;
 };
 
 class TScanManager {
@@ -37,11 +38,12 @@ public:
         return nullptr;
     }
 
-    void Set(ui64 id, TScanRecord record) {
+    TScanRecord::TScanIds& Set(ui64 id, TScanRecord::TSeqNo seqNo) {
         Y_ABORT_UNLESS(id != 0);
         Y_ABORT_UNLESS(Id == 0);
         Id = id;
-        Record = record;
+        Record.SeqNo = seqNo;
+        return Record.ScanIds;
     }
 
     void Drop(ui64 id) {

--- a/ydb/core/tx/schemeshard/schemeshard__init.cpp
+++ b/ydb/core/tx/schemeshard/schemeshard__init.cpp
@@ -4488,6 +4488,55 @@ struct TSchemeShard::TTxInit : public TTransactionBase<TSchemeShard> {
                              << ", records: " << Self->IndexBuilds.size()
                              << ", at schemeshard: " << Self->TabletID());
 
+            // read kmeans tree state
+            {
+                auto rowset = db.Table<Schema::KMeansTreeState>().Range().Select();
+                if (!rowset.IsReady()) {
+                    return false;
+                }
+
+                while (!rowset.EndOfSet()) {
+                    TIndexBuildId id = rowset.GetValue<Schema::KMeansTreeState::Id>();
+                    const auto* buildInfoPtr = Self->IndexBuilds.FindPtr(id);
+                    Y_VERIFY_S(buildInfoPtr, "BuildIndex not found: id# " << id);
+                    auto& buildInfo = *buildInfoPtr->Get();
+                    buildInfo.KMeans.Set(
+                        rowset.GetValue<Schema::KMeansTreeState::Level>(),
+                        rowset.GetValue<Schema::KMeansTreeState::Parent>(),
+                        rowset.GetValue<Schema::KMeansTreeState::State>()
+                    );
+                    buildInfo.Sample.Rows.reserve(buildInfo.KMeans.K * 2);
+
+                    if (!rowset.Next()) {
+                        return false;
+                    }
+                }
+            }
+
+
+            // read kmeans tree sample
+            {
+                auto rowset = db.Table<Schema::KMeansTreeSample>().Range().Select();
+                if (!rowset.IsReady()) {
+                    return false;
+                }
+
+                while (!rowset.EndOfSet()) {
+                    TIndexBuildId id = rowset.GetValue<Schema::KMeansTreeSample::Id>();
+                    const auto* buildInfoPtr = Self->IndexBuilds.FindPtr(id);
+                    Y_VERIFY_S(buildInfoPtr, "BuildIndex not found: id# " << id);
+                    auto& buildInfo = *buildInfoPtr->Get();
+                    buildInfo.Sample.Set(
+                        rowset.GetValue<Schema::KMeansTreeSample::Probability>(),
+                        rowset.GetValue<Schema::KMeansTreeSample::Data>()
+                    );
+
+                    if (!rowset.Next()) {
+                        return false;
+                    }
+                }
+            }
+
             // read index build columns
             {
                 auto rowset = db.Table<Schema::IndexBuildColumns>().Range().Select();
@@ -4543,55 +4592,6 @@ struct TSchemeShard::TTxInit : public TTransactionBase<TSchemeShard> {
                                    << ": id# " << id);
                     auto& buildInfo = *buildInfoPtr->Get();
                     buildInfo.AddShardStatus(rowset);
-
-                    if (!rowset.Next()) {
-                        return false;
-                    }
-                }
-            }
-
-            // read kmeans tree state
-            {
-                auto rowset = db.Table<Schema::KMeansTreeState>().Range().Select();
-                if (!rowset.IsReady()) {
-                    return false;
-                }
-
-                while (!rowset.EndOfSet()) {
-                    TIndexBuildId id = rowset.GetValue<Schema::KMeansTreeState::Id>();
-                    const auto* buildInfoPtr = Self->IndexBuilds.FindPtr(id);
-                    Y_VERIFY_S(buildInfoPtr, "BuildIndex not found: id# " << id);
-                    auto& buildInfo = *buildInfoPtr->Get();
-                    buildInfo.KMeans.Set(
-                        rowset.GetValue<Schema::KMeansTreeState::Level>(),
-                        rowset.GetValue<Schema::KMeansTreeState::Parent>(),
-                        rowset.GetValue<Schema::KMeansTreeState::State>()
-                    );
-                    buildInfo.Sample.Rows.reserve(buildInfo.KMeans.K);
-
-                    if (!rowset.Next()) {
-                        return false;
-                    }
-                }
-            }
-
-
-            // read kmeans tree sample
-            {
-                auto rowset = db.Table<Schema::KMeansTreeSample>().Range().Select();
-                if (!rowset.IsReady()) {
-                    return false;
-                }
-
-                while (!rowset.EndOfSet()) {
-                    TIndexBuildId id = rowset.GetValue<Schema::KMeansTreeSample::Id>();
-                    const auto* buildInfoPtr = Self->IndexBuilds.FindPtr(id);
-                    Y_VERIFY_S(buildInfoPtr, "BuildIndex not found: id# " << id);
-                    auto& buildInfo = *buildInfoPtr->Get();
-                    buildInfo.Sample.Set(
-                        rowset.GetValue<Schema::KMeansTreeSample::Probability>(),
-                        rowset.GetValue<Schema::KMeansTreeSample::Data>()
-                    );
 
                     if (!rowset.Next()) {
                         return false;

--- a/ydb/core/tx/schemeshard/schemeshard__init.cpp
+++ b/ydb/core/tx/schemeshard/schemeshard__init.cpp
@@ -4589,7 +4589,6 @@ struct TSchemeShard::TTxInit : public TTransactionBase<TSchemeShard> {
                     Y_VERIFY_S(buildInfoPtr, "BuildIndex not found: id# " << id);
                     auto& buildInfo = *buildInfoPtr->Get();
                     buildInfo.Sample.Set(
-                        rowset.GetValue<Schema::KMeansTreeSample::Row>(),
                         rowset.GetValue<Schema::KMeansTreeSample::Probability>(),
                         rowset.GetValue<Schema::KMeansTreeSample::Data>()
                     );

--- a/ydb/core/tx/schemeshard/schemeshard__operation_create_build_index.cpp
+++ b/ydb/core/tx/schemeshard/schemeshard__operation_create_build_index.cpp
@@ -113,8 +113,8 @@ TVector<ISubOperation::TPtr> CreateBuildIndex(TOperationId opId, const TTxTransa
         result.push_back(CreateInitializeBuildIndexMainTable(NextPartId(opId, result), outTx));
     }
 
-    auto createImplTable = [&](NKikimrSchemeOp::TTableDescription&& implTableDesc) {
-        implTableDesc.MutablePartitionConfig()->SetShadowData(true);
+    auto createImplTable = [&](bool shadow, NKikimrSchemeOp::TTableDescription&& implTableDesc) {
+        implTableDesc.MutablePartitionConfig()->SetShadowData(shadow);
 
         auto outTx = TransactionTemplate(index.PathString(), NKikimrSchemeOp::EOperationType::ESchemeOpInitiateBuildIndexImplTable);
         *outTx.MutableCreateTable() = std::move(implTableDesc);
@@ -129,12 +129,12 @@ TVector<ISubOperation::TPtr> CreateBuildIndex(TOperationId opId, const TTxTransa
             indexLevelTableDesc = indexDesc.GetIndexImplTableDescriptions(0);
             indexPostingTableDesc = indexDesc.GetIndexImplTableDescriptions(0);
         }
-        result.push_back(createImplTable(CalcVectorKmeansTreeLevelImplTableDesc(tableInfo->PartitionConfig(), indexLevelTableDesc)));
-        result.push_back(createImplTable(CalcVectorKmeansTreePostingImplTableDesc(tableInfo, tableInfo->PartitionConfig(), implTableColumns, indexPostingTableDesc)));
+        result.push_back(createImplTable(true, CalcVectorKmeansTreeLevelImplTableDesc(tableInfo->PartitionConfig(), indexLevelTableDesc)));
+        result.push_back(createImplTable(true, CalcVectorKmeansTreePostingImplTableDesc(tableInfo, tableInfo->PartitionConfig(), implTableColumns, indexPostingTableDesc)));
         // TODO Maybe better to use partition from main table
         // This tables are temporary and handled differently in apply_build_index
-        result.push_back(createImplTable(CalcVectorKmeansTreePostingImplTableDesc(tableInfo, tableInfo->PartitionConfig(), implTableColumns, indexPostingTableDesc, NTableVectorKmeansTreeIndex::BuildSuffix0)));
-        result.push_back(createImplTable(CalcVectorKmeansTreePostingImplTableDesc(tableInfo, tableInfo->PartitionConfig(), implTableColumns, indexPostingTableDesc, NTableVectorKmeansTreeIndex::BuildSuffix1)));
+        result.push_back(createImplTable(false, CalcVectorKmeansTreePostingImplTableDesc(tableInfo, tableInfo->PartitionConfig(), implTableColumns, indexPostingTableDesc, NTableVectorKmeansTreeIndex::BuildSuffix0)));
+        result.push_back(createImplTable(false, CalcVectorKmeansTreePostingImplTableDesc(tableInfo, tableInfo->PartitionConfig(), implTableColumns, indexPostingTableDesc, NTableVectorKmeansTreeIndex::BuildSuffix1)));
     } else {
         NKikimrSchemeOp::TTableDescription indexTableDesc;
         // TODO After IndexImplTableDescriptions are persisted, this should be replaced with Y_ABORT_UNLESS
@@ -144,7 +144,7 @@ TVector<ISubOperation::TPtr> CreateBuildIndex(TOperationId opId, const TTxTransa
         auto implTableDesc = CalcImplTableDesc(tableInfo, implTableColumns, indexTableDesc);
         // TODO if keep erase markers also speedup compaction or something else we can enable it for other impl tables too
         implTableDesc.MutablePartitionConfig()->MutableCompactionPolicy()->SetKeepEraseMarkers(true);
-        result.push_back(createImplTable(std::move(implTableDesc)));
+        result.push_back(createImplTable(true, std::move(implTableDesc)));
     }
 
     return result;

--- a/ydb/core/tx/schemeshard/schemeshard_build_index.cpp
+++ b/ydb/core/tx/schemeshard/schemeshard_build_index.cpp
@@ -284,6 +284,13 @@ void TSchemeShard::PersistBuildIndexForget(NIceDb::TNiceDb& db, const TIndexBuil
     for(ui32 idx = 0; idx < info.BuildColumns.size(); ++idx) {
         db.Table<Schema::BuildColumnOperationSettings>().Key(info.Id, idx).Delete();
     }
+
+    if (info.IsBuildVectorIndex()) {
+        db.Table<Schema::KMeansTreeState>().Key(info.Id).Delete();
+        for (ui32 row = 0; row < info.KMeans.K * 2; ++row) {
+            db.Table<Schema::KMeansTreeSample>().Key(info.Id, row).Delete();
+        }
+    }
 }
 
 void TSchemeShard::Resume(const TDeque<TIndexBuildId>& indexIds, const TActorContext& ctx) {

--- a/ydb/core/tx/schemeshard/schemeshard_build_index.cpp
+++ b/ydb/core/tx/schemeshard/schemeshard_build_index.cpp
@@ -264,6 +264,13 @@ void TSchemeShard::PersistBuildIndexUploadReset(NIceDb::TNiceDb& db, TIndexBuild
     info.Shards.clear();
 }
 
+void TSchemeShard::PersistBuildIndexSampleForget(NIceDb::TNiceDb& db, const TIndexBuildInfo& info) {
+    Y_ASSERT(info.IsBuildVectorIndex());
+    for (ui32 row = 0; row < info.KMeans.K * 2; ++row) {
+        db.Table<Schema::KMeansTreeSample>().Key(info.Id, row).Delete();
+    }
+}
+
 void TSchemeShard::PersistBuildIndexForget(NIceDb::TNiceDb& db, const TIndexBuildInfo& info) {
     db.Table<Schema::IndexBuild>().Key(info.Id).Delete();
 
@@ -287,9 +294,7 @@ void TSchemeShard::PersistBuildIndexForget(NIceDb::TNiceDb& db, const TIndexBuil
 
     if (info.IsBuildVectorIndex()) {
         db.Table<Schema::KMeansTreeState>().Key(info.Id).Delete();
-        for (ui32 row = 0; row < info.KMeans.K * 2; ++row) {
-            db.Table<Schema::KMeansTreeSample>().Key(info.Id, row).Delete();
-        }
+        PersistBuildIndexSampleForget(db, info);
     }
 }
 

--- a/ydb/core/tx/schemeshard/schemeshard_build_index__progress.cpp
+++ b/ydb/core/tx/schemeshard/schemeshard_build_index__progress.cpp
@@ -347,7 +347,7 @@ THolder<TEvSchemeShard::TEvModifySchemeTransaction> CreateBuildPropose(
     const auto [count, parts, step] = ComputeKMeansBoundaries(*tableInfo, buildInfo);
 
     auto& config = *op.MutablePartitionConfig();
-    config.SetShadowData(true);
+    config.SetShadowData(false);
 
     auto& policy = *config.MutablePartitioningPolicy();
     policy.SetSizeToSplit(0); // disable auto split/merge

--- a/ydb/core/tx/schemeshard/schemeshard_build_index__progress.cpp
+++ b/ydb/core/tx/schemeshard/schemeshard_build_index__progress.cpp
@@ -898,6 +898,8 @@ private:
                 return false;
             }
             buildInfo.Sample.Clear();
+            NIceDb::TNiceDb db{txc.DB};
+            Self->PersistBuildIndexSampleForget(db, buildInfo);
             LOG_D("FillIndex::NextState::Done " << buildInfo.KMeansTreeToDebugStr());
         }
 

--- a/ydb/core/tx/schemeshard/schemeshard_impl.h
+++ b/ydb/core/tx/schemeshard/schemeshard_impl.h
@@ -1348,6 +1348,7 @@ public:
     void PersistBuildIndexProcessed(NIceDb::TNiceDb& db, const TIndexBuildInfo& indexInfo);
     void PersistBuildIndexBilled(NIceDb::TNiceDb& db, const TIndexBuildInfo& indexInfo);
 
+    void PersistBuildIndexSampleForget(NIceDb::TNiceDb& db, const TIndexBuildInfo& indexInfo);
     void PersistBuildIndexForget(NIceDb::TNiceDb& db, const TIndexBuildInfo& indexInfo);
 
     struct TIndexBuilder {

--- a/ydb/core/tx/schemeshard/schemeshard_info_types.cpp
+++ b/ydb/core/tx/schemeshard/schemeshard_info_types.cpp
@@ -2197,19 +2197,13 @@ void TIndexBuildInfo::SerializeToProto([[maybe_unused]] TSchemeShard* ss, NKikim
 
 void TIndexBuildInfo::AddParent(const TSerializedTableRange& range, TShardIdx shard) {
     if (KMeans.Parent == 0) {
+        Y_ASSERT(KMeans.ParentEnd == 0);
         // For Parent == 0 only single kmeans needed, so there is only two options:
         // 1. It fits entirely in the single shard => local kmeans for single shard
         // 2. It doesn't fit entirely in the single shard => global kmeans for all shards
         return;
     }
-    const auto to = range.To.GetCells();
-    const auto from = range.From.GetCells();
-    Y_ASSERT(!from.empty());
-    const auto parentTo = to.empty() ? std::numeric_limits<ui32>::max() : to[0].AsValue<ui32>() - (to.size() == 1);
-    Y_ASSERT(parentTo >= 1);
-    const auto parentFrom = from[0].IsNull() ? 1 : from[0].AsValue<ui32>();
-    Y_ASSERT(parentFrom >= 1);
-    Y_ASSERT(parentFrom <= parentTo);
+    const auto [parentFrom, parentTo] = KMeans.RangeToBorders(range);
     // TODO(mbkkt) We can make it more granular
 
     // if new range is not intersect with other ranges, it's local

--- a/ydb/core/tx/schemeshard/schemeshard_info_types.h
+++ b/ydb/core/tx/schemeshard/schemeshard_info_types.h
@@ -3158,6 +3158,28 @@ struct TIndexBuildInfo: public TSimpleRefCount<TIndexBuildInfo> {
             name += Level % 2 != 0 ? BuildSuffix1 : BuildSuffix0;
             return name;
         }
+
+        TString RangeToDebugStr(const TSerializedTableRange& range) const {
+            auto toStr = [&](const TSerializedCellVec& v) -> TString {
+                const auto cells = v.GetCells();
+                if (cells.empty()) {
+                    return "inf";
+                }
+                if (cells[0].IsNull()) {
+                    return "-inf";
+                }
+                auto str = TStringBuilder{} << "{ count: " << cells.size();
+                if (Parent != 0) {
+                    Y_ASSERT(Level != 0);
+                    str << ", parent: " << cells[0].AsValue<ui32>();
+                    if (cells.size() != 1 && cells[1].IsNull()) {
+                        str << ", pk: null";
+                    }
+                }
+                return str << " }";
+            };
+            return TStringBuilder{} << "{ From: " << toStr(range.From) << ", To: " << toStr(range.To) << " }";
+        }
     };
     TKMeans KMeans;
 

--- a/ydb/core/tx/schemeshard/schemeshard_info_types.h
+++ b/ydb/core/tx/schemeshard/schemeshard_info_types.h
@@ -3291,7 +3291,7 @@ struct TIndexBuildInfo: public TSimpleRefCount<TIndexBuildInfo> {
             Sent = false;
         }
 
-        void Set(ui32 row, ui64 probability, TString data) {
+        void Set(ui64 probability, TString data) {
             Rows.emplace_back(probability, std::move(data));
             MaxProbability = std::max(probability + 1, MaxProbability + 1) - 1;
         }

--- a/ydb/core/tx/schemeshard/schemeshard_schema.h
+++ b/ydb/core/tx/schemeshard/schemeshard_schema.h
@@ -1878,6 +1878,36 @@ struct Schema : NIceDb::Schema {
         using TColumns = TableColumns<OwnerPathId, LocalPathId, AlterVersion, Description>;
     };
 
+    struct KMeansTreeState : Table<112> {
+        struct Id : Column<1, NScheme::NTypeIds::Uint64> { using Type = TIndexBuildId; };
+        struct Level : Column<2, NScheme::NTypeIds::Uint32> {};
+        struct Parent : Column<3, NScheme::NTypeIds::Uint32> {};
+        struct State : Column<4, NScheme::NTypeIds::Uint32> {};
+
+        using TKey = TableKey<Id>;
+        using TColumns = TableColumns<
+            Id,
+            Level,
+            Parent,
+            State
+        >;
+    };
+
+    struct KMeansTreeSample : Table<113> {
+        struct Id : Column<1, NScheme::NTypeIds::Uint64> { using Type = TIndexBuildId; };
+        struct Row : Column<2, NScheme::NTypeIds::Uint32> {};
+        struct Probability : Column<3, NScheme::NTypeIds::Uint64> {};
+        struct Data : Column<4, NScheme::NTypeIds::String> {};
+
+        using TKey = TableKey<Id, Row>;
+        using TColumns = TableColumns<
+            Id,
+            Row,
+            Probability,
+            Data
+        >;
+    };
+
     using TTables = SchemaTables<
         Paths,
         TxInFlight,
@@ -1988,7 +2018,9 @@ struct Schema : NIceDb::Schema {
         View,
         BackgroundSessions,
         ResourcePool,
-        BackupCollection
+        BackupCollection,
+        KMeansTreeState,
+        KMeansTreeSample
     >;
 
     static constexpr ui64 SysParam_NextPathId = 1;

--- a/ydb/core/tx/schemeshard/ut_helpers/helpers.cpp
+++ b/ydb/core/tx/schemeshard/ut_helpers/helpers.cpp
@@ -1721,7 +1721,8 @@ namespace NSchemeShardUT_Private {
                 kmeansTreeSettings.mutable_settings()->set_vector_dimension(42);
                 kmeansTreeSettings.mutable_settings()->set_metric(Ydb::Table::VectorIndexSettings::DISTANCE_COSINE);
                 kmeansTreeSettings.set_clusters(4);
-                kmeansTreeSettings.set_levels(5);
+                // More than 2 is too long for reboot tests
+                kmeansTreeSettings.set_levels(2);
             }
 
             if (cfg.GlobalIndexSettings) {
@@ -1770,6 +1771,14 @@ namespace NSchemeShardUT_Private {
     {
         AsyncBuildIndex(runtime, id, schemeShard, dbName, src, TBuildIndexConfig{
             name, NKikimrSchemeOp::EIndexTypeGlobal, columns, dataColumns
+        });
+    }
+
+    void AsyncBuildVectorIndex(TTestActorRuntime& runtime, ui64 id, ui64 schemeShard, const TString &dbName,
+                              const TString &src, const TString &name, TString column, TVector<TString> dataColumns)
+    {
+        AsyncBuildIndex(runtime, id, schemeShard, dbName, src, TBuildIndexConfig{
+            name, NKikimrSchemeOp::EIndexTypeGlobalVectorKmeansTree, {column}, std::move(dataColumns)
         });
     }
 

--- a/ydb/core/tx/schemeshard/ut_helpers/helpers.h
+++ b/ydb/core/tx/schemeshard/ut_helpers/helpers.h
@@ -391,6 +391,7 @@ namespace NSchemeShardUT_Private {
     void AsyncBuildColumn(TTestActorRuntime& runtime, ui64 id, ui64 schemeShard, const TString &dbName, const TString &src, const TString& columnName, const Ydb::TypedValue& literal);
     void AsyncBuildIndex(TTestActorRuntime& runtime, ui64 id, ui64 schemeShard, const TString &dbName, const TString &src, const TBuildIndexConfig &cfg);
     void AsyncBuildIndex(TTestActorRuntime& runtime, ui64 id, ui64 schemeShard, const TString &dbName, const TString &src, const TString &name, TVector<TString> columns, TVector<TString> dataColumns = {});
+    void AsyncBuildVectorIndex(TTestActorRuntime& runtime, ui64 id, ui64 schemeShard, const TString &dbName, const TString &src, const TString &name, TString column, TVector<TString> dataColumns = {});
     void TestBuildColumn(TTestActorRuntime& runtime, ui64 id, ui64 schemeShard, const TString &dbName,
         const TString &src, const TString& columnName, const Ydb::TypedValue& literal, Ydb::StatusIds::StatusCode expectedStatus);
     void TestBuildIndex(TTestActorRuntime& runtime, ui64 id, ui64 schemeShard, const TString &dbName, const TString &src, const TBuildIndexConfig &cfg, Ydb::StatusIds::StatusCode expectedStatus = Ydb::StatusIds::SUCCESS);
@@ -526,8 +527,8 @@ namespace NSchemeShardUT_Private {
     void CreateAlterLoginCreateUser(TTestActorRuntime& runtime, ui64 txId, const TString& database,
         const TString& user, const TString& password,
         const TVector<TExpectedResult>& expectedResults = {{NKikimrScheme::StatusSuccess}});
-    
-    void CreateAlterLoginRemoveUser(TTestActorRuntime& runtime, ui64 txId, const TString& database, 
+
+    void CreateAlterLoginRemoveUser(TTestActorRuntime& runtime, ui64 txId, const TString& database,
         const TString& user,
         const TVector<TExpectedResult>& expectedResults = {{NKikimrScheme::StatusSuccess}});
 

--- a/ydb/core/tx/schemeshard/ut_index_build/ut_vector_index_build.cpp
+++ b/ydb/core/tx/schemeshard/ut_index_build/ut_vector_index_build.cpp
@@ -129,7 +129,7 @@ Y_UNIT_TEST_SUITE (VectorIndexBuildTest) {
         auto descr = TestGetBuildIndex(runtime, tenantSchemeShard, "/MyRoot/ServerLessDB", txId);
         UNIT_ASSERT_VALUES_EQUAL(descr.GetIndexBuild().GetState(), Ydb::Table::IndexBuildState::STATE_DONE);
 
-        const TString meteringData = R"({"usage":{"start":1,"quantity":100,"finish":1,"unit":"request_unit","type":"delta"},"tags":{},"id":"106-72075186233409549-2-0-0-0-0-0-200-0-1290","cloud_id":"CLOUD_ID_VAL","source_wt":1,"source_id":"sless-docapi-ydb-ss","resource_id":"DATABASE_ID_VAL","schema":"ydb.serverless.requests.v1","folder_id":"FOLDER_ID_VAL","version":"1.0.0"})""\n";
+        const TString meteringData = R"({"usage":{"start":0,"quantity":128,"finish":0,"unit":"request_unit","type":"delta"},"tags":{},"id":"106-72075186233409549-2-0-0-0-0-200-0-1290-0","cloud_id":"CLOUD_ID_VAL","source_wt":0,"source_id":"sless-docapi-ydb-ss","resource_id":"DATABASE_ID_VAL","schema":"ydb.serverless.requests.v1","folder_id":"FOLDER_ID_VAL","version":"1.0.0"})""\n";
 
         UNIT_ASSERT_NO_DIFF(meteringMessages, meteringData);
 

--- a/ydb/core/tx/schemeshard/ut_index_build_reboots/ut_vector_index_build_reboots.cpp
+++ b/ydb/core/tx/schemeshard/ut_index_build_reboots/ut_vector_index_build_reboots.cpp
@@ -1,0 +1,146 @@
+#include <ydb/core/tx/schemeshard/ut_helpers/helpers.h>
+
+#include <ydb/core/kqp/ut/common/kqp_ut_common.h>
+
+using namespace NKikimr;
+using namespace NSchemeShard;
+using namespace NSchemeShardUT_Private;
+
+
+static void WriteRows(TTestActorRuntime& runtime, ui64 tabletId, ui32 key, ui32 index) {
+    TString writeQuery = Sprintf(R"(
+        (
+            (let keyNull   '( '('key   (Null) ) ) )
+            (let row0   '( '('embedding (String '%s ) )  '('value (String 'aaaa) ) ) )
+            (let key0   '( '('key   (Uint32 '%u ) ) ) )
+            (let row0   '( '('embedding (String '%s ) )  '('value (String 'aaaa) ) ) )
+            (let key1   '( '('key   (Uint32 '%u ) ) ) )
+            (let row1   '( '('embedding (String '%s ) )  '('value (String 'aaaa) ) ) )
+            (let key2   '( '('key   (Uint32 '%u ) ) ) )
+            (let row2   '( '('embedding (String '%s ) )  '('value (String 'aaaa) ) ) )
+            (let key3   '( '('key   (Uint32 '%u ) ) ) )
+            (let row3   '( '('embedding (String '%s ) )  '('value (String 'aaaa) ) ) )
+            (let key4   '( '('key   (Uint32 '%u ) ) ) )
+            (let row4   '( '('embedding (String '%s ) )  '('value (String 'aaaa) ) ) )
+            (let key5   '( '('key   (Uint32 '%u ) ) ) )
+            (let row5   '( '('embedding (String '%s ) )  '('value (String 'aaaa) ) ) )
+            (let key6   '( '('key   (Uint32 '%u ) ) ) )
+            (let row6   '( '('embedding (String '%s ) )  '('value (String 'aaaa) ) ) )
+            (let key7   '( '('key   (Uint32 '%u ) ) ) )
+            (let row7   '( '('embedding (String '%s ) )  '('value (String 'aaaa) ) ) )
+            (let key8   '( '('key   (Uint32 '%u ) ) ) )
+            (let row8   '( '('embedding (String '%s ) )  '('value (String 'aaaa) ) ) )
+            (let key9   '( '('key   (Uint32 '%u ) ) ) )
+            (let row9   '( '('embedding (String '%s ) )  '('value (String 'aaaa) ) ) )
+
+            (return (AsList
+                        (UpdateRow '__user__Table keyNull row0)
+                        (UpdateRow '__user__Table key0 row0)
+                        (UpdateRow '__user__Table key1 row1)
+                        (UpdateRow '__user__Table key2 row2)
+                        (UpdateRow '__user__Table key3 row3)
+                        (UpdateRow '__user__Table key4 row4)
+                        (UpdateRow '__user__Table key5 row5)
+                        (UpdateRow '__user__Table key6 row6)
+                        (UpdateRow '__user__Table key7 row7)
+                        (UpdateRow '__user__Table key8 row8)
+                        (UpdateRow '__user__Table key9 row9)
+                     )
+            )
+        )
+    )",
+                       std::to_string(1000*index + 0).c_str(),
+         1000*key + 0, std::to_string(1000*index + 0).c_str(),
+         1000*key + 1, std::to_string(1000*index + 1).c_str(),
+         1000*key + 2, std::to_string(1000*index + 2).c_str(),
+         1000*key + 3, std::to_string(1000*index + 3).c_str(),
+         1000*key + 4, std::to_string(1000*index + 4).c_str(),
+         1000*key + 5, std::to_string(1000*index + 5).c_str(),
+         1000*key + 6, std::to_string(1000*index + 6).c_str(),
+         1000*key + 7, std::to_string(1000*index + 7).c_str(),
+         1000*key + 8, std::to_string(1000*index + 8).c_str(),
+         1000*key + 9, std::to_string(1000*index + 9).c_str());
+
+    NKikimrMiniKQL::TResult result;
+    TString err;
+    NKikimrProto::EReplyStatus status = LocalMiniKQL(runtime, tabletId, writeQuery, result, err);
+    UNIT_ASSERT_VALUES_EQUAL(err, "");
+    UNIT_ASSERT_VALUES_EQUAL(status, NKikimrProto::EReplyStatus::OK);;
+}
+
+Y_UNIT_TEST_SUITE(VectorIndexBuildTestReboots) {
+    Y_UNIT_TEST(BaseCase) {
+        TTestWithReboots t(false);
+        t.Run([&](TTestActorRuntime& runtime, bool& activeZone) {
+            {
+                TInactiveZone inactive(activeZone);
+
+                TestCreateTable(runtime, ++t.TxId, "/MyRoot", R"(
+                  Name: "dir/Table"
+                  Columns { Name: "key"       Type: "Uint32" }
+                  Columns { Name: "embedding" Type: "String" }
+                  Columns { Name: "value"     Type: "String" }
+                  KeyColumnNames: ["key"]
+                  UniformPartitionsCount: 2
+                 )");
+                t.TestEnv->TestWaitNotification(runtime, t.TxId);
+
+                for (ui32 delta = 0; delta < 2; ++delta) {
+                    WriteRows(runtime, TTestTxConfig::FakeHiveTablets, 1 + delta, 100 + delta);
+                }
+
+                // Check src shard has the lead key as null
+                {
+                    NKikimrMiniKQL::TResult result;
+                    TString err;
+                    ui32 status = LocalMiniKQL(runtime, TTestTxConfig::FakeHiveTablets, R"(
+                    (
+                        (let range '('('key (Null) (Void))))
+                        (let columns '('key 'embedding))
+                        (let result (SelectRange '__user__Table range columns '()))
+                        (return (AsList (SetResult 'Result result)))
+                    )
+                    )", result, err);
+
+                    UNIT_ASSERT_VALUES_EQUAL_C(status, static_cast<ui32>(NKikimrProto::OK), err);
+                    UNIT_ASSERT_VALUES_EQUAL(err, "");
+
+                    //                                   V -- here the null key
+                    NKqp::CompareYson(R"([[[[[["101000"];#];[["100000"];["1000"]];[["100001"];["1001"]];[["100002"];["1002"]];[["100003"];["1003"]];[["100004"];["1004"]];[["100005"];["1005"]];[["100006"];["1006"]];[["100007"];["1007"]];[["100008"];["1008"]];[["100009"];["1009"]];[["101000"];["2000"]];[["101001"];["2001"]];[["101002"];["2002"]];[["101003"];["2003"]];[["101004"];["2004"]];[["101005"];["2005"]];[["101006"];["2006"]];[["101007"];["2007"]];[["101008"];["2008"]];[["101009"];["2009"]]];%false]]])", result);
+                }
+            }
+
+            AsyncBuildVectorIndex(runtime,  ++t.TxId, TTestTxConfig::SchemeShard, "/MyRoot", "/MyRoot/dir/Table", "index1", "embedding", {"value"});
+            ui64 buildIndexId = t.TxId;
+
+            {
+                auto descr = TestGetBuildIndex(runtime, TTestTxConfig::SchemeShard, "/MyRoot", buildIndexId);
+                UNIT_ASSERT_VALUES_EQUAL((ui64)descr.GetIndexBuild().GetState(), (ui64)Ydb::Table::IndexBuildState::STATE_PREPARING);
+            }
+
+            t.TestEnv->TestWaitNotification(runtime, buildIndexId);
+
+            {
+                auto descr = TestGetBuildIndex(runtime, TTestTxConfig::SchemeShard, "/MyRoot", buildIndexId);
+                UNIT_ASSERT_VALUES_EQUAL((ui64)descr.GetIndexBuild().GetState(), (ui64)Ydb::Table::IndexBuildState::STATE_DONE);
+            }
+
+            TestDescribeResult(DescribePath(runtime, "/MyRoot/dir/Table"),
+                               {NLs::PathExist,
+                                NLs::IndexesCount(1)});
+            const TString indexPath = "/MyRoot/dir/Table/index1";
+            TestDescribeResult(DescribePath(runtime, indexPath, true, true, true),
+                               {NLs::PathExist,
+                                NLs::IndexState(NKikimrSchemeOp::EIndexState::EIndexStateReady)});
+            using namespace NTableIndex::NTableVectorKmeansTreeIndex;
+            TestDescribeResult(DescribePath(runtime, indexPath + "/" + LevelTable, true, true, true),
+                               {NLs::PathExist});
+            TestDescribeResult(DescribePath(runtime, indexPath + "/" + PostingTable, true, true, true),
+                               {NLs::PathExist});
+            TestDescribeResult(DescribePath(runtime, indexPath + "/" + PostingTable + BuildSuffix0, true, true, true),
+                               {NLs::PathNotExist});
+            TestDescribeResult(DescribePath(runtime, indexPath + "/" + PostingTable + BuildSuffix1, true, true, true),
+                               {NLs::PathNotExist});
+        });
+    }
+}

--- a/ydb/core/tx/schemeshard/ut_index_build_reboots/ya.make
+++ b/ydb/core/tx/schemeshard/ut_index_build_reboots/ya.make
@@ -10,7 +10,8 @@ IF (SANITIZER_TYPE OR WITH_VALGRIND)
     SIZE(LARGE)
     TAG(ya:fat)
 ELSE()
-    SIZE(MEDIUM)
+    SIZE(LARGE)
+    TAG(ya:fat)
 ENDIF()
 
 PEERDIR(
@@ -27,6 +28,7 @@ PEERDIR(
 
 SRCS(
     ut_index_build_reboots.cpp
+    ut_vector_index_build_reboots.cpp
 )
 
 YQL_LAST_ABI_VERSION()

--- a/ydb/core/tx/schemeshard/ut_vector_index_build_reboots/ya.make
+++ b/ydb/core/tx/schemeshard/ut_vector_index_build_reboots/ya.make
@@ -6,7 +6,7 @@ IF (WITH_VALGRIND)
     SPLIT_FACTOR(40)
 ENDIF()
 
-IF (SANITIZER_TYPE OR WITH_VALGRIND)
+IF (BUILD_TYPE == "DEBUG" OR SANITIZER_TYPE OR WITH_VALGRIND)
     SIZE(LARGE)
     TAG(ya:fat)
 ELSE()
@@ -26,7 +26,7 @@ PEERDIR(
 )
 
 SRCS(
-    ut_index_build_reboots.cpp
+    ut_vector_index_build_reboots.cpp
 )
 
 YQL_LAST_ABI_VERSION()

--- a/ydb/core/tx/schemeshard/ya.make
+++ b/ydb/core/tx/schemeshard/ya.make
@@ -53,6 +53,7 @@ RECURSE_FOR_TESTS(
     ut_ttl
     ut_user_attributes
     ut_user_attributes_reboots
+    ut_vector_index_build_reboots
     ut_view
 )
 

--- a/ydb/tests/functional/scheme_tests/canondata/tablet_scheme_tests.TestTabletSchemes.test_tablet_schemes_flat_schemeshard_/flat_schemeshard.schema
+++ b/ydb/tests/functional/scheme_tests/canondata/tablet_scheme_tests.TestTabletSchemes.test_tablet_schemes_flat_schemeshard_/flat_schemeshard.schema
@@ -7974,5 +7974,118 @@
                 ]
             }
         }
+    },
+    {
+        "TableId": 112,
+        "TableName": "KMeansTreeState",
+        "TableKey": [
+            1
+        ],
+        "ColumnsAdded": [
+            {
+                "ColumnId": 1,
+                "ColumnName": "Id",
+                "ColumnType": "Uint64"
+            },
+            {
+                "ColumnId": 2,
+                "ColumnName": "Level",
+                "ColumnType": "Uint32"
+            },
+            {
+                "ColumnId": 3,
+                "ColumnName": "Parent",
+                "ColumnType": "Uint32"
+            },
+            {
+                "ColumnId": 4,
+                "ColumnName": "State",
+                "ColumnType": "Uint32"
+            }
+        ],
+        "ColumnsDropped": [],
+        "ColumnFamilies": {
+            "0": {
+                "Columns": [
+                    1,
+                    2,
+                    3,
+                    4
+                ],
+                "RoomID": 0,
+                "Codec": 0,
+                "InMemory": false,
+                "Cache": 0,
+                "Small": 4294967295,
+                "Large": 4294967295
+            }
+        },
+        "Rooms": {
+            "0": {
+                "Main": 1,
+                "Outer": 1,
+                "Blobs": 1,
+                "ExternalBlobs": [
+                    1
+                ]
+            }
+        }
+    },
+    {
+        "TableId": 113,
+        "TableName": "KMeansTreeSample",
+        "TableKey": [
+            1,
+            2
+        ],
+        "ColumnsAdded": [
+            {
+                "ColumnId": 1,
+                "ColumnName": "Id",
+                "ColumnType": "Uint64"
+            },
+            {
+                "ColumnId": 2,
+                "ColumnName": "Row",
+                "ColumnType": "Uint32"
+            },
+            {
+                "ColumnId": 3,
+                "ColumnName": "Probability",
+                "ColumnType": "Uint64"
+            },
+            {
+                "ColumnId": 4,
+                "ColumnName": "Data",
+                "ColumnType": "String"
+            }
+        ],
+        "ColumnsDropped": [],
+        "ColumnFamilies": {
+            "0": {
+                "Columns": [
+                    1,
+                    2,
+                    3,
+                    4
+                ],
+                "RoomID": 0,
+                "Codec": 0,
+                "InMemory": false,
+                "Cache": 0,
+                "Small": 4294967295,
+                "Large": 4294967295
+            }
+        },
+        "Rooms": {
+            "0": {
+                "Main": 1,
+                "Outer": 1,
+                "Blobs": 1,
+                "ExternalBlobs": [
+                    1
+                ]
+            }
+        }
     }
 ]


### PR DESCRIPTION
### Changelog category

* Not for changelog (changelog entry is not required)

### Additional information

* Select vector index now works for indexes with multiple levels
* Local kmeans now parallel even inside single data shard
* Make vector index creation more reliable (if schemeshard fails vector index creation will re-make less work) and observable