### PR TITLE
Update muted_ya.txt

### DIFF
--- a/.github/config/muted_ya.txt
+++ b/.github/config/muted_ya.txt
@@ -3,7 +3,6 @@ ydb/apps/ydb/ut YdbWorkloadTransferTopicToTable.Clean_Without_Init
 ydb/apps/ydb/ut YdbWorkloadTransferTopicToTable.Default_Init_Clean
 ydb/apps/ydb/ut YdbWorkloadTransferTopicToTable.Default_Run
 ydb/core/blobstorage/dsproxy/ut TBlobStorageProxySequenceTest.TestBlock42PutWithChangingSlowDisk
-ydb/core/blobstorage/dsproxy/ut TDSProxyPutTest.TestBlock42PutStatusErrorWith_1_2_VdiskErrors
 ydb/core/blobstorage/dsproxy/ut_fat TBlobStorageProxyTest.TestBatchedPutRequestDoesNotContainAHugeBlob
 ydb/core/blobstorage/ut_blobstorage/ut_huge HugeBlobOnlineSizeChange.Compaction
 ydb/core/blobstorage/ut_blobstorage/ut_huge [*/*] chunk chunk
@@ -15,6 +14,7 @@ ydb/core/blobstorage/ut_vdisk TBsVDiskGC.GCPutKeepBarrierSync
 ydb/core/blobstorage/ut_vdisk TBsVDiskManyPutGet.ManyPutRangeGetCompactionIndexOnly
 ydb/core/blobstorage/ut_vdisk [*/*] chunk chunk
 ydb/core/blobstorage/ut_vdisk2 VDiskTest.HugeBlobWrite
+ydb/core/client/ut TClientTest.PromoteFollower
 ydb/core/cms/ut_sentinel_unstable TSentinelUnstableTests.BSControllerCantChangeStatus
 ydb/core/cms/ut_sentinel_unstable sole chunk chunk
 ydb/core/cms/ut_sentinel_unstable sole+chunk+chunk
@@ -28,6 +28,7 @@ ydb/core/kqp/ut/data_integrity KqpDataIntegrityTrails.UpsertEvWrite
 ydb/core/kqp/ut/olap KqpDecimalColumnShard.TestAggregation
 ydb/core/kqp/ut/olap KqpDecimalColumnShard.TestFilterCompare
 ydb/core/kqp/ut/olap KqpOlap.ManyColumnShardsWithRestarts
+ydb/core/kqp/ut/olap KqpOlap.TableSinkWithOlapStore
 ydb/core/kqp/ut/olap KqpOlapBlobsSharing.BlobsSharingSplit1_1
 ydb/core/kqp/ut/olap KqpOlapBlobsSharing.BlobsSharingSplit1_1_clean
 ydb/core/kqp/ut/olap KqpOlapBlobsSharing.BlobsSharingSplit1_1_clean_with_restarts
@@ -66,13 +67,10 @@ ydb/core/kqp/ut/tx KqpSnapshotIsolation.TConflictWriteOlap
 ydb/core/kqp/ut/tx KqpSnapshotIsolation.TConflictWriteOltp
 ydb/core/kqp/ut/tx KqpSnapshotIsolation.TConflictWriteOltpNoSink
 ydb/core/kqp/ut/yql KqpScripting.StreamExecuteYqlScriptScanOperationTmeoutBruteForce
