### PR TITLE
fix tabletid in TBuildSlicesTask

### DIFF
--- a/ydb/core/tx/columnshard/operations/slice_builder/builder.h
+++ b/ydb/core/tx/columnshard/operations/slice_builder/builder.h
@@ -28,7 +28,7 @@ public:
     TBuildSlicesTask(NEvWrite::TWriteData&& writeData, const std::shared_ptr<arrow::RecordBatch>& batch,
         const TWritingContext& context)
         : WriteData(std::move(writeData))
-        , TabletId(WriteData.GetWriteMeta().GetTableId())
+        , TabletId(context.GetTabletId())
         , OriginalBatch(batch)
         , Context(context) {
         WriteData.MutableWriteMeta().OnStage(NEvWrite::EWriteStage::BuildSlices);


### PR DESCRIPTION
### Changelog category <!-- remove all except one -->
* Bugfix 

### Additional info
TabletId in TWriteActor was initialized by a table pathId. Had now impact as TabletId in TWriteActor is used only for logging