### PR TITLE
Fix uninitialized value in BSC

### DIFF
--- a/ydb/core/mind/bscontroller/bsc.cpp
+++ b/ydb/core/mind/bscontroller/bsc.cpp
@@ -302,7 +302,7 @@ void TBlobStorageController::ApplyStorageConfig(bool ignoreDistconf) {
         return; // not expected to be managed by BSC
     }
 
-    ui64 expectedBoxId;
+    ui64 expectedBoxId = 1;
     std::optional<ui64> generation;
     bool needToDefineBox = true;
     if (!Boxes.empty()) {


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

Fix uninitialized value in BSC

### Changelog category <!-- remove all except one -->

* Not for changelog (changelog entry is not required)

### Description for reviewers <!-- (optional) description for those who read this PR -->

Fixed default box id in BSC.
