### PR TITLE
Add cluster & database restore to YDB CLI

### DIFF
--- a/ydb/apps/ydb/CHANGELOG.md
+++ b/ydb/apps/ydb/CHANGELOG.md
@@ -4,6 +4,8 @@
 * Added `ydb workload log import generator` command.
 * Queries in `ydb workload run` command are now executed in random order.
 * Include topics in local backups (`ydb tools dump` and `ydb tools restore`). In this release, only the settings of the topics are retained; messages are not included in the backup.
+* Added `ydb admin cluster dump` and `ydb admin cluster restore` command for dumping all cluster-level data
+* Added `ydb admin database dump` and `ydb admin database restore` command for dumping all database-level data
 
 ## 2.19.0 ##
 

--- a/ydb/apps/ydb/CHANGELOG.md
+++ b/ydb/apps/ydb/CHANGELOG.md
@@ -4,8 +4,8 @@
 * Added `ydb workload log import generator` command.
 * Queries in `ydb workload run` command are now executed in random order.
 * Include topics in local backups (`ydb tools dump` and `ydb tools restore`). In this release, only the settings of the topics are retained; messages are not included in the backup.
-* Added `ydb admin cluster dump` and `ydb admin cluster restore` command for dumping all cluster-level data
-* Added `ydb admin database dump` and `ydb admin database restore` command for dumping all database-level data
+* Added `ydb admin cluster dump` and `ydb admin cluster restore` commands for dumping all cluster-level data
+* Added `ydb admin database dump` and `ydb admin database restore` commands for dumping all database-level data
 
 ## 2.19.0 ##
 

--- a/ydb/public/lib/ydb_cli/commands/ydb_admin.cpp
+++ b/ydb/public/lib/ydb_cli/commands/ydb_admin.cpp
@@ -30,6 +30,7 @@ public:
     {
         AddCommand(std::make_unique<NDynamicConfig::TCommandConfig>());
         AddCommand(std::make_unique<TCommandDatabaseDump>());
+        AddCommand(std::make_unique<TCommandDatabaseRestore>());
     }
 };
 
@@ -58,6 +59,47 @@ int TCommandDatabaseDump::Run(TConfig& config) {
 
     NDump::TClient client(CreateDriver(config), std::move(log));
     NStatusHelpers::ThrowOnErrorOrPrintIssues(client.DumpDatabase(config.Database, FilePath));
+
+    return EXIT_SUCCESS;
+}
+
+TCommandDatabaseRestore::TCommandDatabaseRestore() 
+    : TYdbCommand("restore", {}, "Restore database from local dump") 
+{}
+
+void TCommandDatabaseRestore::Config(TConfig& config) {
+    TYdbCommand::Config(config);
+    config.SetFreeArgsNum(0);
+    config.AllowEmptyDatabase = true; // it is possible to retrieve database path from dump
+
+    config.Opts->AddLongOption('i', "input", "Path in a local filesystem to a directory with dump.")
+        .RequiredArgument("PATH")
+        .StoreResult(&FilePath);
+
+    config.Opts->AddLongOption('w', "wait-nodes-duration", "Wait for available database nodes for specified duration. Example: 10s, 5m, 1h.")
+        .DefaultValue(TDuration::Minutes(1))
+        .RequiredArgument("DURATION")
+        .StoreResult(&WaitNodesDuration);
+}
+
+void TCommandDatabaseRestore::Parse(TConfig& config) {
+    TClientCommand::Parse(config);
+}
+
+int TCommandDatabaseRestore::Run(TConfig& config) {
+    auto log = std::make_shared<TLog>(CreateLogBackend("cerr", TConfig::VerbosityLevelToELogPriority(config.VerbosityLevel)));
+    log->SetFormatter(GetPrefixLogFormatter(""));
+
+    auto settings = NDump::TRestoreDatabaseSettings()
+        .WaitNodesDuration(WaitNodesDuration);
+
+    if (!config.Database.empty()) {
+        settings.Database(config.Database);
+        config.Database.clear(); // always connect directly to cluster
+    }
+
+    NDump::TClient client(CreateDriver(config), std::move(log));
+    NStatusHelpers::ThrowOnErrorOrPrintIssues(client.RestoreDatabase(FilePath, settings));
 
     return EXIT_SUCCESS;
 }

--- a/ydb/public/lib/ydb_cli/commands/ydb_admin.h
+++ b/ydb/public/lib/ydb_cli/commands/ydb_admin.h
@@ -23,5 +23,17 @@ private:
     TString FilePath;
 };
 
+class TCommandDatabaseRestore : public TYdbCommand {
+public:
+    TCommandDatabaseRestore();
+    void Config(TConfig& config) override;
+    void Parse(TConfig& config) override;
+    int Run(TConfig& config) override;
+
+private:
+    TString FilePath;
+    TDuration WaitNodesDuration;
+};
+
 }
 }

--- a/ydb/public/lib/ydb_cli/commands/ydb_cluster.h
+++ b/ydb/public/lib/ydb_cli/commands/ydb_cluster.h
@@ -33,4 +33,16 @@ private:
     TString FilePath;
 };
 
+class TCommandClusterRestore : public TYdbCommand {
+public:
+    TCommandClusterRestore();
+    void Config(TConfig& config) override;
+    void Parse(TConfig& config) override;
+    int Run(TConfig& config) override;
+
+private:
+    TString FilePath;
+    TDuration WaitNodesDuration;
+};
+
 } // namespace NYdb::NConsoleClient::NCluster

--- a/ydb/public/lib/ydb_cli/dump/dump.cpp
+++ b/ydb/public/lib/ydb_cli/dump/dump.cpp
@@ -37,9 +37,19 @@ public:
         return client.DumpCluster(fsPath);
     }
 
+    TRestoreResult RestoreCluster(const TString& fsPath, const TRestoreClusterSettings& settings) {
+        auto client = TRestoreClient(Driver, Log);
+        return client.RestoreCluster(fsPath, settings);
+    }
+
     TDumpResult DumpDatabase(const TString& database, const TString& fsPath) {
         auto client = TDumpClient(Driver, Log);
         return client.DumpDatabase(database, fsPath);
+    }
+
+    TRestoreResult RestoreDatabase(const TString& fsPath, const TRestoreDatabaseSettings& settings) {
+        auto client = TRestoreClient(Driver, Log);
+        return client.RestoreDatabase(fsPath, settings);
     }
 
 private:
@@ -80,8 +90,16 @@ TDumpResult TClient::DumpCluster(const TString& fsPath) {
     return Impl_->DumpCluster(fsPath);
 }
 
+TRestoreResult TClient::RestoreCluster(const TString& fsPath, const TRestoreClusterSettings& settings) {
+     return Impl_->RestoreCluster(fsPath, settings);
+}
+
 TDumpResult TClient::DumpDatabase(const TString& database, const TString& fsPath) {
     return Impl_->DumpDatabase(database, fsPath);
+}
+
+TRestoreResult TClient::RestoreDatabase(const TString& fsPath, const TRestoreDatabaseSettings& settings) {
+    return Impl_->RestoreDatabase(fsPath, settings);
 }
 
 } // NYdb::NDump

--- a/ydb/public/lib/ydb_cli/dump/dump.h
+++ b/ydb/public/lib/ydb_cli/dump/dump.h
@@ -112,6 +112,20 @@ struct TRestoreSettings: public TOperationRequestSettings<TRestoreSettings> {
 
 }; // TRestoreSettings
 
