### PR TITLE
tests: use result checking versions of TCLient MkDir, CreateUser etc

### DIFF
--- a/ydb/core/external_sources/s3/ut/s3_aws_credentials_ut.cpp
+++ b/ydb/core/external_sources/s3/ut/s3_aws_credentials_ut.cpp
@@ -73,7 +73,7 @@ Y_UNIT_TEST_SUITE(S3AwsCredentials) {
         const TString externalDataSourceName = "/Root/external_data_source";
         auto s3ActorsFactory = NYql::NDq::CreateS3ActorsFactory();
         auto kikimr = MakeKikimrRunner(true, nullptr, nullptr, std::nullopt, s3ActorsFactory);
-        kikimr->GetTestClient().GrantConnect("root1@builtin");
+        kikimr->GetTestClient().TestGrantConnect("root1@builtin");
         auto tc = kikimr->GetTableClient();
         auto session = tc.CreateSession().GetValueSync().GetSession();
         const TString query = fmt::format(R"(
@@ -247,10 +247,10 @@ Y_UNIT_TEST_SUITE(S3AwsCredentials) {
                 UNIT_ASSERT(!scriptExecutionOperation.Metadata().ExecutionId.empty());
 
                 NYdb::NQuery::TScriptExecutionOperation readyOp = WaitScriptExecutionOperation(scriptExecutionOperation.Id(), kikimr->GetDriver());
-                UNIT_ASSERT_EQUAL_C(readyOp.Metadata().ExecStatus, EExecStatus::Completed, readyOp.Status().GetIssues().ToString());             
+                UNIT_ASSERT_EQUAL_C(readyOp.Metadata().ExecStatus, EExecStatus::Completed, readyOp.Status().GetIssues().ToString());
             }
         }
-        
+
     }
 
     Y_UNIT_TEST(TestInsertEscaping) {

--- a/ydb/core/http_proxy/ut/datastreams_fixture.h
+++ b/ydb/core/http_proxy/ut/datastreams_fixture.h
@@ -566,9 +566,9 @@ private:
         acl.AddAccess(NACLib::EAccessType::Allow, NACLib::GenericFull, "Service1_id@as");
         acl.AddAccess(NACLib::EAccessType::Allow, NACLib::GenericFull, "proxy_sa@as");
 
-        client.ModifyACL("/", "Root", acl.SerializeAsString());
+        client.TestModifyACL("/", "Root", acl.SerializeAsString());
 
-        client.MkDir("/Root", "SQS");
+        client.TestMkDir("/Root", "SQS");
 
         client.CreateTable("/Root/SQS",
            "Name: \".Queues\""

--- a/ydb/core/kqp/ut/scheme/kqp_scheme_ut.cpp
+++ b/ydb/core/kqp/ut/scheme/kqp_scheme_ut.cpp
@@ -2785,7 +2785,7 @@ Y_UNIT_TEST_SUITE(KqpScheme) {
 
     Y_UNIT_TEST(AlterIndexImplTableUsingPublicAPI) {
         TKikimrRunner kikimr;
-        kikimr.GetTestClient().GrantConnect("user@builtin");
+        kikimr.GetTestClient().TestGrantConnect("user@builtin");
 
         auto adminSession = kikimr.GetTableClient().CreateSession().GetValueSync().GetSession();
         CreateSampleTablesWithIndex(adminSession);

--- a/ydb/core/sys_view/ut_kqp.cpp
+++ b/ydb/core/sys_view/ut_kqp.cpp
@@ -128,21 +128,21 @@ void SetupAuthAccessEnvironment(TTestEnv& env) {
     env.GetClient().SetSecurityToken("root@builtin");
     CreateTenantsAndTables(env, true);
 
-    env.GetClient().CreateUser("/Root", "user1rootadmin", "password1");
-    env.GetClient().CreateUser("/Root", "user2", "password2");
-    env.GetClient().CreateUser("/Root/Tenant1", "user3", "password3");
-    env.GetClient().CreateUser("/Root/Tenant1", "user4", "password4");
+    env.GetClient().TestCreateUser("/Root", "user1rootadmin", "password1");
+    env.GetClient().TestCreateUser("/Root", "user2", "password2");
+    env.GetClient().TestCreateUser("/Root/Tenant1", "user3", "password3");
+    env.GetClient().TestCreateUser("/Root/Tenant1", "user4", "password4");
 
     {
         NACLib::TDiffACL acl;
         acl.AddAccess(NACLib::EAccessType::Allow, NACLib::GenericUse, "user1rootadmin");
         acl.AddAccess(NACLib::EAccessType::Allow, NACLib::GenericUse, "user2");
-        env.GetClient().ModifyACL("", "Root", acl.SerializeAsString());
+        env.GetClient().TestModifyACL("", "Root", acl.SerializeAsString());
     }
 }
 
 void CheckAuthAdministratorAccessIsRequired(TScanQueryPartIterator& it) {
-    NKqp::StreamResultToYson(it, false, EStatus::INTERNAL_ERROR, 
+    NKqp::StreamResultToYson(it, false, EStatus::INTERNAL_ERROR,
         "Administrator access is required");
 }
 
@@ -1446,7 +1446,7 @@ Y_UNIT_TEST_SUITE(SystemView) {
                 SELECT * FROM `Root/Tenant1/Table1` WHERE Key = 1;
             )", TTxControl::BeginTx().CommitTx()).GetValueSync();
             NKqp::AssertSuccessResult(result);
-            
+
             TString actual = FormatResultSetYson(result.GetResultSet(0));
             NKqp::CompareYson(R"([
                 [[1u]]
@@ -1459,12 +1459,12 @@ Y_UNIT_TEST_SUITE(SystemView) {
                 SELECT * FROM `Root/Tenant1/Table1` WHERE Key = 2;
             )", TTxControl::BeginTx(TTxSettings::StaleRO()).CommitTx()).ExtractValueSync();
             NKqp::AssertSuccessResult(result);
-            
+
             TString actual = FormatResultSetYson(result.GetResultSet(0));
             NKqp::CompareYson(R"([
                 [[2u]]
             ])", actual);
-        }        
+        }
 
         size_t rowCount = 0;
         for (size_t iter = 0; iter < 30; ++iter) {
@@ -1476,7 +1476,7 @@ Y_UNIT_TEST_SUITE(SystemView) {
 
         {
             auto result = session.ExecuteDataQuery(R"(
-                SELECT                     
+                SELECT
                     IntervalEnd,
                     Rank,
                     TabletId,
@@ -1579,8 +1579,8 @@ Y_UNIT_TEST_SUITE(SystemView) {
             check.Uint64(0); // IndexSize
             check.Uint64(0); // InFlightTxCount
             check.Uint64Greater(0); // FollowerId
-        }        
-    }    
+        }
+    }
 
     Y_UNIT_TEST(Describe) {
         TTestEnv env;
@@ -2172,14 +2172,14 @@ Y_UNIT_TEST_SUITE(SystemView) {
         SetupAuthEnvironment(env);
         TTableClient client(env.GetDriver());
 
-        env.GetClient().CreateUser("/Root", "user1", "password1");
-        env.GetClient().CreateUser("/Root/Tenant1", "user2", "password2");
-        env.GetClient().CreateUser("/Root/Tenant2", "user3", "password3");
-        env.GetClient().CreateUser("/Root/Tenant2", "user4", "password4");
-        env.GetClient().CreateGroup("/Root", "group1");
-        env.GetClient().CreateGroup("/Root/Tenant1", "group2");
-        env.GetClient().CreateGroup("/Root/Tenant2", "group3");
-        env.GetClient().CreateGroup("/Root/Tenant2", "group4");
+        env.GetClient().TestCreateUser("/Root", "user1", "password1");
+        env.GetClient().TestCreateUser("/Root/Tenant1", "user2", "password2");
+        env.GetClient().TestCreateUser("/Root/Tenant2", "user3", "password3");
+        env.GetClient().TestCreateUser("/Root/Tenant2", "user4", "password4");
+        env.GetClient().TestCreateGroup("/Root", "group1");
+        env.GetClient().TestCreateGroup("/Root/Tenant1", "group2");
+        env.GetClient().TestCreateGroup("/Root/Tenant2", "group3");
+        env.GetClient().TestCreateGroup("/Root/Tenant2", "group4");
 
         // Cerr << env.GetClient().Describe(env.GetServer().GetRuntime(), "/Root").DebugString() << Endl;
 
@@ -2258,7 +2258,7 @@ Y_UNIT_TEST_SUITE(SystemView) {
             ])";
             NKqp::CompareYson(expected, NKqp::StreamResultToYson(it));
         }
-        
+
         { // user1rootadmin is /Root admin
             auto driverConfig = TDriverConfig()
                 .SetEndpoint(env.GetEndpoint())
@@ -2352,7 +2352,7 @@ Y_UNIT_TEST_SUITE(SystemView) {
             "u",
             "asdf",
         }) {
-            env.GetClient().CreateUser("/Root", user, "password");
+            env.GetClient().TestCreateUser("/Root", user, "password");
         }
 
         auto it = client.StreamExecuteScanQuery(R"(
@@ -2387,7 +2387,7 @@ Y_UNIT_TEST_SUITE(SystemView) {
             "user3",
             "user4"
         }) {
-            env.GetClient().CreateUser("/Root", user, "password");
+            env.GetClient().TestCreateUser("/Root", user, "password");
         }
 
         {
@@ -2503,14 +2503,14 @@ Y_UNIT_TEST_SUITE(SystemView) {
         SetupAuthEnvironment(env);
         TTableClient client(env.GetDriver());
 
-        env.GetClient().CreateUser("/Root", "user1", "password1");
-        env.GetClient().CreateUser("/Root/Tenant1", "user2", "password2");
-        env.GetClient().CreateUser("/Root/Tenant2", "user3", "password3");
-        env.GetClient().CreateUser("/Root/Tenant2", "user4", "password4");
-        env.GetClient().CreateGroup("/Root", "group1");
-        env.GetClient().CreateGroup("/Root/Tenant1", "group2");
-        env.GetClient().CreateGroup("/Root/Tenant2", "group3");
-        env.GetClient().CreateGroup("/Root/Tenant2", "group4");
+        env.GetClient().TestCreateUser("/Root", "user1", "password1");
+        env.GetClient().TestCreateUser("/Root/Tenant1", "user2", "password2");
+        env.GetClient().TestCreateUser("/Root/Tenant2", "user3", "password3");
+        env.GetClient().TestCreateUser("/Root/Tenant2", "user4", "password4");
+        env.GetClient().TestCreateGroup("/Root", "group1");
+        env.GetClient().TestCreateGroup("/Root/Tenant1", "group2");
+        env.GetClient().TestCreateGroup("/Root/Tenant2", "group3");
+        env.GetClient().TestCreateGroup("/Root/Tenant2", "group4");
 
         // Cerr << env.GetClient().Describe(env.GetServer().GetRuntime(), "/Root").DebugString() << Endl;
 
@@ -2560,10 +2560,10 @@ Y_UNIT_TEST_SUITE(SystemView) {
         SetupAuthAccessEnvironment(env);
         TTableClient client(env.GetDriver());
 
-        env.GetClient().CreateGroup("/Root", "group1");
-        env.GetClient().CreateGroup("/Root", "group2");
-        env.GetClient().CreateGroup("/Root/Tenant1", "group3");
-        env.GetClient().CreateGroup("/Root/Tenant1", "group4");
+        env.GetClient().TestCreateGroup("/Root", "group1");
+        env.GetClient().TestCreateGroup("/Root", "group2");
+        env.GetClient().TestCreateGroup("/Root/Tenant1", "group3");
+        env.GetClient().TestCreateGroup("/Root/Tenant1", "group4");
 
         { // anonymous login doesn't give administrative access as `AdministrationAllowedSIDs` isn't empty
             auto driverConfig = TDriverConfig()
@@ -2666,7 +2666,7 @@ Y_UNIT_TEST_SUITE(SystemView) {
             "g",
             "asdf",
         }) {
-            env.GetClient().CreateGroup("/Root", group);
+            env.GetClient().TestCreateGroup("/Root", group);
         }
 
         auto it = client.StreamExecuteScanQuery(R"(
@@ -2701,7 +2701,7 @@ Y_UNIT_TEST_SUITE(SystemView) {
             "group3",
             "group4",
         }) {
-            env.GetClient().CreateGroup("/Root", group);
+            env.GetClient().TestCreateGroup("/Root", group);
         }
 
         {
@@ -2725,23 +2725,23 @@ Y_UNIT_TEST_SUITE(SystemView) {
         SetupAuthEnvironment(env);
         TTableClient client(env.GetDriver());
 
-        env.GetClient().CreateUser("/Root", "user1", "password1");
-        env.GetClient().CreateUser("/Root/Tenant1", "user2", "password2");
-        env.GetClient().CreateUser("/Root/Tenant2", "user3", "password3");
-        env.GetClient().CreateUser("/Root/Tenant2", "user4", "password4");
-        env.GetClient().CreateGroup("/Root", "group1");
-        env.GetClient().CreateGroup("/Root/Tenant1", "group2");
-        env.GetClient().CreateGroup("/Root/Tenant2", "group3");
-        env.GetClient().CreateGroup("/Root/Tenant2", "group4");
-        env.GetClient().CreateGroup("/Root/Tenant2", "group5");
+        env.GetClient().TestCreateUser("/Root", "user1", "password1");
+        env.GetClient().TestCreateUser("/Root/Tenant1", "user2", "password2");
+        env.GetClient().TestCreateUser("/Root/Tenant2", "user3", "password3");
+        env.GetClient().TestCreateUser("/Root/Tenant2", "user4", "password4");
+        env.GetClient().TestCreateGroup("/Root", "group1");
+        env.GetClient().TestCreateGroup("/Root/Tenant1", "group2");
+        env.GetClient().TestCreateGroup("/Root/Tenant2", "group3");
+        env.GetClient().TestCreateGroup("/Root/Tenant2", "group4");
+        env.GetClient().TestCreateGroup("/Root/Tenant2", "group5");
 
-        env.GetClient().AddGroupMembership("/Root", "group1", "user1");
-        env.GetClient().AddGroupMembership("/Root/Tenant1", "group2", "user2");
-        env.GetClient().AddGroupMembership("/Root/Tenant2", "group3", "user4");
-        env.GetClient().AddGroupMembership("/Root/Tenant2", "group4", "user3");
-        env.GetClient().AddGroupMembership("/Root/Tenant2", "group4", "user4");
-        env.GetClient().AddGroupMembership("/Root/Tenant2", "group4", "group3");
-        env.GetClient().AddGroupMembership("/Root/Tenant2", "group4", "group4");
+        env.GetClient().TestAddGroupMembership("/Root", "group1", "user1");
+        env.GetClient().TestAddGroupMembership("/Root/Tenant1", "group2", "user2");
+        env.GetClient().TestAddGroupMembership("/Root/Tenant2", "group3", "user4");
+        env.GetClient().TestAddGroupMembership("/Root/Tenant2", "group4", "user3");
+        env.GetClient().TestAddGroupMembership("/Root/Tenant2", "group4", "user4");
+        env.GetClient().TestAddGroupMembership("/Root/Tenant2", "group4", "group3");
+        env.GetClient().TestAddGroupMembership("/Root/Tenant2", "group4", "group4");
 
         // Cerr << env.GetClient().Describe(env.GetServer().GetRuntime(), "/Root").DebugString() << Endl;
         // Cerr << env.GetClient().Describe(env.GetServer().GetRuntime(), "/Root/Tenant2").DebugString() << Endl;
@@ -2795,15 +2795,15 @@ Y_UNIT_TEST_SUITE(SystemView) {
         SetupAuthAccessEnvironment(env);
         TTableClient client(env.GetDriver());
 
-        env.GetClient().CreateGroup("/Root", "group1");
-        env.GetClient().CreateGroup("/Root", "group2");
-        env.GetClient().CreateGroup("/Root/Tenant1", "group3");
-        env.GetClient().CreateGroup("/Root/Tenant1", "group4");
+        env.GetClient().TestCreateGroup("/Root", "group1");
+        env.GetClient().TestCreateGroup("/Root", "group2");
+        env.GetClient().TestCreateGroup("/Root/Tenant1", "group3");
+        env.GetClient().TestCreateGroup("/Root/Tenant1", "group4");
 
-        env.GetClient().AddGroupMembership("/Root", "group1", "user1rootadmin");
-        env.GetClient().AddGroupMembership("/Root", "group2", "user2");
-        env.GetClient().AddGroupMembership("/Root/Tenant1", "group3", "user3");
-        env.GetClient().AddGroupMembership("/Root/Tenant1", "group4", "user4");
+        env.GetClient().TestAddGroupMembership("/Root", "group1", "user1rootadmin");
+        env.GetClient().TestAddGroupMembership("/Root", "group2", "user2");
+        env.GetClient().TestAddGroupMembership("/Root/Tenant1", "group3", "user3");
+        env.GetClient().TestAddGroupMembership("/Root/Tenant1", "group4", "user4");
 
         { // anonymous login doesn't give administrative access as `AdministrationAllowedSIDs` isn't empty
             auto driverConfig = TDriverConfig()
@@ -2900,7 +2900,7 @@ Y_UNIT_TEST_SUITE(SystemView) {
             "group2",
             "group",
         }) {
-            env.GetClient().CreateGroup("/Root", group);
+            env.GetClient().TestCreateGroup("/Root", group);
         }
 
         for (auto user : {
@@ -2908,7 +2908,7 @@ Y_UNIT_TEST_SUITE(SystemView) {
             "user2",
             "user"
         }) {
-            env.GetClient().CreateUser("/Root", user, "password");
+            env.GetClient().TestCreateUser("/Root", user, "password");
         }
 
         for (auto membership : TVector<std::pair<TString, TString>>{
@@ -2919,9 +2919,9 @@ Y_UNIT_TEST_SUITE(SystemView) {
             {"group2", "user2"},
             {"group", "user2"},
         }) {
-            env.GetClient().AddGroupMembership("/Root", membership.first, membership.second);
+            env.GetClient().TestAddGroupMembership("/Root", membership.first, membership.second);
         }
-        
+
         auto it = client.StreamExecuteScanQuery(R"(
             SELECT *
             FROM `Root/.sys/auth_group_members`
@@ -2949,7 +2949,7 @@ Y_UNIT_TEST_SUITE(SystemView) {
             "group2",
             "group3",
         }) {
-            env.GetClient().CreateGroup("/Root", group);
+            env.GetClient().TestCreateGroup("/Root", group);
         }
 
         for (auto user : {
@@ -2957,7 +2957,7 @@ Y_UNIT_TEST_SUITE(SystemView) {
             "user2",
             "user3"
         }) {
-            env.GetClient().CreateUser("/Root", user, "password");
+            env.GetClient().TestCreateUser("/Root", user, "password");
         }
 
         for (auto membership : TVector<std::pair<TString, TString>>{
@@ -2969,9 +2969,9 @@ Y_UNIT_TEST_SUITE(SystemView) {
             {"group3", "user1"},
             {"group3", "user2"},
         }) {
-            env.GetClient().AddGroupMembership("/Root", membership.first, membership.second);
+            env.GetClient().TestAddGroupMembership("/Root", membership.first, membership.second);
         }
-        
+
         {
             auto it = client.StreamExecuteScanQuery(R"(
                 SELECT *
@@ -3139,28 +3139,28 @@ Y_UNIT_TEST_SUITE(SystemView) {
         SetupAuthEnvironment(env);
         TTableClient client(env.GetDriver());
 
-        env.GetClient().CreateUser("/Root", "user1", "password1");
-        env.GetClient().CreateUser("/Root/Tenant1", "user2", "password2");
-        env.GetClient().CreateUser("/Root/Tenant2", "user3", "password3");
-        env.GetClient().CreateUser("/Root/Tenant2", "user4", "password4");
-        env.GetClient().CreateGroup("/Root/Tenant2", "group1");
+        env.GetClient().TestCreateUser("/Root", "user1", "password1");
+        env.GetClient().TestCreateUser("/Root/Tenant1", "user2", "password2");
+        env.GetClient().TestCreateUser("/Root/Tenant2", "user3", "password3");
+        env.GetClient().TestCreateUser("/Root/Tenant2", "user4", "password4");
+        env.GetClient().TestCreateGroup("/Root/Tenant2", "group1");
 
-        env.GetClient().MkDir("/Root", "Dir1/SubDir1");
-        env.GetClient().ModifyOwner("/Root", "Dir1", "user1");
-        env.GetClient().ModifyOwner("/Root/Dir1", "SubDir1", "user1");
+        env.GetClient().TestMkDir("/Root", "Dir1/SubDir1");
+        env.GetClient().TestModifyOwner("/Root", "Dir1", "user1");
+        env.GetClient().TestModifyOwner("/Root/Dir1", "SubDir1", "user1");
 
-        env.GetClient().MkDir("/Root/Tenant1", "Dir2/SubDir2");
-        env.GetClient().ModifyOwner("/Root/Tenant1", "Dir2", "user2");
-        env.GetClient().ModifyOwner("/Root/Tenant1/Dir2", "SubDir2", "user2");
+        env.GetClient().TestMkDir("/Root/Tenant1", "Dir2/SubDir2");
+        env.GetClient().TestModifyOwner("/Root/Tenant1", "Dir2", "user2");
+        env.GetClient().TestModifyOwner("/Root/Tenant1/Dir2", "SubDir2", "user2");
 
-        env.GetClient().MkDir("/Root/Tenant2", "Dir3/SubDir33");
-        env.GetClient().MkDir("/Root/Tenant2", "Dir3/SubDir34");
-        env.GetClient().MkDir("/Root/Tenant2", "Dir4/SubDir45");
-        env.GetClient().MkDir("/Root/Tenant2", "Dir4/SubDir46");
-        env.GetClient().ModifyOwner("/Root/Tenant2", "Dir3", "user3");
-        env.GetClient().ModifyOwner("/Root/Tenant2", "Dir4", "user4");
-        env.GetClient().ModifyOwner("/Root/Tenant2/Dir3", "SubDir33", "group1");
-        env.GetClient().ModifyOwner("/Root/Tenant2/Dir4", "SubDir46", "user4");
+        env.GetClient().TestMkDir("/Root/Tenant2", "Dir3/SubDir33");
+        env.GetClient().TestMkDir("/Root/Tenant2", "Dir3/SubDir34");
+        env.GetClient().TestMkDir("/Root/Tenant2", "Dir4/SubDir45");
+        env.GetClient().TestMkDir("/Root/Tenant2", "Dir4/SubDir46");
+        env.GetClient().TestModifyOwner("/Root/Tenant2", "Dir3", "user3");
+        env.GetClient().TestModifyOwner("/Root/Tenant2", "Dir4", "user4");
+        env.GetClient().TestModifyOwner("/Root/Tenant2/Dir3", "SubDir33", "group1");
+        env.GetClient().TestModifyOwner("/Root/Tenant2/Dir4", "SubDir46", "user4");
 
         // Cerr << env.GetClient().Describe(env.GetServer().GetRuntime(), "/Root").DebugString() << Endl;
         // Cerr << env.GetClient().Describe(env.GetServer().GetRuntime(), "/Root/Tenant2").DebugString() << Endl;
@@ -3227,12 +3227,12 @@ Y_UNIT_TEST_SUITE(SystemView) {
         SetupAuthAccessEnvironment(env);
         TTableClient client(env.GetDriver());
 
-        env.GetClient().MkDir("/Root", "Dir1");
-        env.GetClient().MkDir("/Root", "Dir2");
-        env.GetClient().MkDir("/Root/Tenant1", "Dir3");
-        env.GetClient().MkDir("/Root/Tenant1", "Dir4");
-        env.GetClient().ModifyOwner("/Root", "Dir1", "user1rootadmin");
-        env.GetClient().ModifyOwner("/Root/Tenant1", "Dir3", "user3");
+        env.GetClient().TestMkDir("/Root", "Dir1");
+        env.GetClient().TestMkDir("/Root", "Dir2");
+        env.GetClient().TestMkDir("/Root/Tenant1", "Dir3");
+        env.GetClient().TestMkDir("/Root/Tenant1", "Dir4");
+        env.GetClient().TestModifyOwner("/Root", "Dir1", "user1rootadmin");
+        env.GetClient().TestModifyOwner("/Root/Tenant1", "Dir3", "user3");
 
         { // anonymous login gives `ydb.granular.describe_schema` access
             auto driverConfig = TDriverConfig()
@@ -3306,7 +3306,7 @@ Y_UNIT_TEST_SUITE(SystemView) {
         { // revoke user1rootadmin /Root/Dir2 GenericUse access
             NACLib::TDiffACL acl;
             acl.AddAccess(NACLib::EAccessType::Deny, NACLib::GenericUse, "user1rootadmin");
-            env.GetClient().ModifyACL("/Root", "Dir2", acl.SerializeAsString());
+            env.GetClient().TestModifyACL("/Root", "Dir2", acl.SerializeAsString());
 
             auto driverConfig = TDriverConfig()
                 .SetEndpoint(env.GetEndpoint())
@@ -3353,9 +3353,9 @@ Y_UNIT_TEST_SUITE(SystemView) {
             "Dir11/SubDir",
             "Dir/SubDir",
         }) {
-            env.GetClient().MkDir("/Root", path);
+            env.GetClient().TestMkDir("/Root", path);
         }
-        
+
         auto it = client.StreamExecuteScanQuery(R"(
             SELECT *
             FROM `Root/.sys/auth_owners`
@@ -3404,15 +3404,15 @@ Y_UNIT_TEST_SUITE(SystemView) {
             "Dir3/SubDir1",
             "Dir3/SubDir2",
         }) {
-            env.GetClient().MkDir("/Root", path);
+            env.GetClient().TestMkDir("/Root", path);
         }
-        env.GetClient().CreateUser("/Root", "user0", "password0");
-        env.GetClient().CreateUser("/Root", "user1", "password1");
-        env.GetClient().CreateUser("/Root", "user2", "password2");
-        env.GetClient().ModifyOwner("/Root/Dir1", "SubDir0", "user0");
-        env.GetClient().ModifyOwner("/Root/Dir1", "SubDir1", "user1");
-        env.GetClient().ModifyOwner("/Root/Dir1", "SubDir2", "user2");
-        
+        env.GetClient().TestCreateUser("/Root", "user0", "password0");
+        env.GetClient().TestCreateUser("/Root", "user1", "password1");
+        env.GetClient().TestCreateUser("/Root", "user2", "password2");
+        env.GetClient().TestModifyOwner("/Root/Dir1", "SubDir0", "user0");
+        env.GetClient().TestModifyOwner("/Root/Dir1", "SubDir1", "user1");
+        env.GetClient().TestModifyOwner("/Root/Dir1", "SubDir2", "user2");
+
         {
             auto it = client.StreamExecuteScanQuery(R"(
                 SELECT *
@@ -3684,57 +3684,57 @@ Y_UNIT_TEST_SUITE(SystemView) {
         SetupAuthEnvironment(env);
         TTableClient client(env.GetDriver());
 
-        env.GetClient().CreateUser("/Root", "user1", "password1");
-        env.GetClient().CreateUser("/Root/Tenant1", "user2", "password2");
-        env.GetClient().CreateUser("/Root/Tenant2", "user3", "password3");
-        env.GetClient().CreateUser("/Root/Tenant2", "user4", "password4");
-        env.GetClient().CreateGroup("/Root/Tenant2", "group1");
+        env.GetClient().TestCreateUser("/Root", "user1", "password1");
+        env.GetClient().TestCreateUser("/Root/Tenant1", "user2", "password2");
+        env.GetClient().TestCreateUser("/Root/Tenant2", "user3", "password3");
+        env.GetClient().TestCreateUser("/Root/Tenant2", "user4", "password4");
+        env.GetClient().TestCreateGroup("/Root/Tenant2", "group1");
 
-        env.GetClient().MkDir("/Root", "Dir1/SubDir1");
-        env.GetClient().MkDir("/Root/Tenant1", "Dir2/SubDir2");
-        env.GetClient().MkDir("/Root/Tenant2", "Dir3/SubDir3");
-        env.GetClient().MkDir("/Root/Tenant2", "Dir4/SubDir4");
+        env.GetClient().TestMkDir("/Root", "Dir1/SubDir1");
+        env.GetClient().TestMkDir("/Root/Tenant1", "Dir2/SubDir2");
+        env.GetClient().TestMkDir("/Root/Tenant2", "Dir3/SubDir3");
+        env.GetClient().TestMkDir("/Root/Tenant2", "Dir4/SubDir4");
 
         {
             NACLib::TDiffACL acl;
             acl.AddAccess(NACLib::EAccessType::Allow, NACLib::GenericUse, "user1");
-            env.GetClient().ModifyACL("/", "Root", acl.SerializeAsString());
-            env.GetClient().ModifyACL("/Root", "Dir1", acl.SerializeAsString());
+            env.GetClient().TestModifyACL("/", "Root", acl.SerializeAsString());
+            env.GetClient().TestModifyACL("/Root", "Dir1", acl.SerializeAsString());
         }
         {
             NACLib::TDiffACL acl;
             acl.AddAccess(NACLib::EAccessType::Allow, NACLib::SelectRow, "user1");
             acl.AddAccess(NACLib::EAccessType::Allow, NACLib::EraseRow, "user1");
-            env.GetClient().ModifyACL("/Root/Dir1", "SubDir1", acl.SerializeAsString());
+            env.GetClient().TestModifyACL("/Root/Dir1", "SubDir1", acl.SerializeAsString());
         }
         {
             NACLib::TDiffACL acl;
             acl.AddAccess(NACLib::EAccessType::Deny, NACLib::UpdateRow, "user1");
-            env.GetClient().ModifyACL("/Root/Dir1", "SubDir1", acl.SerializeAsString());
+            env.GetClient().TestModifyACL("/Root/Dir1", "SubDir1", acl.SerializeAsString());
         }
         {
             NACLib::TDiffACL acl;
             acl.AddAccess(NACLib::EAccessType::Allow, NACLib::GenericUse, "user2");
-            env.GetClient().ModifyACL("/Root", "Tenant1", acl.SerializeAsString());
-            env.GetClient().ModifyACL("/Root/Tenant1/Dir2", "SubDir2", acl.SerializeAsString());
+            env.GetClient().TestModifyACL("/Root", "Tenant1", acl.SerializeAsString());
+            env.GetClient().TestModifyACL("/Root/Tenant1/Dir2", "SubDir2", acl.SerializeAsString());
         }
         {
             NACLib::TDiffACL acl;
             acl.AddAccess(NACLib::EAccessType::Allow, NACLib::GenericUse, "user3");
-            env.GetClient().ModifyACL("/Root", "Tenant2", acl.SerializeAsString());
-            env.GetClient().ModifyACL("/Root/Tenant2", "Dir3", acl.SerializeAsString());
+            env.GetClient().TestModifyACL("/Root", "Tenant2", acl.SerializeAsString());
+            env.GetClient().TestModifyACL("/Root/Tenant2", "Dir3", acl.SerializeAsString());
         }
         {
             NACLib::TDiffACL acl;
             acl.AddAccess(NACLib::EAccessType::Allow, NACLib::GenericUse, "user4");
-            env.GetClient().ModifyACL("/Root/Tenant2/Dir4", "SubDir4", acl.SerializeAsString());
+            env.GetClient().TestModifyACL("/Root/Tenant2/Dir4", "SubDir4", acl.SerializeAsString());
         }
         {
             NACLib::TDiffACL acl;
             acl.AddAccess(NACLib::EAccessType::Allow, NACLib::GenericUse, "group1");
-            env.GetClient().ModifyACL("/Root/Tenant2", "Dir4", acl.SerializeAsString());
+            env.GetClient().TestModifyACL("/Root/Tenant2", "Dir4", acl.SerializeAsString());
         }
-        
+
         // Cerr << env.GetClient().Describe(env.GetServer().GetRuntime(), "/Root/Tenant2/Dir4").DebugString() << Endl;
 
         {
@@ -3793,26 +3793,26 @@ Y_UNIT_TEST_SUITE(SystemView) {
         SetupAuthAccessEnvironment(env);
         TTableClient client(env.GetDriver());
 
-        env.GetClient().MkDir("/Root", "Dir1");
-        env.GetClient().MkDir("/Root", "Dir2");
-        env.GetClient().MkDir("/Root/Tenant1", "Dir3");
-        env.GetClient().MkDir("/Root/Tenant1", "Dir4");
-        
+        env.GetClient().TestMkDir("/Root", "Dir1");
+        env.GetClient().TestMkDir("/Root", "Dir2");
+        env.GetClient().TestMkDir("/Root/Tenant1", "Dir3");
+        env.GetClient().TestMkDir("/Root/Tenant1", "Dir4");
+
         {
             NACLib::TDiffACL acl;
             acl.AddAccess(NACLib::EAccessType::Allow, NACLib::SelectRow, "user1rootadmin");
-            env.GetClient().ModifyACL("/Root", "Dir1", acl.SerializeAsString());
+            env.GetClient().TestModifyACL("/Root", "Dir1", acl.SerializeAsString());
         }
         {
             NACLib::TDiffACL acl;
             acl.AddAccess(NACLib::EAccessType::Allow, NACLib::EraseRow, "user2");
-            env.GetClient().ModifyACL("/Root", "Dir2", acl.SerializeAsString());
+            env.GetClient().TestModifyACL("/Root", "Dir2", acl.SerializeAsString());
         }
         {
             NACLib::TDiffACL acl;
             acl.AddAccess(NACLib::EAccessType::Allow, NACLib::SelectRow, "user3");
             acl.AddAccess(NACLib::EAccessType::Allow, NACLib::EraseRow, "user4");
-            env.GetClient().ModifyACL("/Root/Tenant1", "Dir3", acl.SerializeAsString());
+            env.GetClient().TestModifyACL("/Root/Tenant1", "Dir3", acl.SerializeAsString());
         }
 
         { // anonymous login gives `ydb.granular.describe_schema` access
@@ -3889,7 +3889,7 @@ Y_UNIT_TEST_SUITE(SystemView) {
         { // revoke user1rootadmin /Root/Dir2 GenericUse access
             NACLib::TDiffACL acl;
             acl.AddAccess(NACLib::EAccessType::Deny, NACLib::GenericUse, "user1rootadmin");
-            env.GetClient().ModifyACL("/Root", "Dir2", acl.SerializeAsString());
+            env.GetClient().TestModifyACL("/Root", "Dir2", acl.SerializeAsString());
 
             auto driverConfig = TDriverConfig()
                 .SetEndpoint(env.GetEndpoint())
@@ -3933,7 +3933,7 @@ Y_UNIT_TEST_SUITE(SystemView) {
             "user2",
             "user"
         }) {
-            env.GetClient().CreateUser("/Root", user, "password");
+            env.GetClient().TestCreateUser("/Root", user, "password");
         }
 
         for (auto dir : {
@@ -3943,9 +3943,9 @@ Y_UNIT_TEST_SUITE(SystemView) {
             "Dir/SubDir1",
             "Dir/SubDir2"
         }) {
-            env.GetClient().MkDir("/Root", dir);
+            env.GetClient().TestMkDir("/Root", dir);
         }
-        
+
         for (auto acl : TVector<std::tuple<TString, TString, TString, NACLib::EAccessRights>>{
             {"/", "Root", "user1", NACLib::SelectRow},
             {"/", "Root", "user1", NACLib::EraseRow},
@@ -3958,13 +3958,14 @@ Y_UNIT_TEST_SUITE(SystemView) {
             {"/Root", "Dir2", "user1", NACLib::GenericUse},
             {"/Root", "Dir", "user1", NACLib::GenericUse},
             {"/Root", "Dir1", "user1", NACLib::AlterSchema},
-            {"/Root/Dir1", "SubDir1", "user1", NACLib::AlterSchema},
-            {"/Root/Dir1", "SubDir2", "user2", NACLib::AlterSchema},
-            {"/Root/Dir1", "SubDir2", "user1", NACLib::AlterSchema}
+            {"/Root/Dir", "SubDir1", "user1", NACLib::AlterSchema},
+            {"/Root/Dir", "SubDir2", "user2", NACLib::AlterSchema},
+            {"/Root/Dir", "SubDir2", "user1", NACLib::AlterSchema}
         }) {
             NACLib::TDiffACL diffAcl;
             diffAcl.AddAccess(NACLib::EAccessType::Allow, std::get<3>(acl), std::get<2>(acl));
-            env.GetClient().ModifyACL(std::get<0>(acl), std::get<1>(acl), diffAcl.SerializeAsString());
+            Cerr << "TEST " << std::get<0>(acl) << " " << std::get<1>(acl) << " " << std::get<2>(acl) << " " << NACLib::AccessRightsToString(std::get<3>(acl)) << Endl;
+            env.GetClient().TestModifyACL(std::get<0>(acl), std::get<1>(acl), diffAcl.SerializeAsString());
         }
 
         auto it = client.StreamExecuteScanQuery(R"(
@@ -3982,6 +3983,9 @@ Y_UNIT_TEST_SUITE(SystemView) {
             [["/Root/.metadata/workload_manager/pools/default"];["root@builtin"];["ydb.granular.describe_schema"]];
             [["/Root/.metadata/workload_manager/pools/default"];["root@builtin"];["ydb.granular.select_row"]];
             [["/Root/Dir"];["user1"];["ydb.generic.use"]];
+            [["/Root/Dir/SubDir1"];["user1"];["ydb.granular.alter_schema"]];
+            [["/Root/Dir/SubDir2"];["user1"];["ydb.granular.alter_schema"]];
+            [["/Root/Dir/SubDir2"];["user2"];["ydb.granular.alter_schema"]];
             [["/Root/Dir1"];["user1"];["ydb.generic.use"]];
             [["/Root/Dir1"];["user1"];["ydb.granular.alter_schema"]];
             [["/Root/Dir1"];["user2"];["ydb.generic.use"]];
@@ -3998,23 +4002,23 @@ Y_UNIT_TEST_SUITE(SystemView) {
         SetupAuthEnvironment(env);
         TTableClient client(env.GetDriver());
 
-        env.GetClient().CreateUser("/Root", "user1", "password1");
-        env.GetClient().CreateUser("/Root/Tenant1", "user2", "password2");
+        env.GetClient().TestCreateUser("/Root", "user1", "password1");
+        env.GetClient().TestCreateUser("/Root/Tenant1", "user2", "password2");
 
-        env.GetClient().MkDir("/Root", "Dir1");
-        env.GetClient().MkDir("/Root/Tenant1", "Dir2");
+        env.GetClient().TestMkDir("/Root", "Dir1");
+        env.GetClient().TestMkDir("/Root/Tenant1", "Dir2");
 
         {
             NACLib::TDiffACL acl;
             acl.AddAccess(NACLib::EAccessType::Allow, NACLib::GenericUse, "user1");
-            env.GetClient().ModifyACL("/", "Root", acl.SerializeAsString());
+            env.GetClient().TestModifyACL("/", "Root", acl.SerializeAsString());
         }
         {
             NACLib::TDiffACL acl;
             acl.AddAccess(NACLib::EAccessType::Allow, NACLib::SelectRow, "user2");
-            env.GetClient().ModifyACL("/Root/Tenant1", "Dir2", acl.SerializeAsString());
+            env.GetClient().TestModifyACL("/Root/Tenant1", "Dir2", acl.SerializeAsString());
         }
-        
+
         // Cerr << env.GetClient().Describe(env.GetServer().GetRuntime(), "/Root/Tenant2/Dir4").DebugString() << Endl;
 
         {
@@ -4062,30 +4066,30 @@ Y_UNIT_TEST_SUITE(SystemView) {
         SetupAuthEnvironment(env);
         TTableClient client(env.GetDriver());
 
-        env.GetClient().CreateUser("/Root", "user1", "password1");
-        env.GetClient().CreateUser("/Root", "user2", "password2");
+        env.GetClient().TestCreateUser("/Root", "user1", "password1");
+        env.GetClient().TestCreateUser("/Root", "user2", "password2");
 
-        env.GetClient().MkDir("/Root", "Dir1/SubDir1");
-        env.GetClient().MkDir("/Root", "Dir1/SubDir2");
+        env.GetClient().TestMkDir("/Root", "Dir1/SubDir1");
+        env.GetClient().TestMkDir("/Root", "Dir1/SubDir2");
 
         {
             NACLib::TDiffACL acl;
             acl.AddAccess(NACLib::EAccessType::Allow, NACLib::GenericUse, "user1");
-            env.GetClient().ModifyACL("/", "Root", acl.SerializeAsString());
-            env.GetClient().ModifyACL("/Root", "Dir1", acl.SerializeAsString());
+            env.GetClient().TestModifyACL("/", "Root", acl.SerializeAsString());
+            env.GetClient().TestModifyACL("/Root", "Dir1", acl.SerializeAsString());
         }
         {
             NACLib::TDiffACL acl;
             acl.AddAccess(NACLib::EAccessType::Allow, NACLib::SelectRow, "user2");
-            env.GetClient().ModifyACL("/Root", "Dir1", acl.SerializeAsString());
-            env.GetClient().ModifyACL("/Root/Dir1", "SubDir1", acl.SerializeAsString());
+            env.GetClient().TestModifyACL("/Root", "Dir1", acl.SerializeAsString());
+            env.GetClient().TestModifyACL("/Root/Dir1", "SubDir1", acl.SerializeAsString());
         }
         {
             NACLib::TDiffACL acl;
             acl.AddAccess(NACLib::EAccessType::Allow, NACLib::EraseRow, "user2");
-            env.GetClient().ModifyACL("/Root/Dir1", "SubDir1", acl.SerializeAsString());
+            env.GetClient().TestModifyACL("/Root/Dir1", "SubDir1", acl.SerializeAsString());
         }
-        
+
         {
             auto it = client.StreamExecuteScanQuery(R"(
                 SELECT *

--- a/ydb/core/tx/replication/ut_helpers/test_env.h
+++ b/ydb/core/tx/replication/ut_helpers/test_env.h
@@ -79,7 +79,7 @@ public:
     {
         UNIT_ASSERT_STRING_CONTAINS(builtin, "@builtin");
         Init(builtin);
-        Client.ModifyOwner("/", DomainName, builtin);
+        Client.TestModifyOwner("/", DomainName, builtin);
     }
 
     explicit TEnv(const TString& user, const TString& password)
@@ -93,10 +93,8 @@ public:
         const auto db = "/" + ToString(DomainName);
         // create user & set owner
         {
-            auto st = Client.CreateUser(db, user, password);
-            UNIT_ASSERT_VALUES_EQUAL(st, NMsgBusProxy::EResponseStatus::MSTATUS_OK);
-
-            Client.ModifyOwner("/", DomainName, user);
+            Client.TestCreateUser(db, user, password);
+            Client.TestModifyOwner("/", DomainName, user);
         }
         // init security state
         {

--- a/ydb/core/tx/tx_proxy/proxy_ut.cpp
+++ b/ydb/core/tx/tx_proxy/proxy_ut.cpp
@@ -843,7 +843,7 @@ Y_UNIT_TEST_SUITE(TSubDomainTest) {
         env.GetTenants().Run("/dc-1/USER_0", 1);
         UNIT_ASSERT_VALUES_EQUAL(NMsgBusProxy::MSTATUS_OK,
                                  env.GetClient().AlterSubdomain("/dc-1", GetSubDomainDefaultSetting("USER_0")));
-        env.GetClient().ModifyOwner("/dc-1", "USER_0", "user0@builtin");
+        env.GetClient().TestModifyOwner("/dc-1", "USER_0", "user0@builtin");
         env.GetClient().RefreshPathCache(&env.GetRuntime(), "/dc-1/USER_0");
 
         UNIT_ASSERT_VALUES_EQUAL(NMsgBusProxy::MSTATUS_OK,
@@ -851,7 +851,7 @@ Y_UNIT_TEST_SUITE(TSubDomainTest) {
         env.GetTenants().Run("/dc-1/USER_1", 1);
         UNIT_ASSERT_VALUES_EQUAL(NMsgBusProxy::MSTATUS_OK,
                                  env.GetClient().AlterSubdomain("/dc-1", GetSubDomainDefaultSetting("USER_1")));
-        env.GetClient().ModifyOwner("/dc-1", "USER_1", "user1@builtin");
+        env.GetClient().TestModifyOwner("/dc-1", "USER_1", "user1@builtin");
         env.GetClient().RefreshPathCache(&env.GetRuntime(), "/dc-1/USER_1");
 
 
@@ -894,7 +894,7 @@ Y_UNIT_TEST_SUITE(TSubDomainTest) {
         env.GetTenants().Run("/dc-1/USER_0", 1);
         UNIT_ASSERT_VALUES_EQUAL(NMsgBusProxy::MSTATUS_OK,
                                  env.GetClient().AlterSubdomain("/dc-1", GetSubDomainDefaultSetting("USER_0")));
-        env.GetClient().ModifyOwner("/dc-1", "USER_0", "user0@builtin");
+        env.GetClient().TestModifyOwner("/dc-1", "USER_0", "user0@builtin");
         env.GetClient().RefreshPathCache(&env.GetRuntime(), "/dc-1/USER_0");
 
         UNIT_ASSERT_VALUES_EQUAL(NMsgBusProxy::MSTATUS_OK,
@@ -902,7 +902,7 @@ Y_UNIT_TEST_SUITE(TSubDomainTest) {
         env.GetTenants().Run("/dc-1/USER_1", 1);
         UNIT_ASSERT_VALUES_EQUAL(NMsgBusProxy::MSTATUS_OK,
                                  env.GetClient().AlterSubdomain("/dc-1", GetSubDomainDefaultSetting("USER_1")));
-        env.GetClient().ModifyOwner("/dc-1", "USER_1", "user1@builtin");
+        env.GetClient().TestModifyOwner("/dc-1", "USER_1", "user1@builtin");
         env.GetClient().RefreshPathCache(&env.GetRuntime(), "/dc-1/USER_1");
 
 
@@ -996,13 +996,13 @@ Y_UNIT_TEST_SUITE(TModifyUserTest) {
         auto& client = env.GetClient();
         TString user1Token;
         {
-            client.CreateUser("/dc-1", "user1", "pass1", "root@builtin");
+            client.TestCreateUser("/dc-1", "user1", "pass1", "root@builtin");
             user1Token = CheckLogin(client, env.GetRuntime(), "user1", "pass1");
         }
 
         TString user2Token;
         {
-            client.CreateUser("/dc-1", "user2", "pass2", "root@builtin");
+            client.TestCreateUser("/dc-1", "user2", "pass2", "root@builtin");
             user2Token = CheckLogin(client, env.GetRuntime(), "user2", "pass2");
         }
 
@@ -1038,7 +1038,7 @@ Y_UNIT_TEST_SUITE(TModifyUserTest) {
 
         // grant permission ydb.granular.alter_schema to user1
         {
-            client.Grant("/", "dc-1", "user1", NACLib::EAccessRights::AlterSchema);
+            client.TestGrant("/", "dc-1", "user1", NACLib::EAccessRights::AlterSchema);
 
             // user1 can change password for user2. user1 has ydb.granular.alter_schema permission
             UNIT_ASSERT_VALUES_EQUAL(client.ModifyUser("/dc-1", { .User = "user2", .Password = "pas2user"}, user1Token), NMsgBusProxy::MSTATUS_OK);
@@ -1077,13 +1077,13 @@ Y_UNIT_TEST_SUITE(TModifyUserTest) {
         auto& client = env.GetClient();
         TString user1Token;
         {
-            client.CreateUser("/dc-1", { .User = "user1", .Password = "pass1"}, "root@builtin");
+            client.TestCreateUser("/dc-1", { .User = "user1", .Password = "pass1"}, "root@builtin");
             user1Token = CheckLogin(client, env.GetRuntime(), "user1", "pass1");
         }
 
         TString user2Token;
         {
-            client.CreateUser("/dc-1", { .User = "user2", .Password = "pass2"}, "root@builtin");
+            client.TestCreateUser("/dc-1", { .User = "user2", .Password = "pass2"}, "root@builtin");
             user2Token = CheckLogin(client, env.GetRuntime(), "user2", "pass2");
         }
 

--- a/ydb/core/viewer/viewer_ut.cpp
+++ b/ydb/core/viewer/viewer_ut.cpp
@@ -600,8 +600,8 @@ Y_UNIT_TEST_SUITE(Viewer) {
     }
 
     void GrantConnect(TClient& client) {
-        client.CreateUser("/Root", "username", "password");
-        client.GrantConnect("username");
+        client.TestCreateUser("/Root", "username", "password");
+        client.TestGrantConnect("username");
 
         const auto alterAttrsStatus = client.AlterUserAttributes("/", "Root", {
             { "folder_id", "test_folder_id" },

--- a/ydb/services/cms/cms_ut.cpp
+++ b/ydb/services/cms/cms_ut.cpp
@@ -530,7 +530,7 @@ Y_UNIT_TEST_SUITE(TGRpcCmsTest) {
             acl.AddAccess(NACLib::EAccessType::Allow, NACLib::GenericFull,
                           "user-1@" BUILTIN_ACL_DOMAIN);
             TClient client(*server.ServerSettings);
-            client.ModifyACL("/", "Root", acl.SerializeAsString());
+            client.TestModifyACL("/", "Root", acl.SerializeAsString());
         }
 
         CheckCreateDatabase(server, channel, "/Root/users/user-1",
@@ -545,7 +545,7 @@ Y_UNIT_TEST_SUITE(TGRpcCmsTest) {
             acl.AddAccess(NACLib::EAccessType::Allow, NACLib::GenericFull,
                           "user-2@" BUILTIN_ACL_DOMAIN);
             TClient client(*server.ServerSettings);
-            client.ModifyACL("/Root/users", "user-1", acl.SerializeAsString());
+            client.TestModifyACL("/Root/users", "user-1", acl.SerializeAsString());
             client.RefreshPathCache(server.Server_->GetRuntime(), "/Root/users/user-1");
         }
 

--- a/ydb/services/ydb/ydb_olapstore_ut.cpp
+++ b/ydb/services/ydb/ydb_olapstore_ut.cpp
@@ -332,15 +332,15 @@ Y_UNIT_TEST_SUITE(YdbOlapStore) {
         EnableDebugLogs(server);
 
         TClient annoyingClient(*server.ServerSettings);
-        annoyingClient.GrantConnect("alice@builtin");
-        annoyingClient.GrantConnect("bob@builtin");
+        annoyingClient.TestGrantConnect("alice@builtin");
+        annoyingClient.TestGrantConnect("bob@builtin");
 
         TTestOlapTableOptions opts;
         opts.TsType = pkFirstType;
         opts.HashFunction = "HASH_FUNCTION_MODULO_N";
         CreateOlapTable<NotNull>(*server.ServerSettings, "log1", opts);
 
-        annoyingClient.ModifyOwner("/Root/OlapStore", "log1", "alice@builtin");
+        annoyingClient.TestModifyOwner("/Root/OlapStore", "log1", "alice@builtin");
 
         auto connection = ConnectToServer(server);
         {

--- a/ydb/services/ydb/ydb_ut.cpp
+++ b/ydb/services/ydb/ydb_ut.cpp
@@ -422,7 +422,7 @@ Y_UNIT_TEST_SUITE(TGRpcClientLowTest) {
 
         {
             TClient client(*server.ServerSettings);
-            client.CreateUser("/Root", "qqq", "password");
+            client.TestCreateUser("/Root", "qqq", "password");
         }
         {
             NYdbGrpc::TGRpcClientLow clientLow;


### PR DESCRIPTION
TCLient's MkDir, CreateUser at al. methods return operation status with intention for it to be checked in the test body. But some tests never did.
It could be ok at the test context preparation phase, as missed errors will manifest themselves anyway, just a bit later. It's not ok at the actual test bodies.

This replaces calls to MkDir(), CreateUser() at al. in the places where result statuses were not checked with the calls to TestMkDir(), TestCreateUser() that do.

Stacked on:
- https://github.com/ydb-platform/ydb/pull/14141

### Changelog category

* Not for changelog
