### PR TITLE
[cli] fix the order of parameters parsing

### DIFF
--- a/ydb/public/lib/ydb_cli/commands/ydb_root_common.cpp
+++ b/ydb/public/lib/ydb_cli/commands/ydb_root_common.cpp
@@ -350,11 +350,11 @@ void TClientCommandRootCommon::ExtractParams(TConfig& config) {
     ParseProfile();
 
     ParseDatabase(config);
+    ParseAddress(config);
     ParseCaCerts(config);
     ParseIamEndpoint(config);
 
     ParseCredentials(config);
-    ParseAddress(config);
 }
 
 namespace {


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of changes introduced in this PR -->

Fix the order of parameters parsing for TLS connections.

### Changelog category <!-- remove all except one -->

* Bugfix 

### Additional information

Some time ago, deploying a new cluster via https://ydb.tech/docs/en/devops/ansible/initial-deployment started stumbling upon the following error:
```
➜  ydb --ca-file /opt/ydb/certs/ca.crt --endpoint grpcs://static-node-1.ydb-cluster.com:2135 --database /Root auth get-token -f
"ca-file" option provided for a non-ssl connection. Use grpcs:// prefix for host to connect using SSL.
Try "--help" option for more info.
```