### PR TITLE
DataShard: prioritize cancellation processing for reads

### DIFF
--- a/ydb/core/tablet_flat/flat_executor.cpp
+++ b/ydb/core/tablet_flat/flat_executor.cpp
@@ -224,10 +224,10 @@ void TExecutor::RecreatePageCollectionsCache() noexcept
 
     if (TransactionWaitPads) {
         for (auto &xpair : TransactionWaitPads) {
+            xpair.second->WaitingSpan.EndOk();
             TSeat* seat = xpair.second->Seat;
             Y_ABORT_UNLESS(seat->State == ESeatState::Waiting);
             seat->State = ESeatState::None;
-            xpair.second->WaitingSpan.EndOk();
 
             if (seat->Cancelled) {
                 FinishCancellation(seat, false);
@@ -627,11 +627,11 @@ void TExecutor::ActivateWaitingTransactions(TPrivatePageCache::TPage::TWaitQueue
         bool cancelled = false;
         while (TPrivatePageCacheWaitPad *waitPad = waitPadsQueue->Pop()) {
             if (auto it = TransactionWaitPads.find(waitPad); it != TransactionWaitPads.end()) {
+                it->second->WaitingSpan.EndOk();
                 TSeat* seat = it->second->Seat;
                 Y_ABORT_UNLESS(seat->State == ESeatState::Waiting);
                 seat->State = ESeatState::None;
-                seat->WaitingSpan.EndOk();
-                TransactionWaitPads.erase(waitPad);
+                TransactionWaitPads.erase(it);
                 if (seat->Cancelled) {
                     FinishCancellation(seat, false);
                     cancelled = true;

--- a/ydb/core/tx/datashard/datashard_ut_trace.cpp
+++ b/ydb/core/tx/datashard/datashard_ut_trace.cpp
@@ -359,6 +359,7 @@ Y_UNIT_TEST_SUITE(TDataShardTrace) {
                         Repeat(
                             ExpectedSpan("Datashard.Read",
                                 ExpectedSpan("Tablet.Transaction",
+                                    ExpectedSpan("Tablet.Transaction.Enqueued"),
                                     ExpectedSpan("Tablet.Transaction.Execute",
                                         Repeat("Datashard.Unit", 3)),
                                     // No extra page fault with btree index (root is in meta)
@@ -443,6 +444,7 @@ Y_UNIT_TEST_SUITE(TDataShardTrace) {
                         Repeat(
                             ExpectedSpan("Datashard.Read",
                                 ExpectedSpan("Tablet.Transaction",
+                                    ExpectedSpan("Tablet.Transaction.Enqueued"),
                                     ExpectedSpan("Tablet.Transaction.Execute",
                                         Repeat("Datashard.Unit", 4)),
                                     "Tablet.Transaction.Complete"),

--- a/ydb/core/tx/datashard/read_iterator.h
+++ b/ydb/core/tx/datashard/read_iterator.h
@@ -218,6 +218,9 @@ public:
     TActorId ScanActorId;
     // temporary storage for forwarded events until scan has started
     std::vector<std::unique_ptr<IEventHandle>> ScanPendingEvents;
+
+    // May be used to cancel enqueued transactions
+    ui64 EnqueuedLocalTxId = 0;
 };
 
 using TReadIteratorsMap = THashMap<TReadIteratorId, TReadIteratorState, TReadIteratorId::THash>;


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

...

### Changelog category <!-- remove all except one -->

* Not for changelog (changelog entry is not required)

### Description for reviewers <!-- (optional) description for those who read this PR -->

When datashard has a lot of simple incoming read requests the latency may grow and read requests are eventually cancelled by latency sensitive clients. However, this cancellation had no chance of being processed in many cases, which caused a metastable state where datashard has a long request queue in the mailbox, processing cancelled requests. Use low-priority transactions when starting reads, which makes read cancellation higher priority.

Fixes #14936.