### PR TITLE
Fix follower assertions on attach snapshot races

### DIFF
--- a/ydb/core/tablet_flat/flat_database.cpp
+++ b/ydb/core/tablet_flat/flat_database.cpp
@@ -538,15 +538,11 @@ void TDatabase::SetTableObserver(ui32 table, TIntrusivePtr<ITableObserver> ptr) 
 TDatabase::TChangeCounter TDatabase::Head(ui32 table) const noexcept
 {
     if (table == Max<ui32>()) {
-        return { DatabaseImpl->Serial(), TEpoch::Max() };
+        return { DatabaseImpl->StableSerial(), TEpoch::Max() };
     } else {
         auto &wrap = DatabaseImpl->Get(table, true);
 
-        // We return numbers as they have been at the start of transaction,
-        // but possibly after schema changes or memtable flushes.
-        auto serial = wrap.DataModified && !wrap.EpochSnapshot ? wrap.SerialBackup : wrap.Serial;
-        auto head = wrap.EpochSnapshot ? *wrap.EpochSnapshot : wrap->Head();
-        return { serial, head };
+        return { wrap.StableSerial(), wrap.StableHead() };
     }
 }
 

--- a/ydb/core/tablet_flat/flat_dbase_naked.h
+++ b/ydb/core/tablet_flat/flat_dbase_naked.h
@@ -101,6 +101,24 @@ namespace NTable {
                 aggr.MemTableOps += Self->GetOpsCount();
             }
 
+            /**
+             * Returns serial before the transaction (when in transaction),
+             * but possibly after schema changes or memtable flushes.
+             */
+            ui64 StableSerial() const noexcept
+            {
+                return DataModified && !EpochSnapshot ? SerialBackup : Serial;
+            }
+
+            /**
+             * Returns epoch before the transaction (when in transaction),
+             * but possibly after schema changes or memtable flushes.
+             */
+            TEpoch StableHead() const noexcept
+            {
+                return EpochSnapshot ? *EpochSnapshot : Self->Head();
+            }
+
             const ui32 Table = Max<ui32>();
             const TIntrusivePtr<TTable> Self;
             const TTxStamp Edge = 0;    /* Stamp of last snapshot       */
