### PR TITLE
The `use-heap-after-free` error in the Topic SDK code

### DIFF
--- a/ydb/public/sdk/cpp/src/client/topic/impl/topic_impl.h
+++ b/ydb/public/sdk/cpp/src/client/topic/impl/topic_impl.h
@@ -296,8 +296,8 @@ public:
     {
         auto request = MakeOperationRequest<Ydb::Topic::UpdateOffsetsInTransactionRequest>(settings);
 
-        request.mutable_tx()->set_id(TStringType{GetTxId(tx)});
-        request.mutable_tx()->set_session(TStringType{GetSessionId(tx)});
+        request.mutable_tx()->set_id(tx.TxId);
+        request.mutable_tx()->set_session(tx.SessionId);
 
         for (auto& t : topics) {
             auto* topic = request.mutable_topics()->Add();

--- a/ydb/public/sdk/cpp/src/client/topic/impl/transaction.h
+++ b/ydb/public/sdk/cpp/src/client/topic/impl/transaction.h
@@ -10,18 +10,21 @@ class TTransaction;
 
 namespace NYdb::inline V3::NTopic {
 
-using TTransactionId = std::pair<std::string, std::string>;
+struct TTransactionId {
+    std::string SessionId;
+    std::string TxId;
+};
 
 inline
-const std::string& GetSessionId(const TTransactionId& x)
+bool operator==(const TTransactionId& lhs, const TTransactionId& rhs)
 {
-    return x.first;
+    return (lhs.SessionId == rhs.SessionId) && (lhs.TxId == rhs.TxId);
 }
 
 inline
-const std::string& GetTxId(const TTransactionId& x)
+bool operator!=(const TTransactionId& lhs, const TTransactionId& rhs)
 {
-    return x.second;
+    return !(lhs == rhs);
 }
 
 TTransactionId MakeTransactionId(const NTable::TTransaction& tx);
@@ -30,3 +33,10 @@ TStatus MakeSessionExpiredError();
 TStatus MakeCommitTransactionSuccess();
 
 }
+
+template <>
+struct THash<NYdb::NTopic::TTransactionId> {
+    size_t operator()(const NYdb::NTopic::TTransactionId& v) const noexcept {
+        return CombineHashes(THash<std::string>()(v.SessionId), THash<std::string>()(v.TxId));
+    }
+};

--- a/ydb/public/sdk/cpp/src/client/topic/impl/write_session_impl.cpp
+++ b/ydb/public/sdk/cpp/src/client/topic/impl/write_session_impl.cpp
@@ -12,6 +12,12 @@
 #include <util/stream/buffer.h>
 #include <util/generic/guid.h>
 
+template <>
+void Out<NYdb::NTopic::TTransactionId>(IOutputStream& s, const NYdb::NTopic::TTransactionId& v)
+{
+    s << "{" << v.SessionId << ", " << v.TxId << "}";
+}
+
 namespace NYdb::inline V3::NTopic {
 
 const TDuration UPDATE_TOKEN_PERIOD = TDuration::Hours(1);
@@ -584,7 +590,7 @@ void TWriteSessionImpl::TrySignalAllAcksReceived(ui64 seqNo)
         ++txInfo->AckCount;
 
         LOG_LAZY(DbDriverState->Log, TLOG_DEBUG,
-                 LogPrefixImpl() << "OnAck: seqNo=" << seqNo << ", txId=" << GetTxId(txId) << ", WriteCount=" << txInfo->WriteCount << ", AckCount=" << txInfo->AckCount);
+                 LogPrefixImpl() << "OnAck: seqNo=" << seqNo << ", txId=" << txId << ", WriteCount=" << txInfo->WriteCount << ", AckCount=" << txInfo->AckCount);
 
         if (txInfo->CommitCalled && (txInfo->WriteCount == txInfo->AckCount)) {
             txInfo->AllAcksReceived.SetValue(MakeCommitTransactionSuccess());
@@ -631,7 +637,7 @@ void TWriteSessionImpl::WriteInternal(TContinuationToken&&, TWriteMessage&& mess
                 ++txInfo->WriteCount;
 
                 LOG_LAZY(DbDriverState->Log, TLOG_DEBUG,
-                         LogPrefixImpl() << "OnWrite: seqNo=" << seqNo << ", txId=" << GetTxId(txId) << ", WriteCount=" << txInfo->WriteCount << ", AckCount=" << txInfo->AckCount);
+                         LogPrefixImpl() << "OnWrite: seqNo=" << seqNo << ", txId=" << txId << ", WriteCount=" << txInfo->WriteCount << ", AckCount=" << txInfo->AckCount);
             }
             WrittenInTx[seqNo] = txId;
         }

--- a/ydb/public/sdk/cpp/src/client/topic/impl/write_session_impl.h
+++ b/ydb/public/sdk/cpp/src/client/topic/impl/write_session_impl.h
@@ -164,18 +164,18 @@ private:
         std::optional<ECodec> Codec;
         ui32 OriginalSize; // only for coded messages
         std::vector<std::pair<std::string, std::string>> MessageMeta;
-        const NTable::TTransaction* Tx;
+        std::optional<TTransactionId> Tx;
 
         TMessage(uint64_t id, const TInstant& createdAt, std::string_view data, std::optional<ECodec> codec = {},
                  ui32 originalSize = 0, const std::vector<std::pair<std::string, std::string>>& messageMeta = {},
-                 const NTable::TTransaction* tx = nullptr)
+                 std::optional<TTransactionId>&& tx = {})
             : Id(id)
             , CreatedAt(createdAt)
             , DataRef(data)
             , Codec(codec)
             , OriginalSize(originalSize)
             , MessageMeta(messageMeta)
