### PR TITLE
Workaround for batch processing of transactions (#14874)

### DIFF
--- a/ydb/core/persqueue/blob.h
+++ b/ydb/core/persqueue/blob.h
@@ -333,7 +333,7 @@ public:
     std::optional<TFormedBlobInfo> Add(TClientBlob&& blob);
     std::optional<TFormedBlobInfo> Add(const TKey& key, ui32 size);
 
-    bool IsInited() const { return !SourceId.empty(); }
+    bool IsInited() const { return TotalParts > 0; }
 
     bool IsComplete() const;
 

--- a/ydb/core/persqueue/partition.cpp
+++ b/ydb/core/persqueue/partition.cpp
@@ -1215,6 +1215,10 @@ TPartition::EProcessResult TPartition::ApplyWriteInfoResponse(TTransaction& tx) 
     }
     if (ret == EProcessResult::Continue && tx.Predicate.GetOrElse(true)) {
         TxAffectedSourcesIds.insert(txSourceIds.begin(), txSourceIds.end());
+
+        // A temporary solution. This line should be deleted when we fix the error with the SeqNo promotion.
+        WriteAffectedSourcesIds.insert(txSourceIds.begin(), txSourceIds.end());
+
         tx.WriteInfoApplied = true;
         WriteKeysSizeEstimate += tx.WriteInfo->BodyKeys.size();
         WriteKeysSizeEstimate += tx.WriteInfo->SrcIdInfo.size();
@@ -2255,7 +2259,7 @@ void TPartition::CommitWriteOperations(TTransaction& t)
                                            NewHead.Offset,
                                            "", // SourceId
                                            0,  // SeqNo
-                                           1,  // TotalParts
+                                           0,  // TotalParts
                                            0,  // TotalSize
                                            Head,
                                            NewHead,
@@ -2283,6 +2287,8 @@ void TPartition::CommitWriteOperations(TTransaction& t)
                               PersistRequest.Get(),
                               ctx);
         }
+
+        PartitionedBlob = TPartitionedBlob(Partition, 0, "", 0, 0, 0, Head, NewHead, true, false, MaxBlobSize);
 
         NewHead.Clear();
         NewHead.Offset = Parameters->CurOffset;

