### PR TITLE
streamlookup: add row size estimation for non-POD-type keys

### DIFF
--- a/ydb/library/yql/dq/actors/input_transforms/dq_input_transform_lookup.cpp
+++ b/ydb/library/yql/dq/actors/input_transforms/dq_input_transform_lookup.cpp
@@ -110,6 +110,7 @@ private: //events
     void AddReadyQueue(NUdf::TUnboxedValue& lookupKey, NUdf::TUnboxedValue& inputOther, NUdf::TUnboxedValue *lookupPayload) {
             NUdf::TUnboxedValue* outputRowItems;
             NUdf::TUnboxedValue outputRow = HolderFactory.CreateDirectArrayHolder(OutputRowColumnOrder.size(), outputRowItems);
+            ui32 estimatedRowSize = 2;
             for (size_t i = 0; i != OutputRowColumnOrder.size(); ++i) {
                 const auto& [source, index] = OutputRowColumnOrder[i];
                 switch (source) {
@@ -131,9 +132,8 @@ private: //events
                         Y_ABORT();
                         break;
                 }
+                estimatedRowSize += TDqDataSerializer::EstimateSize(outputRowItems[i], OutputRowType->GetElementType(i));
             }
-            auto estimatedRowSize = TDqDataSerializer::EstimateSize(outputRow, OutputRowType);
-            if (estimatedRowSize < 1) estimatedRowSize = 1;
             EstimatedReadySize += estimatedRowSize;
             ReadyQueue.PushRow(outputRowItems, OutputRowType->GetElementsCount());
     }

