### PR TITLE
generic lookup: enable tcp keep-alive on connector connection

### DIFF
--- a/ydb/library/grpc/client/grpc_client_low.cpp
+++ b/ydb/library/grpc/client/grpc_client_low.cpp
@@ -141,7 +141,7 @@ void TChannelPool::GetStubsHolderLocked(
                 }
             }
         }
-        auto mutator = NImpl::GetGRpcKeepAliveSocketMutator(TcpKeepAliveSettings_);
+        auto mutator = NImpl::CreateGRpcKeepAliveSocketMutator(TcpKeepAliveSettings_);
         // will be destroyed inside grpc
         cb(Pool_.emplace(channelId, CreateChannelInterface(config, mutator)).first->second);
         LastUsedQueue_.emplace(Pool_.at(channelId).GetLastUseTime(), channelId);
@@ -581,9 +581,8 @@ void TGRpcClientLow::ForgetContext(TContextImpl* context) {
     }
 }
 
-grpc_socket_mutator* NImpl::GetGRpcKeepAliveSocketMutator(const TTcpKeepAliveSettings& TcpKeepAliveSettings_) {
+grpc_socket_mutator* NImpl::CreateGRpcKeepAliveSocketMutator(const TTcpKeepAliveSettings& TcpKeepAliveSettings_) {
     TGRpcKeepAliveSocketMutator* mutator = nullptr;
-    // will be destroyed inside grpc
     if (TcpKeepAliveSettings_.Enabled) {
         mutator = new TGRpcKeepAliveSocketMutator(
                 TcpKeepAliveSettings_.Idle,

--- a/ydb/library/grpc/client/grpc_client_low.h
+++ b/ydb/library/grpc/client/grpc_client_low.h
@@ -1391,7 +1391,7 @@ public:
     }
 
     template<typename TGRpcService>
-    std::unique_ptr<TServiceConnection<TGRpcService>> CreateGRpcServiceConnection(const TGRpcClientConfig& config, const TTcpKeepAliveSettings &keepAlive) {
+    std::unique_ptr<TServiceConnection<TGRpcService>> CreateGRpcServiceConnection(const TGRpcClientConfig& config, const TTcpKeepAliveSettings& keepAlive) {
         return std::unique_ptr<TServiceConnection<TGRpcService>>(new TServiceConnection<TGRpcService>(CreateChannelInterface(config, NImpl::GetGRpcKeepAliveSocketMutator(keepAlive)), this));
     }
 

--- a/ydb/library/grpc/client/grpc_client_low.h
+++ b/ydb/library/grpc/client/grpc_client_low.h
@@ -451,6 +451,10 @@ public:
 
 class TGRpcKeepAliveSocketMutator;
 
+namespace NImpl {
+grpc_socket_mutator* GetGRpcKeepAliveSocketMutator(const TTcpKeepAliveSettings& TcpKeepAliveSettings_);
+} // NImpl
+
 // Class to hold stubs allocated on channel.
 // It is poor documented part of grpc. See KIKIMR-6109 and comment to this commit
 
@@ -1384,6 +1388,11 @@ public:
     template<typename TGRpcService>
     std::unique_ptr<TServiceConnection<TGRpcService>> CreateGRpcServiceConnection(const TGRpcClientConfig& config) {
         return std::unique_ptr<TServiceConnection<TGRpcService>>(new TServiceConnection<TGRpcService>(CreateChannelInterface(config), this));
+    }
+
+    template<typename TGRpcService>
+    std::unique_ptr<TServiceConnection<TGRpcService>> CreateGRpcServiceConnection(const TGRpcClientConfig& config, const TTcpKeepAliveSettings &keepAlive) {
+        return std::unique_ptr<TServiceConnection<TGRpcService>>(new TServiceConnection<TGRpcService>(CreateChannelInterface(config, NImpl::GetGRpcKeepAliveSocketMutator(keepAlive)), this));
     }
 
     template<typename TGRpcService>

--- a/ydb/library/grpc/client/grpc_client_low.h
+++ b/ydb/library/grpc/client/grpc_client_low.h
@@ -452,7 +452,7 @@ public:
 class TGRpcKeepAliveSocketMutator;
 
 namespace NImpl {
-grpc_socket_mutator* GetGRpcKeepAliveSocketMutator(const TTcpKeepAliveSettings& TcpKeepAliveSettings_);
+grpc_socket_mutator* CreateGRpcKeepAliveSocketMutator(const TTcpKeepAliveSettings& TcpKeepAliveSettings_);
 } // NImpl
 
 // Class to hold stubs allocated on channel.
@@ -1392,7 +1392,9 @@ public:
 
     template<typename TGRpcService>
     std::unique_ptr<TServiceConnection<TGRpcService>> CreateGRpcServiceConnection(const TGRpcClientConfig& config, const TTcpKeepAliveSettings& keepAlive) {
-        return std::unique_ptr<TServiceConnection<TGRpcService>>(new TServiceConnection<TGRpcService>(CreateChannelInterface(config, NImpl::GetGRpcKeepAliveSocketMutator(keepAlive)), this));
+        auto mutator = NImpl::CreateGRpcKeepAliveSocketMutator(keepAlive);
+        // will be destroyed inside grpc
+        return std::unique_ptr<TServiceConnection<TGRpcService>>(new TServiceConnection<TGRpcService>(CreateChannelInterface(config, mutator), this));
     }
 
     template<typename TGRpcService>

--- a/ydb/library/yql/providers/generic/connector/libcpp/client.cpp
+++ b/ydb/library/yql/providers/generic/connector/libcpp/client.cpp
@@ -44,7 +44,8 @@ namespace NYql::NConnector {
             GrpcClient_ = std::make_unique<NYdbGrpc::TGRpcClientLow>();
 
             // FIXME: is it OK to use single connection during the client lifetime?
-            GrpcConnection_ = GrpcClient_->CreateGRpcServiceConnection<NApi::Connector>(GrpcConfig_);
+            // TODO band-aid; we will need timeouts, re-connection/etc
+            GrpcConnection_ = GrpcClient_->CreateGRpcServiceConnection<NApi::Connector>(GrpcConfig_, NYdbGrpc::TTcpKeepAliveSettings {true, 30, 5, 10}); // TODO configure hardcoded values
         }
 
         virtual TDescribeTableAsyncResult DescribeTable(const NApi::TDescribeTableRequest& request) override {

--- a/ydb/library/yql/providers/generic/connector/libcpp/client.cpp
+++ b/ydb/library/yql/providers/generic/connector/libcpp/client.cpp
@@ -44,8 +44,13 @@ namespace NYql::NConnector {
             GrpcClient_ = std::make_unique<NYdbGrpc::TGRpcClientLow>();
 
             // FIXME: is it OK to use single connection during the client lifetime?
-            // TODO band-aid; we will need timeouts, re-connection/etc
-            GrpcConnection_ = GrpcClient_->CreateGRpcServiceConnection<NApi::Connector>(GrpcConfig_, NYdbGrpc::TTcpKeepAliveSettings {true, 30, 5, 10}); // TODO configure hardcoded values
+            GrpcConnection_ = GrpcClient_->CreateGRpcServiceConnection<NApi::Connector>(GrpcConfig_, NYdbGrpc::TTcpKeepAliveSettings {
+                    // TODO configure hardcoded values
+                    .Enabled = true,
+                    .Idle = 30,
+                    .Count = 5,
+                    .Interval = 10
+            });
         }
 
         virtual TDescribeTableAsyncResult DescribeTable(const NApi::TDescribeTableRequest& request) override {


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of changes introduced in this PR -->

...

### Changelog category <!-- remove all except one -->

* Bugfix 
* Not for changelog (changelog entry is not required)

### Additional information

Problems that it tries to solve: there are long-running streamlookup join, that very rarely tries to look up anything (most of rows are filtered on earlier stages). It freezes, apparently attempting to look up after ~14h delay.