### PR TITLE
sysview: add access for database admins

### DIFF
--- a/ydb/core/sys_view/auth/users.cpp
+++ b/ydb/core/sys_view/auth/users.cpp
@@ -44,6 +44,12 @@ public:
 protected:
     void ProceedToScan() override {
         TBase::Become(&TUsersScan::StateScan);
+
+        //NOTE: here is the earliest point when Base::DatabaseOwner is already set
+        bool isClusterAdmin = IsAdministrator(AppData(), UserToken.Get());
+        bool isDatabaseAdmin = (AppData()->FeatureFlags.GetEnableDatabaseAdmin() && IsDatabaseAdministrator(UserToken.Get(), TBase::DatabaseOwner));
+        IsAdmin = isClusterAdmin || isDatabaseAdmin;
+
         if (TBase::AckReceived) {
             StartScan();
         }
@@ -97,9 +103,9 @@ protected:
         SortBatch(users, [](const auto* left, const auto* right) {
             return left->GetName() < right->GetName();
         });
-        
+
         TVector<TCell> cells(::Reserve(Columns.size()));
-        
+
         for (const auto* user : users) {
             for (auto& column : Columns) {
                 switch (column.Tag) {
@@ -156,7 +162,7 @@ protected:
 
 private:
     bool CanAccessUser(const TString& user) {
-        if (IsAdministrator(AppData(), UserToken.Get())) {
+        if (IsAdmin) {
             return true;
         }
 
@@ -165,6 +171,7 @@ private:
 
 private:
     const TIntrusiveConstPtr<NACLib::TUserToken> UserToken;
+    bool IsAdmin = false;
 };
 
 THolder<NActors::IActor> CreateUsersScan(const NActors::TActorId& ownerId, ui32 scanId, const TTableId& tableId,

--- a/ydb/core/sys_view/common/scan_actor_base_impl.h
+++ b/ydb/core/sys_view/common/scan_actor_base_impl.h
@@ -297,6 +297,8 @@ private:
         DomainKey = entry.DomainInfo->DomainKey;
 
         TenantName = CanonizePath(entry.Path);
+        DatabaseOwner = entry.Self->Info.GetOwner();
+        Y_ABORT_UNLESS(entry.Self->Info.GetOwner() == entry.SecurityObject->GetOwnerSID());
 
         TBase::Register(CreateTenantNodeEnumerationLookup(TBase::SelfId(), TenantName));
         TBase::Become(&TDerived::StateLookup);
@@ -313,9 +315,10 @@ private:
             "Scan prepared, actor: " << TBase::SelfId()
                 << ", schemeshard id: " << SchemeShardId
                 << ", hive id: " << HiveId
-                << ", tenant name: " << TenantName
+                << ", database: " << TenantName
+                << ", database owner: " << DatabaseOwner
                 << ", domain key: " << DomainKey
-                << ", tenant node count: " << TenantNodes.size());
+                << ", database node count: " << TenantNodes.size());
 
         ProceedToScan();
     }
@@ -370,6 +373,7 @@ protected:
     ui64 SchemeShardId = 0;
     TPathId DomainKey;
     TString TenantName;
+    NACLib::TSID DatabaseOwner;
     THashSet<ui32> TenantNodes;
     ui64 HiveId = 0;
     ui64 SysViewProcessorId = 0;

--- a/ydb/tests/functional/tenants/test_auth_system_views.py
+++ b/ydb/tests/functional/tenants/test_auth_system_views.py
@@ -1,0 +1,169 @@
+# -*- coding: utf-8 -*-
+import logging
+import copy
+
+import pytest
+
+from ydb.tests.oss.ydb_sdk_import import ydb
+from ydb.tests.library.harness.util import LogLevels
+from ydb.tests.library.harness.kikimr_config import KikimrConfigGenerator
+
+
+logger = logging.getLogger(__name__)
+
+
+# local configuration for the ydb cluster (fetched by ydb_cluster_configuration fixture)
+CLUSTER_CONFIG = dict(
+    additional_log_configs={
+        # more logs
+        'TX_PROXY': LogLevels.DEBUG,
+        'GRPC_SERVER': LogLevels.INFO,
+        'GRPC_PROXY_NO_CONNECT_ACCESS': LogLevels.DEBUG,
+        'FLAT_TX_SCHEMESHARD': LogLevels.INFO,
+        'SYSTEM_VIEWS': LogLevels.DEBUG,
+        'TICKET_PARSER': LogLevels.DEBUG,
+        # less logs
+        'KQP_PROXY': LogLevels.CRIT,
+        'KQP_WORKER': LogLevels.CRIT,
+        'KQP_GATEWAY': LogLevels.CRIT,
+        'GRPC_PROXY': LogLevels.ERROR,
+        'TX_DATASHARD': LogLevels.ERROR,
+        'TX_PROXY_SCHEME_CACHE': LogLevels.ERROR,
+        'KQP_YQL': LogLevels.ERROR,
+        'KQP_SESSION': LogLevels.CRIT,
+        'KQP_COMPILE_ACTOR': LogLevels.CRIT,
+        'PERSQUEUE_CLUSTER_TRACKER': LogLevels.CRIT,
+        'SCHEME_BOARD_SUBSCRIBER': LogLevels.CRIT,
+        'SCHEME_BOARD_POPULATOR': LogLevels.CRIT,
+    },
+    extra_feature_flags=[
+        'enable_strict_acl_check',
+        'enable_strict_user_management',
+        'enable_database_admin',
+    ],
+    # do not clutter logs with resource pools auto creation
+    enable_resource_pools=False,
+    enforce_user_token_requirement=True,
+    # make all bootstrap and setup under this user
+    default_clusteradmin='root@builtin',
+)
+
+
+# ydb_fixtures.ydb_cluster_configuration local override
+@pytest.fixture(scope='module')
+def ydb_cluster_configuration():
+    conf = copy.deepcopy(CLUSTER_CONFIG)
+    return conf
+
+
+@pytest.fixture(scope='module')
+def ydb_configurator(ydb_cluster_configuration):
+    config_generator = KikimrConfigGenerator(**ydb_cluster_configuration)
+    config_generator.yaml_config['auth_config'] = {
+        'domain_login_only': False,
+    }
+    config_generator.yaml_config['domains_config']['disable_builtin_security'] = True
+    security_config = config_generator.yaml_config['domains_config']['security_config']
+    security_config['administration_allowed_sids'].append('clusteradmin')
+    return config_generator
+
+
+def stream_query_result(driver, query):
+    it = driver.table_client.scan_query(query)
+    result = []
+    error = None
+
+    while True:
+        try:
+            response = next(it)
+        except StopIteration:
+            break
+        except ydb.issues.Error as e:
+            error = e
+            break
+
+        for row in response.result_set.rows:
+            result.append(row)
+
+    return result, error
+
+
+@pytest.fixture(scope='function')
+def prepared_test_env(ydb_cluster, ydb_root, ydb_database, ydb_client):
+    cluster_admin = ydb.AuthTokenCredentials(ydb_cluster.config.default_clusteradmin)
+
+    # prepare root database
+    with ydb_client(ydb_root, credentials=cluster_admin) as driver:
+        pool = ydb.SessionPool(driver)
+        with pool.checkout() as session:
+            session.execute_scheme("create user clusteradmin password '1234'")
+            session.execute_scheme("create user clusteruser password '1234'")
+
+    # prepare tenant database
+    database_path = ydb_database
+    with ydb_client(database_path, credentials=cluster_admin) as driver:
+        pool = ydb.SessionPool(driver)
+        with pool.checkout() as session:
+            # add users
+            session.execute_scheme("create user dbadmin password '1234'")
+            session.execute_scheme("create user ordinaryuser password '1234'")
+
+            # add group and its members
+            session.execute_scheme('create group dbadmins')
+            session.execute_scheme('alter group dbadmins add user dbadmin')
+
+            # add required permissions on paths
+            session.execute_scheme(f'grant "ydb.generic.use" on `{database_path}` to clusteradmin')
+            # shouldn't be possible but we allow that for the admin
+            session.execute_scheme(f'grant "ydb.generic.use" on `{database_path}` to clusteruser')
+            session.execute_scheme(f'grant "ydb.generic.use" on `{database_path}` to dbadmin')
+            session.execute_scheme(f'grant "ydb.generic.use" on `{database_path}` to ordinaryuser')
+
+        # make dbadmin the real admin of the database
+        driver.scheme_client.modify_permissions(database_path, ydb.ModifyPermissionsSettings().change_owner('dbadmin'))
+
+    return database_path
+
+
+# python sdk does not legally expose login method, so that is a crude way
+# to get auth-token in exchange to credentials
+def login_user(endpoint, database, user, password):
+    driver_config = ydb.DriverConfig(endpoint, database)
+    credentials = ydb.StaticCredentials(driver_config, user, password)
+    return credentials._make_token_request()['access_token']
+
+
+@pytest.mark.parametrize('user,expected_access', [
+    ('clusteradmin', True),
+    ('clusteruser', False),
+    ('dbadmin', True),
+    ('ordinaryuser', False)
+])
+def test_tenant_auth_groups_access(ydb_endpoint, ydb_root, prepared_test_env, ydb_client, user, expected_access):
+    tenant_database = prepared_test_env
+
+    # user could be either from the root or tenant database,
+    # but they must obtain auth token by logging in the database they live in
+    login_database = ydb_root if user.startswith('cluster') else tenant_database
+    user_auth_token = login_user(ydb_endpoint, login_database, user, '1234')
+    credentials = ydb.AuthTokenCredentials(user_auth_token)
+
+    with ydb_client(tenant_database, credentials=credentials) as driver:
+        driver.wait()
+
+        result, error = stream_query_result(driver, f'SELECT * FROM `{tenant_database}/.sys/auth_groups`')
+
+        # logger.debug('AAA result row count %s, error %s', len(result), error)
+
+        if expected_access:
+            assert error is None
+            assert len(result) == 1
+            assert result[0]['Sid'] == 'dbadmins'
+
+        else:
+            assert error is not None, result
+
+            # FIXME: status should have been UNAUTHORIZED
+            # assert error.status == ydb.issues.StatusCode.UNAUTHORIZED
+            assert error.status == ydb.issues.StatusCode.INTERNAL_ERROR
+            assert 'Administrator access is required' in error.message

--- a/ydb/tests/functional/tenants/ya.make
+++ b/ydb/tests/functional/tenants/ya.make
@@ -11,6 +11,7 @@ TEST_SRCS(
     test_tenants.py
     test_storage_config.py
     test_system_views.py
+    test_auth_system_views.py
     test_publish_into_schemeboard_with_common_ssring.py
     test_users_groups_with_acl.py
 )

--- a/ydb/tests/library/clients/kikimr_client.py
+++ b/ydb/tests/library/clients/kikimr_client.py
@@ -254,8 +254,10 @@ class KiKiMRMessageBusClient(object):
             raise RuntimeError('console_request failed: %s: %s' % (response.Status.Code, response.Status.Reason))
         return response
 
-    def add_config_item(self, config, cookie=None, raise_on_error=True):
+    def add_config_item(self, config, cookie=None, raise_on_error=True, token=None):
         request = msgbus.TConsoleRequest()
+        if token is not None:
+            request.SecurityToken = token
         action = request.ConfigureRequest.Actions.add()
         item = action.AddConfigItem.ConfigItem
         if isinstance(config, str) or isinstance(config, bytes):

--- a/ydb/tests/library/common/protobuf_console.py
+++ b/ydb/tests/library/common/protobuf_console.py
@@ -2,7 +2,7 @@
 # -*- coding: utf-8 -*-
 import ydb.core.protos.msgbus_pb2 as msgbus
 
-from ydb.tests.library.common.protobuf import AbstractProtobufBuilder
+from ydb.tests.library.common.protobuf import AbstractProtobufBuilder, to_bytes
 
 
 class CreateTenantRequest(AbstractProtobufBuilder):
@@ -13,6 +13,10 @@ class CreateTenantRequest(AbstractProtobufBuilder):
     def __init__(self, path):
         super(CreateTenantRequest, self).__init__(msgbus.TConsoleRequest())
         self.protobuf.CreateTenantRequest.Request.path = path
+
+    def set_user_token(self, token):
+        self.protobuf.SecurityToken = to_bytes(token)
+        self.protobuf.CreateTenantRequest.UserToken = to_bytes(token)
 
     def add_storage_pool(self, pool_type, pool_size):
         pool = self.protobuf.CreateTenantRequest.Request.resources.storage_units.add()
@@ -78,6 +82,10 @@ class AlterTenantRequest(AbstractProtobufBuilder):
         super(AlterTenantRequest, self).__init__(msgbus.TConsoleRequest())
         self.protobuf.AlterTenantRequest.Request.path = path
 
+    def set_user_token(self, token):
+        self.protobuf.SecurityToken = to_bytes(token)
+        self.protobuf.AlterTenantRequest.UserToken = to_bytes(token)
+
     def set_schema_quotas(self, schema_quotas):
         quotas = self.protobuf.AlterTenantRequest.Request.schema_operation_quotas
         quotas.SetInParent()
@@ -106,6 +114,10 @@ class GetTenantStatusRequest(AbstractProtobufBuilder):
         super(GetTenantStatusRequest, self).__init__(msgbus.TConsoleRequest())
         self.protobuf.GetTenantStatusRequest.Request.path = path
 
+    def set_user_token(self, token):
+        self.protobuf.SecurityToken = to_bytes(token)
+        self.protobuf.GetTenantStatusRequest.UserToken = to_bytes(token)
+
 
 class RemoveTenantRequest(AbstractProtobufBuilder):
     """
@@ -115,6 +127,10 @@ class RemoveTenantRequest(AbstractProtobufBuilder):
     def __init__(self, path):
         super(RemoveTenantRequest, self).__init__(msgbus.TConsoleRequest())
         self.protobuf.RemoveTenantRequest.Request.path = path
+
+    def set_user_token(self, token):
+        self.protobuf.SecurityToken = to_bytes(token)
+        self.protobuf.RemoveTenantRequest.UserToken = to_bytes(token)
 
 
 class SetConfigRequest(AbstractProtobufBuilder):
@@ -158,3 +174,6 @@ class GetOperationRequest(AbstractProtobufBuilder):
     def __init__(self, op_id):
         super(GetOperationRequest, self).__init__(msgbus.TConsoleRequest())
         self.protobuf.GetOperationRequest.id = op_id
+
+    def set_user_token(self, token):
+        self.protobuf.SecurityToken = to_bytes(token)

--- a/ydb/tests/library/harness/kikimr_cluster_interface.py
+++ b/ydb/tests/library/harness/kikimr_cluster_interface.py
@@ -110,35 +110,41 @@ class KiKiMRClusterInterface(object):
             )
         return self.__scheme_client
 
-    def get_database_status(self, database_name):
-        response = self.client.send_request(
-            GetTenantStatusRequest(database_name).protobuf,
-            method='ConsoleRequest'
-        ).GetTenantStatusResponse
+    def _send_get_tenant_status_request(self, database_name, token=None):
+        req = GetTenantStatusRequest(database_name)
+
+        if token is not None:
+            req.set_user_token(token)
+
+        return self.client.send_request(req.protobuf, method='ConsoleRequest').GetTenantStatusResponse
+
+    def get_database_status(self, database_name, token=None):
+        response = self._send_get_tenant_status_request(database_name, token=token)
 
         if response.Response.operation.status != StatusIds.SUCCESS:
             logger.critical("Console response status: %s", str(response.Response.operation.status))
             assert False
-            return False
 
         result = cms_tenants_pb.GetDatabaseStatusResult()
         response.Response.operation.result.Unpack(result)
         return result
 
-    def wait_tenant_up(self, database_name):
+    def wait_tenant_up(self, database_name, token=None):
         self.__wait_tenant_up(
             database_name,
-            expected_computational_units=1
+            expected_computational_units=1,
+            token=token,
         )
 
     def __wait_tenant_up(
             self,
             database_name,
             expected_computational_units=None,
-            timeout_seconds=120
+            timeout_seconds=120,
+            token=None
     ):
         def predicate():
-            result = self.get_database_status(database_name)
+            result = self.get_database_status(database_name, token=token)
 
             if expected_computational_units is None:
                 expected = set([2])
@@ -154,21 +160,25 @@ class KiKiMRClusterInterface(object):
         )
         assert tenant_running
 
-    def __get_console_op(self, op_id):
+    def __get_console_op(self, op_id, token=None):
         req = GetOperationRequest(op_id)
+
+        if token is not None:
+            req.set_user_token(token)
+
         response = self.client.send_request(req.protobuf, method='ConsoleRequest')
         operation = response.GetOperationResponse.operation
         if not operation.ready and response.Status.Code != StatusIds.STATUS_CODE_UNSPECIFIED:
             raise RuntimeError('get_console_op failed: %s: %s' % (response.Status.Code, response.Status.Reason))
         return operation
 
-    def __wait_console_op(self, op_id, timeout_seconds, step_seconds=0.5):
+    def __wait_console_op(self, op_id, timeout_seconds, step_seconds=0.5, token=None):
         deadline = time.time() + timeout_seconds
         while True:
             time.sleep(step_seconds)
             if time.time() >= deadline:
                 raise RuntimeError('wait_console_op: deadline exceeded')
-            operation = self.__get_console_op(op_id)
+            operation = self.__get_console_op(op_id, token=token)
             if operation.ready:
                 return operation
 
@@ -177,7 +187,8 @@ class KiKiMRClusterInterface(object):
             database_name,
             storage_pool_units_count,
             disable_external_subdomain=False,
-            timeout_seconds=120
+            timeout_seconds=120,
+            token=None,
     ):
         req = CreateTenantRequest(database_name)
         for storage_pool_type_name, units_count in storage_pool_units_count.items():
@@ -189,19 +200,23 @@ class KiKiMRClusterInterface(object):
         if disable_external_subdomain:
             req.disable_external_subdomain()
 
+        if token is not None:
+            req.set_user_token(token)
+
         response = self.client.send_request(req.protobuf, method='ConsoleRequest')
         operation = response.CreateTenantResponse.Response.operation
         if not operation.ready and response.Status.Code != StatusIds.STATUS_CODE_UNSPECIFIED:
             raise RuntimeError('create_database failed: %s: %s' % (response.Status.Code, response.Status.Reason))
         if not operation.ready:
-            operation = self.__wait_console_op(operation.id, timeout_seconds=timeout_seconds)
+            operation = self.__wait_console_op(operation.id, timeout_seconds=timeout_seconds, token=token)
         if operation.status != StatusIds.SUCCESS:
             raise RuntimeError('create_database failed: %s, %s' % (operation.status, ydb.issues._format_issues(operation.issues)))
 
         self.__wait_tenant_up(
             database_name,
             expected_computational_units=0,
-            timeout_seconds=timeout_seconds
+            timeout_seconds=timeout_seconds,
+            token=token,
         )
         return database_name
 
@@ -209,7 +224,8 @@ class KiKiMRClusterInterface(object):
             self,
             database_name,
             storage_pool_units_count,
-            timeout_seconds=120
+            timeout_seconds=120,
+            token=None,
     ):
         req = CreateTenantRequest(database_name)
         for storage_pool_type_name, units_count in storage_pool_units_count.items():
@@ -218,19 +234,23 @@ class KiKiMRClusterInterface(object):
                 units_count,
             )
 
+        if token is not None:
+            req.set_user_token(token)
+
         response = self.client.send_request(req.protobuf, method='ConsoleRequest')
         operation = response.CreateTenantResponse.Response.operation
         if not operation.ready and response.Status.Code != StatusIds.STATUS_CODE_UNSPECIFIED:
             raise RuntimeError('create_hostel_database failed: %s: %s' % (response.Status.Code, response.Status.Reason))
         if not operation.ready:
-            operation = self.__wait_console_op(operation.id, timeout_seconds=timeout_seconds)
+            operation = self.__wait_console_op(operation.id, timeout_seconds=timeout_seconds, token=token)
         if operation.status != StatusIds.SUCCESS:
             raise RuntimeError('create_hostel_database failed: %s' % (operation.status,))
 
         self.__wait_tenant_up(
             database_name,
             expected_computational_units=0,
-            timeout_seconds=timeout_seconds
+            timeout_seconds=timeout_seconds,
+            token=token,
         )
         return database_name
 
@@ -241,9 +261,13 @@ class KiKiMRClusterInterface(object):
             timeout_seconds=120,
             schema_quotas=None,
             disk_quotas=None,
-            attributes=None
+            attributes=None,
+            token=None,
     ):
         req = CreateTenantRequest(database_name)
+
+        if token is not None:
+            req.set_user_token(token)
 
         req.share_resources_with(hostel_db)
 
@@ -262,13 +286,14 @@ class KiKiMRClusterInterface(object):
         if not operation.ready and response.Status.Code != StatusIds.STATUS_CODE_UNSPECIFIED:
             raise RuntimeError('create_serverless_database failed: %s: %s' % (response.Status.Code, response.Status.Reason))
         if not operation.ready:
-            operation = self.__wait_console_op(operation.id, timeout_seconds=timeout_seconds)
+            operation = self.__wait_console_op(operation.id, timeout_seconds=timeout_seconds, token=token)
         if operation.status != StatusIds.SUCCESS:
             raise RuntimeError('create_serverless_database failed: %s' % (operation.status,))
 
         self.__wait_tenant_up(
             database_name,
-            timeout_seconds=timeout_seconds
+            timeout_seconds=timeout_seconds,
+            token=token,
         )
         return database_name
 
@@ -278,8 +303,12 @@ class KiKiMRClusterInterface(object):
             schema_quotas=None,
             disk_quotas=None,
             timeout_seconds=120,
+            token=None,
     ):
         req = AlterTenantRequest(database_name)
+
+        if token is not None:
+            req.set_user_token(token)
 
         assert schema_quotas is not None or disk_quotas is not None
 
@@ -294,33 +323,39 @@ class KiKiMRClusterInterface(object):
         if not operation.ready and response.Status.Code != StatusIds.STATUS_CODE_UNSPECIFIED:
             raise RuntimeError('alter_serverless_database failed: %s: %s' % (response.Status.Code, response.Status.Reason))
         if not operation.ready:
-            operation = self.__wait_console_op(operation.id, timeout_seconds=timeout_seconds)
+            operation = self.__wait_console_op(operation.id, timeout_seconds=timeout_seconds, token=token)
         if operation.status != StatusIds.SUCCESS:
             raise RuntimeError('alter_serverless_database failed: %s' % (operation.status,))
 
         self.__wait_tenant_up(
             database_name,
-            timeout_seconds=timeout_seconds
+            timeout_seconds=timeout_seconds,
+            token=token,
         )
         return database_name
 
     def remove_database(
             self,
             database_name,
-            timeout_seconds=20
+            timeout_seconds=20,
+            token=None,
     ):
         logger.debug(database_name)
 
-        operation_id = self._remove_database_send_op(database_name)
-        self._remove_database_wait_op(database_name, operation_id, timeout_seconds=timeout_seconds)
-        self._remove_database_wait_tenant_gone(database_name, timeout_seconds=timeout_seconds)
+        operation_id = self._remove_database_send_op(database_name, token=token)
+        self._remove_database_wait_op(database_name, operation_id, timeout_seconds=timeout_seconds, token=token)
+        self._remove_database_wait_tenant_gone(database_name, timeout_seconds=timeout_seconds, token=token)
 
         return database_name
 
-    def _remove_database_send_op(self, database_name):
-        logger.debug('%s: send console operation', database_name)
+    def _remove_database_send_op(self, database_name, token=None):
+        logger.debug('%s: send console operation, token %s', database_name, token)
 
         req = RemoveTenantRequest(database_name)
+
+        if token is not None:
+            req.set_user_token(token)
+
         response = self.client.send_request(req.protobuf, method='ConsoleRequest')
         operation = response.RemoveTenantResponse.Response.operation
         logger.debug('%s: response from console: %s', database_name, response)
@@ -330,20 +365,19 @@ class KiKiMRClusterInterface(object):
 
         return operation.id
 
-    def _remove_database_wait_op(self, database_name, operation_id, timeout_seconds=20):
+    def _remove_database_wait_op(self, database_name, operation_id, timeout_seconds=20, token=None):
         logger.debug('%s: wait console operation done', database_name)
-        operation = self.__wait_console_op(operation_id, timeout_seconds=timeout_seconds)
+        operation = self.__wait_console_op(operation_id, timeout_seconds=timeout_seconds, token=token)
         logger.debug('%s: console operation done', database_name)
 
         if operation.status not in (StatusIds.SUCCESS, StatusIds.NOT_FOUND):
             raise RuntimeError('remove_database failed: %s' % (operation.status,))
 
-    def _remove_database_wait_tenant_gone(self, database_name, timeout_seconds=20):
+    def _remove_database_wait_tenant_gone(self, database_name, timeout_seconds=20, token=None):
         logger.debug('%s: wait tenant gone', database_name)
 
         def predicate():
-            response = self.client.send_request(
-                GetTenantStatusRequest(database_name).protobuf, method='ConsoleRequest').GetTenantStatusResponse
+            response = self._send_get_tenant_status_request(database_name, token=token)
             return response.Response.operation.status == StatusIds.NOT_FOUND
 
         tenant_not_found = wait_for(


### PR DESCRIPTION
Give database admins the same unlimited rights to view system views about users, groups, and their permissions as cluster admins have.

For the ordinary users:
- `.sys/auth_groups` and `.sys/auth_group_members` are closed
- `.sys/auth_users` is filtered to show only the user himself

Cluster admins and now database admins do not have those restrictions.

Stacked on:
- https://github.com/ydb-platform/ydb/pull/15130
