### PR TITLE
Changed alias handling in CBO

### DIFF
--- a/ydb/library/yql/dq/opt/dq_opt_join_hypergraph.h
+++ b/ydb/library/yql/dq/opt/dq_opt_join_hypergraph.h
@@ -54,13 +54,13 @@ public:
 
         void RemoveAttributeAliases() {
             for (auto& leftKey : LeftJoinKeys) {
-                if (auto idx = leftKey.AttributeName.find_last_of('.'); idx != TString::npos) {
+                if (auto idx = leftKey.AttributeName.find('.'); idx != TString::npos) {
                     leftKey.AttributeName = leftKey.AttributeName.substr(idx + 1);
                 }
             }
 
             for (auto& rightKey : RightJoinKeys) {
-                if (auto idx = rightKey.AttributeName.find_last_of('.'); idx != TString::npos) {
+                if (auto idx = rightKey.AttributeName.find('.'); idx != TString::npos) {
                     rightKey.AttributeName = rightKey.AttributeName.substr(idx + 1);
                 }
             }

--- a/ydb/library/yql/dq/opt/dq_opt_stat.cpp
+++ b/ydb/library/yql/dq/opt/dq_opt_stat.cpp
@@ -24,16 +24,16 @@ namespace {
 
 
     TString RemoveAliases(TString attributeName) {
-        if (auto idx = attributeName.find_last_of('.'); idx != TString::npos) {
+        if (auto idx = attributeName.find('.'); idx != TString::npos) {
             return attributeName.substr(idx+1);
         }
         return attributeName;
     }
 
     TString ExtractAlias(TString attributeName) {
-        if (auto idx = attributeName.find_last_of('.'); idx != TString::npos) {
+        if (auto idx = attributeName.find('.'); idx != TString::npos) {
             auto substr = attributeName.substr(0, idx);
-            if (auto idx2 = substr.find_last_of('.'); idx != TString::npos) {
+            if (auto idx2 = substr.find('.'); idx != TString::npos) {
                 substr = substr.substr(idx2+1);
             }
             return substr;


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

The alias name was incorrectly determined for YT CBO usage
An alias may contain a '.' character, but we were mishandling this case
https://github.com/ydb-platform/ydb/issues/15317

### Changelog category <!-- remove all except one -->


* Bugfix 


### Description for reviewers <!-- (optional) description for those who read this PR -->

...
