### PR TITLE
Use explicit DirtyChunks in TCommitRecord

### DIFF
--- a/ydb/core/blobstorage/pdisk/blobstorage_pdisk.h
+++ b/ydb/core/blobstorage/pdisk/blobstorage_pdisk.h
@@ -27,6 +27,7 @@ struct TCommitRecord {
     ui64 FirstLsnToKeep = 0; // 0 == not set
     TVector<TChunkIdx> CommitChunks;
     TVector<TChunkIdx> DeleteChunks;
+    TVector<TChunkIdx> DirtyChunks;
     bool IsStartingPoint = false;
     bool DeleteToDecommitted = false; // 1 == set chunks to Decommitted state that requires a ChunkForget event or a restart
     // the value of DeleteToDecommitted is not stored as a part of the commit record.
@@ -74,6 +75,8 @@ struct TCommitRecord {
         PrintChunks(str, CommitChunks);
         str << " DeleteChunks# ";
         PrintChunks(str, DeleteChunks);
+        str << " DirtyChunks# ";
+        PrintChunks(str, DirtyChunks);
         str << "}";
         return str.Str();
     }

--- a/ydb/core/blobstorage/vdisk/hullop/blobstorage_hullcommit.h
+++ b/ydb/core/blobstorage/vdisk/hullop/blobstorage_hullcommit.h
@@ -128,17 +128,6 @@ namespace NKikimr {
                             THullCommitFinished::TypeToString(NotifyType), CommitMsg->CommitRecord.ToString().data(),
                             Metadata.RemovedHugeBlobs.ToString().data()));
 
-            // notify PDisk about dirty chunks (the ones from which huge slots are being freed right now)
-            THashSet<TChunkIdx> chunkIds;
-            for (const TDiskPart& p : Metadata.RemovedHugeBlobs) {
-                chunkIds.insert(p.ChunkIdx);
-            }
-            if (chunkIds) {
-//              TODO(alexvru): uncommit when PDisk stops breaking tests when this is enabled
-//                ctx.Send(Ctx->PDiskCtx->PDiskId, new NPDisk::TEvMarkDirty(Ctx->PDiskCtx->Dsk->Owner,
-//                    Ctx->PDiskCtx->Dsk->OwnerRound, {chunkIds.begin(), chunkIds.end()}));
-            }
-
             ctx.Send(Ctx->LoggerId, CommitMsg.release());
         }
 
@@ -252,6 +241,13 @@ namespace NKikimr {
             CommitRecord.CommitChunks = std::move(Metadata.CommitChunks);
             CommitRecord.DeleteChunks = std::move(Metadata.DeleteChunks);
             CommitRecord.DeleteToDecommitted = Metadata.DeleteToDecommitted;
+
+            // notify PDisk about dirty chunks (the ones from which huge slots are being freed right now)
+            THashSet<TChunkIdx> chunkIds;
+            for (const TDiskPart& p : Metadata.RemovedHugeBlobs) {
+                chunkIds.insert(p.ChunkIdx);
+            }
+            CommitRecord.DirtyChunks = {chunkIds.begin(), chunkIds.end()};
 
             // validate its contents
             VerifyCommitRecord(CommitRecord);


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of changes introduced in this PR -->

Use explicit DirtyChunks in TCommitRecord

### Changelog category <!-- remove all except one -->

* Not for changelog (changelog entry is not required)

### Additional information

Use explicit DirtyChunks in TCommitRecord.
