### PR TITLE
ALTER USER use LOGIN resets failed attempt count

### DIFF
--- a/ydb/core/tx/schemeshard/schemeshard__operation_alter_login.cpp
+++ b/ydb/core/tx/schemeshard/schemeshard__operation_alter_login.cpp
@@ -88,7 +88,8 @@ public:
                         auto& sid = context.SS->LoginProvider.Sids[modifyUser.GetUser()];
                         db.Table<Schema::LoginSids>().Key(sid.Name).Update<Schema::LoginSids::SidType,
                                                                            Schema::LoginSids::SidHash,
-                                                                           Schema::LoginSids::IsEnabled>(sid.Type, sid.PasswordHash, sid.IsEnabled);
+                                                                           Schema::LoginSids::IsEnabled,
+                                                                           Schema::LoginSids::FailedAttemptCount>(sid.Type, sid.PasswordHash, sid.IsEnabled, sid.FailedLoginAttemptCount);
                         result->SetStatus(NKikimrScheme::StatusSuccess);
 
                         AddIsUserAdmin(modifyUser.GetUser(), context.SS->LoginProvider, additionalParts);

--- a/ydb/library/login/login.h
+++ b/ydb/library/login/login.h
@@ -221,17 +221,16 @@ private:
     bool CheckSubjectExists(const TString& name, const ESidType::SidType& type);
     static bool CheckAllowedName(const TString& name);
 
+    bool CheckLockoutByAttemptCount(const TSidRecord& sid) const;
     bool CheckLockout(const TSidRecord& sid) const;
-    void ResetFailedLoginAttemptCount(TSidRecord* sid);
-    void UnlockAccount(TSidRecord* sid);
+    static void ResetFailedLoginAttemptCount(TSidRecord* sid);
+    static void UnlockAccount(TSidRecord* sid);
     bool ShouldResetFailedAttemptCount(const TSidRecord& sid) const;
     bool ShouldUnlockAccount(const TSidRecord& sid) const;
     bool CheckPasswordOrHash(bool IsHashedPassword, const TString& user, const TString& password, TString& error) const;
 
     struct TImpl;
     THolder<TImpl> Impl;
-
-    std::unordered_set<TString> SidsShouldResetByUnbanning;
 
     TPasswordChecker PasswordChecker;
     THashChecker HashChecker;

--- a/ydb/library/login/login.h
+++ b/ydb/library/login/login.h
@@ -222,14 +222,16 @@ private:
     static bool CheckAllowedName(const TString& name);
 
     bool CheckLockout(const TSidRecord& sid) const;
-    static void ResetFailedLoginAttemptCount(TSidRecord* sid);
-    static void UnlockAccount(TSidRecord* sid);
+    void ResetFailedLoginAttemptCount(TSidRecord* sid);
+    void UnlockAccount(TSidRecord* sid);
     bool ShouldResetFailedAttemptCount(const TSidRecord& sid) const;
     bool ShouldUnlockAccount(const TSidRecord& sid) const;
     bool CheckPasswordOrHash(bool IsHashedPassword, const TString& user, const TString& password, TString& error) const;
 
     struct TImpl;
     THolder<TImpl> Impl;
+
+    std::unordered_set<TString> SidsShouldResetByUnbanning;
 
     TPasswordChecker PasswordChecker;
     THashChecker HashChecker;

