### PR TITLE
Support dual-config mode in distconf

### DIFF
--- a/ydb/core/blobstorage/nodewarden/distconf.cpp
+++ b/ydb/core/blobstorage/nodewarden/distconf.cpp
@@ -68,29 +68,42 @@ namespace NKikimr::NStorage {
     bool TDistributedConfigKeeper::ApplyStorageConfig(const NKikimrBlobStorage::TStorageConfig& config) {
         if (!StorageConfig || StorageConfig->GetGeneration() < config.GetGeneration() ||
                 (!IsSelfStatic && !config.GetGeneration() && !config.GetSelfManagementConfig().GetEnabled())) {
-            StorageConfigYaml = StorageConfigFetchYaml = {};
-            StorageConfigFetchYamlHash = 0;
-            StorageConfigYamlVersion.reset();
+            // extract the main config from newly applied section
+            MainConfigYaml = MainConfigFetchYaml = {};
+            MainConfigYamlVersion.reset();
+            MainConfigFetchYamlHash = 0;
 
             if (config.HasConfigComposite()) {
                 try {
                     // parse the composite stream
                     TStringInput ss(config.GetConfigComposite());
                     TZstdDecompress zstd(&ss);
-                    StorageConfigYaml = TString::Uninitialized(LoadSize(&zstd));
-                    zstd.LoadOrFail(StorageConfigYaml.Detach(), StorageConfigYaml.size());
-                    StorageConfigFetchYaml = TString::Uninitialized(LoadSize(&zstd));
-                    zstd.LoadOrFail(StorageConfigFetchYaml.Detach(), StorageConfigFetchYaml.size());
+                    MainConfigYaml = TString::Uninitialized(LoadSize(&zstd));
+                    zstd.LoadOrFail(MainConfigYaml.Detach(), MainConfigYaml.size());
+                    MainConfigFetchYaml = TString::Uninitialized(LoadSize(&zstd));
+                    zstd.LoadOrFail(MainConfigFetchYaml.Detach(), MainConfigFetchYaml.size());
 
                     // extract _current_ config version
-                    auto metadata = NYamlConfig::GetMainMetadata(StorageConfigYaml);
+                    auto metadata = NYamlConfig::GetMainMetadata(MainConfigYaml);
                     Y_DEBUG_ABORT_UNLESS(metadata.Version.has_value());
-                    StorageConfigYamlVersion = metadata.Version.value_or(0);
+                    MainConfigYamlVersion = metadata.Version.value_or(0);
 
                     // and _fetched_ config hash
-                    StorageConfigFetchYamlHash = NYaml::GetConfigHash(StorageConfigFetchYaml);
+                    MainConfigFetchYamlHash = NYaml::GetConfigHash(MainConfigFetchYaml);
                 } catch (const std::exception& ex) {
                     Y_ABORT("ConfigComposite format incorrect: %s", ex.what());
+                }
+            }
+
+            // now extract the additional storage section
+            StorageConfigYaml.reset();
+            if (config.HasCompressedStorageYaml()) {
+                try {
+                    TStringInput ss(config.GetCompressedStorageYaml());
+                    TZstdDecompress zstd(&ss);
+                    StorageConfigYaml.emplace(zstd.ReadAll());
+                } catch (const std::exception& ex) {
+                    Y_ABORT("CompressedStorageYaml format incorrect: %s", ex.what());
                 }
             }
 

--- a/ydb/core/blobstorage/nodewarden/distconf.h
+++ b/ydb/core/blobstorage/nodewarden/distconf.h
@@ -178,10 +178,11 @@ namespace NKikimr::NStorage {
 
         // currently active storage config
         std::optional<NKikimrBlobStorage::TStorageConfig> StorageConfig;
-        TString StorageConfigYaml; // the part we have to push (unless this is storage-only) to console
-        TString StorageConfigFetchYaml; // the part we would get is we fetch from console
-        ui64 StorageConfigFetchYamlHash = 0;
-        std::optional<ui32> StorageConfigYamlVersion;
+        TString MainConfigYaml; // the part we have to push (unless this is storage-only) to console
+        std::optional<ui64> MainConfigYamlVersion;
+        TString MainConfigFetchYaml; // the part we would get is we fetch from console
+        ui64 MainConfigFetchYamlHash = 0;
+        std::optional<TString> StorageConfigYaml; // set if dedicated storage yaml is enabled; otherwise nullopt
 
         // base config from config file
         NKikimrBlobStorage::TStorageConfig BaseConfig;

--- a/ydb/core/blobstorage/nodewarden/distconf_console.cpp
+++ b/ydb/core/blobstorage/nodewarden/distconf_console.cpp
@@ -39,19 +39,19 @@ namespace NKikimr::NStorage {
             return; // no config yet
         }
 
-        Y_ABORT_UNLESS(StorageConfigYamlVersion);
+        Y_ABORT_UNLESS(MainConfigYamlVersion);
 
         STLOG(PRI_DEBUG, BS_NODE, NWDC67, "SendConfigProposeRequest: sending propose request to the Console",
-            (StorageConfigFetchYamlHash, StorageConfigFetchYamlHash),
-            (StorageConfigYamlVersion, StorageConfigYamlVersion),
+            (MainConfigFetchYamlHash, MainConfigFetchYamlHash),
+            (MainConfigYamlVersion, MainConfigYamlVersion),
             (ProposedConfigHashVersion, ProposedConfigHashVersion),
             (ProposeRequestCookie, ProposeRequestCookie + 1));
 
         Y_DEBUG_ABORT_UNLESS(!ProposedConfigHashVersion || ProposedConfigHashVersion == std::make_tuple(
-            StorageConfigFetchYamlHash, *StorageConfigYamlVersion));
-        ProposedConfigHashVersion.emplace(StorageConfigFetchYamlHash, *StorageConfigYamlVersion);
+            MainConfigFetchYamlHash, *MainConfigYamlVersion));
+        ProposedConfigHashVersion.emplace(MainConfigFetchYamlHash, *MainConfigYamlVersion);
         NTabletPipe::SendData(SelfId(), ConsolePipeId, new TEvBlobStorage::TEvControllerProposeConfigRequest(
-            StorageConfigFetchYamlHash, *StorageConfigYamlVersion), ++ProposeRequestCookie);
+            MainConfigFetchYamlHash, *MainConfigYamlVersion), ++ProposeRequestCookie);
         ProposeRequestInFlight = true;
     }
 
