### PR TITLE
24-4: Force oldest locks into shard locks due to range limits

### DIFF
--- a/ydb/core/tx/locks/locks.cpp
+++ b/ydb/core/tx/locks/locks.cpp
@@ -406,9 +406,60 @@ void TTableLocks::RemoveWriteLock(TLockInfo* lock) {
 
 // TLockLocker
 
+namespace {
+
+    static constexpr ui64 DefaultLockLimit() {
+        // Valgrind and sanitizers are too slow
+        // Some tests cannot exhaust default limit in under 5 minutes
+        return NValgrind::PlainOrUnderValgrind(
+                    NSan::PlainOrUnderSanitizer(
+                        20000,
+                        1000),
+                    1000);
+    }
+
+    static constexpr ui64 DefaultLockRangesLimit() {
+        return 50000;
+    }
+
+    static constexpr ui64 DefaultTotalRangesLimit() {
+        return 1000000;
+    }
+
+    static std::atomic<ui64> g_LockLimit{ DefaultLockLimit() };
+    static std::atomic<ui64> g_LockRangesLimit{ DefaultLockRangesLimit() };
+    static std::atomic<ui64> g_TotalRangesLimit{ DefaultTotalRangesLimit() };
+
+} // namespace
+
+ui64 TLockLocker::LockLimit() {
+    return g_LockLimit.load(std::memory_order_relaxed);
+}
+
+ui64 TLockLocker::LockRangesLimit() {
+    return g_LockRangesLimit.load(std::memory_order_relaxed);
+}
+
+ui64 TLockLocker::TotalRangesLimit() {
+    return g_TotalRangesLimit.load(std::memory_order_relaxed);
+}
+
+void TLockLocker::SetLockLimit(ui64 newLimit) {
+    g_LockLimit.store(newLimit, std::memory_order_relaxed);
+}
+
+void TLockLocker::SetLockRangesLimit(ui64 newLimit) {
+    g_LockRangesLimit.store(newLimit, std::memory_order_relaxed);
+}
+
+void TLockLocker::SetTotalRangesLimit(ui64 newLimit) {
+    g_TotalRangesLimit.store(newLimit, std::memory_order_relaxed);
+}
+
 void TLockLocker::AddPointLock(const TLockInfo::TPtr& lock, const TPointKey& key) {
     if (lock->AddPoint(key)) {
         key.Table->AddPointLock(key, lock.Get());
+        LocksWithRanges.PushBack(lock.Get());
     } else {
         key.Table->AddShardLock(lock.Get());
     }
@@ -417,21 +468,27 @@ void TLockLocker::AddPointLock(const TLockInfo::TPtr& lock, const TPointKey& key
 void TLockLocker::AddRangeLock(const TLockInfo::TPtr& lock, const TRangeKey& key) {
     if (lock->AddRange(key)) {
         key.Table->AddRangeLock(key, lock.Get());
+        LocksWithRanges.PushBack(lock.Get());
     } else {
         key.Table->AddShardLock(lock.Get());
     }
 }
 
-void TLockLocker::AddShardLock(const TLockInfo::TPtr& lock, TIntrusiveList<TTableLocks, TTableLocksReadListTag>& readTables) {
+void TLockLocker::MakeShardLock(TLockInfo* lock) {
     if (!lock->IsShardLock()) {
         for (const TPathId& tableId : lock->GetReadTables()) {
-            Tables.at(tableId)->RemoveRangeLock(lock.Get());
+            Tables.at(tableId)->RemoveRangeLock(lock);
         }
         lock->MakeShardLock();
+        LocksWithRanges.Remove(lock);
         for (const TPathId& tableId : lock->GetReadTables()) {
-            Tables.at(tableId)->AddShardLock(lock.Get());
+            Tables.at(tableId)->AddShardLock(lock);
         }
     }
+}
+
+void TLockLocker::AddShardLock(const TLockInfo::TPtr& lock, TIntrusiveList<TTableLocks, TTableLocksReadListTag>& readTables) {
+    MakeShardLock(lock.Get());
     for (auto& table : readTables) {
         const TPathId& tableId = table.GetTableId();
         Y_ABORT_UNLESS(Tables.at(tableId).Get() == &table);
@@ -523,6 +580,9 @@ void TLockLocker::RemoveBrokenRanges() {
 TLockInfo::TPtr TLockLocker::GetOrAddLock(ui64 lockId, ui32 lockNodeId) {
     auto it = Locks.find(lockId);
     if (it != Locks.end()) {
+        if (it->second->IsInList<TLockInfoRangesListTag>()) {
+            LocksWithRanges.PushBack(it->second.Get());
+        }
         if (it->second->IsInList<TLockInfoExpireListTag>()) {
             ExpireQueue.PushBack(it->second.Get());
         }
@@ -595,6 +655,7 @@ void TLockLocker::RemoveOneLock(ui64 lockTxId, ILocksDb* db) {
         for (const TPathId& tableId : txLock->GetWriteTables()) {
             Tables.at(tableId)->RemoveWriteLock(txLock.Get());
         }
+        LocksWithRanges.Remove(txLock.Get());
         txLock->CleanupConflicts();
         Locks.erase(it);
 
@@ -638,6 +699,7 @@ void TLockLocker::RemoveSchema(const TPathId& tableId, ILocksDb* db) {
     Y_ABORT_UNLESS(Tables.empty());
     Locks.clear();
     ShardLocks.clear();
+    LocksWithRanges.Clear();
     ExpireQueue.Clear();
     BrokenLocks.Clear();
     BrokenPersistentLocks.Clear();
@@ -647,21 +709,41 @@ void TLockLocker::RemoveSchema(const TPathId& tableId, ILocksDb* db) {
     PendingSubscribeLocks.clear();
 }
 
-bool TLockLocker::ForceShardLock(const TPathId& tableId) const {
-    auto it = Tables.find(tableId);
-    if (it != Tables.end()) {
-        if (it->second->RangeCount() > LockLimit()) {
-            return true;
+bool TLockLocker::ForceShardLock(
+    const TLockInfo::TPtr& lock,
+    const TIntrusiveList<TTableLocks, TTableLocksReadListTag>& readTables,
+    ui64 newRanges)
+{
+    if (lock->NumPoints() + lock->NumRanges() + newRanges > LockRangesLimit()) {
+        // Lock has too many ranges, will never fit in
+        return true;
+    }
+
+    for (auto& table : readTables) {
+        while (table.RangeCount() + newRanges > TotalRangesLimit()) {
+            if (LocksWithRanges.Empty()) {
+                // Too many new ranges (e.g. TotalRangesLimit < LockRangesLimit)
+                return true;
+            }
+
+            // Try to reduce the number of ranges until new ranges fit in
+            TLockInfo* next = LocksWithRanges.PopFront();
+            if (next == lock.Get()) {
+                bool wasLast = LocksWithRanges.Empty();
+                LocksWithRanges.PushBack(next);
+                if (wasLast) {
+                    return true;
+                }
+                // We want to handle the newest lock last
+                continue;
+            }
+
+            // Reduce the number of ranges by making the oldest lock into a shard lock
+            MakeShardLock(next);
+            Self->IncCounter(COUNTER_LOCKS_WHOLE_SHARD);
         }
     }
-    return false;
-}
 
-bool TLockLocker::ForceShardLock(const TIntrusiveList<TTableLocks, TTableLocksReadListTag>& readTables) const {
-    for (auto& table : readTables) {
-        if (table.RangeCount() > LockLimit())
-            return true;
-    }
     return false;
 }
 
@@ -775,8 +857,6 @@ TVector<TSysLocks::TLock> TSysLocks::ApplyLocks() {
         return TVector<TLock>();
     }
 
-    bool shardLock = Locker.ForceShardLock(Update->ReadTables);
-
     TLockInfo::TPtr lock;
     ui64 counter = TLock::ErrorNotSet;
 
@@ -795,6 +875,12 @@ TVector<TSysLocks::TLock> TSysLocks::ApplyLocks() {
         } else if (lock->IsBroken()) {
             counter = TLock::ErrorBroken;
         } else {
+            bool shardLock = (
+                lock->IsShardLock() ||
+                Locker.ForceShardLock(
+                    lock,
+                    Update->ReadTables,
+                    Update->PointLocks.size() + Update->RangeLocks.size()));
             if (shardLock) {
                 Locker.AddShardLock(lock, Update->ReadTables);
                 Self->IncCounter(COUNTER_LOCKS_WHOLE_SHARD);

--- a/ydb/core/tx/locks/locks.h
+++ b/ydb/core/tx/locks/locks.h
@@ -252,6 +252,7 @@ struct TLockInfoWriteConflictListTag {};
 struct TLockInfoBrokenListTag {};
 struct TLockInfoBrokenPersistentListTag {};
 struct TLockInfoExpireListTag {};
+struct TLockInfoRangesListTag {};
 
 /// Aggregates shard, point and range locks
 class TLockInfo
@@ -263,6 +264,7 @@ class TLockInfo
     , public TIntrusiveListItem<TLockInfo, TLockInfoBrokenListTag>
     , public TIntrusiveListItem<TLockInfo, TLockInfoBrokenPersistentListTag>
     , public TIntrusiveListItem<TLockInfo, TLockInfoExpireListTag>
+    , public TIntrusiveListItem<TLockInfo, TLockInfoRangesListTag>
 {
     friend class TTableLocks;
     friend class TLockLocker;
@@ -508,16 +510,19 @@ class TLockLocker {
     friend class TSysLocks;
 
 public:
-    /// Prevent unlimited lock's count growth
-    static constexpr ui64 LockLimit() {
-        // Valgrind and sanitizers are too slow
-        // Some tests cannot exhaust default limit in under 5 minutes
-        return NValgrind::PlainOrUnderValgrind(
-            NSan::PlainOrUnderSanitizer(
-                16 * 1024,
-                1024),
-            1024);
-    }
+    /// Prevent unlimited locks count growth
+    static ui64 LockLimit();
+
+    /// Prevent unlimited range count growth
+    static ui64 LockRangesLimit();
+
+    /// Prevent unlimited number of total ranges
+    static ui64 TotalRangesLimit();
+
+    /// Make it possible to override defaults (e.g. for tests)
+    static void SetLockLimit(ui64 newLimit);
+    static void SetLockRangesLimit(ui64 newLimit);
+    static void SetTotalRangesLimit(ui64 newLimit);
 
     /// We don't expire locks until this time limit after they are created
     static constexpr TDuration LockTimeLimit() { return TDuration::Minutes(5); }
@@ -535,6 +540,7 @@ public:
 
     void AddPointLock(const TLockInfo::TPtr& lock, const TPointKey& key);
     void AddRangeLock(const TLockInfo::TPtr& lock, const TRangeKey& key);
+    void MakeShardLock(TLockInfo* lock);
     void AddShardLock(const TLockInfo::TPtr& lock, TIntrusiveList<TTableLocks, TTableLocksReadListTag>& readTables);
     void AddWriteLock(const TLockInfo::TPtr& lock, TIntrusiveList<TTableLocks, TTableLocksWriteListTag>& writeTables);
 
@@ -592,8 +598,10 @@ public:
 
     void UpdateSchema(const TPathId& tableId, const TVector<NScheme::TTypeInfo>& keyColumnTypes);
     void RemoveSchema(const TPathId& tableId, ILocksDb* db);
-    bool ForceShardLock(const TPathId& tableId) const;
-    bool ForceShardLock(const TIntrusiveList<TTableLocks, TTableLocksReadListTag>& readTables) const;
+    bool ForceShardLock(
+        const TLockInfo::TPtr& lock,
+        const TIntrusiveList<TTableLocks,
+        TTableLocksReadListTag>& readTables, ui64 newRanges);
 
     void ScheduleBrokenLock(TLockInfo* lock);
     void ScheduleRemoveBrokenRanges(ui64 lockId, const TRowVersion& at);
@@ -633,6 +641,8 @@ private:
     THashMap<ui64, TLockInfo::TPtr> Locks; // key is LockId
     THashMap<TPathId, TTableLocks::TPtr> Tables;
     THashSet<ui64> ShardLocks;
+    // A list of locks that have ranges (from oldest to newest)
+    TIntrusiveList<TLockInfo, TLockInfoRangesListTag> LocksWithRanges;
     // A list of locks that may be removed when enough time passes
     TIntrusiveList<TLockInfo, TLockInfoExpireListTag> ExpireQueue;
     // A list of broken, but not yet removed locks


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of changes introduced in this PR -->

Force oldest (not newest) locks into shard locks due to range limits.

### Changelog category <!-- remove all except one -->

* Improvement

### Additional information

Historically datashards forced new locks into whole shard locks when reaching limits on the number of ranges (which incidentally have been the same as the number of locks), which is counter intuitive in the presence of long running read-only transactions that perform joins (and hence lots of point reads), causing very short read-write transactions to repeatedly fail due to unrelated conflicts in the presence of older and wider locks. We prefer forcing oldest locks into shard locks now, which are more likely to break due to conflicts anyway, and may not even cause read-only transactions to fail when they do. Newer locks are now exact (as long as they are small enough), with a significant increase to the maximum number of ranges we support (up to 1M total ranges and 50K per-lock ranges, instead of the previous 16K).

Fixes #10725.