### PR TITLE
replay fixes (ignore ast query type as it misses parameters and avoid symbols duplication with external so)

### DIFF
--- a/ydb/tools/query_replay_yt/common_deps.inc
+++ b/ydb/tools/query_replay_yt/common_deps.inc
@@ -84,7 +84,6 @@ SET(YDB_REPLAY_PEERDIRS
     yql/essentials/udfs/common/string
     yql/essentials/udfs/common/top
     yql/essentials/udfs/common/topfreq
-    yql/essentials/udfs/common/unicode_base
     yql/essentials/udfs/common/url_base
     yql/essentials/udfs/common/yson2
     yql/essentials/udfs/logs/dsv

--- a/ydb/tools/query_replay_yt/main.cpp
+++ b/ydb/tools/query_replay_yt/main.cpp
@@ -141,7 +141,7 @@ public:
 
     THolder<TQueryReplayEvents::TEvCompileResponse> RunReplay(NJson::TJsonValue&& json) {
         TString queryType = json["query_type"].GetStringSafe();
-        if (queryType == "QUERY_TYPE_AST_SCAN") {
+        if (queryType == "QUERY_TYPE_AST_SCAN" || queryType == "QUERY_TYPE_AST_DML") {
             return nullptr;
         }
 


### PR DESCRIPTION
### Changelog entry 

replay fixes (ignore ast query type as it misses parameters and avoid symbols duplication with external so)

### Changelog category

* Not for changelog (changelog entry is not required)

### Additional information

...
