### PR TITLE
Revert "Make DEFAULT_EVENTS_PER_MAILBOX unreachable (#14843)" to stable 25-1-1

### DIFF
--- a/ydb/library/actors/core/config.h
+++ b/ydb/library/actors/core/config.h
@@ -13,7 +13,7 @@ namespace NActors {
 
     struct TBasicExecutorPoolConfig {
         static constexpr TDuration DEFAULT_TIME_PER_MAILBOX = TDuration::MilliSeconds(10);
-        static constexpr ui32 DEFAULT_EVENTS_PER_MAILBOX = 1'000'000;
+        static constexpr ui32 DEFAULT_EVENTS_PER_MAILBOX = 100;
 
         ui32 PoolId = 0;
         TString PoolName;


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

- **revert and merge in main**  https://github.com/ydb-platform/ydb/pull/15488
- **revert and merge in stable 25-1**  https://github.com/ydb-platform/ydb/pull/15509

To fix perfomance regression in stable-25-1
https://github.com/ydb-platform/ydb/issues/15185#issue-2886831039

Result in stable-25-1-1
|cluster_monitoring|branch|timestamp|git_commit_timestamp|git_sha|tpmC|newOrderLatency90|efficiency|
|:-|:-:|:-:|:-:|:-:|:-:|:-:|-:|
|[monium](https://nda.ya.ru/t/41NQkLBj7CctpN)|stable-25-1|06.03.2025 21:24:52|06.03.2025 14:59:34|3381008e| 🔴 203494| 🔴  508|98.9|

Result in revert 
|cluster_monitoring|repository|git_branch|run_type|run_start_datetime|git_sha|git_commit_timestamp|duration sec|warehouses|tpmC|efficiency|newOrder90p|
|:-|:-:|:-:|:-:|:-:|:-:|:-:|:-:|:-:|:-:|:-:|-:|
|[monium](https://nda.ya.ru/t/Cl66a-OC7Cctn7)|ydb-platform/ydb|origin/main|25_1_1_and_main_revert_14843|10.03.2025 01:49:44|c2a927f1|09.03.2025 12:59:34|7200|16000| 🟢 205038|99.65| 🟢  100|

Revert "Make DEFAULT_EVENTS_PER_MAILBOX unreachable (#14843)

### Changelog category <!-- remove all except one -->

* Not for changelog (changelog entry is not required)


### Description for reviewers <!-- (optional) description for those who read this PR -->

...
