### PR TITLE
enable index auto-choose by default 24-4

### DIFF
--- a/ydb/core/protos/table_service_config.proto
+++ b/ydb/core/protos/table_service_config.proto
@@ -273,7 +273,7 @@ message TTableServiceConfig {
         ONLY_POINTS = 2; // Accepts iff point prefix len > 0
         MAX_USED_PREFIX = 3;
     }
-    optional EIndexAutoChooseMode IndexAutoChooseMode = 50 [default = DISABLED];
+    optional EIndexAutoChooseMode IndexAutoChooseMode = 50 [default = MAX_USED_PREFIX];
 
     optional bool EnableColumnsWithDefault = 51 [default = true];
 


### PR DESCRIPTION
### Changelog entry 

it's enabled by default in 25-1 and enabled on many clusters already.

### Changelog category 

* Not for changelog (changelog entry is not required)

### Description for reviewers <!-- (optional) description for those who read this PR -->

...
