### PR TITLE
limit in-fly of tablet deletions

### DIFF
--- a/ydb/core/mind/hive/hive_impl.h
+++ b/ydb/core/mind/hive/hive_impl.h
@@ -438,7 +438,7 @@ protected:
     static constexpr ui64 MAX_UPDATE_TABLET_METRICS_IN_PROGRESS = 10000; // 10K
     i64 DeleteTabletInProgress = 0;
     static constexpr i64 MAX_DELETE_TABLET_IN_PROGRESS = 100;
-    std::queue<TEvHive::TEvDeleteTablet::TPtr> DeleteTabletQueue;
+    std::queue<TTabletId> DeleteTabletQueue;
 
     TString BootStateBooting = "Booting";
     TString BootStateStarting = "Starting";
@@ -713,6 +713,7 @@ TTabletInfo* FindTabletEvenInDeleting(TTabletId tabletId, TFollowerId followerId
     TDuration GetBalancerCooldown(EBalancerType balancerType) const;
     void UpdateObjectCount(const TLeaderTabletInfo& tablet, const TNodeInfo& node, i64 diff);
     ui64 GetObjectImbalance(TFullObjectId object);
+    void BlockStorageForDelete(TTabletId tabletId, TSideEffects& sideEffects);
 
     ui32 GetEventPriority(IEventHandle* ev);
     void PushProcessIncomingEvent();

--- a/ydb/core/mind/hive/hive_impl.h
+++ b/ydb/core/mind/hive/hive_impl.h
@@ -436,6 +436,9 @@ protected:
 
     ui64 UpdateTabletMetricsInProgress = 0;
     static constexpr ui64 MAX_UPDATE_TABLET_METRICS_IN_PROGRESS = 10000; // 10K
+    i64 DeleteTabletInProgress = 0;
+    static constexpr i64 MAX_DELETE_TABLET_IN_PROGRESS = 100;
+    std::queue<TEvHive::TEvDeleteTablet::TPtr> DeleteTabletQueue;
 
     TString BootStateBooting = "Booting";
     TString BootStateStarting = "Starting";

--- a/ydb/core/mind/hive/tx__delete_tablet.cpp
+++ b/ydb/core/mind/hive/tx__delete_tablet.cpp
@@ -39,9 +39,7 @@ public:
                     follower.InitiateStop(SideEffects);
                     db.Table<Schema::TabletFollowerTablet>().Key(follower.GetFullTabletId()).Update<Schema::TabletFollowerTablet::FollowerNode>(0);
                 }
-                if (!tablet->InitiateBlockStorage(SideEffects, std::numeric_limits<ui32>::max())) {
-                    Self->DeleteTabletWithoutStorage(tablet, SideEffects);
-                }
+                Self->BlockStorageForDelete(tabletId, SideEffects);
             } else {
                 BLOG_D("THive::TTxDeleteTablet::Execute Tablet " << tabletId << " already in ETabletState::Deleting");
             }

--- a/ydb/core/mind/hive/tx__delete_tablet_result.cpp
+++ b/ydb/core/mind/hive/tx__delete_tablet_result.cpp
@@ -8,6 +8,7 @@ class TTxDeleteTabletResult : public TTransactionBase<THive> {
     TEvTabletBase::TEvDeleteTabletResult::TPtr Result;
     TTabletId TabletId;
     TSideEffects SideEffects;
+    bool Success;
 
 public:
     TTxDeleteTabletResult(TEvTabletBase::TEvDeleteTabletResult::TPtr& ev, THive* hive)
@@ -20,6 +21,7 @@ public:
 
     bool Execute(TTransactionContext& txc, const TActorContext&) override {
         SideEffects.Reset(Self->SelfId());
+        Success = true;
         TEvTabletBase::TEvDeleteTabletResult* msg = Result->Get();
         BLOG_D("THive::TTxDeleteTabletResult::Execute(" << TabletId << " " << NKikimrProto::EReplyStatus_Name(msg->Status) << ")");
         TLeaderTabletInfo* tablet = Self->FindTabletEvenInDeleting(TabletId);
@@ -57,6 +59,7 @@ public:
                 Self->PendingCreateTablets.erase({tablet->Owner.first, tablet->Owner.second});
                 Self->DeleteTablet(tablet->Id);
             } else {
+                Success = false;
                 BLOG_W("THive::TTxDeleteTabletResult retrying for " << TabletId << " because of " << NKikimrProto::EReplyStatus_Name(msg->Status));
                 Y_ENSURE_LOG(tablet->IsDeleting(), " tablet " << tablet->Id);
                 SideEffects.Schedule(TDuration::MilliSeconds(1000), new TEvHive::TEvInitiateDeleteStorage(tablet->Id));
@@ -67,8 +70,14 @@ public:
 
     void Complete(const TActorContext& ctx) override {
         BLOG_D("THive::TTxDeleteTabletResult(" << TabletId << ")::Complete SideEffects " << SideEffects);
+        if (Success) {
+            --Self->DeleteTabletInProgress;
+            while (!Self->DeleteTabletQueue.empty() && Self->DeleteTabletInProgress < THive::MAX_DELETE_TABLET_IN_PROGRESS) {
+                Self->BlockStorageForDelete(Self->DeleteTabletQueue.front(), SideEffects);
+                Self->DeleteTabletQueue.pop();
+            }
+        }
         SideEffects.Complete(ctx);
-
     }
 };
 


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of changes introduced in this PR -->

Limited simultaneous tablet deletions.

### Changelog category <!-- remove all except one -->

* Improvement

### Additional information

Limit number of simultaneous tablet deletions to prevent a deletion of a massive table from causing OOM-failures.
