### PR TITLE
Disable ydb/library/actors/interconnect/ut/event_holder_pool_ut.cpp with sanitizers

### DIFF
--- a/ydb/library/actors/interconnect/ut/event_holder_pool_ut.cpp
+++ b/ydb/library/actors/interconnect/ut/event_holder_pool_ut.cpp
@@ -113,10 +113,18 @@ Y_UNIT_TEST_SUITE(EventHolderPool) {
     }
 
     Y_UNIT_TEST(MemConsumptionSmall) {
-        MemComsumption(100'000, 4);
+        size_t repeats = 100'000;
+#ifdef _san_enabled_
+        repeats /= 100;
+#endif
+        MemComsumption(repeats, 4);
     }
 
     Y_UNIT_TEST(MemConsumptionLarge) {
-        MemComsumption(10'000, 1024*1024);
+        size_t repeats = 10'000;
+#ifdef _san_enabled_
+        repeats /= 100;
+#endif
+        MemComsumption(repeats, 1024*1024);
     }
 }

--- a/ydb/library/actors/interconnect/ut/event_holder_pool_ut.cpp
+++ b/ydb/library/actors/interconnect/ut/event_holder_pool_ut.cpp
@@ -9,6 +9,7 @@
 #include <contrib/libs/tcmalloc/tcmalloc/malloc_extension.h>
 
 #include <atomic>
+#include <iostream>
 
 using namespace NActors;
 
@@ -113,18 +114,18 @@ Y_UNIT_TEST_SUITE(EventHolderPool) {
     }
 
     Y_UNIT_TEST(MemConsumptionSmall) {
-        size_t repeats = 100'000;
 #ifdef _san_enabled_
-        repeats /= 100;
+        std::cout << "Skipping, because TCMalloc unavailable\n";
+        return;
 #endif
-        MemComsumption(repeats, 4);
+        MemComsumption(100'000, 4);
     }
 
     Y_UNIT_TEST(MemConsumptionLarge) {
-        size_t repeats = 10'000;
 #ifdef _san_enabled_
-        repeats /= 100;
+        std::cout << "Skipping, because TCMalloc unavailable\n";
+        return;
 #endif
-        MemComsumption(repeats, 1024*1024);
+        MemComsumption(10'000, 1024*1024);
     }
 }

--- a/ydb/library/actors/interconnect/ut/event_holder_pool_ut.cpp
+++ b/ydb/library/actors/interconnect/ut/event_holder_pool_ut.cpp
@@ -115,7 +115,7 @@ Y_UNIT_TEST_SUITE(EventHolderPool) {
 
     Y_UNIT_TEST(MemConsumptionSmall) {
 #ifdef _san_enabled_
-        std::cout << "Skipping, because TCMalloc unavailable\n";
+        std::cout << "Skipping, because TCMalloc is unavailable\n";
         return;
 #endif
         MemComsumption(100'000, 4);
@@ -123,7 +123,7 @@ Y_UNIT_TEST_SUITE(EventHolderPool) {
 
     Y_UNIT_TEST(MemConsumptionLarge) {
 #ifdef _san_enabled_
-        std::cout << "Skipping, because TCMalloc unavailable\n";
+        std::cout << "Skipping, because TCMalloc is unavailable\n";
         return;
 #endif
         MemComsumption(10'000, 1024*1024);


### PR DESCRIPTION
These tests rely on tcmalloc

```
[[bad]]assertion failed at ydb/library/actors/interconnect/ut/event_holder_pool_ut.cpp:73, NTestSuiteEventHolderPool::TMemProfiler::TMemProfiler(): (tcmallocIsUsed) [[rst]]
[[alt1]]NUnitTest::NPrivate::RaiseError(char const*, TBasicString<char, std::__y1::char_traits<char>> const&, bool)+592 (0xF0DBB0)
NTestSuiteEventHolderPool::TMemProfiler::TMemProfiler()+897 (0xA7C3D1)
NTestSuiteEventHolderPool::MemComsumption(unsigned long, unsigned long)+3011 (0xA79EA3)
std::__y1::__function::__func<NTestSuiteEventHolderPool::TCurrentTest::Execute()::'lambda'(), std::__y1::allocator<NTestSuiteEventHolderPool::TCurrentTest::Execute()::'lambda'()>, void ()>::operator()()+280 (0xA7E5B8)
TColoredProcessor::Run(std::__y1::function<void ()>, TBasicString<char, std::__y1::char_traits<char>> const&, char const*, bool)+537 (0xF4C009)
NUnitTest::TTestBase::Run(std::__y1::function<void ()>, TBasicString<char, std::__y1::char_traits<char>> const&, char const*, bool)+505 (0xF14719)
NTestSuiteEventHolderPool::TCurrentTest::Execute()+1204 (0xA7D784)
NUnitTest::TTestFactory::Execute()+2438 (0xF15FE6)
NUnitTest::RunMain(int, char**)+5149 (0xF45C0D)
??+0 (0x7F9ACA524D90)
__libc_start_main+128 (0x7F9ACA524E40)
_start+41 (0xA21029)
[[rst]]
```