-            , Tx(tx)
+            , Tx(std::move(tx))
         {}
     };
 
@@ -189,11 +189,11 @@ private:
 
         void Add(uint64_t id, const TInstant& createdAt, std::string_view data, std::optional<ECodec> codec, ui32 originalSize,
                  const std::vector<std::pair<std::string, std::string>>& messageMeta,
-                 const NTable::TTransaction* tx) {
+                 std::optional<TTransactionId>&& tx) {
             if (StartedAt == TInstant::Zero())
                 StartedAt = TInstant::Now();
             CurrentSize += codec ? originalSize : data.size();
-            Messages.emplace_back(id, createdAt, data, codec, originalSize, messageMeta, tx);
+            Messages.emplace_back(id, createdAt, data, codec, originalSize, messageMeta, std::move(tx));
             Acquired = false;
         }
 
@@ -263,24 +263,24 @@ private:
         TInstant CreatedAt;
         size_t Size;
         std::vector<std::pair<std::string, std::string>> MessageMeta;
-        const NTable::TTransaction* Tx;
+        std::optional<TTransactionId> Tx;
 
         TOriginalMessage(const uint64_t id, const TInstant createdAt, const size_t size,
-                         const NTable::TTransaction* tx)
+                         std::optional<TTransactionId>&& tx)
             : Id(id)
             , CreatedAt(createdAt)
             , Size(size)
-            , Tx(tx)
+            , Tx(std::move(tx))
         {}
 
         TOriginalMessage(const uint64_t id, const TInstant createdAt, const size_t size,
                          std::vector<std::pair<std::string, std::string>>&& messageMeta,
-                         const NTable::TTransaction* tx)
+                         std::optional<TTransactionId>&& tx)
             : Id(id)
             , CreatedAt(createdAt)
             , Size(size)
             , MessageMeta(std::move(messageMeta))
-            , Tx(tx)
+            , Tx(std::move(tx))
         {}
     };
 


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

A pointer to the transaction was stored in the recorded message. This could lead to a `use-heap-after-free` error in the `linux-x86_64-release-asan` configuration

#15089

### Changelog category <!-- remove all except one -->

* Bugfix 

### Description for reviewers <!-- (optional) description for those who read this PR -->

Added the `TTransactionId` type. Now, instead of a pointer, `std::optional<TTransactionId>` is stored.
