### PR TITLE
stream-nb-24-3. Merge multiple completion threads

### DIFF
--- a/ydb/core/blobstorage/pdisk/blobstorage_pdisk_blockdevice.h
+++ b/ydb/core/blobstorage/pdisk/blobstorage_pdisk_blockdevice.h
@@ -66,7 +66,7 @@ class TPDisk;
 
 IBlockDevice* CreateRealBlockDevice(const TString &path, ui32 pDiskId, TPDiskMon &mon,
         ui64 reorderingCycles, ui64 seekCostNs, ui64 deviceInFlight, TDeviceMode::TFlags flags,
-        ui32 maxQueuedCompletionActions, TIntrusivePtr<TSectorMap> sectorMap, TPDisk * const pdisk = nullptr, bool readOnly = false);
+        ui32 maxQueuedCompletionActions, ui32 completionThreadsCount, TIntrusivePtr<TSectorMap> sectorMap, TPDisk * const pdisk = nullptr, bool readOnly = false);
 IBlockDevice* CreateRealBlockDeviceWithDefaults(const TString &path, TPDiskMon &mon, TDeviceMode::TFlags flags,
         TIntrusivePtr<TSectorMap> sectorMap, TActorSystem *actorSystem, TPDisk * const pdisk = nullptr, bool readOnly = false);
 

