### PR TITLE
feature flags: enable EnableAlterDatabaseCreateHiveFirst

### DIFF
--- a/ydb/core/protos/feature_flags.proto
+++ b/ydb/core/protos/feature_flags.proto
@@ -104,7 +104,7 @@ message TFeatureFlags {
     optional bool EnableDataShardGenericReadSets = 81 [default = false];
     // enable alter database operation to create subdomain's system tablets
     // directly in subdomain's hive
-    optional bool EnableAlterDatabaseCreateHiveFirst = 82 [default = false];
+    optional bool EnableAlterDatabaseCreateHiveFirst = 82 [default = true];
     reserved 83; // EnableKqpDataQuerySourceRead
     optional bool EnableSmallDiskOptimization = 84 [default = true];
     optional bool EnableDataShardVolatileTransactions = 85 [default = true];

--- a/ydb/core/tx/schemeshard/ut_serverless/ya.make
+++ b/ydb/core/tx/schemeshard/ut_serverless/ya.make
@@ -4,6 +4,8 @@ FORK_SUBTESTS()
 
 SIZE(MEDIUM)
 
+TIMEOUT(120)
+
 PEERDIR(
     library/cpp/getopt
     library/cpp/regex/pcre


### PR DESCRIPTION
This is a long awaited improvement in the dedicated database creation process.

`enable_alter_database_create_hive_first` (`EnableAlterDatabaseCreateHiveFirst`) feature flag affects how system tablets of the dedicated database are created (and than managed throughout their lifetime). System tablets (schemeshard, hive, coordinators/mediators, sysview-processor etc) are those that constitute and service the database itself.

Without `EnableAlterDatabaseCreateHiveFirst`, creation of the new dedicated database leaves all it's system tablets in the custody of the main ("root") Hive of the cluster (all other tablets created afterwards live in the custody of the tenant hive). Databases with that separation of responsibilities are working just fine. The downside is that complete lack of common vision and coordination between two hives (root and the tenant's) can lead to suboptimal results when database' tablets (both system and others) are balanced under the load. 

With `EnableAlterDatabaseCreateHiveFirst`, creation of the new dedicated database leaves all tenant tablets (except tenant hive) in the custody of the tenant hive. Which alleviates problem with tablet balancing.

### Changelog category

* Not for changelog