### PR TITLE
security: unify and extend admin checks

### DIFF
--- a/ydb/core/base/auth.cpp
+++ b/ydb/core/base/auth.cpp
@@ -1,3 +1,5 @@
+#include <ydb/library/aclib/aclib.h>
+
 #include "auth.h"
 
 namespace NKikimr {
@@ -66,5 +68,16 @@ bool IsAdministrator(const TAppData* appData, const NACLib::TUserToken* userToke
 }
 
 
+bool IsDatabaseAdministrator(const NACLib::TUserToken* userToken, const NACLib::TSID& databaseOwner) {
+    // no database, no access
+    if (databaseOwner.empty()) {
+        return false;
+    }
+    // empty token can't have raised access level
+    if (!userToken || userToken->GetUserSID().empty()) {
+        return false;
+    }
+    return userToken->IsExist(databaseOwner);
+}
 
 }

--- a/ydb/core/base/auth.cpp
+++ b/ydb/core/base/auth.cpp
@@ -4,9 +4,21 @@ namespace NKikimr {
 
 namespace {
 
-bool HasToken(const TAppData* appData, const NACLib::TUserToken& userToken) {
-    for (const auto& sid : appData->AdministrationAllowedSIDs) {
-        if (userToken.IsExist(sid)) {
+template <class Iterable>
+bool IsTokenAllowedImpl(const NACLib::TUserToken* userToken, const Iterable& allowedSIDs) {
+    // empty set contains any element
+    if (allowedSIDs.empty()) {
+        return true;
+    }
+
+    // empty element does not belong to any non-empty set
+    if (!userToken || userToken->GetUserSID().empty()) {
+        return false;
+    }
+
+    // its enough to a single sid (user or group) from the token to be in the set
+    for (const auto& sid : allowedSIDs) {
+        if (userToken->IsExist(sid)) {
             return true;
         }
     }
@@ -14,35 +26,45 @@ bool HasToken(const TAppData* appData, const NACLib::TUserToken& userToken) {
     return false;
 }
 
+NACLib::TUserToken ParseUserToken(const TString& userTokenSerialized) {
+    NACLibProto::TUserToken tokenPb;
+    if (!tokenPb.ParseFromString(userTokenSerialized)) {
+        // we want to treat invalid token as empty,
+        // so then result object must be recreated (or cleared)
+        // because failed parsing makes result object dirty
+        tokenPb = NACLibProto::TUserToken();
+    }
+    return NACLib::TUserToken(tokenPb);
 }
 
-bool IsAdministrator(const TAppData* appData, const TString& userToken) {
-    if (appData->AdministrationAllowedSIDs.empty()) {
-        return true;
-    }
+}
 
-    if (!userToken) {
-        return false;
-    }
+bool IsTokenAllowed(const NACLib::TUserToken* userToken, const TVector<TString>& allowedSIDs) {
+    return IsTokenAllowedImpl(userToken, allowedSIDs);
+}
 
-    NACLibProto::TUserToken tokenPb;
-    if (!tokenPb.ParseFromString(userToken)) {
-        return false;
-    }
+bool IsTokenAllowed(const NACLib::TUserToken* userToken, const NProtoBuf::RepeatedPtrField<TString>& allowedSIDs) {
+    return IsTokenAllowedImpl(userToken, allowedSIDs);
+}
 
-    return HasToken(appData, NACLib::TUserToken(std::move(tokenPb)));
+bool IsTokenAllowed(const TString& userTokenSerialized, const TVector<TString>& allowedSIDs) {
+    NACLib::TUserToken userToken = ParseUserToken(userTokenSerialized);
+    return IsTokenAllowed(&userToken, allowedSIDs);
+}
+
+bool IsTokenAllowed(const TString& userTokenSerialized, const NProtoBuf::RepeatedPtrField<TString>& allowedSIDs) {
+    NACLib::TUserToken userToken = ParseUserToken(userTokenSerialized);
+    return IsTokenAllowed(&userToken, allowedSIDs);
+}
+
+bool IsAdministrator(const TAppData* appData, const TString& userTokenSerialized) {
+    return IsTokenAllowed(userTokenSerialized, appData->AdministrationAllowedSIDs);
 }
 
 bool IsAdministrator(const TAppData* appData, const NACLib::TUserToken* userToken) {
-    if (appData->AdministrationAllowedSIDs.empty()) {
-        return true;
-    }
-
-    if (!userToken || userToken->GetSerializedToken().empty()) {
-        return false;
-    }
-
-    return HasToken(appData, *userToken);
+    return IsTokenAllowed(userToken, appData->AdministrationAllowedSIDs);
 }
+
+
 
 }

--- a/ydb/core/base/auth.h
+++ b/ydb/core/base/auth.h
@@ -5,8 +5,14 @@
 
 namespace NKikimr {
 
-bool IsAdministrator(const TAppData* appData, const TString& userToken);
+// Check token against given list of allowed sids
+bool IsTokenAllowed(const NACLib::TUserToken* userToken, const TVector<TString>& allowedSIDs);
+bool IsTokenAllowed(const NACLib::TUserToken* userToken, const NProtoBuf::RepeatedPtrField<TString>& allowedSIDs);
+bool IsTokenAllowed(const TString& userTokenSerialized, const TVector<TString>& allowedSIDs);
+bool IsTokenAllowed(const TString& userTokenSerialized, const NProtoBuf::RepeatedPtrField<TString>& allowedSIDs);
 
+// Check token against AdministrationAllowedSIDs
+bool IsAdministrator(const TAppData* appData, const TString& userTokenSerialized);
 bool IsAdministrator(const TAppData* appData, const NACLib::TUserToken* userToken);
 
 }

--- a/ydb/core/base/auth.h
+++ b/ydb/core/base/auth.h
@@ -15,4 +15,7 @@ bool IsTokenAllowed(const TString& userTokenSerialized, const NProtoBuf::Repeate
 bool IsAdministrator(const TAppData* appData, const TString& userTokenSerialized);
 bool IsAdministrator(const TAppData* appData, const NACLib::TUserToken* userToken);
 
+// Check token against database owner
+bool IsDatabaseAdministrator(const NACLib::TUserToken* userToken, const NACLib::TSID& databaseOwner);
+
 }

--- a/ydb/core/base/auth_ut.cpp
+++ b/ydb/core/base/auth_ut.cpp
@@ -81,3 +81,55 @@ Y_UNIT_TEST_SUITE(AuthTokenAllowed) {
     }
 
 }
+
+Y_UNIT_TEST_SUITE(AuthDatabaseAdmin) {
+
+    // Empty owner forbids empty token (regardless of its kind)
+    Y_UNIT_TEST(FailOnEmptyOwnerAndEmptyToken) {
+        NACLib::TUserToken token(NACLib::TUserToken::TUserTokenInitFields{});
+        UNIT_ASSERT_EQUAL(IsDatabaseAdministrator(&token, ""), false);
+    }
+    Y_UNIT_TEST(FailOnEmptyOwnerAndTokenWithEmptyUserSid) {
+        NACLib::TUserToken token({ .UserSID = "" });
+        UNIT_ASSERT_EQUAL(IsDatabaseAdministrator(&token, ""), false);
+    }
+    Y_UNIT_TEST(FailOnEmptyOwnerAndTokenWithEmptyUserSidAndGroups) {
+        NACLib::TUserToken token({ .UserSID = "", .GroupSIDs = {"group1"} });
+        UNIT_ASSERT_EQUAL(IsDatabaseAdministrator(&token, ""), false);
+    }
+    Y_UNIT_TEST(FailOnEmptyOwnerAndNoToken) {
+        UNIT_ASSERT_EQUAL(IsDatabaseAdministrator(nullptr, ""), false);
+    }
+
+    // Non empty owner forbids empty token (regardless of its kind)
+    Y_UNIT_TEST(FailOnOwnerAndEmptyToken) {
+        NACLib::TUserToken token(NACLib::TUserToken::TUserTokenInitFields{});
+        UNIT_ASSERT_EQUAL(IsDatabaseAdministrator(&token, "owner"), false);
+    }
+    Y_UNIT_TEST(FailOnOwnerAndTokenWithEmptyUserSid) {
+        NACLib::TUserToken token({ .UserSID = "" });
+        UNIT_ASSERT_EQUAL(IsDatabaseAdministrator(&token, "owner"), false);
+    }
+    Y_UNIT_TEST(FailOnOwnerAndTokenWithEmptyUserSidAndGroups) {
+        NACLib::TUserToken token({ .UserSID = "", .GroupSIDs = {"group1"} });
+        UNIT_ASSERT_EQUAL(IsDatabaseAdministrator(&token, "owner"), false);
+    }
+    Y_UNIT_TEST(FailOnOwnerAndNoToken) {
+        UNIT_ASSERT_EQUAL(IsDatabaseAdministrator(nullptr, "owner"), false);
+    }
+
+    // Owner matches token
+    Y_UNIT_TEST(PassOnOwnerMatchUserSid) {
+        NACLib::TUserToken token({ .UserSID = "user1" });
+        UNIT_ASSERT_EQUAL(IsDatabaseAdministrator(&token, "user1"), true);
+    }
+    Y_UNIT_TEST(PassOnOwnerMatchUserSidWithGroup) {
+        NACLib::TUserToken token({ .UserSID = "user1", .GroupSIDs = {"group1"} });
+        UNIT_ASSERT_EQUAL(IsDatabaseAdministrator(&token, "user1"), true);
+    }
+    Y_UNIT_TEST(PassOnOwnerMatchGroupSid) {
+        NACLib::TUserToken token({ .UserSID = "user1", .GroupSIDs = {"group1"} });
+        UNIT_ASSERT_EQUAL(IsDatabaseAdministrator(&token, "group1"), true);
+    }
+
+}

--- a/ydb/core/base/auth_ut.cpp
+++ b/ydb/core/base/auth_ut.cpp
@@ -1,0 +1,83 @@
+#include <library/cpp/testing/unittest/registar.h>
+
+#include "auth.h"
+
+using namespace NKikimr;
+
+Y_UNIT_TEST_SUITE(AuthTokenAllowed) {
+
+    const TVector<TString> EmptyList;
+
+    // Empty list allows empty token (regardless of its kind)
+    Y_UNIT_TEST(PassOnEmptyListAndEmptyToken) {
+        NACLib::TUserToken token(NACLib::TUserToken::TUserTokenInitFields{});
+        UNIT_ASSERT_EQUAL(IsTokenAllowed(&token, EmptyList), true);
+        UNIT_ASSERT_EQUAL(IsTokenAllowed(token.SerializeAsString(), EmptyList), true);
+    }
+    Y_UNIT_TEST(PassOnEmptyListAndTokenWithEmptyUserSid) {
+        NACLib::TUserToken token({ .UserSID = "" });
+        UNIT_ASSERT_EQUAL(IsTokenAllowed(&token, EmptyList), true);
+        UNIT_ASSERT_EQUAL(IsTokenAllowed(token.SerializeAsString(), EmptyList), true);
+    }
+    Y_UNIT_TEST(PassOnEmptyListAndTokenWithEmptyUserSidAndGroups) {
+        NACLib::TUserToken token({ .UserSID = "", .GroupSIDs = {"group1"} });
+        UNIT_ASSERT_EQUAL(IsTokenAllowed(&token, EmptyList), true);
+        UNIT_ASSERT_EQUAL(IsTokenAllowed(token.SerializeAsString(), EmptyList), true);
+    }
+    Y_UNIT_TEST(PassOnEmptyListAndNoToken) {
+        UNIT_ASSERT_EQUAL(IsTokenAllowed(nullptr, EmptyList), true);
+    }
+    Y_UNIT_TEST(PassOnEmptyListAndToken) {
+        NACLib::TUserToken token({ .UserSID = "user1" });
+        UNIT_ASSERT_EQUAL(IsTokenAllowed(&token, EmptyList), true);
+        UNIT_ASSERT_EQUAL(IsTokenAllowed(token.SerializeAsString(), EmptyList), true);
+    }
+    Y_UNIT_TEST(PassOnEmptyListAndInvalidTokenSerialized) {
+        UNIT_ASSERT_EQUAL(IsTokenAllowed("invalid-serialized-protobuf", EmptyList), true);
+    }
+
+    // Non empty list forbids empty token (regardless of its kind)
+    Y_UNIT_TEST(FailOnListAndEmptyToken) {
+        NACLib::TUserToken token(NACLib::TUserToken::TUserTokenInitFields{});
+        UNIT_ASSERT_EQUAL(IsTokenAllowed(&token, {"entry"}), false);
+        UNIT_ASSERT_EQUAL(IsTokenAllowed(token.SerializeAsString(), {"entry"}), false);
+    }
+    Y_UNIT_TEST(FailOnListAndTokenWithEmptyUserSid) {
+        NACLib::TUserToken token({ .UserSID = "" });
+        UNIT_ASSERT_EQUAL(IsTokenAllowed(&token, {"entry"}), false);
+        UNIT_ASSERT_EQUAL(IsTokenAllowed(token.SerializeAsString(), {"entry"}), false);
+    }
+    Y_UNIT_TEST(FailOnListAndTokenWithEmptyUserSidAndGroups) {
+        NACLib::TUserToken token({ .UserSID = "", .GroupSIDs = {"group1"} });
+        UNIT_ASSERT_EQUAL(IsTokenAllowed(&token, {"entry"}), false);
+        UNIT_ASSERT_EQUAL(IsTokenAllowed(token.SerializeAsString(), {"entry"}), false);
+    }
+    Y_UNIT_TEST(FailOnListAndNoToken) {
+        UNIT_ASSERT_EQUAL(IsTokenAllowed(nullptr, {"entry"}), false);
+    }
+
+    // List matches token
+    Y_UNIT_TEST(PassOnListMatchUserSid) {
+        NACLib::TUserToken token({ .UserSID = "user1" });
+        UNIT_ASSERT_EQUAL(IsTokenAllowed(&token, {"group1", "group2", "user1", "user2"}), true);
+        UNIT_ASSERT_EQUAL(IsTokenAllowed(token.SerializeAsString(), {"group1", "group2", "user1", "user2"}), true);
+    }
+    Y_UNIT_TEST(PassOnListMatchUserSidWithGroup) {
+        NACLib::TUserToken token({ .UserSID = "user1", .GroupSIDs = {"no-match-group"} });
+        UNIT_ASSERT_EQUAL(IsTokenAllowed(&token, {"group1", "group2", "user1", "user2"}), true);
+        UNIT_ASSERT_EQUAL(IsTokenAllowed(token.SerializeAsString(), {"group1", "group2", "user1", "user2"}), true);
+    }
+    Y_UNIT_TEST(PassOnListMatchGroupSid) {
+        NACLib::TUserToken token({ .UserSID = "no-match-user", .GroupSIDs = {"group2"} });
+        UNIT_ASSERT_EQUAL(IsTokenAllowed(&token, {"group1", "group2", "user1", "user2"}), true);
+        UNIT_ASSERT_EQUAL(IsTokenAllowed(token.SerializeAsString(), {"group1", "group2", "user1", "user2"}), true);
+    }
+
+    // List does not matchs token
+    Y_UNIT_TEST(FailOnListMatchGroupSid) {
+        NACLib::TUserToken token({ .UserSID = "no-match-user", .GroupSIDs = {"no-match-group"} });
+        UNIT_ASSERT_EQUAL(IsTokenAllowed(&token, {"group1", "group2", "user1", "user2"}), false);
+        UNIT_ASSERT_EQUAL(IsTokenAllowed(token.SerializeAsString(), {"group1", "group2", "user1", "user2"}), false);
+    }
+
+}

--- a/ydb/core/base/ut_auth/ya.make
+++ b/ydb/core/base/ut_auth/ya.make
@@ -1,0 +1,18 @@
+UNITTEST_FOR(ydb/core/base)
+
+FORK_SUBTESTS()
+
+SIZE(MEDIUM)
+
+PEERDIR(
+    library/cpp/testing/unittest
+    ydb/library/aclib
+)
+
+YQL_LAST_ABI_VERSION()
+
+SRCS(
+    auth_ut.cpp
+)
+
+END()

--- a/ydb/core/base/ya.make
+++ b/ydb/core/base/ya.make
@@ -125,5 +125,6 @@ RECURSE(
 
 RECURSE_FOR_TESTS(
     ut
+    ut_auth
     ut_board_subscriber
 )


### PR DESCRIPTION
- add `IsTokenAllowed()` to universally check token membership in any `*_allowed_sids` lists
- add `IsDatabaseAdministrator()`

### Changelog category

* Not for changelog