--- a/ydb/core/blobstorage/pdisk/blobstorage_pdisk_blockdevice_async.cpp
+++ b/ydb/core/blobstorage/pdisk/blobstorage_pdisk_blockdevice_async.cpp
@@ -111,14 +111,14 @@ class TRealBlockDevice : public IBlockDevice {
         // Schedule action execution
         // pass action = nullptr to quit
         void Schedule(TCompletionAction *action) noexcept {
-            TAtomicBase queueActions = AtomicIncrement(QueuedActions);
-            if (queueActions >= MaxQueuedActions) {
+            if (AtomicGet(QueuedActions) >= MaxQueuedActions) {
                 Device.Mon.L7.Set(true, AtomicGetAndIncrement(SeqnoL7));
                 while (AtomicGet(QueuedActions) >= MaxQueuedActions) {
                     SpinLockPause();
                 }
                 Device.Mon.L7.Set(false, AtomicGetAndIncrement(SeqnoL7));
             }
+            AtomicIncrement(QueuedActions);
             CompletionActions.Push(action);
             return;
         }

--- a/ydb/core/blobstorage/pdisk/blobstorage_pdisk_blockdevice_async.cpp
+++ b/ydb/core/blobstorage/pdisk/blobstorage_pdisk_blockdevice_async.cpp
@@ -44,41 +44,29 @@ class TRealBlockDevice : public IBlockDevice {
     ////////////////////////////////////////////////////////
     // TCompletionThread
     ////////////////////////////////////////////////////////
-    class TCompletionThread : public TThread {
-        static constexpr ui32 NumOfWriters = 2;
+    class TCompletionThread : public ISimpleThread {
     public:
-        TCompletionThread(TRealBlockDevice &device, ui32 maxQueuedActions)
-            : TThread(&ThreadProc, this)
-            , Device(device)
-            , QueuedActions(0)
-            , MaxQueuedActions(maxQueuedActions)
+        TCompletionThread(TRealBlockDevice &device, TString name)
+            : Device(device)
+            , Name(name)
         {}
 
-        static void* ThreadProc(void* _this) {
-            SetCurrentThreadName("PdCmpl");
-            static_cast<TCompletionThread*>(_this)->Exec();
-            return nullptr;
-        }
-
-        void Exec() {
-            ui32 exitSignalsReceived = 0;
-            Device.Mon.L7.Set(false, AtomicGetAndIncrement(SeqnoL7));
+        void *ThreadProc() override {
+            SetCurrentThreadName(Name.data());
             auto prevCycleEnd = HPNow();
             bool isWorking = true;
             bool stateError = false;
 
+            auto cpuCounter = Device.Mon.PDiskGroup->GetCounter(Name + "CPU", true);
+
             while(isWorking) {
-                TAtomicBase actionCount = CompletionActions.GetWaitingSize();
+                TAtomicBase actionCount = Queue.GetWaitingSize();
 
                 if (actionCount > 0) {
                     for (TAtomicBase idx = 0; idx < actionCount; ++idx) {
-                        TCompletionAction *action = CompletionActions.Pop();
-                        AtomicDecrement(QueuedActions);
+                        TCompletionAction *action = Queue.Pop();
                         if (action == nullptr) {
-                            ++exitSignalsReceived;
-                            if (exitSignalsReceived == NumOfWriters) {
-                                isWorking = false;
-                            }
+                            isWorking = false;
                         } else {
                             if (!stateError && action->CanHandleResult()) {
                                 action->Exec(Device.ActorSystem);
@@ -96,8 +84,8 @@ class TRealBlockDevice : public IBlockDevice {
                         }
                     }
                 } else {
-                    *Device.Mon.CompletionThreadCPU = ThreadCPUTime();
-                    CompletionActions.ProducedWaitI();
+                    *cpuCounter = ThreadCPUTime();
+                    Queue.ProducedWaitI();
                 }
 
                 const auto cycleEnd = HPNow();
@@ -106,37 +94,127 @@ class TRealBlockDevice : public IBlockDevice {
                 }
                 prevCycleEnd = cycleEnd;
             }
+            return nullptr;
+        }
+
+        void Schedule(TCompletionAction *action) {
+            Queue.Push(action);
+        }
+
+        size_t GetQueuedActions() {
+            return Queue.GetWaitingSize();
+        }
+
+    private:
+        TCountedQueueManyOne<TCompletionAction, 4 << 10> Queue;
+        TRealBlockDevice& Device;
+        TString Name;
+    };
+
+    class TCompletionThreads {
+
+    public:
+        std::vector<std::unique_ptr<TCompletionThread>> Threads;
+
+        TCompletionThreads(TRealBlockDevice &device, size_t threadsCount, ui32 maxQueuedActions)
+            : Device(device)
+            , MaxQueuedActions(maxQueuedActions)
+        {
+            for (size_t i = 0; i < threadsCount; ++i) {
+                Threads.push_back(std::make_unique<TCompletionThread>(device, TStringBuilder() << "PdCmpl_" << i));
+                Threads.back()->Start();
+            }
         }
 
         // Schedule action execution
         // pass action = nullptr to quit
         void Schedule(TCompletionAction *action) noexcept {
-            if (AtomicGet(QueuedActions) >= MaxQueuedActions) {
-                Device.Mon.L7.Set(true, AtomicGetAndIncrement(SeqnoL7));
-                while (AtomicGet(QueuedActions) >= MaxQueuedActions) {
-                    SpinLockPause();
-                }
-                Device.Mon.L7.Set(false, AtomicGetAndIncrement(SeqnoL7));
+            if (!action) {
+                StopWork();
+                return;
             }
-            AtomicIncrement(QueuedActions);
-            CompletionActions.Push(action);
+
+            if (!action->ShouldBeExecutedInCompletionThread || Threads.empty()) {
+                ExecuteActionInPlace(action);
+                return;
+            }
+
+            while (true) {
+                auto min_it = Threads.begin();
+                auto minQueueSize = (*min_it)->GetQueuedActions();
+                auto totalSize = minQueueSize;
+                for (auto it = Threads.begin() + 1; it != Threads.end(); ++it) {
+                    auto queueSize = (*it)->GetQueuedActions();
+                    totalSize += queueSize;
+                    if (queueSize < minQueueSize) {
+                        minQueueSize = queueSize;
+                        min_it = it;
+                    }
+                }
+                if (totalSize >= MaxQueuedActions) {
+                    // We have a risk to run out of buffers from BufferPool, so MaxQueuedActions is expected
+                    // to counter that
+                    Device.Mon.L7.Set(true, AtomicGetAndIncrement(SeqnoL7));
+                    Sleep(TDuration::MilliSeconds(1));
+                    Device.Mon.L7.Set(false, AtomicGetAndIncrement(SeqnoL7));
+                    continue;
+                }
+
+                Y_ABORT_UNLESS(min_it != Threads.end());
+                if (action->CanBeExecutedInAdditionalCompletionThread) {
+                    (*min_it)->Schedule(action);
+                } else {
+                    // actions which are supposed to be executed from single thread always will be executer in 0 thread
+                    // scheduled here to pass MaxQueuedActions check above
+                    Threads[0]->Schedule(action);
+                }
+
+                return;
+            }
+        }
+
+        void ExecuteActionInPlace(TCompletionAction *action) {
+            if (action->CanHandleResult()) {
+                action->Exec(Device.PCtx->ActorSystem);
+            } else {
+                TString errorReason = action->ErrorReason;
+
+                action->Release(Device.PCtx->ActorSystem);
+
+                if (!Device.QuitCounter.IsBlocked()) {
+                    Device.BecomeErrorState(TStringBuilder()
+                            << " CompletionAction error, operation info# " << errorReason);
+                }
+            }
+        }
+
+        // This hack make it possible to execute some completion action beside of device but in ComplitionThread
+        void ScheduleHackForLogReader(TCompletionAction *action) noexcept {
+            action->Result = EIoResult::Ok;
+            if (Threads.empty()) {
+                action->Exec(Device.PCtx->ActorSystem);
+            } else {
+                Threads[0]->Schedule(action);
+            }
             return;
         }
 
-        // Schedule action execution
-        // pass action = nullptr to quit
-        void ScheduleHackForLogReader(TCompletionAction *action) noexcept {
-            AtomicIncrement(QueuedActions);
-            action->Result = EIoResult::Ok;
-            CompletionActions.Push(action);
-            return;
+        void StopWork() {
+            for (auto& thread : Threads) {
+                thread->Schedule(nullptr);
+            }
+        }
+
+        void Join() {
+            for (auto& thread : Threads) {
+                thread->Join();
+            }
+            Threads.clear();
         }
 
     private:
-        TCountedQueueManyOne<TCompletionAction, 4 << 10> CompletionActions;
         TRealBlockDevice &Device;
-        TAtomic QueuedActions;
-        const TAtomicBase MaxQueuedActions;
+        const size_t MaxQueuedActions;
         TAtomic SeqnoL7 = 0;
     };
 
@@ -366,25 +444,6 @@ class TRealBlockDevice : public IBlockDevice {
             }
         }
 
-        void ExecuteOrScheduleCompletion(TCompletionAction *action) {
-            if (action->ShouldBeExecutedInCompletionThread) {
-                Device.CompletionThread->Schedule(action);
-            } else {
-                if (action->CanHandleResult()) {
-                    action->Exec(Device.ActorSystem);
-                } else {
-                    TString errorReason = action->ErrorReason;
-
-                    action->Release(Device.ActorSystem);
-
-                    if (!Device.QuitCounter.IsBlocked()) {
-                        Device.BecomeErrorState(TStringBuilder()
-                                << " CompletionAction error, operation info# " << errorReason);
-                    }
-                }
-            }
-        }
-
         void Exec(TAsyncIoOperationResult *event) {
             IAsyncIoOperation *op = event->Operation;
             // Add up the execution time of all the events
@@ -442,7 +501,7 @@ class TRealBlockDevice : public IBlockDevice {
                     WaitingNoops[idx % MaxWaitingNoops] = completionAction->FlushAction;
                     completionAction->FlushAction = nullptr;
                 }
-                ExecuteOrScheduleCompletion(completionAction);
+                Device.CompletionThreads->Schedule(completionAction);
                 auto seqnoL6 = AtomicGetAndIncrement(Device.Mon.SeqnoL6);
                 Device.Mon.L6.Set(duration > Device.Reordering, seqnoL6);
             }
@@ -460,7 +519,7 @@ class TRealBlockDevice : public IBlockDevice {
                     LWTRACK(PDiskDeviceGetFromWaiting, WaitingNoops[i]->Orbit);
                     double durationMs = HPMilliSecondsFloat(HPNow() - WaitingNoops[i]->GetTime);
                     Device.Mon.DeviceFlushDuration.Increment(durationMs);
-                    ExecuteOrScheduleCompletion(WaitingNoops[i]);
+                    Device.CompletionThreads->Schedule(WaitingNoops[i]);
                     WaitingNoops[i] = nullptr;
                 }
                 ++NextPossibleNoop;
@@ -507,7 +566,7 @@ class TRealBlockDevice : public IBlockDevice {
                 }
             }
             // Stop the completion thread
-            Device.CompletionThread->Schedule(nullptr);
+            Device.CompletionThreads->Schedule(nullptr);
         }
     };
 
@@ -687,7 +746,6 @@ class TRealBlockDevice : public IBlockDevice {
                     for (TAtomicBase idx = 0; idx < actionCount; ++idx) {
                         IAsyncIoOperation *op = TrimOperations.Pop();
                         if (op == nullptr) {
-                            Device.CompletionThread->Schedule(nullptr);
                             return;
                         }
                         Y_ABORT_UNLESS(op->GetType() == IAsyncIoOperation::EType::PTrim);
@@ -714,7 +772,7 @@ class TRealBlockDevice : public IBlockDevice {
                             }
                         }
                         completion->SetResult(EIoResult::Ok);
-                        Device.CompletionThread->Schedule(completion);
+                        completion->Exec(Device.PCtx->ActorSystem);
                         Device.IoContext->DestroyAsyncIoOperation(op);
                     }
                 } else {
@@ -743,8 +801,10 @@ protected:
     ui32 PDiskId;
     TActorId PDiskActor;
 
+    TPDiskConfig cfg{0, 0, 0};
+
 private:
-    THolder<TCompletionThread> CompletionThread;
+    THolder<TCompletionThreads> CompletionThreads;
     THolder<TTrimThread> TrimThread;
     THolder<TGetThread> GetEventsThread;
     THolder<TSubmitGetThread> SpdkSubmitGetThread;
@@ -757,7 +817,8 @@ private:
     ui64 Reordering;
     ui64 SeekCostNs;
     bool IsTrimEnabled;
-    ui32 MaxQueuedCompletionActions;
+    const ui32 MaxQueuedCompletionActions; // for all threads
+    const ui32 CompletionThreadsCount;
 
     TIdleCounter IdleCounter; // Includes reads, writes and trims
 
@@ -782,7 +843,7 @@ private:
 public:
     TRealBlockDevice(const TString &path, ui32 pDiskId, TPDiskMon &mon, ui64 reorderingCycles,
             ui64 seekCostNs, ui64 deviceInFlight, TDeviceMode::TFlags flags, ui32 maxQueuedCompletionActions,
-            TIntrusivePtr<TSectorMap> sectorMap, bool readOnly)
+            ui32 completionThreadsCount, TIntrusivePtr<TSectorMap> sectorMap, bool readOnly)
         : Mon(mon)
         , ActorSystem(nullptr)
         , Path(path)
@@ -798,6 +859,7 @@ public:
         , SeekCostNs(seekCostNs)
         , IsTrimEnabled(true)
         , MaxQueuedCompletionActions(maxQueuedCompletionActions)
+        , CompletionThreadsCount(completionThreadsCount)
         , IdleCounter(Mon.IdleLight)
         , Flags(flags)
         , SectorMap(sectorMap)
@@ -862,7 +924,7 @@ protected:
         }
         if (IsFileOpened) {
             IoContext->SetActorSystem(ActorSystem);
-            CompletionThread = MakeHolder<TCompletionThread>(*this, MaxQueuedCompletionActions);
+            CompletionThreads = MakeHolder<TCompletionThreads>(*this, CompletionThreadsCount, MaxQueuedCompletionActions);
             TrimThread = MakeHolder<TTrimThread>(*this);
             SharedCallback = MakeHolder<TSharedCallback>(*this);
             if (Flags & TDeviceMode::UseSpdk) {
@@ -879,7 +941,6 @@ protected:
                     GetEventsThread->Start();
                 }
             }
-            CompletionThread->Start();
             TrimThread->Start();
             IsInitialized = true;
         }
@@ -1049,7 +1110,7 @@ protected:
         }
 
         completionAction->SetResult(EIoResult::Ok);
-        CompletionThread->Schedule(completionAction);
+        CompletionThreads->Schedule(completionAction);
     }
 
     void NoopAsyncHackForLogReader(TCompletionAction *completionAction, TReqId /*reqId*/) override {
@@ -1064,7 +1125,7 @@ protected:
         }
 
         completionAction->SetResult(EIoResult::Ok);
