### PR TITLE
25-1: security: improve database admin access check

### DIFF
--- a/ydb/core/kqp/compute_actor/kqp_pure_compute_actor.cpp
+++ b/ydb/core/kqp/compute_actor/kqp_pure_compute_actor.cpp
@@ -283,7 +283,7 @@ void TKqpComputeActor::HandleExecute(TEvKqpCompute::TEvScanError::TPtr& ev) {
     IssuesFromMessage(ev->Get()->Record.GetIssues(), issues);
 
     State = NDqProto::COMPUTE_STATE_FAILURE;
-    ReportStateAndMaybeDie(YdbStatusToDqStatus(status), issues);
+    ReportStateAndMaybeDie(YdbStatusToDqStatus(status, EStatusCompatibilityLevel::WithUnauthorized), issues);
 }
 
 IActor* CreateKqpComputeActor(const TActorId& executerId, ui64 txId, NDqProto::TDqTask* task,

--- a/ydb/core/sys_view/auth/users.cpp
+++ b/ydb/core/sys_view/auth/users.cpp
@@ -44,6 +44,12 @@ public:
 protected:
     void ProceedToScan() override {
         TBase::Become(&TUsersScan::StateScan);
+
+        //NOTE: here is the earliest point when Base::DatabaseOwner is already set
+        bool isClusterAdmin = IsAdministrator(AppData(), UserToken.Get());
+        bool isDatabaseAdmin = (AppData()->FeatureFlags.GetEnableDatabaseAdmin() && IsDatabaseAdministrator(UserToken.Get(), TBase::DatabaseOwner));
+        IsAdmin = isClusterAdmin || isDatabaseAdmin;
+
         if (TBase::AckReceived) {
             StartScan();
         }
@@ -97,9 +103,9 @@ protected:
         SortBatch(users, [](const auto* left, const auto* right) {
             return left->GetName() < right->GetName();
         });
-        
+
         TVector<TCell> cells(::Reserve(Columns.size()));
-        
+
         for (const auto* user : users) {
             for (auto& column : Columns) {
                 switch (column.Tag) {
@@ -156,7 +162,7 @@ protected:
 
 private:
     bool CanAccessUser(const TString& user) {
-        if (IsAdministrator(AppData(), UserToken.Get())) {
+        if (IsAdmin) {
             return true;
         }
 
@@ -165,6 +171,7 @@ private:
 
 private:
     const TIntrusiveConstPtr<NACLib::TUserToken> UserToken;
+    bool IsAdmin = false;
 };
 
 THolder<NActors::IActor> CreateUsersScan(const NActors::TActorId& ownerId, ui32 scanId, const TTableId& tableId,

--- a/ydb/core/sys_view/common/scan_actor_base_impl.h
+++ b/ydb/core/sys_view/common/scan_actor_base_impl.h
@@ -297,6 +297,8 @@ private:
         DomainKey = entry.DomainInfo->DomainKey;
 
         TenantName = CanonizePath(entry.Path);
+        DatabaseOwner = entry.Self->Info.GetOwner();
+        Y_ABORT_UNLESS(entry.Self->Info.GetOwner() == entry.SecurityObject->GetOwnerSID());
 
         TBase::Register(CreateTenantNodeEnumerationLookup(TBase::SelfId(), TenantName));
         TBase::Become(&TDerived::StateLookup);
@@ -313,9 +315,10 @@ private:
             "Scan prepared, actor: " << TBase::SelfId()
                 << ", schemeshard id: " << SchemeShardId
                 << ", hive id: " << HiveId
-                << ", tenant name: " << TenantName
+                << ", database: " << TenantName
+                << ", database owner: " << DatabaseOwner
                 << ", domain key: " << DomainKey
-                << ", tenant node count: " << TenantNodes.size());
+                << ", database node count: " << TenantNodes.size());
 
         ProceedToScan();
     }
@@ -370,6 +373,7 @@ protected:
     ui64 SchemeShardId = 0;
     TPathId DomainKey;
     TString TenantName;
+    NACLib::TSID DatabaseOwner;
     THashSet<ui32> TenantNodes;
     ui64 HiveId = 0;
     ui64 SysViewProcessorId = 0;

--- a/ydb/core/sys_view/ut_kqp.cpp
+++ b/ydb/core/sys_view/ut_kqp.cpp
@@ -132,11 +132,19 @@ void SetupAuthAccessEnvironment(TTestEnv& env) {
     env.GetClient().CreateUser("/Root", "user2", "password2");
     env.GetClient().CreateUser("/Root/Tenant1", "user3", "password3");
     env.GetClient().CreateUser("/Root/Tenant1", "user4", "password4");
+    env.GetClient().CreateUser("/Root/Tenant2", "user5", "password5");
+
+    // Note: in real scenarios user6tenant1admin should be created in /Root/Tenant1
+    // but it isn't supported by test framework
+    env.GetClient().CreateUser("/Root", "user6tenant1admin", "password6");
+    env.GetClient().ModifyOwner("/Root", "Tenant1", "user6tenant1admin");
 
     {
         NACLib::TDiffACL acl;
         acl.AddAccess(NACLib::EAccessType::Allow, NACLib::GenericUse, "user1rootadmin");
         acl.AddAccess(NACLib::EAccessType::Allow, NACLib::GenericUse, "user2");
+        acl.AddAccess(NACLib::EAccessType::Allow, NACLib::GenericUse, "user6tenant1admin");
+        acl.AddAccess(NACLib::EAccessType::Allow, NACLib::GenericFull, "root@builtin");
         env.GetClient().ModifyACL("", "Root", acl.SerializeAsString());
     }
 }
@@ -144,6 +152,13 @@ void SetupAuthAccessEnvironment(TTestEnv& env) {
 void CheckAuthAdministratorAccessIsRequired(TScanQueryPartIterator& it) {
     NKqp::StreamResultToYson(it, false, EStatus::INTERNAL_ERROR, 
         "Administrator access is required");
+}
+
+void CheckEmpty(TScanQueryPartIterator& it) {
+    auto expected = R"([
+
+    ])";
+    NKqp::CompareYson(expected, NKqp::StreamResultToYson(it));
 }
 
 class TYsonFieldChecker {
@@ -2242,21 +2257,40 @@ Y_UNIT_TEST_SUITE(SystemView) {
         SetupAuthAccessEnvironment(env);
         TTableClient client(env.GetDriver());
 
+        // Cerr << env.GetClient().Describe(env.GetServer().GetRuntime(), "/Root/Tenant1").DebugString() << Endl;
+
         { // anonymous login doesn't give administrative access as `AdministrationAllowedSIDs` isn't empty
             auto driverConfig = TDriverConfig()
                 .SetEndpoint(env.GetEndpoint());
             auto driver = TDriver(driverConfig);
             TTableClient client(driver);
 
-            auto it = client.StreamExecuteScanQuery(R"(
-                SELECT Sid
-                FROM `Root/.sys/auth_users`
-            )").GetValueSync();
+            {
+                auto it = client.StreamExecuteScanQuery(R"(
+                    SELECT Sid
+                    FROM `Root/.sys/auth_users`
+                )").GetValueSync();
 
-            auto expected = R"([
+                CheckEmpty(it);
+            }
 
-            ])";
-            NKqp::CompareYson(expected, NKqp::StreamResultToYson(it));
+            {
+                auto it = client.StreamExecuteScanQuery(R"(
+                    SELECT Sid
+                    FROM `Root/Tenant1/.sys/auth_users`
+                )").GetValueSync();
+
+                CheckEmpty(it);
+            }
+
+            {
+                auto it = client.StreamExecuteScanQuery(R"(
+                    SELECT Sid
+                    FROM `Root/Tenant2/.sys/auth_users`
+                )").GetValueSync();
+
+                CheckEmpty(it);
+            }
         }
         
         { // user1rootadmin is /Root admin
@@ -2278,6 +2312,7 @@ Y_UNIT_TEST_SUITE(SystemView) {
                 auto expected = R"([
                     [["user1rootadmin"]];
                     [["user2"]];
+                    [["user6tenant1admin"]];
                 ])";
                 NKqp::CompareYson(expected, NKqp::StreamResultToYson(it));
             }
@@ -2291,6 +2326,18 @@ Y_UNIT_TEST_SUITE(SystemView) {
                 auto expected = R"([
                     [["user3"]];
                     [["user4"]];
+                ])";
+                NKqp::CompareYson(expected, NKqp::StreamResultToYson(it));
+            }
+
+            {
+                auto it = client.StreamExecuteScanQuery(R"(
+                    SELECT Sid
+                    FROM `Root/Tenant2/.sys/auth_users`
+                )").GetValueSync();
+
+                auto expected = R"([
+                    [["user5"]];
                 ])";
                 NKqp::CompareYson(expected, NKqp::StreamResultToYson(it));
             }
