### PR TITLE
checkpoint storage: fix future handling on error path

### DIFF
--- a/ydb/core/fq/libs/checkpoint_storage/storage_proxy.cpp
+++ b/ydb/core/fq/libs/checkpoint_storage/storage_proxy.cpp
@@ -163,11 +163,11 @@ void TStorageProxy::Handle(TEvCheckpointStorage::TEvCreateCheckpointRequest::TPt
     LOG_STREAMS_STORAGE_SERVICE_DEBUG("[" << event->CoordinatorId << "] [" << event->CheckpointId << "] Got TEvCreateCheckpointRequest")
 
     CheckpointStorage->GetTotalCheckpointsStateSize(event->CoordinatorId.GraphId)
-        .Apply([totalGraphCheckpointsSizeLimit = Config.GetStateStorageLimits().GetMaxGraphCheckpointsSizeBytes(),
-                checkpointId = event->CheckpointId,
+        .Apply([checkpointId = event->CheckpointId,
                 coordinatorId = event->CoordinatorId,
                 cookie = ev->Cookie,
                 sender = ev->Sender,
+                totalGraphCheckpointsSizeLimit = Config.GetStateStorageLimits().GetMaxGraphCheckpointsSizeBytes(),
                 graphDesc = std::move(event->GraphDescription),
                 storage = CheckpointStorage]
                (const NThreading::TFuture<ICheckpointStorage::TGetTotalCheckpointsStateSizeResult>& resultFuture) {


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of changes introduced in this PR -->

...

### Changelog category <!-- remove all except one -->

* Bugfix 
* Not for changelog (changelog entry is not required)

### Additional information

Current code relies on passing unitialized future as indication of error. This does not work as expected (passed future becomes initialized and saves exception; this is not documented behavior and cannot be relied on)