### PR TITLE
Avoid persistent and in-memory tx status getting out-of-sync

### DIFF
--- a/ydb/core/tablet_flat/flat_boot_stages.h
+++ b/ydb/core/tablet_flat/flat_boot_stages.h
@@ -194,6 +194,9 @@ namespace NBoot {
 
             const auto was = Back->DatabaseImpl->Rewind(Back->Serial);
 
+            // Notify database that all merges have completed
+            Back->DatabaseImpl->MergeDone();
+
             result.Database = new NTable::TDatabase(Back->DatabaseImpl.Release());
 
             if (auto logl = Env->Logger()->Log(ELnLev::Info)) {

--- a/ydb/core/tablet_flat/flat_database.h
+++ b/ydb/core/tablet_flat/flat_database.h
@@ -226,7 +226,8 @@ public:
     void UpdateApproximateFreeSharesByChannel(const THashMap<ui32, float>& approximateFreeSpaceShareByChannel);
     TString SnapshotToLog(ui32 table, TTxStamp);
 
-    TAutoPtr<TSubset> Subset(ui32 table, TArrayRef<const TLogoBlobID> bundle, TEpoch before) const;
+    TAutoPtr<TSubset> CompactionSubset(ui32 table, TEpoch before, TArrayRef<const TLogoBlobID> bundle) const;
+    TAutoPtr<TSubset> PartSwitchSubset(ui32 table, TEpoch before, TArrayRef<const TLogoBlobID> bundle, TArrayRef<const TLogoBlobID> txStatus) const;
     TAutoPtr<TSubset> Subset(ui32 table, TEpoch before, TRawVals from, TRawVals to) const;
     TAutoPtr<TSubset> ScanSnapshot(ui32 table, TRowVersion snapshot = TRowVersion::Max());
 
@@ -235,11 +236,15 @@ public:
     TBundleSlicesMap LookupSlices(ui32 table, TArrayRef<const TLogoBlobID> bundles) const;
     void ReplaceSlices(ui32 table, TBundleSlicesMap slices);
 
-    void Replace(ui32 table, TArrayRef<const TPartView>, const TSubset&);
-    void ReplaceTxStatus(ui32 table, TArrayRef<const TIntrusiveConstPtr<TTxStatusPart>>, const TSubset&);
+    void Replace(
+        ui32 table,
+        const TSubset&,
+        TArrayRef<const TPartView>,
+        TArrayRef<const TIntrusiveConstPtr<TTxStatusPart>>);
     void Merge(ui32 table, TPartView);
     void Merge(ui32 table, TIntrusiveConstPtr<TColdPart>);
     void Merge(ui32 table, TIntrusiveConstPtr<TTxStatusPart>);
+    void MergeDone(ui32 table);
 
     void DebugDumpTable(ui32 table, IOutputStream& str, const NScheme::TTypeRegistry& typeRegistry) const;
     void DebugDump(IOutputStream& str, const NScheme::TTypeRegistry& typeRegistry) const;

--- a/ydb/core/tablet_flat/flat_executor_misc.h
+++ b/ydb/core/tablet_flat/flat_executor_misc.h
@@ -34,12 +34,11 @@ namespace NTabletFlatExecutor {
         THolder<NTable::TCompactionParams> Params;
         NTable::TRowVersionRanges::TSnapshot RemovedRowVersions;
 
-        // Non-empty when compaction also needs to write a tx status table part
-        NTable::TTransactionMap CommittedTransactions;
-        NTable::TTransactionSet RemovedTransactions;
-        // The above may contain extra keys, these allow them to be narrowed
+        // Non-empty when compaction also needs to produce a tx status table part
         TVector<TIntrusiveConstPtr<NTable::TMemTable>> Frozen;
         TVector<TIntrusiveConstPtr<NTable::TTxStatusPart>> TxStatus;
+        // Non-empty for transactions that no longer need their status maintained
+        NTable::TTransactionSet GarbageTransactions;
     };
 
 }

--- a/ydb/core/tablet_flat/flat_mem_warm.h
+++ b/ydb/core/tablet_flat/flat_mem_warm.h
@@ -460,7 +460,8 @@ namespace NMem {
             return TxIdStats;
         }
 
-        void CommitTx(ui64 txId, TRowVersion rowVersion) {
+        bool CommitTx(ui64 txId, TRowVersion rowVersion) {
+            bool newRef = false;
             auto it = Committed.find(txId);
             bool toInsert = (it == Committed.end());
 
@@ -480,12 +481,16 @@ namespace NMem {
                             UndoBuffer.push_back(TUndoOpInsertRemoved{ txId });
                         }
                         Removed.erase(itRemoved);
+                    } else {
+                        newRef = true;
                     }
                 }
             }
