### PR TITLE
builtin security: add CreateQueue permission to DDL-ADMINS

### DIFF
--- a/ydb/library/yaml_config/ut_transform/canondata/test_transform.TestYamlConfigTransformations.test_basic_args0-dump_/block-4-2.yaml.result.json
+++ b/ydb/library/yaml_config/ut_transform/canondata/test_transform.TestYamlConfigTransformations.test_basic_args0-dump_/block-4-2.yaml.result.json
@@ -326,7 +326,7 @@
               "+(DS|RA):METADATA-READERS",
               "+(SR):DATA-READERS",
               "+(UR|ER):DATA-WRITERS",
-              "+(CD|CT|WA|AS|RS):DDL-ADMINS",
+              "+(CD|CT|CQ|WA|AS|RS):DDL-ADMINS",
               "+(GAR):ACCESS-ADMINS",
               "+(CDB|DDB):DATABASE-ADMINS"
             ],

--- a/ydb/library/yaml_config/ut_transform/canondata/test_transform.TestYamlConfigTransformations.test_basic_args0-dump_/mirror-3dc-3-nodes-in-memory.yaml.result.json
+++ b/ydb/library/yaml_config/ut_transform/canondata/test_transform.TestYamlConfigTransformations.test_basic_args0-dump_/mirror-3dc-3-nodes-in-memory.yaml.result.json
@@ -267,7 +267,7 @@
               "+(DS|RA):METADATA-READERS",
               "+(SR):DATA-READERS",
               "+(UR|ER):DATA-WRITERS",
-              "+(CD|CT|WA|AS|RS):DDL-ADMINS",
+              "+(CD|CT|CQ|WA|AS|RS):DDL-ADMINS",
               "+(GAR):ACCESS-ADMINS",
               "+(CDB|DDB):DATABASE-ADMINS"
             ],

--- a/ydb/library/yaml_config/ut_transform/canondata/test_transform.TestYamlConfigTransformations.test_basic_args0-dump_/mirror-3dc-3-nodes.yaml.result.json
+++ b/ydb/library/yaml_config/ut_transform/canondata/test_transform.TestYamlConfigTransformations.test_basic_args0-dump_/mirror-3dc-3-nodes.yaml.result.json
@@ -268,7 +268,7 @@
               "+(DS|RA):METADATA-READERS",
               "+(SR):DATA-READERS",
               "+(UR|ER):DATA-WRITERS",
-              "+(CD|CT|WA|AS|RS):DDL-ADMINS",
+              "+(CD|CT|CQ|WA|AS|RS):DDL-ADMINS",
               "+(GAR):ACCESS-ADMINS",
               "+(CDB|DDB):DATABASE-ADMINS"
             ],

--- a/ydb/library/yaml_config/ut_transform/canondata/test_transform.TestYamlConfigTransformations.test_basic_args0-dump_/mirror-3dc-9-nodes.yaml.result.json
+++ b/ydb/library/yaml_config/ut_transform/canondata/test_transform.TestYamlConfigTransformations.test_basic_args0-dump_/mirror-3dc-9-nodes.yaml.result.json
@@ -342,7 +342,7 @@
               "+(DS|RA):METADATA-READERS",
               "+(SR):DATA-READERS",
               "+(UR|ER):DATA-WRITERS",
-              "+(CD|CT|WA|AS|RS):DDL-ADMINS",
+              "+(CD|CT|CQ|WA|AS|RS):DDL-ADMINS",
               "+(GAR):ACCESS-ADMINS",
               "+(CDB|DDB):DATABASE-ADMINS"
             ],

--- a/ydb/library/yaml_config/ut_transform/canondata/test_transform.TestYamlConfigTransformations.test_basic_args0-dump_/simple.yaml.result.json
+++ b/ydb/library/yaml_config/ut_transform/canondata/test_transform.TestYamlConfigTransformations.test_basic_args0-dump_/simple.yaml.result.json
@@ -331,7 +331,7 @@
               "+(DS|RA):METADATA-READERS",
               "+(SR):DATA-READERS",
               "+(UR|ER):DATA-WRITERS",
