### PR TITLE
DataShard and SchemeShard: handle borrowed parts in data erasure

### DIFF
--- a/ydb/core/protos/tx_datashard.proto
+++ b/ydb/core/protos/tx_datashard.proto
@@ -2329,7 +2329,8 @@ message TEvForceDataCleanup {
 message TEvForceDataCleanupResult {
     enum EStatus {
         OK = 0;
-        FAILED = 1;
+        WRONG_SHARD_STATE = 1;
+        BORROWED = 2;
     };
     optional uint64 DataCleanupGeneration = 1; // from corresponding request (or greater)
     optional uint64 TabletId = 2;

--- a/ydb/core/protos/tx_datashard.proto
+++ b/ydb/core/protos/tx_datashard.proto
@@ -2328,9 +2328,10 @@ message TEvForceDataCleanup {
 // Intermediate requests and corresponding TEvForceDataCleanupResult's may be skipped.
 message TEvForceDataCleanupResult {
     enum EStatus {
-        OK = 0;
-        WRONG_SHARD_STATE = 1;
-        BORROWED = 2;
+        UNKNOWN = 0;
+        OK = 1;
+        WRONG_SHARD_STATE = 2;
+        BORROWED = 3;
     };
     optional uint64 DataCleanupGeneration = 1; // from corresponding request (or greater)
     optional uint64 TabletId = 2;

--- a/ydb/core/testlib/storage_helpers.cpp
+++ b/ydb/core/testlib/storage_helpers.cpp
@@ -1,0 +1,28 @@
+#include "storage_helpers.h"
+
+#include <ydb/core/blobstorage/dsproxy/mock/model.h>
+
+namespace NKikimr {
+    int CountBlobsWithSubstring(ui64 tabletId, const TVector<TIntrusivePtr<NFake::TProxyDS>>& proxyDSs, const TString& substring) {
+        int res = 0;
+        for (const auto& proxyDS : proxyDSs) {
+            for (const auto& [id, blob] : proxyDS->AllMyBlobs()) {
+                if (id.TabletID() == tabletId && !blob.DoNotKeep && blob.Buffer.ConvertToString().Contains(substring)) {
+                    ++res;
+                }
+            }
+        }
+        return res;
+    }
+
+    bool BlobStorageContains(const TVector<TIntrusivePtr<NFake::TProxyDS>>& proxyDSs, const TString& value) {
+        for (const auto& proxyDS : proxyDSs) {
+            for (const auto& [id, blob] : proxyDS->AllMyBlobs()) {
+                if (!blob.DoNotKeep && blob.Buffer.ConvertToString().Contains(value)) {
+                    return true;
+                }
+            }
+        }
+        return false;
+    }
+} // namespace NKikimr

--- a/ydb/core/testlib/storage_helpers.h
+++ b/ydb/core/testlib/storage_helpers.h
@@ -1,0 +1,8 @@
+#pragma once
+
+#include <ydb/core/blobstorage/dsproxy/mock/dsproxy_mock.h>
+
+namespace NKikimr {
+    int CountBlobsWithSubstring(ui64 tabletId, const TVector<TIntrusivePtr<NFake::TProxyDS>>& proxyDSs, const TString& substring);
+    bool BlobStorageContains(const TVector<TIntrusivePtr<NFake::TProxyDS>>& proxyDSs, const TString& value);
+} // namespace NKikimr

--- a/ydb/core/testlib/test_client.h
+++ b/ydb/core/testlib/test_client.h
@@ -109,7 +109,6 @@ namespace Tests {
         using TControls = NKikimrConfig::TImmediateControlsConfig;
         using TLoggerInitializer = std::function<void (TTestActorRuntime&)>;
         using TStoragePoolKinds = TDomainsInfo::TDomain::TStoragePoolKinds;
-        using TProxyDSPtr = TIntrusivePtr<NFake::TProxyDS>;
 
         ui16 Port;
         ui16 GrpcPort = 0;
@@ -171,7 +170,7 @@ namespace Tests {
         TString ServerCertFilePath;
         bool Verbose = true;
         bool UseSectorMap = false;
-        TVector<TProxyDSPtr> ProxyDSMocks;
+        TVector<TIntrusivePtr<NFake::TProxyDS>> ProxyDSMocks;
 
         std::function<IActor*(const TTicketParserSettings&)> CreateTicketParser = NKikimr::CreateTicketParser;
         std::shared_ptr<TGrpcServiceFactory> GrpcServiceFactory;
@@ -263,7 +262,7 @@ namespace Tests {
             return *this;
         }
 
-        TServerSettings& SetProxyDSMocks(const TVector<TProxyDSPtr>& proxyDSMocks) {
+        TServerSettings& SetProxyDSMocks(const TVector<TIntrusivePtr<NFake::TProxyDS>>& proxyDSMocks) {
             ProxyDSMocks = proxyDSMocks;
             return *this;
         }

--- a/ydb/core/testlib/ya.make
+++ b/ydb/core/testlib/ya.make
@@ -10,6 +10,7 @@ SRCS(
     fake_scheme_shard.h
     minikql_compile.h
     mock_pq_metacache.h
+    storage_helpers.cpp
     tablet_flat_dummy.cpp
     tablet_helpers.cpp
     tablet_helpers.h

--- a/ydb/core/tx/datashard/datashard__data_cleanup.cpp
+++ b/ydb/core/tx/datashard/datashard__data_cleanup.cpp
@@ -30,6 +30,18 @@ public:
             return true;
         }
 
+        if (Self->Executor()->HasLoanedParts()) {
+            LOG_WARN_S(ctx, NKikimrServices::TX_DATASHARD,
+                "DataCleanup of tablet# " << Self->TabletID()
+                << ": has borrowed parts"
+                << ", requested from " << Ev->Sender);
+            Response = std::make_unique<TEvDataShard::TEvForceDataCleanupResult>(
+                record.GetDataCleanupGeneration(),
+                Self->TabletID(),
+                NKikimrTxDataShard::TEvForceDataCleanupResult::FAILED);
+            return true;
+        }
+
         NIceDb::TNiceDb db(txc.DB);
         ui64 lastGen = 0;
         if (!Self->SysGetUi64(db, Schema::Sys_DataCleanupCompletedGeneration, lastGen)) {

--- a/ydb/core/tx/datashard/datashard__data_cleanup.cpp
+++ b/ydb/core/tx/datashard/datashard__data_cleanup.cpp
@@ -26,7 +26,7 @@ public:
             Response = std::make_unique<TEvDataShard::TEvForceDataCleanupResult>(
                 record.GetDataCleanupGeneration(),
                 Self->TabletID(),
-                NKikimrTxDataShard::TEvForceDataCleanupResult::FAILED);
+                NKikimrTxDataShard::TEvForceDataCleanupResult::WRONG_SHARD_STATE);
             return true;
         }
 
@@ -38,7 +38,7 @@ public:
             Response = std::make_unique<TEvDataShard::TEvForceDataCleanupResult>(
                 record.GetDataCleanupGeneration(),
                 Self->TabletID(),
-                NKikimrTxDataShard::TEvForceDataCleanupResult::FAILED);
+                NKikimrTxDataShard::TEvForceDataCleanupResult::BORROWED);
             return true;
         }
 

--- a/ydb/core/tx/datashard/datashard_ut_data_cleanup.cpp
+++ b/ydb/core/tx/datashard/datashard_ut_data_cleanup.cpp
@@ -328,7 +328,7 @@ Y_UNIT_TEST_SUITE(DataCleanup) {
             runtime.SendToPipe(tableShards.at(0), sender, request.Release(), 0, GetPipeConfigWithRetries());
 
             auto ev = runtime.GrabEdgeEventRethrow<TEvDataShard::TEvForceDataCleanupResult>(sender);
-            UNIT_ASSERT_EQUAL(ev->Get()->Record.GetStatus(), NKikimrTxDataShard::TEvForceDataCleanupResult::FAILED);
+            UNIT_ASSERT_EQUAL(ev->Get()->Record.GetStatus(), NKikimrTxDataShard::TEvForceDataCleanupResult::BORROWED);
             UNIT_ASSERT_VALUES_EQUAL(ev->Get()->Record.GetTabletId(), tableShards.at(0));
             UNIT_ASSERT_VALUES_EQUAL(ev->Get()->Record.GetDataCleanupGeneration(), dataCleanupGeneration);
         }

--- a/ydb/core/tx/datashard/datashard_ut_data_cleanup.cpp
+++ b/ydb/core/tx/datashard/datashard_ut_data_cleanup.cpp
@@ -1,4 +1,5 @@
 #include <ydb/core/tx/datashard/ut_common/datashard_ut_common.h>
+#include <ydb/core/testlib/storage_helpers.h>
 
 namespace NKikimr {
 
@@ -16,31 +17,8 @@ Y_UNIT_TEST_SUITE(DataCleanup) {
     static const TString PresentShortValue3("_Some_value_3_");
     static const TString DeletedLongValue4(size_t(100 * 1024), 't');
 
-    int CountBlobsWithSubstring(ui64 tabletId, const TVector<TServerSettings::TProxyDSPtr>& proxyDSs, const TString& substring) {
-        int res = 0;
-        for (const auto& proxyDS : proxyDSs) {
-            for (const auto& [id, blob] : proxyDS->AllMyBlobs()) {
-                if (id.TabletID() == tabletId && !blob.DoNotKeep && blob.Buffer.ConvertToString().Contains(substring)) {
-                    ++res;
-                }
-            }
-        }
-        return res;
-    }
-
-    bool BlobStorageContains(const TVector<TServerSettings::TProxyDSPtr>& proxyDSs, const TString& value) {
-        for (const auto& proxyDS : proxyDSs) {
-            for (const auto& [id, blob] : proxyDS->AllMyBlobs()) {
-                if (!blob.DoNotKeep && blob.Buffer.ConvertToString().Contains(value)) {
-                    return true;
-                }
-            }
-        }
-        return false;
-    }
-
     auto SetupWithTable(bool withCompaction) {
-        TVector<TServerSettings::TProxyDSPtr> proxyDSs {
+        TVector<TIntrusivePtr<NFake::TProxyDS>> proxyDSs {
             MakeIntrusive<NFake::TProxyDS>(TGroupId::FromValue(0)),
             MakeIntrusive<NFake::TProxyDS>(TGroupId::FromValue(2181038080)),
         };
@@ -113,7 +91,7 @@ Y_UNIT_TEST_SUITE(DataCleanup) {
         UNIT_ASSERT_VALUES_EQUAL(ev.Record.GetDataCleanupGeneration(), generation);
     }
 
-    void CheckTableData(Tests::TServer::TPtr server, const TVector<TServerSettings::TProxyDSPtr>& proxyDSs, const TString& table) {
+    void CheckTableData(Tests::TServer::TPtr server, const TVector<TIntrusivePtr<NFake::TProxyDS>>& proxyDSs, const TString& table) {
         auto result = ReadShardedTable(server, table);
         UNIT_ASSERT_VALUES_EQUAL(result,
             "key = 2, subkey = " + PresentSubkey2 + ", value = " + PresentLongValue2 + "\n"
@@ -325,6 +303,52 @@ Y_UNIT_TEST_SUITE(DataCleanup) {
 
         cleanupAndCheck(table2Shards.at(0), 24);
         cleanupAndCheck(tableShards.at(0), 24);
+
+        CheckTableData(server, proxyDSs, "/Root/table-1");
+        CheckTableData(server, proxyDSs, "/Root/table-2");
+    }
+
+    Y_UNIT_TEST(BorrowerDataCleanedAfterCopyTable) {
+        auto [server, sender, tableShards, proxyDSs] = SetupWithTable(true);
+        auto& runtime = *server->GetRuntime();
+
+        auto txIdCopy = AsyncCreateCopyTable(server, sender, "/Root", "table-2", "/Root/table-1");
+        WaitTxNotification(server, sender, txIdCopy);
+        auto table2Shards = GetTableShards(server, sender, "/Root/table-2");
+        auto table2Id = ResolveTableId(server, sender, "/Root/table-2");
+
+        ExecSQL(server, sender, "DELETE FROM `/Root/table-1` WHERE key IN (1, 4);");
+        ExecSQL(server, sender, "DELETE FROM `/Root/table-2` WHERE key IN (1, 4);");
+        SimulateSleep(runtime, TDuration::Seconds(2));
+
+        ui64 dataCleanupGeneration = 24;
+        {
+            // cleanup for the first table should be failed due to borrowed parts
+            auto request = MakeHolder<TEvDataShard::TEvForceDataCleanup>(dataCleanupGeneration);
+            runtime.SendToPipe(tableShards.at(0), sender, request.Release(), 0, GetPipeConfigWithRetries());
+
+            auto ev = runtime.GrabEdgeEventRethrow<TEvDataShard::TEvForceDataCleanupResult>(sender);
+            UNIT_ASSERT_EQUAL(ev->Get()->Record.GetStatus(), NKikimrTxDataShard::TEvForceDataCleanupResult::FAILED);
+            UNIT_ASSERT_VALUES_EQUAL(ev->Get()->Record.GetTabletId(), tableShards.at(0));
+            UNIT_ASSERT_VALUES_EQUAL(ev->Get()->Record.GetDataCleanupGeneration(), dataCleanupGeneration);
+        }
+        {
+            // cleanup for the second table
+            auto request = MakeHolder<TEvDataShard::TEvForceDataCleanup>(dataCleanupGeneration);
+            runtime.SendToPipe(table2Shards.at(0), sender, request.Release(), 0, GetPipeConfigWithRetries());
+
+            auto ev = runtime.GrabEdgeEventRethrow<TEvDataShard::TEvForceDataCleanupResult>(sender);
+            CheckResultEvent(*ev->Get(), table2Shards.at(0), dataCleanupGeneration);
+        }
+        {
+            // next cleanup for the first table should succeed after compaction of the second table
+            ++dataCleanupGeneration;
+            auto request = MakeHolder<TEvDataShard::TEvForceDataCleanup>(dataCleanupGeneration);
+            runtime.SendToPipe(tableShards.at(0), sender, request.Release(), 0, GetPipeConfigWithRetries());
+
+            auto ev = runtime.GrabEdgeEventRethrow<TEvDataShard::TEvForceDataCleanupResult>(sender);
+            CheckResultEvent(*ev->Get(), tableShards.at(0), dataCleanupGeneration);
+        }
 
         CheckTableData(server, proxyDSs, "/Root/table-1");
         CheckTableData(server, proxyDSs, "/Root/table-2");

--- a/ydb/core/tx/schemeshard/schemeshard__delete_tablet_reply.cpp
+++ b/ydb/core/tx/schemeshard/schemeshard__delete_tablet_reply.cpp
@@ -2,6 +2,7 @@
 
 #include <ydb/core/tablet/tablet_exception.h>
 #include <ydb/core/tablet_flat/flat_cxx_database.h>
+#include <ydb/core/tx/schemeshard/schemeshard__data_erasure_manager.h>
 
 namespace NKikimr {
 namespace NSchemeShard {
@@ -178,6 +179,9 @@ struct TSchemeShard::TTxDeleteTabletReply : public TSchemeShard::TRwTxBase {
                 LOG_DEBUG_S(ctx, NKikimrServices::FLAT_TX_SCHEMESHARD,
                             "Close pipe to deleted shardIdx " << ShardIdx << " tabletId " << TabletId);
                 Self->PipeClientCache->ForceClose(ctx, ui64(TabletId));
+            }
+            if (Self->DataErasureManager->GetStatus() == EDataErasureStatus::IN_PROGRESS) {
+                Self->Execute(Self->CreateTxCancelDataErasureShards({ShardIdx}));
             }
         }
     }

--- a/ydb/core/tx/schemeshard/schemeshard__root_data_erasure_manager.cpp
+++ b/ydb/core/tx/schemeshard/schemeshard__root_data_erasure_manager.cpp
@@ -165,7 +165,7 @@ void TRootDataErasureManager::ScheduleDataErasureWakeup() {
     IsDataErasureWakeupScheduled = true;
 
     LOG_DEBUG_S(ctx, NKikimrServices::FLAT_TX_SCHEMESHARD,
-        "[RootDataErasureManager] ScheduleDataErasureWakeup: Interval# " << CurrentWakeupInterval);
+        "[RootDataErasureManager] ScheduleDataErasureWakeup: Interval# " << CurrentWakeupInterval << ", Timestamp# " << AppData(ctx)->TimeProvider->Now());
 }
 
 void TRootDataErasureManager::WakeupToRunDataErasure(TEvSchemeShard::TEvWakeupToRunDataErasure::TPtr& ev, const NActors::TActorContext& ctx) {

--- a/ydb/core/tx/schemeshard/schemeshard__tenant_data_erasure_manager.cpp
+++ b/ydb/core/tx/schemeshard/schemeshard__tenant_data_erasure_manager.cpp
@@ -527,11 +527,12 @@ struct TSchemeShard::TTxCompleteDataErasureShard : public TSchemeShard::TRwTxBas
             "TTxCompleteDataErasureShard Execute at schemestard: " << Self->TabletID());
         const auto& record = Ev->Get()->Record;
 
-        if (record.GetStatus() == NKikimrTxDataShard::TEvForceDataCleanupResult::FAILED) {
+        if (record.GetStatus() != NKikimrTxDataShard::TEvForceDataCleanupResult::OK) {
             LOG_DEBUG_S(ctx, NKikimrServices::FLAT_TX_SCHEMESHARD,
                 "TTxCompleteDataErasureShard: data erasure failed at DataShard #" << record.GetTabletId()
+                    << " with status: " << NKikimrTxDataShard::TEvForceDataCleanupResult::EStatus_Name(record.GetStatus())
                     << ", schemestard: " << Self->TabletID());
-            return; // will be retried after timout in the queue
+            return; // will be retried after timout in the queue in TTenantDataErasureManager::OnTimeout()
         }
 
         auto& manager = Self->DataErasureManager;

--- a/ydb/core/tx/schemeshard/schemeshard__tenant_data_erasure_manager.cpp
+++ b/ydb/core/tx/schemeshard/schemeshard__tenant_data_erasure_manager.cpp
@@ -527,6 +527,13 @@ struct TSchemeShard::TTxCompleteDataErasureShard : public TSchemeShard::TRwTxBas
             "TTxCompleteDataErasureShard Execute at schemestard: " << Self->TabletID());
         const auto& record = Ev->Get()->Record;
 
+        if (record.GetStatus() == NKikimrTxDataShard::TEvForceDataCleanupResult::FAILED) {
+            LOG_DEBUG_S(ctx, NKikimrServices::FLAT_TX_SCHEMESHARD,
+                "TTxCompleteDataErasureShard: data erasure failed at DataShard #" << record.GetTabletId()
+                    << ", schemestard: " << Self->TabletID());
+            return; // will be retried after timout in the queue
+        }
+
         auto& manager = Self->DataErasureManager;
         const ui64 cleanupGeneration = record.GetDataCleanupGeneration();
         if (cleanupGeneration != manager->GetGeneration()) {

--- a/ydb/core/tx/schemeshard/schemeshard_impl.cpp
+++ b/ydb/core/tx/schemeshard/schemeshard_impl.cpp
@@ -7106,32 +7106,27 @@ void TSchemeShard::SetPartitioning(TPathId pathId, TTableInfo::TPtr tableInfo, T
         newPartitioningSet.reserve(newPartitioning.size());
         const auto& oldPartitioning = tableInfo->GetPartitions();
 
+        std::vector<TShardIdx> dataErasureShards;
         for (const auto& p: newPartitioning) {
             if (!oldPartitioning.empty())
                 newPartitioningSet.insert(p.ShardIdx);
 
             const auto& partitionStats = tableInfo->GetStats().PartitionStats;
             auto it = partitionStats.find(p.ShardIdx);
-            std::vector<TShardIdx> dataErasureShards;
             if (it != partitionStats.end()) {
                 EnqueueBackgroundCompaction(p.ShardIdx, it->second);
                 UpdateShardMetrics(p.ShardIdx, it->second);
                 dataErasureShards.push_back(p.ShardIdx);
             }
-            if (DataErasureManager->GetStatus() == EDataErasureStatus::IN_PROGRESS) {
-                Execute(CreateTxAddEntryToDataErasure(dataErasureShards), this->ActorContext());
-            }
+        }
+        if (DataErasureManager->GetStatus() == EDataErasureStatus::IN_PROGRESS) {
+            Execute(CreateTxAddEntryToDataErasure(dataErasureShards), this->ActorContext());
         }
 
-        std::vector<TShardIdx> cancelDataErasureShards;
         for (const auto& p: oldPartitioning) {
             if (!newPartitioningSet.contains(p.ShardIdx)) {
                 // note that queues might not contain the shard
                 OnShardRemoved(p.ShardIdx);
-                cancelDataErasureShards.push_back(p.ShardIdx);
-            }
-            if (DataErasureManager->GetStatus() == EDataErasureStatus::IN_PROGRESS) {
-                Execute(CreateTxCancelDataErasureShards(cancelDataErasureShards), this->ActorContext());
             }
         }
     }

--- a/ydb/core/tx/schemeshard/ut_data_erasure/ut_data_erasure.cpp
+++ b/ydb/core/tx/schemeshard/ut_data_erasure/ut_data_erasure.cpp
@@ -11,6 +11,69 @@
 using namespace NKikimr;
 using namespace NSchemeShardUT_Private;
 
+namespace {
+    TTestEnv SetupEnv(TTestBasicRuntime& runtime, TVector<TIntrusivePtr<NFake::TProxyDS>>& dsProxies) {
+        TTestEnv env(runtime, TTestEnvOptions()
+            .NChannels(4)
+            .EnablePipeRetries(true)
+            .EnableSystemViews(false)
+            .DSProxies(dsProxies));
+
+        runtime.SetLogPriority(NKikimrServices::TX_PROXY, NLog::PRI_DEBUG);
+        runtime.SetLogPriority(NKikimrServices::FLAT_TX_SCHEMESHARD, NActors::NLog::PRI_TRACE);
+
+        auto info = CreateTestTabletInfo(MakeBSControllerID(), TTabletTypes::BSController);
+        CreateTestBootstrapper(runtime, info, [](const TActorId &tablet, TTabletStorageInfo *info) -> IActor* {
+            return new TFakeBSController(tablet, info);
+        });
+
+        runtime.GetAppData().FeatureFlags.SetEnableDataErasure(true);
+        auto& dataErasureConfig = runtime.GetAppData().DataErasureConfig;
+        dataErasureConfig.SetDataErasureIntervalSeconds(50);
+        dataErasureConfig.SetBlobStorageControllerRequestIntervalSeconds(10);
+
+        return env;
+    }
+
+    void FillData(TTestBasicRuntime& runtime, ui64 schemeshardId, ui64& txId, const TVector<ui64>& shardsIds, TVector<TIntrusivePtr<NFake::TProxyDS>>& dsProxies, const TString& valueToDelete) {
+        TString value(size_t(100 * 1024), 't');
+        ui32 keyToDelete = 42;
+
+        for (ui32 key : xrange(100)) {
+            int partitionIdx = shardsIds.size() == 1 || key < 50 ? 0 : 1;
+            WriteRow(runtime, schemeshardId, ++txId, "/MyRoot/Database1/Simple", partitionIdx, key, key == keyToDelete ? valueToDelete : value);
+        }
+
+        auto tableVersion = TestDescribeResult(DescribePath(runtime, schemeshardId, "/MyRoot/Database1/Simple"), {NLs::PathExist});
+        for (const auto& shardsId : shardsIds) {
+            const auto result = CompactTable(runtime, shardsId, tableVersion.PathId);
+            UNIT_ASSERT_VALUES_EQUAL(result.GetStatus(), NKikimrTxDataShard::TEvCompactTableResult::OK);
+        }
+
+        DeleteRow(runtime, schemeshardId, ++txId, "/MyRoot/Database1/Simple", 0, keyToDelete);
+
+        // BlobStorage should contain deleted value yet
+        UNIT_ASSERT(BlobStorageContains(dsProxies, valueToDelete));
+    }
+
+    void CheckDataErasureStatus(TTestBasicRuntime& runtime, TActorId sender, TVector<TIntrusivePtr<NFake::TProxyDS>>& dsProxies, const TString& valueToDelete, bool completed) {
+        auto request = MakeHolder<TEvSchemeShard::TEvDataErasureInfoRequest>();
+        runtime.SendToPipe(TTestTxConfig::SchemeShard, sender, request.Release(), 0, GetPipeConfigWithRetries());
+
+        TAutoPtr<IEventHandle> handle;
+        auto response = runtime.GrabEdgeEventRethrow<TEvSchemeShard::TEvDataErasureInfoResponse>(handle);
+
+        UNIT_ASSERT_EQUAL_C(response->Record.GetGeneration(), 1, response->Record.GetGeneration());
+        if (completed) {
+            UNIT_ASSERT_EQUAL(response->Record.GetStatus(), NKikimrScheme::TEvDataErasureInfoResponse::COMPLETED);
+            UNIT_ASSERT(!BlobStorageContains(dsProxies, valueToDelete));
+        } else {
+            UNIT_ASSERT_EQUAL(response->Record.GetStatus(), NKikimrScheme::TEvDataErasureInfoResponse::IN_PROGRESS_TENANT);
+            UNIT_ASSERT(BlobStorageContains(dsProxies, valueToDelete));
+        }
+    }
+}
+
 Y_UNIT_TEST_SUITE(TestDataErasure) {
     Y_UNIT_TEST(SimpleDataErasureTest) {
         TTestBasicRuntime runtime;
@@ -187,30 +250,10 @@ Y_UNIT_TEST_SUITE(TestDataErasure) {
 
     Y_UNIT_TEST(DataErasureWithCopyTable) {
         TTestBasicRuntime runtime;
-
         TVector<TIntrusivePtr<NFake::TProxyDS>> dsProxies {
             MakeIntrusive<NFake::TProxyDS>(TGroupId::FromValue(0)),
         };
-
-        TTestEnv env(runtime, TTestEnvOptions()
-            .NChannels(4)
-            .EnablePipeRetries(true)
-            .EnableSystemViews(false)
-            .DSProxies(dsProxies));
-
-        runtime.SetLogPriority(NKikimrServices::TX_PROXY, NLog::PRI_DEBUG);
-        runtime.SetLogPriority(NKikimrServices::FLAT_TX_SCHEMESHARD, NActors::NLog::PRI_TRACE);
-
-        auto info = CreateTestTabletInfo(MakeBSControllerID(), TTabletTypes::BSController);
-        CreateTestBootstrapper(runtime, info, [](const TActorId &tablet, TTabletStorageInfo *info) -> IActor* {
-            return new TFakeBSController(tablet, info);
-        });
-
-        runtime.GetAppData().FeatureFlags.SetEnableDataErasure(true);
-        auto& dataErasureConfig = runtime.GetAppData().DataErasureConfig;
-        dataErasureConfig.SetDataErasureIntervalSeconds(50);
-        dataErasureConfig.SetBlobStorageControllerRequestIntervalSeconds(10);
-
+        auto env = SetupEnv(runtime, dsProxies);
         auto sender = runtime.AllocateEdgeActor();
         RebootTablet(runtime, TTestTxConfig::SchemeShard, sender);
 
@@ -218,23 +261,8 @@ Y_UNIT_TEST_SUITE(TestDataErasure) {
 
         auto schemeshardId = CreateTestSubdomain(runtime, env, &txId, "Database1");
         auto shards = GetTableShards(runtime, schemeshardId, "/MyRoot/Database1/Simple");
-        TString value(size_t(100 * 1024), 't');
-        WriteRow(runtime, schemeshardId, ++txId, "/MyRoot/Database1/Simple", 0, 1, value);
-
-        auto tableVersion = TestDescribeResult(DescribePath(runtime, schemeshardId, "/MyRoot/Database1/Simple"), {NLs::PathExist});
-        {
-            const auto result = CompactTable(runtime, shards.at(0), tableVersion.PathId);
-            UNIT_ASSERT_VALUES_EQUAL(result.GetStatus(), NKikimrTxDataShard::TEvCompactTableResult::OK);
-        }
-        {
-            const auto result = CompactTable(runtime, shards.at(1), tableVersion.PathId);
-            UNIT_ASSERT_VALUES_EQUAL(result.GetStatus(), NKikimrTxDataShard::TEvCompactTableResult::NOT_NEEDED);
-        }
-
-        DeleteRow(runtime, schemeshardId, ++txId, "/MyRoot/Database1/Simple", 0, 1);
-
-        // BlobStorage should contain deleted value yet
-        UNIT_ASSERT(BlobStorageContains(dsProxies, value));
+        TString value(size_t(100 * 1024), 'd');
+        FillData(runtime, schemeshardId, txId, shards, dsProxies, value);
 
         // catch and hold borrow returns
         TBlockEvents<TEvDataShard::TEvReturnBorrowedPart> borrowReturns(runtime);
@@ -244,17 +272,7 @@ Y_UNIT_TEST_SUITE(TestDataErasure) {
         runtime.WaitFor("borrow return", [&borrowReturns]{ return borrowReturns.size() >= 1; });
 
         // data cleanup should not be finished due to holded borrow returns
-        {
-            auto request = MakeHolder<TEvSchemeShard::TEvDataErasureInfoRequest>();
-            runtime.SendToPipe(TTestTxConfig::SchemeShard, sender, request.Release(), 0, GetPipeConfigWithRetries());
-
-            TAutoPtr<IEventHandle> handle;
-            auto response = runtime.GrabEdgeEventRethrow<TEvSchemeShard::TEvDataErasureInfoResponse>(handle);
-
-            UNIT_ASSERT_EQUAL_C(response->Record.GetGeneration(), 1, response->Record.GetGeneration());
-            UNIT_ASSERT_EQUAL(response->Record.GetStatus(), NKikimrScheme::TEvDataErasureInfoResponse::IN_PROGRESS_TENANT);
-            UNIT_ASSERT(BlobStorageContains(dsProxies, value));
-        }
+        CheckDataErasureStatus(runtime, sender, dsProxies, value, false);
 
         // return borrow
         borrowReturns.Stop().Unblock();
@@ -264,14 +282,141 @@ Y_UNIT_TEST_SUITE(TestDataErasure) {
         runtime.DispatchEvents(options);
 
         // data cleanup should be finished after returned borrows
-        {
-            auto request = MakeHolder<TEvSchemeShard::TEvDataErasureInfoRequest>();
-            runtime.SendToPipe(TTestTxConfig::SchemeShard, sender, request.Release(), 0, GetPipeConfigWithRetries());
-            TAutoPtr<IEventHandle> handle;
-            auto response = runtime.GrabEdgeEventRethrow<TEvSchemeShard::TEvDataErasureInfoResponse>(handle);
-            UNIT_ASSERT_EQUAL_C(response->Record.GetGeneration(), 1, response->Record.GetGeneration());
-            UNIT_ASSERT_EQUAL(response->Record.GetStatus(), NKikimrScheme::TEvDataErasureInfoResponse::COMPLETED);
-            UNIT_ASSERT(!BlobStorageContains(dsProxies, value));
-        }
+        CheckDataErasureStatus(runtime, sender, dsProxies, value, true);
+    }
+
+    Y_UNIT_TEST(DataErasureWithSplit) {
+        TTestBasicRuntime runtime;
+        TVector<TIntrusivePtr<NFake::TProxyDS>> dsProxies {
+            MakeIntrusive<NFake::TProxyDS>(TGroupId::FromValue(0)),
+        };
+        auto env = SetupEnv(runtime, dsProxies);
+        auto sender = runtime.AllocateEdgeActor();
+        RebootTablet(runtime, TTestTxConfig::SchemeShard, sender);
+
+        ui64 txId = 100;
+
+        auto schemeshardId = CreateTestSubdomain(runtime, env, &txId, "Database1", false);
+
+        TestCreateTable(runtime, schemeshardId, ++txId, "/MyRoot/Database1",
+            R"____(
+                Name: "Simple"
+                Columns { Name: "key1"  Type: "Uint32"}
+                Columns { Name: "Value" Type: "Utf8"}
+                KeyColumnNames: ["key1"]
+            )____");
+        env.TestWaitNotification(runtime, txId, schemeshardId);
+        auto shards1 = GetTableShards(runtime, schemeshardId, "/MyRoot/Database1/Simple");
+        UNIT_ASSERT_VALUES_EQUAL(shards1.size(), 1);
+
+        TString valueToDelete(size_t(100 * 1024), 'd');
+        FillData(runtime, schemeshardId, txId, shards1, dsProxies, valueToDelete);
+
+        // block borrow returns to suspend SplitTable
+        TBlockEvents<TEvDataShard::TEvReturnBorrowedPart> borrowReturns(runtime);
+
+        // block CollectGarbage requests to suspend DataCleanup
+        TBlockEvents<TEvBlobStorage::TEvCollectGarbage> collectGarbageReqs(runtime);
+        runtime.WaitFor("collect garbage", [&collectGarbageReqs]{ return collectGarbageReqs.size() >= 1; });
+
+        TestSplitTable(runtime, schemeshardId, ++txId, "/MyRoot/Database1/Simple", Sprintf(
+            R"(
+                SourceTabletId: %lu
+                SplitBoundary {
+                    KeyPrefix {
+                        Tuple { Optional { Uint32: 50 } }
+                    }
+                }
+            )", shards1.at(0)));
+        env.TestWaitNotification(runtime, txId, schemeshardId);
+
+        runtime.WaitFor("borrow return", [&borrowReturns]{ return borrowReturns.size() >= 1; });
+
+        // DataErasure should be in progress because of SplitTable and DataCleanup have been suspended
+        CheckDataErasureStatus(runtime, sender, dsProxies, valueToDelete, false);
+
+        auto shards2 = GetTableShards(runtime, schemeshardId, "/MyRoot/Database1/Simple");
+        UNIT_ASSERT_VALUES_EQUAL(shards2.size(), 2);
+
+        collectGarbageReqs.Stop().Unblock();
+        borrowReturns.Stop().Unblock();
+
+        TDispatchOptions options;
+        options.FinalEvents.push_back(TDispatchOptions::TFinalEventCondition(TEvBlobStorage::EvControllerShredResponse, 3));
+        runtime.DispatchEvents(options);
+
+        // now data cleanup should be finished
+        CheckDataErasureStatus(runtime, sender, dsProxies, valueToDelete, true);
+    }
+
+    Y_UNIT_TEST(DataErasureWithMerge) {
+        TTestBasicRuntime runtime;
+        TVector<TIntrusivePtr<NFake::TProxyDS>> dsProxies {
+            MakeIntrusive<NFake::TProxyDS>(TGroupId::FromValue(0)),
+        };
+        auto env = SetupEnv(runtime, dsProxies);
+        auto sender = runtime.AllocateEdgeActor();
+        RebootTablet(runtime, TTestTxConfig::SchemeShard, sender);
+
+        ui64 txId = 100;
+
+        auto schemeshardId = CreateTestSubdomain(runtime, env, &txId, "Database1", false);
+
+        TestCreateTable(runtime, schemeshardId, ++txId, "/MyRoot/Database1",
+            R"____(
+                Name: "Simple"
+                Columns { Name: "key1"  Type: "Uint32"}
+                Columns { Name: "Value" Type: "Utf8"}
+                KeyColumnNames: ["key1"]
+                SplitBoundary {
+                    KeyPrefix {
+                        Tuple { Optional { Uint32: 50 } }
+                    }
+                }
+                PartitionConfig {
+                    PartitioningPolicy {
+                        MinPartitionsCount: 1
+                        MaxPartitionsCount: 2
+                    }
+                }
+            )____");
+        env.TestWaitNotification(runtime, txId, schemeshardId);
+        auto shards1 = GetTableShards(runtime, schemeshardId, "/MyRoot/Database1/Simple");
+        UNIT_ASSERT_VALUES_EQUAL(shards1.size(), 2);
+
+        TString valueToDelete(size_t(100 * 1024), 'd');
+        FillData(runtime, schemeshardId, txId, shards1, dsProxies, valueToDelete);
+
+        // block borrow returns to suspend SplitTable
+        TBlockEvents<TEvDataShard::TEvReturnBorrowedPart> borrowReturns(runtime);
+
+        // block CollectGarbage requests to suspend DataCleanup
+        TBlockEvents<TEvBlobStorage::TEvCollectGarbage> collectGarbageReqs(runtime);
+        runtime.WaitFor("collect garbage", [&collectGarbageReqs]{ return collectGarbageReqs.size() >= 1; });
+
+        TestSplitTable(runtime, schemeshardId, ++txId, "/MyRoot/Database1/Simple", Sprintf(
+            R"(
+                SourceTabletId: %lu
+                SourceTabletId: %lu
+            )", shards1.at(0), shards1.at(1)));
+        env.TestWaitNotification(runtime, txId, schemeshardId);
+
+        runtime.WaitFor("borrow return", [&borrowReturns]{ return borrowReturns.size() >= 1; });
+
+        // DataErasure should be in progress because of SplitTable and DataCleanup have been suspended
+        CheckDataErasureStatus(runtime, sender, dsProxies, valueToDelete, false);
+
+        auto shards2 = GetTableShards(runtime, schemeshardId, "/MyRoot/Database1/Simple");
+        UNIT_ASSERT_VALUES_EQUAL(shards2.size(), 1);
+
+        collectGarbageReqs.Stop().Unblock();
+        borrowReturns.Stop().Unblock();
+
+        TDispatchOptions options;
+        options.FinalEvents.push_back(TDispatchOptions::TFinalEventCondition(TEvBlobStorage::EvControllerShredResponse, 3));
+        runtime.DispatchEvents(options);
+
+        // now data cleanup should be finished
+        CheckDataErasureStatus(runtime, sender, dsProxies, valueToDelete, true);
     }
 }

--- a/ydb/core/tx/schemeshard/ut_helpers/data_erasure_helpers.h
+++ b/ydb/core/tx/schemeshard/ut_helpers/data_erasure_helpers.h
@@ -17,7 +17,7 @@ namespace NSchemeShardUT_Private {
 
 class TTestEnv;
 
-ui64 CreateTestSubdomain(NActors::TTestActorRuntime& runtime, TTestEnv& env, ui64* txId, const TString& name);
+ui64 CreateTestSubdomain(NActors::TTestActorRuntime& runtime, TTestEnv& env, ui64* txId, const TString& name, bool addTable = true);
 
 class TFakeBSController : public NActors::TActor<TFakeBSController>, public NKikimr::NTabletFlatExecutor::TTabletExecutedFlat {
     void DefaultSignalTabletActive(const NActors::TActorContext&) override;

--- a/ydb/core/tx/schemeshard/ut_helpers/helpers.h
+++ b/ydb/core/tx/schemeshard/ut_helpers/helpers.h
@@ -477,6 +477,7 @@ namespace NSchemeShardUT_Private {
 
     NKikimrSchemeOp::TTableDescription GetDatashardSchema(TTestActorRuntime& runtime, ui64 tabletId, ui64 tid);
 
+    TVector<ui64> GetTableShards(TTestActorRuntime& runtime, ui64 schemeShard,  const TString& path);
     NLs::TCheckFunc ShardsIsReady(TTestActorRuntime& runtime);
 
     template <typename TCreateFunc>
@@ -618,7 +619,7 @@ namespace NSchemeShardUT_Private {
 
 
     NKikimrTxDataShard::TEvCompactTableResult CompactTable(
-        TTestActorRuntime& runtime, ui64 shardId, const TTableId& tableId, bool compactBorrowed = false);
+        TTestActorRuntime& runtime, ui64 shardId, const TTableId& tableId, bool compactBorrowed = false, bool compactSinglePartedShards = false);
 
     NKikimrPQ::TDescribeResponse GetDescribeFromPQBalancer(TTestActorRuntime& runtime, ui64 balancerId);
 
@@ -627,7 +628,10 @@ namespace NSchemeShardUT_Private {
     void UpdateRow(TTestActorRuntime& runtime, const TString& table, const ui32 key, const TString& value, ui64 tabletId = TTestTxConfig::FakeHiveTablets);
     void UpdateRowPg(TTestActorRuntime& runtime, const TString& table, const ui32 key, ui32 value, ui64 tabletId = TTestTxConfig::FakeHiveTablets);
     void UploadRow(TTestActorRuntime& runtime, const TString& tablePath, int partitionIdx, const TVector<ui32>& keyTags, const TVector<ui32>& valueTags, const TVector<TCell>& keys, const TVector<TCell>& values);
+    void WriteRow(TTestActorRuntime& runtime, ui64 schemeshardId, const ui64 txId, const TString& tablePath, int partitionIdx, const ui32 key, const TString& value, bool successIsExpected = true);
     void WriteRow(TTestActorRuntime& runtime, const ui64 txId, const TString& tablePath, int partitionIdx, const ui32 key, const TString& value, bool successIsExpected = true);
+    void DeleteRow(TTestActorRuntime& runtime, ui64 schemeshardId, const ui64 txId, const TString& tablePath, int partitionIdx, const ui32 key, bool successIsExpected = true);
+    void DeleteRow(TTestActorRuntime& runtime, const ui64 txId, const TString& tablePath, int partitionIdx, const ui32 key, bool successIsExpected = true);
 
     void SendNextValRequest(TTestActorRuntime& runtime, const TActorId& sender, const TString& path);
     i64 WaitNextValResult(

--- a/ydb/core/tx/schemeshard/ut_helpers/test_env.cpp
+++ b/ydb/core/tx/schemeshard/ut_helpers/test_env.cpp
@@ -654,7 +654,7 @@ NSchemeShardUT_Private::TTestEnv::TTestEnv(TTestActorRuntime& runtime, const TTe
         SetupSchemeCache(runtime, node, app.Domains->GetDomain(TTestTxConfig::DomainUid).Name);
     }
 
-    SetupTabletServices(runtime, &app);
+    SetupTabletServices(runtime, &app, !opts.DSProxies_.empty(), {}, nullptr, false, opts.DSProxies_);
     if (opts.EnablePipeRetries_) {
         EnableSchemeshardPipeRetriesGuard = EnableSchemeshardPipeRetries(runtime);
     }

--- a/ydb/core/tx/schemeshard/ut_helpers/test_env.h
+++ b/ydb/core/tx/schemeshard/ut_helpers/test_env.h
@@ -77,6 +77,7 @@ namespace NSchemeShardUT_Private {
         OPTION(std::optional<bool>, EnableDatabaseAdmin, std::nullopt);
         OPTION(std::optional<bool>, EnablePermissionsExport, std::nullopt);
         OPTION(std::optional<bool>, EnableChecksumsExport, std::nullopt);
+        OPTION(TVector<TIntrusivePtr<NFake::TProxyDS>>, DSProxies, {});
 
         #undef OPTION
     };

--- a/ydb/core/tx/schemeshard/ut_stats/ut_stats.cpp
+++ b/ydb/core/tx/schemeshard/ut_stats/ut_stats.cpp
@@ -141,18 +141,6 @@ void SetStatsObserver(TTestActorRuntime& runtime, const std::function<TTestActor
     });
 }
 
-TVector<ui64> GetTableShards(TTestActorRuntime& runtime,
-                             const TString& path
-) {
-    TVector<ui64> shards;
-    auto tableDescription = DescribePath(runtime, path, true);
-    for (const auto& part : tableDescription.GetPathDescription().GetTablePartitions()) {
-        shards.emplace_back(part.GetDatashardId());
-    }
-
-    return shards;
-}
-
 TTableId ResolveTableId(TTestActorRuntime& runtime, const TString& path) {
     auto response = Navigate(runtime, path);
     return response->ResultSet.at(0).TableId;
@@ -646,7 +634,7 @@ Y_UNIT_TEST_SUITE(TStoragePoolsStatsPersistence) {
         );
         env.TestWaitNotification(runtime, txId);
 
-        auto shards = GetTableShards(runtime, "/MyRoot/SomeTable");
+        auto shards = GetTableShards(runtime, TTestTxConfig::SchemeShard, "/MyRoot/SomeTable");
         UNIT_ASSERT_VALUES_EQUAL(shards.size(), 1);
         auto& datashard = shards[0];
         constexpr ui32 rowsCount = 100u;

--- a/ydb/core/tx/schemeshard/ut_subdomain/ut_subdomain.cpp
+++ b/ydb/core/tx/schemeshard/ut_subdomain/ut_subdomain.cpp
@@ -213,19 +213,6 @@ void CheckQuotaExceedance(TTestActorRuntime& runtime,
     });
 }
 
-TVector<ui64> GetTableShards(TTestActorRuntime& runtime,
-                             ui64 schemeShard,
-                             const TString& path
-) {
-    TVector<ui64> shards;
-    const auto tableDescription = DescribePath(runtime, schemeShard, path, true);
-    for (const auto& part : tableDescription.GetPathDescription().GetTablePartitions()) {
-        shards.emplace_back(part.GetDatashardId());
-    }
-
-    return shards;
-}
-
 TTableId ResolveTableId(TTestActorRuntime& runtime, const TString& path) {
     const auto response = Navigate(runtime, path);
     return response->ResultSet.at(0).TableId;


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

...

### Changelog category <!-- remove all except one -->

* Not for changelog (changelog entry is not required)

### Description for reviewers <!-- (optional) description for those who read this PR -->

Return error in case of borrowed parts being present in DataShard. SchemeShard will retry these failed DataCleanup attempts.
In case of split/merge SchemeShard will wait old tablet deletion.
