### PR TITLE
ci: update docker image tag handling in publish workflow

### DIFF
--- a/.github/workflows/docker_publish.yml
+++ b/.github/workflows/docker_publish.yml
@@ -91,7 +91,7 @@ jobs:
       - name: Test docker image
         continue-on-error: false
         run: |
-          docker run -d --rm --name local-ydb-test ghcr.io/${{ github.repository_owner }}/local-ydb:nightly
+          docker run -d --rm --name local-ydb-test ghcr.io/${{ github.repository_owner }}/local-ydb:${{ inputs.image_tag || 'trunk' }}
           sleep 61  # Wait for the health check to run (--start-period=60s --interval=1s)
           if [ "$(docker inspect --format='{{json .State.Health.Status}}' local-ydb-test)" != "\"healthy\"" ]; then
             echo "Container is not healthy"


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of changes introduced in this PR -->

* Modified the Docker run command to use an input parameter `image_tag` with a default value of 'trunk' instead of a hardcoded 'nightly' tag. This allows for more flexible testing of different image tags.

...

### Changelog category <!-- remove all except one -->

* Not for changelog (changelog entry is not required)

### Additional information

...
