### PR TITLE
no need to write an empty audit log entry

### DIFF
--- a/ydb/core/audit/audit_log_impl.cpp
+++ b/ydb/core/audit/audit_log_impl.cpp
@@ -179,7 +179,9 @@ private:
                 ? AuditLogItemBuilders[builderIndex] : AuditLogItemBuilders[DefaultAuditLogItemBuilder];
             const auto msg = ev->Get();
             const auto auditLogItem = builder(msg->Time, msg->Parts);
-            WriteLog(auditLogItem, logBackends.second);
+            if (!auditLogItem.empty()) {
+                WriteLog(auditLogItem, logBackends.second);
+            }
         }
     }
 


### PR DESCRIPTION
### Changelog entry

No need to write an empty audit log entry. Some audit log item builders do not handle all types of events.

### Changelog category

* Not for changelog (changelog entry is not required)

### Additional information

