### PR TITLE
Add --backport-to-template functionality

### DIFF
--- a/ydb/tools/cfg/base.py
+++ b/ydb/tools/cfg/base.py
@@ -304,6 +304,7 @@ class ClusterDetailsProvider(object):
         self.table_profiles_config = self.__cluster_description.get("table_profiles_config")
         self.http_proxy_config = self.__cluster_description.get("http_proxy_config")
         self.blob_storage_config = self.__cluster_description.get("blob_storage_config")
+        self.bootstrap_config = self.__cluster_description.get("bootstrap_config")
         self.memory_controller_config = self.__cluster_description.get("memory_controller_config")
         self.s3_proxy_resolver_config = self.__cluster_description.get("s3_proxy_resolver_config")
         self.channel_profile_config = self.__cluster_description.get("channel_profile_config")

--- a/ydb/tools/cfg/bin/__main__.py
+++ b/ydb/tools/cfg/bin/__main__.py
@@ -10,7 +10,7 @@ import yaml
 from ydb.tools.cfg.configurator_setup import get_parser, parse_optional_arguments
 from ydb.tools.cfg.dynamic import DynamicConfigGenerator
 from ydb.tools.cfg.static import StaticConfigGenerator
-from ydb.tools.cfg.utils import write_to_file
+from ydb.tools.cfg.utils import write_to_file, backport
 from ydb.tools.cfg.walle import NopHostsInformationProvider, WalleHostsInformationProvider
 from ydb.tools.cfg.k8s_api import K8sApiHostsInformationProvider
 
@@ -76,6 +76,8 @@ def cfg_generate(args):
     for cfg_name, cfg_value in all_configs.items():
         write_to_file(os.path.join(args.output_dir, cfg_name), cfg_value)
 
+    if args.backport_to_template:
+        backport(args.cluster_description, all_configs["config.yaml"], "blob_storage_config")
 
 def main():
     parser = get_parser(cfg_generate)

--- a/ydb/tools/cfg/bin/__main__.py
+++ b/ydb/tools/cfg/bin/__main__.py
@@ -79,6 +79,7 @@ def cfg_generate(args):
     if args.backport_to_template:
         backport(args.cluster_description, all_configs["config.yaml"], ["blob_storage_config"])
 
+
 def main():
     parser = get_parser(cfg_generate)
     args = parser.parse_args()

--- a/ydb/tools/cfg/bin/__main__.py
+++ b/ydb/tools/cfg/bin/__main__.py
@@ -77,7 +77,7 @@ def cfg_generate(args):
         write_to_file(os.path.join(args.output_dir, cfg_name), cfg_value)
 
     if args.backport_to_template:
-        backport(args.cluster_description, all_configs["config.yaml"], "blob_storage_config")
+        backport(args.cluster_description, all_configs["config.yaml"], ["blob_storage_config"])
 
 def main():
     parser = get_parser(cfg_generate)

--- a/ydb/tools/cfg/configurator_setup.py
+++ b/ydb/tools/cfg/configurator_setup.py
@@ -105,5 +105,9 @@ def get_parser(generate_func, extra_cfg_arguments=[]):
         '--nfs-control', action='store_true', help='Forces cfg command to generate NFS Control configuration'
     )
 
+    parser_cfg.add_argument('--backport-to-template',
+                            action='store_true',
+                            help='Backport blob_storage_config and similar sections to template after generation')
+
     parser_cfg.set_defaults(func=generate_func)
     return parser

--- a/ydb/tools/cfg/static.py
+++ b/ydb/tools/cfg/static.py
@@ -488,7 +488,6 @@ class StaticConfigGenerator(object):
         if self.__cluster_details.s3_proxy_resolver_config is not None:
             normalized_config["s3_proxy_resolver_config"] = self.__cluster_details.s3_proxy_resolver_config
 
-
         if not utils.need_generate_bs_config(self.__cluster_details.blob_storage_config):
             normalized_config["blob_storage_config"] = self.__cluster_details.blob_storage_config
         else:

--- a/ydb/tools/cfg/utils.py
+++ b/ydb/tools/cfg/utils.py
@@ -228,6 +228,7 @@ def backport(template_path, config_yaml, backported_sections):
     with open(template_path, 'w') as file:
         file.writelines(lines)
 
+
 def need_generate_bs_config(template_bs_config):
     # We need to generate blob_storage_config if template file does not contain static group:
     # blob_storage_config.service_set.groups

--- a/ydb/tools/cfg/utils.py
+++ b/ydb/tools/cfg/utils.py
@@ -166,6 +166,10 @@ def wrap_parse_dict(dictionary, proto):
             'NtoSelect': 'NToSelect',
             'Ssid': 'SSId',
             'Sids': 'SIDs',
