### PR TITLE
Fix Console version handling

### DIFF
--- a/ydb/core/cms/console/console_handshake.cpp
+++ b/ydb/core/cms/console/console_handshake.cpp
@@ -137,10 +137,13 @@ void TConfigsManager::Handle(TEvBlobStorage::TEvControllerProposeConfigRequest::
         responseRecord.SetYAML(MainYamlConfig);
     } else if (YamlVersion == proposedConfigVersion) {
         responseRecord.SetStatus(NKikimrBlobStorage::TEvControllerProposeConfigResponse::CommitIsNeeded);
-    } else if (YamlVersion != proposedConfigVersion && (proposedConfigVersion && YamlVersion != proposedConfigVersion - 1)) {
+    } else if (YamlVersion != proposedConfigVersion + 1) {
         responseRecord.SetStatus(NKikimrBlobStorage::TEvControllerProposeConfigResponse::UnexpectedConfig);
         responseRecord.SetProposedConfigVersion(proposedConfigVersion);
         responseRecord.SetConsoleConfigVersion(YamlVersion);
+        if (proposedConfigVersion + 1 < YamlVersion) {
+            responseRecord.SetYAML(MainYamlConfig);
+        }
         LOG_ALERT_S(ctx, NKikimrServices::CMS, "Unexpected proposed config.");
     } else if (proposedConfigHash != currentConfigHash) {
         responseRecord.SetStatus(NKikimrBlobStorage::TEvControllerProposeConfigResponse::HashMismatch);


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

Fix Console version handling

### Changelog category <!-- remove all except one -->

* Not for changelog (changelog entry is not required)

### Description for reviewers <!-- (optional) description for those who read this PR -->

This fix allows correct migration between 25-1 and 24-4 stables.
