### PR TITLE
Forbid empty database in `ydb admin database restore`

### DIFF
--- a/ydb/public/lib/ydb_cli/commands/ydb_admin.cpp
+++ b/ydb/public/lib/ydb_cli/commands/ydb_admin.cpp
@@ -70,7 +70,6 @@ TCommandDatabaseRestore::TCommandDatabaseRestore()
 void TCommandDatabaseRestore::Config(TConfig& config) {
     TYdbCommand::Config(config);
     config.SetFreeArgsNum(0);
-    config.AllowEmptyDatabase = true; // it is possible to retrieve database path from dump
 
     config.Opts->AddLongOption('i', "input", "Path in a local filesystem to a directory with dump.")
         .RequiredArgument("PATH")
@@ -91,12 +90,8 @@ int TCommandDatabaseRestore::Run(TConfig& config) {
     log->SetFormatter(GetPrefixLogFormatter(""));
 
     auto settings = NDump::TRestoreDatabaseSettings()
-        .WaitNodesDuration(WaitNodesDuration);
-
-    if (!config.Database.empty()) {
-        settings.Database(config.Database);
-        config.Database.clear(); // always connect directly to cluster
-    }
+        .WaitNodesDuration(WaitNodesDuration)
+        .Database(config.Database);
 
     NDump::TClient client(CreateDriver(config), std::move(log));
     NStatusHelpers::ThrowOnErrorOrPrintIssues(client.RestoreDatabase(FilePath, settings));


### PR DESCRIPTION
### Changelog category <!-- remove all except one -->

* Not for changelog (changelog entry is not required)

### Description for reviewers <!-- (optional) description for those who read this PR -->

Теперь всегда явно нужно указывать путь до восстанавливаемой БД через параметр `-d`. У админа БД нет прав на схему, чтобы автоматически определить корень кластера и подменить его в пути до БД, сохранненом в бекапе.

В будущем можно будет это требование ослабить, и снова разрешить не указывать путь через `-d`.
