### PR TITLE
Allow to enable default allocator via config on start

### DIFF
--- a/ydb/core/driver_lib/run/run.cpp
+++ b/ydb/core/driver_lib/run/run.cpp
@@ -1057,6 +1057,11 @@ void TKikimrRunner::InitializeAllocator(const TKikimrRunConfig& runConfig) {
     for (const auto& a : allocConfig.GetParam()) {
         NMalloc::MallocInfo().SetParam(a.first.c_str(), a.second.c_str());
     }
+#if defined(ALLOW_DEFAULT_ALLOCATOR)
+    if (allocConfig.GetEnableDefaultAllocator()) {
+        NKikimr::UseDefaultAllocator();
+    }
+#endif
 }
 
 void TKikimrRunner::InitializeAppData(const TKikimrRunConfig& runConfig)

--- a/ydb/core/protos/alloc.proto
+++ b/ydb/core/protos/alloc.proto
@@ -4,4 +4,5 @@ option java_package = "ru.yandex.kikimr.proto";
 
 message TAllocatorConfig {
     map<string, string> Param = 1;
+    bool EnableDefaultAllocator = 2;
 };


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of changes introduced in this PR -->

To enable the default allocator option - build with `-DALLOW_DEFAULT_ALLOCATOR`

### Changelog category <!-- remove all except one -->

* New feature