### PR TITLE
Explicit control of SelfManagement enabling in distconf

### DIFF
--- a/ydb/core/blobstorage/base/blobstorage_events.cpp
+++ b/ydb/core/blobstorage/base/blobstorage_events.cpp
@@ -4,11 +4,12 @@
 namespace NKikimr {
 
     TEvNodeWardenStorageConfig::TEvNodeWardenStorageConfig(const NKikimrBlobStorage::TStorageConfig& config,
-            const NKikimrBlobStorage::TStorageConfig *proposedConfig)
+            const NKikimrBlobStorage::TStorageConfig *proposedConfig, bool selfManagementEnabled)
         : Config(std::make_unique<NKikimrBlobStorage::TStorageConfig>(config))
         , ProposedConfig(proposedConfig
             ? std::make_unique<NKikimrBlobStorage::TStorageConfig>(*proposedConfig)
             : nullptr)
+        , SelfManagementEnabled(selfManagementEnabled)
     {}
 
     TEvNodeWardenStorageConfig::~TEvNodeWardenStorageConfig()

--- a/ydb/core/blobstorage/base/blobstorage_events.h
+++ b/ydb/core/blobstorage/base/blobstorage_events.h
@@ -575,9 +575,10 @@ namespace NKikimr {
     {
         std::unique_ptr<NKikimrBlobStorage::TStorageConfig> Config;
         std::unique_ptr<NKikimrBlobStorage::TStorageConfig> ProposedConfig;
+        bool SelfManagementEnabled;
 
         TEvNodeWardenStorageConfig(const NKikimrBlobStorage::TStorageConfig& config,
-                const NKikimrBlobStorage::TStorageConfig *proposedConfig);
+                const NKikimrBlobStorage::TStorageConfig *proposedConfig, bool selfManagementEnabled);
         ~TEvNodeWardenStorageConfig();
     };
 

