### PR TITLE
Return storage pool kind in TChannelBind

### DIFF
--- a/ydb/core/grpc_services/rpc_keyvalue.cpp
+++ b/ydb/core/grpc_services/rpc_keyvalue.cpp
@@ -572,7 +572,7 @@ protected:
         auto *storageConfig = result.mutable_storage_config();
         for (auto &channel : desc.GetBoundChannels()) {
             auto *channelBind = storageConfig->add_channel();
-            channelBind->set_media(channel.GetStoragePoolName());
+            channelBind->set_media(channel.GetStoragePoolKind());
         }
         this->ReplyWithResult(Ydb::StatusIds::SUCCESS, result, TActivationContext::AsActorContext());
     }
@@ -645,7 +645,6 @@ public:
     }
 
     STFUNC(StateWork) {
-        Cerr << "TAlterVolumeRequest::StateWork; received event: " << ev->GetTypeName() << Endl;
         switch (ev->GetTypeRewrite()) {
             hFunc(TEvTxProxySchemeCache::TEvNavigateKeySetResult, Handle);
         default:
@@ -664,7 +663,7 @@ public:
         const NKikimrSchemeOp::TSolomonVolumeDescription &desc = request->ResultSet[0].SolomonVolumeInfo->Description;
         for (auto &channel : desc.GetBoundChannels()) {
             auto *channelBind = StorageConfig.add_channel();
-            channelBind->set_media(channel.GetStoragePoolName());
+            channelBind->set_media(channel.GetStoragePoolKind());
         }
         SendProposeRequest(TActivationContext::AsActorContext());
     }

--- a/ydb/core/protos/bind_channel_storage_pool.proto
+++ b/ydb/core/protos/bind_channel_storage_pool.proto
@@ -9,6 +9,7 @@ message TStoragePool {
 message TChannelBind {
     //optional uint32 Channel = 1; // it should be equal to array index, so it doesn't make any sense to have one
     optional string StoragePoolName = 2;
+    optional string StoragePoolKind = 3;
     optional float IOPS = 10;
     optional uint64 Throughput = 11;
     optional uint64 Size = 12;

--- a/ydb/core/tx/schemeshard/schemeshard_path_describer.cpp
+++ b/ydb/core/tx/schemeshard/schemeshard_path_describer.cpp
@@ -780,6 +780,11 @@ void TPathDescriber::DescribeSolomonVolume(TPathId pathId, TPathElement::TPtr pa
     Y_ABORT_UNLESS(it, "SolomonVolume is not found");
     TSolomonVolumeInfo::TPtr solomonVolumeInfo = *it;
 
+    TPathId domainId = pathEl->DomainPathId;
+    Y_ABORT_UNLESS(domainId != InvalidPathId);
+    auto domainInfo = Self->ResolveDomainInfo(domainId);
+    Y_ABORT_UNLESS(domainInfo, "Domain info is not found");
+
     auto entry = Result->Record.MutablePathDescription()->MutableSolomonDescription();
     entry->SetName(pathEl->Name);
     entry->SetPathId(pathId.LocalPathId);

--- a/ydb/core/tx/schemeshard/schemeshard_path_describer.cpp
+++ b/ydb/core/tx/schemeshard/schemeshard_path_describer.cpp
@@ -780,11 +780,6 @@ void TPathDescriber::DescribeSolomonVolume(TPathId pathId, TPathElement::TPtr pa
     Y_ABORT_UNLESS(it, "SolomonVolume is not found");
     TSolomonVolumeInfo::TPtr solomonVolumeInfo = *it;
 
-    TPathId domainId = pathEl->DomainPathId;
-    Y_ABORT_UNLESS(domainId != InvalidPathId);
-    auto domainInfo = Self->ResolveDomainInfo(domainId);
-    Y_ABORT_UNLESS(domainInfo, "Domain info is not found");
-
     auto entry = Result->Record.MutablePathDescription()->MutableSolomonDescription();
     entry->SetName(pathEl->Name);
     entry->SetPathId(pathId.LocalPathId);

--- a/ydb/services/keyvalue/grpc_service_ut.cpp
+++ b/ydb/services/keyvalue/grpc_service_ut.cpp
@@ -30,29 +30,10 @@
 namespace NKikimr::NGRpcService {
 
 
-struct TKikimrTestSettings {
-    static constexpr bool SSL = false;
-    static constexpr bool AUTH = false;
-    static constexpr bool PrecreatePools = true;
-    static constexpr bool EnableSystemViews = true;
-};
 
-struct TKikimrTestWithAuth : TKikimrTestSettings {
-    static constexpr bool AUTH = true;
-};
-
-struct TKikimrTestWithAuthAndSsl : TKikimrTestWithAuth {
-    static constexpr bool SSL = true;
-};
-
-struct TKikimrTestNoSystemViews : TKikimrTestSettings {
-    static constexpr bool EnableSystemViews = false;
-};
-
-template <typename TestSettings = TKikimrTestSettings>
-class TBasicKikimrWithGrpcAndRootSchema {
+class TKikimrWithGrpcAndRootSchema {
 public:
-    TBasicKikimrWithGrpcAndRootSchema(
+    TKikimrWithGrpcAndRootSchema(
             NKikimrConfig::TAppConfig appConfig = {},
             TAutoPtr<TLogBackend> logBackend = {})
     {
@@ -63,19 +44,13 @@ public:
         ServerSettings->SetLogBackend(logBackend);
         ServerSettings->SetDomainName("Root");
         ServerSettings->SetDynamicNodeCount(1);
-        if (TestSettings::PrecreatePools) {
-            ServerSettings->AddStoragePool("ssd");
-            ServerSettings->AddStoragePool("hdd");
-            ServerSettings->AddStoragePool("hdd1");
-            ServerSettings->AddStoragePool("hdd2");
-        } else {
-            ServerSettings->AddStoragePoolType("ssd");
-            ServerSettings->AddStoragePoolType("hdd");
-            ServerSettings->AddStoragePoolType("hdd1");
-            ServerSettings->AddStoragePoolType("hdd2");
-        }
+        ServerSettings->AddStoragePool("ssd", "ssd-pool");
+        ServerSettings->AddStoragePool("hdd", "hdd-pool");
+        ServerSettings->AddStoragePool("hdd1", "hdd1-pool");
+        ServerSettings->AddStoragePool("hdd2", "hdd2-pool");
         ServerSettings->Formats = new TFormatFactory;
         ServerSettings->FeatureFlags = appConfig.GetFeatureFlags();
+        ServerSettings->FeatureFlags.SetAllowUpdateChannelsBindingOfSolomonPartitions(true);
         ServerSettings->RegisterGrpcService<NKikimr::NGRpcService::TKeyValueGRpcService>("keyvalue");
 
         Server_.Reset(new Tests::TServer(*ServerSettings));
@@ -101,9 +76,6 @@ public:
         //Server_->GetRuntime()->SetLogPriority(NKikimrServices::TX_COLUMNSHARD, NActors::NLog::PRI_DEBUG);
 
         NYdbGrpc::TServerOptions grpcOption;
-        if (TestSettings::AUTH) {
-            grpcOption.SetUseAuth(true);
-        }
         grpcOption.SetPort(grpc);
         Server_->EnableGRpc(grpcOption);
 
@@ -145,7 +117,6 @@ private:
     ui16 GRpcPort_;
 };
 
-using TKikimrWithGrpcAndRootSchema = TBasicKikimrWithGrpcAndRootSchema<TKikimrTestSettings>;
 
 Y_UNIT_TEST_SUITE(KeyValueGRPCService) {
 
@@ -237,13 +208,20 @@ Y_UNIT_TEST_SUITE(KeyValueGRPCService) {
         createVolumeResponse.operation().result().UnpackTo(&createVolumeResult);
     }
 
-    void AlterVolume(auto &channel, const TString &path, ui32 partition_count = 1) {
+    void AlterVolume(auto &channel, const TString &path, ui32 partition_count = 1, std::optional<Ydb::KeyValue::StorageConfig> storage_config = {}) {
         std::unique_ptr<Ydb::KeyValue::V1::KeyValueService::Stub> stub;
         stub = Ydb::KeyValue::V1::KeyValueService::NewStub(channel);
 
         Ydb::KeyValue::AlterVolumeRequest alterVolumeRequest;
         alterVolumeRequest.set_path(path);
         alterVolumeRequest.set_alter_partition_count(partition_count);
+        if (storage_config) {
+            auto *storageConfig = alterVolumeRequest.mutable_storage_config();
+            for (const auto &channel : storage_config->channel()) {
+                auto *channelBind = storageConfig->add_channel();
+                channelBind->set_media(channel.media());
+            }
+        }
 
         Ydb::KeyValue::AlterVolumeResponse alterVolumeResponse;
         Ydb::KeyValue::AlterVolumeResult alterVolumeResult;
@@ -825,6 +803,15 @@ Y_UNIT_TEST_SUITE(KeyValueGRPCService) {
 
         describeVolumeResult = DescribeVolume(channel, tablePath);
         UNIT_ASSERT_VALUES_EQUAL(2, describeVolumeResult.partition_count());
+        UNIT_ASSERT(describeVolumeResult.has_storage_config());
+        UNIT_ASSERT_VALUES_EQUAL(describeVolumeResult.storage_config().channel_size(), 3);
+        for (const auto& channel : describeVolumeResult.storage_config().channel()) {
+            UNIT_ASSERT_VALUES_EQUAL(channel.media(), "ssd");
+        }
+
+        AlterVolume(channel, tablePath, 3, describeVolumeResult.storage_config());
+        describeVolumeResult = DescribeVolume(channel, tablePath);
+        UNIT_ASSERT_VALUES_EQUAL(3, describeVolumeResult.partition_count());
         UNIT_ASSERT(describeVolumeResult.has_storage_config());
         UNIT_ASSERT_VALUES_EQUAL(describeVolumeResult.storage_config().channel_size(), 3);
         for (const auto& channel : describeVolumeResult.storage_config().channel()) {


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

Describe volume required storage pool kinds of channels instead of their names. Now we set pool kind in TChannelBind and use it in grpc request

### Changelog category <!-- remove all except one -->

* Not for changelog (changelog entry is not required)

### Description for reviewers <!-- (optional) description for those who read this PR -->

...
