### PR TITLE
tx-proxy: allow admins to alter logins without alter_schema

### DIFF
--- a/ydb/core/tx/tx_proxy/schemereq.cpp
+++ b/ydb/core/tx/tx_proxy/schemereq.cpp
@@ -1114,7 +1114,7 @@ struct TBaseSchemeReq: public TActorBootstrapped<TDerived> {
                     ReportStatus(TEvTxUserProxy::TEvProposeTransactionStatus::EStatus::AccessDenied, nullptr, &issue, ctx);
                     return false;
                 }
-                allowACLBypass = checkAdmin && isAdmin;
+                allowACLBypass = isAdmin;
 
                 // Any user can change their own password (but nothing else)
                 auto isUserChangesOwnPassword = [](const auto& modifyScheme, const NACLib::TSID& subjectSid) {

--- a/ydb/core/tx/tx_proxy/schemereq_ut.cpp
+++ b/ydb/core/tx/tx_proxy/schemereq_ut.cpp
@@ -383,11 +383,11 @@ Y_UNIT_TEST_SUITE(SchemeReqAccess) {
         },
         { .Tag = "CreateUser", .SqlStatement = "CREATE USER targetuser PASSWORD 'passwd'",
             .SubjectLevel = EAccessLevel::ClusterAdmin, .SubjectPermissions = {"ydb.database.connect"},
-            .EnableStrictUserManagement = false, .EnableDatabaseAdmin = false, .ExpectedResult = false
+            .EnableStrictUserManagement = false, .EnableDatabaseAdmin = false, .ExpectedResult = true
         },
         { .Tag = "CreateUser", .SqlStatement = "CREATE USER targetuser PASSWORD 'passwd'",
             .SubjectLevel = EAccessLevel::ClusterAdmin, .SubjectPermissions = {"ydb.database.connect"},
-            .EnableStrictUserManagement = false, .EnableDatabaseAdmin = true, .ExpectedResult = false
+            .EnableStrictUserManagement = false, .EnableDatabaseAdmin = true, .ExpectedResult = true
         },
         { .Tag = "CreateUser", .SqlStatement = "CREATE USER targetuser PASSWORD 'passwd'",
             .SubjectLevel = EAccessLevel::ClusterAdmin, .SubjectPermissions = {"ydb.database.connect"},
@@ -487,11 +487,11 @@ Y_UNIT_TEST_SUITE(SchemeReqAccess) {
         },
         { .Tag = "ModifyUser", .PrecreateTarget = true, .SqlStatement = "ALTER USER targetuser PASSWORD 'passwd'",
             .SubjectLevel = EAccessLevel::ClusterAdmin, .SubjectPermissions = {"ydb.database.connect"},
-            .EnableStrictUserManagement = false, .EnableDatabaseAdmin = false, .ExpectedResult = false
+            .EnableStrictUserManagement = false, .EnableDatabaseAdmin = false, .ExpectedResult = true
         },
         { .Tag = "ModifyUser", .PrecreateTarget = true, .SqlStatement = "ALTER USER targetuser PASSWORD 'passwd'",
             .SubjectLevel = EAccessLevel::ClusterAdmin, .SubjectPermissions = {"ydb.database.connect"},
-            .EnableStrictUserManagement = false, .EnableDatabaseAdmin = true, .ExpectedResult = false
+            .EnableStrictUserManagement = false, .EnableDatabaseAdmin = true, .ExpectedResult = true
         },
         { .Tag = "ModifyUser", .PrecreateTarget = true, .SqlStatement = "ALTER USER targetuser PASSWORD 'passwd'",
             .SubjectLevel = EAccessLevel::ClusterAdmin, .SubjectPermissions = {"ydb.database.connect"},
@@ -591,11 +591,11 @@ Y_UNIT_TEST_SUITE(SchemeReqAccess) {
         },
         { .Tag = "DropUser", .PrecreateTarget = true, .SqlStatement = "DROP USER targetuser",
             .SubjectLevel = EAccessLevel::ClusterAdmin, .SubjectPermissions = {"ydb.database.connect"},
-            .EnableStrictUserManagement = false, .EnableDatabaseAdmin = false, .ExpectedResult = false
+            .EnableStrictUserManagement = false, .EnableDatabaseAdmin = false, .ExpectedResult = true
         },
         { .Tag = "DropUser", .PrecreateTarget = true, .SqlStatement = "DROP USER targetuser",
             .SubjectLevel = EAccessLevel::ClusterAdmin, .SubjectPermissions = {"ydb.database.connect"},
-            .EnableStrictUserManagement = false, .EnableDatabaseAdmin = true, .ExpectedResult = false
+            .EnableStrictUserManagement = false, .EnableDatabaseAdmin = true, .ExpectedResult = true
         },
         { .Tag = "DropUser", .PrecreateTarget = true, .SqlStatement = "DROP USER targetuser",
             .SubjectLevel = EAccessLevel::ClusterAdmin, .SubjectPermissions = {"ydb.database.connect"},


### PR DESCRIPTION
Allow admins to administer local users and groups without having `ydb.granular.alter_schema`.

### Changelog category

* Not for changelog