### PR TITLE
clickhouse udf: fix errno access without error

### DIFF
--- a/ydb/library/yql/udfs/common/clickhouse/client/src/IO/WriteBufferFromFileDescriptor.cpp
+++ b/ydb/library/yql/udfs/common/clickhouse/client/src/IO/WriteBufferFromFileDescriptor.cpp
@@ -58,7 +58,7 @@ void WriteBufferFromFileDescriptor::nextImpl()
             res = ::write(fd, working_buffer.begin() + bytes_written, offset() - bytes_written);
         }
 
-        if ((-1 == res || 0 == res) && errno != EINTR)
+        if ((-1 == res && errno != EINTR) || 0 == res)
         {
             ProfileEvents::increment(ProfileEvents::WriteBufferFromFileDescriptorWriteFailed);
             throwFromErrnoWithPath("Cannot write to file " + getFileName(), getFileName(),

--- a/ydb/library/yql/udfs/common/clickhouse/client/src/IO/WriteBufferFromFileDescriptorDiscardOnFailure.cpp
+++ b/ydb/library/yql/udfs/common/clickhouse/client/src/IO/WriteBufferFromFileDescriptorDiscardOnFailure.cpp
@@ -15,7 +15,7 @@ void WriteBufferFromFileDescriptorDiscardOnFailure::nextImpl()
     {
         ssize_t res = ::write(fd, working_buffer.begin() + bytes_written, offset() - bytes_written);
 
-        if ((-1 == res || 0 == res) && errno != EINTR)
+        if ((-1 == res && errno != EINTR) || 0 == res)
         {
             ProfileEvents::increment(ProfileEvents::CannotWriteToWriteBufferDiscard);
             break;  /// Discard


### PR DESCRIPTION
when ::write return != -1, errno is undefined

### Changelog entry <!-- a user-readable short description of changes introduced in this PR -->

...

### Changelog category <!-- remove all except one -->

* Bugfix 
* Not for changelog (changelog entry is not required)

### Additional information

...
