### PR TITLE
Add chatty logging to cluster & database dump/restore

### DIFF
--- a/ydb/public/lib/ydb_cli/commands/ydb_admin.cpp
+++ b/ydb/public/lib/ydb_cli/commands/ydb_admin.cpp
@@ -54,7 +54,7 @@ void TCommandDatabaseDump::Parse(TConfig& config) {
 }
 
 int TCommandDatabaseDump::Run(TConfig& config) {
-    auto log = std::make_shared<TLog>(CreateLogBackend("cerr", TConfig::VerbosityLevelToELogPriority(config.VerbosityLevel)));
+    auto log = std::make_shared<TLog>(CreateLogBackend("cerr", TConfig::VerbosityLevelToELogPriorityChatty(config.VerbosityLevel)));
     log->SetFormatter(GetPrefixLogFormatter(""));
 
     NDump::TClient client(CreateDriver(config), std::move(log));
@@ -87,7 +87,7 @@ void TCommandDatabaseRestore::Parse(TConfig& config) {
 }
 
 int TCommandDatabaseRestore::Run(TConfig& config) {
-    auto log = std::make_shared<TLog>(CreateLogBackend("cerr", TConfig::VerbosityLevelToELogPriority(config.VerbosityLevel)));
+    auto log = std::make_shared<TLog>(CreateLogBackend("cerr", TConfig::VerbosityLevelToELogPriorityChatty(config.VerbosityLevel)));
     log->SetFormatter(GetPrefixLogFormatter(""));
 
     auto settings = NDump::TRestoreDatabaseSettings()

--- a/ydb/public/lib/ydb_cli/commands/ydb_cluster.cpp
+++ b/ydb/public/lib/ydb_cli/commands/ydb_cluster.cpp
@@ -66,7 +66,7 @@ void TCommandClusterDump::Parse(TConfig& config) {
 }
 
 int TCommandClusterDump::Run(TConfig& config) {
-    auto log = std::make_shared<TLog>(CreateLogBackend("cerr", TConfig::VerbosityLevelToELogPriority(config.VerbosityLevel)));
+    auto log = std::make_shared<TLog>(CreateLogBackend("cerr", TConfig::VerbosityLevelToELogPriorityChatty(config.VerbosityLevel)));
     log->SetFormatter(GetPrefixLogFormatter(""));
 
     NDump::TClient client(CreateDriver(config), std::move(log));
@@ -99,7 +99,7 @@ void TCommandClusterRestore::Parse(TConfig& config) {
 }
 
 int TCommandClusterRestore::Run(TConfig& config) {
-    auto log = std::make_shared<TLog>(CreateLogBackend("cerr", TConfig::VerbosityLevelToELogPriority(config.VerbosityLevel)));
+    auto log = std::make_shared<TLog>(CreateLogBackend("cerr", TConfig::VerbosityLevelToELogPriorityChatty(config.VerbosityLevel)));
     log->SetFormatter(GetPrefixLogFormatter(""));
 
     auto settings = NDump::TRestoreClusterSettings()

--- a/ydb/public/lib/ydb_cli/commands/ydb_root_common.cpp
+++ b/ydb/public/lib/ydb_cli/commands/ydb_root_common.cpp
@@ -334,7 +334,7 @@ void TClientCommandRootCommon::Config(TConfig& config) {
 
 void TClientCommandRootCommon::Parse(TConfig& config) {
     TClientCommandRootBase::Parse(config);
-    config.VerbosityLevel = std::min(static_cast<TConfig::EVerbosityLevel>(VerbosityLevel), TConfig::EVerbosityLevel::DEBUG);
+    config.VerbosityLevel = std::min(static_cast<TConfig::EVerbosityLevel>(VerbosityLevel), TConfig::EVerbosityLevel::VVV);
 }
 
 void TClientCommandRootCommon::ExtractParams(TConfig& config) {

--- a/ydb/public/lib/ydb_cli/commands/ydb_root_common.cpp
+++ b/ydb/public/lib/ydb_cli/commands/ydb_root_common.cpp
@@ -334,7 +334,7 @@ void TClientCommandRootCommon::Config(TConfig& config) {
 
 void TClientCommandRootCommon::Parse(TConfig& config) {
     TClientCommandRootBase::Parse(config);
-    config.VerbosityLevel = std::min(static_cast<TConfig::EVerbosityLevel>(VerbosityLevel), TConfig::EVerbosityLevel::VVV);
+    config.VerbosityLevel = std::min(static_cast<TConfig::EVerbosityLevel>(VerbosityLevel), TConfig::EVerbosityLevel::DEBUG);
 }
 
 void TClientCommandRootCommon::ExtractParams(TConfig& config) {

--- a/ydb/public/lib/ydb_cli/common/command.cpp
+++ b/ydb/public/lib/ydb_cli/common/command.cpp
@@ -36,11 +36,11 @@ ELogPriority TClientCommand::TConfig::VerbosityLevelToELogPriority(TClientComman
     switch (lvl) {
         case TClientCommand::TConfig::EVerbosityLevel::NONE:
             return ELogPriority::TLOG_EMERG;
-        case TClientCommand::TConfig::EVerbosityLevel::VVV:
+        case TClientCommand::TConfig::EVerbosityLevel::DEBUG:
             return ELogPriority::TLOG_DEBUG;
-        case TClientCommand::TConfig::EVerbosityLevel::VV:
+        case TClientCommand::TConfig::EVerbosityLevel::INFO:
             return ELogPriority::TLOG_INFO;
-        case TClientCommand::TConfig::EVerbosityLevel::V:
+        case TClientCommand::TConfig::EVerbosityLevel::WARN:
             return ELogPriority::TLOG_WARNING;
         default:
             return ELogPriority::TLOG_ERR;
@@ -51,9 +51,9 @@ ELogPriority TClientCommand::TConfig::VerbosityLevelToELogPriorityChatty(TClient
     switch (lvl) {
         case TClientCommand::TConfig::EVerbosityLevel::NONE:
             return ELogPriority::TLOG_INFO;
-        case TClientCommand::TConfig::EVerbosityLevel::VVV:
-        case TClientCommand::TConfig::EVerbosityLevel::VV:
-        case TClientCommand::TConfig::EVerbosityLevel::V:
+        case TClientCommand::TConfig::EVerbosityLevel::DEBUG:
+        case TClientCommand::TConfig::EVerbosityLevel::INFO:
+        case TClientCommand::TConfig::EVerbosityLevel::WARN:
             return ELogPriority::TLOG_DEBUG;
     }
     return ELogPriority::TLOG_INFO;

--- a/ydb/public/lib/ydb_cli/common/command.cpp
+++ b/ydb/public/lib/ydb_cli/common/command.cpp
@@ -36,15 +36,27 @@ ELogPriority TClientCommand::TConfig::VerbosityLevelToELogPriority(TClientComman
     switch (lvl) {
         case TClientCommand::TConfig::EVerbosityLevel::NONE:
             return ELogPriority::TLOG_EMERG;
-        case TClientCommand::TConfig::EVerbosityLevel::DEBUG:
+        case TClientCommand::TConfig::EVerbosityLevel::VVV:
             return ELogPriority::TLOG_DEBUG;
-        case TClientCommand::TConfig::EVerbosityLevel::INFO:
+        case TClientCommand::TConfig::EVerbosityLevel::VV:
             return ELogPriority::TLOG_INFO;
-        case TClientCommand::TConfig::EVerbosityLevel::WARN:
+        case TClientCommand::TConfig::EVerbosityLevel::V:
             return ELogPriority::TLOG_WARNING;
         default:
             return ELogPriority::TLOG_ERR;
     }
+}
+
+ELogPriority TClientCommand::TConfig::VerbosityLevelToELogPriorityChatty(TClientCommand::TConfig::EVerbosityLevel lvl) {
+    switch (lvl) {
+        case TClientCommand::TConfig::EVerbosityLevel::NONE:
+            return ELogPriority::TLOG_INFO;
+        case TClientCommand::TConfig::EVerbosityLevel::VVV:
+        case TClientCommand::TConfig::EVerbosityLevel::VV:
+        case TClientCommand::TConfig::EVerbosityLevel::V:
+            return ELogPriority::TLOG_DEBUG;
+    }
+    return ELogPriority::TLOG_INFO;
 }
 
 size_t TClientCommand::TConfig::ParseHelpCommandVerbosilty(int argc, char** argv) {

--- a/ydb/public/lib/ydb_cli/common/command.h
+++ b/ydb/public/lib/ydb_cli/common/command.h
@@ -85,12 +85,13 @@ public:
 
         enum EVerbosityLevel : ui32 {
             NONE = 0,
-            WARN = 1,
-            INFO = 2,
-            DEBUG = 3,
+            V = 1,
+            VV = 2,
+            VVV = 3,
         };
 
         static ELogPriority VerbosityLevelToELogPriority(EVerbosityLevel lvl);
+        static ELogPriority VerbosityLevelToELogPriorityChatty(EVerbosityLevel lvl);
 
         int ArgC;
         char** ArgV;

--- a/ydb/public/lib/ydb_cli/common/command.h
+++ b/ydb/public/lib/ydb_cli/common/command.h
@@ -85,9 +85,9 @@ public:
 
         enum EVerbosityLevel : ui32 {
             NONE = 0,
-            V = 1,
-            VV = 2,
-            VVV = 3,
+            WARN = 1,
+            INFO = 2,
+            DEBUG = 3,
         };
 
         static ELogPriority VerbosityLevelToELogPriority(EVerbosityLevel lvl);


### PR DESCRIPTION
### Changelog category <!-- remove all except one -->

* Not for changelog (changelog entry is not required)

### Additional information
Предлагается добавить болтливое логгирование для новых команд, на которые еще никто не завязался:
- `ydb admin database dump`
- `ydb admin database restore`
- `ydb admin cluster dump`
- `ydb admin cluster restore`

Стандартное логгирование в CLI:
- `ydb` (без параметров) - `EMERG`
- `ydb -v` - `WARN`
- `ydb -vv` - `INFO`
- `ydb -vvv` - `DEBUG`

Болтливое логгирование в CLI:
- `ydb` (без параметров) - `INFO`
- `ydb -v` - `DEBUG`
- `ydb -vv` - `DEBUG`
- `ydb -vvv` - `DEBUG`

Мотивация:
- Показывает пользователю, что что-то происходит, а не все зависло
- Помогает пользователю дебажить проблемы самому или предоставлять нам сразу логи
- Текущий флажок `-v` еще нужно догадаться, что можно использовать как `-vvv` для действительно `verbose` уровня логгирования
- Для команд дампа и рестора писать лог привычно:
    - `pg_probackup` от `PostgresPro` по дефолту пишет лог уровня `INFO` в консоль
    - `tiup br` от `TiDB` по дефолту пишет подробный лог уровня `INFO` во временный файл, в консоль `summary`
- В нашей реализации команд дампа и рестора в логе есть важные сообщения, которые хотелось бы показывать пользователю по дефолту
