### PR TITLE
[NOT FOR MERGE] grace join: limit join results growth

### DIFF
--- a/yql/essentials/minikql/comp_nodes/mkql_grace_join.cpp
+++ b/yql/essentials/minikql/comp_nodes/mkql_grace_join.cpp
@@ -1000,7 +1000,7 @@ EFetchResult ProcessSpilledData(TComputationContext&, NUdf::TUnboxedValue*const*
                     } else {
                         JoinedTablePtr->Join(*LeftPacker->TablePtr, *RightPacker->TablePtr, JoinKind, *HaveMoreLeftRows, *HaveMoreRightRows, nextBucketToJoin, nextBucketToJoin+1);
                     }
-                    JoinedTablePtr->ResetIterator();
+                    JoinedTablePtr->ResetIterator(nextBucketToJoin);
                     continue;
                 }
 
@@ -1027,7 +1027,7 @@ EFetchResult ProcessSpilledData(TComputationContext&, NUdf::TUnboxedValue*const*
                     JoinedTablePtr->Join(*LeftPacker->TablePtr, *RightPacker->TablePtr, JoinKind, *HaveMoreLeftRows, *HaveMoreRightRows, nextBucketToJoin, nextBucketToJoin+1);
                 }
 
-                JoinedTablePtr->ResetIterator();
+                JoinedTablePtr->ResetIterator(nextBucketToJoin);
                 LeftPacker->EndTime = std::chrono::system_clock::now();
                 RightPacker->EndTime = std::chrono::system_clock::now();
             }

--- a/yql/essentials/minikql/comp_nodes/mkql_grace_join.cpp
+++ b/yql/essentials/minikql/comp_nodes/mkql_grace_join.cpp
@@ -817,7 +817,7 @@ private:
                     return EFetchResult::One;
                 }
 
