### PR TITLE
Fixed use-after-free in C++ SDK v2

### DIFF
--- a/ydb/public/sdk/cpp/client/impl/ydb_internal/grpc_connections/grpc_connections.h
+++ b/ydb/public/sdk/cpp/client/impl/ydb_internal/grpc_connections/grpc_connections.h
@@ -209,7 +209,7 @@ public:
                     SetDatabaseHeader(meta, dbState->Database);
                 }
 
-                static const TStringType clientPid = GetClientPIDHeaderValue();
+                static const std::string clientPid = GetClientPIDHeaderValue();
 
                 meta.Aux.push_back({YDB_SDK_BUILD_INFO_HEADER, CreateSDKBuildInfo()});
                 meta.Aux.push_back({YDB_CLIENT_PID, clientPid});
@@ -539,7 +539,7 @@ public:
                     SetDatabaseHeader(meta, dbState->Database);
                 }
 
-                static const TStringType clientPid = GetClientPIDHeaderValue();
+                static const std::string clientPid = GetClientPIDHeaderValue();
 
                 meta.Aux.push_back({YDB_SDK_BUILD_INFO_HEADER, CreateSDKBuildInfo()});
                 meta.Aux.push_back({YDB_CLIENT_PID, clientPid});


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of changes introduced in this PR -->

...

### Changelog category <!-- remove all except one -->

* Not for changelog (changelog entry is not required)

### Additional information

...
