### PR TITLE
use seqno to dedup drain requests from root hive to tenant hive

### DIFF
--- a/ydb/core/mind/hive/drain.cpp
+++ b/ydb/core/mind/hive/drain.cpp
@@ -19,6 +19,7 @@ protected:
     TActorId DomainHivePipeClient;
     TTabletId DomainHiveId = 0;
     ui32 DomainMovements = 0;
+    ui64 SeqNo = 0;
     TDrainSettings Settings;
 
     TString GetLogPrefix() const {
@@ -150,6 +151,7 @@ protected:
         event->Record.SetDownPolicy(Settings.DownPolicy);
         event->Record.SetPersist(Settings.Persist);
         event->Record.SetDrainInFlight(Settings.DrainInFlight);
+        event->Record.SetSeqNo(SeqNo);
         NTabletPipe::SendData(SelfId(), DomainHivePipeClient, event.Release());
         BLOG_I("Drain " << SelfId() << " forwarded for node " << NodeId << " to hive " << DomainHiveId);
     }
@@ -187,6 +189,7 @@ public:
             if (!DownBefore) {
                 nodeInfo->SetDown(true);
             }
+            SeqNo = nodeInfo->DrainSeqNo;
 
             if (nodeInfo->ServicedDomains.size() == 1) {
                 TDomainInfo* domainInfo = Hive->FindDomain(nodeInfo->ServicedDomains.front());

--- a/ydb/core/mind/hive/hive_impl.cpp
+++ b/ydb/core/mind/hive/hive_impl.cpp
@@ -2213,7 +2213,7 @@ void THive::Handle(TEvHive::TEvDrainNode::TPtr& ev) {
         .Persist = ev->Get()->Record.GetPersist(),
         .DownPolicy = policy,
         .DrainInFlight = ev->Get()->Record.GetDrainInFlight(),
-    }, ev->Sender));
+    }, ev->Sender, ev->Get()->Record.GetSeqNo()));
 }
 
 void THive::Handle(TEvHive::TEvFillNode::TPtr& ev) {

--- a/ydb/core/mind/hive/hive_impl.h
+++ b/ydb/core/mind/hive/hive_impl.h
@@ -297,7 +297,7 @@ protected:
     ITransaction* CreateReleaseTablets(TEvHive::TEvReleaseTablets::TPtr event);
     ITransaction* CreateReleaseTabletsReply(TEvHive::TEvReleaseTabletsReply::TPtr event);
     ITransaction* CreateConfigureSubdomain(TEvHive::TEvConfigureHive::TPtr event);
-    ITransaction* CreateSwitchDrainOn(TNodeId nodeId, TDrainSettings settings, const TActorId& initiator);
+    ITransaction* CreateSwitchDrainOn(TNodeId nodeId, TDrainSettings settings, const TActorId& initiator, ui64 seqNo = 0);
     ITransaction* CreateSwitchDrainOff(TNodeId nodeId, TDrainSettings settings, NKikimrProto::EReplyStatus status, ui32 movements);
     ITransaction* CreateTabletOwnersReply(TEvHive::TEvTabletOwnersReply::TPtr event);
     ITransaction* CreateRequestTabletOwners(TEvHive::TEvRequestTabletOwners::TPtr event);

--- a/ydb/core/mind/hive/hive_schema.h
+++ b/ydb/core/mind/hive/hive_schema.h
@@ -196,9 +196,10 @@ struct Schema : NIceDb::Schema {
         struct Location : Column<9, NScheme::NTypeIds::String> { using Type = NActorsInterconnect::TNodeLocation; };
         struct Name : Column<10, NScheme::NTypeIds::String> {};
         struct BecomeUpOnRestart : Column<11, NScheme::NTypeIds::Bool> {};
+        struct DrainSeqNo : Column<12, NScheme::NTypeIds::Uint64> { static constexpr bool Default = 0; };
 
         using TKey = TableKey<ID>;
-        using TColumns = TableColumns<ID, Local, Down, Freeze, ServicedDomains, Statistics, Drain, DrainInitiators, Location, Name, BecomeUpOnRestart>;
+        using TColumns = TableColumns<ID, Local, Down, Freeze, ServicedDomains, Statistics, Drain, DrainInitiators, Location, Name, BecomeUpOnRestart, DrainSeqNo>;
     };
 
     struct TabletCategory : Table<6> {

--- a/ydb/core/mind/hive/node_info.h
+++ b/ydb/core/mind/hive/node_info.h
@@ -91,6 +91,7 @@ public:
     NKikimrHive::TNodeStatistics Statistics;
     bool DeletionScheduled = false;
     TString Name;
+    ui64 DrainSeqNo;
 
     TNodeInfo(TNodeId nodeId, THive& hive);
     TNodeInfo(const TNodeInfo&) = delete;

--- a/ydb/core/mind/hive/tx__load_everything.cpp
+++ b/ydb/core/mind/hive/tx__load_everything.cpp
@@ -332,6 +332,7 @@ public:
                         node.LocationAcquired = true;
                     }
                 }
+                node.DrainSeqNo = nodeRowset.GetValueOrDefault<Schema::Node::DrainSeqNo>();
                 if (!node.ServicedDomains) {
                     node.ServicedDomains = { Self->RootDomainKey };
                 }

