### PR TITLE
Renamed the audit log parameter account_type to login_user_level

### DIFF
--- a/ydb/core/grpc_services/audit_logins.cpp
+++ b/ydb/core/grpc_services/audit_logins.cpp
@@ -53,7 +53,7 @@ void AuditLogLogin(IAuditCtx* ctx, const TString& database, const Ydb::Auth::Log
         // Login
         AUDIT_PART("login_user", (!request.user().empty() ? request.user() : EmptyValue))
         AUDIT_PART("sanitized_token", (!sanitizedToken.empty() ? sanitizedToken : EmptyValue))
-        AUDIT_PART("account_type", AdminAccountType, (isAdmin && status == Ydb::StatusIds::SUCCESS))
+        AUDIT_PART("login_user_level", AdminAccountType, (isAdmin && status == Ydb::StatusIds::SUCCESS))
 
         //TODO: (?) it is possible to show masked version of the resulting token here
     );

--- a/ydb/core/tx/schemeshard/ut_login/ut_login.cpp
+++ b/ydb/core/tx/schemeshard/ut_login/ut_login.cpp
@@ -965,9 +965,9 @@ Y_UNIT_TEST_SUITE(TWebLoginService) {
         UNIT_ASSERT(last.find("sanitized_token={none}") == std::string::npos);
 
         if (isUserAdmin) {
-            UNIT_ASSERT_STRING_CONTAINS(last, "account_type=admin");
+            UNIT_ASSERT_STRING_CONTAINS(last, "login_user_level=admin");
         } else {
-            UNIT_ASSERT(!last.contains("account_type=admin"));
+            UNIT_ASSERT(!last.contains("login_user_level=admin"));
         }
     }
 


### PR DESCRIPTION
### Changelog entry

Renamed grpc-login audit log parameter account_type to login_user_level.

### Changelog category

* Not for changelog (changelog entry is not required)

### Additional information

