### PR TITLE
ydbd_slice: add support for using raw config.yaml

### DIFF
--- a/ydb/tools/cfg/base.py
+++ b/ydb/tools/cfg/base.py
@@ -622,6 +622,10 @@ class ClusterDetailsProvider(object):
             )
         return domains
 
+    @domains.setter
+    def domains(self, values):
+        self.__cluster_description["domains"] = values
+
     @property
     def domains_config(self):
         domains_config_dict = self.__cluster_description.get("domains_config", {})

--- a/ydb/tools/ydbd_slice/__init__.py
+++ b/ydb/tools/ydbd_slice/__init__.py
@@ -13,10 +13,10 @@ import library.python.resource as rs
 from urllib3.exceptions import HTTPWarning
 
 from ydb.tools.cfg.walle import NopHostsInformationProvider
-from ydb.tools.ydbd_slice import nodes, handlers, cluster_description
+from ydb.tools.ydbd_slice import nodes, handlers, cluster_description, yaml_configurator
 from ydb.tools.ydbd_slice.kube import handlers as kube_handlers, docker
 
-warnings.filterwarnings("ignore", category=DeprecationWarning)
+# warnings.filterwarnings("ignore", category=DeprecationWarning)
 warnings.filterwarnings("ignore", category=HTTPWarning)
 
 