-ydb/core/mind/hive/ut THiveTest.TestHiveBalancerNodeRestarts
 ydb/core/mind/hive/ut THiveTest.TestReassignUseRelativeSpace
 ydb/core/persqueue/ut TPQTest.TestReadAndDeleteConsumer
 ydb/core/persqueue/ut [*/*] chunk chunk
 ydb/core/quoter/ut QuoterWithKesusTest.PrefetchCoefficient
-ydb/core/tablet_flat/ut TSharedPageCache.ClockPro
-ydb/core/tablet_flat/ut TSharedPageCache.Compaction_BTreeIndex
 ydb/core/tablet_flat/ut TSharedPageCache.S3FIFO
 ydb/core/tablet_flat/ut TSharedPageCache.ThreeLeveledLRU
 ydb/core/tx/datashard/ut_incremental_backup IncrementalBackup.ComplexRestoreBackupCollection+WithIncremental
@@ -81,7 +79,6 @@ ydb/core/tx/schemeshard/ut_move_reboots TSchemeShardMoveRebootsTest.WithDataAndP
 ydb/core/tx/schemeshard/ut_pq_reboots TPqGroupTestReboots.AlterWithReboots-PQConfigTransactionsAtSchemeShard-false
 ydb/core/tx/schemeshard/ut_pq_reboots TPqGroupTestReboots.CreateAlter-PQConfigTransactionsAtSchemeShard-true
 ydb/core/tx/schemeshard/ut_pq_reboots TPqGroupTestReboots.CreateAlterDropPqGroupWithReboots-PQConfigTransactionsAtSchemeShard-true
-ydb/core/tx/schemeshard/ut_split_merge TSchemeShardSplitBySizeTest.Merge1KShards
 ydb/core/tx/tiering/ut ColumnShardTiers.TTLUsage
 ydb/core/viewer/ut Viewer.TabletMerging
 ydb/core/viewer/ut Viewer.TabletMergingPacked
@@ -91,11 +88,6 @@ ydb/library/actors/http/ut sole+chunk+chunk
 ydb/library/actors/interconnect/ut_huge_cluster HugeCluster.AllToAll
 ydb/library/actors/interconnect/ut_huge_cluster sole chunk chunk
 ydb/library/yql/providers/generic/connector/tests/datasource/ydb test.py.test_select_positive[column_selection_col2_COL1-kqprun]
-ydb/public/sdk/cpp/client/ydb_topic/ut TxUsage.Sinks_Oltp_WriteToTopic_1
-ydb/public/sdk/cpp/client/ydb_topic/ut TxUsage.Sinks_Oltp_WriteToTopic_2
-ydb/public/sdk/cpp/client/ydb_topic/ut TxUsage.Sinks_Oltp_WriteToTopic_3
-ydb/public/sdk/cpp/client/ydb_topic/ut TxUsage.Sinks_Oltp_WriteToTopic_4
-ydb/public/sdk/cpp/client/ydb_topic/ut TxUsage.Sinks_Oltp_WriteToTopics_3
 ydb/public/sdk/cpp/client/ydb_topic/ut [*/*] chunk chunk
 ydb/public/sdk/cpp/client/ydb_topic/ut [*/*]+chunk+chunk
 ydb/services/datastreams/ut DataStreams.TestPutRecordsCornerCases
@@ -121,10 +113,9 @@ ydb/tests/fq/generic/streaming test_join.py.TestJoinStreaming.test_streamlookup[
 ydb/tests/fq/generic/streaming test_join.py.TestJoinStreaming.test_streamlookup[v1-4-True-3-fq_client0-mvp_external_ydb_endpoint0]
 ydb/tests/fq/generic/streaming test_join.py.TestJoinStreaming.test_streamlookup[v1-5-True-3-fq_client0-mvp_external_ydb_endpoint0]
 ydb/tests/fq/generic/streaming test_join.py.TestJoinStreaming.test_streamlookup[v1-6-True-3-fq_client0-mvp_external_ydb_endpoint0]
+ydb/tests/fq/http_api test_http_api.py.TestHttpApi.test_restart_idempotency
 ydb/tests/fq/mem_alloc sole chunk chunk
 ydb/tests/fq/mem_alloc sole+chunk+chunk
-ydb/tests/fq/mem_alloc test_alloc_default.py.TestAlloc.test_hard_limit[kikimr0]
-ydb/tests/fq/mem_alloc test_result_limits.py.TestResultLimits.test_quotas[kikimr0]
 ydb/tests/fq/mem_alloc test_scheduling.py.TestSchedule.test_skip_busy[kikimr0]
 ydb/tests/fq/multi_plane [test_dispatch.py] chunk chunk
 ydb/tests/fq/multi_plane [test_dispatch.py]+chunk+chunk
@@ -145,7 +136,13 @@ ydb/tests/fq/yds test_select_limit_db_id.py.TestSelectLimitWithDbId.test_select_
 ydb/tests/fq/yds test_yds_bindings.py.TestBindings.test_yds_insert[v1]
 ydb/tests/fq/yt/kqp_yt_file/part18 test.py.test[pg-join_brackets2-default.txt]
 ydb/tests/functional/hive test_drain.py.TestHive.test_drain_on_stop
+ydb/tests/functional/hive test_drain.py.TestHive.test_drain_tablets
 ydb/tests/functional/rename [test_rename.py */*] chunk chunk
