### PR TITLE
topic: preliminary refactoring in the restore tool code

### DIFF
--- a/ydb/public/sdk/cpp/include/ydb-cpp-sdk/client/topic/control_plane.h
+++ b/ydb/public/sdk/cpp/include/ydb-cpp-sdk/client/topic/control_plane.h
@@ -19,7 +19,7 @@ namespace NYdb::inline V3 {
 }
 
 namespace NYdb::inline V3::NTopic {
-    
+
 enum class EMeteringMode : uint32_t {
     Unspecified = 0,
     ReservedCapacity = 1,
@@ -187,6 +187,8 @@ public:
         , DownUtilizationPercent_(downUtilizationPercent)
         , UpUtilizationPercent_(upUtilizationPercent) {}
 
+    void SerializeTo(Ydb::Topic::AutoPartitioningSettings& proto) const;
+
     EAutoPartitioningStrategy GetStrategy() const;
     TDuration GetStabilizationWindow() const;
     ui32 GetDownUtilizationPercent() const;
@@ -227,6 +229,8 @@ public:
         , AutoPartitioningSettings_(autoPartitioning)
     {
     }
+
+    void SerializeTo(Ydb::Topic::PartitioningSettings& proto) const;
 
     uint64_t GetMinActivePartitions() const;
     uint64_t GetMaxActivePartitions() const;
@@ -437,8 +441,11 @@ struct TConsumerSettings {
 
     using TAttributes = std::map<std::string, std::string>;
 
-    TConsumerSettings(TSettings& parent): Parent_(parent) {}
+    TConsumerSettings(TSettings& parent) : Parent_(parent) {}
     TConsumerSettings(TSettings& parent, const std::string& name) : ConsumerName_(name), Parent_(parent) {}
+    TConsumerSettings(TSettings& parent, const Ydb::Topic::Consumer& proto);
+
+    void SerializeTo(Ydb::Topic::Consumer& proto) const;
 
     FLUENT_SETTING(std::string, ConsumerName);
     FLUENT_SETTING_DEFAULT(bool, Important, false);
@@ -525,6 +532,11 @@ struct TCreateTopicSettings : public TOperationRequestSettings<TCreateTopicSetti
 
     using TSelf = TCreateTopicSettings;
     using TAttributes = std::map<std::string, std::string>;
+
+    TCreateTopicSettings() = default;
+    TCreateTopicSettings(const Ydb::Topic::CreateTopicRequest& proto);
+
+    void SerializeTo(Ydb::Topic::CreateTopicRequest& proto) const;
 
     FLUENT_SETTING(TPartitioningSettings, PartitioningSettings);
 

--- a/ydb/public/sdk/cpp/src/client/topic/impl/topic.cpp
+++ b/ydb/public/sdk/cpp/src/client/topic/impl/topic.cpp
@@ -227,6 +227,13 @@ TPartitioningSettings::TPartitioningSettings(const Ydb::Topic::PartitioningSetti
     , AutoPartitioningSettings_(settings.auto_partitioning_settings())
 {}
 
+void TPartitioningSettings::SerializeTo(Ydb::Topic::PartitioningSettings& proto) const {
+    proto.set_min_active_partitions(MinActivePartitions_);
+    proto.set_max_active_partitions(MaxActivePartitions_);
+    proto.set_partition_count_limit(PartitionCountLimit_);
+    AutoPartitioningSettings_.SerializeTo(*proto.mutable_auto_partitioning_settings());
+}
+
 uint64_t TPartitioningSettings::GetMinActivePartitions() const {
     return MinActivePartitions_;
 }
@@ -249,6 +256,14 @@ TAutoPartitioningSettings::TAutoPartitioningSettings(const Ydb::Topic::AutoParti
     , DownUtilizationPercent_(settings.partition_write_speed().down_utilization_percent())
     , UpUtilizationPercent_(settings.partition_write_speed().up_utilization_percent())
 {}
+
+void TAutoPartitioningSettings::SerializeTo(Ydb::Topic::AutoPartitioningSettings& proto) const {
+    proto.set_strategy(static_cast<Ydb::Topic::AutoPartitioningStrategy>(Strategy_));
+    auto& writeSpeed = *proto.mutable_partition_write_speed();
+    writeSpeed.mutable_stabilization_window()->set_seconds(StabilizationWindow_.Seconds());
+    writeSpeed.set_down_utilization_percent(DownUtilizationPercent_);
+    writeSpeed.set_up_utilization_percent(UpUtilizationPercent_);
+}
 
 EAutoPartitioningStrategy TAutoPartitioningSettings::GetStrategy() const {
     return Strategy_;
@@ -533,6 +548,111 @@ std::shared_ptr<IWriteSession> TTopicClient::CreateWriteSession(const TWriteSess
 TAsyncStatus TTopicClient::CommitOffset(const std::string& path, uint64_t partitionId, const std::string& consumerName, uint64_t offset,
     const TCommitOffsetSettings& settings) {
     return Impl_->CommitOffset(path, partitionId, consumerName, offset, settings);
+}
+
+namespace {
+
+Ydb::Topic::SupportedCodecs SerializeCodecs(const std::vector<ECodec>& codecs) {
+    Ydb::Topic::SupportedCodecs proto;
+    for (ECodec codec : codecs) {
+        proto.add_codecs(static_cast<Ydb::Topic::Codec>(codec));
+    }
+    return proto;
+}
+
+std::vector<ECodec> DeserializeCodecs(const Ydb::Topic::SupportedCodecs& proto) {
+    std::vector<ECodec> codecs;
+    codecs.reserve(proto.codecs_size());
+    for (int codec : proto.codecs()) {
+        codecs.emplace_back(static_cast<ECodec>(codec));
+    }
+    return codecs;
+}
+
+google::protobuf::Map<TProtoStringType, TProtoStringType> SerializeAttributes(const std::map<std::string, std::string>& attributes) {
+    google::protobuf::Map<TProtoStringType, TProtoStringType> proto;
+    for (const auto& [key, value] : attributes) {
+        proto.emplace(key, value);
+    }
+    return proto;
+}
+
+std::map<std::string, std::string> DeserializeAttributes(const google::protobuf::Map<TProtoStringType, TProtoStringType>& proto) {
+    std::map<std::string, std::string> attributes;
+    for (const auto& [key, value] : proto) {
+        attributes.emplace(key, value);
+    }
+    return attributes;
+}
+
+template <typename TSettings>
+google::protobuf::RepeatedPtrField<Ydb::Topic::Consumer> SerializeConsumers(const std::vector<TConsumerSettings<TSettings>>& consumers) {
+    google::protobuf::RepeatedPtrField<Ydb::Topic::Consumer> proto;
+    proto.Reserve(consumers.size());
+    for (const auto& consumer : consumers) {
+        consumer.SerializeTo(*proto.Add());
+    }
+    return proto;
+}
+
+template <typename TSettings>
+std::vector<TConsumerSettings<TSettings>> DeserializeConsumers(TSettings& parent, const google::protobuf::RepeatedPtrField<Ydb::Topic::Consumer>& proto) {
+    std::vector<TConsumerSettings<TSettings>> consumers;
+    consumers.reserve(proto.size());
+    for (const auto& consumer : proto) {
+        consumers.emplace_back(TConsumerSettings<TSettings>(parent, consumer));
+    }
+    return consumers;
+}
+
+}
+
+template <typename TSettings>
+TConsumerSettings<TSettings>::TConsumerSettings(TSettings& parent, const Ydb::Topic::Consumer& proto)
+    : ConsumerName_(proto.name())
+    , Important_(proto.important())
+    , ReadFrom_(TInstant::Seconds(proto.read_from().seconds()))
+    , SupportedCodecs_(DeserializeCodecs(proto.supported_codecs()))
+    , Attributes_(DeserializeAttributes(proto.attributes()))
+    , Parent_(parent)
+{
+}
+
+template <typename TSettings>
+void TConsumerSettings<TSettings>::SerializeTo(Ydb::Topic::Consumer& proto) const {
+    proto.set_name(ConsumerName_);
+    proto.set_important(Important_);
+    proto.mutable_read_from()->set_seconds(ReadFrom_.Seconds());
+    *proto.mutable_supported_codecs() = SerializeCodecs(SupportedCodecs_);
+    *proto.mutable_attributes() = SerializeAttributes(Attributes_);
+}
+
+template class TConsumerSettings<TCreateTopicSettings>;
+template class TConsumerSettings<TAlterTopicSettings>;
+
+TCreateTopicSettings::TCreateTopicSettings(const Ydb::Topic::CreateTopicRequest& proto)
+    : PartitioningSettings_(TPartitioningSettings(proto.partitioning_settings()))
+    , RetentionPeriod_(TDuration::Seconds(proto.retention_period().seconds()))
+    , SupportedCodecs_(DeserializeCodecs(proto.supported_codecs()))
+    , RetentionStorageMb_(proto.retention_storage_mb())
+    , MeteringMode_(TProtoAccessor::FromProto(proto.metering_mode()))
+    , PartitionWriteSpeedBytesPerSecond_(proto.partition_write_speed_bytes_per_second())
+    , PartitionWriteBurstBytes_(proto.partition_write_burst_bytes())
+    , Attributes_(DeserializeAttributes(proto.attributes()))
+{
+    Consumers_ = DeserializeConsumers(*this, proto.consumers());
+}
+
+void TCreateTopicSettings::SerializeTo(Ydb::Topic::CreateTopicRequest& request) const {
+    PartitioningSettings_.SerializeTo(*request.mutable_partitioning_settings());
+    request.mutable_retention_period()->set_seconds(RetentionPeriod_.Seconds());
+    *request.mutable_supported_codecs() = SerializeCodecs(SupportedCodecs_);
+    request.set_retention_storage_mb(RetentionStorageMb_);
+    request.set_metering_mode(TProtoAccessor::GetProto(MeteringMode_));
+    request.set_partition_write_speed_bytes_per_second(PartitionWriteSpeedBytesPerSecond_);
+    request.set_partition_write_burst_bytes(PartitionWriteBurstBytes_);
+    *request.mutable_consumers() = SerializeConsumers(Consumers_);
+    *request.mutable_attributes() = SerializeAttributes(Attributes_);
 }
 
 } // namespace NYdb::NTopic

--- a/ydb/public/sdk/cpp/src/client/topic/impl/topic.cpp
+++ b/ydb/public/sdk/cpp/src/client/topic/impl/topic.cpp
@@ -627,8 +627,8 @@ void TConsumerSettings<TSettings>::SerializeTo(Ydb::Topic::Consumer& proto) cons
     *proto.mutable_attributes() = SerializeAttributes(Attributes_);
 }
 
-template class TConsumerSettings<TCreateTopicSettings>;
-template class TConsumerSettings<TAlterTopicSettings>;
+template struct TConsumerSettings<TCreateTopicSettings>;
+template struct TConsumerSettings<TAlterTopicSettings>;
 
 TCreateTopicSettings::TCreateTopicSettings(const Ydb::Topic::CreateTopicRequest& proto)
     : PartitioningSettings_(TPartitioningSettings(proto.partitioning_settings()))

--- a/ydb/public/sdk/cpp/src/client/topic/impl/topic_impl.h
+++ b/ydb/public/sdk/cpp/src/client/topic/impl/topic_impl.h
@@ -42,20 +42,6 @@ public:
     {
     }
 
-    template <class TSettings>
-    static void ConvertConsumerToProto(const TConsumerSettings<TSettings>& settings, Ydb::Topic::Consumer& consumerProto) {
-        consumerProto.set_name(TStringType{settings.ConsumerName_});
-        consumerProto.set_important(settings.Important_);
-        consumerProto.mutable_read_from()->set_seconds(settings.ReadFrom_.Seconds());
-
-        for (const auto& codec : settings.SupportedCodecs_) {
-            consumerProto.mutable_supported_codecs()->add_codecs((static_cast<Ydb::Topic::Codec>(codec)));
-        }
-        for (auto& pair : settings.Attributes_) {
-            (*consumerProto.mutable_attributes())[pair.first] = pair.second;
-        }
-    }
-
     static void ConvertAlterConsumerToProto(const TAlterConsumerSettings& settings, Ydb::Topic::AlterConsumer& consumerProto) {
         consumerProto.set_name(TStringType{settings.ConsumerName_});
         if (settings.SetImportant_)
@@ -78,34 +64,7 @@ public:
     static Ydb::Topic::CreateTopicRequest MakePropsCreateRequest(const std::string& path, const TCreateTopicSettings& settings) {
         Ydb::Topic::CreateTopicRequest request = MakeOperationRequest<Ydb::Topic::CreateTopicRequest>(settings);
         request.set_path(TStringType{path});
-
-        request.mutable_partitioning_settings()->set_min_active_partitions(settings.PartitioningSettings_.GetMinActivePartitions());
-        request.mutable_partitioning_settings()->set_partition_count_limit(settings.PartitioningSettings_.GetPartitionCountLimit());
-        request.mutable_partitioning_settings()->set_max_active_partitions(settings.PartitioningSettings_.GetMaxActivePartitions());
-        request.mutable_partitioning_settings()->mutable_auto_partitioning_settings()->set_strategy(static_cast<Ydb::Topic::AutoPartitioningStrategy>(settings.PartitioningSettings_.GetAutoPartitioningSettings().GetStrategy()));
-        request.mutable_partitioning_settings()->mutable_auto_partitioning_settings()->mutable_partition_write_speed()->mutable_stabilization_window()->set_seconds(settings.PartitioningSettings_.GetAutoPartitioningSettings().GetStabilizationWindow().Seconds());
-        request.mutable_partitioning_settings()->mutable_auto_partitioning_settings()->mutable_partition_write_speed()->set_up_utilization_percent(settings.PartitioningSettings_.GetAutoPartitioningSettings().GetUpUtilizationPercent());
-        request.mutable_partitioning_settings()->mutable_auto_partitioning_settings()->mutable_partition_write_speed()->set_down_utilization_percent(settings.PartitioningSettings_.GetAutoPartitioningSettings().GetDownUtilizationPercent());
-
-        request.mutable_retention_period()->set_seconds(settings.RetentionPeriod_.Seconds());
-
-        for (const auto& codec : settings.SupportedCodecs_) {
-            request.mutable_supported_codecs()->add_codecs((static_cast<Ydb::Topic::Codec>(codec)));
-        }
-        request.set_partition_write_speed_bytes_per_second(settings.PartitionWriteSpeedBytesPerSecond_);
-        request.set_partition_write_burst_bytes(settings.PartitionWriteBurstBytes_);
-        request.set_retention_storage_mb(settings.RetentionStorageMb_);
-        request.set_metering_mode(TProtoAccessor::GetProto(settings.MeteringMode_));
-
-        for (auto& pair : settings.Attributes_) {
-            (*request.mutable_attributes())[pair.first] = pair.second;
-        }
-
-        for (const auto& consumer : settings.Consumers_) {
-            Ydb::Topic::Consumer& consumerProto = *request.add_consumers();
-            ConvertConsumerToProto(consumer, consumerProto);
-        }
-
+        settings.SerializeTo(request);
         return request;
     }
 
@@ -171,8 +130,7 @@ public:
         }
 
         for (const auto& consumer : settings.AddConsumers_) {
-            Ydb::Topic::Consumer& consumerProto = *request.add_add_consumers();
-            ConvertConsumerToProto(consumer, consumerProto);
+            consumer.SerializeTo(*request.add_add_consumers());
         }
 
         for (const auto& consumer : settings.DropConsumers_) {


### PR DESCRIPTION
Preliminary refactoring so that the future addition of the BackupTopic function would have less diffs with the main branch.

Added SerializeTo and DeserializeFrom (in a form of a constructor) for some of the structures used in topic SDK. This way we would able to call CreateTopic on restore (see in the next PR) with TCreateTopicSettings built from the Ydb::Topic::CreateTopicRequest directly.

### Changelog entry <!-- a user-readable short description of changes introduced in this PR -->

### Changelog category <!-- remove all except one -->

* Not for changelog (changelog entry is not required)

### Additional information

- https://github.com/ydb-platform/ydb/issues/13802
