### PR TITLE
Return virtual timestamp for execute query | execute scan api

### DIFF
--- a/ydb/docs/en/core/concepts/cdc.md
+++ b/ydb/docs/en/core/concepts/cdc.md
@@ -52,6 +52,12 @@ Returning these timestamps for each query may cause noticeable overhead in case 
 
 For explicitly created transactions (transactions created via BeginTransactionRequest rpc call), these timestamps are always returned and do not require the flag.
 
+{% note info %}
+
+StreamReadTable and StreamExecuteScanQuery calls also have snapshot_timestamp fields in the response.
+
+{% endnote %}
+
 ## Initial table scan {#initial-scan}
 
 By default, a changefeed only includes records about those table rows that changed after the changefeed was created. Initial table scan enables you to export, to the changefeed, the values of all the rows that existed at the time of changefeed creation.

--- a/ydb/docs/en/core/concepts/cdc.md
+++ b/ydb/docs/en/core/concepts/cdc.md
@@ -38,6 +38,20 @@ By default, virtual timestamps are not uploaded to the changefeed. To enable the
 
 {% endnote %}
 
+## Getting virtual timstamps during query execution
+
+As was writen above virtual timestamp represents coordination time. There is a possibility to return a virtual timestamp during query execution. It can be used to check whether data read or written in a transaction is present in the CDC async replica.
+
+The public API has two field to represent transaction reletaed virtual timestamp.
+
+1. 'snapshot_timestamp' – Represents the moment in time when YDB takes an MVCC or persistent snapshot. It is empty if the request is executed without a snapshot. This is mostly relevant for read-only transactions and is returned during the first part of the result set. The practical purpose is to implement synchronization between readers in transactions and readers from replicas.
+
+1. 'commit_timestamp' – Represents the moment in time when YDB commits data into persistent storage. This is mostly relevant for read-write and write-only transactions and is returned in the last part of the result set. The practical purpose is to implement synchronization between transactional writers and readers from replicas.
+
+Returning these timestamps for each query may cause noticeable overhead in case of tiny result. To use them, the 'with_tx_timestamp' flag must be set in the 'TransactionControl' message.
+
+For explicitly created transactions, these timestamps are always returned and do not require the flag.
+
 ## Initial table scan {#initial-scan}
 
 By default, a changefeed only includes records about those table rows that changed after the changefeed was created. Initial table scan enables you to export, to the changefeed, the values of all the rows that existed at the time of changefeed creation.

--- a/ydb/docs/en/core/concepts/cdc.md
+++ b/ydb/docs/en/core/concepts/cdc.md
@@ -40,17 +40,17 @@ By default, virtual timestamps are not uploaded to the changefeed. To enable the
 
 ## Getting virtual timstamps during query execution
 
-As was writen above virtual timestamp represents coordination time. There is a possibility to return a virtual timestamp during query execution. It can be used to check whether data read or written in a transaction is present in the CDC async replica.
+As was written above virtual timestamp represents Global coordinator time. There is a possibility to return a virtual timestamp during query execution. It can be used to check whether data read or written in a transaction is present in the CDC async replica.
 
-The public API has two field to represent transaction reletaed virtual timestamp.
+The YDB API has two fields to get virtual timestamp from transaction.
 
-1. 'snapshot_timestamp' – Represents the moment in time when YDB takes an MVCC or persistent snapshot. It is empty if the request is executed without a snapshot. This is mostly relevant for read-only transactions and is returned during the first part of the result set. The practical purpose is to implement synchronization between readers in transactions and readers from replicas.
+1. 'snapshot_timestamp' – Represents the moment in time when YDB takes an MVCC or persistent snapshot. It is empty if the request is executed without a snapshot. This is mostly relevant for read-only transactions and is returned with the first part of the stream result. The practical purpose is to implement synchronization between readers in transactions and readers from replicas.
 
-1. 'commit_timestamp' – Represents the moment in time when YDB commits data into persistent storage. This is mostly relevant for read-write and write-only transactions and is returned in the last part of the result set. The practical purpose is to implement synchronization between transactional writers and readers from replicas.
+1. 'commit_timestamp' – Represents the moment in time when YDB commits data into persistent storage. This is mostly relevant for read-write and write-only transactions and is returned with the last part of the stream result. The practical purpose is to implement synchronization between transactional writers and readers from replicas.
 
 Returning these timestamps for each query may cause noticeable overhead in case of tiny result. To use them, the 'with_tx_timestamp' flag must be set in the 'TransactionControl' message.
 
-For explicitly created transactions, these timestamps are always returned and do not require the flag.
+For explicitly created transactions (transactions created via BeginTransactionRequest rpc call), these timestamps are always returned and do not require the flag.
 
 ## Initial table scan {#initial-scan}
 

--- a/ydb/public/api/protos/ydb_query.proto
+++ b/ydb/public/api/protos/ydb_query.proto
@@ -83,6 +83,9 @@ message TransactionControl {
     }
 
     bool commit_tx = 10;