@@ -145,6 +163,14 @@ namespace NTable {
         ui64 Serial() const noexcept
         {
             return Serial_;
+        }
+
+        /**
+         * Returns serial before the transaction (when in transaction)
+         */
+        ui64 StableSerial() const noexcept
+        {
+            return InTransaction ? Begin_ : Serial_;
         }
 
         TTableWrapper& Get(ui32 table, bool require) noexcept

--- a/ydb/core/tablet_flat/flat_executor.cpp
+++ b/ydb/core/tablet_flat/flat_executor.cpp
@@ -1352,8 +1352,8 @@ void TExecutor::AdvancePendingPartSwitches() {
         PlanTransactionActivation();
         MaybeRelaxRejectProbability();
 
-        // followers haven't DataCleanupLogic
-        if (DataCleanupLogic && DataCleanupLogic->NeedLogSnaphot()) {
+        // Note: followers don't have DataCleanupLogic
+        if (NeedFollowerSnapshot || DataCleanupLogic && DataCleanupLogic->NeedLogSnaphot()) {
             MakeLogSnapshot();
         }
     }

--- a/ydb/core/tablet_flat/flat_executor_ut.cpp
+++ b/ydb/core/tablet_flat/flat_executor_ut.cpp
@@ -1,6 +1,7 @@
 #include "flat_dbase_sz_env.h"
 #include "flat_executor_ut_common.h"
 #include <ydb/core/base/counters.h>
+#include <ydb/core/testlib/actors/block_events.h>
 
 namespace NKikimr {
 namespace NTabletFlatExecutor {
@@ -451,6 +452,10 @@ class TTestFlatTablet : public TActor<TTestFlatTablet>, public TTabletExecutedFl
 
     void ScanComplete(NTable::EAbort, TAutoPtr<IDestructable>, ui64 cookie, const TActorContext&) override
     {
+        if (cookie == 12345) {
+            // TEmptyScan in follower tests
+            return;
+        }
         UNIT_ASSERT_VALUES_EQUAL(cookie, ScanCookie);
         Send(Sender, new TEvTestFlatTablet::TEvScanFinished);
     }
@@ -3533,6 +3538,247 @@ Y_UNIT_TEST_SUITE(TFlatTableExecutor_Follower) {
         }
 
         observer.Uninstall(env.Env);
+    }
+
+    struct TTxMakeSnapshot : public ITransaction {
+        bool Execute(TTransactionContext& txc, const TActorContext&) override {
+            TIntrusivePtr<TTableSnapshotContext> snapContext =
+                new TTestTableSnapshotContext({TRowsModel::TableId});
+            txc.Env.MakeSnapshot(snapContext);
+            return true;
+        }
+
+        void Complete(const TActorContext& ctx) override {
+            ctx.Send(ctx.SelfID, new NFake::TEvReturn);
+        }
+    };
+
+    struct TTxBorrowSnapshot : public ITransactionWithExecutor {
+        TTxBorrowSnapshot(TString& snapBody, TIntrusivePtr<TTableSnapshotContext> snapContext, ui64 targetTabletId)
+            : SnapBody(snapBody)
+            , SnapContext(std::move(snapContext))
+            , TargetTabletId(targetTabletId)
+        { }
+
+        bool Execute(TTransactionContext& txc, const TActorContext&) override {
+            SnapBody = Executor->BorrowSnapshot(TRowsModel::TableId, *SnapContext, { }, { }, TargetTabletId);
+            txc.Env.DropSnapshot(SnapContext);
+            return true;
+        }
+
+        void Complete(const TActorContext& ctx) override {
+            ctx.Send(ctx.SelfID, new NFake::TEvReturn);
+        }
+
+    private:
+        TString& SnapBody;
+        TIntrusivePtr<TTableSnapshotContext> SnapContext;
+        const ui64 TargetTabletId;
+    };
+
+    struct TTxLoanSnapshot : public ITransaction {
+        TTxLoanSnapshot(TString snapBody)
+            : SnapBody(snapBody)
+        { }
+
+        bool Execute(TTransactionContext& txc, const TActorContext& ctx) override {
+            txc.Env.LoanTable(TRowsModel::TableId, SnapBody);
+            ctx.Send(ctx.SelfID, new NFake::TEvReturn);
+            return true;
+        }
+
+        void Complete(const TActorContext&) override {
+        }
+
+    private:
+        TString SnapBody;
+    };
+
+    struct TEmptyScan : public NTable::IScan {
+        TEmptyScan() = default;
+
+        void Describe(IOutputStream& out) const noexcept override {
+            out << "TEmptyScan{}";
+        }
+
+        TInitialState Prepare(NTable::IDriver*, TIntrusiveConstPtr<TScheme>) noexcept override {
+            return {EScan::Final, {}};
+        }
+
+        EScan Seek(TLead&, ui64) noexcept override {
+            Y_ABORT("unreachable");
+        }
+
+        EScan Feed(TArrayRef<const TCell>, const TRow&) noexcept override {
+            Y_ABORT("unreachable");
+        }
+
+        TAutoPtr<IDestructable> Finish(EAbort) noexcept override {
+            delete this;
+            return nullptr;
+        }
+    };
+
+    struct TTxQueueScan : public ITransactionWithExecutor {
+        TTxQueueScan() = default;
+
+        bool Execute(TTransactionContext&, const TActorContext& ctx) override {
+            Executor->QueueScan(TRowsModel::TableId,
+                new TEmptyScan(),
+                /* cookie */ 12345,
+                TScanOptions().DisableResourceBroker());
+            ctx.Send(ctx.SelfID, new NFake::TEvReturn);
+            return true;
+        }
+
+        void Complete(const TActorContext&) override {
+            // nothing
+        }
+    };
+
+    // Regression test for KIKIMR-18605
+    Y_UNIT_TEST(FollowerAttachOnTxQueueScanSnapshot) {
+        TMyEnvBase env;
+        TRowsModel rows;
+
+        env->SetLogPriority(NKikimrServices::TABLET_EXECUTOR, NActors::NLog::PRI_DEBUG);
+
+        // Start the tablet
+        env.FireTablet(env.Edge, env.Tablet, [&env](const TActorId &tablet, TTabletStorageInfo *info) {
+            return new TTestFlatTablet(env.Edge, tablet, info);
+        });
+        env.WaitForWakeUp();
+
+        Cerr << "... initializing schema" << Endl;
+        env.SendSync(rows.MakeScheme(new TCompactionPolicy()));
+        Cerr << "... inserting rows" << Endl;
+        env.SendSync(rows.MakeRows(10, 0, 10));
+
+        Cerr << "... starting follower" << Endl;
+        TBlockEvents<TEvTablet::TEvNewFollowerAttached> blockedAttach(env.Env);
+        env.FireFollower(env.Edge, env.Tablet, [&env](const TActorId &tablet, TTabletStorageInfo *info) {
+            return new TTestFlatTablet(env.Edge, tablet, info);
+        }, /* followerId */ 1);
+        env->WaitFor("follower attach", [&]{ return blockedAttach.size() >= 1; });
+
+        TBlockEvents<TEvBlobStorage::TEvPut> blockedSnapshot(env.Env,
+            [tablet = env.Tablet](const auto& ev) {
+                auto* msg = ev->Get();
+                if (msg->Id.TabletID() == tablet && msg->Id.Cookie() == /* SnapLz4 */ 0x7000) {
+                    return true;
+                }
+                return false;
+            });
+
+        Cerr << "... spamming QueueScan transactions" << Endl;
+        for (ui32 i = 0; i < 400; ++i) {
+            env.SendSync(new NFake::TEvExecute{ new TTxQueueScan });
+            if (!blockedSnapshot.empty()) {
+                break;
+            }
+        }
+        UNIT_ASSERT_C(!blockedSnapshot.empty(), "expected tablet to make a log snapshot after 400 scans");
+
+        Cerr << "... unblocking attach" << Endl;
+        blockedAttach.Stop().Unblock();
+
+        Cerr << "... unblocking snapshot, expecting follower to activate" << Endl;
+        blockedSnapshot.Stop().Unblock();
+        env.WaitForWakeUp();
+
+        // Bug 1: snapshot created in TTxQueueScan had an incremented serial, conflicting with the next change
+        Cerr << "... inserting rows" << Endl;
+        env.SendSync(rows.MakeRows(10, 0, 10));
+        env->SimulateSleep(TDuration::MilliSeconds(1));
+
+        Cerr << "... rebooting leader" << Endl;
+        env.SendSync(new TEvents::TEvPoison, false, true);
+        env.FireTablet(env.Edge, env.Tablet, [&env](const TActorId &tablet, TTabletStorageInfo *info) {
+            return new TTestFlatTablet(env.Edge, tablet, info);
+        });
+        env.WaitForWakeUp();
+    }
+
+    Y_UNIT_TEST(FollowerAttachAfterLoan) {
+        TMyEnvBase env;
+        TRowsModel rows;
+
+        env->SetLogPriority(NKikimrServices::TABLET_EXECUTOR, NActors::NLog::PRI_DEBUG);
+
+        // Start the source tablet
+        env.FireTablet(env.Edge, env.Tablet, [&env](const TActorId &tablet, TTabletStorageInfo *info) {
+            return new TTestFlatTablet(env.Edge, tablet, info);
+        });
+        env.WaitForWakeUp();
+
+        Cerr << "... initializing schema" << Endl;
+        env.SendSync(rows.MakeScheme(new TCompactionPolicy()));
+        Cerr << "... inserting rows" << Endl;
+        env.SendSync(rows.MakeRows(10, 0, 10));
+        Cerr << "... making snapshot" << Endl;
+        env.SendSync(new NFake::TEvExecute{ new TTxMakeSnapshot });
+        Cerr << "... waiting for snapshot to complete" << Endl;
+        auto evSnapshot = env.GrabEdgeEvent<TEvTestFlatTablet::TEvSnapshotComplete>();
+        Cerr << "...borrowing snapshot" << Endl;
+        TString snapBody;
+        env.SendSync(new NFake::TEvExecute{ new TTxBorrowSnapshot(snapBody, evSnapshot->Get()->SnapContext, env.Tablet + 1) });
+
+        // Stop the source tablet
+        Cerr << "... stopping the source tablet" << Endl;
+        env.SendSync(new TEvents::TEvPoison, false, true);
+        env.WaitForGone();
+
+        // Starting the destination tablet
+        Cerr << "... starting the destination tablet" << Endl;
+        ++env.Tablet;
+        env.FireTablet(env.Edge, env.Tablet, [&env](const TActorId &tablet, TTabletStorageInfo *info) {
+            return new TTestFlatTablet(env.Edge, tablet, info);
+        });
+        env.WaitForWakeUp();
+
+        Cerr << "... initializing schema" << Endl;
+        env.SendSync(rows.MakeScheme(new TCompactionPolicy()));
+
+        // Loan snapshot while metadata loading is blocked
+        Cerr << "... loaning snapshot" << Endl;
+        TBlockEvents<TEvBlobStorage::TEvGet> blockedMetadata(env.Env,
+            [tablet = env.Tablet - 1](const auto& ev) {
+                auto* msg = ev->Get();
+                for (ui32 i = 0; i < msg->QuerySize; ++i) {
+                    const auto& id = msg->Queries[i].Id;
+                    Cerr << "get blob " << id << Endl;
+                    if (id.TabletID() == tablet && (id.Cookie() >> 12) == /* Pack */ 3) {
+                        return true;
+                    }
+                }
+                return false;
+            });
+        env.SendSync(new NFake::TEvExecute{ new TTxLoanSnapshot(snapBody) });
+        env->WaitFor("blocked metadata", [&]{ return blockedMetadata.size() >= 1; });
+
+        Cerr << "... starting follower" << Endl;
+        TBlockEvents<TEvTablet::TEvNewFollowerAttached> blockedAttach(env.Env);
+        env.FireFollower(env.Edge, env.Tablet, [&env](const TActorId &tablet, TTabletStorageInfo *info) {
+            return new TTestFlatTablet(env.Edge, tablet, info);
+        }, /* followerId */ 1);
+        env->WaitFor("follower attach", [&]{ return blockedAttach.size() >= 1; });
+
+        TBlockEvents<TEvBlobStorage::TEvPut> blockedSnapshot(env.Env,
+            [tablet = env.Tablet](const auto& ev) {
+                auto* msg = ev->Get();
+                if (msg->Id.TabletID() == tablet && msg->Id.Cookie() == /* SnapLz4 */ 0x7000) {
+                    return true;
+                }
+                return false;
+            });
+        blockedAttach.Stop().Unblock();
+
+        // Bug 2: part switch completion was missing follower snapshot condition
+        Cerr << "... unblocking metadata" << Endl;
+        blockedMetadata.Stop().Unblock();
+
+        env->SimulateSleep(TDuration::MilliSeconds(1));
+        UNIT_ASSERT_C(!blockedSnapshot.empty(), "expected tablet to make a log snapshot after part switch");
     }
 
 }


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

Fixed a rare assertion (process crash) when followers attached to leaders with an inconsistent snapshot. Fixes #15042.

### Changelog category <!-- remove all except one -->

* Bugfix 

### Description for reviewers <!-- (optional) description for those who read this PR -->

Followers produced crashes in production periodically complaining about log reordering, with an error message indicating as if they tried to apply a duplicate redo log entry (which shouldn't have been possible). Turns out snapshots created within read-only transactions that used `QueueScan` (e.g. ReadTable and ScanQuery) persisted an incorrect `Serial` field (a monotonically increasing change number) that was equal to the next transaction. When follower attached at just the right time, it could bootstrap from such a snapshot, and discover the next commit has the same `Serial`, indicating a duplicate or reordered change.

Thankfully this didn't affect leaders, since they apply pre-snapshot and post-snapshot redo log entries together, and only use snapshot serial as a hint of previously compacted changes. So even though snapshot technically had an inconsistent value it was self-healing and couldn't produce any externally visible inconsistencies.