### PR TITLE
Add storage config in kv describe request

### DIFF
--- a/ydb/core/grpc_services/rpc_keyvalue.cpp
+++ b/ydb/core/grpc_services/rpc_keyvalue.cpp
@@ -621,6 +621,13 @@ protected:
         Ydb::KeyValue::DescribeVolumeResult result;
         result.set_path(this->GetProtoRequest()->path());
         result.set_partition_count(desc.PartitionsSize());
+        if (desc.PartitionsSize() > 0) {
+            auto *storageConfig = result.mutable_storage_config();
+            for (auto &channel : desc.GetPartitions(0).GetBoundChannels()) {
+                auto *channelBind = storageConfig->add_channel();
+                channelBind->set_media(channel.GetStoragePoolName());
+            }
+        }
         this->ReplyWithResult(Ydb::StatusIds::SUCCESS, result, TActivationContext::AsActorContext());
     }
 

--- a/ydb/public/api/protos/ydb_keyvalue.proto
+++ b/ydb/public/api/protos/ydb_keyvalue.proto
@@ -514,6 +514,9 @@ message DescribeVolumeResult {
 
     // Count of partitions.
     uint64 partition_count = 2;
+
+    // Storage config.
+    StorageConfig storage_config = 3;
 }
 
 message ListLocalPartitionsRequest {

--- a/ydb/services/keyvalue/grpc_service_ut.cpp
+++ b/ydb/services/keyvalue/grpc_service_ut.cpp
@@ -810,15 +810,24 @@ Y_UNIT_TEST_SUITE(KeyValueGRPCService) {
         UNIT_ASSERT_VALUES_EQUAL(listDirectoryResult.self().name(), "mydb");
         UNIT_ASSERT_VALUES_EQUAL(listDirectoryResult.children(0).name(), "mytable");
 
-        UNIT_ASSERT_VALUES_EQUAL(1, DescribeVolume(channel, tablePath).partition_count());
+        auto describeVolumeResult = DescribeVolume(channel, tablePath);
+        UNIT_ASSERT_VALUES_EQUAL(1, describeVolumeResult.partition_count());
+        UNIT_ASSERT(describeVolumeResult.has_storage_config());
+        for (const auto& channel : describeVolumeResult.storage_config().channel()) {
+            UNIT_ASSERT_VALUES_EQUAL(channel.media(), "ssd");
+        }
 
         AlterVolume(channel, tablePath, 2);
         listDirectoryResult = ListDirectory(channel, path);
         UNIT_ASSERT_VALUES_EQUAL(listDirectoryResult.self().name(), "mydb");
         UNIT_ASSERT_VALUES_EQUAL(listDirectoryResult.children(0).name(), "mytable");
 
-
-        UNIT_ASSERT_VALUES_EQUAL(2, DescribeVolume(channel, tablePath).partition_count());
+        describeVolumeResult = DescribeVolume(channel, tablePath);
+        UNIT_ASSERT_VALUES_EQUAL(2, describeVolumeResult.partition_count());
+        UNIT_ASSERT(describeVolumeResult.has_storage_config());
+        for (const auto& channel : describeVolumeResult.storage_config().channel()) {
+            UNIT_ASSERT_VALUES_EQUAL(channel.media(), "ssd");
+        }
 
         DropVolume(channel, tablePath);
         listDirectoryResult = ListDirectory(channel, path);


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

There was storage config in create request, but it was absent in describe result.
Now, we added storage config in describe result

### Changelog category <!-- remove all except one -->

* Improvement

### Description for reviewers <!-- (optional) description for those who read this PR -->

...
