### PR TITLE
security: fix query service for alter-login and domain_login_only

### DIFF
--- a/ydb/core/kqp/executer_actor/kqp_scheme_executer.cpp
+++ b/ydb/core/kqp/executer_actor/kqp_scheme_executer.cpp
@@ -179,12 +179,14 @@ public:
     }
 
     TString GetDatabaseForLoginOperation() const {
-        const auto domainLoginOnly = AppData()->AuthConfig.GetDomainLoginOnly();
-        const auto domain = AppData()->DomainsInfo ? AppData()->DomainsInfo->GetDomain() : nullptr;
-        const auto domainName = domain ? domain->Name : "";
-        TString database;
-        return NSchemeHelpers::SetDatabaseForLoginOperation(database, domainLoginOnly, domainName, Database)
-            ? database : Database;
+        const bool domainLoginOnly = AppData()->AuthConfig.GetDomainLoginOnly();
+        TMaybe<TString> domainName;
+        if (domainLoginOnly && AppData()->DomainsInfo) {
+            domainName = AppData()->DomainsInfo->GetDomain()->Name;
+        }
+        TString result;
+        return NSchemeHelpers::SetDatabaseForLoginOperation(result, domainLoginOnly, domainName, Database)
+            ? result : Database;
     }
 
     void MakeSchemeOperationRequest() {


### PR DESCRIPTION
Fix database selection in kqp_scheme_executor for AlterLogin operations when domain_login_only=false.

Fix after #13969.