### PR TITLE
Reuse S3 locators to prevent false trash accumulation

### DIFF
--- a/ydb/core/blob_depot/agent/agent_impl.h
+++ b/ydb/core/blob_depot/agent/agent_impl.h
@@ -194,6 +194,7 @@ namespace NKikimr::NBlobDepot {
         TActorId PipeId;
         TActorId PipeServerId;
         bool IsConnected = false;
+        ui64 ConnectionInstance = 0;
 
         NMonitoring::TDynamicCounterPtr AgentCounters;
 

--- a/ydb/core/blob_depot/agent/comm.cpp
+++ b/ydb/core/blob_depot/agent/comm.cpp
@@ -155,6 +155,8 @@ namespace NKikimr::NBlobDepot {
     }
 
     void TBlobDepotAgent::OnDisconnect() {
+        ++ConnectionInstance;
+
         while (!TabletRequestInFlight.empty()) {
             auto node = TabletRequestInFlight.extract(TabletRequestInFlight.begin());
             auto& requestInFlight = node.value();

--- a/ydb/core/blob_depot/op_commit_blob_seq.cpp
+++ b/ydb/core/blob_depot/op_commit_blob_seq.cpp
@@ -75,13 +75,8 @@ namespace NKikimr::NBlobDepot {
                         if (item.HasS3Locator()) {
                             const auto& locator = TS3Locator::FromProto(item.GetS3Locator());
                             const size_t numErased = agent.S3WritesInFlight.erase(locator);
-                            if (locator.Generation < generation) {
-                                Y_ABORT_UNLESS(!numErased);
-                                Self->Data->AddToS3Trash(locator, txc, this);
-                            } else {
-                                Y_ABORT_UNLESS(numErased == 1);
-                                Self->S3Manager->AddTrashToCollect(locator);
-                            }
+                            Y_ABORT_UNLESS(numErased);
+                            Self->S3Manager->AddTrashToCollect(locator);
                         }
                     };
 
@@ -244,11 +239,10 @@ namespace NKikimr::NBlobDepot {
         }
 
         for (const auto& item : record.GetS3Locators()) {
-            if (const auto& locator = TS3Locator::FromProto(item); locator.Generation == generation) {
-                const size_t numErased = agent.S3WritesInFlight.erase(locator);
-                Y_ABORT_UNLESS(numErased == 1);
-                S3Manager->AddTrashToCollect(locator);
-            }
+            const auto& locator = TS3Locator::FromProto(item);
+            const size_t numErased = agent.S3WritesInFlight.erase(locator);
+            Y_ABORT_UNLESS(numErased == 1);
+            S3Manager->AddTrashToCollect(locator);
         }
     }
 

--- a/ydb/core/blob_depot/types.h
+++ b/ydb/core/blob_depot/types.h
@@ -153,7 +153,7 @@ namespace NKikimr::NBlobDepot {
         }
 
         TString MakeObjectName(const TString& basePath) const {
-            const size_t hash = THash()(*this);
+            const size_t hash = MultiHash(Generation, KeyId);
             const size_t a = hash % 36;
             const size_t b = hash / 36 % 36;
             static const char vec[] = "0123456789abcdefghijklmnopqrstuvwxyz";


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

Reuse S3 locators to prevent false trash accumulation

### Changelog category <!-- remove all except one -->

* Not for changelog (changelog entry is not required)

### Description for reviewers <!-- (optional) description for those who read this PR -->

S3 locators are now reused, as they are not immutable unlike blobs, but they need explicit collection.
