### PR TITLE
Enable XDC by default, fix ut to use XDC transfers

### DIFF
--- a/ydb/core/protos/config.proto
+++ b/ydb/core/protos/config.proto
@@ -450,7 +450,7 @@ message TInterconnectConfig {
     optional bool SuppressConnectivityCheck = 39 [default = false];
     optional uint32 PreallocatedBufferSize = 40;
     optional uint32 NumPreallocatedBuffers = 41;
-    optional bool EnableExternalDataChannel = 42;
+    optional bool EnableExternalDataChannel = 42 [default = true];
     optional bool ValidateIncomingPeerViaDirectLookup = 44;
     optional uint32 SocketBacklogSize = 45; // SOMAXCONN if not set or zero
 

--- a/ydb/library/actors/interconnect/interconnect_common.h
+++ b/ydb/library/actors/interconnect/interconnect_common.h
@@ -49,7 +49,7 @@ namespace NActors {
         ui32 MaxSerializedEventSize = NActors::EventMaxByteSize;
         ui32 PreallocatedBufferSize = 8 << 10; // 8 KB
         ui32 NumPreallocatedBuffers = 16;
-        bool EnableExternalDataChannel = false;
+        bool EnableExternalDataChannel = true;
         bool ValidateIncomingPeerViaDirectLookup = false;
         ui32 SocketBacklogSize = 0; // SOMAXCONN if zero
         TDuration FirstErrorSleep = TDuration::MilliSeconds(10);

--- a/ydb/library/actors/interconnect/ut/lib/test_events.h
+++ b/ydb/library/actors/interconnect/ut/lib/test_events.h
@@ -15,6 +15,10 @@ namespace NActors {
     struct TEvTest : TEventPB<TEvTest, NInterconnectTest::TEvTest, EvTest> {
         TEvTest() = default;
 
+        explicit TEvTest(ui64 sequenceNumber) {
+            Record.SetSequenceNumber(sequenceNumber);
+        }
+
         TEvTest(ui64 sequenceNumber, const TString& payload) {
             Record.SetSequenceNumber(sequenceNumber);
             Record.SetPayload(payload);

--- a/ydb/library/actors/interconnect/ut/protos/interconnect_test.proto
+++ b/ydb/library/actors/interconnect/ut/protos/interconnect_test.proto
@@ -2,7 +2,11 @@ package NInterconnectTest;
 
 message TEvTest {
     optional uint64 SequenceNumber = 1;
-    optional bytes Payload = 2;
+    optional uint64 DataCrc = 2;
+    oneof Data {
+        bytes Payload = 3;
+        uint32 PayloadId = 4;
+    }
 }
 
 message TEvTestChan {

--- a/ydb/library/yql/providers/dq/config/config.proto
+++ b/ydb/library/yql/providers/dq/config/config.proto
@@ -25,7 +25,7 @@ message TDqConfig {
         optional uint64 MessagePendingTimeoutMs = 15 [default = 5000];
         optional uint64 MessagePendingSize = 16 [default = 18446744073709551615];
         optional uint32 MaxSerializedEventSize = 17 [default = 67108000];
-        optional bool EnableExternalDataChannel = 27 [default = true];
+        optional bool EnableExternalDataChannel = 27 [default = false];
 
         // Scheduler
         optional uint64 ResolutionMicroseconds = 18 [default = 1024];

--- a/ydb/library/yql/providers/dq/config/config.proto
+++ b/ydb/library/yql/providers/dq/config/config.proto
@@ -25,7 +25,7 @@ message TDqConfig {
         optional uint64 MessagePendingTimeoutMs = 15 [default = 5000];
         optional uint64 MessagePendingSize = 16 [default = 18446744073709551615];
         optional uint32 MaxSerializedEventSize = 17 [default = 67108000];
-        optional bool EnableExternalDataChannel = 27 [default = false];
+        optional bool EnableExternalDataChannel = 27 [default = true];
 
         // Scheduler
         optional uint64 ResolutionMicroseconds = 18 [default = 1024];


### PR DESCRIPTION
### Changelog entry

XDC allows to send huge events without splitting into small IC chunks.

### Changelog category <!-- remove all except one -->

* Performance improvement


### Description for reviewers <!-- (optional) description for those who read this PR -->

...
