### PR TITLE
Optimize TEvVPut serialization, issue#1662

### DIFF
--- a/ydb/core/base/blobstorage.h
+++ b/ydb/core/base/blobstorage.h
@@ -938,7 +938,10 @@ struct TEvBlobStorage {
         EvIncrHugeReadLogResult,
         EvIncrHugeScanResult,
 
-        EvEnd
+        EvEnd,
+        
+        // Unique ID for binary-serialized VPut
+        EvVPutBinary = EvPut + 18 * 512,     
     };
 
     static_assert(EvEnd < EventSpaceEnd(TKikimrEvents::ES_BLOBSTORAGE),
@@ -2438,6 +2441,7 @@ struct TEvBlobStorage {
     struct TEvVInplacePatchResult;
     struct TEvVPut;
     struct TEvVPutResult;
+    struct TEvVPutBinary;
     struct TEvVMultiPut;
     struct TEvVMultiPutResult;
     struct TEvVGet;

--- a/ydb/core/blobstorage/ut_blobstorage/binary_serialization_perf.cpp
+++ b/ydb/core/blobstorage/ut_blobstorage/binary_serialization_perf.cpp
@@ -37,7 +37,6 @@ Y_UNIT_TEST_SUITE(BinarySerializationPerformance) {
         deserializationTimes.reserve(iterations);
         messageSizes.reserve(iterations);
         
-        // Прогрев кэша
         Cerr << "Warming up cache for binary format..." << Endl;
         for (size_t i = 0; i < 1000; ++i) {
             auto binaryMsg = MakeHolder<TEvBlobStorage::TEvVPutBinary>(
@@ -148,7 +147,7 @@ Y_UNIT_TEST_SUITE(BinarySerializationPerformance) {
         std::vector<size_t> testSizes = {32, 128, 512, 1024, 4096, 32768, 65536};
         
         Cerr << "===== Binary Serialization Size Metrics =====" << Endl;
-        Cerr << "Payload Size\tTotal Size\tOverhead\tOverhead %" << Endl;
+        Cerr << "Payload Size\tTotal Size\tOverhead\tOverhead %\tCompression Ratio" << Endl;
         
         for (size_t size : testSizes) {
             TString testData = GenerateTestData(size);
@@ -165,18 +164,21 @@ Y_UNIT_TEST_SUITE(BinarySerializationPerformance) {
             size_t binarySize = binaryData.size();
             size_t overhead = binarySize - size;
             double overheadPercent = 100.0 * overhead / binarySize;
+            double compressionRatio = (double)binarySize / size;
             
-            Cerr << size << "\t" << binarySize << "\t" << overhead << "\t" << overheadPercent << "%" << Endl;
+            Cerr << size << "\t" << binarySize << "\t" << overhead << "\t" 
+                 << overheadPercent << "%" << "\t" << compressionRatio << "x" << Endl;
         }
         
         Cerr << "=============================================================" << Endl;
     }
     
     Y_UNIT_TEST(TEvVPutBinarySerializationPerformance) {
+        Cerr << "\n\n=== TESTING BINARY SERIALIZATION SIZES ===" << Endl;
         MeasureBinarySizes();
         
-        // Тестируем производительность для нескольких размеров данных
-        std::vector<size_t> testSizes = {1024, 32768};
+        Cerr << "\n\n=== TESTING BINARY SERIALIZATION PERFORMANCE ===" << Endl;
+        std::vector<size_t> testSizes = {32, 128, 4096};
         
         for (size_t size : testSizes) {
             MeasureBinarySerializationPerformance(size, DEFAULT_ITERATIONS);

--- a/ydb/core/blobstorage/ut_blobstorage/binary_serialization_perf.cpp
+++ b/ydb/core/blobstorage/ut_blobstorage/binary_serialization_perf.cpp
@@ -1,0 +1,186 @@
+#include <ydb/core/blobstorage/ut_blobstorage/lib/env.h>
+#include <ydb/core/base/blobstorage.h>
+#include <ydb/core/blobstorage/vdisk/common/vdisk_events.h>
+#include <ydb/core/blobstorage/vdisk/common/vdisk_events_binary.h>
+
+#include <library/cpp/testing/unittest/registar.h>
+#include <util/system/hp_timer.h>
+#include <util/generic/vector.h>
+#include <util/stream/str.h>
+#include <util/system/compiler.h>
+
+using namespace NKikimr;
+
+Y_UNIT_TEST_SUITE(BinarySerializationPerformance) {
+    
+    const size_t DEFAULT_ITERATIONS = 10000;
+    
+    TString GenerateTestData(size_t size) {
+        TString data;
+        data.reserve(size);
+        for (size_t i = 0; i < size; ++i) {
+            data.append(1, static_cast<char>(i % 256));
+        }
+        return data;
+    }
+
+    void MeasureBinarySerializationPerformance(size_t payloadSize, size_t iterations) {
+        TString testData = GenerateTestData(payloadSize);
+        
+        auto blobId = TLogoBlobID(1, 1, 1, 1, 0x3333, 0x0001A01B);
+        auto vdiskId = TVDiskID(TGroupId::FromValue(1), 1, 1, 1, 1);
+        
+        TVector<double> serializationTimes;
+        TVector<double> deserializationTimes;
+        TVector<size_t> messageSizes;
+        serializationTimes.reserve(iterations);
+        deserializationTimes.reserve(iterations);
+        messageSizes.reserve(iterations);
+        
+        // Прогрев кэша
+        Cerr << "Warming up cache for binary format..." << Endl;
+        for (size_t i = 0; i < 1000; ++i) {
+            auto binaryMsg = MakeHolder<TEvBlobStorage::TEvVPutBinary>(
+                blobId, testData, vdiskId
+            );
+            
+            TString serializedData;
+            TEvBlobStorage::TEvVPutBinary::Serialize(*binaryMsg, serializedData);
+            
+            auto deserializedMsg = TEvBlobStorage::TEvVPutBinary::Deserialize(serializedData);
+            if (!deserializedMsg) {
+                Cerr << "Binary deserialization error during warm-up" << Endl;
+                return;
+            }
+            delete deserializedMsg;
+        }
+        
+        Cerr << "Starting binary measurements for " << payloadSize << " bytes payload..." << Endl;
+        
+        for (size_t i = 0; i < iterations; ++i) {
+            auto binaryMsg = MakeHolder<TEvBlobStorage::TEvVPutBinary>(
+                blobId, testData, vdiskId
+            );
+            
+            TString serializedData;
+            auto startTime = TInstant::Now();
+            TEvBlobStorage::TEvVPutBinary::Serialize(*binaryMsg, serializedData);
+            auto endTime = TInstant::Now();
+            double serializationTime = (endTime - startTime).SecondsFloat();
+            
+            size_t messageSize = serializedData.size();
+            messageSizes.push_back(messageSize);
+            
+            startTime = TInstant::Now();
+            auto deserializedMsg = TEvBlobStorage::TEvVPutBinary::Deserialize(serializedData);
+            endTime = TInstant::Now();
+            double deserializationTime = (endTime - startTime).SecondsFloat();
+            
+            if (!deserializedMsg) {
+                Cerr << "Binary deserialization error in iteration " << i << Endl;
+                continue;
+            }
+            
+            bool dataValid = true;
+            dataValid &= (deserializedMsg->BlobId == blobId);
+            dataValid &= (deserializedMsg->VDiskId == vdiskId);
+            dataValid &= (deserializedMsg->Buffer == testData);
+            
+            if (!dataValid) {
+                Cerr << "Data after binary deserialization is invalid in iteration " << i << Endl;
+            }
+            
+            serializationTimes.push_back(serializationTime);
+            deserializationTimes.push_back(deserializationTime);
+            
+            delete deserializedMsg;
+        }
+        
+        double avgSerializationTime = 0;
+        double avgDeserializationTime = 0;
+        double avgMessageSize = 0;
+        
+        for (size_t i = 0; i < messageSizes.size(); ++i) {
+            avgSerializationTime += serializationTimes[i];
+            avgDeserializationTime += deserializationTimes[i];
+            avgMessageSize += messageSizes[i];
+        }
+        
+        avgSerializationTime /= serializationTimes.size();
+        avgDeserializationTime /= deserializationTimes.size();
+        avgMessageSize /= messageSizes.size();
+        
+        double serializationThroughput = (avgMessageSize / 1024.0 / 1024.0) / avgSerializationTime;
+        double deserializationThroughput = (avgMessageSize / 1024.0 / 1024.0) / avgDeserializationTime;
+        
+        double stddevSerialization = 0;
+        double stddevDeserialization = 0;
+        
+        for (size_t i = 0; i < serializationTimes.size(); ++i) {
+            stddevSerialization += 
+                (serializationTimes[i] - avgSerializationTime) * 
+                (serializationTimes[i] - avgSerializationTime);
+        }
+        
+        for (size_t i = 0; i < deserializationTimes.size(); ++i) {
+            stddevDeserialization += 
+                (deserializationTimes[i] - avgDeserializationTime) * 
+                (deserializationTimes[i] - avgDeserializationTime);
+        }
+        
+        stddevSerialization = std::sqrt(stddevSerialization / serializationTimes.size());
+        stddevDeserialization = std::sqrt(stddevDeserialization / deserializationTimes.size());
+        
+        Cerr << "===== TEvVPutBinary Serialization Performance Results =====" << Endl;
+        Cerr << "Data size: " << payloadSize << " bytes" << Endl;
+        Cerr << "Number of iterations: " << iterations << Endl;
+        Cerr << "Average message size: " << avgMessageSize << " bytes" << Endl;
+        Cerr << "Serialization time: " << (avgSerializationTime * 1e6) << " μs (standard deviation: " 
+             << (stddevSerialization * 1e6) << " μs)" << Endl;
+        Cerr << "Deserialization time: " << (avgDeserializationTime * 1e6) << " μs (standard deviation: " 
+             << (stddevDeserialization * 1e6) << " μs)" << Endl;
+        Cerr << "Serialization throughput: " << serializationThroughput << " MB/s" << Endl;
+        Cerr << "Deserialization throughput: " << deserializationThroughput << " MB/s" << Endl;
+        Cerr << "=============================================================" << Endl;
+    }
+    
+    void MeasureBinarySizes() {
+        std::vector<size_t> testSizes = {32, 128, 512, 1024, 4096, 32768, 65536};
+        
+        Cerr << "===== Binary Serialization Size Metrics =====" << Endl;
+        Cerr << "Payload Size\tTotal Size\tOverhead\tOverhead %" << Endl;
+        
+        for (size_t size : testSizes) {
+            TString testData = GenerateTestData(size);
+            auto blobId = TLogoBlobID(1, 1, 1, 1, size, 0);
+            auto vdiskId = TVDiskID(TGroupId::FromValue(1), 1, 1, 1, 1);
+            
+            auto binaryMsg = MakeHolder<TEvBlobStorage::TEvVPutBinary>(
+                blobId, testData, vdiskId
+            );
+            
+            TString binaryData;
+            TEvBlobStorage::TEvVPutBinary::Serialize(*binaryMsg, binaryData);
+            
+            size_t binarySize = binaryData.size();
+            size_t overhead = binarySize - size;
+            double overheadPercent = 100.0 * overhead / binarySize;
+            
+            Cerr << size << "\t" << binarySize << "\t" << overhead << "\t" << overheadPercent << "%" << Endl;
+        }
+        
+        Cerr << "=============================================================" << Endl;
+    }
+    
+    Y_UNIT_TEST(TEvVPutBinarySerializationPerformance) {
+        MeasureBinarySizes();
+        
+        // Тестируем производительность для нескольких размеров данных
+        std::vector<size_t> testSizes = {1024, 32768};
+        
+        for (size_t size : testSizes) {
+            MeasureBinarySerializationPerformance(size, DEFAULT_ITERATIONS);
+        }
+    }
+    
+} // Y_UNIT_TEST_SUITE(BinarySerializationPerformance) 

--- a/ydb/core/blobstorage/ut_blobstorage/binary_serialization_test.cpp
+++ b/ydb/core/blobstorage/ut_blobstorage/binary_serialization_test.cpp
@@ -1,0 +1,206 @@
+#include <ydb/core/blobstorage/ut_blobstorage/lib/env.h>
+#include <ydb/core/base/blobstorage.h>
+#include <ydb/core/blobstorage/vdisk/common/vdisk_events.h>
+#include <ydb/core/blobstorage/vdisk/common/vdisk_events_binary.h>
+
+#include <library/cpp/testing/unittest/registar.h>
+
+using namespace NKikimr;
+
+Y_UNIT_TEST_SUITE(BinarySerializationTest) {
+    
+    TString GenerateTestData(size_t size) {
+        TString data;
+        data.reserve(size);
+        for (size_t i = 0; i < size; ++i) {
+            data.append(1, static_cast<char>(i % 256));
+        }
+        return data;
+    }
+    
+    Y_UNIT_TEST(BasicBinarySerializationTest) {
+        TLogoBlobID blobId(123456, 1, 2, 3, 1024, 0);
+        TString testData = GenerateTestData(1024);
+        TVDiskID vdiskId(TGroupId::FromValue(42), 1, 2, 3, 4);
+        
+        auto original = MakeHolder<TEvBlobStorage::TEvVPut>(
+            blobId, 
+            TRope(testData), 
+            vdiskId, 
+            true, // ignoreBlock
+            nullptr, // cookie
+            TInstant::Now(), 
+            NKikimrBlobStorage::TabletLog
+        );
+        
+        // Convert to binary format
+        auto binary = MakeHolder<TEvBlobStorage::TEvVPutBinary>(*original);
+        
+        // Serialize and deserialize
+        TString serialized;
+        TEvBlobStorage::TEvVPutBinary::Serialize(*binary, serialized);
+        
+        auto deserialized = TEvBlobStorage::TEvVPutBinary::Deserialize(serialized);
+        UNIT_ASSERT(deserialized != nullptr);
+        
+        UNIT_ASSERT_VALUES_EQUAL(deserialized->BlobId.ToString(), blobId.ToString());
+        UNIT_ASSERT_VALUES_EQUAL(deserialized->VDiskId.ToString(), vdiskId.ToString());
+        UNIT_ASSERT_VALUES_EQUAL(deserialized->IgnoreBlock, true);
+        UNIT_ASSERT_VALUES_EQUAL(deserialized->Buffer.size(), 1024);
+        UNIT_ASSERT_VALUES_EQUAL(deserialized->Buffer, testData);
+        
+        delete deserialized;
+    }
+    
+    Y_UNIT_TEST(TEvVPutBinaryConversionTest) {
+        const size_t payloadSize = 1024;
+        TString testData = GenerateTestData(payloadSize);
+        
+        auto blobId = TLogoBlobID(1, 1, 1, 1, 0x3333, 0x0001A01B);
+        auto vdiskId = TVDiskID(TGroupId::FromValue(1), 1, 1, 1, 1);
+        
+        ui64 cookie = 0x1234567890ABCDEF;
+        auto original = MakeHolder<TEvBlobStorage::TEvVPut>(
+            blobId, TRope(testData), vdiskId, true, &cookie, TInstant::Now(), 
+            NKikimrBlobStorage::TabletLog
+        );
+        
+        original->Record.AddExtraBlockChecks()->SetTabletId(123);
+        original->Record.AddExtraBlockChecks()->SetTabletId(456);
+        
+        auto binary = MakeHolder<TEvBlobStorage::TEvVPutBinary>(*original);
+        
+        UNIT_ASSERT_VALUES_EQUAL(binary->BlobId, blobId);
+        UNIT_ASSERT_VALUES_EQUAL(binary->VDiskId, vdiskId);
+        UNIT_ASSERT_VALUES_EQUAL(binary->IgnoreBlock, true);
+        UNIT_ASSERT_VALUES_EQUAL(binary->HasCookie, true);
+        UNIT_ASSERT_VALUES_EQUAL(binary->Cookie, cookie);
+        UNIT_ASSERT_VALUES_EQUAL(binary->HandleClass, NKikimrBlobStorage::TabletLog);
+        UNIT_ASSERT_VALUES_EQUAL(binary->Buffer, testData);
+        UNIT_ASSERT_VALUES_EQUAL(binary->ExtraBlockChecks.size(), 2);
+        
+        auto converted = binary->ToOriginal();
+        
+        UNIT_ASSERT_VALUES_EQUAL(LogoBlobIDFromLogoBlobID(converted->Record.GetBlobID()), blobId);
+        UNIT_ASSERT_VALUES_EQUAL(VDiskIDFromVDiskID(converted->Record.GetVDiskID()), vdiskId);
+        UNIT_ASSERT_VALUES_EQUAL(converted->Record.GetIgnoreBlock(), true);
+        UNIT_ASSERT_VALUES_EQUAL(converted->Record.HasCookie(), true);
+        UNIT_ASSERT_VALUES_EQUAL(converted->Record.GetCookie(), cookie);
+        UNIT_ASSERT_VALUES_EQUAL(converted->Record.GetHandleClass(), NKikimrBlobStorage::TabletLog);
+        UNIT_ASSERT_VALUES_EQUAL(converted->Record.GetBuffer(), testData);
+        UNIT_ASSERT_VALUES_EQUAL(converted->Record.ExtraBlockChecksSize(), 2);
+        
+        delete converted;
+    }
+    
+    Y_UNIT_TEST(TEvVPutBinarySerializationRoundtrip) {
+        const size_t payloadSize = 1024;
+        TString testData = GenerateTestData(payloadSize);
+        
+        auto blobId = TLogoBlobID(1, 1, 1, 1, 0x3333, 0x0001A01B);
+        auto vdiskId = TVDiskID(TGroupId::FromValue(1), 1, 1, 1, 1);
+        
+        ui64 cookie = 0x1234567890ABCDEF;
+        auto original = MakeHolder<TEvBlobStorage::TEvVPut>(
+            blobId, TRope(testData), vdiskId, true, &cookie, TInstant::Now(), 
+            NKikimrBlobStorage::TabletLog
+        );
+        
+        original->Record.AddExtraBlockChecks()->SetTabletId(123);
+        original->Record.AddExtraBlockChecks()->SetTabletId(456);
+        
+        auto binary = MakeHolder<TEvBlobStorage::TEvVPutBinary>(*original);
+        
+        TString serialized;
+        TEvBlobStorage::TEvVPutBinary::Serialize(*binary, serialized);
+        
+        auto deserialized = TEvBlobStorage::TEvVPutBinary::Deserialize(serialized);
+        UNIT_ASSERT(deserialized != nullptr);
+        
+        UNIT_ASSERT_VALUES_EQUAL(deserialized->BlobId, blobId);
+        UNIT_ASSERT_VALUES_EQUAL(deserialized->VDiskId, vdiskId);
+        UNIT_ASSERT_VALUES_EQUAL(deserialized->IgnoreBlock, true);
+        UNIT_ASSERT_VALUES_EQUAL(deserialized->HasCookie, true);
+        UNIT_ASSERT_VALUES_EQUAL(deserialized->Cookie, cookie);
+        UNIT_ASSERT_VALUES_EQUAL(deserialized->HandleClass, NKikimrBlobStorage::TabletLog);
+        UNIT_ASSERT_VALUES_EQUAL(deserialized->Buffer, testData);
+        UNIT_ASSERT_VALUES_EQUAL(deserialized->ExtraBlockChecks.size(), 2);
+        
+        delete deserialized;
+    }
+    
+    Y_UNIT_TEST(TEvVPutBinaryDirectConstructionTest) {
+        TLogoBlobID blobId(987654, 10, 20, 30, 2048, 5);
+        TString testData = GenerateTestData(2048);
+        TVDiskID vdiskId(TGroupId::FromValue(123), 10, 20, 30, 40);
+        ui64 cookie = 0xDEADBEEF;
+        
+        auto binary = MakeHolder<TEvBlobStorage::TEvVPutBinary>(
+            blobId,
+            testData,
+            vdiskId,
+            true, // ignoreBlock
+            &cookie, //  cookie
+            TInstant::Seconds(1000), // deadline
+            NKikimrBlobStorage::AsyncRead // handleClass
+        );
+        
+        UNIT_ASSERT_VALUES_EQUAL(binary->BlobId, blobId);
+        UNIT_ASSERT_VALUES_EQUAL(binary->VDiskId, vdiskId);
+        UNIT_ASSERT_VALUES_EQUAL(binary->Buffer, testData);
+        UNIT_ASSERT_VALUES_EQUAL(binary->IgnoreBlock, true);
+        UNIT_ASSERT_VALUES_EQUAL(binary->HasCookie, true);
+        UNIT_ASSERT_VALUES_EQUAL(binary->Cookie, cookie);
+        UNIT_ASSERT_VALUES_EQUAL(binary->Deadline, TInstant::Seconds(1000));
+        UNIT_ASSERT_VALUES_EQUAL(binary->HandleClass, NKikimrBlobStorage::AsyncRead);
+        
+        TString serialized;
+        TEvBlobStorage::TEvVPutBinary::Serialize(*binary, serialized);
+        
+        auto deserialized = TEvBlobStorage::TEvVPutBinary::Deserialize(serialized);
+        UNIT_ASSERT(deserialized != nullptr);
+        
+        UNIT_ASSERT_VALUES_EQUAL(deserialized->BlobId, blobId);
+        UNIT_ASSERT_VALUES_EQUAL(deserialized->VDiskId, vdiskId);
+        UNIT_ASSERT_VALUES_EQUAL(deserialized->IgnoreBlock, true);
+        UNIT_ASSERT_VALUES_EQUAL(deserialized->HasCookie, true);
+        UNIT_ASSERT_VALUES_EQUAL(deserialized->Cookie, cookie);
+        UNIT_ASSERT_VALUES_EQUAL(deserialized->Buffer, testData);
+        UNIT_ASSERT_VALUES_EQUAL(deserialized->HandleClass, NKikimrBlobStorage::AsyncRead);
+        
+        delete deserialized;
+    }
+    
+    Y_UNIT_TEST(TEvVPutBinarySerializeToArcadiaStreamTest) {
+        TLogoBlobID blobId(123456, 1, 2, 3, 1024, 0);
+        TString testData = GenerateTestData(1024);
+        TVDiskID vdiskId(TGroupId::FromValue(42), 1, 2, 3, 4);
+        
+        auto original = MakeHolder<TEvBlobStorage::TEvVPut>(
+            blobId, TRope(testData), vdiskId, true, nullptr, TInstant::Now(), 
+            NKikimrBlobStorage::TabletLog
+        );
+        
+        auto binary = MakeHolder<TEvBlobStorage::TEvVPutBinary>(*original);
+        
+        NActors::TAllocChunkSerializer serializer;
+        bool result = binary->SerializeToArcadiaStream(&serializer);
+        UNIT_ASSERT(result);
+        
+        auto serializedData = serializer.Release(TEventSerializationInfo{});
+        UNIT_ASSERT(serializedData);
+        UNIT_ASSERT(serializedData->GetSize() > 0);
+        
+        IEventBase* rawEvent = TEvBlobStorage::TEvVPutBinary::Load(serializedData.Get());
+        UNIT_ASSERT(rawEvent);
+        
+        auto deserializedBinary = dynamic_cast<TEvBlobStorage::TEvVPutBinary*>(rawEvent);
+        UNIT_ASSERT(deserializedBinary);
+        
+        UNIT_ASSERT_VALUES_EQUAL(deserializedBinary->BlobId, blobId);
+        UNIT_ASSERT_VALUES_EQUAL(deserializedBinary->Buffer, testData);
+        
+        delete rawEvent;
+    }
+    
+} // Y_UNIT_TEST_SUITE(BinarySerializationTest) 

--- a/ydb/core/blobstorage/ut_blobstorage/serialization_perf.cpp
+++ b/ydb/core/blobstorage/ut_blobstorage/serialization_perf.cpp
@@ -1,0 +1,89 @@
+#include <ydb/core/blobstorage/ut_blobstorage/lib/env.h>
+#include <ydb/core/base/blobstorage.h>
+#include <library/cpp/testing/unittest/registar.h>
+#include <util/system/hp_timer.h>
+#include <util/generic/vector.h>
+#include <util/stream/str.h>
+#include <ydb/core/protos/blobstorage.pb.h>
+#include <ydb/core/protos/base.pb.h>
+
+Y_UNIT_TEST_SUITE(SerializationPerformance) {
+    
+    TString GenerateTestData(size_t size) {
+        TString data;
+        data.reserve(size);
+        for (size_t i = 0; i < size; ++i) {
+            data.append(1, static_cast<char>(i % 256));
+        }
+        return data;
+    }
+
+    // Функция для измерения производительности сериализации/десериализации
+    void MeasureSerializationPerformance(size_t payloadSize, size_t iterations) {
+        TString testData = GenerateTestData(payloadSize);
+        
+        TString serializedData;
+        serializedData.reserve(payloadSize + 1024); 
+        
+        TInstant startTime;
+        double totalSerializationTime = 0;
+        double totalDeserializationTime = 0;
+        ui64 totalBytes = 0;
+        
+        for (size_t i = 0; i < iterations; ++i) {
+            NKikimrBlobStorage::TEvVPut msg;
+            
+            auto blobId = TLogoBlobID(1, 
+                                    1, 
+                                    1, 
+                                    1, 
+                                    0x3333, 
+                                    0x0001A01B); 
+            LogoBlobIDFromLogoBlobID(blobId, msg.mutable_blobid());
+            
+            msg.set_buffer(testData);
+            
+            auto vdiskId = TVDiskID(TGroupId::FromValue(1), 
+                                  1, 
+                                  1, 
+                                  1, 
+                                  1); 
+            VDiskIDFromVDiskID(vdiskId, msg.mutable_vdiskid());
+            
+            msg.set_handleclass(NKikimrBlobStorage::TabletLog);
+            
+            startTime = TInstant::Now();
+            bool serializeResult = msg.SerializeToString(&serializedData);
+            totalSerializationTime += (TInstant::Now() - startTime).SecondsFloat();
+            UNIT_ASSERT(serializeResult);
+            
+            startTime = TInstant::Now();
+            NKikimrBlobStorage::TEvVPut deserializedMsg;
+            bool parseResult = deserializedMsg.ParseFromString(serializedData);
+            totalDeserializationTime += (TInstant::Now() - startTime).SecondsFloat();
+            UNIT_ASSERT(parseResult);
+            
+            totalBytes += serializedData.size();
+        }
+        
+        double avgSerializationTime = totalSerializationTime / iterations;
+        double avgDeserializationTime = totalDeserializationTime / iterations;
+        double totalTime = totalSerializationTime + totalDeserializationTime;
+        double throughput = (totalBytes * 2) / totalTime; 
+        
+        Cerr << "=== Performance Results for " << payloadSize << " bytes payload ===" << Endl;
+        Cerr << "Average serialization time: " << (avgSerializationTime * 1e6) << " microseconds" << Endl;
+        Cerr << "Average deserialization time: " << (avgDeserializationTime * 1e6) << " microseconds" << Endl;
+        Cerr << "Total throughput: " << (throughput / (1024*1024)) << " MB/s" << Endl;
+        Cerr << "Average message size: " << (totalBytes / iterations) << " bytes" << Endl;
+        Cerr << "=================================================" << Endl;
+    }
+
+    Y_UNIT_TEST(TEvVPutSerializationPerformance) {
+        const size_t iterations = 100000; 
+        
+        MeasureSerializationPerformance(32, iterations);
+        MeasureSerializationPerformance(128, iterations);
+        MeasureSerializationPerformance(4096, iterations);
+    }
+} 

--- a/ydb/core/blobstorage/ut_blobstorage/serialization_perf.cpp
+++ b/ydb/core/blobstorage/ut_blobstorage/serialization_perf.cpp
@@ -18,64 +18,91 @@ Y_UNIT_TEST_SUITE(SerializationPerformance) {
         return data;
     }
 
-    // Функция для измерения производительности сериализации/десериализации
     void MeasureSerializationPerformance(size_t payloadSize, size_t iterations) {
         TString testData = GenerateTestData(payloadSize);
         
-        TString serializedData;
-        serializedData.reserve(payloadSize + 1024); 
+        // cache warming
+        for (size_t i = 0; i < 1000; ++i) {
+            NKikimrBlobStorage::TEvVPut msg;
+            auto blobId = TLogoBlobID(1, 1, 1, 1, 0x3333, 0x0001A01B);
+            LogoBlobIDFromLogoBlobID(blobId, msg.mutable_blobid());
+            msg.set_buffer(testData);
+            auto vdiskId = TVDiskID(TGroupId::FromValue(1), 1, 1, 1, 1);
+            VDiskIDFromVDiskID(vdiskId, msg.mutable_vdiskid());
+            msg.set_handleclass(NKikimrBlobStorage::TabletLog);
+            
+            TString warmupData;
+            auto ser = msg.SerializeToString(&warmupData);
+            NKikimrBlobStorage::TEvVPut warmupMsg;
+            auto der = warmupMsg.ParseFromString(warmupData);
+            if (!ser || !der)  {
+                --i;
+            }
+        }
         
-        TInstant startTime;
-        double totalSerializationTime = 0;
-        double totalDeserializationTime = 0;
-        ui64 totalBytes = 0;
+        // store in array for adding metrics
+        TVector<double> serializationTimes;
+        TVector<double> deserializationTimes;
+        TVector<size_t> messageSizes;
+        serializationTimes.reserve(iterations);
+        deserializationTimes.reserve(iterations);
+        messageSizes.reserve(iterations);
         
         for (size_t i = 0; i < iterations; ++i) {
             NKikimrBlobStorage::TEvVPut msg;
             
-            auto blobId = TLogoBlobID(1, 
-                                    1, 
-                                    1, 
-                                    1, 
-                                    0x3333, 
-                                    0x0001A01B); 
+            auto blobId = TLogoBlobID(1, 1, 1, 1, 0x3333, 0x0001A01B);
             LogoBlobIDFromLogoBlobID(blobId, msg.mutable_blobid());
-            
             msg.set_buffer(testData);
-            
-            auto vdiskId = TVDiskID(TGroupId::FromValue(1), 
-                                  1, 
-                                  1, 
-                                  1, 
-                                  1); 
+            auto vdiskId = TVDiskID(TGroupId::FromValue(1), 1, 1, 1, 1);
             VDiskIDFromVDiskID(vdiskId, msg.mutable_vdiskid());
-            
             msg.set_handleclass(NKikimrBlobStorage::TabletLog);
             
-            startTime = TInstant::Now();
+            TString serializedData;
+            
+            auto startTime = TInstant::Now();
             bool serializeResult = msg.SerializeToString(&serializedData);
-            totalSerializationTime += (TInstant::Now() - startTime).SecondsFloat();
+            auto serializationTime = (TInstant::Now() - startTime).SecondsFloat();
             UNIT_ASSERT(serializeResult);
             
             startTime = TInstant::Now();
             NKikimrBlobStorage::TEvVPut deserializedMsg;
             bool parseResult = deserializedMsg.ParseFromString(serializedData);
-            totalDeserializationTime += (TInstant::Now() - startTime).SecondsFloat();
+            auto deserializationTime = (TInstant::Now() - startTime).SecondsFloat();
             UNIT_ASSERT(parseResult);
             
-            totalBytes += serializedData.size();
+            // correctness check
+            UNIT_ASSERT_VALUES_EQUAL(msg.buffer(), deserializedMsg.buffer());
+            UNIT_ASSERT_VALUES_EQUAL(msg.handleclass(), deserializedMsg.handleclass());
+            
+            serializationTimes.push_back(serializationTime);
+            deserializationTimes.push_back(deserializationTime);
+            messageSizes.push_back(serializedData.size());
         }
         
-        double avgSerializationTime = totalSerializationTime / iterations;
-        double avgDeserializationTime = totalDeserializationTime / iterations;
-        double totalTime = totalSerializationTime + totalDeserializationTime;
-        double throughput = (totalBytes * 2) / totalTime; 
+        double avgSerializationTime = 0;
+        double avgDeserializationTime = 0;
+        double avgMessageSize = 0;
+        
+        for (size_t i = 0; i < iterations; ++i) {
+            avgSerializationTime += serializationTimes[i];
+            avgDeserializationTime += deserializationTimes[i];
+            avgMessageSize += messageSizes[i];
+        }
+        
+        avgSerializationTime /= iterations;
+        avgDeserializationTime /= iterations;
+        avgMessageSize /= iterations;
+        
+        double serializationThroughput = avgMessageSize / avgSerializationTime;
+        double deserializationThroughput = avgMessageSize / avgDeserializationTime;
         
         Cerr << "=== Performance Results for " << payloadSize << " bytes payload ===" << Endl;
         Cerr << "Average serialization time: " << (avgSerializationTime * 1e6) << " microseconds" << Endl;
         Cerr << "Average deserialization time: " << (avgDeserializationTime * 1e6) << " microseconds" << Endl;
-        Cerr << "Total throughput: " << (throughput / (1024*1024)) << " MB/s" << Endl;
-        Cerr << "Average message size: " << (totalBytes / iterations) << " bytes" << Endl;
+        Cerr << "Serialization throughput: " << (serializationThroughput / (1024*1024)) << " MB/s" << Endl;
+        Cerr << "Deserialization throughput: " << (deserializationThroughput / (1024*1024)) << " MB/s" << Endl;
+        Cerr << "Average message size: " << avgMessageSize << " bytes" << Endl;
         Cerr << "=================================================" << Endl;
     }
 

--- a/ydb/core/blobstorage/ut_blobstorage/serialization_perf.cpp
+++ b/ydb/core/blobstorage/ut_blobstorage/serialization_perf.cpp
@@ -21,144 +21,182 @@ Y_UNIT_TEST_SUITE(SerializationPerformance) {
         return data;
     }
     
-    // Testing serialization performance of the actual TEvBlobStorage::TEvVPut actor
-    void MeasureActorSerializationPerformance(size_t payloadSize, size_t iterations) {
-        TString testData = GenerateTestData(payloadSize);
+    // // Testing serialization performance of the actual TEvBlobStorage::TEvVPut actor
+    // void MeasureActorSerializationPerformance(size_t payloadSize, size_t iterations) {
+    //     TString testData = GenerateTestData(payloadSize);
         
-        auto blobId = TLogoBlobID(1, 1, 1, 1, 0x3333, 0x0001A01B);
-        auto vdiskId = TVDiskID(TGroupId::FromValue(1), 1, 1, 1, 1);
+    //     auto blobId = TLogoBlobID(1, 1, 1, 1, 0x3333, 0x0001A01B);
+    //     auto vdiskId = TVDiskID(TGroupId::FromValue(1), 1, 1, 1, 1);
         
-        TVector<double> serializationTimes;
-        TVector<double> deserializationTimes;
-        TVector<size_t> messageSizes;
-        serializationTimes.reserve(iterations);
-        deserializationTimes.reserve(iterations);
-        messageSizes.reserve(iterations);
+    //     TVector<double> serializationTimes;
+    //     TVector<double> deserializationTimes;
+    //     TVector<size_t> messageSizes;
+    //     serializationTimes.reserve(iterations);
+    //     deserializationTimes.reserve(iterations);
+    //     messageSizes.reserve(iterations);
         
-        // Cache warm-up
-        Cerr << "Warming up cache..." << Endl;
-        for (size_t i = 0; i < 1000; ++i) {
-            auto msg = MakeHolder<TEvBlobStorage::TEvVPut>(
-                blobId, TRope(testData), vdiskId, false, nullptr, TInstant::Max(), 
-                NKikimrBlobStorage::TabletLog);
+    //     // Cache warm-up
+    //     Cerr << "Warming up cache..." << Endl;
+        
+    //     // Сначала попробуем один раз, чтобы вывести подробную информацию
+    //     Cerr << "Testing with a single event to diagnose issues..." << Endl;
+        
+    //     auto msg = MakeHolder<TEvBlobStorage::TEvVPut>(
+    //         blobId, TRope(testData), vdiskId, false, nullptr, TInstant::Max(), 
+    //         NKikimrBlobStorage::TabletLog);
+        
+    //     // Выведем информацию о созданном сообщении
+    //     Cerr << "Created message: " << msg->ToString() << Endl;
+    //     Cerr << "Event type: " << TEvBlobStorage::EvVPut << Endl;
+        
+    //     NActors::TAllocChunkSerializer serializer;
+    //     if (!msg->SerializeToArcadiaStream(&serializer)) {
+    //         Cerr << "Serialization error during initial test" << Endl;
+    //         return;
+    //     }
+        
+    //     auto serializedData = serializer.Release(TEventSerializationInfo{});
+    //     Cerr << "Serialized data size: " << serializedData->GetSize() << Endl;
+        
+    //     try {
+    //         // Попробуем десериализовать и выведем детали при ошибке
+    //         IEventBase* rawEvent = TEvBlobStorage::TEvVPut::Load(serializedData.Get());
+    //         if (!rawEvent) {
+    //             Cerr << "Deserialization returned nullptr" << Endl;
+    //             return;
+    //         }
+    //         delete rawEvent;
+    //         Cerr << "Initial test passed successfully" << Endl;
+    //     } catch (const std::exception& e) {
+    //         Cerr << "Exception during deserialization: " << e.what() << Endl;
+    //         return;
+    //     } catch (...) {
+    //         Cerr << "Unknown exception during deserialization" << Endl;
+    //         return;
+    //     }
+        
+    //     for (size_t i = 0; i < 1000; ++i) {
+    //         auto msg = MakeHolder<TEvBlobStorage::TEvVPut>(
+    //             blobId, TRope(testData), vdiskId, false, nullptr, TInstant::Max(), 
+    //             NKikimrBlobStorage::TabletLog);
             
-            NActors::TAllocChunkSerializer serializer;
-            if (!msg->SerializeToArcadiaStream(&serializer)) {
-                Cerr << "Serialization error during warm-up" << Endl;
-                return;
-            }
+    //         NActors::TAllocChunkSerializer serializer;
+    //         if (!msg->SerializeToArcadiaStream(&serializer)) {
+    //             Cerr << "Serialization error during warm-up" << Endl;
+    //             return;
+    //         }
             
-            auto serializedData = serializer.Release(TEventSerializationInfo{});
+    //         auto serializedData = serializer.Release(TEventSerializationInfo{});
             
-            IEventBase* rawEvent = TEvBlobStorage::TEvVPut::Load(serializedData.Get());
-            if (!rawEvent) {
-                Cerr << "Deserialization error during warm-up" << Endl;
-                return;
-            }
-            delete rawEvent;
-        }
+    //         IEventBase* rawEvent = TEvBlobStorage::TEvVPut::Load(serializedData.Get());
+    //         if (!rawEvent) {
+    //             Cerr << "Deserialization error during warm-up" << Endl;
+    //             return;
+    //         }
+    //         delete rawEvent;
+    //     }
         
-        Cerr << "Starting measurements for " << payloadSize << " bytes payload..." << Endl;
+    //     Cerr << "Starting measurements for " << payloadSize << " bytes payload..." << Endl;
         
-        for (size_t i = 0; i < iterations; ++i) {
-            auto msg = MakeHolder<TEvBlobStorage::TEvVPut>(
-                blobId, TRope(testData), vdiskId, false, nullptr, TInstant::Max(), 
-                NKikimrBlobStorage::TabletLog);
+    //     for (size_t i = 0; i < iterations; ++i) {
+    //         auto msg = MakeHolder<TEvBlobStorage::TEvVPut>(
+    //             blobId, TRope(testData), vdiskId, false, nullptr, TInstant::Max(), 
+    //             NKikimrBlobStorage::TabletLog);
             
-            NActors::TAllocChunkSerializer serializer;
-            auto startTime = TInstant::Now();
-            bool serializeResult = msg->SerializeToArcadiaStream(&serializer);
-            auto endTime = TInstant::Now();
-            double serializationTime = (endTime - startTime).SecondsFloat();
+    //         NActors::TAllocChunkSerializer serializer;
+    //         auto startTime = TInstant::Now();
+    //         bool serializeResult = msg->SerializeToArcadiaStream(&serializer);
+    //         auto endTime = TInstant::Now();
+    //         double serializationTime = (endTime - startTime).SecondsFloat();
             
-            if (!serializeResult) {
-                Cerr << "Serialization error in iteration " << i << Endl;
-                continue;
-            }
+    //         if (!serializeResult) {
+    //             Cerr << "Serialization error in iteration " << i << Endl;
+    //             continue;
+    //         }
             
-            auto serializedData = serializer.Release(TEventSerializationInfo{});
-            size_t messageSize = serializedData->GetSize();
-            messageSizes.push_back(messageSize);
+    //         auto serializedData = serializer.Release(TEventSerializationInfo{});
+    //         size_t messageSize = serializedData->GetSize();
+    //         messageSizes.push_back(messageSize);
             
-            startTime = TInstant::Now();
-            IEventBase* rawEvent = TEvBlobStorage::TEvVPut::Load(serializedData.Get());
-            endTime = TInstant::Now();
-            double deserializationTime = (endTime - startTime).SecondsFloat();
+    //         startTime = TInstant::Now();
+    //         IEventBase* rawEvent = TEvBlobStorage::TEvVPut::Load(serializedData.Get());
+    //         endTime = TInstant::Now();
+    //         double deserializationTime = (endTime - startTime).SecondsFloat();
             
-            if (!rawEvent) {
-                Cerr << "Deserialization error in iteration " << i << Endl;
-                continue;
-            }
+    //         if (!rawEvent) {
+    //             Cerr << "Deserialization error in iteration " << i << Endl;
+    //             continue;
+    //         }
             
-            auto deserializedMsg = dynamic_cast<TEvBlobStorage::TEvVPut*>(rawEvent);
-            if (!deserializedMsg) {
-                Cerr << "Invalid type after deserialization in iteration " << i << Endl;
-                delete rawEvent;
-                continue;
-            }
+    //         auto deserializedMsg = dynamic_cast<TEvBlobStorage::TEvVPut*>(rawEvent);
+    //         if (!deserializedMsg) {
+    //             Cerr << "Invalid type after deserialization in iteration " << i << Endl;
+    //             delete rawEvent;
+    //             continue;
+    //         }
             
-            bool dataValid = true;
-            dataValid &= (LogoBlobIDFromLogoBlobID(deserializedMsg->Record.GetBlobID()) == blobId);
-            dataValid &= (deserializedMsg->Record.GetHandleClass() == NKikimrBlobStorage::TabletLog);
-            dataValid &= (deserializedMsg->GetBuffer() == testData);
+    //         bool dataValid = true;
+    //         dataValid &= (LogoBlobIDFromLogoBlobID(deserializedMsg->Record.GetBlobID()) == blobId);
+    //         dataValid &= (deserializedMsg->Record.GetHandleClass() == NKikimrBlobStorage::TabletLog);
+    //         dataValid &= (deserializedMsg->GetBuffer() == testData);
             
-            if (!dataValid) {
-                Cerr << "Data after deserialization is invalid in iteration " << i << Endl;
-            }
+    //         if (!dataValid) {
+    //             Cerr << "Data after deserialization is invalid in iteration " << i << Endl;
+    //         }
             
-            serializationTimes.push_back(serializationTime);
-            deserializationTimes.push_back(deserializationTime);
+    //         serializationTimes.push_back(serializationTime);
+    //         deserializationTimes.push_back(deserializationTime);
             
-            delete rawEvent;
-        }
+    //         delete rawEvent;
+    //     }
         
-        double avgSerializationTime = 0;
-        double avgDeserializationTime = 0;
-        double avgMessageSize = 0;
+    //     double avgSerializationTime = 0;
+    //     double avgDeserializationTime = 0;
+    //     double avgMessageSize = 0;
         
-        for (size_t i = 0; i < messageSizes.size(); ++i) {
-            avgSerializationTime += serializationTimes[i];
-            avgDeserializationTime += deserializationTimes[i];
-            avgMessageSize += messageSizes[i];
-        }
+    //     for (size_t i = 0; i < messageSizes.size(); ++i) {
+    //         avgSerializationTime += serializationTimes[i];
+    //         avgDeserializationTime += deserializationTimes[i];
+    //         avgMessageSize += messageSizes[i];
+    //     }
         
-        avgSerializationTime /= serializationTimes.size();
-        avgDeserializationTime /= deserializationTimes.size();
-        avgMessageSize /= messageSizes.size();
+    //     avgSerializationTime /= serializationTimes.size();
+    //     avgDeserializationTime /= deserializationTimes.size();
+    //     avgMessageSize /= messageSizes.size();
         
-        double serializationThroughput = (avgMessageSize / 1024.0 / 1024.0) / avgSerializationTime;
-        double deserializationThroughput = (avgMessageSize / 1024.0 / 1024.0) / avgDeserializationTime;
+    //     double serializationThroughput = (avgMessageSize / 1024.0 / 1024.0) / avgSerializationTime;
+    //     double deserializationThroughput = (avgMessageSize / 1024.0 / 1024.0) / avgDeserializationTime;
         
-        double stddevSerialization = 0;
-        double stddevDeserialization = 0;
+    //     double stddevSerialization = 0;
+    //     double stddevDeserialization = 0;
         
-        for (size_t i = 0; i < serializationTimes.size(); ++i) {
-            stddevSerialization += 
-                (serializationTimes[i] - avgSerializationTime) * 
-                (serializationTimes[i] - avgSerializationTime);
-        }
+    //     for (size_t i = 0; i < serializationTimes.size(); ++i) {
+    //         stddevSerialization += 
+    //             (serializationTimes[i] - avgSerializationTime) * 
+    //             (serializationTimes[i] - avgSerializationTime);
+    //     }
         
-        for (size_t i = 0; i < deserializationTimes.size(); ++i) {
-            stddevDeserialization += 
-                (deserializationTimes[i] - avgDeserializationTime) * 
-                (deserializationTimes[i] - avgDeserializationTime);
-        }
+    //     for (size_t i = 0; i < deserializationTimes.size(); ++i) {
+    //         stddevDeserialization += 
+    //             (deserializationTimes[i] - avgDeserializationTime) * 
+    //             (deserializationTimes[i] - avgDeserializationTime);
+    //     }
         
-        stddevSerialization = std::sqrt(stddevSerialization / serializationTimes.size());
-        stddevDeserialization = std::sqrt(stddevDeserialization / deserializationTimes.size());
+    //     stddevSerialization = std::sqrt(stddevSerialization / serializationTimes.size());
+    //     stddevDeserialization = std::sqrt(stddevDeserialization / deserializationTimes.size());
         
-        Cerr << "===== TEvVPut Actor Serialization Performance Results =====" << Endl;
-        Cerr << "Data size: " << payloadSize << " bytes" << Endl;
-        Cerr << "Number of iterations: " << iterations << Endl;
-        Cerr << "Average message size: " << avgMessageSize << " bytes" << Endl;
-        Cerr << "Serialization time: " << (avgSerializationTime * 1e6) << " μs (standard deviation: " 
-             << (stddevSerialization * 1e6) << " μs)" << Endl;
-        Cerr << "Deserialization time: " << (avgDeserializationTime * 1e6) << " μs (standard deviation: " 
-             << (stddevDeserialization * 1e6) << " μs)" << Endl;
-        Cerr << "Serialization throughput: " << serializationThroughput << " MB/s" << Endl;
-        Cerr << "Deserialization throughput: " << deserializationThroughput << " MB/s" << Endl;
-        Cerr << "=============================================================" << Endl;
-    }
+    //     Cerr << "===== TEvVPut Actor Serialization Performance Results =====" << Endl;
+    //     Cerr << "Data size: " << payloadSize << " bytes" << Endl;
+    //     Cerr << "Number of iterations: " << iterations << Endl;
+    //     Cerr << "Average message size: " << avgMessageSize << " bytes" << Endl;
+    //     Cerr << "Serialization time: " << (avgSerializationTime * 1e6) << " μs (standard deviation: " 
+    //          << (stddevSerialization * 1e6) << " μs)" << Endl;
+    //     Cerr << "Deserialization time: " << (avgDeserializationTime * 1e6) << " μs (standard deviation: " 
+    //          << (stddevDeserialization * 1e6) << " μs)" << Endl;
+    //     Cerr << "Serialization throughput: " << serializationThroughput << " MB/s" << Endl;
+    //     Cerr << "Deserialization throughput: " << deserializationThroughput << " MB/s" << Endl;
+    //     Cerr << "=============================================================" << Endl;
+    // }
 
     // Testing pure protobuf serialization performance
     void MeasureProtobufSerializationPerformance(size_t payloadSize, size_t iterations) {
@@ -290,10 +328,10 @@ Y_UNIT_TEST_SUITE(SerializationPerformance) {
     }
 
     Y_UNIT_TEST(TEvVPutSerializationPerformance) {
-        Cerr << "\n\n=== TESTING TEvVPut ACTOR SERIALIZATION ===" << Endl;
-        MeasureActorSerializationPerformance(32, DEFAULT_ITERATIONS); 
-        MeasureActorSerializationPerformance(128, DEFAULT_ITERATIONS);   
-        MeasureActorSerializationPerformance(4096, DEFAULT_ITERATIONS);
+        // Cerr << "\n\n=== TESTING TEvVPut ACTOR SERIALIZATION ===" << Endl;
+        // MeasureActorSerializationPerformance(32, DEFAULT_ITERATIONS); 
+        // MeasureActorSerializationPerformance(128, DEFAULT_ITERATIONS);   
+        // MeasureActorSerializationPerformance(4096, DEFAULT_ITERATIONS);
         
         Cerr << "\n\n=== TESTING PURE PROTOBUF SERIALIZATION ===" << Endl;
         MeasureProtobufSerializationPerformance(32, DEFAULT_ITERATIONS);

--- a/ydb/core/blobstorage/ut_blobstorage/serialization_perf.cpp
+++ b/ydb/core/blobstorage/ut_blobstorage/serialization_perf.cpp
@@ -291,13 +291,13 @@ Y_UNIT_TEST_SUITE(SerializationPerformance) {
 
     Y_UNIT_TEST(TEvVPutSerializationPerformance) {
         Cerr << "\n\n=== TESTING TEvVPut ACTOR SERIALIZATION ===" << Endl;
-        MeasureActorSerializationPerformance(32, DEFAULT_ITERATIONS);      // Small size
-        MeasureActorSerializationPerformance(128, DEFAULT_ITERATIONS);     // Medium size
-        MeasureActorSerializationPerformance(4096, DEFAULT_ITERATIONS);    // Large size
+        MeasureActorSerializationPerformance(32, DEFAULT_ITERATIONS); 
+        MeasureActorSerializationPerformance(128, DEFAULT_ITERATIONS);   
+        MeasureActorSerializationPerformance(4096, DEFAULT_ITERATIONS);
         
         Cerr << "\n\n=== TESTING PURE PROTOBUF SERIALIZATION ===" << Endl;
-        MeasureProtobufSerializationPerformance(32, DEFAULT_ITERATIONS);      // Small size
-        MeasureProtobufSerializationPerformance(128, DEFAULT_ITERATIONS);     // Medium size
-        MeasureProtobufSerializationPerformance(4096, DEFAULT_ITERATIONS);    // Large size
+        MeasureProtobufSerializationPerformance(32, DEFAULT_ITERATIONS);
+        MeasureProtobufSerializationPerformance(128, DEFAULT_ITERATIONS);
+        MeasureProtobufSerializationPerformance(4096, DEFAULT_ITERATIONS);
     }
-} 
+}

--- a/ydb/core/blobstorage/ut_blobstorage/serialization_perf.cpp
+++ b/ydb/core/blobstorage/ut_blobstorage/serialization_perf.cpp
@@ -12,7 +12,6 @@ Y_UNIT_TEST_SUITE(SerializationPerformance) {
     
     const size_t DEFAULT_ITERATIONS = 10000;
     
-    // Function to generate test data
     TString GenerateTestData(size_t size) {
         TString data;
         data.reserve(size);
@@ -26,11 +25,9 @@ Y_UNIT_TEST_SUITE(SerializationPerformance) {
     void MeasureActorSerializationPerformance(size_t payloadSize, size_t iterations) {
         TString testData = GenerateTestData(payloadSize);
         
-        // Parameters for message creation
         auto blobId = TLogoBlobID(1, 1, 1, 1, 0x3333, 0x0001A01B);
         auto vdiskId = TVDiskID(TGroupId::FromValue(1), 1, 1, 1, 1);
         
-        // Arrays for storing results
         TVector<double> serializationTimes;
         TVector<double> deserializationTimes;
         TVector<size_t> messageSizes;
@@ -41,23 +38,18 @@ Y_UNIT_TEST_SUITE(SerializationPerformance) {
         // Cache warm-up
         Cerr << "Warming up cache..." << Endl;
         for (size_t i = 0; i < 1000; ++i) {
-            // Create a TEvBlobStorage::TEvVPut instance
-            // It contains an internal protobuf message Record of type NKikimrBlobStorage::TEvVPut
             auto msg = MakeHolder<TEvBlobStorage::TEvVPut>(
                 blobId, TRope(testData), vdiskId, false, nullptr, TInstant::Max(), 
                 NKikimrBlobStorage::TabletLog);
             
-            // Serialize using the standard actor system mechanism
             NActors::TAllocChunkSerializer serializer;
             if (!msg->SerializeToArcadiaStream(&serializer)) {
                 Cerr << "Serialization error during warm-up" << Endl;
                 return;
             }
             
-            // Get serialized data
             auto serializedData = serializer.Release(TEventSerializationInfo{});
             
-            // Deserialize back to TEvBlobStorage::TEvVPut
             IEventBase* rawEvent = TEvBlobStorage::TEvVPut::Load(serializedData.Get());
             if (!rawEvent) {
                 Cerr << "Deserialization error during warm-up" << Endl;
@@ -66,16 +58,13 @@ Y_UNIT_TEST_SUITE(SerializationPerformance) {
             delete rawEvent;
         }
         
-        // Main measurements
         Cerr << "Starting measurements for " << payloadSize << " bytes payload..." << Endl;
         
         for (size_t i = 0; i < iterations; ++i) {
-            // Create a TEvBlobStorage::TEvVPut instance for each iteration
             auto msg = MakeHolder<TEvBlobStorage::TEvVPut>(
                 blobId, TRope(testData), vdiskId, false, nullptr, TInstant::Max(), 
                 NKikimrBlobStorage::TabletLog);
             
-            // Measure serialization time
             NActors::TAllocChunkSerializer serializer;
             auto startTime = TInstant::Now();
             bool serializeResult = msg->SerializeToArcadiaStream(&serializer);
@@ -87,12 +76,10 @@ Y_UNIT_TEST_SUITE(SerializationPerformance) {
                 continue;
             }
             
-            // Get serialized data for subsequent deserialization and statistics
             auto serializedData = serializer.Release(TEventSerializationInfo{});
             size_t messageSize = serializedData->GetSize();
             messageSizes.push_back(messageSize);
             
-            // Measure deserialization time
             startTime = TInstant::Now();
             IEventBase* rawEvent = TEvBlobStorage::TEvVPut::Load(serializedData.Get());
             endTime = TInstant::Now();
@@ -103,7 +90,6 @@ Y_UNIT_TEST_SUITE(SerializationPerformance) {
                 continue;
             }
             
-            // Check type and data correctness
             auto deserializedMsg = dynamic_cast<TEvBlobStorage::TEvVPut*>(rawEvent);
             if (!deserializedMsg) {
                 Cerr << "Invalid type after deserialization in iteration " << i << Endl;
@@ -111,7 +97,6 @@ Y_UNIT_TEST_SUITE(SerializationPerformance) {
                 continue;
             }
             
-            // Validate data correctness in the protobuf Record message
             bool dataValid = true;
             dataValid &= (LogoBlobIDFromLogoBlobID(deserializedMsg->Record.GetBlobID()) == blobId);
             dataValid &= (deserializedMsg->Record.GetHandleClass() == NKikimrBlobStorage::TabletLog);
@@ -121,16 +106,12 @@ Y_UNIT_TEST_SUITE(SerializationPerformance) {
                 Cerr << "Data after deserialization is invalid in iteration " << i << Endl;
             }
             
-            // Save results
             serializationTimes.push_back(serializationTime);
             deserializationTimes.push_back(deserializationTime);
             
-            // Free memory
             delete rawEvent;
         }
         
-        // Calculate statistics
-        // 1. Average time
         double avgSerializationTime = 0;
         double avgDeserializationTime = 0;
         double avgMessageSize = 0;
@@ -145,11 +126,9 @@ Y_UNIT_TEST_SUITE(SerializationPerformance) {
         avgDeserializationTime /= deserializationTimes.size();
         avgMessageSize /= messageSizes.size();
         
-        // 2. Throughput (MB/s)
         double serializationThroughput = (avgMessageSize / 1024.0 / 1024.0) / avgSerializationTime;
         double deserializationThroughput = (avgMessageSize / 1024.0 / 1024.0) / avgDeserializationTime;
         
-        // 3. Standard deviation
         double stddevSerialization = 0;
         double stddevDeserialization = 0;
         
@@ -168,7 +147,6 @@ Y_UNIT_TEST_SUITE(SerializationPerformance) {
         stddevSerialization = std::sqrt(stddevSerialization / serializationTimes.size());
         stddevDeserialization = std::sqrt(stddevDeserialization / deserializationTimes.size());
         
-        // Output results
         Cerr << "===== TEvVPut Actor Serialization Performance Results =====" << Endl;
         Cerr << "Data size: " << payloadSize << " bytes" << Endl;
         Cerr << "Number of iterations: " << iterations << Endl;
@@ -182,15 +160,13 @@ Y_UNIT_TEST_SUITE(SerializationPerformance) {
         Cerr << "=============================================================" << Endl;
     }
 
-    // For comparison - testing pure protobuf serialization performance
+    // Testing pure protobuf serialization performance
     void MeasureProtobufSerializationPerformance(size_t payloadSize, size_t iterations) {
         TString testData = GenerateTestData(payloadSize);
         
-        // Parameters for message creation
         auto blobId = TLogoBlobID(1, 1, 1, 1, 0x3333, 0x0001A01B);
         auto vdiskId = TVDiskID(TGroupId::FromValue(1), 1, 1, 1, 1);
         
-        // Arrays for storing results
         TVector<double> serializationTimes;
         TVector<double> deserializationTimes;
         TVector<size_t> messageSizes;
@@ -198,17 +174,14 @@ Y_UNIT_TEST_SUITE(SerializationPerformance) {
         deserializationTimes.reserve(iterations);
         messageSizes.reserve(iterations);
         
-        // Cache warm-up
         Cerr << "Warming up cache for protobuf..." << Endl;
         for (size_t i = 0; i < 1000; ++i) {
-            // Create protobuf message directly
             NKikimrBlobStorage::TEvVPut msg;
             LogoBlobIDFromLogoBlobID(blobId, msg.mutable_blobid());
             msg.set_buffer(testData);
             VDiskIDFromVDiskID(vdiskId, msg.mutable_vdiskid());
             msg.set_handleclass(NKikimrBlobStorage::TabletLog);
             
-            // Standard protobuf serialization/deserialization
             TString serializedData;
             if (!msg.SerializeToString(&serializedData)) {
                 Cerr << "Protobuf serialization error during warm-up" << Endl;
@@ -222,18 +195,15 @@ Y_UNIT_TEST_SUITE(SerializationPerformance) {
             }
         }
         
-        // Main measurements
         Cerr << "Starting protobuf measurements for " << payloadSize << " bytes payload..." << Endl;
         
         for (size_t i = 0; i < iterations; ++i) {
-            // Create new protobuf message for each iteration
             NKikimrBlobStorage::TEvVPut msg;
             LogoBlobIDFromLogoBlobID(blobId, msg.mutable_blobid());
             msg.set_buffer(testData);
             VDiskIDFromVDiskID(vdiskId, msg.mutable_vdiskid());
             msg.set_handleclass(NKikimrBlobStorage::TabletLog);
             
-            // Measure protobuf serialization time
             TString serializedData;
             auto startTime = TInstant::Now();
             bool serializeResult = msg.SerializeToString(&serializedData);
@@ -247,7 +217,6 @@ Y_UNIT_TEST_SUITE(SerializationPerformance) {
             
             messageSizes.push_back(serializedData.size());
             
-            // Measure protobuf deserialization time
             startTime = TInstant::Now();
             NKikimrBlobStorage::TEvVPut deserializedMsg;
             bool parseResult = deserializedMsg.ParseFromString(serializedData);
@@ -259,7 +228,6 @@ Y_UNIT_TEST_SUITE(SerializationPerformance) {
                 continue;
             }
             
-            // Verify data correctness
             bool dataValid = true;
             dataValid &= (LogoBlobIDFromLogoBlobID(deserializedMsg.GetBlobID()) == blobId);
             dataValid &= (deserializedMsg.GetHandleClass() == NKikimrBlobStorage::TabletLog);
@@ -269,12 +237,10 @@ Y_UNIT_TEST_SUITE(SerializationPerformance) {
                 Cerr << "Data after protobuf deserialization is invalid in iteration " << i << Endl;
             }
             
-            // Save results
             serializationTimes.push_back(serializationTime);
             deserializationTimes.push_back(deserializationTime);
         }
         
-        // Calculate statistics
         double avgSerializationTime = 0;
         double avgDeserializationTime = 0;
         double avgMessageSize = 0;
@@ -292,7 +258,6 @@ Y_UNIT_TEST_SUITE(SerializationPerformance) {
         double serializationThroughput = (avgMessageSize / 1024.0 / 1024.0) / avgSerializationTime;
         double deserializationThroughput = (avgMessageSize / 1024.0 / 1024.0) / avgDeserializationTime;
         
-        // Standard deviation
         double stddevSerialization = 0;
         double stddevDeserialization = 0;
         
@@ -311,7 +276,6 @@ Y_UNIT_TEST_SUITE(SerializationPerformance) {
         stddevSerialization = std::sqrt(stddevSerialization / serializationTimes.size());
         stddevDeserialization = std::sqrt(stddevDeserialization / deserializationTimes.size());
         
-        // Output results
         Cerr << "===== Pure Protobuf Serialization Performance Results =====" << Endl;
         Cerr << "Data size: " << payloadSize << " bytes" << Endl;
         Cerr << "Number of iterations: " << iterations << Endl;
@@ -326,13 +290,11 @@ Y_UNIT_TEST_SUITE(SerializationPerformance) {
     }
 
     Y_UNIT_TEST(TEvVPutSerializationPerformance) {
-        // Test different data sizes for TEvVPut actor
         Cerr << "\n\n=== TESTING TEvVPut ACTOR SERIALIZATION ===" << Endl;
         MeasureActorSerializationPerformance(32, DEFAULT_ITERATIONS);      // Small size
         MeasureActorSerializationPerformance(128, DEFAULT_ITERATIONS);     // Medium size
         MeasureActorSerializationPerformance(4096, DEFAULT_ITERATIONS);    // Large size
         
-        // Compare with pure protobuf
         Cerr << "\n\n=== TESTING PURE PROTOBUF SERIALIZATION ===" << Endl;
         MeasureProtobufSerializationPerformance(32, DEFAULT_ITERATIONS);      // Small size
         MeasureProtobufSerializationPerformance(128, DEFAULT_ITERATIONS);     // Medium size

--- a/ydb/core/blobstorage/ut_blobstorage/serialization_perf.cpp
+++ b/ydb/core/blobstorage/ut_blobstorage/serialization_perf.cpp
@@ -6,9 +6,13 @@
 #include <util/stream/str.h>
 #include <ydb/core/protos/blobstorage.pb.h>
 #include <ydb/core/protos/base.pb.h>
+#include <ydb/library/actors/core/event_pb.h>
 
 Y_UNIT_TEST_SUITE(SerializationPerformance) {
     
+    const size_t DEFAULT_ITERATIONS = 10000;
+    
+    // Function to generate test data
     TString GenerateTestData(size_t size) {
         TString data;
         data.reserve(size);
@@ -17,30 +21,16 @@ Y_UNIT_TEST_SUITE(SerializationPerformance) {
         }
         return data;
     }
-
-    void MeasureSerializationPerformance(size_t payloadSize, size_t iterations) {
+    
+    // Testing serialization performance of the actual TEvBlobStorage::TEvVPut actor
+    void MeasureActorSerializationPerformance(size_t payloadSize, size_t iterations) {
         TString testData = GenerateTestData(payloadSize);
         
-        // cache warming
-        for (size_t i = 0; i < 1000; ++i) {
-            NKikimrBlobStorage::TEvVPut msg;
-            auto blobId = TLogoBlobID(1, 1, 1, 1, 0x3333, 0x0001A01B);
-            LogoBlobIDFromLogoBlobID(blobId, msg.mutable_blobid());
-            msg.set_buffer(testData);
-            auto vdiskId = TVDiskID(TGroupId::FromValue(1), 1, 1, 1, 1);
-            VDiskIDFromVDiskID(vdiskId, msg.mutable_vdiskid());
-            msg.set_handleclass(NKikimrBlobStorage::TabletLog);
-            
-            TString warmupData;
-            auto ser = msg.SerializeToString(&warmupData);
-            NKikimrBlobStorage::TEvVPut warmupMsg;
-            auto der = warmupMsg.ParseFromString(warmupData);
-            if (!ser || !der)  {
-                --i;
-            }
-        }
+        // Parameters for message creation
+        auto blobId = TLogoBlobID(1, 1, 1, 1, 0x3333, 0x0001A01B);
+        auto vdiskId = TVDiskID(TGroupId::FromValue(1), 1, 1, 1, 1);
         
-        // store in array for adding metrics
+        // Arrays for storing results
         TVector<double> serializationTimes;
         TVector<double> deserializationTimes;
         TVector<size_t> messageSizes;
@@ -48,69 +38,304 @@ Y_UNIT_TEST_SUITE(SerializationPerformance) {
         deserializationTimes.reserve(iterations);
         messageSizes.reserve(iterations);
         
-        for (size_t i = 0; i < iterations; ++i) {
-            NKikimrBlobStorage::TEvVPut msg;
+        // Cache warm-up
+        Cerr << "Warming up cache..." << Endl;
+        for (size_t i = 0; i < 1000; ++i) {
+            // Create a TEvBlobStorage::TEvVPut instance
+            // It contains an internal protobuf message Record of type NKikimrBlobStorage::TEvVPut
+            auto msg = MakeHolder<TEvBlobStorage::TEvVPut>(
+                blobId, TRope(testData), vdiskId, false, nullptr, TInstant::Max(), 
+                NKikimrBlobStorage::TabletLog);
             
-            auto blobId = TLogoBlobID(1, 1, 1, 1, 0x3333, 0x0001A01B);
-            LogoBlobIDFromLogoBlobID(blobId, msg.mutable_blobid());
-            msg.set_buffer(testData);
-            auto vdiskId = TVDiskID(TGroupId::FromValue(1), 1, 1, 1, 1);
-            VDiskIDFromVDiskID(vdiskId, msg.mutable_vdiskid());
-            msg.set_handleclass(NKikimrBlobStorage::TabletLog);
+            // Serialize using the standard actor system mechanism
+            NActors::TAllocChunkSerializer serializer;
+            if (!msg->SerializeToArcadiaStream(&serializer)) {
+                Cerr << "Serialization error during warm-up" << Endl;
+                return;
+            }
             
-            TString serializedData;
+            // Get serialized data
+            auto serializedData = serializer.Release(TEventSerializationInfo{});
             
-            auto startTime = TInstant::Now();
-            bool serializeResult = msg.SerializeToString(&serializedData);
-            auto serializationTime = (TInstant::Now() - startTime).SecondsFloat();
-            UNIT_ASSERT(serializeResult);
-            
-            startTime = TInstant::Now();
-            NKikimrBlobStorage::TEvVPut deserializedMsg;
-            bool parseResult = deserializedMsg.ParseFromString(serializedData);
-            auto deserializationTime = (TInstant::Now() - startTime).SecondsFloat();
-            UNIT_ASSERT(parseResult);
-            
-            // correctness check
-            UNIT_ASSERT_VALUES_EQUAL(msg.buffer(), deserializedMsg.buffer());
-            UNIT_ASSERT_VALUES_EQUAL(msg.handleclass(), deserializedMsg.handleclass());
-            
-            serializationTimes.push_back(serializationTime);
-            deserializationTimes.push_back(deserializationTime);
-            messageSizes.push_back(serializedData.size());
+            // Deserialize back to TEvBlobStorage::TEvVPut
+            IEventBase* rawEvent = TEvBlobStorage::TEvVPut::Load(serializedData.Get());
+            if (!rawEvent) {
+                Cerr << "Deserialization error during warm-up" << Endl;
+                return;
+            }
+            delete rawEvent;
         }
         
+        // Main measurements
+        Cerr << "Starting measurements for " << payloadSize << " bytes payload..." << Endl;
+        
+        for (size_t i = 0; i < iterations; ++i) {
+            // Create a TEvBlobStorage::TEvVPut instance for each iteration
+            auto msg = MakeHolder<TEvBlobStorage::TEvVPut>(
+                blobId, TRope(testData), vdiskId, false, nullptr, TInstant::Max(), 
+                NKikimrBlobStorage::TabletLog);
+            
+            // Measure serialization time
+            NActors::TAllocChunkSerializer serializer;
+            auto startTime = TInstant::Now();
+            bool serializeResult = msg->SerializeToArcadiaStream(&serializer);
+            auto endTime = TInstant::Now();
+            double serializationTime = (endTime - startTime).SecondsFloat();
+            
+            if (!serializeResult) {
+                Cerr << "Serialization error in iteration " << i << Endl;
+                continue;
+            }
+            
+            // Get serialized data for subsequent deserialization and statistics
+            auto serializedData = serializer.Release(TEventSerializationInfo{});
+            size_t messageSize = serializedData->GetSize();
+            messageSizes.push_back(messageSize);
+            
+            // Measure deserialization time
+            startTime = TInstant::Now();
+            IEventBase* rawEvent = TEvBlobStorage::TEvVPut::Load(serializedData.Get());
+            endTime = TInstant::Now();
+            double deserializationTime = (endTime - startTime).SecondsFloat();
+            
+            if (!rawEvent) {
+                Cerr << "Deserialization error in iteration " << i << Endl;
+                continue;
+            }
+            
+            // Check type and data correctness
+            auto deserializedMsg = dynamic_cast<TEvBlobStorage::TEvVPut*>(rawEvent);
+            if (!deserializedMsg) {
+                Cerr << "Invalid type after deserialization in iteration " << i << Endl;
+                delete rawEvent;
+                continue;
+            }
+            
+            // Validate data correctness in the protobuf Record message
+            bool dataValid = true;
+            dataValid &= (LogoBlobIDFromLogoBlobID(deserializedMsg->Record.GetBlobID()) == blobId);
+            dataValid &= (deserializedMsg->Record.GetHandleClass() == NKikimrBlobStorage::TabletLog);
+            dataValid &= (deserializedMsg->GetBuffer() == testData);
+            
+            if (!dataValid) {
+                Cerr << "Data after deserialization is invalid in iteration " << i << Endl;
+            }
+            
+            // Save results
+            serializationTimes.push_back(serializationTime);
+            deserializationTimes.push_back(deserializationTime);
+            
+            // Free memory
+            delete rawEvent;
+        }
+        
+        // Calculate statistics
+        // 1. Average time
         double avgSerializationTime = 0;
         double avgDeserializationTime = 0;
         double avgMessageSize = 0;
         
-        for (size_t i = 0; i < iterations; ++i) {
+        for (size_t i = 0; i < messageSizes.size(); ++i) {
             avgSerializationTime += serializationTimes[i];
             avgDeserializationTime += deserializationTimes[i];
             avgMessageSize += messageSizes[i];
         }
         
-        avgSerializationTime /= iterations;
-        avgDeserializationTime /= iterations;
-        avgMessageSize /= iterations;
+        avgSerializationTime /= serializationTimes.size();
+        avgDeserializationTime /= deserializationTimes.size();
+        avgMessageSize /= messageSizes.size();
         
-        double serializationThroughput = avgMessageSize / avgSerializationTime;
-        double deserializationThroughput = avgMessageSize / avgDeserializationTime;
+        // 2. Throughput (MB/s)
+        double serializationThroughput = (avgMessageSize / 1024.0 / 1024.0) / avgSerializationTime;
+        double deserializationThroughput = (avgMessageSize / 1024.0 / 1024.0) / avgDeserializationTime;
         
-        Cerr << "=== Performance Results for " << payloadSize << " bytes payload ===" << Endl;
-        Cerr << "Average serialization time: " << (avgSerializationTime * 1e6) << " microseconds" << Endl;
-        Cerr << "Average deserialization time: " << (avgDeserializationTime * 1e6) << " microseconds" << Endl;
-        Cerr << "Serialization throughput: " << (serializationThroughput / (1024*1024)) << " MB/s" << Endl;
-        Cerr << "Deserialization throughput: " << (deserializationThroughput / (1024*1024)) << " MB/s" << Endl;
+        // 3. Standard deviation
+        double stddevSerialization = 0;
+        double stddevDeserialization = 0;
+        
+        for (size_t i = 0; i < serializationTimes.size(); ++i) {
+            stddevSerialization += 
+                (serializationTimes[i] - avgSerializationTime) * 
+                (serializationTimes[i] - avgSerializationTime);
+        }
+        
+        for (size_t i = 0; i < deserializationTimes.size(); ++i) {
+            stddevDeserialization += 
+                (deserializationTimes[i] - avgDeserializationTime) * 
+                (deserializationTimes[i] - avgDeserializationTime);
+        }
+        
+        stddevSerialization = std::sqrt(stddevSerialization / serializationTimes.size());
+        stddevDeserialization = std::sqrt(stddevDeserialization / deserializationTimes.size());
+        
+        // Output results
+        Cerr << "===== TEvVPut Actor Serialization Performance Results =====" << Endl;
+        Cerr << "Data size: " << payloadSize << " bytes" << Endl;
+        Cerr << "Number of iterations: " << iterations << Endl;
         Cerr << "Average message size: " << avgMessageSize << " bytes" << Endl;
-        Cerr << "=================================================" << Endl;
+        Cerr << "Serialization time: " << (avgSerializationTime * 1e6) << " μs (standard deviation: " 
+             << (stddevSerialization * 1e6) << " μs)" << Endl;
+        Cerr << "Deserialization time: " << (avgDeserializationTime * 1e6) << " μs (standard deviation: " 
+             << (stddevDeserialization * 1e6) << " μs)" << Endl;
+        Cerr << "Serialization throughput: " << serializationThroughput << " MB/s" << Endl;
+        Cerr << "Deserialization throughput: " << deserializationThroughput << " MB/s" << Endl;
+        Cerr << "=============================================================" << Endl;
+    }
+
+    // For comparison - testing pure protobuf serialization performance
+    void MeasureProtobufSerializationPerformance(size_t payloadSize, size_t iterations) {
+        TString testData = GenerateTestData(payloadSize);
+        
+        // Parameters for message creation
+        auto blobId = TLogoBlobID(1, 1, 1, 1, 0x3333, 0x0001A01B);
+        auto vdiskId = TVDiskID(TGroupId::FromValue(1), 1, 1, 1, 1);
+        
+        // Arrays for storing results
+        TVector<double> serializationTimes;
+        TVector<double> deserializationTimes;
+        TVector<size_t> messageSizes;
+        serializationTimes.reserve(iterations);
+        deserializationTimes.reserve(iterations);
+        messageSizes.reserve(iterations);
+        
+        // Cache warm-up
+        Cerr << "Warming up cache for protobuf..." << Endl;
+        for (size_t i = 0; i < 1000; ++i) {
+            // Create protobuf message directly
+            NKikimrBlobStorage::TEvVPut msg;
+            LogoBlobIDFromLogoBlobID(blobId, msg.mutable_blobid());
+            msg.set_buffer(testData);
+            VDiskIDFromVDiskID(vdiskId, msg.mutable_vdiskid());
+            msg.set_handleclass(NKikimrBlobStorage::TabletLog);
+            
+            // Standard protobuf serialization/deserialization
+            TString serializedData;
+            if (!msg.SerializeToString(&serializedData)) {
+                Cerr << "Protobuf serialization error during warm-up" << Endl;
+                return;
+            }
+            
+            NKikimrBlobStorage::TEvVPut deserializedMsg;
+            if (!deserializedMsg.ParseFromString(serializedData)) {
+                Cerr << "Protobuf deserialization error during warm-up" << Endl;
+                return;
+            }
+        }
+        
+        // Main measurements
+        Cerr << "Starting protobuf measurements for " << payloadSize << " bytes payload..." << Endl;
+        
+        for (size_t i = 0; i < iterations; ++i) {
+            // Create new protobuf message for each iteration
+            NKikimrBlobStorage::TEvVPut msg;
+            LogoBlobIDFromLogoBlobID(blobId, msg.mutable_blobid());
+            msg.set_buffer(testData);
+            VDiskIDFromVDiskID(vdiskId, msg.mutable_vdiskid());
+            msg.set_handleclass(NKikimrBlobStorage::TabletLog);
+            
+            // Measure protobuf serialization time
+            TString serializedData;
+            auto startTime = TInstant::Now();
+            bool serializeResult = msg.SerializeToString(&serializedData);
+            auto endTime = TInstant::Now();
+            double serializationTime = (endTime - startTime).SecondsFloat();
+            
+            if (!serializeResult) {
+                Cerr << "Protobuf serialization error in iteration " << i << Endl;
+                continue;
+            }
+            
+            messageSizes.push_back(serializedData.size());
+            
+            // Measure protobuf deserialization time
+            startTime = TInstant::Now();
+            NKikimrBlobStorage::TEvVPut deserializedMsg;
+            bool parseResult = deserializedMsg.ParseFromString(serializedData);
+            endTime = TInstant::Now();
+            double deserializationTime = (endTime - startTime).SecondsFloat();
+            
+            if (!parseResult) {
+                Cerr << "Protobuf deserialization error in iteration " << i << Endl;
+                continue;
+            }
+            
+            // Verify data correctness
+            bool dataValid = true;
+            dataValid &= (LogoBlobIDFromLogoBlobID(deserializedMsg.GetBlobID()) == blobId);
+            dataValid &= (deserializedMsg.GetHandleClass() == NKikimrBlobStorage::TabletLog);
+            dataValid &= (deserializedMsg.GetBuffer() == testData);
+            
+            if (!dataValid) {
+                Cerr << "Data after protobuf deserialization is invalid in iteration " << i << Endl;
+            }
+            
+            // Save results
+            serializationTimes.push_back(serializationTime);
+            deserializationTimes.push_back(deserializationTime);
+        }
+        
+        // Calculate statistics
+        double avgSerializationTime = 0;
+        double avgDeserializationTime = 0;
+        double avgMessageSize = 0;
+        
+        for (size_t i = 0; i < messageSizes.size(); ++i) {
+            avgSerializationTime += serializationTimes[i];
+            avgDeserializationTime += deserializationTimes[i];
+            avgMessageSize += messageSizes[i];
+        }
+        
+        avgSerializationTime /= serializationTimes.size();
+        avgDeserializationTime /= deserializationTimes.size();
+        avgMessageSize /= messageSizes.size();
+        
+        double serializationThroughput = (avgMessageSize / 1024.0 / 1024.0) / avgSerializationTime;
+        double deserializationThroughput = (avgMessageSize / 1024.0 / 1024.0) / avgDeserializationTime;
+        
+        // Standard deviation
+        double stddevSerialization = 0;
+        double stddevDeserialization = 0;
+        
+        for (size_t i = 0; i < serializationTimes.size(); ++i) {
+            stddevSerialization += 
+                (serializationTimes[i] - avgSerializationTime) * 
+                (serializationTimes[i] - avgSerializationTime);
+        }
+        
+        for (size_t i = 0; i < deserializationTimes.size(); ++i) {
+            stddevDeserialization += 
+                (deserializationTimes[i] - avgDeserializationTime) * 
+                (deserializationTimes[i] - avgDeserializationTime);
+        }
+        
+        stddevSerialization = std::sqrt(stddevSerialization / serializationTimes.size());
+        stddevDeserialization = std::sqrt(stddevDeserialization / deserializationTimes.size());
+        
+        // Output results
+        Cerr << "===== Pure Protobuf Serialization Performance Results =====" << Endl;
+        Cerr << "Data size: " << payloadSize << " bytes" << Endl;
+        Cerr << "Number of iterations: " << iterations << Endl;
+        Cerr << "Average message size: " << avgMessageSize << " bytes" << Endl;
+        Cerr << "Serialization time: " << (avgSerializationTime * 1e6) << " μs (standard deviation: " 
+             << (stddevSerialization * 1e6) << " μs)" << Endl;
+        Cerr << "Deserialization time: " << (avgDeserializationTime * 1e6) << " μs (standard deviation: " 
+             << (stddevDeserialization * 1e6) << " μs)" << Endl;
+        Cerr << "Serialization throughput: " << serializationThroughput << " MB/s" << Endl;
+        Cerr << "Deserialization throughput: " << deserializationThroughput << " MB/s" << Endl;
+        Cerr << "=============================================================" << Endl;
     }
 
     Y_UNIT_TEST(TEvVPutSerializationPerformance) {
-        const size_t iterations = 100000; 
+        // Test different data sizes for TEvVPut actor
+        Cerr << "\n\n=== TESTING TEvVPut ACTOR SERIALIZATION ===" << Endl;
+        MeasureActorSerializationPerformance(32, DEFAULT_ITERATIONS);      // Small size
+        MeasureActorSerializationPerformance(128, DEFAULT_ITERATIONS);     // Medium size
+        MeasureActorSerializationPerformance(4096, DEFAULT_ITERATIONS);    // Large size
         
-        MeasureSerializationPerformance(32, iterations);
-        MeasureSerializationPerformance(128, iterations);
-        MeasureSerializationPerformance(4096, iterations);
+        // Compare with pure protobuf
+        Cerr << "\n\n=== TESTING PURE PROTOBUF SERIALIZATION ===" << Endl;
+        MeasureProtobufSerializationPerformance(32, DEFAULT_ITERATIONS);      // Small size
+        MeasureProtobufSerializationPerformance(128, DEFAULT_ITERATIONS);     // Medium size
+        MeasureProtobufSerializationPerformance(4096, DEFAULT_ITERATIONS);    // Large size
     }
 } 

--- a/ydb/core/blobstorage/ut_blobstorage/ya.make
+++ b/ydb/core/blobstorage/ut_blobstorage/ya.make
@@ -41,6 +41,7 @@ SRCS(
     recovery.cpp
     sanitize_groups.cpp
     scrub_fast.cpp
+    serialization_perf.cpp
     shred.cpp
     snapshots.cpp
     space_check.cpp

--- a/ydb/core/blobstorage/ut_blobstorage/ya.make
+++ b/ydb/core/blobstorage/ut_blobstorage/ya.make
@@ -16,8 +16,6 @@ ENDIF()
 SRCS(
     acceleration.cpp
     assimilation.cpp
-    binary_serialization_perf.cpp
-    binary_serialization_test.cpp
     block_race.cpp
     counting_events.cpp
     deadlines.cpp
@@ -32,7 +30,6 @@ SRCS(
     get.cpp
     get_block.cpp
     group_reconfiguration.cpp
-    huge.cpp
     incorrect_queries.cpp
     index_restore_get.cpp
     main.cpp
@@ -40,12 +37,13 @@ SRCS(
     mirror3of4.cpp
     monitoring.cpp
     multiget.cpp
-    osiris.cpp
     patch.cpp
     recovery.cpp
     sanitize_groups.cpp
     scrub_fast.cpp
     serialization_perf.cpp
+    binary_serialization_test.cpp
+    binary_serialization_perf.cpp
     shred.cpp
     snapshots.cpp
     space_check.cpp

--- a/ydb/core/blobstorage/ut_blobstorage/ya.make
+++ b/ydb/core/blobstorage/ut_blobstorage/ya.make
@@ -16,6 +16,8 @@ ENDIF()
 SRCS(
     acceleration.cpp
     assimilation.cpp
+    binary_serialization_perf.cpp
+    binary_serialization_test.cpp
     block_race.cpp
     counting_events.cpp
     deadlines.cpp
@@ -30,6 +32,7 @@ SRCS(
     get.cpp
     get_block.cpp
     group_reconfiguration.cpp
+    huge.cpp
     incorrect_queries.cpp
     index_restore_get.cpp
     main.cpp
@@ -37,6 +40,7 @@ SRCS(
     mirror3of4.cpp
     monitoring.cpp
     multiget.cpp
+    osiris.cpp
     patch.cpp
     recovery.cpp
     sanitize_groups.cpp

--- a/ydb/core/blobstorage/vdisk/common/vdisk_events_binary.h
+++ b/ydb/core/blobstorage/vdisk/common/vdisk_events_binary.h
@@ -1,0 +1,398 @@
+#pragma once
+#include "defs.h"
+#include "vdisk_events.h"
+
+#include <ydb/core/blobstorage/base/blobstorage_syncstate.h>
+#include <ydb/core/blobstorage/base/utility.h>
+#include <ydb/core/blobstorage/vdisk/common/disk_part.h>
+#include <ydb/core/base/blobstorage.h>
+#include <ydb/core/base/event_filter.h>
+#include <ydb/library/actors/core/actor.h>
+#include <ydb/library/actors/core/events.h>
+
+#include <util/digest/murmur.h>
+#include <util/generic/algorithm.h>
+#include <util/stream/mem.h>
+#include <util/system/byteorder.h>
+
+namespace NKikimr {
+
+    struct TEvBlobStorage::TEvVPutBinary
+        : public TEventBase<TEvBlobStorage::TEvVPutBinary, TEvBlobStorage::EvVPutBinary>
+        , TEventWithRelevanceTracker
+    {
+        // Constants for binary format identification
+        static constexpr ui32 MAGIC_NUMBER = 0x565042; // "VPB" in ASCII
+        static constexpr ui8 VERSION = 1;
+
+        TLogoBlobID BlobId;
+        TString Buffer;
+        TVDiskID VDiskId;
+        bool IgnoreBlock = false;
+        ui64 Cookie = 0;
+        TInstant Deadline = TInstant::Max();
+        NKikimrBlobStorage::EPutHandleClass HandleClass = NKikimrBlobStorage::TabletLog;
+        mutable NLWTrace::TOrbit Orbit; // No active usage
+        bool RewriteBlob = false;
+        bool IsInternal = false;
+        std::vector<std::pair<ui64, ui32>> ExtraBlockChecks; // (TabletId, Generation) pairs
+        bool HasCookie = false;
+
+        TEvVPutBinary() = default;
+
+        TEvVPutBinary(const TEvVPut& original) {
+            BlobId = LogoBlobIDFromLogoBlobID(original.Record.GetBlobID());
+            VDiskId = VDiskIDFromVDiskID(original.Record.GetVDiskID());
+            Buffer = original.Record.GetBuffer();
+            IgnoreBlock = original.GetIgnoreBlock();
+            HasCookie = original.Record.HasCookie();
+            if (HasCookie) {
+                Cookie = original.Record.GetCookie();
+            }
+            
+            if (original.Record.GetMsgQoS().HasDeadlineSeconds()) {
+                Deadline = TInstant::Seconds(original.Record.GetMsgQoS().GetDeadlineSeconds());
+            }
+            
+            HandleClass = original.Record.GetHandleClass();
+            
+            for (const auto& check : original.Record.GetExtraBlockChecks()) {
+                ExtraBlockChecks.emplace_back(check.GetTabletId(), check.GetGeneration());
+            }
+        }
+
+        // Преобразование обратно в TEvVPut
+        TEvVPut* ToOriginal() const {
+            auto result = new TEvVPut();
+            
+            // Инициализируем основные поля
+            LogoBlobIDFromLogoBlobID(BlobId, result->Record.MutableBlobID());
+            result->Record.SetFullDataSize(BlobId.BlobSize());
+            VDiskIDFromVDiskID(VDiskId, result->Record.MutableVDiskID());
+            
+            // Устанавливаем флаги и опциональные поля
+            if (IgnoreBlock) {
+                result->Record.SetIgnoreBlock(IgnoreBlock);
+            }
+            
+            if (HasCookie) {
+                result->Record.SetCookie(Cookie);
+            }
+            
+            if (Deadline != TInstant::Max()) {
+                result->Record.MutableMsgQoS()->SetDeadlineSeconds((ui32)Deadline.Seconds());
+            }
+            
+            result->Record.SetHandleClass(HandleClass);
+            result->Record.MutableMsgQoS()->SetExtQueueId(HandleClassToQueueId(HandleClass));
+            
+            // Копируем ExtraBlockChecks
+            for (const auto& check : ExtraBlockChecks) {
+                auto* checkProto = result->Record.AddExtraBlockChecks();
+                checkProto->SetTabletId(check.first);
+                checkProto->SetGeneration(check.second);
+            }
+            
+            // Устанавливаем данные
+            result->Record.SetBuffer(Buffer);
+            
+            return result;
+        }
+
+        // Функция сохранения для актерной системы
+        void Save(TEventSerializedData* data) const {
+            // Сериализуем в строку
+            TString serialized;
+            Serialize(*this, serialized);
+            
+            // Добавляем в данные
+            data->Append(serialized);
+        }
+        
+        // Функция загрузки для актерной системы
+        static IEventBase* Load(TEventSerializedData* data) {
+            if (data->GetSize() == 0) {
+                return nullptr;
+            }
+            
+            TString serialized = data->GetString();
+            return Deserialize(serialized);
+        }
+        
+        // Сериализация в строку
+        static void Serialize(const TEvVPutBinary& msg, TString& out) {
+            // Определяем размер сериализованных данных
+            ui64 size = EstimateSerializeSize(msg);
+            out.resize(size);
+            TMemoryOutput mo(out.begin(), size);
+            
+            // Пишем заголовок формата
+            WriteToStream(mo, HostToLittle(MAGIC_NUMBER));
+            WriteToStream(mo, VERSION);
+            
+            // Сериализуем LogoBlobId
+            const TLogoBlobID& blobId = msg.BlobId;
+            WriteToStream(mo, HostToLittle(blobId.TabletID()));
+            WriteToStream(mo, HostToLittle(blobId.Channel()));
+            WriteToStream(mo, HostToLittle(blobId.Generation()));
+            WriteToStream(mo, HostToLittle(blobId.Step()));
+            WriteToStream(mo, HostToLittle(blobId.BlobSize()));
+            WriteToStream(mo, HostToLittle(blobId.PartId()));
+            
+            // Сериализуем TVDiskId
+            const TVDiskID& vdiskId = msg.VDiskId;
+            WriteToStream(mo, HostToLittle(vdiskId.GroupID.GetRawId()));
+            WriteToStream(mo, HostToLittle(vdiskId.GroupGeneration));
+            WriteToStream(mo, HostToLittle(vdiskId.FailRealm));
+            WriteToStream(mo, HostToLittle(vdiskId.FailDomain));
+            WriteToStream(mo, HostToLittle(vdiskId.VDisk));
+            
+            // Запишем флаги в один байт для компактности
+            ui8 flags = 0;
+            if (msg.IgnoreBlock) flags |= 1;
+            if (msg.HasCookie) flags |= 2;
+            if (msg.RewriteBlob) flags |= 4;
+            if (msg.IsInternal) flags |= 8;
+            if (msg.Deadline != TInstant::Max()) flags |= 16;
+            WriteToStream(mo, flags);
+            
+            // Сериализуем остальные поля только если нужно (на основе флагов)
+            if (msg.HasCookie) {
+                WriteToStream(mo, HostToLittle(msg.Cookie));
+            }
+            
+            if (msg.Deadline != TInstant::Max()) {
+                WriteToStream(mo, HostToLittle((ui64)msg.Deadline.MilliSeconds()));
+            }
+            
+            // Класс обработки
+            WriteToStream(mo, HostToLittle((ui32)msg.HandleClass));
+            
+            // ExtraBlockChecks
+            WriteToStream(mo, HostToLittle((ui32)msg.ExtraBlockChecks.size()));
+            for (const auto& check : msg.ExtraBlockChecks) {
+                WriteToStream(mo, HostToLittle(check.first));  // TabletId
+                WriteToStream(mo, HostToLittle(check.second)); // Generation
+            }
+            
+            // Данные
+            WriteToStream(mo, HostToLittle((ui64)msg.Buffer.size()));
+            if (!msg.Buffer.empty()) {
+                mo.Write(msg.Buffer.data(), msg.Buffer.size());
+            }
+        }
+        
+        // Десериализация из строки
+        static TEvVPutBinary* Deserialize(TStringBuf data) {
+            try {
+                TMemoryInput mi(data.data(), data.size());
+                
+                // Проверка заголовка
+                ui32 magic;
+                ReadFromStream(mi, magic);
+                magic = LittleToHost(magic);
+                if (magic != MAGIC_NUMBER) {
+                    return nullptr;
+                }
+                
+                ui8 version;
+                ReadFromStream(mi, version);
+                if (version != VERSION) {
+                    return nullptr;
+                }
+                
+                // Создаем новый объект
+                THolder<TEvVPutBinary> result = MakeHolder<TEvVPutBinary>();
+                
+                // Десериализуем LogoBlobId
+                ui64 tabletId;
+                ui32 channel;
+                ui32 generation;
+                ui32 step;
+                ui32 blobSize;
+                ui8 partId;
+                
+                ReadFromStream(mi, tabletId);
+                ReadFromStream(mi, channel);
+                ReadFromStream(mi, generation);
+                ReadFromStream(mi, step);
+                ReadFromStream(mi, blobSize);
+                ReadFromStream(mi, partId);
+                
+                result->BlobId = TLogoBlobID(
+                    LittleToHost(tabletId),
+                    LittleToHost(channel),
+                    LittleToHost(generation),
+                    LittleToHost(step),
+                    LittleToHost(blobSize),
+                    LittleToHost(partId)
+                );
+                
+                // Десериализуем TVDiskId
+                ui32 groupId;
+                ui32 groupGeneration;
+                ui8 failRealm;
+                ui8 failDomain;
+                ui8 vDisk;
+                
+                ReadFromStream(mi, groupId);
+                ReadFromStream(mi, groupGeneration);
+                ReadFromStream(mi, failRealm);
+                ReadFromStream(mi, failDomain);
+                ReadFromStream(mi, vDisk);
+                
+                // Создаем TVDiskID с правильными параметрами
+                result->VDiskId = TVDiskID(
+                    TGroupId::FromValue(LittleToHost(groupId)),
+                    LittleToHost(groupGeneration),
+                    LittleToHost(failRealm),
+                    LittleToHost(failDomain),
+                    LittleToHost(vDisk)
+                );
+                
+                // Читаем флаги
+                ui8 flags;
+                ReadFromStream(mi, flags);
+                
+                result->IgnoreBlock = (flags & 1) != 0;
+                result->HasCookie = (flags & 2) != 0;
+                result->RewriteBlob = (flags & 4) != 0;
+                result->IsInternal = (flags & 8) != 0;
+                bool hasDeadline = (flags & 16) != 0;
+                
+                // Читаем опциональные поля
+                if (result->HasCookie) {
+                    ui64 cookie;
+                    ReadFromStream(mi, cookie);
+                    result->Cookie = LittleToHost(cookie);
+                }
+                
+                if (hasDeadline) {
+                    ui64 deadline;
+                    ReadFromStream(mi, deadline);
+                    result->Deadline = TInstant::MilliSeconds(LittleToHost(deadline));
+                }
+                
+                // Класс обработки
+                ui32 handleClass;
+                ReadFromStream(mi, handleClass);
+                result->HandleClass = static_cast<NKikimrBlobStorage::EPutHandleClass>(LittleToHost(handleClass));
+                
+                // ExtraBlockChecks
+                ui32 extraChecksCount;
+                ReadFromStream(mi, extraChecksCount);
+                extraChecksCount = LittleToHost(extraChecksCount);
+                
+                result->ExtraBlockChecks.clear();
+                result->ExtraBlockChecks.reserve(extraChecksCount);
+                
+                for (ui32 i = 0; i < extraChecksCount; ++i) {
+                    ui64 tabletId;
+                    ui32 generation;
+                    ReadFromStream(mi, tabletId);
+                    ReadFromStream(mi, generation);
+                    result->ExtraBlockChecks.emplace_back(LittleToHost(tabletId), LittleToHost(generation));
+                }
+                
+                // Данные
+                ui64 bufferSize;
+                ReadFromStream(mi, bufferSize);
+                bufferSize = LittleToHost(bufferSize);
+                
+                if (bufferSize > 0) {
+                    result->Buffer.resize(bufferSize);
+                    mi.Read(result->Buffer.begin(), bufferSize);
+                } else {
+                    result->Buffer.clear();
+                }
+                
+                return result.Release();
+            } catch (...) {
+                return nullptr;
+            }
+        }
+        
+        // Вспомогательные методы для сериализации/десериализации
+        static ui64 EstimateSerializeSize(const TEvVPutBinary& msg) {
+            ui64 size = 0;
+            
+            // Заголовок (Magic + Version)
+            size += sizeof(ui32) + sizeof(ui8);
+            
+            // TLogoBlobID
+            size += sizeof(ui64) + sizeof(ui32) * 4 + sizeof(ui8);
+            
+            // TVDiskID
+            size += sizeof(ui32) * 3 + sizeof(ui8) * 2;
+            
+            // Флаги
+            size += sizeof(ui8);
+            
+            // Опциональные поля
+            if (msg.HasCookie) {
+                size += sizeof(ui64);
+            }
+            
+            if (msg.Deadline != TInstant::Max()) {
+                size += sizeof(ui64);
+            }
+            
+            // Класс обработки
+            size += sizeof(ui32);
+            
+            // ExtraBlockChecks
+            size += sizeof(ui32); // Размер массива
+            size += (sizeof(ui64) + sizeof(ui32)) * msg.ExtraBlockChecks.size();
+            
+            // Данные
+            size += sizeof(ui64); // Размер буфера
+            size += msg.Buffer.size();
+            
+            return size;
+        }
+        
+        // Шаблонные функции для сериализации/десериализации примитивных типов
+        template<typename T>
+        static void WriteToStream(IOutputStream& output, const T& value) {
+            output.Write(&value, sizeof(T));
+        }
+        
+        template<typename T>
+        static void ReadFromStream(IInputStream& input, T& value) {
+            input.Load(&value, sizeof(T));
+        }
+        
+        TString ToString() const override {
+            TStringStream str;
+            str << "TEvVPutBinary {ID# " << BlobId.ToString();
+            str << " VDiskID# " << VDiskId.ToString();
+            if (IgnoreBlock) {
+                str << " IgnoreBlock";
+            }
+            if (HasCookie) {
+                str << " Cookie# " << Cookie;
+            }
+            if (Deadline != TInstant::Max()) {
+                str << " Deadline# " << Deadline.ToString();
+            }
+            str << " HandleClass# " << (ui32)HandleClass;
+            if (RewriteBlob) {
+                str << " RewriteBlob";
+            }
+            if (IsInternal) {
+                str << " IsInternal";
+            }
+            if (!ExtraBlockChecks.empty()) {
+                str << " ExtraBlockChecks# " << ExtraBlockChecks.size();
+            }
+            str << " BufferSize# " << Buffer.size();
+            str << "}";
+            return str.Str();
+        }
+
+        bool IsSerializable() const override {
+            return true;
+        }
+    };
+
+} // namespace NKikimr 

--- a/ydb/core/blobstorage/vdisk/common/ya.make
+++ b/ydb/core/blobstorage/vdisk/common/ya.make
@@ -33,6 +33,7 @@ SRCS(
     vdisk_defrag.h
     vdisk_events.cpp
     vdisk_events.h
+    vdisk_events_binary.h
     vdisk_handle_class.cpp
     vdisk_handle_class.h
     vdisk_histogram_latency.cpp


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

Added unit test that allows assessing the throughput of serialization/deserialization of TEvVPut messages in MB/s, estimating the current values for messages containing 32, 128, and 4096 bytes of payload.

### Changelog category <!-- remove all except one -->

* Performance improvement

### Description for reviewers <!-- (optional) description for those who read this PR -->

Work in progress, next will be added binary serialization.
