### PR TITLE
fix shared_ptr extraction from PortionsToAccess

### DIFF
--- a/ydb/core/tx/columnshard/engines/changes/abstract/abstract.h
+++ b/ydb/core/tx/columnshard/engines/changes/abstract/abstract.h
@@ -299,7 +299,7 @@ public:
         ActivityFlag = flag;
     }
 
-    std::shared_ptr<TDataAccessorsRequest> ExtractDataAccessorsRequest() const {
+    std::shared_ptr<TDataAccessorsRequest> ExtractDataAccessorsRequest() {
         AFL_VERIFY(!!PortionsToAccess);
         return std::move(PortionsToAccess);
     }


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

Fix shared_ptr extraction from PortionsToAccess on CS [#13514](https://github.com/ydb-platform/ydb/issues/13514)

### Changelog category <!-- remove all except one -->

* Bugfix 

### Description for reviewers <!-- (optional) description for those who read this PR -->
