### PR TITLE
Return original field index in dq transport proto

### DIFF
--- a/ydb/library/yql/dq/proto/dq_transport.proto
+++ b/ydb/library/yql/dq/proto/dq_transport.proto
@@ -16,7 +16,7 @@ enum EDataTransportVersion {
 message TData {
     uint32 TransportVersion = 1;
     bytes Raw = 2;
-    uint32 Rows = 5;
-    uint32 Chunks = 3;
+    uint32 Rows = 3;
+    uint32 Chunks = 5;
     optional uint32 PayloadId = 4;
 }

--- a/ydb/library/yql/dq/proto/dq_transport.proto
+++ b/ydb/library/yql/dq/proto/dq_transport.proto
@@ -17,6 +17,6 @@ message TData {
     uint32 TransportVersion = 1;
     bytes Raw = 2;
     uint32 Rows = 3;
-    uint32 Chunks = 5;
     optional uint32 PayloadId = 4;
+    uint32 Chunks = 5;
 }


### PR DESCRIPTION
Сhanging the original index resulted in data loss during rolling update. See the source #11893 that led to the problem.

* Bugfix 
