### PR TITLE
filter out expired rows on scan

### DIFF
--- a/ydb/core/formats/arrow/accessor/abstract/accessor.h
+++ b/ydb/core/formats/arrow/accessor/abstract/accessor.h
@@ -2,6 +2,7 @@
 
 #include <ydb/library/accessor/accessor.h>
 #include <ydb/library/accessor/validator.h>
+#include <ydb/library/formats/arrow/arrow_helpers.h>
 #include <ydb/library/formats/arrow/splitter/similar_packer.h>
 
 #include <contrib/libs/apache/arrow/cpp/src/arrow/array/array_base.h>
@@ -364,6 +365,7 @@ public:
         void AppendPositionTo(arrow::ArrayBuilder& builder, const ui64 position, ui64* recordSize) const;
         std::shared_ptr<arrow::Array> CopyRecord(const ui64 recordIndex) const;
         TString DebugString(const ui32 position) const;
+        ui64 UpperBoundPosition(const std::shared_ptr<arrow::Scalar>& scalar) const;
     };
 
     std::shared_ptr<arrow::Scalar> GetScalar(const ui32 index) const {

--- a/ydb/core/tx/columnshard/counters/portion_index.cpp
+++ b/ydb/core/tx/columnshard/counters/portion_index.cpp
@@ -25,7 +25,7 @@ void TPortionIndexStats::RemovePortion(const NOlap::TPortionInfo& portion) {
 
     {
         auto findClass = TotalStats.find(portionClass);
-        AFL_VERIFY(!findClass.IsEnd())("path_id", portion.GetPathId());
+        AFL_VERIFY(findClass != TotalStats.end())("path_id", portion.GetPathId());
         findClass->second.RemovePortion(portion);
         if (findClass->second.IsEmpty()) {
             TotalStats.erase(findClass);
@@ -34,9 +34,9 @@ void TPortionIndexStats::RemovePortion(const NOlap::TPortionInfo& portion) {
 
     {
         auto findPathId = StatsByPathId.find(portion.GetPathId());
-        AFL_VERIFY(!findPathId.IsEnd())("path_id", portion.GetPathId());
+        AFL_VERIFY(findPathId != StatsByPathId.end())("path_id", portion.GetPathId());
         auto findClass = findPathId->second.find(portionClass);
-        AFL_VERIFY(!findClass.IsEnd())("path_id", portion.GetPathId());
+        AFL_VERIFY(findClass != findPathId->second.end())("path_id", portion.GetPathId());
         findClass->second.RemovePortion(portion);
         if (findClass->second.IsEmpty()) {
             findPathId->second.erase(findClass);

--- a/ydb/core/tx/columnshard/engines/reader/abstract/constructor.cpp
+++ b/ydb/core/tx/columnshard/engines/reader/abstract/constructor.cpp
@@ -2,6 +2,7 @@
 
 #include <ydb/core/protos/kqp.pb.h>
 #include <ydb/core/tx/columnshard/engines/reader/sys_view/abstract/policy.h>
+#include <ydb/core/tx/columnshard/tables_manager.h>
 #include <ydb/core/tx/program/program.h>
 
 namespace NKikimr::NOlap::NReader {

--- a/ydb/core/tx/columnshard/engines/reader/abstract/constructor.h
+++ b/ydb/core/tx/columnshard/engines/reader/abstract/constructor.h
@@ -8,6 +8,10 @@
 #include <ydb/core/tx/columnshard/engines/scheme/versions/versioned_index.h>
 #include <ydb/core/tx/program/program.h>
 
+namespace NKikimr::NColumnShard {
+class TTablesManager;
+}
+
 namespace NKikimr::NOlap::NReader {
 
 class TScannerConstructorContext {

--- a/ydb/core/tx/columnshard/engines/reader/abstract/read_metadata.h
+++ b/ydb/core/tx/columnshard/engines/reader/abstract/read_metadata.h
@@ -38,12 +38,25 @@ public:
         DESC /* "descending" */,
     };
 
+    class TTtlBound {
+    private:
+        YDB_READONLY_DEF(ui32, ColumnId);
+        YDB_READONLY_DEF(std::shared_ptr<arrow::Scalar>, LargestExpiredScalar);
+
+    public:
+        TTtlBound(const ui32 columnId, const std::shared_ptr<arrow::Scalar>& bound)
+            : ColumnId(columnId)
+            , LargestExpiredScalar(bound) {
+        }
+    };
+
 private:
     YDB_ACCESSOR_DEF(TString, ScanIdentifier);
     std::optional<ui64> FilteredCountLimit;
     std::optional<ui64> RequestedLimit;
     const ESorting Sorting = ESorting::ASC;   // Sorting inside returned batches
     std::shared_ptr<TPKRangesFilter> PKRangesFilter;
+    YDB_READONLY_DEF(std::optional<TTtlBound>, TtlBound);
     TProgramContainer Program;
     std::shared_ptr<TVersionedIndex> IndexVersionsPointer;
     TSnapshot RequestSnapshot;
@@ -168,14 +181,15 @@ public:
     }
 
     TReadMetadataBase(const std::shared_ptr<TVersionedIndex> index, const ESorting sorting, const TProgramContainer& ssaProgram,
-        const std::shared_ptr<ISnapshotSchema>& schema, const TSnapshot& requestSnapshot, const std::shared_ptr<IScanCursor>& scanCursor)
+        const std::shared_ptr<ISnapshotSchema>& schema, const TSnapshot& requestSnapshot, const std::shared_ptr<IScanCursor>& scanCursor,
+        const std::optional<TTtlBound>& ttlBound)
         : Sorting(sorting)
+        , TtlBound(ttlBound)
         , Program(ssaProgram)
         , IndexVersionsPointer(index)
         , RequestSnapshot(requestSnapshot)
         , ScanCursor(scanCursor)
-        , ResultIndexSchema(schema)
-    {
+        , ResultIndexSchema(schema) {
     }
     virtual ~TReadMetadataBase() = default;
 

--- a/ydb/core/tx/columnshard/engines/reader/common/description.h
+++ b/ydb/core/tx/columnshard/engines/reader/common/description.h
@@ -31,7 +31,6 @@ public:
     std::vector<ui32> ColumnIds;
 
     const std::shared_ptr<IScanCursor>& GetScanCursor() const {
-        AFL_VERIFY(ScanCursor);
         return ScanCursor;
     }
 

--- a/ydb/core/tx/columnshard/engines/reader/common/description.h
+++ b/ydb/core/tx/columnshard/engines/reader/common/description.h
@@ -26,6 +26,7 @@ public:
     // operations with potentially different columns. We have to remove columns to support -Inf (Null) and +Inf.
     std::shared_ptr<NOlap::TPKRangesFilter> PKRangesFilter;
     NYql::NDqProto::EDqStatsMode StatsMode = NYql::NDqProto::EDqStatsMode::DQ_STATS_MODE_NONE;
+    bool ReadExpiredRows = false;
 
     // List of columns
     std::vector<ui32> ColumnIds;

--- a/ydb/core/tx/columnshard/engines/reader/common_reader/constructor/read_metadata.cpp
+++ b/ydb/core/tx/columnshard/engines/reader/common_reader/constructor/read_metadata.cpp
@@ -42,6 +42,13 @@ TConclusionStatus TReadMetadata::Init(
     return TConclusionStatus::Success();
 }
 
+TReadMetadata::TReadMetadata(const std::shared_ptr<TVersionedIndex>& schemaIndex, const TReadDescription& read)
+    : TBase(schemaIndex, read.PKRangesFilter->IsReverse() ? TReadMetadataBase::ESorting::DESC : TReadMetadataBase::ESorting::ASC,
+          read.GetProgram(), schemaIndex->GetSchemaVerified(read.GetSnapshot()), read.GetSnapshot(), read.GetScanCursor())
+    , PathId(read.PathId)
+    , ReadStats(std::make_shared<TReadStats>()) {
+}
+
 std::set<ui32> TReadMetadata::GetEarlyFilterColumnIds() const {
     auto& indexInfo = ResultIndexSchema->GetIndexInfo();
     const auto& ids = GetProgram().GetEarlyFilterColumns();

--- a/ydb/core/tx/columnshard/engines/reader/common_reader/constructor/read_metadata.cpp
+++ b/ydb/core/tx/columnshard/engines/reader/common_reader/constructor/read_metadata.cpp
@@ -21,6 +21,15 @@ TConclusionStatus TReadMetadata::Init(
     SelectInfo = dataAccessor.Select(readDescription, !!LockId);
     if (LockId) {
         for (auto&& i : SelectInfo->Portions) {
+            if (!readDescription.ReadExpiredRows && GetTtlBound() &&
+                GetTtlBound()->GetColumnId() == ResultIndexSchema->GetIndexInfo().GetPKFirstColumnId()) {
+                const std::shared_ptr<arrow::Scalar> bound = GetTtlBound()->GetLargestExpiredScalar();
+                const std::shared_ptr<arrow::Scalar> maxValue =
+                    NArrow::TReplaceKey::ToScalar(i->GetMeta().GetFirstLastPK().GetFirst(ResultIndexSchema->GetIndexInfo().GetPrimaryKey()), 0);
+                if (!NArrow::ScalarLess(bound, maxValue)) {
+                    continue;
+                }
+            }
             if (i->HasInsertWriteId() && !i->HasCommitSnapshot()) {
                 if (owner->HasLongTxWrites(i->GetInsertWriteIdVerified())) {
                 } else {
@@ -42,9 +51,11 @@ TConclusionStatus TReadMetadata::Init(
     return TConclusionStatus::Success();
 }
 
-TReadMetadata::TReadMetadata(const std::shared_ptr<TVersionedIndex>& schemaIndex, const TReadDescription& read)
+TReadMetadata::TReadMetadata(
+    const std::shared_ptr<TVersionedIndex>& schemaIndex, const NColumnShard::TTtlVersions& ttlVersions, const TReadDescription& read)
     : TBase(schemaIndex, read.PKRangesFilter->IsReverse() ? TReadMetadataBase::ESorting::DESC : TReadMetadataBase::ESorting::ASC,
-          read.GetProgram(), schemaIndex->GetSchemaVerified(read.GetSnapshot()), read.GetSnapshot(), read.GetScanCursor())
+          read.GetProgram(), schemaIndex->GetSchemaVerified(read.GetSnapshot()), read.GetSnapshot(), read.GetScanCursor(),
+          MakeTtlBound(schemaIndex, ttlVersions, read))
     , PathId(read.PathId)
     , ReadStats(std::make_shared<TReadStats>()) {
 }
@@ -121,6 +132,23 @@ bool TReadMetadata::IsMyUncommitted(const TInsertWriteId writeId) const {
     auto it = ConflictedWriteIds.find(writeId);
     AFL_VERIFY(it != ConflictedWriteIds.end())("write_id", writeId)("write_ids_count", ConflictedWriteIds.size());
     return it->second.GetLockId() == LockSharingInfo->GetLockId();
+}
+
+std::optional<TReadMetadataBase::TTtlBound> TReadMetadata::MakeTtlBound(
+    const std::shared_ptr<TVersionedIndex> schemaIndex, const NColumnShard::TTtlVersions& ttlVersions, const TReadDescription& read) {
+    std::optional<TTiering> ttl = ttlVersions.GetTableTtl(read.PathId, read.GetSnapshot());
+    if (!ttl) {
+        return std::nullopt;
+    }
+    const auto& lastTier = std::prev(ttl->GetOrderedTiers().end())->Get();
+    if (lastTier.GetExternalStorageId()) {
+        return std::nullopt;
+    }
+    const auto& indexInfo = schemaIndex->GetSchemaVerified(read.GetSnapshot())->GetIndexInfo();
+    const ui64 columnId = indexInfo.GetColumnIdVerified(lastTier.GetEvictColumnName());
+    const auto scalar = TValidator::CheckNotNull(lastTier.GetLargestExpiredScalar(
+        read.GetSnapshot().GetPlanInstant(), indexInfo.GetColumnFeaturesVerified(columnId).GetArrowField()->type()->id()));
+    return TReadMetadataBase::TTtlBound(columnId, scalar);
 }
 
 }   // namespace NKikimr::NOlap::NReader::NCommon

--- a/ydb/core/tx/columnshard/engines/reader/common_reader/constructor/read_metadata.h
+++ b/ydb/core/tx/columnshard/engines/reader/common_reader/constructor/read_metadata.h
@@ -117,12 +117,7 @@ public:
     NYql::NDqProto::EDqStatsMode StatsMode = NYql::NDqProto::EDqStatsMode::DQ_STATS_MODE_NONE;
     std::shared_ptr<TReadStats> ReadStats;
 
-    TReadMetadata(const ui64 pathId, const std::shared_ptr<TVersionedIndex> info, const TSnapshot& snapshot, const ESorting sorting,
-        const TProgramContainer& ssaProgram, const std::shared_ptr<IScanCursor>& scanCursor)
-        : TBase(info, sorting, ssaProgram, info->GetSchemaVerified(snapshot), snapshot, scanCursor)
-        , PathId(pathId)
-        , ReadStats(std::make_shared<TReadStats>()) {
-    }
+    TReadMetadata(const std::shared_ptr<TVersionedIndex>& schemaIndex, const TReadDescription& read);
 
     virtual std::vector<TNameTypeInfo> GetKeyYqlSchema() const override {
         return GetResultSchema()->GetIndexInfo().GetPrimaryKeyColumns();

--- a/ydb/core/tx/columnshard/engines/reader/common_reader/constructor/read_metadata.h
+++ b/ydb/core/tx/columnshard/engines/reader/common_reader/constructor/read_metadata.h
@@ -8,6 +8,7 @@
 
 namespace NKikimr::NColumnShard {
 class TLockSharingInfo;
+class TTtlVersions;
 }
 
 namespace NKikimr::NOlap::NReader::NCommon {
@@ -53,6 +54,9 @@ private:
 
     virtual TConclusionStatus DoInitCustom(
         const NColumnShard::TColumnShard* owner, const TReadDescription& readDescription, const TDataStorageAccessor& dataAccessor) = 0;
+
+    static std::optional<TReadMetadataBase::TTtlBound> MakeTtlBound(
+        const std::shared_ptr<TVersionedIndex> schemaIndex, const NColumnShard::TTtlVersions& ttlVersions, const TReadDescription& read);
 
 public:
     using TConstPtr = std::shared_ptr<const TReadMetadata>;
@@ -117,7 +121,8 @@ public:
     NYql::NDqProto::EDqStatsMode StatsMode = NYql::NDqProto::EDqStatsMode::DQ_STATS_MODE_NONE;
     std::shared_ptr<TReadStats> ReadStats;
 
-    TReadMetadata(const std::shared_ptr<TVersionedIndex>& schemaIndex, const TReadDescription& read);
+    TReadMetadata(
+        const std::shared_ptr<TVersionedIndex>& schemaIndex, const NColumnShard::TTtlVersions& ttlVersions, const TReadDescription& read);
 
     virtual std::vector<TNameTypeInfo> GetKeyYqlSchema() const override {
         return GetResultSchema()->GetIndexInfo().GetPrimaryKeyColumns();

--- a/ydb/core/tx/columnshard/engines/reader/common_reader/iterator/columns_set.h
+++ b/ydb/core/tx/columnshard/engines/reader/common_reader/iterator/columns_set.h
@@ -85,6 +85,15 @@ public:
         }
         return result;
     }
+
+    TColumnsSetIds& operator+=(const TColumnsSetIds& external) {
+        return (*this = *this + external);
+    }
+
+    TColumnsSetIds& operator-=(const TColumnsSetIds& external) {
+        return (*this = *this - external);
+    }
+
     bool IsEmpty() const {
         return ColumnIds.empty();
     }

--- a/ydb/core/tx/columnshard/engines/reader/common_reader/iterator/columns_set.h
+++ b/ydb/core/tx/columnshard/engines/reader/common_reader/iterator/columns_set.h
@@ -97,6 +97,9 @@ public:
     bool IsEmpty() const {
         return ColumnIds.empty();
     }
+    bool Size() const {
+        return ColumnIds.size();
+    }
 
     bool operator!() const {
         return IsEmpty();

--- a/ydb/core/tx/columnshard/engines/reader/common_reader/iterator/fetch_steps.h
+++ b/ydb/core/tx/columnshard/engines/reader/common_reader/iterator/fetch_steps.h
@@ -1,6 +1,7 @@
 #pragma once
 #include "fetching.h"
 
+#include <ydb/core/tx/columnshard/engines/reader/abstract/read_metadata.h>
 #include <ydb/core/tx/limiter/grouped_memory/usage/abstract.h>
 
 namespace NKikimr::NOlap::NReader::NCommon {
@@ -20,7 +21,6 @@ private:
         }
     };
     std::vector<TColumnsPack> Packs;
-    THashMap<ui32, THashSet<EMemType>> Control;
     const EStageFeaturesIndexes StageIndex;
     const std::optional<ui64> PredefinedSize;
 
@@ -51,9 +51,7 @@ public:
         if (!ids.GetColumnsCount()) {
             return;
         }
-        for (auto&& i : ids.GetColumnIds()) {
-            AFL_VERIFY(Control[i].emplace(memType).second);
-        }
+        // TODO: valid?
         Packs.emplace_back(ids, memType);
     }
     EStageFeaturesIndexes GetStage() const {
@@ -134,12 +132,32 @@ protected:
         return TStringBuilder() << "columns=" << Columns.DebugString() << ";";
     }
 
+    virtual bool Merge(const std::shared_ptr<const IFetchingStep>& nextStep) override {
+        const auto step = std::dynamic_pointer_cast<const TColumnBlobsFetchingStep>(nextStep);
+        if (!step) {
+            return false;
+        }
+        Columns = Columns + step->Columns;
+        return true;
+    }
+
 public:
     virtual ui64 GetProcessingDataSize(const std::shared_ptr<IDataSource>& source) const override;
     TColumnBlobsFetchingStep(const TColumnsSetIds& columns)
         : TBase("FETCHING_COLUMNS")
         , Columns(columns) {
         AFL_VERIFY(Columns.GetColumnsCount());
+    }
+};
+
+class TTtlFilter: public IFetchingStep {
+private:
+    using TBase = IFetchingStep;
+
+public:
+    virtual TConclusion<bool> DoExecuteInplace(const std::shared_ptr<IDataSource>& source, const TFetchingScriptCursor& step) const override;
+    TTtlFilter()
+        : TBase("TTL") {
     }
 };
 

--- a/ydb/core/tx/columnshard/engines/reader/common_reader/iterator/fetch_steps.h
+++ b/ydb/core/tx/columnshard/engines/reader/common_reader/iterator/fetch_steps.h
@@ -126,7 +126,7 @@ public:
 class TColumnBlobsFetchingStep: public IFetchingStep {
 private:
     using TBase = IFetchingStep;
-    TColumnsSetIds Columns;
+    YDB_READONLY_DEF(TColumnsSetIds, Columns);
 
 protected:
     virtual TConclusion<bool> DoExecuteInplace(const std::shared_ptr<IDataSource>& source, const TFetchingScriptCursor& step) const override;

--- a/ydb/core/tx/columnshard/engines/reader/common_reader/iterator/fetching.cpp
+++ b/ydb/core/tx/columnshard/engines/reader/common_reader/iterator/fetching.cpp
@@ -87,12 +87,9 @@ TString TFetchingScript::DebugString() const {
     return sb;
 }
 
-TFetchingScript::TFetchingScript(const TSpecialReadContext& /*context*/) {
-}
-
-void TFetchingScript::Allocation(const std::set<ui32>& entityIds, const EStageFeaturesIndexes stage, const EMemType mType) {
+void TFetchingScriptBuilder::AddAllocation(const std::set<ui32>& entityIds, const EStageFeaturesIndexes stage, const EMemType mType) {
     if (Steps.size() == 0) {
-        AddStep<TAllocateMemoryStep>(entityIds, mType, stage);
+        AddStep(std::make_shared<TAllocateMemoryStep>(entityIds, mType, stage));
     } else {
         std::optional<ui32> addIndex;
         for (i32 i = Steps.size() - 1; i >= 0; --i) {
@@ -125,42 +122,52 @@ TString IFetchingStep::DebugString() const {
     return sb;
 }
 
-bool TColumnsAccumulator::AddFetchingStep(TFetchingScript& script, const TColumnsSetIds& columns, const EStageFeaturesIndexes stage) {
-    auto actualColumns = GetNotFetchedAlready(columns);
-    FetchingReadyColumns = FetchingReadyColumns + (TColumnsSetIds)columns;
-    if (!actualColumns.IsEmpty()) {
-        script.Allocation(columns.GetColumnIds(), stage, EMemType::Blob);
-        script.AddStep(std::make_shared<TColumnBlobsFetchingStep>(actualColumns));
-        return true;
-    }
-    return false;
+TFetchingScriptBuilder::TFetchingScriptBuilder(const TSpecialReadContext& context)
+    : GuaranteeNotOptional(context.GetMergeColumns())
+    , FullSchema(context.GetReadMetadata()->GetResultSchema()) {
 }
 
-bool TColumnsAccumulator::AddAssembleStep(
-    TFetchingScript& script, const TColumnsSetIds& columns, const TString& purposeId, const EStageFeaturesIndexes stage, const bool sequential) {
-    auto actualColumns = columns - AssemblerReadyColumns;
-    AssemblerReadyColumns = AssemblerReadyColumns + columns;
+void TFetchingScriptBuilder::AddFetchingStep(const TColumnsSetIds& columns, const EStageFeaturesIndexes stage) {
+    auto actualColumns = columns - AddedFetchingColumns;
+    AddedFetchingColumns += columns;
     if (actualColumns.IsEmpty()) {
-        return false;
+        return;
+    }
+    if (Steps.size() && std::dynamic_pointer_cast<TColumnBlobsFetchingStep>(Steps.back())) {
+        TColumnsSetIds fetchingColumns = actualColumns + std::dynamic_pointer_cast<TColumnBlobsFetchingStep>(Steps.back())->GetColumns();
+        Steps.pop_back();
+        AddAllocation(actualColumns.GetColumnIds(), stage, EMemType::Blob);
+        AddStep(std::make_shared<TColumnBlobsFetchingStep>(fetchingColumns));
+    } else {
+        AddAllocation(actualColumns.GetColumnIds(), stage, EMemType::Blob);
+        AddStep(std::make_shared<TColumnBlobsFetchingStep>(actualColumns));
+    }
+}
+
+void TFetchingScriptBuilder::AddAssembleStep(
+    const TColumnsSetIds& columns, const TString& purposeId, const EStageFeaturesIndexes stage, const bool sequential) {
+    auto actualColumns = columns - AddedAssembleColumns;
+    AddedAssembleColumns += columns;
+    if (actualColumns.IsEmpty()) {
+        return;
     }
     auto actualSet = std::make_shared<TColumnsSet>(actualColumns.GetColumnIds(), FullSchema);
     if (sequential) {
         const auto notSequentialColumnIds = GuaranteeNotOptional->Intersect(*actualSet);
         if (notSequentialColumnIds.size()) {
-            script.Allocation(notSequentialColumnIds, stage, EMemType::Raw);
+            AddAllocation(notSequentialColumnIds, stage, EMemType::Raw);
             std::shared_ptr<TColumnsSet> cross = actualSet->BuildSamePtr(notSequentialColumnIds);
-            script.AddStep<TAssemblerStep>(cross, purposeId);
+            AddStep(std::make_shared<TAssemblerStep>(cross, purposeId));
             *actualSet = *actualSet - *cross;
         }
         if (!actualSet->IsEmpty()) {
-            script.Allocation(notSequentialColumnIds, stage, EMemType::RawSequential);
-            script.AddStep<TOptionalAssemblerStep>(actualSet, purposeId);
+            AddAllocation(notSequentialColumnIds, stage, EMemType::RawSequential);
+            AddStep(std::make_shared<TOptionalAssemblerStep>(actualSet, purposeId));
         }
     } else {
-        script.Allocation(actualColumns.GetColumnIds(), stage, EMemType::Raw);
-        script.AddStep<TAssemblerStep>(actualSet, purposeId);
+        AddAllocation(actualColumns.GetColumnIds(), stage, EMemType::Raw);
+        AddStep(std::make_shared<TAssemblerStep>(actualSet, purposeId));
     }
-    return true;
 }
 
 TConclusion<bool> TProgramStep::DoExecuteInplace(const std::shared_ptr<IDataSource>& source, const TFetchingScriptCursor& /*step*/) const {

--- a/ydb/core/tx/columnshard/engines/reader/common_reader/iterator/source.h
+++ b/ydb/core/tx/columnshard/engines/reader/common_reader/iterator/source.h
@@ -203,6 +203,9 @@ public:
         AFL_VERIFY(!!StageResult);
         return *StageResult;
     }
+
+    virtual const NArrow::TReplaceKey& GetMinReplaceKey() const = 0;
+    virtual const NArrow::TReplaceKey& GetMaxReplaceKey() const = 0;
 };
 
 }   // namespace NKikimr::NOlap::NReader::NCommon

--- a/ydb/core/tx/columnshard/engines/reader/common_reader/iterator/ya.make
+++ b/ydb/core/tx/columnshard/engines/reader/common_reader/iterator/ya.make
@@ -13,6 +13,7 @@ SRCS(
 
 PEERDIR(
     ydb/core/tx/columnshard/engines/scheme
+    yql/essentials/minikql
 )
 
 GENERATE_ENUM_SERIALIZATION(columns_set.h)

--- a/ydb/core/tx/columnshard/engines/reader/plain_reader/constructor/constructor.cpp
+++ b/ydb/core/tx/columnshard/engines/reader/plain_reader/constructor/constructor.cpp
@@ -35,7 +35,7 @@ NKikimr::TConclusion<std::shared_ptr<TReadMetadataBase>> TIndexScannerConstructo
 
     TDataStorageAccessor dataAccessor(insertTable, index);
     AFL_VERIFY(read.PathId);
-    auto readMetadata = std::make_shared<TReadMetadata>(index->CopyVersionedIndexPtr(), read);
+    auto readMetadata = std::make_shared<TReadMetadata>(index->CopyVersionedIndexPtr(), self->GetTablesManager().GetTtlVersions(), read);
 
     auto initResult = readMetadata->Init(self, read, dataAccessor);
     if (!initResult) {

--- a/ydb/core/tx/columnshard/engines/reader/plain_reader/constructor/constructor.cpp
+++ b/ydb/core/tx/columnshard/engines/reader/plain_reader/constructor/constructor.cpp
@@ -35,8 +35,7 @@ NKikimr::TConclusion<std::shared_ptr<TReadMetadataBase>> TIndexScannerConstructo
 
     TDataStorageAccessor dataAccessor(insertTable, index);
     AFL_VERIFY(read.PathId);
-    auto readMetadata = std::make_shared<TReadMetadata>(read.PathId, index->CopyVersionedIndexPtr(), read.GetSnapshot(),
-        IsReverse ? TReadMetadataBase::ESorting::DESC : TReadMetadataBase::ESorting::ASC, read.GetProgram(), nullptr);
+    auto readMetadata = std::make_shared<TReadMetadata>(index->CopyVersionedIndexPtr(), read);
 
     auto initResult = readMetadata->Init(self, read, dataAccessor);
     if (!initResult) {

--- a/ydb/core/tx/columnshard/engines/reader/plain_reader/iterator/context.cpp
+++ b/ydb/core/tx/columnshard/engines/reader/plain_reader/iterator/context.cpp
@@ -28,12 +28,13 @@ std::shared_ptr<TFetchingScript> TSpecialReadContext::DoGetColumnsFetchingPlan(c
     auto source = std::static_pointer_cast<IDataSource>(sourceExt);
     if (source->NeedAccessorsFetching()) {
         if (!AskAccumulatorsScript) {
-            AskAccumulatorsScript = std::make_shared<TFetchingScript>(*this);
+            NCommon::TFetchingScriptBuilder acc(*this);
             if (ui64 size = source->PredictAccessorsMemory()) {
-                AskAccumulatorsScript->AddStep<NCommon::TAllocateMemoryStep>(size, EStageFeaturesIndexes::Accessors);
+                acc.AddStep(std::make_shared<NCommon::TAllocateMemoryStep>(size, EStageFeaturesIndexes::Accessors));
             }
-            AskAccumulatorsScript->AddStep<TPortionAccessorFetchingStep>();
-            AskAccumulatorsScript->AddStep<TDetectInMem>(*GetFFColumns());
+            acc.AddStep(std::make_shared<TPortionAccessorFetchingStep>());
+            acc.AddStep(std::make_shared<TDetectInMem>(*GetFFColumns()));
+            AskAccumulatorsScript = std::move(acc).Build();
         }
         return AskAccumulatorsScript;
     }
@@ -72,126 +73,123 @@ std::shared_ptr<TFetchingScript> TSpecialReadContext::DoGetColumnsFetchingPlan(c
         if (result.HasScript()) {
             return result.GetScriptVerified();
         } else {
-            std::shared_ptr<TFetchingScript> result = std::make_shared<TFetchingScript>(*this);
-            result->SetBranchName("FAKE");
-            result->AddStep<TBuildFakeSpec>();
-            return result;
+            NCommon::TFetchingScriptBuilder acc(*this);
+            acc.SetBranchName("FAKE");
+            acc.AddStep(std::make_shared<TBuildFakeSpec>());
+            return std::move(acc).Build();
         }
     }
 }
 
 std::shared_ptr<TFetchingScript> TSpecialReadContext::BuildColumnsFetchingPlan(const bool needSnapshots, const bool exclusiveSource,
     const bool partialUsageByPredicateExt, const bool useIndexes, const bool needFilterSharding, const bool needFilterDeletion) const {
-    std::shared_ptr<TFetchingScript> result = std::make_shared<TFetchingScript>(*this);
     const bool partialUsageByPredicate = partialUsageByPredicateExt && GetPredicateColumns()->GetColumnsCount();
 
-    NCommon::TColumnsAccumulator acc(GetMergeColumns(), GetReadMetadata()->GetResultSchema());
+    NCommon::TFetchingScriptBuilder acc(*this);
     if (!!IndexChecker && useIndexes && exclusiveSource) {
-        result->AddStep(std::make_shared<TIndexBlobsFetchingStep>(std::make_shared<TIndexesSet>(IndexChecker->GetIndexIds())));
-        result->AddStep(std::make_shared<TApplyIndexStep>(IndexChecker));
+        acc.AddStep(std::make_shared<TIndexBlobsFetchingStep>(std::make_shared<TIndexesSet>(IndexChecker->GetIndexIds())));
+        acc.AddStep(std::make_shared<TApplyIndexStep>(IndexChecker));
     }
     bool hasFilterSharding = false;
     if (needFilterSharding && !GetShardingColumns()->IsEmpty()) {
         hasFilterSharding = true;
-        TColumnsSetIds columnsFetch = *GetShardingColumns();
+        acc.AddFetchingStep(*GetShardingColumns(), EStageFeaturesIndexes::Filter);
         if (!exclusiveSource) {
-            columnsFetch = columnsFetch + *GetPKColumns() + *GetSpecColumns();
+            acc.AddFetchingStep(*GetPKColumns(), EStageFeaturesIndexes::Filter);
+            acc.AddFetchingStep(*GetSpecColumns(), EStageFeaturesIndexes::Filter);
         }
-        acc.AddFetchingStep(*result, columnsFetch, EStageFeaturesIndexes::Filter);
-        acc.AddAssembleStep(*result, columnsFetch, "SPEC_SHARDING", EStageFeaturesIndexes::Filter, false);
-        result->AddStep(std::make_shared<TShardingFilter>());
+        acc.AddAssembleStep(acc.GetAddedFetchingColumns(), "SPEC_SHARDING", EStageFeaturesIndexes::Filter, false);
+        acc.AddStep(std::make_shared<TShardingFilter>());
     }
     if (!GetEFColumns()->GetColumnsCount() && !partialUsageByPredicate) {
-        result->SetBranchName("simple");
-        TColumnsSetIds columnsFetch = *GetFFColumns();
+        acc.SetBranchName("simple");
+        acc.AddFetchingStep(*GetFFColumns(), EStageFeaturesIndexes::Fetching);
         if (needFilterDeletion) {
-            columnsFetch = columnsFetch + *GetDeletionColumns();
+            acc.AddFetchingStep(*GetDeletionColumns(), EStageFeaturesIndexes::Fetching);
         }
         if (needSnapshots) {
-            columnsFetch = columnsFetch + *GetSpecColumns();
+            acc.AddFetchingStep(*GetSpecColumns(), EStageFeaturesIndexes::Fetching);
         }
         if (!exclusiveSource) {
-            columnsFetch = columnsFetch + *GetMergeColumns();
+            acc.AddFetchingStep(*GetMergeColumns(), EStageFeaturesIndexes::Fetching);
         } else {
-            if (columnsFetch.GetColumnsCount() == 1 && GetSpecColumns()->Contains(columnsFetch) && !hasFilterSharding) {
+            if (acc.GetAddedFetchingColumns().GetColumnsCount() == 1 && GetSpecColumns()->Contains(acc.GetAddedFetchingColumns()) && !hasFilterSharding) {
                 return nullptr;
             }
         }
-        if (columnsFetch.GetColumnsCount() || hasFilterSharding || needFilterDeletion) {
-            acc.AddFetchingStep(*result, columnsFetch, EStageFeaturesIndexes::Fetching);
+        if (acc.GetAddedFetchingColumns().GetColumnsCount() || hasFilterSharding || needFilterDeletion) {
             if (needSnapshots) {
-                acc.AddAssembleStep(*result, *GetSpecColumns(), "SPEC", EStageFeaturesIndexes::Fetching, false);
+                acc.AddAssembleStep(*GetSpecColumns(), "SPEC", EStageFeaturesIndexes::Fetching, false);
             }
             if (!exclusiveSource) {
-                acc.AddAssembleStep(*result, *GetMergeColumns(), "LAST_PK", EStageFeaturesIndexes::Fetching, false);
+                acc.AddAssembleStep(*GetMergeColumns(), "LAST_PK", EStageFeaturesIndexes::Fetching, false);
             }
             if (needSnapshots) {
-                result->AddStep(std::make_shared<TSnapshotFilter>());
+                acc.AddStep(std::make_shared<TSnapshotFilter>());
             }
             if (needFilterDeletion) {
-                acc.AddAssembleStep(*result, *GetDeletionColumns(), "SPEC_DELETION", EStageFeaturesIndexes::Fetching, false);
-                result->AddStep(std::make_shared<TDeletionFilter>());
+                acc.AddAssembleStep(*GetDeletionColumns(), "SPEC_DELETION", EStageFeaturesIndexes::Fetching, false);
+                acc.AddStep(std::make_shared<TDeletionFilter>());
             }
-            acc.AddAssembleStep(*result, columnsFetch, "LAST", EStageFeaturesIndexes::Fetching, !exclusiveSource);
+            acc.AddAssembleStep(acc.GetAddedFetchingColumns().GetColumnIds(), "LAST", EStageFeaturesIndexes::Fetching, !exclusiveSource);
         } else {
             return nullptr;
         }
     } else if (exclusiveSource) {
-        result->SetBranchName("exclusive");
-        TColumnsSet columnsFetch = *GetEFColumns();
+        acc.SetBranchName("exclusive");
+        acc.AddFetchingStep(*GetEFColumns(), EStageFeaturesIndexes::Filter);
         if (needFilterDeletion) {
-            columnsFetch = columnsFetch + *GetDeletionColumns();
+            acc.AddFetchingStep(*GetDeletionColumns(), EStageFeaturesIndexes::Filter);
         }
         if (needSnapshots || GetFFColumns()->Cross(*GetSpecColumns())) {
-            columnsFetch = columnsFetch + *GetSpecColumns();
+            acc.AddFetchingStep(*GetSpecColumns(), EStageFeaturesIndexes::Filter);
         }
         if (partialUsageByPredicate) {
-            columnsFetch = columnsFetch + *GetPredicateColumns();
+            acc.AddFetchingStep(*GetPredicateColumns(), EStageFeaturesIndexes::Filter);
         }
 
-        AFL_VERIFY(columnsFetch.GetColumnsCount());
-        acc.AddFetchingStep(*result, columnsFetch, EStageFeaturesIndexes::Filter);
+        AFL_VERIFY(acc.GetAddedFetchingColumns().GetColumnsCount());
 
         if (needFilterDeletion) {
-            acc.AddAssembleStep(*result, *GetDeletionColumns(), "SPEC_DELETION", EStageFeaturesIndexes::Filter, false);
-            result->AddStep(std::make_shared<TDeletionFilter>());
+            acc.AddAssembleStep(*GetDeletionColumns(), "SPEC_DELETION", EStageFeaturesIndexes::Filter, false);
+            acc.AddStep(std::make_shared<TDeletionFilter>());
         }
         if (partialUsageByPredicate) {
-            acc.AddAssembleStep(*result, *GetPredicateColumns(), "PREDICATE", EStageFeaturesIndexes::Filter, false);
-            result->AddStep(std::make_shared<TPredicateFilter>());
+            acc.AddAssembleStep(*GetPredicateColumns(), "PREDICATE", EStageFeaturesIndexes::Filter, false);
+            acc.AddStep(std::make_shared<TPredicateFilter>());
         }
         if (needSnapshots || GetFFColumns()->Cross(*GetSpecColumns())) {
-            acc.AddAssembleStep(*result, *GetSpecColumns(), "SPEC", EStageFeaturesIndexes::Filter, false);
-            result->AddStep(std::make_shared<TSnapshotFilter>());
+            acc.AddAssembleStep(*GetSpecColumns(), "SPEC", EStageFeaturesIndexes::Filter, false);
+            acc.AddStep(std::make_shared<TSnapshotFilter>());
         }
-        acc.AddFetchingStep(*result, *GetFFColumns(), EStageFeaturesIndexes::Fetching);
-        acc.AddAssembleStep(*result, *GetFFColumns(), "LAST", EStageFeaturesIndexes::Fetching, !exclusiveSource);
+        acc.AddFetchingStep(*GetFFColumns(), EStageFeaturesIndexes::Fetching);
+        acc.AddAssembleStep(*GetFFColumns(), "LAST", EStageFeaturesIndexes::Fetching, !exclusiveSource);
     } else {
-        result->SetBranchName("merge");
-        TColumnsSet columnsFetch = *GetMergeColumns() + *GetEFColumns();
+        acc.SetBranchName("merge");
+        acc.AddFetchingStep(*GetMergeColumns(), EStageFeaturesIndexes::Filter);
+        acc.AddFetchingStep(*GetEFColumns(), EStageFeaturesIndexes::Filter);
         if (needFilterDeletion) {
-            columnsFetch = columnsFetch + *GetDeletionColumns();
+            acc.AddFetchingStep(*GetDeletionColumns(), EStageFeaturesIndexes::Filter);
         }
-        AFL_VERIFY(columnsFetch.GetColumnsCount());
-        acc.AddFetchingStep(*result, columnsFetch, EStageFeaturesIndexes::Filter);
+        AFL_VERIFY(acc.GetAddedFetchingColumns().GetColumnsCount());
 
-        acc.AddAssembleStep(*result, *GetSpecColumns(), "SPEC", EStageFeaturesIndexes::Filter, false);
-        acc.AddAssembleStep(*result, *GetPKColumns(), "PK", EStageFeaturesIndexes::Filter, false);
+        acc.AddAssembleStep(*GetSpecColumns(), "SPEC", EStageFeaturesIndexes::Filter, false);
+        acc.AddAssembleStep(*GetPKColumns(), "PK", EStageFeaturesIndexes::Filter, false);
         if (needSnapshots) {
-            result->AddStep(std::make_shared<TSnapshotFilter>());
+            acc.AddStep(std::make_shared<TSnapshotFilter>());
         }
         if (needFilterDeletion) {
-            acc.AddAssembleStep(*result, *GetDeletionColumns(), "SPEC_DELETION", EStageFeaturesIndexes::Filter, false);
-            result->AddStep(std::make_shared<TDeletionFilter>());
+            acc.AddAssembleStep(*GetDeletionColumns(), "SPEC_DELETION", EStageFeaturesIndexes::Filter, false);
+            acc.AddStep(std::make_shared<TDeletionFilter>());
         }
         if (partialUsageByPredicate) {
-            result->AddStep(std::make_shared<TPredicateFilter>());
+            acc.AddStep(std::make_shared<TPredicateFilter>());
         }
-        acc.AddFetchingStep(*result, *GetFFColumns(), EStageFeaturesIndexes::Fetching);
-        acc.AddAssembleStep(*result, *GetFFColumns(), "LAST", EStageFeaturesIndexes::Fetching, !exclusiveSource);
+        acc.AddFetchingStep(*GetFFColumns(), EStageFeaturesIndexes::Fetching);
+        acc.AddAssembleStep(*GetFFColumns(), "LAST", EStageFeaturesIndexes::Fetching, !exclusiveSource);
     }
-    result->AddStep<NCommon::TBuildStageResultStep>();
-    return result;
+    acc.AddStep(std::make_shared<NCommon::TBuildStageResultStep>());
+    return std::move(acc).Build();
 }
 
 TSpecialReadContext::TSpecialReadContext(const std::shared_ptr<TReadContext>& commonContext)

--- a/ydb/core/tx/columnshard/engines/reader/plain_reader/iterator/context.h
+++ b/ydb/core/tx/columnshard/engines/reader/plain_reader/iterator/context.h
@@ -26,9 +26,10 @@ private:
     YDB_READONLY_DEF(std::shared_ptr<NGroupedMemoryManager::TStageFeatures>, FetchingStageMemory);
 
     std::shared_ptr<TFetchingScript> BuildColumnsFetchingPlan(const bool needSnapshotsFilter, const bool exclusiveSource,
-        const bool partialUsageByPredicate, const bool useIndexes, const bool needFilterSharding, const bool needFilterDeletion) const;
+        const bool partialUsageByPredicate, const bool useIndexes, const bool needFilterSharding, const bool needFilterDeletion,
+        const bool needFilterTtl) const;
     TMutex Mutex;
-    std::array<std::array<std::array<std::array<std::array<std::array<NCommon::TFetchingScriptOwner, 2>, 2>, 2>, 2>, 2>, 2>
+    std::array<std::array<std::array<std::array<std::array<std::array<std::array<NCommon::TFetchingScriptOwner, 2>, 2>, 2>, 2>, 2>, 2>, 2>
         CacheFetchingScripts;
     std::shared_ptr<TFetchingScript> AskAccumulatorsScript;
 

--- a/ydb/core/tx/columnshard/engines/reader/plain_reader/iterator/fetching.h
+++ b/ydb/core/tx/columnshard/engines/reader/plain_reader/iterator/fetching.h
@@ -44,16 +44,18 @@ public:
     using TBase::TBase;
 };
 
-class TBuildFakeSpec: public IFetchingStep {
+class TBuildFakeColumns: public IFetchingStep {
 private:
     using TBase = IFetchingStep;
+    arrow::FieldVector Fields;
 
 protected:
     virtual TConclusion<bool> DoExecuteInplace(const std::shared_ptr<IDataSource>& source, const TFetchingScriptCursor& step) const override;
 
 public:
-    TBuildFakeSpec()
-        : TBase("FAKE_SPEC") {
+    TBuildFakeColumns(const arrow::FieldVector& fields)
+        : TBase("FAKE_COLUMNS")
+        , Fields(fields) {
     }
 };
 

--- a/ydb/core/tx/columnshard/engines/reader/plain_reader/iterator/source.h
+++ b/ydb/core/tx/columnshard/engines/reader/plain_reader/iterator/source.h
@@ -81,6 +81,13 @@ public:
         return FinishReplaceKey;
     }
 
+    virtual const NArrow::TReplaceKey& GetMinReplaceKey() const override {
+        return StartReplaceKey;
+    }
+    virtual const NArrow::TReplaceKey& GetMaxReplaceKey() const override {
+        return FinishReplaceKey;
+    }
+
     void ApplyIndex(const NIndexes::TIndexCheckerContainer& indexMeta) {
         return DoApplyIndex(indexMeta);
     }

--- a/ydb/core/tx/columnshard/engines/reader/simple_reader/constructor/constructor.cpp
+++ b/ydb/core/tx/columnshard/engines/reader/simple_reader/constructor/constructor.cpp
@@ -34,8 +34,7 @@ NKikimr::TConclusion<std::shared_ptr<TReadMetadataBase>> TIndexScannerConstructo
 
     TDataStorageAccessor dataAccessor(insertTable, index);
     AFL_VERIFY(read.PathId);
-    auto readMetadata = std::make_shared<TReadMetadata>(read.PathId, index->CopyVersionedIndexPtr(), read.GetSnapshot(),
-        IsReverse ? TReadMetadataBase::ESorting::DESC : TReadMetadataBase::ESorting::ASC, read.GetProgram(), read.GetScanCursor());
+    auto readMetadata = std::make_shared<TReadMetadata>(index->CopyVersionedIndexPtr(), read);
 
     auto initResult = readMetadata->Init(self, read, dataAccessor);
     if (!initResult) {

--- a/ydb/core/tx/columnshard/engines/reader/simple_reader/constructor/constructor.cpp
+++ b/ydb/core/tx/columnshard/engines/reader/simple_reader/constructor/constructor.cpp
@@ -34,7 +34,7 @@ NKikimr::TConclusion<std::shared_ptr<TReadMetadataBase>> TIndexScannerConstructo
 
     TDataStorageAccessor dataAccessor(insertTable, index);
     AFL_VERIFY(read.PathId);
-    auto readMetadata = std::make_shared<TReadMetadata>(index->CopyVersionedIndexPtr(), read);
+    auto readMetadata = std::make_shared<TReadMetadata>(index->CopyVersionedIndexPtr(), self->GetTablesManager().GetTtlVersions(), read);
 
     auto initResult = readMetadata->Init(self, read, dataAccessor);
     if (!initResult) {

--- a/ydb/core/tx/columnshard/engines/reader/simple_reader/iterator/context.h
+++ b/ydb/core/tx/columnshard/engines/reader/simple_reader/iterator/context.h
@@ -21,9 +21,9 @@ class TSpecialReadContext: public NCommon::TSpecialReadContext {
 private:
     using TBase = NCommon::TSpecialReadContext;
     std::shared_ptr<TFetchingScript> BuildColumnsFetchingPlan(const bool needSnapshots, const bool partialUsageByPredicateExt,
-        const bool useIndexes, const bool needFilterSharding, const bool needFilterDeletion) const;
+        const bool useIndexes, const bool needFilterSharding, const bool needFilterDeletion, const bool needFilterTtl) const;
     TMutex Mutex;
-    std::array<std::array<std::array<std::array<std::array<NCommon::TFetchingScriptOwner, 2>, 2>, 2>, 2>, 2> CacheFetchingScripts;
+    std::array<std::array<std::array<std::array<std::array<std::array<NCommon::TFetchingScriptOwner, 2>, 2>, 2>, 2>, 2>, 2> CacheFetchingScripts;
     std::shared_ptr<TFetchingScript> AskAccumulatorsScript;
 
     virtual std::shared_ptr<TFetchingScript> DoGetColumnsFetchingPlan(const std::shared_ptr<NCommon::IDataSource>& source) override;

--- a/ydb/core/tx/columnshard/engines/reader/simple_reader/iterator/source.h
+++ b/ydb/core/tx/columnshard/engines/reader/simple_reader/iterator/source.h
@@ -85,6 +85,14 @@ public:
         }
     }
 
+    const NArrow::TReplaceKey& GetReplaceKey() const {
+        return Value;
+    }
+
+    bool IsReversed() const {
+        return Reverse;
+    }
+
     TString DebugString() const {
         return TStringBuilder() << "point:{" << Value.DebugString() << "};reverse:" << Reverse << ";";
     }
@@ -140,8 +148,16 @@ public:
     const TReplaceKeyAdapter& GetStart() const {
         return Start;
     }
-    const TReplaceKeyAdapter GetFinish() const {
+    const TReplaceKeyAdapter& GetFinish() const {
         return Finish;
+    }
+    virtual const NArrow::TReplaceKey& GetMinReplaceKey() const override {
+        AFL_VERIFY(Start.IsReversed() == Finish.IsReversed())("start", Start.IsReversed())("finish", Finish.IsReversed());
+        return Start.IsReversed() ? Finish.GetReplaceKey() : Start.GetReplaceKey();
+    }
+    virtual const NArrow::TReplaceKey& GetMaxReplaceKey() const override {
+        AFL_VERIFY(Start.IsReversed() == Finish.IsReversed())("start", Start.IsReversed())("finish", Finish.IsReversed());
+        return Start.IsReversed() ? Start.GetReplaceKey() : Finish.GetReplaceKey();
     }
 
     bool GetIsStartedByCursor() const {

--- a/ydb/core/tx/columnshard/engines/reader/simple_reader/iterator/ya.make
+++ b/ydb/core/tx/columnshard/engines/reader/simple_reader/iterator/ya.make
@@ -16,6 +16,7 @@ PEERDIR(
     ydb/core/tx/columnshard/engines/reader/common_reader/iterator
     ydb/core/tx/conveyor/usage
     ydb/core/tx/limiter/grouped_memory/usage
+    yql/essentials/minikql
 )
 
 END()

--- a/ydb/core/tx/columnshard/engines/reader/sys_view/abstract/metadata.h
+++ b/ydb/core/tx/columnshard/engines/reader/sys_view/abstract/metadata.h
@@ -18,7 +18,7 @@ public:
 
     explicit TReadStatsMetadata(const std::shared_ptr<TVersionedIndex>& info, ui64 tabletId, const ESorting sorting,
         const TProgramContainer& ssaProgram, const std::shared_ptr<ISnapshotSchema>& schema, const TSnapshot& requestSnapshot)
-        : TBase(info, sorting, ssaProgram, schema, requestSnapshot, nullptr)
+        : TBase(info, sorting, ssaProgram, schema, requestSnapshot, nullptr, std::nullopt)
         , TabletId(tabletId) {
     }
 };

--- a/ydb/core/tx/columnshard/engines/reader/transaction/tx_internal_scan.cpp
+++ b/ydb/core/tx/columnshard/engines/reader/transaction/tx_internal_scan.cpp
@@ -45,6 +45,7 @@ void TTxInternalScan::Complete(const TActorContext& ctx) {
         read.PathId = request.GetPathId();
         read.LockId = LockId;
         read.ReadNothing = !Self->TablesManager.HasTable(read.PathId);
+        read.ReadExpiredRows = true;
         std::unique_ptr<IScannerConstructor> scannerConstructor(new NPlain::TIndexScannerConstructor(context));
         read.ColumnIds = request.GetColumnIds();
         if (request.RangesFilter) {

--- a/ydb/core/tx/columnshard/engines/reader/transaction/tx_scan.cpp
+++ b/ydb/core/tx/columnshard/engines/reader/transaction/tx_scan.cpp
@@ -62,6 +62,7 @@ void TTxScan::Complete(const TActorContext& ctx) {
         }
         read.PathId = request.GetLocalPathId();
         read.ReadNothing = !Self->TablesManager.HasTable(read.PathId);
+        read.ReadExpiredRows = true;
         read.TableName = table;
 
         const TString defaultReader =

--- a/ydb/core/tx/columnshard/engines/scheme/tiering/tier_info.h
+++ b/ydb/core/tx/columnshard/engines/scheme/tiering/tier_info.h
@@ -51,6 +51,7 @@ public:
     }
 
     std::optional<TInstant> ScalarToInstant(const std::shared_ptr<arrow::Scalar>& scalar) const;
+    std::shared_ptr<arrow::Scalar> GetLargestExpiredScalar(const TInstant now, const arrow::Type::type resultType) const;
 
     static std::shared_ptr<TTierInfo> MakeTtl(const TDuration evictDuration, const TString& ttlColumn, ui32 unitsInSecond = 0) {
         return std::make_shared<TTierInfo>(std::nullopt, evictDuration, ttlColumn, unitsInSecond);

--- a/ydb/core/tx/columnshard/tables_manager.h
+++ b/ydb/core/tx/columnshard/tables_manager.h
@@ -234,6 +234,10 @@ public:
         return Ttl.GetTableTtl(pathId, snapshot);
     }
 
+    const TTtlVersions& GetTtlVersions() const {
+        return Ttl;
+    }
+
     const std::map<NOlap::TSnapshot, THashSet<ui64>>& GetPathsToDrop() const {
         return PathsToDrop;
     }

--- a/ydb/library/formats/arrow/replace_key.h
+++ b/ydb/library/formats/arrow/replace_key.h
@@ -217,7 +217,7 @@ public:
         return TReplaceKeyTemplate<TArrayVecPtr>(std::make_shared<TArrayVec>(1, *res), 0);
     }
 
-    static std::shared_ptr<arrow::Scalar> ToScalar(const TReplaceKeyTemplate<TArrayVecPtr>& key, int colNumber = 0) {
+    static std::shared_ptr<arrow::Scalar> ToScalar(const TReplaceKeyTemplate<TArrayVecPtr>& key, ui64 colNumber = 0) {
         Y_DEBUG_ABORT_UNLESS(colNumber < key.Size());
         auto& column = key.Column(colNumber);
         auto res = column.GetScalar(key.GetPosition());


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

Rows expired on TTL are hidden in CS scan

### Changelog category <!-- remove all except one -->

* New feature

### Description for reviewers <!-- (optional) description for those who read this PR -->

...
