### PR TITLE
Add support ydbd start from dynamic config

### DIFF
--- a/ydb/library/yaml_config/yaml_config_parser.cpp
+++ b/ydb/library/yaml_config/yaml_config_parser.cpp
@@ -1435,6 +1435,15 @@ namespace NKikimr::NYaml {
         TTransformContext ctx;
         NKikimrConfig::TEphemeralInputFields ephemeralConfig;
 
+        if (json.Has("metadata")) {
+            ValidateMetadata(json["metadata"]);
+
+            Y_ENSURE_BT(json.Has("config") && json["config"].IsMap(),
+                       "'config' must be an object when 'metadata' is present");
+
+            jsonNode = json["config"];
+        }
+
         if (transform) {
             ExtractExtraFields(jsonNode, ctx);
 
@@ -1456,9 +1465,15 @@ namespace NKikimr::NYaml {
         NJson::TJsonValue jsonNode = Yaml2Json(yamlNode, true);
 
         NKikimrConfig::TAppConfig config;
+
         Parse(jsonNode, GetJsonToProtoConfig(), config, transform);
 
         return config;
+    }
+
+    void ValidateMetadata(const NJson::TJsonValue& metadata) {
+        Y_ENSURE_BT(metadata.Has("cluster") && metadata["cluster"].IsString(), "Metadata must contain a string 'cluster' field");
+        Y_ENSURE_BT(metadata.Has("version") && metadata["version"].IsUInteger(), "Metadata must contain an unsigned int 'version' field");
     }
 
 } // NKikimr::NYaml

--- a/ydb/library/yaml_config/yaml_config_parser.h
+++ b/ydb/library/yaml_config/yaml_config_parser.h
@@ -63,4 +63,6 @@ namespace NKikimr::NYaml {
     void Parse(const NJson::TJsonValue& json, NProtobufJson::TJson2ProtoConfig convertConfig, NKikimrConfig::TAppConfig& config, bool transform, bool relaxed = false);
     NKikimrConfig::TAppConfig Parse(const TString& data, bool transform = true);
 
+    void ValidateMetadata(const NJson::TJsonValue& metadata);
+
 } // namespace NKikimr::NYaml


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

Add support for launching a cluster node from a dynamic configuration format. Merging to 24.4 to simplify the rollback of a node from version 25.1 to version 24.4, without the need to rewrite the config back to the static format.

### Changelog category <!-- remove all except one -->

* New feature

### Description for reviewers <!-- (optional) description for those who read this PR -->

...
