### PR TITLE
Support multiple tenant keys in config

### DIFF
--- a/ydb/core/blobstorage/dsproxy/dsproxy_encrypt.cpp
+++ b/ydb/core/blobstorage/dsproxy/dsproxy_encrypt.cpp
@@ -42,7 +42,7 @@ namespace NKikimr {
                     p++;
                     *p ^= hash2;
 
-                    // Preapre nonce = {Step(32), Cookie(24), Channel(8)}
+                    // Prepare nonce = {Step(32), Cookie(24), Channel(8)}
                     ui64 nonce = (ui64(id.Step()) << 32) | (ui64(id.Cookie()) << 8) | (ui64(id.Channel()));
 
                     // Encrypt the data

--- a/ydb/core/blobstorage/nodewarden/blobstorage_node_warden_ut.cpp
+++ b/ydb/core/blobstorage/nodewarden/blobstorage_node_warden_ut.cpp
@@ -192,8 +192,8 @@ void SetupServices(TTestActorRuntime &runtime, TString extraPath, TIntrusivePtr<
 
         if (nodeIndex == 0) {
             nodeWardenConfig->SectorMaps[extraPath] = extraSectorMap;
-            ObtainTenantKey(&nodeWardenConfig->TenantKey, app.Keys[0]);
-            ObtainStaticKey(&nodeWardenConfig->StaticKey);
+            ObtainTenantKeys(&nodeWardenConfig->TenantKeys, app.Keys[0]);
+            ObtainStaticKeys(&nodeWardenConfig->StaticKeys);
 
             TString baseDir = runtime.GetTempDir();
 
@@ -852,17 +852,17 @@ Y_UNIT_TEST_SUITE(TBlobStorageWardenTest) {
         keyRecord->SetId("Key");
         keyRecord->SetVersion(1);
 
-        TEncryptionKey key1;
-        UNIT_ASSERT(ObtainTenantKey(&key1, keyConfig));
+        TEncryptionKeys key1;
+        UNIT_ASSERT(ObtainTenantKeys(&key1, keyConfig));
 
         keyRecord->SetPin(pin2);
-        TEncryptionKey key2;
-        UNIT_ASSERT(ObtainTenantKey(&key2, keyConfig));
+        TEncryptionKeys key2;
+        UNIT_ASSERT(ObtainTenantKeys(&key2, keyConfig));
 
         if (pin1 == pin2) {
-            UNIT_ASSERT(key1.Key == key2.Key);
+            UNIT_ASSERT(key1.GetCurrentEncryptionKey().Key == key2.GetCurrentEncryptionKey().Key);
         } else {
-            UNIT_ASSERT(!(key1.Key == key2.Key));
+            UNIT_ASSERT(!(key1.GetCurrentEncryptionKey().Key == key2.GetCurrentEncryptionKey().Key));
         }
     }
 

--- a/ydb/core/blobstorage/nodewarden/distconf.h
+++ b/ydb/core/blobstorage/nodewarden/distconf.h
@@ -648,7 +648,7 @@ namespace NKikimr::NStorage {
             }
 
             TStringStream err;
-            TIntrusivePtr<TBlobStorageGroupInfo> info = TBlobStorageGroupInfo::Parse(group, &nwConfig.StaticKey, &err);
+            TIntrusivePtr<TBlobStorageGroupInfo> info = TBlobStorageGroupInfo::Parse(group, &nwConfig.StaticKeys, &err);
             if (!info) {
                 return makeError(TStringBuilder() << "failed to parse static group " << groupId << ": " << err.Str());
             }

--- a/ydb/core/blobstorage/nodewarden/node_warden.h
+++ b/ydb/core/blobstorage/nodewarden/node_warden.h
@@ -30,8 +30,8 @@ namespace NKikimr {
         NKikimrBlobStorage::TIncrHugeConfig IncrHugeConfig;
         THashMap<TString, TIntrusivePtr<NPDisk::TSectorMap>> SectorMaps;
         std::unique_ptr<ICacheAccessor> CacheAccessor;
-        TEncryptionKey TenantKey;
-        TEncryptionKey StaticKey;
+        TEncryptionKeys TenantKeys;
+        TEncryptionKeys StaticKeys;
         NPDisk::TMainKey PDiskKey;
         bool CachePDisks = false;
         bool CacheVDisks = false;
@@ -56,8 +56,8 @@ namespace NKikimr {
 
     IActor* CreateBSNodeWarden(const TIntrusivePtr<TNodeWardenConfig> &cfg);
 
-    bool ObtainTenantKey(TEncryptionKey *key, const NKikimrProto::TKeyConfig& keyConfig);
-    bool ObtainStaticKey(TEncryptionKey *key);
+    bool ObtainTenantKeys(TEncryptionKeys *keys, const NKikimrProto::TKeyConfig& keyConfig);
+    bool ObtainStaticKeys(TEncryptionKeys *keys);
     bool ObtainPDiskKey(NPDisk::TMainKey *key, const NKikimrProto::TKeyConfig& keyConfig);
 
     std::unique_ptr<ICacheAccessor> CreateFileCacheAccessor(const TString& templ, const std::unordered_map<char, TString>& vars);

--- a/ydb/core/blobstorage/nodewarden/node_warden_impl.h
+++ b/ydb/core/blobstorage/nodewarden/node_warden_impl.h
@@ -197,7 +197,7 @@ namespace NKikimr::NStorage {
         TControlWrapper PredictedDelayMultiplier;
         TControlWrapper PredictedDelayMultiplierHDD;
         TControlWrapper PredictedDelayMultiplierSSD;
-    
+
         TControlWrapper MaxNumOfSlowDisks;
         TControlWrapper MaxNumOfSlowDisksHDD;
         TControlWrapper MaxNumOfSlowDisksSSD;
@@ -500,10 +500,10 @@ namespace NKikimr::NStorage {
         TIntrusivePtr<TBlobStorageGroupInfo> NeedGroupInfo(ui32 groupId);
 
         // propose group key
-        void ProposeKey(ui32 groupId, const TEncryptionKey& mainKey, const NKikimrBlobStorage::TGroupInfo& encryptionParams);
+        void ProposeKey(ui32 groupId, const TEncryptionKeys& tenantKeys, const NKikimrBlobStorage::TGroupInfo& encryptionParams);
 
         // get encryption key for the group
-        TEncryptionKey& GetGroupMainKey(ui32 groupId);
+        TEncryptionKeys& GetGroupMainKeys(ui32 groupId);
 
         // process group information structure
         void ApplyGroupInfo(ui32 groupId, ui32 generation, const NKikimrBlobStorage::TGroupInfo *newGroup, bool fromController,

--- a/ydb/core/blobstorage/ut_blobstorage/encryption.cpp
+++ b/ydb/core/blobstorage/ut_blobstorage/encryption.cpp
@@ -8,9 +8,21 @@ Y_UNIT_TEST_SUITE(ProxyEncryption) {
             .Version = 1,
             .Id = "tenant key"
         };
+
+        const ui8 key2Data[32] = "Hello! I'm your new key";
+        const TEncryptionKey key2{
+            .Key = {key2Data, sizeof(key2Data)},
+            .Version = 2,
+            .Id = "tenant key"
+        };
+
         auto preprocess = [&](ui32 nodeId, TNodeWardenConfig& config) {
-            if (nodeId == 9 || nodeId == 10) {
-                config.TenantKey = key;
+            if (nodeId == 9) {
+                UNIT_ASSERT(config.TenantKeys.Init(&key, &key + 1));
+            } else if (nodeId == 10) {
+                auto keys = {key, key2};
+                UNIT_ASSERT(config.TenantKeys.Init(std::begin(keys), std::end(keys)));
+                UNIT_ASSERT_VALUES_EQUAL(config.TenantKeys.GetCurrentEncryptionKey().Id, "tenant key");
             }
         };
         TEnvironmentSetup env(TEnvironmentSetup::TSettings{
@@ -20,29 +32,31 @@ Y_UNIT_TEST_SUITE(ProxyEncryption) {
             .ConfigPreprocessor = preprocess
         });
         auto& runtime = env.Runtime;
-        env.CreateBoxAndPool(1, 1);
+        env.CreateBoxAndPool(1, 2);
         env.Sim(TDuration::Minutes(1));
 
         auto groups = env.GetGroups();
-        UNIT_ASSERT_VALUES_EQUAL(groups.size(), 1);
+        UNIT_ASSERT_VALUES_EQUAL(groups.size(), 2);
 
         TString data = "hello";
-        TLogoBlobID id(1, 1, 1, 0, data.size(), 0);
+        TLogoBlobID id(2, 1, 1, 0, data.size(), 0);
 
         // node with keys: write data
-        {
-            TActorId edge = runtime->AllocateEdgeActor(9);
+        auto write = [&](ui32 nodeId, ui32 group, const TLogoBlobID& id, const TString& data) {
+            TActorId edge = runtime->AllocateEdgeActor(nodeId);
             runtime->WrapInActorContext(edge, [&] {
-                SendToBSProxy(edge, groups[0], new TEvBlobStorage::TEvPut(id, data, TInstant::Max()));
+                SendToBSProxy(edge, group, new TEvBlobStorage::TEvPut(id, data, TInstant::Max()));
             });
             auto res = env.WaitForEdgeActorEvent<TEvBlobStorage::TEvPutResult>(edge);
             UNIT_ASSERT_VALUES_EQUAL(res->Get()->Status, NKikimrProto::OK);
-        }
+        };
 
-        auto tryToRead = [&](ui32 nodeId) {
+        write(9, groups[0], id, data); // write with key version 1
+
+        auto tryToRead = [&](ui32 nodeId, ui32 group, const TLogoBlobID& id) {
             TActorId edge = runtime->AllocateEdgeActor(nodeId);
             runtime->WrapInActorContext(edge, [&] {
-                SendToBSProxy(edge, groups[0], new TEvBlobStorage::TEvGet(id, 0, 0, TInstant::Max(),
+                SendToBSProxy(edge, group, new TEvBlobStorage::TEvGet(id, 0, 0, TInstant::Max(),
                     NKikimrBlobStorage::EGetHandleClass::FastRead));
             });
             auto res = env.WaitForEdgeActorEvent<TEvBlobStorage::TEvGetResult>(edge);
@@ -52,7 +66,14 @@ Y_UNIT_TEST_SUITE(ProxyEncryption) {
         };
 
         for (ui32 i = 1; i <= 11; ++i) {
-            UNIT_ASSERT_VALUES_EQUAL(tryToRead(i), (i == 9 || i == 10) ? NKikimrProto::OK : NKikimrProto::ERROR);
+            UNIT_ASSERT_VALUES_EQUAL_C(tryToRead(i, groups[0], id), (i == 9 || i == 10) ? NKikimrProto::OK : NKikimrProto::ERROR, i);
+        }
+
+        TLogoBlobID id2(1, 2, 2, 0, data.size(), 0);
+        write(10, groups[1], id2, data); // write with key version 2
+
+        for (ui32 i = 1; i <= 11; ++i) {
+            UNIT_ASSERT_VALUES_EQUAL_C(tryToRead(i, groups[1], id2), (i == 10) ? NKikimrProto::OK : NKikimrProto::ERROR, i);
         }
     }
 }

--- a/ydb/core/driver_lib/run/kikimr_services_initializers.cpp
+++ b/ydb/core/driver_lib/run/kikimr_services_initializers.cpp
@@ -951,8 +951,8 @@ void TBSNodeWardenInitializer::InitializeServices(NActors::TActorSystemSetup* se
         nodeWardenConfig->SelfManagementConfig.emplace(Config.GetSelfManagementConfig());
     }
 
-    ObtainTenantKey(&nodeWardenConfig->TenantKey, Config.GetKeyConfig());
-    ObtainStaticKey(&nodeWardenConfig->StaticKey);
+    ObtainTenantKeys(&nodeWardenConfig->TenantKeys, Config.GetKeyConfig());
+    ObtainStaticKeys(&nodeWardenConfig->StaticKeys);
     ObtainPDiskKey(&nodeWardenConfig->PDiskKey, Config.GetPDiskKeyConfig());
 
     setup->LocalServices.push_back(std::pair<TActorId, TActorSetupCmd>(MakeBlobStorageNodeWardenID(NodeId),

--- a/ydb/core/mind/bscontroller/propose_group_key.cpp
+++ b/ydb/core/mind/bscontroller/propose_group_key.cpp
@@ -46,10 +46,10 @@ public:
             STLOG(PRI_ERROR, BS_CONTROLLER, BSCTXPGK04, "Group LifeCyclePhase does not match ELCP_INITIAL",
                 (GroupId.GetRawId(), GroupId.GetRawId()), (LifeCyclePhase, group->LifeCyclePhase.GetOrElse(0)));
             IsAnotherTxInProgress = (group->LifeCyclePhase.GetOrElse(0) == TBlobStorageGroupInfo::ELCP_IN_TRANSITION);
-        } else if (group->MainKeyVersion.GetOrElse(0) != (MainKeyVersion - 1)) {
-            STLOG(PRI_ERROR, BS_CONTROLLER, BSCTXPGK05, "Group MainKeyVersion does not match required MainKeyVersion",
+        } else if (group->MainKeyVersion && *group->MainKeyVersion > MainKeyVersion) {
+            STLOG(PRI_ERROR, BS_CONTROLLER, BSCTXPGK05, "Can't decrease key version",
                 (GroupId.GetRawId(), GroupId.GetRawId()), (MainKeyVersion, group->MainKeyVersion.GetOrElse(0)),
-                (RequiredMainKeyVersion, MainKeyVersion - 1));
+                (NewMainKeyVersion, MainKeyVersion));
         } else if (EncryptedGroupKey.size() != 32 + sizeof(ui32)) {
             STLOG(PRI_ERROR, BS_CONTROLLER, BSCTXPGK06, "Group does not accept EncryptedGroupKey size",
                 (GroupId.GetRawId(), GroupId.GetRawId()), (EncryptedGroupKeySize, EncryptedGroupKey.size()),

--- a/ydb/core/mind/ut_fat/blobstorage_node_warden_ut_fat.cpp
+++ b/ydb/core/mind/ut_fat/blobstorage_node_warden_ut_fat.cpp
@@ -194,8 +194,8 @@ void SetupServices(TTestActorRuntime &runtime) {
         google::protobuf::TextFormat::ParseFromString(staticConfig, nodeWardenConfig->BlobStorageConfig.MutableServiceSet());
 
         app.SetKeyForNode(keyfile, nodeIndex);
-        ObtainTenantKey(&nodeWardenConfig->TenantKey, app.Keys[nodeIndex]);
-        ObtainStaticKey(&nodeWardenConfig->StaticKey);
+        ObtainTenantKeys(&nodeWardenConfig->TenantKeys, app.Keys[nodeIndex]);
+        ObtainStaticKeys(&nodeWardenConfig->StaticKeys);
 
         if (nodeIndex == 0) {
             static TTempDir tempDir;

--- a/ydb/core/testlib/basics/storage.h
+++ b/ydb/core/testlib/basics/storage.h
@@ -108,8 +108,8 @@ namespace NKikimr {
             vDisk->LevelCompaction = true;
             vDisk->MaxLogoBlobDataSize = Conf.UseDisk ? CHUNK_SIZE / 3 : MEM_CHUNK_SIZE / 3;
 
-            ObtainTenantKey(&conf->TenantKey, keyConfig);
-            ObtainStaticKey(&conf->StaticKey);
+            ObtainTenantKeys(&conf->TenantKeys, keyConfig);
+            ObtainStaticKeys(&conf->StaticKeys);
 
             return conf;
         }


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of changes introduced in this PR -->

The main task is to support DSProxy encryption keys rotation. It requires having multiple tenant keys in dynamic node config.

### Changelog category <!-- remove all except one -->

* Improvement

### Additional information

...
