### PR TITLE
kesus resources: dump

### DIFF
--- a/ydb/library/backup/ya.make
+++ b/ydb/library/backup/ya.make
@@ -16,6 +16,7 @@ PEERDIR(
     ydb/public/sdk/cpp/src/client/draft
     ydb/public/sdk/cpp/src/client/driver
     ydb/public/sdk/cpp/src/client/proto
+    ydb/public/sdk/cpp/src/client/rate_limiter
     ydb/public/sdk/cpp/src/client/result
     ydb/public/sdk/cpp/src/client/table
     ydb/public/sdk/cpp/src/client/topic

--- a/ydb/public/lib/ydb_cli/dump/files/files.cpp
+++ b/ydb/public/lib/ydb_cli/dump/files/files.cpp
@@ -9,6 +9,7 @@ enum EFilesType {
     TOPIC_DESCRIPTION,
     CREATE_TOPIC,
     CREATE_COORDINATION_NODE,
+    CREATE_RESOURCE,
     INCOMPLETE_DATA,
     INCOMPLETE,
     EMPTY,
@@ -22,6 +23,7 @@ static constexpr TFileInfo FILES_INFO[] = {
     {"topic_description.pb", "topic"},
     {"create_topic.pb", "topic"},
     {"create_coordination_node.pb", "coordination node"},
+    {"create_resource.pb", "coordination node resource"},
     {"incomplete.csv", "incomplete"},
     {"incomplete", "incomplete"},
     {"empty_dir", "empty_dir"},
@@ -50,6 +52,10 @@ const TFileInfo& CreateTopic() {
 
 const TFileInfo& CreateCoordinationNode() {
     return FILES_INFO[CREATE_COORDINATION_NODE];
+}
+
+const TFileInfo& CreateResource() {
+    return FILES_INFO[CREATE_RESOURCE];
 }
 
 const TFileInfo& IncompleteData() {

--- a/ydb/public/lib/ydb_cli/dump/files/files.cpp
+++ b/ydb/public/lib/ydb_cli/dump/files/files.cpp
@@ -9,7 +9,7 @@ enum EFilesType {
     TOPIC_DESCRIPTION,
     CREATE_TOPIC,
     CREATE_COORDINATION_NODE,
-    CREATE_RESOURCE,
+    CREATE_RATE_LIMITER,
     INCOMPLETE_DATA,
     INCOMPLETE,
     EMPTY,
@@ -23,7 +23,7 @@ static constexpr TFileInfo FILES_INFO[] = {
     {"topic_description.pb", "topic"},
     {"create_topic.pb", "topic"},
     {"create_coordination_node.pb", "coordination node"},
-    {"create_resource.pb", "coordination node resource"},
+    {"create_rate_limiter.pb", "rate limiter"},
     {"incomplete.csv", "incomplete"},
     {"incomplete", "incomplete"},
     {"empty_dir", "empty_dir"},
@@ -54,8 +54,8 @@ const TFileInfo& CreateCoordinationNode() {
     return FILES_INFO[CREATE_COORDINATION_NODE];
 }
 
-const TFileInfo& CreateResource() {
-    return FILES_INFO[CREATE_RESOURCE];
+const TFileInfo& CreateRateLimiter() {
+    return FILES_INFO[CREATE_RATE_LIMITER];
 }
 
 const TFileInfo& IncompleteData() {

--- a/ydb/public/lib/ydb_cli/dump/files/files.h
+++ b/ydb/public/lib/ydb_cli/dump/files/files.h
@@ -13,7 +13,7 @@ const TFileInfo& Changefeed();
 const TFileInfo& TopicDescription();
 const TFileInfo& CreateTopic();
 const TFileInfo& CreateCoordinationNode();
-const TFileInfo& CreateResource();
+const TFileInfo& CreateRateLimiter();
 const TFileInfo& IncompleteData();
 const TFileInfo& Incomplete();
 const TFileInfo& Empty();

--- a/ydb/public/lib/ydb_cli/dump/files/files.h
+++ b/ydb/public/lib/ydb_cli/dump/files/files.h
@@ -13,6 +13,7 @@ const TFileInfo& Changefeed();
 const TFileInfo& TopicDescription();
 const TFileInfo& CreateTopic();
 const TFileInfo& CreateCoordinationNode();
+const TFileInfo& CreateResource();
 const TFileInfo& IncompleteData();
 const TFileInfo& Incomplete();
 const TFileInfo& Empty();

--- a/ydb/public/sdk/cpp/include/ydb-cpp-sdk/client/rate_limiter/rate_limiter.h
+++ b/ydb/public/sdk/cpp/include/ydb-cpp-sdk/client/rate_limiter/rate_limiter.h
@@ -91,6 +91,7 @@ using TAsyncListResourcesResult = NThreading::TFuture<TListResourcesResult>;
 struct TDescribeResourceResult : public TStatus {
     struct THierarchicalDrrProps {
         THierarchicalDrrProps(const Ydb::RateLimiter::HierarchicalDrrSettings&);
+        void SerializeTo(Ydb::RateLimiter::HierarchicalDrrSettings&) const;
 
         // Resource consumption speed limit.
         std::optional<double> GetMaxUnitsPerSecond() const {

--- a/ydb/public/sdk/cpp/src/client/rate_limiter/rate_limiter.cpp
+++ b/ydb/public/sdk/cpp/src/client/rate_limiter/rate_limiter.cpp
@@ -40,6 +40,24 @@ TDescribeResourceResult::THierarchicalDrrProps::THierarchicalDrrProps(const Ydb:
     }
 }
 
+void TDescribeResourceResult::THierarchicalDrrProps::THierarchicalDrrProps::SerializeTo(Ydb::RateLimiter::HierarchicalDrrSettings& settings) const {
+    if (MaxUnitsPerSecond_) {
+        settings.set_max_units_per_second(*MaxUnitsPerSecond_);
+    }
+
+    if (MaxBurstSizeCoefficient_) {
+        settings.set_max_burst_size_coefficient(*MaxBurstSizeCoefficient_);
+    }
+
+    if (PrefetchCoefficient_) {
+        settings.set_prefetch_coefficient(*PrefetchCoefficient_);
+    }
+
+    if (PrefetchWatermark_) {
+        settings.set_prefetch_watermark(*PrefetchWatermark_);
+    }
+}
+
 class TRateLimiterClient::TImpl : public TClientImplCommon<TRateLimiterClient::TImpl> {
 public:
     TImpl(std::shared_ptr<TGRpcConnectionsImpl> connections, const TCommonClientSettings& settings)


### PR DESCRIPTION
Kesuses (a.k.a. coordination nodes) have resources that depend on them. These resources are not scheme objects and are not present in the coordination node's description. To get the list of the resources that depend on a particular coordination node, one needs to list them by the name of the coordination node using a dedicated method of the rate limiter GRPC service. These resources have a protobuf description that we are going to back up in the coordination node's backup folder on the disk. Kesus resources use path-like IDs, which are hierarchical and use '/' as a separator. We are backing them up as a subtree in the coordination node's backup folder. Each folder represents a resource and contains a `create_resource.pb` file with the resource's protobuf description.

### Changelog entry <!-- a user-readable short description of changes introduced in this PR -->

### Changelog category <!-- remove all except one -->

* Not for changelog (changelog entry is not required)

### Additional information

- https://github.com/ydb-platform/ydb/issues/14051 
