### PR TITLE
The `TxUsage::Write_Random_Sized_Messages_In_Wide_Transactions` test is running for a long time

### DIFF
--- a/ydb/public/sdk/cpp/src/client/topic/ut/topic_to_table_ut.cpp
+++ b/ydb/public/sdk/cpp/src/client/topic/ut/topic_to_table_ut.cpp
@@ -3026,7 +3026,7 @@ Y_UNIT_TEST_F(Write_Random_Sized_Messages_In_Wide_Transactions, TFixture)
     // will make sure that when committing transactions, the division into blocks is taken into account.
 
     const size_t PARTITIONS_COUNT = 20;
-    const size_t TXS_COUNT = 100;
+    const size_t TXS_COUNT = 10;
 
     CreateTopic("topic_A", TEST_CONSUMER, PARTITIONS_COUNT);
 

--- a/ydb/public/sdk/cpp/src/client/topic/ut/ya.make
+++ b/ydb/public/sdk/cpp/src/client/topic/ut/ya.make
@@ -1,5 +1,7 @@
 UNITTEST_FOR(ydb/public/sdk/cpp/src/client/topic)
 
+REQUIREMENTS(ram:32)
+
 INCLUDE(${ARCADIA_ROOT}/ydb/public/sdk/cpp/sdk_common.inc)
 
 IF (SANITIZER_TYPE OR WITH_VALGRIND)


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

The test takes a long time to complete. Reduced the number of transactions. This is enough to show the error.

### Changelog category <!-- remove all except one -->

* Not for changelog (changelog entry is not required)

### Description for reviewers <!-- (optional) description for those who read this PR -->

...