+ydb/tests/functional/restarts test_restarts.py.TestRestartMultipleBlock42.test_tablets_are_successfully_started_after_few_killed_nodes
+ydb/tests/functional/restarts test_restarts.py.TestRestartMultipleMirror34.test_tablets_are_successfully_started_after_few_killed_nodes
+ydb/tests/functional/restarts test_restarts.py.TestRestartMultipleMirror3DC.test_tablets_are_successfully_started_after_few_killed_nodes
+ydb/tests/functional/restarts test_restarts.py.TestRestartSingleBlock42.test_restart_single_node_is_ok
+ydb/tests/functional/restarts test_restarts.py.TestRestartSingleMirror3DC.test_restart_single_node_is_ok
 ydb/tests/functional/serializable sole chunk chunk
 ydb/tests/functional/serializable test.py.test_local
 ydb/tests/functional/serverless test_serverless.py.test_database_with_disk_quotas[enable_alter_database_create_hive_first--false]
@@ -159,7 +156,9 @@ ydb/tests/functional/tenants test_tenants.py.TestTenants.test_list_database_abov
 ydb/tests/functional/tenants test_tenants.py.TestTenants.test_list_database_above[enable_alter_database_create_hive_first--true]
 ydb/tests/functional/tenants test_tenants.py.TestTenants.test_stop_start[enable_alter_database_create_hive_first--false]
 ydb/tests/functional/tenants test_tenants.py.TestTenants.test_stop_start[enable_alter_database_create_hive_first--true]
+ydb/tests/olap/scenario sole chunk chunk
 ydb/tests/olap/scenario test_alter_tiering.py.TestAlterTiering.test[many_tables]
+ydb/tests/olap/scenario test_insert.py.TestInsert.test[read_data_during_bulk_upsert]
 ydb/tests/postgres_integrations/go-libpq [docker_wrapper_test.py] chunk chunk
 ydb/tests/postgres_integrations/go-libpq docker_wrapper_test.py.test_pg_generated[Test64BitErrorChecking]
 ydb/tests/postgres_integrations/go-libpq docker_wrapper_test.py.test_pg_generated[TestArrayValueBackend]
@@ -229,5 +228,5 @@ ydb/tests/postgres_integrations/go-libpq docker_wrapper_test.py.test_pg_generate
 ydb/tests/postgres_integrations/go-libpq docker_wrapper_test.py.test_pg_generated[TestStmtQueryContext]
 ydb/tests/postgres_integrations/go-libpq docker_wrapper_test.py.test_pg_generated[TestStringWithNul]
 ydb/tests/postgres_integrations/go-libpq docker_wrapper_test.py.test_pg_generated[TestTimestampWithTimeZone]
-ydb/tests/sql test_inserts.py.TestYdbInsertsOperations.test_insert_multiple_empty_rows
 ydb/tests/postgres_integrations/go-libpq docker_wrapper_test.py.test_pg_generated[TestTxOptions]
+ydb/tests/sql test_inserts.py.TestYdbInsertsOperations.test_insert_multiple_empty_rows


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of changes introduced in this PR -->

**Unmuted tests : stable 12**
```
ydb/core/blobstorage/dsproxy/ut TDSProxyPutTest.TestBlock42PutStatusErrorWith_1_2_VdiskErrors # owner TEAM:@ydb-platform/storage success_rate 100%, state Muted Stable days in state 15
ydb/core/mind/hive/ut THiveTest.TestHiveBalancerNodeRestarts # owner TEAM:@ydb-platform/system-infra success_rate 100%, state Muted Stable days in state 23
ydb/core/tablet_flat/ut TSharedPageCache.ClockPro # owner TEAM:@ydb-platform/datashard success_rate 100%, state Muted Stable days in state 14
ydb/core/tablet_flat/ut TSharedPageCache.Compaction_BTreeIndex # owner TEAM:@ydb-platform/datashard success_rate 100%, state Muted Stable days in state 20
ydb/core/tx/schemeshard/ut_split_merge TSchemeShardSplitBySizeTest.Merge1KShards # owner TEAM:@ydb-platform/system-infra success_rate 100%, state Muted Stable days in state 23
ydb/public/sdk/cpp/client/ydb_topic/ut TxUsage.Sinks_Oltp_WriteToTopic_1 # owner TEAM:@ydb-platform/appteam success_rate 100%, state Muted Stable days in state 15
ydb/public/sdk/cpp/client/ydb_topic/ut TxUsage.Sinks_Oltp_WriteToTopic_2 # owner TEAM:@ydb-platform/appteam success_rate 100%, state Muted Stable days in state 15
ydb/public/sdk/cpp/client/ydb_topic/ut TxUsage.Sinks_Oltp_WriteToTopic_3 # owner TEAM:@ydb-platform/appteam success_rate 100%, state Muted Stable days in state 15
ydb/public/sdk/cpp/client/ydb_topic/ut TxUsage.Sinks_Oltp_WriteToTopic_4 # owner TEAM:@ydb-platform/appteam success_rate 100%, state Muted Stable days in state 15
ydb/public/sdk/cpp/client/ydb_topic/ut TxUsage.Sinks_Oltp_WriteToTopics_3 # owner TEAM:@ydb-platform/appteam success_rate 100%, state Muted Stable days in state 15
ydb/tests/fq/mem_alloc test_alloc_default.py.TestAlloc.test_hard_limit[kikimr0] # owner TEAM:@ydb-platform/fq success_rate 100%, state Muted Stable days in state 23
ydb/tests/fq/mem_alloc test_result_limits.py.TestResultLimits.test_quotas[kikimr0] # owner TEAM:@ydb-platform/fq success_rate 100%, state Muted Stable days in state 15
```

