### PR TITLE
Fix -Wunused-parameter

### DIFF
--- a/ydb/core/cms/console/console_handshake.cpp
+++ b/ydb/core/cms/console/console_handshake.cpp
@@ -29,14 +29,14 @@ public:
         Become(&TThis::StateWork);
     }
 
-    void Handle(TEvConsole::TEvReplaceYamlConfigResponse::TPtr& ev) {
+    void Handle(TEvConsole::TEvReplaceYamlConfigResponse::TPtr& /* ev */) {
         auto response = std::make_unique<TEvBlobStorage::TEvControllerConsoleCommitResponse>();
         response->Record.SetStatus(NKikimrBlobStorage::TEvControllerConsoleCommitResponse::Committed);
         SendInReply(SenderId, InterconnectSession, std::move(response));
         PassAway();
     }
 
-    void Handle(TEvConsole::TEvGenericError::TPtr& ev) {
+    void Handle(TEvConsole::TEvGenericError::TPtr& /* ev */) {
         auto response = std::make_unique<TEvBlobStorage::TEvControllerConsoleCommitResponse>();
         response->Record.SetStatus(NKikimrBlobStorage::TEvControllerConsoleCommitResponse::NotCommitted);
         SendInReply(SenderId, InterconnectSession, std::move(response));
@@ -114,7 +114,7 @@ void TConfigsManager::Handle(TEvBlobStorage::TEvControllerProposeConfigRequest::
     SendInReply(ev->Sender, ev->InterconnectSession, std::move(response));
 }
 
-void TConfigsManager::Handle(TEvBlobStorage::TEvControllerConsoleCommitRequest::TPtr &ev, const TActorContext &ctx) {
+void TConfigsManager::Handle(TEvBlobStorage::TEvControllerConsoleCommitRequest::TPtr& ev, const TActorContext& /* ctx */) {
     auto response = std::make_unique<TEvBlobStorage::TEvControllerConsoleCommitResponse>();
     const auto& yamlConfig = ev->Get()->Record.GetYAML();
     if (!CheckSession(*ev, response, NKikimrBlobStorage::TEvControllerConsoleCommitResponse::SessionMismatch)) {
@@ -125,7 +125,7 @@ void TConfigsManager::Handle(TEvBlobStorage::TEvControllerConsoleCommitRequest::
     CommitActor = Register(actor);
 }
 
-void TConfigsManager::Handle(TEvBlobStorage::TEvControllerValidateConfigRequest::TPtr &ev, const TActorContext &ctx) {
+void TConfigsManager::Handle(TEvBlobStorage::TEvControllerValidateConfigRequest::TPtr& ev, const TActorContext& /* ctx */) {
     auto response = std::make_unique<TEvBlobStorage::TEvControllerValidateConfigResponse>();
     auto requestRecord = ev->Get()->Record;
     response->Record.SetSkipBSCValidation(requestRecord.GetSkipBSCValidation());

--- a/ydb/core/fq/libs/row_dispatcher/format_handler/filters/filters_set.cpp
+++ b/ydb/core/fq/libs/row_dispatcher/format_handler/filters/filters_set.cpp
@@ -236,7 +236,7 @@ public:
     }
 
 private:
-    void PushToFilter(const TFilterHandler& filterHandler, const TVector<ui64>& offsets, const TVector<ui64>& columnIndex, const TVector<const TVector<NYql::NUdf::TUnboxedValue>*>& values, ui64 numberRows) {
+    void PushToFilter(const TFilterHandler& filterHandler, const TVector<ui64>& /* offsets */, const TVector<ui64>& columnIndex, const TVector<const TVector<NYql::NUdf::TUnboxedValue>*>& values, ui64 numberRows) {
         const auto consumer = filterHandler.GetConsumer();
         const auto& columnIds = consumer->GetColumnIds();
 

--- a/ydb/core/fq/libs/row_dispatcher/format_handler/ut/format_handler_ut.cpp
+++ b/ydb/core/fq/libs/row_dispatcher/format_handler/ut/format_handler_ut.cpp
@@ -204,7 +204,7 @@ public:
 
 public:
     static TCallback EmptyCheck() {
-        return [&](TQueue<std::pair<TRope, TVector<ui64>>>&& data) {};
+        return [&](TQueue<std::pair<TRope, TVector<ui64>>>&& /* data */) {};
     }
 
     static TCallback OneBatchCheck(std::function<void(TRope&& messages, TVector<ui64>&& offsets)> callback) {

--- a/ydb/core/fq/libs/row_dispatcher/format_handler/ut/topic_filter_ut.cpp
+++ b/ydb/core/fq/libs/row_dispatcher/format_handler/ut/topic_filter_ut.cpp
@@ -356,7 +356,7 @@ Y_UNIT_TEST_SUITE(TestPurecalcFilter) {
         MakeFilter(
             {{"a1", "[DataType; String]"}},
             "where a2 ... 50",
-            [&](ui64 offset) {}
+            [&](ui64 /* offset */) {}
         );
     }
 }
@@ -411,11 +411,11 @@ Y_UNIT_TEST_SUITE(TestFilterSet) {
         CheckSuccess(MakeFilter(
             {{"a1", "[DataType; String]"}},
             "where a1 = \"str1\"",
-            [&](ui64 offset) {}
+            [&](ui64 /* offset */) {}
         ));
 
         CheckError(
-            FiltersSet->AddFilter(MakeIntrusive<TFilterSetConsumer>(FilterIds.back(), TVector<ui64>(), TVector<TSchemaColumn>(), TString(), [&](ui64 offset) {}, CompileError)),
+            FiltersSet->AddFilter(MakeIntrusive<TFilterSetConsumer>(FilterIds.back(), TVector<ui64>(), TVector<TSchemaColumn>(), TString(), [&](ui64 /* offset */) {}, CompileError)),
             EStatusId::INTERNAL_ERROR,
             "Failed to create new filter, filter with id [0:0:0] already exists"
         );
@@ -426,7 +426,7 @@ Y_UNIT_TEST_SUITE(TestFilterSet) {
         MakeFilter(
             {{"a1", "[DataType; String]"}},
             "where a2 ... 50",
-            [&](ui64 offset) {}
+            [&](ui64 /* offset */) {}
         );
     }
 }

--- a/ydb/core/grpc_services/rpc_ping.cpp
+++ b/ydb/core/grpc_services/rpc_ping.cpp
@@ -221,7 +221,7 @@ private:
 
 ////////////////////////////////////////////////////////////////////////////////
 
-void DoGrpcProxyPing(std::unique_ptr<IRequestNoOpCtx> p, const IFacilityProvider& f) {
+void DoGrpcProxyPing(std::unique_ptr<IRequestNoOpCtx> p, const IFacilityProvider& /* f */) {
     // we are in the GRPC proxy already (or in the check actor in case of auth check),
     // thus ready to reply right here
     using TRequest = TGrpcRequestNoOperationCall<Debug::GrpcProxyRequest, Debug::GrpcProxyResponse>;

--- a/ydb/core/kqp/compute_actor/kqp_compute_actor_impl.h
+++ b/ydb/core/kqp/compute_actor/kqp_compute_actor_impl.h
@@ -24,7 +24,7 @@ public:
     IDqOutputConsumer::TPtr CreateOutputConsumer(const NDqProto::TTaskOutput& outputDesc,
         const NMiniKQL::TType* type, NUdf::IApplyContext* applyCtx, const NMiniKQL::TTypeEnvironment& typeEnv,
         const NKikimr::NMiniKQL::THolderFactory& holderFactory,
-        TVector<IDqOutput::TPtr>&& outputs, NUdf::IPgBuilder* pgBuilder) const override
+        TVector<IDqOutput::TPtr>&& outputs, NUdf::IPgBuilder* /* pgBuilder */) const override
     {
         return KqpBuildOutputConsumer(outputDesc, type, applyCtx, typeEnv, holderFactory, std::move(outputs), MinFillPercentage_);
     }

--- a/ydb/core/kqp/opt/kqp_query_plan.cpp
+++ b/ydb/core/kqp/opt/kqp_query_plan.cpp
@@ -1239,7 +1239,7 @@ private:
         return AddOperator(planNode, "Aggregate", std::move(op));
     }
 
-    std::variant<ui32, TArgContext> Visit(const TCoWideCombiner& combiner, TQueryPlanNode& planNode) {
+    std::variant<ui32, TArgContext> Visit(const TCoWideCombiner& /* combiner */, TQueryPlanNode& planNode) {
         TOperator op;
         op.Properties["Name"] = "Aggregate";
         // op.Properties["GroupBy"] = NPlanUtils::PrettyExprStr(combiner.KeyExtractor());

--- a/ydb/core/kqp/opt/logical/kqp_opt_log_indexes.cpp
+++ b/ydb/core/kqp/opt/logical/kqp_opt_log_indexes.cpp
@@ -17,7 +17,7 @@ using namespace NYql::NNodes;
 
 namespace {
 
-TCoAtomList BuildKeyColumnsList(const TKikimrTableDescription& table, TPositionHandle pos, TExprContext& ctx,
+TCoAtomList BuildKeyColumnsList(const TKikimrTableDescription& /* table */, TPositionHandle pos, TExprContext& ctx,
                                 const auto& columnsToSelect) {
     TVector<TExprBase> columnsList;
     columnsList.reserve(columnsToSelect.size());

--- a/ydb/core/kqp/opt/physical/kqp_opt_phy_sort.cpp
+++ b/ydb/core/kqp/opt/physical/kqp_opt_phy_sort.cpp
@@ -153,7 +153,7 @@ bool CompatibleSort(TOptimizerStatistics::TSortColumns& existingOrder, const TCo
 TExprBase KqpBuildTopStageRemoveSort(
     TExprBase node, 
     TExprContext& ctx, 
-    IOptimizationContext& optCtx, 
+    IOptimizationContext& /* optCtx */, 
     TTypeAnnotationContext& typeCtx,
     const TParentsMap& parentsMap, 
     bool allowStageMultiUsage,

--- a/ydb/core/kqp/ut/olap/indexes_ut.cpp
+++ b/ydb/core/kqp/ut/olap/indexes_ut.cpp
@@ -362,7 +362,7 @@ Y_UNIT_TEST_SUITE(KqpOlapIndexes) {
                 auto alterQuery =
                     TStringBuilder() <<
                     R"(ALTER OBJECT `/Root/olapStore` (TYPE TABLESTORE) SET (ACTION=UPSERT_OPTIONS, `COMPACTION_PLANNER.CLASS_NAME`=`lc-buckets`, `COMPACTION_PLANNER.FEATURES`=`
-                  {"levels" : [{"class_name" : "Zero", "portions_live_duration" : "10s", "expected_blobs_size" : 2048000, "portions_count_available" : 1}, 
+                  {"levels" : [{"class_name" : "Zero", "portions_live_duration" : "10s", "expected_blobs_size" : 2048000, "portions_count_available" : 1},
                                {"class_name" : "Zero"}]}`);
                 )";
                 auto session = tableClient.CreateSession().GetValueSync().GetSession();

--- a/ydb/core/mind/bscontroller/console_interaction.cpp
+++ b/ydb/core/mind/bscontroller/console_interaction.cpp
@@ -46,7 +46,7 @@ namespace NKikimr::NBsController {
         MakeGetBlock();
     }
 
-    void TBlobStorageController::TConsoleInteraction::MakeCommitToConsole(TString& config, ui32 configVersion) {
+    void TBlobStorageController::TConsoleInteraction::MakeCommitToConsole(TString& /* config */, ui32 /* configVersion */) {
         auto ev = MakeHolder<TEvBlobStorage::TEvControllerConsoleCommitRequest>();
         ev->Record.SetYAML(Self.YamlConfig);
         NTabletPipe::SendData(Self.SelfId(), ConsolePipe, ev.Release());
@@ -163,7 +163,7 @@ namespace NKikimr::NBsController {
         Self.Send(ev->Sender, validateConfigResponse.release());
     }
 
-    bool TBlobStorageController::TConsoleInteraction::ParseConfig(const TString& config, ui32& configVersion, NKikimrBlobStorage::TStorageConfig& storageConfig) {
+    bool TBlobStorageController::TConsoleInteraction::ParseConfig(const TString& config, ui32& /* configVersion */, NKikimrBlobStorage::TStorageConfig& storageConfig) {
         NKikimrConfig::TAppConfig appConfig;
         try {
             appConfig = NKikimr::NYaml::Parse(config);
@@ -174,7 +174,7 @@ namespace NKikimr::NBsController {
         return success;
     }
 
-    TBlobStorageController::TConsoleInteraction::TCommitConfigResult::EStatus TBlobStorageController::TConsoleInteraction::CheckConfig(const TString& config, ui32& configVersion, bool skipBSCValidation, 
+    TBlobStorageController::TConsoleInteraction::TCommitConfigResult::EStatus TBlobStorageController::TConsoleInteraction::CheckConfig(const TString& config, ui32& configVersion, bool skipBSCValidation,
                                                                                                                                        NKikimrBlobStorage::TStorageConfig& storageConfig) {
         if (!ParseConfig(config, configVersion, storageConfig)) {
             return TConsoleInteraction::TCommitConfigResult::EStatus::ParseError;
@@ -188,7 +188,7 @@ namespace NKikimr::NBsController {
         return TConsoleInteraction::TCommitConfigResult::EStatus::Success;
     }
 
-    void TBlobStorageController::TConsoleInteraction::Handle(TBlobStorageController::TConsoleInteraction::TEvPrivate::TEvValidationTimeout::TPtr &ev) {
+    void TBlobStorageController::TConsoleInteraction::Handle(TBlobStorageController::TConsoleInteraction::TEvPrivate::TEvValidationTimeout::TPtr& /* ev */) {
         if (TActivationContext::Now() < ValidationTimeout) {
             return;
         }

--- a/ydb/core/mon/mon.cpp
+++ b/ydb/core/mon/mon.cpp
@@ -759,7 +759,7 @@ public:
         CancelSubscriber = std::move(ev);
     }
 
-    void Handle(NHttp::TEvHttpProxy::TEvRequestCancelled::TPtr& ev) {
+    void Handle(NHttp::TEvHttpProxy::TEvRequestCancelled::TPtr& /* ev */) {
         if (CancelSubscriber) {
             Send(CancelSubscriber->Sender, new NHttp::TEvHttpProxy::TEvRequestCancelled(), 0, CancelSubscriber->Cookie);
         }
@@ -900,7 +900,7 @@ public:
         }
     }
 
-    void Disconnected(TEvInterconnect::TEvNodeDisconnected::TPtr& ev) {
+    void Disconnected(TEvInterconnect::TEvNodeDisconnected::TPtr& /* ev */) {
         if (CurrentResponse) {
             Send(Event->Sender, new NHttp::TEvHttpProxy::TEvHttpOutgoingDataChunk("NodeDisconnected"), 0, Event->Cookie);
         } else {
@@ -1009,7 +1009,7 @@ public:
         Become(&THttpMonInitializator::StateWork);
     }
 
-    void Handle(NHttp::TEvHttpProxy::TEvConfirmListen::TPtr& ev) {
+    void Handle(NHttp::TEvHttpProxy::TEvConfirmListen::TPtr& /* ev */) {
         Promise.set_value();
         PassAway();
     }

--- a/ydb/core/persqueue/partition.cpp
+++ b/ydb/core/persqueue/partition.cpp
@@ -1009,7 +1009,7 @@ void TPartition::HandleOnInit(TEvPQ::TEvProposePartitionConfig::TPtr& ev, const 
     PendingEvents.emplace_back(ev->ReleaseBase().Release());
 }
 
-void TPartition::HandleOnInit(TEvPQ::TEvGetWriteInfoRequest::TPtr& ev, const TActorContext& ctx)
+void TPartition::HandleOnInit(TEvPQ::TEvGetWriteInfoRequest::TPtr& ev, const TActorContext& /* ctx */)
 {
     PQ_LOG_D("HandleOnInit TEvPQ::TEvGetWriteInfoRequest");
 
@@ -1019,7 +1019,7 @@ void TPartition::HandleOnInit(TEvPQ::TEvGetWriteInfoRequest::TPtr& ev, const TAc
     PendingEvents.emplace_back(ev->ReleaseBase().Release());
 }
 
-void TPartition::HandleOnInit(TEvPQ::TEvGetWriteInfoResponse::TPtr& ev, const TActorContext& ctx)
+void TPartition::HandleOnInit(TEvPQ::TEvGetWriteInfoResponse::TPtr& ev, const TActorContext& /* ctx */)
 {
     PQ_LOG_D("HandleOnInit TEvPQ::TEvGetWriteInfoResponse");
 
@@ -1028,7 +1028,7 @@ void TPartition::HandleOnInit(TEvPQ::TEvGetWriteInfoResponse::TPtr& ev, const TA
     PendingEvents.emplace_back(ev->ReleaseBase().Release());
 }
 
-void TPartition::HandleOnInit(TEvPQ::TEvGetWriteInfoError::TPtr& ev, const TActorContext& ctx)
+void TPartition::HandleOnInit(TEvPQ::TEvGetWriteInfoError::TPtr& ev, const TActorContext& /* ctx */)
 {
     PQ_LOG_D("HandleOnInit TEvPQ::TEvGetWriteInfoError");
 

--- a/ydb/core/public_http/fq_handlers.h
+++ b/ydb/core/public_http/fq_handlers.h
@@ -422,7 +422,7 @@ public:
         TIntrusivePtr<TGrpcRequestContextWrapper> requestContext = MakeIntrusive<TGrpcRequestContextWrapper>(
             RequestContext,
             std::move(describeRequest),
-            [query_id = std::move(queryId), actorSystem = TActivationContext::ActorSystem()](const THttpRequestContext& requestContext, const TJsonSettings& jsonSettings, NProtoBuf::Message* resp, ui32 status) {
+            [query_id = std::move(queryId), actorSystem = TActivationContext::ActorSystem()](const THttpRequestContext& requestContext, const TJsonSettings& jsonSettings, NProtoBuf::Message* resp, ui32 /* status */) {
 
             Y_ABORT_UNLESS(resp);
             Y_ABORT_UNLESS(resp->GetArena());

--- a/ydb/core/statistics/service/ut/ut_http_request.cpp
+++ b/ydb/core/statistics/service/ut/ut_http_request.cpp
@@ -39,13 +39,13 @@ void ProbeTest(bool isServerless) {
     const auto sender = runtime.AllocateEdgeActor();
 
     bool firstStatsToSA = false;
-    auto statsObserver1 = runtime.AddObserver<TEvStatistics::TEvSchemeShardStats>([&](auto& ev){
+    auto statsObserver1 = runtime.AddObserver<TEvStatistics::TEvSchemeShardStats>([&](auto& /* ev */){
         firstStatsToSA = true;
     });
     runtime.WaitFor("TEvSchemeShardStats 1", [&]{ return firstStatsToSA; });
 
     bool secondStatsToSA = false;
-    auto statsObserver2 = runtime.AddObserver<TEvStatistics::TEvSchemeShardStats>([&](auto& ev){
+    auto statsObserver2 = runtime.AddObserver<TEvStatistics::TEvSchemeShardStats>([&](auto& /* ev */){
         secondStatsToSA = true;
     });
     runtime.WaitFor("TEvSchemeShardStats 2", [&]{ return secondStatsToSA; });

--- a/ydb/core/tx/columnshard/blobs_action/transaction/tx_blobs_written.cpp
+++ b/ydb/core/tx/columnshard/blobs_action/transaction/tx_blobs_written.cpp
@@ -136,14 +136,14 @@ void TTxBlobsWritingFinished::DoComplete(const TActorContext& ctx) {
     Self->SetupCompaction(pathIds);
 }
 
-TTxBlobsWritingFinished::TTxBlobsWritingFinished(TColumnShard* self, const NKikimrProto::EReplyStatus writeStatus,
+TTxBlobsWritingFinished::TTxBlobsWritingFinished(TColumnShard* self, const NKikimrProto::EReplyStatus /* writeStatus */,
     const std::shared_ptr<NOlap::IBlobsWritingAction>& writingActions, TInsertedPortions&& pack)
     : TBase(self, "TTxBlobsWritingFinished")
     , Pack(std::move(pack))
     , WritingActions(writingActions) {
 }
 
-bool TTxBlobsWritingFailed::DoExecute(TTransactionContext& txc, const TActorContext& ctx) {
+bool TTxBlobsWritingFailed::DoExecute(TTransactionContext& txc, const TActorContext& /* ctx */) {
     for (auto&& wResult : Pack.GetWriteResults()) {
         const auto& writeMeta = wResult.GetWriteMeta();
         AFL_VERIFY(!writeMeta.HasLongTxId());

--- a/ydb/core/tx/columnshard/columnshard__write.cpp
+++ b/ydb/core/tx/columnshard/columnshard__write.cpp
@@ -64,7 +64,7 @@ TColumnShard::EOverloadStatus TColumnShard::CheckOverloadedWait(const ui64 pathI
     return EOverloadStatus::None;
 }
 
-TColumnShard::EOverloadStatus TColumnShard::CheckOverloadedImmediate(const ui64 pathId) const {
+TColumnShard::EOverloadStatus TColumnShard::CheckOverloadedImmediate(const ui64 /* pathId */) const {
     if (IsAnyChannelYellowStop()) {
         return EOverloadStatus::Disk;
     }

--- a/ydb/core/tx/columnshard/engines/changes/abstract/move_portions.cpp
+++ b/ydb/core/tx/columnshard/engines/changes/abstract/move_portions.cpp
@@ -15,7 +15,7 @@ std::shared_ptr<NDataLocks::ILock> TMovePortionsChange::DoBuildDataLock(const TS
 }
 
 void TMovePortionsChange::DoApplyOnExecute(
-    NColumnShard::TColumnShard* self, TWriteIndexContext& context, const TDataAccessorsResult& fetchedDataAccessor) {
+    NColumnShard::TColumnShard* /* self */, TWriteIndexContext& context, const TDataAccessorsResult& fetchedDataAccessor) {
     auto schemaPtr = context.EngineLogs.GetVersionedIndex().GetLastSchema();
     for (auto&& [_, i] : Portions) {
         const auto pred = [&](TPortionInfo& portionCopy) {
@@ -28,7 +28,7 @@ void TMovePortionsChange::DoApplyOnExecute(
 }
 
 void TMovePortionsChange::DoApplyOnComplete(
-    NColumnShard::TColumnShard* self, TWriteIndexCompleteContext& context, const TDataAccessorsResult& /*fetchedDataAccessor*/) {
+    NColumnShard::TColumnShard* /* self */, TWriteIndexCompleteContext& context, const TDataAccessorsResult& /*fetchedDataAccessor*/) {
     if (!Portions.size()) {
         return;
     }

--- a/ydb/core/tx/columnshard/engines/changes/abstract/remove_portions.cpp
+++ b/ydb/core/tx/columnshard/engines/changes/abstract/remove_portions.cpp
@@ -15,7 +15,7 @@ std::shared_ptr<NDataLocks::ILock> TRemovePortionsChange::DoBuildDataLock(
 }
 
 void TRemovePortionsChange::DoApplyOnExecute(
-    NColumnShard::TColumnShard* self, TWriteIndexContext& context, const TDataAccessorsResult& fetchedDataAccessors) {
+    NColumnShard::TColumnShard* /* self */, TWriteIndexContext& context, const TDataAccessorsResult& fetchedDataAccessors) {
     THashSet<ui64> usedPortionIds;
     auto schemaPtr = context.EngineLogs.GetVersionedIndex().GetLastSchema();
     for (auto&& [_, i] : Portions) {

--- a/ydb/core/tx/columnshard/engines/changes/general_compaction.cpp
+++ b/ydb/core/tx/columnshard/engines/changes/general_compaction.cpp
@@ -12,7 +12,7 @@ namespace NKikimr::NOlap::NCompaction {
 
 std::shared_ptr<NArrow::TColumnFilter> TGeneralCompactColumnEngineChanges::BuildPortionFilter(
     const std::optional<NKikimr::NOlap::TGranuleShardingInfo>& shardingActual, const std::shared_ptr<NArrow::TGeneralContainer>& batch,
-    const TPortionInfo& pInfo, const THashSet<ui64>& portionsInUsage, const ISnapshotSchema::TPtr& resultSchema) const {
+    const TPortionInfo& pInfo, const THashSet<ui64>& portionsInUsage, const ISnapshotSchema::TPtr& /* resultSchema */) const {
     std::shared_ptr<NArrow::TColumnFilter> filter;
     if (shardingActual && pInfo.NeedShardingFilter(*shardingActual)) {
         std::set<std::string> fieldNames;

--- a/ydb/core/tx/columnshard/engines/reader/simple_reader/constructor/read_metadata.cpp
+++ b/ydb/core/tx/columnshard/engines/reader/simple_reader/constructor/read_metadata.cpp
@@ -12,7 +12,7 @@ std::unique_ptr<TScanIteratorBase> TReadMetadata::StartScan(const std::shared_pt
 }
 
 TConclusionStatus TReadMetadata::DoInitCustom(
-    const NColumnShard::TColumnShard* owner, const TReadDescription& readDescription, const TDataStorageAccessor& dataAccessor) {
+    const NColumnShard::TColumnShard* /* owner */, const TReadDescription& /* readDescription */, const TDataStorageAccessor& /* dataAccessor */) {
     return TConclusionStatus::Success();
 }
 

--- a/ydb/core/tx/columnshard/engines/storage/granule/portions_index.h
+++ b/ydb/core/tx/columnshard/engines/storage/granule/portions_index.h
@@ -15,7 +15,7 @@ private:
     const TGranuleMeta& Owner;
 
 public:
-    TPortionsIndex(const TGranuleMeta& owner, const NColumnShard::TPortionsIndexCounters& counters)
+    TPortionsIndex(const TGranuleMeta& owner, const NColumnShard::TPortionsIndexCounters& /* counters */)
         : Owner(owner)
     {
         Y_UNUSED(Owner);

--- a/ydb/core/tx/columnshard/hooks/testing/controller.h
+++ b/ydb/core/tx/columnshard/hooks/testing/controller.h
@@ -26,7 +26,7 @@ private:
     YDB_ACCESSOR(std::optional<ui64>, OverrideMemoryLimitForPortionReading, 100);
     YDB_ACCESSOR(std::optional<ui64>, OverrideLimitForPortionsMetadataAsk, 1);
     YDB_ACCESSOR(std::optional<NOlap::NSplitter::TSplitSettings>, OverrideBlobSplitSettings, NOlap::NSplitter::TSplitSettings::BuildForTests());
-    
+
     YDB_ACCESSOR_DEF(std::optional<NKikimrProto::EReplyStatus>, OverrideBlobPutResultOnWriteValue);
 
     EOptimizerCompactionWeightControl CompactionControl = EOptimizerCompactionWeightControl::Force;
@@ -201,7 +201,7 @@ protected:
     virtual TDuration DoGetMaxReadStaleness(const TDuration def) const override {
         return OverrideMaxReadStaleness.value_or(def);
     }
-    virtual ui64 DoGetMetadataRequestSoftMemoryLimit(const ui64 def) const override {
+    virtual ui64 DoGetMetadataRequestSoftMemoryLimit(const ui64 /* def */) const override {
         return 0;
     }
     virtual EOptimizerCompactionWeightControl GetCompactionControl() const override {

--- a/ydb/core/tx/columnshard/normalizer/portion/leaked_blobs.cpp
+++ b/ydb/core/tx/columnshard/normalizer/portion/leaked_blobs.cpp
@@ -99,7 +99,7 @@ public:
         , DsGroupSelector(dsGroupSelector) {
     }
 
-    void Bootstrap(const TActorContext& ctx) {
+    void Bootstrap(const TActorContext& /* ctx */) {
         WaitingCount = 0;
 
         for (auto it = Channels.begin(); it != Channels.end(); ++it) {

--- a/ydb/core/tx/columnshard/tablet/write_queue.cpp
+++ b/ydb/core/tx/columnshard/tablet/write_queue.cpp
@@ -6,7 +6,7 @@
 
 namespace NKikimr::NColumnShard {
 
-bool TWriteTask::Execute(TColumnShard* owner, const TActorContext& ctx) {
+bool TWriteTask::Execute(TColumnShard* owner, const TActorContext& /* ctx */) {
     auto overloadStatus = owner->CheckOverloadedWait(PathId);
     if (overloadStatus != TColumnShard::EOverloadStatus::None) {
         AFL_DEBUG(NKikimrServices::TX_COLUMNSHARD_WRITE)("event", "wait_overload")("status", overloadStatus);

--- a/ydb/core/tx/columnshard/test_helper/columnshard_ut_common.cpp
+++ b/ydb/core/tx/columnshard/test_helper/columnshard_ut_common.cpp
@@ -207,7 +207,7 @@ void ScanIndexStats(TTestBasicRuntime& runtime, TActorId& sender, const std::vec
     ForwardToTablet(runtime, TTestTxConfig::TxTablet0, sender, scan.release());
 }
 
-void ProposeCommit(TTestBasicRuntime& runtime, TActorId& sender, ui64 shardId, ui64 txId, const std::vector<ui64>& writeIds, const ui64 lockId) {
+void ProposeCommit(TTestBasicRuntime& runtime, TActorId& sender, ui64 shardId, ui64 txId, const std::vector<ui64>& /* writeIds */, const ui64 lockId) {
     auto write = std::make_unique<NEvents::TDataEvents::TEvWrite>(txId, NKikimrDataEvents::TEvWrite::MODE_PREPARE);
     auto* lock = write->Record.MutableLocks()->AddLocks();
     lock->SetLockId(lockId);

--- a/ydb/core/tx/columnshard/transactions/operators/ev_write/secondary.h
+++ b/ydb/core/tx/columnshard/transactions/operators/ev_write/secondary.h
@@ -64,7 +64,7 @@ private:
         const ui64 TxId;
         bool NeedContinueFlag = false;
 
-        virtual bool DoExecute(NTabletFlatExecutor::TTransactionContext& txc, const NActors::TActorContext& ctx) override {
+        virtual bool DoExecute(NTabletFlatExecutor::TTransactionContext& txc, const NActors::TActorContext& /* ctx */) override {
             auto op = Self->GetProgressTxController().GetTxOperatorVerifiedAs<TEvWriteCommitSecondaryTransactionOperator>(TxId, true);
             if (!op) {
                 AFL_WARN(NKikimrServices::TX_COLUMNSHARD_WRITE)("event", "duplication_tablet_ack_flag")("txId", TxId);
@@ -105,7 +105,7 @@ private:
         const ui64 TxId;
         const bool BrokenFlag;
 
-        virtual bool DoExecute(NTabletFlatExecutor::TTransactionContext& txc, const NActors::TActorContext& ctx) override {
+        virtual bool DoExecute(NTabletFlatExecutor::TTransactionContext& txc, const NActors::TActorContext& /* ctx */) override {
             auto op = Self->GetProgressTxController().GetTxOperatorVerifiedAs<TEvWriteCommitSecondaryTransactionOperator>(TxId, true);
             if (!op) {
                 AFL_WARN(NKikimrServices::TX_COLUMNSHARD_WRITE)("event", "duplication_tablet_broken_flag")("txId", TxId);

--- a/ydb/core/tx/datashard/datashard_kqp.cpp
+++ b/ydb/core/tx/datashard/datashard_kqp.cpp
@@ -1003,7 +1003,7 @@ class TKqpTaskRunnerExecutionContext: public NDq::IDqTaskRunnerExecutionContext 
 public:
     NDq::IDqOutputConsumer::TPtr CreateOutputConsumer(const NDqProto::TTaskOutput& outputDesc, const NMiniKQL::TType* type,
         NUdf::IApplyContext* applyCtx, const NMiniKQL::TTypeEnvironment& typeEnv, const NKikimr::NMiniKQL::THolderFactory& holderFactory,
-        TVector<NDq::IDqOutput::TPtr>&& outputs, NUdf::IPgBuilder* pgBuilder) const override
+        TVector<NDq::IDqOutput::TPtr>&& outputs, NUdf::IPgBuilder* /* pgBuilder */) const override
     {
         return NKqp::KqpBuildOutputConsumer(outputDesc, type, applyCtx, typeEnv, holderFactory, std::move(outputs), {});
     }

--- a/ydb/core/tx/schemeshard/schemeshard__login.cpp
+++ b/ydb/core/tx/schemeshard/schemeshard__login.cpp
@@ -118,7 +118,7 @@ private:
         return true;
     }
 
-    bool HandleLoginAuth(const NLogin::TLoginProvider::TLoginUserRequest& loginRequest, NIceDb::TNiceDb& db, const TActorContext& ctx) {
+    bool HandleLoginAuth(const NLogin::TLoginProvider::TLoginUserRequest& loginRequest, NIceDb::TNiceDb& db, const TActorContext& /* ctx */) {
         auto row = db.Table<Schema::LoginSids>().Key(loginRequest.User).Select();
         if (!row.IsReady()) {
             return false;
@@ -186,11 +186,11 @@ private:
         ResetFailedAttemptCount(loginRequest, db);
     }
 
-    void HandleLoginAuthSuccess(const NLogin::TLoginProvider::TLoginUserRequest& loginRequest, const NLogin::TLoginProvider::TLoginUserResponse& loginResponse, NIceDb::TNiceDb& db) {
+    void HandleLoginAuthSuccess(const NLogin::TLoginProvider::TLoginUserRequest& loginRequest, const NLogin::TLoginProvider::TLoginUserResponse& /* loginResponse */, NIceDb::TNiceDb& db) {
         db.Table<Schema::LoginSids>().Key(loginRequest.User).Update<Schema::LoginSids::LastSuccessfulAttempt, Schema::LoginSids::FailedAttemptCount>(TAppData::TimeProvider->Now().MicroSeconds(), Schema::LoginSids::FailedAttemptCount::Default);
     }
 
-    void HandleLoginAuthInvalidPassword(const NLogin::TLoginProvider::TLoginUserRequest& loginRequest, const NLogin::TLoginProvider::TLoginUserResponse& loginResponse, NIceDb::TNiceDb& db) {
+    void HandleLoginAuthInvalidPassword(const NLogin::TLoginProvider::TLoginUserRequest& loginRequest, const NLogin::TLoginProvider::TLoginUserResponse& /* loginResponse */, NIceDb::TNiceDb& db) {
         db.Table<Schema::LoginSids>().Key(loginRequest.User).Update<Schema::LoginSids::LastFailedAttempt, Schema::LoginSids::FailedAttemptCount>(TAppData::TimeProvider->Now().MicroSeconds(), CurrentFailedAttemptCount + 1);
     }
 };

--- a/ydb/core/tx/schemeshard/schemeshard__operation_create_restore_incremental_backup.cpp
+++ b/ydb/core/tx/schemeshard/schemeshard__operation_create_restore_incremental_backup.cpp
@@ -336,7 +336,7 @@ class TNewRestoreFromAtTable : public TSubOperation {
         Y_ABORT("unreachable");
     }
 
-    TSubOperationState::TPtr SelectStateFunc(TTxState::ETxState state) override {
+    TSubOperationState::TPtr SelectStateFunc(TTxState::ETxState /* state */) override {
         Y_ABORT("unreachable");
     }
 

--- a/ydb/core/viewer/json_handlers.h
+++ b/ydb/core/viewer/json_handlers.h
@@ -9,11 +9,11 @@ class TJsonHandlerBase {
 public:
     virtual ~TJsonHandlerBase() = default;
 
-    virtual IActor* CreateRequestActor(IViewer* viewer, NMon::TEvHttpInfo::TPtr& event) {
+    virtual IActor* CreateRequestActor(IViewer* /* viewer */, NMon::TEvHttpInfo::TPtr& /* event */) {
         return nullptr;
     }
 
-    virtual IActor* CreateRequestActor(IViewer* viewer, NHttp::TEvHttpProxy::TEvHttpIncomingRequest::TPtr& event) {
+    virtual IActor* CreateRequestActor(IViewer* /* viewer */, NHttp::TEvHttpProxy::TEvHttpIncomingRequest::TPtr& /* event */) {
         return nullptr;
     }
 

--- a/ydb/library/yql/dq/runtime/dq_tasks_counters.cpp
+++ b/ydb/library/yql/dq/runtime/dq_tasks_counters.cpp
@@ -2,7 +2,7 @@
 
 namespace NYql::NDq {
 
-NYql::NUdf::TCounter TDqTaskCountersProvider::GetCounter(const NUdf::TStringRef& module, const NUdf::TStringRef& name, bool deriv) {
+NYql::NUdf::TCounter TDqTaskCountersProvider::GetCounter(const NUdf::TStringRef& module, const NUdf::TStringRef& name, bool /* deriv */) {
 
     TString op = TString(module);
 
@@ -37,7 +37,7 @@ NYql::NUdf::TCounter TDqTaskCountersProvider::GetCounter(const NUdf::TStringRef&
     return NYql::NUdf::TCounter();
 }
 
-NYql::NUdf::TScopedProbe TDqTaskCountersProvider::GetScopedProbe(const NUdf::TStringRef& module, const NUdf::TStringRef& name) {
+NYql::NUdf::TScopedProbe TDqTaskCountersProvider::GetScopedProbe(const NUdf::TStringRef& /* module */, const NUdf::TStringRef& /* name */) {
     return NYql::NUdf::TScopedProbe();
 }
 

--- a/ydb/services/metadata/secret/snapshot.cpp
+++ b/ydb/services/metadata/secret/snapshot.cpp
@@ -65,7 +65,7 @@ bool TSnapshot::CheckSecretAccess(const TSecretIdOrValue& sIdOrValue, const NACL
             }
             return &*findSecrets->begin();
         },
-        [](const TString& value) -> const TSecretId*{
+        [](const TString& /* value */) -> const TSecretId*{
             Y_ABORT();
         }
     ),


### PR DESCRIPTION
### Changelog category <!-- remove all except one -->

* Not for changelog (changelog entry is not required)

### Additional information

This PR fixes `-Wunused-parameter` warning that is currently [silenced](https://github.com/ydb-platform/ydb/blob/main/build/conf/compilers/gnu_compiler.conf#L78). I'm going to restore this warning in the near future (https://nda.ya.ru/t/ysFv8tqj7Ao7Rm)