### PR TITLE
Correct ScanActor termination

### DIFF
--- a/ydb/core/kqp/compute_actor/kqp_scan_compute_actor.h
+++ b/ydb/core/kqp/compute_actor/kqp_scan_compute_actor.h
@@ -127,7 +127,7 @@ public:
 
     void PollSources(ui64 prevFreeSpace);
 
-    void PassAway() override {
+    void DoTerminateImpl() override {
         if (TaskRunner) {
             if (TaskRunner->IsAllocatorAttached()) {
                 ComputeCtx.Clear();
@@ -135,9 +135,10 @@ public:
                 auto guard = TaskRunner->BindAllocator(TBase::GetMkqlMemoryLimit());
                 ComputeCtx.Clear();
             }
+            ScanData = nullptr;
         }
 
-        TBase::PassAway();
+        TBase::DoTerminateImpl();
     }
 
     void TerminateSources(const NYql::TIssues& issues, bool success) override {

--- a/ydb/core/kqp/compute_actor/kqp_scan_compute_actor.h
+++ b/ydb/core/kqp/compute_actor/kqp_scan_compute_actor.h
@@ -87,6 +87,7 @@ public:
             TBase::OnMemoryLimitExceptionHandler();
         } catch (const yexception& e) {
             InternalError(NYql::NDqProto::StatusIds::INTERNAL_ERROR, NYql::TIssuesIds::DEFAULT_ERROR, e.what());
+            FreeComputeCtxData();
         }
 
         TBase::ReportEventElapsedTime();
@@ -128,6 +129,11 @@ public:
     void PollSources(ui64 prevFreeSpace);
 
     void DoTerminateImpl() override {
+        FreeComputeCtxData();
+        TBase::DoTerminateImpl();
+    }
+
+    void FreeComputeCtxData() {
         if (TaskRunner) {
             if (TaskRunner->IsAllocatorAttached()) {
                 ComputeCtx.Clear();
@@ -137,8 +143,6 @@ public:
             }
             ScanData = nullptr;
         }
-
-        TBase::DoTerminateImpl();
     }
 
     void TerminateSources(const NYql::TIssues& issues, bool success) override {


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

...

### Changelog category <!-- remove all except one -->

* New feature
* Experimental feature
* Improvement
* Performance improvement
* User Interface
* Bugfix 
* Backward incompatible change
* Documentation (changelog entry is not required)
* Not for changelog (changelog entry is not required)

### Description for reviewers <!-- (optional) description for those who read this PR -->

ComputeActor descendents should NOT override PassAway for resource freeing and use DoTerminateImpl instead
#15393 