### PR TITLE
Add UNAUTHORIZED status to dq

### DIFF
--- a/ydb/core/kqp/compute_actor/kqp_pure_compute_actor.cpp
+++ b/ydb/core/kqp/compute_actor/kqp_pure_compute_actor.cpp
@@ -283,7 +283,7 @@ void TKqpComputeActor::HandleExecute(TEvKqpCompute::TEvScanError::TPtr& ev) {
     IssuesFromMessage(ev->Get()->Record.GetIssues(), issues);
 
     State = NDqProto::COMPUTE_STATE_FAILURE;
-    ReportStateAndMaybeDie(YdbStatusToDqStatus(status), issues);
+    ReportStateAndMaybeDie(YdbStatusToDqStatus(status, EStatusCompatibilityLevel::WithUnauthorized), issues);
 }
 
 IActor* CreateKqpComputeActor(const TActorId& executerId, ui64 txId, NDqProto::TDqTask* task,

--- a/ydb/core/sys_view/ut_kqp.cpp
+++ b/ydb/core/sys_view/ut_kqp.cpp
@@ -150,7 +150,7 @@ void SetupAuthAccessEnvironment(TTestEnv& env) {
 }
 
 void CheckAuthAdministratorAccessIsRequired(TScanQueryPartIterator& it) {
-    NKqp::StreamResultToYson(it, false, EStatus::INTERNAL_ERROR, 
+    NKqp::StreamResultToYson(it, false, EStatus::UNAUTHORIZED, 
         "Administrator access is required");
 }
 

--- a/ydb/library/yql/dq/actors/dq.cpp
+++ b/ydb/library/yql/dq/actors/dq.cpp
@@ -32,6 +32,8 @@ Ydb::StatusIds::StatusCode DqStatusToYdbStatus(NYql::NDqProto::StatusIds::Status
         return Ydb::StatusIds::SCHEME_ERROR;
     case NYql::NDqProto::StatusIds::UNSUPPORTED:
         return Ydb::StatusIds::UNSUPPORTED;
+    case NYql::NDqProto::StatusIds::UNAUTHORIZED:
+        return Ydb::StatusIds::UNAUTHORIZED;
     case NYql::NDqProto::StatusIds::GENERIC_ERROR:
     default:
         return Ydb::StatusIds::GENERIC_ERROR;
@@ -47,6 +49,7 @@ NYql::NDqProto::StatusIds::StatusCode YdbStatusToDqStatus(Ydb::StatusIds::Status
     case Ydb::StatusIds::BAD_REQUEST:
         return NYql::NDqProto::StatusIds::BAD_REQUEST;
     case Ydb::StatusIds::UNAUTHORIZED:
+        return NYql::NDqProto::StatusIds::UNAUTHORIZED;
     case Ydb::StatusIds::INTERNAL_ERROR:
         return NYql::NDqProto::StatusIds::INTERNAL_ERROR;
     case Ydb::StatusIds::ABORTED:

--- a/ydb/library/yql/dq/actors/dq.cpp
+++ b/ydb/library/yql/dq/actors/dq.cpp
@@ -40,7 +40,7 @@ Ydb::StatusIds::StatusCode DqStatusToYdbStatus(NYql::NDqProto::StatusIds::Status
     }
 }
 
-NYql::NDqProto::StatusIds::StatusCode YdbStatusToDqStatus(Ydb::StatusIds::StatusCode statusCode) {
+NYql::NDqProto::StatusIds::StatusCode YdbStatusToDqStatus(Ydb::StatusIds::StatusCode statusCode, EStatusCompatibilityLevel compatibility) {
     switch(statusCode) {
     case Ydb::StatusIds::STATUS_CODE_UNSPECIFIED:
         return NYql::NDqProto::StatusIds::UNSPECIFIED;
@@ -49,7 +49,9 @@ NYql::NDqProto::StatusIds::StatusCode YdbStatusToDqStatus(Ydb::StatusIds::Status
     case Ydb::StatusIds::BAD_REQUEST:
         return NYql::NDqProto::StatusIds::BAD_REQUEST;
     case Ydb::StatusIds::UNAUTHORIZED:
-        return NYql::NDqProto::StatusIds::UNAUTHORIZED;
+        return compatibility >= EStatusCompatibilityLevel::WithUnauthorized
+            ? NYql::NDqProto::StatusIds::UNAUTHORIZED
+            : NYql::NDqProto::StatusIds::INTERNAL_ERROR;
     case Ydb::StatusIds::INTERNAL_ERROR:
         return NYql::NDqProto::StatusIds::INTERNAL_ERROR;
     case Ydb::StatusIds::ABORTED:

--- a/ydb/library/yql/dq/actors/dq.h
+++ b/ydb/library/yql/dq/actors/dq.h
@@ -11,8 +11,13 @@
 
 namespace NYql::NDq {
 
+enum class EStatusCompatibilityLevel {
+    Basic,
+    WithUnauthorized
+};
+
 Ydb::StatusIds::StatusCode DqStatusToYdbStatus(NYql::NDqProto::StatusIds::StatusCode statusCode);
-NYql::NDqProto::StatusIds::StatusCode YdbStatusToDqStatus(Ydb::StatusIds::StatusCode statusCode);
+NYql::NDqProto::StatusIds::StatusCode YdbStatusToDqStatus(Ydb::StatusIds::StatusCode statusCode, EStatusCompatibilityLevel compatibility = EStatusCompatibilityLevel::Basic);
 
 struct TEvDq {
 

--- a/ydb/library/yql/dq/actors/protos/dq_status_codes.proto
+++ b/ydb/library/yql/dq/actors/protos/dq_status_codes.proto
@@ -22,5 +22,6 @@ message StatusIds {
         SCHEME_ERROR = 14;
         GENERIC_ERROR = 15;
         UNDETERMINED =  16;
+        UNAUTHORIZED =  17;
     }
 }

--- a/ydb/tests/functional/tenants/test_auth_system_views.py
+++ b/ydb/tests/functional/tenants/test_auth_system_views.py
@@ -162,8 +162,5 @@ def test_tenant_auth_groups_access(ydb_endpoint, ydb_root, prepared_test_env, yd
 
         else:
             assert error is not None, result
-
-            # FIXME: status should have been UNAUTHORIZED
-            # assert error.status == ydb.issues.StatusCode.UNAUTHORIZED
-            assert error.status == ydb.issues.StatusCode.INTERNAL_ERROR
+            assert error.status == ydb.issues.StatusCode.UNAUTHORIZED
             assert 'Administrator access is required' in error.message


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

...

### Changelog category <!-- remove all except one -->

* Not for changelog (changelog entry is not required)

### Description for reviewers <!-- (optional) description for those who read this PR -->

In order to correctly pass unauthorised status from Sys View scan we need it to be handled in Dq

https://github.com/kunga/ydb/blob/750a898378619f7cd0cbede30cd9c1c4db54b850/ydb/core/kqp/compute_actor/kqp_pure_compute_actor.cpp#L286
