### PR TITLE
Fix ld preload for breakpad

### DIFF
--- a/ydb/apps/ydbd/ya.make
+++ b/ydb/apps/ydbd/ya.make
@@ -69,7 +69,7 @@ PEERDIR(
     yql/essentials/udfs/common/url_base
     yql/essentials/udfs/common/yson2
     yql/essentials/udfs/logs/dsv
-    ydb/library/breakpad
+#    ydb/library/breakpad 
     ydb/public/sdk/cpp/client/ydb_persqueue_public/codecs
 )
 

--- a/ydb/apps/ydbd/ya.make
+++ b/ydb/apps/ydbd/ya.make
@@ -69,7 +69,7 @@ PEERDIR(
     yql/essentials/udfs/common/url_base
     yql/essentials/udfs/common/yson2
     yql/essentials/udfs/logs/dsv
-    # ydb/library/breakpad  # not working properly, see KIKIMR-18829 for details
+    ydb/library/breakpad
     ydb/public/sdk/cpp/client/ydb_persqueue_public/codecs
 )
 

--- a/ydb/deploy/docker/Dockerfile
+++ b/ydb/deploy/docker/Dockerfile
@@ -26,11 +26,19 @@ COPY --chmod=0644 /liblibaio-dynamic.so /lib/liblibaio-dynamic.so
 ###
 
 FROM ${BREAKPAD_INIT_IMAGE}:${BREAKPAD_INIT_IMAGE_TAG} AS breakpad_init
+FROM base AS breakpad-setuid
+COPY --from=breakpad_init /usr/lib/libbreakpad_init.so /usr/lib/libbreakpad_init.so
+# workaround for old docker versions
+# https://github.com/moby/buildkit/issues/3920
+RUN /usr/bin/chmod 4644 /usr/lib/libbreakpad_init.so
+
+
 FROM base AS base-breakpad
 RUN \
     apt-get -yqq update && \
     apt-get -yqq install --no-install-recommends binutils gdb strace linux-tools-generic && \
     apt-get clean && rm -rf /var/lib/apt/lists/*
+ENV LD_PRELOAD=libbreakpad_init.so
 ENV BREAKPAD_MINIDUMPS_PATH=/opt/ydb/volumes/coredumps
 ENV BREAKPAD_MINIDUMPS_SCRIPT=/opt/ydb/bin/minidump_script.py
 # breakpad binaries
@@ -38,6 +46,8 @@ COPY --chmod=0755 --from=breakpad_init /usr/bin/minidump_stackwalk /usr/bin/mini
 COPY --chmod=0755 --from=breakpad_init /usr/bin/minidump-2-core /usr/bin/minidump-2-core
 # minidump callback script
 COPY --chmod=0755 --chown=ydb /minidump_script.py /opt/ydb/bin/minidump_script.py
+# minidump init library
+COPY --link --from=breakpad-setuid /usr/lib/libbreakpad_init.so /usr/lib/libbreakpad_init.so
 
 FROM base AS ydbd-setcap
 COPY --chmod=0755 --chown=ydb /ydbd /opt/ydb/bin/ydbd

--- a/ydb/tests/functional/minidumps/ya.make
+++ b/ydb/tests/functional/minidumps/ya.make
@@ -3,7 +3,7 @@ IF (OS_LINUX AND NOT SANITIZER_TYPE)
 PY3TEST()
 
 TEST_SRCS(
-    test_break.py
+#    test_break.py
 )
 
 SIZE(MEDIUM)

--- a/ydb/tests/functional/ya.make
+++ b/ydb/tests/functional/ya.make
@@ -15,7 +15,7 @@ RECURSE(
     kqp
     large_serializable
     limits
-    # minidumps  # breakpad is disabled now, see KIKIMR-18829 for details
+    minidumps
     postgresql
     query_cache
     rename


### PR DESCRIPTION
Return breakpad support with LD_PRELOAD

Technically this PR reverts 
480b6ddc877d13ea93be0986902284280ef3501b 
acab63449b58cbf333b8e2e2e1d0bb614c32d70a 