### PR TITLE
Make DEFAULT_EVENTS_PER_MAILBOX unreachable

### DIFF
--- a/ydb/library/actors/core/config.h
+++ b/ydb/library/actors/core/config.h
@@ -13,7 +13,7 @@ namespace NActors {
 
     struct TBasicExecutorPoolConfig {
         static constexpr TDuration DEFAULT_TIME_PER_MAILBOX = TDuration::MilliSeconds(10);
-        static constexpr ui32 DEFAULT_EVENTS_PER_MAILBOX = 100;
+        static constexpr ui32 DEFAULT_EVENTS_PER_MAILBOX = 1'000'000;
 
         ui32 PoolId = 0;
         TString PoolName;


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

EVENTS_PER_MAILBOX only make problems with high-load sessions. We made this limit unreachable for stopping processing only by  time quote.

### Changelog category <!-- remove all except one -->

* Improvement

### Description for reviewers <!-- (optional) description for those who read this PR -->

...
