### PR TITLE
LocalDB: low-priority cancellable transactions

### DIFF
--- a/ydb/core/tablet_flat/flat_exec_seat.cpp
+++ b/ydb/core/tablet_flat/flat_exec_seat.cpp
@@ -4,6 +4,13 @@ namespace NKikimr {
 namespace NTabletFlatExecutor {
 
     void TSeat::Complete(const TActorContext& ctx, bool isRW) noexcept {
+        if (Y_UNLIKELY(IsTerminated())) {
+            Y_ABORT_UNLESS(!isRW, "Terminating a read-write transaction");
+            Self->Terminate(TerminationReason, ctx);
+            Self->TxSpan.EndError("Terminated");
+            return;
+        }
+
         NWilson::TSpan span(TWilsonTablet::TabletDetailed, Self->TxSpan.GetTraceId(), "Tablet.Transaction.Complete");
         for (auto& callback : OnPersistent) {
             callback();
@@ -13,12 +20,6 @@ namespace NTabletFlatExecutor {
 
         Self->TxSpan.Attribute("rw", isRW);
         Self->TxSpan.EndOk();
-    }
-
-    void TSeat::Terminate(ETerminationReason reason, const TActorContext& ctx) noexcept {
-        Self->Terminate(reason, ctx);
-
-        Self->TxSpan.EndError("Terminated");
     }
 
 } // namespace NTabletFlatExecutor

--- a/ydb/core/tablet_flat/flat_executor.cpp
+++ b/ydb/core/tablet_flat/flat_executor.cpp
@@ -128,8 +128,6 @@ TExecutor::TExecutor(
     , Time(TAppData::TimeProvider)
     , Owner(owner)
     , OwnerActorId(ownerActorId)
-    , ActivationQueue(new TActivationQueue())
-    , PendingQueue(new TActivationQueue())
     , Emitter(new TIdEmitter)
     , CounterEventsInFlight(new TEvTabletCounters::TInFlightCookie)
     , Stats(new TExecutorStatsImpl())
@@ -144,6 +142,10 @@ TExecutor::~TExecutor() {
 ui64 TExecutor::Stamp() const noexcept
 {
     return CommitManager ? CommitManager->Stamp() : TTxStamp{ Generation0, Step0 }.Raw;
+}
+
+TActorContext TExecutor::SelfCtx() const {
+    return TActivationContext::ActorContextFor(SelfId());
 }
 
 TActorContext TExecutor::OwnerCtx() const {
@@ -222,12 +224,16 @@ void TExecutor::RecreatePageCollectionsCache() noexcept
 
     if (TransactionWaitPads) {
         for (auto &xpair : TransactionWaitPads) {
-            auto &seat = xpair.second->Seat;
+            TSeat* seat = xpair.second->Seat;
+            Y_ABORT_UNLESS(seat->State == ESeatState::Waiting);
+            seat->State = ESeatState::None;
             xpair.second->WaitingSpan.EndOk();
-            LWTRACK(TransactionEnqueued, seat->Self->Orbit, seat->UniqID);
-            seat->StartEnqueuedSpan();
-            ActivationQueue->Push(seat.Release());
-            ActivateTransactionWaiting++;
+
+            if (seat->Cancelled) {
+                FinishCancellation(seat, false);
+            } else {
+                EnqueueActivation(seat, false);
+            }
         }
         TransactionWaitPads.clear();
     }
@@ -547,46 +553,98 @@ void TExecutor::TranscriptFollowerBootOpResult(ui32 res, const TActorContext &ct
     }
 }
 
+std::unique_ptr<TSeat> TExecutor::RemoveTransaction(ui64 id) {
+    auto it = Transactions.find(id);
+    Y_ABORT_UNLESS(it != Transactions.end(), "Cannot find transaction %" PRIu64, id);
+    auto res = std::move(it->second);
+    res->State = ESeatState::Done;
+    Transactions.erase(it);
+    return res;
+}
+
+void TExecutor::FinishCancellation(TSeat* seat, bool activateMore) {
+    UnpinTransactionPages(*seat);
+    Memory->ReleaseMemory(*seat);
+    --Stats->TxInFly;
+    Counters->Simple()[TExecutorCounters::DB_TX_IN_FLY] = Stats->TxInFly;
+    RemoveTransaction(seat->UniqID);
+    if (activateMore) {
+        PlanTransactionActivation();
+        MaybeRelaxRejectProbability();
+    }
+}
+
+void TExecutor::EnqueueActivation(TSeat* seat, bool activate) {
+    LWTRACK(TransactionEnqueued, seat->Self->Orbit, seat->UniqID);
+    seat->StartEnqueuedSpan();
+    if (!seat->LowPriority) {
+        seat->State = ESeatState::Active;
+        ActivationQueue.PushBack(seat);
+        ActivateTransactionWaiting++;
+        if (activate && ActivateTransactionInFlight < ActivateTransactionWaiting) {
+            Send(SelfId(), new TEvPrivate::TEvActivateExecution());
+            ++ActivateTransactionInFlight;
+        }
+    } else {
+        seat->State = ESeatState::ActiveLow;
+        ActivationLowQueue.PushBack(seat);
+        ActivateLowTransactionWaiting++;
+        if (activate && ActivateLowTransactionInFlight < 1) {
+            Send(SelfId(), new TEvPrivate::TEvActivateLowExecution());
+            ++ActivateLowTransactionInFlight;
+        }
+    }
+}
+
 void TExecutor::PlanTransactionActivation() {
     if (!CanExecuteTransaction())
         return;
 
     const ui64 limitTxInFly = Scheme().Executor.LimitInFlyTx;
-    while (PendingQueue->Head() && (!limitTxInFly || (Stats->TxInFly - Stats->TxPending < limitTxInFly))) {
-        TAutoPtr<TSeat> seat = PendingQueue->Pop();
+    while (PendingQueue && (!limitTxInFly || (Stats->TxInFly - Stats->TxPending < limitTxInFly))) {
+        TSeat* seat = PendingQueue.PopFront();
+        Y_ABORT_UNLESS(seat->State == ESeatState::Pending);
+        seat->State = ESeatState::None;
         seat->FinishPendingSpan();
-        LWTRACK(TransactionEnqueued, seat->Self->Orbit, seat->UniqID);
-        seat->StartEnqueuedSpan();
-        ActivationQueue->Push(seat.Release());
-        ActivateTransactionWaiting++;
         --Stats->TxPending;
+        EnqueueActivation(seat, false);
     }
 
     while (ActivateTransactionInFlight < ActivateTransactionWaiting) {
         Send(SelfId(), new TEvPrivate::TEvActivateExecution());
-        ActivateTransactionInFlight++;
+        ++ActivateTransactionInFlight;
+    }
+
+    while (ActivateLowTransactionWaiting > 0 && ActivateLowTransactionInFlight < 1) {
+        Send(SelfId(), new TEvPrivate::TEvActivateLowExecution());
+        ++ActivateLowTransactionInFlight;
     }
 }
 
 void TExecutor::ActivateWaitingTransactions(TPrivatePageCache::TPage::TWaitQueuePtr waitPadsQueue) {
     if (waitPadsQueue) {
-        bool haveTransactions = false;
+        bool activate = CanExecuteTransaction();
+        bool cancelled = false;
         while (TPrivatePageCacheWaitPad *waitPad = waitPadsQueue->Pop()) {
             if (auto it = TransactionWaitPads.find(waitPad); it != TransactionWaitPads.end()) {
-                it->second->WaitingSpan.EndOk();
-                auto &seat = it->second->Seat;
-                LWTRACK(TransactionEnqueued, seat->Self->Orbit, seat->UniqID);
-                seat->StartEnqueuedSpan();
-                ActivationQueue->Push(seat.Release());
-                ActivateTransactionWaiting++;
+                TSeat* seat = it->second->Seat;
+                Y_ABORT_UNLESS(seat->State == ESeatState::Waiting);
+                seat->State = ESeatState::None;
+                seat->WaitingSpan.EndOk();
                 TransactionWaitPads.erase(waitPad);
-                haveTransactions = true;
+                if (seat->Cancelled) {
+                    FinishCancellation(seat, false);
+                    cancelled = true;
+                } else {
+                    EnqueueActivation(seat, activate);
+                }
             } else {
                 Y_Fail("Unexpected wait pad triggered");
             }
         }
-        if (haveTransactions) {
+        if (cancelled && activate) {
             PlanTransactionActivation();
+            MaybeRelaxRejectProbability();
         }
     }
 }
@@ -1678,10 +1736,10 @@ bool TExecutor::CanExecuteTransaction() const {
     return Stats->IsActive && (Stats->IsFollower() || PendingPartSwitches.empty()) && !BrokenTransaction;
 }
 
-void TExecutor::DoExecute(TAutoPtr<ITransaction> self, bool allowImmediate, const TActorContext &ctx) {
-    Y_ABORT_UNLESS(ActivationQueue, "attempt to execute transaction before activation");
-
-    TAutoPtr<TSeat> seat = new TSeat(++TransactionUniqCounter, self);
+ui64 TExecutor::DoExecute(TAutoPtr<ITransaction> self, ETxMode mode) {
+    ui64 uniqId = ++TransactionUniqCounter;
+    TSeat* seat = (Transactions[uniqId] = std::make_unique<TSeat>(uniqId, self)).get();
+    seat->LowPriority = mode == ETxMode::LowPriority;
     seat->Self->SetupTxSpanName();
 
     LWTRACK(TransactionBegin, seat->Self->Orbit, seat->UniqID, Owner->TabletID(), TypeName(*seat->Self));
@@ -1705,11 +1763,9 @@ void TExecutor::DoExecute(TAutoPtr<ITransaction> self, bool allowImmediate, cons
     if (staticRemain < seat->CurrentTxDataLimit) {
         LWTRACK(TransactionNeedMemory, seat->Self->Orbit, seat->UniqID);
         Memory->RequestLimit(*seat, seat->CurrentTxDataLimit);
-        auto *transptr = seat.Release();
-        auto pairIt = PostponedTransactions.emplace(transptr, transptr);
-        Y_ABORT_UNLESS(pairIt.second);
-
-        return;
+        seat->State = ESeatState::Postponed;
+        PostponedTransactions.PushBack(seat);
+        return uniqId;
     }
 
     Memory->AllocStatic(*seat, Memory->Profile->GetInitialTxMemory());
@@ -1720,32 +1776,98 @@ void TExecutor::DoExecute(TAutoPtr<ITransaction> self, bool allowImmediate, cons
         LWTRACK(TransactionPending, seat->Self->Orbit, seat->UniqID,
                 CanExecuteTransaction() ? "tx limit reached" : "transactions paused");
         seat->CreatePendingSpan();
-        PendingQueue->Push(seat.Release());
+        seat->State = ESeatState::Pending;
+        PendingQueue.PushBack(seat);
         ++Stats->TxPending;
-        return;
+        return uniqId;
     }
 
-    if (ActiveTransaction || ActivateTransactionWaiting || !allowImmediate) {
-        LWTRACK(TransactionEnqueued, seat->Self->Orbit, seat->UniqID);
-        seat->StartEnqueuedSpan();
-        ActivationQueue->Push(seat.Release());
-        ActivateTransactionWaiting++;
-        PlanTransactionActivation();
-        return;
+    if (mode == ETxMode::Execute && (ActiveTransaction || ActivateTransactionWaiting)) {
+        mode = ETxMode::Enqueue;
     }
 
-    ExecuteTransaction(seat, ctx);
+    switch (mode) {
+        case ETxMode::Execute:
+            ExecuteTransaction(seat);
+            return uniqId;
+
+        case ETxMode::Enqueue:
+        case ETxMode::LowPriority:
+            EnqueueActivation(seat, true);
+            return uniqId;
+    }
+
+    Y_FAIL("Unimplemented transaction mode");
 }
 
 void TExecutor::Execute(TAutoPtr<ITransaction> self, const TActorContext &ctx) {
-    DoExecute(self, true, ctx);
+    Y_UNUSED(ctx);
+    DoExecute(self, ETxMode::Execute);
 }
 
-void TExecutor::Enqueue(TAutoPtr<ITransaction> self, const TActorContext &ctx) {
-    DoExecute(self, false, ctx);
+ui64 TExecutor::Enqueue(TAutoPtr<ITransaction> self) {
+    return DoExecute(self, ETxMode::Enqueue);
 }
 
-void TExecutor::ExecuteTransaction(TAutoPtr<TSeat> seat, const TActorContext &ctx) {
+ui64 TExecutor::EnqueueLowPriority(TAutoPtr<ITransaction> self) {
+    return DoExecute(self, ETxMode::LowPriority);
+}
+
+bool TExecutor::CancelTransaction(ui64 id) {
+    auto it = Transactions.find(id);
+    if (it == Transactions.end()) {
+        return false;
+    }
+
+    TSeat* seat = it->second.get();
+    switch (seat->State) {
+        case ESeatState::None:
+            // Transaction is not paused in any way
+            Y_DEBUG_ABORT_UNLESS(false,
+                "Tablet %" PRIu64 " CancelTransaction(%" PRIu64 ") from inside transaction?",
+                TabletId(), id);
+            return false;
+
+        case ESeatState::Active:
+            ActivationQueue.Remove(seat);
+            Y_ABORT_UNLESS(ActivateTransactionWaiting > 0);
+            --ActivateTransactionWaiting;
+            break;
+
+        case ESeatState::ActiveLow:
+            ActivationLowQueue.Remove(seat);
+            Y_ABORT_UNLESS(ActivateLowTransactionWaiting > 0);
+            --ActivateLowTransactionWaiting;
+            break;
+
+        case ESeatState::Pending:
+            PendingQueue.Remove(seat);
+            Y_ABORT_UNLESS(Stats->TxPending > 0);
+            --Stats->TxPending;
+            break;
+
+        case ESeatState::Postponed:
+        case ESeatState::Waiting:
+            if (seat->Cancelled) {
+                return false;
+            }
+            // Cannot safely remove now, wait until later
+            seat->Cancelled = true;
+            return true;
+
+        default:
+            Y_DEBUG_ABORT_UNLESS(false,
+                "Tablet %" PRIu64 " CancelTransaction(% " PRIu64 ") for a finished transaction",
+                TabletId(), id);
+            return false;
+    }
+
+    seat->State = ESeatState::None;
+    FinishCancellation(seat);
+    return true;
+}
+
+void TExecutor::ExecuteTransaction(TSeat* seat) {
     TActiveTransactionZone activeTransaction(this);
     ++seat->Retries;
 
@@ -1762,7 +1884,7 @@ void TExecutor::ExecuteTransaction(TAutoPtr<TSeat> seat, const TActorContext &ct
     LWTRACK(TransactionExecuteBegin, seat->Self->Orbit, seat->UniqID);
 
     txc.StartExecutionSpan();
-    const bool done = seat->Self->Execute(txc, ctx.MakeFor(OwnerActorId));
+    const bool done = seat->Self->Execute(txc, OwnerCtx());
     txc.FinishExecutionSpan();
 
     LWTRACK(TransactionExecuteEnd, seat->Self->Orbit, seat->UniqID, done);
@@ -1826,18 +1948,21 @@ void TExecutor::ExecuteTransaction(TAutoPtr<TSeat> seat, const TActorContext &ct
 
         // It may not be safe to call Broken right now, call it later
         Send(SelfId(), new TEvPrivate::TEvBrokenTransaction());
+
+        // Make sure transaction is properly destroyed
+        RemoveTransaction(seat->UniqID);
     } else if (done) {
         Y_ABORT_UNLESS(!txc.IsRescheduled());
         Y_ABORT_UNLESS(!seat->RequestedMemory);
         seat->OnPersistent = std::move(prod.OnPersistent);
-        CommitTransactionLog(seat, env, prod.Change, cpuTimer, ctx);
+        CommitTransactionLog(RemoveTransaction(seat->UniqID), env, prod.Change, cpuTimer);
     } else {
         Y_ABORT_UNLESS(!seat->CapturedMemory);
         if (!PrivatePageCache->GetStats().CurrentCacheMisses && !seat->RequestedMemory && !txc.IsRescheduled()) {
             Y_Fail(NFmt::Do(*this) << " " << NFmt::Do(*seat) << " type "
                     << NFmt::Do(*seat->Self) << " postponed w/o demands");
         }
-        PostponeTransaction(seat, env, prod.Change, cpuTimer, ctx);
+        PostponeTransaction(seat, env, prod.Change, cpuTimer);
     }
     PrivatePageCache->ResetTouchesAndToLoad(false);
 
@@ -1859,14 +1984,14 @@ void TExecutor::UnpinTransactionPages(TSeat &seat) {
     Counters->Simple()[TExecutorCounters::CACHE_TOTAL_USED] = TransactionPagesMemory;
 }
 
-void TExecutor::ReleaseTxData(TSeat &seat, ui64 requested, const TActorContext &ctx)
+void TExecutor::ReleaseTxData(TSeat &seat, ui64 requested)
 {
     if (auto logl = Logger->Log(ELnLev::Debug))
         logl << NFmt::Do(*this) << " " << NFmt::Do(seat) << " release tx data";
 
     TTxMemoryProvider provider(seat.CurrentTxDataLimit - requested, seat.TaskId);
     static_cast<TTxMemoryProviderBase&>(provider).RequestMemory(requested);
-    seat.Self->ReleaseTxData(provider, ctx.MakeFor(OwnerActorId));
+    seat.Self->ReleaseTxData(provider, OwnerCtx());
 
     Counters->Cumulative()[TExecutorCounters::TX_DATA_RELEASES].Increment(1);
 
@@ -1876,9 +2001,9 @@ void TExecutor::ReleaseTxData(TSeat &seat, ui64 requested, const TActorContext &
     Memory->ReleaseTxData(seat);
 }
 
-void TExecutor::PostponeTransaction(TAutoPtr<TSeat> seat, TPageCollectionTxEnv &env,
+void TExecutor::PostponeTransaction(TSeat* seat, TPageCollectionTxEnv &env,
                                     TAutoPtr<NTable::TChange> change,
-                                    THPTimer &bookkeepingTimer, const TActorContext &ctx)
+                                    THPTimer &bookkeepingTimer)
 {
     TTxType txType = seat->Self->GetTxType();
 
@@ -1926,7 +2051,7 @@ void TExecutor::PostponeTransaction(TAutoPtr<TSeat> seat, TPageCollectionTxEnv &
         }
 
         seat->TerminationReason = ETerminationReason::MemoryLimitExceeded;
-        CommitTransactionLog(seat, env, change, bookkeepingTimer, ctx);
+        CommitTransactionLog(RemoveTransaction(seat->UniqID), env, change, bookkeepingTimer);
         return;
     } else if (totalMemory > seat->CurrentMemoryLimit) {
 
@@ -1950,13 +2075,11 @@ void TExecutor::PostponeTransaction(TAutoPtr<TSeat> seat, TPageCollectionTxEnv &
             LWTRACK(TransactionNeedMemory, seat->Self->Orbit, seat->UniqID);
             Memory->FreeStatic(*seat, 0);
             UnpinTransactionPages(*seat);
-            ReleaseTxData(*seat, requestedMemory, ctx);
+            ReleaseTxData(*seat, requestedMemory);
 
             Memory->RequestLimit(*seat, desired);
-
-            auto *transptr = seat.Release();
-            auto pairIt = PostponedTransactions.emplace(transptr, transptr);
-            Y_ABORT_UNLESS(pairIt.second);
+            seat->State = ESeatState::Postponed;
+            PostponedTransactions.PushBack(seat);
 
             // todo: counters
             return;
@@ -1966,16 +2089,13 @@ void TExecutor::PostponeTransaction(TAutoPtr<TSeat> seat, TPageCollectionTxEnv &
     // If memory was allocated and there is nothing to load
     // then tx may be re-activated.
     if (!PrivatePageCache->GetStats().CurrentCacheMisses) {
-        LWTRACK(TransactionEnqueued, seat->Self->Orbit, seat->UniqID);
-        seat->StartEnqueuedSpan();
-        ActivationQueue->Push(seat.Release());
-        ActivateTransactionWaiting++;
-        PlanTransactionActivation();
+        EnqueueActivation(seat, CanExecuteTransaction());
         return;
     }
 
     LWTRACK(TransactionPageFault, seat->Self->Orbit, seat->UniqID);
-    auto padHolder = MakeHolder<TTransactionWaitPad>(std::move(seat));
+    seat->State = ESeatState::Waiting;
+    auto padHolder = MakeHolder<TTransactionWaitPad>(seat);
     auto *const pad = padHolder.Get();
     TransactionWaitPads[pad] = std::move(padHolder);
 
@@ -2041,10 +2161,9 @@ void TExecutor::PostponeTransaction(TAutoPtr<TSeat> seat, TPageCollectionTxEnv &
     Counters->Simple()[TExecutorCounters::CACHE_TOTAL_USED] = TransactionPagesMemory;
 }
 
-void TExecutor::CommitTransactionLog(TAutoPtr<TSeat> seat, TPageCollectionTxEnv &env,
-                    TAutoPtr<NTable::TChange> change, THPTimer &bookkeepingTimer, const TActorContext &ctx) {
+void TExecutor::CommitTransactionLog(std::unique_ptr<TSeat> seat, TPageCollectionTxEnv &env,
+                    TAutoPtr<NTable::TChange> change, THPTimer &bookkeepingTimer) {
     const bool isReadOnly = !(change->HasAny() || env.HasChanges());
-    const bool isTerminated = seat->TerminationReason != ETerminationReason::None;
     const TTxType txType = seat->Self->GetTxType();
 
     size_t touchedBlocks = PrivatePageCache->GetStats().CurrentCacheHits;
@@ -2072,27 +2191,19 @@ void TExecutor::CommitTransactionLog(TAutoPtr<TSeat> seat, TPageCollectionTxEnv 
     const double currentBookkeepingTime = seat->CPUBookkeepingTime;
     const double currentExecTime = seat->CPUExecTime;
 
-    if (isTerminated) {
-        if (Stats->IsFollower()) {
-            --Stats->TxInFly;
-            Counters->Simple()[TExecutorCounters::DB_TX_IN_FLY] = Stats->TxInFly;
-            seat->Terminate(seat->TerminationReason, OwnerCtx());
-        } else if (LogicRedo->TerminateTransaction(seat, ctx, OwnerActorId)) {
-            --Stats->TxInFly;
-            Counters->Simple()[TExecutorCounters::DB_TX_IN_FLY] = Stats->TxInFly;
-        }
-    } else if (isReadOnly) {
+    if (isReadOnly) {
         if (Stats->IsFollower()) {
             // todo: extract completion counters from txloglogic
             --Stats->TxInFly;
             Counters->Simple()[TExecutorCounters::DB_TX_IN_FLY] = Stats->TxInFly;
-            CompleteRoTransaction(seat, OwnerCtx(), Counters.Get(), AppTxCounters);
-        } else if (LogicRedo->CommitROTransaction(seat, OwnerCtx())) {
+            CompleteRoTransaction(std::move(seat), OwnerCtx(), Counters.Get(), AppTxCounters);
+        } else if (LogicRedo->CommitROTransaction(std::move(seat), OwnerCtx())) {
             --Stats->TxInFly;
             Counters->Simple()[TExecutorCounters::DB_TX_IN_FLY] = Stats->TxInFly;
         }
     } else {
         Y_ABORT_UNLESS(!Stats->IsFollower());
+        Y_ABORT_UNLESS(!seat->IsTerminated(), "Read-write transactions cannot be terminated");
 
         const bool allowBatching = Scheme().Executor.AllowLogBatching;
         const bool force = !allowBatching
@@ -2106,7 +2217,7 @@ void TExecutor::CommitTransactionLog(TAutoPtr<TSeat> seat, TPageCollectionTxEnv 
             || env.LoanConfirmation
             || env.BorrowUpdates;
 
-        auto commitResult = LogicRedo->CommitRWTransaction(seat, *change, force);
+        auto commitResult = LogicRedo->CommitRWTransaction(std::move(seat), *change, force);
 
         Y_ABORT_UNLESS(!force || commitResult.Commit);
         auto *commit = commitResult.Commit.Get(); // could be nullptr
@@ -2534,7 +2645,7 @@ void TExecutor::CommitTransactionLog(TAutoPtr<TSeat> seat, TPageCollectionTxEnv 
                 delay = TDuration::MicroSeconds(LogFlushDelayOverrideUsec);
             }
             if (delay.MicroSeconds() == 0) {
-                ctx.Send(ctx.SelfID, new TEvents::TEvFlushLog());
+                Send(SelfId(), new TEvents::TEvFlushLog());
             } else {
                 Y_DEBUG_ABORT_UNLESS(delay < TDuration::Minutes(1));
                 delay = Min(delay, TDuration::Seconds(59));
@@ -2562,7 +2673,7 @@ void TExecutor::CommitTransactionLog(TAutoPtr<TSeat> seat, TPageCollectionTxEnv 
 
     if (ResourceMetrics) {
         ResourceMetrics->CPU.Increment(bookkeepingTimeuS + execTimeuS, Time->Now());
-        ResourceMetrics->TryUpdate(ctx);
+        ResourceMetrics->TryUpdate(SelfCtx());
     }
 
     MaybeRelaxRejectProbability();
@@ -2683,17 +2794,21 @@ void TExecutor::MakeLogSnapshot() {
 
 void TExecutor::Handle(TEvPrivate::TEvActivateExecution::TPtr &ev, const TActorContext &ctx) {
     Y_UNUSED(ev);
+    Y_UNUSED(ctx);
     Y_ABORT_UNLESS(ActivateTransactionInFlight > 0);
     ActivateTransactionInFlight--;
 
     if (!CanExecuteTransaction())
         return;
 
-    if (TAutoPtr<TSeat> seat = ActivationQueue->Pop()) {
+    if (ActivationQueue) {
+        TSeat* seat = ActivationQueue.PopFront();
+        Y_ABORT_UNLESS(seat->State == ESeatState::Active);
+        seat->State = ESeatState::None;
         Y_ABORT_UNLESS(ActivateTransactionWaiting > 0);
         ActivateTransactionWaiting--;
         seat->FinishEnqueuedSpan();
-        ExecuteTransaction(seat, ctx);
+        ExecuteTransaction(seat);
     } else {
         // N.B. it should actually never happen, since ActivationQueue size
         // is always exactly equal to ActivateTransactionWaiting and we never
@@ -2701,6 +2816,35 @@ void TExecutor::Handle(TEvPrivate::TEvActivateExecution::TPtr &ev, const TActorC
         // transactions, so when we handle this event we must have at least
         // one transaction in queue.
         Y_ABORT_UNLESS(ActivateTransactionWaiting == 0);
+    }
+}
+
+void TExecutor::Handle(TEvPrivate::TEvActivateLowExecution::TPtr &ev, const TActorContext &ctx) {
+    Y_UNUSED(ev);
+    Y_UNUSED(ctx);
+    Y_ABORT_UNLESS(ActivateLowTransactionInFlight > 0);
+    ActivateLowTransactionInFlight--;
+
+    if (!CanExecuteTransaction())
+        return;
+
+    if (ActivationLowQueue) {
+        TSeat* seat = ActivationLowQueue.PopFront();
+        Y_ABORT_UNLESS(seat->State == ESeatState::ActiveLow);
+        seat->State = ESeatState::None;
+        Y_ABORT_UNLESS(ActivateLowTransactionWaiting > 0);
+        ActivateLowTransactionWaiting--;
+        seat->FinishEnqueuedSpan();
+
+        // Activate the next transaction
+        if (ActivateLowTransactionWaiting > 0 && ActivateLowTransactionInFlight < 1) {
+            Send(SelfId(), new TEvPrivate::TEvActivateLowExecution());
+            ++ActivateLowTransactionInFlight;
+        }
+
+        ExecuteTransaction(seat);
+    } else {
+        Y_ABORT_UNLESS(ActivateLowTransactionWaiting == 0);
     }
 }
 
@@ -3028,16 +3172,18 @@ void TExecutor::Handle(TEvResourceBroker::TEvResourceAllocated::TPtr &ev) {
 void TExecutor::StartSeat(ui64 task, TResource *cookie_) noexcept
 {
     auto *cookie = CheckedCast<TMemory::TCookie*>(cookie_);
-    auto it = PostponedTransactions.find(cookie->Seat);
-    Y_ABORT_UNLESS(it != PostponedTransactions.end());
-    TAutoPtr<TSeat> seat = std::move(it->second);
-    PostponedTransactions.erase(it);
+    TSeat* seat = cookie->Seat;
+    Y_ABORT_UNLESS(seat->State == ESeatState::Postponed);
+    PostponedTransactions.Remove(seat);
+    seat->State = ESeatState::None;
     Memory->AcquiredMemory(*seat, task);
-    LWTRACK(TransactionEnqueued, seat->Self->Orbit, seat->UniqID);
-    seat->StartEnqueuedSpan();
-    ActivationQueue->Push(seat.Release());
-    ActivateTransactionWaiting++;
-    PlanTransactionActivation();
+
+    if (seat->Cancelled) {
+        FinishCancellation(seat);
+        return;
+    }
+
+    EnqueueActivation(seat, CanExecuteTransaction());
 }
 
 THolder<TScanSnapshot> TExecutor::PrepareScanSnapshot(ui32 table, const NTable::TCompactionParams *params, TRowVersion snapshot)
@@ -3957,6 +4103,7 @@ STFUNC(TExecutor::StateBoot) {
     switch (ev->GetTypeRewrite()) {
         // N.B. must work during follower promotion to leader
         HFunc(TEvPrivate::TEvActivateExecution, Handle);
+        HFunc(TEvPrivate::TEvActivateLowExecution, Handle);
         HFunc(TEvPrivate::TEvBrokenTransaction, Handle);
         HFunc(TEvents::TEvWakeup, Wakeup);
         hFunc(TEvResourceBroker::TEvResourceAllocated, Handle);
@@ -3968,6 +4115,7 @@ STFUNC(TExecutor::StateBoot) {
 STFUNC(TExecutor::StateWork) {
     switch (ev->GetTypeRewrite()) {
         HFunc(TEvPrivate::TEvActivateExecution, Handle);
+        HFunc(TEvPrivate::TEvActivateLowExecution, Handle);
         HFunc(TEvPrivate::TEvBrokenTransaction, Handle);
         HFunc(TEvPrivate::TEvActivateCompactionChanges, Handle);
         CFunc(TEvPrivate::EvUpdateCounters, UpdateCounters);
@@ -4000,6 +4148,7 @@ STFUNC(TExecutor::StateWork) {
 STFUNC(TExecutor::StateFollower) {
     switch (ev->GetTypeRewrite()) {
         HFunc(TEvPrivate::TEvActivateExecution, Handle);
+        HFunc(TEvPrivate::TEvActivateLowExecution, Handle);
         HFunc(TEvPrivate::TEvBrokenTransaction, Handle);
         CFunc(TEvPrivate::EvUpdateCounters, UpdateCounters);
         HFunc(TEvents::TEvWakeup, Wakeup);
@@ -4022,6 +4171,7 @@ STFUNC(TExecutor::StateFollowerBoot) {
     switch (ev->GetTypeRewrite()) {
         // N.B. must handle activities started before resync
         HFunc(TEvPrivate::TEvActivateExecution, Handle);
+        HFunc(TEvPrivate::TEvActivateLowExecution, Handle);
         HFunc(TEvPrivate::TEvBrokenTransaction, Handle);
         HFunc(TEvents::TEvWakeup, Wakeup);
         hFunc(TEvResourceBroker::TEvResourceAllocated, Handle);
@@ -4301,8 +4451,8 @@ TString TExecutor::CheckBorrowConsistency() {
     return BorrowLogic->DebugCheckBorrowConsistency(knownBundles);
 }
 
-TTransactionWaitPad::TTransactionWaitPad(THolder<TSeat> seat)
-    : Seat(std::move(seat))
+TTransactionWaitPad::TTransactionWaitPad(TSeat* seat)
+    : Seat(seat)
     , WaitingSpan(NWilson::TSpan(TWilsonTablet::TabletDetailed, Seat->GetTxTraceId(), "Tablet.Transaction.Wait"))
 {}
 

--- a/ydb/core/tablet_flat/flat_executor_ut.cpp
+++ b/ydb/core/tablet_flat/flat_executor_ut.cpp
@@ -497,11 +497,14 @@ class TTestFlatTablet : public TActor<TTestFlatTablet>, public TTabletExecutedFl
     }
 
     void Handle(NFake::TEvExecute::TPtr &ev, const TActorContext &ctx) {
-        for (auto& f : ev->Get()->Funcs) {
-            if (auto* tx = dynamic_cast<ITransactionWithExecutor*>(f.Get())) {
-                tx->Executor = Executor();
+        for (auto& tx : ev->Get()->Txs) {
+            if (auto* e = dynamic_cast<ITransactionWithExecutor*>(tx.Get())) {
+                e->Executor = Executor();
             }
-            Execute(f.Release(), ctx);
+            Execute(tx.Release(), ctx);
+        }
+        for (auto& lambda : ev->Get()->Lambdas) {
+            std::move(lambda)(Executor(), ctx);
         }
     }
 
@@ -7129,6 +7132,216 @@ Y_UNIT_TEST_SUITE(TFlatTableExecutor_Gc) {
         env->SimulateSleep(TDuration::MilliSeconds(10));
         UNIT_ASSERT_C(gcBarriers.size() >= 2, gcBarriers.size());
         UNIT_ASSERT_C(gcBarriers[0] <= gcBarriers[1], "unexpected barrier decrease");
+    }
+}
+
+Y_UNIT_TEST_SUITE(TFlatTableExecutor_LowPriorityTxs) {
+    struct TTxState {
+        int Executed = 0;
+        int Completed = 0;
+        int Destroyed = 0;
+    };
+
+    struct TSimpleTx : public ITransaction {
+        TTxState& State;
+
+        TSimpleTx(TTxState& state)
+            : State(state)
+        {}
+
+        bool Execute(TTransactionContext&, const TActorContext&) override {
+            ++State.Executed;
+            return true;
+        }
+
+        void Complete(const TActorContext&) override {
+            ++State.Completed;
+        }
+
+        ~TSimpleTx() {
+            ++State.Destroyed;
+        }
+    };
+
+    struct TAllocatingTx : public ITransaction {
+        TTxState& State;
+
+        TAllocatingTx(TTxState& state)
+            : State(state)
+        {}
+
+        bool Execute(TTransactionContext& txc, const TActorContext&) override {
+            ++State.Executed;
+            // Keep requesting 2GB more...
+            txc.RequestMemory(2ULL * 1024 * 1024 * 1024);
+            return false;
+        }
+
+        void Complete(const TActorContext&) override {
+            ++State.Completed;
+        }
+
+        ~TAllocatingTx() {
+            ++State.Destroyed;
+        }
+    };
+
+    Y_UNIT_TEST(TestEnqueueCancel) {
+        TMyEnvBase env;
+
+        env.FireDummyTablet();
+
+        TTxState tx1, tx2, tx3;
+        ui64 id1 = 0;
+        ui64 id2 = 0;
+        ui64 id3 = 0;
+        env.SendSync(new NFake::TEvExecute{[&](auto*, const auto& ctx) {
+            ctx.Send(ctx.SelfID, new NFake::TEvExecute{[&](auto* x, const auto& ctx) {
+                id1 = x->EnqueueLowPriority(new TSimpleTx(tx1));
+                Y_ABORT_UNLESS(tx1.Executed == 0);
+                id2 = x->Enqueue(new TSimpleTx(tx2));
+                Y_ABORT_UNLESS(tx2.Executed == 0);
+                id3 = x->Enqueue(new TSimpleTx(tx3));
+                Y_ABORT_UNLESS(tx3.Executed == 0);
+                // Validate this new mailbox event is handled after tx3 is executed and destroyed, i.e. it's high priority
+                ctx.Send(ctx.SelfID, new NFake::TEvExecute{[&](auto*, const auto&) {
+                    Y_ABORT_UNLESS(tx3.Executed == 1);
+                    Y_ABORT_UNLESS(tx3.Destroyed == 1);
+                }});
+            }});
+            ctx.Send(ctx.SelfID, new NFake::TEvExecute{[&](auto* x, const auto&) {
+                Y_ABORT_UNLESS(id1 != 0);
+                Y_ABORT_UNLESS(tx1.Executed == 0);
+                Y_ABORT_UNLESS(tx1.Destroyed == 0);
+                bool ok = x->CancelTransaction(id1);
+                Y_ABORT_UNLESS(ok);
+                Y_ABORT_UNLESS(tx1.Destroyed == 1);
+            }});
+            ctx.Send(ctx.SelfID, new NFake::TEvExecute{[&](auto* x, const auto&) {
+                Y_ABORT_UNLESS(id2 != 0);
+                Y_ABORT_UNLESS(tx2.Executed == 0);
+                Y_ABORT_UNLESS(tx2.Destroyed == 0);
+                bool ok = x->CancelTransaction(id2);
+                Y_ABORT_UNLESS(ok);
+                Y_ABORT_UNLESS(tx2.Destroyed == 1);
+            }});
+            ctx.Send(ctx.SelfID, new NFake::TEvExecute{[&](auto*, const auto& ctx) {
+                ctx.Send(ctx.SelfID, new NFake::TEvExecute{[&](auto*, const auto& ctx) {
+                    ctx.Send(ctx.SelfID, new NFake::TEvReturn);
+                }});
+            }});
+        }});
+    }
+
+    Y_UNIT_TEST(TestLowPriority) {
+        TMyEnvBase env;
+
+        env.FireDummyTablet();
+
+        TTxState tx1, tx2;
+        ui64 id1 = 0;
+        ui64 id2 = 0;
+        env.SendSync(new NFake::TEvExecute{[&](auto*, const auto& ctx) {
+            ctx.Send(ctx.SelfID, new NFake::TEvExecute{[&](auto* x, const auto& ctx) {
+                id1 = x->EnqueueLowPriority(new TSimpleTx(tx1));
+                Y_ABORT_UNLESS(tx1.Executed == 0);
+                id2 = x->EnqueueLowPriority(new TSimpleTx(tx2));
+                Y_ABORT_UNLESS(tx2.Executed == 0);
+                ctx.Send(ctx.SelfID, new NFake::TEvExecute{[&](auto*, const auto& ctx) {
+                    Y_ABORT_UNLESS(tx1.Executed == 1);
+                    Y_ABORT_UNLESS(tx1.Completed == 1);
+                    Y_ABORT_UNLESS(tx1.Destroyed == 1);
+                    Y_ABORT_UNLESS(tx2.Executed == 0);
+                    Y_ABORT_UNLESS(tx2.Destroyed == 0);
+                    ctx.Send(ctx.SelfID, new NFake::TEvExecute{[&](auto*, const auto& ctx) {
+                        Y_ABORT_UNLESS(tx2.Executed == 1);
+                        Y_ABORT_UNLESS(tx2.Completed == 1);
+                        Y_ABORT_UNLESS(tx2.Destroyed == 1);
+                        ctx.Send(ctx.SelfID, new NFake::TEvReturn);
+                    }});
+                }});
+            }});
+        }});
+    }
+
+    Y_UNIT_TEST(TestLowPriorityCancel) {
+        TMyEnvBase env;
+
+        env.FireDummyTablet();
+
+        TTxState tx1, tx2;
+        ui64 id1 = 0;
+        ui64 id2 = 0;
+        env.SendSync(new NFake::TEvExecute{[&](auto*, const auto& ctx) {
+            ctx.Send(ctx.SelfID, new NFake::TEvExecute{[&](auto* x, const auto& ctx) {
+                id1 = x->EnqueueLowPriority(new TSimpleTx(tx1));
+                Y_ABORT_UNLESS(tx1.Executed == 0);
+                id2 = x->EnqueueLowPriority(new TSimpleTx(tx2));
+                Y_ABORT_UNLESS(tx2.Executed == 0);
+                // The next new mailbox event is supposed to execute after tx1 is executed, but before tx2
+                ctx.Send(ctx.SelfID, new NFake::TEvExecute{[&](auto* x, const auto& ctx) {
+                    Y_ABORT_UNLESS(tx1.Executed == 1);
+                    Y_ABORT_UNLESS(tx1.Destroyed == 1);
+                    bool ok1 = x->CancelTransaction(id1);
+                    Y_ABORT_UNLESS(!ok1); // cannot cancel executed transaction
+                    Y_ABORT_UNLESS(tx2.Executed == 0);
+                    Y_ABORT_UNLESS(tx2.Destroyed == 0);
+                    bool ok2 = x->CancelTransaction(id2);
+                    Y_ABORT_UNLESS(ok2);
+                    Y_ABORT_UNLESS(tx2.Executed == 0);
+                    Y_ABORT_UNLESS(tx2.Destroyed == 1);
+                    ctx.Send(ctx.SelfID, new NFake::TEvExecute{[&](auto*, const auto& ctx) {
+                        ctx.Send(ctx.SelfID, new NFake::TEvReturn);
+                    }});
+                }});
+            }});
+            ctx.Send(ctx.SelfID, new NFake::TEvExecute{[&](auto*, const auto&) {
+                Y_ABORT_UNLESS(id1 != 0);
+                Y_ABORT_UNLESS(tx1.Executed == 0);
+                Y_ABORT_UNLESS(tx1.Destroyed == 0);
+            }});
+            ctx.Send(ctx.SelfID, new NFake::TEvExecute{[&](auto*, const auto&) {
+                Y_ABORT_UNLESS(id2 != 0);
+                Y_ABORT_UNLESS(tx2.Executed == 0);
+                Y_ABORT_UNLESS(tx2.Destroyed == 0);
+            }});
+        }});
+    }
+
+    Y_UNIT_TEST(TestLowPriorityAllocatingCancel) {
+        TMyEnvBase env;
+
+        env.FireDummyTablet();
+
+        TTxState tx1, tx2;
+        ui64 id1 = 0;
+        ui64 id2 = 0;
+        env.SendSync(new NFake::TEvExecute{[&](auto*, const auto& ctx) {
+            ctx.Send(ctx.SelfID, new NFake::TEvExecute{[&](auto* x, const auto& ctx) {
+                id1 = x->EnqueueLowPriority(new TAllocatingTx(tx1));
+                id2 = x->EnqueueLowPriority(new TSimpleTx(tx2));
+                ctx.Send(ctx.SelfID, new NFake::TEvExecute{[&](auto* x, const auto& ctx) {
+                    Y_ABORT_UNLESS(tx1.Executed == 1);
+                    Y_ABORT_UNLESS(tx1.Destroyed == 0);
+                    bool ok = x->CancelTransaction(id1);
+                    Y_ABORT_UNLESS(ok);
+                    // Transaction is requesting more memory and cannot be destroyed
+                    Y_ABORT_UNLESS(tx1.Destroyed == 0);
+                    ctx.Send(ctx.SelfID, new NFake::TEvExecute{[&](auto*, const auto&) {
+                        Y_ABORT_UNLESS(tx2.Executed == 1);
+                        Y_ABORT_UNLESS(tx2.Completed == 1);
+                        Y_ABORT_UNLESS(tx2.Destroyed == 1);
+                    }});
+                    ctx.Schedule(TDuration::MilliSeconds(1), new NFake::TEvExecute{[&](auto*, const auto& ctx) {
+                        // We should observe tx1 destroyed eventually, not executing again
+                        Y_ABORT_UNLESS(tx1.Executed == 1);
+                        Y_ABORT_UNLESS(tx1.Completed == 0);
+                        Y_ABORT_UNLESS(tx1.Destroyed == 1);
+                        ctx.Send(ctx.SelfID, new NFake::TEvReturn);
+                    }});
+                }});
+            }});
+        }});
     }
 }
 

--- a/ydb/core/tablet_flat/tablet_flat_executed.cpp
+++ b/ydb/core/tablet_flat/tablet_flat_executed.cpp
@@ -39,9 +39,24 @@ void TTabletExecutedFlat::Execute(TAutoPtr<ITransaction> transaction) {
         static_cast<TExecutor*>(Executor())->Execute(transaction, ExecutorCtx(*TlsActivationContext));
 }
 
-void TTabletExecutedFlat::EnqueueExecute(TAutoPtr<ITransaction> transaction) {
-    if (transaction)
-        static_cast<TExecutor*>(Executor())->Enqueue(transaction, ExecutorCtx(*TlsActivationContext));
+ui64 TTabletExecutedFlat::Enqueue(TAutoPtr<ITransaction> transaction) {
+    if (transaction) {
+        return static_cast<TExecutor*>(Executor())->Enqueue(transaction);
+    } else {
+        return 0;
+    }
+}
+
+ui64 TTabletExecutedFlat::EnqueueExecute(TAutoPtr<ITransaction> transaction) {
+    return Enqueue(transaction);
+}
+
+ui64 TTabletExecutedFlat::EnqueueLowPriority(TAutoPtr<ITransaction> transaction) {
+    if (transaction) {
+        return static_cast<TExecutor*>(Executor())->EnqueueLowPriority(transaction);
+    } else {
+        return 0;
+    }
 }
 
 const NTable::TScheme& TTabletExecutedFlat::Scheme() const noexcept {

--- a/ydb/core/tablet_flat/tablet_flat_executed.h
+++ b/ydb/core/tablet_flat/tablet_flat_executed.h
@@ -26,7 +26,9 @@ protected:
 
     void Execute(TAutoPtr<ITransaction> transaction, const TActorContext &ctx);
     void Execute(TAutoPtr<ITransaction> transaction);
-    void EnqueueExecute(TAutoPtr<ITransaction> transaction);
+    ui64 Enqueue(TAutoPtr<ITransaction> transaction);
+    ui64 EnqueueExecute(TAutoPtr<ITransaction> transaction);
+    ui64 EnqueueLowPriority(TAutoPtr<ITransaction> transaction);
 
     const NTable::TScheme& Scheme() const noexcept;
 

--- a/ydb/core/tablet_flat/tablet_flat_executor.h
+++ b/ydb/core/tablet_flat/tablet_flat_executor.h
@@ -565,7 +565,26 @@ namespace NFlatExecutorSetup {
         virtual void FollowerGcApplied(ui32 step, TDuration followerSyncDelay) = 0;
 
         virtual void Execute(TAutoPtr<ITransaction> transaction, const TActorContext &ctx) = 0;
-        virtual void Enqueue(TAutoPtr<ITransaction> transaction, const TActorContext &ctx) = 0;
+
+        /**
+         * Enqueue a transaction for execution
+         * Returns the unique id that may be used for cancellation.
+         */
+        virtual ui64 Enqueue(TAutoPtr<ITransaction> transaction) = 0;
+
+        /**
+         * Enqueue a transaction that is low priority with respect to other
+         * mailbox events. Every transaction in turn is scheduled at the end of
+         * the current mailbox, which allows actors to handle possible cancellation
+         * before each transaction's execution.
+         * Returns the unique id that may be used for cancellation.
+         */
+        virtual ui64 EnqueueLowPriority(TAutoPtr<ITransaction> transaction) = 0;
+
+        /**
+         * Cancel a previously enqueued transaction with the specified id.
+         */
+        virtual bool CancelTransaction(ui64 id) = 0;
 
         virtual void ConfirmReadOnlyLease(TMonotonic at) = 0;
         virtual void ConfirmReadOnlyLease(TMonotonic at, std::function<void()> callback) = 0;

--- a/ydb/core/tablet_flat/test/libs/exec/dummy.h
+++ b/ydb/core/tablet_flat/test/libs/exec/dummy.h
@@ -48,8 +48,11 @@ namespace NFake {
             if (auto *ev = eh->CastAsLocal<NFake::TEvExecute>()) {
                 Y_ABORT_UNLESS(State == EState::Work, "Cannot handle TX now");
 
-                for (auto& f : ev->Funcs) {
-                    Execute(f.Release(), this->ActorContext());
+                for (auto& tx : ev->Txs) {
+                    Execute(tx.Release(), this->ActorContext());
+                }
+                for (auto& lambda : ev->Lambdas) {
+                    std::move(lambda)(Executor(), this->ActorContext());
                 }
             } else if (auto *ev = eh->CastAsLocal<NFake::TEvCompact>()) {
                 Y_ABORT_UNLESS(State == EState::Work, "Cannot handle compaction now");

--- a/ydb/core/tx/datashard/conflicts_cache.cpp
+++ b/ydb/core/tx/datashard/conflicts_cache.cpp
@@ -352,7 +352,7 @@ void TConflictsCache::RegisterDistributedWrites(ui64 txId, TPendingWrites&& writ
 
     if (!writes.empty()) {
         PendingWrites[txId] = std::move(writes);
-        Self->EnqueueExecute(new TTxFindWriteConflicts(Self, txId));
+        Self->Enqueue(new TTxFindWriteConflicts(Self, txId));
     }
 }
 

--- a/ydb/core/tx/datashard/datashard_change_receiving.cpp
+++ b/ydb/core/tx/datashard/datashard_change_receiving.cpp
@@ -450,7 +450,7 @@ void TDataShard::Handle(TEvPrivate::TEvChangeExchangeExecuteHandshakes::TPtr&, c
 void TDataShard::RunChangeExchangeHandshakeTx() {
     if (!ChangeExchangeHandshakeTxScheduled && !PendingChangeExchangeHandshakes.empty()) {
         ChangeExchangeHandshakeTxScheduled = true;
-        EnqueueExecute(new TTxChangeExchangeHandshake(this));
+        Enqueue(new TTxChangeExchangeHandshake(this));
     }
 }
 

--- a/ydb/core/tx/datashard/datashard_impl.h
+++ b/ydb/core/tx/datashard/datashard_impl.h
@@ -3087,6 +3087,8 @@ protected:
         StateInitImpl(ev, SelfId());
     }
 
+    using TTabletExecutedFlat::Enqueue;
+
     void Enqueue(STFUNC_SIG) override {
         ALOG_WARN(NKikimrServices::TX_DATASHARD, "TDataShard::StateInit unhandled event type: " << ev->GetTypeRewrite()
                            << " event: " << ev->ToString());

--- a/ydb/core/tx/datashard/volatile_tx.cpp
+++ b/ydb/core/tx/datashard/volatile_tx.cpp
@@ -1059,12 +1059,12 @@ namespace NKikimr::NDataShard {
 
     void TVolatileTxManager::ScheduleCommitTx(TVolatileTxInfo* info) {
         Y_DEBUG_ABORT_UNLESS(info && info->State == EVolatileTxState::Committed);
-        Self->EnqueueExecute(new TDataShard::TTxVolatileTxCommit(Self, info));
+        Self->Enqueue(new TDataShard::TTxVolatileTxCommit(Self, info));
     }
 
     void TVolatileTxManager::ScheduleAbortTx(TVolatileTxInfo* info) {
         Y_DEBUG_ABORT_UNLESS(info && info->State == EVolatileTxState::Aborting);
-        Self->EnqueueExecute(new TDataShard::TTxVolatileTxAbort(Self, info));
+        Self->Enqueue(new TDataShard::TTxVolatileTxAbort(Self, info));
     }
 
     bool TVolatileTxManager::RemoveFromCommitOrder(TVolatileTxInfo* info) {


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

...

### Changelog category <!-- remove all except one -->

* Not for changelog (changelog entry is not required)

### Description for reviewers <!-- (optional) description for those who read this PR -->

Related to #14936.

Support for low-priority cancellable transactions in LocalDB, which will be used to implement better datashard reads cancellation.