+struct TRestoreClusterSettings {
+    using TSelf = TRestoreClusterSettings;
+
+    FLUENT_SETTING_DEFAULT(TDuration, WaitNodesDuration, TDuration::Minutes(1));
+}; // TRestoreClusterSettings
+
+struct TRestoreDatabaseSettings {
+    using TSelf = TRestoreDatabaseSettings;
+
+    FLUENT_SETTING_DEFAULT(TDuration, WaitNodesDuration, TDuration::Minutes(1));
+    FLUENT_SETTING_OPTIONAL(TString, Database);
+    FLUENT_SETTING_DEFAULT(bool, WithContent, true);
+}; // TRestoreDatabaseSettings
+
 class TRestoreResult: public TStatus {
 public:
     TRestoreResult(TStatus&& status);
@@ -131,9 +145,11 @@ public:
     TRestoreResult Restore(const TString& fsPath, const TString& dbPath, const TRestoreSettings& settings = {});
 
     TDumpResult DumpCluster(const TString& fsPath);
+    TRestoreResult RestoreCluster(const TString& fsPath, const TRestoreClusterSettings& settings = {});
 
     TDumpResult DumpDatabase(const TString& database, const TString& fsPath);
-    
+    TRestoreResult RestoreDatabase(const TString& fsPath, const TRestoreDatabaseSettings& settings = {});
+
 private:
     std::shared_ptr<TImpl> Impl_;
 

--- a/ydb/public/lib/ydb_cli/dump/restore_impl.cpp
+++ b/ydb/public/lib/ydb_cli/dump/restore_impl.cpp
@@ -1,7 +1,10 @@
+#include "restore_compat.h"
 #include "restore_impl.h"
 #include "restore_import_data.h"
-#include "restore_compat.h"
 
+#include <ydb-cpp-sdk/client/discovery/discovery.h>
+#include <ydb-cpp-sdk/client/proto/accessor.h>
+#include <ydb/public/api/protos/ydb_cms.pb.h>
 #include <ydb/public/api/protos/ydb_rate_limiter.pb.h>
 #include <ydb/public/api/protos/ydb_table.pb.h>
 #include <ydb/public/lib/ydb_cli/common/recursive_list.h>
@@ -12,7 +15,6 @@
 #include <ydb/public/lib/ydb_cli/dump/util/query_utils.h>
 #include <ydb/public/lib/ydb_cli/dump/util/util.h>
 #include <ydb/public/lib/ydb_cli/dump/util/view_utils.h>
-#include <ydb-cpp-sdk/client/proto/accessor.h>
 #include <yql/essentials/public/issue/yql_issue.h>
 
 #include <library/cpp/threading/future/core/future.h>
@@ -24,6 +26,8 @@
 #include <util/generic/vector.h>
 #include <util/stream/file.h>
 #include <util/string/join.h>
+#include <util/string/split.h>
+#include <util/system/hp_timer.h>
 #include <util/system/info.h>
 
 #include <google/protobuf/text_format.h>
@@ -32,6 +36,7 @@
 
 namespace NYdb::NDump {
 
+using namespace NCms;
 using namespace NConsoleClient;
 using namespace NImport;
 using namespace NOperation;
@@ -97,6 +102,10 @@ Ydb::RateLimiter::CreateResourceRequest ReadRateLimiterCreationRequest(const TFs
 
 Ydb::Scheme::ModifyPermissionsRequest ReadPermissions(const TFsPath& fsDirPath, const TLog* log) {
     return ReadProtoFromFile<Ydb::Scheme::ModifyPermissionsRequest>(fsDirPath, log, NFiles::Permissions());
+}
+
+Ydb::Cms::CreateDatabaseRequest ReadDatabaseDescription(const TFsPath& fsDirPath, const TLog* log) {
+    return ReadProtoFromFile<Ydb::Cms::CreateDatabaseRequest>(fsDirPath, log, NFiles::Database());
 }
 
 TTableDescription TableDescriptionFromProto(const Ydb::Table::CreateTableRequest& proto) {
@@ -295,8 +304,40 @@ TRestoreClient::TRestoreClient(const TDriver& driver, const std::shared_ptr<TLog
     , CoordinationNodeClient(driver)
     , RateLimiterClient(driver)
     , QueryClient(driver)
+    , CmsClient(driver)
     , Log(log)
+    , DriverConfig(driver.GetConfig())
 {
+}
+
+TRestoreResult TRestoreClient::RetryViewRestoration() {
+    auto result = Result<TRestoreResult>();
+
+    if (!ViewRestorationCalls.empty()) {
+        TVector<TRestoreViewCall> calls;
+        TMaybe<TRestoreResult> lastFail;
+        size_t size;
+        do {
+            calls.clear();
+            lastFail.Clear();
+            size = ViewRestorationCalls.size();
+            std::swap(calls, ViewRestorationCalls);
+
+            for (const auto& [fsPath, dbRestoreRoot, dbPathRelativeToRestoreRoot, settings, isAlreadyExisting] : calls) {
+                auto result = RestoreView(fsPath, dbRestoreRoot, dbPathRelativeToRestoreRoot, settings, isAlreadyExisting);
+                if (!result.IsSuccess()) {
+                    lastFail = std::move(result);
+                }
+            }
+        } while (!ViewRestorationCalls.empty() && ViewRestorationCalls.size() < size);
+
+        // retries could not fix the errors
+        if (!ViewRestorationCalls.empty() || lastFail) {
+            result = *lastFail;
+        }
+    }
+
+    return result;
 }
 
 TRestoreResult TRestoreClient::Restore(const TString& fsPath, const TString& dbPath, const TRestoreSettings& settings) {
@@ -335,29 +376,8 @@ TRestoreResult TRestoreClient::Restore(const TString& fsPath, const TString& dbP
 
     // restore
     auto restoreResult = RestoreFolder(fsPath, dbPath, "", settings, oldEntries);
-
-    if (!ViewRestorationCalls.empty()) {
-        TVector<TRestoreViewCall> calls;
-        TMaybe<TRestoreResult> lastFail;
-        size_t size;
-        do {
-            calls.clear();
-            lastFail.Clear();
-            size = ViewRestorationCalls.size();
-            std::swap(calls, ViewRestorationCalls);
-
-            for (const auto& [fsPath, dbRestoreRoot, dbPathRelativeToRestoreRoot, settings, isAlreadyExisting] : calls) {
-                auto result = RestoreView(fsPath, dbRestoreRoot, dbPathRelativeToRestoreRoot, settings, isAlreadyExisting);
-                if (!result.IsSuccess()) {
-                    lastFail = std::move(result);
-                }
-            }
-        } while (!ViewRestorationCalls.empty() && ViewRestorationCalls.size() < size);
-
-        // retries could not fix the errors
-        if (!ViewRestorationCalls.empty() || lastFail) {
-            restoreResult = *lastFail;
-        }
+    if (auto retryViewResult = RetryViewRestoration(); !retryViewResult.IsSuccess()) {
+        restoreResult = retryViewResult;
     }
 
     if (restoreResult.IsSuccess()) {
@@ -428,6 +448,369 @@ TRestoreResult TRestoreClient::Restore(const TString& fsPath, const TString& dbP
     }
 
     return restoreResult;
+}
+
+TRestoreResult TRestoreClient::FindClusterRootPath() {
+    if (!ClusterRootPath.empty()) {
+        return Result<TRestoreResult>();
+    }
+
+    auto status = NDump::ListDirectory(SchemeClient, "/");
+    if (!status.IsSuccess()) {
+        return status;
+    }
+
+    if (status.GetChildren().size() != 1) {
+        return Result<TRestoreResult>(EStatus::PRECONDITION_FAILED,
+            TStringBuilder() << "Exactly one cluster root expected, found: " << JoinSeq(", ", status.GetChildren()));
+    }
+
+    ClusterRootPath = "/" + status.GetChildren().begin()->Name;
+
+    return Result<TRestoreResult>();
+}
+
+TRestoreResult TRestoreClient::RestoreClusterRoot(const TFsPath& fsPath) {
+    if (auto result = FindClusterRootPath(); !result.IsSuccess()) {
+        return result;
+    }
+
+    LOG_I("Restore cluster root " << ClusterRootPath.Quote() << " from " << fsPath.GetPath().Quote());
+    
+    if (!fsPath.Exists()) {
+        return Result<TRestoreResult>(EStatus::BAD_REQUEST,
+            TStringBuilder() << "Specified folder does not exist: " << fsPath.GetPath());
+    }
+
+    if (!fsPath.IsDirectory()) {
+        return Result<TRestoreResult>(EStatus::BAD_REQUEST,
+            TStringBuilder() << "Specified folder is not a directory: " << fsPath.GetPath());
+    }
+
+    if (auto error = ErrorOnIncomplete(fsPath)) {
+        return *error;
+    }
+
+    TDriverConfig rootDriverConfig(DriverConfig);
+    rootDriverConfig.SetDatabase(ClusterRootPath);
+    TDriver rootDriver(rootDriverConfig);
+    TSchemeClient rootSchemeClient(rootDriver);
+    TTableClient rootTableClient(rootDriver);
+
+    if (auto result = RestoreUsers(rootTableClient, fsPath, ClusterRootPath); !result.IsSuccess()) {
+        return result;
+    }
+
+    if (auto result = RestoreGroups(rootTableClient, fsPath, ClusterRootPath); !result.IsSuccess()) {
+        return result;
+    }
+
+    if (auto result = RestoreGroupMembers(rootTableClient, fsPath, ClusterRootPath); !result.IsSuccess()) {
+        return result;
+    }
+    
+    if (auto result = RestorePermissionsImpl(rootSchemeClient, fsPath, ClusterRootPath); !result.IsSuccess()) {
+        return result;
+    }
+
+    return Result<TRestoreResult>();
+}
+
+TRestoreResult TRestoreClient::WaitForAvailableNodes(const TString& database, TDuration waitDuration) {
+    TDriverConfig dbDriverConfig = DriverConfig;
+    dbDriverConfig.SetDatabase(database);
+
+    THPTimer timer;
+    
+    NDiscovery::TDiscoveryClient client(dbDriverConfig);
+    TDuration retrySleep = TDuration::MilliSeconds(1000);
+    while (true) {
+        auto result = client.ListEndpoints().GetValueSync();
+        if (result.GetStatus() == EStatus::UNAVAILABLE) {
+            auto timeSpent = TDuration::Seconds(timer.Passed());
+            if (timeSpent > waitDuration) {
+                auto error = TStringBuilder()
+                    << "Timeout waiting for available database nodes for " << database.Quote()
+                    << " for " << waitDuration
+                    << ", make sure that nodes are running and restart restore";
+                LOG_E(error);
+                return Result<TRestoreResult>(EStatus::TIMEOUT, error);
+            }
+
+            auto timeLeft = waitDuration - timeSpent;
+            LOG_I("Waiting for available database nodes for " << database.Quote()
+                << ", make sure that nodes are running"
+                << ", time left: " << timeLeft);
+            retrySleep = Min(retrySleep, timeLeft);
+            ExponentialBackoff(retrySleep, TDuration::Minutes(1));
+        } else {
+            return result;
+        }
+    }
+}
+
+TRestoreResult TRestoreClient::RestoreUsers(TTableClient& client, const TFsPath& fsPath, const TString& dbPath) {
+    LOG_D("Restore users to " << dbPath.Quote());
+
+    const auto createUserPath = fsPath.Child(NFiles::CreateUser().FileName);
+    auto query = TFileInput(createUserPath).ReadAll();
+
+    TVector<TString> statements;
+    Split(query, "\n", statements);
+    for (const auto& statement : statements) {
+        auto statementResult = client.RetryOperationSync([&](TSession session) {
+            return session.ExecuteSchemeQuery(statement).ExtractValueSync();
+        });
+        
+        if (statement.StartsWith("CREATE")
+            && statementResult.GetStatus() == EStatus::PRECONDITION_FAILED
+            && statementResult.GetIssues().ToOneLineString().find("exists") != TString::npos)
+        {
+            LOG_D("User from create statement " << statement.Quote() << " already exists, trying to alter it");
+            auto alterStatement = "ALTER" + statement.substr(6); 
+            auto alterStatementResult = client.RetryOperationSync([&](TSession session) {
+                return session.ExecuteSchemeQuery(alterStatement).ExtractValueSync();
+            });
+            if (!alterStatementResult.IsSuccess()) {
+                LOG_E("Failed to execute statement for restoring user: "
+                    << alterStatement.Quote() << ", error: "
+                    << alterStatementResult.GetIssues().ToOneLineString());
+                return alterStatementResult;
+            }
+        } else if (statementResult.GetStatus() == EStatus::UNAUTHORIZED) {
+            LOG_W("Not enough rights to restore user from statement " << statement.Quote() << ", skipping");
+            continue;
+        } else if (!statementResult.IsSuccess()) {
+            LOG_E("Failed to execute statement for restoring user: "
+                << statement.Quote() << ", error: "
+                << statementResult.GetIssues().ToOneLineString());
+            return statementResult;
+        }
+    }
+
+    return Result<TRestoreResult>();
+}
+
+TRestoreResult TRestoreClient::RestoreGroups(TTableClient& client, const TFsPath& fsPath, const TString& dbPath) {
+    LOG_D("Restore groups to " << dbPath.Quote());
+
+    const auto createGroupPath = fsPath.Child(NFiles::CreateGroup().FileName);
+    auto query = TFileInput(createGroupPath).ReadAll();
+
+    TVector<TString> statements;
+    Split(query, "\n", statements);
+    for (const auto& statement : statements) {
+        auto statementResult = client.RetryOperationSync([&](TSession session) {
+            return session.ExecuteSchemeQuery(statement).ExtractValueSync();
+        });
+
+        if (statementResult.GetStatus() == EStatus::PRECONDITION_FAILED
+            && statementResult.GetIssues().ToOneLineString().find("exists") != TString::npos) {
+            LOG_D("Group from create statement " << statement.Quote() << " already exists, skipping");
+            continue;
+        } else if (statementResult.GetStatus() == EStatus::UNAUTHORIZED) {
+            LOG_W("Not enough rights to restore group from statement " << statement.Quote() << ", skipping");
+            continue;
+        } else if (!statementResult.IsSuccess()) {
+            LOG_E("Failed to execute statement for restoring group: "
+                << statement.Quote() << ", error: "
+                << statementResult.GetIssues().ToOneLineString());
+            return statementResult;
+        }
+    }
+
+    return Result<TRestoreResult>();
+}
+
+TRestoreResult TRestoreClient::RestoreGroupMembers(TTableClient& client, const TFsPath& fsPath, const TString& dbPath) {
+    LOG_D("Restore group members to " << dbPath.Quote());
+
+    const auto alterGroupPath = fsPath.Child(NFiles::AlterGroup().FileName);
+    auto query = TFileInput(alterGroupPath).ReadAll();
+
+    TVector<TString> statements;
+    Split(query, "\n", statements);
+    for (const auto& statement : statements) {
+        auto statementResult = client.RetryOperationSync([&](TSession session) {
+            return session.ExecuteSchemeQuery(statement).ExtractValueSync();
+        });
+
+        if (statementResult.GetStatus() == EStatus::UNAUTHORIZED) {
+            LOG_W("Not enough rights to restore group member from statement " << statement.Quote() << ", skipping");
+            continue;
+        } else if (!statementResult.IsSuccess()) {
+            LOG_E("Failed to execute statement for restoring group members: "
+                << statement.Quote() << ", error: "
+                << statementResult.GetIssues().ToOneLineString());
+            return statementResult;
+        }
+    }
+
+    return Result<TRestoreResult>();
+}
+
+TRestoreResult TRestoreClient::ReplaceClusterRoot(TString& outPath) {
+    if (auto result = FindClusterRootPath(); !result.IsSuccess()) {
+        return result;
+    }
+
+    size_t clusterRootEnd = outPath.find('/', 1);
+    if (clusterRootEnd != std::string::npos) {
+        outPath = ClusterRootPath + outPath.substr(clusterRootEnd);
+    } else {
+        return Result<TRestoreResult>(EStatus::INTERNAL_ERROR, 
+            TStringBuilder() << "Can't find cluster root path in "
+            << outPath.Quote() << " to replace it on "
+            << ClusterRootPath.Quote());
+    }
+
+    return Result<TRestoreResult>();
+}
+
+TRestoreResult TRestoreClient::RestoreDatabaseImpl(const TString& fsPath, const TRestoreDatabaseSettings& settings) {
+    if (auto error = ErrorOnIncomplete(fsPath)) {
+        return *error;
+    }
+
+    auto dbDesc = ReadDatabaseDescription(fsPath, Log.get());
+
+    TString dbPath;
+    if (settings.Database_.has_value()) {
+        dbPath = *settings.Database_;
+    } else {
+        // Get database path from dump and adjust it to the cluster
+        dbPath = dbDesc.path();
+        if (auto result = ReplaceClusterRoot(dbPath); !result.IsSuccess()) {
+            return result;
+        }
+    }
+
+    LOG_I("Restore database from " << fsPath.Quote() << " to " << dbPath.Quote());
+    
+    if (auto result = CreateDatabase(CmsClient, dbPath, TCreateDatabaseSettings(dbDesc)); !result.IsSuccess()) {
+        if (result.GetStatus() == EStatus::ALREADY_EXISTS) {
+            LOG_W("Database " << dbPath.Quote() << " already exists, continue restoring to this database");
+        } else {
+            return result;
+        }
+    }
+
+    if (auto result = WaitForAvailableNodes(dbPath, settings.WaitNodesDuration_); !result.IsSuccess()) {
+        return result;
+    }
+
+    TDriverConfig dbDriverConfig(DriverConfig);
+    dbDriverConfig.SetDatabase(dbPath);
+    TDriver dbDriver(dbDriverConfig);
+    TSchemeClient dbSchemeClient(dbDriver);
+    TTableClient dbTableClient(dbDriver);
+
+    if (auto result = RestoreUsers(dbTableClient, fsPath, dbPath); !result.IsSuccess()) {
+        return result;
+    }
+
+    if (auto result = RestoreGroups(dbTableClient, fsPath, dbPath); !result.IsSuccess()) {
+        return result;
+    }
+
+    if (auto result = RestoreGroupMembers(dbTableClient, fsPath, dbPath); !result.IsSuccess()) {
+        return result;
+    }
+
+    if (auto result = RestorePermissionsImpl(dbSchemeClient, fsPath, dbPath); !result.IsSuccess()) {
+        return result;
+    }
+
+    if (settings.WithContent_) {
+        auto restoreResult = RestoreFolder(fsPath, dbPath, "", {}, {});
+        if (auto retryViewResult = RetryViewRestoration(); !retryViewResult.IsSuccess()) {
+            restoreResult = retryViewResult;
+        }
+        return restoreResult;
+    } else {
+        return Result<TRestoreResult>();
+    }
+}
+
+TRestoreResult TRestoreClient::RestoreDatabase(const TString& fsPath, const TRestoreDatabaseSettings& settings) {
+    auto result = RestoreDatabaseImpl(fsPath, settings);
+    if (result.IsSuccess()) {
+        LOG_I("Restore database completed successfully");
+    } else {
+        LOG_E("Restore database failed: " << result.GetIssues().ToOneLineString());
+    }
+
+    return result;
+}
+
+TRestoreResult TRestoreClient::RestoreDatabases(const TFsPath& fsPath, const TRestoreClusterSettings& settings) {
+    if (!fsPath.Exists()) {
+        return Result<TRestoreResult>(EStatus::BAD_REQUEST,
+            TStringBuilder() << "Specified folder does not exist: " << fsPath.GetPath());
+    }
+
+    if (!fsPath.IsDirectory()) {
+        return Result<TRestoreResult>(EStatus::BAD_REQUEST,
+            TStringBuilder() << "Specified folder is not a directory: " << fsPath.GetPath());
+    }
+
+    if (auto error = ErrorOnIncomplete(fsPath)) {
+        return *error;
+    }
+
+    if (IsFileExists(fsPath.Child(NFiles::Database().FileName))) {
+        TRestoreDatabaseSettings dbSettings = {
+            .WaitNodesDuration_ = settings.WaitNodesDuration_,
+            .WithContent_ = false
+        };
+
+        if (auto result = RestoreDatabaseImpl(fsPath, dbSettings); !result.IsSuccess()) {
+            return result;
+        }
+    }
+
+    TVector<TFsPath> children;
+    fsPath.List(children);
+
+    EStatus statusCode = EStatus::SUCCESS;
+    NIssue::TIssues issues;
+
+    for (const auto& child : children) {
+        if (child.IsDirectory()) {
+            if (auto result = RestoreDatabases(child, settings); !result.IsSuccess()) {
+                // don't abort, try to restore all databases
+                issues.AddIssues(result.GetIssues());
+                statusCode = EStatus::GENERIC_ERROR;
+            }
+        }
+    }
+
+    return TStatus(statusCode, std::move(issues));
+}
+
+TRestoreResult TRestoreClient::RestoreClusterImpl(const TString& fsPath, const TRestoreClusterSettings& settings) {
+    if (auto result = RestoreClusterRoot(fsPath); !result.IsSuccess()) {
+        return result;
+    }
+
+    if (auto result = RestoreDatabases(fsPath, settings); !result.IsSuccess()) {
+        return result;
+    }
+
+    return Result<TRestoreResult>();
+}
+
+TRestoreResult TRestoreClient::RestoreCluster(const TString& fsPath, const TRestoreClusterSettings& settings) {
+    LOG_I("Restore cluster from " << fsPath.Quote());
+
+    auto result = RestoreClusterImpl(fsPath, settings);
+    if (result.IsSuccess()) {
+        LOG_I("Restore cluster completed successfully");
+    } else {
+        LOG_E("Restore cluster failed: " << result.GetIssues().ToOneLineString());
+    }
+
+    return result;
 }
 
 TRestoreResult TRestoreClient::RestoreFolder(
@@ -1144,6 +1527,28 @@ TRestoreResult TRestoreClient::RestoreConsumers(const TString& topicPath, const 
     return Result<TRestoreResult>();
 }
 
+TRestoreResult TRestoreClient::RestorePermissionsImpl(
+    TSchemeClient& client,
+    const TFsPath& fsPath,
+    const TString& dbPath)
+{
+    if (!fsPath.Child(NFiles::Permissions().FileName).Exists()) {
+        return Result<TRestoreResult>();
+    }
+
+    LOG_D("Restore ACL " << fsPath.GetPath().Quote() << " to " << dbPath.Quote());
+
+    auto permissions = ReadPermissions(fsPath, Log.get());
+    auto result = ModifyPermissions(client, dbPath, TModifyPermissionsSettings(permissions));
+
+    if (result.GetStatus() == EStatus::UNAUTHORIZED) {
+        LOG_W("Not enough rights to restore permissions on " << dbPath.Quote() << ", skipping");
+        return Result<TRestoreResult>();
+    } 
+
+    return result;
+}
+
 TRestoreResult TRestoreClient::RestorePermissions(
         const TFsPath& fsPath,
         const TString& dbPath,
@@ -1162,14 +1567,7 @@ TRestoreResult TRestoreClient::RestorePermissions(
         return Result<TRestoreResult>();
     }
 
-    if (!fsPath.Child(NFiles::Permissions().FileName).Exists()) {
-        return Result<TRestoreResult>();
-    }
-
-    LOG_D("Restore ACL " << fsPath.GetPath().Quote() << " to " << dbPath.Quote());
-
-    auto permissions = ReadPermissions(fsPath, Log.get());
-    return ModifyPermissions(SchemeClient, dbPath, TModifyPermissionsSettings(permissions));
+    return RestorePermissionsImpl(SchemeClient, fsPath, dbPath);
 }
 
 TRestoreResult TRestoreClient::RestoreEmptyDir(

--- a/ydb/public/lib/ydb_cli/dump/restore_impl.h
+++ b/ydb/public/lib/ydb_cli/dump/restore_impl.h
@@ -2,6 +2,7 @@
 
 #include "dump.h"
 
+#include <ydb-cpp-sdk/client/cms/cms.h>
 #include <ydb-cpp-sdk/client/coordination/coordination.h>
 #include <ydb-cpp-sdk/client/import/import.h>
 #include <ydb-cpp-sdk/client/operation/operation.h>
@@ -142,6 +143,21 @@ class TRestoreClient {
     TRestoreResult RestorePermissions(const TFsPath& fsPath, const TString& dbPath, const TRestoreSettings& settings, bool isAlreadyExisting);
     TRestoreResult RestoreConsumers(const TString& topicPath, const std::vector<NTopic::TConsumer>& consumers);
 
+    TRestoreResult FindClusterRootPath();
+    TRestoreResult ReplaceClusterRoot(TString& outPath);
+    TRestoreResult WaitForAvailableNodes(const TString& database, TDuration waitDuration);
+    TRestoreResult RetryViewRestoration();
+
+    TRestoreResult RestoreClusterRoot(const TFsPath& fsPath);
+    TRestoreResult RestoreDatabases(const TFsPath& fsPath, const TRestoreClusterSettings& settings);
+    TRestoreResult RestoreUsers(NTable::TTableClient& client, const TFsPath& fsPath, const TString& dbPath);
+    TRestoreResult RestoreGroups(NTable::TTableClient& client, const TFsPath& fsPath, const TString& dbPath);
+    TRestoreResult RestoreGroupMembers(NTable::TTableClient& client, const TFsPath& fsPath, const TString& dbPath);
+
+    TRestoreResult RestoreClusterImpl(const TString& fsPath, const TRestoreClusterSettings& settings);
+    TRestoreResult RestoreDatabaseImpl(const TString& fsPath, const TRestoreDatabaseSettings& settings);
+    TRestoreResult RestorePermissionsImpl(NScheme::TSchemeClient& client, const TFsPath& fsPath, const TString& dbPath);
+
     THolder<NPrivate::IDataWriter> CreateDataWriter(const TString& dbPath, const TRestoreSettings& settings,
         const NTable::TTableDescription& desc, ui32 partitionCount, const TVector<THolder<NPrivate::IDataAccumulator>>& accumulators);
     TRestoreResult CreateDataAccumulators(TVector<THolder<NPrivate::IDataAccumulator>>& outAccumulators,
@@ -152,6 +168,8 @@ public:
     explicit TRestoreClient(const TDriver& driver, const std::shared_ptr<TLog>& log);
 
     TRestoreResult Restore(const TString& fsPath, const TString& dbPath, const TRestoreSettings& settings = {});
+    TRestoreResult RestoreCluster(const TString& fsPath, const TRestoreClusterSettings& settings = {});
+    TRestoreResult RestoreDatabase(const TString& fsPath, const TRestoreDatabaseSettings& settings = {});
 
 private:
     NImport::TImportClient ImportClient;
@@ -162,7 +180,10 @@ private:
     NCoordination::TClient CoordinationNodeClient;
     NRateLimiter::TRateLimiterClient RateLimiterClient;
     NQuery::TQueryClient QueryClient;
+    NCms::TCmsClient CmsClient;
     std::shared_ptr<TLog> Log;
+    // Used to creating child drivers with different database settings.
+    TDriverConfig DriverConfig;
 
     struct TRestoreViewCall {
         TFsPath FsPath;
@@ -175,7 +196,7 @@ private:
     // If the dependency is not created yet, then the view restoration will fail.
     // We retry failed view creation attempts until either all views are created, or the errors are persistent.
     TVector<TRestoreViewCall> ViewRestorationCalls;
-
+    TString ClusterRootPath;
 }; // TRestoreClient
 
 } // NYdb::NDump

--- a/ydb/public/lib/ydb_cli/dump/util/util.cpp
+++ b/ydb/public/lib/ydb_cli/dump/util/util.cpp
@@ -59,4 +59,10 @@ TGetDatabaseStatusResult GetDatabaseStatus(TCmsClient& cmsClient, const std::str
     });
 }
 
+TStatus CreateDatabase(TCmsClient& cmsClient, const std::string& path, const TCreateDatabaseSettings& settings) {
+    return NConsoleClient::RetryFunction([&]() -> TStatus {
+        return cmsClient.CreateDatabase(path, settings).ExtractValueSync();
+    });
+}
+
 } // NYdb::NDump

--- a/ydb/public/lib/ydb_cli/dump/util/util.h
+++ b/ydb/public/lib/ydb_cli/dump/util/util.h
@@ -71,4 +71,9 @@ NCms::TGetDatabaseStatusResult GetDatabaseStatus(
     const std::string& path,
     const NCms::TGetDatabaseStatusSettings& settings = {});
 
+TStatus CreateDatabase(
+    NCms::TCmsClient& cmsClient,
+    const std::string& path,
+    const NCms::TCreateDatabaseSettings& settings = {});
+
 } // NYdb::NDump

--- a/ydb/public/sdk/cpp/include/ydb-cpp-sdk/client/cms/cms.h
+++ b/ydb/public/sdk/cpp/include/ydb-cpp-sdk/client/cms/cms.h
@@ -133,14 +133,14 @@ struct TTargetTrackingPolicy {
     TTargetTrackingPolicy() = default;
     TTargetTrackingPolicy(const Ydb::Cms::ScaleRecommenderPolicies_ScaleRecommenderPolicy_TargetTrackingPolicy& proto);
 
-    std::variant<TAverageCpuUtilizationPercent> Target;
+    std::variant<std::monostate, TAverageCpuUtilizationPercent> Target;
 };
 
 struct TScaleRecommenderPolicy {
     TScaleRecommenderPolicy() = default;
     TScaleRecommenderPolicy(const Ydb::Cms::ScaleRecommenderPolicies_ScaleRecommenderPolicy& proto);
 
-    std::variant<TTargetTrackingPolicy> Policy;
+    std::variant<std::monostate, TTargetTrackingPolicy> Policy;
 };
 
 struct TScaleRecommenderPolicies {
@@ -150,7 +150,7 @@ struct TScaleRecommenderPolicies {
     std::vector<TScaleRecommenderPolicy> Policies;
 };
 
-using TResourcesKind = std::variant<TResources, TSharedResources, TServerlessResources>;
+using TResourcesKind = std::variant<std::monostate, TResources, TSharedResources, TServerlessResources>;
 
 class TGetDatabaseStatusResult : public TStatus {
 public:

--- a/ydb/public/sdk/cpp/include/ydb-cpp-sdk/client/cms/cms.h
+++ b/ydb/public/sdk/cpp/include/ydb-cpp-sdk/client/cms/cms.h
@@ -150,13 +150,15 @@ struct TScaleRecommenderPolicies {
     std::vector<TScaleRecommenderPolicy> Policies;
 };
 
+using TResourcesKind = std::variant<TResources, TSharedResources, TServerlessResources>;
+
 class TGetDatabaseStatusResult : public TStatus {
 public:
     TGetDatabaseStatusResult(TStatus&& status, const Ydb::Cms::GetDatabaseStatusResult& proto);
 
     const std::string& GetPath() const;
     EState GetState() const;
-    const std::variant<TResources, TSharedResources, TServerlessResources>& GetResourcesKind() const;
+    const TResourcesKind& GetResourcesKind() const;
     const TResources& GetAllocatedResources() const;
     const std::vector<TAllocatedComputationalUnit>& GetRegisteredResources() const;
     std::uint64_t GetGeneration() const;
@@ -170,7 +172,7 @@ public:
 private:
     std::string Path_;
     EState State_;
-    std::variant<TResources, TSharedResources, TServerlessResources> ResourcesKind_;
+    TResourcesKind ResourcesKind_;
     TResources AllocatedResources_;
     std::vector<TAllocatedComputationalUnit> RegisteredResources_;
     std::uint64_t Generation_;
@@ -181,6 +183,19 @@ private:
 
 using TAsyncGetDatabaseStatusResult = NThreading::TFuture<TGetDatabaseStatusResult>;
 
+struct TCreateDatabaseSettings : public TOperationRequestSettings<TCreateDatabaseSettings> {
+    TCreateDatabaseSettings() = default;
+    explicit TCreateDatabaseSettings(const Ydb::Cms::CreateDatabaseRequest& request);
+
+    // Fills CreateDatabaseRequest proto from this settings
+    void SerializeTo(Ydb::Cms::CreateDatabaseRequest& request) const;
+
+    FLUENT_SETTING(TResourcesKind, ResourcesKind);
+    FLUENT_SETTING(TSchemaOperationQuotas, SchemaOperationQuotas);
+    FLUENT_SETTING(TDatabaseQuotas, DatabaseQuotas);
+    FLUENT_SETTING(TScaleRecommenderPolicies, ScaleRecommenderPolicies);
+};
+
 class TCmsClient {
 public:
     explicit TCmsClient(const TDriver& driver, const TCommonClientSettings& settings = TCommonClientSettings());
@@ -188,7 +203,8 @@ public:
     TAsyncListDatabasesResult ListDatabases(const TListDatabasesSettings& settings = TListDatabasesSettings());
     TAsyncGetDatabaseStatusResult GetDatabaseStatus(const std::string& path,
         const TGetDatabaseStatusSettings& settings = TGetDatabaseStatusSettings());
-
+    TAsyncStatus CreateDatabase(const std::string& path,
+        const TCreateDatabaseSettings& settings = TCreateDatabaseSettings());
 private:
     class TImpl;
     std::shared_ptr<TImpl> Impl_;

--- a/ydb/public/sdk/cpp/include/ydb-cpp-sdk/client/driver/driver.h
+++ b/ydb/public/sdk/cpp/include/ydb-cpp-sdk/client/driver/driver.h
@@ -142,6 +142,7 @@ public:
     template<typename TExtension>
     void AddExtension(typename TExtension::TParams params = typename TExtension::TParams());
 
+    TDriverConfig GetConfig() const;
 private:
     std::shared_ptr<TGRpcConnectionsImpl> Impl_;
 };

--- a/ydb/public/sdk/cpp/src/client/cms/cms.cpp
+++ b/ydb/public/sdk/cpp/src/client/cms/cms.cpp
@@ -1,8 +1,12 @@
 #include <ydb-cpp-sdk/client/cms/cms.h>
 
+#include <src/client/common_client/impl/client.h>
 #include <ydb/public/api/grpc/ydb_cms_v1.grpc.pb.h>
 #include <ydb/public/api/protos/ydb_cms.pb.h>
-#include <src/client/common_client/impl/client.h>
+
+#define INCLUDE_YDB_INTERNAL_H
+#include <ydb/public/sdk/cpp/src/client/impl/ydb_internal/make_request/make.h>
+#undef INCLUDE_YDB_INTERNAL_H
 
 namespace NYdb::inline V3::NCms {
 
@@ -23,6 +27,76 @@ namespace {
                 return EState::Configuring;
             default:
                 return EState::StateUnspecified;
+        }
+    }
+
+    void SerializeToImpl(
+        const TResourcesKind& resourcesKind,
+        const TSchemaOperationQuotas& schemaQuotas,
+        const TDatabaseQuotas& dbQuotas,
+        const TScaleRecommenderPolicies& scaleRecommenderPolicies,
+        Ydb::Cms::CreateDatabaseRequest& out)
+    {
+        if (std::holds_alternative<NCms::TResources>(resourcesKind)) {
+            const auto& resources = std::get<NCms::TResources>(resourcesKind);
+            for (const auto& storageUnit : resources.StorageUnits) {
+                auto* protoUnit = out.mutable_resources()->add_storage_units();
+                protoUnit->set_unit_kind(storageUnit.UnitKind);
+                protoUnit->set_count(storageUnit.Count);
+            }
+            for (const auto& computationalUnit : resources.ComputationalUnits) {
+                auto* protoUnit = out.mutable_resources()->add_computational_units();
+                protoUnit->set_unit_kind(computationalUnit.UnitKind);
+                protoUnit->set_count(computationalUnit.Count);
+                protoUnit->set_availability_zone(computationalUnit.AvailabilityZone);
+            }
+        } else if (std::holds_alternative<NCms::TSharedResources>(resourcesKind)) {
+            const auto& resources = std::get<NCms::TSharedResources>(resourcesKind);
+            for (const auto& storageUnit : resources.StorageUnits) {
+                auto* protoUnit = out.mutable_shared_resources()->add_storage_units();
+                protoUnit->set_unit_kind(storageUnit.UnitKind);
+                protoUnit->set_count(storageUnit.Count);
+            }
+            for (const auto& computationalUnit : resources.ComputationalUnits) {
+                auto* protoUnit = out.mutable_shared_resources()->add_computational_units();
+                protoUnit->set_unit_kind(computationalUnit.UnitKind);
+                protoUnit->set_count(computationalUnit.Count);
+                protoUnit->set_availability_zone(computationalUnit.AvailabilityZone);
+            }
+        } else if (std::holds_alternative<NCms::TServerlessResources>(resourcesKind)) {
+            const auto& resources = std::get<NCms::TServerlessResources>(resourcesKind);
+            out.mutable_serverless_resources()->set_shared_database_path(resources.SharedDatabasePath);
+        }
+        
+        for (const auto& quota : schemaQuotas.LeakyBucketQuotas) {
+            auto protoQuota = out.mutable_schema_operation_quotas()->add_leaky_bucket_quotas();
+            protoQuota->set_bucket_seconds(quota.BucketSeconds);
+            protoQuota->set_bucket_size(quota.BucketSize);
+        }
+    
+        out.mutable_database_quotas()->set_data_size_hard_quota(dbQuotas.DataSizeHardQuota);
+        out.mutable_database_quotas()->set_data_size_soft_quota(dbQuotas.DataSizeSoftQuota);
+        out.mutable_database_quotas()->set_data_stream_shards_quota(dbQuotas.DataStreamShardsQuota);
+        out.mutable_database_quotas()->set_data_stream_reserved_storage_quota(dbQuotas.DataStreamReservedStorageQuota);
+        out.mutable_database_quotas()->set_ttl_min_run_internal_seconds(dbQuotas.TtlMinRunInternalSeconds);
+    
+        for (const auto& quota : dbQuotas.StorageQuotas) {
+            auto protoQuota = out.mutable_database_quotas()->add_storage_quotas();
+            protoQuota->set_unit_kind(quota.UnitKind);
+            protoQuota->set_data_size_hard_quota(quota.DataSizeHardQuota);
+            protoQuota->set_data_size_soft_quota(quota.DataSizeSoftQuota);
+        }
+    
+        for (const auto& policy : scaleRecommenderPolicies.Policies) {
+            auto* protoPolicy = out.mutable_scale_recommender_policies()->add_policies();
+            if (std::holds_alternative<NCms::TTargetTrackingPolicy>(policy.Policy)) {
+                const auto& targetTracking = std::get<NCms::TTargetTrackingPolicy>(policy.Policy);
+                auto* protoTargetTracking = protoPolicy->mutable_target_tracking_policy();
+                if (std::holds_alternative<NCms::TTargetTrackingPolicy::TAverageCpuUtilizationPercent>(targetTracking.Target)) {
+                    const auto& target = std::get<NCms::TTargetTrackingPolicy::TAverageCpuUtilizationPercent>(targetTracking.Target);
+                    protoTargetTracking->set_average_cpu_utilization_percent(target);
+                }
+            }
         }
     }
 } // anonymous namespace
@@ -146,7 +220,7 @@ EState TGetDatabaseStatusResult::GetState() const {
     return State_;
 }
 
-const std::variant<TResources, TSharedResources, TServerlessResources>& TGetDatabaseStatusResult::GetResourcesKind() const {
+const TResourcesKind& TGetDatabaseStatusResult::GetResourcesKind() const {
     return ResourcesKind_;
 }
 
@@ -176,67 +250,31 @@ const TScaleRecommenderPolicies& TGetDatabaseStatusResult::GetScaleRecommenderPo
 
 void TGetDatabaseStatusResult::SerializeTo(Ydb::Cms::CreateDatabaseRequest& request) const {
     request.set_path(Path_);
-    if (std::holds_alternative<NCms::TResources>(ResourcesKind_)) {
-        const auto& resources = std::get<NCms::TResources>(ResourcesKind_);
-        for (const auto& storageUnit : resources.StorageUnits) {
-            auto* protoUnit = request.mutable_resources()->add_storage_units();
-            protoUnit->set_unit_kind(storageUnit.UnitKind);
-            protoUnit->set_count(storageUnit.Count);
-        }
-        for (const auto& computationalUnit : resources.ComputationalUnits) {
-            auto* protoUnit = request.mutable_resources()->add_computational_units();
-            protoUnit->set_unit_kind(computationalUnit.UnitKind);
-            protoUnit->set_count(computationalUnit.Count);
-            protoUnit->set_availability_zone(computationalUnit.AvailabilityZone);
-        }
-    } else if (std::holds_alternative<NCms::TSharedResources>(ResourcesKind_)) {
-        const auto& resources = std::get<NCms::TSharedResources>(ResourcesKind_);
-        for (const auto& storageUnit : resources.StorageUnits) {
-            auto* protoUnit = request.mutable_shared_resources()->add_storage_units();
-            protoUnit->set_unit_kind(storageUnit.UnitKind);
-            protoUnit->set_count(storageUnit.Count);
-        }
-        for (const auto& computationalUnit : resources.ComputationalUnits) {
-            auto* protoUnit = request.mutable_shared_resources()->add_computational_units();
-            protoUnit->set_unit_kind(computationalUnit.UnitKind);
-            protoUnit->set_count(computationalUnit.Count);
-            protoUnit->set_availability_zone(computationalUnit.AvailabilityZone);
-        }
-    } else if (std::holds_alternative<NCms::TServerlessResources>(ResourcesKind_)) {
-        const auto& resources = std::get<NCms::TServerlessResources>(ResourcesKind_);
-        request.mutable_serverless_resources()->set_shared_database_path(resources.SharedDatabasePath);
-    }
-    
-    for (const auto& quota : SchemaOperationQuotas_.LeakyBucketQuotas) {
-        auto protoQuota = request.mutable_schema_operation_quotas()->add_leaky_bucket_quotas();
-        protoQuota->set_bucket_seconds(quota.BucketSeconds);
-        protoQuota->set_bucket_size(quota.BucketSize);
-    }
+    SerializeToImpl(ResourcesKind_, SchemaOperationQuotas_, DatabaseQuotas_, ScaleRecommenderPolicies_, request);
+}
 
-    request.mutable_database_quotas()->set_data_size_hard_quota(DatabaseQuotas_.DataSizeHardQuota);
-    request.mutable_database_quotas()->set_data_size_soft_quota(DatabaseQuotas_.DataSizeSoftQuota);
-    request.mutable_database_quotas()->set_data_stream_shards_quota(DatabaseQuotas_.DataStreamShardsQuota);
-    request.mutable_database_quotas()->set_data_stream_reserved_storage_quota(DatabaseQuotas_.DataStreamReservedStorageQuota);
-    request.mutable_database_quotas()->set_ttl_min_run_internal_seconds(DatabaseQuotas_.TtlMinRunInternalSeconds);
+TCreateDatabaseSettings::TCreateDatabaseSettings(const Ydb::Cms::CreateDatabaseRequest& request)
+  : SchemaOperationQuotas_(request.schema_operation_quotas())
+  , DatabaseQuotas_(request.database_quotas())
+  , ScaleRecommenderPolicies_(request.scale_recommender_policies())
+{
+  switch (request.resources_kind_case()) {
+      case Ydb::Cms::CreateDatabaseRequest::kResources:
+          ResourcesKind_ = TResources(request.resources());
+          break;
+      case Ydb::Cms::CreateDatabaseRequest::kSharedResources:
+          ResourcesKind_ = TSharedResources(request.shared_resources());
+          break;
+      case Ydb::Cms::CreateDatabaseRequest::kServerlessResources:
+          ResourcesKind_ = request.serverless_resources();
+          break;
+      case Ydb::Cms::CreateDatabaseRequest::RESOURCES_KIND_NOT_SET:
+          break;
+  }
+}
 
-    for (const auto& quota : DatabaseQuotas_.StorageQuotas) {
-        auto protoQuota = request.mutable_database_quotas()->add_storage_quotas();
-        protoQuota->set_unit_kind(quota.UnitKind);
-        protoQuota->set_data_size_hard_quota(quota.DataSizeHardQuota);
-        protoQuota->set_data_size_soft_quota(quota.DataSizeSoftQuota);
-    }
-
-    for (const auto& policy : ScaleRecommenderPolicies_.Policies) {
-        auto* protoPolicy = request.mutable_scale_recommender_policies()->add_policies();
-        if (std::holds_alternative<NCms::TTargetTrackingPolicy>(policy.Policy)) {
-            const auto& targetTracking = std::get<NCms::TTargetTrackingPolicy>(policy.Policy);
-            auto* protoTargetTracking = protoPolicy->mutable_target_tracking_policy();
-            if (std::holds_alternative<NCms::TTargetTrackingPolicy::TAverageCpuUtilizationPercent>(targetTracking.Target)) {
-                const auto& target = std::get<NCms::TTargetTrackingPolicy::TAverageCpuUtilizationPercent>(targetTracking.Target);
-                protoTargetTracking->set_average_cpu_utilization_percent(target);
-            }
-        }
-    }
+void TCreateDatabaseSettings::SerializeTo(Ydb::Cms::CreateDatabaseRequest& request) const {
+    SerializeToImpl(ResourcesKind_, SchemaOperationQuotas_, DatabaseQuotas_, ScaleRecommenderPolicies_, request);
 }
 
 class TCmsClient::TImpl : public TClientImplCommon<TCmsClient::TImpl> {
@@ -246,7 +284,7 @@ public:
     { }
 
     TAsyncListDatabasesResult ListDatabases(const TListDatabasesSettings& settings) {
-        Ydb::Cms::ListDatabasesRequest request;
+        auto request = MakeOperationRequest<Ydb::Cms::ListDatabasesRequest>(settings);
 
         auto promise = NThreading::NewPromise<TListDatabasesResult>();
 
@@ -272,7 +310,7 @@ public:
     }
 
     TAsyncGetDatabaseStatusResult GetDatabaseStatus(const std::string& path, const TGetDatabaseStatusSettings& settings) {
-        Ydb::Cms::GetDatabaseStatusRequest request;
+        auto request = MakeOperationRequest<Ydb::Cms::GetDatabaseStatusRequest>(settings);
         request.set_path(path);
 
         auto promise = NThreading::NewPromise<TGetDatabaseStatusResult>();
@@ -297,6 +335,29 @@ public:
 
         return promise.GetFuture();
     }
+
+    TAsyncStatus CreateDatabase(const std::string& path, const TCreateDatabaseSettings& settings) {
+        auto request = MakeOperationRequest<Ydb::Cms::CreateDatabaseRequest>(settings);
+        request.set_path(path);
+        settings.SerializeTo(request);
+
+        auto promise = NThreading::NewPromise<TStatus>();
+
+        auto extractor = [promise]
+            (google::protobuf::Any*, TPlainStatus status) mutable {
+                promise.SetValue(TStatus(std::move(status)));
+            };
+
+        Connections_->RunDeferred<Ydb::Cms::V1::CmsService, Ydb::Cms::CreateDatabaseRequest, Ydb::Cms::CreateDatabaseResponse>(
+            std::move(request),
+            extractor,
+            &Ydb::Cms::V1::CmsService::Stub::AsyncCreateDatabase,
+            DbDriverState_,
+            INITIAL_DEFERRED_CALL_DELAY,
+            TRpcRequestSettings::Make(settings));
+
+        return promise.GetFuture();
+    }
 };
 
 TCmsClient::TCmsClient(const TDriver& driver, const TCommonClientSettings& settings)
@@ -312,6 +373,13 @@ TAsyncGetDatabaseStatusResult TCmsClient::GetDatabaseStatus(
     const TGetDatabaseStatusSettings& settings)
 {
     return Impl_->GetDatabaseStatus(path, settings);
+}
+
+TAsyncStatus TCmsClient::CreateDatabase(
+    const std::string& path,
+    const TCreateDatabaseSettings& settings) 
+{
+    return Impl_->CreateDatabase(path, settings);
 }
 
 } // namespace NYdb::NCms

--- a/ydb/public/sdk/cpp/src/client/driver/driver.cpp
+++ b/ydb/public/sdk/cpp/src/client/driver/driver.cpp
@@ -223,4 +223,39 @@ void TDriver::Stop(bool wait) {
     Impl_->Stop(wait);
 }
 
+TDriverConfig TDriver::GetConfig() const {
+    TDriverConfig config;
+
+    config.SetEndpoint(Impl_->DefaultDiscoveryEndpoint_);
+    config.SetNetworkThreadsNum(Impl_->NetworkThreadsNum_);
+    config.SetClientThreadsNum(Impl_->ClientThreadsNum_);
+    config.SetMaxClientQueueSize(Impl_->MaxQueuedResponses_);
+    if (Impl_->SslCredentials_.IsEnabled) {
+        config.UseSecureConnection(Impl_->SslCredentials_.CaCert);
+    }
+    config.UseClientCertificate(Impl_->SslCredentials_.Cert, Impl_->SslCredentials_.PrivateKey);
+    config.SetCredentialsProviderFactory(Impl_->DefaultCredentialsProviderFactory_);
+    config.SetDatabase(Impl_->DefaultDatabase_);
+    config.SetDiscoveryMode(Impl_->DefaultDiscoveryMode_);
+    config.SetMaxQueuedRequests(Impl_->MaxQueuedRequests_);
+    config.SetGrpcMemoryQuota(Impl_->MemoryQuota_);
+    config.SetTcpKeepAliveSettings(
+        Impl_->TcpKeepAliveSettings_.Enabled,
+        Impl_->TcpKeepAliveSettings_.Idle,
+        Impl_->TcpKeepAliveSettings_.Count,
+        Impl_->TcpKeepAliveSettings_.Interval
+    );
+    config.SetDrainOnDtors(Impl_->DrainOnDtors_);
+    config.SetBalancingPolicy(Impl_->BalancingSettings_.Policy, Impl_->BalancingSettings_.PolicyParams);
+    config.SetGRpcKeepAliveTimeout(Impl_->GRpcKeepAliveTimeout_);
+    config.SetGRpcKeepAlivePermitWithoutCalls(Impl_->GRpcKeepAlivePermitWithoutCalls_);
+    config.SetSocketIdleTimeout(Impl_->SocketIdleTimeout_);
+    config.SetMaxInboundMessageSize(Impl_->MaxInboundMessageSize_);
+    config.SetMaxOutboundMessageSize(Impl_->MaxOutboundMessageSize_);
+    config.SetMaxMessageSize(Impl_->MaxMessageSize_);
+    config.Impl_->Log = Impl_->Log;
+    
+    return config;
+}
+
 } // namespace NYdb

--- a/ydb/public/sdk/cpp/src/client/impl/ydb_internal/grpc_connections/grpc_connections.h
+++ b/ydb/public/sdk/cpp/src/client/impl/ydb_internal/grpc_connections/grpc_connections.h
@@ -40,6 +40,7 @@ class TGRpcConnectionsImpl
     , public IInternalClient
 {
     friend class TDeferredAction;
+    friend class TDriver;
 public:
     TGRpcConnectionsImpl(std::shared_ptr<IConnectionsParams> params);
     ~TGRpcConnectionsImpl();
@@ -689,6 +690,7 @@ private:
     std::mutex ExtensionsLock_;
     ::NMonitoring::TMetricRegistry* MetricRegistryPtr_ = nullptr;
 
+    const size_t ClientThreadsNum_;
     std::unique_ptr<IThreadPool> ResponseQueue_;
 
     const std::string DefaultDiscoveryEndpoint_;
@@ -698,6 +700,7 @@ private:
     TDbDriverStateTracker StateTracker_;
     const EDiscoveryMode DefaultDiscoveryMode_;
     const i64 MaxQueuedRequests_;
+    const i64 MaxQueuedResponses_;
     const bool DrainOnDtors_;
     const TBalancingSettings BalancingSettings_;
     const TDuration GRpcKeepAliveTimeout_;
@@ -708,6 +711,8 @@ private:
     const ui64 MaxMessageSize_;
 
     std::atomic_int64_t QueuedRequests_;
+    const NYdbGrpc::TTcpKeepAliveSettings TcpKeepAliveSettings_;
+    const TDuration SocketIdleTimeout_;
 #ifndef YDB_GRPC_BYPASS_CHANNEL_POOL
     NYdbGrpc::TChannelPool ChannelPool_;
 #endif
@@ -719,6 +724,7 @@ private:
 
     IDiscoveryMutatorApi::TMutatorCb DiscoveryMutatorCb;
 
+    const size_t NetworkThreadsNum_;
     // Must be the last member (first called destructor)
     NYdbGrpc::TGRpcClientLow GRpcClientLow_;
     TLog Log;


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of changes introduced in this PR -->

Добавлена возможность делать полный бекап и восстановление кластера и базы данных

### Changelog category <!-- remove all except one -->

* New feature

### Additional information
#### Notes
- Можно указать путь БД, в которую проводить восстановление с помощью параметра `-d`. Если параметр отсутствует, то путь берется из дампа.
- Для восстановления без ожидания запуска нод, необходимо передавать параметр `--wait-nodes-duration 0`.
- При неудачном восстановлении объекты не удаляются, но восстановление можно запустить еще раз поверх уже созданных объектов от предыдущего восстановления.
- При недостатке прав на восстановление объекта, объект пропускается и запись об этом выводится в лог.
- Если при восстановлении кластера не получится восстановить одну из БД, то восстановление остальных БД продолжится, но процесс будет завершен с ошибкой.

#### Help
<details>
    <summary><code>ydb admin cluster restore --help</code></summary>
<img width="1115" alt="image" src="https://github.com/user-attachments/assets/ce5c8047-254a-49b6-9f5e-35cede6b53df" />



</details>

<details>
    <summary><code>ydb admin database restore --help</code></summary>
    
<img width="1531" alt="image" src="https://github.com/user-attachments/assets/6419a05d-5355-42aa-b042-7c0c739b4d26" />


</details>

#### Logs

<details>
    <summary><code>ydb -vv -e &ltendpoint&gt admin cluster restore -i backup</code></summary>
<pre>
This command may damage your cluster, do you want to conitnue? [y/N] y
2025-02-12T10:58:46.615708Z :INFO: Restore cluster from "backup"
2025-02-12T10:58:46.624188Z :INFO: Restore cluster root "/Root" from "backup"
2025-02-12T10:58:47.091366Z :INFO: Restore database from "backup/Root/db1" to "/Root/db1"
2025-02-12T10:58:47.212256Z :INFO: Waiting for available database nodes for "/Root/db1", make sure that nodes are running, time left: 59.977991s
2025-02-12T10:58:48.218221Z :INFO: Waiting for available database nodes for "/Root/db1", make sure that nodes are running, time left: 58.926389s
2025-02-12T10:58:50.550437Z :INFO: Restore cluster completed successfully
</pre>
</details>

<details>
    <summary><code>ydb -vv -e &ltendpoint&gt admin database restore -i backup_db</code></summary>
<pre>
This command may damage your cluster, do you want to conitnue? [y/N] y
2025-02-12T11:00:54.534411Z :INFO: Restore database from "backup_db" to "/Root/db1"
2025-02-12T11:00:54.645544Z :INFO: Waiting for available database nodes for "/Root/db1", make sure that nodes are running, time left: 59.983965s
2025-02-12T11:00:55.651360Z :INFO: Waiting for available database nodes for "/Root/db1", make sure that nodes are running, time left: 58.932479s
2025-02-12T11:00:58.115980Z :INFO: Restore table "backup_db/new" to "/Root/db1/new"
2025-02-12T11:00:58.272490Z :INFO: Restore database completed successfully
</pre>
</details>

#### Verbose logs

<details>
    <summary><code>ydb -vvv -e &ltendpoint&gt admin cluster restore -i backup</code></summary>
<pre>
2025-02-12T11:03:09.243642Z :INFO: Restore cluster from "backup"
2025-02-12T11:03:09.253768Z :INFO: Restore cluster root "/Root" from "backup"
2025-02-12T11:03:09.263763Z :DEBUG: Restore users to "/Root"
2025-02-12T11:03:09.546181Z :DEBUG: User from create statement "CREATE USER `root` HASH '{\"hash\":\"VPxyHDfW95ETmM8vXvCTqjzCKkCxF0jksXq54nS/bb4=\",\"salt\":\"GWijMh0DAAwf2aqqg7NIVw==\",\"type\":\"argon2id\"}';" already exists, trying to alter it
2025-02-12T11:03:09.571730Z :DEBUG: Restore groups to "/Root"
2025-02-12T11:03:09.583974Z :DEBUG: Restore group members to "/Root"
2025-02-12T11:03:09.669050Z :DEBUG: Restore ACL "backup" to "/Root"
2025-02-12T11:03:09.669129Z :DEBUG: Read ACL from "backup/permissions.pb"
2025-02-12T11:03:09.693849Z :DEBUG: Read database description from "backup/Root/db1/database.pb"
2025-02-12T11:03:09.700502Z :INFO: Restore database from "backup/Root/db1" to "/Root/db1"
2025-02-12T11:03:09.813593Z :INFO: Waiting for available database nodes for "/Root/db1", make sure that nodes are running, time left: 59.984446s
2025-02-12T11:03:10.819878Z :INFO: Waiting for available database nodes for "/Root/db1", make sure that nodes are running, time left: 58.932539s
2025-02-12T11:03:12.835972Z :DEBUG: Restore users to "/Root/db1"
2025-02-12T11:03:13.058497Z :DEBUG: Restore groups to "/Root/db1"
2025-02-12T11:03:13.072378Z :DEBUG: Restore group members to "/Root/db1"
2025-02-12T11:03:13.112421Z :DEBUG: Restore ACL "backup/Root/db1" to "/Root/db1"
2025-02-12T11:03:13.112494Z :DEBUG: Read ACL from "backup/Root/db1/permissions.pb"
2025-02-12T11:03:13.133165Z :INFO: Restore cluster completed successfully
</pre>
</details>

<details>
    <summary><code>ydb -vvv -e &ltendpoint&gt admin database restore -i backup_db</code></summary>
<pre>
2025-02-12T11:10:55.946334Z :DEBUG: Read database description from "backup_db/database.pb"
2025-02-12T11:10:55.973248Z :INFO: Restore database from "backup_db" to "/Root/db1"
2025-02-12T11:10:56.094590Z :INFO: Waiting for available database nodes for "/Root/db1", make sure that nodes are running, time left: 59.980497s
2025-02-12T11:10:57.100863Z :INFO: Waiting for available database nodes for "/Root/db1", make sure that nodes are running, time left: 58.928185s
2025-02-12T11:10:59.123856Z :DEBUG: Restore users to "/Root/db1"
2025-02-12T11:10:59.468623Z :DEBUG: Restore groups to "/Root/db1"
2025-02-12T11:10:59.497125Z :DEBUG: Restore group members to "/Root/db1"
2025-02-12T11:10:59.582418Z :DEBUG: Restore ACL "backup_db" to "/Root/db1"
2025-02-12T11:10:59.582490Z :DEBUG: Read ACL from "backup_db/permissions.pb"
2025-02-12T11:10:59.593873Z :DEBUG: Restore folder "backup_db" to "/Root/db1"
2025-02-12T11:10:59.594235Z :DEBUG: Process "backup_db/new"
2025-02-12T11:10:59.594306Z :DEBUG: Read scheme from "backup_db/new/scheme.pb"
2025-02-12T11:10:59.603713Z :INFO: Restore table "backup_db/new" to "/Root/db1/new"
2025-02-12T11:10:59.725621Z :DEBUG: Created "/Root/db1/new"
2025-02-12T11:10:59.730399Z :DEBUG: Read data from "backup_db/new/data_00.csv"
2025-02-12T11:10:59.740758Z :DEBUG: Restore ACL "backup_db/new" to "/Root/db1/new"
2025-02-12T11:10:59.740827Z :DEBUG: Read ACL from "backup_db/new/permissions.pb"
2025-02-12T11:10:59.749696Z :DEBUG: Restore ACL "backup_db" to "/Root/db1"
2025-02-12T11:10:59.749763Z :DEBUG: Read ACL from "backup_db/permissions.pb"
2025-02-12T11:10:59.771926Z :INFO: Restore database completed successfully
</pre>
</details>
