### PR TITLE
Fix warning in ydbd_slice

### DIFF
--- a/ydb/tools/ydbd_slice/ya.make
+++ b/ydb/tools/ydbd_slice/ya.make
@@ -24,7 +24,7 @@ PY_SRCS(
 PEERDIR(
     ydb/tools/cfg
     ydb/public/sdk/python
-    ydb/public/sdk/python/ydb_v3_new_behavior
+    ydb/public/sdk/python/enable_v3_new_behavior
     contrib/python/PyYAML
     contrib/python/ruamel.yaml
     contrib/python/kubernetes

--- a/ydb/tools/ydbd_slice/ya.make
+++ b/ydb/tools/ydbd_slice/ya.make
@@ -24,6 +24,7 @@ PY_SRCS(
 PEERDIR(
     ydb/tools/cfg
     ydb/public/sdk/python
+    ydb/public/sdk/python/ydb_v3_new_behavior
     contrib/python/PyYAML
     contrib/python/ruamel.yaml
     contrib/python/kubernetes


### PR DESCRIPTION
```
contrib/python/ydb/py3/ydb/__init__.py:43: UserWarning: Used deprecated behavior, for fix ADD PEERDIR kikimr/public/sdk/python/ydb_v3_new_behavior
contrib/python/ydb/py3/ydb/global_settings.py:22: UserWarning: Global allow split transaction is deprecated behaviour.
contrib/python/ydb/py3/ydb/global_settings.py:12: UserWarning: Global allow truncated response is deprecated behaviour.```