+            return newRef;
         }
 
-        void RemoveTx(ui64 txId) {
+        bool RemoveTx(ui64 txId) {
+            bool newRef = false;
             auto it = Committed.find(txId);
             if (it == Committed.end()) {
                 auto itRemoved = Removed.find(txId);
@@ -494,8 +499,10 @@ namespace NMem {
                         UndoBuffer.push_back(TUndoOpEraseRemoved{ txId });
                     }
                     Removed.insert(txId);
+                    newRef = true;
                 }
             }
+            return newRef;
         }
 
         const absl::flat_hash_map<ui64, TRowVersion>& GetCommittedTransactions() const {

--- a/ydb/core/tablet_flat/flat_table.h
+++ b/ydb/core/tablet_flat/flat_table.h
@@ -84,7 +84,8 @@ public:
         return Epoch;
     }
 
-    TAutoPtr<TSubset> Subset(TArrayRef<const TLogoBlobID> bundle, TEpoch edge);
+    TAutoPtr<TSubset> CompactionSubset(TEpoch edge, TArrayRef<const TLogoBlobID> bundle);
+    TAutoPtr<TSubset> PartSwitchSubset(TEpoch edge, TArrayRef<const TLogoBlobID> bundle, TArrayRef<const TLogoBlobID> txStatus);
     TAutoPtr<TSubset> Subset(TEpoch edge) const noexcept;
     TAutoPtr<TSubset> ScanSnapshot(TRowVersion snapshot = TRowVersion::Max()) noexcept;
     TAutoPtr<TSubset> Unwrap() noexcept; /* full Subset(..) + final Replace(..) */
@@ -110,8 +111,7 @@ public:
         be displaced from table with Clean() method eventually.
     */
 
-    void Replace(TArrayRef<const TPartView>, const TSubset&) noexcept;
-    void ReplaceTxStatus(TArrayRef<const TIntrusiveConstPtr<TTxStatusPart>>, const TSubset&) noexcept;
+    void Replace(const TSubset&, TArrayRef<const TPartView>, TArrayRef<const TIntrusiveConstPtr<TTxStatusPart>>) noexcept;
 
     /*_ Special interface for clonig flatten part of table for outer usage.
         Cook some TPartView with Subset(...) method and/or TShrink tool first and
@@ -121,6 +121,7 @@ public:
     void Merge(TPartView partView) noexcept;
     void Merge(TIntrusiveConstPtr<TColdPart> part) noexcept;
     void Merge(TIntrusiveConstPtr<TTxStatusPart> txStatus) noexcept;
+    void MergeDone() noexcept;
     void ProcessCheckTransactions() noexcept;
 
     /**
@@ -339,7 +340,9 @@ private:
     void RemoveStat(const TPartView& partView);
 
 private:
-    void AddTxRef(ui64 txId);
+    void AddTxDataRef(ui64 txId);
+    void AddTxStatusRef(ui64 txId);
+    void RemoveTxStatusRef(ui64 txId);
 
 private:
     TEpoch Epoch; /* Monotonic table change number, with holes */
@@ -361,18 +364,38 @@ private:
 
     TRowVersionRanges RemovedRowVersions;
 
