### PR TITLE
Rename EncryptFile/DecryptFile to avoid conflict with windows functions

### DIFF
--- a/ydb/core/backup/common/encryption.cpp
+++ b/ydb/core/backup/common/encryption.cpp
@@ -387,7 +387,7 @@ TBuffer TEncryptedFileSerializer::AddBlock(TStringBuf data, bool last) {
     return Impl->AddBlock(data, last);
 }
 
-TBuffer TEncryptedFileSerializer::EncryptFile(TString algorithm, TEncryptionKey key, TEncryptionIV iv, TStringBuf data) {
+TBuffer TEncryptedFileSerializer::EncryptFullFile(TString algorithm, TEncryptionKey key, TEncryptionIV iv, TStringBuf data) {
     TEncryptedFileSerializer serializer(std::move(algorithm), std::move(key), std::move(iv));
     return serializer.AddBlock(data, true);
 }
@@ -853,7 +853,7 @@ std::pair<TBuffer, TEncryptionIV> TEncryptedFileDeserializer::DecryptFile(TEncry
     return {std::move(*result), deserializer.GetIV()};
 }
 
-TBuffer TEncryptedFileDeserializer::DecryptFile(TEncryptionKey key, TEncryptionIV expectedIV, TBuffer data) {
+TBuffer TEncryptedFileDeserializer::DecryptFullFile(TEncryptionKey key, TEncryptionIV expectedIV, TBuffer data) {
     TEncryptedFileDeserializer deserializer(std::move(key), std::move(expectedIV));
     deserializer.AddData(std::move(data), true);
 

--- a/ydb/core/backup/common/encryption.h
+++ b/ydb/core/backup/common/encryption.h
@@ -181,7 +181,7 @@ public:
     TBuffer AddBlock(TStringBuf data, bool last);
 
     // Helper that serializes the whole file at one time
-    static TBuffer EncryptFile(TString algorithm, TEncryptionKey key, TEncryptionIV iv, TStringBuf data);
+    static TBuffer EncryptFullFile(TString algorithm, TEncryptionKey key, TEncryptionIV iv, TStringBuf data);
 
 private:
     class TImpl;
@@ -224,7 +224,7 @@ public:
 
     // Helper that deserializes the whole file at one time
     static std::pair<TBuffer, TEncryptionIV> DecryptFile(TEncryptionKey key, TBuffer data);
-    static TBuffer DecryptFile(TEncryptionKey key, TEncryptionIV expectedIV, TBuffer data);
+    static TBuffer DecryptFullFile(TEncryptionKey key, TEncryptionIV expectedIV, TBuffer data);
 
 private:
     class TImpl;


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

...

### Changelog category <!-- remove all except one -->

* Not for changelog (changelog entry is not required)

### Description for reviewers <!-- (optional) description for those who read this PR -->

These methods conflict with windows macros that turn them into EncryptFileA/EncryptFileW.
