### PR TITLE
security: update access level checks to IsAdministrator() and IsTokenAllowed()

### DIFF
--- a/ydb/core/base/auth.cpp
+++ b/ydb/core/base/auth.cpp
@@ -1,3 +1,5 @@
+#include <ydb/library/aclib/aclib.h>
+
 #include "auth.h"
 
 namespace NKikimr {
@@ -66,5 +68,16 @@ bool IsAdministrator(const TAppData* appData, const NACLib::TUserToken* userToke
 }
 
 
+bool IsDatabaseAdministrator(const NACLib::TUserToken* userToken, const NACLib::TSID& databaseOwner) {
+    // no database, no access
+    if (databaseOwner.empty()) {
+        return false;
+    }
+    // empty token can't have raised access level
+    if (!userToken || userToken->GetUserSID().empty()) {
+        return false;
+    }
+    return userToken->IsExist(databaseOwner);
+}
 
 }

--- a/ydb/core/base/auth.cpp
+++ b/ydb/core/base/auth.cpp
@@ -4,9 +4,21 @@ namespace NKikimr {
 
 namespace {
 
-bool HasToken(const TAppData* appData, const NACLib::TUserToken& userToken) {
-    for (const auto& sid : appData->AdministrationAllowedSIDs) {
-        if (userToken.IsExist(sid)) {
+template <class Iterable>
+bool IsTokenAllowedImpl(const NACLib::TUserToken* userToken, const Iterable& allowedSIDs) {
+    // empty set contains any element
+    if (allowedSIDs.empty()) {
+        return true;
+    }
+
+    // empty element does not belong to any non-empty set
+    if (!userToken || userToken->GetUserSID().empty()) {
+        return false;
+    }
+
+    // its enough to a single sid (user or group) from the token to be in the set
+    for (const auto& sid : allowedSIDs) {
+        if (userToken->IsExist(sid)) {
             return true;
         }
     }
@@ -14,35 +26,45 @@ bool HasToken(const TAppData* appData, const NACLib::TUserToken& userToken) {
     return false;
 }
 
+NACLib::TUserToken ParseUserToken(const TString& userTokenSerialized) {
+    NACLibProto::TUserToken tokenPb;
+    if (!tokenPb.ParseFromString(userTokenSerialized)) {
+        // we want to treat invalid token as empty,
+        // so then result object must be recreated (or cleared)
+        // because failed parsing makes result object dirty
+        tokenPb = NACLibProto::TUserToken();
+    }
+    return NACLib::TUserToken(tokenPb);
 }
 
-bool IsAdministrator(const TAppData* appData, const TString& userToken) {
-    if (appData->AdministrationAllowedSIDs.empty()) {
-        return true;
-    }
+}
 
-    if (!userToken) {
-        return false;
-    }
+bool IsTokenAllowed(const NACLib::TUserToken* userToken, const TVector<TString>& allowedSIDs) {
+    return IsTokenAllowedImpl(userToken, allowedSIDs);
+}
 
-    NACLibProto::TUserToken tokenPb;
-    if (!tokenPb.ParseFromString(userToken)) {
-        return false;
-    }
+bool IsTokenAllowed(const NACLib::TUserToken* userToken, const NProtoBuf::RepeatedPtrField<TString>& allowedSIDs) {
+    return IsTokenAllowedImpl(userToken, allowedSIDs);
+}
 
-    return HasToken(appData, NACLib::TUserToken(std::move(tokenPb)));
+bool IsTokenAllowed(const TString& userTokenSerialized, const TVector<TString>& allowedSIDs) {
+    NACLib::TUserToken userToken = ParseUserToken(userTokenSerialized);
+    return IsTokenAllowed(&userToken, allowedSIDs);
+}
+
+bool IsTokenAllowed(const TString& userTokenSerialized, const NProtoBuf::RepeatedPtrField<TString>& allowedSIDs) {
+    NACLib::TUserToken userToken = ParseUserToken(userTokenSerialized);
+    return IsTokenAllowed(&userToken, allowedSIDs);
+}
+
+bool IsAdministrator(const TAppData* appData, const TString& userTokenSerialized) {
+    return IsTokenAllowed(userTokenSerialized, appData->AdministrationAllowedSIDs);
 }
 
 bool IsAdministrator(const TAppData* appData, const NACLib::TUserToken* userToken) {
-    if (appData->AdministrationAllowedSIDs.empty()) {
-        return true;
-    }
-
-    if (!userToken || userToken->GetSerializedToken().empty()) {
-        return false;
-    }
-
-    return HasToken(appData, *userToken);
+    return IsTokenAllowed(userToken, appData->AdministrationAllowedSIDs);
 }
+
+
 
 }

--- a/ydb/core/base/auth.h
+++ b/ydb/core/base/auth.h
@@ -5,8 +5,14 @@
 
 namespace NKikimr {
 
-bool IsAdministrator(const TAppData* appData, const TString& userToken);
+// Check token against given list of allowed sids
+bool IsTokenAllowed(const NACLib::TUserToken* userToken, const TVector<TString>& allowedSIDs);
+bool IsTokenAllowed(const NACLib::TUserToken* userToken, const NProtoBuf::RepeatedPtrField<TString>& allowedSIDs);
+bool IsTokenAllowed(const TString& userTokenSerialized, const TVector<TString>& allowedSIDs);
+bool IsTokenAllowed(const TString& userTokenSerialized, const NProtoBuf::RepeatedPtrField<TString>& allowedSIDs);
 
+// Check token against AdministrationAllowedSIDs
+bool IsAdministrator(const TAppData* appData, const TString& userTokenSerialized);
 bool IsAdministrator(const TAppData* appData, const NACLib::TUserToken* userToken);
 
 }

--- a/ydb/core/base/auth.h
+++ b/ydb/core/base/auth.h
@@ -15,4 +15,7 @@ bool IsTokenAllowed(const TString& userTokenSerialized, const NProtoBuf::Repeate
 bool IsAdministrator(const TAppData* appData, const TString& userTokenSerialized);
 bool IsAdministrator(const TAppData* appData, const NACLib::TUserToken* userToken);
 
+// Check token against database owner
+bool IsDatabaseAdministrator(const NACLib::TUserToken* userToken, const NACLib::TSID& databaseOwner);
+
 }

--- a/ydb/core/base/auth_ut.cpp
+++ b/ydb/core/base/auth_ut.cpp
@@ -81,3 +81,55 @@ Y_UNIT_TEST_SUITE(AuthTokenAllowed) {
     }
 
 }
+
+Y_UNIT_TEST_SUITE(AuthDatabaseAdmin) {
+
+    // Empty owner forbids empty token (regardless of its kind)
+    Y_UNIT_TEST(FailOnEmptyOwnerAndEmptyToken) {
+        NACLib::TUserToken token(NACLib::TUserToken::TUserTokenInitFields{});
+        UNIT_ASSERT_EQUAL(IsDatabaseAdministrator(&token, ""), false);
+    }
+    Y_UNIT_TEST(FailOnEmptyOwnerAndTokenWithEmptyUserSid) {
+        NACLib::TUserToken token({ .UserSID = "" });
+        UNIT_ASSERT_EQUAL(IsDatabaseAdministrator(&token, ""), false);
+    }
+    Y_UNIT_TEST(FailOnEmptyOwnerAndTokenWithEmptyUserSidAndGroups) {
+        NACLib::TUserToken token({ .UserSID = "", .GroupSIDs = {"group1"} });
+        UNIT_ASSERT_EQUAL(IsDatabaseAdministrator(&token, ""), false);
+    }
+    Y_UNIT_TEST(FailOnEmptyOwnerAndNoToken) {
+        UNIT_ASSERT_EQUAL(IsDatabaseAdministrator(nullptr, ""), false);
+    }
+
+    // Non empty owner forbids empty token (regardless of its kind)
+    Y_UNIT_TEST(FailOnOwnerAndEmptyToken) {
+        NACLib::TUserToken token(NACLib::TUserToken::TUserTokenInitFields{});
+        UNIT_ASSERT_EQUAL(IsDatabaseAdministrator(&token, "owner"), false);
+    }
+    Y_UNIT_TEST(FailOnOwnerAndTokenWithEmptyUserSid) {
+        NACLib::TUserToken token({ .UserSID = "" });
+        UNIT_ASSERT_EQUAL(IsDatabaseAdministrator(&token, "owner"), false);
+    }
+    Y_UNIT_TEST(FailOnOwnerAndTokenWithEmptyUserSidAndGroups) {
+        NACLib::TUserToken token({ .UserSID = "", .GroupSIDs = {"group1"} });
+        UNIT_ASSERT_EQUAL(IsDatabaseAdministrator(&token, "owner"), false);
+    }
+    Y_UNIT_TEST(FailOnOwnerAndNoToken) {
+        UNIT_ASSERT_EQUAL(IsDatabaseAdministrator(nullptr, "owner"), false);
+    }
+
+    // Owner matches token
+    Y_UNIT_TEST(PassOnOwnerMatchUserSid) {
+        NACLib::TUserToken token({ .UserSID = "user1" });
+        UNIT_ASSERT_EQUAL(IsDatabaseAdministrator(&token, "user1"), true);
+    }
+    Y_UNIT_TEST(PassOnOwnerMatchUserSidWithGroup) {
+        NACLib::TUserToken token({ .UserSID = "user1", .GroupSIDs = {"group1"} });
+        UNIT_ASSERT_EQUAL(IsDatabaseAdministrator(&token, "user1"), true);
+    }
+    Y_UNIT_TEST(PassOnOwnerMatchGroupSid) {
+        NACLib::TUserToken token({ .UserSID = "user1", .GroupSIDs = {"group1"} });
+        UNIT_ASSERT_EQUAL(IsDatabaseAdministrator(&token, "group1"), true);
+    }
+
+}

--- a/ydb/core/base/auth_ut.cpp
+++ b/ydb/core/base/auth_ut.cpp
@@ -1,0 +1,83 @@
+#include <library/cpp/testing/unittest/registar.h>
+
+#include "auth.h"
+
+using namespace NKikimr;
+
+Y_UNIT_TEST_SUITE(AuthTokenAllowed) {
+
+    const TVector<TString> EmptyList;
+
+    // Empty list allows empty token (regardless of its kind)
+    Y_UNIT_TEST(PassOnEmptyListAndEmptyToken) {
+        NACLib::TUserToken token(NACLib::TUserToken::TUserTokenInitFields{});
+        UNIT_ASSERT_EQUAL(IsTokenAllowed(&token, EmptyList), true);
+        UNIT_ASSERT_EQUAL(IsTokenAllowed(token.SerializeAsString(), EmptyList), true);
+    }
+    Y_UNIT_TEST(PassOnEmptyListAndTokenWithEmptyUserSid) {
+        NACLib::TUserToken token({ .UserSID = "" });
+        UNIT_ASSERT_EQUAL(IsTokenAllowed(&token, EmptyList), true);
+        UNIT_ASSERT_EQUAL(IsTokenAllowed(token.SerializeAsString(), EmptyList), true);
+    }
+    Y_UNIT_TEST(PassOnEmptyListAndTokenWithEmptyUserSidAndGroups) {
+        NACLib::TUserToken token({ .UserSID = "", .GroupSIDs = {"group1"} });
+        UNIT_ASSERT_EQUAL(IsTokenAllowed(&token, EmptyList), true);
+        UNIT_ASSERT_EQUAL(IsTokenAllowed(token.SerializeAsString(), EmptyList), true);
+    }
+    Y_UNIT_TEST(PassOnEmptyListAndNoToken) {
+        UNIT_ASSERT_EQUAL(IsTokenAllowed(nullptr, EmptyList), true);
+    }
+    Y_UNIT_TEST(PassOnEmptyListAndToken) {
+        NACLib::TUserToken token({ .UserSID = "user1" });
+        UNIT_ASSERT_EQUAL(IsTokenAllowed(&token, EmptyList), true);
+        UNIT_ASSERT_EQUAL(IsTokenAllowed(token.SerializeAsString(), EmptyList), true);
+    }
+    Y_UNIT_TEST(PassOnEmptyListAndInvalidTokenSerialized) {
+        UNIT_ASSERT_EQUAL(IsTokenAllowed("invalid-serialized-protobuf", EmptyList), true);
+    }
+
+    // Non empty list forbids empty token (regardless of its kind)
+    Y_UNIT_TEST(FailOnListAndEmptyToken) {
+        NACLib::TUserToken token(NACLib::TUserToken::TUserTokenInitFields{});
+        UNIT_ASSERT_EQUAL(IsTokenAllowed(&token, {"entry"}), false);
+        UNIT_ASSERT_EQUAL(IsTokenAllowed(token.SerializeAsString(), {"entry"}), false);
+    }
+    Y_UNIT_TEST(FailOnListAndTokenWithEmptyUserSid) {
+        NACLib::TUserToken token({ .UserSID = "" });
+        UNIT_ASSERT_EQUAL(IsTokenAllowed(&token, {"entry"}), false);
+        UNIT_ASSERT_EQUAL(IsTokenAllowed(token.SerializeAsString(), {"entry"}), false);
+    }
+    Y_UNIT_TEST(FailOnListAndTokenWithEmptyUserSidAndGroups) {
+        NACLib::TUserToken token({ .UserSID = "", .GroupSIDs = {"group1"} });
+        UNIT_ASSERT_EQUAL(IsTokenAllowed(&token, {"entry"}), false);
+        UNIT_ASSERT_EQUAL(IsTokenAllowed(token.SerializeAsString(), {"entry"}), false);
+    }
+    Y_UNIT_TEST(FailOnListAndNoToken) {
+        UNIT_ASSERT_EQUAL(IsTokenAllowed(nullptr, {"entry"}), false);
+    }
+
+    // List matches token
+    Y_UNIT_TEST(PassOnListMatchUserSid) {
+        NACLib::TUserToken token({ .UserSID = "user1" });
+        UNIT_ASSERT_EQUAL(IsTokenAllowed(&token, {"group1", "group2", "user1", "user2"}), true);
+        UNIT_ASSERT_EQUAL(IsTokenAllowed(token.SerializeAsString(), {"group1", "group2", "user1", "user2"}), true);
+    }
+    Y_UNIT_TEST(PassOnListMatchUserSidWithGroup) {
+        NACLib::TUserToken token({ .UserSID = "user1", .GroupSIDs = {"no-match-group"} });
+        UNIT_ASSERT_EQUAL(IsTokenAllowed(&token, {"group1", "group2", "user1", "user2"}), true);
+        UNIT_ASSERT_EQUAL(IsTokenAllowed(token.SerializeAsString(), {"group1", "group2", "user1", "user2"}), true);
+    }
+    Y_UNIT_TEST(PassOnListMatchGroupSid) {
+        NACLib::TUserToken token({ .UserSID = "no-match-user", .GroupSIDs = {"group2"} });
+        UNIT_ASSERT_EQUAL(IsTokenAllowed(&token, {"group1", "group2", "user1", "user2"}), true);
+        UNIT_ASSERT_EQUAL(IsTokenAllowed(token.SerializeAsString(), {"group1", "group2", "user1", "user2"}), true);
+    }
+
+    // List does not matchs token
+    Y_UNIT_TEST(FailOnListMatchGroupSid) {
+        NACLib::TUserToken token({ .UserSID = "no-match-user", .GroupSIDs = {"no-match-group"} });
+        UNIT_ASSERT_EQUAL(IsTokenAllowed(&token, {"group1", "group2", "user1", "user2"}), false);
+        UNIT_ASSERT_EQUAL(IsTokenAllowed(token.SerializeAsString(), {"group1", "group2", "user1", "user2"}), false);
+    }
+
+}

--- a/ydb/core/base/ut_auth/ya.make
+++ b/ydb/core/base/ut_auth/ya.make
@@ -1,0 +1,18 @@
+UNITTEST_FOR(ydb/core/base)
+
+FORK_SUBTESTS()
+
+SIZE(MEDIUM)
+
+PEERDIR(
+    library/cpp/testing/unittest
+    ydb/library/aclib
+)
+
+YQL_LAST_ABI_VERSION()
+
+SRCS(
+    auth_ut.cpp
+)
+
+END()

--- a/ydb/core/base/ya.make
+++ b/ydb/core/base/ya.make
@@ -125,5 +125,6 @@ RECURSE(
 
 RECURSE_FOR_TESTS(
     ut
+    ut_auth
     ut_board_subscriber
 )

--- a/ydb/core/mon/mon.cpp
+++ b/ydb/core/mon/mon.cpp
@@ -3,6 +3,7 @@
 #include <ydb/library/actors/core/interconnect.h>
 #include <ydb/library/actors/http/http_proxy.h>
 #include <ydb/core/base/appdata.h>
+#include <ydb/core/base/auth.h>
 #include <ydb/core/grpc_services/base/base.h>
 #include <ydb/core/base/ticket_parser.h>
 
@@ -538,16 +539,7 @@ public:
         if (result.Status != Ydb::StatusIds::SUCCESS) {
             return ReplyErrorAndPassAway(result);
         }
-        bool found = false;
-        if (result.UserToken) {
-            for (const TString& sid : ActorMonPage->AllowedSIDs) {
-                if (result.UserToken->IsExist(sid)) {
-                    found = true;
-                    break;
-                }
-            }
-        }
-        if (found || ActorMonPage->AllowedSIDs.empty() || !result.UserToken) {
+        if (IsTokenAllowed(result.UserToken.Get(), ActorMonPage->AllowedSIDs)) {
             SendRequest(&result);
         } else {
             return ReplyForbiddenAndPassAway("SID is not allowed");
@@ -1169,16 +1161,7 @@ public:
         if (result.Status != Ydb::StatusIds::SUCCESS) {
             return ReplyErrorAndPassAway(result);
         }
-        bool found = false;
-        if (result.UserToken) {
-            for (const TString& sid : AllowedSIDs) {
-                if (result.UserToken->IsExist(sid)) {
-                    found = true;
-                    break;
-                }
-            }
-        }
-        if (found || AllowedSIDs.empty() || !result.UserToken) {
+        if (IsTokenAllowed(result.UserToken.Get(), AllowedSIDs)) {
             SendRequest(result);
         } else {
             return ReplyForbiddenAndPassAway("SID is not allowed");

--- a/ydb/core/tx/schemeshard/schemeshard__operation_alter_login.cpp
+++ b/ydb/core/tx/schemeshard/schemeshard__operation_alter_login.cpp
@@ -2,7 +2,10 @@
 #include "schemeshard__operation_part.h"
 #include "schemeshard__operation_common.h"
 #include "schemeshard_impl.h"
+
 #include <ydb/library/security/util.h>
+#include <ydb/core/base/auth.h>
+
 #include <ydb/core/protos/auth.pb.h>
 
 namespace {
@@ -303,7 +306,7 @@ public:
             NACLib::TACL acl(path->ACL);
             if (acl.HasAccess(sid)) {
                 auto pathStr = TPath::Init(pathId, context.SS).PathString();
-                return {.Error = TStringBuilder() << 
+                return {.Error = TStringBuilder() <<
                     sidType << " " << sid << " has an ACL record on " << pathStr << " and can't be removed"};
             }
         }
@@ -312,19 +315,11 @@ public:
     }
 
     void AddIsUserAdmin(const TString& user, NLogin::TLoginProvider& loginProvider, TParts& additionalParts) {
-        const auto& adminSids = AppData()->AdministrationAllowedSIDs;
-        bool isAdmin = adminSids.empty();
-        if (!isAdmin) {
-            const auto providerGroups = loginProvider.GetGroupsMembership(user);
-            const TVector<NACLib::TSID> groups(providerGroups.begin(), providerGroups.end());
-            const auto userToken = NACLib::TUserToken(user, groups);
-            auto hasSid = [&userToken](const TString& sid) -> bool {
-                return userToken.IsExist(sid);
-            };
-            isAdmin = std::find_if(adminSids.begin(), adminSids.end(), hasSid) != adminSids.end();   
-        }
+        const auto providerGroups = loginProvider.GetGroupsMembership(user);
+        const TVector<NACLib::TSID> groups(providerGroups.begin(), providerGroups.end());
+        const auto userToken = NACLib::TUserToken(user, groups);
 
-        if (isAdmin) {
+        if (IsAdministrator(AppData(), &userToken)) {
             additionalParts.emplace_back("login_user_level", "admin");
         }
     }

--- a/ydb/core/tx/schemeshard/schemeshard__operation_alter_table.cpp
+++ b/ydb/core/tx/schemeshard/schemeshard__operation_alter_table.cpp
@@ -2,6 +2,8 @@
 #include "schemeshard__operation_common.h"
 #include "schemeshard_impl.h"
 
+#include <ydb/core/base/auth.h>
+
 #include "schemeshard_utils.h"  // for TransactionTemplate
 
 #include <ydb/core/base/subdomain.h>
@@ -29,18 +31,6 @@ bool CheckFreezeStateAlreadySet(const TTableInfo::TPtr table, const NKikimrSchem
     }
 
     return false;
-}
-
-bool IsSuperUser(const NACLib::TUserToken* userToken) {
-    if (!userToken)
-        return false;
-
-    const auto& adminSids = AppData()->AdministrationAllowedSIDs;
-    auto hasSid = [userToken](const TString& sid) -> bool {
-        return userToken->IsExist(sid);
-    };
-    auto it = std::find_if(adminSids.begin(), adminSids.end(), hasSid);
-    return (it != adminSids.end());
 }
 
 template <typename TMessage>
@@ -753,9 +743,12 @@ TVector<ISubOperation::TPtr> CreateConsistentAlterTable(TOperationId id, const T
         return {CreateAlterTable(id, tx)};
     }
 
-    // Admins can alter indexImplTable unconditionally.
-    // Regular users can only alter allowed fields.
-    if (!IsSuperUser(context.UserToken.Get())
+    // Index table (indexImplTable) altering:
+    // - regular users can only alter a list of allowed fields
+    // - as a special case, admins can alter index table unconditionally:
+    //   - but only cluster admins
+    //   - and only the real ones, no "all users are admins by default" trick can be used here
+    if (!(IsAdministrator(AppData(), context.UserToken.Get()) && !AppData()->AdministrationAllowedSIDs.empty())
         && (!CheckAllowedFields(alter, {"Name", "PathId", "PartitionConfig", "ReplicationConfig", "IncrementalBackupConfig"})
             || (alter.HasPartitionConfig()
                 && !CheckAllowedFields(alter.GetPartitionConfig(), {"PartitioningPolicy"})

--- a/ydb/core/viewer/viewer.cpp
+++ b/ydb/core/viewer/viewer.cpp
@@ -11,6 +11,7 @@
 #include <util/stream/file.h>
 #include <util/system/fstat.h>
 #include <ydb/core/base/appdata.h>
+#include <ydb/core/base/auth.h>
 #include <ydb/core/base/path.h>
 #include <ydb/core/base/statestorage.h>
 #include <ydb/core/base/tablet_types.h>
@@ -210,16 +211,7 @@ public:
                 return true;
             }
         }
-        if (userTokenObject.empty()) {
-            return false;
-        }
-        auto token = std::make_unique<NACLib::TUserToken>(userTokenObject);
-        for (const auto& allowedSID : KikimrRunConfig.AppConfig.GetDomainsConfig().GetSecurityConfig().GetAdministrationAllowedSIDs()) {
-            if (token->IsExist(allowedSID)) {
-                return true;
-            }
-        }
-        return false;
+        return IsTokenAllowed(userTokenObject, AppData()->DomainsConfig.GetSecurityConfig().GetAdministrationAllowedSIDs());
     }
 
     static bool IsStaticGroup(ui32 groupId) {


### PR DESCRIPTION
- use `IsTokenAllowed()` for all `*_allowed_sids` membership checks
- use `IsAdministrator()` for all `administration_allowed_sids` membership checks

Stacked on:
- https://github.com/ydb-platform/ydb/pull/14489

### Changelog category

* Not for changelog
