### PR TITLE
Add data cleanup starting in datashard

### DIFF
--- a/ydb/core/blobstorage/dsproxy/mock/model.h
+++ b/ydb/core/blobstorage/dsproxy/mock/model.h
@@ -430,6 +430,10 @@ namespace NFake {
             return Blobs;
         }
 
+        TGroupId GetGroupId() const {
+            return GroupId;
+        }
+
     private:
         // check if provided generation is blocked for specific tablet
         bool IsBlocked(TTabletId tabletId, TGeneration generation) const noexcept {

--- a/ydb/core/protos/counters_datashard.proto
+++ b/ydb/core/protos/counters_datashard.proto
@@ -529,4 +529,6 @@ enum ETxTypes {
     TXTYPE_WRITE = 82                                     [(TxTypeOpts) = {Name: "TxWrite"}];
     TXTYPE_REMOVE_SCHEMA_SNAPSHOTS = 83                   [(TxTypeOpts) = {Name: "TxRemoveSchemaSnapshots"}];
     TXTYPE_INIT_RESTORED = 84                             [(TxTypeOpts) = {Name: "TxInitRestored"}];
+    TXTYPE_DATA_CLEANUP = 85                              [(TxTypeOpts) = {Name: "TxDataCleanup"}];
+    TXTYPE_COMPLETE_DATA_CLEANUP = 86                     [(TxTypeOpts) = {Name: "TTxCompleteDataCleanup"}];
 }

--- a/ydb/core/protos/counters_datashard.proto
+++ b/ydb/core/protos/counters_datashard.proto
@@ -530,5 +530,5 @@ enum ETxTypes {
     TXTYPE_REMOVE_SCHEMA_SNAPSHOTS = 83                   [(TxTypeOpts) = {Name: "TxRemoveSchemaSnapshots"}];
     TXTYPE_INIT_RESTORED = 84                             [(TxTypeOpts) = {Name: "TxInitRestored"}];
     TXTYPE_DATA_CLEANUP = 85                              [(TxTypeOpts) = {Name: "TxDataCleanup"}];
-    TXTYPE_COMPLETE_DATA_CLEANUP = 86                     [(TxTypeOpts) = {Name: "TTxCompleteDataCleanup"}];
+    TXTYPE_COMPLETE_DATA_CLEANUP = 86                     [(TxTypeOpts) = {Name: "TxCompleteDataCleanup"}];
 }

--- a/ydb/core/tablet_flat/flat_executor.cpp
+++ b/ydb/core/tablet_flat/flat_executor.cpp
@@ -3904,8 +3904,8 @@ bool TExecutor::CompactTables() {
     }
 }
 
