### PR TITLE
YQL parsing object creation: init feature nodes

### DIFF
--- a/yql/essentials/sql/v1/object_processing.cpp
+++ b/yql/essentials/sql/v1/object_processing.cpp
@@ -57,6 +57,26 @@ INode::TPtr TCreateObject::FillFeatures(INode::TPtr options) const {
     return options;
 }
 
+namespace {
+
+bool InitFeatures(TContext& ctx, ISource* src, std::map<TString, TDeferredAtom>& features) {
+    for (auto& [name, deferred] : features) {
+        if (deferred.HasNode() && !deferred.Build()->Init(ctx, src)) {
+            return false;
+        }
+    }
+    return true;
+}
+
+}
+
+bool TCreateObject::DoInit(TContext& ctx, ISource* src) {
+    if (!InitFeatures(ctx, src, Features)) {
+        return false;
+    }
+    return TObjectProcessorImpl::DoInit(ctx, src);
+}
+
 TObjectOperatorContext::TObjectOperatorContext(TScopedStatePtr scoped)
     : Scoped(scoped)
     , ServiceId(Scoped->CurrService)

--- a/yql/essentials/sql/v1/object_processing.h
+++ b/yql/essentials/sql/v1/object_processing.h
@@ -55,6 +55,7 @@ protected:
         return Y(Q(Y(Q("mode"), Q(mode))));
     }
     virtual INode::TPtr FillFeatures(INode::TPtr options) const override;
+    bool DoInit(TContext& ctx, ISource* src) override;
 public:
     TCreateObject(TPosition pos, const TString& objectId,
         const TString& typeId, bool existingOk, bool replaceIfExists, std::map<TString, TDeferredAtom>&& features, std::set<TString>&& featuresToReset, const TObjectOperatorContext& context)


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

### Changelog category <!-- remove all except one -->

* Not for changelog (changelog entry is not required)

### Description for reviewers <!-- (optional) description for those who read this PR -->

While working on the followig bug in views:
- https://github.com/ydb-platform/ydb/issues/14709

we have discovered that the object feature nodes haven't been initialized by the translator. It seems to matter only for views, because views have a non-trivial feature, `query_ast` which might potentially need initialization for the proper view query validation to happen.
