### PR TITLE
[filestore] Allow 4G+ throttle values 

### DIFF
--- a/ydb/core/protos/blockstore_config.proto
+++ b/ydb/core/protos/blockstore_config.proto
@@ -60,7 +60,7 @@ message TVolumeConfig {
     optional uint32 StorageMediaKind = 13;
 
     // Performance profile fields, used for correct bs group allocation and iops/bandwidth throttling
-    optional uint32 PerformanceProfileMaxReadBandwidth = 14;
+    optional uint64 PerformanceProfileMaxReadBandwidth = 14;
     /* optional uint32 PerformanceProfileMaxBurstBandwidth = 15; obsolete */
     optional uint32 PerformanceProfileMaxPostponedWeight = 16;
     optional bool PerformanceProfileThrottlingEnabled = 17;
@@ -69,7 +69,7 @@ message TVolumeConfig {
     optional uint32 PerformanceProfileBoostTime = 20;
     optional uint32 PerformanceProfileBoostRefillTime = 21;
     optional uint32 PerformanceProfileBoostPercentage = 22;
-    optional uint32 PerformanceProfileMaxWriteBandwidth = 23;
+    optional uint64 PerformanceProfileMaxWriteBandwidth = 23;
     optional uint32 PerformanceProfileMaxWriteIops = 24;
     optional uint32 PerformanceProfileBurstPercentage = 25;
 

--- a/ydb/core/protos/filestore_config.proto
+++ b/ydb/core/protos/filestore_config.proto
@@ -35,9 +35,9 @@ message TConfig {
 
     optional uint32 StorageMediaKind = 32;
 
-    optional uint32 PerformanceProfileMaxReadBandwidth = 33;
+    optional uint64 PerformanceProfileMaxReadBandwidth = 33;
     optional uint32 PerformanceProfileMaxReadIops = 34;
-    optional uint32 PerformanceProfileMaxWriteBandwidth = 35;
+    optional uint64 PerformanceProfileMaxWriteBandwidth = 35;
     optional uint32 PerformanceProfileMaxWriteIops = 36;
     optional uint32 PerformanceProfileBoostTime = 37;
     optional uint32 PerformanceProfileBoostRefillTime = 38;


### PR DESCRIPTION
Change type of Max[Read/Write]Bandwidth config variables to 64bit for allowing 4GB+ values

### Changelog category <!-- remove all except one -->

* Not for changelog (changelog entry is not required)

### Additional information

https://github.com/ydb-platform/nbs/issues/1709
https://github.com/ydb-platform/nbs/pull/1849
