### PR TITLE
At the start of a partition, the order of messages may change. (#15160)

### DIFF
--- a/ydb/core/persqueue/events/internal.h
+++ b/ydb/core/persqueue/events/internal.h
@@ -1075,6 +1075,8 @@ struct TEvPQ {
         }
 
         ui32 Cookie; // InternalPartitionId
+        TActorId SupportivePartition;
+
         NPQ::TSourceIdMap SrcIdInfo;
         std::deque<NPQ::TDataKey> BodyKeys;
         TVector<NPQ::TClientBlob> BlobsFromHead;
@@ -1091,6 +1093,7 @@ struct TEvPQ {
     struct TEvGetWriteInfoError : public TEventLocal<TEvGetWriteInfoError, EvGetWriteInfoError> {
         ui32 Cookie; // InternalPartitionId
         TString Message;
+        TActorId SupportivePartition;
 
         TEvGetWriteInfoError(ui32 cookie, TString message) :
             Cookie(cookie),

--- a/ydb/core/persqueue/partition.cpp
+++ b/ydb/core/persqueue/partition.cpp
@@ -1091,7 +1091,6 @@ void TPartition::ProcessPendingEvent(std::unique_ptr<TEvPQ::TEvTxCommit> ev, con
                        "PQ: %" PRIu64 ", Partition: %" PRIu32 ", Step: %" PRIu64 ", TxId: %" PRIu64,
                        TabletID, Partition.OriginalPartitionId,
                        ev->Step, ev->TxId);
-        PendingExplicitMessageGroups = ev->ExplicitMessageGroups;
     } else {
         Y_ABORT_UNLESS(!TransactionsInflight.empty(),
                        "PQ: %" PRIu64 ", Partition: %" PRIu32 ", Step: %" PRIu64 ", TxId: %" PRIu64,

--- a/ydb/core/persqueue/partition.cpp
+++ b/ydb/core/persqueue/partition.cpp
@@ -577,7 +577,7 @@ void TPartition::InitComplete(const TActorContext& ctx) {
     TabletCounters.Percentile()[COUNTER_LATENCY_PQ_INIT].IncrementFor(InitDuration.MilliSeconds());
 
     FillReadFromTimestamps(ctx);
-    ResendPendingEvents(ctx);
+    ProcessPendingEvents(ctx);
     ProcessTxsAndUserActs(ctx);
 
     ctx.Send(ctx.SelfID, new TEvents::TEvWakeup());
@@ -951,37 +951,69 @@ void TPartition::Handle(TEvPersQueue::TEvProposeTransaction::TPtr& ev, const TAc
     ProcessTxsAndUserActs(ctx);
 }
 
+template <class T>
+void TPartition::ProcessPendingEvent(TAutoPtr<TEventHandle<T>>& ev, const TActorContext& ctx)
+{
+    if (PendingEvents.empty()) {
+        // Optimization: if the queue is empty, you can process the message immediately
+        ProcessPendingEvent(std::unique_ptr<T>(ev->Release().Release()), ctx);
+    } else {
+        // We need to keep the order in which the messages arrived
+        AddPendingEvent(ev);
+        ProcessPendingEvents(ctx);
+    }
+}
+
+template <>
+void TPartition::ProcessPendingEvent(std::unique_ptr<TEvPQ::TEvProposePartitionConfig> ev, const TActorContext& ctx)
+{
+    PushBackDistrTx(ev.release());
+
+    ProcessTxsAndUserActs(ctx);
+}
+
 void TPartition::Handle(TEvPQ::TEvProposePartitionConfig::TPtr& ev, const TActorContext& ctx)
 {
     PQ_LOG_D("Handle TEvPQ::TEvProposePartitionConfig" <<
              " Step " << ev->Get()->Step <<
              ", TxId " << ev->Get()->TxId);
 
-    PushBackDistrTx(ev->Release());
+    ProcessPendingEvent(ev, ctx);
+}
 
-    ProcessTxsAndUserActs(ctx);
+template <class T>
+void TPartition::AddPendingEvent(TAutoPtr<TEventHandle<T>>& ev)
+{
+    std::unique_ptr<T> p(ev->Release().Release());
+    PendingEvents.emplace_back(std::move(p));
 }
 
 void TPartition::HandleOnInit(TEvPQ::TEvTxCalcPredicate::TPtr& ev, const TActorContext&)
 {
     PQ_LOG_D("HandleOnInit TEvPQ::TEvTxCalcPredicate");
 
-    PendingEvents.emplace_back(ev->ReleaseBase().Release());
+    AddPendingEvent(ev);
 }
 
 void TPartition::HandleOnInit(TEvPQ::TEvTxCommit::TPtr& ev, const TActorContext&)
 {
-    PendingEvents.emplace_back(ev->ReleaseBase().Release());
+    PQ_LOG_D("HandleOnInit TEvPQ::TEvTxCommit");
+
+    AddPendingEvent(ev);
 }
 
 void TPartition::HandleOnInit(TEvPQ::TEvTxRollback::TPtr& ev, const TActorContext&)
 {
-    PendingEvents.emplace_back(ev->ReleaseBase().Release());
+    PQ_LOG_D("HandleOnInit TEvPQ::TEvTxRollback");
+
+    AddPendingEvent(ev);
 }
 
 void TPartition::HandleOnInit(TEvPQ::TEvProposePartitionConfig::TPtr& ev, const TActorContext&)
 {
-    PendingEvents.emplace_back(ev->ReleaseBase().Release());
+    PQ_LOG_D("HandleOnInit TEvPQ::TEvProposePartitionConfig");
+
+    AddPendingEvent(ev);
 }
 
 void TPartition::HandleOnInit(TEvPQ::TEvGetWriteInfoRequest::TPtr& ev, const TActorContext&)
@@ -991,7 +1023,7 @@ void TPartition::HandleOnInit(TEvPQ::TEvGetWriteInfoRequest::TPtr& ev, const TAc
     Y_ABORT_UNLESS(IsSupportive());
 
     ev->Get()->OriginalPartition = ev->Sender;
-    PendingEvents.emplace_back(ev->ReleaseBase().Release());
+    AddPendingEvent(ev);
 }
 
 void TPartition::HandleOnInit(TEvPQ::TEvGetWriteInfoResponse::TPtr& ev, const TActorContext&)
@@ -1000,7 +1032,7 @@ void TPartition::HandleOnInit(TEvPQ::TEvGetWriteInfoResponse::TPtr& ev, const TA
 
     Y_ABORT_UNLESS(!IsSupportive());
 
-    PendingEvents.emplace_back(ev->ReleaseBase().Release());
+    AddPendingEvent(ev);
 }
 
 void TPartition::HandleOnInit(TEvPQ::TEvGetWriteInfoError::TPtr& ev, const TActorContext&)
@@ -1009,7 +1041,26 @@ void TPartition::HandleOnInit(TEvPQ::TEvGetWriteInfoError::TPtr& ev, const TActo
 
     Y_ABORT_UNLESS(!IsSupportive());
 
-    PendingEvents.emplace_back(ev->ReleaseBase().Release());
+    AddPendingEvent(ev);
+}
+
+template <>
+void TPartition::ProcessPendingEvent(std::unique_ptr<TEvPQ::TEvTxCalcPredicate> ev, const TActorContext& ctx)
+{
+    if (PlanStep.Defined() && TxId.Defined()) {
+        if (GetStepAndTxId(*ev) < GetStepAndTxId(*PlanStep, *TxId)) {
+            Send(Tablet,
+                 MakeHolder<TEvPQ::TEvTxCalcPredicateResult>(ev->Step,
+                                                             ev->TxId,
+                                                             Partition,
+                                                             Nothing()).Release());
+            return;
+        }
+    }
+
+    PushBackDistrTx(ev.release());
+
+    ProcessTxsAndUserActs(ctx);
 }
 
 void TPartition::Handle(TEvPQ::TEvTxCalcPredicate::TPtr& ev, const TActorContext& ctx)
@@ -1018,19 +1069,43 @@ void TPartition::Handle(TEvPQ::TEvTxCalcPredicate::TPtr& ev, const TActorContext
              " Step " << ev->Get()->Step <<
              ", TxId " << ev->Get()->TxId);
 
+    ProcessPendingEvent(ev, ctx);
+}
+
+template <>
+void TPartition::ProcessPendingEvent(std::unique_ptr<TEvPQ::TEvTxCommit> ev, const TActorContext& ctx)
+{
     if (PlanStep.Defined() && TxId.Defined()) {
-        if (GetStepAndTxId(*ev->Get()) < GetStepAndTxId(*PlanStep, *TxId)) {
-            Send(Tablet,
-                 MakeHolder<TEvPQ::TEvTxCalcPredicateResult>(ev->Get()->Step,
-                                                             ev->Get()->TxId,
-                                                             Partition,
-                                                             Nothing()).Release());
+        if (GetStepAndTxId(*ev) < GetStepAndTxId(*PlanStep, *TxId)) {
+            PQ_LOG_D("Send TEvTxCommitDone" <<
+                     " Step " << ev->Step <<
+                     ", TxId " << ev->TxId);
+            ctx.Send(Tablet, MakeCommitDone(ev->Step, ev->TxId).Release());
             return;
         }
     }
 
-    PushBackDistrTx(ev->Release());
+    auto txIter = TransactionsInflight.begin();
+    if (ChangeConfig) {
+        Y_ABORT_UNLESS(TransactionsInflight.size() == 1,
+                       "PQ: %" PRIu64 ", Partition: %" PRIu32 ", Step: %" PRIu64 ", TxId: %" PRIu64,
+                       TabletID, Partition.OriginalPartitionId,
+                       ev->Step, ev->TxId);
+        PendingExplicitMessageGroups = ev->ExplicitMessageGroups;
+    } else {
+        Y_ABORT_UNLESS(!TransactionsInflight.empty(),
+                       "PQ: %" PRIu64 ", Partition: %" PRIu32 ", Step: %" PRIu64 ", TxId: %" PRIu64,
+                       TabletID, Partition.OriginalPartitionId,
+                       ev->Step, ev->TxId);
+        txIter = TransactionsInflight.find(ev->TxId);
+        Y_ABORT_UNLESS(!txIter.IsEnd(),
+                       "PQ: %" PRIu64 ", Partition: %" PRIu32 ", Step: %" PRIu64 ", TxId: %" PRIu64,
+                       TabletID, Partition.OriginalPartitionId,
+                       ev->Step, ev->TxId);
+    }
+    Y_ABORT_UNLESS(txIter->second->State == ECommitState::Pending);
 
+    txIter->second->State = ECommitState::Committed;
     ProcessTxsAndUserActs(ctx);
 }
 
@@ -1040,47 +1115,17 @@ void TPartition::Handle(TEvPQ::TEvTxCommit::TPtr& ev, const TActorContext& ctx)
              " Step " << ev->Get()->Step <<
              ", TxId " << ev->Get()->TxId);
 
-    if (PlanStep.Defined() && TxId.Defined()) {
-        if (GetStepAndTxId(*ev->Get()) < GetStepAndTxId(*PlanStep, *TxId)) {
-            PQ_LOG_D("Send TEvTxCommitDone" <<
-                     " Step " << ev->Get()->Step <<
-                     ", TxId " << ev->Get()->TxId);
-            ctx.Send(Tablet, MakeCommitDone(ev->Get()->Step, ev->Get()->TxId).Release());
-            return;
-        }
-    }
-
-    auto txIter = TransactionsInflight.begin();
-    if (ChangeConfig) {
-        Y_ABORT_UNLESS(TransactionsInflight.size() == 1,
-                       "PQ: %" PRIu64 ", Partition: %" PRIu32 ", Step: %" PRIu64 ", TxId: %" PRIu64,
-                       TabletID, Partition.OriginalPartitionId,
-                       ev->Get()->Step, ev->Get()->TxId);
-    } else {
-        Y_ABORT_UNLESS(!TransactionsInflight.empty(),
-                       "PQ: %" PRIu64 ", Partition: %" PRIu32 ", Step: %" PRIu64 ", TxId: %" PRIu64,
-                       TabletID, Partition.OriginalPartitionId,
-                       ev->Get()->Step, ev->Get()->TxId);
-        txIter = TransactionsInflight.find(ev->Get()->TxId);
-        Y_ABORT_UNLESS(!txIter.IsEnd(),
-                       "PQ: %" PRIu64 ", Partition: %" PRIu32 ", Step: %" PRIu64 ", TxId: %" PRIu64,
-                       TabletID, Partition.OriginalPartitionId,
-                       ev->Get()->Step, ev->Get()->TxId);
-    }
-    Y_ABORT_UNLESS(txIter->second->State == ECommitState::Pending);
-
-    txIter->second->State = ECommitState::Committed;
-    ProcessTxsAndUserActs(ctx);
+    ProcessPendingEvent(ev, ctx);
 }
 
-void TPartition::Handle(TEvPQ::TEvTxRollback::TPtr& ev, const TActorContext& ctx)
+template <>
+void TPartition::ProcessPendingEvent(std::unique_ptr<TEvPQ::TEvTxRollback> ev, const TActorContext& ctx)
 {
-    auto* event = ev->Get();
     if (PlanStep.Defined() && TxId.Defined()) {
-        if (GetStepAndTxId(*event) < GetStepAndTxId(*PlanStep, *TxId)) {
+        if (GetStepAndTxId(*ev) < GetStepAndTxId(*PlanStep, *TxId)) {
             PQ_LOG_D("Rollback for" <<
-                     " Step " << ev->Get()->Step <<
-                     ", TxId " << ev->Get()->TxId);
+                     " Step " << ev->Step <<
+                     ", TxId " << ev->TxId);
             return;
         }
     }
@@ -1094,7 +1139,7 @@ void TPartition::Handle(TEvPQ::TEvTxRollback::TPtr& ev, const TActorContext& ctx
         Y_ABORT_UNLESS(!TransactionsInflight.empty(),
                        "PQ: %" PRIu64 ", Partition: %" PRIu32,
                        TabletID, Partition.OriginalPartitionId);
-        txIter = TransactionsInflight.find(ev->Get()->TxId);
+        txIter = TransactionsInflight.find(ev->TxId);
         Y_ABORT_UNLESS(!txIter.IsEnd(),
                        "PQ: %" PRIu64 ", Partition: %" PRIu32,
                        TabletID, Partition.OriginalPartitionId);
@@ -1105,13 +1150,17 @@ void TPartition::Handle(TEvPQ::TEvTxRollback::TPtr& ev, const TActorContext& ctx
     ProcessTxsAndUserActs(ctx);
 }
 
-void TPartition::Handle(TEvPQ::TEvGetWriteInfoRequest::TPtr& ev, const TActorContext& ctx) {
-    PQ_LOG_D("Handle TEvPQ::TEvGetWriteInfoRequest");
-    TActorId originalPartition = ev->Get()->OriginalPartition;
-    if (!originalPartition) {
-        // original message
-        originalPartition = ev->Sender;
-    }
+void TPartition::Handle(TEvPQ::TEvTxRollback::TPtr& ev, const TActorContext& ctx)
+{
+    ProcessPendingEvent(ev, ctx);
+}
+
+template <>
+void TPartition::ProcessPendingEvent(std::unique_ptr<TEvPQ::TEvGetWriteInfoRequest> ev, const TActorContext& ctx)
+{
+    TActorId originalPartition = ev->OriginalPartition;
+    Y_ABORT_UNLESS(originalPartition != TActorId());
+
     if (ClosedInternalPartition || WaitingForPreviousBlobQuota() || (CurrentStateFunc() != &TThis::StateIdle)) {
         PQ_LOG_D("Send TEvPQ::TEvGetWriteInfoError");
         auto* response = new TEvPQ::TEvGetWriteInfoError(Partition.InternalPartitionId,
@@ -1141,6 +1190,14 @@ void TPartition::Handle(TEvPQ::TEvGetWriteInfoRequest::TPtr& ev, const TActorCon
 
     PQ_LOG_D("Send TEvPQ::TEvGetWriteInfoResponse");
     ctx.Send(originalPartition, response);
+}
+
+void TPartition::Handle(TEvPQ::TEvGetWriteInfoRequest::TPtr& ev, const TActorContext& ctx) {
+    PQ_LOG_D("Handle TEvPQ::TEvGetWriteInfoRequest");
+
+    ev->Get()->OriginalPartition = ev->Sender;
+
+    ProcessPendingEvent(ev, ctx);
 }
 
 void TPartition::WriteInfoResponseHandler(
@@ -1231,17 +1288,36 @@ TPartition::EProcessResult TPartition::ApplyWriteInfoResponse(TTransaction& tx) 
     return ret;
 }
 
-void TPartition::Handle(TEvPQ::TEvGetWriteInfoResponse::TPtr& ev, const TActorContext& ctx) {
-    PQ_LOG_D("Handle TEvPQ::TEvGetWriteInfoResponse");
-    WriteInfoResponseHandler(ev->Sender, ev->Release(), ctx);
+template <>
+void TPartition::ProcessPendingEvent(std::unique_ptr<TEvPQ::TEvGetWriteInfoResponse> ev, const TActorContext& ctx)
+{
+    const auto sender = ev->SupportivePartition;
+    WriteInfoResponseHandler(sender, ev.release(), ctx);
 }
 
+void TPartition::Handle(TEvPQ::TEvGetWriteInfoResponse::TPtr& ev, const TActorContext& ctx) {
+    PQ_LOG_D("Handle TEvPQ::TEvGetWriteInfoResponse");
+
+    ev->Get()->SupportivePartition = ev->Sender;
+
+    ProcessPendingEvent(ev, ctx);
+}
+
+template <>
+void TPartition::ProcessPendingEvent(std::unique_ptr<TEvPQ::TEvGetWriteInfoError> ev, const TActorContext& ctx)
+{
+    const auto sender = ev->SupportivePartition;
+    WriteInfoResponseHandler(sender, ev.release(), ctx);
+}
 
 void TPartition::Handle(TEvPQ::TEvGetWriteInfoError::TPtr& ev, const TActorContext& ctx) {
     PQ_LOG_D("Handle TEvPQ::TEvGetWriteInfoError " <<
              "Cookie " << ev->Get()->Cookie <<
              ", Message " << ev->Get()->Message);
-    WriteInfoResponseHandler(ev->Sender, ev->Release(), ctx);
+
+    ev->Get()->SupportivePartition = ev->Sender;
+
+    ProcessPendingEvent(ev, ctx);
 }
 
 void TPartition::ReplyToProposeOrPredicate(TSimpleSharedPtr<TTransaction>& tx, bool isPredicate) {
@@ -2619,16 +2695,6 @@ void TPartition::ChangePlanStepAndTxId(ui64 step, ui64 txId)
     TxIdHasChanged = true;
 }
 
-void TPartition::ResendPendingEvents(const TActorContext& ctx)
-{
-    PQ_LOG_D("Resend pending events. Count " << PendingEvents.size());
-
-    while (!PendingEvents.empty()) {
-        ctx.Schedule(TDuration::Zero(), PendingEvents.front().release());
-        PendingEvents.pop_front();
-    }
-}
-
 TPartition::EProcessResult TPartition::PreProcessImmediateTx(const NKikimrPQ::TEvProposeTransaction& tx)
 {
     if (AffectedUsers.size() >= MAX_USERS) {
@@ -3495,14 +3561,17 @@ void TPartition::Handle(TEvPQ::TEvCheckPartitionStatusRequest::TPtr& ev, const T
 
 void TPartition::HandleOnInit(TEvPQ::TEvDeletePartition::TPtr& ev, const TActorContext&)
 {
+    PQ_LOG_D("HandleOnInit TEvPQ::TEvDeletePartition");
+
     Y_ABORT_UNLESS(IsSupportive());
 
-    PendingEvents.emplace_back(ev->ReleaseBase().Release());
+    AddPendingEvent(ev);
 }
 
-void TPartition::Handle(TEvPQ::TEvDeletePartition::TPtr&, const TActorContext& ctx)
+template <>
+void TPartition::ProcessPendingEvent(std::unique_ptr<TEvPQ::TEvDeletePartition> ev, const TActorContext& ctx)
 {
-    PQ_LOG_D("Handle TEvPQ::TEvDeletePartition");
+    Y_UNUSED(ev);
 
     Y_ABORT_UNLESS(IsSupportive());
     Y_ABORT_UNLESS(DeletePartitionState == DELETION_NOT_INITED);
@@ -3510,6 +3579,13 @@ void TPartition::Handle(TEvPQ::TEvDeletePartition::TPtr&, const TActorContext& c
     DeletePartitionState = DELETION_INITED;
 
     ProcessTxsAndUserActs(ctx);
+}
+
+void TPartition::Handle(TEvPQ::TEvDeletePartition::TPtr& ev, const TActorContext& ctx)
+{
+    PQ_LOG_D("Handle TEvPQ::TEvDeletePartition");
+
+    ProcessPendingEvent(ev, ctx);
 }
 
 void TPartition::ScheduleNegativeReplies()
@@ -3580,6 +3656,23 @@ void TPartition::ScheduleTransactionCompleted(const NKikimrPQ::TEvProposeTransac
 
     Replies.emplace_back(Tablet,
                          MakeHolder<TEvPQ::TEvTransactionCompleted>(writeId).Release());
+}
+
+void TPartition::ProcessPendingEvents(const TActorContext& ctx)
+{
+    PQ_LOG_D("Process pending events. Count " << PendingEvents.size());
+
+    while (!PendingEvents.empty()) {
+        auto ev = std::move(PendingEvents.front());
+        PendingEvents.pop_front();
+
+        auto visitor = [this, &ctx](auto&& v) {
+            using T = std::decay_t<decltype(v)>;
+            ProcessPendingEvent(std::forward<T>(v), ctx);
+        };
+
+        std::visit(visitor, std::move(ev));
+    }
 }
 
 const NKikimrPQ::TPQTabletConfig::TPartition* TPartition::GetPartitionConfig(const NKikimrPQ::TPQTabletConfig& config)

--- a/ydb/core/persqueue/partition.h
+++ b/ydb/core/persqueue/partition.h
@@ -423,7 +423,6 @@ private:
 
     void ChangePlanStepAndTxId(ui64 step, ui64 txId);
 
-    void ResendPendingEvents(const TActorContext& ctx);
     void SendReadPreparedProxyResponse(const TReadAnswer& answer, const TReadInfo& readInfo, TUserInfo& user);
 
     void CheckIfSessionExists(TUserInfoBase& userInfo, const TActorId& newPipe);
@@ -926,7 +925,24 @@ private:
 
     TInstant LastUsedStorageMeterTimestamp;
 
-    TDeque<std::unique_ptr<IEventBase>> PendingEvents;
+    using TPendingEvent = std::variant<
+        std::unique_ptr<TEvPQ::TEvTxCalcPredicate>,
+        std::unique_ptr<TEvPQ::TEvTxCommit>,
+        std::unique_ptr<TEvPQ::TEvTxRollback>,
+        std::unique_ptr<TEvPQ::TEvProposePartitionConfig>,
+        std::unique_ptr<TEvPQ::TEvGetWriteInfoRequest>,
+        std::unique_ptr<TEvPQ::TEvGetWriteInfoResponse>,
+        std::unique_ptr<TEvPQ::TEvGetWriteInfoError>,
+        std::unique_ptr<TEvPQ::TEvDeletePartition>
+    >;
+
+    TDeque<TPendingEvent> PendingEvents;
+
+    template <class T> void AddPendingEvent(TAutoPtr<TEventHandle<T>>& ev);
+    template <class T> void ProcessPendingEvent(std::unique_ptr<T> ev, const TActorContext& ctx);
+    template <class T> void ProcessPendingEvent(TAutoPtr<TEventHandle<T>>& ev, const TActorContext& ctx);
+    void ProcessPendingEvents(const TActorContext& ctx);
+
     TRowVersion LastEmittedHeartbeat;
 
     TLastCounter SourceIdCounter;


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

Move changes from #15160 

The partition actor puts messages in the queue until it enters the `StateIdle` state. Then he sends himself these messages again. There may be a situation when new messages will be processed before the accumulated ones.

#15070

### Changelog category <!-- remove all except one -->

* Bugfix 

### Description for reviewers <!-- (optional) description for those who read this PR -->

Message processing rule:
- in the `StateInit` state, messages are queued up in the `PendingEvents` queue.
- in the `StateIdle` state, messages are processed immediately if the queue is empty and queued otherwise.

After switching from `StateInit` to `StateIdle`, all messages in the queue are processed.