### PR TITLE
Fix log message in GenerateCookie (#8890)

### DIFF
--- a/ydb/core/persqueue/ownerinfo.cpp
+++ b/ydb/core/persqueue/ownerinfo.cpp
@@ -19,7 +19,8 @@ namespace NPQ {
             THolder<TEvPersQueue::TEvResponse> response = MakeHolder<TEvPersQueue::TEvResponse>();
             response->Record.SetStatus(NMsgBusProxy::MSTATUS_OK);
             response->Record.SetErrorCode(NPersQueue::NErrorCode::BAD_REQUEST);
-            response->Record.SetErrorReason("ownership session is killed by another session with id " + OwnerCookie + " partition id " + partition.OriginalPartitionId);
+            response->Record.SetErrorReason(TStringBuilder() << "ownership session is killed by another session with id " << OwnerCookie
+                                                             << " partition id " << partition.OriginalPartitionId);
             ctx.Send(Sender, response.Release());
         }
         Sender = sender;


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

Changes from PR #8890

Binary data is displayed in the log instead of the partition id. Example from the log
```
... partition id ^@" code: BAD_REQUEST sessionId: ...
```

### Changelog category <!-- remove all except one -->

* Not for changelog (changelog entry is not required)

### Description for reviewers <!-- (optional) description for those who read this PR -->

...
