### PR TITLE
Return correct errors (retryable or not) on ticket parser errors

### DIFF
--- a/ydb/core/grpc_services/grpc_request_check_actor.h
+++ b/ydb/core/grpc_services/grpc_request_check_actor.h
@@ -72,6 +72,8 @@ public:
         }
         GrpcRequestBaseCtx_->RaiseIssue(NYql::TIssue{error.Message});
         ReplyBackAndDie();
+            // ReplyUnavailableAndDie(NYql::TIssue{error.Message});
+            // ReplyUnauthorizedAndDie(NYql::TIssue{error.Message});
     }
 
     static constexpr NKikimrServices::TActivity::EType ActorActivityType() {
@@ -562,7 +564,7 @@ private:
         }
 
         const TString error = "No permission to connect to the database";
-        LOG_INFO_S(TlsActivationContext->AsActorContext(), NKikimrServices::GRPC_SERVER, 
+        LOG_INFO_S(TlsActivationContext->AsActorContext(), NKikimrServices::GRPC_SERVER,
             error
             << ": " << CheckedDatabaseName_
             << ", user: " << TBase::GetUserSID()

--- a/ydb/core/grpc_services/grpc_request_check_actor.h
+++ b/ydb/core/grpc_services/grpc_request_check_actor.h
@@ -72,8 +72,6 @@ public:
         }
         GrpcRequestBaseCtx_->RaiseIssue(NYql::TIssue{error.Message});
         ReplyBackAndDie();
-            // ReplyUnavailableAndDie(NYql::TIssue{error.Message});
-            // ReplyUnauthorizedAndDie(NYql::TIssue{error.Message});
     }
 
     static constexpr NKikimrServices::TActivity::EType ActorActivityType() {

--- a/ydb/core/security/secure_request.h
+++ b/ydb/core/security/secure_request.h
@@ -44,10 +44,9 @@ private:
     void Handle(TEvTicketParser::TEvAuthorizeTicketResult::TPtr& ev, const TActorContext& ctx) {
         const TEvTicketParser::TEvAuthorizeTicketResult& result(*ev->Get());
         if (!result.Error.empty()) {
-            // if (IsTokenRequired() || IsTokenExists())
-            // if (!result.Error.Retryable)
-            if (IsTokenRequired())
+            if (IsTokenRequired() || GetRequireCredentialsInNewProtocol()) {
                 return static_cast<TDerived*>(this)->OnAccessDenied(result.Error, ctx);
+            }
         } else {
             if (RequireAdminAccess) {
                 if (!GetAdministrationAllowedSIDs().empty()) {
@@ -160,7 +159,7 @@ public:
 
 public:
     bool IsTokenRequired() const {
-        if (GetEnforceUserTokenRequirement() || GetRequireCredentialsInNewProtocol()) {
+        if (GetEnforceUserTokenRequirement()) {
             return true;
         }
 

--- a/ydb/core/security/secure_request.h
+++ b/ydb/core/security/secure_request.h
@@ -1,6 +1,5 @@
 #pragma once
 #include "ticket_parser.h"
-#include <ydb/core/protos/pqconfig.pb.h>
 #include <ydb/library/aclib/aclib.h>
 #include <ydb/core/base/appdata.h>
 
@@ -19,10 +18,6 @@ private:
 
     static bool GetEnforceUserTokenRequirement() {
         return AppData()->EnforceUserTokenRequirement;
-    }
-
-    static bool GetRequireCredentialsInNewProtocol() {
-        return AppData()->PQConfig.GetRequireCredentialsInNewProtocol();
     }
 
     static bool GetEnforceUserTokenCheckRequirement() {
@@ -44,7 +39,7 @@ private:
     void Handle(TEvTicketParser::TEvAuthorizeTicketResult::TPtr& ev, const TActorContext& ctx) {
         const TEvTicketParser::TEvAuthorizeTicketResult& result(*ev->Get());
         if (!result.Error.empty()) {
-            if (IsTokenRequired() || GetRequireCredentialsInNewProtocol()) {
+            if (IsTokenRequired() || result.Error.Retryable) {
                 return static_cast<TDerived*>(this)->OnAccessDenied(result.Error, ctx);
             }
         } else {

--- a/ydb/core/viewer/ut/ya.make
+++ b/ydb/core/viewer/ut/ya.make
@@ -1,5 +1,9 @@
 UNITTEST_FOR(ydb/core/viewer)
 
+ADDINCL(
+    ydb/public/sdk/cpp
+)
+
 FORK_SUBTESTS()
 
 SIZE(MEDIUM)

--- a/ydb/core/viewer/ut/ya.make
+++ b/ydb/core/viewer/ut/ya.make
@@ -14,6 +14,7 @@ PEERDIR(
     library/cpp/http/misc
     library/cpp/http/simple
     ydb/core/testlib/default
+    ydb/public/sdk/cpp/client/ydb_persqueue_public/ut/ut_utils
 )
 
 END()

--- a/ydb/core/viewer/ut/ya.make
+++ b/ydb/core/viewer/ut/ya.make
@@ -14,7 +14,7 @@ PEERDIR(
     library/cpp/http/misc
     library/cpp/http/simple
     ydb/core/testlib/default
-    ydb/public/sdk/cpp/client/ydb_persqueue_public/ut/ut_utils
+    ydb/public/sdk/cpp/src/client/persqueue_public/ut/ut_utils
 )
 
 END()

--- a/ydb/core/viewer/viewer_ut.cpp
+++ b/ydb/core/viewer/viewer_ut.cpp
@@ -2043,8 +2043,8 @@ Y_UNIT_TEST_SUITE(Viewer) {
         for (auto injectErrors : {ETicketParserErrors::NONE, ETicketParserErrors::PERMANENT, ETicketParserErrors::RETRYABLE}) {
             test(false, false, Nothing(), injectErrors);
             test(false, false, "", injectErrors);
-            test(false, false, wrongToken, injectErrors);
-            test(false, false, rootToken, injectErrors);
+            test(false, false, wrongToken, injectErrors, NYdb::EStatus::UNAUTHORIZED);
+            test(false, false, rootToken, injectErrors, injectErrors == ETicketParserErrors::PERMANENT ? NYdb::EStatus::UNAUTHORIZED : NYdb::EStatus::STATUS_UNDEFINED);
         }
 
         for (auto [enforce, require] : {std::pair<bool, bool>{false, true}, {true, false}, {true, true}}) {

--- a/ydb/core/viewer/viewer_ut.cpp
+++ b/ydb/core/viewer/viewer_ut.cpp
@@ -28,8 +28,8 @@
 
 #include <util/string/builder.h>
 #include <regex>
-#include <ydb/public/sdk/cpp/client/ydb_persqueue_public/ut/ut_utils/test_server.h>
-#include <ydb/public/sdk/cpp/client/ydb_persqueue_public/ut/ut_utils/ut_utils.h>
+#include <ydb/public/sdk/cpp/src/client/persqueue_public/ut/ut_utils/test_server.h>
+#include <ydb/public/sdk/cpp/src/client/persqueue_public/ut/ut_utils/ut_utils.h>
 
 using namespace NKikimr;
 using namespace NViewer;

--- a/ydb/core/viewer/viewer_ut.cpp
+++ b/ydb/core/viewer/viewer_ut.cpp
@@ -1967,7 +1967,7 @@ Y_UNIT_TEST_SUITE(Viewer) {
         TString wrongToken = "wrong";
 
         auto test = [&](bool enforceToken, bool require, TMaybe<TString> authToken, ETicketParserErrors injectErrors, NYdb::EStatus expectedStatus = NYdb::EStatus::STATUS_UNDEFINED) {
-            Cerr << ">>> Run with EnforceUserTokenCheckRequirement=" << enforceToken
+            Cerr << ">>> Run with EnforceUserTokenRequirement=" << enforceToken
                  << ", RequireCredentialsInNewProtocol=" << require
                  << ", AuthToken='" << authToken.GetOrElse("<EMPTY>") << "'"
                  << ", injectErrors=" << ToString(injectErrors)
@@ -2052,12 +2052,12 @@ Y_UNIT_TEST_SUITE(Viewer) {
         for (auto [enforce, require] : {std::pair<bool, bool>{false, true}, {true, false}, {true, true}}) {
             test(enforce, require, Nothing(), ETicketParserErrors::NONE, NYdb::EStatus::CLIENT_UNAUTHENTICATED);
             test(enforce, require, "", ETicketParserErrors::NONE, NYdb::EStatus::CLIENT_UNAUTHENTICATED);
-            test(enforce, require, wrongToken, ETicketParserErrors::NONE, NYdb::EStatus::CLIENT_UNAUTHENTICATED);
+            test(enforce, require, wrongToken, ETicketParserErrors::NONE, enforce ? NYdb::EStatus::CLIENT_UNAUTHENTICATED : NYdb::EStatus::UNAUTHORIZED);
             test(enforce, require, rootToken, ETicketParserErrors::NONE);
 
             test(enforce, require, Nothing(), ETicketParserErrors::RETRYABLE, NYdb::EStatus::CLIENT_UNAUTHENTICATED);
             test(enforce, require, "", ETicketParserErrors::RETRYABLE, NYdb::EStatus::CLIENT_UNAUTHENTICATED);
-            test(enforce, require, wrongToken, ETicketParserErrors::RETRYABLE, NYdb::EStatus::CLIENT_UNAUTHENTICATED);
+            test(enforce, require, wrongToken, ETicketParserErrors::RETRYABLE, enforce ? NYdb::EStatus::CLIENT_UNAUTHENTICATED : NYdb::EStatus::UNAUTHORIZED);
             test(enforce, require, rootToken, ETicketParserErrors::RETRYABLE);
         }
     }

--- a/ydb/core/viewer/viewer_ut.cpp
+++ b/ydb/core/viewer/viewer_ut.cpp
@@ -1954,7 +1954,8 @@ Y_UNIT_TEST_SUITE(Viewer) {
                 .SetEndpoint(TStringBuilder() << "localhost:" << grpcPort)
                 .SetDatabase("/Root")
                 .SetAuthToken("root@builtin")
-                .SetLog(CreateLogBackend("cerr"));
+                // .SetLog(CreateLogBackend("cerr"))
+                ;
 
             auto driver = NYdb::TDriver(driverConfig);
             auto topicClient = NYdb::NTopic::TTopicClient(driver);
@@ -1997,7 +1998,8 @@ Y_UNIT_TEST_SUITE(Viewer) {
             auto driverConfig = NYdb::TDriverConfig()
                 .SetEndpoint(TStringBuilder() << "localhost:" << server.GrpcPort)
                 .SetDatabase("/Root")
-                .SetLog(CreateLogBackend("cerr"));
+                // .SetLog(CreateLogBackend("cerr"))
+                ;
 
             if (authToken.Defined()) {
                 driverConfig.SetAuthToken(*authToken);


### PR DESCRIPTION
I'll move the test from viewer_ut to a more appropriate place in another commit.