### PR TITLE
main: disable breakpad integration temporarily

### DIFF
--- a/ydb/apps/ydbd/ya.make
+++ b/ydb/apps/ydbd/ya.make
@@ -69,7 +69,7 @@ PEERDIR(
     yql/essentials/udfs/common/url_base
     yql/essentials/udfs/common/yson2
     yql/essentials/udfs/logs/dsv
-    ydb/library/breakpad
+    # ydb/library/breakpad  # not working properly, see KIKIMR-18829 for details
     ydb/public/sdk/cpp/client/ydb_persqueue_public/codecs
 )
 

--- a/ydb/tests/functional/ya.make
+++ b/ydb/tests/functional/ya.make
@@ -15,7 +15,7 @@ RECURSE(
     kqp
     large_serializable
     limits
-    minidumps
+    # minidumps  # breakpad is disabled now, see KIKIMR-18829 for details
     postgresql
     query_cache
     rename


### PR DESCRIPTION
embedded breakpad not working properly, we will investiagate this problem later
KIKIMR-18829


Information from @snaury:

У меня на слайсе стоит пакет с breakpad'ом, и на старте используется LD_PRELOAD=/usr/lib/libbreakpad_init.so, к сожалению с asan сборкой возникли проблемы, во время периодической остановки процессов стреляют странные ошибки:

 [ paste.yandex-team.ru/2644904d-c8eb-4f10-8d7a-781e1279268a](https://paste.yandex-team.ru/2644904d-c8eb-4f10-8d7a-781e1279268a)
 [ paste.yandex-team.ru/a153f07f-4492-427d-874b-90c09f362c26](https://paste.yandex-team.ru/a153f07f-4492-427d-874b-90c09f362c26)

Если убрать ydb/library/breakpad из ya.make для ydbd, то ошибки уходят.

Я попытался сделать создание ExceptionHandler'а условным, типа при наличии libbreakpad_init.so в загруженных библиотеках - никакие хендлеры не создавать:

https://github.com/snaury/ydb/commit/c18da16f728a142a6193b65b20aa7d4c7ffe98c5

После этого ошибки от asan'а уходят, однако процессы на остановке очень странно зависают вот в этом потоке:

https://github.com/ydb-platform/ydb/blob/main/library/cpp/sighandler/async_signals_handler.cpp#L101

Он остаётся единственный и процесс висит. Я вижу, что этот обработчик у нас устанавливается вот здесь:

https://github.com/ydb-platform/ydb/blob/4b7849e00657670f233240e0469526c74ec3b1be/ydb/core/driver_lib/run/run.cpp#L1940

Что висит пока понять не могу, т.к. asan сборку приходится делать без дебажных символов и gdb ничего не показывает.

Есть подозрение, что libbreakpad_init.so и ydbd всё-равно каким-то образом шарят символы и что-то неожиданным образом всё-равно ломается. В сборке без санитайзера и без встроенного breakpad'а таких проблем нет.