### PR TITLE
Fix seqNo conflict on concurrent TXs

### DIFF
--- a/ydb/core/persqueue/partition.cpp
+++ b/ydb/core/persqueue/partition.cpp
@@ -1278,6 +1278,7 @@ TPartition::EProcessResult TPartition::ApplyWriteInfoResponse(TTransaction& tx) 
             txSourceIds.insert(s.first);
         }
         auto inFlightIter = TxInflightMaxSeqNoPerSourceId.find(s.first);
+
         if (!inFlightIter.IsEnd()) {
             if (s.second.MinSeqNo <= inFlightIter->second) {
                 tx.Predicate = false;
@@ -1298,9 +1299,7 @@ TPartition::EProcessResult TPartition::ApplyWriteInfoResponse(TTransaction& tx) 
         }
     }
     if (ret == EProcessResult::Continue && tx.Predicate.GetOrElse(true)) {
-        for (const auto& s : txSourceIds) {
-            TxAffectedSourcesIds.insert(s);
-        }
+        TxAffectedSourcesIds.insert(txSourceIds.begin(), txSourceIds.end());
 
         tx.WriteInfoApplied = true;
         WriteKeysSizeEstimate += tx.WriteInfo->BodyKeys.size();

--- a/ydb/core/persqueue/partition.cpp
+++ b/ydb/core/persqueue/partition.cpp
@@ -2397,7 +2397,7 @@ void TPartition::CommitWriteOperations(TTransaction& t)
         return;
     }
     for (const auto& s : t.WriteInfo->SrcIdInfo) {
-        auto [iter, ins] = TxInflightMaxSeqNoPerSourceId.insert(std::make_pair(s.first, s.second.SeqNo));
+        auto [iter, ins] = TxInflightMaxSeqNoPerSourceId.emplace(s.first, s.second.SeqNo);
         if (!ins) {
             Y_ABORT_UNLESS(iter->second < s.second.SeqNo);
             iter->second = s.second.SeqNo;

--- a/ydb/core/persqueue/partition.cpp
+++ b/ydb/core/persqueue/partition.cpp
@@ -2508,19 +2508,17 @@ void TPartition::CommitWriteOperations(TTransaction& t)
 
             WriteInflightSize += msg.Msg.Data.size();
             ExecRequest(msg, *Parameters, PersistRequest.Get());
-
-            auto& info = TxSourceIdForPostPersist[blob.SourceId];
-            info.SeqNo = blob.SeqNo;
-            info.Offset = NewHead.Offset;
         }
     }
     for (const auto& [srcId, info] : t.WriteInfo->SrcIdInfo) {
-
         auto& sourceIdBatch = Parameters->SourceIdBatch;
         auto sourceId = sourceIdBatch.GetSource(srcId);
         sourceId.Update(info.SeqNo, info.Offset + oldHeadOffset, CurrentTimestamp);
-
+        auto& persistInfo = TxSourceIdForPostPersist[srcId];
+        persistInfo.SeqNo = info.SeqNo;
+        persistInfo.Offset = info.Offset + oldHeadOffset;
     }
+
     Parameters->FirstCommitWriteOperations = false;
 
     WriteInfosApplied.emplace_back(std::move(t.WriteInfo));

--- a/ydb/core/persqueue/partition.h
+++ b/ydb/core/persqueue/partition.h
@@ -665,7 +665,7 @@ private:
     THashSet<TString> TxAffectedConsumers;
     THashSet<TString> SetOffsetAffectedConsumers;
     THashMap<TString, TSourceIdPostPersistInfo> TxSourceIdForPostPersist;
-    THashMap<TString, TSet<ui64>> TxInflightMaxSeqNoPerSourceId;
+    THashMap<TString, ui64> TxInflightMaxSeqNoPerSourceId;
 
 
     ui32 MaxBlobSize;

--- a/ydb/core/persqueue/partition.h
+++ b/ydb/core/persqueue/partition.h
@@ -665,7 +665,7 @@ private:
     THashSet<TString> TxAffectedConsumers;
     THashSet<TString> SetOffsetAffectedConsumers;
     THashMap<TString, TSourceIdPostPersistInfo> TxSourceIdForPostPersist;
-    THashMap<TString, ui64> TxInflightMaxSeqNoPerSourceId;
+    THashMap<TString, TSet<ui64>> TxInflightMaxSeqNoPerSourceId;
 
 
     ui32 MaxBlobSize;

