### PR TITLE
Persist config upon being changed by distconf

### DIFF
--- a/ydb/core/blobstorage/nodewarden/distconf.h
+++ b/ydb/core/blobstorage/nodewarden/distconf.h
@@ -738,6 +738,9 @@ namespace NKikimr::NStorage {
 
     std::optional<TString> ValidateConfig(const NKikimrBlobStorage::TStorageConfig& config);
 
+    std::optional<TString> DecomposeConfig(const TString& configComposite, TString *mainConfigYaml,
+        ui64 *mainConfigVersion, TString *mainConfigFetchYaml);
+
 } // NKikimr::NStorage
 
 template<>

--- a/ydb/core/blobstorage/nodewarden/node_warden_impl.cpp
+++ b/ydb/core/blobstorage/nodewarden/node_warden_impl.cpp
@@ -640,6 +640,10 @@ void TNodeWarden::PersistConfig(const TString& configYaml, ui64 version, std::op
         return;
     }
 
+    if (YamlConfig && version <= YamlConfig->GetConfigVersion()) {
+        return; // some kind of a race
+    }
+
     struct TSaveContext {
         TString ConfigStorePath;
         TString ConfigYaml;

--- a/ydb/core/blobstorage/nodewarden/node_warden_resource.cpp
+++ b/ydb/core/blobstorage/nodewarden/node_warden_resource.cpp
@@ -1,11 +1,13 @@
 #include "node_warden.h"
 #include "node_warden_impl.h"
+#include "distconf.h"
 #include <ydb/core/base/statestorage_impl.h>
 #include <ydb/core/blobstorage/crypto/default.h>
 #include <ydb/core/blobstorage/incrhuge/incrhuge_keeper.h>
 #include <ydb/core/blobstorage/nodewarden/node_warden_events.h>
 #include <ydb/library/pdisk_io/file_params.h>
 #include <ydb/library/pdisk_io/wcache.h>
+#include <library/cpp/streams/zstd/zstd.h>
 #include <util/string/split.h>
 
 using namespace NKikimr;
@@ -110,6 +112,30 @@ void TNodeWarden::Handle(TEvNodeWardenStorageConfig::TPtr ev) {
 
     for (const TActorId& subscriber : StorageConfigSubscribers) {
         Send(subscriber, new TEvNodeWardenStorageConfig(StorageConfig, nullptr, SelfManagementEnabled));
+    }
+
+    if (StorageConfig.HasConfigComposite()) {
+        TString mainConfigYaml;
+        ui64 mainConfigYamlVersion;
+        auto error = DecomposeConfig(StorageConfig.GetConfigComposite(), &mainConfigYaml, &mainConfigYamlVersion, nullptr);
+        if (error) {
+            STLOG_DEBUG_FAIL(BS_NODE, NW49, "failed to decompose yaml configuration", (Error, error));
+        } else if (mainConfigYaml) {
+            std::optional<TString> storageConfigYaml;
+            if (StorageConfig.HasCompressedStorageYaml()) {
+                try {
+                    TStringInput s(StorageConfig.GetCompressedStorageYaml());
+                    storageConfigYaml.emplace(TZstdDecompress(&s).ReadAll());
+                } catch (const std::exception& ex) {
+                    Y_ABORT("CompressedStorageYaml format incorrect: %s", ex.what());
+                }
+            }
+
+            // TODO(alexvru): make this blocker for confirmation?
+            PersistConfig(std::move(mainConfigYaml), mainConfigYamlVersion, std::move(storageConfigYaml));
+        }
+    } else {
+        Y_DEBUG_ABORT_UNLESS(!StorageConfig.HasCompressedStorageYaml());
     }
 
     TActivationContext::Send(new IEventHandle(TEvBlobStorage::EvNodeWardenStorageConfigConfirm, 0, ev->Sender, SelfId(),


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

Persist config upon being changed by distconf

### Changelog category <!-- remove all except one -->

* Not for changelog (changelog entry is not required)

### Description for reviewers <!-- (optional) description for those who read this PR -->

Configs are now persisted into the config storage directory when updated through distconf mechanism.
