### PR TITLE
Fix poller heap-use-after-free

### DIFF
--- a/ydb/library/actors/interconnect/poller_actor.cpp
+++ b/ydb/library/actors/interconnect/poller_actor.cpp
@@ -51,10 +51,10 @@ namespace NActors {
         struct TPollerWakeup {};
 
         struct TPollerUnregisterSocket {
-            TIntrusivePtr<TSharedDescriptor> Socket;
+            TIntrusivePtr<TSocketRecord> Record;
 
-            TPollerUnregisterSocket(TIntrusivePtr<TSharedDescriptor> socket)
-                : Socket(std::move(socket))
+            TPollerUnregisterSocket(TIntrusivePtr<TSocketRecord> record)
+                : Record(std::move(record))
             {}
         };
 
@@ -98,7 +98,7 @@ namespace NActors {
         }
 
         void UnregisterSocket(const TIntrusivePtr<TSocketRecord>& record) {
-            ExecuteSyncOperation(TPollerUnregisterSocket(record->Socket));
+            ExecuteSyncOperation(TPollerUnregisterSocket(record));
         }
 
     protected:
@@ -170,7 +170,7 @@ namespace NActors {
             do {
                 TPollerSyncOperationWrapper *op = SyncOperationsQ.Top();
                 if (auto *unregister = std::get_if<TPollerUnregisterSocket>(&op->Operation)) {
-                    static_cast<TDerived&>(*this).UnregisterSocketInLoop(unregister->Socket);
+                    static_cast<TDerived&>(*this).UnregisterSocketInLoop(unregister->Record->Socket);
                     op->SignalDone();
                 } else if (std::get_if<TPollerExitThread>(&op->Operation)) {
                     op->SignalDone();


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of changes introduced in this PR -->

Fix poller heap-use-after-free

### Changelog category <!-- remove all except one -->

* Bugfix 

### Additional information

Due to a bug in poller, a heap-use-after-free situation was possible when epoll\_wait() would return some events on poller being deregistered. This patch fixes that behaviour.
