### PR TITLE
merge to 25-1: Fix describe_volume and alter_volume 

### DIFF
--- a/ydb/core/grpc_services/rpc_keyvalue.cpp
+++ b/ydb/core/grpc_services/rpc_keyvalue.cpp
@@ -432,58 +432,6 @@ public:
     }
 };
 
-class TAlterVolumeRequest : public TRpcSchemeRequestActor<TAlterVolumeRequest, TEvAlterVolumeKeyValueRequest> {
-public:
-    using TBase = TRpcSchemeRequestActor<TAlterVolumeRequest, TEvAlterVolumeKeyValueRequest>;
-    using TBase::TBase;
-
-    void Bootstrap(const TActorContext& ctx) {
-        TBase::Bootstrap(ctx);
-        Become(&TAlterVolumeRequest::StateFunc);
-        SendProposeRequest(ctx);
-    }
-
-    void SendProposeRequest(const TActorContext &ctx) {
-        const auto req = this->GetProtoRequest();
-
-        std::pair<TString, TString> pathPair;
-        try {
-            pathPair = SplitPath(req->path());
-        } catch (const std::exception& ex) {
-            Request_->RaiseIssue(NYql::ExceptionToIssue(ex));
-            return Reply(StatusIds::BAD_REQUEST, ctx);
-        }
-        const auto& workingDir = pathPair.first;
-        const auto& name = pathPair.second;
-
-        std::unique_ptr<TEvTxUserProxy::TEvProposeTransaction> proposeRequest = this->CreateProposeTransaction();
-        NKikimrTxUserProxy::TEvProposeTransaction& record = proposeRequest->Record;
-        NKikimrSchemeOp::TModifyScheme* modifyScheme = record.MutableTransaction()->MutableModifyScheme();
-        modifyScheme->SetWorkingDir(workingDir);
-        NKikimrSchemeOp::TAlterSolomonVolume* tableDesc = nullptr;
-
-        modifyScheme->SetOperationType(NKikimrSchemeOp::EOperationType::ESchemeOpAlterSolomonVolume);
-        tableDesc = modifyScheme->MutableAlterSolomonVolume();
-        tableDesc->SetName(name);
-        tableDesc->SetPartitionCount(req->alter_partition_count());
-
-        if (GetProtoRequest()->has_storage_config()) {
-            tableDesc->SetUpdateChannelsBinding(true);
-            auto &storageConfig = GetProtoRequest()->storage_config();
-            auto *internalStorageConfig = tableDesc->MutableStorageConfig();
-            AssignPoolKinds(storageConfig, internalStorageConfig);
-        } else {
-            tableDesc->SetUpdateChannelsBinding(false);
-            tableDesc->SetChannelProfileId(0);
-        }
-
-        ctx.Send(MakeTxProxyID(), proposeRequest.release());
-    }
-
-    STFUNC(StateFunc) {
-        return TBase::StateWork(ev);
-    }
-};
 
 template <typename TDerived>
 class TBaseKeyValueRequest {
@@ -621,12 +569,10 @@ protected:
         Ydb::KeyValue::DescribeVolumeResult result;
         result.set_path(this->GetProtoRequest()->path());
         result.set_partition_count(desc.PartitionsSize());
-        if (desc.PartitionsSize() > 0) {
-            auto *storageConfig = result.mutable_storage_config();
-            for (auto &channel : desc.GetPartitions(0).GetBoundChannels()) {
-                auto *channelBind = storageConfig->add_channel();
-                channelBind->set_media(channel.GetStoragePoolName());
-            }
+        auto *storageConfig = result.mutable_storage_config();
+        for (auto &channel : desc.GetBoundChannels()) {
+            auto *channelBind = storageConfig->add_channel();
+            channelBind->set_media(channel.GetStoragePoolName());
         }
         this->ReplyWithResult(Ydb::StatusIds::SUCCESS, result, TActivationContext::AsActorContext());
     }
@@ -637,6 +583,95 @@ protected:
 
 private:
     TIntrusiveConstPtr<NACLib::TUserToken> UserToken;
+};
+
+
+class TAlterVolumeRequest
+    : public TRpcSchemeRequestActor<TAlterVolumeRequest, TEvAlterVolumeKeyValueRequest>
+    , public TBaseKeyValueRequest<TAlterVolumeRequest>
+{
+public:
+    using TBase = TRpcSchemeRequestActor<TAlterVolumeRequest, TEvAlterVolumeKeyValueRequest>;
+    using TBase::TBase;
+    using TBaseKeyValueRequest::TBaseKeyValueRequest;
+    friend class TBaseKeyValueRequest<TAlterVolumeRequest>;
+
+    void Bootstrap(const TActorContext& ctx) {
+        TBase::Bootstrap(ctx);
+        Become(&TAlterVolumeRequest::StateWork);
+        if (GetProtoRequest()->has_storage_config()) {
+            StorageConfig = GetProtoRequest()->storage_config();
+            SendProposeRequest(ctx);
+        } else {
+            OnBootstrap();
+        }
+    }
+
+    bool ValidateRequest(Ydb::StatusIds::StatusCode& /*status*/, NYql::TIssues& /*issues*/) {
+        return true;
+    } 
+
+    void SendProposeRequest(const TActorContext &ctx) {
+        const auto req = this->GetProtoRequest();
+
+        std::pair<TString, TString> pathPair;
+        try {
+            pathPair = SplitPath(req->path());
+        } catch (const std::exception& ex) {
+            Request_->RaiseIssue(NYql::ExceptionToIssue(ex));
+            return Reply(StatusIds::BAD_REQUEST, ctx);
+        }
+        const auto& workingDir = pathPair.first;
+        const auto& name = pathPair.second;
+
+        std::unique_ptr<TEvTxUserProxy::TEvProposeTransaction> proposeRequest = this->CreateProposeTransaction();
+        NKikimrTxUserProxy::TEvProposeTransaction& record = proposeRequest->Record;
+        NKikimrSchemeOp::TModifyScheme* modifyScheme = record.MutableTransaction()->MutableModifyScheme();
+        modifyScheme->SetWorkingDir(workingDir);
+        NKikimrSchemeOp::TAlterSolomonVolume* tableDesc = nullptr;
+
+        modifyScheme->SetOperationType(NKikimrSchemeOp::EOperationType::ESchemeOpAlterSolomonVolume);
+        tableDesc = modifyScheme->MutableAlterSolomonVolume();
+        tableDesc->SetName(name);
+        tableDesc->SetPartitionCount(req->alter_partition_count());
+
+        if (GetProtoRequest()->has_storage_config()) {
+            tableDesc->SetUpdateChannelsBinding(true);
+        }
+        auto *internalStorageConfig = tableDesc->MutableStorageConfig();
+        AssignPoolKinds(StorageConfig, internalStorageConfig);
+
+        ctx.Send(MakeTxProxyID(), proposeRequest.release());
+    }
+
+    STFUNC(StateWork) {
+        Cerr << "TAlterVolumeRequest::StateWork; received event: " << ev->GetTypeName() << Endl;
+        switch (ev->GetTypeRewrite()) {
+            hFunc(TEvTxProxySchemeCache::TEvNavigateKeySetResult, Handle);
+        default:
+            return TBase::StateWork(ev);
+        }
+    }
+
+    void Handle(TEvTxProxySchemeCache::TEvNavigateKeySetResult::TPtr &ev) {
+        TEvTxProxySchemeCache::TEvNavigateKeySetResult* res = ev->Get();
+        NSchemeCache::TSchemeCacheNavigate *request = res->Request.Get();
+
+        if (!OnNavigateKeySetResult(ev, NACLib::DescribeSchema)) {
+            return;
+        }
+
+        const NKikimrSchemeOp::TSolomonVolumeDescription &desc = request->ResultSet[0].SolomonVolumeInfo->Description;
+        for (auto &channel : desc.GetBoundChannels()) {
+            auto *channelBind = StorageConfig.add_channel();
+            channelBind->set_media(channel.GetStoragePoolName());
+        }
+        SendProposeRequest(TActivationContext::AsActorContext());
+    }
+
+private:
+    TIntrusiveConstPtr<NACLib::TUserToken> UserToken;
+    Ydb::KeyValue::StorageConfig StorageConfig;
 };
 
 

