### PR TITLE
stable-25-1: disable breakpad integration temporarily

### DIFF
--- a/ydb/apps/ydbd/ya.make
+++ b/ydb/apps/ydbd/ya.make
@@ -69,7 +69,7 @@ PEERDIR(
     yql/essentials/udfs/common/url_base
     yql/essentials/udfs/common/yson2
     yql/essentials/udfs/logs/dsv
-    ydb/library/breakpad
+    # ydb/library/breakpad  # not working properly, see KIKIMR-18829 for details
     ydb/public/sdk/cpp/client/ydb_persqueue_public/codecs
 )
 

--- a/ydb/tests/functional/ya.make
+++ b/ydb/tests/functional/ya.make
@@ -15,7 +15,7 @@ RECURSE(
     kqp
     large_serializable
     limits
-    minidumps
+    # minidumps  # breakpad is disabled now, see KIKIMR-18829 for details
     postgresql
     query_cache
     rename


### PR DESCRIPTION
See description in 
https://github.com/ydb-platform/ydb/pull/14920 