### PR TITLE
Add naive bulk And to Roaring UDF

### DIFF
--- a/ydb/library/yql/udfs/common/roaring/test/canondata/result.json
+++ b/ydb/library/yql/udfs/common/roaring/test/canondata/result.json
@@ -9,6 +9,11 @@
             "uri": "file://test.test_intersect_/results.txt"
         }
     ],
+    "test.test[run_optimize]": [
+        {
+            "uri": "file://test.test_run_optimize_/results.txt"
+        }
+    ],
     "test.test[serialize_deserialize]": [
         {
             "uri": "file://test.test_serialize_deserialize_/results.txt"
@@ -17,11 +22,6 @@
     "test.test[union]": [
         {
             "uri": "file://test.test_union_/results.txt"
-        }
-    ],
-    "test.test[run_optimize]": [
-        {
-            "uri": "file://test.test_run_optimize_/results.txt"
         }
     ]
 }

--- a/ydb/library/yql/udfs/common/roaring/test/canondata/test.test_intersect_/results.txt
+++ b/ydb/library/yql/udfs/common/roaring/test/canondata/test.test_intersect_/results.txt
@@ -206,5 +206,67 @@
                 ]
             }
         ]
+    };
+    {
+        "Write" = [
+            {
+                "Type" = [
+                    "ListType";
+                    [
+                        "StructType";
+                        [
+                            [
+                                "NaiveBulkAnd";
+                                [
+                                    "ListType";
+                                    [
+                                        "DataType";
+                                        "Uint32"
+                                    ]
+                                ]
+                            ]
+                        ]
+                    ]
+                ];
+                "Data" = [
+                    [
+                        [
+                            "42"
+                        ]
+                    ]
+                ]
+            }
+        ]
+    };
+    {
+        "Write" = [
+            {
+                "Type" = [
+                    "ListType";
+                    [
+                        "StructType";
+                        [
+                            [
+                                "NaiveBulkAndWithBinary";
+                                [
+                                    "ListType";
+                                    [
+                                        "DataType";
+                                        "Uint32"
+                                    ]
+                                ]
+                            ]
+                        ]
+                    ]
+                ];
+                "Data" = [
+                    [
+                        [
+                            "1"
+                        ]
+                    ]
+                ]
+            }
+        ]
     }
 ]