-                if (JoinedTablePtr->PartialJoinIncomplete) {
+                if (JoinedTablePtr->PartialJoinIncomplete()) {
                     auto& leftTable = *LeftPacker->TablePtr;
                     auto& rightTable = SelfJoinSameKeys_ ? *LeftPacker->TablePtr : *RightPacker->TablePtr;
                     JoinedTablePtr->Join(leftTable, rightTable, JoinKind, *HaveMoreLeftRows, *HaveMoreRightRows);
@@ -992,7 +992,7 @@ EFetchResult ProcessSpilledData(TComputationContext&, NUdf::TUnboxedValue*const*
                     return EFetchResult::One;
                 }
 
-                if (JoinedTablePtr->PartialJoinIncomplete) {
+                if (JoinedTablePtr->PartialJoinIncomplete()) {
                     if ( SelfJoinSameKeys_ ) {
                         JoinedTablePtr->Join(*LeftPacker->TablePtr, *LeftPacker->TablePtr, JoinKind, *HaveMoreLeftRows, *HaveMoreRightRows, nextBucketToJoin, nextBucketToJoin+1);
                     } else {

--- a/yql/essentials/minikql/comp_nodes/mkql_grace_join.cpp
+++ b/yql/essentials/minikql/comp_nodes/mkql_grace_join.cpp
@@ -844,7 +844,7 @@ private:
                     JoinedTablePtr->ResetIterator();
                 }
             }
-            YQL_DEBUG_ABORT_UNLESS(!JoinedTablePtr->PartialJoinIncomplete());
+            Y_DEBUG_ABORT_UNLESS(!JoinedTablePtr->PartialJoinIncomplete());
 
             if (!*HaveMoreRightRows && !*HaveMoreLeftRows) {
                 *JoinCompleted = true;
@@ -1018,7 +1018,7 @@ EFetchResult ProcessSpilledData(TComputationContext&, NUdf::TUnboxedValue*const*
 
                 SpilledBucketsJoinOrderCurrentIndex++;
             } else {
-                YQL_DEBUG_ABORT_UNLESS(!JoinedTablePtr->PartialJoinIncomplete());
+                Y_DEBUG_ABORT_UNLESS(!JoinedTablePtr->PartialJoinIncomplete());
                 LeftPacker->StartTime = std::chrono::system_clock::now();
                 RightPacker->StartTime = std::chrono::system_clock::now();
                 if ( SelfJoinSameKeys_ ) {

--- a/yql/essentials/minikql/comp_nodes/mkql_grace_join.cpp
+++ b/yql/essentials/minikql/comp_nodes/mkql_grace_join.cpp
@@ -1018,6 +1018,7 @@ EFetchResult ProcessSpilledData(TComputationContext&, NUdf::TUnboxedValue*const*
 
                 SpilledBucketsJoinOrderCurrentIndex++;
             } else {
+		*PartialJoinCompleted = true;
                 Y_DEBUG_ABORT_UNLESS(!JoinedTablePtr->PartialJoinIncomplete());
                 LeftPacker->StartTime = std::chrono::system_clock::now();
                 RightPacker->StartTime = std::chrono::system_clock::now();

--- a/yql/essentials/minikql/comp_nodes/mkql_grace_join.cpp
+++ b/yql/essentials/minikql/comp_nodes/mkql_grace_join.cpp
@@ -818,6 +818,7 @@ private:
                 }
 
                 if (JoinedTablePtr->PartialJoinIncomplete()) {
+                    // Resume suspended join
                     auto& leftTable = *LeftPacker->TablePtr;
                     auto& rightTable = SelfJoinSameKeys_ ? *LeftPacker->TablePtr : *RightPacker->TablePtr;
                     JoinedTablePtr->Join(leftTable, rightTable, JoinKind, *HaveMoreLeftRows, *HaveMoreRightRows);
@@ -843,6 +844,7 @@ private:
                     JoinedTablePtr->ResetIterator();
                 }
             }
+            YQL_DEBUG_ABORT_UNLESS(!JoinedTablePtr->PartialJoinIncomplete());
 
             if (!*HaveMoreRightRows && !*HaveMoreLeftRows) {
                 *JoinCompleted = true;
@@ -1016,7 +1018,7 @@ EFetchResult ProcessSpilledData(TComputationContext&, NUdf::TUnboxedValue*const*
 
                 SpilledBucketsJoinOrderCurrentIndex++;
             } else {
-                *PartialJoinCompleted = true;
+                YQL_DEBUG_ABORT_UNLESS(!JoinedTablePtr->PartialJoinIncomplete());
                 LeftPacker->StartTime = std::chrono::system_clock::now();
                 RightPacker->StartTime = std::chrono::system_clock::now();
                 if ( SelfJoinSameKeys_ ) {

--- a/yql/essentials/minikql/comp_nodes/mkql_grace_join.cpp
+++ b/yql/essentials/minikql/comp_nodes/mkql_grace_join.cpp
@@ -1018,7 +1018,7 @@ EFetchResult ProcessSpilledData(TComputationContext&, NUdf::TUnboxedValue*const*
 
                 SpilledBucketsJoinOrderCurrentIndex++;
             } else {
-		*PartialJoinCompleted = true;
+                *PartialJoinCompleted = true;
                 Y_DEBUG_ABORT_UNLESS(!JoinedTablePtr->PartialJoinIncomplete());
                 LeftPacker->StartTime = std::chrono::system_clock::now();
                 RightPacker->StartTime = std::chrono::system_clock::now();

--- a/yql/essentials/minikql/comp_nodes/mkql_grace_join_imp.cpp
+++ b/yql/essentials/minikql/comp_nodes/mkql_grace_join_imp.cpp
@@ -168,9 +168,9 @@ TTable::EAddTupleResult TTable::AddTuple(  ui64 * intColumns, char ** stringColu
     return EAddTupleResult::Added;
 }
 
-void TTable::ResetIterator() {
+void TTable::ResetIterator(ui32 bucket) {
     CurrIterIndex = 0;
-    CurrIterBucket = 0;
+    CurrIterBucket = bucket;
     if (IsTableJoined) {
         JoinTable1->ResetIterator();
         JoinTable2->ResetIterator();

--- a/yql/essentials/minikql/comp_nodes/mkql_grace_join_imp.cpp
+++ b/yql/essentials/minikql/comp_nodes/mkql_grace_join_imp.cpp
@@ -450,7 +450,7 @@ void TTable::Join( TTable & t1, TTable & t2, EJoinKind joinKind, bool hasMoreLef
         if (tuple1Idx == UINT32_MAX) { // This bucket completely proceeded
 	    Y_DEBUG_ABORT_UNLESS(!hasMoreLeftTuples);
 	    Y_DEBUG_ABORT_UNLESS(!hasMoreRightTuples);
-	    Y_DEBUG_ABORT_UNLESS(PartialJoinIncomplete);
+	    Y_DEBUG_ABORT_UNLESS(PartialJoinIncomplete());
             continue;
         }
 
@@ -699,7 +699,7 @@ void TTable::Join( TTable & t1, TTable & t2, EJoinKind joinKind, bool hasMoreLef
             ;
     }
 
-    PartialJoinIncomplete = partialJoinIncomplete;
+    PartialJoinIncomplete_ = partialJoinIncomplete;
 
     HasMoreLeftTuples_ = hasMoreLeftTuples;
     HasMoreRightTuples_ = hasMoreRightTuples;
@@ -932,7 +932,7 @@ void TTable::Clear() {
 
 void TTable::ClearBucket(ui64 bucket) {
     TTableBucket & tb = TableBuckets[bucket];
-    PartialJoinIncomplete = false;
+    PartialJoinIncomplete_ = false;
     tb.ResumeIdx = 0;
     tb.ResumeOffset = 0;
     tb.KeyIntVals.clear();

--- a/yql/essentials/minikql/comp_nodes/mkql_grace_join_imp.cpp
+++ b/yql/essentials/minikql/comp_nodes/mkql_grace_join_imp.cpp
@@ -454,10 +454,10 @@ void TTable::Join( TTable & t1, TTable & t2, EJoinKind joinKind, bool hasMoreLef
             Y_DEBUG_ABORT_UNLESS(PartialJoinIncomplete()); // join was suspended at previous step
             continue;
         }
-        YQL_LOG_IF(TRACE, tuple1Idx != 0)
+        YQL_LOG_IF(GRACEJOIN_TRACE, tuple1Idx != 0)
             << (const void *)this << '#'
             << bucket
-            << " resume at " << tuple1Idx
+            << " resume at " << tuple1Idx << '/' << bucket1->ResumeOffset
 	    ;
 
         auto &leftIds = bucket1->LeftIds;

--- a/yql/essentials/minikql/comp_nodes/mkql_grace_join_imp.cpp
+++ b/yql/essentials/minikql/comp_nodes/mkql_grace_join_imp.cpp
@@ -458,7 +458,7 @@ void TTable::Join( TTable & t1, TTable & t2, EJoinKind joinKind, bool hasMoreLef
             << (const void *)this << '#'
             << bucket
             << " resume at " << tuple1Idx << '/' << bucket1->ResumeOffset
-	    ;
+            ;
 
         auto &leftIds = bucket1->LeftIds;
         leftIds.clear();

--- a/yql/essentials/minikql/comp_nodes/mkql_grace_join_imp.h
+++ b/yql/essentials/minikql/comp_nodes/mkql_grace_join_imp.h
@@ -333,7 +333,7 @@ class TTable {
     // Pointers to the joined tables. Lifetime of source tables to join should be greater than joined table
     TTable * JoinTable1 = nullptr;
     TTable * JoinTable2 = nullptr;
-    bool PartialJoinIncomplete = false;
+    bool PartialJoinIncomplete_ = false;
 
     // Returns tuple data in td from bucket with id bucketNum.  Tuple id inside bucket is tupleId.
     inline void GetTupleData(ui32 bucketNum, ui32 tupleId, TupleData& td);
@@ -362,6 +362,8 @@ public:
 
     // Returns value of next tuple. Returs true if there are more tuples
     bool NextTuple(TupleData& td);
+   
+    bool PartialJoinIncomplete() { return PartialJoinIncomplete_; } 
 
     bool TryToPreallocateMemoryForJoin(TTable & t1, TTable & t2, EJoinKind joinKind, bool hasMoreLeftTuples, bool hasMoreRightTuples);
 

--- a/yql/essentials/minikql/comp_nodes/mkql_grace_join_imp.h
+++ b/yql/essentials/minikql/comp_nodes/mkql_grace_join_imp.h
@@ -358,7 +358,7 @@ public:
 
 
     // Resets iterators. In case of join results table it also resets iterators for joined tables
-    void ResetIterator();
+    void ResetIterator(ui32 bucket = 0);
 
     // Returns value of next tuple. Returs true if there are more tuples
     bool NextTuple(TupleData& td);

--- a/yql/essentials/minikql/comp_nodes/mkql_grace_join_imp.h
+++ b/yql/essentials/minikql/comp_nodes/mkql_grace_join_imp.h
@@ -10,6 +10,9 @@ namespace NKikimr {
 namespace NMiniKQL {
 namespace GraceJoin {
 
+const ui32 PartialJoinBatchSize = 100000; // Number of tuples for one join batch
+const ui32 JoinResultsSizeLimit = 2*PartialJoinBatchSize; // Number of tuples in
+
 class TTableBucketSpiller;
 #define GRACEJOIN_DEBUG DEBUG
 #define GRACEJOIN_TRACE TRACE
@@ -165,6 +168,8 @@ struct TTableBucket {
 
     std::vector<ui64, TMKQLAllocator<ui64>> JoinSlots;  // Hashtable
     ui64 NSlots = 0;  // Hashtable
+    ui64 ResumeOffset = 0;
+    ui32 ResumeIdx = 0;
 
  };
 
@@ -328,6 +333,7 @@ class TTable {
     // Pointers to the joined tables. Lifetime of source tables to join should be greater than joined table
     TTable * JoinTable1 = nullptr;
     TTable * JoinTable2 = nullptr;
+    bool PartialJoinIncomplete = false;
 
     // Returns tuple data in td from bucket with id bucketNum.  Tuple id inside bucket is tupleId.
     inline void GetTupleData(ui32 bucketNum, ui32 tupleId, TupleData& td);


### PR DESCRIPTION
In certain cases JoinIds may over-grow:
1) large cardinality join ("key-monsters");
2) first batch problem (in first batch left side may be larger than
   usually)
Fix this by splitting join to parts if number of result tuples exceeds limit.

### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

...

### Changelog category <!-- remove all except one -->

* Not for changelog (changelog entry is not required)

### Description for reviewers <!-- (optional) description for those who read this PR -->

...
