### PR TITLE
Fix BS_QUEUE death

### DIFF
--- a/ydb/core/blobstorage/backpressure/queue_backpressure_client.cpp
+++ b/ydb/core/blobstorage/backpressure/queue_backpressure_client.cpp
@@ -462,9 +462,7 @@ private:
                 QLOG_INFO_S("BSQ96", "connection lost status# " << NKikimrProto::EReplyStatus_Name(status)
                     << " errorReason# " << errorReason << " timeout# " << timeout);
                 ctx.Send(BlobStorageProxy, new TEvProxyQueueState(VDiskId, QueueId, false, false, nullptr));
-                Queue.DrainQueue(status, TStringBuilder() << "BS_QUEUE: " << errorReason, ctx);
-                DrainStatus(status, ctx);
-                DrainAssimilate(status, errorReason, ctx);
+                Drain(ctx, status, errorReason);
                 break;
         }
         State = EState::INITIAL;
@@ -474,6 +472,12 @@ private:
         } else {
             RequestReadiness(nullptr, ctx);
         }
+    }
+
+    void Drain(const TActorContext& ctx, NKikimrProto::EReplyStatus status, const TString& errorReason) {
+        Queue.DrainQueue(status, TStringBuilder() << "BS_QUEUE: " << errorReason, ctx);
+        DrainStatus(status, ctx);
+        DrainAssimilate(status, errorReason, ctx);
     }
 
     void HandleConnected(TEvInterconnect::TEvNodeConnected::TPtr ev, const TActorContext& ctx) {
@@ -791,6 +795,7 @@ private:
             RegisterActorInUniversalScheduler(SelfId(), nullptr, ctx.ExecutorThread.ActorSystem);
         }
         Unsubscribe(RemoteVDisk.NodeId(), ctx);
+        Drain(ctx, NKikimrProto::ERROR, "BS_QUEUE terminated");
         return TActor::Die(ctx);
     }
 


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of changes introduced in this PR -->

Fix BS\_QUEUE death

### Changelog category <!-- remove all except one -->

* Not for changelog (changelog entry is not required)

### Additional information

When BS\_QUEUE got terminated before this fix, it did not finish any inflight requests. This would lead to VDisk window leak.
