### PR TITLE
Correct version comparison on Console config proposition

### DIFF
--- a/ydb/core/blobstorage/base/blobstorage_console_events.h
+++ b/ydb/core/blobstorage/base/blobstorage_console_events.h
@@ -33,14 +33,8 @@ namespace NKikimr {
             NKikimrBlobStorage::TEvControllerConsoleCommitRequest, EvControllerConsoleCommitRequest> {
         TEvControllerConsoleCommitRequest() = default;
 
-        TEvControllerConsoleCommitRequest(
-            const TString& yamlConfig,
-            bool allowUnknownFields = false,
-            bool bypassMetadataChecks = false) {
-
+        TEvControllerConsoleCommitRequest(const TString& yamlConfig) {
             Record.SetYAML(yamlConfig);
-            Record.SetAllowUnknownFields(allowUnknownFields);
-            Record.SetBypassMetadataChecks(bypassMetadataChecks);
         }
 
         TString ToString() const override {

--- a/ydb/core/mind/bscontroller/console_interaction.h
+++ b/ydb/core/mind/bscontroller/console_interaction.h
@@ -50,7 +50,6 @@ namespace NKikimr::NBsController {
 
         std::optional<TString> PendingYamlConfig;
         bool AllowUnknownFields = false;
-        bool BypassMetadataChecks = false;
 
         std::optional<std::optional<TString>> PendingStorageYamlConfig;
 

--- a/ydb/core/protos/blobstorage.proto
+++ b/ydb/core/protos/blobstorage.proto
@@ -1428,8 +1428,6 @@ message TEvControllerProposeConfigResponse {
 
 message TEvControllerConsoleCommitRequest {
     optional string YAML = 1;
-    optional bool AllowUnknownFields = 2;
-    optional bool BypassMetadataChecks = 3;
 }
 
 message TEvControllerConsoleCommitResponse {


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

Correct version comparison on Console config proposition

### Changelog category <!-- remove all except one -->

* Not for changelog (changelog entry is not required)

### Description for reviewers <!-- (optional) description for those who read this PR -->

This fix retains BSC/distconf <-> Console interoperation when BSC/distconf version of config changes more than once before commit to console.