+
+    // If set the timestamp will be returned along with ExecuteQueryResponsePart
+    bool return_virtual_timestamp = 11;
 }
 
 message BeginTransactionRequest {
@@ -94,6 +97,8 @@ message BeginTransactionRequest {
 message TransactionMeta {
     // Transaction identifier
     string id = 1 [(Ydb.length).le = 1024];
+    // Optional timestamp that represents snapshot acquired to start transaction
+    VirtualTimestamp snapshot_timestamp = 2;
 }
 
 message BeginTransactionResponse {
@@ -113,6 +118,9 @@ message CommitTransactionRequest {
 message CommitTransactionResponse {
     StatusIds.StatusCode status = 1;
     repeated Ydb.Issue.IssueMessage issues = 2;
+
+    // Optional timestamp that corresponds to the commit transaction
+    VirtualTimestamp commit_timestamp = 3;
 }
 
 message RollbackTransactionRequest {
@@ -202,9 +210,8 @@ message ExecuteQueryResponsePart {
 
     TransactionMeta tx_meta = 6;
 
-    // Optional timestamp that corresponds to the returned data
-    // That timestamp can be compared with CDC timestamp to make sure is data already present in async stream
-    VirtualTimestamp snapshot = 7;
+    // Optional timestamp that corresponds to the commit transaction
+    VirtualTimestamp commit_timestamp = 7;
 }
 
 message ExecuteScriptRequest {

--- a/ydb/public/api/protos/ydb_query.proto
+++ b/ydb/public/api/protos/ydb_query.proto
@@ -85,7 +85,7 @@ message TransactionControl {
     bool commit_tx = 10;
 
     // If set the timestamp will be returned along with ExecuteQueryResponsePart
-    bool return_virtual_timestamp = 11;
+    bool with_tx_timestamp = 11;
 }
 
 message BeginTransactionRequest {

--- a/ydb/public/api/protos/ydb_query.proto
+++ b/ydb/public/api/protos/ydb_query.proto
@@ -13,6 +13,7 @@ import "ydb/public/api/protos/ydb_operation.proto";
 import "ydb/public/api/protos/ydb_query_stats.proto";
 import "ydb/public/api/protos/ydb_status_codes.proto";
 import "ydb/public/api/protos/ydb_value.proto";
+import "ydb/public/api/protos/ydb_common.proto";
 
 message CreateSessionRequest {
 }
@@ -200,6 +201,10 @@ message ExecuteQueryResponsePart {
     Ydb.TableStats.QueryStats exec_stats = 5;
 
     TransactionMeta tx_meta = 6;
+
+    // Optional timestamp that corresponds to the returned data
+    // That timestamp can be compared with CDC timestamp to make sure is data already present in async stream
+    VirtualTimestamp snapshot = 7;
 }
 
 message ExecuteScriptRequest {

--- a/ydb/public/api/protos/ydb_table.proto
+++ b/ydb/public/api/protos/ydb_table.proto
@@ -1293,6 +1293,10 @@ message ExecuteScanQueryPartialResult {
     // works only in mode: MODE_EXPLAIN,
     // collects additional diagnostics about query compilation, including query plan and scheme
     string query_full_diagnostics = 7 [deprecated = true];
+
+    // Optional timestamp that corresponds to the returned data
+    // That timestamp can be compared with CDC timestamp to make sure is data already present in async stream
+    VirtualTimestamp snapshot = 8;
 }
 
 // Returns information about an external data source with a given path.

--- a/ydb/public/api/protos/ydb_table.proto
+++ b/ydb/public/api/protos/ydb_table.proto
@@ -1294,9 +1294,8 @@ message ExecuteScanQueryPartialResult {
     // collects additional diagnostics about query compilation, including query plan and scheme
     string query_full_diagnostics = 7 [deprecated = true];
 
-    // Optional timestamp that corresponds to the returned data
-    // That timestamp can be compared with CDC timestamp to make sure is data already present in async stream
-    VirtualTimestamp snapshot = 8;
+    // Optional timestamp that represents snapshot acquired to scan data
+    VirtualTimestamp snapshot_timestamp = 8;
 }
 
 // Returns information about an external data source with a given path.


### PR DESCRIPTION
![Untitled Diagram drawio-2](https://github.com/user-attachments/assets/d6fb832d-286d-467a-bcf5-57aec3edc2a4)


- YDB has CDC feature which allows to get async stream of changes to process it somewhere outside.
- Although we speak about async changes it is important to know whether particular changes already present in data we read from CDC or not.
- CDC already has feature called virtual timestamp which allows to restore transactions order on the receiver side (used in Aardappel)

The simplest way to achieve it - return virtual timestamp as side information in the execute query result. This feature already implemented for read table result.

Execution modes which can return virtual timestamp in current code base:
ExecuteScanQuery (TableService)
ExecuteQuery RO with MVCC (QueryService)
ExecuteQuery RW non interactive

Execution modes which unable to return virtual timestamp
ExecuteQuery RW interactive
