### PR TITLE
Prepare login lockout info in order to use it in system view

### DIFF
--- a/ydb/core/tx/schemeshard/schemeshard__init.cpp
+++ b/ydb/core/tx/schemeshard/schemeshard__init.cpp
@@ -3884,7 +3884,9 @@ struct TSchemeShard::TTxInit : public TTransactionBase<TSchemeShard> {
                 sid.SetType(rowset.GetValue<Schema::LoginSids::SidType>());
                 sid.SetHash(rowset.GetValue<Schema::LoginSids::SidHash>());
                 sid.SetCreatedAt(rowset.GetValueOrDefault<Schema::LoginSids::CreatedAt>());
-                sid.SetLastSuccessfulLogin(rowset.GetValue<Schema::LoginSids::LastSuccessfulAttempt>());
+                sid.SetCurrentFailedLoginAttemptCount(rowset.GetValueOrDefault<Schema::LoginSids::FailedAttemptCount>());
+                sid.SetLastFailedLoginAttempt(rowset.GetValueOrDefault<Schema::LoginSids::LastFailedAttempt>());
+                sid.SetLastSuccessfulLoginAttempt(rowset.GetValueOrDefault<Schema::LoginSids::LastSuccessfulAttempt>());
                 sidIndex[sid.name()] = securityState.SidsSize() - 1;
                 if (!rowset.Next()) {
                     return false;

--- a/ydb/core/tx/schemeshard/schemeshard__init.cpp
+++ b/ydb/core/tx/schemeshard/schemeshard__init.cpp
@@ -3884,9 +3884,9 @@ struct TSchemeShard::TTxInit : public TTransactionBase<TSchemeShard> {
                 sid.SetType(rowset.GetValue<Schema::LoginSids::SidType>());
                 sid.SetHash(rowset.GetValue<Schema::LoginSids::SidHash>());
                 sid.SetCreatedAt(rowset.GetValueOrDefault<Schema::LoginSids::CreatedAt>());
-                sid.SetCurrentFailedLoginAttemptCount(rowset.GetValueOrDefault<Schema::LoginSids::FailedAttemptCount>());
-                sid.SetLastFailedLoginAttempt(rowset.GetValueOrDefault<Schema::LoginSids::LastFailedAttempt>());
-                sid.SetLastSuccessfulLoginAttempt(rowset.GetValueOrDefault<Schema::LoginSids::LastSuccessfulAttempt>());
+                sid.SetFailedLoginAttemptCount(rowset.GetValueOrDefault<Schema::LoginSids::FailedAttemptCount>());
+                sid.SetLastFailedLogin(rowset.GetValueOrDefault<Schema::LoginSids::LastFailedAttempt>());
+                sid.SetLastSuccessfulLogin(rowset.GetValueOrDefault<Schema::LoginSids::LastSuccessfulAttempt>());
                 sidIndex[sid.name()] = securityState.SidsSize() - 1;
                 if (!rowset.Next()) {
                     return false;

--- a/ydb/core/tx/schemeshard/schemeshard__login.cpp
+++ b/ydb/core/tx/schemeshard/schemeshard__login.cpp
@@ -8,7 +8,7 @@ namespace NSchemeShard {
 
 using namespace NTabletFlatExecutor;
 
-struct TSchemeShard::TTxLogin : TTransactionBase<TSchemeShard> {
+struct TSchemeShard::TTxLogin : TSchemeShard::TRwTxBase {
     TEvSchemeShard::TEvLogin::TPtr Request;
     TPathId SubDomainPathId;
     bool NeedPublishOnComplete = false;
@@ -16,7 +16,7 @@ struct TSchemeShard::TTxLogin : TTransactionBase<TSchemeShard> {
     size_t CurrentFailedAttemptCount = 0;
 
     TTxLogin(TSelf *self, TEvSchemeShard::TEvLogin::TPtr &ev)
-        : TTransactionBase<TSchemeShard>(self)
+        : TRwTxBase(self)
         , Request(std::move(ev))
     {}
 
@@ -36,7 +36,7 @@ struct TSchemeShard::TTxLogin : TTransactionBase<TSchemeShard> {
             };
     }
 
-    bool Execute(TTransactionContext& txc, const TActorContext& ctx) override {
+    void DoExecute(TTransactionContext& txc, const TActorContext& ctx) override {
         LOG_DEBUG_S(ctx, NKikimrServices::FLAT_TX_SCHEMESHARD,
                     "TTxLogin Execute"
                     << " at schemeshard: " << Self->TabletID());
@@ -70,10 +70,10 @@ struct TSchemeShard::TTxLogin : TTransactionBase<TSchemeShard> {
             NeedPublishOnComplete = true;
         }
 
-        return LoginAttempt(db, ctx);
+        LoginAttempt(db, ctx);
     }
 
-    void Complete(const TActorContext &ctx) override {
+    void DoComplete(const TActorContext &ctx) override {
         if (NeedPublishOnComplete) {
             Self->PublishToSchemeBoard(TTxId(), {SubDomainPathId}, ctx);
         }
@@ -107,15 +107,16 @@ private:
         const auto& loginRequest = GetLoginRequest();
         if (!loginRequest.ExternalAuth && !AppData(ctx)->AuthConfig.GetEnableLoginAuthentication()) {
             Result->Record.SetError("Login authentication is disabled");
-            return true;
+            return;
         }
         if (loginRequest.ExternalAuth) {
-            return HandleExternalAuth(loginRequest);
+            HandleExternalAuth(loginRequest);
+        } else {
+            HandleLoginAuth(loginRequest, db);
         }
-        return HandleLoginAuth(loginRequest, db, ctx);
     }
 
-    bool HandleExternalAuth(const NLogin::TLoginProvider::TLoginUserRequest& loginRequest) {
+    void HandleExternalAuth(const NLogin::TLoginProvider::TLoginUserRequest& loginRequest) {
         const NLogin::TLoginProvider::TLoginUserResponse loginResponse = Self->LoginProvider.LoginUser(loginRequest);
         switch (loginResponse.Status) {
         case NLogin::TLoginProvider::TLoginUserResponse::EStatus::SUCCESS: {
@@ -132,84 +133,53 @@ private:
             break;
         }
         }
-        return true;
     }
 
-    bool HandleLoginAuth(const NLogin::TLoginProvider::TLoginUserRequest& loginRequest, NIceDb::TNiceDb& db, const TActorContext& /* ctx */) {
-        auto row = db.Table<Schema::LoginSids>().Key(loginRequest.User).Select();
-        if (!row.IsReady()) {
-            return false;
-        }
-        if (!row.IsValid()) {
-            Result->Record.SetError(TStringBuilder() << "Cannot find user: " << loginRequest.User);
-            return true;
-        }
-        CurrentFailedAttemptCount = row.GetValueOrDefault<Schema::LoginSids::FailedAttemptCount>();
-        TInstant lastFailedAttempt = TInstant::FromValue(row.GetValue<Schema::LoginSids::LastFailedAttempt>());
-        if (CheckAccountLockout()) {
-            if (ShouldUnlockAccount(lastFailedAttempt)) {
-                UnlockAccount(loginRequest, db);
-            } else {
-                Result->Record.SetError(TStringBuilder() << "User " << loginRequest.User << " is locked out");
-                return true;
+    void HandleLoginAuth(const NLogin::TLoginProvider::TLoginUserRequest& loginRequest, NIceDb::TNiceDb& db) {
+        using namespace NLogin;
+        const TLoginProvider::TCheckLockOutResponse checkLockOutResponse = Self->LoginProvider.CheckLockOutUser({.User = loginRequest.User});
+        switch (checkLockOutResponse.Status) {
+            case TLoginProvider::TCheckLockOutResponse::EStatus::SUCCESS:
+            case TLoginProvider::TCheckLockOutResponse::EStatus::INVALID_USER: {
+                Result->Record.SetError(checkLockOutResponse.Error);
+                return;
             }
-        } else if (ShouldResetFailedAttemptCount(lastFailedAttempt)) {
-            ResetFailedAttemptCount(loginRequest, db);
+            case TLoginProvider::TCheckLockOutResponse::EStatus::RESET: {
+                const auto& sid = Self->LoginProvider.Sids[loginRequest.User];
+                db.Table<Schema::LoginSids>().Key(loginRequest.User).Update<Schema::LoginSids::FailedAttemptCount>(sid.CurrentFailedLoginAttemptCount);
+                break;
+            }
+            case TLoginProvider::TCheckLockOutResponse::EStatus::UNLOCKED:
+            case TLoginProvider::TCheckLockOutResponse::EStatus::UNSPECIFIED: {
+                break;
+            }
         }
-        const NLogin::TLoginProvider::TLoginUserResponse loginResponse = Self->LoginProvider.LoginUser(loginRequest);
+
+        const TLoginProvider::TLoginUserResponse loginResponse = Self->LoginProvider.LoginUser(loginRequest);
         switch (loginResponse.Status) {
-        case NLogin::TLoginProvider::TLoginUserResponse::EStatus::SUCCESS: {
-            HandleLoginAuthSuccess(loginRequest, loginResponse, db);
+        case TLoginProvider::TLoginUserResponse::EStatus::SUCCESS: {
+            const auto& sid = Self->LoginProvider.Sids[loginRequest.User];
+            db.Table<Schema::LoginSids>().Key(loginRequest.User).Update<Schema::LoginSids::LastSuccessfulAttempt,
+                                                                        Schema::LoginSids::FailedAttemptCount>(ToInstant(sid.LastSuccessfulLoginAttempt).MilliSeconds(), sid.CurrentFailedLoginAttemptCount);
             Result->Record.SetToken(loginResponse.Token);
             Result->Record.SetSanitizedToken(loginResponse.SanitizedToken);
             Result->Record.SetIsAdmin(IsAdmin());
             break;
         }
-        case NLogin::TLoginProvider::TLoginUserResponse::EStatus::INVALID_PASSWORD: {
-            HandleLoginAuthInvalidPassword(loginRequest, loginResponse, db);
+        case TLoginProvider::TLoginUserResponse::EStatus::INVALID_PASSWORD: {
+            const auto& sid = Self->LoginProvider.Sids[loginRequest.User];
+            db.Table<Schema::LoginSids>().Key(loginRequest.User).Update<Schema::LoginSids::LastFailedAttempt,
+                                                                        Schema::LoginSids::FailedAttemptCount>(ToInstant(sid.LastFailedLoginAttempt).MilliSeconds(), sid.CurrentFailedLoginAttemptCount);
             Result->Record.SetError(loginResponse.Error);
             break;
         }
-        case NLogin::TLoginProvider::TLoginUserResponse::EStatus::INVALID_USER:
-        case NLogin::TLoginProvider::TLoginUserResponse::EStatus::UNAVAILABLE_KEY:
-        case NLogin::TLoginProvider::TLoginUserResponse::EStatus::UNSPECIFIED: {
+        case TLoginProvider::TLoginUserResponse::EStatus::INVALID_USER:
+        case TLoginProvider::TLoginUserResponse::EStatus::UNAVAILABLE_KEY:
+        case TLoginProvider::TLoginUserResponse::EStatus::UNSPECIFIED: {
             Result->Record.SetError(loginResponse.Error);
             break;
         }
         }
-        return true;
-    }
-
-    bool CheckAccountLockout() const {
-        return (Self->AccountLockout.AttemptThreshold != 0 && CurrentFailedAttemptCount >= Self->AccountLockout.AttemptThreshold);
-    }
-
-    bool ShouldResetFailedAttemptCount(const TInstant& lastFailedAttempt) {
-        if (Self->AccountLockout.AttemptResetDuration == TDuration::Zero()) {
-            return false;
-        }
-        return lastFailedAttempt + Self->AccountLockout.AttemptResetDuration < TAppData::TimeProvider->Now();
-    }
-
-    bool ShouldUnlockAccount(const TInstant& lastFailedAttempt) {
-        return ShouldResetFailedAttemptCount(lastFailedAttempt);
-    }
-
-    void ResetFailedAttemptCount(const NLogin::TLoginProvider::TLoginUserRequest& loginRequest, NIceDb::TNiceDb& db) {
-        db.Table<Schema::LoginSids>().Key(loginRequest.User).Update<Schema::LoginSids::FailedAttemptCount>(Schema::LoginSids::FailedAttemptCount::Default);
-        CurrentFailedAttemptCount = Schema::LoginSids::FailedAttemptCount::Default;
-    }
-
-    void UnlockAccount(const NLogin::TLoginProvider::TLoginUserRequest& loginRequest, NIceDb::TNiceDb& db) {
-        ResetFailedAttemptCount(loginRequest, db);
-    }
-
-    void HandleLoginAuthSuccess(const NLogin::TLoginProvider::TLoginUserRequest& loginRequest, const NLogin::TLoginProvider::TLoginUserResponse& loginResponse, NIceDb::TNiceDb& db) {
-        db.Table<Schema::LoginSids>().Key(loginRequest.User).Update<Schema::LoginSids::LastSuccessfulAttempt, Schema::LoginSids::FailedAttemptCount>(loginResponse.LoginAttemptTime, Schema::LoginSids::FailedAttemptCount::Default);
-    }
-
-    void HandleLoginAuthInvalidPassword(const NLogin::TLoginProvider::TLoginUserRequest& loginRequest, const NLogin::TLoginProvider::TLoginUserResponse& /* loginResponse */, NIceDb::TNiceDb& db) {
-        db.Table<Schema::LoginSids>().Key(loginRequest.User).Update<Schema::LoginSids::LastFailedAttempt, Schema::LoginSids::FailedAttemptCount>(TAppData::TimeProvider->Now().MicroSeconds(), CurrentFailedAttemptCount + 1);
     }
 };
 

--- a/ydb/core/tx/schemeshard/schemeshard_impl.cpp
+++ b/ydb/core/tx/schemeshard/schemeshard_impl.cpp
@@ -21,6 +21,7 @@
 #include <ydb/core/tx/columnshard/bg_tasks/events/events.h>
 #include <ydb/core/tx/scheme_board/events_schemeshard.h>
 #include <ydb/library/login/password_checker/password_checker.h>
+#include <ydb/library/login/account_lockout/account_lockout.h>
 #include <yql/essentials/minikql/mkql_type_ops.h>
 #include <yql/essentials/providers/common/proto/gateways_config.pb.h>
 #include <util/random/random.h>
@@ -4438,20 +4439,6 @@ TActorId TSchemeShard::TPipeClientFactory::CreateClient(const TActorContext& ctx
     return clientId;
 }
 
-TSchemeShard::TAccountLockout::TAccountLockout(const ::NKikimrProto::TAccountLockout& accountLockout)
-    : AttemptThreshold(accountLockout.GetAttemptThreshold())
-{
-    AttemptResetDuration = TDuration::Zero();
-    if (accountLockout.GetAttemptResetDuration().empty()) {
-        return;
-    }
-    if (TDuration::TryParse(accountLockout.GetAttemptResetDuration(), AttemptResetDuration)) {
-        if (AttemptResetDuration.Seconds() == 0) {
-            AttemptResetDuration = TDuration::Zero();
-        }
-    }
-}
-
 TSchemeShard::TSchemeShard(const TActorId &tablet, TTabletStorageInfo *info)
     : TActor(&TThis::StateInit)
     , TTabletExecutedFlat(info, tablet, new NMiniKQL::TMiniKQLFactory)
@@ -4489,8 +4476,9 @@ TSchemeShard::TSchemeShard(const TActorId &tablet, TTabletStorageInfo *info)
         .MinSpecialCharsCount = AppData()->AuthConfig.GetPasswordComplexity().GetMinSpecialCharsCount(),
         .SpecialChars = AppData()->AuthConfig.GetPasswordComplexity().GetSpecialChars(),
         .CanContainUsername = AppData()->AuthConfig.GetPasswordComplexity().GetCanContainUsername()
-    }))
-    , AccountLockout(AppData()->AuthConfig.GetAccountLockout())
+    }), {.AttemptThreshold = AppData()->AuthConfig.GetAccountLockout().GetAttemptThreshold(),
+         .AttemptResetDuration = AppData()->AuthConfig.GetAccountLockout().GetAttemptResetDuration()
+    })
 {
     TabletCountersPtr.Reset(new TProtobufTabletCounters<
                             ESimpleCounters_descriptor,
@@ -7403,11 +7391,16 @@ void TSchemeShard::ConfigureAccountLockout(
         const ::NKikimrProto::TAuthConfig& config,
         const TActorContext &ctx)
 {
-    AccountLockout = TAccountLockout(config.GetAccountLockout());
+    NLogin::TAccountLockout::TInitializer accountLockoutInitializer {
+        .AttemptThreshold = config.GetAccountLockout().GetAttemptThreshold(),
+        .AttemptResetDuration = config.GetAccountLockout().GetAttemptResetDuration()
+    };
+
+    LoginProvider.UpdateAccountLockout(accountLockoutInitializer);
 
     LOG_NOTICE_S(ctx, NKikimrServices::FLAT_TX_SCHEMESHARD,
-                 "AccountLockout configured: AttemptThreshold# " << AccountLockout.AttemptThreshold
-                 << ", AttemptResetDuration# " << AccountLockout.AttemptResetDuration.ToString());
+                 "AccountLockout configured: AttemptThreshold# " << accountLockoutInitializer.AttemptThreshold
+                 << ", AttemptResetDuration# " << accountLockoutInitializer.AttemptResetDuration);
 }
 
 void TSchemeShard::StartStopCompactionQueues() {

--- a/ydb/core/tx/schemeshard/schemeshard_impl.h
+++ b/ydb/core/tx/schemeshard/schemeshard_impl.h
@@ -1468,15 +1468,6 @@ public:
 
     NLogin::TLoginProvider LoginProvider;
 
-    struct TAccountLockout {
-        size_t AttemptThreshold = 4;
-        TDuration AttemptResetDuration = TDuration::Hours(1);
-
-        TAccountLockout(const ::NKikimrProto::TAccountLockout& accountLockout);
-    };
-
-    TAccountLockout AccountLockout;
-
 private:
     void OnDetach(const TActorContext &ctx) override;
     void OnTabletDead(TEvTablet::TEvTabletDead::TPtr &ev, const TActorContext &ctx) override;

--- a/ydb/core/tx/schemeshard/ut_login/ut_login.cpp
+++ b/ydb/core/tx/schemeshard/ut_login/ut_login.cpp
@@ -159,7 +159,7 @@ Y_UNIT_TEST_SUITE(TSchemeShardLoginTest) {
         // check login
         {
             auto resultLogin = Login(runtime, "user1", "password1");
-            UNIT_ASSERT_VALUES_EQUAL(resultLogin.GetError(), "Invalid user");
+            UNIT_ASSERT_VALUES_EQUAL(resultLogin.GetError(), "Cannot find user: user1");
         }
 
         // another still has access
@@ -215,7 +215,7 @@ Y_UNIT_TEST_SUITE(TSchemeShardLoginTest) {
         // check login
         {
             auto resultLogin = Login(runtime, "user1", "password1");
-            UNIT_ASSERT_VALUES_EQUAL(resultLogin.GetError(), "Invalid user");
+            UNIT_ASSERT_VALUES_EQUAL(resultLogin.GetError(), "Cannot find user: user1");
         }
 
         // another still has access
@@ -288,7 +288,7 @@ Y_UNIT_TEST_SUITE(TSchemeShardLoginTest) {
             TestDescribeResult(DescribePath(runtime, "/MyRoot/Dir1/DirSub1"),
                 {NLs::HasNoRight("+U:user1"), NLs::HasNoEffectiveRight("+U:user1"), NLs::HasOwner("user2")});
             auto resultLogin = Login(runtime, "user1", "password1");
-            UNIT_ASSERT_VALUES_EQUAL(resultLogin.GetError(), "Invalid user");
+            UNIT_ASSERT_VALUES_EQUAL(resultLogin.GetError(), "Cannot find user: user1");
         }
     }
 
@@ -306,7 +306,7 @@ Y_UNIT_TEST_SUITE(TSchemeShardLoginTest) {
         TTestBasicRuntime runtime;
         TTestEnv env(runtime);
         auto resultLogin = Login(runtime, "ldapuser@ldap.domain", "password1");
-        UNIT_ASSERT_VALUES_EQUAL(resultLogin.error(), "Invalid user");
+        UNIT_ASSERT_VALUES_EQUAL(resultLogin.error(), "Cannot find user: ldapuser@ldap.domain");
         UNIT_ASSERT_VALUES_EQUAL(resultLogin.token(), "");
         auto describe = DescribePath(runtime, TTestTxConfig::SchemeShard, "/MyRoot");
         CheckSecurityState(describe, {.PublicKeysSize = 1, .SidsSize = 0});
@@ -395,7 +395,7 @@ Y_UNIT_TEST_SUITE(TSchemeShardLoginTest) {
 
         CreateAlterLoginCreateGroup(runtime, ++txId, "/MyRoot", "group1");
         auto resultLogin = Login(runtime, "group1", "password1");
-        UNIT_ASSERT_VALUES_EQUAL(resultLogin.error(), "Invalid user");
+        UNIT_ASSERT_VALUES_EQUAL(resultLogin.error(), "group1 is a group");
         UNIT_ASSERT_VALUES_EQUAL(resultLogin.token(), "");
 
         {
@@ -447,7 +447,7 @@ Y_UNIT_TEST_SUITE(TSchemeShardLoginTest) {
             SetPasswordCheckerParameters(runtime, TTestTxConfig::SchemeShard, {.MinLowerCaseCount = 3});
             CreateAlterLoginCreateUser(runtime, ++txId, "/MyRoot", "user3", "PASSWORDU3", {{NKikimrScheme::StatusPreconditionFailed, "Incorrect password format: should contain at least 3 lower case character"}});
             auto resultLogin = Login(runtime, "user3", "PASSWORDU3");
-            UNIT_ASSERT_VALUES_EQUAL(resultLogin.error(), "Invalid user");
+            UNIT_ASSERT_VALUES_EQUAL(resultLogin.error(), "Cannot find user: user3");
             auto describe = DescribePath(runtime, TTestTxConfig::SchemeShard, "/MyRoot");
             CheckSecurityState(describe, {.PublicKeysSize = 1, .SidsSize = 2});
         }
@@ -480,7 +480,7 @@ Y_UNIT_TEST_SUITE(TSchemeShardLoginTest) {
             SetPasswordCheckerParameters(runtime, TTestTxConfig::SchemeShard, {.MinLowerCaseCount = 0, .MinUpperCaseCount = 3});
             CreateAlterLoginCreateUser(runtime, ++txId, "/MyRoot", "user5", "passwordu5", {{NKikimrScheme::StatusPreconditionFailed, "Incorrect password format: should contain at least 3 upper case character"}});
             auto resultLogin = Login(runtime, "user5", "passwordu5");
-            UNIT_ASSERT_VALUES_EQUAL(resultLogin.error(), "Invalid user");
+            UNIT_ASSERT_VALUES_EQUAL(resultLogin.error(), "Cannot find user: user5");
             auto describe = DescribePath(runtime, TTestTxConfig::SchemeShard, "/MyRoot");
             CheckSecurityState(describe, {.PublicKeysSize = 1, .SidsSize = 4});
         }
@@ -515,7 +515,7 @@ Y_UNIT_TEST_SUITE(TSchemeShardLoginTest) {
             SetPasswordCheckerParameters(runtime, TTestTxConfig::SchemeShard, {.MinLength = 8});
             CreateAlterLoginCreateUser(runtime, ++txId, "/MyRoot", "user7", "passwu7", {{NKikimrScheme::StatusPreconditionFailed, "Password is too short"}});
             auto resultLogin = Login(runtime, "user7", "passwu7");
-            UNIT_ASSERT_VALUES_EQUAL(resultLogin.error(), "Invalid user");
+            UNIT_ASSERT_VALUES_EQUAL(resultLogin.error(), "Cannot find user: user7");
             auto describe = DescribePath(runtime, TTestTxConfig::SchemeShard, "/MyRoot");
             CheckSecurityState(describe, {.PublicKeysSize = 1, .SidsSize = 6});
         }
@@ -549,7 +549,7 @@ Y_UNIT_TEST_SUITE(TSchemeShardLoginTest) {
             SetPasswordCheckerParameters(runtime, TTestTxConfig::SchemeShard, {.MinNumbersCount = 3});
             CreateAlterLoginCreateUser(runtime, ++txId, "/MyRoot", "user9", "passwordunine", {{NKikimrScheme::StatusPreconditionFailed, "Incorrect password format: should contain at least 3 number"}});
             auto resultLogin = Login(runtime, "user9", "passwordunine");
-            UNIT_ASSERT_VALUES_EQUAL(resultLogin.error(), "Invalid user");
+            UNIT_ASSERT_VALUES_EQUAL(resultLogin.error(), "Cannot find user: user9");
             auto describe = DescribePath(runtime, TTestTxConfig::SchemeShard, "/MyRoot");
             CheckSecurityState(describe, {.PublicKeysSize = 1, .SidsSize = 8});
         }
@@ -583,7 +583,7 @@ Y_UNIT_TEST_SUITE(TSchemeShardLoginTest) {
             SetPasswordCheckerParameters(runtime, TTestTxConfig::SchemeShard, {.MinSpecialCharsCount = 3});
             CreateAlterLoginCreateUser(runtime, ++txId, "/MyRoot", "user11", "passwordu11", {{NKikimrScheme::StatusPreconditionFailed, "Incorrect password format: should contain at least 3 special character"}});
             auto resultLogin = Login(runtime, "user11", "passwordu11");
-            UNIT_ASSERT_VALUES_EQUAL(resultLogin.error(), "Invalid user");
+            UNIT_ASSERT_VALUES_EQUAL(resultLogin.error(), "Cannot find user: user11");
             auto describe = DescribePath(runtime, TTestTxConfig::SchemeShard, "/MyRoot");
             CheckSecurityState(describe, {.PublicKeysSize = 1, .SidsSize = 10});
         }
@@ -606,7 +606,7 @@ Y_UNIT_TEST_SUITE(TSchemeShardLoginTest) {
             SetPasswordCheckerParameters(runtime, TTestTxConfig::SchemeShard, {.SpecialChars = "*#"}); // Only 2 special symbols are valid
             CreateAlterLoginCreateUser(runtime, ++txId, "/MyRoot", "user12", "passwordu12*&%#", {{NKikimrScheme::StatusPreconditionFailed, "Password contains unacceptable characters"}});
             auto resultLogin = Login(runtime, "user12", "passwordu12*&%#");
-            UNIT_ASSERT_VALUES_EQUAL(resultLogin.error(), "Invalid user");
+            UNIT_ASSERT_VALUES_EQUAL(resultLogin.error(), "Cannot find user: user12");
             auto describe = DescribePath(runtime, TTestTxConfig::SchemeShard, "/MyRoot");
             CheckSecurityState(describe, {.PublicKeysSize = 1, .SidsSize = 11});
         }

--- a/ydb/core/tx/schemeshard/ut_login/ut_login.cpp
+++ b/ydb/core/tx/schemeshard/ut_login/ut_login.cpp
@@ -159,7 +159,7 @@ Y_UNIT_TEST_SUITE(TSchemeShardLoginTest) {
         // check login
         {
             auto resultLogin = Login(runtime, "user1", "password1");
-            UNIT_ASSERT_VALUES_EQUAL(resultLogin.GetError(), "Cannot find user: user1");
+            UNIT_ASSERT_VALUES_EQUAL(resultLogin.GetError(), "Invalid user");
         }
 
         // another still has access
@@ -215,7 +215,7 @@ Y_UNIT_TEST_SUITE(TSchemeShardLoginTest) {
         // check login
         {
             auto resultLogin = Login(runtime, "user1", "password1");
-            UNIT_ASSERT_VALUES_EQUAL(resultLogin.GetError(), "Cannot find user: user1");
+            UNIT_ASSERT_VALUES_EQUAL(resultLogin.GetError(), "Invalid user");
         }
 
         // another still has access
@@ -288,7 +288,7 @@ Y_UNIT_TEST_SUITE(TSchemeShardLoginTest) {
             TestDescribeResult(DescribePath(runtime, "/MyRoot/Dir1/DirSub1"),
                 {NLs::HasNoRight("+U:user1"), NLs::HasNoEffectiveRight("+U:user1"), NLs::HasOwner("user2")});
             auto resultLogin = Login(runtime, "user1", "password1");
-            UNIT_ASSERT_VALUES_EQUAL(resultLogin.GetError(), "Cannot find user: user1");
+            UNIT_ASSERT_VALUES_EQUAL(resultLogin.GetError(), "Invalid user");
         }
     }
 
@@ -306,7 +306,7 @@ Y_UNIT_TEST_SUITE(TSchemeShardLoginTest) {
         TTestBasicRuntime runtime;
         TTestEnv env(runtime);
         auto resultLogin = Login(runtime, "ldapuser@ldap.domain", "password1");
-        UNIT_ASSERT_VALUES_EQUAL(resultLogin.error(), "Cannot find user: ldapuser@ldap.domain");
+        UNIT_ASSERT_VALUES_EQUAL(resultLogin.error(), "Invalid user");
         UNIT_ASSERT_VALUES_EQUAL(resultLogin.token(), "");
         auto describe = DescribePath(runtime, TTestTxConfig::SchemeShard, "/MyRoot");
         CheckSecurityState(describe, {.PublicKeysSize = 1, .SidsSize = 0});
@@ -447,7 +447,7 @@ Y_UNIT_TEST_SUITE(TSchemeShardLoginTest) {
             SetPasswordCheckerParameters(runtime, TTestTxConfig::SchemeShard, {.MinLowerCaseCount = 3});
             CreateAlterLoginCreateUser(runtime, ++txId, "/MyRoot", "user3", "PASSWORDU3", {{NKikimrScheme::StatusPreconditionFailed, "Incorrect password format: should contain at least 3 lower case character"}});
             auto resultLogin = Login(runtime, "user3", "PASSWORDU3");
-            UNIT_ASSERT_VALUES_EQUAL(resultLogin.error(), "Cannot find user: user3");
+            UNIT_ASSERT_VALUES_EQUAL(resultLogin.error(), "Invalid user");
             auto describe = DescribePath(runtime, TTestTxConfig::SchemeShard, "/MyRoot");
             CheckSecurityState(describe, {.PublicKeysSize = 1, .SidsSize = 2});
         }
@@ -480,7 +480,7 @@ Y_UNIT_TEST_SUITE(TSchemeShardLoginTest) {
             SetPasswordCheckerParameters(runtime, TTestTxConfig::SchemeShard, {.MinLowerCaseCount = 0, .MinUpperCaseCount = 3});
             CreateAlterLoginCreateUser(runtime, ++txId, "/MyRoot", "user5", "passwordu5", {{NKikimrScheme::StatusPreconditionFailed, "Incorrect password format: should contain at least 3 upper case character"}});
             auto resultLogin = Login(runtime, "user5", "passwordu5");
-            UNIT_ASSERT_VALUES_EQUAL(resultLogin.error(), "Cannot find user: user5");
+            UNIT_ASSERT_VALUES_EQUAL(resultLogin.error(), "Invalid user");
             auto describe = DescribePath(runtime, TTestTxConfig::SchemeShard, "/MyRoot");
             CheckSecurityState(describe, {.PublicKeysSize = 1, .SidsSize = 4});
         }
@@ -515,7 +515,7 @@ Y_UNIT_TEST_SUITE(TSchemeShardLoginTest) {
             SetPasswordCheckerParameters(runtime, TTestTxConfig::SchemeShard, {.MinLength = 8});
             CreateAlterLoginCreateUser(runtime, ++txId, "/MyRoot", "user7", "passwu7", {{NKikimrScheme::StatusPreconditionFailed, "Password is too short"}});
             auto resultLogin = Login(runtime, "user7", "passwu7");
-            UNIT_ASSERT_VALUES_EQUAL(resultLogin.error(), "Cannot find user: user7");
+            UNIT_ASSERT_VALUES_EQUAL(resultLogin.error(), "Invalid user");
             auto describe = DescribePath(runtime, TTestTxConfig::SchemeShard, "/MyRoot");
             CheckSecurityState(describe, {.PublicKeysSize = 1, .SidsSize = 6});
         }
@@ -549,7 +549,7 @@ Y_UNIT_TEST_SUITE(TSchemeShardLoginTest) {
             SetPasswordCheckerParameters(runtime, TTestTxConfig::SchemeShard, {.MinNumbersCount = 3});
             CreateAlterLoginCreateUser(runtime, ++txId, "/MyRoot", "user9", "passwordunine", {{NKikimrScheme::StatusPreconditionFailed, "Incorrect password format: should contain at least 3 number"}});
             auto resultLogin = Login(runtime, "user9", "passwordunine");
-            UNIT_ASSERT_VALUES_EQUAL(resultLogin.error(), "Cannot find user: user9");
+            UNIT_ASSERT_VALUES_EQUAL(resultLogin.error(), "Invalid user");
             auto describe = DescribePath(runtime, TTestTxConfig::SchemeShard, "/MyRoot");
             CheckSecurityState(describe, {.PublicKeysSize = 1, .SidsSize = 8});
         }
@@ -583,7 +583,7 @@ Y_UNIT_TEST_SUITE(TSchemeShardLoginTest) {
             SetPasswordCheckerParameters(runtime, TTestTxConfig::SchemeShard, {.MinSpecialCharsCount = 3});
             CreateAlterLoginCreateUser(runtime, ++txId, "/MyRoot", "user11", "passwordu11", {{NKikimrScheme::StatusPreconditionFailed, "Incorrect password format: should contain at least 3 special character"}});
             auto resultLogin = Login(runtime, "user11", "passwordu11");
-            UNIT_ASSERT_VALUES_EQUAL(resultLogin.error(), "Cannot find user: user11");
+            UNIT_ASSERT_VALUES_EQUAL(resultLogin.error(), "Invalid user");
             auto describe = DescribePath(runtime, TTestTxConfig::SchemeShard, "/MyRoot");
             CheckSecurityState(describe, {.PublicKeysSize = 1, .SidsSize = 10});
         }
@@ -606,7 +606,7 @@ Y_UNIT_TEST_SUITE(TSchemeShardLoginTest) {
             SetPasswordCheckerParameters(runtime, TTestTxConfig::SchemeShard, {.SpecialChars = "*#"}); // Only 2 special symbols are valid
             CreateAlterLoginCreateUser(runtime, ++txId, "/MyRoot", "user12", "passwordu12*&%#", {{NKikimrScheme::StatusPreconditionFailed, "Password contains unacceptable characters"}});
             auto resultLogin = Login(runtime, "user12", "passwordu12*&%#");
-            UNIT_ASSERT_VALUES_EQUAL(resultLogin.error(), "Cannot find user: user12");
+            UNIT_ASSERT_VALUES_EQUAL(resultLogin.error(), "Invalid user");
             auto describe = DescribePath(runtime, TTestTxConfig::SchemeShard, "/MyRoot");
             CheckSecurityState(describe, {.PublicKeysSize = 1, .SidsSize = 11});
         }
@@ -623,6 +623,12 @@ Y_UNIT_TEST_SUITE(TSchemeShardLoginTest) {
 
     Y_UNIT_TEST(AccountLockoutAndAutomaticallyUnlock) {
         TTestBasicRuntime runtime;
+        runtime.AddAppDataInit([] (ui32 nodeIdx, NKikimr::TAppData& appData) {
+            Y_UNUSED(nodeIdx);
+            auto accountLockout = appData.AuthConfig.MutableAccountLockout();
+            accountLockout->SetAttemptThreshold(4);
+            accountLockout->SetAttemptResetDuration("3s");
+        });
         TTestEnv env(runtime);
         auto accountLockoutConfig = runtime.GetAppData().AuthConfig.GetAccountLockout();
         ui64 txId = 100;
@@ -650,8 +656,9 @@ Y_UNIT_TEST_SUITE(TSchemeShardLoginTest) {
             CheckSecurityState(describe, {.PublicKeysSize = 1, .SidsSize = 1});
         }
 
-        // User is blocked for 1 hour
-        runtime.AdvanceCurrentTime(TDuration::Minutes(61));
+        // User is blocked for 3 seconds
+        // runtime.AdvanceCurrentTime(TDuration::Minutes(61));
+        Sleep(TDuration::Seconds(4));
 
         resultLogin = Login(runtime, "user1", "wrongpassword6");
         UNIT_ASSERT_VALUES_EQUAL(resultLogin.error(), "Invalid password");
@@ -667,6 +674,12 @@ Y_UNIT_TEST_SUITE(TSchemeShardLoginTest) {
 
     Y_UNIT_TEST(ResetFailedAttemptCount) {
         TTestBasicRuntime runtime;
+        runtime.AddAppDataInit([] (ui32 nodeIdx, NKikimr::TAppData& appData) {
+            Y_UNUSED(nodeIdx);
+            auto accountLockout = appData.AuthConfig.MutableAccountLockout();
+            accountLockout->SetAttemptThreshold(4);
+            accountLockout->SetAttemptResetDuration("3s");
+        });
         TTestEnv env(runtime);
         auto accountLockoutConfig = runtime.GetAppData().AuthConfig.GetAccountLockout();
         ui64 txId = 100;
@@ -688,8 +701,9 @@ Y_UNIT_TEST_SUITE(TSchemeShardLoginTest) {
             CheckSecurityState(describe, {.PublicKeysSize = 1, .SidsSize = 1});
         }
 
-        // FailedAttemptCount will reset in 1 hour
-        runtime.AdvanceCurrentTime(TDuration::Minutes(61));
+        // FailedAttemptCount will reset in 3 seconds
+        // runtime.AdvanceCurrentTime(TDuration::Minutes(61));
+        Sleep(TDuration::Seconds(4));
 
         // FailedAttemptCount should be reset
         for (size_t attempt = 0; attempt < accountLockoutConfig.GetAttemptThreshold() - 1; attempt++) {
@@ -708,6 +722,12 @@ Y_UNIT_TEST_SUITE(TSchemeShardLoginTest) {
 
     Y_UNIT_TEST(ChangeAccountLockoutParameters) {
         TTestBasicRuntime runtime;
+        runtime.AddAppDataInit([] (ui32 nodeIdx, NKikimr::TAppData& appData) {
+            Y_UNUSED(nodeIdx);
+            auto accountLockout = appData.AuthConfig.MutableAccountLockout();
+            accountLockout->SetAttemptThreshold(4);
+            accountLockout->SetAttemptResetDuration("3s");
+        });
         TTestEnv env(runtime);
         auto accountLockoutConfig = runtime.GetAppData().AuthConfig.GetAccountLockout();
         ui64 txId = 100;
@@ -731,8 +751,9 @@ Y_UNIT_TEST_SUITE(TSchemeShardLoginTest) {
             CheckSecurityState(describe, {.PublicKeysSize = 1, .SidsSize = 1});
         }
 
-        // user is blocked for 1 hour
-        runtime.AdvanceCurrentTime(TDuration::Minutes(61));
+        // user is blocked for 3 seconds
+        // runtime.AdvanceCurrentTime(TDuration::Minutes(61));
+        Sleep(TDuration::Seconds(4));
 
         // Unlock user after 1 hour
         resultLogin = Login(runtime, "user1", "password1");
@@ -745,7 +766,7 @@ Y_UNIT_TEST_SUITE(TSchemeShardLoginTest) {
         }
 
         size_t newAttemptThreshold = 6;
-        SetAccountLockoutParameters(runtime, TTestTxConfig::SchemeShard, {.AttemptThreshold = newAttemptThreshold, .AttemptResetDuration = "5h"});
+        SetAccountLockoutParameters(runtime, TTestTxConfig::SchemeShard, {.AttemptThreshold = newAttemptThreshold, .AttemptResetDuration = "7s"});
 
         CreateAlterLoginCreateUser(runtime, ++txId, "/MyRoot", "user2", "password2");
         // Now user2 have 6 attempts to login
@@ -762,16 +783,18 @@ Y_UNIT_TEST_SUITE(TSchemeShardLoginTest) {
             CheckSecurityState(describe, {.PublicKeysSize = 1, .SidsSize = 2});
         }
 
-        // user2 is blocked for 10 hour
+        // user2 is blocked for 7 seconds
         // After 3 hours user2 must be locked out
-        runtime.AdvanceCurrentTime(TDuration::Hours(3));
+        // runtime.AdvanceCurrentTime(TDuration::Hours(3));
+        Sleep(TDuration::Seconds(4));
         resultLogin = Login(runtime, "user2", "wrongpassword28");
         UNIT_ASSERT_VALUES_EQUAL(resultLogin.error(), TStringBuilder() << "User user2 is locked out");
 
-        // After 5 h 1 m user2 must be unlocked
-        runtime.AdvanceCurrentTime(TDuration::Minutes(5 * 60 + 1));
+        // After 8 seconds user2 must be unlocked
+        // runtime.AdvanceCurrentTime(TDuration::Minutes(5 * 60 + 1));
+        Sleep(TDuration::Seconds(8));
 
-        // Unlock user after 10 sec
+        // Unlock user after 7 sec
         resultLogin = Login(runtime, "user2", "password2");
         UNIT_ASSERT_VALUES_EQUAL(resultLogin.error(), "");
         {
@@ -851,27 +874,29 @@ Y_UNIT_TEST_SUITE(TSchemeShardLoginTest) {
         }
     }
 
-    Y_UNIT_TEST(LockOutUserPermanentlyIfAttemptResetDurationIsZeroSeconds) {
-        TTestBasicRuntime runtime;
-        runtime.AddAppDataInit([] (ui32 nodeIdx, NKikimr::TAppData& appData) {
-            Y_UNUSED(nodeIdx);
-            auto accountLockout = appData.AuthConfig.MutableAccountLockout();
-            accountLockout->SetAttemptThreshold(4);
-            accountLockout->SetAttemptResetDuration("0s");
-        });
-        CheckUserIsLockedOutPermanently(runtime);
-    }
+    // Incorrect tests. Login library is using std::chrono and we cannot to simulate change current time
 
-    Y_UNIT_TEST(LockOutUserPermanentlyIfAttemptResetDurationCannotParse) {
-        TTestBasicRuntime runtime;
-        runtime.AddAppDataInit([] (ui32 nodeIdx, NKikimr::TAppData& appData) {
-            Y_UNUSED(nodeIdx);
-            auto accountLockout = appData.AuthConfig.MutableAccountLockout();
-            accountLockout->SetAttemptThreshold(4);
-            accountLockout->SetAttemptResetDuration("blablabla");
-        });
-        CheckUserIsLockedOutPermanently(runtime);
-    }
+    // Y_UNIT_TEST(LockOutUserPermanentlyIfAttemptResetDurationIsZeroSeconds) {
+    //     TTestBasicRuntime runtime;
+    //     runtime.AddAppDataInit([] (ui32 nodeIdx, NKikimr::TAppData& appData) {
+    //         Y_UNUSED(nodeIdx);
+    //         auto accountLockout = appData.AuthConfig.MutableAccountLockout();
+    //         accountLockout->SetAttemptThreshold(4);
+    //         accountLockout->SetAttemptResetDuration("0s");
+    //     });
+    //     CheckUserIsLockedOutPermanently(runtime);
+    // }
+
+    // Y_UNIT_TEST(LockOutUserPermanentlyIfAttemptResetDurationCannotParse) {
+    //     TTestBasicRuntime runtime;
+    //     runtime.AddAppDataInit([] (ui32 nodeIdx, NKikimr::TAppData& appData) {
+    //         Y_UNUSED(nodeIdx);
+    //         auto accountLockout = appData.AuthConfig.MutableAccountLockout();
+    //         accountLockout->SetAttemptThreshold(4);
+    //         accountLockout->SetAttemptResetDuration("blablabla");
+    //     });
+    //     CheckUserIsLockedOutPermanently(runtime);
+    // }
 }
 
 namespace NSchemeShardUT_Private {

--- a/ydb/library/login/account_lockout/account_lockout.cpp
+++ b/ydb/library/login/account_lockout/account_lockout.cpp
@@ -1,0 +1,34 @@
+#include <util/datetime/base.h>
+#include "account_lockout.h"
+
+namespace NLogin {
+
+TAccountLockout::TAccountLockout() = default;
+
+TAccountLockout::TAccountLockout(const TInitializer& initializer)
+    : AttemptThreshold(initializer.AttemptThreshold)
+{
+    SetAttemptResetDuration(initializer.AttemptResetDuration);
+}
+
+void TAccountLockout::Update(const TInitializer& initializer) {
+    AttemptThreshold = initializer.AttemptThreshold;
+    SetAttemptResetDuration(initializer.AttemptResetDuration);
+}
+
+void TAccountLockout::SetAttemptResetDuration(const TString& newAttemptResetDuration) {
+    TDuration attemptResetDuration = TDuration::Zero();
+    if (newAttemptResetDuration.empty()) {
+        AttemptResetDuration = std::chrono::system_clock::duration(std::chrono::seconds(attemptResetDuration.Seconds()));
+        return;
+    }
+    if (TDuration::TryParse(newAttemptResetDuration, attemptResetDuration)) {
+        if (attemptResetDuration.Seconds() == 0) {
+            attemptResetDuration = TDuration::Zero();
+        }
+    }
+
+    AttemptResetDuration = std::chrono::system_clock::duration(std::chrono::seconds(attemptResetDuration.Seconds()));
+}
+
+} // NLogin

--- a/ydb/library/login/account_lockout/account_lockout.h
+++ b/ydb/library/login/account_lockout/account_lockout.h
@@ -1,0 +1,26 @@
+#pragma once
+
+#include <chrono>
+#include <util/generic/string.h>
+
+namespace NLogin {
+
+struct TAccountLockout {
+    struct TInitializer {
+        size_t AttemptThreshold = 0;
+        TString AttemptResetDuration;
+    };
+
+    size_t AttemptThreshold = 4;
+    std::chrono::system_clock::duration AttemptResetDuration = std::chrono::hours(1);
+
+    TAccountLockout();
+    TAccountLockout(const TInitializer& initializer);
+
+    void Update(const TInitializer& initializer);
+
+private:
+    void SetAttemptResetDuration(const TString& newAttemptResetDuration);
+};
+
+} // NLogin

--- a/ydb/library/login/account_lockout/account_lockout_ut.cpp
+++ b/ydb/library/login/account_lockout/account_lockout_ut.cpp
@@ -1,0 +1,31 @@
+#include <library/cpp/testing/unittest/registar.h>
+#include <util/string/builder.h>
+#include "account_lockout.h"
+
+using namespace NLogin;
+
+Y_UNIT_TEST_SUITE(AccountLockoutTest) {
+    Y_UNIT_TEST(InitCorrectValue) {
+        TAccountLockout accountLockout({.AttemptThreshold = 5, .AttemptResetDuration = "5h"});
+        UNIT_ASSERT_VALUES_EQUAL(accountLockout.AttemptThreshold, 5);
+        UNIT_ASSERT_EQUAL(accountLockout.AttemptResetDuration, std::chrono::seconds(5 * 60 * 60));
+    }
+
+    Y_UNIT_TEST(InitZeroValue) {
+        TAccountLockout accountLockout({.AttemptThreshold = 5, .AttemptResetDuration = "0"});
+        UNIT_ASSERT_VALUES_EQUAL(accountLockout.AttemptThreshold, 5);
+        UNIT_ASSERT_EQUAL(accountLockout.AttemptResetDuration, std::chrono::seconds(0));
+    }
+
+    Y_UNIT_TEST(InitEmptyValue) {
+        TAccountLockout accountLockout({.AttemptThreshold = 5, .AttemptResetDuration = ""});
+        UNIT_ASSERT_VALUES_EQUAL(accountLockout.AttemptThreshold, 5);
+        UNIT_ASSERT_EQUAL(accountLockout.AttemptResetDuration, std::chrono::seconds(0));
+    }
+
+    Y_UNIT_TEST(InitWrongValue) {
+        TAccountLockout accountLockout({.AttemptThreshold = 5, .AttemptResetDuration = "balablabla"});
+        UNIT_ASSERT_VALUES_EQUAL(accountLockout.AttemptThreshold, 5);
+        UNIT_ASSERT_EQUAL(accountLockout.AttemptResetDuration, std::chrono::seconds(0));
+    }
+}

--- a/ydb/library/login/account_lockout/ut/ya.make
+++ b/ydb/library/login/account_lockout/ut/ya.make
@@ -1,0 +1,9 @@
+UNITTEST_FOR(ydb/library/login/account_lockout)
+
+PEERDIR()
+
+SRCS(
+    account_lockout_ut.cpp
+)
+
+END()

--- a/ydb/library/login/account_lockout/ya.make
+++ b/ydb/library/login/account_lockout/ya.make
@@ -1,0 +1,13 @@
+LIBRARY()
+
+PEERDIR()
+
+SRCS(
+    account_lockout.cpp
+)
+
+END()
+
+RECURSE_FOR_TESTS(
+    ut
+)

--- a/ydb/library/login/login.cpp
+++ b/ydb/library/login/login.cpp
@@ -353,9 +353,13 @@ bool TLoginProvider::ShouldUnlockAccount(const TSidRecord& sid) const {
 TLoginProvider::TCheckLockOutResponse TLoginProvider::CheckLockOutUser(const TCheckLockOutRequest& request) {
     TCheckLockOutResponse response;
     auto itUser = Sids.find(request.User);
-    if (itUser == Sids.end() || itUser->second.Type != ESidType::USER) {
+    if (itUser == Sids.end()) {
         response.Status = TCheckLockOutResponse::EStatus::INVALID_USER;
-        response.Error = "Invalid user";
+        response.Error = TStringBuilder() << "Cannot find user: " << request.User;
+        return response;
+    } else if (itUser->second.Type != ESidType::USER) {
+        response.Status = TCheckLockOutResponse::EStatus::INVALID_USER;
+        response.Error = TStringBuilder() << request.User << " is a group";
         return response;
     }
 

--- a/ydb/library/login/login.cpp
+++ b/ydb/library/login/login.cpp
@@ -754,6 +754,9 @@ void TLoginProvider::UpdateSecurityState(const NLoginProto::TSecurityState& stat
                 ChildToParentIndex[pbSubSid].emplace(sid.Name);
             }
             sid.CreatedAt = std::chrono::system_clock::time_point(std::chrono::milliseconds(pbSid.GetCreatedAt()));
+            sid.CurrentFailedLoginAttemptCount = pbSid.GetCurrentFailedLoginAttemptCount();
+            sid.LastFailedLoginAttempt = std::chrono::system_clock::time_point(std::chrono::milliseconds(pbSid.GetLastFailedLoginAttempt()));
+            sid.LastSuccessfulLoginAttempt = std::chrono::system_clock::time_point(std::chrono::milliseconds(pbSid.GetLastSuccessfulLoginAttempt()));
         }
     }
 }

--- a/ydb/library/login/login.cpp
+++ b/ydb/library/login/login.cpp
@@ -343,10 +343,6 @@ bool TLoginProvider::ShouldResetFailedAttemptCount(const TSidRecord& sid) const 
     if (AccountLockout.AttemptResetDuration == std::chrono::system_clock::duration::zero()) {
         return false;
     }
-    // Cerr << "+++now: " << std::chrono::system_clock::now().time_since_epoch().count() << Endl;;
-    // Cerr << "+++sid.LastFailedLoginAttempt: " << sid.LastFailedLoginAttempt.time_since_epoch().count() << Endl;
-    // Cerr << "+++AccountLockout.AttemptResetDuration: " << AccountLockout.AttemptResetDuration.count() << Endl;
-    // Cerr << "+++sum: " << (sid.LastFailedLoginAttempt + AccountLockout.AttemptResetDuration).time_since_epoch().count() << Endl;
     return sid.LastFailedLoginAttempt + AccountLockout.AttemptResetDuration < std::chrono::system_clock::now();
 }
 
@@ -365,9 +361,7 @@ TLoginProvider::TCheckLockOutResponse TLoginProvider::CheckLockOutUser(const TCh
 
     TSidRecord& sid  = itUser->second;
     if (CheckLockout(sid)) {
-        // Cerr << "+++CheckLockout: true" << Endl;
         if (ShouldUnlockAccount(sid)) {
-            // Cerr << "+++UnlockAccount" << Endl;
             UnlockAccount(&sid);
             response.Status = TCheckLockOutResponse::EStatus::RESET;
         } else {
@@ -376,7 +370,6 @@ TLoginProvider::TCheckLockOutResponse TLoginProvider::CheckLockOutUser(const TCh
         }
         return response;
     } else if (ShouldResetFailedAttemptCount(sid)) {
-        // Cerr << "+++CheckLockout: false" << Endl;
         ResetFailedLoginAttemptCount(&sid);
         response.Status = TCheckLockOutResponse::EStatus::RESET;
         return response;

--- a/ydb/library/login/login.cpp
+++ b/ydb/library/login/login.cpp
@@ -86,7 +86,7 @@ TLoginProvider::TBasicResponse TLoginProvider::CreateUser(const TCreateUserReque
     user.Name = request.User;
     user.Hash = Impl->GenerateHash(request.Password);
     user.CreatedAt = std::chrono::system_clock::now();
-    // user.LastFailedLoginAttempt = std::chrono::system_clock::duration::zero();
+    user.LastFailedLogin = std::chrono::system_clock::time_point();
 
     return response;
 }

--- a/ydb/library/login/login.h
+++ b/ydb/library/login/login.h
@@ -76,7 +76,6 @@ public:
         TString Token;
         TString SanitizedToken; // Token for audit logs
         EStatus Status = EStatus::UNSPECIFIED;
-        ui64 LoginAttemptTime; // microseconds
     };
 
     struct TValidateTokenRequest : TBasicRequest {
@@ -164,9 +163,9 @@ public:
         TString Hash;
         std::unordered_set<TString> Members;
         std::chrono::system_clock::time_point CreatedAt; // CreatedAt does not need in describe result. We will not add to security state
-        size_t CurrentFailedLoginAttemptCount = 0;
-        std::chrono::system_clock::time_point LastFailedLoginAttempt;
-        std::chrono::system_clock::time_point LastSuccessfulLoginAttempt;
+        size_t FailedLoginAttemptCount = 0;
+        std::chrono::system_clock::time_point LastFailedLogin;
+        std::chrono::system_clock::time_point LastSuccessfulLogin;
     };
 
     // our current audience (database name)

--- a/ydb/library/login/login.h
+++ b/ydb/library/login/login.h
@@ -8,6 +8,7 @@
 #include <util/generic/string.h>
 #include <ydb/library/login/protos/login.pb.h>
 #include <ydb/library/login/password_checker/password_checker.h>
+#include <ydb/library/login/account_lockout/account_lockout.h>
 
 namespace NLogin {
 
@@ -35,6 +36,22 @@ public:
         TString Notice;
     };
 
+    struct TCheckLockOutRequest : TBasicRequest {
+        TString User;
+    };
+
+    struct TCheckLockOutResponse : TBasicResponse {
+        enum class EStatus {
+            UNSPECIFIED,
+            SUCCESS,
+            UNLOCKED,
+            INVALID_USER,
+            RESET,
+        };
+
+        EStatus Status = EStatus::UNSPECIFIED;
+    };
+
     struct TLoginUserRequest : TBasicRequest {
         struct TOptions {
             bool WithUserGroups = false;
@@ -53,7 +70,7 @@ public:
             SUCCESS,
             INVALID_USER,
             INVALID_PASSWORD,
-            UNAVAILABLE_KEY
+            UNAVAILABLE_KEY,
         };
 
         TString Token;
@@ -147,7 +164,9 @@ public:
         TString Hash;
         std::unordered_set<TString> Members;
         std::chrono::system_clock::time_point CreatedAt; // CreatedAt does not need in describe result. We will not add to security state
-        ui64 LastSuccessfulLogin;
+        size_t CurrentFailedLoginAttemptCount = 0;
+        std::chrono::system_clock::time_point LastFailedLoginAttempt;
+        std::chrono::system_clock::time_point LastSuccessfulLoginAttempt;
     };
 
     // our current audience (database name)
@@ -167,6 +186,7 @@ public:
     NLoginProto::TSecurityState GetSecurityState() const;
     void UpdateSecurityState(const NLoginProto::TSecurityState& state);
 
+    TCheckLockOutResponse CheckLockOutUser(const TCheckLockOutRequest& request);
     TLoginUserResponse LoginUser(const TLoginUserRequest& request);
     TValidateTokenResponse ValidateToken(const TValidateTokenRequest& request);
 
@@ -182,9 +202,11 @@ public:
     TRemoveGroupResponse RemoveGroup(const TRemoveGroupRequest& request);
 
     void UpdatePasswordCheckParameters(const TPasswordComplexity& passwordComplexity);
+    void UpdateAccountLockout(const TAccountLockout::TInitializer& accountLockoutInitializer);
 
     TLoginProvider();
-    TLoginProvider(const TPasswordComplexity& passwordComplexity);
+    TLoginProvider(const TAccountLockout::TInitializer& accountLockoutInitializer);
+    TLoginProvider(const TPasswordComplexity& passwordComplexity, const TAccountLockout::TInitializer& accountLockoutInitializer);
     ~TLoginProvider();
 
     std::vector<TString> GetGroupsMembership(const TString& member);
@@ -197,10 +219,17 @@ private:
     bool CheckSubjectExists(const TString& name, const ESidType::SidType& type);
     static bool CheckAllowedName(const TString& name);
 
+    bool CheckLockout(const TSidRecord& sid) const;
+    static void ResetFailedLoginAttemptCount(TSidRecord* sid);
+    static void UnlockAccount(TSidRecord* sid);
+    bool ShouldResetFailedAttemptCount(const TSidRecord& sid) const;
+    bool ShouldUnlockAccount(const TSidRecord& sid) const;
+
     struct TImpl;
     THolder<TImpl> Impl;
 
     TPasswordChecker PasswordChecker;
+    TAccountLockout AccountLockout;
 };
 
 }

--- a/ydb/library/login/login.h
+++ b/ydb/library/login/login.h
@@ -162,7 +162,9 @@ public:
         TString Name;
         TString Hash;
         std::unordered_set<TString> Members;
-        std::chrono::system_clock::time_point CreatedAt; // CreatedAt does not need in describe result. We will not add to security state
+        // CreatedAt, FailedLoginAttemptCount, LastFailedLogin, LastSuccessfulLogin do not need in describe result.
+        // We will not add these parameters to security state
+        std::chrono::system_clock::time_point CreatedAt;
         size_t FailedLoginAttemptCount = 0;
         std::chrono::system_clock::time_point LastFailedLogin;
         std::chrono::system_clock::time_point LastSuccessfulLogin;

--- a/ydb/library/login/login_ut.cpp
+++ b/ydb/library/login/login_ut.cpp
@@ -1,6 +1,7 @@
 #include <library/cpp/testing/unittest/registar.h>
 #include <util/generic/algorithm.h>
 #include <ydb/library/login/password_checker/password_checker.h>
+#include <ydb/library/login/account_lockout/account_lockout.h>
 #include "login.h"
 
 using namespace NLogin;
@@ -391,6 +392,114 @@ Y_UNIT_TEST_SUITE(Login) {
             const auto& sid1 = provider.Sids["user1"];
             const auto& sid2 = provider.Sids["user2"];
             UNIT_ASSERT(sid1.CreatedAt < sid2.CreatedAt);
+        }
+    }
+
+    Y_UNIT_TEST(AccountLockoutAndAutomaticallyUnlock) {
+        TAccountLockout::TInitializer accountLockoutInitializer {.AttemptThreshold = 4, .AttemptResetDuration = "3s"};
+        TLoginProvider provider(accountLockoutInitializer);
+        provider.Audience = "test_audience1";
+        provider.RotateKeys();
+
+        TLoginProvider::TCreateUserRequest createUserRequest {
+            .User = "user1",
+            .Password = "password1"
+        };
+        auto createUserResponse = provider.CreateUser(createUserRequest);
+        UNIT_ASSERT(!createUserResponse.Error);
+
+        {
+            for (size_t attempt = 0; attempt < accountLockoutInitializer.AttemptThreshold; attempt++) {
+                auto checkLockoutResponse = provider.CheckLockOutUser({.User = createUserRequest.User});
+                UNIT_ASSERT_EQUAL(checkLockoutResponse.Status, TLoginProvider::TCheckLockOutResponse::EStatus::UNLOCKED);
+                auto loginUserResponse = provider.LoginUser({.User = createUserRequest.User, .Password = TStringBuilder() << "wrongpassword" << attempt});
+                UNIT_ASSERT_EQUAL(loginUserResponse.Status, TLoginProvider::TLoginUserResponse::EStatus::INVALID_PASSWORD);
+                UNIT_ASSERT_VALUES_EQUAL(loginUserResponse.Error, "Invalid password");
+            }
+            auto checkLockoutResponse = provider.CheckLockOutUser({.User = createUserRequest.User});
+            UNIT_ASSERT_EQUAL(checkLockoutResponse.Status, TLoginProvider::TCheckLockOutResponse::EStatus::SUCCESS);
+        }
+
+        Sleep(TDuration::Seconds(4));
+
+        {
+            auto checkLockoutResponse = provider.CheckLockOutUser({.User = createUserRequest.User});
+            UNIT_ASSERT_EQUAL(checkLockoutResponse.Status, TLoginProvider::TCheckLockOutResponse::EStatus::RESET);
+            auto loginUserResponse = provider.LoginUser({.User = createUserRequest.User, .Password = TStringBuilder() << "wrongpassword" << accountLockoutInitializer.AttemptThreshold});
+            UNIT_ASSERT_EQUAL(loginUserResponse.Status, TLoginProvider::TLoginUserResponse::EStatus::INVALID_PASSWORD);
+            UNIT_ASSERT_VALUES_EQUAL(loginUserResponse.Error, "Invalid password");
+        }
+
+        {
+            auto checkLockoutResponse = provider.CheckLockOutUser({.User = createUserRequest.User});
+            UNIT_ASSERT_EQUAL(checkLockoutResponse.Status, TLoginProvider::TCheckLockOutResponse::EStatus::UNLOCKED);
+            auto loginUserResponse = provider.LoginUser({.User = createUserRequest.User, .Password = createUserRequest.Password});
+            UNIT_ASSERT_EQUAL(loginUserResponse.Status, TLoginProvider::TLoginUserResponse::EStatus::SUCCESS);
+            UNIT_ASSERT_VALUES_EQUAL(loginUserResponse.Error, "");
+
+            auto validateTokenResponse = provider.ValidateToken({.Token = loginUserResponse.Token});
+            UNIT_ASSERT_VALUES_EQUAL(validateTokenResponse.Error, "");
+            UNIT_ASSERT(validateTokenResponse.User == createUserRequest.User);
+        }
+    }
+
+    Y_UNIT_TEST(ResetFailedAttemptCount) {
+        TAccountLockout::TInitializer accountLockoutInitializer {.AttemptThreshold = 4, .AttemptResetDuration = "3s"};
+        TLoginProvider provider(accountLockoutInitializer);
+        provider.Audience = "test_audience1";
+        provider.RotateKeys();
+
+        TLoginProvider::TCreateUserRequest createUserRequest {
+            .User = "user1",
+            .Password = "password1"
+        };
+        auto createUserResponse = provider.CreateUser(createUserRequest);
+        UNIT_ASSERT(!createUserResponse.Error);
+
+        {
+            for (size_t attempt = 0; attempt < accountLockoutInitializer.AttemptThreshold - 1; attempt++) {
+                auto checkLockoutResponse = provider.CheckLockOutUser({.User = createUserRequest.User});
+                UNIT_ASSERT_EQUAL(checkLockoutResponse.Status, TLoginProvider::TCheckLockOutResponse::EStatus::UNLOCKED);
+                auto loginUserResponse = provider.LoginUser({.User = createUserRequest.User, .Password = TStringBuilder() << "wrongpassword" << attempt});
+                UNIT_ASSERT_EQUAL(loginUserResponse.Status, TLoginProvider::TLoginUserResponse::EStatus::INVALID_PASSWORD);
+                UNIT_ASSERT_VALUES_EQUAL(loginUserResponse.Error, "Invalid password");
+            }
+            auto checkLockoutResponse = provider.CheckLockOutUser({.User = createUserRequest.User});
+            UNIT_ASSERT_EQUAL(checkLockoutResponse.Status, TLoginProvider::TCheckLockOutResponse::EStatus::UNLOCKED);
+        }
+
+        Sleep(TDuration::Seconds(4));
+
+        {
+            auto checkLockoutResponse = provider.CheckLockOutUser({.User = createUserRequest.User});
+            UNIT_ASSERT_EQUAL(checkLockoutResponse.Status, TLoginProvider::TCheckLockOutResponse::EStatus::RESET);
+            auto loginUserResponse = provider.LoginUser({.User = createUserRequest.User, .Password = "wrongpassword1"});
+            UNIT_ASSERT_EQUAL(loginUserResponse.Status, TLoginProvider::TLoginUserResponse::EStatus::INVALID_PASSWORD);
+            UNIT_ASSERT_VALUES_EQUAL(loginUserResponse.Error, "Invalid password");
+        }
+
+        {
+            for (size_t attempt = 0; attempt < accountLockoutInitializer.AttemptThreshold - 2; attempt++) {
+                auto checkLockoutResponse = provider.CheckLockOutUser({.User = createUserRequest.User});
+                UNIT_ASSERT_EQUAL(checkLockoutResponse.Status, TLoginProvider::TCheckLockOutResponse::EStatus::UNLOCKED);
+                auto loginUserResponse = provider.LoginUser({.User = createUserRequest.User, .Password = TStringBuilder() << "wrongpassword1" << attempt});
+                UNIT_ASSERT_EQUAL(loginUserResponse.Status, TLoginProvider::TLoginUserResponse::EStatus::INVALID_PASSWORD);
+                UNIT_ASSERT_VALUES_EQUAL(loginUserResponse.Error, "Invalid password");
+            }
+            auto checkLockoutResponse = provider.CheckLockOutUser({.User = createUserRequest.User});
+            UNIT_ASSERT_EQUAL(checkLockoutResponse.Status, TLoginProvider::TCheckLockOutResponse::EStatus::UNLOCKED);
+        }
+
+        {
+            auto checkLockoutResponse = provider.CheckLockOutUser({.User = createUserRequest.User});
+            UNIT_ASSERT_EQUAL(checkLockoutResponse.Status, TLoginProvider::TCheckLockOutResponse::EStatus::UNLOCKED);
+            auto loginUserResponse = provider.LoginUser({.User = createUserRequest.User, .Password = createUserRequest.Password});
+            UNIT_ASSERT_EQUAL(loginUserResponse.Status, TLoginProvider::TLoginUserResponse::EStatus::SUCCESS);
+            UNIT_ASSERT_VALUES_EQUAL(loginUserResponse.Error, "");
+
+            auto validateTokenResponse = provider.ValidateToken({.Token = loginUserResponse.Token});
+            UNIT_ASSERT_VALUES_EQUAL(validateTokenResponse.Error, "");
+            UNIT_ASSERT(validateTokenResponse.User == createUserRequest.User);
         }
     }
 }

--- a/ydb/library/login/login_ut.cpp
+++ b/ydb/library/login/login_ut.cpp
@@ -395,6 +395,27 @@ Y_UNIT_TEST_SUITE(Login) {
         }
     }
 
+    Y_UNIT_TEST(CannotCheckLockoutNonExistentUser) {
+        TLoginProvider provider;
+        provider.Audience = "test_audience1";
+        provider.RotateKeys();
+
+        {
+            auto checkLockoutResponse = provider.CheckLockOutUser({.User = "nonExistentUser"});
+            UNIT_ASSERT_EQUAL(checkLockoutResponse.Status, TLoginProvider::TCheckLockOutResponse::EStatus::INVALID_USER);
+            UNIT_ASSERT_VALUES_EQUAL(checkLockoutResponse.Error, "Cannot find user: nonExistentUser");
+        }
+
+        {
+            auto createGroupResponse = provider.CreateGroup({.Group = "group1"});
+            UNIT_ASSERT(!createGroupResponse.Error);
+
+            auto checkLockoutResponse = provider.CheckLockOutUser({.User = "group1"});
+            UNIT_ASSERT_EQUAL(checkLockoutResponse.Status, TLoginProvider::TCheckLockOutResponse::EStatus::INVALID_USER);
+            UNIT_ASSERT_VALUES_EQUAL(checkLockoutResponse.Error, "group1 is a group");
+        }
+    }
+
     Y_UNIT_TEST(AccountLockoutAndAutomaticallyUnlock) {
         TAccountLockout::TInitializer accountLockoutInitializer {.AttemptThreshold = 4, .AttemptResetDuration = "3s"};
         TLoginProvider provider(accountLockoutInitializer);

--- a/ydb/library/login/protos/login.proto
+++ b/ydb/library/login/protos/login.proto
@@ -23,7 +23,9 @@ message TSid {
     string Hash = 3;
     repeated string Members = 4;
     uint64 CreatedAt = 5;
-    uint64 LastSuccessfulLogin = 6; // microseconds
+    uint64 CurrentFailedLoginAttemptCount = 6;
+    uint64 LastFailedLoginAttempt = 7;
+    uint64 LastSuccessfulLoginAttempt = 8;
 }
 
 message TSecurityState {

--- a/ydb/library/login/protos/login.proto
+++ b/ydb/library/login/protos/login.proto
@@ -23,9 +23,9 @@ message TSid {
     string Hash = 3;
     repeated string Members = 4;
     uint64 CreatedAt = 5;
-    uint64 CurrentFailedLoginAttemptCount = 6;
-    uint64 LastFailedLoginAttempt = 7;
-    uint64 LastSuccessfulLoginAttempt = 8;
+    uint64 LastSuccessfulLogin = 6;
+    uint64 LastFailedLogin = 7;
+    uint64 FailedLoginAttemptCount = 8;
 }
 
 message TSecurityState {

--- a/ydb/library/login/protos/login.proto
+++ b/ydb/library/login/protos/login.proto
@@ -22,9 +22,9 @@ message TSid {
     ESidType.SidType Type = 2;
     string Hash = 3;
     repeated string Members = 4;
-    uint64 CreatedAt = 5;
-    uint64 LastSuccessfulLogin = 6;
-    uint64 LastFailedLogin = 7;
+    uint64 CreatedAt = 5; // microseconds
+    uint64 LastSuccessfulLogin = 6; // microseconds
+    uint64 LastFailedLogin = 7; // microseconds
     uint64 FailedLoginAttemptCount = 8;
 }
 

--- a/ydb/library/login/ya.make
+++ b/ydb/library/login/ya.make
@@ -8,6 +8,7 @@ PEERDIR(
     library/cpp/string_utils/base64
     ydb/library/login/protos
     ydb/library/login/password_checker
+    ydb/library/login/account_lockout
 )
 
 SRCS(
@@ -23,4 +24,5 @@ RECURSE_FOR_TESTS(
 
 RECURSE(
     password_checker
+    account_lockout
 )

--- a/ydb/services/ydb/ydb_ldap_login_ut.cpp
+++ b/ydb/services/ydb/ydb_ldap_login_ut.cpp
@@ -412,7 +412,7 @@ Y_UNIT_TEST_SUITE(TGRpcLdapAuthentication) {
         auto factory = CreateLoginCredentialsProviderFactory({.User = login + incorrectLdapDomain, .Password = password});
         TLoginClientConnection loginConnection(InitLdapSettings);
         auto loginProvider = factory->CreateProvider(loginConnection.GetCoreFacility());
-        UNIT_ASSERT_EXCEPTION_CONTAINS(loginProvider->GetAuthInfo(), yexception, "Invalid user");
+        UNIT_ASSERT_EXCEPTION_CONTAINS(loginProvider->GetAuthInfo(), yexception, "Cannot find user: ldapuser@ldap.domain");
 
         loginConnection.Stop();
     }

--- a/ydb/services/ydb/ydb_ldap_login_ut.cpp
+++ b/ydb/services/ydb/ydb_ldap_login_ut.cpp
@@ -412,7 +412,7 @@ Y_UNIT_TEST_SUITE(TGRpcLdapAuthentication) {
         auto factory = CreateLoginCredentialsProviderFactory({.User = login + incorrectLdapDomain, .Password = password});
         TLoginClientConnection loginConnection(InitLdapSettings);
         auto loginProvider = factory->CreateProvider(loginConnection.GetCoreFacility());
-        UNIT_ASSERT_EXCEPTION_CONTAINS(loginProvider->GetAuthInfo(), yexception, "Cannot find user: ldapuser@ldap.domain");
+        UNIT_ASSERT_EXCEPTION_CONTAINS(loginProvider->GetAuthInfo(), yexception, "Invalid user");
 
         loginConnection.Stop();
     }


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of changes introduced in this PR -->

Prepare login lockout info in order to use it in system view

### Changelog category <!-- remove all except one -->

* Improvement


### Additional information

Refactoring in schemeshard login transaction. Move check user lock out from transaction to login provider