@@ -2324,15 +2371,64 @@ Y_UNIT_TEST_SUITE(SystemView) {
                     FROM `Root/Tenant1/.sys/auth_users`
                 )").GetValueSync();
 
-                auto expected = R"([
+                CheckEmpty(it);
+            }
 
-                ])";
-                NKqp::CompareYson(expected, NKqp::StreamResultToYson(it));
+            {
+                auto it = client.StreamExecuteScanQuery(R"(
+                    SELECT Sid
+                    FROM `Root/Tenant2/.sys/auth_users`
+                )").GetValueSync();
+
+                CheckEmpty(it);
             }
         }
 
-        // TODO: fix https://github.com/ydb-platform/ydb/issues/13730
-        // and test tenant user and tenant admin
+        { // user6tenant1admin is /Root/Tenant1 admin
+            auto driverConfig = TDriverConfig()
+                .SetEndpoint(env.GetEndpoint())
+                .SetCredentialsProviderFactory(NYdb::CreateLoginCredentialsProviderFactory({
+                    .User = "user6tenant1admin",
+                    .Password = "password6",
+                }));
+            auto driver = TDriver(driverConfig);
+            TTableClient client(driver);
+
+            {
+                auto it = client.StreamExecuteScanQuery(R"(
+                    SELECT Sid
+                    FROM `Root/.sys/auth_users`
+                )").GetValueSync();
+
+                auto expected = R"([
+                    [["user6tenant1admin"]];
+                ])";
+                NKqp::CompareYson(expected, NKqp::StreamResultToYson(it));
+            }
+
+            // TODO: make it work
+            // {
+            //     auto it = client.StreamExecuteScanQuery(R"(
+            //         SELECT Sid
+            //         FROM `Root/Tenant1/.sys/auth_users`
+            //     )").GetValueSync();
+
+            //     auto expected = R"([
+            //         [["user3"]];
+            //         [["user4"]];
+            //     ])";
+            //     NKqp::CompareYson(expected, NKqp::StreamResultToYson(it));
+            // }
+
+            {
+                auto it = client.StreamExecuteScanQuery(R"(
+                    SELECT Sid
+                    FROM `Root/Tenant2/.sys/auth_users`
+                )").GetValueSync();
+
+                CheckEmpty(it);
+            }
+        }
     }
 
     Y_UNIT_TEST(AuthUsers_ResultOrder) {
@@ -2564,6 +2660,7 @@ Y_UNIT_TEST_SUITE(SystemView) {
         env.GetClient().CreateGroup("/Root", "group2");
         env.GetClient().CreateGroup("/Root/Tenant1", "group3");
         env.GetClient().CreateGroup("/Root/Tenant1", "group4");
+        env.GetClient().CreateGroup("/Root/Tenant2", "group5");
 
         { // anonymous login doesn't give administrative access as `AdministrationAllowedSIDs` isn't empty
             auto driverConfig = TDriverConfig()
@@ -2571,12 +2668,32 @@ Y_UNIT_TEST_SUITE(SystemView) {
             auto driver = TDriver(driverConfig);
             TTableClient client(driver);
 
-            auto it = client.StreamExecuteScanQuery(R"(
-                SELECT Sid
-                FROM `Root/.sys/auth_groups`
-            )").GetValueSync();
+            {
+                auto it = client.StreamExecuteScanQuery(R"(
+                    SELECT Sid
+                    FROM `Root/.sys/auth_groups`
+                )").GetValueSync();
 
-            CheckAuthAdministratorAccessIsRequired(it);
+                CheckAuthAdministratorAccessIsRequired(it);
+            }
+
+            {
+                auto it = client.StreamExecuteScanQuery(R"(
+                    SELECT Sid
+                    FROM `Root/Tenant1/.sys/auth_groups`
+                )").GetValueSync();
+
+                CheckAuthAdministratorAccessIsRequired(it);
+            }
+
+            {
+                auto it = client.StreamExecuteScanQuery(R"(
+                    SELECT Sid
+                    FROM `Root/Tenant2/.sys/auth_groups`
+                )").GetValueSync();
+
+                CheckAuthAdministratorAccessIsRequired(it);
+            }
         }
 
         { // user1rootadmin is /Root admin
@@ -2614,6 +2731,18 @@ Y_UNIT_TEST_SUITE(SystemView) {
                 ])";
                 NKqp::CompareYson(expected, NKqp::StreamResultToYson(it));
             }
+
+            {
+                auto it = client.StreamExecuteScanQuery(R"(
+                    SELECT Sid
+                    FROM `Root/Tenant2/.sys/auth_groups`
+                )").GetValueSync();
+
+                auto expected = R"([
+                    [["group5"]];
+                ])";
+                NKqp::CompareYson(expected, NKqp::StreamResultToYson(it));
+            }
         }
 
         { // user2 isn't /Root admin
@@ -2643,10 +2772,59 @@ Y_UNIT_TEST_SUITE(SystemView) {
 
                 CheckAuthAdministratorAccessIsRequired(it);
             }
+
+            {
+                auto it = client.StreamExecuteScanQuery(R"(
+                    SELECT Sid
+                    FROM `Root/Tenant2/.sys/auth_groups`
+                )").GetValueSync();
+
+                CheckAuthAdministratorAccessIsRequired(it);
+            }
         }
 
