### PR TITLE
Clean ScanActor ComputeCtx when terminated by Fetcher request

### DIFF
--- a/ydb/core/kqp/compute_actor/kqp_scan_compute_actor.cpp
+++ b/ydb/core/kqp/compute_actor/kqp_scan_compute_actor.cpp
@@ -163,6 +163,7 @@ void TKqpScanComputeActor::Handle(TEvScanExchange::TEvTerminateFromFetcher::TPtr
     ALS_DEBUG(NKikimrServices::KQP_COMPUTE) << "TEvTerminateFromFetcher: " << ev->Sender << "/" << SelfId();
     TBase::InternalError(ev->Get()->GetStatusCode(), ev->Get()->GetIssues());
     State = ev->Get()->GetState();
+    DoTerminateImpl();
 }
 
 void TKqpScanComputeActor::Handle(TEvScanExchange::TEvSendData::TPtr& ev) {


### PR DESCRIPTION
When CA descendents calls InternalError it results to PassAway and actor destruction. It bypassess DoTermiateImpl call and correct Scan ComputeCtx cleanup (UVs freeing), so we should call DoTerminateImpl explicitly after each InternalError call