### PR TITLE
24-3: KIKIMR-22120: Take partitioning description of copied table in s3 export (#13067)

### DIFF
--- a/ydb/core/tx/schemeshard/ut_restore/ut_restore.cpp
+++ b/ydb/core/tx/schemeshard/ut_restore/ut_restore.cpp
@@ -1140,6 +1140,340 @@ value {
         UNIT_ASSERT_C(CheckDefaultFromSequence(table), "Invalid default value");
     }
 
+    Y_UNIT_TEST(ShouldRestoreTableWithVolatilePartitioningMerge) {
+        TPortManager portManager;
+        const ui16 port = portManager.GetPort();
+
+        TS3Mock s3Mock({}, TS3Mock::TSettings(port));
+        UNIT_ASSERT(s3Mock.Start());
+
+        TTestBasicRuntime runtime;
+        TTestEnv env(runtime);
+
+        ui64 txId = 100;
+
+        runtime.SetLogPriority(NKikimrServices::DATASHARD_BACKUP, NActors::NLog::PRI_TRACE);
+        runtime.SetLogPriority(NKikimrServices::DATASHARD_RESTORE, NActors::NLog::PRI_TRACE);
+        runtime.SetLogPriority(NKikimrServices::EXPORT, NActors::NLog::PRI_TRACE);
+        runtime.SetLogPriority(NKikimrServices::IMPORT, NActors::NLog::PRI_TRACE);
+        runtime.SetLogPriority(NKikimrServices::SEQUENCEPROXY, NActors::NLog::PRI_TRACE);
+
+        // Create table with 2 tablets
+        TestCreateTable(runtime, ++txId, "/MyRoot", R"(
+            Name: "Original"
+            Columns { Name: "key" Type: "Uint32" }
+            Columns { Name: "value" Type: "Utf8" }
+            KeyColumnNames: ["key"]
+            PartitionConfig {
+                PartitioningPolicy {
+                    MinPartitionsCount: 2
+                    MaxPartitionsCount: 2
+                }
+            }
+            SplitBoundary {
+              KeyPrefix {
+                Tuple { Optional { Uint32: 2 } }
+              }
+            }
+        )");
+        env.TestWaitNotification(runtime, txId);
+
+        // Upload data
+        const auto firstTablet = TTestTxConfig::FakeHiveTablets;
+        const auto secondTablet = TTestTxConfig::FakeHiveTablets + 1;
+        UpdateRow(runtime, "Original", 1, "valueA", firstTablet);
+        UpdateRow(runtime, "Original", 2, "valueB", secondTablet);
+        
+        // Add delay after copying tables
+        bool dropNotification = false;
+        THolder<IEventHandle> delayed;
+        auto prevObserver = runtime.SetObserverFunc([&](TAutoPtr<IEventHandle>& ev) {
+            switch (ev->GetTypeRewrite()) {
+            case TEvSchemeShard::EvModifySchemeTransaction:
+                break;
+            case TEvSchemeShard::EvNotifyTxCompletionResult:
+                if (dropNotification) {
+                    delayed.Reset(ev.Release());
+                    return TTestActorRuntime::EEventAction::DROP;
+                }
+                return TTestActorRuntime::EEventAction::PROCESS;
+            default:
+                return TTestActorRuntime::EEventAction::PROCESS;
+            }
+
+            const auto* msg = ev->Get<TEvSchemeShard::TEvModifySchemeTransaction>();
+            if (msg->Record.GetTransaction(0).GetOperationType() == NKikimrSchemeOp::ESchemeOpCreateConsistentCopyTables) {
+                dropNotification = true;
+            }
+
+            return TTestActorRuntime::EEventAction::PROCESS;
+        });
+
+        // Start exporting table
+        TestExport(runtime, ++txId, "/MyRoot", Sprintf(R"(
+            ExportToS3Settings {
+              endpoint: "localhost:%d"
+              scheme: HTTP
+              items {
+                source_path: "/MyRoot/Original"
+                destination_prefix: ""
+              }
+            }
+        )", port));
+        const ui64 exportId = txId;
+
+        // Wait for delay after copying tables
+        if (!delayed) {
+            TDispatchOptions opts;
+            opts.FinalEvents.emplace_back([&delayed](IEventHandle&) -> bool {
+                return bool(delayed);
+            });
+            runtime.DispatchEvents(opts);
+        }
+        runtime.SetObserverFunc(prevObserver);
+
+        // Merge 2 tablets in 1 during the delay
+        TestAlterTable(runtime, ++txId, "/MyRoot", R"(
+            Name: "Original"
+            PartitionConfig {
+                PartitioningPolicy {
+                    MinPartitionsCount: 1
+                    MaxPartitionsCount: 1
+                }
+            }
+        )");
+        env.TestWaitNotification(runtime, txId);
+
+        TestSplitTable(runtime, ++txId, "/MyRoot/Original", Sprintf(R"(
+            SourceTabletId: %lu
+            SourceTabletId: %lu
+        )", firstTablet, secondTablet));
+        env.TestWaitNotification(runtime, txId);
+
+        // Finish the delay and continue exporting
+        runtime.Send(delayed.Release(), 0, true);
+        env.TestWaitNotification(runtime, exportId);
+
+        // Check export
+        TestGetExport(runtime, exportId, "/MyRoot");
+
+        // Restore table
+        TestImport(runtime, ++txId, "/MyRoot", Sprintf(R"(
+            ImportFromS3Settings {
+              endpoint: "localhost:%d"
+              scheme: HTTP
+              items {
+                source_prefix: ""
+                destination_path: "/MyRoot/Restored"
+              }
+            }
+        )", port));
+        const ui64 importId = txId;
+        env.TestWaitNotification(runtime, importId);
+
+        // Check import
+        TestGetImport(runtime, importId, "/MyRoot");
+
+        // Check partitioning in restored table
+        TestDescribeResult(DescribePath(runtime, "/MyRoot/Restored", true, true), {
+            NLs::MinPartitionsCountEqual(2),
+            NLs::MaxPartitionsCountEqual(2),
+            NLs::CheckBoundaries
+        });
+
+        // Check data in restored table
+        const auto restoredFirstTablet = TTestTxConfig::FakeHiveTablets + 5;
+        const auto restoredSecondTablet = TTestTxConfig::FakeHiveTablets + 6;
+        {
+            auto expectedJson = TStringBuilder() << "[[[["
+                << "["
+                    << R"(["1"];)" // key
+                    << R"(["valueA"])" // value
+                << "];"
+            << "];\%false]]]";
+            auto content = ReadTable(runtime, restoredFirstTablet, "Restored", {"key", "Uint32", "0"});
+            NKqp::CompareYson(expectedJson, content);
+        }
+        {
+            auto expectedJson = TStringBuilder() << "[[[["
+                << "["
+                    << R"(["2"];)" // key
+                    << R"(["valueB"])" // value
+                << "];"
+            << "];\%false]]]";
+            auto content = ReadTable(runtime, restoredSecondTablet, "Restored", {"key", "Uint32", "0"});
+            NKqp::CompareYson(expectedJson, content);
+        }
+    }
+
+    Y_UNIT_TEST(ShouldRestoreTableWithVolatilePartitioningSplit) {
+        TPortManager portManager;
+        const ui16 port = portManager.GetPort();
+
+        TS3Mock s3Mock({}, TS3Mock::TSettings(port));
+        UNIT_ASSERT(s3Mock.Start());
+
+        TTestBasicRuntime runtime;
+        TTestEnv env(runtime);
+
+        ui64 txId = 100;
+
+        runtime.SetLogPriority(NKikimrServices::DATASHARD_BACKUP, NActors::NLog::PRI_TRACE);
+        runtime.SetLogPriority(NKikimrServices::DATASHARD_RESTORE, NActors::NLog::PRI_TRACE);
+        runtime.SetLogPriority(NKikimrServices::EXPORT, NActors::NLog::PRI_TRACE);
+        runtime.SetLogPriority(NKikimrServices::IMPORT, NActors::NLog::PRI_TRACE);
+        runtime.SetLogPriority(NKikimrServices::SEQUENCEPROXY, NActors::NLog::PRI_TRACE);
+
+        // Create table with 2 tablets
+        TestCreateTable(runtime, ++txId, "/MyRoot", R"(
+            Name: "Original"
+            Columns { Name: "key" Type: "Uint32" }
+            Columns { Name: "value" Type: "Utf8" }
+            KeyColumnNames: ["key"]
+            PartitionConfig {
+                PartitioningPolicy {
+                    MinPartitionsCount: 2
+                    MaxPartitionsCount: 2
+                }
+            }
+            SplitBoundary {
+              KeyPrefix {
+                Tuple { Optional { Uint32: 3 } }
+              }
+            }
+        )");
+        env.TestWaitNotification(runtime, txId);
+
+        // Upload data
+        const auto firstTablet = TTestTxConfig::FakeHiveTablets;
+        UpdateRow(runtime, "Original", 1, "valueA", firstTablet);
+        UpdateRow(runtime, "Original", 2, "valueB", firstTablet);
+
+        // Add delay after copying tables
+        bool dropNotification = false;
+        THolder<IEventHandle> delayed;
+        auto prevObserver = runtime.SetObserverFunc([&](TAutoPtr<IEventHandle>& ev) {
+            switch (ev->GetTypeRewrite()) {
+            case TEvSchemeShard::EvModifySchemeTransaction:
+                break;
+            case TEvSchemeShard::EvNotifyTxCompletionResult:
+                if (dropNotification) {
+                    delayed.Reset(ev.Release());
+                    return TTestActorRuntime::EEventAction::DROP;
+                }
+                return TTestActorRuntime::EEventAction::PROCESS;
+            default:
+                return TTestActorRuntime::EEventAction::PROCESS;
+            }
+
+            const auto* msg = ev->Get<TEvSchemeShard::TEvModifySchemeTransaction>();
+            if (msg->Record.GetTransaction(0).GetOperationType() == NKikimrSchemeOp::ESchemeOpCreateConsistentCopyTables) {
+                dropNotification = true;
+            }
+
+            return TTestActorRuntime::EEventAction::PROCESS;
+        });
+
+        // Start exporting table
+        TestExport(runtime, ++txId, "/MyRoot", Sprintf(R"(
+            ExportToS3Settings {
+              endpoint: "localhost:%d"
+              scheme: HTTP
+              items {
+                source_path: "/MyRoot/Original"
+                destination_prefix: ""
+              }
+            }
+        )", port));
+        const ui64 exportId = txId;
+
+         // Wait for delay after copying tables
+        if (!delayed) {
+            TDispatchOptions opts;
+            opts.FinalEvents.emplace_back([&delayed](IEventHandle&) -> bool {
+                return bool(delayed);
+            });
+            runtime.DispatchEvents(opts);
+        }
+        runtime.SetObserverFunc(prevObserver);
+
+        // Split 2 tablets in 3 during the delay
+        TestAlterTable(runtime, ++txId, "/MyRoot", R"(
+            Name: "Original"
+            PartitionConfig {
+                PartitioningPolicy {
+                    MinPartitionsCount: 3
+                    MaxPartitionsCount: 3
+                }
+            }
+        )");
+        env.TestWaitNotification(runtime, txId);
+
+        TestSplitTable(runtime, ++txId, "/MyRoot/Original", Sprintf(R"(
+            SourceTabletId: %lu
+            SplitBoundary {
+                KeyPrefix {
+                    Tuple { Optional { Uint32: 2 } }
+                }
+            }
+        )", firstTablet));
+        env.TestWaitNotification(runtime, txId);
+
+        // Finish the delay and continue exporting
+        runtime.Send(delayed.Release(), 0, true);
+        env.TestWaitNotification(runtime, exportId);
+
+        // Check export
+        TestGetExport(runtime, exportId, "/MyRoot");
+
+        // Restore table
+        TestImport(runtime, ++txId, "/MyRoot", Sprintf(R"(
+            ImportFromS3Settings {
+              endpoint: "localhost:%d"
+              scheme: HTTP
+              items {
+                source_prefix: ""
+                destination_path: "/MyRoot/Restored"
+              }
+            }
+        )", port));
+        const ui64 importId = txId;
+        env.TestWaitNotification(runtime, importId);
+
+        // Check import
+        TestGetImport(runtime, importId, "/MyRoot");
+
+        // Check partitioning in restored table
+        TestDescribeResult(DescribePath(runtime, "/MyRoot/Restored", true, true), {
+            NLs::MinPartitionsCountEqual(2),
+            NLs::MaxPartitionsCountEqual(2),
+            NLs::CheckBoundaries
+        });
+
+        // Check data in restored table
+        const auto restoredFirstTablet = TTestTxConfig::FakeHiveTablets + 6;
+        const auto restoredSecondTablet = TTestTxConfig::FakeHiveTablets + 7;
+        {
+            auto expectedJson = TStringBuilder() << "[[[["
+                << "["
+                    << R"(["1"];)" // key
+                    << R"(["valueA"])" // value
+                << "];"
+                << "["
+                    << R"(["2"];)" // key
+                    << R"(["valueB"])" // value
+                << "];"
+            << "];\%false]]]";
+            auto content = ReadTable(runtime, restoredFirstTablet, "Restored", {"key", "Uint32", "0"});
+            NKqp::CompareYson(expectedJson, content);
+        }
+        {
+            auto expectedJson = "[[[[];\%false]]]";
+            auto content = ReadTable(runtime, restoredSecondTablet, "Restored", {"key", "Uint32", "0"});
+            NKqp::CompareYson(expectedJson, content);
+        }
+    }
+
     Y_UNIT_TEST(ExportImportOnSupportedDatatypes) {
         TTestBasicRuntime runtime;
         TTestEnv env(runtime, TTestEnvOptions());


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of changes introduced in this PR -->

Fixes creating unrestorable S3 backups when splitting and merging the table

### Changelog category <!-- remove all except one -->

* Bugfix 