### PR TITLE
Fix ForceBlockTabletData behaviour in BlobDepot and DS proxy mock

### DIFF
--- a/ydb/core/base/blobstorage.h
+++ b/ydb/core/base/blobstorage.h
@@ -1138,8 +1138,8 @@ struct TEvBlobStorage {
             ui32 Generation = 0;    // tablet generation
         };
 
-        using TForceBlockTabletData = TTabletData;
-        using TReaderTabletData = TTabletData;
+        struct TForceBlockTabletData : TTabletData { using TTabletData::TTabletData; };
+        struct TReaderTabletData : TTabletData { using TTabletData::TTabletData; };
 
         std::optional<TReaderTabletData> ReaderTabletData;
         std::optional<TForceBlockTabletData> ForceBlockTabletData;

--- a/ydb/core/blob_depot/agent/agent_impl.h
+++ b/ydb/core/blob_depot/agent/agent_impl.h
@@ -356,6 +356,7 @@ namespace NKikimr::NBlobDepot {
             NLog::EPriority WatchdogPriority = NLog::PRI_WARN;
             bool Destroyed = false;
             std::shared_ptr<TEvBlobStorage::TExecutionRelay> ExecutionRelay;
+            ui32 BlockChecksRemain = 3;
 
             static constexpr TDuration WatchdogDuration = TDuration::Seconds(10);
 
@@ -376,6 +377,9 @@ namespace NKikimr::NBlobDepot {
             virtual void OnRead(ui64 /*tag*/, TReadOutcome&& /*outcome*/) {}
             virtual void OnIdAllocated(bool /*success*/) {}
             virtual void OnDestroy(bool /*success*/) {}
+
+            NKikimrProto::EReplyStatus CheckBlockForTablet(ui64 tabletId, std::optional<ui32> generation,
+                ui32 *blockedGeneration = nullptr);
 
         protected: // reading logic
             struct TReadContext;

--- a/ydb/core/blob_depot/agent/storage_discover.cpp
+++ b/ydb/core/blob_depot/agent/storage_discover.cpp
@@ -1,5 +1,4 @@
 #include "agent_impl.h"
-#include "blocks.h"
 #include "blob_mapping_cache.h"
 
 namespace NKikimr::NBlobDepot {
@@ -7,8 +6,6 @@ namespace NKikimr::NBlobDepot {
     template<>
     TBlobDepotAgent::TQuery *TBlobDepotAgent::CreateQuery<TEvBlobStorage::EvDiscover>(std::unique_ptr<IEventHandle> ev) {
         class TDiscoverQuery : public TBlobStorageQuery<TEvBlobStorage::TEvDiscover> {
-            ui32 GetBlockedGenerationRetriesRemain = 10;
-
             bool DoneWithBlockedGeneration = false;
             bool DoneWithData = false;
 
@@ -27,17 +24,15 @@ namespace NKikimr::NBlobDepot {
 
                 GenerateInitialResolve();
                 IssueResolve();
+                CheckBlockedGeneration();
+            }
 
-                if (Request.DiscoverBlockedGeneration) {
-                    const auto status = Agent.BlocksManager.CheckBlockForTablet(Request.TabletId, std::nullopt, this, &BlockedGeneration);
-                    if (status == NKikimrProto::OK) {
-                        DoneWithBlockedGeneration = true;
-                    } else if (status != NKikimrProto::UNKNOWN) {
-                        EndWithError(status, "tablet was deleted");
-                    }
-                } else {
-                    DoneWithBlockedGeneration = true;
+            void CheckBlockedGeneration() {
+                if (!DoneWithBlockedGeneration) {
+                    DoneWithBlockedGeneration = !Request.DiscoverBlockedGeneration || 
+                        CheckBlockForTablet(Request.TabletId, std::nullopt, &BlockedGeneration) == NKikimrProto::OK;
                 }
+                CheckIfDone();
             }
 
             void GenerateInitialResolve() {
@@ -85,16 +80,7 @@ namespace NKikimr::NBlobDepot {
             void OnUpdateBlock() override {
                 STLOG(PRI_DEBUG, BLOB_DEPOT_AGENT, BDA18, "OnUpdateBlock", (AgentId, Agent.LogId),
                     (QueryId, GetQueryId()));
-
-                const auto status = Agent.BlocksManager.CheckBlockForTablet(Request.TabletId, std::nullopt, this, &BlockedGeneration);
-                if (status == NKikimrProto::OK) {
-                    DoneWithBlockedGeneration = true;
-                    CheckIfDone();
-                } else if (status != NKikimrProto::UNKNOWN) {
-                    EndWithError(status, "tablet was deleted");
-                } else if (!--GetBlockedGenerationRetriesRemain) {
-                    EndWithError(NKikimrProto::ERROR, "too many retries to obtain blocked generation");
-                }
+                CheckBlockedGeneration();
             }
 
             void HandleResolveResult(ui64 id, TRequestContext::TPtr context, TEvBlobDepot::TEvResolveResult& msg) {

--- a/ydb/core/blob_depot/agent/storage_get.cpp
+++ b/ydb/core/blob_depot/agent/storage_get.cpp
@@ -1,6 +1,5 @@
 #include "agent_impl.h"
 #include "blob_mapping_cache.h"
-#include "blocks.h"
 
 namespace NKikimr::NBlobDepot {
 
@@ -22,6 +21,24 @@ namespace NKikimr::NBlobDepot {
             using TBlobStorageQuery::TBlobStorageQuery;
 
             void Initiate() override {
+                if (const auto& blk = Request.ReaderTabletData) {
+                    if (CheckBlockForTablet(blk->Id, blk->Generation) != NKikimrProto::OK) {
+                        return;
+                    }
+                }
+
+                if (const auto& blk = Request.ForceBlockTabletData; blk && blk->Generation) {
+                    ui32 blockedGeneration;
+                    if (CheckBlockForTablet(blk->Id, std::nullopt, &blockedGeneration) != NKikimrProto::OK) {
+                        return;
+                    }
+                    if (blockedGeneration != blk->Generation) {
+                        // this can happen only in distributed storage, but not possible in BlobDepot
+                        return EndWithError(NKikimrProto::ERROR, "incorrect blocked generation provided for"
+                            " ForceBlockTabletData in TEvGet query to BlobDepot");
+                    }
+                }
+
                 if (IS_LOG_PRIORITY_ENABLED(NLog::PRI_TRACE, NKikimrServices::BLOB_DEPOT_EVENTS)) {
                     for (ui32 i = 0; i < Request.QuerySize; ++i) {
                         const auto& q = Request.Queries[i];
@@ -33,14 +50,6 @@ namespace NKikimr::NBlobDepot {
                 Response = std::make_unique<TEvBlobStorage::TEvGetResult>(NKikimrProto::OK, Request.QuerySize,
                     TGroupId::FromValue(Agent.VirtualGroupId));
                 AnswersRemain = Request.QuerySize;
-
-                if (Request.ReaderTabletData) {
-                    auto status = Agent.BlocksManager.CheckBlockForTablet(Request.ReaderTabletData->Id, Request.ReaderTabletData->Generation, this, nullptr);
-                    if (status == NKikimrProto::BLOCKED) {
-                        EndWithError(status, "Fail TEvGet due to BLOCKED tablet generation");
-                        return;
-                    }
-                }
 
                 for (ui32 i = 0; i < Request.QuerySize; ++i) {
                     auto& query = Request.Queries[i];
@@ -63,6 +72,10 @@ namespace NKikimr::NBlobDepot {
                 }
 
                 CheckAndFinish();
+            }
+
+            void OnUpdateBlock() override {
+                Initiate();
             }
 
             bool ProcessSingleResult(ui32 queryIdx, const TKeyResolved& result) {

--- a/ydb/core/blobstorage/vdisk/common/vdisk_events.h
+++ b/ydb/core/blobstorage/vdisk/common/vdisk_events.h
@@ -1109,7 +1109,7 @@ namespace NKikimr {
             ShowInternals = 2,
         };
 
-        using TForceBlockTabletData = TEvBlobStorage::TEvGet::TTabletData;
+        using TForceBlockTabletData = TEvBlobStorage::TEvGet::TForceBlockTabletData;
 
         struct TExtremeQuery : std::tuple<TLogoBlobID, ui32, ui32, const ui64*> {
             TExtremeQuery(const TLogoBlobID &logoBlobId, ui32 sh, ui32 sz, const ui64 *cookie = nullptr)

--- a/ydb/core/blobstorage/vdisk/skeleton/skeleton_block_and_get.cpp
+++ b/ydb/core/blobstorage/vdisk/skeleton/skeleton_block_and_get.cpp
@@ -12,8 +12,6 @@
 namespace NKikimr {
 
 class TBlockAndGetActor : public TActorBootstrapped<TBlockAndGetActor> {
-private:
-    static constexpr auto VBLOCK_DEFAULT_DEADLINE_SECONDS = 50;
 public:
     TBlockAndGetActor() = delete;
     explicit TBlockAndGetActor(
@@ -40,13 +38,15 @@ public:
 
     void Bootstrap() {
         // create TEvVBlock request
+        const TInstant deadline = Request->Get()->Record.GetMsgQoS().HasDeadlineSeconds()
+            ? TInstant::Seconds(Request->Get()->Record.GetMsgQoS().GetDeadlineSeconds())
+            : TInstant::Max();
+
         auto request = std::make_unique<TEvBlobStorage::TEvVBlock>(
             Request->Get()->Record.GetForceBlockTabletData().GetId(),
             Request->Get()->Record.GetForceBlockTabletData().GetGeneration(),
             VDiskIDFromVDiskID(Request->Get()->Record.GetVDiskID()),
-            Request->Get()->Record.GetMsgQoS().HasDeadlineSeconds() ?
-                TInstant::Seconds(Request->Get()->Record.GetMsgQoS().GetDeadlineSeconds()) :
-                TInstant::Seconds(VBLOCK_DEFAULT_DEADLINE_SECONDS)
+            deadline
         );
 
         // send TEvVBlock request
@@ -62,11 +62,10 @@ public:
 
     void Handle(TEvBlobStorage::TEvVBlockResult::TPtr &ev) {
         switch (ev->Get()->Record.GetStatus()) {
-        case NKikimrProto::OK:
-            break;
-        case NKikimrProto::ALREADY:
-            break;
-        default: {
+            case NKikimrProto::OK:
+            case NKikimrProto::ALREADY:
+                break;
+            default: {
                 // we failed to block required generation, so return failure
                 auto response = NErrBuilder::ErroneousResult(
                     VCtx,


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of changes introduced in this PR -->

Fix ForceBlockTabletData behaviour in BlobDepot and DS proxy mock

### Changelog category <!-- remove all except one -->

* Not for changelog (changelog entry is not required)

### Additional information

BlobDepot agent and DS proxy mock now handle correctly explicit block checking/setting.
