### PR TITLE
Merge kafka-proxy improvements and fixes

### DIFF
--- a/ydb/core/config/init/init_impl.h
+++ b/ydb/core/config/init/init_impl.h
@@ -315,6 +315,7 @@ struct TCommonAppOptions {
     TString GRpcPublicHost = "";
     ui32 GRpcPublicPort = 0;
     ui32 GRpcsPublicPort = 0;
+    ui32 KafkaPort = 0;
     TVector<TString> GRpcPublicAddressesV4;
     TVector<TString> GRpcPublicAddressesV6;
     TString GRpcPublicTargetNameOverride = "";
@@ -383,6 +384,7 @@ struct TCommonAppOptions {
         opts.AddLongOption("grpc-public-host", "set public gRPC host for discovery").RequiredArgument("HOST").StoreResult(&GRpcPublicHost);
         opts.AddLongOption("grpc-public-port", "set public gRPC port for discovery").RequiredArgument("PORT").StoreResult(&GRpcPublicPort);
         opts.AddLongOption("grpcs-public-port", "set public gRPC SSL port for discovery").RequiredArgument("PORT").StoreResult(&GRpcsPublicPort);
+        opts.AddLongOption("kafka-port", "enable kafka proxy to listen on port").OptionalArgument("PORT").StoreResult(&KafkaPort);
         opts.AddLongOption("grpc-public-address-v4", "set public ipv4 address for discovery").RequiredArgument("ADDR").EmplaceTo(&GRpcPublicAddressesV4);
         opts.AddLongOption("grpc-public-address-v6", "set public ipv6 address for discovery").RequiredArgument("ADDR").EmplaceTo(&GRpcPublicAddressesV6);
         opts.AddLongOption("grpc-public-target-name-override", "set public hostname override for TLS in discovery").RequiredArgument("HOST").StoreResult(&GRpcPublicTargetNameOverride);
@@ -596,6 +598,12 @@ struct TCommonAppOptions {
                 }
             }
             ConfigUpdateTracer.AddUpdate(NKikimrConsole::TConfigItem::GRpcConfigItem, TConfigItemInfo::EUpdateKind::UpdateExplicitly);
+        }
+	if (KafkaPort) {
+            auto& conf = *appConfig.MutableKafkaProxyConfig();
+            conf.SetEnableKafkaProxy(true);
+            conf.SetListeningPort(KafkaPort);
+            ConfigUpdateTracer.AddUpdate(NKikimrConsole::TConfigItem::KafkaProxyConfigItem, TConfigItemInfo::EUpdateKind::UpdateExplicitly);
         }
         for (const auto& addr : GRpcPublicAddressesV4) {
             appConfig.MutableGRpcConfig()->AddPublicAddressesV4(addr);

--- a/ydb/core/discovery/discovery.cpp
+++ b/ydb/core/discovery/discovery.cpp
@@ -46,6 +46,16 @@ namespace NDiscovery {
         return false;
     }
 
+    bool CheckEndpointId(const TString& endpointId, const NKikimrStateStorage::TEndpointBoardEntry &entry) {
+        if (endpointId.empty() && !entry.HasEndpointId())
+            return true;
+
+        if (entry.HasEndpointId() && entry.GetEndpointId() == endpointId)
+            return true;
+
+        return false;
+    }
+
     bool IsSafeLocationMarker(TStringBuf location) {
         const ui8* isrc = reinterpret_cast<const ui8*>(location.data());
         for (auto idx : xrange(location.size())) {
@@ -128,6 +138,7 @@ namespace NDiscovery {
                 const TMap<TActorId, TEvStateStorage::TBoardInfoEntry>& prevInfoEntries,
                 TMap<TActorId, TEvStateStorage::TBoardInfoEntry> newInfoEntries,
                 TSet<TString> services,
+                TString endpointId,
                 const THolder<TEvInterconnect::TEvNodeInfo>& nameserviceResponse) {
         TMap<TActorId, TEvStateStorage::TBoardInfoEntry> infoEntries;
         if (prevInfoEntries.empty()) {

--- a/ydb/core/discovery/discovery.h
+++ b/ydb/core/discovery/discovery.h
@@ -59,6 +59,7 @@ namespace NDiscovery {
         const TMap<TActorId, TEvStateStorage::TBoardInfoEntry>&,
         TMap<TActorId, TEvStateStorage::TBoardInfoEntry>,
         TSet<TString>,
+        TString,
         const THolder<TEvInterconnect::TEvNodeInfo>&);
 }
 

--- a/ydb/core/discovery/discovery.h
+++ b/ydb/core/discovery/discovery.h
@@ -74,6 +74,6 @@ IActor* CreateDiscoverer(
     const TActorId& cacheId);
 
 // Used to reduce number of requests to Board
-IActor* CreateDiscoveryCache();
+IActor* CreateDiscoveryCache(const TString& endpointId = {});
 
 }

--- a/ydb/core/driver_lib/run/config_parser.cpp
+++ b/ydb/core/driver_lib/run/config_parser.cpp
@@ -66,6 +66,7 @@ void TRunCommandConfigParser::SetupLastGetOptForConfigFiles(NLastGetopt::TOpts& 
     opts.AddLongOption("grpc-file", "gRPC config file").OptionalArgument("PATH");
     opts.AddLongOption("grpc-port", "enable gRPC server on port").RequiredArgument("PORT");
     opts.AddLongOption("grpcs-port", "enable gRPC SSL server on port").RequiredArgument("PORT");
+    opts.AddLongOption("kafka-port", "enable kafka proxy server on port").OptionalArgument("PORT");
     opts.AddLongOption("grpc-public-host", "set public gRPC host for discovery").RequiredArgument("HOST");
     opts.AddLongOption("grpc-public-port", "set public gRPC port for discovery").RequiredArgument("PORT");
     opts.AddLongOption("grpcs-public-port", "set public gRPC SSL port for discovery").RequiredArgument("PORT");
@@ -162,6 +163,11 @@ void TRunCommandConfigParser::ParseConfigFiles(const NLastGetopt::TOptsParseResu
         auto& conf = *Config.AppConfig.MutableGRpcConfig();
         conf.SetStartGRpcProxy(true);
         conf.SetSslPort(FromString<ui16>(res.Get("grpcs-port")));
+    }
+
+    if (res.Has("kafka-port")) {
+        auto& conf = *Config.AppConfig.MutableKafkaProxyConfig();
+        conf.SetListeningPort(FromString<ui16>(res.Get("kafka-port")));
     }
 
     if (res.Has("grpc-public-host")) {

--- a/ydb/core/driver_lib/run/kikimr_services_initializers.cpp
+++ b/ydb/core/driver_lib/run/kikimr_services_initializers.cpp
@@ -1802,6 +1802,9 @@ void TGRpcServicesInitializer::InitializeServices(NActors::TActorSystemSetup* se
             stringsFromProto(desc->AddressesV6, config.GetPublicAddressesV6());
 
             desc->ServedServices.insert(desc->ServedServices.end(), config.GetServices().begin(), config.GetServices().end());
+            if (config.HasEndpointId()) {
+                desc->EndpointId = config.GetEndpointId();
+            }
             endpoints.push_back(std::move(desc));
         }
 
@@ -1816,6 +1819,9 @@ void TGRpcServicesInitializer::InitializeServices(NActors::TActorSystemSetup* se
             desc->TargetNameOverride = config.GetPublicTargetNameOverride();
 
             desc->ServedServices.insert(desc->ServedServices.end(), config.GetServices().begin(), config.GetServices().end());
+            if (config.HasEndpointId()) {
+                desc->EndpointId = config.GetEndpointId();
+            }
             endpoints.push_back(std::move(desc));
         }
 
@@ -1843,6 +1849,9 @@ void TGRpcServicesInitializer::InitializeServices(NActors::TActorSystemSetup* se
                 stringsFromProto(desc->AddressesV6, sx.GetPublicAddressesV6());
 
                 desc->ServedServices.insert(desc->ServedServices.end(), sx.GetServices().begin(), sx.GetServices().end());
+                if (sx.HasEndpointId()) {
+                    desc->EndpointId = sx.GetEndpointId();
+                }
                 endpoints.push_back(std::move(desc));
             }
 
@@ -1857,6 +1866,9 @@ void TGRpcServicesInitializer::InitializeServices(NActors::TActorSystemSetup* se
                 desc->TargetNameOverride = sx.GetPublicTargetNameOverride();
 
                 desc->ServedServices.insert(desc->ServedServices.end(), sx.GetServices().begin(), sx.GetServices().end());
+                if (sx.HasEndpointId()) {
+                    desc->EndpointId = sx.GetEndpointId();
+                }
                 endpoints.push_back(std::move(desc));
             }
         }

--- a/ydb/core/driver_lib/run/run.cpp
+++ b/ydb/core/driver_lib/run/run.cpp
@@ -920,6 +920,10 @@ void TKikimrRunner::InitializeGRpc(const TKikimrRunConfig& runConfig) {
             opts.SetKeepAliveEnable(false);
         }
 
+        if (grpcConfig.HasEndpointId()) {
+            opts.SetEndpointId(grpcConfig.GetEndpointId());
+        }
+
         NConsole::SetGRpcLibraryFunction();
 
 #define GET_PATH_TO_FILE(GRPC_CONFIG, PRIMARY_FIELD, SECONDARY_FIELD) \
@@ -961,6 +965,10 @@ void TKikimrRunner::InitializeGRpc(const TKikimrRunConfig& runConfig) {
                 if (ex.GetHost())
                     xopts.SetHost(ex.GetHost());
 
+                if (ex.HasEndpointId()) {
+                    xopts.SetEndpointId(ex.GetEndpointId());
+                }
+
                 GRpcServers.push_back({ "grpc", new NYdbGrpc::TGRpcServer(xopts) });
                 fillFn(ex, *GRpcServers.back().second, xopts);
             }
@@ -969,6 +977,9 @@ void TKikimrRunner::InitializeGRpc(const TKikimrRunConfig& runConfig) {
                 NYdbGrpc::TServerOptions xopts = opts;
                 xopts.SetPort(ex.GetSslPort());
 
+                if (ex.HasEndpointId()) {
+                    xopts.SetEndpointId(ex.GetEndpointId());
+                }
 
                 NYdbGrpc::TSslData sslData;
 

--- a/ydb/core/grpc_services/base/base.h
+++ b/ydb/core/grpc_services/base/base.h
@@ -1318,6 +1318,10 @@ public:
         Ctx_->ReplyError(code, msg, details);
     }
 
+    TString GetEndpointId() const {
+        return Ctx_->GetEndpointId();
+    }
+
 private:
     void Reply(NProtoBuf::Message *resp, ui32 status) override {
         // End Of Request for non streaming requests

--- a/ydb/core/grpc_services/grpc_endpoint.h
+++ b/ydb/core/grpc_services/grpc_endpoint.h
@@ -27,5 +27,6 @@ inline TActorId CreateGrpcPublisherServiceActorId() {
     return actorId;
 }
 
+const static TString KafkaEndpointId = "KafkaProxy";
 }
 }

--- a/ydb/core/grpc_services/grpc_endpoint.h
+++ b/ydb/core/grpc_services/grpc_endpoint.h
@@ -17,6 +17,7 @@ struct TGrpcEndpointDescription : public TThrRefBase {
 
     TVector<TString> ServedServices;
     TVector<TString> ServedDatabases;
+    TString EndpointId;
 };
 
 IActor* CreateGrpcEndpointPublishActor(TGrpcEndpointDescription *description);

--- a/ydb/core/grpc_services/grpc_endpoint_publish_actor.cpp
+++ b/ydb/core/grpc_services/grpc_endpoint_publish_actor.cpp
@@ -48,6 +48,9 @@ class TGRpcEndpointPublishActor : public TActorBootstrapped<TGRpcEndpointPublish
         if (Description->TargetNameOverride) {
             entry.SetTargetNameOverride(Description->TargetNameOverride);
         }
+        if (Description->EndpointId) {
+            entry.SetEndpointId(Description->EndpointId);
+        }
         for (const auto &service : Description->ServedServices)
             entry.AddServices(service);
 

--- a/ydb/core/grpc_services/local_grpc/local_grpc.h
+++ b/ydb/core/grpc_services/local_grpc/local_grpc.h
@@ -54,6 +54,8 @@ public:
         return GRPC_COMPRESS_LEVEL_NONE;
     }
 
+    TString GetEndpointId() const override { return {}; }
+
     google::protobuf::Arena* GetArena() override {
         return &Arena_;
     }

--- a/ydb/core/grpc_services/rpc_discovery.cpp
+++ b/ydb/core/grpc_services/rpc_discovery.cpp
@@ -134,14 +134,16 @@ public:
 
         TString cachedMessage, cachedMessageSsl;
 
-        if (services.empty() && !LookupResponse->CachedMessageData->CachedMessage.empty() &&
+        TString endpointId = Request->GetEndpointId();
+
+        if (endpointId.empty() && services.empty() && !LookupResponse->CachedMessageData->CachedMessage.empty() &&
                 !LookupResponse->CachedMessageData->CachedMessageSsl.empty()) {
             cachedMessage = LookupResponse->CachedMessageData->CachedMessage;
             cachedMessageSsl = LookupResponse->CachedMessageData->CachedMessageSsl;
         } else {
             auto cachedMessageData = NDiscovery::CreateCachedMessage(
                 {}, std::move(LookupResponse->CachedMessageData->InfoEntries),
-                std::move(services), NameserviceResponse);
+                std::move(services), std::move(endpointId), NameserviceResponse);
             cachedMessage = std::move(cachedMessageData.CachedMessage);
             cachedMessageSsl = std::move(cachedMessageData.CachedMessageSsl);
         }

--- a/ydb/core/kafka_proxy/actors/actors.h
+++ b/ydb/core/kafka_proxy/actors/actors.h
@@ -54,6 +54,8 @@ struct TContext {
     bool Authenticated() {
         return !RequireAuthentication || AuthenticationStep == SUCCESS;
     }
+
+    TActorId DiscoveryCacheActor;
 };
 
 template<std::derived_from<TApiMessage> T>
@@ -167,7 +169,9 @@ inline TString GetUserSerializedToken(std::shared_ptr<TContext> context) {
 
 NActors::IActor* CreateKafkaApiVersionsActor(const TContext::TPtr context, const ui64 correlationId, const TMessagePtr<TApiVersionsRequestData>& message);
 NActors::IActor* CreateKafkaInitProducerIdActor(const TContext::TPtr context, const ui64 correlationId, const TMessagePtr<TInitProducerIdRequestData>& message);
-NActors::IActor* CreateKafkaMetadataActor(const TContext::TPtr context, const ui64 correlationId, const TMessagePtr<TMetadataRequestData>& message);
+NActors::IActor* CreateKafkaMetadataActor(const TContext::TPtr context, const ui64 correlationId,
+                                          const TMessagePtr<TMetadataRequestData>& message,
+                                          const TActorId& discoveryCacheActor);
 NActors::IActor* CreateKafkaProduceActor(const TContext::TPtr context);
 NActors::IActor* CreateKafkaReadSessionActor(const TContext::TPtr context, ui64 cookie);
 NActors::IActor* CreateKafkaSaslHandshakeActor(const TContext::TPtr context, const ui64 correlationId, const TMessagePtr<TSaslHandshakeRequestData>& message);

--- a/ydb/core/kafka_proxy/actors/kafka_fetch_actor.cpp
+++ b/ydb/core/kafka_proxy/actors/kafka_fetch_actor.cpp
@@ -148,7 +148,7 @@ void TKafkaFetchActor::FillRecordsBatch(const NKikimrClient::TPersQueueFetchResp
         }
 
         lastOffset = result.GetOffset();
-        lastTimestamp = result.GetWriteTimestampMS();
+        lastTimestamp = result.GetCreateTimestampMS();
         auto& record = recordsBatch.Records[recordIndex];
 
         record.DataChunk = NKikimr::GetDeserializedData(result.GetData());

--- a/ydb/core/kafka_proxy/actors/kafka_metadata_actor.cpp
+++ b/ydb/core/kafka_proxy/actors/kafka_metadata_actor.cpp
@@ -140,11 +140,11 @@ void TKafkaMetadataActor::ProcessTopics() {
 }
 
 TActorId TKafkaMetadataActor::SendTopicRequest(const TMetadataRequestData::TMetadataRequestTopic& topicRequest) {
-    KAFKA_LOG_D("Describe partitions locations for topic '" << *topicRequest.Name << "' for user '" << Context->UserToken->GetUserSID() << "'");
+    KAFKA_LOG_D("Describe partitions locations for topic '" << *topicRequest.Name << "' for user '" << GetUsernameOrAnonymous(Context) << "'");
 
     TGetPartitionsLocationRequest locationRequest{};
     locationRequest.Topic = NormalizePath(Context->DatabasePath, topicRequest.Name.value());
-    locationRequest.Token = Context->UserToken->GetSerializedToken();
+    locationRequest.Token = GetUserSerializedToken(Context);
     locationRequest.Database = Context->DatabasePath;
 
     PendingResponses++;

--- a/ydb/core/kafka_proxy/actors/kafka_metadata_actor.cpp
+++ b/ydb/core/kafka_proxy/actors/kafka_metadata_actor.cpp
@@ -2,14 +2,23 @@
 
 #include <ydb/core/kafka_proxy/kafka_events.h>
 #include <ydb/services/persqueue_v1/actors/schema_actors.h>
+#include <ydb/core/grpc_services/grpc_endpoint.h>
+#include <ydb/core/base/statestorage.h>
 
 namespace NKafka {
+using namespace NKikimr;
 using namespace NKikimr::NGRpcProxy::V1;
+
+TActorId MakeKafkaDiscoveryCacheID() {
+    static const char x[12] = "kafka_dsc_c";
+    return TActorId(0, TStringBuf(x, 12));
+}
 
 NActors::IActor* CreateKafkaMetadataActor(const TContext::TPtr context,
                                           const ui64 correlationId,
-                                          const TMessagePtr<TMetadataRequestData>& message) {
-    return new TKafkaMetadataActor(context, correlationId, message);
+                                          const TMessagePtr<TMetadataRequestData>& message,
+                                          const TActorId& discoveryCacheActor) {
+    return new TKafkaMetadataActor(context, correlationId, message, discoveryCacheActor);
 }
 
 void TKafkaMetadataActor::Bootstrap(const TActorContext& ctx) {
@@ -19,31 +28,91 @@ void TKafkaMetadataActor::Bootstrap(const TActorContext& ctx) {
 
     if (WithProxy) {
         AddProxyNodeToBrokers();
-    }
+    } else {
+        SendDiscoveryRequest();
 
-    if (Message->Topics.size() == 0 && !WithProxy) {
-        AddCurrentNodeToBrokers();
+        if (Message->Topics.size() == 0) {
+            NeedCurrentNode = true;
+        }
     }
 
     if (Message->Topics.size() != 0) {
         ProcessTopics();
     }
-    
+
     Become(&TKafkaMetadataActor::StateWork);
     RespondIfRequired(ctx);
 }
 
-void TKafkaMetadataActor::AddCurrentNodeToBrokers() {
+void TKafkaMetadataActor::SendDiscoveryRequest() {
+    Y_VERIFY_DEBUG(DiscoveryCacheActor);
     PendingResponses++;
-    Send(NKikimr::NIcNodeCache::CreateICNodesInfoCacheServiceId(), new NKikimr::NIcNodeCache::TEvICNodesInfoCache::TEvGetAllNodesInfoRequest());
+    Register(CreateDiscoverer(&MakeEndpointsBoardPath, Context->DatabasePath, SelfId(), DiscoveryCacheActor));
+}
+
+
+void TKafkaMetadataActor::HandleDiscoveryError(TEvDiscovery::TEvError::TPtr& ev) {
+    PendingResponses--;
+    HaveError = true;
+    KAFKA_LOG_ERROR("Port discovery failed for database '" << Context->DatabasePath << "' with error '" << ev->Get()->Error
+                    << ", request " << CorrelationId);
+
+    RespondIfRequired(ActorContext());
+}
+
+void TKafkaMetadataActor::HandleDiscoveryData(TEvDiscovery::TEvDiscoveryData::TPtr& ev) {
+    PendingResponses--;
+    ProcessDiscoveryData(ev);
+    RespondIfRequired(ActorContext());
+}
+
+void TKafkaMetadataActor::ProcessDiscoveryData(TEvDiscovery::TEvDiscoveryData::TPtr& ev) {
+    bool expectSsl = Context->Config.HasSslCertificate();
+
+    Ydb::Discovery::ListEndpointsResponse leResponse;
+    Ydb::Discovery::ListEndpointsResult leResult;
+    TString const* cachedMessage;
+    if (expectSsl) {
+        cachedMessage = &ev->Get()->CachedMessageData->CachedMessageSsl;
+    } else {
+        cachedMessage = &ev->Get()->CachedMessageData->CachedMessage;
+    }
+    auto ok = leResponse.ParseFromString(*cachedMessage);
+    if (ok) {
+        ok = leResponse.operation().result().UnpackTo(&leResult);
+    }
+    if (!ok) {
+        KAFKA_LOG_ERROR("Port discovery failed, unable to parse discovery respose for request " << CorrelationId);
+        HaveError = true;
+        return;
+    }
+
+    for (auto& endpoint : leResult.endpoints()) {
+        Nodes.insert({endpoint.node_id(), {endpoint.address(), endpoint.port()}});
+    }
+}
+
+void TKafkaMetadataActor::RequestICNodeCache() {
+    Y_ABORT_UNLESS(!FallbackToIcDiscovery);
+    FallbackToIcDiscovery = true;
+    PendingResponses++;
+    Send(NKikimr::NIcNodeCache::CreateICNodesInfoCacheServiceId(), new NIcNodeCache::TEvICNodesInfoCache::TEvGetAllNodesInfoRequest());
+}
+
+void TKafkaMetadataActor::HandleNodesResponse(
+        NKikimr::NIcNodeCache::TEvICNodesInfoCache::TEvGetAllNodesInfoResponse::TPtr& ev,
+        const NActors::TActorContext& ctx
+) {
+    Y_ABORT_UNLESS(FallbackToIcDiscovery);
+    for (const auto& [nodeId, index] : *ev->Get()->NodeIdsMapping) {
+        Nodes[nodeId] = {(*ev->Get()->Nodes)[index].Host, (ui32)Context->Config.GetListeningPort()};
+    }
+    --PendingResponses;
+    RespondIfRequired(ctx);
 }
 
 void TKafkaMetadataActor::AddProxyNodeToBrokers() {
-    auto broker = TMetadataResponseData::TMetadataResponseBroker{};
-    broker.NodeId = ProxyNodeId;
-    broker.Host = Context->Config.GetProxy().GetHostname();
-    broker.Port = Context->Config.GetProxy().GetPort();
-    Response->Brokers.emplace_back(std::move(broker));
+    AddBroker(ProxyNodeId, Context->Config.GetProxy().GetHostname(), Context->Config.GetProxy().GetPort());
 }
 
 void TKafkaMetadataActor::ProcessTopics() {
@@ -70,34 +139,30 @@ void TKafkaMetadataActor::ProcessTopics() {
     }
 }
 
-void TKafkaMetadataActor::HandleNodesResponse(NKikimr::NIcNodeCache::TEvICNodesInfoCache::TEvGetAllNodesInfoResponse::TPtr& ev, const NActors::TActorContext& ctx) {
-    auto iter = ev->Get()->NodeIdsMapping->find(ctx.SelfID.NodeId());
-    Y_ABORT_UNLESS(!iter.IsEnd());
-	auto host = (*ev->Get()->Nodes)[iter->second].Host;
-    KAFKA_LOG_D("Incoming TEvGetAllNodesInfoResponse. Host#: " << host);
-
-    auto broker = TMetadataResponseData::TMetadataResponseBroker{};
-    broker.NodeId = ctx.SelfID.NodeId();
-    broker.Host = host;
-    broker.Port = Context->Config.GetListeningPort();
-    Response->Brokers.emplace_back(std::move(broker));
-
-    --PendingResponses;
-    RespondIfRequired(ctx);
-}
-
 TActorId TKafkaMetadataActor::SendTopicRequest(const TMetadataRequestData::TMetadataRequestTopic& topicRequest) {
-    KAFKA_LOG_D("Describe partitions locations for topic '" << *topicRequest.Name << "' for user " << GetUsernameOrAnonymous(Context));
+    KAFKA_LOG_D("Describe partitions locations for topic '" << *topicRequest.Name << "' for user '" << Context->UserToken->GetUserSID() << "'");
 
     TGetPartitionsLocationRequest locationRequest{};
     locationRequest.Topic = NormalizePath(Context->DatabasePath, topicRequest.Name.value());
-    locationRequest.Token = GetUserSerializedToken(Context);
+    locationRequest.Token = Context->UserToken->GetSerializedToken();
     locationRequest.Database = Context->DatabasePath;
 
     PendingResponses++;
 
     return Register(new TPartitionsLocationActor(locationRequest, SelfId()));
-} 
+}
+
+TVector<TKafkaMetadataActor::TNodeInfo*> TKafkaMetadataActor::CheckTopicNodes(TEvLocationResponse* response) {
+    TVector<TNodeInfo*> partitionNodes;
+    for (const auto& part : response->Partitions) {
+        auto iter = Nodes.find(part.NodeId);
+        if (iter.IsEnd()) {
+            return {};
+        }
+        partitionNodes.push_back(&iter->second);
+    }
+    return partitionNodes;
+}
 
 void TKafkaMetadataActor::AddTopicError(
     TMetadataResponseData::TMetadataResponseTopic& topic, EKafkaErrors errorCode
@@ -106,10 +171,15 @@ void TKafkaMetadataActor::AddTopicError(
     ErrorCode = errorCode;
 }
 
-void TKafkaMetadataActor::AddTopicResponse(TMetadataResponseData::TMetadataResponseTopic& topic, TEvLocationResponse* response) {
+void TKafkaMetadataActor::AddTopicResponse(
+        TMetadataResponseData::TMetadataResponseTopic& topic,
+        TEvLocationResponse* response,
+        const TVector<TKafkaMetadataActor::TNodeInfo*>& partitionNodes
+) {
     topic.ErrorCode = NONE_ERROR;
 
     topic.Partitions.reserve(response->Partitions.size());
+    auto nodeIter = partitionNodes.begin();
     for (const auto& part : response->Partitions) {
         auto nodeId = WithProxy ? ProxyNodeId : part.NodeId;
 
@@ -126,28 +196,24 @@ void TKafkaMetadataActor::AddTopicResponse(TMetadataResponseData::TMetadataRespo
         if (!WithProxy) {
             auto ins = AllClusterNodes.insert(part.NodeId);
             if (ins.second) {
-                auto hostname = part.Hostname;
+                auto hostname = (*nodeIter)->Host;
                 if (hostname.StartsWith(UnderlayPrefix)) {
                     hostname = hostname.substr(sizeof(UnderlayPrefix) - 1);
                 }
-
-                auto broker = TMetadataResponseData::TMetadataResponseBroker{};
-                broker.NodeId = part.NodeId;
-                broker.Host = hostname;
-                broker.Port = Context->Config.GetListeningPort();
-                Response->Brokers.emplace_back(std::move(broker));
+                AddBroker(part.NodeId, hostname, (*nodeIter)->Port);
             }
         }
+        ++nodeIter;
     }
 }
 
-void TKafkaMetadataActor::HandleResponse(TEvLocationResponse::TPtr ev, const TActorContext& ctx) {
+void TKafkaMetadataActor::HandleLocationResponse(TEvLocationResponse::TPtr ev, const TActorContext& ctx) {
     --PendingResponses;
 
     auto* r = ev->Get();
     auto actorIter = TopicIndexes.find(ev->Sender);
 
-    Y_DEBUG_ABORT_UNLESS(!actorIter.IsEnd()); 
+    Y_DEBUG_ABORT_UNLESS(!actorIter.IsEnd());
     Y_DEBUG_ABORT_UNLESS(!actorIter->second.empty());
 
     if (actorIter.IsEnd()) {
@@ -157,29 +223,79 @@ void TKafkaMetadataActor::HandleResponse(TEvLocationResponse::TPtr ev, const TAc
 
     if (actorIter->second.empty()) {
         KAFKA_LOG_CRIT("Corrupted state (empty actorId in mapping). Ignored location response, expect incomplete reply");
-
         return RespondIfRequired(ctx);
     }
-    
+
     for (auto index : actorIter->second) {
         auto& topic = Response->Topics[index];
         if (r->Status == Ydb::StatusIds::SUCCESS) {
             KAFKA_LOG_D("Describe topic '" << topic.Name << "' location finishied successful");
-            AddTopicResponse(topic, r);
+            PendingTopicResponses.insert(std::make_pair(index, ev->Release()));
         } else {
             KAFKA_LOG_ERROR("Describe topic '" << topic.Name << "' location finishied with error: Code=" << r->Status << ", Issues=" << r->Issues.ToOneLineString());
             AddTopicError(topic, ConvertErrorCode(r->Status));
         }
     }
+    RespondIfRequired(ctx);
+}
 
-    RespondIfRequired(ActorContext());
+void TKafkaMetadataActor::AddBroker(ui64 nodeId, const TString& host, ui64 port) {
+    auto broker = TMetadataResponseData::TMetadataResponseBroker{};
+    broker.NodeId = nodeId;
+    broker.Host = host;
+    broker.Port = port;
+    Response->Brokers.emplace_back(std::move(broker));
 }
 
 void TKafkaMetadataActor::RespondIfRequired(const TActorContext& ctx) {
-    if (PendingResponses == 0) {
+    auto Respond = [&] {
         Send(Context->ConnectionId, new TEvKafka::TEvResponse(CorrelationId, Response, ErrorCode));
         Die(ctx);
+    };
+
+    if (HaveError) {
+        ErrorCode = EKafkaErrors::LISTENER_NOT_FOUND;
+        for (auto& topic : Response->Topics) {
+            AddTopicError(topic, ErrorCode);
+        }
+        Respond();
+        return;
     }
+    if (PendingResponses != 0) {
+        return;
+    }
+
+    if (NeedCurrentNode) {
+        auto nodeIter = Nodes.find(SelfId().NodeId());
+        if (nodeIter.IsEnd()) {
+            // Node info was not found, request from IC nodes cache instead
+            RequestICNodeCache();
+            return;
+        }
+        AddBroker(nodeIter->first, nodeIter->second.Host, nodeIter->second.Port);
+        NeedCurrentNode = false;
+    }
+    while (!PendingTopicResponses.empty()) {
+        auto& [index, ev] = *PendingTopicResponses.begin();
+        auto& topic = Response->Topics[index];
+        auto topicNodes = CheckTopicNodes(ev.Get());
+        if (topicNodes.empty()) {
+            if (!FallbackToIcDiscovery) {
+                // Node info wasn't found via discovery, fallback to interconnect
+                RequestICNodeCache();
+                return;
+            } else {
+                // Already tried both YDB discovery and interconnect, still couldn't find the node for partition. Throw error
+                KAFKA_LOG_ERROR("Could not discovery kafka port for topic '" << topic.Name);
+                AddTopicError(topic, EKafkaErrors::LISTENER_NOT_FOUND);
+            }
+        } else {
+            AddTopicResponse(topic, ev.Get(), topicNodes);
+        }
+        PendingTopicResponses.erase(PendingTopicResponses.begin());
+    }
+
+    Respond();
 }
 
 TString TKafkaMetadataActor::LogPrefix() const {

--- a/ydb/core/kafka_proxy/actors/kafka_metadata_actor.h
+++ b/ydb/core/kafka_proxy/actors/kafka_metadata_actor.h
@@ -7,6 +7,7 @@
 #include <ydb/services/persqueue_v1/actors/schema_actors.h>
 #include <ydb/core/discovery/discovery.h>
 #include <ydb/core/kafka_proxy/kafka_listener.h>
+#include <ydb/core/persqueue/events/internal.h>
 
 
 namespace NKafka {
@@ -33,12 +34,13 @@ private:
         ui32 Port;
     };
 
-    TActorId SendTopicRequest(const TMetadataRequestData::TMetadataRequestTopic& topicRequest);
+    TActorId SendTopicRequest(const TString& topic);
     void HandleLocationResponse(TEvLocationResponse::TPtr ev, const NActors::TActorContext& ctx);
     void HandleNodesResponse(NKikimr::NIcNodeCache::TEvICNodesInfoCache::TEvGetAllNodesInfoResponse::TPtr& ev,
                              const NActors::TActorContext& ctx);
     void HandleDiscoveryData(NKikimr::TEvDiscovery::TEvDiscoveryData::TPtr& ev);
     void HandleDiscoveryError(NKikimr::TEvDiscovery::TEvError::TPtr& ev);
+    void HandleListTopics(NKikimr::TEvPQ::TEvListAllTopicsResponse::TPtr& ev);
 
     void AddTopicResponse(TMetadataResponseData::TMetadataResponseTopic& topic, TEvLocationResponse* response,
                           const TVector<TNodeInfo*>& nodes);
@@ -47,10 +49,12 @@ private:
     void AddProxyNodeToBrokers();
     void AddBroker(ui64 nodeId, const TString& host, ui64 port);
     void RequestICNodeCache();
-    void ProcessTopics();
+    void ProcessTopicsFromRequest();
     void SendDiscoveryRequest();
     void ProcessDiscoveryData(NKikimr::TEvDiscovery::TEvDiscoveryData::TPtr& ev);
     TVector<TNodeInfo*> CheckTopicNodes(TEvLocationResponse* response);
+
+    void AddTopic(const TString& topic, ui64 index);
 
     STATEFN(StateWork) {
         switch (ev->GetTypeRewrite()) {
@@ -58,6 +62,7 @@ private:
             HFunc(NKikimr::NIcNodeCache::TEvICNodesInfoCache::TEvGetAllNodesInfoResponse, HandleNodesResponse);
             hFunc(NKikimr::TEvDiscovery::TEvDiscoveryData, HandleDiscoveryData);
             hFunc(NKikimr::TEvDiscovery::TEvError, HandleDiscoveryError);
+            hFunc(NKikimr::TEvPQ::TEvListAllTopicsResponse, HandleListTopics);
         }
     }
 
@@ -77,12 +82,14 @@ private:
     EKafkaErrors ErrorCode = EKafkaErrors::NONE_ERROR;
 
     TActorId DiscoveryCacheActor;
-    bool NeedCurrentNode = false;
+    bool NeedAllNodes = false;
     bool HaveError = false;
     bool FallbackToIcDiscovery = false;
     TMap<ui64, TAutoPtr<TEvLocationResponse>> PendingTopicResponses;
 
     THashMap<ui64, TNodeInfo> Nodes;
+    THashMap<TString, TActorId> PartitionActors;
+
 };
 
 } // namespace NKafka

--- a/ydb/core/kafka_proxy/actors/kafka_sasl_auth_actor.cpp
+++ b/ydb/core/kafka_proxy/actors/kafka_sasl_auth_actor.cpp
@@ -161,7 +161,12 @@ void TKafkaSaslAuthActor::SendLoginRequest(TKafkaSaslAuthActor::TAuthData authDa
 
 void TKafkaSaslAuthActor::SendApiKeyRequest() {
     auto entries = NKikimr::NGRpcProxy::V1::GetTicketParserEntries(DatabaseId, FolderId);
-
+    TString ticket;
+    if (Context->Config.GetAuthViaApiKey()) {
+        ticket = "ApiKey " + ClientAuthData.Password;
+    } else {
+        ticket = ClientAuthData.Password;
+    }
     Send(NKikimr::MakeTicketParserID(), new NKikimr::TEvTicketParser::TEvAuthorizeTicket({
         .Database = DatabasePath,
         .Ticket = "ApiKey " + ClientAuthData.Password,

--- a/ydb/core/kafka_proxy/kafka_connection.cpp
+++ b/ydb/core/kafka_proxy/kafka_connection.cpp
@@ -83,7 +83,8 @@ public:
     TKafkaConnection(const TActorId& listenerActorId,
                      TIntrusivePtr<TSocketDescriptor> socket,
                      TNetworkConfig::TSocketAddressType address,
-                     const NKikimrConfig::TKafkaProxyConfig& config)
+                     const NKikimrConfig::TKafkaProxyConfig& config,
+                     const TActorId& discoveryCacheActorId)
         : ListenerActorId(listenerActorId)
         , Socket(std::move(socket))
         , Address(address)
@@ -91,9 +92,11 @@ public:
         , Step(SIZE_READ)
         , Demand(NoDemand)
         , InflightSize(0)
-        , Context(std::make_shared<TContext>(config)) {
+        , Context(std::make_shared<TContext>(config))
+    {
         SetNonBlock();
         IsSslRequired = Socket->IsSslSupported();
+        Context->DiscoveryCacheActor = discoveryCacheActorId;
     }
 
     void Bootstrap() {
@@ -271,7 +274,7 @@ protected:
     }
 
     void HandleMessage(TRequestHeaderData* header, const TMessagePtr<TMetadataRequestData>& message) {
-        Register(CreateKafkaMetadataActor(Context, header->CorrelationId, message));
+        Register(CreateKafkaMetadataActor(Context, header->CorrelationId, message, Context->DiscoveryCacheActor));
     }
 
     void HandleMessage(const TRequestHeaderData* header, const TMessagePtr<TSaslAuthenticateRequestData>& message) {
@@ -318,7 +321,7 @@ protected:
     TMessagePtr<T> Cast(std::shared_ptr<Msg>& request) {
         return TMessagePtr<T>(request->Buffer, request->Message);
     }
-   
+
     bool ProcessRequest(const TActorContext& ctx) {
         KAFKA_LOG_D("process message: ApiKey=" << Request->Header.RequestApiKey << ", ExpectedSize=" << Request->ExpectedSize
                                                << ", Size=" << Request->Size);
@@ -372,7 +375,7 @@ protected:
             case FETCH:
                 HandleMessage(&Request->Header, Cast<TFetchRequestData>(Request));
                 break;
-            
+
             case JOIN_GROUP:
                 HandleMessage(&Request->Header, Cast<TJoinGroupRequestData>(Request), ctx);
                 break;
@@ -388,11 +391,11 @@ protected:
             case HEARTBEAT:
                 HandleMessage(&Request->Header, Cast<THeartbeatRequestData>(Request), ctx);
                 break;
-            
+
             case FIND_COORDINATOR:
                 HandleMessage(&Request->Header, Cast<TFindCoordinatorRequestData>(Request));
                 break;
-            
+
             case OFFSET_FETCH:
                 HandleMessage(&Request->Header, Cast<TOffsetFetchRequestData>(Request));
                 break;
@@ -481,7 +484,7 @@ protected:
     void HandleKillReadSession() {
         if (ReadSessionActorId) {
             Send(ReadSessionActorId, new TEvents::TEvPoison());
-            
+
             TActorId emptyActor;
             ReadSessionActorId = emptyActor;
         }
@@ -720,6 +723,7 @@ protected:
                 EApiKey::SASL_AUTHENTICATE == apiKey);
     }
 
+
     void HandleConnected(TEvPollerReady::TPtr event, const TActorContext& ctx) {
         if (event->Get()->Read) {
             if (!CloseConnection) {
@@ -783,8 +787,9 @@ protected:
 NActors::IActor* CreateKafkaConnection(const TActorId& listenerActorId,
                                        TIntrusivePtr<TSocketDescriptor> socket,
                                        TNetworkConfig::TSocketAddressType address,
-                                       const NKikimrConfig::TKafkaProxyConfig& config) {
-    return new TKafkaConnection(listenerActorId, std::move(socket), std::move(address), config);
+                                       const NKikimrConfig::TKafkaProxyConfig& config,
+                                       const TActorId& discoveryCacheActorId) {
+    return new TKafkaConnection(listenerActorId, std::move(socket), std::move(address), config, discoveryCacheActorId);
 }
 
 } // namespace NKafka

--- a/ydb/core/kafka_proxy/kafka_connection.h
+++ b/ydb/core/kafka_proxy/kafka_connection.h
@@ -12,6 +12,7 @@ using namespace NKikimr::NRawSocket;
 NActors::IActor* CreateKafkaConnection(const TActorId& listenerActorId,
                                        TIntrusivePtr<TSocketDescriptor> socket,
                                        TNetworkConfig::TSocketAddressType address,
-                                       const NKikimrConfig::TKafkaProxyConfig& config);
+                                       const NKikimrConfig::TKafkaProxyConfig& config,
+                                       const TActorId& discoveryCacheActorId);
 
 } // namespace NKafka

--- a/ydb/core/kafka_proxy/kafka_listener.h
+++ b/ydb/core/kafka_proxy/kafka_listener.h
@@ -7,11 +7,17 @@ namespace NKafka {
 
 using namespace NKikimr::NRawSocket;
 
-inline NActors::IActor* CreateKafkaListener(const NActors::TActorId& poller, const TListenerSettings& settings, const NKikimrConfig::TKafkaProxyConfig& config) {
+
+TActorId MakeKafkaDiscoveryCacheID();
+
+inline NActors::IActor* CreateKafkaListener(
+        const NActors::TActorId& poller, const TListenerSettings& settings, const NKikimrConfig::TKafkaProxyConfig& config,
+        const TActorId& discoveryCacheActorId
+) {
     return CreateSocketListener(
         poller, settings,
         [=](const TActorId& listenerActorId, TIntrusivePtr<TSocketDescriptor> socket, TNetworkConfig::TSocketAddressType address) {
-            return CreateKafkaConnection(listenerActorId, socket, address, config);
+            return CreateKafkaConnection(listenerActorId, socket, address, config, discoveryCacheActorId);
         },
         NKikimrServices::EServiceKikimr::KAFKA_PROXY, EErrorAction::Abort);
 }

--- a/ydb/core/kafka_proxy/ut/metarequest_ut.cpp
+++ b/ydb/core/kafka_proxy/ut/metarequest_ut.cpp
@@ -93,7 +93,7 @@ Y_UNIT_TEST_SUITE(TMetadataActorTests) {
 
         event = GetEvent(server, edgeId, {});
         response = dynamic_cast<TMetadataResponseData*>(event->Response.get());
-        UNIT_ASSERT_VALUES_EQUAL(response->Topics.size(), 0);
+        UNIT_ASSERT_VALUES_EQUAL(response->Topics.size(), 2);
 
         event = GetEvent(server, edgeId, {topicPath}, "proxy-host");
         response = dynamic_cast<TMetadataResponseData*>(event->Response.get());

--- a/ydb/core/kafka_proxy/ut/metarequest_ut.cpp
+++ b/ydb/core/kafka_proxy/ut/metarequest_ut.cpp
@@ -1,5 +1,6 @@
 #include <library/cpp/testing/unittest/registar.h>
 #include <ydb/public/sdk/cpp/client/ydb_persqueue_core/ut/ut_utils/test_server.h>
+
 #include <ydb/core/kafka_proxy/kafka_events.h>
 #include <ydb/core/kafka_proxy/actors/kafka_metadata_actor.h>
 
@@ -29,9 +30,11 @@ Y_UNIT_TEST_SUITE(TMetadataActorTests) {
 
         auto context = std::make_shared<TContext>(Config);
         context->ConnectionId = edgeActor;
+        context->DatabasePath = "/Root";
         context->UserToken = new NACLib::TUserToken("root@builtin", {});
 
-        auto actorId = runtime->Register(new TKafkaMetadataActor(context, 1, TMessagePtr<TMetadataRequestData>(std::make_shared<TBuffer>(), request)));
+        auto actorId = runtime->Register(new TKafkaMetadataActor(context, 1, TMessagePtr<TMetadataRequestData>(std::make_shared<TBuffer>(), request),
+                                                                 NKafka::MakeKafkaDiscoveryCacheID()));
         runtime->EnableScheduleForActor(actorId);
         runtime->DispatchEvents();
         Cerr << "Wait for response for topics: '";
@@ -43,7 +46,9 @@ Y_UNIT_TEST_SUITE(TMetadataActorTests) {
     }
 
     Y_UNIT_TEST(TopicMetadataGoodAndBad) {
-        NPersQueue::TTestServer server;
+        auto serverSettings = NKikimr::NPersQueueTests::PQSettings(0).SetDomainName("Root").SetNodeCount(1);
+        serverSettings.AppConfig->MutableKafkaProxyConfig()->SetEnableKafkaProxy(true);
+        NPersQueue::TTestServer server{serverSettings};
         TString topicName = "rt3.dc1--topic";
         TString topicName2 = "rt3.dc1--topic2";
         TString topicPath = TString("/Root/PQ/") + topicName;
@@ -51,6 +56,8 @@ Y_UNIT_TEST_SUITE(TMetadataActorTests) {
         ui32 totalPartitions = 5;
         server.AnnoyingClient->CreateTopic(topicName, totalPartitions);
         server.AnnoyingClient->CreateTopic(topicName2, totalPartitions * 2);
+        server.WaitInit("topic");
+
 
         auto edgeId = server.CleverServer->GetRuntime()->AllocateEdgeActor();
         auto event = GetEvent(server, edgeId, {topicPath});

--- a/ydb/core/kafka_proxy/ut/port_discovery_ut.cpp
+++ b/ydb/core/kafka_proxy/ut/port_discovery_ut.cpp
@@ -1,0 +1,305 @@
+#include <library/cpp/testing/unittest/registar.h>
+#include <ydb/public/sdk/cpp/client/ydb_persqueue_core/ut/ut_utils/test_server.h>
+
+#include <ydb/core/testlib/test_pq_client.h>
+#include <ydb/core/discovery/discovery.h>
+#include <ydb/core/grpc_services/grpc_endpoint.h>
+#include <ydb/core/base/statestorage.h>
+#include <ydb/core/kafka_proxy/kafka_messages.h>
+#include <ydb/core/kafka_proxy/actors/actors.h>
+#include <ydb/core/kafka_proxy/actors/kafka_metadata_actor.h>
+#include <ydb/core/discovery/discovery.h>
+
+
+using namespace NKikimr;
+
+auto UnpackDiscoveryData(const TString& data) {
+    Ydb::Discovery::ListEndpointsResponse leResponse;
+    Ydb::Discovery::ListEndpointsResult leResult;
+    auto ok = leResponse.ParseFromString(data);
+    UNIT_ASSERT(ok);
+    ok = leResponse.operation().result().UnpackTo(&leResult);
+    UNIT_ASSERT(ok);
+    return leResult;
+}
+
+class TFakeDiscoveryCache: public TActorBootstrapped<TFakeDiscoveryCache> {
+    std::shared_ptr<NDiscovery::TCachedMessageData> CachedMessage;
+
+public:
+    TFakeDiscoveryCache(const Ydb::Discovery::ListEndpointsResult& leResult, bool triggerError)
+    {
+        if (!triggerError) {
+            Ydb::Discovery::ListEndpointsResponse response;
+            TString out;
+            auto deferred = response.mutable_operation();
+            deferred->set_ready(true);
+            deferred->set_status(Ydb::StatusIds::SUCCESS);
+
+            auto data = deferred->mutable_result();
+            data->PackFrom(leResult);
+
+            Y_PROTOBUF_SUPPRESS_NODISCARD response.SerializeToString(&out);
+
+            TMap<TActorId, TEvStateStorage::TBoardInfoEntry> infoEntries;
+            infoEntries.insert(std::make_pair(SelfId(), TEvStateStorage::TBoardInfoEntry("/Root")));
+            CachedMessage.reset(new NDiscovery::TCachedMessageData(out, "b", std::move(infoEntries)));
+
+        } else {
+            CachedMessage.reset(new NDiscovery::TCachedMessageData("", "", {}));
+        }
+    }
+
+    void Bootstrap() {
+        Become(&TFakeDiscoveryCache::StateWork);
+    }
+
+    STATEFN(StateWork) {
+        Handle(ev);
+    }
+    void Handle(TAutoPtr<NActors::IEventHandle>& ev) {
+        Cerr << "Fake discovery cache: handle request\n";
+        Send(ev->Sender, new TEvDiscovery::TEvDiscoveryData(CachedMessage), 0, ev->Cookie);
+    }
+};
+
+namespace NKafka::NTests {
+    Y_UNIT_TEST_SUITE(DiscoveryIsNotBroken) {
+        void CheckEndpointsInDiscovery(bool withSsl, bool expectKafkaEndpoints) {
+            auto pm = MakeSimpleShared<TPortManager>();
+            ui16 kafkaPort = pm->GetPort();
+            auto serverSettings = NPersQueueTests::PQSettings(0).SetDomainName("Root").SetNodeCount(1);
+            serverSettings.AppConfig->MutableKafkaProxyConfig()->SetEnableKafkaProxy(true);
+            serverSettings.AppConfig->MutableKafkaProxyConfig()->SetListeningPort(kafkaPort);
+            if (withSsl) {
+                serverSettings.AppConfig->MutableKafkaProxyConfig()->SetSslCertificate("12345");
+            }
+            NPersQueue::TTestServer server(serverSettings, true, {}, NActors::NLog::PRI_INFO, pm);
+            auto port = server.GrpcPort;
+            Cerr << "Run with port = " << port << ", kafka port = " << kafkaPort << Endl;
+            auto* runtime = server.GetRuntime();
+            auto edge = runtime->AllocateEdgeActor();
+
+            TActorId discoveryCacheActorID;
+            if (expectKafkaEndpoints) {
+                discoveryCacheActorID = runtime->Register(CreateDiscoveryCache(NGRpcService::KafkaEndpointId));
+            } else {
+                discoveryCacheActorID = runtime->Register(CreateDiscoveryCache());
+            }
+            auto discoverer = runtime->Register(CreateDiscoverer(&MakeEndpointsBoardPath, "/Root", edge, discoveryCacheActorID));
+            Y_UNUSED(discoverer);
+            TAutoPtr<IEventHandle> handle;
+            auto* ev = runtime->GrabEdgeEvent<TEvDiscovery::TEvDiscoveryData>(handle);
+            UNIT_ASSERT(ev);
+            auto discoveryData = UnpackDiscoveryData(ev->CachedMessageData->CachedMessage);
+            auto discoverySslData = UnpackDiscoveryData(ev->CachedMessageData->CachedMessageSsl);
+
+            auto checkEnpoints = [&] (ui32 port, ui32 sslPort) {
+                if (port) {
+                    UNIT_ASSERT_VALUES_EQUAL(discoveryData.endpoints_size(), 1);
+                    UNIT_ASSERT_VALUES_EQUAL(discoveryData.endpoints(0).port(), port);
+                    UNIT_ASSERT_VALUES_EQUAL(discoverySslData.endpoints_size(), 0);
+                }
+                if (sslPort) {
+                    UNIT_ASSERT_VALUES_EQUAL(discoverySslData.endpoints_size(), 1);
+                    UNIT_ASSERT_VALUES_EQUAL(discoverySslData.endpoints(0).port(), sslPort);
+                    UNIT_ASSERT_VALUES_EQUAL(discoveryData.endpoints_size(), 0);
+                }
+            };
+            if (expectKafkaEndpoints) {
+                if (withSsl) {
+                    checkEnpoints(0, kafkaPort);
+                } else {
+                    checkEnpoints(kafkaPort, 0);
+                }
+            } else {
+                checkEnpoints(port, 0);
+            }
+        }
+
+        Y_UNIT_TEST(NoKafkaEndpointInDiscovery) {
+            CheckEndpointsInDiscovery(false, false);
+        }
+
+        Y_UNIT_TEST(NoKafkaSslEndpointInDiscovery) {
+            CheckEndpointsInDiscovery(true, false);
+        }
+
+        Y_UNIT_TEST(HaveKafkaEndpointInDiscovery) {
+            CheckEndpointsInDiscovery(false, true);
+        }
+        Y_UNIT_TEST(HaveKafkaSslEndpointInDiscovery) {
+            CheckEndpointsInDiscovery(true, true);
+        }
+    }
+
+    Y_UNIT_TEST_SUITE(PublishKafkaEndpoints) {
+        Y_UNIT_TEST(HaveEndpointInLookup) {
+            auto pm = MakeSimpleShared<TPortManager>();
+            ui16 kafkaPort = pm->GetPort();
+            auto serverSettings = NPersQueueTests::PQSettings(0).SetDomainName("Root").SetNodeCount(1);
+            serverSettings.AppConfig->MutableKafkaProxyConfig()->SetEnableKafkaProxy(true);
+            serverSettings.AppConfig->MutableKafkaProxyConfig()->SetListeningPort(kafkaPort);
+            NPersQueue::TTestServer server(serverSettings, true, {}, NActors::NLog::PRI_INFO, pm);
+
+            auto* runtime = server.GetRuntime();
+            auto edge = runtime->AllocateEdgeActor();
+            runtime->Register(CreateBoardLookupActor(MakeEndpointsBoardPath("/Root"), edge, EBoardLookupMode::Second));
+            TAutoPtr<IEventHandle> handle;
+            auto* ev = runtime->GrabEdgeEvent<TEvStateStorage::TEvBoardInfo>(handle);
+            UNIT_ASSERT(ev);
+            Cerr << "ev for path: " << ev->Path << ", is unknown: " << (ev->Status == TEvStateStorage::TEvBoardInfo::EStatus::Unknown)
+                 << ", is unavalable: " << (ev->Status == TEvStateStorage::TEvBoardInfo::EStatus::NotAvailable) << Endl;
+            UNIT_ASSERT(ev->Status == TEvStateStorage::TEvBoardInfo::EStatus::Ok);
+            UNIT_ASSERT_VALUES_EQUAL(ev->InfoEntries.size(), 2);
+            bool hasKafkaPort = false;
+            for (const auto& [k, v] : ev->InfoEntries) {
+                NKikimrStateStorage::TEndpointBoardEntry entry;
+                UNIT_ASSERT(entry.ParseFromString(v.Payload));
+                Cerr << "Got entry, actor: " << k.ToString() << ", entry: " << entry.DebugString() << Endl;
+                if (entry.GetPort() == kafkaPort) {
+                    UNIT_ASSERT_STRINGS_EQUAL(entry.GetEndpointId(), NGRpcService::KafkaEndpointId);
+                    hasKafkaPort = true;
+                }
+            }
+            UNIT_ASSERT(hasKafkaPort);
+        }
+        struct TMetarequestTestParams {
+            NPersQueue::TTestServer Server;
+            ui64 KafkaPort;
+            NKikimrConfig::TKafkaProxyConfig KafkaConfig;
+            TString FullTopicName;
+        };
+
+        TMetarequestTestParams SetupServer(const TString shortTopicName) {
+            TStringBuilder fullTopicName;
+            fullTopicName << "rt3.dc1--" << shortTopicName;
+            auto pm = MakeSimpleShared<TPortManager>();
+            ui16 kafkaPort = pm->GetPort();
+            auto serverSettings = NPersQueueTests::PQSettings(0).SetDomainName("Root").SetNodeCount(1);
+            serverSettings.AppConfig->MutableKafkaProxyConfig()->SetEnableKafkaProxy(true);
+
+            serverSettings.AppConfig->MutableKafkaProxyConfig()->SetListeningPort(kafkaPort);
+            NPersQueue::TTestServer server(serverSettings, true, {}, NActors::NLog::PRI_INFO, pm);
+
+            server.AnnoyingClient->CreateTopic(fullTopicName, 1);
+            server.WaitInit(shortTopicName);
+
+            return {std::move(server), kafkaPort, serverSettings.AppConfig->GetKafkaProxyConfig(), fullTopicName};
+        }
+
+        void CreateMetarequestActor(
+                const TActorId& edge, const TString& topicPath, auto* runtime, const auto& kafkaConfig, const TActorId& fakeCacheId = {}
+        ) {
+            TMetadataRequestData::TPtr metaRequest = std::make_shared<TMetadataRequestData>();
+            metaRequest->Topics.emplace_back();
+            auto& topic = metaRequest->Topics[0];
+            topic.Name = topicPath;
+
+            auto context = std::make_shared<TContext>(kafkaConfig);
+            context->ConnectionId = edge;
+            context->DatabasePath = "/Root";
+            context->UserToken = new NACLib::TUserToken("root@builtin", {});
+
+            TActorId actorId;
+            if (fakeCacheId) {
+                actorId = runtime->Register(new NKafka::TKafkaMetadataActor(
+                    context, 1, TMessagePtr<TMetadataRequestData>(std::make_shared<TBuffer>(), metaRequest), fakeCacheId
+                ));
+            } else {
+                actorId = runtime->Register(new NKafka::TKafkaMetadataActor(
+                    context, 1, TMessagePtr<TMetadataRequestData>(std::make_shared<TBuffer>(), metaRequest),
+                    NKafka::MakeKafkaDiscoveryCacheID()
+                ));
+            }
+            runtime->EnableScheduleForActor(actorId);
+        }
+
+        void CheckKafkaMetaResponse(TTestActorRuntime* runtime, ui64 kafkaPort, bool error = false) {
+            TAutoPtr<IEventHandle> handle;
+            auto* ev = runtime->GrabEdgeEvent<TEvKafka::TEvResponse>(handle);
+            UNIT_ASSERT(ev);
+            auto response = dynamic_cast<TMetadataResponseData*>(ev->Response.get());
+            UNIT_ASSERT_VALUES_EQUAL(response->Topics.size(), 1);
+            if (!error) {
+                UNIT_ASSERT(response->Topics[0].ErrorCode == EKafkaErrors::NONE_ERROR);
+            } else {
+                UNIT_ASSERT(response->Topics[0].ErrorCode == EKafkaErrors::LISTENER_NOT_FOUND);
+                UNIT_ASSERT(ev->ErrorCode == EKafkaErrors::LISTENER_NOT_FOUND);
+                return;
+            }
+            UNIT_ASSERT_VALUES_EQUAL(response->Brokers.size(), 1);
+            Cerr << "Broker " << response->Brokers[0].NodeId << " - " << response->Brokers[0].Host << ":" << response->Brokers[0].Port  << Endl;
+            UNIT_ASSERT_VALUES_EQUAL(response->Brokers[0].Port, kafkaPort);
+        }
+
+        Y_UNIT_TEST(MetadataActorGetsEndpoint) {
+            auto [server, kafkaPort, config, topicName] = SetupServer("topic1");
+
+            auto* runtime = server.GetRuntime();
+            auto edge = runtime->AllocateEdgeActor();
+
+            CreateMetarequestActor(edge, NKikimr::JoinPath({"/Root/PQ/", topicName}), runtime,
+                                   config);
+
+            CheckKafkaMetaResponse(runtime, kafkaPort);
+        }
+
+        Y_UNIT_TEST(DiscoveryResponsesWithNoNode) {
+            auto [server, kafkaPort, config, topicName] = SetupServer("topic1");
+
+            auto* runtime = server.GetRuntime();
+            auto edge = runtime->AllocateEdgeActor();
+
+            Ydb::Discovery::ListEndpointsResult leResult;
+            auto* ep = leResult.add_endpoints();
+            ep->set_address("wrong.host");
+            ep->set_port(1);
+            ep->set_node_id(9999);
+            ep = leResult.add_endpoints();
+            ep->set_address("wrong.host2");
+            ep->set_port(2);
+            ep->set_node_id(9998);
+            auto fakeCache = runtime->Register(new TFakeDiscoveryCache(leResult, false));
+            runtime->EnableScheduleForActor(fakeCache);
+            CreateMetarequestActor(edge, NKikimr::JoinPath({"/Root/PQ/", topicName}), runtime,
+                                   config, fakeCache);
+
+            CheckKafkaMetaResponse(runtime, kafkaPort);
+        }
+
+        Y_UNIT_TEST(DiscoveryResponsesWithError) {
+            auto [server, kafkaPort, config, topicName] = SetupServer("topic1");
+
+            auto* runtime = server.GetRuntime();
+            auto edge = runtime->AllocateEdgeActor();
+
+            Ydb::Discovery::ListEndpointsResult leResult;
+            auto fakeCache = runtime->Register(new TFakeDiscoveryCache(leResult, true));
+            runtime->EnableScheduleForActor(fakeCache);
+            CreateMetarequestActor(edge, NKikimr::JoinPath({"/Root/PQ/", topicName}), runtime,
+                                   config, fakeCache);
+
+            CheckKafkaMetaResponse(runtime, kafkaPort, true);
+        }
+
+        Y_UNIT_TEST(DiscoveryResponsesWithOtherPort) {
+            auto [server, kafkaPort, config, topicName] = SetupServer("topic1");
+
+            auto* runtime = server.GetRuntime();
+            auto edge = runtime->AllocateEdgeActor();
+
+            Ydb::Discovery::ListEndpointsResult leResult;
+            auto* ep = leResult.add_endpoints();
+            ep->set_address("localhost");
+            ep->set_port(12345);
+            ep->set_node_id(runtime->GetNodeId(0));
+            auto fakeCache = runtime->Register(new TFakeDiscoveryCache(leResult, false));
+            runtime->EnableScheduleForActor(fakeCache);
+            CreateMetarequestActor(edge, NKikimr::JoinPath({"/Root/PQ/", topicName}), runtime,
+                                   config, fakeCache);
+
+            CheckKafkaMetaResponse(runtime, 12345);
+        }
+    }
+}

--- a/ydb/core/kafka_proxy/ut/ut_protocol.cpp
+++ b/ydb/core/kafka_proxy/ut/ut_protocol.cpp
@@ -121,6 +121,7 @@ public:
         appConfig.MutablePQConfig()->AddValidWriteSpeedLimitsKbPerSec(512);
         appConfig.MutablePQConfig()->AddValidWriteSpeedLimitsKbPerSec(1_KB);
 
+        appConfig.MutableGRpcConfig()->SetHost("::1");
         auto limit = appConfig.MutablePQConfig()->AddValidRetentionLimits();
         limit->SetMinPeriodSeconds(0);
         limit->SetMaxPeriodSeconds(TDuration::Days(1).Seconds());
@@ -835,10 +836,10 @@ private:
 };
 
 Y_UNIT_TEST_SUITE(KafkaProtocol) {
-    // this test imitates kafka producer behaviour: 
-    // 1. get api version, 
-    // 2. authenticate via sasl, 
-    // 3. acquire producer id, 
+    // this test imitates kafka producer behaviour:
+    // 1. get api version,
+    // 2. authenticate via sasl,
+    // 3. acquire producer id,
     // 4. produce to topic several messages, read them and assert correct contents and metadata
     Y_UNIT_TEST(ProduceScenario) {
         TInsecureTestServer testServer("2");
@@ -1240,7 +1241,7 @@ Y_UNIT_TEST_SUITE(KafkaProtocol) {
                 UNIT_ASSERT_VALUES_EQUAL(dataStr, value);
             }
         }
-            
+
         // create table and init cdc for it
         {
             NYdb::NTable::TTableClient tableClient(*testServer.Driver);

--- a/ydb/core/kafka_proxy/ut/ya.make
+++ b/ydb/core/kafka_proxy/ut/ya.make
@@ -8,6 +8,7 @@ SRCS(
     ut_protocol.cpp
     ut_serialization.cpp
     metarequest_ut.cpp
+    port_discovery_ut.cpp
 )
 
 PEERDIR(

--- a/ydb/core/persqueue/events/internal.h
+++ b/ydb/core/persqueue/events/internal.h
@@ -185,7 +185,7 @@ struct TEvPQ {
         EvGetWriteInfoRequest,
         EvGetWriteInfoResponse,
         EvGetWriteInfoError,
-	EvTxBatchComplete,
+	    EvTxBatchComplete,
         EvReadingPartitionStatusRequest,
         EvProcessChangeOwnerRequests,
         EvWakeupReleasePartition,
@@ -195,6 +195,7 @@ struct TEvPQ {
         EvDeletePartition,
         EvDeletePartitionDone,
         EvTransactionCompleted,
+        EvListAllTopicsResponse,
         EvEnd
     };
 
@@ -1167,6 +1168,16 @@ struct TEvPQ {
         }
 
         TMaybe<NPQ::TWriteId> WriteId;
+    };
+
+    struct TEvListAllTopicsResponse : TEventLocal<TEvListAllTopicsResponse, EvListAllTopicsResponse> {
+        explicit TEvListAllTopicsResponse() = default;
+        explicit TEvListAllTopicsResponse(Ydb::StatusIds status, const TString& error);
+
+        TVector<TString> Topics;
+        bool HaveMoreTopics = false;
+        Ydb::StatusIds::StatusCode Status = Ydb::StatusIds::SUCCESS;
+        TString Error;
     };
 };
 

--- a/ydb/core/persqueue/list_all_topics_actor.cpp
+++ b/ydb/core/persqueue/list_all_topics_actor.cpp
@@ -1,0 +1,164 @@
+#include <ydb/core/persqueue/events/internal.h>
+#include <ydb/core/tx/scheme_cache/scheme_cache.h>
+#include <ydb/library/actors/core/actor_bootstrapped.h>
+
+
+using namespace NActors;
+
+namespace NKikimr::NPersQueue {
+
+class TListAllTopicsActor : public NActors::TActorBootstrapped<TListAllTopicsActor> {
+
+    public:
+        TListAllTopicsActor(const TActorId& respondTo, const TString& databasePath, const TString& token,
+                            bool recursive, const TString& startFrom, const TMaybe<ui64>& limit);
+        //~TListStreamsActor() = default;
+
+        void Bootstrap(const NActors::TActorContext& ctx);
+
+        void StateWork(TAutoPtr<IEventHandle>& ev);
+        void Handle(TEvTxProxySchemeCache::TEvNavigateKeySetResult::TPtr& ev);
+
+    protected:
+        void SendNavigateRequest(const TString& path);
+        void SendPendingRequests();
+        void SendResponse();
+
+
+    private:
+        static constexpr ui32 MAX_IN_FLIGHT = 100;
+
+        TActorId RespondTo;
+        TString DatabasePath;
+        TString Token;
+        bool Recursive;
+        TString StartFrom;
+        TMaybe<ui64> Limit;
+
+
+        ui32 RequestsInFlight = 0;
+        std::vector<std::unique_ptr<TEvTxProxySchemeCache::TEvNavigateKeySet>> WaitingList;
+        std::vector<TString> Topics;
+    };
+
+    TListAllTopicsActor::TListAllTopicsActor(
+            const TActorId& respondTo, const TString& databasePath, const TString& token,
+            bool recursive, const TString& startFrom, const TMaybe<ui64>& limit
+    )
+        : RespondTo(respondTo)
+        , DatabasePath(databasePath)
+        , Token(token)
+        , Recursive(recursive)
+        , StartFrom(startFrom)
+        , Limit(limit)
+    {
+    }
+
+    void TListAllTopicsActor::Bootstrap(const NActors::TActorContext&) {
+        SendNavigateRequest(DatabasePath);
+        Become(&TListAllTopicsActor::StateWork);
+    }
+
+    void TListAllTopicsActor::SendPendingRequests() {
+        if (RequestsInFlight < MAX_IN_FLIGHT && WaitingList.size() > 0) {
+            Send(MakeSchemeCacheID(), WaitingList.back().release());
+            WaitingList.pop_back();
+            RequestsInFlight++;
+        }
+    }
+
+    void TListAllTopicsActor::SendResponse() {
+        Y_ENSURE(WaitingList.size() == 0 && RequestsInFlight == 0);
+
+        for (TString& topic : Topics) {
+            topic = TFsPath(topic).RelativePath(DatabasePath).GetPath();
+        }
+        Sort(Topics.begin(), Topics.end());
+        auto response = new TEvPQ::TEvListAllTopicsResponse();
+        for (auto& topicName : Topics) {
+            if (!StartFrom.empty() && StartFrom >= topicName) {
+                continue;
+            }
+            if (Limit.Defined() && response->Topics.size() >= *Limit) {
+                response->HaveMoreTopics = true;
+                break;
+            }
+            response->Topics.emplace_back(std::move(topicName));
+        }
+
+        Send(RespondTo, response);
+        Die(ActorContext());
+    }
+
+    void TListAllTopicsActor::SendNavigateRequest(const TString& path) {
+        auto schemeCacheRequest = std::make_unique<NSchemeCache::TSchemeCacheNavigate>();
+        schemeCacheRequest->DatabaseName = DatabasePath;
+        NSchemeCache::TSchemeCacheNavigate::TEntry entry;
+        entry.Path = NKikimr::SplitPath(path);
+
+        if (!Token.empty()) {
+            schemeCacheRequest->UserToken = new NACLib::TUserToken(Token);
+        }
+
+        entry.Operation = NSchemeCache::TSchemeCacheNavigate::OpList;
+        schemeCacheRequest->ResultSet.emplace_back(entry);
+        WaitingList.push_back(std::make_unique<TEvTxProxySchemeCache::TEvNavigateKeySet>(schemeCacheRequest.release()));
+        SendPendingRequests();
+    }
+
+    void TListAllTopicsActor::StateWork(TAutoPtr<IEventHandle>& ev) {
+        switch (ev->GetTypeRewrite()) {
+            hFunc(TEvTxProxySchemeCache::TEvNavigateKeySetResult, Handle);
+            default:
+                Y_DEBUG_ABORT_UNLESS(false);
+        }
+    }
+
+    void TListAllTopicsActor::Handle(TEvTxProxySchemeCache::TEvNavigateKeySetResult::TPtr& ev) {
+        const NSchemeCache::TSchemeCacheNavigate* navigate = ev->Get()->Request.Get();
+        for (const auto& entry : navigate->ResultSet) {
+
+            if (entry.Kind == NSchemeCache::TSchemeCacheNavigate::EKind::KindTable) {
+                for (const auto& stream : entry.CdcStreams) {
+                    TString childFullPath = JoinPath({JoinPath(entry.Path), stream.GetName()});
+                    Topics.push_back(childFullPath);
+                }
+            } else if (entry.Kind == NSchemeCache::TSchemeCacheNavigate::EKind::KindPath
+                || entry.Kind == NSchemeCache::TSchemeCacheNavigate::EKind::KindSubdomain)
+            {
+                Y_ENSURE(entry.ListNodeEntry, "ListNodeEntry is zero");
+                for (const auto& child : entry.ListNodeEntry->Children) {
+                    TString childFullPath = JoinPath({JoinPath(entry.Path), child.Name});
+                    switch (child.Kind) {
+                        case NSchemeCache::TSchemeCacheNavigate::EKind::KindPath:
+                        case NSchemeCache::TSchemeCacheNavigate::EKind::KindTable:
+                            if (Recursive) {
+                                SendNavigateRequest(childFullPath);
+                            }
+                            break;
+                        case NSchemeCache::TSchemeCacheNavigate::EKind::KindTopic:
+                            Topics.push_back(childFullPath);
+                            break;
+
+                        default:
+                            break;
+                            // ignore all other types
+                    }
+                }
+            }
+        }
+        RequestsInFlight--;
+        SendPendingRequests();
+        if (RequestsInFlight == 0) {
+            SendResponse();
+        }
+    }
+
+NActors::IActor* MakeListAllTopicsActor(
+        const TActorId& respondTo, const TString& databasePath, const TString& token, bool recursive, const TString& startFrom,
+        const TMaybe<ui64>& limit
+) {
+    return new TListAllTopicsActor(respondTo, databasePath, token, recursive, startFrom, limit);
+}
+
+} // namespace

--- a/ydb/core/persqueue/list_all_topics_actor.h
+++ b/ydb/core/persqueue/list_all_topics_actor.h
@@ -1,0 +1,8 @@
+#include <util/generic/maybe.h>
+#include <ydb/library/actors/core/actor.h>
+
+namespace NKikimr::NPersQueue {
+
+NActors::IActor* MakeListAllTopicsActor(const NActors::TActorId& respondTo, const TString& databasePath, const TString& token,
+                                        bool recursive, const TString& startFrom = {}, const TMaybe<ui64>& limit = Nothing());
+}

--- a/ydb/core/persqueue/ut/list_all_topics_ut.cpp
+++ b/ydb/core/persqueue/ut/list_all_topics_ut.cpp
@@ -1,5 +1,5 @@
 #include <ydb/core/persqueue/events/internal.h>
-#include <ydb/public/sdk/cpp/src/client/persqueue_public/ut/ut_utils/test_server.h>
+#include <ydb/public/sdk/cpp/client/ydb_persqueue_public/ut/ut_utils/test_server.h>
 #include <ydb/core/persqueue/list_all_topics_actor.h>
 
 

--- a/ydb/core/persqueue/ut/list_all_topics_ut.cpp
+++ b/ydb/core/persqueue/ut/list_all_topics_ut.cpp
@@ -1,0 +1,129 @@
+#include <ydb/core/persqueue/events/internal.h>
+#include <ydb/public/sdk/cpp/src/client/persqueue_public/ut/ut_utils/test_server.h>
+#include <ydb/core/persqueue/list_all_topics_actor.h>
+
+
+namespace NKikimr::NPersQueueTests {
+
+Y_UNIT_TEST_SUITE(TListAllTopicsTests) {
+    TString db = "/Root";
+
+    THolder<TEvPQ::TEvListAllTopicsResponse> GetListing(
+                TTestActorRuntime* runtime, bool recursive,const TMaybe<ui64>& limit = {}, const TString& startFrom = {}
+    ) {
+        auto edge = runtime->AllocateEdgeActor();
+        runtime->Register(NKikimr::NPersQueue::MakeListAllTopicsActor(
+                    edge, db, "", recursive, startFrom, limit));
+
+
+        auto resp = runtime->GrabEdgeEvent<TEvPQ::TEvListAllTopicsResponse>(TDuration::Seconds(10));
+        return resp;
+    }
+
+    void CreateTopic(auto& pqClient, const TString& topicName, bool wait) {
+        auto settings = NYdb::NPersQueue::TCreateTopicSettings().PartitionsCount(1);
+
+
+            auto createF = pqClient.CreateTopic(topicName, settings);
+            if (!wait)
+                return;
+            auto createRes = createF.GetValueSync();
+            UNIT_ASSERT_C(createRes.IsSuccess(), createRes.GetIssues().ToString());
+    }
+
+    Y_UNIT_TEST(PlainList) {
+        auto settings = PQSettings(0, 1);
+        settings.PQConfig.SetTopicsAreFirstClassCitizen(true);
+        ::NPersQueue::TTestServer server{settings, true};
+
+        auto* runtime = server.GetRuntime();
+        auto port = server.GrpcPort;
+
+        TString endpoint = TStringBuilder() << "localhost:" << port;
+        auto driverConfig = NYdb::TDriverConfig()
+            .SetEndpoint(endpoint)
+            ;
+            //.SetDatabase(db);
+            //.SetLog(std::unique_ptr<TLogBackend>(CreateLogBackend("cerr", ELogPriority::TLOG_DEBUG).Release()));
+        auto driver = MakeHolder<NYdb::TDriver>(driverConfig);
+        auto pqClient = NYdb::NPersQueue::TPersQueueClient(*driver);
+
+        CreateTopic(pqClient, NKikimr::JoinPath({db, "topic1"}), false);
+        CreateTopic(pqClient, NKikimr::JoinPath({db, "topic2"}), true);
+
+        auto resp = GetListing(runtime, true);
+        UNIT_ASSERT_VALUES_EQUAL(resp->Topics.size(), 2);
+        resp = GetListing(runtime, false);
+        UNIT_ASSERT_VALUES_EQUAL(resp->Topics.size(), 2);
+
+        CreateTopic(pqClient, NKikimr::JoinPath({db, "topic3"}), true);
+        resp = GetListing(runtime, false);
+        UNIT_ASSERT_VALUES_EQUAL(resp->Topics.size(), 3);
+    }
+
+    Y_UNIT_TEST(RecursiveList) {
+        auto settings = PQSettings(0, 1);
+        settings.PQConfig.SetTopicsAreFirstClassCitizen(true);
+        ::NPersQueue::TTestServer server{settings, true};
+
+        auto* runtime = server.GetRuntime();
+        auto port = server.GrpcPort;
+
+        TString endpoint = TStringBuilder() << "localhost:" << port;
+        TString db = "/Root";
+        auto driverConfig = NYdb::TDriverConfig()
+            .SetEndpoint(endpoint)
+            ;
+            //.SetDatabase(db);
+            //.SetLog(std::unique_ptr<TLogBackend>(CreateLogBackend("cerr", ELogPriority::TLOG_DEBUG).Release()));
+        auto driver = MakeHolder<NYdb::TDriver>(driverConfig);
+        auto pqClient = NYdb::NPersQueue::TPersQueueClient(*driver);
+
+        CreateTopic(pqClient, NKikimr::JoinPath({db, "topic1"}), false);
+        server.AnnoyingClient->MkDir("/Root", "dir1");
+        server.AnnoyingClient->MkDir("/Root", "dir2");
+        CreateTopic(pqClient, NKikimr::JoinPath({db, "dir1", "topic2"}), false);
+        CreateTopic(pqClient, NKikimr::JoinPath({db, "dir2", "topic3"}), true);
+
+        auto resp = GetListing(runtime, true);
+        UNIT_ASSERT_VALUES_EQUAL(resp->Topics.size(), 3);
+        resp = GetListing(runtime, false);
+        UNIT_ASSERT_VALUES_EQUAL(resp->Topics.size(), 1);
+    }
+
+    Y_UNIT_TEST(ListLimitAndPaging) {
+        auto settings = PQSettings(0, 1);
+        settings.PQConfig.SetTopicsAreFirstClassCitizen(true);
+        ::NPersQueue::TTestServer server{settings, true};
+
+        auto* runtime = server.GetRuntime();
+        auto port = server.GrpcPort;
+
+        TString endpoint = TStringBuilder() << "localhost:" << port;
+        TString db = "/Root";
+        auto driverConfig = NYdb::TDriverConfig()
+            .SetEndpoint(endpoint)
+            ;
+            //.SetDatabase(db);
+            //.SetLog(std::unique_ptr<TLogBackend>(CreateLogBackend("cerr", ELogPriority::TLOG_DEBUG).Release()));
+        auto driver = MakeHolder<NYdb::TDriver>(driverConfig);
+        auto pqClient = NYdb::NPersQueue::TPersQueueClient(*driver);
+
+        CreateTopic(pqClient, NKikimr::JoinPath({db, "topic1"}), false);
+        server.AnnoyingClient->MkDir("/Root", "dir1");
+        server.AnnoyingClient->MkDir("/Root", "dir2");
+        CreateTopic(pqClient, NKikimr::JoinPath({db, "dir1", "topic2"}), false);
+        CreateTopic(pqClient, NKikimr::JoinPath({db, "dir2", "topic3"}), true);
+
+        auto resp = GetListing(runtime, true, 1);
+        UNIT_ASSERT_VALUES_EQUAL(resp->Topics.size(), 1);
+        resp = GetListing(runtime, true, 2);
+        UNIT_ASSERT_VALUES_EQUAL(resp->Topics.size(), 2);
+        resp = GetListing(runtime, true, 3);
+        UNIT_ASSERT_VALUES_EQUAL(resp->Topics.size(), 3);
+        resp = GetListing(runtime, true, Nothing(), NKikimr::JoinPath({"dir2", "topic3"}));
+        UNIT_ASSERT_VALUES_EQUAL(resp->Topics.size(), 1);
+    }
+};
+
+} // namespace

--- a/ydb/core/persqueue/ut/ya.make
+++ b/ydb/core/persqueue/ut/ya.make
@@ -46,6 +46,7 @@ SRCS(
     microseconds_sliding_window_ut.cpp
     fetch_request_ut.cpp
     utils_ut.cpp
+    list_all_topics_ut.cpp
 )
 
 RESOURCE(

--- a/ydb/core/persqueue/ya.make
+++ b/ydb/core/persqueue/ya.make
@@ -11,6 +11,7 @@ SRCS(
     heartbeat.cpp
     key.cpp
     metering_sink.cpp
+    list_all_topics_actor.cpp
     mirrorer.cpp
     mirrorer.h
     ownerinfo.cpp

--- a/ydb/core/protos/config.proto
+++ b/ydb/core/protos/config.proto
@@ -681,6 +681,7 @@ message TGRpcConfig {
 
     optional uint32 GRpcProxyCount = 106 [default = 2];
     optional bool EnableGRpcMemoryQuota = 107 [default = false];
+    optional string EndpointId = 108;
 
     repeated TGRpcConfig ExtEndpoints = 200; // run specific services on separate endpoints
 }

--- a/ydb/core/protos/config.proto
+++ b/ydb/core/protos/config.proto
@@ -1911,7 +1911,8 @@ message TKafkaProxyConfig {
     }
 
     optional TProxy Proxy = 7;
-    optional bool MeteringV2Enabled = 10 [default = false];
+    optional bool MeteringV2Enabled = 10 [default = true];
+    optional bool AuthViaApiKey = 11 [default = true];
 }
 
 message TAwsCompatibilityConfig {

--- a/ydb/core/protos/statestorage.proto
+++ b/ydb/core/protos/statestorage.proto
@@ -137,5 +137,6 @@ message TEndpointBoardEntry {
     repeated string AddressesV4 = 8;
     repeated string AddressesV6 = 9;
     optional string TargetNameOverride = 10;
+    optional string EndpointId = 11;
 };
 

--- a/ydb/core/public_http/grpc_request_context_wrapper.cpp
+++ b/ydb/core/public_http/grpc_request_context_wrapper.cpp
@@ -82,4 +82,6 @@ namespace NKikimr::NPublicHttp {
        return RequestContext.GetPeer();
     }
 
+    TString TGrpcRequestContextWrapper::GetEndpointId() const { return {}; }
+
 } // namespace NKikimr::NPublicHttp

--- a/ydb/core/public_http/grpc_request_context_wrapper.h
+++ b/ydb/core/public_http/grpc_request_context_wrapper.h
@@ -35,6 +35,7 @@ public:
     virtual TVector<TStringBuf> GetPeerMetaValues(TStringBuf key) const;
     virtual TVector<TStringBuf> FindClientCert() const {return {};}
     virtual grpc_compression_level GetCompressionLevel() const { return GRPC_COMPRESS_LEVEL_NONE; }
+    virtual TString GetEndpointId() const;
 
     virtual google::protobuf::Arena* GetArena();
 

--- a/ydb/core/testlib/test_client.cpp
+++ b/ydb/core/testlib/test_client.cpp
@@ -57,6 +57,7 @@
 #include <ydb/core/health_check/health_check.h>
 #include <ydb/core/kafka_proxy/actors/kafka_metrics_actor.h>
 #include <ydb/core/kafka_proxy/kafka_listener.h>
+#include <ydb/core/kafka_proxy/actors/kafka_metadata_actor.h>
 #include <ydb/core/kafka_proxy/kafka_metrics.h>
 #include <ydb/core/kqp/common/kqp.h>
 #include <ydb/core/kqp/rm_service/kqp_rm_service.h>
@@ -1018,21 +1019,45 @@ namespace Tests {
             TActorId actorId = Runtime->Register(actor, nodeIdx);
             Runtime->RegisterService(MakePollerActorId(), actorId, nodeIdx);
         }
-
         if (Settings->AppConfig->GetKafkaProxyConfig().GetEnableKafkaProxy()) {
+
+            IActor* discoveryCache = CreateDiscoveryCache(NGRpcService::KafkaEndpointId);
+            TActorId discoveryCacheId = Runtime->Register(discoveryCache, nodeIdx, userPoolId);
+	    Runtime->RegisterService(NKafka::MakeKafkaDiscoveryCacheID(), discoveryCacheId, nodeIdx);
+
             NKafka::TListenerSettings settings;
             settings.Port = Settings->AppConfig->GetKafkaProxyConfig().GetListeningPort();
+            bool ssl = false;
             if (Settings->AppConfig->GetKafkaProxyConfig().HasSslCertificate()) {
+                ssl = true;
                 settings.SslCertificatePem = Settings->AppConfig->GetKafkaProxyConfig().GetSslCertificate();
             }
 
-            IActor* actor = NKafka::CreateKafkaListener(MakePollerActorId(), settings, Settings->AppConfig->GetKafkaProxyConfig());
+            IActor* actor = NKafka::CreateKafkaListener(MakePollerActorId(), settings, Settings->AppConfig->GetKafkaProxyConfig(),
+                                                        discoveryCacheId);
             TActorId actorId = Runtime->Register(actor, nodeIdx);
             Runtime->RegisterService(TActorId{}, actorId, nodeIdx);
 
             IActor* metricsActor = CreateKafkaMetricsActor(NKafka::TKafkaMetricsSettings{Runtime->GetAppData().Counters->GetSubgroup("counters", "kafka_proxy")});
             TActorId metricsActorId = Runtime->Register(metricsActor, nodeIdx);
             Runtime->RegisterService(NKafka::MakeKafkaMetricsServiceID(), metricsActorId, nodeIdx);
+
+            {
+                auto& appData = Runtime->GetAppData(0);
+
+                TIntrusivePtr<NGRpcService::TGrpcEndpointDescription> desc = new NGRpcService::TGrpcEndpointDescription();
+                desc->Address = Settings->AppConfig->GetGRpcConfig().GetHost();
+                desc->Port = settings.Port;
+                desc->Ssl = ssl;
+                desc->EndpointId = NGRpcService::KafkaEndpointId;
+
+                TVector<TString> rootDomains;
+                if (const auto& domain = appData.DomainsInfo->Domain) {
+                    rootDomains.emplace_back("/" + domain->Name);
+                }
+                desc->ServedDatabases.insert(desc->ServedDatabases.end(), rootDomains.begin(), rootDomains.end());
+                Runtime->GetActorSystem(0)->Register(NGRpcService::CreateGrpcEndpointPublishActor(desc.Get()), TMailboxType::ReadAsFilled, appData.UserPoolId);
+            }
         }
 
         if (Settings->EnableYq) {

--- a/ydb/core/testlib/test_client.cpp
+++ b/ydb/core/testlib/test_client.cpp
@@ -1022,7 +1022,7 @@ namespace Tests {
         if (Settings->AppConfig->GetKafkaProxyConfig().GetEnableKafkaProxy()) {
 
             IActor* discoveryCache = CreateDiscoveryCache(NGRpcService::KafkaEndpointId);
-            TActorId discoveryCacheId = Runtime->Register(discoveryCache, nodeIdx, userPoolId);
+            TActorId discoveryCacheId = Runtime->Register(discoveryCache, nodeIdx);
 	    Runtime->RegisterService(NKafka::MakeKafkaDiscoveryCacheID(), discoveryCacheId, nodeIdx);
 
             NKafka::TListenerSettings settings;

--- a/ydb/library/grpc/server/grpc_request.h
+++ b/ydb/library/grpc/server/grpc_request.h
@@ -188,6 +188,10 @@ public:
         return TBaseAsyncContext<TService>::GetCompressionLevel();
     }
 
+    TString GetEndpointId() const override {
+        return Server_->GetEndpointId();
+    }
+
     //! Get pointer to the request's message.
     const NProtoBuf::Message* GetRequest() const override {
         return Request_;

--- a/ydb/library/grpc/server/grpc_request_base.h
+++ b/ydb/library/grpc/server/grpc_request_base.h
@@ -128,6 +128,8 @@ public:
 
     //! Returns true if client was not interested in result (but we still must send response to make grpc happy)
     virtual bool IsClientLost() const = 0;
+
+    virtual TString GetEndpointId() const = 0;
 };
 
 } // namespace NYdbGrpc

--- a/ydb/library/grpc/server/grpc_server.h
+++ b/ydb/library/grpc/server/grpc_server.h
@@ -108,6 +108,8 @@ struct TServerOptions {
     //! Logger which will be used to write logs about requests handling (iff appropriate log level is enabled).
     DECLARE_FIELD(Logger, TLoggerPtr, nullptr);
 
+    DECLARE_FIELD(EndpointId, TString, "");
+
 #undef DECLARE_FIELD
 };
 
@@ -204,6 +206,8 @@ public:
      * service to inspect server options and initialize accordingly.
      */
     virtual void SetServerOptions(const TServerOptions& options) = 0;
+
+    virtual TString GetEndpointId() const = 0;
 };
 
 template<typename T>
@@ -304,6 +308,11 @@ public:
     void SetServerOptions(const TServerOptions& options) override {
         SslServer_ = bool(options.SslData);
         NeedAuth_ = options.UseAuth;
+        EndpointId_ = options.EndpointId;
+    }
+
+    TString GetEndpointId() const override {
+        return EndpointId_;
     }
 
     void SetGlobalLimiterHandle(TGlobalLimiter* /*limiter*/) override {}
@@ -362,6 +371,7 @@ private:
 
     bool SslServer_ = false;
     bool NeedAuth_ = false;
+    TString EndpointId_;
 
     struct TShard {
         TAdaptiveLock Lock_;

--- a/ydb/services/datastreams/datastreams_proxy.cpp
+++ b/ydb/services/datastreams/datastreams_proxy.cpp
@@ -11,11 +11,13 @@
 #include <ydb/core/persqueue/partition.h>
 #include <ydb/core/persqueue/pq_rl_helpers.h>
 #include <ydb/core/persqueue/write_meta.h>
+#include <ydb/core/persqueue/events/internal.h>
 
 #include <ydb/public/api/protos/ydb_topic.pb.h>
 #include <ydb/services/lib/actors/pq_schema_actor.h>
 #include <ydb/services/lib/sharding/sharding.h>
 #include <ydb/services/persqueue_v1/actors/persqueue_utils.h>
+#include <ydb/core/persqueue/list_all_topics_actor.h>
 
 #include <util/folder/path.h>
 
@@ -914,13 +916,9 @@ namespace NKikimr::NDataStreams::V1 {
         void Bootstrap(const NActors::TActorContext& ctx);
 
         void StateWork(TAutoPtr<IEventHandle>& ev);
-        void Handle(TEvTxProxySchemeCache::TEvNavigateKeySetResult::TPtr& ev, const TActorContext& ctx);
+        void Handle(TEvPQ::TEvListAllTopicsResponse::TPtr& ev, const TActorContext& ctx);
 
     protected:
-        void SendNavigateRequest(const TActorContext& ctx, const TString& path);
-        void SendPendingRequests(const TActorContext& ctx);
-        void SendResponse(const TActorContext& ctx);
-
         void ReplyWithError(Ydb::StatusIds::StatusCode status, NYds::EErrorCodes errorCode,
                             const TString& messageText, const NActors::TActorContext& ctx) {
 
@@ -928,13 +926,6 @@ namespace NKikimr::NDataStreams::V1 {
             this->Request_->ReplyWithYdbStatus(status);
             this->Die(ctx);
         }
-
-    private:
-        static constexpr ui32 MAX_IN_FLIGHT = 100;
-
-        ui32 RequestsInFlight = 0;
-        std::vector<std::unique_ptr<TEvTxProxySchemeCache::TEvNavigateKeySet>> WaitingList;
-        std::vector<TString> Topics;
     };
 
     TListStreamsActor::TListStreamsActor(NKikimr::NGRpcService::IRequestOpCtx* request)
@@ -955,28 +946,6 @@ namespace NKikimr::NDataStreams::V1 {
                                           "Unauthenticated access is forbidden, please provide credentials", ctx);
             }
         }
-
-        SendNavigateRequest(ctx, *Request_->GetDatabaseName());
-        Become(&TListStreamsActor::StateWork);
-    }
-
-    void TListStreamsActor::SendPendingRequests(const TActorContext& ctx) {
-        if (RequestsInFlight < MAX_IN_FLIGHT && WaitingList.size() > 0) {
-            ctx.Send(MakeSchemeCacheID(), WaitingList.back().release());
-            WaitingList.pop_back();
-            RequestsInFlight++;
-        }
-    }
-
-    void TListStreamsActor::SendResponse(const TActorContext& ctx) {
-        Y_ENSURE(WaitingList.size() == 0 && RequestsInFlight == 0);
-
-        for (TString& topic : Topics) {
-            topic = TFsPath(topic).RelativePath(*Request_->GetDatabaseName()).GetPath();
-        }
-        Sort(Topics.begin(), Topics.end());
-        Ydb::DataStreams::V1::ListStreamsResult result;
-
         int limit = GetProtoRequest()->limit() == 0 ? 100 : GetProtoRequest()->limit();
 
         if (limit > 10000) {
@@ -984,86 +953,32 @@ namespace NKikimr::NDataStreams::V1 {
             Request_->ReplyWithYdbStatus(Ydb::StatusIds::BAD_REQUEST);
             return Die(ctx);
         }
-
-        result.set_has_more_streams(false);
-        for (const auto& streamName : Topics) {
-            if (GetProtoRequest()->exclusive_start_stream_name().empty()
-                || GetProtoRequest()->exclusive_start_stream_name() < streamName)
-            {
-                if (result.stream_names().size() >= limit) {
-                    result.set_has_more_streams(true);
-                    break;
-                }
-                result.add_stream_names(streamName);
-            }
-        }
-
-        Request_->SendResult(result, Ydb::StatusIds::SUCCESS);
-        Die(ctx);
+        ctx.Register(NPersQueue::MakeListAllTopicsActor(SelfId(), Request_->GetDatabaseName().GetOrElse(""),
+                                                        this->Request_->GetSerializedToken(), GetProtoRequest()->recurse(),
+                                                        GetProtoRequest()->exclusive_start_stream_name(), limit));
+        Become(&TListStreamsActor::StateWork);
     }
 
-    void TListStreamsActor::SendNavigateRequest(const TActorContext& ctx, const TString &path) {
-        auto schemeCacheRequest = std::make_unique<NSchemeCache::TSchemeCacheNavigate>();
-        schemeCacheRequest->DatabaseName = Request().GetDatabaseName().GetRef();
-        NSchemeCache::TSchemeCacheNavigate::TEntry entry;
-        entry.Path = NKikimr::SplitPath(path);
-
-        if (!this->Request_->GetSerializedToken().empty()) {
-            schemeCacheRequest->UserToken = new NACLib::TUserToken(this->Request_->GetSerializedToken());
-        }
-
-        entry.Operation = NSchemeCache::TSchemeCacheNavigate::OpList;
-        schemeCacheRequest->ResultSet.emplace_back(entry);
-        WaitingList.push_back(std::make_unique<TEvTxProxySchemeCache::TEvNavigateKeySet>(schemeCacheRequest.release()));
-        SendPendingRequests(ctx);
-    }
 
     void TListStreamsActor::StateWork(TAutoPtr<IEventHandle>& ev) {
         switch (ev->GetTypeRewrite()) {
-            HFunc(TEvTxProxySchemeCache::TEvNavigateKeySetResult, Handle);
+            HFunc(TEvPQ::TEvListAllTopicsResponse, Handle);
             default: TBase::StateWork(ev);
         }
     }
 
-    void TListStreamsActor::Handle(TEvTxProxySchemeCache::TEvNavigateKeySetResult::TPtr& ev, const TActorContext& ctx) {
-        const NSchemeCache::TSchemeCacheNavigate* navigate = ev->Get()->Request.Get();
-        for (const auto& entry : navigate->ResultSet) {
+    void TListStreamsActor::Handle(TEvPQ::TEvListAllTopicsResponse::TPtr& ev, const TActorContext& ctx) {
+        auto topics = std::move(ev->Get()->Topics);
+        Sort(topics.begin(), topics.end());
+        Ydb::DataStreams::V1::ListStreamsResult result;
 
-
-            if (entry.Kind == NSchemeCache::TSchemeCacheNavigate::EKind::KindTable) {
-                for (const auto& stream : entry.CdcStreams) {
-                    TString childFullPath = JoinPath({JoinPath(entry.Path), stream.GetName()});
-                    Topics.push_back(childFullPath);
-                }
-            } else if (entry.Kind == NSchemeCache::TSchemeCacheNavigate::EKind::KindPath
-                || entry.Kind == NSchemeCache::TSchemeCacheNavigate::EKind::KindSubdomain)
-            {
-                Y_ENSURE(entry.ListNodeEntry, "ListNodeEntry is zero");
-                for (const auto& child : entry.ListNodeEntry->Children) {
-                    TString childFullPath = JoinPath({JoinPath(entry.Path), child.Name});
-                    switch (child.Kind) {
-                        case NSchemeCache::TSchemeCacheNavigate::EKind::KindPath:
-                        case NSchemeCache::TSchemeCacheNavigate::EKind::KindTable:
-                            if (GetProtoRequest()->recurse()) {
-                                SendNavigateRequest(ctx, childFullPath);
-                            }
-                            break;
-                        case NSchemeCache::TSchemeCacheNavigate::EKind::KindTopic:
-                            Topics.push_back(childFullPath);
-                            break;
-
-                        default:
-                            break;
-                            // ignore all other types
-                    }
-                }
-            }
+        result.set_has_more_streams(ev->Get()->HaveMoreTopics);
+        for (const auto& streamName : topics) {
+            result.add_stream_names(streamName);
         }
-        RequestsInFlight--;
-        SendPendingRequests(ctx);
-        if (RequestsInFlight == 0) {
-            SendResponse(ctx);
-        }
+
+        Request_->SendResult(result, Ydb::StatusIds::SUCCESS);
+        Die(ctx);
     }
 
     //-----------------------------------------------------------------------------------
@@ -1637,8 +1552,8 @@ namespace NKikimr::NDataStreams::V1 {
         switch (record.GetStatus()) {
             case NMsgBusProxy::MSTATUS_ERROR:
                 switch (record.GetErrorCode()) {
-                    case NPersQueue::NErrorCode::READ_ERROR_TOO_SMALL_OFFSET:
-                    case NPersQueue::NErrorCode::READ_ERROR_TOO_BIG_OFFSET:
+                    case ::NPersQueue::NErrorCode::READ_ERROR_TOO_SMALL_OFFSET:
+                    case ::NPersQueue::NErrorCode::READ_ERROR_TOO_BIG_OFFSET:
                         Result.set_next_shard_iterator(TShardIterator(ShardIterator).Serialize());
                         Result.set_millis_behind_latest(0);
 

--- a/ydb/services/persqueue_v1/actors/events.h
+++ b/ydb/services/persqueue_v1/actors/events.h
@@ -505,7 +505,7 @@ struct TEvPQProxy {
         ui64 PartitionId;
         ui64 Generation;
         ui64 NodeId;
-        TString Hostname;
+        //TString Hostname;
     };
 
     struct TEvPartitionLocationResponse : public NActors::TEventLocal<TEvPartitionLocationResponse, EvPartitionLocationResponse>

--- a/ydb/services/persqueue_v1/actors/schema_actors.cpp
+++ b/ydb/services/persqueue_v1/actors/schema_actors.cpp
@@ -1478,13 +1478,10 @@ void TPartitionsLocationActor::Bootstrap(const NActors::TActorContext&)
 {
     SendDescribeProposeRequest();
     UnsafeBecome(&TPartitionsLocationActor::StateWork);
-    SendNodesRequest();
-
 }
 
 void TPartitionsLocationActor::StateWork(TAutoPtr<IEventHandle>& ev) {
     switch (ev->GetTypeRewrite()) {
-        hFunc(TEvICNodesInfoCache::TEvGetAllNodesInfoResponse, Handle);
         default:
             if (!TDescribeTopicActorImpl::StateWork(ev, ActorContext())) {
                 TBase::StateWork(ev);
@@ -1519,25 +1516,8 @@ bool TPartitionsLocationActor::ApplyResponse(
         partLocation.NodeId = nodeId;
         Response->Partitions.emplace_back(std::move(partLocation));
     }
-    if (GotNodesInfo)
-        Finalize();
-    else
-        GotPartitions = true;
+    Finalize();
     return true;
-}
-
-void TPartitionsLocationActor::SendNodesRequest() const {
-    auto* icEv = new TEvICNodesInfoCache::TEvGetAllNodesInfoRequest();
-    ActorContext().Send(CreateICNodesInfoCacheServiceId(), icEv);
-
-}
-
-void TPartitionsLocationActor::Handle(TEvICNodesInfoCache::TEvGetAllNodesInfoResponse::TPtr& ev) {
-    NodesInfoEv = ev;
-    if (GotPartitions)
-        Finalize();
-    else
-        GotNodesInfo = true;
 }
 
 void TPartitionsLocationActor::Finalize() {
@@ -1545,17 +1525,6 @@ void TPartitionsLocationActor::Finalize() {
         Y_ABORT_UNLESS(Response->Partitions.size() == Settings.Partitions.size());
     } else {
         Y_ABORT_UNLESS(Response->Partitions.size() == PQGroupInfo->Description.PartitionsSize());
-    }
-    for (auto& pInResponse : Response->Partitions) {
-        auto iter = NodesInfoEv->Get()->NodeIdsMapping->find(pInResponse.NodeId);
-        if (iter.IsEnd()) {
-            return RaiseError(
-                    TStringBuilder() << "Hostname not found for nodeId " << pInResponse.NodeId,
-                    Ydb::PersQueue::ErrorCode::ERROR,
-                    Ydb::StatusIds::INTERNAL_ERROR, ActorContext()
-            );
-        }
-        pInResponse.Hostname = (*NodesInfoEv->Get()->Nodes)[iter->second].Host;
     }
     TBase::RespondWithCode(Ydb::StatusIds::SUCCESS);
 }

--- a/ydb/services/persqueue_v1/actors/schema_actors.h
+++ b/ydb/services/persqueue_v1/actors/schema_actors.h
@@ -449,16 +449,9 @@ public:
     bool ApplyResponse(TEvPersQueue::TEvGetPartitionsLocationResponse::TPtr& ev, const TActorContext& ctx) override;
     void Reply(const TActorContext&) override {};
 
-    void Handle(NIcNodeCache::TEvICNodesInfoCache::TEvGetAllNodesInfoResponse::TPtr& ev);
     void RaiseError(const TString& error, const Ydb::PersQueue::ErrorCode::ErrorCode errorCode, const Ydb::StatusIds::StatusCode status, const TActorContext&) override;
 private:
-    void SendNodesRequest() const;
-
-    NIcNodeCache::TEvICNodesInfoCache::TEvGetAllNodesInfoResponse::TPtr NodesInfoEv;
     THashSet<ui64> PartitionIds;
-
-    bool GotPartitions = false;
-    bool GotNodesInfo = false;
 };
 
 } // namespace NKikimr::NGRpcProxy::V1

--- a/ydb/services/persqueue_v1/ut/describes_ut/describe_topic_ut.cpp
+++ b/ydb/services/persqueue_v1/ut/describes_ut/describe_topic_ut.cpp
@@ -210,7 +210,6 @@ Y_UNIT_TEST_SUITE(TTopicApiDescribes) {
 
         THashSet<ui64> allParts;
         for (const auto& p : ev->Partitions) {
-            UNIT_ASSERT(!p.Hostname.Empty());
             UNIT_ASSERT(p.NodeId > 0);
 //            UNIT_ASSERT(p.IncGeneration > 0);
             UNIT_ASSERT(p.PartitionId < 15);

--- a/ydb/tests/library/harness/kikimr_config.py
+++ b/ydb/tests/library/harness/kikimr_config.py
@@ -560,6 +560,21 @@ class KikimrConfigGenerator(object):
         with open(os.path.join(configs_path, "config.yaml"), "w") as writer:
             writer.write(yaml.safe_dump(self.yaml_config))
 
+    def clone_grpc_as_ext_endpoint(self, port, endpoint_id=None):
+        cur_grpc_config = copy.deepcopy(self.yaml_config['grpc_config'])
+        if 'ext_endpoints' in cur_grpc_config:
+            del cur_grpc_config['ext_endpoints']
+
+        cur_grpc_config['port'] = port
+
+        if endpoint_id is not None:
+            cur_grpc_config['endpoint_id'] = endpoint_id
+
+        if 'ext_endpoints' not in self.yaml_config['grpc_config']:
+            self.yaml_config['grpc_config']['ext_endpoints'] = []
+
+        self.yaml_config['grpc_config']['ext_endpoints'].append(cur_grpc_config)
+
     def get_yql_udfs_to_load(self):
         if not self.__load_udfs:
             return []


### PR DESCRIPTION
- Kafka port assignment through discoveryCache (#13197)
- Add kafka-port option to binary (#13799)
- Restore changes lost duraing merge (#13884)
- List all topics in kafka metaRequest (#14110)
- Kafka auth flag and bugfix in ts (#14220)
- endpoint slicing support (#10313)
- Clear merge artefacts

### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

Add improvements required for proper discovery of endpoints in KafkaProxy and some fixes

### Changelog category <!-- remove all except one -->

* Improvement

### Description for reviewers <!-- (optional) description for those who read this PR -->

Also support proper full listing of topics for Kafka MetadataRequest
