### PR TITLE
Add prestable into ci checks

### DIFF
--- a/.github/workflows/pr_check.yml
+++ b/.github/workflows/pr_check.yml
@@ -4,6 +4,7 @@ on:
     branches:
       - 'main'
       - 'stable-*'
+      - 'prestable-*'
       - 'stream-nb-*'
       - '*-stable-*'
       - 'dev-*'


### PR DESCRIPTION
We want to run CI checks in cases like 
https://github.com/ydb-platform/ydb/pull/13923 