### PR TITLE
Inline up to 14 bytes in TCell

### DIFF
--- a/ydb/core/scheme/scheme_tablecell.h
+++ b/ydb/core/scheme/scheme_tablecell.h
@@ -10,30 +10,75 @@
 #include <util/system/unaligned_mem.h>
 #include <util/memory/pool.h>
 
+#include <bit>
 #include <deque>
 #include <type_traits>
 
 namespace NKikimr {
 
-#pragma pack(push,4)
+static_assert(std::endian::native == std::endian::little, "TCell expects little endian architecture for data packing");
+
 // Represents one element in a tuple
 // Doesn't own the memory buffer that stores the actual value
-// Small values (<= 8 bytes) are stored inline
+// Small values (<= 14 bytes) are stored inline
 struct TCell {
     template<typename T>
     using TStdLayout = std::enable_if_t<std::is_standard_layout<T>::value, T>;
 
+public:
+    // 14 bytes ensures parity with TUnboxedValuePod
+    static constexpr size_t MaxInlineSize() { return 14; }
+    static constexpr bool CanInline(size_t size) { return size <= MaxInlineSize(); }
+
 private:
-    ui32 DataSize_ : 30;
-    ui32 IsInline_ : 1;
-    ui32 IsNull_   : 1;
-    union {
-        i64 IntVal;
-        const char* Ptr;
-        double DoubleVal;
-        float FloatVal;
-        char Bytes[8];
+    // NotInline (low bit):
+    //   0: IsInline() returns true
+    //   1: IsInline() returns false
+    // NotRefValue (high bit):
+    //   0: data is TRefValue
+    //   1: data is TInlineValue
+    // Null values are IsInline() with a nullptr data pointer and zero size
+    // TCell filled with zeroes is always a null value
+    // This bit arrangment allows methods to check a single flag
+    enum EKind : ui8 {
+        // Both bits 0: null value
+        KindNull = 0,
+        // Low bit 1: ref value
+        KindRefValue = 1,
+        // High bit 1: inline value
+        KindInlineValue = 2,
     };
+
+    struct TRefValue {
+        const char* Ptr;
+        ui64 Size : 62;
+        ui64 Kind : 2;
+    };
+
+    struct TInlineValue {
+        char Data[15];
+        ui8 Size : 6;
+        ui8 Kind : 2;
+    };
+
+private:
+    union {
+        char Raw[16];
+        TRefValue Ref;
+        TInlineValue Inline;
+    };
+
+    constexpr ui8 GetKind() const noexcept {
+        return ui8(Raw[15]) >> 6;
+    }
+
+    constexpr bool IsRefValue() const noexcept {
+        return (GetKind() & 2) == 0;
+    }
+
+    constexpr bool HasInlineFlag() const noexcept {
+        return (GetKind() & 1) == 0;
+    }
 
 public:
     TCell()
@@ -41,33 +86,42 @@ public:
     {}
 
     TCell(TArrayRef<const char> ref)
-        : TCell(ref.begin(), ui32(ref.size()))
-    {
-        Y_ABORT_UNLESS(ref.size() < Max<ui32>(), " Too large blob size for TCell");
-    }
+        : TCell(ref.data(), ref.size())
+    {}
 
-    TCell(const char* ptr, ui32 size)
-        : DataSize_(size)
-        , IsInline_(0)
-        , IsNull_(ptr == nullptr)
-        , Ptr(ptr)
-    {
-        Y_DEBUG_ABORT_UNLESS(ptr || size == 0);
-
-        if (CanInline(size)) {
-            IsInline_ = 1;
-            IntVal = 0;
-
+    TCell(const char* ptr, size_t size) {
+        if (!ptr) {
+            Y_DEBUG_ABORT_UNLESS(size == 0);
+            // All zeroes represents the null value
+            ::memset(Raw, 0, 16);
+        } else if (CanInline(size)) {
+            // We use switch with constant size memcpy for better codegen
             switch (size) {
-                case 8: memcpy(&IntVal, ptr, 8); break;
-                case 7: memcpy(&IntVal, ptr, 7); break;
-                case 6: memcpy(&IntVal, ptr, 6); break;
-                case 5: memcpy(&IntVal, ptr, 5); break;
-                case 4: memcpy(&IntVal, ptr, 4); break;
-                case 3: memcpy(&IntVal, ptr, 3); break;
-                case 2: memcpy(&IntVal, ptr, 2); break;
-                case 1: memcpy(&IntVal, ptr, 1); break;
+                case 15: ::memcpy(Inline.Data, ptr, 15); break;
+                case 14: ::memcpy(Inline.Data, ptr, 14); break;
+                case 13: ::memcpy(Inline.Data, ptr, 13); break;
+                case 12: ::memcpy(Inline.Data, ptr, 12); break;
+                case 11: ::memcpy(Inline.Data, ptr, 11); break;
+                case 10: ::memcpy(Inline.Data, ptr, 10); break;
+                case 9: ::memcpy(Inline.Data, ptr, 9); break;
+                case 8: ::memcpy(Inline.Data, ptr, 8); break;
+                case 7: ::memcpy(Inline.Data, ptr, 7); break;
+                case 6: ::memcpy(Inline.Data, ptr, 6); break;
+                case 5: ::memcpy(Inline.Data, ptr, 5); break;
+                case 4: ::memcpy(Inline.Data, ptr, 4); break;
+                case 3: ::memcpy(Inline.Data, ptr, 3); break;
+                case 2: ::memcpy(Inline.Data, ptr, 2); break;
+                case 1: ::memcpy(Inline.Data, ptr, 1); break;
+                case 0: break;
+                default: Y_ABORT("unreachable");
             }
+            Inline.Size = size;
+            Inline.Kind = KindInlineValue;
+        } else {
+            Y_DEBUG_ABORT_UNLESS(size <= Max<ui32>());
+            Ref.Ptr = ptr;
+            Ref.Size = size;
+            Ref.Kind = KindRefValue;
         }
     }
 
@@ -75,14 +129,30 @@ public:
         : TCell((const char*)v->Data(), v->Size())
     {}
 
-    explicit operator bool() const
-    {
+    constexpr explicit operator bool() const {
         return !IsNull();
     }
 
-    bool IsInline() const       { return IsInline_; }
-    bool IsNull() const         { return IsNull_; }
-    ui32 Size() const           { return DataSize_; }
+    constexpr bool IsNull() const {
+        return GetKind() == KindNull;
+    }
+
+    constexpr bool IsInline() const {
+        return HasInlineFlag();
+    }
+
+    constexpr const char* InlineData() const {
+        Y_DEBUG_ABORT_UNLESS(IsInline());
+        return Raw;
+    }
+
+    constexpr const char* Data() const {
+        return IsRefValue() ? Ref.Ptr : Inline.Data;
+    }
+
+    constexpr ui32 Size() const {
+        return IsRefValue() ? Ref.Size : Inline.Size;
+    }
 
     TArrayRef<const char> AsRef() const noexcept
     {
@@ -104,7 +174,7 @@ public:
 
     template <typename T, typename = TStdLayout<T>>
     bool ToValue(T& value, TString& err) const noexcept {
-        if (sizeof(T) != Size()) {
+        if (Y_UNLIKELY(sizeof(T) != Size())) {
             err = Sprintf("ToValue<T>() type size %" PRISZT " doesn't match TCell size %" PRIu32, sizeof(T), Size());
             return false;
         }
@@ -127,46 +197,40 @@ public:
     static inline TCell Make(const T& val) noexcept {
         auto *ptr = static_cast<const char*>(static_cast<const void*>(&val));
 
-        return TCell{ ptr, sizeof(val) };
+        return TCell(ptr, sizeof(val));
     }
 
-#if 1
-    // Optimization to store small values (<= 8 bytes) inplace
-    static constexpr bool CanInline(ui32 sz) { return sz <= 8; }
-    static constexpr size_t MaxInlineSize() { return 8; }
-    const char* InlineData() const                  { Y_DEBUG_ABORT_UNLESS(IsInline_); return IsNull_ ? nullptr : (char*)&IntVal; }
-    const char* Data() const                        { return IsNull_ ? nullptr : (IsInline_ ? (char*)&IntVal : Ptr); }
-#else
-    // Non-inlinable version for perf comparisons
-    static bool CanInline(ui32)                     { return false; }
-    const char* InlineData() const                  { Y_DEBUG_ABORT_UNLESS(!IsInline_); return Ptr; }
-    const char* Data() const                        { Y_DEBUG_ABORT_UNLESS(!IsInline_); return Ptr; }
-#endif
-
-    void CopyDataInto(char * dst) const {
-        if (IsInline_) {
-            switch (DataSize_) {
-                case 8: memcpy(dst, &IntVal, 8); break;
-                case 7: memcpy(dst, &IntVal, 7); break;
-                case 6: memcpy(dst, &IntVal, 6); break;
-                case 5: memcpy(dst, &IntVal, 5); break;
-                case 4: memcpy(dst, &IntVal, 4); break;
-                case 3: memcpy(dst, &IntVal, 3); break;
-                case 2: memcpy(dst, &IntVal, 2); break;
-                case 1: memcpy(dst, &IntVal, 1); break;
+    void CopyDataInto(char* dst) const {
+        if (IsRefValue()) {
+            if (Ref.Size > 0) {
+                ::memcpy(dst, Ref.Ptr, Ref.Size);
             }
-            return;
-        }
-
-        if (Ptr) {
-            memcpy(dst, Ptr, DataSize_);
+        } else {
+            // We use switch with constant size memcpy for better codegen
+            switch (Inline.Size) {
+                case 15: ::memcpy(dst, Inline.Data, 15); break;
+                case 14: ::memcpy(dst, Inline.Data, 14); break;
+                case 13: ::memcpy(dst, Inline.Data, 13); break;
+                case 12: ::memcpy(dst, Inline.Data, 12); break;
+                case 11: ::memcpy(dst, Inline.Data, 11); break;
+                case 10: ::memcpy(dst, Inline.Data, 10); break;
+                case 9: ::memcpy(dst, Inline.Data, 9); break;
+                case 8: ::memcpy(dst, Inline.Data, 8); break;
+                case 7: ::memcpy(dst, Inline.Data, 7); break;
+                case 6: ::memcpy(dst, Inline.Data, 6); break;
+                case 5: ::memcpy(dst, Inline.Data, 5); break;
+                case 4: ::memcpy(dst, Inline.Data, 4); break;
+                case 3: ::memcpy(dst, Inline.Data, 3); break;
+                case 2: ::memcpy(dst, Inline.Data, 2); break;
+                case 1: ::memcpy(dst, Inline.Data, 1); break;
+                case 0: break;
+                default: Y_ABORT("unreachable");
+            }
         }
     }
 };
 
-#pragma pack(pop)
-
-static_assert(sizeof(TCell) == 12, "TCell must be 12 bytes");
+static_assert(sizeof(TCell) == 16, "TCell must be 16 bytes");
 using TCellsRef = TConstArrayRef<const TCell>;
 
 inline size_t EstimateSize(TCellsRef cells) {
@@ -196,8 +260,8 @@ struct TCellVectorsEquals {
 };
 
 inline int CompareCellsAsByteString(const TCell& a, const TCell& b, bool isDescending) {
-    const char* pa = (const char*)a.Data();
-    const char* pb = (const char*)b.Data();
+    const char* pa = a.Data();
+    const char* pb = b.Data();
     size_t sza = a.Size();
     size_t szb = b.Size();
     int cmp = memcmp(pa, pb, sza < szb ? sza : szb);
@@ -227,6 +291,14 @@ inline int CompareTypedCells(const TCell& a, const TCell& b, const NScheme::TTyp
         return va == vb ? 0 : ((va < vb) != type.IsDescending() ? -1 : 1);   \
     }
 
+#define LARGER_TYPE_SWITCH(typeEnum, castType)      \
+    case NKikimr::NScheme::NTypeIds::typeEnum:      \
+    {                                               \
+        castType va = ReadUnaligned<castType>((const castType*)a.Data()); \
+        castType vb = ReadUnaligned<castType>((const castType*)b.Data()); \
+        return va == vb ? 0 : ((va < vb) != type.IsDescending() ? -1 : 1);   \
+    }
+
     SIMPLE_TYPE_SWITCH(Int8,   i8);
     SIMPLE_TYPE_SWITCH(Int16,  i16);
     SIMPLE_TYPE_SWITCH(Uint16, ui16);
@@ -238,7 +310,7 @@ inline int CompareTypedCells(const TCell& a, const TCell& b, const NScheme::TTyp
     SIMPLE_TYPE_SWITCH(Bool,   ui8);
     SIMPLE_TYPE_SWITCH(Double, double);
     SIMPLE_TYPE_SWITCH(Float,  float);
-    SIMPLE_TYPE_SWITCH(PairUi64Ui64,  TPair);
+    LARGER_TYPE_SWITCH(PairUi64Ui64, TPair);
     SIMPLE_TYPE_SWITCH(Date,   ui16);
     SIMPLE_TYPE_SWITCH(Datetime,  ui32);
     SIMPLE_TYPE_SWITCH(Timestamp, ui64);
@@ -249,6 +321,7 @@ inline int CompareTypedCells(const TCell& a, const TCell& b, const NScheme::TTyp
     SIMPLE_TYPE_SWITCH(Interval64, i64);
 
 #undef SIMPLE_TYPE_SWITCH
+#undef LARGER_TYPE_SWITCH
 
     case NKikimr::NScheme::NTypeIds::String:
     case NKikimr::NScheme::NTypeIds::String4k:

--- a/ydb/core/scheme/scheme_tablecell_ut.cpp
+++ b/ydb/core/scheme/scheme_tablecell_ut.cpp
@@ -14,6 +14,40 @@ Y_UNIT_TEST_SUITE(Scheme) {
     namespace NTypeIds = NScheme::NTypeIds;
     using TTypeInfo = NScheme::TTypeInfo;
 
+    Y_UNIT_TEST(NullCell) {
+        TCell nullCell;
+        UNIT_ASSERT_VALUES_EQUAL(nullCell.IsNull(), true);
+        UNIT_ASSERT_VALUES_EQUAL(nullCell.IsInline(), true);
+        UNIT_ASSERT_VALUES_EQUAL(nullCell.Data(), nullptr);
+        UNIT_ASSERT_VALUES_EQUAL(nullCell.Size(), 0u);
+        TCell nullPtrCell(nullptr, 0);
+        UNIT_ASSERT_VALUES_EQUAL(nullPtrCell.IsNull(), true);
+        UNIT_ASSERT_VALUES_EQUAL(nullPtrCell.IsInline(), true);
+        UNIT_ASSERT_VALUES_EQUAL(nullPtrCell.Data(), nullptr);
+        UNIT_ASSERT_VALUES_EQUAL(nullPtrCell.Size(), 0u);
+    }
+
+    Y_UNIT_TEST(EmptyCell) {
+        TCell emptyCell("", 0);
+        UNIT_ASSERT_VALUES_EQUAL(emptyCell.IsNull(), false);
+        UNIT_ASSERT_VALUES_EQUAL(emptyCell.IsInline(), true);
+        UNIT_ASSERT_VALUES_EQUAL(emptyCell.Size(), 0u);
+        UNIT_ASSERT(emptyCell.Data() != nullptr);
+    }
+
+    Y_UNIT_TEST(NotEmptyCell) {
+        TCell smallValue("abcdefghijklmn", 14);
+        UNIT_ASSERT_VALUES_EQUAL(smallValue.IsNull(), false);
+        UNIT_ASSERT_VALUES_EQUAL(smallValue.IsInline(), true);
+        UNIT_ASSERT_VALUES_EQUAL(smallValue.Size(), 14u);
+        UNIT_ASSERT_VALUES_EQUAL(smallValue.AsBuf(), "abcdefghijklmn");
+        TCell largeValue("abcdefghijklmnopq", 17);
+        UNIT_ASSERT_VALUES_EQUAL(largeValue.IsNull(), false);
+        UNIT_ASSERT_VALUES_EQUAL(largeValue.IsInline(), false);
+        UNIT_ASSERT_VALUES_EQUAL(largeValue.Size(), 17u);
+        UNIT_ASSERT_VALUES_EQUAL(largeValue.AsBuf(), "abcdefghijklmnopq");
+    }
+
     Y_UNIT_TEST(EmptyOwnedCellVec) {
         TOwnedCellVec empty;
         UNIT_ASSERT_VALUES_EQUAL(empty.size(), 0u);

--- a/ydb/core/scheme_types/scheme_raw_type_value.h
+++ b/ydb/core/scheme_types/scheme_raw_type_value.h
@@ -17,7 +17,7 @@ public:
         , ValueType()
     {}
 
-    TRawTypeValue(const void* buf, ui32 bufSize, NScheme::TTypeId vtype)
+    TRawTypeValue(const void* buf, size_t bufSize, NScheme::TTypeId vtype)
         : Buffer(buf)
         , BufferSize(bufSize)
         , ValueType(vtype)

--- a/ydb/core/sys_view/ut_kqp.cpp
+++ b/ydb/core/sys_view/ut_kqp.cpp
@@ -774,7 +774,7 @@ Y_UNIT_TEST_SUITE(SystemView) {
         check.Uint64GreaterOrEquals(nowUs); // AccessTime
         check.DoubleGreaterOrEquals(0.0); // CPUCores
         check.Uint64(1u); // CoordinatedTxCompleted
-        check.Uint64(576u); // DataSize
+        check.Uint64(584u); // DataSize
         check.Uint64(1u); // ImmediateTxCompleted
         check.Uint64(0u); // IndexSize
         check.Uint64(0u); // InFlightTxCount

--- a/ydb/core/tablet_flat/flat_mem_eggs.h
+++ b/ydb/core/tablet_flat/flat_mem_eggs.h
@@ -10,25 +10,21 @@ namespace NKikimr {
 namespace NTable {
 namespace NMem {
 
-#pragma pack(push,4)
-
     struct TColumnUpdate {
         TColumnUpdate() : TColumnUpdate(Max<TTag>(), ECellOp::Empty, { }) { }
 
         TColumnUpdate(TTag tag, TCellOp op, const TCell& value)
             : Tag(tag)
-            , Op((ui32)op.Raw())
+            , Op(op)
             , Value(value)
         {
 
         }
 
-        ui32 Tag:24;
-        ui32 Op:8;
+        TTag Tag;
+        TCellOp Op;
         TCell Value;
     };
-
-#pragma pack(pop)
 
     struct TUpdate {
         TColumnUpdate* Ops() noexcept
@@ -72,7 +68,7 @@ namespace NMem {
         const TUpdate* Chain;
     };
 
-    static_assert(sizeof(TColumnUpdate) == 16, "TColumnUpdate must be 16 bytes");
+    static_assert(sizeof(TColumnUpdate) == 24, "TColumnUpdate must be 24 bytes");
     static_assert(sizeof(TUpdate) == 32, "TUpdate must be 32 bytes");
 }
 }

--- a/ydb/core/tablet_flat/flat_mem_iter.h
+++ b/ydb/core/tablet_flat/flat_mem_iter.h
@@ -387,7 +387,7 @@ namespace NTable {
         void ApplyColumn(TRowState& row, const NMem::TColumnUpdate &up) const noexcept
         {
             const auto pos = Remap->Has(up.Tag);
-            auto op = TCellOp::Decode(up.Op);
+            auto op = up.Op;
 
             if (!pos || row.IsFinalized(pos)) {
                 /* Out of remap or row slot is already filled */

--- a/ydb/core/tx/datashard/datashard_ut_stats.cpp
+++ b/ydb/core/tx/datashard/datashard_ut_stats.cpp
@@ -97,7 +97,7 @@ Y_UNIT_TEST_SUITE(DataShardStats) {
             UNIT_ASSERT_VALUES_EQUAL(stats.GetDatashardId(), shard1);
             UNIT_ASSERT_VALUES_EQUAL(stats.GetTableStats().GetRowCount(), 3);
             UNIT_ASSERT_VALUES_EQUAL(stats.GetTableStats().GetPartCount(), 0);
-            UNIT_ASSERT_VALUES_EQUAL(stats.GetTableStats().GetDataSize(), 704);
+            UNIT_ASSERT_VALUES_EQUAL(stats.GetTableStats().GetDataSize(), 728);
             UNIT_ASSERT_VALUES_EQUAL(stats.GetTableStats().GetIndexSize(), 0);
             UNIT_ASSERT_VALUES_EQUAL(stats.GetTableStats().GetImmediateTxCompleted(), 1);
         }
@@ -162,7 +162,7 @@ Y_UNIT_TEST_SUITE(DataShardStats) {
             UNIT_ASSERT_VALUES_EQUAL(stats.GetDatashardId(), shard1);
             UNIT_ASSERT_VALUES_EQUAL(stats.GetTableStats().GetRowCount(), 3);
             UNIT_ASSERT_VALUES_EQUAL(stats.GetTableStats().GetPartCount(), 0);
-            UNIT_ASSERT_VALUES_EQUAL(stats.GetTableStats().GetDataSize(), 752);
+            UNIT_ASSERT_VALUES_EQUAL(stats.GetTableStats().GetDataSize(), 800);
             UNIT_ASSERT_VALUES_EQUAL(stats.GetTableStats().GetIndexSize(), 0);
         }
 
@@ -219,7 +219,7 @@ Y_UNIT_TEST_SUITE(DataShardStats) {
             UNIT_ASSERT_VALUES_EQUAL(stats.GetDatashardId(), shard1);
             UNIT_ASSERT_VALUES_EQUAL(stats.GetTableStats().GetRowCount(), 2000);
             UNIT_ASSERT_VALUES_EQUAL(stats.GetTableStats().GetPartCount(), 0);
-            UNIT_ASSERT_VALUES_EQUAL(stats.GetTableStats().GetDataSize(), 196096);
+            UNIT_ASSERT_VALUES_EQUAL(stats.GetTableStats().GetDataSize(), 212096);
             UNIT_ASSERT_VALUES_EQUAL(stats.GetTableStats().GetIndexSize(), 0);
         }
 
@@ -301,7 +301,7 @@ Y_UNIT_TEST_SUITE(DataShardStats) {
             UNIT_ASSERT_VALUES_EQUAL(stats.GetDatashardId(), shard1);
             UNIT_ASSERT_VALUES_EQUAL(stats.GetTableStats().GetRowCount(), 5);
             UNIT_ASSERT_VALUES_EQUAL(stats.GetTableStats().GetPartCount(), 0);
-            UNIT_ASSERT_VALUES_EQUAL(stats.GetTableStats().GetDataSize(), 4232);
+            UNIT_ASSERT_VALUES_EQUAL(stats.GetTableStats().GetDataSize(), 4312);
             UNIT_ASSERT_VALUES_EQUAL(stats.GetTableStats().GetIndexSize(), 0);
         }
 

--- a/ydb/core/tx/schemeshard/ut_serverless/ut_serverless.cpp
+++ b/ydb/core/tx/schemeshard/ut_serverless/ut_serverless.cpp
@@ -231,7 +231,7 @@ Y_UNIT_TEST_SUITE(TSchemeShardServerLess) {
         waitMeteringMessage();
 
         {
-            TString meteringData = R"({"usage":{"start":1600452120,"quantity":59,"finish":1600452179,"type":"delta","unit":"byte*second"},"tags":{"ydb_size":11664},"id":"72057594046678944-3-1600452120-1600452179-11664","cloud_id":"CLOUD_ID_VAL","source_wt":1600452180,"source_id":"sless-docapi-ydb-storage","resource_id":"DATABASE_ID_VAL","schema":"ydb.serverless.v1","folder_id":"FOLDER_ID_VAL","version":"1.0.0"})";
+            TString meteringData = R"({"usage":{"start":1600452120,"quantity":59,"finish":1600452179,"type":"delta","unit":"byte*second"},"tags":{"ydb_size":13280},"id":"72057594046678944-3-1600452120-1600452179-13280","cloud_id":"CLOUD_ID_VAL","source_wt":1600452180,"source_id":"sless-docapi-ydb-storage","resource_id":"DATABASE_ID_VAL","schema":"ydb.serverless.v1","folder_id":"FOLDER_ID_VAL","version":"1.0.0"})";
             meteringData += "\n";
             UNIT_ASSERT_NO_DIFF(meteringMessages, meteringData);
         }


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of changes introduced in this PR -->

...

### Changelog category <!-- remove all except one -->

* Not for changelog (changelog entry is not required)

### Additional information

This will remove edge cases where TCell and TUnboxedValuePod behave differently for data between 9 and 14 bytes long.