### PR TITLE
Fix typo

### DIFF
--- a/ydb/library/actors/interconnect/interconnect_tcp_session.h
+++ b/ydb/library/actors/interconnect/interconnect_tcp_session.h
@@ -671,8 +671,10 @@ namespace NActors {
                 }
                 Total = UtilizedPart + WaitingCpuPart + IdlePart;
                 if (Total) {
-                    Utilized = (Utilized + WaitingCpuPart) / Total;
+                    Utilized = (UtilizedPart + WaitingCpuPart) / Total;
                     Starving = WaitingCpuPart / Total;
+                } else {
+                    Utilized = Starving = 0;
                 }
                 if (newState) {
                     State = *newState;


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of changes introduced in this PR -->

Fix typo

### Changelog category <!-- remove all except one -->

* Bugfix 

### Additional information

Fixed typo leading to incorrect calculation of utilization ratio in interconnect.
