### PR TITLE
ci: test docker image before publishing

### DIFF
--- a/.github/workflows/docker_publish.yml
+++ b/.github/workflows/docker_publish.yml
@@ -75,10 +75,9 @@ jobs:
             type=schedule,pattern=nightly
             type=raw,value=${{ inputs.image_tag || 'trunk' }}
 
-      - name: Build and push docker image
+      - name: Build docker image
         uses: docker/build-push-action@v4
         with:
-          push: true
           context: .
           file: main/.github/docker/Dockerfile
           tags: ${{ steps.meta.outputs.tags }}
@@ -86,4 +85,25 @@ jobs:
           platforms: linux/amd64
           provenance: false
           cache-from: type=s3,name=local_ydb,region=ru-central1,bucket=${{ vars.AWS_BUCKET }},endpoint_url=${{ vars.AWS_ENDPOINT }},access_key_id=${{ secrets.AWS_KEY_ID }},secret_access_key=${{ secrets.AWS_KEY_VALUE }}
+          cache-to: type=s3,name=local_ydb,region=ru-central1,bucket=${{ vars.AWS_BUCKET }},endpoint_url=${{ vars.AWS_ENDPOINT }},access_key_id=${{ secrets.AWS_KEY_ID }},secret_access_key=${{ secrets.AWS_KEY_VALUE }},mode=max
+
+      - name: Test docker image
+        continue-on-error: false
+        run: |
+          docker run -d --name local-ydb-test ghcr.io/${{ github.repository_owner }}/local-ydb:nightly
+          sleep 61  # Wait for the health check to run (--start-period=60s --interval=1s)
+          if [ "$(docker inspect --format='{{json .State.Health.Status}}' local-ydb-test)" != "\"healthy\"" ]; then
+            echo "Container is not healthy"
+            docker logs local-ydb-test
+            exit 1
+          fi
+          docker stop local-ydb-test
+          docker rm local-ydb-test
+
+      - name: Push docker image
+        uses: docker/build-push-action@v4
+        with:
+          context: .
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
           cache-to: type=s3,name=local_ydb,region=ru-central1,bucket=${{ vars.AWS_BUCKET }},endpoint_url=${{ vars.AWS_ENDPOINT }},access_key_id=${{ secrets.AWS_KEY_ID }},secret_access_key=${{ secrets.AWS_KEY_VALUE }},mode=max


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of changes introduced in this PR -->

This pull request includes changes to the `.github/workflows/docker_publish.yml` file to enhance the Docker image build and testing process. The most important changes are the addition of a new job to test the Docker image and the reorganization of the build and push steps.

Enhancements to Docker image build and testing process:

* [`.github/workflows/docker_publish.yml`](diffhunk://#diff-32bbfae130935e2e5210914fb725da45f9ab4c110e98c49a78b4c7498384da74L78-L81): The job name for building the Docker image has been updated to "Build docker image" and the `push` parameter has been removed.
* [`.github/workflows/docker_publish.yml`](diffhunk://#diff-32bbfae130935e2e5210914fb725da45f9ab4c110e98c49a78b4c7498384da74R89-R109): Added a new job to test the Docker image. This job runs the Docker container, waits for a health check, and verifies the container's health status. If the container is not healthy, it logs the container output and exits with an error.
* [`.github/workflows/docker_publish.yml`](diffhunk://#diff-32bbfae130935e2e5210914fb725da45f9ab4c110e98c49a78b4c7498384da74R89-R109): Re-added the job to push the Docker image after testing, ensuring that the image is only pushed if it passes the health check.

...

### Changelog category <!-- remove all except one -->

* Not for changelog (changelog entry is not required)

### Additional information

...