--- a/ydb/core/blobstorage/nodewarden/distconf.h
+++ b/ydb/core/blobstorage/nodewarden/distconf.h
@@ -174,6 +174,7 @@ namespace NKikimr::NStorage {
 
         const bool IsSelfStatic = false;
         TIntrusivePtr<TNodeWardenConfig> Cfg;
+        bool SelfManagementEnabled = false;
 
         // currently active storage config
         std::optional<NKikimrBlobStorage::TStorageConfig> StorageConfig;

--- a/ydb/core/blobstorage/nodewarden/distconf_console.cpp
+++ b/ydb/core/blobstorage/nodewarden/distconf_console.cpp
@@ -12,10 +12,8 @@ namespace NKikimr::NStorage {
             return; // this is not the root node
         } else if (enablingDistconf) {
             // NO RETURN HERE -> right now we are enabling distconf, so we can skip rest of the checks
-        } else if (!StorageConfig || !StorageConfig->GetSelfManagementConfig().GetEnabled()) {
-            return; // no self-management config enabled
-        } else if (!StorageConfig->HasStateStorageConfig()) {
-            return; // no way to find Console too
+        } else if (!SelfManagementEnabled || !StorageConfig->HasStateStorageConfig()) {
+            return; // no self-management config enabled or no way to find Console (no statestorage configured yet)
         }
 
         STLOG(PRI_DEBUG, BS_NODE, NWDC66, "ConnectToConsole: creating pipe to the Console");

--- a/ydb/core/blobstorage/nodewarden/distconf_dynamic.cpp
+++ b/ydb/core/blobstorage/nodewarden/distconf_dynamic.cpp
@@ -109,7 +109,7 @@ namespace NKikimr::NStorage {
             ev->Record.SetNoQuorum(true);
         } else if (!StorageConfig) {
             // no storage configuration -- no nothing
-        } else if (auto *target = record.MutableConfig(); StorageConfig->GetSelfManagementConfig().GetEnabled()) {
+        } else if (auto *target = record.MutableConfig(); SelfManagementEnabled) {
             target->CopyFrom(*StorageConfig);
         } else {
             target->CopyFrom(BaseConfig);

--- a/ydb/core/blobstorage/nodewarden/distconf_mon.cpp
+++ b/ydb/core/blobstorage/nodewarden/distconf_mon.cpp
@@ -153,6 +153,15 @@ namespace NKikimr::NStorage {
                     }
                 }
 
+                DIV_CLASS("panel panel-info") {
+                    DIV_CLASS("panel-heading") {
+                        out << "Main operational parameters";
+                    }
+                    DIV_CLASS("panel-body") {
+                        out << "Self-management enabled: " << (SelfManagementEnabled ? "yes" : "no") << "<br/>";
+                    }
+                }
+
                 auto outputConfig = [&](const char *name, auto *config) {
                     DIV_CLASS("panel panel-info") {
                         DIV_CLASS("panel-heading") {

--- a/ydb/core/blobstorage/nodewarden/distconf_persistent_storage.cpp
+++ b/ydb/core/blobstorage/nodewarden/distconf_persistent_storage.cpp
@@ -293,12 +293,15 @@ namespace NKikimr::NStorage {
 
             // generate new list of drives to acquire
             std::vector<TString> drivesToRead;
-            EnumerateConfigDrives(InitialConfig, SelfId().NodeId(), [&](const auto& /*node*/, const auto& drive) {
-                drivesToRead.push_back(drive.GetPath());
-            });
-            std::sort(drivesToRead.begin(), drivesToRead.end());
+            if (BaseConfig.GetSelfManagementConfig().GetEnabled()) {
+                EnumerateConfigDrives(InitialConfig, SelfId().NodeId(), [&](const auto& /*node*/, const auto& drive) {
+                    drivesToRead.push_back(drive.GetPath());
+                });
+                std::sort(drivesToRead.begin(), drivesToRead.end());
+            }
 
             if (DrivesToRead != drivesToRead) { // re-read configuration as it may cover additional drives
+                DrivesToRead = std::move(drivesToRead);
                 ReadConfig();
             } else {
                 ApplyStorageConfig(InitialConfig);

--- a/ydb/core/blobstorage/nodewarden/node_warden_impl.h
+++ b/ydb/core/blobstorage/nodewarden/node_warden_impl.h
@@ -586,6 +586,7 @@ namespace NKikimr::NStorage {
         void ForwardToDistributedConfigKeeper(STATEFN_SIG);
 
         NKikimrBlobStorage::TStorageConfig StorageConfig;
+        bool SelfManagementEnabled = false;
         THashSet<TActorId> StorageConfigSubscribers;
 
         void Handle(TEvNodeWardenQueryStorageConfig::TPtr ev);

--- a/ydb/core/blobstorage/nodewarden/node_warden_mon.cpp
+++ b/ydb/core/blobstorage/nodewarden/node_warden_mon.cpp
@@ -105,6 +105,7 @@ void TNodeWarden::RenderWholePage(IOutputStream& out) {
 
         TAG(TH3) { out << "StorageConfig"; }
         DIV() {
+            out << "<p>Self-management enabled: " << (SelfManagementEnabled ? "yes" : "no") << "</p>";
             TString s;
             NProtoBuf::TextFormat::PrintToString(StorageConfig, &s);
             out << "<pre>" << s << "</pre>";

--- a/ydb/core/blobstorage/ut_blobstorage/lib/node_warden_mock_bsc.cpp
+++ b/ydb/core/blobstorage/ut_blobstorage/lib/node_warden_mock_bsc.cpp
@@ -226,7 +226,7 @@ void TNodeWardenMockActor::Handle(TEvBlobStorage::TEvControllerNodeServiceSetUpd
 }
 
 void TNodeWardenMockActor::Handle(TEvNodeWardenQueryStorageConfig::TPtr ev) {
-    Send(ev->Sender, new TEvNodeWardenStorageConfig(NKikimrBlobStorage::TStorageConfig(), nullptr));
+    Send(ev->Sender, new TEvNodeWardenStorageConfig(NKikimrBlobStorage::TStorageConfig(), nullptr, false));
 }
 
 void TNodeWardenMockActor::HandleUnsubscribe(STATEFN_SIG) {

--- a/ydb/core/mind/bscontroller/bsc.cpp
+++ b/ydb/core/mind/bscontroller/bsc.cpp
@@ -97,6 +97,8 @@ NKikimrBlobStorage::TGroupStatus::E TBlobStorageController::DeriveStatus(const T
 }
 
 void TBlobStorageController::OnActivateExecutor(const TActorContext&) {
+    StartConsoleInteraction();
+
     // create stat processor
     StatProcessorActorId = Register(CreateStatProcessorActor());
 
@@ -124,6 +126,7 @@ void TBlobStorageController::OnActivateExecutor(const TActorContext&) {
 
 void TBlobStorageController::Handle(TEvNodeWardenStorageConfig::TPtr ev) {
     ev->Get()->Config->Swap(&StorageConfig);
+    SelfManagementEnabled = ev->Get()->SelfManagementEnabled;
 
     auto prevStaticPDisks = std::exchange(StaticPDisks, {});
     auto prevStaticVSlots = std::exchange(StaticVSlots, {});
@@ -158,20 +161,21 @@ void TBlobStorageController::Handle(TEvNodeWardenStorageConfig::TPtr ev) {
         }
     }
 
-    if (StorageConfig.GetSelfManagementConfig().GetEnabled()) {
+    if (SelfManagementEnabled) {
         // assuming that in autoconfig mode HostRecords are managed by the distconf; we need to apply it here to
         // avoid race with box autoconfiguration and node list change
         HostRecords = std::make_shared<THostRecordMap::element_type>(StorageConfig);
         if (SelfHealId) {
             Send(SelfHealId, new TEvPrivate::TEvUpdateHostRecords(HostRecords));
         }
+
+        ConsoleInteraction->Stop(); // distconf will handle the Console from now on
     } else {
-        StartConsoleInteraction();
-        ConsoleInteraction->Start(); // start console interaction when working in non-distconf mode
+        ConsoleInteraction->Start(); // we control the Console now
     }
 
     if (!std::exchange(StorageConfigObtained, true)) { // this is the first time we get StorageConfig in this instance of BSC
-        if (HostRecords) {
+        if (SelfManagementEnabled) {
             OnHostRecordsInitiate();
         } else {
             Send(GetNameserviceActorId(), new TEvInterconnect::TEvListNodes(true));
@@ -192,9 +196,7 @@ void TBlobStorageController::Handle(TEvents::TEvUndelivered::TPtr ev) {
 }
 
 void TBlobStorageController::ApplyStorageConfig(bool ignoreDistconf) {
-    if (!StorageConfig.HasBlobStorageConfig() || // this would be strange
-            !ignoreDistconf && (!StorageConfig.GetSelfManagementConfig().GetEnabled() ||
-            !StorageConfig.GetSelfManagementConfig().GetAutomaticBoxManagement())) {
+    if (!StorageConfig.HasBlobStorageConfig()) {
         return;
     }
     const auto& bsConfig = StorageConfig.GetBlobStorageConfig();
@@ -202,6 +204,11 @@ void TBlobStorageController::ApplyStorageConfig(bool ignoreDistconf) {
     if (Boxes.size() > 1) {
         return;
     }
+
+    if (!ignoreDistconf && (!SelfManagementEnabled || !StorageConfig.GetSelfManagementConfig().GetAutomaticBoxManagement())) {
+        return; // not expected to be managed by BSC
+    }
+
     std::optional<ui64> generation;
     if (!Boxes.empty()) {
         const auto& [boxId, box] = *Boxes.begin();
@@ -292,11 +299,10 @@ void TBlobStorageController::OnHostRecordsInitiate() {
                 "BlobStorageControllerControls.EnableSelfHealWithDegraded");
         }
     }
+    Y_ABORT_UNLESS(!SelfHealId);
     SelfHealId = Register(CreateSelfHealActor());
     PushStaticGroupsToSelfHeal();
-    if (StorageConfigObtained) {
-        Execute(CreateTxInitScheme());
-    }
+    Execute(CreateTxInitScheme());
 }
 
 void TBlobStorageController::IssueInitialGroupContent() {
@@ -471,9 +477,9 @@ void TBlobStorageController::PassAway() {
     TActivationContext::Send(new IEventHandle(TEvents::TSystem::Unsubscribe, 0, MakeBlobStorageNodeWardenID(SelfId().NodeId()),
         SelfId(), nullptr, 0));
     if (ConsoleInteraction) {
-        ConsoleInteraction->OnPassAway();
+        ConsoleInteraction->Stop();
     }
-    return TActor::PassAway();
+    TActor::PassAway();
 }
 
 TBlobStorageController::TBlobStorageController(const TActorId &tablet, TTabletStorageInfo *info)

--- a/ydb/core/mind/bscontroller/console_interaction.h
+++ b/ydb/core/mind/bscontroller/console_interaction.h
@@ -31,7 +31,7 @@ namespace NKikimr::NBsController {
         TConsoleInteraction(TBlobStorageController& controller);
         void Start();
         void OnConfigCommit(const TCommitConfigResult& result);
-        void OnPassAway();
+        void Stop();
         bool ParseConfig(const TString& config, ui32& configVersion, NKikimrBlobStorage::TStorageConfig& storageConfig);
         TCommitConfigResult::EStatus CheckConfig(const TString& config, ui32& configVersion, bool skipBSCValidation, NKikimrBlobStorage::TStorageConfig& storageConfig);
 
@@ -53,6 +53,7 @@ namespace NKikimr::NBsController {
         TBackoffTimer GetBlockBackoff{1, 1000};
         ui32 BlockedGeneration = 0;
         bool NeedRetrySession = false;
+        bool Working = false;
 
         void MakeCommitToConsole(TString& config, ui32 configVersion);
         void MakeGetBlock();

--- a/ydb/core/mind/bscontroller/impl.h
+++ b/ydb/core/mind/bscontroller/impl.h
@@ -1539,6 +1539,7 @@ private:
     bool DonorMode = false;
     TDuration ScrubPeriodicity;
     NKikimrBlobStorage::TStorageConfig StorageConfig;
+    bool SelfManagementEnabled = false;
     TString YamlConfig;
     ui32 ConfigVersion = 0;
     TBackoffTimer GetBlockBackoff{1, 1000};
@@ -1572,7 +1573,6 @@ private:
     class TNodeWardenUpdateNotifier;
 
     class TConsoleInteraction;
-
     std::unique_ptr<TConsoleInteraction> ConsoleInteraction;
 
     struct TEvPrivate {
@@ -2111,10 +2111,6 @@ public:
         SignalTabletActive(TActivationContext::AsActorContext());
         Loaded = true;
         ApplyStorageConfig();
-
-        if (!ConsoleInteraction) { // maybe we are in distconf mode, no console interaction yet started
-            StartConsoleInteraction();
-        }
 
         for (const auto& [id, info] : GroupMap) {
             if (info->VirtualGroupState) {

--- a/ydb/core/mind/bscontroller/self_heal.cpp
+++ b/ydb/core/mind/bscontroller/self_heal.cpp
@@ -955,8 +955,7 @@ namespace NKikimr::NBsController {
     }
 
     void TBlobStorageController::PushStaticGroupsToSelfHeal() {
-        if (!SelfHealId || !StorageConfigObtained || !StorageConfig.HasBlobStorageConfig() ||
-                !StorageConfig.GetSelfManagementConfig().GetEnabled()) {
+        if (!SelfHealId || !StorageConfigObtained || !StorageConfig.HasBlobStorageConfig() || !SelfManagementEnabled) {
             return;
         }
 

--- a/ydb/core/mind/bscontroller/ut_bscontroller/main.cpp
+++ b/ydb/core/mind/bscontroller/ut_bscontroller/main.cpp
@@ -243,7 +243,7 @@ struct TEnvironmentSetup {
             {}
 
             void Handle(TEvNodeWardenQueryStorageConfig::TPtr ev) {
-                Send(ev->Sender, new TEvNodeWardenStorageConfig(NKikimrBlobStorage::TStorageConfig(), nullptr));
+                Send(ev->Sender, new TEvNodeWardenStorageConfig(NKikimrBlobStorage::TStorageConfig(), nullptr, false));
             }
 
             STATEFN(StateFunc) {

--- a/ydb/core/mind/bscontroller/ut_selfheal/node_warden_mock.h
+++ b/ydb/core/mind/bscontroller/ut_selfheal/node_warden_mock.h
@@ -180,7 +180,7 @@ public:
     }
 
     void Handle(TEvNodeWardenQueryStorageConfig::TPtr ev) {
-        Send(ev->Sender, new TEvNodeWardenStorageConfig(NKikimrBlobStorage::TStorageConfig(), nullptr));
+        Send(ev->Sender, new TEvNodeWardenStorageConfig(NKikimrBlobStorage::TStorageConfig(), nullptr, false));
     }
 
     STRICT_STFUNC(StateFunc, {

--- a/ydb/core/mind/dynamic_nameserver.cpp
+++ b/ydb/core/mind/dynamic_nameserver.cpp
@@ -146,22 +146,35 @@ void TDynamicNameserver::Bootstrap(const TActorContext &ctx)
 void TDynamicNameserver::Handle(TEvNodeWardenStorageConfig::TPtr ev) {
     Y_ABORT_UNLESS(ev->Get()->Config);
     const auto& config = *ev->Get()->Config;
-    if (config.GetSelfManagementConfig().GetEnabled()) {
+    std::unique_ptr<IEventBase> consoleQuery;
+
+    if (ev->Get()->SelfManagementEnabled) {
         // self-management through distconf is enabled and we are operating based on their tables, so apply them now
-        auto newStaticConfig = BuildNameserverTable(config);
-        if (StaticConfig->StaticNodeTable != newStaticConfig->StaticNodeTable) {
-            StaticConfig = std::move(newStaticConfig);
-            ListNodesCache->Invalidate();
-            for (const auto& subscriber : StaticNodeChangeSubscribers) {
-                TActivationContext::Send(new IEventHandle(SelfId(), subscriber, new TEvInterconnect::TEvListNodes));
-            }
+        ReplaceNameserverSetup(BuildNameserverTable(config));
+
+        // unsubscribe from console if we were operating without self-management before
+        if (std::exchange(SubscribedToConsole, false)) {
+            consoleQuery = std::make_unique<NConsole::TEvConfigsDispatcher::TEvRemoveConfigSubscriptionRequest>(SelfId());
         }
-    } else if (!SubscribedToConsole) {
-        Send(NConsole::MakeConfigsDispatcherID(SelfId().NodeId()), new NConsole::TEvConfigsDispatcher::TEvSetConfigSubscriptionRequest(
+    } else if (!std::exchange(SubscribedToConsole, true)) {
+        consoleQuery = std::make_unique<NConsole::TEvConfigsDispatcher::TEvSetConfigSubscriptionRequest>(
             NKikimrConsole::TConfigItem::NameserviceConfigItem,
             SelfId()
-        ));
-        SubscribedToConsole = true;
+        );
+    }
+
+    if (consoleQuery) {
+        Send(NConsole::MakeConfigsDispatcherID(SelfId().NodeId()), consoleQuery.release());
+    }
+}
+
+void TDynamicNameserver::ReplaceNameserverSetup(TIntrusivePtr<TTableNameserverSetup> newStaticConfig) {
+    if (StaticConfig->StaticNodeTable != newStaticConfig->StaticNodeTable) {
+        StaticConfig = std::move(newStaticConfig);
+        ListNodesCache->Invalidate();
+        for (const auto& subscriber : StaticNodeChangeSubscribers) {
+            TActivationContext::Send(new IEventHandle(SelfId(), subscriber, new TEvInterconnect::TEvListNodes));
+        }
     }
 }
 
@@ -467,19 +480,13 @@ void TDynamicNameserver::Handle(TEvPrivate::TEvUpdateEpoch::TPtr &ev, const TAct
 void TDynamicNameserver::Handle(NConsole::TEvConfigsDispatcher::TEvSetConfigSubscriptionResponse::TPtr /*ev*/)
 {}
 
+void TDynamicNameserver::Handle(NConsole::TEvConfigsDispatcher::TEvRemoveConfigSubscriptionResponse::TPtr /*ev*/)
+{}
+
 void TDynamicNameserver::Handle(NConsole::TEvConsole::TEvConfigNotificationRequest::TPtr ev) {
     auto& record = ev->Get()->Record;
-    if (record.HasConfig()) {
-        if (const auto& config = record.GetConfig(); config.HasNameserviceConfig()) {
-            auto newStaticConfig = BuildNameserverTable(config.GetNameserviceConfig());
-            if (StaticConfig->StaticNodeTable != newStaticConfig->StaticNodeTable) {
-                StaticConfig = std::move(newStaticConfig);
-                ListNodesCache->Invalidate();
-                for (const auto& subscriber : StaticNodeChangeSubscribers) {
-                    TActivationContext::Send(new IEventHandle(SelfId(), subscriber, new TEvInterconnect::TEvListNodes));
-                }
-            }
-        }
+    if (SubscribedToConsole && record.HasConfig() && record.GetConfig().HasNameserviceConfig()) {
+        ReplaceNameserverSetup(BuildNameserverTable(record.GetConfig().GetNameserviceConfig()));
     }
     Send(ev->Sender, new NConsole::TEvConsole::TEvConfigNotificationResponse(record), 0, ev->Cookie);
 }

--- a/ydb/core/mind/dynamic_nameserver_impl.h
+++ b/ydb/core/mind/dynamic_nameserver_impl.h
@@ -232,6 +232,7 @@ public:
             hFunc(TEvents::TEvUnsubscribe, Handle);
 
             hFunc(NConsole::TEvConfigsDispatcher::TEvSetConfigSubscriptionResponse, Handle);
+            hFunc(NConsole::TEvConfigsDispatcher::TEvRemoveConfigSubscriptionResponse, Handle);
             hFunc(NConsole::TEvConsole::TEvConfigNotificationRequest, Handle);
 
             hFunc(TEvNodeWardenStorageConfig, Handle);
@@ -269,9 +270,12 @@ private:
     void Handle(NMon::TEvHttpInfo::TPtr &ev, const TActorContext &ctx);
 
     void Handle(NConsole::TEvConfigsDispatcher::TEvSetConfigSubscriptionResponse::TPtr ev);
+    void Handle(NConsole::TEvConfigsDispatcher::TEvRemoveConfigSubscriptionResponse::TPtr ev);
     void Handle(NConsole::TEvConsole::TEvConfigNotificationRequest::TPtr ev);
 
     void Handle(TEvents::TEvUnsubscribe::TPtr ev);
+
+    void ReplaceNameserverSetup(TIntrusivePtr<TTableNameserverSetup> newStaticConfig);
 
 private:
     TIntrusivePtr<TTableNameserverSetup> StaticConfig;


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of changes introduced in this PR -->

Explicit control of SelfManagement enabling in distconf

### Changelog category <!-- remove all except one -->

* Not for changelog (changelog entry is not required)

### Additional information

Now both of self-management flags are accounted for, stored and loaded from the config.yaml at start.
