### PR TITLE
ci: test docker image before publishing

### DIFF
--- a/.github/workflows/docker_publish.yml
+++ b/.github/workflows/docker_publish.yml
@@ -75,15 +75,35 @@ jobs:
             type=schedule,pattern=nightly
             type=raw,value=${{ inputs.image_tag || 'trunk' }}
 
-      - name: Build and push docker image
+      - name: Build docker image
         uses: docker/build-push-action@v4
         with:
-          push: true
           context: .
+          load: true
           file: main/.github/docker/Dockerfile
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
           platforms: linux/amd64
           provenance: false
           cache-from: type=s3,name=local_ydb,region=ru-central1,bucket=${{ vars.AWS_BUCKET }},endpoint_url=${{ vars.AWS_ENDPOINT }},access_key_id=${{ secrets.AWS_KEY_ID }},secret_access_key=${{ secrets.AWS_KEY_VALUE }}
+
+      - name: Test docker image
+        continue-on-error: false
+        run: |
+          docker run -d --rm --name local-ydb-test ghcr.io/${{ github.repository_owner }}/local-ydb:nightly
+          sleep 61  # Wait for the health check to run (--start-period=60s --interval=1s)
+          if [ "$(docker inspect --format='{{json .State.Health.Status}}' local-ydb-test)" != "\"healthy\"" ]; then
+            echo "Container is not healthy"
+            docker inspect --format='{{json .State.Health}}' local-ydb-test
+            docker logs local-ydb-test
+            exit 1
+          fi
+          docker stop local-ydb-test
+          docker rm local-ydb-test
+
+      - name: Push docker image
+        uses: docker/build-push-action@v4
+        with:
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
           cache-to: type=s3,name=local_ydb,region=ru-central1,bucket=${{ vars.AWS_BUCKET }},endpoint_url=${{ vars.AWS_ENDPOINT }},access_key_id=${{ secrets.AWS_KEY_ID }},secret_access_key=${{ secrets.AWS_KEY_VALUE }},mode=max


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of changes introduced in this PR -->

This pull request includes changes to the `.github/workflows/docker_publish.yml` file to enhance the Docker image build and deployment process. The most important changes include splitting the build and push steps, adding a test step for the Docker image, and modifying the build step to load the image locally.

Enhancements to Docker workflow:

* `jobs:` in `.github/workflows/docker_publish.yml`: Split the build and push steps into separate actions to improve clarity and control.
* `jobs:` in `.github/workflows/docker_publish.yml`: Added a new step to test the Docker image to ensure it is healthy before pushing it to the repository.
* `jobs:` in `.github/workflows/docker_publish.yml`: Modified the build step to load the Docker image locally instead of pushing it immediately.

...

### Changelog category <!-- remove all except one -->
* Not for changelog (changelog entry is not required)

### Additional information

...