@@ -39,6 +39,9 @@ Guide for ad-hoc Kubernetes operations could be found here
 
 \033[95msample-config\033[94m - get sample configuration for cluster:
     %(prog)s sample-config --cluster-type=block-4-2-8-nodes --output-file=cluster.yaml
+
+\033[95mdynconfig-generator\033[94m - generate simple dynamic configuration for cluster:
+    %(prog)s dynconfig-generator --yaml-config=config.yaml --output-file=dynconfig.yaml
 
 \033[95minstall\033[94m - full install process from scratch:
     %(prog)s install cluster.yaml --arcadia
@@ -254,9 +257,9 @@ class Terminate(BaseException):
         raise Terminate(signum, frame)
 
 
-def safe_load_cluster_details(cluster_yaml, walle_provider):
+def safe_load_cluster_details(cluster_yaml, walle_provider, validator=None):
     try:
-        cluster_details = cluster_description.ClusterDetails(cluster_yaml, walle_provider)
+        cluster_details = cluster_description.ClusterDetails(cluster_yaml, walle_provider, validator=validator)
     except IOError as io_err:
         print('', file=sys.stderr)
         print("unable to open YAML params as a file, check args", file=sys.stderr)
@@ -310,8 +313,7 @@ def deduce_components_from_args(args, cluster_details):
     return result
 
 
-def deduce_nodes_from_args(args, walle_provider, ssh_user, ssh_key_path):
-    cluster_hosts = safe_load_cluster_details(args.cluster, walle_provider).hosts_names
+def deduce_nodes_from_args(args, cluster_hosts, ssh_user, ssh_key_path):
     result = cluster_hosts
 
     if args.nodes is not None:
@@ -547,6 +549,26 @@ def databases_config_path_args():
     return args
 
 
+def yaml_config_path_args():
+    args = argparse.ArgumentParser(add_help=False)
+    args.add_argument(
+        "--yaml-config",
+        metavar="YAML_CONFIG",
+        default="",
+        required=False,
+        help="Path to file with config.yaml configuration",
+    )
+    args.add_argument(
+        "--yaml-dynconfig",
+        metavar="YAML_DYNCONFIG",
+        default="",
+        required=False,
+        help="Path to file with dynconfig.yaml configuration",
+    )
+
+    return args
+
+
 def cluster_type_args():
     args = argparse.ArgumentParser(add_help=False)
     available_erasure_types = [
@@ -628,37 +650,64 @@ def dispatch_run(func, args, walle_provider, need_confirmation=False):
 
     logger.debug("run func '%s' with cmd args is '%s'", func.__name__, args)
 
-    cluster_details = safe_load_cluster_details(args.cluster, walle_provider)
-    components = deduce_components_from_args(args, cluster_details)
-
-    nodes = deduce_nodes_from_args(args, walle_provider, args.ssh_user, args.ssh_key_path)
-
     temp_dir = deduce_temp_dir_from_args(args)
+    kikimr_bin, kikimr_compressed_bin = deduce_kikimr_bin_from_args(args)
     clear_tmp = not args.dry_run and args.temp_dir is None
 
-    kikimr_bin, kikimr_compressed_bin = deduce_kikimr_bin_from_args(args)
+    if args.yaml_config and args.yaml_dynconfig:
+        configurator = yaml_configurator.YamlConfigurator(
+            args.cluster,
+            temp_dir,
+            kikimr_bin,
+            kikimr_compressed_bin,
+            args.yaml_config,
+            args.yaml_dynconfig
+        )
+        cluster_details = configurator.cluster_description
+    else:
+        cluster_details = safe_load_cluster_details(args.cluster, walle_provider)
+        configurator = cluster_description.Configurator(
+            cluster_details,
+            out_dir=temp_dir,
+            kikimr_bin=kikimr_bin,
+            kikimr_compressed_bin=kikimr_compressed_bin,
+            walle_provider=walle_provider
+        )
 
-    configurator = cluster_description.Configurator(
-        cluster_details,
-        out_dir=temp_dir,
-        kikimr_bin=kikimr_bin,
-        kikimr_compressed_bin=kikimr_compressed_bin,
-        walle_provider=walle_provider
-    )
+    components = deduce_components_from_args(args, cluster_details)
 
     v = vars(args)
     clear_logs = v.get('clear_logs')
     yav_version = v.get('yav_version')
+
+    nodes = deduce_nodes_from_args(args, configurator.hosts_names, args.ssh_user, args.ssh_key_path)
     slice = handlers.Slice(
         components,
         nodes,
         cluster_details,
-        configurator,
+        kikimr_bin,
+        kikimr_compressed_bin,
         clear_logs,
         yav_version,
         walle_provider,
+        configurator,
     )
     func(slice)
+
+    # used only for configurator and will be removed soon
+    save_raw_cfg = v.get('save_raw_cfg')
+    if save_raw_cfg and configurator:
+        logger.debug("save raw cfg to '%s'", save_raw_cfg)
+        for root, dirs, files in os.walk(temp_dir):
+            for dir in dirs:
+                os.makedirs(os.path.join(save_raw_cfg, dir), 0o755, exist_ok=True)
+
+            for file in files:
+                src = os.path.join(root, file)
+                dst = os.path.join(save_raw_cfg, os.path.relpath(src, temp_dir))
+                with open(src, 'r') as src_f:
+                    with open(dst, 'w') as dst_f:
+                        dst_f.write(src_f.read())
 
     if clear_tmp:
         logger.debug("remove temp dirs '%s'", temp_dir)
@@ -699,6 +748,7 @@ def add_install_mode(modes, walle_provider):
         parents=[
             direct_nodes_args(),
             cluster_description_args(),
+            yaml_config_path_args(),
             binaries_args(),
             component_args(),
             log_args(),
@@ -708,6 +758,13 @@ def add_install_mode(modes, walle_provider):
         ],
         description="Full installation of the cluster from scratch. "
         "You can use --hosts to specify particular hosts. But it is tricky.",
+    )
+    mode.add_argument(
+        "--save-raw-cfg",
+        metavar="DIR",
+        required=False,
+        default="",
+        help="Directory to save all static configuration files generated by configuration.create_static_cfg and configuration.create_dynamic_cfg",
     )
     mode.set_defaults(handler=_run)
 
@@ -722,6 +779,7 @@ def add_update_mode(modes, walle_provider):
         parents=[
             direct_nodes_args(),
             cluster_description_args(),
+            yaml_config_path_args(),
             binaries_args(),
             component_args(),
             log_args(),
@@ -759,7 +817,14 @@ def add_stop_mode(modes, walle_provider):
 
     mode = modes.add_parser(
         "stop",
-        parents=[direct_nodes_args(), cluster_description_args(), binaries_args(), component_args(), ssh_args()],
+        parents=[
+            direct_nodes_args(),
+            cluster_description_args(),
+            yaml_config_path_args(),
+            binaries_args(),
+            component_args(),
+            ssh_args()
+        ],
         description="Stop ydbd static instances at the nodes. "
                     "If option components specified, try to stop particular component. "
                     "Use --hosts to specify particular hosts."
@@ -773,7 +838,14 @@ def add_start_mode(modes, walle_provider):
 
     mode = modes.add_parser(
         "start",
-        parents=[direct_nodes_args(), cluster_description_args(), binaries_args(), component_args(), ssh_args()],
+        parents=[
+            direct_nodes_args(),
+            cluster_description_args(),
+            yaml_config_path_args(),
+            binaries_args(),
+            component_args(),
+            ssh_args()
+        ],
         description="Start all ydbd instances at the nodes. "
                     "If option components specified, try to start particular component. "
                     "Otherwise only kikimr-multi-all will be started. "
@@ -791,6 +863,7 @@ def add_clear_mode(modes, walle_provider):
         parents=[
             direct_nodes_args(),
             cluster_description_args(),
+            yaml_config_path_args(),
             binaries_args(),
             component_args(),
             ssh_args(),
@@ -812,6 +885,7 @@ def add_format_mode(modes, walle_provider):
         parents=[
             direct_nodes_args(),
             cluster_description_args(),
+            yaml_config_path_args(),
             binaries_args(),
             component_args(),
             ssh_args(),
@@ -856,6 +930,24 @@ def add_sample_config_mode(modes):
         "sample-config",
         parents=[cluster_type_args(), output_file()],
         description="Generate default mock-configuration for provided cluster-type"
+    )
+
+    mode.set_defaults(handler=_run)
+
+
+def add_dynconfig_generator(modes):
+    def _run(args):
+        if args.yaml_config:
+            yaml_config = yaml_configurator.YamlConfig(args.yaml_config)
+
+        if args.output_file is not None and args.output_file:
+            with open(args.output_file, "w") as output:
+                output.write(yaml_config.dynamic_simple)
+
+    mode = modes.add_parser(
+        "dynconfig-generator",
+        parents=[yaml_config_path_args(), output_file()],
+        description="Generate a minimalistic dynconfig.yaml for the provided config.yaml"
     )
 
     mode.set_defaults(handler=_run)
@@ -1413,6 +1505,7 @@ def main(walle_provider=None):
         add_format_mode(modes, walle_provider)
         add_explain_mode(modes, walle_provider)
         add_sample_config_mode(modes)
+        add_dynconfig_generator(modes)
 
         add_docker_build_mode(modes)
         add_docker_push_mode(modes)
@@ -1429,8 +1522,41 @@ def main(walle_provider=None):
 
         args = parser.parse_args()
         logging.root.setLevel(args.log_level.upper())
-        args.handler(args)
 
+        if not hasattr(args, 'handler'):
+            parser.print_help()
+            return
+
+        if not args.yaml_config:
+            warnings.warn(
+                '''
+
+
+###### WARNING #######
+
+Using cluster.yaml for cluster configuration is deprecated.
+Only the 'domains' section should be filled with database and slot configurations.
+The config.yaml and dynconfig.yaml should be passed as raw files through the --yaml-config and --yaml-dynconfig parameters.
+
+    ydbd_slice install cluster.yaml all --binary /path/to/ydbd --yaml-config /path/to/config.yaml --yaml-dynconfig /path/to/dynconfig.yaml
+
+To save the resulting configuration files from an old cluster.yaml, use the --save-raw-cfg option.
+
+    ydbd_slice install cluster.yaml all --binary /path/to/ydbd --save-raw-cfg /path/to/save
+
+The resulting configuration files will be saved in the /path/to/save directory. You can find config.yaml and dynconfig.yaml in the /path/to/save/kikimr-static directory.
+
+To generate dynconfig.yaml from config.yaml, you can use the dynconfig-generator command.
+
+    ydbd_slice dynconfig-generator --yaml-config /path/to/config.yaml --output-file /path/to/dynconfig.yaml
+
+###### WARNING #######
+
+''',
+                DeprecationWarning
+            )
+
+        args.handler(args)
     except KeyboardInterrupt:
         sys.exit('\nStopped by KeyboardInterrupt.')
     except Terminate:

--- a/ydb/tools/ydbd_slice/__init__.py
+++ b/ydb/tools/ydbd_slice/__init__.py
@@ -558,13 +558,6 @@ def yaml_config_path_args():
         required=False,
         help="Path to file with config.yaml configuration",
     )
-    args.add_argument(
-        "--yaml-dynconfig",
-        metavar="YAML_DYNCONFIG",
-        default="",
-        required=False,
-        help="Path to file with dynconfig.yaml configuration",
-    )
 
     return args
 
@@ -654,14 +647,13 @@ def dispatch_run(func, args, walle_provider, need_confirmation=False):
     kikimr_bin, kikimr_compressed_bin = deduce_kikimr_bin_from_args(args)
     clear_tmp = not args.dry_run and args.temp_dir is None
 
-    if args.yaml_config and args.yaml_dynconfig:
+    if args.yaml_config:
         configurator = yaml_configurator.YamlConfigurator(
             args.cluster,
             temp_dir,
             kikimr_bin,
             kikimr_compressed_bin,
-            args.yaml_config,
-            args.yaml_dynconfig
+            args.yaml_config
         )
         cluster_details = configurator.cluster_description
     else:
@@ -1530,28 +1522,19 @@ def main(walle_provider=None):
         if not args.yaml_config:
             warnings.warn(
                 '''
-
-
-###### WARNING #######
-
 Using cluster.yaml for cluster configuration is deprecated.
 Only the 'domains' section should be filled with database and slot configurations.
-The config.yaml and dynconfig.yaml should be passed as raw files through the --yaml-config and --yaml-dynconfig parameters.
+The config.yaml should be passed as a raw file through the --yaml-config.
 
-    ydbd_slice install cluster.yaml all --binary /path/to/ydbd --yaml-config /path/to/config.yaml --yaml-dynconfig /path/to/dynconfig.yaml
+Example:
+    ydbd_slice install cluster.yaml all --binary /path/to/ydbd --yaml-config /path/to/config.yaml
 
 To save the resulting configuration files from an old cluster.yaml, use the --save-raw-cfg option.
 
+Example:
     ydbd_slice install cluster.yaml all --binary /path/to/ydbd --save-raw-cfg /path/to/save
 
-The resulting configuration files will be saved in the /path/to/save directory. You can find config.yaml and dynconfig.yaml in the /path/to/save/kikimr-static directory.
-
-To generate dynconfig.yaml from config.yaml, you can use the dynconfig-generator command.
-
-    ydbd_slice dynconfig-generator --yaml-config /path/to/config.yaml --output-file /path/to/dynconfig.yaml
-
-###### WARNING #######
-
+The resulting configuration files will be saved in the /path/to/save directory. You can find config.yaml in the /path/to/save/kikimr-static directory.
 ''',
                 DeprecationWarning
             )

--- a/ydb/tools/ydbd_slice/cluster_description.py
+++ b/ydb/tools/ydbd_slice/cluster_description.py
@@ -27,7 +27,7 @@ class ClusterDetails(ClusterDetailsProvider):
     SLOTS_PORTS_START = 31000
     PORTS_SHIFT = 10
 
-    def __init__(self, cluster_description_path, walle_provider):
+    def __init__(self, cluster_description_path, walle_provider, validator=None):
         self.__template = None
         self.__details = None
         self.__databases = None
@@ -35,7 +35,7 @@ class ClusterDetails(ClusterDetailsProvider):
         self._cluster_description_file = cluster_description_path
         self._walle_provider = walle_provider
 
-        super(ClusterDetails, self).__init__(self.template, self._walle_provider, use_new_style_cfg=True)
+        super(ClusterDetails, self).__init__(self.template, self._walle_provider, validator=validator, use_new_style_cfg=True)
 
     @property
     def template(self):
@@ -132,6 +132,10 @@ class Configurator(object):
     def detail(self):
         return self.__cluster_details
 
+    @property
+    def hosts_names(self):
+        return self.detail.hosts_names
+
     @staticmethod
     def _generate_fake_keys():
         content = 'Keys {\n'
@@ -140,6 +144,7 @@ class Configurator(object):
         content += '  Id: "fake-secret"\n'
         content += '  Version: 1\n'
         content += '}\n'
+
         return content
 
     @staticmethod

--- a/ydb/tools/ydbd_slice/handlers.py
+++ b/ydb/tools/ydbd_slice/handlers.py
@@ -21,13 +21,15 @@ class CalledProcessError(subprocess.CalledProcessError):
 
 
 class Slice:
-    def __init__(self, components, nodes, cluster_details, configurator, do_clear_logs, yav_version, walle_provider):
+    def __init__(self, components, nodes, cluster_details, bin, compressed_bin, do_clear_logs, yav_version, walle_provider, configurator=None):
         self.slice_kikimr_path = '/Berkanavt/kikimr/bin/kikimr'
         self.slice_cfg_path = '/Berkanavt/kikimr/cfg'
         self.slice_secrets_path = '/Berkanavt/kikimr/token'
         self.components = components
         self.nodes = nodes
         self.cluster_details = cluster_details
+        self.bin = bin
+        self.compressed_bin = compressed_bin
         self.configurator = configurator
         self.do_clear_logs = do_clear_logs
         self.yav_version = yav_version
@@ -113,6 +115,25 @@ class Slice:
             )
         )
 
+    def _dynamic_provision(self):
+
+        self.nodes.execute_async(
+            f"{self.slice_kikimr_path} admin blobstorage config init --yaml-file /Berkanavt/kikimr/cfg/config.yaml",
+            nodes=self.nodes.nodes_list[:1],
+            check_retcode=False
+        )
+
+        create_db_template = f"{self.slice_kikimr_path} admin database /{{}}/{{}} create {{}}:{{}}"
+        for domain in self.cluster_details.domains:
+            for tenant in domain.tenants:
+                for storage in tenant.storage_units:
+                    self.nodes.execute_async(
+                        create_db_template.format(domain.domain_name, tenant.name, storage.kind, storage.count),
+                        nodes=self.nodes.nodes_list[:1]
+                    )
+
+        return
+
     def slice_install(self):
         self._ensure_berkanavt_exists()
         self.slice_stop()
@@ -136,7 +157,8 @@ class Slice:
                 self._deploy_secrets()
 
             self._start_static()
-            self._dynamic_configure()
+            self._dynamic_provision()
+            # self._dynamic_configure()
 
         self._deploy_slot_configs()
         self._start_dynamic()
@@ -355,8 +377,8 @@ mon={mon}""".format(
             self._stop_static()
 
     def _update_kikimr(self):
-        bin_directory = os.path.dirname(self.configurator.kikimr_bin)
-        self.nodes.copy(self.configurator.kikimr_bin, self.slice_kikimr_path, compressed_path=self.configurator.kikimr_compressed_bin)
+        bin_directory = os.path.dirname(self.bin)
+        self.nodes.copy(self.bin, self.slice_kikimr_path, compressed_path=self.compressed_bin)
         for lib in ['libiconv.so', 'liblibaio-dynamic.so', 'liblibidn-dynamic.so']:
             lib_path = os.path.join(bin_directory, lib)
             if os.path.exists(lib_path):

--- a/ydb/tools/ydbd_slice/nodes.py
+++ b/ydb/tools/ydbd_slice/nodes.py
@@ -159,10 +159,26 @@ class Nodes(object):
 
         self._check_async_execution(running_jobs)
 
-    # copy local_path to remote_path for every node in nodes
     def copy(self, local_path, remote_path, directory=False, compressed_path=None):
-        if directory:
+        """
+        Copies a file or directory from a local path to a remote path, with optional compression.
+        Args:
+            local_path (str): The local path of the file or directory to copy.
+            remote_path (str): The remote path where the file or directory will be copied.
+            directory (bool, optional): If True, treats the remote path as a directory. Defaults to False.
+            compressed_path (str, optional): If provided, compresses the local file or directory to this path before copying. Defaults to None.
+        Raises:
+            subprocess.CalledProcessError: If the compression command fails.
+        Notes:
+            - If `compressed_path` is provided, the method will compress the local file or directory using `zstd` before copying.
+            - The method ensures that the remote directory exists before copying.
+            - The method copies the file or directory to a hub node first, then distributes it to other nodes.
+            - If `compressed_path` is provided, the method will decompress the file on the remote side if necessary.
+        """
+
+        if os.path.isdir(local_path):
             local_path += '/'
+        if directory:
             remote_path += '/'
         if compressed_path is not None:
             self._logger.info('compressing %s to %s' % (local_path, compressed_path))

--- a/ydb/tools/ydbd_slice/ya.make
+++ b/ydb/tools/ydbd_slice/ya.make
@@ -7,6 +7,7 @@ PY3_LIBRARY(ydbd_slice)
 PY_SRCS(
     __init__.py
     cluster_description.py
+    yaml_configurator.py
     kube/__init__.py
     kube/api.py
     kube/cms.py

--- a/ydb/tools/ydbd_slice/yaml_configurator.py
+++ b/ydb/tools/ydbd_slice/yaml_configurator.py
@@ -12,11 +12,11 @@ from ydb.tools.cfg.templates import (
 
 # Remove specified keys
 STORAGE_ONLY_KEYS = [
-        'static_erasure',
-        'host_configs',
-        'nameservice_config',
-        'blob_storage_config',
-        'hosts'
+    'static_erasure',
+    'host_configs',
+    'nameservice_config',
+    'blob_storage_config',
+    'hosts'
 ]
 
 
@@ -56,13 +56,12 @@ class YamlConfig(object):
 
 class YamlConfigurator(object):
     def __init__(
-                self,
-                cluster_path: os.PathLike,
-                out_dir: os.PathLike,
-                bin_path: os.PathLike,
-                compressed_bin_path: os.PathLike,
-                config_path: os.PathLike,
-            ):
+            self,
+            cluster_path: os.PathLike,
+            out_dir: os.PathLike,
+            bin_path: os.PathLike,
+            compressed_bin_path: os.PathLike,
+            config_path: os.PathLike):
         # walle provider is not used
         # use config_path instad of cluster_path
         self.cluster_description = cluster_description.ClusterDetails(config_path, None)

--- a/ydb/tools/ydbd_slice/yaml_configurator.py
+++ b/ydb/tools/ydbd_slice/yaml_configurator.py
@@ -1,0 +1,169 @@
+import os
+import yaml
+
+from ydb.tools.ydbd_slice import cluster_description
+import copy
+from ydb.tools.cfg.utils import write_to_file
+
+from ydb.tools.cfg.templates import (
+    dynamic_cfg_new_style,
+    kikimr_cfg_for_static_node_new_style,
+)
+
+
+class YamlConfig(object):
+    def __init__(self, yaml_config_path: str):
+        try:
+            with open(yaml_config_path, 'r') as f:
+                self.__yaml_config = yaml.safe_load(f)
+        except (yaml.scanner.ScannerError, yaml.parser.ParserError) as e:
+            raise "Invalid yaml config: {}".format(e)
+
+    @property
+    def dynamic_simple(self):
+        cluster_uuid = self.__yaml_config.get('nameservice_config', {}).get('cluster_uuid', '')
+        dynconfig = {
+            'metadata': {
+                'kind': 'MainConfig',
+                'cluster': cluster_uuid,
+                'version': 0,
+            },
+            'config': copy.deepcopy(self.__yaml_config),
+            'allowed_labels': {
+                'node_id': {'type': 'string'},
+                'host': {'type': 'string'},
+                'tenant': {'type': 'string'},
+            },
+            'selector_config': [],
+        }
+
+        return yaml.dump(dynconfig, sort_keys=True, default_flow_style=False, indent=2)
+
+
+class YamlConfigurator(object):
+    def __init__(
+                self,
+                cluster_path: os.PathLike,
+                out_dir: os.PathLike,
+                bin_path: os.PathLike,
+                compressed_bin_path: os.PathLike,
+                config_path: os.PathLike,
+                dynconfig_path: os.PathLike = ""
+            ):
+        # walle provider is not used
+        # use config_path instad of cluster_path
+        self.cluster_description = cluster_description.ClusterDetails(config_path, None)
+
+        with open(cluster_path, 'r') as f:
+            _domains = yaml.safe_load(f)
+            self.cluster_description.domains = _domains.get('domains', [])
+
+        self.__static_cfg = out_dir
+        self.__kikimr_bin_file = bin_path
+        self.__kikimr_compressed_bin_file = compressed_bin_path
+        with open(config_path, 'r') as f:
+            self.static = f.read()
+
+        with open(dynconfig_path, 'r') as f:
+            self.dynamic = f.read()
+
+    @property
+    def kikimr_bin(self):
+        return self.bin_path
+
+    @property
+    def kikimr_compressed_bin(self):
+        return self.compressed_bin_path
+
+    @property
+    def static(self):
+        return self.__static
+
+    @property
+    def static_dict(self):
+        return self.__static_dict
+
+    @static.setter
+    def static(self, value):
+        try:
+            self.__static_dict = yaml.safe_load(value)
+        except (yaml.scanner.ScannerError, yaml.parser.ParserError) as e:
+            raise "Invalid yaml config: {}".format(e)
+
+        self.__static = value
+
+    @property
+    def dynamic(self):
+        return self.__dynamic
+
+    @property
+    def dynamic_dict(self):
+        return self.__dynamic_dict
+
+    @dynamic.setter
+    def dynamic(self, value):
+        try:
+            self.__dynamic_dict = yaml.safe_load(value)
+        except (yaml.scanner.ScannerError, yaml.parser.ParserError) as e:
+            raise "Invalid yaml config: {}".format(e)
+
+        self.__dynamic = value
+
+    @staticmethod
+    def _generate_fake_keys():
+        return '''Keys {
+  ContainerPath: "/Berkanavt/kikimr/cfg/fake-secret.txt"
+  Pin: ""
+  Id: "fake-secret"
+  Version: 1
+}'''
+
+    @staticmethod
+    def _generate_fake_secret():
+        return 'not a secret at all, only for more similar behavior with cloud'
+
+    @property
+    def hosts_names(self):
+        return [host['host'] for host in self.static_dict.get('hosts', [])]
+
+    @property
+    def kickimr_cfg(self):
+        return kikimr_cfg_for_static_node_new_style()
+
+    @property
+    def dynamic_cfg(self):
+        return dynamic_cfg_new_style()
+
+    def create_static_cfg(self) -> str:
+        write_to_file(
+            os.path.join(self.__static_cfg, 'key.txt'),
+            self._generate_fake_keys()
+        )
+        write_to_file(
+            os.path.join(self.__static_cfg, 'fake-secret.txt'),
+            self._generate_fake_secret()
+        )
+        write_to_file(
+            os.path.join(self.__static_cfg, 'config.yaml'),
+            self.__static
+        )
+        write_to_file(
+            os.path.join(self.__static_cfg, 'kikimr.cfg'),
+            self.kickimr_cfg
+        )
+        write_to_file(
+            os.path.join(self.__static_cfg, 'dynconfig.yaml'),
+            self.__dynamic
+        )
+        write_to_file(
+            os.path.join(self.__static_cfg, 'dynamic_server.cfg'),
+            self.dynamic_cfg
+        )
+
+        return self.__static_cfg
+
+    def create_dynamic_cfg(self) -> str:
+        write_to_file(
+            os.path.join(self.__static_cfg, 'dynconfig.yaml'),
+            self.__dynamic
+        )


### PR DESCRIPTION
ydbd_slice: add support for using raw config.yaml via --yaml-config and dynconfig.yaml via --yaml-dynconfig



### Changelog entry 

- Add yaml_configurator instead of configurator
- Add warning for old style cluster.yaml
- Add dynconfig-generator for generating simple dynconfig.yaml
- Add --save-raw-cfg option for saving raw config from old cluster.yaml

### Changelog category 

* Experimental feature


### Description for reviewers
This PR introduces a new slice with the following changes:

1. **Configuration Files**:
   - Created `config.yaml` and `cluster.yaml` (containing only the `domains` section).
   - Generated the minimally required `dynconfig.yaml` using:
     ```bash
     ydbd_slice dynconfig-generator --yaml-config config.yaml --output-file dynconfig.yaml
     ```

2. **Slice Creation**:
   - The slice is created using the following command:
     ```bash
     ydbd_slice install cluster.yaml all --yaml-config config.yaml --binary /path/to/ydbd
     ```

3. **Notes**:
   - If `ydbd_slice` is run without the `--yaml-config` parameter, a warning with instructions will be displayed.
