### PR TITLE
Fix log workload for one key column

### DIFF
--- a/ydb/library/workload/log/log.cpp
+++ b/ydb/library/workload/log/log.cpp
@@ -50,12 +50,9 @@ std::string TLogGenerator::GetDDLQueries() const {
     }
 
     ss << "PRIMARY KEY(";
-    ss << "ts, ";
+    ss << "ts";
     for (size_t i = 1; i < Params.KeyColumnsCnt; ++i) {
-        ss << "c" << i;
-        if (i + 1 < Params.KeyColumnsCnt) {
-            ss << ", ";
-        }
+        ss << ", c" << i;
     }
     ss << ")) WITH (";
 


### PR DESCRIPTION
It was not working with `--key-cols=1` because extra comma in CREATE TABLE