### PR TITLE
Add create_time & last_refresh_time to Task in Maintenance API

### DIFF
--- a/ydb/core/cms/api_adapters.cpp
+++ b/ydb/core/cms/api_adapters.cpp
@@ -109,6 +109,11 @@ namespace {
         ConvertPermission(taskUid, protoPermission, actionState);
     }
 
+    void ConvertInstant(const TInstant& instant, google::protobuf::Timestamp& protoValue) {
+        protoValue.set_seconds(instant.Seconds());
+        protoValue.set_nanos(instant.NanoSecondsOfSecond());
+    }
+
 } // anonymous
 
 template <typename TDerived, typename TEvRequest, typename TEvResponse>
@@ -312,6 +317,10 @@ public:
         // performed actions: existing permissions
         if (cmsState->MaintenanceTasks.contains(taskUid)) {
             const auto& task = cmsState->MaintenanceTasks.at(taskUid);
+
+            ConvertInstant(task.CreateTime, *result.mutable_create_time());
+            ConvertInstant(task.LastRefreshTime, *result.mutable_last_refresh_time());
+
             for (const auto& id : task.Permissions) {
                 if (!cmsState->Permissions.contains(id) || permissionsSeen.contains(id)) {
                     continue;
@@ -501,6 +510,8 @@ public:
 
             auto& result = *response->Record.MutableResult();
             result.set_task_uid(taskUid);
+            ConvertInstant(task.CreateTime, *result.mutable_create_time());
+            ConvertInstant(task.LastRefreshTime, *result.mutable_last_refresh_time());
 
             // performed actions
             for (const auto& id : task.Permissions) {
@@ -566,6 +577,8 @@ public:
 
             auto& result = *response->Record.MutableResult();
             result.mutable_task_options()->set_task_uid(taskUid);
+            ConvertInstant(task.CreateTime, *result.mutable_create_time());
+            ConvertInstant(task.LastRefreshTime, *result.mutable_last_refresh_time());
 
             // performed actions
             for (const auto& id : task.Permissions) {
@@ -633,6 +646,10 @@ public:
         // performed actions
         if (cmsState->MaintenanceTasks.contains(taskUid)) {
             const auto& task = cmsState->MaintenanceTasks.at(taskUid);
+
+            ConvertInstant(task.CreateTime, *result.mutable_create_time());
+            ConvertInstant(task.LastRefreshTime, *result.mutable_last_refresh_time());
+
             for (const auto& id : task.Permissions) {
                 if (!cmsState->Permissions.contains(id)) {
                     continue;

--- a/ydb/core/cms/cms_state.h
+++ b/ydb/core/cms/cms_state.h
@@ -16,6 +16,8 @@ struct TTaskInfo {
     TString Owner;
     TSet<TString> Permissions;
     bool HasSingleCompositeActionGroup = false;
+    TInstant CreateTime;
+    TInstant LastRefreshTime;
 
     TString ToString() const {
         return TStringBuilder() << "{"
@@ -24,6 +26,8 @@ struct TTaskInfo {
             << " Owner: " << Owner
             << " Permissions: [" << JoinSeq(", ", Permissions) << "]"
             << " HasSingleCompositeActionGroup: " << HasSingleCompositeActionGroup
+            << " CreateTime: " << CreateTime
+            << " LastRefreshTime: " << LastRefreshTime
             << " }";
     }
 };

--- a/ydb/core/cms/cms_tx_load_state.cpp
+++ b/ydb/core/cms/cms_tx_load_state.cpp
@@ -135,13 +135,17 @@ public:
             TString requestId = maintenanceTasksRowset.GetValue<Schema::MaintenanceTasks::RequestID>();
             TString owner = maintenanceTasksRowset.GetValue<Schema::MaintenanceTasks::Owner>();
             bool hasSingleCompositeActionGroup = maintenanceTasksRowset.GetValue<Schema::MaintenanceTasks::HasSingleCompositeActionGroup>();
+            ui64 createTime = maintenanceTasksRowset.GetValue<Schema::MaintenanceTasks::CreateTime>();
+            ui64 lastRefreshTime = maintenanceTasksRowset.GetValue<Schema::MaintenanceTasks::LastRefreshTime>();
 
             state->MaintenanceRequests.emplace(requestId, taskId);
             state->MaintenanceTasks.emplace(taskId, TTaskInfo{
                 .TaskId = taskId,
                 .RequestId = requestId,
                 .Owner = owner,
-                .HasSingleCompositeActionGroup = hasSingleCompositeActionGroup
+                .HasSingleCompositeActionGroup = hasSingleCompositeActionGroup,
+                .CreateTime = TInstant::MicroSeconds(createTime),
+                .LastRefreshTime = TInstant::MicroSeconds(lastRefreshTime)
             });
 
             LOG_DEBUG(ctx, NKikimrServices::CMS, "Loaded maintenance task %s mapped to request %s",

--- a/ydb/core/cms/cms_tx_store_permissions.cpp
+++ b/ydb/core/cms/cms_tx_store_permissions.cpp
@@ -54,7 +54,7 @@ public:
             );
         } else if (Scheduled != nullptr && Self->State->MaintenanceRequests.contains(Scheduled->RequestId)) {
             const auto& taskId = Self->State->MaintenanceRequests[Scheduled->RequestId];
-            auto& task = Self->State->MaintenanceTasks[taskId];
+            auto& task = Self->State->MaintenanceTasks.at(taskId);
 
             task.LastRefreshTime = now;
             db.Table<Schema::MaintenanceTasks>().Key(taskId).Update(

--- a/ydb/core/cms/cms_tx_store_permissions.cpp
+++ b/ydb/core/cms/cms_tx_store_permissions.cpp
@@ -31,6 +31,7 @@ public:
 
         const auto &rec = Response->Get<TEvCms::TEvPermissionResponse>()->Record;
 
+        auto now = ctx.Now();
         if (MaintenanceTaskId) {
             Y_ABORT_UNLESS(Scheduled);
 
@@ -39,13 +40,25 @@ public:
                 .TaskId = *MaintenanceTaskId,
                 .RequestId = Scheduled->RequestId,
                 .Owner = Scheduled->Owner,
-                .HasSingleCompositeActionGroup = !Scheduled->Request.GetPartialPermissionAllowed()
+                .HasSingleCompositeActionGroup = !Scheduled->Request.GetPartialPermissionAllowed(),
+                .CreateTime = now,
+                .LastRefreshTime = now
             });
 
             db.Table<Schema::MaintenanceTasks>().Key(*MaintenanceTaskId).Update(
                 NIceDb::TUpdate<Schema::MaintenanceTasks::RequestID>(Scheduled->RequestId),
                 NIceDb::TUpdate<Schema::MaintenanceTasks::Owner>(Scheduled->Owner),
-                NIceDb::TUpdate<Schema::MaintenanceTasks::HasSingleCompositeActionGroup>(!Scheduled->Request.GetPartialPermissionAllowed())
+                NIceDb::TUpdate<Schema::MaintenanceTasks::HasSingleCompositeActionGroup>(!Scheduled->Request.GetPartialPermissionAllowed()),
+                NIceDb::TUpdate<Schema::MaintenanceTasks::CreateTime>(now.MicroSeconds()),
+                NIceDb::TUpdate<Schema::MaintenanceTasks::LastRefreshTime>(now.MicroSeconds())
+            );
+        } else if (Scheduled != nullptr && Self->State->MaintenanceRequests.contains(Scheduled->RequestId)) {
+            const auto& taskId = Self->State->MaintenanceRequests[Scheduled->RequestId];
+            auto& task = Self->State->MaintenanceTasks[taskId];
+
+            task.LastRefreshTime = now;
+            db.Table<Schema::MaintenanceTasks>().Key(taskId).Update(
+                NIceDb::TUpdate<Schema::MaintenanceTasks::LastRefreshTime>(now.MicroSeconds())
             );
         }
 

--- a/ydb/core/cms/scheme.h
+++ b/ydb/core/cms/scheme.h
@@ -135,9 +135,18 @@ struct Schema : NIceDb::Schema {
         struct RequestID : Column<2, NScheme::NTypeIds::Utf8> {};
         struct Owner : Column<3, NScheme::NTypeIds::Utf8> {};
         struct HasSingleCompositeActionGroup : Column<4, NScheme::NTypeIds::Bool> {};
+        struct CreateTime : Column<5, NScheme::NTypeIds::Uint64> {};
+        struct LastRefreshTime : Column<6, NScheme::NTypeIds::Uint64> {};
 
         using TKey = TableKey<TaskID>;
-        using TColumns = TableColumns<TaskID, RequestID, Owner, HasSingleCompositeActionGroup>;
+        using TColumns = TableColumns<
+            TaskID,
+            RequestID,
+            Owner,
+            HasSingleCompositeActionGroup,
+            CreateTime,
+            LastRefreshTime
+        >;
     };
 
     using TTables = SchemaTables<Param, Permission, Request, WalleTask, Notification, NodeTenant,

--- a/ydb/public/api/protos/draft/ydb_maintenance.proto
+++ b/ydb/public/api/protos/draft/ydb_maintenance.proto
@@ -182,6 +182,10 @@ message MaintenanceTaskResult {
     repeated ActionGroupStates action_group_states = 2;
     // Try again after this deadline. Specified if there are no performed actions.
     optional google.protobuf.Timestamp retry_after = 3;
+    // The time when the mainteance task was created.
+    google.protobuf.Timestamp create_time = 4;
+    // The last time when the mainteance task was refreshed. Initially equals to create_time.
+    google.protobuf.Timestamp last_refresh_time = 5;
 }
 
 message MaintenanceTaskResponse {
@@ -197,6 +201,10 @@ message GetMaintenanceTaskRequest {
 message GetMaintenanceTaskResult {
     MaintenanceTaskOptions task_options = 1;
     repeated ActionGroupStates action_group_states = 2;
+    // The time when the mainteance task was created.
+    google.protobuf.Timestamp create_time = 3;
+    // The last time when the mainteance task was refreshed. Initially equals to create_time.
+    google.protobuf.Timestamp last_refresh_time = 4;
 }
 
 message GetMaintenanceTaskResponse {


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

Добавлены время создания и время последнего обновления задачи обслуживания

### Changelog category <!-- remove all except one -->

* New feature

### Description for reviewers <!-- (optional) description for those who read this PR -->

Поможет находить неактивные задачи обслуживания. Если пользователь не указал у задачи описание, то поможет сопоставить задачу с инфраструктурными событиями.