### PR TITLE
Add data cleanup logic in localDB

### DIFF
--- a/ydb/core/base/tablet.h
+++ b/ydb/core/base/tablet.h
@@ -99,6 +99,8 @@ struct TEvTablet {
         // utilitary
         EvCheckBlobstorageStatusResult = EvBoot + 3072,
         EvResetTabletResult,
+        EvGcForStepAckRequest, // from executer to sys tablet
+        EvGcForStepAckResponse, // from sys tablet to executer
 
         EvEnd
     };
@@ -787,6 +789,28 @@ struct TEvTablet {
         TEvResetTabletResult(NKikimrProto::EReplyStatus status, ui64 tabletId)
             : Status(status)
             , TabletId(tabletId)
+        {}
+    };
+
+    // will send TEvGcForStepAckResponse when the requested Generation and Step are less
+    // than the actual garbage collected Generation and Step
+    struct TEvGcForStepAckRequest : public TEventLocal<TEvGcForStepAckRequest, EvGcForStepAckRequest> {
+        const ui32 Generation;
+        const ui32 Step;
+
+        TEvGcForStepAckRequest(ui32 generation, ui32 step)
+            : Generation(generation)
+            , Step(step)
+        {}
+    };
+
+    struct TEvGcForStepAckResponse : public TEventLocal<TEvGcForStepAckResponse, EvGcForStepAckResponse> {
+        const ui32 Generation;
+        const ui32 Step;
+
+        TEvGcForStepAckResponse(ui32 generation, ui32 step)
+            : Generation(generation)
+            , Step(step)
         {}
     };
 

--- a/ydb/core/tablet/tablet_sys.cpp
+++ b/ydb/core/tablet/tablet_sys.cpp
@@ -1285,7 +1285,7 @@ void TTablet::Handle(TEvBlobStorage::TEvCollectGarbageResult::TPtr &ev) {
         }
         break;
     case NKikimrProto::OK:
