### PR TITLE
Fixed segmentation fault in ThrowOnError function

### DIFF
--- a/ydb/public/sdk/cpp/include/ydb-cpp-sdk/client/types/status/status.h
+++ b/ydb/public/sdk/cpp/include/ydb-cpp-sdk/client/types/status/status.h
@@ -55,7 +55,6 @@ public:
     TYdbErrorException(TStatus status)
         : Status_(std::move(status))
     {
-        *this << status;
     }
 
     friend IOutputStream& operator<<(IOutputStream& out, const TYdbErrorException& e) {


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of changes introduced in this PR -->

TYdbErrorException constructor uses moved value, that leads to segfault

### Changelog category <!-- remove all except one -->

* Bugfix 

### Additional information

...
