### PR TITLE
fixed bug in S3 Physical Optimizer 2

### DIFF
--- a/ydb/core/kqp/ut/federated_query/s3/kqp_federated_query_ut.cpp
+++ b/ydb/core/kqp/ut/federated_query/s3/kqp_federated_query_ut.cpp
@@ -2384,7 +2384,37 @@ Y_UNIT_TEST_SUITE(KqpFederatedQuery) {
         {
             const TString sql = fmt::format(R"(
                     INSERT INTO {destination}
+                        SELECT key, value FROM {source} LIMIT 1;)",
+                    "destination"_a = table1,
+                    "source"_a = olapTable);
+
+            auto scriptExecutionOperation = db.ExecuteScript(sql).ExtractValueSync();
+            UNIT_ASSERT_VALUES_EQUAL_C(scriptExecutionOperation.Status().GetStatus(), EStatus::SUCCESS, scriptExecutionOperation.Status().GetIssues().ToString());
+            UNIT_ASSERT(scriptExecutionOperation.Metadata().ExecutionId);
+
+            NYdb::NQuery::TScriptExecutionOperation readyOp = WaitScriptExecutionOperation(scriptExecutionOperation.Id(), kikimr->GetDriver());
+            UNIT_ASSERT_EQUAL_C(readyOp.Metadata().ExecStatus, EExecStatus::Completed, readyOp.Status().GetIssues().ToString());
+        }
+
+        {
+            const TString sql = fmt::format(R"(
+                    INSERT INTO {destination}
                         SELECT key, value, "2024" AS year FROM {source};)",
+                    "destination"_a = table2,
+                    "source"_a = olapTable);
+
+            auto scriptExecutionOperation = db.ExecuteScript(sql).ExtractValueSync();
+            UNIT_ASSERT_VALUES_EQUAL_C(scriptExecutionOperation.Status().GetStatus(), EStatus::SUCCESS, scriptExecutionOperation.Status().GetIssues().ToString());
+            UNIT_ASSERT(scriptExecutionOperation.Metadata().ExecutionId);
+
+            NYdb::NQuery::TScriptExecutionOperation readyOp = WaitScriptExecutionOperation(scriptExecutionOperation.Id(), kikimr->GetDriver());
+            UNIT_ASSERT_EQUAL_C(readyOp.Metadata().ExecStatus, EExecStatus::Completed, readyOp.Status().GetIssues().ToString());
+        }
+
+        {
+            const TString sql = fmt::format(R"(
+                    INSERT INTO {destination}
+                        SELECT key, value, "2024" AS year FROM {source} LIMIT 1;)",
                     "destination"_a = table2,
                     "source"_a = olapTable);
 

--- a/ydb/core/kqp/ut/federated_query/s3/kqp_federated_query_ut.cpp
+++ b/ydb/core/kqp/ut/federated_query/s3/kqp_federated_query_ut.cpp
@@ -2369,7 +2369,7 @@ Y_UNIT_TEST_SUITE(KqpFederatedQuery) {
         {
             const TString sql = fmt::format(R"(
                     INSERT INTO {destination}
-                        SELECT key, value FROM {source} LIMIT 1;)",
+                        SELECT key, value FROM {source};)",
                     "destination"_a = table1,
                     "source"_a = olapTable);
 
@@ -2384,7 +2384,7 @@ Y_UNIT_TEST_SUITE(KqpFederatedQuery) {
         {
             const TString sql = fmt::format(R"(
                     INSERT INTO {destination}
-                        SELECT key, value, "2024" AS year FROM {source} LIMIT 1;)",
+                        SELECT key, value, "2024" AS year FROM {source};)",
                     "destination"_a = table2,
                     "source"_a = olapTable);
 

--- a/ydb/library/yql/providers/s3/provider/yql_s3_phy_opt.cpp
+++ b/ydb/library/yql/providers/s3/provider/yql_s3_phy_opt.cpp
@@ -208,9 +208,10 @@ public:
             TVector<TCoArgument> args;
 
             if (shouldBePassedAsInput) {
+                auto arg = Build<TCoArgument>(ctx, writePos).Name("in").Done();
                 stageInputs.Add(input);
-                args.push_back(Build<TCoArgument>(ctx, writePos).Name("in").Done());
-                toFlow.Input("in");
+                args.push_back(arg);
+                toFlow.Input(arg);
             }
             else {
                 toFlow.Input(input);


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of changes introduced in this PR -->

исправление для [YQ-3957](https://st.yandex-team.ru/YQ-3957) 

откат https://github.com/ydb-platform/ydb/pull/12985

оптимизатор ругался на вложенные DQ стейджи, которые получались при работе TS3PhysicalOptimizer (yql_s3_phy_opt.cpp:211, 244). Чтобы стейджи не были вложенными надо передавать input в Inputs() dq стейджа, а в лямбде тела стейджа использовать входной аргумент 

### Changelog category <!-- remove all except one -->

* Bugfix 