--- a/ydb/core/protos/flat_scheme_op.proto
+++ b/ydb/core/protos/flat_scheme_op.proto
@@ -1415,6 +1415,7 @@ message TSolomonVolumeDescription {
     optional uint64 PathId = 2;
     optional uint64 PartitionCount = 3;
     repeated TPartition Partitions = 4;
+    repeated NKikimrStoragePool.TChannelBind BoundChannels = 5;
 }
 
 message TCreateSolomonVolume {

--- a/ydb/core/tx/schemeshard/schemeshard__operation_alter_solomon.cpp
+++ b/ydb/core/tx/schemeshard/schemeshard__operation_alter_solomon.cpp
@@ -254,17 +254,16 @@ public:
             return result;
         }
 
-        if (!alter.HasChannelProfileId()) {
-            result->SetError(TEvSchemeShard::EStatus::StatusInvalidParameter, "set channel profile id, please");
-            return result;
-        }
-
         TChannelsBindings channelsBinding;
         bool isResolved = false;
         if (alter.HasStorageConfig()) {
             isResolved = context.SS->ResolveSolomonChannels(alter.GetStorageConfig(), path.GetPathIdForDomain(), channelsBinding);
         } else {
-            isResolved = context.SS->ResolveSolomonChannels(channelProfileId, path.GetPathIdForDomain(), channelsBinding);
+            if (!alter.HasChannelProfileId()) {
+                result->SetError(TEvSchemeShard::EStatus::StatusInvalidParameter, "set channel profile id, please");
+                return result;
+            }
+            isResolved = context.SS->ResolveSolomonChannels(alter.GetChannelProfileId(), path.GetPathIdForDomain(), channelsBinding);
         }
         if (!isResolved) {
             result->SetError(NKikimrScheme::StatusInvalidParameter, "Unable to construct channel binding with the storage pool");

--- a/ydb/core/tx/schemeshard/schemeshard_path_describer.cpp
+++ b/ydb/core/tx/schemeshard/schemeshard_path_describer.cpp
@@ -810,6 +810,15 @@ void TPathDescriber::DescribeSolomonVolume(TPathId pathId, TPathElement::TPtr pa
         }
     }
 
