### PR TITLE
Inefficient work with PQ Cache L2

### DIFF
--- a/ydb/core/persqueue/partition.cpp
+++ b/ydb/core/persqueue/partition.cpp
@@ -2118,6 +2118,8 @@ void TPartition::RunPersist() {
         WriteInfosApplied.clear();
         //Done with counters.
 
+        DumpKeyValueRequest(PersistRequest->Record);
+
         PersistRequestSpan.Attribute("bytes", static_cast<i64>(PersistRequest->Record.ByteSizeLong()));
         ctx.Send(HaveWriteMsg ? BlobCache : Tablet, PersistRequest.Release(), 0, 0, PersistRequestSpan.GetTraceId());
         CurrentPersistRequestSpan = std::move(PersistRequestSpan);

--- a/ydb/core/persqueue/partition.cpp
+++ b/ydb/core/persqueue/partition.cpp
@@ -2118,8 +2118,6 @@ void TPartition::RunPersist() {
         WriteInfosApplied.clear();
         //Done with counters.
 
-        DumpKeyValueRequest(PersistRequest->Record);
-
         PersistRequestSpan.Attribute("bytes", static_cast<i64>(PersistRequest->Record.ByteSizeLong()));
         ctx.Send(HaveWriteMsg ? BlobCache : Tablet, PersistRequest.Release(), 0, 0, PersistRequestSpan.GetTraceId());
         CurrentPersistRequestSpan = std::move(PersistRequestSpan);

--- a/ydb/core/persqueue/pq_l2_cache.h
+++ b/ydb/core/persqueue/pq_l2_cache.h
@@ -45,26 +45,45 @@ public:
         TPartitionId Partition;
         ui64 Offset;
         ui16 PartNo;
+        ui32 Count;
+        ui16 InternalPartsCount;
 
         TKey(ui64 tabletId, const TCacheBlobL2& blob)
             : TabletId(tabletId)
             , Partition(blob.Partition)
             , Offset(blob.Offset)
             , PartNo(blob.PartNo)
+            , Count(blob.Count)
+            , InternalPartsCount(blob.InternalPartsCount)
         {
             KeyHash = Hash128to32(TabletId, (static_cast<ui64>(Partition.InternalPartitionId) << 17) + PartNo + (Partition.IsSupportivePartition() ? 0 : (1 << 16)));
             KeyHash = Hash128to32(KeyHash, Offset);
+            KeyHash = Hash128to32(KeyHash, Count);
+            KeyHash = Hash128to32(KeyHash, InternalPartsCount);
         }
 
-        bool operator == (const TKey& key) const {
+        bool operator ==(const TKey& key) const {
             return TabletId == key.TabletId &&
                 Partition == key.Partition &&
                 Offset == key.Offset &&
-                PartNo == key.PartNo;
+                PartNo == key.PartNo &&
+                Count == key.Count &&
+                InternalPartsCount == key.InternalPartsCount;
         }
 
         ui64 Hash() const noexcept {
             return KeyHash;
+        }
+
+        TString ToString() const {
+            TString s;
+            s += "Tablet '"; s += ::ToString(TabletId); s += "'";
+            s += " partition "; s += Partition.ToString();
+            s += " offset "; s += ::ToString(Offset);
+            s += " partno "; s += ::ToString(PartNo);
+            s += " count "; s += ::ToString(Count);
+            s += " parts "; s += ::ToString(InternalPartsCount);
+            return s;
         }
 
     private:

--- a/ydb/core/persqueue/pq_l2_service.h
+++ b/ydb/core/persqueue/pq_l2_service.h
@@ -72,6 +72,8 @@ struct TCacheBlobL2 {
     TPartitionId Partition;
     ui64 Offset;
     ui16 PartNo;
+    ui32 Count;
+    ui16 InternalPartsCount;
     TCacheValue::TPtr Value;
 };
 

--- a/ydb/services/persqueue_v1/persqueue_ut.cpp
+++ b/ydb/services/persqueue_v1/persqueue_ut.cpp
@@ -2825,9 +2825,9 @@ Y_UNIT_TEST_SUITE(TPersQueueTest) {
         Cerr << ">>>>> 2" << Endl << Flush;
         auto info16 = server.AnnoyingClient->ReadFromPQ({DEFAULT_TOPIC_NAME, 0, 16, 16, "user"}, 16);
 
-        UNIT_ASSERT_VALUES_EQUAL(info0.BlobsFromCache, 3);
-        UNIT_ASSERT_VALUES_EQUAL(info16.BlobsFromCache, 2);
-        UNIT_ASSERT_VALUES_EQUAL(info0.BlobsFromDisk + info16.BlobsFromDisk, 0);
+        UNIT_ASSERT_VALUES_EQUAL(info0.BlobsFromCache, 2);
+        UNIT_ASSERT_VALUES_EQUAL(info16.BlobsFromCache, 1);
+        UNIT_ASSERT_VALUES_EQUAL(info0.BlobsFromDisk + info16.BlobsFromDisk, 2);
 
         for (ui32 i = 0; i < 8; ++i)
             server.AnnoyingClient->WriteToPQ({DEFAULT_TOPIC_NAME, 0, "source1", 32+i}, value);


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

Move changes from PR #15600

Offset and PartNo are used for keys. As a result, after compaction, the blobs in the cache are updated and deleted from it on the next iteration of the write.

#15601

### Changelog category <!-- remove all except one -->

* Not for changelog

### Description for reviewers <!-- (optional) description for those who read this PR -->

The full set of values is used for keys in the `PQ Cache L2` - `Offset`, `PartNo`, `Count`, `InternalPartsCount`