### PR TITLE
Workaround for batch processing of transactions

### DIFF
--- a/ydb/core/persqueue/blob.h
+++ b/ydb/core/persqueue/blob.h
@@ -333,7 +333,7 @@ public:
     std::optional<TFormedBlobInfo> Add(TClientBlob&& blob);
     std::optional<TFormedBlobInfo> Add(const TKey& key, ui32 size);
 
-    bool IsInited() const { return !SourceId.empty(); }
+    bool IsInited() const { return TotalParts > 0; }
 
     bool IsComplete() const;
 

--- a/ydb/core/persqueue/partition.cpp
+++ b/ydb/core/persqueue/partition.cpp
@@ -1234,6 +1234,7 @@ TPartition::EProcessResult TPartition::ApplyWriteInfoResponse(TTransaction& tx) 
     }
     if (ret == EProcessResult::Continue && tx.Predicate.GetOrElse(true)) {
         TxAffectedSourcesIds.insert(txSourceIds.begin(), txSourceIds.end());
+        WriteAffectedSourcesIds.insert(txSourceIds.begin(), txSourceIds.end());
         tx.WriteInfoApplied = true;
         WriteKeysSizeEstimate += tx.WriteInfo->BodyKeys.size();
         WriteKeysSizeEstimate += tx.WriteInfo->SrcIdInfo.size();

--- a/ydb/core/persqueue/partition.cpp
+++ b/ydb/core/persqueue/partition.cpp
@@ -1234,7 +1234,10 @@ TPartition::EProcessResult TPartition::ApplyWriteInfoResponse(TTransaction& tx) 
     }
     if (ret == EProcessResult::Continue && tx.Predicate.GetOrElse(true)) {
         TxAffectedSourcesIds.insert(txSourceIds.begin(), txSourceIds.end());
+
+        // A temporary solution. This line should be deleted when we fix the error with the SeqNo promotion.
         WriteAffectedSourcesIds.insert(txSourceIds.begin(), txSourceIds.end());
+
         tx.WriteInfoApplied = true;
         WriteKeysSizeEstimate += tx.WriteInfo->BodyKeys.size();
         WriteKeysSizeEstimate += tx.WriteInfo->SrcIdInfo.size();

--- a/ydb/core/persqueue/partition.cpp
+++ b/ydb/core/persqueue/partition.cpp
@@ -2337,7 +2337,7 @@ void TPartition::CommitWriteOperations(TTransaction& t)
                                            NewHead.Offset,
                                            "", // SourceId
                                            0,  // SeqNo
-                                           1,  // TotalParts
+                                           0,  // TotalParts
                                            0,  // TotalSize
                                            Head,
                                            NewHead,
@@ -2366,6 +2366,8 @@ void TPartition::CommitWriteOperations(TTransaction& t)
                               PersistRequest.Get(),
                               ctx);
         }
+
+        PartitionedBlob = TPartitionedBlob(Partition, 0, "", 0, 0, 0, Head, NewHead, true, false, MaxBlobSize);
 
         NewHead.Clear();
         NewHead.Offset = Parameters->CurOffset;

