### PR TITLE
Avoid unnecessary ReadStep coordinator subscriptions

### DIFF
--- a/ydb/core/tx/datashard/datashard.cpp
+++ b/ydb/core/tx/datashard/datashard.cpp
@@ -3758,12 +3758,13 @@ void TDataShard::Handle(TEvMediatorTimecast::TEvSubscribeReadStepResult::TPtr& e
     auto it = CoordinatorSubscriptionById.find(msg->CoordinatorId);
     Y_VERIFY_S(it != CoordinatorSubscriptionById.end(),
         "Unexpected TEvSubscribeReadStepResult for coordinator " << msg->CoordinatorId);
-    size_t index = it->second;
-    auto& subscription = CoordinatorSubscriptions.at(index);
-    subscription.ReadStep = msg->ReadStep;
     CoordinatorPrevReadStepMin = Max(CoordinatorPrevReadStepMin, msg->LastReadStep);
     CoordinatorPrevReadStepMax = Min(CoordinatorPrevReadStepMax, msg->NextReadStep);
     --CoordinatorSubscriptionsPending;
+
+    // Note: we don't use the subscription and unsubscribe immediately
+    ctx.Send(MakeMediatorTimecastProxyID(), new TEvMediatorTimecast::TEvUnsubscribeReadStep(msg->CoordinatorId));
+
     CheckMediatorStateRestored();
 }
 

--- a/ydb/core/tx/datashard/datashard_impl.h
+++ b/ydb/core/tx/datashard/datashard_impl.h
@@ -2755,7 +2755,6 @@ private:
 
     struct TCoordinatorSubscription {
         ui64 CoordinatorId;
-        TMediatorTimecastReadStep::TCPtr ReadStep;
     };
 
     TVector<TCoordinatorSubscription> CoordinatorSubscriptions;

