### PR TITLE
Support pausing TestShard writes through ICB

### DIFF
--- a/ydb/core/protos/config.proto
+++ b/ydb/core/protos/config.proto
@@ -1573,6 +1573,15 @@ message TImmediateControlsConfig {
             DefaultValue: 0 }];
     }
 
+    message TTestShardControls {
+        optional uint64 DisableWrites = 1 [(ControlOptions) = {
+            Description: "Disable write load in all node TestShard tablets",
+            MinValue: 0,
+            MaxValue: 1,
+            DefaultValue: 0
+        }];
+    }
+
     optional TDataShardControls DataShardControls = 1;
     optional TTxLimitControls TxLimitControls = 2;
     optional TCoordinatorControls CoordinatorControls = 3;
@@ -1585,6 +1594,7 @@ message TImmediateControlsConfig {
     optional TPDiskControls PDiskControls = 10;
     optional TBlobStorageControllerControls BlobStorageControllerControls = 11;
     optional TTableServiceControls TableServiceControls = 12;
+    optional TTestShardControls TestShardControls = 13;
 };
 
 message TMeteringConfig {

--- a/ydb/core/test_tablet/load_actor_impl.h
+++ b/ydb/core/test_tablet/load_actor_impl.h
@@ -138,6 +138,8 @@ namespace NKikimr::NTestShard {
         bool WriteOnTimeScheduled = false;
         bool DoSomeActionInFlight = false;
 
+        TControlWrapper DisableWrites;
+
         void GenerateKeyValue(TString *key, TString *value, bool *isInline);
         void IssueWrite();
         void IssuePatch();


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

Support pausing TestShard writes through ICB

### Changelog category <!-- remove all except one -->

* Not for changelog (changelog entry is not required)

### Description for reviewers <!-- (optional) description for those who read this PR -->

All writes on a node generated by TestShard can now be paused through ICB.
