### PR TITLE
Remove Private Cache wait pads

### DIFF
--- a/ydb/core/tablet_flat/flat_executor.cpp
+++ b/ydb/core/tablet_flat/flat_executor.cpp
@@ -646,7 +646,7 @@ void TExecutor::PlanTransactionActivation() {
 
 void TExecutor::TryActivateWaitingTransaction(TIntrusivePtr<NPageCollection::TPagesWaitPad>&& waitPad) {
     Y_ENSURE(waitPad);
-    Y_ASSERT(waitPad->PendingRequests);
+    Y_ENSURE(waitPad->PendingRequests);
     if (--waitPad->PendingRequests) {
         LogWaitingTransaction(std::move(waitPad));
     } else {

--- a/ydb/core/tablet_flat/flat_executor_bootlogic.cpp
+++ b/ydb/core/tablet_flat/flat_executor_bootlogic.cpp
@@ -186,7 +186,7 @@ NBoot::TSpawned TExecutorBootLogic::LoadPages(NBoot::IStep *step, TAutoPtr<NPage
         new NSharedCache::TEvRequest(
             NBlockIO::EPriority::Fast,
             req),
-        0, (ui64)EPageCollectionRequest::BootLogic);
+        0, (ui64)ESharedCacheRequestType::BootLogic);
 
     return NBoot::TSpawned(true);
 }
@@ -268,7 +268,7 @@ TExecutorBootLogic::EOpResult TExecutorBootLogic::Receive(::NActors::IEventHandl
             return OpResultBroken;
 
     } else if (auto *msg = ev.CastAsLocal<NSharedCache::TEvResult>()) {
-        if (EPageCollectionRequest(ev.Cookie) != EPageCollectionRequest::BootLogic)
+        if (ESharedCacheRequestType(ev.Cookie) != ESharedCacheRequestType::BootLogic)
             return OpResultUnhandled;
 
         auto it = Loads.find(msg->PageCollection.Get());

--- a/ydb/core/tablet_flat/flat_sausage_fetch.h
+++ b/ydb/core/tablet_flat/flat_sausage_fetch.h
@@ -9,7 +9,7 @@ namespace NKikimr {
 namespace NPageCollection {
 
     struct TPagesWaitPad : public TThrRefBase {
-        // no internal state
+        ui64 PendingRequests = 0;
     };
 
     struct TFetch {

--- a/ydb/core/tablet_flat/flat_sausage_fetch.h
+++ b/ydb/core/tablet_flat/flat_sausage_fetch.h
@@ -1,7 +1,6 @@
 #pragma once
 
 #include "flat_sausage_gut.h"
-#include "flat_part_iface.h"
 
 #include <util/generic/xrange.h>
 #include <ydb/library/actors/util/shared_data.h>
@@ -9,14 +8,16 @@
 namespace NKikimr {
 namespace NPageCollection {
 
+    struct TPagesWaitPad : public TThrRefBase {
+        // no internal state
+    };
+
     struct TFetch {
-        TFetch(ui64 cookie, TIntrusiveConstPtr<IPageCollection> pageCollection, TVector<TPageId> pages, NWilson::TTraceId traceId = {})
+        TFetch(ui64 cookie, TIntrusiveConstPtr<IPageCollection> pageCollection, TVector<TPageId> pages)
             : Cookie(cookie)
             , PageCollection(std::move(pageCollection))
             , Pages(std::move(pages))
-            , TraceId(std::move(traceId))
         {
-
         }
 
         TString DebugString(bool detailed = false) const
@@ -39,6 +40,7 @@ namespace NPageCollection {
         ui64 Cookie = Max<ui64>();
         TIntrusiveConstPtr<IPageCollection> PageCollection;
         TVector<TPageId> Pages;
+        TIntrusivePtr<TPagesWaitPad> WaitPad;
         NWilson::TTraceId TraceId;
     };
 

--- a/ydb/core/tablet_flat/flat_sausagecache.cpp
+++ b/ydb/core/tablet_flat/flat_sausagecache.cpp
@@ -63,41 +63,17 @@ void TPrivatePageCache::RegisterPageCollection(TIntrusivePtr<TInfo> info) {
     }
 }
 
-TPrivatePageCache::TPage::TWaitQueuePtr TPrivatePageCache::ForgetPageCollection(TIntrusivePtr<TInfo> info) {
-    // todo: amortize destruction cost (how?)
-
-    TPage::TWaitQueuePtr ret;
+void TPrivatePageCache::ForgetPageCollection(TIntrusivePtr<TInfo> info) {
     for (const auto& kv : info->PageMap) {
         auto* page = kv.second.Get();
         Y_DEBUG_ABORT_UNLESS(page);
-
-        if (page->LoadState == TPage::LoadStateRequested) {
-            while (TPrivatePageCacheWaitPad *x = page->WaitQueue->Pop()) {
-                if (0 == x->Dec()) {
-                    if (!ret)
-                        ret = new TPrivatePageCache::TPage::TWaitQueue;
-                    ret->Push(x);
-                }
-            }
-            page->WaitQueue.Destroy();
-        }
 
         if (page->PinPad) {
             page->PinPad.Drop();
             Stats.PinnedSetSize -= page->Size;
-
             if (page->LoadState != TPage::LoadStateLoaded)
                 Stats.PinnedLoadSize -= page->Size;
         }
-    }
-
-    // Completely forget page collection
-    for (const auto& kv : info->PageMap) {
-        auto* page = kv.second.Get();
-        Y_DEBUG_ABORT_UNLESS(page);
-
-            Y_ENSURE(!page->WaitQueue, "non-empty wait queue in forgotten page.");
-            Y_ENSURE(!page->PinPad, "non-empty pin pad in forgotten page.");
 
         if (page->SharedBody)
             Stats.TotalSharedBody -= page->Size;
@@ -111,8 +87,6 @@ TPrivatePageCache::TPage::TWaitQueuePtr TPrivatePageCache::ForgetPageCollection(
     PageCollections.erase(info->Id);
     ToTouchShared.erase(info->Id);
     --Stats.TotalCollections;
-
-    return ret;
 }
 
 TPrivatePageCache::TInfo* TPrivatePageCache::Info(TLogoBlobID id) {
@@ -149,48 +123,6 @@ void TPrivatePageCache::Unpin(TPage *page, TPrivatePageCachePinPad *pad) {
             TryUnload(page);
         }
     }
-}
-
-std::pair<ui32, ui64> TPrivatePageCache::Request(TVector<TPageId> &pages, TPrivatePageCacheWaitPad *waitPad, TInfo *info) {
-    ui32 blocksToRequest = 0;
-    ui64 bytesToRequest = 0;
-
-    auto it = pages.begin();
-    auto end = pages.end();
-
-    while (it != end) {
-        TPage *page = info->EnsurePage(*it);
-        switch (page->LoadState) {
-        case TPage::LoadStateNo:
-        case TPage::LoadStateRequestedAsync:
-            page->LoadState = TPage::LoadStateRequested;
-            bytesToRequest += page->Size;
-
-            Y_ENSURE(!page->WaitQueue);
-            page->WaitQueue = new TPage::TWaitQueue();
-            page->WaitQueue->Push(waitPad);
-            waitPad->Inc();
-
-            ++blocksToRequest;
-            ++it;
-            break;
-        case TPage::LoadStateLoaded:
-            Y_TABLET_ERROR("must not request already loaded pages");
-        case TPage::LoadStateRequested:
-            if (!page->WaitQueue)
-                page->WaitQueue = new TPage::TWaitQueue();
-
-            page->WaitQueue->Push(waitPad);
-            waitPad->Inc();
-
-            --end;
-            if (end != it)
-                *it = *end;
-            break;
-        }
-    }
-    pages.erase(end, pages.end());
-    return std::make_pair(blocksToRequest, bytesToRequest);
 }
 
 void TPrivatePageCache::TryLoad(TPage *page) {
@@ -393,7 +325,7 @@ void TPrivatePageCache::DropSharedBody(TInfo *info, TPageId pageId) {
     }
 }
 
-TPrivatePageCache::TPage::TWaitQueuePtr TPrivatePageCache::ProvideBlock(
+void TPrivatePageCache::ProvideBlock(
         NSharedCache::TEvResult::TLoaded&& loaded, TInfo *info)
 {
     Y_DEBUG_ABORT_UNLESS(loaded.Page && loaded.Page.IsUsed());
@@ -413,20 +345,6 @@ TPrivatePageCache::TPage::TWaitQueuePtr TPrivatePageCache::ProvideBlock(
     Stats.TotalSharedBody += page->Size;
     Stats.TotalPinnedBody += page->Size;
     TryUnload(page);
-
-    TPage::TWaitQueuePtr ret;
-    if (page->WaitQueue) {
-        while (TPrivatePageCacheWaitPad *x = page->WaitQueue->Pop()) {
-            if (0 == x->Dec()) {
-                if (!ret)
-                    ret = new TPage::TWaitQueue();
-                ret->Push(x);
-            }
-        }
-        page->WaitQueue.Destroy();
-    }
-
-    return ret;
 }
 
 THashMap<TLogoBlobID, TIntrusivePtr<TPrivatePageCache::TInfo>> TPrivatePageCache::DetachPrivatePageCache() {

--- a/ydb/core/tablet_flat/shared_cache_events.h
+++ b/ydb/core/tablet_flat/shared_cache_events.h
@@ -133,6 +133,7 @@ namespace NKikimr::NSharedCache {
         const ui64 Cookie;
         const TIntrusiveConstPtr<NPageCollection::IPageCollection> PageCollection;
         TVector<TLoaded> Pages;
+        TIntrusivePtr<NPageCollection::TPagesWaitPad> WaitPad;
     };
 
     struct TEvUpdated : public TEventLocal<TEvUpdated, EvUpdated> {

--- a/ydb/core/tablet_flat/ut/ut_shared_sausagecache.cpp
+++ b/ydb/core/tablet_flat/ut/ut_shared_sausagecache.cpp
@@ -1203,8 +1203,7 @@ Y_UNIT_TEST(Two_Transactions_One_Key) {
     env.SendAsync(new NFake::TEvExecute{ new TTxReadRows({33}, retried1, completed1) });
     env.SendAsync(new NFake::TEvExecute{ new TTxReadRows({33}, retried2, completed2) });
 
-    // CHANGE LATER: block.size() == 2
-    env.Env.WaitFor("blocked TEvRequest 1", [&]{ return block.size() == 1; }, TDuration::Seconds(10));
+    env.Env.WaitFor("blocked TEvRequest 1", [&]{ return block.size() == 2; }, TDuration::Seconds(10));
     LogCounters(counters);
     UNIT_ASSERT_VALUES_EQUAL(retried1, (TVector<ui32>{1}));
     UNIT_ASSERT_VALUES_EQUAL(retried2, (TVector<ui32>{1}));
@@ -1213,37 +1212,31 @@ Y_UNIT_TEST(Two_Transactions_One_Key) {
     UNIT_ASSERT_VALUES_EQUAL(counters->CacheMissPages->Val(), 0);
 
     block.Unblock();
-    // CHANGE LATER: block.size() == 2
-    env.Env.WaitFor("blocked TEvRequest 2", [&]{ return block.size() == 1; }, TDuration::Seconds(10));
+    env.Env.WaitFor("blocked TEvRequest 2", [&]{ return block.size() == 2; }, TDuration::Seconds(10));
     LogCounters(counters);
     UNIT_ASSERT_VALUES_EQUAL(retried1, (TVector<ui32>{1, 1}));
     UNIT_ASSERT_VALUES_EQUAL(retried2, (TVector<ui32>{1, 1}));
     UNIT_ASSERT_VALUES_EQUAL(completed1, false);
     UNIT_ASSERT_VALUES_EQUAL(completed2, false);
-    // CHANGE LATER: counters->CacheMissPages->Val() == 2
-    UNIT_ASSERT_VALUES_EQUAL(counters->CacheMissPages->Val(), 1);
+    UNIT_ASSERT_VALUES_EQUAL(counters->CacheMissPages->Val(), 2);
 
     block.Unblock();
-    // CHANGE LATER: block.size() == 2
-    env.Env.WaitFor("blocked TEvRequest 3", [&]{ return block.size() == 1; }, TDuration::Seconds(10));
+    env.Env.WaitFor("blocked TEvRequest 3", [&]{ return block.size() == 2; }, TDuration::Seconds(10));
     LogCounters(counters);
     UNIT_ASSERT_VALUES_EQUAL(retried1, (TVector<ui32>{1, 1, 1}));
     UNIT_ASSERT_VALUES_EQUAL(retried2, (TVector<ui32>{1, 1, 1}));
     UNIT_ASSERT_VALUES_EQUAL(completed1, false);
     UNIT_ASSERT_VALUES_EQUAL(completed2, false);
-    // CHANGE LATER: counters->CacheMissPages->Val() == 4
-    UNIT_ASSERT_VALUES_EQUAL(counters->CacheMissPages->Val(), 2);
+    UNIT_ASSERT_VALUES_EQUAL(counters->CacheMissPages->Val(), 4);
 
     block.Unblock();
-    // CHANGE LATER: block.size() == 2
-    env.Env.WaitFor("blocked TEvRequest 3", [&]{ return block.size() == 1; }, TDuration::Seconds(10));
+    env.Env.WaitFor("blocked TEvRequest 3", [&]{ return block.size() == 2; }, TDuration::Seconds(10));
     LogCounters(counters);
     UNIT_ASSERT_VALUES_EQUAL(retried1, (TVector<ui32>{1, 1, 1, 1}));
     UNIT_ASSERT_VALUES_EQUAL(retried2, (TVector<ui32>{1, 1, 1, 1}));
     UNIT_ASSERT_VALUES_EQUAL(completed1, false);
     UNIT_ASSERT_VALUES_EQUAL(completed2, false);
-    // CHANGE LATER: counters->CacheMissPages->Val() == 6
-    UNIT_ASSERT_VALUES_EQUAL(counters->CacheMissPages->Val(), 3);
+    UNIT_ASSERT_VALUES_EQUAL(counters->CacheMissPages->Val(), 6);
 
     block.Unblock();
     env.Env.WaitFor("blocked TEvRequest 4", [&]{ return completed1 && completed2; }, TDuration::Seconds(10));
@@ -1251,8 +1244,7 @@ Y_UNIT_TEST(Two_Transactions_One_Key) {
     UNIT_ASSERT(block.empty());
     UNIT_ASSERT_VALUES_EQUAL(retried1, (TVector<ui32>{1, 1, 1, 1, 1}));
     UNIT_ASSERT_VALUES_EQUAL(retried2, (TVector<ui32>{1, 1, 1, 1, 1}));
-    // CHANGE LATER: counters->CacheMissPages->Val() == 8
-    UNIT_ASSERT_VALUES_EQUAL(counters->CacheMissPages->Val(), 4);
+    UNIT_ASSERT_VALUES_EQUAL(counters->CacheMissPages->Val(), 8);
 }
 
 Y_UNIT_TEST(Two_Transactions_Two_Keys) {
@@ -1271,8 +1263,7 @@ Y_UNIT_TEST(Two_Transactions_Two_Keys) {
     env.SendAsync(new NFake::TEvExecute{ new TTxReadRows({66}, retried2, completed2) });
 
     // b-tree index root is common page:
-    // CHANGE LATER: block.size() == 2
-    env.Env.WaitFor("blocked TEvRequest 1", [&]{ return block.size() == 1; }, TDuration::Seconds(10));
+    env.Env.WaitFor("blocked TEvRequest 1", [&]{ return block.size() == 2; }, TDuration::Seconds(10));
     LogCounters(counters);
     UNIT_ASSERT_VALUES_EQUAL(retried1, (TVector<ui32>{1}));
     UNIT_ASSERT_VALUES_EQUAL(retried2, (TVector<ui32>{1}));
@@ -1287,8 +1278,7 @@ Y_UNIT_TEST(Two_Transactions_Two_Keys) {
     UNIT_ASSERT_VALUES_EQUAL(retried2, (TVector<ui32>{1, 1}));
     UNIT_ASSERT_VALUES_EQUAL(completed1, false);
     UNIT_ASSERT_VALUES_EQUAL(completed2, false);
-    // CHANGE LATER: counters->CacheMissPages->Val() == 1
-    UNIT_ASSERT_VALUES_EQUAL(counters->CacheMissPages->Val(), 1);
+    UNIT_ASSERT_VALUES_EQUAL(counters->CacheMissPages->Val(), 2);
 
     block.Unblock();
     env.Env.WaitFor("blocked TEvRequest 3", [&]{ return block.size() == 2; }, TDuration::Seconds(10));
@@ -1297,8 +1287,7 @@ Y_UNIT_TEST(Two_Transactions_Two_Keys) {
     UNIT_ASSERT_VALUES_EQUAL(retried2, (TVector<ui32>{1, 1, 1}));
     UNIT_ASSERT_VALUES_EQUAL(completed1, false);
     UNIT_ASSERT_VALUES_EQUAL(completed2, false);
-    // CHANGE LATER: counters->CacheMissPages->Val() == 4
-    UNIT_ASSERT_VALUES_EQUAL(counters->CacheMissPages->Val(), 3);
+    UNIT_ASSERT_VALUES_EQUAL(counters->CacheMissPages->Val(), 4);
 
     block.Unblock();
     env.Env.WaitFor("blocked TEvRequest 3", [&]{ return block.size() == 2; }, TDuration::Seconds(10));
@@ -1307,8 +1296,7 @@ Y_UNIT_TEST(Two_Transactions_Two_Keys) {
     UNIT_ASSERT_VALUES_EQUAL(retried2, (TVector<ui32>{1, 1, 1, 1}));
     UNIT_ASSERT_VALUES_EQUAL(completed1, false);
     UNIT_ASSERT_VALUES_EQUAL(completed2, false);
-    // CHANGE LATER: counters->CacheMissPages->Val() == 6
-    UNIT_ASSERT_VALUES_EQUAL(counters->CacheMissPages->Val(), 5);
+    UNIT_ASSERT_VALUES_EQUAL(counters->CacheMissPages->Val(), 6);
 
     block.Unblock();
     env.Env.WaitFor("blocked TEvRequest 4", [&]{ return completed1 && completed2; }, TDuration::Seconds(10));
@@ -1316,8 +1304,7 @@ Y_UNIT_TEST(Two_Transactions_Two_Keys) {
     UNIT_ASSERT(block.empty());
     UNIT_ASSERT_VALUES_EQUAL(retried1, (TVector<ui32>{1, 1, 1, 1, 1}));
     UNIT_ASSERT_VALUES_EQUAL(retried2, (TVector<ui32>{1, 1, 1, 1, 1}));
-    // CHANGE LATER: counters->CacheMissPages->Val() == 8
-    UNIT_ASSERT_VALUES_EQUAL(counters->CacheMissPages->Val(), 7);
+    UNIT_ASSERT_VALUES_EQUAL(counters->CacheMissPages->Val(), 8);
 }
 
 Y_UNIT_TEST(Compaction) {
@@ -1347,13 +1334,14 @@ Y_UNIT_TEST(Compaction) {
     Cerr << "...waiting until compacted" << Endl;
     env.WaitFor<NFake::TEvCompacted>();
 
+    block.Unblock();
+
     // page collection invalidation activates waiting transactions:
     env.Env.WaitFor("blocked TEvRequest 2", [&]{ return completed; }, TDuration::Seconds(10));
     LogCounters(counters);
     UNIT_ASSERT_VALUES_EQUAL(retried, (TVector<ui32>{1, 1, 1, 1, 1, 1}));
-    UNIT_ASSERT_VALUES_EQUAL(counters->CacheMissPages->Val(), 121);
+    UNIT_ASSERT_VALUES_EQUAL(counters->CacheMissPages->Val(), 122);
 
-    block.Unblock();
     env->SimulateSleep(TDuration::Seconds(3));
     // nothing should crash    
 }


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

...

### Changelog category <!-- remove all except one -->

* Not for changelog (changelog entry is not required)

### Description for reviewers <!-- (optional) description for those who read this PR -->

In order to remove all excess functionality from Private Cache, track loading pages and their transactions in Shared Cache.

Although it may lead to increase of requested data (in terms of local `NSharedCache::TEvRequest` and `NSharedCache::TEvResult` messages content), I expect that it won't effect much as different transactions usually needs different data pages. Also, we are already tracking all requests and pages in `NKikimr::NSharedCache::TRequest`.