### PR TITLE
Add node interlace to GroupMapper's TScore

### DIFF
--- a/ydb/core/mind/bscontroller/group_mapper.cpp
+++ b/ydb/core/mind/bscontroller/group_mapper.cpp
@@ -405,7 +405,7 @@ namespace NKikimr::NBsController {
 
                 static std::pair<TPDiskLayoutPosition, TPDiskLayoutPosition> MakeRange(const TPDiskLayoutPosition& x, TEntityId& scope) {
                     scope = x.Realm;
-                    return {{x.RealmGroup, x.Realm, TEntityId::Min()}, {x.RealmGroup, x.Realm, TEntityId::Max()}};
+                    return {{x.RealmGroup, x.Realm, TEntityId::Min(), TEntityId::Min()}, {x.RealmGroup, x.Realm, TEntityId::Max(), TEntityId::Max()}};
                 }
             };
 
@@ -415,7 +415,7 @@ namespace NKikimr::NBsController {
 
                 static std::pair<TPDiskLayoutPosition, TPDiskLayoutPosition> MakeRange(const TPDiskLayoutPosition& x, TEntityId& scope) {
                     scope = x.RealmGroup;
-                    return {{x.RealmGroup, TEntityId::Min(), TEntityId::Min()}, {x.RealmGroup, TEntityId::Max(), TEntityId::Max()}};
+                    return {{x.RealmGroup, TEntityId::Min(), TEntityId::Min(), TEntityId::Min()}, {x.RealmGroup, TEntityId::Max(), TEntityId::Max(), TEntityId::Max()}};
                 }
             };
 

--- a/ydb/core/mind/bscontroller/group_mapper_ut.cpp
+++ b/ydb/core/mind/bscontroller/group_mapper_ut.cpp
@@ -593,10 +593,6 @@ Y_UNIT_TEST_SUITE(TGroupMapperTest) {
         TestBlock42(1);
     }
 
-    Y_UNIT_TEST(Block42_2disk) {
-        TestBlock42(2);
-    }
-
     Y_UNIT_TEST(Mirror3dc) {
         TTestContext context(6, 3, 3, 3, 3);
         TGroupMapper mapper(TTestContext::CreateGroupGeometry(TBlobStorageGroupType::ErasureMirror3dc));

--- a/ydb/core/mind/bscontroller/group_mapper_ut.cpp
+++ b/ydb/core/mind/bscontroller/group_mapper_ut.cpp
@@ -638,6 +638,39 @@ Y_UNIT_TEST_SUITE(TGroupMapperTest) {
         }
     }
 
+    Y_UNIT_TEST(InterlacedRacksWithoutInterlacedNodes) {
+        TTestContext context(
+            {
+                {1, 1, 1, 1, 1}, // node 1
+                {1, 1, 2, 1, 1},
+                {1, 1, 3, 1, 2}, // node 3 has two disks
+                {1, 1, 4, 1, 1},
+                {1, 1, 5, 1, 1},
+                {1, 1, 6, 1, 1},
+                {1, 1, 2, 1, 1}, // node 7 is in the same rack as node 2
+                {1, 1, 8, 1, 1},
+                {1, 1, 3, 1, 1}, // node 9 is in the same rack as node 3 
+            }
+        );
+
+        TGroupMapper mapper(TTestContext::CreateGroupGeometry(TBlobStorageGroupType::Erasure4Plus2Block));
+        context.PopulateGroupMapper(mapper, 8);
+        
+        TGroupMapper::TGroupDefinition group;
+        group.emplace_back(TVector<TVector<TPDiskId>>(8));
+        auto& g = group[0];
+
+        for (int i = 0; i < 8; i++) {
+            g[i].emplace_back(TPDiskId(i + 1, 1));
+        }
+
+        context.SetGroup(1, group);
+
+        TGroupMapper::TGroupDefinition newGroup = context.ReallocateGroup(mapper, 1, {TPDiskId(8, 1)});
+
+        UNIT_ASSERT_EQUAL_C(TPDiskId(9, 1), newGroup[0][7][0], context.FormatGroup(newGroup));
+    }
+
     Y_UNIT_TEST(NonUniformClusterDifferentSlotsPerDisk) {
         std::vector<std::tuple<ui32, ui32, ui32, ui32, ui32>> disks;
         for (ui32 rack = 0; rack < 12; ++rack) {


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of changes introduced in this PR -->
Added NodeInterlace to `TScore` so that in case there are multiple VDisks in one rack (and group's DomainInterlace is > 0) next PDisk would not be selected from nodes that already have disks from this group. 

### Changelog category <!-- remove all except one -->

* Improvement