-void TExecutor::CleanupData() {
-    if (DataCleanupLogic->TryStartCleanup()) {
+void TExecutor::CleanupData(ui64 dataCleanupGeneration) {
+    if (DataCleanupLogic->TryStartCleanup(dataCleanupGeneration, OwnerCtx())) {
         for (const auto& [tableId, _] : Scheme().Tables) {
             auto compactionId = CompactionLogic->PrepareForceCompaction(tableId);
             DataCleanupLogic->OnCompactionPrepared(tableId, compactionId);

--- a/ydb/core/tablet_flat/flat_executor.h
+++ b/ydb/core/tablet_flat/flat_executor.h
@@ -640,7 +640,7 @@ public:
     ui64 CompactTable(ui32 tableId) override;
     bool CompactTables() override;
 
-    void CleanupData() override;
+    void CleanupData(ui64 dataCleanupGeneration) override;
 
     void Handle(NMemory::TEvMemTableRegistered::TPtr &ev);
     void Handle(NMemory::TEvMemTableCompact::TPtr &ev);

--- a/ydb/core/tablet_flat/flat_executor_data_cleanup_logic.cpp
+++ b/ydb/core/tablet_flat/flat_executor_data_cleanup_logic.cpp
@@ -35,7 +35,7 @@ bool TDataCleanupLogic::TryStartCleanup(ui64 dataCleanupGeneration, const TActor
         }
         default: { // DataCleanup in progress
             if (dataCleanupGeneration > CurrentDataCleanupGeneration) {
-                NextDataCleanupGeneration = Max(dataCleanupGeneration, NextDataCleanupGeneration.value_or(0));
+                NextDataCleanupGeneration = Max(dataCleanupGeneration, NextDataCleanupGeneration);
                 if (auto logl = Logger->Log(ELnLev::Info)) {
                     logl << "TDataCleanupLogic: schedule next DataCleanup for tablet with id " << Owner->TabletID()
                         << ", current DataCleanup generation: " << CurrentDataCleanupGeneration
@@ -192,7 +192,7 @@ bool TDataCleanupLogic::NeedGC() {
 void TDataCleanupLogic::CompleteDataCleanup(const TActorContext& ctx) {
     State = EDataCleanupState::Idle;
     if (NextDataCleanupGeneration) {
-        Executor->CleanupData(*std::exchange(NextDataCleanupGeneration, std::nullopt));
+        Executor->CleanupData(std::exchange(NextDataCleanupGeneration, 0));
     } else {
         // report complete only if all planned cleanups completed
         Owner->DataCleanupComplete(CurrentDataCleanupGeneration, ctx);

--- a/ydb/core/tablet_flat/flat_executor_data_cleanup_logic.cpp
+++ b/ydb/core/tablet_flat/flat_executor_data_cleanup_logic.cpp
@@ -10,19 +10,43 @@ TDataCleanupLogic::TDataCleanupLogic(IOps* ops, IExecutor* executor, ITablet* ow
     , GcLogic(gcLogic)
 {}
 
-bool TDataCleanupLogic::TryStartCleanup() {
-    if (State == EDataCleanupState::Idle) {
-        if (auto logl = Logger->Log(ELnLev::Info)) {
-            logl << "TDataCleanupLogic: Starting DataCleanup for tablet with id " << Owner->TabletID();
+bool TDataCleanupLogic::TryStartCleanup(ui64 dataCleanupGeneration, const TActorContext& ctx) {
+    switch (State) {
+        case EDataCleanupState::Idle: {
+            if (CurrentDataCleanupGeneration >= dataCleanupGeneration) {
+                if (auto logl = Logger->Log(ELnLev::Info)) {
+                    logl << "TDataCleanupLogic: DataCleanup for tablet with id " << Owner->TabletID()
+                        << " had already completed for generation " << dataCleanupGeneration
+                        << ", current DataCleanup generation: " << CurrentDataCleanupGeneration;
+                }
+                // repeat DataCleanupComplete callback
+                CompleteDataCleanup(ctx);
+                return false;
+            } else {
+                CurrentDataCleanupGeneration = dataCleanupGeneration;
+                if (auto logl = Logger->Log(ELnLev::Info)) {
+                    logl << "TDataCleanupLogic: Starting DataCleanup for tablet with id " << Owner->TabletID()
+                        << ", current DataCleanup generation: " << CurrentDataCleanupGeneration;
+                }
+                State = EDataCleanupState::PendingCompaction;
+                return true;
+            }
+            break;
         }
-        State = EDataCleanupState::PendingCompaction;
-        return true;
-    } else {
-        if (auto logl = Logger->Log(ELnLev::Info)) {
-            logl << "TDataCleanupLogic: schedule next DataCleanup for tablet with id " << Owner->TabletID();
+        default: { // DataCleanup in progress
+            if (dataCleanupGeneration > CurrentDataCleanupGeneration) {
+                NextDataCleanupGeneration = Max(dataCleanupGeneration, NextDataCleanupGeneration.value_or(0));
+                if (auto logl = Logger->Log(ELnLev::Info)) {
+                    logl << "TDataCleanupLogic: schedule next DataCleanup for tablet with id " << Owner->TabletID()
+                        << ", current DataCleanup generation: " << CurrentDataCleanupGeneration
+                        << ", next DataCleanup generation: " << NextDataCleanupGeneration;
+                }
+                return false;
+            } else {
+                // more recent DataCleanup in progress, so just ignore osolete generation
+                return false;
+            }
         }
-        StartNextCleanup = true;
-        return false;
     }
 }
 
@@ -166,14 +190,16 @@ bool TDataCleanupLogic::NeedGC() {
 }
 
 void TDataCleanupLogic::CompleteDataCleanup(const TActorContext& ctx) {
-    Owner->DataCleanupComplete(ctx);
-    if (auto logl = Logger->Log(ELnLev::Info)) {
-        logl << "TDataCleanupLogic: DataCleanup finished for tablet with id " << Owner->TabletID();
-    }
     State = EDataCleanupState::Idle;
-    if (StartNextCleanup) {
-        StartNextCleanup = false;
-        Executor->CleanupData();
+    if (NextDataCleanupGeneration) {
+        Executor->CleanupData(*std::exchange(NextDataCleanupGeneration, std::nullopt));
+    } else {
+        // report complete only if all planned cleanups completed
+        Owner->DataCleanupComplete(CurrentDataCleanupGeneration, ctx);
+        if (auto logl = Logger->Log(ELnLev::Info)) {
+            logl << "TDataCleanupLogic: DataCleanup finished for tablet with id " << Owner->TabletID()
+                << ", current DataCleanup generation: " << CurrentDataCleanupGeneration;
+        }
     }
 }
 

--- a/ydb/core/tablet_flat/flat_executor_data_cleanup_logic.h
+++ b/ydb/core/tablet_flat/flat_executor_data_cleanup_logic.h
@@ -33,7 +33,7 @@ public:
 
     TDataCleanupLogic(IOps* ops, IExecutor* executor, ITablet* owner, NUtil::ILogger* logger, TExecutorGCLogic* gcLogic);
 
-    bool TryStartCleanup();
+    bool TryStartCleanup(ui64 dataCleanupGeneration, const TActorContext& ctx);
     void OnCompactionPrepared(ui32 tableId, ui64 compactionId);
     void WaitCompaction();
     void OnCompleteCompaction(ui32 tableId, const TFinishedCompactionInfo& finishedCompactionInfo);
@@ -54,8 +54,9 @@ private:
     NUtil::ILogger* const Logger;
     TExecutorGCLogic* const GcLogic;
 
+    ui64 CurrentDataCleanupGeneration = 0;
+    std::optional<ui64> NextDataCleanupGeneration;
     EDataCleanupState State = EDataCleanupState::Idle;
-    bool StartNextCleanup = false;
     THashMap<ui32, TCleanupTableInfo> CompactingTables; // tracks statuses of compaction
 
     // two subsequent are snapshots required to force GC

--- a/ydb/core/tablet_flat/flat_executor_data_cleanup_logic.h
+++ b/ydb/core/tablet_flat/flat_executor_data_cleanup_logic.h
@@ -55,7 +55,7 @@ private:
     TExecutorGCLogic* const GcLogic;
 
     ui64 CurrentDataCleanupGeneration = 0;
-    std::optional<ui64> NextDataCleanupGeneration;
+    ui64 NextDataCleanupGeneration = 0;
     EDataCleanupState State = EDataCleanupState::Idle;
     THashMap<ui32, TCleanupTableInfo> CompactingTables; // tracks statuses of compaction
 

--- a/ydb/core/tablet_flat/flat_executor_ut.cpp
+++ b/ydb/core/tablet_flat/flat_executor_ut.cpp
@@ -445,8 +445,8 @@ class TTestFlatTablet : public TActor<TTestFlatTablet>, public TTabletExecutedFl
         Send(Sender, new NFake::TEvCompacted(table));
     }
 
-    void DataCleanupComplete(const TActorContext&) override {
-        Send(Sender, new NFake::TEvDataCleaned());
+    void DataCleanupComplete(ui64 dataCleanupComplete, const TActorContext&) override {
+        Send(Sender, new NFake::TEvDataCleaned(dataCleanupComplete));
     }
 
     void ScanComplete(NTable::EAbort, TAutoPtr<IDestructable>, ui64 cookie, const TActorContext&) override

--- a/ydb/core/tablet_flat/tablet_flat_executor.cpp
+++ b/ydb/core/tablet_flat/tablet_flat_executor.cpp
@@ -20,7 +20,8 @@ namespace NFlatExecutorSetup {
         Y_UNUSED(ctx);
     }
 
-    void ITablet::DataCleanupComplete(const TActorContext& ctx) {
+    void ITablet::DataCleanupComplete(ui64 dataCleanupGeneration, const TActorContext& ctx) {
+        Y_UNUSED(dataCleanupGeneration);
         Y_UNUSED(ctx);
     }
 

--- a/ydb/core/tablet_flat/tablet_flat_executor.h
+++ b/ydb/core/tablet_flat/tablet_flat_executor.h
@@ -499,7 +499,7 @@ namespace NFlatExecutorSetup {
         virtual void SnapshotComplete(TIntrusivePtr<TTableSnapshotContext> snapContext, const TActorContext &ctx); // would be FAIL in default implementation
         virtual void CompletedLoansChanged(const TActorContext &ctx); // would be no-op in default implementation
         virtual void CompactionComplete(ui32 tableId, const TActorContext &ctx); // would be no-op in default implementation
-        virtual void DataCleanupComplete(const TActorContext& ctx);
+        virtual void DataCleanupComplete(ui64 dataCleanupGeneration, const TActorContext& ctx);
 
         virtual void ScanComplete(NTable::EAbort status, TAutoPtr<IDestructable> prod, ui64 cookie, const TActorContext &ctx);
 
@@ -634,7 +634,7 @@ namespace NFlatExecutorSetup {
 
         virtual void SetPreloadTablesData(THashSet<ui32> tables) = 0;
 
-        virtual void CleanupData() = 0;
+        virtual void CleanupData(ui64 dataCleanupGeneration) = 0;
 
         ui32 Generation() const { return Generation0; }
         ui32 Step() const { return Step0; }

--- a/ydb/core/tablet_flat/test/libs/exec/dummy.h
+++ b/ydb/core/tablet_flat/test/libs/exec/dummy.h
@@ -124,10 +124,10 @@ namespace NFake {
                 Send(Owner, new NFake::TEvCompacted(table));
         }
 
-        void DataCleanupComplete(const TActorContext&) override
+        void DataCleanupComplete(ui64 dataCleanupGeneration, const TActorContext&) override
         {
             if (Flags & ui32(EFlg::Clean))
-                Send(Owner, new NFake::TEvDataCleaned());
+                Send(Owner, new NFake::TEvDataCleaned(dataCleanupGeneration));
         }
 
         void SnapshotComplete(

--- a/ydb/core/tablet_flat/test/libs/exec/events.h
+++ b/ydb/core/tablet_flat/test/libs/exec/events.h
@@ -80,7 +80,11 @@ namespace NFake {
         ui64 Table;
     };
 
-    struct TEvDataCleaned : public TEventLocal<TEvDataCleaned, EvDataCleaned> { };
+    struct TEvDataCleaned : public TEventLocal<TEvDataCleaned, EvDataCleaned> {
+        TEvDataCleaned(ui64 dataCleanupGeneration) : DataCleanupGeneration(dataCleanupGeneration) { }
+
+        ui64 DataCleanupGeneration;
+    };
 
     struct TEvCompact : public TEventLocal<TEvCompact, EvCompact> {
         TEvCompact(ui32 table, bool memOnly = false)

--- a/ydb/core/testlib/basics/helpers.h
+++ b/ydb/core/testlib/basics/helpers.h
@@ -5,6 +5,7 @@
 #include <ydb/core/tablet_flat/shared_sausagecache.h>
 #include <ydb/core/util/defs.h>
 #include <ydb/core/base/blobstorage.h>
+#include <ydb/core/blobstorage/dsproxy/mock/model.h>
 #include <ydb/core/blobstorage/nodewarden/node_warden.h>
 #include <ydb/core/blobstorage/pdisk/blobstorage_pdisk.h>
 #include <ydb/core/blobstorage/pdisk/blobstorage_pdisk_factory.h>
@@ -57,7 +58,8 @@ namespace NFake {
 
     // StateStorage, NodeWarden, TabletResolver, ResourceBroker, SharedPageCache
     void SetupBasicServices(TTestActorRuntime &runtime, TAppPrepare &app, bool mockDisk = false,
-                            NFake::INode *factory = nullptr, NFake::TStorage storage = {}, const NSharedCache::TSharedCacheConfig* sharedCacheConfig = nullptr, bool forceFollowers = false);
+                            NFake::INode *factory = nullptr, NFake::TStorage storage = {}, const NSharedCache::TSharedCacheConfig* sharedCacheConfig = nullptr, bool forceFollowers = false,
+                            TVector<TIntrusivePtr<NFake::TProxyDS>> dsProxies = {});
 
     ///
     class TStrandedPDiskServiceFactory : public IPDiskServiceFactory {

--- a/ydb/core/testlib/basics/storage.h
+++ b/ydb/core/testlib/basics/storage.h
@@ -25,9 +25,10 @@ namespace NKikimr {
         static constexpr bool USE_SYNC_PDISK = false;
         static constexpr bool USE_MEM_SYNC_PDISK = true;
 
-        TTestStorageFactory(TRuntime &runtime, NFake::TStorage conf, bool mock)
+        TTestStorageFactory(TRuntime &runtime, NFake::TStorage conf, bool mock, bool addGroups)
             : DomainsNum(TBlobStorageGroupType(BootGroupErasure).BlobSubgroupSize())
             , Mock(mock)
+            , AddGroups(addGroups)
             , Conf(FixConf(conf))
             , Runtime(runtime)
         {
@@ -142,26 +143,28 @@ namespace NKikimr {
                 }
             }
 
-            str << "" << Endl;
-            str << "Groups {" << Endl;
-            str << "    GroupID: 0" << Endl;
-            str << "    GroupGeneration: 1 " << Endl;
-            str << "    ErasureSpecies: " << (ui32)BootGroupErasure << Endl;
+            if (AddGroups) {
+                str << "" << Endl;
+                str << "Groups {" << Endl;
+                str << "    GroupID: 0" << Endl;
+                str << "    GroupGeneration: 1 " << Endl;
+                str << "    ErasureSpecies: " << (ui32)BootGroupErasure << Endl;
 
-            for (const ui32 ringIdx : xrange(1)) {
-                str << "    Rings {" << Endl;
-                for (const ui32 domainIdx : xrange(DomainsNum)) {
-                    str << "        FailDomains {" << Endl;
-                    for (const ui32 vDiskIdx : xrange(DisksInDomain)) {
-                        ui32 slotId = vDiskIdx + domainIdx * DisksInDomain + ringIdx * DomainsNum * DisksInDomain;
-                        str << "            VDiskLocations { NodeID: " << Runtime.GetNodeId(0) << " PDiskID: 1 VDiskSlotID: " << slotId
-                            << " PDiskGuid: " << PDiskGuid << " }" << Endl;
+                for (const ui32 ringIdx : xrange(1)) {
+                    str << "    Rings {" << Endl;
+                    for (const ui32 domainIdx : xrange(DomainsNum)) {
+                        str << "        FailDomains {" << Endl;
+                        for (const ui32 vDiskIdx : xrange(DisksInDomain)) {
+                            ui32 slotId = vDiskIdx + domainIdx * DisksInDomain + ringIdx * DomainsNum * DisksInDomain;
+                            str << "            VDiskLocations { NodeID: " << Runtime.GetNodeId(0) << " PDiskID: 1 VDiskSlotID: " << slotId
+                                << " PDiskGuid: " << PDiskGuid << " }" << Endl;
+                        }
+                        str << "        }" << Endl;
                     }
-                    str << "        }" << Endl;
+                    str << "    }" << Endl;
                 }
-                str << "    }" << Endl;
+                str << "}";
             }
-            str << "}";
 
             return str.Str();
         }
@@ -170,6 +173,7 @@ namespace NKikimr {
         const ui32 DomainsNum = 0;
         const ui64 PDiskGuid = 123;
         const bool Mock = false;
+        const bool AddGroups = true;
         const NFake::TStorage Conf;
 
     private:

--- a/ydb/core/testlib/tablet_helpers.cpp
+++ b/ydb/core/testlib/tablet_helpers.cpp
@@ -640,13 +640,14 @@ namespace NKikimr {
     }
 
     void SetupTabletServices(TTestActorRuntime &runtime, TAppPrepare *app, bool mockDisk, NFake::TStorage storage,
-                            const NSharedCache::TSharedCacheConfig* sharedCacheConfig, bool forceFollowers) {
+                            const NSharedCache::TSharedCacheConfig* sharedCacheConfig, bool forceFollowers,
+                            TVector<TIntrusivePtr<NFake::TProxyDS>> dsProxies) {
         TAutoPtr<TAppPrepare> dummy;
         if (app == nullptr) {
             dummy = app = new TAppPrepare;
         }
         TUltimateNodes nodes(runtime, app);
-        SetupBasicServices(runtime, *app, mockDisk, &nodes, storage, sharedCacheConfig, forceFollowers);
+        SetupBasicServices(runtime, *app, mockDisk, &nodes, storage, sharedCacheConfig, forceFollowers, dsProxies);
     }
 
     TDomainsInfo::TDomain::TStoragePoolKinds DefaultPoolKinds(ui32 count) {

--- a/ydb/core/testlib/tablet_helpers.h
+++ b/ydb/core/testlib/tablet_helpers.h
@@ -6,6 +6,7 @@
 #include <ydb/core/base/blobstorage.h>
 #include <ydb/core/base/hive.h>
 #include <ydb/core/base/storage_pools.h>
+#include <ydb/core/blobstorage/dsproxy/mock/model.h>
 #include <ydb/core/blobstorage/pdisk/blobstorage_pdisk.h>
 #include <ydb/core/blobstorage/pdisk/blobstorage_pdisk_factory.h>
 #include <ydb/core/mind/hive/domain_info.h>
@@ -27,7 +28,8 @@ namespace NKikimr {
     void RebootTablet(TTestActorRuntime& runtime, ui64 tabletId, const TActorId& sender, ui32 nodeIndex = 0, bool sysTablet = false);
     void GracefulRestartTablet(TTestActorRuntime& runtime, ui64 tabletId, const TActorId& sender, ui32 nodeIndex = 0);
     void SetupTabletServices(TTestActorRuntime& runtime, TAppPrepare* app = nullptr, bool mockDisk = false,
-                             NFake::TStorage storage = {}, const NSharedCache::TSharedCacheConfig* sharedCacheConfig = nullptr, bool forceFollowers = false);
+                             NFake::TStorage storage = {}, const NSharedCache::TSharedCacheConfig* sharedCacheConfig = nullptr, bool forceFollowers = false,
+                             TVector<TIntrusivePtr<NFake::TProxyDS>> dsProxies = {});
 
     const TString DEFAULT_STORAGE_POOL = "Storage Pool with id: 1";
 

--- a/ydb/core/testlib/test_client.cpp
+++ b/ydb/core/testlib/test_client.cpp
@@ -549,7 +549,15 @@ namespace Tests {
         if (!Settings->AppConfig->HasSharedCacheConfig()) {
             Settings->AppConfig->MutableSharedCacheConfig()->SetMemoryLimit(32_MB);
         }
-        SetupTabletServices(*Runtime, &app, mockDisk, Settings->CustomDiskParams, &Settings->AppConfig->GetSharedCacheConfig(), Settings->EnableForceFollowers);
+
+        SetupTabletServices(
+            *Runtime,
+            &app,
+            mockDisk,
+            Settings->CustomDiskParams,
+            &Settings->AppConfig->GetSharedCacheConfig(),
+            Settings->EnableForceFollowers,
+            Settings->ProxyDSMocks);
 
         // WARNING: must be careful about modifying app data after actor system starts
 

--- a/ydb/core/testlib/test_client.h
+++ b/ydb/core/testlib/test_client.h
@@ -19,6 +19,8 @@
 #include <yql/essentials/minikql/mkql_program_builder.h>
 #include <yql/essentials/minikql/mkql_function_registry.h>
 #include <ydb/library/mkql_proto/protos/minikql.pb.h>
+#include <ydb/core/blobstorage/dsproxy/mock/dsproxy_mock.h>
+#include <ydb/core/blobstorage/dsproxy/mock/model.h>
 #include <ydb/core/protos/flat_scheme_op.pb.h>
 #include <ydb/core/testlib/basics/runtime.h>
 #include <ydb/core/testlib/basics/appdata.h>
@@ -107,6 +109,7 @@ namespace Tests {
         using TControls = NKikimrConfig::TImmediateControlsConfig;
         using TLoggerInitializer = std::function<void (TTestActorRuntime&)>;
         using TStoragePoolKinds = TDomainsInfo::TDomain::TStoragePoolKinds;
+        using TProxyDSPtr = TIntrusivePtr<NFake::TProxyDS>;
 
         ui16 Port;
         ui16 GrpcPort = 0;
@@ -167,6 +170,7 @@ namespace Tests {
         TString ServerCertFilePath;
         bool Verbose = true;
         bool UseSectorMap = false;
+        TVector<TProxyDSPtr> ProxyDSMocks;
 
         std::function<IActor*(const TTicketParserSettings&)> CreateTicketParser = NKikimr::CreateTicketParser;
         std::shared_ptr<TGrpcServiceFactory> GrpcServiceFactory;
@@ -254,6 +258,11 @@ namespace Tests {
 
         TServerSettings& SetColumnShardAlterObjectEnabled(bool enable) {
             AppConfig->MutableColumnShardConfig()->SetAlterObjectEnabled(enable);
+            return *this;
+        }
+
+        TServerSettings& SetProxyDSMocks(const TVector<TProxyDSPtr>& proxyDSMocks) {
+            ProxyDSMocks = proxyDSMocks;
             return *this;
         }
 

--- a/ydb/core/tx/datashard/datashard__data_cleanup.cpp
+++ b/ydb/core/tx/datashard/datashard__data_cleanup.cpp
@@ -32,7 +32,7 @@ public:
 
         NIceDb::TNiceDb db(txc.DB);
         ui64 lastGen = 0;
-        if (!Self->SysGetUi64(db, Schema::Sys_DataCleanupGeneration, lastGen)) {
+        if (!Self->SysGetUi64(db, Schema::Sys_DataCleanupCompletedGeneration, lastGen)) {
             return false;
         }
 
@@ -78,7 +78,7 @@ public:
     bool Execute(TTransactionContext& txc, const TActorContext& ctx) override {
         Y_UNUSED(ctx);
         NIceDb::TNiceDb db(txc.DB);
-        Self->PersistSys(db, Schema::Sys_DataCleanupGeneration, DataCleanupGeneration);
+        Self->PersistSys(db, Schema::Sys_DataCleanupCompletedGeneration, DataCleanupGeneration);
         return true;
     }
 

--- a/ydb/core/tx/datashard/datashard__data_cleanup.cpp
+++ b/ydb/core/tx/datashard/datashard__data_cleanup.cpp
@@ -2,14 +2,104 @@
 
 namespace NKikimr::NDataShard {
 
+class TDataShard::TTxDataCleanup : public NTabletFlatExecutor::TTransactionBase<TDataShard> {
+private:
+    TEvDataShard::TEvForceDataCleanup::TPtr Ev;
+
+public:
+    TTxDataCleanup(TDataShard* ds, TEvDataShard::TEvForceDataCleanup::TPtr ev)
+        : TBase(ds)
+        , Ev(ev)
+    {}
+
+    TTxType GetTxType() const override { return TXTYPE_DATA_CLEANUP; }
+
+    bool Execute(TTransactionContext& txc, const TActorContext& ctx) override {
+        auto& record = Ev->Get()->Record;
+
+        if (!Self->IsStateActive()) {
+            LOG_WARN_S(ctx, NKikimrServices::TX_DATASHARD,
+                "DataCleanup tx at non-ready tablet " << Self->TabletID()
+                << " state " << Self->State
+                << ", requested from " << Ev->Sender);
+            auto response = MakeHolder<TEvDataShard::TEvForceDataCleanupResult>(
+                record.GetDataCleanupGeneration(),
+                Self->TabletID(),
+                NKikimrTxDataShard::TEvForceDataCleanupResult::FAILED);
+            ctx.Send(Ev->Sender, std::move(response));
+            return true;
+        }
+
+        NIceDb::TNiceDb db(txc.DB);
+        ui64 lastGen = 0;
+        auto hasLastGen = Self->SysGetUi64(db, Schema::Sys_DataCleanupGeneration, lastGen);
+
+        if (hasLastGen && lastGen >= record.GetDataCleanupGeneration()) {
+            LOG_DEBUG_S(ctx, NKikimrServices::TX_DATASHARD,
+                "DataCleanup of tablet# " << Self->TabletID()
+                << " for requested generation " << record.GetDataCleanupGeneration()
+                << ", requested from# " << Ev->Sender
+                << " already completed"
+                << ", last persisted DataCleanup generation: " << lastGen);
+            auto response = MakeHolder<TEvDataShard::TEvForceDataCleanupResult>(
+                lastGen,
+                Self->TabletID(),
+                NKikimrTxDataShard::TEvForceDataCleanupResult::OK);
+            ctx.Send(Ev->Sender, std::move(response));
+            return true;
+        }
+
+        Self->Executor()->CleanupData(record.GetDataCleanupGeneration());
+        Self->DataCleanupWaiters.emplace_back(Ev->Sender);
+        return true;
+    }
+
+    void Complete(const TActorContext& ctx) override {
+        Y_UNUSED(ctx);
+    }
+};
+
+class TDataShard::TTxCompleteDataCleanup : public NTabletFlatExecutor::TTransactionBase<TDataShard> {
+private:
+    ui64 DataCleanupGeneration;
+
+public:
+    TTxCompleteDataCleanup(TDataShard* ds, ui64 dataCleanupGeneration)
+        : TBase(ds)
+        , DataCleanupGeneration(dataCleanupGeneration)
+    {}
+
+    TTxType GetTxType() const override { return TXTYPE_COMPLETE_DATA_CLEANUP; }
+
+    bool Execute(TTransactionContext& txc, const TActorContext& ctx) override {
+        Y_UNUSED(ctx);
+        NIceDb::TNiceDb db(txc.DB);
+        Self->PersistSys(db, Schema::Sys_DataCleanupGeneration, DataCleanupGeneration);
+        return true;
+    }
+
+    void Complete(const TActorContext& ctx) override {
+        // requested generations of all DataCleanupWaiters less or equal to dataCleanupGeneration
+        for (const auto& waiter : Self->DataCleanupWaiters) {
+            auto response = MakeHolder<TEvDataShard::TEvForceDataCleanupResult>(
+                DataCleanupGeneration,
+                Self->TabletID(),
+                NKikimrTxDataShard::TEvForceDataCleanupResult::OK);
+            ctx.Send(waiter, std::move(response));
+        }
+        Self->DataCleanupWaiters.clear();
+        LOG_DEBUG_S(ctx, NKikimrServices::TX_DATASHARD,
+            "Updated last DataCleanupof tablet# "<< Self->TabletID()
+            << ", last persisted DataCleanup generation: " << DataCleanupGeneration);
+    }
+};
+
 void TDataShard::Handle(TEvDataShard::TEvForceDataCleanup::TPtr& ev, const TActorContext& ctx) {
-    // TODO: implement
-    const auto& record = ev->Get()->Record;
-    auto result = MakeHolder<TEvDataShard::TEvForceDataCleanupResult>(
-        record.GetDataCleanupGeneration(),
-        TabletID(),
-        NKikimrTxDataShard::TEvForceDataCleanupResult::OK);
-    ctx.Send(ev->Sender, std::move(result));
+    Executor()->Execute(new TTxDataCleanup(this, ev), ctx);
+}
+
+void TDataShard::DataCleanupComplete(ui64 dataCleanupGeneration, const TActorContext& ctx) {
+    Executor()->Execute(new TTxCompleteDataCleanup(this, dataCleanupGeneration), ctx);
 }
 
 } // namespace NKikimr::NDataShard

--- a/ydb/core/tx/datashard/datashard_impl.h
+++ b/ydb/core/tx/datashard/datashard_impl.h
@@ -1160,7 +1160,7 @@ class TDataShard
             Sys_InMemoryStateActorId = 45,
             Sys_InMemoryStateGeneration = 46,
 
-            Sys_DataCleanupGeneration = 47,
+            Sys_DataCleanupCompletedGeneration = 47,
 
             // reserved
             SysPipeline_Flags = 1000,

--- a/ydb/core/tx/datashard/datashard_impl.h
+++ b/ydb/core/tx/datashard/datashard_impl.h
@@ -234,6 +234,8 @@ class TDataShard
     class TTxUpdateFollowerReadEdge;
     class TTxRemoveSchemaSnapshots;
     class TTxCleanupUncommitted;
+    class TTxDataCleanup;
+    class TTxCompleteDataCleanup;
 
     template <typename T> friend class TTxDirectBase;
     class TTxUploadRows;
@@ -1158,6 +1160,8 @@ class TDataShard
             Sys_InMemoryStateActorId = 45,
             Sys_InMemoryStateGeneration = 46,
 
+            Sys_DataCleanupGeneration = 47,
+
             // reserved
             SysPipeline_Flags = 1000,
             SysPipeline_LimitActiveTx,
@@ -1777,6 +1781,7 @@ public:
     void SnapshotComplete(TIntrusivePtr<NTabletFlatExecutor::TTableSnapshotContext> snapContext, const TActorContext &ctx) override;
     void CompactionComplete(ui32 tableId, const TActorContext &ctx) override;
     void CompletedLoansChanged(const TActorContext &ctx) override;
+    void DataCleanupComplete(ui64 dataCleanupGeneration, const TActorContext &ctx) override;
 
     void ReplyCompactionWaiters(
         ui32 tableId,
@@ -2972,6 +2977,8 @@ private:
     // from the front
     THashMap<ui32, TCompactionWaiterList> CompactionWaiters;
 
+    TVector<TActorId> DataCleanupWaiters;
+
     struct TCompactBorrowedWaiter : public TThrRefBase {
         TCompactBorrowedWaiter(TActorId actorId, TLocalPathId requestedTable)
             : ActorId(actorId)
@@ -3021,6 +3028,8 @@ private:
 
     ui32 StatisticsScanTableId = 0;
     ui64 StatisticsScanId = 0;
+
+    ui64 CurrentDataCleanupGeneration = 0;
 
 public:
     auto& GetLockChangeRecords() {

--- a/ydb/core/tx/datashard/datashard_impl.h
+++ b/ydb/core/tx/datashard/datashard_impl.h
@@ -2977,7 +2977,7 @@ private:
     // from the front
     THashMap<ui32, TCompactionWaiterList> CompactionWaiters;
 
-    TVector<TActorId> DataCleanupWaiters;
+    TMap<ui64, TActorId> DataCleanupWaiters;
 
     struct TCompactBorrowedWaiter : public TThrRefBase {
         TCompactBorrowedWaiter(TActorId actorId, TLocalPathId requestedTable)

--- a/ydb/core/tx/datashard/datashard_ut_data_cleanup.cpp
+++ b/ydb/core/tx/datashard/datashard_ut_data_cleanup.cpp
@@ -5,29 +5,148 @@ namespace NKikimr {
 using namespace Tests;
 
 Y_UNIT_TEST_SUITE(DataCleanup) {
-    Y_UNIT_TEST(ForceDataCleanup) {
+    std::tuple<Tests::TServer::TPtr, TActorId, TVector<ui64>> SetupWithTable() {
         TPortManager pm;
         TServerSettings serverSettings(pm.GetPort(2134));
         serverSettings.SetDomainName("Root")
             .SetUseRealThreads(false);
 
-        Tests::TServer::TPtr server = new TServer(serverSettings);
-        auto &runtime = *server->GetRuntime();
+        Tests::TServer::TPtr server = MakeIntrusive<TServer>(serverSettings);
+        auto& runtime = *server->GetRuntime();
         auto sender = runtime.AllocateEdgeActor();
 
         InitRoot(server, sender);
 
         auto [shards, tableId] = CreateShardedTable(server, sender, "/Root", "table-1", 1);
+        ExecSQL(server, sender, "UPSERT INTO `/Root/table-1` (key, value) VALUES (1, 100), (2, 200), (3, 300), (4, 400);");
+        ExecSQL(server, sender, "DELETE FROM `/Root/table-1` WHERE key IN (1, 2, 4);");
 
-        ui64 expectedDataCleanupGeneration = 42;
-        auto request = MakeHolder<TEvDataShard::TEvForceDataCleanup>(expectedDataCleanupGeneration);
+        return {server, sender, shards};
+    }
 
-        runtime.SendToPipe(shards.at(0), sender, request.Release(), 0, GetPipeConfigWithRetries());
+    Y_UNIT_TEST(ForceDataCleanup) {
+        auto [server, sender, tableShards] = SetupWithTable();
+        auto& runtime = *server->GetRuntime();
 
-        auto ev = runtime.GrabEdgeEventRethrow<TEvDataShard::TEvForceDataCleanupResult>(sender);
-        UNIT_ASSERT_VALUES_EQUAL(ev->Get()->Record.GetDataCleanupGeneration(), expectedDataCleanupGeneration);
-        UNIT_ASSERT_VALUES_EQUAL(ev->Get()->Record.GetTabletId(), shards.at(0));
-        UNIT_ASSERT_EQUAL(ev->Get()->Record.GetStatus(), NKikimrTxDataShard::TEvForceDataCleanupResult::OK);
+        auto cleanupAndCheck = [&runtime, &sender, &tableShards](ui64 expectedDataCleanupGeneration) {
+            auto request = MakeHolder<TEvDataShard::TEvForceDataCleanup>(expectedDataCleanupGeneration);
+
+            runtime.SendToPipe(tableShards.at(0), sender, request.Release(), 0, GetPipeConfigWithRetries());
+
+            auto ev = runtime.GrabEdgeEventRethrow<TEvDataShard::TEvForceDataCleanupResult>(sender);
+            UNIT_ASSERT_EQUAL(ev->Get()->Record.GetStatus(), NKikimrTxDataShard::TEvForceDataCleanupResult::OK);
+            UNIT_ASSERT_VALUES_EQUAL(ev->Get()->Record.GetDataCleanupGeneration(), expectedDataCleanupGeneration);
+        };
+
+        cleanupAndCheck(24);
+        cleanupAndCheck(24);
+        cleanupAndCheck(25);
+
+        auto result = ReadShardedTable(server, "/Root/table-1");
+        UNIT_ASSERT_VALUES_EQUAL(result, "key = 3, value = 300\n");
+    }
+
+    Y_UNIT_TEST(MultipleDataCleanups) {
+        auto [server, sender, tableShards] = SetupWithTable();
+        auto& runtime = *server->GetRuntime();
+
+        ui64 expectedGenFirst = 42;
+        ui64 expectedGenLast = 43;
+        auto request1 = MakeHolder<TEvDataShard::TEvForceDataCleanup>(expectedGenFirst);
+        auto request2 = MakeHolder<TEvDataShard::TEvForceDataCleanup>(expectedGenLast);
+
+        runtime.SendToPipe(tableShards.at(0), sender, request1.Release(), 0, GetPipeConfigWithRetries());
+        runtime.SendToPipe(tableShards.at(0), sender, request2.Release(), 0, GetPipeConfigWithRetries());
+
+        {
+            auto ev = runtime.GrabEdgeEventRethrow<TEvDataShard::TEvForceDataCleanupResult>(sender);
+            UNIT_ASSERT_EQUAL(ev->Get()->Record.GetStatus(), NKikimrTxDataShard::TEvForceDataCleanupResult::OK);
+            UNIT_ASSERT_VALUES_EQUAL(ev->Get()->Record.GetDataCleanupGeneration(), expectedGenLast);
+        }
+
+        {
+            auto ev = runtime.GrabEdgeEventRethrow<TEvDataShard::TEvForceDataCleanupResult>(sender);
+            UNIT_ASSERT_EQUAL(ev->Get()->Record.GetStatus(), NKikimrTxDataShard::TEvForceDataCleanupResult::OK);
+            UNIT_ASSERT_VALUES_EQUAL(ev->Get()->Record.GetDataCleanupGeneration(), expectedGenLast);
+        }
+
+        auto result = ReadShardedTable(server, "/Root/table-1");
+        UNIT_ASSERT_VALUES_EQUAL(result, "key = 3, value = 300\n");
+    }
+
+    Y_UNIT_TEST(MultipleDataCleanupsWithOldGenerations) {
+        auto [server, sender, tableShards] = SetupWithTable();
+        auto& runtime = *server->GetRuntime();
+
+        ui64 expectedGenFirst = 42;
+        ui64 expectedGenOld = 10;
+        auto request1 = MakeHolder<TEvDataShard::TEvForceDataCleanup>(expectedGenFirst);
+        auto request2 = MakeHolder<TEvDataShard::TEvForceDataCleanup>(expectedGenOld);
+
+        runtime.SendToPipe(tableShards.at(0), sender, request1.Release(), 0, GetPipeConfigWithRetries());
+        runtime.SendToPipe(tableShards.at(0), sender, request2.Release(), 0, GetPipeConfigWithRetries());
+
+        {
+            auto ev = runtime.GrabEdgeEventRethrow<TEvDataShard::TEvForceDataCleanupResult>(sender);
+            UNIT_ASSERT_EQUAL(ev->Get()->Record.GetStatus(), NKikimrTxDataShard::TEvForceDataCleanupResult::OK);
+            UNIT_ASSERT_VALUES_EQUAL(ev->Get()->Record.GetDataCleanupGeneration(), expectedGenFirst);
+        }
+
+        {
+            auto ev = runtime.GrabEdgeEventRethrow<TEvDataShard::TEvForceDataCleanupResult>(sender);
+            UNIT_ASSERT_EQUAL(ev->Get()->Record.GetStatus(), NKikimrTxDataShard::TEvForceDataCleanupResult::OK);
+            UNIT_ASSERT_VALUES_EQUAL(ev->Get()->Record.GetDataCleanupGeneration(), expectedGenFirst);
+        }
+
+        auto result = ReadShardedTable(server, "/Root/table-1");
+        UNIT_ASSERT_VALUES_EQUAL(result, "key = 3, value = 300\n");
+    }
+
+    Y_UNIT_TEST(ForceDataCleanupWithRestart) {
+        auto [server, sender, tableShards] = SetupWithTable();
+        auto& runtime = *server->GetRuntime();
+
+        ui64 cleanupGeneration = 33;
+        ui64 oldGeneration = 10;
+        ui64 olderGeneration = 5;
+
+        {
+            auto request = MakeHolder<TEvDataShard::TEvForceDataCleanup>(cleanupGeneration);
+
+            runtime.SendToPipe(tableShards.at(0), sender, request.Release(), 0, GetPipeConfigWithRetries());
+
+            auto ev = runtime.GrabEdgeEventRethrow<TEvDataShard::TEvForceDataCleanupResult>(sender);
+            UNIT_ASSERT_EQUAL(ev->Get()->Record.GetStatus(), NKikimrTxDataShard::TEvForceDataCleanupResult::OK);
+            UNIT_ASSERT_VALUES_EQUAL(ev->Get()->Record.GetDataCleanupGeneration(), cleanupGeneration);
+        }
+
+        {
+            auto request = MakeHolder<TEvDataShard::TEvForceDataCleanup>(oldGeneration);
+
+            runtime.SendToPipe(tableShards.at(0), sender, request.Release(), 0, GetPipeConfigWithRetries());
+
+            auto ev = runtime.GrabEdgeEventRethrow<TEvDataShard::TEvForceDataCleanupResult>(sender);
+            UNIT_ASSERT_EQUAL(ev->Get()->Record.GetStatus(), NKikimrTxDataShard::TEvForceDataCleanupResult::OK);
+            UNIT_ASSERT_VALUES_EQUAL(ev->Get()->Record.GetDataCleanupGeneration(), cleanupGeneration);
+        }
+
+        // restart tablet
+        SendViaPipeCache(runtime, tableShards.at(0), sender, std::make_unique<TEvents::TEvPoison>());
+        runtime.SimulateSleep(TDuration::Seconds(1));
+
+        {
+            auto request = MakeHolder<TEvDataShard::TEvForceDataCleanup>(olderGeneration);
+
+            runtime.SendToPipe(tableShards.at(0), sender, request.Release(), 0, GetPipeConfigWithRetries());
+
+            auto ev = runtime.GrabEdgeEventRethrow<TEvDataShard::TEvForceDataCleanupResult>(sender);
+            UNIT_ASSERT_EQUAL(ev->Get()->Record.GetStatus(), NKikimrTxDataShard::TEvForceDataCleanupResult::OK);
+            // more recent generation should be persisted
+            UNIT_ASSERT_VALUES_EQUAL(ev->Get()->Record.GetDataCleanupGeneration(), cleanupGeneration);
+        }
+
+        auto result = ReadShardedTable(server, "/Root/table-1");
+        UNIT_ASSERT_VALUES_EQUAL(result, "key = 3, value = 300\n");
     }
 }
 


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of changes introduced in this PR -->

### Changelog category <!-- remove all except one -->

* Not for changelog (changelog entry is not required)

### Additional information

- Start cleanup in LocalDb by TEvForceDataCleanup event
- Add Status in TEvForceDataCleanupResult
- Support Generation logic in localDB
- Persist last succesfull Generation
