### PR TITLE
Forbid to remove user with access

### DIFF
--- a/ydb/core/tablet_flat/util_fmt_basic.h
+++ b/ydb/core/tablet_flat/util_fmt_basic.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "util_fmt_desc.h"
+#include <util/datetime/base.h>
 
 namespace NKikimr {
 namespace NFmt {

--- a/ydb/core/tx/schemeshard/schemeshard__operation_alter_login.cpp
+++ b/ydb/core/tx/schemeshard/schemeshard__operation_alter_login.cpp
@@ -203,6 +203,12 @@ public:
                 return {.Error = TStringBuilder() << 
                     "User " << user << " owns " << pathStr << " and can't be removed"};
             }
+            NACLib::TACL acl(path->ACL);
+            if (acl.HasAccess(user)) {
+                auto pathStr = TPath::Init(pathId, context.SS).PathString();
+                return {.Error = TStringBuilder() << 
+                    "User " << user << " has ACL record on " << pathStr << " and can't be removed"};
+            }
         }
 
         auto removeUserResponse = context.SS->LoginProvider.RemoveUser(user);
@@ -210,31 +216,6 @@ public:
             return removeUserResponse;
         }
 
-        for (auto pathId : subTree) {
-            TPathElement::TPtr path = context.SS->PathsById.at(pathId);
-            NACLib::TACL acl(path->ACL);
-            if (acl.TryRemoveAccess(user)) {
-                ++path->ACLVersion;
-                path->ACL = acl.SerializeAsString();
-                context.SS->PersistACL(db, path);
-                if (!path->IsPQGroup()) {
-                    const auto parent = context.SS->PathsById.at(path->ParentPathId);
-                    ++parent->DirAlterVersion;
-                    context.SS->PersistPathDirAlterVersion(db, parent);
-                    context.SS->ClearDescribePathCaches(parent);
-                    context.OnComplete.PublishToSchemeBoard(OperationId, parent->PathId);
-                }
-            }
-            NACLib::TACL effectiveACL(path->CachedEffectiveACL.GetForSelf());
-            if (effectiveACL.HasAccess(user)) {
-                // publish paths from which the user's access is being removed
-                // user access could have been granted directly (ACL, handled by `acl.TryRemoveAccess(user)` above)
-                // or it might have been inherited from a parent (effective ACL)
-                context.OnComplete.PublishToSchemeBoard(OperationId, pathId);
-            }
-        }
-
-        context.OnComplete.UpdateTenants(std::move(subTree));
         db.Table<Schema::LoginSids>().Key(user).Delete();
         for (const TString& group : removeUserResponse.TouchedGroups) {
             db.Table<Schema::LoginSidMembers>().Key(group, user).Delete();

--- a/ydb/core/tx/schemeshard/schemeshard__operation_alter_login.cpp
+++ b/ydb/core/tx/schemeshard/schemeshard__operation_alter_login.cpp
@@ -207,7 +207,7 @@ public:
             if (acl.HasAccess(user)) {
                 auto pathStr = TPath::Init(pathId, context.SS).PathString();
                 return {.Error = TStringBuilder() << 
-                    "User " << user << " has ACL record on " << pathStr << " and can't be removed"};
+                    "User " << user << " has an ACL record on " << pathStr << " and can't be removed"};
             }
         }
 

--- a/ydb/core/tx/schemeshard/ut_helpers/ls_checks.cpp
+++ b/ydb/core/tx/schemeshard/ut_helpers/ls_checks.cpp
@@ -1280,9 +1280,9 @@ void CheckRight(const NKikimrScheme::TEvDescribeSchemeResult& record, const TStr
             }
         }
 
-        UNIT_ASSERT_C(!(has ^ mustHave), "" << record.GetPath() << " " << (mustHave ? "no " : "") << "ace found"
+        UNIT_ASSERT_C(!(has ^ mustHave), "" << record.GetPath() << "ace check fail"
             << ", got " << src.ShortDebugString()
-            << ", required " << required.ShortDebugString());
+            << ", required " << (mustHave ? "" : "no ") << required.ShortDebugString());
     }
 }
 

