### PR TITLE
stable-25-1-1: set previous stable as 24-4 for tests

### DIFF
--- a/ydb/tests/library/compatibility/ya.make
+++ b/ydb/tests/library/compatibility/ya.make
@@ -1,7 +1,7 @@
 UNION()
 
 RUN_PROGRAM(
-    ydb/tests/library/compatibility/downloader stable-24-3/release/ydbd ydbd-last-stable
+    ydb/tests/library/compatibility/downloader stable-24-4/release/ydbd ydbd-last-stable
     OUT_NOAUTO ydbd-last-stable
 )
 


### PR DESCRIPTION
It is used in https://github.com/ydb-platform/ydb/tree/main/ydb/tests/functional/compatibility