### PR TITLE
Add EnablePermissionsExport feature flag

### DIFF
--- a/ydb/core/protos/feature_flags.proto
+++ b/ydb/core/protos/feature_flags.proto
@@ -194,4 +194,5 @@ message TFeatureFlags {
     optional bool EnableStrictUserManagement = 168 [default = false];
     optional bool EnableDatabaseAdmin = 169 [default = false];
     optional bool EnableChangefeedsImport = 170 [default = false];
+    optional bool EnablePermissionsExport = 171 [default = false];
 }

--- a/ydb/core/protos/flat_scheme_op.proto
+++ b/ydb/core/protos/flat_scheme_op.proto
@@ -1252,11 +1252,13 @@ message TBackupTask {
         optional int32 Level = 2;
     }
 
-    optional TCompressionOptions Compression = 13; // currently available for s3
-
     optional uint64 SnapshotStep = 14;
     optional uint64 SnapshotTxId = 15;
-    optional bool EnableChecksums = 16; // currently available for s3
+
+    // currently available only for s3:
+    optional TCompressionOptions Compression = 13;
+    optional bool EnableChecksums = 16; 
+    optional bool EnablePermissions = 18;
 }
 
 message TRestoreTask {

--- a/ydb/core/testlib/basics/feature_flags.h
+++ b/ydb/core/testlib/basics/feature_flags.h
@@ -75,6 +75,7 @@ public:
     FEATURE_FLAG_SETTER(EnableTopicTransfer)
     FEATURE_FLAG_SETTER(EnableStrictUserManagement)
     FEATURE_FLAG_SETTER(EnableDatabaseAdmin)
+    FEATURE_FLAG_SETTER(EnablePermissionsExport)
 
     #undef FEATURE_FLAG_SETTER
 };

--- a/ydb/core/tx/schemeshard/schemeshard__init.cpp
+++ b/ydb/core/tx/schemeshard/schemeshard__init.cpp
@@ -803,7 +803,7 @@ struct TSchemeShard::TTxInit : public TTransactionBase<TSchemeShard> {
         return true;
     }
 
-    typedef std::tuple<TPathId, TString, TString, TString, TString, bool, TString, ui32, bool> TBackupSettingsRec;
+    typedef std::tuple<TPathId, TString, TString, TString, TString, bool, TString, ui32, bool, bool> TBackupSettingsRec;
     typedef TDeque<TBackupSettingsRec> TBackupSettingsRows;
 
     template <typename SchemaTable, typename TRowSet>
@@ -816,7 +816,8 @@ struct TSchemeShard::TTxInit : public TTransactionBase<TSchemeShard> {
             rowSet.template GetValueOrDefault<typename SchemaTable::NeedToBill>(true),
             rowSet.template GetValueOrDefault<typename SchemaTable::TableDescription>(""),
             rowSet.template GetValueOrDefault<typename SchemaTable::NumberOfRetries>(0),
-            rowSet.template GetValueOrDefault<typename SchemaTable::EnableChecksums>(false)
+            rowSet.template GetValueOrDefault<typename SchemaTable::EnableChecksums>(false),
+            rowSet.template GetValueOrDefault<typename SchemaTable::EnablePermissions>(false)
         );
     }
 
