### PR TITLE
Support TString = std::string in TSerializedCellVec

### DIFF
--- a/ydb/core/scheme/scheme_tablecell.cpp
+++ b/ydb/core/scheme/scheme_tablecell.cpp
@@ -396,10 +396,8 @@ namespace {
         return true;
     }
 
-    Y_FORCE_INLINE bool TryDeserializeCellVec(const TString& data, TString& resultBuffer, TVector<TCell> & resultCells) {
-        resultBuffer.clear();
+    Y_FORCE_INLINE bool TryDeserializeCellVec(const TString& data, TVector<TCell>& resultCells) {
         resultCells.clear();
-
         if (data.empty()) {
             return true;
         }
@@ -415,14 +413,11 @@ namespace {
             return false;
         }
 
-        resultBuffer = data;
         return true;
     }
 
-    Y_FORCE_INLINE bool TryDeserializeCellMatrix(const TString& data, TString& resultBuffer, TVector<TCell>& resultCells, ui32& rowCount, ui16& colCount) {
-        resultBuffer.clear();
+    Y_FORCE_INLINE bool TryDeserializeCellMatrix(const TString& data, TVector<TCell>& resultCells, ui32& rowCount, ui16& colCount) {
         resultCells.clear();
-
         if (data.empty()) {
             return true;
         }
@@ -437,7 +432,6 @@ namespace {
             return false;
         }
 
-        resultBuffer = data;
         return true;
     }
 }
@@ -466,8 +460,13 @@ size_t TSerializedCellVec::SerializedSize(TConstArrayRef<TCell> cells) {
     return size;
 }
 
-bool TSerializedCellVec::DoTryParse(const TString& data) {
-    return TryDeserializeCellVec(data, Buf, Cells);
+bool TSerializedCellVec::DoTryParse() {
+    if (!TryDeserializeCellVec(Buf, Cells)) {
+        Buf.clear();
+        Cells.clear();
+        return false;
+    }
+    return true;
 }
 
 bool TSerializedCellVec::UnsafeAppendCells(TConstArrayRef<TCell> cells, TString& serializedCellVec) {
@@ -554,8 +553,15 @@ TString TSerializedCellMatrix::Serialize(TConstArrayRef<TCell> cells, ui32 rowCo
     return result;
 }
 
-bool TSerializedCellMatrix::DoTryParse(const TString& data) {
-    return TryDeserializeCellMatrix(data, Buf, Cells, RowCount, ColCount);
+bool TSerializedCellMatrix::DoTryParse() {
+    if (!TryDeserializeCellMatrix(Buf, Cells, RowCount, ColCount)) {
+        Buf.clear();
+        Cells.clear();
+        RowCount = 0;
+        ColCount = 0;
+        return false;
+    }
+    return true;
 }
 
 void TCellsStorage::Reset(TArrayRef<const TCell> cells)

--- a/ydb/core/scheme/scheme_tablecell.h
+++ b/ydb/core/scheme/scheme_tablecell.h
@@ -512,55 +512,84 @@ static_assert(std::is_nothrow_default_constructible_v<TOwnedCellVec>, "Expected 
 // When loading from a buffer the cells will point to the buffer contents
 class TSerializedCellVec {
 public:
-    explicit TSerializedCellVec(TConstArrayRef<TCell> cells);
-
-    explicit TSerializedCellVec(const TString& buf)
-    {
-        Parse(buf);
-    }
-
     TSerializedCellVec() = default;
 
-    TSerializedCellVec(const TSerializedCellVec &other)
-        : Buf(other.Buf)
-        , Cells(other.Cells)
+    explicit TSerializedCellVec(TConstArrayRef<TCell> cells);
+
+    explicit TSerializedCellVec(TString&& buf)
+        : Buf(std::move(buf))
     {
-        Y_ABORT_UNLESS(Buf.data() == other.Buf.data(), "Buffer must be shared");
+        Y_ABORT_UNLESS(DoTryParse());
     }
 
-    TSerializedCellVec(TSerializedCellVec &&other)
+    explicit TSerializedCellVec(const TString& buf)
+        : Buf(buf)
+    {
+        Y_ABORT_UNLESS(DoTryParse());
+    }
+
+    TSerializedCellVec(TSerializedCellVec&& other)
     {
         *this = std::move(other);
     }
 
-    TSerializedCellVec &operator=(const TSerializedCellVec &other)
+    TSerializedCellVec(const TSerializedCellVec& other)
+    {
+        *this = other;
+    }
+
+    TSerializedCellVec& operator=(TSerializedCellVec&& other)
     {
         if (this == &other)
             return *this;
 
-        TSerializedCellVec tmp(other);
-        *this = std::move(tmp);
+        const char* prevPtr = other.Buf.data();
+        Buf = std::move(other.Buf);
+        if (Buf.data() != prevPtr) {
+            // Data address changed, e.g. when TString is a small std::string
+            Y_ABORT_UNLESS(DoTryParse(), "Failed to re-parse TSerializedCellVec");
+            other.Cells.clear();
+        } else {
+            // Data address unchanged, reuse parsed Cells
+            Cells = std::move(other.Cells);
+        }
         return *this;
     }
 
-    TSerializedCellVec &operator=(TSerializedCellVec &&other)
+    TSerializedCellVec& operator=(const TSerializedCellVec& other)
     {
         if (this == &other)
             return *this;
 
-        const char* otherPtr = other.Buf.data();
-        Buf = std::move(other.Buf);
-        Y_ABORT_UNLESS(Buf.data() == otherPtr, "Buffer address must not change");
-        Cells = std::move(other.Cells);
+        Buf = other.Buf;
+        if (Buf.data() != other.Buf.data()) {
+            // Data address changed, e.g. when TString is std::string
+            Y_ABORT_UNLESS(DoTryParse(), "Failed to re-parse TSerializedCellVec");
+        } else {
+            // Data address unchanged, reuse parsed Cells
+            Cells = other.Cells;
+        }
         return *this;
+    }
+
+    static bool TryParse(TString&& data, TSerializedCellVec& vec) {
+        vec.Buf = std::move(data);
+        return vec.DoTryParse();
     }
 
     static bool TryParse(const TString& data, TSerializedCellVec& vec) {
-        return vec.DoTryParse(data);
+        vec.Buf = data;
+        return vec.DoTryParse();
     }
 
-    void Parse(const TString &buf) {
-        Y_ABORT_UNLESS(DoTryParse(buf));
+    void Parse(TString&& buf) {
+        Buf = std::move(buf);
+        Y_ABORT_UNLESS(DoTryParse());
+    }
+
+    void Parse(const TString& buf) {
+        Buf = buf;
+        Y_ABORT_UNLESS(DoTryParse());
     }
 
     TConstArrayRef<TCell> GetCells() const {
@@ -581,7 +610,7 @@ public:
 
     static size_t SerializedSize(TConstArrayRef<TCell> cells);
 
-    const TString &GetBuffer() const { return Buf; }
+    const TString& GetBuffer() const { return Buf; }
 
     TString ReleaseBuffer() {
         Cells.clear();
@@ -589,7 +618,7 @@ public:
     }
 
 private:
-    bool DoTryParse(const TString& data);
+    bool DoTryParse();
 
 private:
     TString Buf;
@@ -600,14 +629,21 @@ private:
 // When loading from a buffer the cells will point to the buffer contents
 class TSerializedCellMatrix {
 public:
+    TSerializedCellMatrix() = default;
+
     explicit TSerializedCellMatrix(TConstArrayRef<TCell> cells, ui32 rowCount, ui16 colCount);
 
-    explicit TSerializedCellMatrix(const TString& buf)
+    explicit TSerializedCellMatrix(TString&& buf)
+        : Buf(std::move(buf))
     {
-        Parse(buf);
+        Y_ABORT_UNLESS(DoTryParse());
     }
 
-    TSerializedCellMatrix() = default;
+    explicit TSerializedCellMatrix(const TString& buf)
+        : Buf(buf)
+    {
+        Y_ABORT_UNLESS(DoTryParse());
+    }
 
     TSerializedCellMatrix(const TSerializedCellMatrix& other)
         : Buf(other.Buf)
@@ -623,36 +659,64 @@ public:
         *this = std::move(other);
     }
 
-    TSerializedCellMatrix& operator=(const TSerializedCellMatrix& other)
-    {
-        if (this == &other)
-            return *this;
-
-        TSerializedCellMatrix tmp(other);
-        *this = std::move(tmp);
-        return *this;
-    }
-
     TSerializedCellMatrix& operator=(TSerializedCellMatrix&& other)
     {
         if (this == &other)
             return *this;
 
-        const char* otherPtr = other.Buf.data();
+        const char* prevPtr = other.Buf.data();
         Buf = std::move(other.Buf);
-        Y_ABORT_UNLESS(Buf.data() == otherPtr, "Buffer address must not change");
-        Cells = std::move(other.Cells);
-        RowCount = std::move(other.RowCount);
-        ColCount = std::move(other.ColCount);
+        if (Buf.data() != prevPtr) {
+            // Data address changed, e.g. when TString is a small std::string
+            Y_ABORT_UNLESS(DoTryParse(), "Failed to re-parse TSerializedCellMatrix");
+            other.Cells.clear();
+        } else {
+            // Data address unchanged, reuse parsed cells
+            Cells = std::move(other.Cells);
+            RowCount = other.RowCount;
+            ColCount = other.ColCount;
+        }
+        other.RowCount = 0;
+        other.ColCount = 0;
         return *this;
     }
 
+    TSerializedCellMatrix& operator=(const TSerializedCellMatrix& other)
+    {
+        if (this == &other)
+            return *this;
+
+        Buf = other.Buf;
+        if (Buf.data() != other.Buf.data()) {
+            // Data address changed, e.g. when TString is std::string
+            Y_ABORT_UNLESS(DoTryParse(), "Failed to re-parse TSerializedCellMatrix");
+        } else {
+            // Data address unchanged, reuse parsed cells
+            Cells = other.Cells;
+            RowCount = other.RowCount;
+            ColCount = other.ColCount;
+        }
+        return *this;
+    }
+
+    static bool TryParse(TString&& data, TSerializedCellMatrix& vec) {
+        vec.Buf = std::move(data);
+        return vec.DoTryParse();
+    }
+
     static bool TryParse(const TString& data, TSerializedCellMatrix& vec) {
-        return vec.DoTryParse(data);
+        vec.Buf = data;
+        return vec.DoTryParse();
+    }
+
+    void Parse(TString&& buf) {
+        Buf = std::move(buf);
+        Y_ABORT_UNLESS(DoTryParse());
     }
 
     void Parse(const TString& buf) {
-        Y_ABORT_UNLESS(DoTryParse(buf));
+        Buf = buf;
+        Y_ABORT_UNLESS(DoTryParse());
     }
 
     TConstArrayRef<TCell> GetCells() const { return Cells; }
@@ -680,7 +744,7 @@ public:
     }
 
 private:
-    bool DoTryParse(const TString& data);
+    bool DoTryParse();
 
 private:
     TString Buf;


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of changes introduced in this PR -->

...

### Changelog category <!-- remove all except one -->

* Not for changelog (changelog entry is not required)

### Additional information

Currently TSerializedCellVec aborts when TString is std::string since addresses often change.