### PR TITLE
Database admin cannot use ALTER/DROP USER on cluster admin

### DIFF
--- a/ydb/core/tx/tx_proxy/schemereq.cpp
+++ b/ydb/core/tx/tx_proxy/schemereq.cpp
@@ -1115,18 +1115,8 @@ struct TBaseSchemeReq: public TActorBootstrapped<TDerived> {
                 };
 
                 const auto& alter = modifyScheme.GetAlterLogin();
-
-                bool isDbAdminManagesUser = 
-                    checkAdmin
-                    &&
-                    IsDatabaseAdministrator
-                    &&
-                    (
-                        alter.GetAlterCase() == NKikimrSchemeOp::TAlterLogin::kModifyUser
-                        ||
-                        alter.GetAlterCase() == NKikimrSchemeOp::TAlterLogin::kRemoveUser
-                    )
-                ;
+                bool isManageUser = (alter.GetAlterCase() == NKikimrSchemeOp::TAlterLogin::kModifyUser || alter.GetAlterCase() == NKikimrSchemeOp::TAlterLogin::kRemoveUser);
+                bool isDbAdminManagesUser = checkAdmin && IsDatabaseAdministrator && isManageUser;
 
                 if (isDbAdminManagesUser) {
                     const auto& targetUser = (alter.GetAlterCase() == NKikimrSchemeOp::TAlterLogin::kModifyUser ? 


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of changes introduced in this PR -->
In this pull request the verification of permissions on ALTER USER by database admin on cluster admin is corrected.

### Changelog category <!-- remove all except one -->

* Bugfix 