### PR TITLE
External data source: convert the private protobuf to the public one on describe RPC

### DIFF
--- a/ydb/core/grpc_services/rpc_describe_external_data_source.cpp
+++ b/ydb/core/grpc_services/rpc_describe_external_data_source.cpp
@@ -2,12 +2,91 @@
 #include "service_table.h"
 
 #include <ydb/core/grpc_services/base/base.h>
+#include <ydb/core/ydb_convert/ydb_convert.h>
 #include <ydb/public/api/protos/ydb_table.pb.h>
 
 namespace NKikimr::NGRpcService {
 
 using namespace NActors;
+using namespace NKikimrSchemeOp;
 using namespace NYql;
+
+namespace {
+
+using TProperties = google::protobuf::Map<TProtoStringType, TProtoStringType>;
+
+void Convert(const TServiceAccountAuth& in, TProperties& out) {
+    out["SERVICE_ACCOUNT_ID"] = in.GetId();
+    out["SERVICE_ACCOUNT_SECRET_NAME"] = in.GetSecretName();
+}
+
+void Convert(const TBasic& in, TProperties& out) {
+    out["LOGIN"] = in.GetLogin();
+    out["PASSWORD_SECRET_NAME"] = in.GetPasswordSecretName();
+}
+
+void Convert(const TMdbBasic& in, TProperties& out) {
+    out["SERVICE_ACCOUNT_ID"] = in.GetServiceAccountId();
+    out["SERVICE_ACCOUNT_SECRET_NAME"] = in.GetServiceAccountSecretName();
+    out["LOGIN"] = in.GetLogin();
+    out["PASSWORD_SECRET_NAME"] = in.GetPasswordSecretName();
+}
+
+void Convert(const TAws& in, TProperties& out) {
+    out["AWS_ACCESS_KEY_ID_SECRET_NAME"] = in.GetAwsAccessKeyIdSecretName();
+    out["AWS_SECRET_ACCESS_KEY_SECRET_NAME"] = in.GetAwsSecretAccessKeySecretName();
+    out["AWS_REGION"] = in.GetAwsRegion();
+}
+
+void Convert(const TToken& in, TProperties& out) {
+    out["TOKEN_SECRET_NAME"] = in.GetTokenSecretName();
+}
+
+void Convert(const TAuth& in, TProperties& out) {
+    auto& authMethod = out["AUTH_METHOD"];
+
+    switch (in.GetIdentityCase()) {
+    case TAuth::kNone:
+        authMethod = "NONE";
+        return;
+    case TAuth::kServiceAccount:
+        authMethod = "SERVICE_ACCOUNT";
+        Convert(in.GetServiceAccount(), out);
+        return;
+    case TAuth::kBasic:
+        authMethod = "BASIC";
+        Convert(in.GetBasic(), out);
+        return;
+    case TAuth::kMdbBasic:
+        authMethod = "MDB_BASIC";
+        Convert(in.GetMdbBasic(), out);
+        return;
+    case TAuth::kAws:
+        authMethod = "AWS";
+        Convert(in.GetAws(), out);
+        return;
+    case TAuth::kToken:
+        authMethod = "TOKEN";
+        Convert(in.GetToken(), out);
+        return;
+    case TAuth::IDENTITY_NOT_SET:
+        return;
+    }
+}
+
+Ydb::Table::DescribeExternalDataSourceResult Convert(const TDirEntry& inSelf, const TExternalDataSourceDescription& inDesc) {
+    Ydb::Table::DescribeExternalDataSourceResult out;
+    ConvertDirectoryEntry(inSelf, out.mutable_self(), true);
+
+    out.set_source_type(inDesc.GetSourceType());
+    out.set_location(inDesc.GetLocation());
+    auto& properties = *out.mutable_properties();
+    properties = inDesc.GetProperties().GetProperties();
+    Convert(inDesc.GetAuth(), properties);
+    return out;
+}
+
+}
 
 using TEvDescribeExternalDataSourceRequest = TGrpcRequestOperationCall<
     Ydb::Table::DescribeExternalDataSourceRequest,
@@ -64,7 +143,7 @@ private:
 
                 return ReplyWithResult(
                     Ydb::StatusIds::SUCCESS,
-                    Ydb::Table::DescribeExternalDataSourceResult(), // to do: convert private protobuf to public
+                    Convert(pathDescription.GetSelf(), pathDescription.GetExternalDataSourceDescription()),
                     ctx
                 );
             }

