### PR TITLE
Fixes for parallel tests execution

### DIFF
--- a/ydb/tests/sql/large/test_workload_manager.py
+++ b/ydb/tests/sql/large/test_workload_manager.py
@@ -3,9 +3,8 @@ import concurrent.futures
 from ydb.tests.sql.lib.test_base import TpchTestBaseH1
 from ydb.tests.library.common import workload_manager
 import ydb
-import yatest.common
-import os
 import time
+import pytest
 
 
 class TestWorkloadManager(TpchTestBaseH1):
@@ -19,8 +18,9 @@ class TestWorkloadManager(TpchTestBaseH1):
             Validates successful deletion of both classifier and resource pool.
         """
 
-        pool_definition = """
-                CREATE RESOURCE POOL test_pool WITH (
+        pool_name = f"test_pool{self.hash_short}"
+        pool_definition = f"""
+                CREATE RESOURCE POOL {pool_name} WITH (
                 CONCURRENT_QUERY_LIMIT=10,
                 QUEUE_SIZE=1000,
                 DATABASE_LOAD_CPU_THRESHOLD=80,
@@ -34,8 +34,9 @@ class TestWorkloadManager(TpchTestBaseH1):
             # create another pool with the same name
             self.query(pool_definition)
 
-        pool_classifier_definition = """
-            CREATE RESOURCE POOL CLASSIFIER test_classifier
+        classifier_name = f"test_classifier{self.hash_short}"
+        pool_classifier_definition = f"""
+            CREATE RESOURCE POOL CLASSIFIER {classifier_name}
             WITH (
                 RESOURCE_POOL = 'test_pool',
                 MEMBER_NAME = 'all-users@well-known'
@@ -46,17 +47,18 @@ class TestWorkloadManager(TpchTestBaseH1):
             # create another pool with the same name
             self.query(pool_classifier_definition)
 
-        pool_definition = """
-            DROP RESOURCE POOL CLASSIFIER test_classifier
+        pool_definition = f"""
+            DROP RESOURCE POOL CLASSIFIER {classifier_name}
             """
         self.query(pool_definition)
 
-        pool_definition = """
-            DROP RESOURCE POOL test_pool
+        pool_definition = f"""
+            DROP RESOURCE POOL {pool_name}
             """
         self.query(pool_definition)
 
-    def test_pool_classifier_with_init_timeout(self):
+    @pytest.mark.parametrize("wait_for_timeout", [(False), (True)])
+    def test_pool_classifier_init(self, wait_for_timeout):
         """
             Verifies query execution in a specific pool based on classifier rules with initialization timeout.
             Creates resource pool with defined limits and assigns user to it via classifier.
@@ -65,13 +67,14 @@ class TestWorkloadManager(TpchTestBaseH1):
 
         table_name = f"{self.tpch_default_path()}/lineitem"
 
-        self.query(f"CREATE USER testuser PASSWORD NULL")
-        self.query(f"GRANT ALL ON `{self.database}` TO testuser ")
+        user_name = "testuser" + self.hash_short
+        self.query(f"CREATE USER {user_name} PASSWORD NULL")
+        self.query(f"GRANT ALL ON `{self.database}` TO {user_name} ")
 
-        test_user_connection = self.create_connection("testuser")
+        test_user_connection = self.create_connection(user_name)
         test_user_connection.query("select 1")
 
-        resource_pool = "test_pool"
+        resource_pool = "test_pool"+self.hash_short
         pool_definition = f"""
         CREATE RESOURCE POOL {resource_pool} WITH (
             CONCURRENT_QUERY_LIMIT=1,
@@ -85,92 +88,18 @@ class TestWorkloadManager(TpchTestBaseH1):
         self.query(pool_definition)
 
         pool_classifier_definition = f"""
-            CREATE RESOURCE POOL CLASSIFIER test_classifier
+            CREATE RESOURCE POOL CLASSIFIER test_classifier{self.hash_short}
             WITH (
                 RESOURCE_POOL = '{resource_pool}',
-                MEMBER_NAME = 'testuser'
+                MEMBER_NAME = '{user_name}'
             )"""
         self.query(pool_classifier_definition)
 
-        # Wait until resource pool fetches resource classifiers list
-        time.sleep(12)
+        if wait_for_timeout:
+            # Wait until resource pool fetches resource classifiers list
+            time.sleep(12)
 
-        assert self.get_pool("testuser", f'select count(*) from `{table_name}`') == resource_pool
-
-    def test_pool_classifier_without_init_timeout(self):
-        """
-            Verifies query execution in a specific pool based on classifier rules.
-            Creates resource pool with defined limits and assigns user to it via classifier.
-            Validates that query is correctly routed to the specified pool without initialization timeout.
-        """
-
-        table_name = f"{self.tpch_default_path()}/lineitem"
-
-        self.query(f"CREATE USER testuser PASSWORD NULL")
-        self.query(f"GRANT ALL ON `{self.database}` TO testuser ")
-
-        test_user_connection = self.create_connection("testuser")
-        test_user_connection.query("select 1")
-
-        resource_pool = "test_pool"
-        pool_definition = f"""
-        CREATE RESOURCE POOL {resource_pool} WITH (
-            CONCURRENT_QUERY_LIMIT=1,
-            QUEUE_SIZE=1,
-            DATABASE_LOAD_CPU_THRESHOLD=80,
-            RESOURCE_WEIGHT=100,
-            QUERY_CPU_LIMIT_PERCENT_PER_NODE=50,
-            TOTAL_CPU_LIMIT_PERCENT_PER_NODE=70
-            )
-        """
-        self.query(pool_definition)
-
-        pool_classifier_definition = f"""
-            CREATE RESOURCE POOL CLASSIFIER test_classifier
-            WITH (
-                RESOURCE_POOL = '{resource_pool}',
-                MEMBER_NAME = 'testuser'
-            )"""
-        self.query(pool_classifier_definition)
-
-        self.verify_pool("testuser", resource_pool, f'select count(*) from `{table_name}`')
-
-
-    def test_pool_classifier_without_init_timeout(self):
-        """
-        Test queue size
-        """
-
-        table_name = f"{self.tpch_default_path()}/lineitem"
-
-        self.query(f"CREATE USER testuser PASSWORD NULL")
-        self.query(f"GRANT ALL ON `{self.database}` TO testuser ")
-
-        test_user_connection = self.create_connection("testuser")
-        test_user_connection.query("select 1")
-
-        resource_pool = "test_pool"
-        pool_definition = f"""
-        CREATE RESOURCE POOL {resource_pool} WITH (
-            CONCURRENT_QUERY_LIMIT=1,
-            QUEUE_SIZE=1,
-            DATABASE_LOAD_CPU_THRESHOLD=80,
-            RESOURCE_WEIGHT=100,
-            QUERY_CPU_LIMIT_PERCENT_PER_NODE=50,
-            TOTAL_CPU_LIMIT_PERCENT_PER_NODE=70
-            )
-        """
-        self.query(pool_definition)
-
-        pool_classifier_definition = f"""
-            CREATE RESOURCE POOL CLASSIFIER test_classifier
-            WITH (
-                RESOURCE_POOL = '{resource_pool}',
-                MEMBER_NAME = 'testuser'
-            )"""
-        self.query(pool_classifier_definition)
-
-        assert self.get_pool("testuser", f'select count(*) from `{table_name}`') == resource_pool
+        assert self.get_pool(user_name, f'select count(*) from `{table_name}`') == resource_pool
 
     def test_resource_pool_queue_size_limit(self):
         """
@@ -180,12 +109,13 @@ class TestWorkloadManager(TpchTestBaseH1):
         """
 
         table_name = f"{self.tpch_default_path()}/lineitem"
-        self.query(f"CREATE USER testuser PASSWORD NULL")
-        self.query(f"GRANT ALL ON `{self.database}` TO testuser ")
+        testuser_username = 'testuser' + self.hash_short
+        self.query(f"CREATE USER {testuser_username} PASSWORD NULL")
+        self.query(f"GRANT ALL ON `{self.database}` TO {testuser_username}")
 
         queue_size = 3
 
-        resource_pool = "test_pool"
+        resource_pool = "test_pool" + self.hash_short
         pool_definition = f"""
         CREATE RESOURCE POOL `{resource_pool}` WITH (
             CONCURRENT_QUERY_LIMIT=1,
@@ -199,19 +129,19 @@ class TestWorkloadManager(TpchTestBaseH1):
         self.query(pool_definition)
 
         pool_classifier_definition = f"""
-            CREATE RESOURCE POOL CLASSIFIER test_classifier
+            CREATE RESOURCE POOL CLASSIFIER test_classifier{self.hash_short}
             WITH (
                 RESOURCE_POOL = '{resource_pool}',
-                MEMBER_NAME = 'testuser'
+                MEMBER_NAME = '{testuser_username}'
             )"""
         self.query(pool_classifier_definition)
 
         # Wait until resource pool fetches resource classifiers list
         time.sleep(12)
 
-        self.verify_pool("testuser", resource_pool, f'select count(*) from `{table_name}`')
+        assert self.get_pool(testuser_username, f'select count(*) from `{table_name}`') == resource_pool
 
-        test_user_connection = self.create_connection("testuser")
+        test_user_connection = self.create_connection(testuser_username)
 
         success_count = 0
         error_count = 0
@@ -219,10 +149,10 @@ class TestWorkloadManager(TpchTestBaseH1):
 
         with concurrent.futures.ThreadPoolExecutor(max_workers=num_threads) as executor:
             def execute_query(query):
-                test_user_connection.query(query)
+                test_user_connection.query(query, retry_settings=ydb.RetrySettings(max_retries=0))
 
-            query_futures = [executor.submit(execute_query,
-                                             f"select sum(l_linenumber) from `{table_name}`") for _ in range(num_threads)]
+            query_futures = [executor.submit(execute_query, f"select sum(l_linenumber) from `{table_name}`")
+                             for _ in range(num_threads)]
 
             # Wait for the insert operation to complete, then allow reading to complete
             concurrent.futures.wait(query_futures)
@@ -234,94 +164,97 @@ class TestWorkloadManager(TpchTestBaseH1):
                 except Exception:
                     error_count += 1
 
-        assert success_count == queue_size, f"Expected {queue_size} successful queries, got {success_count}"
-        assert error_count == 0, f"Expected 0 failed queries, got {error_count}"
+        # CONCURRENT_QUERY_LIMIT (1) queries are executing, 2 in queue
+        assert success_count == queue_size + 1, f"Expected {queue_size+1} successful queries, got {success_count}"
 
-
-    def test_resource_pool_queue_resource_weight(self):
+    @pytest.mark.parametrize("run_count,use_classifiers", [(1, False), (1, True)])
+    def test_resource_pool_queue_resource_weight(self, run_count, use_classifiers):
         """
-        Test queue size limit for resource pool.
+        Tests resource pool performance based on different resource weights and priorities.
+        Creates two pools with different resource weights and CPU limits for high and low priority users.
+        If resource pool classifiers are set, verifies that high priority pool executes queries significantly faster than low priority pool.
         """
 
         table_name = f"{self.tpch_default_path()}/lineitem"
-        self.query(f"CREATE USER testuser1 PASSWORD NULL")
-        self.query(f"GRANT ALL ON `{self.database}` TO testuser1 ")
+        high_priority_user = "userhighpriority" + self.hash_short
+        self.query(f"CREATE USER {high_priority_user} PASSWORD NULL")
+        self.query(f"GRANT ALL ON `{self.database}` TO {high_priority_user} ")
 
-        self.query(f"CREATE USER testuser2 PASSWORD NULL")
-        self.query(f"GRANT ALL ON `{self.database}` TO testuser2 ")
+        low_priority_user = "userlowpriority" + self.hash_short
+        self.query(f"CREATE USER {low_priority_user} PASSWORD NULL")
+        self.query(f"GRANT ALL ON `{self.database}` TO {low_priority_user} ")
 
         queue_size = 2
 
-        resource_pool1 = "test_pool1"
+        high_resource_pool = "high_resource_pool" + self.hash_short
         pool_definition = f"""
-        CREATE RESOURCE POOL `{resource_pool1}` WITH (
+        CREATE RESOURCE POOL `{high_resource_pool}` WITH (
             CONCURRENT_QUERY_LIMIT=1,
             QUEUE_SIZE={queue_size},
             DATABASE_LOAD_CPU_THRESHOLD=80,
             RESOURCE_WEIGHT=100,
             QUERY_CPU_LIMIT_PERCENT_PER_NODE=100,
-            TOTAL_CPU_LIMIT_PERCENT_PER_NODE=70
+            TOTAL_CPU_LIMIT_PERCENT_PER_NODE=100
             )
         """
         self.query(pool_definition)
 
-        resource_pool2 = "test_pool2"
+        low_resource_pool = "low_resource_pool" + self.hash_short
         pool_definition = f"""
-        CREATE RESOURCE POOL `{resource_pool2}` WITH (
+        CREATE RESOURCE POOL `{low_resource_pool}` WITH (
             CONCURRENT_QUERY_LIMIT=1,
             QUEUE_SIZE={queue_size},
             DATABASE_LOAD_CPU_THRESHOLD=80,
             RESOURCE_WEIGHT=0,
-            QUERY_CPU_LIMIT_PERCENT_PER_NODE=40,
-            TOTAL_CPU_LIMIT_PERCENT_PER_NODE=40
+            QUERY_CPU_LIMIT_PERCENT_PER_NODE=100,
+            TOTAL_CPU_LIMIT_PERCENT_PER_NODE=30
             )
         """
         self.query(pool_definition)
 
-        pool_classifier1_definition = f"""
-            CREATE RESOURCE POOL CLASSIFIER test_classifier1
-            WITH (
-                RESOURCE_POOL = '{resource_pool1}',
-                MEMBER_NAME = 'testuser1'
-            )"""
-        self.query(pool_classifier1_definition)
+        if use_classifiers:
+            pool_classifier1_definition = f"""
+                CREATE RESOURCE POOL CLASSIFIER test_classifier1{self.hash_short}
+                WITH (
+                    RESOURCE_POOL = '{high_resource_pool}',
+                    MEMBER_NAME = '{high_priority_user}'
+                )"""
+            self.query(pool_classifier1_definition)
 
-        pool_classifier2_definition = f"""
-            CREATE RESOURCE POOL CLASSIFIER test_classifier2
-            WITH (
-                RESOURCE_POOL = '{resource_pool2}',
-                MEMBER_NAME = 'testuser2'
-            )"""
-        self.query(pool_classifier2_definition)
+            pool_classifier2_definition = f"""
+                CREATE RESOURCE POOL CLASSIFIER test_classifier2{self.hash_short}
+                WITH (
+                    RESOURCE_POOL = '{low_resource_pool}',
+                    MEMBER_NAME = '{low_priority_user}'
+                )"""
+            self.query(pool_classifier2_definition)
 
-        # Wait until resource pool fetches resource classifiers list
-        time.sleep(12)
+            # Wait until resource pool fetches resource classifiers list
+            time.sleep(12)
 
-        self.verify_pool("testuser1", resource_pool1, f'select count(*) from `{table_name}`')
-        self.verify_pool("testuser2", resource_pool2, f'select count(*) from `{table_name}`')
+            assert self.get_pool(high_priority_user, f'select count(*) from `{table_name}`') == high_resource_pool
+            assert self.get_pool(low_priority_user, f'select count(*) from `{table_name}`') == low_resource_pool
 
-        test_user1_connection = self.create_connection("testuser1")
-        test_user2_connection = self.create_connection("testuser2")
+        highpriority_user_connection = self.create_connection(high_priority_user)
+        lowpriority_user_connection = self.create_connection(low_priority_user)
 
         num_threads = 2
         with concurrent.futures.ThreadPoolExecutor(max_workers=num_threads) as executor:
             def execute_query(connection, query):
                 start_time = time.time()
-                for _ in range(3):
+                for _ in range(run_count):
                     connection.query(query)
                 end_time = time.time()
                 return end_time - start_time
 
             query = f"select sum(l_linenumber) from `{table_name}`"
-            query_testuser1_future = executor.submit(execute_query,test_user1_connection, query)
-            query_testuser2_future = executor.submit(execute_query,test_user2_connection, query)
+            highpriorityuser_future = executor.submit(execute_query, highpriority_user_connection, query)
+            lowpriorityuser_future = executor.submit(execute_query, lowpriority_user_connection, query)
 
             # Wait for the insert operation to complete, then allow reading to complete
-            concurrent.futures.wait([query_testuser1_future, query_testuser2_future])
+            concurrent.futures.wait([highpriorityuser_future, lowpriorityuser_future])
 
-            q1_time = query_testuser1_future.result()
-            q2_time = query_testuser2_future.result()
+            highpriority_time = highpriorityuser_future.result()
+            lowpriority_time = lowpriorityuser_future.result()
 
-            print(f"q1={q1_time} q2={q2_time}")
-
-            assert q1_time < q2_time/2, "Low CPU user2 task works faster than high cpu user 1"
+            assert highpriority_time < lowpriority_time/2, "Low CPU user2 task works faster than high cpu user 1"


### PR DESCRIPTION
Added .hash_short suffixes to all identifiers. So now tests can run concurrently