-              "+(CD|CT|WA|AS|RS):DDL-ADMINS",
+              "+(CD|CT|CQ|WA|AS|RS):DDL-ADMINS",
               "+(GAR):ACCESS-ADMINS",
               "+(CDB|DDB):DATABASE-ADMINS"
             ],

--- a/ydb/library/yaml_config/ut_transform/canondata/test_transform.TestYamlConfigTransformations.test_basic_args0-dump_/single-node-in-memory.yaml.result.json
+++ b/ydb/library/yaml_config/ut_transform/canondata/test_transform.TestYamlConfigTransformations.test_basic_args0-dump_/single-node-in-memory.yaml.result.json
@@ -234,7 +234,7 @@
               "+(DS|RA):METADATA-READERS",
               "+(SR):DATA-READERS",
               "+(UR|ER):DATA-WRITERS",
-              "+(CD|CT|WA|AS|RS):DDL-ADMINS",
+              "+(CD|CT|CQ|WA|AS|RS):DDL-ADMINS",
               "+(GAR):ACCESS-ADMINS",
               "+(CDB|DDB):DATABASE-ADMINS"
             ],

--- a/ydb/library/yaml_config/ut_transform/canondata/test_transform.TestYamlConfigTransformations.test_basic_args0-dump_/single-node-with-file.yaml.result.json
+++ b/ydb/library/yaml_config/ut_transform/canondata/test_transform.TestYamlConfigTransformations.test_basic_args0-dump_/single-node-with-file.yaml.result.json
@@ -234,7 +234,7 @@
               "+(DS|RA):METADATA-READERS",
               "+(SR):DATA-READERS",
               "+(UR|ER):DATA-WRITERS",
-              "+(CD|CT|WA|AS|RS):DDL-ADMINS",
+              "+(CD|CT|CQ|WA|AS|RS):DDL-ADMINS",
               "+(GAR):ACCESS-ADMINS",
               "+(CDB|DDB):DATABASE-ADMINS"
             ],

--- a/ydb/library/yaml_config/ut_transform/canondata/test_transform.TestYamlConfigTransformations.test_simplified_dump_/block-4-2.yaml.result.json
+++ b/ydb/library/yaml_config/ut_transform/canondata/test_transform.TestYamlConfigTransformations.test_simplified_dump_/block-4-2.yaml.result.json
@@ -275,7 +275,7 @@
               "+(DS|RA):METADATA-READERS",
               "+(SR):DATA-READERS",
               "+(UR|ER):DATA-WRITERS",
-              "+(CD|CT|WA|AS|RS):DDL-ADMINS",
+              "+(CD|CT|CQ|WA|AS|RS):DDL-ADMINS",
               "+(GAR):ACCESS-ADMINS",
               "+(CDB|DDB):DATABASE-ADMINS"
             ],

--- a/ydb/library/yaml_config/ut_transform/canondata/test_transform.TestYamlConfigTransformations.test_simplified_dump_/disk.yaml.result.json
+++ b/ydb/library/yaml_config/ut_transform/canondata/test_transform.TestYamlConfigTransformations.test_simplified_dump_/disk.yaml.result.json
@@ -179,7 +179,7 @@
               "+(DS|RA):METADATA-READERS",
               "+(SR):DATA-READERS",
               "+(UR|ER):DATA-WRITERS",
-              "+(CD|CT|WA|AS|RS):DDL-ADMINS",
+              "+(CD|CT|CQ|WA|AS|RS):DDL-ADMINS",
               "+(GAR):ACCESS-ADMINS",
               "+(CDB|DDB):DATABASE-ADMINS"
             ],

--- a/ydb/library/yaml_config/ut_transform/canondata/test_transform.TestYamlConfigTransformations.test_simplified_dump_/drive.yaml.result.json
+++ b/ydb/library/yaml_config/ut_transform/canondata/test_transform.TestYamlConfigTransformations.test_simplified_dump_/drive.yaml.result.json
@@ -179,7 +179,7 @@
               "+(DS|RA):METADATA-READERS",
               "+(SR):DATA-READERS",
               "+(UR|ER):DATA-WRITERS",
