### PR TITLE
Change MAX_REORDER_TX_KEYS from 100 to 1000 (24-4)

### DIFF
--- a/ydb/core/tx/datashard/const.h
+++ b/ydb/core/tx/datashard/const.h
@@ -9,7 +9,7 @@ constexpr ui64 INVALID_TABLET_ID = Max<ui64>();
 constexpr ui64 MEMORY_REQUEST_FACTOR = 8;
 
 // TODO: make configurable
-constexpr ui64 MAX_REORDER_TX_KEYS = 100;
+constexpr ui64 MAX_REORDER_TX_KEYS = 1000;
 
 namespace NLimits {
     static constexpr ui64 MaxWriteKeySize = 1024 * 1024 + 1024; // 1MB + small delta (for old ugc tests)


### PR DESCRIPTION
### Changelog category <!-- remove all except one -->

* Not for changelog (changelog entry is not required)

### Description for reviewers <!-- (optional) description for those who read this PR -->

Improve out of order tx batching

https://github.com/ydb-platform/ydb/pull/15293