-    absl::flat_hash_map<ui64, size_t> TxRefs;
+    // The number of entities (memtable/sst) that have rows with a TxId. As
+    // long as there is at least one row with a TxId its commit/remove status
+    // must be preserved.
+    absl::flat_hash_map<ui64, size_t> TxDataRefs;
+
+    // The number of entities (memtable/txstatus) that have a commit/remove
+    // status for a TxId. As long as there is at least one such entity the
+    // transaction cannot be used again without artifacts, and must stay
+    // in committed/removed set.
+    absl::flat_hash_map<ui64, size_t> TxStatusRefs;
+
+    // A set of open transactions, i.e. transactions that have rows with the
+    // specified TxId and that have not been committed or removed yet.
     absl::flat_hash_set<ui64> OpenTxs;
+
+    // A set of transactions that need to be re-checked after a merge.
     absl::flat_hash_set<ui64> CheckTransactions;
+
     TTransactionMap CommittedTransactions;
     TTransactionSet RemovedTransactions;
     TTransactionSet DecidedTransactions;
+    TTransactionSet GarbageTransactions;
     TIntrusivePtr<ITableObserver> TableObserver;
 
     ui64 RemovedCommittedTxs = 0;
 
 private:
-    struct TRollbackRemoveTxRef {
+    struct TRollbackRemoveTxDataRef {
+        ui64 TxId;
+    };
+
+    struct TRollbackRemoveTxStatusRef {
         ui64 TxId;
     };
 
@@ -402,7 +425,8 @@ private:
     };
 
     using TRollbackOp = std::variant<
-        TRollbackRemoveTxRef,
+        TRollbackRemoveTxDataRef,
+        TRollbackRemoveTxStatusRef,
         TRollbackAddCommittedTx,
         TRollbackRemoveCommittedTx,
         TRollbackAddRemovedTx,

--- a/ydb/core/tablet_flat/flat_table_subset.h
+++ b/ydb/core/tablet_flat/flat_table_subset.h
@@ -118,6 +118,7 @@ namespace NTable {
         TVector<TIntrusiveConstPtr<TColdPart>> ColdParts;
         TTransactionMap CommittedTransactions;
         TTransactionSet RemovedTransactions;
+        TTransactionSet GarbageTransactions;
         TVector<TIntrusiveConstPtr<TTxStatusPart>> TxStatus;
     };
 

--- a/ydb/core/tablet_flat/test/libs/table/test_dbase.h
+++ b/ydb/core/tablet_flat/test/libs/table/test_dbase.h
@@ -246,8 +246,11 @@ namespace NTest {
             if (last /* make full subset */) {
                 subset = Base->Subset(table, TEpoch::Max(), { }, { });
             } else /* only flush memtables */ {
-                subset = Base->Subset(table, { }, TEpoch::Max());
+                subset = Base->CompactionSubset(table, TEpoch::Max(), { });
             }
+
+            // Note: we don't compact TxStatus in these tests
+            Y_ABORT_UNLESS(subset->TxStatus.empty());
 
             TLogoBlobID logo(1, Gen, ++Step, 1, 0, 0);
 
@@ -279,7 +282,7 @@ namespace NTest {
             for (auto &part : eggs.Parts)
                 partViews.push_back({ part, nullptr, part->Slices });
 
-            Base->Replace(table, std::move(partViews), *subset);
+            Base->Replace(table, *subset, std::move(partViews), { });
 
             return *this;
         }


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

...

### Changelog category <!-- remove all except one -->

* Not for changelog (changelog entry is not required)

### Description for reviewers <!-- (optional) description for those who read this PR -->

It was discovered that in certain situation tx status parts and in-memory state may diverge, allowing transaction ids to be reused, which would unexpectedly become committed or removed after a restart. Make sure in-memory state doesn't diverge from the state that could be restored from disk on restart.

Fixes KIKIMR-22538.