### PR TITLE
add subdomain key to required fiels for non-database requests

### DIFF
--- a/ydb/core/viewer/json_handlers_viewer.cpp
+++ b/ydb/core/viewer/json_handlers_viewer.cpp
@@ -246,7 +246,7 @@ void InitViewerHealthCheckJsonHandler(TJsonHandlers& handlers) {
 }
 
 void InitViewerNodesJsonHandler(TJsonHandlers& handlers) {
-    handlers.AddHandler("/viewer/nodes", new TJsonHandler<TJsonNodes>(TJsonNodes::GetSwagger()), 14);
+    handlers.AddHandler("/viewer/nodes", new TJsonHandler<TJsonNodes>(TJsonNodes::GetSwagger()), 15);
 }
 
 void InitViewerACLJsonHandler(TJsonHandlers &jsonHandlers) {

--- a/ydb/core/viewer/protos/viewer.proto
+++ b/ydb/core/viewer/protos/viewer.proto
@@ -561,6 +561,12 @@ message TNodeInfo {
     repeated NKikimrWhiteboard.TNodeStateInfo ReversePeers = 55;
 }
 
+message TNodeBatch {
+    repeated uint32 NodesToAskFor = 1;
+    repeated uint32 NodesToAskAbout = 2;
+    optional bool HasStaticNodes = 3;
+}
+
 message TNodesInfo {
     uint32 Version = 1;
     optional uint64 TotalNodes = 2;
@@ -578,6 +584,7 @@ message TNodesInfo {
     optional uint64 MaximumSlotsPerDisk = 51;
     optional bool NoDC = 60;
     optional bool NoRack = 61;
+    repeated TNodeBatch OriginalNodeBatches = 62;
 }
 
 enum ENodeType {

--- a/ydb/core/viewer/tests/canondata/result.json
+++ b/ydb/core/viewer/tests/canondata/result.json
@@ -2975,7 +2975,7 @@
     "test.test_viewer_nodes_issue_14992": {
         "response_group": {
             "FieldsAvailable": "0000000110111110111111100000111",
-            "FieldsRequired": "0000000001000000010000000000101",
+            "FieldsRequired": "0000000001100000010000000000101",
             "FoundNodes": "3",
             "MaximumDisksPerNode": "1",
             "Nodes": [
@@ -3196,7 +3196,7 @@
         },
         "response_group_by": {
             "FieldsAvailable": "0000000110111110111111100000111",
-            "FieldsRequired": "0000000001000000010000000000101",
+            "FieldsRequired": "0000000001100000010000000000101",
             "FoundNodes": "3",
             "MaximumDisksPerNode": "1",
             "NodeGroups": [


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

fix for unstable version grouping, closes #14827

### Changelog category <!-- remove all except one -->

* Bugfix 

### Description for reviewers <!-- (optional) description for those who read this PR -->

add subdomain key to all non-datrequired fiels for non-database requests
it forces offload merge to correctly distribute requests across database nodes
add ability to specify offload merge batch size and dump merge batches in output for debugging