-              "+(CD|CT|WA|AS|RS):DDL-ADMINS",
+              "+(CD|CT|CQ|WA|AS|RS):DDL-ADMINS",
               "+(GAR):ACCESS-ADMINS",
               "+(CDB|DDB):DATABASE-ADMINS"
             ],

--- a/ydb/library/yaml_config/ut_transform/canondata/test_transform.TestYamlConfigTransformations.test_simplified_dump_/mirror-3dc-3-nodes-distconf.yaml.result.json
+++ b/ydb/library/yaml_config/ut_transform/canondata/test_transform.TestYamlConfigTransformations.test_simplified_dump_/mirror-3dc-3-nodes-distconf.yaml.result.json
@@ -199,7 +199,7 @@
               "+(DS|RA):METADATA-READERS",
               "+(SR):DATA-READERS",
               "+(UR|ER):DATA-WRITERS",
-              "+(CD|CT|WA|AS|RS):DDL-ADMINS",
+              "+(CD|CT|CQ|WA|AS|RS):DDL-ADMINS",
               "+(GAR):ACCESS-ADMINS",
               "+(CDB|DDB):DATABASE-ADMINS"
             ],

--- a/ydb/library/yaml_config/ut_transform/canondata/test_transform.TestYamlConfigTransformations.test_simplified_dump_/mirror-3dc-3-nodes-in-memory.yaml.result.json
+++ b/ydb/library/yaml_config/ut_transform/canondata/test_transform.TestYamlConfigTransformations.test_simplified_dump_/mirror-3dc-3-nodes-in-memory.yaml.result.json
@@ -217,7 +217,7 @@
               "+(DS|RA):METADATA-READERS",
               "+(SR):DATA-READERS",
               "+(UR|ER):DATA-WRITERS",
-              "+(CD|CT|WA|AS|RS):DDL-ADMINS",
+              "+(CD|CT|CQ|WA|AS|RS):DDL-ADMINS",
               "+(GAR):ACCESS-ADMINS",
               "+(CDB|DDB):DATABASE-ADMINS"
             ],

--- a/ydb/library/yaml_config/ut_transform/canondata/test_transform.TestYamlConfigTransformations.test_simplified_dump_/mirror-3dc-3-nodes.yaml.result.json
+++ b/ydb/library/yaml_config/ut_transform/canondata/test_transform.TestYamlConfigTransformations.test_simplified_dump_/mirror-3dc-3-nodes.yaml.result.json
@@ -217,7 +217,7 @@
               "+(DS|RA):METADATA-READERS",
               "+(SR):DATA-READERS",
               "+(UR|ER):DATA-WRITERS",
-              "+(CD|CT|WA|AS|RS):DDL-ADMINS",
+              "+(CD|CT|CQ|WA|AS|RS):DDL-ADMINS",
               "+(GAR):ACCESS-ADMINS",
               "+(CDB|DDB):DATABASE-ADMINS"
             ],

--- a/ydb/library/yaml_config/ut_transform/canondata/test_transform.TestYamlConfigTransformations.test_simplified_dump_/mirror-3dc-9-nodes.yaml.result.json
+++ b/ydb/library/yaml_config/ut_transform/canondata/test_transform.TestYamlConfigTransformations.test_simplified_dump_/mirror-3dc-9-nodes.yaml.result.json
@@ -288,7 +288,7 @@
               "+(DS|RA):METADATA-READERS",
               "+(SR):DATA-READERS",
               "+(UR|ER):DATA-WRITERS",
-              "+(CD|CT|WA|AS|RS):DDL-ADMINS",
+              "+(CD|CT|CQ|WA|AS|RS):DDL-ADMINS",
               "+(GAR):ACCESS-ADMINS",
               "+(CDB|DDB):DATABASE-ADMINS"
             ],

