### PR TITLE
#13427 Add a monitoring counter for fds kept open by the spilling system

### DIFF
--- a/ydb/library/yql/dq/actors/spilling/spilling_counters.cpp
+++ b/ydb/library/yql/dq/actors/spilling/spilling_counters.cpp
@@ -10,6 +10,7 @@ TSpillingCounters::TSpillingCounters(const TIntrusivePtr<::NMonitoring::TDynamic
     SpillingTooBigFileErrors = counters->GetCounter("Spilling/TooBigFileErrors", true);
     SpillingNoSpaceErrors = counters->GetCounter("Spilling/NoSpaceErrors", true);
     SpillingIoErrors = counters->GetCounter("Spilling/IoErrors", true);
+    SpillingFileDescriptors = counters->GetCounter("Spilling/FileDescriptors", false);
 }
 
 } // namespace NYql::NDq

--- a/ydb/library/yql/dq/actors/spilling/spilling_counters.h
+++ b/ydb/library/yql/dq/actors/spilling/spilling_counters.h
@@ -17,6 +17,7 @@ struct TSpillingCounters : public TThrRefBase {
     ::NMonitoring::TDynamicCounters::TCounterPtr SpillingTooBigFileErrors;
     ::NMonitoring::TDynamicCounters::TCounterPtr SpillingNoSpaceErrors;
     ::NMonitoring::TDynamicCounters::TCounterPtr SpillingIoErrors;
+    ::NMonitoring::TDynamicCounters::TCounterPtr SpillingFileDescriptors;
 };
 
 struct TSpillingTaskCounters : public TThrRefBase {


### PR DESCRIPTION
Monitor file descriptor usage from the moment a new spill file is registered with the spilling system until it's closed and released. Seems to work but might be a bit raw.

TODO: Does not account for additional opens in TReadFileOp/TWriteFileOp; do we need that? These additional fds are short-lived (only held open for the duration of read/write call) and the total amount is bounded by IoThreadPoolWorkersCount.

TODO: The spilling system actor shutdown sequence should be extracted into a function in the _ut.cpp.

Why are these long-lived fds being held open anyway? TReadFileOp and TWriteFileOp only need the file name. To keep files alive during GC, maybe?