### PR TITLE
Ingore basic scheme limits for internal operations

### DIFF
--- a/ydb/core/protos/index_builder.proto
+++ b/ydb/core/protos/index_builder.proto
@@ -49,6 +49,8 @@ message TEvCreateRequest {
     optional uint64 TxId = 2;
     optional string DatabaseName = 3;
     optional TIndexBuildSettings Settings = 4;
+    // Internal flag is true for system-generated operations and is false for those initiated directly by the user.
+    optional bool Internal = 5 [default = false];
 }
 
 message TEvCreateResponse {

--- a/ydb/core/tx/schemeshard/schemeshard__operation_create_build_index.cpp
+++ b/ydb/core/tx/schemeshard/schemeshard__operation_create_build_index.cpp
@@ -24,6 +24,7 @@ TVector<ISubOperation::TPtr> CreateBuildColumn(TOperationId opId, const TTxTrans
     {
         auto outTx = TransactionTemplate(table.Parent().PathString(), NKikimrSchemeOp::EOperationType::ESchemeOpInitiateBuildIndexMainTable);
         *outTx.MutableLockGuard() = tx.GetLockGuard();
+        outTx.SetInternal(tx.GetInternal());
 
         auto& snapshot = *outTx.MutableInitiateBuildIndexMainTable();
         snapshot.SetTableName(table.LeafName());
@@ -64,7 +65,7 @@ TVector<ISubOperation::TPtr> CreateBuildIndex(TOperationId opId, const TTxTransa
             .PathsLimit(2) // index and impl-table
             .DirChildrenLimit();
 
-        if (!tx.internal()) {
+        if (!tx.GetInternal()) {
             checks
                 .ShardsLimit(1); // impl-table
         }
@@ -99,6 +100,7 @@ TVector<ISubOperation::TPtr> CreateBuildIndex(TOperationId opId, const TTxTransa
         *outTx.MutableLockGuard() = tx.GetLockGuard();
         outTx.MutableCreateTableIndex()->CopyFrom(indexDesc);
         outTx.MutableCreateTableIndex()->SetState(NKikimrSchemeOp::EIndexStateWriteOnly);
+        outTx.SetInternal(tx.GetInternal());
 
         if (!indexDesc.HasType()) {
             outTx.MutableCreateTableIndex()->SetType(NKikimrSchemeOp::EIndexTypeGlobal);
@@ -110,6 +112,7 @@ TVector<ISubOperation::TPtr> CreateBuildIndex(TOperationId opId, const TTxTransa
     {
         auto outTx = TransactionTemplate(table.Parent().PathString(), NKikimrSchemeOp::EOperationType::ESchemeOpInitiateBuildIndexMainTable);
         *outTx.MutableLockGuard() = tx.GetLockGuard();
+        outTx.SetInternal(tx.GetInternal());
 
         auto& snapshot = *outTx.MutableInitiateBuildIndexMainTable();
         snapshot.SetTableName(table.LeafName());

--- a/ydb/core/tx/schemeshard/schemeshard__operation_create_build_index.cpp
+++ b/ydb/core/tx/schemeshard/schemeshard__operation_create_build_index.cpp
@@ -60,10 +60,14 @@ TVector<ISubOperation::TPtr> CreateBuildIndex(TOperationId opId, const TTxTransa
 
         // TODO(mbkkt) less than necessary for vector index
         checks
-            .IsValidLeafName()
-            .PathsLimit(2) // index and impl-table
-            .DirChildrenLimit()
-            .ShardsLimit(1); // impl-table
+            .IsValidLeafName();
+
+        if (!tx.internal()) {
+            checks
+                .PathsLimit(2) // index and impl-table
+                .DirChildrenLimit()
+                .ShardsLimit(1); // impl-table
+        }
 
         if (!checks) {
             return {CreateReject(opId, checks.GetStatus(), checks.GetError())};
@@ -118,6 +122,7 @@ TVector<ISubOperation::TPtr> CreateBuildIndex(TOperationId opId, const TTxTransa
 
         auto outTx = TransactionTemplate(index.PathString(), NKikimrSchemeOp::EOperationType::ESchemeOpInitiateBuildIndexImplTable);
         *outTx.MutableCreateTable() = std::move(implTableDesc);
+        outTx.SetInternal(tx.GetInternal());
 
         return CreateInitializeBuildIndexImplTable(NextPartId(opId, result), outTx);
     };

--- a/ydb/core/tx/schemeshard/schemeshard__operation_create_build_index.cpp
+++ b/ydb/core/tx/schemeshard/schemeshard__operation_create_build_index.cpp
@@ -60,12 +60,12 @@ TVector<ISubOperation::TPtr> CreateBuildIndex(TOperationId opId, const TTxTransa
 
         // TODO(mbkkt) less than necessary for vector index
         checks
-            .IsValidLeafName();
+            .IsValidLeafName()
+            .PathsLimit(2) // index and impl-table
+            .DirChildrenLimit();
 
         if (!tx.internal()) {
             checks
-                .PathsLimit(2) // index and impl-table
-                .DirChildrenLimit()
                 .ShardsLimit(1); // impl-table
         }
 

--- a/ydb/core/tx/schemeshard/schemeshard__operation_create_indexed_table.cpp
+++ b/ydb/core/tx/schemeshard/schemeshard__operation_create_indexed_table.cpp
@@ -110,11 +110,11 @@ TVector<ISubOperation::TPtr> CreateIndexedTable(TOperationId nextId, const TTxTr
     {
         auto checks = baseTablePath.Check();
         checks
-            .PathShardsLimit(baseShards)
             .PathsLimit(pathToCreate);
 
         if (!tx.GetInternal()) {
             checks
+                .PathShardsLimit(baseShards)
                 .ShardsLimit(shardsToCreate);
         }
 
@@ -317,6 +317,7 @@ TVector<ISubOperation::TPtr> CreateIndexedTable(TOperationId nextId, const TTxTr
             NKikimrSchemeOp::EOperationType::ESchemeOpCreateSequence);
         scheme.SetFailOnExist(tx.GetFailOnExist());
         scheme.SetAllowCreateInTempDir(tx.GetAllowCreateInTempDir());
+        scheme.SetInternal(tx.GetInternal());
 
         *scheme.MutableSequence() = sequenceDescription;
 

--- a/ydb/core/tx/schemeshard/schemeshard__operation_create_indexed_table.cpp
+++ b/ydb/core/tx/schemeshard/schemeshard__operation_create_indexed_table.cpp
@@ -107,7 +107,7 @@ TVector<ISubOperation::TPtr> CreateIndexedTable(TOperationId nextId, const TTxTr
         return {CreateReject(nextId, NKikimrScheme::EStatus::StatusResourceExhausted, msg)};
     }
 
-    {
+    if (!tx.internal()) {
         auto checks = baseTablePath.Check();
         checks
             .PathShardsLimit(baseShards)
@@ -224,6 +224,7 @@ TVector<ISubOperation::TPtr> CreateIndexedTable(TOperationId nextId, const TTxTr
         auto scheme = TransactionTemplate(tx.GetWorkingDir(), NKikimrSchemeOp::EOperationType::ESchemeOpCreateTable);
         scheme.SetFailOnExist(tx.GetFailOnExist());
         scheme.SetAllowCreateInTempDir(tx.GetAllowCreateInTempDir());
+        scheme.SetInternal(tx.GetInternal());
 
         scheme.MutableCreateTable()->CopyFrom(baseTableDescription);
         if (tx.HasAlterUserAttributes()) {
@@ -270,6 +271,7 @@ TVector<ISubOperation::TPtr> CreateIndexedTable(TOperationId nextId, const TTxTr
                 NKikimrSchemeOp::EOperationType::ESchemeOpCreateTable);
             scheme.SetFailOnExist(tx.GetFailOnExist());
             scheme.SetAllowCreateInTempDir(tx.GetAllowCreateInTempDir());
+            scheme.SetInternal(tx.GetInternal());
 
             *scheme.MutableCreateTable() = std::move(implTableDesc);
 

--- a/ydb/core/tx/schemeshard/schemeshard__operation_create_indexed_table.cpp
+++ b/ydb/core/tx/schemeshard/schemeshard__operation_create_indexed_table.cpp
@@ -107,12 +107,16 @@ TVector<ISubOperation::TPtr> CreateIndexedTable(TOperationId nextId, const TTxTr
         return {CreateReject(nextId, NKikimrScheme::EStatus::StatusResourceExhausted, msg)};
     }
 
-    if (!tx.internal()) {
+    {
         auto checks = baseTablePath.Check();
         checks
             .PathShardsLimit(baseShards)
-            .PathsLimit(pathToCreate)
-            .ShardsLimit(shardsToCreate);
+            .PathsLimit(pathToCreate);
+
+        if (!tx.GetInternal()) {
+            checks
+                .ShardsLimit(shardsToCreate);
+        }
 
         if (!checks) {
             return {CreateReject(nextId, NKikimrScheme::EStatus::StatusResourceExhausted, checks.GetError())};

--- a/ydb/core/tx/schemeshard/schemeshard__operation_create_table.cpp
+++ b/ydb/core/tx/schemeshard/schemeshard__operation_create_table.cpp
@@ -501,11 +501,15 @@ public:
 
                 checks
                     .IsValidLeafName()
-                    .PathsLimit()
-                    .DirChildrenLimit()
-                    .ShardsLimit(shardsToCreate)
-                    .PathShardsLimit(shardsToCreate)
                     .IsValidACL(acl);
+
+                if (!Transaction.internal()) {
+                    checks
+                        .PathsLimit()
+                        .DirChildrenLimit()
+                        .ShardsLimit(shardsToCreate)
+                        .PathShardsLimit(shardsToCreate);
+                }
             }
 
             if (!checks) {

--- a/ydb/core/tx/schemeshard/schemeshard__operation_create_table.cpp
+++ b/ydb/core/tx/schemeshard/schemeshard__operation_create_table.cpp
@@ -501,12 +501,12 @@ public:
 
                 checks
                     .IsValidLeafName()
+                    .PathsLimit()
+                    .DirChildrenLimit()
                     .IsValidACL(acl);
 
                 if (!Transaction.internal()) {
                     checks
-                        .PathsLimit()
-                        .DirChildrenLimit()
                         .ShardsLimit(shardsToCreate)
                         .PathShardsLimit(shardsToCreate);
                 }

--- a/ydb/core/tx/schemeshard/schemeshard__operation_create_table.cpp
+++ b/ydb/core/tx/schemeshard/schemeshard__operation_create_table.cpp
@@ -505,7 +505,7 @@ public:
                     .DirChildrenLimit()
                     .IsValidACL(acl);
 
-                if (!Transaction.internal()) {
+                if (!Transaction.GetInternal()) {
                     checks
                         .ShardsLimit(shardsToCreate)
                         .PathShardsLimit(shardsToCreate);

--- a/ydb/core/tx/schemeshard/schemeshard__operation_split_merge.cpp
+++ b/ydb/core/tx/schemeshard/schemeshard__operation_split_merge.cpp
@@ -751,7 +751,8 @@ public:
                 .NotUnderOperation();
 
             if (checks) {
-                if (dstCount >= srcCount) { //allow over commit for merge
+                // allow over commit for merge
+                if (dstCount >= srcCount && !Transaction.internal()) {
                     checks
                         .ShardsLimit(dstCount)
                         .PathShardsLimit(dstCount);

--- a/ydb/core/tx/schemeshard/schemeshard__operation_split_merge.cpp
+++ b/ydb/core/tx/schemeshard/schemeshard__operation_split_merge.cpp
@@ -751,8 +751,7 @@ public:
                 .NotUnderOperation();
 
             if (checks) {
-                // allow over commit for merge
-                if (dstCount >= srcCount && !Transaction.internal()) {
+                if (dstCount >= srcCount) { //allow over commit for merge
                     checks
                         .ShardsLimit(dstCount)
                         .PathShardsLimit(dstCount);

--- a/ydb/core/tx/schemeshard/schemeshard_build_index__create.cpp
+++ b/ydb/core/tx/schemeshard/schemeshard_build_index__create.cpp
@@ -119,7 +119,7 @@ public:
                     .PathsLimit(2) // index and impl-table
                     .DirChildrenLimit();
 
-                if (!request.GetOperationParams().labels().contains("internal")) {
+                if (bool isInternal = Self->TxIdToImport.contains(TTxId(request.GetTxId())); !isInternal) {
                     checks
                         .ShardsLimit(1); // impl-table
                 }

--- a/ydb/core/tx/schemeshard/schemeshard_build_index__create.cpp
+++ b/ydb/core/tx/schemeshard/schemeshard_build_index__create.cpp
@@ -115,10 +115,14 @@ public:
                 }
 
                 checks
-                    .IsValidLeafName()
-                    .PathsLimit(2) // index and impl-table
-                    .DirChildrenLimit()
-                    .ShardsLimit(1); // impl-table
+                    .IsValidLeafName();
+
+                if (!request.GetOperationParams().labels().contains("internal")) {
+                    checks
+                        .PathsLimit(2) // index and impl-table
+                        .DirChildrenLimit()
+                        .ShardsLimit(1); // impl-table
+                }
 
                 if (!checks) {
                     return Reply(checks.GetStatus(), checks.GetError());

--- a/ydb/core/tx/schemeshard/schemeshard_build_index__create.cpp
+++ b/ydb/core/tx/schemeshard/schemeshard_build_index__create.cpp
@@ -115,12 +115,12 @@ public:
                 }
 
                 checks
-                    .IsValidLeafName();
+                    .IsValidLeafName()
+                    .PathsLimit(2) // index and impl-table
+                    .DirChildrenLimit();
 
                 if (!request.GetOperationParams().labels().contains("internal")) {
                     checks
-                        .PathsLimit(2) // index and impl-table
-                        .DirChildrenLimit()
                         .ShardsLimit(1); // impl-table
                 }
 

--- a/ydb/core/tx/schemeshard/schemeshard_build_index__create.cpp
+++ b/ydb/core/tx/schemeshard/schemeshard_build_index__create.cpp
@@ -119,7 +119,7 @@ public:
                     .PathsLimit(2) // index and impl-table
                     .DirChildrenLimit();
 
-                if (bool isInternal = Self->TxIdToImport.contains(TTxId(request.GetTxId())); !isInternal) {
+                if (!request.GetInternal()) {
                     checks
                         .ShardsLimit(1); // impl-table
                 }

--- a/ydb/core/tx/schemeshard/schemeshard_import_flow_proposals.cpp
+++ b/ydb/core/tx/schemeshard/schemeshard_import_flow_proposals.cpp
@@ -217,7 +217,9 @@ THolder<TEvIndexBuilder::TEvCreateRequest> BuildIndexPropose(
 
     const TPath domainPath = TPath::Init(importInfo->DomainPathId, ss);
     auto propose = MakeHolder<TEvIndexBuilder::TEvCreateRequest>(ui64(txId), domainPath.PathString(), std::move(settings));
-    (*propose->Record.MutableOperationParams()->mutable_labels())["uid"] = uid;
+    auto& labels = *propose->Record.MutableOperationParams()->mutable_labels();
+    labels["uid"] = uid;
+    labels["internal"] = "";
 
     return propose;
 }
@@ -259,11 +261,11 @@ THolder<TEvSchemeShard::TEvModifySchemeTransaction> CreateChangefeedPropose(
     if (!FillChangefeedDescription(cdcStreamDescription, changefeed, status, error)) {
         return nullptr;
     }
-    
+
     if (topic.has_retention_period()) {
         cdcStream.SetRetentionPeriodSeconds(topic.retention_period().seconds());
     }
-    
+
     if (topic.has_partitioning_settings()) {
         i64 minActivePartitions =
             topic.partitioning_settings().min_active_partitions();

--- a/ydb/core/tx/schemeshard/schemeshard_import_flow_proposals.cpp
+++ b/ydb/core/tx/schemeshard/schemeshard_import_flow_proposals.cpp
@@ -217,7 +217,9 @@ THolder<TEvIndexBuilder::TEvCreateRequest> BuildIndexPropose(
 
     const TPath domainPath = TPath::Init(importInfo->DomainPathId, ss);
     auto propose = MakeHolder<TEvIndexBuilder::TEvCreateRequest>(ui64(txId), domainPath.PathString(), std::move(settings));
-    (*propose->Record.MutableOperationParams()->mutable_labels())["uid"] = uid;
+    auto& request = propose->Record;
+    (*request.MutableOperationParams()->mutable_labels())["uid"] = uid;
+    request.SetInternal(true);
 
     return propose;
 }
@@ -259,11 +261,11 @@ THolder<TEvSchemeShard::TEvModifySchemeTransaction> CreateChangefeedPropose(
     if (!FillChangefeedDescription(cdcStreamDescription, changefeed, status, error)) {
         return nullptr;
     }
-    
+
     if (topic.has_retention_period()) {
         cdcStream.SetRetentionPeriodSeconds(topic.retention_period().seconds());
     }
-    
+
     if (topic.has_partitioning_settings()) {
         i64 minActivePartitions =
             topic.partitioning_settings().min_active_partitions();

--- a/ydb/core/tx/schemeshard/schemeshard_import_flow_proposals.cpp
+++ b/ydb/core/tx/schemeshard/schemeshard_import_flow_proposals.cpp
@@ -217,9 +217,7 @@ THolder<TEvIndexBuilder::TEvCreateRequest> BuildIndexPropose(
 
     const TPath domainPath = TPath::Init(importInfo->DomainPathId, ss);
     auto propose = MakeHolder<TEvIndexBuilder::TEvCreateRequest>(ui64(txId), domainPath.PathString(), std::move(settings));
-    auto& labels = *propose->Record.MutableOperationParams()->mutable_labels();
-    labels["uid"] = uid;
-    labels["internal"] = "";
+    (*propose->Record.MutableOperationParams()->mutable_labels())["uid"] = uid;
 
     return propose;
 }
@@ -261,11 +259,11 @@ THolder<TEvSchemeShard::TEvModifySchemeTransaction> CreateChangefeedPropose(
     if (!FillChangefeedDescription(cdcStreamDescription, changefeed, status, error)) {
         return nullptr;
     }
-
+    
     if (topic.has_retention_period()) {
         cdcStream.SetRetentionPeriodSeconds(topic.retention_period().seconds());
     }
-
+    
     if (topic.has_partitioning_settings()) {
         i64 minActivePartitions =
             topic.partitioning_settings().min_active_partitions();

--- a/ydb/core/tx/schemeshard/ut_restore/ut_restore.cpp
+++ b/ydb/core/tx/schemeshard/ut_restore/ut_restore.cpp
@@ -5062,6 +5062,7 @@ Y_UNIT_TEST_SUITE(TImportTests) {
 
         TSchemeLimits basicLimits;
         basicLimits.MaxShards = 4;
+        basicLimits.MaxShardsInPath = 2;
         SetSchemeshardSchemaLimits(runtime, basicLimits, tenantSchemeShard);
 
         TestDescribeResult(DescribePath(runtime, tenantSchemeShard, "/MyRoot/Alice"), {
@@ -5133,6 +5134,12 @@ Y_UNIT_TEST_SUITE(TImportTests) {
         ));
         env.TestWaitNotification(runtime, importId, tenantSchemeShard);
         TestGetImport(runtime, tenantSchemeShard, importId, "/MyRoot/Alice");
+
+        TestDescribeResult(DescribePath(runtime, tenantSchemeShard, "/MyRoot/Alice"), {
+            NLs::DomainLimitsIs(basicLimits.MaxPaths, basicLimits.MaxShards),
+            NLs::PathsInsideDomain(5),
+            NLs::ShardsInsideDomain(7)
+        });
     }
 }
 


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

### Changelog category <!-- remove all except one -->

* Not for changelog (changelog entry is not required)

### Description for reviewers <!-- (optional) description for those who read this PR -->

Hacky solution for inability to import a database from a backup that was successfully created. Shard limit might be broken on import. Probably due to the index building. We decided to ignore the shard limits if the operation is a child of the import operation (i.e. is internal).

- https://github.com/ydb-platform/ydb/issues/14772
