### PR TITLE
don't return childrenExist prop for databases

### DIFF
--- a/ydb/core/tx/schemeshard/schemeshard_path_describer.cpp
+++ b/ydb/core/tx/schemeshard/schemeshard_path_describer.cpp
@@ -176,7 +176,10 @@ void TPathDescriber::FillChildDescr(NKikimrSchemeOp::TDirEntry* descr, TPathElem
         descr->SetCreateStep(ui64(pathEl->StepCreated));
     }
 
-    descr->SetChildrenExist(pathEl->GetAliveChildren() > 0);
+    if (pathEl->PathType != NKikimrSchemeOp::EPathTypeSubDomain
+        && pathEl->PathType != NKikimrSchemeOp::EPathTypeExtSubDomain) {
+        descr->SetChildrenExist(pathEl->GetAliveChildren() > 0);
+    }
 
     if (pathEl->PathType == NKikimrSchemeOp::EPathTypePersQueueGroup) {
         auto it = Self->Topics.FindPtr(pathEl->PathId);

--- a/ydb/core/viewer/tests/canondata/result.json
+++ b/ydb/core/viewer/tests/canondata/result.json
@@ -1512,7 +1512,6 @@
                     },
                     {
                         "ACL": "",
-                        "ChildrenExist": false,
                         "CreateFinished": true,
                         "CreateStep": "not-zero-number-text",
                         "CreateTxId": "not-zero-number-text",
@@ -1526,7 +1525,6 @@
                     },
                     {
                         "ACL": "",
-                        "ChildrenExist": false,
                         "CreateFinished": true,
                         "CreateStep": "not-zero-number-text",
                         "CreateTxId": "not-zero-number-text",
@@ -1540,7 +1538,6 @@
                     },
                     {
                         "ACL": "",
-                        "ChildrenExist": false,
                         "CreateFinished": true,
                         "CreateStep": "not-zero-number-text",
                         "CreateTxId": "not-zero-number-text",
@@ -1768,7 +1765,6 @@
                 },
                 "Self": {
                     "ACL": "",
-                    "ChildrenExist": true,
                     "CreateFinished": true,
                     "CreateStep": "0",
                     "CreateTxId": "not-zero-number-text",
@@ -1849,7 +1845,6 @@
                 },
                 "Self": {
                     "ACL": "",
-                    "ChildrenExist": false,
                     "CreateFinished": true,
                     "CreateStep": "0",
                     "CreateTxId": "not-zero-number-text",
@@ -1946,7 +1941,6 @@
                 },
                 "Self": {
                     "ACL": "",
-                    "ChildrenExist": true,
                     "CreateFinished": true,
                     "CreateStep": "0",
                     "CreateTxId": "not-zero-number-text",


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

don't return childrenExist prop for databases, closes #15256

### Changelog category <!-- remove all except one -->

* Bugfix 

### Description for reviewers <!-- (optional) description for those who read this PR -->

this will trigger default behavior where we draw a toggle to expand the element and remove it if it doesn't have any children
