### PR TITLE
Support dynamic config propagation when distconf is off

### DIFF
--- a/ydb/core/blobstorage/nodewarden/distconf_dynamic.cpp
+++ b/ydb/core/blobstorage/nodewarden/distconf_dynamic.cpp
@@ -105,11 +105,14 @@ namespace NKikimr::NStorage {
     void TDistributedConfigKeeper::PushConfigToDynamicNode(TActorId actorId, TActorId sessionId) {
         auto ev = std::make_unique<TEvNodeWardenDynamicConfigPush>();
         auto& record = ev->Record;
-        if (StorageConfig) {
-            record.MutableConfig()->CopyFrom(*StorageConfig);
-        }
-        if (!PartOfNodeQuorum()) {
+        if (!PartOfNodeQuorum()) { // this configuration is not reliable, don't push anything
             ev->Record.SetNoQuorum(true);
+        } else if (!StorageConfig) {
+            // no storage configuration -- no nothing
+        } else if (auto *target = record.MutableConfig(); StorageConfig->GetSelfManagementConfig().GetEnabled()) {
+            target->CopyFrom(*StorageConfig);
+        } else {
+            target->CopyFrom(BaseConfig);
         }
         auto handle = std::make_unique<IEventHandle>(actorId, SelfId(), ev.release());
         handle->Rewrite(TEvInterconnect::EvForward, sessionId);


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of changes introduced in this PR -->

Support dynamic config propagation when distconf is off

### Changelog category <!-- remove all except one -->

* Not for changelog (changelog entry is not required)

### Additional information

Distconf can now propagate configuration to dynamic nodes when self-management is off.
