### PR TITLE
Revert "Correct Rows count in Block Output Channels (#11893)"

### DIFF
--- a/ydb/library/yql/dq/common/dq_serialized_batch.cpp
+++ b/ydb/library/yql/dq/common/dq_serialized_batch.cpp
@@ -65,13 +65,11 @@ TChunkedBuffer SaveForSpilling(TDqSerializedBatch&& batch) {
 
     ui32 transportversion = batch.Proto.GetTransportVersion();
     ui32 rowCount = batch.Proto.GetRows();
-    ui32 chunkCount = batch.Proto.GetChunks();
 
     TChunkedBuffer protoPayload(std::move(*batch.Proto.MutableRaw()));
 
     AppendNumber(result, transportversion);
     AppendNumber(result, rowCount);
-    AppendNumber(result, chunkCount);
     AppendNumber(result, protoPayload.Size());
     result.Append(std::move(protoPayload));
     AppendNumber(result, batch.Payload.Size());
@@ -87,7 +85,6 @@ TDqSerializedBatch LoadSpilled(TBuffer&& blob) {
     TDqSerializedBatch result;
     result.Proto.SetTransportVersion(ReadNumber<ui32>(source));
     result.Proto.SetRows(ReadNumber<ui32>(source));
-    result.Proto.SetChunks(ReadNumber<ui32>(source));
 
     size_t protoSize = ReadNumber<size_t>(source);
     YQL_ENSURE(source.size() >= protoSize, "Premature end of spilled data");

--- a/ydb/library/yql/dq/common/dq_serialized_batch.h
+++ b/ydb/library/yql/dq/common/dq_serialized_batch.h
@@ -28,10 +28,6 @@ struct TDqSerializedBatch {
         return Proto.GetRows();
     }
 
-    ui32 ChunkCount() const {
-        return Proto.GetChunks();
-    }
-
     void Clear() {
         Payload.Clear();
         Proto.Clear();

--- a/ydb/library/yql/dq/proto/dq_transport.proto
+++ b/ydb/library/yql/dq/proto/dq_transport.proto
@@ -16,7 +16,6 @@ enum EDataTransportVersion {
 message TData {
     uint32 TransportVersion = 1;
     bytes Raw = 2;
-    uint32 Rows = 5;
-    uint32 Chunks = 3;
+    uint32 Rows = 3;
     optional uint32 PayloadId = 4;
 }

--- a/ydb/library/yql/dq/runtime/dq_input_channel.cpp
+++ b/ydb/library/yql/dq/runtime/dq_input_channel.cpp
@@ -47,7 +47,7 @@ private:
 
     void PushImpl(TDqSerializedBatch&& data) {
         const i64 space = data.Size();
-        const size_t chunkCount = data.ChunkCount();
+        const size_t rowCount = data.RowCount();
         auto inputType = Impl.GetInputType();
         NKikimr::NMiniKQL::TUnboxedValueBatch batch(inputType);
         if (Y_UNLIKELY(PushStats.CollectProfile())) {
@@ -58,8 +58,7 @@ private:
             DataSerializer.Deserialize(std::move(data), inputType, batch);
         }
 
-        // single batch row is chunk and may be Arrow block
-        YQL_ENSURE(batch.RowCount() == chunkCount);
+        YQL_ENSURE(batch.RowCount() == rowCount);
         Impl.AddBatch(std::move(batch), space);
     }
 

--- a/ydb/library/yql/dq/runtime/dq_output_channel.cpp
+++ b/ydb/library/yql/dq/runtime/dq_output_channel.cpp
@@ -58,7 +58,7 @@ public:
     }
 
     ui64 GetValuesCount() const override {
-        return SpilledRowCount + PackedRowCount + PackerCurrentRowCount;
+        return SpilledRowCount + PackedRowCount + ChunkRowCount;
     }
 
     const TDqOutputStats& GetPushStats() const override {
@@ -95,12 +95,8 @@ public:
             return;
         }
 
-        ui32 rows = Packer.IsBlock() ?
-            NKikimr::NMiniKQL::TArrowBlock::From(values[width - 1]).GetDatum().scalar_as<arrow::UInt64Scalar>().value
-            : 1;
-
         if (PushStats.CollectBasic()) {
-            PushStats.Rows += rows;
+            PushStats.Rows++;
             PushStats.Chunks++;
             PushStats.Resume();
         }
@@ -114,8 +110,7 @@ public:
             values[i] = {};
         }
 
-        PackerCurrentRowCount += rows;
-        PackerCurrentChunkCount++;
+        ChunkRowCount++;
 
         size_t packerSize = Packer.PackedSizeEstimate();
         if (packerSize >= MaxChunkBytes) {
@@ -125,12 +120,9 @@ public:
                 PushStats.Bytes += Data.back().Buffer.Size();
             }
             PackedDataSize += Data.back().Buffer.Size();
-            PackedRowCount += PackerCurrentRowCount;
-            PackedChunkCount += PackerCurrentChunkCount;
-            Data.back().RowCount = PackerCurrentRowCount;
-            Data.back().ChunkCount = PackerCurrentChunkCount;
-            PackerCurrentRowCount = 0;
-            PackerCurrentChunkCount = 0;
+            PackedRowCount += ChunkRowCount;
+            Data.back().RowCount = ChunkRowCount;
+            ChunkRowCount = 0;
             packerSize = 0;
         }
 
@@ -142,13 +134,11 @@ public:
             TDqSerializedBatch data;
             data.Proto.SetTransportVersion(TransportVersion);
             data.Proto.SetRows(head.RowCount);
-            data.Proto.SetChunks(head.ChunkCount);
             data.SetPayload(std::move(head.Buffer));
             Storage->Put(NextStoredId++, SaveForSpilling(std::move(data)));
 
             PackedDataSize -= bufSize;
             PackedRowCount -= head.RowCount;
-            PackedChunkCount -= head.ChunkCount;
 
             SpilledRowCount += head.RowCount;
 
@@ -209,29 +199,22 @@ public:
         } else if (!Data.empty()) {
             auto& packed = Data.front();
             PackedRowCount -= packed.RowCount;
-            PackedChunkCount -= packed.ChunkCount;
             PackedDataSize -= packed.Buffer.Size();
             data.Proto.SetRows(packed.RowCount);
-            data.Proto.SetChunks(packed.ChunkCount);
             data.SetPayload(std::move(packed.Buffer));
             Data.pop_front();
         } else {
-            data.Proto.SetRows(PackerCurrentRowCount);
-            data.Proto.SetChunks(PackerCurrentChunkCount);
+            data.Proto.SetRows(ChunkRowCount);
             data.SetPayload(FinishPackAndCheckSize());
-            if (PushStats.CollectBasic()) {
-                PushStats.Bytes += data.Payload.Size();
-            }
-            PackerCurrentRowCount = 0;
-            PackerCurrentChunkCount = 0;
+            ChunkRowCount = 0;
         }
 
         DLOG("Took " << data.RowCount() << " rows");
 
         if (PopStats.CollectBasic()) {
             PopStats.Bytes += data.Size();
-            PopStats.Rows += data.RowCount(); 
-            PopStats.Chunks++; // pop chunks do not match push chunks
+            PopStats.Rows += data.RowCount();
+            PopStats.Chunks++;
             if (!IsFull() || FirstStoredId == NextStoredId) {
                 PopStats.Resume();
             }
@@ -273,31 +256,20 @@ public:
         data.Clear();
         data.Proto.SetTransportVersion(TransportVersion);
         if (SpilledRowCount == 0 && PackedRowCount == 0) {
-            data.Proto.SetRows(PackerCurrentRowCount);
-            data.Proto.SetChunks(PackerCurrentChunkCount);
+            data.Proto.SetRows(ChunkRowCount);
             data.SetPayload(FinishPackAndCheckSize());
-            if (PushStats.CollectBasic()) {
-                PushStats.Bytes += data.Payload.Size();
-            }
-            PackerCurrentRowCount = 0;
-            PackerCurrentChunkCount = 0;
+            ChunkRowCount = 0;
             return true;
         }
 
         // Repack all - thats why PopAll should never be used
-        if (PackerCurrentRowCount) {
+        if (ChunkRowCount) {
             Data.emplace_back();
             Data.back().Buffer = FinishPackAndCheckSize();
-            if (PushStats.CollectBasic()) {
-                PushStats.Bytes += Data.back().Buffer.Size();
-            }
             PackedDataSize += Data.back().Buffer.Size();
-            PackedRowCount += PackerCurrentRowCount;
-            PackedChunkCount += PackerCurrentChunkCount;
-            Data.back().RowCount = PackerCurrentRowCount;
-            Data.back().ChunkCount = PackerCurrentChunkCount;
-            PackerCurrentRowCount = 0;
-            PackerCurrentChunkCount = 0;
+            PackedRowCount += ChunkRowCount;
+            Data.back().RowCount = ChunkRowCount;
+            ChunkRowCount = 0;
         }
 
         NKikimr::NMiniKQL::TUnboxedValueBatch rows(OutputType);
@@ -360,9 +332,7 @@ public:
         ui64 rows = GetValuesCount();
         Data.clear();
         Packer.Clear();
-        PackedDataSize = 0;
-        SpilledRowCount = PackedRowCount = PackerCurrentRowCount = 0;
-        PackedChunkCount = PackerCurrentChunkCount = 0;
+        SpilledRowCount = PackedDataSize = PackedRowCount = ChunkRowCount = 0;
         FirstStoredId = NextStoredId;
         return rows;
     }
@@ -389,7 +359,6 @@ private:
     struct TSerializedBatch {
         TChunkedBuffer Buffer;
         ui64 RowCount = 0;
-        ui64 ChunkCount = 0;
     };
     std::deque<TSerializedBatch> Data;
 
@@ -399,10 +368,8 @@ private:
 
     size_t PackedDataSize = 0;
     size_t PackedRowCount = 0;
-    size_t PackedChunkCount = 0;
     
-    size_t PackerCurrentRowCount = 0;
-    size_t PackerCurrentChunkCount = 0;
+    size_t ChunkRowCount = 0;
 
     bool Finished = false;
 


### PR DESCRIPTION
This reverts commit 398fb410adba8fede893681a5e67a809f02d0750, which breaks transport backward compatibility

* Bugfix 
