### PR TITLE
don't limit volume of evicted data

### DIFF
--- a/ydb/core/tx/columnshard/counters/aggregation/table_stats.h
+++ b/ydb/core/tx/columnshard/counters/aggregation/table_stats.h
@@ -25,10 +25,11 @@ private:
                 bytesInBlobStorage += dataSize;
             }
         }
-        // TODO: Report total volume of table's data after migration to separate quotas by storage kinds.
+        // TODO: Report total volume of table's data in DataSize after migration
+        // to separate quotas by storage kinds:
         // https://github.com/ydb-platform/ydb-rfc/blob/main/per_storage_kind_quotas.md#migration
-        // Reason: TTableStats::DataSize is used for limiting storage consumption, but also for displaying
-        // total volume of table's data in UI.
+        // Reason: TTableStats::DataSize is currently used for limiting storage
+        // consumption, but also shown as total volume of table's data in UI.
         to.SetDataSize(bytesInBlobStorage);
     }
 

--- a/ydb/core/tx/columnshard/counters/aggregation/table_stats.h
+++ b/ydb/core/tx/columnshard/counters/aggregation/table_stats.h
@@ -16,14 +16,11 @@ private:
     void FillPortionStats(::NKikimrTableStats::TTableStats& to, const NOlap::TColumnEngineStats::TPortionsStats& from) const {
         to.SetRowCount(from.Rows);
         ui64 bytesInBlobStorage = 0;
-        for (ui32 ch = 0; ch < from.BytesByChannel.size(); ch++) {
-            ui64 dataSize = from.BytesByChannel[ch];
-            if (dataSize > 0) {
-                auto item = to.AddChannels();
-                item->SetChannel(ch);
-                item->SetDataSize(dataSize);
-                bytesInBlobStorage += dataSize;
-            }
+        for (const auto& [channel, bytes] : from.BytesByChannel) {
+            auto item = to.AddChannels();
+            item->SetChannel(channel);
+            item->SetDataSize(bytes);
+            bytesInBlobStorage += bytes;
         }
         to.SetDataSize(bytesInBlobStorage);
     }

--- a/ydb/core/tx/columnshard/counters/aggregation/table_stats.h
+++ b/ydb/core/tx/columnshard/counters/aggregation/table_stats.h
@@ -25,6 +25,10 @@ private:
                 bytesInBlobStorage += dataSize;
             }
         }
+        // TODO: Report total volume of table's data after migration to separate quotas by storage kinds.
+        // https://github.com/ydb-platform/ydb-rfc/blob/main/per_storage_kind_quotas.md#migration
+        // Reason: TTableStats::DataSize is used for limiting storage consumption, but also for displaying
+        // total volume of table's data in UI.
         to.SetDataSize(bytesInBlobStorage);
     }
 

--- a/ydb/core/tx/columnshard/counters/aggregation/table_stats.h
+++ b/ydb/core/tx/columnshard/counters/aggregation/table_stats.h
@@ -22,11 +22,6 @@ private:
             item->SetDataSize(bytes);
             bytesInBlobStorage += bytes;
         }
-        // TODO: Report total volume of table's data in DataSize after migration
-        // to separate quotas by storage kinds:
-        // https://github.com/ydb-platform/ydb-rfc/blob/main/per_storage_kind_quotas.md#migration
-        // Reason: TTableStats::DataSize is currently used for limiting storage
-        // consumption, but also shown as total volume of table's data in UI.
         to.SetDataSize(bytesInBlobStorage);
     }
 

--- a/ydb/core/tx/columnshard/engines/column_engine.h
+++ b/ydb/core/tx/columnshard/engines/column_engine.h
@@ -94,7 +94,7 @@ public:
             result.Bytes = kff * Bytes;
             result.RawBytes = kff * RawBytes;
             for (const auto& [channel, bytes] : BytesByChannel) {
-                result.BytesByChannel[channel] = bytes * kff;
+                result.BytesByChannel[channel] = kff * bytes;
             }
             return result;
         }