--- a/ydb/core/tx/time_cast/time_cast.cpp
+++ b/ydb/core/tx/time_cast/time_cast.cpp
@@ -17,9 +17,6 @@
 
 namespace NKikimr {
 
-// We will unsubscribe from idle coordinators after 5 minutes
-static constexpr TDuration MaxIdleCoordinatorSubscriptionTime = TDuration::Minutes(5);
-
 ui64 TMediatorTimecastSharedEntry::Get() const noexcept {
     return Step.load(std::memory_order_acquire);
 }
@@ -192,7 +189,7 @@ class TMediatorTimecastProxy : public TActor<TMediatorTimecastProxy> {
         THashSet<TActorId> Subscribers;
         TMap<std::pair<ui64, TActorId>, ui64> SubscribeRequests; // (seqno, subscriber) -> Cookie
         TMap<std::pair<ui64, TActorId>, ui64> WaitRequests; // (step, subscriber) -> Cookie
-        TMonotonic IdleStart;
+        bool Unsubscribed = false;
     };
 
     THashMap<ui64, TMediator> Mediators; // mediator tablet -> info
@@ -391,6 +388,7 @@ class TMediatorTimecastProxy : public TActor<TMediatorTimecastProxy> {
 
     void SyncCoordinator(ui64 coordinatorId, TCoordinator& coordinator, const TActorContext& ctx);
     void ResyncCoordinator(ui64 coordinatorId, const TActorId& pipeClient, const TActorContext& ctx);
+    void UnsubscribeCoordinator(ui64 coordinatorId, TCoordinator& coordinator, const TActorContext& ctx);
     void NotifyCoordinatorWaiters(ui64 coordinatorId, TCoordinator& coordinator, const TActorContext& ctx);
 
     void Handle(TEvMediatorTimecast::TEvRegisterTablet::TPtr& ev, const TActorContext& ctx);
@@ -870,8 +868,9 @@ void TMediatorTimecastProxy::SyncCoordinator(ui64 coordinatorId, TCoordinator& c
             NTabletPipe::CreateClient(ctx.SelfID, coordinatorId, retryPolicy));
     }
 
-    coordinator.LastSentSeqNo = seqNo;
     NTabletPipe::SendData(ctx, coordinator.PipeClient, new TEvTxProxy::TEvSubscribeReadStep(coordinatorId, seqNo));
+    coordinator.LastSentSeqNo = seqNo;
+    coordinator.Unsubscribed = false;
 }
 
 void TMediatorTimecastProxy::ResyncCoordinator(ui64 coordinatorId, const TActorId& pipeClient, const TActorContext& ctx) {
@@ -894,6 +893,17 @@ void TMediatorTimecastProxy::ResyncCoordinator(ui64 coordinatorId, const TActorI
 
     ++LastSeqNo;
     SyncCoordinator(coordinatorId, coordinator, ctx);
+}
+
+void TMediatorTimecastProxy::UnsubscribeCoordinator(ui64 coordinatorId, TCoordinator& coordinator, const TActorContext& ctx) {
+    if (coordinator.Unsubscribed || !coordinator.PipeClient) {
+        return;
+    }
+
+    // Note: we leave the pipe open to make new subscriptions faster
+    // The idle entry will be removed when the pipe eventually disconnects
+    NTabletPipe::SendData(ctx, coordinator.PipeClient, new TEvTxProxy::TEvUnsubscribeReadStep(coordinatorId, coordinator.LastSentSeqNo));
+    coordinator.Unsubscribed = true;
 }
 
 void TMediatorTimecastProxy::Handle(TEvMediatorTimecast::TEvSubscribeReadStep::TPtr& ev, const TActorContext& ctx) {
@@ -924,7 +934,7 @@ void TMediatorTimecastProxy::Handle(TEvMediatorTimecast::TEvUnsubscribeReadStep:
             auto& coordinator = Coordinators[coordinatorId];
             coordinator.Subscribers.erase(ev->Sender);
             if (coordinator.Subscribers.empty()) {
-                coordinator.IdleStart = ctx.Monotonic();
+                UnsubscribeCoordinator(coordinatorId, coordinator, ctx);
             }
         }
         subscriber.Coordinators.clear();
@@ -933,7 +943,7 @@ void TMediatorTimecastProxy::Handle(TEvMediatorTimecast::TEvUnsubscribeReadStep:
         auto& coordinator = Coordinators[msg->CoordinatorId];
         coordinator.Subscribers.erase(ev->Sender);
         if (coordinator.Subscribers.empty()) {
-            coordinator.IdleStart = ctx.Monotonic();
+            UnsubscribeCoordinator(msg->CoordinatorId, coordinator, ctx);
         }
         subscriber.Coordinators.erase(msg->CoordinatorId);
     }
@@ -1041,16 +1051,6 @@ void TMediatorTimecastProxy::Handle(TEvTxProxy::TEvSubscribeReadStepUpdate::TPtr
         coordinator.ReadStep->Update(nextReadStep);
 
         NotifyCoordinatorWaiters(coordinatorId, coordinator, ctx);
-    }
-
-    // Unsubscribe from idle coordinators
-    if (coordinator.Subscribers.empty() && (ctx.Monotonic() - coordinator.IdleStart) >= MaxIdleCoordinatorSubscriptionTime) {
-        if (coordinator.PipeClient) {
-            NTabletPipe::CloseClient(ctx, coordinator.PipeClient);
-            coordinator.PipeClient = TActorId();
-        }
-
-        Coordinators.erase(itCoordinator);
     }
 }
 


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of changes introduced in this PR -->

...

### Changelog category <!-- remove all except one -->

* Not for changelog (changelog entry is not required)

### Additional information

We use ReadStep subscriptions to restore the maximum version that could have been used in snapshot reads by previous generations. While we need the initial subscription response, we don't actually use ReadStep updates, which end up wasting interconnect capacity at coordinator nodes. Unsubscribe from these updates in datashard and timecast as soon as possible, which is a backwards compatible change. Later we could switch to a more efficient API.

Fixes #13548.