### PR TITLE
reset CS schemas cache in unit-tests

### DIFF
--- a/ydb/core/kqp/ut/common/columnshard.cpp
+++ b/ydb/core/kqp/ut/common/columnshard.cpp
@@ -4,6 +4,7 @@
 #include <ydb/core/formats/arrow/serializer/native.h>
 #include <ydb/core/formats/arrow/serializer/parsing.h>
 #include <ydb/core/testlib/cs_helper.h>
+#include <ydb/core/tx/columnshard/engines/scheme/objects_cache.h>
 
 extern "C" {
 #include <yql/essentials/parser/pg_wrapper/postgresql/src/include/catalog/pg_type_d.h>
@@ -26,6 +27,8 @@ namespace NKqp {
         TableClient =
             std::make_unique<NYdb::NTable::TTableClient>(Kikimr->GetTableClient(NYdb::NTable::TClientSettings().AuthToken("root@builtin")));
         Session = std::make_unique<NYdb::NTable::TSession>(TableClient->CreateSession().GetValueSync().GetSession());
+
+        NOlap::TSchemaCachesManager::DropCaches();
     }
 
     NKikimr::NKqp::TKikimrRunner& TTestHelper::GetKikimr() {

--- a/ydb/core/tx/columnshard/engines/scheme/objects_cache.h
+++ b/ydb/core/tx/columnshard/engines/scheme/objects_cache.h
@@ -94,9 +94,18 @@ private:
         return CacheByTableOwner.emplace(ownerPathId, std::make_shared<TSchemaObjectsCache>()).first->second;
     }
 
+    void DropCachesImpl() {
+        TGuard lock(Mutex);
+        CacheByTableOwner.clear();
+    }
+
 public:
     static std::shared_ptr<TSchemaObjectsCache> GetCache(const ui64 ownerPathId) {
         return Singleton<TSchemaCachesManager>()->GetCacheImpl(ownerPathId);
+    }
+
+    static void DropCaches() {
+        Singleton<TSchemaCachesManager>()->DropCachesImpl();
     }
 };
 


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of changes introduced in this PR -->

Reset CS schemas cache in-between unit-tests

### Changelog category <!-- remove all except one -->

* Not for changelog (changelog entry is not required)

### Additional information

...
