### PR TITLE
Ydb configure features, part 2

### DIFF
--- a/ydb/tools/cfg/base.py
+++ b/ydb/tools/cfg/base.py
@@ -683,7 +683,6 @@ class ClusterDetailsProvider(object):
             utils.wrap_parse_dict(log_config_dict, log_config)
             return log_config
 
-
         # Old, `template.yaml` style
         log_config = copy.deepcopy(self.__cluster_description.get("log", {}))
 

--- a/ydb/tools/cfg/base.py
+++ b/ydb/tools/cfg/base.py
@@ -290,10 +290,6 @@ class ClusterDetailsProvider(object):
             self._host_info_provider = walle.NopHostsInformationProvider
 
         self.__translated_storage_pools_deprecated = None
-        self.__translated_hosts = None
-        self.__racks = {}
-        self.__bodies = {}
-        self.__dcs = {}
         self.use_new_style_kikimr_cfg = self.__cluster_description.get("use_new_style_kikimr_cfg", use_new_style_cfg)
         self.need_generate_app_config = self.__cluster_description.get("need_generate_app_config", False)
         self.need_txt_files = self.__cluster_description.get("need_txt_files", True)

--- a/ydb/tools/cfg/base.py
+++ b/ydb/tools/cfg/base.py
@@ -5,7 +5,9 @@ import copy
 import os
 from concurrent.futures import ThreadPoolExecutor
 
-from ydb.tools.cfg import types, validation, walle
+from ydb.tools.cfg import types, validation, walle, utils
+
+from ydb.core.protos import config_pb2
 
 DEFAULT_LOG_LEVEL = types.LogLevels.NOTICE
 
@@ -662,6 +664,17 @@ class ClusterDetailsProvider(object):
     # Log Stuff
     @property
     def log_config(self):
+        # `config.yaml` style
+        log_config_dict = self.__cluster_description.get("log_config", {})
+        if log_config_dict != {}:
+            log_config = config_pb2.TLogConfig()
+            if "default_level" not in log_config_dict:
+                log_config["default_level"] = self.default_log_level
+            utils.wrap_parse_dict(log_config_dict, log_config)
+            return log_config
+
+
+        # Old, `template.yaml` style
         log_config = copy.deepcopy(self.__cluster_description.get("log", {}))
 
         if "entries" in log_config:

--- a/ydb/tools/cfg/base.py
+++ b/ydb/tools/cfg/base.py
@@ -304,6 +304,7 @@ class ClusterDetailsProvider(object):
         self.memory_controller_config = self.__cluster_description.get("memory_controller_config", {})
         self.channel_profile_config = self.__cluster_description.get("channel_profile_config")
         self.immediate_controls_config = self.__cluster_description.get("immediate_controls_config")
+        self.cms_config = self.__cluster_description.get("cms_config")
         self.pdisk_key_config = self.__cluster_description.get("pdisk_key_config", {})
         if not self.need_txt_files and not self.use_new_style_kikimr_cfg:
             assert "cannot remove txt files without new style kikimr cfg!"

--- a/ydb/tools/cfg/base.py
+++ b/ydb/tools/cfg/base.py
@@ -370,6 +370,10 @@ class ClusterDetailsProvider(object):
         return self.__cluster_description.get("security_settings", {})
 
     @property
+    def security_config(self):
+        return self.__cluster_description.get("security_config", {})
+
+    @property
     def forbid_implicit_storage_pools(self):
         return self.__cluster_description.get("forbid_implicit_storage_pools", False)
 
@@ -623,6 +627,16 @@ class ClusterDetailsProvider(object):
                 )
             )
         return domains
+
+    @property
+    def domains_config(self):
+        domains_config_dict = self.__cluster_description.get("domains_config", {})
+        if domains_config_dict == {}:
+            return None
+
+        domains_config = config_pb2.TDomainsConfig()
+        utils.wrap_parse_dict(domains_config_dict, domains_config)
+        return domains_config
 
     @staticmethod
     def _get_domain_tenants(domain_description):

--- a/ydb/tools/cfg/base.py
+++ b/ydb/tools/cfg/base.py
@@ -369,10 +369,6 @@ class ClusterDetailsProvider(object):
     def security_config(self):
         return self.__cluster_description.get("security_config", {})
 
-    @property
-    def forbid_implicit_storage_pools(self):
-        return self.__cluster_description.get("forbid_implicit_storage_pools", False)
-
     def _get_datacenter(self, host_description):
         if host_description.get("datacenter") is not None:
             return str(host_description.get("datacenter"))

