### PR TITLE
Add port_count=1 to DQ job in YT

### DIFF
--- a/ydb/library/yql/providers/dq/actors/yt/yt_resource_manager.cpp
+++ b/ydb/library/yql/providers/dq/actors/yt/yt_resource_manager.cpp
@@ -678,6 +678,7 @@ namespace NYql {
                                             fluent.Item("file_paths").Value(*filePaths);
                                         })
                                         .Item("job_count").Value(1)
+                                        .Item("port_count").Value(1)
                                         .DoIf(Options.YtBackend.HasMemoryLimit(), [&] (NYT::TFluentMap fluent) {
                                             fluent.Item("memory_limit").Value(Options.YtBackend.GetMemoryLimit());
                                         })


### PR DESCRIPTION
### Changelog category <!-- remove all except one -->

* Not for changelog (changelog entry is not required)

### Additional information

Currently, DQ job binds on some port and expects it to be reachable from yql agent

Ideally, it should declare `port_count = 1` and use the port provided by exec node

This PR adds `port_count = 1` to this job to prevent it from being placed on portless exec nodes (that do not have ports)

I created an issue to ytsaurus to start using this port: https://github.com/ytsaurus/ytsaurus/issues/1034