-        if (GcForStepAckRequest) {
+        if (GcInFly == 0 && GcForStepAckRequest) {
             const auto& req = *GcForStepAckRequest->Get();
             const ui32 gen = StateStorageInfo.KnownGeneration;
             if (std::tie(req.Generation, req.Step) <= std::tie(gen, GcInFlyStep)) {
@@ -1307,7 +1307,7 @@ void TTablet::Handle(TEvBlobStorage::TEvCollectGarbageResult::TPtr &ev) {
 void TTablet::Handle(TEvTablet::TEvGcForStepAckRequest::TPtr& ev) {
     const auto& req = *ev->Get();
     const ui32 gen = StateStorageInfo.KnownGeneration;
-    if (std::tie(req.Generation, req.Step) <= std::tie(gen, GcInFlyStep)) {
+    if (GcInFly == 0 && std::tie(req.Generation, req.Step) <= std::tie(gen, GcInFlyStep)) {
         Send(ev->Sender, new TEvTablet::TEvGcForStepAckResponse(gen, GcInFlyStep));
     } else {
         GcForStepAckRequest = ev;

--- a/ydb/core/tablet/tablet_sys.cpp
+++ b/ydb/core/tablet/tablet_sys.cpp
@@ -1285,6 +1285,15 @@ void TTablet::Handle(TEvBlobStorage::TEvCollectGarbageResult::TPtr &ev) {
         }
         break;
     case NKikimrProto::OK:
+        if (GcForStepAckRequest) {
+            const auto& req = *GcForStepAckRequest->Get();
+            const ui32 gen = StateStorageInfo.KnownGeneration;
+            if (std::tie(req.Generation, req.Step) <= std::tie(gen, GcInFlyStep)) {
+                Send(GcForStepAckRequest->Sender, new TEvTablet::TEvGcForStepAckResponse(gen, GcInFlyStep));
+                GcForStepAckRequest = nullptr;
+            }
+        }
+        [[fallthrough]];
     default: // silently ignore unrecognized errors (assume temporary)
         if (GcInFly == 0 && GcNextStep != 0) {
             GcLogChannel(std::exchange(GcNextStep, 0));
@@ -1293,6 +1302,16 @@ void TTablet::Handle(TEvBlobStorage::TEvCollectGarbageResult::TPtr &ev) {
     }
 
     CheckBlobStorageError();
+}
+
+void TTablet::Handle(TEvTablet::TEvGcForStepAckRequest::TPtr& ev) {
+    const auto& req = *ev->Get();
+    const ui32 gen = StateStorageInfo.KnownGeneration;
+    if (std::tie(req.Generation, req.Step) <= std::tie(gen, GcInFlyStep)) {
+        Send(ev->Sender, new TEvTablet::TEvGcForStepAckResponse(gen, GcInFlyStep));
+    } else {
+        GcForStepAckRequest = ev;
+    }
 }
 
 void TTablet::GcLogChannel(ui32 step) {

--- a/ydb/core/tablet/tablet_sys.h
+++ b/ydb/core/tablet/tablet_sys.h
@@ -225,6 +225,7 @@ class TTablet : public TActor<TTablet> {
     ui32 GcInFly;
     ui32 GcInFlyStep;
     ui32 GcNextStep;
+    TEvTablet::TEvGcForStepAckRequest::TPtr GcForStepAckRequest;
     TResourceProfilesPtr ResourceProfiles;
     TSharedQuotaPtr TxCacheQuota;
     THolder<NTracing::ITrace> IntrospectionTrace;
@@ -314,6 +315,8 @@ class TTablet : public TActor<TTablet> {
 
     void Handle(TEvBlobStorage::TEvCollectGarbageResult::TPtr &ev);
     void Handle(TEvTablet::TEvPreCommit::TPtr &ev);
+
+    void Handle(TEvTablet::TEvGcForStepAckRequest::TPtr& ev);
 
     void Handle(TEvTablet::TEvCommit::TPtr &ev);
     bool HandleNext(TEvTablet::TEvCommit::TPtr &ev);
@@ -533,6 +536,7 @@ class TTablet : public TActor<TTablet> {
             hFunc(TEvInterconnect::TEvNodeDisconnected, HandleByLeader);
             hFunc(TEvents::TEvUndelivered, HandleByLeader);
             hFunc(TEvBlobStorage::TEvCollectGarbageResult, Handle);
+            hFunc(TEvTablet::TEvGcForStepAckRequest, Handle);
         }
     }
 

--- a/ydb/core/tablet_flat/flat_executor.cpp
+++ b/ydb/core/tablet_flat/flat_executor.cpp
@@ -446,6 +446,7 @@ void TExecutor::Active(const TActorContext &ctx) {
 
     CompactionLogic = THolder<TCompactionLogic>(new TCompactionLogic(MemTableMemoryConsumersCollection.Get(), Logger.Get(), Broker.Get(), this, loadedState->Comp,
                                                                      Sprintf("tablet-%" PRIu64, Owner->TabletID())));
+    DataCleanupLogic = MakeHolder<TDataCleanupLogic>(static_cast<NActors::IActorOps*>(this), this, Owner, Logger.Get());
     LogicRedo->InstallCounters(Counters.Get(), nullptr);
 
     ResourceMetrics = MakeHolder<NMetrics::TResourceMetrics>(Owner->TabletID(), 0, Launcher);
@@ -729,6 +730,7 @@ TExecutorCaches TExecutor::CleanupState() {
     Y_ABORT_UNLESS(!LogicAlter);
     Y_ABORT_UNLESS(!CompactionLogic);
     BorrowLogic.Destroy();
+    DataCleanupLogic.Destroy();
 
     return caches;
 }
@@ -911,6 +913,9 @@ void TExecutor::CheckCollectionBarrier(TIntrusivePtr<TBarrier> &barrier) {
             if (Owner) {
                 Owner->CompletedLoansChanged(OwnerCtx());
             }
+        }
+        if (DataCleanupLogic->NeedGC(TGCTime(Generation(), barrier->Step), TGCTime(Generation(), GcLogic->GetActiveGcBarrier()))) {
+            GcLogic->SendCollectGarbage(ActorContext());
         }
     }
 
@@ -1327,6 +1332,14 @@ void TExecutor::Handle(TEvBlobStorage::TEvGetResult::TPtr& ev, const TActorConte
     }
 }
 
+void TExecutor::Handle(TEvTablet::TEvGcForStepAckResponse::TPtr &ev) {
+    if (ev->Get()->Generation != Generation()) {
+        return;
+    }
+
+    DataCleanupLogic->OnGcForStepAckResponse(ev->Get()->Step, OwnerCtx());
+}
+
 void TExecutor::AdvancePendingPartSwitches() {
     while (PendingPartSwitches && ApplyReadyPartSwitches()) {
         if (Stats->IsFollower()) {
@@ -1338,6 +1351,11 @@ void TExecutor::AdvancePendingPartSwitches() {
     if (PendingPartSwitches.empty()) {
         PlanTransactionActivation();
         MaybeRelaxRejectProbability();
+
+        // followers haven't DataCleanupLogic
+        if (DataCleanupLogic && DataCleanupLogic->NeedLogSnaphot()) {
+            MakeLogSnapshot();
+        }
     }
 }
 
@@ -2643,6 +2661,7 @@ void TExecutor::MakeLogSnapshot() {
     BorrowLogic->SnapToLog(snap, *commit);
     GcLogic->SnapToLog(snap, commit->Step);
     LogicSnap->MakeSnap(snap, *commit, Logger.Get());
+    DataCleanupLogic->OnMakeLogSnapshot(Generation(), commit->Step, commit->GcDelta);
 
     AttachLeaseCommit(commit.Get(), /* force */ true);
     CommitManager->Commit(commit);
@@ -2936,7 +2955,8 @@ void TExecutor::Handle(TEvTablet::TEvCommitResult::TPtr &ev, const TActorContext
     case ECommit::Snap:
         LogicSnap->Confirm(msg->Step);
 
-        if (NeedFollowerSnapshot)
+        DataCleanupLogic->OnSnapshotCommited(step, ctx);
+        if (NeedFollowerSnapshot || DataCleanupLogic->NeedLogSnaphot())
             MakeLogSnapshot();
 
         break;
@@ -2973,6 +2993,8 @@ void TExecutor::Handle(TEvTablet::TEvCommitResult::TPtr &ev, const TActorContext
 
 void TExecutor::Handle(TEvBlobStorage::TEvCollectGarbageResult::TPtr &ev) {
     GcLogic->OnCollectGarbageResult(ev);
+    auto channel = ev->Get()->Channel;
+    DataCleanupLogic->OnCollectedGarbage(channel, GcLogic->GetCommitedGcBarrier(channel), OwnerCtx());
 }
 
 void TExecutor::Handle(TEvResourceBroker::TEvResourceAllocated::TPtr &ev) {
@@ -3488,6 +3510,8 @@ void TExecutor::Handle(NOps::TEvResult *ops, TProdCompact *msg, bool cancelled) 
 
     Y_ABORT_UNLESS(InFlyCompactionGcBarriers.emplace(commit->Step, ops->Barrier).second);
 
+    DataCleanupLogic->OnCompleteCompaction(Generation(), commit->Step, tableId, CompactionLogic->GetFinishedCompactionInfo(tableId), commit->GcDelta);
+
     AttachLeaseCommit(commit.Get());
     CommitManager->Commit(commit);
 
@@ -3519,7 +3543,7 @@ void TExecutor::Handle(NOps::TEvResult *ops, TProdCompact *msg, bool cancelled) 
 
     activeTransaction.Done();
 
-    if (LogicSnap->MayFlush(false)) {
+    if (LogicSnap->MayFlush(false) || DataCleanupLogic->NeedLogSnaphot()) {
         MakeLogSnapshot();
     }
 }
@@ -3881,6 +3905,19 @@ bool TExecutor::CompactTables() {
     }
 }
 
+void TExecutor::CleanupData() {
+    if (DataCleanupLogic->TryStartCleanup(GcLogic->GetCommitedGcBarriers())) {
+        if (Scheme().Tables.empty()) {
+            DataCleanupLogic->OnNoTables(OwnerCtx());
+            return;
+        }
+        for (const auto& [tableId, _] : Scheme().Tables) {
+            auto compactionId = CompactionLogic->PrepareForceCompaction(tableId);
+            DataCleanupLogic->OnCompactionPrepared(tableId, compactionId);
+        }
+    }
+}
+
 void TExecutor::Handle(NMemory::TEvMemTableRegistered::TPtr &ev) {
     const auto *msg = ev->Get();
 
@@ -3945,6 +3982,7 @@ STFUNC(TExecutor::StateWork) {
         HFunc(NBlockIO::TEvStat, Handle);
         hFunc(NMemory::TEvMemTableRegistered, Handle);
         hFunc(NMemory::TEvMemTableCompact, Handle);
+        hFunc(TEvTablet::TEvGcForStepAckResponse, Handle);
     default:
         break;
     }

--- a/ydb/core/tablet_flat/flat_executor.h
+++ b/ydb/core/tablet_flat/flat_executor.h
@@ -14,6 +14,7 @@
 #include "flat_exec_commit.h"
 #include "flat_executor_misc.h"
 #include "flat_executor_compaction_logic.h"
+#include "flat_executor_data_cleanup_logic.h"
 #include "flat_executor_gclogic.h"
 #include "flat_bio_events.h"
 #include "flat_bio_stats.h"
@@ -434,6 +435,7 @@ class TExecutor
     THolder<TExecutorGCLogic> GcLogic;
     THolder<TCompactionLogic> CompactionLogic;
     THolder<TExecutorBorrowLogic> BorrowLogic;
+    THolder<TDataCleanupLogic> DataCleanupLogic;
 
     TLoadBlobQueue PendingBlobQueue;
 
@@ -563,6 +565,7 @@ class TExecutor
     void Handle(NBlockIO::TEvStat::TPtr &ev, const TActorContext &ctx);
     void Handle(NOps::TEvResult *ops, TProdCompact *msg, bool cancelled);
     void Handle(TEvBlobStorage::TEvGetResult::TPtr&, const TActorContext&);
+    void Handle(TEvTablet::TEvGcForStepAckResponse::TPtr &ev);
 
     void UpdateUsedTabletMemory();
     void UpdateCounters(const TActorContext &ctx);
@@ -636,6 +639,8 @@ public:
     ui64 CompactMemTable(ui32 tableId) override;
     ui64 CompactTable(ui32 tableId) override;
     bool CompactTables() override;
+
+    void CleanupData() override;
 
     void Handle(NMemory::TEvMemTableRegistered::TPtr &ev);
     void Handle(NMemory::TEvMemTableCompact::TPtr &ev);

--- a/ydb/core/tablet_flat/flat_executor_data_cleanup_logic.cpp
+++ b/ydb/core/tablet_flat/flat_executor_data_cleanup_logic.cpp
@@ -1,0 +1,163 @@
+#include "flat_executor_data_cleanup_logic.h"
+
+namespace NKikimr::NTabletFlatExecutor {
+
+TDataCleanupLogic::TDataCleanupLogic(IOps* ops, IExecutor* executor, ITablet* owner, NUtil::ILogger* logger)
+    : Ops(ops)
+    , Executor(executor)
+    , Owner(owner)
+    , Logger(logger)
+{}
+
+bool TDataCleanupLogic::TryStartCleanup(const THashMap<ui32, TGCTime>& commitedGcBarriers) {
+    if (State == EDataCleanupState::Idle) {
+        if (auto logl = Logger->Log(ELnLev::Info)) {
+            logl << "TDataCleanupLogic: Starting DataCleanup for tablet with id " << Owner->TabletID();
+        }
+        for (const auto& [channel, barrier] : commitedGcBarriers) {
+            // init WriteEdge to the latest known commited GC barrier,
+            // so we won't wait infinitly if there is no subsequent writes
+            ChannelsGCInfo[channel] = {barrier, barrier};
+        }
+        State = EDataCleanupState::PendingCompaction;
+        return true;
+    } else {
+        if (auto logl = Logger->Log(ELnLev::Info)) {
+            logl << "TDataCleanupLogic: schedule next DataCleanup for tablet with id " << Owner->TabletID();
+        }
+        StartNextCleanup = true;
+        return false;
+    }
+}
+
+void TDataCleanupLogic::OnNoTables(const TActorContext& ctx) {
+    Y_ABORT_UNLESS(State == EDataCleanupState::PendingCompaction && Tables.empty());
+    CompleteDataCleanup(ctx);
+}
+
+void TDataCleanupLogic::OnCompactionPrepared(ui32 tableId, ui64 compactionId) {
+    Y_ABORT_UNLESS(State == EDataCleanupState::PendingCompaction);
+    Tables[tableId] = {tableId, compactionId};
+}
+
+void TDataCleanupLogic::OnCompleteCompaction(
+    ui32 generation,
+    ui32 step,
+    ui32 tableId,
+    const TFinishedCompactionInfo& finishedCompactionInfo,
+    const TGCBlobDelta& gcDelta)
+{
+    if (State != EDataCleanupState::PendingCompaction) {
+        return;
+    }
+
+    if (auto* table = Tables.FindPtr(tableId)) {
+        if (finishedCompactionInfo.Edge >= table->CompactionId) {
+            table->CompactionCompleted = true;
+            UpdateWriteEdges(TGCTime(generation, step), gcDelta);
+        }
+    }
+    if (AllOf(Tables, [](const auto& t) { return t.second.CompactionCompleted; })) {
+        State = EDataCleanupState::PendingFirstSnapshot;
+        Tables.clear();
+    }
+}
+
+bool TDataCleanupLogic::NeedLogSnaphot() {
+    return State == EDataCleanupState::PendingFirstSnapshot && !FirstLogSnaphotStep
+        || State == EDataCleanupState::PendingSecondSnapshot && !SecondLogSnaphotStep;
+}
+
+void TDataCleanupLogic::OnMakeLogSnapshot(ui32 generation, ui32 step, const TGCBlobDelta& gcDelta) {
+    if (State == EDataCleanupState::PendingFirstSnapshot && !FirstLogSnaphotStep) {
+        FirstLogSnaphotStep = step;
+        UpdateWriteEdges(TGCTime(generation, step), gcDelta);
+        if (!GcForStepAckRequested) {
+            Ops->Send(Owner->Tablet(), new TEvTablet::TEvGcForStepAckRequest(generation, *FirstLogSnaphotStep));
+            GcForStepAckRequested = true;
+        }
+    } else if (State == EDataCleanupState::PendingSecondSnapshot && !SecondLogSnaphotStep) {
+        SecondLogSnaphotStep = step;
+    }
+}
+
+void TDataCleanupLogic::OnSnapshotCommited(ui32 step, const TActorContext& ctx) {
+    if (State == EDataCleanupState::PendingFirstSnapshot && FirstLogSnaphotStep && *FirstLogSnaphotStep <= step) {
+        State = EDataCleanupState::PendingSecondSnapshot;
+    }
+    if (State == EDataCleanupState::PendingSecondSnapshot && SecondLogSnaphotStep && *SecondLogSnaphotStep <= step) {
+        State = EDataCleanupState::PendingGCs;
+    }
+    if (State == EDataCleanupState::PendingGCs && CheckGCsSteps()) {
+        CompleteDataCleanup(ctx);
+    }
+}
+
+void TDataCleanupLogic::OnCollectedGarbage(ui32 channel, TGCTime commitedGcBarrier, const TActorContext& ctx) {
+    if (auto* info = ChannelsGCInfo.FindPtr(channel)) {
+        info->CommitedGcBarrier = commitedGcBarrier;
+    }
+    if (State == EDataCleanupState::PendingGCs && CheckGCsSteps()) {
+        CompleteDataCleanup(ctx);
+    }
+}
+
+void TDataCleanupLogic::OnGcForStepAckResponse(ui32 step, const TActorContext& ctx) {
+    GcLogSnaphotStep = step;
+    if (State == EDataCleanupState::PendingGCs && CheckGCsSteps()) {
+        CompleteDataCleanup(ctx);
+    }
+}
+
+bool TDataCleanupLogic::NeedGC(TGCTime releasedBarrier, TGCTime activeBarrier) {
+    if (State == EDataCleanupState::PendingSecondSnapshot || State == EDataCleanupState::PendingGCs) {
+        bool needGC = false;
+        for (const auto& [_, info] : ChannelsGCInfo) {
+            needGC = needGC || (
+                info.CommitedGcBarrier < info.WriteEdge &&
+                releasedBarrier <= info.WriteEdge &&
+                info.WriteEdge <= activeBarrier
+            );
+        }
+        return needGC;
+    }
+    return false;
+}
+
+void TDataCleanupLogic::CompleteDataCleanup(const TActorContext& ctx) {
+    Owner->DataCleanupComplete(ctx);
+    if (auto logl = Logger->Log(ELnLev::Info)) {
+        logl << "TDataCleanupLogic: DataCleanup finished for tablet with id " << Owner->TabletID();
+    }
+    State = EDataCleanupState::Idle;
+    FirstLogSnaphotStep = Nothing();
+    SecondLogSnaphotStep = Nothing();
+    ChannelsGCInfo.clear();
+    GcLogSnaphotStep = Nothing();
+    GcForStepAckRequested = false;
+    if (StartNextCleanup) {
+        StartNextCleanup = false;
+        Executor->CleanupData();
+    }
+}
+
+bool TDataCleanupLogic::CheckGCsSteps() {
+    bool completed = FirstLogSnaphotStep && GcLogSnaphotStep && *FirstLogSnaphotStep <= *GcLogSnaphotStep;
+    for (const auto& [_, info] : ChannelsGCInfo) {
+        completed = completed && info.WriteEdge <= info.CommitedGcBarrier;
+    }
+    return completed;
+}
+
+void TDataCleanupLogic::UpdateWriteEdges(TGCTime commitTime, const TGCBlobDelta& gcDelta) {
+    for (const auto& blobId : gcDelta.Created) {
+        auto& info = ChannelsGCInfo[blobId.Channel()];
+        info.WriteEdge = Max(info.WriteEdge, TGCTime(blobId.Generation(), blobId.Step()));
+    }
+    for (const auto& blobId : gcDelta.Deleted) {
+        auto& info = ChannelsGCInfo[blobId.Channel()];
+        info.WriteEdge = Max(info.WriteEdge, commitTime);
+    }
+}
+
+} // namespace NKikimr::NTabletFlatExecutor

--- a/ydb/core/tablet_flat/flat_executor_data_cleanup_logic.h
+++ b/ydb/core/tablet_flat/flat_executor_data_cleanup_logic.h
@@ -1,0 +1,78 @@
+#pragma once
+
+#include "tablet_flat_executor.h"
+#include "flat_executor_gclogic.h"
+#include "util_fmt_logger.h"
+
+namespace NKikimr::NTabletFlatExecutor {
+
+enum class EDataCleanupState {
+    Idle,
+    PendingCompaction,
+    PendingFirstSnapshot,
+    PendingSecondSnapshot,
+    PendingGCs,
+};
+
+struct TCleanupTableInfo {
+    ui32 TableId = Max<ui32>();
+    ui64 CompactionId = 0;
+    bool CompactionCompleted = false;
+};
+
+struct TCleanupChannesInfo {
+    TGCTime WriteEdge;
+    TGCTime CommitedGcBarrier;
+};
+
+class TDataCleanupLogic {
+public:
+    using IOps = NActors::IActorOps;
+    using IExecutor = NFlatExecutorSetup::IExecutor;
+    using ITablet = NFlatExecutorSetup::ITablet;
+    using ELnLev = NUtil::ELnLev;
+
+    TDataCleanupLogic(IOps* ops, IExecutor* executor, ITablet* owner, NUtil::ILogger* Logger);
+
+    bool TryStartCleanup(const THashMap<ui32, TGCTime>& commitedGcBarriers);
+    void OnNoTables(const TActorContext& ctx);
+    void OnCompactionPrepared(ui32 tableId, ui64 compactionId);
+    void OnCompleteCompaction(
+        ui32 generation,
+        ui32 step,
+        ui32 tableId,
+        const TFinishedCompactionInfo& finishedCompactionInfo,
+        const TGCBlobDelta& gcDelta);
+    bool NeedLogSnaphot();
+    void OnMakeLogSnapshot(ui32 generation, ui32 step, const TGCBlobDelta& gcDelta);
+    void OnSnapshotCommited(ui32 step, const TActorContext& ctx);
+    void OnCollectedGarbage(ui32 channel, TGCTime commitedGcBarrier, const TActorContext& ctx);
+    void OnGcForStepAckResponse(ui32 step, const TActorContext& ctx);
+    bool NeedGC(TGCTime releasedBarrier, TGCTime activeBarrier);
+
+private:
+    void CompleteDataCleanup(const TActorContext& ctx);
+    bool CheckGCsSteps();
+    void UpdateWriteEdges(TGCTime commitTime, const TGCBlobDelta& gcDelta);
+
+private:
+    IOps* Ops;
+    IExecutor* Executor;
+    ITablet* Owner;
+    NUtil::ILogger* const Logger;
+
+    EDataCleanupState State = EDataCleanupState::Idle;
+    bool StartNextCleanup = false;
+    THashMap<ui32, TCleanupTableInfo> Tables; // tracks statuses of compaction
+
+    // tracks commited GC barriers and writes of upcoming compactions and snapshots per channel
+    THashMap<ui32, TCleanupChannesInfo> ChannelsGCInfo;
+
+    // two subsequent are snapshots required to force GC
+    TMaybe<ui32> FirstLogSnaphotStep = Nothing(); // snapshot requested if not empty
+    TMaybe<ui32> SecondLogSnaphotStep = Nothing(); // snapshot requested if not empty
+    bool GcForStepAckRequested = false;
+    TMaybe<ui32> GcLogSnaphotStep = Nothing();
+};
+
+} // NKikimr::NTabletFlatExecutor

--- a/ydb/core/tablet_flat/flat_executor_data_cleanup_logic.h
+++ b/ydb/core/tablet_flat/flat_executor_data_cleanup_logic.h
@@ -6,26 +6,25 @@
 
 namespace NKikimr::NTabletFlatExecutor {
 
-enum class EDataCleanupState {
-    Idle,
-    PendingCompaction,
-    PendingFirstSnapshot,
-    PendingSecondSnapshot,
-    PendingGCs,
-};
-
-struct TCleanupTableInfo {
-    ui32 TableId = Max<ui32>();
-    ui64 CompactionId = 0;
-    bool CompactionCompleted = false;
-};
-
-struct TCleanupChannesInfo {
-    TGCTime WriteEdge;
-    TGCTime CommitedGcBarrier;
-};
-
 class TDataCleanupLogic {
+    enum class EDataCleanupState {
+        Idle,
+        PendingCompaction,
+        PendingFirstSnapshot,
+        PendingSecondSnapshot,
+        PendingGCs,
+    };
+
+    struct TCleanupTableInfo {
+        ui32 TableId = Max<ui32>();
+        ui64 CompactionId = 0;
+    };
+
+    struct TCleanupChannesInfo {
+        TGCTime WriteEdge;
+        TGCTime CommitedGcBarrier;
+    };
+
 public:
     using IOps = NActors::IActorOps;
     using IExecutor = NFlatExecutorSetup::IExecutor;
@@ -63,7 +62,7 @@ private:
 
     EDataCleanupState State = EDataCleanupState::Idle;
     bool StartNextCleanup = false;
-    THashMap<ui32, TCleanupTableInfo> Tables; // tracks statuses of compaction
+    THashMap<ui32, TCleanupTableInfo> CompactingTables; // tracks statuses of compaction
 
     // tracks commited GC barriers and writes of upcoming compactions and snapshots per channel
     THashMap<ui32, TCleanupChannesInfo> ChannelsGCInfo;

--- a/ydb/core/tablet_flat/flat_executor_gclogic.cpp
+++ b/ydb/core/tablet_flat/flat_executor_gclogic.cpp
@@ -160,14 +160,6 @@ void TExecutorGCLogic::FollowersSyncComplete(bool isBoot) {
     AllowGarbageCollection = true;
 }
 
-TGCTime TExecutorGCLogic::GetCommitedGcBarrier(ui32 channel) {
-    if (const auto* info = ChannelInfo.FindPtr(channel)) {
-        return info->CommitedGcBarrier;
-    } else {
-        return TGCTime();
-    }
-}
-
 void TExecutorGCLogic::ApplyDelta(TGCTime time, TGCBlobDelta &delta) {
     for (const TLogoBlobID &blobId : delta.Created) {
         auto &channel = ChannelInfo[blobId.Channel()];

--- a/ydb/core/tablet_flat/flat_executor_gclogic.cpp
+++ b/ydb/core/tablet_flat/flat_executor_gclogic.cpp
@@ -160,6 +160,14 @@ void TExecutorGCLogic::FollowersSyncComplete(bool isBoot) {
     AllowGarbageCollection = true;
 }
 
+TGCTime TExecutorGCLogic::GetCommitedGcBarrier(ui32 channel) {
+    if (const auto* info = ChannelInfo.FindPtr(channel)) {
+        return info->CommitedGcBarrier;
+    } else {
+        return TGCTime();
+    }
+}
+
 void TExecutorGCLogic::ApplyDelta(TGCTime time, TGCBlobDelta &delta) {
     for (const TLogoBlobID &blobId : delta.Created) {
         auto &channel = ChannelInfo[blobId.Channel()];
@@ -172,6 +180,14 @@ void TExecutorGCLogic::ApplyDelta(TGCTime time, TGCBlobDelta &delta) {
         auto &channel = ChannelInfo[blobId.Channel()];
         channel.CommittedDelta[time].Deleted.push_back(blobId);
     }
+}
+
+THashMap<ui32, TGCTime> TExecutorGCLogic::GetCommitedGcBarriers() {
+    THashMap<ui32, TGCTime> result;
+    for (const auto& [channel, info] : ChannelInfo) {
+        result[channel] = info.CommitedGcBarrier;
+    }
+    return result;
 }
 
 void TExecutorGCLogic::SendCollectGarbage(const TActorContext& ctx) {

--- a/ydb/core/tablet_flat/flat_executor_gclogic.h
+++ b/ydb/core/tablet_flat/flat_executor_gclogic.h
@@ -49,6 +49,9 @@ public:
     void ReleaseBarrier(ui32 step);
     ui32 GetActiveGcBarrier();
     void FollowersSyncComplete(bool isBoot);
+    TGCTime GetCommitedGcBarrier(ui32 channel);
+    void SendCollectGarbage(const TActorContext& executor);
+    THashMap<ui32, TGCTime> GetCommitedGcBarriers();
 
     struct TIntrospection {
         ui64 UncommitedEntries;
@@ -105,7 +108,6 @@ protected:
     bool AllowGarbageCollection;
 
     void ApplyDelta(TGCTime time, TGCBlobDelta &delta);
-    void SendCollectGarbage(const TActorContext& executor);
     static inline void MergeVectors(THolder<TVector<TLogoBlobID>>& destination, const TVector<TLogoBlobID>& source);
     static inline void MergeVectors(TVector<TLogoBlobID>& destination, const TVector<TLogoBlobID>& source);
     static inline TVector<TLogoBlobID>* CreateVector(const TVector<TLogoBlobID>& source);

--- a/ydb/core/tablet_flat/flat_executor_gclogic.h
+++ b/ydb/core/tablet_flat/flat_executor_gclogic.h
@@ -51,7 +51,7 @@ public:
     void FollowersSyncComplete(bool isBoot);
     TGCTime GetCommitedGcBarrier(ui32 channel);
     void SendCollectGarbage(const TActorContext& executor);
-    THashMap<ui32, TGCTime> GetCommitedGcBarriers();
+    bool HasGarbageBefore(TGCTime snapshotTime);
 
     struct TIntrospection {
         ui64 UncommitedEntries;
@@ -87,6 +87,7 @@ protected:
         TGCTime CollectSent;
         TGCTime KnownGcBarrier;
         TGCTime CommitedGcBarrier;
+        TGCTime MinUncollectedTime;
         ui32 GcCounter;
         ui32 GcWaitFor;
 

--- a/ydb/core/tablet_flat/flat_executor_gclogic.h
+++ b/ydb/core/tablet_flat/flat_executor_gclogic.h
@@ -49,7 +49,6 @@ public:
     void ReleaseBarrier(ui32 step);
     ui32 GetActiveGcBarrier();
     void FollowersSyncComplete(bool isBoot);
-    TGCTime GetCommitedGcBarrier(ui32 channel);
     void SendCollectGarbage(const TActorContext& executor);
     bool HasGarbageBefore(TGCTime snapshotTime);
 

--- a/ydb/core/tablet_flat/flat_executor_ut.cpp
+++ b/ydb/core/tablet_flat/flat_executor_ut.cpp
@@ -445,6 +445,10 @@ class TTestFlatTablet : public TActor<TTestFlatTablet>, public TTabletExecutedFl
         Send(Sender, new NFake::TEvCompacted(table));
     }
 
+    void DataCleanupComplete(const TActorContext&) override {
+        Send(Sender, new NFake::TEvDataCleaned());
+    }
+
     void ScanComplete(NTable::EAbort, TAutoPtr<IDestructable>, ui64 cookie, const TActorContext&) override
     {
         UNIT_ASSERT_VALUES_EQUAL(cookie, ScanCookie);

--- a/ydb/core/tablet_flat/flat_executor_ut.cpp
+++ b/ydb/core/tablet_flat/flat_executor_ut.cpp
@@ -6549,8 +6549,8 @@ Y_UNIT_TEST_SUITE(TFlatTableExecutor_Reboot) {
         IActor *tabletActor = nullptr; // save tablet to get its actor id and avoid using tablet resolver which has outdated info
         while (true) {
             struct TReassignedStarter : NFake::TStarter {
-                NFake::TStorageInfo* MakeTabletInfo(ui64 tablet) noexcept override {
-                    auto *info = TStarter::MakeTabletInfo(tablet);
+                NFake::TStorageInfo* MakeTabletInfo(ui64 tablet, ui32 channelsCount) noexcept override {
+                    auto *info = TStarter::MakeTabletInfo(tablet, channelsCount);
                     info->Channels[1].History.emplace_back(3, 3);
                     return info;
                 }

--- a/ydb/core/tablet_flat/flat_executor_ut_common.h
+++ b/ydb/core/tablet_flat/flat_executor_ut_common.h
@@ -93,13 +93,19 @@ namespace NTabletFlatExecutor {
             Env.SendToPipe(Tablet, Edge, event, 0, config);
         }
 
+        void RestartTablet(ui32 flags = 0)
+        {
+            SendSync(new TEvents::TEvPoison, false, true);
+            FireDummyTablet(flags);
+        }
+
         void WaitForWakeUp(size_t num = 1) { WaitFor<TEvents::TEvWakeup>(num); }
         void WaitForGone(size_t num = 1) { WaitFor<TEvents::TEvGone>(num); }
 
         template<typename TEv>
-        typename TEv::TPtr GrabEdgeEvent()
+        typename TEv::TPtr GrabEdgeEvent(TDuration timeout = TDuration::Max())
         {
-            return Env.GrabEdgeEventRethrow<TEv>(Edge);
+            return Env.GrabEdgeEventRethrow<TEv>(Edge, timeout);
         }
 
         template<typename TEv>

--- a/ydb/core/tablet_flat/flat_executor_ut_common.h
+++ b/ydb/core/tablet_flat/flat_executor_ut_common.h
@@ -116,6 +116,11 @@ namespace NTabletFlatExecutor {
             Env.Send(new IEventHandle(to, Edge, ev));
         }
 
+        void SendEvToBSProxy(ui32 groupId, IEventBase *ev)
+        {
+            Env.Send(CreateEventForBSProxy(Edge, groupId, ev, 0));
+        }
+
         static NTabletPipe::TClientConfig PipeCfgRetries()
         {
             NTabletPipe::TClientConfig pipeConfig;

--- a/ydb/core/tablet_flat/tablet_flat_executor.cpp
+++ b/ydb/core/tablet_flat/tablet_flat_executor.cpp
@@ -20,6 +20,10 @@ namespace NFlatExecutorSetup {
         Y_UNUSED(ctx);
     }
 
+    void ITablet::DataCleanupComplete(const TActorContext& ctx) {
+        Y_UNUSED(ctx);
+    }
+
     void ITablet::CompletedLoansChanged(const TActorContext &ctx) {
         Y_UNUSED(ctx);
     }

--- a/ydb/core/tablet_flat/tablet_flat_executor.h
+++ b/ydb/core/tablet_flat/tablet_flat_executor.h
@@ -498,6 +498,7 @@ namespace NFlatExecutorSetup {
         virtual void SnapshotComplete(TIntrusivePtr<TTableSnapshotContext> snapContext, const TActorContext &ctx); // would be FAIL in default implementation
         virtual void CompletedLoansChanged(const TActorContext &ctx); // would be no-op in default implementation
         virtual void CompactionComplete(ui32 tableId, const TActorContext &ctx); // would be no-op in default implementation
+        virtual void DataCleanupComplete(const TActorContext& ctx);
 
         virtual void ScanComplete(NTable::EAbort status, TAutoPtr<IDestructable> prod, ui64 cookie, const TActorContext &ctx);
 
@@ -630,6 +631,8 @@ namespace NFlatExecutorSetup {
         virtual const NTable::TScheme& Scheme() const noexcept = 0;
 
         virtual void SetPreloadTablesData(THashSet<ui32> tables) = 0;
+
+        virtual void CleanupData() = 0;
 
         ui32 Generation() const { return Generation0; }
         ui32 Step() const { return Step0; }

--- a/ydb/core/tablet_flat/test/libs/exec/dummy.h
+++ b/ydb/core/tablet_flat/test/libs/exec/dummy.h
@@ -30,6 +30,7 @@ namespace NFake {
 
         enum class EFlg : ui32 {
             Comp    = 0x01,
+            Clean   = 0x02,
         };
 
         TDummy(const TActorId &tablet, TInfo *info, const TActorId& owner,
@@ -121,6 +122,12 @@ namespace NFake {
         {
             if (Flags & ui32(EFlg::Comp))
                 Send(Owner, new NFake::TEvCompacted(table));
+        }
+
+        void DataCleanupComplete(const TActorContext&) override
+        {
+            if (Flags & ui32(EFlg::Clean))
+                Send(Owner, new NFake::TEvDataCleaned());
         }
 
         void SnapshotComplete(

--- a/ydb/core/tablet_flat/test/libs/exec/events.h
+++ b/ydb/core/tablet_flat/test/libs/exec/events.h
@@ -22,6 +22,8 @@ namespace NFake {
         EvCompact   = Base_ + 15,
         EvCall      = Base_ + 16,
         EvDataCleaned = Base_ + 17,
+        EvBlobStorageContainsRequest = Base_ + 18,
+        EvBlobStorageContainsResponse = Base_ + 19,
     };
 
     struct TEvTerm : public TEventLocal<TEvTerm, EvTerm> { };
@@ -96,6 +98,22 @@ namespace NFake {
         TEvCall(TCallback callback) : Callback(std::move(callback)) { }
 
         TCallback Callback;
+    };
+
+    struct TEvBlobStorageContainsRequest :  public TEventLocal<TEvBlobStorageContainsRequest, EvBlobStorageContainsRequest> {
+        TEvBlobStorageContainsRequest(TVector<TString> values)
+            : Values(std::move(values))
+        { }
+
+        const TVector<TString> Values;
+    };
+
+    struct TEvBlobStorageContainsResponse :  public TEventLocal<TEvBlobStorageContainsResponse, EvBlobStorageContainsResponse> {
+        TEvBlobStorageContainsResponse(TVector<bool> contains)
+            : Contains(std::move(contains))
+        { }
+
+        const TVector<bool> Contains;
     };
 
 }

--- a/ydb/core/tablet_flat/test/libs/exec/events.h
+++ b/ydb/core/tablet_flat/test/libs/exec/events.h
@@ -24,6 +24,7 @@ namespace NFake {
         EvDataCleaned = Base_ + 17,
         EvBlobStorageContainsRequest = Base_ + 18,
         EvBlobStorageContainsResponse = Base_ + 19,
+        EvBlobStorageDeferGC = Base_ + 20,
     };
 
     struct TEvTerm : public TEventLocal<TEvTerm, EvTerm> { };
@@ -101,19 +102,33 @@ namespace NFake {
     };
 
     struct TEvBlobStorageContainsRequest :  public TEventLocal<TEvBlobStorageContainsRequest, EvBlobStorageContainsRequest> {
-        TEvBlobStorageContainsRequest(TVector<TString> values)
-            : Values(std::move(values))
+        TEvBlobStorageContainsRequest(TString value)
+            : Value(value)
         { }
 
-        const TVector<TString> Values;
+        const TString Value;
     };
 
     struct TEvBlobStorageContainsResponse :  public TEventLocal<TEvBlobStorageContainsResponse, EvBlobStorageContainsResponse> {
-        TEvBlobStorageContainsResponse(TVector<bool> contains)
+        struct TBlobInfo {
+            TLogoBlobID BlobId;
+            bool Keep;
+            bool DoNotKeep;
+        };
+
+        TEvBlobStorageContainsResponse(TVector<TBlobInfo> contains)
             : Contains(std::move(contains))
         { }
 
-        const TVector<bool> Contains;
+        const TVector<TBlobInfo> Contains;
+    };
+
+    struct TEvBlobStorageDeferGc : public TEventLocal<TEvBlobStorageDeferGc, EvBlobStorageDeferGC> {
+        TEvBlobStorageDeferGc(bool defer)
+            : Defer(defer)
+        { }
+
+        bool Defer;
     };
 
 }

--- a/ydb/core/tablet_flat/test/libs/exec/events.h
+++ b/ydb/core/tablet_flat/test/libs/exec/events.h
@@ -21,6 +21,7 @@ namespace NFake {
         EvCompacted = Base_ + 14,
         EvCompact   = Base_ + 15,
         EvCall      = Base_ + 16,
+        EvDataCleaned = Base_ + 17,
     };
 
     struct TEvTerm : public TEventLocal<TEvTerm, EvTerm> { };
@@ -75,6 +76,8 @@ namespace NFake {
 
         ui64 Table;
     };
+
+    struct TEvDataCleaned : public TEventLocal<TEvDataCleaned, EvDataCleaned> { };
 
     struct TEvCompact : public TEventLocal<TEvCompact, EvCompact> {
         TEvCompact(ui32 table, bool memOnly = false)

--- a/ydb/core/tablet_flat/test/libs/exec/helper.h
+++ b/ydb/core/tablet_flat/test/libs/exec/helper.h
@@ -11,17 +11,17 @@ namespace NFake {
     struct TStarter {
         using TMake = TTabletSetupInfo::TTabletCreationFunc;
 
-        IActor* Do(TActorId user, ui32 retry, ui32 tablet, TMake make, ui32 followerId = 0) noexcept
+        IActor* Do(TActorId user, ui32 retry, ui32 tablet, TMake make, ui32 channelsCount, ui32 followerId = 0) noexcept
         {
             const auto simple = TMailboxType::Simple;
 
-            auto *info = MakeTabletInfo(tablet);
+            auto *info = MakeTabletInfo(tablet, channelsCount);
             auto *setup = new TTabletSetupInfo(make, simple, 0, simple, 0);
 
             return new NFake::TOwner(user, retry, info, setup, followerId);
         }
 
-        virtual TStorageInfo* MakeTabletInfo(ui64 tablet) noexcept
+        virtual TStorageInfo* MakeTabletInfo(ui64 tablet, ui32 channelsCount) noexcept
         {
             const auto none = TErasureType::ErasureNone;
 
@@ -29,7 +29,7 @@ namespace NFake {
 
             info->TabletID = tablet;
             info->TabletType = TTabletTypes::Dummy;
-            info->Channels.resize(4);
+            info->Channels.resize(channelsCount);
 
             for (auto num: xrange(info->Channels.size())) {
                 info->Channels[num].Channel = num;

--- a/ydb/core/tablet_flat/test/libs/exec/nanny.h
+++ b/ydb/core/tablet_flat/test/libs/exec/nanny.h
@@ -180,7 +180,7 @@ namespace NFake {
                 return new NFake::TDummy(tablet, info, SelfId());
             };
 
-            auto *actor = TStarter().Do(SelfId(), 1, MyId, std::move(make));
+            auto *actor = TStarter().Do(SelfId(), 1, MyId, std::move(make), 4);
             auto *event = new TEvFire{ 7, { }, { actor, EMail::Simple, 0 } };
 
             Send(TWorld::Where(EPath::Root), event);

--- a/ydb/core/tablet_flat/test/libs/exec/runner.h
+++ b/ydb/core/tablet_flat/test/libs/exec/runner.h
@@ -69,7 +69,7 @@ namespace NFake {
                 starter = &defaultStarter;
             }
 
-            RunOn(7, { }, starter->Do(user, 1, tablet, std::move(make), followerId), mbx);
+            RunOn(7, { }, starter->Do(user, 1, tablet, std::move(make), StorageGroupCount, followerId), mbx);
         }
 
         void FireFollower(TActorId user, ui32 tablet, TStarter::TMake make, ui32 followerId)

--- a/ydb/core/tablet_flat/test/libs/exec/runner.h
+++ b/ydb/core/tablet_flat/test/libs/exec/runner.h
@@ -32,6 +32,7 @@ namespace NFake {
             , Names(MakeComponentsNames())
             , Sink(new TSink(false ? Time->Now() : TInstant::Now(), Names))
             , Logger(new TLogEnv(Time, ELnLev::Info, Sink))
+            , StorageGroupCount(4)
         {
             if (auto logl = Logger->Log(ELnLev::Info)) {
                 logl << "Born at "<< TInstant::Now();
@@ -169,7 +170,7 @@ namespace NFake {
         void SetupModelServices()
         {
             { /*_ Blob storage proxies mock factory */
-                auto *actor = new NFake::TWarden(4);
+                auto *actor = new NFake::TWarden(StorageGroupCount);
 
                 RunOn(2, MakeBlobStorageNodeWardenID(NodeId), actor, EMail::Simple);
             }
@@ -212,6 +213,7 @@ namespace NFake {
         const TVector<TString> Names;   /* { Component -> Name } */
         const TIntrusivePtr<TSink> Sink;
         const TAutoPtr<TLogEnv> Logger;
+        const ui32 StorageGroupCount;
 
     private:
         TActorId Leader;

--- a/ydb/core/tablet_flat/test/libs/exec/warden.h
+++ b/ydb/core/tablet_flat/test/libs/exec/warden.h
@@ -152,7 +152,8 @@ namespace NFake {
                 || ev == TEvBlobStorage::EvDiscover
                 || ev == TEvBlobStorage::EvRange
                 || ev == TEvBlobStorage::EvCollectGarbage
-                || ev == TEvBlobStorage::EvStatus;
+                || ev == TEvBlobStorage::EvStatus
+                || ev == NFake::EvBlobStorageContainsRequest;
         }
 
     public:

--- a/ydb/core/tablet_flat/test/libs/exec/warden.h
+++ b/ydb/core/tablet_flat/test/libs/exec/warden.h
@@ -153,7 +153,8 @@ namespace NFake {
                 || ev == TEvBlobStorage::EvRange
                 || ev == TEvBlobStorage::EvCollectGarbage
                 || ev == TEvBlobStorage::EvStatus
-                || ev == NFake::EvBlobStorageContainsRequest;
+                || ev == NFake::EvBlobStorageContainsRequest
+                || ev == NFake::EvBlobStorageDeferGC;
         }
 
     public:

--- a/ydb/core/tablet_flat/ut/ut_data_cleanup.cpp
+++ b/ydb/core/tablet_flat/ut/ut_data_cleanup.cpp
@@ -1,0 +1,279 @@
+#include "flat_executor_ut_common.h"
+
+#include <library/cpp/testing/unittest/registar.h>
+
+namespace NKikimr::NTable {
+
+using namespace NTabletFlatExecutor;
+
+enum : ui32  {
+    KeyColumnId = 1,
+    ValueColumnId = 2,
+};
+
+class TTxInitSchema : public ITransaction {
+public:
+    TTxInitSchema(const TVector<ui32>& tableIds)
+        : TableIds(tableIds)
+    { }
+
+    bool Execute(TTransactionContext& txc, const TActorContext&) override {
+        TCompactionPolicy policy;
+        policy.MinBTreeIndexNodeSize = 128;
+
+        for (const auto& tableId : TableIds) {
+            if (txc.DB.GetScheme().GetTableInfo(tableId)) {
+                continue;
+            }
+
+            txc.DB.Alter()
+                .AddTable("test" + ToString(tableId), tableId)
+                .AddColumn(tableId, "key", KeyColumnId, NScheme::TInt64::TypeId, false)
+                .AddColumn(tableId, "value", ValueColumnId, NScheme::TString::TypeId, false)
+                .AddColumnToKey(tableId, KeyColumnId)
+                .SetCompactionPolicy(tableId, policy);
+        }
+
+        return true;
+    }
+
+    void Complete(const TActorContext& ctx) override {
+        ctx.Send(ctx.SelfID, new NFake::TEvReturn);
+    }
+
+private:
+    const TVector<ui32> TableIds;
+};
+
+class TTxWriteRow : public ITransaction {
+public:
+    TTxWriteRow(ui32 tableId, i64 key, TString value)
+        : TableId(tableId)
+        , Key(key)
+        , Value(std::move(value))
+    { }
+
+    bool Execute(TTransactionContext& txc, const TActorContext&) override {
+        const auto key = NScheme::TInt64::TInstance(Key);
+
+        const auto val = NScheme::TString::TInstance(Value);
+        NTable::TUpdateOp ops{ ValueColumnId, NTable::ECellOp::Set, val };
+
+        txc.DB.Update(TableId, NTable::ERowOp::Upsert, { key }, { ops });
+        
+        return true;
+    }
+
+    void Complete(const TActorContext&ctx) override {
+        ctx.Send(ctx.SelfID, new NFake::TEvReturn);
+    }
+
+private:
+    ui32 TableId;
+    i64 Key;
+    TString Value;
+};
+
+class TTxDeleteRow : public ITransaction {
+public:
+    TTxDeleteRow(ui32 tableId, i64 key)
+        : TableId(tableId)
+        , Key(key)
+    { }
+
+    bool Execute(TTransactionContext& txc, const TActorContext&) override {
+        const auto key = NScheme::TInt64::TInstance(Key);
+
+        txc.DB.Update(TableId, NTable::ERowOp::Erase, { key }, {});
+        
+        return true;
+    }
+
+    void Complete(const TActorContext&ctx) override {
+        ctx.Send(ctx.SelfID, new NFake::TEvReturn);
+    }
+
+private:
+    ui32 TableId;
+    i64 Key;
+};
+
+class TTxFullScan : public ITransaction {
+public:
+    TTxFullScan(ui32 tableId, int& readRows)
+        : TableId(tableId)
+        , ReadRows(readRows)
+    {
+        ReadRows = 0;
+    }
+
+    bool Execute(TTransactionContext &txc, const TActorContext &) override
+    {
+        TVector<NTable::TTag> tags{ { KeyColumnId, ValueColumnId } };
+
+        auto iter = txc.DB.IterateRange(TableId, { }, tags);
+
+        ReadRows = 0;
+        while (iter->Next(ENext::Data) == EReady::Data) {
+            ReadRows++;
+        }
+
+        if (iter->Last() != EReady::Page) {
+            return true;
+        }
+
+        return false;
+    }
+
+    void Complete(const TActorContext &ctx) override
+    {
+        ctx.Send(ctx.SelfID, new NFake::TEvReturn);
+    }
+
+private:
+    ui32 TableId;
+    int& ReadRows;
+};
+
+Y_UNIT_TEST_SUITE(DataCleanup) {
+    Y_UNIT_TEST(CleanupDataNoTables) {
+        TMyEnvBase env;
+        env.FireDummyTablet(ui32(NFake::TDummy::EFlg::Clean));
+
+        env.SendSync(new NFake::TEvCall{ [](auto* executor, const auto& ctx) {
+            executor->CleanupData();
+            ctx.Send(ctx.SelfID, new NFake::TEvReturn);
+        } });
+
+        env.WaitFor<NFake::TEvDataCleaned>();
+    }
+
+    Y_UNIT_TEST(CleanupData) {
+        TMyEnvBase env;
+        env.FireDummyTablet(ui32(NFake::TDummy::EFlg::Clean));
+        env.SendSync(new NFake::TEvExecute{ new TTxInitSchema({ 101 }) });
+        env.SendSync(new NFake::TEvExecute{ new TTxWriteRow(101, 42, "Some_value") });
+        env.SendSync(new NFake::TEvExecute{ new TTxDeleteRow(101, 42) });
+
+        int readRows = 0;
+        env.SendSync(new NFake::TEvExecute{ new TTxFullScan(101, readRows) });
+        UNIT_ASSERT_EQUAL(readRows, 0);
+
+        env.SendSync(new NFake::TEvCall{ [](auto* executor, const auto& ctx) {
+            executor->CleanupData();
+            ctx.Send(ctx.SelfID, new NFake::TEvReturn);
+        } });
+
+        env.WaitFor<NFake::TEvDataCleaned>();
+    }
+
+    Y_UNIT_TEST(CleanupDataMultipleTables) {
+        TMyEnvBase env;
+        env.FireDummyTablet(ui32(NFake::TDummy::EFlg::Clean));
+        env.SendSync(new NFake::TEvExecute{ new TTxInitSchema({ 101, 102, 103 }) });
+        env.SendSync(new NFake::TEvExecute{ new TTxWriteRow(101, 42, "Some_value") });
+        env.SendSync(new NFake::TEvExecute{ new TTxWriteRow(102, 43, "Some_other_value") });
+        env.SendSync(new NFake::TEvExecute{ new TTxDeleteRow(101, 42) });
+        env.SendSync(new NFake::TEvExecute{ new TTxWriteRow(103, 44, "Some_another_value") });
+        env.SendSync(new NFake::TEvExecute{ new TTxDeleteRow(102, 43) });
+        env.SendSync(new NFake::TEvExecute{ new TTxDeleteRow(103, 44) });
+
+        int readRows = 0;
+        env.SendSync(new NFake::TEvExecute{ new TTxFullScan(101, readRows) });
+        UNIT_ASSERT_EQUAL(readRows, 0);
+        env.SendSync(new NFake::TEvExecute{ new TTxFullScan(102, readRows) });
+        UNIT_ASSERT_EQUAL(readRows, 0);
+        env.SendSync(new NFake::TEvExecute{ new TTxFullScan(103, readRows) });
+        UNIT_ASSERT_EQUAL(readRows, 0);
+
+        env.SendSync(new NFake::TEvCall{ [](auto* executor, const auto& ctx) {
+            executor->CleanupData();
+            ctx.Send(ctx.SelfID, new NFake::TEvReturn);
+        } });
+
+        env.WaitFor<NFake::TEvDataCleaned>();
+    }
+
+    Y_UNIT_TEST(CleanupDataWithFollowers) {
+        TMyEnvBase env;
+        env.FireDummyTablet(ui32(NFake::TDummy::EFlg::Clean));
+
+        env.FireDummyFollower(1);
+
+        env.SendSync(new NFake::TEvExecute{ new TTxInitSchema({ 101 }) });
+        env.SendSync(new NFake::TEvExecute{ new TTxWriteRow(101, 41, "Some_value_1") });
+        env.SendSync(new NFake::TEvExecute{ new TTxWriteRow(101, 42, "Some_value_2") });
+        env.SendSync(new NFake::TEvExecute{ new TTxDeleteRow(101, 41) });
+
+        env.FireDummyFollower(2);
+        env.SendSync(new NFake::TEvExecute{ new TTxWriteRow(101, 43, "Some_value_3") });
+        env.SendSync(new NFake::TEvExecute{ new TTxDeleteRow(101, 43) });
+        env.SendSync(new NFake::TEvExecute{ new TTxDeleteRow(101, 42) });
+
+        int readRows = 0;
+        env.SendSync(new NFake::TEvExecute{ new TTxFullScan(101, readRows) });
+        UNIT_ASSERT_EQUAL(readRows, 0);
+
+        env.SendSync(new NFake::TEvCall{ [](auto* executor, const auto& ctx) {
+            executor->CleanupData();
+            ctx.Send(ctx.SelfID, new NFake::TEvReturn);
+        } });
+
+        env.WaitFor<NFake::TEvDataCleaned>();
+    }
+
+    Y_UNIT_TEST(CleanupDataMultipleTimes) {
+        TMyEnvBase env;
+        env.FireDummyTablet(ui32(NFake::TDummy::EFlg::Clean));
+        env.SendSync(new NFake::TEvExecute{ new TTxInitSchema({ 101 }) });
+        env.SendSync(new NFake::TEvExecute{ new TTxWriteRow(101, 42, "Some_value_1") });
+        env.SendSync(new NFake::TEvExecute{ new TTxDeleteRow(101, 42) });
+
+        int readRows = 0;
+        env.SendSync(new NFake::TEvExecute{ new TTxFullScan(101, readRows) });
+        UNIT_ASSERT_EQUAL(readRows, 0);
+
+        env.SendSync(new NFake::TEvCall{ [](auto* executor, const auto& ctx) {
+            executor->CleanupData();
+            executor->CleanupData();
+            ctx.Send(ctx.SelfID, new NFake::TEvReturn);
+        } });
+
+        env.WaitFor<NFake::TEvDataCleaned>(2);
+
+        env.SendSync(new NFake::TEvExecute{ new TTxWriteRow(101, 43, "Some_value_2") });
+        env.SendSync(new NFake::TEvExecute{ new TTxDeleteRow(101, 43) });
+        env.SendSync(new NFake::TEvExecute{ new TTxFullScan(101, readRows) });
+        UNIT_ASSERT_EQUAL(readRows, 0);
+
+        env.SendAsync(new NFake::TEvCall{ [](auto* executor, const auto& ctx) {
+            executor->CleanupData();
+            ctx.Send(ctx.SelfID, new NFake::TEvReturn);
+        } });
+
+        env.SendAsync(new NFake::TEvCall{ [](auto* executor, const auto& ctx) {
+            executor->CleanupData();
+            ctx.Send(ctx.SelfID, new NFake::TEvReturn);
+        } });
+
+        env.WaitFor<NFake::TEvDataCleaned>(2);
+    }
+
+    Y_UNIT_TEST(CleanupDataEmptyTable) {
+        TMyEnvBase env;
+        env.FireDummyTablet(ui32(NFake::TDummy::EFlg::Clean));
+        env.SendSync(new NFake::TEvExecute{ new TTxInitSchema({ 101 }) });
+
+        int readRows = 0;
+        env.SendSync(new NFake::TEvExecute{ new TTxFullScan(101, readRows) });
+        UNIT_ASSERT_EQUAL(readRows, 0);
+
+        env.SendSync(new NFake::TEvCall{ [](auto* executor, const auto& ctx) {
+            executor->CleanupData();
+            ctx.Send(ctx.SelfID, new NFake::TEvReturn);
+        } });
+
+        env.WaitFor<NFake::TEvDataCleaned>();
+    }
+}
+} // namespace NKikimr::NTable

--- a/ydb/core/tablet_flat/ut/ut_data_cleanup.cpp
+++ b/ydb/core/tablet_flat/ut/ut_data_cleanup.cpp
@@ -9,12 +9,24 @@ using namespace NTabletFlatExecutor;
 enum : ui32  {
     KeyColumnId = 1,
     ValueColumnId = 2,
+    ValueFamily2ColumnId = 3,
+    ValueFamily3ColumnId = 4,
+};
+
+enum : ui32  {
+    FamilyId2Channel = 2,
+    FamilyId3Channel = 3,
+    RoomId2 = 102,
+    RoomId3 = 103,
+    FamilyId2 = 202,
+    FamilyId3 = 205,
 };
 
 class TTxInitSchema : public ITransaction {
 public:
-    TTxInitSchema(const TVector<ui32>& tableIds)
+    TTxInitSchema(const TVector<ui32>& tableIds, bool addColumnsInFamily = false)
         : TableIds(tableIds)
+        , AddColumnsInFamily(addColumnsInFamily)
     { }
 
     bool Execute(TTransactionContext& txc, const TActorContext&) override {
@@ -26,12 +38,28 @@ public:
                 continue;
             }
 
-            txc.DB.Alter()
+            auto alter = txc.DB.Alter()
                 .AddTable("test" + ToString(tableId), tableId)
                 .AddColumn(tableId, "key", KeyColumnId, NScheme::TInt64::TypeId, false)
                 .AddColumn(tableId, "value", ValueColumnId, NScheme::TString::TypeId, false)
                 .AddColumnToKey(tableId, KeyColumnId)
                 .SetCompactionPolicy(tableId, policy);
+
+            if (AddColumnsInFamily) {
+                txc.DB.Alter()
+                    .SetRoom(tableId, RoomId2, FamilyId2Channel, {FamilyId2Channel}, FamilyId2Channel)
+                    .AddFamily(tableId, FamilyId2, RoomId2)
+                    .SetFamily(tableId, FamilyId2, NTable::NPage::ECache::None, NTable::NPage::ECodec::Plain)
+                    .AddColumn(tableId, "value_family_2", ValueFamily2ColumnId, NScheme::TString::TypeId, false)
+                    .AddColumnToFamily(tableId, ValueFamily2ColumnId, FamilyId2);
+
+                txc.DB.Alter()
+                    .SetRoom(tableId, RoomId3, FamilyId3Channel, {FamilyId3Channel}, FamilyId3Channel)
+                    .AddFamily(tableId, FamilyId3, RoomId3)
+                    .SetFamily(tableId, FamilyId3, NTable::NPage::ECache::None, NTable::NPage::ECodec::Plain)
+                    .AddColumn(tableId, "value_family_3", ValueFamily3ColumnId, NScheme::TString::TypeId, false)
+                    .AddColumnToFamily(tableId, ValueFamily3ColumnId, FamilyId3);
+            }
         }
 
         return true;
@@ -43,21 +71,23 @@ public:
 
 private:
     const TVector<ui32> TableIds;
+    const bool AddColumnsInFamily;
 };
 
 class TTxWriteRow : public ITransaction {
 public:
-    TTxWriteRow(ui32 tableId, i64 key, TString value)
+    TTxWriteRow(ui32 tableId, i64 key, TString value, ui32 valueColumnId = ValueColumnId)
         : TableId(tableId)
         , Key(key)
         , Value(std::move(value))
+        , ValueColumnId_(valueColumnId)
     { }
 
     bool Execute(TTransactionContext& txc, const TActorContext&) override {
         const auto key = NScheme::TInt64::TInstance(Key);
 
         const auto val = NScheme::TString::TInstance(Value);
-        NTable::TUpdateOp ops{ ValueColumnId, NTable::ECellOp::Set, val };
+        NTable::TUpdateOp ops{ ValueColumnId_, NTable::ECellOp::Set, val };
 
         txc.DB.Update(TableId, NTable::ERowOp::Upsert, { key }, { ops });
         
@@ -72,6 +102,7 @@ private:
     ui32 TableId;
     i64 Key;
     TString Value;
+    ui32 ValueColumnId_;
 };
 
 class TTxDeleteRow : public ITransaction {
@@ -135,21 +166,33 @@ private:
     int& ReadRows;
 };
 
-bool ContainsInBlobStorage(TMyEnvBase& env, const TVector<TString>& values) {
-    for (auto group : xrange(env.StorageGroupCount)) {
-        env.SendEvToBSProxy(group, new NFake::TEvBlobStorageContainsRequest(values));
-        auto ev = env.GrabEdgeEvent<NFake::TEvBlobStorageContainsResponse>();
-        if (AnyOf(ev->Get()->Contains, [](bool v) { return v; }) ) {
-            return true;
+int BlobStorageValueCount(TMyEnvBase& env, const TString& value, ui32 channel) {
+    int count = 0;
+    env.SendEvToBSProxy(channel, new NFake::TEvBlobStorageContainsRequest(value));
+    auto ev = env.GrabEdgeEvent<NFake::TEvBlobStorageContainsResponse>();
+    for (const auto& blobInfo : ev->Get()->Contains) {
+        UNIT_ASSERT(blobInfo.BlobId.Channel() == channel);
+        if (!blobInfo.DoNotKeep) {
+            ++count;
         }
     }
-    return false;
+    return count;
+}
+
+int BlobStorageValueCountInAllGroups(TMyEnvBase& env, const TString& value) {
+    int count = 0;
+    for (auto group : xrange(env.StorageGroupCount)) {
+        count += BlobStorageValueCount(env, value, group);
+    }
+    return count;
 }
 
 Y_UNIT_TEST_SUITE(DataCleanup) {
+    ui32 TestTabletFlags = ui32(NFake::TDummy::EFlg::Comp) | ui32(NFake::TDummy::EFlg::Clean);
+
     Y_UNIT_TEST(CleanupDataNoTables) {
         TMyEnvBase env;
-        env.FireDummyTablet(ui32(NFake::TDummy::EFlg::Clean));
+        env.FireDummyTablet(TestTabletFlags);
 
         env.SendSync(new NFake::TEvCall{ [](auto* executor, const auto& ctx) {
             executor->CleanupData();
@@ -159,12 +202,42 @@ Y_UNIT_TEST_SUITE(DataCleanup) {
         env.WaitFor<NFake::TEvDataCleaned>();
     }
 
-    Y_UNIT_TEST(CleanupData) {
+    Y_UNIT_TEST(CleanupDataNoTablesWithRestart) {
         TMyEnvBase env;
-        env.FireDummyTablet(ui32(NFake::TDummy::EFlg::Clean));
-        env.SendSync(new NFake::TEvExecute{ new TTxInitSchema({ 101 }) });
+        env.FireDummyTablet(TestTabletFlags);
+
+        env.SendSync(new NFake::TEvCall{ [](auto* executor, const auto& ctx) {
+            executor->CleanupData();
+            ctx.Send(ctx.SelfID, new NFake::TEvReturn);
+        } });
+        env.WaitFor<NFake::TEvDataCleaned>();
+
+        env.RestartTablet(TestTabletFlags);
+
+        env.SendSync(new NFake::TEvCall{ [](auto* executor, const auto& ctx) {
+            executor->CleanupData();
+            ctx.Send(ctx.SelfID, new NFake::TEvReturn);
+        } }, true);
+        env.WaitFor<NFake::TEvDataCleaned>();
+    }
+
+    Y_UNIT_TEST(CleanupDataLog) {
+        TMyEnvBase env;
+        env.FireDummyTablet(TestTabletFlags);
+        env.SendSync(new NFake::TEvExecute{ new TTxInitSchema({ 101 }, true) });
         env.SendSync(new NFake::TEvExecute{ new TTxWriteRow(101, 42, "Some_value") });
+        env.SendSync(new NFake::TEvExecute{ new TTxWriteRow(101, 43, "Some_other_value", ValueFamily2ColumnId) });
+
+        env.SendSync(new NFake::TEvCompact(101));
+        env.WaitFor<NFake::TEvCompacted>();
+
+        // short string should be present uncompressed in log and sst
+        UNIT_ASSERT_VALUES_EQUAL(BlobStorageValueCount(env, "Some_value", 1), 2);
+        UNIT_ASSERT_VALUES_EQUAL(BlobStorageValueCount(env, "Some_other_value", 1), 1);
+        UNIT_ASSERT_VALUES_EQUAL(BlobStorageValueCount(env, "Some_other_value", 2), 1);
+
         env.SendSync(new NFake::TEvExecute{ new TTxDeleteRow(101, 42) });
+        env.SendSync(new NFake::TEvExecute{ new TTxDeleteRow(101, 43) });
 
         int readRows = 0;
         env.SendSync(new NFake::TEvExecute{ new TTxFullScan(101, readRows) });
@@ -177,17 +250,137 @@ Y_UNIT_TEST_SUITE(DataCleanup) {
 
         env.WaitFor<NFake::TEvDataCleaned>();
 
-        UNIT_ASSERT(!ContainsInBlobStorage(env, {"Some_value"}));
+        UNIT_ASSERT_VALUES_EQUAL(BlobStorageValueCountInAllGroups(env, "Some_value"), 0);
+        UNIT_ASSERT_VALUES_EQUAL(BlobStorageValueCountInAllGroups(env, "Some_other_value"), 0);
+    }
+
+    Y_UNIT_TEST(CleanupData) {
+        TString value42(size_t(100 * 1024), 'a');
+
+        TMyEnvBase env;
+        env.FireDummyTablet(TestTabletFlags);
+        env.SendSync(new NFake::TEvExecute{ new TTxInitSchema({ 101 }) });
+        env.SendSync(new NFake::TEvExecute{ new TTxWriteRow(101, 42, value42) });
+
+        env.SendSync(new NFake::TEvCompact(101));
+        env.WaitFor<NFake::TEvCompacted>();
+
+        UNIT_ASSERT_VALUES_EQUAL(BlobStorageValueCount(env, value42, 1), 1);
+
+        env.SendSync(new NFake::TEvExecute{ new TTxDeleteRow(101, 42) });
+
+        int readRows = 0;
+        env.SendSync(new NFake::TEvExecute{ new TTxFullScan(101, readRows) });
+        UNIT_ASSERT_VALUES_EQUAL(readRows, 0);
+
+        env.SendSync(new NFake::TEvCall{ [](auto* executor, const auto& ctx) {
+            executor->CleanupData();
+            ctx.Send(ctx.SelfID, new NFake::TEvReturn);
+        } });
+
+        env.WaitFor<NFake::TEvDataCleaned>();
+
+        UNIT_ASSERT_VALUES_EQUAL(BlobStorageValueCountInAllGroups(env, value42), 0);
+    }
+
+    Y_UNIT_TEST(CleanupDataMultipleFamilies) {
+        TString value42(size_t(100 * 1024), 'a');
+        TString value43(size_t(100 * 1024), 'b');
+        TString value44(size_t(100 * 1024), 'c');
+
+        TMyEnvBase env;
+        env.FireDummyTablet(TestTabletFlags);
+        env.SendSync(new NFake::TEvExecute{ new TTxInitSchema({ 101 }, true) });
+        env.SendSync(new NFake::TEvExecute{ new TTxWriteRow(101, 42, value42) });
+        env.SendSync(new NFake::TEvExecute{ new TTxWriteRow(101, 43, value43, ValueFamily2ColumnId) });
+        env.SendSync(new NFake::TEvExecute{ new TTxWriteRow(101, 44, value44, ValueFamily3ColumnId) });
+
+        env.SendSync(new NFake::TEvCompact(101));
+        env.WaitFor<NFake::TEvCompacted>();
+
+        UNIT_ASSERT_VALUES_EQUAL(BlobStorageValueCount(env, value42, 1), 1);
+        UNIT_ASSERT_VALUES_EQUAL(BlobStorageValueCount(env, value43, 2), 1);
+        UNIT_ASSERT_VALUES_EQUAL(BlobStorageValueCount(env, value44, 3), 1);
+
+        // delete row with value in family 3 and cleanup
+
+        env.SendSync(new NFake::TEvExecute{ new TTxDeleteRow(101, 44) });
+
+        int readRows = 0;
+        env.SendSync(new NFake::TEvExecute{ new TTxFullScan(101, readRows) });
+        UNIT_ASSERT_VALUES_EQUAL(readRows, 2);
+
+        env.SendSync(new NFake::TEvCall{ [](auto* executor, const auto& ctx) {
+            executor->CleanupData();
+            ctx.Send(ctx.SelfID, new NFake::TEvReturn);
+        } });
+        env.WaitFor<NFake::TEvDataCleaned>();
+
+        UNIT_ASSERT_VALUES_EQUAL(BlobStorageValueCount(env, value42, 1), 1);
+        UNIT_ASSERT_VALUES_EQUAL(BlobStorageValueCount(env, value43, 2), 1);
+        UNIT_ASSERT_VALUES_EQUAL(BlobStorageValueCountInAllGroups(env, value44), 0);
+
+        // restart and delete other rows with deffered GC in family 2
+
+        env.RestartTablet(TestTabletFlags);
+
+        readRows = 0;
+        env.SendSync(new NFake::TEvExecute{ new TTxFullScan(101, readRows) }, true);
+        UNIT_ASSERT_EQUAL(readRows, 2);
+
+        UNIT_ASSERT_VALUES_EQUAL(BlobStorageValueCount(env, value42, 1), 1);
+        UNIT_ASSERT_VALUES_EQUAL(BlobStorageValueCount(env, value43, 2), 1);
+        UNIT_ASSERT_VALUES_EQUAL(BlobStorageValueCountInAllGroups(env, value44), 0);
+
+        env.SendSync(new NFake::TEvExecute{ new TTxDeleteRow(101, 42) });
+        env.SendSync(new NFake::TEvExecute{ new TTxDeleteRow(101, 43) });
+
+        // defer GC after compaction in channel 2
+        env.SendEvToBSProxy(2, new NFake::TEvBlobStorageDeferGc(true));
+
+        env.SendSync(new NFake::TEvCompact(101));
+        env.WaitFor<NFake::TEvCompacted>();
+
+        env.SendSync(new NFake::TEvCall{ [](auto* executor, const auto& ctx) {
+            executor->CleanupData();
+            ctx.Send(ctx.SelfID, new NFake::TEvReturn);
+        } });
+
+        // should not be cleaned without GC
+        UNIT_ASSERT(!env.GrabEdgeEvent<NFake::TEvDataCleaned>(TDuration::Seconds(10)));
+
+        env.SendEvToBSProxy(2, new NFake::TEvBlobStorageDeferGc(false));
+        env.WaitFor<NFake::TEvDataCleaned>();
+
+        UNIT_ASSERT_VALUES_EQUAL(BlobStorageValueCountInAllGroups(env, value42), 0);
+        UNIT_ASSERT_VALUES_EQUAL(BlobStorageValueCountInAllGroups(env, value43), 0);
+        UNIT_ASSERT_VALUES_EQUAL(BlobStorageValueCountInAllGroups(env, value44), 0);
     }
 
     Y_UNIT_TEST(CleanupDataMultipleTables) {
+        TString value42(size_t(100 * 1024), 'a');
+        TString value43(size_t(100 * 1024), 'b');
+        TString value44(size_t(100 * 1024), 'c');
+
         TMyEnvBase env;
-        env.FireDummyTablet(ui32(NFake::TDummy::EFlg::Clean));
+        env.FireDummyTablet(TestTabletFlags);
         env.SendSync(new NFake::TEvExecute{ new TTxInitSchema({ 101, 102, 103 }) });
-        env.SendSync(new NFake::TEvExecute{ new TTxWriteRow(101, 42, "Some_value") });
-        env.SendSync(new NFake::TEvExecute{ new TTxWriteRow(102, 43, "Some_other_value") });
+        env.SendSync(new NFake::TEvExecute{ new TTxWriteRow(101, 42, value42) });
+        env.SendSync(new NFake::TEvExecute{ new TTxWriteRow(102, 43, value43) });
+        env.SendSync(new NFake::TEvExecute{ new TTxWriteRow(103, 44, value44) });
+
+        env.SendSync(new NFake::TEvCompact(101));
+        env.WaitFor<NFake::TEvCompacted>();
+        env.SendSync(new NFake::TEvCompact(102));
+        env.WaitFor<NFake::TEvCompacted>();
+        env.SendSync(new NFake::TEvCompact(103));
+        env.WaitFor<NFake::TEvCompacted>();
+
+        UNIT_ASSERT_VALUES_EQUAL(BlobStorageValueCount(env, value42, 1), 1);
+        UNIT_ASSERT_VALUES_EQUAL(BlobStorageValueCount(env, value43, 1), 1);
+        UNIT_ASSERT_VALUES_EQUAL(BlobStorageValueCount(env, value44, 1), 1);
+
         env.SendSync(new NFake::TEvExecute{ new TTxDeleteRow(101, 42) });
-        env.SendSync(new NFake::TEvExecute{ new TTxWriteRow(103, 44, "Some_another_value") });
         env.SendSync(new NFake::TEvExecute{ new TTxDeleteRow(102, 43) });
         env.SendSync(new NFake::TEvExecute{ new TTxDeleteRow(103, 44) });
 
@@ -203,27 +396,39 @@ Y_UNIT_TEST_SUITE(DataCleanup) {
             executor->CleanupData();
             ctx.Send(ctx.SelfID, new NFake::TEvReturn);
         } });
-
         env.WaitFor<NFake::TEvDataCleaned>();
 
-        UNIT_ASSERT(!ContainsInBlobStorage(env, {"Some_value", "Some_other_value", "Some_another_value"}));
+        UNIT_ASSERT_VALUES_EQUAL(BlobStorageValueCountInAllGroups(env, value42), 0);
+        UNIT_ASSERT_VALUES_EQUAL(BlobStorageValueCountInAllGroups(env, value43), 0);
+        UNIT_ASSERT_VALUES_EQUAL(BlobStorageValueCountInAllGroups(env, value44), 0);
     }
 
     Y_UNIT_TEST(CleanupDataWithFollowers) {
+        TString value41(size_t(100 * 1024), 'a');
+        TString value42(size_t(100 * 1024), 'b');
+        TString value43(size_t(100 * 1024), 'c');
+
         TMyEnvBase env;
-        env.FireDummyTablet(ui32(NFake::TDummy::EFlg::Clean));
+        env.FireDummyTablet(TestTabletFlags);
 
         env.FireDummyFollower(1);
-
         env.SendSync(new NFake::TEvExecute{ new TTxInitSchema({ 101 }) });
-        env.SendSync(new NFake::TEvExecute{ new TTxWriteRow(101, 41, "Some_value_1") });
-        env.SendSync(new NFake::TEvExecute{ new TTxWriteRow(101, 42, "Some_value_2") });
-        env.SendSync(new NFake::TEvExecute{ new TTxDeleteRow(101, 41) });
+        env.SendSync(new NFake::TEvExecute{ new TTxWriteRow(101, 41, value41) });
+        env.SendSync(new NFake::TEvExecute{ new TTxWriteRow(101, 42, value42) });
 
         env.FireDummyFollower(2);
-        env.SendSync(new NFake::TEvExecute{ new TTxWriteRow(101, 43, "Some_value_3") });
-        env.SendSync(new NFake::TEvExecute{ new TTxDeleteRow(101, 43) });
+        env.SendSync(new NFake::TEvExecute{ new TTxWriteRow(101, 43, value43) });
+
+        env.SendSync(new NFake::TEvCompact(101));
+        env.WaitFor<NFake::TEvCompacted>();
+
+        UNIT_ASSERT_VALUES_EQUAL(BlobStorageValueCount(env, value41, 1), 1);
+        UNIT_ASSERT_VALUES_EQUAL(BlobStorageValueCount(env, value42, 1), 1);
+        UNIT_ASSERT_VALUES_EQUAL(BlobStorageValueCount(env, value43, 1), 1);
+
+        env.SendSync(new NFake::TEvExecute{ new TTxDeleteRow(101, 41) });
         env.SendSync(new NFake::TEvExecute{ new TTxDeleteRow(101, 42) });
+        env.SendSync(new NFake::TEvExecute{ new TTxDeleteRow(101, 43) });
 
         int readRows = 0;
         env.SendSync(new NFake::TEvExecute{ new TTxFullScan(101, readRows) });
@@ -233,17 +438,27 @@ Y_UNIT_TEST_SUITE(DataCleanup) {
             executor->CleanupData();
             ctx.Send(ctx.SelfID, new NFake::TEvReturn);
         } });
-
         env.WaitFor<NFake::TEvDataCleaned>();
 
-        UNIT_ASSERT(!ContainsInBlobStorage(env, {"Some_value_1", "Some_value_2", "Some_value_3"}));
+        UNIT_ASSERT_VALUES_EQUAL(BlobStorageValueCountInAllGroups(env, value41), 0);
+        UNIT_ASSERT_VALUES_EQUAL(BlobStorageValueCountInAllGroups(env, value42), 0);
+        UNIT_ASSERT_VALUES_EQUAL(BlobStorageValueCountInAllGroups(env, value43), 0);
     }
 
     Y_UNIT_TEST(CleanupDataMultipleTimes) {
+        TString value42(size_t(100 * 1024), 'b');
+        TString value43(size_t(90 * 1024), 'f');
+
         TMyEnvBase env;
-        env.FireDummyTablet(ui32(NFake::TDummy::EFlg::Clean));
+        env.FireDummyTablet(TestTabletFlags);
         env.SendSync(new NFake::TEvExecute{ new TTxInitSchema({ 101 }) });
-        env.SendSync(new NFake::TEvExecute{ new TTxWriteRow(101, 42, "Some_value_1") });
+        env.SendSync(new NFake::TEvExecute{ new TTxWriteRow(101, 42, value42) });
+
+        env.SendSync(new NFake::TEvCompact(101));
+        env.WaitFor<NFake::TEvCompacted>();
+
+        UNIT_ASSERT_VALUES_EQUAL(BlobStorageValueCount(env, value42, 1), 1);
+
         env.SendSync(new NFake::TEvExecute{ new TTxDeleteRow(101, 42) });
 
         int readRows = 0;
@@ -255,10 +470,15 @@ Y_UNIT_TEST_SUITE(DataCleanup) {
             executor->CleanupData();
             ctx.Send(ctx.SelfID, new NFake::TEvReturn);
         } });
-
         env.WaitFor<NFake::TEvDataCleaned>(2);
 
-        env.SendSync(new NFake::TEvExecute{ new TTxWriteRow(101, 43, "Some_value_2") });
+        env.SendSync(new NFake::TEvExecute{ new TTxWriteRow(101, 43, value43) });
+
+        env.SendSync(new NFake::TEvCompact(101));
+        env.WaitFor<NFake::TEvCompacted>();
+
+        UNIT_ASSERT_VALUES_EQUAL(BlobStorageValueCount(env, value43, 1), 1);
+
         env.SendSync(new NFake::TEvExecute{ new TTxDeleteRow(101, 43) });
         env.SendSync(new NFake::TEvExecute{ new TTxFullScan(101, readRows) });
         UNIT_ASSERT_EQUAL(readRows, 0);
@@ -275,12 +495,13 @@ Y_UNIT_TEST_SUITE(DataCleanup) {
 
         env.WaitFor<NFake::TEvDataCleaned>(2);
 
-        UNIT_ASSERT(!ContainsInBlobStorage(env, {"Some_value_1", "Some_value_2"}));
+        UNIT_ASSERT_VALUES_EQUAL(BlobStorageValueCountInAllGroups(env, value42), 0);
+        UNIT_ASSERT_VALUES_EQUAL(BlobStorageValueCountInAllGroups(env, value43), 0);
     }
 
     Y_UNIT_TEST(CleanupDataEmptyTable) {
         TMyEnvBase env;
-        env.FireDummyTablet(ui32(NFake::TDummy::EFlg::Clean));
+        env.FireDummyTablet(TestTabletFlags);
         env.SendSync(new NFake::TEvExecute{ new TTxInitSchema({ 101 }) });
 
         int readRows = 0;
@@ -293,6 +514,64 @@ Y_UNIT_TEST_SUITE(DataCleanup) {
         } });
 
         env.WaitFor<NFake::TEvDataCleaned>();
+    }
+
+    Y_UNIT_TEST(CleanupDataWithRestarts) {
+        TString value42(size_t(100 * 1024), 'a');
+        TString value43(size_t(100 * 1024), 'b');
+
+        TMyEnvBase env;
+        env.FireDummyTablet(TestTabletFlags);
+        env.SendSync(new NFake::TEvExecute{ new TTxInitSchema({ 101 }) });
+        env.SendSync(new NFake::TEvExecute{ new TTxWriteRow(101, 42, value42) });
+        env.SendSync(new NFake::TEvExecute{ new TTxWriteRow(101, 43, value43) });
+
+        env.SendSync(new NFake::TEvCompact(101));
+        env.WaitFor<NFake::TEvCompacted>();
+
+        UNIT_ASSERT_VALUES_EQUAL(BlobStorageValueCount(env, value42, 1), 1);
+        UNIT_ASSERT_VALUES_EQUAL(BlobStorageValueCount(env, value43, 1), 1);
+
+        env.RestartTablet(TestTabletFlags);
+
+        env.SendSync(new NFake::TEvExecute{ new TTxDeleteRow(101, 43) }, true);
+
+        env.SendSync(new NFake::TEvCall{ [](auto* executor, const auto& ctx) {
+            executor->CleanupData();
+            ctx.Send(ctx.SelfID, new NFake::TEvReturn);
+        } });
+        env.WaitFor<NFake::TEvDataCleaned>();
+
+        env.RestartTablet(TestTabletFlags);
+
+        int readRows = 0;
+        env.SendSync(new NFake::TEvExecute{ new TTxFullScan(101, readRows) }, true);
+        UNIT_ASSERT_EQUAL(readRows, 1);
+
+        UNIT_ASSERT_VALUES_EQUAL(BlobStorageValueCount(env, value42, 1), 1);
+        UNIT_ASSERT_VALUES_EQUAL(BlobStorageValueCountInAllGroups(env, value43), 0);
+
+        env.SendSync(new NFake::TEvExecute{ new TTxDeleteRow(101, 42) });
+
+        // defer GC after compaction in channel 1
+        env.SendEvToBSProxy(1, new NFake::TEvBlobStorageDeferGc(true));
+
+        env.SendSync(new NFake::TEvCompact(101));
+        env.WaitFor<NFake::TEvCompacted>();
+
+        env.SendSync(new NFake::TEvCall{ [](auto* executor, const auto& ctx) {
+            executor->CleanupData();
+            ctx.Send(ctx.SelfID, new NFake::TEvReturn);
+        } });
+
+        // should not be cleaned without GC
+        UNIT_ASSERT(!env.GrabEdgeEvent<NFake::TEvDataCleaned>(TDuration::Seconds(10)));
+
+        env.SendEvToBSProxy(1, new NFake::TEvBlobStorageDeferGc(false));
+        env.WaitFor<NFake::TEvDataCleaned>();
+
+        UNIT_ASSERT_VALUES_EQUAL(BlobStorageValueCountInAllGroups(env, value42), 0);
+        UNIT_ASSERT_VALUES_EQUAL(BlobStorageValueCountInAllGroups(env, value43), 0);
     }
 }
 } // namespace NKikimr::NTable

--- a/ydb/core/tablet_flat/ut/ya.make
+++ b/ydb/core/tablet_flat/ut/ya.make
@@ -37,6 +37,7 @@ SRCS(
     ut_comp_gen.cpp
     ut_compaction.cpp
     ut_compaction_multi.cpp
+    ut_data_cleanup.cpp
     ut_datetime.cpp
     ut_decimal.cpp    
     ut_charge.cpp

--- a/ydb/core/tablet_flat/ya.make
+++ b/ydb/core/tablet_flat/ya.make
@@ -26,6 +26,7 @@ SRCS(
     flat_executor_compaction_logic.h
     flat_executor_counters.cpp
     flat_executor_counters.h
+    flat_executor_data_cleanup_logic.cpp
     flat_executor_db_mon.cpp
     flat_executor_gclogic.cpp
     flat_executor_gclogic.h


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of changes introduced in this PR -->

### Changelog category <!-- remove all except one -->

* Not for changelog

### Additional information

- Add IExecutor::CleanupData() method for cleanup starting
- Add ITablet::DataCleanupComplete() method to notify the tablet when the cleanup is finished
- Add TEvGcForStepAckRequest and TEvGcForStepAckResponse events in the system tablet
- Implement data cleanup logic: sequentially force compaction, snapshot 1, snapshot 2, wait for GC and GC Log
