### PR TITLE
Switch to library/cpp/charset/lite to avoid unneded dependency on libiconv

### DIFF
--- a/ydb/core/scheme/ya.make
+++ b/ydb/core/scheme/ya.make
@@ -12,7 +12,7 @@ SRCS(
 
 PEERDIR(
     ydb/library/actors/core
-    library/cpp/charset
+    library/cpp/charset/lite
     library/cpp/containers/bitseq
     library/cpp/deprecated/enum_codegen
     library/cpp/yson

--- a/ydb/core/tablet_flat/test/tool/perf/ya.make
+++ b/ydb/core/tablet_flat/test/tool/perf/ya.make
@@ -7,7 +7,7 @@ SRCS(
 
 PEERDIR(
     ydb/core/tablet_flat/test/libs/table
-    library/cpp/charset
+    library/cpp/charset/lite
     library/cpp/getopt
     ydb/core/tablet_flat
     yql/essentials/sql/pg_dummy

--- a/ydb/library/actors/prof/ya.make
+++ b/ydb/library/actors/prof/ya.make
@@ -7,7 +7,7 @@ SRCS(
 
 PEERDIR(
     contrib/libs/tcmalloc/malloc_extension
-    library/cpp/charset
+    library/cpp/charset/lite
     library/cpp/containers/atomizer
 )
 

--- a/ydb/library/workload/tpcds/ya.make
+++ b/ydb/library/workload/tpcds/ya.make
@@ -50,7 +50,7 @@ ALL_RESOURCE_FILES_FROM_DIRS(
 )
 
 PEERDIR(
-    library/cpp/charset
+    library/cpp/charset/lite
     library/cpp/resource
     ydb/library/accessor
     ydb/library/workload/tpc_base


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

Switch to library/cpp/charset/lite to avoid unneded dependency on libiconv

### Changelog category <!-- remove all except one -->

* Improvement

### Description for reviewers <!-- (optional) description for those who read this PR -->

...
