### PR TITLE
Removed alias stripping from CBO

### DIFF
--- a/ydb/library/yql/dq/opt/dq_opt_join_hypergraph.h
+++ b/ydb/library/yql/dq/opt/dq_opt_join_hypergraph.h
@@ -49,21 +49,6 @@ public:
             , IsReversed(false)
         {
             Y_ASSERT(LeftJoinKeys.size() == RightJoinKeys.size());
-            RemoveAttributeAliases();
-        }
-
-        void RemoveAttributeAliases() {
-            for (auto& leftKey : LeftJoinKeys) {
-                if (auto idx = leftKey.AttributeName.find('.'); idx != TString::npos) {
-                    leftKey.AttributeName = leftKey.AttributeName.substr(idx + 1);
-                }
-            }
-
-            for (auto& rightKey : RightJoinKeys) {
-                if (auto idx = rightKey.AttributeName.find('.'); idx != TString::npos) {
-                    rightKey.AttributeName = rightKey.AttributeName.substr(idx + 1);
-                }
-            }
         }
 
         inline bool IsSimple() const {


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

Cost-based optimizer was stripping aliases from column names, but turns out EquiJoin should not have aliases in the first place, but column names actually may contain '.'

https://github.com/ydb-platform/ydb/issues/15372

### Changelog category <!-- remove all except one -->

* Bugfix 


### Description for reviewers <!-- (optional) description for those who read this PR -->

...
