### PR TITLE
24-3-15-hotfix: Return default decimal if scheme proto is empty

### DIFF
--- a/ydb/core/scheme/scheme_types_proto.cpp
+++ b/ydb/core/scheme/scheme_types_proto.cpp
@@ -92,8 +92,9 @@ NScheme::TTypeInfo TypeInfoFromProto(NScheme::TTypeId typeId, const ::NKikimrPro
         return NScheme::TTypeInfo(NPg::TypeDescFromPgTypeId(typeInfoProto.GetPgTypeId()));
     }
     case NScheme::NTypeIds::Decimal: {
-        Y_ABORT_UNLESS(typeInfoProto.HasDecimalPrecision());
-        Y_ABORT_UNLESS(typeInfoProto.HasDecimalScale());
+        if (!typeInfoProto.HasDecimalPrecision() || !typeInfoProto.HasDecimalScale()) {
+            return NScheme::TTypeInfo(NScheme::TDecimalType::Default());
+        }
         NScheme::TDecimalType decimal(typeInfoProto.GetDecimalPrecision(), typeInfoProto.GetDecimalScale());
         return NScheme::TTypeInfo(decimal);
     }


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of changes introduced in this PR -->

Scheme proto propagation could be slow in some races and new code can return old proto. In this case we should not throw exception.

### Changelog category <!-- remove all except one -->

* Bugfix 


### Additional information

...
