### PR TITLE
Fix macro name ALLOW_MEMORY_ALLOCATOR → ALLOW_DEFAULT_ALLOCATOR

### DIFF
--- a/yql/essentials/minikql/mkql_alloc.cpp
+++ b/yql/essentials/minikql/mkql_alloc.cpp
@@ -309,7 +309,7 @@ void MKQLArrowFree(const void* mem, ui64 size) {
 
     Y_ENSURE(size == header->Size);
 
-#if defined(ALLOW_MEMORY_ALLOCATOR)
+#if defined(ALLOW_DEFAULT_ALLOCATOR)
     if (Y_UNLIKELY(TAllocState::IsDefaultAllocatorUsed())) {
         free(header);
         return;


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

Original commit 2588470476adc99d13bddfd544ed5c9123e7242b