### PR TITLE
24-3: Fix uncommitted changes leak and clean them up on startup

### DIFF
--- a/ydb/core/tx/datashard/datashard.cpp
+++ b/ydb/core/tx/datashard/datashard.cpp
@@ -409,6 +409,7 @@ void TDataShard::SwitchToWork(const TActorContext &ctx) {
     NotifySchemeshard(ctx);
     CheckInitiateBorrowedPartsReturn(ctx);
     CheckStateChange(ctx);
+    CleanupUncommitted(ctx);
 }
 
 void TDataShard::SyncConfig() {

--- a/ydb/core/tx/datashard/datashard__cleanup_uncommitted.cpp
+++ b/ydb/core/tx/datashard/datashard__cleanup_uncommitted.cpp
@@ -1,0 +1,88 @@
+#include "datashard_impl.h"
+
+namespace NKikimr::NDataShard {
+
+using namespace NTabletFlatExecutor;
+
+class TDataShard::TTxCleanupUncommitted : public TTransactionBase<TDataShard> {
+public:
+    TTxCleanupUncommitted(TDataShard* self)
+        : TTransactionBase(self)
+    {}
+
+    bool Execute(TTransactionContext& txc, const TActorContext& ctx) override {
+        if (Self->State != TShardState::Ready) {
+            // We need to be very careful about cleaning up uncommitted changes
+            // Avoid mistakes by waiting until shard restarts in a Ready state
+            return true;
+        }
+
+        size_t removed = 0;
+        for (const auto& pr : Self->TableInfos) {
+            if (pr.second->IsReplicated()) {
+                // Replicated tables use uncommitted changes for replication
+                // Since we don't track them we cannot know whether they leaked or not
+                continue;
+            }
+
+            auto localTid = pr.second->LocalTid;
+            if (!txc.DB.GetScheme().GetTableInfo(localTid)) {
+                // Note: this check is likely not needed, since all user tables
+                // must be present in the Ready state, but make sure we don't
+                // trip since this code always runs at startup.
+                continue;
+            }
+
+            auto openTxs = txc.DB.GetOpenTxs(localTid);
+            for (ui64 txId : openTxs) {
+                if (Self->SysLocksTable().GetLocks().contains(txId)) {
+                    // Changes are associated with a known lock
+                    continue;
+                }
+                if (Self->GetVolatileTxManager().FindByCommitTxId(txId)) {
+                    // Changes are associated with a known volatile tx
+                    continue;
+                }
+
+                // Changes are neither committed nor removed and are not tracked
+                if (removed >= 1000) {
+                    // Avoid removing more than 1k transactions per transaction
+                    Reschedule = true;
+                    break;
+                }
+
+                // Remove otherwise untracked changes
+                txc.DB.RemoveTx(localTid, txId);
+                ++removed;
+            }
+
+            if (Reschedule) {
+                break;
+            }
+        }
+
+        if (removed > 0) {
+            LOG_WARN_S(ctx, NKikimrServices::TX_DATASHARD,
+                "DataShard " << Self->TabletID() << " removed " << removed << " untracked uncommitted changes");
+        }
+
+        return true;
+    }
+
+    void Complete(const TActorContext& ctx) override {
+        if (Reschedule) {
+            Self->CleanupUncommitted(ctx);
+        }
+    }
+
+private:
+    bool Reschedule = false;
+};
+
+void TDataShard::CleanupUncommitted(const TActorContext& ctx) {
+    if (State == TShardState::Ready) {
+        Execute(new TTxCleanupUncommitted(this), ctx);
+    }
+}
+
+} // namespace NKikimr::NDataShard

--- a/ydb/core/tx/datashard/datashard_impl.h
+++ b/ydb/core/tx/datashard/datashard_impl.h
@@ -242,6 +242,7 @@ class TDataShard
     class TTxCdcStreamEmitHeartbeats;
     class TTxUpdateFollowerReadEdge;
     class TTxRemoveSchemaSnapshots;
+    class TTxCleanupUncommitted;
 
     template <typename T> friend class TTxDirectBase;
     class TTxUploadRows;
@@ -1421,6 +1422,9 @@ class TDataShard
     void Cleanup(const TActorContext &ctx);
     void SwitchToWork(const TActorContext &ctx);
     void SyncConfig();
+
+    // Cleanup for bug https://github.com/ydb-platform/ydb/issues/13387
+    void CleanupUncommitted(const TActorContext &ctx);
 
     TMaybe<TInstant> GetTxPlanStartTimeAndCleanup(ui64 step);
 

--- a/ydb/core/tx/datashard/execute_write_unit.cpp
+++ b/ydb/core/tx/datashard/execute_write_unit.cpp
@@ -286,6 +286,12 @@ public:
             }
 
             if (guardLocks.LockTxId) {
+                auto abortLock = [&]() {
+                    LOG_TRACE_S(ctx, NKikimrServices::TX_DATASHARD, "Operation " << *op << " at " << tabletId << " aborting because it cannot acquire locks");
+                    writeOp->SetError(NKikimrDataEvents::TEvWriteResult::STATUS_LOCKS_BROKEN, "Operation is aborting because it cannot acquire locks");
+                    return EExecutionStatus::Executed;
+                };
+
                 switch (DataShard.SysLocksTable().EnsureCurrentLock()) {
                     case EEnsureCurrentLock::Success:
                         // Lock is valid, we may continue with reads and side-effects
@@ -294,23 +300,23 @@ public:
                     case EEnsureCurrentLock::Broken:
                         // Lock is valid, but broken, we could abort early in some
                         // cases, but it doesn't affect correctness.
+                        if (!op->IsReadOnly()) {
+                            return abortLock();
+                        }
                         break;
 
                     case EEnsureCurrentLock::TooMany:
                         // Lock cannot be created, it's not necessarily a problem
                         // for read-only transactions, for non-readonly we need to
                         // abort;
-                        if (op->IsReadOnly()) {
-                            break;
+                        if (!op->IsReadOnly()) {
+                            return abortLock();
                         }
-
-                        [[fallthrough]];
+                        break;
 
                     case EEnsureCurrentLock::Abort:
                         // Lock cannot be created and we must abort
-                        LOG_TRACE_S(ctx, NKikimrServices::TX_DATASHARD, "Operation " << *op << " at " << tabletId << " aborting because it cannot acquire locks");
-                        writeOp->SetError(NKikimrDataEvents::TEvWriteResult::STATUS_LOCKS_BROKEN, "Operation is aborting because it cannot acquire locks");
-                        return EExecutionStatus::Executed;
+                        return abortLock();
                 }
             }
 

--- a/ydb/core/tx/datashard/ya.make
+++ b/ydb/core/tx/datashard/ya.make
@@ -49,6 +49,7 @@ SRCS(
     datashard__cleanup_borrowed.cpp
     datashard__cleanup_in_rs.cpp
     datashard__cleanup_tx.cpp
+    datashard__cleanup_uncommitted.cpp
     datashard__conditional_erase_rows.cpp
     datashard__engine_host.cpp
     datashard__engine_host.h


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of changes introduced in this PR -->

Fix uncommitted changes leak and clean them up on startup.

### Changelog category <!-- remove all except one -->

* Bugfix 

### Additional information

It was discovered that uncommitted changes are slowly leaking in some workloads, which turned out to be due to writes combined with a broken read-only lock. This patch fixes the issue and adds automatic cleanup on shard startup.

Fixes #13387.