### PR TITLE
Revert "Make DEFAULT_EVENTS_PER_MAILBOX unreachable (#14843)"

### DIFF
--- a/ydb/library/actors/core/config.h
+++ b/ydb/library/actors/core/config.h
@@ -13,7 +13,7 @@ namespace NActors {
 
     struct TBasicExecutorPoolConfig {
         static constexpr TDuration DEFAULT_TIME_PER_MAILBOX = TDuration::MilliSeconds(10);
-        static constexpr ui32 DEFAULT_EVENTS_PER_MAILBOX = 1'000'000;
+        static constexpr ui32 DEFAULT_EVENTS_PER_MAILBOX = 100;
 
         ui32 PoolId = 0;
         TString PoolName;


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

- **revert and merge in stable-25-1-1** https://github.com/ydb-platform/ydb/pull/15489
- **revert and merge in stable 25-1**  https://github.com/ydb-platform/ydb/pull/15509

To fix perfomance regression in stable-25-1
https://github.com/ydb-platform/ydb/issues/15185#issue-2886831039

Result after revert
|cluster_monitoring|repository|git_branch|run_type|run_start_datetime|git_sha|git_commit_timestamp|duration sec|warehouses|tpmC|efficiency|newOrder90p|
|:-|:-:|:-:|:-:|:-:|:-:|:-:|:-:|:-:|:-:|:-:|-:|
|[monium](https://nda.ya.ru/t/QfjkNjxs7Cc8Tt)|ydb-platform/ydb|origin/main|25_1_1_and_main_revert_14843|09.03.2025 21:51:44|926459d8|08.03.2025 20:13:18|7200|16000|🟢 204806|99.54| 🟢 112|

Before revert
|cluster_monitoring|repository|git_branch|run_type|run_start_datetime|git_sha|git_commit_timestamp|duration sec|warehouses|tpmC|efficiency|newOrder90p|
|:-|:-:|:-:|:-:|:-:|:-:|:-:|:-:|:-:|:-:|:-:|-:|
|[monium](https://nda.ya.ru/t/hXbKqgNC7CZp6k)|ydb-platform/ydb|origin/main|EnableLocalDBBtreeIndex-false|08.03.2025 02:08:37|2b1cfa76|20.02.2025 18:07:12|10800|16000|🔴 201910|98.13| 🔴  750|


Reverts ydb-platform/ydb#14843

revert in stable 25-1 https://github.com/ydb-platform/ydb/pull/15509
revert in stable 25-1-1 https://github.com/ydb-platform/ydb/pull/15489



### Changelog category <!-- remove all except one -->

* Not for changelog (changelog entry is not required)


### Description for reviewers <!-- (optional) description for those who read this PR -->

...


