### PR TITLE
ClickHouse Client optional type fix

### DIFF
--- a/ydb/core/grpc_services/rpc_kh_describe.cpp
+++ b/ydb/core/grpc_services/rpc_kh_describe.cpp
@@ -178,7 +178,7 @@ private:
             auto* colMeta = Result.add_columns();
             colMeta->set_name(col.second.Name);
             auto& typeInfo = col.second.PType;
-            ProtoFromTypeInfo(typeInfo, *colMeta->mutable_type());
+            ProtoFromTypeInfo(typeInfo, *colMeta->mutable_type(), false);
 
             if (col.second.KeyOrder == -1)
                 continue;


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of changes introduced in this PR -->

When loading metadata from the YDB side, optional type was no longer added to the data type.

### Changelog category <!-- remove all except one -->

* Bugfix 

### Additional information

...
