### PR TITLE
Remove dummy actorsystem config

### DIFF
--- a/ydb/core/config/init/dummy.cpp
+++ b/ydb/core/config/init/dummy.cpp
@@ -2,36 +2,6 @@
 #include <ydb/core/base/blobstorage_grouptype.h>
 #include <ydb/core/protos/alloc.pb.h>
 
-TAutoPtr<NKikimrConfig::TActorSystemConfig> DummyActorSystemConfig() {
-    TAutoPtr<NKikimrConfig::TActorSystemConfig> ret(new NKikimrConfig::TActorSystemConfig());
-
-    NKikimrConfig::TActorSystemConfig::TScheduler *sched = ret->MutableScheduler();
-    sched->SetResolution(512);
-    sched->SetSpinThreshold(0);
-    sched->SetProgressThreshold(10000);
-
-    NKikimrConfig::TActorSystemConfig::TExecutor *exec1 = ret->AddExecutor();
-    NKikimrConfig::TActorSystemConfig::TExecutor *exec2 = ret->AddExecutor();
-    NKikimrConfig::TActorSystemConfig::TExecutor *exec3 = ret->AddExecutor();
-
-    exec1->SetType(NKikimrConfig::TActorSystemConfig::TExecutor::BASIC);
-    exec1->SetThreads(1);
-    exec1->SetSpinThreshold(50);
-
-    exec2->SetType(NKikimrConfig::TActorSystemConfig::TExecutor::BASIC);
-    exec2->SetThreads(2);
-    exec2->SetSpinThreshold(50);
-
-    exec3->SetType(NKikimrConfig::TActorSystemConfig::TExecutor::IO);
-    exec3->SetThreads(10);
-
-    ret->SetSysExecutor(0);
-    ret->SetUserExecutor(1);
-    ret->SetBatchExecutor(1);
-    ret->SetIoExecutor(2);
-
-    return ret;
-}
 
 TAutoPtr<NKikimrConfig::TChannelProfileConfig> DummyChannelProfileConfig() {
     TAutoPtr<NKikimrConfig::TChannelProfileConfig> ret(new NKikimrConfig::TChannelProfileConfig());

--- a/ydb/core/config/init/dummy.h
+++ b/ydb/core/config/init/dummy.h
@@ -2,6 +2,5 @@
 #include <util/generic/ptr.h>
 #include <ydb/core/protos/config.pb.h>
 
-TAutoPtr<NKikimrConfig::TActorSystemConfig> DummyActorSystemConfig();
 TAutoPtr<NKikimrConfig::TChannelProfileConfig> DummyChannelProfileConfig();
 TAutoPtr<NKikimrConfig::TAllocatorConfig> DummyAllocatorConfig();

--- a/ydb/core/config/init/init_impl.h
+++ b/ydb/core/config/init/init_impl.h
@@ -44,7 +44,6 @@
 
 namespace fs = std::filesystem;
 
-extern TAutoPtr<NKikimrConfig::TActorSystemConfig> DummyActorSystemConfig();
 extern TAutoPtr<NKikimrConfig::TAllocatorConfig> DummyAllocatorConfig();
 
 using namespace NYdb::NConsoleClient;
@@ -1103,11 +1102,6 @@ public:
         LoadMainYamlConfig(refs, yamlConfigFile, AppConfig);
 
         Option("sys-file", TCfg::TActorSystemConfigFieldTag{});
-
-        if (!AppConfig.HasActorSystemConfig()) {
-            AppConfig.MutableActorSystemConfig()->CopyFrom(*DummyActorSystemConfig());
-            ConfigUpdateTracer.AddUpdate(NKikimrConsole::TConfigItem::ActorSystemConfigItem, TConfigItemInfo::EUpdateKind::SetExplicitly);
-        }
 
         Option("domains-file", TCfg::TDomainsConfigFieldTag{});
         Option("bs-file", TCfg::TBlobStorageConfigFieldTag{});

--- a/ydb/core/driver_lib/run/config_parser.cpp
+++ b/ydb/core/driver_lib/run/config_parser.cpp
@@ -89,9 +89,6 @@ void TRunCommandConfigParser::SetupLastGetOptForConfigFiles(NLastGetopt::TOpts& 
 void TRunCommandConfigParser::ParseConfigFiles(const NLastGetopt::TOptsParseResult& res) {
     if (res.Has("sys-file")) {
         Y_ABORT_UNLESS(ParsePBFromFile(res.Get("sys-file"), Config.AppConfig.MutableActorSystemConfig()));
-    } else {
-        auto sysConfig = DummyActorSystemConfig();
-        Config.AppConfig.MutableActorSystemConfig()->CopyFrom(*sysConfig);
     }
 
     if (res.Has("naming-file")) {

--- a/ydb/core/driver_lib/run/kikimr_services_initializers.cpp
+++ b/ydb/core/driver_lib/run/kikimr_services_initializers.cpp
@@ -502,13 +502,13 @@ static TInterconnectSettings GetInterconnectSettings(const NKikimrConfig::TInter
 
 void TBasicServicesInitializer::InitializeServices(NActors::TActorSystemSetup* setup,
                                                    const NKikimr::TAppData* appData) {
-    auto& systemConfig = Config.GetActorSystemConfig();
     bool hasASCfg = Config.HasActorSystemConfig();
-    if (!hasASCfg || (systemConfig.HasUseAutoConfig() && systemConfig.GetUseAutoConfig())) {
+    if (!hasASCfg || Config.GetActorSystemConfig().GetUseAutoConfig()) {
         NAutoConfigInitializer::ApplyAutoConfig(Config.MutableActorSystemConfig());
     }
 
     Y_ABORT_UNLESS(Config.HasActorSystemConfig());
+    auto& systemConfig = Config.GetActorSystemConfig();
     Y_ABORT_UNLESS(systemConfig.HasScheduler());
     Y_ABORT_UNLESS(systemConfig.ExecutorSize());
     const ui32 systemPoolId = appData->SystemPoolId;


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

When autoconfig was not assigned, ydbd used a dummy configuration. Now, it is fixed, and ydbd uses autoconfig.

### Changelog category <!-- remove all except one -->

* Not for changelog (changelog entry is not required)

### Description for reviewers <!-- (optional) description for those who read this PR -->

...
