### PR TITLE
Remove C++ SDKv2 from dependency graph in github

### DIFF
--- a/ydb/public/sdk/cpp/ya.make
+++ b/ydb/public/sdk/cpp/ya.make
@@ -1,9 +1,14 @@
 RECURSE(
     adapters
-    client
     examples
     src
 )
+
+IF (NOT OPENSOURCE)
+    RECURSE(
+        client
+    )
+ENDIF()
 
 RECURSE_FOR_TESTS(
     tests


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of changes introduced in this PR -->

...

### Changelog category <!-- remove all except one -->

* Not for changelog (changelog entry is not required)

### Additional information

...