-        // TODO: fix https://github.com/ydb-platform/ydb/issues/13730
-        // and test tenant user and tenant admin
+        { // user6tenant1admin is /Root/Tenant1 admin
+            auto driverConfig = TDriverConfig()
+                .SetEndpoint(env.GetEndpoint())
+                .SetCredentialsProviderFactory(NYdb::CreateLoginCredentialsProviderFactory({
+                    .User = "user6tenant1admin",
+                    .Password = "password6",
+                }));
+            auto driver = TDriver(driverConfig);
+            TTableClient client(driver);
+
+            {
+                auto it = client.StreamExecuteScanQuery(R"(
+                    SELECT Sid
+                    FROM `Root/.sys/auth_groups`
+                )").GetValueSync();
+
+                CheckAuthAdministratorAccessIsRequired(it);
+            }
+
+            // TODO: make it work
+            // {
+            //     auto it = client.StreamExecuteScanQuery(R"(
+            //         SELECT Sid
+            //         FROM `Root/Tenant1/.sys/auth_groups`
+            //     )").GetValueSync();
+
+            //     auto expected = R"([
+            //         [["group3"]];
+            //         [["group4"]];
+            //     ])";
+            //     NKqp::CompareYson(expected, NKqp::StreamResultToYson(it));
+            // }
+
+            {
+                auto it = client.StreamExecuteScanQuery(R"(
+                    SELECT Sid
+                    FROM `Root/Tenant2/.sys/auth_groups`
+                )").GetValueSync();
+
+                CheckAuthAdministratorAccessIsRequired(it);
+            }
+        }
     }
 
     Y_UNIT_TEST(AuthGroups_ResultOrder) {
@@ -2799,11 +2977,13 @@ Y_UNIT_TEST_SUITE(SystemView) {
         env.GetClient().CreateGroup("/Root", "group2");
         env.GetClient().CreateGroup("/Root/Tenant1", "group3");
         env.GetClient().CreateGroup("/Root/Tenant1", "group4");
+        env.GetClient().CreateGroup("/Root/Tenant2", "group5");
 
         env.GetClient().AddGroupMembership("/Root", "group1", "user1rootadmin");
         env.GetClient().AddGroupMembership("/Root", "group2", "user2");
         env.GetClient().AddGroupMembership("/Root/Tenant1", "group3", "user3");
         env.GetClient().AddGroupMembership("/Root/Tenant1", "group4", "user4");
+        env.GetClient().AddGroupMembership("/Root/Tenant2", "group5", "user5");
 
         { // anonymous login doesn't give administrative access as `AdministrationAllowedSIDs` isn't empty
             auto driverConfig = TDriverConfig()
@@ -2811,12 +2991,32 @@ Y_UNIT_TEST_SUITE(SystemView) {
             auto driver = TDriver(driverConfig);
             TTableClient client(driver);
 
-            auto it = client.StreamExecuteScanQuery(R"(
-                SELECT *
-                FROM `Root/.sys/auth_group_members`
-            )").GetValueSync();
+            {
+                auto it = client.StreamExecuteScanQuery(R"(
+                    SELECT *
+                    FROM `Root/.sys/auth_group_members`
+                )").GetValueSync();
 
-            CheckAuthAdministratorAccessIsRequired(it);
+                CheckAuthAdministratorAccessIsRequired(it);
+            }
+
+            {
+                auto it = client.StreamExecuteScanQuery(R"(
+                    SELECT *
+                    FROM `Root/Tenant1/.sys/auth_group_members`
+                )").GetValueSync();
+
+                CheckAuthAdministratorAccessIsRequired(it);
+            }
+
+            {
+                auto it = client.StreamExecuteScanQuery(R"(
+                    SELECT *
+                    FROM `Root/Tenant2/.sys/auth_group_members`
+                )").GetValueSync();
+
+                CheckAuthAdministratorAccessIsRequired(it);
+            }
         }
 
         { // user1rootadmin is /Root admin
@@ -2854,6 +3054,18 @@ Y_UNIT_TEST_SUITE(SystemView) {
                 ])";
                 NKqp::CompareYson(expected, NKqp::StreamResultToYson(it));
             }
+
+            {
+                auto it = client.StreamExecuteScanQuery(R"(
+                    SELECT *
+                    FROM `Root/Tenant2/.sys/auth_group_members`
+                )").GetValueSync();
+
+                auto expected = R"([
+                    [["group5"];["user5"]];
+                ])";
+                NKqp::CompareYson(expected, NKqp::StreamResultToYson(it));
+            }
         }
 
         { // user2 isn't /Root admin
@@ -2883,10 +3095,59 @@ Y_UNIT_TEST_SUITE(SystemView) {
 
                 CheckAuthAdministratorAccessIsRequired(it);
             }
+
+            {
+                auto it = client.StreamExecuteScanQuery(R"(
+                    SELECT *
+                    FROM `Root/Tenant2/.sys/auth_group_members`
+                )").GetValueSync();
+
+                CheckAuthAdministratorAccessIsRequired(it);
+            }
         }
 
-        // TODO: fix https://github.com/ydb-platform/ydb/issues/13730
-        // and test tenant user and tenant admin
+        { // user6tenant1admin is /Root/Tenant1 admin
+            auto driverConfig = TDriverConfig()
+                .SetEndpoint(env.GetEndpoint())
+                .SetCredentialsProviderFactory(NYdb::CreateLoginCredentialsProviderFactory({
+                    .User = "user6tenant1admin",
+                    .Password = "password6",
+                }));
+            auto driver = TDriver(driverConfig);
+            TTableClient client(driver);
+
+            {
+                auto it = client.StreamExecuteScanQuery(R"(
+                    SELECT *
+                    FROM `Root/.sys/auth_group_members`
+                )").GetValueSync();
+
+                CheckAuthAdministratorAccessIsRequired(it);
+            }
+
+            // TODO: make it work
+            // {
+            //     auto it = client.StreamExecuteScanQuery(R"(
+            //         SELECT *
+            //         FROM `Root/Tenant1/.sys/auth_group_members`
+            //     )").GetValueSync();
+
+            //     auto expected = R"([
+            //         [["group3"];["user3"]];
+            //         [["group4"];["user4"]];
+            //     ])";
+            //     NKqp::CompareYson(expected, NKqp::StreamResultToYson(it));
+            // }
+
+            {
+                auto it = client.StreamExecuteScanQuery(R"(
+                    SELECT *
+                    FROM `Root/Tenant2/.sys/auth_group_members`
+                )").GetValueSync();
+
+                CheckAuthAdministratorAccessIsRequired(it);
+            }
+        }
     }
 
     Y_UNIT_TEST(AuthGroupMembers_ResultOrder) {
@@ -3294,7 +3555,7 @@ Y_UNIT_TEST_SUITE(SystemView) {
                 )").GetValueSync();
 
                 auto expected = R"([
-                    [["/Root/Tenant1"];["root@builtin"]];
+                    [["/Root/Tenant1"];["user6tenant1admin"]];
                     [["/Root/Tenant1/Dir3"];["user3"]];
                     [["/Root/Tenant1/Dir4"];["root@builtin"]];
                     [["/Root/Tenant1/Table1"];["root@builtin"]]
@@ -3333,9 +3594,6 @@ Y_UNIT_TEST_SUITE(SystemView) {
             ])";
             NKqp::CompareYson(expected, NKqp::StreamResultToYson(it));
         }
