### PR TITLE
Preliminary fix for erase cache consistency problems

### DIFF
--- a/ydb/core/tablet_flat/flat_mem_iter.h
+++ b/ydb/core/tablet_flat/flat_mem_iter.h
@@ -243,6 +243,9 @@ namespace NTable {
                               NTable::ITransactionObserverSimplePtr transactionObserver,
                               const NTable::ITransactionSet& decidedTransactions) noexcept
         {
+            // Temporary: we don't cache erases when there are uncompacted deltas
+            Y_UNUSED(decidedTransactions);
+
             Y_DEBUG_ABORT_UNLESS(IsValid(), "Attempt to access an invalid row");
 
             auto* chain = GetCurrentVersion();
@@ -250,11 +253,10 @@ namespace NTable {
 
             // Skip uncommitted deltas
             while (chain->RowVersion.Step == Max<ui64>() && !committedTransactions.Find(chain->RowVersion.TxId)) {
+                // We cannot cache when there are uncompacted deltas
+                stats.UncertainErase = true;
+
                 transactionObserver.OnSkipUncommitted(chain->RowVersion.TxId);
-                if (chain->Rop != ERowOp::Erase && !decidedTransactions.Contains(chain->RowVersion.TxId)) {
-                    // This change may commit and change the iteration result
-                    stats.UncertainErase = true;
-                }
                 if (!(chain = chain->Next)) {
                     CurrentVersion = nullptr;
                     return false;
@@ -268,24 +270,23 @@ namespace NTable {
                     return true;
                 }
                 transactionObserver.OnSkipCommitted(chain->RowVersion);
+                if (chain->Rop != ERowOp::Erase) {
+                    // We are skipping non-erase op, so any erase below cannot be trusted
+                    stats.UncertainErase = true;
+                }
             } else {
+                // We cannot cache when there are uncompacted deltas
+                stats.UncertainErase = true;
+
                 auto* commitVersion = committedTransactions.Find(chain->RowVersion.TxId);
                 Y_ABORT_UNLESS(commitVersion);
                 if (*commitVersion <= rowVersion) {
-                    if (!decidedTransactions.Contains(chain->RowVersion.TxId)) {
-                        // This change may rollback and change the iteration result
-                        stats.UncertainErase = true;
-                    }
                     return true;
                 }
                 transactionObserver.OnSkipCommitted(*commitVersion, chain->RowVersion.TxId);
             }
 
             stats.InvisibleRowSkips++;
-            if (chain->Rop != ERowOp::Erase) {
-                // We are skipping non-erase op, so any erase below cannot be trusted
-                stats.UncertainErase = true;
-            }
 
             while ((chain = chain->Next)) {
                 if (chain->RowVersion.Step != Max<ui64>()) {
@@ -296,13 +297,16 @@ namespace NTable {
 
                     transactionObserver.OnSkipCommitted(chain->RowVersion);
                     stats.InvisibleRowSkips++;
+                    if (chain->Rop != ERowOp::Erase) {
+                        // We are skipping non-erase op, so any erase below cannot be trusted
+                        stats.UncertainErase = true;
+                    }
                 } else {
+                    // We cannot cache when there are uncompacted deltas
+                    stats.UncertainErase = true;
+
                     auto* commitVersion = committedTransactions.Find(chain->RowVersion.TxId);
                     if (commitVersion && *commitVersion <= rowVersion) {
-                        if (!decidedTransactions.Contains(chain->RowVersion.TxId)) {
-                            // This change may rollback and change the iteration result
-                            stats.UncertainErase = true;
-                        }
                         CurrentVersion = chain;
                         return true;
                     }
@@ -312,16 +316,7 @@ namespace NTable {
                         stats.InvisibleRowSkips++;
                     } else {
                         transactionObserver.OnSkipUncommitted(chain->RowVersion.TxId);
-                        if (decidedTransactions.Contains(chain->RowVersion.TxId)) {
-                            // This is a decided uncommitted change and will never be committed
-                            // Make sure we don't mark possible erase below as uncertain
-                            continue;
-                        }
                     }
-                }
-                if (chain->Rop != ERowOp::Erase) {
-                    // We are skipping non-erase op, so any erase below cannot be trusted
-                    stats.UncertainErase = true;
                 }
             }
 

--- a/ydb/core/tablet_flat/flat_table.cpp
+++ b/ydb/core/tablet_flat/flat_table.cpp
@@ -908,7 +908,7 @@ void TTable::UpdateTx(ERowOp rop, TRawVals key, TOpsRef ops, TArrayRef<const TMe
     auto& memTable = MemTable();
     bool hadTxRef = memTable.GetTxIdStats().contains(txId);
 
-    if (ErasedKeysCache && rop != ERowOp::Erase) {
+    if (ErasedKeysCache) {
         const TCelled cells(key, *Scheme->Keys, true);
         auto res = ErasedKeysCache->FindKey(cells);
         if (res.second) {

--- a/ydb/core/tablet_flat/ut/ut_db_iface.cpp
+++ b/ydb/core/tablet_flat/ut/ut_db_iface.cpp
@@ -929,7 +929,7 @@ Y_UNIT_TEST_SUITE(DBase) {
             .Next().Is(*me.SchemedCookRow(table).Col(18_u64, 18_u64))
             .Next().Is(EReady::Gone);
 
-        UNIT_ASSERT_VALUES_EQUAL(dumpCache(), "TKeyRangeCache{ [{1}, {16}] }");
+        UNIT_ASSERT_VALUES_EQUAL(dumpCache(), "TKeyRangeCache{ [{1}, {9}), [{10}, {16}] }");
     }
 
     Y_UNIT_TEST(EraseCacheWithUncommittedChanges) {


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of changes introduced in this PR -->

Fixed consistency issues related to caching deleted ranges.

### Changelog category <!-- remove all except one -->

* Bugfix 

### Additional information

Several issues have been identified using a new jepsen workload that produces and tests deleted rows. The root cause is due to datashard transaction map remapping already committed or rolled back transactions to different committed versions, which doesn't affect correctness when replying to requests (datashards use transaction observers to filter inconsistent results), but confuses LocalDB when it uses these remapped versions for caching.

This temporary fix avoids caching over uncompacted deltas so it's easier to backport.

Fixes KIKIMR-22506.