### PR TITLE
TOPIC: do not save topic attributes to backups

### DIFF
--- a/ydb/library/backup/backup.cpp
+++ b/ydb/library/backup/backup.cpp
@@ -604,6 +604,7 @@ void BackupTopic(TDriver driver, const TString& dbPath, const TFsPath& fsBackupF
 
     Ydb::Topic::CreateTopicRequest creationRequest;
     topicDescription.SerializeTo(creationRequest);
+    creationRequest.clear_attributes();
 
     WriteProtoToFile(creationRequest, fsBackupFolder, NDump::NFiles::CreateTopic());
     BackupPermissions(driver, dbPath, fsBackupFolder);


### PR DESCRIPTION
## Description

Drop topic attributes when backing it up.

## Story

Attributes must be dropped in order for the topic to be restorable.

I have encountered the following error:
```
2025-01-31T17:45:34.527354Z :ERROR: Creation of the topic: "/Root/dedicated/topic" failed
2025-01-31T17:45:34.527573Z :ERROR: Restore failed: [ { <main>: Info: Path: /Root/dedicated/topic } { <main>: Error: Attribute __max_partition_message_groups_seqno_stored is not supported, code: 500003 } ]
Status: BAD_REQUEST
Issues: 
<main>: Info: Path: /Root/dedicated/topic
<main>: Error: Attribute __max_partition_message_groups_seqno_stored is not supported, code: 500003
```
on attempting to restore a topic that was originally created by:
```
ydb sql --script 'create topic topic'
```

I see only one viable explanation: you cannot specify [attributes](https://github.com/ydb-platform/ydb/blob/21c6640077167db61e0d02346aaf0f1395a5052f/ydb/public/sdk/cpp/include/ydb-cpp-sdk/client/topic/control_plane.h#L543) in the [TCreateTopicSettings](https://github.com/ydb-platform/ydb/blob/21c6640077167db61e0d02346aaf0f1395a5052f/ydb/public/sdk/cpp/include/ydb-cpp-sdk/client/topic/control_plane.h#L524) when creating a topic via [TTopicClient::CreateTopic](https://github.com/ydb-platform/ydb/blob/21c6640077167db61e0d02346aaf0f1395a5052f/ydb/public/sdk/cpp/include/ydb-cpp-sdk/client/topic/client.h#L29).

### Changelog entry <!-- a user-readable short description of changes introduced in this PR -->

### Changelog category <!-- remove all except one -->

* Not for changelog (changelog entry is not required)

### Additional information

- https://github.com/ydb-platform/ydb/issues/13802
