### PR TITLE
Refactor protos namespace in C++ SDK for common usage in different repos

### DIFF
--- a/ydb/public/sdk/cpp/include/ydb-cpp-sdk/client/cms/cms.h
+++ b/ydb/public/sdk/cpp/include/ydb-cpp-sdk/client/cms/cms.h
@@ -1,8 +1,10 @@
 #pragma once
 
 #include <ydb-cpp-sdk/client/driver/driver.h>
+#include <ydb-cpp-sdk/type_switcher.h>
 
-namespace Ydb::Cms {
+YDB_PROTOS_NAMESPACE {
+namespace Cms {
     class CreateDatabaseRequest;
     class ListDatabasesResult;
     class GetDatabaseStatusResult;
@@ -19,7 +21,8 @@ namespace Ydb::Cms {
     class ScaleRecommenderPolicies;
     class ScaleRecommenderPolicies_ScaleRecommenderPolicy;
     class ScaleRecommenderPolicies_ScaleRecommenderPolicy_TargetTrackingPolicy;
-} // namespace Ydb::Cms
+} // namespace Cms
+}
 
 namespace NYdb::inline V3::NCms {
 
@@ -27,7 +30,7 @@ struct TListDatabasesSettings : public TOperationRequestSettings<TListDatabasesS
 
 class TListDatabasesResult : public TStatus {
 public:
-    TListDatabasesResult(TStatus&& status, const Ydb::Cms::ListDatabasesResult& proto);
+    TListDatabasesResult(TStatus&& status, const NYdbProtos::Cms::ListDatabasesResult& proto);
     const std::vector<std::string>& GetPaths() const;
 private:
     std::vector<std::string> Paths_;
@@ -48,7 +51,7 @@ enum class EState {
 
 struct TStorageUnits {
     TStorageUnits() = default;
-    TStorageUnits(const Ydb::Cms::StorageUnits& proto);
+    TStorageUnits(const NYdbProtos::Cms::StorageUnits& proto);
 
     std::string UnitKind;
     std::uint64_t Count;
@@ -56,7 +59,7 @@ struct TStorageUnits {
 
 struct TComputationalUnits {
     TComputationalUnits() = default;
-    TComputationalUnits(const Ydb::Cms::ComputationalUnits& proto);
+    TComputationalUnits(const NYdbProtos::Cms::ComputationalUnits& proto);
 
     std::string UnitKind;
     std::string AvailabilityZone;
@@ -65,7 +68,7 @@ struct TComputationalUnits {
 
 struct TAllocatedComputationalUnit {
     TAllocatedComputationalUnit() = default;
-    TAllocatedComputationalUnit(const Ydb::Cms::AllocatedComputationalUnit& proto);
+    TAllocatedComputationalUnit(const NYdbProtos::Cms::AllocatedComputationalUnit& proto);
 
     std::string Host;
     std::uint32_t Port;
@@ -74,7 +77,7 @@ struct TAllocatedComputationalUnit {
 
 struct TResources {
     TResources() = default;
-    TResources(const Ydb::Cms::Resources& proto);
+    TResources(const NYdbProtos::Cms::Resources& proto);
 
     std::vector<TStorageUnits> StorageUnits;
     std::vector<TComputationalUnits> ComputationalUnits;
@@ -86,7 +89,7 @@ struct TSharedResources : public TResources {
 
 struct TServerlessResources {
     TServerlessResources() = default;
-    TServerlessResources(const Ydb::Cms::ServerlessResources& proto);
+    TServerlessResources(const NYdbProtos::Cms::ServerlessResources& proto);
 
     std::string SharedDatabasePath;
 };
@@ -94,14 +97,14 @@ struct TServerlessResources {
 struct TSchemaOperationQuotas {
     struct TLeakyBucket {
         TLeakyBucket() = default;
-        TLeakyBucket(const Ydb::Cms::SchemaOperationQuotas_LeakyBucket& proto);
+        TLeakyBucket(const NYdbProtos::Cms::SchemaOperationQuotas_LeakyBucket& proto);
 
         double BucketSize = 1;
         std::uint64_t BucketSeconds = 2;
     };
 
     TSchemaOperationQuotas() = default;
-    TSchemaOperationQuotas(const Ydb::Cms::SchemaOperationQuotas& proto);
+    TSchemaOperationQuotas(const NYdbProtos::Cms::SchemaOperationQuotas& proto);
 
     std::vector<TLeakyBucket> LeakyBucketQuotas;
 };
@@ -109,7 +112,7 @@ struct TSchemaOperationQuotas {
 struct TDatabaseQuotas {
     struct TStorageQuotas {
         TStorageQuotas() = default;
-        TStorageQuotas(const Ydb::Cms::DatabaseQuotas_StorageQuotas& proto);
+        TStorageQuotas(const NYdbProtos::Cms::DatabaseQuotas_StorageQuotas& proto);
 
         std::string UnitKind;
         std::uint64_t DataSizeHardQuota;
@@ -117,7 +120,7 @@ struct TDatabaseQuotas {
     };
 
     TDatabaseQuotas() = default;
-    TDatabaseQuotas(const Ydb::Cms::DatabaseQuotas& proto);
+    TDatabaseQuotas(const NYdbProtos::Cms::DatabaseQuotas& proto);
 
     std::uint64_t DataSizeHardQuota;
     std::uint64_t DataSizeSoftQuota;
@@ -131,21 +134,21 @@ struct TTargetTrackingPolicy {
     using TAverageCpuUtilizationPercent = std::uint32_t;
 
     TTargetTrackingPolicy() = default;
-    TTargetTrackingPolicy(const Ydb::Cms::ScaleRecommenderPolicies_ScaleRecommenderPolicy_TargetTrackingPolicy& proto);
+    TTargetTrackingPolicy(const NYdbProtos::Cms::ScaleRecommenderPolicies_ScaleRecommenderPolicy_TargetTrackingPolicy& proto);
 
     std::variant<std::monostate, TAverageCpuUtilizationPercent> Target;
 };
 
 struct TScaleRecommenderPolicy {
     TScaleRecommenderPolicy() = default;
-    TScaleRecommenderPolicy(const Ydb::Cms::ScaleRecommenderPolicies_ScaleRecommenderPolicy& proto);
+    TScaleRecommenderPolicy(const NYdbProtos::Cms::ScaleRecommenderPolicies_ScaleRecommenderPolicy& proto);
 
     std::variant<std::monostate, TTargetTrackingPolicy> Policy;
 };
 
 struct TScaleRecommenderPolicies {
     TScaleRecommenderPolicies() = default;
-    TScaleRecommenderPolicies(const Ydb::Cms::ScaleRecommenderPolicies& proto);
+    TScaleRecommenderPolicies(const NYdbProtos::Cms::ScaleRecommenderPolicies& proto);
 
     std::vector<TScaleRecommenderPolicy> Policies;
 };
@@ -154,7 +157,7 @@ using TResourcesKind = std::variant<std::monostate, TResources, TSharedResources
 
 class TGetDatabaseStatusResult : public TStatus {
 public:
-    TGetDatabaseStatusResult(TStatus&& status, const Ydb::Cms::GetDatabaseStatusResult& proto);
+    TGetDatabaseStatusResult(TStatus&& status, const NYdbProtos::Cms::GetDatabaseStatusResult& proto);
 
     const std::string& GetPath() const;
     EState GetState() const;
@@ -167,7 +170,7 @@ public:
     const TScaleRecommenderPolicies& GetScaleRecommenderPolicies() const;
 
     // Fills CreateDatabaseRequest proto from this database status
-    void SerializeTo(Ydb::Cms::CreateDatabaseRequest& request) const;
+    void SerializeTo(NYdbProtos::Cms::CreateDatabaseRequest& request) const;
 
 private:
     std::string Path_;
@@ -185,10 +188,10 @@ using TAsyncGetDatabaseStatusResult = NThreading::TFuture<TGetDatabaseStatusResu
 
 struct TCreateDatabaseSettings : public TOperationRequestSettings<TCreateDatabaseSettings> {
     TCreateDatabaseSettings() = default;
-    explicit TCreateDatabaseSettings(const Ydb::Cms::CreateDatabaseRequest& request);
+    explicit TCreateDatabaseSettings(const NYdbProtos::Cms::CreateDatabaseRequest& request);
 
     // Fills CreateDatabaseRequest proto from this settings
-    void SerializeTo(Ydb::Cms::CreateDatabaseRequest& request) const;
+    void SerializeTo(NYdbProtos::Cms::CreateDatabaseRequest& request) const;
 
     FLUENT_SETTING(TResourcesKind, ResourcesKind);
     FLUENT_SETTING(TSchemaOperationQuotas, SchemaOperationQuotas);

--- a/ydb/public/sdk/cpp/include/ydb-cpp-sdk/client/coordination/coordination.h
+++ b/ydb/public/sdk/cpp/include/ydb-cpp-sdk/client/coordination/coordination.h
@@ -1,8 +1,9 @@
 #pragma once
 
 #include <ydb-cpp-sdk/client/driver/driver.h>
+#include <ydb-cpp-sdk/type_switcher.h>
 
-namespace Ydb {
+YDB_PROTOS_NAMESPACE {
 namespace Coordination {
     class Config;
     class CreateNodeRequest;
@@ -97,7 +98,7 @@ enum class ERateLimiterCountersMode {
 //! Represents coordination node description
 class TNodeDescription {
 public:
-    TNodeDescription(const Ydb::Coordination::DescribeNodeResult& desc);
+    TNodeDescription(const NYdbProtos::Coordination::DescribeNodeResult& desc);
 
     const std::optional<TDuration>& GetSelfCheckPeriod() const;
     const std::optional<TDuration>& GetSessionGracePeriod() const;
@@ -107,9 +108,9 @@ public:
 
     const std::string& GetOwner() const;
     const std::vector<NScheme::TPermissions>& GetEffectivePermissions() const;
-    const Ydb::Coordination::DescribeNodeResult& GetProto() const;
+    const NYdbProtos::Coordination::DescribeNodeResult& GetProto() const;
 
-    void SerializeTo(Ydb::Coordination::CreateNodeRequest& creationRequest) const;
+    void SerializeTo(NYdbProtos::Coordination::CreateNodeRequest& creationRequest) const;
 
 private:
     struct TImpl;
@@ -123,7 +124,7 @@ class TSemaphoreSession {
 public:
     TSemaphoreSession();
 
-    TSemaphoreSession(const Ydb::Coordination::SemaphoreSession& desc);
+    TSemaphoreSession(const NYdbProtos::Coordination::SemaphoreSession& desc);
 
     uint64_t GetOrderId() const { return OrderId_; }
     uint64_t GetSessionId() const { return SessionId_; }
@@ -146,7 +147,7 @@ class TSemaphoreDescription {
 public:
     TSemaphoreDescription();
 
-    TSemaphoreDescription(const Ydb::Coordination::SemaphoreDescription& desc);
+    TSemaphoreDescription(const NYdbProtos::Coordination::SemaphoreDescription& desc);
 
     const std::string& GetName() const { return Name_; }
     const std::string& GetData() const { return Data_; }
@@ -195,7 +196,7 @@ struct TNodeSettings : public TOperationRequestSettings<TDerived> {
 
 struct TCreateNodeSettings : public TNodeSettings<TCreateNodeSettings> {
     TCreateNodeSettings() = default;
-    TCreateNodeSettings(const Ydb::Coordination::Config& config);
+    TCreateNodeSettings(const NYdbProtos::Coordination::Config& config);
 };
 struct TAlterNodeSettings : public TNodeSettings<TAlterNodeSettings> { };
 struct TDropNodeSettings : public TOperationRequestSettings<TDropNodeSettings> { };

--- a/ydb/public/sdk/cpp/include/ydb-cpp-sdk/client/datastreams/datastreams.h
+++ b/ydb/public/sdk/cpp/include/ydb-cpp-sdk/client/datastreams/datastreams.h
@@ -33,36 +33,36 @@ namespace NYdb::inline V3::NDataStreams::V1 {
         ESM_ON_DEMAND = 2,
     };
 
-    using TCreateStreamResult = TProtoResultWrapper<Ydb::DataStreams::V1::CreateStreamResult>;
-    using TDeleteStreamResult = TProtoResultWrapper<Ydb::DataStreams::V1::DeleteStreamResult>;
-    using TDescribeStreamResult = TProtoResultWrapper<Ydb::DataStreams::V1::DescribeStreamResult>;
-    using TPutRecordResult = TProtoResultWrapper<Ydb::DataStreams::V1::PutRecordResult>;
-    using TRegisterStreamConsumerResult = TProtoResultWrapper<Ydb::DataStreams::V1::RegisterStreamConsumerResult>;
-    using TDeregisterStreamConsumerResult = TProtoResultWrapper<Ydb::DataStreams::V1::DeregisterStreamConsumerResult>;
-    using TDescribeStreamConsumerResult = TProtoResultWrapper<Ydb::DataStreams::V1::DescribeStreamConsumerResult>;
-    using TListStreamsResult = TProtoResultWrapper<Ydb::DataStreams::V1::ListStreamsResult>;
-    using TListShardsResult = TProtoResultWrapper<Ydb::DataStreams::V1::ListShardsResult>;
-    using TPutRecordsResult = TProtoResultWrapper<Ydb::DataStreams::V1::PutRecordsResult>;
-    using TGetRecordsResult = TProtoResultWrapper<Ydb::DataStreams::V1::GetRecordsResult>;
-    using TGetShardIteratorResult = TProtoResultWrapper<Ydb::DataStreams::V1::GetShardIteratorResult>;
-    // using TSubscribeToShardResult = TProtoResultWrapper<Ydb::DataStreams::V1::SubscribeToShardResult>;
-    using TDescribeLimitsResult = TProtoResultWrapper<Ydb::DataStreams::V1::DescribeLimitsResult>;
-    using TDescribeStreamSummaryResult = TProtoResultWrapper<Ydb::DataStreams::V1::DescribeStreamSummaryResult>;
-    using TDecreaseStreamRetentionPeriodResult = TProtoResultWrapper<Ydb::DataStreams::V1::DecreaseStreamRetentionPeriodResult>;
-    using TIncreaseStreamRetentionPeriodResult = TProtoResultWrapper<Ydb::DataStreams::V1::IncreaseStreamRetentionPeriodResult>;
-    using TUpdateShardCountResult = TProtoResultWrapper<Ydb::DataStreams::V1::UpdateShardCountResult>;
-    using TUpdateStreamModeResult = TProtoResultWrapper<Ydb::DataStreams::V1::UpdateStreamModeResult>;
-    using TListStreamConsumersResult = TProtoResultWrapper<Ydb::DataStreams::V1::ListStreamConsumersResult>;
-    using TAddTagsToStreamResult = TProtoResultWrapper<Ydb::DataStreams::V1::AddTagsToStreamResult>;
-    using TDisableEnhancedMonitoringResult = TProtoResultWrapper<Ydb::DataStreams::V1::DisableEnhancedMonitoringResult>;
-    using TEnableEnhancedMonitoringResult = TProtoResultWrapper<Ydb::DataStreams::V1::EnableEnhancedMonitoringResult>;
-    using TListTagsForStreamResult = TProtoResultWrapper<Ydb::DataStreams::V1::ListTagsForStreamResult>;
-    using TMergeShardsResult = TProtoResultWrapper<Ydb::DataStreams::V1::MergeShardsResult>;
-    using TRemoveTagsFromStreamResult = TProtoResultWrapper<Ydb::DataStreams::V1::RemoveTagsFromStreamResult>;
-    using TSplitShardResult = TProtoResultWrapper<Ydb::DataStreams::V1::SplitShardResult>;
-    using TStartStreamEncryptionResult = TProtoResultWrapper<Ydb::DataStreams::V1::StartStreamEncryptionResult>;
-    using TStopStreamEncryptionResult = TProtoResultWrapper<Ydb::DataStreams::V1::StopStreamEncryptionResult>;
-    using TUpdateStreamResult = TProtoResultWrapper<Ydb::DataStreams::V1::UpdateStreamResult>;
+    using TCreateStreamResult = TProtoResultWrapper<NYdbProtos::DataStreams::V1::CreateStreamResult>;
+    using TDeleteStreamResult = TProtoResultWrapper<NYdbProtos::DataStreams::V1::DeleteStreamResult>;
+    using TDescribeStreamResult = TProtoResultWrapper<NYdbProtos::DataStreams::V1::DescribeStreamResult>;
+    using TPutRecordResult = TProtoResultWrapper<NYdbProtos::DataStreams::V1::PutRecordResult>;
+    using TRegisterStreamConsumerResult = TProtoResultWrapper<NYdbProtos::DataStreams::V1::RegisterStreamConsumerResult>;
+    using TDeregisterStreamConsumerResult = TProtoResultWrapper<NYdbProtos::DataStreams::V1::DeregisterStreamConsumerResult>;
+    using TDescribeStreamConsumerResult = TProtoResultWrapper<NYdbProtos::DataStreams::V1::DescribeStreamConsumerResult>;
+    using TListStreamsResult = TProtoResultWrapper<NYdbProtos::DataStreams::V1::ListStreamsResult>;
+    using TListShardsResult = TProtoResultWrapper<NYdbProtos::DataStreams::V1::ListShardsResult>;
+    using TPutRecordsResult = TProtoResultWrapper<NYdbProtos::DataStreams::V1::PutRecordsResult>;
+    using TGetRecordsResult = TProtoResultWrapper<NYdbProtos::DataStreams::V1::GetRecordsResult>;
+    using TGetShardIteratorResult = TProtoResultWrapper<NYdbProtos::DataStreams::V1::GetShardIteratorResult>;
+    // using TSubscribeToShardResult = TProtoResultWrapper<NYdbProtos::DataStreams::V1::SubscribeToShardResult>;
+    using TDescribeLimitsResult = TProtoResultWrapper<NYdbProtos::DataStreams::V1::DescribeLimitsResult>;
+    using TDescribeStreamSummaryResult = TProtoResultWrapper<NYdbProtos::DataStreams::V1::DescribeStreamSummaryResult>;
+    using TDecreaseStreamRetentionPeriodResult = TProtoResultWrapper<NYdbProtos::DataStreams::V1::DecreaseStreamRetentionPeriodResult>;
+    using TIncreaseStreamRetentionPeriodResult = TProtoResultWrapper<NYdbProtos::DataStreams::V1::IncreaseStreamRetentionPeriodResult>;
+    using TUpdateShardCountResult = TProtoResultWrapper<NYdbProtos::DataStreams::V1::UpdateShardCountResult>;
+    using TUpdateStreamModeResult = TProtoResultWrapper<NYdbProtos::DataStreams::V1::UpdateStreamModeResult>;
+    using TListStreamConsumersResult = TProtoResultWrapper<NYdbProtos::DataStreams::V1::ListStreamConsumersResult>;
+    using TAddTagsToStreamResult = TProtoResultWrapper<NYdbProtos::DataStreams::V1::AddTagsToStreamResult>;
+    using TDisableEnhancedMonitoringResult = TProtoResultWrapper<NYdbProtos::DataStreams::V1::DisableEnhancedMonitoringResult>;
+    using TEnableEnhancedMonitoringResult = TProtoResultWrapper<NYdbProtos::DataStreams::V1::EnableEnhancedMonitoringResult>;
+    using TListTagsForStreamResult = TProtoResultWrapper<NYdbProtos::DataStreams::V1::ListTagsForStreamResult>;
+    using TMergeShardsResult = TProtoResultWrapper<NYdbProtos::DataStreams::V1::MergeShardsResult>;
+    using TRemoveTagsFromStreamResult = TProtoResultWrapper<NYdbProtos::DataStreams::V1::RemoveTagsFromStreamResult>;
+    using TSplitShardResult = TProtoResultWrapper<NYdbProtos::DataStreams::V1::SplitShardResult>;
+    using TStartStreamEncryptionResult = TProtoResultWrapper<NYdbProtos::DataStreams::V1::StartStreamEncryptionResult>;
+    using TStopStreamEncryptionResult = TProtoResultWrapper<NYdbProtos::DataStreams::V1::StopStreamEncryptionResult>;
+    using TUpdateStreamResult = TProtoResultWrapper<NYdbProtos::DataStreams::V1::UpdateStreamResult>;
 
     using TAsyncCreateStreamResult = NThreading::TFuture<TCreateStreamResult>;
     using TAsyncDeleteStreamResult = NThreading::TFuture<TDeleteStreamResult>;
@@ -128,7 +128,7 @@ namespace NYdb::inline V3::NDataStreams::V1 {
             , DownUtilizationPercent_(0)
             , UpUtilizationPercent_(0) {
         }
-        TAutoPartitioningSettings(const Ydb::DataStreams::V1::AutoPartitioningSettings& settings);
+        TAutoPartitioningSettings(const NYdbProtos::DataStreams::V1::AutoPartitioningSettings& settings);
         TAutoPartitioningSettings(EAutoPartitioningStrategy strategy, TDuration stabilizationWindow, uint64_t downUtilizationPercent, uint64_t upUtilizationPercent)
             : Strategy_(strategy)
             , StabilizationWindow_(stabilizationWindow)
@@ -153,7 +153,7 @@ namespace NYdb::inline V3::NDataStreams::V1 {
         friend struct TPartitioningSettingsBuilder<TUpdateStreamSettings>;
     public:
         TPartitioningSettings() : MinActivePartitions_(0), MaxActivePartitions_(0), AutoPartitioningSettings_(){}
-        TPartitioningSettings(const Ydb::DataStreams::V1::PartitioningSettings& settings);
+        TPartitioningSettings(const NYdbProtos::DataStreams::V1::PartitioningSettings& settings);
         TPartitioningSettings(uint64_t minActivePartitions, uint64_t maxActivePartitions, TAutoPartitioningSettings autoscalingSettings = {})
             : MinActivePartitions_(minActivePartitions)
             , MaxActivePartitions_(maxActivePartitions)
@@ -334,10 +334,10 @@ namespace NYdb::inline V3::NDataStreams::V1 {
         TAsyncDescribeStreamResult DescribeStream(const std::string& path, TDescribeStreamSettings settings = TDescribeStreamSettings());
         TAsyncPutRecordResult PutRecord(const std::string& path, const TDataRecord& record, TPutRecordSettings settings = TPutRecordSettings());
         TAsyncListStreamsResult ListStreams(TListStreamsSettings settings = TListStreamsSettings());
-        TAsyncListShardsResult ListShards(const std::string& path, const Ydb::DataStreams::V1::ShardFilter& shardFilter, TListShardsSettings settings = TListShardsSettings());
+        TAsyncListShardsResult ListShards(const std::string& path, const NYdbProtos::DataStreams::V1::ShardFilter& shardFilter, TListShardsSettings settings = TListShardsSettings());
         TAsyncPutRecordsResult PutRecords(const std::string& path, const std::vector<TDataRecord>& records, TPutRecordsSettings settings = TPutRecordsSettings());
         TAsyncGetRecordsResult GetRecords(const std::string& shardIterator, TGetRecordsSettings settings = TGetRecordsSettings());
-        TAsyncGetShardIteratorResult GetShardIterator(const std::string& path, const std::string& shardId, Ydb::DataStreams::V1::ShardIteratorType shardIteratorTypeStr,
+        TAsyncGetShardIteratorResult GetShardIterator(const std::string& path, const std::string& shardId, NYdbProtos::DataStreams::V1::ShardIteratorType shardIteratorTypeStr,
                                                       TGetShardIteratorSettings settings = TGetShardIteratorSettings());
         // TAsyncSubscribeToShardResult SubscribeToShard(TSubscribeToShardSettings settings = TSubscribeToShardSettings());
         TAsyncDescribeLimitsResult DescribeLimits(TDescribeLimitsSettings settings = TDescribeLimitsSettings());

--- a/ydb/public/sdk/cpp/include/ydb-cpp-sdk/client/discovery/discovery.h
+++ b/ydb/public/sdk/cpp/include/ydb-cpp-sdk/client/discovery/discovery.h
@@ -1,8 +1,9 @@
 #pragma once
 
 #include <ydb-cpp-sdk/client/driver/driver.h>
+#include <ydb-cpp-sdk/type_switcher.h>
 
-namespace Ydb {
+YDB_PROTOS_NAMESPACE {
 namespace Discovery {
     class ListEndpointsResult;
     class WhoAmIResult;
@@ -10,7 +11,7 @@ namespace Discovery {
     class NodeLocation;
     class NodeInfo;
 } // namespace Discovery
-} // namespace Ydb
+}
 
 namespace NYdb::inline V3 {
 namespace NDiscovery {
@@ -25,7 +26,7 @@ struct TWhoAmISettings : public TSimpleRequestSettings<TWhoAmISettings> {
 
 struct TNodeLocation {
     TNodeLocation() = default;
-    TNodeLocation(const Ydb::Discovery::NodeLocation& location);
+    TNodeLocation(const NYdbProtos::Discovery::NodeLocation& location);
 
     std::optional<uint32_t> DataCenterNum;
     std::optional<uint32_t> RoomNum;
@@ -65,7 +66,7 @@ struct TEndpointInfo {
 
 class TListEndpointsResult : public TStatus {
 public:
-    TListEndpointsResult(TStatus&& status, const Ydb::Discovery::ListEndpointsResult& endpoints);
+    TListEndpointsResult(TStatus&& status, const NYdbProtos::Discovery::ListEndpointsResult& endpoints);
     const std::vector<TEndpointInfo>& GetEndpointsInfo() const;
 private:
     std::vector<TEndpointInfo> Info_;
@@ -75,7 +76,7 @@ using TAsyncListEndpointsResult = NThreading::TFuture<TListEndpointsResult>;
 
 class TWhoAmIResult : public TStatus {
 public:
-    TWhoAmIResult(TStatus&& status, const Ydb::Discovery::WhoAmIResult& proto);
+    TWhoAmIResult(TStatus&& status, const NYdbProtos::Discovery::WhoAmIResult& proto);
     const std::string& GetUserName() const;
     const std::vector<std::string>& GetGroups() const;
 private:
@@ -87,7 +88,7 @@ using TAsyncWhoAmIResult = NThreading::TFuture<TWhoAmIResult>;
 
 struct TNodeInfo {
     TNodeInfo() = default;
-    TNodeInfo(const Ydb::Discovery::NodeInfo& info);
+    TNodeInfo(const NYdbProtos::Discovery::NodeInfo& info);
 
     uint32_t NodeId;
     std::string Host;
@@ -101,7 +102,7 @@ struct TNodeInfo {
 class TNodeRegistrationResult : public TStatus {
 public:
     TNodeRegistrationResult() : TStatus(EStatus::GENERIC_ERROR, NYdb::NIssue::TIssues()) {}
-    TNodeRegistrationResult(TStatus&& status, const Ydb::Discovery::NodeRegistrationResult& proto);
+    TNodeRegistrationResult(TStatus&& status, const NYdbProtos::Discovery::NodeRegistrationResult& proto);
     uint32_t GetNodeId() const;
     const std::string& GetDomainPath() const;
     uint64_t GetExpire() const;

--- a/ydb/public/sdk/cpp/include/ydb-cpp-sdk/client/draft/ydb_replication.h
+++ b/ydb/public/sdk/cpp/include/ydb-cpp-sdk/client/draft/ydb_replication.h
@@ -2,16 +2,19 @@
 
 #include <ydb-cpp-sdk/client/scheme/scheme.h>
 #include <ydb-cpp-sdk/client/driver/driver.h>
+#include <ydb-cpp-sdk/type_switcher.h>
 
 #include <optional>
 
 #include <util/datetime/base.h>
 
-namespace Ydb::Replication {
+YDB_PROTOS_NAMESPACE {
+namespace Replication {
     class ConnectionParams;
     class ConsistencyLevelGlobal;
     class DescribeReplicationResult;
     class DescribeReplicationResult_Stats;
+}
 }
 
 namespace NYdb::inline V3 {
@@ -44,7 +47,7 @@ public:
         OAuth,
     };
 
-    explicit TConnectionParams(const Ydb::Replication::ConnectionParams& params);
+    explicit TConnectionParams(const NYdbProtos::Replication::ConnectionParams& params);
 
     const std::string& GetDiscoveryEndpoint() const;
     const std::string& GetDatabase() const;
@@ -66,7 +69,7 @@ struct TRowConsistency {
 
 class TGlobalConsistency {
 public:
-    explicit TGlobalConsistency(const Ydb::Replication::ConsistencyLevelGlobal& proto);
+    explicit TGlobalConsistency(const NYdbProtos::Replication::ConsistencyLevelGlobal& proto);
 
     const TDuration& GetCommitInterval() const;
 
@@ -77,7 +80,7 @@ private:
 class TStats {
 public:
     TStats() = default;
-    TStats(const Ydb::Replication::DescribeReplicationResult_Stats& stats);
+    TStats(const NYdbProtos::Replication::DescribeReplicationResult_Stats& stats);
 
     const std::optional<TDuration>& GetLag() const;
     const std::optional<float>& GetInitialScanProgress() const;
@@ -133,7 +136,7 @@ public:
         Done,
     };
 
-    explicit TReplicationDescription(const Ydb::Replication::DescribeReplicationResult& desc);
+    explicit TReplicationDescription(const NYdbProtos::Replication::DescribeReplicationResult& desc);
 
     const TConnectionParams& GetConnectionParams() const;
     const std::vector<TItem> GetItems() const;
@@ -164,15 +167,15 @@ private:
 
 class TDescribeReplicationResult: public NScheme::TDescribePathResult {
     friend class NYdb::V3::TProtoAccessor;
-    const Ydb::Replication::DescribeReplicationResult& GetProto() const;
+    const NYdbProtos::Replication::DescribeReplicationResult& GetProto() const;
 
 public:
-    TDescribeReplicationResult(TStatus&& status, Ydb::Replication::DescribeReplicationResult&& desc);
+    TDescribeReplicationResult(TStatus&& status, NYdbProtos::Replication::DescribeReplicationResult&& desc);
     const TReplicationDescription& GetReplicationDescription() const;
 
 private:
     TReplicationDescription ReplicationDescription_;
-    std::unique_ptr<Ydb::Replication::DescribeReplicationResult> Proto_;
+    std::unique_ptr<NYdbProtos::Replication::DescribeReplicationResult> Proto_;
 };
 
 class TReplicationClient {

--- a/ydb/public/sdk/cpp/include/ydb-cpp-sdk/client/draft/ydb_scripting.h
+++ b/ydb/public/sdk/cpp/include/ydb-cpp-sdk/client/draft/ydb_scripting.h
@@ -84,13 +84,13 @@ private:
 
 class TExplainYqlResult : public TStatus {
 public:
-    TExplainYqlResult(TStatus&& status, const ::google::protobuf::Map<TStringType, Ydb::Type>&& types, std::string&& plan);
+    TExplainYqlResult(TStatus&& status, const ::google::protobuf::Map<TStringType, NYdbProtos::Type>&& types, std::string&& plan);
 
     std::map<std::string, TType> GetParameterTypes() const;
     const std::string& GetPlan() const;
 
 private:
-    ::google::protobuf::Map<TStringType, Ydb::Type> ParameterTypes_;
+    ::google::protobuf::Map<TStringType, NYdbProtos::Type> ParameterTypes_;
     std::string Plan_;
 };
 
@@ -101,7 +101,7 @@ using TAsyncExplainYqlResult = NThreading::TFuture<TExplainYqlResult>;
 ////////////////////////////////////////////////////////////////////////////////
 
 struct TExecuteYqlRequestSettings : public TOperationRequestSettings<TExecuteYqlRequestSettings> {
-    FLUENT_SETTING_DEFAULT(Ydb::Query::Syntax, Syntax, Ydb::Query::SYNTAX_YQL_V1);
+    FLUENT_SETTING_DEFAULT(NYdbProtos::Query::Syntax, Syntax, NYdbProtos::Query::SYNTAX_YQL_V1);
     FLUENT_SETTING_DEFAULT(NTable::ECollectQueryStatsMode, CollectQueryStats, NTable::ECollectQueryStatsMode::None);
 };
 

--- a/ydb/public/sdk/cpp/include/ydb-cpp-sdk/client/draft/ydb_view.h
+++ b/ydb/public/sdk/cpp/include/ydb-cpp-sdk/client/draft/ydb_view.h
@@ -2,9 +2,12 @@
 
 #include <ydb-cpp-sdk/client/driver/driver.h>
 #include <ydb-cpp-sdk/client/scheme/scheme.h>
+#include <ydb-cpp-sdk/type_switcher.h>
 
-namespace Ydb::View {
+YDB_PROTOS_NAMESPACE {
+namespace View {
     class DescribeViewResult;
+}
 }
 
 namespace NYdb::inline V3 {
@@ -22,7 +25,7 @@ struct TDescribeViewSettings : public TOperationRequestSettings<TDescribeViewSet
 
 class TViewDescription {
 public:
-    explicit TViewDescription(const Ydb::View::DescribeViewResult& desc);
+    explicit TViewDescription(const NYdbProtos::View::DescribeViewResult& desc);
 
     const std::string& GetQueryText() const;
 
@@ -32,14 +35,14 @@ private:
 
 class TDescribeViewResult : public NScheme::TDescribePathResult {
     friend class NYdb::V3::TProtoAccessor;
-    const Ydb::View::DescribeViewResult& GetProto() const;
+    const NYdbProtos::View::DescribeViewResult& GetProto() const;
 
 public:
-    TDescribeViewResult(TStatus&& status, Ydb::View::DescribeViewResult&& desc);
+    TDescribeViewResult(TStatus&& status, NYdbProtos::View::DescribeViewResult&& desc);
     TViewDescription GetViewDescription() const;
 
 private:
-    std::unique_ptr<Ydb::View::DescribeViewResult> Proto_;
+    std::unique_ptr<NYdbProtos::View::DescribeViewResult> Proto_;
 };
 
 class TViewClient {

--- a/ydb/public/sdk/cpp/include/ydb-cpp-sdk/client/export/export.h
+++ b/ydb/public/sdk/cpp/include/ydb-cpp-sdk/client/export/export.h
@@ -52,7 +52,7 @@ public:
 
 public:
     using TOperation::TOperation;
-    TExportToYtResponse(TStatus&& status, Ydb::Operations::Operation&& operation);
+    TExportToYtResponse(TStatus&& status, NYdbProtos::Operations::Operation&& operation);
 
     const TMetadata& Metadata() const;
 
@@ -101,7 +101,7 @@ public:
 
 public:
     using TOperation::TOperation;
-    TExportToS3Response(TStatus&& status, Ydb::Operations::Operation&& operation);
+    TExportToS3Response(TStatus&& status, NYdbProtos::Operations::Operation&& operation);
 
     const TMetadata& Metadata() const;
 

--- a/ydb/public/sdk/cpp/include/ydb-cpp-sdk/client/extension_common/extension.h
+++ b/ydb/public/sdk/cpp/include/ydb-cpp-sdk/client/extension_common/extension.h
@@ -1,10 +1,11 @@
 #pragma once
 
 #include <ydb-cpp-sdk/client/driver/driver.h>
+#include <ydb-cpp-sdk/type_switcher.h>
 
 #include <library/cpp/monlib/metrics/metric_registry.h>
 
-namespace Ydb {
+YDB_PROTOS_NAMESPACE {
 namespace Discovery {
 
 class ListEndpointsResult;
@@ -52,7 +53,7 @@ public:
         std::string_view Database;
         std::string_view DiscoveryEndpoint;
     };
-    using TMutatorCb = std::function<TStatus(Ydb::Discovery::ListEndpointsResult* proto, TStatus status, const TAuxInfo& aux)>;
+    using TMutatorCb = std::function<TStatus(NYdbProtos::Discovery::ListEndpointsResult* proto, TStatus status, const TAuxInfo& aux)>;
 
     static IDiscoveryMutatorApi* Create(TDriver driver);
 public:

--- a/ydb/public/sdk/cpp/include/ydb-cpp-sdk/client/federated_topic/federated_topic.h
+++ b/ydb/public/sdk/cpp/include/ydb-cpp-sdk/client/federated_topic/federated_topic.h
@@ -11,7 +11,7 @@
 namespace NYdb::inline V3::NFederatedTopic {
 
 using NTopic::TPrintable;
-using TDbInfo = Ydb::FederationDiscovery::DatabaseInfo;
+using TDbInfo = NYdbProtos::FederationDiscovery::DatabaseInfo;
 
 using TSessionClosedEvent = NTopic::TSessionClosedEvent;
 

--- a/ydb/public/sdk/cpp/include/ydb-cpp-sdk/client/import/import.h
+++ b/ydb/public/sdk/cpp/include/ydb-cpp-sdk/client/import/import.h
@@ -55,7 +55,7 @@ public:
 
 public:
     using TOperation::TOperation;
-    TImportFromS3Response(TStatus&& status, Ydb::Operations::Operation&& operation);
+    TImportFromS3Response(TStatus&& status, NYdbProtos::Operations::Operation&& operation);
 
     const TMetadata& Metadata() const;
 

--- a/ydb/public/sdk/cpp/include/ydb-cpp-sdk/client/monitoring/monitoring.h
+++ b/ydb/public/sdk/cpp/include/ydb-cpp-sdk/client/monitoring/monitoring.h
@@ -1,8 +1,9 @@
 #pragma once
 
 #include <ydb-cpp-sdk/client/driver/driver.h>
+#include <ydb-cpp-sdk/type_switcher.h>
 
-namespace Ydb {
+YDB_PROTOS_NAMESPACE {
 namespace Monitoring {
     class SelfCheckResult;
 }
@@ -35,7 +36,7 @@ struct TSelfCheckSettings : public TOperationRequestSettings<TSelfCheckSettings>
 class TSelfCheckResult : public TStatus {
     friend class NYdb::V3::TProtoAccessor;
 public:
-    TSelfCheckResult(TStatus&& status, Ydb::Monitoring::SelfCheckResult&& result);
+    TSelfCheckResult(TStatus&& status, NYdbProtos::Monitoring::SelfCheckResult&& result);
 private:
     class TImpl;
     std::shared_ptr<TImpl> Impl_;

--- a/ydb/public/sdk/cpp/include/ydb-cpp-sdk/client/params/params.h
+++ b/ydb/public/sdk/cpp/include/ydb-cpp-sdk/client/params/params.h
@@ -7,7 +7,7 @@
 
 #include <google/protobuf/map.h>
 
-namespace Ydb {
+YDB_PROTOS_NAMESPACE {
     class TypedValue;
 }
 
@@ -51,10 +51,10 @@ public:
     std::optional<TValue> GetValue(const std::string& name) const;
 
 private:
-    TParams(::google::protobuf::Map<TStringType, Ydb::TypedValue>&& protoMap);
+    TParams(::google::protobuf::Map<TStringType, NYdbProtos::TypedValue>&& protoMap);
 
-    ::google::protobuf::Map<TStringType, Ydb::TypedValue>* GetProtoMapPtr();
-    const ::google::protobuf::Map<TStringType, Ydb::TypedValue>& GetProtoMap() const;
+    ::google::protobuf::Map<TStringType, NYdbProtos::TypedValue>* GetProtoMapPtr();
+    const ::google::protobuf::Map<TStringType, NYdbProtos::TypedValue>& GetProtoMap() const;
 
     class TImpl;
     std::shared_ptr<TImpl> Impl_;
@@ -67,7 +67,7 @@ public:
     bool Finished();
 
 private:
-    TParamValueBuilder(TParamsBuilder& owner, Ydb::Type& typeProto, Ydb::Value& valueProto);
+    TParamValueBuilder(TParamsBuilder& owner, NYdbProtos::Type& typeProto, NYdbProtos::Value& valueProto);
 
     TParamsBuilder& Owner_;
     bool Finished_;
@@ -90,7 +90,7 @@ public:
     TParams Build();
 
 private:
-    TParamsBuilder(const ::google::protobuf::Map<TStringType, Ydb::Type>& typeInfo);
+    TParamsBuilder(const ::google::protobuf::Map<TStringType, NYdbProtos::Type>& typeInfo);
 
     class TImpl;
     std::unique_ptr<TImpl> Impl_;

--- a/ydb/public/sdk/cpp/include/ydb-cpp-sdk/client/proto/accessor.h
+++ b/ydb/public/sdk/cpp/include/ydb-cpp-sdk/client/proto/accessor.h
@@ -36,43 +36,43 @@ class TIndexDescription;
 //! change. Use functionality provided by YDB SDK classes.
 class TProtoAccessor {
 public:
-    static const Ydb::Type& GetProto(const TType& type);
-    static const Ydb::Value& GetProto(const TValue& value);
-    static const Ydb::ResultSet& GetProto(const TResultSet& resultSet);
-    static const ::google::protobuf::Map<TStringType, Ydb::TypedValue>& GetProtoMap(const TParams& params);
-    static ::google::protobuf::Map<TStringType, Ydb::TypedValue>* GetProtoMapPtr(TParams& params);
-    static const Ydb::TableStats::QueryStats& GetProto(const NTable::TQueryStats& queryStats);
-    static const Ydb::Table::DescribeTableResult& GetProto(const NTable::TTableDescription& tableDescription);
-    static const Ydb::Table::DescribeExternalDataSourceResult& GetProto(const NTable::TExternalDataSourceDescription&);
-    static const Ydb::Table::DescribeExternalTableResult& GetProto(const NTable::TExternalTableDescription&);
-    static const Ydb::Topic::DescribeTopicResult& GetProto(const NYdb::NTopic::TTopicDescription& topicDescription);
-    static const Ydb::Topic::DescribeConsumerResult& GetProto(const NYdb::NTopic::TConsumerDescription& consumerDescription);
-    static const Ydb::Monitoring::SelfCheckResult& GetProto(const NYdb::NMonitoring::TSelfCheckResult& selfCheckResult);
-    static const Ydb::Coordination::DescribeNodeResult& GetProto(const NYdb::NCoordination::TNodeDescription &describeNodeResult);
-    static const Ydb::Replication::DescribeReplicationResult& GetProto(const NYdb::NReplication::TDescribeReplicationResult& desc);
-    static const Ydb::View::DescribeViewResult& GetProto(const NYdb::NView::TDescribeViewResult& desc);
+    static const NYdbProtos::Type& GetProto(const TType& type);
+    static const NYdbProtos::Value& GetProto(const TValue& value);
+    static const NYdbProtos::ResultSet& GetProto(const TResultSet& resultSet);
+    static const ::google::protobuf::Map<TStringType, NYdbProtos::TypedValue>& GetProtoMap(const TParams& params);
+    static ::google::protobuf::Map<TStringType, NYdbProtos::TypedValue>* GetProtoMapPtr(TParams& params);
+    static const NYdbProtos::TableStats::QueryStats& GetProto(const NTable::TQueryStats& queryStats);
+    static const NYdbProtos::Table::DescribeTableResult& GetProto(const NTable::TTableDescription& tableDescription);
+    static const NYdbProtos::Table::DescribeExternalDataSourceResult& GetProto(const NTable::TExternalDataSourceDescription&);
+    static const NYdbProtos::Table::DescribeExternalTableResult& GetProto(const NTable::TExternalTableDescription&);
+    static const NYdbProtos::Topic::DescribeTopicResult& GetProto(const NYdb::NTopic::TTopicDescription& topicDescription);
+    static const NYdbProtos::Topic::DescribeConsumerResult& GetProto(const NYdb::NTopic::TConsumerDescription& consumerDescription);
+    static const NYdbProtos::Monitoring::SelfCheckResult& GetProto(const NYdb::NMonitoring::TSelfCheckResult& selfCheckResult);
+    static const NYdbProtos::Coordination::DescribeNodeResult& GetProto(const NYdb::NCoordination::TNodeDescription &describeNodeResult);
+    static const NYdbProtos::Replication::DescribeReplicationResult& GetProto(const NYdb::NReplication::TDescribeReplicationResult& desc);
+    static const NYdbProtos::View::DescribeViewResult& GetProto(const NYdb::NView::TDescribeViewResult& desc);
 
-    static NTable::TQueryStats FromProto(const Ydb::TableStats::QueryStats& queryStats);
-    static NTable::TTableDescription FromProto(const Ydb::Table::CreateTableRequest& request);
-    static NTable::TIndexDescription FromProto(const Ydb::Table::TableIndex& tableIndex);
-    static NTable::TIndexDescription FromProto(const Ydb::Table::TableIndexDescription& tableIndexDesc);
+    static NTable::TQueryStats FromProto(const NYdbProtos::TableStats::QueryStats& queryStats);
+    static NTable::TTableDescription FromProto(const NYdbProtos::Table::CreateTableRequest& request);
+    static NTable::TIndexDescription FromProto(const NYdbProtos::Table::TableIndex& tableIndex);
+    static NTable::TIndexDescription FromProto(const NYdbProtos::Table::TableIndexDescription& tableIndexDesc);
 
-    static NTable::TChangefeedDescription FromProto(const Ydb::Table::Changefeed& changefeed);
-    static NTable::TChangefeedDescription FromProto(const Ydb::Table::ChangefeedDescription& changefeed);
+    static NTable::TChangefeedDescription FromProto(const NYdbProtos::Table::Changefeed& changefeed);
+    static NTable::TChangefeedDescription FromProto(const NYdbProtos::Table::ChangefeedDescription& changefeed);
 
-    static Ydb::Table::ValueSinceUnixEpochModeSettings::Unit GetProto(NTable::TValueSinceUnixEpochModeSettings::EUnit value);
-    static NTable::TValueSinceUnixEpochModeSettings::EUnit FromProto(Ydb::Table::ValueSinceUnixEpochModeSettings::Unit value);
+    static NYdbProtos::Table::ValueSinceUnixEpochModeSettings::Unit GetProto(NTable::TValueSinceUnixEpochModeSettings::EUnit value);
+    static NTable::TValueSinceUnixEpochModeSettings::EUnit FromProto(NYdbProtos::Table::ValueSinceUnixEpochModeSettings::Unit value);
 
-    static Ydb::Topic::MeteringMode GetProto(NTopic::EMeteringMode mode);
-    static NTopic::EMeteringMode FromProto(Ydb::Topic::MeteringMode mode);
+    static NYdbProtos::Topic::MeteringMode GetProto(NTopic::EMeteringMode mode);
+    static NTopic::EMeteringMode FromProto(NYdbProtos::Topic::MeteringMode mode);
 
     // exports & imports
     template <typename TProtoSettings> static typename TProtoSettings::Scheme GetProto(ES3Scheme value);
     template <typename TProtoSettings> static ES3Scheme FromProto(typename TProtoSettings::Scheme value);
-    static Ydb::Export::ExportToS3Settings::StorageClass GetProto(NExport::TExportToS3Settings::EStorageClass value);
-    static NExport::TExportToS3Settings::EStorageClass FromProto(Ydb::Export::ExportToS3Settings::StorageClass value);
-    static NExport::EExportProgress FromProto(Ydb::Export::ExportProgress::Progress value);
-    static NImport::EImportProgress FromProto(Ydb::Import::ImportProgress::Progress value);
+    static NYdbProtos::Export::ExportToS3Settings::StorageClass GetProto(NExport::TExportToS3Settings::EStorageClass value);
+    static NExport::TExportToS3Settings::EStorageClass FromProto(NYdbProtos::Export::ExportToS3Settings::StorageClass value);
+    static NExport::EExportProgress FromProto(NYdbProtos::Export::ExportProgress::Progress value);
+    static NImport::EImportProgress FromProto(NYdbProtos::Import::ImportProgress::Progress value);
 };
 
 } // namespace NYdb

--- a/ydb/public/sdk/cpp/include/ydb-cpp-sdk/client/query/query.h
+++ b/ydb/public/sdk/cpp/include/ydb-cpp-sdk/client/query/query.h
@@ -142,7 +142,7 @@ public:
     };
 
     using TOperation::TOperation;
-    TScriptExecutionOperation(TStatus&& status, Ydb::Operations::Operation&& operation);
+    TScriptExecutionOperation(TStatus&& status, NYdbProtos::Operations::Operation&& operation);
 
     const TMetadata& Metadata() const {
         return Metadata_;

--- a/ydb/public/sdk/cpp/include/ydb-cpp-sdk/client/query/stats.h
+++ b/ydb/public/sdk/cpp/include/ydb-cpp-sdk/client/query/stats.h
@@ -1,13 +1,17 @@
 #pragma once
 
+#include <ydb-cpp-sdk/type_switcher.h>
+
 #include <util/datetime/base.h>
 
 #include <memory>
 #include <optional>
 #include <string>
 
-namespace Ydb::TableStats {
+YDB_PROTOS_NAMESPACE {
+namespace TableStats {
     class QueryStats;
+}
 }
 
 namespace NYdb::inline V3 {
@@ -22,8 +26,8 @@ class TExecStats {
 public:
     TExecStats() = default;
 
-    explicit TExecStats(Ydb::TableStats::QueryStats&& proto);
-    explicit TExecStats(const Ydb::TableStats::QueryStats& proto);
+    explicit TExecStats(NYdbProtos::TableStats::QueryStats&& proto);
+    explicit TExecStats(const NYdbProtos::TableStats::QueryStats& proto);
 
     std::string ToString(bool withPlan = false) const;
 
@@ -35,7 +39,7 @@ public:
     TDuration GetTotalCpuTime() const;
 
 private:
-    const Ydb::TableStats::QueryStats& GetProto() const;
+    const NYdbProtos::TableStats::QueryStats& GetProto() const;
 
 private:
     class TImpl;

--- a/ydb/public/sdk/cpp/include/ydb-cpp-sdk/client/rate_limiter/rate_limiter.h
+++ b/ydb/public/sdk/cpp/include/ydb-cpp-sdk/client/rate_limiter/rate_limiter.h
@@ -1,19 +1,22 @@
 #pragma once
 
 #include <ydb-cpp-sdk/client/driver/driver.h>
+#include <ydb-cpp-sdk/type_switcher.h>
 
 #include <chrono>
 #include <unordered_map>
 #include <variant>
 
-namespace Ydb::RateLimiter {
+YDB_PROTOS_NAMESPACE {
+namespace RateLimiter {
     class CreateResourceRequest;
     class DescribeResourceResult;
     class HierarchicalDrrSettings;
     class ReplicatedBucketSettings;
     class MeteringConfig;
     class MeteringConfig_Metric;
-} // namespace Ydb::RateLimiter
+} // namespace RateLimiter
+}
 
 namespace NYdb::inline V3::NRateLimiter {
 
@@ -21,9 +24,9 @@ struct TReplicatedBucketSettings {
     using TSelf = TReplicatedBucketSettings;
 
     TReplicatedBucketSettings() = default;
-    TReplicatedBucketSettings(const Ydb::RateLimiter::ReplicatedBucketSettings&);
+    TReplicatedBucketSettings(const NYdbProtos::RateLimiter::ReplicatedBucketSettings&);
 
-    void SerializeTo(Ydb::RateLimiter::ReplicatedBucketSettings&) const;
+    void SerializeTo(NYdbProtos::RateLimiter::ReplicatedBucketSettings&) const;
 
     // Interval between syncs from kesus and between consumption reports.
     // Default value equals 5000 ms and not inherited.
@@ -39,10 +42,10 @@ public:
     EBehavior GetBehavior() const;
 
     TLeafBehavior(const TReplicatedBucketSettings&);
-    TLeafBehavior(const Ydb::RateLimiter::ReplicatedBucketSettings&);
+    TLeafBehavior(const NYdbProtos::RateLimiter::ReplicatedBucketSettings&);
     const TReplicatedBucketSettings& GetReplicatedBucket() const;
 
-    void SerializeTo(Ydb::RateLimiter::HierarchicalDrrSettings&) const;
+    void SerializeTo(NYdbProtos::RateLimiter::HierarchicalDrrSettings&) const;
 
 private:
     std::variant<TReplicatedBucketSettings> BehaviorSettings_;
@@ -54,9 +57,9 @@ struct THierarchicalDrrSettings {
     using TSelf = TDerived;
 
     THierarchicalDrrSettings() = default;
-    THierarchicalDrrSettings(const Ydb::RateLimiter::HierarchicalDrrSettings&);
+    THierarchicalDrrSettings(const NYdbProtos::RateLimiter::HierarchicalDrrSettings&);
 
-    void SerializeTo(Ydb::RateLimiter::HierarchicalDrrSettings&) const;
+    void SerializeTo(NYdbProtos::RateLimiter::HierarchicalDrrSettings&) const;
 
     // Resource consumption speed limit.
     // Value is required for root resource.
@@ -101,9 +104,9 @@ struct TMetric {
     using TLabels = std::unordered_map<std::string, std::string>;
 
     TMetric() = default;
-    TMetric(const Ydb::RateLimiter::MeteringConfig_Metric&);
+    TMetric(const NYdbProtos::RateLimiter::MeteringConfig_Metric&);
 
-    void SerializeTo(Ydb::RateLimiter::MeteringConfig_Metric&) const;
+    void SerializeTo(NYdbProtos::RateLimiter::MeteringConfig_Metric&) const;
 
     // Send this metric to billing.
     // Default value is false (not inherited).
@@ -124,9 +127,9 @@ struct TMeteringConfig {
     using TSelf = TMeteringConfig;
 
     TMeteringConfig() = default;
-    TMeteringConfig(const Ydb::RateLimiter::MeteringConfig&);
+    TMeteringConfig(const NYdbProtos::RateLimiter::MeteringConfig&);
 
-    void SerializeTo(Ydb::RateLimiter::MeteringConfig&) const;
+    void SerializeTo(NYdbProtos::RateLimiter::MeteringConfig&) const;
 
     // Meter consumed resources and send billing metrics.
     FLUENT_SETTING_DEFAULT(bool, Enabled, false);
@@ -177,7 +180,7 @@ struct TCreateResourceSettings
     , public THierarchicalDrrSettings<TCreateResourceSettings>
 {
     TCreateResourceSettings() = default;
-    TCreateResourceSettings(const Ydb::RateLimiter::CreateResourceRequest&);
+    TCreateResourceSettings(const NYdbProtos::RateLimiter::CreateResourceRequest&);
 
     FLUENT_SETTING_OPTIONAL(TMeteringConfig, MeteringConfig);
 };
@@ -232,7 +235,7 @@ struct TDescribeResourceResult : public TStatus {
     // Note for YDB developers: THierarchicalDrrProps wrapper class exists for compatibility with older client code.
     // Newer code should use the THierarchicalDrrSettings class directly.
     struct THierarchicalDrrProps : public THierarchicalDrrSettings<THierarchicalDrrProps> {
-        THierarchicalDrrProps(const Ydb::RateLimiter::HierarchicalDrrSettings&);
+        THierarchicalDrrProps(const NYdbProtos::RateLimiter::HierarchicalDrrSettings&);
 
         // Resource consumption speed limit.
         std::optional<double> GetMaxUnitsPerSecond() const {
@@ -264,7 +267,7 @@ struct TDescribeResourceResult : public TStatus {
         }
     };
 
-    TDescribeResourceResult(TStatus status, const Ydb::RateLimiter::DescribeResourceResult& result);
+    TDescribeResourceResult(TStatus status, const NYdbProtos::RateLimiter::DescribeResourceResult& result);
 
     // Path of resource inside a coordination node.
     const std::string& GetResourcePath() const {

--- a/ydb/public/sdk/cpp/include/ydb-cpp-sdk/client/result/result.h
+++ b/ydb/public/sdk/cpp/include/ydb-cpp-sdk/client/result/result.h
@@ -3,10 +3,11 @@
 #include "fwd.h"
 
 #include <ydb-cpp-sdk/client/value/value.h>
+#include <ydb-cpp-sdk/type_switcher.h>
 
 #include <string>
 
-namespace Ydb {
+YDB_PROTOS_NAMESPACE {
     class ResultSet;
 }
 
@@ -34,8 +35,8 @@ class TResultSet {
     friend class TResultSetParser;
     friend class NYdb::V3::TProtoAccessor;
 public:
-    TResultSet(const Ydb::ResultSet& proto);
-    TResultSet(Ydb::ResultSet&& proto);
+    TResultSet(const NYdbProtos::ResultSet& proto);
+    TResultSet(NYdbProtos::ResultSet&& proto);
 
     //! Returns number of columns
     size_t ColumnsCount() const;
@@ -50,7 +51,7 @@ public:
     const std::vector<TColumn>& GetColumnsMeta() const;
 
 private:
-    const Ydb::ResultSet& GetProto() const;
+    const NYdbProtos::ResultSet& GetProto() const;
 
 private:
     class TImpl;

--- a/ydb/public/sdk/cpp/include/ydb-cpp-sdk/client/scheme/scheme.h
+++ b/ydb/public/sdk/cpp/include/ydb-cpp-sdk/client/scheme/scheme.h
@@ -1,8 +1,9 @@
 #pragma once
 
 #include <ydb-cpp-sdk/client/driver/driver.h>
+#include <ydb-cpp-sdk/type_switcher.h>
 
-namespace Ydb {
+YDB_PROTOS_NAMESPACE {
     class VirtualTimestamp;
     namespace Scheme {
         class Entry;
@@ -24,12 +25,12 @@ struct TPermissions {
         : Subject(subject)
         , PermissionNames(names)
     {}
-    TPermissions(const ::Ydb::Scheme::Permissions& proto);
+    TPermissions(const ::NYdbProtos::Scheme::Permissions& proto);
 
     std::string Subject;
     std::vector<std::string> PermissionNames;
 
-    void SerializeTo(::Ydb::Scheme::Permissions& proto) const;
+    void SerializeTo(::NYdbProtos::Scheme::Permissions& proto) const;
 };
 
 enum class ESchemeEntryType : i32 {
@@ -58,7 +59,7 @@ struct TVirtualTimestamp {
 
     TVirtualTimestamp() = default;
     TVirtualTimestamp(uint64_t planStep, uint64_t txId);
-    TVirtualTimestamp(const ::Ydb::VirtualTimestamp& proto);
+    TVirtualTimestamp(const ::NYdbProtos::VirtualTimestamp& proto);
 
     std::string ToString() const;
     void Out(IOutputStream& out) const;
@@ -81,12 +82,12 @@ struct TSchemeEntry {
     TVirtualTimestamp CreatedAt;
 
     TSchemeEntry() = default;
-    TSchemeEntry(const ::Ydb::Scheme::Entry& proto);
+    TSchemeEntry(const ::NYdbProtos::Scheme::Entry& proto);
 
     void Out(IOutputStream& out) const;
 
     // Fills ModifyPermissionsRequest proto from this entry
-    void SerializeTo(::Ydb::Scheme::ModifyPermissionsRequest& request) const;
+    void SerializeTo(::NYdbProtos::Scheme::ModifyPermissionsRequest& request) const;
 };
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -155,7 +156,7 @@ struct TModifyPermissionsSettings : public TOperationRequestSettings<TModifyPerm
     }
 
     TModifyPermissionsSettings() = default;
-    explicit TModifyPermissionsSettings(const ::Ydb::Scheme::ModifyPermissionsRequest& request);
+    explicit TModifyPermissionsSettings(const ::NYdbProtos::Scheme::ModifyPermissionsRequest& request);
 };
 
 class TSchemeClient {

--- a/ydb/public/sdk/cpp/include/ydb-cpp-sdk/client/table/query_stats/stats.h
+++ b/ydb/public/sdk/cpp/include/ydb-cpp-sdk/client/table/query_stats/stats.h
@@ -4,7 +4,7 @@
 
 class TDuration;
 
-namespace Ydb {
+YDB_PROTOS_NAMESPACE {
     namespace TableStats {
         class QueryStats;
     }

--- a/ydb/public/sdk/cpp/include/ydb-cpp-sdk/client/table/table.h
+++ b/ydb/public/sdk/cpp/include/ydb-cpp-sdk/client/table/table.h
@@ -14,7 +14,7 @@
 
 #include <variant>
 
-namespace Ydb {
+YDB_PROTOS_NAMESPACE {
 namespace Table {
 
 class StorageSettings;
@@ -39,7 +39,7 @@ class ValueSinceUnixEpochModeSettings;
 class EvictionToExternalStorageSettings;
 
 } // namespace Table
-} // namespace Ydb
+}
 
 namespace NYdb::inline V3 {
 
@@ -174,9 +174,9 @@ struct TAlterTableColumn {
 class TPartitioningSettings {
 public:
     TPartitioningSettings();
-    explicit TPartitioningSettings(const Ydb::Table::PartitioningSettings& proto);
+    explicit TPartitioningSettings(const NYdbProtos::Table::PartitioningSettings& proto);
 
-    const Ydb::Table::PartitioningSettings& GetProto() const;
+    const NYdbProtos::Table::PartitioningSettings& GetProto() const;
 
     std::optional<bool> GetPartitioningBySize() const;
     std::optional<bool> GetPartitioningByLoad() const;
@@ -194,9 +194,9 @@ struct TExplicitPartitions {
 
     FLUENT_SETTING_VECTOR(TValue, SplitPoints);
 
-    static TExplicitPartitions FromProto(const Ydb::Table::ExplicitPartitions& proto);
+    static TExplicitPartitions FromProto(const NYdbProtos::Table::ExplicitPartitions& proto);
 
-    void SerializeTo(Ydb::Table::ExplicitPartitions& proto) const;
+    void SerializeTo(NYdbProtos::Table::ExplicitPartitions& proto) const;
 };
 
 struct TGlobalIndexSettings {
@@ -205,9 +205,9 @@ struct TGlobalIndexSettings {
     TPartitioningSettings PartitioningSettings;
     TUniformOrExplicitPartitions Partitions;
 
-    static TGlobalIndexSettings FromProto(const Ydb::Table::GlobalIndexSettings& proto);
+    static TGlobalIndexSettings FromProto(const NYdbProtos::Table::GlobalIndexSettings& proto);
 
-    void SerializeTo(Ydb::Table::GlobalIndexSettings& proto) const;
+    void SerializeTo(NYdbProtos::Table::GlobalIndexSettings& proto) const;
 };
 
 struct TVectorIndexSettings {
@@ -233,9 +233,9 @@ public:
     EVectorType VectorType = EVectorType::Unspecified;
     uint32_t VectorDimension = 0;
 
-    static TVectorIndexSettings FromProto(const Ydb::Table::VectorIndexSettings& proto);
+    static TVectorIndexSettings FromProto(const NYdbProtos::Table::VectorIndexSettings& proto);
 
-    void SerializeTo(Ydb::Table::VectorIndexSettings& settings) const;
+    void SerializeTo(NYdbProtos::Table::VectorIndexSettings& settings) const;
 
     void Out(IOutputStream &o) const;
 };
@@ -263,9 +263,9 @@ public:
     uint32_t Clusters = 0;
     uint32_t Levels = 0;
 
-    static TKMeansTreeSettings FromProto(const Ydb::Table::KMeansTreeSettings& proto);
+    static TKMeansTreeSettings FromProto(const NYdbProtos::Table::KMeansTreeSettings& proto);
 
-    void SerializeTo(Ydb::Table::KMeansTreeSettings& settings) const;
+    void SerializeTo(NYdbProtos::Table::KMeansTreeSettings& settings) const;
 
     void Out(IOutputStream &o) const;
 };
@@ -298,13 +298,13 @@ public:
     const std::variant<std::monostate, TKMeansTreeSettings>& GetIndexSettings() const;
     uint64_t GetSizeBytes() const;
 
-    void SerializeTo(Ydb::Table::TableIndex& proto) const;
+    void SerializeTo(NYdbProtos::Table::TableIndex& proto) const;
     std::string ToString() const;
     void Out(IOutputStream& o) const;
 
 private:
-    explicit TIndexDescription(const Ydb::Table::TableIndex& tableIndex);
-    explicit TIndexDescription(const Ydb::Table::TableIndexDescription& tableIndexDesc);
+    explicit TIndexDescription(const NYdbProtos::Table::TableIndex& tableIndex);
+    explicit TIndexDescription(const NYdbProtos::Table::TableIndexDescription& tableIndexDesc);
 
     template <typename TProto>
     static TIndexDescription FromProto(const TProto& proto);
@@ -331,7 +331,7 @@ bool operator!=(const TIndexDescription& lhs, const TIndexDescription& rhs);
 class TBuildIndexOperation : public TOperation {
 public:
     using TOperation::TOperation;
-    TBuildIndexOperation(TStatus&& status, Ydb::Operations::Operation&& operation);
+    TBuildIndexOperation(TStatus&& status, NYdbProtos::Operations::Operation&& operation);
 
     struct TMetadata {
         EBuildIndexState State;
@@ -397,8 +397,8 @@ public:
     const std::string& GetAwsRegion() const;
     const std::optional<TInitialScanProgress>& GetInitialScanProgress() const;
 
-    void SerializeTo(Ydb::Table::Changefeed& proto) const;
-    void SerializeTo(Ydb::Table::ChangefeedDescription& proto) const;
+    void SerializeTo(NYdbProtos::Table::Changefeed& proto) const;
+    void SerializeTo(NYdbProtos::Table::ChangefeedDescription& proto) const;
     std::string ToString() const;
     void Out(IOutputStream& o) const;
 
@@ -406,8 +406,8 @@ public:
     void SerializeCommonFields(TProto& proto) const;
 
 private:
-    explicit TChangefeedDescription(const Ydb::Table::Changefeed& proto);
-    explicit TChangefeedDescription(const Ydb::Table::ChangefeedDescription& proto);
+    explicit TChangefeedDescription(const NYdbProtos::Table::Changefeed& proto);
+    explicit TChangefeedDescription(const NYdbProtos::Table::ChangefeedDescription& proto);
 
     template <typename TProto>
     static TChangefeedDescription FromProto(const TProto& proto);
@@ -440,7 +440,7 @@ struct TPartitionStats {
 class TDateTypeColumnModeSettings {
 public:
     explicit TDateTypeColumnModeSettings(const std::string& columnName, const TDuration& applyAfter);
-    void SerializeTo(Ydb::Table::DateTypeColumnModeSettings& proto) const;
+    void SerializeTo(NYdbProtos::Table::DateTypeColumnModeSettings& proto) const;
 
     const std::string& GetColumnName() const;
     const TDuration& GetExpireAfter() const;
@@ -463,7 +463,7 @@ public:
 
 public:
     explicit TValueSinceUnixEpochModeSettings(const std::string& columnName, EUnit columnUnit, const TDuration& applyAfter);
-    void SerializeTo(Ydb::Table::ValueSinceUnixEpochModeSettings& proto) const;
+    void SerializeTo(NYdbProtos::Table::ValueSinceUnixEpochModeSettings& proto) const;
 
     const std::string& GetColumnName() const;
     EUnit GetColumnUnit() const;
@@ -483,7 +483,7 @@ class TTtlDeleteAction {};
 class TTtlEvictToExternalStorageAction {
 public:
     TTtlEvictToExternalStorageAction(const std::string& storageName);
-    void SerializeTo(Ydb::Table::EvictionToExternalStorageSettings& proto) const;
+    void SerializeTo(NYdbProtos::Table::EvictionToExternalStorageSettings& proto) const;
 
     std::string GetStorage() const;
 
@@ -506,8 +506,8 @@ public:
 public:
     explicit TTtlTierSettings(const TExpression& expression, const TAction& action);
 
-    static std::optional<TTtlTierSettings> FromProto(const Ydb::Table::TtlTier& tier);
-    void SerializeTo(Ydb::Table::TtlTier& proto) const;
+    static std::optional<TTtlTierSettings> FromProto(const NYdbProtos::Table::TtlTier& tier);
+    void SerializeTo(NYdbProtos::Table::TtlTier& proto) const;
 
     const TExpression& GetExpression() const;
     const TAction& GetAction() const;
@@ -537,14 +537,14 @@ public:
 
     explicit TTtlSettings(const std::string& columnName, const TDuration& expireAfter);
     const TDateTypeColumnModeSettings& GetDateTypeColumn() const;
-    explicit TTtlSettings(const Ydb::Table::DateTypeColumnModeSettings& mode, uint32_t runIntervalSeconds);
+    explicit TTtlSettings(const NYdbProtos::Table::DateTypeColumnModeSettings& mode, uint32_t runIntervalSeconds);
 
     explicit TTtlSettings(const std::string& columnName, EUnit columnUnit, const TDuration& expireAfter);
     const TValueSinceUnixEpochModeSettings& GetValueSinceUnixEpoch() const;
-    explicit TTtlSettings(const Ydb::Table::ValueSinceUnixEpochModeSettings& mode, uint32_t runIntervalSeconds);
+    explicit TTtlSettings(const NYdbProtos::Table::ValueSinceUnixEpochModeSettings& mode, uint32_t runIntervalSeconds);
 
-    static std::optional<TTtlSettings> FromProto(const Ydb::Table::TtlSettings& proto);
-    void SerializeTo(Ydb::Table::TtlSettings& proto) const;
+    static std::optional<TTtlSettings> FromProto(const NYdbProtos::Table::TtlSettings& proto);
+    void SerializeTo(NYdbProtos::Table::TtlSettings& proto) const;
     EMode GetMode() const;
 
     TTtlSettings& SetRunInterval(const TDuration& value);
@@ -598,9 +598,9 @@ private:
 class TStorageSettings {
 public:
     TStorageSettings();
-    explicit TStorageSettings(const Ydb::Table::StorageSettings& proto);
+    explicit TStorageSettings(const NYdbProtos::Table::StorageSettings& proto);
 
-    const Ydb::Table::StorageSettings& GetProto() const;
+    const NYdbProtos::Table::StorageSettings& GetProto() const;
 
     std::optional<std::string> GetTabletCommitLog0() const;
     std::optional<std::string> GetTabletCommitLog1() const;
@@ -615,9 +615,9 @@ private:
 //! Represents column family description
 class TColumnFamilyDescription {
 public:
-    explicit TColumnFamilyDescription(const Ydb::Table::ColumnFamily& desc);
+    explicit TColumnFamilyDescription(const NYdbProtos::Table::ColumnFamily& desc);
 
-    const Ydb::Table::ColumnFamily& GetProto() const;
+    const NYdbProtos::Table::ColumnFamily& GetProto() const;
 
     const std::string& GetName() const;
     std::optional<std::string> GetData() const;
@@ -660,7 +660,7 @@ class TTableDescription {
     using EUnit = TValueSinceUnixEpochModeSettings::EUnit;
 
 public:
-    TTableDescription(Ydb::Table::DescribeTableResult&& desc, const TDescribeTableSettings& describeSettings);
+    TTableDescription(NYdbProtos::Table::DescribeTableResult&& desc, const TDescribeTableSettings& describeSettings);
 
     const std::vector<std::string>& GetPrimaryKeyColumns() const;
     // DEPRECATED: use GetTableColumns()
@@ -717,13 +717,13 @@ public:
     std::optional<TReadReplicasSettings> GetReadReplicasSettings() const;
 
     // Fills CreateTableRequest proto from this description
-    void SerializeTo(Ydb::Table::CreateTableRequest& request) const;
+    void SerializeTo(NYdbProtos::Table::CreateTableRequest& request) const;
 
 private:
     TTableDescription();
-    explicit TTableDescription(const Ydb::Table::CreateTableRequest& request);
+    explicit TTableDescription(const NYdbProtos::Table::CreateTableRequest& request);
 
-    void AddColumn(const std::string& name, const Ydb::Type& type, const std::string& family, std::optional<bool> notNull, std::optional<TSequenceDescription> sequenceDescription);
+    void AddColumn(const std::string& name, const NYdbProtos::Type& type, const std::string& family, std::optional<bool> notNull, std::optional<TSequenceDescription> sequenceDescription);
     void SetPrimaryKeyColumns(const std::vector<std::string>& primaryKeyColumns);
 
     // common
@@ -762,7 +762,7 @@ private:
     void SetKeyBloomFilter(bool enabled);
     void SetReadReplicasSettings(TReadReplicasSettings::EMode mode, uint64_t readReplicasCount);
     void SetStoreType(EStoreType type);
-    const Ydb::Table::DescribeTableResult& GetProto() const;
+    const NYdbProtos::Table::DescribeTableResult& GetProto() const;
 
     class TImpl;
     std::shared_ptr<TImpl> Impl_;
@@ -1150,7 +1150,7 @@ struct TClientSettings : public TCommonClientSettingsBase<TClientSettings> {
 
 struct TBulkUpsertSettings : public TOperationRequestSettings<TBulkUpsertSettings> {
     // Format setting proto serialized into string. If not set format defaults are used.
-    // I.e. it's Ydb.Table.CsvSettings for CSV.
+    // I.e. it's NYdbProtos.Table.CsvSettings for CSV.
     FLUENT_SETTING_DEFAULT(std::string, FormatSettings, "");
 };
 
@@ -1968,7 +1968,7 @@ public:
 private:
     TDataQuery(const TSession& session, const std::string& text, const std::string& id);
     TDataQuery(const TSession& session, const std::string& text, const std::string& id,
-        const ::google::protobuf::Map<TStringType, Ydb::Type>& types);
+        const ::google::protobuf::Map<TStringType, NYdbProtos::Type>& types);
 
     class TImpl;
     std::shared_ptr<TImpl> Impl_;
@@ -2009,7 +2009,7 @@ private:
 //! Represents result of DescribeTable call
 class TDescribeTableResult : public NScheme::TDescribePathResult {
 public:
-    TDescribeTableResult(TStatus&& status, Ydb::Table::DescribeTableResult&& desc,
+    TDescribeTableResult(TStatus&& status, NYdbProtos::Table::DescribeTableResult&& desc,
         const TDescribeTableSettings& describeSettings);
 
     TTableDescription GetTableDescription() const;
@@ -2215,14 +2215,14 @@ class TReadRowsResult : public TStatus {
 
 class TExternalDataSourceDescription {
 public:
-    TExternalDataSourceDescription(Ydb::Table::DescribeExternalDataSourceResult&& description);
+    TExternalDataSourceDescription(NYdbProtos::Table::DescribeExternalDataSourceResult&& description);
 
 private:
     class TImpl;
     std::shared_ptr<TImpl> Impl_;
 
     friend class NYdb::V3::TProtoAccessor;
-    const Ydb::Table::DescribeExternalDataSourceResult& GetProto() const;
+    const NYdbProtos::Table::DescribeExternalDataSourceResult& GetProto() const;
 };
 
 //! Represents the result of a DescribeExternalDataSource call.
@@ -2230,7 +2230,7 @@ class TDescribeExternalDataSourceResult : public NScheme::TDescribePathResult {
 public:
     TDescribeExternalDataSourceResult(
         TStatus&& status,
-        Ydb::Table::DescribeExternalDataSourceResult&& description
+        NYdbProtos::Table::DescribeExternalDataSourceResult&& description
     );
 
     TExternalDataSourceDescription GetExternalDataSourceDescription() const;
@@ -2241,14 +2241,14 @@ private:
 
 class TExternalTableDescription {
 public:
-    TExternalTableDescription(Ydb::Table::DescribeExternalTableResult&& description);
+    TExternalTableDescription(NYdbProtos::Table::DescribeExternalTableResult&& description);
 
 private:
     class TImpl;
     std::shared_ptr<TImpl> Impl_;
 
     friend class NYdb::V3::TProtoAccessor;
-    const Ydb::Table::DescribeExternalTableResult& GetProto() const;
+    const NYdbProtos::Table::DescribeExternalTableResult& GetProto() const;
 };
 
 //! Represents the result of a DescribeExternalTable call.
@@ -2256,7 +2256,7 @@ class TDescribeExternalTableResult : public NScheme::TDescribePathResult {
 public:
     TDescribeExternalTableResult(
         TStatus&& status,
-        Ydb::Table::DescribeExternalTableResult&& description
+        NYdbProtos::Table::DescribeExternalTableResult&& description
     );
 
     TExternalTableDescription GetExternalTableDescription() const;

--- a/ydb/public/sdk/cpp/include/ydb-cpp-sdk/client/topic/control_plane.h
+++ b/ydb/public/sdk/cpp/include/ydb-cpp-sdk/client/topic/control_plane.h
@@ -38,7 +38,7 @@ enum class EAutoPartitioningStrategy: uint32_t {
 
 class TConsumer {
 public:
-    TConsumer(const Ydb::Topic::Consumer&);
+    TConsumer(const NYdbProtos::Topic::Consumer&);
 
     const std::string& GetConsumerName() const;
     bool GetImportant() const;
@@ -58,7 +58,7 @@ private:
 
 class TTopicStats {
 public:
-    TTopicStats(const Ydb::Topic::DescribeTopicResult::TopicStats& topicStats);
+    TTopicStats(const NYdbProtos::Topic::DescribeTopicResult::TopicStats& topicStats);
 
     uint64_t GetStoreSizeBytes() const;
     TDuration GetMaxWriteTimeLag() const;
@@ -79,7 +79,7 @@ private:
 
 class TPartitionStats {
 public:
-    TPartitionStats(const Ydb::Topic::PartitionStats& partitionStats);
+    TPartitionStats(const NYdbProtos::Topic::PartitionStats& partitionStats);
 
     uint64_t GetStartOffset() const;
     uint64_t GetEndOffset() const;
@@ -103,7 +103,7 @@ private:
 
 class TPartitionConsumerStats {
 public:
-    TPartitionConsumerStats(const Ydb::Topic::DescribeConsumerResult::PartitionConsumerStats& partitionStats);
+    TPartitionConsumerStats(const NYdbProtos::Topic::DescribeConsumerResult::PartitionConsumerStats& partitionStats);
     uint64_t GetCommittedOffset() const;
     uint64_t GetLastReadOffset() const;
     std::string GetReaderName() const;
@@ -125,7 +125,7 @@ private:
 // Topic partition location
 class TPartitionLocation {
 public:
-    TPartitionLocation(const Ydb::Topic::PartitionLocation& partitionLocation);
+    TPartitionLocation(const NYdbProtos::Topic::PartitionLocation& partitionLocation);
     int32_t GetNodeId() const;
     int64_t GetGeneration() const;
 
@@ -139,8 +139,8 @@ private:
 
 class TPartitionInfo {
 public:
-    TPartitionInfo(const Ydb::Topic::DescribeTopicResult::PartitionInfo& partitionInfo);
-    TPartitionInfo(const Ydb::Topic::DescribeConsumerResult::PartitionInfo& partitionInfo);
+    TPartitionInfo(const NYdbProtos::Topic::DescribeTopicResult::PartitionInfo& partitionInfo);
+    TPartitionInfo(const NYdbProtos::Topic::DescribeConsumerResult::PartitionInfo& partitionInfo);
 
     uint64_t GetPartitionId() const;
     bool GetActive() const;
@@ -180,14 +180,14 @@ public:
         , DownUtilizationPercent_(0)
         , UpUtilizationPercent_(0) {
     }
-    TAutoPartitioningSettings(const Ydb::Topic::AutoPartitioningSettings& settings);
+    TAutoPartitioningSettings(const NYdbProtos::Topic::AutoPartitioningSettings& settings);
     TAutoPartitioningSettings(EAutoPartitioningStrategy strategy, TDuration stabilizationWindow, ui64 downUtilizationPercent, ui64 upUtilizationPercent)
         : Strategy_(strategy)
         , StabilizationWindow_(stabilizationWindow)
         , DownUtilizationPercent_(downUtilizationPercent)
         , UpUtilizationPercent_(upUtilizationPercent) {}
 
-    void SerializeTo(Ydb::Topic::AutoPartitioningSettings& proto) const;
+    void SerializeTo(NYdbProtos::Topic::AutoPartitioningSettings& proto) const;
 
     EAutoPartitioningStrategy GetStrategy() const;
     TDuration GetStabilizationWindow() const;
@@ -221,7 +221,7 @@ class TPartitioningSettings {
     friend struct TPartitioningSettingsBuilder;
 public:
     TPartitioningSettings() : MinActivePartitions_(0), MaxActivePartitions_(0), PartitionCountLimit_(0), AutoPartitioningSettings_(){}
-    TPartitioningSettings(const Ydb::Topic::PartitioningSettings& settings);
+    TPartitioningSettings(const NYdbProtos::Topic::PartitioningSettings& settings);
     TPartitioningSettings(uint64_t minActivePartitions, uint64_t maxActivePartitions, TAutoPartitioningSettings autoPartitioning = {})
         : MinActivePartitions_(minActivePartitions)
         , MaxActivePartitions_(maxActivePartitions)
@@ -230,7 +230,7 @@ public:
     {
     }
 
-    void SerializeTo(Ydb::Topic::PartitioningSettings& proto) const;
+    void SerializeTo(NYdbProtos::Topic::PartitioningSettings& proto) const;
 
     uint64_t GetMinActivePartitions() const;
     uint64_t GetMaxActivePartitions() const;
@@ -270,7 +270,7 @@ class TTopicDescription {
     friend class NYdb::V3::TProtoAccessor;
 
 public:
-    TTopicDescription(Ydb::Topic::DescribeTopicResult&& desc);
+    TTopicDescription(NYdbProtos::Topic::DescribeTopicResult&& desc);
 
     const std::string& GetOwner() const;
 
@@ -304,12 +304,12 @@ public:
 
     const TTopicStats& GetTopicStats() const;
 
-    void SerializeTo(Ydb::Topic::CreateTopicRequest& request) const;
+    void SerializeTo(NYdbProtos::Topic::CreateTopicRequest& request) const;
 private:
 
-    const Ydb::Topic::DescribeTopicResult& GetProto() const;
+    const NYdbProtos::Topic::DescribeTopicResult& GetProto() const;
 
-    const Ydb::Topic::DescribeTopicResult Proto_;
+    const NYdbProtos::Topic::DescribeTopicResult Proto_;
     std::vector<TPartitionInfo> Partitions_;
     std::vector<ECodec> SupportedCodecs_;
     TPartitioningSettings PartitioningSettings_;
@@ -333,7 +333,7 @@ class TConsumerDescription {
     friend class NYdb::V3::TProtoAccessor;
 
 public:
-    TConsumerDescription(Ydb::Topic::DescribeConsumerResult&& desc);
+    TConsumerDescription(NYdbProtos::Topic::DescribeConsumerResult&& desc);
 
     const std::vector<TPartitionInfo>& GetPartitions() const;
 
@@ -341,10 +341,10 @@ public:
 
 private:
 
-    const Ydb::Topic::DescribeConsumerResult& GetProto() const;
+    const NYdbProtos::Topic::DescribeConsumerResult& GetProto() const;
 
 
-    const Ydb::Topic::DescribeConsumerResult Proto_;
+    const NYdbProtos::Topic::DescribeConsumerResult Proto_;
     std::vector<TPartitionInfo> Partitions_;
     TConsumer Consumer_;
 };
@@ -353,13 +353,13 @@ class TPartitionDescription {
     friend class NYdb::V3::TProtoAccessor;
 
 public:
-    TPartitionDescription(Ydb::Topic::DescribePartitionResult&& desc);
+    TPartitionDescription(NYdbProtos::Topic::DescribePartitionResult&& desc);
 
     const TPartitionInfo& GetPartition() const;
 private:
-    const Ydb::Topic::DescribePartitionResult& GetProto() const;
+    const NYdbProtos::Topic::DescribePartitionResult& GetProto() const;
 
-    const Ydb::Topic::DescribePartitionResult Proto_;
+    const NYdbProtos::Topic::DescribePartitionResult Proto_;
     TPartitionInfo Partition_;
 };
 
@@ -367,7 +367,7 @@ private:
 struct TDescribeTopicResult : public TStatus {
     friend class NYdb::V3::TProtoAccessor;
 
-    TDescribeTopicResult(TStatus&& status, Ydb::Topic::DescribeTopicResult&& result);
+    TDescribeTopicResult(TStatus&& status, NYdbProtos::Topic::DescribeTopicResult&& result);
 
     const TTopicDescription& GetTopicDescription() const;
 
@@ -379,7 +379,7 @@ private:
 struct TDescribeConsumerResult : public TStatus {
     friend class NYdb::V3::TProtoAccessor;
 
-    TDescribeConsumerResult(TStatus&& status, Ydb::Topic::DescribeConsumerResult&& result);
+    TDescribeConsumerResult(TStatus&& status, NYdbProtos::Topic::DescribeConsumerResult&& result);
 
     const TConsumerDescription& GetConsumerDescription() const;
 
@@ -391,7 +391,7 @@ private:
 struct TDescribePartitionResult: public TStatus {
     friend class NYdb::V3::TProtoAccessor;
 
-    TDescribePartitionResult(TStatus&& status, Ydb::Topic::DescribePartitionResult&& result);
+    TDescribePartitionResult(TStatus&& status, NYdbProtos::Topic::DescribePartitionResult&& result);
 
     const TPartitionDescription& GetPartitionDescription() const;
 
@@ -443,9 +443,9 @@ struct TConsumerSettings {
 
     TConsumerSettings(TSettings& parent) : Parent_(parent) {}
     TConsumerSettings(TSettings& parent, const std::string& name) : ConsumerName_(name), Parent_(parent) {}
-    TConsumerSettings(TSettings& parent, const Ydb::Topic::Consumer& proto);
+    TConsumerSettings(TSettings& parent, const NYdbProtos::Topic::Consumer& proto);
 
-    void SerializeTo(Ydb::Topic::Consumer& proto) const;
+    void SerializeTo(NYdbProtos::Topic::Consumer& proto) const;
 
     FLUENT_SETTING(std::string, ConsumerName);
     FLUENT_SETTING_DEFAULT(bool, Important, false);
@@ -534,9 +534,9 @@ struct TCreateTopicSettings : public TOperationRequestSettings<TCreateTopicSetti
     using TAttributes = std::map<std::string, std::string>;
 
     TCreateTopicSettings() = default;
-    TCreateTopicSettings(const Ydb::Topic::CreateTopicRequest& proto);
+    TCreateTopicSettings(const NYdbProtos::Topic::CreateTopicRequest& proto);
 
-    void SerializeTo(Ydb::Topic::CreateTopicRequest& proto) const;
+    void SerializeTo(NYdbProtos::Topic::CreateTopicRequest& proto) const;
 
     FLUENT_SETTING(TPartitioningSettings, PartitioningSettings);
 

--- a/ydb/public/sdk/cpp/include/ydb-cpp-sdk/client/types/operation/operation.h
+++ b/ydb/public/sdk/cpp/include/ydb-cpp-sdk/client/types/operation/operation.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <ydb-cpp-sdk/client/types/fwd.h>
+#include <ydb-cpp-sdk/type_switcher.h>
 
 #include <ydb-cpp-sdk/library/operation_id/operation_id.h>
 
@@ -10,13 +11,13 @@
 #include <google/protobuf/timestamp.pb.h>
 #include <google/protobuf/util/json_util.h>
 
-namespace Ydb {
+YDB_PROTOS_NAMESPACE {
 namespace Operations {
 
 class Operation;
 
 } // namespace Operations
-} // namespace Ydb
+}
 
 namespace NYdb::inline V3 {
 
@@ -26,7 +27,7 @@ public:
 
 public:
     TOperation(TStatus&& status);
-    TOperation(TStatus&& status, Ydb::Operations::Operation&& operation);
+    TOperation(TStatus&& status, NYdbProtos::Operations::Operation&& operation);
     virtual ~TOperation() = default;
 
     const TOperationId& Id() const;
@@ -41,7 +42,7 @@ public:
     void Out(IOutputStream& o) const;
 
 protected:
-    const Ydb::Operations::Operation& GetProto() const;
+    const NYdbProtos::Operations::Operation& GetProto() const;
 
 private:
     class TImpl;

--- a/ydb/public/sdk/cpp/include/ydb-cpp-sdk/client/value/value.h
+++ b/ydb/public/sdk/cpp/include/ydb-cpp-sdk/client/value/value.h
@@ -2,12 +2,14 @@
 
 #include "fwd.h"
 
+#include <ydb-cpp-sdk/type_switcher.h>
+
 #include <util/datetime/base.h>
 
 #include <optional>
 #include <memory>
 
-namespace Ydb {
+YDB_PROTOS_NAMESPACE {
     class Type;
     class Value;
 }
@@ -20,14 +22,14 @@ class TResultSetParser;
 class TType {
     friend class TProtoAccessor;
 public:
-    TType(const Ydb::Type& typeProto);
-    TType(Ydb::Type&& typeProto);
+    TType(const NYdbProtos::Type& typeProto);
+    TType(NYdbProtos::Type&& typeProto);
 
     std::string ToString() const;
     void Out(IOutputStream& o) const;
 
-    const Ydb::Type& GetProto() const;
-    Ydb::Type& GetProto();
+    const NYdbProtos::Type& GetProto() const;
+    NYdbProtos::Type& GetProto();
 
 private:
     class TImpl;
@@ -225,7 +227,7 @@ private:
 
 struct TDecimalValue {
     std::string ToString() const;
-    TDecimalValue(const Ydb::Value& decimalValueProto, const TDecimalType& decimalType);
+    TDecimalValue(const NYdbProtos::Value& decimalValueProto, const TDecimalType& decimalType);
     TDecimalValue(const std::string& decimalString, uint8_t precision, uint8_t scale);
 
     TDecimalType DecimalType_;
@@ -240,7 +242,7 @@ struct TPgValue {
         VK_BINARY
     };
 
-    TPgValue(const Ydb::Value& pgValueProto, const TPgType& pgType);
+    TPgValue(const NYdbProtos::Value& pgValueProto, const TPgType& pgType);
     TPgValue(EPgValueKind kind, const std::string& content, const TPgType& pgType);
     bool IsNull() const;
     bool IsText() const;
@@ -253,7 +255,7 @@ struct TPgValue {
 struct TUuidValue {
     std::string ToString() const;
     TUuidValue(uint64_t low_128, uint64_t high_128);
-    TUuidValue(const Ydb::Value& uuidValueProto);
+    TUuidValue(const NYdbProtos::Value& uuidValueProto);
     TUuidValue(const std::string& uuidString);
 
     union {
@@ -267,14 +269,14 @@ class TValue {
     friend class TValueParser;
     friend class TProtoAccessor;
 public:
-    TValue(const TType& type, const Ydb::Value& valueProto);
-    TValue(const TType& type, Ydb::Value&& valueProto);
+    TValue(const TType& type, const NYdbProtos::Value& valueProto);
+    TValue(const TType& type, NYdbProtos::Value&& valueProto);
 
     const TType& GetType() const;
     TType & GetType();
 
-    const Ydb::Value& GetProto() const;
-    Ydb::Value& GetProto();
+    const NYdbProtos::Value& GetProto() const;
+    NYdbProtos::Value& GetProto();
 
 private:
     class TImpl;
@@ -394,7 +396,7 @@ public:
 
 private:
     TValueParser(const TType& type);
-    void Reset(const Ydb::Value& value);
+    void Reset(const NYdbProtos::Value& value);
 
     class TImpl;
     std::unique_ptr<TImpl> Impl_;
@@ -519,7 +521,7 @@ protected:
 
     TValueBuilderBase(const TType& type);
 
-    TValueBuilderBase(Ydb::Type& type, Ydb::Value& value);
+    TValueBuilderBase(NYdbProtos::Type& type, NYdbProtos::Value& value);
 
     ~TValueBuilderBase();
 

--- a/ydb/public/sdk/cpp/include/ydb-cpp-sdk/library/operation_id/operation_id.h
+++ b/ydb/public/sdk/cpp/include/ydb-cpp-sdk/library/operation_id/operation_id.h
@@ -1,10 +1,12 @@
 #pragma once
 
+#include <ydb-cpp-sdk/type_switcher.h>
+
 #include <memory>
 #include <string>
 #include <vector>
 
-namespace Ydb {
+YDB_PROTOS_NAMESPACE {
     class TOperationId;
 }
 
@@ -54,15 +56,15 @@ public:
     std::string GetSubKind() const;
     std::string ToString() const;
 
-    const Ydb::TOperationId& GetProto() const;
+    const NYdbProtos::TOperationId& GetProto() const;
 private:
     class TImpl;
     std::unique_ptr<TImpl> Impl;
 };
 
-std::string ProtoToString(const Ydb::TOperationId& proto);
+std::string ProtoToString(const NYdbProtos::TOperationId& proto);
 
-void AddOptionalValue(Ydb::TOperationId& operarionId, const std::string& key, const std::string& value);
+void AddOptionalValue(NYdbProtos::TOperationId& operarionId, const std::string& key, const std::string& value);
 
 TOperationId::EKind ParseKind(const std::string_view value);
 

--- a/ydb/public/sdk/cpp/include/ydb-cpp-sdk/type_switcher.h
+++ b/ydb/public/sdk/cpp/include/ydb-cpp-sdk/type_switcher.h
@@ -1,17 +1,13 @@
 #pragma once
 
-#ifdef YDB_SDK_USE_STD_STRING
-
-#include <string>
-namespace NYdb {
-using TStringType = std::string;
-}
-
-#else
-
 #include <util/generic/string.h>
+
+#define YDB_PROTOS_NAMESPACE namespace Ydb
+
+YDB_PROTOS_NAMESPACE {}
+
+namespace NYdbProtos = Ydb;
+
 namespace NYdb {
 using TStringType = TString;
 }
-
-#endif

--- a/ydb/public/sdk/cpp/src/client/bsconfig/storage_config.cpp
+++ b/ydb/public/sdk/cpp/src/client/bsconfig/storage_config.cpp
@@ -19,7 +19,7 @@ public:
             std::optional<bool> switch_dedicated_storage_section,
             bool dedicated_config_mode,
             const TReplaceStorageConfigSettings& settings) {
-        auto request = MakeRequest<Ydb::BSConfig::ReplaceStorageConfigRequest>();
+        auto request = MakeRequest<NYdbProtos::BSConfig::ReplaceStorageConfigRequest>();
 
         if (yaml_config) {
             request.set_yaml_config(*yaml_config);
@@ -32,15 +32,15 @@ public:
         }
         request.set_dedicated_config_mode(dedicated_config_mode);
 
-        return RunSimple<Ydb::BSConfig::V1::BSConfigService, Ydb::BSConfig::ReplaceStorageConfigRequest, Ydb::BSConfig::ReplaceStorageConfigResponse>(
+        return RunSimple<NYdbProtos::BSConfig::V1::BSConfigService, NYdbProtos::BSConfig::ReplaceStorageConfigRequest, NYdbProtos::BSConfig::ReplaceStorageConfigResponse>(
             std::move(request),
-            &Ydb::BSConfig::V1::BSConfigService::Stub::AsyncReplaceStorageConfig,
+            &NYdbProtos::BSConfig::V1::BSConfigService::Stub::AsyncReplaceStorageConfig,
             TRpcRequestSettings::Make(settings));
     }
 
     TAsyncFetchStorageConfigResult FetchStorageConfig(bool dedicated_storage_section, bool dedicated_cluster_section,
 			const TFetchStorageConfigSettings& settings) {
-        auto request = MakeOperationRequest<Ydb::BSConfig::FetchStorageConfigRequest>(settings);
+        auto request = MakeOperationRequest<NYdbProtos::BSConfig::FetchStorageConfigRequest>(settings);
         if (dedicated_storage_section) {
             request.set_dedicated_storage_section(true);
         }
@@ -52,7 +52,7 @@ public:
         auto extractor = [promise] (google::protobuf::Any* any, TPlainStatus status) mutable {
             NYdb::TStringType config;
             NYdb::TStringType storage_config;
-            if (Ydb::BSConfig::FetchStorageConfigResult result; any && any->UnpackTo(&result)) {
+            if (NYdbProtos::BSConfig::FetchStorageConfigResult result; any && any->UnpackTo(&result)) {
                 config = result.yaml_config();
                 storage_config = result.storage_yaml_config();
             }
@@ -62,10 +62,10 @@ public:
             promise.SetValue(std::move(val));
         };
 
-        Connections_->RunDeferred<Ydb::BSConfig::V1::BSConfigService, Ydb::BSConfig::FetchStorageConfigRequest, Ydb::BSConfig::FetchStorageConfigResponse>(
+        Connections_->RunDeferred<NYdbProtos::BSConfig::V1::BSConfigService, NYdbProtos::BSConfig::FetchStorageConfigRequest, NYdbProtos::BSConfig::FetchStorageConfigResponse>(
             std::move(request),
             extractor,
-            &Ydb::BSConfig::V1::BSConfigService::Stub::AsyncFetchStorageConfig,
+            &NYdbProtos::BSConfig::V1::BSConfigService::Stub::AsyncFetchStorageConfig,
             DbDriverState_,
             INITIAL_DEFERRED_CALL_DELAY,
             TRpcRequestSettings::Make(settings));
@@ -73,11 +73,11 @@ public:
     }
 
     TAsyncStatus BootstrapCluster(const std::string& selfAssemblyUUID, const TBootstrapClusterSettings& settings) {
-        auto request = MakeRequest<Ydb::BSConfig::BootstrapClusterRequest>();
+        auto request = MakeRequest<NYdbProtos::BSConfig::BootstrapClusterRequest>();
         request.set_self_assembly_uuid(selfAssemblyUUID);
-        return RunSimple<Ydb::BSConfig::V1::BSConfigService, Ydb::BSConfig::BootstrapClusterRequest,
-            Ydb::BSConfig::BootstrapClusterResponse>(std::move(request),
-            &Ydb::BSConfig::V1::BSConfigService::Stub::AsyncBootstrapCluster,
+        return RunSimple<NYdbProtos::BSConfig::V1::BSConfigService, NYdbProtos::BSConfig::BootstrapClusterRequest,
+            NYdbProtos::BSConfig::BootstrapClusterResponse>(std::move(request),
+            &NYdbProtos::BSConfig::V1::BSConfigService::Stub::AsyncBootstrapCluster,
             TRpcRequestSettings::Make(settings));
     }
 };

--- a/ydb/public/sdk/cpp/src/client/cms/cms.cpp
+++ b/ydb/public/sdk/cpp/src/client/cms/cms.cpp
@@ -11,19 +11,19 @@
 namespace NYdb::inline V3::NCms {
 
 namespace {
-    EState ConvertState(Ydb::Cms::GetDatabaseStatusResult_State protoState) {
+    EState ConvertState(NYdbProtos::Cms::GetDatabaseStatusResult_State protoState) {
         switch (protoState) {
-            case Ydb::Cms::GetDatabaseStatusResult_State_STATE_UNSPECIFIED:
+            case NYdbProtos::Cms::GetDatabaseStatusResult_State_STATE_UNSPECIFIED:
                 return EState::StateUnspecified;
-            case Ydb::Cms::GetDatabaseStatusResult_State_CREATING:
+            case NYdbProtos::Cms::GetDatabaseStatusResult_State_CREATING:
                 return EState::Creating;
-            case Ydb::Cms::GetDatabaseStatusResult_State_RUNNING:
+            case NYdbProtos::Cms::GetDatabaseStatusResult_State_RUNNING:
                 return EState::Running;
-            case Ydb::Cms::GetDatabaseStatusResult_State_REMOVING:
+            case NYdbProtos::Cms::GetDatabaseStatusResult_State_REMOVING:
                 return EState::Removing;
-            case Ydb::Cms::GetDatabaseStatusResult_State_PENDING_RESOURCES:
+            case NYdbProtos::Cms::GetDatabaseStatusResult_State_PENDING_RESOURCES:
                 return EState::PendingResources;
-            case Ydb::Cms::GetDatabaseStatusResult_State_CONFIGURING:
+            case NYdbProtos::Cms::GetDatabaseStatusResult_State_CONFIGURING:
                 return EState::Configuring;
             default:
                 return EState::StateUnspecified;
@@ -35,7 +35,7 @@ namespace {
         const TSchemaOperationQuotas& schemaQuotas,
         const TDatabaseQuotas& dbQuotas,
         const TScaleRecommenderPolicies& scaleRecommenderPolicies,
-        Ydb::Cms::CreateDatabaseRequest& out)
+        NYdbProtos::Cms::CreateDatabaseRequest& out)
     {
         if (std::holds_alternative<NCms::TResources>(resourcesKind)) {
             const auto& resources = std::get<NCms::TResources>(resourcesKind);
@@ -107,7 +107,7 @@ namespace {
     }
 } // anonymous namespace
 
-TListDatabasesResult::TListDatabasesResult(TStatus&& status, const Ydb::Cms::ListDatabasesResult& proto)
+TListDatabasesResult::TListDatabasesResult(TStatus&& status, const NYdbProtos::Cms::ListDatabasesResult& proto)
     : TStatus(std::move(status))
     , Paths_(proto.paths().begin(), proto.paths().end())
 {}
@@ -116,48 +116,48 @@ const std::vector<std::string>& TListDatabasesResult::GetPaths() const {
     return Paths_;
 }
 
-TStorageUnits::TStorageUnits(const Ydb::Cms::StorageUnits& proto)
+TStorageUnits::TStorageUnits(const NYdbProtos::Cms::StorageUnits& proto)
     : UnitKind(proto.unit_kind())
     , Count(proto.count())
 {}
 
-TComputationalUnits::TComputationalUnits(const Ydb::Cms::ComputationalUnits& proto) 
+TComputationalUnits::TComputationalUnits(const NYdbProtos::Cms::ComputationalUnits& proto) 
     : UnitKind(proto.unit_kind())
     , AvailabilityZone(proto.availability_zone())
     , Count(proto.count())
 {}
 
-TAllocatedComputationalUnit::TAllocatedComputationalUnit(const Ydb::Cms::AllocatedComputationalUnit& proto)
+TAllocatedComputationalUnit::TAllocatedComputationalUnit(const NYdbProtos::Cms::AllocatedComputationalUnit& proto)
     : Host(proto.host())
     , Port(proto.port())
     , UnitKind(proto.unit_kind())
 {}
 
-TResources::TResources(const Ydb::Cms::Resources& proto)
+TResources::TResources(const NYdbProtos::Cms::Resources& proto)
     : StorageUnits(proto.storage_units().begin(), proto.storage_units().end())
     , ComputationalUnits(proto.computational_units().begin(), proto.computational_units().end())
 {}
 
-TServerlessResources::TServerlessResources(const Ydb::Cms::ServerlessResources& proto)
+TServerlessResources::TServerlessResources(const NYdbProtos::Cms::ServerlessResources& proto)
     : SharedDatabasePath(proto.shared_database_path())
 {}
 
-TSchemaOperationQuotas::TLeakyBucket::TLeakyBucket(const Ydb::Cms::SchemaOperationQuotas_LeakyBucket& proto)
+TSchemaOperationQuotas::TLeakyBucket::TLeakyBucket(const NYdbProtos::Cms::SchemaOperationQuotas_LeakyBucket& proto)
     : BucketSize(proto.bucket_size())
     , BucketSeconds(proto.bucket_seconds())
 {}
 
-TSchemaOperationQuotas::TSchemaOperationQuotas(const Ydb::Cms::SchemaOperationQuotas& proto)
+TSchemaOperationQuotas::TSchemaOperationQuotas(const NYdbProtos::Cms::SchemaOperationQuotas& proto)
     : LeakyBucketQuotas(proto.leaky_bucket_quotas().begin(), proto.leaky_bucket_quotas().end())
 {}
 
-TDatabaseQuotas::TStorageQuotas::TStorageQuotas(const Ydb::Cms::DatabaseQuotas_StorageQuotas& proto)
+TDatabaseQuotas::TStorageQuotas::TStorageQuotas(const NYdbProtos::Cms::DatabaseQuotas_StorageQuotas& proto)
     : UnitKind(proto.unit_kind()) 
     , DataSizeHardQuota(proto.data_size_hard_quota())
     , DataSizeSoftQuota(proto.data_size_soft_quota())
 {}
 
-TDatabaseQuotas::TDatabaseQuotas(const Ydb::Cms::DatabaseQuotas& proto)
+TDatabaseQuotas::TDatabaseQuotas(const NYdbProtos::Cms::DatabaseQuotas& proto)
     : DataSizeHardQuota(proto.data_size_hard_quota())
     , DataSizeSoftQuota(proto.data_size_soft_quota())
     , DataStreamShardsQuota(proto.data_stream_shards_quota())
@@ -166,35 +166,35 @@ TDatabaseQuotas::TDatabaseQuotas(const Ydb::Cms::DatabaseQuotas& proto)
     , StorageQuotas(proto.storage_quotas().begin(), proto.storage_quotas().end())
 {}
 
-TTargetTrackingPolicy::TTargetTrackingPolicy(const Ydb::Cms::ScaleRecommenderPolicies_ScaleRecommenderPolicy_TargetTrackingPolicy& proto)
+TTargetTrackingPolicy::TTargetTrackingPolicy(const NYdbProtos::Cms::ScaleRecommenderPolicies_ScaleRecommenderPolicy_TargetTrackingPolicy& proto)
 {
     switch (proto.target_case()) {
-        case Ydb::Cms::ScaleRecommenderPolicies_ScaleRecommenderPolicy_TargetTrackingPolicy::kAverageCpuUtilizationPercent:
+        case NYdbProtos::Cms::ScaleRecommenderPolicies_ScaleRecommenderPolicy_TargetTrackingPolicy::kAverageCpuUtilizationPercent:
             Target = proto.average_cpu_utilization_percent();
             break;
-        case Ydb::Cms::ScaleRecommenderPolicies_ScaleRecommenderPolicy_TargetTrackingPolicy::TARGET_NOT_SET:
+        case NYdbProtos::Cms::ScaleRecommenderPolicies_ScaleRecommenderPolicy_TargetTrackingPolicy::TARGET_NOT_SET:
             Target = std::monostate();
             break;
     }
 }
 
-TScaleRecommenderPolicy::TScaleRecommenderPolicy(const Ydb::Cms::ScaleRecommenderPolicies_ScaleRecommenderPolicy& proto)
+TScaleRecommenderPolicy::TScaleRecommenderPolicy(const NYdbProtos::Cms::ScaleRecommenderPolicies_ScaleRecommenderPolicy& proto)
 {
     switch (proto.policy_case()) {
-        case Ydb::Cms::ScaleRecommenderPolicies_ScaleRecommenderPolicy::kTargetTrackingPolicy:
+        case NYdbProtos::Cms::ScaleRecommenderPolicies_ScaleRecommenderPolicy::kTargetTrackingPolicy:
             Policy = proto.target_tracking_policy();
             break;
-        case Ydb::Cms::ScaleRecommenderPolicies_ScaleRecommenderPolicy::POLICY_NOT_SET:
+        case NYdbProtos::Cms::ScaleRecommenderPolicies_ScaleRecommenderPolicy::POLICY_NOT_SET:
             Policy = std::monostate();
             break;
     }
 }
 
-TScaleRecommenderPolicies::TScaleRecommenderPolicies(const Ydb::Cms::ScaleRecommenderPolicies& proto) 
+TScaleRecommenderPolicies::TScaleRecommenderPolicies(const NYdbProtos::Cms::ScaleRecommenderPolicies& proto) 
     : Policies(proto.policies().begin(), proto.policies().end())
 {}
 
-TGetDatabaseStatusResult::TGetDatabaseStatusResult(TStatus&& status, const Ydb::Cms::GetDatabaseStatusResult& proto)
+TGetDatabaseStatusResult::TGetDatabaseStatusResult(TStatus&& status, const NYdbProtos::Cms::GetDatabaseStatusResult& proto)
     : TStatus(std::move(status))
     , Path_(proto.path())
     , State_(ConvertState(proto.state()))
@@ -206,16 +206,16 @@ TGetDatabaseStatusResult::TGetDatabaseStatusResult(TStatus&& status, const Ydb::
     , ScaleRecommenderPolicies_(proto.scale_recommender_policies())
 {
     switch (proto.resources_kind_case()) {
-        case Ydb::Cms::GetDatabaseStatusResult::kRequiredResources:
+        case NYdbProtos::Cms::GetDatabaseStatusResult::kRequiredResources:
             ResourcesKind_ = TResources(proto.required_resources());
             break;
-        case Ydb::Cms::GetDatabaseStatusResult::kRequiredSharedResources:
+        case NYdbProtos::Cms::GetDatabaseStatusResult::kRequiredSharedResources:
             ResourcesKind_ = TSharedResources(proto.required_shared_resources());
             break;
-        case Ydb::Cms::GetDatabaseStatusResult::kServerlessResources:
+        case NYdbProtos::Cms::GetDatabaseStatusResult::kServerlessResources:
             ResourcesKind_ = proto.serverless_resources();
             break;
-        case Ydb::Cms::GetDatabaseStatusResult::RESOURCES_KIND_NOT_SET:
+        case NYdbProtos::Cms::GetDatabaseStatusResult::RESOURCES_KIND_NOT_SET:
             ResourcesKind_ = std::monostate();
             break;
     }
@@ -257,33 +257,33 @@ const TScaleRecommenderPolicies& TGetDatabaseStatusResult::GetScaleRecommenderPo
     return ScaleRecommenderPolicies_;
 }
 
-void TGetDatabaseStatusResult::SerializeTo(Ydb::Cms::CreateDatabaseRequest& request) const {
+void TGetDatabaseStatusResult::SerializeTo(NYdbProtos::Cms::CreateDatabaseRequest& request) const {
     request.set_path(Path_);
     SerializeToImpl(ResourcesKind_, SchemaOperationQuotas_, DatabaseQuotas_, ScaleRecommenderPolicies_, request);
 }
 
-TCreateDatabaseSettings::TCreateDatabaseSettings(const Ydb::Cms::CreateDatabaseRequest& request)
+TCreateDatabaseSettings::TCreateDatabaseSettings(const NYdbProtos::Cms::CreateDatabaseRequest& request)
   : SchemaOperationQuotas_(request.schema_operation_quotas())
   , DatabaseQuotas_(request.database_quotas())
   , ScaleRecommenderPolicies_(request.scale_recommender_policies())
 {
   switch (request.resources_kind_case()) {
-      case Ydb::Cms::CreateDatabaseRequest::kResources:
+      case NYdbProtos::Cms::CreateDatabaseRequest::kResources:
           ResourcesKind_ = TResources(request.resources());
           break;
-      case Ydb::Cms::CreateDatabaseRequest::kSharedResources:
+      case NYdbProtos::Cms::CreateDatabaseRequest::kSharedResources:
           ResourcesKind_ = TSharedResources(request.shared_resources());
           break;
-      case Ydb::Cms::CreateDatabaseRequest::kServerlessResources:
+      case NYdbProtos::Cms::CreateDatabaseRequest::kServerlessResources:
           ResourcesKind_ = request.serverless_resources();
           break;
-      case Ydb::Cms::CreateDatabaseRequest::RESOURCES_KIND_NOT_SET:
+      case NYdbProtos::Cms::CreateDatabaseRequest::RESOURCES_KIND_NOT_SET:
           ResourcesKind_ = std::monostate();
           break;
   }
 }
 
-void TCreateDatabaseSettings::SerializeTo(Ydb::Cms::CreateDatabaseRequest& request) const {
+void TCreateDatabaseSettings::SerializeTo(NYdbProtos::Cms::CreateDatabaseRequest& request) const {
     SerializeToImpl(ResourcesKind_, SchemaOperationQuotas_, DatabaseQuotas_, ScaleRecommenderPolicies_, request);
 }
 
@@ -294,13 +294,13 @@ public:
     { }
 
     TAsyncListDatabasesResult ListDatabases(const TListDatabasesSettings& settings) {
-        auto request = MakeOperationRequest<Ydb::Cms::ListDatabasesRequest>(settings);
+        auto request = MakeOperationRequest<NYdbProtos::Cms::ListDatabasesRequest>(settings);
 
         auto promise = NThreading::NewPromise<TListDatabasesResult>();
 
         auto extractor = [promise]
             (google::protobuf::Any* any, TPlainStatus status) mutable {
-                Ydb::Cms::ListDatabasesResult result;
+                NYdbProtos::Cms::ListDatabasesResult result;
                 if (any) {
                     any->UnpackTo(&result);
                 }
@@ -308,10 +308,10 @@ public:
                 promise.SetValue(std::move(val));
             };
 
-        Connections_->RunDeferred<Ydb::Cms::V1::CmsService, Ydb::Cms::ListDatabasesRequest, Ydb::Cms::ListDatabasesResponse>(
+        Connections_->RunDeferred<NYdbProtos::Cms::V1::CmsService, NYdbProtos::Cms::ListDatabasesRequest, NYdbProtos::Cms::ListDatabasesResponse>(
             std::move(request),
             extractor,
-            &Ydb::Cms::V1::CmsService::Stub::AsyncListDatabases,
+            &NYdbProtos::Cms::V1::CmsService::Stub::AsyncListDatabases,
             DbDriverState_,
             INITIAL_DEFERRED_CALL_DELAY,
             TRpcRequestSettings::Make(settings));
@@ -320,14 +320,14 @@ public:
     }
 
     TAsyncGetDatabaseStatusResult GetDatabaseStatus(const std::string& path, const TGetDatabaseStatusSettings& settings) {
-        auto request = MakeOperationRequest<Ydb::Cms::GetDatabaseStatusRequest>(settings);
+        auto request = MakeOperationRequest<NYdbProtos::Cms::GetDatabaseStatusRequest>(settings);
         request.set_path(path);
 
         auto promise = NThreading::NewPromise<TGetDatabaseStatusResult>();
 
         auto extractor = [promise]
             (google::protobuf::Any* any, TPlainStatus status) mutable {
-                Ydb::Cms::GetDatabaseStatusResult result;
+                NYdbProtos::Cms::GetDatabaseStatusResult result;
                 if (any) {
                     any->UnpackTo(&result);
                 }
@@ -335,10 +335,10 @@ public:
                 promise.SetValue(std::move(val));
             };
 
-        Connections_->RunDeferred<Ydb::Cms::V1::CmsService, Ydb::Cms::GetDatabaseStatusRequest, Ydb::Cms::GetDatabaseStatusResponse>(
+        Connections_->RunDeferred<NYdbProtos::Cms::V1::CmsService, NYdbProtos::Cms::GetDatabaseStatusRequest, NYdbProtos::Cms::GetDatabaseStatusResponse>(
             std::move(request),
             extractor,
-            &Ydb::Cms::V1::CmsService::Stub::AsyncGetDatabaseStatus,
+            &NYdbProtos::Cms::V1::CmsService::Stub::AsyncGetDatabaseStatus,
             DbDriverState_,
             INITIAL_DEFERRED_CALL_DELAY,
             TRpcRequestSettings::Make(settings));
@@ -347,13 +347,13 @@ public:
     }
 
     TAsyncStatus CreateDatabase(const std::string& path, const TCreateDatabaseSettings& settings) {
-        auto request = MakeOperationRequest<Ydb::Cms::CreateDatabaseRequest>(settings);
+        auto request = MakeOperationRequest<NYdbProtos::Cms::CreateDatabaseRequest>(settings);
         request.set_path(path);
         settings.SerializeTo(request);
 
-        return RunSimple<Ydb::Cms::V1::CmsService, Ydb::Cms::CreateDatabaseRequest, Ydb::Cms::CreateDatabaseResponse>(
+        return RunSimple<NYdbProtos::Cms::V1::CmsService, NYdbProtos::Cms::CreateDatabaseRequest, NYdbProtos::Cms::CreateDatabaseResponse>(
             std::move(request),
-            &Ydb::Cms::V1::CmsService::Stub::AsyncCreateDatabase,
+            &NYdbProtos::Cms::V1::CmsService::Stub::AsyncCreateDatabase,
             TRpcRequestSettings::Make(settings));
     }
 };

--- a/ydb/public/sdk/cpp/src/client/common_client/impl/client.h
+++ b/ydb/public/sdk/cpp/src/client/common_client/impl/client.h
@@ -105,7 +105,7 @@ protected:
         auto promise = NThreading::NewPromise<TOp>();
 
         auto extractor = [promise]
-            (Ydb::Operations::Operation* operation, TPlainStatus status) mutable {
+            (NYdbProtos::Operations::Operation* operation, TPlainStatus status) mutable {
                 TStatus st(std::move(status));
                 if (!operation) {
                     promise.SetValue(TOp(std::move(st)));

--- a/ydb/public/sdk/cpp/src/client/coordination/proto_accessor.cpp
+++ b/ydb/public/sdk/cpp/src/client/coordination/proto_accessor.cpp
@@ -4,7 +4,7 @@
 
 namespace NYdb::inline V3 {
 
-const Ydb::Coordination::DescribeNodeResult& TProtoAccessor::GetProto(const NCoordination::TNodeDescription& nodeDescription) {
+const NYdbProtos::Coordination::DescribeNodeResult& TProtoAccessor::GetProto(const NCoordination::TNodeDescription& nodeDescription) {
     return nodeDescription.GetProto();
 }
 

--- a/ydb/public/sdk/cpp/src/client/datastreams/datastreams.cpp
+++ b/ydb/public/sdk/cpp/src/client/datastreams/datastreams.cpp
@@ -21,24 +21,24 @@ namespace NYdb::inline V3::NDataStreams::V1 {
         return { *this };
     }
 
-    void SetPartitionSettings(const TPartitioningSettings& ps, ::Ydb::DataStreams::V1::PartitioningSettings* pt) {
+    void SetPartitionSettings(const TPartitioningSettings& ps, ::NYdbProtos::DataStreams::V1::PartitioningSettings* pt) {
         pt->set_max_active_partitions(ps.GetMaxActivePartitions());
         pt->set_min_active_partitions(ps.GetMinActivePartitions());
 
-        ::Ydb::DataStreams::V1::AutoPartitioningStrategy strategy;
+        ::NYdbProtos::DataStreams::V1::AutoPartitioningStrategy strategy;
         switch (ps.GetAutoPartitioningSettings().GetStrategy()) {
             case EAutoPartitioningStrategy::Unspecified:
             case EAutoPartitioningStrategy::Disabled:
-                strategy = ::Ydb::DataStreams::V1::AutoPartitioningStrategy::AUTO_PARTITIONING_STRATEGY_DISABLED;
+                strategy = ::NYdbProtos::DataStreams::V1::AutoPartitioningStrategy::AUTO_PARTITIONING_STRATEGY_DISABLED;
                 break;
             case EAutoPartitioningStrategy::ScaleUp:
-                strategy = ::Ydb::DataStreams::V1::AutoPartitioningStrategy::AUTO_PARTITIONING_STRATEGY_SCALE_UP;
+                strategy = ::NYdbProtos::DataStreams::V1::AutoPartitioningStrategy::AUTO_PARTITIONING_STRATEGY_SCALE_UP;
                 break;
             case EAutoPartitioningStrategy::ScaleUpAndDown:
-                strategy = ::Ydb::DataStreams::V1::AutoPartitioningStrategy::AUTO_PARTITIONING_STRATEGY_SCALE_UP_AND_DOWN;
+                strategy = ::NYdbProtos::DataStreams::V1::AutoPartitioningStrategy::AUTO_PARTITIONING_STRATEGY_SCALE_UP_AND_DOWN;
                 break;
             case EAutoPartitioningStrategy::Paused:
-                strategy = ::Ydb::DataStreams::V1::AutoPartitioningStrategy::AUTO_PARTITIONING_STRATEGY_PAUSED;
+                strategy = ::NYdbProtos::DataStreams::V1::AutoPartitioningStrategy::AUTO_PARTITIONING_STRATEGY_PAUSED;
                 break;
         }
 
@@ -103,16 +103,16 @@ namespace NYdb::inline V3::NDataStreams::V1 {
 
         TAsyncCreateStreamResult CreateStream(const std::string &path, TCreateStreamSettings settings) {
             if (settings.RetentionPeriodHours_.has_value() && settings.RetentionStorageMegabytes_.has_value()) {
-                return NThreading::MakeFuture(TProtoResultWrapper<Ydb::DataStreams::V1::CreateStreamResult>(
+                return NThreading::MakeFuture(TProtoResultWrapper<NYdbProtos::DataStreams::V1::CreateStreamResult>(
                     NYdb::TPlainStatus(NYdb::EStatus::BAD_REQUEST, "both retention types can not be set"),
-                    std::make_unique<Ydb::DataStreams::V1::CreateStreamResult>()));
+                    std::make_unique<NYdbProtos::DataStreams::V1::CreateStreamResult>()));
             }
-            return CallImpl<Ydb::DataStreams::V1::DataStreamsService,
-                    Ydb::DataStreams::V1::CreateStreamRequest,
-                    Ydb::DataStreams::V1::CreateStreamResponse,
-                    Ydb::DataStreams::V1::CreateStreamResult>(settings,
-                        &Ydb::DataStreams::V1::DataStreamsService::Stub::AsyncCreateStream,
-                        [&](Ydb::DataStreams::V1::CreateStreamRequest& req) {
+            return CallImpl<NYdbProtos::DataStreams::V1::DataStreamsService,
+                    NYdbProtos::DataStreams::V1::CreateStreamRequest,
+                    NYdbProtos::DataStreams::V1::CreateStreamResponse,
+                    NYdbProtos::DataStreams::V1::CreateStreamResult>(settings,
+                        &NYdbProtos::DataStreams::V1::DataStreamsService::Stub::AsyncCreateStream,
+                        [&](NYdbProtos::DataStreams::V1::CreateStreamRequest& req) {
                             req.set_stream_name(TStringType{path});
                             req.set_shard_count(settings.ShardCount_);
                             if (settings.RetentionStorageMegabytes_.has_value()) {
@@ -125,8 +125,8 @@ namespace NYdb::inline V3::NDataStreams::V1 {
                             req.set_write_quota_kb_per_sec(settings.WriteQuotaKbPerSec_);
                             if (settings.StreamMode_.has_value()) {
                                 req.mutable_stream_mode_details()->set_stream_mode(
-                                        *settings.StreamMode_ == ESM_PROVISIONED ? Ydb::DataStreams::V1::StreamMode::PROVISIONED
-                                                                                : Ydb::DataStreams::V1::StreamMode::ON_DEMAND);
+                                        *settings.StreamMode_ == ESM_PROVISIONED ? NYdbProtos::DataStreams::V1::StreamMode::PROVISIONED
+                                                                                : NYdbProtos::DataStreams::V1::StreamMode::ON_DEMAND);
                             }
 
                             if (settings.PartitioningSettings_.has_value()) {
@@ -136,11 +136,11 @@ namespace NYdb::inline V3::NDataStreams::V1 {
         }
 
         TAsyncListStreamsResult ListStreams(TListStreamsSettings settings) {
-            return CallImpl<Ydb::DataStreams::V1::DataStreamsService,
-                    Ydb::DataStreams::V1::ListStreamsRequest,
-                    Ydb::DataStreams::V1::ListStreamsResponse,
-                    Ydb::DataStreams::V1::ListStreamsResult>(settings, &Ydb::DataStreams::V1::DataStreamsService::Stub::AsyncListStreams,
-                                                             [&](Ydb::DataStreams::V1::ListStreamsRequest& req) {
+            return CallImpl<NYdbProtos::DataStreams::V1::DataStreamsService,
+                    NYdbProtos::DataStreams::V1::ListStreamsRequest,
+                    NYdbProtos::DataStreams::V1::ListStreamsResponse,
+                    NYdbProtos::DataStreams::V1::ListStreamsResult>(settings, &NYdbProtos::DataStreams::V1::DataStreamsService::Stub::AsyncListStreams,
+                                                             [&](NYdbProtos::DataStreams::V1::ListStreamsRequest& req) {
                                                                  req.set_exclusive_start_stream_name(TStringType{settings.ExclusiveStartStreamName_});
                                                                  req.set_limit(settings.Limit_);
                                                                  req.set_recurse(settings.Recurse_);
@@ -148,20 +148,20 @@ namespace NYdb::inline V3::NDataStreams::V1 {
         }
 
         TAsyncDescribeStreamResult DescribeStream(TDescribeStreamSettings settings) {
-            return CallImpl<Ydb::DataStreams::V1::DataStreamsService,
-                    Ydb::DataStreams::V1::DescribeStreamRequest,
-                    Ydb::DataStreams::V1::DescribeStreamResponse,
-                    Ydb::DataStreams::V1::DescribeStreamResult>(settings, &Ydb::DataStreams::V1::DataStreamsService::Stub::AsyncDescribeStream);
+            return CallImpl<NYdbProtos::DataStreams::V1::DataStreamsService,
+                    NYdbProtos::DataStreams::V1::DescribeStreamRequest,
+                    NYdbProtos::DataStreams::V1::DescribeStreamResponse,
+                    NYdbProtos::DataStreams::V1::DescribeStreamResult>(settings, &NYdbProtos::DataStreams::V1::DataStreamsService::Stub::AsyncDescribeStream);
         }
 
         TAsyncListShardsResult ListShards(const std::string &path,
-            const Ydb::DataStreams::V1::ShardFilter& shardFilter,
+            const NYdbProtos::DataStreams::V1::ShardFilter& shardFilter,
             TListShardsSettings settings) {
-            return CallImpl<Ydb::DataStreams::V1::DataStreamsService,
-                    Ydb::DataStreams::V1::ListShardsRequest,
-                    Ydb::DataStreams::V1::ListShardsResponse,
-                    Ydb::DataStreams::V1::ListShardsResult>(settings, &Ydb::DataStreams::V1::DataStreamsService::Stub::AsyncListShards,
-                    [&](Ydb::DataStreams::V1::ListShardsRequest& req) {
+            return CallImpl<NYdbProtos::DataStreams::V1::DataStreamsService,
+                    NYdbProtos::DataStreams::V1::ListShardsRequest,
+                    NYdbProtos::DataStreams::V1::ListShardsResponse,
+                    NYdbProtos::DataStreams::V1::ListShardsResult>(settings, &NYdbProtos::DataStreams::V1::DataStreamsService::Stub::AsyncListShards,
+                    [&](NYdbProtos::DataStreams::V1::ListShardsRequest& req) {
                         req.set_exclusive_start_shard_id(TStringType{settings.ExclusiveStartShardId_});
                         req.set_max_results(settings.MaxResults_);
                         req.set_next_token(TStringType{settings.NextToken_});
@@ -172,11 +172,11 @@ namespace NYdb::inline V3::NDataStreams::V1 {
         }
 
         TAsyncPutRecordsResult PutRecords(const std::string& path, const std::vector<TDataRecord>& records, TPutRecordsSettings settings) {
-            return CallImpl<Ydb::DataStreams::V1::DataStreamsService,
-                    Ydb::DataStreams::V1::PutRecordsRequest,
-                    Ydb::DataStreams::V1::PutRecordsResponse,
-                    Ydb::DataStreams::V1::PutRecordsResult>(settings, &Ydb::DataStreams::V1::DataStreamsService::Stub::AsyncPutRecords,
-                                                            [&](Ydb::DataStreams::V1::PutRecordsRequest& req) {
+            return CallImpl<NYdbProtos::DataStreams::V1::DataStreamsService,
+                    NYdbProtos::DataStreams::V1::PutRecordsRequest,
+                    NYdbProtos::DataStreams::V1::PutRecordsResponse,
+                    NYdbProtos::DataStreams::V1::PutRecordsResult>(settings, &NYdbProtos::DataStreams::V1::DataStreamsService::Stub::AsyncPutRecords,
+                                                            [&](NYdbProtos::DataStreams::V1::PutRecordsRequest& req) {
                                                                 req.set_stream_name(TStringType{path});
                                                                 for (const auto& record : records) {
                                                                     auto* protoRecord = req.add_records();
@@ -188,24 +188,24 @@ namespace NYdb::inline V3::NDataStreams::V1 {
         }
 
         TAsyncGetRecordsResult GetRecords(const std::string& shardIterator, TGetRecordsSettings settings) {
-            return CallImpl<Ydb::DataStreams::V1::DataStreamsService,
-                    Ydb::DataStreams::V1::GetRecordsRequest,
-                    Ydb::DataStreams::V1::GetRecordsResponse,
-                    Ydb::DataStreams::V1::GetRecordsResult>(settings, &Ydb::DataStreams::V1::DataStreamsService::Stub::AsyncGetRecords,
-                        [&](Ydb::DataStreams::V1::GetRecordsRequest& req) {
+            return CallImpl<NYdbProtos::DataStreams::V1::DataStreamsService,
+                    NYdbProtos::DataStreams::V1::GetRecordsRequest,
+                    NYdbProtos::DataStreams::V1::GetRecordsResponse,
+                    NYdbProtos::DataStreams::V1::GetRecordsResult>(settings, &NYdbProtos::DataStreams::V1::DataStreamsService::Stub::AsyncGetRecords,
+                        [&](NYdbProtos::DataStreams::V1::GetRecordsRequest& req) {
                             req.set_shard_iterator(TStringType{shardIterator});
                             req.set_limit(settings.Limit_);
                         });
         }
 
         TAsyncGetShardIteratorResult GetShardIterator(const std::string& path, const std::string& shardId,
-                                                      Ydb::DataStreams::V1::ShardIteratorType shardIteratorType,
+                                                      NYdbProtos::DataStreams::V1::ShardIteratorType shardIteratorType,
                                                       TGetShardIteratorSettings settings) {
-            return CallImpl<Ydb::DataStreams::V1::DataStreamsService,
-                    Ydb::DataStreams::V1::GetShardIteratorRequest,
-                    Ydb::DataStreams::V1::GetShardIteratorResponse,
-                    Ydb::DataStreams::V1::GetShardIteratorResult>(settings, &Ydb::DataStreams::V1::DataStreamsService::Stub::AsyncGetShardIterator,
-                        [&](Ydb::DataStreams::V1::GetShardIteratorRequest& req) {
+            return CallImpl<NYdbProtos::DataStreams::V1::DataStreamsService,
+                    NYdbProtos::DataStreams::V1::GetShardIteratorRequest,
+                    NYdbProtos::DataStreams::V1::GetShardIteratorResponse,
+                    NYdbProtos::DataStreams::V1::GetShardIteratorResult>(settings, &NYdbProtos::DataStreams::V1::DataStreamsService::Stub::AsyncGetShardIterator,
+                        [&](NYdbProtos::DataStreams::V1::GetShardIteratorRequest& req) {
                             req.set_stream_name(TStringType{path});
                             req.set_shard_id(TStringType{shardId});
                             req.set_shard_iterator_type(shardIteratorType);
@@ -215,35 +215,35 @@ namespace NYdb::inline V3::NDataStreams::V1 {
         }
 
         /*TAsyncSubscribeToShardResult SubscribeToShard(TSubscribeToShardSettings settings) {
-            return CallImpl<Ydb::DataStreams::V1::DataStreamsService,
-                    Ydb::DataStreams::V1::SubscribeToShardRequest,
-                    Ydb::DataStreams::V1::SubscribeToShardResponse,
-                    Ydb::DataStreams::V1::SubscribeToShardResult>(settings, &Ydb::DataStreams::V1::DataStreamsService::Stub::AsyncSubscribeToShard);
+            return CallImpl<NYdbProtos::DataStreams::V1::DataStreamsService,
+                    NYdbProtos::DataStreams::V1::SubscribeToShardRequest,
+                    NYdbProtos::DataStreams::V1::SubscribeToShardResponse,
+                    NYdbProtos::DataStreams::V1::SubscribeToShardResult>(settings, &NYdbProtos::DataStreams::V1::DataStreamsService::Stub::AsyncSubscribeToShard);
         }*/
 
         TAsyncDescribeLimitsResult DescribeLimits(TDescribeLimitsSettings settings) {
-            return CallImpl<Ydb::DataStreams::V1::DataStreamsService,
-                    Ydb::DataStreams::V1::DescribeLimitsRequest,
-                    Ydb::DataStreams::V1::DescribeLimitsResponse,
-                    Ydb::DataStreams::V1::DescribeLimitsResult>(settings, &Ydb::DataStreams::V1::DataStreamsService::Stub::AsyncDescribeLimits);
+            return CallImpl<NYdbProtos::DataStreams::V1::DataStreamsService,
+                    NYdbProtos::DataStreams::V1::DescribeLimitsRequest,
+                    NYdbProtos::DataStreams::V1::DescribeLimitsResponse,
+                    NYdbProtos::DataStreams::V1::DescribeLimitsResult>(settings, &NYdbProtos::DataStreams::V1::DataStreamsService::Stub::AsyncDescribeLimits);
         }
 
         TAsyncDescribeStreamSummaryResult DescribeStreamSummary(const std::string& path, TDescribeStreamSummarySettings settings) {
-            return CallImpl<Ydb::DataStreams::V1::DataStreamsService,
-                    Ydb::DataStreams::V1::DescribeStreamSummaryRequest,
-                    Ydb::DataStreams::V1::DescribeStreamSummaryResponse,
-                    Ydb::DataStreams::V1::DescribeStreamSummaryResult>(settings, &Ydb::DataStreams::V1::DataStreamsService::Stub::AsyncDescribeStreamSummary,
-                                                                       [&](Ydb::DataStreams::V1::DescribeStreamSummaryRequest& req) {
+            return CallImpl<NYdbProtos::DataStreams::V1::DataStreamsService,
+                    NYdbProtos::DataStreams::V1::DescribeStreamSummaryRequest,
+                    NYdbProtos::DataStreams::V1::DescribeStreamSummaryResponse,
+                    NYdbProtos::DataStreams::V1::DescribeStreamSummaryResult>(settings, &NYdbProtos::DataStreams::V1::DataStreamsService::Stub::AsyncDescribeStreamSummary,
+                                                                       [&](NYdbProtos::DataStreams::V1::DescribeStreamSummaryRequest& req) {
                                                                            req.set_stream_name(TStringType{path});
                                                                        });
         }
 
         TAsyncDecreaseStreamRetentionPeriodResult DecreaseStreamRetentionPeriod(const std::string& path, TDecreaseStreamRetentionPeriodSettings settings) {
-            return CallImpl<Ydb::DataStreams::V1::DataStreamsService,
-                    Ydb::DataStreams::V1::DecreaseStreamRetentionPeriodRequest,
-                    Ydb::DataStreams::V1::DecreaseStreamRetentionPeriodResponse,
-                    Ydb::DataStreams::V1::DecreaseStreamRetentionPeriodResult>(settings, &Ydb::DataStreams::V1::DataStreamsService::Stub::AsyncDecreaseStreamRetentionPeriod,
-                                                                               [&](Ydb::DataStreams::V1::DecreaseStreamRetentionPeriodRequest& req) {
+            return CallImpl<NYdbProtos::DataStreams::V1::DataStreamsService,
+                    NYdbProtos::DataStreams::V1::DecreaseStreamRetentionPeriodRequest,
+                    NYdbProtos::DataStreams::V1::DecreaseStreamRetentionPeriodResponse,
+                    NYdbProtos::DataStreams::V1::DecreaseStreamRetentionPeriodResult>(settings, &NYdbProtos::DataStreams::V1::DataStreamsService::Stub::AsyncDecreaseStreamRetentionPeriod,
+                                                                               [&](NYdbProtos::DataStreams::V1::DecreaseStreamRetentionPeriodRequest& req) {
                                                                                    req.set_stream_name(TStringType{path});
                                                                                    req.set_retention_period_hours(settings.RetentionPeriodHours_);
                                                                                });
@@ -251,11 +251,11 @@ namespace NYdb::inline V3::NDataStreams::V1 {
         }
 
         TAsyncIncreaseStreamRetentionPeriodResult IncreaseStreamRetentionPeriod(const std::string& path, TIncreaseStreamRetentionPeriodSettings settings) {
-            return CallImpl<Ydb::DataStreams::V1::DataStreamsService,
-                    Ydb::DataStreams::V1::IncreaseStreamRetentionPeriodRequest,
-                    Ydb::DataStreams::V1::IncreaseStreamRetentionPeriodResponse,
-                    Ydb::DataStreams::V1::IncreaseStreamRetentionPeriodResult>(settings, &Ydb::DataStreams::V1::DataStreamsService::Stub::AsyncIncreaseStreamRetentionPeriod,
-                                                                  [&](Ydb::DataStreams::V1::IncreaseStreamRetentionPeriodRequest& req) {
+            return CallImpl<NYdbProtos::DataStreams::V1::DataStreamsService,
+                    NYdbProtos::DataStreams::V1::IncreaseStreamRetentionPeriodRequest,
+                    NYdbProtos::DataStreams::V1::IncreaseStreamRetentionPeriodResponse,
+                    NYdbProtos::DataStreams::V1::IncreaseStreamRetentionPeriodResult>(settings, &NYdbProtos::DataStreams::V1::DataStreamsService::Stub::AsyncIncreaseStreamRetentionPeriod,
+                                                                  [&](NYdbProtos::DataStreams::V1::IncreaseStreamRetentionPeriodRequest& req) {
                                                                       req.set_stream_name(TStringType{path});
                                                                       req.set_retention_period_hours(settings.RetentionPeriodHours_);
                                                                   });
@@ -263,64 +263,64 @@ namespace NYdb::inline V3::NDataStreams::V1 {
         }
 
         TAsyncUpdateShardCountResult UpdateShardCount(const std::string& path, TUpdateShardCountSettings settings) {
-            return CallImpl<Ydb::DataStreams::V1::DataStreamsService,
-                    Ydb::DataStreams::V1::UpdateShardCountRequest,
-                    Ydb::DataStreams::V1::UpdateShardCountResponse,
-                    Ydb::DataStreams::V1::UpdateShardCountResult>(settings, &Ydb::DataStreams::V1::DataStreamsService::Stub::AsyncUpdateShardCount,
-                                                                  [&](Ydb::DataStreams::V1::UpdateShardCountRequest& req) {
+            return CallImpl<NYdbProtos::DataStreams::V1::DataStreamsService,
+                    NYdbProtos::DataStreams::V1::UpdateShardCountRequest,
+                    NYdbProtos::DataStreams::V1::UpdateShardCountResponse,
+                    NYdbProtos::DataStreams::V1::UpdateShardCountResult>(settings, &NYdbProtos::DataStreams::V1::DataStreamsService::Stub::AsyncUpdateShardCount,
+                                                                  [&](NYdbProtos::DataStreams::V1::UpdateShardCountRequest& req) {
                                                                       req.set_stream_name(TStringType{path});
                                                                       req.set_target_shard_count(settings.TargetShardCount_);
                                                                   });
         }
 
         TAsyncUpdateStreamModeResult UpdateStreamMode(const std::string& path, TUpdateStreamModeSettings settings) {
-            return CallImpl<Ydb::DataStreams::V1::DataStreamsService,
-                    Ydb::DataStreams::V1::UpdateStreamModeRequest,
-                    Ydb::DataStreams::V1::UpdateStreamModeResponse,
-                    Ydb::DataStreams::V1::UpdateStreamModeResult>(settings, &Ydb::DataStreams::V1::DataStreamsService::Stub::AsyncUpdateStreamMode,
-                                                                  [&](Ydb::DataStreams::V1::UpdateStreamModeRequest& req) {
+            return CallImpl<NYdbProtos::DataStreams::V1::DataStreamsService,
+                    NYdbProtos::DataStreams::V1::UpdateStreamModeRequest,
+                    NYdbProtos::DataStreams::V1::UpdateStreamModeResponse,
+                    NYdbProtos::DataStreams::V1::UpdateStreamModeResult>(settings, &NYdbProtos::DataStreams::V1::DataStreamsService::Stub::AsyncUpdateStreamMode,
+                                                                  [&](NYdbProtos::DataStreams::V1::UpdateStreamModeRequest& req) {
                                                                     req.set_stream_arn(TStringType{path});
 
                                                                     req.mutable_stream_mode_details()->set_stream_mode(
-                                                                        settings.StreamMode_ == ESM_PROVISIONED ? Ydb::DataStreams::V1::StreamMode::PROVISIONED
-                                                                                                                : Ydb::DataStreams::V1::StreamMode::ON_DEMAND);
+                                                                        settings.StreamMode_ == ESM_PROVISIONED ? NYdbProtos::DataStreams::V1::StreamMode::PROVISIONED
+                                                                                                                : NYdbProtos::DataStreams::V1::StreamMode::ON_DEMAND);
                                                                         });
         }
 
         TAsyncRegisterStreamConsumerResult RegisterStreamConsumer(const std::string& path, const std::string& consumer_name, TRegisterStreamConsumerSettings settings) {
-            return CallImpl<Ydb::DataStreams::V1::DataStreamsService,
-                    Ydb::DataStreams::V1::RegisterStreamConsumerRequest,
-                    Ydb::DataStreams::V1::RegisterStreamConsumerResponse,
-                    Ydb::DataStreams::V1::RegisterStreamConsumerResult>(settings, &Ydb::DataStreams::V1::DataStreamsService::Stub::AsyncRegisterStreamConsumer,
-                    [&](Ydb::DataStreams::V1::RegisterStreamConsumerRequest& req) {
+            return CallImpl<NYdbProtos::DataStreams::V1::DataStreamsService,
+                    NYdbProtos::DataStreams::V1::RegisterStreamConsumerRequest,
+                    NYdbProtos::DataStreams::V1::RegisterStreamConsumerResponse,
+                    NYdbProtos::DataStreams::V1::RegisterStreamConsumerResult>(settings, &NYdbProtos::DataStreams::V1::DataStreamsService::Stub::AsyncRegisterStreamConsumer,
+                    [&](NYdbProtos::DataStreams::V1::RegisterStreamConsumerRequest& req) {
                         req.set_stream_arn(TStringType{path});
                         req.set_consumer_name(TStringType{consumer_name});
                     });
         }
 
         TAsyncDeregisterStreamConsumerResult DeregisterStreamConsumer(const std::string& path, const std::string& consumer_name, TDeregisterStreamConsumerSettings settings) {
-            return CallImpl<Ydb::DataStreams::V1::DataStreamsService,
-                    Ydb::DataStreams::V1::DeregisterStreamConsumerRequest,
-                    Ydb::DataStreams::V1::DeregisterStreamConsumerResponse,
-                    Ydb::DataStreams::V1::DeregisterStreamConsumerResult>(settings, &Ydb::DataStreams::V1::DataStreamsService::Stub::AsyncDeregisterStreamConsumer,
-                    [&](Ydb::DataStreams::V1::DeregisterStreamConsumerRequest& req) {
+            return CallImpl<NYdbProtos::DataStreams::V1::DataStreamsService,
+                    NYdbProtos::DataStreams::V1::DeregisterStreamConsumerRequest,
+                    NYdbProtos::DataStreams::V1::DeregisterStreamConsumerResponse,
+                    NYdbProtos::DataStreams::V1::DeregisterStreamConsumerResult>(settings, &NYdbProtos::DataStreams::V1::DataStreamsService::Stub::AsyncDeregisterStreamConsumer,
+                    [&](NYdbProtos::DataStreams::V1::DeregisterStreamConsumerRequest& req) {
                         req.set_stream_arn(TStringType{path});
                         req.set_consumer_name(TStringType{consumer_name});
                     });
         }
 
         TAsyncDescribeStreamConsumerResult DescribeStreamConsumer(TDescribeStreamConsumerSettings settings) {
-            return CallImpl<Ydb::DataStreams::V1::DataStreamsService,
-                    Ydb::DataStreams::V1::DescribeStreamConsumerRequest,
-                    Ydb::DataStreams::V1::DescribeStreamConsumerResponse,
-                    Ydb::DataStreams::V1::DescribeStreamConsumerResult>(settings, &Ydb::DataStreams::V1::DataStreamsService::Stub::AsyncDescribeStreamConsumer);
+            return CallImpl<NYdbProtos::DataStreams::V1::DataStreamsService,
+                    NYdbProtos::DataStreams::V1::DescribeStreamConsumerRequest,
+                    NYdbProtos::DataStreams::V1::DescribeStreamConsumerResponse,
+                    NYdbProtos::DataStreams::V1::DescribeStreamConsumerResult>(settings, &NYdbProtos::DataStreams::V1::DataStreamsService::Stub::AsyncDescribeStreamConsumer);
         }
 
         TAsyncListStreamConsumersResult ListStreamConsumers(const std::string& path, TListStreamConsumersSettings settings) {
-            return CallImpl<Ydb::DataStreams::V1::DataStreamsService,
-                    Ydb::DataStreams::V1::ListStreamConsumersRequest,
-                    Ydb::DataStreams::V1::ListStreamConsumersResponse,
-                    Ydb::DataStreams::V1::ListStreamConsumersResult>(settings, &Ydb::DataStreams::V1::DataStreamsService::Stub::AsyncListStreamConsumers, [&](Ydb::DataStreams::V1::ListStreamConsumersRequest& req) {
+            return CallImpl<NYdbProtos::DataStreams::V1::DataStreamsService,
+                    NYdbProtos::DataStreams::V1::ListStreamConsumersRequest,
+                    NYdbProtos::DataStreams::V1::ListStreamConsumersResponse,
+                    NYdbProtos::DataStreams::V1::ListStreamConsumersResult>(settings, &NYdbProtos::DataStreams::V1::DataStreamsService::Stub::AsyncListStreamConsumers, [&](NYdbProtos::DataStreams::V1::ListStreamConsumersRequest& req) {
                         req.set_stream_arn(TStringType{path});
                         req.set_next_token(TStringType{settings.NextToken_});
                         req.set_max_results(settings.MaxResults_);
@@ -328,80 +328,80 @@ namespace NYdb::inline V3::NDataStreams::V1 {
         }
 
         TAsyncAddTagsToStreamResult AddTagsToStream(TAddTagsToStreamSettings settings) {
-            return CallImpl<Ydb::DataStreams::V1::DataStreamsService,
-                    Ydb::DataStreams::V1::AddTagsToStreamRequest,
-                    Ydb::DataStreams::V1::AddTagsToStreamResponse,
-                    Ydb::DataStreams::V1::AddTagsToStreamResult>(settings, &Ydb::DataStreams::V1::DataStreamsService::Stub::AsyncAddTagsToStream);
+            return CallImpl<NYdbProtos::DataStreams::V1::DataStreamsService,
+                    NYdbProtos::DataStreams::V1::AddTagsToStreamRequest,
+                    NYdbProtos::DataStreams::V1::AddTagsToStreamResponse,
+                    NYdbProtos::DataStreams::V1::AddTagsToStreamResult>(settings, &NYdbProtos::DataStreams::V1::DataStreamsService::Stub::AsyncAddTagsToStream);
         }
 
         TAsyncDisableEnhancedMonitoringResult DisableEnhancedMonitoring(TDisableEnhancedMonitoringSettings settings) {
-            return CallImpl<Ydb::DataStreams::V1::DataStreamsService,
-                    Ydb::DataStreams::V1::DisableEnhancedMonitoringRequest,
-                    Ydb::DataStreams::V1::DisableEnhancedMonitoringResponse,
-                    Ydb::DataStreams::V1::DisableEnhancedMonitoringResult>(settings, &Ydb::DataStreams::V1::DataStreamsService::Stub::AsyncDisableEnhancedMonitoring);
+            return CallImpl<NYdbProtos::DataStreams::V1::DataStreamsService,
+                    NYdbProtos::DataStreams::V1::DisableEnhancedMonitoringRequest,
+                    NYdbProtos::DataStreams::V1::DisableEnhancedMonitoringResponse,
+                    NYdbProtos::DataStreams::V1::DisableEnhancedMonitoringResult>(settings, &NYdbProtos::DataStreams::V1::DataStreamsService::Stub::AsyncDisableEnhancedMonitoring);
         }
 
         TAsyncEnableEnhancedMonitoringResult EnableEnhancedMonitoring(TEnableEnhancedMonitoringSettings settings) {
-            return CallImpl<Ydb::DataStreams::V1::DataStreamsService,
-                    Ydb::DataStreams::V1::EnableEnhancedMonitoringRequest,
-                    Ydb::DataStreams::V1::EnableEnhancedMonitoringResponse,
-                    Ydb::DataStreams::V1::EnableEnhancedMonitoringResult>(settings, &Ydb::DataStreams::V1::DataStreamsService::Stub::AsyncEnableEnhancedMonitoring);
+            return CallImpl<NYdbProtos::DataStreams::V1::DataStreamsService,
+                    NYdbProtos::DataStreams::V1::EnableEnhancedMonitoringRequest,
+                    NYdbProtos::DataStreams::V1::EnableEnhancedMonitoringResponse,
+                    NYdbProtos::DataStreams::V1::EnableEnhancedMonitoringResult>(settings, &NYdbProtos::DataStreams::V1::DataStreamsService::Stub::AsyncEnableEnhancedMonitoring);
         }
 
         TAsyncListTagsForStreamResult ListTagsForStream(TListTagsForStreamSettings settings) {
-            return CallImpl<Ydb::DataStreams::V1::DataStreamsService,
-                    Ydb::DataStreams::V1::ListTagsForStreamRequest,
-                    Ydb::DataStreams::V1::ListTagsForStreamResponse,
-                    Ydb::DataStreams::V1::ListTagsForStreamResult>(settings, &Ydb::DataStreams::V1::DataStreamsService::Stub::AsyncListTagsForStream);
+            return CallImpl<NYdbProtos::DataStreams::V1::DataStreamsService,
+                    NYdbProtos::DataStreams::V1::ListTagsForStreamRequest,
+                    NYdbProtos::DataStreams::V1::ListTagsForStreamResponse,
+                    NYdbProtos::DataStreams::V1::ListTagsForStreamResult>(settings, &NYdbProtos::DataStreams::V1::DataStreamsService::Stub::AsyncListTagsForStream);
         }
 
         TAsyncMergeShardsResult MergeShards(TMergeShardsSettings settings) {
-            return CallImpl<Ydb::DataStreams::V1::DataStreamsService,
-                    Ydb::DataStreams::V1::MergeShardsRequest,
-                    Ydb::DataStreams::V1::MergeShardsResponse,
-                    Ydb::DataStreams::V1::MergeShardsResult>(settings, &Ydb::DataStreams::V1::DataStreamsService::Stub::AsyncMergeShards);
+            return CallImpl<NYdbProtos::DataStreams::V1::DataStreamsService,
+                    NYdbProtos::DataStreams::V1::MergeShardsRequest,
+                    NYdbProtos::DataStreams::V1::MergeShardsResponse,
+                    NYdbProtos::DataStreams::V1::MergeShardsResult>(settings, &NYdbProtos::DataStreams::V1::DataStreamsService::Stub::AsyncMergeShards);
         }
 
         TAsyncRemoveTagsFromStreamResult RemoveTagsFromStream(TRemoveTagsFromStreamSettings settings) {
-            return CallImpl<Ydb::DataStreams::V1::DataStreamsService,
-                    Ydb::DataStreams::V1::RemoveTagsFromStreamRequest,
-                    Ydb::DataStreams::V1::RemoveTagsFromStreamResponse,
-                    Ydb::DataStreams::V1::RemoveTagsFromStreamResult>(settings, &Ydb::DataStreams::V1::DataStreamsService::Stub::AsyncRemoveTagsFromStream);
+            return CallImpl<NYdbProtos::DataStreams::V1::DataStreamsService,
+                    NYdbProtos::DataStreams::V1::RemoveTagsFromStreamRequest,
+                    NYdbProtos::DataStreams::V1::RemoveTagsFromStreamResponse,
+                    NYdbProtos::DataStreams::V1::RemoveTagsFromStreamResult>(settings, &NYdbProtos::DataStreams::V1::DataStreamsService::Stub::AsyncRemoveTagsFromStream);
         }
 
         TAsyncSplitShardResult SplitShard(TSplitShardSettings settings) {
-            return CallImpl<Ydb::DataStreams::V1::DataStreamsService,
-                    Ydb::DataStreams::V1::SplitShardRequest,
-                    Ydb::DataStreams::V1::SplitShardResponse,
-                    Ydb::DataStreams::V1::SplitShardResult>(settings, &Ydb::DataStreams::V1::DataStreamsService::Stub::AsyncSplitShard);
+            return CallImpl<NYdbProtos::DataStreams::V1::DataStreamsService,
+                    NYdbProtos::DataStreams::V1::SplitShardRequest,
+                    NYdbProtos::DataStreams::V1::SplitShardResponse,
+                    NYdbProtos::DataStreams::V1::SplitShardResult>(settings, &NYdbProtos::DataStreams::V1::DataStreamsService::Stub::AsyncSplitShard);
         }
 
         TAsyncStartStreamEncryptionResult StartStreamEncryption(TStartStreamEncryptionSettings settings) {
-            return CallImpl<Ydb::DataStreams::V1::DataStreamsService,
-                    Ydb::DataStreams::V1::StartStreamEncryptionRequest,
-                    Ydb::DataStreams::V1::StartStreamEncryptionResponse,
-                    Ydb::DataStreams::V1::StartStreamEncryptionResult>(settings, &Ydb::DataStreams::V1::DataStreamsService::Stub::AsyncStartStreamEncryption);
+            return CallImpl<NYdbProtos::DataStreams::V1::DataStreamsService,
+                    NYdbProtos::DataStreams::V1::StartStreamEncryptionRequest,
+                    NYdbProtos::DataStreams::V1::StartStreamEncryptionResponse,
+                    NYdbProtos::DataStreams::V1::StartStreamEncryptionResult>(settings, &NYdbProtos::DataStreams::V1::DataStreamsService::Stub::AsyncStartStreamEncryption);
         }
 
         TAsyncStopStreamEncryptionResult StopStreamEncryption(TStopStreamEncryptionSettings settings) {
-            return CallImpl<Ydb::DataStreams::V1::DataStreamsService,
-                    Ydb::DataStreams::V1::StopStreamEncryptionRequest,
-                    Ydb::DataStreams::V1::StopStreamEncryptionResponse,
-                    Ydb::DataStreams::V1::StopStreamEncryptionResult>(settings, &Ydb::DataStreams::V1::DataStreamsService::Stub::AsyncStopStreamEncryption);
+            return CallImpl<NYdbProtos::DataStreams::V1::DataStreamsService,
+                    NYdbProtos::DataStreams::V1::StopStreamEncryptionRequest,
+                    NYdbProtos::DataStreams::V1::StopStreamEncryptionResponse,
+                    NYdbProtos::DataStreams::V1::StopStreamEncryptionResult>(settings, &NYdbProtos::DataStreams::V1::DataStreamsService::Stub::AsyncStopStreamEncryption);
         }
 
         TAsyncUpdateStreamResult UpdateStream(const std::string& streamName, TUpdateStreamSettings settings) {
             if (settings.RetentionPeriodHours_.has_value() && settings.RetentionStorageMegabytes_.has_value()) {
-                return NThreading::MakeFuture(TProtoResultWrapper<Ydb::DataStreams::V1::UpdateStreamResult>(
+                return NThreading::MakeFuture(TProtoResultWrapper<NYdbProtos::DataStreams::V1::UpdateStreamResult>(
                     NYdb::TPlainStatus(NYdb::EStatus::BAD_REQUEST, "both retention types can not be set"),
-                    std::make_unique<Ydb::DataStreams::V1::UpdateStreamResult>()));
+                    std::make_unique<NYdbProtos::DataStreams::V1::UpdateStreamResult>()));
             }
-            return CallImpl<Ydb::DataStreams::V1::DataStreamsService,
-                    Ydb::DataStreams::V1::UpdateStreamRequest,
-                    Ydb::DataStreams::V1::UpdateStreamResponse,
-                    Ydb::DataStreams::V1::UpdateStreamResult>(settings,
-                        &Ydb::DataStreams::V1::DataStreamsService::Stub::AsyncUpdateStream,
-                        [&](Ydb::DataStreams::V1::UpdateStreamRequest& req) {
+            return CallImpl<NYdbProtos::DataStreams::V1::DataStreamsService,
+                    NYdbProtos::DataStreams::V1::UpdateStreamRequest,
+                    NYdbProtos::DataStreams::V1::UpdateStreamResponse,
+                    NYdbProtos::DataStreams::V1::UpdateStreamResult>(settings,
+                        &NYdbProtos::DataStreams::V1::DataStreamsService::Stub::AsyncUpdateStream,
+                        [&](NYdbProtos::DataStreams::V1::UpdateStreamRequest& req) {
                             req.set_stream_name(TStringType{streamName});
                             req.set_target_shard_count(settings.TargetShardCount_);
                             if (settings.RetentionPeriodHours_.has_value()) {
@@ -413,8 +413,8 @@ namespace NYdb::inline V3::NDataStreams::V1 {
                             req.set_write_quota_kb_per_sec(settings.WriteQuotaKbPerSec_);
                             if (settings.StreamMode_.has_value()) {
                                 req.mutable_stream_mode_details()->set_stream_mode(
-                                        *settings.StreamMode_ == ESM_PROVISIONED ? Ydb::DataStreams::V1::StreamMode::PROVISIONED
-                                                                                : Ydb::DataStreams::V1::StreamMode::ON_DEMAND);
+                                        *settings.StreamMode_ == ESM_PROVISIONED ? NYdbProtos::DataStreams::V1::StreamMode::PROVISIONED
+                                                                                : NYdbProtos::DataStreams::V1::StreamMode::ON_DEMAND);
                             }
 
                             if (settings.PartitioningSettings_.has_value()) {
@@ -424,23 +424,23 @@ namespace NYdb::inline V3::NDataStreams::V1 {
         }
 
         TAsyncDeleteStreamResult DeleteStream(const std::string &path, TDeleteStreamSettings settings) {
-            return CallImpl<Ydb::DataStreams::V1::DataStreamsService,
-                    Ydb::DataStreams::V1::DeleteStreamRequest,
-                    Ydb::DataStreams::V1::DeleteStreamResponse,
-                    Ydb::DataStreams::V1::DeleteStreamResult>(settings,
-                        &Ydb::DataStreams::V1::DataStreamsService::Stub::AsyncDeleteStream,
-                        [&](Ydb::DataStreams::V1::DeleteStreamRequest& req) {
+            return CallImpl<NYdbProtos::DataStreams::V1::DataStreamsService,
+                    NYdbProtos::DataStreams::V1::DeleteStreamRequest,
+                    NYdbProtos::DataStreams::V1::DeleteStreamResponse,
+                    NYdbProtos::DataStreams::V1::DeleteStreamResult>(settings,
+                        &NYdbProtos::DataStreams::V1::DataStreamsService::Stub::AsyncDeleteStream,
+                        [&](NYdbProtos::DataStreams::V1::DeleteStreamRequest& req) {
                             req.set_stream_name(TStringType{path});
                             req.set_enforce_consumer_deletion(settings.EnforceConsumerDeletion_);
                         });
         }
 
         TAsyncDescribeStreamResult DescribeStream(const std::string &path, TDescribeStreamSettings settings) {
-            return CallImpl<Ydb::DataStreams::V1::DataStreamsService,
-                    Ydb::DataStreams::V1::DescribeStreamRequest,
-                    Ydb::DataStreams::V1::DescribeStreamResponse,
-                    Ydb::DataStreams::V1::DescribeStreamResult>(settings, &Ydb::DataStreams::V1::DataStreamsService::Stub::AsyncDescribeStream,
-                                                              [&](Ydb::DataStreams::V1::DescribeStreamRequest& req) {
+            return CallImpl<NYdbProtos::DataStreams::V1::DataStreamsService,
+                    NYdbProtos::DataStreams::V1::DescribeStreamRequest,
+                    NYdbProtos::DataStreams::V1::DescribeStreamResponse,
+                    NYdbProtos::DataStreams::V1::DescribeStreamResult>(settings, &NYdbProtos::DataStreams::V1::DataStreamsService::Stub::AsyncDescribeStream,
+                                                              [&](NYdbProtos::DataStreams::V1::DescribeStreamRequest& req) {
                                                                   req.set_stream_name(TStringType{path});
                                                                   req.set_exclusive_start_shard_id(TStringType{settings.ExclusiveStartShardId_});
                                                                   req.set_limit(settings.Limit_);
@@ -448,11 +448,11 @@ namespace NYdb::inline V3::NDataStreams::V1 {
         }
 
         TAsyncPutRecordResult PutRecord(const std::string &path, const TDataRecord& record, TPutRecordSettings settings) {
-            return CallImpl<Ydb::DataStreams::V1::DataStreamsService,
-                    Ydb::DataStreams::V1::PutRecordRequest,
-                    Ydb::DataStreams::V1::PutRecordResponse,
-                    Ydb::DataStreams::V1::PutRecordResult>(settings, &Ydb::DataStreams::V1::DataStreamsService::Stub::AsyncPutRecord,
-                                                                [&](Ydb::DataStreams::V1::PutRecordRequest& req) {
+            return CallImpl<NYdbProtos::DataStreams::V1::DataStreamsService,
+                    NYdbProtos::DataStreams::V1::PutRecordRequest,
+                    NYdbProtos::DataStreams::V1::PutRecordResponse,
+                    NYdbProtos::DataStreams::V1::PutRecordResult>(settings, &NYdbProtos::DataStreams::V1::DataStreamsService::Stub::AsyncPutRecord,
+                                                                [&](NYdbProtos::DataStreams::V1::PutRecordRequest& req) {
                                                                     req.set_stream_name(TStringType{path});
                                                                     req.set_explicit_hash_key(TStringType{record.ExplicitHashDecimal});
                                                                     req.set_partition_key(TStringType{record.PartitionKey});
@@ -462,7 +462,7 @@ namespace NYdb::inline V3::NDataStreams::V1 {
 
         template<class TProtoRequest, class TProtoResponse, class TProtoResult, class TMethod>
         NThreading::TFuture<TProtoResultWrapper<TProtoResult>> DoProtoRequest(const TProtoRequest& proto, TMethod method, const TProtoRequestSettings& settings) {
-            return CallImpl<Ydb::DataStreams::V1::DataStreamsService, TProtoRequest, TProtoResponse, TProtoResult>(settings, method,
+            return CallImpl<NYdbProtos::DataStreams::V1::DataStreamsService, TProtoRequest, TProtoResponse, TProtoResult>(settings, method,
                [&](TProtoRequest& req) {
                     req.CopyFrom(proto);
                });
@@ -499,7 +499,7 @@ namespace NYdb::inline V3::NDataStreams::V1 {
     }
 
     TAsyncListShardsResult TDataStreamsClient::ListShards(const std::string& path,
-                                                          const Ydb::DataStreams::V1::ShardFilter& shardFilter,
+                                                          const NYdbProtos::DataStreams::V1::ShardFilter& shardFilter,
                                                           TListShardsSettings settings) {
         return Impl_->ListShards(path, shardFilter, settings);
     }
@@ -512,7 +512,7 @@ namespace NYdb::inline V3::NDataStreams::V1 {
         return Impl_->GetRecords(shardIterator, settings);
     }
 
-    TAsyncGetShardIteratorResult TDataStreamsClient::GetShardIterator(const std::string& path, const std::string& shardId, Ydb::DataStreams::V1::ShardIteratorType shardIteratorType, TGetShardIteratorSettings settings) {
+    TAsyncGetShardIteratorResult TDataStreamsClient::GetShardIterator(const std::string& path, const std::string& shardId, NYdbProtos::DataStreams::V1::ShardIteratorType shardIteratorType, TGetShardIteratorSettings settings) {
         return Impl_->GetShardIterator(path, shardId, shardIteratorType, settings);
     }
 
@@ -607,351 +607,351 @@ namespace NYdb::inline V3::NDataStreams::V1 {
 
 
     // Instantiate template protobuf methods
-    template NThreading::TFuture<TProtoResultWrapper<Ydb::DataStreams::V1::PutRecordsResult>> TDataStreamsClient::DoProtoRequest
+    template NThreading::TFuture<TProtoResultWrapper<NYdbProtos::DataStreams::V1::PutRecordsResult>> TDataStreamsClient::DoProtoRequest
             <
-                Ydb::DataStreams::V1::PutRecordsRequest,
-                Ydb::DataStreams::V1::PutRecordsResponse,
-                Ydb::DataStreams::V1::PutRecordsResult,
-                decltype(&Ydb::DataStreams::V1::DataStreamsService::Stub::AsyncPutRecords)
+                NYdbProtos::DataStreams::V1::PutRecordsRequest,
+                NYdbProtos::DataStreams::V1::PutRecordsResponse,
+                NYdbProtos::DataStreams::V1::PutRecordsResult,
+                decltype(&NYdbProtos::DataStreams::V1::DataStreamsService::Stub::AsyncPutRecords)
             >(
-                    const Ydb::DataStreams::V1::PutRecordsRequest& request,
-                    decltype(&Ydb::DataStreams::V1::DataStreamsService::Stub::AsyncPutRecords) method,
+                    const NYdbProtos::DataStreams::V1::PutRecordsRequest& request,
+                    decltype(&NYdbProtos::DataStreams::V1::DataStreamsService::Stub::AsyncPutRecords) method,
                     TProtoRequestSettings settings
             );
 
-    template NThreading::TFuture<TProtoResultWrapper<Ydb::DataStreams::V1::PutRecordResult>>TDataStreamsClient::DoProtoRequest
+    template NThreading::TFuture<TProtoResultWrapper<NYdbProtos::DataStreams::V1::PutRecordResult>>TDataStreamsClient::DoProtoRequest
                 <
-                    Ydb::DataStreams::V1::PutRecordRequest,
-                    Ydb::DataStreams::V1::PutRecordResponse,
-                    Ydb::DataStreams::V1::PutRecordResult,
-                    decltype(&Ydb::DataStreams::V1::DataStreamsService::Stub::AsyncPutRecord)
+                    NYdbProtos::DataStreams::V1::PutRecordRequest,
+                    NYdbProtos::DataStreams::V1::PutRecordResponse,
+                    NYdbProtos::DataStreams::V1::PutRecordResult,
+                    decltype(&NYdbProtos::DataStreams::V1::DataStreamsService::Stub::AsyncPutRecord)
                 >(
-                        const Ydb::DataStreams::V1::PutRecordRequest& request,
-                        decltype(&Ydb::DataStreams::V1::DataStreamsService::Stub::AsyncPutRecord) method,
+                        const NYdbProtos::DataStreams::V1::PutRecordRequest& request,
+                        decltype(&NYdbProtos::DataStreams::V1::DataStreamsService::Stub::AsyncPutRecord) method,
                         TProtoRequestSettings settings
                 );
 
-    template NThreading::TFuture<TProtoResultWrapper<Ydb::DataStreams::V1::ListStreamsResult>> TDataStreamsClient::DoProtoRequest
+    template NThreading::TFuture<TProtoResultWrapper<NYdbProtos::DataStreams::V1::ListStreamsResult>> TDataStreamsClient::DoProtoRequest
                 <
-                    Ydb::DataStreams::V1::ListStreamsRequest,
-                    Ydb::DataStreams::V1::ListStreamsResponse,
-                    Ydb::DataStreams::V1::ListStreamsResult,
-                    decltype(&Ydb::DataStreams::V1::DataStreamsService::Stub::AsyncListStreams)
+                    NYdbProtos::DataStreams::V1::ListStreamsRequest,
+                    NYdbProtos::DataStreams::V1::ListStreamsResponse,
+                    NYdbProtos::DataStreams::V1::ListStreamsResult,
+                    decltype(&NYdbProtos::DataStreams::V1::DataStreamsService::Stub::AsyncListStreams)
                 >(
-                        const Ydb::DataStreams::V1::ListStreamsRequest& request,
-                        decltype(&Ydb::DataStreams::V1::DataStreamsService::Stub::AsyncListStreams) method,
+                        const NYdbProtos::DataStreams::V1::ListStreamsRequest& request,
+                        decltype(&NYdbProtos::DataStreams::V1::DataStreamsService::Stub::AsyncListStreams) method,
                         TProtoRequestSettings settings
                 );
 
-    template NThreading::TFuture<TProtoResultWrapper<Ydb::DataStreams::V1::CreateStreamResult>> TDataStreamsClient::DoProtoRequest
+    template NThreading::TFuture<TProtoResultWrapper<NYdbProtos::DataStreams::V1::CreateStreamResult>> TDataStreamsClient::DoProtoRequest
                 <
-                    Ydb::DataStreams::V1::CreateStreamRequest,
-                    Ydb::DataStreams::V1::CreateStreamResponse,
-                    Ydb::DataStreams::V1::CreateStreamResult,
-                    decltype(&Ydb::DataStreams::V1::DataStreamsService::Stub::AsyncCreateStream)
+                    NYdbProtos::DataStreams::V1::CreateStreamRequest,
+                    NYdbProtos::DataStreams::V1::CreateStreamResponse,
+                    NYdbProtos::DataStreams::V1::CreateStreamResult,
+                    decltype(&NYdbProtos::DataStreams::V1::DataStreamsService::Stub::AsyncCreateStream)
                 >(
-                        const Ydb::DataStreams::V1::CreateStreamRequest& request,
-                        decltype(&Ydb::DataStreams::V1::DataStreamsService::Stub::AsyncCreateStream) method,
+                        const NYdbProtos::DataStreams::V1::CreateStreamRequest& request,
+                        decltype(&NYdbProtos::DataStreams::V1::DataStreamsService::Stub::AsyncCreateStream) method,
                         TProtoRequestSettings settings
                 );
 
-    template NThreading::TFuture<TProtoResultWrapper<Ydb::DataStreams::V1::UpdateStreamResult>> TDataStreamsClient::DoProtoRequest
+    template NThreading::TFuture<TProtoResultWrapper<NYdbProtos::DataStreams::V1::UpdateStreamResult>> TDataStreamsClient::DoProtoRequest
                 <
-                    Ydb::DataStreams::V1::UpdateStreamRequest,
-                    Ydb::DataStreams::V1::UpdateStreamResponse,
-                    Ydb::DataStreams::V1::UpdateStreamResult,
-                    decltype(&Ydb::DataStreams::V1::DataStreamsService::Stub::AsyncUpdateStream)
+                    NYdbProtos::DataStreams::V1::UpdateStreamRequest,
+                    NYdbProtos::DataStreams::V1::UpdateStreamResponse,
+                    NYdbProtos::DataStreams::V1::UpdateStreamResult,
+                    decltype(&NYdbProtos::DataStreams::V1::DataStreamsService::Stub::AsyncUpdateStream)
                 >(
-                        const Ydb::DataStreams::V1::UpdateStreamRequest& request,
-                        decltype(&Ydb::DataStreams::V1::DataStreamsService::Stub::AsyncUpdateStream) method,
+                        const NYdbProtos::DataStreams::V1::UpdateStreamRequest& request,
+                        decltype(&NYdbProtos::DataStreams::V1::DataStreamsService::Stub::AsyncUpdateStream) method,
                         TProtoRequestSettings settings
                 );
 
-    template NThreading::TFuture<TProtoResultWrapper<Ydb::DataStreams::V1::DeleteStreamResult>> TDataStreamsClient::DoProtoRequest
+    template NThreading::TFuture<TProtoResultWrapper<NYdbProtos::DataStreams::V1::DeleteStreamResult>> TDataStreamsClient::DoProtoRequest
                 <
-                    Ydb::DataStreams::V1::DeleteStreamRequest,
-                    Ydb::DataStreams::V1::DeleteStreamResponse,
-                    Ydb::DataStreams::V1::DeleteStreamResult,
-                    decltype(&Ydb::DataStreams::V1::DataStreamsService::Stub::AsyncDeleteStream)
+                    NYdbProtos::DataStreams::V1::DeleteStreamRequest,
+                    NYdbProtos::DataStreams::V1::DeleteStreamResponse,
+                    NYdbProtos::DataStreams::V1::DeleteStreamResult,
+                    decltype(&NYdbProtos::DataStreams::V1::DataStreamsService::Stub::AsyncDeleteStream)
                 >(
-                        const Ydb::DataStreams::V1::DeleteStreamRequest& request,
-                        decltype(&Ydb::DataStreams::V1::DataStreamsService::Stub::AsyncDeleteStream) method,
+                        const NYdbProtos::DataStreams::V1::DeleteStreamRequest& request,
+                        decltype(&NYdbProtos::DataStreams::V1::DataStreamsService::Stub::AsyncDeleteStream) method,
                         TProtoRequestSettings settings
                 );
 
-    template NThreading::TFuture<TProtoResultWrapper<Ydb::DataStreams::V1::DescribeStreamResult>> TDataStreamsClient::DoProtoRequest
+    template NThreading::TFuture<TProtoResultWrapper<NYdbProtos::DataStreams::V1::DescribeStreamResult>> TDataStreamsClient::DoProtoRequest
                 <
-                    Ydb::DataStreams::V1::DescribeStreamRequest,
-                    Ydb::DataStreams::V1::DescribeStreamResponse,
-                    Ydb::DataStreams::V1::DescribeStreamResult,
-                    decltype(&Ydb::DataStreams::V1::DataStreamsService::Stub::AsyncDescribeStream)
+                    NYdbProtos::DataStreams::V1::DescribeStreamRequest,
+                    NYdbProtos::DataStreams::V1::DescribeStreamResponse,
+                    NYdbProtos::DataStreams::V1::DescribeStreamResult,
+                    decltype(&NYdbProtos::DataStreams::V1::DataStreamsService::Stub::AsyncDescribeStream)
                 >(
-                        const Ydb::DataStreams::V1::DescribeStreamRequest& request,
-                        decltype(&Ydb::DataStreams::V1::DataStreamsService::Stub::AsyncDescribeStream) method,
+                        const NYdbProtos::DataStreams::V1::DescribeStreamRequest& request,
+                        decltype(&NYdbProtos::DataStreams::V1::DataStreamsService::Stub::AsyncDescribeStream) method,
                         TProtoRequestSettings settings
                 );
 
-    template NThreading::TFuture<TProtoResultWrapper<Ydb::DataStreams::V1::ListShardsResult>> TDataStreamsClient::DoProtoRequest
+    template NThreading::TFuture<TProtoResultWrapper<NYdbProtos::DataStreams::V1::ListShardsResult>> TDataStreamsClient::DoProtoRequest
                 <
-                    Ydb::DataStreams::V1::ListShardsRequest,
-                    Ydb::DataStreams::V1::ListShardsResponse,
-                    Ydb::DataStreams::V1::ListShardsResult,
-                    decltype(&Ydb::DataStreams::V1::DataStreamsService::Stub::AsyncListShards)
+                    NYdbProtos::DataStreams::V1::ListShardsRequest,
+                    NYdbProtos::DataStreams::V1::ListShardsResponse,
+                    NYdbProtos::DataStreams::V1::ListShardsResult,
+                    decltype(&NYdbProtos::DataStreams::V1::DataStreamsService::Stub::AsyncListShards)
                 >(
-                        const Ydb::DataStreams::V1::ListShardsRequest& request,
-                        decltype(&Ydb::DataStreams::V1::DataStreamsService::Stub::AsyncListShards) method,
+                        const NYdbProtos::DataStreams::V1::ListShardsRequest& request,
+                        decltype(&NYdbProtos::DataStreams::V1::DataStreamsService::Stub::AsyncListShards) method,
                         TProtoRequestSettings settings
                 );
 
-    template NThreading::TFuture<TProtoResultWrapper<Ydb::DataStreams::V1::GetRecordsResult>> TDataStreamsClient::DoProtoRequest
+    template NThreading::TFuture<TProtoResultWrapper<NYdbProtos::DataStreams::V1::GetRecordsResult>> TDataStreamsClient::DoProtoRequest
                 <
-                    Ydb::DataStreams::V1::GetRecordsRequest,
-                    Ydb::DataStreams::V1::GetRecordsResponse,
-                    Ydb::DataStreams::V1::GetRecordsResult,
-                    decltype(&Ydb::DataStreams::V1::DataStreamsService::Stub::AsyncGetRecords)
+                    NYdbProtos::DataStreams::V1::GetRecordsRequest,
+                    NYdbProtos::DataStreams::V1::GetRecordsResponse,
+                    NYdbProtos::DataStreams::V1::GetRecordsResult,
+                    decltype(&NYdbProtos::DataStreams::V1::DataStreamsService::Stub::AsyncGetRecords)
                 >(
-                        const Ydb::DataStreams::V1::GetRecordsRequest& request,
-                        decltype(&Ydb::DataStreams::V1::DataStreamsService::Stub::AsyncGetRecords) method,
+                        const NYdbProtos::DataStreams::V1::GetRecordsRequest& request,
+                        decltype(&NYdbProtos::DataStreams::V1::DataStreamsService::Stub::AsyncGetRecords) method,
                         TProtoRequestSettings settings
                 );
 
-    template NThreading::TFuture<TProtoResultWrapper<Ydb::DataStreams::V1::GetShardIteratorResult>> TDataStreamsClient::DoProtoRequest
+    template NThreading::TFuture<TProtoResultWrapper<NYdbProtos::DataStreams::V1::GetShardIteratorResult>> TDataStreamsClient::DoProtoRequest
                 <
-                    Ydb::DataStreams::V1::GetShardIteratorRequest,
-                    Ydb::DataStreams::V1::GetShardIteratorResponse,
-                    Ydb::DataStreams::V1::GetShardIteratorResult,
-                    decltype(&Ydb::DataStreams::V1::DataStreamsService::Stub::AsyncGetShardIterator)
+                    NYdbProtos::DataStreams::V1::GetShardIteratorRequest,
+                    NYdbProtos::DataStreams::V1::GetShardIteratorResponse,
+                    NYdbProtos::DataStreams::V1::GetShardIteratorResult,
+                    decltype(&NYdbProtos::DataStreams::V1::DataStreamsService::Stub::AsyncGetShardIterator)
                 >(
-                        const Ydb::DataStreams::V1::GetShardIteratorRequest& request,
-                        decltype(&Ydb::DataStreams::V1::DataStreamsService::Stub::AsyncGetShardIterator) method,
+                        const NYdbProtos::DataStreams::V1::GetShardIteratorRequest& request,
+                        decltype(&NYdbProtos::DataStreams::V1::DataStreamsService::Stub::AsyncGetShardIterator) method,
                         TProtoRequestSettings settings
                 );
 
-    template NThreading::TFuture<TProtoResultWrapper<Ydb::DataStreams::V1::DescribeLimitsResult>> TDataStreamsClient::DoProtoRequest
+    template NThreading::TFuture<TProtoResultWrapper<NYdbProtos::DataStreams::V1::DescribeLimitsResult>> TDataStreamsClient::DoProtoRequest
                 <
-                    Ydb::DataStreams::V1::DescribeLimitsRequest,
-                    Ydb::DataStreams::V1::DescribeLimitsResponse,
-                    Ydb::DataStreams::V1::DescribeLimitsResult,
-                    decltype(&Ydb::DataStreams::V1::DataStreamsService::Stub::AsyncDescribeLimits)
+                    NYdbProtos::DataStreams::V1::DescribeLimitsRequest,
+                    NYdbProtos::DataStreams::V1::DescribeLimitsResponse,
+                    NYdbProtos::DataStreams::V1::DescribeLimitsResult,
+                    decltype(&NYdbProtos::DataStreams::V1::DataStreamsService::Stub::AsyncDescribeLimits)
                 >(
-                        const Ydb::DataStreams::V1::DescribeLimitsRequest& request,
-                        decltype(&Ydb::DataStreams::V1::DataStreamsService::Stub::AsyncDescribeLimits) method,
+                        const NYdbProtos::DataStreams::V1::DescribeLimitsRequest& request,
+                        decltype(&NYdbProtos::DataStreams::V1::DataStreamsService::Stub::AsyncDescribeLimits) method,
                         TProtoRequestSettings settings
                 );
 
-    template NThreading::TFuture<TProtoResultWrapper<Ydb::DataStreams::V1::DecreaseStreamRetentionPeriodResult>> TDataStreamsClient::DoProtoRequest
+    template NThreading::TFuture<TProtoResultWrapper<NYdbProtos::DataStreams::V1::DecreaseStreamRetentionPeriodResult>> TDataStreamsClient::DoProtoRequest
                 <
-                    Ydb::DataStreams::V1::DecreaseStreamRetentionPeriodRequest,
-                    Ydb::DataStreams::V1::DecreaseStreamRetentionPeriodResponse,
-                    Ydb::DataStreams::V1::DecreaseStreamRetentionPeriodResult,
-                    decltype(&Ydb::DataStreams::V1::DataStreamsService::Stub::AsyncDecreaseStreamRetentionPeriod)
+                    NYdbProtos::DataStreams::V1::DecreaseStreamRetentionPeriodRequest,
+                    NYdbProtos::DataStreams::V1::DecreaseStreamRetentionPeriodResponse,
+                    NYdbProtos::DataStreams::V1::DecreaseStreamRetentionPeriodResult,
+                    decltype(&NYdbProtos::DataStreams::V1::DataStreamsService::Stub::AsyncDecreaseStreamRetentionPeriod)
                 >(
-                        const Ydb::DataStreams::V1::DecreaseStreamRetentionPeriodRequest& request,
-                        decltype(&Ydb::DataStreams::V1::DataStreamsService::Stub::AsyncDecreaseStreamRetentionPeriod) method,
+                        const NYdbProtos::DataStreams::V1::DecreaseStreamRetentionPeriodRequest& request,
+                        decltype(&NYdbProtos::DataStreams::V1::DataStreamsService::Stub::AsyncDecreaseStreamRetentionPeriod) method,
                         TProtoRequestSettings settings
                 );
 
-    template NThreading::TFuture<TProtoResultWrapper<Ydb::DataStreams::V1::IncreaseStreamRetentionPeriodResult>> TDataStreamsClient::DoProtoRequest
+    template NThreading::TFuture<TProtoResultWrapper<NYdbProtos::DataStreams::V1::IncreaseStreamRetentionPeriodResult>> TDataStreamsClient::DoProtoRequest
                 <
-                    Ydb::DataStreams::V1::IncreaseStreamRetentionPeriodRequest,
-                    Ydb::DataStreams::V1::IncreaseStreamRetentionPeriodResponse,
-                    Ydb::DataStreams::V1::IncreaseStreamRetentionPeriodResult,
-                    decltype(&Ydb::DataStreams::V1::DataStreamsService::Stub::AsyncIncreaseStreamRetentionPeriod)
+                    NYdbProtos::DataStreams::V1::IncreaseStreamRetentionPeriodRequest,
+                    NYdbProtos::DataStreams::V1::IncreaseStreamRetentionPeriodResponse,
+                    NYdbProtos::DataStreams::V1::IncreaseStreamRetentionPeriodResult,
+                    decltype(&NYdbProtos::DataStreams::V1::DataStreamsService::Stub::AsyncIncreaseStreamRetentionPeriod)
                 >(
-                        const Ydb::DataStreams::V1::IncreaseStreamRetentionPeriodRequest& request,
-                        decltype(&Ydb::DataStreams::V1::DataStreamsService::Stub::AsyncIncreaseStreamRetentionPeriod) method,
+                        const NYdbProtos::DataStreams::V1::IncreaseStreamRetentionPeriodRequest& request,
+                        decltype(&NYdbProtos::DataStreams::V1::DataStreamsService::Stub::AsyncIncreaseStreamRetentionPeriod) method,
                         TProtoRequestSettings settings
                 );
 
-    template NThreading::TFuture<TProtoResultWrapper<Ydb::DataStreams::V1::UpdateShardCountResult>> TDataStreamsClient::DoProtoRequest
+    template NThreading::TFuture<TProtoResultWrapper<NYdbProtos::DataStreams::V1::UpdateShardCountResult>> TDataStreamsClient::DoProtoRequest
                 <
-                    Ydb::DataStreams::V1::UpdateShardCountRequest,
-                    Ydb::DataStreams::V1::UpdateShardCountResponse,
-                    Ydb::DataStreams::V1::UpdateShardCountResult,
-                    decltype(&Ydb::DataStreams::V1::DataStreamsService::Stub::AsyncUpdateShardCount)
+                    NYdbProtos::DataStreams::V1::UpdateShardCountRequest,
+                    NYdbProtos::DataStreams::V1::UpdateShardCountResponse,
+                    NYdbProtos::DataStreams::V1::UpdateShardCountResult,
+                    decltype(&NYdbProtos::DataStreams::V1::DataStreamsService::Stub::AsyncUpdateShardCount)
                 >(
-                        const Ydb::DataStreams::V1::UpdateShardCountRequest& request,
-                        decltype(&Ydb::DataStreams::V1::DataStreamsService::Stub::AsyncUpdateShardCount) method,
+                        const NYdbProtos::DataStreams::V1::UpdateShardCountRequest& request,
+                        decltype(&NYdbProtos::DataStreams::V1::DataStreamsService::Stub::AsyncUpdateShardCount) method,
                         TProtoRequestSettings settings
                 );
 
-    template NThreading::TFuture<TProtoResultWrapper<Ydb::DataStreams::V1::UpdateStreamModeResult>> TDataStreamsClient::DoProtoRequest
+    template NThreading::TFuture<TProtoResultWrapper<NYdbProtos::DataStreams::V1::UpdateStreamModeResult>> TDataStreamsClient::DoProtoRequest
                 <
-                    Ydb::DataStreams::V1::UpdateStreamModeRequest,
-                    Ydb::DataStreams::V1::UpdateStreamModeResponse,
-                    Ydb::DataStreams::V1::UpdateStreamModeResult,
-                    decltype(&Ydb::DataStreams::V1::DataStreamsService::Stub::AsyncUpdateStreamMode)
+                    NYdbProtos::DataStreams::V1::UpdateStreamModeRequest,
+                    NYdbProtos::DataStreams::V1::UpdateStreamModeResponse,
+                    NYdbProtos::DataStreams::V1::UpdateStreamModeResult,
+                    decltype(&NYdbProtos::DataStreams::V1::DataStreamsService::Stub::AsyncUpdateStreamMode)
                 >(
-                        const Ydb::DataStreams::V1::UpdateStreamModeRequest& request,
-                        decltype(&Ydb::DataStreams::V1::DataStreamsService::Stub::AsyncUpdateStreamMode) method,
+                        const NYdbProtos::DataStreams::V1::UpdateStreamModeRequest& request,
+                        decltype(&NYdbProtos::DataStreams::V1::DataStreamsService::Stub::AsyncUpdateStreamMode) method,
                         TProtoRequestSettings settings
                 );
 
-    template NThreading::TFuture<TProtoResultWrapper<Ydb::DataStreams::V1::RegisterStreamConsumerResult>> TDataStreamsClient::DoProtoRequest
+    template NThreading::TFuture<TProtoResultWrapper<NYdbProtos::DataStreams::V1::RegisterStreamConsumerResult>> TDataStreamsClient::DoProtoRequest
                 <
-                    Ydb::DataStreams::V1::RegisterStreamConsumerRequest,
-                    Ydb::DataStreams::V1::RegisterStreamConsumerResponse,
-                    Ydb::DataStreams::V1::RegisterStreamConsumerResult,
-                    decltype(&Ydb::DataStreams::V1::DataStreamsService::Stub::AsyncRegisterStreamConsumer)
+                    NYdbProtos::DataStreams::V1::RegisterStreamConsumerRequest,
+                    NYdbProtos::DataStreams::V1::RegisterStreamConsumerResponse,
+                    NYdbProtos::DataStreams::V1::RegisterStreamConsumerResult,
+                    decltype(&NYdbProtos::DataStreams::V1::DataStreamsService::Stub::AsyncRegisterStreamConsumer)
                 >(
-                        const Ydb::DataStreams::V1::RegisterStreamConsumerRequest& request,
-                        decltype(&Ydb::DataStreams::V1::DataStreamsService::Stub::AsyncRegisterStreamConsumer) method,
+                        const NYdbProtos::DataStreams::V1::RegisterStreamConsumerRequest& request,
+                        decltype(&NYdbProtos::DataStreams::V1::DataStreamsService::Stub::AsyncRegisterStreamConsumer) method,
                         TProtoRequestSettings settings
                 );
 
-    template NThreading::TFuture<TProtoResultWrapper<Ydb::DataStreams::V1::DeregisterStreamConsumerResult>> TDataStreamsClient::DoProtoRequest
+    template NThreading::TFuture<TProtoResultWrapper<NYdbProtos::DataStreams::V1::DeregisterStreamConsumerResult>> TDataStreamsClient::DoProtoRequest
                 <
-                    Ydb::DataStreams::V1::DeregisterStreamConsumerRequest,
-                    Ydb::DataStreams::V1::DeregisterStreamConsumerResponse,
-                    Ydb::DataStreams::V1::DeregisterStreamConsumerResult,
-                    decltype(&Ydb::DataStreams::V1::DataStreamsService::Stub::AsyncDeregisterStreamConsumer)
+                    NYdbProtos::DataStreams::V1::DeregisterStreamConsumerRequest,
+                    NYdbProtos::DataStreams::V1::DeregisterStreamConsumerResponse,
+                    NYdbProtos::DataStreams::V1::DeregisterStreamConsumerResult,
+                    decltype(&NYdbProtos::DataStreams::V1::DataStreamsService::Stub::AsyncDeregisterStreamConsumer)
                 >(
-                        const Ydb::DataStreams::V1::DeregisterStreamConsumerRequest& request,
-                        decltype(&Ydb::DataStreams::V1::DataStreamsService::Stub::AsyncDeregisterStreamConsumer) method,
+                        const NYdbProtos::DataStreams::V1::DeregisterStreamConsumerRequest& request,
+                        decltype(&NYdbProtos::DataStreams::V1::DataStreamsService::Stub::AsyncDeregisterStreamConsumer) method,
                         TProtoRequestSettings settings
                 );
 
-    template NThreading::TFuture<TProtoResultWrapper<Ydb::DataStreams::V1::DescribeStreamConsumerResult>> TDataStreamsClient::DoProtoRequest
+    template NThreading::TFuture<TProtoResultWrapper<NYdbProtos::DataStreams::V1::DescribeStreamConsumerResult>> TDataStreamsClient::DoProtoRequest
                 <
-                    Ydb::DataStreams::V1::DescribeStreamConsumerRequest,
-                    Ydb::DataStreams::V1::DescribeStreamConsumerResponse,
-                    Ydb::DataStreams::V1::DescribeStreamConsumerResult,
-                    decltype(&Ydb::DataStreams::V1::DataStreamsService::Stub::AsyncDescribeStreamConsumer)
+                    NYdbProtos::DataStreams::V1::DescribeStreamConsumerRequest,
+                    NYdbProtos::DataStreams::V1::DescribeStreamConsumerResponse,
+                    NYdbProtos::DataStreams::V1::DescribeStreamConsumerResult,
+                    decltype(&NYdbProtos::DataStreams::V1::DataStreamsService::Stub::AsyncDescribeStreamConsumer)
                 >(
-                        const Ydb::DataStreams::V1::DescribeStreamConsumerRequest& request,
-                        decltype(&Ydb::DataStreams::V1::DataStreamsService::Stub::AsyncDescribeStreamConsumer) method,
+                        const NYdbProtos::DataStreams::V1::DescribeStreamConsumerRequest& request,
+                        decltype(&NYdbProtos::DataStreams::V1::DataStreamsService::Stub::AsyncDescribeStreamConsumer) method,
                         TProtoRequestSettings settings
                 );
 
-    template NThreading::TFuture<TProtoResultWrapper<Ydb::DataStreams::V1::ListStreamConsumersResult>> TDataStreamsClient::DoProtoRequest
+    template NThreading::TFuture<TProtoResultWrapper<NYdbProtos::DataStreams::V1::ListStreamConsumersResult>> TDataStreamsClient::DoProtoRequest
                 <
-                    Ydb::DataStreams::V1::ListStreamConsumersRequest,
-                    Ydb::DataStreams::V1::ListStreamConsumersResponse,
-                    Ydb::DataStreams::V1::ListStreamConsumersResult,
-                    decltype(&Ydb::DataStreams::V1::DataStreamsService::Stub::AsyncListStreamConsumers)
+                    NYdbProtos::DataStreams::V1::ListStreamConsumersRequest,
+                    NYdbProtos::DataStreams::V1::ListStreamConsumersResponse,
+                    NYdbProtos::DataStreams::V1::ListStreamConsumersResult,
+                    decltype(&NYdbProtos::DataStreams::V1::DataStreamsService::Stub::AsyncListStreamConsumers)
                 >(
-                        const Ydb::DataStreams::V1::ListStreamConsumersRequest& request,
-                        decltype(&Ydb::DataStreams::V1::DataStreamsService::Stub::AsyncListStreamConsumers) method,
+                        const NYdbProtos::DataStreams::V1::ListStreamConsumersRequest& request,
+                        decltype(&NYdbProtos::DataStreams::V1::DataStreamsService::Stub::AsyncListStreamConsumers) method,
                         TProtoRequestSettings settings
                 );
 
-    template NThreading::TFuture<TProtoResultWrapper<Ydb::DataStreams::V1::AddTagsToStreamResult>> TDataStreamsClient::DoProtoRequest
+    template NThreading::TFuture<TProtoResultWrapper<NYdbProtos::DataStreams::V1::AddTagsToStreamResult>> TDataStreamsClient::DoProtoRequest
                 <
-                    Ydb::DataStreams::V1::AddTagsToStreamRequest,
-                    Ydb::DataStreams::V1::AddTagsToStreamResponse,
-                    Ydb::DataStreams::V1::AddTagsToStreamResult,
-                    decltype(&Ydb::DataStreams::V1::DataStreamsService::Stub::AsyncAddTagsToStream)
+                    NYdbProtos::DataStreams::V1::AddTagsToStreamRequest,
+                    NYdbProtos::DataStreams::V1::AddTagsToStreamResponse,
+                    NYdbProtos::DataStreams::V1::AddTagsToStreamResult,
+                    decltype(&NYdbProtos::DataStreams::V1::DataStreamsService::Stub::AsyncAddTagsToStream)
                 >(
-                        const Ydb::DataStreams::V1::AddTagsToStreamRequest& request,
-                        decltype(&Ydb::DataStreams::V1::DataStreamsService::Stub::AsyncAddTagsToStream) method,
+                        const NYdbProtos::DataStreams::V1::AddTagsToStreamRequest& request,
+                        decltype(&NYdbProtos::DataStreams::V1::DataStreamsService::Stub::AsyncAddTagsToStream) method,
                         TProtoRequestSettings settings
                 );
 
-    template NThreading::TFuture<TProtoResultWrapper<Ydb::DataStreams::V1::DisableEnhancedMonitoringResult>> TDataStreamsClient::DoProtoRequest
+    template NThreading::TFuture<TProtoResultWrapper<NYdbProtos::DataStreams::V1::DisableEnhancedMonitoringResult>> TDataStreamsClient::DoProtoRequest
                 <
-                    Ydb::DataStreams::V1::DisableEnhancedMonitoringRequest,
-                    Ydb::DataStreams::V1::DisableEnhancedMonitoringResponse,
-                    Ydb::DataStreams::V1::DisableEnhancedMonitoringResult,
-                    decltype(&Ydb::DataStreams::V1::DataStreamsService::Stub::AsyncDisableEnhancedMonitoring)
+                    NYdbProtos::DataStreams::V1::DisableEnhancedMonitoringRequest,
+                    NYdbProtos::DataStreams::V1::DisableEnhancedMonitoringResponse,
+                    NYdbProtos::DataStreams::V1::DisableEnhancedMonitoringResult,
+                    decltype(&NYdbProtos::DataStreams::V1::DataStreamsService::Stub::AsyncDisableEnhancedMonitoring)
                 >(
-                        const Ydb::DataStreams::V1::DisableEnhancedMonitoringRequest& request,
-                        decltype(&Ydb::DataStreams::V1::DataStreamsService::Stub::AsyncDisableEnhancedMonitoring) method,
+                        const NYdbProtos::DataStreams::V1::DisableEnhancedMonitoringRequest& request,
+                        decltype(&NYdbProtos::DataStreams::V1::DataStreamsService::Stub::AsyncDisableEnhancedMonitoring) method,
                         TProtoRequestSettings settings
                 );
 
-    template NThreading::TFuture<TProtoResultWrapper<Ydb::DataStreams::V1::EnableEnhancedMonitoringResult>> TDataStreamsClient::DoProtoRequest
+    template NThreading::TFuture<TProtoResultWrapper<NYdbProtos::DataStreams::V1::EnableEnhancedMonitoringResult>> TDataStreamsClient::DoProtoRequest
                 <
-                    Ydb::DataStreams::V1::EnableEnhancedMonitoringRequest,
-                    Ydb::DataStreams::V1::EnableEnhancedMonitoringResponse,
-                    Ydb::DataStreams::V1::EnableEnhancedMonitoringResult,
-                    decltype(&Ydb::DataStreams::V1::DataStreamsService::Stub::AsyncEnableEnhancedMonitoring)
+                    NYdbProtos::DataStreams::V1::EnableEnhancedMonitoringRequest,
+                    NYdbProtos::DataStreams::V1::EnableEnhancedMonitoringResponse,
+                    NYdbProtos::DataStreams::V1::EnableEnhancedMonitoringResult,
+                    decltype(&NYdbProtos::DataStreams::V1::DataStreamsService::Stub::AsyncEnableEnhancedMonitoring)
                 >(
-                        const Ydb::DataStreams::V1::EnableEnhancedMonitoringRequest& request,
-                        decltype(&Ydb::DataStreams::V1::DataStreamsService::Stub::AsyncEnableEnhancedMonitoring) method,
+                        const NYdbProtos::DataStreams::V1::EnableEnhancedMonitoringRequest& request,
+                        decltype(&NYdbProtos::DataStreams::V1::DataStreamsService::Stub::AsyncEnableEnhancedMonitoring) method,
                         TProtoRequestSettings settings
                 );
 
-    template NThreading::TFuture<TProtoResultWrapper<Ydb::DataStreams::V1::MergeShardsResult>> TDataStreamsClient::DoProtoRequest
+    template NThreading::TFuture<TProtoResultWrapper<NYdbProtos::DataStreams::V1::MergeShardsResult>> TDataStreamsClient::DoProtoRequest
                 <
-                    Ydb::DataStreams::V1::MergeShardsRequest,
-                    Ydb::DataStreams::V1::MergeShardsResponse,
-                    Ydb::DataStreams::V1::MergeShardsResult,
-                    decltype(&Ydb::DataStreams::V1::DataStreamsService::Stub::AsyncMergeShards)
+                    NYdbProtos::DataStreams::V1::MergeShardsRequest,
+                    NYdbProtos::DataStreams::V1::MergeShardsResponse,
+                    NYdbProtos::DataStreams::V1::MergeShardsResult,
+                    decltype(&NYdbProtos::DataStreams::V1::DataStreamsService::Stub::AsyncMergeShards)
                 >(
-                        const Ydb::DataStreams::V1::MergeShardsRequest& request,
-                        decltype(&Ydb::DataStreams::V1::DataStreamsService::Stub::AsyncMergeShards) method,
+                        const NYdbProtos::DataStreams::V1::MergeShardsRequest& request,
+                        decltype(&NYdbProtos::DataStreams::V1::DataStreamsService::Stub::AsyncMergeShards) method,
                         TProtoRequestSettings settings
                 );
 
-    template NThreading::TFuture<TProtoResultWrapper<Ydb::DataStreams::V1::ListTagsForStreamResult>> TDataStreamsClient::DoProtoRequest
+    template NThreading::TFuture<TProtoResultWrapper<NYdbProtos::DataStreams::V1::ListTagsForStreamResult>> TDataStreamsClient::DoProtoRequest
                 <
-                    Ydb::DataStreams::V1::ListTagsForStreamRequest,
-                    Ydb::DataStreams::V1::ListTagsForStreamResponse,
-                    Ydb::DataStreams::V1::ListTagsForStreamResult,
-                    decltype(&Ydb::DataStreams::V1::DataStreamsService::Stub::AsyncListTagsForStream)
+                    NYdbProtos::DataStreams::V1::ListTagsForStreamRequest,
+                    NYdbProtos::DataStreams::V1::ListTagsForStreamResponse,
+                    NYdbProtos::DataStreams::V1::ListTagsForStreamResult,
+                    decltype(&NYdbProtos::DataStreams::V1::DataStreamsService::Stub::AsyncListTagsForStream)
                 >(
-                        const Ydb::DataStreams::V1::ListTagsForStreamRequest& request,
-                        decltype(&Ydb::DataStreams::V1::DataStreamsService::Stub::AsyncListTagsForStream) method,
+                        const NYdbProtos::DataStreams::V1::ListTagsForStreamRequest& request,
+                        decltype(&NYdbProtos::DataStreams::V1::DataStreamsService::Stub::AsyncListTagsForStream) method,
                         TProtoRequestSettings settings
                 );
 
-    template NThreading::TFuture<TProtoResultWrapper<Ydb::DataStreams::V1::RemoveTagsFromStreamResult>> TDataStreamsClient::DoProtoRequest
+    template NThreading::TFuture<TProtoResultWrapper<NYdbProtos::DataStreams::V1::RemoveTagsFromStreamResult>> TDataStreamsClient::DoProtoRequest
                 <
-                    Ydb::DataStreams::V1::RemoveTagsFromStreamRequest,
-                    Ydb::DataStreams::V1::RemoveTagsFromStreamResponse,
-                    Ydb::DataStreams::V1::RemoveTagsFromStreamResult,
-                    decltype(&Ydb::DataStreams::V1::DataStreamsService::Stub::AsyncRemoveTagsFromStream)
+                    NYdbProtos::DataStreams::V1::RemoveTagsFromStreamRequest,
+                    NYdbProtos::DataStreams::V1::RemoveTagsFromStreamResponse,
+                    NYdbProtos::DataStreams::V1::RemoveTagsFromStreamResult,
+                    decltype(&NYdbProtos::DataStreams::V1::DataStreamsService::Stub::AsyncRemoveTagsFromStream)
                 >(
-                        const Ydb::DataStreams::V1::RemoveTagsFromStreamRequest& request,
-                        decltype(&Ydb::DataStreams::V1::DataStreamsService::Stub::AsyncRemoveTagsFromStream) method,
+                        const NYdbProtos::DataStreams::V1::RemoveTagsFromStreamRequest& request,
+                        decltype(&NYdbProtos::DataStreams::V1::DataStreamsService::Stub::AsyncRemoveTagsFromStream) method,
                         TProtoRequestSettings settings
                 );
 
-    template NThreading::TFuture<TProtoResultWrapper<Ydb::DataStreams::V1::SplitShardResult>> TDataStreamsClient::DoProtoRequest
+    template NThreading::TFuture<TProtoResultWrapper<NYdbProtos::DataStreams::V1::SplitShardResult>> TDataStreamsClient::DoProtoRequest
                 <
-                    Ydb::DataStreams::V1::SplitShardRequest,
-                    Ydb::DataStreams::V1::SplitShardResponse,
-                    Ydb::DataStreams::V1::SplitShardResult,
-                    decltype(&Ydb::DataStreams::V1::DataStreamsService::Stub::AsyncSplitShard)
+                    NYdbProtos::DataStreams::V1::SplitShardRequest,
+                    NYdbProtos::DataStreams::V1::SplitShardResponse,
+                    NYdbProtos::DataStreams::V1::SplitShardResult,
+                    decltype(&NYdbProtos::DataStreams::V1::DataStreamsService::Stub::AsyncSplitShard)
                 >(
-                        const Ydb::DataStreams::V1::SplitShardRequest& request,
-                        decltype(&Ydb::DataStreams::V1::DataStreamsService::Stub::AsyncSplitShard) method,
+                        const NYdbProtos::DataStreams::V1::SplitShardRequest& request,
+                        decltype(&NYdbProtos::DataStreams::V1::DataStreamsService::Stub::AsyncSplitShard) method,
                         TProtoRequestSettings settings
                 );
 
-    template NThreading::TFuture<TProtoResultWrapper<Ydb::DataStreams::V1::StartStreamEncryptionResult>> TDataStreamsClient::DoProtoRequest
+    template NThreading::TFuture<TProtoResultWrapper<NYdbProtos::DataStreams::V1::StartStreamEncryptionResult>> TDataStreamsClient::DoProtoRequest
                 <
-                    Ydb::DataStreams::V1::StartStreamEncryptionRequest,
-                    Ydb::DataStreams::V1::StartStreamEncryptionResponse,
-                    Ydb::DataStreams::V1::StartStreamEncryptionResult,
-                    decltype(&Ydb::DataStreams::V1::DataStreamsService::Stub::AsyncStartStreamEncryption)
+                    NYdbProtos::DataStreams::V1::StartStreamEncryptionRequest,
+                    NYdbProtos::DataStreams::V1::StartStreamEncryptionResponse,
+                    NYdbProtos::DataStreams::V1::StartStreamEncryptionResult,
+                    decltype(&NYdbProtos::DataStreams::V1::DataStreamsService::Stub::AsyncStartStreamEncryption)
                 >(
-                        const Ydb::DataStreams::V1::StartStreamEncryptionRequest& request,
-                        decltype(&Ydb::DataStreams::V1::DataStreamsService::Stub::AsyncStartStreamEncryption) method,
+                        const NYdbProtos::DataStreams::V1::StartStreamEncryptionRequest& request,
+                        decltype(&NYdbProtos::DataStreams::V1::DataStreamsService::Stub::AsyncStartStreamEncryption) method,
                         TProtoRequestSettings settings
                 );
 
-    template NThreading::TFuture<TProtoResultWrapper<Ydb::DataStreams::V1::StopStreamEncryptionResult>> TDataStreamsClient::DoProtoRequest
+    template NThreading::TFuture<TProtoResultWrapper<NYdbProtos::DataStreams::V1::StopStreamEncryptionResult>> TDataStreamsClient::DoProtoRequest
                 <
-                    Ydb::DataStreams::V1::StopStreamEncryptionRequest,
-                    Ydb::DataStreams::V1::StopStreamEncryptionResponse,
-                    Ydb::DataStreams::V1::StopStreamEncryptionResult,
-                    decltype(&Ydb::DataStreams::V1::DataStreamsService::Stub::AsyncStopStreamEncryption)
+                    NYdbProtos::DataStreams::V1::StopStreamEncryptionRequest,
+                    NYdbProtos::DataStreams::V1::StopStreamEncryptionResponse,
+                    NYdbProtos::DataStreams::V1::StopStreamEncryptionResult,
+                    decltype(&NYdbProtos::DataStreams::V1::DataStreamsService::Stub::AsyncStopStreamEncryption)
                 >(
-                        const Ydb::DataStreams::V1::StopStreamEncryptionRequest& request,
-                        decltype(&Ydb::DataStreams::V1::DataStreamsService::Stub::AsyncStopStreamEncryption) method,
+                        const NYdbProtos::DataStreams::V1::StopStreamEncryptionRequest& request,
+                        decltype(&NYdbProtos::DataStreams::V1::DataStreamsService::Stub::AsyncStopStreamEncryption) method,
                         TProtoRequestSettings settings
                 );
 
-    template NThreading::TFuture<TProtoResultWrapper<Ydb::DataStreams::V1::DescribeStreamSummaryResult>> TDataStreamsClient::DoProtoRequest
+    template NThreading::TFuture<TProtoResultWrapper<NYdbProtos::DataStreams::V1::DescribeStreamSummaryResult>> TDataStreamsClient::DoProtoRequest
             <
-                    Ydb::DataStreams::V1::DescribeStreamSummaryRequest,
-                    Ydb::DataStreams::V1::DescribeStreamSummaryResponse,
-                    Ydb::DataStreams::V1::DescribeStreamSummaryResult,
-                    decltype(&Ydb::DataStreams::V1::DataStreamsService::Stub::AsyncDescribeStreamSummary)
+                    NYdbProtos::DataStreams::V1::DescribeStreamSummaryRequest,
+                    NYdbProtos::DataStreams::V1::DescribeStreamSummaryResponse,
+                    NYdbProtos::DataStreams::V1::DescribeStreamSummaryResult,
+                    decltype(&NYdbProtos::DataStreams::V1::DataStreamsService::Stub::AsyncDescribeStreamSummary)
             >(
-            const Ydb::DataStreams::V1::DescribeStreamSummaryRequest& request,
-            decltype(&Ydb::DataStreams::V1::DataStreamsService::Stub::AsyncDescribeStreamSummary) method,
+            const NYdbProtos::DataStreams::V1::DescribeStreamSummaryRequest& request,
+            decltype(&NYdbProtos::DataStreams::V1::DataStreamsService::Stub::AsyncDescribeStreamSummary) method,
             TProtoRequestSettings settings
     );
 }

--- a/ydb/public/sdk/cpp/src/client/debug/client.cpp
+++ b/ydb/public/sdk/cpp/src/client/debug/client.cpp
@@ -12,7 +12,7 @@
 
 namespace NYdb::inline V3::NDebug {
 
-using namespace Ydb;
+using namespace NYdbProtos;
 
 using namespace NThreading;
 

--- a/ydb/public/sdk/cpp/src/client/discovery/discovery.cpp
+++ b/ydb/public/sdk/cpp/src/client/discovery/discovery.cpp
@@ -5,7 +5,7 @@
 namespace NYdb::inline V3 {
 namespace NDiscovery {
 
-TListEndpointsResult::TListEndpointsResult(TStatus&& status, const Ydb::Discovery::ListEndpointsResult& proto)
+TListEndpointsResult::TListEndpointsResult(TStatus&& status, const NYdbProtos::Discovery::ListEndpointsResult& proto)
     : TStatus(std::move(status))
 {
     const auto& endpoints = proto.endpoints();
@@ -38,7 +38,7 @@ const std::vector<TEndpointInfo>& TListEndpointsResult::GetEndpointsInfo() const
     return Info_;
 }
 
-TWhoAmIResult::TWhoAmIResult(TStatus&& status, const Ydb::Discovery::WhoAmIResult& proto)
+TWhoAmIResult::TWhoAmIResult(TStatus&& status, const NYdbProtos::Discovery::WhoAmIResult& proto)
     : TStatus(std::move(status))
 {
     UserName_ = proto.user();
@@ -57,7 +57,7 @@ const std::vector<std::string>& TWhoAmIResult::GetGroups() const {
     return Groups_;
 }
 
-TNodeLocation::TNodeLocation(const Ydb::Discovery::NodeLocation& location)
+TNodeLocation::TNodeLocation(const NYdbProtos::Discovery::NodeLocation& location)
     : DataCenterNum(location.has_data_center_num() ? std::make_optional(location.data_center_num()) : std::nullopt)
     , RoomNum(location.has_room_num() ? std::make_optional(location.room_num()) : std::nullopt)
     , RackNum(location.has_rack_num() ? std::make_optional(location.rack_num()) : std::nullopt)
@@ -69,7 +69,7 @@ TNodeLocation::TNodeLocation(const Ydb::Discovery::NodeLocation& location)
     , Unit(location.has_unit() ? std::make_optional(location.unit()) : std::nullopt)
     {}
 
-TNodeInfo::TNodeInfo(const Ydb::Discovery::NodeInfo& info)
+TNodeInfo::TNodeInfo(const NYdbProtos::Discovery::NodeInfo& info)
     : NodeId(info.node_id())
     , Host(info.host())
     , Port(info.port())
@@ -79,7 +79,7 @@ TNodeInfo::TNodeInfo(const Ydb::Discovery::NodeInfo& info)
     , Expire(info.expire())
     {}
 
-TNodeRegistrationResult::TNodeRegistrationResult(TStatus&& status, const Ydb::Discovery::NodeRegistrationResult& proto)
+TNodeRegistrationResult::TNodeRegistrationResult(TStatus&& status, const NYdbProtos::Discovery::NodeRegistrationResult& proto)
     : TStatus(std::move(status))
     , NodeId_(proto.node_id())
     , DomainPath_(proto.domain_path())
@@ -142,14 +142,14 @@ public:
     { }
 
     TAsyncListEndpointsResult ListEndpoints(const TListEndpointsSettings& settings) {
-        Ydb::Discovery::ListEndpointsRequest request;
+        NYdbProtos::Discovery::ListEndpointsRequest request;
         request.set_database(TStringType{DbDriverState_->Database});
 
         auto promise = NThreading::NewPromise<TListEndpointsResult>();
 
         auto extractor = [promise]
             (google::protobuf::Any* any, TPlainStatus status) mutable {
-                Ydb::Discovery::ListEndpointsResult result;
+                NYdbProtos::Discovery::ListEndpointsResult result;
                 if (any) {
                     any->UnpackTo(&result);
                 }
@@ -157,10 +157,10 @@ public:
                 promise.SetValue(std::move(val));
             };
 
-        Connections_->RunDeferred<Ydb::Discovery::V1::DiscoveryService, Ydb::Discovery::ListEndpointsRequest, Ydb::Discovery::ListEndpointsResponse>(
+        Connections_->RunDeferred<NYdbProtos::Discovery::V1::DiscoveryService, NYdbProtos::Discovery::ListEndpointsRequest, NYdbProtos::Discovery::ListEndpointsResponse>(
             std::move(request),
             extractor,
-            &Ydb::Discovery::V1::DiscoveryService::Stub::AsyncListEndpoints,
+            &NYdbProtos::Discovery::V1::DiscoveryService::Stub::AsyncListEndpoints,
             DbDriverState_,
             INITIAL_DEFERRED_CALL_DELAY,
             TRpcRequestSettings::Make(settings));
@@ -169,7 +169,7 @@ public:
     }
 
     TAsyncWhoAmIResult WhoAmI(const TWhoAmISettings& settings) {
-        Ydb::Discovery::WhoAmIRequest request;
+        NYdbProtos::Discovery::WhoAmIRequest request;
         if (settings.WithGroups_) {
             request.set_include_groups(true);
         }
@@ -178,7 +178,7 @@ public:
 
         auto extractor = [promise]
         (google::protobuf::Any* any, TPlainStatus status) mutable {
-            Ydb::Discovery::WhoAmIResult result;
+            NYdbProtos::Discovery::WhoAmIResult result;
             if (any) {
                 any->UnpackTo(&result);
             }
@@ -186,10 +186,10 @@ public:
             promise.SetValue(std::move(val));
         };
 
-        Connections_->RunDeferred<Ydb::Discovery::V1::DiscoveryService, Ydb::Discovery::WhoAmIRequest, Ydb::Discovery::WhoAmIResponse>(
+        Connections_->RunDeferred<NYdbProtos::Discovery::V1::DiscoveryService, NYdbProtos::Discovery::WhoAmIRequest, NYdbProtos::Discovery::WhoAmIResponse>(
             std::move(request),
             extractor,
-            &Ydb::Discovery::V1::DiscoveryService::Stub::AsyncWhoAmI,
+            &NYdbProtos::Discovery::V1::DiscoveryService::Stub::AsyncWhoAmI,
             DbDriverState_,
             INITIAL_DEFERRED_CALL_DELAY,
             TRpcRequestSettings::Make(settings));
@@ -198,7 +198,7 @@ public:
     }
 
     TAsyncNodeRegistrationResult NodeRegistration(const TNodeRegistrationSettings& settings) {
-        Ydb::Discovery::NodeRegistrationRequest request;
+        NYdbProtos::Discovery::NodeRegistrationRequest request;
         request.set_host(TStringType{settings.Host_});
         request.set_port(settings.Port_);
         request.set_resolve_host(TStringType{settings.ResolveHost_});
@@ -244,7 +244,7 @@ public:
         auto promise = NThreading::NewPromise<TNodeRegistrationResult>();
 
         auto extractor = [promise] (google::protobuf::Any* any, TPlainStatus status) mutable {
-            Ydb::Discovery::NodeRegistrationResult result;
+            NYdbProtos::Discovery::NodeRegistrationResult result;
             if (any) {
                 any->UnpackTo(&result);
             }
@@ -252,10 +252,10 @@ public:
             promise.SetValue(std::move(val));
         };
 
-        Connections_->RunDeferred<Ydb::Discovery::V1::DiscoveryService, Ydb::Discovery::NodeRegistrationRequest, Ydb::Discovery::NodeRegistrationResponse>(
+        Connections_->RunDeferred<NYdbProtos::Discovery::V1::DiscoveryService, NYdbProtos::Discovery::NodeRegistrationRequest, NYdbProtos::Discovery::NodeRegistrationResponse>(
             std::move(request),
             extractor,
-            &Ydb::Discovery::V1::DiscoveryService::Stub::AsyncNodeRegistration,
+            &NYdbProtos::Discovery::V1::DiscoveryService::Stub::AsyncNodeRegistration,
             DbDriverState_,
             INITIAL_DEFERRED_CALL_DELAY,
             TRpcRequestSettings::Make(settings));

--- a/ydb/public/sdk/cpp/src/client/draft/ydb_dynamic_config.cpp
+++ b/ydb/public/sdk/cpp/src/client/draft/ydb_dynamic_config.cpp
@@ -14,53 +14,53 @@ public:
     }
 
     TAsyncStatus SetConfig(const std::string& config, bool dryRun, bool allowUnknownFields, const TClusterConfigSettings& settings = {}) {
-        auto request = MakeOperationRequest<Ydb::DynamicConfig::SetConfigRequest>(settings);
+        auto request = MakeOperationRequest<NYdbProtos::DynamicConfig::SetConfigRequest>(settings);
         request.set_config(TStringType{config});
         request.set_dry_run(dryRun);
         request.set_allow_unknown_fields(allowUnknownFields);
 
-        return RunSimple<Ydb::DynamicConfig::V1::DynamicConfigService, Ydb::DynamicConfig::SetConfigRequest, Ydb::DynamicConfig::SetConfigResponse>(
+        return RunSimple<NYdbProtos::DynamicConfig::V1::DynamicConfigService, NYdbProtos::DynamicConfig::SetConfigRequest, NYdbProtos::DynamicConfig::SetConfigResponse>(
             std::move(request),
-            &Ydb::DynamicConfig::V1::DynamicConfigService::Stub::AsyncSetConfig,
+            &NYdbProtos::DynamicConfig::V1::DynamicConfigService::Stub::AsyncSetConfig,
             TRpcRequestSettings::Make(settings));
     }
 
     TAsyncStatus ReplaceConfig(const std::string& config, bool dryRun, bool allowUnknownFields, const TClusterConfigSettings& settings = {}) {
-        auto request = MakeOperationRequest<Ydb::DynamicConfig::ReplaceConfigRequest>(settings);
+        auto request = MakeOperationRequest<NYdbProtos::DynamicConfig::ReplaceConfigRequest>(settings);
         request.set_config(TStringType{config});
         request.set_dry_run(dryRun);
         request.set_allow_unknown_fields(allowUnknownFields);
 
-        return RunSimple<Ydb::DynamicConfig::V1::DynamicConfigService, Ydb::DynamicConfig::ReplaceConfigRequest, Ydb::DynamicConfig::ReplaceConfigResponse>(
+        return RunSimple<NYdbProtos::DynamicConfig::V1::DynamicConfigService, NYdbProtos::DynamicConfig::ReplaceConfigRequest, NYdbProtos::DynamicConfig::ReplaceConfigResponse>(
             std::move(request),
-            &Ydb::DynamicConfig::V1::DynamicConfigService::Stub::AsyncReplaceConfig,
+            &NYdbProtos::DynamicConfig::V1::DynamicConfigService::Stub::AsyncReplaceConfig,
             TRpcRequestSettings::Make(settings));
     }
 
     TAsyncStatus DropConfig(const std::string& cluster, uint64_t version, const TClusterConfigSettings& settings = {}) {
-        auto request = MakeOperationRequest<Ydb::DynamicConfig::DropConfigRequest>(settings);
+        auto request = MakeOperationRequest<NYdbProtos::DynamicConfig::DropConfigRequest>(settings);
 
         request.mutable_identity()->set_cluster(TStringType{cluster});
         request.mutable_identity()->set_version(version);
 
-        return RunSimple<Ydb::DynamicConfig::V1::DynamicConfigService, Ydb::DynamicConfig::DropConfigRequest, Ydb::DynamicConfig::DropConfigResponse>(
+        return RunSimple<NYdbProtos::DynamicConfig::V1::DynamicConfigService, NYdbProtos::DynamicConfig::DropConfigRequest, NYdbProtos::DynamicConfig::DropConfigResponse>(
             std::move(request),
-            &Ydb::DynamicConfig::V1::DynamicConfigService::Stub::AsyncDropConfig,
+            &NYdbProtos::DynamicConfig::V1::DynamicConfigService::Stub::AsyncDropConfig,
             TRpcRequestSettings::Make(settings));
     }
 
     TAsyncStatus AddVolatileConfig(const std::string& config, const TClusterConfigSettings& settings = {}) {
-        auto request = MakeOperationRequest<Ydb::DynamicConfig::AddVolatileConfigRequest>(settings);
+        auto request = MakeOperationRequest<NYdbProtos::DynamicConfig::AddVolatileConfigRequest>(settings);
         request.set_config(TStringType{config});
 
-        return RunSimple<Ydb::DynamicConfig::V1::DynamicConfigService, Ydb::DynamicConfig::AddVolatileConfigRequest, Ydb::DynamicConfig::AddVolatileConfigResponse>(
+        return RunSimple<NYdbProtos::DynamicConfig::V1::DynamicConfigService, NYdbProtos::DynamicConfig::AddVolatileConfigRequest, NYdbProtos::DynamicConfig::AddVolatileConfigResponse>(
             std::move(request),
-            &Ydb::DynamicConfig::V1::DynamicConfigService::Stub::AsyncAddVolatileConfig,
+            &NYdbProtos::DynamicConfig::V1::DynamicConfigService::Stub::AsyncAddVolatileConfig,
             TRpcRequestSettings::Make(settings));
     }
 
     TAsyncStatus RemoveVolatileConfig(const std::string& cluster, uint64_t version, const std::vector<uint64_t>& ids, const TClusterConfigSettings& settings = {}) {
-        auto request = MakeOperationRequest<Ydb::DynamicConfig::RemoveVolatileConfigRequest>(settings);
+        auto request = MakeOperationRequest<NYdbProtos::DynamicConfig::RemoveVolatileConfigRequest>(settings);
 
         request.mutable_identity()->set_cluster(TStringType{cluster});
         request.mutable_identity()->set_version(version);
@@ -69,27 +69,27 @@ public:
             request.mutable_ids()->add_ids(id);
         }
 
-        return RunSimple<Ydb::DynamicConfig::V1::DynamicConfigService, Ydb::DynamicConfig::RemoveVolatileConfigRequest, Ydb::DynamicConfig::RemoveVolatileConfigResponse>(
+        return RunSimple<NYdbProtos::DynamicConfig::V1::DynamicConfigService, NYdbProtos::DynamicConfig::RemoveVolatileConfigRequest, NYdbProtos::DynamicConfig::RemoveVolatileConfigResponse>(
             std::move(request),
-            &Ydb::DynamicConfig::V1::DynamicConfigService::Stub::AsyncRemoveVolatileConfig,
+            &NYdbProtos::DynamicConfig::V1::DynamicConfigService::Stub::AsyncRemoveVolatileConfig,
             TRpcRequestSettings::Make(settings));
     }
 
     TAsyncStatus RemoveAllVolatileConfigs(const std::string& cluster, uint64_t version, const TClusterConfigSettings& settings = {}) {
-        auto request = MakeOperationRequest<Ydb::DynamicConfig::RemoveVolatileConfigRequest>(settings);
+        auto request = MakeOperationRequest<NYdbProtos::DynamicConfig::RemoveVolatileConfigRequest>(settings);
 
         request.mutable_identity()->set_cluster(TStringType{cluster});
         request.mutable_identity()->set_version(version);
         request.set_all(true);
 
-        return RunSimple<Ydb::DynamicConfig::V1::DynamicConfigService, Ydb::DynamicConfig::RemoveVolatileConfigRequest, Ydb::DynamicConfig::RemoveVolatileConfigResponse>(
+        return RunSimple<NYdbProtos::DynamicConfig::V1::DynamicConfigService, NYdbProtos::DynamicConfig::RemoveVolatileConfigRequest, NYdbProtos::DynamicConfig::RemoveVolatileConfigResponse>(
             std::move(request),
-            &Ydb::DynamicConfig::V1::DynamicConfigService::Stub::AsyncRemoveVolatileConfig,
+            &NYdbProtos::DynamicConfig::V1::DynamicConfigService::Stub::AsyncRemoveVolatileConfig,
             TRpcRequestSettings::Make(settings));
     }
 
     TAsyncStatus ForceRemoveVolatileConfig(const std::vector<uint64_t>& ids, const TClusterConfigSettings& settings = {}) {
-        auto request = MakeOperationRequest<Ydb::DynamicConfig::RemoveVolatileConfigRequest>(settings);
+        auto request = MakeOperationRequest<NYdbProtos::DynamicConfig::RemoveVolatileConfigRequest>(settings);
 
         for (auto& id: ids) {
             request.mutable_ids()->add_ids(id);
@@ -97,34 +97,34 @@ public:
 
         request.set_force(true);
 
-        return RunSimple<Ydb::DynamicConfig::V1::DynamicConfigService, Ydb::DynamicConfig::RemoveVolatileConfigRequest, Ydb::DynamicConfig::RemoveVolatileConfigResponse>(
+        return RunSimple<NYdbProtos::DynamicConfig::V1::DynamicConfigService, NYdbProtos::DynamicConfig::RemoveVolatileConfigRequest, NYdbProtos::DynamicConfig::RemoveVolatileConfigResponse>(
             std::move(request),
-            &Ydb::DynamicConfig::V1::DynamicConfigService::Stub::AsyncRemoveVolatileConfig,
+            &NYdbProtos::DynamicConfig::V1::DynamicConfigService::Stub::AsyncRemoveVolatileConfig,
             TRpcRequestSettings::Make(settings));
     }
 
     TAsyncStatus ForceRemoveAllVolatileConfigs(const TClusterConfigSettings& settings = {}) {
-        auto request = MakeOperationRequest<Ydb::DynamicConfig::RemoveVolatileConfigRequest>(settings);
+        auto request = MakeOperationRequest<NYdbProtos::DynamicConfig::RemoveVolatileConfigRequest>(settings);
 
         request.set_all(true);
         request.set_force(true);
 
-        return RunSimple<Ydb::DynamicConfig::V1::DynamicConfigService, Ydb::DynamicConfig::RemoveVolatileConfigRequest, Ydb::DynamicConfig::RemoveVolatileConfigResponse>(
+        return RunSimple<NYdbProtos::DynamicConfig::V1::DynamicConfigService, NYdbProtos::DynamicConfig::RemoveVolatileConfigRequest, NYdbProtos::DynamicConfig::RemoveVolatileConfigResponse>(
             std::move(request),
-            &Ydb::DynamicConfig::V1::DynamicConfigService::Stub::AsyncRemoveVolatileConfig,
+            &NYdbProtos::DynamicConfig::V1::DynamicConfigService::Stub::AsyncRemoveVolatileConfig,
             TRpcRequestSettings::Make(settings));
     }
 
 
     TAsyncGetNodeLabelsResult GetNodeLabels(uint64_t nodeId, const TClusterConfigSettings& settings = {}) {
-        auto request = MakeOperationRequest<Ydb::DynamicConfig::GetNodeLabelsRequest>(settings);
+        auto request = MakeOperationRequest<NYdbProtos::DynamicConfig::GetNodeLabelsRequest>(settings);
         request.set_node_id(nodeId);
 
         auto promise = NThreading::NewPromise<TGetNodeLabelsResult>();
 
         auto extractor = [promise] (google::protobuf::Any* any, TPlainStatus status) mutable {
                 std::map<std::string, std::string> labels;
-                if (Ydb::DynamicConfig::GetNodeLabelsResult result; any && any->UnpackTo(&result)) {
+                if (NYdbProtos::DynamicConfig::GetNodeLabelsResult result; any && any->UnpackTo(&result)) {
                     for (auto& label : result.labels()) {
                         labels[label.label()] = label.value();
                     }
@@ -134,10 +134,10 @@ public:
                 promise.SetValue(std::move(val));
             };
 
-        Connections_->RunDeferred<Ydb::DynamicConfig::V1::DynamicConfigService, Ydb::DynamicConfig::GetNodeLabelsRequest, Ydb::DynamicConfig::GetNodeLabelsResponse>(
+        Connections_->RunDeferred<NYdbProtos::DynamicConfig::V1::DynamicConfigService, NYdbProtos::DynamicConfig::GetNodeLabelsRequest, NYdbProtos::DynamicConfig::GetNodeLabelsResponse>(
             std::move(request),
             extractor,
-            &Ydb::DynamicConfig::V1::DynamicConfigService::Stub::AsyncGetNodeLabels,
+            &NYdbProtos::DynamicConfig::V1::DynamicConfigService::Stub::AsyncGetNodeLabels,
             DbDriverState_,
             INITIAL_DEFERRED_CALL_DELAY,
             TRpcRequestSettings::Make(settings));
@@ -146,7 +146,7 @@ public:
     }
 
     TAsyncGetConfigResult GetConfig(const TClusterConfigSettings& settings = {}) {
-        auto request = MakeOperationRequest<Ydb::DynamicConfig::GetConfigRequest>(settings);
+        auto request = MakeOperationRequest<NYdbProtos::DynamicConfig::GetConfigRequest>(settings);
 
         auto promise = NThreading::NewPromise<TGetConfigResult>();
 
@@ -155,7 +155,7 @@ public:
                 uint64_t version = 0;
                 std::string config;
                 std::map<uint64_t, std::string> volatileConfigs;
-                if (Ydb::DynamicConfig::GetConfigResult result; any && any->UnpackTo(&result)) {
+                if (NYdbProtos::DynamicConfig::GetConfigResult result; any && any->UnpackTo(&result)) {
                     // only if they are present
                     if (result.identity_size() && result.config_size()) {
                         clusterName = result.identity(0).cluster();
@@ -171,10 +171,10 @@ public:
                 promise.SetValue(std::move(val));
             };
 
-        Connections_->RunDeferred<Ydb::DynamicConfig::V1::DynamicConfigService, Ydb::DynamicConfig::GetConfigRequest, Ydb::DynamicConfig::GetConfigResponse>(
+        Connections_->RunDeferred<NYdbProtos::DynamicConfig::V1::DynamicConfigService, NYdbProtos::DynamicConfig::GetConfigRequest, NYdbProtos::DynamicConfig::GetConfigResponse>(
             std::move(request),
             extractor,
-            &Ydb::DynamicConfig::V1::DynamicConfigService::Stub::AsyncGetConfig,
+            &NYdbProtos::DynamicConfig::V1::DynamicConfigService::Stub::AsyncGetConfig,
             DbDriverState_,
             INITIAL_DEFERRED_CALL_DELAY,
             TRpcRequestSettings::Make(settings));
@@ -183,14 +183,14 @@ public:
     }
 
     TAsyncGetMetadataResult GetMetadata(const TClusterConfigSettings& settings = {}) {
-        auto request = MakeOperationRequest<Ydb::DynamicConfig::GetMetadataRequest>(settings);
+        auto request = MakeOperationRequest<NYdbProtos::DynamicConfig::GetMetadataRequest>(settings);
 
         auto promise = NThreading::NewPromise<TGetMetadataResult>();
 
         auto extractor = [promise] (google::protobuf::Any* any, TPlainStatus status) mutable {
                 std::string metadata;
                 std::map<uint64_t, std::string> volatileConfigs;
-                if (Ydb::DynamicConfig::GetMetadataResult result; any && any->UnpackTo(&result)) {
+                if (NYdbProtos::DynamicConfig::GetMetadataResult result; any && any->UnpackTo(&result)) {
                     metadata = result.metadata();
                     for (const auto& config : result.volatile_configs()) {
                         volatileConfigs.emplace(config.id(), config.metadata());
@@ -201,10 +201,10 @@ public:
                 promise.SetValue(std::move(val));
             };
 
-        Connections_->RunDeferred<Ydb::DynamicConfig::V1::DynamicConfigService, Ydb::DynamicConfig::GetMetadataRequest, Ydb::DynamicConfig::GetMetadataResponse>(
+        Connections_->RunDeferred<NYdbProtos::DynamicConfig::V1::DynamicConfigService, NYdbProtos::DynamicConfig::GetMetadataRequest, NYdbProtos::DynamicConfig::GetMetadataResponse>(
             std::move(request),
             extractor,
-            &Ydb::DynamicConfig::V1::DynamicConfigService::Stub::AsyncGetMetadata,
+            &NYdbProtos::DynamicConfig::V1::DynamicConfigService::Stub::AsyncGetMetadata,
             DbDriverState_,
             INITIAL_DEFERRED_CALL_DELAY,
             TRpcRequestSettings::Make(settings));
@@ -213,7 +213,7 @@ public:
     }
 
     TAsyncResolveConfigResult ResolveConfig(const std::string& config, const std::map<uint64_t, std::string>& volatileConfigs, const std::map<std::string, std::string>& labels, const TClusterConfigSettings& settings = {}) {
-        auto request = MakeOperationRequest<Ydb::DynamicConfig::ResolveConfigRequest>(settings);
+        auto request = MakeOperationRequest<NYdbProtos::DynamicConfig::ResolveConfigRequest>(settings);
         request.set_config(TStringType{config});
         for (auto& [id, volatileConfig] : volatileConfigs) {
             auto* proto = request.add_volatile_configs();
@@ -230,7 +230,7 @@ public:
 
         auto extractor = [promise] (google::protobuf::Any* any, TPlainStatus status) mutable {
                 std::string config;
-                if (Ydb::DynamicConfig::ResolveConfigResult result; any && any->UnpackTo(&result)) {
+                if (NYdbProtos::DynamicConfig::ResolveConfigResult result; any && any->UnpackTo(&result)) {
                     config = result.config();
                 }
 
@@ -238,10 +238,10 @@ public:
                 promise.SetValue(std::move(val));
             };
 
-        Connections_->RunDeferred<Ydb::DynamicConfig::V1::DynamicConfigService, Ydb::DynamicConfig::ResolveConfigRequest, Ydb::DynamicConfig::ResolveConfigResponse>(
+        Connections_->RunDeferred<NYdbProtos::DynamicConfig::V1::DynamicConfigService, NYdbProtos::DynamicConfig::ResolveConfigRequest, NYdbProtos::DynamicConfig::ResolveConfigResponse>(
             std::move(request),
             extractor,
-            &Ydb::DynamicConfig::V1::DynamicConfigService::Stub::AsyncResolveConfig,
+            &NYdbProtos::DynamicConfig::V1::DynamicConfigService::Stub::AsyncResolveConfig,
             DbDriverState_,
             INITIAL_DEFERRED_CALL_DELAY,
             TRpcRequestSettings::Make(settings));
@@ -250,7 +250,7 @@ public:
     }
 
     TAsyncResolveConfigResult ResolveConfig(const std::string& config, const std::map<uint64_t, std::string>& volatileConfigs, const TClusterConfigSettings& settings = {}) {
-        auto request = MakeOperationRequest<Ydb::DynamicConfig::ResolveAllConfigRequest>(settings);
+        auto request = MakeOperationRequest<NYdbProtos::DynamicConfig::ResolveAllConfigRequest>(settings);
         request.set_config(TStringType{config});
         for (auto& [id, volatileConfig] : volatileConfigs) {
             auto* proto = request.add_volatile_configs();
@@ -262,7 +262,7 @@ public:
 
         auto extractor = [promise] (google::protobuf::Any* any, TPlainStatus status) mutable {
                 std::string config;
-                if (Ydb::DynamicConfig::ResolveAllConfigResult result; any && any->UnpackTo(&result)) {
+                if (NYdbProtos::DynamicConfig::ResolveAllConfigResult result; any && any->UnpackTo(&result)) {
                     config = result.config();
                 }
 
@@ -270,10 +270,10 @@ public:
                 promise.SetValue(std::move(val));
             };
 
-        Connections_->RunDeferred<Ydb::DynamicConfig::V1::DynamicConfigService, Ydb::DynamicConfig::ResolveAllConfigRequest, Ydb::DynamicConfig::ResolveAllConfigResponse>(
+        Connections_->RunDeferred<NYdbProtos::DynamicConfig::V1::DynamicConfigService, NYdbProtos::DynamicConfig::ResolveAllConfigRequest, NYdbProtos::DynamicConfig::ResolveAllConfigResponse>(
             std::move(request),
             extractor,
-            &Ydb::DynamicConfig::V1::DynamicConfigService::Stub::AsyncResolveAllConfig,
+            &NYdbProtos::DynamicConfig::V1::DynamicConfigService::Stub::AsyncResolveAllConfig,
             DbDriverState_,
             INITIAL_DEFERRED_CALL_DELAY,
             TRpcRequestSettings::Make(settings));
@@ -282,7 +282,7 @@ public:
     }
 
     TAsyncVerboseResolveConfigResult VerboseResolveConfig(const std::string& config, const std::map<uint64_t, std::string>& volatileConfigs, const TClusterConfigSettings& settings = {}) {
-        auto request = MakeOperationRequest<Ydb::DynamicConfig::ResolveAllConfigRequest>(settings);
+        auto request = MakeOperationRequest<NYdbProtos::DynamicConfig::ResolveAllConfigRequest>(settings);
         request.set_config(TStringType{config});
         for (auto& [id, volatileConfig] : volatileConfigs) {
             auto* proto = request.add_volatile_configs();
@@ -294,13 +294,13 @@ public:
         auto promise = NThreading::NewPromise<TVerboseResolveConfigResult>();
 
         auto extractor = [promise] (google::protobuf::Any* any, TPlainStatus status) mutable {
-            auto convert = [] (const Ydb::DynamicConfig::YamlLabelExt::LabelType& label) -> TVerboseResolveConfigResult::TLabel::EType {
+            auto convert = [] (const NYdbProtos::DynamicConfig::YamlLabelExt::LabelType& label) -> TVerboseResolveConfigResult::TLabel::EType {
                 switch(label) {
-                case Ydb::DynamicConfig::YamlLabelExt::NOT_SET:
+                case NYdbProtos::DynamicConfig::YamlLabelExt::NOT_SET:
                     return TVerboseResolveConfigResult::TLabel::EType::Negative;
-                case Ydb::DynamicConfig::YamlLabelExt::COMMON:
+                case NYdbProtos::DynamicConfig::YamlLabelExt::COMMON:
                     return TVerboseResolveConfigResult::TLabel::EType::Common;
-                case Ydb::DynamicConfig::YamlLabelExt::EMPTY:
+                case NYdbProtos::DynamicConfig::YamlLabelExt::EMPTY:
                     return TVerboseResolveConfigResult::TLabel::EType::Empty;
                 default:
                     Y_ABORT("unexpected enum value");
@@ -310,7 +310,7 @@ public:
             std::set<std::string> labels;
             TVerboseResolveConfigResult::ConfigByLabelSet configs;
 
-            if (Ydb::DynamicConfig::ResolveAllConfigResult result; any && any->UnpackTo(&result)) {
+            if (NYdbProtos::DynamicConfig::ResolveAllConfigResult result; any && any->UnpackTo(&result)) {
                 for (auto& config : result.configs()) {
                     std::set<std::vector<TVerboseResolveConfigResult::TLabel>> labelSets;
                     for (auto& labelSet : config.label_sets()) {
@@ -329,10 +329,10 @@ public:
             promise.SetValue(std::move(val));
         };
 
-        Connections_->RunDeferred<Ydb::DynamicConfig::V1::DynamicConfigService, Ydb::DynamicConfig::ResolveAllConfigRequest, Ydb::DynamicConfig::ResolveAllConfigResponse>(
+        Connections_->RunDeferred<NYdbProtos::DynamicConfig::V1::DynamicConfigService, NYdbProtos::DynamicConfig::ResolveAllConfigRequest, NYdbProtos::DynamicConfig::ResolveAllConfigResponse>(
             std::move(request),
             extractor,
-            &Ydb::DynamicConfig::V1::DynamicConfigService::Stub::AsyncResolveAllConfig,
+            &NYdbProtos::DynamicConfig::V1::DynamicConfigService::Stub::AsyncResolveAllConfig,
             DbDriverState_,
             INITIAL_DEFERRED_CALL_DELAY,
             TRpcRequestSettings::Make(settings));
@@ -341,13 +341,13 @@ public:
     }
 
     TAsyncFetchStartupConfigResult FetchStartupConfig(const TClusterConfigSettings& settings = {}) {
-        auto request = MakeOperationRequest<Ydb::DynamicConfig::FetchStartupConfigRequest>(settings);
+        auto request = MakeOperationRequest<NYdbProtos::DynamicConfig::FetchStartupConfigRequest>(settings);
 
         auto promise = NThreading::NewPromise<TFetchStartupConfigResult>();
 
         auto extractor = [promise] (google::protobuf::Any* any, TPlainStatus status) mutable {
                 std::string config;
-                if (Ydb::DynamicConfig::FetchStartupConfigResult result; any && any->UnpackTo(&result)) {
+                if (NYdbProtos::DynamicConfig::FetchStartupConfigResult result; any && any->UnpackTo(&result)) {
                     config = result.config();
                 }
 
@@ -355,10 +355,10 @@ public:
                 promise.SetValue(std::move(val));
             };
 
-        Connections_->RunDeferred<Ydb::DynamicConfig::V1::DynamicConfigService, Ydb::DynamicConfig::FetchStartupConfigRequest, Ydb::DynamicConfig::FetchStartupConfigResponse>(
+        Connections_->RunDeferred<NYdbProtos::DynamicConfig::V1::DynamicConfigService, NYdbProtos::DynamicConfig::FetchStartupConfigRequest, NYdbProtos::DynamicConfig::FetchStartupConfigResponse>(
             std::move(request),
             extractor,
-            &Ydb::DynamicConfig::V1::DynamicConfigService::Stub::AsyncFetchStartupConfig,
+            &NYdbProtos::DynamicConfig::V1::DynamicConfigService::Stub::AsyncFetchStartupConfig,
             DbDriverState_,
             INITIAL_DEFERRED_CALL_DELAY,
             TRpcRequestSettings::Make(settings));

--- a/ydb/public/sdk/cpp/src/client/draft/ydb_view.cpp
+++ b/ydb/public/sdk/cpp/src/client/draft/ydb_view.cpp
@@ -12,7 +12,7 @@
 namespace NYdb::inline V3 {
 namespace NView {
 
-TViewDescription::TViewDescription(const Ydb::View::DescribeViewResult& desc)
+TViewDescription::TViewDescription(const NYdbProtos::View::DescribeViewResult& desc)
     : QueryText_(desc.query_text())
 {
 }
@@ -21,9 +21,9 @@ const std::string& TViewDescription::GetQueryText() const {
     return QueryText_;
 }
 
-TDescribeViewResult::TDescribeViewResult(TStatus&& status, Ydb::View::DescribeViewResult&& desc)
+TDescribeViewResult::TDescribeViewResult(TStatus&& status, NYdbProtos::View::DescribeViewResult&& desc)
     : NScheme::TDescribePathResult(std::move(status), desc.self())
-    , Proto_(std::make_unique<Ydb::View::DescribeViewResult>(std::move(desc)))
+    , Proto_(std::make_unique<NYdbProtos::View::DescribeViewResult>(std::move(desc)))
 {
 }
 
@@ -31,7 +31,7 @@ TViewDescription TDescribeViewResult::GetViewDescription() const {
     return TViewDescription(*Proto_);
 }
 
-const Ydb::View::DescribeViewResult& TDescribeViewResult::GetProto() const {
+const NYdbProtos::View::DescribeViewResult& TDescribeViewResult::GetProto() const {
     return *Proto_;
 }
 
@@ -43,7 +43,7 @@ public:
     }
 
     TAsyncDescribeViewResult DescribeView(const std::string& path, const TDescribeViewSettings& settings) {
-        using namespace Ydb::View;
+        using namespace NYdbProtos::View;
 
         auto request = MakeOperationRequest<DescribeViewRequest>(settings);
         request.set_path(TStringType{path});
@@ -85,7 +85,7 @@ TAsyncDescribeViewResult TViewClient::DescribeView(const std::string& path, cons
 
 } // NView
 
-const Ydb::View::DescribeViewResult& TProtoAccessor::GetProto(const NView::TDescribeViewResult& result) {
+const NYdbProtos::View::DescribeViewResult& TProtoAccessor::GetProto(const NView::TDescribeViewResult& result) {
     return result.GetProto();
 }
 

--- a/ydb/public/sdk/cpp/src/client/driver/driver.cpp
+++ b/ydb/public/sdk/cpp/src/client/driver/driver.cpp
@@ -23,7 +23,7 @@ using NYdbGrpc::TResponseCallback;
 using NYdbGrpc::TGrpcStatus;
 using NYdbGrpc::TTcpKeepAliveSettings;
 
-using Ydb::StatusIds;
+using NYdbProtos::StatusIds;
 
 using namespace NThreading;
 

--- a/ydb/public/sdk/cpp/src/client/export/export.cpp
+++ b/ydb/public/sdk/cpp/src/client/export/export.cpp
@@ -19,7 +19,7 @@ namespace NYdb::inline V3 {
 namespace NExport {
 
 using namespace NThreading;
-using namespace Ydb::Export;
+using namespace NYdbProtos::Export;
 
 /// Common
 namespace {
@@ -41,7 +41,7 @@ std::vector<TExportItemProgress> ItemsProgressFromProto(const google::protobuf::
 } // anonymous
 
 /// YT
-TExportToYtResponse::TExportToYtResponse(TStatus&& status, Ydb::Operations::Operation&& operation)
+TExportToYtResponse::TExportToYtResponse(TStatus&& status, NYdbProtos::Operations::Operation&& operation)
     : TOperation(std::move(status), std::move(operation))
 {
     ExportToYtMetadata metadata;
@@ -70,7 +70,7 @@ const TExportToYtResponse::TMetadata& TExportToYtResponse::Metadata() const {
 }
 
 /// S3
-TExportToS3Response::TExportToS3Response(TStatus&& status, Ydb::Operations::Operation&& operation)
+TExportToS3Response::TExportToS3Response(TStatus&& status, NYdbProtos::Operations::Operation&& operation)
     : TOperation(std::move(status), std::move(operation))
 {
     ExportToS3Metadata metadata;

--- a/ydb/public/sdk/cpp/src/client/federated_topic/impl/federated_read_session.cpp
+++ b/ydb/public/sdk/cpp/src/client/federated_topic/impl/federated_read_session.cpp
@@ -174,7 +174,7 @@ void TFederatedReadSessionImpl::OnFederatedStateUpdateImpl() {
         issue << " } not found. Available databases {";
         first = true;
         for (auto const& db : FederationState->DbInfos) {
-            if (db->status() == Ydb::FederationDiscovery::DatabaseInfo_Status_AVAILABLE) {
+            if (db->status() == NYdbProtos::FederationDiscovery::DatabaseInfo_Status_AVAILABLE) {
                 if (first) first = false; else issue << ",";
                 issue << " { name: " << db->name()
                       << ", endpoint: " << db->endpoint()

--- a/ydb/public/sdk/cpp/src/client/federated_topic/impl/federation_observer.h
+++ b/ydb/public/sdk/cpp/src/client/federated_topic/impl/federation_observer.h
@@ -20,7 +20,7 @@ namespace NYdb::inline V3::NFederatedTopic {
 
 struct TFederatedDbState {
 public:
-    using TDbInfo = Ydb::FederationDiscovery::DatabaseInfo;
+    using TDbInfo = NYdbProtos::FederationDiscovery::DatabaseInfo;
 
     TStatus Status;
     std::string ControlPlaneEndpoint;
@@ -29,7 +29,7 @@ public:
 
 public:
     TFederatedDbState() : Status(EStatus::STATUS_UNDEFINED, {}) {}
-    TFederatedDbState(Ydb::FederationDiscovery::ListFederationDatabasesResult result, TStatus status)
+    TFederatedDbState(NYdbProtos::FederationDiscovery::ListFederationDatabasesResult result, TStatus status)
         : Status(std::move(status))
         , ControlPlaneEndpoint(result.control_plane_endpoint())
         , SelfLocation(result.self_location())
@@ -75,10 +75,10 @@ public:
     bool IsStale() const;
 
 private:
-    Ydb::FederationDiscovery::ListFederationDatabasesRequest ComposeRequest() const;
+    NYdbProtos::FederationDiscovery::ListFederationDatabasesRequest ComposeRequest() const;
     void RunFederationDiscoveryImpl();
     void ScheduleFederationDiscoveryImpl(TDuration delay);
-    void OnFederationDiscovery(TStatus&& status, Ydb::FederationDiscovery::ListFederationDatabasesResult&& result);
+    void OnFederationDiscovery(TStatus&& status, NYdbProtos::FederationDiscovery::ListFederationDatabasesResult&& result);
 
 private:
     std::shared_ptr<TFederatedDbState> FederatedDbState;

--- a/ydb/public/sdk/cpp/src/client/federated_topic/ut/basic_usage_ut.cpp
+++ b/ydb/public/sdk/cpp/src/client/federated_topic/ut/basic_usage_ut.cpp
@@ -65,14 +65,14 @@ Y_UNIT_TEST_SUITE(BasicUsage) {
         Y_ASSERT(fdsRequest.has_value());
         // TODO check fdsRequest->Req db header
 
-        Ydb::FederationDiscovery::ListFederationDatabasesResponse response;
+        NYdbProtos::FederationDiscovery::ListFederationDatabasesResponse response;
 
         auto op = response.mutable_operation();
-        op->set_status(Ydb::StatusIds::SUCCESS);
+        op->set_status(NYdbProtos::StatusIds::SUCCESS);
         response.mutable_operation()->set_ready(true);
         response.mutable_operation()->set_id("12345");
 
-        Ydb::FederationDiscovery::ListFederationDatabasesResult mockResult;
+        NYdbProtos::FederationDiscovery::ListFederationDatabasesResult mockResult;
         mockResult.set_control_plane_endpoint("cp.logbroker-federation:2135");
         mockResult.set_self_location("fancy_datacenter");
         auto c1 = mockResult.add_federation_databases();
@@ -81,7 +81,7 @@ Y_UNIT_TEST_SUITE(BasicUsage) {
         c1->set_id("account-dc1");
         c1->set_endpoint("localhost:" + ToString(fdsMock.Port));
         c1->set_location("dc1");
-        c1->set_status(::Ydb::FederationDiscovery::DatabaseInfo::Status::DatabaseInfo_Status_AVAILABLE);
+        c1->set_status(::NYdbProtos::FederationDiscovery::DatabaseInfo::Status::DatabaseInfo_Status_AVAILABLE);
         c1->set_weight(1000);
         auto c2 = mockResult.add_federation_databases();
         c2->set_name("dc2");
@@ -89,7 +89,7 @@ Y_UNIT_TEST_SUITE(BasicUsage) {
         c2->set_id("account-dc2");
         c2->set_endpoint("localhost:" + ToString(fdsMock.Port));
         c2->set_location("dc2");
-        c2->set_status(::Ydb::FederationDiscovery::DatabaseInfo::Status::DatabaseInfo_Status_AVAILABLE);
+        c2->set_status(::NYdbProtos::FederationDiscovery::DatabaseInfo::Status::DatabaseInfo_Status_AVAILABLE);
         c2->set_weight(500);
 
         op->mutable_result()->PackFrom(mockResult);
@@ -240,14 +240,14 @@ Y_UNIT_TEST_SUITE(BasicUsage) {
         auto events = ReadSession->GetEvents(false);
         UNIT_ASSERT(events.empty());
 
-        Ydb::FederationDiscovery::ListFederationDatabasesResponse Response;
+        NYdbProtos::FederationDiscovery::ListFederationDatabasesResponse Response;
 
         auto op = Response.mutable_operation();
-        op->set_status(Ydb::StatusIds::SUCCESS);
+        op->set_status(NYdbProtos::StatusIds::SUCCESS);
         Response.mutable_operation()->set_ready(true);
         Response.mutable_operation()->set_id("12345");
 
-        Ydb::FederationDiscovery::ListFederationDatabasesResult mockResult;
+        NYdbProtos::FederationDiscovery::ListFederationDatabasesResult mockResult;
         mockResult.set_control_plane_endpoint("cp.logbroker-federation:2135");
         mockResult.set_self_location("fancy_datacenter");
         auto c1 = mockResult.add_federation_databases();
@@ -256,7 +256,7 @@ Y_UNIT_TEST_SUITE(BasicUsage) {
         c1->set_id("account-dc1");
         c1->set_endpoint("localhost:" + ToString(fdsMock.Port));
         c1->set_location("dc1");
-        c1->set_status(::Ydb::FederationDiscovery::DatabaseInfo::Status::DatabaseInfo_Status_AVAILABLE);
+        c1->set_status(::NYdbProtos::FederationDiscovery::DatabaseInfo::Status::DatabaseInfo_Status_AVAILABLE);
         c1->set_weight(1000);
         auto c2 = mockResult.add_federation_databases();
         c2->set_name("dc2");
@@ -264,7 +264,7 @@ Y_UNIT_TEST_SUITE(BasicUsage) {
         c2->set_id("account-dc2");
         c2->set_endpoint("localhost:" + ToString(fdsMock.Port));
         c2->set_location("dc2");
-        c2->set_status(::Ydb::FederationDiscovery::DatabaseInfo::Status::DatabaseInfo_Status_AVAILABLE);
+        c2->set_status(::NYdbProtos::FederationDiscovery::DatabaseInfo::Status::DatabaseInfo_Status_AVAILABLE);
         c2->set_weight(500);
 
         op->mutable_result()->PackFrom(mockResult);
@@ -440,9 +440,9 @@ Y_UNIT_TEST_SUITE(BasicUsage) {
         {
             auto fdsRequest = fdsMock.GetNextPendingRequest();
             Y_ASSERT(fdsRequest.has_value());
-            Ydb::FederationDiscovery::ListFederationDatabasesResponse response;
+            NYdbProtos::FederationDiscovery::ListFederationDatabasesResponse response;
             auto op = response.mutable_operation();
-            op->set_status(Ydb::StatusIds::BAD_REQUEST);
+            op->set_status(NYdbProtos::StatusIds::BAD_REQUEST);
             response.mutable_operation()->set_ready(true);
             response.mutable_operation()->set_id("12345");
             fdsRequest->Result.SetValue({std::move(response), grpc::Status::OK});
@@ -955,12 +955,12 @@ Y_UNIT_TEST_SUITE(BasicUsage) {
 
         auto writer = topicClient.CreateWriteSession(writeSettings);
 
-        Ydb::FederationDiscovery::ListFederationDatabasesResponse response;
+        NYdbProtos::FederationDiscovery::ListFederationDatabasesResponse response;
         auto op = response.mutable_operation();
-        op->set_status(Ydb::StatusIds::SUCCESS);
+        op->set_status(NYdbProtos::StatusIds::SUCCESS);
         response.mutable_operation()->set_ready(true);
         response.mutable_operation()->set_id("12345");
-        Ydb::FederationDiscovery::ListFederationDatabasesResult mockResult;
+        NYdbProtos::FederationDiscovery::ListFederationDatabasesResult mockResult;
         mockResult.set_control_plane_endpoint("cp.logbroker-federation:2135");
         mockResult.set_self_location("fancy_datacenter");
         auto c1 = mockResult.add_federation_databases();
@@ -969,7 +969,7 @@ Y_UNIT_TEST_SUITE(BasicUsage) {
         c1->set_id("account-dc1");
         c1->set_endpoint("localhost:" + ToString(fdsMock.Port));
         c1->set_location("dc1");
-        c1->set_status(::Ydb::FederationDiscovery::DatabaseInfo::Status::DatabaseInfo_Status_AVAILABLE);
+        c1->set_status(::NYdbProtos::FederationDiscovery::DatabaseInfo::Status::DatabaseInfo_Status_AVAILABLE);
         c1->set_weight(1000);
         auto c2 = mockResult.add_federation_databases();
         c2->set_name("dc2");
@@ -977,7 +977,7 @@ Y_UNIT_TEST_SUITE(BasicUsage) {
         c2->set_id("account-dc2");
         c2->set_endpoint("localhost:" + ToString(fdsMock.Port));
         c2->set_location("dc2");
-        c2->set_status(::Ydb::FederationDiscovery::DatabaseInfo::Status::DatabaseInfo_Status_UNAVAILABLE);
+        c2->set_status(::NYdbProtos::FederationDiscovery::DatabaseInfo::Status::DatabaseInfo_Status_UNAVAILABLE);
         c2->set_weight(500);
         op->mutable_result()->PackFrom(mockResult);
         auto fdsRequest = fdsMock.WaitNextPendingRequest();
@@ -1229,16 +1229,16 @@ Y_UNIT_TEST_SUITE(BasicUsage) {
         db->set_name("db" + ToString(id));
         db->set_location("dc" + ToString(id));
         db->set_weight(weight);
-        db->set_status(Ydb::FederationDiscovery::DatabaseInfo_Status_AVAILABLE);
+        db->set_status(NYdbProtos::FederationDiscovery::DatabaseInfo_Status_AVAILABLE);
         dbInfos.push_back(db);
     }
 
     void EnableDatabase(std::vector<std::shared_ptr<TDbInfo>>& dbInfos, int id) {
-        dbInfos[id - 1]->set_status(Ydb::FederationDiscovery::DatabaseInfo_Status_AVAILABLE);
+        dbInfos[id - 1]->set_status(NYdbProtos::FederationDiscovery::DatabaseInfo_Status_AVAILABLE);
     }
 
     void DisableDatabase(std::vector<std::shared_ptr<TDbInfo>>& dbInfos, int id) {
-        dbInfos[id - 1]->set_status(Ydb::FederationDiscovery::DatabaseInfo_Status_UNAVAILABLE);
+        dbInfos[id - 1]->set_status(NYdbProtos::FederationDiscovery::DatabaseInfo_Status_UNAVAILABLE);
     }
 
     Y_UNIT_TEST(SelectDatabaseByHash) {

--- a/ydb/public/sdk/cpp/src/client/federated_topic/ut/fds_mock/fds_mock.h
+++ b/ydb/public/sdk/cpp/src/client/federated_topic/ut/fds_mock/fds_mock.h
@@ -14,10 +14,10 @@ namespace NYdb::NFederatedTopic::NTests {
 // create 2 queues, for requests and responses
 // getrequest() - put request and returns<request, promise<response>>
 // sendresponse()
-class TFederationDiscoveryServiceMock: public Ydb::FederationDiscovery::V1::FederationDiscoveryService::Service {
+class TFederationDiscoveryServiceMock: public NYdbProtos::FederationDiscovery::V1::FederationDiscoveryService::Service {
 public:
-    using TRequest = Ydb::FederationDiscovery::ListFederationDatabasesRequest;
-    using TResponse = Ydb::FederationDiscovery::ListFederationDatabasesResponse;
+    using TRequest = NYdbProtos::FederationDiscovery::ListFederationDatabasesRequest;
+    using TResponse = NYdbProtos::FederationDiscovery::ListFederationDatabasesResponse;
 
     struct TGrpcResult {
         TResponse Response;
@@ -80,15 +80,15 @@ public:
         return grpc::Status(grpc::StatusCode::UNKNOWN, "No response after timeout");
     }
 
-    TGrpcResult ComposeOkResult(::Ydb::FederationDiscovery::DatabaseInfo::Status status) {
-        Ydb::FederationDiscovery::ListFederationDatabasesResponse okResponse;
+    TGrpcResult ComposeOkResult(::NYdbProtos::FederationDiscovery::DatabaseInfo::Status status) {
+        NYdbProtos::FederationDiscovery::ListFederationDatabasesResponse okResponse;
 
         auto op = okResponse.mutable_operation();
-        op->set_status(Ydb::StatusIds::SUCCESS);
+        op->set_status(NYdbProtos::StatusIds::SUCCESS);
         okResponse.mutable_operation()->set_ready(true);
         okResponse.mutable_operation()->set_id("12345");
 
-        Ydb::FederationDiscovery::ListFederationDatabasesResult mockResult;
+        NYdbProtos::FederationDiscovery::ListFederationDatabasesResult mockResult;
         mockResult.set_control_plane_endpoint("cp.logbroker-federation:2135");
         mockResult.set_self_location("fancy_datacenter");
         auto c1 = mockResult.add_federation_databases();
@@ -122,31 +122,31 @@ public:
     }
 
     TGrpcResult ComposeOkResultAvailableDatabases() {
-        return ComposeOkResult(::Ydb::FederationDiscovery::DatabaseInfo::Status::DatabaseInfo_Status_AVAILABLE);
+        return ComposeOkResult(::NYdbProtos::FederationDiscovery::DatabaseInfo::Status::DatabaseInfo_Status_AVAILABLE);
     }
 
     TGrpcResult ComposeOkResultUnavailableDatabases() {
-        return ComposeOkResult(::Ydb::FederationDiscovery::DatabaseInfo::Status::DatabaseInfo_Status_UNAVAILABLE);
+        return ComposeOkResult(::NYdbProtos::FederationDiscovery::DatabaseInfo::Status::DatabaseInfo_Status_UNAVAILABLE);
     }
 
     TGrpcResult ComposeUnavailableResult() {
-        Ydb::FederationDiscovery::ListFederationDatabasesResponse response;
+        NYdbProtos::FederationDiscovery::ListFederationDatabasesResponse response;
         auto op = response.mutable_operation();
-        op->set_status(Ydb::StatusIds::UNAVAILABLE);
+        op->set_status(NYdbProtos::StatusIds::UNAVAILABLE);
         response.mutable_operation()->set_ready(true);
         response.mutable_operation()->set_id("12345");
         return {response, grpc::Status::OK};
     }
 
     TGrpcResult ComposeOkResultWithUnavailableDatabase(int unavailableDb) {
-        Ydb::FederationDiscovery::ListFederationDatabasesResponse okResponse;
+        NYdbProtos::FederationDiscovery::ListFederationDatabasesResponse okResponse;
 
         auto op = okResponse.mutable_operation();
-        op->set_status(Ydb::StatusIds::SUCCESS);
+        op->set_status(NYdbProtos::StatusIds::SUCCESS);
         okResponse.mutable_operation()->set_ready(true);
         okResponse.mutable_operation()->set_id("12345");
 
-        Ydb::FederationDiscovery::ListFederationDatabasesResult mockResult;
+        NYdbProtos::FederationDiscovery::ListFederationDatabasesResult mockResult;
         mockResult.set_control_plane_endpoint("cp.logbroker-federation:2135");
         mockResult.set_self_location("fancy_datacenter");
         for (int i = 1; i <= 3; ++i) {
@@ -157,9 +157,9 @@ public:
             c1->set_endpoint("localhost:" + ToString(Port));
             c1->set_location(TStringBuilder() << "dc" << i);
             if (i == unavailableDb) {
-                c1->set_status(::Ydb::FederationDiscovery::DatabaseInfo::Status::DatabaseInfo_Status_UNAVAILABLE);
+                c1->set_status(::NYdbProtos::FederationDiscovery::DatabaseInfo::Status::DatabaseInfo_Status_UNAVAILABLE);
             } else {
-                c1->set_status(::Ydb::FederationDiscovery::DatabaseInfo::Status::DatabaseInfo_Status_AVAILABLE);
+                c1->set_status(::NYdbProtos::FederationDiscovery::DatabaseInfo::Status::DatabaseInfo_Status_AVAILABLE);
             }
             c1->set_weight(i == 0 ? 1000 : 500);
         }

--- a/ydb/public/sdk/cpp/src/client/impl/ydb_internal/db_driver_state/endpoint_pool.h
+++ b/ydb/public/sdk/cpp/src/client/impl/ydb_internal/db_driver_state/endpoint_pool.h
@@ -14,7 +14,7 @@
 namespace NYdb::inline V3 {
 
 struct TListEndpointsResult {
-    Ydb::Discovery::ListEndpointsResult Result;
+    NYdbProtos::Discovery::ListEndpointsResult Result;
     TPlainStatus DiscoveryStatus;
 };
 

--- a/ydb/public/sdk/cpp/src/client/impl/ydb_internal/grpc_connections/actions.cpp
+++ b/ydb/public/sdk/cpp/src/client/impl/ydb_internal/grpc_connections/actions.cpp
@@ -41,16 +41,16 @@ TDeferredAction::TDeferredAction(const std::string& operationId,
 void TDeferredAction::OnAlarm() {
     Y_ABORT_UNLESS(Connection_);
 
-    Ydb::Operations::GetOperationRequest getOperationRequest;
+    NYdbProtos::Operations::GetOperationRequest getOperationRequest;
     getOperationRequest.set_id(TStringType{OperationId_});
 
     TRpcRequestSettings settings;
     settings.PreferredEndpoint = TEndpointKey(Endpoint_, 0);
     
-    Connection_->RunDeferred<Ydb::Operation::V1::OperationService, Ydb::Operations::GetOperationRequest, Ydb::Operations::GetOperationResponse>(
+    Connection_->RunDeferred<NYdbProtos::Operation::V1::OperationService, NYdbProtos::Operations::GetOperationRequest, NYdbProtos::Operations::GetOperationResponse>(
         std::move(getOperationRequest),
         std::move(UserResponseCb_),
-        &Ydb::Operation::V1::OperationService::Stub::AsyncGetOperation,
+        &NYdbProtos::Operation::V1::OperationService::Stub::AsyncGetOperation,
         DbDriverState_,
         NextDelay_,
         settings,
@@ -63,7 +63,7 @@ void TDeferredAction::OnError() {
     NYdbGrpc::TGrpcStatus status = {"Deferred timer interrupted", -1, true};
     DbDriverState_->StatCollector.IncDiscoveryFailDueTransportError();
 
-    auto resp = new TGRpcErrorResponse<Ydb::Operations::Operation>(
+    auto resp = new TGRpcErrorResponse<NYdbProtos::Operations::Operation>(
         std::move(status),
         std::move(UserResponseCb_),
         Connection_,

--- a/ydb/public/sdk/cpp/src/client/impl/ydb_internal/grpc_connections/actions.h
+++ b/ydb/public/sdk/cpp/src/client/impl/ydb_internal/grpc_connections/actions.h
@@ -24,7 +24,7 @@ struct TPlainStatus;
 
 template<typename TResponse>
 using TResponseCb = std::function<void(TResponse*, TPlainStatus status)>;
-using TDeferredOperationCb = std::function<void(Ydb::Operations::Operation*, TPlainStatus status)>;
+using TDeferredOperationCb = std::function<void(NYdbProtos::Operations::Operation*, TPlainStatus status)>;
 
 template<typename TCb>
 class TGenericCbHolder {

--- a/ydb/public/sdk/cpp/src/client/impl/ydb_internal/grpc_connections/grpc_connections.cpp
+++ b/ydb/public/sdk/cpp/src/client/impl/ydb_internal/grpc_connections/grpc_connections.cpp
@@ -317,14 +317,14 @@ void TGRpcConnectionsImpl::SetGrpcKeepAlive(NYdbGrpc::TGRpcClientConfig& config,
 }
 
 TAsyncListEndpointsResult TGRpcConnectionsImpl::GetEndpoints(TDbDriverStatePtr dbState) {
-    Ydb::Discovery::ListEndpointsRequest request;
+    NYdbProtos::Discovery::ListEndpointsRequest request;
     request.set_database(TStringType{dbState->Database});
 
     auto promise = NThreading::NewPromise<TListEndpointsResult>();
 
     auto extractor = [promise]
         (google::protobuf::Any* any, TPlainStatus status) mutable {
-            Ydb::Discovery::ListEndpointsResult result;
+            NYdbProtos::Discovery::ListEndpointsResult result;
             if (any) {
                 any->UnpackTo(&result);
             }
@@ -335,10 +335,10 @@ TAsyncListEndpointsResult TGRpcConnectionsImpl::GetEndpoints(TDbDriverStatePtr d
     TRpcRequestSettings rpcSettings;
     rpcSettings.ClientTimeout = GET_ENDPOINTS_TIMEOUT;
 
-    RunDeferred<Ydb::Discovery::V1::DiscoveryService, Ydb::Discovery::ListEndpointsRequest, Ydb::Discovery::ListEndpointsResponse>(
+    RunDeferred<NYdbProtos::Discovery::V1::DiscoveryService, NYdbProtos::Discovery::ListEndpointsRequest, NYdbProtos::Discovery::ListEndpointsResponse>(
         std::move(request),
         extractor,
-        &Ydb::Discovery::V1::DiscoveryService::Stub::AsyncListEndpoints,
+        &NYdbProtos::Discovery::V1::DiscoveryService::Stub::AsyncListEndpoints,
         dbState->shared_from_this(),
         INITIAL_DEFERRED_CALL_DELAY,
         rpcSettings);

--- a/ydb/public/sdk/cpp/src/client/impl/ydb_internal/grpc_connections/grpc_connections.h
+++ b/ydb/public/sdk/cpp/src/client/impl/ydb_internal/grpc_connections/grpc_connections.h
@@ -98,7 +98,7 @@ public:
             clientConfig.MaxOutboundMessageSize = MaxOutboundMessageSize_;
         }
 
-        if (std::is_same<TService,Ydb::Discovery::V1::DiscoveryService>()
+        if (std::is_same<TService,NYdbProtos::Discovery::V1::DiscoveryService>()
             || dbState->Database.empty()
             || endpointPolicy == TRpcRequestSettings::TEndpointPolicy::UseDiscoveryEndpoint)
         {
@@ -291,7 +291,7 @@ public:
             (TResponse* response, TPlainStatus status) mutable
         {
             if (response) {
-                Ydb::Operations::Operation* operation = response->mutable_operation();
+                NYdbProtos::Operations::Operation* operation = response->mutable_operation();
                 if (!operation->ready() && poll) {
                     auto action = MakeIntrusive<TDeferredAction>(
                         operation->id(),
@@ -359,7 +359,7 @@ public:
         const TRpcRequestSettings& requestSettings,
         std::shared_ptr<IQueueClientContext> context = nullptr)
     {
-        auto operationCb = [userResponseCb = std::move(userResponseCb)](Ydb::Operations::Operation* operation, TPlainStatus status) mutable {
+        auto operationCb = [userResponseCb = std::move(userResponseCb)](NYdbProtos::Operations::Operation* operation, TPlainStatus status) mutable {
             if (operation) {
                 status.SetCostInfo(std::move(*operation->mutable_cost_info()));
                 userResponseCb(operation->mutable_result(), std::move(status));

--- a/ydb/public/sdk/cpp/src/client/impl/ydb_internal/make_request/make.h
+++ b/ydb/public/sdk/cpp/src/client/impl/ydb_internal/make_request/make.h
@@ -2,6 +2,7 @@
 
 #include <src/client/impl/ydb_internal/internal_header.h>
 #include <ydb/public/api/protos/ydb_common.pb.h>
+#include <ydb-cpp-sdk/type_switcher.h>
 
 #include <util/datetime/base.h>
 
@@ -30,7 +31,7 @@ void FillOperationParams(const TRequestSettings& settings, TProtoRequest& params
     }
 
     if (settings.ReportCostInfo_) {
-        operationParams.set_report_cost_info(Ydb::FeatureFlag::ENABLED);
+        operationParams.set_report_cost_info(NYdbProtos::FeatureFlag::ENABLED);
     }
 }
 

--- a/ydb/public/sdk/cpp/src/client/impl/ydb_internal/plain_status/status.h
+++ b/ydb/public/sdk/cpp/src/client/impl/ydb_internal/plain_status/status.h
@@ -18,7 +18,7 @@ struct TPlainStatus {
     NYdb::NIssue::TIssues Issues;
     std::string Endpoint;
     std::multimap<std::string, std::string> Metadata;
-    Ydb::CostInfo ConstInfo;
+    NYdbProtos::CostInfo ConstInfo;
 
     TPlainStatus()
         : Status(EStatus::SUCCESS)

--- a/ydb/public/sdk/cpp/src/client/impl/ydb_internal/table_helpers/helpers.h
+++ b/ydb/public/sdk/cpp/src/client/impl/ydb_internal/table_helpers/helpers.h
@@ -7,23 +7,23 @@
 
 namespace NYdb::inline V3 {
 
-inline Ydb::Table::QueryStatsCollection::Mode GetStatsCollectionMode(std::optional<NTable::ECollectQueryStatsMode> mode) {
+inline NYdbProtos::Table::QueryStatsCollection::Mode GetStatsCollectionMode(std::optional<NTable::ECollectQueryStatsMode> mode) {
     if (mode.has_value()) {
         switch (*mode) {
             case NTable::ECollectQueryStatsMode::None:
-                return Ydb::Table::QueryStatsCollection::STATS_COLLECTION_NONE;
+                return NYdbProtos::Table::QueryStatsCollection::STATS_COLLECTION_NONE;
             case NTable::ECollectQueryStatsMode::Basic:
-                return Ydb::Table::QueryStatsCollection::STATS_COLLECTION_BASIC;
+                return NYdbProtos::Table::QueryStatsCollection::STATS_COLLECTION_BASIC;
             case NTable::ECollectQueryStatsMode::Full:
-                return Ydb::Table::QueryStatsCollection::STATS_COLLECTION_FULL;
+                return NYdbProtos::Table::QueryStatsCollection::STATS_COLLECTION_FULL;
             case NTable::ECollectQueryStatsMode::Profile:
-                return Ydb::Table::QueryStatsCollection::STATS_COLLECTION_PROFILE;
+                return NYdbProtos::Table::QueryStatsCollection::STATS_COLLECTION_PROFILE;
             default:
                 break;
         }
     }
 
-    return Ydb::Table::QueryStatsCollection::STATS_COLLECTION_UNSPECIFIED;
+    return NYdbProtos::Table::QueryStatsCollection::STATS_COLLECTION_UNSPECIFIED;
 }
 
 } // namespace NYdb

--- a/ydb/public/sdk/cpp/src/client/impl/ydb_internal/value_helpers/helpers.cpp
+++ b/ydb/public/sdk/cpp/src/client/impl/ydb_internal/value_helpers/helpers.cpp
@@ -6,28 +6,28 @@
 
 namespace NYdb::inline V3 {
 
-bool TypesEqual(const Ydb::Type& t1, const Ydb::Type& t2) {
+bool TypesEqual(const NYdbProtos::Type& t1, const NYdbProtos::Type& t2) {
     if (t1.type_case() != t2.type_case()) {
         return false;
     }
 
     switch (t1.type_case()) {
-        case Ydb::Type::kTypeId:
+        case NYdbProtos::Type::kTypeId:
             return t1.type_id() == t2.type_id();
-        case Ydb::Type::kDecimalType:
+        case NYdbProtos::Type::kDecimalType:
             return t1.decimal_type().precision() == t2.decimal_type().precision()
                 && t1.decimal_type().scale() == t2.decimal_type().scale();
-        case Ydb::Type::kPgType:
+        case NYdbProtos::Type::kPgType:
             return t1.pg_type().type_name() == t2.pg_type().type_name()
                 && t1.pg_type().type_modifier() == t2.pg_type().type_modifier();
-        case Ydb::Type::kOptionalType:
+        case NYdbProtos::Type::kOptionalType:
             return TypesEqual(t1.optional_type().item(), t2.optional_type().item());
-        case Ydb::Type::kTaggedType:
+        case NYdbProtos::Type::kTaggedType:
             return t1.tagged_type().tag() == t2.tagged_type().tag() &&
                 TypesEqual(t1.tagged_type().type(), t2.tagged_type().type());
-        case Ydb::Type::kListType:
+        case NYdbProtos::Type::kListType:
             return TypesEqual(t1.list_type().item(), t2.list_type().item());
-        case Ydb::Type::kTupleType:
+        case NYdbProtos::Type::kTupleType:
             if (t1.tuple_type().elements_size() != t2.tuple_type().elements_size()) {
                 return false;
             }
@@ -37,7 +37,7 @@ bool TypesEqual(const Ydb::Type& t1, const Ydb::Type& t2) {
                 }
             }
             return true;
-        case Ydb::Type::kStructType:
+        case NYdbProtos::Type::kStructType:
             if (t1.struct_type().members_size() != t2.struct_type().members_size()) {
                 return false;
             }
@@ -53,17 +53,17 @@ bool TypesEqual(const Ydb::Type& t1, const Ydb::Type& t2) {
                 }
             }
             return true;
-        case Ydb::Type::kDictType:
+        case NYdbProtos::Type::kDictType:
             return TypesEqual(t1.dict_type().key(), t2.dict_type().key())
                 && TypesEqual(t1.dict_type().payload(), t2.dict_type().payload());
-        case Ydb::Type::kVariantType: {
+        case NYdbProtos::Type::kVariantType: {
             const auto& v1 = t1.variant_type();
             const auto& v2 = t2.variant_type();
             if (v1.type_case() != v2.type_case()) {
                 return false;
             }
             switch (v1.type_case()) {
-                case Ydb::VariantType::kTupleItems:
+                case NYdbProtos::VariantType::kTupleItems:
                     if (v1.tuple_items().elements_size() != v2.tuple_items().elements_size()) {
                         return false;
                     }
@@ -73,7 +73,7 @@ bool TypesEqual(const Ydb::Type& t1, const Ydb::Type& t2) {
                         }
                     }
                     return true;
-                case Ydb::VariantType::kStructItems:
+                case NYdbProtos::VariantType::kStructItems:
                     if (v1.struct_items().members_size() != v2.struct_items().members_size()) {
                         return false;
                     }
@@ -95,13 +95,13 @@ bool TypesEqual(const Ydb::Type& t1, const Ydb::Type& t2) {
             }
             return false;
         }
-        case Ydb::Type::kVoidType:
+        case NYdbProtos::Type::kVoidType:
             return true;
-        case Ydb::Type::kNullType:
+        case NYdbProtos::Type::kNullType:
             return true;
-        case Ydb::Type::kEmptyListType:
+        case NYdbProtos::Type::kEmptyListType:
             return true;
-        case Ydb::Type::kEmptyDictType:
+        case NYdbProtos::Type::kEmptyDictType:
             return true;
         default:
             ThrowFatalError(TStringBuilder() << "Unexpected type case " << static_cast<int>(t1.type_case()));

--- a/ydb/public/sdk/cpp/src/client/impl/ydb_internal/value_helpers/helpers.h
+++ b/ydb/public/sdk/cpp/src/client/impl/ydb_internal/value_helpers/helpers.h
@@ -4,8 +4,10 @@
 
 #include <ydb/public/api/protos/ydb_value.pb.h>
 
+#include <ydb-cpp-sdk/type_switcher.h>
+
 namespace NYdb::inline V3 {
 
-bool TypesEqual(const Ydb::Type& t1, const Ydb::Type& t2);
+bool TypesEqual(const NYdbProtos::Type& t1, const NYdbProtos::Type& t2);
 
 } // namespace NYdb

--- a/ydb/public/sdk/cpp/src/client/import/import.cpp
+++ b/ydb/public/sdk/cpp/src/client/import/import.cpp
@@ -14,12 +14,12 @@ namespace NYdb::inline V3 {
 namespace NImport {
 
 using namespace NThreading;
-using namespace Ydb::Import;
+using namespace NYdbProtos::Import;
 
 /// Common
 namespace {
 
-std::vector<TImportItemProgress> ItemsProgressFromProto(const google::protobuf::RepeatedPtrField<Ydb::Import::ImportItemProgress>& proto) {
+std::vector<TImportItemProgress> ItemsProgressFromProto(const google::protobuf::RepeatedPtrField<NYdbProtos::Import::ImportItemProgress>& proto) {
     std::vector<TImportItemProgress> result;
     result.reserve(proto.size());
 
@@ -37,7 +37,7 @@ std::vector<TImportItemProgress> ItemsProgressFromProto(const google::protobuf::
 } // anonymous
 
 /// S3
-TImportFromS3Response::TImportFromS3Response(TStatus&& status, Ydb::Operations::Operation&& operation)
+TImportFromS3Response::TImportFromS3Response(TStatus&& status, NYdbProtos::Operations::Operation&& operation)
     : TOperation(std::move(status), std::move(operation))
 {
     ImportFromS3Metadata metadata;

--- a/ydb/public/sdk/cpp/src/client/operation/operation.cpp
+++ b/ydb/public/sdk/cpp/src/client/operation/operation.cpp
@@ -21,8 +21,8 @@ namespace NOperation {
 constexpr TDuration OPERATION_CLIENT_TIMEOUT = TDuration::Seconds(5);
 
 using namespace NThreading;
-using namespace Ydb::Operation;
-using namespace Ydb::Operations;
+using namespace NYdbProtos::Operation;
+using namespace NYdbProtos::Operations;
 
 class TOperationClient::TImpl : public TClientImplCommon<TOperationClient::TImpl> {
     template <typename TRequest, typename TResponse>

--- a/ydb/public/sdk/cpp/src/client/params/impl.cpp
+++ b/ydb/public/sdk/cpp/src/client/params/impl.cpp
@@ -6,7 +6,7 @@
 
 namespace NYdb::inline V3 {
 
-TParams::TImpl::TImpl(::google::protobuf::Map<TStringType, Ydb::TypedValue>&& paramsMap) {
+TParams::TImpl::TImpl(::google::protobuf::Map<TStringType, NYdbProtos::TypedValue>&& paramsMap) {
     ParamsMap_.swap(paramsMap);
 }
 
@@ -36,11 +36,11 @@ std::optional<TValue> TParams::TImpl::GetValue(const std::string& name) const {
     return std::optional<TValue>();
 }
 
-::google::protobuf::Map<TStringType, Ydb::TypedValue>* TParams::TImpl::GetProtoMapPtr() {
+::google::protobuf::Map<TStringType, NYdbProtos::TypedValue>* TParams::TImpl::GetProtoMapPtr() {
     return &ParamsMap_;
 }
 
-const ::google::protobuf::Map<TStringType, Ydb::TypedValue>& TParams::TImpl::GetProtoMap() const {
+const ::google::protobuf::Map<TStringType, NYdbProtos::TypedValue>& TParams::TImpl::GetProtoMap() const {
     return ParamsMap_;
 }
 

--- a/ydb/public/sdk/cpp/src/client/params/impl.h
+++ b/ydb/public/sdk/cpp/src/client/params/impl.h
@@ -6,16 +6,16 @@ namespace NYdb::inline V3 {
 
 class TParams::TImpl {
 public:
-    TImpl(::google::protobuf::Map<TStringType, Ydb::TypedValue>&& paramsMap);
+    TImpl(::google::protobuf::Map<TStringType, NYdbProtos::TypedValue>&& paramsMap);
 
     bool Empty() const;
     std::map<std::string, TValue> GetValues() const;
     std::optional<TValue> GetValue(const std::string& name) const;
-    ::google::protobuf::Map<TStringType, Ydb::TypedValue>* GetProtoMapPtr();
-    const ::google::protobuf::Map<TStringType, Ydb::TypedValue>& GetProtoMap() const;
+    ::google::protobuf::Map<TStringType, NYdbProtos::TypedValue>* GetProtoMapPtr();
+    const ::google::protobuf::Map<TStringType, NYdbProtos::TypedValue>& GetProtoMap() const;
 
 private:
-    ::google::protobuf::Map<TStringType, Ydb::TypedValue> ParamsMap_;
+    ::google::protobuf::Map<TStringType, NYdbProtos::TypedValue> ParamsMap_;
 };
 
 } // namespace NYdb

--- a/ydb/public/sdk/cpp/src/client/params/params.cpp
+++ b/ydb/public/sdk/cpp/src/client/params/params.cpp
@@ -12,14 +12,14 @@ namespace NYdb::inline V3 {
 
 ////////////////////////////////////////////////////////////////////////////////
 
-TParams::TParams(::google::protobuf::Map<TStringType, Ydb::TypedValue>&& protoMap)
+TParams::TParams(::google::protobuf::Map<TStringType, NYdbProtos::TypedValue>&& protoMap)
     : Impl_(new TImpl(std::move(protoMap))) {}
 
-::google::protobuf::Map<TStringType, Ydb::TypedValue>* TParams::GetProtoMapPtr() {
+::google::protobuf::Map<TStringType, NYdbProtos::TypedValue>* TParams::GetProtoMapPtr() {
     return Impl_->GetProtoMapPtr();
 }
 
-const ::google::protobuf::Map<TStringType, Ydb::TypedValue>& TParams::GetProtoMap() const {
+const ::google::protobuf::Map<TStringType, NYdbProtos::TypedValue>& TParams::GetProtoMap() const {
     return Impl_->GetProtoMap();
 }
 
@@ -41,7 +41,7 @@ class TParamsBuilder::TImpl {
 public:
     TImpl() = default;
 
-    TImpl(const ::google::protobuf::Map<TStringType, Ydb::Type>& typeInfo)
+    TImpl(const ::google::protobuf::Map<TStringType, NYdbProtos::Type>& typeInfo)
         : HasTypeInfo_(true)
     {
         for (const auto& pair : typeInfo) {
@@ -97,13 +97,13 @@ public:
 
         ValueBuildersMap_.clear();
 
-        ::google::protobuf::Map<TStringType, Ydb::TypedValue> paramsMap;
+        ::google::protobuf::Map<TStringType, NYdbProtos::TypedValue> paramsMap;
         paramsMap.swap(ParamsMap_);
         return TParams(std::move(paramsMap));
     }
 
 private:
-    Ydb::TypedValue* GetParam(const std::string& name) {
+    NYdbProtos::TypedValue* GetParam(const std::string& name) {
         if (HasTypeInfo()) {
             auto it = ParamsMap_.find(name);
             if (it == ParamsMap_.end()) {
@@ -123,13 +123,13 @@ private:
 
 private:
     bool HasTypeInfo_ = false;
-    ::google::protobuf::Map<TStringType, Ydb::TypedValue> ParamsMap_;
+    ::google::protobuf::Map<TStringType, NYdbProtos::TypedValue> ParamsMap_;
     std::map<std::string, TParamValueBuilder> ValueBuildersMap_;
 };
 
 ////////////////////////////////////////////////////////////////////////////////
 
-TParamValueBuilder::TParamValueBuilder(TParamsBuilder& owner, Ydb::Type& typeProto, Ydb::Value& valueProto)
+TParamValueBuilder::TParamValueBuilder(TParamsBuilder& owner, NYdbProtos::Type& typeProto, NYdbProtos::Value& valueProto)
     : TValueBuilderBase(typeProto, valueProto)
     , Owner_(owner)
     , Finished_(false) {}
@@ -156,7 +156,7 @@ TParamsBuilder::TParamsBuilder()
 TParamsBuilder::TParamsBuilder(const std::map<std::string, TType>& typeInfo)
     : Impl_(new TImpl(typeInfo)) {}
 
-TParamsBuilder::TParamsBuilder(const ::google::protobuf::Map<TStringType, Ydb::Type>& typeInfo)
+TParamsBuilder::TParamsBuilder(const ::google::protobuf::Map<TStringType, NYdbProtos::Type>& typeInfo)
     : Impl_(new TImpl(typeInfo)) {}
 
 bool TParamsBuilder::HasTypeInfo() const {

--- a/ydb/public/sdk/cpp/src/client/persqueue_public/impl/persqueue.cpp
+++ b/ydb/public/sdk/cpp/src/client/persqueue_public/impl/persqueue.cpp
@@ -27,23 +27,23 @@ const std::vector<ECodec>& GetDefaultCodecs() {
 using TTopicSettingsCreate = TTopicSettings<TCreateTopicSettings>;
 using TTopicSettingsAlter = TTopicSettings<TAlterTopicSettings>;
 
-TCredentials::TCredentials(const Ydb::PersQueue::V1::Credentials& settings)
+TCredentials::TCredentials(const NYdbProtos::PersQueue::V1::Credentials& settings)
     : Credentials_(settings)
 {
     switch (Credentials_.credentials_case()) {
-        case Ydb::PersQueue::V1::Credentials::kOauthToken: {
+        case NYdbProtos::PersQueue::V1::Credentials::kOauthToken: {
             Mode_ = EMode::OAUTH_TOKEN;
             break;
         }
-        case Ydb::PersQueue::V1::Credentials::kJwtParams: {
+        case NYdbProtos::PersQueue::V1::Credentials::kJwtParams: {
             Mode_ = EMode::JWT_PARAMS;
             break;
         }
-        case Ydb::PersQueue::V1::Credentials::kIam: {
+        case NYdbProtos::PersQueue::V1::Credentials::kIam: {
             Mode_ = EMode::IAM;
             break;
         }
-        case Ydb::PersQueue::V1::Credentials::CREDENTIALS_NOT_SET: {
+        case NYdbProtos::PersQueue::V1::Credentials::CREDENTIALS_NOT_SET: {
             Mode_ = EMode::NOT_SET;
             break;
         }
@@ -77,14 +77,14 @@ std::string TCredentials::GetIamServiceAccountKey() const {
     return Credentials_.iam().service_account_key();
 }
 
-TDescribeTopicResult::TDescribeTopicResult(TStatus status, const Ydb::PersQueue::V1::DescribeTopicResult& result)
+TDescribeTopicResult::TDescribeTopicResult(TStatus status, const NYdbProtos::PersQueue::V1::DescribeTopicResult& result)
     : TStatus(std::move(status))
     , TopicSettings_(result.settings())
     , Proto_(result)
 {
 }
 
-TDescribeTopicResult::TTopicSettings::TTopicSettings(const Ydb::PersQueue::V1::TopicSettings& settings) {
+TDescribeTopicResult::TTopicSettings::TTopicSettings(const NYdbProtos::PersQueue::V1::TopicSettings& settings) {
     RetentionPeriod_ = TDuration::MilliSeconds(settings.retention_period_ms());
     SupportedFormat_ = static_cast<EFormat>(settings.supported_format());
 
@@ -132,7 +132,7 @@ TDescribeTopicResult::TTopicSettings::TTopicSettings(const Ydb::PersQueue::V1::T
 }
 
 
-TDescribeTopicResult::TTopicSettings::TReadRule::TReadRule(const Ydb::PersQueue::V1::TopicSettings::ReadRule& settings) {
+TDescribeTopicResult::TTopicSettings::TReadRule::TReadRule(const NYdbProtos::PersQueue::V1::TopicSettings::ReadRule& settings) {
 
     ConsumerName_ = settings.consumer_name();
     Important_ = settings.important();
@@ -146,7 +146,7 @@ TDescribeTopicResult::TTopicSettings::TReadRule::TReadRule(const Ydb::PersQueue:
     ServiceType_ = settings.service_type();
 }
 
-TDescribeTopicResult::TTopicSettings::TRemoteMirrorRule::TRemoteMirrorRule(const Ydb::PersQueue::V1::TopicSettings::RemoteMirrorRule& settings)
+TDescribeTopicResult::TTopicSettings::TRemoteMirrorRule::TRemoteMirrorRule(const NYdbProtos::PersQueue::V1::TopicSettings::RemoteMirrorRule& settings)
     : Credentials_(settings.credentials())
 {
     Endpoint_ = settings.endpoint();

--- a/ydb/public/sdk/cpp/src/client/persqueue_public/impl/persqueue_impl.cpp
+++ b/ydb/public/sdk/cpp/src/client/persqueue_public/impl/persqueue_impl.cpp
@@ -72,16 +72,16 @@ std::shared_ptr<TPersQueueClient::TImpl> TPersQueueClient::TImpl::GetClientForEn
 }
 
 std::shared_ptr<TPersQueueClient::TImpl::IReadSessionConnectionProcessorFactory> TPersQueueClient::TImpl::CreateReadSessionConnectionProcessorFactory() {
-    using TService = Ydb::PersQueue::V1::PersQueueService;
-    using TRequest = Ydb::PersQueue::V1::MigrationStreamingReadClientMessage;
-    using TResponse = Ydb::PersQueue::V1::MigrationStreamingReadServerMessage;
+    using TService = NYdbProtos::PersQueue::V1::PersQueueService;
+    using TRequest = NYdbProtos::PersQueue::V1::MigrationStreamingReadClientMessage;
+    using TResponse = NYdbProtos::PersQueue::V1::MigrationStreamingReadServerMessage;
     return CreateConnectionProcessorFactory<TService, TRequest, TResponse>(&TService::Stub::AsyncMigrationStreamingRead, Connections_, DbDriverState_);
 }
 
 std::shared_ptr<TPersQueueClient::TImpl::IWriteSessionConnectionProcessorFactory> TPersQueueClient::TImpl::CreateWriteSessionConnectionProcessorFactory() {
-    using TService = Ydb::PersQueue::V1::PersQueueService;
-    using TRequest = Ydb::PersQueue::V1::StreamingWriteClientMessage;
-    using TResponse = Ydb::PersQueue::V1::StreamingWriteServerMessage;
+    using TService = NYdbProtos::PersQueue::V1::PersQueueService;
+    using TRequest = NYdbProtos::PersQueue::V1::StreamingWriteClientMessage;
+    using TResponse = NYdbProtos::PersQueue::V1::StreamingWriteServerMessage;
     return CreateConnectionProcessorFactory<TService, TRequest, TResponse>(&TService::Stub::AsyncStreamingWrite, Connections_, DbDriverState_);
 }
 

--- a/ydb/public/sdk/cpp/src/client/persqueue_public/impl/persqueue_impl.h
+++ b/ydb/public/sdk/cpp/src/client/persqueue_public/impl/persqueue_impl.h
@@ -34,14 +34,14 @@ public:
     }
 
     template<class TReadRule>
-    static void ConvertToProtoReadRule(const TReadRule& readRule, Ydb::PersQueue::V1::TopicSettings::ReadRule& rrProps) {
+    static void ConvertToProtoReadRule(const TReadRule& readRule, NYdbProtos::PersQueue::V1::TopicSettings::ReadRule& rrProps) {
         rrProps.set_consumer_name(TStringType{readRule.ConsumerName_});
         rrProps.set_important(readRule.Important_);
         rrProps.set_starting_message_timestamp_ms(readRule.StartingMessageTimestamp_.MilliSeconds());
         rrProps.set_version(readRule.Version_);
-        rrProps.set_supported_format(static_cast<Ydb::PersQueue::V1::TopicSettings::Format>(readRule.SupportedFormat_));
+        rrProps.set_supported_format(static_cast<NYdbProtos::PersQueue::V1::TopicSettings::Format>(readRule.SupportedFormat_));
         for (const auto& codec : readRule.SupportedCodecs_) {
-            rrProps.add_supported_codecs((static_cast<Ydb::PersQueue::V1::Codec>(codec)));
+            rrProps.add_supported_codecs((static_cast<NYdbProtos::PersQueue::V1::Codec>(codec)));
         }
         rrProps.set_service_type(TStringType{readRule.ServiceType_});
     }
@@ -51,7 +51,7 @@ public:
         TRequest request = MakeOperationRequest<TRequest>(settings);
         request.set_path(TStringType{path});
 
-        Ydb::PersQueue::V1::TopicSettings& props = *request.mutable_settings();
+        NYdbProtos::PersQueue::V1::TopicSettings& props = *request.mutable_settings();
 
         props.set_partitions_count(settings.PartitionsCount_);
 
@@ -82,9 +82,9 @@ public:
         }
 
         props.set_retention_period_ms(settings.RetentionPeriod_.MilliSeconds());
-        props.set_supported_format(static_cast<Ydb::PersQueue::V1::TopicSettings::Format>(settings.SupportedFormat_));
+        props.set_supported_format(static_cast<NYdbProtos::PersQueue::V1::TopicSettings::Format>(settings.SupportedFormat_));
         for (const auto& codec : settings.SupportedCodecs_) {
-            props.add_supported_codecs((static_cast<Ydb::PersQueue::V1::Codec>(codec)));
+            props.add_supported_codecs((static_cast<NYdbProtos::PersQueue::V1::Codec>(codec)));
         }
         props.set_max_partition_storage_size(settings.MaxPartitionStorageSize_);
         props.set_max_partition_write_speed(settings.MaxPartitionWriteSpeed_);
@@ -98,7 +98,7 @@ public:
         if (settings.FederationAccount_) (*props.mutable_attributes())["_federation_account"] = ToString(*settings.FederationAccount_);
 
         for (const auto& readRule : settings.ReadRules_) {
-            Ydb::PersQueue::V1::TopicSettings::ReadRule& rrProps = *props.add_read_rules();
+            NYdbProtos::PersQueue::V1::TopicSettings::ReadRule& rrProps = *props.add_read_rules();
             ConvertToProtoReadRule(readRule, rrProps);
         }
 
@@ -164,66 +164,66 @@ public:
     }
 
     TAsyncStatus CreateTopic(const std::string& path, const TCreateTopicSettings& settings) {
-        auto request = MakePropsCreateOrAlterRequest<Ydb::PersQueue::V1::CreateTopicRequest>(path,
+        auto request = MakePropsCreateOrAlterRequest<NYdbProtos::PersQueue::V1::CreateTopicRequest>(path,
             settings.PartitionsPerTablet_ ? settings : TCreateTopicSettings(settings).PartitionsPerTablet(2));
 
-        return RunSimple<Ydb::PersQueue::V1::PersQueueService, Ydb::PersQueue::V1::CreateTopicRequest, Ydb::PersQueue::V1::CreateTopicResponse>(
+        return RunSimple<NYdbProtos::PersQueue::V1::PersQueueService, NYdbProtos::PersQueue::V1::CreateTopicRequest, NYdbProtos::PersQueue::V1::CreateTopicResponse>(
             std::move(request),
-            &Ydb::PersQueue::V1::PersQueueService::Stub::AsyncCreateTopic,
+            &NYdbProtos::PersQueue::V1::PersQueueService::Stub::AsyncCreateTopic,
             TRpcRequestSettings::Make(settings));
     }
 
     TAsyncStatus AlterTopic(const std::string& path, const TAlterTopicSettings& settings) {
-        auto request = MakePropsCreateOrAlterRequest<Ydb::PersQueue::V1::AlterTopicRequest>(path, settings);
+        auto request = MakePropsCreateOrAlterRequest<NYdbProtos::PersQueue::V1::AlterTopicRequest>(path, settings);
 
-        return RunSimple<Ydb::PersQueue::V1::PersQueueService, Ydb::PersQueue::V1::AlterTopicRequest, Ydb::PersQueue::V1::AlterTopicResponse>(
+        return RunSimple<NYdbProtos::PersQueue::V1::PersQueueService, NYdbProtos::PersQueue::V1::AlterTopicRequest, NYdbProtos::PersQueue::V1::AlterTopicResponse>(
             std::move(request),
-            &Ydb::PersQueue::V1::PersQueueService::Stub::AsyncAlterTopic,
+            &NYdbProtos::PersQueue::V1::PersQueueService::Stub::AsyncAlterTopic,
             TRpcRequestSettings::Make(settings));
     }
 
 
     TAsyncStatus DropTopic(const std::string& path, const TDropTopicSettings& settings) {
-        auto request = MakeOperationRequest<Ydb::PersQueue::V1::DropTopicRequest>(settings);
+        auto request = MakeOperationRequest<NYdbProtos::PersQueue::V1::DropTopicRequest>(settings);
         request.set_path(TStringType{path});
 
-        return RunSimple<Ydb::PersQueue::V1::PersQueueService, Ydb::PersQueue::V1::DropTopicRequest, Ydb::PersQueue::V1::DropTopicResponse>(
+        return RunSimple<NYdbProtos::PersQueue::V1::PersQueueService, NYdbProtos::PersQueue::V1::DropTopicRequest, NYdbProtos::PersQueue::V1::DropTopicResponse>(
             std::move(request),
-            &Ydb::PersQueue::V1::PersQueueService::Stub::AsyncDropTopic,
+            &NYdbProtos::PersQueue::V1::PersQueueService::Stub::AsyncDropTopic,
             TRpcRequestSettings::Make(settings));
     }
 
     TAsyncStatus AddReadRule(const std::string& path, const TAddReadRuleSettings& settings) {
-        auto request = MakeOperationRequest<Ydb::PersQueue::V1::AddReadRuleRequest>(settings);
+        auto request = MakeOperationRequest<NYdbProtos::PersQueue::V1::AddReadRuleRequest>(settings);
         request.set_path(TStringType{path});
         ConvertToProtoReadRule(settings.ReadRule_, *request.mutable_read_rule());
-        return RunSimple<Ydb::PersQueue::V1::PersQueueService, Ydb::PersQueue::V1::AddReadRuleRequest, Ydb::PersQueue::V1::AddReadRuleResponse>(
+        return RunSimple<NYdbProtos::PersQueue::V1::PersQueueService, NYdbProtos::PersQueue::V1::AddReadRuleRequest, NYdbProtos::PersQueue::V1::AddReadRuleResponse>(
                 std::move(request),
-                &Ydb::PersQueue::V1::PersQueueService::Stub::AsyncAddReadRule,
+                &NYdbProtos::PersQueue::V1::PersQueueService::Stub::AsyncAddReadRule,
                 TRpcRequestSettings::Make(settings));
     }
 
     TAsyncStatus RemoveReadRule(const std::string& path, const TRemoveReadRuleSettings& settings) {
-        auto request = MakeOperationRequest<Ydb::PersQueue::V1::RemoveReadRuleRequest>(settings);
+        auto request = MakeOperationRequest<NYdbProtos::PersQueue::V1::RemoveReadRuleRequest>(settings);
         request.set_path(TStringType{path});
 
         request.set_consumer_name(TStringType{settings.ConsumerName_});
-        return RunSimple<Ydb::PersQueue::V1::PersQueueService, Ydb::PersQueue::V1::RemoveReadRuleRequest, Ydb::PersQueue::V1::RemoveReadRuleResponse>(
+        return RunSimple<NYdbProtos::PersQueue::V1::PersQueueService, NYdbProtos::PersQueue::V1::RemoveReadRuleRequest, NYdbProtos::PersQueue::V1::RemoveReadRuleResponse>(
                 std::move(request),
-                &Ydb::PersQueue::V1::PersQueueService::Stub::AsyncRemoveReadRule,
+                &NYdbProtos::PersQueue::V1::PersQueueService::Stub::AsyncRemoveReadRule,
                 TRpcRequestSettings::Make(settings));
     }
 
 
     TAsyncDescribeTopicResult DescribeTopic(const std::string& path, const TDescribeTopicSettings& settings) {
-        auto request = MakeOperationRequest<Ydb::PersQueue::V1::DescribeTopicRequest>(settings);
+        auto request = MakeOperationRequest<NYdbProtos::PersQueue::V1::DescribeTopicRequest>(settings);
         request.set_path(TStringType{path});
 
         auto promise = NThreading::NewPromise<TDescribeTopicResult>();
 
         auto extractor = [promise]
             (google::protobuf::Any* any, TPlainStatus status) mutable {
-                Ydb::PersQueue::V1::DescribeTopicResult result;
+                NYdbProtos::PersQueue::V1::DescribeTopicResult result;
                 if (any) {
                     any->UnpackTo(&result);
                 }
@@ -232,10 +232,10 @@ public:
                 promise.SetValue(std::move(val));
             };
 
-        Connections_->RunDeferred<Ydb::PersQueue::V1::PersQueueService, Ydb::PersQueue::V1::DescribeTopicRequest, Ydb::PersQueue::V1::DescribeTopicResponse>(
+        Connections_->RunDeferred<NYdbProtos::PersQueue::V1::PersQueueService, NYdbProtos::PersQueue::V1::DescribeTopicRequest, NYdbProtos::PersQueue::V1::DescribeTopicResponse>(
             std::move(request),
             extractor,
-            &Ydb::PersQueue::V1::PersQueueService::Stub::AsyncDescribeTopic,
+            &NYdbProtos::PersQueue::V1::PersQueueService::Stub::AsyncDescribeTopic,
             DbDriverState_,
             INITIAL_DEFERRED_CALL_DELAY,
             TRpcRequestSettings::Make(settings));
@@ -250,13 +250,13 @@ public:
 
     std::shared_ptr<TImpl> GetClientForEndpoint(const std::string& clusterEndoint);
 
-    using IReadSessionConnectionProcessorFactory = ISessionConnectionProcessorFactory<Ydb::PersQueue::V1::MigrationStreamingReadClientMessage, Ydb::PersQueue::V1::MigrationStreamingReadServerMessage>;
+    using IReadSessionConnectionProcessorFactory = ISessionConnectionProcessorFactory<NYdbProtos::PersQueue::V1::MigrationStreamingReadClientMessage, NYdbProtos::PersQueue::V1::MigrationStreamingReadServerMessage>;
 
     std::shared_ptr<IReadSessionConnectionProcessorFactory> CreateReadSessionConnectionProcessorFactory();
 
     using IWriteSessionConnectionProcessorFactory = ISessionConnectionProcessorFactory<
-            Ydb::PersQueue::V1::StreamingWriteClientMessage,
-            Ydb::PersQueue::V1::StreamingWriteServerMessage>;
+            NYdbProtos::PersQueue::V1::StreamingWriteClientMessage,
+            NYdbProtos::PersQueue::V1::StreamingWriteServerMessage>;
 
     std::shared_ptr<IWriteSessionConnectionProcessorFactory> CreateWriteSessionConnectionProcessorFactory();
 

--- a/ydb/public/sdk/cpp/src/client/persqueue_public/impl/read_session.h
+++ b/ydb/public/sdk/cpp/src/client/persqueue_public/impl/read_session.h
@@ -85,9 +85,9 @@ private:
     bool ValidateSettings();
 
     // Cluster discovery
-    Ydb::PersQueue::ClusterDiscovery::DiscoverClustersRequest MakeClusterDiscoveryRequest() const;
+    NYdbProtos::PersQueue::ClusterDiscovery::DiscoverClustersRequest MakeClusterDiscoveryRequest() const;
     void StartClusterDiscovery();
-    void OnClusterDiscovery(const TStatus& status, const Ydb::PersQueue::ClusterDiscovery::DiscoverClustersResult& result);
+    void OnClusterDiscovery(const TStatus& status, const NYdbProtos::PersQueue::ClusterDiscovery::DiscoverClustersResult& result);
     void ProceedWithoutClusterDiscovery();
     void RestartClusterDiscoveryImpl(TDuration delay, TDeferredActions& deferred);
     void CreateClusterSessionsImpl(TDeferredActions& deferred);

--- a/ydb/public/sdk/cpp/src/client/persqueue_public/impl/write_session_impl.h
+++ b/ydb/public/sdk/cpp/src/client/persqueue_public/impl/write_session_impl.h
@@ -159,8 +159,8 @@ private:
     friend class NTests::TSimpleWriteSessionTestAdapter;
 
 private:
-    using TClientMessage = Ydb::PersQueue::V1::StreamingWriteClientMessage;
-    using TServerMessage = Ydb::PersQueue::V1::StreamingWriteServerMessage;
+    using TClientMessage = NYdbProtos::PersQueue::V1::StreamingWriteClientMessage;
+    using TServerMessage = NYdbProtos::PersQueue::V1::StreamingWriteServerMessage;
     using IWriteSessionConnectionProcessorFactory =
             TPersQueueClient::TImpl::IWriteSessionConnectionProcessorFactory;
     using IProcessor = IWriteSessionConnectionProcessorFactory::IProcessor;
@@ -335,7 +335,7 @@ private:
     void InitWriter();
 
     void DoCdsRequest(TDuration delay = TDuration::Zero());
-    void OnCdsResponse(TStatus& status, const Ydb::PersQueue::ClusterDiscovery::DiscoverClustersResult& result);
+    void OnCdsResponse(TStatus& status, const NYdbProtos::PersQueue::ClusterDiscovery::DiscoverClustersResult& result);
     void OnConnect(TPlainStatus&& st, typename IProcessor::TPtr&& processor,
             const NYdbGrpc::IQueueClientContextPtr& connectContext);
     void OnConnectTimeout(const NYdbGrpc::IQueueClientContextPtr& connectTimeoutContext);
@@ -355,7 +355,7 @@ private:
     TMemoryUsageChange OnCompressedImpl(TBlock&& block);
 
     //std::string GetDebugIdentity() const;
-    Ydb::PersQueue::V1::StreamingWriteClientMessage GetInitClientMessage();
+    NYdbProtos::PersQueue::V1::StreamingWriteClientMessage GetInitClientMessage();
     bool CleanupOnAcknowledged(ui64 id);
     bool IsReadyToSendNextImpl();
     void DumpState();

--- a/ydb/public/sdk/cpp/src/client/persqueue_public/include/control_plane.h
+++ b/ydb/public/sdk/cpp/src/client/persqueue_public/include/control_plane.h
@@ -5,6 +5,7 @@
 #include <ydb-cpp-sdk/client/topic/codecs.h>
 #include <ydb-cpp-sdk/client/types/fluent_settings_helpers.h>
 #include <ydb-cpp-sdk/client/types/request_settings.h>
+#include <ydb-cpp-sdk/type_switcher.h>
 
 #include <ydb/public/api/grpc/draft/ydb_persqueue_v1.grpc.pb.h>
 

--- a/ydb/public/sdk/cpp/src/client/persqueue_public/include/control_plane.h
+++ b/ydb/public/sdk/cpp/src/client/persqueue_public/include/control_plane.h
@@ -29,7 +29,7 @@ struct TCredentials {
     };
 
     TCredentials() = default;
-    TCredentials(const Ydb::PersQueue::V1::Credentials& credentials);
+    TCredentials(const NYdbProtos::PersQueue::V1::Credentials& credentials);
     EMode GetMode() const;
     std::string GetOauthToken() const;
     std::string GetJwtParams() const;
@@ -39,7 +39,7 @@ struct TCredentials {
 
 private:
     EMode Mode_;
-    Ydb::PersQueue::V1::Credentials Credentials_;
+    NYdbProtos::PersQueue::V1::Credentials Credentials_;
 };
 
 
@@ -48,12 +48,12 @@ struct TDescribeTopicResult : public TStatus {
     friend class NYdb::V3::TProtoAccessor;
 
     struct TTopicSettings {
-        TTopicSettings(const Ydb::PersQueue::V1::TopicSettings&);
+        TTopicSettings(const NYdbProtos::PersQueue::V1::TopicSettings&);
 
         #define GETTER(TYPE, NAME) TYPE NAME() const { return NAME##_; }
 
         struct TReadRule {
-            TReadRule(const Ydb::PersQueue::V1::TopicSettings::ReadRule&);
+            TReadRule(const NYdbProtos::PersQueue::V1::TopicSettings::ReadRule&);
 
             GETTER(std::string, ConsumerName);
             GETTER(bool, Important);
@@ -76,7 +76,7 @@ struct TDescribeTopicResult : public TStatus {
         };
 
         struct TRemoteMirrorRule {
-            TRemoteMirrorRule(const Ydb::PersQueue::V1::TopicSettings::RemoteMirrorRule&);
+            TRemoteMirrorRule(const NYdbProtos::PersQueue::V1::TopicSettings::RemoteMirrorRule&);
             GETTER(std::string, Endpoint);
             GETTER(std::string, TopicPath);
             GETTER(std::string, ConsumerName);
@@ -121,7 +121,7 @@ struct TDescribeTopicResult : public TStatus {
         GETTER(std::optional<TDuration>, StabilizationWindow);
         GETTER(std::optional<uint64_t>, UpUtilizationPercent);
         GETTER(std::optional<uint64_t>, DownUtilizationPercent);
-        GETTER(std::optional<Ydb::PersQueue::V1::AutoPartitioningStrategy>, AutoPartitioningStrategy);
+        GETTER(std::optional<NYdbProtos::PersQueue::V1::AutoPartitioningStrategy>, AutoPartitioningStrategy);
 
 
 #undef GETTER
@@ -149,10 +149,10 @@ struct TDescribeTopicResult : public TStatus {
         std::optional<TDuration> StabilizationWindow_;
         std::optional<uint64_t> UpUtilizationPercent_;
         std::optional<uint64_t> DownUtilizationPercent_;
-        std::optional<Ydb::PersQueue::V1::AutoPartitioningStrategy> AutoPartitioningStrategy_;
+        std::optional<NYdbProtos::PersQueue::V1::AutoPartitioningStrategy> AutoPartitioningStrategy_;
     };
 
-    TDescribeTopicResult(TStatus status, const Ydb::PersQueue::V1::DescribeTopicResult& result);
+    TDescribeTopicResult(TStatus status, const NYdbProtos::PersQueue::V1::DescribeTopicResult& result);
 
     const TTopicSettings& TopicSettings() const {
         return TopicSettings_;
@@ -160,10 +160,10 @@ struct TDescribeTopicResult : public TStatus {
 
 private:
     TTopicSettings TopicSettings_;
-    [[nodiscard]] const Ydb::PersQueue::V1::DescribeTopicResult& GetProto() const {
+    [[nodiscard]] const NYdbProtos::PersQueue::V1::DescribeTopicResult& GetProto() const {
         return Proto_;
     }
-    const Ydb::PersQueue::V1::DescribeTopicResult Proto_;
+    const NYdbProtos::PersQueue::V1::DescribeTopicResult Proto_;
 };
 
 using TAsyncDescribeTopicResult = NThreading::TFuture<TDescribeTopicResult>;
@@ -294,7 +294,7 @@ private:
     std::optional<TDuration> StabilizationWindow_;
     std::optional<uint64_t> UpUtilizationPercent_;
     std::optional<uint64_t> DownUtilizationPercent_;
-    std::optional<Ydb::PersQueue::V1::AutoPartitioningStrategy> AutoPartitioningStrategy_;
+    std::optional<NYdbProtos::PersQueue::V1::AutoPartitioningStrategy> AutoPartitioningStrategy_;
 };
 
 

--- a/ydb/public/sdk/cpp/src/client/persqueue_public/ut/compression_ut.cpp
+++ b/ydb/public/sdk/cpp/src/client/persqueue_public/ut/compression_ut.cpp
@@ -25,38 +25,38 @@ Y_UNIT_TEST_SUITE(Compression) {
 
     void AlterTopic(TPersQueueYdbSdkTestSetup& setup) {
         std::shared_ptr<grpc::Channel> channel;
-        std::unique_ptr<Ydb::PersQueue::V1::PersQueueService::Stub> stub;
+        std::unique_ptr<NYdbProtos::PersQueue::V1::PersQueueService::Stub> stub;
 
         {
             channel = grpc::CreateChannel("localhost:" + ToString(setup.GetGrpcPort()), grpc::InsecureChannelCredentials());
-            stub = Ydb::PersQueue::V1::PersQueueService::NewStub(channel);
+            stub = NYdbProtos::PersQueue::V1::PersQueueService::NewStub(channel);
         }
 
-        Ydb::PersQueue::V1::AlterTopicRequest request;
+        NYdbProtos::PersQueue::V1::AlterTopicRequest request;
         request.set_path(TStringBuilder() << "/Root/PQ/rt3.dc1--" << setup.GetTestTopic());
         auto props = request.mutable_settings();
         props->set_partitions_count(1);
-        props->set_supported_format(Ydb::PersQueue::V1::TopicSettings::FORMAT_BASE);
+        props->set_supported_format(NYdbProtos::PersQueue::V1::TopicSettings::FORMAT_BASE);
         props->set_retention_period_ms(TDuration::Days(1).MilliSeconds());
-        props->add_supported_codecs(Ydb::PersQueue::V1::CODEC_RAW);
-        props->add_supported_codecs(Ydb::PersQueue::V1::CODEC_GZIP);
-        props->add_supported_codecs(Ydb::PersQueue::V1::CODEC_ZSTD);
+        props->add_supported_codecs(NYdbProtos::PersQueue::V1::CODEC_RAW);
+        props->add_supported_codecs(NYdbProtos::PersQueue::V1::CODEC_GZIP);
+        props->add_supported_codecs(NYdbProtos::PersQueue::V1::CODEC_ZSTD);
         auto rr = props->add_read_rules();
         rr->set_consumer_name(setup.GetTestConsumer());
-        rr->set_supported_format(Ydb::PersQueue::V1::TopicSettings::Format(1));
-        rr->add_supported_codecs(Ydb::PersQueue::V1::CODEC_RAW);
-        rr->add_supported_codecs(Ydb::PersQueue::V1::CODEC_GZIP);
-        rr->add_supported_codecs(Ydb::PersQueue::V1::CODEC_ZSTD);
+        rr->set_supported_format(NYdbProtos::PersQueue::V1::TopicSettings::Format(1));
+        rr->add_supported_codecs(NYdbProtos::PersQueue::V1::CODEC_RAW);
+        rr->add_supported_codecs(NYdbProtos::PersQueue::V1::CODEC_GZIP);
+        rr->add_supported_codecs(NYdbProtos::PersQueue::V1::CODEC_ZSTD);
         rr->set_version(1);
 
-        Ydb::PersQueue::V1::AlterTopicResponse response;
+        NYdbProtos::PersQueue::V1::AlterTopicResponse response;
         grpc::ClientContext rcontext;
         auto status = stub->AlterTopic(&rcontext, request, &response);
         UNIT_ASSERT(status.ok());
-        Ydb::PersQueue::V1::AlterTopicResult result;
+        NYdbProtos::PersQueue::V1::AlterTopicResult result;
         response.operation().result().UnpackTo(&result);
         Cerr << "Alter topic response: " << response << "\nAlter result: " << result << "\n";
-        UNIT_ASSERT_VALUES_EQUAL(response.operation().status(), Ydb::StatusIds::SUCCESS);
+        UNIT_ASSERT_VALUES_EQUAL(response.operation().status(), NYdbProtos::StatusIds::SUCCESS);
     }
 
     void Write(TPersQueueYdbSdkTestSetup& setup, const TVector<TString>& messages, ECodec codec) {

--- a/ydb/public/sdk/cpp/src/client/proto/accessor.cpp
+++ b/ydb/public/sdk/cpp/src/client/proto/accessor.cpp
@@ -4,11 +4,11 @@
 
 namespace NYdb::inline V3 {
 
-const Ydb::Type& TProtoAccessor::GetProto(const TType& type) {
+const NYdbProtos::Type& TProtoAccessor::GetProto(const TType& type) {
     return type.GetProto();
 }
 
-const Ydb::Value& TProtoAccessor::GetProto(const TValue& value) {
+const NYdbProtos::Value& TProtoAccessor::GetProto(const TValue& value) {
     return value.GetProto();
 }
 
@@ -23,16 +23,16 @@ typename TProtoSettings::Scheme TProtoAccessor::GetProto(ES3Scheme value) {
     }
 }
 
-const ::google::protobuf::Map<TStringType, Ydb::TypedValue>& TProtoAccessor::GetProtoMap(const TParams& params) {
+const ::google::protobuf::Map<TStringType, NYdbProtos::TypedValue>& TProtoAccessor::GetProtoMap(const TParams& params) {
     return params.GetProtoMap();
 }
 
-::google::protobuf::Map<TStringType, Ydb::TypedValue>* TProtoAccessor::GetProtoMapPtr(TParams& params) {
+::google::protobuf::Map<TStringType, NYdbProtos::TypedValue>* TProtoAccessor::GetProtoMapPtr(TParams& params) {
     return params.GetProtoMapPtr();
 }
 
-template Ydb::Export::ExportToS3Settings::Scheme TProtoAccessor::GetProto<Ydb::Export::ExportToS3Settings>(ES3Scheme value);
-template Ydb::Import::ImportFromS3Settings::Scheme TProtoAccessor::GetProto<Ydb::Import::ImportFromS3Settings>(ES3Scheme value);
+template NYdbProtos::Export::ExportToS3Settings::Scheme TProtoAccessor::GetProto<NYdbProtos::Export::ExportToS3Settings>(ES3Scheme value);
+template NYdbProtos::Import::ImportFromS3Settings::Scheme TProtoAccessor::GetProto<NYdbProtos::Import::ImportFromS3Settings>(ES3Scheme value);
 
 template <typename TProtoSettings>
 ES3Scheme TProtoAccessor::FromProto(typename TProtoSettings::Scheme value) {
@@ -44,91 +44,91 @@ ES3Scheme TProtoAccessor::FromProto(typename TProtoSettings::Scheme value) {
     }
 }
 
-template ES3Scheme TProtoAccessor::FromProto<Ydb::Export::ExportToS3Settings>(Ydb::Export::ExportToS3Settings::Scheme value);
-template ES3Scheme TProtoAccessor::FromProto<Ydb::Import::ImportFromS3Settings>(Ydb::Import::ImportFromS3Settings::Scheme value);
+template ES3Scheme TProtoAccessor::FromProto<NYdbProtos::Export::ExportToS3Settings>(NYdbProtos::Export::ExportToS3Settings::Scheme value);
+template ES3Scheme TProtoAccessor::FromProto<NYdbProtos::Import::ImportFromS3Settings>(NYdbProtos::Import::ImportFromS3Settings::Scheme value);
 
-Ydb::Export::ExportToS3Settings::StorageClass TProtoAccessor::GetProto(NExport::TExportToS3Settings::EStorageClass value) {
+NYdbProtos::Export::ExportToS3Settings::StorageClass TProtoAccessor::GetProto(NExport::TExportToS3Settings::EStorageClass value) {
     switch (value) {
     case NExport::TExportToS3Settings::EStorageClass::STANDARD:
-        return Ydb::Export::ExportToS3Settings::STANDARD;
+        return NYdbProtos::Export::ExportToS3Settings::STANDARD;
     case NExport::TExportToS3Settings::EStorageClass::REDUCED_REDUNDANCY:
-        return Ydb::Export::ExportToS3Settings::REDUCED_REDUNDANCY;
+        return NYdbProtos::Export::ExportToS3Settings::REDUCED_REDUNDANCY;
     case NExport::TExportToS3Settings::EStorageClass::STANDARD_IA:
-        return Ydb::Export::ExportToS3Settings::STANDARD_IA;
+        return NYdbProtos::Export::ExportToS3Settings::STANDARD_IA;
     case NExport::TExportToS3Settings::EStorageClass::ONEZONE_IA:
-        return Ydb::Export::ExportToS3Settings::ONEZONE_IA;
+        return NYdbProtos::Export::ExportToS3Settings::ONEZONE_IA;
     case NExport::TExportToS3Settings::EStorageClass::INTELLIGENT_TIERING:
-        return Ydb::Export::ExportToS3Settings::INTELLIGENT_TIERING;
+        return NYdbProtos::Export::ExportToS3Settings::INTELLIGENT_TIERING;
     case NExport::TExportToS3Settings::EStorageClass::GLACIER:
-        return Ydb::Export::ExportToS3Settings::GLACIER;
+        return NYdbProtos::Export::ExportToS3Settings::GLACIER;
     case NExport::TExportToS3Settings::EStorageClass::DEEP_ARCHIVE:
-        return Ydb::Export::ExportToS3Settings::DEEP_ARCHIVE;
+        return NYdbProtos::Export::ExportToS3Settings::DEEP_ARCHIVE;
     case NExport::TExportToS3Settings::EStorageClass::OUTPOSTS:
-        return Ydb::Export::ExportToS3Settings::OUTPOSTS;
+        return NYdbProtos::Export::ExportToS3Settings::OUTPOSTS;
     default:
-        return Ydb::Export::ExportToS3Settings::STORAGE_CLASS_UNSPECIFIED;
+        return NYdbProtos::Export::ExportToS3Settings::STORAGE_CLASS_UNSPECIFIED;
     }
 }
 
-NExport::TExportToS3Settings::EStorageClass TProtoAccessor::FromProto(Ydb::Export::ExportToS3Settings::StorageClass value) {
+NExport::TExportToS3Settings::EStorageClass TProtoAccessor::FromProto(NYdbProtos::Export::ExportToS3Settings::StorageClass value) {
     switch (value) {
-    case Ydb::Export::ExportToS3Settings::STORAGE_CLASS_UNSPECIFIED:
+    case NYdbProtos::Export::ExportToS3Settings::STORAGE_CLASS_UNSPECIFIED:
         return NExport::TExportToS3Settings::EStorageClass::NOT_SET;
-    case Ydb::Export::ExportToS3Settings::STANDARD:
+    case NYdbProtos::Export::ExportToS3Settings::STANDARD:
         return NExport::TExportToS3Settings::EStorageClass::STANDARD;
-    case Ydb::Export::ExportToS3Settings::REDUCED_REDUNDANCY:
+    case NYdbProtos::Export::ExportToS3Settings::REDUCED_REDUNDANCY:
         return NExport::TExportToS3Settings::EStorageClass::REDUCED_REDUNDANCY;
-    case Ydb::Export::ExportToS3Settings::STANDARD_IA:
+    case NYdbProtos::Export::ExportToS3Settings::STANDARD_IA:
         return NExport::TExportToS3Settings::EStorageClass::STANDARD_IA;
-    case Ydb::Export::ExportToS3Settings::ONEZONE_IA:
+    case NYdbProtos::Export::ExportToS3Settings::ONEZONE_IA:
         return NExport::TExportToS3Settings::EStorageClass::ONEZONE_IA;
-    case Ydb::Export::ExportToS3Settings::INTELLIGENT_TIERING:
+    case NYdbProtos::Export::ExportToS3Settings::INTELLIGENT_TIERING:
         return NExport::TExportToS3Settings::EStorageClass::INTELLIGENT_TIERING;
-    case Ydb::Export::ExportToS3Settings::GLACIER:
+    case NYdbProtos::Export::ExportToS3Settings::GLACIER:
         return NExport::TExportToS3Settings::EStorageClass::GLACIER;
-    case Ydb::Export::ExportToS3Settings::DEEP_ARCHIVE:
+    case NYdbProtos::Export::ExportToS3Settings::DEEP_ARCHIVE:
         return NExport::TExportToS3Settings::EStorageClass::DEEP_ARCHIVE;
-    case Ydb::Export::ExportToS3Settings::OUTPOSTS:
+    case NYdbProtos::Export::ExportToS3Settings::OUTPOSTS:
         return NExport::TExportToS3Settings::EStorageClass::OUTPOSTS;
     default:
         return NExport::TExportToS3Settings::EStorageClass::UNKNOWN;
     }
 }
 
-NExport::EExportProgress TProtoAccessor::FromProto(Ydb::Export::ExportProgress::Progress value) {
+NExport::EExportProgress TProtoAccessor::FromProto(NYdbProtos::Export::ExportProgress::Progress value) {
     switch (value) {
-    case Ydb::Export::ExportProgress::PROGRESS_UNSPECIFIED:
+    case NYdbProtos::Export::ExportProgress::PROGRESS_UNSPECIFIED:
         return NExport::EExportProgress::Unspecified;
-    case Ydb::Export::ExportProgress::PROGRESS_PREPARING:
+    case NYdbProtos::Export::ExportProgress::PROGRESS_PREPARING:
         return NExport::EExportProgress::Preparing;
-    case Ydb::Export::ExportProgress::PROGRESS_TRANSFER_DATA:
+    case NYdbProtos::Export::ExportProgress::PROGRESS_TRANSFER_DATA:
         return NExport::EExportProgress::TransferData;
-    case Ydb::Export::ExportProgress::PROGRESS_DONE:
+    case NYdbProtos::Export::ExportProgress::PROGRESS_DONE:
         return NExport::EExportProgress::Done;
-    case Ydb::Export::ExportProgress::PROGRESS_CANCELLATION:
+    case NYdbProtos::Export::ExportProgress::PROGRESS_CANCELLATION:
         return NExport::EExportProgress::Cancellation;
-    case Ydb::Export::ExportProgress::PROGRESS_CANCELLED:
+    case NYdbProtos::Export::ExportProgress::PROGRESS_CANCELLED:
         return NExport::EExportProgress::Cancelled;
     default:
         return NExport::EExportProgress::Unknown;
     }
 }
 
-NImport::EImportProgress TProtoAccessor::FromProto(Ydb::Import::ImportProgress::Progress value) {
+NImport::EImportProgress TProtoAccessor::FromProto(NYdbProtos::Import::ImportProgress::Progress value) {
     switch (value) {
-    case Ydb::Import::ImportProgress::PROGRESS_UNSPECIFIED:
+    case NYdbProtos::Import::ImportProgress::PROGRESS_UNSPECIFIED:
         return NImport::EImportProgress::Unspecified;
-    case Ydb::Import::ImportProgress::PROGRESS_PREPARING:
+    case NYdbProtos::Import::ImportProgress::PROGRESS_PREPARING:
         return NImport::EImportProgress::Preparing;
-    case Ydb::Import::ImportProgress::PROGRESS_TRANSFER_DATA:
+    case NYdbProtos::Import::ImportProgress::PROGRESS_TRANSFER_DATA:
         return NImport::EImportProgress::TransferData;
-    case Ydb::Import::ImportProgress::PROGRESS_BUILD_INDEXES:
+    case NYdbProtos::Import::ImportProgress::PROGRESS_BUILD_INDEXES:
         return NImport::EImportProgress::BuildIndexes;
-    case Ydb::Import::ImportProgress::PROGRESS_DONE:
+    case NYdbProtos::Import::ImportProgress::PROGRESS_DONE:
         return NImport::EImportProgress::Done;
-    case Ydb::Import::ImportProgress::PROGRESS_CANCELLATION:
+    case NYdbProtos::Import::ImportProgress::PROGRESS_CANCELLATION:
         return NImport::EImportProgress::Cancellation;
-    case Ydb::Import::ImportProgress::PROGRESS_CANCELLED:
+    case NYdbProtos::Import::ImportProgress::PROGRESS_CANCELLED:
         return NImport::EImportProgress::Cancelled;
     default:
         return NImport::EImportProgress::Unknown;

--- a/ydb/public/sdk/cpp/src/client/query/impl/client_session.cpp
+++ b/ydb/public/sdk/cpp/src/client/query/impl/client_session.cpp
@@ -73,7 +73,7 @@ public:
 void TSession::TImpl::StartAsyncRead(TStreamProcessorPtr ptr, std::weak_ptr<ISessionClient> client,
     std::shared_ptr<TSafeTSessionImplHolder> holder)
 {
-    auto resp = std::make_shared<Ydb::Query::SessionState>();
+    auto resp = std::make_shared<NYdbProtos::Query::SessionState>();
     ptr->Read(resp.get(), [resp, ptr, client, holder](NYdbGrpc::TGrpcStatus grpcStatus) mutable {
         switch (grpcStatus.GRpcStatusCode) {
             case grpc::StatusCode::OK:
@@ -116,14 +116,14 @@ TSession::TImpl::~TImpl()
 void TSession::TImpl::MakeImplAsync(TStreamProcessorPtr ptr,
     std::shared_ptr<TAttachSessionArgs> args)
 {
-    auto resp = std::make_shared<Ydb::Query::SessionState>();
+    auto resp = std::make_shared<NYdbProtos::Query::SessionState>();
     ptr->Read(resp.get(), [args, resp, ptr](NYdbGrpc::TGrpcStatus grpcStatus) mutable {
         if (grpcStatus.GRpcStatusCode != grpc::StatusCode::OK) {
             TStatus st(TPlainStatus(grpcStatus, args->Endpoint));
             args->Promise.SetValue(TCreateSessionResult(std::move(st), TSession(args->Client)));
 
         } else {
-            if (resp->status() == Ydb::StatusIds::SUCCESS) {
+            if (resp->status() == NYdbProtos::StatusIds::SUCCESS) {
                 NYdb::TStatus st(TPlainStatus(grpcStatus, args->Endpoint));
                 TSession::TImpl::NewSmartShared(ptr, std::move(args), st);
 

--- a/ydb/public/sdk/cpp/src/client/query/impl/client_session.h
+++ b/ydb/public/sdk/cpp/src/client/query/impl/client_session.h
@@ -30,7 +30,7 @@ public:
         std::weak_ptr<ISessionClient> SessionClient;
     };
 
-    using TResponse = Ydb::Query::SessionState;
+    using TResponse = NYdbProtos::Query::SessionState;
     using TStreamProcessorPtr = NYdbGrpc::IStreamRequestReadProcessor<TResponse>::TPtr;
     TImpl(TStreamProcessorPtr ptr, const std::string& id, const std::string& endpoint, std::weak_ptr<ISessionClient> client);
     ~TImpl();

--- a/ydb/public/sdk/cpp/src/client/query/query.cpp
+++ b/ydb/public/sdk/cpp/src/client/query/query.cpp
@@ -35,10 +35,10 @@ std::string_view StatsModeToString(const EStatsMode statsMode) {
     }
 }
 
-TScriptExecutionOperation::TScriptExecutionOperation(TStatus&& status, Ydb::Operations::Operation&& operation)
+TScriptExecutionOperation::TScriptExecutionOperation(TStatus&& status, NYdbProtos::Operations::Operation&& operation)
     : TOperation(std::move(status), std::move(operation))
 {
-    Ydb::Query::ExecuteScriptMetadata metadata;
+    NYdbProtos::Query::ExecuteScriptMetadata metadata;
     GetProto().metadata().UnpackTo(&metadata);
 
     Metadata_.ExecutionId = metadata.execution_id();

--- a/ydb/public/sdk/cpp/src/client/query/stats.cpp
+++ b/ydb/public/sdk/cpp/src/client/query/stats.cpp
@@ -12,15 +12,15 @@ namespace NYdb::inline V3::NQuery {
 
 class TExecStats::TImpl {
 public:
-    Ydb::TableStats::QueryStats Proto;
+    NYdbProtos::TableStats::QueryStats Proto;
 };
 
-TExecStats::TExecStats(const Ydb::TableStats::QueryStats& proto) {
+TExecStats::TExecStats(const NYdbProtos::TableStats::QueryStats& proto) {
     Impl_ = std::make_shared<TImpl>();
     Impl_->Proto = proto;
 }
 
-TExecStats::TExecStats(Ydb::TableStats::QueryStats&& proto) {
+TExecStats::TExecStats(NYdbProtos::TableStats::QueryStats&& proto) {
     Impl_ = std::make_shared<TImpl>();
     Impl_->Proto = std::move(proto);
 }
@@ -77,7 +77,7 @@ TDuration TExecStats::GetTotalCpuTime() const {
     return TDuration::MicroSeconds(Impl_->Proto.total_cpu_time_us());
 }
 
-const Ydb::TableStats::QueryStats& TExecStats::GetProto() const {
+const NYdbProtos::TableStats::QueryStats& TExecStats::GetProto() const {
     return Impl_->Proto;
 }
 

--- a/ydb/public/sdk/cpp/src/client/rate_limiter/rate_limiter.cpp
+++ b/ydb/public/sdk/cpp/src/client/rate_limiter/rate_limiter.cpp
@@ -11,13 +11,13 @@
 
 namespace NYdb::inline V3::NRateLimiter {
 
-TReplicatedBucketSettings::TReplicatedBucketSettings(const Ydb::RateLimiter::ReplicatedBucketSettings& proto) {
+TReplicatedBucketSettings::TReplicatedBucketSettings(const NYdbProtos::RateLimiter::ReplicatedBucketSettings& proto) {
     if (proto.has_report_interval_ms()) {
         ReportInterval_ = std::chrono::milliseconds(proto.report_interval_ms());
     }
 }
 
-void TReplicatedBucketSettings::SerializeTo(Ydb::RateLimiter::ReplicatedBucketSettings& proto) const {
+void TReplicatedBucketSettings::SerializeTo(NYdbProtos::RateLimiter::ReplicatedBucketSettings& proto) const {
     if (ReportInterval_) {
         proto.set_report_interval_ms(ReportInterval_->count());
     }
@@ -32,7 +32,7 @@ TLeafBehavior::TLeafBehavior(const TReplicatedBucketSettings& replicatedBucket)
 {
 }
 
-TLeafBehavior::TLeafBehavior(const Ydb::RateLimiter::ReplicatedBucketSettings& replicatedBucket)
+TLeafBehavior::TLeafBehavior(const NYdbProtos::RateLimiter::ReplicatedBucketSettings& replicatedBucket)
     : BehaviorSettings_(replicatedBucket)
 {
 }
@@ -41,7 +41,7 @@ const TReplicatedBucketSettings& TLeafBehavior::GetReplicatedBucket() const {
     return std::get<TReplicatedBucketSettings>(BehaviorSettings_);
 }
 
-void TLeafBehavior::SerializeTo(Ydb::RateLimiter::HierarchicalDrrSettings& proto) const {
+void TLeafBehavior::SerializeTo(NYdbProtos::RateLimiter::HierarchicalDrrSettings& proto) const {
     switch (GetBehavior()) {
         case REPLICATED_BUCKET:
             return GetReplicatedBucket().SerializeTo(*proto.mutable_replicated_bucket());
@@ -49,7 +49,7 @@ void TLeafBehavior::SerializeTo(Ydb::RateLimiter::HierarchicalDrrSettings& proto
 }
 
 template <class TDerived>
-THierarchicalDrrSettings<TDerived>::THierarchicalDrrSettings(const Ydb::RateLimiter::HierarchicalDrrSettings& proto) {
+THierarchicalDrrSettings<TDerived>::THierarchicalDrrSettings(const NYdbProtos::RateLimiter::HierarchicalDrrSettings& proto) {
     if (proto.max_units_per_second()) {
         MaxUnitsPerSecond_ = proto.max_units_per_second();
     }
@@ -71,16 +71,16 @@ THierarchicalDrrSettings<TDerived>::THierarchicalDrrSettings(const Ydb::RateLimi
     }
 
     switch (proto.leaf_behavior_case()) {
-        case Ydb::RateLimiter::HierarchicalDrrSettings::kReplicatedBucket:
+        case NYdbProtos::RateLimiter::HierarchicalDrrSettings::kReplicatedBucket:
             LeafBehavior_.emplace(proto.replicated_bucket());
             break;
-        case Ydb::RateLimiter::HierarchicalDrrSettings::LEAF_BEHAVIOR_NOT_SET:
+        case NYdbProtos::RateLimiter::HierarchicalDrrSettings::LEAF_BEHAVIOR_NOT_SET:
             break;
     }
 }
 
 template <class TDerived>
-void THierarchicalDrrSettings<TDerived>::SerializeTo(Ydb::RateLimiter::HierarchicalDrrSettings& proto) const {
+void THierarchicalDrrSettings<TDerived>::SerializeTo(NYdbProtos::RateLimiter::HierarchicalDrrSettings& proto) const {
     if (MaxUnitsPerSecond_) {
         proto.set_max_units_per_second(*MaxUnitsPerSecond_);
     }
@@ -106,7 +106,7 @@ void THierarchicalDrrSettings<TDerived>::SerializeTo(Ydb::RateLimiter::Hierarchi
     }
 }
 
-TMetric::TMetric(const Ydb::RateLimiter::MeteringConfig_Metric& proto) {
+TMetric::TMetric(const NYdbProtos::RateLimiter::MeteringConfig_Metric& proto) {
     Enabled_ = proto.enabled();
     if (proto.billing_period_sec()) {
         BillingPeriod_ = std::chrono::seconds(proto.billing_period_sec());
@@ -122,7 +122,7 @@ TMetric::TMetric(const Ydb::RateLimiter::MeteringConfig_Metric& proto) {
     }
 }
 
-void TMetric::SerializeTo(Ydb::RateLimiter::MeteringConfig_Metric& proto) const {
+void TMetric::SerializeTo(NYdbProtos::RateLimiter::MeteringConfig_Metric& proto) const {
     proto.set_enabled(Enabled_);
     if (BillingPeriod_) {
         proto.set_billing_period_sec(BillingPeriod_->count());
@@ -135,7 +135,7 @@ void TMetric::SerializeTo(Ydb::RateLimiter::MeteringConfig_Metric& proto) const 
     }
 }
 
-TMeteringConfig::TMeteringConfig(const Ydb::RateLimiter::MeteringConfig& proto) {
+TMeteringConfig::TMeteringConfig(const NYdbProtos::RateLimiter::MeteringConfig& proto) {
     Enabled_ = proto.enabled();
     if (proto.report_period_ms()) {
         ReportPeriod_ = std::chrono::milliseconds(proto.report_period_ms());
@@ -166,7 +166,7 @@ TMeteringConfig::TMeteringConfig(const Ydb::RateLimiter::MeteringConfig& proto) 
     }
 }
 
-void TMeteringConfig::SerializeTo(Ydb::RateLimiter::MeteringConfig& proto) const {
+void TMeteringConfig::SerializeTo(NYdbProtos::RateLimiter::MeteringConfig& proto) const {
     proto.set_enabled(Enabled_);
     if (ReportPeriod_) {
         proto.set_report_period_ms(ReportPeriod_->count());
@@ -201,7 +201,7 @@ template struct THierarchicalDrrSettings<TCreateResourceSettings>;
 template struct THierarchicalDrrSettings<TAlterResourceSettings>;
 template struct THierarchicalDrrSettings<TDescribeResourceResult::THierarchicalDrrProps>;
 
-TCreateResourceSettings::TCreateResourceSettings(const Ydb::RateLimiter::CreateResourceRequest& proto)
+TCreateResourceSettings::TCreateResourceSettings(const NYdbProtos::RateLimiter::CreateResourceRequest& proto)
     : THierarchicalDrrSettings(proto.resource().hierarchical_drr())
 {
     if (proto.resource().has_metering_config()) {
@@ -215,7 +215,7 @@ TListResourcesResult::TListResourcesResult(TStatus status, std::vector<std::stri
 {
 }
 
-TDescribeResourceResult::TDescribeResourceResult(TStatus status, const Ydb::RateLimiter::DescribeResourceResult& result)
+TDescribeResourceResult::TDescribeResourceResult(TStatus status, const NYdbProtos::RateLimiter::DescribeResourceResult& result)
     : TStatus(std::move(status))
     , ResourcePath_(result.resource().resource_path())
     , HierarchicalDrrProps_(result.resource().hierarchical_drr())
@@ -225,7 +225,7 @@ TDescribeResourceResult::TDescribeResourceResult(TStatus status, const Ydb::Rate
     }
 }
 
-TDescribeResourceResult::THierarchicalDrrProps::THierarchicalDrrProps(const Ydb::RateLimiter::HierarchicalDrrSettings& settings)
+TDescribeResourceResult::THierarchicalDrrProps::THierarchicalDrrProps(const NYdbProtos::RateLimiter::HierarchicalDrrSettings& settings)
     : THierarchicalDrrSettings<THierarchicalDrrProps>(settings)
 {
 }
@@ -242,10 +242,10 @@ public:
         TRequest request = MakeOperationRequest<TRequest>(settings);
         request.set_coordination_node_path(TStringType{coordinationNodePath});
 
-        Ydb::RateLimiter::Resource& resource = *request.mutable_resource();
+        NYdbProtos::RateLimiter::Resource& resource = *request.mutable_resource();
         resource.set_resource_path(TStringType{resourcePath});
 
-        Ydb::RateLimiter::HierarchicalDrrSettings& hdrr = *resource.mutable_hierarchical_drr();
+        NYdbProtos::RateLimiter::HierarchicalDrrSettings& hdrr = *resource.mutable_hierarchical_drr();
         if (settings.MaxUnitsPerSecond_) {
             hdrr.set_max_units_per_second(*settings.MaxUnitsPerSecond_);
         }
@@ -272,36 +272,36 @@ public:
     }
 
     TAsyncStatus CreateResource(const std::string& coordinationNodePath, const std::string& resourcePath, const TCreateResourceSettings& settings) {
-        auto request = MakePropsCreateOrAlterRequest<Ydb::RateLimiter::CreateResourceRequest>(coordinationNodePath, resourcePath, settings);
+        auto request = MakePropsCreateOrAlterRequest<NYdbProtos::RateLimiter::CreateResourceRequest>(coordinationNodePath, resourcePath, settings);
 
-        return RunSimple<Ydb::RateLimiter::V1::RateLimiterService, Ydb::RateLimiter::CreateResourceRequest, Ydb::RateLimiter::CreateResourceResponse>(
+        return RunSimple<NYdbProtos::RateLimiter::V1::RateLimiterService, NYdbProtos::RateLimiter::CreateResourceRequest, NYdbProtos::RateLimiter::CreateResourceResponse>(
             std::move(request),
-            &Ydb::RateLimiter::V1::RateLimiterService::Stub::AsyncCreateResource,
+            &NYdbProtos::RateLimiter::V1::RateLimiterService::Stub::AsyncCreateResource,
             TRpcRequestSettings::Make(settings));
     }
 
     TAsyncStatus AlterResource(const std::string& coordinationNodePath, const std::string& resourcePath, const TAlterResourceSettings& settings) {
-        auto request = MakePropsCreateOrAlterRequest<Ydb::RateLimiter::AlterResourceRequest>(coordinationNodePath, resourcePath, settings);
+        auto request = MakePropsCreateOrAlterRequest<NYdbProtos::RateLimiter::AlterResourceRequest>(coordinationNodePath, resourcePath, settings);
 
-        return RunSimple<Ydb::RateLimiter::V1::RateLimiterService, Ydb::RateLimiter::AlterResourceRequest, Ydb::RateLimiter::AlterResourceResponse>(
+        return RunSimple<NYdbProtos::RateLimiter::V1::RateLimiterService, NYdbProtos::RateLimiter::AlterResourceRequest, NYdbProtos::RateLimiter::AlterResourceResponse>(
             std::move(request),
-            &Ydb::RateLimiter::V1::RateLimiterService::Stub::AsyncAlterResource,
+            &NYdbProtos::RateLimiter::V1::RateLimiterService::Stub::AsyncAlterResource,
             TRpcRequestSettings::Make(settings));
     }
 
     TAsyncStatus DropResource(const std::string& coordinationNodePath, const std::string& resourcePath, const TDropResourceSettings& settings) {
-        auto request = MakeOperationRequest<Ydb::RateLimiter::DropResourceRequest>(settings);
+        auto request = MakeOperationRequest<NYdbProtos::RateLimiter::DropResourceRequest>(settings);
         request.set_coordination_node_path(TStringType{coordinationNodePath});
         request.set_resource_path(TStringType{resourcePath});
 
-        return RunSimple<Ydb::RateLimiter::V1::RateLimiterService, Ydb::RateLimiter::DropResourceRequest, Ydb::RateLimiter::DropResourceResponse>(
+        return RunSimple<NYdbProtos::RateLimiter::V1::RateLimiterService, NYdbProtos::RateLimiter::DropResourceRequest, NYdbProtos::RateLimiter::DropResourceResponse>(
             std::move(request),
-            &Ydb::RateLimiter::V1::RateLimiterService::Stub::AsyncDropResource,
+            &NYdbProtos::RateLimiter::V1::RateLimiterService::Stub::AsyncDropResource,
             TRpcRequestSettings::Make(settings));
     }
 
     TAsyncListResourcesResult ListResources(const std::string& coordinationNodePath, const std::string& resourcePath, const TListResourcesSettings& settings) {
-        auto request = MakeOperationRequest<Ydb::RateLimiter::ListResourcesRequest>(settings);
+        auto request = MakeOperationRequest<NYdbProtos::RateLimiter::ListResourcesRequest>(settings);
         request.set_coordination_node_path(TStringType{coordinationNodePath});
         request.set_resource_path(TStringType{resourcePath});
         request.set_recursive(settings.Recursive_);
@@ -312,7 +312,7 @@ public:
             (google::protobuf::Any* any, TPlainStatus status) mutable {
                 std::vector<std::string> list;
                 if (any) {
-                    Ydb::RateLimiter::ListResourcesResult result;
+                    NYdbProtos::RateLimiter::ListResourcesResult result;
                     any->UnpackTo(&result);
                     list.reserve(result.resource_paths_size());
                     for (const std::string& path : result.resource_paths()) {
@@ -324,10 +324,10 @@ public:
                 promise.SetValue(std::move(val));
             };
 
-        Connections_->RunDeferred<Ydb::RateLimiter::V1::RateLimiterService, Ydb::RateLimiter::ListResourcesRequest, Ydb::RateLimiter::ListResourcesResponse>(
+        Connections_->RunDeferred<NYdbProtos::RateLimiter::V1::RateLimiterService, NYdbProtos::RateLimiter::ListResourcesRequest, NYdbProtos::RateLimiter::ListResourcesResponse>(
             std::move(request),
             extractor,
-            &Ydb::RateLimiter::V1::RateLimiterService::Stub::AsyncListResources,
+            &NYdbProtos::RateLimiter::V1::RateLimiterService::Stub::AsyncListResources,
             DbDriverState_,
             INITIAL_DEFERRED_CALL_DELAY,
             TRpcRequestSettings::Make(settings));
@@ -336,7 +336,7 @@ public:
     }
 
     TAsyncDescribeResourceResult DescribeResource(const std::string& coordinationNodePath, const std::string& resourcePath, const TDescribeResourceSettings& settings) {
-        auto request = MakeOperationRequest<Ydb::RateLimiter::DescribeResourceRequest>(settings);
+        auto request = MakeOperationRequest<NYdbProtos::RateLimiter::DescribeResourceRequest>(settings);
         request.set_coordination_node_path(TStringType{coordinationNodePath});
         request.set_resource_path(TStringType{resourcePath});
 
@@ -344,7 +344,7 @@ public:
 
         auto extractor = [promise]
             (google::protobuf::Any* any, TPlainStatus status) mutable {
-                Ydb::RateLimiter::DescribeResourceResult result;
+                NYdbProtos::RateLimiter::DescribeResourceResult result;
                 if (any) {
                     any->UnpackTo(&result);
                 }
@@ -353,10 +353,10 @@ public:
                 promise.SetValue(std::move(val));
             };
 
-        Connections_->RunDeferred<Ydb::RateLimiter::V1::RateLimiterService, Ydb::RateLimiter::DescribeResourceRequest, Ydb::RateLimiter::DescribeResourceResponse>(
+        Connections_->RunDeferred<NYdbProtos::RateLimiter::V1::RateLimiterService, NYdbProtos::RateLimiter::DescribeResourceRequest, NYdbProtos::RateLimiter::DescribeResourceResponse>(
             std::move(request),
             extractor,
-            &Ydb::RateLimiter::V1::RateLimiterService::Stub::AsyncDescribeResource,
+            &NYdbProtos::RateLimiter::V1::RateLimiterService::Stub::AsyncDescribeResource,
             DbDriverState_,
             INITIAL_DEFERRED_CALL_DELAY,
             TRpcRequestSettings::Make(settings));
@@ -365,7 +365,7 @@ public:
     }
 
     TAsyncStatus AcquireResource(const std::string& coordinationNodePath, const std::string& resourcePath, const TAcquireResourceSettings& settings) {
-        auto request = MakeOperationRequest<Ydb::RateLimiter::AcquireResourceRequest>(settings);
+        auto request = MakeOperationRequest<NYdbProtos::RateLimiter::AcquireResourceRequest>(settings);
         request.set_coordination_node_path(TStringType{coordinationNodePath});
         request.set_resource_path(TStringType{resourcePath});
 
@@ -375,9 +375,9 @@ public:
             request.set_required(settings.Amount_.value());
         }
 
-        return RunSimple<Ydb::RateLimiter::V1::RateLimiterService, Ydb::RateLimiter::AcquireResourceRequest, Ydb::RateLimiter::AcquireResourceResponse>(
+        return RunSimple<NYdbProtos::RateLimiter::V1::RateLimiterService, NYdbProtos::RateLimiter::AcquireResourceRequest, NYdbProtos::RateLimiter::AcquireResourceResponse>(
             std::move(request),
-            &Ydb::RateLimiter::V1::RateLimiterService::Stub::AsyncAcquireResource,
+            &NYdbProtos::RateLimiter::V1::RateLimiterService::Stub::AsyncAcquireResource,
             TRpcRequestSettings::Make(settings));
     }
 };

--- a/ydb/public/sdk/cpp/src/client/result/proto_accessor.cpp
+++ b/ydb/public/sdk/cpp/src/client/result/proto_accessor.cpp
@@ -4,7 +4,7 @@
 
 namespace NYdb::inline V3 {
 
-const Ydb::ResultSet& TProtoAccessor::GetProto(const TResultSet& resultSet) {
+const NYdbProtos::ResultSet& TProtoAccessor::GetProto(const TResultSet& resultSet) {
     return resultSet.GetProto();
 }
 

--- a/ydb/public/sdk/cpp/src/client/result/result.cpp
+++ b/ydb/public/sdk/cpp/src/client/result/result.cpp
@@ -36,13 +36,13 @@ bool operator!=(const TColumn& col1, const TColumn& col2) {
 
 class TResultSet::TImpl {
 public:
-    TImpl(const Ydb::ResultSet& proto)
+    TImpl(const NYdbProtos::ResultSet& proto)
         : ProtoResultSet_(proto)
     {
         Init();
     }
 
-    TImpl(Ydb::ResultSet&& proto)
+    TImpl(NYdbProtos::ResultSet&& proto)
         : ProtoResultSet_(std::move(proto))
     {
         Init();
@@ -56,16 +56,16 @@ public:
     }
 
 public:
-    const Ydb::ResultSet ProtoResultSet_;
+    const NYdbProtos::ResultSet ProtoResultSet_;
     std::vector<TColumn> ColumnsMeta_;
 };
 
 ////////////////////////////////////////////////////////////////////////////////
 
-TResultSet::TResultSet(const Ydb::ResultSet& proto)
+TResultSet::TResultSet(const NYdbProtos::ResultSet& proto)
     : Impl_(new TResultSet::TImpl(proto)) {}
 
-TResultSet::TResultSet(Ydb::ResultSet&& proto)
+TResultSet::TResultSet(NYdbProtos::ResultSet&& proto)
     : Impl_(new TResultSet::TImpl(std::move(proto))) {}
 
 size_t TResultSet::ColumnsCount() const {
@@ -84,7 +84,7 @@ const std::vector<TColumn>& TResultSet::GetColumnsMeta() const {
     return Impl_->ColumnsMeta_;
 }
 
-const Ydb::ResultSet& TResultSet::GetProto() const {
+const NYdbProtos::ResultSet& TResultSet::GetProto() const {
     return Impl_->ProtoResultSet_;
 }
 

--- a/ydb/public/sdk/cpp/src/client/scheme/scheme.cpp
+++ b/ydb/public/sdk/cpp/src/client/scheme/scheme.cpp
@@ -15,14 +15,14 @@ namespace NYdb::inline V3 {
 namespace NScheme {
 
 using namespace NThreading;
-using namespace Ydb::Scheme;
+using namespace NYdbProtos::Scheme;
 
-TPermissions::TPermissions(const ::Ydb::Scheme::Permissions& proto)
+TPermissions::TPermissions(const ::NYdbProtos::Scheme::Permissions& proto)
     : Subject(proto.subject())
     , PermissionNames(proto.permission_names().begin(), proto.permission_names().end())
 {}
 
-void TPermissions::SerializeTo(::Ydb::Scheme::Permissions& proto) const {
+void TPermissions::SerializeTo(::NYdbProtos::Scheme::Permissions& proto) const {
     proto.set_subject(TStringType{Subject});
     for (const auto& name : PermissionNames) {
         proto.add_permission_names(TStringType{name});
@@ -34,7 +34,7 @@ TVirtualTimestamp::TVirtualTimestamp(uint64_t planStep, uint64_t txId)
     , TxId(txId)
 {}
 
-TVirtualTimestamp::TVirtualTimestamp(const ::Ydb::VirtualTimestamp& proto)
+TVirtualTimestamp::TVirtualTimestamp(const ::NYdbProtos::VirtualTimestamp& proto)
     : TVirtualTimestamp(proto.plan_step(), proto.tx_id())
 {}
 
@@ -75,46 +75,46 @@ bool TVirtualTimestamp::operator!=(const TVirtualTimestamp& rhs) const {
     return !(*this == rhs);
 }
 
-static ESchemeEntryType ConvertProtoEntryType(::Ydb::Scheme::Entry::Type entry) {
+static ESchemeEntryType ConvertProtoEntryType(::NYdbProtos::Scheme::Entry::Type entry) {
     switch (entry) {
-    case ::Ydb::Scheme::Entry::DIRECTORY:
+    case ::NYdbProtos::Scheme::Entry::DIRECTORY:
         return ESchemeEntryType::Directory;
-    case ::Ydb::Scheme::Entry::TABLE:
+    case ::NYdbProtos::Scheme::Entry::TABLE:
         return ESchemeEntryType::Table;
-    case ::Ydb::Scheme::Entry::COLUMN_TABLE:
+    case ::NYdbProtos::Scheme::Entry::COLUMN_TABLE:
         return ESchemeEntryType::ColumnTable;
-    case ::Ydb::Scheme::Entry::PERS_QUEUE_GROUP:
+    case ::NYdbProtos::Scheme::Entry::PERS_QUEUE_GROUP:
         return ESchemeEntryType::PqGroup;
-    case ::Ydb::Scheme::Entry::DATABASE:
+    case ::NYdbProtos::Scheme::Entry::DATABASE:
         return ESchemeEntryType::SubDomain;
-    case ::Ydb::Scheme::Entry::RTMR_VOLUME:
+    case ::NYdbProtos::Scheme::Entry::RTMR_VOLUME:
         return ESchemeEntryType::RtmrVolume;
-    case ::Ydb::Scheme::Entry::BLOCK_STORE_VOLUME:
+    case ::NYdbProtos::Scheme::Entry::BLOCK_STORE_VOLUME:
         return ESchemeEntryType::BlockStoreVolume;
-    case ::Ydb::Scheme::Entry::COORDINATION_NODE:
+    case ::NYdbProtos::Scheme::Entry::COORDINATION_NODE:
         return ESchemeEntryType::CoordinationNode;
-    case ::Ydb::Scheme::Entry::SEQUENCE:
+    case ::NYdbProtos::Scheme::Entry::SEQUENCE:
         return ESchemeEntryType::Sequence;
-    case ::Ydb::Scheme::Entry::REPLICATION:
+    case ::NYdbProtos::Scheme::Entry::REPLICATION:
         return ESchemeEntryType::Replication;
-    case ::Ydb::Scheme::Entry::TOPIC:
+    case ::NYdbProtos::Scheme::Entry::TOPIC:
         return ESchemeEntryType::Topic;
-    case ::Ydb::Scheme::Entry::COLUMN_STORE:
+    case ::NYdbProtos::Scheme::Entry::COLUMN_STORE:
         return ESchemeEntryType::ColumnStore;
-    case ::Ydb::Scheme::Entry::EXTERNAL_TABLE:
+    case ::NYdbProtos::Scheme::Entry::EXTERNAL_TABLE:
         return ESchemeEntryType::ExternalTable;
-    case ::Ydb::Scheme::Entry::EXTERNAL_DATA_SOURCE:
+    case ::NYdbProtos::Scheme::Entry::EXTERNAL_DATA_SOURCE:
         return ESchemeEntryType::ExternalDataSource;
-    case ::Ydb::Scheme::Entry::VIEW:
+    case ::NYdbProtos::Scheme::Entry::VIEW:
         return ESchemeEntryType::View;
-    case ::Ydb::Scheme::Entry::RESOURCE_POOL:
+    case ::NYdbProtos::Scheme::Entry::RESOURCE_POOL:
         return ESchemeEntryType::ResourcePool;
     default:
         return ESchemeEntryType::Unknown;
     }
 }
 
-TSchemeEntry::TSchemeEntry(const ::Ydb::Scheme::Entry& proto)
+TSchemeEntry::TSchemeEntry(const ::NYdbProtos::Scheme::Entry& proto)
     : Name(proto.name())
     , Owner(proto.owner())
     , Type(ConvertProtoEntryType(proto.type()))
@@ -134,29 +134,29 @@ void TSchemeEntry::Out(IOutputStream& out) const {
         << " }";
 }
 
-void TSchemeEntry::SerializeTo(::Ydb::Scheme::ModifyPermissionsRequest& request) const {
+void TSchemeEntry::SerializeTo(::NYdbProtos::Scheme::ModifyPermissionsRequest& request) const {
     request.mutable_actions()->Add()->set_change_owner(TStringType{Owner});
     for (const auto& permission : Permissions) {
         permission.SerializeTo(*request.mutable_actions()->Add()->mutable_grant());
     }
 }
 
-TModifyPermissionsSettings::TModifyPermissionsSettings(const ::Ydb::Scheme::ModifyPermissionsRequest& request) {
+TModifyPermissionsSettings::TModifyPermissionsSettings(const ::NYdbProtos::Scheme::ModifyPermissionsRequest& request) {
     for (const auto& action : request.actions()) {
         switch (action.action_case()) {
-            case Ydb::Scheme::PermissionsAction::kGrant:
+            case NYdbProtos::Scheme::PermissionsAction::kGrant:
                 AddGrantPermissions(action.grant());
                 break;
-            case Ydb::Scheme::PermissionsAction::kRevoke:
+            case NYdbProtos::Scheme::PermissionsAction::kRevoke:
                 AddRevokePermissions(action.revoke());
                 break;
-            case Ydb::Scheme::PermissionsAction::kSet:
+            case NYdbProtos::Scheme::PermissionsAction::kSet:
                 AddSetPermissions(action.set());
                 break;
-            case Ydb::Scheme::PermissionsAction::kChangeOwner:
+            case NYdbProtos::Scheme::PermissionsAction::kChangeOwner:
                 AddChangeOwner(action.change_owner());
                 break;
-            case Ydb::Scheme::PermissionsAction::ACTION_NOT_SET:
+            case NYdbProtos::Scheme::PermissionsAction::ACTION_NOT_SET:
                 break;
         }
     }
@@ -168,27 +168,27 @@ public:
         : TClientImplCommon(std::move(connections), settings) {}
 
     TAsyncStatus MakeDirectory(const std::string& path, const TMakeDirectorySettings& settings) {
-        auto request = MakeOperationRequest<Ydb::Scheme::MakeDirectoryRequest>(settings);
+        auto request = MakeOperationRequest<NYdbProtos::Scheme::MakeDirectoryRequest>(settings);
         request.set_path(TStringType{path});
 
-        return RunSimple<Ydb::Scheme::V1::SchemeService, MakeDirectoryRequest, MakeDirectoryResponse>(
+        return RunSimple<NYdbProtos::Scheme::V1::SchemeService, MakeDirectoryRequest, MakeDirectoryResponse>(
             std::move(request),
-            &Ydb::Scheme::V1::SchemeService::Stub::AsyncMakeDirectory,
+            &NYdbProtos::Scheme::V1::SchemeService::Stub::AsyncMakeDirectory,
             TRpcRequestSettings::Make(settings));
     }
 
     TAsyncStatus RemoveDirectory(const std::string& path, const TRemoveDirectorySettings& settings) {
-        auto request = MakeOperationRequest<Ydb::Scheme::RemoveDirectoryRequest>(settings);
+        auto request = MakeOperationRequest<NYdbProtos::Scheme::RemoveDirectoryRequest>(settings);
         request.set_path(TStringType{path});
 
-        return RunSimple<Ydb::Scheme::V1::SchemeService, RemoveDirectoryRequest, RemoveDirectoryResponse>(
+        return RunSimple<NYdbProtos::Scheme::V1::SchemeService, RemoveDirectoryRequest, RemoveDirectoryResponse>(
             std::move(request),
-            &Ydb::Scheme::V1::SchemeService::Stub::AsyncRemoveDirectory,
+            &NYdbProtos::Scheme::V1::SchemeService::Stub::AsyncRemoveDirectory,
             TRpcRequestSettings::Make(settings));
     }
 
     TAsyncDescribePathResult DescribePath(const std::string& path, const TDescribePathSettings& settings) {
-        auto request = MakeOperationRequest<Ydb::Scheme::DescribePathRequest>(settings);
+        auto request = MakeOperationRequest<NYdbProtos::Scheme::DescribePathRequest>(settings);
         request.set_path(TStringType{path});
 
         auto promise = NThreading::NewPromise<TDescribePathResult>();
@@ -203,10 +203,10 @@ public:
                 promise.SetValue(TDescribePathResult(TStatus(std::move(status)), result.self()));
             };
 
-        Connections_->RunDeferred<Ydb::Scheme::V1::SchemeService, DescribePathRequest, DescribePathResponse>(
+        Connections_->RunDeferred<NYdbProtos::Scheme::V1::SchemeService, DescribePathRequest, DescribePathResponse>(
             std::move(request),
             extractor,
-            &Ydb::Scheme::V1::SchemeService::Stub::AsyncDescribePath,
+            &NYdbProtos::Scheme::V1::SchemeService::Stub::AsyncDescribePath,
             DbDriverState_,
             INITIAL_DEFERRED_CALL_DELAY,
             TRpcRequestSettings::Make(settings));
@@ -215,7 +215,7 @@ public:
     }
 
     TAsyncListDirectoryResult ListDirectory(const std::string& path, const TListDirectorySettings& settings) {
-        auto request = MakeOperationRequest<Ydb::Scheme::ListDirectoryRequest>(settings);
+        auto request = MakeOperationRequest<NYdbProtos::Scheme::ListDirectoryRequest>(settings);
         request.set_path(TStringType{path});
 
         auto promise = NThreading::NewPromise<TListDirectoryResult>();
@@ -236,10 +236,10 @@ public:
                 promise.SetValue(TListDirectoryResult(TStatus(std::move(status)), result.self(), std::move(children)));
             };
 
-        Connections_->RunDeferred<Ydb::Scheme::V1::SchemeService, ListDirectoryRequest, ListDirectoryResponse>(
+        Connections_->RunDeferred<NYdbProtos::Scheme::V1::SchemeService, ListDirectoryRequest, ListDirectoryResponse>(
             std::move(request),
             extractor,
-            &Ydb::Scheme::V1::SchemeService::Stub::AsyncListDirectory,
+            &NYdbProtos::Scheme::V1::SchemeService::Stub::AsyncListDirectory,
             DbDriverState_,
             INITIAL_DEFERRED_CALL_DELAY,
             TRpcRequestSettings::Make(settings));
@@ -255,7 +255,7 @@ public:
     }
 
     TAsyncStatus ModifyPermissions(const std::string& path, const TModifyPermissionsSettings& settings) {
-        auto request = MakeOperationRequest<Ydb::Scheme::ModifyPermissionsRequest>(settings);
+        auto request = MakeOperationRequest<NYdbProtos::Scheme::ModifyPermissionsRequest>(settings);
         request.set_path(TStringType{path});
         if (settings.ClearAcl_) {
             request.set_clear_permissions(true);
@@ -286,9 +286,9 @@ public:
             }
         }
 
-        return RunSimple<Ydb::Scheme::V1::SchemeService, ModifyPermissionsRequest, ModifyPermissionsResponse>(
+        return RunSimple<NYdbProtos::Scheme::V1::SchemeService, ModifyPermissionsRequest, ModifyPermissionsResponse>(
             std::move(request),
-            &Ydb::Scheme::V1::SchemeService::Stub::AsyncModifyPermissions,
+            &NYdbProtos::Scheme::V1::SchemeService::Stub::AsyncModifyPermissions,
             TRpcRequestSettings::Make(settings));
     }
 

--- a/ydb/public/sdk/cpp/src/client/ss_tasks/task.cpp
+++ b/ydb/public/sdk/cpp/src/client/ss_tasks/task.cpp
@@ -9,7 +9,7 @@ namespace NYdb::inline V3 {
 namespace NSchemeShard {
 
 /// YT
-TBackgroundProcessesResponse::TBackgroundProcessesResponse(TStatus&& status, Ydb::Operations::Operation&& operation)
+TBackgroundProcessesResponse::TBackgroundProcessesResponse(TStatus&& status, NYdbProtos::Operations::Operation&& operation)
     : TOperation(std::move(status), std::move(operation))
 {
     Metadata_.Id = GetProto().DebugString();

--- a/ydb/public/sdk/cpp/src/client/ss_tasks/task.h
+++ b/ydb/public/sdk/cpp/src/client/ss_tasks/task.h
@@ -18,7 +18,7 @@ public:
 
 public:
     using TOperation::TOperation;
-    TBackgroundProcessesResponse(TStatus&& status, Ydb::Operations::Operation&& operation);
+    TBackgroundProcessesResponse(TStatus&& status, NYdbProtos::Operations::Operation&& operation);
 
     const TMetadata& Metadata() const;
 

--- a/ydb/public/sdk/cpp/src/client/table/impl/client_session.h
+++ b/ydb/public/sdk/cpp/src/client/table/impl/client_session.h
@@ -31,12 +31,12 @@ public:
 public:
     struct TDataQueryInfo {
         std::string QueryId;
-        ::google::protobuf::Map<TStringType, Ydb::Type> ParameterTypes;
+        ::google::protobuf::Map<TStringType, NYdbProtos::Type> ParameterTypes;
 
         TDataQueryInfo() {}
 
         TDataQueryInfo(const std::string& queryId,
-            const ::google::protobuf::Map<TStringType, Ydb::Type>& parameterTypes)
+            const ::google::protobuf::Map<TStringType, NYdbProtos::Type>& parameterTypes)
             : QueryId(queryId)
             , ParameterTypes(parameterTypes) {}
     };

--- a/ydb/public/sdk/cpp/src/client/table/impl/data_query.cpp
+++ b/ydb/public/sdk/cpp/src/client/table/impl/data_query.cpp
@@ -33,7 +33,7 @@ TDataQuery::TImpl::TImpl(const TSession& session, const std::string& text, bool 
 {}
 
 TDataQuery::TImpl::TImpl(const TSession& session, const std::string& text, bool keepText, const std::string& id, bool allowMigration,
-    const ::google::protobuf::Map<TStringType, Ydb::Type>& types)
+    const ::google::protobuf::Map<TStringType, NYdbProtos::Type>& types)
     : Session_(session)
     , Id_(id)
     , ParameterTypes_(types)
@@ -45,7 +45,7 @@ const std::string& TDataQuery::TImpl::GetId() const {
     return Id_;
 }
 
-const ::google::protobuf::Map<TStringType, Ydb::Type>& TDataQuery::TImpl::GetParameterTypes() const {
+const ::google::protobuf::Map<TStringType, NYdbProtos::Type>& TDataQuery::TImpl::GetParameterTypes() const {
     return ParameterTypes_;
 }
 

--- a/ydb/public/sdk/cpp/src/client/table/impl/data_query.h
+++ b/ydb/public/sdk/cpp/src/client/table/impl/data_query.h
@@ -21,17 +21,17 @@ public:
     TImpl(const TSession& session, const std::string& text, bool keepText, const std::string& id, bool allowMigration);
 
     TImpl(const TSession& session, const std::string& text, bool keepText, const std::string& id, bool allowMigration,
-        const ::google::protobuf::Map<TStringType, Ydb::Type>& types);
+        const ::google::protobuf::Map<TStringType, NYdbProtos::Type>& types);
 
     const std::string& GetId() const;
-    const ::google::protobuf::Map<TStringType, Ydb::Type>& GetParameterTypes() const;
+    const ::google::protobuf::Map<TStringType, NYdbProtos::Type>& GetParameterTypes() const;
     const std::string& GetTextHash() const;
     const std::optional<std::string>& GetText() const;
 
 private:
     NTable::TSession Session_;
     std::string Id_;
-    ::google::protobuf::Map<TStringType, Ydb::Type> ParameterTypes_;
+    ::google::protobuf::Map<TStringType, NYdbProtos::Type> ParameterTypes_;
     std::string TextHash_;
     std::optional<std::string> Text_;
 };

--- a/ydb/public/sdk/cpp/src/client/table/impl/readers.h
+++ b/ydb/public/sdk/cpp/src/client/table/impl/readers.h
@@ -21,7 +21,7 @@ using namespace NThreading;
 class TTablePartIterator::TReaderImpl {
 public:
     using TSelf = TTablePartIterator::TReaderImpl;
-    using TResponse = Ydb::Table::ReadTableResponse;
+    using TResponse = NYdbProtos::Table::ReadTableResponse;
     using TStreamProcessorPtr = NYdbGrpc::IStreamRequestReadProcessor<TResponse>::TPtr;
     using TReadCallback = NYdbGrpc::IStreamRequestReadProcessor<TResponse>::TReadCallback;
     using TGRpcStatus = NYdbGrpc::TGrpcStatus;
@@ -43,7 +43,7 @@ private:
 class TScanQueryPartIterator::TReaderImpl {
 public:
     using TSelf = TScanQueryPartIterator::TReaderImpl;
-    using TResponse = Ydb::Table::ExecuteScanQueryPartialResponse;
+    using TResponse = NYdbProtos::Table::ExecuteScanQueryPartialResponse;
     using TStreamProcessorPtr = NYdbGrpc::IStreamRequestReadProcessor<TResponse>::TPtr;
     using TReadCallback = NYdbGrpc::IStreamRequestReadProcessor<TResponse>::TReadCallback;
     using TGRpcStatus = NYdbGrpc::TGrpcStatus;

--- a/ydb/public/sdk/cpp/src/client/table/impl/table_client.h
+++ b/ydb/public/sdk/cpp/src/client/table/impl/table_client.h
@@ -57,13 +57,13 @@ public:
         std::string preferredLocation = std::string());
     TAsyncKeepAliveResult KeepAlive(const TSession::TImpl* session, const TKeepAliveSettings& settings);
 
-    TFuture<TStatus> CreateTable(Ydb::Table::CreateTableRequest&& request, const TCreateTableSettings& settings);
-    TFuture<TStatus> AlterTable(Ydb::Table::AlterTableRequest&& request, const TAlterTableSettings& settings);
-    TAsyncOperation AlterTableLong(Ydb::Table::AlterTableRequest&& request, const TAlterTableSettings& settings);
+    TFuture<TStatus> CreateTable(NYdbProtos::Table::CreateTableRequest&& request, const TCreateTableSettings& settings);
+    TFuture<TStatus> AlterTable(NYdbProtos::Table::AlterTableRequest&& request, const TAlterTableSettings& settings);
+    TAsyncOperation AlterTableLong(NYdbProtos::Table::AlterTableRequest&& request, const TAlterTableSettings& settings);
     TFuture<TStatus> CopyTable(const std::string& sessionId, const std::string& src, const std::string& dst,
         const TCopyTableSettings& settings);
-    TFuture<TStatus> CopyTables(Ydb::Table::CopyTablesRequest&& request, const TCopyTablesSettings& settings);
-    TFuture<TStatus> RenameTables(Ydb::Table::RenameTablesRequest&& request, const TRenameTablesSettings& settings);
+    TFuture<TStatus> CopyTables(NYdbProtos::Table::CopyTablesRequest&& request, const TCopyTablesSettings& settings);
+    TFuture<TStatus> RenameTables(NYdbProtos::Table::RenameTablesRequest&& request, const TRenameTablesSettings& settings);
     TFuture<TStatus> DropTable(const std::string& sessionId, const std::string& path, const TDropTableSettings& settings);
     TAsyncDescribeTableResult DescribeTable(const std::string& sessionId, const std::string& path, const TDescribeTableSettings& settings);
     TAsyncDescribeExternalDataSourceResult DescribeExternalDataSource(const std::string& path, const TDescribeExternalDataSourceSettings& settings);
@@ -119,7 +119,7 @@ public:
     TAsyncExplainDataQueryResult ExplainDataQuery(const TSession& session, const std::string& query,
         const TExplainDataQuerySettings& settings);
 
-    static void SetTypedValue(Ydb::TypedValue* protoValue, const TValue& value);
+    static void SetTypedValue(NYdbProtos::TypedValue* protoValue, const TValue& value);
 
     NThreading::TFuture<std::pair<TPlainStatus, TReadTableStreamProcessorPtr>> ReadTable(
         const std::string& sessionId,
@@ -141,10 +141,10 @@ public:
         const std::string& data, const std::string& schema, const TBulkUpsertSettings& settings);
 
     TFuture<std::pair<TPlainStatus, TScanQueryProcessorPtr>> StreamExecuteScanQueryInternal(const std::string& query,
-        const ::google::protobuf::Map<TStringType, Ydb::TypedValue>* params,
+        const ::google::protobuf::Map<TStringType, NYdbProtos::TypedValue>* params,
         const TStreamExecScanQuerySettings& settings);
     TAsyncScanQueryPartIterator StreamExecuteScanQuery(const std::string& query,
-        const ::google::protobuf::Map<TStringType, Ydb::TypedValue>* params,
+        const ::google::protobuf::Map<TStringType, NYdbProtos::TypedValue>* params,
         const TStreamExecScanQuerySettings& settings);
     void CollectRetryStatAsync(EStatus status);
     void CollectRetryStatSync(EStatus status);
@@ -154,19 +154,19 @@ public:
 
 private:
     static void SetParams(
-        ::google::protobuf::Map<TStringType, Ydb::TypedValue>* params,
-        Ydb::Table::ExecuteDataQueryRequest* request);
+        ::google::protobuf::Map<TStringType, NYdbProtos::TypedValue>* params,
+        NYdbProtos::Table::ExecuteDataQueryRequest* request);
 
     static void SetParams(
-        const ::google::protobuf::Map<TStringType, Ydb::TypedValue>& params,
-        Ydb::Table::ExecuteDataQueryRequest* request);
+        const ::google::protobuf::Map<TStringType, NYdbProtos::TypedValue>& params,
+        NYdbProtos::Table::ExecuteDataQueryRequest* request);
 
     static void CollectParams(
-        ::google::protobuf::Map<TStringType, Ydb::TypedValue>* params,
+        ::google::protobuf::Map<TStringType, NYdbProtos::TypedValue>* params,
         NSdkStats::TAtomicHistogram<::NMonitoring::THistogram> histgoram);
 
     static void CollectParams(
-        const ::google::protobuf::Map<TStringType, Ydb::TypedValue>& params,
+        const ::google::protobuf::Map<TStringType, NYdbProtos::TypedValue>& params,
         NSdkStats::TAtomicHistogram<::NMonitoring::THistogram> histgoram);
 
     static void CollectQuerySize(const std::string& query, NSdkStats::TAtomicHistogram<::NMonitoring::THistogram>& querySizeHistogram);
@@ -204,7 +204,7 @@ private:
         const TTxControl& txControl, TParamsType params,
         const TExecDataQuerySettings& settings, bool fromCache
     ) {
-        auto request = MakeOperationRequest<Ydb::Table::ExecuteDataQueryRequest>(settings);
+        auto request = MakeOperationRequest<NYdbProtos::Table::ExecuteDataQueryRequest>(settings);
         request.set_session_id(TStringType{session.GetId()});
         auto txControlProto = request.mutable_tx_control();
         txControlProto->set_commit_tx(txControl.CommitTx_);
@@ -245,7 +245,7 @@ private:
 
                 auto queryText = GetQueryText(query);
                 if (any) {
-                    Ydb::Table::ExecuteQueryResult result;
+                    NYdbProtos::Table::ExecuteQueryResult result;
                     any->UnpackTo(&result);
 
                     for (size_t i = 0; i < static_cast<size_t>(result.result_sets_size()); i++) {
@@ -281,10 +281,10 @@ private:
                 promise.SetValue(std::move(dataQueryResult));
             };
 
-        Connections_->RunDeferred<Ydb::Table::V1::TableService, Ydb::Table::ExecuteDataQueryRequest, Ydb::Table::ExecuteDataQueryResponse>(
+        Connections_->RunDeferred<NYdbProtos::Table::V1::TableService, NYdbProtos::Table::ExecuteDataQueryRequest, NYdbProtos::Table::ExecuteDataQueryResponse>(
             std::move(request),
             extractor,
-            &Ydb::Table::V1::TableService::Stub::AsyncExecuteDataQuery,
+            &NYdbProtos::Table::V1::TableService::Stub::AsyncExecuteDataQuery,
             DbDriverState_,
             INITIAL_DEFERRED_CALL_DELAY,
             TRpcRequestSettings::Make(settings, session.SessionImpl_->GetEndpointKey())
@@ -293,17 +293,17 @@ private:
         return promise.GetFuture();
     }
 
-    static void SetTxSettings(const TTxSettings& txSettings, Ydb::Table::TransactionSettings* proto);
+    static void SetTxSettings(const TTxSettings& txSettings, NYdbProtos::Table::TransactionSettings* proto);
 
-    static void SetQuery(const std::string& queryText, Ydb::Table::Query* query);
+    static void SetQuery(const std::string& queryText, NYdbProtos::Table::Query* query);
 
-    static void SetQuery(const TDataQuery& queryData, Ydb::Table::Query* query);
+    static void SetQuery(const TDataQuery& queryData, NYdbProtos::Table::Query* query);
 
     static void SetQueryCachePolicy(const std::string&, const TExecDataQuerySettings& settings,
-        Ydb::Table::QueryCachePolicy* queryCachePolicy);
+        NYdbProtos::Table::QueryCachePolicy* queryCachePolicy);
 
     static void SetQueryCachePolicy(const TDataQuery&, const TExecDataQuerySettings& settings,
-        Ydb::Table::QueryCachePolicy* queryCachePolicy);
+        NYdbProtos::Table::QueryCachePolicy* queryCachePolicy);
 
     static std::optional<std::string> GetQueryText(const std::string& queryText);
 

--- a/ydb/public/sdk/cpp/src/client/table/proto_accessor.cpp
+++ b/ydb/public/sdk/cpp/src/client/table/proto_accessor.cpp
@@ -4,70 +4,70 @@
 
 namespace NYdb::inline V3 {
 
-const Ydb::TableStats::QueryStats& TProtoAccessor::GetProto(const NTable::TQueryStats& queryStats) {
+const NYdbProtos::TableStats::QueryStats& TProtoAccessor::GetProto(const NTable::TQueryStats& queryStats) {
     return queryStats.GetProto();
 }
 
-const Ydb::Table::DescribeTableResult& TProtoAccessor::GetProto(const NTable::TTableDescription& tableDescription) {
+const NYdbProtos::Table::DescribeTableResult& TProtoAccessor::GetProto(const NTable::TTableDescription& tableDescription) {
     return tableDescription.GetProto();
 }
 
-const Ydb::Table::DescribeExternalDataSourceResult& TProtoAccessor::GetProto(const NTable::TExternalDataSourceDescription& description) {
+const NYdbProtos::Table::DescribeExternalDataSourceResult& TProtoAccessor::GetProto(const NTable::TExternalDataSourceDescription& description) {
     return description.GetProto();
 }
 
-const Ydb::Table::DescribeExternalTableResult& TProtoAccessor::GetProto(const NTable::TExternalTableDescription& description) {
+const NYdbProtos::Table::DescribeExternalTableResult& TProtoAccessor::GetProto(const NTable::TExternalTableDescription& description) {
     return description.GetProto();
 }
 
-NTable::TQueryStats TProtoAccessor::FromProto(const Ydb::TableStats::QueryStats& queryStats) {
+NTable::TQueryStats TProtoAccessor::FromProto(const NYdbProtos::TableStats::QueryStats& queryStats) {
     return NTable::TQueryStats(queryStats);
 }
 
-NTable::TTableDescription TProtoAccessor::FromProto(const Ydb::Table::CreateTableRequest& request) {
+NTable::TTableDescription TProtoAccessor::FromProto(const NYdbProtos::Table::CreateTableRequest& request) {
     return NTable::TTableDescription(request);
 }
 
-NTable::TIndexDescription TProtoAccessor::FromProto(const Ydb::Table::TableIndex& tableIndex) {
+NTable::TIndexDescription TProtoAccessor::FromProto(const NYdbProtos::Table::TableIndex& tableIndex) {
     return NTable::TIndexDescription(tableIndex);
 }
 
-NTable::TIndexDescription TProtoAccessor::FromProto(const Ydb::Table::TableIndexDescription& tableIndexDesc) {
+NTable::TIndexDescription TProtoAccessor::FromProto(const NYdbProtos::Table::TableIndexDescription& tableIndexDesc) {
     return NTable::TIndexDescription(tableIndexDesc);
 }
 
-NTable::TChangefeedDescription TProtoAccessor::FromProto(const Ydb::Table::Changefeed& changefeed) {
+NTable::TChangefeedDescription TProtoAccessor::FromProto(const NYdbProtos::Table::Changefeed& changefeed) {
     return NTable::TChangefeedDescription(changefeed);
 }
 
-NTable::TChangefeedDescription TProtoAccessor::FromProto(const Ydb::Table::ChangefeedDescription& changefeed) {
+NTable::TChangefeedDescription TProtoAccessor::FromProto(const NYdbProtos::Table::ChangefeedDescription& changefeed) {
     return NTable::TChangefeedDescription(changefeed);
 }
 
-Ydb::Table::ValueSinceUnixEpochModeSettings::Unit TProtoAccessor::GetProto(NTable::TValueSinceUnixEpochModeSettings::EUnit value) {
+NYdbProtos::Table::ValueSinceUnixEpochModeSettings::Unit TProtoAccessor::GetProto(NTable::TValueSinceUnixEpochModeSettings::EUnit value) {
     switch (value) {
     case NTable::TValueSinceUnixEpochModeSettings::EUnit::Seconds:
-        return Ydb::Table::ValueSinceUnixEpochModeSettings::UNIT_SECONDS;
+        return NYdbProtos::Table::ValueSinceUnixEpochModeSettings::UNIT_SECONDS;
     case NTable::TValueSinceUnixEpochModeSettings::EUnit::MilliSeconds:
-        return Ydb::Table::ValueSinceUnixEpochModeSettings::UNIT_MILLISECONDS;
+        return NYdbProtos::Table::ValueSinceUnixEpochModeSettings::UNIT_MILLISECONDS;
     case NTable::TValueSinceUnixEpochModeSettings::EUnit::MicroSeconds:
-        return Ydb::Table::ValueSinceUnixEpochModeSettings::UNIT_MICROSECONDS;
+        return NYdbProtos::Table::ValueSinceUnixEpochModeSettings::UNIT_MICROSECONDS;
     case NTable::TValueSinceUnixEpochModeSettings::EUnit::NanoSeconds:
-        return Ydb::Table::ValueSinceUnixEpochModeSettings::UNIT_NANOSECONDS;
+        return NYdbProtos::Table::ValueSinceUnixEpochModeSettings::UNIT_NANOSECONDS;
     case NTable::TValueSinceUnixEpochModeSettings::EUnit::Unknown:
-        return Ydb::Table::ValueSinceUnixEpochModeSettings::UNIT_UNSPECIFIED;
+        return NYdbProtos::Table::ValueSinceUnixEpochModeSettings::UNIT_UNSPECIFIED;
     }
 }
 
-NTable::TValueSinceUnixEpochModeSettings::EUnit TProtoAccessor::FromProto(Ydb::Table::ValueSinceUnixEpochModeSettings::Unit value) {
+NTable::TValueSinceUnixEpochModeSettings::EUnit TProtoAccessor::FromProto(NYdbProtos::Table::ValueSinceUnixEpochModeSettings::Unit value) {
     switch (value) {
-    case Ydb::Table::ValueSinceUnixEpochModeSettings::UNIT_SECONDS:
+    case NYdbProtos::Table::ValueSinceUnixEpochModeSettings::UNIT_SECONDS:
         return NTable::TValueSinceUnixEpochModeSettings::EUnit::Seconds;
-    case Ydb::Table::ValueSinceUnixEpochModeSettings::UNIT_MILLISECONDS:
+    case NYdbProtos::Table::ValueSinceUnixEpochModeSettings::UNIT_MILLISECONDS:
         return NTable::TValueSinceUnixEpochModeSettings::EUnit::MilliSeconds;
-    case Ydb::Table::ValueSinceUnixEpochModeSettings::UNIT_MICROSECONDS:
+    case NYdbProtos::Table::ValueSinceUnixEpochModeSettings::UNIT_MICROSECONDS:
         return NTable::TValueSinceUnixEpochModeSettings::EUnit::MicroSeconds;
-    case Ydb::Table::ValueSinceUnixEpochModeSettings::UNIT_NANOSECONDS:
+    case NYdbProtos::Table::ValueSinceUnixEpochModeSettings::UNIT_NANOSECONDS:
         return NTable::TValueSinceUnixEpochModeSettings::EUnit::NanoSeconds;
     default:
         return NTable::TValueSinceUnixEpochModeSettings::EUnit::Unknown;

--- a/ydb/public/sdk/cpp/src/client/table/table.cpp
+++ b/ydb/public/sdk/cpp/src/client/table/table.cpp
@@ -47,23 +47,23 @@ class TStorageSettings::TImpl {
 public:
     TImpl() { }
 
-    explicit TImpl(const Ydb::Table::StorageSettings& proto)
+    explicit TImpl(const NYdbProtos::Table::StorageSettings& proto)
         : Proto_(proto)
     { }
 
 public:
-    const Ydb::Table::StorageSettings Proto_;
+    const NYdbProtos::Table::StorageSettings Proto_;
 };
 
 TStorageSettings::TStorageSettings()
     : Impl_(std::make_shared<TImpl>())
 { }
 
-TStorageSettings::TStorageSettings(const Ydb::Table::StorageSettings& proto)
+TStorageSettings::TStorageSettings(const NYdbProtos::Table::StorageSettings& proto)
     : Impl_(std::make_shared<TImpl>(proto))
 { }
 
-const Ydb::Table::StorageSettings& TStorageSettings::GetProto() const {
+const NYdbProtos::Table::StorageSettings& TStorageSettings::GetProto() const {
     return Impl_->Proto_;
 }
 
@@ -93,9 +93,9 @@ std::optional<std::string> TStorageSettings::GetExternal() const {
 
 std::optional<bool> TStorageSettings::GetStoreExternalBlobs() const {
     switch (GetProto().store_external_blobs()) {
-        case Ydb::FeatureFlag::ENABLED:
+        case NYdbProtos::FeatureFlag::ENABLED:
             return true;
-        case Ydb::FeatureFlag::DISABLED:
+        case NYdbProtos::FeatureFlag::DISABLED:
             return false;
         default:
             return { };
@@ -106,19 +106,19 @@ std::optional<bool> TStorageSettings::GetStoreExternalBlobs() const {
 
 class TColumnFamilyDescription::TImpl {
 public:
-    explicit TImpl(const Ydb::Table::ColumnFamily& desc)
+    explicit TImpl(const NYdbProtos::Table::ColumnFamily& desc)
         : Proto_(desc)
     { }
 
 public:
-    const Ydb::Table::ColumnFamily Proto_;
+    const NYdbProtos::Table::ColumnFamily Proto_;
 };
 
-TColumnFamilyDescription::TColumnFamilyDescription(const Ydb::Table::ColumnFamily& desc)
+TColumnFamilyDescription::TColumnFamilyDescription(const NYdbProtos::Table::ColumnFamily& desc)
     : Impl_(std::make_shared<TImpl>(desc))
 { }
 
-const Ydb::Table::ColumnFamily& TColumnFamilyDescription::GetProto() const {
+const NYdbProtos::Table::ColumnFamily& TColumnFamilyDescription::GetProto() const {
     return Impl_->Proto_;
 }
 
@@ -136,9 +136,9 @@ std::optional<std::string> TColumnFamilyDescription::GetData() const {
 
 std::optional<EColumnFamilyCompression> TColumnFamilyDescription::GetCompression() const {
     switch (GetProto().compression()) {
-        case Ydb::Table::ColumnFamily::COMPRESSION_NONE:
+        case NYdbProtos::Table::ColumnFamily::COMPRESSION_NONE:
             return EColumnFamilyCompression::None;
-        case Ydb::Table::ColumnFamily::COMPRESSION_LZ4:
+        case NYdbProtos::Table::ColumnFamily::COMPRESSION_LZ4:
             return EColumnFamilyCompression::LZ4;
         default:
             return { };
@@ -147,19 +147,19 @@ std::optional<EColumnFamilyCompression> TColumnFamilyDescription::GetCompression
 
 std::optional<bool> TColumnFamilyDescription::GetKeepInMemory() const {
     switch (GetProto().keep_in_memory()) {
-        case Ydb::FeatureFlag::ENABLED:
+        case NYdbProtos::FeatureFlag::ENABLED:
             return true;
-        case Ydb::FeatureFlag::DISABLED:
+        case NYdbProtos::FeatureFlag::DISABLED:
             return false;
         default:
             return { };
     }
 }
 
-TBuildIndexOperation::TBuildIndexOperation(TStatus &&status, Ydb::Operations::Operation &&operation)
+TBuildIndexOperation::TBuildIndexOperation(TStatus &&status, NYdbProtos::Operations::Operation &&operation)
     : TOperation(std::move(status), std::move(operation))
 {
-    Ydb::Table::IndexBuildMetadata metadata;
+    NYdbProtos::Table::IndexBuildMetadata metadata;
     GetProto().metadata().UnpackTo(&metadata);
     Metadata_.State = static_cast<EBuildIndexState>(metadata.state());
     Metadata_.Progress = metadata.progress();
@@ -178,31 +178,31 @@ class TPartitioningSettings::TImpl {
 public:
     TImpl() { }
 
-    explicit TImpl(const Ydb::Table::PartitioningSettings& proto)
+    explicit TImpl(const NYdbProtos::Table::PartitioningSettings& proto)
         : Proto_(proto)
     { }
 
 public:
-    const Ydb::Table::PartitioningSettings Proto_;
+    const NYdbProtos::Table::PartitioningSettings Proto_;
 };
 
 TPartitioningSettings::TPartitioningSettings()
     : Impl_(std::make_shared<TImpl>())
 { }
 
-TPartitioningSettings::TPartitioningSettings(const Ydb::Table::PartitioningSettings& proto)
+TPartitioningSettings::TPartitioningSettings(const NYdbProtos::Table::PartitioningSettings& proto)
     : Impl_(std::make_shared<TImpl>(proto))
 { }
 
-const Ydb::Table::PartitioningSettings& TPartitioningSettings::GetProto() const {
+const NYdbProtos::Table::PartitioningSettings& TPartitioningSettings::GetProto() const {
     return Impl_->Proto_;
 }
 
 std::optional<bool> TPartitioningSettings::GetPartitioningBySize() const {
     switch (GetProto().partitioning_by_size()) {
-    case Ydb::FeatureFlag::ENABLED:
+    case NYdbProtos::FeatureFlag::ENABLED:
         return true;
-    case Ydb::FeatureFlag::DISABLED:
+    case NYdbProtos::FeatureFlag::DISABLED:
         return false;
     default:
         return { };
@@ -211,9 +211,9 @@ std::optional<bool> TPartitioningSettings::GetPartitioningBySize() const {
 
 std::optional<bool> TPartitioningSettings::GetPartitioningByLoad() const {
     switch (GetProto().partitioning_by_load()) {
-    case Ydb::FeatureFlag::ENABLED:
+    case NYdbProtos::FeatureFlag::ENABLED:
         return true;
-    case Ydb::FeatureFlag::DISABLED:
+    case NYdbProtos::FeatureFlag::DISABLED:
         return false;
     default:
         return { };
@@ -248,13 +248,13 @@ static TInstant ProtobufTimestampToTInstant(const google::protobuf::Timestamp& t
     return TInstant::MicroSeconds(lastModificationUs);
 }
 
-static void SerializeTo(const TRenameIndex& rename, Ydb::Table::RenameIndexItem& proto) {
+static void SerializeTo(const TRenameIndex& rename, NYdbProtos::Table::RenameIndexItem& proto) {
     proto.set_source_name(TStringType{rename.SourceName_});
     proto.set_destination_name(TStringType{rename.DestinationName_});
     proto.set_replace_destination(rename.ReplaceDestination_);
 }
 
-TExplicitPartitions TExplicitPartitions::FromProto(const Ydb::Table::ExplicitPartitions& proto) {
+TExplicitPartitions TExplicitPartitions::FromProto(const NYdbProtos::Table::ExplicitPartitions& proto) {
     TExplicitPartitions out;
     for (const auto& splitPoint : proto.split_points()) {
         TValue value(TType(splitPoint.type()), splitPoint.value());
@@ -263,7 +263,7 @@ TExplicitPartitions TExplicitPartitions::FromProto(const Ydb::Table::ExplicitPar
     return out;
 }
 
-void TExplicitPartitions::SerializeTo(Ydb::Table::ExplicitPartitions& proto) const {
+void TExplicitPartitions::SerializeTo(NYdbProtos::Table::ExplicitPartitions& proto) const {
     for (const auto& splitPoint : SplitPoints_) {
         auto* boundary = proto.add_split_points();
         boundary->mutable_type()->CopyFrom(TProtoAccessor::GetProto(splitPoint.GetType()));
@@ -294,7 +294,7 @@ class TTableDescription::TImpl {
             }
             std::optional<TSequenceDescription> sequenceDescription;
             switch (col.default_value_case()) {
-                case Ydb::Table::ColumnMeta::kFromSequence: {
+                case NYdbProtos::Table::ColumnMeta::kFromSequence: {
                     if (col.from_sequence().name() == "_serial_column_" + col.name()) {
                         TSequenceDescription currentSequenceDescription;
                         if (col.from_sequence().has_set_val()) {
@@ -318,7 +318,7 @@ class TTableDescription::TImpl {
             Indexes_.emplace_back(TProtoAccessor::FromProto(index));
         }
 
-        if constexpr (std::is_same_v<TProto, Ydb::Table::DescribeTableResult>) {
+        if constexpr (std::is_same_v<TProto, NYdbProtos::Table::DescribeTableResult>) {
             // changefeeds
             Changefeeds_.reserve(proto.changefeeds_size());
             for (const auto& changefeed : proto.changefeeds()) {
@@ -332,7 +332,7 @@ class TTableDescription::TImpl {
         }
 
         if (proto.store_type()) {
-            StoreType_ = (proto.store_type() == Ydb::Table::STORE_TYPE_COLUMN) ? EStoreType::Column : EStoreType::Row;
+            StoreType_ = (proto.store_type() == NYdbProtos::Table::STORE_TYPE_COLUMN) ? EStoreType::Column : EStoreType::Row;
         }
 
         // column families
@@ -348,10 +348,10 @@ class TTableDescription::TImpl {
 
         // key bloom filter
         switch (proto.key_bloom_filter()) {
-        case Ydb::FeatureFlag::ENABLED:
+        case NYdbProtos::FeatureFlag::ENABLED:
             KeyBloomFilter_ = true;
             break;
-        case Ydb::FeatureFlag::DISABLED:
+        case NYdbProtos::FeatureFlag::DISABLED:
             KeyBloomFilter_ = false;
             break;
         default:
@@ -362,12 +362,12 @@ class TTableDescription::TImpl {
         if (proto.has_read_replicas_settings()) {
             const auto settings = proto.read_replicas_settings();
             switch (settings.settings_case()) {
-            case Ydb::Table::ReadReplicasSettings::kPerAzReadReplicasCount:
+            case NYdbProtos::Table::ReadReplicasSettings::kPerAzReadReplicasCount:
                 ReadReplicasSettings_ = TReadReplicasSettings(
                     TReadReplicasSettings::EMode::PerAz,
                     settings.per_az_read_replicas_count());
                 break;
-            case Ydb::Table::ReadReplicasSettings::kAnyAzReadReplicasCount:
+            case NYdbProtos::Table::ReadReplicasSettings::kAnyAzReadReplicasCount:
                 ReadReplicasSettings_ = TReadReplicasSettings(
                     TReadReplicasSettings::EMode::AnyAz,
                     settings.any_az_read_replicas_count());
@@ -379,7 +379,7 @@ class TTableDescription::TImpl {
     }
 
 public:
-    TImpl(Ydb::Table::DescribeTableResult&& desc, const TDescribeTableSettings& describeSettings)
+    TImpl(NYdbProtos::Table::DescribeTableResult&& desc, const TDescribeTableSettings& describeSettings)
         : TImpl(desc)
     {
         Proto_ = std::move(desc);
@@ -421,7 +421,7 @@ public:
 
     struct TCreateTableRequestTag {}; // to avoid delegation cycle
 
-    TImpl(const Ydb::Table::CreateTableRequest& request, TCreateTableRequestTag)
+    TImpl(const NYdbProtos::Table::CreateTableRequest& request, TCreateTableRequestTag)
         : TImpl(request)
     {
         if (!request.compaction_policy().empty()) {
@@ -429,11 +429,11 @@ public:
         }
 
         switch (request.partitions_case()) {
-            case Ydb::Table::CreateTableRequest::kUniformPartitions:
+            case NYdbProtos::Table::CreateTableRequest::kUniformPartitions:
                 SetUniformPartitions(request.uniform_partitions());
                 break;
 
-            case Ydb::Table::CreateTableRequest::kPartitionAtKeys: {
+            case NYdbProtos::Table::CreateTableRequest::kPartitionAtKeys: {
                 SetPartitionAtKeys(TExplicitPartitions::FromProto(request.partition_at_keys()));
                 break;
             }
@@ -445,11 +445,11 @@ public:
 
     TImpl() = default;
 
-    const Ydb::Table::DescribeTableResult& GetProto() const {
+    const NYdbProtos::Table::DescribeTableResult& GetProto() const {
         return Proto_;
     }
 
-    void AddColumn(const std::string& name, const Ydb::Type& type, const std::string& family, std::optional<bool> notNull, std::optional<TSequenceDescription> sequenceDescription) {
+    void AddColumn(const std::string& name, const NYdbProtos::Type& type, const std::string& family, std::optional<bool> notNull, std::optional<TSequenceDescription> sequenceDescription) {
         Columns_.emplace_back(name, type, family, notNull, std::move(sequenceDescription));
     }
 
@@ -632,7 +632,7 @@ public:
     }
 
 private:
-    Ydb::Table::DescribeTableResult Proto_;
+    NYdbProtos::Table::DescribeTableResult Proto_;
     TStorageSettings StorageSettings_;
     std::vector<std::string> PrimaryKey_;
     std::vector<TTableColumn> Columns_;
@@ -663,13 +663,13 @@ TTableDescription::TTableDescription()
 {
 }
 
-TTableDescription::TTableDescription(Ydb::Table::DescribeTableResult&& desc,
+TTableDescription::TTableDescription(NYdbProtos::Table::DescribeTableResult&& desc,
     const TDescribeTableSettings& describeSettings)
     : Impl_(new TImpl(std::move(desc), describeSettings))
 {
 }
 
-TTableDescription::TTableDescription(const Ydb::Table::CreateTableRequest& request)
+TTableDescription::TTableDescription(const NYdbProtos::Table::CreateTableRequest& request)
     : Impl_(new TImpl(request, TImpl::TCreateTableRequestTag()))
 {
 }
@@ -729,7 +729,7 @@ const std::vector<TKeyRange>& TTableDescription::GetKeyRanges() const {
     return Impl_->GetKeyRanges();
 }
 
-void TTableDescription::AddColumn(const std::string& name, const Ydb::Type& type, const std::string& family, std::optional<bool> notNull, std::optional<TSequenceDescription> sequenceDescription) {
+void TTableDescription::AddColumn(const std::string& name, const NYdbProtos::Type& type, const std::string& family, std::optional<bool> notNull, std::optional<TSequenceDescription> sequenceDescription) {
     Impl_->AddColumn(name, type, family, notNull, std::move(sequenceDescription));
 }
 
@@ -893,11 +893,11 @@ std::optional<TReadReplicasSettings> TTableDescription::GetReadReplicasSettings(
     return Impl_->GetReadReplicasSettings();
 }
 
-const Ydb::Table::DescribeTableResult& TTableDescription::GetProto() const {
+const NYdbProtos::Table::DescribeTableResult& TTableDescription::GetProto() const {
     return Impl_->GetProto();
 }
 
-void TTableDescription::SerializeTo(Ydb::Table::CreateTableRequest& request) const {
+void TTableDescription::SerializeTo(NYdbProtos::Table::CreateTableRequest& request) const {
     for (const auto& column : Impl_->GetColumns()) {
         auto& protoColumn = *request.add_columns();
         protoColumn.set_name(TStringType{column.Name});
@@ -930,7 +930,7 @@ void TTableDescription::SerializeTo(Ydb::Table::CreateTableRequest& request) con
     }
 
     if (Impl_->GetStoreType() == EStoreType::Column) {
-        request.set_store_type(Ydb::Table::StoreType::STORE_TYPE_COLUMN);
+        request.set_store_type(NYdbProtos::Table::StoreType::STORE_TYPE_COLUMN);
     }
 
     if (Impl_->HasStorageSettings()) {
@@ -966,9 +966,9 @@ void TTableDescription::SerializeTo(Ydb::Table::CreateTableRequest& request) con
 
     if (auto keyBloomFilter = Impl_->GetKeyBloomFilter()) {
         if (keyBloomFilter.value()) {
-            request.set_key_bloom_filter(Ydb::FeatureFlag::ENABLED);
+            request.set_key_bloom_filter(NYdbProtos::FeatureFlag::ENABLED);
         } else {
-            request.set_key_bloom_filter(Ydb::FeatureFlag::DISABLED);
+            request.set_key_bloom_filter(NYdbProtos::FeatureFlag::DISABLED);
         }
     }
 
@@ -990,7 +990,7 @@ void TTableDescription::SerializeTo(Ydb::Table::CreateTableRequest& request) con
 
 class TStorageSettingsBuilder::TImpl {
 public:
-    Ydb::Table::StorageSettings Proto;
+    NYdbProtos::Table::StorageSettings Proto;
 };
 
 TStorageSettingsBuilder::TStorageSettingsBuilder()
@@ -1016,7 +1016,7 @@ TStorageSettingsBuilder& TStorageSettingsBuilder::SetExternal(const std::string&
 
 TStorageSettingsBuilder& TStorageSettingsBuilder::SetStoreExternalBlobs(bool enabled) {
     Impl_->Proto.set_store_external_blobs(
-        enabled ? Ydb::FeatureFlag::ENABLED : Ydb::FeatureFlag::DISABLED);
+        enabled ? NYdbProtos::FeatureFlag::ENABLED : NYdbProtos::FeatureFlag::DISABLED);
     return *this;
 }
 
@@ -1028,7 +1028,7 @@ TStorageSettings TStorageSettingsBuilder::Build() const {
 
 class TPartitioningSettingsBuilder::TImpl {
 public:
-    Ydb::Table::PartitioningSettings Proto;
+    NYdbProtos::Table::PartitioningSettings Proto;
 };
 
 TPartitioningSettingsBuilder::TPartitioningSettingsBuilder()
@@ -1039,13 +1039,13 @@ TPartitioningSettingsBuilder::~TPartitioningSettingsBuilder() { }
 
 TPartitioningSettingsBuilder& TPartitioningSettingsBuilder::SetPartitioningBySize(bool enabled) {
     Impl_->Proto.set_partitioning_by_size(
-        enabled ? Ydb::FeatureFlag::ENABLED : Ydb::FeatureFlag::DISABLED);
+        enabled ? NYdbProtos::FeatureFlag::ENABLED : NYdbProtos::FeatureFlag::DISABLED);
     return *this;
 }
 
 TPartitioningSettingsBuilder& TPartitioningSettingsBuilder::SetPartitioningByLoad(bool enabled) {
     Impl_->Proto.set_partitioning_by_load(
-        enabled ? Ydb::FeatureFlag::ENABLED : Ydb::FeatureFlag::DISABLED);
+        enabled ? NYdbProtos::FeatureFlag::ENABLED : NYdbProtos::FeatureFlag::DISABLED);
     return *this;
 }
 
@@ -1072,7 +1072,7 @@ TPartitioningSettings TPartitioningSettingsBuilder::Build() const {
 
 class TColumnFamilyBuilder::TImpl {
 public:
-    Ydb::Table::ColumnFamily Proto;
+    NYdbProtos::Table::ColumnFamily Proto;
 };
 
 TColumnFamilyBuilder::TColumnFamilyBuilder(const std::string& name)
@@ -1091,17 +1091,17 @@ TColumnFamilyBuilder& TColumnFamilyBuilder::SetData(const std::string& media) {
 TColumnFamilyBuilder& TColumnFamilyBuilder::SetCompression(EColumnFamilyCompression compression) {
     switch (compression) {
         case EColumnFamilyCompression::None:
-            Impl_->Proto.set_compression(Ydb::Table::ColumnFamily::COMPRESSION_NONE);
+            Impl_->Proto.set_compression(NYdbProtos::Table::ColumnFamily::COMPRESSION_NONE);
             break;
         case EColumnFamilyCompression::LZ4:
-            Impl_->Proto.set_compression(Ydb::Table::ColumnFamily::COMPRESSION_LZ4);
+            Impl_->Proto.set_compression(NYdbProtos::Table::ColumnFamily::COMPRESSION_LZ4);
             break;
     }
     return *this;
 }
 
 TColumnFamilyBuilder& TColumnFamilyBuilder::SetKeepInMemory(bool enabled) {
-    Impl_->Proto.set_keep_in_memory(enabled ? Ydb::FeatureFlag::ENABLED : Ydb::FeatureFlag::DISABLED);
+    Impl_->Proto.set_keep_in_memory(enabled ? NYdbProtos::FeatureFlag::ENABLED : NYdbProtos::FeatureFlag::DISABLED);
     return *this;
 }
 
@@ -1514,7 +1514,7 @@ TAsyncScanQueryPartIterator TTableClient::StreamExecuteScanQuery(const std::stri
 
 ////////////////////////////////////////////////////////////////////////////////
 
-static void ConvertCreateTableSettingsToProto(const TCreateTableSettings& settings, Ydb::Table::TableProfile* proto) {
+static void ConvertCreateTableSettingsToProto(const TCreateTableSettings& settings, NYdbProtos::Table::TableProfile* proto) {
     if (settings.PresetName_) {
         proto->set_preset_name(TStringType{settings.PresetName_.value()});
     }
@@ -1530,7 +1530,7 @@ static void ConvertCreateTableSettingsToProto(const TCreateTableSettings& settin
             proto->mutable_partitioning_policy()->set_preset_name(TStringType{policy.PresetName_.value()});
         }
         if (policy.AutoPartitioning_) {
-            proto->mutable_partitioning_policy()->set_auto_partitioning(static_cast<Ydb::Table::PartitioningPolicy_AutoPartitioningPolicy>(policy.AutoPartitioning_.value()));
+            proto->mutable_partitioning_policy()->set_auto_partitioning(static_cast<NYdbProtos::Table::PartitioningPolicy_AutoPartitioningPolicy>(policy.AutoPartitioning_.value()));
         }
         if (policy.UniformPartitions_) {
             proto->mutable_partitioning_policy()->set_uniform_partitions(policy.UniformPartitions_.value());
@@ -1575,14 +1575,14 @@ static void ConvertCreateTableSettingsToProto(const TCreateTableSettings& settin
             if (familyPolicy.KeepInMemory_) {
                 familyProto->set_keep_in_memory(
                     familyPolicy.KeepInMemory_.value()
-                    ? Ydb::FeatureFlag_Status::FeatureFlag_Status_ENABLED
-                    : Ydb::FeatureFlag_Status::FeatureFlag_Status_DISABLED
+                    ? NYdbProtos::FeatureFlag_Status::FeatureFlag_Status_ENABLED
+                    : NYdbProtos::FeatureFlag_Status::FeatureFlag_Status_DISABLED
                 );
             }
             if (familyPolicy.Compressed_) {
                 familyProto->set_compression(familyPolicy.Compressed_.value()
-                    ? Ydb::Table::ColumnFamilyPolicy::COMPRESSED
-                    : Ydb::Table::ColumnFamilyPolicy::UNCOMPRESSED);
+                    ? NYdbProtos::Table::ColumnFamilyPolicy::COMPRESSED
+                    : NYdbProtos::Table::ColumnFamilyPolicy::UNCOMPRESSED);
             }
         }
     }
@@ -1597,15 +1597,15 @@ static void ConvertCreateTableSettingsToProto(const TCreateTableSettings& settin
         if (policy.CreatePerAvailabilityZone_) {
             proto->mutable_replication_policy()->set_create_per_availability_zone(
                 policy.CreatePerAvailabilityZone_.value()
-                ? Ydb::FeatureFlag_Status::FeatureFlag_Status_ENABLED
-                : Ydb::FeatureFlag_Status::FeatureFlag_Status_DISABLED
+                ? NYdbProtos::FeatureFlag_Status::FeatureFlag_Status_ENABLED
+                : NYdbProtos::FeatureFlag_Status::FeatureFlag_Status_DISABLED
             );
         }
         if (policy.AllowPromotion_) {
             proto->mutable_replication_policy()->set_allow_promotion(
                 policy.AllowPromotion_.value()
-                ? Ydb::FeatureFlag_Status::FeatureFlag_Status_ENABLED
-                : Ydb::FeatureFlag_Status::FeatureFlag_Status_DISABLED
+                ? NYdbProtos::FeatureFlag_Status::FeatureFlag_Status_ENABLED
+                : NYdbProtos::FeatureFlag_Status::FeatureFlag_Status_DISABLED
             );
         }
     }
@@ -1636,7 +1636,7 @@ TSession::TSession(std::shared_ptr<TTableClient::TImpl> client, std::shared_ptr<
 TFuture<TStatus> TSession::CreateTable(const std::string& path, TTableDescription&& tableDesc,
         const TCreateTableSettings& settings)
 {
-    auto request = MakeOperationRequest<Ydb::Table::CreateTableRequest>(settings);
+    auto request = MakeOperationRequest<NYdbProtos::Table::CreateTableRequest>(settings);
     request.set_session_id(TStringType{SessionImpl_->GetId()});
     request.set_path(TStringType{path});
 
@@ -1659,10 +1659,10 @@ TFuture<TStatus> TSession::DropTable(const std::string& path, const TDropTableSe
         GetMinTimeToTouch(Client_->Settings_.SessionPoolSettings_));
 }
 
-static Ydb::Table::AlterTableRequest MakeAlterTableProtoRequest(
+static NYdbProtos::Table::AlterTableRequest MakeAlterTableProtoRequest(
     const std::string& path, const TAlterTableSettings& settings, const std::string& sessionId)
 {
-    auto request = MakeOperationRequest<Ydb::Table::AlterTableRequest>(settings);
+    auto request = MakeOperationRequest<NYdbProtos::Table::AlterTableRequest>(settings);
     request.set_session_id(TStringType{sessionId});
     request.set_path(TStringType{path});
 
@@ -1740,7 +1740,7 @@ static Ydb::Table::AlterTableRequest MakeAlterTableProtoRequest(
 
     if (settings.SetKeyBloomFilter_.has_value()) {
         request.set_set_key_bloom_filter(
-            settings.SetKeyBloomFilter_.value() ? Ydb::FeatureFlag::ENABLED : Ydb::FeatureFlag::DISABLED);
+            settings.SetKeyBloomFilter_.value() ? NYdbProtos::FeatureFlag::ENABLED : NYdbProtos::FeatureFlag::DISABLED);
     }
 
     if (settings.SetReadReplicasSettings_.has_value()) {
@@ -1783,7 +1783,7 @@ TAsyncOperation TSession::AlterTableLong(const std::string& path, const TAlterTa
 }
 
 TAsyncStatus TSession::RenameTables(const std::vector<TRenameItem>& renameItems, const TRenameTablesSettings& settings) {
-    auto request = MakeOperationRequest<Ydb::Table::RenameTablesRequest>(settings);
+    auto request = MakeOperationRequest<NYdbProtos::Table::RenameTablesRequest>(settings);
     request.set_session_id(TStringType{SessionImpl_->GetId()});
 
     for (const auto& item: renameItems) {
@@ -1801,7 +1801,7 @@ TAsyncStatus TSession::RenameTables(const std::vector<TRenameItem>& renameItems,
 }
 
 TAsyncStatus TSession::CopyTables(const std::vector<TCopyItem>& copyItems, const TCopyTablesSettings& settings) {
-    auto request = MakeOperationRequest<Ydb::Table::CopyTablesRequest>(settings);
+    auto request = MakeOperationRequest<NYdbProtos::Table::CopyTablesRequest>(settings);
     request.set_session_id(TStringType{SessionImpl_->GetId()});
 
     for (const auto& item: copyItems) {
@@ -1862,7 +1862,7 @@ TAsyncDataQueryResult TSession::ExecuteDataQuery(const std::string& query, const
             nullptr,
             settings);
     } else {
-        using TProtoParamsType = const ::google::protobuf::Map<TStringType, Ydb::TypedValue>;
+        using TProtoParamsType = const ::google::protobuf::Map<TStringType, NYdbProtos::TypedValue>;
         return Client_->ExecuteDataQuery<TProtoParamsType&>(
             *this,
             query,
@@ -2027,7 +2027,7 @@ TDataQuery::TDataQuery(const TSession& session, const std::string& text, const s
 {}
 
 TDataQuery::TDataQuery(const TSession& session, const std::string& text, const std::string& id,
-    const ::google::protobuf::Map<TStringType, Ydb::Type>& types)
+    const ::google::protobuf::Map<TStringType, NYdbProtos::Type>& types)
     : Impl_(new TImpl(session, text, session.Client_->Settings_.KeepDataQueryText_, id,
                       session.Client_->Settings_.AllowRequestMigration_, types))
 {}
@@ -2075,7 +2075,7 @@ TAsyncDataQueryResult TDataQuery::Execute(const TTxControl& txControl, const TPa
             settings,
             false);
     } else {
-        using TProtoParamsType = const ::google::protobuf::Map<TStringType, Ydb::TypedValue>;
+        using TProtoParamsType = const ::google::protobuf::Map<TStringType, NYdbProtos::TypedValue>;
         return Impl_->Session_.Client_->ExecuteDataQuery<TProtoParamsType&>(
             Impl_->Session_,
             *this,
@@ -2153,7 +2153,7 @@ const std::string& TExplainQueryResult::GetDiagnostics() const {
 
 ////////////////////////////////////////////////////////////////////////////////
 
-TDescribeTableResult::TDescribeTableResult(TStatus&& status, Ydb::Table::DescribeTableResult&& desc,
+TDescribeTableResult::TDescribeTableResult(TStatus&& status, NYdbProtos::Table::DescribeTableResult&& desc,
     const TDescribeTableSettings& describeSettings)
     : NScheme::TDescribePathResult(std::move(status), desc.self())
     , TableDescription_(std::move(desc), describeSettings)
@@ -2324,11 +2324,11 @@ TIndexDescription::TIndexDescription(
 )   : TIndexDescription(name, EIndexType::GlobalSync, indexColumns, dataColumns, globalIndexSettings)
 {}
 
-TIndexDescription::TIndexDescription(const Ydb::Table::TableIndex& tableIndex)
+TIndexDescription::TIndexDescription(const NYdbProtos::Table::TableIndex& tableIndex)
     : TIndexDescription(FromProto(tableIndex))
 {}
 
-TIndexDescription::TIndexDescription(const Ydb::Table::TableIndexDescription& tableIndexDesc)
+TIndexDescription::TIndexDescription(const NYdbProtos::Table::TableIndexDescription& tableIndexDesc)
     : TIndexDescription(FromProto(tableIndexDesc))
 {}
 
@@ -2356,12 +2356,12 @@ uint64_t TIndexDescription::GetSizeBytes() const {
     return SizeBytes_;
 }
 
-TGlobalIndexSettings TGlobalIndexSettings::FromProto(const Ydb::Table::GlobalIndexSettings& proto) {
-    auto partitionsFromProto = [](const Ydb::Table::GlobalIndexSettings& proto) -> TUniformOrExplicitPartitions {
+TGlobalIndexSettings TGlobalIndexSettings::FromProto(const NYdbProtos::Table::GlobalIndexSettings& proto) {
+    auto partitionsFromProto = [](const NYdbProtos::Table::GlobalIndexSettings& proto) -> TUniformOrExplicitPartitions {
         switch (proto.partitions_case()) {
-        case Ydb::Table::GlobalIndexSettings::kUniformPartitions:
+        case NYdbProtos::Table::GlobalIndexSettings::kUniformPartitions:
             return proto.uniform_partitions();
-        case Ydb::Table::GlobalIndexSettings::kPartitionAtKeys:
+        case NYdbProtos::Table::GlobalIndexSettings::kPartitionAtKeys:
             return TExplicitPartitions::FromProto(proto.partition_at_keys());
         default:
             return {};
@@ -2374,7 +2374,7 @@ TGlobalIndexSettings TGlobalIndexSettings::FromProto(const Ydb::Table::GlobalInd
     };
 }
 
-void TGlobalIndexSettings::SerializeTo(Ydb::Table::GlobalIndexSettings& settings) const {
+void TGlobalIndexSettings::SerializeTo(NYdbProtos::Table::GlobalIndexSettings& settings) const {
     *settings.mutable_partitioning_settings() = PartitioningSettings.GetProto();
 
     auto variantVisitor = [&settings](auto&& partitions) {
@@ -2388,18 +2388,18 @@ void TGlobalIndexSettings::SerializeTo(Ydb::Table::GlobalIndexSettings& settings
     std::visit(std::move(variantVisitor), Partitions);
 }
 
-TVectorIndexSettings TVectorIndexSettings::FromProto(const Ydb::Table::VectorIndexSettings& proto) {
+TVectorIndexSettings TVectorIndexSettings::FromProto(const NYdbProtos::Table::VectorIndexSettings& proto) {
     auto covertMetric = [&] {
         switch (proto.metric()) {
-        case Ydb::Table::VectorIndexSettings::SIMILARITY_INNER_PRODUCT:
+        case NYdbProtos::Table::VectorIndexSettings::SIMILARITY_INNER_PRODUCT:
             return EMetric::InnerProduct;
-        case Ydb::Table::VectorIndexSettings::SIMILARITY_COSINE:
+        case NYdbProtos::Table::VectorIndexSettings::SIMILARITY_COSINE:
             return EMetric::CosineSimilarity;
-        case Ydb::Table::VectorIndexSettings::DISTANCE_COSINE:
+        case NYdbProtos::Table::VectorIndexSettings::DISTANCE_COSINE:
             return EMetric::CosineDistance;
-        case Ydb::Table::VectorIndexSettings::DISTANCE_MANHATTAN:
+        case NYdbProtos::Table::VectorIndexSettings::DISTANCE_MANHATTAN:
             return EMetric::Manhattan;
-        case Ydb::Table::VectorIndexSettings::DISTANCE_EUCLIDEAN:
+        case NYdbProtos::Table::VectorIndexSettings::DISTANCE_EUCLIDEAN:
             return EMetric::Euclidean;
         default:
             return EMetric::Unspecified;
@@ -2408,13 +2408,13 @@ TVectorIndexSettings TVectorIndexSettings::FromProto(const Ydb::Table::VectorInd
 
     auto convertVectorType = [&] {
         switch (proto.vector_type()) {
-        case Ydb::Table::VectorIndexSettings::VECTOR_TYPE_FLOAT:
+        case NYdbProtos::Table::VectorIndexSettings::VECTOR_TYPE_FLOAT:
             return EVectorType::Float;
-        case Ydb::Table::VectorIndexSettings::VECTOR_TYPE_UINT8:
+        case NYdbProtos::Table::VectorIndexSettings::VECTOR_TYPE_UINT8:
             return EVectorType::Uint8;
-        case Ydb::Table::VectorIndexSettings::VECTOR_TYPE_INT8:
+        case NYdbProtos::Table::VectorIndexSettings::VECTOR_TYPE_INT8:
             return EVectorType::Int8;
-        case Ydb::Table::VectorIndexSettings::VECTOR_TYPE_BIT:
+        case NYdbProtos::Table::VectorIndexSettings::VECTOR_TYPE_BIT:
             return EVectorType::Bit;
         default:
             return EVectorType::Unspecified;
@@ -2428,36 +2428,36 @@ TVectorIndexSettings TVectorIndexSettings::FromProto(const Ydb::Table::VectorInd
     };
 }
 
-void TVectorIndexSettings::SerializeTo(Ydb::Table::VectorIndexSettings& settings) const {
+void TVectorIndexSettings::SerializeTo(NYdbProtos::Table::VectorIndexSettings& settings) const {
     auto convertMetric = [&] {
         switch (Metric) {
         case EMetric::InnerProduct:
-            return Ydb::Table::VectorIndexSettings::SIMILARITY_INNER_PRODUCT;
+            return NYdbProtos::Table::VectorIndexSettings::SIMILARITY_INNER_PRODUCT;
         case EMetric::CosineSimilarity:
-            return Ydb::Table::VectorIndexSettings::SIMILARITY_COSINE;
+            return NYdbProtos::Table::VectorIndexSettings::SIMILARITY_COSINE;
         case EMetric::CosineDistance:
-            return Ydb::Table::VectorIndexSettings::DISTANCE_COSINE;
+            return NYdbProtos::Table::VectorIndexSettings::DISTANCE_COSINE;
         case EMetric::Manhattan:
-            return Ydb::Table::VectorIndexSettings::DISTANCE_MANHATTAN;
+            return NYdbProtos::Table::VectorIndexSettings::DISTANCE_MANHATTAN;
         case EMetric::Euclidean:
-            return Ydb::Table::VectorIndexSettings::DISTANCE_EUCLIDEAN;
+            return NYdbProtos::Table::VectorIndexSettings::DISTANCE_EUCLIDEAN;
         case EMetric::Unspecified:
-            return Ydb::Table::VectorIndexSettings::METRIC_UNSPECIFIED;
+            return NYdbProtos::Table::VectorIndexSettings::METRIC_UNSPECIFIED;
         }
     };
 
     auto convertVectorType = [&] {
         switch (VectorType) {
         case EVectorType::Float:
-            return Ydb::Table::VectorIndexSettings::VECTOR_TYPE_FLOAT;
+            return NYdbProtos::Table::VectorIndexSettings::VECTOR_TYPE_FLOAT;
         case EVectorType::Uint8:
-            return Ydb::Table::VectorIndexSettings::VECTOR_TYPE_UINT8;
+            return NYdbProtos::Table::VectorIndexSettings::VECTOR_TYPE_UINT8;
         case EVectorType::Int8:
-            return Ydb::Table::VectorIndexSettings::VECTOR_TYPE_INT8;
+            return NYdbProtos::Table::VectorIndexSettings::VECTOR_TYPE_INT8;
         case EVectorType::Bit:
-            return Ydb::Table::VectorIndexSettings::VECTOR_TYPE_BIT;
+            return NYdbProtos::Table::VectorIndexSettings::VECTOR_TYPE_BIT;
         case EVectorType::Unspecified:
-            return Ydb::Table::VectorIndexSettings::VECTOR_TYPE_UNSPECIFIED;
+            return NYdbProtos::Table::VectorIndexSettings::VECTOR_TYPE_UNSPECIFIED;
         }
     };
 
@@ -2470,7 +2470,7 @@ void TVectorIndexSettings::Out(IOutputStream& o) const {
     o << *this;
 }
 
-TKMeansTreeSettings TKMeansTreeSettings::FromProto(const Ydb::Table::KMeansTreeSettings& proto) {
+TKMeansTreeSettings TKMeansTreeSettings::FromProto(const NYdbProtos::Table::KMeansTreeSettings& proto) {
     return {
         .Settings = TVectorIndexSettings::FromProto(proto.settings()),
         .Clusters = proto.clusters(),
@@ -2478,7 +2478,7 @@ TKMeansTreeSettings TKMeansTreeSettings::FromProto(const Ydb::Table::KMeansTreeS
     };
 }
 
-void TKMeansTreeSettings::SerializeTo(Ydb::Table::KMeansTreeSettings& settings) const {
+void TKMeansTreeSettings::SerializeTo(NYdbProtos::Table::KMeansTreeSettings& settings) const {
     Settings.SerializeTo(*settings.mutable_settings());
     settings.set_clusters(Clusters);
     settings.set_levels(Levels);
@@ -2527,14 +2527,14 @@ TIndexDescription TIndexDescription::FromProto(const TProto& proto) {
     }
 
     auto result = TIndexDescription(proto.name(), type, indexColumns, dataColumns, globalIndexSettings, specializedIndexSettings);
-    if constexpr (std::is_same_v<TProto, Ydb::Table::TableIndexDescription>) {
+    if constexpr (std::is_same_v<TProto, NYdbProtos::Table::TableIndexDescription>) {
         result.SizeBytes_ = proto.size_bytes();
     }
 
     return result;
 }
 
-void TIndexDescription::SerializeTo(Ydb::Table::TableIndex& proto) const {
+void TIndexDescription::SerializeTo(NYdbProtos::Table::TableIndex& proto) const {
     proto.set_name(TStringType{IndexName_});
     for (const auto& indexCol : IndexColumns_) {
         proto.add_index_columns(TStringType{indexCol});
@@ -2624,11 +2624,11 @@ TChangefeedDescription::TChangefeedDescription(const std::string& name, EChangef
     , Format_(format)
 {}
 
-TChangefeedDescription::TChangefeedDescription(const Ydb::Table::Changefeed& proto)
+TChangefeedDescription::TChangefeedDescription(const NYdbProtos::Table::Changefeed& proto)
     : TChangefeedDescription(FromProto(proto))
 {}
 
-TChangefeedDescription::TChangefeedDescription(const Ydb::Table::ChangefeedDescription& proto)
+TChangefeedDescription::TChangefeedDescription(const NYdbProtos::Table::ChangefeedDescription& proto)
     : TChangefeedDescription(FromProto(proto))
 {}
 
@@ -2748,19 +2748,19 @@ template <typename TProto>
 TChangefeedDescription TChangefeedDescription::FromProto(const TProto& proto) {
     EChangefeedMode mode;
     switch (proto.mode()) {
-    case Ydb::Table::ChangefeedMode::MODE_KEYS_ONLY:
+    case NYdbProtos::Table::ChangefeedMode::MODE_KEYS_ONLY:
         mode = EChangefeedMode::KeysOnly;
         break;
-    case Ydb::Table::ChangefeedMode::MODE_UPDATES:
+    case NYdbProtos::Table::ChangefeedMode::MODE_UPDATES:
         mode = EChangefeedMode::Updates;
         break;
-    case Ydb::Table::ChangefeedMode::MODE_NEW_IMAGE:
+    case NYdbProtos::Table::ChangefeedMode::MODE_NEW_IMAGE:
         mode = EChangefeedMode::NewImage;
         break;
-    case Ydb::Table::ChangefeedMode::MODE_OLD_IMAGE:
+    case NYdbProtos::Table::ChangefeedMode::MODE_OLD_IMAGE:
         mode = EChangefeedMode::OldImage;
         break;
-    case Ydb::Table::ChangefeedMode::MODE_NEW_AND_OLD_IMAGES:
+    case NYdbProtos::Table::ChangefeedMode::MODE_NEW_AND_OLD_IMAGES:
         mode = EChangefeedMode::NewAndOldImages;
         break;
     default:
@@ -2770,13 +2770,13 @@ TChangefeedDescription TChangefeedDescription::FromProto(const TProto& proto) {
 
     EChangefeedFormat format;
     switch (proto.format()) {
-    case Ydb::Table::ChangefeedFormat::FORMAT_JSON:
+    case NYdbProtos::Table::ChangefeedFormat::FORMAT_JSON:
         format = EChangefeedFormat::Json;
         break;
-    case Ydb::Table::ChangefeedFormat::FORMAT_DYNAMODB_STREAMS_JSON:
+    case NYdbProtos::Table::ChangefeedFormat::FORMAT_DYNAMODB_STREAMS_JSON:
         format = EChangefeedFormat::DynamoDBStreamsJson;
         break;
-    case Ydb::Table::ChangefeedFormat::FORMAT_DEBEZIUM_JSON:
+    case NYdbProtos::Table::ChangefeedFormat::FORMAT_DEBEZIUM_JSON:
         format = EChangefeedFormat::DebeziumJson;
         break;
     default:
@@ -2796,15 +2796,15 @@ TChangefeedDescription TChangefeedDescription::FromProto(const TProto& proto) {
         ret.WithAwsRegion(proto.aws_region());
     }
 
-    if constexpr (std::is_same_v<TProto, Ydb::Table::ChangefeedDescription>) {
+    if constexpr (std::is_same_v<TProto, NYdbProtos::Table::ChangefeedDescription>) {
         switch (proto.state()) {
-        case Ydb::Table::ChangefeedDescription::STATE_ENABLED:
+        case NYdbProtos::Table::ChangefeedDescription::STATE_ENABLED:
             ret.State_= EChangefeedState::Enabled;
             break;
-        case Ydb::Table::ChangefeedDescription::STATE_DISABLED:
+        case NYdbProtos::Table::ChangefeedDescription::STATE_DISABLED:
             ret.State_ = EChangefeedState::Disabled;
             break;
-        case Ydb::Table::ChangefeedDescription::STATE_INITIAL_SCAN:
+        case NYdbProtos::Table::ChangefeedDescription::STATE_INITIAL_SCAN:
             ret.State_ = EChangefeedState::InitialScan;
             break;
         default:
@@ -2835,19 +2835,19 @@ void TChangefeedDescription::SerializeCommonFields(TProto& proto) const {
 
     switch (Mode_) {
     case EChangefeedMode::KeysOnly:
-        proto.set_mode(Ydb::Table::ChangefeedMode::MODE_KEYS_ONLY);
+        proto.set_mode(NYdbProtos::Table::ChangefeedMode::MODE_KEYS_ONLY);
         break;
     case EChangefeedMode::Updates:
-        proto.set_mode(Ydb::Table::ChangefeedMode::MODE_UPDATES);
+        proto.set_mode(NYdbProtos::Table::ChangefeedMode::MODE_UPDATES);
         break;
     case EChangefeedMode::NewImage:
-        proto.set_mode(Ydb::Table::ChangefeedMode::MODE_NEW_IMAGE);
+        proto.set_mode(NYdbProtos::Table::ChangefeedMode::MODE_NEW_IMAGE);
         break;
     case EChangefeedMode::OldImage:
-        proto.set_mode(Ydb::Table::ChangefeedMode::MODE_OLD_IMAGE);
+        proto.set_mode(NYdbProtos::Table::ChangefeedMode::MODE_OLD_IMAGE);
         break;
     case EChangefeedMode::NewAndOldImages:
-        proto.set_mode(Ydb::Table::ChangefeedMode::MODE_NEW_AND_OLD_IMAGES);
+        proto.set_mode(NYdbProtos::Table::ChangefeedMode::MODE_NEW_AND_OLD_IMAGES);
         break;
     case EChangefeedMode::Unknown:
         break;
@@ -2855,13 +2855,13 @@ void TChangefeedDescription::SerializeCommonFields(TProto& proto) const {
 
     switch (Format_) {
     case EChangefeedFormat::Json:
-        proto.set_format(Ydb::Table::ChangefeedFormat::FORMAT_JSON);
+        proto.set_format(NYdbProtos::Table::ChangefeedFormat::FORMAT_JSON);
         break;
     case EChangefeedFormat::DynamoDBStreamsJson:
-        proto.set_format(Ydb::Table::ChangefeedFormat::FORMAT_DYNAMODB_STREAMS_JSON);
+        proto.set_format(NYdbProtos::Table::ChangefeedFormat::FORMAT_DYNAMODB_STREAMS_JSON);
         break;
     case EChangefeedFormat::DebeziumJson:
-        proto.set_format(Ydb::Table::ChangefeedFormat::FORMAT_DEBEZIUM_JSON);
+        proto.set_format(NYdbProtos::Table::ChangefeedFormat::FORMAT_DEBEZIUM_JSON);
         break;
     case EChangefeedFormat::Unknown:
         break;
@@ -2876,7 +2876,7 @@ void TChangefeedDescription::SerializeCommonFields(TProto& proto) const {
     }
 }
 
-void TChangefeedDescription::SerializeTo(Ydb::Table::Changefeed& proto) const {
+void TChangefeedDescription::SerializeTo(NYdbProtos::Table::Changefeed& proto) const {
     SerializeCommonFields(proto);
     proto.set_initial_scan(InitialScan_);
 
@@ -2885,18 +2885,18 @@ void TChangefeedDescription::SerializeTo(Ydb::Table::Changefeed& proto) const {
     }
 }
 
-void TChangefeedDescription::SerializeTo(Ydb::Table::ChangefeedDescription& proto) const {
+void TChangefeedDescription::SerializeTo(NYdbProtos::Table::ChangefeedDescription& proto) const {
     SerializeCommonFields(proto);
 
     switch (State_) {
     case EChangefeedState::Enabled:
-        proto.set_state(Ydb::Table::ChangefeedDescription_State::ChangefeedDescription_State_STATE_ENABLED);
+        proto.set_state(NYdbProtos::Table::ChangefeedDescription_State::ChangefeedDescription_State_STATE_ENABLED);
         break;
     case EChangefeedState::Disabled:
-        proto.set_state(Ydb::Table::ChangefeedDescription_State::ChangefeedDescription_State_STATE_DISABLED);
+        proto.set_state(NYdbProtos::Table::ChangefeedDescription_State::ChangefeedDescription_State_STATE_DISABLED);
         break;
     case EChangefeedState::InitialScan:
-        proto.set_state(Ydb::Table::ChangefeedDescription_State::ChangefeedDescription_State_STATE_INITIAL_SCAN);
+        proto.set_state(NYdbProtos::Table::ChangefeedDescription_State::ChangefeedDescription_State_STATE_INITIAL_SCAN);
         break;
     case EChangefeedState::Unknown:
         break;
@@ -2955,39 +2955,39 @@ TTtlTierSettings::TTtlTierSettings(const TExpression& expression, const TAction&
     , Action_(action)
 { }
 
-std::optional<TTtlTierSettings> TTtlTierSettings::FromProto(const Ydb::Table::TtlTier& tier) {
+std::optional<TTtlTierSettings> TTtlTierSettings::FromProto(const NYdbProtos::Table::TtlTier& tier) {
     std::optional<TExpression> expression;
     switch (tier.expression_case()) {
-    case Ydb::Table::TtlTier::kDateTypeColumn:
+    case NYdbProtos::Table::TtlTier::kDateTypeColumn:
         expression = TDateTypeColumnModeSettings(
             tier.date_type_column().column_name(), TDuration::Seconds(tier.date_type_column().expire_after_seconds()));
         break;
-    case Ydb::Table::TtlTier::kValueSinceUnixEpoch:
+    case NYdbProtos::Table::TtlTier::kValueSinceUnixEpoch:
         expression = TValueSinceUnixEpochModeSettings(tier.value_since_unix_epoch().column_name(),
             TProtoAccessor::FromProto(tier.value_since_unix_epoch().column_unit()),
             TDuration::Seconds(tier.value_since_unix_epoch().expire_after_seconds()));
         break;
-    case Ydb::Table::TtlTier::EXPRESSION_NOT_SET:
+    case NYdbProtos::Table::TtlTier::EXPRESSION_NOT_SET:
         return std::nullopt;
     }
 
     TAction action;
 
     switch (tier.action_case()) {
-    case Ydb::Table::TtlTier::kDelete:
+    case NYdbProtos::Table::TtlTier::kDelete:
         action = TTtlDeleteAction();
         break;
-    case Ydb::Table::TtlTier::kEvictToExternalStorage:
+    case NYdbProtos::Table::TtlTier::kEvictToExternalStorage:
         action = TTtlEvictToExternalStorageAction(tier.evict_to_external_storage().storage());
         break;
-    case Ydb::Table::TtlTier::ACTION_NOT_SET:
+    case NYdbProtos::Table::TtlTier::ACTION_NOT_SET:
         return std::nullopt;
     }
 
     return TTtlTierSettings(std::move(*expression), std::move(action));
 }
 
-void TTtlTierSettings::SerializeTo(Ydb::Table::TtlTier& proto) const {
+void TTtlTierSettings::SerializeTo(NYdbProtos::Table::TtlTier& proto) const {
     std::visit(TOverloaded{
             [&proto](const TDateTypeColumnModeSettings& expr) { expr.SerializeTo(*proto.mutable_date_type_column()); },
             [&proto](const TValueSinceUnixEpochModeSettings& expr) { expr.SerializeTo(*proto.mutable_value_since_unix_epoch()); },
@@ -3014,7 +3014,7 @@ TDateTypeColumnModeSettings::TDateTypeColumnModeSettings(const std::string& colu
     , ApplyAfter_(applyAfter)
 {}
 
-void TDateTypeColumnModeSettings::SerializeTo(Ydb::Table::DateTypeColumnModeSettings& proto) const {
+void TDateTypeColumnModeSettings::SerializeTo(NYdbProtos::Table::DateTypeColumnModeSettings& proto) const {
     proto.set_column_name(TStringType{ColumnName_});
     proto.set_expire_after_seconds(ApplyAfter_.Seconds());
 }
@@ -3033,7 +3033,7 @@ TValueSinceUnixEpochModeSettings::TValueSinceUnixEpochModeSettings(const std::st
     , ApplyAfter_(applyAfter)
 {}
 
-void TValueSinceUnixEpochModeSettings::SerializeTo(Ydb::Table::ValueSinceUnixEpochModeSettings& proto) const {
+void TValueSinceUnixEpochModeSettings::SerializeTo(NYdbProtos::Table::ValueSinceUnixEpochModeSettings& proto) const {
     proto.set_column_name(TStringType{ColumnName_});
     proto.set_column_unit(TProtoAccessor::GetProto(ColumnUnit_));
     proto.set_expire_after_seconds(ApplyAfter_.Seconds());
@@ -3095,7 +3095,7 @@ TTtlEvictToExternalStorageAction::TTtlEvictToExternalStorageAction(const std::st
     : Storage_(storageName)
 {}
 
-void TTtlEvictToExternalStorageAction::SerializeTo(Ydb::Table::EvictionToExternalStorageSettings& proto) const {
+void TTtlEvictToExternalStorageAction::SerializeTo(NYdbProtos::Table::EvictionToExternalStorageSettings& proto) const {
     proto.set_storage(Storage_);
 }
 
@@ -3111,7 +3111,7 @@ TTtlSettings::TTtlSettings(const std::string& columnName, const TDuration& expir
     : TTtlSettings({TTtlTierSettings(TDateTypeColumnModeSettings(columnName, expireAfter), TTtlDeleteAction())})
 {}
 
-TTtlSettings::TTtlSettings(const Ydb::Table::DateTypeColumnModeSettings& mode, ui32 runIntervalSeconds)
+TTtlSettings::TTtlSettings(const NYdbProtos::Table::DateTypeColumnModeSettings& mode, ui32 runIntervalSeconds)
     : TTtlSettings(mode.column_name(), TDuration::Seconds(mode.expire_after_seconds()))
 {
     RunInterval_ = TDuration::Seconds(runIntervalSeconds);
@@ -3125,7 +3125,7 @@ TTtlSettings::TTtlSettings(const std::string& columnName, EUnit columnUnit, cons
     : TTtlSettings({TTtlTierSettings(TValueSinceUnixEpochModeSettings(columnName, columnUnit, expireAfter), TTtlDeleteAction())})
 {}
 
-TTtlSettings::TTtlSettings(const Ydb::Table::ValueSinceUnixEpochModeSettings& mode, ui32 runIntervalSeconds)
+TTtlSettings::TTtlSettings(const NYdbProtos::Table::ValueSinceUnixEpochModeSettings& mode, ui32 runIntervalSeconds)
     : TTtlSettings(mode.column_name(), TProtoAccessor::FromProto(mode.column_unit()), TDuration::Seconds(mode.expire_after_seconds()))
 {
     RunInterval_ = TDuration::Seconds(runIntervalSeconds);
@@ -3135,13 +3135,13 @@ const TValueSinceUnixEpochModeSettings& TTtlSettings::GetValueSinceUnixEpoch() c
     return std::get<TValueSinceUnixEpochModeSettings>(Tiers_.front().GetExpression());
 }
 
-std::optional<TTtlSettings> TTtlSettings::FromProto(const Ydb::Table::TtlSettings& proto) {
+std::optional<TTtlSettings> TTtlSettings::FromProto(const NYdbProtos::Table::TtlSettings& proto) {
     switch(proto.mode_case()) {
-    case Ydb::Table::TtlSettings::kDateTypeColumn:
+    case NYdbProtos::Table::TtlSettings::kDateTypeColumn:
         return TTtlSettings(proto.date_type_column(), proto.run_interval_seconds());
-    case Ydb::Table::TtlSettings::kValueSinceUnixEpoch:
+    case NYdbProtos::Table::TtlSettings::kValueSinceUnixEpoch:
         return TTtlSettings(proto.value_since_unix_epoch(), proto.run_interval_seconds());
-    case Ydb::Table::TtlSettings::kTieredTtl: {
+    case NYdbProtos::Table::TtlSettings::kTieredTtl: {
         std::vector<TTtlTierSettings> tiers;
         for (const auto& tier : proto.tiered_ttl().tiers()) {
             if (auto deserialized = TTtlTierSettings::FromProto(tier)) {
@@ -3154,12 +3154,12 @@ std::optional<TTtlSettings> TTtlSettings::FromProto(const Ydb::Table::TtlSetting
         settings.SetRunInterval(TDuration::Seconds(proto.run_interval_seconds()));
         return settings;
     }
-    case Ydb::Table::TtlSettings::MODE_NOT_SET:
+    case NYdbProtos::Table::TtlSettings::MODE_NOT_SET:
         return std::nullopt;
     }
 }
 
-void TTtlSettings::SerializeTo(Ydb::Table::TtlSettings& proto) const {
+void TTtlSettings::SerializeTo(NYdbProtos::Table::TtlSettings& proto) const {
     if (Tiers_.size() == 1 && std::holds_alternative<TTtlDeleteAction>(Tiers_.back().GetAction())) {
         // serialize DELETE-only TTL to legacy format for backwards-compatibility
         std::visit(TOverloaded{
@@ -3319,28 +3319,28 @@ TReadRowsResult::TReadRowsResult(TStatus&& status, TResultSet&& resultSet)
 ////////////////////////////////////////////////////////////////////////////////
 
 class TExternalDataSourceDescription::TImpl {
-    Ydb::Table::DescribeExternalDataSourceResult Proto_;
+    NYdbProtos::Table::DescribeExternalDataSourceResult Proto_;
 
 public:
-    TImpl(Ydb::Table::DescribeExternalDataSourceResult&& description)
+    TImpl(NYdbProtos::Table::DescribeExternalDataSourceResult&& description)
         : Proto_(std::move(description))
     {}
 
-    const Ydb::Table::DescribeExternalDataSourceResult& GetProto() const {
+    const NYdbProtos::Table::DescribeExternalDataSourceResult& GetProto() const {
         return Proto_;
     }
 };
 
-TExternalDataSourceDescription::TExternalDataSourceDescription(Ydb::Table::DescribeExternalDataSourceResult&& description)
+TExternalDataSourceDescription::TExternalDataSourceDescription(NYdbProtos::Table::DescribeExternalDataSourceResult&& description)
     : Impl_(std::make_shared<TImpl>(std::move(description)))
 {
 }
 
-const Ydb::Table::DescribeExternalDataSourceResult& TExternalDataSourceDescription::GetProto() const {
+const NYdbProtos::Table::DescribeExternalDataSourceResult& TExternalDataSourceDescription::GetProto() const {
     return Impl_->GetProto();
 }
 
-TDescribeExternalDataSourceResult::TDescribeExternalDataSourceResult(TStatus&& status, Ydb::Table::DescribeExternalDataSourceResult&& description)
+TDescribeExternalDataSourceResult::TDescribeExternalDataSourceResult(TStatus&& status, NYdbProtos::Table::DescribeExternalDataSourceResult&& description)
     : NScheme::TDescribePathResult(std::move(status), description.self())
     , ExternalDataSourceDescription_(std::move(description))
 {}
@@ -3353,28 +3353,28 @@ TExternalDataSourceDescription TDescribeExternalDataSourceResult::GetExternalDat
 ////////////////////////////////////////////////////////////////////////////////
 
 class TExternalTableDescription::TImpl {
-    Ydb::Table::DescribeExternalTableResult Proto_;
+    NYdbProtos::Table::DescribeExternalTableResult Proto_;
 
 public:
-    TImpl(Ydb::Table::DescribeExternalTableResult&& description)
+    TImpl(NYdbProtos::Table::DescribeExternalTableResult&& description)
         : Proto_(std::move(description))
     {}
 
-    const Ydb::Table::DescribeExternalTableResult& GetProto() const {
+    const NYdbProtos::Table::DescribeExternalTableResult& GetProto() const {
         return Proto_;
     }
 };
 
-TExternalTableDescription::TExternalTableDescription(Ydb::Table::DescribeExternalTableResult&& description)
+TExternalTableDescription::TExternalTableDescription(NYdbProtos::Table::DescribeExternalTableResult&& description)
     : Impl_(std::make_shared<TImpl>(std::move(description)))
 {
 }
 
-const Ydb::Table::DescribeExternalTableResult& TExternalTableDescription::GetProto() const {
+const NYdbProtos::Table::DescribeExternalTableResult& TExternalTableDescription::GetProto() const {
     return Impl_->GetProto();
 }
 
-TDescribeExternalTableResult::TDescribeExternalTableResult(TStatus&& status, Ydb::Table::DescribeExternalTableResult&& description)
+TDescribeExternalTableResult::TDescribeExternalTableResult(TStatus&& status, NYdbProtos::Table::DescribeExternalTableResult&& description)
     : NScheme::TDescribePathResult(std::move(status), description.self())
     , ExternalTableDescription_(std::move(description))
 {}

--- a/ydb/public/sdk/cpp/src/client/topic/impl/common.h
+++ b/ydb/public/sdk/cpp/src/client/topic/impl/common.h
@@ -55,8 +55,8 @@ size_t CalcDataSize(const typename TEvent::TEvent& event) {
 
 template <class TMessage>
 bool IsErrorMessage(const TMessage& serverMessage) {
-    const Ydb::StatusIds::StatusCode status = serverMessage.status();
-    return status != Ydb::StatusIds::SUCCESS && status != Ydb::StatusIds::STATUS_CODE_UNSPECIFIED;
+    const NYdbProtos::StatusIds::StatusCode status = serverMessage.status();
+    return status != NYdbProtos::StatusIds::SUCCESS && status != NYdbProtos::StatusIds::STATUS_CODE_UNSPECIFIED;
 }
 
 template <class TMessage>

--- a/ydb/public/sdk/cpp/src/client/topic/impl/read_session_impl.h
+++ b/ydb/public/sdk/cpp/src/client/topic/impl/read_session_impl.h
@@ -34,13 +34,13 @@ namespace NYdb::inline V3::NTopic {
 
 template <bool UseMigrationProtocol>
 using TClientMessage = std::conditional_t<UseMigrationProtocol,
-    Ydb::PersQueue::V1::MigrationStreamingReadClientMessage,
-    Ydb::Topic::StreamReadMessage::FromClient>;
+    NYdbProtos::PersQueue::V1::MigrationStreamingReadClientMessage,
+    NYdbProtos::Topic::StreamReadMessage::FromClient>;
 
 template <bool UseMigrationProtocol>
 using TServerMessage = std::conditional_t<UseMigrationProtocol,
-    Ydb::PersQueue::V1::MigrationStreamingReadServerMessage,
-    Ydb::Topic::StreamReadMessage::FromServer>;
+    NYdbProtos::PersQueue::V1::MigrationStreamingReadServerMessage,
+    NYdbProtos::Topic::StreamReadMessage::FromServer>;
 
 template <bool UseMigrationProtocol>
 using IReadSessionConnectionProcessorFactory =
@@ -51,8 +51,8 @@ using IProcessor = typename IReadSessionConnectionProcessorFactory<UseMigrationP
 
 template <bool UseMigrationProtocol>
 using TPartitionData = std::conditional_t<UseMigrationProtocol,
-    Ydb::PersQueue::V1::MigrationStreamingReadServerMessage::DataBatch::PartitionData,
-    Ydb::Topic::StreamReadMessage::ReadResponse::PartitionData>;
+    NYdbProtos::PersQueue::V1::MigrationStreamingReadServerMessage::DataBatch::PartitionData,
+    NYdbProtos::Topic::StreamReadMessage::ReadResponse::PartitionData>;
 
 template <bool UseMigrationProtocol>
 using TAWriteSessionMeta = std::conditional_t<UseMigrationProtocol,
@@ -1281,7 +1281,7 @@ private:
         typename TSingleClusterReadSessionImpl<UseMigrationProtocol>::TPartitionCookieMapping::TCookie::TPtr CommitOffset(ui64 partitionStreamId, ui64 offset);
 
         // Gets and then removes committed cookie from mapping.
-        typename TSingleClusterReadSessionImpl<UseMigrationProtocol>::TPartitionCookieMapping::TCookie::TPtr RetrieveCommittedCookie(const Ydb::PersQueue::V1::CommitCookie& cookieProto);
+        typename TSingleClusterReadSessionImpl<UseMigrationProtocol>::TPartitionCookieMapping::TCookie::TPtr RetrieveCommittedCookie(const NYdbProtos::PersQueue::V1::CommitCookie& cookieProto);
 
         // Removes mapping on partition stream.
         void RemoveMapping(ui64 partitionStreamId);

--- a/ydb/public/sdk/cpp/src/client/topic/impl/topic.cpp
+++ b/ydb/public/sdk/cpp/src/client/topic/impl/topic.cpp
@@ -20,7 +20,7 @@ public:
 };
 TCommonCodecsProvider COMMON_CODECS_PROVIDER;
 
-TDescribeTopicResult::TDescribeTopicResult(TStatus&& status, Ydb::Topic::DescribeTopicResult&& result)
+TDescribeTopicResult::TDescribeTopicResult(TStatus&& status, NYdbProtos::Topic::DescribeTopicResult&& result)
     : TStatus(std::move(status))
     , TopicDescription_(std::move(result))
 {
@@ -30,7 +30,7 @@ const TTopicDescription& TDescribeTopicResult::GetTopicDescription() const {
     return TopicDescription_;
 }
 
-TDescribeConsumerResult::TDescribeConsumerResult(TStatus&& status, Ydb::Topic::DescribeConsumerResult&& result)
+TDescribeConsumerResult::TDescribeConsumerResult(TStatus&& status, NYdbProtos::Topic::DescribeConsumerResult&& result)
     : TStatus(std::move(status))
     , ConsumerDescription_(std::move(result))
 {
@@ -40,7 +40,7 @@ const TConsumerDescription& TDescribeConsumerResult::GetConsumerDescription() co
     return ConsumerDescription_;
 }
 
-TDescribePartitionResult::TDescribePartitionResult(TStatus&& status, Ydb::Topic::DescribePartitionResult&& result)
+TDescribePartitionResult::TDescribePartitionResult(TStatus&& status, NYdbProtos::Topic::DescribePartitionResult&& result)
     : TStatus(std::move(status))
     , PartitionDescription_(std::move(result))
 {
@@ -50,7 +50,7 @@ const TPartitionDescription& TDescribePartitionResult::GetPartitionDescription()
     return PartitionDescription_;
 }
 
-TTopicDescription::TTopicDescription(Ydb::Topic::DescribeTopicResult&& result)
+TTopicDescription::TTopicDescription(NYdbProtos::Topic::DescribeTopicResult&& result)
     : Proto_(std::move(result))
     , PartitioningSettings_(Proto_.partitioning_settings())
     , RetentionPeriod_(TDuration::Seconds(Proto_.retention_period().seconds()))
@@ -79,7 +79,7 @@ TTopicDescription::TTopicDescription(Ydb::Topic::DescribeTopicResult&& result)
     }
 }
 
-TConsumerDescription::TConsumerDescription(Ydb::Topic::DescribeConsumerResult&& result)
+TConsumerDescription::TConsumerDescription(NYdbProtos::Topic::DescribeConsumerResult&& result)
     : Proto_(std::move(result))
     , Consumer_(Proto_.consumer())
 {
@@ -88,13 +88,13 @@ TConsumerDescription::TConsumerDescription(Ydb::Topic::DescribeConsumerResult&& 
     }
 }
 
-TPartitionDescription::TPartitionDescription(Ydb::Topic::DescribePartitionResult&& result)
+TPartitionDescription::TPartitionDescription(NYdbProtos::Topic::DescribePartitionResult&& result)
     : Proto_(std::move(result))
     , Partition_(Proto_.partition())
 {
 }
 
-TConsumer::TConsumer(const Ydb::Topic::Consumer& consumer)
+TConsumer::TConsumer(const NYdbProtos::Topic::Consumer& consumer)
     : ConsumerName_(consumer.name())
     , Important_(consumer.important())
     , ReadFrom_(TInstant::Seconds(consumer.read_from().seconds()))
@@ -183,7 +183,7 @@ const std::vector<TConsumer>& TTopicDescription::GetConsumers() const {
     return Consumers_;
 }
 
-void TTopicDescription::SerializeTo(Ydb::Topic::CreateTopicRequest& request) const {
+void TTopicDescription::SerializeTo(NYdbProtos::Topic::CreateTopicRequest& request) const {
     *request.mutable_partitioning_settings() = Proto_.partitioning_settings();
     *request.mutable_retention_period() = Proto_.retention_period();
     request.set_retention_storage_mb(Proto_.retention_storage_mb());
@@ -195,15 +195,15 @@ void TTopicDescription::SerializeTo(Ydb::Topic::CreateTopicRequest& request) con
     request.set_metering_mode(Proto_.metering_mode());
 }
 
-const Ydb::Topic::DescribeTopicResult& TTopicDescription::GetProto() const {
+const NYdbProtos::Topic::DescribeTopicResult& TTopicDescription::GetProto() const {
     return Proto_;
 }
 
-const Ydb::Topic::DescribeConsumerResult& TConsumerDescription::GetProto() const {
+const NYdbProtos::Topic::DescribeConsumerResult& TConsumerDescription::GetProto() const {
     return Proto_;
 }
 
-const Ydb::Topic::DescribePartitionResult& TPartitionDescription::GetProto() const {
+const NYdbProtos::Topic::DescribePartitionResult& TPartitionDescription::GetProto() const {
     return Proto_;
 }
 
@@ -227,14 +227,14 @@ const std::vector<NScheme::TPermissions>& TTopicDescription::GetEffectivePermiss
     return EffectivePermissions_;
 }
 
-TPartitioningSettings::TPartitioningSettings(const Ydb::Topic::PartitioningSettings& settings)
+TPartitioningSettings::TPartitioningSettings(const NYdbProtos::Topic::PartitioningSettings& settings)
     : MinActivePartitions_(settings.min_active_partitions())
     , MaxActivePartitions_(settings.max_active_partitions())
     , PartitionCountLimit_(settings.partition_count_limit())
     , AutoPartitioningSettings_(settings.auto_partitioning_settings())
 {}
 
-void TPartitioningSettings::SerializeTo(Ydb::Topic::PartitioningSettings& proto) const {
+void TPartitioningSettings::SerializeTo(NYdbProtos::Topic::PartitioningSettings& proto) const {
     proto.set_min_active_partitions(MinActivePartitions_);
     proto.set_max_active_partitions(MaxActivePartitions_);
     proto.set_partition_count_limit(PartitionCountLimit_);
@@ -257,15 +257,15 @@ TAutoPartitioningSettings TPartitioningSettings::GetAutoPartitioningSettings() c
     return AutoPartitioningSettings_;
 }
 
-TAutoPartitioningSettings::TAutoPartitioningSettings(const Ydb::Topic::AutoPartitioningSettings& settings)
+TAutoPartitioningSettings::TAutoPartitioningSettings(const NYdbProtos::Topic::AutoPartitioningSettings& settings)
     : Strategy_(static_cast<EAutoPartitioningStrategy>(settings.strategy()))
     , StabilizationWindow_(TDuration::Seconds(settings.partition_write_speed().stabilization_window().seconds()))
     , DownUtilizationPercent_(settings.partition_write_speed().down_utilization_percent())
     , UpUtilizationPercent_(settings.partition_write_speed().up_utilization_percent())
 {}
 
-void TAutoPartitioningSettings::SerializeTo(Ydb::Topic::AutoPartitioningSettings& proto) const {
-    proto.set_strategy(static_cast<Ydb::Topic::AutoPartitioningStrategy>(Strategy_));
+void TAutoPartitioningSettings::SerializeTo(NYdbProtos::Topic::AutoPartitioningSettings& proto) const {
+    proto.set_strategy(static_cast<NYdbProtos::Topic::AutoPartitioningStrategy>(Strategy_));
     auto& writeSpeed = *proto.mutable_partition_write_speed();
     writeSpeed.mutable_stabilization_window()->set_seconds(StabilizationWindow_.Seconds());
     writeSpeed.set_down_utilization_percent(DownUtilizationPercent_);
@@ -288,7 +288,7 @@ uint32_t TAutoPartitioningSettings::GetDownUtilizationPercent() const {
     return DownUtilizationPercent_;
 }
 
-TTopicStats::TTopicStats(const Ydb::Topic::DescribeTopicResult::TopicStats& topicStats)
+TTopicStats::TTopicStats(const NYdbProtos::Topic::DescribeTopicResult::TopicStats& topicStats)
     : StoreSizeBytes_(topicStats.store_size_bytes())
     , MinLastWriteTime_(TInstant::Seconds(topicStats.min_last_write_time().seconds()))
     , MaxWriteTimeLag_(TDuration::Seconds(topicStats.max_write_time_lag().seconds()) + TDuration::MicroSeconds(topicStats.max_write_time_lag().nanos() / 1000))
@@ -323,7 +323,7 @@ uint64_t TTopicStats::GetBytesWrittenPerDay() const {
 }
 
 
-TPartitionStats::TPartitionStats(const Ydb::Topic::PartitionStats& partitionStats)
+TPartitionStats::TPartitionStats(const NYdbProtos::Topic::PartitionStats& partitionStats)
     : StartOffset_(partitionStats.partition_offsets().start())
     , EndOffset_(partitionStats.partition_offsets().end())
     , StoreSizeBytes_(partitionStats.store_size_bytes())
@@ -368,7 +368,7 @@ uint64_t TPartitionStats::GetBytesWrittenPerDay() const {
 }
 
 
-TPartitionConsumerStats::TPartitionConsumerStats(const Ydb::Topic::DescribeConsumerResult::PartitionConsumerStats& partitionStats)
+TPartitionConsumerStats::TPartitionConsumerStats(const NYdbProtos::Topic::DescribeConsumerResult::PartitionConsumerStats& partitionStats)
     : CommittedOffset_(partitionStats.committed_offset())
     , LastReadOffset_(partitionStats.last_read_offset())
     , ReaderName_(partitionStats.reader_name())
@@ -406,7 +406,7 @@ const TDuration& TPartitionConsumerStats::GetMaxWriteTimeLag() const {
     return MaxWriteTimeLag_;
 }
 
-TPartitionLocation::TPartitionLocation(const Ydb::Topic::PartitionLocation& partitionLocation)
+TPartitionLocation::TPartitionLocation(const NYdbProtos::Topic::PartitionLocation& partitionLocation)
     : NodeId_(partitionLocation.node_id())
     , Generation_(partitionLocation.generation())
 {
@@ -420,7 +420,7 @@ int64_t TPartitionLocation::GetGeneration() const {
     return Generation_;
 }
 
-TPartitionInfo::TPartitionInfo(const Ydb::Topic::DescribeTopicResult::PartitionInfo& partitionInfo)
+TPartitionInfo::TPartitionInfo(const NYdbProtos::Topic::DescribeTopicResult::PartitionInfo& partitionInfo)
     : PartitionId_(partitionInfo.partition_id())
     , Active_(partitionInfo.active())
     , PartitionStats_()
@@ -450,7 +450,7 @@ TPartitionInfo::TPartitionInfo(const Ydb::Topic::DescribeTopicResult::PartitionI
     }
 }
 
-TPartitionInfo::TPartitionInfo(const Ydb::Topic::DescribeConsumerResult::PartitionInfo& partitionInfo)
+TPartitionInfo::TPartitionInfo(const NYdbProtos::Topic::DescribeConsumerResult::PartitionInfo& partitionInfo)
     : PartitionId_(partitionInfo.partition_id())
     , Active_(partitionInfo.active())
     , PartitionStats_()
@@ -559,15 +559,15 @@ TAsyncStatus TTopicClient::CommitOffset(const std::string& path, uint64_t partit
 
 namespace {
 
-Ydb::Topic::SupportedCodecs SerializeCodecs(const std::vector<ECodec>& codecs) {
-    Ydb::Topic::SupportedCodecs proto;
+NYdbProtos::Topic::SupportedCodecs SerializeCodecs(const std::vector<ECodec>& codecs) {
+    NYdbProtos::Topic::SupportedCodecs proto;
     for (ECodec codec : codecs) {
-        proto.add_codecs(static_cast<Ydb::Topic::Codec>(codec));
+        proto.add_codecs(static_cast<NYdbProtos::Topic::Codec>(codec));
     }
     return proto;
 }
 
-std::vector<ECodec> DeserializeCodecs(const Ydb::Topic::SupportedCodecs& proto) {
+std::vector<ECodec> DeserializeCodecs(const NYdbProtos::Topic::SupportedCodecs& proto) {
     std::vector<ECodec> codecs;
     codecs.reserve(proto.codecs_size());
     for (int codec : proto.codecs()) {
@@ -593,8 +593,8 @@ std::map<std::string, std::string> DeserializeAttributes(const google::protobuf:
 }
 
 template <typename TSettings>
-google::protobuf::RepeatedPtrField<Ydb::Topic::Consumer> SerializeConsumers(const std::vector<TConsumerSettings<TSettings>>& consumers) {
-    google::protobuf::RepeatedPtrField<Ydb::Topic::Consumer> proto;
+google::protobuf::RepeatedPtrField<NYdbProtos::Topic::Consumer> SerializeConsumers(const std::vector<TConsumerSettings<TSettings>>& consumers) {
+    google::protobuf::RepeatedPtrField<NYdbProtos::Topic::Consumer> proto;
     proto.Reserve(consumers.size());
     for (const auto& consumer : consumers) {
         consumer.SerializeTo(*proto.Add());
@@ -603,7 +603,7 @@ google::protobuf::RepeatedPtrField<Ydb::Topic::Consumer> SerializeConsumers(cons
 }
 
 template <typename TSettings>
-std::vector<TConsumerSettings<TSettings>> DeserializeConsumers(TSettings& parent, const google::protobuf::RepeatedPtrField<Ydb::Topic::Consumer>& proto) {
+std::vector<TConsumerSettings<TSettings>> DeserializeConsumers(TSettings& parent, const google::protobuf::RepeatedPtrField<NYdbProtos::Topic::Consumer>& proto) {
     std::vector<TConsumerSettings<TSettings>> consumers;
     consumers.reserve(proto.size());
     for (const auto& consumer : proto) {
@@ -615,7 +615,7 @@ std::vector<TConsumerSettings<TSettings>> DeserializeConsumers(TSettings& parent
 }
 
 template <typename TSettings>
-TConsumerSettings<TSettings>::TConsumerSettings(TSettings& parent, const Ydb::Topic::Consumer& proto)
+TConsumerSettings<TSettings>::TConsumerSettings(TSettings& parent, const NYdbProtos::Topic::Consumer& proto)
     : ConsumerName_(proto.name())
     , Important_(proto.important())
     , ReadFrom_(TInstant::Seconds(proto.read_from().seconds()))
@@ -626,7 +626,7 @@ TConsumerSettings<TSettings>::TConsumerSettings(TSettings& parent, const Ydb::To
 }
 
 template <typename TSettings>
-void TConsumerSettings<TSettings>::SerializeTo(Ydb::Topic::Consumer& proto) const {
+void TConsumerSettings<TSettings>::SerializeTo(NYdbProtos::Topic::Consumer& proto) const {
     proto.set_name(ConsumerName_);
     proto.set_important(Important_);
     proto.mutable_read_from()->set_seconds(ReadFrom_.Seconds());
@@ -637,7 +637,7 @@ void TConsumerSettings<TSettings>::SerializeTo(Ydb::Topic::Consumer& proto) cons
 template struct TConsumerSettings<TCreateTopicSettings>;
 template struct TConsumerSettings<TAlterTopicSettings>;
 
-TCreateTopicSettings::TCreateTopicSettings(const Ydb::Topic::CreateTopicRequest& proto)
+TCreateTopicSettings::TCreateTopicSettings(const NYdbProtos::Topic::CreateTopicRequest& proto)
     : PartitioningSettings_(TPartitioningSettings(proto.partitioning_settings()))
     , RetentionPeriod_(TDuration::Seconds(proto.retention_period().seconds()))
     , SupportedCodecs_(DeserializeCodecs(proto.supported_codecs()))
@@ -650,7 +650,7 @@ TCreateTopicSettings::TCreateTopicSettings(const Ydb::Topic::CreateTopicRequest&
     Consumers_ = DeserializeConsumers(*this, proto.consumers());
 }
 
-void TCreateTopicSettings::SerializeTo(Ydb::Topic::CreateTopicRequest& request) const {
+void TCreateTopicSettings::SerializeTo(NYdbProtos::Topic::CreateTopicRequest& request) const {
     PartitioningSettings_.SerializeTo(*request.mutable_partitioning_settings());
     request.mutable_retention_period()->set_seconds(RetentionPeriod_.Seconds());
     *request.mutable_supported_codecs() = SerializeCodecs(SupportedCodecs_);

--- a/ydb/public/sdk/cpp/src/client/topic/impl/topic_impl.cpp
+++ b/ydb/public/sdk/cpp/src/client/topic/impl/topic_impl.cpp
@@ -62,16 +62,16 @@ std::shared_ptr<ISimpleBlockingWriteSession> TTopicClient::TImpl::CreateSimpleWr
 }
 
 std::shared_ptr<TTopicClient::TImpl::IReadSessionConnectionProcessorFactory> TTopicClient::TImpl::CreateReadSessionConnectionProcessorFactory() {
-    using TService = Ydb::Topic::V1::TopicService;
-    using TRequest = Ydb::Topic::StreamReadMessage::FromClient;
-    using TResponse = Ydb::Topic::StreamReadMessage::FromServer;
+    using TService = NYdbProtos::Topic::V1::TopicService;
+    using TRequest = NYdbProtos::Topic::StreamReadMessage::FromClient;
+    using TResponse = NYdbProtos::Topic::StreamReadMessage::FromServer;
     return CreateConnectionProcessorFactory<TService, TRequest, TResponse>(&TService::Stub::AsyncStreamRead, Connections_, DbDriverState_);
 }
 
 std::shared_ptr<TTopicClient::TImpl::IWriteSessionConnectionProcessorFactory> TTopicClient::TImpl::CreateWriteSessionConnectionProcessorFactory() {
-    using TService = Ydb::Topic::V1::TopicService;
-    using TRequest = Ydb::Topic::StreamWriteMessage::FromClient;
-    using TResponse = Ydb::Topic::StreamWriteMessage::FromServer;
+    using TService = NYdbProtos::Topic::V1::TopicService;
+    using TRequest = NYdbProtos::Topic::StreamWriteMessage::FromClient;
+    using TResponse = NYdbProtos::Topic::StreamWriteMessage::FromServer;
     return CreateConnectionProcessorFactory<TService, TRequest, TResponse>(&TService::Stub::AsyncStreamWrite, Connections_, DbDriverState_);
 }
 

--- a/ydb/public/sdk/cpp/src/client/topic/impl/topic_impl.h
+++ b/ydb/public/sdk/cpp/src/client/topic/impl/topic_impl.h
@@ -42,7 +42,7 @@ public:
     {
     }
 
-    static void ConvertAlterConsumerToProto(const TAlterConsumerSettings& settings, Ydb::Topic::AlterConsumer& consumerProto) {
+    static void ConvertAlterConsumerToProto(const TAlterConsumerSettings& settings, NYdbProtos::Topic::AlterConsumer& consumerProto) {
         consumerProto.set_name(TStringType{settings.ConsumerName_});
         if (settings.SetImportant_)
             consumerProto.set_set_important(*settings.SetImportant_);
@@ -51,7 +51,7 @@ public:
 
         if (settings.SetSupportedCodecs_) {
             for (const auto& codec : *settings.SetSupportedCodecs_) {
-                consumerProto.mutable_set_supported_codecs()->add_codecs((static_cast<Ydb::Topic::Codec>(codec)));
+                consumerProto.mutable_set_supported_codecs()->add_codecs((static_cast<NYdbProtos::Topic::Codec>(codec)));
             }
         }
 
@@ -61,8 +61,8 @@ public:
     }
 
 
-    static Ydb::Topic::CreateTopicRequest MakePropsCreateRequest(const std::string& path, const TCreateTopicSettings& settings) {
-        Ydb::Topic::CreateTopicRequest request = MakeOperationRequest<Ydb::Topic::CreateTopicRequest>(settings);
+    static NYdbProtos::Topic::CreateTopicRequest MakePropsCreateRequest(const std::string& path, const TCreateTopicSettings& settings) {
+        NYdbProtos::Topic::CreateTopicRequest request = MakeOperationRequest<NYdbProtos::Topic::CreateTopicRequest>(settings);
         request.set_path(TStringType{path});
         settings.SerializeTo(request);
         return request;
@@ -71,15 +71,15 @@ public:
     TAsyncStatus CreateTopic(const std::string& path, const TCreateTopicSettings& settings) {
         auto request = MakePropsCreateRequest(path, settings);
 
-        return RunSimple<Ydb::Topic::V1::TopicService, Ydb::Topic::CreateTopicRequest, Ydb::Topic::CreateTopicResponse>(
+        return RunSimple<NYdbProtos::Topic::V1::TopicService, NYdbProtos::Topic::CreateTopicRequest, NYdbProtos::Topic::CreateTopicResponse>(
             std::move(request),
-            &Ydb::Topic::V1::TopicService::Stub::AsyncCreateTopic,
+            &NYdbProtos::Topic::V1::TopicService::Stub::AsyncCreateTopic,
             TRpcRequestSettings::Make(settings));
     }
 
 
-    static Ydb::Topic::AlterTopicRequest MakePropsAlterRequest(const std::string& path, const TAlterTopicSettings& settings) {
-        Ydb::Topic::AlterTopicRequest request = MakeOperationRequest<Ydb::Topic::AlterTopicRequest>(settings);
+    static NYdbProtos::Topic::AlterTopicRequest MakePropsAlterRequest(const std::string& path, const TAlterTopicSettings& settings) {
+        NYdbProtos::Topic::AlterTopicRequest request = MakeOperationRequest<NYdbProtos::Topic::AlterTopicRequest>(settings);
         request.set_path(TStringType{path});
 
         if (settings.AlterPartitioningSettings_) {
@@ -91,7 +91,7 @@ public:
             }
             if (settings.AlterPartitioningSettings_->AutoPartitioningSettings_) {
                 if (settings.AlterPartitioningSettings_->AutoPartitioningSettings_->Strategy_) {
-                    request.mutable_alter_partitioning_settings()->mutable_alter_auto_partitioning_settings()->set_set_strategy(static_cast<Ydb::Topic::AutoPartitioningStrategy>(*settings.AlterPartitioningSettings_->AutoPartitioningSettings_->Strategy_));
+                    request.mutable_alter_partitioning_settings()->mutable_alter_auto_partitioning_settings()->set_set_strategy(static_cast<NYdbProtos::Topic::AutoPartitioningStrategy>(*settings.AlterPartitioningSettings_->AutoPartitioningSettings_->Strategy_));
                 }
                 if (settings.AlterPartitioningSettings_->AutoPartitioningSettings_->DownUtilizationPercent_) {
                     request.mutable_alter_partitioning_settings()->mutable_alter_auto_partitioning_settings()->mutable_set_partition_write_speed()->set_set_down_utilization_percent(*settings.AlterPartitioningSettings_->AutoPartitioningSettings_->DownUtilizationPercent_);
@@ -109,7 +109,7 @@ public:
         }
         if (settings.SetSupportedCodecs_) {
             for (const auto& codec : *settings.SetSupportedCodecs_) {
-                request.mutable_set_supported_codecs()->add_codecs((static_cast<Ydb::Topic::Codec>(codec)));
+                request.mutable_set_supported_codecs()->add_codecs((static_cast<NYdbProtos::Topic::Codec>(codec)));
             }
         }
         if (settings.SetPartitionWriteSpeedBytesPerSecond_) {
@@ -138,7 +138,7 @@ public:
         }
 
         for (const auto& consumer : settings.AlterConsumers_) {
-            Ydb::Topic::AlterConsumer& consumerProto = *request.add_alter_consumers();
+            NYdbProtos::Topic::AlterConsumer& consumerProto = *request.add_alter_consumers();
             ConvertAlterConsumerToProto(consumer, consumerProto);
         }
 
@@ -149,25 +149,25 @@ public:
     TAsyncStatus AlterTopic(const std::string& path, const TAlterTopicSettings& settings) {
         auto request = MakePropsAlterRequest(path, settings);
 
-        return RunSimple<Ydb::Topic::V1::TopicService, Ydb::Topic::AlterTopicRequest, Ydb::Topic::AlterTopicResponse>(
+        return RunSimple<NYdbProtos::Topic::V1::TopicService, NYdbProtos::Topic::AlterTopicRequest, NYdbProtos::Topic::AlterTopicResponse>(
             std::move(request),
-            &Ydb::Topic::V1::TopicService::Stub::AsyncAlterTopic,
+            &NYdbProtos::Topic::V1::TopicService::Stub::AsyncAlterTopic,
             TRpcRequestSettings::Make(settings));
     }
 
 
     TAsyncStatus DropTopic(const std::string& path, const TDropTopicSettings& settings) {
-        auto request = MakeOperationRequest<Ydb::Topic::DropTopicRequest>(settings);
+        auto request = MakeOperationRequest<NYdbProtos::Topic::DropTopicRequest>(settings);
         request.set_path(TStringType{path});
 
-        return RunSimple<Ydb::Topic::V1::TopicService, Ydb::Topic::DropTopicRequest, Ydb::Topic::DropTopicResponse>(
+        return RunSimple<NYdbProtos::Topic::V1::TopicService, NYdbProtos::Topic::DropTopicRequest, NYdbProtos::Topic::DropTopicResponse>(
             std::move(request),
-            &Ydb::Topic::V1::TopicService::Stub::AsyncDropTopic,
+            &NYdbProtos::Topic::V1::TopicService::Stub::AsyncDropTopic,
             TRpcRequestSettings::Make(settings));
     }
 
     TAsyncDescribeTopicResult DescribeTopic(const std::string& path, const TDescribeTopicSettings& settings) {
-        auto request = MakeOperationRequest<Ydb::Topic::DescribeTopicRequest>(settings);
+        auto request = MakeOperationRequest<NYdbProtos::Topic::DescribeTopicRequest>(settings);
         request.set_path(TStringType{path});
 
         if (settings.IncludeStats_) {
@@ -182,7 +182,7 @@ public:
 
         auto extractor = [promise]
             (google::protobuf::Any* any, TPlainStatus status) mutable {
-                Ydb::Topic::DescribeTopicResult result;
+                NYdbProtos::Topic::DescribeTopicResult result;
                 if (any) {
                     any->UnpackTo(&result);
                 }
@@ -191,10 +191,10 @@ public:
                 promise.SetValue(std::move(val));
             };
 
-        Connections_->RunDeferred<Ydb::Topic::V1::TopicService, Ydb::Topic::DescribeTopicRequest, Ydb::Topic::DescribeTopicResponse>(
+        Connections_->RunDeferred<NYdbProtos::Topic::V1::TopicService, NYdbProtos::Topic::DescribeTopicRequest, NYdbProtos::Topic::DescribeTopicResponse>(
             std::move(request),
             extractor,
-            &Ydb::Topic::V1::TopicService::Stub::AsyncDescribeTopic,
+            &NYdbProtos::Topic::V1::TopicService::Stub::AsyncDescribeTopic,
             DbDriverState_,
             INITIAL_DEFERRED_CALL_DELAY,
             TRpcRequestSettings::Make(settings));
@@ -203,7 +203,7 @@ public:
     }
 
     TAsyncDescribeConsumerResult DescribeConsumer(const std::string& path, const std::string& consumer, const TDescribeConsumerSettings& settings) {
-        auto request = MakeOperationRequest<Ydb::Topic::DescribeConsumerRequest>(settings);
+        auto request = MakeOperationRequest<NYdbProtos::Topic::DescribeConsumerRequest>(settings);
         request.set_path(TStringType{path});
         request.set_consumer(TStringType{consumer});
 
@@ -219,7 +219,7 @@ public:
 
         auto extractor = [promise]
             (google::protobuf::Any* any, TPlainStatus status) mutable {
-                Ydb::Topic::DescribeConsumerResult result;
+                NYdbProtos::Topic::DescribeConsumerResult result;
                 if (any) {
                     any->UnpackTo(&result);
                 }
@@ -228,10 +228,10 @@ public:
                 promise.SetValue(std::move(val));
             };
 
-        Connections_->RunDeferred<Ydb::Topic::V1::TopicService, Ydb::Topic::DescribeConsumerRequest, Ydb::Topic::DescribeConsumerResponse>(
+        Connections_->RunDeferred<NYdbProtos::Topic::V1::TopicService, NYdbProtos::Topic::DescribeConsumerRequest, NYdbProtos::Topic::DescribeConsumerResponse>(
             std::move(request),
             extractor,
-            &Ydb::Topic::V1::TopicService::Stub::AsyncDescribeConsumer,
+            &NYdbProtos::Topic::V1::TopicService::Stub::AsyncDescribeConsumer,
             DbDriverState_,
             INITIAL_DEFERRED_CALL_DELAY,
             TRpcRequestSettings::Make(settings));
@@ -240,7 +240,7 @@ public:
     }
 
     TAsyncDescribePartitionResult DescribePartition(const std::string& path, i64 partitionId, const TDescribePartitionSettings& settings) {
-        auto request = MakeOperationRequest<Ydb::Topic::DescribePartitionRequest>(settings);
+        auto request = MakeOperationRequest<NYdbProtos::Topic::DescribePartitionRequest>(settings);
         request.set_path(TStringType{path});
         request.set_partition_id(partitionId);
 
@@ -255,7 +255,7 @@ public:
         auto promise = NThreading::NewPromise<TDescribePartitionResult>();
 
         auto extractor = [promise](google::protobuf::Any* any, TPlainStatus status) mutable {
-            Ydb::Topic::DescribePartitionResult result;
+            NYdbProtos::Topic::DescribePartitionResult result;
             if (any) {
                 any->UnpackTo(&result);
             }
@@ -264,10 +264,10 @@ public:
             promise.SetValue(std::move(val));
         };
 
-        Connections_->RunDeferred<Ydb::Topic::V1::TopicService, Ydb::Topic::DescribePartitionRequest, Ydb::Topic::DescribePartitionResponse>(
+        Connections_->RunDeferred<NYdbProtos::Topic::V1::TopicService, NYdbProtos::Topic::DescribePartitionRequest, NYdbProtos::Topic::DescribePartitionResponse>(
             std::move(request),
             extractor,
-            &Ydb::Topic::V1::TopicService::Stub::AsyncDescribePartition,
+            &NYdbProtos::Topic::V1::TopicService::Stub::AsyncDescribePartition,
             DbDriverState_,
             INITIAL_DEFERRED_CALL_DELAY,
             TRpcRequestSettings::Make(settings));
@@ -277,15 +277,15 @@ public:
 
     TAsyncStatus CommitOffset(const std::string& path, ui64 partitionId, const std::string& consumerName, ui64 offset,
         const TCommitOffsetSettings& settings) {
-        Ydb::Topic::CommitOffsetRequest request = MakeOperationRequest<Ydb::Topic::CommitOffsetRequest>(settings);
+        NYdbProtos::Topic::CommitOffsetRequest request = MakeOperationRequest<NYdbProtos::Topic::CommitOffsetRequest>(settings);
         request.set_path(TStringType{path});
         request.set_partition_id(partitionId);
         request.set_consumer(TStringType{consumerName});
         request.set_offset(offset);
 
-        return RunSimple<Ydb::Topic::V1::TopicService, Ydb::Topic::CommitOffsetRequest, Ydb::Topic::CommitOffsetResponse>(
+        return RunSimple<NYdbProtos::Topic::V1::TopicService, NYdbProtos::Topic::CommitOffsetRequest, NYdbProtos::Topic::CommitOffsetResponse>(
             std::move(request),
-            &Ydb::Topic::V1::TopicService::Stub::AsyncCommitOffset,
+            &NYdbProtos::Topic::V1::TopicService::Stub::AsyncCommitOffset,
             TRpcRequestSettings::Make(settings));
     }
 
@@ -294,7 +294,7 @@ public:
                                             const std::string& consumerName,
                                             const TUpdateOffsetsInTransactionSettings& settings)
     {
-        auto request = MakeOperationRequest<Ydb::Topic::UpdateOffsetsInTransactionRequest>(settings);
+        auto request = MakeOperationRequest<NYdbProtos::Topic::UpdateOffsetsInTransactionRequest>(settings);
 
         request.mutable_tx()->set_id(TStringType{GetTxId(tx)});
         request.mutable_tx()->set_session(TStringType{GetSessionId(tx)});
@@ -317,9 +317,9 @@ public:
 
         request.set_consumer(TStringType{consumerName});
 
-        return RunSimple<Ydb::Topic::V1::TopicService, Ydb::Topic::UpdateOffsetsInTransactionRequest, Ydb::Topic::UpdateOffsetsInTransactionResponse>(
+        return RunSimple<NYdbProtos::Topic::V1::TopicService, NYdbProtos::Topic::UpdateOffsetsInTransactionRequest, NYdbProtos::Topic::UpdateOffsetsInTransactionResponse>(
             std::move(request),
-            &Ydb::Topic::V1::TopicService::Stub::AsyncUpdateOffsetsInTransaction,
+            &NYdbProtos::Topic::V1::TopicService::Stub::AsyncUpdateOffsetsInTransaction,
             TRpcRequestSettings::Make(settings)
         );
     }
@@ -330,14 +330,14 @@ public:
     std::shared_ptr<IWriteSession> CreateWriteSession(const TWriteSessionSettings& settings);
 
     using IReadSessionConnectionProcessorFactory =
-        ISessionConnectionProcessorFactory<Ydb::Topic::StreamReadMessage::FromClient,
-                                           Ydb::Topic::StreamReadMessage::FromServer>;
+        ISessionConnectionProcessorFactory<NYdbProtos::Topic::StreamReadMessage::FromClient,
+                                           NYdbProtos::Topic::StreamReadMessage::FromServer>;
 
     std::shared_ptr<IReadSessionConnectionProcessorFactory> CreateReadSessionConnectionProcessorFactory();
 
     using IWriteSessionConnectionProcessorFactory =
-        ISessionConnectionProcessorFactory<Ydb::Topic::StreamWriteMessage::FromClient,
-                                           Ydb::Topic::StreamWriteMessage::FromServer>;
+        ISessionConnectionProcessorFactory<NYdbProtos::Topic::StreamWriteMessage::FromClient,
+                                           NYdbProtos::Topic::StreamWriteMessage::FromServer>;
 
     std::shared_ptr<IWriteSessionConnectionProcessorFactory> CreateWriteSessionConnectionProcessorFactory();
 

--- a/ydb/public/sdk/cpp/src/client/topic/impl/write_session_impl.h
+++ b/ydb/public/sdk/cpp/src/client/topic/impl/write_session_impl.h
@@ -151,8 +151,8 @@ private:
     friend class TSimpleBlockingWriteSession;
 
 private:
-    using TClientMessage = Ydb::Topic::StreamWriteMessage::FromClient;
-    using TServerMessage = Ydb::Topic::StreamWriteMessage::FromServer;
+    using TClientMessage = NYdbProtos::Topic::StreamWriteMessage::FromClient;
+    using TServerMessage = NYdbProtos::Topic::StreamWriteMessage::FromServer;
     using IWriteSessionConnectionProcessorFactory =
             TTopicClient::TImpl::IWriteSessionConnectionProcessorFactory;
     using IProcessor = IWriteSessionConnectionProcessorFactory::IProcessor;
@@ -419,11 +419,11 @@ private:
     void UpdateTimedCountersImpl();
 
     void ConnectToPreferredPartitionLocation(const TDuration& delay);
-    void OnDescribePartition(const TStatus& status, const Ydb::Topic::DescribePartitionResult& proto, const NYdbGrpc::IQueueClientContextPtr& describePartitionContext);
+    void OnDescribePartition(const TStatus& status, const NYdbProtos::Topic::DescribePartitionResult& proto, const NYdbGrpc::IQueueClientContextPtr& describePartitionContext);
 
     std::optional<TEndpointKey> GetPreferredEndpointImpl(ui32 partitionId, uint64_t partitionNodeId);
 
-    bool TxIsChanged(const Ydb::Topic::StreamWriteMessage_WriteRequest* writeRequest) const;
+    bool TxIsChanged(const NYdbProtos::Topic::StreamWriteMessage_WriteRequest* writeRequest) const;
 
     void TrySubscribeOnTransactionCommit(TTransaction* tx);
     void CancelTransactions();

--- a/ydb/public/sdk/cpp/src/client/topic/proto_accessor.cpp
+++ b/ydb/public/sdk/cpp/src/client/topic/proto_accessor.cpp
@@ -1,34 +1,34 @@
 #include <ydb-cpp-sdk/client/proto/accessor.h>
 
 namespace NYdb::inline V3 {
-    const Ydb::Topic::DescribeTopicResult& TProtoAccessor::GetProto(const NTopic::TTopicDescription& topicDescription) {
+    const NYdbProtos::Topic::DescribeTopicResult& TProtoAccessor::GetProto(const NTopic::TTopicDescription& topicDescription) {
         return topicDescription.GetProto();
     }
 
-    const Ydb::Topic::DescribeConsumerResult& TProtoAccessor::GetProto(const NTopic::TConsumerDescription& consumerDescription) {
+    const NYdbProtos::Topic::DescribeConsumerResult& TProtoAccessor::GetProto(const NTopic::TConsumerDescription& consumerDescription) {
         return consumerDescription.GetProto();
     }
 
-    Ydb::Topic::MeteringMode TProtoAccessor::GetProto(NTopic::EMeteringMode mode) {
+    NYdbProtos::Topic::MeteringMode TProtoAccessor::GetProto(NTopic::EMeteringMode mode) {
         switch (mode) {
         case NTopic::EMeteringMode::Unspecified:
-            return Ydb::Topic::METERING_MODE_UNSPECIFIED;
+            return NYdbProtos::Topic::METERING_MODE_UNSPECIFIED;
         case NTopic::EMeteringMode::RequestUnits:
-            return Ydb::Topic::METERING_MODE_REQUEST_UNITS;
+            return NYdbProtos::Topic::METERING_MODE_REQUEST_UNITS;
         case NTopic::EMeteringMode::ReservedCapacity:
-            return Ydb::Topic::METERING_MODE_RESERVED_CAPACITY;
+            return NYdbProtos::Topic::METERING_MODE_RESERVED_CAPACITY;
         case NTopic::EMeteringMode::Unknown:
-            return Ydb::Topic::METERING_MODE_UNSPECIFIED;
+            return NYdbProtos::Topic::METERING_MODE_UNSPECIFIED;
         }
     }
 
-    NTopic::EMeteringMode TProtoAccessor::FromProto(Ydb::Topic::MeteringMode mode) {
+    NTopic::EMeteringMode TProtoAccessor::FromProto(NYdbProtos::Topic::MeteringMode mode) {
         switch (mode) {
-        case Ydb::Topic::MeteringMode::METERING_MODE_UNSPECIFIED:
+        case NYdbProtos::Topic::MeteringMode::METERING_MODE_UNSPECIFIED:
             return NTopic::EMeteringMode::Unspecified;
-        case Ydb::Topic::MeteringMode::METERING_MODE_REQUEST_UNITS:
+        case NYdbProtos::Topic::MeteringMode::METERING_MODE_REQUEST_UNITS:
             return NTopic::EMeteringMode::RequestUnits;
-        case Ydb::Topic::MeteringMode::METERING_MODE_RESERVED_CAPACITY:
+        case NYdbProtos::Topic::MeteringMode::METERING_MODE_RESERVED_CAPACITY:
             return NTopic::EMeteringMode::ReservedCapacity;
         default:
             return NTopic::EMeteringMode::Unknown;

--- a/ydb/public/sdk/cpp/src/client/topic/ut/describe_topic_ut.cpp
+++ b/ydb/public/sdk/cpp/src/client/topic/ut/describe_topic_ut.cpp
@@ -407,11 +407,11 @@ namespace NYdb::NTopic::NTests {
             };
 
             std::vector<Expectation> expectations{
-                {0, 0, 0, EStatus::SCHEME_ERROR, Ydb::PersQueue::ErrorCode::ACCESS_DENIED},
-                {0, 0, 1, EStatus::SCHEME_ERROR, Ydb::PersQueue::ErrorCode::ACCESS_DENIED},
-                {0, 1, 0, EStatus::SCHEME_ERROR, Ydb::PersQueue::ErrorCode::ACCESS_DENIED},
-                {0, 1, 1, EStatus::SCHEME_ERROR, Ydb::PersQueue::ErrorCode::ACCESS_DENIED},
-                {1, 0, 0, EStatus::SCHEME_ERROR, Ydb::PersQueue::ErrorCode::ACCESS_DENIED},
+                {0, 0, 0, EStatus::SCHEME_ERROR, NYdbProtos::PersQueue::ErrorCode::ACCESS_DENIED},
+                {0, 0, 1, EStatus::SCHEME_ERROR, NYdbProtos::PersQueue::ErrorCode::ACCESS_DENIED},
+                {0, 1, 0, EStatus::SCHEME_ERROR, NYdbProtos::PersQueue::ErrorCode::ACCESS_DENIED},
+                {0, 1, 1, EStatus::SCHEME_ERROR, NYdbProtos::PersQueue::ErrorCode::ACCESS_DENIED},
+                {1, 0, 0, EStatus::SCHEME_ERROR, NYdbProtos::PersQueue::ErrorCode::ACCESS_DENIED},
                 {1, 0, 1, EStatus::SUCCESS, 0},
                 {1, 1, 0, EStatus::SUCCESS, 0},
                 {1, 1, 1, EStatus::SUCCESS, 0},

--- a/ydb/public/sdk/cpp/src/client/topic/ut/local_partition_ut.cpp
+++ b/ydb/public/sdk/cpp/src/client/topic/ut/local_partition_ut.cpp
@@ -116,7 +116,7 @@ namespace NYdb::NTopic::NTests {
             return builder.BuildAndStart();
         }
 
-        class TMockDiscoveryService: public Ydb::Discovery::V1::DiscoveryService::Service {
+        class TMockDiscoveryService: public NYdbProtos::Discovery::V1::DiscoveryService::Service {
         public:
             TMockDiscoveryService()
             {
@@ -141,14 +141,14 @@ namespace NYdb::NTopic::NTests {
                 MockResults.clear_endpoints();
                 if (nodeCount > 0)
                 {
-                    Ydb::Discovery::EndpointInfo* endpoint = MockResults.add_endpoints();
+                    NYdbProtos::Discovery::EndpointInfo* endpoint = MockResults.add_endpoints();
                     endpoint->set_address(TStringBuilder() << "localhost");
                     endpoint->set_port(port);
                     endpoint->set_node_id(firstNodeId);
                 }
                 if (nodeCount > 1)
                 {
-                    Ydb::Discovery::EndpointInfo* endpoint = MockResults.add_endpoints();
+                    NYdbProtos::Discovery::EndpointInfo* endpoint = MockResults.add_endpoints();
                     endpoint->set_address(TStringBuilder() << "ip6-localhost"); // name should be different
                     endpoint->set_port(port);
                     endpoint->set_node_id(firstNodeId + 1);
@@ -164,7 +164,7 @@ namespace NYdb::NTopic::NTests {
                 SetEndpointsLocked(firstNodeId, nodeCount, port);
             }
 
-            grpc::Status ListEndpoints(grpc::ServerContext* context, const Ydb::Discovery::ListEndpointsRequest* request, Ydb::Discovery::ListEndpointsResponse* response) override {
+            grpc::Status ListEndpoints(grpc::ServerContext* context, const NYdbProtos::Discovery::ListEndpointsRequest* request, NYdbProtos::Discovery::ListEndpointsResponse* response) override {
                 std::lock_guard lock(Lock);
                 UNIT_ASSERT(context);
 
@@ -184,7 +184,7 @@ namespace NYdb::NTopic::NTests {
 
                 auto* op = response->mutable_operation();
                 op->set_ready(true);
-                op->set_status(Ydb::StatusIds::SUCCESS);
+                op->set_status(NYdbProtos::StatusIds::SUCCESS);
                 op->mutable_result()->PackFrom(MockResults);
 
                 Cerr << "==== ListEndpoints response: " << response->ShortDebugString() << Endl;
@@ -201,7 +201,7 @@ namespace NYdb::NTopic::NTests {
             }
 
         private:
-            Ydb::Discovery::ListEndpointsResult MockResults;
+            NYdbProtos::Discovery::ListEndpointsResult MockResults;
             TString DiscoveryAddr;
             std::unique_ptr<grpc::Server> Server;
             TAdaptiveLock Lock;

--- a/ydb/public/sdk/cpp/src/client/types/operation/operation.cpp
+++ b/ydb/public/sdk/cpp/src/client/types/operation/operation.cpp
@@ -17,7 +17,7 @@ public:
         , Ready_(true)
     { }
 
-    TImpl(TStatus&& status, Ydb::Operations::Operation&& operation)
+    TImpl(TStatus&& status, NYdbProtos::Operations::Operation&& operation)
         : Id_(operation.id(), true /* allowEmpty */)
         , Status_(std::move(status))
         , Ready_(operation.ready())
@@ -51,7 +51,7 @@ public:
         return CreatedBy_;
     }
 
-    const Ydb::Operations::Operation& GetProto() const {
+    const NYdbProtos::Operations::Operation& GetProto() const {
         return Operation_;
     }
 
@@ -62,14 +62,14 @@ private:
     const TInstant CreateTime_;
     const TInstant EndTime_;
     const std::string CreatedBy_;
-    const Ydb::Operations::Operation Operation_;
+    const NYdbProtos::Operations::Operation Operation_;
 };
 
 TOperation::TOperation(TStatus&& status)
     : Impl_(std::make_shared<TImpl>(std::move(status)))
 { }
 
-TOperation::TOperation(TStatus&& status, Ydb::Operations::Operation&& operation)
+TOperation::TOperation(TStatus&& status, NYdbProtos::Operations::Operation&& operation)
     : Impl_(std::make_shared<TImpl>(std::move(status), std::move(operation)))
 { }
 
@@ -117,7 +117,7 @@ std::string TOperation::ToJsonString() const {
     return json;
 }
 
-const Ydb::Operations::Operation& TOperation::GetProto() const {
+const NYdbProtos::Operations::Operation& TOperation::GetProto() const {
     return Impl_->GetProto();
 }
 

--- a/ydb/public/sdk/cpp/src/library/issue/yql_issue_message.cpp
+++ b/ydb/public/sdk/cpp/src/library/issue/yql_issue_message.cpp
@@ -10,9 +10,9 @@
 
 namespace NYdb::NIssue {
 
-TIssue IssueFromMessage(const Ydb::Issue::IssueMessage& issueMessage) {
+TIssue IssueFromMessage(const NYdbProtos::Issue::IssueMessage& issueMessage) {
     TIssue topIssue;
-    std::deque<std::pair<TIssue*, const Ydb::Issue::IssueMessage*>> queue;
+    std::deque<std::pair<TIssue*, const NYdbProtos::Issue::IssueMessage*>> queue;
     queue.push_front(std::make_pair(&topIssue, &issueMessage));
     while (!queue.empty()) {
         TIssue& issue = *queue.back().first;
@@ -41,7 +41,7 @@ TIssue IssueFromMessage(const Ydb::Issue::IssueMessage& issueMessage) {
     return topIssue;
 }
 
-void IssuesFromMessage(const ::google::protobuf::RepeatedPtrField<Ydb::Issue::IssueMessage> &message, TIssues &issues) {
+void IssuesFromMessage(const ::google::protobuf::RepeatedPtrField<NYdbProtos::Issue::IssueMessage> &message, TIssues &issues) {
     issues.Clear();
     if (message.size()) {
         issues.Reserve(message.size());
@@ -51,8 +51,8 @@ void IssuesFromMessage(const ::google::protobuf::RepeatedPtrField<Ydb::Issue::Is
     }
 }
 
-void IssueToMessage(const TIssue& topIssue, Ydb::Issue::IssueMessage* issueMessage) {
-    std::deque<std::pair<const TIssue*, Ydb::Issue::IssueMessage*>> queue;
+void IssueToMessage(const TIssue& topIssue, NYdbProtos::Issue::IssueMessage* issueMessage) {
+    std::deque<std::pair<const TIssue*, NYdbProtos::Issue::IssueMessage*>> queue;
     queue.push_front(std::make_pair(&topIssue, issueMessage));
     while (!queue.empty()) {
         const TIssue& issue = *queue.back().first;
@@ -74,13 +74,13 @@ void IssueToMessage(const TIssue& topIssue, Ydb::Issue::IssueMessage* issueMessa
         message.set_severity(static_cast<uint32_t>(issue.GetSeverity()));
 
         for (auto subIssue : issue.GetSubIssues()) {
-            Ydb::Issue::IssueMessage* subMessage = message.add_issues();
+            NYdbProtos::Issue::IssueMessage* subMessage = message.add_issues();
             queue.push_front(std::make_pair(subIssue.Get(), subMessage));
         }
     }
 }
 
-void IssuesToMessage(const TIssues& issues, ::google::protobuf::RepeatedPtrField<Ydb::Issue::IssueMessage> *message) {
+void IssuesToMessage(const TIssues& issues, ::google::protobuf::RepeatedPtrField<NYdbProtos::Issue::IssueMessage> *message) {
     message->Clear();
     if (!issues)
         return;

--- a/ydb/public/sdk/cpp/src/library/issue/yql_issue_message.h
+++ b/ydb/public/sdk/cpp/src/library/issue/yql_issue_message.h
@@ -1,15 +1,16 @@
 #pragma once
 
 #include <ydb-cpp-sdk/library/issue/yql_issue.h>
+#include <ydb-cpp-sdk/type_switcher.h>
 
 #include <ydb/public/api/protos/ydb_issue_message.pb.h>
 
 namespace NYdb::NIssue {
 
-TIssue IssueFromMessage(const Ydb::Issue::IssueMessage& issueMessage);
-void IssuesFromMessage(const ::google::protobuf::RepeatedPtrField<Ydb::Issue::IssueMessage>& message, TIssues& issues);
+TIssue IssueFromMessage(const NYdbProtos::Issue::IssueMessage& issueMessage);
+void IssuesFromMessage(const ::google::protobuf::RepeatedPtrField<NYdbProtos::Issue::IssueMessage>& message, TIssues& issues);
 
-void IssueToMessage(const TIssue& topIssue, Ydb::Issue::IssueMessage* message);
-void IssuesToMessage(const TIssues& issues, ::google::protobuf::RepeatedPtrField<Ydb::Issue::IssueMessage>* message);
+void IssueToMessage(const TIssue& topIssue, NYdbProtos::Issue::IssueMessage* message);
+void IssuesToMessage(const TIssues& issues, ::google::protobuf::RepeatedPtrField<NYdbProtos::Issue::IssueMessage>* message);
 
 }

--- a/ydb/public/sdk/cpp/src/library/operation_id/operation_id.cpp
+++ b/ydb/public/sdk/cpp/src/library/operation_id/operation_id.cpp
@@ -31,36 +31,36 @@ bool DecodePreparedQueryIdCompat(const std::string& in, std::string& out) {
     return false;
 }
 
-std::string ProtoToString(const Ydb::TOperationId& proto) {
+std::string ProtoToString(const NYdbProtos::TOperationId& proto) {
     using namespace ::google::protobuf;
     const Reflection& reflection = *proto.GetReflection();
     std::vector<const FieldDescriptor*> fields;
     reflection.ListFields(proto, &fields);
     TStringStream res;
     switch (proto.kind()) {
-        case Ydb::TOperationId::OPERATION_DDL:
-        case Ydb::TOperationId::OPERATION_DML:
+        case NYdbProtos::TOperationId::OPERATION_DDL:
+        case NYdbProtos::TOperationId::OPERATION_DML:
             res << "ydb://operation";
             break;
-        case Ydb::TOperationId::SESSION_YQL:
+        case NYdbProtos::TOperationId::SESSION_YQL:
             res << "ydb://session";
             break;
-        case Ydb::TOperationId::PREPARED_QUERY_ID:
+        case NYdbProtos::TOperationId::PREPARED_QUERY_ID:
             res << "ydb://preparedqueryid";
             break;
-        case Ydb::TOperationId::CMS_REQUEST:
+        case NYdbProtos::TOperationId::CMS_REQUEST:
             res << "ydb://cmsrequest";
             break;
-        case Ydb::TOperationId::EXPORT:
+        case NYdbProtos::TOperationId::EXPORT:
             res << "ydb://export";
             break;
-        case Ydb::TOperationId::IMPORT:
+        case NYdbProtos::TOperationId::IMPORT:
             res << "ydb://import";
             break;
-        case Ydb::TOperationId::BUILD_INDEX:
+        case NYdbProtos::TOperationId::BUILD_INDEX:
             res << "ydb://buildindex";
             break;
-        case Ydb::TOperationId::SCRIPT_EXECUTION:
+        case NYdbProtos::TOperationId::SCRIPT_EXECUTION:
             res << "ydb://scriptexec";
             break;
         default:
@@ -79,7 +79,7 @@ std::string ProtoToString(const Ydb::TOperationId& proto) {
                 }
                 for (int i = 0; i < size; i++) {
                     const auto& message = reflection.GetRepeatedMessage(proto, field, i);
-                    const auto& data = dynamic_cast<const Ydb::TOperationId::TData&>(message);
+                    const auto& data = dynamic_cast<const NYdbProtos::TOperationId::TData&>(message);
                     TUri::ReEncode(res, data.key());
                     res << "=";
                     TUri::ReEncode(res, data.value());
@@ -107,12 +107,12 @@ std::string ProtoToString(const Ydb::TOperationId& proto) {
 class TOperationId::TImpl {
 public:
     TImpl() {
-        Proto.set_kind(Ydb::TOperationId::UNUSED);
+        Proto.set_kind(NYdbProtos::TOperationId::UNUSED);
     }
 
     TImpl(const std::string &string, bool allowEmpty) {
         if (allowEmpty && string.empty()) {
-            Proto.set_kind(Ydb::TOperationId::UNUSED);
+            Proto.set_kind(NYdbProtos::TOperationId::UNUSED);
             return;
         }
 
@@ -134,7 +134,7 @@ public:
             ythrow yexception() << "Invalid operation kind: " << kind;
         }
 
-        Proto.set_kind(static_cast<Ydb::TOperationId::EKind>(kind));
+        Proto.set_kind(static_cast<NYdbProtos::TOperationId::EKind>(kind));
 
         std::string query = uri.PrintS(TField::FlagQuery);
 
@@ -165,11 +165,11 @@ public:
 
     ~TImpl() = default;
 
-    Ydb::TOperationId& GetProto() {
+    NYdbProtos::TOperationId& GetProto() {
         return Proto;
     }
 
-    const Ydb::TOperationId& GetProto() const {
+    const NYdbProtos::TOperationId& GetProto() const {
         return Proto;
     }
 
@@ -205,7 +205,7 @@ private:
         }
     }
 
-    Ydb::TOperationId Proto;
+    NYdbProtos::TOperationId Proto;
     std::unordered_map<std::string, std::vector<const std::string*>> Index;
 };
 
@@ -244,7 +244,7 @@ TOperationId::EKind TOperationId::GetKind() const {
 }
 
 void TOperationId::SetKind(const EKind& kind) {
-    Impl->GetProto().set_kind(static_cast<Ydb::TOperationId_EKind>(kind));
+    Impl->GetProto().set_kind(static_cast<NYdbProtos::TOperationId_EKind>(kind));
 }
 
 std::vector<TOperationId::TData> TOperationId::GetData() const {
@@ -271,11 +271,11 @@ std::string TOperationId::ToString() const {
     return ProtoToString(Impl->GetProto());
 }
 
-const Ydb::TOperationId& TOperationId::GetProto() const {
+const NYdbProtos::TOperationId& TOperationId::GetProto() const {
     return Impl->GetProto();
 }
 
-void AddOptionalValue(Ydb::TOperationId& proto, const std::string& key, const std::string& value) {
+void AddOptionalValue(NYdbProtos::TOperationId& proto, const std::string& key, const std::string& value) {
     auto data = proto.add_data();
     data->set_key(NYdb::TStringType{key});
     data->set_value(NYdb::TStringType{value});

--- a/ydb/public/sdk/cpp/src/library/proto_output/proto_output.cpp
+++ b/ydb/public/sdk/cpp/src/library/proto_output/proto_output.cpp
@@ -26,7 +26,7 @@ namespace {
     }
 }
 
-Y_DECLARE_OUT_SPEC(, Ydb::Issue::IssueMessage, stream, value) {
+Y_DECLARE_OUT_SPEC(, NYdbProtos::Issue::IssueMessage, stream, value) {
     google::protobuf::TextFormat::Printer printer;
     printer.SetSingleLineMode(true);
     printer.SetUseUtf8StringEscaping(true);
@@ -43,14 +43,14 @@ Y_DECLARE_OUT_SPEC(, Ydb::Issue::IssueMessage, stream, value) {
     stream << "{ " << str << " }";
 }
 
-Y_DECLARE_OUT_SPEC(, Ydb::VariantType, stream, value) {
+Y_DECLARE_OUT_SPEC(, NYdbProtos::VariantType, stream, value) {
     stream << "{ " << ShortUtf8DebugString(value) << " }";
 }
 
-Y_DECLARE_OUT_SPEC(, Ydb::Topic::StreamReadMessage_ReadResponse, stream, value) {
+Y_DECLARE_OUT_SPEC(, NYdbProtos::Topic::StreamReadMessage_ReadResponse, stream, value) {
     stream << "{ " << ShortUtf8DebugString(value) << " }";
 }
 
-Y_DECLARE_OUT_SPEC(, Ydb::Topic::StreamReadMessage_CommitOffsetResponse, stream, value) {
+Y_DECLARE_OUT_SPEC(, NYdbProtos::Topic::StreamReadMessage_CommitOffsetResponse, stream, value) {
     stream << "{ " << ShortUtf8DebugString(value) << " }";
 }

--- a/ydb/public/sdk/cpp/tests/integration/basic_example/main.cpp
+++ b/ydb/public/sdk/cpp/tests/integration/basic_example/main.cpp
@@ -11,7 +11,7 @@
 static void ValidateResultSet(const std::vector<NYdb::TColumn>& columns,
                               const std::vector<std::vector<NYdb::TValue>>& values,
                               const NYdb::TResultSet& rs) {
-    Ydb::ResultSet protoResultSet;
+    NYdbProtos::ResultSet protoResultSet;
     for (const auto& column : columns) {
         auto* protoColumn = protoResultSet.add_columns();
         protoColumn->set_name(column.Name);

--- a/ydb/public/sdk/cpp/tests/unit/client/coordination/coordination_ut.cpp
+++ b/ydb/public/sdk/cpp/tests/unit/client/coordination/coordination_ut.cpp
@@ -18,12 +18,12 @@ using namespace NYdb::NCoordination;
 
 namespace {
 
-    class TMockDiscoveryService : public Ydb::Discovery::V1::DiscoveryService::Service {
+    class TMockDiscoveryService : public NYdbProtos::Discovery::V1::DiscoveryService::Service {
     public:
         grpc::Status ListEndpoints(
                 grpc::ServerContext* context,
-                const Ydb::Discovery::ListEndpointsRequest* request,
-                Ydb::Discovery::ListEndpointsResponse* response) override
+                const NYdbProtos::Discovery::ListEndpointsRequest* request,
+                NYdbProtos::Discovery::ListEndpointsResponse* response) override
         {
             Y_UNUSED(context);
 
@@ -34,28 +34,28 @@ namespace {
 
             auto* op = response->mutable_operation();
             op->set_ready(true);
-            op->set_status(Ydb::StatusIds::SUCCESS);
+            op->set_status(NYdbProtos::StatusIds::SUCCESS);
             op->mutable_result()->PackFrom(*result);
             return grpc::Status::OK;
         }
 
         // From database name to result
-        std::unordered_map<std::string, Ydb::Discovery::ListEndpointsResult> MockResults;
+        std::unordered_map<std::string, NYdbProtos::Discovery::ListEndpointsResult> MockResults;
     };
 
-    class TMockCoordinationService : public Ydb::Coordination::V1::CoordinationService::Service {
+    class TMockCoordinationService : public NYdbProtos::Coordination::V1::CoordinationService::Service {
     public:
         grpc::Status Session(
                 grpc::ServerContext* context,
                 grpc::ServerReaderWriter<
-                    Ydb::Coordination::SessionResponse,
-                    Ydb::Coordination::SessionRequest>* stream) override
+                    NYdbProtos::Coordination::SessionResponse,
+                    NYdbProtos::Coordination::SessionRequest>* stream) override
         {
             Y_UNUSED(context);
 
             std::cerr << "Session stream started" << std::endl;
 
-            Ydb::Coordination::SessionRequest request;
+            NYdbProtos::Coordination::SessionRequest request;
 
             // Process session start
             {
@@ -70,7 +70,7 @@ namespace {
                 if (!sessionId) {
                     sessionId = ++LastSessionId;
                 }
-                Ydb::Coordination::SessionResponse response;
+                NYdbProtos::Coordination::SessionResponse response;
                 auto* started = response.mutable_session_started();
                 started->set_session_id(sessionId);
                 started->set_timeout_millis(start.timeout_millis());
@@ -84,7 +84,7 @@ namespace {
                 Y_ABORT_UNLESS(request.has_ping(), "Only ping requests are supported");
                 if (++pings_received <= 2) {
                     // Only reply to the first 2 ping requests
-                    Ydb::Coordination::SessionResponse response;
+                    NYdbProtos::Coordination::SessionResponse response;
                     auto* pong = response.mutable_pong();
                     pong->set_opaque(request.ping().opaque());
                     stream->Write(response);

--- a/ydb/public/sdk/cpp/tests/unit/client/discovery_mutator/discovery_mutator_ut.cpp
+++ b/ydb/public/sdk/cpp/tests/unit/client/discovery_mutator/discovery_mutator_ut.cpp
@@ -16,7 +16,7 @@ Y_UNIT_TEST_SUITE(DiscoveryMutator) {
         std::unordered_set<std::string_view> dbs;
         std::string discoveryEndpont = "localhost:100";
 
-        auto mutator = [&](Ydb::Discovery::ListEndpointsResult* proto, TStatus status, const IDiscoveryMutatorApi::TAuxInfo& aux) {
+        auto mutator = [&](NYdbProtos::Discovery::ListEndpointsResult* proto, TStatus status, const IDiscoveryMutatorApi::TAuxInfo& aux) {
             UNIT_ASSERT_VALUES_EQUAL(discoveryEndpont, status.GetEndpoint());
             UNIT_ASSERT_VALUES_EQUAL(discoveryEndpont, aux.DiscoveryEndpoint);
             dbs.insert(aux.Database);

--- a/ydb/public/sdk/cpp/tests/unit/client/draft/helpers/grpc_services/scripting.cpp
+++ b/ydb/public/sdk/cpp/tests/unit/client/draft/helpers/grpc_services/scripting.cpp
@@ -4,15 +4,15 @@ namespace NYdb::inline V3::NScripting {
 
 grpc::Status TMockSlyDbProxy::ExecuteYql(
     grpc::ServerContext* context,
-    [[maybe_unused]] const Ydb::Scripting::ExecuteYqlRequest* request,
-    Ydb::Scripting::ExecuteYqlResponse* response
+    [[maybe_unused]] const NYdbProtos::Scripting::ExecuteYqlRequest* request,
+    NYdbProtos::Scripting::ExecuteYqlResponse* response
 ) {
     context->AddInitialMetadata("key", "value");
 
     // Just to make sdk core happy
     auto* op = response->mutable_operation();
     op->set_ready(true);
-    op->set_status(Ydb::StatusIds::SUCCESS);
+    op->set_status(NYdbProtos::StatusIds::SUCCESS);
     op->mutable_result();
 
     return grpc::Status::OK;

--- a/ydb/public/sdk/cpp/tests/unit/client/draft/helpers/grpc_services/scripting.h
+++ b/ydb/public/sdk/cpp/tests/unit/client/draft/helpers/grpc_services/scripting.h
@@ -1,16 +1,17 @@
 #pragma once
 
 #include <ydb/public/api/grpc/ydb_scripting_v1.grpc.pb.h>
+#include <ydb-cpp-sdk/type_switcher.h>
 
 namespace NYdb::inline V3::NScripting {
 
-class TMockSlyDbProxy : public Ydb::Scripting::V1::ScriptingService::Service
+class TMockSlyDbProxy : public NYdbProtos::Scripting::V1::ScriptingService::Service
 {
 public:
     grpc::Status ExecuteYql(
         grpc::ServerContext* context,
-        const Ydb::Scripting::ExecuteYqlRequest* request,
-        Ydb::Scripting::ExecuteYqlResponse* response) override;
+        const NYdbProtos::Scripting::ExecuteYqlRequest* request,
+        NYdbProtos::Scripting::ExecuteYqlResponse* response) override;
 };
 
 }

--- a/ydb/public/sdk/cpp/tests/unit/client/draft/helpers/grpc_services/view.cpp
+++ b/ydb/public/sdk/cpp/tests/unit/client/draft/helpers/grpc_services/view.cpp
@@ -4,13 +4,13 @@ namespace NYdb::inline V3::NView {
 
 grpc::Status TViewDummyService::DescribeView(
     [[maybe_unused]] grpc::ServerContext* context,
-    [[maybe_unused]] const Ydb::View::DescribeViewRequest* request,
-    Ydb::View::DescribeViewResponse* response
+    [[maybe_unused]] const NYdbProtos::View::DescribeViewRequest* request,
+    NYdbProtos::View::DescribeViewResponse* response
 ) {
     auto* op = response->mutable_operation();
     op->set_ready(true);
-    op->set_status(Ydb::StatusIds::SUCCESS);
-    Ydb::View::DescribeViewResult describeResult;
+    op->set_status(NYdbProtos::StatusIds::SUCCESS);
+    NYdbProtos::View::DescribeViewResult describeResult;
     describeResult.set_query_text(DummyQueryText);
     op->mutable_result()->PackFrom(describeResult);
     return grpc::Status::OK;

--- a/ydb/public/sdk/cpp/tests/unit/client/draft/helpers/grpc_services/view.h
+++ b/ydb/public/sdk/cpp/tests/unit/client/draft/helpers/grpc_services/view.h
@@ -1,18 +1,19 @@
 #pragma once
 
 #include <ydb/public/api/grpc/draft/ydb_view_v1.grpc.pb.h>
+#include <ydb-cpp-sdk/type_switcher.h>
 
 namespace NYdb::inline V3::NView {
 
 constexpr const char* DummyQueryText = "select 42";
 
-class TViewDummyService : public Ydb::View::V1::ViewService::Service
+class TViewDummyService : public NYdbProtos::View::V1::ViewService::Service
 {
 public:
     grpc::Status DescribeView(
         grpc::ServerContext* context,
-        const Ydb::View::DescribeViewRequest* request,
-        Ydb::View::DescribeViewResponse* response) override;
+        const NYdbProtos::View::DescribeViewRequest* request,
+        NYdbProtos::View::DescribeViewResponse* response) override;
 };
 
 }

--- a/ydb/public/sdk/cpp/tests/unit/client/driver/driver_ut.cpp
+++ b/ydb/public/sdk/cpp/tests/unit/client/driver/driver_ut.cpp
@@ -22,12 +22,12 @@ using namespace NYdb::NTable;
 
 namespace {
 
-    class TMockDiscoveryService : public Ydb::Discovery::V1::DiscoveryService::Service {
+    class TMockDiscoveryService : public NYdbProtos::Discovery::V1::DiscoveryService::Service {
     public:
         grpc::Status ListEndpoints(
                 grpc::ServerContext* context,
-                const Ydb::Discovery::ListEndpointsRequest* request,
-                Ydb::Discovery::ListEndpointsResponse* response) override
+                const NYdbProtos::Discovery::ListEndpointsRequest* request,
+                NYdbProtos::Discovery::ListEndpointsResponse* response) override
         {
             Y_UNUSED(context);
 
@@ -38,32 +38,32 @@ namespace {
 
             auto* op = response->mutable_operation();
             op->set_ready(true);
-            op->set_status(Ydb::StatusIds::SUCCESS);
+            op->set_status(NYdbProtos::StatusIds::SUCCESS);
             op->mutable_result()->PackFrom(*result);
             return grpc::Status::OK;
         }
 
         // From database name to result
-        std::unordered_map<std::string, Ydb::Discovery::ListEndpointsResult> MockResults;
+        std::unordered_map<std::string, NYdbProtos::Discovery::ListEndpointsResult> MockResults;
     };
 
-    class TMockTableService : public Ydb::Table::V1::TableService::Service {
+    class TMockTableService : public NYdbProtos::Table::V1::TableService::Service {
     public:
         grpc::Status CreateSession(
                 grpc::ServerContext* context,
-                const Ydb::Table::CreateSessionRequest* request,
-                Ydb::Table::CreateSessionResponse* response) override
+                const NYdbProtos::Table::CreateSessionRequest* request,
+                NYdbProtos::Table::CreateSessionResponse* response) override
         {
             Y_UNUSED(context);
 
             std::cerr << "CreateSession: " << request->ShortDebugString() << std::endl;
 
-            Ydb::Table::CreateSessionResult result;
+            NYdbProtos::Table::CreateSessionResult result;
             result.set_session_id("my-session-id");
 
             auto* op = response->mutable_operation();
             op->set_ready(true);
-            op->set_status(Ydb::StatusIds::SUCCESS);
+            op->set_status(NYdbProtos::StatusIds::SUCCESS);
             op->mutable_result()->PackFrom(result);
             return grpc::Status::OK;
         }

--- a/ydb/public/sdk/cpp/tests/unit/client/result/result_ut.cpp
+++ b/ydb/public/sdk/cpp/tests/unit/client/result/result_ut.cpp
@@ -50,7 +50,7 @@ Y_UNIT_TEST_SUITE(CppGrpcClientResultSetTest) {
             "    }\n"
             "  }\n"
             "}\n";
-        Ydb::ResultSet rsProto;
+        NYdbProtos::ResultSet rsProto;
         google::protobuf::TextFormat::ParseFromString(TStringType{resultSetString}, &rsProto);
 
         NYdb::TResultSet rs(std::move(rsProto));
@@ -112,7 +112,7 @@ Y_UNIT_TEST_SUITE(CppGrpcClientResultSetTest) {
             "    }\n"
             "  }\n"
             "}\n";
-        Ydb::ResultSet rsProto;
+        NYdbProtos::ResultSet rsProto;
         google::protobuf::TextFormat::ParseFromString(TStringType{resultSetString}, &rsProto);
 
         NYdb::TResultSet rs(std::move(rsProto));
@@ -173,7 +173,7 @@ Y_UNIT_TEST_SUITE(CppGrpcClientResultSetTest) {
             "    null_flag_value: NULL_VALUE\n"
             "  }\n"
             "}\n";
-        Ydb::ResultSet rsProto;
+        NYdbProtos::ResultSet rsProto;
         google::protobuf::TextFormat::ParseFromString(TStringType{resultSetString}, &rsProto);
 
         NYdb::TResultSet rs(std::move(rsProto));
@@ -224,7 +224,7 @@ Y_UNIT_TEST_SUITE(CppGrpcClientResultSetTest) {
             "    bytes_value: \"test content\"\n"
             "  }\n"
             "}\n";
-        Ydb::ResultSet rsProto;
+        NYdbProtos::ResultSet rsProto;
         google::protobuf::TextFormat::ParseFromString(TStringType{resultSetString}, &rsProto);
 
         NYdb::TResultSet rs(std::move(rsProto));

--- a/ydb/public/sdk/cpp/tests/unit/client/value/value_ut.cpp
+++ b/ydb/public/sdk/cpp/tests/unit/client/value/value_ut.cpp
@@ -61,7 +61,7 @@ Y_UNIT_TEST_SUITE(YdbValue) {
             }
         )";
 
-        Ydb::Type protoType;
+        NYdbProtos::Type protoType;
         google::protobuf::TextFormat::ParseFromString(protoTypeStr, &protoType);
 
         UNIT_ASSERT_NO_DIFF(FormatType(protoType),
@@ -87,7 +87,7 @@ Y_UNIT_TEST_SUITE(YdbValue) {
             }
         )";
 
-        Ydb::Type protoType;
+        NYdbProtos::Type protoType;
         google::protobuf::TextFormat::ParseFromString(protoTypeStr, &protoType);
 
         UNIT_ASSERT_NO_DIFF(FormatType(protoType),
@@ -104,7 +104,7 @@ Y_UNIT_TEST_SUITE(YdbValue) {
             }
         )";
 
-        Ydb::Type protoType;
+        NYdbProtos::Type protoType;
         google::protobuf::TextFormat::ParseFromString(protoTypeStr, &protoType);
 
         UNIT_ASSERT_NO_DIFF(FormatType(protoType),
@@ -287,10 +287,10 @@ Y_UNIT_TEST_SUITE(YdbValue) {
             }
         )";
 
-        Ydb::Type protoType;
+        NYdbProtos::Type protoType;
         google::protobuf::TextFormat::ParseFromString(protoTypeStr, &protoType);
 
-        Ydb::Value protoValue;
+        NYdbProtos::Value protoValue;
         google::protobuf::TextFormat::ParseFromString(protoValueStr, &protoValue);
 
         TValue value(TType(protoType), protoValue);
@@ -341,10 +341,10 @@ Y_UNIT_TEST_SUITE(YdbValue) {
             }
         )";
 
-        Ydb::Type protoType;
+        NYdbProtos::Type protoType;
         google::protobuf::TextFormat::ParseFromString(protoTypeStr, &protoType);
 
-        Ydb::Value protoValue;
+        NYdbProtos::Value protoValue;
         google::protobuf::TextFormat::ParseFromString(protoValueStr, &protoValue);
 
         TValue value(TType(protoType), protoValue);
@@ -428,10 +428,10 @@ Y_UNIT_TEST_SUITE(YdbValue) {
             }
         )";
 
-        Ydb::Type protoType;
+        NYdbProtos::Type protoType;
         google::protobuf::TextFormat::ParseFromString(protoTypeStr, &protoType);
 
-        Ydb::Value protoValue;
+        NYdbProtos::Value protoValue;
         google::protobuf::TextFormat::ParseFromString(protoValueStr, &protoValue);
 
         TValue value(TType(protoType), protoValue);
@@ -507,10 +507,10 @@ Y_UNIT_TEST_SUITE(YdbValue) {
             }
         )";
 
-        Ydb::Type protoType;
+        NYdbProtos::Type protoType;
         google::protobuf::TextFormat::ParseFromString(protoTypeStr, &protoType);
 
-        Ydb::Value protoValue;
+        NYdbProtos::Value protoValue;
         google::protobuf::TextFormat::ParseFromString(protoValueStr, &protoValue);
 
         TValue value(TType(protoType), protoValue);

--- a/ydb/public/sdk/cpp/tests/unit/library/issue/yql_issue_ut.cpp
+++ b/ydb/public/sdk/cpp/tests/unit/library/issue/yql_issue_ut.cpp
@@ -37,11 +37,11 @@ Y_UNIT_TEST_SUITE(ToMessage) {
         TIssue issue;
         issue.SetMessage(nonUtf8String);
 
-        Ydb::Issue::IssueMessage msg;
+        NYdbProtos::Issue::IssueMessage msg;
         IssueToMessage(issue, &msg);
         NYdb::TStringType serialized;
         UNIT_ASSERT(msg.SerializeToString(&serialized));
-        Ydb::Issue::IssueMessage msg2;
+        NYdbProtos::Issue::IssueMessage msg2;
         UNIT_ASSERT(msg2.ParseFromString(serialized));
     }
 }

--- a/ydb/public/sdk/cpp/tests/unit/library/operation_id/operation_id_ut.cpp
+++ b/ydb/public/sdk/cpp/tests/unit/library/operation_id/operation_id_ut.cpp
@@ -11,8 +11,8 @@ Y_UNIT_TEST_SUITE(OperationIdTest) {
     const std::string PreparedQueryId = "9d629c27-2c3036b3-4b180476-64435bca";
 
     Y_UNIT_TEST(ConvertKindOnly) {
-        Ydb::TOperationId proto;
-        proto.set_kind(Ydb::TOperationId::OPERATION_DDL);
+        NYdbProtos::TOperationId proto;
+        proto.set_kind(NYdbProtos::TOperationId::OPERATION_DDL);
         auto str = ProtoToString(proto);
         UNIT_ASSERT_EQUAL(str, "ydb://operation/1");
         auto newProto = TOperationId(str);
@@ -21,8 +21,8 @@ Y_UNIT_TEST_SUITE(OperationIdTest) {
     }
 
     Y_UNIT_TEST(PreparedQueryIdCompatibleFormatter) {
-        Ydb::TOperationId opId;
-        opId.set_kind(Ydb::TOperationId::PREPARED_QUERY_ID);
+        NYdbProtos::TOperationId opId;
+        opId.set_kind(NYdbProtos::TOperationId::PREPARED_QUERY_ID);
         AddOptionalValue(opId, "id", PreparedQueryId);
         auto result = ProtoToString(opId);
         UNIT_ASSERT_VALUES_EQUAL(FormatPreparedQueryIdCompat(PreparedQueryId), result);
@@ -80,8 +80,8 @@ Y_UNIT_TEST_SUITE(OperationIdTest) {
     Y_UNIT_TEST(PreparedQueryIdOldFormatterPerf) {
         ui64 x = 0;
         for (int i = 0; i < 10000000; i++) {
-            Ydb::TOperationId opId;
-            opId.SetKind(Ydb::TOperationId::PREPARED_QUERY_ID);
+            NYdbProtos::TOperationId opId;
+            opId.SetKind(NYdbProtos::TOperationId::PREPARED_QUERY_ID);
             AddOptionalValue(opId, "id", PreparedQueryId);
             auto result = ProtoToString(opId);
             x += result.size();
@@ -90,8 +90,8 @@ Y_UNIT_TEST_SUITE(OperationIdTest) {
     }
 #endif
     Y_UNIT_TEST(ConvertKindAndValues) {
-        Ydb::TOperationId proto;
-        proto.set_kind(Ydb::TOperationId::OPERATION_DDL);
+        NYdbProtos::TOperationId proto;
+        proto.set_kind(NYdbProtos::TOperationId::OPERATION_DDL);
         {
             auto data = proto.add_data();
             data->set_key("key1");

--- a/ydb/services/persqueue_v1/persqueue_ut.cpp
+++ b/ydb/services/persqueue_v1/persqueue_ut.cpp
@@ -3033,30 +3033,30 @@ Y_UNIT_TEST_SUITE(TPersQueueTest) {
     class TTestCredentialsProvider : public NYdb::ICredentialsProvider {
         public:
 
-        TTestCredentialsProvider(const NYdb::TStringType& token)
+        TTestCredentialsProvider(const std::string& token)
         : Token(token)
         {}
 
         virtual ~TTestCredentialsProvider()
         {}
 
-        NYdb::TStringType GetAuthInfo() const override {
+        std::string GetAuthInfo() const override {
             return Token;
         }
 
-        void SetToken(const NYdb::TStringType& token) {
+        void SetToken(const std::string& token) {
             Token = token;
         }
         bool IsValid() const override {
             return true;
         }
 
-        NYdb::TStringType Token;
+        std::string Token;
     };
 
     class TTestCredentialsProviderFactory : public NYdb::ICredentialsProviderFactory {
     public:
-        TTestCredentialsProviderFactory(const NYdb::TStringType& token)
+        TTestCredentialsProviderFactory(const std::string& token)
         : CredentialsProvider(new TTestCredentialsProvider(token))
         {}
 
@@ -3070,11 +3070,11 @@ Y_UNIT_TEST_SUITE(TPersQueueTest) {
             return CredentialsProvider;
         }
 
-        NYdb::TStringType GetClientIdentity() const override {
+        std::string GetClientIdentity() const override {
             return CreateGuidAsString();
         }
 
-        void SetToken(const NYdb::TStringType& token) {
+        void SetToken(const std::string& token) {
             CredentialsProvider->SetToken(token);
         }
     private:
@@ -3108,8 +3108,8 @@ Y_UNIT_TEST_SUITE(TPersQueueTest) {
 
 
         for (ui32 i = 0; i < 2; ++i) {
-            std::shared_ptr<NYdb::ICredentialsProviderFactory> creds = std::make_shared<TTestCredentialsProviderFactory>(NYdb::TStringType("topic1@" BUILTIN_ACL_DOMAIN));
-            dynamic_cast<TTestCredentialsProviderFactory*>(creds.get())->SetToken(NYdb::TStringType("topic1@" BUILTIN_ACL_DOMAIN));
+            std::shared_ptr<NYdb::ICredentialsProviderFactory> creds = std::make_shared<TTestCredentialsProviderFactory>("topic1@" BUILTIN_ACL_DOMAIN);
+            dynamic_cast<TTestCredentialsProviderFactory*>(creds.get())->SetToken("topic1@" BUILTIN_ACL_DOMAIN);
 
             auto writer = CreateWriter(*driver, SHORT_TOPIC_NAME, "123", {}, {}, {}, creds);
 
@@ -3135,7 +3135,7 @@ Y_UNIT_TEST_SUITE(TPersQueueTest) {
             auto ack = std::get_if<NYdb::NPersQueue::TWriteSessionEvent::TAcksEvent>(&*msg);
             UNIT_ASSERT(ack);
 
-            NYdb::TStringType token = i == 0 ? "user_without_rights@" BUILTIN_ACL_DOMAIN : "invalid_ticket";
+            std::string token = i == 0 ? "user_without_rights@" BUILTIN_ACL_DOMAIN : "invalid_ticket";
             Cerr << "Set token " << token << "\n";
 
             dynamic_cast<TTestCredentialsProviderFactory*>(creds.get())->SetToken(token);
@@ -3216,7 +3216,7 @@ Y_UNIT_TEST_SUITE(TPersQueueTest) {
         Cerr << "==== Start consuming loop\n";
         for (ui32 i = 0; i < 2; ++i) {
 
-            std::shared_ptr<NYdb::ICredentialsProviderFactory> creds = std::make_shared<TTestCredentialsProviderFactory>(NYdb::TStringType("user3@" BUILTIN_ACL_DOMAIN));
+            std::shared_ptr<NYdb::ICredentialsProviderFactory> creds = std::make_shared<TTestCredentialsProviderFactory>("user3@" BUILTIN_ACL_DOMAIN);
 
             NYdb::NPersQueue::TReadSessionSettings settings;
             settings.ConsumerName("user1").AppendTopics(shortTopic2Name).ReadOriginal({"dc1"});


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

### Changelog category <!-- remove all except one -->

* Not for changelog (changelog entry is not required)

### Description for reviewers <!-- (optional) description for those who read this PR -->

В разных репах протоспеки будут с разными неймспейсами. Это нужно, чтобы эта версия SDK не конфликтовала с контрибной (contrib/libs/ydb-cpp-sdk).

Решение такое:
Явный `namespace Ydb` в форвард декларациях сделал через 
`#define YDB_PROTOS_NAMESPACE namespace Ydb`.
Использовать этот  неймспейс надо через другой прокси неймспейс: `namespace NYdbProtos = Ydb`.

В репозитории ydb-cpp-sdk это будут соответственно:
`#define YDB_PROTOS_NAMESPACE namespace Ydb::Sdk`
и
`namespace NYdbProtos = Ydb::Sdk`
