### PR TITLE
core/testlib: unify some client operation methods

### DIFF
--- a/ydb/core/testlib/test_client.cpp
+++ b/ydb/core/testlib/test_client.cpp
@@ -1878,6 +1878,10 @@ namespace Tests {
         const NKikimrClient::TResponse &response = dynamic_cast<NMsgBusProxy::TBusResponse *>(reply.Get())->Record;
         return (NMsgBusProxy::EResponseStatus)response.GetStatus();
     }
+    void TClient::TestMkDir(const TString& parent, const TString& name, const TApplyIf& applyIf) {
+        auto status = MkDir(parent, name, applyIf);
+        UNIT_ASSERT_VALUES_EQUAL(status, NMsgBusProxy::EResponseStatus::MSTATUS_OK);
+    }
 
     NMsgBusProxy::EResponseStatus TClient::RmDir(const TString& parent, const TString& name, const TApplyIf& applyIf) {
         NMsgBusProxy::TBusSchemeOperation* request(new NMsgBusProxy::TBusSchemeOperation());
@@ -1892,6 +1896,10 @@ namespace Tests {
         UNIT_ASSERT_VALUES_EQUAL(msgStatus, NBus::MESSAGE_OK);
         const NKikimrClient::TResponse &response = dynamic_cast<NMsgBusProxy::TBusResponse *>(reply.Get())->Record;
         return (NMsgBusProxy::EResponseStatus)response.GetStatus();
+    }
+    void TClient::TestRmDir(const TString& parent, const TString& name, const TApplyIf& applyIf) {
+        auto status = RmDir(parent, name, applyIf);
+        UNIT_ASSERT_VALUES_EQUAL(status, NMsgBusProxy::EResponseStatus::MSTATUS_OK);
     }
 
     NMsgBusProxy::EResponseStatus TClient::CreateSubdomain(const TString &parent, const TString &description) {
@@ -2050,12 +2058,19 @@ namespace Tests {
         NBus::EMessageStatus status = SendAndWaitCompletion(request.Release(), reply);
         UNIT_ASSERT_VALUES_EQUAL(status, NBus::MESSAGE_OK);
         const NKikimrClient::TResponse &response = dynamic_cast<NMsgBusProxy::TBusResponse *>(reply.Get())->Record;
-        UNIT_ASSERT_VALUES_EQUAL_C(response.GetStatus(), NMsgBusProxy::EResponseStatus::MSTATUS_OK, response.GetErrorReason());
         return (NMsgBusProxy::EResponseStatus)response.GetStatus();
+    }
+    void TClient::TestCreateUser(const TString& parent, const TCreateUserOption& options, const TString& userToken) {
+        auto status = CreateUser(parent, options, userToken);
+        UNIT_ASSERT_VALUES_EQUAL(status, NMsgBusProxy::EResponseStatus::MSTATUS_OK);
     }
 
     NMsgBusProxy::EResponseStatus TClient::CreateUser(const TString& parent, const TString& user, const TString& password, const TString& userToken) {
         return CreateUser(parent, {.User = user, .Password = password}, userToken);
+    }
+    void TClient::TestCreateUser(const TString& parent, const TString& user, const TString& password, const TString& userToken) {
+        auto status = CreateUser(parent, user, password, userToken);
+        UNIT_ASSERT_VALUES_EQUAL(status, NMsgBusProxy::EResponseStatus::MSTATUS_OK);
     }
 
     NMsgBusProxy::EResponseStatus TClient::ModifyUser(const TString& parent, const TModifyUserOption& options, const TString& userToken) {
@@ -2083,22 +2098,9 @@ namespace Tests {
         const NKikimrClient::TResponse &response = dynamic_cast<NMsgBusProxy::TBusResponse *>(reply.Get())->Record;
         return (NMsgBusProxy::EResponseStatus)response.GetStatus();
     }
-
-    NKikimrScheme::TEvLoginResult TClient::Login(TTestActorRuntime& runtime, const TString& user, const TString& password) {
-        TActorId sender = runtime.AllocateEdgeActor();
-        TAutoPtr<NSchemeShard::TEvSchemeShard::TEvLogin> evLogin(new NSchemeShard::TEvSchemeShard::TEvLogin());
-        evLogin->Record.SetUser(user);
-        evLogin->Record.SetPassword(password);
-
-        if (auto ldapDomain = runtime.GetAppData().AuthConfig.GetLdapAuthenticationDomain(); user.EndsWith("@" + ldapDomain)) {
-            evLogin->Record.SetExternalAuth(ldapDomain);
-        }
-        const ui64 schemeRoot = GetPatchedSchemeRoot(SchemeRoot, Domain, SupportsRedirect);
-        ForwardToTablet(runtime, schemeRoot, sender, evLogin.Release());
-        TAutoPtr<IEventHandle> handle;
-        auto event = runtime.GrabEdgeEvent<NSchemeShard::TEvSchemeShard::TEvLoginResult>(handle);
-        UNIT_ASSERT(event);
-        return event->Record;
+    void TClient::TestModifyUser(const TString& parent, const TModifyUserOption& options, const TString& userToken) {
+        auto status = ModifyUser(parent, options, userToken);
+        UNIT_ASSERT_VALUES_EQUAL(status, NMsgBusProxy::EResponseStatus::MSTATUS_OK);
     }
 
     NMsgBusProxy::EResponseStatus TClient::CreateGroup(const TString& parent, const TString& group) {
@@ -2116,6 +2118,10 @@ namespace Tests {
         const NKikimrClient::TResponse &response = dynamic_cast<NMsgBusProxy::TBusResponse *>(reply.Get())->Record;
         return (NMsgBusProxy::EResponseStatus)response.GetStatus();
     }
+    void TClient::TestCreateGroup(const TString& parent, const TString& group) {
+        auto status = CreateGroup(parent, group);
+        UNIT_ASSERT_VALUES_EQUAL(status, NMsgBusProxy::EResponseStatus::MSTATUS_OK);
+    }
 
     NMsgBusProxy::EResponseStatus TClient::AddGroupMembership(const TString& parent, const TString& group, const TString& member) {
         TAutoPtr<NMsgBusProxy::TBusSchemeOperation> request(new NMsgBusProxy::TBusSchemeOperation());
@@ -2132,6 +2138,27 @@ namespace Tests {
         UNIT_ASSERT_VALUES_EQUAL(status, NBus::MESSAGE_OK);
         const NKikimrClient::TResponse &response = dynamic_cast<NMsgBusProxy::TBusResponse *>(reply.Get())->Record;
         return (NMsgBusProxy::EResponseStatus)response.GetStatus();
+    }
+    void TClient::TestAddGroupMembership(const TString& parent, const TString& group, const TString& member) {
+        auto status = AddGroupMembership(parent, group, member);
+        UNIT_ASSERT_VALUES_EQUAL(status, NMsgBusProxy::EResponseStatus::MSTATUS_OK);
+    }
+
+    NKikimrScheme::TEvLoginResult TClient::Login(TTestActorRuntime& runtime, const TString& user, const TString& password) {
+        TActorId sender = runtime.AllocateEdgeActor();
+        TAutoPtr<NSchemeShard::TEvSchemeShard::TEvLogin> evLogin(new NSchemeShard::TEvSchemeShard::TEvLogin());
+        evLogin->Record.SetUser(user);
+        evLogin->Record.SetPassword(password);
+
+        if (auto ldapDomain = runtime.GetAppData().AuthConfig.GetLdapAuthenticationDomain(); user.EndsWith("@" + ldapDomain)) {
+            evLogin->Record.SetExternalAuth(ldapDomain);
+        }
+        const ui64 schemeRoot = GetPatchedSchemeRoot(SchemeRoot, Domain, SupportsRedirect);
+        ForwardToTablet(runtime, schemeRoot, sender, evLogin.Release());
+        TAutoPtr<IEventHandle> handle;
+        auto event = runtime.GrabEdgeEvent<NSchemeShard::TEvSchemeShard::TEvLoginResult>(handle);
+        UNIT_ASSERT(event);
+        return event->Record;
     }
 
     NMsgBusProxy::EResponseStatus TClient::CreateTable(const TString& parent, const NKikimrSchemeOp::TTableDescription &table, TDuration timeout) {
@@ -2512,7 +2539,7 @@ namespace Tests {
         Y_ABORT_UNLESS(ev);
     }
 
-    void TClient::ModifyOwner(const TString& parent, const TString& name, const TString& owner) {
+    NMsgBusProxy::EResponseStatus TClient::ModifyOwner(const TString& parent, const TString& name, const TString& owner) {
         TAutoPtr<NMsgBusProxy::TBusSchemeOperation> request(new NMsgBusProxy::TBusSchemeOperation());
         auto *op = request->Record.MutableTransaction()->MutableModifyScheme();
         op->SetOperationType(NKikimrSchemeOp::EOperationType::ESchemeOpModifyACL);
@@ -2522,9 +2549,15 @@ namespace Tests {
         TAutoPtr<NBus::TBusMessage> reply;
         NBus::EMessageStatus status = SendAndWaitCompletion(request.Release(), reply);
         UNIT_ASSERT_VALUES_EQUAL(status, NBus::MESSAGE_OK);
+        const NKikimrClient::TResponse &response = dynamic_cast<NMsgBusProxy::TBusResponse *>(reply.Get())->Record;
+        return (NMsgBusProxy::EResponseStatus)response.GetStatus();
+    }
+    void TClient::TestModifyOwner(const TString& parent, const TString& name, const TString& owner) {
+        auto status = ModifyOwner(parent, name, owner);
+        UNIT_ASSERT_VALUES_EQUAL(status, NMsgBusProxy::EResponseStatus::MSTATUS_OK);
     }
 
-    void TClient::ModifyACL(const TString& parent, const TString& name, const TString& acl) {
+    NMsgBusProxy::EResponseStatus TClient::ModifyACL(const TString& parent, const TString& name, const TString& acl) {
         TAutoPtr<NMsgBusProxy::TBusSchemeOperation> request(new NMsgBusProxy::TBusSchemeOperation());
         auto *op = request->Record.MutableTransaction()->MutableModifyScheme();
         op->SetOperationType(NKikimrSchemeOp::EOperationType::ESchemeOpModifyACL);
@@ -2534,16 +2567,30 @@ namespace Tests {
         TAutoPtr<NBus::TBusMessage> reply;
         NBus::EMessageStatus status = SendAndWaitCompletion(request.Release(), reply);
         UNIT_ASSERT_VALUES_EQUAL(status, NBus::MESSAGE_OK);
+        const NKikimrClient::TResponse &response = dynamic_cast<NMsgBusProxy::TBusResponse *>(reply.Get())->Record;
+        return (NMsgBusProxy::EResponseStatus)response.GetStatus();
+    }
+    void TClient::TestModifyACL(const TString& parent, const TString& name, const TString& acl) {
+        auto status = ModifyACL(parent, name, acl);
+        UNIT_ASSERT_VALUES_EQUAL(status, NMsgBusProxy::EResponseStatus::MSTATUS_OK);
     }
 
-    void TClient::Grant(const TString& parent, const TString& name, const TString& subject, NACLib::EAccessRights rights) {
+    NMsgBusProxy::EResponseStatus TClient::Grant(const TString& parent, const TString& name, const TString& subject, NACLib::EAccessRights rights) {
         NACLib::TDiffACL acl;
         acl.AddAccess(NACLib::EAccessType::Allow, rights, subject);
-        ModifyACL(parent, name, acl.SerializeAsString());
+        return ModifyACL(parent, name, acl.SerializeAsString());
+    }
+    void TClient::TestGrant(const TString& parent, const TString& name, const TString& subject, NACLib::EAccessRights rights) {
+        auto status = Grant(parent, name, subject, rights);
+        UNIT_ASSERT_VALUES_EQUAL(status, NMsgBusProxy::EResponseStatus::MSTATUS_OK);
     }
 
-    void TClient::GrantConnect(const TString& subject) {
-        Grant("/", DomainName, subject, NACLib::EAccessRights::ConnectDatabase);
+    NMsgBusProxy::EResponseStatus TClient::GrantConnect(const TString& subject) {
+        return Grant("/", DomainName, subject, NACLib::EAccessRights::ConnectDatabase);
+    }
+    void TClient::TestGrantConnect(const TString& subject) {
+        auto status = GrantConnect(subject);
+        UNIT_ASSERT_VALUES_EQUAL(status, NMsgBusProxy::EResponseStatus::MSTATUS_OK);
     }
 
     TAutoPtr<NMsgBusProxy::TBusResponse> TClient::HiveCreateTablet(ui32 domainUid, ui64 owner, ui64 owner_index, TTabletTypes::EType tablet_type,

--- a/ydb/core/testlib/test_client.h
+++ b/ydb/core/testlib/test_client.h
@@ -464,9 +464,13 @@ namespace Tests {
         void InitRootScheme(const TString& root);
 
         // Flat DB operations
+        // Plain methods return request status that should be checked.
+        // `Test` prefixed methods check for the success internally.
         NMsgBusProxy::EResponseStatus WaitCreateTx(TTestActorRuntime* runtime, const TString& path, TDuration timeout);
         NMsgBusProxy::EResponseStatus MkDir(const TString& parent, const TString& name, const TApplyIf& applyIf = {});
+        void TestMkDir(const TString& parent, const TString& name, const TApplyIf& applyIf = {});
         NMsgBusProxy::EResponseStatus RmDir(const TString& parent, const TString& name, const TApplyIf& applyIf = {});
+        void TestRmDir(const TString& parent, const TString& name, const TApplyIf& applyIf = {});
         NMsgBusProxy::EResponseStatus CreateSubdomain(const TString &parent, const TString &description);
         NMsgBusProxy::EResponseStatus CreateSubdomain(const TString& parent, const NKikimrSubDomains::TSubDomainSettings &subdomain);
         NMsgBusProxy::EResponseStatus CreateExtSubdomain(const TString &parent, const TString &description);
@@ -478,12 +482,6 @@ namespace Tests {
         NMsgBusProxy::EResponseStatus DeleteSubdomain(const TString& parent, const TString &name);
         NMsgBusProxy::EResponseStatus ForceDeleteSubdomain(const TString& parent, const TString &name);
         NMsgBusProxy::EResponseStatus ForceDeleteUnsafe(const TString& parent, const TString &name);
-        NMsgBusProxy::EResponseStatus CreateUser(const TString& parent, const TCreateUserOption& options, const TString& userToken = "");
-        NMsgBusProxy::EResponseStatus CreateUser(const TString& parent, const TString& user, const TString& password, const TString& userToken = "");
-        NMsgBusProxy::EResponseStatus ModifyUser(const TString& parent, const TModifyUserOption& options, const TString& userToken = "");
-        NKikimrScheme::TEvLoginResult Login(TTestActorRuntime& runtime, const TString& user, const TString& password);
-        NMsgBusProxy::EResponseStatus CreateGroup(const TString& parent, const TString& group);
-        NMsgBusProxy::EResponseStatus AddGroupMembership(const TString& parent, const TString& group, const TString& member);
 
         NMsgBusProxy::EResponseStatus CreateTable(const TString& parent, const TString& scheme, TDuration timeout = TDuration::Seconds(5000));
         NMsgBusProxy::EResponseStatus CreateTable(const TString& parent, const NKikimrSchemeOp::TTableDescription &table, TDuration timeout = TDuration::Seconds(5000));
@@ -533,22 +531,45 @@ namespace Tests {
         ui32 FlatQueryRaw(TTestActorRuntime* runtime, const TString &query, TFlatQueryOptions& opts, NKikimrClient::TResponse& response, int retryCnt = 10);
 
         bool Compile(const TString &mkql, TString &compiled);
-        void SetSecurityToken(const TString& token) { SecurityToken = token; }
-        void ModifyOwner(const TString& parent, const TString& name, const TString& owner);
-        void ModifyACL(const TString& parent, const TString& name, const TString& acl);
         NKikimrScheme::TEvDescribeSchemeResult Describe(TTestActorRuntime* runtime, const TString& path, ui64 tabletId = SchemeRoot);
         TString CreateStoragePool(const TString& poolKind, const TString& partOfName, ui32 groups = 1);
         NKikimrBlobStorage::TDefineStoragePool DescribeStoragePool(const TString& name);
         void RemoveStoragePool(const TString& name);
 
-        void Grant(const TString& parent, const TString& name, const TString& subject, NACLib::EAccessRights rights);
-        void GrantConnect(const TString& subject);
+        void SetSecurityToken(const TString& token) { SecurityToken = token; }
 
+        // User operations
+        NMsgBusProxy::EResponseStatus CreateUser(const TString& parent, const TCreateUserOption& options, const TString& userToken = "");
+        void TestCreateUser(const TString& parent, const TCreateUserOption& options, const TString& userToken = "");
+        NMsgBusProxy::EResponseStatus CreateUser(const TString& parent, const TString& user, const TString& password, const TString& userToken = "");
+        void TestCreateUser(const TString& parent, const TString& user, const TString& password, const TString& userToken = "");
+        NMsgBusProxy::EResponseStatus ModifyUser(const TString& parent, const TModifyUserOption& options, const TString& userToken = "");
+        void TestModifyUser(const TString& parent, const TModifyUserOption& options, const TString& userToken = "");
+        NMsgBusProxy::EResponseStatus DeleteUser(const TString& parent, const TModifyUserOption& options, const TString& userToken = "");
+        void TestDeleteUser(const TString& parent, const TModifyUserOption& options, const TString& userToken = "");
+        NMsgBusProxy::EResponseStatus CreateGroup(const TString& parent, const TString& group);
+        void TestCreateGroup(const TString& parent, const TString& group);
+        NMsgBusProxy::EResponseStatus AddGroupMembership(const TString& parent, const TString& group, const TString& member);
+        void TestAddGroupMembership(const TString& parent, const TString& group, const TString& member);
+        NMsgBusProxy::EResponseStatus DeleteGroup(const TString& parent, const TString& group);
+        void TestDeleteGroup(const TString& parent, const TString& group);
+        NKikimrScheme::TEvLoginResult Login(TTestActorRuntime& runtime, const TString& user, const TString& password);
+
+        // ACL operations
+        NMsgBusProxy::EResponseStatus ModifyOwner(const TString& parent, const TString& name, const TString& owner);
+        void TestModifyOwner(const TString& parent, const TString& name, const TString& owner);
+        NMsgBusProxy::EResponseStatus ModifyACL(const TString& parent, const TString& name, const TString& acl);
+        void TestModifyACL(const TString& parent, const TString& name, const TString& acl);
+
+        NMsgBusProxy::EResponseStatus Grant(const TString& parent, const TString& name, const TString& subject, NACLib::EAccessRights rights);
+        void TestGrant(const TString& parent, const TString& name, const TString& subject, NACLib::EAccessRights rights);
+        NMsgBusProxy::EResponseStatus GrantConnect(const TString& subject);
+        void TestGrantConnect(const TString& subject);
+
+        // Helper functions
         TAutoPtr<NMsgBusProxy::TBusResponse> HiveCreateTablet(ui32 domainUid, ui64 owner, ui64 owner_index, TTabletTypes::EType tablet_type,
                 const TVector<ui32>& allowed_node_ids, const TVector<TSubDomainKey>& allowed_domains = {}, const TChannelsBindings& binding = {});
 
-
-        // Helper functions
         TString SendTabletMonQuery(TTestActorRuntime* runtime, ui64 tabletId, TString query);
         TString MarkNodeInHive(TTestActorRuntime* runtime, ui32 nodeIdx, bool up);
         TString KickNodeInHive(TTestActorRuntime* runtime, ui32 nodeIdx);


### PR DESCRIPTION
Make `NKikimr::Tests::TClient::{CreateUser,ModifyACL,Grant,GrantConnect}()` to behave the same as all other TClient operation methods -- -- return operation status and not assert for it to be a success. Intended use for plain TClient operation methods is to call them and check for the result status in the test body.

Add (some) `Test*()` variants that do additionally check for the success. Those are convenient in test context preparations.

### Changelog category

* Not for changelog