@@ -3793,6 +3794,7 @@ struct TSchemeShard::TTxInit : public TTransactionBase<TSchemeShard> {
                 TString tableDesc = std::get<6>(rec);
                 ui32 nRetries = std::get<7>(rec);
                 bool enableChecksums = std::get<8>(rec);
+                bool enablePermissions = std::get<9>(rec);
 
                 Y_ABORT_UNLESS(tableName.size() > 0);
 
@@ -3803,6 +3805,7 @@ struct TSchemeShard::TTxInit : public TTransactionBase<TSchemeShard> {
                 tableInfo->BackupSettings.SetNeedToBill(needToBill);
                 tableInfo->BackupSettings.SetNumberOfRetries(nRetries);
                 tableInfo->BackupSettings.SetEnableChecksums(enableChecksums);
+                tableInfo->BackupSettings.SetEnablePermissions(enablePermissions);
 
                 if (ytSerializedSettings) {
                     auto settings = tableInfo->BackupSettings.MutableYTSettings();
@@ -4296,6 +4299,7 @@ struct TSchemeShard::TTxInit : public TTransactionBase<TSchemeShard> {
                     exportInfo->StartTime = TInstant::Seconds(rowset.GetValueOrDefault<Schema::Exports::StartTime>());
                     exportInfo->EndTime = TInstant::Seconds(rowset.GetValueOrDefault<Schema::Exports::EndTime>());
                     exportInfo->EnableChecksums = rowset.GetValueOrDefault<Schema::Exports::EnableChecksums>(false);
+                    exportInfo->EnablePermissions = rowset.GetValueOrDefault<Schema::Exports::EnablePermissions>(false);
 
                     Self->Exports[id] = exportInfo;
                     if (uid) {

--- a/ydb/core/tx/schemeshard/schemeshard_export.cpp
+++ b/ydb/core/tx/schemeshard/schemeshard_export.cpp
@@ -154,7 +154,8 @@ void TSchemeShard::PersistCreateExport(NIceDb::TNiceDb& db, const TExportInfo::T
         NIceDb::TUpdate<Schema::Exports::DomainPathOwnerId>(exportInfo->DomainPathId.OwnerId),
         NIceDb::TUpdate<Schema::Exports::DomainPathId>(exportInfo->DomainPathId.LocalPathId),
         NIceDb::TUpdate<Schema::Exports::Items>(exportInfo->Items.size()),
-        NIceDb::TUpdate<Schema::Exports::EnableChecksums>(exportInfo->EnableChecksums)
+        NIceDb::TUpdate<Schema::Exports::EnableChecksums>(exportInfo->EnableChecksums),
+        NIceDb::TUpdate<Schema::Exports::EnablePermissions>(exportInfo->EnablePermissions)
     );
 
     if (exportInfo->UserSID) {

--- a/ydb/core/tx/schemeshard/schemeshard_export__create.cpp
+++ b/ydb/core/tx/schemeshard/schemeshard_export__create.cpp
@@ -130,6 +130,7 @@ struct TSchemeShard::TExport::TTxCreate: public TSchemeShard::TXxport::TTxBase {
 
                 exportInfo = new TExportInfo(id, uid, TExportInfo::EKind::S3, settings, domainPath.Base()->PathId, request.GetPeerName());
                 exportInfo->EnableChecksums = AppData()->FeatureFlags.GetEnableExportChecksums();
+                exportInfo->EnablePermissions = AppData()->FeatureFlags.GetEnablePermissionsExport();
                 TString explain;
                 if (!FillItems(exportInfo, settings, explain)) {
                     return Reply(
@@ -359,7 +360,7 @@ private:
 
             item.SchemeUploader = ctx.Register(CreateSchemeUploader(
                 Self->SelfId(), exportInfo->Id, itemIdx, item.SourcePathId,
-                exportSettings, databaseRoot, metadata.Serialize()
+                exportSettings, databaseRoot, metadata.Serialize(), exportInfo->EnablePermissions
             ));
             Self->RunningExportSchemeUploaders.emplace(item.SchemeUploader);
         }

--- a/ydb/core/tx/schemeshard/schemeshard_export_flow_proposals.cpp
+++ b/ydb/core/tx/schemeshard/schemeshard_export_flow_proposals.cpp
@@ -248,6 +248,7 @@ THolder<TEvSchemeShard::TEvModifySchemeTransaction> BackupPropose(
             }
 
             task.SetEnableChecksums(exportInfo->EnableChecksums);
+            task.SetEnablePermissions(exportInfo->EnablePermissions);
         }
         break;
     }

--- a/ydb/core/tx/schemeshard/schemeshard_export_scheme_uploader.h
+++ b/ydb/core/tx/schemeshard/schemeshard_export_scheme_uploader.h
@@ -10,7 +10,8 @@ namespace Ydb::Export {
 namespace NKikimr::NSchemeShard {
 
 NActors::IActor* CreateSchemeUploader(NActors::TActorId schemeShard, ui64 exportId, ui32 itemIdx, TPathId sourcePathId,
-    const Ydb::Export::ExportToS3Settings& settings, const TString& databaseRoot, const TString& metadata
+    const Ydb::Export::ExportToS3Settings& settings, const TString& databaseRoot, const TString& metadata, 
+    bool enablePermissions
 );
 
 }

--- a/ydb/core/tx/schemeshard/schemeshard_export_scheme_uploader_fallback.cpp
+++ b/ydb/core/tx/schemeshard/schemeshard_export_scheme_uploader_fallback.cpp
@@ -31,9 +31,10 @@ private:
 
 
 IActor* CreateSchemeUploader(TActorId schemeShard, ui64 exportId, ui32 itemIdx, TPathId sourcePathId,
-    const Ydb::Export::ExportToS3Settings& settings, const TString& databaseRoot, const TString& metadata
+    const Ydb::Export::ExportToS3Settings& settings, const TString& databaseRoot, const TString& metadata,
+    bool enablePermissions
 ) {
-    Y_UNUSED(sourcePathId, settings, databaseRoot, metadata);
+    Y_UNUSED(sourcePathId, settings, databaseRoot, metadata, enablePermissions);
     return new TSchemeUploaderFallback(schemeShard, exportId, itemIdx);
 }
 

--- a/ydb/core/tx/schemeshard/schemeshard_impl.cpp
+++ b/ydb/core/tx/schemeshard/schemeshard_impl.cpp
@@ -3362,7 +3362,8 @@ void TSchemeShard::PersistBackupSettings(
                 NIceDb::TUpdate<Schema::BackupSettings::NeedToBill>(settings.GetNeedToBill()), \
                 NIceDb::TUpdate<Schema::BackupSettings::TableDescription>(settings.GetTable().SerializeAsString()), \
                 NIceDb::TUpdate<Schema::BackupSettings::NumberOfRetries>(settings.GetNumberOfRetries()), \
-                NIceDb::TUpdate<Schema::BackupSettings::EnableChecksums>(settings.GetEnableChecksums())); \
+                NIceDb::TUpdate<Schema::BackupSettings::EnableChecksums>(settings.GetEnableChecksums()), \
+                NIceDb::TUpdate<Schema::BackupSettings::EnablePermissions>(settings.GetEnablePermissions())); \
         } else { \
             db.Table<Schema::MigratedBackupSettings>().Key(pathId.OwnerId, pathId.LocalPathId).Update( \
                 NIceDb::TUpdate<Schema::MigratedBackupSettings::TableName>(settings.GetTableName()), \
@@ -3371,7 +3372,8 @@ void TSchemeShard::PersistBackupSettings(
                 NIceDb::TUpdate<Schema::MigratedBackupSettings::NeedToBill>(settings.GetNeedToBill()), \
                 NIceDb::TUpdate<Schema::MigratedBackupSettings::TableDescription>(settings.GetTable().SerializeAsString()), \
                 NIceDb::TUpdate<Schema::MigratedBackupSettings::NumberOfRetries>(settings.GetNumberOfRetries()), \
-                NIceDb::TUpdate<Schema::MigratedBackupSettings::EnableChecksums>(settings.GetEnableChecksums())); \
+                NIceDb::TUpdate<Schema::MigratedBackupSettings::EnableChecksums>(settings.GetEnableChecksums()), \
+                NIceDb::TUpdate<Schema::MigratedBackupSettings::EnablePermissions>(settings.GetEnablePermissions())); \
         } \
     }
 

--- a/ydb/core/tx/schemeshard/schemeshard_info_types.h
+++ b/ydb/core/tx/schemeshard/schemeshard_info_types.h
@@ -2736,6 +2736,7 @@ struct TExportInfo: public TSimpleRefCount<TExportInfo> {
     TInstant EndTime = TInstant::Zero();
 
     bool EnableChecksums = false;
+    bool EnablePermissions = false;
 
     explicit TExportInfo(
             const ui64 id,

--- a/ydb/core/tx/schemeshard/schemeshard_schema.h
+++ b/ydb/core/tx/schemeshard/schemeshard_schema.h
@@ -587,6 +587,7 @@ struct Schema : NIceDb::Schema {
         struct ScanSettings : Column<9, NScheme::NTypeIds::String> {};
         struct NeedToBill : Column<10, NScheme::NTypeIds::Bool> {};
         struct EnableChecksums : Column<11, NScheme::NTypeIds::Bool> {};
+        struct EnablePermissions : Column<12, NScheme::NTypeIds::Bool> {};
         // deprecated
         struct CreateDestinationFlag : Column<4, NScheme::NTypeIds::Bool> {};
         struct EraseOldDataFlag : Column<5, NScheme::NTypeIds::Bool> {};
@@ -603,7 +604,8 @@ struct Schema : NIceDb::Schema {
             NumberOfRetries,
             ScanSettings,
             NeedToBill,
-            EnableChecksums
+            EnableChecksums,
+            EnablePermissions
         >;
     };
 
@@ -619,6 +621,7 @@ struct Schema : NIceDb::Schema {
         struct ScanSettings : Column<10, NScheme::NTypeIds::String> {};
         struct NeedToBill : Column<11, NScheme::NTypeIds::Bool> {};
         struct EnableChecksums : Column<12, NScheme::NTypeIds::Bool> {};
+        struct EnablePermissions : Column<13, NScheme::NTypeIds::Bool> {};
         // deprecated
         struct CreateDestinationFlag : Column<5, NScheme::NTypeIds::Bool> {};
         struct EraseOldDataFlag : Column<6, NScheme::NTypeIds::Bool> {};
@@ -636,7 +639,8 @@ struct Schema : NIceDb::Schema {
             NumberOfRetries,
             ScanSettings,
             NeedToBill,
-            EnableChecksums
+            EnableChecksums,
+            EnablePermissions
         >;
     };
 
@@ -1187,6 +1191,7 @@ struct Schema : NIceDb::Schema {
         struct PeerName : Column<16, NScheme::NTypeIds::Utf8> {};
 
         struct EnableChecksums : Column<17, NScheme::NTypeIds::Bool> {};
+        struct EnablePermissions : Column<18, NScheme::NTypeIds::Bool> {};
 
         using TKey = TableKey<Id>;
         using TColumns = TableColumns<
@@ -1206,7 +1211,8 @@ struct Schema : NIceDb::Schema {
             StartTime,
             EndTime,
             PeerName,
-            EnableChecksums
+            EnableChecksums,
+            EnablePermissions
         >;
     };
 

--- a/ydb/core/tx/schemeshard/ut_backup/ut_backup.cpp
+++ b/ydb/core/tx/schemeshard/ut_backup/ut_backup.cpp
@@ -162,11 +162,11 @@ Y_UNIT_TEST_SUITE(TBackupTests) {
     }
 
     Y_UNIT_TEST_WITH_COMPRESSION(ShouldSucceedOnLargeData) {
-        ShouldSucceedOnLargeData<Codec>(0, std::make_pair(101, 3));
+        ShouldSucceedOnLargeData<Codec>(0, std::make_pair(101, 2));
     }
 
     Y_UNIT_TEST(ShouldSucceedOnLargeData_MinWriteBatch) {
-        ShouldSucceedOnLargeData<ECompressionCodec::Zstd>(1 << 20, std::make_pair(0, 4));
+        ShouldSucceedOnLargeData<ECompressionCodec::Zstd>(1 << 20, std::make_pair(0, 3));
     }
 
 } // TBackupTests

--- a/ydb/core/tx/schemeshard/ut_helpers/export_reboots_common.h
+++ b/ydb/core/tx/schemeshard/ut_helpers/export_reboots_common.h
@@ -5,6 +5,10 @@
 #include <util/generic/string.h>
 #include <util/generic/vector.h>
 
+namespace NActors {
+    class TTestActorRuntime;
+}
+
 namespace NSchemeShardUT_Private {
 
 class TTestWithReboots;
@@ -14,6 +18,7 @@ namespace NExportReboots {
 void Run(const TVector<TTypedScheme>& schemeObjects, const TString& request, TTestWithReboots& t);
 void Cancel(const TVector<TTypedScheme>& schemeObjects, const TString& request, TTestWithReboots& t);
 void Forget(const TVector<TTypedScheme>& schemeObjects, const TString& request, TTestWithReboots& t);
+void CreateSchemeObjects(TTestWithReboots& t, NActors::TTestActorRuntime& runtime, const TVector<TTypedScheme>& schemeObjects);
 
 } // NExportReboots
 } // NSchemeShardUT_Private

--- a/ydb/core/tx/schemeshard/ut_helpers/test_env.cpp
+++ b/ydb/core/tx/schemeshard/ut_helpers/test_env.cpp
@@ -608,6 +608,7 @@ NSchemeShardUT_Private::TTestEnv::TTestEnv(TTestActorRuntime& runtime, const TTe
     app.SetEnableBackupService(opts.EnableBackupService_);
     app.SetEnableExportChecksums(true);
     app.SetEnableTopicTransfer(opts.EnableTopicTransfer_);
+    app.SetEnablePermissionsExport(opts.EnablePermissionsExport_);
 
     app.ColumnShardConfig.SetDisabledOnSchemeShard(false);
 

--- a/ydb/core/tx/schemeshard/ut_helpers/test_env.h
+++ b/ydb/core/tx/schemeshard/ut_helpers/test_env.h
@@ -75,6 +75,7 @@ namespace NSchemeShardUT_Private {
         OPTION(bool, EnableStrictAclCheck, false);
         OPTION(std::optional<bool>, EnableStrictUserManagement, std::nullopt);
         OPTION(std::optional<bool>, EnableDatabaseAdmin, std::nullopt);
+        OPTION(std::optional<bool>, EnablePermissionsExport, std::nullopt);
 
         #undef OPTION
     };

--- a/ydb/tests/functional/backup/backup_ut.cpp
+++ b/ydb/tests/functional/backup/backup_ut.cpp
@@ -113,11 +113,10 @@ Y_UNIT_TEST_SUITE(Backup)
 
         auto ob = NTestUtils::GetObjectKeys(bucketName);
         std::sort(ob.begin(), ob.end());
-        UNIT_ASSERT_VALUES_EQUAL(ob.size(), 4);
+        UNIT_ASSERT_VALUES_EQUAL(ob.size(), 3);
         UNIT_ASSERT_VALUES_EQUAL(ob[0], "ProducerUuidValueBackup/data_00.csv");
         UNIT_ASSERT_VALUES_EQUAL(ob[1], "ProducerUuidValueBackup/metadata.json");
-        UNIT_ASSERT_VALUES_EQUAL(ob[2], "ProducerUuidValueBackup/permissions.pb");
-        UNIT_ASSERT_VALUES_EQUAL(ob[3], "ProducerUuidValueBackup/scheme.pb");
+        UNIT_ASSERT_VALUES_EQUAL(ob[2], "ProducerUuidValueBackup/scheme.pb");
 
         {
             NImport::TImportFromS3Settings settings;

--- a/ydb/tests/functional/scheme_tests/canondata/tablet_scheme_tests.TestTabletSchemes.test_tablet_schemes_flat_schemeshard_/flat_schemeshard.schema
+++ b/ydb/tests/functional/scheme_tests/canondata/tablet_scheme_tests.TestTabletSchemes.test_tablet_schemes_flat_schemeshard_/flat_schemeshard.schema
@@ -1174,6 +1174,11 @@
                 "ColumnId": 11,
                 "ColumnName": "EnableChecksums",
                 "ColumnType": "Bool"
+            },
+            {
+                "ColumnId": 12,
+                "ColumnName": "EnablePermissions",
+                "ColumnType": "Bool"
             }
         ],
         "ColumnsDropped": [],
@@ -1190,7 +1195,8 @@
                     8,
                     9,
                     10,
-                    11
+                    11,
+                    12
                 ],
                 "RoomID": 0,
                 "Codec": 0,
@@ -3044,11 +3050,6 @@
         ],
         "ColumnsAdded": [
             {
-                "ColumnId": 17,
-                "ColumnName": "EnableChecksums",
-                "ColumnType": "Bool"
-            },
-            {
                 "ColumnId": 1,
                 "ColumnName": "Id",
                 "ColumnType": "Uint64"
@@ -3127,13 +3128,22 @@
                 "ColumnId": 16,
                 "ColumnName": "PeerName",
                 "ColumnType": "Utf8"
+            },
+            {
+                "ColumnId": 17,
+                "ColumnName": "EnableChecksums",
+                "ColumnType": "Bool"
+            },
+            {
+                "ColumnId": 18,
+                "ColumnName": "EnablePermissions",
+                "ColumnType": "Bool"
             }
         ],
         "ColumnsDropped": [],
         "ColumnFamilies": {
             "0": {
                 "Columns": [
-                    17,
                     1,
                     2,
                     3,
@@ -3149,7 +3159,9 @@
                     13,
                     14,
                     15,
-                    16
+                    16,
+                    17,
+                    18
                 ],
                 "RoomID": 0,
                 "Codec": 0,
@@ -4560,6 +4572,11 @@
                 "ColumnId": 12,
                 "ColumnName": "EnableChecksums",
                 "ColumnType": "Bool"
+            },
+            {
+                "ColumnId": 13,
+                "ColumnName": "EnablePermissions",
+                "ColumnType": "Bool"
             }
         ],
         "ColumnsDropped": [],
@@ -4577,7 +4594,8 @@
                     9,
                     10,
                     11,
-                    12
+                    12,
+                    13
                 ],
                 "RoomID": 0,
                 "Codec": 0,


### PR DESCRIPTION
### Changelog category <!-- remove all except one -->

* Not for changelog (changelog entry is not required)

### Description for reviewers <!-- (optional) description for those who read this PR -->

Фича-флаг, который определяет нужно ли экспортировать ACL для объектов. Фича флаг читается из конфигурации в момент создания экспорта.
