### PR TITLE
Fix a possibly decreasing gc barrier after the first gc fails

### DIFF
--- a/ydb/core/tablet_flat/flat_executor_gclogic.cpp
+++ b/ydb/core/tablet_flat/flat_executor_gclogic.cpp
@@ -207,12 +207,6 @@ TExecutorGCLogic::TChannelInfo::TChannelInfo()
 {
 }
 
-void TExecutorGCLogic::TChannelInfo::ApplyDelta(TGCTime time, TGCBlobDelta& delta) {
-    TGCBlobDelta& committedDelta = CommittedDelta[time];
-    DoSwap(committedDelta, delta);
-    Y_DEBUG_ABORT_UNLESS(delta.Created.empty() && delta.Deleted.empty());
-}
-
 void TExecutorGCLogic::MergeVectors(TVector<TLogoBlobID>& destination, const TVector<TLogoBlobID>& source) {
     if (!source.empty()) {
         destination.insert(destination.end(), source.begin(), source.end());
@@ -388,7 +382,7 @@ void TExecutorGCLogic::TChannelInfo::SendCollectGarbage(TGCTime uncommittedTime,
 
     // The first barrier of gen:0 (zero entry) is special
     TGCTime zeroTime{ generation, 0 };
-    if (KnownGcBarrier < zeroTime && collectBarrier < zeroTime && zeroTime <= uncommittedTime) {
+    if (CommitedGcBarrier < zeroTime && collectBarrier < zeroTime && zeroTime <= uncommittedTime) {
         collectBarrier = zeroTime;
     }
 

--- a/ydb/core/tablet_flat/flat_executor_gclogic.h
+++ b/ydb/core/tablet_flat/flat_executor_gclogic.h
@@ -91,7 +91,6 @@ protected:
         ui32 GcWaitFor;
 
         inline TChannelInfo();
-        void ApplyDelta(TGCTime time, TGCBlobDelta &delta);
         void SendCollectGarbage(TGCTime uncommittedTime, const TTabletStorageInfo *tabletStorageInfo, ui32 channel, ui32 generation, const TActorContext& executor);
         void SendCollectGarbageEntry(const TActorContext &ctx, TVector<TLogoBlobID> &&keep, TVector<TLogoBlobID> &&notKeep, ui64 tabletid, ui32 channel, ui32 bsgroup, ui32 generation);
         void OnCollectGarbageSuccess();

--- a/ydb/core/tablet_flat/test/libs/exec/runner.h
+++ b/ydb/core/tablet_flat/test/libs/exec/runner.h
@@ -56,6 +56,11 @@ namespace NFake {
             SetupModelServices();
         }
 
+        TTestActorRuntime& operator*() noexcept
+        {
+            return Env;
+        }
+
         TTestActorRuntime* operator->() noexcept
         {
             return &Env;


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

...

### Changelog category <!-- remove all except one -->

* Not for changelog (changelog entry is not required)

### Description for reviewers <!-- (optional) description for those who read this PR -->

It was discovered that tablets sometimes attempted to decrease a gc barrier, which caused CRIT messages to be logged at storage nodes due to possible protocol violation. This PR makes sure we don't decrease the gc barrier and keep sending at least gen:0 as a barrier.

Fixes #14578.