### PR TITLE
audiglog: fix item_count field name for the imports

### DIFF
--- a/ydb/core/tx/schemeshard/schemeshard_audit_log.cpp
+++ b/ydb/core/tx/schemeshard/schemeshard_audit_log.cpp
@@ -278,7 +278,7 @@ TParts ImportKindSpecificParts(const Proto& proto) {
 template <> TParts ImportKindSpecificParts(const Ydb::Import::ImportFromS3Settings& proto) {
     return {
         {"import_type", "s3"},
-        {"export_item_count", ToString(proto.items().size())},
+        {"import_item_count", ToString(proto.items().size())},
         {"import_s3_bucket", proto.bucket()},
         //NOTE: take first item's source_prefix as a "good enough approximation"
         // (each item has its own source_prefix, but in practice they are all the same)


### PR DESCRIPTION
Fix audit record field name (`import_item_count`) for the (database/tables) import operations.

Follow-up to #8550.

KIKIMR-21797

### Changelog category

* Not for changelog