### PR TITLE
IGNIETFERRO-2114: fix the sorting predicate in the partition_chooser, which violates the strict-weak-ordering requirement

### DIFF
--- a/ydb/core/persqueue/writer/partition_chooser_impl.h
+++ b/ydb/core/persqueue/writer/partition_chooser_impl.h
@@ -86,7 +86,13 @@ TBoundaryChooser<THasher>::TBoundaryChooser(const NKikimrSchemeOp::TPersQueueGro
     }
 
     std::sort(Partitions.begin(), Partitions.end(),
-        [](const TPartitionInfo& a, const TPartitionInfo& b) { return !b.ToBound || (a.ToBound && a.ToBound < b.ToBound); });
+        [](const TPartitionInfo& a, const TPartitionInfo& b) {
+            if (!a.ToBound.has_value() || !b.ToBound.has_value()) {
+                return a.ToBound.has_value() > b.ToBound.has_value();
+            }
+            return a.ToBound < b.ToBound;
+        }
+    );
 }
 
 template<class THasher>


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of changes introduced in this PR -->

Fix UB caused by comparator not defining a valid strict-weak ordering.

### Changelog category <!-- remove all except one -->

* Bugfix 

### Additional information

Crash may be reproduced by defining the `_LIBCPP_DEBUG_STRICT_WEAK_ORDERING_CHECK` macro.
For example, backtrace from the `ydb/core/persqueue/ut` unittest:
```
Problem thread backtrace:
Thread 1 (LWP 170720):
#0  0x00007fee7dcd400b in raise () from /lib/x86_64-linux-gnu/libc.so.6
No symbol table info available.
#1  0x00007fee7dcb3859 in abort () from /lib/x86_64-linux-gnu/libc.so.6
No symbol table info available.
#2  0x0000000012cd6ccd in std::__y1::__libcpp_verbose_abort(char const*, ...) () at /-S/contrib/libs/cxxsupp/libcxx/src/verbose_abort.cpp:74
No locals.
#3  0x0000000012ae1651 in __check_strict_weak_ordering_sorted<NKikimr::NPQ::NPartitionChooser::TBoundaryChooser<NKikimr::NPQ::NPartitionChooser::TAsIsConverter>::TPartitionInfo *, (lambda at /-S/contrib/ydb/core/persqueue/writer/partition_chooser_impl.h:89:9)>(void) () at /-S/contrib/libs/cxxsupp/libcxx/include/__debug_utils/strict_weak_ordering_check.h:49
No locals.
#4  0x0000000012ab1271 in __sort_impl<std::__y1::_ClassicAlgPolicy, NKikimr::NPQ::NPartitionChooser::TBoundaryChooser<NKikimr::NPQ::NPartitionChooser::TAsIsConverter>::TPartitionInfo *, (lambda at /-S/contrib/ydb/core/persqueue/writer/partition_chooser_impl.h:89:9)> () at /-S/contrib/libs/cxxsupp/libcxx/include/__algorithm/sort.h:995
No locals.
#5  sort<NKikimr::NPQ::NPartitionChooser::TBoundaryChooser<NKikimr::NPQ::NPartitionChooser::TAsIsConverter>::TPartitionInfo *, (lambda at /-S/contrib/ydb/core/persqueue/writer/partition_chooser_impl.h:89:9)> () at /-S/contrib/libs/cxxsupp/libcxx/include/__algorithm/sort.h:1001
No locals.
#6  TBoundaryChooser () at /-S/contrib/ydb/core/persqueue/writer/partition_chooser_impl.h:88
No locals.
#7  0x0000000012aad6a6 in Execute_ () at /-S/contrib/ydb/core/persqueue/ut/partition_chooser_ut.cpp:78
No locals.
#8  0x0000000012acd8e6 in operator() () at /-S/contrib/ydb/core/persqueue/ut/partition_chooser_ut.cpp:73
No locals.
#9  0x0000000012ed1eeb in Run () at /-S/library/cpp/testing/unittest/registar.cpp:374
No locals.
#10 0x0000000012acd29a in Execute () at /-S/contrib/ydb/core/persqueue/ut/partition_chooser_ut.cpp:73
No locals.
#11 0x0000000012ed25fe in Execute () at /-S/library/cpp/testing/unittest/registar.cpp:495
No locals.
#12 0x0000000012ee592d in RunMain () at /-S/library/cpp/testing/unittest/utmain.cpp:872
No locals.
#13 0x00007fee7dcb5083 in __libc_start_main () from /lib/x86_64-linux-gnu/libc.so.6
No symbol table info available.
#14 0x0000000011de9029 in _start ()
No symbol table info available.
```