### PR TITLE
Support Console interoperation through distconf

### DIFF
--- a/ydb/core/blobstorage/base/blobstorage_console_events.h
+++ b/ydb/core/blobstorage/base/blobstorage_console_events.h
@@ -10,7 +10,7 @@ namespace NKikimr {
         NKikimrBlobStorage::TEvControllerProposeConfigRequest, TEvBlobStorage::EvControllerProposeConfigRequest> {
         TEvControllerProposeConfigRequest() = default;
 
-        TEvControllerProposeConfigRequest(const ui32 configHash, const ui32 configVersion) {
+        TEvControllerProposeConfigRequest(ui64 configHash, ui32 configVersion) {
             Record.SetConfigHash(configHash);
             Record.SetConfigVersion(configVersion);
         }
@@ -68,6 +68,8 @@ namespace NKikimr {
     struct TEvBlobStorage::TEvControllerValidateConfigResponse : TEventPB<TEvBlobStorage::TEvControllerValidateConfigResponse,
         NKikimrBlobStorage::TEvControllerValidateConfigResponse, TEvBlobStorage::EvControllerValidateConfigResponse> {
         TEvControllerValidateConfigResponse() = default;
+
+        std::optional<TString> InternalError;
     };
 
     struct TEvBlobStorage::TEvControllerReplaceConfigRequest : TEventPB<TEvBlobStorage::TEvControllerReplaceConfigRequest,

--- a/ydb/core/blobstorage/nodewarden/distconf.cpp
+++ b/ydb/core/blobstorage/nodewarden/distconf.cpp
@@ -1,6 +1,9 @@
 #include "distconf.h"
 #include "node_warden_impl.h"
 #include <ydb/core/mind/dynamic_nameserver.h>
+#include <ydb/library/yaml_config/yaml_config_helpers.h>
+#include <ydb/library/yaml_config/yaml_config.h>
+#include <library/cpp/streams/zstd/zstd.h>
 
 namespace NKikimr::NStorage {
 
@@ -61,16 +64,48 @@ namespace NKikimr::NStorage {
 
     bool TDistributedConfigKeeper::ApplyStorageConfig(const NKikimrBlobStorage::TStorageConfig& config) {
         if (!StorageConfig || StorageConfig->GetGeneration() < config.GetGeneration()) {
+            StorageConfigYaml = StorageConfigFetchYaml = {};
+            StorageConfigFetchYamlHash = 0;
+            StorageConfigYamlVersion.reset();
+
+            if (config.HasConfigComposite()) {
+                try {
+                    // parse the composite stream
+                    TStringInput ss(config.GetConfigComposite());
+                    TZstdDecompress zstd(&ss);
+                    StorageConfigYaml = TString::Uninitialized(LoadSize(&zstd));
+                    zstd.LoadOrFail(StorageConfigYaml.Detach(), StorageConfigYaml.size());
+                    StorageConfigFetchYaml = TString::Uninitialized(LoadSize(&zstd));
+                    zstd.LoadOrFail(StorageConfigFetchYaml.Detach(), StorageConfigFetchYaml.size());
+
+                    // extract _current_ config version
+                    auto metadata = NYamlConfig::GetMetadata(StorageConfigYaml);
+                    Y_DEBUG_ABORT_UNLESS(metadata.Version.has_value());
+                    StorageConfigYamlVersion = metadata.Version.value_or(0);
+
+                    // and _fetched_ config hash
+                    StorageConfigFetchYamlHash = NYaml::GetConfigHash(StorageConfigFetchYaml);
+                } catch (const std::exception& ex) {
+                    Y_ABORT("ConfigComposite format incorrect: %s", ex.what());
+                }
+            }
+
             StorageConfig.emplace(config);
             if (ProposedStorageConfig && ProposedStorageConfig->GetGeneration() <= StorageConfig->GetGeneration()) {
                 ProposedStorageConfig.reset();
             }
+
             Send(MakeBlobStorageNodeWardenID(SelfId().NodeId()), new TEvNodeWardenStorageConfig(*StorageConfig,
                 ProposedStorageConfig ? &ProposedStorageConfig.value() : nullptr));
+
             if (IsSelfStatic) {
                 PersistConfig({});
                 ApplyConfigUpdateToDynamicNodes(false);
             }
+
+            ConnectToConsole();
+            SendConfigProposeRequest();
+
             return true;
         } else if (StorageConfig->GetGeneration() && StorageConfig->GetGeneration() == config.GetGeneration() &&
                 StorageConfig->GetFingerprint() != config.GetFingerprint()) {
@@ -197,6 +232,10 @@ namespace NKikimr::NStorage {
             Y_ABORT_UNLESS(!Binding);
         } else {
             Y_ABORT_UNLESS(RootState == ERootState::INITIAL || RootState == ERootState::ERROR_TIMEOUT);
+
+            // we can't have connection to the Console without being the root node
+            Y_ABORT_UNLESS(!ConsolePipeId);
+            Y_ABORT_UNLESS(!ConsoleConnected);
         }
     }
 #endif
@@ -280,6 +319,11 @@ namespace NKikimr::NStorage {
             fFunc(TEvents::TSystem::Gone, HandleGone);
             cFunc(TEvents::TSystem::Wakeup, HandleWakeup);
             cFunc(TEvents::TSystem::Poison, PassAway);
+            hFunc(TEvTabletPipe::TEvClientConnected, Handle);
+            hFunc(TEvTabletPipe::TEvClientDestroyed, Handle);
+            hFunc(TEvBlobStorage::TEvControllerValidateConfigResponse, Handle);
+            hFunc(TEvBlobStorage::TEvControllerProposeConfigResponse, Handle);
+            hFunc(TEvBlobStorage::TEvControllerConsoleCommitResponse, Handle);
         )
         for (ui32 nodeId : std::exchange(UnsubscribeQueue, {})) {
             UnsubscribeInterconnect(nodeId);

--- a/ydb/core/blobstorage/nodewarden/distconf_console.cpp
+++ b/ydb/core/blobstorage/nodewarden/distconf_console.cpp
@@ -1,0 +1,244 @@
+#include "distconf.h"
+
+#include <ydb/library/yaml_config/yaml_config.h>
+#include <library/cpp/streams/zstd/zstd.h>
+
+namespace NKikimr::NStorage {
+
+    void TDistributedConfigKeeper::ConnectToConsole(bool enablingDistconf) {
+        if (ConsolePipeId) {
+            return; // connection is already established
+        } else if (!Scepter) {
+            return; // this is not the root node
+        } else if (enablingDistconf) {
+            // NO RETURN HERE -> right now we are enabling distconf, so we can skip rest of the checks
+        } else if (!StorageConfig || !StorageConfig->GetSelfManagementConfig().GetEnabled()) {
+            return; // no self-management config enabled
+        } else if (!StorageConfig->HasStateStorageConfig()) {
+            return; // no way to find Console too
+        }
+
+        STLOG(PRI_DEBUG, BS_NODE, NWDC66, "ConnectToConsole: creating pipe to the Console");
+        ConsolePipeId = Register(NTabletPipe::CreateClient(SelfId(), MakeConsoleID(),
+            NTabletPipe::TClientRetryPolicy::WithRetries()));
+    }
+
+    void TDistributedConfigKeeper::DisconnectFromConsole() {
+        NTabletPipe::CloseAndForgetClient(SelfId(), ConsolePipeId);
+        ConsoleConnected = false;
+    }
+
+    void TDistributedConfigKeeper::SendConfigProposeRequest() {
+        if (!ConsoleConnected) {
+            return;
+        }
+
+        if (ProposeRequestInFlight) {
+            return; // still waiting for previous one
+        }
+
+        if (!StorageConfig || !StorageConfig->HasConfigComposite()) {
+            return; // no config yet
+        }
+
+        Y_ABORT_UNLESS(StorageConfigYamlVersion);
+
+        STLOG(PRI_DEBUG, BS_NODE, NWDC67, "SendConfigProposeRequest: sending propose request to the Console",
+            (StorageConfigFetchYamlHash, StorageConfigFetchYamlHash),
+            (StorageConfigYamlVersion, StorageConfigYamlVersion),
+            (ProposedConfigHashVersion, ProposedConfigHashVersion),
+            (ProposeRequestCookie, ProposeRequestCookie + 1));
+
+        Y_DEBUG_ABORT_UNLESS(!ProposedConfigHashVersion || ProposedConfigHashVersion == std::make_tuple(
+            StorageConfigFetchYamlHash, *StorageConfigYamlVersion));
+        ProposedConfigHashVersion.emplace(StorageConfigFetchYamlHash, *StorageConfigYamlVersion);
+        NTabletPipe::SendData(SelfId(), ConsolePipeId, new TEvBlobStorage::TEvControllerProposeConfigRequest(
+            StorageConfigFetchYamlHash, *StorageConfigYamlVersion), ++ProposeRequestCookie);
+        ProposeRequestInFlight = true;
+    }
+
+    void TDistributedConfigKeeper::Handle(TEvBlobStorage::TEvControllerValidateConfigResponse::TPtr ev) {
+        auto& q = ConsoleConfigValidationQ;
+        auto pred = [&](const auto& item) {
+            const auto& [actorId, yaml, cookie] = item;
+            const bool match = cookie == ev->Cookie;
+            if (match) {
+                TActivationContext::Send(ev->Forward(actorId));
+            }
+            return match;
+        };
+        q.erase(std::remove_if(q.begin(), q.end(), pred), q.end());
+    }
+
+    void TDistributedConfigKeeper::Handle(TEvBlobStorage::TEvControllerProposeConfigResponse::TPtr ev) {
+        STLOG(PRI_DEBUG, BS_NODE, NWDC68, "received TEvControllerProposeConfigResponse",
+            (ConsoleConnected, ConsoleConnected),
+            (ProposeRequestInFlight, ProposeRequestInFlight),
+            (Cookie, ev->Cookie),
+            (ProposeRequestCookie, ProposeRequestCookie),
+            (ProposedConfigHashVersion, ProposedConfigHashVersion),
+            (Record, ev->Get()->Record));
+
+        if (!ConsoleConnected || !ProposeRequestInFlight || ev->Cookie != ProposeRequestCookie) {
+            return;
+        }
+        ProposeRequestInFlight = false;
+
+        const auto& record = ev->Get()->Record;
+        switch (record.GetStatus()) {
+            case NKikimrBlobStorage::TEvControllerProposeConfigResponse::HashMismatch:
+            case NKikimrBlobStorage::TEvControllerProposeConfigResponse::UnexpectedConfig:
+                // TODO: error condition; restart?
+                ProposedConfigHashVersion.reset();
+                break;
+
+            case NKikimrBlobStorage::TEvControllerProposeConfigResponse::CommitIsNeeded: {
+                if (!StorageConfig || !StorageConfig->HasConfigComposite() || ProposedConfigHashVersion !=
+                        std::make_tuple(StorageConfigFetchYamlHash, *StorageConfigYamlVersion)) {
+                    const char *err = "proposed config, but something has gone awfully wrong";
+                    STLOG(PRI_CRIT, BS_NODE, NWDC69, err, (StorageConfig, StorageConfig),
+                        (ProposedConfigHashVersion, ProposedConfigHashVersion),
+                        (StorageConfigFetchYamlHash, StorageConfigFetchYamlHash),
+                        (StorageConfigYamlVersion, StorageConfigYamlVersion));
+                    Y_DEBUG_ABORT("%s", err);
+                    return;
+                }
+
+                NTabletPipe::SendData(SelfId(), ConsolePipeId, new TEvBlobStorage::TEvControllerConsoleCommitRequest(
+                    StorageConfigYaml), ++CommitRequestCookie);
+                break;
+            }
+
+            case NKikimrBlobStorage::TEvControllerProposeConfigResponse::CommitIsNotNeeded:
+                // it's okay, just wait for another configuration change or something like that
+                ConfigCommittedToConsole = true;
+                break;
+        }
+    }
+
+    void TDistributedConfigKeeper::Handle(TEvBlobStorage::TEvControllerConsoleCommitResponse::TPtr ev) {
+        STLOG(PRI_DEBUG, BS_NODE, NWDC70, "received TEvControllerConsoleCommitResponse",
+            (ConsoleConnected, ConsoleConnected),
+            (Cookie, ev->Cookie),
+            (CommitRequestCookie, CommitRequestCookie),
+            (Record, ev->Get()->Record));
+
+        if (!ConsoleConnected || ev->Cookie != CommitRequestCookie) {
+            return;
+        }
+
+        const auto& record = ev->Get()->Record;
+        switch (record.GetStatus()) {
+            case NKikimrBlobStorage::TEvControllerConsoleCommitResponse::SessionMismatch:
+                DisconnectFromConsole();
+                ConnectToConsole();
+                break;
+
+            case NKikimrBlobStorage::TEvControllerConsoleCommitResponse::NotCommitted:
+                break;
+
+            case NKikimrBlobStorage::TEvControllerConsoleCommitResponse::Committed:
+                ConfigCommittedToConsole = true;
+                break;
+        }
+
+        ProposedConfigHashVersion.reset();
+    }
+
+    void TDistributedConfigKeeper::Handle(TEvTabletPipe::TEvClientConnected::TPtr ev) {
+        STLOG(PRI_DEBUG, BS_NODE, NWDC71, "received TEvClientConnected", (ConsolePipeId, ConsolePipeId),
+            (TabletId, ev->Get()->TabletId), (Status, ev->Get()->Status), (ClientId, ev->Get()->ClientId),
+            (ServerId, ev->Get()->ServerId));
+        if (ev->Get()->ClientId == ConsolePipeId) {
+            if (ev->Get()->Status == NKikimrProto::OK) {
+                Y_ABORT_UNLESS(!ConsoleConnected);
+                ConsoleConnected = true;
+                SendConfigProposeRequest();
+                for (auto& [actorId, yaml, cookie] : ConsoleConfigValidationQ) {
+                    Y_ABORT_UNLESS(!cookie);
+                    cookie = ++ValidateRequestCookie;
+                    NTabletPipe::SendData(SelfId(), ConsolePipeId, new TEvBlobStorage::TEvControllerValidateConfigRequest(
+                        yaml), cookie);
+                }
+            } else {
+                OnConsolePipeError();
+            }
+        }
+    }
+
+    void TDistributedConfigKeeper::Handle(TEvTabletPipe::TEvClientDestroyed::TPtr ev) {
+        STLOG(PRI_DEBUG, BS_NODE, NWDC72, "received TEvClientDestroyed", (ConsolePipeId, ConsolePipeId),
+            (TabletId, ev->Get()->TabletId), (ClientId, ev->Get()->ClientId), (ServerId, ev->Get()->ServerId));
+        if (ev->Get()->ClientId == ConsolePipeId) {
+            OnConsolePipeError();
+        }
+    }
+
+    void TDistributedConfigKeeper::OnConsolePipeError() {
+        ConsolePipeId = {};
+        ConsoleConnected = false;
+        ConfigCommittedToConsole = false;
+        ProposedConfigHashVersion.reset();
+        ProposeRequestInFlight = false;
+        ++CommitRequestCookie; // to prevent processing any messages
+
+        // cancel any pending requests
+        for (const auto& [actorId, yaml, cookie] : ConsoleConfigValidationQ) {
+            auto ev = std::make_unique<TEvBlobStorage::TEvControllerValidateConfigResponse>();
+            ev->InternalError = "pipe disconnected";
+            Send(actorId, ev.release());
+        }
+        ConsoleConfigValidationQ.clear();
+
+        ConnectToConsole();
+    }
+
+    std::optional<TString> TDistributedConfigKeeper::UpdateConfigComposite(NKikimrBlobStorage::TStorageConfig& config,
+            const TString& yaml, const std::optional<TString>& fetched) {
+        TString temp;
+        const TString *finalFetchedConfig = fetched ? &fetched.value() : &temp;
+
+        if (!fetched) { // fill in 'to-be-fetched' version of config with version incremented by one
+            try {
+                auto metadata = NYamlConfig::GetMetadata(yaml);
+                metadata.Cluster = metadata.Cluster.value_or("unknown"); // TODO: fix this
+                metadata.Version = metadata.Version.value_or(0) + 1;
+                temp = NYamlConfig::ReplaceMetadata(yaml, metadata);
+            } catch (const std::exception& ex) {
+                return ex.what();
+            }
+        }
+
+        TStringStream ss;
+        {
+            TZstdCompress zstd(&ss);
+            SaveSize(&zstd, yaml.size());
+            zstd.Write(yaml);
+            SaveSize(&zstd, finalFetchedConfig->size());
+            zstd.Write(*finalFetchedConfig);
+        }
+        config.SetConfigComposite(ss.Str());
+
+        return {};
+    }
+
+    bool TDistributedConfigKeeper::EnqueueConsoleConfigValidation(TActorId actorId, bool enablingDistconf, TString yaml) {
+        if (!ConsolePipeId) {
+            ConnectToConsole(enablingDistconf);
+            if (!ConsolePipeId) {
+                return false;
+            }
+        }
+
+        auto& [qActorId, qYaml, qCookie] = ConsoleConfigValidationQ.emplace_back(actorId, std::move(yaml), 0);
+
+        if (ConsoleConnected) {
+            qCookie = ++ValidateRequestCookie;
+            NTabletPipe::SendData(SelfId(), ConsolePipeId, new TEvBlobStorage::TEvControllerValidateConfigRequest(qYaml),
+                qCookie);
+        }
+
+        return true;
+    }
+
+}

--- a/ydb/core/blobstorage/nodewarden/distconf_fsm.cpp
+++ b/ydb/core/blobstorage/nodewarden/distconf_fsm.cpp
@@ -40,9 +40,14 @@ namespace NKikimr::NStorage {
         task.SetTaskId(RandomNumber<ui64>());
         task.MutableCollectConfigs();
         IssueScatterTask(TActorId(), std::move(task));
+
+        // establish connection to console tablet (if we have means to do it)
+        Y_ABORT_UNLESS(!ConsolePipeId);
+        ConnectToConsole();
     }
 
     void TDistributedConfigKeeper::UnbecomeRoot() {
+        DisconnectFromConsole();
     }
 
     void TDistributedConfigKeeper::SwitchToError(const TString& reason) {
@@ -349,8 +354,7 @@ namespace NKikimr::NStorage {
                 configToPropose = persistedConfig;
             }
         } else if (baseConfig && !baseConfig->GetGeneration()) {
-            const bool canBootstrapAutomatically = baseConfig->HasSelfManagementConfig() &&
-                baseConfig->GetSelfManagementConfig().GetEnabled() &&
+            const bool canBootstrapAutomatically = baseConfig->GetSelfManagementConfig().GetEnabled() &&
                 baseConfig->GetSelfManagementConfig().GetAutomaticBootstrap();
             if (canBootstrapAutomatically || selfAssemblyUUID) {
                 if (!selfAssemblyUUID) {

--- a/ydb/core/blobstorage/nodewarden/node_warden_impl.cpp
+++ b/ydb/core/blobstorage/nodewarden/node_warden_impl.cpp
@@ -1071,7 +1071,7 @@ bool NKikimr::NStorage::DeriveStorageConfig(const NKikimrConfig::TAppConfig& app
         };
 
         // update static group information unless distconf is enabled
-        if (!hasStaticGroupInfo(ssFrom) && config->HasSelfManagementConfig() && config->GetSelfManagementConfig().GetEnabled()) {
+        if (!hasStaticGroupInfo(ssFrom) && config->GetSelfManagementConfig().GetEnabled()) {
             // distconf enabled, keep it as is
         } else if (!hasStaticGroupInfo(*ssTo)) {
             ssTo->MutablePDisks()->CopyFrom(ssFrom.GetPDisks());

--- a/ydb/core/blobstorage/nodewarden/ya.make
+++ b/ydb/core/blobstorage/nodewarden/ya.make
@@ -6,6 +6,7 @@ SRCS(
     distconf.cpp
     distconf.h
     distconf_binding.cpp
+    distconf_console.cpp
     distconf_dynamic.cpp
     distconf_generate.cpp
     distconf_fsm.cpp

--- a/ydb/core/config/init/init.cpp
+++ b/ydb/core/config/init/init.cpp
@@ -589,7 +589,7 @@ void LoadYamlConfig(TConfigRefs refs, const TString& yamlConfigFile, NKikimrConf
 
     const TString yamlConfigString = protoConfigFileProvider.GetProtoFromFile(yamlConfigFile, errorCollector);
 
-    if (appConfig.HasSelfManagementConfig() && appConfig.GetSelfManagementConfig().GetEnabled()) {
+    if (appConfig.GetSelfManagementConfig().GetEnabled()) {
         // fill in InitialConfigYaml only when self-management through distconf is enabled
         appConfig.MutableSelfManagementConfig()->SetInitialConfigYaml(yamlConfigString);
     }

--- a/ydb/core/grpc_services/rpc_bsconfig.cpp
+++ b/ydb/core/grpc_services/rpc_bsconfig.cpp
@@ -109,7 +109,7 @@ public:
         } catch (const std::exception&) {
             return false; // assuming no distconf enabled in this config
         }
-        return newConfig.HasSelfManagementConfig() && newConfig.GetSelfManagementConfig().GetEnabled();
+        return newConfig.GetSelfManagementConfig().GetEnabled();
     }
 };
 

--- a/ydb/core/mind/bscontroller/impl.h
+++ b/ydb/core/mind/bscontroller/impl.h
@@ -2098,7 +2098,10 @@ public:
         SignalTabletActive(TActivationContext::AsActorContext());
         Loaded = true;
         ApplyStorageConfig();
-        StartConsoleInteraction();
+
+        if (!ConsoleInteraction) { // maybe we are in distconf mode, no console interaction yet started
+            StartConsoleInteraction();
+        }
 
         for (const auto& [id, info] : GroupMap) {
             if (info->VirtualGroupState) {

--- a/ydb/core/mind/bscontroller/self_heal.cpp
+++ b/ydb/core/mind/bscontroller/self_heal.cpp
@@ -956,7 +956,7 @@ namespace NKikimr::NBsController {
 
     void TBlobStorageController::PushStaticGroupsToSelfHeal() {
         if (!SelfHealId || !StorageConfigObtained || !StorageConfig.HasBlobStorageConfig() ||
-                !StorageConfig.HasSelfManagementConfig() || !StorageConfig.GetSelfManagementConfig().GetEnabled()) {
+                !StorageConfig.GetSelfManagementConfig().GetEnabled()) {
             return;
         }
 

--- a/ydb/core/mind/dynamic_nameserver.cpp
+++ b/ydb/core/mind/dynamic_nameserver.cpp
@@ -146,7 +146,7 @@ void TDynamicNameserver::Bootstrap(const TActorContext &ctx)
 void TDynamicNameserver::Handle(TEvNodeWardenStorageConfig::TPtr ev) {
     Y_ABORT_UNLESS(ev->Get()->Config);
     const auto& config = *ev->Get()->Config;
-    if (config.HasSelfManagementConfig() && config.GetSelfManagementConfig().GetEnabled()) {
+    if (config.GetSelfManagementConfig().GetEnabled()) {
         // self-management through distconf is enabled and we are operating based on their tables, so apply them now
         auto newStaticConfig = BuildNameserverTable(config);
         if (StaticConfig->StaticNodeTable != newStaticConfig->StaticNodeTable) {

--- a/ydb/core/protos/blobstorage.proto
+++ b/ydb/core/protos/blobstorage.proto
@@ -1392,6 +1392,7 @@ message TEvControllerConsoleCommitResponse {
         Committed = 2;
     }
     optional EStatus Status = 1;
+    optional string ErrorReason = 2;
 }
 
 message TEvControllerReplaceConfigRequest {
@@ -1430,6 +1431,7 @@ message TEvControllerValidateConfigResponse {
     optional bool SkipBSCValidation = 2;
     optional string YAML = 3;
     optional uint32 ConfigVersion = 4;
+    optional string ErrorReason = 5;
 }
 
 message TEvControllerValidationTimeout {

--- a/ydb/core/protos/blobstorage_distributed_config.proto
+++ b/ydb/core/protos/blobstorage_distributed_config.proto
@@ -28,9 +28,8 @@ message TStorageConfig { // contents of storage metadata
     repeated TNodeIdentifier AllNodes = 5; // set of all known nodes
     string ClusterUUID = 6; // cluster GUID as provided in nameservice config
     string SelfAssemblyUUID = 7; // self-assembly UUID generated when config is first created
-    optional bytes StorageConfigCompressedYAML = 12; // compressed stored storage config YAML (if stored)
+    optional bytes ConfigComposite = 12; // compressed stored storage config YAML (if stored)
     NKikimrConfig.TSelfManagementConfig SelfManagementConfig = 13;
-
     TStorageConfig PrevConfig = 100; // previous version of StorageConfig (if any)
 }
 
@@ -196,6 +195,7 @@ message TEvNodeConfigInvokeOnRoot {
 
     message TReplaceStorageConfig {
         string YAML = 1;
+        bool SkipConsoleValidation = 2;
     }
 
     message TBootstrapCluster {


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of changes introduced in this PR -->

Support Console interoperation through distconf

### Changelog category <!-- remove all except one -->

* New feature

### Additional information

Distconf now can track config.yaml stored in Console and operate over it.