-
-        // TODO: fix https://github.com/ydb-platform/ydb/issues/13730
-        // and test tenant user and tenant admin
     }
 
     Y_UNIT_TEST(AuthOwners_ResultOrder) {
@@ -3827,8 +4085,10 @@ Y_UNIT_TEST_SUITE(SystemView) {
             )").GetValueSync();
 
             auto expected = R"([
+                [["/Root"];["ydb.generic.full"];["root@builtin"]];
                 [["/Root"];["ydb.generic.use"];["user1rootadmin"]];
                 [["/Root"];["ydb.generic.use"];["user2"]];
+                [["/Root"];["ydb.generic.use"];["user6tenant1admin"]];
                 [["/Root/.metadata/workload_manager/pools/default"];["ydb.granular.describe_schema"];["all-users@well-known"]];
                 [["/Root/.metadata/workload_manager/pools/default"];["ydb.granular.select_row"];["all-users@well-known"]];
                 [["/Root/.metadata/workload_manager/pools/default"];["ydb.generic.full"];["root@builtin"]];
@@ -3858,8 +4118,10 @@ Y_UNIT_TEST_SUITE(SystemView) {
                 )").GetValueSync();
 
                 auto expected = R"([
+                    [["/Root"];["ydb.generic.full"];["root@builtin"]];
                     [["/Root"];["ydb.generic.use"];["user1rootadmin"]];
                     [["/Root"];["ydb.generic.use"];["user2"]];
+                    [["/Root"];["ydb.generic.use"];["user6tenant1admin"]];
                     [["/Root/.metadata/workload_manager/pools/default"];["ydb.granular.describe_schema"];["all-users@well-known"]];
                     [["/Root/.metadata/workload_manager/pools/default"];["ydb.granular.select_row"];["all-users@well-known"]];
                     [["/Root/.metadata/workload_manager/pools/default"];["ydb.generic.full"];["root@builtin"]];
@@ -3906,8 +4168,10 @@ Y_UNIT_TEST_SUITE(SystemView) {
             )").GetValueSync();
 
             auto expected = R"([
+                [["/Root"];["ydb.generic.full"];["root@builtin"]];
                 [["/Root"];["ydb.generic.use"];["user1rootadmin"]];
                 [["/Root"];["ydb.generic.use"];["user2"]];
+                [["/Root"];["ydb.generic.use"];["user6tenant1admin"]];
                 [["/Root/.metadata/workload_manager/pools/default"];["ydb.granular.describe_schema"];["all-users@well-known"]];
                 [["/Root/.metadata/workload_manager/pools/default"];["ydb.granular.select_row"];["all-users@well-known"]];
                 [["/Root/.metadata/workload_manager/pools/default"];["ydb.generic.full"];["root@builtin"]];
@@ -3918,9 +4182,6 @@ Y_UNIT_TEST_SUITE(SystemView) {
             ])";
             NKqp::CompareYson(expected, NKqp::StreamResultToYson(it));
         }
