### PR TITLE
KESUS: local backups (ydb tools dump / restore)

### DIFF
--- a/ydb/library/backup/db_iterator.h
+++ b/ydb/library/backup/db_iterator.h
@@ -137,6 +137,10 @@ public:
         return GetCurrentNode()->Type == NScheme::ESchemeEntryType::Topic;
     }
 
+    bool IsCoordinationNode() const {
+        return GetCurrentNode()->Type == NScheme::ESchemeEntryType::CoordinationNode;
+    }
+
     bool IsDir() const {
         return GetCurrentNode()->Type == NScheme::ESchemeEntryType::Directory;
     }

--- a/ydb/library/backup/ya.make
+++ b/ydb/library/backup/ya.make
@@ -12,6 +12,7 @@ PEERDIR(
     ydb/public/lib/ydb_cli/dump/util
     ydb/public/lib/yson_value
     ydb/public/lib/ydb_cli/dump/files
+    ydb/public/sdk/cpp/src/client/coordination
     ydb/public/sdk/cpp/src/client/draft
     ydb/public/sdk/cpp/src/client/driver
     ydb/public/sdk/cpp/src/client/proto

--- a/ydb/public/lib/ydb_cli/dump/files/files.cpp
+++ b/ydb/public/lib/ydb_cli/dump/files/files.cpp
@@ -8,6 +8,7 @@ enum EFilesType {
     CHANGEFEED_DESCRIPTION,
     TOPIC_DESCRIPTION,
     CREATE_TOPIC,
+    CREATE_COORDINATION_NODE,
     INCOMPLETE_DATA,
     INCOMPLETE,
     EMPTY,
@@ -20,6 +21,7 @@ static constexpr TFileInfo FILES_INFO[] = {
     {"changefeed_description.pb", "changefeed"},
     {"topic_description.pb", "topic"},
     {"create_topic.pb", "topic"},
+    {"create_coordination_node.pb", "coordination node"},
     {"incomplete.csv", "incomplete"},
     {"incomplete", "incomplete"},
     {"empty_dir", "empty_dir"},
@@ -44,6 +46,10 @@ const TFileInfo& TopicDescription() {
 
 const TFileInfo& CreateTopic() {
     return FILES_INFO[CREATE_TOPIC];
+}
+
+const TFileInfo& CreateCoordinationNode() {
+    return FILES_INFO[CREATE_COORDINATION_NODE];
 }
 
 const TFileInfo& IncompleteData() {

--- a/ydb/public/lib/ydb_cli/dump/files/files.h
+++ b/ydb/public/lib/ydb_cli/dump/files/files.h
@@ -12,6 +12,7 @@ const TFileInfo& Permissions();
 const TFileInfo& Changefeed();
 const TFileInfo& TopicDescription();
 const TFileInfo& CreateTopic();
+const TFileInfo& CreateCoordinationNode();
 const TFileInfo& IncompleteData();
 const TFileInfo& Incomplete();
 const TFileInfo& Empty();

--- a/ydb/public/lib/ydb_cli/dump/restore_impl.h
+++ b/ydb/public/lib/ydb_cli/dump/restore_impl.h
@@ -2,6 +2,7 @@
 
 #include "dump.h"
 
+#include <ydb-cpp-sdk/client/coordination/coordination.h>
 #include <ydb-cpp-sdk/client/import/import.h>
 #include <ydb-cpp-sdk/client/operation/operation.h>
 #include <ydb-cpp-sdk/client/query/client.h>
@@ -129,6 +130,7 @@ class TRestoreClient {
     TRestoreResult RestoreTable(const TFsPath& fsPath, const TString& dbPath, const TRestoreSettings& settings, bool isAlreadyExisting);
     TRestoreResult RestoreView(const TFsPath& fsPath, const TString& dbRestoreRoot, const TString& dbPathRelativeToRestoreRoot, const TRestoreSettings& settings, bool isAlreadyExisting);
     TRestoreResult RestoreTopic(const TFsPath& fsPath, const TString& dbPath, const TRestoreSettings& settings, bool isAlreadyExisting);
+    TRestoreResult RestoreCoordinationNode(const TFsPath& fsPath, const TString& dbPath, const TRestoreSettings& settings, bool isAlreadyExisting);
 
     TRestoreResult CheckSchema(const TString& dbPath, const NTable::TTableDescription& desc);
     TRestoreResult RestoreData(const TFsPath& fsPath, const TString& dbPath, const TRestoreSettings& settings, const NTable::TTableDescription& desc);
@@ -154,6 +156,7 @@ private:
     NScheme::TSchemeClient SchemeClient;
     NTable::TTableClient TableClient;
     NTopic::TTopicClient TopicClient;
+    NCoordination::TClient CoordinationNodeClient;
     NQuery::TQueryClient QueryClient;
     std::shared_ptr<TLog> Log;
 

--- a/ydb/public/sdk/cpp/include/ydb-cpp-sdk/client/coordination/coordination.h
+++ b/ydb/public/sdk/cpp/include/ydb-cpp-sdk/client/coordination/coordination.h
@@ -4,6 +4,7 @@
 
 namespace Ydb {
 namespace Coordination {
+    class CreateNodeRequest;
     class DescribeNodeResult;
     class SemaphoreSession;
     class SemaphoreDescription;
@@ -106,6 +107,8 @@ public:
     const std::string& GetOwner() const;
     const std::vector<NScheme::TPermissions>& GetEffectivePermissions() const;
     const Ydb::Coordination::DescribeNodeResult& GetProto() const;
+
+    void SerializeTo(Ydb::Coordination::CreateNodeRequest& creationRequest) const;
 
 private:
     struct TImpl;

--- a/ydb/public/sdk/cpp/include/ydb-cpp-sdk/client/coordination/coordination.h
+++ b/ydb/public/sdk/cpp/include/ydb-cpp-sdk/client/coordination/coordination.h
@@ -4,10 +4,11 @@
 
 namespace Ydb {
 namespace Coordination {
+    class Config;
     class CreateNodeRequest;
     class DescribeNodeResult;
-    class SemaphoreSession;
     class SemaphoreDescription;
+    class SemaphoreSession;
 }
 }
 
@@ -192,7 +193,10 @@ struct TNodeSettings : public TOperationRequestSettings<TDerived> {
     FLUENT_SETTING_DEFAULT(ERateLimiterCountersMode, RateLimiterCountersMode, ERateLimiterCountersMode::UNSET);
 };
 
-struct TCreateNodeSettings : public TNodeSettings<TCreateNodeSettings> { };
+struct TCreateNodeSettings : public TNodeSettings<TCreateNodeSettings> {
+    TCreateNodeSettings() = default;
+    TCreateNodeSettings(const Ydb::Coordination::Config& config);
+};
 struct TAlterNodeSettings : public TNodeSettings<TAlterNodeSettings> { };
 struct TDropNodeSettings : public TOperationRequestSettings<TDropNodeSettings> { };
 struct TDescribeNodeSettings : public TOperationRequestSettings<TDescribeNodeSettings> { };

--- a/ydb/public/sdk/cpp/src/client/coordination/coordination.cpp
+++ b/ydb/public/sdk/cpp/src/client/coordination/coordination.cpp
@@ -17,7 +17,6 @@ namespace NCoordination {
 using NThreading::TFuture;
 using NThreading::TPromise;
 using NThreading::NewPromise;
-using NYdbGrpc::TQueueClientFixedEvent;
 
 namespace {
 
@@ -31,30 +30,6 @@ inline TResultPromise<T> NewResultPromise() {
     return NewPromise<TResult<T>>();
 
 
-}
-
-////////////////////////////////////////////////////////////////////////////////
-
-template<class Settings>
-void ConvertSettingsToProtoConfig(
-    const Settings& settings,
-    Ydb::Coordination::Config* config)
-{
-    if (settings.SelfCheckPeriod_) {
-        config->set_self_check_period_millis(settings.SelfCheckPeriod_->MilliSeconds());
-    }
-    if (settings.SessionGracePeriod_) {
-        config->set_session_grace_period_millis(settings.SessionGracePeriod_->MilliSeconds());
-    }
-    if (settings.ReadConsistencyMode_ != EConsistencyMode::UNSET) {
-        config->set_read_consistency_mode(static_cast<Ydb::Coordination::ConsistencyMode>(settings.ReadConsistencyMode_));
-    }
-    if (settings.AttachConsistencyMode_ != EConsistencyMode::UNSET) {
-        config->set_attach_consistency_mode(static_cast<Ydb::Coordination::ConsistencyMode>(settings.AttachConsistencyMode_));
-    }
-    if (settings.RateLimiterCountersMode_ != ERateLimiterCountersMode::UNSET) {
-        config->set_rate_limiter_counters_mode(static_cast<Ydb::Coordination::RateLimiterCountersMode>(settings.RateLimiterCountersMode_));
-    }
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -1814,6 +1789,52 @@ private:
 
     bool IsStopping = false;
 };
+
+////////////////////////////////////////////////////////////////////////////////
+
+namespace {
+
+template<class Settings>
+void ConvertSettingsToProtoConfig(
+    const Settings& settings,
+    Ydb::Coordination::Config* config)
+{
+    if (settings.SelfCheckPeriod_) {
+        config->set_self_check_period_millis(settings.SelfCheckPeriod_->MilliSeconds());
+    }
+    if (settings.SessionGracePeriod_) {
+        config->set_session_grace_period_millis(settings.SessionGracePeriod_->MilliSeconds());
+    }
+    if (settings.ReadConsistencyMode_ != EConsistencyMode::UNSET) {
+        config->set_read_consistency_mode(static_cast<Ydb::Coordination::ConsistencyMode>(settings.ReadConsistencyMode_));
+    }
+    if (settings.AttachConsistencyMode_ != EConsistencyMode::UNSET) {
+        config->set_attach_consistency_mode(static_cast<Ydb::Coordination::ConsistencyMode>(settings.AttachConsistencyMode_));
+    }
+    if (settings.RateLimiterCountersMode_ != ERateLimiterCountersMode::UNSET) {
+        config->set_rate_limiter_counters_mode(static_cast<Ydb::Coordination::RateLimiterCountersMode>(settings.RateLimiterCountersMode_));
+    }
+}
+
+}
+
+TCreateNodeSettings::TCreateNodeSettings(const Ydb::Coordination::Config& config) {
+    if (config.self_check_period_millis() != 0u) {
+        SelfCheckPeriod(TDuration::MilliSeconds(config.self_check_period_millis()));
+    }
+    if (config.session_grace_period_millis() != 0u) {
+        SessionGracePeriod(TDuration::MilliSeconds(config.session_grace_period_millis()));
+    }
+    if (config.read_consistency_mode() != Ydb::Coordination::CONSISTENCY_MODE_UNSET) {
+        ReadConsistencyMode(static_cast<EConsistencyMode>(config.read_consistency_mode()));
+    }
+    if (config.attach_consistency_mode() != Ydb::Coordination::CONSISTENCY_MODE_UNSET) {
+        AttachConsistencyMode(static_cast<EConsistencyMode>(config.attach_consistency_mode()));
+    }
+    if (config.rate_limiter_counters_mode() != Ydb::Coordination::RATE_LIMITER_COUNTERS_MODE_UNSET) {
+        RateLimiterCountersMode(static_cast<ERateLimiterCountersMode>(config.rate_limiter_counters_mode()));
+    }
+}
 
 ////////////////////////////////////////////////////////////////////////////////
 

--- a/ydb/public/sdk/cpp/src/client/coordination/coordination.cpp
+++ b/ydb/public/sdk/cpp/src/client/coordination/coordination.cpp
@@ -89,6 +89,12 @@ struct TNodeDescription::TImpl {
         Proto_ = desc;
     }
 
+    void SerializeTo(Ydb::Coordination::CreateNodeRequest& creationRequest) {
+        auto& config = *creationRequest.mutable_config();
+        config.CopyFrom(Proto_.config());
+        config.clear_path();
+    }
+
     std::optional<TDuration> SelfCheckPeriod_;
     std::optional<TDuration> SessionGracePeriod_;
     EConsistencyMode ReadConsistencyMode_;
@@ -134,6 +140,10 @@ const std::vector<NScheme::TPermissions>& TNodeDescription::GetEffectivePermissi
 
 const Ydb::Coordination::DescribeNodeResult& TNodeDescription::GetProto() const {
     return Impl_->Proto_;
+}
+
+void TNodeDescription::SerializeTo(Ydb::Coordination::CreateNodeRequest& creationRequest) const {
+    return Impl_->SerializeTo(creationRequest);
 }
 
 ////////////////////////////////////////////////////////////////////////////////


### PR DESCRIPTION
Support Kesuses (a.k.a. Coordination Nodes) in local backups: `ydb tools dump` and `ydb tools restore`.

### Changelog entry <!-- a user-readable short description of changes introduced in this PR -->

### Changelog category <!-- remove all except one -->

* Not for changelog (changelog entry is not required)

### Additional information

- #10444
- #14051
