### PR TITLE
Support distconf shutdown

### DIFF
--- a/ydb/core/blobstorage/nodewarden/distconf.cpp
+++ b/ydb/core/blobstorage/nodewarden/distconf.cpp
@@ -95,8 +95,7 @@ namespace NKikimr::NStorage {
                 ProposedStorageConfig.reset();
             }
 
-            Send(MakeBlobStorageNodeWardenID(SelfId().NodeId()), new TEvNodeWardenStorageConfig(*StorageConfig,
-                ProposedStorageConfig ? &ProposedStorageConfig.value() : nullptr));
+            ReportStorageConfigToNodeWarden(0);
 
             if (IsSelfStatic) {
                 PersistConfig({});
@@ -288,6 +287,20 @@ namespace NKikimr::NStorage {
             }
             processPendingEvents();
         }
+    }
+
+    void TDistributedConfigKeeper::ReportStorageConfigToNodeWarden(ui64 cookie) {
+        Y_ABORT_UNLESS(StorageConfig);
+        const TActorId wardenId = MakeBlobStorageNodeWardenID(SelfId().NodeId());
+        const bool distconfEnabled = StorageConfig->GetSelfManagementConfig().GetEnabled();
+        const NKikimrBlobStorage::TStorageConfig *config = distconfEnabled
+            ? &StorageConfig.value()
+            : &BaseConfig;
+        const NKikimrBlobStorage::TStorageConfig *proposedConfig = ProposedStorageConfig && distconfEnabled
+            ? &ProposedStorageConfig.value()
+            : nullptr;
+        auto ev = std::make_unique<TEvNodeWardenStorageConfig>(*config, proposedConfig);
+        Send(wardenId, ev.release(), 0, cookie);
     }
 
     STFUNC(TDistributedConfigKeeper::StateFunc) {

--- a/ydb/core/blobstorage/nodewarden/distconf.h
+++ b/ydb/core/blobstorage/nodewarden/distconf.h
@@ -292,6 +292,7 @@ namespace NKikimr::NStorage {
         void Halt(); // cease any distconf activity, unbind and reject any bindings
         bool ApplyStorageConfig(const NKikimrBlobStorage::TStorageConfig& config);
         void HandleConfigConfirm(STATEFN_SIG);
+        void ReportStorageConfigToNodeWarden(ui64 cookie);
 
         ////////////////////////////////////////////////////////////////////////////////////////////////////////////////
         // PDisk configuration retrieval and storing

--- a/ydb/core/blobstorage/nodewarden/distconf_fsm.cpp
+++ b/ydb/core/blobstorage/nodewarden/distconf_fsm.cpp
@@ -481,9 +481,7 @@ namespace NKikimr::NStorage {
                     // issue notification to node warden
                     if (StorageConfig && StorageConfig->GetGeneration() &&
                             StorageConfig->GetGeneration() < ProposedStorageConfig->GetGeneration()) {
-                        const TActorId wardenId = MakeBlobStorageNodeWardenID(SelfId().NodeId());
-                        auto ev = std::make_unique<TEvNodeWardenStorageConfig>(*StorageConfig, &ProposedStorageConfig.value());
-                        Send(wardenId, ev.release(), 0, cookie);
+                        ReportStorageConfigToNodeWarden(cookie);
                         ++task.AsyncOperationsPending;
                         ++ProposedStorageConfigCookieUsage;
                     }

--- a/ydb/core/blobstorage/nodewarden/distconf_invoke.cpp
+++ b/ydb/core/blobstorage/nodewarden/distconf_invoke.cpp
@@ -678,7 +678,7 @@ namespace NKikimr::NStorage {
 
             if (Self->StorageConfigYamlVersion && newYamlVersion != *Self->StorageConfigYamlVersion + 1) {
                 return FinishWithError(TResult::ERROR, TStringBuilder() << "version must be increasing by one"
-                    << " new version# " << newYamlVersion << " expected version# " << *Self->StorageConfigYamlVersion);
+                    << " new version# " << newYamlVersion << " expected version# " << *Self->StorageConfigYamlVersion + 1);
             }
 
             TString errorReason;


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of changes introduced in this PR -->

Support distconf shutdown

### Changelog category <!-- remove all except one -->

* Not for changelog (changelog entry is not required)

### Additional information

This allows distconf to be shut down consistently using standard configuration update procedure.
