### PR TITLE
Disable ydb/docs RECURSE

### DIFF
--- a/ydb/ya.make
+++ b/ydb/ya.make
@@ -10,15 +10,15 @@ RECURSE(
 )
 
 IF(NOT EXPORT_CMAKE)
-RECURSE(
-  tests
-)
+  RECURSE(
+    tests
+  )
 ENDIF()
 
 IF(NOT OPENSOURCE)
-# YFM tool is not supported 
-# for OSS ya make yet
-RECURSE(
-  docs
-)
+  # YFM tool is not supported 
+  # for OSS ya make yet
+  RECURSE(
+    docs
+  )
 ENDIF()

--- a/ydb/ya.make
+++ b/ydb/ya.make
@@ -1,6 +1,5 @@
 RECURSE(
     apps
-    docs
     core
     library
     mvp
@@ -11,7 +10,15 @@ RECURSE(
 )
 
 IF(NOT EXPORT_CMAKE)
-  RECURSE(
-    tests
-  )
+RECURSE(
+  tests
+)
+ENDIF()
+
+IF(NOT OPENSOURCE)
+# YFM tool is not supported 
+# for OSS ya make yet
+RECURSE(
+  docs
+)
 ENDIF()


### PR DESCRIPTION
YFM tool for docs is not officially suported in OSS ya make 

Also sync is broken by that reason: https://github.com/ydb-platform/ydb/pull/14468#issuecomment-2652122127 (because troubles with mapping)

So, temporary disable it