### PR TITLE
Muted unstable and unmute stable tests

### DIFF
--- a/.github/config/muted_ya.txt
+++ b/.github/config/muted_ya.txt
@@ -17,6 +17,7 @@ ydb/core/client/ut TClientTest.PromoteFollower
 ydb/core/cms/ut_sentinel_unstable TSentinelUnstableTests.BSControllerCantChangeStatus
 ydb/core/cms/ut_sentinel_unstable sole chunk chunk
 ydb/core/cms/ut_sentinel_unstable sole+chunk+chunk
+ydb/core/fq/libs/row_dispatcher/ut sole chunk chunk
 ydb/core/keyvalue/ut_trace TKeyValueTracingTest.ReadHuge
 ydb/core/keyvalue/ut_trace TKeyValueTracingTest.ReadSmall
 ydb/core/keyvalue/ut_trace TKeyValueTracingTest.WriteHuge
@@ -57,6 +58,7 @@ ydb/core/kqp/ut/scheme [*/*]+chunk+chunk
 ydb/core/kqp/ut/service KqpQueryService.ExecuteQueryWithResourcePoolClassifier
 ydb/core/kqp/ut/service [*/*] chunk chunk
 ydb/core/kqp/ut/service [*/*]+chunk+chunk
+ydb/core/kqp/ut/spilling KqpScanSpilling.SelfJoinQueryService
 ydb/core/kqp/ut/tx KqpSnapshotIsolation.TConflictReadWriteOlap
 ydb/core/kqp/ut/tx KqpSnapshotIsolation.TConflictReadWriteOltp
 ydb/core/kqp/ut/tx KqpSnapshotIsolation.TConflictReadWriteOltpNoSink
@@ -94,6 +96,8 @@ ydb/services/persqueue_v1/ut TPersQueueCommonTest.TestLimiterLimitsWithBlobsRate
 ydb/services/persqueue_v1/ut TPersQueueCommonTest.TestLimiterLimitsWithUserPayloadRateLimit
 ydb/services/ydb/sdk_sessions_pool_ut YdbSdkSessionsPool.StressTestSync1
 ydb/services/ydb/sdk_sessions_pool_ut YdbSdkSessionsPool.StressTestSync10
+ydb/services/ydb/sdk_sessions_ut YdbSdkSessions.TestSdkFreeSessionAfterBadSessionQueryService
+ydb/services/ydb/sdk_sessions_ut YdbSdkSessions.TestSdkFreeSessionAfterBadSessionQueryServiceStreamCall
 ydb/services/ydb/sdk_sessions_ut [*/*] chunk chunk
 ydb/services/ydb/table_split_ut [*/*] chunk chunk
 ydb/services/ydb/ut YdbLogStore.AlterLogTable
@@ -131,7 +135,6 @@ ydb/tests/fq/yds test_mem_alloc.py.TestMemAlloc.test_join_alloc[v1]
 ydb/tests/fq/yds test_recovery.py.TestRecovery.test_ic_disconnection
 ydb/tests/fq/yds test_select_limit_db_id.py.TestSelectLimitWithDbId.test_select_same_with_id[v1-mvp_external_ydb_endpoint0]
 ydb/tests/fq/yds test_yds_bindings.py.TestBindings.test_yds_insert[v1]
-ydb/tests/fq/yt/kqp_yt_file/part18 test.py.test[pg-join_brackets2-default.txt]
 ydb/tests/functional/hive test_drain.py.TestHive.test_drain_on_stop
 ydb/tests/functional/hive test_drain.py.TestHive.test_drain_tablets
 ydb/tests/functional/rename [test_rename.py */*] chunk chunk


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of changes introduced in this PR -->

**Unmuted tests : stable 0 and deleted 1**

```

ydb/tests/fq/yt/kqp_yt_file/part18 test.py.test[pg-join_brackets2-default.txt] # owner TEAM:@ydb-platform/fq success_rate 0%, state no_runs days in state 14
```

**Flaky tests : 4**

```

ydb/core/fq/libs/row_dispatcher/ut sole chunk chunk # owner TEAM:@ydb-platform/fq success_rate 85%, state Flaky, days in state 2, pass_count 17, fail count 3
ydb/core/kqp/ut/spilling KqpScanSpilling.SelfJoinQueryService # owner TEAM:@ydb-platform/qp success_rate 73%, state Flaky, days in state 3, pass_count 17, fail count 6
ydb/services/ydb/sdk_sessions_ut YdbSdkSessions.TestSdkFreeSessionAfterBadSessionQueryService # owner TEAM:@ydb-platform/duty success_rate 73%, state Flaky, days in state 3, pass_count 17, fail count 6
ydb/services/ydb/sdk_sessions_ut YdbSdkSessions.TestSdkFreeSessionAfterBadSessionQueryServiceStreamCall # owner TEAM:@ydb-platform/duty success_rate 80%, state Flaky, days in state 3, pass_count 17, fail count 4
```

Created issue 'Mute ydb/core/fq/libs/row_dispatcher/ut/sole chunk chunk' for TEAM:@ydb-platform/fq, url https://github.com/ydb-platform/ydb/issues/13472
Created issue 'Mute ydb/services/ydb/sdk_sessions_ut 2 tests' for TEAM:@ydb-platform/appteam, url https://github.com/ydb-platform/ydb/issues/13473
Created issue 'Mute ydb/core/kqp/ut/spilling/KqpScanSpilling.SelfJoinQueryService' for TEAM:@ydb-platform/qp, url https://github.com/ydb-platform/ydb/issues/13475

### Changelog category <!-- remove all except one -->

* Not for changelog (changelog entry is not required)

### Additional information

...
