### PR TITLE
Feature flag EnableStrictAclCheck

### DIFF
--- a/ydb/core/protos/feature_flags.proto
+++ b/ydb/core/protos/feature_flags.proto
@@ -188,4 +188,5 @@ message TFeatureFlags {
     optional bool EnableTopicTransfer = 163 [default = false];
     optional bool EnableViewExport = 164 [default = false];
     optional bool EnableColumnStore = 165 [default = false];
+    optional bool EnableStrictAclCheck = 166 [default = false];
 }

--- a/ydb/core/tx/schemeshard/schemeshard__operation_alter_login.cpp
+++ b/ydb/core/tx/schemeshard/schemeshard__operation_alter_login.cpp
@@ -288,6 +288,10 @@ public:
     }
 
     NLogin::TLoginProvider::TBasicResponse CanRemoveSid(TOperationContext& context, const TString sid, const TString& sidType) {
+        if (!AppData()->FeatureFlags.GetEnableStrictAclCheck()) {
+            return {}; 
+        }
+
         auto subTree = context.SS->ListSubTree(context.SS->RootPathId(), context.Ctx);
         for (auto pathId : subTree) {
             TPathElement::TPtr path = context.SS->PathsById.at(pathId);

--- a/ydb/core/tx/schemeshard/schemeshard__operation_modify_acl.cpp
+++ b/ydb/core/tx/schemeshard/schemeshard__operation_modify_acl.cpp
@@ -56,7 +56,7 @@ public:
             return result;
         }
 
-        if (acl) {
+        if (acl && AppData()->FeatureFlags.GetEnableStrictAclCheck()) {
             NACLib::TDiffACL diffACL(acl);
             for (const NACLibProto::TDiffACE& diffACE : diffACL.GetDiffACE()) {
                 if (static_cast<NACLib::EDiffType>(diffACE.GetDiffType()) == NACLib::EDiffType::Add) {
@@ -68,7 +68,7 @@ public:
                 } // remove diff type is allowed in any case
             }
         }
-        if (owner) {
+        if (owner && AppData()->FeatureFlags.GetEnableStrictAclCheck()) {
             if (!CheckSidExistsOrIsNonYdb(context.SS->LoginProvider.Sids, owner)) {
                 result->SetError(NKikimrScheme::StatusPreconditionFailed,
                     TStringBuilder() << "Owner SID " << owner << " not found");

--- a/ydb/core/tx/schemeshard/ut_helpers/test_env.cpp
+++ b/ydb/core/tx/schemeshard/ut_helpers/test_env.cpp
@@ -587,6 +587,7 @@ NSchemeShardUT_Private::TTestEnv::TTestEnv(TTestActorRuntime& runtime, const TTe
     app.FeatureFlags.SetEnableTableDatetime64(true);
     app.FeatureFlags.SetEnableVectorIndex(true);
     app.FeatureFlags.SetEnableColumnStore(true);
+    app.FeatureFlags.SetEnableStrictAclCheck(opts.EnableStrictAclCheck_);    
     app.SetEnableMoveIndex(opts.EnableMoveIndex_);
     app.SetEnableChangefeedInitialScan(opts.EnableChangefeedInitialScan_);
     app.SetEnableNotNullDataColumns(opts.EnableNotNullDataColumns_);

--- a/ydb/core/tx/schemeshard/ut_helpers/test_env.h
+++ b/ydb/core/tx/schemeshard/ut_helpers/test_env.h
@@ -72,6 +72,7 @@ namespace NSchemeShardUT_Private {
         OPTION(std::optional<bool>, EnableBackupService, std::nullopt);
         OPTION(std::optional<bool>, EnableTopicTransfer, std::nullopt);
         OPTION(bool, SetupKqpProxy, false);
+        OPTION(bool, EnableStrictAclCheck, false);
 
         #undef OPTION
     };


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of changes introduced in this PR -->

Feature flag `EnableStrictAclCheck` turn on strict ACL checks:
* `GRANT` or `REVOKE`  requires the existence of a subject.
* `DROP` requires that a subject does not have ACLs.

### Changelog category <!-- remove all except one -->

* Experimental feature

### Additional information

...