@@ -92,18 +92,18 @@ namespace NKikimr::NStorage {
 
             case NKikimrBlobStorage::TEvControllerProposeConfigResponse::CommitIsNeeded: {
                 if (!StorageConfig || !StorageConfig->HasConfigComposite() || ProposedConfigHashVersion !=
-                        std::make_tuple(StorageConfigFetchYamlHash, *StorageConfigYamlVersion)) {
+                        std::make_tuple(MainConfigFetchYamlHash, *MainConfigYamlVersion)) {
                     const char *err = "proposed config, but something has gone awfully wrong";
                     STLOG(PRI_CRIT, BS_NODE, NWDC69, err, (StorageConfig, StorageConfig),
                         (ProposedConfigHashVersion, ProposedConfigHashVersion),
-                        (StorageConfigFetchYamlHash, StorageConfigFetchYamlHash),
-                        (StorageConfigYamlVersion, StorageConfigYamlVersion));
+                        (MainConfigFetchYamlHash, MainConfigFetchYamlHash),
+                        (MainConfigYamlVersion, MainConfigYamlVersion));
                     Y_DEBUG_ABORT("%s", err);
                     return;
                 }
 
                 NTabletPipe::SendData(SelfId(), ConsolePipeId, new TEvBlobStorage::TEvControllerConsoleCommitRequest(
-                    StorageConfigYaml), ++CommitRequestCookie);
+                    MainConfigYaml), ++CommitRequestCookie);
                 break;
             }
 

--- a/ydb/core/grpc_services/rpc_bsconfig.cpp
+++ b/ydb/core/grpc_services/rpc_bsconfig.cpp
@@ -95,7 +95,17 @@ public:
 
     void FillDistconfQuery(NStorage::TEvNodeConfigInvokeOnRoot& ev) {
         auto *cmd = ev.Record.MutableReplaceStorageConfig();
-        cmd->SetYAML(GetProtoRequest()->yaml_config());
+        auto *request = GetProtoRequest();
+        if (request->has_yaml_config()) {
+            cmd->SetYAML(request->yaml_config());
+        }
+        if (request->has_storage_yaml_config()) {
+            cmd->SetStorageYAML(request->storage_yaml_config());
+        }
+        if (request->has_switch_dedicated_storage_section()) {
+            cmd->SetSwitchDedicatedStorageSection(request->switch_dedicated_storage_section());
+        }
+        cmd->SetDedicatedStorageSectionConfigMode(request->dedicated_config_mode());
     }
 
     void FillDistconfResult(NKikimrBlobStorage::TEvNodeConfigInvokeOnRootResult& /*record*/,

--- a/ydb/core/protos/blobstorage_distributed_config.proto
+++ b/ydb/core/protos/blobstorage_distributed_config.proto
@@ -31,6 +31,8 @@ message TStorageConfig { // contents of storage metadata
     optional bytes ConfigComposite = 12; // compressed stored storage config YAML (if stored)
     NKikimrConfig.TSelfManagementConfig SelfManagementConfig = 13;
     TStorageConfig PrevConfig = 100; // previous version of StorageConfig (if any)
+    optional bytes CompressedStorageYaml = 14; // compressed storage YAML config (if dual-config is enabled)
+    optional uint64 ExpectedStorageYamlVersion = 15;
 }
 
 message TPDiskMetadataRecord {
@@ -194,7 +196,10 @@ message TEvNodeConfigInvokeOnRoot {
     }
 
     message TReplaceStorageConfig {
-        string YAML = 1;
+        optional string YAML = 1;
+        optional string StorageYAML = 3;
+        optional bool SwitchDedicatedStorageSection = 4;
+        bool DedicatedStorageSectionConfigMode = 5;
         bool SkipConsoleValidation = 2;
     }
 


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

Support dual-config mode in distconf

### Changelog category <!-- remove all except one -->

* Not for changelog (changelog entry is not required)

### Description for reviewers <!-- (optional) description for those who read this PR -->

Dual-config now can be enabled/disabled through distconf.