--- a/ydb/library/login/login_ut.cpp
+++ b/ydb/library/login/login_ut.cpp
@@ -474,6 +474,72 @@ Y_UNIT_TEST_SUITE(Login) {
         provider.Audience = "test_audience1";
         provider.RotateKeys();
 
+        TLoginProvider::TCreateUserRequest createUserRequest {
+            .User = "user1",
+            .Password = "password1"
+        };
+        auto createUserResponse = provider.CreateUser(createUserRequest);
+        UNIT_ASSERT(!createUserResponse.Error);
+
+        {
+            for (size_t attempt = 0; attempt < accountLockoutInitializer.AttemptThreshold - 1; attempt++) {
+                UNIT_ASSERT_VALUES_EQUAL(provider.IsLockedOut(provider.Sids[createUserRequest.User]), false);
+                auto checkLockoutResponse = provider.CheckLockOutUser({.User = createUserRequest.User});
+                UNIT_ASSERT_EQUAL(checkLockoutResponse.Status, TLoginProvider::TCheckLockOutResponse::EStatus::UNLOCKED);
+                auto loginUserResponse = provider.LoginUser({.User = createUserRequest.User, .Password = TStringBuilder() << "wrongpassword" << attempt});
+                UNIT_ASSERT_EQUAL(loginUserResponse.Status, TLoginProvider::TLoginUserResponse::EStatus::INVALID_PASSWORD);
+                UNIT_ASSERT_VALUES_EQUAL(loginUserResponse.Error, "Invalid password");
+            }
+            UNIT_ASSERT_VALUES_EQUAL(provider.IsLockedOut(provider.Sids[createUserRequest.User]), false);
+            auto checkLockoutResponse = provider.CheckLockOutUser({.User = createUserRequest.User});
+            UNIT_ASSERT_EQUAL(checkLockoutResponse.Status, TLoginProvider::TCheckLockOutResponse::EStatus::UNLOCKED);
+        }
+
+        Sleep(TDuration::Seconds(4));
+
+        {
+            UNIT_ASSERT_VALUES_EQUAL(provider.IsLockedOut(provider.Sids[createUserRequest.User]), false);
+            auto checkLockoutResponse = provider.CheckLockOutUser({.User = createUserRequest.User});
+            UNIT_ASSERT_EQUAL(checkLockoutResponse.Status, TLoginProvider::TCheckLockOutResponse::EStatus::RESET);
+            auto loginUserResponse = provider.LoginUser({.User = createUserRequest.User, .Password = "wrongpassword1"});
+            UNIT_ASSERT_EQUAL(loginUserResponse.Status, TLoginProvider::TLoginUserResponse::EStatus::INVALID_PASSWORD);
+            UNIT_ASSERT_VALUES_EQUAL(loginUserResponse.Error, "Invalid password");
+        }
+
+        {
+            for (size_t attempt = 0; attempt < accountLockoutInitializer.AttemptThreshold - 2; attempt++) {
+                UNIT_ASSERT_VALUES_EQUAL(provider.IsLockedOut(provider.Sids[createUserRequest.User]), false);
+                auto checkLockoutResponse = provider.CheckLockOutUser({.User = createUserRequest.User});
+                UNIT_ASSERT_EQUAL(checkLockoutResponse.Status, TLoginProvider::TCheckLockOutResponse::EStatus::UNLOCKED);
+                auto loginUserResponse = provider.LoginUser({.User = createUserRequest.User, .Password = TStringBuilder() << "wrongpassword1" << attempt});
+                UNIT_ASSERT_EQUAL(loginUserResponse.Status, TLoginProvider::TLoginUserResponse::EStatus::INVALID_PASSWORD);
+                UNIT_ASSERT_VALUES_EQUAL(loginUserResponse.Error, "Invalid password");
+            }
+            UNIT_ASSERT_VALUES_EQUAL(provider.IsLockedOut(provider.Sids[createUserRequest.User]), false);
+            auto checkLockoutResponse = provider.CheckLockOutUser({.User = createUserRequest.User});
+            UNIT_ASSERT_EQUAL(checkLockoutResponse.Status, TLoginProvider::TCheckLockOutResponse::EStatus::UNLOCKED);
+        }
+
+        {
+            UNIT_ASSERT_VALUES_EQUAL(provider.IsLockedOut(provider.Sids[createUserRequest.User]), false);
+            auto checkLockoutResponse = provider.CheckLockOutUser({.User = createUserRequest.User});
+            UNIT_ASSERT_EQUAL(checkLockoutResponse.Status, TLoginProvider::TCheckLockOutResponse::EStatus::UNLOCKED);
+            auto loginUserResponse = provider.LoginUser({.User = createUserRequest.User, .Password = createUserRequest.Password});
+            UNIT_ASSERT_EQUAL(loginUserResponse.Status, TLoginProvider::TLoginUserResponse::EStatus::SUCCESS);
+            UNIT_ASSERT_VALUES_EQUAL(loginUserResponse.Error, "");
+
+            auto validateTokenResponse = provider.ValidateToken({.Token = loginUserResponse.Token});
+            UNIT_ASSERT_VALUES_EQUAL(validateTokenResponse.Error, "");
+            UNIT_ASSERT(validateTokenResponse.User == createUserRequest.User);
+        }
+    }
+
+    Y_UNIT_TEST(ResetFailedAttemptCountWithAlterUserLogin) {
+        TAccountLockout::TInitializer accountLockoutInitializer {.AttemptThreshold = 4, .AttemptResetDuration = "3s"};
+        TLoginProvider provider(accountLockoutInitializer);
+        provider.Audience = "test_audience1";
+        provider.RotateKeys();
+
         TString userName = "user1";
         TString userPassword = "password1";
 
@@ -481,84 +547,38 @@ Y_UNIT_TEST_SUITE(Login) {
             .User = userName,
             .Password = userPassword
         };
+
         auto createUserResponse = provider.CreateUser(createUserRequest);
         UNIT_ASSERT(!createUserResponse.Error);
 
-        auto LoginWithWrongPassword = [&](TLoginProvider::TCheckLockOutResponse::EStatus checkLockoutStatus, int attempt) {
+        for (size_t attempt = 0; attempt < accountLockoutInitializer.AttemptThreshold; attempt++) {
             UNIT_ASSERT_VALUES_EQUAL(provider.IsLockedOut(provider.Sids[userName]), false);
             auto checkLockoutResponse = provider.CheckLockOutUser({.User = userName});
-            UNIT_ASSERT_EQUAL(checkLockoutResponse.Status, checkLockoutStatus);
+            UNIT_ASSERT_EQUAL(checkLockoutResponse.Status, TLoginProvider::TCheckLockOutResponse::EStatus::UNLOCKED);
             auto loginUserResponse = provider.LoginUser({.User = userName, .Password = TStringBuilder() << "wrongpassword" << attempt});
             UNIT_ASSERT_EQUAL(loginUserResponse.Status, TLoginProvider::TLoginUserResponse::EStatus::INVALID_PASSWORD);
             UNIT_ASSERT_VALUES_EQUAL(loginUserResponse.Error, "Invalid password");
-        };
-
-        {
-            for (size_t attempt = 0; attempt < accountLockoutInitializer.AttemptThreshold - 1; attempt++) {
-                LoginWithWrongPassword(TLoginProvider::TCheckLockOutResponse::EStatus::UNLOCKED, attempt);
-            }
-
-            UNIT_ASSERT_VALUES_EQUAL(provider.IsLockedOut(provider.Sids[userName]), false);
-            auto checkLockoutResponse = provider.CheckLockOutUser({.User = userName});
-            UNIT_ASSERT_EQUAL(checkLockoutResponse.Status, TLoginProvider::TCheckLockOutResponse::EStatus::UNLOCKED);
-        }
-
-        Sleep(TDuration::Seconds(4));
-
-        {
-            LoginWithWrongPassword(TLoginProvider::TCheckLockOutResponse::EStatus::RESET, 1);
         }
 
         {
-            for (size_t attempt = 0; attempt < accountLockoutInitializer.AttemptThreshold - 2; attempt++) {
-                LoginWithWrongPassword(TLoginProvider::TCheckLockOutResponse::EStatus::UNLOCKED, attempt);
-            }
-
-            UNIT_ASSERT_VALUES_EQUAL(provider.IsLockedOut(provider.Sids[userName]), false);
+            UNIT_ASSERT_VALUES_EQUAL(provider.IsLockedOut(provider.Sids[userName]), true);
             auto checkLockoutResponse = provider.CheckLockOutUser({.User = userName});
-            UNIT_ASSERT_EQUAL(checkLockoutResponse.Status, TLoginProvider::TCheckLockOutResponse::EStatus::UNLOCKED);
+            UNIT_ASSERT_EQUAL(checkLockoutResponse.Status, TLoginProvider::TCheckLockOutResponse::EStatus::SUCCESS);
+            UNIT_ASSERT_STRING_CONTAINS(checkLockoutResponse.Error, TStringBuilder() << "User " << userName << " is not permitted to log in");
+        }
+
+        {
+            TLoginProvider::TModifyUserRequest alterRequest;
+            alterRequest.User = userName;
+            alterRequest.CanLogin = true;
+            auto alterResponse = provider.ModifyUser(alterRequest);
+            UNIT_ASSERT(!alterResponse.Error);
         }
 
         {
             UNIT_ASSERT_VALUES_EQUAL(provider.IsLockedOut(provider.Sids[userName]), false);
             auto checkLockoutResponse = provider.CheckLockOutUser({.User = userName});
             UNIT_ASSERT_EQUAL(checkLockoutResponse.Status, TLoginProvider::TCheckLockOutResponse::EStatus::UNLOCKED);
-            auto loginUserResponse = provider.LoginUser({.User = userName, .Password = userPassword});
-            UNIT_ASSERT_EQUAL(loginUserResponse.Status, TLoginProvider::TLoginUserResponse::EStatus::SUCCESS);
-            UNIT_ASSERT_VALUES_EQUAL(loginUserResponse.Error, "");
-
-            auto validateTokenResponse = provider.ValidateToken({.Token = loginUserResponse.Token});
-            UNIT_ASSERT_VALUES_EQUAL(validateTokenResponse.Error, "");
-            UNIT_ASSERT(validateTokenResponse.User == userName);
-        }
-
-        Sleep(TDuration::Seconds(4));
-
-        {
-            for (size_t attempt = 0; attempt < accountLockoutInitializer.AttemptThreshold; attempt++) {
-                LoginWithWrongPassword(TLoginProvider::TCheckLockOutResponse::EStatus::UNLOCKED, attempt);
-            }
-
-            {
-                UNIT_ASSERT_VALUES_EQUAL(provider.IsLockedOut(provider.Sids[userName]), true);
-                auto checkLockoutResponse = provider.CheckLockOutUser({.User = userName});
-                UNIT_ASSERT_EQUAL(checkLockoutResponse.Status, TLoginProvider::TCheckLockOutResponse::EStatus::SUCCESS);
-                UNIT_ASSERT_STRING_CONTAINS(checkLockoutResponse.Error, TStringBuilder() << "User " << userName << " is not permitted to log in");
-            }
-
-            {
-                TLoginProvider::TModifyUserRequest alterRequest;
-                alterRequest.User = userName;
-                alterRequest.CanLogin = true;
-                auto alterResponse = provider.ModifyUser(alterRequest);
-                UNIT_ASSERT(!alterResponse.Error);
-            }
-
-            {
-                UNIT_ASSERT_VALUES_EQUAL(provider.IsLockedOut(provider.Sids[userName]), false);
-                auto checkLockoutResponse = provider.CheckLockOutUser({.User = userName});
-                UNIT_ASSERT_EQUAL(checkLockoutResponse.Status, TLoginProvider::TCheckLockOutResponse::EStatus::RESET);
-            }
         }
     }
 


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of changes introduced in this PR -->
The ALTER USER user LOGIN query should unban the user who has been banned for exceeding the limit of authentication attempts.

### Changelog category <!-- remove all except one -->

* Improvement

### Additional information