--- a/ydb/core/mind/hive/tx__switch_drain.cpp
+++ b/ydb/core/mind/hive/tx__switch_drain.cpp
@@ -9,12 +9,15 @@ class TTxSwitchDrainOn : public TTransactionBase<THive> {
     TDrainSettings Settings;
     TActorId Initiator;
     NKikimrProto::EReplyStatus Status = NKikimrProto::UNKNOWN;
+    ui64 SeqNo;
+    bool ShouldStartDrain = true;
 public:
-    TTxSwitchDrainOn(TNodeId nodeId, TDrainSettings settings, const TActorId& initiator, THive* hive)
+    TTxSwitchDrainOn(TNodeId nodeId, TDrainSettings settings, const TActorId& initiator, ui64 seqNo, THive* hive)
         : TBase(hive)
         , NodeId(nodeId)
         , Settings(std::move(settings))
         , Initiator(initiator)
+        , SeqNo(seqNo)
     {}
 
     bool Execute(TTransactionContext& txc, const TActorContext&) override {
@@ -23,14 +26,22 @@ public:
         NIceDb::TNiceDb db(txc.DB);
         TNodeInfo* node = Self->FindNode(NodeId);
         if (node != nullptr) {
-            if (!(node->Drain) && Self->BalancerNodes.count(NodeId) != 0) {
-                Status = NKikimrProto::ALREADY; // another balancer is active on the node
+            if (!(node->Drain) && (Self->BalancerNodes.count(NodeId) != 0 || (SeqNo != 0 && SeqNo <= node->DrainSeqNo))) {
+                Status = NKikimrProto::ALREADY;
+                ShouldStartDrain = false;
             } else {
                 Status = NKikimrProto::OK;
+                if (node->Drain) {
+                    ShouldStartDrain = false;
+                }
                 node->Drain = true;
                 node->DrainInitiators.emplace_back(Initiator);
                 if (Settings.Persist) {
-                    db.Table<Schema::Node>().Key(NodeId).Update<Schema::Node::Drain, Schema::Node::DrainInitiators>(node->Drain, node->DrainInitiators);
+                    if (Self->AreWeRootHive()) {
+                        ++node->DrainSeqNo;
+                    }
+                    node->DrainSeqNo = std::max(node->DrainSeqNo, SeqNo);
+                    db.Table<Schema::Node>().Key(NodeId).Update<Schema::Node::Drain, Schema::Node::DrainInitiators, Schema::Node::DrainSeqNo>(node->Drain, node->DrainInitiators, node->DrainSeqNo);
                 }
                 if (Settings.DownPolicy != NKikimrHive::EDrainDownPolicy::DRAIN_POLICY_NO_DOWN) {
                     if (!node->Down && Settings.DownPolicy == NKikimrHive::EDrainDownPolicy::DRAIN_POLICY_KEEP_DOWN_UNTIL_RESTART) {
@@ -44,17 +55,19 @@ public:
                         }
                     }
                 }
-                Self->StartHiveDrain(NodeId, std::move(Settings));
             }
         } else {
             Status = NKikimrProto::ERROR;
+            ShouldStartDrain = false;
         }
         return true;
     }
 
     void Complete(const TActorContext&) override {
         BLOG_D("THive::TTxSwitchDrainOn::Complete NodeId: " << NodeId << " Status: " << Status);
-        if (Status != NKikimrProto::OK) {
+        if (ShouldStartDrain) {
+            Self->StartHiveDrain(NodeId, std::move(Settings));
+        } else {
             if (Initiator) {
                 Self->Send(Initiator, new TEvHive::TEvDrainNodeResult(Status));
             }
@@ -106,8 +119,8 @@ public:
     }
 };
 
-ITransaction* THive::CreateSwitchDrainOn(NHive::TNodeId nodeId, TDrainSettings settings, const TActorId& initiator) {
-    return new TTxSwitchDrainOn(nodeId, std::move(settings), initiator, this);
+ITransaction* THive::CreateSwitchDrainOn(NHive::TNodeId nodeId, TDrainSettings settings, const TActorId& initiator, ui64 seqNo) {
+    return new TTxSwitchDrainOn(nodeId, std::move(settings), initiator, seqNo, this);
 }
 
 ITransaction* THive::CreateSwitchDrainOff(NHive::TNodeId nodeId, TDrainSettings settings, NKikimrProto::EReplyStatus status, ui32 movements) {

--- a/ydb/core/protos/hive.proto
+++ b/ydb/core/protos/hive.proto
@@ -376,6 +376,7 @@ message TEvDrainNode {
     optional bool KeepDown = 4 [default = false]; // deprecated in favor of DownPolicy
     optional uint32 DrainInFlight = 5;
     optional EDrainDownPolicy DownPolicy = 6 [default = DRAIN_POLICY_KEEP_DOWN_UNTIL_RESTART];
+    optional uint64 SeqNo = 7;
 }
 
 message TEvDrainNodeResult {

--- a/ydb/tests/functional/scheme_tests/canondata/tablet_scheme_tests.TestTabletSchemes.test_tablet_schemes_flat_hive_/flat_hive.schema
+++ b/ydb/tests/functional/scheme_tests/canondata/tablet_scheme_tests.TestTabletSchemes.test_tablet_schemes_flat_hive_/flat_hive.schema
@@ -702,6 +702,11 @@
                 "ColumnId": 11,
                 "ColumnName": "BecomeUpOnRestart",
                 "ColumnType": "Bool"
+            },
+            {
+                "ColumnId": 12,
+                "ColumnName": "DrainSeqNo",
+                "ColumnType": "Uint64"
             }
         ],
         "ColumnsDropped": [],
@@ -718,7 +723,8 @@
                     8,
                     9,
                     10,
-                    11
+                    11,
+                    12
                 ],
                 "RoomID": 0,
                 "Codec": 0,


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of changes introduced in this PR -->

Fix a problem where during cluster update node drain was sometimes performed twice, leading to node being marked as down after update

### Changelog category <!-- remove all except one -->

* Improvement
* Bugfix 

### Additional information

...
