### PR TITLE
VIEW: enable export and import in YDB CLI

### DIFF
--- a/ydb/apps/ydb/CHANGELOG.md
+++ b/ydb/apps/ydb/CHANGELOG.md
@@ -1,3 +1,4 @@
+* Enable view exports and imports. Views are exported as `CREATE VIEW` YQL statements which are executed on import.
 * Save current stats in `ydb workload run`.
 * Added message if global timeout expiried in `ydb workload run` comamnd.
 * Fixed return code of `ydb workload run` comamnd.

--- a/ydb/public/lib/ydb_cli/commands/ydb_service_export.cpp
+++ b/ydb/public/lib/ydb_cli/commands/ydb_service_export.cpp
@@ -5,6 +5,7 @@
 #include <ydb/public/lib/ydb_cli/common/print_operation.h>
 #include <ydb/public/lib/ydb_cli/common/recursive_list.h>
 
+#include <util/generic/is_in.h>
 #include <util/generic/serialized_enum.h>
 #include <util/string/builder.h>
 
@@ -18,8 +19,11 @@ namespace {
     const char slashC = '/';
     const TStringBuf slash(&slashC, 1);
 
-    bool FilterTables(const NScheme::TSchemeEntry& entry) {
-        return entry.Type == NScheme::ESchemeEntryType::Table;
+    bool FilterSupportedSchemeObjects(const NScheme::TSchemeEntry& entry) {
+        return IsIn({
+            NScheme::ESchemeEntryType::Table,
+            NScheme::ESchemeEntryType::View,
+        }, entry.Type);
     }
 
     TVector<std::pair<TString, TString>> ExpandItem(NScheme::TSchemeClient& client, TStringBuf srcPath, TStringBuf dstPath) {
@@ -27,7 +31,7 @@ namespace {
         srcPath.ChopSuffix(slash);
         dstPath.ChopSuffix(slash);
 
-        const auto ret = RecursiveList(client, TString{srcPath}, TRecursiveListSettings().Filter(&FilterTables));
+        const auto ret = RecursiveList(client, TString{srcPath}, TRecursiveListSettings().Filter(&FilterSupportedSchemeObjects));
         NStatusHelpers::ThrowOnErrorOrPrintIssues(ret.Status);
 
         if (ret.Entries.size() == 1 && srcPath == ret.Entries[0].Name) {
@@ -282,7 +286,7 @@ void TCommandExportToS3::Config(TConfig& config) {
             << "    - zstd-N (N is compression level in range [1, 22], e.g. zstd-3)" << Endl)
         .RequiredArgument("STRING").StoreResult(&Compression);
 
-    config.Opts->AddLongOption("use-virtual-addressing", TStringBuilder() 
+    config.Opts->AddLongOption("use-virtual-addressing", TStringBuilder()
             << "Sets bucket URL style. Value "
             << colors.BoldColor() << "true" << colors.OldColor()
             << " means use Virtual-Hosted-Style URL, "

--- a/ydb/public/lib/ydb_cli/commands/ydb_service_import.cpp
+++ b/ydb/public/lib/ydb_cli/commands/ydb_service_import.cpp
@@ -94,7 +94,7 @@ void TCommandImportFromS3::Config(TConfig& config) {
     config.Opts->AddLongOption("retries", "Number of retries")
         .RequiredArgument("NUM").StoreResult(&NumberOfRetries).DefaultValue(NumberOfRetries);
 
-    config.Opts->AddLongOption("use-virtual-addressing", TStringBuilder() 
+    config.Opts->AddLongOption("use-virtual-addressing", TStringBuilder()
             << "Sets bucket URL style. Value "
             << colors.BoldColor() << "true" << colors.OldColor()
             << " means use Virtual-Hosted-Style URL, "
@@ -173,7 +173,9 @@ int TCommandImportFromS3::Run(TConfig& config) {
                 auto listResult = s3Client->ListObjectKeys(item.Source, token);
                 token = listResult.NextToken;
                 for (TStringBuf key : listResult.Keys) {
-                    if (key.ChopSuffix(NDump::NFiles::TableScheme().FileName)) {
+                    if (key.ChopSuffix(NDump::NFiles::TableScheme().FileName)
+                        || key.ChopSuffix(NDump::NFiles::CreateView().FileName)
+                    ) {
                         TString destination = item.Destination + key.substr(item.Source.size());
                         settings.AppendItem({TString(key), std::move(destination)});
                     }


### PR DESCRIPTION
### Ticket
- https://github.com/ydb-platform/ydb/issues/13995

### Summary
- Enable view exports and imports in YDB CLI.
- Retry exports limiting the scope to tables only on the CLI side if the first response has the BAD_REQUEST status. This workaround allows us to release YDB CLI separately from the YDB server code. Newer YDB CLI would not fail exports if the YDB server version does not support view exports.

### Changelog entry <!-- a user-readable short description of changes introduced in this PR -->

### Changelog category <!-- remove all except one -->

* Not for changelog (changelog entry is not required)

### Additional information

- https://github.com/ydb-platform/ydb/issues/12724
