### PR TITLE
Use an empty AckTo for plans from mediator to tablets

### DIFF
--- a/ydb/core/tx/columnshard/columnshard__plan_step.cpp
+++ b/ydb/core/tx/columnshard/columnshard__plan_step.cpp
@@ -49,12 +49,16 @@ bool TTxPlanStep::Execute(TTransactionContext& txc, const TActorContext& ctx) {
     std::vector<ui64> txIds;
     for (const auto& tx : record.GetTransactions()) {
         Y_ABORT_UNLESS(tx.HasTxId());
-        Y_ABORT_UNLESS(tx.HasAckTo());
 
         txIds.push_back(tx.GetTxId());
 
-        TActorId txOwner = ActorIdFromProto(tx.GetAckTo());
-        TxAcks[txOwner].push_back(tx.GetTxId());
+        // Note: we plan to remove AckTo in the future
+        if (tx.HasAckTo()) {
+            TActorId txOwner = ActorIdFromProto(tx.GetAckTo());
+            // Note: when mediators ack transactions on their own they also
+            // specify an empty AckTo. Sends to empty actors are a no-op anyway.
+            TxAcks[txOwner].push_back(tx.GetTxId());
+        }
     }
 
     size_t plannedCount = 0;

--- a/ydb/core/tx/mediator/tablet_queue.cpp
+++ b/ydb/core/tx/mediator/tablet_queue.cpp
@@ -112,7 +112,7 @@ class TTxMediatorTabletQueue : public TActor<TTxMediatorTabletQueue> {
             x->SetTxId(tx.TxId);
             if (tx.Moderator)
                 x->SetModerator(tx.Moderator);
-            ActorIdToProto(tx.AckTo, x->MutableAckTo());
+            ActorIdToProto(TActorId(), x->MutableAckTo());
             LOG_DEBUG(ctx, NKikimrServices::TX_MEDIATOR_PRIVATE, "Send from %" PRIu64 " to tablet %" PRIu64 ", step# %"
                 PRIu64 ", txid# %" PRIu64 ", marker M5" PRIu64, Mediator, tabletId, tabletStep->StepRef->Step, tx.TxId);
         }

--- a/ydb/core/tx/schemeshard/schemeshard__operation_side_effects.cpp
+++ b/ydb/core/tx/schemeshard/schemeshard__operation_side_effects.cpp
@@ -13,7 +13,9 @@ void TSideEffects::ProposeToCoordinator(TOperationId opId, TPathId pathId, TStep
 }
 
 void TSideEffects::CoordinatorAck(TActorId coordinator, TStepId stepId, TTxId txId) {
-    CoordinatorAcks.push_back(TCoordinatorAck(coordinator, stepId, txId));
+    if (coordinator) {
+        CoordinatorAcks.push_back(TCoordinatorAck(coordinator, stepId, txId));
+    }
 }
 
 void TSideEffects::MediatorAck(TActorId mediator, TStepId stepId) {


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of changes introduced in this PR -->

...

### Changelog category <!-- remove all except one -->

* Not for changelog (changelog entry is not required)

### Additional information

Since mediators now ack transactions when plan step is accepted, use an empty AckTo to avoid unnecessary acks from tablets to coordinators.