### PR TITLE
Fix proxy crash on duplicate topics in request

### DIFF
--- a/ydb/core/kafka_proxy/actors/kafka_metadata_actor.h
+++ b/ydb/core/kafka_proxy/actors/kafka_metadata_actor.h
@@ -85,10 +85,11 @@ private:
     bool NeedAllNodes = false;
     bool HaveError = false;
     bool FallbackToIcDiscovery = false;
-    TMap<ui64, TAutoPtr<TEvLocationResponse>> PendingTopicResponses;
+    TMap<ui64, TSimpleSharedPtr<TEvLocationResponse>> PendingTopicResponses;
 
     THashMap<ui64, TNodeInfo> Nodes;
     THashMap<TString, TActorId> PartitionActors;
+    THashSet<ui64> HaveBrokers;
 
 };
 


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

Fix metadataRequest containg same topic multiple times crashing KafkaProxy

### Changelog category <!-- remove all except one -->

* Bugfix 

### Description for reviewers <!-- (optional) description for those who read this PR -->

...
