### PR TITLE
Sync EvaluteExpr execution (#11801) (#14455)

### DIFF
--- a/ydb/core/kqp/gateway/kqp_gateway.h
+++ b/ydb/core/kqp/gateway/kqp_gateway.h
@@ -200,6 +200,9 @@ public:
     using NYql::IKikimrGateway::ExecuteLiteral;
     virtual NThreading::TFuture<TExecPhysicalResult> ExecuteLiteral(TExecPhysicalRequest&& request,
         TQueryData::TPtr params, ui32 txIndex) = 0;
+    using NYql::IKikimrGateway::ExecuteLiteralInstant;
+    virtual TExecPhysicalResult ExecuteLiteralInstant(TExecPhysicalRequest&& request,
+        TQueryData::TPtr params, ui32 txIndex) = 0;
 
     /* Scripting */
     virtual NThreading::TFuture<TQueryResult> ExplainDataQueryAst(const TString& cluster, const TString& query) = 0;

--- a/ydb/core/kqp/host/kqp_gateway_proxy.cpp
+++ b/ydb/core/kqp/host/kqp_gateway_proxy.cpp
@@ -2219,6 +2219,12 @@ public:
         return Gateway->ExecuteLiteral(program, resultType, txAlloc);
     }
 
+    TExecuteLiteralResult ExecuteLiteralInstant(const TString& program,
+        const NKikimrMiniKQL::TType& resultType, NKikimr::NKqp::TTxAllocatorState::TPtr txAlloc) override
+    {
+        return Gateway->ExecuteLiteralInstant(program, resultType, txAlloc);
+    }
+
 private:
     bool IsPrepare() const {
         if (!SessionCtx) {

--- a/ydb/core/kqp/provider/yql_kikimr_gateway.h
+++ b/ydb/core/kqp/provider/yql_kikimr_gateway.h
@@ -1028,6 +1028,8 @@ public:
 
     virtual NThreading::TFuture<TExecuteLiteralResult> ExecuteLiteral(const TString& program, const NKikimrMiniKQL::TType& resultType, NKikimr::NKqp::TTxAllocatorState::TPtr txAlloc) = 0;
 
+    virtual TExecuteLiteralResult ExecuteLiteralInstant(const TString& program, const NKikimrMiniKQL::TType& resultType, NKikimr::NKqp::TTxAllocatorState::TPtr txAlloc) = 0;
+
 public:
     using TCreateDirFunc = std::function<void(const TString&, const TString&, NThreading::TPromise<TGenericResult>)>;
 


### PR DESCRIPTION
During query compilation special subroutine called "Expression Evaluation" may be triggered (most common case is Constant Folding in query optimization phase).

It was implemented with async API and future waiting. In some rare cases (erros or failures) future was not completed and compilation hangs forever

This path removes future from call stack and replaces it with direct sync call. It requires change of internal API, it is one of the reason why this pattern was not choosed at the time of the development.

The fix was checked with load test (enabled in this PR) and by @dcherednik in manual runs.