### PR TITLE
CA: fix inverted condition in TInputChannelInfo::IsPaused

### DIFF
--- a/ydb/library/yql/dq/actors/compute/dq_compute_actor_impl.h
+++ b/ydb/library/yql/dq/actors/compute/dq_compute_actor_impl.h
@@ -834,7 +834,7 @@ protected:
         }
 
         bool IsPaused() const {
-            return PendingWatermarks.empty() || PendingCheckpoint.has_value();
+            return (!PendingWatermarks.empty()) || PendingCheckpoint.has_value();
         }
 
         void Pause(TInstant watermark) {

--- a/ydb/library/yql/dq/actors/compute/dq_compute_actor_impl.h
+++ b/ydb/library/yql/dq/actors/compute/dq_compute_actor_impl.h
@@ -834,7 +834,7 @@ protected:
         }
 
         bool IsPaused() const {
-            return (!PendingWatermarks.empty()) || PendingCheckpoint.has_value();
+            return !PendingWatermarks.empty() || PendingCheckpoint.has_value();
         }
 
         void Pause(TInstant watermark) {


### PR DESCRIPTION
Grave-but-harmless: this function is only used in monitoring page for async CA, and when checkpoint are used in sync CA (this combination is not used anywhere)

### Changelog entry <!-- a user-readable short description of changes introduced in this PR -->

...

### Changelog category <!-- remove all except one -->

* Not for changelog (changelog entry is not required)

### Additional information

...