--- a/ydb/library/yql/udfs/common/roaring/test/canondata/test.test_intersect_/results.txt
+++ b/ydb/library/yql/udfs/common/roaring/test/canondata/test.test_intersect_/results.txt
@@ -216,6 +216,214 @@
                         "StructType";
                         [
                             [
+                                "AndListInplace";
+                                [
+                                    "OptionalType";
+                                    [
+                                        "ListType";
+                                        [
+                                            "DataType";
+                                            "Uint32"
+                                        ]
+                                    ]
+                                ]
+                            ]
+                        ]
+                    ]
+                ];
+                "Data" = [
+                    [
+                        [
+                            [
+                                "1"
+                            ]
+                        ]
+                    ]
+                ]
+            }
+        ]
+    };
+    {
+        "Write" = [
+            {
+                "Type" = [
+                    "ListType";
+                    [
+                        "StructType";
+                        [
+                            [
+                                "AndWithBinaryListInplace";
+                                [
+                                    "OptionalType";
+                                    [
+                                        "ListType";
+                                        [
+                                            "DataType";
+                                            "Uint32"
+                                        ]
+                                    ]
+                                ]
+                            ]
+                        ]
+                    ]
+                ];
+                "Data" = [
+                    [
+                        [
+                            [
+                                "1"
+                            ]
+                        ]
+                    ]
+                ]
+            }
+        ]
+    };
+    {
+        "Write" = [
+            {
+                "Type" = [
+                    "ListType";
+                    [
+                        "StructType";
+                        [
+                            [
+                                "AndWithBinaryListEmptyInplace";
+                                [
+                                    "OptionalType";
+                                    [
+                                        "ListType";
+                                        [
+                                            "DataType";
+                                            "Uint32"
+                                        ]
+                                    ]
+                                ]
+                            ]
+                        ]
+                    ]
+                ];
+                "Data" = [
+                    [
+                        #
+                    ]
+                ]
+            }
+        ]
+    };
+    {
+        "Write" = [
+            {
+                "Type" = [
+                    "ListType";
+                    [
+                        "StructType";
+                        [
+                            [
+                                "AndNotListInplace";
+                                [
+                                    "OptionalType";
+                                    [
+                                        "ListType";
+                                        [
+                                            "DataType";
+                                            "Uint32"
+                                        ]
+                                    ]
+                                ]
+                            ]
+                        ]
+                    ]
+                ];
+                "Data" = [
+                    [
+                        [
+                            [
+                                "2"
+                            ]
+                        ]
+                    ]
+                ]
+            }
+        ]
+    };
+    {
+        "Write" = [
+            {
+                "Type" = [
+                    "ListType";
+                    [
+                        "StructType";
+                        [
+                            [
+                                "AndNotWithBinaryListInplace";
+                                [
+                                    "OptionalType";
+                                    [
+                                        "ListType";
+                                        [
+                                            "DataType";
+                                            "Uint32"
+                                        ]
+                                    ]
+                                ]
+                            ]
+                        ]
+                    ]
+                ];
+                "Data" = [
+                    [
+                        [
+                            [
+                                "3"
+                            ]
+                        ]
+                    ]
+                ]
+            }
+        ]
+    };
+    {
+        "Write" = [
+            {
+                "Type" = [
+                    "ListType";
+                    [
+                        "StructType";
+                        [
+                            [
+                                "AndNotWithBinaryListEmptyInplace";
+                                [
+                                    "OptionalType";
+                                    [
+                                        "ListType";
+                                        [
+                                            "DataType";
+                                            "Uint32"
+                                        ]
+                                    ]
+                                ]
+                            ]
+                        ]
+                    ]
+                ];
+                "Data" = [
+                    [
+                        #
+                    ]
+                ]
+            }
+        ]
+    };
+    {
+        "Write" = [
+            {
+                "Type" = [
+                    "ListType";
+                    [
+                        "StructType";
+                        [
+                            [
                                 "NaiveBulkAnd";
                                 [
                                     "ListType";
@@ -231,7 +439,7 @@
                 "Data" = [
                     [
                         [
-                            "42"
+                            "1"
                         ]
                     ]
                 ]

--- a/ydb/library/yql/udfs/common/roaring/test/canondata/test.test_union_/results.txt
+++ b/ydb/library/yql/udfs/common/roaring/test/canondata/test.test_union_/results.txt
@@ -74,5 +74,81 @@
                 ]
             }
         ]
+    };
+    {
+        "Write" = [
+            {
+                "Type" = [
+                    "ListType";
+                    [
+                        "StructType";
+                        [
+                            [
+                                "OrListInplace";
+                                [
+                                    "OptionalType";
+                                    [
+                                        "ListType";
+                                        [
+                                            "DataType";
+                                            "Uint32"
+                                        ]
+                                    ]
+                                ]
+                            ]
+                        ]
+                    ]
+                ];
+                "Data" = [
+                    [
+                        [
+                            [
+                                "1";
+                                "2";
+                                "3"
+                            ]
+                        ]
+                    ]
+                ]
+            }
+        ]
+    };
+    {
+        "Write" = [
+            {
+                "Type" = [
+                    "ListType";
+                    [
+                        "StructType";
+                        [
+                            [
+                                "OrWithBinaryListInplace";
+                                [
+                                    "OptionalType";
+                                    [
+                                        "ListType";
+                                        [
+                                            "DataType";
+                                            "Uint32"
+                                        ]
+                                    ]
+                                ]
+                            ]
+                        ]
+                    ]
+                ];
+                "Data" = [
+                    [
+                        [
+                            [
+                                "1";
+                                "2";
+                                "3"
+                            ]
+                        ]
+                    ]
+                ]
+            }
+        ]
     }
 ]

--- a/ydb/library/yql/udfs/common/roaring/test/cases/intersect.sql
+++ b/ydb/library/yql/udfs/common/roaring/test/cases/intersect.sql
@@ -6,5 +6,13 @@ SELECT Roaring::Uint32List(Roaring::AndNot(Roaring::Deserialize(left), Roaring::
 SELECT Roaring::Uint32List(Roaring::AndNotWithBinary(Roaring::Deserialize(right), left)) AS AndNotWithBinaryList FROM Input;
 SELECT Roaring::Uint32List(Roaring::AndNotWithBinary(Roaring::Deserialize(right), NULL)) AS AndNotWithBinaryListEmpty FROM Input;
 
-SELECT Roaring::Uint32List(Roaring::NaiveBulkAnd(AsList(Roaring::FromUint32List(AsList(10, 567, 42)), Roaring::FromUint32List(AsList(42))))) AS NaiveBulkAnd FROM Input;
+SELECT Roaring::Uint32List(Roaring::And(Roaring::Deserialize(left), Roaring::Deserialize(right), true)) AS AndListInplace FROM Input;
+SELECT Roaring::Uint32List(Roaring::AndWithBinary(Roaring::Deserialize(right), left, true)) AS AndWithBinaryListInplace FROM Input;
+SELECT Roaring::Uint32List(Roaring::AndWithBinary(Roaring::Deserialize(right), NULL, true)) AS AndWithBinaryListEmptyInplace FROM Input;
+
+SELECT Roaring::Uint32List(Roaring::AndNot(Roaring::Deserialize(left), Roaring::Deserialize(right), true)) AS AndNotListInplace FROM Input;
+SELECT Roaring::Uint32List(Roaring::AndNotWithBinary(Roaring::Deserialize(right), left, true)) AS AndNotWithBinaryListInplace FROM Input;
+SELECT Roaring::Uint32List(Roaring::AndNotWithBinary(Roaring::Deserialize(right), NULL, true)) AS AndNotWithBinaryListEmptyInplace FROM Input;
+
+SELECT Roaring::Uint32List(Roaring::NaiveBulkAnd(AsList(Roaring::Deserialize(right), Roaring::Deserialize(left)))) AS NaiveBulkAnd FROM Input;
 SELECT Roaring::Uint32List(Roaring::NaiveBulkAndWithBinary(AsList(right, left))) AS NaiveBulkAndWithBinary FROM Input;

--- a/ydb/library/yql/udfs/common/roaring/test/cases/intersect.sql
+++ b/ydb/library/yql/udfs/common/roaring/test/cases/intersect.sql
@@ -5,3 +5,6 @@ SELECT Roaring::Uint32List(Roaring::AndWithBinary(Roaring::Deserialize(right), N
 SELECT Roaring::Uint32List(Roaring::AndNot(Roaring::Deserialize(left), Roaring::Deserialize(right))) AS AndNotList FROM Input;
 SELECT Roaring::Uint32List(Roaring::AndNotWithBinary(Roaring::Deserialize(right), left)) AS AndNotWithBinaryList FROM Input;
 SELECT Roaring::Uint32List(Roaring::AndNotWithBinary(Roaring::Deserialize(right), NULL)) AS AndNotWithBinaryListEmpty FROM Input;
+
+SELECT Roaring::Uint32List(Roaring::NaiveBulkAnd(AsList(Roaring::FromUint32List(AsList(10, 567, 42)), Roaring::FromUint32List(AsList(42))))) AS NaiveBulkAnd FROM Input;
+SELECT Roaring::Uint32List(Roaring::NaiveBulkAndWithBinary(AsList(right, left))) AS NaiveBulkAndWithBinary FROM Input;

--- a/ydb/library/yql/udfs/common/roaring/test/cases/union.sql
+++ b/ydb/library/yql/udfs/common/roaring/test/cases/union.sql
@@ -1,3 +1,6 @@
 SELECT Roaring::Uint32List(Roaring::Or(Roaring::Deserialize(left), Roaring::Deserialize(right))) AS OrList FROM Input;
 SELECT Roaring::Uint32List(Roaring::OrWithBinary(Roaring::Deserialize(right), left)) AS OrWithBinaryList FROM Input;
 
+SELECT Roaring::Uint32List(Roaring::Or(Roaring::Deserialize(left), Roaring::Deserialize(right), true)) AS OrListInplace FROM Input;
+SELECT Roaring::Uint32List(Roaring::OrWithBinary(Roaring::Deserialize(right), left, true)) AS OrWithBinaryListInplace FROM Input;
+


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

Introduce NaiveBulkAnd and NaiveBulkAndWithBinary operations
Intersection of bitmaps performed finding smallest bitmap first, and then intersecting others bitmap with it
Smallest bitmap is always copied, as there's no way to ensure that modifying it state will not interfere with other data (item can be used in another part of the query)

### Changelog category <!-- remove all except one -->

* Performance improvement

### Description for reviewers <!-- (optional) description for those who read this PR -->

Findind smallest bitmap does not use cardinality to find smallest bitmap. Instead it counts number of containers that Roaring uses to store bitmap. This way CPU intensive calculation of cardinality is skipped, but it is still a good approximation to finding smallest bitmap to produce result