### PR TITLE
Fix multiple streamlookup

### DIFF
--- a/ydb/library/yql/dq/actors/input_transforms/dq_input_transform_lookup.cpp
+++ b/ydb/library/yql/dq/actors/input_transforms/dq_input_transform_lookup.cpp
@@ -522,6 +522,16 @@ std::pair<
             } else {
                 result[i] = { EOutputRowItemSource::LookupOther, lookupPayloadColumns.at(name) };
             }
+        } else if (leftLabel.empty()) {
+            const auto name = prefixedName;
+            if (auto j = leftJoinColumns.FindPtr(name)) {
+                result[i] = { EOutputRowItemSource::InputKey, lookupKeyColumns.at(rightNames[*j]) };
+            } else if (auto k = inputColumns.FindPtr(name)) {
+                result[i] = { EOutputRowItemSource::InputOther, otherInputIndexes.size() };
+                otherInputIndexes.push_back(*k);
+            } else {
+                Y_ABORT();
+            }
         } else {
             Y_ABORT();
         }

--- a/ydb/library/yql/dq/type_ann/dq_type_ann.cpp
+++ b/ydb/library/yql/dq/type_ann/dq_type_ann.cpp
@@ -648,7 +648,7 @@ TStatus AnnotateDqCnStreamLookup(const TExprNode::TPtr& input, TExprContext& ctx
     }
     auto rightInput = cnStreamLookup.RightInput();
     if (!rightInput.Raw()->IsCallable("TDqLookupSourceWrap")) {
-        ctx.AddError(TIssue(ctx.GetPosition(rightInput.Pos()), TStringBuilder() << "DqCnStreamLookup: RightInput: Expected TDqLookupSourceWrap, but got " << rightInput));
+        ctx.AddError(TIssue(ctx.GetPosition(rightInput.Pos()), TStringBuilder() << "DqCnStreamLookup: RightInput: Expected TDqLookupSourceWrap, but got " << rightInput.Raw()->Content()));
         return TStatus::Error;
     }
     const auto& leftRowType = GetSeqItemType(*leftInputType);