--- a/ydb/tools/cfg/base.py
+++ b/ydb/tools/cfg/base.py
@@ -702,7 +702,12 @@ class ClusterDetailsProvider(object):
 
     @property
     def grpc_config(self):
-        return merge_with_default(GRPC_DEFAULT_CONFIG, self.__cluster_description.get("grpc", {}))
+        grpc_config = merge_with_default(GRPC_DEFAULT_CONFIG, self.__cluster_description.get("grpc", {}))
+        # specifying both `port` and `ssl_port` leads to erroneous behavior in ydbd, half of the incoming
+        # connections use tls, half do not, so this is prohibited
+        if grpc_config.get("ssl_port") is not None:
+            del grpc_config["port"]
+        return grpc_config
 
     @property
     def dynamicnameservice_config(self):

--- a/ydb/tools/cfg/k8s_api/k8s_api.py
+++ b/ydb/tools/cfg/k8s_api/k8s_api.py
@@ -45,14 +45,11 @@ class K8sApiHostsInformationProvider(HostsInformationProvider):
 
         labels = self._cache.get(hostname)
         if labels and self._k8s_rack_label in labels:
-            logging.info(f"get_rack invoked on {hostname}, value {labels[self._k8s_rack_label]}")
             return labels[self._k8s_rack_label]
         logging.info(f"rack not found for hostname {hostname}")
         return ""
 
     def get_datacenter(self, hostname):
-        logging.info(f"get_datacenter invoked on {hostname}")
-
         if self._k8s_dc_label is None:
             return "defaultDC"
 

--- a/ydb/tools/cfg/static.py
+++ b/ydb/tools/cfg/static.py
@@ -1217,11 +1217,16 @@ class StaticConfigGenerator(object):
         state_storage_cfg.Ring.Node.extend(selected_ids)
 
     def __generate_log_txt(self):
-        self.__proto_configs["log.txt"] = config_pb2.TLogConfig()
-        utils.apply_config_changes(
-            self.__proto_configs["log.txt"],
-            self.__cluster_details.log_config,
-        )
+        log_config = self.__cluster_details.log_config
+        if isinstance(log_config, config_pb2.TLogConfig):
+            self.__proto_configs["log.txt"] = log_config
+        else:
+            self.__proto_configs["log.txt"] = config_pb2.TLogConfig()
+            utils.apply_config_changes(
+                self.__proto_configs["log.txt"],
+                self.__cluster_details.log_config,
+            )
+
 
     def __generate_names_txt(self):
         self.__proto_configs["names.txt"] = config_pb2.TStaticNameserviceConfig()

--- a/ydb/tools/cfg/static.py
+++ b/ydb/tools/cfg/static.py
@@ -109,6 +109,7 @@ class StaticConfigGenerator(object):
             "failure_injection.txt": None,
             "pdisk_key.txt": None,
             "immediate_controls_config.txt": None,
