### PR TITLE
Avoid relying on refcount for mediator bucket cleanup

### DIFF
--- a/ydb/core/tx/time_cast/time_cast.cpp
+++ b/ydb/core/tx/time_cast/time_cast.cpp
@@ -333,7 +333,12 @@ class TMediatorTimecastProxy : public TActor<TMediatorTimecastProxy> {
             if (bucket.Tablets.empty()) {
                 // There are no tablets interested in this bucket, avoid unnecessary watches
                 bucket.WatchSent = false;
-                bucket.Waiters = { };
+                if (!bucket.Waiters.empty()) {
+                    bucket.Waiters = { };
+                }
+                if (!bucket.TabletWaiters.empty()) {
+                    bucket.TabletWaiters.clear();
+                }
                 continue;
             }
 
@@ -627,48 +632,46 @@ void TMediatorTimecastProxy::Handle(TEvMediatorTimecast::TEvUpdate::TPtr& ev, co
         Y_ABORT_UNLESS(record.GetBucket() < mediator.BucketsSz);
         auto& bucket = mediator.Buckets[record.GetBucket()];
         const ui64 step = record.GetTimeBarrier();
-        switch (bucket.SafeStep.RefCount()) {
-            case 0:
-                break;
-            case 1:
+        bucket.SafeStep->Set(step);
+        if (bucket.Tablets.empty()) {
+            if (!bucket.Waiters.empty()) {
                 bucket.Waiters = { };
-                bucket.TabletWaiters = { };
-                [[fallthrough]];
-            default: {
-                bucket.SafeStep->Set(step);
-                THashSet<std::pair<TActorId, ui64>> processed; // a set of processed tablets
-                while (!bucket.Waiters.empty()) {
-                    const auto& top = bucket.Waiters.top();
-                    if (step < top.PlanStep) {
-                        break;
-                    }
-                    if (processed.insert(std::make_pair(top.Sender, top.TabletId)).second) {
-                        ctx.Send(top.Sender, new TEvMediatorTimecast::TEvNotifyPlanStep(top.TabletId, step));
-                    }
-                    bucket.Waiters.pop();
+            }
+            if (!bucket.TabletWaiters.empty()) {
+                bucket.TabletWaiters.clear();
+            }
+        } else {
+            THashSet<std::pair<TActorId, ui64>> processed; // a set of processed tablets
+            while (!bucket.Waiters.empty()) {
+                const auto& top = bucket.Waiters.top();
+                if (step < top.PlanStep) {
+                    break;
                 }
-                while (!bucket.TabletWaiters.empty()) {
-                    const auto& candidate = *bucket.TabletWaiters.begin();
-                    if (step < candidate.PlanStep) {
-                        break;
-                    }
-                    auto it = Tablets.find(candidate.TabletId);
-                    if (it != Tablets.end()) {
-                        auto& tabletInfo = it->second;
-                        while (!tabletInfo.Waiters.empty()) {
-                            const auto& top = *tabletInfo.Waiters.begin();
-                            if (step < top.PlanStep) {
-                                break;
-                            }
-                            if (processed.insert(std::make_pair(top.Sender, top.TabletId)).second) {
-                                ctx.Send(top.Sender, new TEvMediatorTimecast::TEvNotifyPlanStep(top.TabletId, step));
-                            }
-                            tabletInfo.Waiters.erase(tabletInfo.Waiters.begin());
+                if (processed.insert(std::make_pair(top.Sender, top.TabletId)).second) {
+                    ctx.Send(top.Sender, new TEvMediatorTimecast::TEvNotifyPlanStep(top.TabletId, step));
+                }
+                bucket.Waiters.pop();
+            }
+            while (!bucket.TabletWaiters.empty()) {
+                const auto& candidate = *bucket.TabletWaiters.begin();
+                if (step < candidate.PlanStep) {
+                    break;
+                }
+                auto it = Tablets.find(candidate.TabletId);
+                if (it != Tablets.end()) {
+                    auto& tabletInfo = it->second;
+                    while (!tabletInfo.Waiters.empty()) {
+                        const auto& top = *tabletInfo.Waiters.begin();
+                        if (step < top.PlanStep) {
+                            break;
                         }
+                        if (processed.insert(std::make_pair(top.Sender, top.TabletId)).second) {
+                            ctx.Send(top.Sender, new TEvMediatorTimecast::TEvNotifyPlanStep(top.TabletId, step));
+                        }
+                        tabletInfo.Waiters.erase(tabletInfo.Waiters.begin());
                     }
-                    bucket.TabletWaiters.erase(bucket.TabletWaiters.begin());
                 }
-                break;
+                bucket.TabletWaiters.erase(bucket.TabletWaiters.begin());
             }
         }
         for (ui64 coordinatorId : mediator.Coordinators) {


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

...

### Changelog category <!-- remove all except one -->

* Not for changelog (changelog entry is not required)

### Description for reviewers <!-- (optional) description for those who read this PR -->

I noticed that timecast service used bucket entry refcount to make some decisions, which are leftovers of the old behavior before the rewrite (e.g. the case for `RefCount() == 0` cannot even happen anymore). Check for `Tablets.empty()` explicitly instead, and clear waiters consistently on either update or reconnect.

Related to #14029.