### PR TITLE
tests/library/harness: get rid of warnings on un-closed files

### DIFF
--- a/ydb/tests/library/harness/daemon.py
+++ b/ydb/tests/library/harness/daemon.py
@@ -62,6 +62,7 @@ class Daemon(object):
         stderr_file="/dev/null",
         stderr_on_error_lines=0,
         core_pattern=None,
+        templog_file=None
     ):
         self.__cwd = cwd
         self.__timeout = timeout
@@ -73,6 +74,7 @@ class Daemon(object):
         self.logger = logger.getChild(self.__class__.__name__)
         self.__stdout_file = open(stdout_file, mode='wb')
         self.__stderr_file = open(stderr_file, mode='wb')
+        self.__templog_file = templog_file
 
     @property
     def daemon(self):
@@ -91,6 +93,12 @@ class Daemon(object):
             return os.path.abspath(self.__stderr_file.name)
         else:
             return None
+
+    def __del__(self):
+        self.__stdout_file.close()
+        self.__stderr_file.close()
+        if self.__templog_file is not None:
+            self.__templog_file.close()
 
     def is_alive(self):
         return self.__daemon is not None and self.__daemon.running

--- a/ydb/tests/library/harness/kikimr_runner.py
+++ b/ydb/tests/library/harness/kikimr_runner.py
@@ -89,14 +89,17 @@ class KiKiMRNode(daemon.Daemon, kikimr_node_interface.NodeInterface):
         )
 
         if configurator.use_log_files:
-            self.__log_file = tempfile.NamedTemporaryFile(dir=self.__working_dir, prefix="logfile_", suffix=".log", delete=False, delete_on_close=False)
+            # use NamedTemporaryFile only as a unique name generator
+            log_file = tempfile.NamedTemporaryFile(dir=self.__working_dir, prefix="logfile_", suffix=".log", delete=False)
+            self.__log_file_name = log_file.name
+            log_file.close()
             kwargs = {
                 "stdout_file": os.path.join(self.__working_dir, "stdout"),
                 "stderr_file": os.path.join(self.__working_dir, "stderr"),
-                "templog_file": self.__log_file,
+                "aux_file": self.__log_file_name,
                 }
         else:
-            self.__log_file = None
+            self.__log_file_name = None
             kwargs = {
                 "stdout_file": "/dev/stdout",
                 "stderr_file": "/dev/stderr"
@@ -169,9 +172,9 @@ class KiKiMRNode(daemon.Daemon, kikimr_node_interface.NodeInterface):
                 "--node-kind=%s" % self.__configurator.node_kind
             )
 
-        if self.__log_file is not None:
+        if self.__log_file_name is not None:
             command.append(
-                "--log-file-name=%s" % self.__log_file.name,
+                "--log-file-name=%s" % self.__log_file_name,
             )
 
         command.extend(

--- a/ydb/tests/library/harness/kikimr_runner.py
+++ b/ydb/tests/library/harness/kikimr_runner.py
@@ -89,10 +89,11 @@ class KiKiMRNode(daemon.Daemon, kikimr_node_interface.NodeInterface):
         )
 
         if configurator.use_log_files:
-            self.__log_file = tempfile.NamedTemporaryFile(dir=self.__working_dir, prefix="logfile_", suffix=".log", delete=False)
+            self.__log_file = tempfile.NamedTemporaryFile(dir=self.__working_dir, prefix="logfile_", suffix=".log", delete=False, delete_on_close=False)
             kwargs = {
                 "stdout_file": os.path.join(self.__working_dir, "stdout"),
-                "stderr_file": os.path.join(self.__working_dir, "stderr")
+                "stderr_file": os.path.join(self.__working_dir, "stderr"),
+                "templog_file": self.__log_file,
                 }
         else:
             self.__log_file = None


### PR DESCRIPTION
tests/library/harness: get rid of warnings on un-closed files.

`KiKiMRNode`-`Daemon` manage process of ydb node (ydbd).
`Daemon` opens stderr, stdout.
`KiKiMRNode` opens log file.

Change `Daemon` to open all those files on (every) `Daemon.start()` and close on (every) `Daemon.{stop,kill}()` instead of opening them once at `KiKiMRNode`-`Daemon` construction and never closing.