### PR TITLE
merge to 25.1: Use autoconfig when used node_type or cpu_count 

### DIFF
--- a/ydb/core/driver_lib/run/kikimr_services_initializers.cpp
+++ b/ydb/core/driver_lib/run/kikimr_services_initializers.cpp
@@ -499,11 +499,17 @@ static TInterconnectSettings GetInterconnectSettings(const NKikimrConfig::TInter
     return result;
 }
 
+bool NeedToUseAutoConfig(const NKikimrConfig::TActorSystemConfig& config) {
+    return config.GetUseAutoConfig()
+        || config.HasNodeType()
+        || config.HasCpuCount();
+}
 
 void TBasicServicesInitializer::InitializeServices(NActors::TActorSystemSetup* setup,
                                                    const NKikimr::TAppData* appData) {
     bool hasASCfg = Config.HasActorSystemConfig();
-    if (!hasASCfg || Config.GetActorSystemConfig().GetUseAutoConfig()) {
+    bool useAutoConfig = !hasASCfg || NeedToUseAutoConfig(Config.GetActorSystemConfig());
+    if (useAutoConfig) {
         bool isDynamicNode = appData->DynamicNameserviceConfig->MinDynamicNodeId <= NodeId;
         NAutoConfigInitializer::ApplyAutoConfig(Config.MutableActorSystemConfig(), isDynamicNode);
     }


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

Autoconfig in the actor system configuration can be used without the field 'use_auto_config.' Autoconfig is enabled when the fields 'node_type' or 'cpu_count' are used

(#15045)

### Changelog category <!-- remove all except one -->


* Improvement

### Description for reviewers <!-- (optional) description for those who read this PR -->

...