+            "cms_config.txt": None,
         }
         self.__optional_config_files = set(
             (
@@ -126,7 +127,6 @@ class StaticConfigGenerator(object):
             self.__tracing = tracing
         else:
             self.__tracing = None
-        self.__write_mbus_settings_to_kikimr_cfg = False
 
     @property
     def auth_txt(self):
@@ -223,10 +223,6 @@ class StaticConfigGenerator(object):
         return self.__proto_config("sqs.txt", config_pb2.TSqsConfig, self.__cluster_details.get_service("sqs"))
 
     @property
-    def cms_txt(self):
-        return self.__proto_config("cms.txt", cms_pb2.TCmsConfig, self.__cluster_details.get_service("cms"))
-
-    @property
     def rb_txt(self):
         return self.__proto_config(
             "rb.txt", resource_broker_pb2.TResourceBrokerConfig, self.__cluster_details.get_service("resource_broker")
@@ -275,6 +271,20 @@ class StaticConfigGenerator(object):
     @property
     def immediate_controls_config_txt_enabled(self):
         return self.__proto_config("immediate_controls_config.txt").ByteSize() > 0
+
+    # Old `template.yaml` CMS style
+    @property
+    def cms_txt(self):
+        return self.__proto_config("cms.txt", cms_pb2.TCmsConfig, self.__cluster_details.get_service("cms"))
+
+    # New `config.yaml` CMS style
+    @property
+    def cms_config_txt(self):
+        return self.__proto_config("cms_config.txt", cms_pb2.TCmsConfig, self.__cluster_details.cms_config)
+
+    @property
+    def cms_config_txt_enabled(self):
+        return self.__proto_config("cms_config.txt").ByteSize() > 0
 
     @property
     def mbus_enabled(self):
@@ -655,6 +665,8 @@ class StaticConfigGenerator(object):
             app_config.PDiskKeyConfig.CopyFrom(self.pdisk_key_txt)
         if self.immediate_controls_config_txt_enabled:
             app_config.ImmediateControlsConfig.CopyFrom(self.immediate_controls_config_txt)
+        if self.cms_config_txt_enabled:
+            app_config.CmsConfig.CopyFrom(self.cms_config_txt)
         return app_config
 
     def __proto_config(self, config_file, config_class=None, cluster_details_for_field=None):

--- a/ydb/tools/cfg/static.py
+++ b/ydb/tools/cfg/static.py
@@ -1244,7 +1244,6 @@ class StaticConfigGenerator(object):
                 self.__cluster_details.log_config,
             )
 
-
     def __generate_names_txt(self):
         self.__proto_configs["names.txt"] = config_pb2.TStaticNameserviceConfig()
         if self.__cluster_details.nameservice_config is not None:

--- a/ydb/tools/cfg/static.py
+++ b/ydb/tools/cfg/static.py
@@ -1021,17 +1021,12 @@ class StaticConfigGenerator(object):
 
     def __generate_domains_from_proto(self, domains_config):
         self.__configure_security_config(domains_config)
-        if self.__cluster_details.forbid_implicit_storage_pools:
-            domains_config.ForbidImplicitStoragePools = True
         self.__proto_configs["domains.txt"] = domains_config
 
     def __generate_domains_from_old_domains_key(self):
         self.__proto_configs["domains.txt"] = config_pb2.TDomainsConfig()
 
         domains_config = self.__proto_configs["domains.txt"]
-
-        if self.__cluster_details.forbid_implicit_storage_pools:
-            domains_config.ForbidImplicitStoragePools = True
 
         self.__configure_security_config(domains_config)
 

--- a/ydb/tools/cfg/static.py
+++ b/ydb/tools/cfg/static.py
@@ -555,7 +555,6 @@ class StaticConfigGenerator(object):
             if 'channel_profile_config' in normalized_config:
                 for profile in normalized_config['channel_profile_config']['profile']:
                     for channel in profile['channel']:
-                        print(channel)
                         channel['pdisk_category'] = int(channel['pdisk_category'])
         if 'system_tablets' in normalized_config:
             for tablets in normalized_config['system_tablets'].values():
@@ -1037,7 +1036,6 @@ class StaticConfigGenerator(object):
         self.__configure_security_config(domains_config)
 
         tablet_types = self.__tablet_types
-
         for domain_description in self.__cluster_details.domains:
             domain_id = domain_description.domain_id
             domain_name = domain_description.domain_name


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of changes introduced in this PR -->

...

### Changelog category <!-- remove all except one -->

* Not for changelog (changelog entry is not required)

### log_config

Now the `config.yaml` format of `log_config` is also supported in `template.yaml`:
```
log_config:
  default_level: 5
  format: json
```
The above is equivalent to the previous `template.yaml`:
```
log:
  default: 5
  format: json
```

There is no reason to use an old `template.yaml` format of this field.

### domains_config

Now the `config.yaml` format of `domains_config` is also supported in `template.yaml`:

```
domains_config:
  domain:
  - name: ydb-slice-1
    storage_pool_types:
    - kind: ssd
      pool_config:
        box_id: 1
        erasure_species: mirror-3-dc
        kind: ssd
        geometry:
          realm_level_begin: 10
          realm_level_end: 20
          domain_level_begin: 10
          domain_level_end: 256
        pdisk_filter:
        - property:
          - type: SSD
        vdisk_kind: Default
  state_storage:
  - ring:
      node: [1, 2, 3]
      nto_select: 3
    ssid: 1
```

The old format looked something like this:

```
domains:
  - domain_name: ydb-slice-1
    storage_pool_kinds:
      - kind: "ssd"
        erasure: mirror-3-dc
        fail_domain_type: disk
        filter_properties:
          type: SSD
    console_initializers:
      - cloud_ssd_table_profile
```

There is no reason to use an old `template.yaml` format of this field.

### cms_config

Now you can specify it directly in `template.yaml`, for example:

```
cms_config:
  sentinel_config:
    default_state_limit: 1
```

This would be validated and dumped into `config.yaml`, as with all the other fields

### Minor fixes
- `forbid_implicit_storage_pools: True` is removed from ydb_configure codebase as [it is the default in YDB](https://github.com/ydb-platform/ydb/blob/a85e7bbc0cbe909ac14a283e89b88e97bb242740/ydb/core/protos/config.proto#L270)
- ydb_configure no longer produces both `ssl_port` and `port` both equal to the same value in `grpc_config`
