### PR TITLE
Prefixed vector index construction

### DIFF
--- a/ydb/core/kqp/opt/logical/kqp_opt_log_indexes.cpp
+++ b/ydb/core/kqp/opt/logical/kqp_opt_log_indexes.cpp
@@ -150,7 +150,7 @@ bool CanUseVectorIndex(const TIndexDescription& indexDesc, const TExprBase& lamb
     // TODO(mbkkt) We need to account top.Count(), but not clear what to if it's value is runtime?
     auto checkMember = [&] (const TExprBase& expr) {
         auto member = expr.Maybe<TCoMember>();
-        return member && member.Cast().Name().Value() == indexDesc.KeyColumns[0];
+        return member && member.Cast().Name().Value() == indexDesc.KeyColumns.back();
     };
     auto checkUdf = [&] (const TExprBase& expr, bool checkMembers) {
         auto apply = expr.Maybe<TCoApply>();
@@ -452,7 +452,7 @@ TExprBase DoRewriteTopSortOverKMeansTree(
             auto apply = newLambda.Body().Cast<TCoApply>();
             for (auto arg : apply.Args()) {
                 auto oldMember = arg.Maybe<TCoMember>();
-                if (oldMember && oldMember.Cast().Name().Value() == indexDesc.KeyColumns[0]) {
+                if (oldMember && oldMember.Cast().Name().Value() == indexDesc.KeyColumns.back()) {
                     auto newMember = Build<TCoMember>(ctx, pos)
                         .Name().Build(NTableIndex::NTableVectorKmeansTreeIndex::CentroidColumn)
                         .Struct(oldMember.Cast().Struct())

--- a/ydb/core/kqp/ut/indexes/kqp_indexes_ut.cpp
+++ b/ydb/core/kqp/ut/indexes/kqp_indexes_ut.cpp
@@ -2350,7 +2350,7 @@ Y_UNIT_TEST_SUITE(KqpIndexes) {
         return session;
     }
 
-    Y_UNIT_TEST(VectorIndexOrderByCosineDistanceNotNullableLevel1) {
+    Y_UNIT_TEST(SimpleVectorIndexOrderByCosineDistanceNotNullableLevel1) {
         NKikimrConfig::TFeatureFlags featureFlags;
         featureFlags.SetEnableVectorIndex(true);
         auto setting = NKikimrKqp::TKqpSetting();
@@ -2392,7 +2392,7 @@ Y_UNIT_TEST_SUITE(KqpIndexes) {
         DoPositiveQueriesVectorIndexOrderByCosine(session);
     }
 
-    Y_UNIT_TEST(VectorIndexOrderByCosineSimilarityNotNullableLevel1) {
+    Y_UNIT_TEST(SimpleVectorIndexOrderByCosineSimilarityNotNullableLevel1) {
         NKikimrConfig::TFeatureFlags featureFlags;
         featureFlags.SetEnableVectorIndex(true);
         auto setting = NKikimrKqp::TKqpSetting();
@@ -2434,7 +2434,7 @@ Y_UNIT_TEST_SUITE(KqpIndexes) {
         DoPositiveQueriesVectorIndexOrderByCosine(session);
     }
 
-    Y_UNIT_TEST(VectorIndexOrderByCosineDistanceNullableLevel1) {
+    Y_UNIT_TEST(SimpleVectorIndexOrderByCosineDistanceNullableLevel1) {
         NKikimrConfig::TFeatureFlags featureFlags;
         featureFlags.SetEnableVectorIndex(true);
         auto setting = NKikimrKqp::TKqpSetting();
@@ -2476,7 +2476,7 @@ Y_UNIT_TEST_SUITE(KqpIndexes) {
         DoPositiveQueriesVectorIndexOrderByCosine(session);
     }
 
-    Y_UNIT_TEST(VectorIndexOrderByCosineSimilarityNullableLevel1) {
+    Y_UNIT_TEST(SimpleVectorIndexOrderByCosineSimilarityNullableLevel1) {
         NKikimrConfig::TFeatureFlags featureFlags;
         featureFlags.SetEnableVectorIndex(true);
         auto setting = NKikimrKqp::TKqpSetting();
@@ -2518,7 +2518,7 @@ Y_UNIT_TEST_SUITE(KqpIndexes) {
         DoPositiveQueriesVectorIndexOrderByCosine(session);
     }
 
-    Y_UNIT_TEST(VectorIndexOrderByCosineDistanceNotNullableLevel2) {
+    Y_UNIT_TEST(SimpleVectorIndexOrderByCosineDistanceNotNullableLevel2) {
         NKikimrConfig::TFeatureFlags featureFlags;
         featureFlags.SetEnableVectorIndex(true);
         auto setting = NKikimrKqp::TKqpSetting();
@@ -2560,7 +2560,7 @@ Y_UNIT_TEST_SUITE(KqpIndexes) {
         DoPositiveQueriesVectorIndexOrderByCosine(session);
     }
 
-    Y_UNIT_TEST(VectorIndexOrderByCosineSimilarityNotNullableLevel2) {
+    Y_UNIT_TEST(SimpleVectorIndexOrderByCosineSimilarityNotNullableLevel2) {
         NKikimrConfig::TFeatureFlags featureFlags;
         featureFlags.SetEnableVectorIndex(true);
         auto setting = NKikimrKqp::TKqpSetting();
@@ -2602,7 +2602,7 @@ Y_UNIT_TEST_SUITE(KqpIndexes) {
         DoPositiveQueriesVectorIndexOrderByCosine(session);
     }
 
-    Y_UNIT_TEST(VectorIndexOrderByCosineDistanceNullableLevel2) {
+    Y_UNIT_TEST(SimpleVectorIndexOrderByCosineDistanceNullableLevel2) {
         NKikimrConfig::TFeatureFlags featureFlags;
         featureFlags.SetEnableVectorIndex(true);
         auto setting = NKikimrKqp::TKqpSetting();
@@ -2644,7 +2644,7 @@ Y_UNIT_TEST_SUITE(KqpIndexes) {
         DoPositiveQueriesVectorIndexOrderByCosine(session);
     }
 
-    Y_UNIT_TEST(VectorIndexOrderByCosineSimilarityNullableLevel2) {
+    Y_UNIT_TEST(SimpleVectorIndexOrderByCosineSimilarityNullableLevel2) {
         NKikimrConfig::TFeatureFlags featureFlags;
         featureFlags.SetEnableVectorIndex(true);
         auto setting = NKikimrKqp::TKqpSetting();
@@ -2684,6 +2684,545 @@ Y_UNIT_TEST_SUITE(KqpIndexes) {
             UNIT_ASSERT_EQUAL(settings.Clusters, 2);
         }
         DoPositiveQueriesVectorIndexOrderByCosine(session);
+    }
+
+    std::vector<i64> DoPositiveQueryPrefixedVectorIndex(TSession& session, const TString& query) {
+        {
+            auto result = session.ExplainDataQuery(query).ExtractValueSync();
+            UNIT_ASSERT_C(result.IsSuccess(),
+                "Failed to explain: `" << query << "` with " << result.GetIssues().ToString());
+        }
+        {
+            auto result = session.ExecuteDataQuery(query,
+                TTxControl::BeginTx(TTxSettings::SerializableRW()).CommitTx()
+            ).ExtractValueSync();
+            UNIT_ASSERT_C(result.IsSuccess(),
+                "Failed to execute: `" << query << "` with " << result.GetIssues().ToString());
+
+            std::vector<i64> r;
+            auto sets = result.GetResultSets();
+            for (const auto& set : sets) {
+                TResultSetParser parser{set};
+                while (parser.TryNextRow()) {
+                    auto value = parser.GetValue("pk");
+                    UNIT_ASSERT_C(value.GetProto().has_int64_value(), value.GetProto().ShortUtf8DebugString());
+                    r.push_back(value.GetProto().int64_value());
+                }
+            }
+            return r;
+        }
+    }
+
+    void DoPositiveQueriesPrefixedVectorIndex(TSession& session, const TString& mainQuery, const TString& indexQuery) {
+        // TODO(mbkkt) results are not precise so for now can differ between main and index
+        // But they're still should contains exactly 3 unique rows
+        auto mainResults = DoPositiveQueryPrefixedVectorIndex(session, mainQuery);
+        UNIT_ASSERT_EQUAL(mainResults.size(), 3);
+        auto indexResults = DoPositiveQueryPrefixedVectorIndex(session, indexQuery);
+        UNIT_ASSERT_EQUAL(indexResults.size(), 3);
+
+        absl::c_sort(mainResults);
+        UNIT_ASSERT(std::unique(mainResults.begin(), mainResults.end()) == mainResults.end());
+
+        absl::c_sort(indexResults);
+        UNIT_ASSERT(std::unique(indexResults.begin(), indexResults.end()) == indexResults.end());
+    }
+
+    void DoPositiveQueriesPrefixedVectorIndexOrderBy(
+        TSession& session,
+        std::string_view function,
+        std::string_view direction,
+        std::string_view left,
+        std::string_view right) {
+        constexpr std::string_view target = "$target = \"\x67\x73\x03\";";
+        std::string metric = std::format("Knn::{}({}, {})", function, left, right);
+        // no metric in result
+        {
+            const TString plainQuery(Q1_(std::format(R"({}
+                SELECT * FROM `/Root/TestTable`
+                ORDER BY {} {}
+                LIMIT 3;
+            )", target, metric, direction)));
+            const TString indexQuery(Q1_(std::format(R"(
+                pragma ydb.KMeansTreeSearchTopSize = "3";
+                {}
+                SELECT * FROM `/Root/TestTable` VIEW index
+                ORDER BY {} {}
+                LIMIT 3;
+            )", target, metric, direction)));
+            DoPositiveQueriesPrefixedVectorIndex(session, plainQuery, indexQuery);
+        }
+        // metric in result
+        {
+            const TString plainQuery(Q1_(std::format(R"({}
+                SELECT {}, `/Root/TestTable`.* FROM `/Root/TestTable`
+                ORDER BY {} {}
+                LIMIT 3;
+            )", target, metric, metric, direction)));
+            const TString indexQuery(Q1_(std::format(R"({}
+                pragma ydb.KMeansTreeSearchTopSize = "2";
+                SELECT {}, `/Root/TestTable`.* FROM `/Root/TestTable` VIEW index
+                ORDER BY {} {}
+                LIMIT 3;
+            )", target, metric, metric, direction)));
+            DoPositiveQueriesPrefixedVectorIndex(session, plainQuery, indexQuery);
+        }
+        // metric as result
+        {
+            const TString plainQuery(Q1_(std::format(R"({}
+                SELECT {} AS m, `/Root/TestTable`.* FROM `/Root/TestTable`
+                ORDER BY m {}
+                LIMIT 3;
+            )", target, metric, direction)));
+            const TString indexQuery(Q1_(std::format(R"(
+                pragma ydb.KMeansTreeSearchTopSize = "1";
+                {}
+                SELECT {} AS m, `/Root/TestTable`.* FROM `/Root/TestTable` VIEW index
+                ORDER BY m {}
+                LIMIT 3;
+            )", target, metric, direction)));
+            DoPositiveQueriesPrefixedVectorIndex(session, plainQuery, indexQuery);
+        }
+    }
+
+    void DoPositiveQueriesPrefixedVectorIndexOrderBy(
+        TSession& session,
+        std::string_view function,
+        std::string_view direction) {
+        // target is left, member is right
+        DoPositiveQueriesPrefixedVectorIndexOrderBy(session, function, direction, "$target", "emb");
+        // target is right, member is left
+        DoPositiveQueriesPrefixedVectorIndexOrderBy(session, function, direction, "emb", "$target");
+    }
+
+    void DoPositiveQueriesPrefixedVectorIndexOrderByCosine(TSession& session) {
+        // distance, default direction
+        DoPositiveQueriesPrefixedVectorIndexOrderBy(session, "CosineDistance", "");
+        // distance, asc direction
+        DoPositiveQueriesPrefixedVectorIndexOrderBy(session, "CosineDistance", "ASC");
+        // similarity, desc direction
+        DoPositiveQueriesPrefixedVectorIndexOrderBy(session, "CosineSimilarity", "DESC");
+    }
+
+    TSession DoCreateTableForPrefixedVectorIndex(TTableClient& db, bool nullable) {
+        auto session = db.CreateSession().GetValueSync().GetSession();
+
+        {
+            auto tableBuilder = db.GetTableBuilder();
+            if (nullable) {
+                tableBuilder
+                    .AddNullableColumn("pk", EPrimitiveType::Int64)
+                    .AddNullableColumn("user", EPrimitiveType::String)
+                    .AddNullableColumn("emb", EPrimitiveType::String)
+                    .AddNullableColumn("data", EPrimitiveType::String);
+            } else {
+                tableBuilder
+                    .AddNonNullableColumn("pk", EPrimitiveType::Int64)
+                    .AddNonNullableColumn("user", EPrimitiveType::String)
+                    .AddNonNullableColumn("emb", EPrimitiveType::String)
+                    .AddNonNullableColumn("data", EPrimitiveType::String);
+            }
+            tableBuilder.SetPrimaryKeyColumns({"pk"});
+            tableBuilder.BeginPartitioningSettings()
+                .SetMinPartitionsCount(3)
+            .EndPartitioningSettings();
+            auto partitions = TExplicitPartitions{}
+                .AppendSplitPoints(TValueBuilder{}.BeginTuple().AddElement().OptionalInt64(4).EndTuple().Build())
+                .AppendSplitPoints(TValueBuilder{}.BeginTuple().AddElement().OptionalInt64(6).EndTuple().Build());
+            tableBuilder.SetPartitionAtKeys(partitions);
+            auto result = session.CreateTable("/Root/TestTable", tableBuilder.Build()).ExtractValueSync();
+            UNIT_ASSERT_VALUES_EQUAL(result.IsTransportError(), false);
+            UNIT_ASSERT_VALUES_EQUAL_C(result.GetStatus(), EStatus::SUCCESS, result.GetIssues().ToString());
+        }
+
+        {
+            const TString query1(Q_(R"(
+                UPSERT INTO `/Root/TestTable` (pk, user, emb, data) VALUES)"
+                "(0, \"user_a\", \"\x03\x30\x03\", \"0\"),"
+                "(1, \"user_a\", \"\x13\x31\x03\", \"1\"),"
+                "(2, \"user_a\", \"\x23\x32\x03\", \"2\"),"
+                "(3, \"user_a\", \"\x33\x33\x03\", \"3\"),"
+                "(4, \"user_a\", \"\x43\x34\x03\", \"4\"),"
+                "(5, \"user_a\", \"\x60\x60\x03\", \"5\"),"
+                "(6, \"user_a\", \"\x61\x61\x03\", \"6\"),"
+                "(7, \"user_a\", \"\x62\x62\x03\", \"7\"),"
+                "(8, \"user_a\", \"\x75\x76\x03\", \"8\"),"
+                "(9, \"user_a\", \"\x76\x76\x03\", \"9\"),"
+
+                "(0, \"user_b\", \"\x03\x30\x03\", \"0\"),"
+                "(1, \"user_b\", \"\x13\x31\x03\", \"1\"),"
+                "(2, \"user_b\", \"\x23\x32\x03\", \"2\"),"
+                "(3, \"user_b\", \"\x33\x33\x03\", \"3\"),"
+                "(4, \"user_b\", \"\x43\x34\x03\", \"4\"),"
+                "(5, \"user_b\", \"\x60\x60\x03\", \"5\"),"
+                "(6, \"user_b\", \"\x61\x61\x03\", \"6\"),"
+                "(7, \"user_b\", \"\x62\x62\x03\", \"7\"),"
+                "(8, \"user_b\", \"\x75\x76\x03\", \"8\"),"
+                "(9, \"user_b\", \"\x76\x76\x03\", \"9\"),"
+
+                "(0, \"user_c\", \"\x03\x30\x03\", \"0\"),"
+                "(1, \"user_c\", \"\x13\x31\x03\", \"1\"),"
+                "(2, \"user_c\", \"\x23\x32\x03\", \"2\"),"
+                "(3, \"user_c\", \"\x33\x33\x03\", \"3\"),"
+                "(4, \"user_c\", \"\x43\x34\x03\", \"4\"),"
+                "(5, \"user_c\", \"\x60\x60\x03\", \"5\"),"
+                "(6, \"user_c\", \"\x61\x61\x03\", \"6\"),"
+                "(7, \"user_c\", \"\x62\x62\x03\", \"7\"),"
+                "(8, \"user_c\", \"\x75\x76\x03\", \"8\"),"
+                "(9, \"user_c\", \"\x76\x76\x03\", \"9\");"
+            ));
+
+            auto result = session.ExecuteDataQuery(
+                                 query1,
+                                 TTxControl::BeginTx(TTxSettings::SerializableRW()).CommitTx())
+                          .ExtractValueSync();
+            UNIT_ASSERT_C(result.IsSuccess(), result.GetIssues().ToString());
+        }
+        return session;
+    }
+
+    Y_UNIT_TEST(PrefixedVectorIndexOrderByCosineDistanceNotNullableLevel1) {
+        NKikimrConfig::TFeatureFlags featureFlags;
+        featureFlags.SetEnableVectorIndex(true);
+        auto setting = NKikimrKqp::TKqpSetting();
+        auto serverSettings = TKikimrSettings()
+            .SetFeatureFlags(featureFlags)
+            .SetKqpSettings({setting});
+
+        TKikimrRunner kikimr(serverSettings);
+        auto db = kikimr.GetTableClient();
+        auto session = DoCreateTableForPrefixedVectorIndex(db, false);
+        {
+            const TString createIndex(Q_(R"(
+                ALTER TABLE `/Root/TestTable`
+                    ADD INDEX index
+                    GLOBAL USING vector_kmeans_tree
+                    ON (user, emb)
+                    WITH (distance=cosine, vector_type="uint8", vector_dimension=2, levels=1, clusters=2);
+            )"));
+
+            auto result = session.ExecuteSchemeQuery(createIndex)
+                          .ExtractValueSync();
+
+            UNIT_ASSERT_C(result.IsSuccess(), result.GetIssues().ToString());
+        }
+        {
+            auto result = session.DescribeTable("/Root/TestTable").ExtractValueSync();
+            UNIT_ASSERT_VALUES_EQUAL(result.GetStatus(), NYdb::EStatus::SUCCESS);
+            const auto& indexes = result.GetTableDescription().GetIndexDescriptions();
+            UNIT_ASSERT_EQUAL(indexes.size(), 1);
+            UNIT_ASSERT_EQUAL(indexes[0].GetIndexName(), "index");
+            std::vector<std::string> indexKeyColumns{"user", "emb"};
+            UNIT_ASSERT_EQUAL(indexes[0].GetIndexColumns(), indexKeyColumns);
+            const auto& settings = std::get<TKMeansTreeSettings>(indexes[0].GetIndexSettings());
+            UNIT_ASSERT_EQUAL(settings.Settings.Metric, NYdb::NTable::TVectorIndexSettings::EMetric::CosineDistance);
+            UNIT_ASSERT_EQUAL(settings.Settings.VectorType, NYdb::NTable::TVectorIndexSettings::EVectorType::Uint8);
+            UNIT_ASSERT_EQUAL(settings.Settings.VectorDimension, 2);
+            UNIT_ASSERT_EQUAL(settings.Levels, 1);
+            UNIT_ASSERT_EQUAL(settings.Clusters, 2);
+        }
+        DoPositiveQueriesPrefixedVectorIndexOrderByCosine(session);
+    }
+
+    Y_UNIT_TEST(PrefixedVectorIndexOrderByCosineSimilarityNotNullableLevel1) {
+        NKikimrConfig::TFeatureFlags featureFlags;
+        featureFlags.SetEnableVectorIndex(true);
+        auto setting = NKikimrKqp::TKqpSetting();
+        auto serverSettings = TKikimrSettings()
+            .SetFeatureFlags(featureFlags)
+            .SetKqpSettings({setting});
+
+        TKikimrRunner kikimr(serverSettings);
+        auto db = kikimr.GetTableClient();
+        auto session = DoCreateTableForPrefixedVectorIndex(db, false);
+        {
+            const TString createIndex(Q_(R"(
+                ALTER TABLE `/Root/TestTable`
+                    ADD INDEX index
+                    GLOBAL USING vector_kmeans_tree
+                    ON (user, emb)
+                    WITH (similarity=cosine, vector_type="uint8", vector_dimension=2, levels=1, clusters=2);
+            )"));
+
+            auto result = session.ExecuteSchemeQuery(createIndex)
+                          .ExtractValueSync();
+
+            UNIT_ASSERT_C(result.IsSuccess(), result.GetIssues().ToString());
+        }
+        {
+            auto result = session.DescribeTable("/Root/TestTable").ExtractValueSync();
+            UNIT_ASSERT_VALUES_EQUAL(result.GetStatus(), NYdb::EStatus::SUCCESS);
+            const auto& indexes = result.GetTableDescription().GetIndexDescriptions();
+            UNIT_ASSERT_EQUAL(indexes.size(), 1);
+            UNIT_ASSERT_EQUAL(indexes[0].GetIndexName(), "index");
+            std::vector<std::string> indexKeyColumns{"user", "emb"};
+            UNIT_ASSERT_EQUAL(indexes[0].GetIndexColumns(), indexKeyColumns);
+            const auto& settings = std::get<TKMeansTreeSettings>(indexes[0].GetIndexSettings());
+            UNIT_ASSERT_EQUAL(settings.Settings.Metric, NYdb::NTable::TVectorIndexSettings::EMetric::CosineSimilarity);
+            UNIT_ASSERT_EQUAL(settings.Settings.VectorType, NYdb::NTable::TVectorIndexSettings::EVectorType::Uint8);
+            UNIT_ASSERT_EQUAL(settings.Settings.VectorDimension, 2);
+            UNIT_ASSERT_EQUAL(settings.Levels, 1);
+            UNIT_ASSERT_EQUAL(settings.Clusters, 2);
+        }
+        DoPositiveQueriesPrefixedVectorIndexOrderByCosine(session);
+    }
+
+    Y_UNIT_TEST(PrefixedVectorIndexOrderByCosineDistanceNullableLevel1) {
+        NKikimrConfig::TFeatureFlags featureFlags;
+        featureFlags.SetEnableVectorIndex(true);
+        auto setting = NKikimrKqp::TKqpSetting();
+        auto serverSettings = TKikimrSettings()
+            .SetFeatureFlags(featureFlags)
+            .SetKqpSettings({setting});
+
+        TKikimrRunner kikimr(serverSettings);
+        auto db = kikimr.GetTableClient();
+        auto session = DoCreateTableForPrefixedVectorIndex(db, true);
+        {
+            const TString createIndex(Q_(R"(
+                ALTER TABLE `/Root/TestTable`
+                    ADD INDEX index
+                    GLOBAL USING vector_kmeans_tree
+                    ON (user, emb)
+                    WITH (distance=cosine, vector_type="uint8", vector_dimension=2, levels=1, clusters=2);
+            )"));
+
+            auto result = session.ExecuteSchemeQuery(createIndex)
+                          .ExtractValueSync();
+
+            UNIT_ASSERT_C(result.IsSuccess(), result.GetIssues().ToString());
+        }
+        {
+            auto result = session.DescribeTable("/Root/TestTable").ExtractValueSync();
+            UNIT_ASSERT_VALUES_EQUAL(result.GetStatus(), NYdb::EStatus::SUCCESS);
+            const auto& indexes = result.GetTableDescription().GetIndexDescriptions();
+            UNIT_ASSERT_EQUAL(indexes.size(), 1);
+            UNIT_ASSERT_EQUAL(indexes[0].GetIndexName(), "index");
+            std::vector<std::string> indexKeyColumns{"user", "emb"};
+            UNIT_ASSERT_EQUAL(indexes[0].GetIndexColumns(), indexKeyColumns);
+            const auto& settings = std::get<TKMeansTreeSettings>(indexes[0].GetIndexSettings());
+            UNIT_ASSERT_EQUAL(settings.Settings.Metric, NYdb::NTable::TVectorIndexSettings::EMetric::CosineDistance);
+            UNIT_ASSERT_EQUAL(settings.Settings.VectorType, NYdb::NTable::TVectorIndexSettings::EVectorType::Uint8);
+            UNIT_ASSERT_EQUAL(settings.Settings.VectorDimension, 2);
+            UNIT_ASSERT_EQUAL(settings.Levels, 1);
+            UNIT_ASSERT_EQUAL(settings.Clusters, 2);
+        }
+        DoPositiveQueriesPrefixedVectorIndexOrderByCosine(session);
+    }
+
+    Y_UNIT_TEST(PrefixedVectorIndexOrderByCosineSimilarityNullableLevel1) {
+        NKikimrConfig::TFeatureFlags featureFlags;
+        featureFlags.SetEnableVectorIndex(true);
+        auto setting = NKikimrKqp::TKqpSetting();
+        auto serverSettings = TKikimrSettings()
+            .SetFeatureFlags(featureFlags)
+            .SetKqpSettings({setting});
+
+        TKikimrRunner kikimr(serverSettings);
+        auto db = kikimr.GetTableClient();
+        auto session = DoCreateTableForPrefixedVectorIndex(db, true);
+        {
+            const TString createIndex(Q_(R"(
+                ALTER TABLE `/Root/TestTable`
+                    ADD INDEX index
+                    GLOBAL USING vector_kmeans_tree
+                    ON (user, emb)
+                    WITH (similarity=cosine, vector_type="uint8", vector_dimension=2, levels=1, clusters=2);
+            )"));
+
+            auto result = session.ExecuteSchemeQuery(createIndex)
+                          .ExtractValueSync();
+
+            UNIT_ASSERT_C(result.IsSuccess(), result.GetIssues().ToString());
+        }
+        {
+            auto result = session.DescribeTable("/Root/TestTable").ExtractValueSync();
+            UNIT_ASSERT_VALUES_EQUAL(result.GetStatus(), NYdb::EStatus::SUCCESS);
+            const auto& indexes = result.GetTableDescription().GetIndexDescriptions();
+            UNIT_ASSERT_EQUAL(indexes.size(), 1);
+            UNIT_ASSERT_EQUAL(indexes[0].GetIndexName(), "index");
+            std::vector<std::string> indexKeyColumns{"user", "emb"};
+            UNIT_ASSERT_EQUAL(indexes[0].GetIndexColumns(), indexKeyColumns);
+            const auto& settings = std::get<TKMeansTreeSettings>(indexes[0].GetIndexSettings());
+            UNIT_ASSERT_EQUAL(settings.Settings.Metric, NYdb::NTable::TVectorIndexSettings::EMetric::CosineSimilarity);
+            UNIT_ASSERT_EQUAL(settings.Settings.VectorType, NYdb::NTable::TVectorIndexSettings::EVectorType::Uint8);
+            UNIT_ASSERT_EQUAL(settings.Settings.VectorDimension, 2);
+            UNIT_ASSERT_EQUAL(settings.Levels, 1);
+            UNIT_ASSERT_EQUAL(settings.Clusters, 2);
+        }
+        DoPositiveQueriesPrefixedVectorIndexOrderByCosine(session);
+    }
+
+    Y_UNIT_TEST(PrefixedVectorIndexOrderByCosineDistanceNotNullableLevel2) {
+        NKikimrConfig::TFeatureFlags featureFlags;
+        featureFlags.SetEnableVectorIndex(true);
+        auto setting = NKikimrKqp::TKqpSetting();
+        auto serverSettings = TKikimrSettings()
+            .SetFeatureFlags(featureFlags)
+            .SetKqpSettings({setting});
+
+        TKikimrRunner kikimr(serverSettings);
+        auto db = kikimr.GetTableClient();
+        auto session = DoCreateTableForPrefixedVectorIndex(db, false);
+        {
+            const TString createIndex(Q_(R"(
+                ALTER TABLE `/Root/TestTable`
+                    ADD INDEX index
+                    GLOBAL USING vector_kmeans_tree
+                    ON (user, emb)
+                    WITH (distance=cosine, vector_type="uint8", vector_dimension=2, levels=2, clusters=2);
+            )"));
+
+            auto result = session.ExecuteSchemeQuery(createIndex)
+                          .ExtractValueSync();
+
+            UNIT_ASSERT_C(result.IsSuccess(), result.GetIssues().ToString());
+        }
+        {
+            auto result = session.DescribeTable("/Root/TestTable").ExtractValueSync();
+            UNIT_ASSERT_VALUES_EQUAL(result.GetStatus(), NYdb::EStatus::SUCCESS);
+            const auto& indexes = result.GetTableDescription().GetIndexDescriptions();
+            UNIT_ASSERT_EQUAL(indexes.size(), 1);
+            UNIT_ASSERT_EQUAL(indexes[0].GetIndexName(), "index");
+            std::vector<std::string> indexKeyColumns{"user", "emb"};
+            UNIT_ASSERT_EQUAL(indexes[0].GetIndexColumns(), indexKeyColumns);
+            const auto& settings = std::get<TKMeansTreeSettings>(indexes[0].GetIndexSettings());
+            UNIT_ASSERT_EQUAL(settings.Settings.Metric, NYdb::NTable::TVectorIndexSettings::EMetric::CosineDistance);
+            UNIT_ASSERT_EQUAL(settings.Settings.VectorType, NYdb::NTable::TVectorIndexSettings::EVectorType::Uint8);
+            UNIT_ASSERT_EQUAL(settings.Settings.VectorDimension, 2);
+            UNIT_ASSERT_EQUAL(settings.Levels, 2);
+            UNIT_ASSERT_EQUAL(settings.Clusters, 2);
+        }
+        DoPositiveQueriesPrefixedVectorIndexOrderByCosine(session);
+    }
+
+    Y_UNIT_TEST(PrefixedVectorIndexOrderByCosineSimilarityNotNullableLevel2) {
+        NKikimrConfig::TFeatureFlags featureFlags;
+        featureFlags.SetEnableVectorIndex(true);
+        auto setting = NKikimrKqp::TKqpSetting();
+        auto serverSettings = TKikimrSettings()
+            .SetFeatureFlags(featureFlags)
+            .SetKqpSettings({setting});
+
+        TKikimrRunner kikimr(serverSettings);
+        auto db = kikimr.GetTableClient();
+        auto session = DoCreateTableForPrefixedVectorIndex(db, false);
+        {
+            const TString createIndex(Q_(R"(
+                ALTER TABLE `/Root/TestTable`
+                    ADD INDEX index
+                    GLOBAL USING vector_kmeans_tree
+                    ON (user, emb)
+                    WITH (similarity=cosine, vector_type="uint8", vector_dimension=2, levels=2, clusters=2);
+            )"));
+
+            auto result = session.ExecuteSchemeQuery(createIndex)
+                          .ExtractValueSync();
+
+            UNIT_ASSERT_C(result.IsSuccess(), result.GetIssues().ToString());
+        }
+        {
+            auto result = session.DescribeTable("/Root/TestTable").ExtractValueSync();
+            UNIT_ASSERT_VALUES_EQUAL(result.GetStatus(), NYdb::EStatus::SUCCESS);
+            const auto& indexes = result.GetTableDescription().GetIndexDescriptions();
+            UNIT_ASSERT_EQUAL(indexes.size(), 1);
+            UNIT_ASSERT_EQUAL(indexes[0].GetIndexName(), "index");
+            std::vector<std::string> indexKeyColumns{"user", "emb"};
+            UNIT_ASSERT_EQUAL(indexes[0].GetIndexColumns(), indexKeyColumns);
+            const auto& settings = std::get<TKMeansTreeSettings>(indexes[0].GetIndexSettings());
+            UNIT_ASSERT_EQUAL(settings.Settings.Metric, NYdb::NTable::TVectorIndexSettings::EMetric::CosineSimilarity);
+            UNIT_ASSERT_EQUAL(settings.Settings.VectorType, NYdb::NTable::TVectorIndexSettings::EVectorType::Uint8);
+            UNIT_ASSERT_EQUAL(settings.Settings.VectorDimension, 2);
+            UNIT_ASSERT_EQUAL(settings.Levels, 2);
+            UNIT_ASSERT_EQUAL(settings.Clusters, 2);
+        }
+        DoPositiveQueriesPrefixedVectorIndexOrderByCosine(session);
+    }
+
+    Y_UNIT_TEST(PrefixedVectorIndexOrderByCosineDistanceNullableLevel2) {
+        NKikimrConfig::TFeatureFlags featureFlags;
+        featureFlags.SetEnableVectorIndex(true);
+        auto setting = NKikimrKqp::TKqpSetting();
+        auto serverSettings = TKikimrSettings()
+            .SetFeatureFlags(featureFlags)
+            .SetKqpSettings({setting});
+
+        TKikimrRunner kikimr(serverSettings);
+        auto db = kikimr.GetTableClient();
+        auto session = DoCreateTableForPrefixedVectorIndex(db, true);
+        {
+            const TString createIndex(Q_(R"(
+                ALTER TABLE `/Root/TestTable`
+                    ADD INDEX index
+                    GLOBAL USING vector_kmeans_tree
+                    ON (user, emb)
+                    WITH (distance=cosine, vector_type="uint8", vector_dimension=2, levels=2, clusters=2);
+            )"));
+
+            auto result = session.ExecuteSchemeQuery(createIndex)
+                          .ExtractValueSync();
+
+            UNIT_ASSERT_C(result.IsSuccess(), result.GetIssues().ToString());
+        }
+        {
+            auto result = session.DescribeTable("/Root/TestTable").ExtractValueSync();
+            UNIT_ASSERT_VALUES_EQUAL(result.GetStatus(), NYdb::EStatus::SUCCESS);
+            const auto& indexes = result.GetTableDescription().GetIndexDescriptions();
+            UNIT_ASSERT_EQUAL(indexes.size(), 1);
+            UNIT_ASSERT_EQUAL(indexes[0].GetIndexName(), "index");
+            std::vector<std::string> indexKeyColumns{"user", "emb"};
+            UNIT_ASSERT_EQUAL(indexes[0].GetIndexColumns(), indexKeyColumns);
+            const auto& settings = std::get<TKMeansTreeSettings>(indexes[0].GetIndexSettings());
+            UNIT_ASSERT_EQUAL(settings.Settings.Metric, NYdb::NTable::TVectorIndexSettings::EMetric::CosineDistance);
+            UNIT_ASSERT_EQUAL(settings.Settings.VectorType, NYdb::NTable::TVectorIndexSettings::EVectorType::Uint8);
+            UNIT_ASSERT_EQUAL(settings.Settings.VectorDimension, 2);
+            UNIT_ASSERT_EQUAL(settings.Levels, 2);
+            UNIT_ASSERT_EQUAL(settings.Clusters, 2);
+        }
+        DoPositiveQueriesPrefixedVectorIndexOrderByCosine(session);
+    }
+
+    Y_UNIT_TEST(PrefixedVectorIndexOrderByCosineSimilarityNullableLevel2) {
+        NKikimrConfig::TFeatureFlags featureFlags;
+        featureFlags.SetEnableVectorIndex(true);
+        auto setting = NKikimrKqp::TKqpSetting();
+        auto serverSettings = TKikimrSettings()
+            .SetFeatureFlags(featureFlags)
+            .SetKqpSettings({setting});
+
+        TKikimrRunner kikimr(serverSettings);
+        auto db = kikimr.GetTableClient();
+        auto session = DoCreateTableForPrefixedVectorIndex(db, true);
+        {
+            const TString createIndex(Q_(R"(
+                ALTER TABLE `/Root/TestTable`
+                    ADD INDEX index
+                    GLOBAL USING vector_kmeans_tree
+                    ON (user, emb)
+                    WITH (similarity=cosine, vector_type="uint8", vector_dimension=2, levels=2, clusters=2);
+            )"));
+
+            auto result = session.ExecuteSchemeQuery(createIndex)
+                          .ExtractValueSync();
+
+            UNIT_ASSERT_C(result.IsSuccess(), result.GetIssues().ToString());
+        }
+        {
+            auto result = session.DescribeTable("/Root/TestTable").ExtractValueSync();
+            UNIT_ASSERT_VALUES_EQUAL(result.GetStatus(), NYdb::EStatus::SUCCESS);
+            const auto& indexes = result.GetTableDescription().GetIndexDescriptions();
+            UNIT_ASSERT_EQUAL(indexes.size(), 1);
+            UNIT_ASSERT_EQUAL(indexes[0].GetIndexName(), "index");
+            std::vector<std::string> indexKeyColumns{"user", "emb"};
+            UNIT_ASSERT_EQUAL(indexes[0].GetIndexColumns(), indexKeyColumns);
+            const auto& settings = std::get<TKMeansTreeSettings>(indexes[0].GetIndexSettings());
+            UNIT_ASSERT_EQUAL(settings.Settings.Metric, NYdb::NTable::TVectorIndexSettings::EMetric::CosineSimilarity);
+            UNIT_ASSERT_EQUAL(settings.Settings.VectorType, NYdb::NTable::TVectorIndexSettings::EVectorType::Uint8);
+            UNIT_ASSERT_EQUAL(settings.Settings.VectorDimension, 2);
+            UNIT_ASSERT_EQUAL(settings.Levels, 2);
+            UNIT_ASSERT_EQUAL(settings.Clusters, 2);
+        }
+        DoPositiveQueriesPrefixedVectorIndexOrderByCosine(session);
     }
 
     Y_UNIT_TEST(ExplainCollectFullDiagnostics) {

--- a/ydb/core/kqp/ut/indexes/kqp_indexes_ut.cpp
+++ b/ydb/core/kqp/ut/indexes/kqp_indexes_ut.cpp
@@ -2890,6 +2890,8 @@ Y_UNIT_TEST_SUITE(KqpIndexes) {
             .SetKqpSettings({setting});
 
         TKikimrRunner kikimr(serverSettings);
+        kikimr.GetTestServer().GetRuntime()->SetLogPriority(NKikimrServices::BUILD_INDEX, NLog::PRI_DEBUG);
+
         auto db = kikimr.GetTableClient();
         auto session = DoCreateTableForPrefixedVectorIndex(db, false);
         {
@@ -2933,6 +2935,8 @@ Y_UNIT_TEST_SUITE(KqpIndexes) {
             .SetKqpSettings({setting});
 
         TKikimrRunner kikimr(serverSettings);
+        kikimr.GetTestServer().GetRuntime()->SetLogPriority(NKikimrServices::BUILD_INDEX, NLog::PRI_DEBUG);
+
         auto db = kikimr.GetTableClient();
         auto session = DoCreateTableForPrefixedVectorIndex(db, false);
         {
@@ -2976,6 +2980,8 @@ Y_UNIT_TEST_SUITE(KqpIndexes) {
             .SetKqpSettings({setting});
 
         TKikimrRunner kikimr(serverSettings);
+        kikimr.GetTestServer().GetRuntime()->SetLogPriority(NKikimrServices::BUILD_INDEX, NLog::PRI_DEBUG);
+
         auto db = kikimr.GetTableClient();
         auto session = DoCreateTableForPrefixedVectorIndex(db, true);
         {
@@ -3019,6 +3025,8 @@ Y_UNIT_TEST_SUITE(KqpIndexes) {
             .SetKqpSettings({setting});
 
         TKikimrRunner kikimr(serverSettings);
+        kikimr.GetTestServer().GetRuntime()->SetLogPriority(NKikimrServices::BUILD_INDEX, NLog::PRI_DEBUG);
+
         auto db = kikimr.GetTableClient();
         auto session = DoCreateTableForPrefixedVectorIndex(db, true);
         {
@@ -3062,6 +3070,8 @@ Y_UNIT_TEST_SUITE(KqpIndexes) {
             .SetKqpSettings({setting});
 
         TKikimrRunner kikimr(serverSettings);
+        kikimr.GetTestServer().GetRuntime()->SetLogPriority(NKikimrServices::BUILD_INDEX, NLog::PRI_DEBUG);
+
         auto db = kikimr.GetTableClient();
         auto session = DoCreateTableForPrefixedVectorIndex(db, false);
         {
@@ -3105,6 +3115,8 @@ Y_UNIT_TEST_SUITE(KqpIndexes) {
             .SetKqpSettings({setting});
 
         TKikimrRunner kikimr(serverSettings);
+        kikimr.GetTestServer().GetRuntime()->SetLogPriority(NKikimrServices::BUILD_INDEX, NLog::PRI_DEBUG);
+
         auto db = kikimr.GetTableClient();
         auto session = DoCreateTableForPrefixedVectorIndex(db, false);
         {
@@ -3148,6 +3160,8 @@ Y_UNIT_TEST_SUITE(KqpIndexes) {
             .SetKqpSettings({setting});
 
         TKikimrRunner kikimr(serverSettings);
+        kikimr.GetTestServer().GetRuntime()->SetLogPriority(NKikimrServices::BUILD_INDEX, NLog::PRI_DEBUG);
+
         auto db = kikimr.GetTableClient();
         auto session = DoCreateTableForPrefixedVectorIndex(db, true);
         {
@@ -3191,6 +3205,8 @@ Y_UNIT_TEST_SUITE(KqpIndexes) {
             .SetKqpSettings({setting});
 
         TKikimrRunner kikimr(serverSettings);
+        kikimr.GetTestServer().GetRuntime()->SetLogPriority(NKikimrServices::BUILD_INDEX, NLog::PRI_DEBUG);
+
         auto db = kikimr.GetTableClient();
         auto session = DoCreateTableForPrefixedVectorIndex(db, true);
         {

--- a/ydb/core/kqp/ut/indexes/kqp_indexes_ut.cpp
+++ b/ydb/core/kqp/ut/indexes/kqp_indexes_ut.cpp
@@ -2923,7 +2923,8 @@ Y_UNIT_TEST_SUITE(KqpIndexes) {
             UNIT_ASSERT_EQUAL(settings.Levels, 1);
             UNIT_ASSERT_EQUAL(settings.Clusters, 2);
         }
-        DoPositiveQueriesPrefixedVectorIndexOrderByCosine(session);
+        // TODO(mbkkt) enable it when kqp part will be ready
+        // DoPositiveQueriesPrefixedVectorIndexOrderByCosine(session);
     }
 
     Y_UNIT_TEST(PrefixedVectorIndexOrderByCosineSimilarityNotNullableLevel1) {
@@ -2968,7 +2969,8 @@ Y_UNIT_TEST_SUITE(KqpIndexes) {
             UNIT_ASSERT_EQUAL(settings.Levels, 1);
             UNIT_ASSERT_EQUAL(settings.Clusters, 2);
         }
-        DoPositiveQueriesPrefixedVectorIndexOrderByCosine(session);
+        // TODO(mbkkt) enable it when kqp part will be ready
+        // DoPositiveQueriesPrefixedVectorIndexOrderByCosine(session);
     }
 
     Y_UNIT_TEST(PrefixedVectorIndexOrderByCosineDistanceNullableLevel1) {
@@ -3013,7 +3015,8 @@ Y_UNIT_TEST_SUITE(KqpIndexes) {
             UNIT_ASSERT_EQUAL(settings.Levels, 1);
             UNIT_ASSERT_EQUAL(settings.Clusters, 2);
         }
-        DoPositiveQueriesPrefixedVectorIndexOrderByCosine(session);
+        // TODO(mbkkt) enable it when kqp part will be ready
+        // DoPositiveQueriesPrefixedVectorIndexOrderByCosine(session);
     }
 
     Y_UNIT_TEST(PrefixedVectorIndexOrderByCosineSimilarityNullableLevel1) {
@@ -3058,7 +3061,8 @@ Y_UNIT_TEST_SUITE(KqpIndexes) {
             UNIT_ASSERT_EQUAL(settings.Levels, 1);
             UNIT_ASSERT_EQUAL(settings.Clusters, 2);
         }
-        DoPositiveQueriesPrefixedVectorIndexOrderByCosine(session);
+        // TODO(mbkkt) enable it when kqp part will be ready
+        // DoPositiveQueriesPrefixedVectorIndexOrderByCosine(session);
     }
 
     Y_UNIT_TEST(PrefixedVectorIndexOrderByCosineDistanceNotNullableLevel2) {
@@ -3103,7 +3107,8 @@ Y_UNIT_TEST_SUITE(KqpIndexes) {
             UNIT_ASSERT_EQUAL(settings.Levels, 2);
             UNIT_ASSERT_EQUAL(settings.Clusters, 2);
         }
-        DoPositiveQueriesPrefixedVectorIndexOrderByCosine(session);
+        // TODO(mbkkt) enable it when kqp part will be ready
+        // DoPositiveQueriesPrefixedVectorIndexOrderByCosine(session);
     }
 
     Y_UNIT_TEST(PrefixedVectorIndexOrderByCosineSimilarityNotNullableLevel2) {
@@ -3148,7 +3153,8 @@ Y_UNIT_TEST_SUITE(KqpIndexes) {
             UNIT_ASSERT_EQUAL(settings.Levels, 2);
             UNIT_ASSERT_EQUAL(settings.Clusters, 2);
         }
-        DoPositiveQueriesPrefixedVectorIndexOrderByCosine(session);
+        // TODO(mbkkt) enable it when kqp part will be ready
+        // DoPositiveQueriesPrefixedVectorIndexOrderByCosine(session);
     }
 
     Y_UNIT_TEST(PrefixedVectorIndexOrderByCosineDistanceNullableLevel2) {
@@ -3193,7 +3199,8 @@ Y_UNIT_TEST_SUITE(KqpIndexes) {
             UNIT_ASSERT_EQUAL(settings.Levels, 2);
             UNIT_ASSERT_EQUAL(settings.Clusters, 2);
         }
-        DoPositiveQueriesPrefixedVectorIndexOrderByCosine(session);
+        // TODO(mbkkt) enable it when kqp part will be ready
+        // DoPositiveQueriesPrefixedVectorIndexOrderByCosine(session);
     }
 
     Y_UNIT_TEST(PrefixedVectorIndexOrderByCosineSimilarityNullableLevel2) {
@@ -3238,7 +3245,8 @@ Y_UNIT_TEST_SUITE(KqpIndexes) {
             UNIT_ASSERT_EQUAL(settings.Levels, 2);
             UNIT_ASSERT_EQUAL(settings.Clusters, 2);
         }
-        DoPositiveQueriesPrefixedVectorIndexOrderByCosine(session);
+        // TODO(mbkkt) enable it when kqp part will be ready
+        // DoPositiveQueriesPrefixedVectorIndexOrderByCosine(session);
     }
 
     Y_UNIT_TEST(ExplainCollectFullDiagnostics) {

--- a/ydb/core/protos/tx_datashard.proto
+++ b/ydb/core/protos/tx_datashard.proto
@@ -1632,6 +1632,54 @@ message TEvReshuffleKMeansResponse {
     // optional last written primary key
 }
 
+message TEvPrefixKMeansRequest {
+    optional uint64 Id = 1;
+
+    optional uint64 TabletId = 2;
+    optional NKikimrProto.TPathID PathId = 3;
+    
+    optional uint64 SeqNoGeneration = 4;
+    optional uint64 SeqNoRound = 5;
+
+    optional Ydb.Table.VectorIndexSettings Settings = 6;
+
+    optional uint64 Seed = 7;
+
+    optional TEvLocalKMeansRequest.EState Upload = 8;
+
+    optional uint32 K = 9;
+    optional uint32 NeedsRounds = 10;
+
+    // [Child ... Child + (1 + TableSize) * ShardIndex]
+    optional uint64 Child = 11;
+
+    optional string LevelName = 12;
+    optional string PostingName = 13;
+    optional string PrefixName = 14;
+
+    optional string EmbeddingColumn = 15;
+    repeated string DataColumns = 16;
+    optional uint32 PrefixColumns = 17;
+}
+
+message TEvPrefixKMeansResponse {
+    optional uint64 Id = 1;
+
+    optional uint64 TabletId = 2;
+    optional NKikimrProto.TPathID PathId = 3;
+
+    optional uint64 RequestSeqNoGeneration = 4;
+    optional uint64 RequestSeqNoRound = 5;
+
+    optional NKikimrIndexBuilder.EBuildStatus Status = 6;
+    repeated Ydb.Issue.IssueMessage Issues = 7;
+
+    optional uint64 UploadRows = 8;
+    optional uint64 UploadBytes = 9;
+    optional uint64 ReadRows = 10;
+    optional uint64 ReadBytes = 11;
+}
+
 message TEvCdcStreamScanRequest {
     message TLimits {
         optional uint32 BatchMaxBytes = 1 [default = 512000];

--- a/ydb/core/tx/datashard/datashard.h
+++ b/ydb/core/tx/datashard/datashard.h
@@ -349,6 +349,9 @@ namespace TEvDataShard {
         EvForceDataCleanup,
         EvForceDataCleanupResult,
 
+        EvPrefixKMeansRequest,
+        EvPrefixKMeansResponse,
+
         EvEnd
     };
 
@@ -1512,6 +1515,18 @@ namespace TEvDataShard {
         : public TEventPB<TEvLocalKMeansResponse,
                           NKikimrTxDataShard::TEvLocalKMeansResponse,
                           TEvDataShard::EvLocalKMeansResponse> {
+    };
+
+    struct TEvPrefixKMeansRequest
+        : public TEventPB<TEvPrefixKMeansRequest,
+                          NKikimrTxDataShard::TEvPrefixKMeansRequest,
+                          TEvDataShard::EvLocalKMeansRequest> {
+    };
+
+    struct TEvPrefixKMeansResponse
+        : public TEventPB<TEvPrefixKMeansResponse,
+                          NKikimrTxDataShard::TEvPrefixKMeansResponse,
+                          TEvDataShard::EvPrefixKMeansResponse> {
     };
 
     struct TEvKqpScan

--- a/ydb/core/tx/datashard/datashard.h
+++ b/ydb/core/tx/datashard/datashard.h
@@ -1520,7 +1520,7 @@ namespace TEvDataShard {
     struct TEvPrefixKMeansRequest
         : public TEventPB<TEvPrefixKMeansRequest,
                           NKikimrTxDataShard::TEvPrefixKMeansRequest,
-                          TEvDataShard::EvLocalKMeansRequest> {
+                          TEvDataShard::EvPrefixKMeansRequest> {
     };
 
     struct TEvPrefixKMeansResponse

--- a/ydb/core/tx/datashard/datashard_impl.h
+++ b/ydb/core/tx/datashard/datashard_impl.h
@@ -3209,6 +3209,7 @@ protected:
             HFunc(TEvDataShard::TEvSampleKRequest, Handle);
             HFunc(TEvDataShard::TEvReshuffleKMeansRequest, Handle);
             HFunc(TEvDataShard::TEvLocalKMeansRequest, Handle);
+            HFunc(TEvDataShard::TEvPrefixKMeansRequest, Handle);
             HFunc(TEvDataShard::TEvCdcStreamScanRequest, Handle);
             HFunc(TEvPrivate::TEvCdcStreamScanRegistered, Handle);
             HFunc(TEvPrivate::TEvCdcStreamScanProgress, Handle);

--- a/ydb/core/tx/datashard/datashard_impl.h
+++ b/ydb/core/tx/datashard/datashard_impl.h
@@ -250,6 +250,7 @@ class TDataShard
     class TTxHandleSafeBuildIndexScan;
     class TTxHandleSafeSampleKScan;
     class TTxHandleSafeLocalKMeansScan;
+    class TTxHandleSafePrefixKMeansScan;
     class TTxHandleSafeReshuffleKMeansScan;
     class TTxHandleSafeStatisticsScan;
 
@@ -1335,6 +1336,8 @@ class TDataShard
     void HandleSafe(TEvDataShard::TEvReshuffleKMeansRequest::TPtr& ev, const TActorContext& ctx);
     void Handle(TEvDataShard::TEvLocalKMeansRequest::TPtr& ev, const TActorContext& ctx);
     void HandleSafe(TEvDataShard::TEvLocalKMeansRequest::TPtr& ev, const TActorContext& ctx);
+    void Handle(TEvDataShard::TEvPrefixKMeansRequest::TPtr& ev, const TActorContext& ctx);
+    void HandleSafe(TEvDataShard::TEvPrefixKMeansRequest::TPtr& ev, const TActorContext& ctx);
     void Handle(TEvDataShard::TEvCdcStreamScanRequest::TPtr& ev, const TActorContext& ctx);
     void Handle(TEvPrivate::TEvCdcStreamScanRegistered::TPtr& ev, const TActorContext& ctx);
     void Handle(TEvPrivate::TEvCdcStreamScanProgress::TPtr& ev, const TActorContext& ctx);

--- a/ydb/core/tx/datashard/datashard_ut_prefix_kmeans.cpp
+++ b/ydb/core/tx/datashard/datashard_ut_prefix_kmeans.cpp
@@ -1,0 +1,667 @@
+#include <ydb/core/base/table_index.h>
+#include <ydb/core/testlib/test_client.h>
+#include <ydb/core/tx/datashard/ut_common/datashard_ut_common.h>
+#include <ydb/core/tx/schemeshard/schemeshard.h>
+#include <ydb/core/tx/tx_proxy/proxy.h>
+#include <ydb/core/tx/tx_proxy/upload_rows.h>
+#include <ydb/core/protos/index_builder.pb.h>
+
+#include <yql/essentials/public/issue/yql_issue_message.h>
+
+#include <library/cpp/testing/unittest/registar.h>
+
+namespace NKikimr {
+using namespace Tests;
+using Ydb::Table::VectorIndexSettings;
+using namespace NTableIndex::NTableVectorKmeansTreeIndex;
+
+static std::atomic<ui64> sId = 1;
+static constexpr const char* kMainTable = "/Root/table-main";
+static constexpr const char* kLevelTable = "/Root/table-level";
+static constexpr const char* kPostingTable = "/Root/table-posting";
+
+Y_UNIT_TEST_SUITE (TTxDataShardPrefixKMeansScan) {
+    static void DoBadRequest(Tests::TServer::TPtr server, TActorId sender,
+                             std::unique_ptr<TEvDataShard::TEvPrefixKMeansRequest> & ev, size_t dims = 2,
+                             VectorIndexSettings::VectorType type = VectorIndexSettings::VECTOR_TYPE_FLOAT,
+                             VectorIndexSettings::Metric metric = VectorIndexSettings::DISTANCE_COSINE)
+    {
+        auto id = sId.fetch_add(1, std::memory_order_relaxed);
+        auto& runtime = *server->GetRuntime();
+        auto snapshot = CreateVolatileSnapshot(server, {kMainTable});
+        auto datashards = GetTableShards(server, sender, kMainTable);
+        TTableId tableId = ResolveTableId(server, sender, kMainTable);
+
+        TStringBuilder data;
+        TString err;
+        UNIT_ASSERT(datashards.size() == 1);
+
+        for (auto tid : datashards) {
+            auto& rec = ev->Record;
+            rec.SetId(1);
+
+            rec.SetSeqNoGeneration(id);
+            rec.SetSeqNoRound(1);
+
+            if (!rec.HasTabletId()) {
+                rec.SetTabletId(tid);
+            }
+            if (!rec.HasPathId()) {
+                tableId.PathId.ToProto(rec.MutablePathId());
+            }
+
+            rec.SetSnapshotTxId(snapshot.TxId);
+            rec.SetSnapshotStep(snapshot.Step);
+
+            VectorIndexSettings settings;
+            settings.set_vector_dimension(dims);
+            settings.set_vector_type(type);
+            settings.set_metric(metric);
+            *rec.MutableSettings() = settings;
+
+            if (!rec.HasK()) {
+                rec.SetK(2);
+            }
+            rec.SetSeed(1337);
+
+            rec.SetState(NKikimrTxDataShard::TEvPrefixKMeansRequest::SAMPLE);
+            rec.SetUpload(NKikimrTxDataShard::TEvPrefixKMeansRequest::UPLOAD_MAIN_TO_POSTING);
+
+            rec.SetDoneRounds(0);
+            rec.SetNeedsRounds(3);
+
+            rec.SetParentFrom(0);
+            rec.SetParentTo(0);
+            rec.SetChild(1);
+
+            if (rec.HasEmbeddingColumn()) {
+                rec.ClearEmbeddingColumn();
+            } else {
+                rec.SetEmbeddingColumn("embedding");
+            }
+
+            rec.SetLevelName(kLevelTable);
+            rec.SetPostingName(kPostingTable);
+
+            runtime.SendToPipe(tid, sender, ev.release(), 0, GetPipeConfigWithRetries());
+
+            TAutoPtr<IEventHandle> handle;
+            auto reply = runtime.GrabEdgeEventRethrow<TEvDataShard::TEvPrefixKMeansResponse>(handle);
+            UNIT_ASSERT_VALUES_EQUAL(reply->Record.GetStatus(), NKikimrIndexBuilder::EBuildStatus::BAD_REQUEST);
+        }
+    }
+
+    static std::tuple<TString, TString> DoPrefixKMeans(
+        Tests::TServer::TPtr server, TActorId sender, NTableIndex::TClusterId parent, ui64 seed, ui64 k,
+        NKikimrTxDataShard::TEvLocalKMeansRequest::EState upload, VectorIndexSettings::VectorType type,
+        VectorIndexSettings::Metric metric)
+    {
+        auto id = sId.fetch_add(1, std::memory_order_relaxed);
+        auto& runtime = *server->GetRuntime();
+        auto snapshot = CreateVolatileSnapshot(server, {kMainTable});
+        auto datashards = GetTableShards(server, sender, kMainTable);
+        TTableId tableId = ResolveTableId(server, sender, kMainTable);
+
+        TString err;
+
+        for (auto tid : datashards) {
+            auto ev1 = std::make_unique<TEvDataShard::TEvPrefixKMeansRequest>();
+            auto ev2 = std::make_unique<TEvDataShard::TEvPrefixKMeansRequest>();
+            auto fill = [&](std::unique_ptr<TEvDataShard::TEvPrefixKMeansRequest>& ev) {
+                auto& rec = ev->Record;
+                rec.SetId(1);
+
+                rec.SetSeqNoGeneration(id);
+                rec.SetSeqNoRound(1);
+
+                rec.SetTabletId(tid);
+                tableId.PathId.ToProto(rec.MutablePathId());
+
+                VectorIndexSettings settings;
+                settings.set_vector_dimension(2);
+                settings.set_vector_type(type);
+                settings.set_metric(metric);
+                *rec.MutableSettings() = settings;
+
+                rec.SetK(k);
+                rec.SetSeed(seed);
+
+                rec.SetUpload(upload);
+
+                rec.SetNeedsRounds(300);
+
+                rec.SetParentFrom(parent);
+                rec.SetParentTo(parent);
+                rec.SetChild(parent + 1);
+
+                rec.SetEmbeddingColumn("embedding");
+                rec.AddDataColumns("data");
+
+                rec.SetLevelName(kLevelTable);
+                rec.SetPostingName(kPostingTable);
+            };
+            fill(ev1);
+            fill(ev2);
+
+            runtime.SendToPipe(tid, sender, ev1.release(), 0, GetPipeConfigWithRetries());
+            runtime.SendToPipe(tid, sender, ev2.release(), 0, GetPipeConfigWithRetries());
+
+            TAutoPtr<IEventHandle> handle;
+            auto reply = runtime.GrabEdgeEventRethrow<TEvDataShard::TEvPrefixKMeansResponse>(handle);
+
+            NYql::TIssues issues;
+            NYql::IssuesFromMessage(reply->Record.GetIssues(), issues);
+            UNIT_ASSERT_EQUAL_C(reply->Record.GetStatus(), NKikimrIndexBuilder::EBuildStatus::DONE,
+                                issues.ToOneLineString());
+        }
+
+        auto level = ReadShardedTable(server, kLevelTable);
+        auto posting = ReadShardedTable(server, kPostingTable);
+        return {std::move(level), std::move(posting)};
+    }
+
+    static void DropTable(Tests::TServer::TPtr server, TActorId sender, const char* name)
+    {
+        ui64 txId = AsyncDropTable(server, sender, "/Root", name);
+        WaitTxNotification(server, sender, txId);
+    }
+
+    static void CreateMainTable(Tests::TServer::TPtr server, TActorId sender, TShardedTableOptions options)
+    {
+        options.AllowSystemColumnNames(false);
+        options.Columns({
+            {"key", "Uint32", true, true},
+            {"embedding", "String", false, false},
+            {"data", "String", false, false},
+        });
+        CreateShardedTable(server, sender, "/Root", "table-main", options);
+    }
+
+    static void CreateLevelTable(Tests::TServer::TPtr server, TActorId sender, TShardedTableOptions options)
+    {
+        options.AllowSystemColumnNames(true);
+        options.Columns({
+            {ParentColumn, NTableIndex::ClusterIdTypeName, true, true},
+            {IdColumn, NTableIndex::ClusterIdTypeName, true, true},
+            {CentroidColumn, "String", false, true},
+        });
+        CreateShardedTable(server, sender, "/Root", "table-level", options);
+    }
+
+    static void CreatePostingTable(Tests::TServer::TPtr server, TActorId sender, TShardedTableOptions options)
+    {
+        options.AllowSystemColumnNames(true);
+        options.Columns({
+            {ParentColumn, NTableIndex::ClusterIdTypeName, true, true},
+            {"key", "Uint32", true, true},
+            {"data", "String", false, false},
+        });
+        CreateShardedTable(server, sender, "/Root", "table-posting", options);
+    }
+
+    static void CreateBuildTable(Tests::TServer::TPtr server, TActorId sender, TShardedTableOptions options,
+                                 const char* name)
+    {
+        options.AllowSystemColumnNames(true);
+        options.Columns({
+            {ParentColumn, NTableIndex::ClusterIdTypeName, true, true},
+            {"key", "Uint32", true, true},
+            {"embedding", "String", false, false},
+            {"data", "String", false, false},
+        });
+        CreateShardedTable(server, sender, "/Root", name, options);
+    }
+
+    Y_UNIT_TEST (BadRequest) {
+        TPortManager pm;
+        TServerSettings serverSettings(pm.GetPort(2134));
+        serverSettings.SetDomainName("Root");
+
+        Tests::TServer::TPtr server = new TServer(serverSettings);
+        auto& runtime = *server->GetRuntime();
+        auto sender = runtime.AllocateEdgeActor();
+
+        runtime.SetLogPriority(NKikimrServices::TX_DATASHARD, NLog::PRI_DEBUG);
+
+        InitRoot(server, sender);
+
+        CreateShardedTable(server, sender, "/Root", "table-main", 1);
+
+        {
+            auto ev = std::make_unique<TEvDataShard::TEvPrefixKMeansRequest>();
+            auto& rec = ev->Record;
+
+            rec.SetK(0);
+            DoBadRequest(server, sender, ev);
+        }
+        {
+            auto ev = std::make_unique<TEvDataShard::TEvPrefixKMeansRequest>();
+            auto& rec = ev->Record;
+
+            rec.SetK(1);
+            DoBadRequest(server, sender, ev);
+        }
+        {
+            auto ev = std::make_unique<TEvDataShard::TEvPrefixKMeansRequest>();
+            auto& rec = ev->Record;
+
+            rec.SetEmbeddingColumn("some");
+            DoBadRequest(server, sender, ev);
+        }
+        {
+            auto ev = std::make_unique<TEvDataShard::TEvPrefixKMeansRequest>();
+            auto& rec = ev->Record;
+
+            rec.SetTabletId(0);
+            DoBadRequest(server, sender, ev);
+        }
+        {
+            auto ev = std::make_unique<TEvDataShard::TEvPrefixKMeansRequest>();
+            auto& rec = ev->Record;
+
+            TPathId(0, 0).ToProto(rec.MutablePathId());
+            DoBadRequest(server, sender, ev);
+        }
+        {
+            auto ev = std::make_unique<TEvDataShard::TEvPrefixKMeansRequest>();
+
+            DoBadRequest(server, sender, ev, 0);
+        }
+        {
+            auto ev = std::make_unique<TEvDataShard::TEvPrefixKMeansRequest>();
+
+            // TODO(mbkkt) bit vector not supported for now
+            DoBadRequest(server, sender, ev, 2, VectorIndexSettings::VECTOR_TYPE_BIT);
+        }
+        {
+            auto ev = std::make_unique<TEvDataShard::TEvPrefixKMeansRequest>();
+
+            DoBadRequest(server, sender, ev, 2, VectorIndexSettings::VECTOR_TYPE_UNSPECIFIED);
+        }
+        {
+            auto ev = std::make_unique<TEvDataShard::TEvPrefixKMeansRequest>();
+
+            DoBadRequest(server, sender, ev, 2, VectorIndexSettings::VECTOR_TYPE_FLOAT,
+                         VectorIndexSettings::METRIC_UNSPECIFIED);
+        }
+        // TODO(mbkkt) For now all build_index, sample_k, build_columns, local_kmeans doesn't really check this
+        // {
+        //     auto ev = std::make_unique<TEvDataShard::TEvPrefixKMeansRequest>();
+        //     auto snapshotCopy = snapshot;
+        //     snapshotCopy.Step++;
+        //     DoBadRequest(server, sender, ev);
+        // }
+        // {
+        //     auto ev = std::make_unique<TEvDataShard::TEvPrefixKMeansRequest>();
+        //     auto snapshotCopy = snapshot;
+        //     snapshotCopy.TxId++;
+        //     DoBadRequest(server, sender, ev);
+        // }
+    }
+
+    Y_UNIT_TEST (MainToPosting) {
+        TPortManager pm;
+        TServerSettings serverSettings(pm.GetPort(2134));
+        serverSettings.SetDomainName("Root");
+
+        Tests::TServer::TPtr server = new TServer(serverSettings);
+        auto& runtime = *server->GetRuntime();
+        auto sender = runtime.AllocateEdgeActor();
+
+        runtime.SetLogPriority(NKikimrServices::TX_DATASHARD, NLog::PRI_DEBUG);
+
+        InitRoot(server, sender);
+
+        TShardedTableOptions options;
+        options.EnableOutOfOrder(true); // TODO(mbkkt) what is it?
+        options.Shards(1);
+
+        CreateMainTable(server, sender, options);
+        // Upsert some initial values
+        ExecSQL(server, sender,
+                R"(
+        UPSERT INTO `/Root/table-main`
+            (key, embedding, data)
+        VALUES )"
+                "(1, \"\x30\x30\3\", \"one\"),"
+                "(2, \"\x31\x31\3\", \"two\"),"
+                "(3, \"\x32\x32\3\", \"three\"),"
+                "(4, \"\x65\x65\3\", \"four\"),"
+                "(5, \"\x75\x75\3\", \"five\");");
+
+        auto create = [&] {
+            CreateLevelTable(server, sender, options);
+            CreatePostingTable(server, sender, options);
+        };
+        create();
+        auto recreate = [&] {
+            DropTable(server, sender, "table-level");
+            DropTable(server, sender, "table-posting");
+            create();
+        };
+
+        ui64 seed, k;
+        k = 2;
+
+        seed = 0;
+        for (auto distance : {VectorIndexSettings::DISTANCE_MANHATTAN, VectorIndexSettings::DISTANCE_EUCLIDEAN}) {
+            auto [level, posting] = DoPrefixKMeans(server, sender, 0, seed, k,
+                                                  NKikimrTxDataShard::TEvPrefixKMeansRequest::UPLOAD_MAIN_TO_POSTING,
+                                                  VectorIndexSettings::VECTOR_TYPE_UINT8, distance);
+            UNIT_ASSERT_VALUES_EQUAL(level, "__ydb_parent = 0, __ydb_id = 1, __ydb_centroid = mm\3\n"
+                                            "__ydb_parent = 0, __ydb_id = 2, __ydb_centroid = 11\3\n");
+            UNIT_ASSERT_VALUES_EQUAL(posting, "__ydb_parent = 1, key = 4, data = four\n"
+                                              "__ydb_parent = 1, key = 5, data = five\n"
+                                              "__ydb_parent = 2, key = 1, data = one\n"
+                                              "__ydb_parent = 2, key = 2, data = two\n"
+                                              "__ydb_parent = 2, key = 3, data = three\n");
+            recreate();
+        }
+
+        seed = 111;
+        for (auto distance : {VectorIndexSettings::DISTANCE_MANHATTAN, VectorIndexSettings::DISTANCE_EUCLIDEAN}) {
+            auto [level, posting] = DoPrefixKMeans(server, sender, 0, seed, k,
+                                                  NKikimrTxDataShard::TEvPrefixKMeansRequest::UPLOAD_MAIN_TO_POSTING,
+                                                  VectorIndexSettings::VECTOR_TYPE_UINT8, distance);
+            UNIT_ASSERT_VALUES_EQUAL(level, "__ydb_parent = 0, __ydb_id = 1, __ydb_centroid = 11\3\n"
+                                            "__ydb_parent = 0, __ydb_id = 2, __ydb_centroid = mm\3\n");
+            UNIT_ASSERT_VALUES_EQUAL(posting, "__ydb_parent = 1, key = 1, data = one\n"
+                                              "__ydb_parent = 1, key = 2, data = two\n"
+                                              "__ydb_parent = 1, key = 3, data = three\n"
+                                              "__ydb_parent = 2, key = 4, data = four\n"
+                                              "__ydb_parent = 2, key = 5, data = five\n");
+            recreate();
+        }
+        seed = 32;
+        for (auto similarity : {VectorIndexSettings::SIMILARITY_INNER_PRODUCT, VectorIndexSettings::SIMILARITY_COSINE,
+                                VectorIndexSettings::DISTANCE_COSINE})
+        {
+            auto [level, posting] = DoPrefixKMeans(server, sender, 0, seed, k,
+                                                  NKikimrTxDataShard::TEvPrefixKMeansRequest::UPLOAD_MAIN_TO_POSTING,
+                                                  VectorIndexSettings::VECTOR_TYPE_UINT8, similarity);
+            UNIT_ASSERT_VALUES_EQUAL(level, "__ydb_parent = 0, __ydb_id = 1, __ydb_centroid = II\3\n");
+            UNIT_ASSERT_VALUES_EQUAL(posting, "__ydb_parent = 1, key = 1, data = one\n"
+                                              "__ydb_parent = 1, key = 2, data = two\n"
+                                              "__ydb_parent = 1, key = 3, data = three\n"
+                                              "__ydb_parent = 1, key = 4, data = four\n"
+                                              "__ydb_parent = 1, key = 5, data = five\n");
+            recreate();
+        }
+    }
+
+    Y_UNIT_TEST (MainToBuild) {
+        TPortManager pm;
+        TServerSettings serverSettings(pm.GetPort(2134));
+        serverSettings.SetDomainName("Root");
+
+        Tests::TServer::TPtr server = new TServer(serverSettings);
+        auto& runtime = *server->GetRuntime();
+        auto sender = runtime.AllocateEdgeActor();
+
+        runtime.SetLogPriority(NKikimrServices::TX_DATASHARD, NLog::PRI_DEBUG);
+
+        InitRoot(server, sender);
+
+        TShardedTableOptions options;
+        options.EnableOutOfOrder(true); // TODO(mbkkt) what is it?
+        options.Shards(1);
+
+        CreateMainTable(server, sender, options);
+        // Upsert some initial values
+        ExecSQL(server, sender,
+                R"(
+        UPSERT INTO `/Root/table-main`
+            (key, embedding, data)
+        VALUES )"
+                "(1, \"\x30\x30\3\", \"one\"),"
+                "(2, \"\x31\x31\3\", \"two\"),"
+                "(3, \"\x32\x32\3\", \"three\"),"
+                "(4, \"\x65\x65\3\", \"four\"),"
+                "(5, \"\x75\x75\3\", \"five\");");
+
+        auto create = [&] {
+            CreateLevelTable(server, sender, options);
+            CreateBuildTable(server, sender, options, "table-posting");
+        };
+        create();
+        auto recreate = [&] {
+            DropTable(server, sender, "table-level");
+            DropTable(server, sender, "table-posting");
+            create();
+        };
+
+        ui64 seed, k;
+        k = 2;
+
+        seed = 0;
+        for (auto distance : {VectorIndexSettings::DISTANCE_MANHATTAN, VectorIndexSettings::DISTANCE_EUCLIDEAN}) {
+            auto [level, posting] = DoPrefixKMeans(server, sender, 0, seed, k,
+                                                  NKikimrTxDataShard::TEvPrefixKMeansRequest::UPLOAD_MAIN_TO_BUILD,
+                                                  VectorIndexSettings::VECTOR_TYPE_UINT8, distance);
+            UNIT_ASSERT_VALUES_EQUAL(level, "__ydb_parent = 0, __ydb_id = 1, __ydb_centroid = mm\3\n"
+                                            "__ydb_parent = 0, __ydb_id = 2, __ydb_centroid = 11\3\n");
+            UNIT_ASSERT_VALUES_EQUAL(posting, "__ydb_parent = 1, key = 4, embedding = \x65\x65\3, data = four\n"
+                                              "__ydb_parent = 1, key = 5, embedding = \x75\x75\3, data = five\n"
+                                              "__ydb_parent = 2, key = 1, embedding = \x30\x30\3, data = one\n"
+                                              "__ydb_parent = 2, key = 2, embedding = \x31\x31\3, data = two\n"
+                                              "__ydb_parent = 2, key = 3, embedding = \x32\x32\3, data = three\n");
+            recreate();
+        }
+
+        seed = 111;
+        for (auto distance : {VectorIndexSettings::DISTANCE_MANHATTAN, VectorIndexSettings::DISTANCE_EUCLIDEAN}) {
+            auto [level, posting] = DoPrefixKMeans(server, sender, 0, seed, k,
+                                                  NKikimrTxDataShard::TEvPrefixKMeansRequest::UPLOAD_MAIN_TO_BUILD,
+                                                  VectorIndexSettings::VECTOR_TYPE_UINT8, distance);
+            UNIT_ASSERT_VALUES_EQUAL(level, "__ydb_parent = 0, __ydb_id = 1, __ydb_centroid = 11\3\n"
+                                            "__ydb_parent = 0, __ydb_id = 2, __ydb_centroid = mm\3\n");
+            UNIT_ASSERT_VALUES_EQUAL(posting, "__ydb_parent = 1, key = 1, embedding = \x30\x30\3, data = one\n"
+                                              "__ydb_parent = 1, key = 2, embedding = \x31\x31\3, data = two\n"
+                                              "__ydb_parent = 1, key = 3, embedding = \x32\x32\3, data = three\n"
+                                              "__ydb_parent = 2, key = 4, embedding = \x65\x65\3, data = four\n"
+                                              "__ydb_parent = 2, key = 5, embedding = \x75\x75\3, data = five\n");
+            recreate();
+        }
+        seed = 32;
+        for (auto similarity : {VectorIndexSettings::SIMILARITY_INNER_PRODUCT, VectorIndexSettings::SIMILARITY_COSINE,
+                                VectorIndexSettings::DISTANCE_COSINE})
+        {
+            auto [level, posting] = DoPrefixKMeans(server, sender, 0, seed, k,
+                                                  NKikimrTxDataShard::TEvPrefixKMeansRequest::UPLOAD_MAIN_TO_BUILD,
+                                                  VectorIndexSettings::VECTOR_TYPE_UINT8, similarity);
+            UNIT_ASSERT_VALUES_EQUAL(level, "__ydb_parent = 0, __ydb_id = 1, __ydb_centroid = II\3\n");
+            UNIT_ASSERT_VALUES_EQUAL(posting, "__ydb_parent = 1, key = 1, embedding = \x30\x30\3, data = one\n"
+                                              "__ydb_parent = 1, key = 2, embedding = \x31\x31\3, data = two\n"
+                                              "__ydb_parent = 1, key = 3, embedding = \x32\x32\3, data = three\n"
+                                              "__ydb_parent = 1, key = 4, embedding = \x65\x65\3, data = four\n"
+                                              "__ydb_parent = 1, key = 5, embedding = \x75\x75\3, data = five\n");
+            recreate();
+        }
+    }
+
+    Y_UNIT_TEST (BuildToPosting) {
+        TPortManager pm;
+        TServerSettings serverSettings(pm.GetPort(2134));
+        serverSettings.SetDomainName("Root");
+
+        Tests::TServer::TPtr server = new TServer(serverSettings);
+        auto& runtime = *server->GetRuntime();
+        auto sender = runtime.AllocateEdgeActor();
+
+        runtime.SetLogPriority(NKikimrServices::TX_DATASHARD, NLog::PRI_DEBUG);
+
+        InitRoot(server, sender);
+
+        TShardedTableOptions options;
+        options.EnableOutOfOrder(true); // TODO(mbkkt) what is it?
+        options.Shards(1);
+
+        CreateBuildTable(server, sender, options, "table-main");
+        // Upsert some initial values
+        ExecSQL(server, sender,
+                R"(
+        UPSERT INTO `/Root/table-main`
+            (__ydb_parent, key, embedding, data)
+        VALUES )"
+                "(39, 1, \"\x30\x30\3\", \"one\"),"
+                "(40, 1, \"\x30\x30\3\", \"one\"),"
+                "(40, 2, \"\x31\x31\3\", \"two\"),"
+                "(40, 3, \"\x32\x32\3\", \"three\"),"
+                "(40, 4, \"\x65\x65\3\", \"four\"),"
+                "(40, 5, \"\x75\x75\3\", \"five\"),"
+                "(41, 5, \"\x75\x75\3\", \"five\");");
+
+        auto create = [&] {
+            CreateLevelTable(server, sender, options);
+            CreatePostingTable(server, sender, options);
+        };
+        create();
+        auto recreate = [&] {
+            DropTable(server, sender, "table-level");
+            DropTable(server, sender, "table-posting");
+            create();
+        };
+
+        ui64 seed, k;
+        k = 2;
+
+        seed = 0;
+        for (auto distance : {VectorIndexSettings::DISTANCE_MANHATTAN, VectorIndexSettings::DISTANCE_EUCLIDEAN}) {
+            auto [level, posting] = DoPrefixKMeans(server, sender, 40, seed, k,
+                                                  NKikimrTxDataShard::TEvPrefixKMeansRequest::UPLOAD_BUILD_TO_POSTING,
+                                                  VectorIndexSettings::VECTOR_TYPE_UINT8, distance);
+            UNIT_ASSERT_VALUES_EQUAL(level, "__ydb_parent = 40, __ydb_id = 41, __ydb_centroid = mm\3\n"
+                                            "__ydb_parent = 40, __ydb_id = 42, __ydb_centroid = 11\3\n");
+            UNIT_ASSERT_VALUES_EQUAL(posting, "__ydb_parent = 41, key = 4, data = four\n"
+                                              "__ydb_parent = 41, key = 5, data = five\n"
+                                              "__ydb_parent = 42, key = 1, data = one\n"
+                                              "__ydb_parent = 42, key = 2, data = two\n"
+                                              "__ydb_parent = 42, key = 3, data = three\n");
+            recreate();
+        }
+
+        seed = 111;
+        for (auto distance : {VectorIndexSettings::DISTANCE_MANHATTAN, VectorIndexSettings::DISTANCE_EUCLIDEAN}) {
+            auto [level, posting] = DoPrefixKMeans(server, sender, 40, seed, k,
+                                                  NKikimrTxDataShard::TEvPrefixKMeansRequest::UPLOAD_BUILD_TO_POSTING,
+                                                  VectorIndexSettings::VECTOR_TYPE_UINT8, distance);
+            UNIT_ASSERT_VALUES_EQUAL(level, "__ydb_parent = 40, __ydb_id = 41, __ydb_centroid = 11\3\n"
+                                            "__ydb_parent = 40, __ydb_id = 42, __ydb_centroid = mm\3\n");
+            UNIT_ASSERT_VALUES_EQUAL(posting, "__ydb_parent = 41, key = 1, data = one\n"
+                                              "__ydb_parent = 41, key = 2, data = two\n"
+                                              "__ydb_parent = 41, key = 3, data = three\n"
+                                              "__ydb_parent = 42, key = 4, data = four\n"
+                                              "__ydb_parent = 42, key = 5, data = five\n");
+            recreate();
+        }
+        seed = 32;
+        for (auto similarity : {VectorIndexSettings::SIMILARITY_INNER_PRODUCT, VectorIndexSettings::SIMILARITY_COSINE,
+                                VectorIndexSettings::DISTANCE_COSINE})
+        {
+            auto [level, posting] = DoPrefixKMeans(server, sender, 40, seed, k,
+                                                  NKikimrTxDataShard::TEvPrefixKMeansRequest::UPLOAD_BUILD_TO_POSTING,
+                                                  VectorIndexSettings::VECTOR_TYPE_UINT8, similarity);
+            UNIT_ASSERT_VALUES_EQUAL(level, "__ydb_parent = 40, __ydb_id = 41, __ydb_centroid = II\3\n");
+            UNIT_ASSERT_VALUES_EQUAL(posting, "__ydb_parent = 41, key = 1, data = one\n"
+                                              "__ydb_parent = 41, key = 2, data = two\n"
+                                              "__ydb_parent = 41, key = 3, data = three\n"
+                                              "__ydb_parent = 41, key = 4, data = four\n"
+                                              "__ydb_parent = 41, key = 5, data = five\n");
+            recreate();
+        }
+    }
+
+    Y_UNIT_TEST (BuildToBuild) {
+        TPortManager pm;
+        TServerSettings serverSettings(pm.GetPort(2134));
+        serverSettings.SetDomainName("Root");
+
+        Tests::TServer::TPtr server = new TServer(serverSettings);
+        auto& runtime = *server->GetRuntime();
+        auto sender = runtime.AllocateEdgeActor();
+
+        runtime.SetLogPriority(NKikimrServices::TX_DATASHARD, NLog::PRI_DEBUG);
+
+        InitRoot(server, sender);
+
+        TShardedTableOptions options;
+        options.EnableOutOfOrder(true); // TODO(mbkkt) what is it?
+        options.Shards(1);
+
+        CreateBuildTable(server, sender, options, "table-main");
+        // Upsert some initial values
+        ExecSQL(server, sender,
+                R"(
+        UPSERT INTO `/Root/table-main`
+            (__ydb_parent, key, embedding, data)
+        VALUES )"
+                "(39, 1, \"\x30\x30\3\", \"one\"),"
+                "(40, 1, \"\x30\x30\3\", \"one\"),"
+                "(40, 2, \"\x31\x31\3\", \"two\"),"
+                "(40, 3, \"\x32\x32\3\", \"three\"),"
+                "(40, 4, \"\x65\x65\3\", \"four\"),"
+                "(40, 5, \"\x75\x75\3\", \"five\"),"
+                "(41, 5, \"\x75\x75\3\", \"five\");");
+
+        auto create = [&] {
+            CreateLevelTable(server, sender, options);
+            CreateBuildTable(server, sender, options, "table-posting");
+        };
+        create();
+        auto recreate = [&] {
+            DropTable(server, sender, "table-level");
+            DropTable(server, sender, "table-posting");
+            create();
+        };
+
+        ui64 seed, k;
+        k = 2;
+
+        seed = 0;
+        for (auto distance : {VectorIndexSettings::DISTANCE_MANHATTAN, VectorIndexSettings::DISTANCE_EUCLIDEAN}) {
+            auto [level, posting] = DoPrefixKMeans(server, sender, 40, seed, k,
+                                                  NKikimrTxDataShard::TEvPrefixKMeansRequest::UPLOAD_BUILD_TO_BUILD,
+                                                  VectorIndexSettings::VECTOR_TYPE_UINT8, distance);
+            UNIT_ASSERT_VALUES_EQUAL(level, "__ydb_parent = 40, __ydb_id = 41, __ydb_centroid = mm\3\n"
+                                            "__ydb_parent = 40, __ydb_id = 42, __ydb_centroid = 11\3\n");
+            UNIT_ASSERT_VALUES_EQUAL(posting, "__ydb_parent = 41, key = 4, embedding = \x65\x65\3, data = four\n"
+                                              "__ydb_parent = 41, key = 5, embedding = \x75\x75\3, data = five\n"
+                                              "__ydb_parent = 42, key = 1, embedding = \x30\x30\3, data = one\n"
+                                              "__ydb_parent = 42, key = 2, embedding = \x31\x31\3, data = two\n"
+                                              "__ydb_parent = 42, key = 3, embedding = \x32\x32\3, data = three\n");
+            recreate();
+        }
+
+        seed = 111;
+        for (auto distance : {VectorIndexSettings::DISTANCE_MANHATTAN, VectorIndexSettings::DISTANCE_EUCLIDEAN}) {
+            auto [level, posting] = DoPrefixKMeans(server, sender, 40, seed, k,
+                                                  NKikimrTxDataShard::TEvPrefixKMeansRequest::UPLOAD_BUILD_TO_BUILD,
+                                                  VectorIndexSettings::VECTOR_TYPE_UINT8, distance);
+            UNIT_ASSERT_VALUES_EQUAL(level, "__ydb_parent = 40, __ydb_id = 41, __ydb_centroid = 11\3\n"
+                                            "__ydb_parent = 40, __ydb_id = 42, __ydb_centroid = mm\3\n");
+            UNIT_ASSERT_VALUES_EQUAL(posting, "__ydb_parent = 41, key = 1, embedding = \x30\x30\3, data = one\n"
+                                              "__ydb_parent = 41, key = 2, embedding = \x31\x31\3, data = two\n"
+                                              "__ydb_parent = 41, key = 3, embedding = \x32\x32\3, data = three\n"
+                                              "__ydb_parent = 42, key = 4, embedding = \x65\x65\3, data = four\n"
+                                              "__ydb_parent = 42, key = 5, embedding = \x75\x75\3, data = five\n");
+            recreate();
+        }
+        seed = 32;
+        for (auto similarity : {VectorIndexSettings::SIMILARITY_INNER_PRODUCT, VectorIndexSettings::SIMILARITY_COSINE,
+                                VectorIndexSettings::DISTANCE_COSINE})
+        {
+            auto [level, posting] = DoPrefixKMeans(server, sender, 40, seed, k,
+                                                  NKikimrTxDataShard::TEvPrefixKMeansRequest::UPLOAD_BUILD_TO_BUILD,
+                                                  VectorIndexSettings::VECTOR_TYPE_UINT8, similarity);
+            UNIT_ASSERT_VALUES_EQUAL(level, "__ydb_parent = 40, __ydb_id = 41, __ydb_centroid = II\3\n");
+            UNIT_ASSERT_VALUES_EQUAL(posting, "__ydb_parent = 41, key = 1, embedding = \x30\x30\3, data = one\n"
+                                              "__ydb_parent = 41, key = 2, embedding = \x31\x31\3, data = two\n"
+                                              "__ydb_parent = 41, key = 3, embedding = \x32\x32\3, data = three\n"
+                                              "__ydb_parent = 41, key = 4, embedding = \x65\x65\3, data = four\n"
+                                              "__ydb_parent = 41, key = 5, embedding = \x75\x75\3, data = five\n");
+            recreate();
+        }
+    }
+}
+
+}

--- a/ydb/core/tx/datashard/kmeans_helper.cpp
+++ b/ydb/core/tx/datashard/kmeans_helper.cpp
@@ -47,21 +47,23 @@ void AddRowMain2Posting(TBufferData& buffer, NTableIndex::TClusterId parent, TAr
                   TSerializedCellVec::Serialize((*row).Slice(dataPos)));
 }
 
-void AddRowBuild2Build(TBufferData& buffer, NTableIndex::TClusterId parent, TArrayRef<const TCell> key, const NTable::TRowState& row) {
-    std::array<TCell, 1> cells;
-    cells[0] = TCell::Make(parent);
-    auto pk = TSerializedCellVec::Serialize(cells);
-    TSerializedCellVec::UnsafeAppendCells(key.Slice(1), pk);
-    buffer.AddRow(TSerializedCellVec{key}, TSerializedCellVec{std::move(pk)}, TSerializedCellVec::Serialize(*row));
-}
-
-void AddRowBuild2Posting(TBufferData& buffer, NTableIndex::TClusterId parent, TArrayRef<const TCell> key, const NTable::TRowState& row,
-                         ui32 dataPos)
+void AddRowBuild2Build(TBufferData& buffer, NTableIndex::TClusterId parent, TArrayRef<const TCell> key, const NTable::TRowState& row,
+                       ui32 prefixColumns)
 {
     std::array<TCell, 1> cells;
     cells[0] = TCell::Make(parent);
     auto pk = TSerializedCellVec::Serialize(cells);
-    TSerializedCellVec::UnsafeAppendCells(key.Slice(1), pk);
+    TSerializedCellVec::UnsafeAppendCells(key.Slice(prefixColumns), pk);
+    buffer.AddRow(TSerializedCellVec{key}, TSerializedCellVec{std::move(pk)}, TSerializedCellVec::Serialize(*row));
+}
+
+void AddRowBuild2Posting(TBufferData& buffer, NTableIndex::TClusterId parent, TArrayRef<const TCell> key, const NTable::TRowState& row,
+                         ui32 dataPos, ui32 prefixColumns)
+{
+    std::array<TCell, 1> cells;
+    cells[0] = TCell::Make(parent);
+    auto pk = TSerializedCellVec::Serialize(cells);
+    TSerializedCellVec::UnsafeAppendCells(key.Slice(prefixColumns), pk);
     buffer.AddRow(TSerializedCellVec{key}, TSerializedCellVec{std::move(pk)},
                   TSerializedCellVec::Serialize((*row).Slice(dataPos)));
 }

--- a/ydb/core/tx/datashard/kmeans_helper.h
+++ b/ydb/core/tx/datashard/kmeans_helper.h
@@ -206,10 +206,11 @@ void AddRowMain2Build(TBufferData& buffer, NTableIndex::TClusterId parent, TArra
 void AddRowMain2Posting(TBufferData& buffer, NTableIndex::TClusterId parent, TArrayRef<const TCell> key, const NTable::TRowState& row,
                         ui32 dataPos);
 
-void AddRowBuild2Build(TBufferData& buffer, NTableIndex::TClusterId parent, TArrayRef<const TCell> key, const NTable::TRowState& row);
+void AddRowBuild2Build(TBufferData& buffer, NTableIndex::TClusterId parent, TArrayRef<const TCell> key, const NTable::TRowState& row,
+                       ui32 prefixColumns = 1);
 
 void AddRowBuild2Posting(TBufferData& buffer, NTableIndex::TClusterId parent, TArrayRef<const TCell> key, const NTable::TRowState& row,
-                         ui32 dataPos);
+                         ui32 dataPos, ui32 prefixColumns = 1);
 
 TTags MakeUploadTags(const TUserTable& table, const TProtoStringType& embedding,
                      const google::protobuf::RepeatedPtrField<TProtoStringType>& data, ui32& embeddingPos,

--- a/ydb/core/tx/datashard/kmeans_helper.h
+++ b/ydb/core/tx/datashard/kmeans_helper.h
@@ -217,7 +217,8 @@ TTags MakeUploadTags(const TUserTable& table, const TProtoStringType& embedding,
 
 std::shared_ptr<NTxProxy::TUploadTypes>
 MakeUploadTypes(const TUserTable& table, NKikimrTxDataShard::TEvLocalKMeansRequest::EState uploadState,
-                const TProtoStringType& embedding, const google::protobuf::RepeatedPtrField<TProtoStringType>& data);
+                const TProtoStringType& embedding, const google::protobuf::RepeatedPtrField<TProtoStringType>& data,
+                ui32 prefixColumns = 0);
 
 void MakeScan(auto& record, const auto& createScan, const auto& badRequest)
 {

--- a/ydb/core/tx/datashard/prefix_kmeans.cpp
+++ b/ydb/core/tx/datashard/prefix_kmeans.cpp
@@ -1,0 +1,720 @@
+#include "datashard_impl.h"
+#include "kmeans_helper.h"
+#include "scan_common.h"
+#include "upload_stats.h"
+#include "buffer_data.h"
+
+#include <ydb/core/base/appdata.h>
+#include <ydb/core/base/counters.h>
+#include <ydb/core/kqp/common/kqp_types.h>
+#include <ydb/core/scheme/scheme_tablecell.h>
+
+#include <ydb/core/tx/tx_proxy/proxy.h>
+#include <ydb/core/tx/tx_proxy/upload_rows.h>
+
+#include <ydb/core/ydb_convert/table_description.h>
+#include <ydb/core/ydb_convert/ydb_convert.h>
+#include <yql/essentials/public/issue/yql_issue_message.h>
+
+#include <util/generic/algorithm.h>
+#include <util/string/builder.h>
+
+namespace NKikimr::NDataShard {
+using namespace NKMeans;
+
+// This scan needed to run kmeans reshuffle which is part of global kmeans run.
+static constexpr double MinVectorsNeedsReassigned = 0.01;
+
+class TPrefixKMeansScanBase: public TActor<TPrefixKMeansScanBase>, public NTable::IScan {
+protected:
+    using EState = NKikimrTxDataShard::TEvLocalKMeansRequest;
+
+    NTableIndex::TClusterId Parent = 0;
+    NTableIndex::TClusterId Child = 0;
+
+    ui32 Round = 0;
+    const ui32 MaxRounds = 0;
+
+    const ui32 InitK = 0;
+    ui32 K = 0;
+
+    EState::EState State;
+    const EState::EState UploadState;
+
+    IDriver* Driver = nullptr;
+
+    TLead Lead;
+
+    ui64 BuildId = 0;
+
+    ui64 ReadRows = 0;
+    ui64 ReadBytes = 0;
+
+    // Sample
+    ui64 MaxProbability = std::numeric_limits<ui64>::max();
+    TReallyFastRng32 Rng;
+
+    struct TProbability {
+        ui64 P = 0;
+        ui64 I = 0;
+
+        bool operator==(const TProbability&) const noexcept = default;
+        auto operator<=>(const TProbability&) const noexcept = default;
+    };
+
+    std::vector<TProbability> MaxRows;
+    std::vector<TString> Clusters;
+    std::vector<ui64> ClusterSizes;
+
+    // Upload
+    std::shared_ptr<NTxProxy::TUploadTypes> InitTargetTypes;
+    std::shared_ptr<NTxProxy::TUploadTypes> InitNextTypes;
+
+    std::shared_ptr<NTxProxy::TUploadTypes> TargetTypes;
+    std::shared_ptr<NTxProxy::TUploadTypes> NextTypes;
+
+    const TString TargetTable;
+    const TString NextTable;
+    TString CurrTable;
+
+    TBufferData ReadBuf;
+    TBufferData WriteBuf;
+
+    NTable::TPos EmbeddingPos = 0;
+    NTable::TPos DataPos = 1;
+
+    ui32 RetryCount = 0;
+
+    TActorId Uploader;
+    TUploadLimits Limits;
+
+    NTable::TTag KMeansScan;
+    TTags UploadScan;
+
+    TUploadStatus UploadStatus;
+
+    ui64 UploadRows = 0;
+    ui64 UploadBytes = 0;
+
+    // Response
+    TActorId ResponseActorId;
+    TAutoPtr<TEvDataShard::TEvPrefixKMeansResponse> Response;
+
+    ui32 PrefixColulmns;
+    TSerializedCellVec Key;
+    bool HasNextKey = false;
+
+public:
+    static constexpr NKikimrServices::TActivity::EType ActorActivityType()
+    {
+        return NKikimrServices::TActivity::LOCAL_KMEANS_SCAN_ACTOR;
+    }
+
+    TPrefixKMeansScanBase(const TUserTable& table, TLead&& lead,
+                          const NKikimrTxDataShard::TEvPrefixKMeansRequest& request,
+                          const TActorId& responseActorId,
+                          TAutoPtr<TEvDataShard::TEvPrefixKMeansResponse>&& response)
+        : TActor{&TThis::StateWork}
+        , Parent{request.GetChild()}
+        , Child{Parent + 1}
+        , MaxRounds{request.GetNeedsRounds()}
+        , InitK{request.GetK()}
+        , K{request.GetK()}
+        , State{EState::SAMPLE}
+        , UploadState{request.GetUpload()}
+        , Lead{std::move(lead)}
+        , BuildId{request.GetId()}
+        , Rng{request.GetSeed()}
+        , TargetTable{request.GetLevelName()}
+        , NextTable{request.GetPostingName()}
+        , ResponseActorId{responseActorId}
+        , Response{std::move(response)}
+        , PrefixColulmns{request.GetPrefixColumns()}
+    {
+        const auto& embedding = request.GetEmbeddingColumn();
+        const auto& data = request.GetDataColumns();
+        // scan tags
+        UploadScan = MakeUploadTags(table, embedding, data, EmbeddingPos, DataPos, KMeansScan);
+        // upload types
+        if (Ydb::Type type; State <= EState::KMEANS) {
+            TargetTypes = std::make_shared<NTxProxy::TUploadTypes>(3);
+            type.set_type_id(NTableIndex::ClusterIdType);
+            (*TargetTypes)[0] = {NTableIndex::NTableVectorKmeansTreeIndex::ParentColumn, type};
+            (*TargetTypes)[1] = {NTableIndex::NTableVectorKmeansTreeIndex::IdColumn, type};
+            type.set_type_id(Ydb::Type::STRING);
+            (*TargetTypes)[2] = {NTableIndex::NTableVectorKmeansTreeIndex::CentroidColumn, type};
+        }
+        NextTypes = MakeUploadTypes(table, UploadState, embedding, data, PrefixColulmns);
+
+        InitTargetTypes = TargetTypes;
+        InitNextTypes = NextTypes;
+        CurrTable = TargetTable;
+    }
+
+    TInitialState Prepare(IDriver* driver, TIntrusiveConstPtr<TScheme>) noexcept final
+    {
+        TActivationContext::AsActorContext().RegisterWithSameMailbox(this);
+        LOG_D("Prepare " << Debug());
+
+        Driver = driver;
+        return {EScan::Feed, {}};
+    }
+
+    TAutoPtr<IDestructable> Finish(EAbort abort) noexcept final
+    {
+        LOG_D("Finish " << Debug());
+
+        if (Uploader) {
+            Send(Uploader, new TEvents::TEvPoison);
+            Uploader = {};
+        }
+
+        auto& record = Response->Record;
+        record.SetReadRows(ReadRows);
+        record.SetReadBytes(ReadBytes);
+        record.SetUploadRows(UploadRows);
+        record.SetUploadBytes(UploadBytes);
+        if (abort != EAbort::None) {
+            record.SetStatus(NKikimrIndexBuilder::EBuildStatus::ABORTED);
+        } else if (UploadStatus.IsSuccess()) {
+            record.SetStatus(NKikimrIndexBuilder::EBuildStatus::DONE);
+        } else {
+            record.SetStatus(NKikimrIndexBuilder::EBuildStatus::BUILD_ERROR);
+        }
+        NYql::IssuesToMessage(UploadStatus.Issues, record.MutableIssues());
+        Send(ResponseActorId, Response.Release());
+
+        Driver = nullptr;
+        this->PassAway();
+        return nullptr;
+    }
+
+    void Describe(IOutputStream& out) const noexcept final
+    {
+        out << Debug();
+    }
+
+    TString Debug() const
+    {
+        return TStringBuilder() << " TPrefixKMeansScan Id: " << BuildId << " Parent: " << Parent << " Child: " << Child
+            << " CurrTable: " << CurrTable << " K: " << K << " Clusters: " << Clusters.size()
+            << " State: " << State << " Round: " << Round << " / " << MaxRounds
+            << " ReadBuf size: " << ReadBuf.Size() << " WriteBuf size: " << WriteBuf.Size() << " ";
+    }
+
+    EScan PageFault() noexcept final
+    {
+        LOG_T("PageFault " << Debug());
+
+        if (!ReadBuf.IsEmpty() && WriteBuf.IsEmpty()) {
+            ReadBuf.FlushTo(WriteBuf);
+            Upload(false);
+        }
+
+        return EScan::Feed;
+    }
+
+protected:
+    STFUNC(StateWork)
+    {
+        switch (ev->GetTypeRewrite()) {
+            HFunc(TEvTxUserProxy::TEvUploadRowsResponse, Handle);
+            CFunc(TEvents::TSystem::Wakeup, HandleWakeup);
+            default:
+                LOG_E("TPrefixKMeansScan: StateWork unexpected event type: " << ev->GetTypeRewrite() << " event: "
+                                                                            << ev->ToString() << " " << Debug());
+        }
+    }
+
+    void HandleWakeup(const NActors::TActorContext& /*ctx*/)
+    {
+        LOG_T("Retry upload " << Debug());
+
+        if (!WriteBuf.IsEmpty()) {
+            Upload(true);
+        }
+    }
+
+    void Handle(TEvTxUserProxy::TEvUploadRowsResponse::TPtr& ev, const TActorContext& ctx)
+    {
+        LOG_D("Handle TEvUploadRowsResponse " << Debug()
+            << " Uploader: " << Uploader.ToString() << " ev->Sender: " << ev->Sender.ToString());
+
+        if (Uploader) {
+            Y_VERIFY_S(Uploader == ev->Sender, "Mismatch Uploader: " << Uploader.ToString() << " ev->Sender: "
+                                                                     << ev->Sender.ToString() << Debug());
+        } else {
+            Y_ABORT_UNLESS(Driver == nullptr);
+            return;
+        }
+
+        UploadStatus.StatusCode = ev->Get()->Status;
+        UploadStatus.Issues = ev->Get()->Issues;
+        if (UploadStatus.IsSuccess()) {
+            UploadRows += WriteBuf.GetRows();
+            UploadBytes += WriteBuf.GetBytes();
+            WriteBuf.Clear();
+            if (!ReadBuf.IsEmpty() && ReadBuf.IsReachLimits(Limits)) {
+                ReadBuf.FlushTo(WriteBuf);
+                Upload(false);
+            }
+
+            Driver->Touch(EScan::Feed);
+            return;
+        }
+
+        if (RetryCount < Limits.MaxUploadRowsRetryCount && UploadStatus.IsRetriable()) {
+            LOG_N("Got retriable error, " << Debug() << UploadStatus.ToString());
+
+            ctx.Schedule(Limits.GetTimeoutBackouff(RetryCount), new TEvents::TEvWakeup());
+            return;
+        }
+
+        LOG_N("Got error, abort scan, " << Debug() << UploadStatus.ToString());
+
+        Driver->Touch(EScan::Final);
+    }
+
+    EScan FeedUpload()
+    {
+        if (!ReadBuf.IsReachLimits(Limits)) {
+            return EScan::Feed;
+        }
+        if (!WriteBuf.IsEmpty()) {
+            return EScan::Sleep;
+        }
+        ReadBuf.FlushTo(WriteBuf);
+        Upload(false);
+        return EScan::Feed;
+    }
+
+    ui64 GetProbability()
+    {
+        return Rng.GenRand64();
+    }
+
+    void Upload(bool isRetry)
+    {
+        if (isRetry) {
+            ++RetryCount;
+        } else {
+            RetryCount = 0;
+            if (State != EState::KMEANS && NextTypes) {
+                TargetTypes = std::exchange(NextTypes, {});
+                CurrTable = NextTable;
+            }
+        }
+
+        auto actor = NTxProxy::CreateUploadRowsInternal(
+            this->SelfId(), CurrTable, TargetTypes, WriteBuf.GetRowsData(),
+            NTxProxy::EUploadRowsMode::WriteToTableShadow, true /*writeToPrivateTable*/);
+
+        Uploader = this->Register(actor);
+    }
+
+    void UploadSample()
+    {
+        Y_ASSERT(ReadBuf.IsEmpty());
+        Y_ASSERT(WriteBuf.IsEmpty());
+        std::array<TCell, 2> pk;
+        std::array<TCell, 1> data;
+        for (NTable::TPos pos = 0; const auto& row : Clusters) {
+            pk[0] = TCell::Make(Parent);
+            pk[1] = TCell::Make(Child + pos);
+            data[0] = TCell{row};
+            WriteBuf.AddRow({}, TSerializedCellVec{pk}, TSerializedCellVec::Serialize(data));
+            ++pos;
+        }
+        Upload(false);
+    }
+};
+
+template <typename TMetric>
+class TPrefixKMeansScan final: public TPrefixKMeansScanBase, private TCalculation<TMetric> {
+    // KMeans
+    using TEmbedding = std::vector<typename TMetric::TSum>;
+
+    struct TAggregatedCluster {
+        TEmbedding Cluster;
+        ui64 Size = 0;
+    };
+    std::vector<TAggregatedCluster> AggregatedClusters;
+
+public:
+    TPrefixKMeansScan(const TUserTable& table, TLead&& lead, NKikimrTxDataShard::TEvPrefixKMeansRequest& request,
+                      const TActorId& responseActorId, TAutoPtr<TEvDataShard::TEvPrefixKMeansResponse>&& response)
+        : TPrefixKMeansScanBase{table, std::move(lead), request, responseActorId, std::move(response)}
+    {
+        this->Dimensions = request.GetSettings().vector_dimension();
+        LOG_D("Create " << Debug());
+    }
+
+    EScan Seek(TLead& lead, ui64 seq) noexcept final
+    {
+        LOG_D("Seek " << Debug());
+        if (State == UploadState) {
+            if (!WriteBuf.IsEmpty()) {
+                return EScan::Sleep;
+            }
+            if (!ReadBuf.IsEmpty()) {
+                ReadBuf.FlushTo(WriteBuf);
+                Upload(false);
+                return EScan::Sleep;
+            }
+            if (!HasNextKey) {
+                if (UploadStatus.IsNone()) {
+                    UploadStatus.StatusCode = Ydb::StatusIds::SUCCESS;
+                }
+                return EScan::Final;
+            }
+
+            Parent = Child + K;
+            ++Child;
+            Round = 0;
+            K = InitK;
+            State = EState::SAMPLE;
+            Lead.To(Key.GetCells(), NTable::ESeek::Upper);
+            Key = {};
+            MaxProbability = std::numeric_limits<ui64>::max();
+            MaxRows.clear();
+            Clusters.clear();
+            ClusterSizes.clear();
+            TargetTypes = InitTargetTypes;
+            NextTypes = InitNextTypes;
+            CurrTable = TargetTable;
+            HasNextKey = false;
+            AggregatedClusters.clear();
+        }
+
+        lead = Lead;
+        if (State == EState::SAMPLE) {
+            lead.SetTags({&KMeansScan, 1});
+            if (seq == 0) {
+                return EScan::Feed;
+            }
+            State = EState::KMEANS;
+            if (!InitAggregatedClusters()) {
+                // We don't need to do anything,
+                // because this datashard doesn't have valid embeddings for this parent
+                if (UploadStatus.IsNone()) {
+                    UploadStatus.StatusCode = Ydb::StatusIds::SUCCESS;
+                }
+                return EScan::Final;
+            }
+            ++Round;
+            return EScan::Feed;
+        }
+
+        Y_ASSERT(State == EState::KMEANS);
+        if (RecomputeClusters()) {
+            lead.SetTags(UploadScan);
+
+            UploadSample();
+            State = UploadState;
+        } else {
+            lead.SetTags({&KMeansScan, 1});
+            ++Round;
+        }
+        return EScan::Feed;
+    }
+
+    EScan Feed(TArrayRef<const TCell> key, const TRow& row) noexcept final
+    {
+        LOG_T("Feed " << Debug());
+        if (!TCellVectorsEquals{}(Key.GetCells().subspan(0, PrefixColulmns), key.subspan(0, PrefixColulmns))) {
+            if (!Key) {
+                Key = TSerializedCellVec{key};
+            } else {
+                HasNextKey = true;
+                return EScan::Reset;
+            }
+        }
+        ++ReadRows;
+        ReadBytes += CountBytes(key, row);
+        switch (State) {
+            case EState::SAMPLE:
+                return FeedSample(row);
+            case EState::KMEANS:
+                return FeedKMeans(row);
+            case EState::UPLOAD_MAIN_TO_BUILD:
+                return FeedUploadMain2Build(key, row);
+            case EState::UPLOAD_MAIN_TO_POSTING:
+                return FeedUploadMain2Posting(key, row);
+            case EState::UPLOAD_BUILD_TO_BUILD:
+                return FeedUploadBuild2Build(key, row);
+            case EState::UPLOAD_BUILD_TO_POSTING:
+                return FeedUploadBuild2Posting(key, row);
+            default:
+                return EScan::Final;
+        }
+    }
+
+private:
+    bool InitAggregatedClusters()
+    {
+        if (Clusters.size() == 0) {
+            return false;
+        }
+        if (Clusters.size() < K) {
+            // if this datashard have smaller than K count of valid embeddings for this parent
+            // lets make single centroid for it
+            K = 1;
+            Clusters.resize(K);
+        }
+        Y_ASSERT(Clusters.size() == K);
+        ClusterSizes.resize(K, 0);
+        AggregatedClusters.resize(K);
+        for (auto& aggregate : AggregatedClusters) {
+            aggregate.Cluster.resize(this->Dimensions, 0);
+        }
+        return true;
+    }
+
+    void AggregateToCluster(ui32 pos, const char* embedding)
+    {
+        if (pos >= K) {
+            return;
+        }
+        auto& aggregate = AggregatedClusters[pos];
+        auto* coords = aggregate.Cluster.data();
+        for (auto coord : this->GetCoords(embedding)) {
+            *coords++ += coord;
+        }
+        ++aggregate.Size;
+    }
+
+    bool RecomputeClusters()
+    {
+        Y_ASSERT(K >= 1);
+        ui64 vectorCount = 0;
+        ui64 reassignedCount = 0;
+        for (size_t i = 0; auto& aggregate : AggregatedClusters) {
+            vectorCount += aggregate.Size;
+
+            auto& clusterSize = ClusterSizes[i];
+            reassignedCount += clusterSize < aggregate.Size ? aggregate.Size - clusterSize : 0;
+            clusterSize = aggregate.Size;
+
+            if (aggregate.Size != 0) {
+                this->Fill(Clusters[i], aggregate.Cluster.data(), aggregate.Size);
+                Y_ASSERT(aggregate.Size == 0);
+            }
+            ++i;
+        }
+        Y_ASSERT(vectorCount >= K);
+        Y_ASSERT(reassignedCount <= vectorCount);
+        if (K == 1) {
+            return true;
+        }
+
+        bool last = Round >= MaxRounds;
+        if (!last && Round > 1) {
+            const auto changes = static_cast<double>(reassignedCount) / static_cast<double>(vectorCount);
+            last = changes < MinVectorsNeedsReassigned;
+        }
+        if (!last) {
+            return false;
+        }
+
+        size_t w = 0;
+        for (size_t r = 0; r < ClusterSizes.size(); ++r) {
+            if (ClusterSizes[r] != 0) {
+                ClusterSizes[w] = ClusterSizes[r];
+                Clusters[w] = std::move(Clusters[r]);
+                ++w;
+            }
+        }
+        ClusterSizes.erase(ClusterSizes.begin() + w, ClusterSizes.end());
+        Clusters.erase(Clusters.begin() + w, Clusters.end());
+        return true;
+    }
+
+    EScan FeedSample(const TRow& row) noexcept
+    {
+        Y_ASSERT(row.Size() == 1);
+        const auto embedding = row.Get(0).AsRef();
+        if (!this->IsExpectedSize(embedding)) {
+            return EScan::Feed;
+        }
+
+        const auto probability = GetProbability();
+        if (Clusters.size() < K) {
+            MaxRows.push_back({probability, Clusters.size()});
+            Clusters.emplace_back(embedding.data(), embedding.size());
+            if (Clusters.size() == K) {
+                std::make_heap(MaxRows.begin(), MaxRows.end());
+                MaxProbability = MaxRows.front().P;
+            }
+        } else if (probability < MaxProbability) {
+            // TODO(mbkkt) use tournament tree to make less compare and swaps
+            std::pop_heap(MaxRows.begin(), MaxRows.end());
+            Clusters[MaxRows.back().I].assign(embedding.data(), embedding.size());
+            MaxRows.back().P = probability;
+            std::push_heap(MaxRows.begin(), MaxRows.end());
+            MaxProbability = MaxRows.front().P;
+        }
+        return MaxProbability != 0 ? EScan::Feed : EScan::Reset;
+    }
+
+    EScan FeedKMeans(const TRow& row) noexcept
+    {
+        Y_ASSERT(row.Size() == 1);
+        const ui32 pos = FeedEmbedding(*this, Clusters, row, 0);
+        AggregateToCluster(pos, row.Get(0).Data());
+        return EScan::Feed;
+    }
+
+    EScan FeedUploadMain2Build(TArrayRef<const TCell> key, const TRow& row) noexcept
+    {
+        const ui32 pos = FeedEmbedding(*this, Clusters, row, EmbeddingPos);
+        if (pos > K) {
+            return EScan::Feed;
+        }
+        AddRowMain2Build(ReadBuf, Child + pos, key, row);
+        return FeedUpload();
+    }
+
+    EScan FeedUploadMain2Posting(TArrayRef<const TCell> key, const TRow& row) noexcept
+    {
+        const ui32 pos = FeedEmbedding(*this, Clusters, row, EmbeddingPos);
+        if (pos > K) {
+            return EScan::Feed;
+        }
+        AddRowMain2Posting(ReadBuf, Child + pos, key, row, DataPos);
+        return FeedUpload();
+    }
+
+    EScan FeedUploadBuild2Build(TArrayRef<const TCell> key, const TRow& row) noexcept
+    {
+        const ui32 pos = FeedEmbedding(*this, Clusters, row, EmbeddingPos);
+        if (pos > K) {
+            return EScan::Feed;
+        }
+        AddRowBuild2Build(ReadBuf, Child + pos, key, row);
+        return FeedUpload();
+    }
+
+    EScan FeedUploadBuild2Posting(TArrayRef<const TCell> key, const TRow& row) noexcept
+    {
+        const ui32 pos = FeedEmbedding(*this, Clusters, row, EmbeddingPos);
+        if (pos > K) {
+            return EScan::Feed;
+        }
+        AddRowBuild2Posting(ReadBuf, Child + pos, key, row, DataPos);
+        return FeedUpload();
+    }
+};
+
+class TDataShard::TTxHandleSafePrefixKMeansScan final: public NTabletFlatExecutor::TTransactionBase<TDataShard> {
+public:
+    TTxHandleSafePrefixKMeansScan(TDataShard* self, TEvDataShard::TEvPrefixKMeansRequest::TPtr&& ev)
+        : TTransactionBase(self)
+        , Ev(std::move(ev))
+    {
+    }
+
+    bool Execute(TTransactionContext&, const TActorContext& ctx) final
+    {
+        Self->HandleSafe(Ev, ctx);
+        return true;
+    }
+
+    void Complete(const TActorContext&) final
+    {
+    }
+
+private:
+    TEvDataShard::TEvPrefixKMeansRequest::TPtr Ev;
+};
+
+void TDataShard::Handle(TEvDataShard::TEvPrefixKMeansRequest::TPtr& ev, const TActorContext&)
+{
+    Execute(new TTxHandleSafePrefixKMeansScan(this, std::move(ev)));
+}
+
+void TDataShard::HandleSafe(TEvDataShard::TEvPrefixKMeansRequest::TPtr& ev, const TActorContext& ctx)
+{
+    auto& record = ev->Get()->Record;
+    TRowVersion rowVersion = GetMvccTxVersion(EMvccTxMode::ReadOnly);
+
+    // Note: it's very unlikely that we have volatile txs before this snapshot
+    if (VolatileTxManager.HasVolatileTxsAtSnapshot(rowVersion)) {
+        VolatileTxManager.AttachWaitingSnapshotEvent(rowVersion, std::unique_ptr<IEventHandle>(ev.Release()));
+        return;
+    }
+    const ui64 id = record.GetId();
+
+    auto response = MakeHolder<TEvDataShard::TEvPrefixKMeansResponse>();
+    response->Record.SetId(id);
+    response->Record.SetTabletId(TabletID());
+
+    TScanRecord::TSeqNo seqNo = {record.GetSeqNoGeneration(), record.GetSeqNoRound()};
+    response->Record.SetRequestSeqNoGeneration(seqNo.Generation);
+    response->Record.SetRequestSeqNoRound(seqNo.Round);
+
+    auto badRequest = [&](const TString& error) {
+        response->Record.SetStatus(NKikimrIndexBuilder::EBuildStatus::BAD_REQUEST);
+        auto issue = response->Record.AddIssues();
+        issue->set_severity(NYql::TSeverityIds::S_ERROR);
+        issue->set_message(error);
+        ctx.Send(ev->Sender, std::move(response));
+        response.Reset();
+    };
+
+    if (const ui64 shardId = record.GetTabletId(); shardId != TabletID()) {
+        badRequest(TStringBuilder() << "Wrong shard " << shardId << " this is " << TabletID());
+        return;
+    }
+
+    const auto pathId = TPathId::FromProto(record.GetPathId());
+    const auto* userTableIt = GetUserTables().FindPtr(pathId.LocalPathId);
+    if (!userTableIt) {
+        badRequest(TStringBuilder() << "Unknown table id: " << pathId.LocalPathId);
+        return;
+    }
+    Y_ABORT_UNLESS(*userTableIt);
+    const auto& userTable = **userTableIt;
+
+    if (const auto* recCard = ScanManager.Get(id)) {
+        if (recCard->SeqNo == seqNo) {
+            // do no start one more scan
+            return;
+        }
+
+        for (auto scanId : recCard->ScanIds) {
+            CancelScan(userTable.LocalTid, scanId);
+        }
+        ScanManager.Drop(id);
+    }
+
+    const auto range = userTable.GetTableRange();
+    if (range.IsEmptyRange(userTable.KeyColumnTypes)) {
+        badRequest(TStringBuilder() << " requested range doesn't intersect with table range");
+        return;
+    }
+
+    if (!IsStateActive()) {
+        badRequest(TStringBuilder() << "Shard " << TabletID() << " is not ready for requests");
+        return;
+    }
+
+    TAutoPtr<NTable::IScan> scan;
+    auto createScan = [&]<typename T> {
+        scan = new TPrefixKMeansScan<T>{
+            userTable, CreateLeadFrom(range), record, ev->Sender, std::move(response),
+        };
+    };
+    MakeScan(record, createScan, badRequest);
+    if (!scan) {
+        Y_ASSERT(!response);
+        return;
+    }
+
+    TScanOptions scanOpts;
+    scanOpts.SetSnapshotRowVersion(rowVersion);
+    scanOpts.SetResourceBroker("build_index", 10); // TODO(mbkkt) Should be different group?
+    const auto scanId = QueueScan(userTable.LocalTid, std::move(scan), 0, scanOpts);
+    ScanManager.Set(id, seqNo).push_back(scanId);
+}
+
+}

--- a/ydb/core/tx/datashard/ut_prefix_kmeans/ya.make
+++ b/ydb/core/tx/datashard/ut_prefix_kmeans/ya.make
@@ -1,0 +1,33 @@
+UNITTEST_FOR(ydb/core/tx/datashard)
+
+FORK_SUBTESTS()
+
+SPLIT_FACTOR(1)
+
+IF (SANITIZER_TYPE == "thread" OR WITH_VALGRIND)
+    SIZE(LARGE)
+    TAG(ya:fat)
+ELSE()
+    SIZE(MEDIUM)
+ENDIF()
+
+PEERDIR(
+    ydb/core/tx/datashard/ut_common
+    library/cpp/getopt
+    library/cpp/regex/pcre
+    library/cpp/svnversion
+    ydb/core/kqp/ut/common
+    ydb/core/testlib/default
+    ydb/core/tx
+    yql/essentials/public/udf/service/exception_policy
+    ydb/public/lib/yson_value
+    ydb/public/sdk/cpp/src/client/result
+)
+
+YQL_LAST_ABI_VERSION()
+
+SRCS(
+    datashard_ut_prefix_kmeans.cpp
+)
+
+END()

--- a/ydb/core/tx/datashard/ya.make
+++ b/ydb/core/tx/datashard/ya.make
@@ -181,6 +181,7 @@ SRCS(
     operation.cpp
     operation.h
     plan_queue_unit.cpp
+    prefix_kmeans.cpp
     prepare_data_tx_in_rs_unit.cpp
     prepare_distributed_erase_tx_in_rs_unit.cpp
     prepare_kqp_data_tx_in_rs_unit.cpp

--- a/ydb/core/tx/datashard/ya.make
+++ b/ydb/core/tx/datashard/ya.make
@@ -327,6 +327,7 @@ RECURSE_FOR_TESTS(
     ut_minstep
     ut_object_storage_listing
     ut_order
+    ut_prefix_kmeans
     ut_range_ops
     ut_read_iterator
     ut_read_table

--- a/ydb/core/tx/schemeshard/schemeshard_build_index.cpp
+++ b/ydb/core/tx/schemeshard/schemeshard_build_index.cpp
@@ -40,6 +40,10 @@ void TSchemeShard::Handle(TEvDataShard::TEvLocalKMeansResponse::TPtr& ev, const 
     Execute(CreateTxReply(ev), ctx);
 }
 
+void TSchemeShard::Handle(TEvDataShard::TEvPrefixKMeansResponse::TPtr& ev, const TActorContext& ctx) {
+    Execute(CreateTxReply(ev), ctx);
+}
+
 void TSchemeShard::Handle(TEvIndexBuilder::TEvUploadSampleKResponse::TPtr& ev, const TActorContext& ctx) {
     Execute(CreateTxReply(ev), ctx);
 }

--- a/ydb/core/tx/schemeshard/schemeshard_build_index__create.cpp
+++ b/ydb/core/tx/schemeshard/schemeshard_build_index__create.cpp
@@ -228,13 +228,15 @@ private:
             explain = "unsupported index type to build";
             return false;
         case Ydb::Table::TableIndex::TypeCase::kGlobalVectorKmeansTreeIndex: {
-            buildInfo.BuildKind = TIndexBuildInfo::EBuildKind::BuildVectorIndex;
+            buildInfo.BuildKind = index.index_columns().size() == 1
+                ? TIndexBuildInfo::EBuildKind::BuildVectorIndex
+                : TIndexBuildInfo::EBuildKind::BuildPrefixedVectorIndex;
             buildInfo.IndexType = NKikimrSchemeOp::EIndexType::EIndexTypeGlobalVectorKmeansTree;
             NKikimrSchemeOp::TVectorIndexKmeansTreeDescription vectorIndexKmeansTreeDescription;
             *vectorIndexKmeansTreeDescription.MutableSettings() = index.global_vector_kmeans_tree_index().vector_settings();
             buildInfo.SpecializedIndexDescription = vectorIndexKmeansTreeDescription;
             buildInfo.KMeans.K = std::max<ui32>(2, vectorIndexKmeansTreeDescription.GetSettings().clusters());
-            buildInfo.KMeans.Levels = std::max<ui32>(1, vectorIndexKmeansTreeDescription.GetSettings().levels());
+            buildInfo.KMeans.Levels = buildInfo.IsBuildPrefixedVectorIndex() + std::max<ui32>(1, vectorIndexKmeansTreeDescription.GetSettings().levels());
             break;
         }
         case Ydb::Table::TableIndex::TypeCase::TYPE_NOT_SET:

--- a/ydb/core/tx/schemeshard/schemeshard_build_index__progress.cpp
+++ b/ydb/core/tx/schemeshard/schemeshard_build_index__progress.cpp
@@ -21,6 +21,9 @@
 namespace NKikimr {
 namespace NSchemeShard {
 
+// TODO(mbkkt) get table rows count (but even better to have unique prefixes count)
+static constexpr ui64 TableSize = 1'000;
+
 static constexpr const char* Name(TIndexBuildInfo::EState state) noexcept {
     switch (state) {
     case TIndexBuildInfo::EState::Invalid:
@@ -64,7 +67,7 @@ static constexpr const char* Name(TIndexBuildInfo::EState state) noexcept {
 static std::tuple<NTableIndex::TClusterId, NTableIndex::TClusterId, NTableIndex::TClusterId> ComputeKMeansBoundaries(const NSchemeShard::TTableInfo& tableInfo, const TIndexBuildInfo& buildInfo) {
     const auto& kmeans = buildInfo.KMeans;
     Y_ASSERT(kmeans.K != 0);
-    const auto count = TIndexBuildInfo::TKMeans::BinPow(kmeans.K, kmeans.Level);
+    const auto count = kmeans.ChildCount();
     NTableIndex::TClusterId step = 1;
     auto parts = count;
     auto shards = tableInfo.GetShard2PartitionIdx().size();
@@ -323,8 +326,8 @@ THolder<TEvSchemeShard::TEvModifySchemeTransaction> CreateBuildPropose(
         const auto& baseTableColumns = NTableIndex::ExtractInfo(tableInfo);
         const auto& indexKeys = NTableIndex::ExtractInfo(indexDesc);
         implTableColumns = CalcTableImplDescription(buildInfo.IndexType, baseTableColumns, indexKeys);
-        Y_ABORT_UNLESS(indexKeys.KeyColumns.size() == 1);
-        implTableColumns.Columns.emplace(indexKeys.KeyColumns[0]);
+        Y_ABORT_UNLESS(indexKeys.KeyColumns.size() >= 1);
+        implTableColumns.Columns.emplace(indexKeys.KeyColumns.back());
         modifyScheme.ClearInitiateIndexBuild();
     }
 
@@ -337,26 +340,38 @@ THolder<TEvSchemeShard::TEvModifySchemeTransaction> CreateBuildPropose(
     modifyScheme.SetOperationType(NKikimrSchemeOp::ESchemeOpInitiateBuildIndexImplTable);
     auto& op = *modifyScheme.MutableCreateTable();
     std::string_view suffix = buildInfo.KMeans.Level % 2 != 0 ? BuildSuffix0 : BuildSuffix1;
-    op = CalcVectorKmeansTreePostingImplTableDesc({}, tableInfo, tableInfo->PartitionConfig(), implTableColumns, {}, suffix);
+    auto resetPartitionsSettings = [&] {
+        auto& config = *op.MutablePartitionConfig();
+        config.SetShadowData(false);
 
+        auto& policy = *config.MutablePartitioningPolicy();
+        policy.SetSizeToSplit(0); // disable auto split/merge
+        policy.ClearFastSplitSettings();
+        policy.ClearSplitByLoadSettings();
+
+        op.ClearSplitBoundary();
+        return &policy;
+    };
+    if (buildInfo.IsBuildPrefixedVectorIndex() && buildInfo.KMeans.Level == 1) {
+        op.SetName(TString::Join(PostingTable, suffix));
+        NTableIndex::FillIndexImplTableColumns(tableInfo->Columns, implTableColumns.Keys, implTableColumns.Columns, op);
+        auto& policy = *resetPartitionsSettings();
+        const auto shards = tableInfo->GetShard2PartitionIdx().size();
+        policy.SetMinPartitionsCount(shards);
+        policy.SetMaxPartitionsCount(shards);
+        return propose;
+    }
+    op = CalcVectorKmeansTreePostingImplTableDesc({}, tableInfo, tableInfo->PartitionConfig(), implTableColumns, {}, suffix);
     const auto [count, parts, step] = ComputeKMeansBoundaries(*tableInfo, buildInfo);
 
-    auto& config = *op.MutablePartitionConfig();
-    config.SetShadowData(false);
-
-    auto& policy = *config.MutablePartitioningPolicy();
-    policy.SetSizeToSplit(0); // disable auto split/merge
-    policy.ClearFastSplitSettings();
-    policy.ClearSplitByLoadSettings();
-
-    op.ClearSplitBoundary();
+    auto& policy = *resetPartitionsSettings();
     static constexpr std::string_view LogPrefix = "Create build table boundaries for ";
     LOG_D(buildInfo.Id << " table " << suffix
         << ", count: " << count << ", parts: " << parts << ", step: " << step
         << ", kmeans: " << buildInfo.KMeansTreeToDebugStr());
     if (parts > 1) {
-        const auto parentFrom = buildInfo.KMeans.ParentEnd + 1;
-        for (auto i = parentFrom + step, e = parentFrom + count; i < e; i += step) {
+        const auto from = buildInfo.KMeans.ChildBegin;
+        for (auto i = from + step, e = from + count; i < e; i += step) {
             LOG_D(buildInfo.Id << " table " << suffix << " value: " << i);
             auto cell = TCell::Make(i);
             op.AddSplitBoundary()->SetSerializedKeyPrefix(TSerializedCellVec::Serialize({&cell, 1}));
@@ -491,14 +506,16 @@ private:
 
     TDeque<std::tuple<TTabletId, ui64, THolder<IEventBase>>> ToTabletSend;
 
-    template <typename Record>
+    template <bool WithSnapshot = true, typename Record>
     TTabletId CommonFillRecord(Record& record, TShardIdx shardIdx, TIndexBuildInfo& buildInfo) {
         TTabletId shardId = Self->ShardInfos.at(shardIdx).TabletID;
         record.SetTabletId(ui64(shardId));
-        if (buildInfo.SnapshotTxId) {
-            Y_ASSERT(buildInfo.SnapshotStep);
-            record.SetSnapshotTxId(ui64(buildInfo.SnapshotTxId));
-            record.SetSnapshotStep(ui64(buildInfo.SnapshotStep));
+        if constexpr (WithSnapshot) {
+            if (buildInfo.SnapshotTxId) {
+                Y_ASSERT(buildInfo.SnapshotStep);
+                record.SetSnapshotTxId(ui64(buildInfo.SnapshotTxId));
+                record.SetSnapshotStep(ui64(buildInfo.SnapshotStep));
+            }
         }
 
         auto& shardStatus = buildInfo.Shards.at(shardIdx);
@@ -537,7 +554,7 @@ private:
             range.Serialize(*ev->Record.MutableKeyRange());
         }
 
-        ev->Record.AddColumns(buildInfo.IndexColumns[0]);
+        ev->Record.AddColumns(buildInfo.IndexColumns.back());
 
         auto shardId = CommonFillRecord(ev->Record, shardIdx, buildInfo);
         ev->Record.SetSeed(ui64(shardId));
@@ -563,7 +580,7 @@ private:
             buildInfo.SpecializedIndexDescription).GetSettings().settings();
         ev->Record.SetUpload(buildInfo.KMeans.GetUpload());
         ev->Record.SetParent(buildInfo.KMeans.Parent);
-        ev->Record.SetChild(buildInfo.KMeans.ChildBegin);
+        ev->Record.SetChild(buildInfo.KMeans.Child);
 
         auto& clusters = *ev->Record.MutableClusters();
         clusters.Reserve(buildInfo.Sample.Rows.size());
@@ -573,7 +590,7 @@ private:
 
         ev->Record.SetPostingName(path.Dive(buildInfo.KMeans.WriteTo()).PathString());
 
-        ev->Record.SetEmbeddingColumn(buildInfo.IndexColumns[0]);
+        ev->Record.SetEmbeddingColumn(buildInfo.IndexColumns.back());
         *ev->Record.MutableDataColumns() = {
             buildInfo.DataColumns.begin(), buildInfo.DataColumns.end()
         };
@@ -614,12 +631,11 @@ private:
         if (buildInfo.KMeans.State != TIndexBuildInfo::TKMeans::MultiLocal) {
             ev->Record.SetParentFrom(buildInfo.KMeans.Parent);
             ev->Record.SetParentTo(buildInfo.KMeans.Parent);
-            ev->Record.SetChild(buildInfo.KMeans.ChildBegin);
+            ev->Record.SetChild(buildInfo.KMeans.Child);
         } else {
             const auto& range = buildInfo.Shards.at(shardIdx).Range;
             const auto [parentFrom, parentTo] = buildInfo.KMeans.RangeToBorders(range);
-            // child begin for parent from = (last child begin + K) - (last parent - parent from + 1) * K
-            const auto childBegin = buildInfo.KMeans.ChildBegin - (buildInfo.KMeans.ParentEnd - parentFrom) * buildInfo.KMeans.K;
+            const auto childBegin = buildInfo.KMeans.ChildBegin + (parentFrom - buildInfo.KMeans.ParentBegin) * buildInfo.KMeans.K;
             LOG_D("shard " << shardIdx << ", parent range { From: " << parentFrom << ", To: " << parentTo << " }, child begin " << childBegin);
             ev->Record.SetParentFrom(parentFrom);
             ev->Record.SetParentTo(parentTo);
@@ -630,7 +646,7 @@ private:
         path.Rise().Dive(NTableIndex::NTableVectorKmeansTreeIndex::LevelTable);
         ev->Record.SetLevelName(path.PathString());
 
-        ev->Record.SetEmbeddingColumn(buildInfo.IndexColumns[0]);
+        ev->Record.SetEmbeddingColumn(buildInfo.IndexColumns.back());
         *ev->Record.MutableDataColumns() = {
             buildInfo.DataColumns.begin(), buildInfo.DataColumns.end()
         };
@@ -642,6 +658,48 @@ private:
         ToTabletSend.emplace_back(shardId, ui64(BuildId), std::move(ev));
     }
 
+    void SendPrefixKMeansRequest(TShardIdx shardIdx, TIndexBuildInfo& buildInfo) {
+        Y_ASSERT(buildInfo.IsBuildPrefixedVectorIndex());
+        Y_ASSERT(buildInfo.KMeans.Parent == 1);
+
+        auto ev = MakeHolder<TEvDataShard::TEvPrefixKMeansRequest>();
+        ev->Record.SetId(ui64(BuildId));
+
+        auto path = TPath::Init(buildInfo.TablePathId, Self).Dive(buildInfo.IndexName);
+        if (buildInfo.KMeans.Parent == 0) {
+            buildInfo.TablePathId.ToProto(ev->Record.MutablePathId());
+        } else {
+            path.Dive(buildInfo.KMeans.ReadFrom())->PathId.ToProto(ev->Record.MutablePathId());
+            path.Rise();
+        }
+        *ev->Record.MutableSettings() = std::get<NKikimrSchemeOp::TVectorIndexKmeansTreeDescription>(
+            buildInfo.SpecializedIndexDescription).GetSettings().settings();
+        ev->Record.SetUpload(buildInfo.KMeans.GetUpload());
+
+        ev->Record.SetNeedsRounds(3); // TODO(mbkkt) should be configurable
+
+        const auto shardIndex = buildInfo.Shards.at(shardIdx).Index;
+        ev->Record.SetChild(buildInfo.KMeans.ParentBegin + (1 + TableSize) * shardIndex);
+
+        ev->Record.SetPostingName(path.Dive(buildInfo.KMeans.WriteTo()).PathString());
+        path.Rise().Dive(NTableIndex::NTableVectorKmeansTreeIndex::LevelTable);
+        ev->Record.SetLevelName(path.PathString());
+        path.Rise().Dive(NTableIndex::NTableVectorKmeansTreeIndex::PrefixTable);
+        ev->Record.SetPrefixName(path.PathString());
+
+        ev->Record.SetPrefixColumns(buildInfo.IndexColumns.size() - 1);
+        ev->Record.SetEmbeddingColumn(buildInfo.IndexColumns.back());
+        *ev->Record.MutableDataColumns() = {
+            buildInfo.DataColumns.begin(), buildInfo.DataColumns.end()
+        };
+
+        auto shardId = CommonFillRecord<false>(ev->Record, shardIdx, buildInfo);
+        ev->Record.SetSeed(ui64(shardId));
+        LOG_D("TTxBuildProgress: TEvPrefixKMeansRequest: " << ev->Record.ShortDebugString());
+
+        ToTabletSend.emplace_back(shardId, ui64(BuildId), std::move(ev));
+    }
+
     void SendBuildIndexRequest(TShardIdx shardIdx, TIndexBuildInfo& buildInfo) {
         auto ev = MakeHolder<TEvDataShard::TEvBuildIndexCreateRequest>();
         ev->Record.SetBuildIndexId(ui64(BuildId));
@@ -649,9 +707,12 @@ private:
         ev->Record.SetOwnerId(buildInfo.TablePathId.OwnerId);
         ev->Record.SetPathId(buildInfo.TablePathId.LocalPathId);
 
-        if (buildInfo.IsBuildSecondaryIndex()) {
+        if (buildInfo.IsBuildColumns()) {
+            buildInfo.SerializeToProto(Self, ev->Record.MutableColumnBuildSettings());
+        } else {
             if (buildInfo.TargetName.empty()) {
-                TPath implTable = TPath::Init(buildInfo.TablePathId, Self).Dive(buildInfo.IndexName).Dive(NTableIndex::ImplTable);
+                TPath implTable = TPath::Init(buildInfo.TablePathId, Self).Dive(buildInfo.IndexName).Dive(
+                    buildInfo.IsBuildPrefixedVectorIndex() ? buildInfo.KMeans.WriteTo() : NTableIndex::ImplTable);
                 buildInfo.TargetName = implTable.PathString();
 
                 const auto& implTableInfo = Self->Tables.at(implTable.Base()->PathId);
@@ -662,6 +723,7 @@ private:
                     buildInfo.FillIndexColumns.emplace_back(x);
                     implTableColumns.Columns.erase(x);
                 }
+                // TODO(mbkkt) why order doesn't matter?
                 buildInfo.FillDataColumns.clear();
                 buildInfo.FillDataColumns.reserve(implTableColumns.Columns.size());
                 for (const auto& x: implTableColumns.Columns) {
@@ -676,8 +738,6 @@ private:
                 buildInfo.FillDataColumns.begin(),
                 buildInfo.FillDataColumns.end()
             };
-        } else if (buildInfo.IsBuildColumns()) {
-            buildInfo.SerializeToProto(Self, ev->Record.MutableColumnBuildSettings());
         }
 
         ev->Record.SetTargetName(buildInfo.TargetName);
@@ -701,7 +761,7 @@ private:
         Y_ASSERT(buildInfo.Sample.Rows.size() <= buildInfo.KMeans.K);
         auto actor = new TUploadSampleK(path.PathString(),
             buildInfo.Limits, Self->SelfId(), ui64(BuildId),
-            buildInfo.Sample.Rows, buildInfo.KMeans.Parent, buildInfo.KMeans.ChildBegin);
+            buildInfo.Sample.Rows, buildInfo.KMeans.Parent, buildInfo.KMeans.Child);
 
         TActivationContext::AsActorContext().MakeFor(Self->SelfId()).Register(actor);
         buildInfo.Sample.State = TIndexBuildInfo::TSample::EState::Upload;
@@ -755,6 +815,14 @@ private:
             AddAllShards(buildInfo);
         }
         return SendToShards(buildInfo, [&](TShardIdx shardIdx) { SendBuildIndexRequest(shardIdx, buildInfo); }) &&
+               buildInfo.DoneShards.size() == buildInfo.Shards.size();
+    }
+
+    bool FillPrefixKMeans(TIndexBuildInfo& buildInfo) {
+        if (buildInfo.DoneShards.empty() && buildInfo.ToUploadShards.empty() && buildInfo.InProgressShards.empty()) {
+            AddAllShards(buildInfo);
+        }
+        return SendToShards(buildInfo, [&](TShardIdx shardIdx) { SendPrefixKMeansRequest(shardIdx, buildInfo); }) &&
                buildInfo.DoneShards.size() == buildInfo.Shards.size();
     }
 
@@ -866,6 +934,40 @@ private:
     }
 
     bool FillVectorIndex(TTransactionContext& txc, TIndexBuildInfo& buildInfo) {
+        if (buildInfo.IsBuildPrefixedVectorIndex() && buildInfo.KMeans.Level == 1) {
+            if (!FillTable(buildInfo)) {
+                return false;
+            }
+            const ui64 doneShards = buildInfo.DoneShards.size();
+
+            ClearDoneShards(txc, buildInfo);
+            buildInfo.KMeans.PrefixTableDone(TableSize, doneShards);
+            PersistKMeansState(txc, buildInfo);
+            NIceDb::TNiceDb db{txc.DB};
+            Self->PersistBuildIndexUploadReset(db, buildInfo);
+            ChangeState(BuildId, TIndexBuildInfo::EState::CreateBuild);
+            Progress(BuildId);
+            return false;
+        }
+
+        if (buildInfo.IsBuildPrefixedVectorIndex() && buildInfo.KMeans.Level == 2) {
+            if (!FillPrefixKMeans(buildInfo)) {
+                return false;
+            }
+
+            ClearDoneShards(txc, buildInfo);
+            const bool needsAnotherLevel = buildInfo.KMeans.NextLevel();
+            PersistKMeansState(txc, buildInfo);
+            NIceDb::TNiceDb db{txc.DB};
+            Self->PersistBuildIndexUploadReset(db, buildInfo);
+            if (!needsAnotherLevel) {
+                return true;
+            }
+            ChangeState(BuildId, TIndexBuildInfo::EState::DropBuild);
+            Progress(BuildId);
+            return false;
+        }
+
         if (buildInfo.Sample.State == TIndexBuildInfo::TSample::EState::Upload) {
             return false;
         }
@@ -1012,11 +1114,7 @@ public:
             } else if (!buildInfo.InitiateTxDone) {
                 Send(Self->SelfId(), MakeHolder<TEvSchemeShard::TEvNotifyTxCompletion>(ui64(buildInfo.InitiateTxId)));
             } else {
-                if (buildInfo.IsBuildVectorIndex() && buildInfo.IndexColumns.size() != 1) {
-                    // TODO(mbkkt) in this state every prefixed vector index is empty
-                    // So we need some new code to fill it
-                    ChangeState(BuildId, TIndexBuildInfo::EState::Applying);
-                } else if (buildInfo.IsBuildVectorIndex() && buildInfo.KMeans.NeedsAnotherLevel()) {
+                if (buildInfo.IsBuildVectorIndex() && buildInfo.KMeans.NeedsAnotherLevel()) {
                     ChangeState(BuildId, TIndexBuildInfo::EState::CreateBuild);
                 } else {
                     ChangeState(BuildId, TIndexBuildInfo::EState::Filling);
@@ -1218,7 +1316,7 @@ public:
             shardRange.To = bound;
             LOG_D("shard " << x.ShardIdx << " range " << buildInfo.KMeans.RangeToDebugStr(shardRange));
             buildInfo.AddParent(shardRange, x.ShardIdx);
-            auto [it, emplaced] = buildInfo.Shards.emplace(x.ShardIdx, TIndexBuildInfo::TShardStatus{std::move(shardRange), ""});
+            auto [it, emplaced] = buildInfo.Shards.emplace(x.ShardIdx, TIndexBuildInfo::TShardStatus{std::move(shardRange), "", buildInfo.Shards.size()});
             Y_ASSERT(emplaced);
             shardRange.From = std::move(bound);
 
@@ -1755,6 +1853,131 @@ public:
         case TIndexBuildInfo::EState::Rejection_Unlocking:
         case TIndexBuildInfo::EState::Rejected:
             LOG_D("TTxReply : TEvReshuffleKMeansResponse"
+                  << " superfluous message " << record.ShortDebugString());
+            break;
+        }
+
+        return true;
+    }
+};
+
+struct TSchemeShard::TIndexBuilder::TTxReplyPrefixKMeans: public TSchemeShard::TIndexBuilder::TTxReply {
+private:
+    TEvDataShard::TEvPrefixKMeansResponse::TPtr Local;
+
+public:
+    explicit TTxReplyPrefixKMeans(TSelf* self, TEvDataShard::TEvPrefixKMeansResponse::TPtr& local)
+        : TTxReply(self)
+        , Local(local)
+    {
+    }
+
+    bool DoExecute(TTransactionContext& txc, const TActorContext& ctx) override {
+        auto& record = Local->Get()->Record;
+
+        LOG_I("TTxReply : TEvPrefixKMeansResponse, id# " << record.GetId());
+
+        const auto buildId = TIndexBuildId(record.GetId());
+        const auto* buildInfoPtr = Self->IndexBuilds.FindPtr(buildId);
+        if (!buildInfoPtr) {
+            return true;
+        }
+        auto& buildInfo = *buildInfoPtr->Get();
+        LOG_D("TTxReply : TEvPrefixKMeansResponse"
+              << ", TIndexBuildInfo: " << buildInfo
+              << ", record: " << record.ShortDebugString());
+
+        TTabletId shardId = TTabletId(record.GetTabletId());
+        if (!Self->TabletIdToShardIdx.contains(shardId)) {
+            return true;
+        }
+
+        TShardIdx shardIdx = Self->TabletIdToShardIdx.at(shardId);
+        if (!buildInfo.Shards.contains(shardIdx)) {
+            return true;
+        }
+
+        switch (const auto state = buildInfo.State; state) {
+        case TIndexBuildInfo::EState::Filling:
+        {
+            TIndexBuildInfo::TShardStatus& shardStatus = buildInfo.Shards.at(shardIdx);
+
+            auto actualSeqNo = std::pair<ui64, ui64>(Self->Generation(), shardStatus.SeqNoRound);
+            auto recordSeqNo = std::pair<ui64, ui64>(record.GetRequestSeqNoGeneration(), record.GetRequestSeqNoRound());
+
+            if (actualSeqNo != recordSeqNo) {
+                LOG_D("TTxReply : TEvPrefixKMeansResponse"
+                      << " ignore progress message by seqNo"
+                      << ", TIndexBuildInfo: " << buildInfo
+                      << ", actual seqNo for the shard " << shardId << " (" << shardIdx << ") is: "  << Self->Generation() << ":" <<  shardStatus.SeqNoRound
+                      << ", record: " << record.ShortDebugString());
+                Y_ABORT_UNLESS(actualSeqNo > recordSeqNo);
+                return true;
+            }
+
+            TBillingStats stats{record.GetUploadRows(), record.GetUploadBytes(), record.GetReadRows(), record.GetReadBytes()};
+            shardStatus.Processed += stats;
+            buildInfo.Processed += stats;
+
+            NYql::TIssues issues;
+            NYql::IssuesFromMessage(record.GetIssues(), issues);
+            shardStatus.DebugMessage = issues.ToString();
+
+            NIceDb::TNiceDb db(txc.DB);
+            shardStatus.Status = record.GetStatus();
+
+            switch (shardStatus.Status) {
+            case  NKikimrIndexBuilder::EBuildStatus::DONE:
+                if (buildInfo.InProgressShards.erase(shardIdx)) {
+                    buildInfo.DoneShards.emplace_back(shardIdx);
+                }
+                break;
+            case  NKikimrIndexBuilder::EBuildStatus::ABORTED:
+                // datashard gracefully rebooted, reschedule shard
+                if (buildInfo.InProgressShards.erase(shardIdx)) {
+                    buildInfo.ToUploadShards.emplace_front(shardIdx);
+                }
+                break;
+            case  NKikimrIndexBuilder::EBuildStatus::BUILD_ERROR:
+            case  NKikimrIndexBuilder::EBuildStatus::BAD_REQUEST:
+                buildInfo.Issue += TStringBuilder()
+                    << "One of the shards report "<< shardStatus.Status
+                    << " at Filling stage, process has to be canceled"
+                    << ", shardId: " << shardId
+                    << ", shardIdx: " << shardIdx;
+                Self->PersistBuildIndexIssue(db, buildInfo);
+                ChangeState(buildInfo.Id, TIndexBuildInfo::EState::Rejection_Applying);
+
+                Progress(buildId);
+                return true;
+            case  NKikimrIndexBuilder::EBuildStatus::INVALID:
+            case  NKikimrIndexBuilder::EBuildStatus::ACCEPTED:
+            case  NKikimrIndexBuilder::EBuildStatus::IN_PROGRESS:
+                Y_ABORT("Unreachable");
+            }
+            Self->PersistBuildIndexUploadProgress(db, buildId, shardIdx, shardStatus);
+            Self->IndexBuildPipes.Close(buildId, shardId, ctx);
+            Progress(buildId);
+            break;
+        }
+        case TIndexBuildInfo::EState::AlterMainTable:
+        case TIndexBuildInfo::EState::Invalid:
+        case TIndexBuildInfo::EState::Locking:
+        case TIndexBuildInfo::EState::GatheringStatistics:
+        case TIndexBuildInfo::EState::Initiating:
+        case TIndexBuildInfo::EState::DropBuild:
+        case TIndexBuildInfo::EState::CreateBuild:
+        case TIndexBuildInfo::EState::Applying:
+        case TIndexBuildInfo::EState::Unlocking:
+        case TIndexBuildInfo::EState::Done:
+            Y_FAIL_S("Unreachable " << Name(state));
+        case TIndexBuildInfo::EState::Cancellation_Applying:
+        case TIndexBuildInfo::EState::Cancellation_Unlocking:
+        case TIndexBuildInfo::EState::Cancelled:
+        case TIndexBuildInfo::EState::Rejection_Applying:
+        case TIndexBuildInfo::EState::Rejection_Unlocking:
+        case TIndexBuildInfo::EState::Rejected:
+            LOG_D("TTxReply : TEvPrefixKMeansResponse"
                   << " superfluous message " << record.ShortDebugString());
             break;
         }
@@ -2396,6 +2619,10 @@ ITransaction* TSchemeShard::CreateTxReply(TEvDataShard::TEvReshuffleKMeansRespon
 
 ITransaction* TSchemeShard::CreateTxReply(TEvDataShard::TEvLocalKMeansResponse::TPtr& local) {
     return new TIndexBuilder::TTxReplyLocalKMeans(this, local);
+}
+
+ITransaction* TSchemeShard::CreateTxReply(TEvDataShard::TEvPrefixKMeansResponse::TPtr& local) {
+    return new TIndexBuilder::TTxReplyPrefixKMeans(this, local);
 }
 
 ITransaction* TSchemeShard::CreateTxReply(TEvIndexBuilder::TEvUploadSampleKResponse::TPtr& upload) {

--- a/ydb/core/tx/schemeshard/schemeshard_build_index__progress.cpp
+++ b/ydb/core/tx/schemeshard/schemeshard_build_index__progress.cpp
@@ -358,7 +358,7 @@ THolder<TEvSchemeShard::TEvModifySchemeTransaction> CreateBuildPropose(
     };
     if (buildInfo.IsBuildPrefixedVectorIndex() && buildInfo.KMeans.Level == 1) {
         op.SetName(TString::Join(PostingTable, suffix));
-        NTableIndex::FillIndexImplTableColumns(tableInfo->Columns, implTableColumns.Keys, implTableColumns.Columns, op);
+        NTableIndex::FillIndexTableColumns(tableInfo->Columns, implTableColumns.Keys, implTableColumns.Columns, op);
         auto& policy = *resetPartitionsSettings();
         const auto shards = tableInfo->GetShard2PartitionIdx().size();
         policy.SetMinPartitionsCount(shards);

--- a/ydb/core/tx/schemeshard/schemeshard_impl.cpp
+++ b/ydb/core/tx/schemeshard/schemeshard_impl.cpp
@@ -4919,6 +4919,7 @@ void TSchemeShard::StateWork(STFUNC_SIG) {
         HFuncTraced(TEvDataShard::TEvSampleKResponse, Handle);
         HFuncTraced(TEvDataShard::TEvReshuffleKMeansResponse, Handle);
         HFuncTraced(TEvDataShard::TEvLocalKMeansResponse, Handle);
+        HFuncTraced(TEvDataShard::TEvPrefixKMeansResponse, Handle);
         HFuncTraced(TEvIndexBuilder::TEvUploadSampleKResponse, Handle);
         // } // NIndexBuilder
 

--- a/ydb/core/tx/schemeshard/schemeshard_impl.h
+++ b/ydb/core/tx/schemeshard/schemeshard_impl.h
@@ -1426,6 +1426,7 @@ public:
         struct TTxReplySampleK;
         struct TTxReplyReshuffleKMeans;
         struct TTxReplyLocalKMeans;
+        struct TTxReplyPrefixKMeans;
         struct TTxReplyUpload;
 
         struct TTxPipeReset;
@@ -1445,6 +1446,7 @@ public:
     NTabletFlatExecutor::ITransaction* CreateTxReply(TEvDataShard::TEvSampleKResponse::TPtr& sampleK);
     NTabletFlatExecutor::ITransaction* CreateTxReply(TEvDataShard::TEvReshuffleKMeansResponse::TPtr& reshuffle);
     NTabletFlatExecutor::ITransaction* CreateTxReply(TEvDataShard::TEvLocalKMeansResponse::TPtr& local);
+    NTabletFlatExecutor::ITransaction* CreateTxReply(TEvDataShard::TEvPrefixKMeansResponse::TPtr& prefix);
     NTabletFlatExecutor::ITransaction* CreateTxReply(TEvIndexBuilder::TEvUploadSampleKResponse::TPtr& upload);
     NTabletFlatExecutor::ITransaction* CreatePipeRetry(TIndexBuildId indexBuildId, TTabletId tabletId);
     NTabletFlatExecutor::ITransaction* CreateTxBilling(TEvPrivate::TEvIndexBuildingMakeABill::TPtr& ev);
@@ -1459,6 +1461,7 @@ public:
     void Handle(TEvDataShard::TEvSampleKResponse::TPtr& ev, const TActorContext& ctx);
     void Handle(TEvDataShard::TEvReshuffleKMeansResponse::TPtr& ev, const TActorContext& ctx);
     void Handle(TEvDataShard::TEvLocalKMeansResponse::TPtr& ev, const TActorContext& ctx);
+    void Handle(TEvDataShard::TEvPrefixKMeansResponse::TPtr& ev, const TActorContext& ctx);
     void Handle(TEvIndexBuilder::TEvUploadSampleKResponse::TPtr& ev, const TActorContext& ctx);
 
     void Handle(TEvPrivate::TEvIndexBuildingMakeABill::TPtr& ev, const TActorContext& ctx);

--- a/ydb/core/tx/schemeshard/schemeshard_info_types.cpp
+++ b/ydb/core/tx/schemeshard/schemeshard_info_types.cpp
@@ -2164,9 +2164,10 @@ void TImportInfo::AddNotifySubscriber(const TActorId &actorId) {
     Subscribers.insert(actorId);
 }
 
-TIndexBuildInfo::TShardStatus::TShardStatus(TSerializedTableRange range, TString lastKeyAck)
+TIndexBuildInfo::TShardStatus::TShardStatus(TSerializedTableRange range, TString lastKeyAck, size_t shardsCount)
     : Range(std::move(range))
     , LastKeyAck(std::move(lastKeyAck))
+    , Index(shardsCount)
 {}
 
 void TIndexBuildInfo::SerializeToProto(TSchemeShard* ss, NKikimrSchemeOp::TIndexBuildConfig* result) const {
@@ -2208,7 +2209,6 @@ void TIndexBuildInfo::SerializeToProto([[maybe_unused]] TSchemeShard* ss, NKikim
 
 void TIndexBuildInfo::AddParent(const TSerializedTableRange& range, TShardIdx shard) {
     if (KMeans.Parent == 0) {
-        Y_ASSERT(KMeans.ParentEnd == 0);
         // For Parent == 0 only single kmeans needed, so there is only two options:
         // 1. It fits entirely in the single shard => local kmeans for single shard
         // 2. It doesn't fit entirely in the single shard => global kmeans for all shards

--- a/ydb/core/tx/schemeshard/schemeshard_info_types.h
+++ b/ydb/core/tx/schemeshard/schemeshard_info_types.h
@@ -3165,6 +3165,7 @@ struct TIndexBuildInfo: public TSimpleRefCount<TIndexBuildInfo> {
             }
             State = MultiLocal;
             NextLevel((1 + tableSize) * shards);
+            Parent = ParentEnd();
             return true;
         }
 

--- a/ydb/core/tx/schemeshard/schemeshard_info_types.h
+++ b/ydb/core/tx/schemeshard/schemeshard_info_types.h
@@ -3115,7 +3115,7 @@ struct TIndexBuildInfo: public TSimpleRefCount<TIndexBuildInfo> {
 
         TString ToStr() const {
             return TStringBuilder()
-                << "{ K = " << K << ", ParentBegin = " << ParentBegin << ", ChildBegin = " << ChildBegin
+                << "{ K = " << K
                 << ", Level = " << Level << " / " << Levels
                 << ", Parent = [" << ParentBegin << ".." << Parent << ".." << ParentEnd()
                 << "], Child = [" << ChildBegin << ".." << Child << ".." << ChildEnd()

--- a/ydb/core/tx/schemeshard/schemeshard_info_types.h
+++ b/ydb/core/tx/schemeshard/schemeshard_info_types.h
@@ -3047,6 +3047,7 @@ struct TIndexBuildInfo: public TSimpleRefCount<TIndexBuildInfo> {
         BuildKindUnspecified = 0,
         BuildSecondaryIndex = 10,
         BuildVectorIndex = 11,
+        BuildPrefixedVectorIndex = 12,
         BuildColumns = 20,
     };
 
@@ -3092,42 +3093,46 @@ struct TIndexBuildInfo: public TSimpleRefCount<TIndexBuildInfo> {
 
         EState State = Sample;
 
-        NTableIndex::TClusterId Parent = 0;
-        NTableIndex::TClusterId ParentEnd = 0;  // included
+        NTableIndex::TClusterId ParentBegin = 0;  // included
+        NTableIndex::TClusterId Parent = ParentBegin;
 
         NTableIndex::TClusterId ChildBegin = 1;  // included
+        NTableIndex::TClusterId Child = ChildBegin;
+
+        ui64 ParentEnd() const noexcept {  // included
+            return ChildBegin - 1;
+        }
+        ui64 ChildEnd() const noexcept {  // included
+            return ChildBegin + ChildCount() - 1;
+        }
+
+        ui64 ParentCount() const noexcept {
+            return ParentEnd() - ParentBegin + 1;
+        }
+        ui64 ChildCount() const noexcept {
+            return ParentCount() * K;
+        }
 
         TString ToStr() const {
             return TStringBuilder()
-                << "{ K = " << K
+                << "{ K = " << K << ", ParentBegin = " << ParentBegin << ", ChildBegin = " << ChildBegin
                 << ", Level = " << Level << " / " << Levels
-                << ", Parent = " << Parent << " / " << ParentEnd
-                << ", State = " << State << " }";
+                << ", Parent = [" << ParentBegin << ".." << Parent << ".." << ParentEnd()
+                << "], Child = [" << ChildBegin << ".." << Child << ".." << ChildEnd()
+                << "], State = " << State << " }";
         }
 
-        static NTableIndex::TClusterId BinPow(NTableIndex::TClusterId k, ui32 l) {
-            NTableIndex::TClusterId r = 1;
-            while (l != 0) {
-                if (l % 2 != 0) {
-                    r *= k;
-                }
-                k *= k;
-                l /= 2;
-            }
-            return r;
-        }
-
-        bool NeedsAnotherLevel() const {
+        bool NeedsAnotherLevel() const noexcept {
             return Level < Levels;
         }
-        bool NeedsAnotherParent() const {
-            return Parent < ParentEnd;
+        bool NeedsAnotherParent() const noexcept {
+            return Parent < ParentEnd();
         }
-        bool NeedsAnotherState() const {
+        bool NeedsAnotherState() const noexcept {
             return State == Sample /*|| State == Recompute*/;
         }
 
-        bool NextState() {
+        bool NextState() noexcept {
             if (!NeedsAnotherState()) {
                 return false;
             }
@@ -3135,26 +3140,28 @@ struct TIndexBuildInfo: public TSimpleRefCount<TIndexBuildInfo> {
             return true;
         }
 
-        bool NextParent() {
+        bool NextParent() noexcept {
             if (!NeedsAnotherParent()) {
                 return false;
             }
-            ChildBegin += K;
             State = Sample;
             ++Parent;
+            Child += K;
             return true;
         }
 
-        bool NextLevel() {
+        bool NextLevel() noexcept {
             if (!NeedsAnotherLevel()) {
                 return false;
             }
-            ChildBegin += K;
             State = Sample;
-            ++Parent;
-            ParentEnd += BinPow(K, Level);
-            ++Level;
+            NextLevel(ParentCount());
             return true;
+        }
+
+        void PrefixTableDone(ui64 tableSize, ui64 shards) {
+            State = MultiLocal;
+            NextLevel((1 + tableSize) * shards);
         }
 
         void Set(ui32 level, NTableIndex::TClusterId parent, ui32 state) {
@@ -3201,11 +3208,8 @@ struct TIndexBuildInfo: public TSimpleRefCount<TIndexBuildInfo> {
         }
 
         std::pair<NTableIndex::TClusterId, NTableIndex::TClusterId> RangeToBorders(const TSerializedTableRange& range) const {
-            Y_ASSERT(ParentEnd != 0);
-            const NTableIndex::TClusterId maxParent = ParentEnd;
-            const NTableIndex::TClusterId levelSize = TKMeans::BinPow(K, Level - 1);
-            Y_ASSERT(levelSize <= maxParent);
-            const NTableIndex::TClusterId minParent = maxParent - levelSize + 1;
+            const NTableIndex::TClusterId minParent = ParentBegin;
+            const NTableIndex::TClusterId maxParent = ParentEnd();
             const NTableIndex::TClusterId parentFrom = [&, from = range.From.GetCells()] {
                 if (!from.empty()) {
                     if (!from[0].IsNull()) {
@@ -3222,9 +3226,9 @@ struct TIndexBuildInfo: public TSimpleRefCount<TIndexBuildInfo> {
                 }
                 return maxParent;
             }();
-            Y_VERIFY_DEBUG_S(minParent <= parentFrom, "minParent(" << minParent << ") > parentFrom(" << parentFrom << ")");
-            Y_VERIFY_DEBUG_S(parentFrom <= parentTo, "parentFrom(" << parentFrom << ") > parentTo(" << parentTo << ")");
-            Y_VERIFY_DEBUG_S(parentTo <= maxParent, "parentTo(" << parentTo << ") > maxParent(" << maxParent << ")");
+            Y_VERIFY_DEBUG_S(minParent <= parentFrom, "minParent(" << minParent << ") > parentFrom(" << parentFrom << ") " << ToStr());
+            Y_VERIFY_DEBUG_S(parentFrom <= parentTo, "parentFrom(" << parentFrom << ") > parentTo(" << parentTo << ") " << ToStr());
+            Y_VERIFY_DEBUG_S(parentTo <= maxParent, "parentTo(" << parentTo << ") > maxParent(" << maxParent << ") " << ToStr());
             return {parentFrom, parentTo};
         }
 
@@ -3248,6 +3252,15 @@ struct TIndexBuildInfo: public TSimpleRefCount<TIndexBuildInfo> {
                 return str << " }";
             };
             return TStringBuilder{} << "{ From: " << toStr(range.From) << ", To: " << toStr(range.To) << " }";
+        }
+
+    private:
+        void NextLevel(ui64 parentCount) noexcept {
+            ParentBegin = ChildBegin;
+            Parent = ParentBegin;
+            ChildBegin = ParentBegin + parentCount * K;
+            Child = ChildBegin;
+            ++Level;
         }
     };
     TKMeans KMeans;
@@ -3288,6 +3301,7 @@ struct TIndexBuildInfo: public TSimpleRefCount<TIndexBuildInfo> {
         TSerializedTableRange Range;
         TString LastKeyAck;
         ui64 SeqNoRound = 0;
+        size_t Index = 0;  // size of Shards map before this element was added
 
         NKikimrIndexBuilder::EBuildStatus Status = NKikimrIndexBuilder::EBuildStatus::INVALID;
 
@@ -3296,7 +3310,7 @@ struct TIndexBuildInfo: public TSimpleRefCount<TIndexBuildInfo> {
 
         TBillingStats Processed;
 
-        TShardStatus(TSerializedTableRange range, TString lastKeyAck);
+        TShardStatus(TSerializedTableRange range, TString lastKeyAck, size_t shardsCount);
 
         TString ToString(TShardIdx shardIdx = InvalidShardIdx) const {
             TStringBuilder result;
@@ -3485,6 +3499,12 @@ struct TIndexBuildInfo: public TSimpleRefCount<TIndexBuildInfo> {
         indexInfo->IndexName = row.template GetValue<Schema::IndexBuild::IndexName>();
         indexInfo->IndexType = row.template GetValue<Schema::IndexBuild::IndexType>();
 
+        // note: please note that here we specify BuildSecondaryIndex as operation default,
+        // because previosly this table was dedicated for build secondary index operations only.
+        indexInfo->BuildKind = TIndexBuildInfo::EBuildKind(
+            row.template GetValueOrDefault<Schema::IndexBuild::BuildKind>(
+                ui32(TIndexBuildInfo::EBuildKind::BuildSecondaryIndex)));
+
         // Restore the operation details: ImplTableDescriptions and SpecializedIndexDescription.
         if (row.template HaveValue<Schema::IndexBuild::CreationConfig>()) {
             NKikimrSchemeOp::TIndexCreationConfig creationConfig;
@@ -3500,7 +3520,7 @@ struct TIndexBuildInfo: public TSimpleRefCount<TIndexBuildInfo> {
                 case NKikimrSchemeOp::TIndexCreationConfig::kVectorIndexKmeansTreeDescription: {
                     auto& desc = *creationConfig.MutableVectorIndexKmeansTreeDescription();
                     indexInfo->KMeans.K = std::max<ui32>(2, desc.settings().clusters());
-                    indexInfo->KMeans.Levels = std::max<ui32>(1, desc.settings().levels());
+                    indexInfo->KMeans.Levels = indexInfo->IsBuildPrefixedVectorIndex() + std::max<ui32>(1, desc.settings().levels());
                     indexInfo->SpecializedIndexDescription =std::move(desc);
                 } break;
                 case NKikimrSchemeOp::TIndexCreationConfig::SPECIALIZEDINDEXDESCRIPTION_NOT_SET:
@@ -3566,19 +3586,12 @@ struct TIndexBuildInfo: public TSimpleRefCount<TIndexBuildInfo> {
             row.template GetValueOrDefault<Schema::IndexBuild::UnlockTxDone>(
                 indexInfo->UnlockTxDone);
 
-        // note: please note that here we specify BuildSecondaryIndex as operation default,
-        // because previosly this table was dedicated for build secondary index operations only.
-        indexInfo->BuildKind = TIndexBuildInfo::EBuildKind(
-            row.template GetValueOrDefault<Schema::IndexBuild::BuildKind>(
-                ui32(TIndexBuildInfo::EBuildKind::BuildSecondaryIndex)));
-
         indexInfo->AlterMainTableTxId =
             row.template GetValueOrDefault<Schema::IndexBuild::AlterMainTableTxId>(
                 indexInfo->AlterMainTableTxId);
         indexInfo->AlterMainTableTxStatus =
-            row
-                .template GetValueOrDefault<Schema::IndexBuild::AlterMainTableTxStatus>(
-                    indexInfo->AlterMainTableTxStatus);
+            row.template GetValueOrDefault<Schema::IndexBuild::AlterMainTableTxStatus>(
+                indexInfo->AlterMainTableTxStatus);
         indexInfo->AlterMainTableTxDone =
             row.template GetValueOrDefault<Schema::IndexBuild::AlterMainTableTxDone>(
                 indexInfo->AlterMainTableTxDone);
@@ -3623,7 +3636,7 @@ struct TIndexBuildInfo: public TSimpleRefCount<TIndexBuildInfo> {
             "AddShardStatus id# " << Id << " shard " << shardIdx << " range " << KMeans.RangeToDebugStr(bound));
         AddParent(bound, shardIdx);
         Shards.emplace(
-            shardIdx, TIndexBuildInfo::TShardStatus(std::move(bound), std::move(lastKeyAck)));
+            shardIdx, TIndexBuildInfo::TShardStatus(std::move(bound), std::move(lastKeyAck), Shards.size()));
         TIndexBuildInfo::TShardStatus &shardStatus = Shards.at(shardIdx);
 
         shardStatus.Status =
@@ -3661,8 +3674,12 @@ struct TIndexBuildInfo: public TSimpleRefCount<TIndexBuildInfo> {
         return BuildKind == EBuildKind::BuildSecondaryIndex;
     }
 
+    bool IsBuildPrefixedVectorIndex() const {
+        return BuildKind == EBuildKind::BuildPrefixedVectorIndex;
+    }
+
     bool IsBuildVectorIndex() const {
-        return BuildKind == EBuildKind::BuildVectorIndex;
+        return BuildKind == EBuildKind::BuildVectorIndex || IsBuildPrefixedVectorIndex();
     }
 
     bool IsBuildIndex() const {
@@ -3701,16 +3718,8 @@ struct TIndexBuildInfo: public TSimpleRefCount<TIndexBuildInfo> {
                 && toUpload == 0 && inProgress == 0) {
                 return 100.f;
             }
-            auto percent = static_cast<float>(KMeans.Level - 1) / KMeans.Levels;
-            auto multiply = 1.f / KMeans.Levels;
-            if (KMeans.State == TKMeans::MultiLocal) {
-                percent += (multiply * (total - inProgress - toUpload)) / total;
-            } else {
-                const auto parentSize = KMeans.BinPow(KMeans.K, KMeans.Level - 1);
-                const auto parentFrom = KMeans.ParentEnd - parentSize + 1;
-                percent += (multiply * (KMeans.Parent - parentFrom)) / parentSize;
-            }
-            return 100.f * percent;
+            // TODO(mbkkt) more detailed progress?
+            return (100.f * (KMeans.Level - 1)) / KMeans.Levels;
         }
         if (Shards) {
             return (100.f * done) / total;

--- a/ydb/core/tx/schemeshard/schemeshard_path_describer.cpp
+++ b/ydb/core/tx/schemeshard/schemeshard_path_describer.cpp
@@ -1401,12 +1401,6 @@ void TSchemeShard::DescribeTableIndex(const TPathId& pathId, const TString& name
     const auto* indexPathPtr = PathsById.FindPtr(pathId);
     Y_ABORT_UNLESS(indexPathPtr);
     const auto& indexPath = *indexPathPtr->Get();
-    if (const auto size = indexPath.GetChildren().size(); indexInfo->Type == NKikimrSchemeOp::EIndexType::EIndexTypeGlobalVectorKmeansTree) {
-        // For vector index we have 2-3 impl tables and 2 build impl tables
-        Y_VERIFY_S(2 <= size && size <= 5, size);
-    } else {
-        Y_VERIFY_S(size == 1, size);
-    }
 
     ui64 dataSize = 0;
     for (const auto& indexImplTablePathId : indexPath.GetChildren()) {

--- a/ydb/core/tx/schemeshard/schemeshard_path_describer.cpp
+++ b/ydb/core/tx/schemeshard/schemeshard_path_describer.cpp
@@ -1402,8 +1402,8 @@ void TSchemeShard::DescribeTableIndex(const TPathId& pathId, const TString& name
     Y_ABORT_UNLESS(indexPathPtr);
     const auto& indexPath = *indexPathPtr->Get();
     if (const auto size = indexPath.GetChildren().size(); indexInfo->Type == NKikimrSchemeOp::EIndexType::EIndexTypeGlobalVectorKmeansTree) {
-        // For vector index we have 2 impl tables and 2 build impl tables
-        Y_VERIFY_S(2 <= size && size <= 4, size);
+        // For vector index we have 2-3 impl tables and 2 build impl tables
+        Y_VERIFY_S(2 <= size && size <= 5, size);
     } else {
         Y_VERIFY_S(size == 1, size);
     }

--- a/ydb/core/tx/schemeshard/schemeshard_utils.cpp
+++ b/ydb/core/tx/schemeshard/schemeshard_utils.cpp
@@ -63,6 +63,71 @@ TTableColumns ExtractInfo(const NSchemeShard::TTableInfo::TPtr &tableInfo) {
     return result;
 }
 
+template<typename T>
+void FillIndexImplTableColumns(
+    const T& baseTableColumns,
+    std::span<const TString> keys,
+    const THashSet<TString>& columns,
+    NKikimrSchemeOp::TTableDescription& implTableDesc)
+{
+    // The function that calls this may have already added some columns
+    // and we want to add new columns after those that have already been added
+    const auto was = implTableDesc.ColumnsSize();
+
+    THashMap<TString, ui32> implKeyToImplColumn;
+    for (ui32 keyId = 0; keyId < keys.size(); ++keyId) {
+        implKeyToImplColumn[keys[keyId]] = keyId;
+    }
+
+    // We want data columns order in index table same as in indexed table,
+    // so we use counter to keep this order in the std::sort
+    // Counter starts with Max/2 to avoid intersection with key columns counter
+    for (ui32 i = Max<ui32>() / 2; auto& columnIt: baseTableColumns) {
+        NKikimrSchemeOp::TColumnDescription* column = nullptr;
+        using TColumn = std::decay_t<decltype(columnIt)>;
+        if constexpr (std::is_same_v<TColumn, std::pair<const ui32, NSchemeShard::TTableInfo::TColumn>>) {
+            const auto& columnInfo = columnIt.second;
+            if (!columnInfo.IsDropped() && columns.contains(columnInfo.Name)) {
+                column = implTableDesc.AddColumns();
+                column->SetName(columnInfo.Name);
+                column->SetType(NScheme::TypeName(columnInfo.PType, columnInfo.PTypeMod));
+                column->SetNotNull(columnInfo.NotNull);
+            }
+        } else if constexpr (std::is_same_v<TColumn, NKikimrSchemeOp::TColumnDescription>) {
+            if (columns.contains(columnIt.GetName())) {
+                column = implTableDesc.AddColumns();
+                *column = columnIt;
+                column->ClearFamily();
+                column->ClearFamilyName();
+                column->ClearDefaultValue();
+            }
+        } else {
+            static_assert(dependent_false<TColumn>::value);
+        }
+        if (column) {
+            ui32 order = i++;
+            if (const auto* id = implKeyToImplColumn.FindPtr(column->GetName())) {
+                order = *id;
+            }
+            column->SetId(order);
+        }
+    }
+
+    std::sort(implTableDesc.MutableColumns()->begin() + was,
+              implTableDesc.MutableColumns()->end(),
+              [] (auto& left, auto& right) {
+                  return left.GetId() < right.GetId();
+              });
+
+    for (auto& column: *implTableDesc.MutableColumns()) {
+        column.ClearId();
+    }
+
+    for (const auto& keyName: keys) {
+        implTableDesc.AddKeyColumnNames(keyName);
+    }
+}
+
 namespace {
 
 NKikimrSchemeOp::TPartitionConfig PartitionConfigForIndexes(
@@ -156,70 +221,6 @@ void SetImplTablePartitionConfig(
     }
 
     *tableDescription.MutablePartitionConfig() = PartitionConfigForIndexes(baseTablePartitionConfig, indexTableDesc);
-}
-
-void FillIndexImplTableColumns(
-    const auto& baseTableColumns,
-    std::span<const TString> keys,
-    const THashSet<TString>& columns,
-    NKikimrSchemeOp::TTableDescription& implTableDesc)
-{
-    // The function that calls this may have already added some columns
-    // and we want to add new columns after those that have already been added
-    const auto was = implTableDesc.ColumnsSize();
-
-    THashMap<TString, ui32> implKeyToImplColumn;
-    for (ui32 keyId = 0; keyId < keys.size(); ++keyId) {
-        implKeyToImplColumn[keys[keyId]] = keyId;
-    }
-
-    // We want data columns order in index table same as in indexed table,
-    // so we use counter to keep this order in the std::sort
-    // Counter starts with Max/2 to avoid intersection with key columns counter
-    for (ui32 i = Max<ui32>() / 2; auto& columnIt: baseTableColumns) {
-        NKikimrSchemeOp::TColumnDescription* column = nullptr;
-        using TColumn = std::decay_t<decltype(columnIt)>;
-        if constexpr (std::is_same_v<TColumn, std::pair<const ui32, NSchemeShard::TTableInfo::TColumn>>) {
-            const auto& columnInfo = columnIt.second;
-            if (!columnInfo.IsDropped() && columns.contains(columnInfo.Name)) {
-                column = implTableDesc.AddColumns();
-                column->SetName(columnInfo.Name);
-                column->SetType(NScheme::TypeName(columnInfo.PType, columnInfo.PTypeMod));
-                column->SetNotNull(columnInfo.NotNull);
-            }
-        } else if constexpr (std::is_same_v<TColumn, NKikimrSchemeOp::TColumnDescription>) {
-            if (columns.contains(columnIt.GetName())) {
-                column = implTableDesc.AddColumns();
-                *column = columnIt;
-                column->ClearFamily();
-                column->ClearFamilyName();
-                column->ClearDefaultValue();
-            }
-        } else {
-            static_assert(dependent_false<TColumn>::value);
-        }
-        if (column) {
-            ui32 order = i++;
-            if (const auto* id = implKeyToImplColumn.FindPtr(column->GetName())) {
-                order = *id;
-            }
-            column->SetId(order);
-        }
-    }
-
-    std::sort(implTableDesc.MutableColumns()->begin() + was,
-              implTableDesc.MutableColumns()->end(),
-              [] (auto& left, auto& right) {
-                  return left.GetId() < right.GetId();
-              });
-
-    for (auto& column: *implTableDesc.MutableColumns()) {
-        column.ClearId();
-    }
-
-    for (const auto& keyName: keys) {
-        implTableDesc.AddKeyColumnNames(keyName);
-    }
 }
 
 const auto& GetPartitionConfig(const NSchemeShard::TTableInfo::TPtr& tableInfo) {

--- a/ydb/core/tx/schemeshard/schemeshard_utils.h
+++ b/ydb/core/tx/schemeshard/schemeshard_utils.h
@@ -96,6 +96,13 @@ TTableColumns ExtractInfo(const NSchemeShard::TTableInfo::TPtr& tableInfo);
 TTableColumns ExtractInfo(const NKikimrSchemeOp::TTableDescription& tableDesc);
 TIndexColumns ExtractInfo(const NKikimrSchemeOp::TIndexCreationConfig& indexDesc);
 
+template<typename T>
+void FillIndexImplTableColumns(
+    const T& baseTableColumns,
+    std::span<const TString> keys,
+    const THashSet<TString>& columns,
+    NKikimrSchemeOp::TTableDescription& implTableDesc);
+
 using TColumnTypes = THashMap<TString, NScheme::TTypeInfo>;
 
 bool ExtractTypes(const NSchemeShard::TTableInfo::TPtr& baseTableInfo, TColumnTypes& columnsTypes, TString& explain);

--- a/ydb/core/tx/schemeshard/schemeshard_utils.h
+++ b/ydb/core/tx/schemeshard/schemeshard_utils.h
@@ -96,9 +96,8 @@ TTableColumns ExtractInfo(const NSchemeShard::TTableInfo::TPtr& tableInfo);
 TTableColumns ExtractInfo(const NKikimrSchemeOp::TTableDescription& tableDesc);
 TIndexColumns ExtractInfo(const NKikimrSchemeOp::TIndexCreationConfig& indexDesc);
 
-template<typename T>
-void FillIndexImplTableColumns(
-    const T& baseTableColumns,
+void FillIndexTableColumns(
+    const THashMap<ui32, NSchemeShard::TTableInfo::TColumn>& baseTableColumns,
     std::span<const TString> keys,
     const THashSet<TString>& columns,
     NKikimrSchemeOp::TTableDescription& implTableDesc);

--- a/ydb/core/tx/tx_proxy/upload_rows_common_impl.h
+++ b/ydb/core/tx/tx_proxy/upload_rows_common_impl.h
@@ -343,7 +343,7 @@ private:
     }
 
     TStringBuilder LogPrefix() {
-        return TStringBuilder() << "Bulk upsert to table '" << GetTable() << "'";
+        return TStringBuilder() << "Bulk upsert to table '" << GetTable() << "' ";
     }
 
     static bool SameDstType(NScheme::TTypeInfo type1, NScheme::TTypeInfo type2, bool allowConvert) {

--- a/ydb/services/ydb/backup_ut/ydb_backup_ut.cpp
+++ b/ydb/services/ydb/backup_ut/ydb_backup_ut.cpp
@@ -1830,6 +1830,10 @@ Y_UNIT_TEST_SUITE(BackupRestore) {
                 UNIT_FAIL("Client backup/restore were not implemented for this index type");
         }
     }
+
+    Y_UNIT_TEST(PrefixedVectorIndex) {
+        TestTableWithIndexBackupRestore(NKikimrSchemeOp::EIndexTypeGlobalVectorKmeansTree);
+    }
 }
 
 Y_UNIT_TEST_SUITE(BackupRestoreS3) {

--- a/ydb/services/ydb/backup_ut/ydb_backup_ut.cpp
+++ b/ydb/services/ydb/backup_ut/ydb_backup_ut.cpp
@@ -235,7 +235,7 @@ auto CreateMinPartitionsChecker(ui32 expectedMinPartitions, const TString& debug
     };
 }
 
-auto CreateHasIndexChecker(const TString& indexName, EIndexType indexType) {
+auto CreateHasIndexChecker(const TString& indexName, EIndexType indexType, bool prefix) {
     return [=](const TTableDescription& tableDescription) {
         for (const auto& indexDesc : tableDescription.GetIndexDescriptions()) {
             if (indexDesc.GetIndexName() != indexName) {
@@ -244,13 +244,16 @@ auto CreateHasIndexChecker(const TString& indexName, EIndexType indexType) {
             if (indexDesc.GetIndexType() != indexType) {
                 continue;
             }
-            if (indexDesc.GetIndexColumns().size() != 1) {
+            if (indexDesc.GetIndexColumns().size() != (prefix ? 2 : 1)) {
                 continue;
             }
             if (indexDesc.GetDataColumns().size() != 0) {
                 continue;
             }
-            if (indexDesc.GetIndexColumns()[0] != "Value") {
+            if (prefix && indexDesc.GetIndexColumns().front() != "Group") {
+                continue;
+            }
+            if (indexDesc.GetIndexColumns().back() != "Value") {
                 continue;
             }
             if (indexType != NYdb::NTable::EIndexType::GlobalVectorKMeansTree) {
@@ -587,23 +590,37 @@ NYdb::NTable::EIndexType ConvertIndexTypeToAPI(NKikimrSchemeOp::EIndexType index
 }
 
 void TestRestoreTableWithIndex(
-    const char* table, const char* index, NKikimrSchemeOp::EIndexType indexType, TSession& session,
+    const char* table, const char* index, NKikimrSchemeOp::EIndexType indexType, bool prefix, TSession& session,
     TBackupFunction&& backup, TRestoreFunction&& restore
 ) {
     TString query;
     if (indexType == NKikimrSchemeOp::EIndexTypeGlobalVectorKmeansTree) {
-        query = Sprintf(R"(CREATE TABLE `%s` (
-            Key Uint32,
-            Value String,
-            PRIMARY KEY (Key),
-            INDEX %s GLOBAL USING vector_kmeans_tree
-                ON (Value)
-                WITH (similarity=inner_product, vector_type=float, vector_dimension=768, levels=2, clusters=80)
-        );)", table, index);
+        if (prefix) {
+            query = Sprintf(R"(CREATE TABLE `%s` (
+                Key Uint32,
+                Group Uint32,
+                Value String,
+                PRIMARY KEY (Key),
+                INDEX %s GLOBAL USING vector_kmeans_tree
+                    ON (Group, Value)
+                    WITH (similarity=inner_product, vector_type=float, vector_dimension=768, levels=2, clusters=80)
+            );)", table, index);
+        } else {
+            query = Sprintf(R"(CREATE TABLE `%s` (
+                Key Uint32,
+                Group Uint32,
+                Value String,
+                PRIMARY KEY (Key),
+                INDEX %s GLOBAL USING vector_kmeans_tree
+                    ON (Value)
+                    WITH (similarity=inner_product, vector_type=float, vector_dimension=768, levels=2, clusters=80)
+            );)", table, index);
+        }
     } else {
         query = Sprintf(R"(
             CREATE TABLE `%s` (
                 Key Uint32,
+                Group Uint32,
                 Value Uint32,
                 PRIMARY KEY (Key),
                 INDEX %s %s ON (Value)
@@ -622,7 +639,7 @@ void TestRestoreTableWithIndex(
 
     restore();
 
-    CheckTableDescription(session, table, CreateHasIndexChecker(index, ConvertIndexTypeToAPI(indexType)));
+    CheckTableDescription(session, table, CreateHasIndexChecker(index, ConvertIndexTypeToAPI(indexType), prefix));
 }
 
 void TestRestoreDirectory(const char* directory, TSchemeClient& client, TBackupFunction&& backup, TRestoreFunction&& restore) {
@@ -1487,7 +1504,7 @@ Y_UNIT_TEST_SUITE(BackupRestore) {
         );
     }
 
-    void TestTableWithIndexBackupRestore(NKikimrSchemeOp::EIndexType indexType = NKikimrSchemeOp::EIndexTypeGlobal) {
+    void TestTableWithIndexBackupRestore(NKikimrSchemeOp::EIndexType indexType = NKikimrSchemeOp::EIndexTypeGlobal, bool prefix = false) {
         NKikimrConfig::TAppConfig appConfig;
         appConfig.MutableFeatureFlags()->SetEnableVectorIndex(true);
         TKikimrWithGrpcAndRootSchema server{std::move(appConfig)};
@@ -1504,6 +1521,7 @@ Y_UNIT_TEST_SUITE(BackupRestore) {
             table,
             index,
             indexType,
+            prefix,
             session,
             CreateBackupLambda(driver, pathToBackup),
             CreateRestoreLambda(driver, pathToBackup)
@@ -1832,7 +1850,7 @@ Y_UNIT_TEST_SUITE(BackupRestore) {
     }
 
     Y_UNIT_TEST(PrefixedVectorIndex) {
-        TestTableWithIndexBackupRestore(NKikimrSchemeOp::EIndexTypeGlobalVectorKmeansTree);
+        TestTableWithIndexBackupRestore(NKikimrSchemeOp::EIndexTypeGlobalVectorKmeansTree, true);
     }
 }
 
@@ -2221,7 +2239,7 @@ Y_UNIT_TEST_SUITE(BackupRestoreS3) {
         );
     }
 
-    void TestTableWithIndexBackupRestore(NKikimrSchemeOp::EIndexType indexType = NKikimrSchemeOp::EIndexTypeGlobal) {
+    void TestTableWithIndexBackupRestore(NKikimrSchemeOp::EIndexType indexType = NKikimrSchemeOp::EIndexTypeGlobal, bool prefix = false) {
         TS3TestEnv testEnv;
         constexpr const char* table = "/Root/table";
         constexpr const char* index = "value_idx";
@@ -2230,6 +2248,7 @@ Y_UNIT_TEST_SUITE(BackupRestoreS3) {
             table,
             index,
             indexType,
+            prefix,
             testEnv.GetTableSession(),
             CreateBackupLambda(testEnv.GetDriver(), testEnv.GetS3Port()),
             CreateRestoreLambda(testEnv.GetDriver(), testEnv.GetS3Port(), { "table" })
@@ -2348,5 +2367,9 @@ Y_UNIT_TEST_SUITE(BackupRestoreS3) {
             default:
                 UNIT_FAIL("S3 backup/restore were not implemented for this index type");
         }
+    }
+
+    Y_UNIT_TEST(PrefixedVectorIndex) {
+        TestTableWithIndexBackupRestore(NKikimrSchemeOp::EIndexTypeGlobalVectorKmeansTree, true);
     }
 }


### PR DESCRIPTION
### Changelog category <!-- remove all except one -->

* Not for changelog (changelog entry is not required)

### Description for reviewers <!-- (optional) description for those who read this PR -->

It finishes initial prefixed vector index implementation, except:
1. search in kqp over such index
2. filling prefix impl table (can be easily separated, PR already big, so better to add it in prefix_kmeans in next PR)