--- a/ydb/library/yql/dq/type_ann/dq_type_ann.cpp
+++ b/ydb/library/yql/dq/type_ann/dq_type_ann.cpp
@@ -651,7 +651,6 @@ TStatus AnnotateDqCnStreamLookup(const TExprNode::TPtr& input, TExprContext& ctx
         ctx
     );
     if (!outputRowType) {
-        ctx.AddError(TIssue(ctx.GetPosition(rightInput.Pos()), "DqCnStreamLookup: Failed to annotate output row type"));
         return TStatus::Error;
     }
     if (!EnsureConvertibleTo<ui64>(cnStreamLookup.MaxCachedRows().Ref(), "MaxCachedRows", ctx) ||

--- a/ydb/library/yql/dq/type_ann/dq_type_ann.cpp
+++ b/ydb/library/yql/dq/type_ann/dq_type_ann.cpp
@@ -616,7 +616,7 @@ TStatus AnnotateDqConnection(const TExprNode::TPtr& input, TExprContext& ctx) {
 }
 
 TStatus AnnotateDqCnStreamLookup(const TExprNode::TPtr& input, TExprContext& ctx) {
-    if (!EnsureArgsCount(*input, 10, ctx)) {
+    if (!EnsureArgsCount(*input, 11, ctx)) {
         return TStatus::Error;
     }
     if (!EnsureAtom(*input->Child(TDqCnStreamLookup::idx_LeftLabel), ctx)) {

--- a/ydb/library/yql/dq/type_ann/dq_type_ann.cpp
+++ b/ydb/library/yql/dq/type_ann/dq_type_ann.cpp
@@ -625,8 +625,13 @@ TStatus AnnotateDqCnStreamLookup(const TExprNode::TPtr& input, TExprContext& ctx
         ctx.AddError(TIssue(ctx.GetPosition(joinType.Pos()), "Streamlookup supports only LEFT JOIN ... ANY"));
         return TStatus::Error;
     }
+    auto rightInput = cnStreamLookup.RightInput();
+    if (!rightInput.Raw()->IsCallable("TDqLookupSourceWrap")) {
+        ctx.AddError(TIssue(ctx.GetPosition(rightInput.Pos()), "Unknown DqCnStreamLookup RightInput type (must be TDqLookupSourceWrap)"));
+        return TStatus::Error;
+    }
     const auto leftRowType = GetSeqItemType(leftInputType);
-    const auto rightRowType = GetSeqItemType(cnStreamLookup.RightInput().Raw()->GetTypeAnn());
+    const auto rightRowType = GetSeqItemType(rightInput.Raw()->GetTypeAnn());
     const auto outputRowType = GetDqJoinResultType<true>(
         input->Pos(),
         *leftRowType->Cast<TStructExprType>(),

--- a/ydb/library/yql/providers/dq/opt/logical_optimize.cpp
+++ b/ydb/library/yql/providers/dq/opt/logical_optimize.cpp
@@ -232,10 +232,13 @@ protected:
             return node;
         }
         const auto left = equiJoin.Arg(0).Cast<TCoEquiJoinInput>().List();
-        const auto right = equiJoin.Arg(1).Cast<TCoEquiJoinInput>().List();
+        auto right = equiJoin.Arg(1).Cast<TCoEquiJoinInput>().List();
         const auto joinTuple = equiJoin.Arg(equiJoin.ArgCount() - 2).Cast<TCoEquiJoinTuple>();
         if (!IsStreamLookup(joinTuple)) {
             return node;
+        }
+        if (auto maybeRightExtractMembers = right.Maybe<TCoExtractMembers>()) {
+            right = maybeRightExtractMembers.Cast().Input();
         }
         if (!right.Maybe<TDqSourceWrap>() && !right.Maybe<TDqReadWrap>()) {
             return node;

--- a/ydb/library/yql/providers/dq/opt/logical_optimize.cpp
+++ b/ydb/library/yql/providers/dq/opt/logical_optimize.cpp
@@ -227,6 +227,7 @@ protected:
 
     // Recursively walk join tree and replace right-side of StreamLookupJoin
     ui32 RewriteStreamJoinTuple(ui32 leftIdx, const TCoEquiJoin& equiJoin, const TCoEquiJoinTuple& joinTuple, std::vector<TExprNode::TPtr>& args, TExprContext& ctx, bool& changed) {
+        Y_ENSURE(leftIdx < args.size());
         auto rightIdx = leftIdx + 1;
         if (!joinTuple.LeftScope().Maybe<TCoAtom>()) {
             rightIdx = RewriteStreamJoinTuple(leftIdx, equiJoin, joinTuple.LeftScope().Cast<TCoEquiJoinTuple>(), args, ctx, changed);
@@ -234,6 +235,7 @@ protected:
         if (!joinTuple.RightScope().Maybe<TCoAtom>()) {
             return RewriteStreamJoinTuple(rightIdx, equiJoin, joinTuple.RightScope().Cast<TCoEquiJoinTuple>(), args, ctx, changed);
         }
+        Y_ENSURE(rightIdx < args.size());
         do { // not a loop
             if (!IsStreamLookup(joinTuple)) {
                 break;
@@ -273,6 +275,7 @@ protected:
         if (!changed) {
             return node;
         }
+        // fill copies of remaining args
         for (ui32 i = 0; i < argCount; ++i) {
             if (!args[i]) {
                 args[i] = equiJoin.Arg(i).Ptr();

--- a/ydb/library/yql/providers/dq/opt/physical_optimize.cpp
+++ b/ydb/library/yql/providers/dq/opt/physical_optimize.cpp
@@ -316,9 +316,11 @@ protected:
         if (auto maybe = TExprBase(rightInput).Maybe<TCoExtractMembers>()) {
             rightInput = maybe.Cast().Input().Ptr();
         }
+        auto leftLabel = join.LeftLabel().Maybe<NNodes::TCoAtom>() ? join.LeftLabel().Cast<NNodes::TCoAtom>().Ptr() : ctx.NewAtom(pos, "");
+        Y_ENSURE(join.RightLabel().Maybe<NNodes::TCoAtom>());
         auto cn = Build<TDqCnStreamLookup>(ctx, pos)
             .Output(left.Output().Cast())
-            .LeftLabel(join.LeftLabel().Cast<NNodes::TCoAtom>())
+            .LeftLabel(leftLabel)
             .RightInput(rightInput)
             .RightLabel(join.RightLabel().Cast<NNodes::TCoAtom>())
             .JoinKeys(join.JoinKeys())

--- a/ydb/library/yql/providers/dq/opt/physical_optimize.cpp
+++ b/ydb/library/yql/providers/dq/opt/physical_optimize.cpp
@@ -312,10 +312,14 @@ protected:
         if (!maxDelayedRows) {
             maxDelayedRows = ctx.NewAtom(pos, 1'000'000);
         }
+        auto rightInput = join.RightInput().Ptr();
+        if (auto maybe = TExprBase(rightInput).Maybe<TCoExtractMembers>()) {
+            rightInput = maybe.Cast().Input().Ptr();
+        }
         auto cn = Build<TDqCnStreamLookup>(ctx, pos)
             .Output(left.Output().Cast())
             .LeftLabel(join.LeftLabel().Cast<NNodes::TCoAtom>())
-            .RightInput(join.RightInput())
+            .RightInput(rightInput)
             .RightLabel(join.RightLabel().Cast<NNodes::TCoAtom>())
             .JoinKeys(join.JoinKeys())
             .JoinType(join.JoinType())

--- a/ydb/library/yql/providers/dq/planner/execution_planner.cpp
+++ b/ydb/library/yql/providers/dq/planner/execution_planner.cpp
@@ -608,7 +608,7 @@ namespace NYql::NDqs {
         settings.SetRightLabel(streamLookup.RightLabel().StringValue());
         settings.SetJoinType(streamLookup.JoinType().StringValue());
         for (const auto& k: streamLookup.LeftJoinKeyNames()) {
-            *settings.AddLeftJoinKeyNames() = RemoveAliases(k.StringValue());
+            *settings.AddLeftJoinKeyNames() = streamLookup.LeftLabel().StringValue().empty() ? k.StringValue() : RemoveAliases(k.StringValue());
         }
         for (const auto& k: streamLookup.RightJoinKeyNames()) {
             *settings.AddRightJoinKeyNames() = RemoveAliases(k.StringValue());

--- a/ydb/tests/fq/generic/streaming/test_join.py
+++ b/ydb/tests/fq/generic/streaming/test_join.py
@@ -476,20 +476,20 @@ TESTCASES = [
                     WITH (
                         FORMAT=json_each_row,
                         SCHEMA (
-                            za Int32,
-                            yb STRING,
-                            yc Int32,
-                            zd Int32,
+                            a Int32,
+                            b STRING,
+                            c Int32,
+                            d Int32,
                         )
                     )            ;
 
-            $enriched12 = select u.a as a, u.b as b, u.c as c, u.d as d, u.e as e, u.f as f, za, yb, yc, zd, u2.c as c2, u2.d as d2
+            $enriched12 = select u.a as a, u.b as b, u.c as c, u.d as d, u.e as e, u.f as f, e.a as za, e.b as yb, e.c as yc, e.d as zd, u2.c as c2, u2.d as d2
                 from
                     $input as e
                 left join {streamlookup} any ydb_conn_{table_name}.db as u
-                on(e.za = u.a AND e.yb = u.b)
+                on(e.a = u.a AND e.b = u.b)
                 left join {streamlookup} any ydb_conn_{table_name}.db as u2
-                on(e.yb = u2.b AND e.za = u2.a)
+                on(e.b = u2.b AND e.a = u2.a)
             ;
 
             $enriched = select a, b, c, d, e, f, za, yb, yc, zd, (c2 IS NOT DISTINCT FROM c) as eq1, (d2 IS NOT DISTINCT FROM d) as eq2
@@ -503,19 +503,19 @@ TESTCASES = [
         ResequenceId(
             [
                 (
-                    '{"id":1,"za":1,"yb":"2","yc":100,"zd":101}',
+                    '{"id":1,"a":1,"b":"2","c":100,"d":101}',
                     '{"a":1,"b":"2","c":3,"d":4,"e":5,"f":6,"za":1,"yb":"2","yc":100,"zd":101,"eq1":true,"eq2":true}',
                 ),
                 (
-                    '{"id":2,"za":7,"yb":"8","yc":106,"zd":107}',
+                    '{"id":2,"a":7,"b":"8","c":106,"d":107}',
                     '{"a":7,"b":"8","c":9,"d":10,"e":11,"f":12,"za":7,"yb":"8","yc":106,"zd":107,"eq1":true,"eq2":true}',
                 ),
                 (
-                    '{"id":3,"za":2,"yb":"1","yc":114,"zd":115}',
+                    '{"id":3,"a":2,"b":"1","c":114,"d":115}',
                     '{"a":null,"b":null,"c":null,"d":null,"e":null,"f":null,"za":2,"yb":"1","yc":114,"zd":115,"eq1":true,"eq2":true}',
                 ),
                 (
-                    '{"id":3,"za":null,"yb":"1","yc":114,"zd":115}',
+                    '{"id":3,"a":null,"b":"1","c":114,"d":115}',
                     '{"a":null,"b":null,"c":null,"d":null,"e":null,"f":null,"za":null,"yb":"1","yc":114,"zd":115,"eq1":true,"eq2":true}',
                 ),
             ]

--- a/ydb/tests/fq/generic/streaming/test_join.py
+++ b/ydb/tests/fq/generic/streaming/test_join.py
@@ -433,7 +433,7 @@ TESTCASES = [
                 on(e.za = u.a AND e.yb = u.b)
             ;
 
-            $enriched2 = select a, b, c, d, e, f, za, yb, yc, zd, u.c as c2, u.d as d2
+            $enriched2 = SELECT e.a AS a, e.b AS b, e.c AS c, e.d AS d, e.e AS e, e.f AS f, za, yb, yc, zd, u.c AS c2, u.d AS d2
                 from
                     $enriched1 as e
                 left join {streamlookup} any ydb_conn_{table_name}.db as u

--- a/ydb/tests/fq/generic/streaming/test_join.py
+++ b/ydb/tests/fq/generic/streaming/test_join.py
@@ -381,11 +381,23 @@ TESTCASES = [
                         )
                     )            ;
 
-            $enriched = select a, b, c, d, e, f, za, yb, yc, zd
+            $enriched1 = select a, b, c, d, e, f, za, yb, yc, zd
                 from
                     $input as e
                 left join {streamlookup} any ydb_conn_{table_name}.db as u
                 on(e.za = u.a AND e.yb = u.b)
+            ;
+
+            $enriched2 = select a, b, c, d, e, f, za, yb, yc, zd, u.c as c2, u.d as d2
+                from
+                    $input as enriched1
+                left join {streamlookup} any ydb_conn_{table_name}.db as u
+                on(e.za = u.a AND e.yb = u.b)
+            ;
+
+            $enriched = select a, b, c, d, e, f, za, yb, yc, zd, (c2 IS NOT DISTINCT FROM c) as eq1, (d2 IS NOT DISTINCT FROM d) as eq2
+                from
+                    $input as enriched
             ;
 
             insert into myyds.`{output_topic}`
@@ -395,19 +407,19 @@ TESTCASES = [
             [
                 (
                     '{"id":1,"za":1,"yb":"2","yc":100,"zd":101}',
-                    '{"a":1,"b":"2","c":3,"d":4,"e":5,"f":6,"za":1,"yb":"2","yc":100,"zd":101}',
+                    '{"a":1,"b":"2","c":3,"d":4,"e":5,"f":6,"za":1,"yb":"2","yc":100,"zd":101,"eq1":true,"eq2":true}',
                 ),
                 (
                     '{"id":2,"za":7,"yb":"8","yc":106,"zd":107}',
-                    '{"a":7,"b":"8","c":9,"d":10,"e":11,"f":12,"za":7,"yb":"8","yc":106,"zd":107}',
+                    '{"a":7,"b":"8","c":9,"d":10,"e":11,"f":12,"za":7,"yb":"8","yc":106,"zd":107,"eq1":true,"eq2":true}',
                 ),
                 (
                     '{"id":3,"za":2,"yb":"1","yc":114,"zd":115}',
-                    '{"a":null,"b":null,"c":null,"d":null,"e":null,"f":null,"za":2,"yb":"1","yc":114,"zd":115}',
+                    '{"a":null,"b":null,"c":null,"d":null,"e":null,"f":null,"za":2,"yb":"1","yc":114,"zd":115,"eq1":true,"eq2":true}',
                 ),
                 (
                     '{"id":3,"za":null,"yb":"1","yc":114,"zd":115}',
-                    '{"a":null,"b":null,"c":null,"d":null,"e":null,"f":null,"za":null,"yb":"1","yc":114,"zd":115}',
+                    '{"a":null,"b":null,"c":null,"d":null,"e":null,"f":null,"za":null,"yb":"1","yc":114,"zd":115,"eq1":true,"eq2":true}',
                 ),
             ]
         ),

--- a/ydb/tests/fq/generic/streaming/ydb/01_basic.sh
+++ b/ydb/tests/fq/generic/streaming/ydb/01_basic.sh
@@ -35,7 +35,7 @@ set -ex
       (56, 12, "2a02:1812:1713:4f00:517e:1d79:c88b:704", "Elena", 2),
       (18, 17, "ivalid ip", "newUser", 12);
     COMMIT;
-    CREATE TABLE db (b STRING NOT NULL, c Int32, a Int32 NOT NULL, d Int32, f Int32, e Int32, PRIMARY KEY(b, a));
+    CREATE TABLE db (b STRING NOT NULL, c Int32, a Int32 NOT NULL, d Int32, f Int32, e Int32, g Int32, h Int32, PRIMARY KEY(b, a));
     COMMIT;
     INSERT INTO db (a, b, c, d, e, f) VALUES
       (1, "2", 3, 4, 5, 6),


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of changes introduced in this PR -->

Handle multiple streamlookup joins in query

### Changelog category <!-- remove all except one -->

* Bugfix 
* Not for changelog (changelog entry is not required)

### Additional information
Fixes
```
SELECT ... FROM a
LEFT JOIN /* streamlookup() */ b ON ...
LEFT JOIN /* streamlookup() */ c ON ...
```
There were several issues:
1) `DqReadWrap` -> `TDqLookupSourceWrap` conversion failed to handle `ExtractMembers` (current fix: just drop)
2) `DqJoin` -> `DqCnStreamLookup` conversion failed to handle `ExtractMembers` (current fix: just drop)
3) `DqReadWrap` -> `TDqLookupSourceWrap` conversion only handled 2-way `EquiJoin`
4) `DqJoin` -> `DqCnStreamLookup` conversion failed to handle `(Void)` as `LeftLabel`