--- a/ydb/core/tx/schemeshard/ut_helpers/ls_checks.h
+++ b/ydb/core/tx/schemeshard/ut_helpers/ls_checks.h
@@ -174,6 +174,7 @@ namespace NLs {
     void NoBackupInFly(const NKikimrScheme::TEvDescribeSchemeResult& record);
     TCheckFunc BackupHistoryCount(ui64 count);
 
+    TCheckFunc HasGroup(const TString& group, const TSet<TString> members);
     TCheckFunc HasOwner(const TString& owner);
     TCheckFunc HasRight(const TString& right);
     TCheckFunc HasNoRight(const TString& right);

--- a/ydb/core/tx/schemeshard/ut_login/ut_login.cpp
+++ b/ydb/core/tx/schemeshard/ut_login/ut_login.cpp
@@ -263,7 +263,7 @@ Y_UNIT_TEST_SUITE(TSchemeShardLoginTest) {
         // Cerr << DescribePath(runtime, TTestTxConfig::SchemeShard, "/MyRoot/Dir1").DebugString() << Endl;
 
         CreateAlterLoginRemoveUser(runtime, ++txId, "/MyRoot", "user1",
-            TVector<TExpectedResult>{{NKikimrScheme::StatusPreconditionFailed, "User user1 has ACL record on /MyRoot/Dir1 and can't be removed"}});
+            TVector<TExpectedResult>{{NKikimrScheme::StatusPreconditionFailed, "User user1 has an ACL record on /MyRoot/Dir1 and can't be removed"}});
 
         // check user still exists and has their rights:
         {

--- a/ydb/core/tx/schemeshard/ut_login_large/ut_login_large.cpp
+++ b/ydb/core/tx/schemeshard/ut_login_large/ut_login_large.cpp
@@ -25,7 +25,7 @@ Y_UNIT_TEST_SUITE(TSchemeShardLoginLargeTest) {
     Y_UNIT_TEST(RemoveLogin_Many) {
         const size_t pathsToCreate = 10'000;
         const size_t usersWithAccess = 200; // 2M ACL rules in total
-        const size_t usersTotal = 300; // 2M ACL rules in total
+        const size_t usersTotal = 300;
 
         TTestBasicRuntime runtime;
         TTestEnv env(runtime);
@@ -40,7 +40,7 @@ Y_UNIT_TEST_SUITE(TSchemeShardLoginLargeTest) {
         UNIT_ASSERT_VALUES_EQUAL(resultLogin.error(), "");
         
         {
-            TLogStopwatch stopwatch(TStringBuilder() << "Created " << pathsToCreate << " paths");
+            TLogStopwatch stopwatch(TStringBuilder() << "Created " << pathsToCreate << " paths with " << usersWithAccess * pathsToCreate << " acls");
 
             NACLib::TDiffACL diffACL;
             for (auto userId : xrange(usersWithAccess)) {

--- a/ydb/core/tx/schemeshard/ut_login_large/ut_login_large.cpp
+++ b/ydb/core/tx/schemeshard/ut_login_large/ut_login_large.cpp
@@ -1,4 +1,6 @@
+#include <chrono>
 #include <ydb/core/protos/schemeshard/operations.pb.h>
+#include <ydb/core/tablet_flat/util_fmt_basic.h>
 #include <ydb/core/tx/schemeshard/ut_helpers/helpers.h>
 
 using namespace NKikimr;
@@ -8,16 +10,17 @@ using namespace NSchemeShardUT_Private;
 struct TLogStopwatch {
     TLogStopwatch(TString message)
         : Message(std::move(message))
-        , Started(TAppData::TimeProvider->Now())
+        , Started(std::chrono::steady_clock::now())
     {}
     
     ~TLogStopwatch() {
-        Cerr << "[STOPWATCH] " << Message << " in " << (TAppData::TimeProvider->Now() - Started).MilliSeconds() << "ms" << Endl;
+        std::chrono::steady_clock::time_point ended = std::chrono::steady_clock::now();
+        Cerr << "[STOPWATCH] " << Message << " in " << NFmt::TDelay(TDuration::MicroSeconds(std::chrono::duration_cast<std::chrono::microseconds>(ended - Started).count())) << Endl;
     }
 
 private:
     TString Message;
-    TInstant Started;
+    std::chrono::steady_clock::time_point Started;
 };
 
 Y_UNIT_TEST_SUITE(TSchemeShardLoginLargeTest) {

--- a/ydb/library/aclib/aclib.cpp
+++ b/ydb/library/aclib/aclib.cpp
@@ -379,22 +379,6 @@ std::pair<ui32, ui32> TACL::RemoveAccess(const NACLibProto::TACE& filter) {
     return modified;
 }
 
-bool TACL::TryRemoveAccess(const NACLib::TSID& sid) {
-    auto* ACL = MutableACE();
-    
-    auto newEnd = std::remove_if(ACL->begin(), ACL->end(), [&sid](const NACLibProto::TACE& ace) {
-        return ace.GetSID() == sid;
-    });
-
-    if (newEnd == ACL->end()) {
-        return false;
-    }
-    
-    ACL->erase(newEnd, ACL->end());
-    
-    return true;
-}
-
 bool TACL::HasAccess(const NACLib::TSID& sid) {
     for (const auto& ace : GetACE()) {
         if (ace.GetSID() == sid) {

--- a/ydb/library/aclib/aclib.h
+++ b/ydb/library/aclib/aclib.h
@@ -117,7 +117,6 @@ public:
     std::pair<ui32, ui32> AddAccess(EAccessType type, ui32 access, const TSID& sid, ui32 inheritance = InheritObject | InheritContainer);
     std::pair<ui32, ui32> RemoveAccess(NACLib::EAccessType type, ui32 access, const NACLib::TSID& sid, ui32 inheritance = InheritObject | InheritContainer);
     std::pair<ui32, ui32> RemoveAccess(const NACLibProto::TACE& filter);
-    bool TryRemoveAccess(const NACLib::TSID& sid);
     bool HasAccess(const NACLib::TSID& sid);
     std::pair<ui32, ui32> ClearAccess();
     std::pair<ui32, ui32> ApplyDiff(const NACLibProto::TDiffACL& diffACL);

--- a/ydb/library/aclib/benchmark/b_aclib.cpp
+++ b/ydb/library/aclib/benchmark/b_aclib.cpp
@@ -1,0 +1,47 @@
+#include <benchmark/benchmark.h>
+#include <util/generic/xrange.h>
+#include <ydb/library/aclib/aclib.h>
+
+namespace NACLib {
+
+namespace {
+    struct TFixture : public benchmark::Fixture {
+        void SetUp(::benchmark::State& state) 
+        {
+            const size_t count = state.range(0);
+            
+            for (auto userId : xrange(count)) {
+                Obj.AddAccess(EAccessType::Allow, EAccessRights::SelectRow, "user" + std::to_string(userId), EInheritanceType::InheritContainer);
+            }
+
+            Serialized = Obj.SerializeAsString();
+        }
+
+        TString Serialized;
+        TACL Obj;
+    };
+}
+
+BENCHMARK_DEFINE_F(TFixture, Deserialize)(benchmark::State& state) {
+    for (auto _ : state) {
+        benchmark::DoNotOptimize( NACLib::TACL(Serialized));
+    }
+}
+
+BENCHMARK_DEFINE_F(TFixture, HasAccess)(benchmark::State& state) {
+    for (auto _ : state) {
+        benchmark::DoNotOptimize(Obj.HasAccess("userxxx"));
+    }
+}
+
+BENCHMARK_REGISTER_F(TFixture, Deserialize)
+    ->ArgsProduct({
+        {20, 200, 2000}})
+    ->Unit(benchmark::kMicrosecond);
+
+BENCHMARK_REGISTER_F(TFixture, HasAccess)
+    ->ArgsProduct({
+        {20, 200, 2000}})
+    ->Unit(benchmark::kMicrosecond);
+
+}

--- a/ydb/library/aclib/benchmark/ya.make
+++ b/ydb/library/aclib/benchmark/ya.make
@@ -1,0 +1,14 @@
+G_BENCHMARK()
+
+TAG(ya:fat)
+SIZE(LARGE)
+
+SRCS(
+    b_aclib.cpp
+)
+
+PEERDIR(
+    ydb/library/aclib
+)
+
+END()

--- a/ydb/library/aclib/ya.make
+++ b/ydb/library/aclib/ya.make
@@ -15,4 +15,5 @@ END()
 
 RECURSE_FOR_TESTS(
     ut
+    benchmark
 )


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of changes introduced in this PR -->

...

### Changelog category <!-- remove all except one -->

* Not for changelog (changelog entry is not required)

### Additional information

Reverts some changes from #12334

```
[STOPWATCH] Created 10000 paths with 2000000 acls in 4.717m
[STOPWATCH] Created single user userx in 0.032s
[STOPWATCH] Added single root acl userx in 1.783m
[STOPWATCH] Removed single root acl userx in 1.783m
[STOPWATCH] Removed single user userx in 2.804s
[STOPWATCH] Removed user200 in 2.822s
[STOPWATCH] Removed user201 in 2.812s
[STOPWATCH] Removed user202 in 2.831s
[STOPWATCH] Don't removed user0 in 0.016s
[STOPWATCH] Don't removed user1 in 0.014s
[STOPWATCH] Don't removed user2 in 0.014s
```

```
--------------------------------------------------------------------
Benchmark                          Time             CPU   Iterations
--------------------------------------------------------------------
TFixture/Deserialize/20         1.28 us         1.28 us       547689
TFixture/Deserialize/200        10.7 us         10.7 us        65695
TFixture/Deserialize/2000        105 us          105 us         6725
TFixture/HasAccess/20          0.026 us        0.026 us     26650258
TFixture/HasAccess/200         0.392 us        0.392 us      1634520
TFixture/HasAccess/2000         3.95 us         3.95 us       180391
```