--- a/ydb/core/tx/columnshard/engines/column_engine.h
+++ b/ydb/core/tx/columnshard/engines/column_engine.h
@@ -74,7 +74,7 @@ public:
         i64 Rows = 0;
         i64 Bytes = 0;
         i64 RawBytes = 0;
-        std::vector<i64> ByChannel;
+        std::vector<i64> BytesByChannel;
 
         TString DebugString() const {
             return TStringBuilder() << "portions=" << Portions << ";blobs=" << Blobs << ";rows=" << Rows << ";bytes=" << Bytes
@@ -93,9 +93,9 @@ public:
             result.Rows = kff * Rows;
             result.Bytes = kff * Bytes;
             result.RawBytes = kff * RawBytes;
-            result.ByChannel.reserve(ByChannel.size());
-            for (ui64 channelBytes: ByChannel) {
-                result.ByChannel.push_back(channelBytes * kff);
+            result.BytesByChannel.reserve(BytesByChannel.size());
+            for (i64 channelBytes: BytesByChannel) {
+                result.BytesByChannel.push_back(kff * channelBytes);
             }
             return result;
         }
@@ -110,11 +110,11 @@ public:
             Rows = SumVerifiedPositive(Rows, item.Rows);
             Bytes = SumVerifiedPositive(Bytes, item.Bytes);
             RawBytes = SumVerifiedPositive(RawBytes, item.RawBytes);
-            if (ByChannel.size() < item.ByChannel.size()) {
-                ByChannel.resize(item.ByChannel.size());
+            if (BytesByChannel.size() < item.BytesByChannel.size()) {
+                BytesByChannel.resize(item.BytesByChannel.size());
             }
-            for (ui32 ch = 0; ch < item.ByChannel.size(); ch++) {
-                ByChannel[ch] = SumVerifiedPositive(ByChannel[ch], item.ByChannel[ch]);
+            for (ui32 ch = 0; ch < item.BytesByChannel.size(); ch++) {
+                BytesByChannel[ch] = SumVerifiedPositive(BytesByChannel[ch], item.BytesByChannel[ch]);
             }
             return *this;
         }

--- a/ydb/core/tx/columnshard/engines/column_engine.h
+++ b/ydb/core/tx/columnshard/engines/column_engine.h
@@ -60,21 +60,13 @@ private:
 
 public:
     class TPortionsStats {
-    private:
-        template <class T>
-        T SumVerifiedPositive(const T v1, const T v2) const {
-            T result = v1 + v2;
-            Y_ABORT_UNLESS(result >= 0);
-            return result;
-        }
-
     public:
-        i64 Portions = 0;
-        i64 Blobs = 0;
-        i64 Rows = 0;
-        i64 Bytes = 0;
-        i64 RawBytes = 0;
-        THashMap<ui32, i64> BytesByChannel;
+        TPositiveControlInteger Portions;
+        TPositiveControlInteger Blobs;
+        TPositiveControlInteger Rows;
+        TPositiveControlInteger Bytes;
+        TPositiveControlInteger RawBytes;
+        THashMap<ui32, TPositiveControlInteger> BytesByChannel;
 
         TString DebugString() const {
             return TStringBuilder() << "portions=" << Portions << ";blobs=" << Blobs << ";rows=" << Rows << ";bytes=" << Bytes
@@ -100,17 +92,27 @@ public:
         }
 
         TPortionsStats& operator-=(const TPortionsStats& item) {
-            return *this += item * -1;
+            Portions.Sub(item.Portions);
+            Blobs.Sub(item.Blobs);
+            Rows.Sub(item.Rows);
+            Bytes.Sub(item.Bytes);
+            RawBytes.Sub(item.RawBytes);
+            for (const auto& [channel, bytes] : item.BytesByChannel) {
+                auto findChannel = BytesByChannel.FindPtr(channel);
+                AFL_VERIFY(findChannel)("channel", channel);
+                findChannel->Sub(bytes);
+            }
+            return *this;
         }
 
         TPortionsStats& operator+=(const TPortionsStats& item) {
-            Portions = SumVerifiedPositive(Portions, item.Portions);
-            Blobs = SumVerifiedPositive(Blobs, item.Blobs);
-            Rows = SumVerifiedPositive(Rows, item.Rows);
-            Bytes = SumVerifiedPositive(Bytes, item.Bytes);
-            RawBytes = SumVerifiedPositive(RawBytes, item.RawBytes);
+            Portions.Add(item.Portions);
+            Blobs.Add(item.Blobs);
+            Rows.Add(item.Rows);
+            Bytes.Add(item.Bytes);
+            RawBytes.Add(item.RawBytes);
             for (const auto& [channel, bytes] : item.BytesByChannel) {
-                BytesByChannel[channel] = SumVerifiedPositive(BytesByChannel[channel], bytes);
+                BytesByChannel[channel].Add(bytes);
             }
             return *this;
         }

--- a/ydb/core/tx/columnshard/engines/column_engine.h
+++ b/ydb/core/tx/columnshard/engines/column_engine.h
@@ -74,7 +74,7 @@ public:
         i64 Rows = 0;
         i64 Bytes = 0;
         i64 RawBytes = 0;
-        std::vector<i64> BytesByChannel;
+        THashMap<ui32, i64> BytesByChannel;
 
         TString DebugString() const {
             return TStringBuilder() << "portions=" << Portions << ";blobs=" << Blobs << ";rows=" << Rows << ";bytes=" << Bytes
@@ -93,9 +93,8 @@ public:
             result.Rows = kff * Rows;
             result.Bytes = kff * Bytes;
             result.RawBytes = kff * RawBytes;
-            result.BytesByChannel.reserve(BytesByChannel.size());
-            for (i64 channelBytes: BytesByChannel) {
-                result.BytesByChannel.push_back(kff * channelBytes);
+            for (const auto& [channel, bytes] : BytesByChannel) {
+                result.BytesByChannel[channel] = bytes * kff;
             }
             return result;
         }
@@ -110,11 +109,8 @@ public:
             Rows = SumVerifiedPositive(Rows, item.Rows);
             Bytes = SumVerifiedPositive(Bytes, item.Bytes);
             RawBytes = SumVerifiedPositive(RawBytes, item.RawBytes);
-            if (BytesByChannel.size() < item.BytesByChannel.size()) {
-                BytesByChannel.resize(item.BytesByChannel.size());
-            }
-            for (ui32 ch = 0; ch < item.BytesByChannel.size(); ch++) {
-                BytesByChannel[ch] = SumVerifiedPositive(BytesByChannel[ch], item.BytesByChannel[ch]);
+            for (const auto& [channel, bytes] : item.BytesByChannel) {
+                BytesByChannel[channel] = SumVerifiedPositive(BytesByChannel[channel], bytes);
             }
             return *this;
         }

--- a/ydb/core/tx/columnshard/engines/column_engine_logs.cpp
+++ b/ydb/core/tx/columnshard/engines/column_engine_logs.cpp
@@ -92,10 +92,8 @@ TColumnEngineStats::TPortionsStats DeltaStats(const TPortionInfo& portionInfo) {
     deltaStats.RawBytes = portionInfo.GetTotalRawBytes();
     deltaStats.Blobs = portionInfo.GetBlobIdsCount();
     deltaStats.Portions = 1;
-    deltaStats.BytesByChannel.resize(portionInfo.GetBlobIdsCount());
     for (const auto& blob : portionInfo.GetBlobIds()) {
         const ui32 channel = blob.Channel();
-        AFL_VERIFY(deltaStats.BytesByChannel.size() > channel)("channel", channel)("size", deltaStats.BytesByChannel.size());
         deltaStats.BytesByChannel[channel] += blob.BlobSize();
     }
     return deltaStats;

--- a/ydb/core/tx/columnshard/engines/column_engine_logs.cpp
+++ b/ydb/core/tx/columnshard/engines/column_engine_logs.cpp
@@ -86,15 +86,14 @@ void TColumnEngineForLogs::UpdatePortionStats(const TPortionInfo& portionInfo, E
 
 TColumnEngineStats::TPortionsStats DeltaStats(const TPortionInfo& portionInfo) {
     TColumnEngineStats::TPortionsStats deltaStats;
-    deltaStats.Bytes = 0;
+    deltaStats.Bytes = 0u;
     deltaStats.Rows = portionInfo.GetRecordsCount();
     deltaStats.Bytes = portionInfo.GetTotalBlobBytes();
     deltaStats.RawBytes = portionInfo.GetTotalRawBytes();
     deltaStats.Blobs = portionInfo.GetBlobIdsCount();
-    deltaStats.Portions = 1;
+    deltaStats.Portions = 1u;
     for (const auto& blob : portionInfo.GetBlobIds()) {
-        const ui32 channel = blob.Channel();
-        deltaStats.BytesByChannel[channel] += blob.BlobSize();
+        deltaStats.BytesByChannel[blob.Channel()].Add(blob.BlobSize());
     }
     return deltaStats;
 }

--- a/ydb/core/tx/columnshard/engines/column_engine_logs.cpp
+++ b/ydb/core/tx/columnshard/engines/column_engine_logs.cpp
@@ -86,7 +86,6 @@ void TColumnEngineForLogs::UpdatePortionStats(const TPortionInfo& portionInfo, E
 
 TColumnEngineStats::TPortionsStats DeltaStats(const TPortionInfo& portionInfo) {
     TColumnEngineStats::TPortionsStats deltaStats;
-    deltaStats.Bytes = 0u;
     deltaStats.Rows = portionInfo.GetRecordsCount();
     deltaStats.Bytes = portionInfo.GetTotalBlobBytes();
     deltaStats.RawBytes = portionInfo.GetTotalRawBytes();

--- a/ydb/core/tx/columnshard/engines/column_engine_logs.cpp
+++ b/ydb/core/tx/columnshard/engines/column_engine_logs.cpp
@@ -92,25 +92,18 @@ TColumnEngineStats::TPortionsStats DeltaStats(const TPortionInfo& portionInfo) {
     deltaStats.RawBytes = portionInfo.GetTotalRawBytes();
     deltaStats.Blobs = portionInfo.GetBlobIdsCount();
     deltaStats.Portions = 1;
+    deltaStats.BytesByChannel.resize(portionInfo.GetBlobIdsCount());
+    for (const auto& blob : portionInfo.GetBlobIds()) {
+        const ui32 channel = blob.Channel();
+        AFL_VERIFY(deltaStats.BytesByChannel.size() > channel)("channel", channel)("size", deltaStats.BytesByChannel.size());
+        deltaStats.BytesByChannel[channel] += blob.BlobSize();
+    }
     return deltaStats;
 }
 
 void TColumnEngineForLogs::UpdatePortionStats(
     TColumnEngineStats& engineStats, const TPortionInfo& portionInfo, EStatsUpdateType updateType, const TPortionInfo* exPortionInfo) const {
     TColumnEngineStats::TPortionsStats deltaStats = DeltaStats(portionInfo);
-
-    ui64 totalBlobsSize = 0;
-    ui32 blobCount = portionInfo.GetBlobIdsCount();
-    for (ui32 i = 0; i < blobCount; i++) {
-        const auto& blob = portionInfo.GetBlobId(i);
-        ui32 channel = blob.Channel();
-        if (deltaStats.ByChannel.size() <= channel) {
-            deltaStats.ByChannel.resize(channel + 1);
-        }
-        deltaStats.ByChannel[channel] += blob.BlobSize();
-        totalBlobsSize += blob.BlobSize();
-    }
-    AFL_DEBUG(NKikimrServices::TX_COLUMNSHARD)("event", "update_portion")("blobs_size", totalBlobsSize)("portion_bytes", deltaStats.Bytes)("portion_raw_bytes", deltaStats.RawBytes);
 
     Y_ABORT_UNLESS(!exPortionInfo || exPortionInfo->GetMeta().Produced != TPortionMeta::EProduced::UNSPECIFIED);
     Y_ABORT_UNLESS(portionInfo.GetMeta().Produced != TPortionMeta::EProduced::UNSPECIFIED);


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of changes introduced in this PR -->

Don't limit volume of evicted data in OLAP tables

### Changelog category <!-- remove all except one -->

* Improvement

### Additional information

Убрал учёт вытесненных данных в Table.DataSize в статистике таблицы