### PR TITLE
The test TPQTest::TestReadAndDeleteConsumer

### DIFF
--- a/ydb/core/persqueue/ut/pq_ut.cpp
+++ b/ydb/core/persqueue/ut/pq_ut.cpp
@@ -2352,7 +2352,9 @@ Y_UNIT_TEST(TestReadAndDeleteConsumer) {
             data.emplace_back(i, msg);
         }
 
-        PQTabletPrepare({.maxCountInPartition=100, .deleteTime=TDuration::Days(2).Seconds(), .partitions=1},
+        static ui32 pqConfigVersion = 1'000;
+
+        PQTabletPrepare({.maxCountInPartition=100, .deleteTime=TDuration::Days(2).Seconds(), .partitions=1, .specVersion=pqConfigVersion++},
                         {{"user1", true}, {"user2", true}}, tc);
         CmdWrite(0, "sourceid1", data, tc, false, {}, true);
 
@@ -2383,7 +2385,7 @@ Y_UNIT_TEST(TestReadAndDeleteConsumer) {
             consumerDeleteRequest.Reset(new TEvPersQueue::TEvUpdateConfig());
             consumerDeleteRequest->MutableRecord()->SetTxId(42);
             auto& cfg = *consumerDeleteRequest->MutableRecord()->MutableTabletConfig();
-            cfg.SetVersion(42);
+            cfg.SetVersion(pqConfigVersion++);
             cfg.AddPartitionIds(0);
             cfg.AddPartitions()->SetPartitionId(0);
             cfg.SetLocalDC(true);


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of changes introduced in this PR -->

The test breaks if you run all the tests in the `ydb/core/persqueue/ut` subdirectory. If you run it separately, it completes without an error.

The problem is that the version of the config is fixed in the source code.

### Changelog category <!-- remove all except one -->

* Bugfix 
* Not for changelog (changelog entry is not required)

### Additional information

...