--- a/ydb/library/yaml_config/ut_transform/canondata/test_transform.TestYamlConfigTransformations.test_simplified_dump_/ram.yaml.result.json
+++ b/ydb/library/yaml_config/ut_transform/canondata/test_transform.TestYamlConfigTransformations.test_simplified_dump_/ram.yaml.result.json
@@ -179,7 +179,7 @@
               "+(DS|RA):METADATA-READERS",
               "+(SR):DATA-READERS",
               "+(UR|ER):DATA-WRITERS",
-              "+(CD|CT|WA|AS|RS):DDL-ADMINS",
+              "+(CD|CT|CQ|WA|AS|RS):DDL-ADMINS",
               "+(GAR):ACCESS-ADMINS",
               "+(CDB|DDB):DATABASE-ADMINS"
             ],

--- a/ydb/library/yaml_config/ut_transform/canondata/test_transform.TestYamlConfigTransformations.test_simplified_dump_/single-node-in-memory.yaml.result.json
+++ b/ydb/library/yaml_config/ut_transform/canondata/test_transform.TestYamlConfigTransformations.test_simplified_dump_/single-node-in-memory.yaml.result.json
@@ -179,7 +179,7 @@
               "+(DS|RA):METADATA-READERS",
               "+(SR):DATA-READERS",
               "+(UR|ER):DATA-WRITERS",
-              "+(CD|CT|WA|AS|RS):DDL-ADMINS",
+              "+(CD|CT|CQ|WA|AS|RS):DDL-ADMINS",
               "+(GAR):ACCESS-ADMINS",
               "+(CDB|DDB):DATABASE-ADMINS"
             ],

--- a/ydb/library/yaml_config/ut_transform/canondata/test_transform.TestYamlConfigTransformations.test_simplified_dump_/single-node-with-file.yaml.result.json
+++ b/ydb/library/yaml_config/ut_transform/canondata/test_transform.TestYamlConfigTransformations.test_simplified_dump_/single-node-with-file.yaml.result.json
@@ -179,7 +179,7 @@
               "+(DS|RA):METADATA-READERS",
               "+(SR):DATA-READERS",
               "+(UR|ER):DATA-WRITERS",
-              "+(CD|CT|WA|AS|RS):DDL-ADMINS",
+              "+(CD|CT|CQ|WA|AS|RS):DDL-ADMINS",
               "+(GAR):ACCESS-ADMINS",
               "+(CDB|DDB):DATABASE-ADMINS"
             ],

--- a/ydb/library/yaml_config/yaml_config_parser.cpp
+++ b/ydb/library/yaml_config/yaml_config_parser.cpp
@@ -513,7 +513,7 @@ namespace NKikimr::NYaml {
             securityConfig->AddDefaultAccess("+(DS|RA):METADATA-READERS"); // DescribeSchema | ReadAttributes
             securityConfig->AddDefaultAccess("+(SR):DATA-READERS"); // SelectRow
             securityConfig->AddDefaultAccess("+(UR|ER):DATA-WRITERS"); // UpdateRow | EraseRow
-            securityConfig->AddDefaultAccess("+(CD|CT|WA|AS|RS):DDL-ADMINS"); // CreateDirectory | CreateTable | WriteAttributes | AlterSchema | RemoveSchema
+            securityConfig->AddDefaultAccess("+(CD|CT|CQ|WA|AS|RS):DDL-ADMINS"); // CreateDirectory | CreateTable | CreateQueue | WriteAttributes | AlterSchema | RemoveSchema
             securityConfig->AddDefaultAccess("+(GAR):ACCESS-ADMINS"); // GrantAccessRights
             securityConfig->AddDefaultAccess("+(CDB|DDB):DATABASE-ADMINS"); // CreateDatabase | DropDatabase
         }


### PR DESCRIPTION
Add missing `CreateQueue` permission to `DDL-ADMINS` group at builtin security configuration phase.

### Changelog category

* Not for changelog