-        CompletionThread->ScheduleHackForLogReader(completionAction);
+        CompletionThreads->ScheduleHackForLogReader(completionAction);
     }
 
     void TrimAsync(ui32 size, ui64 offset, TCompletionAction *completionAction, TReqId reqId) override {
@@ -1142,7 +1203,7 @@ protected:
         if (res.PrevA ^ res.A) { // res.ToggledA()
             if (IsInitialized) {
                 Y_ABORT_UNLESS(TrimThread);
-                Y_ABORT_UNLESS(CompletionThread);
+                Y_ABORT_UNLESS(CompletionThreads);
                 TrimThread->Schedule(nullptr); // Stop the Trim thread
                 if (Flags & TDeviceMode::UseSpdk) {
                     Y_ABORT_UNLESS(SpdkSubmitGetThread);
@@ -1160,13 +1221,13 @@ protected:
                 }
                 SharedCallback->Destroy();
                 TrimThread->Join();
-                CompletionThread->Join();
+                CompletionThreads->Join();
                 IsInitialized = false;
             } else {
                 Y_ABORT_UNLESS(SubmitThread.Get() == nullptr);
                 Y_ABORT_UNLESS(GetEventsThread.Get() == nullptr);
                 Y_ABORT_UNLESS(TrimThread.Get() == nullptr);
-                Y_ABORT_UNLESS(CompletionThread.Get() == nullptr);
+                Y_ABORT_UNLESS(CompletionThreads.Get() == nullptr);
             }
             if (IsFileOpened) {
                 EIoResult ret = IoContext->Destroy();
@@ -1306,9 +1367,15 @@ class TCachedBlockDevice : public TRealBlockDevice {
 public:
     TCachedBlockDevice(const TString &path, ui32 pDiskId, TPDiskMon &mon, ui64 reorderingCycles,
             ui64 seekCostNs, ui64 deviceInFlight, TDeviceMode::TFlags flags, ui32 maxQueuedCompletionActions,
+<<<<<<< HEAD
             TIntrusivePtr<TSectorMap> sectorMap, TPDisk * const pdisk, bool readOnly)
         : TRealBlockDevice(path, pDiskId, mon, reorderingCycles, seekCostNs, deviceInFlight, flags,
                 maxQueuedCompletionActions, sectorMap, readOnly)
+=======
+            ui32 completionThreadsCount, TIntrusivePtr<TSectorMap> sectorMap, TPDisk * const pdisk)
+        : TRealBlockDevice(path, pDiskId, mon, reorderingCycles, seekCostNs, deviceInFlight, flags,
+                maxQueuedCompletionActions, completionThreadsCount, sectorMap)
+>>>>>>> b68baacc399 (Implement configurable number of completion threads (#9715))
         , ReadsInFly(0), PDisk(pdisk)
     {}
 
@@ -1446,6 +1513,7 @@ public:
 
 IBlockDevice* CreateRealBlockDevice(const TString &path, ui32 pDiskId, TPDiskMon &mon, ui64 reorderingCycles,
         ui64 seekCostNs, ui64 deviceInFlight, TDeviceMode::TFlags flags, ui32 maxQueuedCompletionActions,
+<<<<<<< HEAD
         TIntrusivePtr<TSectorMap> sectorMap, TPDisk * const pdisk, bool readOnly) {
     return new TCachedBlockDevice(path, pDiskId, mon, reorderingCycles, seekCostNs, deviceInFlight, flags,
             maxQueuedCompletionActions, sectorMap, pdisk, readOnly);
@@ -1454,6 +1522,16 @@ IBlockDevice* CreateRealBlockDevice(const TString &path, ui32 pDiskId, TPDiskMon
 IBlockDevice* CreateRealBlockDeviceWithDefaults(const TString &path, TPDiskMon &mon, TDeviceMode::TFlags flags,
         TIntrusivePtr<TSectorMap> sectorMap, TActorSystem *actorSystem, TPDisk * const pdisk, bool readOnly) {
     IBlockDevice *device = CreateRealBlockDevice(path, 0, mon, 0, 0, 4, flags, 8, sectorMap, pdisk, readOnly);
+=======
+        ui32 completionThreadsCount, TIntrusivePtr<TSectorMap> sectorMap, TPDisk * const pdisk) {
+    return new TCachedBlockDevice(path, pDiskId, mon, reorderingCycles, seekCostNs, deviceInFlight, flags,
+            maxQueuedCompletionActions, completionThreadsCount, sectorMap, pdisk);
+}
+
+IBlockDevice* CreateRealBlockDeviceWithDefaults(const TString &path, TPDiskMon &mon, TDeviceMode::TFlags flags,
+        TIntrusivePtr<TSectorMap> sectorMap, TActorSystem *actorSystem, TPDisk * const pdisk) {
+    IBlockDevice *device = CreateRealBlockDevice(path, 0, mon, 0, 0, 4, flags, 8, 1, sectorMap, pdisk);
+>>>>>>> b68baacc399 (Implement configurable number of completion threads (#9715))
     device->Initialize(actorSystem, {});
     return device;
 }

--- a/ydb/core/blobstorage/pdisk/blobstorage_pdisk_blockdevice_ut.cpp
+++ b/ydb/core/blobstorage/pdisk/blobstorage_pdisk_blockdevice_ut.cpp
@@ -358,11 +358,12 @@ Y_UNIT_TEST_SUITE(TBlockDeviceTest) {
             THolder<NPDisk::TBufferPool> bufferPool(NPDisk::CreateBufferPool(buffSize, bufferPoolSize, false, {}));
             ui64 inFlight = 128;
             ui32 maxQueuedCompletionActions = bufferPoolSize / 2;
+            ui32 completionThreadsCount = 1;
             ui64 diskSize = 32_GB;
 
             TIntrusivePtr<NPDisk::TSectorMap> sectorMap = new NPDisk::TSectorMap(diskSize, NSectorMap::DM_NONE);
             THolder<NPDisk::IBlockDevice> device(CreateRealBlockDevice("", *mon, 0, 0, inFlight, TDeviceMode::None,
-                    maxQueuedCompletionActions, sectorMap));
+                    maxQueuedCompletionActions, completionThreadsCount, sectorMap));
             device->Initialize(std::make_shared<TPDiskCtx>(creator.GetActorSystem()));
 
             TAtomic counter = 0;

--- a/ydb/core/blobstorage/pdisk/blobstorage_pdisk_blockdevice_ut.cpp
+++ b/ydb/core/blobstorage/pdisk/blobstorage_pdisk_blockdevice_ut.cpp
@@ -172,44 +172,6 @@ void WaitForValue(TAtomic *counter, TDuration maxDuration, TAtomicBase expectedV
     }
 }
 
-void RunTestMultipleRequestsFromCompletionAction() {
-    const TIntrusivePtr<::NMonitoring::TDynamicCounters> counters = new ::NMonitoring::TDynamicCounters;
-    THolder<TPDiskMon> mon(new TPDiskMon(counters, 0, nullptr));
-    const ui32 dataSize = 4 << 10;
-    const ui64 generations = 8;
-    TAtomic counter = 0;
-
-
-    TTempDir tempDir;
-    TString path = CreateFile(tempDir().c_str(), dataSize);
-
-    {
-        TActorSystemCreator creator;
-        THolder<NPDisk::TBufferPool> bufferPool(NPDisk::CreateBufferPool(dataSize, 1, false, {}));
-        NPDisk::TBuffer::TPtr alignedBuffer(bufferPool->Pop());
-        memset(alignedBuffer->Data(), 0, dataSize);
-        THolder<NPDisk::IBlockDevice> device(NPDisk::CreateRealBlockDevice(path, 0, *mon, 0, 0, 4,
-                NPDisk::TDeviceMode::LockFile, 2 << generations, nullptr));
-        device->Initialize(creator.GetActorSystem(), {});
-
-        (new TWriter(*device, alignedBuffer.Get(), (i32)generations, &counter))->Exec(nullptr);
-
-        TAtomicBase expectedCounter = 0;
-        for (ui64 i = 0; i <= generations; ++i) {
-            expectedCounter += 1ull << i;
-        }
-        WaitForValue(&counter, TIMEOUT, expectedCounter);
-
-        TAtomicBase resultingCounter = AtomicGet(counter);
-
-        UNIT_ASSERT_VALUES_EQUAL(
-            resultingCounter,
-            expectedCounter
-        );
-    }
-    Ctest << "Done" << Endl;
-}
-
 void RunTestDestructionWithMultipleFlushesFromCompletionAction() {
     const TIntrusivePtr<::NMonitoring::TDynamicCounters> counters = new ::NMonitoring::TDynamicCounters;
     THolder<TPDiskMon> mon(new TPDiskMon(counters, 0, nullptr));
@@ -222,7 +184,7 @@ void RunTestDestructionWithMultipleFlushesFromCompletionAction() {
 
     TActorSystemCreator creator;
     THolder<NPDisk::IBlockDevice> device(NPDisk::CreateRealBlockDevice(path, 0, *mon, 0, 0, 4,
-                NPDisk::TDeviceMode::LockFile, 2 << generations, nullptr));
+                NPDisk::TDeviceMode::LockFile, 1, 2 << generations, nullptr));
     device->Initialize(creator.GetActorSystem(), {});
 
     (new TFlusher(*device, generations, &counter))->Exec(nullptr);
@@ -262,10 +224,6 @@ void RunWriteTestWithSectorMap(NPDisk::NSectorMap::EDiskMode diskMode, ui32 disk
 }
 
 Y_UNIT_TEST_SUITE(TBlockDeviceTest) {
-
-    Y_UNIT_TEST(TestMultipleRequestsFromCompletionAction) {
-        RunTestMultipleRequestsFromCompletionAction();
-    }
 
     Y_UNIT_TEST(TestDestructionWithMultipleFlushesFromCompletionAction) {
         RunTestDestructionWithMultipleFlushesFromCompletionAction();
@@ -363,9 +321,9 @@ Y_UNIT_TEST_SUITE(TBlockDeviceTest) {
                 ui64 diskSize = 32_GB;
 
                 TIntrusivePtr<NPDisk::TSectorMap> sectorMap = new NPDisk::TSectorMap(diskSize, NSectorMap::DM_NONE);
-                THolder<NPDisk::IBlockDevice> device(CreateRealBlockDevice("", *mon, 0, 0, inFlight, TDeviceMode::None,
+                THolder<NPDisk::IBlockDevice> device(CreateRealBlockDevice("", 0, *mon, 0, 0, inFlight, TDeviceMode::None,
                         maxQueuedCompletionActions, completionThreadsCount, sectorMap));
-                device->Initialize(std::make_shared<TPDiskCtx>(creator.GetActorSystem()));
+                device->Initialize(creator.GetActorSystem(), {});
 
                 TAtomic counter = 0;
                 const i64 totalRequests = 500;

--- a/ydb/core/blobstorage/pdisk/blobstorage_pdisk_blockdevice_ut.cpp
+++ b/ydb/core/blobstorage/pdisk/blobstorage_pdisk_blockdevice_ut.cpp
@@ -5,6 +5,7 @@
 #include "blobstorage_pdisk_actorsystem_creator.h"
 #include "blobstorage_pdisk_mon.h"
 #include "blobstorage_pdisk_ut_defs.h"
+#include "blobstorage_pdisk_ut_helpers.h"
 
 #include <ydb/core/control/immediate_control_board_wrapper.h>
 
@@ -133,16 +134,6 @@ private:
     TAtomic& Counter;
     TDuration WorkTime;
 };
-
-static TString MakeDatabasePath(const char *dir) {
-    TString databaseDirectory = Sprintf("%s/yard", dir);
-    return databaseDirectory;
-}
-
-static TString MakePDiskPath(const char *dir) {
-    TString databaseDirectory = MakeDatabasePath(dir);
-    return databaseDirectory + "/pdisk.dat";
-}
 
 TString CreateFile(const char *baseDir, ui32 dataSize) {
     TString databaseDirectory = MakeDatabasePath(baseDir);

--- a/ydb/core/blobstorage/pdisk/blobstorage_pdisk_completion.h
+++ b/ydb/core/blobstorage/pdisk/blobstorage_pdisk_completion.h
@@ -23,6 +23,7 @@ struct TCompletionAction {
     // to BlockDevice from Exec() and it's more safe to use WhiteList to allow only
     // LogWrite and ChunkWrite to be executed from GetThread
     bool ShouldBeExecutedInCompletionThread = true;
+    bool CanBeExecutedInAdditionalCompletionThread = false;
 
     mutable NLWTrace::TOrbit Orbit;
 protected:

--- a/ydb/core/blobstorage/pdisk/blobstorage_pdisk_completion_impl.cpp
+++ b/ydb/core/blobstorage/pdisk/blobstorage_pdisk_completion_impl.cpp
@@ -128,11 +128,17 @@ TCompletionChunkReadPart::TCompletionChunkReadPart(TPDisk *pDisk, TIntrusivePtr<
     , PayloadReadSize(payloadReadSize)
     , CommonBufferOffset(commonBufferOffset)
     , CumulativeCompletion(cumulativeCompletion)
+    , ChunkNonce(CumulativeCompletion->GetChunkNonce())
     , Buffer(PDisk->BufferPool->Pop())
     , IsTheLastPart(isTheLastPart)
     , UseT1ha0Hasher(useT1ha0Hasher)
     , Span(std::move(span))
 {
+    TCompletionAction::CanBeExecutedInAdditionalCompletionThread = true;
+
+    TBufferWithGaps *commonBuffer = CumulativeCompletion->GetCommonBuffer();
+    Destination = commonBuffer->RawDataPtr(CommonBufferOffset, PayloadReadSize);
+
     if (!IsTheLastPart) {
         CumulativeCompletion->AddPart();
     }
@@ -167,8 +173,6 @@ void TCompletionChunkReadPart::Exec(TActorSystem *actorSystem) {
             Read->Offset + CommonBufferOffset, PayloadReadSize, firstSector, lastSector, sectorOffset);
     Y_ABORT_UNLESS(isOk);
 
-    TBufferWithGaps *commonBuffer = CumulativeCompletion->GetCommonBuffer();
-    ui8 *destination = commonBuffer->RawDataPtr(CommonBufferOffset, PayloadReadSize);
 
     ui8* source = Buffer->Data();
 
@@ -184,8 +188,6 @@ void TCompletionChunkReadPart::Exec(TActorSystem *actorSystem) {
         sectorOffset = 0;
     }
 
-    ui64 chunkNonce = CumulativeCompletion->GetChunkNonce();
-
     ui32 beginBadUserOffset = 0xffffffff;
     ui32 endBadUserOffset = 0xffffffff;
     ui32 userSectorSize = format.SectorPayloadSize();
@@ -194,7 +196,7 @@ void TCompletionChunkReadPart::Exec(TActorSystem *actorSystem) {
 
         TSectorRestorator restorator(false, 1, false,
             format, actorSystem, PDisk->PDiskActor, PDisk->PDiskId, &PDisk->Mon, PDisk->BufferPool.Get());
-        ui64 lastNonce = Min((ui64)0, chunkNonce - 1);
+        ui64 lastNonce = Min((ui64)0, ChunkNonce - 1);
         restorator.Restore(source, format.Offset(Read->ChunkIdx, sectorIdx), format.MagicDataChunk, lastNonce,
                 UseT1ha0Hasher, Read->Owner);
 
@@ -212,7 +214,7 @@ void TCompletionChunkReadPart::Exec(TActorSystem *actorSystem) {
                         << " for owner# " << Read->Owner
                         << " beginBadUserOffet# " << beginBadUserOffset << " endBadUserOffset# " << endBadUserOffset
                         << " due to multiple sectors with incorrect hashes. Marker# BPC001");
-                commonBuffer->AddGap(beginBadUserOffset, endBadUserOffset);
+                CumulativeCompletion->AddGap(beginBadUserOffset, endBadUserOffset);
                 beginBadUserOffset = 0xffffffff;
                 endBadUserOffset = 0xffffffff;
             }
@@ -222,16 +224,16 @@ void TCompletionChunkReadPart::Exec(TActorSystem *actorSystem) {
 
         // Decrypt data
         if (beginBadUserOffset != 0xffffffff) {
-            memset(destination, 0, sectorPayloadSize);
+            memset(Destination, 0, sectorPayloadSize);
         } else {
             TDataSectorFooter *footer = (TDataSectorFooter*) (source + format.SectorSize - sizeof(TDataSectorFooter));
-            if (footer->Nonce != chunkNonce + sectorIdx) {
+            if (footer->Nonce != ChunkNonce + sectorIdx) {
                 ui32 userOffset = sectorIdx * userSectorSize;
                 LOG_INFO_S(*actorSystem, NKikimrServices::BS_PDISK, "PDiskId# " << (ui32)PDisk->PDiskId
                         << " ReqId# " << Read->ReqId
                         << " Can't read chunk chunkIdx# " << Read->ChunkIdx
                         << " for owner# " << Read->Owner
-                        << " nonce mismatch: expected# " << (ui64)(chunkNonce + sectorIdx)
+                        << " nonce mismatch: expected# " << (ui64)(ChunkNonce + sectorIdx)
                         << ", on-disk# " << (ui64)footer->Nonce
                         << " for userOffset# " << userOffset
                         << " ! Marker# BPC002");
@@ -239,18 +241,18 @@ void TCompletionChunkReadPart::Exec(TActorSystem *actorSystem) {
                     beginBadUserOffset = userOffset;
                 }
                 endBadUserOffset = beginUserOffset + userSectorSize;
-                memset(destination, 0, sectorPayloadSize);
+                memset(Destination, 0, sectorPayloadSize);
             } else {
                 cypher.StartMessage(footer->Nonce);
-                if (sectorOffset > 0 || intptr_t(destination) % 32) {
+                if (sectorOffset > 0 || intptr_t(Destination) % 32) {
                     cypher.InplaceEncrypt(source, sectorOffset + sectorPayloadSize);
                     if (CommonBufferOffset == 0 || !IsTheLastPart) {
-                        memcpy(destination, source + sectorOffset, sectorPayloadSize);
+                        memcpy(Destination, source + sectorOffset, sectorPayloadSize);
                     } else {
-                        memcpy(destination, source, sectorPayloadSize);
+                        memcpy(Destination, source, sectorPayloadSize);
                     }
                 } else {
-                    cypher.Encrypt(destination, source, sectorPayloadSize);
+                    cypher.Encrypt(Destination, source, sectorPayloadSize);
                 }
                 if (CanarySize > 0) {
                     ui32 canaryPosition = sectorOffset + sectorPayloadSize;
@@ -260,7 +262,7 @@ void TCompletionChunkReadPart::Exec(TActorSystem *actorSystem) {
                 }
             }
         }
-        destination += sectorPayloadSize;
+        Destination += sectorPayloadSize;
         source += format.SectorSize;
         PayloadReadSize -= sectorPayloadSize;
         sectorPayloadSize = Min(format.SectorPayloadSize(), PayloadReadSize);
@@ -274,7 +276,7 @@ void TCompletionChunkReadPart::Exec(TActorSystem *actorSystem) {
             << " for owner# " << Read->Owner
             << " beginBadUserOffet# " << beginBadUserOffset << " endBadUserOffset# " << endBadUserOffset
             << " due to multiple sectors with incorrect hashes/nonces. Marker# BPC003");
-        commonBuffer->AddGap(beginBadUserOffset, endBadUserOffset);
+        CumulativeCompletion->AddGap(beginBadUserOffset, endBadUserOffset);
         beginBadUserOffset = 0xffffffff;
         endBadUserOffset = 0xffffffff;
     }
@@ -408,4 +410,3 @@ void TChunkTrimCompletion::Exec(TActorSystem *actorSystem) {
 
 } // NPDisk
 } // NKikimr
-

--- a/ydb/core/blobstorage/pdisk/blobstorage_pdisk_config.h
+++ b/ydb/core/blobstorage/pdisk/blobstorage_pdisk_config.h
@@ -157,6 +157,8 @@ struct TPDiskConfig : public TThrRefBase {
 
     bool ReadOnly = false;
 
+    ui32 CompletionThreadsCount = 1;
+
     TPDiskConfig(ui64 pDiskGuid, ui32 pdiskId, ui64 pDiskCategory)
         : TPDiskConfig({}, pDiskGuid, pdiskId, pDiskCategory)
     {}
@@ -304,6 +306,7 @@ struct TPDiskConfig : public TThrRefBase {
         str << " WarningLogChunksMultiplier# " << WarningLogChunksMultiplier << x;
         str << " YellowLogChunksMultiplier# " << YellowLogChunksMultiplier << x;
         str << " SpaceColorBorder# " << SpaceColorBorder << x;
+        str << " CompletionThreadsCount# " << CompletionThreadsCount << x;
         str << "}";
         return str.Str();
     }
@@ -385,8 +388,11 @@ struct TPDiskConfig : public TThrRefBase {
         if (cfg->HasChunkBaseLimit()) {
             ChunkBaseLimit = cfg->GetChunkBaseLimit();
         }
+
+        if (cfg->HasCompletionThreadsCount()) {
+            CompletionThreadsCount = cfg->GetCompletionThreadsCount();
+        }
     }
 };
 
 } // NKikimr
-

--- a/ydb/core/blobstorage/pdisk/blobstorage_pdisk_driveestimator.cpp
+++ b/ydb/core/blobstorage/pdisk/blobstorage_pdisk_driveestimator.cpp
@@ -236,7 +236,7 @@ TDriveEstimator::TDriveEstimator(const TString filename)
     , ActorSystemCreator(new TActorSystemCreator)
     , ActorSystem(ActorSystemCreator->GetActorSystem())
     , QueueDepth(4)
-    , Device(CreateRealBlockDevice(filename, 0, PDiskMon, 50, 0, QueueDepth, TDeviceMode::LockFile, 128, nullptr, nullptr))
+    , Device(CreateRealBlockDevice(filename, 0, PDiskMon, 50, 0, QueueDepth, TDeviceMode::LockFile, 128, 1, nullptr, nullptr))
     , BufferPool(CreateBufferPool(BufferSize, 1, false, {}))
     , Buffer(BufferPool->Pop())
 {

--- a/ydb/core/blobstorage/pdisk/blobstorage_pdisk_impl.cpp
+++ b/ydb/core/blobstorage/pdisk/blobstorage_pdisk_impl.cpp
@@ -48,7 +48,7 @@ TPDisk::TPDisk(const TIntrusivePtr<TPDiskConfig> cfg, const TIntrusivePtr<::NMon
     , BlockDevice(CreateRealBlockDevice(cfg->GetDevicePath(), cfg->PDiskId, Mon,
                     HPCyclesMs(ReorderingMs), DriveModel.SeekTimeNs(), cfg->DeviceInFlight,
                     TDeviceMode::LockFile | (cfg->UseSpdkNvmeDriver ? TDeviceMode::UseSpdk : 0),
-                    cfg->MaxQueuedCompletionActions, cfg->SectorMap, this, cfg->ReadOnly))
+                    cfg->MaxQueuedCompletionActions, cfg->CompletionThreadsCount, cfg->SectorMap, this, cfg->ReadOnly))
     , Cfg(cfg)
     , CreationTime(TInstant::Now())
     , ExpectedSlotCount(cfg->ExpectedSlotCount)

--- a/ydb/core/blobstorage/pdisk/blobstorage_pdisk_ut.cpp
+++ b/ydb/core/blobstorage/pdisk/blobstorage_pdisk_ut.cpp
@@ -918,7 +918,7 @@ Y_UNIT_TEST_SUITE(TPDiskTest) {
                 .DiskSize = 16_MB,
                 .SmallDisk = true,
             });
-            
+
             UNIT_ASSERT(false);
         } catch (const yexception &e) {
             UNIT_ASSERT_STRING_CONTAINS(e.what(), "Total chunks# 0, System chunks needed# 1, cant run with < 3 free chunks!");
@@ -1005,7 +1005,7 @@ Y_UNIT_TEST_SUITE(PDiskCompatibilityInfo) {
 
     void TestMajorVerionMigration(TCurrent oldInfo, TCurrent intermediateInfo, TCurrent newInfo) {
         TCompatibilityInfoTest::Reset(&oldInfo);
-    
+
         TActorTestContext testCtx({
             .IsBad = false,
             .SuppressCompatibilityCheck = false,

--- a/ydb/core/protos/blobstorage_pdisk_config.proto
+++ b/ydb/core/protos/blobstorage_pdisk_config.proto
@@ -91,4 +91,6 @@ message TPDiskConfig {
     optional uint64 ExpectedSlotCount = 2001; // Number of slots to calculate per-vdisk disk space limit.
 
     optional uint32 ChunkBaseLimit = 2002; // Free chunk permille that triggers Cyan color (e.g. 100 is 10%). Between 130 (default) and 13.
+
+    optional uint32 CompletionThreadsCount = 2003;
 };


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of changes introduced in this PR -->

b944f4df1b5cfb71883198d368dd80dad805054a
1120c1a9ca535b79199374672e2d64a242a9487a
e55564f7a0a0ff7b638ce199c1b5005b696d349d
9b97c8ff2469b21f21163c4ee70118b3152a15c0 


- Fix uninitialized value in PDisk UT
- Test a few small completion threads count (#10253)
- Implement configurable number of completion threads (#9715)
- Fix unimportant deadlock in TBlockDevice and add new UT (#9991)

### Changelog category <!-- remove all except one -->

* Performance improvement

### Additional information

...
