### PR TITLE
25-1: Refactor cache miss in `DynamicNameserver` to use one pipe

### DIFF
--- a/ydb/core/base/tablet_pipe.h
+++ b/ydb/core/base/tablet_pipe.h
@@ -141,6 +141,18 @@ namespace NKikimr {
                 , VersionInfo(std::move(versionInfo))
             {}
 
+            TString ToString() const override {
+                return TStringBuilder() << ToStringHeader() << " {"
+                    << " TabletId: " << TabletId
+                    << " Status: " << Status
+                    << " ServerId: " << ServerId
+                    << " Leader: " << Leader
+                    << " Dead: " << Dead
+                    << " Generation: " << Generation
+                    << " VersionInfo: " << VersionInfo
+                << " }";
+            }
+
             const ui64 TabletId;
             const NKikimrProto::EReplyStatus Status;
             const TActorId ClientId;
@@ -172,6 +184,14 @@ namespace NKikimr {
                 , ClientId(clientId)
                 , ServerId(serverId)
             {}
+
+            TString ToString() const override {
+                return TStringBuilder() << ToStringHeader() << " {"
+                    << " TabletId: " << TabletId
+                    << " ClientId: " << ClientId
+                    << " ServerId: " << ServerId
+                << " }";
+            }
 
             const ui64 TabletId;
             const TActorId ClientId;

--- a/ydb/core/mind/dynamic_nameserver.cpp
+++ b/ydb/core/mind/dynamic_nameserver.cpp
@@ -17,112 +17,175 @@ static void ResetInterconnectProxyConfig(ui32 nodeId, const TActorContext &ctx)
     ctx.Send(aid, new TEvInterconnect::TEvDisconnect);
 }
 
-void TDynamicNodeResolverBase::Bootstrap(const TActorContext &ctx)
-{
-    auto dinfo = AppData(ctx)->DomainsInfo;
+template<typename TCacheMiss>
+class TActorCacheMiss : public TActor<TActorCacheMiss<TCacheMiss>>, public TCacheMiss {
+public:
+    using TThis = TActorCacheMiss<TCacheMiss>;
+    using TActorBase = TActor<TThis>;
 
-    NTabletPipe::TClientRetryPolicy retryPolicy = {
-        .RetryLimitCount = 12,
-        .MinRetryTime = TDuration::MilliSeconds(50),
-        .MaxRetryTime = TDuration::Seconds(2)
-    };
-
-    auto pipe = NTabletPipe::CreateClient(ctx.SelfID, MakeNodeBrokerID(), NTabletPipe::TClientConfig(retryPolicy));
-    NodeBrokerPipe = ctx.RegisterWithSameMailbox(pipe);
-
-    TAutoPtr<TEvNodeBroker::TEvResolveNode> request = new TEvNodeBroker::TEvResolveNode;
-    request->Record.SetNodeId(NodeId);
-    NTabletPipe::SendData(ctx, NodeBrokerPipe, request.Release());
-
-    Become(&TDynamicNodeResolverBase::StateWork);
-    if (Deadline != TInstant::Max()) {
-        Schedule(Deadline, new TEvents::TEvWakeup);
-    }
-}
-
-void TDynamicNodeResolverBase::Die(const TActorContext &ctx)
-{
-    if (NodeBrokerPipe)
-        NTabletPipe::CloseClient(ctx, NodeBrokerPipe);
-    TBase::Die(ctx);
-}
-
-void TDynamicNodeResolverBase::ReplyWithErrorAndDie(const TActorContext &ctx)
-{
-    OnError(ctx);
-    Die(ctx);
-}
-
-void TDynamicNodeResolverBase::Handle(TEvNodeBroker::TEvResolvedNode::TPtr &ev, const TActorContext &ctx)
-{
-    auto &rec = ev->Get()->Record;
-    TDynamicConfig::TDynamicNodeInfo oldNode;
-    auto it = Config->DynamicNodes.find(NodeId);
-    bool exists = it != Config->DynamicNodes.end();
-
-    if (exists) {
-        oldNode = it->second;
-        Config->DynamicNodes.erase(it);
+    static constexpr NKikimrServices::TActivity::EType ActorActivityType() {
+        return NKikimrServices::TActivity::NAMESERVICE;
     }
 
-    if (rec.GetStatus().GetCode() != NKikimrNodeBroker::TStatus::OK) {
-        // Reset proxy if node expired.
-        if (exists) {
-            ResetInterconnectProxyConfig(NodeId, ctx);
-            ListNodesCache->Invalidate(); // node was erased
+    TActorCacheMiss(TDynamicNameserver* owner, ui32 nodeId, TDynamicConfigPtr config,
+                    TIntrusivePtr<TListNodesCache> listNodesCache,
+                    TAutoPtr<IEventHandle> origRequest, TMonotonic deadline)
+        : TActorBase(&TThis::StateWork)
+        , TCacheMiss(nodeId, config, origRequest, deadline)
+        , Owner(owner)
+        , ListNodesCache(listNodesCache)
+    {
+    }
+
+    STFUNC(StateWork) {
+        switch (ev->GetTypeRewrite()) {
+            HFunc(TEvNodeBroker::TEvResolvedNode, Handle);
         }
-        ReplyWithErrorAndDie(ctx);
-        return;
     }
 
-    TDynamicConfig::TDynamicNodeInfo node(rec.GetNode());
-    if (!exists || !oldNode.EqualExceptExpire(node)) {
-        ListNodesCache->Invalidate();
+    void SendRequest() {
+        Owner->OpenPipe(Config->NodeBrokerPipe);
+        TAutoPtr<TEvNodeBroker::TEvResolveNode> request = new TEvNodeBroker::TEvResolveNode;
+        request->Record.SetNodeId(NodeId);
+        NTabletPipe::SendData(TActorBase::SelfId(), Config->NodeBrokerPipe, request.Release());
     }
 
-    // If ID is re-used by another node then proxy has to be reset.
-    if (exists && !oldNode.EqualExceptExpire(node))
-        ResetInterconnectProxyConfig(NodeId, ctx);
-    Config->DynamicNodes.emplace(NodeId, node);
+    void OnSuccess(const TActorContext &ctx) override {
+        TCacheMiss::OnSuccess(ctx);
+        TActorBase::PassAway();
+    }
 
-    OnSuccess(ctx);
-    Die(ctx);
-}
+    void OnError(const TString& error, const TActorContext &ctx) override {
+        TCacheMiss::OnError(error, ctx);
+        TActorBase::PassAway();
+    }
 
-void TDynamicNodeResolverBase::Handle(TEvTabletPipe::TEvClientConnected::TPtr &ev, const TActorContext &ctx)
+private:
+    using TCacheMiss::Config;
+    using TCacheMiss::NodeId;
+
+    void Handle(TEvNodeBroker::TEvResolvedNode::TPtr &ev, const TActorContext &ctx) {
+        LOG_D("Handle " << ev->Get()->ToString());
+        
+        Config->PendingCacheMisses.Remove(this);
+
+        TDynamicConfig::TDynamicNodeInfo oldNode;
+        auto it = Config->DynamicNodes.find(NodeId);
+        bool exists = it != Config->DynamicNodes.end();
+
+        if (exists) {
+            oldNode = it->second;
+            this->Config->DynamicNodes.erase(it);
+        }
+
+        auto &rec = ev->Get()->Record;
+        if (rec.GetStatus().GetCode() != NKikimrNodeBroker::TStatus::OK) {
+            // Reset proxy if node expired.
+            if (exists) {
+                ResetInterconnectProxyConfig(NodeId, ctx);
+                ListNodesCache->Invalidate(); // node was erased
+            }
+            OnError(rec.GetStatus().GetReason(), ctx);
+            return;
+        }
+
+        TDynamicConfig::TDynamicNodeInfo node(rec.GetNode());
+        if (!exists || !oldNode.EqualExceptExpire(node)) {
+            ListNodesCache->Invalidate();
+        }
+
+        // If ID is re-used by another node then proxy has to be reset.
+        if (exists && !oldNode.EqualExceptExpire(node))
+            ResetInterconnectProxyConfig(NodeId, ctx);
+        Config->DynamicNodes.emplace(NodeId, node);
+
+        OnSuccess(ctx);
+    }
+
+    TDynamicNameserver* Owner;
+    TIntrusivePtr<TListNodesCache> ListNodesCache;
+};
+
+TCacheMiss::TCacheMiss(ui32 nodeId, TDynamicConfigPtr config, TAutoPtr<IEventHandle> origRequest, TMonotonic deadline)
+    : NodeId(nodeId)
+    , Deadline(deadline)
+    , NeedScheduleDeadline(Deadline != TMonotonic::Max())
+    , Config(config)
+    , OrigRequest(origRequest)
 {
-    if (ev->Get()->Status != NKikimrProto::OK)
-        ReplyWithErrorAndDie(ctx);
 }
 
-void TDynamicNodeResolver::OnSuccess(const TActorContext &ctx)
-{
-    ctx.Send(OrigRequest);
+void TCacheMiss::OnSuccess(const TActorContext &) {
+    LOG_D("Cache miss succeed"
+        << ": nodeId=" << NodeId);
 }
 
-void TDynamicNodeResolver::OnError(const TActorContext &ctx)
-{
-    auto reply = new TEvLocalNodeInfo;
-    reply->NodeId = NodeId;
-    ctx.Send(OrigRequest->Sender, reply);
+void TCacheMiss::OnError(const TString &error, const TActorContext &) {
+    LOG_D("Cache miss failed"
+        << ": nodeId=" << NodeId
+        << ", error=" << error);
 }
 
-void TDynamicNodeSearcher::OnSuccess(const TActorContext &ctx)
-{
-    THolder<TEvInterconnect::TEvNodeInfo> reply(new TEvInterconnect::TEvNodeInfo(NodeId));
-    auto it = Config->DynamicNodes.find(NodeId);
-    if (it != Config->DynamicNodes.end())
-        reply->Node = MakeHolder<TEvInterconnect::TNodeInfo>(it->first, it->second.Address,
-                                                     it->second.Host, it->second.ResolveHost,
-                                                     it->second.Port, it->second.Location);
-    ctx.Send(OrigRequest->Sender, reply.Release());
+size_t& TCacheMiss::THeapIndexByDeadline::operator()(TCacheMiss& cacheMiss) const {
+    return cacheMiss.DeadlineHeapIndex;
 }
 
-void TDynamicNodeSearcher::OnError(const TActorContext &ctx)
-{
-    THolder<TEvInterconnect::TEvNodeInfo> reply(new TEvInterconnect::TEvNodeInfo(NodeId));
-    ctx.Send(OrigRequest->Sender, reply.Release());
+bool TCacheMiss::TCompareByDeadline::operator()(const TCacheMiss& a, const TCacheMiss& b) const {
+    return a.Deadline < b.Deadline;
 }
+
+class TCacheMissGet : public TCacheMiss {
+public:
+    using TBase = TCacheMiss;
+
+    TCacheMissGet(ui32 nodeId, TDynamicConfigPtr config, TAutoPtr<IEventHandle> origRequest, TMonotonic deadline)
+        : TCacheMiss(nodeId, config, origRequest, deadline)
+    {
+    }
+
+    void OnSuccess(const TActorContext &ctx) override {
+        TBase::OnSuccess(ctx);
+
+        THolder<TEvInterconnect::TEvNodeInfo> reply(new TEvInterconnect::TEvNodeInfo(NodeId));
+        auto it = Config->DynamicNodes.find(NodeId);
+        if (it != Config->DynamicNodes.end())
+            reply->Node = MakeHolder<TEvInterconnect::TNodeInfo>(it->first, it->second.Address,
+                                                         it->second.Host, it->second.ResolveHost,
+                                                         it->second.Port, it->second.Location);
+        ctx.Send(OrigRequest->Sender, reply.Release());
+    }
+
+    void OnError(const TString &error, const TActorContext &ctx) override {
+        TBase::OnError(error, ctx);
+
+        THolder<TEvInterconnect::TEvNodeInfo> reply(new TEvInterconnect::TEvNodeInfo(NodeId));
+        ctx.Send(OrigRequest->Sender, reply.Release());
+    }
+};
+
+class TCacheMissResolve : public TCacheMiss {
+public:
+    using TBase = TCacheMiss;
+
+    TCacheMissResolve(ui32 nodeId, TDynamicConfigPtr config, TAutoPtr<IEventHandle> origRequest, TMonotonic deadline)
+        : TCacheMiss(nodeId, config, origRequest, deadline)
+    {
+    }
+
+    void OnSuccess(const TActorContext &ctx) override {
+        TBase::OnSuccess(ctx);
+
+        ctx.Send(OrigRequest);
+    }
+
+    void OnError(const TString &error, const TActorContext &ctx) override {
+        TBase::OnError(error, ctx);
+
+        auto reply = new TEvLocalNodeInfo;
+        reply->NodeId = NodeId;
+        ctx.Send(OrigRequest->Sender, reply);
+    }
+};
 
 void TDynamicNameserver::Bootstrap(const TActorContext &ctx)
 {
@@ -180,35 +243,46 @@ void TDynamicNameserver::ReplaceNameserverSetup(TIntrusivePtr<TTableNameserverSe
 
 void TDynamicNameserver::Die(const TActorContext &ctx)
 {
-    for (auto &pipe : NodeBrokerPipes) {
-        if (pipe)
-            NTabletPipe::CloseClient(ctx, pipe);
+    for (auto &config : DynamicConfigs) {
+        if (config->NodeBrokerPipe)
+            NTabletPipe::CloseClient(ctx, config->NodeBrokerPipe);
     }
     TBase::Die(ctx);
 }
 
-void TDynamicNameserver::OpenPipe(ui32 domain,
-                                  const TActorContext &ctx)
+void TDynamicNameserver::OpenPipe(ui32 domain)
 {
-    if (!NodeBrokerPipes[domain]) {
-        auto pipe = NTabletPipe::CreateClient(ctx.SelfID, MakeNodeBrokerID());
-        NodeBrokerPipes[domain] = ctx.RegisterWithSameMailbox(pipe);
+    OpenPipe(DynamicConfigs[domain]->NodeBrokerPipe);
+}
+
+void TDynamicNameserver::OpenPipe(TActorId& pipe)
+{
+    if (!pipe) {
+        pipe = RegisterWithSameMailbox(NTabletPipe::CreateClient(SelfId(), MakeNodeBrokerID()));
     }
+}
+
+size_t TDynamicNameserver::GetTotalPendingCacheMissesSize() const {
+    size_t total = 0;
+    for (const auto &config : DynamicConfigs) {
+        total += config->PendingCacheMisses.Size();
+    }
+    return total;
 }
 
 void TDynamicNameserver::RequestEpochUpdate(ui32 domain,
                                             ui32 epoch,
                                             const TActorContext &ctx)
 {
-    OpenPipe(domain, ctx);
+    OpenPipe(domain);
 
     TAutoPtr<TEvNodeBroker::TEvListNodes> request = new TEvNodeBroker::TEvListNodes;
     request->Record.SetMinEpoch(epoch);
-    NTabletPipe::SendData(ctx, NodeBrokerPipes[domain], request.Release());
+    NTabletPipe::SendData(ctx, DynamicConfigs[domain]->NodeBrokerPipe, request.Release());
     EpochUpdates[domain] = epoch;
 }
 
-void TDynamicNameserver::ResolveStaticNode(ui32 nodeId, TActorId sender, TInstant deadline, const TActorContext &ctx)
+void TDynamicNameserver::ResolveStaticNode(ui32 nodeId, TActorId sender, TMonotonic deadline, const TActorContext &ctx)
 {
     auto it = StaticConfig->StaticNodeTable.find(nodeId);
 
@@ -224,7 +298,7 @@ void TDynamicNameserver::ResolveStaticNode(ui32 nodeId, TActorId sender, TInstan
 
 void TDynamicNameserver::ResolveDynamicNode(ui32 nodeId,
                                             TAutoPtr<IEventHandle> ev,
-                                            TInstant deadline,
+                                            TMonotonic deadline,
                                             const TActorContext &ctx)
 {
     ui32 domain = AppData()->DomainsInfo->GetDomain()->DomainUid;
@@ -240,8 +314,11 @@ void TDynamicNameserver::ResolveDynamicNode(ui32 nodeId,
         reply->NodeId = nodeId;
         ctx.Send(ev->Sender, reply);
     } else {
-        ctx.RegisterWithSameMailbox(new TDynamicNodeResolver(SelfId(), nodeId, DynamicConfigs[domain],
-            ListNodesCache, ev, deadline));
+        auto* actor = new TActorCacheMiss<TCacheMissResolve>(this, nodeId, DynamicConfigs[domain],
+            ListNodesCache, ev, deadline);
+        RegisterWithSameMailbox(actor);
+        actor->SendRequest();
+        RegisterNewCacheMiss(actor, DynamicConfigs[domain]);
     }
 }
 
@@ -346,10 +423,9 @@ void TDynamicNameserver::UpdateState(const NKikimrNodeBroker::TNodesInfo &rec,
     }
 }
 
-void TDynamicNameserver::OnPipeDestroyed(ui32 domain,
-                                         const TActorContext &ctx)
+void TDynamicNameserver::OnPipeDestroyed(ui32 domain, const TActorContext &ctx)
 {
-    NodeBrokerPipes[domain] = TActorId();
+    DynamicConfigs[domain]->NodeBrokerPipe = TActorId();
     PendingRequestAnswered(domain, ctx);
 
     if (EpochUpdates.contains(domain)) {
@@ -357,14 +433,19 @@ void TDynamicNameserver::OnPipeDestroyed(ui32 domain,
                      new TEvPrivate::TEvUpdateEpoch(domain, EpochUpdates.at(domain)));
         EpochUpdates.erase(domain);
     }
+
+    while (auto* cacheMiss = DynamicConfigs[domain]->PendingCacheMisses.Top()) {
+        DynamicConfigs[domain]->PendingCacheMisses.Remove(cacheMiss);
+        cacheMiss->OnError("Pipe was destroyed", ctx);
+    }
 }
 
 void TDynamicNameserver::Handle(TEvInterconnect::TEvResolveNode::TPtr &ev,
                                 const TActorContext &ctx)
 {
-    auto& record = ev->Get()->Record;
-    const ui32 nodeId = record.GetNodeId();
-    const TInstant deadline = record.HasDeadline() ? TInstant::FromValue(record.GetDeadline()) : TInstant::Max();
+    LOG_D("Handle " << ev->Get()->ToString());
+    const ui32 nodeId = ev->Get()->NodeId;
+    const TMonotonic deadline = ev->Get()->Deadline;
     auto config = AppData(ctx)->DynamicNameserviceConfig;
 
     if (!config || nodeId <= config->MaxStaticNodeId)
@@ -378,7 +459,7 @@ void TDynamicNameserver::Handle(TEvResolveAddress::TPtr &ev, const TActorContext
 
     const TEvResolveAddress* request = ev->Get();
 
-    RegisterWithSameMailbox(CreateResolveActor(request->Address, request->Port, ev->Sender, SelfId(), TInstant::Max()));
+    RegisterWithSameMailbox(CreateResolveActor(request->Address, request->Port, ev->Sender, SelfId(), TMonotonic::Max()));
 }
 
 void TDynamicNameserver::Handle(TEvInterconnect::TEvListNodes::TPtr &ev,
@@ -388,10 +469,10 @@ void TDynamicNameserver::Handle(TEvInterconnect::TEvListNodes::TPtr &ev,
         auto dinfo = AppData(ctx)->DomainsInfo;
         if (const auto& d = dinfo->Domain) {
             ui32 domain = d->DomainUid;
-            OpenPipe(domain, ctx);
+            OpenPipe(domain);
             TAutoPtr<TEvNodeBroker::TEvListNodes> request = new TEvNodeBroker::TEvListNodes;
             request->Record.SetCachedVersion(DynamicConfigs[domain]->Epoch.Version);
-            NTabletPipe::SendData(ctx, NodeBrokerPipes[domain], request.Release());
+            NTabletPipe::SendData(ctx, DynamicConfigs[domain]->NodeBrokerPipe, request.Release());
             PendingRequests.Set(domain);
         }
     }
@@ -403,6 +484,8 @@ void TDynamicNameserver::Handle(TEvInterconnect::TEvListNodes::TPtr &ev,
 
 void TDynamicNameserver::Handle(TEvInterconnect::TEvGetNode::TPtr &ev, const TActorContext &ctx)
 {
+    LOG_D("Handle " << ev->Get()->ToString());
+
     ui32 nodeId = ev->Get()->NodeId;
     THolder<TEvInterconnect::TEvNodeInfo> reply(new TEvInterconnect::TEvNodeInfo(nodeId));
     auto config = AppData(ctx)->DynamicNameserviceConfig;
@@ -426,26 +509,45 @@ void TDynamicNameserver::Handle(TEvInterconnect::TEvGetNode::TPtr &ev, const TAc
                    && ctx.Now() < DynamicConfigs[domain]->Epoch.End) {
             ctx.Send(ev->Sender, reply.Release());
         } else {
-            const TInstant deadline = ev->Get()->Deadline;
-            ctx.RegisterWithSameMailbox(new TDynamicNodeSearcher(SelfId(), nodeId, DynamicConfigs[domain],
-                ListNodesCache, ev.Release(), deadline));
+            const TMonotonic deadline = ev->Get()->Deadline;
+            auto* actor = new TActorCacheMiss<TCacheMissGet>(this, nodeId, DynamicConfigs[domain],
+                ListNodesCache, ev.Release(), deadline);
+            RegisterWithSameMailbox(actor);
+            actor->SendRequest();
+            RegisterNewCacheMiss(actor, DynamicConfigs[domain]);
         }
     }
 }
 
+void TDynamicNameserver::RegisterNewCacheMiss(TCacheMiss* cacheMiss, TDynamicConfigPtr config) {
+    LOG_D("New cache miss"
+        << ": nodeId# " << cacheMiss->NodeId
+        << ", deadline# " << cacheMiss->Deadline);
+    
+    bool newEarliestDeadline = config->PendingCacheMisses.Empty() || config->PendingCacheMisses.Top()->Deadline > cacheMiss->Deadline;
+    if (cacheMiss->NeedScheduleDeadline && newEarliestDeadline) {
+        LOG_D("Schedule wakeup for new earliest deadline " << cacheMiss->Deadline);
+        Schedule(cacheMiss->Deadline, new TEvents::TEvWakeup);
+        cacheMiss->NeedScheduleDeadline = false;
+    }
+    config->PendingCacheMisses.Add(cacheMiss);
+};
+
 void TDynamicNameserver::Handle(TEvTabletPipe::TEvClientDestroyed::TPtr &ev, const TActorContext &ctx)
 {
+    LOG_D("Handle " << ev->Get()->ToString());
     ui32 domain = AppData()->DomainsInfo->GetDomain()->DomainUid;
-    if (NodeBrokerPipes[domain] == ev->Get()->ClientId)
+    if (DynamicConfigs[domain]->NodeBrokerPipe == ev->Get()->ClientId)
         OnPipeDestroyed(domain, ctx);
 }
 
 void TDynamicNameserver::Handle(TEvTabletPipe::TEvClientConnected::TPtr &ev, const TActorContext &ctx)
 {
+    LOG_D("Handle " << ev->Get()->ToString());
     if (ev->Get()->Status != NKikimrProto::OK) {
         ui32 domain = AppData(ctx)->DomainsInfo->GetDomain()->DomainUid;
-        if (NodeBrokerPipes[domain] == ev->Get()->ClientId) {
-            NTabletPipe::CloseClient(ctx, NodeBrokerPipes[domain]);
+        if (DynamicConfigs[domain]->NodeBrokerPipe == ev->Get()->ClientId) {
+            NTabletPipe::CloseClient(ctx, DynamicConfigs[domain]->NodeBrokerPipe);
             OnPipeDestroyed(domain, ctx);
         }
     }
@@ -493,6 +595,27 @@ void TDynamicNameserver::Handle(NConsole::TEvConsole::TEvConfigNotificationReque
 
 void TDynamicNameserver::Handle(TEvents::TEvUnsubscribe::TPtr ev) {
     StaticNodeChangeSubscribers.erase(ev->Sender);
+}
+
+void TDynamicNameserver::HandleWakeup(const TActorContext &ctx) {
+    auto now = ctx.Monotonic();
+    LOG_D("HandleWakeup at " << now);
+
+    ui32 domain = AppData()->DomainsInfo->GetDomain()->DomainUid;
+    auto &pendingCacheMisses = DynamicConfigs[domain]->PendingCacheMisses;
+
+    while (!pendingCacheMisses.Empty() && pendingCacheMisses.Top()->Deadline <= now) {
+        auto* cacheMiss = pendingCacheMisses.Top();
+        pendingCacheMisses.Remove(cacheMiss);
+        cacheMiss->OnError("Deadline exceeded", ctx);
+    }
+
+    if (!pendingCacheMisses.Empty() && pendingCacheMisses.Top()->NeedScheduleDeadline) {
+        auto* cacheMiss = pendingCacheMisses.Top();
+        LOG_D("Schedule next wakeup at " << cacheMiss->Deadline);
+        Schedule(cacheMiss->Deadline, new TEvents::TEvWakeup);
+        cacheMiss->NeedScheduleDeadline = false;
+    }
 }
 
 IActor *CreateDynamicNameserver(const TIntrusivePtr<TTableNameserverSetup> &setup, ui32 poolId) {

--- a/ydb/core/mind/node_broker_ut.cpp
+++ b/ydb/core/mind/node_broker_ut.cpp
@@ -18,6 +18,7 @@
 #include <ydb/core/tablet_flat/shared_cache_events.h>
 #include <ydb/core/tablet_flat/shared_sausagecache.h>
 #include <ydb/core/tx/schemeshard/schemeshard.h>
+#include <ydb/core/testlib/actors/block_events.h>
 
 #include <google/protobuf/text_format.h>
 #include <library/cpp/malloc/api/malloc.h>
@@ -49,6 +50,7 @@ void SetupLogging(TTestActorRuntime& runtime)
     NActors::NLog::EPriority priority = ENABLE_DETAILED_NODE_BROKER_LOG ? NLog::PRI_TRACE : NLog::PRI_ERROR;
 
     runtime.SetLogPriority(NKikimrServices::NODE_BROKER, priority);
+    runtime.SetLogPriority(NKikimrServices::NAMESERVICE, priority);
 }
 
 THashMap<ui32, TIntrusivePtr<TNodeWardenConfig>> NodeWardenConfigs;
@@ -234,7 +236,8 @@ void Setup(TTestActorRuntime& runtime,
 
     auto scheduledFilter = [](TTestActorRuntimeBase& runtime, TAutoPtr<IEventHandle>& event, TDuration delay, TInstant& deadline) {
         if (event->HasEvent()
-            && event->Type == TDynamicNameserver::TEvPrivate::TEvUpdateEpoch::EventType)
+            && (event->Type == TDynamicNameserver::TEvPrivate::TEvUpdateEpoch::EventType 
+                || event->Type == TEvents::TSystem::Wakeup))
             return false;
         return TTestActorRuntime::DefaultScheduledFilterFunc(runtime, event, delay, deadline);
     };
@@ -591,14 +594,21 @@ void CheckLeaseExtension(TTestActorRuntime &runtime,
     }
 }
 
-void CheckResolveNode(TTestActorRuntime &runtime,
+void AsyncResolveNode(TTestActorRuntime &runtime,
                       TActorId sender,
                       ui32 nodeId,
-                      const TString &addr)
+                      TDuration responseTime = TDuration::Max())
 {
-    TAutoPtr<TEvInterconnect::TEvResolveNode> event = new TEvInterconnect::TEvResolveNode(nodeId);
+    TMonotonic deadline = TMonotonic::Max();
+    if (responseTime != TDuration::Max()) {
+        deadline = runtime.GetCurrentMonotonicTime() + responseTime;
+    }
+    TAutoPtr<TEvInterconnect::TEvResolveNode> event = new TEvInterconnect::TEvResolveNode(nodeId, deadline);
     runtime.Send(new IEventHandle(GetNameserviceActorId(), sender, event.Release()));
+}
 
+void CheckAsyncResolveNode(TTestActorRuntime &runtime, ui32 nodeId, const TString &addr)
+{
     TAutoPtr<IEventHandle> handle;
     auto reply = runtime.GrabEdgeEventRethrow<TEvLocalNodeInfo>(handle);
     UNIT_ASSERT(reply);
@@ -607,19 +617,40 @@ void CheckResolveNode(TTestActorRuntime &runtime,
     UNIT_ASSERT_VALUES_EQUAL(reply->Addresses[0].GetAddress(), addr);
 }
 
-void CheckResolveUnknownNode(TTestActorRuntime &runtime,
-                             TActorId sender,
-                             ui32 nodeId)
+void CheckAsyncResolveUnknownNode(TTestActorRuntime &runtime, ui32 nodeId)
 {
-    TAutoPtr<TEvInterconnect::TEvResolveNode> event = new TEvInterconnect::TEvResolveNode(nodeId);
-    runtime.Send(new IEventHandle(GetNameserviceActorId(), sender, event.Release()));
-
     TAutoPtr<IEventHandle> handle;
     auto reply = runtime.GrabEdgeEventRethrow<TEvLocalNodeInfo>(handle);
     UNIT_ASSERT(reply);
 
     UNIT_ASSERT_VALUES_EQUAL(reply->NodeId, nodeId);
     UNIT_ASSERT(reply->Addresses.empty());
+}
+
+void CheckResolveNode(TTestActorRuntime &runtime,
+                      TActorId sender,
+                      ui32 nodeId,
+                      const TString &addr,
+                      TDuration responseTime = TDuration::Max())
+{
+    AsyncResolveNode(runtime, sender, nodeId, responseTime);
+    CheckAsyncResolveNode(runtime, nodeId, addr);
+}
+
+void CheckResolveUnknownNode(TTestActorRuntime &runtime,
+                             TActorId sender,
+                             ui32 nodeId,
+                             TDuration responseTime = TDuration::Max())
+{
+    AsyncResolveNode(runtime, sender, nodeId, responseTime);
+    CheckAsyncResolveUnknownNode(runtime, nodeId);
+}
+
+void CheckNoPendingCacheMissesLeft(TTestActorRuntime &runtime, ui32 nodeIndex)
+{
+    const auto* nameserver = dynamic_cast<TDynamicNameserver*>(runtime.FindActor(GetNameserviceActorId(), nodeIndex));
+    UNIT_ASSERT(nameserver != nullptr);
+    UNIT_ASSERT_VALUES_EQUAL(nameserver->GetTotalPendingCacheMissesSize(), 0);
 }
 
 THolder<TEvInterconnect::TEvNodesInfo> GetNameserverNodesListEv(TTestActorRuntime &runtime, TActorId sender) {
@@ -1617,6 +1648,9 @@ Y_UNIT_TEST_SUITE(TDynamicNameserverTest) {
         CheckGetNode(runtime, sender, NODE2, true);
         // Get unknown dynamic node.
         CheckGetNode(runtime, sender, 1057, false);
+
+        // No pending cache miss requests are left
+        CheckNoPendingCacheMissesLeft(runtime, 0);
     }
 
     Y_UNIT_TEST(TestCacheUsage)
@@ -1726,6 +1760,9 @@ Y_UNIT_TEST_SUITE(TDynamicNameserverTest) {
         CheckResolveUnknownNode(runtime, sender, NODE1);
         CheckResolveNode(runtime, sender, NODE2, "1.2.3.5");
         UNIT_ASSERT_VALUES_EQUAL(resolveRequests.size(), 3);
+
+        // No pending cache miss requests are left
+        CheckNoPendingCacheMissesLeft(runtime, 0);
     }
 
     Y_UNIT_TEST(ListNodesCacheWhenNoChanges) {
@@ -1757,6 +1794,213 @@ Y_UNIT_TEST_SUITE(TDynamicNameserverTest) {
 
         // When changes are made, a new ListNodesCache is allocated
         UNIT_ASSERT_VALUES_UNEQUAL(ev2->NodesPtr.Get(), ev3->NodesPtr.Get());
+    }
+
+    Y_UNIT_TEST(CacheMissPipeDisconnect) {
+        TTestBasicRuntime runtime(1, false);
+        Setup(runtime);
+        TActorId sender = runtime.AllocateEdgeActor();
+
+        // Register a dynamic node in NodeBroker
+        CheckRegistration(runtime, sender, "host1", 1001, "host1.host1.host1", "1.2.3.4",
+                          1, 2, 3, 4, TStatus::OK, NODE1);
+
+        // Block cache miss requests
+        TBlockEvents<TEvNodeBroker::TEvResolveNode> block(runtime);
+        
+        // Send an asynchronous node resolve request to DynamicNameserver
+        AsyncResolveNode(runtime, sender, NODE1);
+
+        // Wait until cache miss is blocked
+        runtime.WaitFor("cache miss", [&]{ return block.size() >= 1; });
+        
+        // Reboot NodeBroker to break pipe
+        RebootTablet(runtime, MakeNodeBrokerID(), sender);
+
+        // Stop blocking new cache miss requests
+        block.Stop();
+
+        // Resolve request is failed, because pipe was broken
+        CheckAsyncResolveUnknownNode(runtime, NODE1);
+        
+        // The following requests should be OK
+        CheckResolveNode(runtime, sender, NODE1, "1.2.3.4");
+
+        // No pending cache miss requests are left
+        CheckNoPendingCacheMissesLeft(runtime, 0);
+    }
+
+    Y_UNIT_TEST(CacheMissSimpleDeadline) {
+        TTestBasicRuntime runtime(1, false);
+        Setup(runtime);
+        TActorId sender = runtime.AllocateEdgeActor();
+
+        // Register dynamic node in NodeBroker
+        CheckRegistration(runtime, sender, "host1", 1001, "host1.host1.host1", "1.2.3.4",
+            1, 2, 3, 4, TStatus::OK, NODE1);
+
+        // Block cache miss requests
+        TBlockEvents<TEvNodeBroker::TEvResolveNode> block(runtime);
+        
+        // Send an asynchronous node resolve request to DynamicNameserver with deadline
+        AsyncResolveNode(runtime, sender, NODE1, TDuration::Seconds(1));
+        
+        // Wait until cache miss is blocked
+        runtime.WaitFor("cache miss", [&]{ return block.size() >= 1; });
+        
+        // Move time to the deadline
+        runtime.AdvanceCurrentTime(TDuration::Seconds(1));
+        
+        // Resolve request is failed, because of deadline
+        CheckAsyncResolveUnknownNode(runtime, NODE1);
+
+        // No pending cache miss requests are left
+        CheckNoPendingCacheMissesLeft(runtime, 0);
+    }
+
+    Y_UNIT_TEST(CacheMissSameDeadline) {
+        TTestBasicRuntime runtime(1, false);
+        Setup(runtime);
+        TActorId sender = runtime.AllocateEdgeActor();
+
+        // Register dynamic nodes in NodeBroker
+        CheckRegistration(runtime, sender, "host1", 1001, "host1.host1.host1", "1.2.3.4",
+            1, 2, 3, 4, TStatus::OK, NODE1);
+        CheckRegistration(runtime, sender, "host2", 1001, "host2.host2.host2", "1.2.3.5",
+            1, 2, 3, 5, TStatus::OK, NODE2);
+
+        // Block cache miss requests
+        TBlockEvents<TEvNodeBroker::TEvResolveNode> block(runtime);
+
+        // Send two asynchronous node resolve requests to DynamicNameserver with same deadline
+        AsyncResolveNode(runtime, sender, NODE1, TDuration::Seconds(1));
+        AsyncResolveNode(runtime, sender, NODE2, TDuration::Seconds(1));
+
+        // Wait until cache misses are blocked
+        runtime.WaitFor("cache miss", [&]{ return block.size() >= 2; });
+
+        // Move time to the deadline
+        runtime.AdvanceCurrentTime(TDuration::Seconds(1));
+            
+        // Resolve requests are failed, because of deadline
+        CheckAsyncResolveUnknownNode(runtime, NODE1);
+        CheckAsyncResolveUnknownNode(runtime, NODE2);
+
+        // No pending cache miss requests are left
+        CheckNoPendingCacheMissesLeft(runtime, 0);
+    }
+
+    Y_UNIT_TEST(CacheMissNoDeadline) {
+        TTestBasicRuntime runtime(1, false);
+        Setup(runtime);
+        TActorId sender = runtime.AllocateEdgeActor();
+
+        // Register dynamic nodes in NodeBroker
+        CheckRegistration(runtime, sender, "host1", 1001, "host1.host1.host1", "1.2.3.4",
+            1, 2, 3, 4, TStatus::OK, NODE1);
+        CheckRegistration(runtime, sender, "host2", 1001, "host2.host2.host2", "1.2.3.5",
+            1, 2, 3, 5, TStatus::OK, NODE2);
+
+        // Block cache miss requests
+        TBlockEvents<TEvNodeBroker::TEvResolveNode> block(runtime);
+
+        // Send asynchronous node resolve request to DynamicNameserver with no deadline
+        AsyncResolveNode(runtime, sender, NODE1);
+        
+        // Send asynchronous node resolve request to DynamicNameserver with deadline
+        AsyncResolveNode(runtime, sender, NODE2, TDuration::Seconds(1));
+
+        // Wait until cache misses are blocked
+        runtime.WaitFor("cache miss", [&]{ return block.size() >= 2; });
+
+        // Move time to the deadline
+        runtime.AdvanceCurrentTime(TDuration::Seconds(1));
+            
+        // Resolve request is failed, because of deadline
+        CheckAsyncResolveUnknownNode(runtime, NODE2);
+        
+        // Unblock blocked cache misses
+        block.Unblock();
+        
+        // Resolve request with no deadline is OK
+        CheckAsyncResolveNode(runtime, NODE1, "1.2.3.4");
+
+        // No pending cache miss requests are left
+        CheckNoPendingCacheMissesLeft(runtime, 0);
+    }
+
+    Y_UNIT_TEST(CacheMissDifferentDeadline) {
+        TTestBasicRuntime runtime(1, false);
+        Setup(runtime);
+        TActorId sender = runtime.AllocateEdgeActor();
+
+        // Register dynamic nodes in NodeBroker
+        CheckRegistration(runtime, sender, "host1", 1001, "host1.host1.host1", "1.2.3.4",
+            1, 2, 3, 4, TStatus::OK, NODE1);
+        CheckRegistration(runtime, sender, "host2", 1001, "host2.host2.host2", "1.2.3.5",
+            1, 2, 3, 5, TStatus::OK, NODE2);
+
+        // Block cache miss requests
+        TBlockEvents<TEvNodeBroker::TEvResolveNode> block(runtime);
+
+        // Send asynchronous node resolve requests to DynamicNameserver with different deadline
+        AsyncResolveNode(runtime, sender, NODE1, TDuration::Seconds(1));
+        AsyncResolveNode(runtime, sender, NODE2, TDuration::Seconds(2));
+
+        // Wait until cache misses are blocked
+        runtime.WaitFor("cache miss", [&]{ return block.size() >= 2; });
+
+        // Move time to the first deadline
+        runtime.AdvanceCurrentTime(TDuration::Seconds(1));
+            
+        // Resolve request is failed, because of deadline
+        CheckAsyncResolveUnknownNode(runtime, NODE1);
+        
+        // Move time to the second deadline
+        runtime.AdvanceCurrentTime(TDuration::Seconds(1));
+        
+        // Resolve request is failed, because of deadline
+        CheckAsyncResolveUnknownNode(runtime, NODE2);
+
+        // No pending cache miss requests are left
+        CheckNoPendingCacheMissesLeft(runtime, 0);
+    }
+
+    Y_UNIT_TEST(CacheMissDifferentDeadlineInverseOrder) {
+        TTestBasicRuntime runtime(1, false);
+        Setup(runtime);
+        TActorId sender = runtime.AllocateEdgeActor();
+
+        // Register dynamic nodes in NodeBroker
+        CheckRegistration(runtime, sender, "host1", 1001, "host1.host1.host1", "1.2.3.4",
+            1, 2, 3, 4, TStatus::OK, NODE1);
+        CheckRegistration(runtime, sender, "host2", 1001, "host2.host2.host2", "1.2.3.5",
+            1, 2, 3, 5, TStatus::OK, NODE2);
+
+        // Block cache miss requests
+        TBlockEvents<TEvNodeBroker::TEvResolveNode> block(runtime);
+
+        // Send asynchronous node resolve requests to DynamicNameserver with different deadline
+        AsyncResolveNode(runtime, sender, NODE1, TDuration::Seconds(2));
+        AsyncResolveNode(runtime, sender, NODE2, TDuration::Seconds(1));
+
+        // Wait until cache misses are blocked
+        runtime.WaitFor("cache miss", [&]{ return block.size() >= 2; });
+
+        // Move time to the first deadline
+        runtime.AdvanceCurrentTime(TDuration::Seconds(1));
+            
+        // Resolve request is failed, because of deadline
+        CheckAsyncResolveUnknownNode(runtime, NODE2);
+        
+        // Move time to the second deadline
+        runtime.AdvanceCurrentTime(TDuration::Seconds(1));
+        
+        // Resolve request is failed, because of deadline
+        CheckAsyncResolveUnknownNode(runtime, NODE1);
+
+        // No pending cache miss requests are left
+        CheckNoPendingCacheMissesLeft(runtime, 0);
     }
 }
 

--- a/ydb/library/actors/core/interconnect.cpp
+++ b/ydb/library/actors/core/interconnect.cpp
@@ -178,4 +178,19 @@ namespace NActors {
         return {dataCenterId, moduleId, rackId, unitId};
     }
 
+
+    TString TEvInterconnect::TEvGetNode::ToString() const {
+        return TStringBuilder() << ToStringHeader() << " {"
+            << " NodeId: " << NodeId
+            << " Deadline: " << Deadline
+        << " }";
+    }
+
+    TString TEvInterconnect::TEvResolveNode::ToString() const {
+        return TStringBuilder() << ToStringHeader() << " {"
+            << " NodeId: " << NodeId
+            << " Deadline: " << Deadline
+        << " }";
+    }
+
 } // NActors

--- a/ydb/library/actors/core/interconnect.h
+++ b/ydb/library/actors/core/interconnect.h
@@ -150,7 +150,6 @@ namespace NActors {
 
         static_assert(EvEnd < EventSpaceEnd(TEvents::ES_INTERCONNECT), "expect EvEnd < EventSpaceEnd(TEvents::ES_INTERCONNECT)");
 
-        struct TEvResolveNode;
         struct TEvNodeAddress;
 
         struct TEvConnectNode: public TEventLocal<TEvConnectNode, EvConnectNode> {
@@ -243,13 +242,28 @@ namespace NActors {
 
         struct TEvGetNode: public TEventLocal<TEvGetNode, EvGetNode> {
             ui32 NodeId;
-            TInstant Deadline;
+            TMonotonic Deadline;
 
-            TEvGetNode(ui32 nodeId, TInstant deadline = TInstant::Max())
+            TEvGetNode(ui32 nodeId, TMonotonic deadline = TMonotonic::Max())
                 : NodeId(nodeId)
                 , Deadline(deadline)
             {
             }
+
+            TString ToString() const override;
+        };
+
+        struct TEvResolveNode: public TEventLocal<TEvResolveNode, EvResolveNode> {
+            ui32 NodeId;
+            TMonotonic Deadline;
+
+            TEvResolveNode(ui32 nodeId, TMonotonic deadline = TMonotonic::Max())
+                : NodeId(nodeId)
+                , Deadline(deadline)
+            {
+            }
+
+            TString ToString() const override;
         };
 
         struct TEvNodeInfo: public TEventLocal<TEvNodeInfo, EvNodeInfo> {

--- a/ydb/library/actors/interconnect/interconnect.h
+++ b/ydb/library/actors/interconnect/interconnect.h
@@ -166,11 +166,11 @@ namespace NActors {
      */
     IActor* CreateResolveActor(
         const TString& host, ui16 port, ui32 nodeId, const TString& defaultAddress,
-        const TActorId& replyTo, const TActorId& replyFrom, TInstant deadline);
+        const TActorId& replyTo, const TActorId& replyFrom, TMonotonic deadline);
 
     inline IActor* CreateResolveActor(
         ui32 nodeId, const TTableNameserverSetup::TNodeInfo& nodeInfo,
-        const TActorId& replyTo, const TActorId& replyFrom, TInstant deadline)
+        const TActorId& replyTo, const TActorId& replyFrom, TMonotonic deadline)
     {
         return CreateResolveActor(nodeInfo.ResolveHost, nodeInfo.Port, nodeId, nodeInfo.Address,
             replyTo, replyFrom, deadline);
@@ -184,6 +184,6 @@ namespace NActors {
      */
     IActor* CreateResolveActor(
         const TString& host, ui16 port,
-        const TActorId& replyTo, const TActorId& replyFrom, TInstant deadline);
+        const TActorId& replyTo, const TActorId& replyFrom, TMonotonic deadline);
 
 }

--- a/ydb/library/actors/interconnect/interconnect_handshake.cpp
+++ b/ydb/library/actors/interconnect/interconnect_handshake.cpp
@@ -818,7 +818,7 @@ namespace NActors {
         std::vector<NInterconnect::TAddress> ResolvePeer() {
             // issue request to a nameservice to resolve peer node address
             const auto mono = TActivationContext::Monotonic();
-            Send(Common->NameserviceId, new TEvInterconnect::TEvResolveNode(PeerNodeId, TActivationContext::Now() + (Deadline - mono)));
+            Send(Common->NameserviceId, new TEvInterconnect::TEvResolveNode(PeerNodeId, Deadline));
 
             // wait for the result
             auto ev = WaitForSpecificEvent<TEvResolveError, TEvLocalNodeInfo, TEvInterconnect::TEvNodeAddress>(
@@ -1208,8 +1208,7 @@ namespace NActors {
 
         THolder<TEvInterconnect::TNodeInfo> GetPeerNodeInfo() {
             Y_ABORT_UNLESS(PeerNodeId);
-            Send(Common->NameserviceId, new TEvInterconnect::TEvGetNode(PeerNodeId, TActivationContext::Now() +
-                (Deadline - TActivationContext::Monotonic())));
+            Send(Common->NameserviceId, new TEvInterconnect::TEvGetNode(PeerNodeId, Deadline));
             auto response = WaitForSpecificEvent<TEvInterconnect::TEvNodeInfo>("GetPeerNodeInfo");
             return std::move(response->Get()->Node);
         }

--- a/ydb/library/actors/interconnect/interconnect_impl.h
+++ b/ydb/library/actors/interconnect/interconnect_impl.h
@@ -6,19 +6,6 @@
 #include <library/cpp/monlib/dynamic_counters/counters.h>
 
 namespace NActors {
-    // resolve node info
-    struct TEvInterconnect::TEvResolveNode: public TEventPB<TEvInterconnect::TEvResolveNode, NActorsInterconnect::TEvResolveNode, TEvInterconnect::EvResolveNode> {
-        TEvResolveNode() {
-        }
-
-        TEvResolveNode(ui32 nodeId, TInstant deadline = TInstant::Max()) {
-            Record.SetNodeId(nodeId);
-            if (deadline != TInstant::Max()) {
-                Record.SetDeadline(deadline.GetValue());
-            }
-        }
-    };
-
     // node info
     struct TEvInterconnect::TEvNodeAddress: public TEventPB<TEvInterconnect::TEvNodeAddress, NActorsInterconnect::TEvNodeInfo, TEvInterconnect::EvNodeAddress> {
         TEvNodeAddress() {

--- a/ydb/library/actors/interconnect/interconnect_nameserver_base.h
+++ b/ydb/library/actors/interconnect/interconnect_nameserver_base.h
@@ -23,18 +23,17 @@ namespace NActors {
 
         void HandleMissedNodeId(TEvInterconnect::TEvResolveNode::TPtr& ev,
                                 const TActorContext& ctx,
-                                const TInstant&) {
+                                const TMonotonic&) {
             auto reply = new TEvLocalNodeInfo;
-            reply->NodeId = ev->Get()->Record.GetNodeId();
+            reply->NodeId = ev->Get()->NodeId;
             ctx.Send(ev->Sender, reply);
         }
 
         void Handle(TEvInterconnect::TEvResolveNode::TPtr& ev,
                     const TActorContext& ctx) {
             const TEvInterconnect::TEvResolveNode* request = ev->Get();
-            auto& record = request->Record;
-            const ui32 nodeId = record.GetNodeId();
-            const TInstant deadline = record.HasDeadline() ? TInstant::FromValue(record.GetDeadline()) : TInstant::Max();
+            const ui32 nodeId = request->NodeId;
+            const TMonotonic deadline = request->Deadline;
             auto it = NodeTable.find(nodeId);
 
             if (it == NodeTable.end()) {
@@ -50,7 +49,7 @@ namespace NActors {
             const TEvResolveAddress* request = ev->Get();
 
             IActor::RegisterWithSameMailbox(
-                CreateResolveActor(request->Address, request->Port, ev->Sender, this->SelfId(), TInstant::Max()));
+                CreateResolveActor(request->Address, request->Port, ev->Sender, this->SelfId(), TMonotonic::Max()));
         }
 
         void Handle(TEvInterconnect::TEvListNodes::TPtr& ev,

--- a/ydb/library/actors/interconnect/interconnect_nameserver_dynamic.cpp
+++ b/ydb/library/actors/interconnect/interconnect_nameserver_dynamic.cpp
@@ -16,9 +16,9 @@ namespace NActors {
     {
         struct TPendingRequest {
             TEvInterconnect::TEvResolveNode::TPtr Request;
-            TInstant Deadline;
+            TMonotonic Deadline;
 
-            TPendingRequest(TEvInterconnect::TEvResolveNode::TPtr request, const TInstant& deadline)
+            TPendingRequest(TEvInterconnect::TEvResolveNode::TPtr request, const TMonotonic& deadline)
                 : Request(request), Deadline(deadline)
             {
             }
@@ -55,13 +55,13 @@ namespace NActors {
 
         void DiscardTimedOutRequests(const TActorContext& ctx, ui32 compactionCount = 0) {
 
-            auto now = Now();
+            auto now = ctx.Monotonic();
 
             for (auto& pending : PendingRequests) {
                 if (pending.Request && pending.Deadline > now) {
-                    LOG_ERROR_IC("ICN06", "Unknown nodeId: %u", pending.Request->Get()->Record.GetNodeId());
+                    LOG_ERROR_IC("ICN06", "Unknown nodeId: %u", pending.Request->Get()->NodeId);
                     auto reply = new TEvLocalNodeInfo;
-                    reply->NodeId = pending.Request->Get()->Record.GetNodeId();
+                    reply->NodeId = pending.Request->Get()->NodeId;
                     ctx.Send(pending.Request->Sender, reply);
                     pending.Request.Reset();
                     compactionCount++;
@@ -116,14 +116,14 @@ namespace NActors {
 
         void HandleMissedNodeId(TEvInterconnect::TEvResolveNode::TPtr& ev,
                     const TActorContext& ctx,
-                    const TInstant& deadline) {
+                    const TMonotonic& deadline) {
             if (PendingPeriod) {
                 if (PendingRequests.size() == 0) {
                     SchedulePeriodic();
                 }
-                PendingRequests.emplace_back(std::move(ev), Min(deadline, Now() + PendingPeriod));
+                PendingRequests.emplace_back(std::move(ev), Min(deadline, ctx.Monotonic() + PendingPeriod));
             } else {
-                LOG_ERROR_IC("ICN07", "Unknown nodeId: %u", ev->Get()->Record.GetNodeId());
+                LOG_ERROR_IC("ICN07", "Unknown nodeId: %u", ev->Get()->NodeId);
                 TInterconnectNameserverBase::HandleMissedNodeId(ev, ctx, deadline);
             }
         }
@@ -144,7 +144,7 @@ namespace NActors {
                     node.Address, node.Host, node.ResolveHost, node.Port, node.Location);
 
                 for (auto& pending : PendingRequests) {
-                    if (pending.Request && pending.Request->Get()->Record.GetNodeId() == node.NodeId) {
+                    if (pending.Request && pending.Request->Get()->NodeId == node.NodeId) {
                         LOG_TRACE_IC("ICN05", "Pending nodeId: %u discovered", node.NodeId);
                         RegisterWithSameMailbox(
                             CreateResolveActor(node.NodeId, NodeTable[node.NodeId], pending.Request->Sender, SelfId(), pending.Deadline));

--- a/ydb/library/actors/interconnect/interconnect_resolve.cpp
+++ b/ydb/library/actors/interconnect/interconnect_resolve.cpp
@@ -18,7 +18,7 @@ namespace NActors {
     public:
         TInterconnectResolveActor(
                 const TString& host, ui16 port, ui32 nodeId, const TString& defaultAddress,
-                const TActorId& replyTo, const TActorId& replyFrom, TInstant deadline)
+                const TActorId& replyTo, const TActorId& replyFrom, TMonotonic deadline)
             : Host(host)
             , NodeId(nodeId)
             , Port(port)
@@ -30,7 +30,7 @@ namespace NActors {
 
         TInterconnectResolveActor(
                 const TString& host, ui16 port,
-                const TActorId& replyTo, const TActorId& replyFrom, TInstant deadline)
+                const TActorId& replyTo, const TActorId& replyFrom, TMonotonic deadline)
             : Host(host)
             , Port(port)
             , ReplyTo(replyTo)
@@ -57,7 +57,7 @@ namespace NActors {
                 SendErrorAndDie(*errorText);
             }
 
-            auto now = TActivationContext::Now();
+            auto now = TActivationContext::Monotonic();
             if (Deadline < now) {
                 SendErrorAndDie("Deadline");
                 return;
@@ -70,7 +70,7 @@ namespace NActors {
                     : static_cast<IEventBase*>(new TEvDns::TEvGetAddr(Host, AF_UNSPEC)),
                 IEventHandle::FlagTrackDelivery);
 
-            if (Deadline != TInstant::Max()) {
+            if (Deadline != TMonotonic::Max()) {
                 Schedule(Deadline, new TEvents::TEvWakeup);
             }
 
@@ -188,19 +188,19 @@ namespace NActors {
         const TString DefaultAddress;
         const TActorId ReplyTo;
         const TActorId ReplyFrom;
-        const TInstant Deadline;
+        const TMonotonic Deadline;
     };
 
     IActor* CreateResolveActor(
         const TString& host, ui16 port, ui32 nodeId, const TString& defaultAddress,
-        const TActorId& replyTo, const TActorId& replyFrom, TInstant deadline)
+        const TActorId& replyTo, const TActorId& replyFrom, TMonotonic deadline)
     {
         return new TInterconnectResolveActor(host, port, nodeId, defaultAddress, replyTo, replyFrom, deadline);
     }
 
     IActor* CreateResolveActor(
         const TString& host, ui16 port,
-        const TActorId& replyTo, const TActorId& replyFrom, TInstant deadline)
+        const TActorId& replyTo, const TActorId& replyFrom, TMonotonic deadline)
     {
         return new TInterconnectResolveActor(host, port, replyTo, replyFrom, deadline);
     }

--- a/ydb/library/actors/testlib/test_runtime.cpp
+++ b/ydb/library/actors/testlib/test_runtime.cpp
@@ -1722,6 +1722,9 @@ namespace NActors {
         if (!actor) {
             actor = mailbox->FindAlias(localId);
         }
+        if (!actor && node->LocalServicesActors.contains(actorId)) {
+            actor = node->LocalServicesActors[actorId];
+        }
         return actor;
     }
 

--- a/ydb/library/services/services.proto
+++ b/ydb/library/services/services.proto
@@ -414,6 +414,8 @@ enum EServiceKikimr {
     TX_PRIORITIES_QUEUE = 3100;
 
     BSCONFIG = 3200;
+
+    NAMESERVICE = 3300;
 };
 
 message TActivity {

--- a/ydb/library/yql/providers/dq/actors/dynamic_nameserver.cpp
+++ b/ydb/library/yql/providers/dq/actors/dynamic_nameserver.cpp
@@ -119,8 +119,8 @@ namespace NYql::NDqs {
                     const TActorContext& ctx)
         {
             const TEvInterconnect::TEvResolveNode* request = ev->Get();
-            const ui32 nodeId = request->Record.GetNodeId();
-            const TInstant deadline = request->Record.HasDeadline() ? TInstant::FromValue(request->Record.GetDeadline()) : TInstant::Max();
+            const ui32 nodeId = request->NodeId;
+            const TMonotonic deadline = request->Deadline;
             auto it = NodeTable.find(nodeId);
 
             if (it == NodeTable.end()) {
@@ -149,7 +149,7 @@ namespace NYql::NDqs {
                                              request->Port,
                                              ev->Sender,
                                              SelfId(),
-                                             TInstant::Max()));
+                                             TMonotonic::Max()));
         }
 
         TVector<NActors::TEvInterconnect::TNodeInfo> GetNodesInfo()


### PR DESCRIPTION
### Changelog category <!-- remove all except one -->

* Not for changelog (changelog entry is not required)

### Description for reviewers <!-- (optional) description for those who read this PR -->

Cherry-picked from https://github.com/ydb-platform/ydb/pull/15161
