### PR TITLE
Remove unnecessary noexcept uses in LocalDB

### DIFF
--- a/ydb/core/tablet_flat/benchmark/b_part.cpp
+++ b/ydb/core/tablet_flat/benchmark/b_part.cpp
@@ -30,7 +30,7 @@ namespace {
     using TCheckIter = TChecker<TWrapIter, TSubset>;
     using TCheckReverseIter = TChecker<TWrapReverseIter, TSubset>;
 
-    NPage::TConf PageConf(size_t groups, bool writeBTreeIndex) noexcept
+    NPage::TConf PageConf(size_t groups, bool writeBTreeIndex)
     {
         NPage::TConf conf;
 

--- a/ydb/core/tablet_flat/defs.h
+++ b/ydb/core/tablet_flat/defs.h
@@ -49,7 +49,7 @@ namespace NTable {
          *
          * It is always non-negative and materialized as ui64.
          */
-        ui64 ToCounter() const noexcept {
+        ui64 ToCounter() const {
             const auto value = Value;
             Y_ABORT_UNLESS(value >= 0);
             return value;

--- a/ydb/core/tablet_flat/flat_abi_check.h
+++ b/ydb/core/tablet_flat/flat_abi_check.h
@@ -9,7 +9,7 @@ namespace NTable {
     struct TAbi {
         using EVol = ECompatibility;
 
-        void Check(ui32 tail, ui32 head, const char *label) const noexcept
+        void Check(ui32 tail, ui32 head, const char *label) const
         {
             if (tail > head) {
                 Y_Fail(label << " ABI [" << tail << ", " << head << "]"

--- a/ydb/core/tablet_flat/flat_bio_actor.cpp
+++ b/ydb/core/tablet_flat/flat_bio_actor.cpp
@@ -54,7 +54,7 @@ void TBlockIO::Inbox(TEventHandlePtr &eh)
     }
 }
 
-void TBlockIO::Bootstrap(EPriority priority, TAutoPtr<NPageCollection::TFetch> origin) noexcept
+void TBlockIO::Bootstrap(EPriority priority, TAutoPtr<NPageCollection::TFetch> origin)
 {
     Origin = origin;
     Priority = priority;
@@ -73,7 +73,7 @@ void TBlockIO::Bootstrap(EPriority priority, TAutoPtr<NPageCollection::TFetch> o
     Dispatch();
 }
 
-void TBlockIO::Dispatch() noexcept
+void TBlockIO::Dispatch()
 {
     const auto ctx = ActorContext();
 
@@ -138,7 +138,7 @@ void TBlockIO::Dispatch() noexcept
     Y_ABORT_UNLESS(PagesToBlobsConverter->Complete(), "NPageCollection::TPagesToBlobsConverter cooked incomplete loads");
 }
 
-void TBlockIO::Handle(ui32 base, TArrayRef<TLoaded> items) noexcept
+void TBlockIO::Handle(ui32 base, TArrayRef<TLoaded> items)
 {
     if (auto logl = Logger->Log(ELnLev::Debug)) {
         logl
@@ -197,7 +197,7 @@ void TBlockIO::Handle(ui32 base, TArrayRef<TLoaded> items) noexcept
     Terminate(NKikimrProto::OK);
 }
 
-void TBlockIO::Terminate(EStatus code) noexcept
+void TBlockIO::Terminate(EStatus code)
 {
     if (auto logl = Logger->Log(code ? ELnLev::Warn : ELnLev::Debug)) {
         logl

--- a/ydb/core/tablet_flat/flat_bio_actor.h
+++ b/ydb/core/tablet_flat/flat_bio_actor.h
@@ -24,10 +24,10 @@ namespace NBlockIO {
     private:
         void Registered(TActorSystem*, const TActorId&) override;
         void Inbox(TEventHandlePtr &eh);
-        void Bootstrap(EPriority priority, TAutoPtr<NPageCollection::TFetch>) noexcept;
-        void Dispatch() noexcept;
-        void Handle(ui32 offset, TArrayRef<TLoaded>) noexcept;
-        void Terminate(EStatus code) noexcept;
+        void Bootstrap(EPriority priority, TAutoPtr<NPageCollection::TFetch>);
+        void Dispatch();
+        void Handle(ui32 offset, TArrayRef<TLoaded>);
+        void Terminate(EStatus code);
 
     private:
         const TActorId Service;
@@ -61,7 +61,7 @@ namespace NBlockIO {
 
     template<typename ... TArgs>
     inline void Start(NActors::IActorOps *ops, TActorId service,
-                        ui64 cookie, TArgs&& ... args) noexcept
+                        ui64 cookie, TArgs&& ... args)
     {
         auto self = ops->Register(new TBlockIO(service, cookie));
 

--- a/ydb/core/tablet_flat/flat_bloom_hash.h
+++ b/ydb/core/tablet_flat/flat_bloom_hash.h
@@ -29,7 +29,7 @@ namespace NBloom {
             }
         }
 
-        inline TStringBuf Get(ui32 len) const noexcept
+        inline TStringBuf Get(ui32 len) const
         {
             Y_ABORT_UNLESS(len > 0 && len <= Offsets.size());
 

--- a/ydb/core/tablet_flat/flat_bloom_writer.h
+++ b/ydb/core/tablet_flat/flat_bloom_writer.h
@@ -39,7 +39,7 @@ namespace NBloom {
             HashCount = Min(ui64(Max<ui16>()), ui64(ceil(-log2err)));
         }
 
-        ui64 Bits(ui64 rows) const noexcept
+        ui64 Bits(ui64 rows) const
         {
             Y_ABORT_UNLESS(!(rows >> 54),
                 "Too many rows, probably an invalid value passed");

--- a/ydb/core/tablet_flat/flat_boot_alter.h
+++ b/ydb/core/tablet_flat/flat_boot_alter.h
@@ -25,7 +25,7 @@ namespace NBoot {
         }
 
     private: /* IStep, boot logic DSL actor interface   */
-        void Start() noexcept override
+        void Start() override
         {
             for (auto slot: xrange(Queue.size()))
                 if (const auto &largeGlobId = Queue.at(slot).LargeGlobId)
@@ -34,7 +34,7 @@ namespace NBoot {
             Flush();
         }
 
-        void HandleStep(TIntrusivePtr<IStep> step) noexcept override
+        void HandleStep(TIntrusivePtr<IStep> step) override
         {
             auto *load = step->ConsumeAs<TLoadBlobs>(Pending);
 
@@ -47,7 +47,7 @@ namespace NBoot {
         }
 
     private:
-        void Flush() noexcept
+        void Flush()
         {
             for (TBody *head = nullptr; Queue && *(head = &Queue[0]); ) {
                 Apply(head->LargeGlobId, head->Body);
@@ -62,7 +62,7 @@ namespace NBoot {
             }
         }
 
-        void Apply(const NPageCollection::TLargeGlobId &largeGlobId, TArrayRef<const char> body) noexcept
+        void Apply(const NPageCollection::TLargeGlobId &largeGlobId, TArrayRef<const char> body)
         {
             bool rewrite = false;
             if (body) {

--- a/ydb/core/tablet_flat/flat_boot_back.h
+++ b/ydb/core/tablet_flat/flat_boot_back.h
@@ -43,7 +43,7 @@ namespace NBoot {
     };
 
     struct TBody {
-        void Describe(IOutputStream &out) const noexcept
+        void Describe(IOutputStream &out) const
         {
             out
                 << "Body{ " << NFmt::Do(LargeGlobId)
@@ -68,7 +68,7 @@ namespace NBoot {
 
         }
 
-        void Describe(IOutputStream &out) const noexcept
+        void Describe(IOutputStream &out) const
         {
             out
                 << (Follower ? "Follower" : "Leader")

--- a/ydb/core/tablet_flat/flat_boot_blobs.h
+++ b/ydb/core/tablet_flat/flat_boot_blobs.h
@@ -26,7 +26,7 @@ namespace NBoot {
             Y_ABORT_UNLESS(!RefCount(), "TLoadBlobs is still referenced somewhere");
         }
 
-        void Start() noexcept override { }
+        void Start() override { }
 
         void Feed(TLogoBlobID blobId, TString body)
         {

--- a/ydb/core/tablet_flat/flat_boot_bundle.h
+++ b/ydb/core/tablet_flat/flat_boot_bundle.h
@@ -35,7 +35,7 @@ namespace NBoot {
         }
 
     private: /* IStep, boot logic DSL actor interface   */
-        void Start() noexcept override
+        void Start() override
         {
             PageCollections.resize(LargeGlobIds.size());
 
@@ -50,7 +50,7 @@ namespace NBoot {
             TryLoad();
         }
 
-        bool HandleBio(NSharedCache::TEvResult &msg) noexcept override
+        bool HandleBio(NSharedCache::TEvResult &msg) override
         {
             Y_ABORT_UNLESS(Loader, "PageCollections loader got un unexpected pages fetch");
 
@@ -70,7 +70,7 @@ namespace NBoot {
             return msg.Status == NKikimrProto::OK;
         }
 
-        void HandleStep(TIntrusivePtr<IStep> step) noexcept override
+        void HandleStep(TIntrusivePtr<IStep> step) override
         {
             auto *load = step->ConsumeAs<TLoadBlobs>(LeftMetas);
 

--- a/ydb/core/tablet_flat/flat_boot_cookie.h
+++ b/ydb/core/tablet_flat/flat_boot_cookie.h
@@ -36,7 +36,7 @@ namespace NBoot {
         static_assert(MaskType ^ MaskIdx ^ MaskSub == 0xffffff, "");
         static_assert((MaskIdx >> OffIdx) == ui32(EIdx::End), "");
 
-        TCookie(ui32 raw) : Raw(raw) { }
+        TCookie(ui32 raw) noexcept : Raw(raw) { }
 
         TCookie(EType type, EIdx index, ui32 sub)
             : Raw((ui32(type) << OffType) | (ui32(index) << OffIdx) | sub)
@@ -48,24 +48,24 @@ namespace NBoot {
         EIdx Index() const { return EIdx((Raw & MaskIdx) >> OffIdx); }
         ui32 Sub() const { return (Raw & MaskSub); }
 
-        static NPageCollection::TCookieRange CookieRange(EIdx index) noexcept
+        static NPageCollection::TCookieRange CookieRange(EIdx index)
         {
             return { RawFor(index, 0), RawFor(index, Max<ui32>()) };
         }
 
-        static NPageCollection::TCookieRange CookieRangeRaw() noexcept
+        static NPageCollection::TCookieRange CookieRangeRaw()
         {
             return { RawFor(EIdx::Raw, 0), RawFor(EIdx::End, Max<ui32>()) };
         }
 
-        static ui32 RawFor(EIdx type, ui32 offset) noexcept
+        static ui32 RawFor(EIdx type, ui32 offset)
         {
             offset = Min(offset, ui32(MaskSub));
 
             return TCookie(EType::Log, type, offset).Raw;
         }
 
-        const ui32 Raw = 0; /* only lower 24 bits are used */
+        const ui32 Raw; /* only lower 24 bits are used */
     };
 
     enum class ELogCommitMeta : ui32 {

--- a/ydb/core/tablet_flat/flat_boot_env.h
+++ b/ydb/core/tablet_flat/flat_boot_env.h
@@ -27,7 +27,7 @@ namespace NBoot {
             return Logger_.Get();
         }
 
-        void Describe(IOutputStream &out) const noexcept override
+        void Describe(IOutputStream &out) const override
         {
             out
                 << "Boot{ " << Queue.size() << " que"
@@ -45,7 +45,7 @@ namespace NBoot {
             Start(new TStep(this, std::forward<TArgs>(args)...));
         }
 
-        void Execute() noexcept
+        void Execute()
         {
             for (; Queue; Queue.pop_front()) {
                 auto order = std::move(Queue.front());
@@ -69,9 +69,9 @@ namespace NBoot {
         }
 
     protected:
-        void Start() noexcept override { }
+        void Start() override { }
 
-        void Start(TIntrusivePtr<IStep> step) noexcept override
+        void Start(TIntrusivePtr<IStep> step) override
         {
             Y_ABORT_UNLESS(step->Env == nullptr, "IStep is already fired");
             Y_ABORT_UNLESS(step->Owner, "Start called on step without an owner");
@@ -79,7 +79,7 @@ namespace NBoot {
             Queue.emplace_back(EOp::Start, std::move(step));
         }
 
-        void Finish(TIntrusivePtr<IStep> step) noexcept override
+        void Finish(TIntrusivePtr<IStep> step) override
         {
             Y_ABORT_UNLESS(step, "Finish called without a step");
             Y_ABORT_UNLESS(step->Owner, "Finish called on step without an owner");

--- a/ydb/core/tablet_flat/flat_boot_gclog.h
+++ b/ydb/core/tablet_flat/flat_boot_gclog.h
@@ -26,7 +26,7 @@ namespace NBoot {
         }
 
     private: /* IStep, boot logic DSL actor interface   */
-        void Start() noexcept override
+        void Start() override
         {
             for (auto slot: xrange(Queue.size()))
                 if (const auto &largeGlobId = Queue.at(slot).LargeGlobId)
@@ -35,7 +35,7 @@ namespace NBoot {
             Flush();
         }
 
-        void HandleStep(TIntrusivePtr<IStep> step) noexcept override
+        void HandleStep(TIntrusivePtr<IStep> step) override
         {
             auto *load = step->ConsumeAs<TLoadBlobs>(Pending);
 
@@ -48,7 +48,7 @@ namespace NBoot {
         }
 
     private:
-        void Flush() noexcept
+        void Flush()
         {
             for (TBody *head = nullptr; Queue && *(head = &Queue[0]); ) {
                 auto gen = head->LargeGlobId.Lead.Generation();
@@ -66,7 +66,7 @@ namespace NBoot {
             }
         }
 
-        void Apply(ui32 gen, ui32 step, TArrayRef<const char> body) noexcept
+        void Apply(ui32 gen, ui32 step, TArrayRef<const char> body)
         {
             TProtoBox<NKikimrExecutorFlat::TExternalGcEntry> proto(body);
 

--- a/ydb/core/tablet_flat/flat_boot_iface.h
+++ b/ydb/core/tablet_flat/flat_boot_iface.h
@@ -39,9 +39,9 @@ namespace NBoot {
 
     struct IEnv {
         virtual const NUtil::ILogger* Logger() const noexcept = 0;
-        virtual void Describe(IOutputStream&) const noexcept = 0;
-        virtual void Start(TIntrusivePtr<IStep>) noexcept = 0;
-        virtual void Finish(TIntrusivePtr<IStep>) noexcept = 0;
+        virtual void Describe(IOutputStream&) const = 0;
+        virtual void Start(TIntrusivePtr<IStep>) = 0;
+        virtual void Finish(TIntrusivePtr<IStep>) = 0;
     };
 
     class IStep : public TSimpleRefCount<IStep> {
@@ -70,14 +70,14 @@ namespace NBoot {
 
         virtual ~IStep() = default;
 
-        virtual void Start() noexcept = 0;
+        virtual void Start() = 0;
 
-        virtual bool HandleBio(NSharedCache::TEvResult&) noexcept
+        virtual bool HandleBio(NSharedCache::TEvResult&)
         {
             Y_ABORT("Boot IStep got an unhandled NSharedCache::TEvResult event");
         }
 
-        virtual void HandleStep(TIntrusivePtr<IStep>) noexcept
+        virtual void HandleStep(TIntrusivePtr<IStep>)
         {
             Y_ABORT("Boot IStep got an unhandled child step result");
         }

--- a/ydb/core/tablet_flat/flat_boot_lease.cpp
+++ b/ydb/core/tablet_flat/flat_boot_lease.cpp
@@ -81,7 +81,7 @@ private:
     const TDuration LeaseDuration;
 };
 
-void TExecutorBootLogic::StartLeaseWaiter(TMonotonic bootTimestamp, const TEvTablet::TDependencyGraph& graph) noexcept
+void TExecutorBootLogic::StartLeaseWaiter(TMonotonic bootTimestamp, const TEvTablet::TDependencyGraph& graph)
 {
     TActorId leaseHolder;
     TDuration leaseDuration;

--- a/ydb/core/tablet_flat/flat_boot_loans.h
+++ b/ydb/core/tablet_flat/flat_boot_loans.h
@@ -26,7 +26,7 @@ namespace NBoot {
         }
 
     private: /* IStep, boot logic DSL actor interface   */
-        void Start() noexcept override
+        void Start() override
         {
             for (auto slot: xrange(Queue.size()))
                 if (const auto &largeGlobId = Queue.at(slot).LargeGlobId)
@@ -35,7 +35,7 @@ namespace NBoot {
             Flush();
         }
 
-        void HandleStep(TIntrusivePtr<IStep> step) noexcept override
+        void HandleStep(TIntrusivePtr<IStep> step) override
         {
             auto *load = step->ConsumeAs<TLoadBlobs>(Pending);
 
@@ -48,7 +48,7 @@ namespace NBoot {
         }
 
     private:
-        void Flush() noexcept
+        void Flush()
         {
             for (TBody *head = nullptr; Queue && *(head = &Queue[0]); ) {
                 Apply(head->LargeGlobId.Lead, Codec->Decode(head->Body));
@@ -63,7 +63,7 @@ namespace NBoot {
             }
         }
 
-        void Apply(const TLogoBlobID &label, TArrayRef<const char> body) noexcept
+        void Apply(const TLogoBlobID &label, TArrayRef<const char> body)
         {
             TProtoBox<NKikimrExecutorFlat::TBorrowedPart> proto(body);
 

--- a/ydb/core/tablet_flat/flat_boot_misc.cpp
+++ b/ydb/core/tablet_flat/flat_boot_misc.cpp
@@ -9,7 +9,7 @@ namespace NKikimr {
 namespace NTabletFlatExecutor {
 namespace NBoot {
 
-void TStages::FinalizeLeaderLogics(TResult &result, TSteppedCookieAllocatorFactory &steppedCookieAllocatorFactory) noexcept
+void TStages::FinalizeLeaderLogics(TResult &result, TSteppedCookieAllocatorFactory &steppedCookieAllocatorFactory)
 {
     using EIdx = TCookie::EIdx;
 

--- a/ydb/core/tablet_flat/flat_boot_oven.h
+++ b/ydb/core/tablet_flat/flat_boot_oven.h
@@ -26,7 +26,7 @@ namespace NBoot {
 
         }
 
-        TAutoPtr<TSteppedCookieAllocator> Sys(TCookie::EIdx idx) noexcept
+        TAutoPtr<TSteppedCookieAllocator> Sys(TCookie::EIdx idx)
         {
             Acquire(idx);
 
@@ -35,7 +35,7 @@ namespace NBoot {
             return new TSteppedCookieAllocator(Tablet, stamp, TCookie::CookieRange(idx), { Sys1 });
         }
 
-        TAutoPtr<TSteppedCookieAllocator> Data() noexcept
+        TAutoPtr<TSteppedCookieAllocator> Data()
         {
             Acquire(TCookie::EIdx::Raw);
 
@@ -65,7 +65,7 @@ namespace NBoot {
         }
 
     private:
-        void Acquire(TCookie::EIdx idx) noexcept
+        void Acquire(TCookie::EIdx idx)
         {
             const auto mask = ui64(1) << unsigned(idx);
 

--- a/ydb/core/tablet_flat/flat_boot_redo.h
+++ b/ydb/core/tablet_flat/flat_boot_redo.h
@@ -29,7 +29,7 @@ namespace NBoot {
         }
 
     private: /* IStep, boot logic DSL actor interface   */
-        void Start() noexcept override
+        void Start() override
         {
             if (auto logl = Env->Logger()->Log(ELnLev::Info)) {
                 const auto last = Queue ? Queue.back().Stamp + 1 : 0;
@@ -46,7 +46,7 @@ namespace NBoot {
             Flush();
         }
 
-        void HandleStep(TIntrusivePtr<IStep> step) noexcept override
+        void HandleStep(TIntrusivePtr<IStep> step) override
         {
             auto *load = step->ConsumeAs<TLoadBlobs>(Pending);
 
@@ -59,7 +59,7 @@ namespace NBoot {
         }
 
     private:
-        void Flush() noexcept
+        void Flush()
         {
             for (TLogEntry *head = nullptr; Queue && *(head = &Queue[0]); ) {
                 auto index = TCookie(head->LargeGlobId.Lead.Cookie()).Index();
@@ -80,7 +80,7 @@ namespace NBoot {
             }
         }
 
-        void Apply(ui64 stamp, const TLogEntry &entry, TString redo) noexcept
+        void Apply(ui64 stamp, const TLogEntry &entry, TString redo)
         {
             const auto begin_ = Back->DatabaseImpl->Serial();
 

--- a/ydb/core/tablet_flat/flat_boot_snap.h
+++ b/ydb/core/tablet_flat/flat_boot_snap.h
@@ -34,7 +34,7 @@ namespace NBoot {
         }
 
     private: /* IStep, boot logic DSL actor interface   */
-        void Start() noexcept override
+        void Start() override
         {
             GrabSnapFromDeps();
 
@@ -49,7 +49,7 @@ namespace NBoot {
             }
         }
 
-        void HandleStep(TIntrusivePtr<IStep> step) noexcept override
+        void HandleStep(TIntrusivePtr<IStep> step) override
         {
             auto *load = step->ConsumeAs<TLoadBlobs>(Pending);
 
@@ -57,7 +57,7 @@ namespace NBoot {
         }
 
     private:
-        void Apply(const NPageCollection::TLargeGlobId &snap, TArrayRef<const char> body) noexcept
+        void Apply(const NPageCollection::TLargeGlobId &snap, TArrayRef<const char> body)
         {
             if (EIdx::SnapLz4 == TCookie(snap.Lead.Cookie()).Index()) {
                 Decode(snap, Codec->Decode(body));
@@ -68,7 +68,7 @@ namespace NBoot {
             ProcessSnap(snap), ProcessDeps(), Env->Finish(this);
         }
 
-        void Decode(const NPageCollection::TLargeGlobId &snap, TArrayRef<const char> body) noexcept
+        void Decode(const NPageCollection::TLargeGlobId &snap, TArrayRef<const char> body)
         {
             bool ok = ParseFromStringNoSizeLimit(Proto, body);
             Y_VERIFY_S(ok, "Failed to parse snapshot " << snap.Lead);
@@ -94,7 +94,7 @@ namespace NBoot {
                 NTable::TAbi().Check(abi->GetTail(), abi->GetHead(), "snap");
         }
 
-        void ProcessSnap(const NPageCollection::TLargeGlobId &snap) noexcept
+        void ProcessSnap(const NPageCollection::TLargeGlobId &snap)
         {
             Back->Snap = snap;
             Back->Serial = Proto.GetSerial();
@@ -137,7 +137,7 @@ namespace NBoot {
             ReadWaste();
         }
 
-        void ReadAlterLog() noexcept
+        void ReadAlterLog()
         {
             TVector<TLogoBlobID> blobs;
 
@@ -161,7 +161,7 @@ namespace NBoot {
             }
         }
 
-        void ReadRedoSnap() noexcept
+        void ReadRedoSnap()
         {
             /* Merge of two lists with redo log records preferring records with
                 embedded bodies. Later merge will be dropped and replaced with
@@ -197,7 +197,7 @@ namespace NBoot {
             }
         }
 
-        void ReadGcSnap() noexcept
+        void ReadGcSnap()
         {
             if (auto *logic = Logic->Result().GcLogic.Get()) {
                 const auto &lead = Back->Snap.Lead;
@@ -229,7 +229,7 @@ namespace NBoot {
             }
         }
 
-        void ReadWaste() const noexcept
+        void ReadWaste() const
         {
             if (auto *waste = Back->Waste.Get()) {
                 if (Proto.HasWaste()) {
@@ -249,7 +249,7 @@ namespace NBoot {
             }
         }
 
-        void GrabSnapFromDeps() noexcept
+        void GrabSnapFromDeps()
         {
             auto *entry = (Deps && Deps->Entries) ? &Deps->Entries[0] : nullptr;
 
@@ -276,7 +276,7 @@ namespace NBoot {
             }
         }
 
-        void ProcessDeps() noexcept
+        void ProcessDeps()
         {
             if (Deps) {
                 for (auto &entry : Deps->Entries) {

--- a/ydb/core/tablet_flat/flat_boot_stages.h
+++ b/ydb/core/tablet_flat/flat_boot_stages.h
@@ -44,18 +44,18 @@ namespace NBoot {
         }
 
     private: /* IStep, boot logic DSL actor interface   */
-        void Start() noexcept override
+        void Start() override
         {
             Execute();
         }
 
-        void HandleStep(TIntrusivePtr<IStep>) noexcept override
+        void HandleStep(TIntrusivePtr<IStep>) override
         {
             Pending -=1, Execute();
         }
 
     private:
-        void Execute() noexcept
+        void Execute()
         {
             while (!Pending && Next < EStage::Ready) {
                 if (EStage::Snap == Next) {
@@ -81,7 +81,7 @@ namespace NBoot {
             }
         }
 
-        void StartStageSnap() noexcept
+        void StartStageSnap()
         {
             if (auto logl = Env->Logger()->Log(ELnLev::Info)) {
                 logl
@@ -93,7 +93,7 @@ namespace NBoot {
             Pending += Spawn<TSnap>(std::move(Deps), Snap);
         }
 
-        void StartStageMeta() noexcept
+        void StartStageMeta()
         {
             if (auto logl = Env->Logger()->Log(ELnLev::Info)) {
                 logl
@@ -110,7 +110,7 @@ namespace NBoot {
             Pending += Spawn<TTurns>();
         }
 
-        void StartStageDatabaseImpl() noexcept
+        void StartStageDatabaseImpl()
         {
             auto weak = Back->RedoLog ? Back->RedoLog.back().Stamp + 1 : 0;
 
@@ -172,7 +172,7 @@ namespace NBoot {
             Pending += Spawn<TRedo>(std::move(Back->RedoLog));
         }
 
-        void StartStageResult(TResult &result) noexcept
+        void StartStageResult(TResult &result)
         {
             /* Tail of redo log before snapshot may have holes in space of
                 db change serial numbers. Thus embedded serials into log may
@@ -212,7 +212,7 @@ namespace NBoot {
             }
         }
 
-        void FinalizeLeaderLogics(TResult&, TSteppedCookieAllocatorFactory&) noexcept;
+        void FinalizeLeaderLogics(TResult&, TSteppedCookieAllocatorFactory&);
 
     private:
         EStage Next = EStage::Snap;   /* Next stage to execute */

--- a/ydb/core/tablet_flat/flat_boot_turns.h
+++ b/ydb/core/tablet_flat/flat_boot_turns.h
@@ -22,7 +22,7 @@ namespace NBoot {
         }
 
     private: /* IStep, boot logic DSL actor interface   */
-        void Start() noexcept override
+        void Start() override
         {
             for (auto slot: xrange(Back->Switches.size()))
                 if (const auto &largeGlobId = Back->Switches[slot].LargeGlobId)
@@ -31,7 +31,7 @@ namespace NBoot {
             Flush();
         }
 
-        void HandleStep(TIntrusivePtr<IStep> step) noexcept override
+        void HandleStep(TIntrusivePtr<IStep> step) override
         {
             auto *load = step->ConsumeAs<TLoadBlobs>(Pending);
 
@@ -40,14 +40,14 @@ namespace NBoot {
         }
 
     private:
-        void Flush() noexcept
+        void Flush()
         {
             Process();
 
             if (!Pending && Handled >= Back->Switches.size()) Env->Finish(this);
         }
 
-        void Assign(ui32 slot, TArrayRef<const char> body) noexcept
+        void Assign(ui32 slot, TArrayRef<const char> body)
         {
             Y_ABORT_UNLESS(slot < Back->Switches.size(), "Invalid switch index");
 
@@ -63,7 +63,7 @@ namespace NBoot {
             }
         }
 
-        void Apply(TSwitch &entry, TArrayRef<const char> body) noexcept
+        void Apply(TSwitch &entry, TArrayRef<const char> body)
         {
             TProtoBox<NKikimrExecutorFlat::TTablePartSwitch> proto(body);
 
@@ -96,7 +96,7 @@ namespace NBoot {
                 Back->SetTableEdge(proto.GetTableSnapshoted());
         }
 
-        void Process() noexcept
+        void Process()
         {
             for (; Handled < Back->Switches.size(); Handled++) {
                 auto &front = Back->Switches[Handled];

--- a/ydb/core/tablet_flat/flat_boot_txstatus.h
+++ b/ydb/core/tablet_flat/flat_boot_txstatus.h
@@ -21,7 +21,7 @@ namespace NBoot {
         { }
 
     private:
-        void Start() noexcept override {
+        void Start() override {
             if (TSharedData* data = Back->TxStatusCaches.FindPtr(DataId.Lead)) {
                 TxStatus = MakeIntrusive<NTable::TTxStatusPartStore>(DataId, Epoch, *data);
             } else {
@@ -30,7 +30,7 @@ namespace NBoot {
             TryFinish();
         }
 
-        void HandleStep(TIntrusivePtr<IStep> step) noexcept override
+        void HandleStep(TIntrusivePtr<IStep> step) override
         {
             auto *load = step->ConsumeAs<TLoadBlobs>(LeftBlobs);
             TSharedData data = load->PlainData();
@@ -40,7 +40,7 @@ namespace NBoot {
         }
 
     private:
-        void TryFinish() noexcept {
+        void TryFinish() {
             if (!LeftBlobs) {
                 // TODO: we probably want to delay merge as late as possible?
                 Back->DatabaseImpl->Merge(Table, std::move(TxStatus));

--- a/ydb/core/tablet_flat/flat_boot_util.h
+++ b/ydb/core/tablet_flat/flat_boot_util.h
@@ -36,7 +36,7 @@ namespace NBoot {
             return Value;
         }
 
-        TLeft& operator +=(const TSpawned& spawned) noexcept
+        TLeft& operator +=(const TSpawned& spawned)
         {
             if (spawned) {
                 *this += size_t(1);
@@ -45,7 +45,7 @@ namespace NBoot {
             return *this;
         }
 
-        TLeft& operator +=(size_t inc) noexcept
+        TLeft& operator +=(size_t inc)
         {
             if (Value > Max<decltype(Value)>() - inc) {
 
@@ -57,7 +57,7 @@ namespace NBoot {
             return *this;
         }
 
-        TLeft& operator -=(size_t dec) noexcept
+        TLeft& operator -=(size_t dec)
         {
             Y_ABORT_UNLESS(Value >= dec, "TLeft counter is underflowed");
 

--- a/ydb/core/tablet_flat/flat_boot_warm.h
+++ b/ydb/core/tablet_flat/flat_boot_warm.h
@@ -19,7 +19,7 @@ namespace NBoot {
         TMemTable(IStep *owner) : IStep(owner, NBoot::EStep::MemTable) { }
 
     private: /* IStep, boot logic DSL actor interface   */
-        void Start() noexcept override
+        void Start() override
         {
             for (auto it: Back->DatabaseImpl->Scheme->Tables) {
                 const auto &wrap = Back->DatabaseImpl->Get(it.first, true);
@@ -48,7 +48,7 @@ namespace NBoot {
             }
         }
 
-        void HandleStep(TIntrusivePtr<IStep> step) noexcept override
+        void HandleStep(TIntrusivePtr<IStep> step) override
         {
             auto *load = step->ConsumeAs<TLoadBlobs>(Pending);
 

--- a/ydb/core/tablet_flat/flat_comp.cpp
+++ b/ydb/core/tablet_flat/flat_comp.cpp
@@ -3,7 +3,7 @@
 namespace NKikimr {
 namespace NTable {
 
-void TCompactionParams::Describe(IOutputStream& out) const noexcept {
+void TCompactionParams::Describe(IOutputStream& out) const {
     out << "TCompactionParams{" << Table << ":";
 
     if (Edge.Head == TEpoch::Max()) {

--- a/ydb/core/tablet_flat/flat_comp.h
+++ b/ydb/core/tablet_flat/flat_comp.h
@@ -21,7 +21,7 @@ namespace NTable {
         virtual ~TCompactionParams() = default;
 
         // Used to log compaction parameters
-        virtual void Describe(IOutputStream& out) const noexcept;
+        virtual void Describe(IOutputStream& out) const;
 
     public:
         ui32 Table = Max<ui32>();

--- a/ydb/core/tablet_flat/flat_comp_gen.cpp
+++ b/ydb/core/tablet_flat/flat_comp_gen.cpp
@@ -14,7 +14,7 @@ static constexpr ui32 PRIORITY_UPDATE_FACTOR = 20;
 
 }
 
-void TGenCompactionParams::Describe(IOutputStream& out) const noexcept {
+void TGenCompactionParams::Describe(IOutputStream& out) const {
     out << "TGenCompactionParams{" << Table << ": gen " << Generation;
 
     if (Edge.Head == TEpoch::Max()) {
@@ -31,7 +31,7 @@ struct TGenCompactionStrategy::TPartAggregator {
     THashMap<ui64, TStats> StatsPerTablet;
     ui64 PartEpochCount = 0;
 
-    TPartAggregator& Add(const TPartInfo& part) noexcept {
+    TPartAggregator& Add(const TPartInfo& part) {
         Y_ABORT_UNLESS(part.Epoch != TEpoch::Max(),
             "Unexpected part with an infinite epoch found");
         Stats += part.Stats;
@@ -44,7 +44,7 @@ struct TGenCompactionStrategy::TPartAggregator {
     }
 
     template<class Container>
-    TPartAggregator& Add(const Container& container) noexcept {
+    TPartAggregator& Add(const Container& container) {
         for (auto& part : container) {
             Add(part);
         }
@@ -89,7 +89,7 @@ struct TGenCompactionStrategy::TExtraState {
     }
 };
 
-TGenCompactionStrategy::TPartInfo& TGenCompactionStrategy::TGeneration::PushFront(TPartView partView) noexcept {
+TGenCompactionStrategy::TPartInfo& TGenCompactionStrategy::TGeneration::PushFront(TPartView partView) {
     Y_ABORT_UNLESS(TakenHeadParts == 0,
         "Attempting to prepend part to generation that has taken head parts");
 
@@ -104,7 +104,7 @@ TGenCompactionStrategy::TPartInfo& TGenCompactionStrategy::TGeneration::PushFron
     return front;
 }
 
-TGenCompactionStrategy::TPartInfo& TGenCompactionStrategy::TGeneration::PushBack(TPartView partView) noexcept {
+TGenCompactionStrategy::TPartInfo& TGenCompactionStrategy::TGeneration::PushBack(TPartView partView) {
     Y_ABORT_UNLESS(CompactingTailParts == 0,
         "Attempting to append part to generation that has compacting tail parts");
 
@@ -123,7 +123,7 @@ TGenCompactionStrategy::TPartInfo& TGenCompactionStrategy::TGeneration::PushBack
     return back;
 }
 
-void TGenCompactionStrategy::TGeneration::PopFront() noexcept {
+void TGenCompactionStrategy::TGeneration::PopFront() {
     Y_ABORT_UNLESS(Parts.size() > CompactingTailParts,
         "Attempting to remove part crossing compacting tail parts");
 
@@ -151,7 +151,7 @@ void TGenCompactionStrategy::TGeneration::PopFront() noexcept {
     }
 }
 
-void TGenCompactionStrategy::TGeneration::PopBack() noexcept {
+void TGenCompactionStrategy::TGeneration::PopBack() {
     Y_ABORT_UNLESS(Parts.size() > TakenHeadParts,
         "Attempting to remove part crossing taken head parts");
 

--- a/ydb/core/tablet_flat/flat_comp_gen.h
+++ b/ydb/core/tablet_flat/flat_comp_gen.h
@@ -12,7 +12,7 @@ namespace NCompGen {
 
     class TGenCompactionParams final : public TCompactionParams {
     public:
-        void Describe(IOutputStream& out) const noexcept override;
+        void Describe(IOutputStream& out) const override;
 
     public:
         ui32 Generation = Max<ui32>();
@@ -195,10 +195,10 @@ namespace NCompGen {
             THashMap<ui64, TStats> StatsPerTablet;
             float OverloadFactor = 0.0;
 
-            TPartInfo& PushFront(TPartView partView) noexcept;
-            TPartInfo& PushBack(TPartView partView) noexcept;
-            void PopFront() noexcept;
-            void PopBack() noexcept;
+            TPartInfo& PushFront(TPartView partView);
+            TPartInfo& PushBack(TPartView partView);
+            void PopFront();
+            void PopBack();
         };
 
         struct TFinalState {

--- a/ydb/core/tablet_flat/flat_database.cpp
+++ b/ydb/core/tablet_flat/flat_database.cpp
@@ -38,7 +38,7 @@ bool TDatabase::TChangeCounter::operator<(const TChangeCounter& rhs) const {
     return Epoch < rhs.Epoch;
 }
 
-TDatabase::TDatabase(TDatabaseImpl *databaseImpl) noexcept
+TDatabase::TDatabase(TDatabaseImpl *databaseImpl)
     : DatabaseImpl(databaseImpl ? databaseImpl : new TDatabaseImpl(0, new TScheme, nullptr))
 {
 
@@ -51,12 +51,12 @@ const TScheme& TDatabase::GetScheme() const noexcept
     return *DatabaseImpl->Scheme;
 }
 
-TIntrusiveConstPtr<TRowScheme> TDatabase::GetRowScheme(ui32 table) const noexcept
+TIntrusiveConstPtr<TRowScheme> TDatabase::GetRowScheme(ui32 table) const
 {
     return Require(table)->GetScheme();
 }
 
-TAutoPtr<TTableIter> TDatabase::Iterate(ui32 table, TRawVals key, TTagsRef tags, ELookup mode) const noexcept
+TAutoPtr<TTableIter> TDatabase::Iterate(ui32 table, TRawVals key, TTagsRef tags, ELookup mode) const
 {
     CheckReadAllowed(table);
 
@@ -89,7 +89,7 @@ TAutoPtr<TTableIter> TDatabase::Iterate(ui32 table, TRawVals key, TTagsRef tags,
 TAutoPtr<TTableIter> TDatabase::IterateExact(ui32 table, TRawVals key, TTagsRef tags,
         TRowVersion snapshot,
         const ITransactionMapPtr& visible,
-        const ITransactionObserverPtr& observer) const noexcept
+        const ITransactionObserverPtr& observer) const
 {
     CheckReadAllowed(table);
 
@@ -141,7 +141,7 @@ namespace {
 TAutoPtr<TTableIter> TDatabase::IterateRange(ui32 table, const TKeyRange& range, TTagsRef tags,
         TRowVersion snapshot,
         const ITransactionMapPtr& visible,
-        const ITransactionObserverPtr& observer) const noexcept
+        const ITransactionObserverPtr& observer) const
 {
     CheckReadAllowed(table);
 
@@ -168,7 +168,7 @@ TAutoPtr<TTableIter> TDatabase::IterateRange(ui32 table, const TKeyRange& range,
 TAutoPtr<TTableReverseIter> TDatabase::IterateRangeReverse(ui32 table, const TKeyRange& range, TTagsRef tags,
         TRowVersion snapshot,
         const ITransactionMapPtr& visible,
-        const ITransactionObserverPtr& observer) const noexcept
+        const ITransactionObserverPtr& observer) const
 {
     CheckReadAllowed(table);
 
@@ -196,7 +196,7 @@ template<>
 TAutoPtr<TTableIter> TDatabase::IterateRangeGeneric<TTableIter>(ui32 table, const TKeyRange& range, TTagsRef tags,
         TRowVersion snapshot,
         const ITransactionMapPtr& visible,
-        const ITransactionObserverPtr& observer) const noexcept
+        const ITransactionObserverPtr& observer) const
 {
     return IterateRange(table, range, tags, snapshot, visible, observer);
 }
@@ -205,7 +205,7 @@ template<>
 TAutoPtr<TTableReverseIter> TDatabase::IterateRangeGeneric<TTableReverseIter>(ui32 table, const TKeyRange& range, TTagsRef tags,
         TRowVersion snapshot,
         const ITransactionMapPtr& visible,
-        const ITransactionObserverPtr& observer) const noexcept
+        const ITransactionObserverPtr& observer) const
 {
     return IterateRangeReverse(table, range, tags, snapshot, visible, observer);
 }
@@ -213,7 +213,7 @@ TAutoPtr<TTableReverseIter> TDatabase::IterateRangeGeneric<TTableReverseIter>(ui
 EReady TDatabase::Select(ui32 table, TRawVals key, TTagsRef tags, TRowState &row, ui64 flg,
         TRowVersion snapshot,
         const ITransactionMapPtr& visible,
-        const ITransactionObserverPtr& observer) const noexcept
+        const ITransactionObserverPtr& observer) const
 {
     TSelectStats stats;
     return Select(table, key, tags, row, stats, flg, snapshot, visible, observer);
@@ -222,7 +222,7 @@ EReady TDatabase::Select(ui32 table, TRawVals key, TTagsRef tags, TRowState &row
 EReady TDatabase::Select(ui32 table, TRawVals key, TTagsRef tags, TRowState &row, TSelectStats& stats, ui64 flg,
         TRowVersion snapshot,
         const ITransactionMapPtr& visible,
-        const ITransactionObserverPtr& observer) const noexcept
+        const ITransactionObserverPtr& observer) const
 {
     TempIterators.clear();
     CheckReadAllowed(table);
@@ -244,7 +244,7 @@ EReady TDatabase::Select(ui32 table, TRawVals key, TTagsRef tags, TRowState &row
 TSelectRowVersionResult TDatabase::SelectRowVersion(
         ui32 table, TRawVals key, ui64 readFlags,
         const ITransactionMapPtr& visible,
-        const ITransactionObserverPtr& observer) const noexcept
+        const ITransactionObserverPtr& observer) const
 {
     return Require(table)->SelectRowVersion(key, Env, readFlags, visible, observer);
 }
@@ -252,7 +252,7 @@ TSelectRowVersionResult TDatabase::SelectRowVersion(
 TSelectRowVersionResult TDatabase::SelectRowVersion(
         ui32 table, TArrayRef<const TCell> key, ui64 readFlags,
         const ITransactionMapPtr& visible,
-        const ITransactionObserverPtr& observer) const noexcept
+        const ITransactionObserverPtr& observer) const
 {
     return Require(table)->SelectRowVersion(key, Env, readFlags, visible, observer);
 }
@@ -530,12 +530,12 @@ void TDatabase::UpdateApproximateFreeSharesByChannel(const THashMap<ui32, float>
     }
 }
 
-void TDatabase::SetTableObserver(ui32 table, TIntrusivePtr<ITableObserver> ptr) noexcept
+void TDatabase::SetTableObserver(ui32 table, TIntrusivePtr<ITableObserver> ptr)
 {
     Require(table)->SetTableObserver(std::move(ptr));
 }
 
-TDatabase::TChangeCounter TDatabase::Head(ui32 table) const noexcept
+TDatabase::TChangeCounter TDatabase::Head(ui32 table) const
 {
     if (table == Max<ui32>()) {
         return { DatabaseImpl->StableSerial(), TEpoch::Max() };
@@ -809,17 +809,17 @@ TDatabase::TProd TDatabase::Commit(TTxStamp stamp, bool commit, TCookieAllocator
     return { std::move(Change), std::move(onPersistent) };
 }
 
-TTable* TDatabase::Require(ui32 table) const noexcept
+TTable* TDatabase::Require(ui32 table) const
 {
     return DatabaseImpl->Get(table, true).Self.Get();
 }
 
-TTable* TDatabase::RequireForUpdate(ui32 table) const noexcept
+TTable* TDatabase::RequireForUpdate(ui32 table) const
 {
     return DatabaseImpl->GetForUpdate(table).Self.Get();
 }
 
-void TDatabase::CheckReadAllowed(ui32 table) const noexcept
+void TDatabase::CheckReadAllowed(ui32 table) const
 {
     Y_ABORT_UNLESS(!NoMoreReadsFlag, "Trying to read after reads prohibited, table %u", table);
     if (NoMoreUnprechargedReadsFlag) [[unlikely]] {
@@ -829,7 +829,7 @@ void TDatabase::CheckReadAllowed(ui32 table) const noexcept
     }
 }
 
-void TDatabase::CheckPrechargeAllowed(ui32 table, TRawVals minKey, TRawVals maxKey) const noexcept
+void TDatabase::CheckPrechargeAllowed(ui32 table, TRawVals minKey, TRawVals maxKey) const
 {
     Y_ABORT_UNLESS(!NoMoreReadsFlag, "Trying to precharge after reads prohibited, table %u", table);
     if (NoMoreUnprechargedReadsFlag) [[unlikely]] {

--- a/ydb/core/tablet_flat/flat_database.h
+++ b/ydb/core/tablet_flat/flat_database.h
@@ -82,58 +82,58 @@ public:
     };
 
     TDatabase(const TDatabase&) = delete;
-    TDatabase(TDatabaseImpl *databaseImpl = nullptr) noexcept;
+    TDatabase(TDatabaseImpl *databaseImpl = nullptr);
     ~TDatabase();
 
-    void SetTableObserver(ui32 table, TIntrusivePtr<ITableObserver> ptr) noexcept;
+    void SetTableObserver(ui32 table, TIntrusivePtr<ITableObserver> ptr);
 
     /**
      * Returns durable monotonic change counter for a table (or a database when
      * table = Max<ui32>() by default).
      */
-    TChangeCounter Head(ui32 table = Max<ui32>()) const noexcept;
+    TChangeCounter Head(ui32 table = Max<ui32>()) const;
 
     /*_ Call Next() before accessing each row including the 1st row. */
 
-    TAutoPtr<TTableIter> Iterate(ui32 table, TRawVals key, TTagsRef tags, ELookup) const noexcept;
+    TAutoPtr<TTableIter> Iterate(ui32 table, TRawVals key, TTagsRef tags, ELookup) const;
     TAutoPtr<TTableIter> IterateExact(ui32 table, TRawVals key, TTagsRef tags,
             TRowVersion snapshot = TRowVersion::Max(),
             const ITransactionMapPtr& visible = nullptr,
-            const ITransactionObserverPtr& observer = nullptr) const noexcept;
+            const ITransactionObserverPtr& observer = nullptr) const;
     TAutoPtr<TTableIter> IterateRange(ui32 table, const TKeyRange& range, TTagsRef tags,
             TRowVersion snapshot = TRowVersion::Max(),
             const ITransactionMapPtr& visible = nullptr,
-            const ITransactionObserverPtr& observer = nullptr) const noexcept;
+            const ITransactionObserverPtr& observer = nullptr) const;
     TAutoPtr<TTableReverseIter> IterateRangeReverse(ui32 table, const TKeyRange& range, TTagsRef tags,
             TRowVersion snapshot = TRowVersion::Max(),
             const ITransactionMapPtr& visible = nullptr,
-            const ITransactionObserverPtr& observer = nullptr) const noexcept;
+            const ITransactionObserverPtr& observer = nullptr) const;
 
     template<class TIteratorType>
     TAutoPtr<TIteratorType> IterateRangeGeneric(ui32 table, const TKeyRange& range, TTagsRef tags,
             TRowVersion snapshot = TRowVersion::Max(),
             const ITransactionMapPtr& visible = nullptr,
-            const ITransactionObserverPtr& observer = nullptr) const noexcept;
+            const ITransactionObserverPtr& observer = nullptr) const;
 
     // NOTE: the row refeneces data in some internal buffers that get invalidated on the next Select() or Commit() call
     EReady Select(ui32 table, TRawVals key, TTagsRef tags, TRowState& row,
                   ui64 readFlags = 0, TRowVersion snapshot = TRowVersion::Max(),
                   const ITransactionMapPtr& visible = nullptr,
-                  const ITransactionObserverPtr& observer = nullptr) const noexcept;
+                  const ITransactionObserverPtr& observer = nullptr) const;
 
     EReady Select(ui32 table, TRawVals key, TTagsRef tags, TRowState& row, TSelectStats& stats,
                   ui64 readFlags = 0, TRowVersion snapshot = TRowVersion::Max(),
                   const ITransactionMapPtr& visible = nullptr,
-                  const ITransactionObserverPtr& observer = nullptr) const noexcept;
+                  const ITransactionObserverPtr& observer = nullptr) const;
 
     TSelectRowVersionResult SelectRowVersion(
             ui32 table, TRawVals key, ui64 readFlags = 0,
             const ITransactionMapPtr& visible = nullptr,
-            const ITransactionObserverPtr& observer = nullptr) const noexcept;
+            const ITransactionObserverPtr& observer = nullptr) const;
     TSelectRowVersionResult SelectRowVersion(
             ui32 table, TArrayRef<const TCell> key, ui64 readFlags = 0,
             const ITransactionMapPtr& visible = nullptr,
-            const ITransactionObserverPtr& observer = nullptr) const noexcept;
+            const ITransactionObserverPtr& observer = nullptr) const;
 
     bool Precharge(ui32 table, TRawVals minKey, TRawVals maxKey,
                         TTagsRef tags, ui64 readFlags, ui64 itemsLimit, ui64 bytesLimit,
@@ -205,7 +205,7 @@ public:
 
     const TScheme& GetScheme() const noexcept;
 
-    TIntrusiveConstPtr<TRowScheme> GetRowScheme(ui32 table) const noexcept;
+    TIntrusiveConstPtr<TRowScheme> GetRowScheme(ui32 table) const;
 
     TPartView GetPartView(ui32 table, const TLogoBlobID &bundle) const;
     TVector<TPartView> GetTableParts(ui32 table) const;
@@ -301,11 +301,11 @@ public:
     }
 
 private:
-    TTable* Require(ui32 tableId) const noexcept;
-    TTable* RequireForUpdate(ui32 tableId) const noexcept;
+    TTable* Require(ui32 tableId) const;
+    TTable* RequireForUpdate(ui32 tableId) const;
 
-    void CheckReadAllowed(ui32 table) const noexcept;
-    void CheckPrechargeAllowed(ui32 table, TRawVals minKey, TRawVals maxKey) const noexcept;
+    void CheckReadAllowed(ui32 table) const;
+    void CheckPrechargeAllowed(ui32 table, TRawVals minKey, TRawVals maxKey) const;
 
 private:
     const THolder<TDatabaseImpl> DatabaseImpl;

--- a/ydb/core/tablet_flat/flat_dbase_annex.h
+++ b/ydb/core/tablet_flat/flat_dbase_annex.h
@@ -44,7 +44,7 @@ namespace NTable {
             }
         }
 
-        TResult Place(ui32 table, TTag, TArrayRef<const char> data) noexcept override
+        TResult Place(ui32 table, TTag, TArrayRef<const char> data) override
         {
             Y_ABORT_UNLESS(Lookup(table) && data.size() >= Family->Large);
 
@@ -61,7 +61,7 @@ namespace NTable {
             return ref;
         }
 
-        bool Lookup(ui32 table) noexcept
+        bool Lookup(ui32 table)
         {
             if (std::exchange(Table, table) != table) {
                 Family = Scheme.DefaultFamilyFor(Table);

--- a/ydb/core/tablet_flat/flat_dbase_apply.cpp
+++ b/ydb/core/tablet_flat/flat_dbase_apply.cpp
@@ -408,7 +408,7 @@ bool TSchemeModifier::SetCompactionPolicy(ui32 tid, const NKikimrCompaction::TCo
     return true;
 }
 
-void TSchemeModifier::PreserveTable(ui32 tid) noexcept
+void TSchemeModifier::PreserveTable(ui32 tid)
 {
     if (RollbackState && !RollbackState->Tables.contains(tid)) {
         auto it = Scheme.Tables.find(tid);
@@ -420,14 +420,14 @@ void TSchemeModifier::PreserveTable(ui32 tid) noexcept
     }
 }
 
-void TSchemeModifier::PreserveExecutor() noexcept
+void TSchemeModifier::PreserveExecutor()
 {
     if (RollbackState && !RollbackState->Executor) {
         RollbackState->Executor = Scheme.Executor;
     }
 }
 
-void TSchemeModifier::PreserveRedo() noexcept
+void TSchemeModifier::PreserveRedo()
 {
     if (RollbackState && !RollbackState->Redo) {
         RollbackState->Redo = Scheme.Redo;

--- a/ydb/core/tablet_flat/flat_dbase_apply.h
+++ b/ydb/core/tablet_flat/flat_dbase_apply.h
@@ -46,7 +46,7 @@ namespace NTable {
         bool SetExecutorResourceProfile(const TString &name);
         bool SetCompactionPolicy(ui32 tableId, const NKikimrCompaction::TCompactionPolicy& newPolicy);
 
-        TTable* Table(ui32 tid) const noexcept
+        TTable* Table(ui32 tid) const
         {
             auto* table = Scheme.GetTableInfo(tid);
             Y_ABORT_UNLESS(table, "Acccessing table that doesn't exist");
@@ -83,9 +83,9 @@ namespace NTable {
             return false;
         }
 
-        void PreserveTable(ui32 tid) noexcept;
-        void PreserveExecutor() noexcept;
-        void PreserveRedo() noexcept;
+        void PreserveTable(ui32 tid);
+        void PreserveExecutor();
+        void PreserveRedo();
 
     public:
         TScheme &Scheme;

--- a/ydb/core/tablet_flat/flat_dbase_change.h
+++ b/ydb/core/tablet_flat/flat_dbase_change.h
@@ -34,7 +34,7 @@ namespace NTable {
             return Scheme || Redo || RemovedRowVersions;
         }
 
-        void Describe(IOutputStream &out) const noexcept
+        void Describe(IOutputStream &out) const
         {
             out
                 << "Change{" << Serial

--- a/ydb/core/tablet_flat/flat_dbase_misc.h
+++ b/ydb/core/tablet_flat/flat_dbase_misc.h
@@ -12,7 +12,7 @@ namespace NTable {
 
     struct TDbStats {
 
-        void Describe(IOutputStream &out) const noexcept
+        void Describe(IOutputStream &out) const
         {
             const ui64 sys = Parts.FlatIndexBytes + Parts.BTreeIndexBytes + Parts.ByKeyBytes + Parts.OtherBytes;
 

--- a/ydb/core/tablet_flat/flat_dbase_naked.h
+++ b/ydb/core/tablet_flat/flat_dbase_naked.h
@@ -59,7 +59,7 @@ namespace NTable {
                 return false;
             }
 
-            void Aggr(TDbStats &aggr, bool enter) const noexcept
+            void Aggr(TDbStats &aggr, bool enter) const
             {
                 const auto &stat = Self->Stat();
 
@@ -84,14 +84,14 @@ namespace NTable {
                 }
             }
 
-            void BackupMemStats() noexcept
+            void BackupMemStats()
             {
                 BackupMemTableWaste = Self->GetMemWaste();
                 BackupMemTableBytes = Self->GetMemSize();
                 BackupMemTableOps = Self->GetOpsCount();
             }
 
-            void RestoreMemStats(TDbStats &aggr) const noexcept
+            void RestoreMemStats(TDbStats &aggr) const
             {
                 NUtil::SubSafe(aggr.MemTableWaste, BackupMemTableWaste);
                 NUtil::SubSafe(aggr.MemTableBytes, BackupMemTableBytes);
@@ -173,7 +173,7 @@ namespace NTable {
             return InTransaction ? Begin_ : Serial_;
         }
 
-        TTableWrapper& Get(ui32 table, bool require) noexcept
+        TTableWrapper& Get(ui32 table, bool require)
         {
             auto *wrap = Tables.FindPtr(table);
 
@@ -218,7 +218,7 @@ namespace NTable {
             return *wrap;
         }
 
-        TTableWrapper& GetForUpdate(ui32 table) noexcept
+        TTableWrapper& GetForUpdate(ui32 table)
         {
             Y_ABORT_UNLESS(InTransaction);
             TTableWrapper& wrap = Get(table, true);
@@ -236,13 +236,13 @@ namespace NTable {
             return wrap;
         }
 
-        ui64 Rewind(ui64 serial) noexcept
+        ui64 Rewind(ui64 serial)
         {
             Y_ABORT_UNLESS(!InTransaction, "Unexpected rewind inside a transaction");
             return std::exchange(Serial_, Max(Serial_, serial));
         }
 
-        void BeginTransaction() noexcept
+        void BeginTransaction()
         {
             Y_ABORT_UNLESS(!InTransaction);
             InTransaction = true;
@@ -258,7 +258,7 @@ namespace NTable {
             Y_DEBUG_ABORT_UNLESS(Prepared.empty());
         }
 
-        TEpoch FlushTable(ui32 tid) noexcept
+        TEpoch FlushTable(ui32 tid)
         {
             Y_ABORT_UNLESS(InTransaction);
             auto& wrap = Get(tid, true);
@@ -275,7 +275,7 @@ namespace NTable {
             return *wrap.EpochSnapshot;
         }
 
-        void CommitTransaction(TTxStamp stamp, TArrayRef<const TMemGlob> annex, NRedo::TWriter& writer) noexcept
+        void CommitTransaction(TTxStamp stamp, TArrayRef<const TMemGlob> annex, NRedo::TWriter& writer)
         {
             Y_ABORT_UNLESS(Stamp <= stamp, "Executor tx stamp cannot go to the past");
             Stamp = stamp;
@@ -332,7 +332,7 @@ namespace NTable {
             InTransaction = false;
         }
 
-        void CommitScheme(TArrayRef<const TMemGlob> annex) noexcept
+        void CommitScheme(TArrayRef<const TMemGlob> annex)
         {
             if (!SchemeRollbackState.Tables.empty() || SchemeRollbackState.Redo) {
                 // Table or redo settings have changed
@@ -389,7 +389,7 @@ namespace NTable {
             SchemeRollbackState.Redo.reset();
         }
 
-        void RollbackTransaction() noexcept
+        void RollbackTransaction()
         {
             for (ui32 tid : Prepared) {
                 auto& wrap = Tables.at(tid);
@@ -422,7 +422,7 @@ namespace NTable {
             InTransaction = false;
         }
 
-        void RollbackScheme() noexcept
+        void RollbackScheme()
         {
             // Note: we assume schema rollback is very rare,
             // so it doesn't have to be efficient
@@ -477,7 +477,7 @@ namespace NTable {
             GCList->RunGC();
         }
 
-        TDatabaseImpl& Switch(TTxStamp stamp) noexcept
+        TDatabaseImpl& Switch(TTxStamp stamp)
         {
             Y_ABORT_UNLESS(!InTransaction, "Unexpected switch inside a transaction");
             Y_ABORT_UNLESS(Stamp <= stamp, "Executor tx stamp cannot go to the past");
@@ -491,14 +491,14 @@ namespace NTable {
             return *this;
         }
 
-        void Assign(TVector<TMemGlob> annex) noexcept
+        void Assign(TVector<TMemGlob> annex)
         {
             Y_ABORT_UNLESS(!Annex, "Annex has been already attached to TDatabaseImpl");
 
             Annex = std::move(annex);
         }
 
-        void ReplaceSlices(ui32 tid, TBundleSlicesMap slices) noexcept
+        void ReplaceSlices(ui32 tid, TBundleSlicesMap slices)
         {
             auto &wrap = Get(tid, true);
 
@@ -511,7 +511,7 @@ namespace NTable {
             ui32 tid,
             const TSubset &subset,
             TArrayRef<const TPartView> newParts,
-            TArrayRef<const TIntrusiveConstPtr<TTxStatusPart>> newTxStatus) noexcept
+            TArrayRef<const TIntrusiveConstPtr<TTxStatusPart>> newTxStatus)
         {
             auto &wrap = Get(tid, true);
 
@@ -520,7 +520,7 @@ namespace NTable {
             wrap.Aggr(Stats, true /* enter */);
         }
 
-        void Merge(ui32 tid, TPartView partView) noexcept
+        void Merge(ui32 tid, TPartView partView)
         {
             auto &wrap = Get(tid, true);
 
@@ -529,7 +529,7 @@ namespace NTable {
             wrap.Aggr(Stats, true /* enter */);
         }
 
-        void Merge(ui32 tid, TIntrusiveConstPtr<TColdPart> part) noexcept
+        void Merge(ui32 tid, TIntrusiveConstPtr<TColdPart> part)
         {
             auto &wrap = Get(tid, true);
 
@@ -538,7 +538,7 @@ namespace NTable {
             wrap.Aggr(Stats, true /* enter */);
         }
 
-        void Merge(ui32 tid, TIntrusiveConstPtr<TTxStatusPart> txStatus) noexcept
+        void Merge(ui32 tid, TIntrusiveConstPtr<TTxStatusPart> txStatus)
         {
             auto &wrap = Get(tid, true);
 
@@ -547,7 +547,7 @@ namespace NTable {
             wrap.Aggr(Stats, true /* enter */);
         }
 
-        void MergeDone(ui32 tid) noexcept
+        void MergeDone(ui32 tid)
         {
             auto &wrap = Get(tid, true);
 
@@ -556,7 +556,7 @@ namespace NTable {
             wrap.Aggr(Stats, true /* enter */);
         }
 
-        void MergeDone() noexcept
+        void MergeDone()
         {
             for (auto &pr : Tables) {
                 MergeDone(pr.first);
@@ -576,7 +576,7 @@ namespace NTable {
             }
         }
 
-        TDatabaseImpl& ApplyRedo(TArrayRef<const char> plain) noexcept
+        TDatabaseImpl& ApplyRedo(TArrayRef<const char> plain)
         {
             return Redo.Replay(plain), *this;
         }
@@ -608,7 +608,7 @@ namespace NTable {
             Large = Max(Large, Scheme->Redo.Annex);
         }
 
-        TTableWrapper& MakeTable(ui32 table, TSnapEdge edge) noexcept
+        TTableWrapper& MakeTable(ui32 table, TSnapEdge edge)
         {
             if (edge.TxStamp == Max<ui64>()) {
                 Y_ABORT("Cannot make table on undefined TxStamp edge");
@@ -659,7 +659,7 @@ namespace NTable {
         }
 
     public: /*_ Redo log player interface impl. */
-        bool NeedIn(ui32 table) noexcept
+        bool NeedIn(ui32 table)
         {
             /* Scheme deltas are applied before any redo log entries on
                 db bootstrap and udate log entries for already deleted
@@ -671,7 +671,7 @@ namespace NTable {
             return wrap ? Stamp > wrap.Edge : false;
         }
 
-        void DoBegin(ui32 tail, ui32 head, ui64 serial, ui64 stamp) noexcept
+        void DoBegin(ui32 tail, ui32 head, ui64 serial, ui64 stamp)
         {
             TAbi().Check(tail, head, "redo");
 
@@ -692,7 +692,7 @@ namespace NTable {
             First_ = Min(First_, Serial_);
         }
 
-        void DoAnnex(TArrayRef<const TStdPad<NPageCollection::TGlobId>> annex) noexcept
+        void DoAnnex(TArrayRef<const TStdPad<NPageCollection::TGlobId>> annex)
         {
             if (Annex) {
                 Y_ABORT_UNLESS(annex.size() == Annex.size());
@@ -710,7 +710,7 @@ namespace NTable {
             }
         }
 
-        void DoUpdate(ui32 tid, ERowOp rop, TKeys key, TOps ops, TRowVersion rowVersion) noexcept
+        void DoUpdate(ui32 tid, ERowOp rop, TKeys key, TOps ops, TRowVersion rowVersion)
         {
             auto &wrap = Touch(tid);
 
@@ -722,7 +722,7 @@ namespace NTable {
             Stats.MemTableOps += 1;
         }
 
-        void DoUpdateTx(ui32 tid, ERowOp rop, TKeys key, TOps ops, ui64 txId) noexcept
+        void DoUpdateTx(ui32 tid, ERowOp rop, TKeys key, TOps ops, ui64 txId)
         {
             auto &wrap = Touch(tid);
 
@@ -734,7 +734,7 @@ namespace NTable {
             Stats.MemTableOps += 1;
         }
 
-        void DoCommitTx(ui32 tid, ui64 txId, TRowVersion rowVersion) noexcept
+        void DoCommitTx(ui32 tid, ui64 txId, TRowVersion rowVersion)
         {
             auto &wrap = Touch(tid);
 
@@ -745,7 +745,7 @@ namespace NTable {
             Stats.MemTableBytes += wrap->GetMemSize();
         }
 
-        void DoRemoveTx(ui32 tid, ui64 txId) noexcept
+        void DoRemoveTx(ui32 tid, ui64 txId)
         {
             auto &wrap = Touch(tid);
 
@@ -756,7 +756,7 @@ namespace NTable {
             Stats.MemTableBytes += wrap->GetMemSize();
         }
 
-        void DoFlush(ui32 tid, ui64 /* stamp */, TEpoch epoch) noexcept
+        void DoFlush(ui32 tid, ui64 /* stamp */, TEpoch epoch)
         {
             auto on = Touch(tid)->Snapshot();
 
@@ -766,7 +766,7 @@ namespace NTable {
             }
         }
 
-        TTableWrapper& Touch(ui32 table) noexcept
+        TTableWrapper& Touch(ui32 table)
         {
             auto &wrap = Get(table, true);
 

--- a/ydb/core/tablet_flat/flat_dbase_scheme.h
+++ b/ydb/core/tablet_flat/flat_dbase_scheme.h
@@ -137,7 +137,7 @@ public:
         return Tables.empty();
     }
 
-    const TRoom* DefaultRoomFor(ui32 id) const noexcept
+    const TRoom* DefaultRoomFor(ui32 id) const
     {
         if (auto *table = GetTableInfo(id))
             return table->Rooms.FindPtr(DefaultRoom);
@@ -145,7 +145,7 @@ public:
         return nullptr;
     }
 
-    const TFamily* DefaultFamilyFor(ui32 id) const noexcept
+    const TFamily* DefaultFamilyFor(ui32 id) const
     {
         if (auto *table = GetTableInfo(id))
             return table->Families.FindPtr(TColumn::LeaderFamily);
@@ -153,7 +153,7 @@ public:
         return nullptr;
     }
 
-    ECompactionStrategy CompactionStrategyFor(ui32 id) const noexcept
+    ECompactionStrategy CompactionStrategyFor(ui32 id) const
     {
         if (auto *table = GetTableInfo(id)) {
             auto strategy = table->CompactionPolicy->CompactionStrategy;

--- a/ydb/core/tablet_flat/flat_dbase_sz_env.h
+++ b/ydb/core/tablet_flat/flat_dbase_sz_env.h
@@ -16,12 +16,12 @@ namespace NTable {
         {
         }
 
-        TResult Locate(const TMemTable*, ui64, ui32) noexcept override
+        TResult Locate(const TMemTable*, ui64, ui32) override
         {
             Y_ABORT("IPages::Locate(TMemTable*, ...) shouldn't be used here");
         }
 
-        TResult Locate(const TPart *part, ui64 ref, ELargeObj lob) noexcept override
+        TResult Locate(const TPart *part, ui64 ref, ELargeObj lob) override
         {
             auto *partStore = CheckedCast<const NTable::TPartStore*>(part);
 
@@ -55,7 +55,7 @@ namespace NTable {
         }
 
     private:
-        void AddPageSize(TInfo *info, TPageId pageId) noexcept
+        void AddPageSize(TInfo *info, TPageId pageId)
         {
             if (Touched[info].insert(pageId).second) {
                 Pages++;

--- a/ydb/core/tablet_flat/flat_exec_broker.h
+++ b/ydb/core/tablet_flat/flat_exec_broker.h
@@ -19,7 +19,7 @@ namespace NTabletFlatExecutor {
     };
 
     struct TIdEmitter : public TSimpleRefCount<TIdEmitter> {
-        ui64 Do() noexcept
+        ui64 Do()
         {
             return ++Serial;
         }

--- a/ydb/core/tablet_flat/flat_exec_commit.cpp
+++ b/ydb/core/tablet_flat/flat_exec_commit.cpp
@@ -4,7 +4,7 @@
 namespace NKikimr {
 namespace NTabletFlatExecutor {
 
-    void TLogCommit::PushTx(TSeat* seat) noexcept {
+    void TLogCommit::PushTx(TSeat* seat) {
         Y_DEBUG_ABORT_UNLESS(!seat->NextCommitTx);
         if (LastTx) {
             Y_DEBUG_ABORT_UNLESS(!LastTx->NextCommitTx);
@@ -17,7 +17,7 @@ namespace NTabletFlatExecutor {
         }
     }
 
-    TSeat* TLogCommit::PopTx() noexcept {
+    TSeat* TLogCommit::PopTx() {
         TSeat* seat = FirstTx;
         if (seat) {
             FirstTx = seat->NextCommitTx;

--- a/ydb/core/tablet_flat/flat_exec_commit.h
+++ b/ydb/core/tablet_flat/flat_exec_commit.h
@@ -36,7 +36,7 @@ namespace NTabletFlatExecutor {
 
         }
 
-        void Describe(IOutputStream &out) const noexcept
+        void Describe(IOutputStream &out) const
         {
             out
                 << "Commit{" << Step << " orig " << ui32(Type)
@@ -46,8 +46,8 @@ namespace NTabletFlatExecutor {
                     << " -" << GcDelta.Deleted.size() << ")}";
         }
 
-        void PushTx(TSeat *seat) noexcept;
-        TSeat* PopTx() noexcept;
+        void PushTx(TSeat *seat);
+        TSeat* PopTx();
 
         const ui32 Step = Max<ui32>();
         const ECommit Type = ECommit::Misc;

--- a/ydb/core/tablet_flat/flat_exec_commit_mgr.cpp
+++ b/ydb/core/tablet_flat/flat_exec_commit_mgr.cpp
@@ -7,7 +7,7 @@ LWTRACE_USING(TABLET_FLAT_PROVIDER)
 namespace NKikimr {
 namespace NTabletFlatExecutor {
 
-    void TCommitManager::TrackCommitTxs(TLogCommit &commit) noexcept {
+    void TCommitManager::TrackCommitTxs(TLogCommit &commit) {
         while (TSeat *seat = commit.PopTx()) {
             LWTRACK(TransactionReadWriteCommit, seat->Self->Orbit, seat->UniqID, commit.Step);
         }

--- a/ydb/core/tablet_flat/flat_exec_commit_mgr.h
+++ b/ydb/core/tablet_flat/flat_exec_commit_mgr.h
@@ -67,7 +67,7 @@ namespace NTabletFlatExecutor {
 
         }
 
-        void Describe(IOutputStream &out) const noexcept
+        void Describe(IOutputStream &out) const
         {
             out
                 << "CommitManager{" << Tablet << ":" << Gen << " | "
@@ -94,7 +94,7 @@ namespace NTabletFlatExecutor {
             return NTable::TTxStamp{ Gen, Head };
         }
 
-        TAutoPtr<TLogCommit> Begin(bool sync, ECommit type, NWilson::TTraceId traceId) noexcept
+        TAutoPtr<TLogCommit> Begin(bool sync, ECommit type, NWilson::TTraceId traceId)
         {
             const auto step = Head;
 
@@ -111,7 +111,7 @@ namespace NTabletFlatExecutor {
             return new TLogCommit(sync, step, type, std::move(traceId));
         }
 
-        void Commit(TAutoPtr<TLogCommit> commit) noexcept
+        void Commit(TAutoPtr<TLogCommit> commit)
         {
             if (commit->Step != Tail || (commit->Sync && !Sync)) {
                 Y_Fail(
@@ -130,7 +130,7 @@ namespace NTabletFlatExecutor {
             SendCommitEv(*commit);
         }
 
-        void Confirm(const ui32 step) noexcept
+        void Confirm(const ui32 step)
         {
             if (Back == Max<ui32>() || step != Back || step >= Tail) {
                 Y_Fail(NFmt::Do(*this) << " got unexpected confirm " << step);
@@ -140,7 +140,7 @@ namespace NTabletFlatExecutor {
         }
 
     private:
-        void Switch(ui32 step) noexcept
+        void Switch(ui32 step)
         {
             *Step0 = step;
 
@@ -148,7 +148,7 @@ namespace NTabletFlatExecutor {
             Annex->Switch(step, true /* require step switch */);
         }
 
-        void StatsAccount(const TLogCommit &commit) noexcept
+        void StatsAccount(const TLogCommit &commit)
         {
             ui64 bytes = 0;
 
@@ -160,9 +160,9 @@ namespace NTabletFlatExecutor {
             MonCo->Cumulative()[TMonCo::LOG_EMBEDDED].Increment(commit.Embedded.size());
         }
 
-        void TrackCommitTxs(TLogCommit &commit) noexcept;
+        void TrackCommitTxs(TLogCommit &commit);
 
-        void SendCommitEv(TLogCommit &commit) noexcept
+        void SendCommitEv(TLogCommit &commit)
         {
             const bool snap = (commit.Type == ECommit::Snap);
 

--- a/ydb/core/tablet_flat/flat_exec_memory.h
+++ b/ydb/core/tablet_flat/flat_exec_memory.h
@@ -19,7 +19,7 @@ namespace NTabletFlatExecutor {
         using IOps = NActors::IActorOps;
 
         struct TUsed {
-            void Describe(IOutputStream &out) const noexcept
+            void Describe(IOutputStream &out) const
             {
                 out << "Memory{" << Static << " dyn " << Dynamic << "}";
             }
@@ -55,7 +55,7 @@ namespace NTabletFlatExecutor {
 
         const TUsed& Stats() const noexcept { return Used; }
 
-        ui64 RemainedStatic(const TSeat &seat) noexcept
+        ui64 RemainedStatic(const TSeat &seat)
         {
             ui64 txLimit = Profile->GetStaticTxMemoryLimit()
                 ? Profile->GetStaticTxMemoryLimit() : Max<ui64>();
@@ -71,7 +71,7 @@ namespace NTabletFlatExecutor {
             return Min(remain, tabletLimit - Used.Static);
         }
 
-        void RequestLimit(TSeat &seat, ui64 desired) noexcept
+        void RequestLimit(TSeat &seat, ui64 desired)
         {
             seat.CurrentMemoryLimit = desired;
 
@@ -101,7 +101,7 @@ namespace NTabletFlatExecutor {
             }
         }
 
-        void AcquiredMemory(TSeat &seat, ui32 task) noexcept
+        void AcquiredMemory(TSeat &seat, ui32 task)
         {
             seat.TaskId = task;
 
@@ -115,7 +115,7 @@ namespace NTabletFlatExecutor {
             }
         }
 
-        void ReleaseMemory(TSeat &seat) noexcept
+        void ReleaseMemory(TSeat &seat)
         {
             if (!seat.TaskId) {
                 FreeStatic(seat, seat.CapturedMemory ? seat.CapturedMemory->Size : 0);
@@ -168,7 +168,7 @@ namespace NTabletFlatExecutor {
             }
         }
 
-        void ReleaseTxData(TSeat &seat) noexcept
+        void ReleaseTxData(TSeat &seat)
         {
             if (seat.CapturedMemory) {
 
@@ -202,7 +202,7 @@ namespace NTabletFlatExecutor {
             }
         }
 
-        void AttachMemory(TSeat &seat) noexcept
+        void AttachMemory(TSeat &seat)
         {
             const ui64 taskId = seat.AttachedMemory->GCToken->TaskId;
             const ui64 bytes = seat.AttachedMemory->GCToken->Size;
@@ -276,7 +276,7 @@ namespace NTabletFlatExecutor {
             seat.AttachedMemory = nullptr;
         }
 
-        void AllocStatic(TSeat &seat, ui64 newLimit) noexcept
+        void AllocStatic(TSeat &seat, ui64 newLimit)
         {
             Y_ABORT_UNLESS(newLimit >= seat.CurrentTxDataLimit + seat.MemoryTouched);
 
@@ -291,7 +291,7 @@ namespace NTabletFlatExecutor {
             }
         }
 
-        void FreeStatic(TSeat &seat, ui64 hold) noexcept
+        void FreeStatic(TSeat &seat, ui64 hold)
         {
             if (seat.TaskId)
                 return;
@@ -307,7 +307,7 @@ namespace NTabletFlatExecutor {
             }
         }
 
-        void RunMemoryGC() noexcept
+        void RunMemoryGC()
         {
             GCScheduled = false;
 
@@ -339,14 +339,14 @@ namespace NTabletFlatExecutor {
             ScheduleGC();
         }
 
-        void ScheduleGC() noexcept
+        void ScheduleGC()
         {
             if (Tokens && !std::exchange(GCScheduled, true))
                 Ops->Schedule(TDuration::Minutes(1),
                     new TEvents::TEvWakeup(ui64(EWakeTag::Memory)));
         }
 
-        void DumpStateToHTML(IOutputStream &out) noexcept
+        void DumpStateToHTML(IOutputStream &out)
         {
             HTML(out) {
                 DIV_CLASS("row") {out << "profile: " << Profile->ShortDebugString(); }
@@ -361,18 +361,18 @@ namespace NTabletFlatExecutor {
             }
         }
 
-        void SetProfiles(TResourceProfilesPtr profiles) noexcept
+        void SetProfiles(TResourceProfilesPtr profiles)
         {
             Profiles = profiles ? profiles : new TResourceProfiles;
         }
 
-        void UseProfile(ETablet type, const TString &name) noexcept
+        void UseProfile(ETablet type, const TString &name)
         {
             Profile = Profiles->GetProfile(type, name);
         }
 
     private:
-        void CaptureDynamic(TSeat &seat) noexcept
+        void CaptureDynamic(TSeat &seat)
         {
             const auto type =  GetTaskType(seat.CapturedMemory->Size);
 
@@ -403,7 +403,7 @@ namespace NTabletFlatExecutor {
             Ops->Send(MakeResourceBrokerID(), event.Release(), 0);
         }
 
-        TString GetTaskType(ui64 limit) const noexcept
+        TString GetTaskType(ui64 limit) const
         {
             if (limit <= Profile->GetSmallTxMemoryLimit())
                 return Profile->GetSmallTxTaskType();

--- a/ydb/core/tablet_flat/flat_exec_scans.h
+++ b/ydb/core/tablet_flat/flat_exec_scans.h
@@ -66,7 +66,7 @@ namespace NTabletFlatExecutor {
             TOne& operator=(const TOne&) = delete;
             TOne& operator=(TOne&&) = delete;
 
-            void Describe(IOutputStream &out, bool full = true) const noexcept
+            void Describe(IOutputStream &out, bool full = true) const
             {
                 out << "Scan{" << Serial << " on " << Table;
 
@@ -129,7 +129,7 @@ namespace NTabletFlatExecutor {
 
         }
 
-        void Describe(IOutputStream &out) const noexcept
+        void Describe(IOutputStream &out) const
         {
             out
                 << "Scans{serial " << Serial << ", " << Tables.size() << " tbl"
@@ -182,7 +182,7 @@ namespace NTabletFlatExecutor {
             return one.Serial;
         }
 
-        TAcquired Acquired(ui64 task, TResource *cookie) noexcept
+        TAcquired Acquired(ui64 task, TResource *cookie)
         {
             auto *one = Lookup(CheckedCast<TCookie*>(cookie)->Serial, false);
 
@@ -214,14 +214,14 @@ namespace NTabletFlatExecutor {
             return Start(one, conf);
         }
 
-        void Drop() noexcept
+        void Drop()
         {
             while (Tables) {
                 Drop(Tables.begin()->first);
             }
         }
 
-        TVector<THolder<TScanSnapshot>> Drop(ui32 table) noexcept
+        TVector<THolder<TScanSnapshot>> Drop(ui32 table)
         {
             TVector<THolder<TScanSnapshot>> snapshots;
 
@@ -240,7 +240,7 @@ namespace NTabletFlatExecutor {
             return snapshots;
         }
 
-        TCancelled Cancel(ui64 serial) noexcept
+        TCancelled Cancel(ui64 serial)
         {
             auto *one = Lookup(serial, false);
 
@@ -261,7 +261,7 @@ namespace NTabletFlatExecutor {
             return cancelled;
         }
 
-        bool CancelSystem(ui64 serial) noexcept
+        bool CancelSystem(ui64 serial)
         {
             auto *one = Lookup(serial, false);
 
@@ -276,7 +276,7 @@ namespace NTabletFlatExecutor {
             return Cancel(*one, EState::Forget);
         }
 
-        TScanOutcome Release(ui64 serial, EAbort &code, TAutoPtr<IDestructable> &result) noexcept
+        TScanOutcome Release(ui64 serial, EAbort &code, TAutoPtr<IDestructable> &result)
         {
             auto *one = Lookup(serial, true);
 
@@ -294,7 +294,7 @@ namespace NTabletFlatExecutor {
         }
 
     private:
-        TOne& Make(ui32 table, TAutoPtr<IScan> scan, EType type, const TScanOptions& options, THolder<TScanSnapshot> snapshot) noexcept
+        TOne& Make(ui32 table, TAutoPtr<IScan> scan, EType type, const TScanOptions& options, THolder<TScanSnapshot> snapshot)
         {
             /* odd NOps used to mark compactions (system scans) */
 
@@ -361,7 +361,7 @@ namespace NTabletFlatExecutor {
             return one.Serial;
         }
 
-        bool Cancel(TOne &one, EState state) noexcept
+        bool Cancel(TOne &one, EState state)
         {
             if (one.State == EState::Task || one.State == EState::Ready) {
                 TAutoPtr<IDestructable> result;
@@ -411,7 +411,7 @@ namespace NTabletFlatExecutor {
             return outcome;
         }
 
-        TOne* Lookup(ui64 serial, bool require) noexcept
+        TOne* Lookup(ui64 serial, bool require)
         {
             auto *one = Scans.FindPtr(serial);
 
@@ -422,7 +422,7 @@ namespace NTabletFlatExecutor {
             return one;
         }
 
-        TString MakeLabelFor(const TOne &one) const noexcept
+        TString MakeLabelFor(const TOne &one) const
         {
             TStringStream out;
 

--- a/ydb/core/tablet_flat/flat_exec_seat.cpp
+++ b/ydb/core/tablet_flat/flat_exec_seat.cpp
@@ -3,7 +3,7 @@
 namespace NKikimr {
 namespace NTabletFlatExecutor {
 
-    void TSeat::Complete(const TActorContext& ctx, bool isRW) noexcept {
+    void TSeat::Complete(const TActorContext& ctx, bool isRW) {
         if (Y_UNLIKELY(IsTerminated())) {
             Y_ABORT_UNLESS(!isRW, "Terminating a read-write transaction");
             Self->Terminate(TerminationReason, ctx);

--- a/ydb/core/tablet_flat/flat_exec_seat.h
+++ b/ydb/core/tablet_flat/flat_exec_seat.h
@@ -35,7 +35,7 @@ namespace NTabletFlatExecutor {
         {
         }
 
-        void Describe(IOutputStream &out) const noexcept
+        void Describe(IOutputStream &out) const
         {
             out << "Tx{" << UniqID << ", ";
             Self->Describe(out);
@@ -46,25 +46,25 @@ namespace NTabletFlatExecutor {
             return TerminationReason != ETerminationReason::None;
         }
 
-        void Complete(const TActorContext& ctx, bool isRW) noexcept;
+        void Complete(const TActorContext& ctx, bool isRW);
 
-        void StartEnqueuedSpan() noexcept {
+        void StartEnqueuedSpan() {
             WaitingSpan = NWilson::TSpan(TWilsonTablet::TabletDetailed, Self->TxSpan.GetTraceId(), "Tablet.Transaction.Enqueued");
         }
 
-        void FinishEnqueuedSpan() noexcept {
+        void FinishEnqueuedSpan() {
             WaitingSpan.EndOk();
         }
 
-        void CreatePendingSpan() noexcept {
+        void CreatePendingSpan() {
             WaitingSpan = NWilson::TSpan(TWilsonTablet::TabletDetailed, Self->TxSpan.GetTraceId(), "Tablet.Transaction.Pending");
         }
 
-        void FinishPendingSpan() noexcept {
+        void FinishPendingSpan() {
             WaitingSpan.EndOk();
         }
 
-        NWilson::TTraceId GetTxTraceId() const noexcept {
+        NWilson::TTraceId GetTxTraceId() const {
             return Self->TxSpan.GetTraceId();
         }
 

--- a/ydb/core/tablet_flat/flat_executor.cpp
+++ b/ydb/core/tablet_flat/flat_executor.cpp
@@ -207,7 +207,7 @@ void TExecutor::Broken() {
     return PassAway();
 }
 
-void TExecutor::RecreatePageCollectionsCache() noexcept
+void TExecutor::RecreatePageCollectionsCache()
 {
     PrivatePageCache = MakeHolder<TPrivatePageCache>();
     StickyPagesMemory = 0;
@@ -223,11 +223,13 @@ void TExecutor::RecreatePageCollectionsCache() noexcept
     }
 
     if (TransactionWaitPads) {
-        for (auto &xpair : TransactionWaitPads) {
-            xpair.second->WaitingSpan.EndOk();
-            TSeat* seat = xpair.second->Seat;
+        auto it = TransactionWaitPads.begin();
+        while (it != TransactionWaitPads.end()) {
+            it->second->WaitingSpan.EndOk();
+            TSeat* seat = it->second->Seat;
             Y_ABORT_UNLESS(seat->State == ESeatState::Waiting);
             seat->State = ESeatState::None;
+            TransactionWaitPads.erase(it++);
 
             if (seat->Cancelled) {
                 FinishCancellation(seat, false);
@@ -235,11 +237,10 @@ void TExecutor::RecreatePageCollectionsCache() noexcept
                 EnqueueActivation(seat, false);
             }
         }
-        TransactionWaitPads.clear();
     }
 }
 
-void TExecutor::ReflectSchemeSettings() noexcept
+void TExecutor::ReflectSchemeSettings()
 {
     for (const auto &it : Scheme().Tables) {
         auto &policy = *it.second.CompactionPolicy;
@@ -652,7 +653,7 @@ void TExecutor::ActivateWaitingTransactions(TPrivatePageCache::TPage::TWaitQueue
     }
 }
 
-void TExecutor::AddCachesOfBundle(const NTable::TPartView &partView) noexcept
+void TExecutor::AddCachesOfBundle(const NTable::TPartView &partView)
 {
     auto *partStore = partView.As<NTable::TPartStore>();
 
@@ -670,7 +671,7 @@ void TExecutor::AddCachesOfBundle(const NTable::TPartView &partView) noexcept
         AddSingleCache(blobs);
 }
 
-void TExecutor::AddSingleCache(const TIntrusivePtr<TPrivatePageCache::TInfo> &info) noexcept
+void TExecutor::AddSingleCache(const TIntrusivePtr<TPrivatePageCache::TInfo> &info)
 {
     PrivatePageCache->RegisterPageCollection(info);
     Send(MakeSharedPageCacheId(), new NSharedCache::TEvAttach(info->PageCollection, SelfId()));
@@ -680,7 +681,7 @@ void TExecutor::AddSingleCache(const TIntrusivePtr<TPrivatePageCache::TInfo> &in
     Counters->Simple()[TExecutorCounters::CACHE_TOTAL_STICKY] = StickyPagesMemory;
 }
 
-void TExecutor::DropCachesOfBundle(const NTable::TPart &part) noexcept
+void TExecutor::DropCachesOfBundle(const NTable::TPart &part)
 {
     auto *partStore = CheckedCast<const NTable::TPartStore*>(&part);
 
@@ -698,7 +699,7 @@ void TExecutor::DropCachesOfBundle(const NTable::TPart &part) noexcept
         DropSingleCache(blobs->Id);
 }
 
-void TExecutor::DropSingleCache(const TLogoBlobID &label) noexcept
+void TExecutor::DropSingleCache(const TLogoBlobID &label)
 {
     auto pageCollection = PrivatePageCache->GetPageCollection(label);
 
@@ -3177,7 +3178,7 @@ void TExecutor::Handle(TEvResourceBroker::TEvResourceAllocated::TPtr &ev) {
     }
 }
 
-void TExecutor::StartSeat(ui64 task, TResource *cookie_) noexcept
+void TExecutor::StartSeat(ui64 task, TResource *cookie_)
 {
     auto *cookie = CheckedCast<TMemory::TCookie*>(cookie_);
     TSeat* seat = cookie->Seat;
@@ -3246,13 +3247,13 @@ THolder<TScanSnapshot> TExecutor::PrepareScanSnapshot(ui32 table, const NTable::
     return THolder<TScanSnapshot>(new TScanSnapshot{table, std::move(barrier), subset, snapshot});
 }
 
-void TExecutor::StartScan(ui64 serial, ui32 table) noexcept
+void TExecutor::StartScan(ui64 serial, ui32 table)
 {
     Y_UNUSED(table);
     Scans->Start(serial);
 }
 
-void TExecutor::StartScan(ui64 task, TResource *cookie) noexcept
+void TExecutor::StartScan(ui64 task, TResource *cookie)
 {
     if (auto acquired = Scans->Acquired(task, cookie)) {
         StartScan(acquired.Serial, acquired.Table);
@@ -4468,7 +4469,7 @@ TTransactionWaitPad::TTransactionWaitPad(TSeat* seat)
 TTransactionWaitPad::~TTransactionWaitPad()
 {}
 
-NWilson::TTraceId TTransactionWaitPad::GetWaitingTraceId() const noexcept {
+NWilson::TTraceId TTransactionWaitPad::GetWaitingTraceId() const {
     return WaitingSpan.GetTraceId();
 }
 

--- a/ydb/core/tablet_flat/flat_executor.cpp
+++ b/ydb/core/tablet_flat/flat_executor.cpp
@@ -4386,7 +4386,7 @@ void TExecutor::RenderHtmlPage(NMon::TEvRemoteHttpInfo::TPtr &ev) const {
     Send(ev->Sender, new NMon::TEvRemoteHttpInfoRes(str.Str()));
 }
 
-const NTable::TScheme& TExecutor::Scheme() const noexcept {
+const NTable::TScheme& TExecutor::Scheme() const {
     Y_DEBUG_ABORT_UNLESS(Database);
     return Database->GetScheme();
 }

--- a/ydb/core/tablet_flat/flat_executor.cpp
+++ b/ydb/core/tablet_flat/flat_executor.cpp
@@ -97,7 +97,7 @@ using namespace NResourceBroker;
 
 class TExecutor::TActiveTransactionZone {
 public:
-    explicit TActiveTransactionZone(TExecutor* self) noexcept
+    explicit TActiveTransactionZone(TExecutor* self)
         : Self(self)
     {
         Y_DEBUG_ABORT_UNLESS(!Self->ActiveTransaction);
@@ -105,11 +105,11 @@ public:
         Active = true;
     }
 
-    ~TActiveTransactionZone() noexcept {
+    ~TActiveTransactionZone() {
         Done();
     }
 
-    void Done() noexcept {
+    void Done() {
         if (Active) {
             Self->ActiveTransaction = false;
             Active = false;

--- a/ydb/core/tablet_flat/flat_executor.h
+++ b/ydb/core/tablet_flat/flat_executor.h
@@ -712,7 +712,7 @@ public:
     STFUNC(StateFollower);
 
     // database interface
-    const NTable::TScheme& Scheme() const noexcept override;
+    const NTable::TScheme& Scheme() const override;
     ui64 TabletId() const { return Owner->TabletID(); }
 
     float GetRejectProbability() const override;

--- a/ydb/core/tablet_flat/flat_executor.h
+++ b/ydb/core/tablet_flat/flat_executor.h
@@ -299,7 +299,7 @@ struct TTransactionWaitPad : public TPrivatePageCacheWaitPad {
     TTransactionWaitPad(TSeat* seat);
     ~TTransactionWaitPad();
 
-    NWilson::TTraceId GetWaitingTraceId() const noexcept;
+    NWilson::TTraceId GetWaitingTraceId() const;
 };
 
 struct TCompactionChangesCtx;
@@ -496,8 +496,8 @@ class TExecutor
     void Broken();
     void Active(const TActorContext &ctx);
     void ActivateFollower(const TActorContext &ctx);
-    void RecreatePageCollectionsCache() noexcept;
-    void ReflectSchemeSettings() noexcept;
+    void RecreatePageCollectionsCache();
+    void ReflectSchemeSettings();
     void OnYellowChannels(TVector<ui32> yellowMoveChannels, TVector<ui32> yellowStopChannels) override;
     void CheckYellow(TVector<ui32> &&yellowMoveChannels, TVector<ui32> &&yellowStopChannels, bool terminal = false);
     void SendReassignYellowChannels(const TVector<ui32> &yellowChannels);
@@ -529,10 +529,10 @@ class TExecutor
     void PlanTransactionActivation();
     void MakeLogSnapshot();
     void ActivateWaitingTransactions(TPrivatePageCache::TPage::TWaitQueuePtr waitPadsQueue);
-    void AddCachesOfBundle(const NTable::TPartView &partView) noexcept;
-    void AddSingleCache(const TIntrusivePtr<TPrivatePageCache::TInfo> &info) noexcept;
-    void DropCachesOfBundle(const NTable::TPart &part) noexcept;
-    void DropSingleCache(const TLogoBlobID&) noexcept;
+    void AddCachesOfBundle(const NTable::TPartView &partView);
+    void AddSingleCache(const TIntrusivePtr<TPrivatePageCache::TInfo> &info);
+    void DropCachesOfBundle(const NTable::TPart &part);
+    void DropSingleCache(const TLogoBlobID&);
 
     void TranslateCacheTouchesToSharedCache();
     void RequestInMemPagesForDatabase(bool pendingOnly = false);
@@ -544,9 +544,9 @@ class TExecutor
     THolder<TScanSnapshot> PrepareScanSnapshot(ui32 table,
         const NTable::TCompactionParams* params, TRowVersion snapshot = TRowVersion::Max());
     void ReleaseScanLocks(TIntrusivePtr<TBarrier>, const NTable::TSubset&);
-    void StartScan(ui64 serial, ui32 table) noexcept;
-    void StartScan(ui64 task, TResource*) noexcept;
-    void StartSeat(ui64 task, TResource*) noexcept;
+    void StartScan(ui64 serial, ui32 table);
+    void StartScan(ui64 task, TResource*);
+    void StartSeat(ui64 task, TResource*);
     void PostponedScanCleared(NResourceBroker::TEvResourceBroker::TEvResourceAllocated *msg, const TActorContext &ctx);
 
     void ApplyFollowerUpdate(THolder<TEvTablet::TFUpdateBody> update);
@@ -622,7 +622,7 @@ class TExecutor
             NKikimrCompaction::ECompactionStrategy strategy);
 
 public:
-    void Describe(IOutputStream &out) const noexcept override
+    void Describe(IOutputStream &out) const override
     {
         out
             << (Stats->IsFollower() ? "Follower" : "Leader")

--- a/ydb/core/tablet_flat/flat_executor_bootlogic.cpp
+++ b/ydb/core/tablet_flat/flat_executor_bootlogic.cpp
@@ -53,7 +53,7 @@ TExecutorBootLogic::~TExecutorBootLogic()
     Y_ABORT_UNLESS(Steps->Alone(), "Bootlogic is still has pending IStep()s");
 }
 
-void TExecutorBootLogic::Describe(IOutputStream &out) const noexcept
+void TExecutorBootLogic::Describe(IOutputStream &out) const
 {
     return Steps->Describe(out);
 }
@@ -118,7 +118,7 @@ TExecutorBootLogic::EOpResult TExecutorBootLogic::ReceiveBoot(
     return CheckCompletion();
 }
 
-void TExecutorBootLogic::PrepareEnv(bool follower, ui32 gen, TExecutorCaches caches) noexcept
+void TExecutorBootLogic::PrepareEnv(bool follower, ui32 gen, TExecutorCaches caches)
 {
     BootTimestamp = AppData()->MonotonicTimeProvider->Now();
 
@@ -301,7 +301,7 @@ TExecutorBootLogic::EOpResult TExecutorBootLogic::Receive(::NActors::IEventHandl
     return CheckCompletion();
 }
 
-TAutoPtr<NBoot::TResult> TExecutorBootLogic::ExtractState() noexcept {
+TAutoPtr<NBoot::TResult> TExecutorBootLogic::ExtractState() {
     Y_ABORT_UNLESS(Result_->Database, "Looks like booting hasn't been done");
     return Result_;
 }

--- a/ydb/core/tablet_flat/flat_executor_bootlogic.h
+++ b/ydb/core/tablet_flat/flat_executor_bootlogic.h
@@ -92,8 +92,8 @@ private:
 
     EOpResult CheckCompletion();
 
-    void PrepareEnv(bool follower, ui32 generation, TExecutorCaches caches) noexcept;
-    void StartLeaseWaiter(TMonotonic bootTimestamp, const TEvTablet::TDependencyGraph& graph) noexcept;
+    void PrepareEnv(bool follower, ui32 generation, TExecutorCaches caches);
+    void StartLeaseWaiter(TMonotonic bootTimestamp, const TEvTablet::TDependencyGraph& graph);
     ui32 GetBSGroupFor(const TLogoBlobID &logo) const;
     ui32 GetBSGroupID(ui32 channel, ui32 generation);
     void LoadEntry(TIntrusivePtr<NBoot::TLoadBlobs>);
@@ -108,7 +108,7 @@ public:
     TExecutorBootLogic(IOps*, const TActorId&, TTabletStorageInfo *info, ui64 maxBytesInFly);
     ~TExecutorBootLogic();
 
-    void Describe(IOutputStream&) const noexcept;
+    void Describe(IOutputStream&) const;
     EOpResult ReceiveBoot(TEvTablet::TEvBoot::TPtr &ev, TExecutorCaches &&caches);
     EOpResult ReceiveFollowerBoot(TEvTablet::TEvFBoot::TPtr &ev, TExecutorCaches &&caches);
     EOpResult ReceiveRestored(TEvTablet::TEvRestored::TPtr &ev);
@@ -117,7 +117,7 @@ public:
     void FollowersSyncComplete();
     void Cancel();
 
-    TAutoPtr<NBoot::TResult> ExtractState() noexcept;
+    TAutoPtr<NBoot::TResult> ExtractState();
 
     TExecutorCaches DetachCaches();
 };

--- a/ydb/core/tablet_flat/flat_executor_borrowlogic.h
+++ b/ydb/core/tablet_flat/flat_executor_borrowlogic.h
@@ -23,7 +23,7 @@ class TExecutorBorrowLogic {
             TVector<TLogoBlobID> Keep;
             ui64 KeepBytes = 0;
 
-            bool HasKeep(const TLogoBlobID &blob) const noexcept
+            bool HasKeep(const TLogoBlobID &blob) const
             {
                 return std::find(Keep.begin(), Keep.end(), blob) != Keep.end();
             }

--- a/ydb/core/tablet_flat/flat_executor_database_ut.cpp
+++ b/ydb/core/tablet_flat/flat_executor_database_ut.cpp
@@ -77,7 +77,7 @@ public:
     }
 
 private:
-    EDo Spawn() noexcept
+    EDo Spawn()
     {
         Respawn -= Min(Respawn, ui32(1));
 

--- a/ydb/core/tablet_flat/flat_executor_gclogic.h
+++ b/ydb/core/tablet_flat/flat_executor_gclogic.h
@@ -23,7 +23,7 @@ struct TGCTime {
     inline void Clear() { Generation = Step = 0; }
     static TGCTime Infinity() { return TGCTime(std::numeric_limits<ui32>::max(), std::numeric_limits<ui32>::max()); }
 
-    explicit operator bool() const noexcept { return Valid(); }
+    explicit operator bool() const { return Valid(); }
 };
 
 struct TGCLogEntry {

--- a/ydb/core/tablet_flat/flat_executor_tx_env.h
+++ b/ydb/core/tablet_flat/flat_executor_tx_env.h
@@ -20,12 +20,12 @@ namespace NTabletFlatExecutor {
         { }
 
     protected: /* NTable::IPages, page collection backend implementation */
-        TResult Locate(const TMemTable *memTable, ui64 ref, ui32 tag) noexcept override
+        TResult Locate(const TMemTable *memTable, ui64 ref, ui32 tag) override
         {
             return NTable::MemTableRefLookup(memTable, ref, tag);
         }
 
-        TResult Locate(const TPart *part, ui64 ref, ELargeObj lob) noexcept override
+        TResult Locate(const TPart *part, ui64 ref, ELargeObj lob) override
         {
             auto *partStore = CheckedCast<const NTable::TPartStore*>(part);
 
@@ -45,22 +45,22 @@ namespace NTabletFlatExecutor {
             return Lookup(partStore->PageCollections.at(groupId.Index).Get(), pageId);
         }
 
-        void EnableReadMissingReferences() noexcept {
+        void EnableReadMissingReferences() {
             ReadMissingReferences = true;
         }
 
-        void DisableReadMissingReferences() noexcept {
+        void DisableReadMissingReferences() {
             ReadMissingReferences = false;
             MissingReferencesSize_ = 0;
         }
 
-        ui64 MissingReferencesSize() const noexcept
+        ui64 MissingReferencesSize() const
         { 
             return MissingReferencesSize_;
         }
 
     private:
-        const TSharedData* Lookup(TPrivatePageCache::TInfo *info, TPageId pageId) noexcept
+        const TSharedData* Lookup(TPrivatePageCache::TInfo *info, TPageId pageId)
         {
             return Cache.Lookup(pageId, info);
         }
@@ -136,7 +136,7 @@ namespace NTabletFlatExecutor {
 
         using TPageCollectionReadEnv::TPageCollectionReadEnv;
 
-        bool HasChanges() const noexcept
+        bool HasChanges() const
         {
             return
                 DropSnap
@@ -148,7 +148,7 @@ namespace NTabletFlatExecutor {
         }
 
     protected:
-        void OnRollbackChanges() noexcept override {
+        void OnRollbackChanges() override {
             MakeSnap.clear();
             DropSnap.Reset();
             BorrowUpdates.clear();
@@ -212,17 +212,17 @@ namespace NTabletFlatExecutor {
             LoanConfirmation.insert(std::make_pair(bundle, TLoanConfirmation{borrow}));
         }
 
-        void EnableReadMissingReferences() noexcept override
+        void EnableReadMissingReferences() override
         {
             TPageCollectionReadEnv::EnableReadMissingReferences();
         }
 
-        void DisableReadMissingReferences() noexcept override
+        void DisableReadMissingReferences() override
         {
             TPageCollectionReadEnv::DisableReadMissingReferences();
         }
 
-        ui64 MissingReferencesSize() const noexcept override
+        ui64 MissingReferencesSize() const override
         {
             return TPageCollectionReadEnv::MissingReferencesSize();
         }

--- a/ydb/core/tablet_flat/flat_executor_txloglogic.cpp
+++ b/ydb/core/tablet_flat/flat_executor_txloglogic.cpp
@@ -37,7 +37,7 @@ TLogicRedo::TLogicRedo(TAutoPtr<NPageCollection::TSteppedCookieAllocator> cookie
 TLogicRedo::~TLogicRedo()
 {}
 
-void TLogicRedo::Describe(IOutputStream &out) const noexcept
+void TLogicRedo::Describe(IOutputStream &out) const
 {
     return Queue->Describe(out);
 }
@@ -47,12 +47,12 @@ void TLogicRedo::InstallCounters(TExecutorCounters *counters, TTabletCountersWit
     AppTxCounters = appTxCounters;
 }
 
-NRedo::TStats TLogicRedo::LogStats() const noexcept
+NRedo::TStats TLogicRedo::LogStats() const
 {
     return { Queue->Items, Queue->Memory, Queue->LargeGlobIdsBytes };
 }
 
-TArrayRef<const NRedo::TUsage> TLogicRedo::GrabLogUsage() const noexcept
+TArrayRef<const NRedo::TUsage> TLogicRedo::GrabLogUsage() const
 {
     return Queue->GrabUsage();
 }

--- a/ydb/core/tablet_flat/flat_executor_txloglogic.h
+++ b/ydb/core/tablet_flat/flat_executor_txloglogic.h
@@ -55,7 +55,7 @@ public:
     TLogicRedo(TAutoPtr<NPageCollection::TSteppedCookieAllocator>, TCommitManager*, TAutoPtr<NRedo::TQueue>);
     ~TLogicRedo();
 
-    void Describe(IOutputStream &out) const noexcept;
+    void Describe(IOutputStream &out) const;
     void InstallCounters(TExecutorCounters *counters, TTabletCountersWithTxTypes* appTxCounters);
     bool CommitROTransaction(std::unique_ptr<TSeat> seat, const TActorContext &ownerCtx);
     TCommitRWTransactionResult CommitRWTransaction(std::unique_ptr<TSeat> seat, NTable::TChange &change, bool force);
@@ -66,8 +66,8 @@ public:
 
     void CutLog(ui32 table, NTable::TSnapEdge, TGCBlobDelta&);
     void SnapToLog(NKikimrExecutorFlat::TLogSnapshot&);
-    NRedo::TStats LogStats() const noexcept;
-    TArrayRef<const NRedo::TUsage> GrabLogUsage() const noexcept;
+    NRedo::TStats LogStats() const;
+    TArrayRef<const NRedo::TUsage> GrabLogUsage() const;
 };
 
 void CompleteRoTransaction(std::unique_ptr<TSeat>, const TActorContext &ownerCtx, TExecutorCounters *counters, TTabletCountersWithTxTypes *appTxCounters);

--- a/ydb/core/tablet_flat/flat_executor_ut.cpp
+++ b/ydb/core/tablet_flat/flat_executor_ut.cpp
@@ -260,7 +260,7 @@ public:
     {}
     ~TDummyScan() {}
 
-    void Describe(IOutputStream &out) const noexcept override
+    void Describe(IOutputStream &out) const override
     {
         out << "DummyScan";
     }
@@ -279,7 +279,7 @@ public:
     }
 
 private:
-    TInitialState Prepare(IDriver *driver, TIntrusiveConstPtr<TScheme> scheme) noexcept override
+    TInitialState Prepare(IDriver *driver, TIntrusiveConstPtr<TScheme> scheme) override
     {
         Driver = driver;
         Scheme = std::move(scheme);
@@ -295,7 +295,7 @@ private:
         }
     }
 
-    EScan Seek(TLead &lead, ui64 seq) noexcept override
+    EScan Seek(TLead &lead, ui64 seq) override
     {
         if (seq && Abort == EAbort::None)
             return EScan::Final;
@@ -307,7 +307,7 @@ private:
         return EScan::Feed;
     }
 
-    EScan Feed(TArrayRef<const TCell> key, const TRow &) noexcept override
+    EScan Feed(TArrayRef<const TCell> key, const TRow &) override
     {
         Y_ABORT_UNLESS(key[0].AsValue<ui64>() == ExpectedRowId);
         ++ExpectedRowId;
@@ -315,12 +315,12 @@ private:
         return EScan::Feed;
     }
 
-    EScan PageFault() noexcept override {
+    EScan PageFault() override {
         PageFaults++;
         return EScan::Feed;
     }
 
-    TAutoPtr<IDestructable> Finish(EAbort abort) noexcept override
+    TAutoPtr<IDestructable> Finish(EAbort abort) override
     {
         Y_ABORT_UNLESS((int)Abort == (int)abort);
 
@@ -855,7 +855,7 @@ Y_UNIT_TEST_SUITE(TFlatTableExecutor_BackgroundCompactions) {
             SendEv(MakeResourceBrokerID(), event.Release());
         }
 
-        static TCompactionPolicy* MakeCompactionPolicy() noexcept
+        static TCompactionPolicy* MakeCompactionPolicy()
         {
             auto *policy = new TCompactionPolicy();
             policy->InMemSizeToSnapshot = 40 * 1024 *1024;
@@ -1023,7 +1023,7 @@ Y_UNIT_TEST_SUITE(TFlatTableExecutor_PostponedScan) {
             SendSync(new TEvents::TEvPoison, false, true);
         }
 
-        static TCompactionPolicy* MakeCompactionPolicy() noexcept
+        static TCompactionPolicy* MakeCompactionPolicy()
         {
             auto *policy = new TCompactionPolicy();
             policy->InMemSizeToSnapshot = 40 * 1024 *1024;
@@ -1416,7 +1416,7 @@ Y_UNIT_TEST_SUITE(TFlatTableExecutor_ResourceProfile) {
             SendSync(new TEvents::TEvPoison, false, true);
         }
 
-        static TCompactionPolicy* MakeCompactionPolicy() noexcept
+        static TCompactionPolicy* MakeCompactionPolicy()
         {
             auto *policy = new TCompactionPolicy();
             policy->InMemSizeToSnapshot = 40 * 1024 *1024;
@@ -3600,23 +3600,23 @@ Y_UNIT_TEST_SUITE(TFlatTableExecutor_Follower) {
     struct TEmptyScan : public NTable::IScan {
         TEmptyScan() = default;
 
-        void Describe(IOutputStream& out) const noexcept override {
+        void Describe(IOutputStream& out) const override {
             out << "TEmptyScan{}";
         }
 
-        TInitialState Prepare(NTable::IDriver*, TIntrusiveConstPtr<TScheme>) noexcept override {
+        TInitialState Prepare(NTable::IDriver*, TIntrusiveConstPtr<TScheme>) override {
             return {EScan::Final, {}};
         }
 
-        EScan Seek(TLead&, ui64) noexcept override {
+        EScan Seek(TLead&, ui64) override {
             Y_ABORT("unreachable");
         }
 
-        EScan Feed(TArrayRef<const TCell>, const TRow&) noexcept override {
+        EScan Feed(TArrayRef<const TCell>, const TRow&) override {
             Y_ABORT("unreachable");
         }
 
-        TAutoPtr<IDestructable> Finish(EAbort) noexcept override {
+        TAutoPtr<IDestructable> Finish(EAbort) override {
             delete this;
             return nullptr;
         }
@@ -7050,7 +7050,7 @@ Y_UNIT_TEST_SUITE(TFlatTableExecutor_Reboot) {
         IActor *tabletActor = nullptr; // save tablet to get its actor id and avoid using tablet resolver which has outdated info
         while (true) {
             struct TReassignedStarter : NFake::TStarter {
-                NFake::TStorageInfo* MakeTabletInfo(ui64 tablet, ui32 channelsCount) noexcept override {
+                NFake::TStorageInfo* MakeTabletInfo(ui64 tablet, ui32 channelsCount) override {
                     auto *info = TStarter::MakeTabletInfo(tablet, channelsCount);
                     info->Channels[1].History.emplace_back(3, 3);
                     return info;

--- a/ydb/core/tablet_flat/flat_fwd_blobs.h
+++ b/ydb/core/tablet_flat/flat_fwd_blobs.h
@@ -32,7 +32,7 @@ namespace NFwd {
             for (auto &it: Pages) it.Release();
         }
 
-        TResult Get(IPageLoadingQueue *head, ui32 ref, EPage, ui64 lower) noexcept override
+        TResult Get(IPageLoadingQueue *head, ui32 ref, EPage, ui64 lower) override
         {
             Y_ABORT_UNLESS(ref >= Lower, "Cannot handle backward blob reads");
 
@@ -49,12 +49,12 @@ namespace NFwd {
             return { page.Touch(ref, Stat), more, page.Size < Edge[page.Tag] };
         }
 
-        void Forward(IPageLoadingQueue *head, ui64 upper) noexcept override
+        void Forward(IPageLoadingQueue *head, ui64 upper) override
         {
             Preload(head, upper);
         }
 
-        void Fill(NPageCollection::TLoadedPage& page, NSharedCache::TSharedPageRef sharedPageRef, EPage) noexcept override
+        void Fill(NPageCollection::TLoadedPage& page, NSharedCache::TSharedPageRef sharedPageRef, EPage) override
         {
             if (!Pages || page.PageId < Pages.front().PageId) {
                 Y_ABORT("Blobs fwd cache got page below queue");
@@ -71,25 +71,25 @@ namespace NFwd {
             Shrink(false /* do not drop loading pages */);
         }
 
-        TDeque<TScreen::THole> Traced() noexcept
+        TDeque<TScreen::THole> Traced()
         {
             Rewind(Max<TPageId>()).Shrink(true /* complete trace */);
 
             return Trace ? Trace->Unwrap() : TDeque<TScreen::THole>{ };
         }
 
-        TIntrusiveConstPtr<NPage::TFrames> GetFrames() const noexcept
+        TIntrusiveConstPtr<NPage::TFrames> GetFrames() const
         {
             return Frames;
         }
 
-        TIntrusiveConstPtr<TSlices> GetSlices() const noexcept
+        TIntrusiveConstPtr<TSlices> GetSlices() const
         {
             return Filter.GetSlices();
         }
 
     private:
-        TPage& Lookup(ui32 ref) noexcept
+        TPage& Lookup(ui32 ref)
         {
             const auto end = Pages.begin() + Offset;
 
@@ -104,7 +104,7 @@ namespace NFwd {
             }
         }
 
-        ui32 FrameTo(TPageId ref) noexcept
+        ui32 FrameTo(TPageId ref)
         {
             if (ref >= Lower && ref < Upper) {
                 return Lookup(ref).Tag;
@@ -120,7 +120,7 @@ namespace NFwd {
             }
         }
 
-        ui32 FrameTo(TPageId ref, NPage::TFrames::TEntry rel) noexcept
+        ui32 FrameTo(TPageId ref, NPage::TFrames::TEntry rel)
         {
             Lower = Min(ref, rel.AbsRef(ref));
             Upper = ref + 1; /* will be extended eventually */
@@ -128,7 +128,7 @@ namespace NFwd {
             return rel.Tag;
         }
 
-        TBlobs& Preload(IPageLoadingQueue *head, ui64 upper) noexcept
+        TBlobs& Preload(IPageLoadingQueue *head, ui64 upper)
         {
             auto until = [this, upper]() { return OnHold + OnFetch < upper; };
 
@@ -160,7 +160,7 @@ namespace NFwd {
             return *this;
         }
 
-        TPageId Propagate(const TPageId base) noexcept
+        TPageId Propagate(const TPageId base)
         {
             if (Pages && base <= Pages.back().PageId) {
                 return Lookup(base).Refer;
@@ -182,7 +182,7 @@ namespace NFwd {
             }
         }
 
-        TBlobs& Rewind(TPageId until) noexcept
+        TBlobs& Rewind(TPageId until)
         {
             for (; Offset < Pages.size(); Offset++) {
                 auto &page = Pages.at(Offset);
@@ -202,7 +202,7 @@ namespace NFwd {
             return *this;
         }
 
-        TBlobs& Shrink(bool force = false) noexcept
+        TBlobs& Shrink(bool force = false)
         {
             for (; Offset && (Pages[0].Ready() || force); Offset--) {
 

--- a/ydb/core/tablet_flat/flat_fwd_cache.h
+++ b/ydb/core/tablet_flat/flat_fwd_cache.h
@@ -119,7 +119,7 @@ namespace NFwd {
             }
         }
 
-        TResult Get(IPageLoadingQueue *head, TPageId pageId, EPage type, ui64 lower) noexcept override
+        TResult Get(IPageLoadingQueue *head, TPageId pageId, EPage type, ui64 lower) override
         {
             if (type == EPage::FlatIndex) {
                 Y_ABORT_UNLESS(pageId == IndexPage.PageId);
@@ -153,14 +153,14 @@ namespace NFwd {
             return {Pages.at(PagesBeginOffset).Touch(pageId, Stat), grow, true};
         }
 
-        void Forward(IPageLoadingQueue *head, ui64 upper) noexcept override
+        void Forward(IPageLoadingQueue *head, ui64 upper) override
         {
             while (Iter && Iter->GetRowId() < EndRowId && OnHold + OnFetch < upper) {
                 RequestNextPage(head);
             }
         }
 
-        void Fill(NPageCollection::TLoadedPage& page, NSharedCache::TSharedPageRef sharedPageRef, EPage type) noexcept override
+        void Fill(NPageCollection::TLoadedPage& page, NSharedCache::TSharedPageRef sharedPageRef, EPage type) override
         {
             Stat.Saved += page.Data.size();
             
@@ -186,7 +186,7 @@ namespace NFwd {
         }
 
     private:
-        void DropPagesBefore(TPageId pageId) noexcept
+        void DropPagesBefore(TPageId pageId)
         {
             while (PagesBeginOffset < Pages.size()) {
                 auto &page = Pages.at(PagesBeginOffset);
@@ -209,7 +209,7 @@ namespace NFwd {
             }
         }
 
-        void ShrinkPages() noexcept
+        void ShrinkPages()
         {
             while (PagesBeginOffset && Pages.front().Ready()) {
                 Pages.pop_front();
@@ -217,7 +217,7 @@ namespace NFwd {
             }
         }
 
-        void AdvanceNextPage(TPageId pageId) noexcept
+        void AdvanceNextPage(TPageId pageId)
         {
             Y_ABORT_UNLESS(Iter);
             Y_ABORT_UNLESS(Iter->GetPageId() <= pageId);
@@ -229,7 +229,7 @@ namespace NFwd {
             Y_ABORT_UNLESS(Iter->GetPageId() == pageId);
         }
 
-        void RequestNextPage(IPageLoadingQueue *head) noexcept
+        void RequestNextPage(IPageLoadingQueue *head)
         {
             Y_ABORT_UNLESS(Iter);
 
@@ -316,7 +316,7 @@ namespace NFwd {
             }
         }
 
-        TResult Get(IPageLoadingQueue *head, TPageId pageId, EPage type, ui64 lower) noexcept override
+        TResult Get(IPageLoadingQueue *head, TPageId pageId, EPage type, ui64 lower) override
         {
             auto levelId = GetLevel(pageId, type);
             auto& level = Levels[levelId];
@@ -340,7 +340,7 @@ namespace NFwd {
             return {level.Pages.at(level.PagesBeginOffset).Touch(pageId, Stat), grow, true};
         }
 
-        void Forward(IPageLoadingQueue *head, ui64 upper) noexcept override
+        void Forward(IPageLoadingQueue *head, ui64 upper) override
         {
             for (auto& level : Levels) {
                 if (level.Pages.empty()) {
@@ -353,7 +353,7 @@ namespace NFwd {
             }
         }
 
-        void Fill(NPageCollection::TLoadedPage& page, NSharedCache::TSharedPageRef sharedPageRef, EPage type) noexcept override
+        void Fill(NPageCollection::TLoadedPage& page, NSharedCache::TSharedPageRef sharedPageRef, EPage type) override
         {
             Stat.Saved += page.Data.size();
               
@@ -393,7 +393,7 @@ namespace NFwd {
             }
         }
 
-        void DropPagesBefore(TLevel& level, TPageId pageId) noexcept
+        void DropPagesBefore(TLevel& level, TPageId pageId)
         {
             while (level.PagesBeginOffset < level.Pages.size()) {
                 auto &page = level.Pages.at(level.PagesBeginOffset);
@@ -417,7 +417,7 @@ namespace NFwd {
             }
         }
 
-        void AdvancePending(ui32 levelId) noexcept
+        void AdvancePending(ui32 levelId)
         {
             auto& level = Levels[levelId];
 
@@ -448,7 +448,7 @@ namespace NFwd {
             }
         }
 
-        void ShrinkPages(TLevel& level) noexcept
+        void ShrinkPages(TLevel& level)
         {
             while (level.PagesBeginOffset && level.Pages.front().Ready()) {
                 level.Pages.pop_front();
@@ -459,7 +459,7 @@ namespace NFwd {
             }
         }
 
-        ui64 GetDataSize(TLevel& level) noexcept
+        ui64 GetDataSize(TLevel& level)
         {
             if (&level == &Levels.back()) {
                 return 
@@ -475,7 +475,7 @@ namespace NFwd {
             }
         }
 
-        void AdvanceNextPage(TLevel& level, TPageId pageId) noexcept
+        void AdvanceNextPage(TLevel& level, TPageId pageId)
         {
             auto& queue = level.Queue;
 
@@ -489,7 +489,7 @@ namespace NFwd {
             Y_ABORT_UNLESS(queue.front().PageId == pageId);
         }
 
-        void RequestNextPage(TLevel& level, IPageLoadingQueue *head) noexcept
+        void RequestNextPage(TLevel& level, IPageLoadingQueue *head)
         {
             Y_ABORT_UNLESS(!level.Queue.empty());
             auto pageId = level.Queue.front().PageId;

--- a/ydb/core/tablet_flat/flat_fwd_conf.h
+++ b/ydb/core/tablet_flat/flat_fwd_conf.h
@@ -10,7 +10,7 @@ namespace NTable {
 namespace NFwd {
 
     struct TConf {
-        void Describe(IOutputStream &out) const noexcept
+        void Describe(IOutputStream &out) const
         {
             out
                 << "TConf{"

--- a/ydb/core/tablet_flat/flat_fwd_env.h
+++ b/ydb/core/tablet_flat/flat_fwd_env.h
@@ -48,7 +48,7 @@ namespace NFwd {
             return PageLoadingLogic.Get();
         }
 
-        ui64 AddToQueue(TPageId pageId, EPage type) noexcept override
+        ui64 AddToQueue(TPageId pageId, EPage type) override
         {
             if (IsIndexPage(type)) {
                 return AddToQueue(pageId, type, IndexPageCollection, IndexFetch);
@@ -109,7 +109,7 @@ namespace NFwd {
                 AddPartView(one);
         }
 
-        void AddCold(const TPartView& partView) noexcept
+        void AddCold(const TPartView& partView)
         {
             auto r = ColdParts.insert(partView.Part.Get());
             Y_ABORT_UNLESS(r.second, "Cannot add a duplicate cold part");
@@ -117,7 +117,7 @@ namespace NFwd {
             AddPartView(partView);
         }
 
-        bool MayProgress() const noexcept
+        bool MayProgress() const
         {
             return Pending == 0;
         }
@@ -134,12 +134,12 @@ namespace NFwd {
             return Get(GetQueue(part, groupId), pageId, type).Page;
         }
 
-        TResult Locate(const TMemTable *memTable, ui64 ref, ui32 tag) noexcept override
+        TResult Locate(const TMemTable *memTable, ui64 ref, ui32 tag) override
         {
             return MemTable->Locate(memTable, ref, tag);
         }
 
-        TResult Locate(const TPart *part, ui64 ref, ELargeObj lob) noexcept override
+        TResult Locate(const TPart *part, ui64 ref, ELargeObj lob) override
         {
             if ((lob != ELargeObj::Extern && lob != ELargeObj::Outer) || (ref >> 32)) {
                 Y_Fail("Invalid ref ELargeObj{" << int(lob) << ", " << ref << "}");
@@ -179,7 +179,7 @@ namespace NFwd {
             }
         }
 
-        IPages* Reset() noexcept
+        IPages* Reset()
         {
             /* Current version of cache works only on forward iterations over
                 parts and cannot handle backward jumps. This call is temporary
@@ -203,7 +203,7 @@ namespace NFwd {
             return this;
         }
 
-        TStat Stats() const noexcept
+        TStat Stats() const
         {
             auto aggr = [](auto &&stat, const TPartGroupLoadingQueue &q) {
                 return stat += q->Stat;
@@ -212,7 +212,7 @@ namespace NFwd {
             return std::accumulate(GroupQueues.begin(), GroupQueues.end(), Total, aggr);
         }
 
-        TAutoPtr<TFetch> GrabFetches() noexcept
+        TAutoPtr<TFetch> GrabFetches()
         {
             while (FetchingQueues) {
                 auto queue = FetchingQueues.Front();
@@ -238,7 +238,7 @@ namespace NFwd {
             return nullptr;
         }
 
-        TAutoPtr<TSeen> GrabTraces() noexcept
+        TAutoPtr<TSeen> GrabTraces()
         {
             TDeque<TSieve> sieves(PartGroupQueues.size() - ColdParts.size() + 1);
 
@@ -273,7 +273,7 @@ namespace NFwd {
         }
 
     private:
-        TResult Get(TPartGroupLoadingQueue &queue, TPageId pageId, EPage type) noexcept
+        TResult Get(TPartGroupLoadingQueue &queue, TPageId pageId, EPage type)
         {
             auto got = queue->Get(&queue, pageId, type, Conf.AheadLo);
 
@@ -289,7 +289,7 @@ namespace NFwd {
             return { got.Need, got.Page };
         }
 
-        void AddPartView(const TPartView& partView) noexcept
+        void AddPartView(const TPartView& partView)
         {
             const auto *part = partView.Part.Get();
 
@@ -311,13 +311,13 @@ namespace NFwd {
             }
         }
 
-        TPartGroupLoadingQueue& GetQueue(const TPart *part, TGroupId groupId) noexcept
+        TPartGroupLoadingQueue& GetQueue(const TPart *part, TGroupId groupId)
         {
             ui16 room = (groupId.Historic ? part->GroupsCount + 2 : 0) + groupId.Index;
             return GetQueue(part, room);
         }
 
-        TPartGroupLoadingQueue& GetQueue(const TPart *part, ui16 room) noexcept
+        TPartGroupLoadingQueue& GetQueue(const TPart *part, ui16 room)
         {
             auto it = PartGroupQueues.FindPtr(part);
             Y_ABORT_UNLESS(it, "NFwd cache trying to access part outside of subset");
@@ -329,7 +329,7 @@ namespace NFwd {
             return *queue;
         }
 
-        TPartGroupLoadingQueue* Settle(TGroupPages pages, ui32 partIndex) noexcept
+        TPartGroupLoadingQueue* Settle(TGroupPages pages, ui32 partIndex)
         {
             if (pages.PageLoadingLogic || pages.IndexPageCollection || pages.GroupPageCollection) {
                 const ui64 cookie = (ui64(GroupQueues.size()) << 32) | ui32(Salt + Epoch);
@@ -344,7 +344,7 @@ namespace NFwd {
             }
         }
 
-        TGroupPages MakeCache(const TPart *part, NPage::TGroupId groupId, TIntrusiveConstPtr<TSlices> slices) noexcept
+        TGroupPages MakeCache(const TPart *part, NPage::TGroupId groupId, TIntrusiveConstPtr<TSlices> slices)
         {
             auto *partStore = CheckedCast<const TPartStore*>(part);
 
@@ -355,7 +355,7 @@ namespace NFwd {
                 partStore->PageCollections[groupId.Index]->PageCollection};
         }
 
-        TGroupPages MakeExtern(const TPart *part, TIntrusiveConstPtr<TSlices> bounds) const noexcept
+        TGroupPages MakeExtern(const TPart *part, TIntrusiveConstPtr<TSlices> bounds) const
         {
             if (auto blobs = part->Blobs) {
                 /* Should always materialize key columns to values since
@@ -384,7 +384,7 @@ namespace NFwd {
             }
         }
 
-        TGroupPages MakeOuter(const TPart *part, TIntrusiveConstPtr<TSlices> bounds) const noexcept
+        TGroupPages MakeOuter(const TPart *part, TIntrusiveConstPtr<TSlices> bounds) const
         {
             if (auto small = part->Small) {
                 auto *partStore = CheckedCast<const TPartStore*>(part);

--- a/ydb/core/tablet_flat/flat_fwd_iface.h
+++ b/ydb/core/tablet_flat/flat_fwd_iface.h
@@ -18,7 +18,7 @@ namespace NFwd {
     public:
         virtual ~IPageLoadingQueue() = default;
 
-        virtual ui64 AddToQueue(TPageId pageId, EPage type) noexcept = 0;
+        virtual ui64 AddToQueue(TPageId pageId, EPage type) = 0;
     };
 
     class IPageLoadingLogic {
@@ -31,9 +31,9 @@ namespace NFwd {
 
         virtual ~IPageLoadingLogic() = default;
 
-        virtual TResult Get(IPageLoadingQueue *head, TPageId pageId, EPage type, ui64 lower) noexcept = 0;
-        virtual void Forward(IPageLoadingQueue *head, ui64 upper) noexcept = 0;
-        virtual void Fill(NPageCollection::TLoadedPage& page, NSharedCache::TSharedPageRef sharedPageRef, EPage type) noexcept = 0;
+        virtual TResult Get(IPageLoadingQueue *head, TPageId pageId, EPage type, ui64 lower) = 0;
+        virtual void Forward(IPageLoadingQueue *head, ui64 upper) = 0;
+        virtual void Fill(NPageCollection::TLoadedPage& page, NSharedCache::TSharedPageRef sharedPageRef, EPage type) = 0;
 
         IPageLoadingQueue* Head = nullptr; /* will be set outside of IPageLoadingLogic impl */
         TStat Stat;

--- a/ydb/core/tablet_flat/flat_fwd_misc.h
+++ b/ydb/core/tablet_flat/flat_fwd_misc.h
@@ -15,7 +15,7 @@ namespace NFwd {
             eff = Usage * [ /Fetch; /(Before + Usage + After) ];
         */
 
-        void Describe(IOutputStream &out) const noexcept
+        void Describe(IOutputStream &out) const
         {
             out
                 << "TFwd{"

--- a/ydb/core/tablet_flat/flat_fwd_page.h
+++ b/ydb/core/tablet_flat/flat_fwd_page.h
@@ -55,7 +55,7 @@ namespace NFwd {
             return Data ? &Data : nullptr;
         }
 
-        ui32 Settle(NPageCollection::TLoadedPage &page, NSharedCache::TSharedPageRef ref) noexcept
+        ui32 Settle(NPageCollection::TLoadedPage &page, NSharedCache::TSharedPageRef ref)
         {
             const auto was = std::exchange(Fetch, EFetch::Done);
 
@@ -75,7 +75,7 @@ namespace NFwd {
             return Data.size();
         }
 
-        const TSharedData* Touch(TPageId pageId, TStat &stat) noexcept
+        const TSharedData* Touch(TPageId pageId, TStat &stat)
         {
             if (PageId != pageId || (!Data && Fetch == EFetch::Done)) {
                 Y_ABORT("Touching page that doesn't fit to this action");
@@ -89,7 +89,7 @@ namespace NFwd {
             return Plain();
         }
 
-        TSharedData Release() noexcept
+        TSharedData Release()
         {
             Fetch = Max(Fetch, EFetch::Drop);
 

--- a/ydb/core/tablet_flat/flat_fwd_sieve.h
+++ b/ydb/core/tablet_flat/flat_fwd_sieve.h
@@ -27,7 +27,7 @@ namespace NFwd {
 
         }
 
-        ui32 Total() const noexcept
+        ui32 Total() const
         {
             if (!Blobs) {
                 return 0;
@@ -47,12 +47,12 @@ namespace NFwd {
             return total;
         }
 
-        ui32 Removed() const noexcept
+        ui32 Removed() const
         {
             return TScreen::Sum(Holes);
         }
 
-        void MaterializeTo(TVector<TLogoBlobID> &vec) const noexcept
+        void MaterializeTo(TVector<TLogoBlobID> &vec) const
         {
             const auto limit = Blobs ? Blobs->Total() : 0;
 

--- a/ydb/core/tablet_flat/flat_fwd_warmed.h
+++ b/ydb/core/tablet_flat/flat_fwd_warmed.h
@@ -33,7 +33,7 @@ namespace NFwd {
             }
         }
 
-        TResult Locate(const TMemTable *memTable, ui64 ref, ui32 tag) noexcept
+        TResult Locate(const TMemTable *memTable, ui64 ref, ui32 tag)
         {
             const auto &glob = memTable->GetBlobs()->Get(ref);
 
@@ -47,7 +47,7 @@ namespace NFwd {
             return { !omit, omit ? nullptr : &glob.Data };
         }
 
-        TSieve Traced() noexcept
+        TSieve Traced()
         {
             /* Blobs in TMemTable catalog isn't sorted in order of appearance
                 in rows cells. That is way bitmap is used instead of just

--- a/ydb/core/tablet_flat/flat_iterator.h
+++ b/ydb/core/tablet_flat/flat_iterator.h
@@ -227,7 +227,7 @@ class TTableIterBase : TNonCopyable {
         bool FutureEntryValid = false;
     };
 
-    bool SkipErase(TArrayRef<const TCell> endKey, bool inclusive = true) noexcept {
+    bool SkipErase(TArrayRef<const TCell> endKey, bool inclusive = true) {
         if (inclusive) {
             // Pretend we saw endKey last, but the pointer correctness is very
             // subtle. We only seek to the erased range end when we don't have
@@ -257,17 +257,17 @@ public:
     void StopBefore(TArrayRef<const TCell> key);
     void StopAfter(TArrayRef<const TCell> key);
 
-    bool SkipTo(TCelled::TRaw key, bool inclusive = true) noexcept {
+    bool SkipTo(TCelled::TRaw key, bool inclusive = true) {
         TCelled cells(key, *Scheme->Keys, false);
 
         return SkipTo(cells, inclusive);
     }
 
-    bool SkipTo(TArrayRef<const TCell> key, bool inclusive = true) noexcept {
+    bool SkipTo(TArrayRef<const TCell> key, bool inclusive = true) {
         return SeekInternal(key, inclusive ? ESeek::Lower : ESeek::Upper);
     }
 
-    EReady Next(ENext mode) noexcept
+    EReady Next(ENext mode)
     {
         TEraseCachingState eraseCache(this);
 
@@ -338,11 +338,11 @@ public:
         return LastKeyState;
     }
 
-    bool IsUncommitted() const noexcept;
-    ui64 GetUncommittedTxId() const noexcept;
-    EReady SkipUncommitted() noexcept;
-    TRowVersion GetRowVersion() const noexcept;
-    EReady SkipToRowVersion(TRowVersion rowVersion) noexcept;
+    bool IsUncommitted() const;
+    ui64 GetUncommittedTxId() const;
+    EReady SkipUncommitted();
+    TRowVersion GetRowVersion() const;
+    EReady SkipToRowVersion(TRowVersion rowVersion);
 
 public:
     const TRowScheme* Scheme;
@@ -394,12 +394,12 @@ private:
             : Types(types)
         {}
 
-        int CompareKeys(TArrayRef<const TCell> a, TArrayRef<const TCell> b) const noexcept
+        int CompareKeys(TArrayRef<const TCell> a, TArrayRef<const TCell> b) const
         {
             return TIterOps::CompareKeys(Types, a, b);
         }
 
-        bool operator() (const TElement& a, const TElement& b) const noexcept
+        bool operator() (const TElement& a, const TElement& b) const
         {
             if (int cmp = CompareKeys(a.Key, b.Key))
                 return cmp > 0;
@@ -448,17 +448,17 @@ private:
     bool Delta = false;
     bool Uncommitted = false;
 
-    EReady Start() noexcept;
-    EReady Turn() noexcept;
-    EReady Snap() noexcept;
-    EReady Snap(TRowVersion rowVersion) noexcept;
-    EReady DoSkipUncommitted() noexcept;
-    EReady Apply() noexcept;
-    void InitLastKey(ERowOp op) noexcept;
+    EReady Start();
+    EReady Turn();
+    EReady Snap();
+    EReady Snap(TRowVersion rowVersion);
+    EReady DoSkipUncommitted();
+    EReady Apply();
+    void InitLastKey(ERowOp op);
     void AddReadyIterator(TArrayRef<const TCell> key, TIteratorId itId);
     void AddNotReadyIterator(TIteratorId itId);
 
-    bool SeekInternal(TArrayRef<const TCell> key, ESeek seek) noexcept;
+    bool SeekInternal(TArrayRef<const TCell> key, ESeek seek);
 };
 
 class TTableIter;
@@ -584,7 +584,7 @@ inline void TTableIterBase<TIteratorOps>::StopAfter(TArrayRef<const TCell> key)
 }
 
 template<class TIteratorOps>
-inline EReady TTableIterBase<TIteratorOps>::Start() noexcept
+inline EReady TTableIterBase<TIteratorOps>::Start()
 {
     if (Active != Iterators.end()) {
         return EReady::Page;
@@ -622,7 +622,7 @@ inline EReady TTableIterBase<TIteratorOps>::Start() noexcept
 }
 
 template<class TIteratorOps>
-inline EReady TTableIterBase<TIteratorOps>::Turn() noexcept
+inline EReady TTableIterBase<TIteratorOps>::Turn()
 {
     if (!Limit) {
         // Optimization: avoid calling Next after returning the last row
@@ -690,7 +690,7 @@ inline EReady TTableIterBase<TIteratorOps>::Turn() noexcept
 }
 
 template<class TIteratorOps>
-inline bool TTableIterBase<TIteratorOps>::IsUncommitted() const noexcept
+inline bool TTableIterBase<TIteratorOps>::IsUncommitted() const
 {
     // Must only be called after a fully successful Apply()
     Y_DEBUG_ABORT_UNLESS(Stage == EStage::Done && Ready == EReady::Data);
@@ -702,7 +702,7 @@ inline bool TTableIterBase<TIteratorOps>::IsUncommitted() const noexcept
 }
 
 template<class TIteratorOps>
-inline ui64 TTableIterBase<TIteratorOps>::GetUncommittedTxId() const noexcept
+inline ui64 TTableIterBase<TIteratorOps>::GetUncommittedTxId() const
 {
     // Must only be called after a fully successful Apply()
     Y_DEBUG_ABORT_UNLESS(Stage == EStage::Done && Ready == EReady::Data);
@@ -717,7 +717,7 @@ inline ui64 TTableIterBase<TIteratorOps>::GetUncommittedTxId() const noexcept
 }
 
 template<class TIteratorOps>
-inline EReady TTableIterBase<TIteratorOps>::SkipUncommitted() noexcept
+inline EReady TTableIterBase<TIteratorOps>::SkipUncommitted()
 {
     // Must only be called after successful Apply() or page fault in SkipUncommitted()
     Y_DEBUG_ABORT_UNLESS(Stage == EStage::Done && Ready != EReady::Gone);
@@ -742,7 +742,7 @@ inline EReady TTableIterBase<TIteratorOps>::SkipUncommitted() noexcept
 }
 
 template<class TIteratorOps>
-inline TRowVersion TTableIterBase<TIteratorOps>::GetRowVersion() const noexcept
+inline TRowVersion TTableIterBase<TIteratorOps>::GetRowVersion() const
 {
     // Must only be called after a fully successful Apply()
     Y_DEBUG_ABORT_UNLESS(Stage == EStage::Done && Ready == EReady::Data);
@@ -769,7 +769,7 @@ inline TRowVersion TTableIterBase<TIteratorOps>::GetRowVersion() const noexcept
 }
 
 template<class TIteratorOps>
-inline EReady TTableIterBase<TIteratorOps>::SkipToRowVersion(TRowVersion rowVersion) noexcept
+inline EReady TTableIterBase<TIteratorOps>::SkipToRowVersion(TRowVersion rowVersion)
 {
     // Must only be called after successful Apply()
     Y_DEBUG_ABORT_UNLESS(Stage == EStage::Done && Ready != EReady::Gone);
@@ -789,7 +789,7 @@ inline EReady TTableIterBase<TIteratorOps>::SkipToRowVersion(TRowVersion rowVers
 }
 
 template<class TIteratorOps>
-inline EReady TTableIterBase<TIteratorOps>::Snap() noexcept
+inline EReady TTableIterBase<TIteratorOps>::Snap()
 {
     Y_DEBUG_ABORT_UNLESS(Active != Inactive);
 
@@ -810,7 +810,7 @@ inline EReady TTableIterBase<TIteratorOps>::Snap() noexcept
 }
 
 template<class TIteratorOps>
-inline EReady TTableIterBase<TIteratorOps>::Snap(TRowVersion rowVersion) noexcept
+inline EReady TTableIterBase<TIteratorOps>::Snap(TRowVersion rowVersion)
 {
     for (auto i = TReverseIter(Inactive), e = TReverseIter(Active); i != e; ++i) {
         TIteratorId ai = i->IteratorId;
@@ -846,7 +846,7 @@ inline EReady TTableIterBase<TIteratorOps>::Snap(TRowVersion rowVersion) noexcep
 }
 
 template<class TIteratorOps>
-inline EReady TTableIterBase<TIteratorOps>::DoSkipUncommitted() noexcept
+inline EReady TTableIterBase<TIteratorOps>::DoSkipUncommitted()
 {
     Y_DEBUG_ABORT_UNLESS(Delta && Uncommitted);
 
@@ -889,7 +889,7 @@ inline EReady TTableIterBase<TIteratorOps>::DoSkipUncommitted() noexcept
 }
 
 template<class TIteratorOps>
-inline EReady TTableIterBase<TIteratorOps>::Apply() noexcept
+inline EReady TTableIterBase<TIteratorOps>::Apply()
 {
     State.Reset(Remap.CellDefaults());
 
@@ -962,7 +962,7 @@ inline EReady TTableIterBase<TIteratorOps>::Apply() noexcept
 }
 
 template<class TIteratorOps>
-inline void TTableIterBase<TIteratorOps>::InitLastKey(ERowOp op) noexcept
+inline void TTableIterBase<TIteratorOps>::InitLastKey(ERowOp op)
 {
     TArrayRef<const TCell> key = Iterators.back().Key;
 
@@ -1006,7 +1006,7 @@ inline TDbTupleRef TTableIterBase<TIteratorOps>::GetValues() const noexcept
 }
 
 template<class TIteratorOps>
-inline bool TTableIterBase<TIteratorOps>::SeekInternal(TArrayRef<const TCell> key, ESeek seek) noexcept
+inline bool TTableIterBase<TIteratorOps>::SeekInternal(TArrayRef<const TCell> key, ESeek seek)
 {
     Stage = EStage::Seek;
 

--- a/ydb/core/tablet_flat/flat_iterator_ops.h
+++ b/ydb/core/tablet_flat/flat_iterator_ops.h
@@ -11,7 +11,7 @@ struct TTableIterOps {
     static inline int CompareKeys(
             TArrayRef<const NScheme::TTypeInfoOrder> types,
             TArrayRef<const TCell> a,
-            TArrayRef<const TCell> b) noexcept
+            TArrayRef<const TCell> b)
     {
         if (int cmp = CompareTypedCellVectors(a.data(), b.data(), types.data(), Min(a.size(), b.size()))) {
             return cmp;
@@ -160,7 +160,7 @@ struct TTableItReverseOps {
     static int CompareKeys(
             TArrayRef<const NScheme::TTypeInfoOrder> types,
             TArrayRef<const TCell> a,
-            TArrayRef<const TCell> b) noexcept
+            TArrayRef<const TCell> b)
     {
         return -TTableIterOps::CompareKeys(types, a, b);
     }

--- a/ydb/core/tablet_flat/flat_mem_blobs.h
+++ b/ydb/core/tablet_flat/flat_mem_blobs.h
@@ -45,19 +45,19 @@ namespace NMem {
             return Store[index];
         }
 
-        const NPageCollection::TMemGlob& Get(ui64 ref) const noexcept
+        const NPageCollection::TMemGlob& Get(ui64 ref) const
         {
             Y_ABORT_UNLESS(ref >= Head && ref < Tail(), "ELargeObj ref is out of cache");
 
             return Store[ref - Head];
         }
 
-        ui64 Push(const NPageCollection::TMemGlob &glob) noexcept
+        ui64 Push(const NPageCollection::TMemGlob &glob)
         {
             return Push(glob.GId, glob.Data);
         }
 
-        ui64 Push(const NPageCollection::TGlobId& glob, TSharedData data) noexcept
+        ui64 Push(const NPageCollection::TGlobId& glob, TSharedData data)
         {
             Y_ABORT_UNLESS(glob.Logo.BlobSize(), "Blob cannot have zero bytes");
 
@@ -69,7 +69,7 @@ namespace NMem {
             return ref;
         }
 
-        void Assign(TArrayRef<NPageCollection::TLoadedPage> pages) noexcept
+        void Assign(TArrayRef<NPageCollection::TLoadedPage> pages)
         {
             for (auto &one : pages) {
                 Y_ABORT_UNLESS(one.PageId < Store.size());
@@ -78,7 +78,7 @@ namespace NMem {
             }
         }
 
-        void Commit(size_t count, TArrayRef<const NPageCollection::TMemGlob> pages) noexcept
+        void Commit(size_t count, TArrayRef<const NPageCollection::TMemGlob> pages)
         {
             if (count > 0) {
                 size_t currentSize = Store.size();
@@ -93,7 +93,7 @@ namespace NMem {
             }
         }
 
-        void Rollback(size_t count) noexcept
+        void Rollback(size_t count)
         {
             if (count > 0) {
                 size_t currentSize = Store.size();

--- a/ydb/core/tablet_flat/flat_mem_iter.h
+++ b/ydb/core/tablet_flat/flat_mem_iter.h
@@ -44,7 +44,7 @@ namespace NTable {
                 TIntrusiveConstPtr<TKeyCellDefaults> keyDefaults,
                 const TRemap *remap,
                 IPages *env,
-                EDirection direction = EDirection::Forward) noexcept
+                EDirection direction = EDirection::Forward)
         {
             auto *iter = new TMemIter(&memTable, std::move(keyDefaults), remap, env, snapshot.Iterator());
 
@@ -60,7 +60,7 @@ namespace NTable {
             return iter;
         }
 
-        void Seek(TCells key, ESeek seek) noexcept
+        void Seek(TCells key, ESeek seek)
         {
             Key.clear();
             CurrentVersion = nullptr;
@@ -92,7 +92,7 @@ namespace NTable {
             }
         }
 
-        void SeekReverse(TCells key, ESeek seek) noexcept
+        void SeekReverse(TCells key, ESeek seek)
         {
             Key.clear();
             CurrentVersion = nullptr;
@@ -141,7 +141,7 @@ namespace NTable {
             return { KeyCellDefaults->BasicTypes().begin(), Key.begin(), ui32(Key.size()) };
         }
 
-        bool IsDelta() const noexcept
+        bool IsDelta() const
         {
             auto* update = GetCurrentVersion();
             Y_ABORT_UNLESS(update);
@@ -149,7 +149,7 @@ namespace NTable {
             return update->RowVersion.Step == Max<ui64>();
         }
 
-        ui64 GetDeltaTxId() const noexcept
+        ui64 GetDeltaTxId() const
         {
             auto* update = GetCurrentVersion();
             Y_ABORT_UNLESS(update);
@@ -158,7 +158,7 @@ namespace NTable {
             return update->RowVersion.TxId;
         }
 
-        void ApplyDelta(TRowState& row) const noexcept
+        void ApplyDelta(TRowState& row) const
         {
             Y_ABORT_UNLESS(row.Size() == Remap->Size(), "row state doesn't match the remap index");
 
@@ -173,7 +173,7 @@ namespace NTable {
             }
         }
 
-        bool SkipDelta() noexcept
+        bool SkipDelta()
         {
             auto* update = GetCurrentVersion();
             Y_ABORT_UNLESS(update);
@@ -185,7 +185,7 @@ namespace NTable {
 
         void Apply(TRowState& row,
                    NTable::ITransactionMapSimplePtr committedTransactions,
-                   NTable::ITransactionObserverSimplePtr transactionObserver) const noexcept
+                   NTable::ITransactionObserverSimplePtr transactionObserver) const
         {
             Y_ABORT_UNLESS(row.Size() == Remap->Size(), "row state doesn't match the remap index");
 
@@ -224,7 +224,7 @@ namespace NTable {
         /**
          * Returns row version at which current row state materialized
          */
-        TRowVersion GetRowVersion() const noexcept
+        TRowVersion GetRowVersion() const
         {
             auto* update = GetCurrentVersion();
             Y_ABORT_UNLESS(update);
@@ -241,7 +241,7 @@ namespace NTable {
         bool SkipToRowVersion(TRowVersion rowVersion, TIteratorStats& stats,
                               NTable::ITransactionMapSimplePtr committedTransactions,
                               NTable::ITransactionObserverSimplePtr transactionObserver,
-                              const NTable::ITransactionSet& decidedTransactions) noexcept
+                              const NTable::ITransactionSet& decidedTransactions)
         {
             // Temporary: we don't cache erases when there are uncompacted deltas
             Y_UNUSED(decidedTransactions);
@@ -329,7 +329,7 @@ namespace NTable {
          */
         std::optional<TRowVersion> SkipToCommitted(
                 NTable::ITransactionMapSimplePtr committedTransactions,
-                NTable::ITransactionObserverSimplePtr transactionObserver) noexcept
+                NTable::ITransactionObserverSimplePtr transactionObserver)
         {
             Y_DEBUG_ABORT_UNLESS(IsValid(), "Attempt to access an invalid row");
 
@@ -379,7 +379,7 @@ namespace NTable {
         }
 
     private:
-        void ApplyColumn(TRowState& row, const NMem::TColumnUpdate &up) const noexcept
+        void ApplyColumn(TRowState& row, const NMem::TColumnUpdate &up) const
         {
             const auto pos = Remap->Has(up.Tag);
             auto op = up.Op;
@@ -407,7 +407,7 @@ namespace NTable {
             }
         }
 
-        const NMem::TUpdate* GetCurrentVersion() const noexcept
+        const NMem::TUpdate* GetCurrentVersion() const
         {
             Y_DEBUG_ABORT_UNLESS(IsValid(), "Attempt to access an invalid row");
 

--- a/ydb/core/tablet_flat/flat_mem_warm.h
+++ b/ydb/core/tablet_flat/flat_mem_warm.h
@@ -514,7 +514,7 @@ namespace NMem {
         }
 
     private:
-        NMem::TTreeKey NewKey(const TCell* src) noexcept {
+        NMem::TTreeKey NewKey(const TCell* src) {
             const size_t items = Scheme->Keys->Size();
             const size_t bytes = sizeof(TCell) * items;
 
@@ -529,14 +529,14 @@ namespace NMem {
             return NMem::TTreeKey(key);
         }
 
-        NMem::TUpdate* NewUpdate(ui32 cols) noexcept
+        NMem::TUpdate* NewUpdate(ui32 cols)
         {
             const size_t bytes = sizeof(NMem::TUpdate) + cols * sizeof(NMem::TColumnUpdate);
 
             return (NMem::TUpdate*)Pool.Allocate(bytes);
         }
 
-        TCell Clone(const char *data, ui32 size) noexcept
+        TCell Clone(const char *data, ui32 size)
         {
             const bool small = TCell::CanInline(size);
 

--- a/ydb/core/tablet_flat/flat_ops_compact.h
+++ b/ydb/core/tablet_flat/flat_ops_compact.h
@@ -82,7 +82,7 @@ namespace NTabletFlatExecutor {
             // Y_ABORT_UNLESS(!Driver, "TOpsCompact is still running under scan");
         }
 
-        void Describe(IOutputStream &out) const noexcept override
+        void Describe(IOutputStream &out) const override
         {
             out
                 << "Compact{" << Mask.TabletID()
@@ -98,7 +98,7 @@ namespace NTabletFlatExecutor {
             Logger = new NUtil::TLogger(sys, NKikimrServices::OPS_COMPACT);
         }
 
-        TInitialState Prepare(IDriver *driver, TIntrusiveConstPtr<TScheme> scheme) noexcept override
+        TInitialState Prepare(IDriver *driver, TIntrusiveConstPtr<TScheme> scheme) override
         {
             TActivationContext::AsActorContext().RegisterWithSameMailbox(this);
 
@@ -116,7 +116,7 @@ namespace NTabletFlatExecutor {
             return { EScan::Feed, conf };
         }
 
-        EScan Seek(TLead &lead, ui64 seq) noexcept override
+        EScan Seek(TLead &lead, ui64 seq) override
         {
             if (seq == 0) /* on first Seek() init compaction */ {
                 Y_ABORT_UNLESS(!Writer, "Initial IScan::Seek(...) called twice");
@@ -146,7 +146,7 @@ namespace NTabletFlatExecutor {
             }
         }
 
-        EScan BeginKey(TArrayRef<const TCell> key) noexcept override
+        EScan BeginKey(TArrayRef<const TCell> key) override
         {
             Writer->BeginKey(key);
 
@@ -160,7 +160,7 @@ namespace NTabletFlatExecutor {
             return Flush(false /* intermediate, sleep or feed */);
         }
 
-        EScan BeginDeltas() noexcept override
+        EScan BeginDeltas() override
         {
             if (auto logl = Logger->Log(ELnLev::Dbg03)) {
                 logl << NFmt::Do(*this) << " begin deltas";
@@ -169,7 +169,7 @@ namespace NTabletFlatExecutor {
             return Flush(false /* intermediate, sleep or feed */);
         }
 
-        EScan Feed(const TRow &row, ui64 txId) noexcept override
+        EScan Feed(const TRow &row, ui64 txId) override
         {
             if (auto logl = Logger->Log(ELnLev::Dbg03)) {
                 logl << NFmt::Do(*this) << " feed row { ";
@@ -194,7 +194,7 @@ namespace NTabletFlatExecutor {
             return Flush(false /* intermediate, sleep or feed */);
         }
 
-        EScan EndDeltas() noexcept override
+        EScan EndDeltas() override
         {
             if (auto logl = Logger->Log(ELnLev::Dbg03)) {
                 logl << NFmt::Do(*this) << " end deltas";
@@ -218,7 +218,7 @@ namespace NTabletFlatExecutor {
             return Flush(false /* intermediate, sleep or feed */);
         }
 
-        EScan Feed(const TRow &row, TRowVersion &rowVersion) noexcept override
+        EScan Feed(const TRow &row, TRowVersion &rowVersion) override
         {
             if (Conf->RemovedRowVersions) {
                 // Adjust rowVersion so removed versions become compacted
@@ -242,7 +242,7 @@ namespace NTabletFlatExecutor {
             return Flush(false /* intermediate, sleep or feed */);
         }
 
-        EScan EndKey() noexcept override
+        EScan EndKey() override
         {
             ui32 written = Writer->EndKey();
 
@@ -253,7 +253,7 @@ namespace NTabletFlatExecutor {
             return Flush(false /* intermediate, sleep or feed */);
         }
 
-        void WriteTxStatus() noexcept
+        void WriteTxStatus()
         {
             if (!Conf->Frozen && !Conf->TxStatus) {
                 // Nothing to compact
@@ -325,7 +325,7 @@ namespace NTabletFlatExecutor {
             TxStatus.emplace_back(new NTable::TTxStatusPartStore(dataId, Conf->Epoch, data));
         }
 
-        TAutoPtr<IDestructable> Finish(EAbort abort) noexcept override
+        TAutoPtr<IDestructable> Finish(EAbort abort) override
         {
             const auto fail = Failed || !Finished || abort != EAbort::None;
 
@@ -441,7 +441,7 @@ namespace NTabletFlatExecutor {
             return prod;
         }
 
-        EScan Flush(bool last) noexcept
+        EScan Flush(bool last)
         {
             for (NPageCollection::TGlob& one : Bundle->GetBlobsToSave())
                 FlushToBs(std::move(one));
@@ -476,7 +476,7 @@ namespace NTabletFlatExecutor {
             }
         }
 
-        void Handle(TEvPutResult &msg) noexcept
+        void Handle(TEvPutResult &msg)
         {
             if (!NPageCollection::TGroupBlobsByCookie::IsInPlane(msg.Id, Mask)) {
                 Y_ABORT("TEvPutResult Id mask is differ from used");
@@ -538,7 +538,7 @@ namespace NTabletFlatExecutor {
             }
         }
 
-        void FlushToBs(NPageCollection::TGlob&& glob) noexcept
+        void FlushToBs(NPageCollection::TGlob&& glob)
         {
             Y_ABORT_UNLESS(glob.GId.Logo.BlobSize() == glob.Data.size(),
                 "Written LogoBlob size doesn't match id");
@@ -554,7 +554,7 @@ namespace NTabletFlatExecutor {
             }
         }
 
-        void SendToBs(NPageCollection::TGlob&& glob) noexcept
+        void SendToBs(NPageCollection::TGlob&& glob)
         {
             auto id = glob.GId;
 

--- a/ydb/core/tablet_flat/flat_page_base.h
+++ b/ydb/core/tablet_flat/flat_page_base.h
@@ -280,17 +280,17 @@ struct TCompare {
         Y_ABORT_UNLESS(KeyCellDefaults->size() >= Info.size());
     }
 
-    bool operator()(const TRecord &record, TCells key) const noexcept
+    bool operator()(const TRecord &record, TCells key) const
     {
         return Compare(record, key) < 0;
     }
 
-    bool operator()(TCells key, const TRecord &record) const noexcept
+    bool operator()(TCells key, const TRecord &record) const
     {
         return Compare(record, key) > 0;
     }
 
-    int Compare(const TRecord &rec, const TCells key) const noexcept
+    int Compare(const TRecord &rec, const TCells key) const
     {
         for (TPos it = 0; it < Min(key.size(), KeyCellDefaults->size()); it++) {
             const TCell left = it < Info.size() ? rec.Cell(Info[it]) : KeyCellDefaults[it];

--- a/ydb/core/tablet_flat/flat_page_bloom.h
+++ b/ydb/core/tablet_flat/flat_page_bloom.h
@@ -58,7 +58,7 @@ namespace NPage {
             return { Items, Hashes };
         }
 
-        bool MightHave(TArrayRef<const char> raw) const noexcept
+        bool MightHave(TArrayRef<const char> raw) const
         {
             NBloom::THash hash(raw);
 

--- a/ydb/core/tablet_flat/flat_page_btree_index.h
+++ b/ydb/core/tablet_flat/flat_page_btree_index.h
@@ -142,7 +142,7 @@ namespace NKikimr::NTable::NPage {
                 return DataSize_ + GroupDataSize_;
             }
 
-            TString ToString() const noexcept {
+            TString ToString() const {
                 TStringBuilder result;
                 result << "PageId: " << GetPageId() << " RowCount: " << GetRowCount() << " DataSize: " << GetDataSize();
                 if (GetGroupDataSize()) {
@@ -226,7 +226,7 @@ namespace NKikimr::NTable::NPage {
                 return Next();
             }
 
-            int CompareTo(const TCells key, const TKeyCellDefaults *keyDefaults) noexcept
+            int CompareTo(const TCells key, const TKeyCellDefaults *keyDefaults)
             {
                 Y_ABORT_UNLESS(Pos == 0, "Shouldn't be used");
 
@@ -272,7 +272,7 @@ namespace NKikimr::NTable::NPage {
                 return {IsNullBitmap, Columns, Ptr};
             }
 
-            int CompareTo(const TCells key, const TKeyCellDefaults *keyDefaults) const noexcept
+            int CompareTo(const TCells key, const TKeyCellDefaults *keyDefaults) const
             {
                 return Iter().CompareTo(key, keyDefaults);
             }
@@ -364,13 +364,13 @@ namespace NKikimr::NTable::NPage {
             return *GetShortChildRef(pos);
         }
 
-        const TChild* GetChildRef(TRecIdx pos) const noexcept
+        const TChild* GetChildRef(TRecIdx pos) const
         {
             Y_DEBUG_ABORT_UNLESS(!Header->IsShortChildFormat, "GetShortChildRef should be used instead");
             return TDeref<const TChild>::At(Children, pos * sizeof(TChild));
         }
 
-        const TChild& GetChild(TRecIdx pos) const noexcept
+        const TChild& GetChild(TRecIdx pos) const
         {
             return *GetChildRef(pos);
         }
@@ -379,7 +379,7 @@ namespace NKikimr::NTable::NPage {
             return beginRowId <= rowId && rowId < endRowId;
         }
 
-        TRecIdx Seek(TRowId rowId, std::optional<TRecIdx> on = { }) const noexcept
+        TRecIdx Seek(TRowId rowId, std::optional<TRecIdx> on = { }) const
         {
             const TRecIdx childrenCount = GetChildrenCount();
             if (on && on >= childrenCount) {
@@ -431,7 +431,7 @@ namespace NKikimr::NTable::NPage {
             return result;
         }
 
-        static bool Has(ESeek seek, TCells key, TCellsIterable beginKey, TCellsIterable endKey, const TKeyCellDefaults *keyDefaults) noexcept
+        static bool Has(ESeek seek, TCells key, TCellsIterable beginKey, TCellsIterable endKey, const TKeyCellDefaults *keyDefaults)
         {
             Y_ABORT_UNLESS(key);
             Y_UNUSED(seek);
@@ -445,7 +445,7 @@ namespace NKikimr::NTable::NPage {
         *
         * Result is approximate and may be off by one page
         */
-        TRecIdx Seek(ESeek seek, TCells key, TColumns columns, const TKeyCellDefaults *keyDefaults) const noexcept
+        TRecIdx Seek(ESeek seek, TCells key, TColumns columns, const TKeyCellDefaults *keyDefaults) const
         {
             Y_ABORT_UNLESS(key);
             Y_UNUSED(seek);
@@ -461,7 +461,7 @@ namespace NKikimr::NTable::NPage {
             return *std::upper_bound(range.begin(), range.end(), key, cmp);
         }
 
-        static bool HasReverse(ESeek seek, TCells key, TCellsIterable beginKey, TCellsIterable endKey, const TKeyCellDefaults *keyDefaults) noexcept
+        static bool HasReverse(ESeek seek, TCells key, TCellsIterable beginKey, TCellsIterable endKey, const TKeyCellDefaults *keyDefaults)
         {
             Y_ABORT_UNLESS(key);
 
@@ -476,7 +476,7 @@ namespace NKikimr::NTable::NPage {
         *
         * Result is approximate and may be off by one page
         */
-        TRecIdx SeekReverse(ESeek seek, TCells key, TColumns columns, const TKeyCellDefaults *keyDefaults) const noexcept
+        TRecIdx SeekReverse(ESeek seek, TCells key, TColumns columns, const TKeyCellDefaults *keyDefaults) const
         {
             Y_ABORT_UNLESS(key);
 
@@ -507,7 +507,7 @@ namespace NKikimr::NTable::NPage {
 
     private:
         template <typename TCellsType>
-        TCellsType GetCells(TRecIdx pos, TColumns columns) const noexcept
+        TCellsType GetCells(TRecIdx pos, TColumns columns) const
         {
             if (IsFixedFormat()) {
                 const char* ptr = TDeref<const char>::At(Keys, pos * Header->FixedKeySize);
@@ -532,7 +532,7 @@ namespace NKikimr::NTable::NPage {
 
         auto operator<=>(const TBtreeIndexMeta&) const = default;
 
-        TString ToString() const noexcept
+        TString ToString() const
         {
             return TStringBuilder() << TBtreeIndexNode::TChild::ToString() << " LevelCount: " << LevelCount << " IndexSize: " << IndexSize;
         }

--- a/ydb/core/tablet_flat/flat_page_btree_index_writer.h
+++ b/ydb/core/tablet_flat/flat_page_btree_index_writer.h
@@ -241,12 +241,12 @@ namespace NKikimr::NTable::NPage {
             }
         }
 
-        void PlaceBytes(TString&& data) noexcept
+        void PlaceBytes(TString&& data)
         {
             std::copy(data.data(), data.data() + data.size(), Advance(data.size()));
         }
 
-        void PlaceChild(const TChild& child) noexcept
+        void PlaceChild(const TChild& child)
         {
             if (IsShortChildFormat()) {
                 Y_DEBUG_ABORT_UNLESS(child.GetGroupDataSize() == 0);
@@ -258,18 +258,18 @@ namespace NKikimr::NTable::NPage {
         }
 
         template<typename T>
-        T& Place() noexcept
+        T& Place()
         {
             return *reinterpret_cast<T*>(Advance(TPgSizeOf<T>::Value));
         }
 
-        void Zero(size_t size) noexcept
+        void Zero(size_t size)
         {
             auto *from = Advance(size);
             std::fill(from, Ptr, 0);
         }
 
-        char* Advance(size_t size) noexcept
+        char* Advance(size_t size)
         {
             auto newPtr = Ptr + size;
             Y_ABORT_UNLESS(newPtr <= End);

--- a/ydb/core/tablet_flat/flat_page_conf.h
+++ b/ydb/core/tablet_flat/flat_page_conf.h
@@ -21,14 +21,14 @@ namespace NPage {
         /**
          * Resets this instance back to the beginning
          */
-        virtual void Reset() noexcept = 0;
+        virtual void Reset() = 0;
 
         /**
          * Returns true if the specified key intersects with the key space
          *
          * NOTE: consecutive calls to HasKey must be in an increasing key order
          */
-        virtual bool HasKey(TCellsRef key) noexcept = 0;
+        virtual bool HasKey(TCellsRef key) = 0;
     };
 
     /**
@@ -41,14 +41,14 @@ namespace NPage {
         /**
          * Resets this instance back to the beginning
          */
-        virtual void Reset() noexcept = 0;
+        virtual void Reset() = 0;
 
         /**
          * Returns true if key crosses a split boundary
          *
          * NOTE: consecutive calls to ShouldSplit must be in an increasing key order
          */
-        virtual bool ShouldSplit(TCellsRef key) noexcept = 0;
+        virtual bool ShouldSplit(TCellsRef key) = 0;
     };
 
     /**

--- a/ydb/core/tablet_flat/flat_page_data.h
+++ b/ydb/core/tablet_flat/flat_page_data.h
@@ -114,12 +114,12 @@ namespace NPage {
             // N.B. Get Min/Max version and GetDeltaTxId below read from the same record position
             // right after column entries. Up to caller to decide what kind of data is there
 
-            TRowVersion GetMaxVersion(const TPartScheme::TGroupInfo& group) const noexcept {
+            TRowVersion GetMaxVersion(const TPartScheme::TGroupInfo& group) const {
                 Y_DEBUG_ABORT_UNLESS(IsErased());
                 return GetTail<TVersion>(group)->Get();
             }
 
-            TRowVersion GetMinVersion(const TPartScheme::TGroupInfo& group) const noexcept {
+            TRowVersion GetMinVersion(const TPartScheme::TGroupInfo& group) const {
                 Y_DEBUG_ABORT_UNLESS(IsVersioned());
                 auto* v = GetTail<TVersion>(group);
                 if (IsErased()) {
@@ -128,12 +128,12 @@ namespace NPage {
                 return v->Get();
             }
 
-            ui64 GetDeltaTxId(const TPartScheme::TGroupInfo& group) const noexcept {
+            ui64 GetDeltaTxId(const TPartScheme::TGroupInfo& group) const {
                 Y_DEBUG_ABORT_UNLESS(IsDelta());
                 return GetTail<TDelta>(group)->GetTxId();
             }
 
-            const TRecord* GetAltRecord(size_t index) const noexcept {
+            const TRecord* GetAltRecord(size_t index) const {
                 if (index == 0) {
                     return this;
                 }
@@ -170,7 +170,7 @@ namespace NPage {
     public:
         using TIter = TBlock::TIterator;
 
-        TDataPage(const TSharedData *raw = nullptr) noexcept
+        TDataPage(const TSharedData *raw = nullptr)
         {
             Set(raw);
         }
@@ -195,7 +195,7 @@ namespace NPage {
             return BaseRow_;
         }
 
-        TDataPage& Set(const TSharedData *raw = nullptr) noexcept
+        TDataPage& Set(const TSharedData *raw = nullptr)
         {
             Page = { };
 
@@ -250,7 +250,7 @@ namespace NPage {
         }
 
         TIter LookupKey(TCells key, const TPartScheme::TGroupInfo &group,
-                        ESeek seek, const TKeyCellDefaults *keyDefaults) const noexcept
+                        ESeek seek, const TKeyCellDefaults *keyDefaults) const
         {
             if (!key) {
                 switch (seek) {
@@ -287,7 +287,7 @@ namespace NPage {
         }
 
         TIter LookupKeyReverse(TCells key, const TPartScheme::TGroupInfo &group,
-                        ESeek seek, const TKeyCellDefaults *keyDefaults) const noexcept
+                        ESeek seek, const TKeyCellDefaults *keyDefaults) const
         {
             if (!key) {
                 switch (seek) {

--- a/ydb/core/tablet_flat/flat_page_flat_index.h
+++ b/ydb/core/tablet_flat/flat_page_flat_index.h
@@ -150,7 +150,7 @@ namespace NPage {
          */
         TIter LookupKey(
                 TCells key, const TPartScheme::TGroupInfo &group,
-                const ESeek seek, const TKeyCellDefaults *keyDefaults) const noexcept
+                const ESeek seek, const TKeyCellDefaults *keyDefaults) const
         {
             if (!key) {
                 // Special treatment for an empty key
@@ -194,7 +194,7 @@ namespace NPage {
          */
         TIter LookupKeyReverse(
                 TCells key, const TPartScheme::TGroupInfo &group,
-                const ESeek seek, const TKeyCellDefaults *keyDefaults) const noexcept
+                const ESeek seek, const TKeyCellDefaults *keyDefaults) const
         {
             if (!key) {
                 // Special treatment for an empty key

--- a/ydb/core/tablet_flat/flat_page_frames.h
+++ b/ydb/core/tablet_flat/flat_page_frames.h
@@ -37,7 +37,7 @@ namespace NPage {
                 return Refer < 0;
             }
 
-            ui32 AbsRef(const ui32 page) const noexcept
+            ui32 AbsRef(const ui32 page) const
             {
                 Y_ABORT_UNLESS(Refer < 0 || page >= ui32(Refer));
 
@@ -106,7 +106,7 @@ namespace NPage {
             return page < +Records.size() ? Records[page] : End;
         }
 
-        ui32 Lower(ui64 row, ui32 begin, ui32 end) const noexcept
+        ui32 Lower(ui64 row, ui32 begin, ui32 end) const
         {
             begin = Min(begin, Stats_.Items);
             end = Min(end, Stats_.Items);

--- a/ydb/core/tablet_flat/flat_page_gstat.h
+++ b/ydb/core/tablet_flat/flat_page_gstat.h
@@ -270,7 +270,7 @@ namespace NPage {
         TGarbageStatsAgg& operator=(TGarbageStatsAgg&&) noexcept = default;
 
     private:
-        TGarbageStatsAgg(TVector<TItem>&& items)
+        TGarbageStatsAgg(TVector<TItem>&& items) noexcept
             : Items(std::move(items))
         { }
 

--- a/ydb/core/tablet_flat/flat_page_label.cpp
+++ b/ydb/core/tablet_flat/flat_page_label.cpp
@@ -8,7 +8,7 @@ namespace NKikimr {
 namespace NTable {
 namespace NPage {
 
-    TLabelWrapper::TResult TLabelWrapper::Read(TArrayRef<const char> raw, EPage type) const noexcept
+    TLabelWrapper::TResult TLabelWrapper::Read(TArrayRef<const char> raw, EPage type) const
     {
         Y_ABORT_UNLESS(raw.size() >= sizeof(TLabel), "Page blob is too small to hold label");
 
@@ -45,7 +45,7 @@ namespace NPage {
         return { label.Type, version, codec, { begin, raw.end() } };
     }
 
-    TSharedData TLabelWrapper::Wrap(TArrayRef<const char> plain, EPage page, ui16 version) noexcept
+    TSharedData TLabelWrapper::Wrap(TArrayRef<const char> plain, EPage page, ui16 version)
     {
         Y_ABORT_UNLESS(!(version >> 15), "Version can use only 15 bits");
 
@@ -60,7 +60,7 @@ namespace NPage {
         return blob;
     }
 
-    TString TLabelWrapper::WrapString(TArrayRef<const char> plain, EPage page, ui16 version) noexcept
+    TString TLabelWrapper::WrapString(TArrayRef<const char> plain, EPage page, ui16 version)
     {
         Y_ABORT_UNLESS(!(version >> 15), "Version can use only 15 bits");
 

--- a/ydb/core/tablet_flat/flat_page_label.h
+++ b/ydb/core/tablet_flat/flat_page_label.h
@@ -88,9 +88,9 @@ namespace NPage {
             TArrayRef<const char> Page;
         };
 
-        TResult Read(TArrayRef<const char>, EPage type = EPage::Undef) const noexcept;
-        static TSharedData Wrap(TArrayRef<const char>, EPage, ui16 version) noexcept;
-        static TString WrapString(TArrayRef<const char>, EPage, ui16 version) noexcept;
+        TResult Read(TArrayRef<const char>, EPage type = EPage::Undef) const;
+        static TSharedData Wrap(TArrayRef<const char>, EPage, ui16 version);
+        static TString WrapString(TArrayRef<const char>, EPage, ui16 version);
     };
 
 }

--- a/ydb/core/tablet_flat/flat_page_other.h
+++ b/ydb/core/tablet_flat/flat_page_other.h
@@ -31,7 +31,7 @@ namespace NPage {
             Y_ABORT_UNLESS(tags <= ui32(-Min<i16>()), "Too many column tags");
         }
 
-        void Put(TRowId row, ui16 tag, ui32 bytes) noexcept
+        void Put(TRowId row, ui16 tag, ui32 bytes)
         {
             if (row < Last && Last != Max<TRowId>()) {
                 Y_ABORT("Frame items have to follow sorted by row");
@@ -47,12 +47,12 @@ namespace NPage {
             Cook.emplace_back(TFresh{ tag, bytes });
         }
 
-        void FlushRow() noexcept
+        void FlushRow()
         {
             Flush();
         }
 
-        TSharedData Make() noexcept
+        TSharedData Make()
         {
             Flush();
 
@@ -70,7 +70,7 @@ namespace NPage {
             return 0;
         }
 
-        void Reset() noexcept
+        void Reset()
         {
             Last = Max<TRowId>();
             Rows = 0;
@@ -81,7 +81,7 @@ namespace NPage {
         }
 
     private:
-        TSharedData MakeAnyway() noexcept
+        TSharedData MakeAnyway()
         {
             auto size = sizeof(NPage::TLabel) + sizeof(THeader)
                             + NUtil::NBin::SizeOf(Tags, Array);
@@ -110,7 +110,7 @@ namespace NPage {
             return buf;
         }
 
-        void Flush() noexcept
+        void Flush()
         {
             for (auto it: xrange(Cook.size())) {
                 const i16 ref = it ? i16(it) : -i16(Cook.size());
@@ -137,14 +137,14 @@ namespace NPage {
         using TEntry = TExtBlobs::TEntry;
 
     public:
-        ui32 Put(const NPageCollection::TGlobId &glob) noexcept
+        ui32 Put(const NPageCollection::TGlobId &glob)
         {
             Bytes += glob.Logo.BlobSize();
             Globs.emplace_back(glob);
             return Globs.size() - 1;
         }
 
-        TSharedData Make(bool force = false) const noexcept
+        TSharedData Make(bool force = false) const
         {
             return (Globs  || force) ? MakeAnyway() : TSharedData{ };
         }
@@ -164,13 +164,13 @@ namespace NPage {
             return 0;
         }
 
-        void Reset() noexcept
+        void Reset()
         {
             Globs.clear();
         }
 
     private:
-        TSharedData MakeAnyway() const noexcept
+        TSharedData MakeAnyway() const
         {
             auto size = sizeof(NPage::TLabel) + sizeof(THeader)
                             + NUtil::NBin::SizeOf(Globs);

--- a/ydb/core/tablet_flat/flat_page_txidstat.h
+++ b/ydb/core/tablet_flat/flat_page_txidstat.h
@@ -90,7 +90,7 @@ namespace NPage {
             return !Stats.empty();
         }
 
-        TSharedData Finish() const noexcept {
+        TSharedData Finish() const {
             if (Stats.empty()) {
                 return { };
             }

--- a/ydb/core/tablet_flat/flat_page_txstatus.h
+++ b/ydb/core/tablet_flat/flat_page_txstatus.h
@@ -131,7 +131,7 @@ namespace NPage {
             }
         }
 
-        TSharedData Finish() noexcept {
+        TSharedData Finish() {
             if (CommittedItems.empty() && RemovedItems.empty()) {
                 return { };
             }

--- a/ydb/core/tablet_flat/flat_page_writer.h
+++ b/ydb/core/tablet_flat/flat_page_writer.h
@@ -34,14 +34,14 @@ namespace NPage {
         }
 
         template<typename T>
-        T* ExtraAs() noexcept
+        T* ExtraAs()
         {
             Y_ABORT_UNLESS(sizeof(T) == Extra, "Cannot cast extra block to T");
 
             return TDeref<T>::At(Blob.mutable_data(), Prefix - Extra);
         }
 
-        void Grow(size_t more, size_t least, float factor) noexcept
+        void Grow(size_t more, size_t least, float factor)
         {
             if (Blob) {
                 size_t desired = BytesUsed() + more;
@@ -55,7 +55,7 @@ namespace NPage {
             }
         }
 
-        void Open(size_t more, size_t least, ui32 rows = 0) noexcept
+        void Open(size_t more, size_t least, ui32 rows = 0)
         {
             Y_ABORT_UNLESS(!Blob, "TDataPageBuilder is already has live page");
 
@@ -64,12 +64,12 @@ namespace NPage {
             Resize(PageBytes);
         }
 
-        bool Overflow(size_t more, ui32 rows) const noexcept
+        bool Overflow(size_t more, ui32 rows) const
         {
             return Blob && Deltas.empty() && ((BytesUsed() + more) > PageBytes || (Offsets.size() + rows > PageRows));
         }
 
-        TSharedData Close() noexcept
+        TSharedData Close()
         {
             Y_ABORT_UNLESS(Deltas.empty());
 
@@ -107,7 +107,7 @@ namespace NPage {
             return Reset();
         }
 
-        TSharedData Reset() noexcept
+        TSharedData Reset()
         {
             Tail = nullptr;
             Deltas.clear();
@@ -137,7 +137,7 @@ namespace NPage {
             return Tail ? (Blob.size() - BytesUsed()) : 0;
         }
 
-        void Zero(size_t size) noexcept
+        void Zero(size_t size)
         {
             auto *from = Advance(size);
             std::fill(from, Tail, 0);
@@ -154,7 +154,7 @@ namespace NPage {
             return !Deltas.empty();
         }
 
-        void PushDelta(TPgSize recordSize) noexcept
+        void PushDelta(TPgSize recordSize)
         {
             Y_DEBUG_ABORT_UNLESS(recordSize > 0);
 
@@ -170,7 +170,7 @@ namespace NPage {
             Deltas.push_back(offset);
         }
 
-        void PushOffset(TPgSize recordSize) noexcept
+        void PushOffset(TPgSize recordSize)
         {
             if (Deltas.empty()) {
                 Y_DEBUG_ABORT_UNLESS(recordSize > 0);
@@ -236,7 +236,7 @@ namespace NPage {
         }
 
     private:
-        void Resize(size_t bytes) noexcept
+        void Resize(size_t bytes)
         {
             Y_ABORT_UNLESS(bytes > Prefix, "Too few bytes for page");
 
@@ -253,17 +253,17 @@ namespace NPage {
             }
         }
 
-        size_t Offset(const void *base = nullptr) const noexcept
+        size_t Offset(const void *base = nullptr) const
         {
             return Tail - (const char*)(base ? base : Blob.begin());
         }
 
-        void Write(const char *buf, size_t size) noexcept
+        void Write(const char *buf, size_t size)
         {
             std::copy(buf, buf + size, Advance(size));
         }
 
-        char* Advance(size_t size) noexcept
+        char* Advance(size_t size)
         {
             size_t offset = Tail - Blob.mutable_begin();
             size_t available = Blob.size() - offset;
@@ -374,7 +374,7 @@ namespace NPage {
             return ret;
         }
 
-        void Add(const TSizeInfo& more, TCellsRef key, const TRowState& row, ISaver &saver, bool finalRow, TRowVersion minVersion, TRowVersion maxVersion, ui64 txId) noexcept
+        void Add(const TSizeInfo& more, TCellsRef key, const TRowState& row, ISaver &saver, bool finalRow, TRowVersion minVersion, TRowVersion maxVersion, ui64 txId)
         {
             if (more.Overflow) {
                 LastRecord = nullptr;
@@ -393,20 +393,20 @@ namespace NPage {
             }
         }
 
-        void FlushDeltas() noexcept
+        void FlushDeltas()
         {
             DataPageBuilder.PushOffset(0);
             BlobRowId = ++RowId;
         }
 
-        void Flush(ISaver &saver) noexcept
+        void Flush(ISaver &saver)
         {
             LastRecord = nullptr;
             if (auto flesh = DataPageBuilder.Close())
                 saver.Save(flesh, GroupId);
         }
 
-        void Reset() noexcept
+        void Reset()
         {
             BlobRowId = RowId = 0;
             DataPageBuilder.Reset();
@@ -422,14 +422,14 @@ namespace NPage {
             return RowId - 1;
         }
 
-        NPage::TDataPage::TRecord& GetLastRecord() const noexcept
+        NPage::TDataPage::TRecord& GetLastRecord() const
         {
             Y_ABORT_UNLESS(LastRecord != nullptr);
             return *LastRecord;
         }
 
     private:
-        void Put(TCellsRef key, const TRowState& row, ISaver &saver, bool finalRow, TRowVersion minVersion, TRowVersion maxVersion, ui64 txId, TPgSize recordSize) noexcept
+        void Put(TCellsRef key, const TRowState& row, ISaver &saver, bool finalRow, TRowVersion minVersion, TRowVersion maxVersion, ui64 txId, TPgSize recordSize)
         {
             const bool isErased = !maxVersion.IsMax();
             const bool isVersioned = !minVersion.IsMin();
@@ -508,7 +508,7 @@ namespace NPage {
             LastRecord = isDelta ? nullptr : &rec;
         }
 
-        TLargeObj SaveBlob(TCellOp cellOp, ui32 pin, const TCell &cell, ISaver &saver, bool isDelta) noexcept
+        TLargeObj SaveBlob(TCellOp cellOp, ui32 pin, const TCell &cell, ISaver &saver, bool isDelta)
         {
             if (cellOp == ELargeObj::GlobId) {
                 return saver.Save(BlobRowId, pin, cell.AsValue<NPageCollection::TGlobId>());
@@ -569,7 +569,7 @@ namespace NPage {
             return DataPageBuilder.BytesUsed();
         }
 
-        TPgSize CalcSize(TCellsRef key) const noexcept
+        TPgSize CalcSize(TCellsRef key) const
         {
             Y_ABORT_UNLESS(key.size() == GroupInfo.KeyTypes.size());
 
@@ -584,30 +584,30 @@ namespace NPage {
             return ret;
         }
 
-        void Add(TPgSize more, TCellsRef key, TRowId row, TPageId page) noexcept
+        void Add(TPgSize more, TCellsRef key, TRowId row, TPageId page)
         {
             DataPageBuilder.Grow(more, MinSize, 1.42);
 
             return Put(key, row, page, more);
         }
 
-        void Add(TCellsRef key, TRowId row, TPageId page) noexcept
+        void Add(TCellsRef key, TRowId row, TPageId page)
         {
             return Add(CalcSize(key), key, row, page);
         }
 
-        TSharedData Flush() noexcept
+        TSharedData Flush()
         {
             return DataPageBuilder.Close();
         }
 
-        void Reset() noexcept
+        void Reset()
         {
             DataPageBuilder.Reset();
         }
 
     private:
-        void Put(TCellsRef key, TRowId row, TPageId page, TPgSize recordSize) noexcept
+        void Put(TCellsRef key, TRowId row, TPageId page, TPgSize recordSize)
         {
             DataPageBuilder.PushOffset(recordSize);
 

--- a/ydb/core/tablet_flat/flat_part_charge_btree_index.h
+++ b/ydb/core/tablet_flat/flat_part_charge_btree_index.h
@@ -67,7 +67,7 @@ public:
 
 public:
     TResult Do(TCells key1, TCells key2, TRowId beginRowId, TRowId endRowId, 
-            const TKeyCellDefaults &keyDefaults, ui64 itemsLimit, ui64 bytesLimit) const noexcept override {
+            const TKeyCellDefaults &keyDefaults, ui64 itemsLimit, ui64 bytesLimit) const override {
         endRowId++; // current interface accepts inclusive row2 bound
 
         bool ready = true, overshot = true, hasValidRowsRange = Groups || IncludeHistory;
@@ -217,7 +217,7 @@ public:
     }
 
     TResult DoReverse(TCells key1, TCells key2, TRowId endRowId, TRowId beginRowId, 
-            const TKeyCellDefaults &keyDefaults, ui64 itemsLimit, ui64 bytesLimit) const noexcept override {
+            const TKeyCellDefaults &keyDefaults, ui64 itemsLimit, ui64 bytesLimit) const override {
         endRowId++; // current interface accepts inclusive row1 bound
         
         bool ready = true, overshot = true, hasValidRowsRange = Groups || IncludeHistory;
@@ -378,7 +378,7 @@ public:
     }
 
 private:
-    bool DoGroupsAndHistory(bool hasValidRowsRange, TRowId beginRowId, TRowId endRowId, const TChildState& firstChild, ui64 itemsLimit, ui64 bytesLimit) const noexcept {
+    bool DoGroupsAndHistory(bool hasValidRowsRange, TRowId beginRowId, TRowId endRowId, const TChildState& firstChild, ui64 itemsLimit, ui64 bytesLimit) const {
         bool ready = true;
         
         if (!hasValidRowsRange) {
@@ -410,7 +410,7 @@ private:
         return ready;
     }
 
-    bool DoGroupsAndHistoryReverse(bool hasValidRowsRange, TRowId beginRowId, TRowId endRowId, const TChildState& lastChild, ui64 itemsLimit, ui64 bytesLimit) const noexcept {
+    bool DoGroupsAndHistoryReverse(bool hasValidRowsRange, TRowId beginRowId, TRowId endRowId, const TChildState& lastChild, ui64 itemsLimit, ui64 bytesLimit) const {
         bool ready = true;
         
         if (!hasValidRowsRange) {
@@ -443,7 +443,7 @@ private:
     }
 
 private:
-    bool DoGroup(TGroupId groupId, TRowId beginRowId, TRowId endRowId, TRowId firstChildBeginRowId, ui64 bytesLimit) const noexcept {
+    bool DoGroup(TGroupId groupId, TRowId beginRowId, TRowId endRowId, TRowId firstChildBeginRowId, ui64 bytesLimit) const {
         bool ready = true;
         const auto& meta = Part->IndexPages.GetBTree(groupId);
 
@@ -499,7 +499,7 @@ private:
         return ready;
     }
 
-    bool DoGroupReverse(TGroupId groupId, TRowId beginRowId, TRowId endRowId, TRowId lastChildEndRowId, ui64 bytesLimit) const noexcept {
+    bool DoGroupReverse(TGroupId groupId, TRowId beginRowId, TRowId endRowId, TRowId lastChildEndRowId, ui64 bytesLimit) const {
         bool ready = true;
         const auto& meta = Part->IndexPages.GetBTree(groupId);
 
@@ -556,7 +556,7 @@ private:
     }
 
 private:
-    bool DoHistory(TRowId keyBeginRowId, TRowId keyEndRowId) const noexcept {
+    bool DoHistory(TRowId keyBeginRowId, TRowId keyEndRowId) const {
         bool ready = true;
 
         // Minimum key is (startRowId, max, max)
@@ -690,7 +690,7 @@ private:
         return ready;
     }
 
-    bool DoHistoricGroups(TRowId beginRowId, TRowId endRowId) const noexcept {
+    bool DoHistoricGroups(TRowId beginRowId, TRowId endRowId) const {
         bool ready = true;
         
         if (beginRowId < endRowId) {
@@ -742,15 +742,15 @@ private:
     }
 
 private:
-    const TSharedData* TryGetDataPage(TPageId pageId, TGroupId groupId) const noexcept {
+    const TSharedData* TryGetDataPage(TPageId pageId, TGroupId groupId) const {
         return Env->TryGetPage(Part, pageId, groupId);
     };
 
-    bool HasDataPage(TPageId pageId, TGroupId groupId) const noexcept {
+    bool HasDataPage(TPageId pageId, TGroupId groupId) const {
         return bool(Env->TryGetPage(Part, pageId, groupId));
     }
 
-    bool TryLoadNode(const TChildState& child, TVector<TNodeState>& level) const noexcept {
+    bool TryLoadNode(const TChildState& child, TVector<TNodeState>& level) const {
         auto page = Env->TryGetPage(Part, child.PageId, {});
         if (!page) {
             return false;
@@ -760,7 +760,7 @@ private:
         return true;
     }
 
-    int Compare(TCells left, TCells right, const TKeyCellDefaults &keyDefaults) const noexcept
+    int Compare(TCells left, TCells right, const TKeyCellDefaults &keyDefaults) const
     {
         Y_DEBUG_ABORT_UNLESS(left, "Empty keys should be handled separately");
         Y_DEBUG_ABORT_UNLESS(right, "Empty keys should be handled separately");
@@ -777,28 +777,28 @@ private:
             : (left.size() > right.size() ? -1 : 1);
     }
 
-    TChildState BuildRootChildState(const TBtreeIndexMeta& meta) const noexcept {
+    TChildState BuildRootChildState(const TBtreeIndexMeta& meta) const {
         return TChildState(meta.GetPageId(),
             0, meta.GetRowCount(),
             0, meta.GetNonErasedRowCount(),
             0, meta.GetDataSize());
     }
 
-    TChildState BuildChildState(const TNodeState& parent, TChild child, const TChild* prevChild) const noexcept {
+    TChildState BuildChildState(const TNodeState& parent, TChild child, const TChild* prevChild) const {
         return TChildState(child.GetPageId(),
             prevChild ? prevChild->GetRowCount() : parent.BeginRowId, child.GetRowCount(),
             prevChild ? prevChild->GetNonErasedRowCount() : parent.PrevItems, child.GetNonErasedRowCount(),
             prevChild ? prevChild->GetDataSize() : parent.PrevBytes, child.GetDataSize());
     }
 
-    TChildState BuildChildState(const TNodeState& parent, TShortChild child, const TShortChild* prevChild) const noexcept {
+    TChildState BuildChildState(const TNodeState& parent, TShortChild child, const TShortChild* prevChild) const {
         return TChildState(child.GetPageId(),
             prevChild ? prevChild->GetRowCount() : parent.BeginRowId, child.GetRowCount(),
             prevChild ? prevChild->GetRowCount() : parent.BeginRowId, child.GetRowCount(),
             prevChild ? prevChild->GetDataSize() : parent.PrevBytes, child.GetDataSize());
     }
 
-    bool LimitExceeded(ui64 prev, ui64 current, ui64 limit) const noexcept {
+    bool LimitExceeded(ui64 prev, ui64 current, ui64 limit) const {
         return limit && current > prev && current - prev > limit;
     }
 

--- a/ydb/core/tablet_flat/flat_part_charge_flat_index.h
+++ b/ydb/core/tablet_flat/flat_part_charge_flat_index.h
@@ -44,7 +44,7 @@ namespace NTable {
         }
 
         TResult Do(const TCells key1, const TCells key2, TRowId row1, TRowId row2, 
-                const TKeyCellDefaults &keyDefaults, ui64 itemsLimit, ui64 bytesLimit) const noexcept override
+                const TKeyCellDefaults &keyDefaults, ui64 itemsLimit, ui64 bytesLimit) const override
         {
             auto index = Index.TryLoadRaw();
             if (!index) {
@@ -112,7 +112,7 @@ namespace NTable {
         }
 
         TResult DoReverse(const TCells key1, const TCells key2, TRowId row1, TRowId row2, 
-                const TKeyCellDefaults &keyDefaults, ui64 itemsLimit, ui64 bytesLimit) const noexcept override
+                const TKeyCellDefaults &keyDefaults, ui64 itemsLimit, ui64 bytesLimit) const override
         {
             auto index = Index.TryLoadRaw();
             if (!index) {
@@ -198,7 +198,7 @@ namespace NTable {
          */
         bool DoPrecharge(const TCells key1, const TCells key2, const TIter key1Page, const TIter key2Page,
                 const TIter first, const TIter last, TRowId startRowId, TRowId endRowId,
-                const TKeyCellDefaults &keyDefaults, ui64 itemsLimit, ui64 bytesLimit) const noexcept
+                const TKeyCellDefaults &keyDefaults, ui64 itemsLimit, ui64 bytesLimit) const
         {
             bool ready = true;
 
@@ -296,7 +296,7 @@ namespace NTable {
          */
         bool DoPrechargeReverse(const TCells key1, const TCells key2, const TIter key1Page, const TIter key2Page,
                 TIter first, TIter last, TRowId startRowId, TRowId endRowId,
-                const TKeyCellDefaults &keyDefaults, ui64 itemsLimit, ui64 bytesLimit) const noexcept
+                const TKeyCellDefaults &keyDefaults, ui64 itemsLimit, ui64 bytesLimit) const
         {
             bool ready = true;
 
@@ -388,7 +388,7 @@ namespace NTable {
         }
 
     private:
-        bool DoPrechargeHistory(TRowId startRowId, TRowId endRowId) const noexcept {
+        bool DoPrechargeHistory(TRowId startRowId, TRowId endRowId) const {
             auto index = HistoryIndex->TryLoadRaw();
             if (!index) {
                 return false;
@@ -507,7 +507,7 @@ namespace NTable {
         /**
          * Precharges pages that contain row1 to row2 inclusive
          */
-        bool DoPrechargeGroup(TGroupState& group, TRowId row1, TRowId row2, ui64& bytes) const noexcept {
+        bool DoPrechargeGroup(TGroupState& group, TRowId row1, TRowId row2, ui64& bytes) const {
             auto groupIndex = group.GroupIndex.TryLoadRaw();
             if (!groupIndex) {
                 if (bytes) {
@@ -550,7 +550,7 @@ namespace NTable {
         /**
          * Precharges pages that contain row1 to row2 inclusive in reverse
          */
-        bool DoPrechargeGroupReverse(TGroupState& group, TRowId row1, TRowId row2, ui64& bytes) const noexcept {
+        bool DoPrechargeGroupReverse(TGroupState& group, TRowId row1, TRowId row2, ui64& bytes) const {
             auto groupIndex = group.GroupIndex.TryLoadRaw();
             if (!groupIndex) {
                 if (bytes) {
@@ -591,7 +591,7 @@ namespace NTable {
         }
 
     private:
-        TRowId LookupRowId(const TCells key, const TSharedData* page, const TPartScheme::TGroupInfo &group, ESeek seek, const TKeyCellDefaults &keyDefaults) const noexcept
+        TRowId LookupRowId(const TCells key, const TSharedData* page, const TPartScheme::TGroupInfo &group, ESeek seek, const TKeyCellDefaults &keyDefaults) const
         {
             auto data = TDataPage(page);
             auto lookup = data.LookupKey(key, group, seek, &keyDefaults);
@@ -600,7 +600,7 @@ namespace NTable {
         }
 
     private:
-        TRowId LookupRowIdReverse(const TCells key, const TSharedData* page, const TPartScheme::TGroupInfo &group, ESeek seek, const TKeyCellDefaults &keyDefaults) const noexcept
+        TRowId LookupRowIdReverse(const TCells key, const TSharedData* page, const TPartScheme::TGroupInfo &group, ESeek seek, const TKeyCellDefaults &keyDefaults) const
         {
             auto data = TDataPage(page);
             auto lookup = data.LookupKeyReverse(key, group, seek, &keyDefaults);
@@ -611,7 +611,7 @@ namespace NTable {
         }
 
     private:
-        bool LimitExceeded(ui64 value, ui64 limit) const noexcept {
+        bool LimitExceeded(ui64 value, ui64 limit) const {
             return limit && value > limit;
         }
 

--- a/ydb/core/tablet_flat/flat_part_charge_iface.h
+++ b/ydb/core/tablet_flat/flat_part_charge_iface.h
@@ -18,7 +18,7 @@ namespace NKikimr::NTable {
          * Important caveat: assumes iteration won't touch any row > row2
          */
         bool Do(TRowId row1, TRowId row2,
-                const TKeyCellDefaults &keyDefaults, ui64 itemsLimit, ui64 bytesLimit) const noexcept
+                const TKeyCellDefaults &keyDefaults, ui64 itemsLimit, ui64 bytesLimit) const
         {
             return Do(TCells{}, TCells{}, row1, row2, 
                 keyDefaults, itemsLimit, bytesLimit).Ready;
@@ -30,7 +30,7 @@ namespace NKikimr::NTable {
          * Important caveat: assumes iteration won't touch any row > row2
          */
         bool DoReverse(TRowId row1, TRowId row2, 
-                const TKeyCellDefaults &keyDefaults, ui64 itemsLimit, ui64 bytesLimit) const noexcept
+                const TKeyCellDefaults &keyDefaults, ui64 itemsLimit, ui64 bytesLimit) const
         {
             return DoReverse(TCells{}, TCells{}, row1, row2, 
                 keyDefaults, itemsLimit, bytesLimit).Ready;
@@ -40,13 +40,13 @@ namespace NKikimr::NTable {
          * Precharges data for rows between max(key1, row1) and min(key2, row2) inclusive
          */
         virtual TResult Do(const TCells key1, const TCells key2, TRowId row1, TRowId row2, 
-                const TKeyCellDefaults &keyDefaults, ui64 itemsLimit, ui64 bytesLimit) const noexcept = 0;
+                const TKeyCellDefaults &keyDefaults, ui64 itemsLimit, ui64 bytesLimit) const = 0;
 
         /**
          * Precharges data for rows between min(key1, row1) and max(key2, row2) inclusive in reverse
          */
         virtual TResult DoReverse(const TCells key1, const TCells key2, TRowId row1, TRowId row2, 
-                const TKeyCellDefaults &keyDefaults, ui64 itemsLimit, ui64 bytesLimit) const noexcept = 0;
+                const TKeyCellDefaults &keyDefaults, ui64 itemsLimit, ui64 bytesLimit) const = 0;
 
         virtual ~ICharge() = default;
 };

--- a/ydb/core/tablet_flat/flat_part_charge_range.cpp
+++ b/ydb/core/tablet_flat/flat_part_charge_range.cpp
@@ -5,7 +5,7 @@ namespace NKikimr::NTable {
 
 bool ChargeRange(IPages *env, const TCells key1, const TCells key2,
             const TRun &run, const TKeyCellDefaults &keyDefaults, TTagsRef tags,
-            ui64 items, ui64 bytes, bool includeHistory) noexcept
+            ui64 items, ui64 bytes, bool includeHistory)
 {
     bool ready = true;
     auto pos = run.LowerBound(key1);
@@ -57,7 +57,7 @@ bool ChargeRange(IPages *env, const TCells key1, const TCells key2,
 
 bool ChargeRangeReverse(IPages *env, const TCells key1, const TCells key2,
             const TRun &run, const TKeyCellDefaults &keyDefaults, TTagsRef tags,
-            ui64 items, ui64 bytes, bool includeHistory) noexcept
+            ui64 items, ui64 bytes, bool includeHistory)
 {
     bool ready = true;
     auto pos = run.LowerBoundReverse(key1);

--- a/ydb/core/tablet_flat/flat_part_charge_range.h
+++ b/ydb/core/tablet_flat/flat_part_charge_range.h
@@ -11,10 +11,10 @@ namespace {
 
 bool ChargeRange(IPages *env, const TCells key1, const TCells key2,
             const TRun &run, const TKeyCellDefaults &keyDefaults, TTagsRef tags,
-            ui64 items, ui64 bytes, bool includeHistory) noexcept;
+            ui64 items, ui64 bytes, bool includeHistory);
 
 bool ChargeRangeReverse(IPages *env, const TCells key1, const TCells key2,
             const TRun &run, const TKeyCellDefaults &keyDefaults, TTagsRef tags,
-            ui64 items, ui64 bytes, bool includeHistory) noexcept;
+            ui64 items, ui64 bytes, bool includeHistory);
 
 }

--- a/ydb/core/tablet_flat/flat_part_dump.cpp
+++ b/ydb/core/tablet_flat/flat_part_dump.cpp
@@ -39,7 +39,7 @@ namespace {
 
     TDump::~TDump() { }
 
-    void TDump::Part(const TPart &part, ui32 depth) noexcept
+    void TDump::Part(const TPart &part, ui32 depth)
     {
         Out << NFmt::Do(part) << " data " << part.DataSize() << "b" << Endl;
 
@@ -70,7 +70,7 @@ namespace {
         }
     }
 
-    void TDump::Frames(const NPage::TFrames &page, const char *tag) noexcept
+    void TDump::Frames(const NPage::TFrames &page, const char *tag)
     {
         Out
             << " + " << tag << " Label{" << page.Raw.size() << "b}"
@@ -79,7 +79,7 @@ namespace {
             << Endl;
     }
 
-    void TDump::Blobs(const NPage::TExtBlobs &page) noexcept
+    void TDump::Blobs(const NPage::TExtBlobs &page)
     {
         Out
             << " + Blobs Label{" << page.Raw.size() << "b} "
@@ -88,7 +88,7 @@ namespace {
             << Endl;
     }
 
-    void TDump::Bloom(const NPage::TBloom &page) noexcept
+    void TDump::Bloom(const NPage::TBloom &page)
     {
         Out
             << " + Bloom Label{" << page.Raw.size() << "b} "
@@ -97,7 +97,7 @@ namespace {
             << Endl;
     }
 
-    void TDump::Index(const TPart &part, ui32 depth) noexcept
+    void TDump::Index(const TPart &part, ui32 depth)
     {
         if (!part.IndexPages.HasFlat()) {
             return;
@@ -170,7 +170,7 @@ namespace {
         }
     }
 
-    void TDump::BTreeIndex(const TPart &part) noexcept
+    void TDump::BTreeIndex(const TPart &part)
     {
         if (part.IndexPages.HasBTree()) {
             auto meta = part.IndexPages.GetBTree({});
@@ -184,7 +184,7 @@ namespace {
         }
     }
 
-    void TDump::DataPage(const TPart &part, ui32 page) noexcept
+    void TDump::DataPage(const TPart &part, ui32 page)
     {
         TVector<TCell> key(Reserve(part.Scheme->Groups[0].KeyTypes.size()));
 
@@ -268,7 +268,7 @@ namespace {
         }
     }
 
-    void TDump::TName(ui32 num) noexcept
+    void TDump::TName(ui32 num)
     {
         const auto &type = Reg->GetType(num);
 
@@ -279,7 +279,7 @@ namespace {
         }
     }
 
-    void TDump::Key(TCellsRef key, const TPartScheme &scheme) noexcept
+    void TDump::Key(TCellsRef key, const TPartScheme &scheme)
     {
         Out << "(";
 
@@ -294,7 +294,7 @@ namespace {
         Out << ")";
     }
 
-    void TDump::BTreeIndexNode(const TPart &part, NPage::TBtreeIndexNode::TChild meta, ui32 level) noexcept
+    void TDump::BTreeIndexNode(const TPart &part, NPage::TBtreeIndexNode::TChild meta, ui32 level)
     {
         TVector<TCell> key(Reserve(part.Scheme->Groups[0].KeyTypes.size()));
 

--- a/ydb/core/tablet_flat/flat_part_dump.h
+++ b/ydb/core/tablet_flat/flat_part_dump.h
@@ -14,18 +14,18 @@ namespace NTable {
         TDump(IOut &out, IPages *env, const TReg *reg);
         ~TDump();
 
-        void Part(const TPart&, ui32 depth = 10) noexcept;
+        void Part(const TPart&, ui32 depth = 10);
 
     private:
-        void Frames(const NPage::TFrames&, const char *tag) noexcept;
-        void Blobs(const NPage::TExtBlobs&) noexcept;
-        void Bloom(const NPage::TBloom&) noexcept;
-        void Index(const TPart&, ui32 depth = 10) noexcept;
-        void BTreeIndex(const TPart&) noexcept;
-        void DataPage(const TPart&, ui32 page) noexcept;
-        void TName(ui32 num) noexcept;
-        void Key(TCellsRef cells, const TPartScheme&) noexcept;
-        void BTreeIndexNode(const TPart &part, NPage::TBtreeIndexNode::TChild meta, ui32 level = 0) noexcept;
+        void Frames(const NPage::TFrames&, const char *tag);
+        void Blobs(const NPage::TExtBlobs&);
+        void Bloom(const NPage::TBloom&);
+        void Index(const TPart&, ui32 depth = 10);
+        void BTreeIndex(const TPart&);
+        void DataPage(const TPart&, ui32 page);
+        void TName(ui32 num);
+        void Key(TCellsRef cells, const TPartScheme&);
+        void BTreeIndexNode(const TPart &part, NPage::TBtreeIndexNode::TChild meta, ui32 level = 0);
 
         IOutputStream &Out;
         IPages * const Env = nullptr;

--- a/ydb/core/tablet_flat/flat_part_iface.h
+++ b/ydb/core/tablet_flat/flat_part_iface.h
@@ -24,9 +24,9 @@ namespace NTable {
     struct ISaver {
         using TGlobId = NPageCollection::TGlobId;
 
-        virtual void Save(TSharedData raw, NPage::TGroupId groupId) noexcept = 0;
-        virtual TLargeObj Save(TRowId, ui32 tag, const TGlobId &glob) noexcept = 0;
-        virtual TLargeObj Save(TRowId, ui32 tag, TArrayRef<const char> blob) noexcept = 0;
+        virtual void Save(TSharedData raw, NPage::TGroupId groupId) = 0;
+        virtual TLargeObj Save(TRowId, ui32 tag, const TGlobId &glob) = 0;
+        virtual TLargeObj Save(TRowId, ui32 tag, TArrayRef<const char> blob) = 0;
     };
 
     class IPageWriter {
@@ -36,10 +36,10 @@ namespace NTable {
 
         virtual ~IPageWriter() = default;
         virtual TPageId Write(TSharedData page, EPage type, ui32 group) = 0;
-        virtual TPageId WriteOuter(TSharedData) noexcept = 0;
+        virtual TPageId WriteOuter(TSharedData) = 0;
         virtual void WriteInplace(TPageId page, TArrayRef<const char> body) = 0;
-        virtual NPageCollection::TGlobId WriteLarge(TString blob, ui64 ref) noexcept = 0;
-        virtual void Finish(TString overlay) noexcept = 0;
+        virtual NPageCollection::TGlobId WriteLarge(TString blob, ui64 ref) = 0;
+        virtual void Finish(TString overlay) = 0;
     };
 
     struct IPages {
@@ -66,14 +66,14 @@ namespace NTable {
             const TSharedData *Page;
         };
 
-        virtual TResult Locate(const TMemTable*, ui64 ref, ui32 tag) noexcept = 0;
-        virtual TResult Locate(const TPart*, ui64 ref, ELargeObj lob) noexcept = 0;
+        virtual TResult Locate(const TMemTable*, ui64 ref, ui32 tag) = 0;
+        virtual TResult Locate(const TPart*, ui64 ref, ELargeObj lob) = 0;
         virtual const TSharedData* TryGetPage(const TPart* part, TPageId pageId, TGroupId groupId) = 0;
 
         /**
          * Hook for cleaning up env on DB.RollbackChanges()
          */
-        virtual void OnRollbackChanges() noexcept {
+        virtual void OnRollbackChanges() {
             // nothing by default
         }
     };

--- a/ydb/core/tablet_flat/flat_part_index_iter_bree_index.h
+++ b/ydb/core/tablet_flat/flat_part_index_iter_bree_index.h
@@ -35,13 +35,13 @@ class TPartGroupBtreeIndexIter : public IPartGroupIndexIter {
         {
         }
 
-        bool IsLastPos() const noexcept {
+        bool IsLastPos() const {
             Y_ABORT_UNLESS(Node);
             Y_ABORT_UNLESS(Pos);
             return *Pos == Node->GetKeysCount();
         }
 
-        bool IsFirstPos() const noexcept {
+        bool IsFirstPos() const {
             Y_ABORT_UNLESS(Node);
             Y_ABORT_UNLESS(Pos);
             return *Pos == 0;
@@ -57,7 +57,7 @@ class TPartGroupBtreeIndexIter : public IPartGroupIndexIter {
             return TBtreeIndexNode::Has(RowId, state.BeginRowId, state.EndRowId);
         }
 
-        TRecIdx Do(const TNodeState& state) const noexcept {
+        TRecIdx Do(const TNodeState& state) const {
             return state.Node->Seek(RowId, state.Pos);
         }
 
@@ -72,11 +72,11 @@ class TPartGroupBtreeIndexIter : public IPartGroupIndexIter {
             , KeyDefaults(keyDefaults)
         {}
 
-        bool BelongsTo(const TNodeState& state) const noexcept {
+        bool BelongsTo(const TNodeState& state) const {
             return TBtreeIndexNode::Has(Seek, Key, state.BeginKey, state.EndKey, KeyDefaults);
         }
 
-        TRecIdx Do(const TNodeState& state) const noexcept {
+        TRecIdx Do(const TNodeState& state) const {
             return state.Node->Seek(Seek, Key, Columns, KeyDefaults);
         }
 
@@ -94,11 +94,11 @@ class TPartGroupBtreeIndexIter : public IPartGroupIndexIter {
             , KeyDefaults(keyDefaults)
         {}
 
-        bool BelongsTo(const TNodeState& state) const noexcept {
+        bool BelongsTo(const TNodeState& state) const {
             return TBtreeIndexNode::HasReverse(Seek, Key, state.BeginKey, state.EndKey, KeyDefaults);
         }
 
-        TRecIdx Do(const TNodeState& state) const noexcept {
+        TRecIdx Do(const TNodeState& state) const {
             return state.Node->SeekReverse(Seek, Key, Columns, KeyDefaults);
         }
 

--- a/ydb/core/tablet_flat/flat_part_iter.h
+++ b/ydb/core/tablet_flat/flat_part_iter.h
@@ -27,7 +27,7 @@ namespace NTable {
         {
         }
 
-        EReady Seek(TRowId rowId) noexcept {
+        EReady Seek(TRowId rowId) {
             // Fast path, check if we already have the needed data page
             if (Data) {
                 TRowId minRowId = Page.BaseRow();
@@ -77,7 +77,7 @@ namespace NTable {
         }
 
     protected:
-        bool LoadPage(TPageId pageId, TRowId baseRow) noexcept
+        bool LoadPage(TPageId pageId, TRowId baseRow)
         {
             if (PageId != pageId) {
                 Data = { };
@@ -120,7 +120,7 @@ namespace NTable {
         {
         }
 
-        void SetBounds(TRowId beginRowId, TRowId endRowId) noexcept
+        void SetBounds(TRowId beginRowId, TRowId endRowId)
         {
             BeginRowId = beginRowId;
             EndRowId = Min(endRowId, Index.GetEndRowId());
@@ -130,7 +130,7 @@ namespace NTable {
         }
 
         EReady Seek(const TCells key, ESeek seek,
-                const TPartScheme::TGroupInfo& scheme, const TKeyCellDefaults* keyDefaults) noexcept
+                const TPartScheme::TGroupInfo& scheme, const TKeyCellDefaults* keyDefaults)
         {
             Y_DEBUG_ABORT_UNLESS(seek == ESeek::Exact || seek == ESeek::Lower || seek == ESeek::Upper,
                     "Only ESeek{Exact, Upper, Lower} are currently supported here");
@@ -210,7 +210,7 @@ namespace NTable {
         }
 
         EReady SeekReverse(const TCells key, ESeek seek,
-                const TPartScheme::TGroupInfo& scheme, const TKeyCellDefaults* keyDefaults) noexcept
+                const TPartScheme::TGroupInfo& scheme, const TKeyCellDefaults* keyDefaults)
         {
             Y_DEBUG_ABORT_UNLESS(seek == ESeek::Exact || seek == ESeek::Lower || seek == ESeek::Upper,
                     "Only ESeek{Exact, Upper, Lower} are currently supported here");
@@ -280,7 +280,7 @@ namespace NTable {
             return Exhausted();
         }
 
-        EReady Seek(TRowId rowId) noexcept
+        EReady Seek(TRowId rowId)
         {
             if (Y_UNLIKELY(rowId < BeginRowId || rowId >= EndRowId)) {
                 return Exhausted();
@@ -298,12 +298,12 @@ namespace NTable {
             return EReady::Data;
         }
 
-        EReady SeekToSliceFirstRow() noexcept
+        EReady SeekToSliceFirstRow()
         {
             return Seek(BeginRowId);
         }
 
-        EReady SeekToSliceLastRow() noexcept
+        EReady SeekToSliceLastRow()
         {
             return Seek(EndRowId - 1);
         }
@@ -313,7 +313,7 @@ namespace NTable {
          * 
          * If doesn't have Data, loads the current row
          */
-        EReady Next() noexcept
+        EReady Next()
         {
             if (Y_UNLIKELY(RowId == Max<TRowId>())) {
                 return EReady::Gone;
@@ -360,7 +360,7 @@ namespace NTable {
          * 
          * If doesn't have Data, loads the current row
          */
-        EReady Prev() noexcept
+        EReady Prev()
         {
             if (Y_UNLIKELY(RowId == Max<TRowId>())) {
                 return EReady::Gone;
@@ -415,19 +415,19 @@ namespace NTable {
         }
 
     private:
-        Y_FORCE_INLINE EReady Exhausted() noexcept
+        Y_FORCE_INLINE EReady Exhausted()
         {
             return Terminate(EReady::Gone);
         }
         
-        Y_FORCE_INLINE EReady Terminate(EReady ready) noexcept
+        Y_FORCE_INLINE EReady Terminate(EReady ready)
         {
             Data = { };
             RowId = Max<TRowId>();
             return ready;
         }
 
-        EReady LoadRowData() noexcept
+        EReady LoadRowData()
         {
             Y_DEBUG_ABORT_UNLESS(Index.IsValid() && Index.GetRowId() <= RowId,
                 "Called without a valid index record");
@@ -443,7 +443,7 @@ namespace NTable {
             return EReady::Gone;
         }
 
-        EReady SeekIndex(TRowId rowId) noexcept
+        EReady SeekIndex(TRowId rowId)
         {
             auto ready = Index.Seek(rowId);
             Y_DEBUG_ABORT_UNLESS(ready != EReady::Gone,
@@ -470,7 +470,7 @@ namespace NTable {
             : TPartGroupRowIter(part, env, NPage::TGroupId(0, /* historic */ true))
         { }
 
-        EReady Seek(TRowId rowId, const TRowVersion& rowVersion) noexcept
+        EReady Seek(TRowId rowId, const TRowVersion& rowVersion)
         {
             Y_DEBUG_ABORT_UNLESS(rowId != Max<TRowId>());
 
@@ -749,12 +749,12 @@ namespace NTable {
         }
 
     private:
-        Y_FORCE_INLINE EReady Exhausted() noexcept
+        Y_FORCE_INLINE EReady Exhausted()
         {
             return Terminate(EReady::Gone);
         }
 
-        Y_FORCE_INLINE EReady Terminate(EReady ready) noexcept
+        Y_FORCE_INLINE EReady Terminate(EReady ready)
         {
             Data = { };
             RowId = Max<TRowId>();
@@ -801,53 +801,53 @@ namespace NTable {
             }
         }
 
-        void SetBounds(const TSlice& slice) noexcept
+        void SetBounds(const TSlice& slice)
         {
             Main.SetBounds(slice.BeginRowId(), slice.EndRowId());
         }
 
-        void SetBounds(TRowId beginRowId, TRowId endRowId) noexcept
+        void SetBounds(TRowId beginRowId, TRowId endRowId)
         {
             Main.SetBounds(beginRowId, endRowId);
         }
 
-        EReady Seek(const TCells key, ESeek seek) noexcept
+        EReady Seek(const TCells key, ESeek seek)
         {
             ClearKey();
             return Main.Seek(key, seek, Part->Scheme->Groups[0], &*KeyCellDefaults);
         }
 
-        EReady SeekReverse(const TCells key, ESeek seek) noexcept
+        EReady SeekReverse(const TCells key, ESeek seek)
         {
             ClearKey();
             return Main.SeekReverse(key, seek, Part->Scheme->Groups[0], &*KeyCellDefaults);
         }
 
-        EReady Seek(TRowId rowId) noexcept
+        EReady Seek(TRowId rowId)
         {
             ClearKey();
             return Main.Seek(rowId);
         }
 
-        EReady SeekToSliceFirstRow() noexcept
+        EReady SeekToSliceFirstRow()
         {
             ClearKey();
             return Main.SeekToSliceFirstRow();
         }
 
-        EReady SeekToSliceLastRow() noexcept
+        EReady SeekToSliceLastRow()
         {
             ClearKey();
             return Main.SeekToSliceLastRow();
         }
 
-        EReady Next() noexcept
+        EReady Next()
         {
             ClearKey();
             return Main.Next();
         }
 
-        EReady Prev() noexcept
+        EReady Prev()
         {
             ClearKey();
             return Main.Prev();
@@ -869,7 +869,7 @@ namespace NTable {
             return Main.GetRowId();
         }
 
-        TDbTupleRef GetKey() const noexcept
+        TDbTupleRef GetKey() const
         {
             InitKey();
 
@@ -881,14 +881,14 @@ namespace NTable {
             return Main.GetPageData();
         }
 
-        TCells GetRawKey() const noexcept
+        TCells GetRawKey() const
         {
             InitKey();
 
             return TCells(Key).Slice(0, Part->Scheme->Groups[0].ColsKeyData.size());
         }
 
-        TRowVersion GetRowVersion() const noexcept
+        TRowVersion GetRowVersion() const
         {
             Y_DEBUG_ABORT_UNLESS(IsValid(), "Attempt to get invalid row version");
 
@@ -924,7 +924,7 @@ namespace NTable {
         EReady SkipToRowVersion(TRowVersion rowVersion, TIteratorStats& stats,
                                 NTable::ITransactionMapSimplePtr committedTransactions,
                                 NTable::ITransactionObserverSimplePtr transactionObserver,
-                                const NTable::ITransactionSet& decidedTransactions) noexcept
+                                const NTable::ITransactionSet& decidedTransactions)
         {
             // Temporary: we don't cache erases when there are uncompacted deltas
             Y_UNUSED(decidedTransactions);
@@ -1086,7 +1086,7 @@ namespace NTable {
         }
 
         std::optional<TRowVersion> SkipToCommitted(NTable::ITransactionMapSimplePtr committedTransactions,
-                NTable::ITransactionObserverSimplePtr transactionObserver) noexcept
+                NTable::ITransactionObserverSimplePtr transactionObserver)
         {
             Y_DEBUG_ABORT_UNLESS(Main.IsValid(), "Attempt to use an invalid iterator");
             Y_ABORT_UNLESS(!SkipMainVersion, "Cannot use SkipToCommitted after positioning to history");
@@ -1144,7 +1144,7 @@ namespace NTable {
             return data->GetDeltaTxId(info);
         }
 
-        void ApplyDelta(TRowState& row) const noexcept
+        void ApplyDelta(TRowState& row) const
         {
             Y_DEBUG_ABORT_UNLESS(!SkipMainVersion, "Current record is not a delta record");
             Y_DEBUG_ABORT_UNLESS(Main.IsValid(), "Cannot use unpositioned iterators");
@@ -1162,7 +1162,7 @@ namespace NTable {
             }
         }
 
-        EReady SkipDelta() noexcept
+        EReady SkipDelta()
         {
             Y_DEBUG_ABORT_UNLESS(!SkipMainVersion, "Current record is not a delta record");
             Y_DEBUG_ABORT_UNLESS(Main.IsValid(), "Cannot use unpositioned iterators");
@@ -1181,7 +1181,7 @@ namespace NTable {
 
         void Apply(TRowState& row,
                    NTable::ITransactionMapSimplePtr committedTransactions,
-                   NTable::ITransactionObserverSimplePtr transactionObserver) const noexcept
+                   NTable::ITransactionObserverSimplePtr transactionObserver) const
         {
             Y_DEBUG_ABORT_UNLESS(IsValid(), "Attempt to apply an invalid row");
 
@@ -1243,7 +1243,7 @@ namespace NTable {
         }
 
     private:
-        Y_FORCE_INLINE void ClearKey() noexcept
+        Y_FORCE_INLINE void ClearKey()
         {
             KeyInitialized = false;
             SkipMainDeltas = 0;
@@ -1251,7 +1251,7 @@ namespace NTable {
             SkipEraseVersion = false;
         }
 
-        Y_FORCE_INLINE void InitKey() const noexcept
+        Y_FORCE_INLINE void InitKey() const
         {
             Y_DEBUG_ABORT_UNLESS(Main.IsValid(), "Attempt to get an invalid key");
             if (KeyInitialized)
@@ -1267,7 +1267,7 @@ namespace NTable {
             }
         }
 
-        void Apply(TRowState& row, TPinout::TPin pin, const NPage::TDataPage::TRecord* mainRecord, ui32 altIndex) const noexcept
+        void Apply(TRowState& row, TPinout::TPin pin, const NPage::TDataPage::TRecord* mainRecord, ui32 altIndex) const
         {
             auto& col = SkipMainVersion ? Part->Scheme->HistoryColumns[pin.From] : Part->Scheme->AllColumns[pin.From];
 
@@ -1300,7 +1300,7 @@ namespace NTable {
         }
 
         void Apply(TRowState& row, TPinout::TPin pin, const NPage::TDataPage::TRecord* data,
-                const TPartScheme::TColumn& info) const noexcept
+                const TPartScheme::TColumn& info) const
         {
             auto op = data->GetCellOp(info);
 
@@ -1396,7 +1396,7 @@ namespace NTable {
             Y_DEBUG_ABORT_UNLESS(!Run.empty(), "Cannot iterate over an empty run");
         }
 
-        EReady Seek(const TCells key, ESeek seek) noexcept
+        EReady Seek(const TCells key, ESeek seek)
         {
             bool seekToSliceFirstRow = false;
             TRun::const_iterator pos;
@@ -1475,7 +1475,7 @@ namespace NTable {
             return SeekToSliceFirstRow();
         }
 
-        EReady SeekReverse(const TCells key, ESeek seek) noexcept
+        EReady SeekReverse(const TCells key, ESeek seek)
         {
             bool seekToSliceLastRow = false;
             TRun::const_iterator pos;
@@ -1557,7 +1557,7 @@ namespace NTable {
             return SeekToSliceLastRow();
         }
 
-        EReady Next() noexcept
+        EReady Next()
         {
             if (Y_UNLIKELY(Current == Run.end())) {
                 // Calling Next on an exhausted iterator (e.g. from tests)
@@ -1587,7 +1587,7 @@ namespace NTable {
             return ready;
         }
 
-        EReady Prev() noexcept
+        EReady Prev()
         {
             if (Y_UNLIKELY(Current == Run.end())) {
                 // Calling Prev on an exhausted iterator (e.g. from tests)
@@ -1643,7 +1643,7 @@ namespace NTable {
             return CurrentIt ? CurrentIt->GetRowId() : Max<TRowId>();
         }
 
-        TDbTupleRef GetKey() const noexcept
+        TDbTupleRef GetKey() const
         {
             Y_DEBUG_ABORT_UNLESS(CurrentIt);
             return CurrentIt->GetKey();
@@ -1657,13 +1657,13 @@ namespace NTable {
 
         void Apply(TRowState& row,
                    NTable::ITransactionMapSimplePtr committedTransactions,
-                   NTable::ITransactionObserverSimplePtr transactionObserver) const noexcept
+                   NTable::ITransactionObserverSimplePtr transactionObserver) const
         {
             Y_DEBUG_ABORT_UNLESS(CurrentIt);
             CurrentIt->Apply(row, committedTransactions, transactionObserver);
         }
 
-        TRowVersion GetRowVersion() const noexcept
+        TRowVersion GetRowVersion() const
         {
             Y_DEBUG_ABORT_UNLESS(CurrentIt);
             return CurrentIt->GetRowVersion();
@@ -1672,7 +1672,7 @@ namespace NTable {
         EReady SkipToRowVersion(TRowVersion rowVersion, TIteratorStats& stats,
                                 NTable::ITransactionMapSimplePtr committedTransactions,
                                 NTable::ITransactionObserverSimplePtr transactionObserver,
-                                const NTable::ITransactionSet& decidedTransactions) noexcept
+                                const NTable::ITransactionSet& decidedTransactions)
         {
             Y_DEBUG_ABORT_UNLESS(CurrentIt);
             auto ready = CurrentIt->SkipToRowVersion(rowVersion, stats, committedTransactions, transactionObserver, decidedTransactions);
@@ -1691,20 +1691,20 @@ namespace NTable {
             return CurrentIt->GetDeltaTxId();
         }
 
-        void ApplyDelta(TRowState& row) const noexcept
+        void ApplyDelta(TRowState& row) const
         {
             Y_DEBUG_ABORT_UNLESS(CurrentIt);
             return CurrentIt->ApplyDelta(row);
         }
 
-        EReady SkipDelta() noexcept
+        EReady SkipDelta()
         {
             Y_DEBUG_ABORT_UNLESS(CurrentIt);
             return CurrentIt->SkipDelta();
         }
 
     private:
-        Y_FORCE_INLINE void InitCurrent() noexcept
+        Y_FORCE_INLINE void InitCurrent()
         {
             const auto* part = Current->Part.Get();
             auto it = Cache.find(part);
@@ -1717,14 +1717,14 @@ namespace NTable {
             CurrentIt->SetBounds(Current->Slice);
         }
 
-        Y_FORCE_INLINE void DropCurrent() noexcept
+        Y_FORCE_INLINE void DropCurrent()
         {
             Y_DEBUG_ABORT_UNLESS(CurrentIt, "Dropping non-existant current iterator");
             const auto* part = CurrentIt->Part;
             Cache[part] = std::move(CurrentIt);
         }
 
-        Y_FORCE_INLINE void UpdateCurrent() noexcept
+        Y_FORCE_INLINE void UpdateCurrent()
         {
             if (CurrentIt) {
                 if (CurrentIt->Part == Current->Part.Get()) {
@@ -1739,7 +1739,7 @@ namespace NTable {
             InitCurrent();
         }
 
-        Y_FORCE_INLINE EReady SeekToSliceFirstRow() noexcept
+        Y_FORCE_INLINE EReady SeekToSliceFirstRow()
         {
             auto ready = CurrentIt->SeekToSliceFirstRow();
             Y_ABORT_UNLESS(ready != EReady::Gone,
@@ -1747,7 +1747,7 @@ namespace NTable {
             return ready;
         }
 
-        Y_FORCE_INLINE EReady SeekToSliceLastRow() noexcept
+        Y_FORCE_INLINE EReady SeekToSliceLastRow()
         {
             auto ready = CurrentIt->SeekToSliceLastRow();
             Y_ABORT_UNLESS(ready != EReady::Gone,

--- a/ydb/core/tablet_flat/flat_part_keys.h
+++ b/ydb/core/tablet_flat/flat_part_keys.h
@@ -67,12 +67,12 @@ namespace NTable {
             return RowId;
         }
 
-        TSerializedCellVec GetKey() const noexcept
+        TSerializedCellVec GetKey() const
         {
             return TSerializedCellVec(Key);
         }
 
-        bool SeekRow(TRowId rowId) noexcept
+        bool SeekRow(TRowId rowId)
         {
             if (RowId != rowId) {
                 if (rowId == Max<TRowId>()) {
@@ -108,7 +108,7 @@ namespace NTable {
             return true;
         }
 
-        bool SeekLastRow() noexcept
+        bool SeekLastRow()
         {
             auto hasLast = Index->SeekLast();
             if (hasLast == EReady::Page) {
@@ -125,7 +125,7 @@ namespace NTable {
             return true;
         }
 
-        bool LoadPage(TPageId pageId) noexcept
+        bool LoadPage(TPageId pageId)
         {
             Y_ABORT_UNLESS(pageId != Max<TPageId>(), "Unexpected seek to an invalid page id");
             if (PageId != pageId) {
@@ -139,7 +139,7 @@ namespace NTable {
             return true;
         }
 
-        void LoadRow(TRowId rowId) noexcept
+        void LoadRow(TRowId rowId)
         {
             if (RowId != rowId) {
                 auto it = Page->Begin() + (rowId - Page.BaseRow());

--- a/ydb/core/tablet_flat/flat_part_loader.cpp
+++ b/ydb/core/tablet_flat/flat_part_loader.cpp
@@ -28,7 +28,7 @@ TLoader::TLoader(TVector<TIntrusivePtr<TCache>> pageCollections,
 
 TLoader::~TLoader() { }
 
-void TLoader::StageParseMeta() noexcept
+void TLoader::StageParseMeta()
 {
     auto* metaPacket = dynamic_cast<const NPageCollection::TPageCollection*>(Packs.at(0)->PageCollection.Get());
     if (!metaPacket) {
@@ -149,7 +149,7 @@ void TLoader::StageParseMeta() noexcept
     }
 }
 
-TAutoPtr<NPageCollection::TFetch> TLoader::StageCreatePartView(bool preloadIndex) noexcept
+TAutoPtr<NPageCollection::TFetch> TLoader::StageCreatePartView(bool preloadIndex)
 {
     Y_ABORT_UNLESS(!PartView, "PartView already initialized in CreatePartView stage");
     Y_ABORT_UNLESS(Packs && Packs.front());
@@ -275,7 +275,7 @@ TAutoPtr<NPageCollection::TFetch> TLoader::StageCreatePartView(bool preloadIndex
     return nullptr;
 }
 
-TAutoPtr<NPageCollection::TFetch> TLoader::StageSliceBounds() noexcept
+TAutoPtr<NPageCollection::TFetch> TLoader::StageSliceBounds()
 {
     Y_ABORT_UNLESS(PartView, "Cannot generate bounds for a missing part");
 
@@ -301,7 +301,7 @@ TAutoPtr<NPageCollection::TFetch> TLoader::StageSliceBounds() noexcept
     }
 }
 
-void TLoader::StageDeltas() noexcept
+void TLoader::StageDeltas()
 {
     Y_ABORT_UNLESS(PartView, "Cannot apply deltas to a missing part");
     Y_ABORT_UNLESS(PartView.Slices, "Missing slices in deltas stage");
@@ -316,7 +316,7 @@ void TLoader::StageDeltas() noexcept
     }
 }
 
-TAutoPtr<NPageCollection::TFetch> TLoader::StagePreloadData() noexcept
+TAutoPtr<NPageCollection::TFetch> TLoader::StagePreloadData()
 {
     auto partStore = PartView.As<TPartStore>();
 
@@ -331,7 +331,7 @@ TAutoPtr<NPageCollection::TFetch> TLoader::StagePreloadData() noexcept
     return LoaderEnv->GetFetch();
 }
 
-void TLoader::Save(ui64 cookie, TArrayRef<NSharedCache::TEvResult::TLoaded> loadedPages) noexcept
+void TLoader::Save(ui64 cookie, TArrayRef<NSharedCache::TEvResult::TLoaded> loadedPages)
 {
     Y_ABORT_UNLESS(cookie == 0, "Only the leader pack is used on load");
 

--- a/ydb/core/tablet_flat/flat_part_loader.h
+++ b/ydb/core/tablet_flat/flat_part_loader.h
@@ -32,17 +32,17 @@ namespace NTable {
             {
             }
 
-            TResult Locate(const TMemTable*, ui64, ui32) noexcept override
+            TResult Locate(const TMemTable*, ui64, ui32) override
             {
                 Y_ABORT("IPages::Locate(TMemTable*, ...) shouldn't be used here");
             }
 
-            TResult Locate(const TPart*, ui64, ELargeObj) noexcept override
+            TResult Locate(const TPart*, ui64, ELargeObj) override
             {
                 Y_ABORT("IPages::Locate(TPart*, ...) shouldn't be used here");
             }
 
-            void ProvidePart(const TPart* part) noexcept
+            void ProvidePart(const TPart* part)
             {
                 Y_ABORT_IF(Part);
                 Part = part;
@@ -73,7 +73,7 @@ namespace NTable {
                 }
             }
 
-            void EnsureNoNeedPages() const noexcept
+            void EnsureNoNeedPages() const
             {
                 Y_ABORT_UNLESS(!NeedPages);
             }
@@ -89,7 +89,7 @@ namespace NTable {
                 }
             }
 
-            void Save(ui32 cookie, NSharedCache::TEvResult::TLoaded&& loaded) noexcept
+            void Save(ui32 cookie, NSharedCache::TEvResult::TLoaded&& loaded)
             {
                 if (cookie == 0 && NeedPages.erase(loaded.PageId)) {
                     auto pageType = Cache->GetPageType(loaded.PageId);
@@ -100,7 +100,7 @@ namespace NTable {
             }
 
         private:
-            void AddSavedPage(TPageId pageId, NSharedCache::TSharedPageRef page) noexcept
+            void AddSavedPage(TPageId pageId, NSharedCache::TSharedPageRef page)
             {
                 SavedPages[pageId] = NSharedCache::TPinnedPageRef(page).GetData();
                 SavedPagesRefs.emplace_back(std::move(page));
@@ -178,7 +178,7 @@ namespace NTable {
             return { };
         }
 
-        void Save(ui64 cookie, TArrayRef<NSharedCache::TEvResult::TLoaded>) noexcept;
+        void Save(ui64 cookie, TArrayRef<NSharedCache::TEvResult::TLoaded>);
 
         constexpr static bool NeedIn(EPage page) noexcept
         {
@@ -190,7 +190,7 @@ namespace NTable {
                 || page == EPage::TxIdStats;
         }
 
-        TPartView Result() noexcept
+        TPartView Result()
         {
             Y_ABORT_UNLESS(Stage == EStage::Result);
             Y_ABORT_UNLESS(PartView, "Result may only be grabbed once");
@@ -242,7 +242,7 @@ namespace NTable {
                 (FlatGroupIndexes || BTreeGroupIndexes);
         }
 
-        void ParseMeta(TArrayRef<const char> plain) noexcept
+        void ParseMeta(TArrayRef<const char> plain)
         {
             TMemoryInput stream(plain.data(), plain.size());
             bool parsed = Root.ParseFromArcadiaStream(&stream);
@@ -250,11 +250,11 @@ namespace NTable {
             Y_ABORT_UNLESS(Root.HasEpoch(), "TPart meta has no epoch info");
         }
 
-        void StageParseMeta() noexcept;
-        TAutoPtr<NPageCollection::TFetch> StageCreatePartView(bool preloadIndex) noexcept;
-        TAutoPtr<NPageCollection::TFetch> StageSliceBounds() noexcept;
-        void StageDeltas() noexcept;
-        TAutoPtr<NPageCollection::TFetch> StagePreloadData() noexcept;
+        void StageParseMeta();
+        TAutoPtr<NPageCollection::TFetch> StageCreatePartView(bool preloadIndex);
+        TAutoPtr<NPageCollection::TFetch> StageSliceBounds();
+        void StageDeltas();
+        TAutoPtr<NPageCollection::TFetch> StagePreloadData();
 
     private:
         TVector<TIntrusivePtr<TCache>> Packs;

--- a/ydb/core/tablet_flat/flat_part_overlay.cpp
+++ b/ydb/core/tablet_flat/flat_part_overlay.cpp
@@ -42,7 +42,7 @@ namespace {
     }
 }
 
-TString TOverlay::Encode() const noexcept
+TString TOverlay::Encode() const
 {
     if (!Screen && !Slices) {
         return { };
@@ -76,7 +76,7 @@ TString TOverlay::Encode() const noexcept
     return encoded;
 }
 
-TOverlay TOverlay::Decode(TArrayRef<const char> opaque, TArrayRef<const char> opaqueExt) noexcept
+TOverlay TOverlay::Decode(TArrayRef<const char> opaque, TArrayRef<const char> opaqueExt)
 {
     TOverlay overlay;
 
@@ -123,7 +123,7 @@ TOverlay TOverlay::Decode(TArrayRef<const char> opaque, TArrayRef<const char> op
     return overlay;
 }
 
-void TOverlay::Validate() const noexcept
+void TOverlay::Validate() const
 {
     if (Screen) {
         Screen->Validate();
@@ -171,7 +171,7 @@ void TOverlay::Validate() const noexcept
     }
 }
 
-void TOverlay::ApplyDelta(TArrayRef<const char> rawDelta) noexcept
+void TOverlay::ApplyDelta(TArrayRef<const char> rawDelta)
 {
     NProto::TOverlayDelta plain;
 
@@ -199,7 +199,7 @@ void TOverlay::ApplyDelta(TArrayRef<const char> rawDelta) noexcept
     }
 }
 
-TString TOverlay::EncodeRemoveSlices(const TIntrusiveConstPtr<TSlices>& slices) noexcept
+TString TOverlay::EncodeRemoveSlices(const TIntrusiveConstPtr<TSlices>& slices)
 {
     NProto::TOverlayDelta plain;
 
@@ -212,7 +212,7 @@ TString TOverlay::EncodeRemoveSlices(const TIntrusiveConstPtr<TSlices>& slices) 
     return encoded;
 }
 
-TString TOverlay::EncodeChangeSlices(TConstArrayRef<TSlice> slices) noexcept
+TString TOverlay::EncodeChangeSlices(TConstArrayRef<TSlice> slices)
 {
     NProto::TOverlayDelta plain;
 
@@ -225,7 +225,7 @@ TString TOverlay::EncodeChangeSlices(TConstArrayRef<TSlice> slices) noexcept
     return encoded;
 }
 
-TString TOverlay::MaybeUnsplitSlices(const TString& opaque, size_t maxSize) noexcept
+TString TOverlay::MaybeUnsplitSlices(const TString& opaque, size_t maxSize)
 {
     if (opaque.size() <= maxSize) {
         return { };

--- a/ydb/core/tablet_flat/flat_part_overlay.h
+++ b/ydb/core/tablet_flat/flat_part_overlay.h
@@ -8,21 +8,21 @@ namespace NKikimr {
 namespace NTable {
 
     struct TOverlay {
-        static TOverlay Decode(TArrayRef<const char> opaque, TArrayRef<const char> ext) noexcept;
-        TString Encode() const noexcept;
-        void Validate() const noexcept;
+        static TOverlay Decode(TArrayRef<const char> opaque, TArrayRef<const char> ext);
+        TString Encode() const;
+        void Validate() const;
 
-        void ApplyDelta(TArrayRef<const char> delta) noexcept;
+        void ApplyDelta(TArrayRef<const char> delta);
 
-        static TString EncodeRemoveSlices(const TIntrusiveConstPtr<TSlices>& slices) noexcept;
-        static TString EncodeChangeSlices(TConstArrayRef<TSlice> slices) noexcept;
+        static TString EncodeRemoveSlices(const TIntrusiveConstPtr<TSlices>& slices);
+        static TString EncodeChangeSlices(TConstArrayRef<TSlice> slices);
 
         /**
          * Returns a modified opaque with redundant splits in slices stitched back
          *
          * Returns an empty string if no modifications are needed
          */
-        static TString MaybeUnsplitSlices(const TString& opaque, size_t maxSize = 1024 * 1024) noexcept;
+        static TString MaybeUnsplitSlices(const TString& opaque, size_t maxSize = 1024 * 1024);
 
         TIntrusiveConstPtr<TScreen> Screen;
         TIntrusiveConstPtr<TSlices> Slices;

--- a/ydb/core/tablet_flat/flat_part_scheme.h
+++ b/ydb/core/tablet_flat/flat_part_scheme.h
@@ -103,7 +103,7 @@ namespace NTable {
             }
         }
 
-        const TGroupInfo& GetLayout(NPage::TGroupId groupId) const noexcept
+        const TGroupInfo& GetLayout(NPage::TGroupId groupId) const
         {
             Y_ABORT_UNLESS(groupId.Index < Groups.size(), "Group is out of range");
 

--- a/ydb/core/tablet_flat/flat_part_screen.h
+++ b/ydb/core/tablet_flat/flat_part_screen.h
@@ -55,14 +55,14 @@ namespace NTable {
         };
 
         struct TCook {
-            TDeque<THole> Unwrap() noexcept
+            TDeque<THole> Unwrap()
             {
                 Pass(Max<TRowId>()); /* will flush current hole */
 
                 return std::exchange(Holes, TDeque<THole>{ });
             }
 
-            void Pass(TRowId ref) noexcept
+            void Pass(TRowId ref)
             {
                 Y_ABORT_UNLESS(Tail <= ref, "Got page ref from the past");
 
@@ -135,7 +135,7 @@ namespace NTable {
                 && std::equal(begin(), end(), screen.begin());
         }
 
-        size_t Lookup(TRowId rowId, int dir) const noexcept
+        size_t Lookup(TRowId rowId, int dir) const
         {
             Y_ABORT_UNLESS(dir == +1, "Only forward direction supported");
 
@@ -161,7 +161,7 @@ namespace NTable {
                     Holes ? Holes.back().End : Max<TRowId>() );
         }
 
-        void Validate() const noexcept
+        void Validate() const
         {
             TRowId last = 0;
             for (const auto &hole : Holes) {
@@ -170,7 +170,7 @@ namespace NTable {
             }
         }
 
-        static TIntrusiveConstPtr<TScreen> Cut(TIntrusiveConstPtr<TScreen> scr, THole hole) noexcept
+        static TIntrusiveConstPtr<TScreen> Cut(TIntrusiveConstPtr<TScreen> scr, THole hole)
         {
             if (hole == THole(true)) {
                 return scr;

--- a/ydb/core/tablet_flat/flat_part_slice.cpp
+++ b/ydb/core/tablet_flat/flat_part_slice.cpp
@@ -10,7 +10,7 @@ namespace NTable {
 
 namespace {
 
-void PrintCells(IOutputStream& out, TArrayRef<const TCell> cells, const TCellDefaults& cellDefaults) noexcept
+void PrintCells(IOutputStream& out, TArrayRef<const TCell> cells, const TCellDefaults& cellDefaults)
 {
     out << '{';
     size_t pos = 0;
@@ -44,7 +44,7 @@ bool ValidateSlices(TConstArrayRef<TSlice> slices) noexcept
 
 ////////////////////////////////////////////////////////////////////////////////
 
-int ComparePartKeys(TCellsRef left, TCellsRef right, const TKeyCellDefaults &keyDefaults) noexcept {
+int ComparePartKeys(TCellsRef left, TCellsRef right, const TKeyCellDefaults &keyDefaults) {
     size_t end = Max(left.size(), right.size());
     Y_DEBUG_ABORT_UNLESS(end <= keyDefaults.Size(), "Key schema is smaller than compared keys");
 
@@ -61,7 +61,7 @@ int ComparePartKeys(TCellsRef left, TCellsRef right, const TKeyCellDefaults &key
 
 ////////////////////////////////////////////////////////////////////////////////
 
-void TBounds::Describe(IOutputStream& out, const TKeyCellDefaults& keyDefaults) const noexcept
+void TBounds::Describe(IOutputStream& out, const TKeyCellDefaults& keyDefaults) const
 {
     auto left = FirstKey.GetCells();
     auto right = LastKey.GetCells();
@@ -80,7 +80,7 @@ void TBounds::Describe(IOutputStream& out, const TKeyCellDefaults& keyDefaults) 
     out << (LastInclusive ? ']' : ')');
 }
 
-bool TBounds::LessByKey(const TBounds& a, const TBounds& b, const TKeyCellDefaults& keyDefaults) noexcept
+bool TBounds::LessByKey(const TBounds& a, const TBounds& b, const TKeyCellDefaults& keyDefaults)
 {
     auto left = a.LastKey.GetCells();
     auto right = b.FirstKey.GetCells();
@@ -112,7 +112,7 @@ bool TBounds::LessByKey(const TBounds& a, const TBounds& b, const TKeyCellDefaul
 int TBounds::CompareSearchKeyFirstKey(
         TArrayRef<const TCell> key,
         const TBounds& bounds,
-        const TKeyCellDefaults& keyDefaults) noexcept
+        const TKeyCellDefaults& keyDefaults)
 {
     if (!key) {
         // Search key is +inf => +inf > any
@@ -145,7 +145,7 @@ int TBounds::CompareSearchKeyFirstKey(
 int TBounds::CompareLastKeySearchKey(
         const TBounds& bounds,
         TArrayRef<const TCell> key,
-        const TKeyCellDefaults& keyDefaults) noexcept
+        const TKeyCellDefaults& keyDefaults)
 {
     auto left = bounds.LastKey.GetCells();
     if (Y_UNLIKELY(!left)) {
@@ -179,7 +179,7 @@ int TBounds::CompareLastKeySearchKey(
 
 ////////////////////////////////////////////////////////////////////////////////
 
-void TSlice::Describe(IOutputStream& out) const noexcept
+void TSlice::Describe(IOutputStream& out) const
 {
     out << (FirstInclusive ? '[' : '(');
     out << FirstRowId;
@@ -192,7 +192,7 @@ void TSlice::Describe(IOutputStream& out) const noexcept
     out << (LastInclusive ? ']' : ')');
 }
 
-void TSlices::Describe(IOutputStream& out) const noexcept
+void TSlices::Describe(IOutputStream& out) const
 {
     bool first = true;
     out << "{ ";
@@ -206,7 +206,7 @@ void TSlices::Describe(IOutputStream& out) const noexcept
     out << (first ? "}" : " }");
 }
 
-void TSlices::Validate() const noexcept
+void TSlices::Validate() const
 {
     TRowId lastEnd = 0;
     for (const auto& bounds : *this) {
@@ -230,7 +230,7 @@ void TSlices::Validate() const noexcept
     }
 }
 
-TIntrusiveConstPtr<TScreen> TSlices::ToScreen() const noexcept
+TIntrusiveConstPtr<TScreen> TSlices::ToScreen() const
 {
     TVector<TScreen::THole> holes;
     auto it = IterateRowRanges();
@@ -290,7 +290,7 @@ bool TSlices::SupersetByRowId(const TIntrusiveConstPtr<TSlices>& a, const TIntru
 
 TIntrusiveConstPtr<TSlices> TSlices::Subtract(
         const TIntrusiveConstPtr<TSlices>& a,
-        const TIntrusiveConstPtr<TSlices>& b) noexcept
+        const TIntrusiveConstPtr<TSlices>& b)
 {
     if (!a || a->empty() || !b || b->empty()) {
         return a; // there's nothing to remove
@@ -377,7 +377,7 @@ TIntrusiveConstPtr<TSlices> TSlices::Subtract(
 
 TIntrusiveConstPtr<TSlices> TSlices::Merge(
         const TIntrusiveConstPtr<TSlices>& a,
-        const TIntrusiveConstPtr<TSlices>& b) noexcept
+        const TIntrusiveConstPtr<TSlices>& b)
 {
     if (!b || b->empty()) {
         return a;
@@ -430,7 +430,7 @@ TIntrusiveConstPtr<TSlices> TSlices::Cut(
         TRowId beginRowId,
         TRowId endRowId,
         TConstArrayRef<TCell> beginKey,
-        TConstArrayRef<TCell> endKey) noexcept
+        TConstArrayRef<TCell> endKey)
 {
     if (!run || run->empty()) {
         return run;
@@ -491,7 +491,7 @@ TIntrusiveConstPtr<TSlices> TSlices::Cut(
     return result;
 }
 
-TIntrusiveConstPtr<TSlices> TSlices::Replace(TIntrusiveConstPtr<TSlices> run, TConstArrayRef<TSlice> slices) noexcept
+TIntrusiveConstPtr<TSlices> TSlices::Replace(TIntrusiveConstPtr<TSlices> run, TConstArrayRef<TSlice> slices)
 {
     Y_ABORT_UNLESS(run && !run->empty());
     Y_ABORT_UNLESS(slices);

--- a/ydb/core/tablet_flat/flat_part_slice.h
+++ b/ydb/core/tablet_flat/flat_part_slice.h
@@ -13,7 +13,7 @@ namespace NTable {
     /**
      * A very simple comparator for part keys (extended with schema defaults)
      */
-    int ComparePartKeys(TCellsRef left, TCellsRef right, const TKeyCellDefaults &keyDefaults) noexcept;
+    int ComparePartKeys(TCellsRef left, TCellsRef right, const TKeyCellDefaults &keyDefaults);
 
     /**
      * Bounds for a range of keys
@@ -41,12 +41,12 @@ namespace NTable {
         {
         }
 
-        void Describe(IOutputStream& out, const TKeyCellDefaults& keyDefaults) const noexcept;
+        void Describe(IOutputStream& out, const TKeyCellDefaults& keyDefaults) const;
 
         /**
          * Returns true if a is less than b without any intersections
          */
-        static bool LessByKey(const TBounds& a, const TBounds& b, const TKeyCellDefaults& keyDefaults) noexcept;
+        static bool LessByKey(const TBounds& a, const TBounds& b, const TKeyCellDefaults& keyDefaults);
 
         /**
          * Compares search key and bounds first key
@@ -56,7 +56,7 @@ namespace NTable {
         static int CompareSearchKeyFirstKey(
                 TArrayRef<const TCell> key,
                 const TBounds& bounds,
-                const TKeyCellDefaults& keyDefaults) noexcept;
+                const TKeyCellDefaults& keyDefaults);
 
         /**
          * Compares bounds last key and search key
@@ -66,7 +66,7 @@ namespace NTable {
         static int CompareLastKeySearchKey(
                 const TBounds& bounds,
                 TArrayRef<const TCell> key,
-                const TKeyCellDefaults& keyDefaults) noexcept;
+                const TKeyCellDefaults& keyDefaults);
     };
 
     /**
@@ -132,7 +132,7 @@ namespace NTable {
             return EndRowId() - BeginRowId();
         }
 
-        void Describe(IOutputStream& out) const noexcept;
+        void Describe(IOutputStream& out) const;
 
         /**
          * Returns true if first row of a is less than first row of b
@@ -326,24 +326,24 @@ namespace NTable {
             return TSlicesRowsIterator(*this);
         }
 
-        void Describe(IOutputStream& out) const noexcept;
+        void Describe(IOutputStream& out) const;
 
         /**
          * Validate slices are correct, crash otherwise
          */
-        void Validate() const noexcept;
+        void Validate() const;
 
         /**
          * Converts run to a matching screen
          */
-        TIntrusiveConstPtr<TScreen> ToScreen() const noexcept;
+        TIntrusiveConstPtr<TScreen> ToScreen() const;
 
         /**
          * Returns a special run that includes all possible rows
          *
          * Currently only used in tests when bounds are unavailable
          */
-        static TIntrusiveConstPtr<TSlices> All() noexcept
+        static TIntrusiveConstPtr<TSlices> All()
         {
             TIntrusivePtr<TSlices> run = new TSlices;
             run->emplace_back();
@@ -363,13 +363,13 @@ namespace NTable {
         /**
          * Returns the result of removing b from a
          */
-        static TIntrusiveConstPtr<TSlices> Subtract(const TIntrusiveConstPtr<TSlices>& a, const TIntrusiveConstPtr<TSlices>& b) noexcept;
+        static TIntrusiveConstPtr<TSlices> Subtract(const TIntrusiveConstPtr<TSlices>& a, const TIntrusiveConstPtr<TSlices>& b);
 
         /**
          * Merges two sorted runs
          * Runs may intersect in which case they are merged
          */
-        static TIntrusiveConstPtr<TSlices> Merge(const TIntrusiveConstPtr<TSlices>& a, const TIntrusiveConstPtr<TSlices>& b) noexcept;
+        static TIntrusiveConstPtr<TSlices> Merge(const TIntrusiveConstPtr<TSlices>& a, const TIntrusiveConstPtr<TSlices>& b);
 
         /**
          * Cuts run using [begin,end) range of row ids, with specified keys
@@ -381,12 +381,12 @@ namespace NTable {
                 TRowId beginRowId,
                 TRowId endRowId,
                 TConstArrayRef<TCell> beginKey,
-                TConstArrayRef<TCell> endKey) noexcept;
+                TConstArrayRef<TCell> endKey);
 
         /**
          * Replaces row ranges with new slices in the specified run
          */
-        static TIntrusiveConstPtr<TSlices> Replace(TIntrusiveConstPtr<TSlices> run, TConstArrayRef<TSlice> slices) noexcept;
+        static TIntrusiveConstPtr<TSlices> Replace(TIntrusiveConstPtr<TSlices> run, TConstArrayRef<TSlice> slices);
 
         /**
          * Walks backwards until the first potential intersection with [0, rowId] range

--- a/ydb/core/tablet_flat/flat_part_store.h
+++ b/ydb/core/tablet_flat/flat_part_store.h
@@ -54,12 +54,12 @@ public:
 
     }
 
-    const TLogoBlobID& BundleId() const override
+    const TLogoBlobID& BundleId() const noexcept override
     {
         return PageCollections[0]->PageCollection->Label();
     }
 
-    ui64 BackingSize() const override
+    ui64 BackingSize() const noexcept override
     {
         ui64 size = 0;
         for (const auto &cache : PageCollections) {
@@ -68,7 +68,7 @@ public:
         return size;
     }
 
-    ui64 DataSize() const override
+    ui64 DataSize() const noexcept override
     {
         return BackingSize() - IndexesRawSize;
     }
@@ -125,7 +125,7 @@ public:
         return dynamic_cast<const NPageCollection::TPageCollection*>(pageCollection);
     }
 
-    TCache* Locate(ELargeObj lob, ui64 ref) const noexcept
+    TCache* Locate(ELargeObj lob, ui64 ref) const
     {
         if ((lob != ELargeObj::Extern && lob != ELargeObj::Outer) || (ref >> 32)) {
             Y_Fail("Invalid ref ELargeObj{" << int(lob) << ", " << ref << "}");
@@ -134,7 +134,7 @@ public:
         return (lob == ELargeObj::Extern ? Pseudo : PageCollections.at(GroupsCount)).Get();
     }
 
-    TAutoPtr<NPageCollection::TFetch> GetPages(ui32 room) const noexcept
+    TAutoPtr<NPageCollection::TFetch> GetPages(ui32 room) const
     {
         Y_ABORT_UNLESS(room < PageCollections.size());
 
@@ -148,7 +148,7 @@ public:
         return new NPageCollection::TFetch{ 0, PageCollections[room]->PageCollection, std::move(pages) };
     }
 
-    static TVector<TIntrusivePtr<TCache>> Construct(TVector<TPageCollectionComponents> components) noexcept
+    static TVector<TIntrusivePtr<TCache>> Construct(TVector<TPageCollectionComponents> components)
     {
         TVector<TIntrusivePtr<TCache>> caches;
 
@@ -159,7 +159,7 @@ public:
         return caches;
     }
 
-    static TArrayRef<const TIntrusivePtr<TCache>> Storages(const TPartView &partView) noexcept
+    static TArrayRef<const TIntrusivePtr<TCache>> Storages(const TPartView &partView)
     {
         auto *part = partView.As<TPartStore>();
 
@@ -179,15 +179,15 @@ public:
         , DataId(dataId)
     { }
 
-    const NPageCollection::TLargeGlobId& GetDataId() const {
+    const NPageCollection::TLargeGlobId& GetDataId() const noexcept {
         return DataId;
     }
 
-    const TLogoBlobID& BundleId() const override {
+    const TLogoBlobID& BundleId() const noexcept override {
         return DataId.Lead;
     }
 
-    ui64 BackingSize() const override {
+    ui64 BackingSize() const noexcept override {
         return DataId.Bytes;
     }
 

--- a/ydb/core/tablet_flat/flat_range_cache.h
+++ b/ydb/core/tablet_flat/flat_range_cache.h
@@ -65,14 +65,14 @@ public:
         TArrayRef<const TCell> Key;
     };
 
-    int CompareKeys(TArrayRef<const TCell> a, TArrayRef<const TCell> b) const noexcept {
+    int CompareKeys(TArrayRef<const TCell> a, TArrayRef<const TCell> b) const {
         Y_DEBUG_ABORT_UNLESS(a.size() == KeyTypes.size());
         Y_DEBUG_ABORT_UNLESS(b.size() == KeyTypes.size());
         return CompareTypedCellVectors(a.data(), b.data(), KeyTypes.data(), KeyTypes.size());
     }
 
     template<class TPoint>
-    bool PointLessThanLeftBorder(const TPoint& a, const TKeyRangeEntry& b) const noexcept {
+    bool PointLessThanLeftBorder(const TPoint& a, const TKeyRangeEntry& b) const {
         Y_DEBUG_ABORT_UNLESS(a.Key.size() == KeyTypes.size());
         Y_DEBUG_ABORT_UNLESS(b.FromKey.size() == KeyTypes.size());
         if (int cmp = CompareTypedCellVectors(a.Key.data(), b.FromKey.data(), KeyTypes.data(), KeyTypes.size())) {
@@ -82,7 +82,7 @@ public:
     }
 
     template<class TPoint>
-    bool RightBorderLessThanPoint(const TKeyRangeEntry& a, const TPoint& b) const noexcept {
+    bool RightBorderLessThanPoint(const TKeyRangeEntry& a, const TPoint& b) const {
         Y_DEBUG_ABORT_UNLESS(b.Key.size() == KeyTypes.size());
         if (!a.ToKey) {
             // the left ends at +inf
@@ -95,23 +95,23 @@ public:
         return !a.ToInclusive;
     }
 
-    bool operator()(const TSearchPoint& a, const TKeyRangeEntry& b) const noexcept {
+    bool operator()(const TSearchPoint& a, const TKeyRangeEntry& b) const {
         return PointLessThanLeftBorder(a, b);
     }
 
-    bool operator()(const TKeyRangeEntry& a, const TSearchPoint& b) const noexcept {
+    bool operator()(const TKeyRangeEntry& a, const TSearchPoint& b) const {
         return RightBorderLessThanPoint(a, b);
     }
 
-    bool operator()(const TKeyRangeEntry& a, const TLowerBound& b) const noexcept {
+    bool operator()(const TKeyRangeEntry& a, const TLowerBound& b) const {
         return RightBorderLessThanPoint(a, b);
     }
 
-    bool operator()(const TLowerBoundReverse& a, const TKeyRangeEntry& b) const noexcept {
+    bool operator()(const TLowerBoundReverse& a, const TKeyRangeEntry& b) const {
         return PointLessThanLeftBorder(a, b);
     }
 
-    bool operator()(const TKeyRangeEntry& a, const TKeyRangeEntry& b) const noexcept {
+    bool operator()(const TKeyRangeEntry& a, const TKeyRangeEntry& b) const {
         Y_DEBUG_ABORT_UNLESS(b.FromKey.size() == KeyTypes.size());
         if (!a.ToKey) {
             // the left ends at +inf
@@ -143,7 +143,7 @@ private:
 
     class TChunk : public TIntrusiveListItem<TChunk> {
     public:
-        TChunk(size_t size) noexcept
+        TChunk(size_t size)
             : Next_(Data())
             , Left_(size)
         {
@@ -151,7 +151,7 @@ private:
             Y_DEBUG_ABORT_UNLESS(AlignUp(Left_) == Left_, "Chunk size is not properly aligned");
         }
 
-        void* Allocate(size_t len) noexcept {
+        void* Allocate(size_t len) {
             Y_DEBUG_ABORT_UNLESS(AlignUp(len) == len, "Chunk allocation is not aligned");
 
             if (len > Left_) {
@@ -164,7 +164,7 @@ private:
             return ptr;
         }
 
-        bool Deallocate(void* ptr, size_t len) noexcept {
+        bool Deallocate(void* ptr, size_t len) {
             Y_DEBUG_ABORT_UNLESS(AlignUp(len) == len, "Chunk allocation is not aligned");
 
             if (Used() < len) {
@@ -206,11 +206,11 @@ private:
     };
 
 public:
-    ~TSpecialMemoryPool() noexcept {
+    ~TSpecialMemoryPool() {
         Clear();
     }
 
-    void Clear() noexcept {
+    void Clear() {
         Current = nullptr;
         while (!Chunks.Empty()) {
             TChunk* chunk = Chunks.PopBack();
@@ -255,7 +255,7 @@ public:
         return ptr;
     }
 
-    void Deallocate(void* ptr, size_t len) noexcept {
+    void Deallocate(void* ptr, size_t len) {
         len = AlignUp(len);
         Y_DEBUG_ABORT_UNLESS(Current, "Deallocate from an empty pool, possible bug");
         Y_DEBUG_ABORT_UNLESS(TotalUsed_ >= len, "Used memory underflow, possible bug");
@@ -368,7 +368,7 @@ private:
             return TBase::allocate(n);
         }
 
-        void deallocate(T* ptr, size_t n) noexcept {
+        void deallocate(T* ptr, size_t n) {
             auto size = sizeof(T) * n;
             Y_DEBUG_ABORT_UNLESS(*UsedMemory >= size);
             *UsedMemory -= size;

--- a/ydb/core/tablet_flat/flat_redo_player.h
+++ b/ydb/core/tablet_flat/flat_redo_player.h
@@ -15,7 +15,7 @@ namespace NRedo {
     public:
         TReader(TArrayRef<const char> plain): Plain(plain), On(Plain.data()) { }
 
-        TArrayRef<const char> Next() noexcept
+        TArrayRef<const char> Next()
         {
             if (On >= Plain.end()) {
                 return { nullptr, size_t(0) };

--- a/ydb/core/tablet_flat/flat_redo_writer.h
+++ b/ydb/core/tablet_flat/flat_redo_writer.h
@@ -44,8 +44,8 @@ namespace NRedo {
             single family tables but it is not scaled to multiple families.
          */
 
-        virtual TLimit Limit(ui32 table) noexcept = 0;
-        virtual TResult Place(ui32 table, TTag, TArrayRef<const char>) noexcept = 0;
+        virtual TLimit Limit(ui32 table) = 0;
+        virtual TResult Place(ui32 table, TTag, TArrayRef<const char>) = 0;
     };
 
     class TWriter {
@@ -203,7 +203,7 @@ namespace NRedo {
             return *this;
         }
 
-        TString Finish() && noexcept
+        TString Finish() &&
         {
             TString events;
             events.swap(Events);
@@ -254,7 +254,7 @@ namespace NRedo {
             return size;
         }
 
-        void Write(IOut &out, TRawVals key) noexcept
+        void Write(IOut &out, TRawVals key)
         {
             for (const auto &one : key) {
                 /* The only way of converting nulls in keys now */
@@ -268,7 +268,7 @@ namespace NRedo {
             }
         }
 
-        void Write(IOut &out, TOpsRef ops) noexcept
+        void Write(IOut &out, TOpsRef ops)
         {
             for (const auto &one: ops) {
                 /* Log enty cannot represent this ECellOp types with payload */

--- a/ydb/core/tablet_flat/flat_row_misc.h
+++ b/ydb/core/tablet_flat/flat_row_misc.h
@@ -35,7 +35,7 @@ namespace NFmt {
             Y_ABORT_UNLESS(cells.size() == Types.size(), "Cells and types size missmatch");
         }
 
-        TOut& Do(TOut &out) const noexcept
+        TOut& Do(TOut &out) const
         {
             TDbTupleRef tp{ Types.begin(), Cells.begin(), ui32(Cells.size()) };
 

--- a/ydb/core/tablet_flat/flat_row_nulls.h
+++ b/ydb/core/tablet_flat/flat_row_nulls.h
@@ -35,7 +35,7 @@ namespace NTable {
         static TIntrusiveConstPtr<TSelf> Make(
                 TArrayRef<const TType> types,
                 TArrayRef<const TOrder> order,
-                TArrayRef<const TCell> defs) noexcept
+                TArrayRef<const TCell> defs)
         {
             size_t offT = AlignUp(sizeof(TSelf));
             size_t offO = offT + AlignUp(sizeof(TType) * types.size());
@@ -124,7 +124,7 @@ namespace NTable {
     public:
         static TIntrusiveConstPtr<TRowCellDefaults> Make(
                 TArrayRef<const TType> types,
-                TArrayRef<const TCell> defs) noexcept
+                TArrayRef<const TCell> defs)
         {
             return TCellDefaults::Make<TRowCellDefaults>(types, { }, defs);
         }
@@ -149,7 +149,7 @@ namespace NTable {
     public:
         static TIntrusiveConstPtr<TKeyCellDefaults> Make(
                 TArrayRef<const TOrder> order,
-                TArrayRef<const TCell> defs) noexcept
+                TArrayRef<const TCell> defs)
         {
             TStackVec<TType> types;
             types.reserve(order.size());

--- a/ydb/core/tablet_flat/flat_row_scheme.h
+++ b/ydb/core/tablet_flat/flat_row_scheme.h
@@ -29,7 +29,7 @@ namespace NTable {
                 Cells[idx] = cell;
             }
 
-            TIntrusiveConstPtr<TNullsType> operator*() const noexcept
+            TIntrusiveConstPtr<TNullsType> operator*() const
             {
                 return TNullsType::Make(Types, Cells);
             }
@@ -109,7 +109,7 @@ namespace NTable {
             return ci == ByTag.end() ? nullptr : &Cols[ci->second];
         }
 
-        TVector<ui32> Tags(bool keysOnly = false) const noexcept
+        TVector<ui32> Tags(bool keysOnly = false) const
         {
             TVector<ui32> tags; /* ordered by value tags */
 

--- a/ydb/core/tablet_flat/flat_row_state.h
+++ b/ydb/core/tablet_flat/flat_row_state.h
@@ -50,7 +50,7 @@ namespace NTable {
             return Rop;
         }
 
-        bool Touch(ERowOp op) noexcept
+        bool Touch(ERowOp op)
         {
             Y_ABORT_UNLESS(!(Rop == ERowOp::Erase || Rop == ERowOp::Reset),
                 "Sequence for row state is already finalized");
@@ -68,7 +68,7 @@ namespace NTable {
             }
         }
 
-        void Set(TPos on, TCellOp code, const TCell &cell) noexcept
+        void Set(TPos on, TCellOp code, const TCell &cell)
         {
             Y_ABORT_UNLESS(State[on] == ECellOp::Empty, "Updating cell that already has a value assigned");
 
@@ -101,7 +101,7 @@ namespace NTable {
             }
         }
 
-        void Merge(const TRowState& other) noexcept {
+        void Merge(const TRowState& other) {
             Y_ABORT_UNLESS(!(Rop == ERowOp::Erase || Rop == ERowOp::Reset),
                 "Sequence for row state is already finalized");
 

--- a/ydb/core/tablet_flat/flat_sausage_align.h
+++ b/ydb/core/tablet_flat/flat_sausage_align.h
@@ -10,7 +10,7 @@ namespace NPageCollection {
     public:
         TAlign(TArrayRef<const ui64> steps) : Steps(steps) { }
 
-        TBorder Lookup(ui64 offset, const ui64 sz) const noexcept
+        TBorder Lookup(ui64 offset, const ui64 sz) const
         {
             auto it = UpperBound(Steps.begin(), Steps.end(), offset);
             Y_ABORT_UNLESS(it != Steps.end(), "Lookup span is out of borders");

--- a/ydb/core/tablet_flat/flat_sausage_chop.h
+++ b/ydb/core/tablet_flat/flat_sausage_chop.h
@@ -35,7 +35,7 @@ namespace NPageCollection {
                 && left.Cookie() != TLogoBlobID::MaxCookie - way;
         }
 
-        static TLargeGlobId ToLargeGlobId(TArray logo, ui32 group = TLargeGlobId::InvalidGroup) noexcept
+        static TLargeGlobId ToLargeGlobId(TArray logo, ui32 group = TLargeGlobId::InvalidGroup)
         {
             if (logo) {
                 for (auto num : xrange(logo.size())) {

--- a/ydb/core/tablet_flat/flat_sausage_fetch.h
+++ b/ydb/core/tablet_flat/flat_sausage_fetch.h
@@ -17,7 +17,7 @@ namespace NPageCollection {
 
         }
 
-        void Describe(IOutputStream &out) const noexcept
+        void Describe(IOutputStream &out) const
         {
             out
                 << "Fetch{" << Pages.size() << " pages"

--- a/ydb/core/tablet_flat/flat_sausage_flow.h
+++ b/ydb/core/tablet_flat/flat_sausage_flow.h
@@ -12,7 +12,7 @@ namespace NPageCollection {
     public:
         struct TReadPortion {
 
-            void Describe(IOutputStream &out) const noexcept
+            void Describe(IOutputStream &out) const
             {
                 out
                     << "{" << Slot << "p +" << Skip << "b " << Size << "b}";
@@ -55,7 +55,7 @@ namespace NPageCollection {
             return Tail >= Slice.size();
         }
 
-        TReadPortionRange Grow(ui64 bytes) noexcept
+        TReadPortionRange Grow(ui64 bytes)
         {
             const ui32 from = Queue.size();
             const ui64 limit = OnHold + Min(Max<ui64>() - OnHold, bytes);

--- a/ydb/core/tablet_flat/flat_sausage_grind.h
+++ b/ydb/core/tablet_flat/flat_sausage_grind.h
@@ -62,14 +62,14 @@ namespace NPageCollection {
             State.resize(Group.size(), 0);
         }
 
-        void Describe(IOutputStream &out) const noexcept
+        void Describe(IOutputStream &out) const
         {
             out
                 << "Cookies{" << Tablet << ":" << Gen << ":" << Step
                 << " cookieRange[" << CookieRange.Head << " +" << Span << "]}";
         }
 
-        ui32 GroupBy(ui8 channel) const noexcept
+        ui32 GroupBy(ui8 channel) const
         {
             return Group[Locate(channel)];
         }
@@ -79,7 +79,7 @@ namespace NPageCollection {
             return (ui64(Gen) << 32) | Step;
         }
 
-        TGlobId Do(ui8 channel, ui32 bytes) noexcept
+        TGlobId Do(ui8 channel, ui32 bytes)
         {
             const auto slot = Locate(channel);
 
@@ -90,7 +90,7 @@ namespace NPageCollection {
             return { lead, Group[slot] };
         }
 
-        TLargeGlobId Do(ui8 cnl, ui32 bytes, ui32 lim) noexcept
+        TLargeGlobId Do(ui8 cnl, ui32 bytes, ui32 lim)
         {
             const auto slot = Locate(cnl);
 
@@ -105,7 +105,7 @@ namespace NPageCollection {
         }
 
     private:
-        ui8 Locate(ui8 channel) const noexcept
+        ui8 Locate(ui8 channel) const
         {
             auto slot = Slots[channel];
 
@@ -114,7 +114,7 @@ namespace NPageCollection {
             return slot;
         }
 
-        ui32 Allocate(ui8 slot, ui32 num, bool gap) noexcept
+        ui32 Allocate(ui8 slot, ui32 num, bool gap)
         {
             auto &value = State.at(slot);
 
@@ -148,7 +148,7 @@ namespace NPageCollection {
     public:
         using TCookieAllocator::TCookieAllocator;
 
-        void Switch(const ui32 step, bool strict) noexcept
+        void Switch(const ui32 step, bool strict)
         {
             if (step == Max<ui32>()) {
                 Y_Fail(NFmt::Do(*this) << " is out of steps capacity");

--- a/ydb/core/tablet_flat/flat_sausage_gut.h
+++ b/ydb/core/tablet_flat/flat_sausage_gut.h
@@ -12,10 +12,10 @@ namespace NPageCollection {
 
         virtual const TLogoBlobID& Label() const noexcept = 0;
         virtual ui32 Total() const noexcept = 0;
-        virtual TInfo Page(ui32 page) const noexcept = 0;
-        virtual TBorder Bounds(ui32 page) const noexcept = 0;
-        virtual TGlobId Glob(ui32 blob) const noexcept = 0;
-        virtual bool Verify(ui32 page, TArrayRef<const char>) const noexcept = 0;
+        virtual TInfo Page(ui32 page) const = 0;
+        virtual TBorder Bounds(ui32 page) const = 0;
+        virtual TGlobId Glob(ui32 blob) const = 0;
+        virtual bool Verify(ui32 page, TArrayRef<const char>) const = 0;
         virtual size_t BackingSize() const noexcept = 0;
     };
 

--- a/ydb/core/tablet_flat/flat_sausage_meta.cpp
+++ b/ydb/core/tablet_flat/flat_sausage_meta.cpp
@@ -41,7 +41,7 @@ size_t TMeta::BackingSize() const noexcept
     return Steps ? Steps.back() : 0;
 }
 
-TBorder TMeta::Bounds(ui32 begin, ui32 end) const noexcept
+TBorder TMeta::Bounds(ui32 begin, ui32 end) const
 {
     Y_ABORT_UNLESS(begin <= end && Max(begin, end) < Header->Pages);
 
@@ -50,7 +50,7 @@ TBorder TMeta::Bounds(ui32 begin, ui32 end) const noexcept
     return TAlign(Steps).Lookup(offset, Index[end].Page - offset);
 }
 
-TInfo TMeta::Page(ui32 page) const noexcept
+TInfo TMeta::Page(ui32 page) const
 {
     Y_ABORT_UNLESS(page < Header->Pages,
             "Requested page %" PRIu32 " out of %" PRIu32 " total pages",
@@ -59,19 +59,19 @@ TInfo TMeta::Page(ui32 page) const noexcept
     return { GetPageSize(page), Extra[page].Type };
 }
 
-ui32 TMeta::GetPageType(ui32 pageId) const noexcept
+ui32 TMeta::GetPageType(ui32 pageId) const
 {
     Y_DEBUG_ABORT_UNLESS(pageId < Header->Pages);
     return Extra[pageId].Type;
 }
 
-ui32 TMeta::GetPageChecksum(ui32 pageId) const noexcept
+ui32 TMeta::GetPageChecksum(ui32 pageId) const
 {
     Y_DEBUG_ABORT_UNLESS(pageId < Header->Pages);
     return Extra[pageId].Crc32;
 }
 
-ui64 TMeta::GetPageSize(ui32 pageId) const noexcept
+ui64 TMeta::GetPageSize(ui32 pageId) const
 {
     Y_DEBUG_ABORT_UNLESS(pageId < Header->Pages);
 
@@ -79,7 +79,7 @@ ui64 TMeta::GetPageSize(ui32 pageId) const noexcept
     return Index[pageId].Page - begin;
 }
 
-TStringBuf TMeta::GetPageInplaceData(ui32 pageId) const noexcept
+TStringBuf TMeta::GetPageInplaceData(ui32 pageId) const
 {
     Y_DEBUG_ABORT_UNLESS(pageId < Header->Pages);
 

--- a/ydb/core/tablet_flat/flat_sausage_meta.h
+++ b/ydb/core/tablet_flat/flat_sausage_meta.h
@@ -14,7 +14,7 @@ namespace NPageCollection {
         TMeta(TSharedData blob, ui32 group);
         ~TMeta();
 
-        ui32 TotalPages() const { return Header->Pages; }
+        ui32 TotalPages() const noexcept { return Header->Pages; }
 
         inline TArrayRef<const TLogoBlobID> Blobs() const noexcept
         {
@@ -23,23 +23,23 @@ namespace NPageCollection {
             return TArrayRef<const TLogoBlobID>(blobs,  Header->Blobs);
         }
 
-        inline TBorder Bounds(ui32 page) const noexcept
+        inline TBorder Bounds(ui32 page) const
         {
             return Bounds(page, page);
         }
 
-        inline TGlobId Glob(ui32 blob) const noexcept
+        inline TGlobId Glob(ui32 blob) const
         {
             return { Blobs()[blob], Group };
         }
 
         size_t BackingSize() const noexcept;
-        TBorder Bounds(ui32 begin, ui32 end) const noexcept;
-        TInfo Page(ui32 page) const noexcept;
-        ui32 GetPageType(ui32 pageId) const noexcept;
-        ui32 GetPageChecksum(ui32 pageId) const noexcept;
-        ui64 GetPageSize(ui32 pageId) const noexcept;
-        TStringBuf GetPageInplaceData(ui32 pageId) const noexcept;
+        TBorder Bounds(ui32 begin, ui32 end) const;
+        TInfo Page(ui32 page) const;
+        ui32 GetPageType(ui32 pageId) const;
+        ui32 GetPageChecksum(ui32 pageId) const;
+        ui64 GetPageSize(ui32 pageId) const;
+        TStringBuf GetPageInplaceData(ui32 pageId) const;
 
     public:
         const TSharedData Raw;  /* Page collection serialized meta blob */

--- a/ydb/core/tablet_flat/flat_sausage_packet.h
+++ b/ydb/core/tablet_flat/flat_sausage_packet.h
@@ -29,22 +29,22 @@ namespace NPageCollection {
             return Meta.TotalPages();
         }
 
-        TBorder Bounds(ui32 page) const noexcept override
+        TBorder Bounds(ui32 page) const override
         {
             return Meta.Bounds(page);
         }
 
-        TGlobId Glob(ui32 blob) const noexcept override
+        TGlobId Glob(ui32 blob) const override
         {
             return Meta.Glob(blob);
         }
 
-        TInfo Page(ui32 page) const noexcept override
+        TInfo Page(ui32 page) const override
         {
             return Meta.Page(page);
         }
 
-        bool Verify(ui32 page, TArrayRef<const char> body) const noexcept override
+        bool Verify(ui32 page, TArrayRef<const char> body) const override
         {
             return
                 Meta.Page(page).Size == body.size()

--- a/ydb/core/tablet_flat/flat_sausage_slicer.h
+++ b/ydb/core/tablet_flat/flat_sausage_slicer.h
@@ -67,7 +67,7 @@ namespace NPageCollection {
             return largeGlobId;
         }
 
-        static inline const NBlockCodecs::ICodec* Lz4() noexcept
+        static inline const NBlockCodecs::ICodec* Lz4()
         {
             auto **lz4 = FastTlsSingleton<const NBlockCodecs::ICodec*>();
 

--- a/ydb/core/tablet_flat/flat_sausage_solid.h
+++ b/ydb/core/tablet_flat/flat_sausage_solid.h
@@ -32,7 +32,7 @@ namespace NPageCollection {
             Y_ABORT_UNLESS(Lead && Lead.BlobSize() && Lead.BlobSize() <= Bytes);
         }
 
-        void Describe(IOutputStream &out) const noexcept
+        void Describe(IOutputStream &out) const
         {
             out
                 << "TLargeGlobId{" << Lead << " ~" << Bytes
@@ -130,7 +130,7 @@ namespace NPageCollection {
         }
 
         template<typename TOut>
-        void MaterializeTo(TOut &out) const noexcept
+        void MaterializeTo(TOut &out) const
         {
             for (auto blobId : Blobs()) {
                 out.emplace_back(blobId);
@@ -234,7 +234,7 @@ namespace NPageCollection {
             Bodies.resize(Blobs.size());
         }
 
-        bool Apply(const TLogoBlobID& id, TString body) noexcept {
+        bool Apply(const TLogoBlobID& id, TString body) {
             for (size_t idx = 0, end = Blobs.size(); idx < end; ++idx) {
                 if (Blobs[idx] != id) {
                     continue;

--- a/ydb/core/tablet_flat/flat_sausage_writer.h
+++ b/ydb/core/tablet_flat/flat_sausage_writer.h
@@ -61,13 +61,13 @@ namespace NPageCollection {
             return meta;
         }
 
-        TVector<TGlob> Grab() noexcept
+        TVector<TGlob> Grab()
         {
             return std::exchange(Blobs, TVector<TGlob>());
         }
 
     private:
-        void Flush() noexcept
+        void Flush()
         {
             if (Buffer) {
                 auto glob = CookieAllocator.Do(Channel, Buffer.size());
@@ -79,7 +79,7 @@ namespace NPageCollection {
             }
         }
 
-        TString TakeBuffer() noexcept
+        TString TakeBuffer()
         {
             TString data;
 

--- a/ydb/core/tablet_flat/flat_sausagecache.h
+++ b/ydb/core/tablet_flat/flat_sausagecache.h
@@ -116,7 +116,7 @@ public:
             return PageCollection->Page(pageId).Size;
         }
 
-        TPage* EnsurePage(TPageId pageId) noexcept {
+        TPage* EnsurePage(TPageId pageId) {
             auto* page = GetPage(pageId);
             if (!page) {
                 PageMap.emplace(pageId, THolder<TPage>(page = new TPage(PageCollection->Page(pageId).Size, pageId, this)));
@@ -125,14 +125,14 @@ public:
         }
 
         // Note: this method is only called during a page collection creation
-        void Fill(TPageId pageId, TSharedPageRef sharedBody, bool sticky) noexcept {
+        void Fill(TPageId pageId, TSharedPageRef sharedBody, bool sticky) {
             if (sticky) {
                 AddSticky(pageId, sharedBody);
             }
             EnsurePage(pageId)->ProvideSharedBody(std::move(sharedBody));
         }
 
-        void AddSticky(TPageId pageId, TSharedPageRef page) noexcept {
+        void AddSticky(TPageId pageId, TSharedPageRef page) {
             Y_ABORT_UNLESS(page.IsUsed());
             if (StickyPages.emplace(pageId, page).second) {
                 StickyPagesSize += TPinnedPageRef(page)->size();

--- a/ydb/core/tablet_flat/flat_scan_actor.h
+++ b/ydb/core/tablet_flat/flat_scan_actor.h
@@ -70,7 +70,7 @@ namespace NOps {
                 delete DetachScan();
         }
 
-        void Describe(IOutputStream &out) const noexcept override
+        void Describe(IOutputStream &out) const override
         {
             out
                 << "Scan{" << Serial << " on " << Snapshot->Table
@@ -240,7 +240,7 @@ namespace NOps {
         };
 
     private:
-        void MakeCache() noexcept
+        void MakeCache()
         {
             NTable::NFwd::TConf conf;
 
@@ -280,7 +280,7 @@ namespace NOps {
             }
         }
 
-        NTable::IPages* MakeEnv() noexcept override
+        NTable::IPages* MakeEnv() override
         {
             if (Resets++ != 0) {
                 Cache->Reset();
@@ -292,7 +292,7 @@ namespace NOps {
             return Cache.Get();
         }
 
-        TPartView LoadPart(const TIntrusiveConstPtr<TColdPart>& part) noexcept override
+        TPartView LoadPart(const TIntrusiveConstPtr<TColdPart>& part) override
         {
             const auto label = part->Label;
             auto itLoaded = ColdPartLoaded.find(label);
@@ -313,11 +313,11 @@ namespace NOps {
             return { };
         }
 
-        bool MayProgress() noexcept {
+        bool MayProgress() {
             return !IsPaused() && Cache->MayProgress() && ColdPartLoaders.empty();
         }
 
-        void Touch(EScan scan) noexcept override
+        void Touch(EScan scan) override
         {
             Y_ABORT_UNLESS(Depth == 0, "Touch(..) is used from invalid context");
 
@@ -369,7 +369,7 @@ namespace NOps {
             cFunc(TEvents::TEvPoison::EventType, HandlePoison);
         });
 
-        void Bootstrap() noexcept
+        void Bootstrap()
         {
             Y_ABORT_UNLESS(!Spent, "Talble scan actor bootstrapped twice");
 
@@ -442,7 +442,7 @@ namespace NOps {
             SendToOwner(new TEvScanStat(elapsedUs, stat.Seen, stat.Skipped));
         }
 
-        void React() noexcept
+        void React()
         {
             TGuard<ui64, NUtil::TIncDecOps<ui64>> guard(Depth);
 
@@ -511,7 +511,7 @@ namespace NOps {
             SendStat(stat);
         }
 
-        void Handle(TEvContinue::TPtr&) noexcept
+        void Handle(TEvContinue::TPtr&)
         {
             Y_ABORT_UNLESS(ContinueInFly);
 
@@ -522,7 +522,7 @@ namespace NOps {
             }
         }
 
-        void Handle(TEvPrivate::TEvLoadBlob::TPtr& ev) noexcept
+        void Handle(TEvPrivate::TEvLoadBlob::TPtr& ev)
         {
             Y_ABORT_UNLESS(ev->Sender);
             auto* msg = ev->Get();
@@ -536,7 +536,7 @@ namespace NOps {
             BlobQueue.SendRequests(SelfId());
         }
 
-        void Handle(TEvBlobStorage::TEvGetResult::TPtr& ev) noexcept
+        void Handle(TEvBlobStorage::TEvGetResult::TPtr& ev)
         {
             if (!BlobQueue.ProcessResult(ev->Get())) {
                 return Terminate(EAbort::Host);
@@ -545,7 +545,7 @@ namespace NOps {
             BlobQueue.SendRequests(SelfId());
         }
 
-        void OnBlobLoaded(const TLogoBlobID& id, TString body, uintptr_t cookie) noexcept override
+        void OnBlobLoaded(const TLogoBlobID& id, TString body, uintptr_t cookie) override
         {
             Y_ABORT_UNLESS(cookie >= BlobQueueRequestsOffset);
             size_t idx = cookie - BlobQueueRequestsOffset;
@@ -560,7 +560,7 @@ namespace NOps {
             }
         }
 
-        void Handle(TEvPrivate::TEvLoadPages::TPtr& ev) noexcept
+        void Handle(TEvPrivate::TEvLoadPages::TPtr& ev)
         {
             auto* msg = ev->Get();
 
@@ -570,13 +570,13 @@ namespace NOps {
                 ev->Flags, ev->Cookie);
         }
 
-        void Handle(NBlockIO::TEvStat::TPtr& ev) noexcept
+        void Handle(NBlockIO::TEvStat::TPtr& ev)
         {
             ev->Rewrite(ev->GetTypeRewrite(), Owner);
             TActivationContext::Send(ev.Release());
         }
 
-        void Handle(TEvPrivate::TEvPartLoaded::TPtr& ev) noexcept
+        void Handle(TEvPrivate::TEvPartLoaded::TPtr& ev)
         {
             auto* msg = ev->Get();
 
@@ -597,7 +597,7 @@ namespace NOps {
             }
         }
 
-        void Handle(TEvPrivate::TEvPartFailed::TPtr& ev) noexcept
+        void Handle(TEvPrivate::TEvPartFailed::TPtr& ev)
         {
             auto* msg = ev->Get();
 
@@ -607,7 +607,7 @@ namespace NOps {
             Terminate(EAbort::Host);
         }
 
-        void Handle(NSharedCache::TEvResult::TPtr& ev) noexcept
+        void Handle(NSharedCache::TEvResult::TPtr& ev)
         {
             auto& msg = *ev->Get();
 
@@ -632,17 +632,17 @@ namespace NOps {
             }
         }
 
-        void HandleUndelivered() noexcept
+        void HandleUndelivered()
         {
             Terminate(EAbort::Lost);
         }
 
-        void HandlePoison() noexcept
+        void HandlePoison()
         {
             Terminate(EAbort::Term);
         }
 
-        void Terminate(EAbort abort) noexcept
+        void Terminate(EAbort abort)
         {
             auto trace = Args.Trace ? Cache->GrabTraces() : nullptr;
 
@@ -683,12 +683,12 @@ namespace NOps {
             PassAway();
         }
 
-        void SendToSelf(THolder<IEventBase> event) noexcept
+        void SendToSelf(THolder<IEventBase> event)
         {
             Send(SelfId(), event.Release());
         }
 
-        void SendToOwner(TAutoPtr<IEventBase> event, bool nack = false) noexcept
+        void SendToOwner(TAutoPtr<IEventBase> event, bool nack = false)
         {
             ui32 flags = nack ? NActors::IEventHandle::FlagTrackDelivery : 0;
 

--- a/ydb/core/tablet_flat/flat_scan_feed.h
+++ b/ydb/core/tablet_flat/flat_scan_feed.h
@@ -20,11 +20,11 @@ namespace NTable {
 
         }
 
-        void Pause() noexcept {
+        void Pause() {
             OnPause = true;
         }
 
-        void Resume(EScan op) noexcept
+        void Resume(EScan op)
         {
             Y_DEBUG_ABORT_UNLESS(op == EScan::Feed || op == EScan::Reset);
 
@@ -35,7 +35,7 @@ namespace NTable {
             }
         }
 
-        EReady Process() noexcept
+        EReady Process()
         {
             if (OnPause) {
                 return EReady::Page;
@@ -230,17 +230,17 @@ namespace NTable {
         }
 
     protected:
-        IScan* DetachScan() noexcept
+        IScan* DetachScan()
         {
             return std::exchange(const_cast<IScan*&>(Scan), nullptr);
         }
 
-        bool IsPaused() const noexcept
+        bool IsPaused() const
         {
             return OnPause;
         }
 
-        EReady ImplicitPageFault() noexcept
+        EReady ImplicitPageFault()
         {
             if (Iter) {
                 // Implicit page fault during iteration
@@ -254,11 +254,11 @@ namespace NTable {
         }
 
     private:
-        virtual IPages* MakeEnv() noexcept = 0;
+        virtual IPages* MakeEnv() = 0;
 
-        virtual TPartView LoadPart(const TIntrusiveConstPtr<TColdPart>& part) noexcept = 0;
+        virtual TPartView LoadPart(const TIntrusiveConstPtr<TColdPart>& part) = 0;
 
-        EReady NotifyPageFault() noexcept
+        EReady NotifyPageFault()
         {
             EScan op = Scan->PageFault();
 
@@ -280,7 +280,7 @@ namespace NTable {
             Y_ABORT("Unexpected EScan result from IScan::PageFault(...)");
         }
 
-        EReady NotifyExhausted() noexcept
+        EReady NotifyExhausted()
         {
             Iter = nullptr;
 
@@ -305,7 +305,7 @@ namespace NTable {
             Y_ABORT("Unexpected EScan result from IScan::Exhausted(...)");
         }
 
-        bool Reset() noexcept
+        bool Reset()
         {
             Seeks++;
 
@@ -342,7 +342,7 @@ namespace NTable {
             return true;
         }
 
-        bool LoadColdParts() noexcept
+        bool LoadColdParts()
         {
             LoadedParts.clear();
             LoadingParts = 0;
@@ -360,7 +360,7 @@ namespace NTable {
             return LoadingParts == 0;
         }
 
-        void PrepareBoots() noexcept
+        void PrepareBoots()
         {
             auto keyDefaults = Subset.Scheme->Keys;
 
@@ -398,7 +398,7 @@ namespace NTable {
             }
         }
 
-        bool SeekBoots() noexcept
+        bool SeekBoots()
         {
             if (Boots) {
                 auto saved = Boots.begin();
@@ -440,7 +440,7 @@ namespace NTable {
         /**
          * @return true on page fault
          */
-        bool Seek() noexcept
+        bool Seek()
         {
             switch (SeekState) {
                 case ESeekState::LoadColdParts:

--- a/ydb/core/tablet_flat/flat_scan_iface.h
+++ b/ydb/core/tablet_flat/flat_scan_iface.h
@@ -74,7 +74,7 @@ namespace NTable {
 
     class IDriver {
     public:
-        virtual void Touch(EScan) noexcept = 0;
+        virtual void Touch(EScan) = 0;
     };
 
 
@@ -112,11 +112,11 @@ namespace NTable {
             TConf Conf;     /* Scan conveyer configuration  */
         };
 
-        virtual TInitialState Prepare(IDriver*, TIntrusiveConstPtr<TScheme>) noexcept = 0;
-        virtual EScan Seek(TLead&, ui64 seq) noexcept = 0;
-        virtual EScan Feed(TArrayRef<const TCell>, const TRow&) noexcept = 0;
-        virtual TAutoPtr<IDestructable> Finish(EAbort) noexcept = 0;
-        virtual void Describe(IOutputStream&) const noexcept = 0;
+        virtual TInitialState Prepare(IDriver*, TIntrusiveConstPtr<TScheme>) = 0;
+        virtual EScan Seek(TLead&, ui64 seq) = 0;
+        virtual EScan Feed(TArrayRef<const TCell>, const TRow&) = 0;
+        virtual TAutoPtr<IDestructable> Finish(EAbort) = 0;
+        virtual void Describe(IOutputStream&) const = 0;
 
         /**
          * Called on page faults during iteration
@@ -124,7 +124,7 @@ namespace NTable {
          * The default is to return EScan::Feed, to keep trying to fetch data
          * until the next row is available or iteration is exhausted.
          */
-        virtual EScan PageFault() noexcept {
+        virtual EScan PageFault() {
             return EScan::Feed;
         }
 
@@ -134,7 +134,7 @@ namespace NTable {
          * The default is to return EScan::Reset, causing another Seek for
          * compatibility and making it possible to iterate multiple times.
          */
-        virtual EScan Exhausted() noexcept {
+        virtual EScan Exhausted() {
             return EScan::Reset;
         }
     };
@@ -142,17 +142,17 @@ namespace NTable {
 
     class IVersionScan : public IScan {
     private:
-        EScan Feed(TArrayRef<const TCell>, const TRow&) noexcept override final {
+        EScan Feed(TArrayRef<const TCell>, const TRow&) override final {
             Y_ABORT("Unexpected unversioned call");
         }
 
     public:
-        virtual EScan BeginKey(TArrayRef<const TCell>) noexcept = 0;
-        virtual EScan BeginDeltas() noexcept = 0;
-        virtual EScan Feed(const TRow&, ui64) noexcept = 0;
-        virtual EScan EndDeltas() noexcept = 0;
-        virtual EScan Feed(const TRow&, TRowVersion&) noexcept = 0;
-        virtual EScan EndKey() noexcept = 0;
+        virtual EScan BeginKey(TArrayRef<const TCell>) = 0;
+        virtual EScan BeginDeltas() = 0;
+        virtual EScan Feed(const TRow&, ui64) = 0;
+        virtual EScan EndDeltas() = 0;
+        virtual EScan Feed(const TRow&, TRowVersion&) = 0;
+        virtual EScan EndKey() = 0;
     };
 
 }

--- a/ydb/core/tablet_flat/flat_scan_spent.h
+++ b/ydb/core/tablet_flat/flat_scan_spent.h
@@ -21,7 +21,7 @@ namespace NTable {
 
         }
 
-        void Describe(IOutputStream &out) const noexcept
+        void Describe(IOutputStream &out) const
         {
             const auto now = Time->Now();
 
@@ -31,7 +31,7 @@ namespace NTable {
                 << ",interrupts=" << Interrupts << "}";
         }
 
-        void Alter(bool available) noexcept
+        void Alter(bool available)
         {
             if (bool(available) == bool(Since == TInstant::Max())) {
                 /* State isn't changed since last Alter(...) */

--- a/ydb/core/tablet_flat/flat_stat_part.h
+++ b/ydb/core/tablet_flat/flat_stat_part.h
@@ -199,7 +199,7 @@ private:
         }
     }
 
-    ui64 CountUnscreenedRows(TRowId beginRowId, TRowId endRowId) noexcept {
+    ui64 CountUnscreenedRows(TRowId beginRowId, TRowId endRowId) {
         if (!Screen) {
             // Include all rows
             return endRowId - beginRowId;
@@ -227,7 +227,7 @@ private:
         return rowCount;
     }
 
-    void AddBlobsSize(TChanneledDataSize& stats, const TFrames* frames, ELargeObj lob, ui32 &prevPage) noexcept {
+    void AddBlobsSize(TChanneledDataSize& stats, const TFrames* frames, ELargeObj lob, ui32 &prevPage) {
         const auto row = GetLastRowId();
         const auto end = GetCurrentRowId();
 

--- a/ydb/core/tablet_flat/flat_stat_table.h
+++ b/ydb/core/tablet_flat/flat_stat_table.h
@@ -76,7 +76,7 @@ public:
     }
 
 private:
-    int CompareKeys(const TDbTupleRef& a, const TDbTupleRef& b) const noexcept {
+    int CompareKeys(const TDbTupleRef& a, const TDbTupleRef& b) const {
         return ComparePartKeys(a.Cells(), b.Cells(), *KeyDefaults);
     }
 
@@ -126,7 +126,7 @@ struct TStats {
         DataSizeHistogram.swap(other.DataSizeHistogram);
     }
 
-    TString ToString() const noexcept {
+    TString ToString() const {
         return TStringBuilder() 
             << "RowCount: " << RowCount
             << " DataSize: " << DataSize.Size

--- a/ydb/core/tablet_flat/flat_stat_table_btree_index.cpp
+++ b/ydb/core/tablet_flat/flat_stat_table_btree_index.cpp
@@ -93,7 +93,7 @@ ui64 GetPrevHistoricDataSize(const TPart* part, TGroupId groupId, TRowId rowId, 
     return prevDataSize;
 }
 
-void AddBlobsSize(const TPart* part, TChanneledDataSize& stats, const TFrames* frames, ELargeObj lob, TRowId beginRowId, TRowId endRowId) noexcept {
+void AddBlobsSize(const TPart* part, TChanneledDataSize& stats, const TFrames* frames, ELargeObj lob, TRowId beginRowId, TRowId endRowId) {
     ui32 page = frames->Lower(beginRowId, 0, Max<ui32>());
 
     while (auto &rel = frames->Relation(page)) {

--- a/ydb/core/tablet_flat/flat_stat_table_btree_index_histogram.cpp
+++ b/ydb/core/tablet_flat/flat_stat_table_btree_index_histogram.cpp
@@ -48,7 +48,7 @@ class TTableHistogramBuilderBtreeIndex {
         {
         }
 
-        TString ToString() const noexcept {
+        TString ToString() const {
             return TStringBuilder() 
                 << "Part: " << Part->Label.ToString()
                 << " PageId: " << PageId
@@ -83,7 +83,7 @@ class TTableHistogramBuilderBtreeIndex {
         //   1. Initial
         //   2. Closed - after processing TEvent.IsBegin = false
 
-        bool Open(ui64& openedRowCount, ui64& openedDataSize) noexcept {
+        bool Open(ui64& openedRowCount, ui64& openedDataSize) {
             if (Y_LIKELY(State == ENodeState::Initial)) {
                 State = ENodeState::Opened;
                 openedRowCount += GetRowCount();
@@ -93,7 +93,7 @@ class TTableHistogramBuilderBtreeIndex {
             return false;            
         }
 
-        bool Close(ui64& openedRowCount, ui64& closedRowCount, ui64& openedDataSize, ui64& closedDataSize) noexcept {
+        bool Close(ui64& openedRowCount, ui64& closedRowCount, ui64& openedDataSize, ui64& closedDataSize) {
             if (State == ENodeState::Opened) {
                 State = ENodeState::Closed;
                 ui64 rowCount = GetRowCount();
@@ -114,7 +114,7 @@ class TTableHistogramBuilderBtreeIndex {
             return false;
         }
 
-        bool IgnoreOpened(ui64& openedRowCount, ui64& openedDataSize) noexcept {
+        bool IgnoreOpened(ui64& openedRowCount, ui64& openedDataSize) {
             if (Y_LIKELY(State == ENodeState::Opened)) {
                 State = ENodeState::Ignored;
                 ui64 rowCount = GetRowCount();
@@ -134,7 +134,7 @@ class TTableHistogramBuilderBtreeIndex {
         bool IsBegin;
         TNodeState* Node;
 
-        TString ToString() const noexcept {
+        TString ToString() const {
             return TStringBuilder()
                 << Node->ToString()
                 << " IsBegin: " << IsBegin
@@ -145,11 +145,11 @@ class TTableHistogramBuilderBtreeIndex {
     struct TNodeEventKeyGreater {
         const TKeyCellDefaults& KeyDefaults;
 
-        bool operator ()(const TEvent& a, const TEvent& b) const noexcept {
+        bool operator ()(const TEvent& a, const TEvent& b) const {
             return Compare(a, b) > 0;
         }
 
-        i8 Compare(const TEvent& a, const TEvent& b) const noexcept {
+        i8 Compare(const TEvent& a, const TEvent& b) const {
             // events go in order:
             // - Key = {}, IsBegin = true
             // - ...
@@ -177,14 +177,14 @@ class TTableHistogramBuilderBtreeIndex {
         }
 
     private:
-        static i8 GetCategory(const TEvent& a) noexcept {
+        static i8 GetCategory(const TEvent& a) {
             if (a.Key) {
                 return 0;
             }
             return a.IsBegin ? -1 : +1;
         }
 
-        static i8 Compare(i8 a, i8 b) noexcept {
+        static i8 Compare(i8 a, i8 b) {
             if (a < b) return -1;
             if (a > b) return +1;
             return 0;
@@ -192,13 +192,13 @@ class TTableHistogramBuilderBtreeIndex {
     };
 
     struct TNodeRowCountLess {
-        bool operator ()(const TNodeState* a, const TNodeState* b) const noexcept {
+        bool operator ()(const TNodeState* a, const TNodeState* b) const {
             return a->GetRowCount() < b->GetRowCount();
         }
     };
 
     struct TNodeDataSizeLess {
-        bool operator ()(const TNodeState* a, const TNodeState* b) const noexcept {
+        bool operator ()(const TNodeState* a, const TNodeState* b) const {
             return a->GetDataSize() < b->GetDataSize();
         }
     };

--- a/ydb/core/tablet_flat/flat_store_bundle.h
+++ b/ydb/core/tablet_flat/flat_store_bundle.h
@@ -10,8 +10,8 @@ namespace NTable {
 
     class IBundle : public virtual TThrRefBase {
     public:
-        virtual const TLogoBlobID& BundleId() const = 0;
-        virtual ui64 BackingSize() const = 0;
+        virtual const TLogoBlobID& BundleId() const noexcept = 0;
+        virtual ui64 BackingSize() const noexcept = 0;
         virtual const NPageCollection::TPageCollection* Packet(ui32 room) const noexcept = 0;
 
         template<typename TContainer>
@@ -29,8 +29,8 @@ namespace NTable {
      */
     class IBorrowBundle : public virtual TThrRefBase {
     public:
-        virtual const TLogoBlobID& BundleId() const = 0;
-        virtual ui64 BackingSize() const = 0;
+        virtual const TLogoBlobID& BundleId() const noexcept = 0;
+        virtual ui64 BackingSize() const noexcept = 0;
 
         virtual void SaveAllBlobIdsTo(TVector<TLogoBlobID> &vec) const = 0;
     };

--- a/ydb/core/tablet_flat/flat_table.cpp
+++ b/ydb/core/tablet_flat/flat_table.cpp
@@ -288,7 +288,7 @@ TAutoPtr<TSubset> TTable::PartSwitchSubset(TEpoch head, TArrayRef<const TLogoBlo
     return subset;
 }
 
-TAutoPtr<TSubset> TTable::Subset(TEpoch head) const noexcept
+TAutoPtr<TSubset> TTable::Subset(TEpoch head) const
 {
     head = Min(head, Epoch);
 
@@ -327,7 +327,7 @@ TAutoPtr<TSubset> TTable::Subset(TEpoch head) const noexcept
     return subset;
 }
 
-bool TTable::HasBorrowed(ui64 selfTabletId) const noexcept
+bool TTable::HasBorrowed(ui64 selfTabletId) const
 {
     for (const auto &it : TxStatus)
         if (it.second->Label.TabletID() != selfTabletId)
@@ -344,7 +344,7 @@ bool TTable::HasBorrowed(ui64 selfTabletId) const noexcept
     return false;
 }
 
-TAutoPtr<TSubset> TTable::ScanSnapshot(TRowVersion snapshot) noexcept
+TAutoPtr<TSubset> TTable::ScanSnapshot(TRowVersion snapshot)
 {
     if (RollbackState) {
         Y_ABORT_UNLESS(Epoch == RollbackState->Epoch &&
@@ -382,7 +382,7 @@ TAutoPtr<TSubset> TTable::ScanSnapshot(TRowVersion snapshot) noexcept
     return subset;
 }
 
-TAutoPtr<TSubset> TTable::Unwrap() noexcept
+TAutoPtr<TSubset> TTable::Unwrap()
 {
     Snapshot();
 
@@ -395,7 +395,7 @@ TAutoPtr<TSubset> TTable::Unwrap() noexcept
     return subset;
 }
 
-TBundleSlicesMap TTable::LookupSlices(TArrayRef<const TLogoBlobID> bundles) const noexcept
+TBundleSlicesMap TTable::LookupSlices(TArrayRef<const TLogoBlobID> bundles) const
 {
     TBundleSlicesMap slices;
     for (const TLogoBlobID &bundle : bundles) {
@@ -407,7 +407,7 @@ TBundleSlicesMap TTable::LookupSlices(TArrayRef<const TLogoBlobID> bundles) cons
     return slices;
 }
 
-void TTable::ReplaceSlices(TBundleSlicesMap slices) noexcept
+void TTable::ReplaceSlices(TBundleSlicesMap slices)
 {
     Y_ABORT_UNLESS(!RollbackState, "Cannot perform this in a transaction");
 
@@ -428,7 +428,7 @@ void TTable::ReplaceSlices(TBundleSlicesMap slices) noexcept
 void TTable::Replace(
     const TSubset& subset,
     TArrayRef<const TPartView> newParts,
-    TArrayRef<const TIntrusiveConstPtr<TTxStatusPart>> newTxStatus) noexcept
+    TArrayRef<const TIntrusiveConstPtr<TTxStatusPart>> newTxStatus)
 {
     Y_ABORT_UNLESS(!RollbackState, "Cannot perform this in a transaction");
 
@@ -653,7 +653,7 @@ void TTable::Replace(
     }
 }
 
-void TTable::Merge(TPartView partView) noexcept
+void TTable::Merge(TPartView partView)
 {
     Y_ABORT_UNLESS(!RollbackState, "Cannot perform this in a transaction");
 
@@ -687,7 +687,7 @@ void TTable::Merge(TPartView partView) noexcept
     ErasedKeysCache.Reset();
 }
 
-void TTable::Merge(TIntrusiveConstPtr<TColdPart> part) noexcept
+void TTable::Merge(TIntrusiveConstPtr<TColdPart> part)
 {
     Y_ABORT_UNLESS(!RollbackState, "Cannot perform this in a transaction");
 
@@ -719,7 +719,7 @@ void TTable::Merge(TIntrusiveConstPtr<TColdPart> part) noexcept
     ErasedKeysCache.Reset();
 }
 
-void TTable::Merge(TIntrusiveConstPtr<TTxStatusPart> txStatus) noexcept
+void TTable::Merge(TIntrusiveConstPtr<TTxStatusPart> txStatus)
 {
     Y_ABORT_UNLESS(!RollbackState, "Cannot perform this in a transaction");
 
@@ -770,12 +770,12 @@ void TTable::Merge(TIntrusiveConstPtr<TTxStatusPart> txStatus) noexcept
     // eventuality, so doesn't need to be invalidated.
 }
 
-void TTable::MergeDone() noexcept
+void TTable::MergeDone()
 {
     // nothing
 }
 
-const TLevels& TTable::GetLevels() const noexcept
+const TLevels& TTable::GetLevels() const
 {
     if (!Levels) {
         Y_ABORT_UNLESS(ColdParts.empty(), "Cannot construct Levels with cold parts");
@@ -799,7 +799,7 @@ const TLevels& TTable::GetLevels() const noexcept
     return *Levels;
 }
 
-ui64 TTable::GetSearchHeight() const noexcept
+ui64 TTable::GetSearchHeight() const
 {
     if (!ColdParts.empty())
         return 0;
@@ -811,7 +811,7 @@ ui64 TTable::GetSearchHeight() const noexcept
     return height;
 }
 
-TVector<TIntrusiveConstPtr<TMemTable>> TTable::GetMemTables() const noexcept
+TVector<TIntrusiveConstPtr<TMemTable>> TTable::GetMemTables() const
 {
     Y_ABORT_UNLESS(!RollbackState, "Cannot perform this in a transaction");
 
@@ -823,7 +823,7 @@ TVector<TIntrusiveConstPtr<TMemTable>> TTable::GetMemTables() const noexcept
     return vec;
 }
 
-TEpoch TTable::Snapshot() noexcept
+TEpoch TTable::Snapshot()
 {
     if (Mutable) {
         Annexed = Mutable->GetBlobs()->Tail();
@@ -1202,7 +1202,7 @@ TMemTable& TTable::MemTable()
 TAutoPtr<TTableIter> TTable::Iterate(TRawVals key_, TTagsRef tags, IPages* env, ESeek seek,
         TRowVersion snapshot,
         const ITransactionMapPtr& visible,
-        const ITransactionObserverPtr& observer) const noexcept
+        const ITransactionObserverPtr& observer) const
 {
     Y_ABORT_UNLESS(ColdParts.empty(), "Cannot iterate with cold parts");
 
@@ -1254,7 +1254,7 @@ TAutoPtr<TTableIter> TTable::Iterate(TRawVals key_, TTagsRef tags, IPages* env, 
 TAutoPtr<TTableReverseIter> TTable::IterateReverse(TRawVals key_, TTagsRef tags, IPages* env, ESeek seek,
         TRowVersion snapshot,
         const ITransactionMapPtr& visible,
-        const ITransactionObserverPtr& observer) const noexcept
+        const ITransactionObserverPtr& observer) const
 {
     Y_ABORT_UNLESS(ColdParts.empty(), "Cannot iterate with cold parts");
 
@@ -1308,7 +1308,7 @@ EReady TTable::Select(TRawVals key_, TTagsRef tags, IPages* env, TRowState& row,
                       TDeque<TPartIter>& tempIterators,
                       TSelectStats& stats,
                       const ITransactionMapPtr& visible,
-                      const ITransactionObserverPtr& observer) const noexcept
+                      const ITransactionObserverPtr& observer) const
 {
     Y_ABORT_UNLESS(ColdParts.empty(), "Cannot select with cold parts");
     Y_ABORT_UNLESS(key_.size() == Scheme->Keys->Types.size());
@@ -1425,7 +1425,7 @@ EReady TTable::Select(TRawVals key_, TTagsRef tags, IPages* env, TRowState& row,
 TSelectRowVersionResult TTable::SelectRowVersion(
         TRawVals key_, IPages* env, ui64 readFlags,
         const ITransactionMapPtr& visible,
-        const ITransactionObserverPtr& observer) const noexcept
+        const ITransactionObserverPtr& observer) const
 {
     const TCelled key(key_, *Scheme->Keys, true);
 
@@ -1435,7 +1435,7 @@ TSelectRowVersionResult TTable::SelectRowVersion(
 TSelectRowVersionResult TTable::SelectRowVersion(
         TArrayRef<const TCell> key_, IPages* env, ui64 readFlags,
         const ITransactionMapPtr& visible,
-        const ITransactionObserverPtr& observer) const noexcept
+        const ITransactionObserverPtr& observer) const
 {
     const TCelled key(key_, *Scheme->Keys, true);
 
@@ -1445,7 +1445,7 @@ TSelectRowVersionResult TTable::SelectRowVersion(
 TSelectRowVersionResult TTable::SelectRowVersion(
         const TCelled& key, IPages* env, ui64 readFlags,
         const ITransactionMapPtr& visible,
-        const ITransactionObserverPtr& observer) const noexcept
+        const ITransactionObserverPtr& observer) const
 {
     Y_ABORT_UNLESS(ColdParts.empty(), "Cannot select with cold parts");
 
@@ -1581,7 +1581,7 @@ TCompactionStats TTable::GetCompactionStats() const
     };
 }
 
-void TTable::SetTableObserver(TIntrusivePtr<ITableObserver> ptr) noexcept
+void TTable::SetTableObserver(TIntrusivePtr<ITableObserver> ptr)
 {
     TableObserver = std::move(ptr);
 }

--- a/ydb/core/tablet_flat/flat_table.h
+++ b/ydb/core/tablet_flat/flat_table.h
@@ -77,7 +77,7 @@ public:
 
     TIntrusiveConstPtr<TRowScheme> GetScheme() const noexcept;
 
-    TEpoch Snapshot() noexcept;
+    TEpoch Snapshot();
 
     TEpoch Head() const noexcept
     {
@@ -86,23 +86,23 @@ public:
 
     TAutoPtr<TSubset> CompactionSubset(TEpoch edge, TArrayRef<const TLogoBlobID> bundle);
     TAutoPtr<TSubset> PartSwitchSubset(TEpoch edge, TArrayRef<const TLogoBlobID> bundle, TArrayRef<const TLogoBlobID> txStatus);
-    TAutoPtr<TSubset> Subset(TEpoch edge) const noexcept;
-    TAutoPtr<TSubset> ScanSnapshot(TRowVersion snapshot = TRowVersion::Max()) noexcept;
-    TAutoPtr<TSubset> Unwrap() noexcept; /* full Subset(..) + final Replace(..) */
+    TAutoPtr<TSubset> Subset(TEpoch edge) const;
+    TAutoPtr<TSubset> ScanSnapshot(TRowVersion snapshot = TRowVersion::Max());
+    TAutoPtr<TSubset> Unwrap(); /* full Subset(..) + final Replace(..) */
 
-    bool HasBorrowed(ui64 selfTabletId) const noexcept;
+    bool HasBorrowed(ui64 selfTabletId) const;
 
     /**
      * Returns current slices for bundles
      *
      * Map will only contain bundles that currently exist in the table
      */
-    TBundleSlicesMap LookupSlices(TArrayRef<const TLogoBlobID> bundles) const noexcept;
+    TBundleSlicesMap LookupSlices(TArrayRef<const TLogoBlobID> bundles) const;
 
     /**
      * Replaces slices for bundles in the slices map
      */
-    void ReplaceSlices(TBundleSlicesMap slices) noexcept;
+    void ReplaceSlices(TBundleSlicesMap slices);
 
     /* Interface for redistributing data layout within the table. Take some
         subset with Subset(...) call, do some work and then return result
@@ -111,57 +111,57 @@ public:
         be displaced from table with Clean() method eventually.
     */
 
-    void Replace(const TSubset&, TArrayRef<const TPartView>, TArrayRef<const TIntrusiveConstPtr<TTxStatusPart>>) noexcept;
+    void Replace(const TSubset&, TArrayRef<const TPartView>, TArrayRef<const TIntrusiveConstPtr<TTxStatusPart>>);
 
     /*_ Special interface for clonig flatten part of table for outer usage.
         Cook some TPartView with Subset(...) method and/or TShrink tool first and
         then merge produced TPartView to outer table.
     */
 
-    void Merge(TPartView partView) noexcept;
-    void Merge(TIntrusiveConstPtr<TColdPart> part) noexcept;
-    void Merge(TIntrusiveConstPtr<TTxStatusPart> txStatus) noexcept;
-    void MergeDone() noexcept;
+    void Merge(TPartView partView);
+    void Merge(TIntrusiveConstPtr<TColdPart> part);
+    void Merge(TIntrusiveConstPtr<TTxStatusPart> txStatus);
+    void MergeDone();
 
     /**
      * Returns constructed levels for slices
      */
-    const TLevels& GetLevels() const noexcept;
+    const TLevels& GetLevels() const;
 
     /**
      * Returns search height if there are no cold parts, 0 otherwise
      */
-    ui64 GetSearchHeight() const noexcept;
+    ui64 GetSearchHeight() const;
 
     /* Hack for filling external blobs in TMemTable tables with data */
 
-    TVector<TIntrusiveConstPtr<TMemTable>> GetMemTables() const noexcept;
+    TVector<TIntrusiveConstPtr<TMemTable>> GetMemTables() const;
 
     TAutoPtr<TTableIter> Iterate(TRawVals key, TTagsRef tags, IPages* env, ESeek,
             TRowVersion snapshot,
             const ITransactionMapPtr& visible = nullptr,
-            const ITransactionObserverPtr& observer = nullptr) const noexcept;
+            const ITransactionObserverPtr& observer = nullptr) const;
     TAutoPtr<TTableReverseIter> IterateReverse(TRawVals key, TTagsRef tags, IPages* env, ESeek,
             TRowVersion snapshot,
             const ITransactionMapPtr& visible = nullptr,
-            const ITransactionObserverPtr& observer = nullptr) const noexcept;
+            const ITransactionObserverPtr& observer = nullptr) const;
     EReady Select(TRawVals key, TTagsRef tags, IPages* env, TRowState& row,
                   ui64 flg, TRowVersion snapshot, TDeque<TPartIter>& tempIterators,
                   TSelectStats& stats,
                   const ITransactionMapPtr& visible = nullptr,
-                  const ITransactionObserverPtr& observer = nullptr) const noexcept;
+                  const ITransactionObserverPtr& observer = nullptr) const;
     TSelectRowVersionResult SelectRowVersion(
             TRawVals key, IPages* env, ui64 readFlags,
             const ITransactionMapPtr& visible = nullptr,
-            const ITransactionObserverPtr& observer = nullptr) const noexcept;
+            const ITransactionObserverPtr& observer = nullptr) const;
     TSelectRowVersionResult SelectRowVersion(
             TArrayRef<const TCell> key, IPages* env, ui64 readFlags,
             const ITransactionMapPtr& visible = nullptr,
-            const ITransactionObserverPtr& observer = nullptr) const noexcept;
+            const ITransactionObserverPtr& observer = nullptr) const;
     TSelectRowVersionResult SelectRowVersion(
             const TCelled& key, IPages* env, ui64 readFlags,
             const ITransactionMapPtr& visible = nullptr,
-            const ITransactionObserverPtr& observer = nullptr) const noexcept;
+            const ITransactionObserverPtr& observer = nullptr) const;
 
     EReady Precharge(TRawVals minKey, TRawVals maxKey, TTagsRef tags,
                      IPages* env, ui64 flg,
@@ -329,7 +329,7 @@ public:
 
     TCompactionStats GetCompactionStats() const;
 
-    void SetTableObserver(TIntrusivePtr<ITableObserver> ptr) noexcept;
+    void SetTableObserver(TIntrusivePtr<ITableObserver> ptr);
 
 private:
     TMemTable& MemTable();

--- a/ydb/core/tablet_flat/flat_table_misc.cpp
+++ b/ydb/core/tablet_flat/flat_table_misc.cpp
@@ -4,7 +4,7 @@
 namespace NKikimr {
 namespace NTable {
 
-    IPages::TResult MemTableRefLookup(const TMemTable *memTable, ui64 ref, ui32) noexcept
+    IPages::TResult MemTableRefLookup(const TMemTable *memTable, ui64 ref, ui32)
     {
         const auto &data = memTable->GetBlobs()->Get(ref).Data;
 

--- a/ydb/core/tablet_flat/flat_table_misc.h
+++ b/ydb/core/tablet_flat/flat_table_misc.h
@@ -14,6 +14,6 @@ namespace NTable {
         }
     };
 
-    IPages::TResult MemTableRefLookup(const TMemTable*, ui64 ref, ui32 tag) noexcept;
+    IPages::TResult MemTableRefLookup(const TMemTable*, ui64 ref, ui32 tag);
 }
 }

--- a/ydb/core/tablet_flat/flat_table_part.h
+++ b/ydb/core/tablet_flat/flat_table_part.h
@@ -30,7 +30,7 @@ namespace NTable {
 
         virtual ~TColdPart() = default;
 
-        void Describe(IOutputStream &out) const noexcept
+        void Describe(IOutputStream &out) const
         {
             out << "ColdPart{" << Label << " eph " << Epoch << "}";
         }
@@ -63,7 +63,7 @@ namespace NTable {
                 return !FlatGroups.empty();
             }
 
-            const TBtreeIndexMeta& GetBTree(TGroupId groupId) const noexcept {
+            const TBtreeIndexMeta& GetBTree(TGroupId groupId) const {
                 if (groupId.IsHistoric()) {
                     Y_ABORT_UNLESS(groupId.Index < BTreeHistoric.size());
                     return BTreeHistoric[groupId.Index];
@@ -73,7 +73,7 @@ namespace NTable {
                 }
             }
 
-            TPageId GetFlat(TGroupId groupId) const noexcept {
+            TPageId GetFlat(TGroupId groupId) const {
                 if (groupId.IsHistoric()) {
                     Y_ABORT_UNLESS(groupId.Index < FlatHistoric.size());
                     return FlatHistoric[groupId.Index];
@@ -136,7 +136,7 @@ namespace NTable {
 
         virtual ~TPart() = default;
 
-        void Describe(IOutputStream &out) const noexcept
+        void Describe(IOutputStream &out) const
         {
             out
                 << "Part{" << Label << " eph " << Epoch << ", "
@@ -153,8 +153,8 @@ namespace NTable {
          */
         virtual TIntrusiveConstPtr<TPart> CloneWithEpoch(TEpoch epoch) const = 0;
 
-        virtual ui64 DataSize() const = 0;
-        virtual ui64 BackingSize() const = 0;
+        virtual ui64 DataSize() const noexcept = 0;
+        virtual ui64 BackingSize() const noexcept = 0;
         virtual ui64 GetPageSize(NPage::TPageId pageId, NPage::TGroupId groupId) const = 0;
         virtual ui64 GetPageSize(ELargeObj lob, ui64 ref) const = 0;
         virtual NPage::EPage GetPageType(NPage::TPageId pageId, NPage::TGroupId groupId) const = 0;
@@ -213,7 +213,7 @@ namespace NTable {
 
         virtual ~TTxStatusPart() = default;
 
-        void Describe(IOutputStream &out) const noexcept
+        void Describe(IOutputStream &out) const
         {
             out
                 << "TxStatus{" << Label << " epoch " << Epoch << ", "

--- a/ydb/core/tablet_flat/flat_table_subset.h
+++ b/ydb/core/tablet_flat/flat_table_subset.h
@@ -45,7 +45,7 @@ namespace NTable {
             return Head == TEpoch::Zero() || Head == Epoch() + 1;
         }
 
-        void Describe(IOutputStream &out) const noexcept
+        void Describe(IOutputStream &out) const
         {
             out
                 << "TSubset{" << "head " << Head

--- a/ydb/core/tablet_flat/flat_util_misc.h
+++ b/ydb/core/tablet_flat/flat_util_misc.h
@@ -48,7 +48,7 @@ namespace NUtil {
     };
 
     template <typename TVal>
-    TVal SubSafe(TVal &val, TVal sub) noexcept
+    TVal SubSafe(TVal &val, TVal sub)
     {
         Y_ABORT_UNLESS(val >= sub, "Counter is underflowed");
 
@@ -56,7 +56,7 @@ namespace NUtil {
     }
 
     template<typename TVal, typename TBase>
-    TVal* ExactCast(TBase *base) noexcept
+    TVal* ExactCast(TBase *base)
     {
         bool same = (typeid(*base) == typeid(TVal));
 

--- a/ydb/core/tablet_flat/flat_writer_banks.h
+++ b/ydb/core/tablet_flat/flat_writer_banks.h
@@ -10,9 +10,9 @@ namespace NWriter {
 
     class ICone {
     public:
-        virtual NPageCollection::TCookieAllocator& CookieRange(ui32 cookieRange) noexcept = 0;
-        virtual void Put(NPageCollection::TGlob&&) noexcept = 0;
-        virtual NPageCollection::TLargeGlobId Put(ui32 cookieRange, ui8 channel, TArrayRef<const char> body, ui32 block) noexcept = 0;
+        virtual NPageCollection::TCookieAllocator& CookieRange(ui32 cookieRange) = 0;
+        virtual void Put(NPageCollection::TGlob&&) = 0;
+        virtual NPageCollection::TLargeGlobId Put(ui32 cookieRange, ui8 channel, TArrayRef<const char> body, ui32 block) = 0;
     };
 
     class TBanks {

--- a/ydb/core/tablet_flat/flat_writer_blocks.h
+++ b/ydb/core/tablet_flat/flat_writer_blocks.h
@@ -43,7 +43,7 @@ namespace NWriter {
             return Writer || Result.RegularPages || Result.StickyPages;
         }
 
-        TResult Finish() noexcept
+        TResult Finish()
         {
             if (auto meta = Writer.Finish(false /* omit empty page collection */)) {
                 for (auto &glob : Writer.Grab()) {

--- a/ydb/core/tablet_flat/flat_writer_bundle.h
+++ b/ydb/core/tablet_flat/flat_writer_bundle.h
@@ -50,7 +50,7 @@ namespace NWriter {
             return std::exchange(Blobs, { });
         }
 
-        TVector<TResult> Results() noexcept
+        TVector<TResult> Results()
         {
             for (auto &blocks : Blocks) {
                 Y_ABORT_UNLESS(!*blocks, "Bundle writer has unflushed data");
@@ -59,7 +59,7 @@ namespace NWriter {
             return std::move(Results_);
         }
 
-        NPageCollection::TLargeGlobId WriteExtra(TArrayRef<const char> body) noexcept
+        NPageCollection::TLargeGlobId WriteExtra(TArrayRef<const char> body)
         {
             return Put(/* data cookieRange */ 1, ExtraChannel, body, Groups[0].MaxBlobSize);
         }
@@ -70,7 +70,7 @@ namespace NWriter {
             return Blocks.at(group)->Write(std::move(page), type);
         }
 
-        TPageId WriteOuter(TSharedData page) noexcept override
+        TPageId WriteOuter(TSharedData page) override
         {
             return
                 Blocks.back()->Write(std::move(page), EPage::Opaque);
@@ -81,7 +81,7 @@ namespace NWriter {
             Blocks[0]->WriteInplace(page, body);
         }
 
-        NPageCollection::TGlobId WriteLarge(TString blob, ui64 ref) noexcept override
+        NPageCollection::TGlobId WriteLarge(TString blob, ui64 ref) override
         {
             ui8 bestChannel = ChannelsShares.Select(BlobsChannels);
             
@@ -93,7 +93,7 @@ namespace NWriter {
             return glob;
         }
 
-        void Finish(TString overlay) noexcept override
+        void Finish(TString overlay) override
         {
             auto &result = Results_.emplace_back();
 
@@ -113,19 +113,19 @@ namespace NWriter {
             result.Overlay = overlay;
         }
 
-        NPageCollection::TCookieAllocator& CookieRange(ui32 cookieRange) noexcept override
+        NPageCollection::TCookieAllocator& CookieRange(ui32 cookieRange) override
         {
             Y_ABORT_UNLESS(cookieRange == 0 || cookieRange == 1, "Invalid cookieRange requested");
 
             return cookieRange == 0 ? Banks.Meta : Banks.Data;
         }
 
-        void Put(NPageCollection::TGlob&& glob) noexcept override
+        void Put(NPageCollection::TGlob&& glob) override
         {
             Blobs.emplace_back(std::move(glob));
         }
 
-        NPageCollection::TLargeGlobId Put(ui32 cookieRange, ui8 channel, TArrayRef<const char> body, ui32 block) noexcept override
+        NPageCollection::TLargeGlobId Put(ui32 cookieRange, ui8 channel, TArrayRef<const char> body, ui32 block) override
         {
             const auto largeGlobId = CookieRange(cookieRange).Do(channel, body.size(), block);
 

--- a/ydb/core/tablet_flat/logic_alter_main.h
+++ b/ydb/core/tablet_flat/logic_alter_main.h
@@ -19,19 +19,19 @@ namespace NTabletFlatExecutor {
 
         }
 
-        void Describe(IOutputStream &out) const noexcept
+        void Describe(IOutputStream &out) const
         {
             out << "LAlter{log " << Log.size() << ", " << Bytes << "b}";
         }
 
         ui64 LogBytes() const noexcept { return Bytes; }
 
-        void RestoreLog(const NPageCollection::TLargeGlobId &largeGlobId) noexcept
+        void RestoreLog(const NPageCollection::TLargeGlobId &largeGlobId)
         {
             largeGlobId.MaterializeTo(Log), Bytes += largeGlobId.Bytes;
         }
 
-        void SnapToLog(NKikimrExecutorFlat::TLogSnapshot &snap) noexcept
+        void SnapToLog(NKikimrExecutorFlat::TLogSnapshot &snap)
         {
             auto items = snap.MutableSchemeInfoBodies();
             for (const auto &logo : Log)
@@ -43,7 +43,7 @@ namespace NTabletFlatExecutor {
             }
         }
 
-        void WriteLog(TLogCommit &commit, TString alter) noexcept
+        void WriteLog(TLogCommit &commit, TString alter)
         {
             Cookies->Switch(commit.Step, true /* require step switch */);
 

--- a/ydb/core/tablet_flat/logic_redo_batch.h
+++ b/ydb/core/tablet_flat/logic_redo_batch.h
@@ -20,7 +20,7 @@ namespace NRedo {
             Tables.insert(affects.begin(), affects.end());
         }
 
-        TArrayRef<const ui32> Affects() noexcept
+        TArrayRef<const ui32> Affects()
         {
             Affects_.assign(Tables.begin(), Tables.end());
             return Affects_;

--- a/ydb/core/tablet_flat/logic_redo_entry.h
+++ b/ydb/core/tablet_flat/logic_redo_entry.h
@@ -23,7 +23,7 @@ namespace NRedo {
             free(p);
         }
 
-        void Describe(IOutputStream &out) const noexcept
+        void Describe(IOutputStream &out) const
         {
             out
                 << "Redo{" << NFmt::TStamp(Stamp) << " (" << Embedded.size()

--- a/ydb/core/tablet_flat/logic_redo_queue.h
+++ b/ydb/core/tablet_flat/logic_redo_queue.h
@@ -37,14 +37,14 @@ namespace NRedo {
             Push(TEntry::Create(stamp, affects, std::move(embedded)));
         }
 
-        void Describe(IOutputStream &out) const noexcept
+        void Describe(IOutputStream &out) const
         {
             out
                 << "LRedo{" << Overhead.size() << "t" << ", " << Items
                 << " (" << Memory << " mem" << ", " << LargeGlobIdsBytes << " raw)b }";
         }
 
-        void Push(TEntry *entry) noexcept
+        void Push(TEntry *entry)
         {
             if (bool(entry->Embedded) == bool(entry->LargeGlobId)) {
                 Y_Fail(NFmt::Do(*entry) << " has incorrect payload");
@@ -72,7 +72,7 @@ namespace NRedo {
                 Y_Fail(NFmt::Do(*entry) << " has no effects on data");
         }
 
-        void Cut(ui32 table, NTable::TSnapEdge edge, TGCBlobDelta &gc) noexcept
+        void Cut(ui32 table, NTable::TSnapEdge edge, TGCBlobDelta &gc)
         {
             Y_ABORT_UNLESS(edge.TxStamp != Max<ui64>(), "Undefined TxStamp of edge");
 
@@ -121,7 +121,7 @@ namespace NRedo {
             }
         }
 
-        TArrayRef<const TUsage> GrabUsage() noexcept
+        TArrayRef<const TUsage> GrabUsage()
         {
             Usage.clear();
 

--- a/ydb/core/tablet_flat/logic_redo_table.h
+++ b/ydb/core/tablet_flat/logic_redo_table.h
@@ -18,7 +18,7 @@ namespace NRedo {
             Bytes = 0;
         }
 
-        TOverhead* Push(ui32 table, TEntry* entry) noexcept
+        TOverhead* Push(ui32 table, TEntry* entry)
         {
             if (Trace && Trace.back() == entry) {
                 Y_Fail(NFmt::Do(*entry) << " is dublicated in table trace");
@@ -34,7 +34,7 @@ namespace NRedo {
             return this;
         }
 
-        TOverhead* Cut(TTxStamp stamp, TGCBlobDelta &gc, ui64 &largeGlobIds) noexcept
+        TOverhead* Cut(TTxStamp stamp, TGCBlobDelta &gc, ui64 &largeGlobIds)
         {
             if (!Trace || stamp < Trace.front()->Stamp) {
                 return nullptr;

--- a/ydb/core/tablet_flat/logic_snap_main.h
+++ b/ydb/core/tablet_flat/logic_snap_main.h
@@ -27,7 +27,7 @@ namespace NTabletFlatExecutor {
 
         }
 
-        void Describe(IOutputStream &out) const noexcept
+        void Describe(IOutputStream &out) const
         {
             out
                 << "LSnap{" << Cookies->Tablet << ":" << Cookies->Gen
@@ -50,7 +50,7 @@ namespace NTabletFlatExecutor {
 
         const NSnap::TWaste& Waste() const noexcept { return *Waste_; }
 
-        void Confirm(ui32 step) noexcept
+        void Confirm(ui32 step)
         {
             if (Pending == 0 || Pending != step)
                 Y_Fail(

--- a/ydb/core/tablet_flat/logic_snap_waste.h
+++ b/ydb/core/tablet_flat/logic_snap_waste.h
@@ -14,7 +14,7 @@ namespace NSnap {
 
         TWaste(ui32 gen) : Since(ui64(gen) << 32) { }
 
-        void Describe(IOutputStream &out, bool full = false) const noexcept
+        void Describe(IOutputStream &out, bool full = false) const
         {
             out
                 << "Waste{" << NFmt::TStamp(Since) << ", " << Level << "b"

--- a/ydb/core/tablet_flat/tablet_flat_executed.cpp
+++ b/ydb/core/tablet_flat/tablet_flat_executed.cpp
@@ -59,7 +59,7 @@ ui64 TTabletExecutedFlat::EnqueueLowPriority(TAutoPtr<ITransaction> transaction)
     }
 }
 
-const NTable::TScheme& TTabletExecutedFlat::Scheme() const noexcept {
+const NTable::TScheme& TTabletExecutedFlat::Scheme() const {
     return static_cast<TExecutor*>(Executor())->Scheme();
 }
 

--- a/ydb/core/tablet_flat/tablet_flat_executed.h
+++ b/ydb/core/tablet_flat/tablet_flat_executed.h
@@ -30,7 +30,7 @@ protected:
     ui64 EnqueueExecute(TAutoPtr<ITransaction> transaction);
     ui64 EnqueueLowPriority(TAutoPtr<ITransaction> transaction);
 
-    const NTable::TScheme& Scheme() const noexcept;
+    const NTable::TScheme& Scheme() const;
 
     TActorContext ExecutorCtx(const TActivationContext &ctx) {
         return TActorContext(ctx.Mailbox, ctx.ExecutorThread, ctx.EventStart, ExecutorID());

--- a/ydb/core/tablet_flat/tablet_flat_executor.h
+++ b/ydb/core/tablet_flat/tablet_flat_executor.h
@@ -59,7 +59,7 @@ public:
         AtomicStore(&Dropped, true);
     }
 
-    void Describe(IOutputStream &out) const noexcept
+    void Describe(IOutputStream &out) const
     {
         out << "Res{";
 
@@ -104,9 +104,9 @@ struct IExecuting {
     virtual void LoanTable(ui32 tableId, const TString &partsInfo) = 0; // attach table parts to table (called on part destination)
     virtual void CleanupLoan(const TLogoBlobID &bundleId, ui64 from) = 0; // mark loan completion (called on part source)
     virtual void ConfirmLoan(const TLogoBlobID &bundleId, const TLogoBlobID &borrowId) = 0; // confirm loan update delivery (called on part destination)
-    virtual void EnableReadMissingReferences() noexcept = 0;
-    virtual void DisableReadMissingReferences() noexcept = 0;
-    virtual ui64 MissingReferencesSize() const noexcept = 0;
+    virtual void EnableReadMissingReferences() = 0;
+    virtual void DisableReadMissingReferences() = 0;
+    virtual ui64 MissingReferencesSize() const = 0;
 };
 
 class TTxMemoryProviderBase : TNonCopyable {
@@ -232,11 +232,11 @@ public:
         return Rescheduled_;
     }
 
-    void StartExecutionSpan() noexcept {
+    void StartExecutionSpan() {
         TransactionExecutionSpan = NWilson::TSpan(TWilsonTablet::TabletDetailed, TransactionSpan.GetTraceId(), "Tablet.Transaction.Execute");
     }
 
-    void FinishExecutionSpan() noexcept {
+    void FinishExecutionSpan() {
         TransactionExecutionSpan.EndOk();
     }
 
@@ -306,18 +306,18 @@ public:
     virtual void ReleaseTxData(TTxMemoryProvider &/*provider*/, const TActorContext &/*ctx*/) {}
     virtual TTxType GetTxType() const { return UnknownTxType; }
 
-    virtual void Describe(IOutputStream &out) const noexcept
+    virtual void Describe(IOutputStream &out) const
     {
         out << TypeName(*this);
     }
 
-    void SetupTxSpanName() noexcept {
+    void SetupTxSpanName() {
         if (TxSpan) {
             TxSpan.Attribute("Type", TypeName(*this));
         }
     }
 
-    void SetupTxSpan(NWilson::TTraceId traceId) noexcept {
+    void SetupTxSpan(NWilson::TTraceId traceId) {
         TxSpan = NWilson::TSpan(TWilsonTablet::TabletBasic, std::move(traceId), "Tablet.Transaction");
         if (TxSpan) {
             TxSpan.Attribute("Type", TypeName(*this));

--- a/ydb/core/tablet_flat/tablet_flat_executor.h
+++ b/ydb/core/tablet_flat/tablet_flat_executor.h
@@ -649,7 +649,7 @@ namespace NFlatExecutorSetup {
         virtual float GetRejectProbability() const = 0;
 
         // Returns current database scheme (executor must be active)
-        virtual const NTable::TScheme& Scheme() const noexcept = 0;
+        virtual const NTable::TScheme& Scheme() const = 0;
 
         virtual void SetPreloadTablesData(THashSet<ui32> tables) = 0;
 

--- a/ydb/core/tablet_flat/test/libs/exec/fuzzy.h
+++ b/ydb/core/tablet_flat/test/libs/exec/fuzzy.h
@@ -133,7 +133,7 @@ namespace NFake {
         }
 
     protected:
-        bool RegisterTable(ui32 table) noexcept
+        bool RegisterTable(ui32 table)
         {
             Y_ABORT_UNLESS(table < 8 * sizeof(Tables));
 

--- a/ydb/core/tablet_flat/test/libs/exec/helper.h
+++ b/ydb/core/tablet_flat/test/libs/exec/helper.h
@@ -11,7 +11,7 @@ namespace NFake {
     struct TStarter {
         using TMake = TTabletSetupInfo::TTabletCreationFunc;
 
-        IActor* Do(TActorId user, ui32 retry, ui32 tablet, TMake make, ui32 channelsCount, ui32 followerId = 0) noexcept
+        IActor* Do(TActorId user, ui32 retry, ui32 tablet, TMake make, ui32 channelsCount, ui32 followerId = 0)
         {
             const auto simple = TMailboxType::Simple;
 
@@ -21,7 +21,7 @@ namespace NFake {
             return new NFake::TOwner(user, retry, info, setup, followerId);
         }
 
-        virtual TStorageInfo* MakeTabletInfo(ui64 tablet, ui32 channelsCount) noexcept
+        virtual TStorageInfo* MakeTabletInfo(ui64 tablet, ui32 channelsCount)
         {
             const auto none = TErasureType::ErasureNone;
 

--- a/ydb/core/tablet_flat/test/libs/exec/leader.h
+++ b/ydb/core/tablet_flat/test/libs/exec/leader.h
@@ -74,7 +74,7 @@ namespace NFake {
             }
         }
 
-        void HandleGone(const TActorId &actor) noexcept
+        void HandleGone(const TActorId &actor)
         {
             auto it = Childs.find(actor);
 
@@ -117,7 +117,7 @@ namespace NFake {
             }
         }
 
-        void DoShutDown(bool force) noexcept
+        void DoShutDown(bool force)
         {
             force = force && (State < EState::Shut);
 

--- a/ydb/core/tablet_flat/test/libs/exec/logger.h
+++ b/ydb/core/tablet_flat/test/libs/exec/logger.h
@@ -21,7 +21,7 @@ namespace NFake {
 
         }
 
-        void Put(TInstant stamp, ui32 level, EComp comp, TArrayRef<const char> line) noexcept
+        void Put(TInstant stamp, ui32 level, EComp comp, TArrayRef<const char> line)
         {
             Y_ABORT_UNLESS(line.size() < 8192 * 16, "Too large log line");
 
@@ -86,13 +86,13 @@ namespace NFake {
 
         }
 
-        NUtil::TLogLn Log(ELnLev prio) const noexcept override
+        NUtil::TLogLn Log(ELnLev prio) const override
         {
             return { prio <= Level ? this : nullptr, prio };
         }
 
     private:
-        void LogLn(ELnLev prio, const TString &line) const noexcept override
+        void LogLn(ELnLev prio, const TString &line) const override
         {
             const auto comp = NKikimrServices::FAKE_ENV;
 

--- a/ydb/core/tablet_flat/test/libs/exec/nanny.h
+++ b/ydb/core/tablet_flat/test/libs/exec/nanny.h
@@ -97,7 +97,7 @@ namespace NFake {
         }
 
     protected:
-        void QueueTx(TFuncTx::TCall func) noexcept
+        void QueueTx(TFuncTx::TCall func)
         {
             TxInFlight++;
 
@@ -138,7 +138,7 @@ namespace NFake {
             }
         }
 
-        void Handle(NFake::TEvReady &ev) noexcept
+        void Handle(NFake::TEvReady &ev)
         {
             if (std::exchange(State, EDo::More) != EDo::Born) {
                 Y_ABORT("Got an unexpected TEvReady{ } event");
@@ -151,7 +151,7 @@ namespace NFake {
             QueueTx(CompareDbs);
         }
 
-        void Handle(NFake::TEvResult&) noexcept
+        void Handle(NFake::TEvResult&)
         {
             Y_ABORT_UNLESS(TxInFlight-- > 0, "Tx counter is underflowed");
 
@@ -170,7 +170,7 @@ namespace NFake {
             }
         }
 
-        void StartTablet() noexcept
+        void StartTablet()
         {
             if (auto logl = Logger->Log(NUtil::ELnLev::Info)) {
                 logl << "TNanny initiates TDummy tablet " << MyId << " birth";
@@ -186,7 +186,7 @@ namespace NFake {
             Send(TWorld::Where(EPath::Root), event);
         }
 
-        void DoSuicide() noexcept
+        void DoSuicide()
         {
             Send(std::exchange(Owner, { }), new TEvents::TEvGone);
             State = EDo::Gone;

--- a/ydb/core/tablet_flat/test/libs/exec/owner.h
+++ b/ydb/core/tablet_flat/test/libs/exec/owner.h
@@ -83,7 +83,7 @@ namespace NFake {
             }
         }
 
-        void Start(const TActorContext &ctx) noexcept
+        void Start(const TActorContext &ctx)
         {
             Y_ABORT_UNLESS(!Agent, "Tablet actor is already started");
 
@@ -106,7 +106,7 @@ namespace NFake {
             Borns += 1;
         }
 
-        void DoSuicide() noexcept
+        void DoSuicide()
         {
             Send(std::exchange(Owner, { }), new TEvents::TEvGone);
             Send(std::exchange(User, { }), new TEvents::TEvGone);

--- a/ydb/core/tablet_flat/test/libs/exec/runner.h
+++ b/ydb/core/tablet_flat/test/libs/exec/runner.h
@@ -87,7 +87,7 @@ namespace NFake {
             Env.AddLocalService(service, TActorSetupCmd(actor, box, 0), 0);
         }
 
-        void RunTest(TAutoPtr<IActor> actor) noexcept
+        void RunTest(TAutoPtr<IActor> actor)
         {
             return RunOn(8, { }, actor.Release(), EMail::Simple);
         }
@@ -192,7 +192,7 @@ namespace NFake {
             }
         }
 
-        static TVector<TString> MakeComponentsNames() noexcept
+        static TVector<TString> MakeComponentsNames()
         {
             const auto begin = ui32(NKikimrServices::EServiceKikimr_MIN);
             const auto end = ui32(NKikimrServices::EServiceKikimr_MAX) + 1;

--- a/ydb/core/tablet_flat/test/libs/exec/storage.h
+++ b/ydb/core/tablet_flat/test/libs/exec/storage.h
@@ -93,7 +93,7 @@ namespace NFake {
             Send(eh->Sender, ev, 0, eh->Cookie);
         }
 
-        void ReportUsage() const noexcept
+        void ReportUsage() const
         {
             if (auto logl = Logger->Log(ELnLev::Info)) {
 

--- a/ydb/core/tablet_flat/test/libs/exec/warden.h
+++ b/ydb/core/tablet_flat/test/libs/exec/warden.h
@@ -122,7 +122,7 @@ namespace NFake {
             }
         }
 
-        void StartGroup(ui32 group) noexcept
+        void StartGroup(ui32 group)
         {
             if (auto logl = Logger->Log(ELnLev::Info))
                 logl << "Starting storage for BS group " << group;
@@ -132,7 +132,7 @@ namespace NFake {
             Sys->RegisterLocalService(MakeBlobStorageProxyID(group), actor);
         }
 
-        void TryToDie() noexcept
+        void TryToDie()
         {
             if (Shutting && Alive == 0) {
                 if (auto logl = Logger->Log(ELnLev::Info))

--- a/ydb/core/tablet_flat/test/libs/rows/cook.h
+++ b/ydb/core/tablet_flat/test/libs/rows/cook.h
@@ -44,7 +44,7 @@ namespace NTest {
             return std::move(Row);
         }
 
-        TSchemedCookRow& To(TPos to) noexcept
+        TSchemedCookRow& To(TPos to)
         {
             if (to < On || to >= Scheme.Cols.size()) {
                 Y_ABORT("TSchemedCookRow row builder skip position is out of range");

--- a/ydb/core/tablet_flat/test/libs/rows/heap.h
+++ b/ydb/core/tablet_flat/test/libs/rows/heap.h
@@ -26,19 +26,19 @@ namespace NTest {
         TRowsHeap(TIntrusivePtr<TGrowHeap> heap) : Heap(std::move(heap)) { }
 
         template<typename TRand>
-        TIter Any(TRand &rnd) const noexcept
+        TIter Any(TRand &rnd) const
         {
             return begin() + rnd.Uniform(Rows.size());
         }
 
         template<typename TRand>
-        TIter AnyIn(TRand &rnd, TIter it, const TIter end) const noexcept
+        TIter AnyIn(TRand &rnd, TIter it, const TIter end) const
         {
             return it + rnd.Uniform(std::distance(it, end));
         }
 
         template<typename TRand>
-        TIter AnyOff(TRand &rnd, TIter it, const TIter end) const noexcept
+        TIter AnyOff(TRand &rnd, TIter it, const TIter end) const
         {
             size_t on = rnd.Uniform(Size() - std::distance(it, end));
 
@@ -62,7 +62,7 @@ namespace NTest {
             return Rows.size();
         }
 
-        const TRow& operator[](size_t on) const noexcept
+        const TRow& operator[](size_t on) const
         {
             Y_ABORT_UNLESS(on < Rows.size(), "Row index is out of hole scope");
 

--- a/ydb/core/tablet_flat/test/libs/rows/mass.h
+++ b/ydb/core/tablet_flat/test/libs/rows/mass.h
@@ -17,10 +17,10 @@ namespace NTest {
         IModel(TIntrusiveConstPtr<TRowScheme> scheme) : Scheme(scheme) { }
 
         virtual ~IModel() = default;
-        virtual TRow Make(ui64 seq, bool hole) noexcept = 0;
-        virtual ui64 Base(const TRow &row) const noexcept = 0;
+        virtual TRow Make(ui64 seq, bool hole) = 0;
+        virtual ui64 Base(const TRow &row) const = 0;
         virtual void Check(TArrayRef<const ui64>) const = 0;
-        virtual void Describe(IOutputStream&) const noexcept = 0;
+        virtual void Describe(IOutputStream&) const = 0;
 
         const TIntrusiveConstPtr<TRowScheme> Scheme;
     };
@@ -54,7 +54,7 @@ namespace NTest {
             }
         }
 
-        void Describe(IOutputStream &out) const noexcept
+        void Describe(IOutputStream &out) const
         {
             out
                 << "Mass{"
@@ -62,7 +62,7 @@ namespace NTest {
                 << " rows, " << Heap->Used() << "b}";
         }
 
-        const TRow* SnapBy(const TRow &row, bool next, bool hole) const noexcept
+        const TRow* SnapBy(const TRow &row, bool next, bool hole) const
         {
             auto it = Model->Base(row);
 

--- a/ydb/core/tablet_flat/test/libs/rows/misc.h
+++ b/ydb/core/tablet_flat/test/libs/rows/misc.h
@@ -37,7 +37,7 @@ namespace NTest{
     struct TRandomString {
         TRandomString(TGen &gen): Gen(gen) { }
 
-        TString Do(const size_t len) noexcept
+        TString Do(const size_t len)
         {
             TString line;
 

--- a/ydb/core/tablet_flat/test/libs/table/misc.cpp
+++ b/ydb/core/tablet_flat/test/libs/table/misc.cpp
@@ -53,7 +53,7 @@ TString PrintRow(const TMemIter& it)
 
 namespace NTest {
 
-    TString DumpPart(const TPartStore &partStore, ui32 depth) noexcept
+    TString DumpPart(const TPartStore &partStore, ui32 depth)
     {
         TStringStream out;
         TTestEnv env;

--- a/ydb/core/tablet_flat/test/libs/table/model/keys.h
+++ b/ydb/core/tablet_flat/test/libs/table/model/keys.h
@@ -29,7 +29,7 @@ namespace NTest {
             }
         }
 
-        TRow Make(ui64 seq, bool hole) noexcept override
+        TRow Make(ui64 seq, bool hole) override
         {
             TSchemedCookRow row(*Scheme);
 
@@ -40,12 +40,12 @@ namespace NTest {
             return *row.Col(hash, bucket, name, ui32(Saved += hole ? 0 : 1));
         }
 
-        void Describe(IOutputStream &out) const noexcept override
+        void Describe(IOutputStream &out) const override
         {
             out << "ModelS3Hash";
         }
 
-        ui64 Base(const TRow &row) const noexcept override
+        ui64 Base(const TRow &row) const override
         {
             auto *up = row.Get(NTable::TTag(8));
 

--- a/ydb/core/tablet_flat/test/libs/table/model/large.h
+++ b/ydb/core/tablet_flat/test/libs/table/model/large.h
@@ -21,7 +21,7 @@ namespace NTest {
 
         }
 
-        TRow Make(ui64, bool hole) noexcept override
+        TRow Make(ui64, bool hole) override
         {
             const ui64 up = hole ? 0 : 1;
 
@@ -52,7 +52,7 @@ namespace NTest {
             return Seq++, *row;
         }
 
-        void Describe(IOutputStream &out) const noexcept override
+        void Describe(IOutputStream &out) const override
         {
             out
                 << "Std{"
@@ -76,7 +76,7 @@ namespace NTest {
                     .Key({ 0, 1 });
         }
 
-        ui64 Base(const TRow &row) const noexcept override
+        ui64 Base(const TRow &row) const override
         {
             auto *up = row.Get(NTable::TTag(2));
 

--- a/ydb/core/tablet_flat/test/libs/table/model/small.h
+++ b/ydb/core/tablet_flat/test/libs/table/model/small.h
@@ -21,7 +21,7 @@ namespace NTest {
 
         }
 
-        TRow Make(ui64 seq, bool hole) noexcept override
+        TRow Make(ui64 seq, bool hole) override
         {
             TSchemedCookRow row(*Scheme);
 
@@ -30,12 +30,12 @@ namespace NTest {
             return *row;
         }
 
-        void Describe(IOutputStream &out) const noexcept override
+        void Describe(IOutputStream &out) const override
         {
             out << "Model2Cols";
         }
 
-        ui64 Base(const TRow &row) const noexcept override
+        ui64 Base(const TRow &row) const override
         {
             auto *up = row.Get(NTable::TTag(1));
 

--- a/ydb/core/tablet_flat/test/libs/table/test_comp.h
+++ b/ydb/core/tablet_flat/test/libs/table/test_comp.h
@@ -23,12 +23,12 @@ namespace NTest {
                 Conf.NoErased = false; /* Need all technical rows */
             }
 
-            IPages* MakeEnv() noexcept override
+            IPages* MakeEnv() override
             {
                 return Env;
             }
 
-            TPartView LoadPart(const TIntrusiveConstPtr<TColdPart>&) noexcept override {
+            TPartView LoadPart(const TIntrusiveConstPtr<TColdPart>&) override {
                 Y_ABORT("not supported in test scans");
             }
 
@@ -130,12 +130,12 @@ namespace NTest {
         }
 
     private:
-        virtual TInitialState Prepare(IDriver*, TIntrusiveConstPtr<TScheme>) noexcept override
+        virtual TInitialState Prepare(IDriver*, TIntrusiveConstPtr<TScheme>) override
         {
             Y_ABORT("IScan::Prepare(...) isn't used in test env compaction");
         }
 
-        EScan Seek(TLead &lead, ui64 seq) noexcept override
+        EScan Seek(TLead &lead, ui64 seq) override
         {
             Y_ABORT_UNLESS(seq < 2, "Test IScan impl Got too many Seek() calls");
 
@@ -144,31 +144,31 @@ namespace NTest {
             return seq == 0 ? EScan::Feed : EScan::Final;
         }
 
-        EScan BeginKey(TArrayRef<const TCell> key) noexcept override
+        EScan BeginKey(TArrayRef<const TCell> key) override
         {
             Writer->BeginKey(key);
 
             return Failed = 0, EScan::Feed;
         }
 
-        EScan BeginDeltas() noexcept override
+        EScan BeginDeltas() override
         {
             return Failed = 0, EScan::Feed;
         }
 
-        EScan Feed(const TRow &row, ui64 txId) noexcept override
+        EScan Feed(const TRow &row, ui64 txId) override
         {
             Writer->AddKeyDelta(row, txId);
 
             return Failed = 0, EScan::Feed;
         }
 
-        EScan EndDeltas() noexcept override
+        EScan EndDeltas() override
         {
             return Failed = 0, EScan::Feed;
         }
 
-        EScan Feed(const TRow &row, TRowVersion &rowVersion) noexcept override
+        EScan Feed(const TRow &row, TRowVersion &rowVersion) override
         {
             if (RemovedRowVersions) {
                 rowVersion = RemovedRowVersions.AdjustDown(rowVersion);
@@ -179,19 +179,19 @@ namespace NTest {
             return Failed = 0, EScan::Feed;
         }
 
-        EScan EndKey() noexcept override
+        EScan EndKey() override
         {
             Writer->EndKey();
 
             return Failed = 0, EScan::Feed;
         }
 
-        TAutoPtr<IDestructable> Finish(EAbort) noexcept override
+        TAutoPtr<IDestructable> Finish(EAbort) override
         {
             Y_ABORT("IScan::Finish(...) shouldn't be called in test env");
         }
 
-        void Describe(IOutputStream &out) const noexcept override
+        void Describe(IOutputStream &out) const override
         {
             out << "Compact{test env}";
         }

--- a/ydb/core/tablet_flat/test/libs/table/test_curtain.h
+++ b/ydb/core/tablet_flat/test/libs/table/test_curtain.h
@@ -61,7 +61,7 @@ namespace NTest {
     struct TSlicer {
         TSlicer(const TRowScheme &scheme) : Scheme(scheme) { }
 
-        TIntrusiveConstPtr<TSlices> Cut(const TPartStore &partStore, const TScreen &screen) noexcept
+        TIntrusiveConstPtr<TSlices> Cut(const TPartStore &partStore, const TScreen &screen)
         {
             TTestEnv env;
             TPartIter first(&partStore, { }, Scheme.Keys, &env);

--- a/ydb/core/tablet_flat/test/libs/table/test_dbase.h
+++ b/ydb/core/tablet_flat/test/libs/table/test_dbase.h
@@ -62,9 +62,9 @@ namespace NTest {
 
         TDbExec(TAutoPtr<TSchemeChanges> delta) : Base(Make(delta)) { }
 
-        const TRedoLog& GetLog() const noexcept { return RedoLog; }
+        const TRedoLog& GetLog() const { return RedoLog; }
 
-        const TChange& BackLog() const noexcept
+        const TChange& BackLog() const
         {
             Y_ABORT_UNLESS(RedoLog, "Redo log is empty, cannot get last entry");
 
@@ -73,7 +73,7 @@ namespace NTest {
 
         TDatabase* operator->() const noexcept { return Base.Get(); }
 
-        TDbExec& Begin() noexcept
+        TDbExec& Begin()
         {
             return DoBegin(true);
         }
@@ -192,12 +192,12 @@ namespace NTest {
             return Base->TxSnapTable(table);
         }
 
-        NTest::TSchemedCookRow SchemedCookRow(ui32 table) noexcept
+        NTest::TSchemedCookRow SchemedCookRow(ui32 table)
         {
             return { RowSchemeFor(table) };
         }
 
-        TCheckIter Iter(ui32 table, bool erased = true) noexcept
+        TCheckIter Iter(ui32 table, bool erased = true)
         {
             DoBegin(false), RowSchemeFor(table);
 
@@ -206,7 +206,7 @@ namespace NTest {
             return check.To(CurrentStep()), check;
         }
 
-        TCheckIter IterData(ui32 table) noexcept
+        TCheckIter IterData(ui32 table)
         {
             DoBegin(false), RowSchemeFor(table);
 
@@ -215,7 +215,7 @@ namespace NTest {
             return check.To(CurrentStep()), check;
         }
 
-        TCheckSelect Select(ui32 table, bool erased = true) noexcept
+        TCheckSelect Select(ui32 table, bool erased = true)
         {
             DoBegin(false), RowSchemeFor(table);
 
@@ -341,7 +341,7 @@ namespace NTest {
             return *this;
         }
 
-        const TRowScheme& RowSchemeFor(ui32 table) noexcept
+        const TRowScheme& RowSchemeFor(ui32 table)
         {
             if (std::exchange(Last, table) != table) {
                 // Note: it's ok if the table has been altered, since
@@ -373,7 +373,7 @@ namespace NTest {
             return *this;
         }
 
-        void DumpChanges(IOutputStream &stream) const noexcept
+        void DumpChanges(IOutputStream &stream) const
         {
             for (auto &one: RedoLog) {
                 NUtil::NBin::TOut(stream)
@@ -420,12 +420,12 @@ namespace NTest {
         }
 
     private:
-        void Birth() noexcept
+        void Birth()
         {
             Annex = new TSteppedCookieAllocator(1, ui64(++Gen) << 32, { 0, 999 }, {{ 1, 7 }});
         }
 
-        TDbExec& DoBegin(bool real) noexcept
+        TDbExec& DoBegin(bool real)
         {
             if (OnTx == EOnTx::Real && real) {
                 Y_ABORT("Cannot run multiple tx at the same time");

--- a/ydb/core/tablet_flat/test/libs/table/test_dummy.h
+++ b/ydb/core/tablet_flat/test/libs/table/test_dummy.h
@@ -8,12 +8,12 @@ namespace NTable {
 
     class TDummyEnv: public IPages {
     public:
-        TResult Locate(const TMemTable *memTable, ui64 ref, ui32 tag) noexcept override
+        TResult Locate(const TMemTable *memTable, ui64 ref, ui32 tag) override
         {
             return MemTableRefLookup(memTable, ref, tag);
         }
 
-        TResult Locate(const TPart*, ui64, ELargeObj) noexcept override
+        TResult Locate(const TPart*, ui64, ELargeObj) override
         {
             Y_ABORT("Dummy env cannot deal with storage");
         }

--- a/ydb/core/tablet_flat/test/libs/table/test_envs.h
+++ b/ydb/core/tablet_flat/test/libs/table/test_envs.h
@@ -32,12 +32,12 @@ namespace NTest {
 
         TNoEnv(bool pages, ELargeObjNeed lobs) : Pages(pages) , Lobs(lobs) { }
 
-        TResult Locate(const TMemTable *memTable, ui64 ref, ui32 tag) noexcept override
+        TResult Locate(const TMemTable *memTable, ui64 ref, ui32 tag) override
         {
             return TTestEnv::Locate(memTable, ref, tag);
         }
 
-        TResult Locate(const TPart *part, ui64 ref, ELargeObj lob) noexcept override
+        TResult Locate(const TPart *part, ui64 ref, ELargeObj lob) override
         {
             const bool pass = Lobs == ELargeObjNeed::Has;
             const bool need = Lobs == ELargeObjNeed::Yes;
@@ -60,15 +60,15 @@ namespace NTest {
         struct TSeen {
             TSeen() = default;
 
-            TSeen(const void *token, ui64 ref) noexcept
+            TSeen(const void *token, ui64 ref)
                 : Token(token) , Ref(ref) { }
 
-            bool operator==(const TSeen &seen) const noexcept
+            bool operator==(const TSeen &seen) const
             {
                 return Token == seen.Token && Ref == seen.Ref;
             }
             
-            bool operator<(const TSeen &seen) const noexcept
+            bool operator<(const TSeen &seen) const
             {
                 return Token < seen.Token || Token == seen.Token && Ref < seen.Ref;
             }
@@ -93,12 +93,12 @@ namespace NTest {
             }
         }
 
-        TResult Locate(const TMemTable *memTable, ui64 ref, ui32 tag) noexcept override
+        TResult Locate(const TMemTable *memTable, ui64 ref, ui32 tag) override
         {
             return TTestEnv::Locate(memTable, ref, tag);
         }
 
-        TResult Locate(const TPart *part, ui64 ref, ELargeObj lob) noexcept override
+        TResult Locate(const TPart *part, ui64 ref, ELargeObj lob) override
         {
             if (ShouldPass((const void*)part->Large.Get(), ref, false)) {
                 return TTestEnv::Locate(part, ref, lob);
@@ -135,7 +135,7 @@ namespace NTest {
             return pass;
         }
 
-        bool IsRecent(TSeen seen, bool isIndex) noexcept
+        bool IsRecent(TSeen seen, bool isIndex)
         {
             if (isIndex) {
                 auto it = IndexTraceTtl.find(seen);
@@ -151,7 +151,7 @@ namespace NTest {
             }
         }
 
-        bool AmILucky() noexcept
+        bool AmILucky()
         {
             return Rate >= 1. || Rnd.GenRandReal4() <= Rate;
         }
@@ -174,7 +174,7 @@ namespace NTest {
             {
             }
 
-            TResult DoLoad(TPageId pageId, EPage type, ui64 lower, ui64 upper) noexcept
+            TResult DoLoad(TPageId pageId, EPage type, ui64 lower, ui64 upper)
             {
                 if (std::exchange(Grow, false)) {
                     PageLoadingLogic->Forward(this, upper);
@@ -200,7 +200,7 @@ namespace NTest {
             }
 
         private:
-            ui64 AddToQueue(TPageId pageId, EPage type) noexcept override
+            ui64 AddToQueue(TPageId pageId, EPage type) override
             {
                 if (IsIndexPage(type)) {
                     IndexFetch.push_back(pageId);
@@ -240,7 +240,7 @@ namespace NTest {
 
         }
 
-        TResult Locate(const TMemTable *memTable, ui64 ref, ui32 tag) noexcept override
+        TResult Locate(const TMemTable *memTable, ui64 ref, ui32 tag) override
         {
             return
                 MemTable
@@ -248,7 +248,7 @@ namespace NTest {
                     : MemTableRefLookup(memTable, ref, tag);
         }
 
-        TResult Locate(const TPart *part, ui64 ref, ELargeObj lob) noexcept override
+        TResult Locate(const TPart *part, ui64 ref, ELargeObj lob) override
         {
             InitPart(part);
 
@@ -284,7 +284,7 @@ namespace NTest {
         }
 
     private:
-        TPartGroupLoadingQueue& Get(const TPart *part, ui32 queueIndex) noexcept
+        TPartGroupLoadingQueue& Get(const TPart *part, ui32 queueIndex)
         {
             auto& partGroupQueues = PartGroupQueues[part];
 
@@ -330,7 +330,7 @@ namespace NTest {
             }
         }
 
-        THolder<NFwd::IPageLoadingLogic> MakeExtern(const TPartStore *part) const noexcept
+        THolder<NFwd::IPageLoadingLogic> MakeExtern(const TPartStore *part) const
         {
             if (auto &large = part->Large) {
                 Y_ABORT_UNLESS(part->Blobs, "Part has frames but not blobs");
@@ -342,7 +342,7 @@ namespace NTest {
                 return nullptr;
         }
 
-        THolder<NFwd::IPageLoadingLogic> MakeOuter(const TPart *part) const noexcept
+        THolder<NFwd::IPageLoadingLogic> MakeOuter(const TPart *part) const
         {
             if (auto &small = part->Small) {
                 TVector<ui32> edge(small->Stats().Tags.size(), Max<ui32>());

--- a/ydb/core/tablet_flat/test/libs/table/test_iter.h
+++ b/ydb/core/tablet_flat/test/libs/table/test_iter.h
@@ -56,7 +56,7 @@ namespace NTest {
         }
 
         template<typename TEnv>
-        TAutoPtr<TEnv> Displace(TAutoPtr<IPages> env) noexcept
+        TAutoPtr<TEnv> Displace(TAutoPtr<IPages> env)
         {
             auto *origin = std::exchange(Env, env).Release();
             auto *casted = dynamic_cast<TEnv*>(origin);

--- a/ydb/core/tablet_flat/test/libs/table/test_make.h
+++ b/ydb/core/tablet_flat/test/libs/table/test_make.h
@@ -20,7 +20,7 @@ namespace NTest {
 
         struct IBand {
             virtual ~IBand() = default;
-            virtual void Add(const TRow&) noexcept = 0;
+            virtual void Add(const TRow&) = 0;
             virtual void Ver(TRowVersion rowVersion = TRowVersion::Min()) = 0;
         };
 
@@ -32,7 +32,7 @@ namespace NTest {
 
             }
 
-            void Add(const TRow &row) noexcept override
+            void Add(const TRow &row) override
             {
                 Cook.Add(row);
             }
@@ -53,7 +53,7 @@ namespace NTest {
 
             }
 
-            void Add(const TRow &row) noexcept override
+            void Add(const TRow &row) override
             {
                 Cooker.Add(row, ERowOp::Upsert);
             }

--- a/ydb/core/tablet_flat/test/libs/table/test_part.h
+++ b/ydb/core/tablet_flat/test/libs/table/test_part.h
@@ -37,12 +37,12 @@ namespace NTest {
 
         }
 
-        ui64 DataSize() const override
+        ui64 DataSize() const noexcept override
         {
             return Store->PageCollectionBytes(0);
         }
 
-        ui64 BackingSize() const override
+        ui64 BackingSize() const noexcept override
         {
             return Store->PageCollectionBytes(0) + Store->PageCollectionBytes(Store->GetOuterRoom());
         }
@@ -88,12 +88,12 @@ namespace NTest {
 
     class TTestEnv: public IPages {
     public:
-        TResult Locate(const TMemTable *memTable, ui64 ref, ui32 tag) noexcept override
+        TResult Locate(const TMemTable *memTable, ui64 ref, ui32 tag) override
         {
             return MemTableRefLookup(memTable, ref, tag);
         }
 
-        TResult Locate(const TPart *part, ui64 ref, ELargeObj lob) noexcept override
+        TResult Locate(const TPart *part, ui64 ref, ELargeObj lob) override
         {
             auto* partStore = CheckedCast<const TPartStore*>(part);
 
@@ -123,24 +123,24 @@ namespace NTest {
     };
 
     struct TPartEggs {
-        const TIntrusiveConstPtr<TPartStore>& At(size_t num) const noexcept
+        const TIntrusiveConstPtr<TPartStore>& At(size_t num) const
         {
             return Parts.at(num);
         }
 
-        const TIntrusiveConstPtr<TPartStore>& Lone() const noexcept
+        const TIntrusiveConstPtr<TPartStore>& Lone() const
         {
             Y_ABORT_UNLESS(Parts.size() == 1, "Need egg with one part inside");
 
             return Parts[0];
         }
 
-        bool NoResult() const noexcept
+        bool NoResult() const
         {
             return Written == nullptr;  /* compaction was aborted */
         }
 
-        TPartView ToPartView() const noexcept
+        TPartView ToPartView() const
         {
             return { Lone(), nullptr, Lone()->Slices };
         }
@@ -150,7 +150,7 @@ namespace NTest {
         TVector<TIntrusiveConstPtr<TPartStore>> Parts;
     };
 
-    TString DumpPart(const TPartStore&, ui32 depth = 10) noexcept;
+    TString DumpPart(const TPartStore&, ui32 depth = 10);
 
     namespace IndexTools {
         using TGroupId = NPage::TGroupId;

--- a/ydb/core/tablet_flat/test/libs/table/test_steps.h
+++ b/ydb/core/tablet_flat/test/libs/table/test_steps.h
@@ -11,7 +11,7 @@ namespace NTest {
     template<typename TImpl>
     class TSteps {
     public:
-        TImpl& To(size_t seq) noexcept
+        TImpl& To(size_t seq)
         {
             Y_ABORT_UNLESS(seq >= Seq, "Invalid sequence flow");
 
@@ -20,7 +20,7 @@ namespace NTest {
             return static_cast<TImpl&>(*this);
         }
 
-        IOutputStream& Log() const noexcept
+        IOutputStream& Log() const
         {
             Cerr << CurrentStepStr() << ": ";
 
@@ -29,7 +29,7 @@ namespace NTest {
 
         size_t CurrentStep() const noexcept { return Seq; }
 
-        TString CurrentStepStr() const noexcept { return TStringBuilder() << "On " << CurrentStep(); }
+        TString CurrentStepStr() const { return TStringBuilder() << "On " << CurrentStep(); }
 
     private:
         size_t Seq     = 0;

--- a/ydb/core/tablet_flat/test/libs/table/test_store.h
+++ b/ydb/core/tablet_flat/test/libs/table/test_store.h
@@ -53,7 +53,7 @@ namespace NTest {
             return Groups + 1;
         }
 
-        const TSharedData* GetPage(ui32 room, ui32 page) const noexcept
+        const TSharedData* GetPage(ui32 room, ui32 page) const
         {
             Y_ABORT_UNLESS(room < PageCollections.size(), "Room is out of bounds");
 
@@ -62,40 +62,40 @@ namespace NTest {
             return &PageCollections.at(room).at(page);
         }
 
-        size_t GetPageSize(ui32 room, ui32 page) const noexcept
+        size_t GetPageSize(ui32 room, ui32 page) const
         {
             Y_ABORT_UNLESS(room < PageCollections.size(), "Room is out of bounds");
 
             return PageCollections.at(room).at(page).size();
         }
 
-        NPage::EPage GetPageType(ui32 room, ui32 page) const noexcept
+        NPage::EPage GetPageType(ui32 room, ui32 page) const
         {
             Y_ABORT_UNLESS(room < PageCollections.size(), "Room is out of bounds");
 
             return PageTypes.at(room).at(page);
         }
 
-        TArrayRef<const TSharedData> PageCollectionArray(ui32 room) const noexcept
+        TArrayRef<const TSharedData> PageCollectionArray(ui32 room) const
         {
             Y_ABORT_UNLESS(room < PageCollections.size(), "Only regular rooms can be used as arr");
 
             return PageCollections[room];
         }
 
-        NPageCollection::TGlobId GlobForBlob(ui64 ref) const noexcept
+        NPageCollection::TGlobId GlobForBlob(ui64 ref) const
         {
             const auto& blob = PageCollections[GetExternRoom()].at(ref);
 
             return { TLogoBlobID(1, 2, 3, 7, blob.size(), GlobOffset + ref), /* fake group */ 123 };
         }
 
-        ui32 PageCollectionPagesCount(ui32 room) const noexcept
+        ui32 PageCollectionPagesCount(ui32 room) const
         {
             return PageCollections.at(room).size();
         }
 
-        ui64 PageCollectionBytes(ui32 room) const noexcept
+        ui64 PageCollectionBytes(ui32 room) const
         {
             auto &pages = PageCollections.at(room);
 
@@ -119,7 +119,7 @@ namespace NTest {
         /**
          * Used for legacy part from a binary file
          */
-        TEggs LegacyEggs() const noexcept
+        TEggs LegacyEggs() const
         {
             if (PageCollectionPagesCount(MainPageCollection) == 0) {
                 Y_ABORT("Cannot construct an empty part");
@@ -146,7 +146,7 @@ namespace NTest {
             };
         }
 
-        void Dump(IOutputStream &stream) const noexcept
+        void Dump(IOutputStream &stream) const
         {
             NUtil::NBin::TOut out(stream);
 
@@ -206,7 +206,7 @@ namespace NTest {
             return storage;
         }
 
-        TPageId WriteOuter(TSharedData page) noexcept
+        TPageId WriteOuter(TSharedData page)
         {
             Y_ABORT_UNLESS(!Finished, "This store is already finished");
 
@@ -219,7 +219,7 @@ namespace NTest {
             return pageId;
         }
 
-        TPageId Write(TSharedData page, EPage type, ui32 group) noexcept
+        TPageId Write(TSharedData page, EPage type, ui32 group)
         {
             Y_ABORT_UNLESS(group < PageCollections.size() - 1, "Invalid column group");
             Y_ABORT_UNLESS(!Finished, "This store is already finished");
@@ -259,14 +259,14 @@ namespace NTest {
             return pageId;
         }
 
-        void WriteInplace(TPageId page, TArrayRef<const char> body) noexcept
+        void WriteInplace(TPageId page, TArrayRef<const char> body)
         {
             Y_ABORT_UNLESS(page == Scheme);
 
             Meta = TSharedData::Copy(body.data(), body.size());
         }
 
-        NPageCollection::TGlobId WriteLarge(TSharedData data) noexcept
+        NPageCollection::TGlobId WriteLarge(TSharedData data)
         {
             Y_ABORT_UNLESS(!Finished, "This store is already finished");
 
@@ -279,7 +279,7 @@ namespace NTest {
             return GlobForBlob(pageId);
         }
 
-        void Finish() noexcept
+        void Finish()
         {
             Y_ABORT_UNLESS(!Finished, "Cannot finish test store more than once");
             Finished = true;

--- a/ydb/core/tablet_flat/test/libs/table/test_writer.h
+++ b/ydb/core/tablet_flat/test/libs/table/test_writer.h
@@ -31,7 +31,7 @@ namespace NTest {
 
         }
 
-        TIntrusiveConstPtr<TPartStore> Load(const TLogoBlobID token) noexcept
+        TIntrusiveConstPtr<TPartStore> Load(const TLogoBlobID token)
         {
             using NPage::TFrames;
             using NPage::TExtBlobs;
@@ -120,7 +120,7 @@ namespace NTest {
         }
 
     private:
-        TStore::TEggs RootedEggs(const NProto::TLayout &lay) const noexcept
+        TStore::TEggs RootedEggs(const NProto::TLayout &lay) const
         {
             const auto undef = Max<NPage::TPageId>();
 
@@ -192,34 +192,34 @@ namespace NTest {
                 { new TWriteStats(written), std::move(scheme), std::move(Parts) };
         }
 
-        TStore& Back() noexcept
+        TStore& Back()
         {
             return Store ? *Store : *(Store = new TStore(Groups, NextGlobOffset));
         }
 
     private:
-        TPageId WriteOuter(TSharedData blob) noexcept override
+        TPageId WriteOuter(TSharedData blob) override
         {
             return Back().WriteOuter(blob);
         }
 
-        TPageId Write(TSharedData page, EPage type, ui32 group) noexcept override
+        TPageId Write(TSharedData page, EPage type, ui32 group) override
         {
             return Back().Write(page, type, group);
         }
 
-        void WriteInplace(TPageId page, TArrayRef<const char> body) noexcept override
+        void WriteInplace(TPageId page, TArrayRef<const char> body) override
         {
             Back().WriteInplace(page, body);
         }
 
-        NPageCollection::TGlobId WriteLarge(TString blob, ui64 ref) noexcept override
+        NPageCollection::TGlobId WriteLarge(TString blob, ui64 ref) override
         {
             Growth->Pass(ref);
             return Back().WriteLarge(TSharedData::Copy(blob));
         }
 
-        void Finish(TString overlay) noexcept override
+        void Finish(TString overlay) override
         {
             Y_ABORT_UNLESS(Store, "Finish called without any writes");
 
@@ -403,7 +403,7 @@ namespace NTest {
             return Pages.Flush(std::move(Scheme), Writer->Finish());
         }
 
-        ui64 GetDataBytes(ui32 room) noexcept
+        ui64 GetDataBytes(ui32 room)
         {
             return Pages.Back().GetDataBytes(room);
         }

--- a/ydb/core/tablet_flat/test/libs/table/wrap_dbase.h
+++ b/ydb/core/tablet_flat/test/libs/table/wrap_dbase.h
@@ -38,12 +38,12 @@ namespace NTest {
             return Iter->Remap;
         }
 
-        void Make(IPages*) noexcept
+        void Make(IPages*)
         {
             Iter = nullptr;
         }
 
-        EReady Seek(TRawVals key, ESeek seek) noexcept
+        EReady Seek(TRawVals key, ESeek seek)
         {
             if (seek == ESeek::Upper && !key)
                 Y_ABORT("Cannot cast ESeek::Upper with empty key to ELookup");
@@ -80,12 +80,12 @@ namespace NTest {
             return Iter->Next(Mode);
         }
 
-        EReady Next() noexcept
+        EReady Next()
         {
             return Iter->Next(Mode);
         }
 
-        const TRowState& Apply() noexcept
+        const TRowState& Apply()
         {
             return Iter->Row();
         }

--- a/ydb/core/tablet_flat/test/libs/table/wrap_iter.h
+++ b/ydb/core/tablet_flat/test/libs/table/wrap_iter.h
@@ -54,12 +54,12 @@ namespace NTest {
             return Iter->Remap;
         }
 
-        void Make(IPages *env) noexcept
+        void Make(IPages *env)
         {
             Iter = nullptr, Env = env; /* Have to make on each Seek(...) */
         }
 
-        EReady Seek(TRawVals key_, ESeek seek) noexcept
+        EReady Seek(TRawVals key_, ESeek seek)
         {
             const TCelled key(key_, *Scheme->Keys, false);
 
@@ -89,12 +89,12 @@ namespace NTest {
             return Iter->Next(ENext::All);
         }
 
-        EReady Next() noexcept
+        EReady Next()
         {
             return Iter->Next(ENext::All);
         }
 
-        const TRowState& Apply() noexcept
+        const TRowState& Apply()
         {
             return Iter->Row();
         }

--- a/ydb/core/tablet_flat/test/libs/table/wrap_part.h
+++ b/ydb/core/tablet_flat/test/libs/table/wrap_part.h
@@ -73,19 +73,19 @@ namespace NTest {
             return Remap_;
         }
 
-        void Make(IPages *env) noexcept
+        void Make(IPages *env)
         {
             Ready = EReady::Gone;
             Iter = MakeHolder<TRunIter>(Run, Remap_.Tags, Scheme->Keys, env);
         }
 
-        EReady Seek(TRawVals key_, ESeek seek) noexcept
+        EReady Seek(TRawVals key_, ESeek seek)
         {
             const TCelled key(key_, *Scheme->Keys, false);
             return Seek(key, seek);
         }
 
-        EReady Seek(const TCells key, ESeek seek) noexcept
+        EReady Seek(const TCells key, ESeek seek)
         {
             if constexpr (Direction == EDirection::Reverse) {
                 Ready = Iter->SeekReverse(key, seek);
@@ -101,7 +101,7 @@ namespace NTest {
             return Ready;
         }
 
-        EReady SkipToRowVersion(TRowVersion rowVersion) noexcept
+        EReady SkipToRowVersion(TRowVersion rowVersion)
         {
             TIteratorStats stats;
             Ready = Iter->SkipToRowVersion(rowVersion, stats, /* committed */ nullptr, /* observer */ nullptr,
@@ -115,7 +115,7 @@ namespace NTest {
             return Ready;
         }
 
-        TRowVersion GetRowVersion() const noexcept
+        TRowVersion GetRowVersion() const
         {
             Y_ABORT_UNLESS(Ready == EReady::Data);
 
@@ -126,7 +126,7 @@ namespace NTest {
             StopKey = TOwnedCellVec::Make(key);
         }
 
-        EReady Next() noexcept
+        EReady Next()
         {
             if (std::exchange(NoBlobs, false)) {
                 Ready = RollUp();
@@ -138,7 +138,7 @@ namespace NTest {
             return Ready;
         }
 
-        const TRowState& Apply() noexcept
+        const TRowState& Apply()
         {
             Y_ABORT_UNLESS(Ready == EReady::Data, "Row state isn't ready");
 
@@ -180,7 +180,7 @@ namespace NTest {
         const bool Defaults = true;
 
     private:
-        EReady DoIterNext() noexcept
+        EReady DoIterNext()
         {
             if constexpr (Direction == EDirection::Reverse) {
                 return Iter->Prev();

--- a/ydb/core/tablet_flat/test/libs/table/wrap_select.h
+++ b/ydb/core/tablet_flat/test/libs/table/wrap_select.h
@@ -37,12 +37,12 @@ namespace NTest {
             return Remap_;
         }
 
-        void Make(IPages*) noexcept
+        void Make(IPages*)
         {
             State.Init(0);
         }
 
-        EReady Seek(TRawVals key, ESeek seek) noexcept
+        EReady Seek(TRawVals key, ESeek seek)
         {
             Y_ABORT_UNLESS(seek == ESeek::Exact, "Db Select(...) is a point lookup");
 
@@ -54,12 +54,12 @@ namespace NTest {
             return (Ready = Base.Select(Table, key, Scheme->Tags(), State, /* readFlags */ 0, Snapshot, txMap));
         }
 
-        EReady Next() noexcept
+        EReady Next()
         {
             return (Ready = EReady::Gone);
         }
 
-        const TRowState& Apply() noexcept
+        const TRowState& Apply()
         {
             return State;
         }

--- a/ydb/core/tablet_flat/test/libs/table/wrap_warm.h
+++ b/ydb/core/tablet_flat/test/libs/table/wrap_warm.h
@@ -36,12 +36,12 @@ namespace NTest {
             return Remap_;
         }
 
-        void Make(IPages *env) noexcept
+        void Make(IPages *env)
         {
             Iter = nullptr, Env = env; /* Have to make on each Seek(...) */
         }
 
-        EReady Seek(TRawVals key_, ESeek seek) noexcept
+        EReady Seek(TRawVals key_, ESeek seek)
         {
             const TCelled key(key_, *Scheme->Keys, false);
 
@@ -50,7 +50,7 @@ namespace NTest {
             return RollUp();
         }
 
-        EReady Next() noexcept
+        EReady Next()
         {
             if constexpr (Direction == EDirection::Reverse) {
                 Iter->Prev();
@@ -61,7 +61,7 @@ namespace NTest {
             return RollUp();
         }
 
-        const TRowState& Apply() noexcept
+        const TRowState& Apply()
         {
             Y_ABORT_UNLESS(*this, "Iterator isn't ready");
 

--- a/ydb/core/tablet_flat/test/tool/perf/colons.cpp
+++ b/ydb/core/tablet_flat/test/tool/perf/colons.cpp
@@ -18,7 +18,7 @@ TColons::~TColons()
 }
 
 
-TString TColons::Next() noexcept
+TString TColons::Next()
 {
     TString token;
 
@@ -37,7 +37,7 @@ TString TColons::Next() noexcept
 }
 
 
-TString TColons::Token(const TString &def) noexcept
+TString TColons::Token(const TString &def)
 {
     TString token = Next();
 

--- a/ydb/core/tablet_flat/test/tool/perf/colons.h
+++ b/ydb/core/tablet_flat/test/tool/perf/colons.h
@@ -16,8 +16,8 @@ namespace NKikiSched {
             return At != TString::npos && At < Line.size();
         }
 
-        TString Next() noexcept;
-        TString Token(const TString &def) noexcept;
+        TString Next();
+        TString Token(const TString &def);
 
         template<typename TVal>
         TVal Pop(const TVal &def)

--- a/ydb/core/tablet_flat/test/tool/perf/desc.h
+++ b/ydb/core/tablet_flat/test/tool/perf/desc.h
@@ -16,7 +16,7 @@ namespace NKikiSched {
         struct TPut {
 
             template<typename ...TArg>
-            static void Do(TOut &out, const Type *ob, TArg&& ... args) noexcept
+            static void Do(TOut &out, const Type *ob, TArg&& ... args)
             {
                 ob->Describe(out, std::forward<TArg>(args)...);
             }
@@ -27,7 +27,7 @@ namespace NKikiSched {
             TDesc(const Type *ob, TArg&& ...args)
                 : Ob(ob), Args(std::forward<TArg>(args)...) { }
 
-            inline TOut& Do(TOut &out) const noexcept
+            inline TOut& Do(TOut &out) const
             {
                 using Tups = std::tuple_size<std::tuple<TArg...>>;
 
@@ -36,7 +36,7 @@ namespace NKikiSched {
 
         private:
             template<size_t ... Index>
-            inline TOut& Do(TOut &out, NHelp::TIndexes<Index...>) const noexcept
+            inline TOut& Do(TOut &out, NHelp::TIndexes<Index...>) const
             {
                 if (Ob == nullptr) return out << "{nil}";
 
@@ -50,19 +50,19 @@ namespace NKikiSched {
         };
 
         template<typename Type, typename ...TArg>
-        inline TDesc<Type, TArg...> If(const Type *ob, TArg&& ...args) noexcept
+        inline TDesc<Type, TArg...> If(const Type *ob, TArg&& ...args)
         {
             return { ob, std::forward<TArg>(args)... };
         }
 
         template<typename Type, typename ...TArg>
-        inline TDesc<Type, TArg...> Do(const Type &ob, TArg&& ...args) noexcept
+        inline TDesc<Type, TArg...> Do(const Type &ob, TArg&& ...args)
         {
             return { &ob, std::forward<TArg>(args)... };
         }
 
         template<typename Type, typename ...TArg>
-        inline TString Ln(const Type &ob, TArg&& ...args) noexcept
+        inline TString Ln(const Type &ob, TArg&& ...args)
         {
             TStringStream ss;
 

--- a/ydb/core/tablet_flat/test/tool/perf/do_mem.h
+++ b/ydb/core/tablet_flat/test/tool/perf/do_mem.h
@@ -55,7 +55,7 @@ namespace NPerf {
         }
 
     private:
-        void Apply(TSponge &aggr) noexcept
+        void Apply(TSponge &aggr)
         {
             State.Reset(Remap.CellDefaults());
 

--- a/ydb/core/tablet_flat/test/tool/perf/do_part.h
+++ b/ydb/core/tablet_flat/test/tool/perf/do_part.h
@@ -42,7 +42,7 @@ namespace NPerf {
             }
         }
 
-        static NPage::TConf Config(bool compress) noexcept
+        static NPage::TConf Config(bool compress)
         {
             NPage::TConf conf;
 
@@ -54,7 +54,7 @@ namespace NPerf {
             return conf;
         }
 
-        static TStats Stats(const TPart &part_) noexcept
+        static TStats Stats(const TPart &part_)
         {
             auto &part = dynamic_cast<const NTest::TPartStore&>(part_);
 

--- a/ydb/core/tablet_flat/test/tool/perf/format.h
+++ b/ydb/core/tablet_flat/test/tool/perf/format.h
@@ -21,7 +21,7 @@ namespace NKikiSched {
                 return sizeof(TVal) * 2;
             }
 
-            TOut& Do(TOut &out) const noexcept
+            TOut& Do(TOut &out) const
             {
                 const char _pad_zero[] = "00000000000000000000";
                 const char _pad_ffff[] = "ff..ffffffffffffffff";
@@ -56,7 +56,7 @@ namespace NKikiSched {
         struct TLarge {
             TLarge(ui64 val, bool pad = false): Val(val), Pad(pad) { }
 
-            TOut& Do(TOut &out) const noexcept
+            TOut& Do(TOut &out) const
             {
                 const ui64 grid[] = {
                         0x00000000000003e8, /* K 10 ** 3    */
@@ -78,7 +78,7 @@ namespace NKikiSched {
             }
 
         protected:
-            inline TOut& Small(TOut &out) const noexcept
+            inline TOut& Small(TOut &out) const
             {
                 char ln_[8];
 
@@ -97,7 +97,7 @@ namespace NKikiSched {
                 return out;
             }
 
-            TOut& Fixed(TOut &out, char suff, ui64 base) const noexcept
+            TOut& Fixed(TOut &out, char suff, ui64 base) const
             {
                 char ln_[8];
 
@@ -115,7 +115,7 @@ namespace NKikiSched {
             TAverage(ui64 over, ui64 val, bool pad = true)
                 : Pad(pad), Ovr(over), Val(val) { }
 
-            TOut& Do(TOut &out) const noexcept
+            TOut& Do(TOut &out) const
             {
                 if (Val > 0 && Val < Ovr * 100) {
                     char ln[8];
@@ -141,7 +141,7 @@ namespace NKikiSched {
         struct TStamp {
             TStamp(TInstant on): On(on) { }
 
-            TOut& Do(TOut &out) const noexcept
+            TOut& Do(TOut &out) const
             {
                 char ln_[24];
 
@@ -162,7 +162,7 @@ namespace NKikiSched {
         struct TDelay {
             TDelay(TDuration val): Val(val) { }
 
-            TOut& Do(TOut &out) const noexcept
+            TOut& Do(TOut &out) const
             {
                 const ui64 grid[] =  {
                         60ull,          /* minute                   */
@@ -189,7 +189,7 @@ namespace NKikiSched {
             }
 
         protected:
-            inline TOut& Small(TOut &out, ui64 secs) const noexcept
+            inline TOut& Small(TOut &out, ui64 secs) const
             {
                 char ln_[8];
 
@@ -216,7 +216,7 @@ namespace NKikiSched {
         struct TDelta {
             TDelta(TInstant on, TInstant to): On(on), To(to) { }
 
-            TOut& Do(TOut &out) const noexcept
+            TOut& Do(TOut &out) const
             {
                 const auto pfx = (On <= To ? '+' : '-');
 

--- a/ydb/core/tablet_flat/test/tool/perf/iface_logger.h
+++ b/ydb/core/tablet_flat/test/tool/perf/iface_logger.h
@@ -23,7 +23,7 @@ namespace NKikiSched {
 
     class ILogged {
     public:
-        virtual void LogLn(ELnLev, const TString&) const noexcept = 0;
+        virtual void LogLn(ELnLev, const TString&) const = 0;
     };
 
     class TLogLn : public TStringStream {
@@ -65,6 +65,6 @@ namespace NKikiSched {
 
         }
 
-        virtual TLogLn Log(ELnLev) const noexcept = 0;
+        virtual TLogLn Log(ELnLev) const = 0;
     };
 }

--- a/ydb/core/tablet_flat/test/tool/perf/logger.h
+++ b/ydb/core/tablet_flat/test/tool/perf/logger.h
@@ -31,23 +31,23 @@ namespace NPerf {
 
         }
 
-        TLogLn operator ()(ELnLev lev) const noexcept
+        TLogLn operator ()(ELnLev lev) const
         {
             return Log(lev);
         }
 
-        TLogLn Log(ELnLev lev) const noexcept override
+        TLogLn Log(ELnLev lev) const override
         {
             return { ShouldLog(lev) ? this : nullptr, lev };
         }
 
     protected:
-        bool ShouldLog(ELnLev level) const noexcept
+        bool ShouldLog(ELnLev level) const
         {
             return (int)level <= Max(Level, Relev);
         }
 
-        void LogLn(ELnLev level, const TString &line) const noexcept override
+        void LogLn(ELnLev level, const TString &line) const override
         {
             auto left = (Now() - Start).SecondsFloat();
 
@@ -59,7 +59,7 @@ namespace NPerf {
             if ((int)level <= Relev) *Redir << out;
         }
 
-        static const char* Lev2Label(ELnLev level) noexcept
+        static const char* Lev2Label(ELnLev level)
         {
             static const char *line[] = { "??", "**", "EE", "WW", "I0",
                 "I1", "I2", "I3", "D0", "D1", "D2", "D3" };

--- a/ydb/core/tablet_flat/test/tool/perf/meter.h
+++ b/ydb/core/tablet_flat/test/tool/perf/meter.h
@@ -38,7 +38,7 @@ namespace NTest {
             return Stop ? 0 : 4096;
         }
 
-        TString Report() const noexcept
+        TString Report() const
         {
             TStringStream out;
 

--- a/ydb/core/tablet_flat/test/tool/perf/sponge.h
+++ b/ydb/core/tablet_flat/test/tool/perf/sponge.h
@@ -17,7 +17,7 @@ namespace NTest {
     struct TSponge {
         TSponge(ESponge kind) : Kind(kind) { }
 
-        void Describe(IOutputStream &out) const noexcept
+        void Describe(IOutputStream &out) const
         {
             out
                 << "Sponge{"
@@ -28,7 +28,7 @@ namespace NTest {
                 << "}";
         }
 
-        void operator()(const TRowState &row) noexcept
+        void operator()(const TRowState &row)
         {
             Rows += 1;
 
@@ -48,7 +48,7 @@ namespace NTest {
             }
         }
 
-        void operator()(const void *ptr_, ui64 bytes) noexcept
+        void operator()(const void *ptr_, ui64 bytes)
         {
             Bytes += bytes, Cells += 1, Upper = Max(Upper, bytes);
 

--- a/ydb/core/tablet_flat/test/tool/surg/main.cpp
+++ b/ydb/core/tablet_flat/test/tool/surg/main.cpp
@@ -77,7 +77,7 @@ namespace NTest {
             return true;
         }
 
-        void DoBegin(ui32 tail, ui32 head, ui64 serial, ui64 stamp) noexcept
+        void DoBegin(ui32 tail, ui32 head, ui64 serial, ui64 stamp)
         {
             Out
                 << " +Begin ABI[" << tail << ", " << head << "]"
@@ -85,7 +85,7 @@ namespace NTest {
                 << Endl;
         }
 
-        void DoAnnex(TArrayRef<const TStdPad<NPageCollection::TGlobId>> annex) noexcept
+        void DoAnnex(TArrayRef<const TStdPad<NPageCollection::TGlobId>> annex)
         {
             Out << " | Annex " << annex.size() << " items" << Endl;
 
@@ -93,7 +93,7 @@ namespace NTest {
                 Out << " | " << (*one).Group << " : " << (*one).Logo << Endl;
         }
 
-        void DoUpdate(ui32 tid, ERowOp rop, TKeys key, TOps ops, TRowVersion rowVersion) noexcept
+        void DoUpdate(ui32 tid, ERowOp rop, TKeys key, TOps ops, TRowVersion rowVersion)
         {
             ui32 keyBytes = 0, opsBytes = 0;
 
@@ -119,7 +119,7 @@ namespace NTest {
             }
         }
 
-        void DoUpdateTx(ui32 tid, ERowOp rop, TKeys key, TOps ops, ui64 txId) noexcept
+        void DoUpdateTx(ui32 tid, ERowOp rop, TKeys key, TOps ops, ui64 txId)
         {
             ui32 keyBytes = 0, opsBytes = 0;
 
@@ -145,24 +145,24 @@ namespace NTest {
             }
         }
 
-        void DoCommitTx(ui32 tid, ui64 txId, TRowVersion rowVersion) noexcept
+        void DoCommitTx(ui32 tid, ui64 txId, TRowVersion rowVersion)
         {
             Out << " | CommitTx " << tid << " txId " << txId << " @" << rowVersion << Endl;
         }
 
-        void DoRemoveTx(ui32 tid, ui64 txId) noexcept
+        void DoRemoveTx(ui32 tid, ui64 txId)
         {
             Out << " | RemoveTx " << tid << " txId " << txId << Endl;
         }
 
-        void DoFlush(ui32 tid, ui64 stamp, TEpoch epoch) noexcept
+        void DoFlush(ui32 tid, ui64 stamp, TEpoch epoch)
         {
             Out
                 << " | Flush " << tid << ", " << epoch << " eph"
                 << ", stamp " << NFmt::TStamp(stamp) << Endl;
         }
 
-        void Finalize() const noexcept
+        void Finalize() const
         {
             Out
                 << " ' Stats: " << Updates << " ups"

--- a/ydb/core/tablet_flat/ut/flat_comp_ut_common.h
+++ b/ydb/core/tablet_flat/ut/flat_comp_ut_common.h
@@ -19,18 +19,18 @@ public:
         SwitchGen();
     }
 
-    NIceDb::TNiceDb Begin() noexcept {
+    NIceDb::TNiceDb Begin() {
         Annex->Switch(++Step, /* require step switch */ true);
         DB.Begin({ Gen, Step }, Env.emplace());
         return DB;
     }
 
-    void Commit() noexcept {
+    void Commit() {
         DB.Commit({ Gen, Step }, true, Annex.Get());
         Env.reset();
     }
 
-    TSnapEdge SnapshotTable(ui32 table) noexcept {
+    TSnapEdge SnapshotTable(ui32 table) {
         const auto scn = DB.Head().Serial + 1;
         TTxStamp txStamp(Gen, ++Step);
         DB.SnapshotToLog(table, txStamp);
@@ -372,7 +372,7 @@ private:
 };
 
 struct TSimpleLogger : public NUtil::ILogger {
-    NUtil::TLogLn Log(NUtil::ELnLev level) const noexcept override {
+    NUtil::TLogLn Log(NUtil::ELnLev level) const override {
         return { nullptr, level };
     }
 };

--- a/ydb/core/tablet_flat/ut/flat_test_db.cpp
+++ b/ydb/core/tablet_flat/ut/flat_test_db.cpp
@@ -51,7 +51,7 @@ struct TFakeVal {
 
     TCell Read(
             TArrayRef<const TFakeTableCell> key, const TColumn &col)
-                const noexcept
+                const
     {
         if (col.KeyOrder != Max<ui32>()) {
             return *key[col.KeyOrder]; /* has no default values */
@@ -279,7 +279,7 @@ public:
         Y_UNUSED(flags);
     }
 
-    ITestIterator* Iterate(ui32 root, TRawVals key, TTagsRef tags, ELookup mode) noexcept override {
+    ITestIterator* Iterate(ui32 root, TRawVals key, TTagsRef tags, ELookup mode) override {
         if (!key) {
             return new TFakeDbIterator(GetScheme(), root, tags, Tables[root].begin(), Tables[root].end());
         }

--- a/ydb/core/tablet_flat/ut/ut_bloom.cpp
+++ b/ydb/core/tablet_flat/ut/ut_bloom.cpp
@@ -44,7 +44,7 @@ Y_UNIT_TEST_SUITE(Bloom) {
             return Writer.Add(key), *this;
         }
 
-        TIntrusiveConstPtr<NPage::TBloom> Flush() noexcept
+        TIntrusiveConstPtr<NPage::TBloom> Flush()
         {
             return new NPage::TBloom(Writer.Make());
         }

--- a/ydb/core/tablet_flat/ut/ut_btree_index_nodes.cpp
+++ b/ydb/core/tablet_flat/ut/ut_btree_index_nodes.cpp
@@ -62,7 +62,7 @@ namespace {
         return {index + 10000, index + 100, index + 1000};
     }
 
-    void Dump(TChild meta, const TPartScheme::TGroupInfo& groupInfo, const TStore& store, ui32 level = 0) noexcept
+    void Dump(TChild meta, const TPartScheme::TGroupInfo& groupInfo, const TStore& store, ui32 level = 0)
     {
         TString intend;
         for (size_t i = 0; i < level; i++) {

--- a/ydb/core/tablet_flat/ut/ut_charge.cpp
+++ b/ydb/core/tablet_flat/ut/ut_charge.cpp
@@ -108,7 +108,7 @@ namespace {
             UNIT_ASSERT(NTest::IndexTools::CountMainPages(*Eggs.Lone()) == 9);
         }
 
-        NTest::TPartEggs MakeEggs(bool groups, bool history) noexcept
+        NTest::TPartEggs MakeEggs(bool groups, bool history)
         {
             NPage::TConf conf{ true, 8192 };
 

--- a/ydb/core/tablet_flat/ut/ut_forward.cpp
+++ b/ydb/core/tablet_flat/ut/ut_forward.cpp
@@ -40,14 +40,14 @@ namespace {
         {
         }
 
-        ui64 AddToQueue(ui32 page, EPage) noexcept override
+        ui64 AddToQueue(ui32 page, EPage) override
         {
             Pages.push_back(page);
 
             return Large->Relation(page).Size;
         }
 
-        TDeque<TScreen::THole> Trace() noexcept
+        TDeque<TScreen::THole> Trace()
         {
             return dynamic_cast<NFwd::TBlobs&>(*Cache).Traced();
         }
@@ -148,7 +148,7 @@ namespace {
         {
         }
 
-        ui64 AddToQueue(TPageId pageId, EPage type) noexcept override
+        ui64 AddToQueue(TPageId pageId, EPage type) override
         {
             Y_ABORT_UNLESS(type == Part->GetPageType(pageId, { }));
 

--- a/ydb/core/tablet_flat/ut/ut_iterator.cpp
+++ b/ydb/core/tablet_flat/ut/ut_iterator.cpp
@@ -19,7 +19,7 @@ namespace NKikimr {
 namespace NTable {
 
 namespace {
-    static NPage::TConf Conf(ui32 page = NPage::TConf().Groups.at(0).PageSize) noexcept
+    static NPage::TConf Conf(ui32 page = NPage::TConf().Groups.at(0).PageSize)
     {
         NPage::TConf conf;
 
@@ -167,7 +167,7 @@ Y_UNIT_TEST_SUITE(TIterator) {
             : AutoLoad(autoLoad)
         {}
 
-        TResult Locate(const TPart *part, ui64 ref, ELargeObj lob) noexcept override {
+        TResult Locate(const TPart *part, ui64 ref, ELargeObj lob) override {
             if (lob == ELargeObj::Extern) {
                 if (AutoLoad) {
                     if (LoadedExtern.insert(ref).second) {

--- a/ydb/core/tablet_flat/ut/ut_memtable.cpp
+++ b/ydb/core/tablet_flat/ut/ut_memtable.cpp
@@ -22,7 +22,7 @@ Y_UNIT_TEST_SUITE(Memtable)
 {
     using namespace NTest;
 
-    TIntrusiveConstPtr<TRowScheme> BasicRowLayout() noexcept
+    TIntrusiveConstPtr<TRowScheme> BasicRowLayout()
     {
         return
             TLayoutCook()

--- a/ydb/core/tablet_flat/ut/ut_part.cpp
+++ b/ydb/core/tablet_flat/ut/ut_part.cpp
@@ -16,7 +16,7 @@ namespace NTable {
 namespace {
     using namespace NTest;
 
-    NPage::TConf PageConf(size_t groups = 1) noexcept
+    NPage::TConf PageConf(size_t groups = 1)
     {
         NPage::TConf conf{ true, 2 * 1024 };
 

--- a/ydb/core/tablet_flat/ut/ut_slice_loader.cpp
+++ b/ydb/core/tablet_flat/ut/ut_slice_loader.cpp
@@ -22,7 +22,7 @@ using TPageCollectionProtoHelper = NTabletFlatExecutor::TPageCollectionProtoHelp
 using TCache = NTabletFlatExecutor::TPrivatePageCache::TInfo;
 
 namespace {
-    NPage::TConf PageConf() noexcept
+    NPage::TConf PageConf()
     {
         NPage::TConf conf{ true, 2 * 1024 };
 
@@ -78,24 +78,24 @@ namespace {
             return Part->Store->PageCollectionPagesCount(Room);
         }
 
-        NPageCollection::TInfo Page(ui32 page) const noexcept override
+        NPageCollection::TInfo Page(ui32 page) const override
         {
             const auto array = Part->Store->PageCollectionArray(Room);
 
             return { array.at(page).size(), ui32(EPage::Undef) };
         }
 
-        NPageCollection::TBorder Bounds(ui32) const noexcept override
+        NPageCollection::TBorder Bounds(ui32) const override
         {
             Y_ABORT("Unexpected Bounds(...) call");
         }
 
-        NPageCollection::TGlobId Glob(ui32) const noexcept override
+        NPageCollection::TGlobId Glob(ui32) const override
         {
             Y_ABORT("Unexpected Glob(...) call");
         }
 
-        bool Verify(ui32, TArrayRef<const char>) const noexcept override
+        bool Verify(ui32, TArrayRef<const char>) const override
         {
             Y_ABORT("Unexpected Verify(...) call");
         }

--- a/ydb/core/tablet_flat/ut/ut_stat.cpp
+++ b/ydb/core/tablet_flat/ut/ut_stat.cpp
@@ -48,7 +48,7 @@ namespace {
         ui64 TouchedBytes = 0, TouchedRows = 0, TouchedIndexBytes = 0, TouchedIndexPages = 0;
     };
 
-    NPage::TConf PageConf(size_t groups, bool writeBTreeIndex, bool lowResolution = false) noexcept
+    NPage::TConf PageConf(size_t groups, bool writeBTreeIndex, bool lowResolution = false)
     {
         NPage::TConf conf{ true, 2 * 1024 };
 
@@ -438,7 +438,7 @@ Y_UNIT_TEST_SUITE(BuildStatsHistogram) {
         MixedIndex,
     };
 
-    NPage::TConf PageConf(size_t groups, TMode mode) noexcept
+    NPage::TConf PageConf(size_t groups, TMode mode)
     {
         NPage::TConf conf{ true, 2 * 1024 };
 
@@ -705,7 +705,7 @@ Y_UNIT_TEST_SUITE(BuildStatsHistogram) {
             {
             }
 
-            ui32 operator()(const TRow&) noexcept
+            ui32 operator()(const TRow&)
             {
                 while (CurrentSize >= RowsPerBucket) {
                     CurrentSize = NextSize;
@@ -744,7 +744,7 @@ Y_UNIT_TEST_SUITE(BuildStatsHistogram) {
             {
             }
 
-            ui32 operator()(const TRow&) noexcept
+            ui32 operator()(const TRow&)
             {
                 auto x = Random.Uniform(1, 1 << Buckets);
                 return Min(ui32(log2(x)), Buckets - 1);
@@ -770,7 +770,7 @@ Y_UNIT_TEST_SUITE(BuildStatsHistogram) {
             {
             }
 
-            ui32 operator()(const TRow&) noexcept
+            ui32 operator()(const TRow&)
             {
                 while (CurrentSize >= RowsPerBucket && RowsPerBucket) {
                     CurrentSize = 0;
@@ -806,7 +806,7 @@ Y_UNIT_TEST_SUITE(BuildStatsHistogram) {
             {
             }
 
-            ui32 operator()(const TRow&) noexcept
+            ui32 operator()(const TRow&)
             {
                 while (CurrentSize >= RowsPerBucket && RowsPerBucket) {
                     CurrentSize = NextSize;
@@ -846,7 +846,7 @@ Y_UNIT_TEST_SUITE(BuildStatsHistogram) {
             {
             }
 
-            ui32 operator()(const TRow&) noexcept
+            ui32 operator()(const TRow&)
             {
                 if (Random.Uniform(20) == 0) {
                     return Random.Uniform(Buckets / 2);
@@ -877,7 +877,7 @@ Y_UNIT_TEST_SUITE(BuildStatsHistogram) {
             {
             }
 
-            ui32 operator()(const TRow&) noexcept
+            ui32 operator()(const TRow&)
             {
                 while (CurrentSize >= RowsPerBucket) {
                     CurrentSize = 0;
@@ -916,7 +916,7 @@ Y_UNIT_TEST_SUITE(BuildStatsHistogram) {
             {
             }
 
-            ui32 operator()(const TRow&) noexcept
+            ui32 operator()(const TRow&)
             {
                 while (CurrentSize >= RowsPerBucket && RowsPerBucket) {
                     CurrentSize = NextSize;

--- a/ydb/core/tablet_flat/ut/ut_versions.cpp
+++ b/ydb/core/tablet_flat/ut/ut_versions.cpp
@@ -18,7 +18,7 @@ using TCheckIter = TChecker<TWrapIter, TSubset>;
 using TCheckReverseIter = TChecker<TWrapReverseIter, TSubset>;
 
 namespace {
-    NPage::TConf PageConf(size_t groups) noexcept
+    NPage::TConf PageConf(size_t groups)
     {
         NPage::TConf conf{ false, 2 * 1024 };
 

--- a/ydb/core/tablet_flat/util_fmt_basic.h
+++ b/ydb/core/tablet_flat/util_fmt_basic.h
@@ -9,7 +9,7 @@ namespace NFmt {
     struct TDelay {
         TDelay(TDuration val): Val(val) { }
 
-        TOut& Do(TOut &out) const noexcept
+        TOut& Do(TOut &out) const
         {
             const ui64 grid[] =  {
                     60ull,          /* minute                   */
@@ -36,7 +36,7 @@ namespace NFmt {
         }
 
     protected:
-        inline TOut& Small(TOut &out, ui64 secs) const noexcept
+        inline TOut& Small(TOut &out, ui64 secs) const
         {
             char ln_[8];
 

--- a/ydb/core/tablet_flat/util_fmt_desc.h
+++ b/ydb/core/tablet_flat/util_fmt_desc.h
@@ -47,7 +47,7 @@ namespace NKikimr {
             TDesc(const Type *ob, TArg&& ...args)
                 : Ob(ob), Args(std::forward<TArg>(args)...) { }
 
-            inline TOut& Do(TOut &out) const noexcept
+            inline TOut& Do(TOut &out) const
             {
                 using Tups = std::tuple_size<std::tuple<TArg...>>;
 
@@ -73,7 +73,7 @@ namespace NKikimr {
         struct TArr {
             TArr(TIter begin, TIter end) : Begin(begin), End(end) { }
 
-            TOut& Do(TOut &out) const noexcept
+            TOut& Do(TOut &out) const
             {
                 out << "{ ";
 
@@ -100,7 +100,7 @@ namespace NKikimr {
         }
 
         template<typename Type, typename ...TArg>
-        inline TString Ln(const Type &ob, TArg&& ...args) noexcept
+        inline TString Ln(const Type &ob, TArg&& ...args)
         {
             TStringStream ss;
 
@@ -111,7 +111,7 @@ namespace NKikimr {
 
         template<typename Type,
             typename It = decltype(std::declval<const Type>().begin())>
-        inline TArr<It> Arr(const Type &arr) noexcept
+        inline TArr<It> Arr(const Type &arr)
         {
             return { arr.begin(), arr.end() };
         }

--- a/ydb/core/tablet_flat/util_fmt_flat.h
+++ b/ydb/core/tablet_flat/util_fmt_flat.h
@@ -10,7 +10,7 @@ namespace NKikimr {
         struct TStamp {
             TStamp(ui64 stamp) : Stamp(stamp) { }
 
-            TOut& Do(TOut &out) const noexcept
+            TOut& Do(TOut &out) const
             {
                 return out << Stamp.Gen() << ":" << Stamp.Step();
             }

--- a/ydb/core/tablet_flat/util_fmt_line.h
+++ b/ydb/core/tablet_flat/util_fmt_line.h
@@ -31,7 +31,7 @@ namespace NUtil {
 
     class ILogged {
     public:
-        virtual void LogLn(ELnLev, const TString&) const noexcept = 0;
+        virtual void LogLn(ELnLev, const TString&) const = 0;
     };
 
     class TLogLn : public TStringOutput {
@@ -73,7 +73,7 @@ namespace NUtil {
     class ILogger {
     public:
         virtual ~ILogger() = default;
-        virtual TLogLn Log(ELnLev) const noexcept = 0;
+        virtual TLogLn Log(ELnLev) const = 0;
     };
 
 }

--- a/ydb/core/tablet_flat/util_fmt_logger.h
+++ b/ydb/core/tablet_flat/util_fmt_logger.h
@@ -26,7 +26,7 @@ namespace NUtil {
 
         }
 
-        TLogLn Log(ELnLev level_) const noexcept override
+        TLogLn Log(ELnLev level_) const override
         {
             const NActors::NLog::TLevel level{ ui32(level_) };
 
@@ -37,7 +37,7 @@ namespace NUtil {
         }
 
     private:
-        bool ShouldLog(EPrio prio_, ui8 minor) const noexcept
+        bool ShouldLog(EPrio prio_, ui8 minor) const
         {
             /* Minor filtering isn't implemented in levle settings */
 
@@ -48,7 +48,7 @@ namespace NUtil {
             return conf && conf->Satisfies(prio, Comp, 0ull);
         }
 
-        void LogLn(ELnLev level, const TString &line) const noexcept override
+        void LogLn(ELnLev level, const TString &line) const override
         {
             /* Usage of time provider will be possible on complete migration
                 to this logger. Legacy macros based logging takes just Now().

--- a/ydb/core/tablet_flat/util_pool.h
+++ b/ydb/core/tablet_flat/util_pool.h
@@ -140,19 +140,19 @@ namespace NKikimr::NUtil {
             return ptr;
         }
 
-        void BeginTransaction() noexcept {
+        void BeginTransaction() {
             Y_ABORT_UNLESS(!RollbackState_);
             auto& state = RollbackState_.emplace();
             state.Chunk = Current;
             state.Ptr = Current->Ptr;
         }
 
-        void CommitTransaction() noexcept {
+        void CommitTransaction() {
             Y_ABORT_UNLESS(RollbackState_);
             RollbackState_.reset();
         }
 
-        void RollbackTransaction() noexcept {
+        void RollbackTransaction() {
             Y_ABORT_UNLESS(RollbackState_);
             auto& state = *RollbackState_;
             DoRollback(state.Chunk, state.Ptr);

--- a/ydb/core/tablet_flat/util_store.h
+++ b/ydb/core/tablet_flat/util_store.h
@@ -105,7 +105,7 @@ namespace NUtil {
         };
 
     public:
-        TConcurrentStore() { }
+        TConcurrentStore() noexcept { }
 
         ~TConcurrentStore() noexcept {
             size_t count = Count.exchange(0, std::memory_order_release);

--- a/ydb/core/tx/datashard/build_index.cpp
+++ b/ydb/core/tx/datashard/build_index.cpp
@@ -155,7 +155,7 @@ protected:
     }
 
     template <typename TAddRow>
-    EScan FeedImpl(TArrayRef<const TCell> key, const TRow& /*row*/, TAddRow&& addRow) noexcept {
+    EScan FeedImpl(TArrayRef<const TCell> key, const TRow& /*row*/, TAddRow&& addRow) {
         LOG_T("Feed key " << DebugPrintPoint(KeyTypes, key, *AppData()->TypeRegistry) << " " << Debug());
 
         addRow();
@@ -182,7 +182,7 @@ public:
 
     ~TBuildScanUpload() override = default;
 
-    TInitialState Prepare(IDriver* driver, TIntrusiveConstPtr<TScheme>) noexcept override {
+    TInitialState Prepare(IDriver* driver, TIntrusiveConstPtr<TScheme>) override {
         TActivationContext::AsActorContext().RegisterWithSameMailbox(this);
 
         LOG_D("Prepare " << Debug());
@@ -192,7 +192,7 @@ public:
         return {EScan::Feed, {}};
     }
 
-    EScan Seek(TLead& lead, ui64 seq) noexcept override {
+    EScan Seek(TLead& lead, ui64 seq) override {
         LOG_T("Seek no " << seq << " " << Debug());
         if (seq) {
             if (!WriteBuf.IsEmpty()) {
@@ -229,7 +229,7 @@ public:
         return EScan::Feed;
     }
 
-    TAutoPtr<IDestructable> Finish(EAbort abort) noexcept override {
+    TAutoPtr<IDestructable> Finish(EAbort abort) override {
         if (Uploader) {
             this->Send(Uploader, new TEvents::TEvPoisonPill);
             Uploader = {};
@@ -268,7 +268,7 @@ public:
         NYql::IssuesToMessage(UploadStatus.Issues, msg.MutableIssues());
     }
 
-    void Describe(IOutputStream& out) const noexcept override {
+    void Describe(IOutputStream& out) const override {
         out << Debug();
     }
 
@@ -281,7 +281,7 @@ public:
                                 << UploadStatus.ToString();
     }
 
-    EScan PageFault() noexcept override {
+    EScan PageFault() override {
         LOG_T("Page fault"
               << " ReadBuf empty: " << ReadBuf.IsEmpty()
               << " WriteBuf empty: " << WriteBuf.IsEmpty()
@@ -420,7 +420,7 @@ public:
         UploadMode = NTxProxy::EUploadRowsMode::WriteToTableShadow;
     }
 
-    EScan Feed(TArrayRef<const TCell> key, const TRow& row) noexcept final {
+    EScan Feed(TArrayRef<const TCell> key, const TRow& row) final {
         return FeedImpl(key, row, [&] {
             const auto rowCells = *row;
 
@@ -457,7 +457,7 @@ public:
         ValueSerialized = TSerializedCellVec::Serialize(cells);
     }
 
-    EScan Feed(TArrayRef<const TCell> key, const TRow& row) noexcept final {
+    EScan Feed(TArrayRef<const TCell> key, const TRow& row) final {
         return FeedImpl(key, row, [&] {
             TSerializedCellVec pk(key);
             auto pkTarget = pk;

--- a/ydb/core/tx/datashard/cdc_stream_scan.cpp
+++ b/ydb/core/tx/datashard/cdc_stream_scan.cpp
@@ -455,7 +455,7 @@ public:
     {
     }
 
-    void Describe(IOutputStream& o) const noexcept override {
+    void Describe(IOutputStream& o) const override {
         o << "CdcStreamScan {"
           << " TxId: " << TxId
           << " TablePathId: " << TablePathId
@@ -463,7 +463,7 @@ public:
         << " }";
     }
 
-    IScan::TInitialState Prepare(IDriver* driver, TIntrusiveConstPtr<TScheme> scheme) noexcept override {
+    IScan::TInitialState Prepare(IDriver* driver, TIntrusiveConstPtr<TScheme> scheme) override {
         TlsActivationContext->AsActorContext().RegisterWithSameMailbox(this);
         Driver = driver;
         Y_ABORT_UNLESS(!LastKey || LastKey->GetCells().size() == scheme->Tags(true).size());
@@ -474,7 +474,7 @@ public:
         sys->Send(DataShard.ActorId, new TDataShard::TEvPrivate::TEvCdcStreamScanRegistered(TxId, SelfId()));
     }
 
-    EScan Seek(TLead& lead, ui64) noexcept override {
+    EScan Seek(TLead& lead, ui64) override {
         if (LastKey) {
             lead.To(ValueTags, LastKey->GetCells(), ESeek::Upper);
         } else {
@@ -484,7 +484,7 @@ public:
         return EScan::Feed;
     }
 
-    EScan Feed(TArrayRef<const TCell> key, const TRow& row) noexcept override {
+    EScan Feed(TArrayRef<const TCell> key, const TRow& row) override {
         Buffer.AddRow(key, *row);
         if (Buffer.Bytes() < Limits.BatchMaxBytes) {
             if (Buffer.Rows() < Limits.BatchMaxRows) {
@@ -500,7 +500,7 @@ public:
         return EScan::Sleep;
     }
 
-    EScan Exhausted() noexcept override {
+    EScan Exhausted() override {
         NoMoreData = true;
 
         if (!Buffer) {
@@ -511,7 +511,7 @@ public:
         return EScan::Sleep;
     }
 
-    TAutoPtr<IDestructable> Finish(EAbort abort) noexcept override {
+    TAutoPtr<IDestructable> Finish(EAbort abort) override {
         if (abort != EAbort::None) {
             Reply(NKikimrTxDataShard::TEvCdcStreamScanResponse::ABORTED);
         } else {

--- a/ydb/core/tx/datashard/datashard__column_stats.cpp
+++ b/ydb/core/tx/datashard/datashard__column_stats.cpp
@@ -20,11 +20,11 @@ public:
         , StartKey(std::move(startKey))
     {}
 
-    void Describe(IOutputStream& o) const noexcept override {
+    void Describe(IOutputStream& o) const override {
         o << "StatisticsScan";
     }
 
-    IScan::TInitialState Prepare(IDriver* driver, TIntrusiveConstPtr<TScheme> scheme) noexcept override {
+    IScan::TInitialState Prepare(IDriver* driver, TIntrusiveConstPtr<TScheme> scheme) override {
         Driver = driver;
         Scheme = std::move(scheme);
 
@@ -37,13 +37,13 @@ public:
         return {EScan::Feed, {}};
     }
 
-    EScan Seek(TLead& lead, ui64) noexcept override {
+    EScan Seek(TLead& lead, ui64) override {
         lead.To(Scheme->Tags(), StartKey.GetCells(), ESeek::Lower);
 
         return EScan::Feed;
     }
 
-    EScan Feed(TArrayRef<const TCell> key, const TRow& row) noexcept override {
+    EScan Feed(TArrayRef<const TCell> key, const TRow& row) override {
         Y_UNUSED(key);
         auto rowCells = *row;
         for (size_t i = 0; i < rowCells.size(); ++i) {
@@ -53,11 +53,11 @@ public:
         return EScan::Feed;
     }
 
-    EScan Exhausted() noexcept override {
+    EScan Exhausted() override {
         return EScan::Final;
     }
 
-    TAutoPtr<IDestructable> Finish(EAbort abort) noexcept override {
+    TAutoPtr<IDestructable> Finish(EAbort abort) override {
         auto response = std::make_unique<NStat::TEvStatistics::TEvStatisticsResponse>();
         auto& record = response->Record;
         record.SetShardTabletId(ShardTabletId);

--- a/ydb/core/tx/datashard/datashard__conditional_erase_rows.cpp
+++ b/ydb/core/tx/datashard/datashard__conditional_erase_rows.cpp
@@ -230,14 +230,14 @@ public:
     {
     }
 
-    void Describe(IOutputStream& o) const noexcept override {
+    void Describe(IOutputStream& o) const override {
         o << "CondEraseScan {"
           << " TableId: " << TableId
           << " TxId: " << TxId
         << " }";
     }
 
-    IScan::TInitialState Prepare(IDriver* driver, TIntrusiveConstPtr<TScheme> scheme) noexcept override {
+    IScan::TInitialState Prepare(IDriver* driver, TIntrusiveConstPtr<TScheme> scheme) override {
         TlsActivationContext->AsActorContext().RegisterWithSameMailbox(this);
 
         Driver = driver;
@@ -273,12 +273,12 @@ public:
         sys->Send(DataShard.ActorId, new TDataShard::TEvPrivate::TEvConditionalEraseRowsRegistered(TxId, SelfId()));
     }
 
-    EScan Seek(TLead& lead, ui64) noexcept override {
+    EScan Seek(TLead& lead, ui64) override {
         lead.To(ScanTags, {}, ESeek::Lower);
         return EScan::Feed;
     }
 
-    EScan Feed(TArrayRef<const TCell>, const TRow& row) noexcept override {
+    EScan Feed(TArrayRef<const TCell>, const TRow& row) override {
         Stats.IncProcessed();
         if (!Condition->Check(row)) {
             return EScan::Feed;
@@ -294,7 +294,7 @@ public:
         return EScan::Sleep;
     }
 
-    EScan Exhausted() noexcept override {
+    EScan Exhausted() override {
         NoMoreData = true;
 
         if (!SerializedKeys) {
@@ -305,7 +305,7 @@ public:
         return EScan::Sleep;
     }
 
-    TAutoPtr<IDestructable> Finish(EAbort abort) noexcept override {
+    TAutoPtr<IDestructable> Finish(EAbort abort) override {
         Reply(abort != EAbort::None);
         PassAway();
 

--- a/ydb/core/tx/datashard/datashard__kqp_scan.cpp
+++ b/ydb/core/tx/datashard/datashard__kqp_scan.cpp
@@ -183,7 +183,7 @@ private:
     }
 
 private:
-    TInitialState Prepare(IDriver* driver, TIntrusiveConstPtr<TScheme> scheme) noexcept final {
+    TInitialState Prepare(IDriver* driver, TIntrusiveConstPtr<TScheme> scheme) final {
         Y_ABORT_UNLESS(scheme);
         Y_ABORT_UNLESS(driver);
 
@@ -216,7 +216,7 @@ private:
         return startConfig;
     }
 
-    EScan Seek(TLead& lead, ui64 seq) noexcept final {
+    EScan Seek(TLead& lead, ui64 seq) final {
         YQL_ENSURE(seq == CurrentRange);
 
         if (CurrentRange == TableRanges.size()) {
@@ -259,7 +259,7 @@ private:
         return EScan::Feed;
     }
 
-    EScan Feed(TArrayRef<const TCell> key, const TRow& row) noexcept final {
+    EScan Feed(TArrayRef<const TCell> key, const TRow& row) final {
         LastKey = TOwnedCellVec(key);
 
         Y_ABORT_UNLESS(SkipNullKeys.size() <= key.size());
@@ -298,7 +298,7 @@ private:
         return EScan::Feed; // sent by rows limit, can send one more batch
     }
 
-    EScan Exhausted() noexcept override {
+    EScan Exhausted() override {
         LOG_DEBUG_S(*TlsActivationContext, NKikimrServices::TX_DATASHARD,
             "Range " << CurrentRange << " of " << TableRanges.size() << " exhausted: try next one."
             << " table: " << TablePath
@@ -314,7 +314,7 @@ private:
         return EScan::Reset;
     }
 
-    EScan PageFault() noexcept override final {
+    EScan PageFault() override final {
         ++PageFaults;
         if (Result && !Result->Rows.empty()) {
             bool sent = SendResult(/* pageFault */ true);
@@ -332,7 +332,7 @@ private:
     }
 
 private:
-    TAutoPtr<IDestructable> Finish(EAbort abort) noexcept final {
+    TAutoPtr<IDestructable> Finish(EAbort abort) final {
         auto prio = abort == EAbort::None ? NActors::NLog::PRI_DEBUG : NActors::NLog::PRI_ERROR;
         LOG_LOG_S(*TlsActivationContext, prio, NKikimrServices::TX_DATASHARD, "Finish scan"
             << ", at: " << ScanActorId << ", scanId: " << ScanId
@@ -378,7 +378,7 @@ private:
         return new TKqpScanResult();
     }
 
-    void Describe(IOutputStream& out) const noexcept final {
+    void Describe(IOutputStream& out) const final {
         out << "TExecuteKqpScanTxUnit, TKqpScan";
     }
 
@@ -422,7 +422,7 @@ private:
         }
     }
 
-    bool SendResult(bool pageFault, bool finish = false) noexcept {
+    bool SendResult(bool pageFault, bool finish = false) {
         if (Rows >= MAX_BATCH_ROWS || CellvecBytes >= ChunksLimiter.GetRemainedBytes() ||
             (pageFault && (Rows >= MIN_BATCH_ROWS_ON_PAGEFAULT || CellvecBytes >= MIN_BATCH_SIZE_ON_PAGEFAULT)) || finish)
         {

--- a/ydb/core/tx/datashard/datashard__read_columns.cpp
+++ b/ydb/core/tx/datashard/datashard__read_columns.cpp
@@ -86,7 +86,7 @@ public:
         , BlockBuilder(std::move(blockBuilder))
     {}
 
-    TInitialState Prepare(IDriver* driver, TIntrusiveConstPtr<TScheme> scheme) noexcept override {
+    TInitialState Prepare(IDriver* driver, TIntrusiveConstPtr<TScheme> scheme) override {
         Driver = driver;
         Scheme = std::move(scheme);
 
@@ -95,7 +95,7 @@ public:
         return hello;
     }
 
-    EScan Seek(TLead& lead, ui64 seq) noexcept override {
+    EScan Seek(TLead& lead, ui64 seq) override {
         Y_ABORT_UNLESS(seq == 0, "Unexpected repeated Seek");
 
         lead.To(ValueColumns, From.Key.GetCells(), From.Inclusive ? NTable::ESeek::Lower : NTable::ESeek::Upper);
@@ -104,7 +104,7 @@ public:
         return EScan::Feed;
     }
 
-    EScan Feed(TArrayRef<const TCell> key, const TRow& row) noexcept override {
+    EScan Feed(TArrayRef<const TCell> key, const TRow& row) override {
         const auto& keyTypes = Scheme->Keys->BasicTypes();
 
         Y_ABORT_UNLESS(key.size() == keyTypes.size());
@@ -127,7 +127,7 @@ public:
         return EScan::Feed;
     }
 
-    TAutoPtr<IDestructable> Finish(EAbort reason) noexcept override {
+    TAutoPtr<IDestructable> Finish(EAbort reason) override {
         Result = new TEvDataShard::TEvReadColumnsResponse(TabletId);
 
         if (reason == EAbort::None) {
@@ -158,11 +158,11 @@ public:
         return this;
     }
 
-    EScan Exhausted() noexcept override {
+    EScan Exhausted() override {
         return EScan::Final;
     }
 
-    void Describe(IOutputStream& str) const noexcept override {
+    void Describe(IOutputStream& str) const override {
         str << "ReadColumnsScan table: ["<< TableName << "]shard: " << TabletId;
     }
 

--- a/ydb/core/tx/datashard/datashard__read_iterator.cpp
+++ b/ydb/core/tx/datashard/datashard__read_iterator.cpp
@@ -1182,7 +1182,7 @@ public:
     }
 
 private:
-    void Describe(IOutputStream& out) const noexcept final {
+    void Describe(IOutputStream& out) const final {
         out << "TDataShard::TReadScan{"
             << " TabletId# " << TabletId
             << " Reader# " << Ev->Sender
@@ -1190,7 +1190,7 @@ private:
             << " }";
     }
 
-    TInitialState Prepare(IDriver* driver, TIntrusiveConstPtr<TScheme> scheme) noexcept final {
+    TInitialState Prepare(IDriver* driver, TIntrusiveConstPtr<TScheme> scheme) final {
         Y_ABORT_UNLESS(driver);
         Y_ABORT_UNLESS(scheme);
 
@@ -1202,7 +1202,7 @@ private:
         return { EScan::Feed, {} };
     }
 
-    EScan Seek(TLead& lead, ui64 /* seq */) noexcept final {
+    EScan Seek(TLead& lead, ui64 /* seq */) final {
         if (RangeIndex >= Request->Ranges.size() || TotalRows >= TotalRowsLimit) {
             return EScan::Final;
         }
@@ -1237,7 +1237,7 @@ private:
         return EScan::Feed;
     }
 
-    EScan Feed(TArrayRef<const TCell> key, const TRow& row) noexcept final {
+    EScan Feed(TArrayRef<const TCell> key, const TRow& row) final {
         if (!BlockBuilder) {
             TString error;
             BlockBuilder = CreateBlockBuilder(ColumnNamesTypes, Format, Max<ui64>(), Max<ui64>(), error);
@@ -1266,7 +1266,7 @@ private:
         return EScan::Feed;
     }
 
-    EScan Exhausted() noexcept final {
+    EScan Exhausted() final {
         ++RangeIndex;
         if (RangeIndex >= Request->Ranges.size()) {
             return EScan::Final;
@@ -1275,7 +1275,7 @@ private:
         return EScan::Reset;
     }
 
-    TAutoPtr<IDestructable> Finish(EAbort abort) noexcept final {
+    TAutoPtr<IDestructable> Finish(EAbort abort) final {
         if (!Aborted) {
             switch (abort) {
                 case EAbort::None:

--- a/ydb/core/tx/datashard/datashard__stats.cpp
+++ b/ydb/core/tx/datashard/datashard__stats.cpp
@@ -80,11 +80,11 @@ public:
         Send(MakeSharedPageCacheId(), new NSharedCache::TEvUnregister);
     }
 
-    TResult Locate(const TMemTable*, ui64, ui32) noexcept override {
+    TResult Locate(const TMemTable*, ui64, ui32) override {
         Y_ABORT("IPages::Locate(TMemTable*, ...) shouldn't be used here");
     }
 
-    TResult Locate(const TPart*, ui64, ELargeObj) noexcept override {
+    TResult Locate(const TPart*, ui64, ELargeObj) override {
         Y_ABORT("IPages::Locate(TPart*, ...) shouldn't be used here");
     }
 

--- a/ydb/core/tx/datashard/datashard_dep_tracker.cpp
+++ b/ydb/core/tx/datashard/datashard_dep_tracker.cpp
@@ -51,7 +51,7 @@ namespace {
     }
 }
 
-void TDependencyTracker::UpdateSchema(const TPathId& tableId, const TUserTable& tableInfo) noexcept {
+void TDependencyTracker::UpdateSchema(const TPathId& tableId, const TUserTable& tableInfo) {
     auto& state = Tables[tableId.LocalPathId];
     state.PlannedReads.SetKeyTypes(tableInfo.KeyColumnTypes);
     state.PlannedWrites.SetKeyTypes(tableInfo.KeyColumnTypes);
@@ -59,19 +59,19 @@ void TDependencyTracker::UpdateSchema(const TPathId& tableId, const TUserTable& 
     state.ImmediateWrites.SetKeyTypes(tableInfo.KeyColumnTypes);
 }
 
-void TDependencyTracker::RemoveSchema(const TPathId& tableId) noexcept {
+void TDependencyTracker::RemoveSchema(const TPathId& tableId) {
     Tables.erase(tableId.LocalPathId);
 }
 
-void TDependencyTracker::ClearTmpRead() noexcept {
+void TDependencyTracker::ClearTmpRead() {
     TmpRead.clear();
 }
 
-void TDependencyTracker::ClearTmpWrite() noexcept {
+void TDependencyTracker::ClearTmpWrite() {
     TmpWrite.clear();
 }
 
-void TDependencyTracker::AddPlannedReads(const TOperation::TPtr& op, const TKeys& reads) noexcept {
+void TDependencyTracker::AddPlannedReads(const TOperation::TPtr& op, const TKeys& reads) {
     for (const auto& read : reads) {
         auto it = Tables.find(read.TableId);
         Y_ABORT_UNLESS(it != Tables.end());
@@ -80,7 +80,7 @@ void TDependencyTracker::AddPlannedReads(const TOperation::TPtr& op, const TKeys
     }
 }
 
-void TDependencyTracker::AddPlannedWrites(const TOperation::TPtr& op, const TKeys& writes) noexcept {
+void TDependencyTracker::AddPlannedWrites(const TOperation::TPtr& op, const TKeys& writes) {
     for (const auto& write : writes) {
         auto it = Tables.find(write.TableId);
         Y_ABORT_UNLESS(it != Tables.end());
@@ -89,7 +89,7 @@ void TDependencyTracker::AddPlannedWrites(const TOperation::TPtr& op, const TKey
     }
 }
 
-void TDependencyTracker::AddImmediateReads(const TOperation::TPtr& op, const TKeys& reads) noexcept {
+void TDependencyTracker::AddImmediateReads(const TOperation::TPtr& op, const TKeys& reads) {
     for (const auto& read : reads) {
         auto it = Tables.find(read.TableId);
         Y_ABORT_UNLESS(it != Tables.end());
@@ -98,7 +98,7 @@ void TDependencyTracker::AddImmediateReads(const TOperation::TPtr& op, const TKe
     }
 }
 
-void TDependencyTracker::AddImmediateWrites(const TOperation::TPtr& op, const TKeys& writes) noexcept {
+void TDependencyTracker::AddImmediateWrites(const TOperation::TPtr& op, const TKeys& writes) {
     for (const auto& write : writes) {
         auto it = Tables.find(write.TableId);
         Y_ABORT_UNLESS(it != Tables.end());
@@ -107,7 +107,7 @@ void TDependencyTracker::AddImmediateWrites(const TOperation::TPtr& op, const TK
     }
 }
 
-void TDependencyTracker::FlushPlannedReads() noexcept {
+void TDependencyTracker::FlushPlannedReads() {
     while (!DelayedPlannedReads.Empty()) {
         TOperation::TPtr op = DelayedPlannedReads.PopFront();
         auto reads = op->RemoveDelayedKnownReads();
@@ -115,7 +115,7 @@ void TDependencyTracker::FlushPlannedReads() noexcept {
     }
 }
 
-void TDependencyTracker::FlushPlannedWrites() noexcept {
+void TDependencyTracker::FlushPlannedWrites() {
     while (!DelayedPlannedWrites.Empty()) {
         TOperation::TPtr op = DelayedPlannedWrites.PopFront();
         auto writes = op->RemoveDelayedKnownWrites();
@@ -123,7 +123,7 @@ void TDependencyTracker::FlushPlannedWrites() noexcept {
     }
 }
 
-void TDependencyTracker::FlushImmediateReads() noexcept {
+void TDependencyTracker::FlushImmediateReads() {
     while (!DelayedImmediateReads.Empty()) {
         TOperation::TPtr op = DelayedImmediateReads.PopFront();
         auto reads = op->RemoveDelayedKnownReads();
@@ -131,7 +131,7 @@ void TDependencyTracker::FlushImmediateReads() noexcept {
     }
 }
 
-void TDependencyTracker::FlushImmediateWrites() noexcept {
+void TDependencyTracker::FlushImmediateWrites() {
     while (!DelayedImmediateWrites.Empty()) {
         TOperation::TPtr op = DelayedImmediateWrites.PopFront();
         auto writes = op->RemoveDelayedKnownWrites();
@@ -146,7 +146,7 @@ const TDependencyTracker::TDependencyTrackingLogic& TDependencyTracker::GetTrack
     return MvccLogic;
 }
 
-void TDependencyTracker::TMvccDependencyTrackingLogic::AddOperation(const TOperation::TPtr& op) const noexcept {
+void TDependencyTracker::TMvccDependencyTrackingLogic::AddOperation(const TOperation::TPtr& op) const {
     if (op->IsUsingSnapshot()) {
         return;
     }
@@ -600,7 +600,7 @@ void TDependencyTracker::TMvccDependencyTrackingLogic::AddOperation(const TOpera
     }
 }
 
-void TDependencyTracker::TMvccDependencyTrackingLogic::RemoveOperation(const TOperation::TPtr& op) const noexcept {
+void TDependencyTracker::TMvccDependencyTrackingLogic::RemoveOperation(const TOperation::TPtr& op) const {
     if (Parent.LastSnapshotOp == op) {
         Parent.LastSnapshotOp = nullptr;
     }
@@ -643,11 +643,11 @@ void TDependencyTracker::TMvccDependencyTrackingLogic::RemoveOperation(const TOp
     }
 }
 
-void TDependencyTracker::TFollowerDependencyTrackingLogic::AddOperation(const TOperation::TPtr&) const noexcept {
+void TDependencyTracker::TFollowerDependencyTrackingLogic::AddOperation(const TOperation::TPtr&) const {
     // all follower operations are readonly and don't conflict
 }
 
-void TDependencyTracker::TFollowerDependencyTrackingLogic::RemoveOperation(const TOperation::TPtr&) const noexcept {
+void TDependencyTracker::TFollowerDependencyTrackingLogic::RemoveOperation(const TOperation::TPtr&) const {
     // all follower operations are readonly and don't conflict
 }
 

--- a/ydb/core/tx/datashard/datashard_dep_tracker.h
+++ b/ydb/core/tx/datashard/datashard_dep_tracker.h
@@ -59,26 +59,26 @@ private:
             : Parent(parent) {}
 
         // Adds operation to the tracker
-        virtual void AddOperation(const TOperation::TPtr& op) const noexcept = 0;
+        virtual void AddOperation(const TOperation::TPtr& op) const = 0;
 
         // Removes operation from the tracker, no future operations may conflict with it
-        virtual void RemoveOperation(const TOperation::TPtr& op) const noexcept = 0;
+        virtual void RemoveOperation(const TOperation::TPtr& op) const = 0;
     };
 
     struct TMvccDependencyTrackingLogic : public TDependencyTrackingLogic {
         explicit TMvccDependencyTrackingLogic(TDependencyTracker& parent)
             : TDependencyTrackingLogic(parent) {}
 
-        void AddOperation(const TOperation::TPtr& op) const noexcept override;
-        void RemoveOperation(const TOperation::TPtr& op) const noexcept override;
+        void AddOperation(const TOperation::TPtr& op) const override;
+        void RemoveOperation(const TOperation::TPtr& op) const override;
     };
 
     struct TFollowerDependencyTrackingLogic : public TDependencyTrackingLogic {
         explicit TFollowerDependencyTrackingLogic(TDependencyTracker& parent)
             : TDependencyTrackingLogic(parent) {}
 
-        void AddOperation(const TOperation::TPtr& op) const noexcept override;
-        void RemoveOperation(const TOperation::TPtr& op) const noexcept override;
+        void AddOperation(const TOperation::TPtr& op) const override;
+        void RemoveOperation(const TOperation::TPtr& op) const override;
     };
 
 public:
@@ -88,18 +88,18 @@ public:
 
 public:
     // Called to update this table schema
-    void UpdateSchema(const TPathId& tableId, const TUserTable& tableInfo) noexcept;
+    void UpdateSchema(const TPathId& tableId, const TUserTable& tableInfo);
 
     // Calld to update this table schema upon move
-    void RemoveSchema(const TPathId& tableId) noexcept;
+    void RemoveSchema(const TPathId& tableId);
 
     // Adds operation to the tracker
-    void AddOperation(const TOperation::TPtr& op) noexcept {
+    void AddOperation(const TOperation::TPtr& op) {
         GetTrackingLogic().AddOperation(op);
     }
 
     // Removes operation from the tracker, no future operations may conflict with it
-    void RemoveOperation(const TOperation::TPtr& op) noexcept {
+    void RemoveOperation(const TOperation::TPtr& op) {
         GetTrackingLogic().RemoveOperation(op);
     }
 
@@ -112,18 +112,18 @@ public:
     }
 
 private:
-    void ClearTmpRead() noexcept;
-    void ClearTmpWrite() noexcept;
+    void ClearTmpRead();
+    void ClearTmpWrite();
 
-    void AddPlannedReads(const TOperation::TPtr& op, const TKeys& reads) noexcept;
-    void AddPlannedWrites(const TOperation::TPtr& op, const TKeys& writes) noexcept;
-    void AddImmediateReads(const TOperation::TPtr& op, const TKeys& reads) noexcept;
-    void AddImmediateWrites(const TOperation::TPtr& op, const TKeys& writes) noexcept;
+    void AddPlannedReads(const TOperation::TPtr& op, const TKeys& reads);
+    void AddPlannedWrites(const TOperation::TPtr& op, const TKeys& writes);
+    void AddImmediateReads(const TOperation::TPtr& op, const TKeys& reads);
+    void AddImmediateWrites(const TOperation::TPtr& op, const TKeys& writes);
 
-    void FlushPlannedReads() noexcept;
-    void FlushPlannedWrites() noexcept;
-    void FlushImmediateReads() noexcept;
-    void FlushImmediateWrites() noexcept;
+    void FlushPlannedReads();
+    void FlushPlannedWrites();
+    void FlushImmediateReads();
+    void FlushImmediateWrites();
 
     const TDependencyTrackingLogic& GetTrackingLogic() const noexcept;
 

--- a/ydb/core/tx/datashard/export_scan.cpp
+++ b/ydb/core/tx/datashard/export_scan.cpp
@@ -163,7 +163,7 @@ public:
     {
     }
 
-    void Describe(IOutputStream& o) const noexcept override {
+    void Describe(IOutputStream& o) const override {
         o << "ExportScan { "
               << "Uploader: " << Uploader
               << Stats->ToString() << " "
@@ -172,7 +172,7 @@ public:
           << " }";
     }
 
-    IScan::TInitialState Prepare(IDriver* driver, TIntrusiveConstPtr<TScheme> scheme) noexcept override {
+    IScan::TInitialState Prepare(IDriver* driver, TIntrusiveConstPtr<TScheme> scheme) override {
         TlsActivationContext->AsActorContext().RegisterWithSameMailbox(this);
 
         Driver = driver;
@@ -190,7 +190,7 @@ public:
         MaybeReady();
     }
 
-    EScan Seek(TLead& lead, ui64) noexcept override {
+    EScan Seek(TLead& lead, ui64) override {
         lead.To(Scheme->Tags(), {}, ESeek::Lower);
         Buffer->Clear();
 
@@ -201,7 +201,7 @@ public:
         return EScan::Feed;
     }
 
-    EScan Feed(TArrayRef<const TCell>, const TRow& row) noexcept override {
+    EScan Feed(TArrayRef<const TCell>, const TRow& row) override {
         if (!Buffer->Collect(row)) {
             Success = false;
             Error = Buffer->GetError();
@@ -212,12 +212,12 @@ public:
         return MaybeSendBuffer();
     }
 
-    EScan Exhausted() noexcept override {
+    EScan Exhausted() override {
         State.Set(ES_NO_MORE_DATA);
         return MaybeSendBuffer();
     }
 
-    TAutoPtr<IDestructable> Finish(EAbort abort) noexcept override {
+    TAutoPtr<IDestructable> Finish(EAbort abort) override {
         auto outcome = EExportOutcome::Success;
         if (abort != EAbort::None) {
             outcome = EExportOutcome::Aborted;

--- a/ydb/core/tx/datashard/incr_restore_scan.cpp
+++ b/ydb/core/tx/datashard/incr_restore_scan.cpp
@@ -137,7 +137,7 @@ public:
         }
     }
 
-    IScan::TInitialState Prepare(IDriver* driver, TIntrusiveConstPtr<TScheme> scheme) noexcept override {
+    IScan::TInitialState Prepare(IDriver* driver, TIntrusiveConstPtr<TScheme> scheme) override {
         TlsActivationContext->AsActorContext().RegisterWithSameMailbox(this);
         Driver = driver;
         Y_ABORT_UNLESS(!LastKey || LastKey->GetCells().size() == scheme->Tags(true).size());
@@ -145,7 +145,7 @@ public:
         return {EScan::Sleep, {}};
     }
 
-    EScan Seek(TLead& lead, ui64) noexcept override {
+    EScan Seek(TLead& lead, ui64) override {
         LOG_D("Seek");
 
         if (LastKey) {
@@ -157,7 +157,7 @@ public:
         return EScan::Feed;
     }
 
-    EScan Feed(TArrayRef<const TCell> key, const TRow& row) noexcept override {
+    EScan Feed(TArrayRef<const TCell> key, const TRow& row) override {
         Buffer.AddRow(key, *row);
         if (Buffer.Bytes() < Limits.BatchMaxBytes) {
             if (Buffer.Rows() < Limits.BatchMaxRows) {
@@ -173,7 +173,7 @@ public:
         return EScan::Sleep;
     }
 
-    EScan Exhausted() noexcept override {
+    EScan Exhausted() override {
         LOG_D("Exhausted");
 
         NoMoreData = true;
@@ -186,7 +186,7 @@ public:
         return Progress();
     }
 
-    TAutoPtr<IDestructable> Finish(EAbort abort) noexcept override {
+    TAutoPtr<IDestructable> Finish(EAbort abort) override {
         LOG_D("Finish " << static_cast<ui64>(abort));
 
         if (abort != EAbort::None) {
@@ -199,7 +199,7 @@ public:
         return nullptr;
     }
 
-    void Describe(IOutputStream& o) const noexcept override {
+    void Describe(IOutputStream& o) const override {
         o << "IncrRestoreScan {"
           << " TxId: " << TxId
           << " SourcePathId: " << SourcePathId

--- a/ydb/core/tx/datashard/local_kmeans.cpp
+++ b/ydb/core/tx/datashard/local_kmeans.cpp
@@ -189,7 +189,7 @@ public:
         NextTypes = MakeUploadTypes(table, UploadState, embedding, data);
     }
 
-    TInitialState Prepare(IDriver* driver, TIntrusiveConstPtr<TScheme>) noexcept final
+    TInitialState Prepare(IDriver* driver, TIntrusiveConstPtr<TScheme>) final
     {
         TActivationContext::AsActorContext().RegisterWithSameMailbox(this);
         LOG_D("Prepare " << Debug());
@@ -198,7 +198,7 @@ public:
         return {EScan::Feed, {}};
     }
 
-    TAutoPtr<IDestructable> Finish(EAbort abort) noexcept final
+    TAutoPtr<IDestructable> Finish(EAbort abort) final
     {
         LOG_D("Finish " << Debug());
 
@@ -230,7 +230,7 @@ public:
         return nullptr;
     }
 
-    void Describe(IOutputStream& out) const noexcept final
+    void Describe(IOutputStream& out) const final
     {
         out << Debug();
     }
@@ -243,7 +243,7 @@ public:
             << " ReadBuf size: " << ReadBuf.Size() << " WriteBuf size: " << WriteBuf.Size() << " ";
     }
 
-    EScan PageFault() noexcept final
+    EScan PageFault() final
     {
         LOG_T("PageFault " << Debug());
 
@@ -390,7 +390,7 @@ public:
         LOG_D("Create " << Debug());
     }
 
-    EScan Seek(TLead& lead, ui64 seq) noexcept final
+    EScan Seek(TLead& lead, ui64 seq) final
     {
         LOG_D("Seek " << Debug());
         if (State == UploadState) {
@@ -442,7 +442,7 @@ public:
         return EScan::Feed;
     }
 
-    EScan Feed(TArrayRef<const TCell> key, const TRow& row) noexcept final
+    EScan Feed(TArrayRef<const TCell> key, const TRow& row) final
     {
         LOG_T("Feed " << Debug());
         ++ReadRows;
@@ -545,7 +545,7 @@ private:
         return true;
     }
 
-    EScan FeedSample(const TRow& row) noexcept
+    EScan FeedSample(const TRow& row)
     {
         Y_ASSERT(row.Size() == 1);
         const auto embedding = row.Get(0).AsRef();
@@ -572,7 +572,7 @@ private:
         return MaxProbability != 0 ? EScan::Feed : EScan::Reset;
     }
 
-    EScan FeedKMeans(const TRow& row) noexcept
+    EScan FeedKMeans(const TRow& row)
     {
         Y_ASSERT(row.Size() == 1);
         const ui32 pos = FeedEmbedding(*this, Clusters, row, 0);
@@ -580,7 +580,7 @@ private:
         return EScan::Feed;
     }
 
-    EScan FeedUploadMain2Build(TArrayRef<const TCell> key, const TRow& row) noexcept
+    EScan FeedUploadMain2Build(TArrayRef<const TCell> key, const TRow& row)
     {
         const ui32 pos = FeedEmbedding(*this, Clusters, row, EmbeddingPos);
         if (pos > K) {
@@ -590,7 +590,7 @@ private:
         return FeedUpload();
     }
 
-    EScan FeedUploadMain2Posting(TArrayRef<const TCell> key, const TRow& row) noexcept
+    EScan FeedUploadMain2Posting(TArrayRef<const TCell> key, const TRow& row)
     {
         const ui32 pos = FeedEmbedding(*this, Clusters, row, EmbeddingPos);
         if (pos > K) {
@@ -600,7 +600,7 @@ private:
         return FeedUpload();
     }
 
-    EScan FeedUploadBuild2Build(TArrayRef<const TCell> key, const TRow& row) noexcept
+    EScan FeedUploadBuild2Build(TArrayRef<const TCell> key, const TRow& row)
     {
         const ui32 pos = FeedEmbedding(*this, Clusters, row, EmbeddingPos);
         if (pos > K) {
@@ -610,7 +610,7 @@ private:
         return FeedUpload();
     }
 
-    EScan FeedUploadBuild2Posting(TArrayRef<const TCell> key, const TRow& row) noexcept
+    EScan FeedUploadBuild2Posting(TArrayRef<const TCell> key, const TRow& row)
     {
         const ui32 pos = FeedEmbedding(*this, Clusters, row, EmbeddingPos);
         if (pos > K) {

--- a/ydb/core/tx/datashard/operation.h
+++ b/ydb/core/tx/datashard/operation.h
@@ -857,7 +857,7 @@ public:
     void SetFinishProposeTs(TMonotonic now) noexcept { FinishProposeTs = now; }
     void SetFinishProposeTs() noexcept;
 
-    NWilson::TTraceId GetTraceId() const noexcept {
+    NWilson::TTraceId GetTraceId() const {
         return OperationSpan.GetTraceId();
     }
 

--- a/ydb/core/tx/datashard/read_table_scan.cpp
+++ b/ydb/core/tx/datashard/read_table_scan.cpp
@@ -423,7 +423,7 @@ public:
 
     ~TReadTableScan() {}
 
-    void Describe(IOutputStream &out) const noexcept override
+    void Describe(IOutputStream &out) const override
     {
         out << "TReadTableScan";
     }
@@ -552,7 +552,7 @@ private:
                  IEventHandle::FlagTrackDelivery | IEventHandle::FlagSubscribeOnSession);
     }
 
-    TInitialState Prepare(IDriver *driver, TIntrusiveConstPtr<TScheme> scheme) noexcept override
+    TInitialState Prepare(IDriver *driver, TIntrusiveConstPtr<TScheme> scheme) override
     {
         Driver = driver;
 
@@ -576,7 +576,7 @@ private:
         return { EScan::Sleep, { } };
     }
 
-    EScan Seek(TLead &lead, ui64 seq) noexcept override
+    EScan Seek(TLead &lead, ui64 seq) override
     {
         if (seq) {
             MaybeSendResponseMessage(true);
@@ -672,7 +672,7 @@ private:
         return MessageQuota ? EScan::Feed : EScan::Sleep;
     }
 
-    EScan Feed(TArrayRef<const TCell> key, const TRow &row) noexcept override
+    EScan Feed(TArrayRef<const TCell> key, const TRow &row) override
     {
         Y_DEBUG_ABORT_UNLESS(DebugCheckKeyInRange(key));
 
@@ -694,7 +694,7 @@ private:
         return cmp <= 0;
     }
 
-    TAutoPtr<IDestructable> Finish(EAbort abort) noexcept override
+    TAutoPtr<IDestructable> Finish(EAbort abort) override
     {
         auto ctx = ActorContext();
 

--- a/ydb/core/tx/datashard/reshuffle_kmeans.cpp
+++ b/ydb/core/tx/datashard/reshuffle_kmeans.cpp
@@ -103,7 +103,7 @@ public:
         TargetTypes = MakeUploadTypes(table, UploadState, embedding, data);
     }
 
-    TInitialState Prepare(IDriver* driver, TIntrusiveConstPtr<TScheme>) noexcept final
+    TInitialState Prepare(IDriver* driver, TIntrusiveConstPtr<TScheme>) final
     {
         TActivationContext::AsActorContext().RegisterWithSameMailbox(this);
         LOG_D("Prepare " << Debug());
@@ -112,7 +112,7 @@ public:
         return {EScan::Feed, {}};
     }
 
-    EScan Seek(TLead& lead, ui64 seq) noexcept final
+    EScan Seek(TLead& lead, ui64 seq) final
     {
         LOG_D("Seek " << Debug());
         if (seq == 0) {
@@ -134,7 +134,7 @@ public:
         return EScan::Final;
     }
 
-    TAutoPtr<IDestructable> Finish(EAbort abort) noexcept final
+    TAutoPtr<IDestructable> Finish(EAbort abort) final
     {
         LOG_D("Finish " << Debug());
 
@@ -163,7 +163,7 @@ public:
         return nullptr;
     }
 
-    void Describe(IOutputStream& out) const noexcept final
+    void Describe(IOutputStream& out) const final
     {
         out << Debug();
     }
@@ -175,7 +175,7 @@ public:
             << " ReadBuf size: " << ReadBuf.Size() << " WriteBuf size: " << WriteBuf.Size() << " ";
     }
 
-    EScan PageFault() noexcept final
+    EScan PageFault() final
     {
         LOG_T("PageFault " << Debug());
 
@@ -288,7 +288,7 @@ public:
         LOG_D("Create " << Debug());
     }
 
-    EScan Feed(TArrayRef<const TCell> key, const TRow& row) noexcept final
+    EScan Feed(TArrayRef<const TCell> key, const TRow& row) final
     {
         LOG_T("Feed " << Debug());
         ++ReadRows;
@@ -308,7 +308,7 @@ public:
     }
 
 private:
-    EScan FeedUploadMain2Build(TArrayRef<const TCell> key, const TRow& row) noexcept
+    EScan FeedUploadMain2Build(TArrayRef<const TCell> key, const TRow& row)
     {
         const ui32 pos = FeedEmbedding(*this, Clusters, row, EmbeddingPos);
         if (pos > K) {
@@ -318,7 +318,7 @@ private:
         return FeedUpload();
     }
 
-    EScan FeedUploadMain2Posting(TArrayRef<const TCell> key, const TRow& row) noexcept
+    EScan FeedUploadMain2Posting(TArrayRef<const TCell> key, const TRow& row)
     {
         const ui32 pos = FeedEmbedding(*this, Clusters, row, EmbeddingPos);
         if (pos > K) {
@@ -328,7 +328,7 @@ private:
         return FeedUpload();
     }
 
-    EScan FeedUploadBuild2Build(TArrayRef<const TCell> key, const TRow& row) noexcept
+    EScan FeedUploadBuild2Build(TArrayRef<const TCell> key, const TRow& row)
     {
         const ui32 pos = FeedEmbedding(*this, Clusters, row, EmbeddingPos);
         if (pos > K) {
@@ -338,7 +338,7 @@ private:
         return FeedUpload();
     }
 
-    EScan FeedUploadBuild2Posting(TArrayRef<const TCell> key, const TRow& row) noexcept
+    EScan FeedUploadBuild2Posting(TArrayRef<const TCell> key, const TRow& row)
     {
         const ui32 pos = FeedEmbedding(*this, Clusters, row, EmbeddingPos);
         if (pos > K) {

--- a/ydb/core/tx/datashard/sample_k.cpp
+++ b/ydb/core/tx/datashard/sample_k.cpp
@@ -86,7 +86,7 @@ public:
 
     ~TSampleKScan() final = default;
 
-    TInitialState Prepare(IDriver* driver, TIntrusiveConstPtr<TScheme>) noexcept final {
+    TInitialState Prepare(IDriver* driver, TIntrusiveConstPtr<TScheme>) final {
         TActivationContext::AsActorContext().RegisterWithSameMailbox(this);
 
         LOG_D("Prepare " << Debug());
@@ -96,7 +96,7 @@ public:
         return {EScan::Feed, {}};
     }
 
-    EScan Seek(TLead& lead, ui64 seq) noexcept final {
+    EScan Seek(TLead& lead, ui64 seq) final {
         Y_ABORT_UNLESS(seq == 0);
         LOG_D("Seek " << Debug());
 
@@ -116,7 +116,7 @@ public:
         return EScan::Feed;
     }
 
-    EScan Feed(TArrayRef<const TCell> key, const TRow& row) noexcept final {
+    EScan Feed(TArrayRef<const TCell> key, const TRow& row) final {
         LOG_T("Feed key " << DebugPrintPoint(KeyTypes, key, *AppData()->TypeRegistry) << " " << Debug());
         ++ReadRows;
         ReadBytes += CountBytes(key, row);
@@ -148,7 +148,7 @@ public:
         return EScan::Feed;
     }
 
-    TAutoPtr<IDestructable> Finish(EAbort abort) noexcept final {
+    TAutoPtr<IDestructable> Finish(EAbort abort) final {
         Y_ABORT_UNLESS(Response);
         Response->Record.SetReadRows(ReadRows);
         Response->Record.SetReadBytes(ReadBytes);
@@ -164,11 +164,11 @@ public:
         return nullptr;
     }
 
-    void Describe(IOutputStream& out) const noexcept final {
+    void Describe(IOutputStream& out) const final {
         out << Debug();
     }
 
-    EScan Exhausted() noexcept final {
+    EScan Exhausted() final {
         return EScan::Final;
     }
 

--- a/ydb/core/tx/datashard/snapshot_key.h
+++ b/ydb/core/tx/datashard/snapshot_key.h
@@ -30,7 +30,7 @@ struct TCommonOps {
         return a.ToTuple() == b.ToTuple();
     }
 
-    explicit operator size_t() const noexcept {
+    explicit operator size_t() const {
         return HashTuple(static_cast<const TDerived*>(this)->ToTuple());
     }
 };

--- a/ydb/core/tx/locks/locks.h
+++ b/ydb/core/tx/locks/locks.h
@@ -840,14 +840,14 @@ public:
         , Locker(self)
     {}
 
-    void SetupUpdate(TLocksUpdate* update, ILocksDb* db = nullptr) noexcept {
+    void SetupUpdate(TLocksUpdate* update, ILocksDb* db = nullptr) {
         Y_ABORT_UNLESS(!Update, "Cannot setup a recursive update");
         Y_ABORT_UNLESS(update, "Cannot setup a nullptr update");
         Update = update;
         Db = db;
     }
 
-    void ResetUpdate() noexcept {
+    void ResetUpdate() {
         if (Y_LIKELY(Update)) {
             if (Update->Lock && Update->Lock->Empty()) {
                 Locker.RemoveLock(Update->LockTxId, nullptr);

--- a/ydb/core/tx/locks/range_treap.h
+++ b/ydb/core/tx/locks/range_treap.h
@@ -11,11 +11,11 @@ namespace NDataShard {
 
     template<class TValue>
     struct TRangeTreapDefaultValueTraits {
-        static bool Less(const TValue& a, const TValue& b) noexcept {
+        static bool Less(const TValue& a, const TValue& b) {
             return a < b;
         }
 
-        static bool Equal(const TValue& a, const TValue& b) noexcept {
+        static bool Equal(const TValue& a, const TValue& b) {
             return a == b;
         }
     };
@@ -123,7 +123,7 @@ namespace NDataShard {
         /**
          * Removes all ranges with the given value
          */
-        void RemoveRanges(const TValue& value) noexcept {
+        void RemoveRanges(const TValue& value) {
             auto it = Values.find(value);
             if (it != Values.end()) {
                 while (!it->second.Empty()) {
@@ -250,7 +250,7 @@ namespace NDataShard {
          */
         TNode* FindOrSplit(THolder<TNode>&& t,
                            THolder<TNode>& l, THolder<TNode>& r,
-                           const TBorder& key, const TValue& value) noexcept
+                           const TBorder& key, const TValue& value)
         {
             if (!t) {
                 return nullptr;
@@ -295,7 +295,7 @@ namespace NDataShard {
         /**
          * Removes node t from the tree
          */
-        void DoRemove(TNode* t) noexcept {
+        void DoRemove(TNode* t) {
             Y_DEBUG_ABORT_UNLESS(t, "Trying to remove a nullptr node");
             TNode* p = t->Parent;
             if (p) {
@@ -314,7 +314,7 @@ namespace NDataShard {
         /**
          * Removes the node linked by tptr from the tree
          */
-        void DoRemove(THolder<TNode>* tptr) noexcept {
+        void DoRemove(THolder<TNode>* tptr) {
             THolder<TNode> d = std::move(*tptr);
             Y_DEBUG_ABORT_UNLESS(d, "Cannot remove a null node");
             ++Stats_.Deletes;
@@ -334,7 +334,7 @@ namespace NDataShard {
         /**
          * Merges two subtrees l and r (where l < r)
          */
-        THolder<TNode> Merge(THolder<TNode> l, THolder<TNode> r) noexcept {
+        THolder<TNode> Merge(THolder<TNode> l, THolder<TNode> r) {
             Y_DEBUG_ABORT_UNLESS(!l || l->Parent == nullptr);
             Y_DEBUG_ABORT_UNLESS(!r || r->Parent == nullptr);
             if (!l || !r) {
@@ -356,7 +356,7 @@ namespace NDataShard {
          *
          * Returns the node which was the source of the new MaxRightKey
          */
-        TNode* RecomputeMaxRight(TNode* t) noexcept {
+        TNode* RecomputeMaxRight(TNode* t) {
             TNode* source = t;
             t->MaxRightKey = t->RightKey;
             t->MaxRightMode = t->RightMode;
@@ -379,7 +379,7 @@ namespace NDataShard {
         /**
          * Recomputes MaxRightKey for subtree root t and its parents
          */
-        void RecomputeMaxRights(TNode* t) noexcept {
+        void RecomputeMaxRights(TNode* t) {
             while (t) {
                 RecomputeMaxRight(t);
                 t = t->Parent;
@@ -418,7 +418,7 @@ namespace NDataShard {
          *
          * Returns true when t->MaxRightKey is modified
          */
-        bool ExtendMaxRightKey(TNode* t, const TOwnedCellVec& rightKey, EPrefixMode rightMode) noexcept {
+        bool ExtendMaxRightKey(TNode* t, const TOwnedCellVec& rightKey, EPrefixMode rightMode) {
             int cmp = CompareBorders(t->MaxRightBorder(), TBorder{ rightKey, rightMode });
             if (cmp < 0) {
                 t->MaxRightKey = rightKey;
@@ -433,7 +433,7 @@ namespace NDataShard {
         /**
          * Extends MaxRightKey of node t and all its parents
          */
-        void ExtendMaxRightKeys(TNode* t, const TOwnedCellVec& rightKey, EPrefixMode rightMode) noexcept {
+        void ExtendMaxRightKeys(TNode* t, const TOwnedCellVec& rightKey, EPrefixMode rightMode) {
             while (t && ExtendMaxRightKey(t, rightKey, rightMode)) {
                 t = t->Parent;
             }
@@ -516,7 +516,7 @@ namespace NDataShard {
         /**
          * Validates all invariants for the tree, used for tests
          */
-        void Validate() const noexcept {
+        void Validate() const {
             if (Root) {
                 Y_ABORT_UNLESS(Root->Parent == nullptr, "Root must not have a parent");
                 DoValidate(Root.Get());
@@ -527,7 +527,7 @@ namespace NDataShard {
         /**
          * Validates all invariants for subtree t
          */
-        std::tuple<TNode*, TNode*> DoValidate(TNode* t) const noexcept {
+        std::tuple<TNode*, TNode*> DoValidate(TNode* t) const {
             int cmp;
             TNode* leftMost = t;
             TNode* rightMost = t;

--- a/ydb/core/tx/locks/range_tree_base.h
+++ b/ydb/core/tx/locks/range_tree_base.h
@@ -101,7 +101,7 @@ namespace NDataShard {
             }
         };
 
-        int CompareBorders(const TBorder& a, const TBorder& b) const noexcept {
+        int CompareBorders(const TBorder& a, const TBorder& b) const {
             ++Stats_.Comparisons;
             return ComparePrefixBorders(KeyTypes, a.Key, a.Mode, b.Key, b.Mode);
         }

--- a/ydb/core/tx/locks/time_counters.h
+++ b/ydb/core/tx/locks/time_counters.h
@@ -12,14 +12,14 @@ namespace NDataShard {
     class TMicrosecTimerCounter {
     public:
         template<class TDataShardClass>
-        TMicrosecTimerCounter(TDataShardClass& dataShard, NDataShard::ECumulativeCounters counter) noexcept
+        TMicrosecTimerCounter(TDataShardClass& dataShard, NDataShard::ECumulativeCounters counter)
             : Callback(
                 [&dataShard, counter](ui64 us) {
                     dataShard.IncCounter(counter, us);
                 })
         { }
 
-        ~TMicrosecTimerCounter() noexcept {
+        ~TMicrosecTimerCounter() {
             Callback(ui64(1000000.0 * Timer.Passed()));
         }
 

--- a/ydb/library/actors/core/actor.cpp
+++ b/ydb/library/actors/core/actor.cpp
@@ -102,7 +102,7 @@ namespace NActors {
         return (double)Min(passed, used) / passed;
     }
 
-    void IActor::Describe(IOutputStream &out) const noexcept {
+    void IActor::Describe(IOutputStream &out) const {
         SelfActorId.Out(out);
     }
 

--- a/ydb/library/actors/core/actor.h
+++ b/ydb/library/actors/core/actor.h
@@ -245,7 +245,7 @@ namespace NActors {
 
     class IActorOps : TNonCopyable {
     public:
-        virtual void Describe(IOutputStream&) const noexcept = 0;
+        virtual void Describe(IOutputStream&) const = 0;
         virtual bool Send(const TActorId& recipient, IEventBase*, IEventHandle::TEventFlags flags = 0, ui64 cookie = 0, NWilson::TTraceId traceId = {}) const noexcept = 0;
 
         /**
@@ -565,7 +565,7 @@ namespace NActors {
     protected:
         void SetEnoughCpu(bool isEnough);
 
-        void Describe(IOutputStream&) const noexcept override;
+        void Describe(IOutputStream&) const override;
         bool Send(TAutoPtr<IEventHandle> ev) const noexcept;
         bool Send(const TActorId& recipient, IEventBase* ev, TEventFlags flags = 0, ui64 cookie = 0, NWilson::TTraceId traceId = {}) const noexcept final;
         bool Send(const TActorId& recipient, THolder<IEventBase> ev, TEventFlags flags = 0, ui64 cookie = 0, NWilson::TTraceId traceId = {}) const{


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

...

### Changelog category <!-- remove all except one -->

* Not for changelog (changelog entry is not required)

### Description for reviewers <!-- (optional) description for those who read this PR -->

Historically LocalDB marked most methods noexcept (I in the spirit of "improving performance"), which becomes very inconvenient over time (e.g. unable to throw exceptions on conflict from transaction observers), and prevents switching from `Y_ABORT` to `Y_ENSURE` in many places, so we could restart the affected tablet instead of the entire process.

This PR removes most of noexcept uses in `tablet_flat` and `datashard` that I could find, leaving (and even adding in rare cases) `noexcept` where it's provably supposed to never fail. Note: functions that use allocators directly or indirectly, as well as those that currently abort in release builds (or those that currently don't but might theoretically add argument validation) are considered potentially failing and cannot be noexcept.

Related to #15118.