### PR TITLE
security: make domain_login_only+enable_strict_* mode work

### DIFF
--- a/ydb/core/kqp/ut/scheme/kqp_scheme_ut.cpp
+++ b/ydb/core/kqp/ut/scheme/kqp_scheme_ut.cpp
@@ -2823,7 +2823,7 @@ Y_UNIT_TEST_SUITE(KqpScheme) {
             auto result = userSession.AlterTable("/Root/SecondaryKeys/Index/indexImplTable", tableSettings).ExtractValueSync();
             UNIT_ASSERT_VALUES_EQUAL_C(result.GetStatus(), EStatus::UNAUTHORIZED, result.GetIssues().ToString());
             UNIT_ASSERT_STRING_CONTAINS(result.GetIssues().ToString(),
-                "Error: Access denied for user@builtin on path Root/SecondaryKeys/Index/indexImplTable"
+                "Error: Access denied for user@builtin on path /Root/SecondaryKeys/Index/indexImplTable"
             );
         }
         // grant necessary permission

--- a/ydb/core/security/secure_request.h
+++ b/ydb/core/security/secure_request.h
@@ -44,12 +44,9 @@ private:
                 return static_cast<TDerived*>(this)->OnAccessDenied(result.Error, ctx);
             }
         } else {
-            if (RequireAdminAccess) {
-                UserAdmin = IsTokenAllowed(result.Token.Get(), GetAdministrationAllowedSIDs());
-                if (!UserAdmin) {
-                    return static_cast<TDerived*>(this)->OnAccessDenied(TEvTicketParser::TError{.Message = "Administrative access denied", .Retryable = false}, ctx);
-
-                }
+            UserAdmin = IsTokenAllowed(result.Token.Get(), GetAdministrationAllowedSIDs());
+            if (RequireAdminAccess && !UserAdmin) {
+                return static_cast<TDerived*>(this)->OnAccessDenied(TEvTicketParser::TError{.Message = "Administrative access denied", .Retryable = false}, ctx);
             }
         }
         AuthorizeTicketResult = ev.Get()->Release();

--- a/ydb/core/security/ticket_parser_impl.h
+++ b/ydb/core/security/ticket_parser_impl.h
@@ -746,12 +746,12 @@ private:
             // In a special case, when DomainLoginOnly = false and a user from the root database attempts to
             // access a tenant database, target database must be selected between the two candidates: tenant and the root,
             // based on the database (or audience) embedded in the token itself.
-            const auto database = NLogin::TLoginProvider::GetTokenAudience(record.Ticket);
+            auto database = NLogin::TLoginProvider::GetTokenAudience(record.Ticket);
             BLOG_TRACE("CanInitLoginToken, domain db " << DomainName << ", request db " << record.Database
                 << ", token db " << database << ", DomainLoginOnly " << Config.GetDomainLoginOnly()
             );
             if (database.empty()) {
-                return false;
+                database = DomainName;
             }
             const auto& lookupDatabases = GetLookupDatabases(record);
             BLOG_TRACE("CanInitLoginToken, target database candidates(" << lookupDatabases.size() << "): " << JoinSeq(", ", lookupDatabases));
@@ -1910,9 +1910,9 @@ protected:
         if (record.IsExternalAuthEnabled()) {
             return RefreshTicketViaExternalAuthProvider(key, record);
         }
-        const auto database = NLogin::TLoginProvider::GetTokenAudience(record.Ticket);
+        auto database = NLogin::TLoginProvider::GetTokenAudience(record.Ticket);
         if (database.empty()) {
-            return false;
+            database = DomainName;
         }
         const auto& lookupDatabases = GetLookupDatabases(record);
         if (std::find(lookupDatabases.begin(), lookupDatabases.end(), database) == lookupDatabases.end()) {

--- a/ydb/core/tx/schemeshard/schemeshard__operation_modify_acl.cpp
+++ b/ydb/core/tx/schemeshard/schemeshard__operation_modify_acl.cpp
@@ -1,6 +1,8 @@
 #include "schemeshard__operation_part.h"
 #include "schemeshard_impl.h"
 
+#include <ydb/core/base/auth.h>
+
 namespace {
 
 using namespace NKikimr;
@@ -57,20 +59,33 @@ public:
             return result;
         }
 
+        bool isAdmin = (context.UserToken && IsAdministrator(AppData(), context.UserToken.Get()));
+
         if (acl && AppData()->FeatureFlags.GetEnableStrictAclCheck()) {
             NACLib::TDiffACL diffACL(acl);
             for (const NACLibProto::TDiffACE& diffACE : diffACL.GetDiffACE()) {
                 if (static_cast<NACLib::EDiffType>(diffACE.GetDiffType()) == NACLib::EDiffType::Add) {
-                    if (!CheckSidExistsOrIsNonYdb(context.SS->LoginProvider.Sids, diffACE.GetACE().GetSID())) {
+                    // add diff type is allowed if:
+                    // - subject is a cluster administrator
+                    // - or target sid is an external one (not a ydb-local)
+                    // - or target sid is a local one and exist in this database
+                    const auto& targetSid = diffACE.GetACE().GetSID();
+                    bool allowed = (isAdmin || CheckSidExistsOrIsNonYdb(context.SS->LoginProvider.Sids, targetSid));
+                    if (!allowed) {
                         result->SetError(NKikimrScheme::StatusPreconditionFailed,
-                            TStringBuilder() << "SID " << diffACE.GetACE().GetSID() << " not found in database `" << databaseName << "`");
+                            TStringBuilder() << "SID " << targetSid << " not found in database `" << databaseName << "`");
                         return result;
                     }
                 } // remove diff type is allowed in any case
             }
         }
         if (owner && AppData()->FeatureFlags.GetEnableStrictAclCheck()) {
-            if (!CheckSidExistsOrIsNonYdb(context.SS->LoginProvider.Sids, owner)) {
+            // ownership transfer is allowed if:
+            // - subject is a cluster administrator
+            // - or target sid is an external one (not a ydb-local)
+            // - or target sid is a local one and exist in this database
+            bool allowed = (isAdmin || CheckSidExistsOrIsNonYdb(context.SS->LoginProvider.Sids, owner));
+            if (!allowed) {
                 result->SetError(NKikimrScheme::StatusPreconditionFailed,
                     TStringBuilder() << "Owner SID " << owner << " not found in database `" << databaseName << "`");
                 return result;

--- a/ydb/core/tx/tx_proxy/schemereq.cpp
+++ b/ydb/core/tx/tx_proxy/schemereq.cpp
@@ -1153,9 +1153,7 @@ struct TBaseSchemeReq: public TActorBootstrapped<TDerived> {
                 }
 
                 // Admins can always change ACLs
-                if (!modifyScheme.GetModifyACL().GetDiffACL().empty()) {
-                    allowACLBypass = isAdmin;
-                }
+                allowACLBypass = isAdmin;
             }
 
             ui32 access = requestIt->RequireAccess;

--- a/ydb/library/login/login.cpp
+++ b/ydb/library/login/login.cpp
@@ -385,7 +385,7 @@ bool TLoginProvider::ShouldUnlockAccount(const TSidRecord& sid) const {
 
 bool TLoginProvider::IsLockedOut(const TSidRecord& user) const {
     Y_ABORT_UNLESS(user.Type == NLoginProto::ESidType::USER);
-    
+
     if (AccountLockout.AttemptThreshold == 0) {
         return false;
     }
@@ -533,6 +533,7 @@ TLoginProvider::TValidateTokenResponse TLoginProvider::ValidateToken(const TVali
             // we check audience manually because we want an explicit error instead of wrong key id in case of databases mismatch
             auto audience = decoded_token.get_audience();
             if (audience.empty() || TString(*audience.begin()) != Audience) {
+                response.WrongAudience = true;
                 response.Error = "Wrong audience";
                 return response;
             }

--- a/ydb/library/login/login.h
+++ b/ydb/library/login/login.h
@@ -86,6 +86,7 @@ public:
     struct TValidateTokenResponse : TBasicResponse {
         bool TokenUnrecognized = false;
         bool ErrorRetryable = false;
+        bool WrongAudience = false;
         TString User;
         std::optional<std::vector<TString>> Groups;
         std::chrono::system_clock::time_point ExpiresAt;

--- a/ydb/services/ydb/ydb_table_ut.cpp
+++ b/ydb/services/ydb/ydb_table_ut.cpp
@@ -397,7 +397,7 @@ Y_UNIT_TEST_SUITE(YdbYqlClient) {
             UNIT_ASSERT_VALUES_EQUAL(columnParser.GetDecimal().DecimalType_.Precision, 35);
             UNIT_ASSERT_VALUES_EQUAL(columnParser.GetDecimal().DecimalType_.Scale, 10);
         }
-    }    
+    }
 
     Y_UNIT_TEST(TestDecimalFullStack) {
         TKikimrWithGrpcAndRootSchema server;
@@ -755,9 +755,11 @@ Y_UNIT_TEST_SUITE(YdbYqlClient) {
     }
 
     Y_UNIT_TEST(ConnectDbAclIsStrictlyChecked) {
+        const TString clusterAdminToken = "root@builtin";
         NKikimrConfig::TAppConfig appConfig;
         appConfig.MutableFeatureFlags()->SetAllowYdbRequestsWithoutDatabase(false);
         appConfig.MutableDomainsConfig()->MutableSecurityConfig()->SetEnforceUserTokenRequirement(true);
+        appConfig.MutableDomainsConfig()->MutableSecurityConfig()->AddAdministrationAllowedSIDs(clusterAdminToken);
         appConfig.MutableDomainsConfig()->MutableSecurityConfig()->AddDefaultUserSIDs("test_user_no_rights@builtin");
         TKikimrWithGrpcAndRootSchemaWithAuth server(appConfig);
 
@@ -772,7 +774,7 @@ Y_UNIT_TEST_SUITE(YdbYqlClient) {
                     .SetEndpoint(location));
 
             NYdb::NTable::TClientSettings settings;
-            settings.AuthToken("root@builtin");
+            settings.AuthToken(clusterAdminToken);
 
             NYdb::NTable::TTableClient client(driver, settings);
             auto call = [] (NYdb::NTable::TTableClient& client) -> NYdb::TStatus {
@@ -818,7 +820,7 @@ Y_UNIT_TEST_SUITE(YdbYqlClient) {
             UNIT_ASSERT_VALUES_EQUAL_C(status.GetStatus(), EStatus::CLIENT_UNAUTHENTICATED, status.GetIssues().ToString());
         }
 
-        { // no connect right
+        { // no connect right (for the ordinary user)
             TString location = TStringBuilder() << "localhost:" << grpc;
             auto driver = NYdb::TDriver(
                 TDriverConfig()
@@ -839,7 +841,7 @@ Y_UNIT_TEST_SUITE(YdbYqlClient) {
 
         { // set connect
             NYdb::TCommonClientSettings settings;
-            settings.AuthToken("root@builtin");
+            settings.AuthToken(clusterAdminToken);
             auto scheme = NYdb::NScheme::TSchemeClient(driver, settings);
             auto status = scheme.ModifyPermissions("/Root",
                 NYdb::NScheme::TModifyPermissionsSettings()
@@ -878,6 +880,11 @@ Y_UNIT_TEST_SUITE(YdbYqlClient) {
         appConfig.MutableDomainsConfig()->MutableSecurityConfig()->SetEnforceUserTokenRequirement(false);
         appConfig.MutableDomainsConfig()->MutableSecurityConfig()->AddDefaultUserSIDs("test_user_no_rights@builtin");
         TKikimrWithGrpcAndRootSchema server(appConfig);
+
+        // Make all users except root@builtin non-admins.
+        // (Can't set AdministrationAllowedSIDs before `server` initialization --
+        // initial scheme root initialization would not work.)
+        server.GetRuntime()->GetAppData().AdministrationAllowedSIDs.push_back("root@builtin");
 
         ui16 grpc = server.GetPort();
         {

--- a/ydb/tests/functional/tenants/test_dynamic_tenants.py
+++ b/ydb/tests/functional/tenants/test_dynamic_tenants.py
@@ -409,8 +409,8 @@ def test_check_access(ydb_cluster):
         ydb_cluster.wait_tenant_up(user['path'])
 
         driver_config = ydb.DriverConfig(
-            "%s:%s" % (ydb_cluster.nodes[1].host, ydb_cluster.nodes[1].port),
-            user['path']
+            database=user['path'],
+            endpoint="%s:%s" % (ydb_cluster.nodes[1].host, ydb_cluster.nodes[1].port),
         )
 
         with ydb.Driver(driver_config) as driver:
@@ -426,8 +426,9 @@ def test_check_access(ydb_cluster):
     user_2 = users['user_2']
 
     driver_config = ydb.DriverConfig(
-        "%s:%s" % (ydb_cluster.nodes[1].host, ydb_cluster.nodes[1].port),
-        user_1['path'], auth_token=user_1['owner']
+        database=user_1['path'],
+        endpoint="%s:%s" % (ydb_cluster.nodes[1].host, ydb_cluster.nodes[1].port),
+        auth_token=user_1['owner'],
     )
 
     with ydb.Driver(driver_config) as driver:


### PR DESCRIPTION
Make `domain_login_only`+`enable_strict_acl_check`+`enable_strict_user_management` work.

- grpc-proxy: fix bug that require admin to have explicit `ydb.database.connect` permission on a database to be able to work with it (while original intention was that admins should bypass database connect check)
- ticket-parser: allow users from the root database to authenticate in a tenant database
- allow cluster admin to set the owner of a database (e.g. database admin) at the root schemeshard, without checking target sid for existence, effectively bypassing `enable_strict_acl_check` restriction in that particular case

### Changelog category

* Not for changelog