--- a/ydb/core/persqueue/ut/partition_ut.cpp
+++ b/ydb/core/persqueue/ut/partition_ut.cpp
@@ -2729,6 +2729,7 @@ Y_UNIT_TEST_F(TestTxBatchInFederation, TPartitionTxTestHelper) {
 }
 
 Y_UNIT_TEST_F(ConflictingActsInSeveralBatches, TPartitionTxTestHelper) {
+    // A temporary solution. This line should be deleted when we fix the error with the SeqNo promotion.
     return;
 
     TTxBatchingTestParams params {.WriterSessions{"src1", "src4"},.EndOffset=1};
@@ -2812,6 +2813,7 @@ Y_UNIT_TEST_F(ConflictingTxIsAborted, TPartitionTxTestHelper) {
 }
 
 Y_UNIT_TEST_F(ConflictingTxProceedAfterRollback, TPartitionTxTestHelper) {
+    // A temporary solution. This line should be deleted when we fix the error with the SeqNo promotion.
     return;
 
     Init();

--- a/ydb/core/persqueue/ut/partition_ut.cpp
+++ b/ydb/core/persqueue/ut/partition_ut.cpp
@@ -2729,6 +2729,8 @@ Y_UNIT_TEST_F(TestTxBatchInFederation, TPartitionTxTestHelper) {
 }
 
 Y_UNIT_TEST_F(ConflictingActsInSeveralBatches, TPartitionTxTestHelper) {
+    return;
+
     TTxBatchingTestParams params {.WriterSessions{"src1", "src4"},.EndOffset=1};
     Init(std::move(params));
 
@@ -2810,6 +2812,8 @@ Y_UNIT_TEST_F(ConflictingTxIsAborted, TPartitionTxTestHelper) {
 }
 
 Y_UNIT_TEST_F(ConflictingTxProceedAfterRollback, TPartitionTxTestHelper) {
+    return;
+
     Init();
 
     auto tx1 = MakeAndSendWriteTx({{"src1", {1, 3}}, {"src2", {5, 10}}});

--- a/ydb/public/sdk/cpp/src/client/topic/ut/topic_to_table_ut.cpp
+++ b/ydb/public/sdk/cpp/src/client/topic/ut/topic_to_table_ut.cpp
@@ -94,7 +94,7 @@ protected:
                                TDuration stabilizationWindow,
                                ui64 downUtilizationPercent,
                                ui64 upUtilizationPercent);
-    void SetPartitionWriteSpeed(const TString& topicPath,
+    void SetPartitionWriteSpeed(const std::string& topicPath,
                                 size_t bytesPerSeconds);
 
     void WriteToTopicWithInvalidTxId(bool invalidTxId);
@@ -513,7 +513,7 @@ void TFixture::AlterAutoPartitioning(const TString& topicPath,
     UNIT_ASSERT_C(result.IsSuccess(), result.GetIssues().ToString());
 }
 
-void TFixture::SetPartitionWriteSpeed(const TString& topicPath,
+void TFixture::SetPartitionWriteSpeed(const std::string& topicPath,
                                       size_t bytesPerSeconds)
 {
     NTopic::TTopicClient client(GetDriver());
@@ -3075,7 +3075,7 @@ Y_UNIT_TEST_F(Write_Random_Sized_Messages_In_Wide_Transactions, TFixture)
 Y_UNIT_TEST_F(Write_Only_Big_Messages_In_Wide_Transactions, TFixture)
 {
     // The test verifies the simultaneous execution of several transactions. There is a topic `topic_A` and
-    // it contains a `PARTITIONS_COUNT' of partitions. In each transaction, the test writes to all partitions.                                                                                                          
+    // it contains a `PARTITIONS_COUNT' of partitions. In each transaction, the test writes to all partitions.
     // The size of the messages is chosen so that only large blobs are recorded in the transaction and there
     // are no records in the head. Thus, we verify that transaction bundling is working correctly.
 
@@ -3170,8 +3170,8 @@ Y_UNIT_TEST_F(Transactions_Conflict_On_SeqNo, TFixture)
             sourceId += "_";
             sourceId += ToString(j);
 
-            for (size_t k = 0, count = RandomNumber<size_t>(20); k < count; ++k) {
-                const TString data(RandomNumber<size_t>(1'000) + 100, 'x');
+            for (size_t k = 0, count = RandomNumber<size_t>(20) + 1; k < count; ++k) {
+                const std::string data(RandomNumber<size_t>(1'000) + 100, 'x');
                 NTopic::TWriteMessage params(data);
                 params.Tx(tx);
 

--- a/ydb/public/sdk/cpp/src/client/topic/ut/ya.make
+++ b/ydb/public/sdk/cpp/src/client/topic/ut/ya.make
@@ -2,7 +2,7 @@ UNITTEST_FOR(ydb/public/sdk/cpp/src/client/topic)
 
 INCLUDE(${ARCADIA_ROOT}/ydb/public/sdk/cpp/sdk_common.inc)
 
-IF (SANITIZER_TYPE == "thread" OR WITH_VALGRIND)
+IF (SANITIZER_TYPE OR WITH_VALGRIND)
     SIZE(LARGE)
     TAG(ya:fat)
 ELSE()


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

Transactions can be executed simultaneously. In this case, when the predicate is calculated, `SeqNo` is not promoted for `SourceId`. We decided to temporarily disable simultaneous execution of transactions.

### Changelog category <!-- remove all except one -->

* Not for changelog (changelog entry is not required)

### Description for reviewers <!-- (optional) description for those who read this PR -->

The `Transactions_Conflict_On_SeqNo` test reproduced the error from the client. Transaction patching has been temporarily disabled.