### PR TITLE
Fixed underflow in C++ SDK decimal FromString, ToString and IsValid

### DIFF
--- a/ydb/public/sdk/cpp/src/library/decimal/yql_decimal.cpp
+++ b/ydb/public/sdk/cpp/src/library/decimal/yql_decimal.cpp
@@ -180,7 +180,7 @@ TInt128 FromString(const std::string_view& str, ui8 precision, ui8 scale) {
 
         bool plus = c > '5';
         if (!plus && c == '5') {
-            for (plus = v & 1; !plus && l > -; --l) {
+            for (plus = v & 1; !plus && l > 0; --l) {
                 const char c = *s++;
                 if (!std::isdigit(c))
                     return Err();


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

Fixed underflow in YDB C++ SDK decimal parser: https://github.com/ydb-platform/ydb-cpp-sdk/issues/379

### Changelog category <!-- remove all except one -->

* Bugfix 

### Description for reviewers <!-- (optional) description for those who read this PR -->

Linter outputs underflow in FromString, but it doesn't affect on execution
