### PR TITLE
Test environment settings

### DIFF
--- a/ydb/apps/ydb/ut/ya.make
+++ b/ydb/apps/ydb/ut/ya.make
@@ -1,5 +1,7 @@
 UNITTEST()
 
+REQUIREMENTS(ram:32)
+
 IF (SANITIZER_TYPE)
     SIZE(LARGE)
     INCLUDE(${ARCADIA_ROOT}/ydb/tests/large.inc)


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

In some projects, the tests fail in the `default-linux-x86_64-release-hardening` configuration with the code `RS_RAM_REQUIREMENTS_EXCEEDED`

### Changelog category <!-- remove all except one -->

* Not for changelog (changelog entry is not required)

### Description for reviewers <!-- (optional) description for those who read this PR -->

...
