### PR TITLE
fix decoding version output in sql tests

### DIFF
--- a/ydb/tests/sql/lib/test_base.py
+++ b/ydb/tests/sql/lib/test_base.py
@@ -20,7 +20,7 @@ class TestBase(TestLib):
     @classmethod
     def setup_class(cls):
         ydb_path = yatest.common.build_path(os.environ.get("YDB_DRIVER_BINARY", "ydb/apps/ydbd/ydbd"))
-        logger.error(yatest.common.execute([ydb_path, "-V"], wait=True).stdout.decode("ascii"))
+        logger.error(yatest.common.execute([ydb_path, "-V"], wait=True).stdout.decode("utf-8"))
 
         cls.database = "/Root"
         cls.cluster = KiKiMR(KikimrConfigGenerator(erasure=cls.get_cluster_configuration()))


### PR DESCRIPTION
### Changelog category <!-- remove all except one -->
* Not for changelog (changelog entry is not required)

Падает на кириллических авторах коммитов. Пример 0ae852e9ca897c9f5813a6f5487f3bc5b207238d