-
-        // TODO: fix https://github.com/ydb-platform/ydb/issues/13730
-        // and test tenant user and tenant admin
     }
 
     Y_UNIT_TEST(AuthPermissions_ResultOrder) {

--- a/ydb/core/sys_view/ut_kqp.cpp
+++ b/ydb/core/sys_view/ut_kqp.cpp
@@ -151,7 +151,7 @@ void SetupAuthAccessEnvironment(TTestEnv& env) {
 }
 
 void CheckAuthAdministratorAccessIsRequired(TScanQueryPartIterator& it) {
-    NKqp::StreamResultToYson(it, false, EStatus::INTERNAL_ERROR, 
+    NKqp::StreamResultToYson(it, false, EStatus::UNAUTHORIZED, 
         "Administrator access is required");
 }
 

--- a/ydb/core/sys_view/ut_kqp.cpp
+++ b/ydb/core/sys_view/ut_kqp.cpp
@@ -125,6 +125,7 @@ void SetupAuthAccessEnvironment(TTestEnv& env) {
     env.GetServer().GetRuntime()->SetLogPriority(NKikimrServices::SYSTEM_VIEWS, NLog::PRI_TRACE);
     env.GetServer().GetRuntime()->GetAppData().AdministrationAllowedSIDs.emplace_back("root@builtin");
     env.GetServer().GetRuntime()->GetAppData().AdministrationAllowedSIDs.emplace_back("user1rootadmin");
+    env.GetServer().GetRuntime()->GetAppData().FeatureFlags.SetEnableDatabaseAdmin(true);
     env.GetClient().SetSecurityToken("root@builtin");
     CreateTenantsAndTables(env, true);
 
@@ -2406,19 +2407,18 @@ Y_UNIT_TEST_SUITE(SystemView) {
                 NKqp::CompareYson(expected, NKqp::StreamResultToYson(it));
             }
 
-            // TODO: make it work
-            // {
-            //     auto it = client.StreamExecuteScanQuery(R"(
-            //         SELECT Sid
-            //         FROM `Root/Tenant1/.sys/auth_users`
-            //     )").GetValueSync();
+            {
+                auto it = client.StreamExecuteScanQuery(R"(
+                    SELECT Sid
+                    FROM `Root/Tenant1/.sys/auth_users`
+                )").GetValueSync();
 
-            //     auto expected = R"([
-            //         [["user3"]];
-            //         [["user4"]];
-            //     ])";
-            //     NKqp::CompareYson(expected, NKqp::StreamResultToYson(it));
-            // }
+                auto expected = R"([
+                    [["user3"]];
+                    [["user4"]];
+                ])";
+                NKqp::CompareYson(expected, NKqp::StreamResultToYson(it));
+            }
 
             {
                 auto it = client.StreamExecuteScanQuery(R"(
@@ -2802,19 +2802,18 @@ Y_UNIT_TEST_SUITE(SystemView) {
                 CheckAuthAdministratorAccessIsRequired(it);
             }
 
-            // TODO: make it work
-            // {
-            //     auto it = client.StreamExecuteScanQuery(R"(
-            //         SELECT Sid
-            //         FROM `Root/Tenant1/.sys/auth_groups`
-            //     )").GetValueSync();
+            {
+                auto it = client.StreamExecuteScanQuery(R"(
+                    SELECT Sid
+                    FROM `Root/Tenant1/.sys/auth_groups`
+                )").GetValueSync();
 
-            //     auto expected = R"([
-            //         [["group3"]];
-            //         [["group4"]];
-            //     ])";
-            //     NKqp::CompareYson(expected, NKqp::StreamResultToYson(it));
-            // }
+                auto expected = R"([
+                    [["group3"]];
+                    [["group4"]];
+                ])";
+                NKqp::CompareYson(expected, NKqp::StreamResultToYson(it));
+            }
 
             {
                 auto it = client.StreamExecuteScanQuery(R"(
@@ -3125,19 +3124,18 @@ Y_UNIT_TEST_SUITE(SystemView) {
                 CheckAuthAdministratorAccessIsRequired(it);
             }
 
-            // TODO: make it work
-            // {
-            //     auto it = client.StreamExecuteScanQuery(R"(
-            //         SELECT *
-            //         FROM `Root/Tenant1/.sys/auth_group_members`
-            //     )").GetValueSync();
+            {
+                auto it = client.StreamExecuteScanQuery(R"(
+                    SELECT *
+                    FROM `Root/Tenant1/.sys/auth_group_members`
+                )").GetValueSync();
 
-            //     auto expected = R"([
-            //         [["group3"];["user3"]];
-            //         [["group4"];["user4"]];
-            //     ])";
-            //     NKqp::CompareYson(expected, NKqp::StreamResultToYson(it));
-            // }
+                auto expected = R"([
+                    [["group3"];["user3"]];
+                    [["group4"];["user4"]];
+                ])";
+                NKqp::CompareYson(expected, NKqp::StreamResultToYson(it));
+            }
 
             {
                 auto it = client.StreamExecuteScanQuery(R"(

--- a/ydb/library/yql/dq/actors/dq.cpp
+++ b/ydb/library/yql/dq/actors/dq.cpp
@@ -32,13 +32,15 @@ Ydb::StatusIds::StatusCode DqStatusToYdbStatus(NYql::NDqProto::StatusIds::Status
         return Ydb::StatusIds::SCHEME_ERROR;
     case NYql::NDqProto::StatusIds::UNSUPPORTED:
         return Ydb::StatusIds::UNSUPPORTED;
+    case NYql::NDqProto::StatusIds::UNAUTHORIZED:
+        return Ydb::StatusIds::UNAUTHORIZED;
     case NYql::NDqProto::StatusIds::GENERIC_ERROR:
     default:
         return Ydb::StatusIds::GENERIC_ERROR;
     }
 }
 
-NYql::NDqProto::StatusIds::StatusCode YdbStatusToDqStatus(Ydb::StatusIds::StatusCode statusCode) {
+NYql::NDqProto::StatusIds::StatusCode YdbStatusToDqStatus(Ydb::StatusIds::StatusCode statusCode, EStatusCompatibilityLevel compatibility) {
     switch(statusCode) {
     case Ydb::StatusIds::STATUS_CODE_UNSPECIFIED:
         return NYql::NDqProto::StatusIds::UNSPECIFIED;
@@ -47,6 +49,9 @@ NYql::NDqProto::StatusIds::StatusCode YdbStatusToDqStatus(Ydb::StatusIds::Status
     case Ydb::StatusIds::BAD_REQUEST:
         return NYql::NDqProto::StatusIds::BAD_REQUEST;
     case Ydb::StatusIds::UNAUTHORIZED:
+        return compatibility >= EStatusCompatibilityLevel::WithUnauthorized
+            ? NYql::NDqProto::StatusIds::UNAUTHORIZED
+            : NYql::NDqProto::StatusIds::INTERNAL_ERROR;
     case Ydb::StatusIds::INTERNAL_ERROR:
         return NYql::NDqProto::StatusIds::INTERNAL_ERROR;
     case Ydb::StatusIds::ABORTED:

--- a/ydb/library/yql/dq/actors/dq.h
+++ b/ydb/library/yql/dq/actors/dq.h
@@ -11,8 +11,13 @@
 
 namespace NYql::NDq {
 
+enum class EStatusCompatibilityLevel {
+    Basic,
+    WithUnauthorized
+};
+
 Ydb::StatusIds::StatusCode DqStatusToYdbStatus(NYql::NDqProto::StatusIds::StatusCode statusCode);
-NYql::NDqProto::StatusIds::StatusCode YdbStatusToDqStatus(Ydb::StatusIds::StatusCode statusCode);
+NYql::NDqProto::StatusIds::StatusCode YdbStatusToDqStatus(Ydb::StatusIds::StatusCode statusCode, EStatusCompatibilityLevel compatibility = EStatusCompatibilityLevel::Basic);
 
 struct TEvDq {
 

--- a/ydb/library/yql/dq/actors/protos/dq_status_codes.proto
+++ b/ydb/library/yql/dq/actors/protos/dq_status_codes.proto
@@ -22,5 +22,6 @@ message StatusIds {
         SCHEME_ERROR = 14;
         GENERIC_ERROR = 15;
         UNDETERMINED =  16;
+        UNAUTHORIZED =  17;
     }
 }

--- a/ydb/tests/functional/tenants/test_auth_system_views.py
+++ b/ydb/tests/functional/tenants/test_auth_system_views.py
@@ -1,0 +1,169 @@
+# -*- coding: utf-8 -*-
+import logging
+import copy
+
+import pytest
+
+from ydb.tests.oss.ydb_sdk_import import ydb
+from ydb.tests.library.harness.util import LogLevels
+from ydb.tests.library.harness.kikimr_config import KikimrConfigGenerator
+
+
+logger = logging.getLogger(__name__)
+
+
+# local configuration for the ydb cluster (fetched by ydb_cluster_configuration fixture)
+CLUSTER_CONFIG = dict(
+    additional_log_configs={
+        # more logs
+        'TX_PROXY': LogLevels.DEBUG,
+        'GRPC_SERVER': LogLevels.INFO,
+        'GRPC_PROXY_NO_CONNECT_ACCESS': LogLevels.DEBUG,
+        'FLAT_TX_SCHEMESHARD': LogLevels.INFO,
+        'SYSTEM_VIEWS': LogLevels.DEBUG,
+        'TICKET_PARSER': LogLevels.DEBUG,
+        # less logs
+        'KQP_PROXY': LogLevels.CRIT,
+        'KQP_WORKER': LogLevels.CRIT,
+        'KQP_GATEWAY': LogLevels.CRIT,
+        'GRPC_PROXY': LogLevels.ERROR,
+        'TX_DATASHARD': LogLevels.ERROR,
+        'TX_PROXY_SCHEME_CACHE': LogLevels.ERROR,
+        'KQP_YQL': LogLevels.ERROR,
+        'KQP_SESSION': LogLevels.CRIT,
+        'KQP_COMPILE_ACTOR': LogLevels.CRIT,
+        'PERSQUEUE_CLUSTER_TRACKER': LogLevels.CRIT,
+        'SCHEME_BOARD_SUBSCRIBER': LogLevels.CRIT,
+        'SCHEME_BOARD_POPULATOR': LogLevels.CRIT,
+    },
+    extra_feature_flags=[
+        'enable_strict_acl_check',
+        'enable_strict_user_management',
+        'enable_database_admin',
+    ],
+    # do not clutter logs with resource pools auto creation
+    enable_resource_pools=False,
+    enforce_user_token_requirement=True,
+    # make all bootstrap and setup under this user
+    default_clusteradmin='root@builtin',
+)
+
+
+# ydb_fixtures.ydb_cluster_configuration local override
+@pytest.fixture(scope='module')
+def ydb_cluster_configuration():
+    conf = copy.deepcopy(CLUSTER_CONFIG)
+    return conf
+
+
+@pytest.fixture(scope='module')
+def ydb_configurator(ydb_cluster_configuration):
+    config_generator = KikimrConfigGenerator(**ydb_cluster_configuration)
+    config_generator.yaml_config['auth_config'] = {
+        'domain_login_only': False,
+    }
+    config_generator.yaml_config['domains_config']['disable_builtin_security'] = True
+    security_config = config_generator.yaml_config['domains_config']['security_config']
+    security_config['administration_allowed_sids'].append('clusteradmin')
+    return config_generator
+
+
+def stream_query_result(driver, query):
+    it = driver.table_client.scan_query(query)
+    result = []
+    error = None
+
+    while True:
+        try:
+            response = next(it)
+        except StopIteration:
+            break
+        except ydb.issues.Error as e:
+            error = e
+            break
+
+        for row in response.result_set.rows:
+            result.append(row)
+
+    return result, error
+
+
+@pytest.fixture(scope='function')
+def prepared_test_env(ydb_cluster, ydb_root, ydb_database, ydb_client):
+    cluster_admin = ydb.AuthTokenCredentials(ydb_cluster.config.default_clusteradmin)
+
+    # prepare root database
+    with ydb_client(ydb_root, credentials=cluster_admin) as driver:
+        pool = ydb.SessionPool(driver)
+        with pool.checkout() as session:
+            session.execute_scheme("create user clusteradmin password '1234'")
+            session.execute_scheme("create user clusteruser password '1234'")
+
+    # prepare tenant database
+    database_path = ydb_database
+    with ydb_client(database_path, credentials=cluster_admin) as driver:
+        pool = ydb.SessionPool(driver)
+        with pool.checkout() as session:
+            # add users
+            session.execute_scheme("create user dbadmin password '1234'")
+            session.execute_scheme("create user ordinaryuser password '1234'")
+
+            # add group and its members
+            session.execute_scheme('create group dbadmins')
+            session.execute_scheme('alter group dbadmins add user dbadmin')
+
+            # add required permissions on paths
+            session.execute_scheme(f'grant "ydb.generic.use" on `{database_path}` to clusteradmin')
+            # shouldn't be possible but we allow that for the admin
+            session.execute_scheme(f'grant "ydb.generic.use" on `{database_path}` to clusteruser')
+            session.execute_scheme(f'grant "ydb.generic.use" on `{database_path}` to dbadmin')
+            session.execute_scheme(f'grant "ydb.generic.use" on `{database_path}` to ordinaryuser')
+
+        # make dbadmin the real admin of the database
+        driver.scheme_client.modify_permissions(database_path, ydb.ModifyPermissionsSettings().change_owner('dbadmin'))
+
+    return database_path
+
+
+# python sdk does not legally expose login method, so that is a crude way
+# to get auth-token in exchange to credentials
+def login_user(endpoint, database, user, password):
+    driver_config = ydb.DriverConfig(endpoint, database)
+    credentials = ydb.StaticCredentials(driver_config, user, password)
+    return credentials._make_token_request()['access_token']
+
+
+@pytest.mark.parametrize('user,expected_access', [
+    ('clusteradmin', True),
+    ('clusteruser', False),
+    ('dbadmin', True),
+    ('ordinaryuser', False)
+])
+def test_tenant_auth_groups_access(ydb_endpoint, ydb_root, prepared_test_env, ydb_client, user, expected_access):
+    tenant_database = prepared_test_env
+
+    # user could be either from the root or tenant database,
+    # but they must obtain auth token by logging in the database they live in
+    login_database = ydb_root if user.startswith('cluster') else tenant_database
+    user_auth_token = login_user(ydb_endpoint, login_database, user, '1234')
+    credentials = ydb.AuthTokenCredentials(user_auth_token)
+
+    with ydb_client(tenant_database, credentials=credentials) as driver:
+        driver.wait()
+
+        result, error = stream_query_result(driver, f'SELECT * FROM `{tenant_database}/.sys/auth_groups`')
+
+        # logger.debug('AAA result row count %s, error %s', len(result), error)
+
+        if expected_access:
+            assert error is None
+            assert len(result) == 1
+            assert result[0]['Sid'] == 'dbadmins'
+
+        else:
+            assert error is not None, result
+
+            # FIXME: status should have been UNAUTHORIZED
+            # assert error.status == ydb.issues.StatusCode.UNAUTHORIZED
+            assert error.status == ydb.issues.StatusCode.INTERNAL_ERROR
+            assert 'Administrator access is required' in error.message

--- a/ydb/tests/functional/tenants/test_auth_system_views.py
+++ b/ydb/tests/functional/tenants/test_auth_system_views.py
@@ -162,8 +162,5 @@ def test_tenant_auth_groups_access(ydb_endpoint, ydb_root, prepared_test_env, yd
 
         else:
             assert error is not None, result
-
-            # FIXME: status should have been UNAUTHORIZED
-            # assert error.status == ydb.issues.StatusCode.UNAUTHORIZED
-            assert error.status == ydb.issues.StatusCode.INTERNAL_ERROR
+            assert error.status == ydb.issues.StatusCode.UNAUTHORIZED
             assert 'Administrator access is required' in error.message

--- a/ydb/tests/functional/tenants/ya.make
+++ b/ydb/tests/functional/tenants/ya.make
@@ -11,6 +11,7 @@ TEST_SRCS(
     test_tenants.py
     test_storage_config.py
     test_system_views.py
+    test_auth_system_views.py
     test_publish_into_schemeboard_with_common_ssring.py
     test_users_groups_with_acl.py
 )

--- a/ydb/tests/library/clients/kikimr_client.py
+++ b/ydb/tests/library/clients/kikimr_client.py
@@ -254,8 +254,10 @@ class KiKiMRMessageBusClient(object):
             raise RuntimeError('console_request failed: %s: %s' % (response.Status.Code, response.Status.Reason))
         return response
 
-    def add_config_item(self, config, cookie=None, raise_on_error=True):
+    def add_config_item(self, config, cookie=None, raise_on_error=True, token=None):
         request = msgbus.TConsoleRequest()
+        if token is not None:
+            request.SecurityToken = token
         action = request.ConfigureRequest.Actions.add()
         item = action.AddConfigItem.ConfigItem
         if isinstance(config, str) or isinstance(config, bytes):

--- a/ydb/tests/library/common/protobuf_console.py
+++ b/ydb/tests/library/common/protobuf_console.py
@@ -2,7 +2,7 @@
 # -*- coding: utf-8 -*-
 import ydb.core.protos.msgbus_pb2 as msgbus
 
-from ydb.tests.library.common.protobuf import AbstractProtobufBuilder
+from ydb.tests.library.common.protobuf import AbstractProtobufBuilder, to_bytes
 
 
 class CreateTenantRequest(AbstractProtobufBuilder):
@@ -13,6 +13,10 @@ class CreateTenantRequest(AbstractProtobufBuilder):
     def __init__(self, path):
         super(CreateTenantRequest, self).__init__(msgbus.TConsoleRequest())
         self.protobuf.CreateTenantRequest.Request.path = path
+
+    def set_user_token(self, token):
+        self.protobuf.SecurityToken = to_bytes(token)
+        self.protobuf.CreateTenantRequest.UserToken = to_bytes(token)
 
     def add_storage_pool(self, pool_type, pool_size):
         pool = self.protobuf.CreateTenantRequest.Request.resources.storage_units.add()
@@ -78,6 +82,10 @@ class AlterTenantRequest(AbstractProtobufBuilder):
         super(AlterTenantRequest, self).__init__(msgbus.TConsoleRequest())
         self.protobuf.AlterTenantRequest.Request.path = path
 
+    def set_user_token(self, token):
+        self.protobuf.SecurityToken = to_bytes(token)
+        self.protobuf.AlterTenantRequest.UserToken = to_bytes(token)
+
     def set_schema_quotas(self, schema_quotas):
         quotas = self.protobuf.AlterTenantRequest.Request.schema_operation_quotas
         quotas.SetInParent()
@@ -106,6 +114,10 @@ class GetTenantStatusRequest(AbstractProtobufBuilder):
         super(GetTenantStatusRequest, self).__init__(msgbus.TConsoleRequest())
         self.protobuf.GetTenantStatusRequest.Request.path = path
 
+    def set_user_token(self, token):
+        self.protobuf.SecurityToken = to_bytes(token)
+        self.protobuf.GetTenantStatusRequest.UserToken = to_bytes(token)
+
 
 class RemoveTenantRequest(AbstractProtobufBuilder):
     """
@@ -115,6 +127,10 @@ class RemoveTenantRequest(AbstractProtobufBuilder):
     def __init__(self, path):
         super(RemoveTenantRequest, self).__init__(msgbus.TConsoleRequest())
         self.protobuf.RemoveTenantRequest.Request.path = path
+
+    def set_user_token(self, token):
+        self.protobuf.SecurityToken = to_bytes(token)
+        self.protobuf.RemoveTenantRequest.UserToken = to_bytes(token)
 
 
 class SetConfigRequest(AbstractProtobufBuilder):
@@ -158,3 +174,6 @@ class GetOperationRequest(AbstractProtobufBuilder):
     def __init__(self, op_id):
         super(GetOperationRequest, self).__init__(msgbus.TConsoleRequest())
         self.protobuf.GetOperationRequest.id = op_id
+
+    def set_user_token(self, token):
+        self.protobuf.SecurityToken = to_bytes(token)

--- a/ydb/tests/library/harness/kikimr_cluster_interface.py
+++ b/ydb/tests/library/harness/kikimr_cluster_interface.py
@@ -110,35 +110,41 @@ class KiKiMRClusterInterface(object):
             )
         return self.__scheme_client
 
-    def get_database_status(self, database_name):
-        response = self.client.send_request(
-            GetTenantStatusRequest(database_name).protobuf,
-            method='ConsoleRequest'
-        ).GetTenantStatusResponse
+    def _send_get_tenant_status_request(self, database_name, token=None):
+        req = GetTenantStatusRequest(database_name)
+
+        if token is not None:
+            req.set_user_token(token)
+
+        return self.client.send_request(req.protobuf, method='ConsoleRequest').GetTenantStatusResponse
+
+    def get_database_status(self, database_name, token=None):
+        response = self._send_get_tenant_status_request(database_name, token=token)
 
         if response.Response.operation.status != StatusIds.SUCCESS:
             logger.critical("Console response status: %s", str(response.Response.operation.status))
             assert False
-            return False
 
         result = cms_tenants_pb.GetDatabaseStatusResult()
         response.Response.operation.result.Unpack(result)
         return result
 
-    def wait_tenant_up(self, database_name):
+    def wait_tenant_up(self, database_name, token=None):
         self.__wait_tenant_up(
             database_name,
-            expected_computational_units=1
+            expected_computational_units=1,
+            token=token,
         )
 
     def __wait_tenant_up(
             self,
             database_name,
             expected_computational_units=None,
-            timeout_seconds=120
+            timeout_seconds=120,
+            token=None
     ):
         def predicate():
-            result = self.get_database_status(database_name)
+            result = self.get_database_status(database_name, token=token)
 
             if expected_computational_units is None:
                 expected = set([2])
@@ -154,21 +160,25 @@ class KiKiMRClusterInterface(object):
         )
         assert tenant_running
 
-    def __get_console_op(self, op_id):
+    def __get_console_op(self, op_id, token=None):
         req = GetOperationRequest(op_id)
+
+        if token is not None:
+            req.set_user_token(token)
+
         response = self.client.send_request(req.protobuf, method='ConsoleRequest')
         operation = response.GetOperationResponse.operation
         if not operation.ready and response.Status.Code != StatusIds.STATUS_CODE_UNSPECIFIED:
             raise RuntimeError('get_console_op failed: %s: %s' % (response.Status.Code, response.Status.Reason))
         return operation
 
-    def __wait_console_op(self, op_id, timeout_seconds, step_seconds=0.5):
+    def __wait_console_op(self, op_id, timeout_seconds, step_seconds=0.5, token=None):
         deadline = time.time() + timeout_seconds
         while True:
             time.sleep(step_seconds)
             if time.time() >= deadline:
                 raise RuntimeError('wait_console_op: deadline exceeded')
-            operation = self.__get_console_op(op_id)
+            operation = self.__get_console_op(op_id, token=token)
             if operation.ready:
                 return operation
 
@@ -177,7 +187,8 @@ class KiKiMRClusterInterface(object):
             database_name,
             storage_pool_units_count,
             disable_external_subdomain=False,
-            timeout_seconds=120
+            timeout_seconds=120,
+            token=None,
     ):
         req = CreateTenantRequest(database_name)
         for storage_pool_type_name, units_count in storage_pool_units_count.items():
@@ -189,19 +200,23 @@ class KiKiMRClusterInterface(object):
         if disable_external_subdomain:
             req.disable_external_subdomain()
 
+        if token is not None:
+            req.set_user_token(token)
+
         response = self.client.send_request(req.protobuf, method='ConsoleRequest')
         operation = response.CreateTenantResponse.Response.operation
         if not operation.ready and response.Status.Code != StatusIds.STATUS_CODE_UNSPECIFIED:
             raise RuntimeError('create_database failed: %s: %s' % (response.Status.Code, response.Status.Reason))
         if not operation.ready:
-            operation = self.__wait_console_op(operation.id, timeout_seconds=timeout_seconds)
+            operation = self.__wait_console_op(operation.id, timeout_seconds=timeout_seconds, token=token)
         if operation.status != StatusIds.SUCCESS:
             raise RuntimeError('create_database failed: %s, %s' % (operation.status, ydb.issues._format_issues(operation.issues)))
 
         self.__wait_tenant_up(
             database_name,
             expected_computational_units=0,
-            timeout_seconds=timeout_seconds
+            timeout_seconds=timeout_seconds,
+            token=token,
         )
         return database_name
 
@@ -209,7 +224,8 @@ class KiKiMRClusterInterface(object):
             self,
             database_name,
             storage_pool_units_count,
-            timeout_seconds=120
+            timeout_seconds=120,
+            token=None,
     ):
         req = CreateTenantRequest(database_name)
         for storage_pool_type_name, units_count in storage_pool_units_count.items():
@@ -218,19 +234,23 @@ class KiKiMRClusterInterface(object):
                 units_count,
             )
 
+        if token is not None:
+            req.set_user_token(token)
+
         response = self.client.send_request(req.protobuf, method='ConsoleRequest')
         operation = response.CreateTenantResponse.Response.operation
         if not operation.ready and response.Status.Code != StatusIds.STATUS_CODE_UNSPECIFIED:
             raise RuntimeError('create_hostel_database failed: %s: %s' % (response.Status.Code, response.Status.Reason))
         if not operation.ready:
-            operation = self.__wait_console_op(operation.id, timeout_seconds=timeout_seconds)
+            operation = self.__wait_console_op(operation.id, timeout_seconds=timeout_seconds, token=token)
         if operation.status != StatusIds.SUCCESS:
             raise RuntimeError('create_hostel_database failed: %s' % (operation.status,))
 
         self.__wait_tenant_up(
             database_name,
             expected_computational_units=0,
-            timeout_seconds=timeout_seconds
+            timeout_seconds=timeout_seconds,
+            token=token,
         )
         return database_name
 
@@ -241,9 +261,13 @@ class KiKiMRClusterInterface(object):
             timeout_seconds=120,
             schema_quotas=None,
             disk_quotas=None,
-            attributes=None
+            attributes=None,
+            token=None,
     ):
         req = CreateTenantRequest(database_name)
+
+        if token is not None:
+            req.set_user_token(token)
 
         req.share_resources_with(hostel_db)
 
@@ -262,13 +286,14 @@ class KiKiMRClusterInterface(object):
         if not operation.ready and response.Status.Code != StatusIds.STATUS_CODE_UNSPECIFIED:
             raise RuntimeError('create_serverless_database failed: %s: %s' % (response.Status.Code, response.Status.Reason))
         if not operation.ready:
-            operation = self.__wait_console_op(operation.id, timeout_seconds=timeout_seconds)
+            operation = self.__wait_console_op(operation.id, timeout_seconds=timeout_seconds, token=token)
         if operation.status != StatusIds.SUCCESS:
             raise RuntimeError('create_serverless_database failed: %s' % (operation.status,))
 
         self.__wait_tenant_up(
             database_name,
-            timeout_seconds=timeout_seconds
+            timeout_seconds=timeout_seconds,
+            token=token,
         )
         return database_name
 
@@ -278,8 +303,12 @@ class KiKiMRClusterInterface(object):
             schema_quotas=None,
             disk_quotas=None,
             timeout_seconds=120,
+            token=None,
     ):
         req = AlterTenantRequest(database_name)
+
+        if token is not None:
+            req.set_user_token(token)
 
         assert schema_quotas is not None or disk_quotas is not None
 
@@ -294,33 +323,39 @@ class KiKiMRClusterInterface(object):
         if not operation.ready and response.Status.Code != StatusIds.STATUS_CODE_UNSPECIFIED:
             raise RuntimeError('alter_serverless_database failed: %s: %s' % (response.Status.Code, response.Status.Reason))
         if not operation.ready:
-            operation = self.__wait_console_op(operation.id, timeout_seconds=timeout_seconds)
+            operation = self.__wait_console_op(operation.id, timeout_seconds=timeout_seconds, token=token)
         if operation.status != StatusIds.SUCCESS:
             raise RuntimeError('alter_serverless_database failed: %s' % (operation.status,))
 
         self.__wait_tenant_up(
             database_name,
-            timeout_seconds=timeout_seconds
+            timeout_seconds=timeout_seconds,
+            token=token,
         )
         return database_name
 
     def remove_database(
             self,
             database_name,
-            timeout_seconds=20
+            timeout_seconds=20,
+            token=None,
     ):
         logger.debug(database_name)
 
-        operation_id = self._remove_database_send_op(database_name)
-        self._remove_database_wait_op(database_name, operation_id, timeout_seconds=timeout_seconds)
-        self._remove_database_wait_tenant_gone(database_name, timeout_seconds=timeout_seconds)
+        operation_id = self._remove_database_send_op(database_name, token=token)
+        self._remove_database_wait_op(database_name, operation_id, timeout_seconds=timeout_seconds, token=token)
+        self._remove_database_wait_tenant_gone(database_name, timeout_seconds=timeout_seconds, token=token)
 
         return database_name
 
-    def _remove_database_send_op(self, database_name):
-        logger.debug('%s: send console operation', database_name)
+    def _remove_database_send_op(self, database_name, token=None):
+        logger.debug('%s: send console operation, token %s', database_name, token)
 
         req = RemoveTenantRequest(database_name)
+
+        if token is not None:
+            req.set_user_token(token)
+
         response = self.client.send_request(req.protobuf, method='ConsoleRequest')
         operation = response.RemoveTenantResponse.Response.operation
         logger.debug('%s: response from console: %s', database_name, response)
@@ -330,20 +365,19 @@ class KiKiMRClusterInterface(object):
 
         return operation.id
 
-    def _remove_database_wait_op(self, database_name, operation_id, timeout_seconds=20):
+    def _remove_database_wait_op(self, database_name, operation_id, timeout_seconds=20, token=None):
         logger.debug('%s: wait console operation done', database_name)
-        operation = self.__wait_console_op(operation_id, timeout_seconds=timeout_seconds)
+        operation = self.__wait_console_op(operation_id, timeout_seconds=timeout_seconds, token=token)
         logger.debug('%s: console operation done', database_name)
 
         if operation.status not in (StatusIds.SUCCESS, StatusIds.NOT_FOUND):
             raise RuntimeError('remove_database failed: %s' % (operation.status,))
 
-    def _remove_database_wait_tenant_gone(self, database_name, timeout_seconds=20):
+    def _remove_database_wait_tenant_gone(self, database_name, timeout_seconds=20, token=None):
         logger.debug('%s: wait tenant gone', database_name)
 
         def predicate():
-            response = self.client.send_request(
-                GetTenantStatusRequest(database_name).protobuf, method='ConsoleRequest').GetTenantStatusResponse
+            response = self._send_get_tenant_status_request(database_name, token=token)
             return response.Response.operation.status == StatusIds.NOT_FOUND
 
         tenant_not_found = wait_for(


### PR DESCRIPTION
Merge from `main`:
- 9504685 -- https://github.com/ydb-platform/ydb/pull/15121
- 1d43db6 -- https://github.com/ydb-platform/ydb/pull/15130
- e285c7c -- https://github.com/ydb-platform/ydb/pull/15098
- 89703a2 -- https://github.com/ydb-platform/ydb/pull/15180
- a697f06 -- https://github.com/ydb-platform/ydb/pull/15138

Improvements for `enable_strict_user_management`+`enable_database_admin`+`domain_login_only` mode:
- database admin must have the same access to sysviews (in its own database) as cluster admin
- database admin must not be able to administer database admins
