### PR TITLE
24-4: Set EnableDataShardVolatileTransactions = true by default

### DIFF
--- a/ydb/core/protos/feature_flags.proto
+++ b/ydb/core/protos/feature_flags.proto
@@ -97,7 +97,7 @@ message TFeatureFlags {
     optional bool EnableAlterDatabaseCreateHiveFirst = 82 [default = false];
     reserved 83; // EnableKqpDataQuerySourceRead
     optional bool EnableSmallDiskOptimization = 84 [default = true];
-    optional bool EnableDataShardVolatileTransactions = 85 [default = false];
+    optional bool EnableDataShardVolatileTransactions = 85 [default = true];
     optional bool EnableTopicServiceTx = 86 [default = true];
     optional bool EnableLLVMCache = 87 [default = false];
     optional bool EnableExternalDataSources = 88 [default = false];


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of changes introduced in this PR -->

New volatile distributed transaction protocol enabled by default for OLTP tables.

### Changelog category <!-- remove all except one -->

* New feature

### Additional information

Volatile transactions improve latency and throughput in certain workloads.