--- a/ydb/core/ydb_convert/table_description.cpp
+++ b/ydb/core/ydb_convert/table_description.cpp
@@ -506,6 +506,10 @@ Ydb::Type* AddColumn<NKikimrSchemeOp::TColumnDescription>(Ydb::Table::ColumnMeta
     return columnType;
 }
 
+void FillColumnDescription(Ydb::Table::ColumnMeta& out, const NKikimrSchemeOp::TColumnDescription& in) {
+    AddColumn(&out, in);
+}
+
 template <typename TYdbProto>
 void FillColumnDescriptionImpl(TYdbProto& out,
         NKikimrMiniKQL::TType& splitKeyType, const NKikimrSchemeOp::TTableDescription& in) {
@@ -1138,7 +1142,7 @@ void FillAttributesImpl(TOutProto& out, const TInProto& in) {
 }
 void FillChangefeedDescription(Ydb::Table::ChangefeedDescription& out,
     const NKikimrSchemeOp::TCdcStreamDescription& in) {
-    
+
     out.set_name(in.GetName());
     out.set_virtual_timestamps(in.GetVirtualTimestamps());
     out.set_aws_region(in.GetAwsRegion());

--- a/ydb/core/ydb_convert/table_description.h
+++ b/ydb/core/ydb_convert/table_description.h
@@ -51,6 +51,7 @@ bool BuildAlterTableAddIndexRequest(const Ydb::Table::AlterTableRequest* req, NK
     Ydb::StatusIds::StatusCode& status, TString& error);
 
 // out
+void FillColumnDescription(Ydb::Table::ColumnMeta& out, const NKikimrSchemeOp::TColumnDescription& in);
 void FillColumnDescription(Ydb::Table::DescribeTableResult& out,
     NKikimrMiniKQL::TType& splitKeyType, const NKikimrSchemeOp::TTableDescription& in);
 void FillColumnDescription(Ydb::Table::CreateTableRequest& out,
@@ -147,7 +148,7 @@ bool FillSequenceDescription(Ydb::Table::CreateTableRequest& out, const NKikimrS
 
 // in
 bool FillSequenceDescription(
-    NKikimrSchemeOp::TSequenceDescription& out, const Ydb::Table::SequenceDescription& in, 
+    NKikimrSchemeOp::TSequenceDescription& out, const Ydb::Table::SequenceDescription& in,
     Ydb::StatusIds::StatusCode& status, TString& error);
 
 } // namespace NKikimr


### PR DESCRIPTION
Convert the private protobuf description of External Data Source and External Table scheme objects to the public ones in the corresponding RPC implementing actors.

The conversion of the External Data Source protobuf is mostly the reversal of the conversion from the parser's map of features to the private protobuf executed [here](https://github.com/ydb-platform/ydb/blob/8af7595650a3d7370a517a3d597348520ec4e3ff/ydb/core/kqp/gateway/behaviour/external_data_source/manager.cpp#L44).

The conversion of the content of External Tables is copied from [here](https://github.com/ydb-platform/ydb/blob/8af7595650a3d7370a517a3d597348520ec4e3ff/ydb/core/viewer/viewer_describe.h#L310).

### Example

Create an external data source and an external table:
```sql
CREATE EXTERNAL DATA SOURCE external_data_source WITH (
    SOURCE_TYPE="ObjectStorage",
    LOCATION="192.168.1.1:8123",
    AUTH_METHOD="NONE"
);

CREATE EXTERNAL TABLE external_table (
    key Utf8 NOT NULL,
    value Utf8 NOT NULL
) WITH (
    DATA_SOURCE="external_data_source",
    LOCATION="folder",
    FORMAT="csv_with_names",
    COMPRESSION="gzip"
);
```

Now let's check the output of the `ydb scheme describe` command:

<details><summary>ydb scheme describe external_data_source --format proto-json-base64</summary>

```text
<external-data-source> external_data_source
{"self":{"name":"external_data_source","owner":"root@builtin","type":"EXTERNAL_DATA_SOURCE","effective_permissions":[{"subject":"USERS","permission_names":["ydb.database.connect"]},{"subject":"METADATA-READERS","permission_names":["ydb.generic.list"]},{"subject":"DATA-READERS","permission_names":["ydb.granular.select_row"]},{"subject":"DATA-WRITERS","permission_names":["ydb.tables.modify"]},{"subject":"DDL-ADMINS","permission_names":["ydb.granular.create_directory","ydb.granular.write_attributes","ydb.granular.create_table","ydb.granular.remove_schema","ydb.granular.create_queue","ydb.granular.alter_schema"]},{"subject":"ACCESS-ADMINS","permission_names":["ydb.access.grant"]},{"subject":"DATABASE-ADMINS","permission_names":["ydb.generic.manage"]}],"created_at":{"plan_step":"1739462700490","tx_id":"281474976720659"}},"source_type":"ObjectStorage","location":"192.168.1.1:8123","properties":{"AUTH_METHOD":"NONE"}}
```

</details>

<details><summary>same, but without the description of "self" and formatted</summary>

```json
{
  "source_type": "ObjectStorage",
  "location": "192.168.1.1:8123",
  "properties": {
    "AUTH_METHOD": "NONE"
  }
}
```

</details>

<details><summary>ydb scheme describe external_table --format proto-json-base64</summary>

```text
<external-table> external_table
{"self":{"name":"external_table","owner":"root@builtin","type":"EXTERNAL_TABLE","effective_permissions":[{"subject":"USERS","permission_names":["ydb.database.connect"]},{"subject":"METADATA-READERS","permission_names":["ydb.generic.list"]},{"subject":"DATA-READERS","permission_names":["ydb.granular.select_row"]},{"subject":"DATA-WRITERS","permission_names":["ydb.tables.modify"]},{"subject":"DDL-ADMINS","permission_names":["ydb.granular.create_directory","ydb.granular.write_attributes","ydb.granular.create_table","ydb.granular.remove_schema","ydb.granular.create_queue","ydb.granular.alter_schema"]},{"subject":"ACCESS-ADMINS","permission_names":["ydb.access.grant"]},{"subject":"DATABASE-ADMINS","permission_names":["ydb.generic.manage"]}],"created_at":{"plan_step":"1739462700530","tx_id":"281474976720660"}},"source_type":"ObjectStorage","data_source_path":"/Root/dedicated/external_data_source","location":"folder","columns":[{"name":"key","type":{"type_id":"UTF8"}},{"name":"value","type":{"type_id":"UTF8"}}],"content":{"format":"[\"csv_with_names\"]","compression":"[\"gzip\"]"}}
```

</details>

<details><summary>same, but without the description of "self" and formatted</summary>

```json
{
  "source_type": "ObjectStorage",
  "data_source_path": "/Root/dedicated/external_data_source",
  "location": "folder",
  "columns": [
    {
      "name": "key",
      "type": {
        "type_id": "UTF8"
      }
    },
    {
      "name": "value",
      "type": {
        "type_id": "UTF8"
      }
    }
  ],
  "content": {
    "format": "[\"csv_with_names\"]",
    "compression": "[\"gzip\"]"
  }
}
```

</details>

### Changelog entry <!-- a user-readable short description of changes introduced in this PR -->

### Changelog category <!-- remove all except one -->

* Not for changelog (changelog entry is not required)

### Additional information

- https://github.com/ydb-platform/ydb/issues/14436
