### PR TITLE
External data sources: dump

### DIFF
--- a/ydb/core/grpc_services/rpc_describe_external_data_source.cpp
+++ b/ydb/core/grpc_services/rpc_describe_external_data_source.cpp
@@ -81,7 +81,9 @@ Ydb::Table::DescribeExternalDataSourceResult Convert(const TDirEntry& inSelf, co
     out.set_source_type(inDesc.GetSourceType());
     out.set_location(inDesc.GetLocation());
     auto& properties = *out.mutable_properties();
-    properties = inDesc.GetProperties().GetProperties();
+    for (const auto& [key, value] : inDesc.GetProperties().GetProperties()) {
+        properties[to_upper(key)] = value;
+    }
     Convert(inDesc.GetAuth(), properties);
     return out;
 }

--- a/ydb/core/grpc_services/rpc_describe_external_table.cpp
+++ b/ydb/core/grpc_services/rpc_describe_external_table.cpp
@@ -44,7 +44,7 @@ bool ConvertContent(
             for (const auto& item : items) {
                 json.AppendValue(item);
             }
-            out[key] = WriteJson(json, false);
+            out[to_upper(key)] = WriteJson(json, false);
         }
     } catch (...) {
         issues.AddIssue(TStringBuilder() << "Cannot unpack the content of an external table of type: " << sourceType

--- a/ydb/library/backup/backup.cpp
+++ b/ydb/library/backup/backup.cpp
@@ -890,11 +890,10 @@ std::string ColumnToString(const Ydb::Table::ColumnMeta& column) {
 
 TString BuildCreateExternalTableQuery(const Ydb::Table::DescribeExternalTableResult& description) {
     return std::format(
-        "CREATE EXTERNAL TABLE IF NOT EXISTS `{}` (\n{}\n) WITH (\n{},\n{},\n{}{}\n);",
+        "CREATE EXTERNAL TABLE IF NOT EXISTS `{}` (\n{}\n) WITH (\n{},\n{}{}\n);",
         description.self().name().c_str(),
         JoinSeq(",\n", std::views::transform(description.columns(), ColumnToString)).c_str(),
-        ToString("SOURCE_TYPE", description.source_type()),
-        ToString("DATA_SOURCE_PATH", description.data_source_path()),
+        ToString("DATA_SOURCE", description.data_source_path()),
         ToString("LOCATION", description.location()),
         description.content().empty()
             ? ""

--- a/ydb/library/backup/db_iterator.h
+++ b/ydb/library/backup/db_iterator.h
@@ -165,6 +165,10 @@ public:
         return GetCurrentNode()->Type == NScheme::ESchemeEntryType::ExternalDataSource;
     }
 
+    bool IsExternalTable() const {
+        return GetCurrentNode()->Type == NScheme::ESchemeEntryType::ExternalTable;
+    }
+
     bool IsListed() const {
         return NextNodes.front().IsListed;
     }

--- a/ydb/library/backup/db_iterator.h
+++ b/ydb/library/backup/db_iterator.h
@@ -161,6 +161,10 @@ public:
         return GetCurrentNode()->Type == NScheme::ESchemeEntryType::Replication;
     }
 
+    bool IsExternalDataSource() const {
+        return GetCurrentNode()->Type == NScheme::ESchemeEntryType::ExternalDataSource;
+    }
+
     bool IsListed() const {
         return NextNodes.front().IsListed;
     }

--- a/ydb/public/lib/ydb_cli/dump/files/files.cpp
+++ b/ydb/public/lib/ydb_cli/dump/files/files.cpp
@@ -19,6 +19,7 @@ enum EFilesType {
     CREATE_GROUP,
     ALTER_GROUP,
     CREATE_ASYNC_REPLICATION,
+    CREATE_EXTERNAL_DATA_SOURCE,
 };
 
 static constexpr TFileInfo FILES_INFO[] = {
@@ -38,6 +39,7 @@ static constexpr TFileInfo FILES_INFO[] = {
     {"create_group.sql", "groups"},
     {"alter_group.sql", "group members"},
     {"create_async_replication.sql", "async replication"},
+    {"create_external_data_source.sql", "external data source"},
 };
 
 const TFileInfo& TableScheme() {
@@ -102,6 +104,10 @@ const TFileInfo& AlterGroup() {
 
 const TFileInfo& CreateAsyncReplication() {
     return FILES_INFO[CREATE_ASYNC_REPLICATION];
+}
+
+const TFileInfo& CreateExternalDataSource() {
+    return FILES_INFO[CREATE_EXTERNAL_DATA_SOURCE];
 }
 
 } // NYdb::NDump::NFiles

--- a/ydb/public/lib/ydb_cli/dump/files/files.cpp
+++ b/ydb/public/lib/ydb_cli/dump/files/files.cpp
@@ -20,6 +20,7 @@ enum EFilesType {
     ALTER_GROUP,
     CREATE_ASYNC_REPLICATION,
     CREATE_EXTERNAL_DATA_SOURCE,
+    CREATE_EXTERNAL_TABLE,
 };
 
 static constexpr TFileInfo FILES_INFO[] = {
@@ -40,6 +41,7 @@ static constexpr TFileInfo FILES_INFO[] = {
     {"alter_group.sql", "group members"},
     {"create_async_replication.sql", "async replication"},
     {"create_external_data_source.sql", "external data source"},
+    {"create_external_table.sql", "external table"},
 };
 
 const TFileInfo& TableScheme() {
@@ -108,6 +110,10 @@ const TFileInfo& CreateAsyncReplication() {
 
 const TFileInfo& CreateExternalDataSource() {
     return FILES_INFO[CREATE_EXTERNAL_DATA_SOURCE];
+}
+
+const TFileInfo& CreateExternalTable() {
+    return FILES_INFO[CREATE_EXTERNAL_TABLE];
 }
 
 } // NYdb::NDump::NFiles

--- a/ydb/public/lib/ydb_cli/dump/files/files.h
+++ b/ydb/public/lib/ydb_cli/dump/files/files.h
@@ -24,5 +24,6 @@ const TFileInfo& CreateGroup();
 const TFileInfo& AlterGroup();
 const TFileInfo& CreateAsyncReplication();
 const TFileInfo& CreateExternalDataSource();
+const TFileInfo& CreateExternalTable();
 
 } // NYdb::NDump:NFiles

--- a/ydb/public/lib/ydb_cli/dump/files/files.h
+++ b/ydb/public/lib/ydb_cli/dump/files/files.h
@@ -23,5 +23,6 @@ const TFileInfo& CreateUser();
 const TFileInfo& CreateGroup();
 const TFileInfo& AlterGroup();
 const TFileInfo& CreateAsyncReplication();
+const TFileInfo& CreateExternalDataSource();
 
 } // NYdb::NDump:NFiles


### PR DESCRIPTION
Dump (`ydb tools dump`) external data sources and tables as `create_smth.sql` queries in the objects' backup folders on the file system.

### Changelog entry <!-- a user-readable short description of changes introduced in this PR -->

### Changelog category <!-- remove all except one -->

* Not for changelog (changelog entry is not required)

### Additional information

- https://github.com/ydb-platform/ydb/issues/14437
