### PR TITLE
Fix memory leak in ldap auth provider

### DIFF
--- a/ydb/core/security/ldap_auth_provider/ldap_auth_provider.cpp
+++ b/ydb/core/security/ldap_auth_provider/ldap_auth_provider.cpp
@@ -321,6 +321,7 @@ private:
             response.Status = NKikimrLdap::ErrorToStatus(result);
             response.Error = {.Message = ERROR_MESSAGE, .LogMessage = logErrorMessage, .Retryable = NKikimrLdap::IsRetryableError(result)};
             LDAP_LOG_D(logErrorMessage);
+            NKikimrLdap::MsgFree(searchMessage);
             return response;
         }
         const int countEntries = NKikimrLdap::CountEntries(request.Ld, searchMessage);
@@ -357,6 +358,7 @@ private:
         LDAPMessage* searchMessage = nullptr;
         int result = NKikimrLdap::Search(ld, Settings.GetBaseDn(), NKikimrLdap::EScope::SUBTREE, filter, NKikimrLdap::noAttributes, 0, &searchMessage);
         if (!NKikimrLdap::IsSuccess(result)) {
+            NKikimrLdap::MsgFree(searchMessage);
             return {};
         }
         const int countEntries = NKikimrLdap::CountEntries(ld, searchMessage);
@@ -403,6 +405,7 @@ private:
             LDAPMessage* searchMessage = nullptr;
             int result = NKikimrLdap::Search(ld, Settings.GetBaseDn(), NKikimrLdap::EScope::SUBTREE, filter, RequestedAttributes, 0, &searchMessage);
             if (!NKikimrLdap::IsSuccess(result)) {
+                NKikimrLdap::MsgFree(searchMessage);
                 return;
             }
             if (NKikimrLdap::CountEntries(ld, searchMessage) == 0) {

--- a/ydb/core/security/ldap_auth_provider/ldap_auth_provider.cpp
+++ b/ydb/core/security/ldap_auth_provider/ldap_auth_provider.cpp
@@ -322,7 +322,6 @@ private:
             response.Error = {.Message = ERROR_MESSAGE, .LogMessage = logErrorMessage, .Retryable = NKikimrLdap::IsRetryableError(result)};
             LDAP_LOG_D(logErrorMessage);
             NKikimrLdap::MsgFree(searchMessage);
-            searchMessage = nullptr;
             return response;
         }
         const int countEntries = NKikimrLdap::CountEntries(request.Ld, searchMessage);
@@ -338,7 +337,6 @@ private:
             response.Error = {.Message = ERROR_MESSAGE, .LogMessage = logErrorMessage, .Retryable = false};
             response.Status = TEvLdapAuthProvider::EStatus::UNAUTHORIZED;
             NKikimrLdap::MsgFree(searchMessage);
-            searchMessage = nullptr;
             LDAP_LOG_D(logErrorMessage);
             return response;
         }
@@ -361,13 +359,11 @@ private:
         int result = NKikimrLdap::Search(ld, Settings.GetBaseDn(), NKikimrLdap::EScope::SUBTREE, filter, NKikimrLdap::noAttributes, 0, &searchMessage);
         if (!NKikimrLdap::IsSuccess(result)) {
             NKikimrLdap::MsgFree(searchMessage);
-            searchMessage = nullptr;
             return {};
         }
         const int countEntries = NKikimrLdap::CountEntries(ld, searchMessage);
         if (countEntries == 0) {
             NKikimrLdap::MsgFree(searchMessage);
-            searchMessage = nullptr;
             return {};
         }
         std::vector<TString> groups;
@@ -379,7 +375,6 @@ private:
             dn = nullptr;
         }
         NKikimrLdap::MsgFree(searchMessage);
-        searchMessage = nullptr;
         return groups;
     }
 
