### PR TITLE
merge to 25.1: Return storage pool kind in TChannelBind

### DIFF
--- a/ydb/core/grpc_services/rpc_keyvalue.cpp
+++ b/ydb/core/grpc_services/rpc_keyvalue.cpp
@@ -572,7 +572,7 @@ protected:
         auto *storageConfig = result.mutable_storage_config();
         for (auto &channel : desc.GetBoundChannels()) {
             auto *channelBind = storageConfig->add_channel();
-            channelBind->set_media(channel.GetStoragePoolName());
+            channelBind->set_media(channel.GetStoragePoolKind());
         }
         this->ReplyWithResult(Ydb::StatusIds::SUCCESS, result, TActivationContext::AsActorContext());
     }
@@ -645,7 +645,6 @@ public:
     }
 
     STFUNC(StateWork) {
-        Cerr << "TAlterVolumeRequest::StateWork; received event: " << ev->GetTypeName() << Endl;
         switch (ev->GetTypeRewrite()) {
             hFunc(TEvTxProxySchemeCache::TEvNavigateKeySetResult, Handle);
         default:
@@ -664,7 +663,7 @@ public:
         const NKikimrSchemeOp::TSolomonVolumeDescription &desc = request->ResultSet[0].SolomonVolumeInfo->Description;
         for (auto &channel : desc.GetBoundChannels()) {
             auto *channelBind = StorageConfig.add_channel();
-            channelBind->set_media(channel.GetStoragePoolName());
+            channelBind->set_media(channel.GetStoragePoolKind());
         }
         SendProposeRequest(TActivationContext::AsActorContext());
     }

--- a/ydb/core/protos/bind_channel_storage_pool.proto
+++ b/ydb/core/protos/bind_channel_storage_pool.proto
@@ -9,6 +9,7 @@ message TStoragePool {
 message TChannelBind {
     //optional uint32 Channel = 1; // it should be equal to array index, so it doesn't make any sense to have one
     optional string StoragePoolName = 2;
+    optional string StoragePoolKind = 3;
     optional float IOPS = 10;
     optional uint64 Throughput = 11;
     optional uint64 Size = 12;

--- a/ydb/core/tx/schemeshard/schemeshard_impl.cpp
+++ b/ydb/core/tx/schemeshard/schemeshard_impl.cpp
@@ -62,6 +62,7 @@ bool ResolvePoolNames(
 
         result.emplace_back();
         result.back().SetStoragePoolName(poolIt->GetName());
+        result.back().SetStoragePoolKind(poolIt->GetKind());
     }
 
     channelsBinding.swap(result);
@@ -532,8 +533,8 @@ bool TSchemeShard::ApplyStorageConfig(
         return pools.cend();
     };
 
-    auto allocateChannel = [&] (const TString& poolName, bool reuseExisting = true) -> ui32 {
-        auto it = reverseBinding.find(poolName);
+    auto allocateChannel = [&] (const TStoragePool& pool, bool reuseExisting = true) -> ui32 {
+        auto it = reverseBinding.find(pool.GetName());
         if (it != reverseBinding.end()) {
             if (reuseExisting) {
                 return it->second[0];
@@ -542,8 +543,9 @@ bool TSchemeShard::ApplyStorageConfig(
 
         ui32 channel = channelsBinding.size();
         channelsBinding.emplace_back();
-        channelsBinding.back().SetStoragePoolName(poolName);
-        reverseBinding[poolName].emplace_back(channel);
+        channelsBinding.back().SetStoragePoolName(pool.GetName());
+        channelsBinding.back().SetStoragePoolKind(pool.GetKind());
+        reverseBinding[pool.GetName()].emplace_back(channel);
         return channel;
     };
 
@@ -560,6 +562,7 @@ bool TSchemeShard::ApplyStorageConfig(
 
         channelsBinding.emplace_back();
         channelsBinding.back().SetStoragePoolName(sysLogPool->GetName());
+        channelsBinding.back().SetStoragePoolKind(sysLogPool->GetKind());
     }
 
     if (channelsBinding.size() < 2) {
@@ -567,7 +570,7 @@ bool TSchemeShard::ApplyStorageConfig(
         auto logPool = resolve(storagePools, storageConfig.GetLog());
         LOCAL_CHECK(logPool != storagePools.end(), "unable determine pool for log storage");
 
-        ui32 channel = allocateChannel(logPool->GetName());
+        ui32 channel = allocateChannel(*logPool);
         Y_ABORT_UNLESS(channel == 1, "Expected to allocate log channel, not %" PRIu32, channel);
     }
 
@@ -581,7 +584,7 @@ bool TSchemeShard::ApplyStorageConfig(
         auto dataPool = resolve(storagePools, storageConfig.GetData());
         LOCAL_CHECK(dataPool != storagePools.end(), "definition of data storage present but unable determine pool for it");
 
-        ui32 channel = allocateChannel(dataPool->GetName());
+        ui32 channel = allocateChannel(*dataPool);
         room.AssignChannel(NKikimrStorageSettings::TChannelPurpose::Data, channel);
     }
 
@@ -594,7 +597,7 @@ bool TSchemeShard::ApplyStorageConfig(
         LOCAL_CHECK(externalChannelsCount < Max<ui8>(), "more than 255 external channels requested");
         for (ui32 i = 0; i < externalChannelsCount; ++i) {
             // In case if we have 1 external channel, leave old behavior untouched and reuse channel by pool's name
-            ui32 channel = allocateChannel(externalPool->GetName(), externalChannelsCount == 1 ? true : false);
+            ui32 channel = allocateChannel(*externalPool, externalChannelsCount == 1 ? true : false);
             room.AssignChannel(NKikimrStorageSettings::TChannelPurpose::External, channel);
         }
     }

--- a/ydb/services/keyvalue/grpc_service_ut.cpp
+++ b/ydb/services/keyvalue/grpc_service_ut.cpp
@@ -30,29 +30,10 @@
 namespace NKikimr::NGRpcService {
 
 
-struct TKikimrTestSettings {
-    static constexpr bool SSL = false;
-    static constexpr bool AUTH = false;
-    static constexpr bool PrecreatePools = true;
-    static constexpr bool EnableSystemViews = true;
-};
 
-struct TKikimrTestWithAuth : TKikimrTestSettings {
-    static constexpr bool AUTH = true;
-};
-
-struct TKikimrTestWithAuthAndSsl : TKikimrTestWithAuth {
-    static constexpr bool SSL = true;
-};
-
-struct TKikimrTestNoSystemViews : TKikimrTestSettings {
-    static constexpr bool EnableSystemViews = false;
-};
-
-template <typename TestSettings = TKikimrTestSettings>
-class TBasicKikimrWithGrpcAndRootSchema {
+class TKikimrWithGrpcAndRootSchema {
 public:
-    TBasicKikimrWithGrpcAndRootSchema(
+    TKikimrWithGrpcAndRootSchema(
             NKikimrConfig::TAppConfig appConfig = {},
             TAutoPtr<TLogBackend> logBackend = {})
     {
@@ -63,19 +44,13 @@ public:
         ServerSettings->SetLogBackend(logBackend);
         ServerSettings->SetDomainName("Root");
         ServerSettings->SetDynamicNodeCount(1);
-        if (TestSettings::PrecreatePools) {
-            ServerSettings->AddStoragePool("ssd");
-            ServerSettings->AddStoragePool("hdd");
-            ServerSettings->AddStoragePool("hdd1");
-            ServerSettings->AddStoragePool("hdd2");
-        } else {
-            ServerSettings->AddStoragePoolType("ssd");
-            ServerSettings->AddStoragePoolType("hdd");
-            ServerSettings->AddStoragePoolType("hdd1");
-            ServerSettings->AddStoragePoolType("hdd2");
-        }
+        ServerSettings->AddStoragePool("ssd", "ssd-pool");
+        ServerSettings->AddStoragePool("hdd", "hdd-pool");
+        ServerSettings->AddStoragePool("hdd1", "hdd1-pool");
+        ServerSettings->AddStoragePool("hdd2", "hdd2-pool");
         ServerSettings->Formats = new TFormatFactory;
         ServerSettings->FeatureFlags = appConfig.GetFeatureFlags();
+        ServerSettings->FeatureFlags.SetAllowUpdateChannelsBindingOfSolomonPartitions(true);
         ServerSettings->RegisterGrpcService<NKikimr::NGRpcService::TKeyValueGRpcService>("keyvalue");
 
         Server_.Reset(new Tests::TServer(*ServerSettings));
@@ -101,9 +76,6 @@ public:
         //Server_->GetRuntime()->SetLogPriority(NKikimrServices::TX_COLUMNSHARD, NActors::NLog::PRI_DEBUG);
 
         NYdbGrpc::TServerOptions grpcOption;
-        if (TestSettings::AUTH) {
-            grpcOption.SetUseAuth(true);
-        }
         grpcOption.SetPort(grpc);
         Server_->EnableGRpc(grpcOption);
 
@@ -145,7 +117,6 @@ private:
     ui16 GRpcPort_;
 };
 
-using TKikimrWithGrpcAndRootSchema = TBasicKikimrWithGrpcAndRootSchema<TKikimrTestSettings>;
 
 Y_UNIT_TEST_SUITE(KeyValueGRPCService) {
 
@@ -237,13 +208,20 @@ Y_UNIT_TEST_SUITE(KeyValueGRPCService) {
         createVolumeResponse.operation().result().UnpackTo(&createVolumeResult);
     }
 
-    void AlterVolume(auto &channel, const TString &path, ui32 partition_count = 1) {
+    void AlterVolume(auto &channel, const TString &path, ui32 partition_count = 1, std::optional<Ydb::KeyValue::StorageConfig> storage_config = {}) {
         std::unique_ptr<Ydb::KeyValue::V1::KeyValueService::Stub> stub;
         stub = Ydb::KeyValue::V1::KeyValueService::NewStub(channel);
 
         Ydb::KeyValue::AlterVolumeRequest alterVolumeRequest;
         alterVolumeRequest.set_path(path);
         alterVolumeRequest.set_alter_partition_count(partition_count);
+        if (storage_config) {
+            auto *storageConfig = alterVolumeRequest.mutable_storage_config();
+            for (const auto &channel : storage_config->channel()) {
+                auto *channelBind = storageConfig->add_channel();
+                channelBind->set_media(channel.media());
+            }
+        }
 
         Ydb::KeyValue::AlterVolumeResponse alterVolumeResponse;
         Ydb::KeyValue::AlterVolumeResult alterVolumeResult;
@@ -825,6 +803,15 @@ Y_UNIT_TEST_SUITE(KeyValueGRPCService) {
 
         describeVolumeResult = DescribeVolume(channel, tablePath);
         UNIT_ASSERT_VALUES_EQUAL(2, describeVolumeResult.partition_count());
+        UNIT_ASSERT(describeVolumeResult.has_storage_config());
+        UNIT_ASSERT_VALUES_EQUAL(describeVolumeResult.storage_config().channel_size(), 3);
+        for (const auto& channel : describeVolumeResult.storage_config().channel()) {
+            UNIT_ASSERT_VALUES_EQUAL(channel.media(), "ssd");
+        }
+
+        AlterVolume(channel, tablePath, 3, describeVolumeResult.storage_config());
+        describeVolumeResult = DescribeVolume(channel, tablePath);
+        UNIT_ASSERT_VALUES_EQUAL(3, describeVolumeResult.partition_count());
         UNIT_ASSERT(describeVolumeResult.has_storage_config());
         UNIT_ASSERT_VALUES_EQUAL(describeVolumeResult.storage_config().channel_size(), 3);
         for (const auto& channel : describeVolumeResult.storage_config().channel()) {


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

Describe volume required storage pool kinds of channels instead of their names. Now we set pool kind in TChannelBind and use it in grpc request

 (#15135)

### Changelog category <!-- remove all except one -->


* Not for changelog (changelog entry is not required)

### Description for reviewers <!-- (optional) description for those who read this PR -->

...