--- a/ydb/library/yql/dq/actors/input_transforms/dq_input_transform_lookup.cpp
+++ b/ydb/library/yql/dq/actors/input_transforms/dq_input_transform_lookup.cpp
@@ -111,7 +111,6 @@ private: //events
     void AddReadyQueue(NUdf::TUnboxedValue& lookupKey, NUdf::TUnboxedValue& inputOther, NUdf::TUnboxedValue *lookupPayload) {
             NUdf::TUnboxedValue* outputRowItems;
             NUdf::TUnboxedValue outputRow = HolderFactory.CreateDirectArrayHolder(OutputRowColumnOrder.size(), outputRowItems);
-            ui32 estimatedRowSize = 2;
             for (size_t i = 0; i != OutputRowColumnOrder.size(); ++i) {
                 const auto& [source, index] = OutputRowColumnOrder[i];
                 switch (source) {

--- a/ydb/tests/fq/generic/streaming/test_join.py
+++ b/ydb/tests/fq/generic/streaming/test_join.py
@@ -452,20 +452,20 @@ TESTCASES = [
         ResequenceId(
             [
                 (
-                    '{"id":1,"za":1,"yb":"2","yc":100,"zd":101,ll:[1,2,3]}',
-                    '{"a":1,"b":"2","c":3,"d":4,"e":5,"f":6,"za":1,"yb":"2","yc":100,"zd":101,"eq1":true,"eq2":true,ll:[1,2,3]}',
+                    '{"id":1,"za":1,"yb":"2","yc":100,"zd":101,"ll":[1,2,3]}',
+                    '{"a":1,"b":"2","c":3,"d":4,"e":5,"f":6,"za":1,"yb":"2","yc":100,"zd":101,"eq1":true,"eq2":true,"ll":[1,2,3]}',
                 ),
                 (
-                    '{"id":2,"za":7,"yb":"8","yc":106,"zd":107,ll:[1,2]}',
-                    '{"a":7,"b":"8","c":9,"d":10,"e":11,"f":12,"za":7,"yb":"8","yc":106,"zd":107,"eq1":true,"eq2":true,ll:[1,2]}',
+                    '{"id":2,"za":7,"yb":"8","yc":106,"zd":107,"ll":[1,2]}',
+                    '{"a":7,"b":"8","c":9,"d":10,"e":11,"f":12,"za":7,"yb":"8","yc":106,"zd":107,"eq1":true,"eq2":true,"ll":[1,2]}',
                 ),
                 (
-                    '{"id":3,"za":2,"yb":"1","yc":114,"zd":115,ll:[]}',
-                    '{"a":null,"b":null,"c":null,"d":null,"e":null,"f":null,"za":2,"yb":"1","yc":114,"zd":115,"eq1":true,"eq2":true,ll:[]}',
+                    '{"id":3,"za":2,"yb":"1","yc":114,"zd":115,"ll":[]}',
+                    '{"a":null,"b":null,"c":null,"d":null,"e":null,"f":null,"za":2,"yb":"1","yc":114,"zd":115,"eq1":true,"eq2":true,"ll":[]}',
                 ),
                 (
-                    '{"id":3,"za":null,"yb":"1","yc":114,"zd":115,ll:[1,2,3,4]}',
-                    '{"a":null,"b":null,"c":null,"d":null,"e":null,"f":null,"za":null,"yb":"1","yc":114,"zd":115,"eq1":true,"eq2":true,ll:[1,2,3,4]}',
+                    '{"id":3,"za":null,"yb":"1","yc":114,"zd":115,"ll":[1,2,3,4]}',
+                    '{"a":null,"b":null,"c":null,"d":null,"e":null,"f":null,"za":null,"yb":"1","yc":114,"zd":115,"eq1":true,"eq2":true,"ll":[1,2,3,4]}',
                 ),
             ]
         ),

--- a/ydb/tests/fq/generic/streaming/test_join.py
+++ b/ydb/tests/fq/generic/streaming/test_join.py
@@ -423,24 +423,25 @@ TESTCASES = [
                             yb STRING,
                             yc Int32,
                             zd Int32,
+                            ll List<Int32>,
                         )
                     )            ;
 
-            $enriched1 = select a, b, c, d, e, f, za, yb, yc, zd
+            $enriched1 = select a, b, c, d, e, f, za, yb, yc, zd, ll
                 from
                     $input as e
                 left join {streamlookup} any ydb_conn_{table_name}.db as u
                 on(e.za = u.a AND e.yb = u.b)
             ;
 
-            $enriched2 = SELECT e.a AS a, e.b AS b, e.c AS c, e.d AS d, e.e AS e, e.f AS f, za, yb, yc, zd, u.c AS c2, u.d AS d2
+            $enriched2 = SELECT e.a AS a, e.b AS b, e.c AS c, e.d AS d, e.e AS e, e.f AS f, za, yb, yc, zd, u.c AS c2, u.d AS d2, ll
                 from
                     $enriched1 as e
                 left join {streamlookup} any ydb_conn_{table_name}.db as u
                 on(e.za = u.a AND e.yb = u.b)
             ;
 
-            $enriched = select a, b, c, d, e, f, za, yb, yc, zd, (c2 IS NOT DISTINCT FROM c) as eq1, (d2 IS NOT DISTINCT FROM d) as eq2
+            $enriched = select a, b, c, d, e, f, za, yb, yc, zd, (c2 IS NOT DISTINCT FROM c) as eq1, (d2 IS NOT DISTINCT FROM d) as eq2, ll
                 from
                     $enriched2 as e
             ;
@@ -451,20 +452,20 @@ TESTCASES = [
         ResequenceId(
             [
                 (
-                    '{"id":1,"za":1,"yb":"2","yc":100,"zd":101}',
-                    '{"a":1,"b":"2","c":3,"d":4,"e":5,"f":6,"za":1,"yb":"2","yc":100,"zd":101,"eq1":true,"eq2":true}',
+                    '{"id":1,"za":1,"yb":"2","yc":100,"zd":101,ll:[1,2,3]}',
+                    '{"a":1,"b":"2","c":3,"d":4,"e":5,"f":6,"za":1,"yb":"2","yc":100,"zd":101,"eq1":true,"eq2":true,ll:[1,2,3]}',
                 ),
                 (
-                    '{"id":2,"za":7,"yb":"8","yc":106,"zd":107}',
-                    '{"a":7,"b":"8","c":9,"d":10,"e":11,"f":12,"za":7,"yb":"8","yc":106,"zd":107,"eq1":true,"eq2":true}',
+                    '{"id":2,"za":7,"yb":"8","yc":106,"zd":107,ll:[1,2]}',
+                    '{"a":7,"b":"8","c":9,"d":10,"e":11,"f":12,"za":7,"yb":"8","yc":106,"zd":107,"eq1":true,"eq2":true,ll:[1,2]}',
                 ),
                 (
-                    '{"id":3,"za":2,"yb":"1","yc":114,"zd":115}',
-                    '{"a":null,"b":null,"c":null,"d":null,"e":null,"f":null,"za":2,"yb":"1","yc":114,"zd":115,"eq1":true,"eq2":true}',
+                    '{"id":3,"za":2,"yb":"1","yc":114,"zd":115,ll:[]}',
+                    '{"a":null,"b":null,"c":null,"d":null,"e":null,"f":null,"za":2,"yb":"1","yc":114,"zd":115,"eq1":true,"eq2":true,ll:[]}',
                 ),
                 (
-                    '{"id":3,"za":null,"yb":"1","yc":114,"zd":115}',
-                    '{"a":null,"b":null,"c":null,"d":null,"e":null,"f":null,"za":null,"yb":"1","yc":114,"zd":115,"eq1":true,"eq2":true}',
+                    '{"id":3,"za":null,"yb":"1","yc":114,"zd":115,ll:[1,2,3,4]}',
+                    '{"a":null,"b":null,"c":null,"d":null,"e":null,"f":null,"za":null,"yb":"1","yc":114,"zd":115,"eq1":true,"eq2":true,ll:[1,2,3,4]}',
                 ),
             ]
         ),


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of changes introduced in this PR -->

...

### Changelog category <!-- remove all except one -->

* Not for changelog (changelog entry is not required)

### Additional information

Still keep fast/simple bulk accounting for most common pod case
