### PR TITLE
Introduce locality counters for single node tx. (#13415)

### DIFF
--- a/ydb/core/kqp/counters/kqp_counters.cpp
+++ b/ydb/core/kqp/counters/kqp_counters.cpp
@@ -829,6 +829,9 @@ TKqpCounters::TKqpCounters(const ::NMonitoring::TDynamicCounterPtr& counters, co
         "PhyTx/ScanTxTotalTimeMs", NMonitoring::ExponentialHistogram(20, 2, 1));
 
     FullScansExecuted = KqpGroup->GetCounter("FullScans", true);
+
+    TotalSingleNodeReqCount = KqpGroup->GetCounter("TotalSingleNodeReqCount", true);
+    NonLocalSingleNodeReqCount = KqpGroup->GetCounter("NonLocalSingleNodeReqCount", true);
 }
 
 ::NMonitoring::TDynamicCounterPtr TKqpCounters::GetKqpCounters() const {

--- a/ydb/core/kqp/counters/kqp_counters.h
+++ b/ydb/core/kqp/counters/kqp_counters.h
@@ -419,6 +419,10 @@ public:
     NMonitoring::THistogramPtr DataTxTotalTimeHistogram;
     NMonitoring::THistogramPtr ScanTxTotalTimeHistogram;
 
+    // Locality metrics for request
+    NMonitoring::TDynamicCounters::TCounterPtr TotalSingleNodeReqCount;
+    NMonitoring::TDynamicCounters::TCounterPtr NonLocalSingleNodeReqCount;
+
     TAlignedPagePoolCounters AllocCounters;
 
     // db counters

--- a/ydb/core/kqp/executer_actor/kqp_executer_impl.h
+++ b/ydb/core/kqp/executer_actor/kqp_executer_impl.h
@@ -232,6 +232,7 @@ protected:
         ShardIdToNodeId = std::move(reply.ShardNodes);
         for (auto& [shardId, nodeId] : ShardIdToNodeId) {
             ShardsOnNode[nodeId].push_back(shardId);
+            ParticipantNodes.emplace(nodeId);
         }
 
         if (IsDebugLogEnabled()) {
@@ -1991,6 +1992,10 @@ protected:
     THashMap<NYql::NDq::TStageId, THashMap<ui64, TShardInfo>> SourceScanStageIdToParititions;
 
     ui32 StatementResultIndex;
+
+    // Track which nodes has been involved during execution
+    THashSet<ui32> ParticipantNodes;
+
     bool AlreadyReplied = false;
 
 private:

--- a/ydb/core/kqp/session_actor/kqp_query_state.h
+++ b/ydb/core/kqp/session_actor/kqp_query_state.h
@@ -166,6 +166,17 @@ public:
     ui32 StatementResultSize = 0;
 
     TMaybe<TString> CommandTagName;
+    THashSet<uint32_t> ParticipantNodes;
+
+    bool IsLocalExecution(ui32 nodeId) const {
+        if (RequestEv->GetRequestCtx() == nullptr) {
+            return false;
+        }
+        if (ParticipantNodes.size() == 1) {
+            return *ParticipantNodes.begin() == nodeId;
+        }
+        return false;
+    }
 
     NKikimrKqp::EQueryAction GetAction() const {
         return QueryAction;

--- a/ydb/core/kqp/ut/query/kqp_stats_ut.cpp
+++ b/ydb/core/kqp/ut/query/kqp_stats_ut.cpp
@@ -1,4 +1,5 @@
 #include <ydb/core/kqp/ut/common/kqp_ut_common.h>
+#include <ydb/core/kqp/counters/kqp_counters.h>
 #include <ydb/public/sdk/cpp/client/ydb_table/table.h>
 #include <ydb/public/sdk/cpp/client/resources/ydb_resources.h>
 #include <ydb/public/sdk/cpp/client/ydb_proto/accessor.h>
@@ -630,6 +631,221 @@ Y_UNIT_TEST(SysViewCancelled) {
         UNIT_ASSERT(queryCount == 1);
         UNIT_ASSERT(rowsCount == 2);
     }
+}
+
+Y_UNIT_TEST(OneShardLocalExec) {
+    TKikimrRunner kikimr;
+    auto db = kikimr.GetTableClient();
+    auto session = db.CreateSession().GetValueSync().GetSession();
+
+    TKqpCounters counters(kikimr.GetTestServer().GetRuntime()->GetAppData().Counters);
+    {
+        auto result = session.ExecuteDataQuery(R"(
+            SELECT * FROM `/Root/KeyValue` WHERE Key = 1;
+        )", TTxControl::BeginTx().CommitTx()).ExtractValueSync();
+        UNIT_ASSERT(result.IsSuccess());
+        UNIT_ASSERT_VALUES_EQUAL(counters.TotalSingleNodeReqCount->Val(), 2);
+    }
+    {
+        auto result = session.ExecuteDataQuery(R"(
+            UPSERT INTO `/Root/KeyValue` (Key, Value) VALUES (1, "1");
+        )", TTxControl::BeginTx().CommitTx()).ExtractValueSync();
+        UNIT_ASSERT(result.IsSuccess());
+        UNIT_ASSERT_VALUES_EQUAL(counters.TotalSingleNodeReqCount->Val(), 3);
+    }
+    {
+        auto result = kikimr.GetQueryClient().ExecuteQuery(R"(
+            SELECT * FROM `/Root/KeyValue` WHERE Key = 1;
+        )", NYdb::NQuery::TTxControl::BeginTx().CommitTx()).ExtractValueSync();
+        UNIT_ASSERT(result.IsSuccess());
+        UNIT_ASSERT_VALUES_EQUAL(counters.TotalSingleNodeReqCount->Val(), 4);
+    }
+    {
+        auto result = kikimr.GetQueryClient().ExecuteQuery(R"(
+            UPSERT INTO `/Root/KeyValue` (Key, Value) VALUES (1, "1");
+        )", NYdb::NQuery::TTxControl::BeginTx().CommitTx()).ExtractValueSync();
+        UNIT_ASSERT(result.IsSuccess());
+        UNIT_ASSERT_VALUES_EQUAL(counters.TotalSingleNodeReqCount->Val(), 5);
+    }
+    UNIT_ASSERT_VALUES_EQUAL(counters.NonLocalSingleNodeReqCount->Val(), 0);
+}
+
+Y_UNIT_TEST(OneShardNonLocalExec) {
+    TKikimrRunner kikimr(TKikimrSettings().SetNodeCount(2));
+    auto db = kikimr.GetTableClient();
+    auto session = db.CreateSession().GetValueSync().GetSession();
+    auto monPort = kikimr.GetTestServer().GetRuntime()->GetMonPort();
+
+    auto firstNodeId = kikimr.GetTestServer().GetRuntime()->GetFirstNodeId();
+
+    TKqpCounters counters(kikimr.GetTestServer().GetRuntime()->GetAppData().Counters);
+
+    auto expectedTotalSingleNodeReqCount = counters.TotalSingleNodeReqCount->Val();
+    auto expectedNonLocalSingleNodeReqCount = counters.NonLocalSingleNodeReqCount->Val();
+
+    auto drainNode = [monPort](size_t nodeId, bool undrain = false) {
+        TNetworkAddress addr("localhost", monPort);
+        TSocket s(addr);
+        TString url;
+        if (undrain) {
+            url = "/tablets/app?TabletID=72057594037968897&node=" + std::to_string(nodeId) + "&page=SetDown&down=0";
+        } else {
+            url = "/tablets/app?TabletID=72057594037968897&node=" + std::to_string(nodeId) + "&page=DrainNode";
+        }
+        SendMinimalHttpRequest(s, "localhost", url);
+        TSocketInput si(s);
+        THttpInput input(&si);
+        TString firstLine = input.FirstLine();
+
+        const auto httpCode = ParseHttpRetCode(firstLine);
+        UNIT_ASSERT_VALUES_EQUAL(httpCode, 200);
+    };
+
+    auto waitTablets = [&session](size_t nodeId) mutable {
+        TDescribeTableSettings describeTableSettings =
+            TDescribeTableSettings()
+                .WithTableStatistics(true)
+                .WithPartitionStatistics(true)
+                .WithShardNodesInfo(true);
+
+        bool done = false;
+        for (int i = 0; i < 10; i++) {
+            std::unordered_set<ui32> nodeIds;
+            auto res = session.DescribeTable("Root/EightShard", describeTableSettings)
+                .ExtractValueSync();
+
+            UNIT_ASSERT_EQUAL(res.IsTransportError(), false);
+            UNIT_ASSERT_EQUAL(res.GetStatus(), EStatus::SUCCESS);
+            UNIT_ASSERT_VALUES_EQUAL(res.GetTableDescription().GetPartitionsCount(), 8);
+            UNIT_ASSERT_VALUES_EQUAL(res.GetTableDescription().GetPartitionStats().size(), 8);
+            for (const auto& s : res.GetTableDescription().GetPartitionStats()) {
+                nodeIds.emplace(s.LeaderNodeId);
+            }
+            if (nodeIds.size() == 1 && *nodeIds.begin() == nodeId) {
+                done = true;
+                break;
+            }
+            Sleep(TDuration::Seconds(1));
+        }
+        UNIT_ASSERT_C(done, "unable to wait tablets move on specific node");
+    };
+
+    // Move all tablets on the node2, we have a grpc connection to node 1
+    // so all sessions will be created on the node 1
+    drainNode(firstNodeId);
+    waitTablets(firstNodeId + 1);
+
+    {
+        auto result = session.ExecuteDataQuery(R"(
+            SELECT * FROM `/Root/EightShard` WHERE Key = 1;
+        )", TTxControl::BeginTx().CommitTx()).ExtractValueSync();
+        UNIT_ASSERT(result.IsSuccess());
+        UNIT_ASSERT_VALUES_EQUAL(counters.TotalSingleNodeReqCount->Val(), ++expectedTotalSingleNodeReqCount);
+    }
+    {
+        auto result = session.ExecuteDataQuery(R"(
+            UPSERT INTO `/Root/EightShard` (Key, Data) VALUES (1, 1);
+        )", TTxControl::BeginTx().CommitTx()).ExtractValueSync();
+        UNIT_ASSERT(result.IsSuccess());
+        UNIT_ASSERT_VALUES_EQUAL(counters.TotalSingleNodeReqCount->Val(), ++expectedTotalSingleNodeReqCount);
+    }
+    {
+        auto result = kikimr.GetQueryClient().ExecuteQuery(R"(
+            SELECT * FROM `/Root/EightShard` WHERE Key = 1;
+        )", NYdb::NQuery::TTxControl::BeginTx().CommitTx()).ExtractValueSync();
+        UNIT_ASSERT(result.IsSuccess());
+        UNIT_ASSERT_VALUES_EQUAL(counters.TotalSingleNodeReqCount->Val(), ++expectedTotalSingleNodeReqCount);
+    }
+    {
+        auto result = kikimr.GetQueryClient().ExecuteQuery(R"(
+            UPSERT INTO `/Root/EightShard` (Key, Data) VALUES (1, 1);
+        )", NYdb::NQuery::TTxControl::BeginTx().CommitTx()).ExtractValueSync();
+        UNIT_ASSERT(result.IsSuccess());
+        UNIT_ASSERT_VALUES_EQUAL(counters.TotalSingleNodeReqCount->Val(), ++expectedTotalSingleNodeReqCount);
+    }
+    {
+        auto result = session.ExecuteDataQuery(R"(
+            UPDATE `/Root/EightShard` SET Data = 111 WHERE Key = 1;
+        )", TTxControl::BeginTx().CommitTx()).ExtractValueSync();
+        UNIT_ASSERT(result.IsSuccess());
+        UNIT_ASSERT_VALUES_EQUAL(counters.TotalSingleNodeReqCount->Val(), ++expectedTotalSingleNodeReqCount);
+    }
+    {
+        auto result = kikimr.GetQueryClient().ExecuteQuery(R"(
+            UPDATE `/Root/EightShard` SET Data = 111 WHERE Key = 1;
+        )", NYdb::NQuery::TTxControl::BeginTx().CommitTx()).ExtractValueSync();
+        UNIT_ASSERT(result.IsSuccess());
+        UNIT_ASSERT_VALUES_EQUAL(counters.TotalSingleNodeReqCount->Val(), ++expectedTotalSingleNodeReqCount);
+    }
+    expectedNonLocalSingleNodeReqCount += 6;
+    UNIT_ASSERT_VALUES_EQUAL(counters.NonLocalSingleNodeReqCount->Val(), expectedNonLocalSingleNodeReqCount);
+
+    // Now resume node 1 and move all tablets on the node1
+    // so all tablets will be on the same node with session
+    drainNode(firstNodeId, true);
+    drainNode(firstNodeId + 1);
+    waitTablets(firstNodeId);
+
+    {
+        auto result = session.ExecuteDataQuery(R"(
+            SELECT * FROM `/Root/EightShard` WHERE Key = 1;
+        )", TTxControl::BeginTx().CommitTx()).ExtractValueSync();
+        UNIT_ASSERT(result.IsSuccess());
+        UNIT_ASSERT_VALUES_EQUAL(counters.TotalSingleNodeReqCount->Val(), ++expectedTotalSingleNodeReqCount);
+    }
+    {
+        auto result = session.ExecuteDataQuery(R"(
+            UPSERT INTO `/Root/EightShard` (Key, Data) VALUES (1, 1);
+        )", TTxControl::BeginTx().CommitTx()).ExtractValueSync();
+        UNIT_ASSERT(result.IsSuccess());
+        UNIT_ASSERT_VALUES_EQUAL(counters.TotalSingleNodeReqCount->Val(), ++expectedTotalSingleNodeReqCount);
+    }
+    {
+        auto result = kikimr.GetQueryClient().ExecuteQuery(R"(
+            SELECT * FROM `/Root/EightShard` WHERE Key = 1;
+        )", NYdb::NQuery::TTxControl::BeginTx().CommitTx()).ExtractValueSync();
+        UNIT_ASSERT(result.IsSuccess());
+        UNIT_ASSERT_VALUES_EQUAL(counters.TotalSingleNodeReqCount->Val(), ++expectedTotalSingleNodeReqCount);
+    }
+    {
+        auto result = kikimr.GetQueryClient().ExecuteQuery(R"(
+            UPSERT INTO `/Root/EightShard` (Key, Data) VALUES (1, 1);
+        )", NYdb::NQuery::TTxControl::BeginTx().CommitTx()).ExtractValueSync();
+        UNIT_ASSERT(result.IsSuccess());
+        UNIT_ASSERT_VALUES_EQUAL(counters.TotalSingleNodeReqCount->Val(), ++expectedTotalSingleNodeReqCount);
+    }
+    {
+        auto result = session.ExecuteDataQuery(R"(
+            UPDATE `/Root/EightShard` SET Data = 111 WHERE Key = 1;
+        )", TTxControl::BeginTx().CommitTx()).ExtractValueSync();
+        UNIT_ASSERT(result.IsSuccess());
+        UNIT_ASSERT_VALUES_EQUAL(counters.TotalSingleNodeReqCount->Val(), ++expectedTotalSingleNodeReqCount);
+    }
+    {
+        auto result = kikimr.GetQueryClient().ExecuteQuery(R"(
+            UPDATE `/Root/EightShard` SET Data = 111 WHERE Key = 1;
+        )", NYdb::NQuery::TTxControl::BeginTx().CommitTx()).ExtractValueSync();
+        UNIT_ASSERT(result.IsSuccess());
+        UNIT_ASSERT_VALUES_EQUAL(counters.TotalSingleNodeReqCount->Val(), ++expectedTotalSingleNodeReqCount);
+    }
+        {
+        auto result = session.ExecuteDataQuery(R"(
+            UPDATE `/Root/EightShard` SET Data = 111 WHERE Key = 1;
+            SELECT * FROM `/Root/EightShard` WHERE Key = 1;
+        )", TTxControl::BeginTx().CommitTx()).ExtractValueSync();
+        UNIT_ASSERT(result.IsSuccess());
+        UNIT_ASSERT_VALUES_EQUAL(counters.TotalSingleNodeReqCount->Val(), ++expectedTotalSingleNodeReqCount);
+    }
+    {
+        auto result = kikimr.GetQueryClient().ExecuteQuery(R"(
+            UPDATE `/Root/EightShard` SET Data = 111 WHERE Key = 1;
+            SELECT * FROM `/Root/EightShard` WHERE Key = 1;
+        )", NYdb::NQuery::TTxControl::BeginTx().CommitTx()).ExtractValueSync();
+        UNIT_ASSERT(result.IsSuccess());
+        UNIT_ASSERT_VALUES_EQUAL(counters.TotalSingleNodeReqCount->Val(), ++expectedTotalSingleNodeReqCount);
+    }
+    // All executions are local - same value of counter
+    UNIT_ASSERT_VALUES_EQUAL(counters.NonLocalSingleNodeReqCount->Val(), expectedNonLocalSingleNodeReqCount);
 }
 
 } // suite

--- a/ydb/core/protos/kqp.proto
+++ b/ydb/core/protos/kqp.proto
@@ -477,6 +477,7 @@ message TExecuterTxResult {
     reserved 5; // (deprecated) Stats
     optional NYql.NDqProto.TDqExecutionStats Stats = 6;
     reserved 7;
+    repeated uint32 ParticipantNodes = 8;
 };
 
 message TExecuterTxResponse {


### PR DESCRIPTION
TotalSingleNodeReqCount    -     increases if tx touches the only one node (all shards located on the same node)
NonLocalSingleNodeReqCount - increases if tx touches the only one node and this node is same with session node (node where located kqp session and grpc request accepted)

[cherry-pich from main 1ad3712409a7582fcea95deb088a6c3deeea7a1c]
