### PR TITLE
Increase QUERY_TEXT_LIMIT for query stats to 10KB. (#15186)

### DIFF
--- a/ydb/core/kqp/session_actor/kqp_query_stats.cpp
+++ b/ydb/core/kqp/session_actor/kqp_query_stats.cpp
@@ -26,7 +26,7 @@ ui64 TKqpQueryStats::GetWorkerCpuTimeUs() const {
     return WorkerCpuTimeUs;
 }
 
-constexpr size_t QUERY_TEXT_LIMIT = 4096;
+constexpr size_t QUERY_TEXT_LIMIT = 10240;
 
 template <typename T>
 void CollectQueryStatsImpl(const TActorContext& ctx, const T* queryStats,


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->
Increase query text limit size in query stats system views.

### Changelog category <!-- remove all except one -->
* Improvement
