### PR TITLE
Use the root domain as a database for all operations with users and groups

### DIFF
--- a/ydb/core/kqp/executer_actor/kqp_scheme_executer.cpp
+++ b/ydb/core/kqp/executer_actor/kqp_scheme_executer.cpp
@@ -123,7 +123,7 @@ public:
         Become(&TKqpSchemeExecuter::ExecuteState);
     }
 
-    TString GetDatabaseName() const {
+    TString GetDatabaseForLoginOperation() const {
         const auto domainLoginOnly = AppData()->AuthConfig.GetDomainLoginOnly();
         const auto domain = AppData()->DomainsInfo ? AppData()->DomainsInfo->GetDomain() : nullptr;
         const auto domainName = domain ? domain->Name : "";
@@ -193,21 +193,21 @@ public:
             case NKqpProto::TKqpSchemeOperation::kCreateUser: {
                 const auto& modifyScheme = schemeOp.GetCreateUser();
                 ev->Record.MutableTransaction()->MutableModifyScheme()->CopyFrom(modifyScheme);
-                ev->Record.SetDatabaseName(GetDatabaseName());
+                ev->Record.SetDatabaseName(GetDatabaseForLoginOperation());
                 break;
             }
 
             case NKqpProto::TKqpSchemeOperation::kAlterUser: {
                 const auto& modifyScheme = schemeOp.GetAlterUser();
                 ev->Record.MutableTransaction()->MutableModifyScheme()->CopyFrom(modifyScheme);
-                ev->Record.SetDatabaseName(GetDatabaseName());
+                ev->Record.SetDatabaseName(GetDatabaseForLoginOperation());
                 break;
             }
 
             case NKqpProto::TKqpSchemeOperation::kDropUser: {
                 const auto& modifyScheme = schemeOp.GetDropUser();
                 ev->Record.MutableTransaction()->MutableModifyScheme()->CopyFrom(modifyScheme);
-                ev->Record.SetDatabaseName(GetDatabaseName());
+                ev->Record.SetDatabaseName(GetDatabaseForLoginOperation());
                 break;
             }
             case NKqpProto::TKqpSchemeOperation::kCreateExternalTable: {
@@ -229,35 +229,35 @@ public:
             case NKqpProto::TKqpSchemeOperation::kCreateGroup: {
                 const auto& modifyScheme = schemeOp.GetCreateGroup();
                 ev->Record.MutableTransaction()->MutableModifyScheme()->CopyFrom(modifyScheme);
-                ev->Record.SetDatabaseName(GetDatabaseName());
+                ev->Record.SetDatabaseName(GetDatabaseForLoginOperation());
                 break;
             }
 
             case NKqpProto::TKqpSchemeOperation::kAddGroupMembership: {
                 const auto& modifyScheme = schemeOp.GetAddGroupMembership();
                 ev->Record.MutableTransaction()->MutableModifyScheme()->CopyFrom(modifyScheme);
-                ev->Record.SetDatabaseName(GetDatabaseName());
+                ev->Record.SetDatabaseName(GetDatabaseForLoginOperation());
                 break;
             }
 
             case NKqpProto::TKqpSchemeOperation::kRemoveGroupMembership: {
                 const auto& modifyScheme = schemeOp.GetRemoveGroupMembership();
                 ev->Record.MutableTransaction()->MutableModifyScheme()->CopyFrom(modifyScheme);
-                ev->Record.SetDatabaseName(GetDatabaseName());
+                ev->Record.SetDatabaseName(GetDatabaseForLoginOperation());
                 break;
             }
 
             case NKqpProto::TKqpSchemeOperation::kRenameGroup: {
                 const auto& modifyScheme = schemeOp.GetRenameGroup();
                 ev->Record.MutableTransaction()->MutableModifyScheme()->CopyFrom(modifyScheme);
-                ev->Record.SetDatabaseName(GetDatabaseName());
+                ev->Record.SetDatabaseName(GetDatabaseForLoginOperation());
                 break;
             }
 
             case NKqpProto::TKqpSchemeOperation::kDropGroup: {
                 const auto& modifyScheme = schemeOp.GetDropGroup();
                 ev->Record.MutableTransaction()->MutableModifyScheme()->CopyFrom(modifyScheme);
-                ev->Record.SetDatabaseName(GetDatabaseName());
+                ev->Record.SetDatabaseName(GetDatabaseForLoginOperation());
                 break;
             }
 

--- a/ydb/tests/functional/tenants/test_users_groups_with_acl.py
+++ b/ydb/tests/functional/tenants/test_users_groups_with_acl.py
@@ -1,11 +1,6 @@
 # -*- coding: utf-8 -*-
+
 import logging
-
-from hamcrest import (
-    assert_that,
-    has_length,
-)
-
 from ydb.tests.library.harness.kikimr_runner import KiKiMR
 from ydb.tests.library.harness.kikimr_config import KikimrConfigGenerator
 from ydb.tests.oss.ydb_sdk_import import ydb

--- a/ydb/tests/functional/tenants/test_users_groups_with_acl.py
+++ b/ydb/tests/functional/tenants/test_users_groups_with_acl.py
@@ -1,0 +1,183 @@
+# -*- coding: utf-8 -*-
+import logging
+import os
+import inspect
+
+from hamcrest import (
+    anything,
+    assert_that,
+    has_length,
+    has_properties,
+)
+
+from ydb.tests.library.harness.kikimr_runner import KiKiMR
+from ydb.tests.library.harness.kikimr_config import KikimrConfigGenerator
+from ydb.tests.oss.ydb_sdk_import import ydb
+
+
+logger = logging.getLogger(__name__)
+
+
+class BaseCreateSubjects(object):
+    @classmethod
+    def setup_class(cls):
+        config_generator = KikimrConfigGenerator()
+        config_generator.yaml_config["auth_config"] = {
+            "domain_login_only": cls.DomainLoginOnly,
+        }
+        cls.cluster = KiKiMR(config_generator)
+        cls.cluster.start()
+
+    @classmethod
+    def teardown_class(cls):
+        if hasattr(cls, 'cluster'):
+            cls.cluster.stop()
+
+    def setup_method(self, method=None):
+        self.database = "/Root/users/{class_name}_{method_name}".format(
+            class_name=self.__class__.__name__,
+            method_name=method.__name__,
+        )
+        host = self.cluster.nodes[1].host
+        port = self.cluster.nodes[1].port
+        self.domain_admin_driver_config = ydb.DriverConfig(
+            endpoint="%s:%s" % (host, port),
+            database="/Root",
+        )
+        self.tenant_admin_driver_config = ydb.DriverConfig(
+            endpoint="%s:%s" % (host, port),
+            database=self.database,
+        )
+        self.tenant_user_driver_config = ydb.DriverConfig(
+            endpoint="%s:%s" % (host, port),
+            database=self.database,
+            credentials=ydb.StaticCredentials.from_user_password("user", ""),
+        )
+
+        logger.debug("Create database %s" % self.database)
+        self.cluster.create_database(
+            self.database,
+            storage_pool_units_count={
+                'hdd': 1
+            }
+        )
+        self.cluster.register_and_start_slots(self.database, count=1)
+        self.cluster.wait_tenant_up(self.database)
+
+    def teardown_method(self, method=None):
+        logger.debug("Remove database %s" % self.database)
+        self.cluster.remove_database(self.database)
+        self.database = None
+
+    def yql_check_permission(self):
+        with ydb.Driver(self.tenant_user_driver_config) as driver:
+            driver.wait(5)
+            script_client = ydb.ScriptingClient(driver)
+            script_client.execute_yql("CREATE TABLE table (key Int32, value String, primary key(key));")
+            script_client.execute_yql("""UPSERT INTO table (key, value) VALUES (1, "value1");""")
+
+            result_sets = script_client.execute_yql("SELECT * FROM table")
+            assert_that(result_sets, has_length(1))
+            assert_that(result_sets[0].rows, has_length(1))
+            assert_that(result_sets[0].rows[0].key == 1)
+            assert_that(result_sets[0].rows[0].value == b"value1")
+
+            script_client.execute_yql("DROP TABLE table;")
+
+    def query_check_permission(self):
+        with ydb.Driver(self.tenant_user_driver_config) as driver:
+            with ydb.QuerySessionPool(driver, size=1) as pool:
+                pool.execute_with_retries("CREATE TABLE table (key Int32, value String, primary key(key));")
+                pool.execute_with_retries("""UPSERT INTO table (key, value) VALUES (1, "value1");""")
+
+                result_sets = pool.execute_with_retries("SELECT * FROM table")
+                assert_that(result_sets, has_length(1))
+                assert_that(result_sets[0].rows, has_length(1))
+                assert_that(result_sets[0].rows[0].key == 1)
+                assert_that(result_sets[0].rows[0].value == b"value1")
+
+                pool.execute_with_retries("DROP TABLE table;")
+
+    def yql_create_user(self, admin_driver_config):
+        with ydb.Driver(admin_driver_config) as driver:
+            driver.wait(5)
+            script_client = ydb.ScriptingClient(driver)
+            script_client.execute_yql('CREATE USER user;')
+            #script_client.execute_yql(f"GRANT ALL ON `{self.database}` TO user;")
+            # REVOKE 'ydb.generic.read' ON `/shop_db/orders` FROM user1;
+            script_client.execute_yql('ALTER USER user WITH PASSWORD NULL;')
+            script_client.execute_yql('DROP USER user;')
+
+
+    def query_create_user(self, admin_driver_config):
+        with ydb.Driver(admin_driver_config) as driver:
+            with ydb.QuerySessionPool(driver, size=1) as pool:
+                pool.execute_with_retries("CREATE USER user;")
+                #pool.execute_with_retries(f"GRANT ALL ON `{self.database}` TO user;")
+                pool.execute_with_retries('ALTER USER user WITH PASSWORD NULL;')
+                pool.execute_with_retries("DROP USER user;")
+
+    def yql_create_group(self, admin_driver_config):
+        with ydb.Driver(admin_driver_config) as driver:
+            driver.wait(5)
+            script_client = ydb.ScriptingClient(driver)
+            script_client.execute_yql("CREATE GROUP group;")
+            #script_client.execute_yql(f"GRANT ALL ON `{self.database}` TO group;")
+            script_client.execute_yql("CREATE USER user;")
+            script_client.execute_yql("ALTER GROUP group ADD USER user;")
+            script_client.execute_yql("ALTER GROUP group DROP USER user;")
+            script_client.execute_yql("DROP GROUP group;")
+            script_client.execute_yql("DROP USER user;")
+
+    def query_create_group(self, admin_driver_config):
+        with ydb.Driver(admin_driver_config) as driver:
+            with ydb.QuerySessionPool(driver, size=1) as pool:
+                pool.execute_with_retries("CREATE GROUP group;")
+                #pool.execute_with_retries(f"GRANT ALL ON `{self.database}` TO group;")
+                pool.execute_with_retries("CREATE USER user;")
+                pool.execute_with_retries("ALTER GROUP group ADD USER user;")
+                pool.execute_with_retries("ALTER GROUP group DROP USER user;")
+                pool.execute_with_retries("DROP GROUP group;")
+                pool.execute_with_retries("DROP USER user;")
+
+    def test_yql_create_user_by_domain_admin(self):
+        self.yql_create_user(self.domain_admin_driver_config)
+        # self.yql_check_permission()
+    
+    def test_yql_create_user_by_tenant_admin(self):
+        self.yql_create_user(self.tenant_admin_driver_config)
+        #self.yql_check_permission()
+
+    def test_yql_create_group_by_domain_admin(self):
+        self.yql_create_group(self.domain_admin_driver_config)
+        # self.yql_check_permission()
+    
+    def test_yql_create_group_by_tenant_admin(self):
+        self.yql_create_group(self.tenant_admin_driver_config)
+        #self.yql_check_permission()
+
+
+
+
+    def test_query_create_user_by_domain_admin(self):
+        self.query_create_user(self.domain_admin_driver_config)
+        #self.query_check_permission()
+    
+    def test_query_create_user_by_tenant_admin(self):
+        self.query_create_user(self.tenant_admin_driver_config)
+        #self.query_check_permission()
+
+    def test_query_create_group_by_domain_admin(self):
+        self.query_create_group(self.domain_admin_driver_config)
+        #self.query_check_permission()
+    
+    def test_query_create_group_by_tenant_admin(self):
+        self.query_create_group(self.tenant_admin_driver_config)
+        #self.query_check_permission()
+
+
+class TestCreateSubjectsWithDomainLoginOnly(BaseCreateSubjects):
+    DomainLoginOnly = True
+
+class TestCreateSubjectsWithoutDomainLoginOnly(BaseCreateSubjects):
+    DomainLoginOnly = False

--- a/ydb/tests/functional/tenants/test_users_groups_with_acl.py
+++ b/ydb/tests/functional/tenants/test_users_groups_with_acl.py
@@ -1,129 +1,132 @@
 # -*- coding: utf-8 -*-
 
 import logging
-from ydb.tests.library.harness.kikimr_runner import KiKiMR
+import pytest
 from ydb.tests.library.harness.kikimr_config import KikimrConfigGenerator
+from ydb.tests.library.harness.ydb_fixtures import ydb_database_ctx
 from ydb.tests.oss.ydb_sdk_import import ydb
 
 
 logger = logging.getLogger(__name__)
 
 
-class BaseCreateSubjects(object):
-    @classmethod
-    def setup_class(cls):
-        config_generator = KikimrConfigGenerator()
-        config_generator.yaml_config["auth_config"] = {
-            "domain_login_only": cls.DomainLoginOnly,
-        }
-        cls.cluster = KiKiMR(config_generator)
-        cls.cluster.start()
-
-    @classmethod
-    def teardown_class(cls):
-        if hasattr(cls, 'cluster'):
-            cls.cluster.stop()
-
-    def setup_method(self, method=None):
-        self.database = "/Root/users/{class_name}_{method_name}".format(
-            class_name=self.__class__.__name__,
-            method_name=method.__name__,
-        )
-        host = self.cluster.nodes[1].host
-        port = self.cluster.nodes[1].port
-        self.domain_admin_driver_config = ydb.DriverConfig(
-            endpoint="%s:%s" % (host, port),
-            database="/Root",
-        )
-        self.tenant_admin_driver_config = ydb.DriverConfig(
-            endpoint="%s:%s" % (host, port),
-            database=self.database,
-        )
-        self.tenant_user_driver_config = ydb.DriverConfig(
-            endpoint="%s:%s" % (host, port),
-            database=self.database,
-            credentials=ydb.StaticCredentials.from_user_password("user", ""),
-        )
-
-        logger.debug("Create database %s" % self.database)
-        self.cluster.create_database(
-            self.database,
-            storage_pool_units_count={
-                'hdd': 1
-            }
-        )
-        self.cluster.register_and_start_slots(self.database, count=1)
-        self.cluster.wait_tenant_up(self.database)
-
-    def teardown_method(self, method=None):
-        logger.debug("Remove database %s" % self.database)
-        self.cluster.remove_database(self.database)
-        self.database = None
-
-    def yql_create_user(self, admin_driver_config):
-        with ydb.Driver(admin_driver_config) as driver:
-            driver.wait(5)
-            script_client = ydb.ScriptingClient(driver)
-            script_client.execute_yql('CREATE USER user;')
-            script_client.execute_yql('ALTER USER user WITH PASSWORD NULL;')
-            script_client.execute_yql('DROP USER user;')
-
-    def query_create_user(self, admin_driver_config):
-        with ydb.Driver(admin_driver_config) as driver:
-            with ydb.QuerySessionPool(driver, size=1) as pool:
-                pool.execute_with_retries("CREATE USER user;")
-                pool.execute_with_retries('ALTER USER user WITH PASSWORD NULL;')
-                pool.execute_with_retries("DROP USER user;")
-
-    def yql_create_group(self, admin_driver_config):
-        with ydb.Driver(admin_driver_config) as driver:
-            driver.wait(5)
-            script_client = ydb.ScriptingClient(driver)
-            script_client.execute_yql("CREATE GROUP group;")
-            script_client.execute_yql("CREATE USER user;")
-            script_client.execute_yql("ALTER GROUP group ADD USER user;")
-            script_client.execute_yql("ALTER GROUP group DROP USER user;")
-            script_client.execute_yql("DROP GROUP group;")
-            script_client.execute_yql("DROP USER user;")
-
-    def query_create_group(self, admin_driver_config):
-        with ydb.Driver(admin_driver_config) as driver:
-            with ydb.QuerySessionPool(driver, size=1) as pool:
-                pool.execute_with_retries("CREATE GROUP group;")
-                pool.execute_with_retries("CREATE USER user;")
-                pool.execute_with_retries("ALTER GROUP group ADD USER user;")
-                pool.execute_with_retries("ALTER GROUP group DROP USER user;")
-                pool.execute_with_retries("DROP GROUP group;")
-                pool.execute_with_retries("DROP USER user;")
-
-    def test_yql_create_user_by_domain_admin(self):
-        self.yql_create_user(self.domain_admin_driver_config)
-
-    def test_yql_create_user_by_tenant_admin(self):
-        self.yql_create_user(self.tenant_admin_driver_config)
-
-    def test_yql_create_group_by_domain_admin(self):
-        self.yql_create_group(self.domain_admin_driver_config)
-
-    def test_yql_create_group_by_tenant_admin(self):
-        self.yql_create_group(self.tenant_admin_driver_config)
-
-    def test_query_create_user_by_domain_admin(self):
-        self.query_create_user(self.domain_admin_driver_config)
-
-    def test_query_create_user_by_tenant_admin(self):
-        self.query_create_user(self.tenant_admin_driver_config)
-
-    def test_query_create_group_by_domain_admin(self):
-        self.query_create_group(self.domain_admin_driver_config)
-
-    def test_query_create_group_by_tenant_admin(self):
-        self.query_create_group(self.tenant_admin_driver_config)
+DATABASE = '/Root/users/database'
 
 
-class TestCreateSubjectsWithDomainLoginOnly(BaseCreateSubjects):
-    DomainLoginOnly = True
+@pytest.fixture(scope='module', params=[True, False], ids=['domain_login_only--true', 'domain_login_only--false'])
+def domain_login_only(request):
+    return request.param
 
 
-class TestCreateSubjectsWithoutDomainLoginOnly(BaseCreateSubjects):
-    DomainLoginOnly = False
+@pytest.fixture(scope='module')
+def ydb_configurator(ydb_cluster_configuration, domain_login_only):
+    config_generator = KikimrConfigGenerator(**ydb_cluster_configuration)
+    config_generator.yaml_config['auth_config'] = {
+        'domain_login_only': domain_login_only,
+    }
+    return config_generator
+
+
+@pytest.fixture(scope='function')
+def domain_admin_driver_config(ydb_endpoint):
+    return ydb.DriverConfig(
+        endpoint=ydb_endpoint,
+        database="/Root",
+    )
+
+
+@pytest.fixture(scope='function')
+def tenant_admin_driver_config(ydb_endpoint):
+    return ydb.DriverConfig(
+        endpoint=ydb_endpoint,
+        database=DATABASE,
+    )
+
+
+@pytest.fixture(scope='function')
+def tenant_user_driver_config(ydb_endpoint):
+    return ydb.DriverConfig(
+        endpoint=ydb_endpoint,
+        database=DATABASE,
+        credentials=ydb.StaticCredentials.from_user_password('user', ''),
+    )
+
+
+def yql_create_user(config):
+    with ydb.Driver(config) as driver:
+        driver.wait()
+        script_client = ydb.ScriptingClient(driver)
+        script_client.execute_yql('CREATE USER user;')
+        script_client.execute_yql('ALTER USER user WITH PASSWORD NULL;')
+        script_client.execute_yql('DROP USER user;')
+
+
+def query_create_user(config):
+    with ydb.Driver(config) as driver:
+        with ydb.QuerySessionPool(driver, size=1) as pool:
+            pool.execute_with_retries('CREATE USER user;')
+            pool.execute_with_retries('ALTER USER user WITH PASSWORD NULL;')
+            pool.execute_with_retries('DROP USER user;')
+
+
+def yql_create_group(config):
+    with ydb.Driver(config) as driver:
+        driver.wait()
+        script_client = ydb.ScriptingClient(driver)
+        script_client.execute_yql('CREATE GROUP group;')
+        script_client.execute_yql('CREATE USER user;')
+        script_client.execute_yql('ALTER GROUP group ADD USER user;')
+        script_client.execute_yql('ALTER GROUP group DROP USER user;')
+        script_client.execute_yql('DROP GROUP group;')
+        script_client.execute_yql('DROP USER user;')
+
+
+def query_create_group(config):
+    with ydb.Driver(config) as driver:
+        with ydb.QuerySessionPool(driver, size=1) as pool:
+            pool.execute_with_retries('CREATE GROUP group;')
+            pool.execute_with_retries('CREATE USER user;')
+            pool.execute_with_retries('ALTER GROUP group ADD USER user;')
+            pool.execute_with_retries('ALTER GROUP group DROP USER user;')
+            pool.execute_with_retries('DROP GROUP group;')
+            pool.execute_with_retries('DROP USER user;')
+
+
+def test_yql_create_user_by_domain_admin(ydb_cluster, domain_admin_driver_config):
+    with ydb_database_ctx(ydb_cluster, DATABASE):
+        yql_create_user(domain_admin_driver_config)
+
+
+def test_yql_create_user_by_tenant_admin(ydb_cluster, tenant_admin_driver_config):
+    with ydb_database_ctx(ydb_cluster, DATABASE):
+        yql_create_user(tenant_admin_driver_config)
+
+
+def test_yql_create_group_by_domain_admin(ydb_cluster, domain_admin_driver_config):
+    with ydb_database_ctx(ydb_cluster, DATABASE):
+        yql_create_group(domain_admin_driver_config)
+
+
+def test_yql_create_group_by_tenant_admin(ydb_cluster, tenant_admin_driver_config):
+    with ydb_database_ctx(ydb_cluster, DATABASE):
+        yql_create_group(tenant_admin_driver_config)
+
+
+def test_query_create_user_by_domain_admin(ydb_cluster, domain_admin_driver_config):
+    with ydb_database_ctx(ydb_cluster, DATABASE):
+        query_create_user(domain_admin_driver_config)
+
+
+def test_query_create_user_by_tenant_admin(ydb_cluster, tenant_admin_driver_config):
+    with ydb_database_ctx(ydb_cluster, DATABASE):
+        query_create_user(tenant_admin_driver_config)
+
+
+def test_query_create_group_by_domain_admin(ydb_cluster, domain_admin_driver_config):
+    with ydb_database_ctx(ydb_cluster, DATABASE):
+        query_create_group(domain_admin_driver_config)
+
+
+def test_query_create_group_by_tenant_admin(ydb_cluster, tenant_admin_driver_config):
+    with ydb_database_ctx(ydb_cluster, DATABASE):
+        query_create_group(tenant_admin_driver_config)

--- a/ydb/tests/functional/tenants/test_users_groups_with_acl.py
+++ b/ydb/tests/functional/tenants/test_users_groups_with_acl.py
@@ -1,13 +1,9 @@
 # -*- coding: utf-8 -*-
 import logging
-import os
-import inspect
 
 from hamcrest import (
-    anything,
     assert_that,
     has_length,
-    has_properties,
 )
 
 from ydb.tests.library.harness.kikimr_runner import KiKiMR
@@ -69,51 +65,18 @@ class BaseCreateSubjects(object):
         self.cluster.remove_database(self.database)
         self.database = None
 
-    def yql_check_permission(self):
-        with ydb.Driver(self.tenant_user_driver_config) as driver:
-            driver.wait(5)
-            script_client = ydb.ScriptingClient(driver)
-            script_client.execute_yql("CREATE TABLE table (key Int32, value String, primary key(key));")
-            script_client.execute_yql("""UPSERT INTO table (key, value) VALUES (1, "value1");""")
-
-            result_sets = script_client.execute_yql("SELECT * FROM table")
-            assert_that(result_sets, has_length(1))
-            assert_that(result_sets[0].rows, has_length(1))
-            assert_that(result_sets[0].rows[0].key == 1)
-            assert_that(result_sets[0].rows[0].value == b"value1")
-
-            script_client.execute_yql("DROP TABLE table;")
-
-    def query_check_permission(self):
-        with ydb.Driver(self.tenant_user_driver_config) as driver:
-            with ydb.QuerySessionPool(driver, size=1) as pool:
-                pool.execute_with_retries("CREATE TABLE table (key Int32, value String, primary key(key));")
-                pool.execute_with_retries("""UPSERT INTO table (key, value) VALUES (1, "value1");""")
-
-                result_sets = pool.execute_with_retries("SELECT * FROM table")
-                assert_that(result_sets, has_length(1))
-                assert_that(result_sets[0].rows, has_length(1))
-                assert_that(result_sets[0].rows[0].key == 1)
-                assert_that(result_sets[0].rows[0].value == b"value1")
-
-                pool.execute_with_retries("DROP TABLE table;")
-
     def yql_create_user(self, admin_driver_config):
         with ydb.Driver(admin_driver_config) as driver:
             driver.wait(5)
             script_client = ydb.ScriptingClient(driver)
             script_client.execute_yql('CREATE USER user;')
-            #script_client.execute_yql(f"GRANT ALL ON `{self.database}` TO user;")
-            # REVOKE 'ydb.generic.read' ON `/shop_db/orders` FROM user1;
             script_client.execute_yql('ALTER USER user WITH PASSWORD NULL;')
             script_client.execute_yql('DROP USER user;')
-
 
     def query_create_user(self, admin_driver_config):
         with ydb.Driver(admin_driver_config) as driver:
             with ydb.QuerySessionPool(driver, size=1) as pool:
                 pool.execute_with_retries("CREATE USER user;")
-                #pool.execute_with_retries(f"GRANT ALL ON `{self.database}` TO user;")
                 pool.execute_with_retries('ALTER USER user WITH PASSWORD NULL;')
                 pool.execute_with_retries("DROP USER user;")
 
@@ -122,7 +85,6 @@ class BaseCreateSubjects(object):
             driver.wait(5)
             script_client = ydb.ScriptingClient(driver)
             script_client.execute_yql("CREATE GROUP group;")
-            #script_client.execute_yql(f"GRANT ALL ON `{self.database}` TO group;")
             script_client.execute_yql("CREATE USER user;")
             script_client.execute_yql("ALTER GROUP group ADD USER user;")
             script_client.execute_yql("ALTER GROUP group DROP USER user;")
@@ -133,7 +95,6 @@ class BaseCreateSubjects(object):
         with ydb.Driver(admin_driver_config) as driver:
             with ydb.QuerySessionPool(driver, size=1) as pool:
                 pool.execute_with_retries("CREATE GROUP group;")
-                #pool.execute_with_retries(f"GRANT ALL ON `{self.database}` TO group;")
                 pool.execute_with_retries("CREATE USER user;")
                 pool.execute_with_retries("ALTER GROUP group ADD USER user;")
                 pool.execute_with_retries("ALTER GROUP group DROP USER user;")
@@ -142,42 +103,32 @@ class BaseCreateSubjects(object):
 
     def test_yql_create_user_by_domain_admin(self):
         self.yql_create_user(self.domain_admin_driver_config)
-        # self.yql_check_permission()
-    
+
     def test_yql_create_user_by_tenant_admin(self):
         self.yql_create_user(self.tenant_admin_driver_config)
-        #self.yql_check_permission()
 
     def test_yql_create_group_by_domain_admin(self):
         self.yql_create_group(self.domain_admin_driver_config)
-        # self.yql_check_permission()
-    
+
     def test_yql_create_group_by_tenant_admin(self):
         self.yql_create_group(self.tenant_admin_driver_config)
-        #self.yql_check_permission()
-
-
-
 
     def test_query_create_user_by_domain_admin(self):
         self.query_create_user(self.domain_admin_driver_config)
-        #self.query_check_permission()
-    
+
     def test_query_create_user_by_tenant_admin(self):
         self.query_create_user(self.tenant_admin_driver_config)
-        #self.query_check_permission()
 
     def test_query_create_group_by_domain_admin(self):
         self.query_create_group(self.domain_admin_driver_config)
-        #self.query_check_permission()
-    
+
     def test_query_create_group_by_tenant_admin(self):
         self.query_create_group(self.tenant_admin_driver_config)
-        #self.query_check_permission()
 
 
 class TestCreateSubjectsWithDomainLoginOnly(BaseCreateSubjects):
     DomainLoginOnly = True
+
 
 class TestCreateSubjectsWithoutDomainLoginOnly(BaseCreateSubjects):
     DomainLoginOnly = False

--- a/ydb/tests/functional/tenants/ya.make
+++ b/ydb/tests/functional/tenants/ya.make
@@ -10,6 +10,7 @@ TEST_SRCS(
     test_storage_config.py
     test_system_views.py
     test_publish_into_schemeboard_with_common_ssring.py
+    test_users_groups_with_acl.py
 )
 
 SPLIT_FACTOR(20)


### PR DESCRIPTION
### Changelog entry

Now, with the "DomainLoginOnly" flag set, authorization occurs on the root SchemeShard. "SQL Script" creates users and groups in the same way on the root SchemeShard. But "QueryService" creates them in a domain. It is  proposed to unify this behavior and, in all cases where the "DomainLoginOnly" flag is set, use the root SchemeShard to store users and authorize them. Otherwise, either the domain or the root SchemeShard will be used, depending on the value specified in the "Database" parameter.

### Changelog category

* Not for changelog (changelog entry is not required)

### Additional information

