### PR TITLE
Revert "Column Shard Bytes Time Series (#15423)"

### DIFF
--- a/ydb/core/kqp/compute_actor/kqp_scan_compute_actor.cpp
+++ b/ydb/core/kqp/compute_actor/kqp_scan_compute_actor.cpp
@@ -80,9 +80,7 @@ void TKqpScanComputeActor::AcquireRateQuota() {
 }
 
 void TKqpScanComputeActor::FillExtraStats(NDqProto::TDqComputeActorStats* dst, bool last) {
-    Y_UNUSED(last);
-
-    if (ScanData && dst->TasksSize() > 0) {
+    if (last && ScanData && dst->TasksSize() > 0) {
         YQL_ENSURE(dst->TasksSize() == 1);
 
         auto* taskStats = dst->MutableTasks(0);
@@ -98,24 +96,22 @@ void TKqpScanComputeActor::FillExtraStats(NDqProto::TDqComputeActorStats* dst, b
         tableStats->SetTablePath(ScanData->TablePath);
 
         if (auto* stats = ScanData->BasicStats.get()) {
-            if (RuntimeSettings.StatsMode >= NYql::NDqProto::DQ_STATS_MODE_FULL) {
-                ingressStats.SetRows(stats->Rows);
-                ingressStats.SetBytes(stats->Bytes);
-                ingressStats.SetFirstMessageMs(stats->FirstMessageMs);
-                ingressStats.SetLastMessageMs(stats->LastMessageMs);
+            ingressStats.SetRows(stats->Rows);
+            ingressStats.SetBytes(stats->Bytes);
+            ingressStats.SetFirstMessageMs(stats->FirstMessageMs);
+            ingressStats.SetLastMessageMs(stats->LastMessageMs);
 
-                for (auto& [shardId, stat] : stats->ExternalStats) {
-                    auto& externalStat = *sourceStats.AddExternalPartitions();
-                    externalStat.SetPartitionId(ToString(shardId));
-                    externalStat.SetExternalRows(stat.ExternalRows);
-                    externalStat.SetExternalBytes(stat.ExternalBytes);
-                    externalStat.SetFirstMessageMs(stat.FirstMessageMs);
-                    externalStat.SetLastMessageMs(stat.LastMessageMs);
-                }
-
-                taskStats->SetIngressRows(taskStats->GetIngressRows() + stats->Rows);
-                taskStats->SetIngressBytes(taskStats->GetIngressBytes() + stats->Bytes);
+            for (auto& [shardId, stat] : stats->ExternalStats) {
+                auto& externalStat = *sourceStats.AddExternalPartitions();
+                externalStat.SetPartitionId(ToString(shardId));
+                externalStat.SetExternalRows(stat.ExternalRows);
+                externalStat.SetExternalBytes(stat.ExternalBytes);
+                externalStat.SetFirstMessageMs(stat.FirstMessageMs);
+                externalStat.SetLastMessageMs(stat.LastMessageMs);
             }
+
+            taskStats->SetIngressRows(taskStats->GetIngressRows() + stats->Rows);
+            taskStats->SetIngressBytes(taskStats->GetIngressBytes() + stats->Bytes);
 
             tableStats->SetReadRows(stats->Rows);
             tableStats->SetReadBytes(stats->Bytes);

--- a/ydb/core/kqp/executer_actor/kqp_executer_stats.h
+++ b/ydb/core/kqp/executer_actor/kqp_executer_stats.h
@@ -23,39 +23,10 @@ struct TTimeSeriesStats {
     std::vector<std::pair<ui64, ui64>> History;
 
     void ExportHistory(ui64 baseTimeMs, NYql::NDqProto::TDqStatsAggr& stats);
-    void ExportAggStats(NYql::NDqProto::TDqStatsAggr& stats);
     void ExportAggStats(ui64 baseTimeMs, NYql::NDqProto::TDqStatsAggr& stats);
-    void Resize(ui32 count);
-    void SetNonZero(ui32 index, ui64 value);
-    void Pack();
-    void AppendHistory();
-};
-
-struct TPartitionedStats : public TTimeSeriesStats {
-    std::vector<std::vector<ui64>> Parts;
-
-    void ResizeByTasks(ui32 taskCount);
-    void ResizeByParts(ui32 partCount, ui32 taskCount);
-    void SetNonZero(ui32 taskIndex, ui32 partIndex, ui64 value, bool recordTimeSeries);
-};
-
-struct TTimeMultiSeriesStats {
-    std::unordered_map<TString, ui32> Indices;
-    ui32 TaskCount = 0;
-    ui32 PartCount = 0;
-
-    void SetNonZero(TPartitionedStats& stats, ui32 taskIndex, const TString& key, ui64 value, bool recordTimeSeries);
-};
-
-struct TExternalStats : public TTimeMultiSeriesStats {
-    TPartitionedStats ExternalRows;
-    TPartitionedStats ExternalBytes;
-    TPartitionedStats FirstMessageMs;
-    TPartitionedStats LastMessageMs;
-
     void Resize(ui32 taskCount);
-    void SetHistorySampleCount(ui32 historySampleCount);
-    void ExportHistory(ui64 baseTimeMs, NYql::NDqProto::TDqExternalAggrStats& stats);
+    void SetNonZero(ui32 taskIndex, ui64 value);
+    void Pack();
 };
 
 struct TMetricInfo {
@@ -109,7 +80,6 @@ struct TAsyncBufferStats {
         Resize(taskCount);
     }
 
-    TExternalStats External;
     TAsyncStats Ingress;
     TAsyncStats Push;
     TAsyncStats Pop;
@@ -209,8 +179,8 @@ struct TStageExecutionStats {
     std::map<TString, TTableStats> Tables;
     std::map<TString, TAsyncBufferStats> Ingress;
     std::map<TString, TAsyncBufferStats> Egress;
-    std::unordered_map<ui32, TAsyncBufferStats> Input;
-    std::unordered_map<ui32, TAsyncBufferStats> Output;
+    std::map<ui32, TAsyncBufferStats> Input;
+    std::map<ui32, TAsyncBufferStats> Output;
 
     std::map<TString, TOperatorStats> Joins;
     std::map<TString, TOperatorStats> Filters;


### PR DESCRIPTION
This reverts commit a69244babdeaed394b284e6ae7d3f17f83d6fafa.

В нем найдены падения на перфомансе тестировании.

https://github.com/ydb-platform/ydb/issues/15598
