### PR TITLE
Correct BSC teardown on Console race

### DIFF
--- a/ydb/core/mind/bscontroller/console_interaction.cpp
+++ b/ydb/core/mind/bscontroller/console_interaction.cpp
@@ -239,7 +239,7 @@ namespace NKikimr::NBsController {
         switch (status) {
             case NKikimrProto::OK:
                 if (generation <= blockedGeneration) {
-                    Self.PassAway();
+                    Self.HandlePoison(TActivationContext::AsActorContext());
                     return;
                 }
                 if (generation == blockedGeneration + 1 && NeedRetrySession) {
@@ -249,7 +249,7 @@ namespace NKikimr::NBsController {
                 Y_VERIFY_DEBUG_S(generation == blockedGeneration + 1, "BlockedGeneration#" << blockedGeneration << " Tablet generation#" << generation);
                 break;
             case NKikimrProto::BLOCKED:
-                Self.PassAway();
+                Self.HandlePoison(TActivationContext::AsActorContext());
                 break;
             case NKikimrProto::DEADLINE:
             case NKikimrProto::RACE:


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of changes introduced in this PR -->

Correct BSC teardown on Console race

### Changelog category <!-- remove all except one -->

* Not for changelog (changelog entry is not required)

### Additional information

BSC terminates correctly in case of Console race detection.
