### PR TITLE
Do not cleanup MKQL pool pages

### DIFF
--- a/ydb/core/base/pool_stats_collector.cpp
+++ b/ydb/core/base/pool_stats_collector.cpp
@@ -37,7 +37,6 @@ private:
         }
 
         void Update() {
-            TAlignedPagePool::DoCleanupGlobalFreeList();
             *TotalBytes = TAlignedPagePool::GetGlobalPagePoolSize();
             *TotalMmapped = ::NKikimr::GetTotalMmapedBytes();
             *TotalFreeList = ::NKikimr::GetTotalFreeListBytes();


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

While enabled the cleanup method cleans not only physically-allocated (RSS) pages, but also reserved ones that are never used. Thus we get a lot of "holes" inside mapped memory regions:
```
    3'000'000 - regions with cleanup
      100'000 - regions without cleanup
```

### Changelog category <!-- remove all except one -->

* Improvement