@@ -411,12 +406,10 @@ private:
             int result = NKikimrLdap::Search(ld, Settings.GetBaseDn(), NKikimrLdap::EScope::SUBTREE, filter, RequestedAttributes, 0, &searchMessage);
             if (!NKikimrLdap::IsSuccess(result)) {
                 NKikimrLdap::MsgFree(searchMessage);
-                searchMessage = nullptr;
                 return;
             }
             if (NKikimrLdap::CountEntries(ld, searchMessage) == 0) {
                 NKikimrLdap::MsgFree(searchMessage);
-                searchMessage = nullptr;
                 return;
             }
             for (LDAPMessage* groupEntry = NKikimrLdap::FirstEntry(ld, searchMessage); groupEntry != nullptr; groupEntry = NKikimrLdap::NextEntry(ld, groupEntry)) {
@@ -439,7 +432,6 @@ private:
                 }
             }
             NKikimrLdap::MsgFree(searchMessage);
-            searchMessage = nullptr;
         }
     }
 

--- a/ydb/core/security/ldap_auth_provider/ldap_auth_provider.cpp
+++ b/ydb/core/security/ldap_auth_provider/ldap_auth_provider.cpp
@@ -322,6 +322,7 @@ private:
             response.Error = {.Message = ERROR_MESSAGE, .LogMessage = logErrorMessage, .Retryable = NKikimrLdap::IsRetryableError(result)};
             LDAP_LOG_D(logErrorMessage);
             NKikimrLdap::MsgFree(searchMessage);
+            searchMessage = nullptr;
             return response;
         }
         const int countEntries = NKikimrLdap::CountEntries(request.Ld, searchMessage);
@@ -337,6 +338,7 @@ private:
             response.Error = {.Message = ERROR_MESSAGE, .LogMessage = logErrorMessage, .Retryable = false};
             response.Status = TEvLdapAuthProvider::EStatus::UNAUTHORIZED;
             NKikimrLdap::MsgFree(searchMessage);
+            searchMessage = nullptr;
             LDAP_LOG_D(logErrorMessage);
             return response;
         }
@@ -359,11 +361,13 @@ private:
         int result = NKikimrLdap::Search(ld, Settings.GetBaseDn(), NKikimrLdap::EScope::SUBTREE, filter, NKikimrLdap::noAttributes, 0, &searchMessage);
         if (!NKikimrLdap::IsSuccess(result)) {
             NKikimrLdap::MsgFree(searchMessage);
+            searchMessage = nullptr;
             return {};
         }
         const int countEntries = NKikimrLdap::CountEntries(ld, searchMessage);
         if (countEntries == 0) {
             NKikimrLdap::MsgFree(searchMessage);
+            searchMessage = nullptr;
             return {};
         }
         std::vector<TString> groups;
@@ -375,6 +379,7 @@ private:
             dn = nullptr;
         }
         NKikimrLdap::MsgFree(searchMessage);
+        searchMessage = nullptr;
         return groups;
     }
 
@@ -406,10 +411,12 @@ private:
             int result = NKikimrLdap::Search(ld, Settings.GetBaseDn(), NKikimrLdap::EScope::SUBTREE, filter, RequestedAttributes, 0, &searchMessage);
             if (!NKikimrLdap::IsSuccess(result)) {
                 NKikimrLdap::MsgFree(searchMessage);
+                searchMessage = nullptr;
                 return;
             }
             if (NKikimrLdap::CountEntries(ld, searchMessage) == 0) {
                 NKikimrLdap::MsgFree(searchMessage);
+                searchMessage = nullptr;
                 return;
             }
             for (LDAPMessage* groupEntry = NKikimrLdap::FirstEntry(ld, searchMessage); groupEntry != nullptr; groupEntry = NKikimrLdap::NextEntry(ld, groupEntry)) {
@@ -432,6 +439,7 @@ private:
                 }
             }
             NKikimrLdap::MsgFree(searchMessage);
+            searchMessage = nullptr;
         }
     }
 


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

https://github.com/ydb-platform/ydb/issues/14324

### Changelog category <!-- remove all except one -->

* Bugfix 


### Description for reviewers <!-- (optional) description for those who read this PR -->

https://storage.yandexcloud.net/ydb-gh-logs/ydb-platform/ydb/PR-check/13541234982/ya-x86-64-asan/try_2/artifacts/logs/ydb/core/security/ldap_auth_provider/ut/test-results/unittest/testing_out_stuff/LdapAuthProviderTest_StartTls.LdapRefreshGroupsInfoWithError.err