**Flaky tests : 11**

```
ydb/core/client/ut TClientTest.PromoteFollower # owner TEAM:@ydb-platform/duty success_rate 72%, state Flaky, days in state 2, pass_count 16, fail count 6
ydb/core/kqp/ut/olap KqpOlap.TableSinkWithOlapStore # owner TEAM:@ydb-platform/qp success_rate 38%, state Flaky, days in state 3, pass_count 13, fail count 21
ydb/tests/fq/http_api test_http_api.py.TestHttpApi.test_restart_idempotency # owner TEAM:@ydb-platform/fq success_rate 86%, state Flaky, days in state 2, pass_count 20, fail count 3
ydb/tests/functional/hive test_drain.py.TestHive.test_drain_tablets # owner TEAM:@ydb-platform/system-infra success_rate 65%, state Flaky, days in state 15, pass_count 19, fail count 10
ydb/tests/functional/restarts test_restarts.py.TestRestartMultipleBlock42.test_tablets_are_successfully_started_after_few_killed_nodes # owner Unknown success_rate 87%, state Flaky, days in state 9, pass_count 21, fail count 3
ydb/tests/functional/restarts test_restarts.py.TestRestartMultipleMirror34.test_tablets_are_successfully_started_after_few_killed_nodes # owner Unknown success_rate 87%, state Flaky, days in state 2, pass_count 21, fail count 3
ydb/tests/functional/restarts test_restarts.py.TestRestartMultipleMirror3DC.test_tablets_are_successfully_started_after_few_killed_nodes # owner Unknown success_rate 80%, state Flaky, days in state 4, pass_count 20, fail count 5
ydb/tests/functional/restarts test_restarts.py.TestRestartSingleBlock42.test_restart_single_node_is_ok # owner Unknown success_rate 77%, state Flaky, days in state 7, pass_count 21, fail count 6
ydb/tests/functional/restarts test_restarts.py.TestRestartSingleMirror3DC.test_restart_single_node_is_ok # owner Unknown success_rate 87%, state Flaky, days in state 2, pass_count 21, fail count 3
ydb/tests/olap/scenario sole chunk chunk # owner Unknown success_rate 85%, state Flaky, days in state 15, pass_count 49, fail count 8
ydb/tests/olap/scenario test_insert.py.TestInsert.test[read_data_during_bulk_upsert] # owner Unknown success_rate 87%, state Flaky, days in state 2, pass_count 21, fail count 3
```

Created issue 'Mute ydb/tests/olap/scenario 2 tests' for Unknown, url https://github.com/ydb-platform/ydb/issues/13331
Created issue 'Mute ydb/tests/functional/hive/test_drain.py.TestHive.test_drain_tablets' for TEAM:@ydb-platform/system-infra, url https://github.com/ydb-platform/ydb/issues/13332
Created issue 'Mute ydb/tests/fq/http_api/test_http_api.py.TestHttpApi.test_restart_idempotency' for TEAM:@ydb-platform/fq, url https://github.com/ydb-platform/ydb/issues/13333
Created issue 'Mute ydb/tests/functional/restarts 5 tests' for Unknown, url https://github.com/ydb-platform/ydb/issues/13334

### Changelog category <!-- remove all except one -->


* Not for changelog (changelog entry is not required)

### Additional information

...