+            'GroupId': 'GroupID',
+            'NodeId': 'NodeID',
+            'DiskId': 'DiskID',
+            'SlotId': 'SlotID',
         }
         for k, v in abbreviations.items():
             camelCased = camelCased.replace(k, v)
@@ -223,3 +227,12 @@ def backport(template_path, config_yaml, backported_sections):
 
     with open(template_path, 'w') as file:
         file.writelines(lines)
+
+def need_generate_bs_config(template_bs_config):
+    # We need to generate blob_storage_config if template file does not contain static group:
+    # blob_storage_config.service_set.groups
+
+    if template_bs_config is None:
+        return True
+
+    return template_bs_config.get("service_set", {}).get("groups") is None

--- a/ydb/tools/cfg/utils.py
+++ b/ydb/tools/cfg/utils.py
@@ -3,6 +3,7 @@
 import os
 import random
 import string
+import yaml
 
 import six
 from google.protobuf import text_format, json_format
@@ -179,3 +180,46 @@ def wrap_parse_dict(dictionary, proto):
             return data
 
     json_format.ParseDict(convert_keys(dictionary), proto)
+
+
+# This function does some extra work, text processing to ensure no extra diff is
+# created when backporting sections like blob_storage_config. If we parse
+# template file and dump it again, there will be a lot of meaningless diff
+# in formatting, which is undesirable.
+def backport(template_path, config_yaml, backported_sections):
+    config_data = yaml.safe_load(config_yaml)
+
+    with open(template_path, 'r') as file:
+        lines = file.readlines()
+
+    for section_key in backported_sections:
+        section = config_data.get(section_key)
+
+        if section is None:
+            raise KeyError(f"The key '{section_key}' was not found in config_yaml")
+
+        new_section_yaml = yaml.safe_dump({section_key: section}, default_flow_style=False).splitlines(True)
+        new_section_yaml.append(os.linesep)
+
+        start_index = None
+        end_index = None
+
+        for i, line in enumerate(lines):
+            if line.startswith(f"{section_key}:"):
+                start_index = i
+                break
+
+        if start_index is not None:
+            end_index = start_index + 1
+            while end_index < len(lines):
+                line = lines[end_index]
+                if line.strip() and not line.startswith(' ') and not line.startswith('#'):  # Check for a top-level key
+                    break
+                end_index += 1
+
+            lines = lines[:start_index] + new_section_yaml + lines[end_index:]
+        else:
+            lines.extend(new_section_yaml)
+
+    with open(template_path, 'w') as file:
+        file.writelines(lines)


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

- added option `--backport-to-template` to ydb_configure

### Changelog category <!-- remove all except one -->

* New feature

### Description for reviewers <!-- (optional) description for those who read this PR -->

- `--backport-to-template`: new boolean flag that will attempt to add generated `blob_storage_config` into `cluster_config_template.yaml` so you don't have to do it by hand. It will do it without excessive diff, template formatting will be kept, only the `blob_storage_config` section will be changed
- added support for `bootstrap_config`, now this can be specified in `config.yaml` directly:
```
bootstrap_config:
  shared_cache_config:
    memory_limit: 100000000000
```
Earlier, `template.yaml` format was different, just like for many other options:
```
shared_cache:
  memory_limit: 200000000000

```
 
- it is now possible to specify `blob_storage_config` without a static group, and ydb_configure will correctly keep those settings while generating a static group. For example:
```
blob_storage_config:
  vdisk_performance_settings:
    vdisk_types:
    - min_huge_blob_size_in_bytes: 100000
      pdisk_type: ROT
    - min_huge_blob_size_in_bytes: 100000
      pdisk_type: UNKNOWN_TYPE
```

will turn into

```
blob_storage_config:
  service_set: # generated service_set
    availability_domains:
    - '1'
    groups:
    - erasure_species: 4
      group_generation: 1
      group_id: 0
      rings:
      - fail_domains:
        - vdisk_locations:
          - node_id: 1
            path: /dev/disk/by-partlabel/ydb_disk_ssd_01_01
            pdisk_category: 1
            pdisk_guid: 8882996296504668847
            pdisk_id: 1
...
        - vdisk_locations:
          - node_id: 8
            path: /dev/disk/by-partlabel/ydb_disk_ssd_01_01
            pdisk_category: 1
            pdisk_guid: 17495542895019359475
            pdisk_id: 1
  vdisk_performance_settings: # kept this from template
    vdisk_types:
    - min_huge_blob_size_in_bytes: 100000
      pdisk_type: ROT
    - min_huge_blob_size_in_bytes: 100000
      pdisk_type: UNKNOWN_TYPE
```