--- a/ydb/core/persqueue/ut/partition_ut.cpp
+++ b/ydb/core/persqueue/ut/partition_ut.cpp
@@ -2657,6 +2657,9 @@ Y_UNIT_TEST_F(NonConflictingActsBatchOk, TPartitionTxTestHelper) {
 }
 
 Y_UNIT_TEST_F(ConflictingActsInSeveralBatches, TPartitionTxTestHelper) {
+    // A temporary solution. This line should be deleted when we fix the error with the SeqNo promotion.
+    return;
+
     TTxBatchingTestParams params {.WriterSessions{"src1", "src4"},.EndOffset=1};
     Init(std::move(params));
 
@@ -2738,6 +2741,9 @@ Y_UNIT_TEST_F(ConflictingTxIsAborted, TPartitionTxTestHelper) {
 }
 
 Y_UNIT_TEST_F(ConflictingTxProceedAfterRollback, TPartitionTxTestHelper) {
+    // A temporary solution. This line should be deleted when we fix the error with the SeqNo promotion.
+    return;
+
     Init();
 
     auto tx1 = MakeAndSendWriteTx({{"src1", {1, 3}}, {"src2", {5, 10}}});

--- a/ydb/core/persqueue/ut/partition_ut.cpp
+++ b/ydb/core/persqueue/ut/partition_ut.cpp
@@ -2596,6 +2596,7 @@ Y_UNIT_TEST_F(DataTxCalcPredicateError, TPartitionTxTestHelper)
 
 Y_UNIT_TEST_F(DataTxCalcPredicateOrder, TPartitionTxTestHelper)
 {
+    return;
     Init();
     auto tx1 = MakeAndSendWriteTx({{"src1", {1, 10}}});
     WaitWriteInfoRequest(tx1, true);

--- a/ydb/public/sdk/cpp/client/ydb_topic/ut/topic_to_table_ut.cpp
+++ b/ydb/public/sdk/cpp/client/ydb_topic/ut/topic_to_table_ut.cpp
@@ -82,6 +82,8 @@ protected:
                                TDuration stabilizationWindow,
                                ui64 downUtilizationPercent,
                                ui64 upUtilizationPercent);
+    void SetPartitionWriteSpeed(const TString& topicPath,
+                                size_t bytesPerSeconds);
 
     void WriteToTopicWithInvalidTxId(bool invalidTxId);
 
@@ -429,6 +431,18 @@ void TFixture::AlterAutoPartitioning(const TString& topicPath,
             .EndAlterAutoPartitioningSettings()
         .EndAlterTopicPartitioningSettings()
         ;
+
+    auto result = client.AlterTopic(topicPath, settings).GetValueSync();
+    UNIT_ASSERT_C(result.IsSuccess(), result.GetIssues().ToString());
+}
+
+void TFixture::SetPartitionWriteSpeed(const TString& topicPath,
+                                      size_t bytesPerSeconds)
+{
+    NTopic::TTopicClient client(GetDriver());
+    NTopic::TAlterTopicSettings settings;
+
+    settings.SetPartitionWriteSpeedBytesPerSecond(bytesPerSeconds);
 
     auto result = client.AlterTopic(topicPath, settings).GetValueSync();
     UNIT_ASSERT_C(result.IsSuccess(), result.GetIssues().ToString());
@@ -2389,6 +2403,8 @@ Y_UNIT_TEST_F(Write_Random_Sized_Messages_In_Wide_Transactions, TFixture)
 
     CreateTopic("topic_A", TEST_CONSUMER, PARTITIONS_COUNT);
 
+    SetPartitionWriteSpeed("topic_A", 50'000'000);
+
     TVector<NTable::TSession> sessions;
     TVector<NTable::TTransaction> transactions;
 
@@ -2427,6 +2443,141 @@ Y_UNIT_TEST_F(Write_Random_Sized_Messages_In_Wide_Transactions, TFixture)
         const auto& result = futures[i].GetValueSync();
         UNIT_ASSERT_VALUES_EQUAL_C(result.GetStatus(), EStatus::SUCCESS, result.GetIssues().ToString());
     }
+}
+
+Y_UNIT_TEST_F(Write_Only_Big_Messages_In_Wide_Transactions, TFixture)
+{
+    // The test verifies the simultaneous execution of several transactions. There is a topic `topic_A` and
+    // it contains a `PARTITIONS_COUNT' of partitions. In each transaction, the test writes to all partitions.
+    // The size of the messages is chosen so that only large blobs are recorded in the transaction and there
+    // are no records in the head. Thus, we verify that transaction bundling is working correctly.
+
+    const size_t PARTITIONS_COUNT = 20;
+    const size_t TXS_COUNT = 100;
+
+    CreateTopic("topic_A", TEST_CONSUMER, PARTITIONS_COUNT);
+
+    SetPartitionWriteSpeed("topic_A", 50'000'000);
+
+    std::vector<NTable::TSession> sessions;
+    std::vector<NTable::TTransaction> transactions;
+
+    // We open TXS_COUNT transactions and write messages to the topic.
+    for (size_t i = 0; i < TXS_COUNT; ++i) {
+        sessions.push_back(CreateTableSession());
+        auto& session = sessions.back();
+
+        transactions.push_back(BeginTx(session));
+        auto& tx = transactions.back();
+
+        for (size_t j = 0; j < PARTITIONS_COUNT; ++j) {
+            TString sourceId = TEST_MESSAGE_GROUP_ID;
+            sourceId += "_";
+            sourceId += ToString(i);
+            sourceId += "_";
+            sourceId += ToString(j);
+
+            WriteToTopic("topic_A", sourceId, TString(6'500'000, 'x'), &tx, j);
+
+            WaitForAcks("topic_A", sourceId);
+        }
+    }
+
+    // We are doing an asynchronous commit of transactions. They will be executed simultaneously.
+    std::vector<NTable::TAsyncCommitTransactionResult> futures;
+
+    for (size_t i = 0; i < TXS_COUNT; ++i) {
+        futures.push_back(transactions[i].Commit());
+    }
+
+    // All transactions must be completed successfully.
+    for (size_t i = 0; i < TXS_COUNT; ++i) {
+        futures[i].Wait();
+        const auto& result = futures[i].GetValueSync();
+        UNIT_ASSERT_VALUES_EQUAL_C(result.GetStatus(), EStatus::SUCCESS, result.GetIssues().ToString());
+    }
+}
+
+Y_UNIT_TEST_F(Transactions_Conflict_On_SeqNo, TFixture)
+{
+    const ui32 PARTITIONS_COUNT = 20;
+    const size_t TXS_COUNT = 100;
+
+    CreateTopic("topic_A", TEST_CONSUMER, PARTITIONS_COUNT);
+
+    SetPartitionWriteSpeed("topic_A", 50'000'000);
+
+    auto tableSession = CreateTableSession();
+    std::vector<std::shared_ptr<NTopic::ISimpleBlockingWriteSession>> topicWriteSessions;
+
+    for (ui32 i = 0; i < PARTITIONS_COUNT; ++i) {
+        TString sourceId = TEST_MESSAGE_GROUP_ID;
+        sourceId += "_";
+        sourceId += ToString(i);
+
+        NTopic::TTopicClient client(GetDriver());
+        NTopic::TWriteSessionSettings options;
+        options.Path("topic_A");
+        options.ProducerId(sourceId);
+        options.MessageGroupId(sourceId);
+        options.PartitionId(i);
+        options.Codec(ECodec::RAW);
+
+        auto session = client.CreateSimpleBlockingWriteSession(options);
+
+        topicWriteSessions.push_back(std::move(session));
+    }
+
+    std::vector<NTable::TSession> sessions;
+    std::vector<NTable::TTransaction> transactions;
+
+    for (size_t i = 0; i < TXS_COUNT; ++i) {
+        sessions.push_back(CreateTableSession());
+        auto& session = sessions.back();
+
+        transactions.push_back(BeginTx(session));
+        auto& tx = transactions.back();
+
+        for (size_t j = 0; j < PARTITIONS_COUNT; ++j) {
+            TString sourceId = TEST_MESSAGE_GROUP_ID;
+            sourceId += "_";
+            sourceId += ToString(j);
+
+            for (size_t k = 0, count = RandomNumber<size_t>(20) + 1; k < count; ++k) {
+                const std::string data(RandomNumber<size_t>(1'000) + 100, 'x');
+                NTopic::TWriteMessage params(data);
+                params.Tx(tx);
+
+                topicWriteSessions[j]->Write(std::move(params));
+            }
+        }
+    }
+
+    std::vector<NTable::TAsyncCommitTransactionResult> futures;
+
+    for (size_t i = 0; i < TXS_COUNT; ++i) {
+        futures.push_back(transactions[i].Commit());
+    }
+
+    // Some transactions should end with the error `ABORTED`
+    size_t successCount = 0;
+
+    for (size_t i = 0; i < TXS_COUNT; ++i) {
+        futures[i].Wait();
+        const auto& result = futures[i].GetValueSync();
+        switch (result.GetStatus()) {
+        case EStatus::SUCCESS:
+            ++successCount;
+            break;
+        case EStatus::ABORTED:
+            break;
+        default:
+            UNIT_FAIL("unexpected status: " << static_cast<const NYdb::TStatus&>(result));
+            break;
+        }
+    }
+
+    UNIT_ASSERT_VALUES_UNEQUAL(successCount, TXS_COUNT);
 }
 
 }

--- a/ydb/public/sdk/cpp/client/ydb_topic/ut/ya.make
+++ b/ydb/public/sdk/cpp/client/ydb_topic/ut/ya.make
@@ -1,6 +1,6 @@
 UNITTEST_FOR(ydb/public/sdk/cpp/client/ydb_topic)
 
-IF (SANITIZER_TYPE == "thread" OR WITH_VALGRIND)
+IF (SANITIZER_TYPE OR WITH_VALGRIND)
     TIMEOUT(1200)
     SIZE(LARGE)
     TAG(ya:fat)


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

Moved changes from PR #14874 

Transactions can be executed simultaneously. In this case, when the predicate is calculated, `SeqNo` is not promoted for `SourceId`. We decided to temporarily disable simultaneous execution of transactions.

### Changelog category <!-- remove all except one -->

* Not for changelog (changelog entry is not required)

### Description for reviewers <!-- (optional) description for those who read this PR -->

The `Transactions_Conflict_On_SeqNo` test reproduced the error from the client. Transaction batching has been temporarily disabled.