### PR TITLE
Add new option to Storage LoadActor config to emulate large deletions and trigger compaction

### DIFF
--- a/ydb/core/protos/load_test.proto
+++ b/ydb/core/protos/load_test.proto
@@ -42,6 +42,7 @@ message TEvLoadTestRequest {
             optional uint32 MaxWriteBytesInFlight = 5;
             optional NKikimrBlobStorage.EPutHandleClass PutHandleClass = 6;
             optional uint32 DelayAfterCompletionSec = 7;
+            optional uint32 CollectedBlobsPerMille = 8;
         }
 
         message TRequestInfo {


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of changes introduced in this PR -->

Add new option to Storage LoadActor config to emulate large deletions and trigger compaction

### Changelog category <!-- remove all except one -->

* New feature
* Improvement

### Additional information

Usage example:
```text
StorageLoad: {
    DurationSeconds: 300000
    Tablets: {
        Tablets: { TabletName: "Loader" Channel: 4 GroupId: 2181038080 Generation: 1 }
        Tablets: { TabletName: "Loader" Channel: 5 GroupId: 2181038081 Generation: 1 }
        Tablets: { TabletName: "Loader" Channel: 6 GroupId: 2181038082 Generation: 1 }
        Tablets: { TabletName: "Loader" Channel: 7 GroupId: 2181038083 Generation: 1 }
        Tablets: { TabletName: "Loader" Channel: 8 GroupId: 2181038084 Generation: 1 }
        Tablets: { TabletName: "Loader" Channel: 9 GroupId: 2181038085 Generation: 1 }
        Tablets: { TabletName: "Loader" Channel: 10 GroupId: 2181038086 Generation: 1 }
        Tablets: { TabletName: "Loader" Channel: 11 GroupId: 2181038087 Generation: 1 }

        MaxInFlightReadRequests: 10
        GetHandleClass: FastRead
        ReadHardRateDispatcher {
                RequestsPerSecondAtStart: 1
                RequestsPerSecondOnFinish: 1
        }
        FlushIntervals: { Weight: 1.0 Uniform: { MinMs: 10000 MaxMs: 10000 } }
        WriteHardRateDispatcher {
                RequestsPerSecondAtStart: 1
                RequestsPerSecondOnFinish: 1
        }
        WriteSizes: { Weight: 1.0 Min: 2000000 Max: 2000000 }

        InitialAllocation {
                TotalSize: 4000000000
                BlobSizes: { Weight: 1.0 Min: 200000 Max: 600000 }
                CollectedBlobsPerMille: 500
                DelayAfterCompletionSec: 1200
                MaxWritesInFlight: 500
        }
    }
}
```