--- a/ydb/core/persqueue/partition.h
+++ b/ydb/core/persqueue/partition.h
@@ -665,6 +665,8 @@ private:
     THashSet<TString> TxAffectedConsumers;
     THashSet<TString> SetOffsetAffectedConsumers;
     THashMap<TString, TSourceIdPostPersistInfo> TxSourceIdForPostPersist;
+    THashMap<TString, ui64> TxInflightMaxSeqNoPerSourceId;
+
 
     ui32 MaxBlobSize;
     const ui32 TotalLevels = 4;

--- a/ydb/core/persqueue/partition_write.cpp
+++ b/ydb/core/persqueue/partition_write.cpp
@@ -521,6 +521,7 @@ void TPartition::HandleWriteResponse(const TActorContext& ctx) {
         SourceIdCounter.Use(sourceId, now);
     }
     TxSourceIdForPostPersist.clear();
+    TxInflightMaxSeqNoPerSourceId.clear();
 
     TxAffectedSourcesIds.clear();
     WriteAffectedSourcesIds.clear();

--- a/ydb/core/persqueue/partition_write.cpp
+++ b/ydb/core/persqueue/partition_write.cpp
@@ -1052,6 +1052,12 @@ TPartition::EProcessResult TPartition::PreProcessRequest(TWriteMsg& p) {
     if (TxAffectedSourcesIds.contains(p.Msg.SourceId)) {
         return EProcessResult::Blocked;
     }
+    auto inflightMaxSeqNo = TxInflightMaxSeqNoPerSourceId.find(p.Msg.SourceId);
+    if (!inflightMaxSeqNo.IsEnd()) {
+        if (p.Msg.SeqNo <= inflightMaxSeqNo->second) {
+            return EProcessResult::Blocked;
+        }
+    }
     WriteAffectedSourcesIds.insert(p.Msg.SourceId);
     return EProcessResult::Continue;
 }

--- a/ydb/core/persqueue/partition_write.cpp
+++ b/ydb/core/persqueue/partition_write.cpp
@@ -1053,6 +1053,7 @@ TPartition::EProcessResult TPartition::PreProcessRequest(TWriteMsg& p) {
         return EProcessResult::Blocked;
     }
     auto inflightMaxSeqNo = TxInflightMaxSeqNoPerSourceId.find(p.Msg.SourceId);
+
     if (!inflightMaxSeqNo.IsEnd()) {
         if (p.Msg.SeqNo <= inflightMaxSeqNo->second) {
             return EProcessResult::Blocked;

--- a/ydb/core/persqueue/ut/common/pq_ut_common.h
+++ b/ydb/core/persqueue/ut/common/pq_ut_common.h
@@ -127,7 +127,6 @@ struct TTestContext {
 
     static bool RequestTimeoutFilter(TTestActorRuntimeBase& runtime, TAutoPtr<IEventHandle>& event, TDuration duration, TInstant& deadline) {
         if (event->GetTypeRewrite() == TEvents::TSystem::Wakeup) {
-            Cerr << "Captured TEvents::TSystem::Wakeup to " << runtime.FindActorName(event->GetRecipientRewrite()) << Endl;
             if (runtime.FindActorName(event->GetRecipientRewrite()) == "PERSQUEUE_ANS_ACTOR") {
                 return true;
             }

--- a/ydb/core/persqueue/ut/partition_ut.cpp
+++ b/ydb/core/persqueue/ut/partition_ut.cpp
@@ -2753,9 +2753,6 @@ Y_UNIT_TEST_F(TestTxBatchInFederation, TPartitionTxTestHelper) {
 }
 
 Y_UNIT_TEST_F(ConflictingActsInSeveralBatches, TPartitionTxTestHelper) {
-    // A temporary solution. This line should be deleted when we fix the error with the SeqNo promotion.
-    return;
-
     TTxBatchingTestParams params {.WriterSessions{"src1", "src4"},.EndOffset=1};
     Init(std::move(params));
 
@@ -2837,9 +2834,6 @@ Y_UNIT_TEST_F(ConflictingTxIsAborted, TPartitionTxTestHelper) {
 }
 
 Y_UNIT_TEST_F(ConflictingTxProceedAfterRollback, TPartitionTxTestHelper) {
-    // A temporary solution. This line should be deleted when we fix the error with the SeqNo promotion.
-    return;
-
     Init();
 
     auto tx1 = MakeAndSendWriteTx({{"src1", {1, 3}}, {"src2", {5, 10}}});


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

Fix SeqNo conflict for concurrent transactions using same SourceId

### Changelog category <!-- remove all except one -->

* Bugfix 

### Description for reviewers <!-- (optional) description for those who read this PR -->

Fix possible conflict of several concurrent transactions using same SourceId and conflicting SeqNo ranges