+    if (solomonVolumeInfo->Partitions.size() > 0) {
+        auto shardId = solomonVolumeInfo->Partitions.begin()->first;
+        auto shardInfo = Self->ShardInfos.FindPtr(shardId);
+        Y_ABORT_UNLESS(shardInfo);
+        for (const auto& channel : shardInfo->BindedChannels) {
+            entry->AddBoundChannels()->CopyFrom(channel);
+        }
+    }
+
     Sort(entry->MutablePartitions()->begin(),
          entry->MutablePartitions()->end(),
          [] (auto& part1, auto& part2) {

--- a/ydb/services/keyvalue/grpc_service_ut.cpp
+++ b/ydb/services/keyvalue/grpc_service_ut.cpp
@@ -813,6 +813,7 @@ Y_UNIT_TEST_SUITE(KeyValueGRPCService) {
         auto describeVolumeResult = DescribeVolume(channel, tablePath);
         UNIT_ASSERT_VALUES_EQUAL(1, describeVolumeResult.partition_count());
         UNIT_ASSERT(describeVolumeResult.has_storage_config());
+        UNIT_ASSERT_VALUES_EQUAL(describeVolumeResult.storage_config().channel_size(), 3);
         for (const auto& channel : describeVolumeResult.storage_config().channel()) {
             UNIT_ASSERT_VALUES_EQUAL(channel.media(), "ssd");
         }
@@ -825,6 +826,7 @@ Y_UNIT_TEST_SUITE(KeyValueGRPCService) {
         describeVolumeResult = DescribeVolume(channel, tablePath);
         UNIT_ASSERT_VALUES_EQUAL(2, describeVolumeResult.partition_count());
         UNIT_ASSERT(describeVolumeResult.has_storage_config());
+        UNIT_ASSERT_VALUES_EQUAL(describeVolumeResult.storage_config().channel_size(), 3);
         for (const auto& channel : describeVolumeResult.storage_config().channel()) {
             UNIT_ASSERT_VALUES_EQUAL(channel.media(), "ssd");
         }


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

The describe request previously failed to return channels, and the alter_volume function incorrectly modified channels based on channel_profile_id when storage_config was not set. These issues have now been resolved.

(#14978)

### Changelog category <!-- remove all except one -->

* Bugfix 

### Description for reviewers <!-- (optional) description for those who read this PR -->

...
