### PR TITLE
Refactor ydb cli options

### DIFF
--- a/ydb/apps/ydb/CHANGELOG.md
+++ b/ydb/apps/ydb/CHANGELOG.md
@@ -1,3 +1,4 @@
+* YDB CLI help message improvements. Different display for detailed help and brief help.
 * Support coordination nodes in `ydb scheme rmdir --recursive`.
 * Fixed return code of command `ydb workload * run --check-canonical` for the case when benchmark query results differ from canonical ones.
 

--- a/ydb/apps/ydb/commands/ydb_root.cpp
+++ b/ydb/apps/ydb/commands/ydb_root.cpp
@@ -45,6 +45,10 @@ void TClientCommandRoot::SetCredentialsGetter(TConfig& config) {
             if (config.UseMetadataCredentials) {
                 return CreateIamCredentialsProviderFactory();
             }
+            if (config.SaKeyParams) {
+                return CreateIamJwtParamsCredentialsProviderFactory(
+                    { {.Endpoint = config.IamEndpoint}, config.SaKeyParams });
+            }
             if (config.SaKeyFile) {
                 return CreateIamJwtFileCredentialsProviderFactory(
                     { {.Endpoint = config.IamEndpoint}, config.SaKeyFile });
@@ -77,8 +81,7 @@ namespace {
 void TYdbClientCommandRoot::Config(TConfig& config) {
     TClientCommandRoot::Config(config);
 
-    NLastGetopt::TOpts& opts = *config.Opts;
-    RemoveOption(opts, "svnrevision");
+    RemoveOption(config.Opts->GetOpts(), "svnrevision");
 }
 
 int TYdbClientCommandRoot::Run(TConfig& config) {

--- a/ydb/apps/ydb/ut/parse_command_line.cpp
+++ b/ydb/apps/ydb/ut/parse_command_line.cpp
@@ -525,17 +525,16 @@ Y_UNIT_TEST_SUITE(ParseOptionsTest) {
             {"YDB_PASSWORD", "pwd"},
         });
 
-        // TODO: make these options mutually exclusive
-        // ExpectFail();
-        // RunCli({
-        //     "-v",
-        //     "-e", GetEndpoint(),
-        //     "-d", GetDatabase(),
-        //     "--user", "test-user",
-        //     "--no-password",
-        //     "--password-file", passwordFile,
-        //     "scheme", "ls",
-        // });
+        ExpectFail();
+        RunCli({
+            "-v",
+            "-e", GetEndpoint(),
+            "-d", GetDatabase(),
+            "--user", "test-user",
+            "--no-password",
+            "--password-file", passwordFile,
+            "scheme", "ls",
+        });
 
         TString profile = fmt::format(R"yaml(
         profiles:
@@ -636,18 +635,16 @@ Y_UNIT_TEST_SUITE(ParseOptionsTest) {
         {},
         profile);
 
-        // TODO: validate that there is no ambiguity in setting passwords
-        // ExpectFail();
-        // RunCli({
-        //     "-v",
-        //     "-p", "test_profile_with_both_passwords",
-        //     "scheme", "ls",
-        // },
-        // {},
-        // profile);
+        ExpectFail();
+        RunCli({
+            "-v",
+            "-p", "test_profile_with_both_passwords",
+            "scheme", "ls",
+        },
+        {},
+        profile);
 
-        // TODO: Fix this case
-        //ExpectUserAndPassword("user_no_password", "", "no-password-token");
+        ExpectUserAndPassword("user_no_password", "", "no-password-token");
         RunCli({
             "-v",
             "-p", "test_profile_without_password",

--- a/ydb/core/driver_lib/cli_base/cli_cmds_db.cpp
+++ b/ydb/core/driver_lib/cli_base/cli_cmds_db.cpp
@@ -131,7 +131,7 @@ public:
     virtual void Config(TConfig& config) override {
         TClientCommand::Config(config);
         ReturnTxId = false;
-        config.Opts->AddLongOption('t', "txid", "Print TxId").NoArgument().SetFlag(&ReturnTxId);
+        config.Opts->AddLongOption('t', "txid", "Print TxId").StoreTrue(&ReturnTxId);
         config.SetFreeArgsNum(1);
         SetFreeArgTitle(0, "<SCHEMA-PROTO>", "Schema protobuf or file with schema protobuf");
     }
@@ -205,14 +205,14 @@ public:
         Boundaries = false;
         config.SetFreeArgsNum(1);
         SetFreeArgTitle(0, "<PATH>", "Schema path or pathId (e.g. 72075186232623600/1225)");
-        config.Opts->AddLongOption('t', "tree", "Show schema path tree").NoArgument().SetFlag(&Tree);
-        config.Opts->AddLongOption('d', "details", "Show detailed information (like columns in a table)").NoArgument().SetFlag(&Details);
-        config.Opts->AddLongOption('a', "acl", "Show owner and acl information").NoArgument().SetFlag(&AccessRights);
-        config.Opts->AddLongOption('e', "effacl", "Show effective acl information").NoArgument().SetFlag(&AccessRightsEffective);
-        config.Opts->AddLongOption('b', "backup", "Show backup information").NoArgument().SetFlag(&BackupInfo);
-        config.Opts->AddLongOption('P', "protobuf", "Debug print all info as is").NoArgument().SetFlag(&Protobuf);
-        config.Opts->AddLongOption('s', "stats", "Return partition stats").NoArgument().SetFlag(&PartitionStats);
-        config.Opts->AddLongOption("boundaries", "Return boundaries").NoArgument().SetFlag(&Boundaries);
+        config.Opts->AddLongOption('t', "tree", "Show schema path tree").StoreTrue(&Tree);
+        config.Opts->AddLongOption('d', "details", "Show detailed information (like columns in a table)").StoreTrue(&Details);
+        config.Opts->AddLongOption('a', "acl", "Show owner and acl information").StoreTrue(&AccessRights);
+        config.Opts->AddLongOption('e', "effacl", "Show effective acl information").StoreTrue(&AccessRightsEffective);
+        config.Opts->AddLongOption('b', "backup", "Show backup information").StoreTrue(&BackupInfo);
+        config.Opts->AddLongOption('P', "protobuf", "Debug print all info as is").StoreTrue(&Protobuf);
+        config.Opts->AddLongOption('s', "stats", "Return partition stats").StoreTrue(&PartitionStats);
+        config.Opts->AddLongOption("boundaries", "Return boundaries").StoreTrue(&Boundaries);
     }
 
     virtual void Parse(TConfig& config) override {
@@ -581,8 +581,8 @@ public:
         SetFreeArgTitle(0, "<USER>", "User");
         SetFreeArgTitle(1, "<PATH>", "Full pathname of an object (e.g. /ru/home/user/mydb/test1/test2).\n"
             "          Or short pathname if profile path is set (e.g. test1/test2).");
-        config.Opts->AddLongOption('R', "recursive", "Change owner on schema objects recursively").NoArgument().SetFlag(&Recursive);
-        config.Opts->AddLongOption('v', "verbose", "Verbose output").NoArgument().SetFlag(&Verbose);
+        config.Opts->AddLongOption('R', "recursive", "Change owner on schema objects recursively").StoreTrue(&Recursive);
+        config.Opts->AddLongOption('v', "verbose", "Verbose output").StoreTrue(&Verbose);
     }
 
     TString Owner;
@@ -1318,7 +1318,7 @@ public:
         config.SetFreeArgsNum(1, 2);
         SetFreeArgTitle(0, "<MINIKQL>", "Text MiniKQL");
         SetFreeArgTitle(1, "<PARAMS>", "Text MiniKQL parameters");
-        config.Opts->AddLongOption('p', "proto", "MiniKQL parameters are in protobuf format").NoArgument().SetFlag(&Proto);
+        config.Opts->AddLongOption('p', "proto", "MiniKQL parameters are in protobuf format").StoreTrue(&Proto);
     }
 
     virtual void Parse(TConfig& config) override {

--- a/ydb/core/driver_lib/cli_base/cli_cmds_root.cpp
+++ b/ydb/core/driver_lib/cli_base/cli_cmds_root.cpp
@@ -58,7 +58,7 @@ void TClientCommandRootKikimrBase::Config(TConfig& config) {
     NColorizer::TColors colors = NColorizer::AutoColors(Cout);
     stream << " -s <[protocol://]host[:port]> [options] <subcommand>" << Endl << Endl
         << colors.BoldColor() << "Subcommands" << colors.OldColor() << ":" << Endl;
-    RenderCommandsDescription(stream, colors);
+    RenderCommandDescription(stream, config.HelpCommandVerbosiltyLevel > 1, colors);
     opts.SetCmdLineDescr(stream.Str());
 }
 

--- a/ydb/core/driver_lib/cli_base/cli_cmds_root.cpp
+++ b/ydb/core/driver_lib/cli_base/cli_cmds_root.cpp
@@ -18,7 +18,7 @@ TClientCommandRootKikimrBase::TClientCommandRootKikimrBase(const TString& name)
 
 void TClientCommandRootKikimrBase::Config(TConfig& config) {
     TClientCommandRootBase::Config(config);
-    NLastGetopt::TOpts& opts = *config.Opts;
+    NLastGetopt::TOpts& opts = config.Opts->GetOpts();
     opts.AddLongOption('d', "dump", "Dump requests to error log").NoArgument().Hidden().SetFlag(&DumpRequests);
 
     TStringBuilder tokenHelp;

--- a/ydb/core/driver_lib/cli_utils/cli_cmds_cms.cpp
+++ b/ydb/core/driver_lib/cli_utils/cli_cmds_cms.cpp
@@ -207,7 +207,7 @@ public:
         } else {
             config.SetFreeArgsNum(0);
         }
-        config.Opts->AddLongOption("dry", "Dry run").NoArgument().SetFlag(&DryRun);
+        config.Opts->AddLongOption("dry", "Dry run").StoreTrue(&DryRun);
     }
 
     void Parse(TConfig& config) override
@@ -278,7 +278,7 @@ public:
             .RequiredArgument("NAME").StoreResult(&User);
         config.SetFreeArgsNum(1);
         SetFreeArgTitle(0, "<ID>", "Request ID");
-        config.Opts->AddLongOption("dry", "Dry run").NoArgument().SetFlag(&DryRun);
+        config.Opts->AddLongOption("dry", "Dry run").StoreTrue(&DryRun);
     }
 
     void Parse(TConfig& config) override
@@ -334,7 +334,7 @@ public:
             config.Opts->AddLongOption("duration", "Action duration in minutes")
                 .Required().RequiredArgument("NUM").StoreResult(&Duration);
         config.SetFreeArgsMin(1);
-        config.Opts->SetFreeArgDefaultTitle("<NAME>", FreeArgDescr(FreeArgField));
+        config.Opts->GetOpts().SetFreeArgDefaultTitle("<NAME>", FreeArgDescr(FreeArgField));
     }
 
     void Parse(TConfig& config) override
@@ -440,11 +440,11 @@ public:
 
         config.Opts->AddLongOption("user", "User name").Required()
             .RequiredArgument("NAME").StoreResult(&User);
-        config.Opts->AddLongOption("dry", "Dry run").NoArgument().SetFlag(&DryRun);
+        config.Opts->AddLongOption("dry", "Dry run").StoreTrue(&DryRun);
         config.Opts->AddLongOption("reason", "Informational request description")
             .RequiredArgument("STRING").StoreResult(&Reason);
         config.Opts->AddLongOption("schedule", "Schedule action in CMS if it's disallowed right now")
-            .NoArgument().SetFlag(&Schedule);
+            .StoreTrue(&Schedule);
         config.Opts->AddLongOption("hours", "Permission duration")
             .RequiredArgument("NUM").StoreResult(&Hours);
         config.Opts->AddLongOption("minutes", "Permission duration")
@@ -452,14 +452,14 @@ public:
         config.Opts->AddLongOption("tenant-policy", "Policy for computation node restart")
             .RequiredArgument("none|default").StoreResult(&TenantPolicy);
         config.Opts->AddLongOption("allow-partial", "Allow partial permission")
-            .NoArgument().SetFlag(&AllowPartial);
+            .StoreTrue(&AllowPartial);
         config.Opts->AddLongOption("availability-mode", "Availability mode")
             .RequiredArgument("max|keep|force").DefaultValue("max").StoreResult(&AvailabilityMode);
         config.Opts->AddLongOption("evict-vdisks", "Evict vdisks before granting permission(s)")
-            .NoArgument().SetFlag(&EvictVDisks);
+            .StoreTrue(&EvictVDisks);
         config.Opts->AddLongOption("priority", "Request priority")
             .RequiredArgument("NUM").StoreResult(&Priority);
-            
+
     }
 
     void Parse(TConfig& config) override
@@ -718,7 +718,7 @@ public:
         } else {
             config.SetFreeArgsNum(0);
         }
-        config.Opts->AddLongOption("dry", "Dry run").NoArgument().SetFlag(&DryRun);
+        config.Opts->AddLongOption("dry", "Dry run").StoreTrue(&DryRun);
     }
 
     void Parse(TConfig& config) override
@@ -846,7 +846,7 @@ public:
             config.Opts->AddLongOption("minutes", "New permission duration")
                 .RequiredArgument("NUM").StoreResult(&Minutes);
         }
-        config.Opts->AddLongOption("dry", "Dry run").NoArgument().SetFlag(&DryRun);
+        config.Opts->AddLongOption("dry", "Dry run").StoreTrue(&DryRun);
     }
 
     void Parse(TConfig& config) override

--- a/ydb/core/driver_lib/cli_utils/cli_cmds_config.cpp
+++ b/ydb/core/driver_lib/cli_utils/cli_cmds_config.cpp
@@ -95,8 +95,7 @@ public:
 
         config.Opts->AddLongOption('n', "dry-run", "do not apply updates")
             .Optional()
-            .NoArgument()
-            .SetFlag(&DryRun);
+            .StoreTrue(&DryRun);
     }
 
     int Run(TConfig& config) override {
@@ -180,8 +179,7 @@ public:
 
         config.Opts->AddLongOption('n', "dry-run", "do not apply updates")
             .Optional()
-            .NoArgument()
-            .SetFlag(&DryRun);
+            .StoreTrue(&DryRun);
     }
 
     int Run(TConfig& config) override {

--- a/ydb/core/driver_lib/cli_utils/cli_cmds_console.cpp
+++ b/ydb/core/driver_lib/cli_utils/cli_cmds_console.cpp
@@ -195,7 +195,7 @@ public:
     virtual void Config(TConfig& config) override {
         TConsoleClientCommand::Config(config);
         config.Opts->AddLongOption("dry-run", "Execute configure request in dry-run mode")
-            .NoArgument().SetFlag(&DryRun);
+            .StoreTrue(&DryRun);
         config.Opts->AddLongOption("out-dir", "Output affected configs into specified directory")
             .RequiredArgument("PATH").StoreResult(&OutDir);
         config.SetFreeArgsNum(1);
@@ -525,10 +525,10 @@ public:
     virtual void Config(TConfig& config) override {
         TConsoleClientCommand::Config(config);
         config.Opts->AddLongOption("merge", "Merge provided config with the current one")
-            .NoArgument().SetFlag(&Merge);
+            .StoreTrue(&Merge);
         config.Opts->AddLongOption("merge-overwrite-repeated", "Merge provided config with the current one"
                                    " but overwrite those repeated field which are not empty in provided config")
-            .NoArgument().SetFlag(&MergeOverwriteRepeated);
+            .StoreTrue(&MergeOverwriteRepeated);
         config.SetFreeArgsNum(1);
         SetFreeArgTitle(0, "<CONFIG-PROTO>", "Console config protobuf or file with protobuf");
     }

--- a/ydb/core/driver_lib/cli_utils/cli_cmds_disk.cpp
+++ b/ydb/core/driver_lib/cli_utils/cli_cmds_disk.cpp
@@ -29,19 +29,19 @@ public:
             .Optional().AppendTo(&MainKeyTmp); // TODO: make required
         config.Opts->AddLongOption("master-key", "obsolete: use main-key").RequiredArgument("NUM")
             .Optional().AppendTo(&MainKeyTmp); // TODO: remove after migration
-        config.Opts->AddLongOption('v', "verbose", "output detailed information for debugging").Optional().NoArgument()
-            .SetFlag(&IsVerbose);
-        config.Opts->AddLongOption('l', "lock", "lock device before reading disk info").Optional().NoArgument()
-            .SetFlag(&LockDevice);
+        config.Opts->AddLongOption('v', "verbose", "output detailed information for debugging").Optional()
+            .StoreTrue(&IsVerbose);
+        config.Opts->AddLongOption('l', "lock", "lock device before reading disk info").Optional()
+            .StoreTrue(&LockDevice);
     }
 
     virtual void Parse(TConfig& config) override {
         TClientCommand::Parse(config);
         Path = config.ParseResult->GetFreeArgs()[0];
         // TODO: remove after master->main key migration
-        bool hasMainOption = config.ParseResult->FindLongOptParseResult("main-key");
-        bool hasMasterOption = config.ParseResult->FindLongOptParseResult("master-key");
-        bool hasKOption = config.ParseResult->FindCharOptParseResult('k');
+        bool hasMainOption = config.ParseResult->Has("main-key");
+        bool hasMasterOption = config.ParseResult->Has("master-key");
+        bool hasKOption = config.ParseResult->Has('k');
         if (!hasMainOption && !hasMasterOption && !hasKOption)
             ythrow yexception() << "missing main-key param";
 
@@ -148,7 +148,7 @@ public:
         config.Opts->AddLongOption('t', "text-message", "text message to store in format sector (up to 4000 characters long)")
             .OptionalArgument("STR").Optional().StoreResult(&TextMessage);
         config.Opts->AddLongOption('e', "erasure-encode", "erasure-encode data to recover from single-sector failures")
-            .Optional().NoArgument().SetFlag(&IsErasureEncode);
+            .Optional().StoreTrue(&IsErasureEncode);
 
         config.Opts->SetCmdLineDescr("\n\n"
             "Kikimr was designed to work with large block-devices, like 4 TiB HDDs and 1 TiB SSDs\n"
@@ -167,9 +167,9 @@ public:
         SafeEntropyPoolRead(&ChunkKey, sizeof(NKikimr::NPDisk::TKey));
         SafeEntropyPoolRead(&LogKey, sizeof(NKikimr::NPDisk::TKey));
         SafeEntropyPoolRead(&SysLogKey, sizeof(NKikimr::NPDisk::TKey));
-        bool hasMainOption = config.ParseResult->FindLongOptParseResult("main-key");
-        bool hasMasterOption = config.ParseResult->FindLongOptParseResult("master-key");
-        bool hasKOption = config.ParseResult->FindCharOptParseResult('k');
+        bool hasMainOption = config.ParseResult->Has("main-key");
+        bool hasMasterOption = config.ParseResult->Has("master-key");
+        bool hasKOption = config.ParseResult->Has('k');
         if (!hasMainOption && !hasMasterOption && !hasKOption)
             ythrow yexception() << "missing main-key param";
 

--- a/ydb/core/driver_lib/cli_utils/cli_cmds_root.cpp
+++ b/ydb/core/driver_lib/cli_utils/cli_cmds_root.cpp
@@ -31,8 +31,8 @@ public:
     }
 
     void Config(TConfig& config) override {
-        NLastGetopt::TOpts& opts = *config.Opts;
-        HideOptions(*config.Opts);
+        TClientCommandOptions& opts = *config.Opts;
+        HideOptions(config.Opts->GetOpts());
         opts.AddLongOption('k', "token", "security token").RequiredArgument("TOKEN").StoreResult(&Token);
         opts.AddLongOption('s', "server", "server address to connect")
             .RequiredArgument("HOST[:PORT]").StoreResult(&Address);

--- a/ydb/core/driver_lib/cli_utils/cli_cmds_root.cpp
+++ b/ydb/core/driver_lib/cli_utils/cli_cmds_root.cpp
@@ -83,7 +83,7 @@ TString NewClientCommandsDescription(const TString& name, std::shared_ptr<TModul
     NColorizer::TColors colors = NColorizer::AutoColors(Cout);
     stream << " [options] <subcommand>" << Endl << Endl
         << colors.BoldColor() << "Subcommands" << colors.OldColor() << ":" << Endl;
-    commandsRoot->RenderCommandsDescription(stream, colors);
+    commandsRoot->RenderCommandDescription(stream, false, colors);
     return stream.Str();
 }
 

--- a/ydb/core/driver_lib/cli_utils/cli_cmds_server.cpp
+++ b/ydb/core/driver_lib/cli_utils/cli_cmds_server.cpp
@@ -55,16 +55,16 @@ void TClientCommandServer::Config(TConfig& config) {
     TClientCommand::Config(config);
 
     NConfig::AddProtoConfigOptions(DepsRecorder->GetDeps().ProtoConfigFileProvider);
-    InitCfg.RegisterCliOptions(*config.Opts);
-    ProtoConfigFileProvider->RegisterCliOptions(*config.Opts);
+    InitCfg.RegisterCliOptions(config.Opts->GetOpts());
+    ProtoConfigFileProvider->RegisterCliOptions(config.Opts->GetOpts());
     config.SetFreeArgsMin(0);
 
-    config.Opts->AddHelpOption('h');
+    config.Opts->GetOpts().AddHelpOption('h');
 }
 
 void TClientCommandServer::Parse(TConfig& config) {
     TClientCommand::Parse(config);
-    InitCfg.ValidateOptions(*config.Opts, *config.ParseResult);
+    InitCfg.ValidateOptions(config.Opts->GetOpts(), config.ParseResult->GetCommandLineParseResult());
     InitCfg.Parse(config.ParseResult->GetFreeArgs(), Factories->ConfigSwissKnife.get());
 }
 

--- a/ydb/core/driver_lib/cli_utils/cli_cmds_tenant.cpp
+++ b/ydb/core/driver_lib/cli_utils/cli_cmds_tenant.cpp
@@ -363,7 +363,7 @@ public:
         config.Opts->AddLongOption("serverless", "Create a serverless database (free arg must specify shared database for resources)")
             .NoArgument().StoreTrue(&Serverless);
         config.SetFreeArgsMin(1);
-        config.Opts->SetFreeArgDefaultTitle("<pool type>:<pool size>", "Pairs describing storage pool type and size (number of groups).");
+        config.Opts->GetOpts().SetFreeArgDefaultTitle("<pool type>:<pool size>", "Pairs describing storage pool type and size (number of groups).");
     }
 
     void Parse(TConfig& config) override
@@ -427,7 +427,7 @@ public:
     {
         TTenantClientGRpcCommand::Config(config);
         config.Opts->AddLongOption("force", "Force command execution")
-            .NoArgument().SetFlag(&Force);
+            .StoreTrue(&Force);
     }
 
     void Parse(TConfig& config) override
@@ -465,7 +465,7 @@ public:
     void Config(TConfig& config) override {
         TTenantClientGRpcCommand::Config(config);
         config.SetFreeArgsMin(0);
-        config.Opts->SetFreeArgDefaultTitle("[[<availability zone>:]<unit kind>:]<units count>", "Triples describing units.");
+        config.Opts->GetOpts().SetFreeArgDefaultTitle("[[<availability zone>:]<unit kind>:]<units count>", "Triples describing units.");
     }
 
     void Parse(TConfig& config) override
@@ -500,7 +500,7 @@ public:
     void Config(TConfig& config) override {
         TTenantClientGRpcCommand::Config(config);
         config.SetFreeArgsMin(0);
-        config.Opts->SetFreeArgDefaultTitle("[[<availability zone>:]<unit kind>:]<units count>", "Triples describing units.");
+        config.Opts->GetOpts().SetFreeArgDefaultTitle("[[<availability zone>:]<unit kind>:]<units count>", "Triples describing units.");
     }
 
     void Parse(TConfig& config) override
@@ -535,7 +535,7 @@ public:
     void Config(TConfig& config) override {
         TTenantClientGRpcCommand::Config(config);
         config.SetFreeArgsMin(0);
-        config.Opts->SetFreeArgDefaultTitle("<host>:<port>:<kind>", "Triples describing registered units.");
+        config.Opts->GetOpts().SetFreeArgDefaultTitle("<host>:<port>:<kind>", "Triples describing registered units.");
     }
 
     void Parse(TConfig& config) override
@@ -576,7 +576,7 @@ public:
     void Config(TConfig& config) override {
         TTenantClientGRpcCommand::Config(config);
         config.SetFreeArgsMin(0);
-        config.Opts->SetFreeArgDefaultTitle("<host>:<port>", "Pairs describing deregistered units.");
+        config.Opts->GetOpts().SetFreeArgDefaultTitle("<host>:<port>", "Pairs describing deregistered units.");
     }
 
     void Parse(TConfig& config) override
@@ -615,7 +615,7 @@ public:
     void Config(TConfig& config) override {
         TTenantClientGRpcCommand::Config(config);
         config.SetFreeArgsMin(1);
-        config.Opts->SetFreeArgDefaultTitle("<pool kind>:<pool size>", "Pairs describing storage pool type and size (number of groups).");
+        config.Opts->GetOpts().SetFreeArgDefaultTitle("<pool kind>:<pool size>", "Pairs describing storage pool type and size (number of groups).");
     }
 
     void Parse(TConfig& config) override

--- a/ydb/core/kqp/tests/tpch/cmd_prepare_scheme.cpp
+++ b/ydb/core/kqp/tests/tpch/cmd_prepare_scheme.cpp
@@ -14,7 +14,7 @@ void TCommandPrepareScheme::Config(TConfig& config) {
     config.Opts->AddLongOption('p', "partitions", "Uniform partitions count in comma-separated key=value format.\n"
                                                   "Ex.: -p nation=1,lineitem=10,...")
         .Optional()
-        .Handler1T<TStringBuf>([this](TStringBuf opt) {
+        .Handler([this](const TString& opt) {
             for (TStringBuf kv : StringSplitter(opt).Split(',').SkipEmpty()) {
                 TStringBuf table, partitions;
                 kv.Split('=', table, partitions);

--- a/ydb/core/kqp/tests/tpch/cmd_run_bench.cpp
+++ b/ydb/core/kqp/tests/tpch/cmd_run_bench.cpp
@@ -218,7 +218,7 @@ void TCommandRunBenchmark::Config(TConfig& config) {
     }
     config.Opts->AddLongOption('i', "include", "Run only specified queries (ex.: 1,2,3,5-10,20)")
         .Optional()
-        .Handler1T<TStringBuf>([this, fillTestCases](TStringBuf line) {
+        .Handler([this, fillTestCases](const TString& line) {
             TestCases.clear();
             fillTestCases(line, [this](ui32 q) {
                 TestCases.insert(q);
@@ -226,7 +226,7 @@ void TCommandRunBenchmark::Config(TConfig& config) {
         });
     config.Opts->AddLongOption('e', "exclude", "Run all queries except given onces (ex.: 1,2,3,5-10,20)")
         .Optional()
-        .Handler1T<TStringBuf>([this, fillTestCases](TStringBuf line) {
+        .Handler([this, fillTestCases](const TString& line) {
             fillTestCases(line, [this](ui32 q) {
                 TestCases.erase(q);
             });

--- a/ydb/core/kqp/tests/tpch/cmd_run_query.cpp
+++ b/ydb/core/kqp/tests/tpch/cmd_run_query.cpp
@@ -14,7 +14,7 @@ void TCommandRunQuery::Config(TConfig& config){
     config.Opts->AddLongOption('p', "profile", "Execute query with enabled profiling mode and save profile to this file")
         .StoreResult(&Profile);
     config.SetFreeArgsNum(1);
-    config.Opts->SetFreeArgDefaultTitle("Query number (1-22)");
+    config.Opts->GetOpts().SetFreeArgDefaultTitle("Query number (1-22)");
 }
 
 int TCommandRunQuery::Run(TConfig& config){

--- a/ydb/core/kqp/tests/tpch/commands.cpp
+++ b/ydb/core/kqp/tests/tpch/commands.cpp
@@ -32,7 +32,7 @@ void TClientCommandTpchRoot::Config(TConfig& config) {
         .StoreResult(&Database);
     config.Opts->AddLongOption('p', "path", "Path to TPC-H tables (relative)")
         .Required()
-        .Handler1T<TStringBuf>([this](TStringBuf arg) {
+        .Handler([this](const TString& arg) {
             if (arg.StartsWith('/')) {
                 ythrow NLastGetopt::TUsageException() << "Path must be relative";
             }

--- a/ydb/core/kqp/tests/tpch/commands.cpp
+++ b/ydb/core/kqp/tests/tpch/commands.cpp
@@ -44,7 +44,7 @@ void TClientCommandTpchRoot::Config(TConfig& config) {
     NColorizer::TColors colors = NColorizer::AutoColors(Cout);
     stream << " [options...] <subcommand>" << Endl << Endl
            << colors.BoldColor() << "Subcommands" << colors.OldColor() << ":" << Endl;
-    RenderCommandsDescription(stream, colors);
+    RenderCommandDescription(stream, config.HelpCommandVerbosiltyLevel > 1, colors);
     config.Opts->SetCmdLineDescr(stream.Str());
 }
 

--- a/ydb/public/lib/ydb_cli/commands/topic_workload/topic_workload_run_full.cpp
+++ b/ydb/public/lib/ydb_cli/commands/topic_workload/topic_workload_run_full.cpp
@@ -64,17 +64,17 @@ void TCommandWorkloadTopicRunFull::Config(TConfig& config)
         .StoreResult(&Scenario.ConsumerCount);
     config.Opts->AddLongOption('m', "message-size", "Message size.")
         .DefaultValue(10_KB)
-        .StoreMappedResultT<TString>(&Scenario.MessageSizeBytes, &TCommandWorkloadTopicParams::StrToBytes);
+        .StoreMappedResult(&Scenario.MessageSizeBytes, &TCommandWorkloadTopicParams::StrToBytes);
     config.Opts->AddLongOption("message-rate", "Total message rate for all producer threads (messages per second). Exclusive with --byte-rate.")
         .DefaultValue(0)
         .StoreResult(&Scenario.MessagesPerSec);
     config.Opts->AddLongOption("byte-rate", "Total message rate for all producer threads (bytes per second). Exclusive with --message-rate.")
         .DefaultValue(0)
-        .StoreMappedResultT<TString>(&Scenario.BytesPerSec, &TCommandWorkloadTopicParams::StrToBytes);
+        .StoreMappedResult(&Scenario.BytesPerSec, &TCommandWorkloadTopicParams::StrToBytes);
     config.Opts->AddLongOption("codec", PrepareAllowedCodecsDescription("Client-side compression algorithm. When read, data will be uncompressed transparently with a codec used on write", InitAllowedCodecs()))
         .Optional()
         .DefaultValue((TStringBuilder() << NTopic::ECodec::RAW))
-        .StoreMappedResultT<TString>(&Scenario.Codec, &TCommandWorkloadTopicParams::StrToCodec);
+        .StoreMappedResult(&Scenario.Codec, &TCommandWorkloadTopicParams::StrToCodec);
     config.Opts->AddLongOption("direct", "Direct write to a partition node.")
         .Hidden()
         .StoreTrue(&Scenario.Direct);
@@ -92,7 +92,7 @@ void TCommandWorkloadTopicRunFull::Config(TConfig& config)
                                                             " Both tx-commit-messages and tx-commit-interval can trigger transaction commit.")
         .DefaultValue(1000)
         .StoreResult(&Scenario.TxCommitIntervalMs);
-    config.Opts->AddLongOption("tx-commit-messages", "Number of messages to commit transaction. " 
+    config.Opts->AddLongOption("tx-commit-messages", "Number of messages to commit transaction. "
                                                             " Both tx-commit-messages and tx-commit-interval can trigger transaction commit.")
         .DefaultValue(1'000'000)
         .StoreResult(&Scenario.CommitMessages);
@@ -109,7 +109,7 @@ void TCommandWorkloadTopicRunFull::Config(TConfig& config)
 }
 
 void TCommandWorkloadTopicRunFull::Parse(TConfig& config)
-{   
+{
     TClientCommand::Parse(config);
 
     Scenario.EnsurePercentileIsValid();

--- a/ydb/public/lib/ydb_cli/commands/topic_workload/topic_workload_run_write.cpp
+++ b/ydb/public/lib/ydb_cli/commands/topic_workload/topic_workload_run_write.cpp
@@ -55,17 +55,17 @@ void TCommandWorkloadTopicRunWrite::Config(TConfig& config)
         .StoreTrue(&Scenario.UseCpuTimestamp);
     config.Opts->AddLongOption('m', "message-size", "Message size.")
         .DefaultValue(10_KB)
-        .StoreMappedResultT<TString>(&Scenario.MessageSizeBytes, &TCommandWorkloadTopicParams::StrToBytes);
+        .StoreMappedResult(&Scenario.MessageSizeBytes, &TCommandWorkloadTopicParams::StrToBytes);
     config.Opts->AddLongOption("message-rate", "Total message rate for all producer threads (messages per second). Exclusive with --byte-rate.")
         .DefaultValue(0)
         .StoreResult(&Scenario.MessagesPerSec);
     config.Opts->AddLongOption("byte-rate", "Total message rate for all producer threads (bytes per second). Exclusive with --message-rate.")
         .DefaultValue(0)
-        .StoreMappedResultT<TString>(&Scenario.BytesPerSec, &TCommandWorkloadTopicParams::StrToBytes);
+        .StoreMappedResult(&Scenario.BytesPerSec, &TCommandWorkloadTopicParams::StrToBytes);
     config.Opts->AddLongOption("codec", PrepareAllowedCodecsDescription("Client-side compression algorithm. When read, data will be uncompressed transparently with a codec used on write", InitAllowedCodecs()))
         .Optional()
         .DefaultValue((TStringBuilder() << NTopic::ECodec::RAW))
-        .StoreMappedResultT<TString>(&Scenario.Codec, &TCommandWorkloadTopicParams::StrToCodec);
+        .StoreMappedResult(&Scenario.Codec, &TCommandWorkloadTopicParams::StrToCodec);
     config.Opts->AddLongOption("direct", "Direct write to a partition node.")
         .Hidden()
         .StoreTrue(&Scenario.Direct);
@@ -91,7 +91,7 @@ void TCommandWorkloadTopicRunWrite::Config(TConfig& config)
         .DefaultValue(1'000'000)
         .Hidden()
         .StoreResult(&Scenario.CommitMessages);
-    config.Opts->AddLongOption("tx-commit-messages", "Number of messages to commit transaction. " 
+    config.Opts->AddLongOption("tx-commit-messages", "Number of messages to commit transaction. "
                                                             " Both tx-commit-messages and tx-commit-interval can trigger transaction commit.")
         .DefaultValue(1'000'000)
         .StoreResult(&Scenario.CommitMessages);
@@ -99,7 +99,7 @@ void TCommandWorkloadTopicRunWrite::Config(TConfig& config)
     config.IsNetworkIntensive = true;
 }
 
-void TCommandWorkloadTopicRunWrite::Parse(TConfig& config) 
+void TCommandWorkloadTopicRunWrite::Parse(TConfig& config)
 {
     TClientCommand::Parse(config);
 

--- a/ydb/public/lib/ydb_cli/commands/transfer_workload/transfer_workload_topic_to_table_run.cpp
+++ b/ydb/public/lib/ydb_cli/commands/transfer_workload/transfer_workload_topic_to_table_run.cpp
@@ -69,17 +69,17 @@ void TCommandWorkloadTransferTopicToTableRun::Config(TConfig& config)
         .StoreResult(&Scenario.ConsumerCount);
     config.Opts->AddLongOption('m', "message-size", "Message size.")
         .DefaultValue(10_KB)
-        .StoreMappedResultT<TString>(&Scenario.MessageSizeBytes, &TCommandWorkloadTopicParams::StrToBytes);
+        .StoreMappedResult(&Scenario.MessageSizeBytes, &TCommandWorkloadTopicParams::StrToBytes);
     config.Opts->AddLongOption("message-rate", "Total message rate for all producer threads (messages per second). Exclusive with --byte-rate.")
         .DefaultValue(0)
         .StoreResult(&Scenario.MessagesPerSec);
     config.Opts->AddLongOption("byte-rate", "Total message rate for all producer threads (bytes per second). Exclusive with --message-rate.")
         .DefaultValue(0)
-        .StoreMappedResultT<TString>(&Scenario.BytesPerSec, &TCommandWorkloadTopicParams::StrToBytes);
+        .StoreMappedResult(&Scenario.BytesPerSec, &TCommandWorkloadTopicParams::StrToBytes);
     config.Opts->AddLongOption("codec", PrepareAllowedCodecsDescription("Client-side compression algorithm. When read, data will be uncompressed transparently with a codec used on write", InitAllowedCodecs()))
         .Optional()
         .DefaultValue((TStringBuilder() << NTopic::ECodec::RAW))
-        .StoreMappedResultT<TString>(&Scenario.Codec, &TCommandWorkloadTopicParams::StrToCodec);
+        .StoreMappedResult(&Scenario.Codec, &TCommandWorkloadTopicParams::StrToCodec);
 
     config.Opts->MutuallyExclusive("message-rate", "byte-rate");
 
@@ -98,7 +98,7 @@ void TCommandWorkloadTransferTopicToTableRun::Config(TConfig& config)
         .DefaultValue(1'000'000)
         .Hidden()
         .StoreResult(&Scenario.CommitMessages);
-    config.Opts->AddLongOption("tx-commit-messages", "Number of messages to commit transaction. " 
+    config.Opts->AddLongOption("tx-commit-messages", "Number of messages to commit transaction. "
                                                             " Both tx-commit-messages and tx-commit-interval can trigger transaction commit.")
         .DefaultValue(1'000'000)
         .StoreResult(&Scenario.CommitMessages);

--- a/ydb/public/lib/ydb_cli/commands/ydb_admin.cpp
+++ b/ydb/public/lib/ydb_cli/commands/ydb_admin.cpp
@@ -37,8 +37,8 @@ public:
     }
 };
 
-TCommandDatabaseDump::TCommandDatabaseDump() 
-    : TYdbReadOnlyCommand("dump", {}, "Dump database into local directory") 
+TCommandDatabaseDump::TCommandDatabaseDump()
+    : TYdbReadOnlyCommand("dump", {}, "Dump database into local directory")
 {}
 
 void TCommandDatabaseDump::Config(TConfig& config) {
@@ -66,8 +66,8 @@ int TCommandDatabaseDump::Run(TConfig& config) {
     return EXIT_SUCCESS;
 }
 
-TCommandDatabaseRestore::TCommandDatabaseRestore() 
-    : TYdbCommand("restore", {}, "Restore database from local dump") 
+TCommandDatabaseRestore::TCommandDatabaseRestore()
+    : TYdbCommand("restore", {}, "Restore database from local dump")
 {}
 
 void TCommandDatabaseRestore::Config(TConfig& config) {
@@ -135,7 +135,7 @@ void TCommandAdmin::Config(TConfig& config) {
     stream << Endl << Endl
         << colors.BoldColor() << "Description" << colors.OldColor() << ": " << Description << Endl << Endl
         << colors.BoldColor() << "Subcommands" << colors.OldColor() << ":" << Endl;
-    RenderCommandsDescription(stream, colors);
+    RenderCommandDescription(stream, config.HelpCommandVerbosiltyLevel > 1, colors);
     stream << Endl;
     PrintParentOptions(stream, config, colors);
     config.Opts->SetCmdLineDescr(stream.Str());

--- a/ydb/public/lib/ydb_cli/commands/ydb_benchmark.cpp
+++ b/ydb/public/lib/ydb_cli/commands/ydb_benchmark.cpp
@@ -60,19 +60,21 @@ void TWorkloadCommandBenchmark::Config(TConfig& config) {
         }
     };
 
-    auto includeOpt = config.Opts->AddLongOption("include",
-        "Run only specified queries (ex.: 0,1,2,3,5-10,20)")
+    auto& includeOpt = config.Opts->AddLongOption("include",
+        "Run only specified queries (ex.: 0,1,2,3,5-10,20)");
+    includeOpt
         .Optional()
-        .Handler1T<TStringBuf>([this, fillTestCases](TStringBuf line) {
+        .GetOpt().Handler1T<TStringBuf>([this, fillTestCases](TStringBuf line) {
             QueriesToRun.clear();
             fillTestCases(line, [this](ui32 q) {
                 QueriesToRun.insert(q);
             });
         });
-    auto excludeOpt = config.Opts->AddLongOption("exclude",
-        "Run all queries except given ones (ex.: 0,1,2,3,5-10,20)")
+    auto& excludeOpt = config.Opts->AddLongOption("exclude",
+        "Run all queries except given ones (ex.: 0,1,2,3,5-10,20)");
+    excludeOpt
         .Optional()
-        .Handler1T<TStringBuf>([this, fillTestCases](TStringBuf line) {
+        .GetOpt().Handler1T<TStringBuf>([this, fillTestCases](TStringBuf line) {
             fillTestCases(line, [this](ui32 q) {
                 QueriesToSkip.emplace(q);
             });
@@ -85,7 +87,7 @@ void TWorkloadCommandBenchmark::Config(TConfig& config) {
             "scan - use scan queries;\n"
             "generic - use generic queries.")
         .DefaultValue(QueryExecuterType)
-        .Handler1T<TStringBuf>([this](TStringBuf arg) {
+        .GetOpt().Handler1T<TStringBuf>([this](TStringBuf arg) {
                 const auto l = to_lower(TString(arg));
                 if (!TryFromString(arg, QueryExecuterType)) {
                     throw yexception() << "Ivalid query executer type: " << arg;

--- a/ydb/public/lib/ydb_cli/commands/ydb_command.cpp
+++ b/ydb/public/lib/ydb_cli/commands/ydb_command.cpp
@@ -58,7 +58,7 @@ TYdbSimpleCommand::TYdbSimpleCommand(const TString& name, const std::initializer
 void TYdbSimpleCommand::Config(TConfig& config) {
     TClientCommand::Config(config);
 
-    NLastGetopt::TOpts& opts = *config.Opts;
+    TClientCommandOptions& opts = *config.Opts;
     opts.AddLongOption("timeout", "Client timeout. There is no point waiting for the result after this long.")
         .RequiredArgument("ms").StoreResult(&ClientTimeout);
 }
@@ -70,7 +70,7 @@ TYdbOperationCommand::TYdbOperationCommand(const TString& name, const std::initi
 void TYdbOperationCommand::Config(TConfig& config) {
     TYdbCommand::Config(config);
 
-    NLastGetopt::TOpts& opts = *config.Opts;
+    TClientCommandOptions& opts = *config.Opts;
     opts.AddLongOption("timeout", "Operation timeout. Operation should be executed on server within this timeout. "
             "There could also be a delay up to 200ms to receive timeout error from server.")
         .RequiredArgument("ms").StoreResult(&OperationTimeout);

--- a/ydb/public/lib/ydb_cli/commands/ydb_dynamic_config.cpp
+++ b/ydb/public/lib/ydb_cli/commands/ydb_dynamic_config.cpp
@@ -81,7 +81,7 @@ void TCommandConfigFetch::Config(TConfig& config) {
     config.Opts->AddLongOption("output-directory", "Directory to save config(s)")
         .RequiredArgument("[directory]").StoreResult(&OutDir);
     config.Opts->AddLongOption("strip-metadata", "Strip metadata from config")
-        .NoArgument().SetFlag(&StripMetadata);
+        .StoreTrue(&StripMetadata);
     config.Opts->AddLongOption("dedicated-storage-section", "Fetch dedicated storage section")
         .StoreTrue(&DedicatedStorageSection);
     config.Opts->AddLongOption("dedicated-cluster-section", "Fetch dedicated cluster section")
@@ -194,13 +194,13 @@ void TCommandConfigReplace::Config(TConfig& config) {
     config.Opts->AddLongOption('f', "filename", "Filename of the file containing configuration")
         .Required().RequiredArgument("[config.yaml]").StoreResult(&Filename);
     config.Opts->AddLongOption("ignore-local-validation", "Ignore local config applicability checks")
-        .NoArgument().SetFlag(&IgnoreCheck);
+        .StoreTrue(&IgnoreCheck);
     config.Opts->AddLongOption("dry-run", "Check config applicability")
-        .NoArgument().SetFlag(&DryRun);
+        .StoreTrue(&DryRun);
     config.Opts->AddLongOption("allow-unknown-fields", "Allow fields not present in config")
-        .NoArgument().SetFlag(&AllowUnknownFields);
+        .StoreTrue(&AllowUnknownFields);
     config.Opts->AddLongOption("force", "Ignore metadata on config replacement")
-        .NoArgument().SetFlag(&Force);
+        .StoreTrue(&Force);
     config.AllowEmptyDatabase = AllowEmptyDatabase;
     config.SetFreeArgsNum(0);
 }
@@ -281,10 +281,10 @@ TCommandConfigResolve::TCommandConfigResolve()
 void TCommandConfigResolve::Config(TConfig& config) {
     TYdbCommand::Config(config);
     config.Opts->AddLongOption("all", "Resolve for all combinations")
-        .NoArgument().SetFlag(&All);
+        .StoreTrue(&All);
     config.Opts->AddLongOption("label", "Labels for this node")
         .Optional().RequiredArgument("[LABEL=VALUE]")
-        .KVHandler([this](TString key, TString val) {
+        .GetOpt().KVHandler([this](TString key, TString val) {
             Labels[key] = val;
         });
     config.Opts->AddLongOption('f', "filename", "Filename of the file containing configuration to resolve")
@@ -294,13 +294,13 @@ void TCommandConfigResolve::Config(TConfig& config) {
     config.Opts->AddLongOption("output-directory", "Directory to save config(s)")
         .Optional().RequiredArgument("[directory]").StoreResult(&OutDir);
     config.Opts->AddLongOption("from-cluster", "Fetch current config from cluster instead of the local file")
-        .NoArgument().SetFlag(&FromCluster);
+        .StoreTrue(&FromCluster);
     config.Opts->AddLongOption("remote-resolve", "Use resolver on cluster instead of built-in resolver")
-        .NoArgument().SetFlag(&RemoteResolve);
+        .StoreTrue(&RemoteResolve);
     config.Opts->AddLongOption("node-id", "Take labels from node with the specified id")
         .Optional().RequiredArgument("[node]").StoreResult(&NodeId);
     config.Opts->AddLongOption("skip-volatile", "Ignore volatile configs")
-        .NoArgument().SetFlag(&SkipVolatile);
+        .StoreTrue(&SkipVolatile);
     config.SetFreeArgsNum(0);
 }
 
@@ -558,9 +558,9 @@ void TCommandConfigVolatileAdd::Config(TConfig& config) {
     config.Opts->AddLongOption('f', "filename", "filename to set")
         .Required().RequiredArgument("[config.yaml]").StoreResult(&Filename);
     config.Opts->AddLongOption("ignore-local-validation", "Ignore local config applicability checks")
-        .NoArgument().SetFlag(&IgnoreCheck);
+        .StoreTrue(&IgnoreCheck);
     config.Opts->AddLongOption("dry-run", "Check config applicability")
-        .NoArgument().SetFlag(&DryRun);
+        .StoreTrue(&DryRun);
     config.SetFreeArgsNum(0);
 
 }
@@ -619,7 +619,7 @@ void TCommandConfigVolatileDrop::Config(TConfig& config) {
         .Optional().RequiredArgument("[ui64]")
         .InsertTo(&Ids);
     config.Opts->AddLongOption("all", "Remove all volatile configs")
-        .NoArgument().SetFlag(&All);
+        .StoreTrue(&All);
     config.Opts->AddLongOption('f', "filename", "Filename of the file containing configuration to remove")
         .RequiredArgument("[String]").DefaultValue("").StoreResult(&Filename);
     config.Opts->AddLongOption("cluster", "Cluster name")
@@ -627,7 +627,7 @@ void TCommandConfigVolatileDrop::Config(TConfig& config) {
     config.Opts->AddLongOption("version", "Config version")
         .RequiredArgument("[ui64]").StoreResult(&Version);
     config.Opts->AddLongOption("force", "Ignore version and cluster check")
-        .NoArgument().SetFlag(&Force);
+        .StoreTrue(&Force);
     config.Opts->AddLongOption("directory", "Directory with volatile configs")
         .Optional().RequiredArgument("[directory]").StoreResult(&Dir);
 }
@@ -715,11 +715,11 @@ void TCommandConfigVolatileFetch::Config(TConfig& config) {
     config.Opts->AddLongOption("id", "Volatile config id")
         .Optional().RequiredArgument("[ui64]").InsertTo(&Ids);
     config.Opts->AddLongOption("all", "Fetch all volatile configs")
-        .NoArgument().SetFlag(&All);
+        .StoreTrue(&All);
     config.Opts->AddLongOption("output-directory", "Directory to save config(s)")
         .RequiredArgument("[directory]").StoreResult(&OutDir);
     config.Opts->AddLongOption("strip-metadata", "Strip metadata from config(s)")
-        .NoArgument().SetFlag(&StripMetadata);
+        .StoreTrue(&StripMetadata);
     config.SetFreeArgsNum(0);
     config.Opts->MutuallyExclusive("output-directory", "strip-metadata");
 }

--- a/ydb/public/lib/ydb_cli/commands/ydb_latency.cpp
+++ b/ydb/public/lib/ydb_cli/commands/ydb_latency.cpp
@@ -183,7 +183,7 @@ void TCommandLatency::Config(TConfig& config) {
             .OptionalArgument("INT").StoreResult(&ChainConfig->WorkUsec_).DefaultValue(ChainConfig->WorkUsec_);
     config.Opts->AddLongOption(
         "no-tail-chain", TStringBuilder() << "Don't use Tail sends and registrations (ActorChain kind only)")
-            .NoArgument().SetFlag(&ChainConfig->NoTailChain_).DefaultValue(ChainConfig->NoTailChain_);
+            .StoreTrue(&ChainConfig->NoTailChain_).DefaultValue(ChainConfig->NoTailChain_);
 }
 
 void TCommandLatency::Parse(TConfig& config) {

--- a/ydb/public/lib/ydb_cli/commands/ydb_node_config.cpp
+++ b/ydb/public/lib/ydb_cli/commands/ydb_node_config.cpp
@@ -19,11 +19,6 @@ TCommandNodeConfigInit::TCommandNodeConfigInit()
 {
 }
 
-void TCommandNodeConfigInit::PropagateFlags(const TCommandFlags& flags) {
-    TYdbCommand::PropagateFlags(flags);
-    Dangerous = false;
-}
-
 void TCommandNodeConfigInit::Config(TConfig& config) {
     TYdbCommand::Config(config);
     config.Opts->AddLongOption('f', "from-config", "Path to the initial configuration file.")
@@ -92,14 +87,14 @@ int TCommandNodeConfigInit::Run(TConfig& config) {
             storageSaved = SaveConfig(storageConfig, STORAGE_CONFIG_FILE_NAME, ConfigDirPath);
 
             if (clusterSaved && storageSaved) {
-                Cout << "Initialized main and storage configs in " << ConfigDirPath << "/" 
+                Cout << "Initialized main and storage configs in " << ConfigDirPath << "/"
                      << CONFIG_FILE_NAME << " and " << STORAGE_CONFIG_FILE_NAME << Endl;
                 return EXIT_SUCCESS;
             }
-            Cerr << "Failed to save configs: " 
+            Cerr << "Failed to save configs: "
                  << (clusterSaved ? "" : "main config")
-                 << (clusterSaved && storageSaved ? ", " : "") 
-                 << (storageSaved ? "" : "storage config") 
+                 << (clusterSaved && storageSaved ? ", " : "")
+                 << (storageSaved ? "" : "storage config")
                  << Endl;
             return EXIT_FAILURE;
         }

--- a/ydb/public/lib/ydb_cli/commands/ydb_node_config.h
+++ b/ydb/public/lib/ydb_cli/commands/ydb_node_config.h
@@ -12,7 +12,6 @@ public:
 class TCommandNodeConfigInit : public TYdbCommand {
 public:
     TCommandNodeConfigInit();
-    void PropagateFlags(const TCommandFlags& flags) override;
     void Config(TConfig& config) override;
     int Run(TConfig& config) override;
     bool SaveConfig(const TString& config, const TString& configName, const TString& configDirPath);

--- a/ydb/public/lib/ydb_cli/commands/ydb_profile.cpp
+++ b/ydb/public/lib/ydb_cli/commands/ydb_profile.cpp
@@ -716,7 +716,7 @@ void TCommandProfileCommon::Config(TConfig& config) {
 
     config.SetFreeArgsMax(1);
     SetFreeArgTitle(0, "<name>", "Profile name");
-    NLastGetopt::TOpts& opts = *config.Opts;
+    TClientCommandOptions& opts = *config.Opts;
 
     opts.AddLongOption('e', "endpoint", "Endpoint to save in the profile").RequiredArgument("STRING").StoreResult(&Endpoint);
     opts.AddLongOption('d', "database", "Database to save in the profile").RequiredArgument("PATH").StoreResult(&Database);
@@ -1096,7 +1096,7 @@ void TCommandUpdateProfile::Config(TConfig& config) {
     TCommandProfileCommon::Config(config);
 
     config.SetFreeArgsMin(1);
-    NLastGetopt::TOpts& opts = *config.Opts;
+    TClientCommandOptions& opts = *config.Opts;
     opts.AddLongOption("no-endpoint", "Delete endpoint from the profile").StoreTrue(&NoEndpoint);
     opts.AddLongOption("no-database", "Delete database from the profile").StoreTrue(&NoDatabase);
     opts.AddLongOption("no-auth", "Delete authentication data from the profile").StoreTrue(&NoAuth);

--- a/ydb/public/lib/ydb_cli/commands/ydb_root_common.cpp
+++ b/ydb/public/lib/ydb_cli/commands/ydb_root_common.cpp
@@ -118,146 +118,203 @@ void TClientCommandRootCommon::SetCredentialsGetter(TConfig& config) {
 
 void TClientCommandRootCommon::Config(TConfig& config) {
     FillConfig(config);
-    NLastGetopt::TOpts& opts = *config.Opts;
+    TClientCommandOptions& opts = *config.Opts;
+
+    NColorizer::TColors colors = NColorizer::AutoColors(Cout);
 
     TStringBuilder endpointHelp;
-    endpointHelp << "Endpoint to connect. Protocols: grpc, grpcs (Default: "
-        << (Settings.EnableSsl.GetRef() ? "grpcs" : "grpc" ) << ")." << Endl;
+    endpointHelp << "Endpoint to connect. Protocols: "
+        << colors.BoldColor() << "grpc" << colors.OldColor() << ", "
+        << colors.BoldColor() << "grpcs" << colors.OldColor() << " (default: "
+        << colors.Cyan() << (Settings.EnableSsl.GetRef() ? "grpcs" : "grpc" ) << colors.OldColor() << ")";
 
-    endpointHelp << "  Endpoint search order:" << Endl
-        << "    1. This option" << Endl
-        << "    2. Profile specified with --profile option" << Endl
-        << "    3. Active configuration profile";
-    TStringBuilder databaseHelp;
-    databaseHelp << "Database to work with." << Endl
-        << "  Database search order:" << Endl
-        << "    1. This option" << Endl
-        << "    2. Profile specified with --profile option" << Endl
-        << "    3. Active configuration profile";
-
+    EnableSsl = Settings.EnableSsl.GetRef(); // default
     opts.AddLongOption('e', "endpoint", endpointHelp)
-        .RequiredArgument("[PROTOCOL://]HOST[:PORT]").StoreResult(&Address);
-    opts.AddLongOption('d', "database", databaseHelp)
-        .RequiredArgument("PATH").StoreResult(&Database);
-    opts.AddLongOption('v', "verbose", "Increase verbosity of operations")
+        .RequiredArgument("[PROTOCOL://]HOST[:PORT]")
+        .ProfileParam("endpoint")
+        .LogToConnectionParams("endpoint")
+        .Handler([this](const TString& value) {
+            // Parse address & enable SSL at one time
+            Address = GetAddressFromString(value, &EnableSsl);
+        })
+        .Validator([](const TString& value) {
+            // Get errors from parsing
+            std::vector<TString> errors;
+            GetAddressFromString(value, nullptr, &errors);
+            return errors;
+        });
+    opts.AddLongOption('d', "database", "Database to work with")
+        .RequiredArgument("PATH").StoreResult(&Database)
+        .ProfileParam("database")
+        .LogToConnectionParams("database");
+    opts.GetOpts().AddLongOption('v', "verbose", "Increase verbosity of operations")
         .Optional().NoArgument().Handler0([&](){
             VerbosityLevel++;
         });
-    opts.AddLongOption('p', "profile", "Profile name to use configuration parameters from.")
+    opts.AddLongOption('p', "profile", "Profile name to use configuration parameters from")
         .RequiredArgument("NAME").StoreResult(&ProfileName);
-    opts.AddLongOption('y', "assume-yes", "Automatic yes to prompts; assume \"yes\" as answer to all prompts and run non-interactively.")
+    opts.AddLongOption('y', "assume-yes", "Automatic yes to prompts; assume \"yes\" as answer to all prompts and run non-interactively")
         .Optional().StoreTrue(&config.AssumeYes);
     TClientCommandRootBase::Config(config);
 
+    TAuthMethodOption* iamTokenAuth = nullptr;
+    TAuthMethodOption* ycTokenAuth = nullptr;
+    TAuthMethodOption* metadataAuth = nullptr;
+    TAuthMethodOption* saKeyAuth = nullptr;
+    TAuthMethodOption* ydbTokenAuth = nullptr;
+    TAuthMethodOption* ydbUserAuth = nullptr;
+    TAuthMethodOption* oauth2TokenExchangeAuth = nullptr;
+
     if (config.UseIamAuth) {
         const TString docsUrl = "cloud.yandex.ru/docs";
-        TStringBuilder iamTokenHelp;
-        iamTokenHelp << "IAM token file. Note: IAM tokens expire in 12 hours." << Endl
-            << "  For more info go to: " << docsUrl << "/iam/concepts/authorization/iam-token" << Endl
-            << "  Token search order:" << Endl
-            << "    1. This option" << Endl
-            << "    2. Profile specified with --profile option" << Endl
-            << "    3. \"IAM_TOKEN\" environment variable" << Endl
-            << "    4. Active configuration profile";
-        opts.AddLongOption("iam-token-file", iamTokenHelp).RequiredArgument("PATH").StoreResult(&TokenFile);
+        iamTokenAuth = &opts.AddAuthMethodOption("iam-token-file", "IAM token file. Note: IAM tokens expire in 12 hours");
+        (*iamTokenAuth)
+            .AuthMethod("token")
+            .SimpleProfileDataParam("iam-token", false)
+            .DocLink(TStringBuilder() << docsUrl << "/iam/concepts/authorization/iam-token")
+            .LogToConnectionParams("token")
+            .Env("IAM_TOKEN", false)
+            .FileName("token").RequiredArgument("PATH")
+            .StoreFilePath(&TokenFile)
+            .StoreResult(&config.SecurityToken);
 
-        TStringBuilder ycTokenHelp;
-        ycTokenHelp << "YC token file. It should contain OAuth token of a Yandex Passport user to get IAM token with." << Endl
-            << "  For more info go to: " << docsUrl << "/iam/concepts/authorization/oauth-token" << Endl
-            << "  Token search order:" << Endl
-            << "    1. This option" << Endl
-            << "    2. Profile specified with --profile option" << Endl
-            << "    3. \"YC_TOKEN\" environment variable" << Endl
-            << "    4. Active configuration profile";
-        opts.AddLongOption("yc-token-file", ycTokenHelp).RequiredArgument("PATH").StoreResult(&YCTokenFile);
+        ycTokenAuth = &opts.AddAuthMethodOption("yc-token-file", "YC token file. It should contain OAuth token of a Yandex Passport user to get IAM token with");
+        (*ycTokenAuth)
+            .AuthMethod("yc-token")
+            .SimpleProfileDataParam("yc-token", false) // parse token directly from profile
+            .SimpleProfileDataParam("yc-token-file", true) // parse token from file specified in profile
+            .DocLink(TStringBuilder() << docsUrl << "/iam/concepts/authorization/oauth-token")
+            .LogToConnectionParams("yc-token")
+            .Env("YC_TOKEN", false)
+            .FileName("YC token").RequiredArgument("PATH")
+            .StoreResult(&config.YCToken);
 
-        TStringBuilder metadataHelp;
-        metadataHelp << "Use metadata service on a virtual machine to get credentials" << Endl
-            << "  For more info go to: " << docsUrl << "/compute/operations/vm-connect/auth-inside-vm" << Endl
-            << "  Definition priority:" << Endl
-            << "    1. This option" << Endl
-            << "    2. Profile specified with --profile option" << Endl
-            << "    3. \"USE_METADATA_CREDENTIALS\" environment variable" << Endl
-            << "    4. Active configuration profile";
-        opts.AddLongOption("use-metadata-credentials", metadataHelp).Optional().StoreTrue(&UseMetadataCredentials);
+        metadataAuth = &opts.AddAuthMethodOption("use-metadata-credentials", "Use metadata service on a virtual machine to get credentials");
+        (*metadataAuth)
+            .AuthMethod("use-metadata-credentials")
+            .SimpleProfileDataParam()
+            .DocLink(TStringBuilder() << docsUrl << "/compute/operations/vm-connect/auth-inside-vm")
+            .LogToConnectionParams("use-metadata-credentials")
+            .Env("USE_METADATA_CREDENTIALS", false)
+            .StoreTrue(&config.UseMetadataCredentials);
 
-        TStringBuilder saKeyHelp;
-        saKeyHelp << "Service account";
-        if (Settings.MentionUserAccount.GetRef()) {
-            saKeyHelp << " (or user account)";
-        }
-        saKeyHelp << " key file" << Endl
-            << "  For more info go to: " << docsUrl << "/iam/operations/iam-token/create-for-sa" << Endl
-            << "  Definition priority:" << Endl
-            << "    1. This option" << Endl
-            << "    2. Profile specified with --profile option" << Endl
-            << "    3. \"SA_KEY_FILE\" environment variable" << Endl
-            << "    4. Active configuration profile";
-        opts.AddLongOption("sa-key-file", saKeyHelp).RequiredArgument("PATH").StoreResult(&SaKeyFile);
+        saKeyAuth = &opts.AddAuthMethodOption("sa-key-file", TStringBuilder() << "Service account" << (Settings.MentionUserAccount.GetRef() ? " (or user account) key file" : " key file"));
+        (*saKeyAuth)
+            .AuthMethod("sa-key-file")
+            .SimpleProfileDataParam("", true)
+            .DocLink(TStringBuilder() << docsUrl << "/iam/operations/iam-token/create-for-sa")
+            .LogToConnectionParams("sa-key-file")
+            .Env("SA_KEY_FILE", true, "SA key file")
+            .FileName("SA key file").RequiredArgument("PATH")
+            .StoreFilePath(&config.SaKeyFile)
+            .StoreResult(&config.SaKeyParams);
     }
 
     if (config.UseAccessToken) {
-        TStringBuilder tokenHelp;
-        tokenHelp << "Access token file" << Endl
-            << "  Token search order:" << Endl
-            << "    1. This option" << Endl
-            << "    2. Profile specified with --profile option" << Endl
-            << "    3. \"YDB_TOKEN\" environment variable" << Endl
-            << "    4. Active configuration profile";
+        ydbTokenAuth = &opts.AddAuthMethodOption("token-file", "Access token file");
+        (*ydbTokenAuth)
+            .AuthMethod("token")
+            .SimpleProfileDataParam()
+            .SimpleProfileDataParam("token-file", true)
+            .SimpleProfileDataParam("ydb-token", false)
+            .LogToConnectionParams("token")
+            .Env("YDB_TOKEN", false)
+            .FileName("token").RequiredArgument("PATH")
+            .StoreFilePath(&TokenFile)
+            .StoreResult(&config.SecurityToken);
         if (Settings.UseDefaultTokenFile.GetRef()) {
-            tokenHelp << Endl << "    5. Default token file \"" << defaultTokenFile << "\"";
+            (*ydbTokenAuth)
+                .DefaultValue(defaultTokenFile);
         }
-        opts.AddLongOption("token-file", tokenHelp).RequiredArgument("PATH").StoreResult(&TokenFile);
     }
 
     if (config.UseStaticCredentials) {
-        TStringBuilder userHelp;
-        userHelp << "User name to authenticate with" << Endl
-            << "  User name search order:" << Endl
-            << "    1. This option" << Endl
-            << "    2. Profile specified with --profile option" << Endl
-            << "    3. \"YDB_USER\" environment variable" << Endl
-            << "    4. Active configuration profile";
-        opts.AddLongOption("user", userHelp).RequiredArgument("STR").StoreResult(&UserName);
+        auto parser = [this](const YAML::Node& authData, TString* value, std::vector<TString>* errors, bool parseOnly) -> bool {
+            TString user, password;
+            bool hasPasswordOption = false;
+            if (authData["user"]) {
+                user = authData["user"].as<TString>();
+            }
+            if (authData["password"]) {
+                hasPasswordOption = true;
+                password = authData["password"].as<TString>();
+            }
+            if (authData["password-file"]) {
+                if (hasPasswordOption) {
+                    if (errors) {
+                        errors->push_back(TStringBuilder() << "Profile has both password and password-file");
+                    }
+                    return false;
+                }
+                PasswordFile = authData["password-file"].as<TString>();
+                TString fileContent;
+                if (!ReadFromFileIfExists(PasswordFile, "password", fileContent, true)) {
+                    if (errors) {
+                        errors->push_back(TStringBuilder() << "Couldn't read password from file " << PasswordFile);
+                    }
+                    return false;
+                }
+                password = std::move(fileContent);
+            }
+            if (value) {
+                *value = user;
+            }
+            // Assign values
+            if (!parseOnly) {
+                if (!password.empty()) {
+                    DoNotAskForPassword = true;
+                }
+                UserName = std::move(user);
+                Password = std::move(password);
+            }
+            return true;
+        };
+        ydbUserAuth = &opts.AddAuthMethodOption("user", "User name to authenticate with");
+        (*ydbUserAuth)
+            .AuthMethod("static-credentials")
+            .AuthProfileParser(std::move(parser))
+            .LogToConnectionParams("user")
+            .Env("YDB_USER", false)
+            .RequiredArgument("NAME").StoreResult(&UserName);
 
-        TStringBuilder passwordHelp;
-        passwordHelp << "File with password to authenticate with" << Endl
-            << "  Password search order:" << Endl
-            << "    1. This option" << Endl
-            << "    2. Profile specified with --profile option" << Endl
-            << "    3. \"YDB_PASSWORD\" environment variable" << Endl
-            << "    4. Active configuration profile";
-        opts.AddLongOption("password-file", passwordHelp).RequiredArgument("PATH").StoreResult(&PasswordFile);
+        auto& passwordOpt = opts.AddLongOption("password-file", "File with password to authenticate with")
+            .Env("YDB_PASSWORD", false)
+            .SetSupportsProfile()
+            .FileName("password").RequiredArgument("PATH")
+            .StoreFilePath(&PasswordFileOption)
+            .StoreResult(&PasswordOption);
 
-        opts.AddLongOption("no-password", "Do not ask for user password (if empty)").Optional().StoreTrue(&DoNotAskForPassword);
+        auto& noPasswordOpt = opts.AddLongOption("no-password", "Do not ask for user password (if empty)")
+            .Optional().StoreTrue(&DoNotAskForPassword);
+
+        opts.MutuallyExclusiveOpt(passwordOpt, noPasswordOpt);
     }
 
     if (config.UseOauth2TokenExchange) {
         TOauth2TokenExchangeParams defaultParams;
         TJwtTokenSourceParams defaultJwtParams;
-        NColorizer::TColors colors = NColorizer::AutoColors(Cout);
 
-#define FIELD(name) "    " << colors.BoldColor() << name << colors.OldColor() << ": "
+#define FIELD(name) "  " << colors.BoldColor() << name << colors.OldColor() << ": "
 #define TYPE(type) "[" << colors.YellowColor() << type << colors.OldColor() << "] "
 #define TYPE2(type1, type2) "[" << colors.YellowColor() << type1 << colors.OldColor() << " | " << colors.YellowColor() << type2 << colors.OldColor() << "] "
 #define DEFAULT(value) " (default: " << colors.CyanColor() << value << colors.OldColor() << ")"
 
-        TStringBuilder oauth2TokenExchangeHelp;
-        oauth2TokenExchangeHelp << "OAuth 2.0 RFC8693 token exchange credentials parameters json file" << Endl;
-        if (config.HelpCommandVerbosiltyLevel <= 1) {
-            oauth2TokenExchangeHelp << "  Use -hh option to see file format description" << Endl;
-        }
-        oauth2TokenExchangeHelp
-            << "  Parameters file search order:" << Endl
-            << "    1. This option" << Endl
-            << "    2. Profile specified with --profile option" << Endl
-            << "    3. \"YDB_OAUTH2_KEY_FILE\" environment variable" << Endl
-            << "    4. Active configuration profile" << Endl << Endl
-            << "  Detailed information about OAuth 2.0 token exchange protocol: https://www.rfc-editor.org/rfc/rfc8693" << Endl
-            << "  Detailed description about file parameters: https://ydb.tech/docs/en/reference/ydb-cli/connect" << Endl
-            << Endl;
+        oauth2TokenExchangeAuth = &opts.AddAuthMethodOption("oauth2-key-file", "OAuth 2.0 RFC8693 token exchange credentials parameters json file");
+        (*oauth2TokenExchangeAuth)
+            .AuthMethod("oauth2-key-file")
+            .SimpleProfileDataParam()
+            .LogToConnectionParams("oauth2-key-file")
+            .DocLink("ydb.tech/docs/en/reference/ydb-cli/connect")
+            .Env("YDB_OAUTH2_KEY_FILE", true, "OAuth 2 key file")
+            .RequiredArgument("PATH")
+            .FileName("OAuth 2 key file")
+            .StoreFilePath(&config.Oauth2KeyFile)
+            .StoreResult(&config.Oauth2KeyParams);
 
         if (config.HelpCommandVerbosiltyLevel >= 2) {
+            TStringBuilder additionalHelp;
+            additionalHelp << "Detailed information about OAuth 2.0 token exchange protocol: https://www.rfc-editor.org/rfc/rfc8693" << Endl << Endl;
+
             TStringBuilder supportedJwtAlgorithms;
             for (const std::string& alg : GetSupportedOauth2TokenExchangeJwtAlgorithms()) {
                 if (supportedJwtAlgorithms) {
@@ -266,8 +323,8 @@ void TClientCommandRootCommon::Config(TConfig& config) {
                 supportedJwtAlgorithms << colors.BoldColor() << alg << colors.OldColor();
             }
 
-            oauth2TokenExchangeHelp
-                << "  Fields of json file:" << Endl
+            additionalHelp
+                << "Fields of json file:" << Endl
                 << FIELD("grant-type") "          " TYPE("string") "Grant type" DEFAULT(defaultParams.GrantType_) << Endl
                 << FIELD("res") "                 " TYPE("string") "Resource (optional)" << Endl
                 << FIELD("aud") "                 " TYPE2("string", "list of strings") "Audience option for token exchange request (optional)" << Endl
@@ -276,7 +333,7 @@ void TClientCommandRootCommon::Config(TConfig& config) {
                 << FIELD("subject-credentials") " " TYPE("creds_json") "Subject credentials (optional)" << Endl
                 << FIELD("actor-credentials") "   " TYPE("creds_json") "Actor credentials (optional)" << Endl
                 << Endl
-                << "  Fields of " << colors.BoldColor() << "creds_json" << colors.OldColor() << " (JWT):" << Endl
+                << "Fields of " << colors.BoldColor() << "creds_json" << colors.OldColor() << " (JWT):" << Endl
                 << FIELD("type") "                " TYPE("string") "Token source type. Set " << colors.BoldColor() << "JWT" << colors.OldColor() << Endl
                 << FIELD("alg") "                 " TYPE("string") "Algorithm for JWT signature. Supported algorithms: " << supportedJwtAlgorithms << Endl
                 << FIELD("private-key") "         " TYPE("string") "(Private) key in PEM format for JWT signature" << Endl
@@ -287,18 +344,18 @@ void TClientCommandRootCommon::Config(TConfig& config) {
                 << FIELD("jti") "                 " TYPE("string") "JWT ID JWT standard claim (optional)" << Endl
                 << FIELD("ttl") "                 " TYPE("string") "Token TTL" DEFAULT(defaultJwtParams.TokenTtl_) << Endl
                 << Endl
-                << "  Fields of " << colors.BoldColor() << "creds_json" << colors.OldColor() << " (FIXED):" << Endl
+                << "Fields of " << colors.BoldColor() << "creds_json" << colors.OldColor() << " (FIXED):" << Endl
                 << FIELD("type") "                " TYPE("string") "Token source type. Set " << colors.BoldColor() << "FIXED" << colors.OldColor() << Endl
                 << FIELD("token") "               " TYPE("string") "Token value" << Endl
                 << FIELD("token-type") "          " TYPE("string") "Token type value. It will become subject_token_type/actor_token_type parameter in token exchange request (https://www.rfc-editor.org/rfc/rfc8693)" << Endl
                 << Endl;
+
+            additionalHelp
+                << "Note that additionally you need to set " << colors.BoldColor() << "--iam-endpoint" << colors.OldColor() << " option" << Endl
+                << "  in url format (SCHEMA://HOST:PORT/PATH) to configure endpoint.";
+
+            oauth2TokenExchangeAuth->AdditionalHelpNotes(additionalHelp);
         }
-
-        oauth2TokenExchangeHelp
-            << "  Note that additionally you need to set " << colors.BoldColor() << "--iam-endpoint" << colors.OldColor() << " option" << Endl
-            << "    in url format (SCHEMA://HOST:PORT/PATH) to configure endpoint.";
-
-        opts.AddLongOption("oauth2-key-file", oauth2TokenExchangeHelp).RequiredArgument("PATH").StoreResult(&Oauth2KeyFile);
 
 #undef DEFAULT
 #undef TYPE2
@@ -307,28 +364,45 @@ void TClientCommandRootCommon::Config(TConfig& config) {
     }
 
     if (config.UseIamAuth) {
-        TStringBuilder iamEndpointHelp;
-        NColorizer::TColors colors = NColorizer::AutoColors(Cout);
-        iamEndpointHelp << "Endpoint of IAM service (default: " << colors.Cyan();
-        iamEndpointHelp << "\"" << config.IamEndpoint << "\"" << colors.OldColor() << ")";
-        opts.AddLongOption("iam-endpoint", iamEndpointHelp)
+        opts.AddLongOption("iam-endpoint", "Endpoint of IAM service")
             .RequiredArgument("STR")
-            .StoreResult(&IamEndpoint);
+            .StoreResult(&config.IamEndpoint)
+            .LogToConnectionParams("iam-endpoint")
+            .ProfileParam("iam-endpoint")
+            .DefaultValue(config.IamEndpoint);
     }
+
+    // Special auth method that is not parsed from command line,
+    // but is parsed from profile
+    opts.AddAnonymousAuthMethodOption();
 
     opts.AddLongOption("profile-file", "Path to config file with profile data in yaml format")
         .RequiredArgument("PATH").StoreResult(&ProfileFile);
 
+    opts.SetAuthMethodsEnvPriority(
+        iamTokenAuth,
+        ycTokenAuth,
+        metadataAuth,
+        saKeyAuth,
+        ydbTokenAuth,
+        ydbUserAuth,
+        oauth2TokenExchangeAuth
+    );
+
     TStringStream stream;
-    NColorizer::TColors colors = NColorizer::AutoColors(Cout);
     stream << " [options...] <subcommand>" << Endl << Endl
         << colors.BoldColor() << "Subcommands" << colors.OldColor() << ":" << Endl;
     RenderCommandDescription(stream, config.HelpCommandVerbosiltyLevel > 1, colors);
     stream << Endl << Endl << colors.BoldColor() << "Commands in " << colors.Red() << colors.BoldColor() <<  "admin" << colors.OldColor() << colors.BoldColor() << " subtree may treat global flags and profile differently, see corresponding help" << colors.OldColor() << Endl;
-    opts.SetCmdLineDescr(stream.Str());
 
-    opts.GetLongOption("time").Hidden();
-    opts.GetLongOption("progress").Hidden();
+    // detailed help
+    stream << Endl << Endl << colors.BoldColor() << "Detailed help" << colors.OldColor() << ":" << Endl;
+    stream << colors.Green() << "-hh" << colors.OldColor() << ": Print detailed help" << Endl;
+
+    opts.GetOpts().SetCmdLineDescr(stream.Str());
+
+    opts.GetOpts().GetLongOption("time").Hidden();
+    opts.GetOpts().GetLongOption("progress").Hidden();
 
     config.SetFreeArgsMin(0);
 }
@@ -350,236 +424,134 @@ void TClientCommandRootCommon::ExtractParams(TConfig& config) {
     ProfileManager = CreateProfileManager(config.ProfileFile);
     ParseProfile();
 
-    ParseDatabase(config);
-    ParseAddress(config);
+    if (std::vector<TString> errors = ParseResult->Validate(); !errors.empty()) {
+        MisuseErrors.insert(MisuseErrors.end(), errors.begin(), errors.end());
+    }
+    if (std::vector<TString> errors = ParseResult->ParseFromProfilesAndEnv(Profile, !config.OnlyExplicitProfile ? ProfileManager->GetActiveProfile() : nullptr); !errors.empty()) {
+        MisuseErrors.insert(MisuseErrors.end(), errors.begin(), errors.end());
+    }
+    if (IsVerbose()) {
+        std::vector<TString> errors = ParseResult->LogConnectionParams([&](const TString& paramName, const TString& value, const TString& sourceText) {
+            config.ConnectionParams[paramName].push_back({value, sourceText});
+        });
+        if (!errors.empty()) {
+            MisuseErrors.insert(MisuseErrors.end(), errors.begin(), errors.end());
+        }
+    }
+
     ParseCaCerts(config);
     ParseClientCert(config);
-    ParseIamEndpoint(config);
+    ParseStaticCredentials(config);
 
-    ParseCredentials(config);
-}
-
-namespace {
-    inline void PrintSettingFromProfile(const TString& setting, const std::shared_ptr<IProfile>& profile, bool explicitOption) {
-        Cerr << "Using " << setting << " due to configuration in" << (explicitOption ? "" : " active") << " profile \""
-            << profile->GetName() << "\"" << (explicitOption ? " from explicit --profile option" : "") << Endl;
-    }
-
-    inline TString GetProfileSource(const std::shared_ptr<IProfile>& profile, bool explicitOption) {
-        Y_ABORT_UNLESS(profile, "No profile to get source");
-        if (explicitOption) {
-            return TStringBuilder() << "profile \"" << profile->GetName() << "\" from explicit --profile option";
-        }
-        return TStringBuilder() << "active profile \"" << profile->GetName() << "\"";
-    }
-}
-
-bool TClientCommandRootCommon::TryGetParamFromProfile(const TString& name, const std::shared_ptr<IProfile>& profile, bool explicitOption,
-                                                      std::function<bool(const TString&, const TString&, bool)> callback) {
-    if (profile && profile->Has(name)) {
-        return callback(profile->GetValue(name).as<TString>(), GetProfileSource(profile, explicitOption), explicitOption);
-    }
-    return false;
-}
-
-bool TClientCommandRootCommon::TryGetParamsPackFromProfile(const std::shared_ptr<IProfile>& profile, bool explicitOption,
-                                                           std::function<bool(const TString& /*source*/, bool /*explicit*/, const std::vector<TString>& /*values*/)> callback,
-                                                           const std::initializer_list<TString>& names) {
-    if (!profile) {
-        return false;
-    }
-    bool hasAtLeastOne = false;
-    for (const TString& name : names) {
-        if (profile->Has(name)) {
-            hasAtLeastOne = true;
-            break;
-        }
-    }
-    if (hasAtLeastOne) {
-        std::vector<TString> values;
-        values.reserve(names.size());
-        for (const TString& name : names) {
-            if (profile->Has(name)) {
-                values.emplace_back(profile->GetValue(name).as<TString>());
-            } else {
-                values.emplace_back();
-            }
-        }
-        return callback(GetProfileSource(profile, explicitOption), explicitOption, values);
-    }
-    return false;
+    config.Address = Address;
+    config.EnableSsl = EnableSsl;
+    config.Database = Database;
+    config.ChosenAuthMethod = ParseResult->GetChosenAuthMethod();
 }
 
 void TClientCommandRootCommon::ParseCaCerts(TConfig& config) {
-    auto getCaFile = [this, &config] (const TString& param, const TString& sourceText, bool explicitOption) {
-        if (!IsCaCertsFileSet && (explicitOption || !Profile)) {
-            config.CaCertsFile = param;
-            IsCaCertsFileSet = true;
-            GetCaCerts(config);
-        }
-        if (!IsVerbose()) {
-            return true;
-        }
-        config.ConnectionParams["ca-file"].push_back({param, sourceText});
-        return false;
-    };
-    // Priority 1. Explicit --ca-file option
-    if (CaCertsFile && getCaFile(CaCertsFile, "explicit --ca-file option", true)) {
-        return;
-    }
-    // Priority 2. Explicit --profile option
-    if (TryGetParamFromProfile("ca-file", Profile, true, getCaFile)) {
-        return;
-    }
-    // Priority 3. Active profile (if --profile option is not specified)
-    if (TryGetParamFromProfile("ca-file", ProfileManager->GetActiveProfile(), false, getCaFile)) {
-        return;
+    if (!config.EnableSsl && config.CaCerts) {
+        MisuseErrors.push_back("\"ca-file\" option is provided for a non-ssl connection. Use grpcs:// prefix for host to connect using SSL.");
     }
 }
 
 void TClientCommandRootCommon::ParseClientCert(TConfig& config) {
-    auto getClientCertFiles = [this, &config] (const TString& sourceText, bool explicitOption, const std::vector<TString>& values) {
-        Y_ABORT_UNLESS(values.size() == 3);
-        const TString& clientCertFileParam = values[0];
-        const TString& clientCertPrivateKeyFileParam = values[1];
-        const TString& clientCertPrivateKeyPasswordFileParam = values[2];
-        if (!IsClientCertFileSet && (explicitOption || !Profile)) {
-            config.ClientCertFile = clientCertFileParam;
-            config.ClientCertPrivateKeyFile = clientCertPrivateKeyFileParam;
-            config.ClientCertPrivateKeyPasswordFile = clientCertPrivateKeyPasswordFileParam;
-            IsClientCertFileSet = true;
-            GetClientCert(config);
-        }
-        if (!IsVerbose()) {
-            return true;
-        }
-        Cerr << "Using client certificate from file: " << clientCertFileParam << Endl;
-        config.ConnectionParams["client-cert-file"].push_back({clientCertFileParam, sourceText});
-        config.ConnectionParams["client-cert-key-file"].push_back({clientCertPrivateKeyFileParam, sourceText});
-        config.ConnectionParams["client-cert-key-password-file"].push_back({clientCertPrivateKeyPasswordFileParam, sourceText});
-        return false;
-    };
-    // Priority 1. Explicit --client-cert-file/--client-cert-key-file options
-    if (ClientCertFile) {
-        if (getClientCertFiles("explicit --client-cert-file/--client-cert-key-file/--client-cert-key-password-file options", true, { ClientCertFile, ClientCertPrivateKeyFile, ClientCertPrivateKeyPasswordFile })) {
-            return;
-        }
+    if (!config.EnableSsl && config.ClientCert) {
+        MisuseErrors.push_back("\"client-cert-file\"/\"client-cert-key-file\"/\"client-cert-key-password-file\" options are provided for a non-ssl connection. Use grpcs:// prefix for host to connect using SSL.");
     }
-    // Priority 2. Explicit --profile option
-    if (TryGetParamsPackFromProfile(Profile, true, getClientCertFiles, { "client-cert-file", "client-cert-key-file", "client-cert-key-password-file" })) {
-        return;
-    }
-    // Priority 3. Active profile (if --profile option is not specified)
-    if (TryGetParamsPackFromProfile(ProfileManager->GetActiveProfile(), false, getClientCertFiles, { "client-cert-file", "client-cert-key-file", "client-cert-key-password-file" })) {
-        return;
+
+    if (config.ClientCert) {
+        // Convert certificates from PKCS#12 to PEM or encrypted private key to nonencrypted
+        // May ask for password
+        std::tie(config.ClientCert, config.ClientCertPrivateKey) = ConvertCertToPEM(config.ClientCert, config.ClientCertPrivateKey, config.ClientCertPrivateKeyPassword);
     }
 }
 
-void TClientCommandRootCommon::GetCaCerts(TConfig& config) {
-    if (!config.EnableSsl && !config.CaCertsFile.empty()) {
-        throw TMisuseException()
-            << "\"ca-file\" option is provided for a non-ssl connection. Use grpcs:// prefix for host to connect using SSL.";
+void TClientCommandRootCommon::ParseStaticCredentials(TConfig& config) {
+    if (!config.UseStaticCredentials) {
+        return;
     }
-    if (!config.CaCertsFile.empty()) {
-        config.CaCerts = ReadFromFile(config.CaCertsFile, "CA certificates");
+
+    if (ParseResult->GetChosenAuthMethod() != "static-credentials") {
+        return;
+    }
+
+    // Check that we have username/password from one source
+    const TOptionParseResult* userResult = ParseResult->FindResult("user");
+    const TOptionParseResult* passwordResult = ParseResult->FindResult("password-file");
+    if (passwordResult && passwordResult->GetValueSource() == userResult->GetValueSource()) { // Both from command line or both from env
+        Password = PasswordOption;
+        PasswordFile = PasswordFileOption;
+    }
+
+    if (passwordResult && static_cast<int>(passwordResult->GetValueSource()) < static_cast<int>(userResult->GetValueSource())) { // Password is set from command line/env, but user is taken from source with less priority
+        MisuseErrors.push_back("User password was provided without user name");
+        return;
+    }
+
+    // Assign values
+    config.StaticCredentials.User = UserName;
+    config.StaticCredentials.Password = Password;
+
+    if (!config.StaticCredentials.Password.empty()) {
+        DoNotAskForPassword = true;
+    }
+
+    // Interactively ask for password
+    if (!config.StaticCredentials.User.empty()) {
+        if (config.StaticCredentials.Password.empty() && !DoNotAskForPassword) {
+            Cerr << "Enter password for user " << config.StaticCredentials.User << ": ";
+            config.StaticCredentials.Password = InputPassword();
+            if (IsVerbose()) {
+                config.ConnectionParams["password"].push_back({TString{config.StaticCredentials.Password}, "standard input"});
+            }
+        }
     }
 }
 
-void TClientCommandRootCommon::GetClientCert(TConfig& config) {
-    if (!config.EnableSsl && !config.ClientCertFile.empty()) {
-        throw TMisuseException()
-            << "\"client-cert-file\"/\"client-cert-key-file\"/\"client-cert-key-password-file\" options are provided for a non-ssl connection. Use grpcs:// prefix for host to connect using SSL.";
-    }
-    if (!config.ClientCertFile.empty()) {
-        config.ClientCert = ReadFromFile(config.ClientCertFile, "Client certificate");
-    }
-    if (!config.ClientCertPrivateKeyFile.empty()) {
-        config.ClientCertPrivateKey = ReadFromFile(config.ClientCertPrivateKeyFile, "Client certificate private key");
-    }
-    if (!config.ClientCertPrivateKeyPasswordFile.empty()) {
-        config.ClientCertPrivateKeyPassword = ReadFromFile(config.ClientCertPrivateKeyPasswordFile, "Client certificate private key password");
-    }
-
-    // Convert certificates from PKCS#12 to PEM or encrypted private key to nonencrypted
-    // May ask for password
-    std::tie(config.ClientCert, config.ClientCertPrivateKey) = ConvertCertToPEM(config.ClientCert, config.ClientCertPrivateKey, config.ClientCertPrivateKeyPassword);
-}
-
-void TClientCommandRootCommon::ParseAddress(TConfig& config) {
-    auto getAddress = [this, &config] (const TString& param, const TString& sourceText, bool explicitOption) {
-        TString address;
-        if (!IsAddressSet && (explicitOption || !Profile)) {
-            config.Address = param;
-            IsAddressSet = true;
-            GetAddressFromString(config);
-            address = config.Address;
-        }
-        if (!IsVerbose()) {
-            return true;
-        }
-        if (!address) {
-            address = param;
-            GetAddressFromString(config, &address);
-        }
-        config.ConnectionParams["endpoint"].push_back({address, sourceText});
-        return false;
-    };
-    // Priority 1. Explicit --endpoint option
-    if (Address && getAddress(Address, "explicit --endpoint option", true)) {
-        return;
-    }
-    // Priority 2. Explicit --profile option
-    if (TryGetParamFromProfile("endpoint", Profile, true, getAddress)) {
-        return;
-    }
-    // Priority 3. Active profile (if --profile option is not specified)
-    if (!config.OnlyExplicitProfile && TryGetParamFromProfile("endpoint", ProfileManager->GetActiveProfile(), false, getAddress)) {
-        return;
-    }
-}
-
-void TClientCommandRootCommon::GetAddressFromString(TConfig& config, TString* result) {
+TString TClientCommandRootCommon::GetAddressFromString(const TString& address_, bool* enableSsl, std::vector<TString>* errors) {
     TString port = "2135";
-    Address = result ? *result : config.Address;
-    if (!Address.empty()) {
-        if (!result) {
-            config.EnableSsl = Settings.EnableSsl.GetRef();
+    TString address = address_;
+    TString message;
+    if (!ParseProtocolNoConfig(address, enableSsl, message)) {
+        if (errors) {
+            errors->emplace_back(std::move(message));
         }
-        TString message;
-        if ((result && !ParseProtocolNoConfig(message)) || (!result && !ParseProtocol(config, message))) {
-            MisuseErrors.push_back(message);
+        return {};
+    }
+
+    const size_t colonPos = address.find(":");
+    if (colonPos == TString::npos) {
+        address = address + ':' + port;
+    } else {
+        if (colonPos != address.rfind(":")) {
+            if (errors) {
+                errors->emplace_back("Wrong format for option 'endpoint': more than one colon found.");
+            }
+            return {};
         }
-        auto colon_pos = Address.find(":");
-        if (colon_pos == TString::npos) {
-            if (result) {
-                *result = Address + ":" + port;
-            } else {
-                config.Address =  Address + ":" + port;
+    }
+    return address;
+}
+
+bool TClientCommandRootCommon::ParseProtocolNoConfig(TString& address, bool* enableSsl, TString& message) {
+    auto separatorPos = address.find("://");
+    if (separatorPos != TString::npos) {
+        TString protocol = address.substr(0, separatorPos);
+        protocol.to_lower();
+        if (protocol == "grpcs") {
+            if (enableSsl) {
+                *enableSsl = true;
+            }
+        } else if (protocol == "grpc") {
+            if (enableSsl) {
+                *enableSsl = false;
             }
         } else {
-            if (colon_pos == Address.rfind(":")) {
-                if (result) {
-                    *result = Address;
-                } else {
-                    config.Address =  Address;
-                }
-            } else {
-                MisuseErrors.push_back("Wrong format for option 'endpoint': more than one colon found.");
-            }
-        }
-    }
-}
-
-bool TClientCommandRootCommon::ParseProtocolNoConfig(TString& message) {
-    auto separator_pos = Address.find("://");
-    if (separator_pos != TString::npos) {
-        TString protocol = Address.substr(0, separator_pos);
-        protocol.to_lower();
-        if (protocol != "grpcs" && protocol != "grpc") {
             message = TStringBuilder() << "Unknown protocol \"" << protocol << "\".";
             return false;
         }
-        Address = Address.substr(separator_pos + 3);
+        address = address.substr(separatorPos + 3);
     }
     return true;
 }
@@ -593,63 +565,6 @@ void TClientCommandRootCommon::ParseProfile() {
                 << "Run \"ydb config profile list\" to see existing profiles");
             return;
         }
-    }
-}
-
-void TClientCommandRootCommon::ParseDatabase(TConfig& config) {
-    auto getDatabase = [this, &config] (const TString& param, const TString& sourceText, bool explicitOption) {
-        if (!IsDatabaseSet && (explicitOption || !Profile)) {
-            config.Database = param;
-            IsDatabaseSet = true;
-        }
-        if (!IsVerbose()) {
-            return true;
-        }
-        config.ConnectionParams["database"].push_back({param, sourceText});
-        return false;
-    };
-
-    // Priority 1. Explicit --database option
-    if (Database && getDatabase(Database, "explicit --database option", true)) {
-        return;
-    }
-    // Priority 2. Explicit --profile option
-    if (TryGetParamFromProfile("database", Profile, true, getDatabase)) {
-        return;
-    }
-    // Priority 3. Active profile (if --profile option is not specified)
-    if (!config.OnlyExplicitProfile && TryGetParamFromProfile("database", ProfileManager->GetActiveProfile(), false, getDatabase)) {
-        return;
-    }
-}
-
-void TClientCommandRootCommon::ParseIamEndpoint(TConfig& config) {
-    auto getIamEndpoint = [this, &config] (const TString& param, const TString& sourceText, bool explicitOption) {
-        if (!IsIamEndpointSet && (explicitOption || !Profile)) {
-            config.IamEndpoint = param;
-            IsIamEndpointSet = true;
-        }
-        if (!IsVerbose()) {
-            return true;
-        }
-        config.ConnectionParams["iam-endpoint"].push_back({param, sourceText});
-        return false;
-    };
-    // Priority 1. Explicit --iam-endpoint option
-    if (IamEndpoint && getIamEndpoint(IamEndpoint, "explicit --iam-endpoint option", true)) {
-        return;
-    }
-    // Priority 2. Explicit --profile option
-    if (TryGetParamFromProfile("iam-endpoint", Profile, true, getIamEndpoint)) {
-        return;
-    }
-    // Priority 3. Active profile (if --profile option is not specified)
-    if (TryGetParamFromProfile("iam-endpoint", ProfileManager->GetActiveProfile(), false, getIamEndpoint)) {
-        return;
-    }
-    // Priority 4. Default value
-    if (IsVerbose()) {
-        config.ConnectionParams["iam-endpoint"].push_back({config.IamEndpoint, "default value"});
     }
 }
 
@@ -714,517 +629,8 @@ int TClientCommandRootCommon::Run(TConfig& config) {
     return EXIT_SUCCESS;
 }
 
-bool TClientCommandRootCommon::GetCredentialsFromProfile(std::shared_ptr<IProfile> profile, TConfig& config, bool explicitOption) {
-    if (!profile || !profile->Has("authentication")) {
-        return false;
-    }
-    auto authValue = profile->GetValue("authentication");
-    if (!authValue["method"]) {
-        MisuseErrors.push_back("Configuration profile has \"authentication\" but does not have \"method\" in it");
-        return false;
-    }
-    TString authMethod = authValue["method"].as<TString>();
-
-    if (authMethod == "use-metadata-credentials") {
-        if (!IsAuthSet && (explicitOption || !Profile)) {
-            if (IsVerbose()) {
-                PrintSettingFromProfile("metadata service", profile, explicitOption);
-            }
-            config.UseMetadataCredentials = true;
-            config.ChosenAuthMethod = "use-metadata-credentials";
-            IsAuthSet = true;
-        }
-        if (IsVerbose()) {
-            config.ConnectionParams["use-metadata-credentials"].push_back({"true", GetProfileSource(profile, explicitOption)});
-        }
-        return true;
-    }
-    if (authMethod == "anonymous-auth") {
-        if (!IsAuthSet && (explicitOption || !Profile)) {
-            if (IsVerbose()) {
-                PrintSettingFromProfile("anonymous authentication", profile, explicitOption);
-            }
-            config.ChosenAuthMethod = "anonymous-auth";
-            IsAuthSet = true;
-        }
-        if (IsVerbose()) {
-            config.ConnectionParams["anonymous-auth"].push_back({"true", GetProfileSource(profile, explicitOption)});
-        }
-        return true;
-    }
-    bool knownMethod = false;
-    if (config.UseOauth2TokenExchange) {
-        knownMethod |= (authMethod == "oauth2-key-file");
-    }
-    if (config.UseIamAuth) {
-        knownMethod |= (authMethod == "iam-token" || authMethod == "yc-token" || authMethod == "sa-key-file" ||
-                        authMethod == "token-file" || authMethod == "yc-token-file");
-    }
-    if (config.UseAccessToken) {
-        knownMethod |= (authMethod == "ydb-token" || authMethod == "token-file");
-    }
-    if (config.UseStaticCredentials) {
-        knownMethod |= (authMethod == "static-credentials");
-    }
-    if (!knownMethod) {
-        MisuseErrors.push_back(TStringBuilder() << "Unknown authentication method in configuration profile: \""
-            << authMethod << "\"");
-        return false;
-    }
-    if (!authValue["data"]) {
-        MisuseErrors.push_back(TStringBuilder() << "Active configuration profile has \"authentication\" with method \""
-            << authMethod << "\" in it, but no \"data\"");
-        return false;
-    }
-    auto authData = authValue["data"];
-
-    if (authMethod == "iam-token") {
-        if (!IsAuthSet && (explicitOption || !Profile)) {
-            if (IsVerbose()) {
-                PrintSettingFromProfile("iam token", profile, explicitOption);
-            }
-            config.SecurityToken = authData.as<TString>();
-            config.ChosenAuthMethod = "token";
-            IsAuthSet = true;
-        }
-        if (IsVerbose()) {
-            config.ConnectionParams["token"].push_back({authData.as<TString>(), GetProfileSource(profile, explicitOption)});
-        }
-    } else if (authMethod == "token-file") {
-        TString filename = authData.as<TString>();
-        TString fileContent;
-        if (!ReadFromFileIfExists(filename, "token", fileContent, true)) {
-            MisuseErrors.push_back(TStringBuilder() << "Couldn't read token from file " << filename);
-            return false;
-        }
-        if (!fileContent) {
-            MisuseErrors.push_back(TStringBuilder() << "Empty token file " << filename << " provided");
-            return false;
-        }
-        if (!IsAuthSet && (explicitOption || !Profile)) {
-            if (IsVerbose()) {
-                PrintSettingFromProfile("token file", profile, explicitOption);
-            }
-            config.SecurityToken = fileContent;
-            config.ChosenAuthMethod = "token";
-            IsAuthSet = true;
-        }
-        if (IsVerbose()) {
-            config.ConnectionParams["token"].push_back({fileContent, GetProfileSource(profile, explicitOption)});
-        }
-    } else if (authMethod == "oauth2-key-file") {
-        TString filePath = authData.as<TString>();
-        if (filePath.StartsWith("~")) {
-            filePath = HomeDir + filePath.substr(1);
-        }
-        if (!IsAuthSet && (explicitOption || !Profile)) {
-            if (IsVerbose()) {
-                PrintSettingFromProfile("oauth2 key file (oauth2-key-file)", profile, explicitOption);
-            }
-            config.Oauth2KeyFile = filePath;
-            config.ChosenAuthMethod = "oauth2-key-file";
-            IsAuthSet = true;
-        }
-        if (IsVerbose()) {
-            config.ConnectionParams["oauth2-key-file"].push_back({filePath, GetProfileSource(profile, explicitOption)});
-        }
-    } else if (authMethod == "yc-token") {
-        if (!IsAuthSet && (explicitOption || !Profile)) {
-            if (IsVerbose()) {
-                PrintSettingFromProfile("Yandex.Cloud Passport token (yc-token)", profile, explicitOption);
-            }
-            config.YCToken = authData.as<TString>();
-            config.ChosenAuthMethod = "yc-token";
-            IsAuthSet = true;
-        }
-        if (IsVerbose()) {
-            config.ConnectionParams["yc-token"].push_back({authData.as<TString>(), GetProfileSource(profile, explicitOption)});
-        }
-    } else if (authMethod == "yc-token-file") {
-        TString filename = authData.as<TString>();
-        TString fileContent;
-        if (!ReadFromFileIfExists(filename, "token", fileContent, true)) {
-            MisuseErrors.push_back(TStringBuilder() << "Couldn't read token from file " << filename);
-            return false;
-        }
-        if (!fileContent) {
-            MisuseErrors.push_back(TStringBuilder() << "Empty token file " << filename << " provided");
-            return false;
-        }
-        if (!IsAuthSet && (explicitOption || !Profile)) {
-            if (IsVerbose()) {
-                PrintSettingFromProfile("Yandex.Cloud Passport token file (yc-token-file)", profile, explicitOption);
-            }
-            config.YCToken = fileContent;
-            config.ChosenAuthMethod = "yc-token";
-            IsAuthSet = true;
-        }
-        if (IsVerbose()) {
-            config.ConnectionParams["yc-token"].push_back({fileContent, GetProfileSource(profile, explicitOption)});
-        }
-    } else if (authMethod == "sa-key-file") {
-        TString filePath = authData.as<TString>();
-        if (filePath.StartsWith("~")) {
-            filePath = HomeDir + filePath.substr(1);
-        }
-        if (!IsAuthSet && (explicitOption || !Profile)) {
-            if (IsVerbose()) {
-                PrintSettingFromProfile("service account key file (sa-key-file)", profile, explicitOption);
-            }
-            config.SaKeyFile = filePath;
-            config.ChosenAuthMethod = "sa-key-file";
-            IsAuthSet = true;
-        }
-        if (IsVerbose()) {
-            config.ConnectionParams["sa-key-file"].push_back({filePath, GetProfileSource(profile, explicitOption)});
-        }
-    } else if (authMethod == "ydb-token") {
-        if (!IsAuthSet && (explicitOption || !Profile)) {
-            if (IsVerbose()) {
-                PrintSettingFromProfile("Access token (ydb-token)", profile, explicitOption);
-            }
-            config.SecurityToken = authData.as<TString>();
-            config.ChosenAuthMethod = "token";
-            IsAuthSet = true;
-        }
-        if (IsVerbose()) {
-            config.ConnectionParams["token"].push_back({authData.as<TString>(), GetProfileSource(profile, explicitOption)});
-        }
-    } else if (authMethod == "static-credentials") {
-        if (!IsAuthSet && (explicitOption || !Profile) && IsVerbose()) {
-            PrintSettingFromProfile("user name & password", profile, explicitOption);
-        }
-        if (authData["user"]) {
-            if (!IsAuthSet && (explicitOption || !Profile)) {
-                config.StaticCredentials.User = authData["user"].as<TString>();
-            }
-            if (IsVerbose()) {
-                config.ConnectionParams["user"].push_back({authData["user"].as<TString>(), GetProfileSource(profile, explicitOption)});
-            }
-        }
-        if (authData["password"]) {
-            if (!IsAuthSet && (explicitOption || !Profile)) {
-                config.StaticCredentials.Password = authData["password"].as<TString>();
-                if (config.StaticCredentials.Password.empty()) {
-                    DoNotAskForPassword = true;
-                }
-            }
-            if (IsVerbose()) {
-                config.ConnectionParams["password"].push_back({authData["password"].as<TString>(), GetProfileSource(profile, explicitOption)});
-            }
-        }
-        if (authData["password-file"]) {
-            TString filename = authData["password-file"].as<TString>();
-            TString fileContent;
-            if (!ReadFromFileIfExists(filename, "password", fileContent, true)) {
-                MisuseErrors.push_back(TStringBuilder() << "Couldn't read password from file " << filename);
-                DoNotAskForPassword = true;
-                return false;
-            }
-            if (!IsAuthSet && (explicitOption || !Profile)) {
-                config.StaticCredentials.Password = fileContent;
-                if (config.StaticCredentials.Password.empty()) {
-                    DoNotAskForPassword = true;
-                }
-            }
-            if (IsVerbose()) {
-                config.ConnectionParams["password"].push_back({fileContent, GetProfileSource(profile, explicitOption)});
-            }
-        }
-        config.ChosenAuthMethod = "static-credentials";
-        IsAuthSet = true;
-    } else {
-        return false;
-    }
-    return true;
-}
-
 void TClientCommandRootCommon::ParseCredentials(TConfig& config) {
-    size_t explicitAuthMethodCount = (size_t)(config.ParseResult->Has("iam-token-file")) + (size_t)(config.ParseResult->Has("token-file"))
-        + (size_t)(!YCTokenFile.empty())
-        + (size_t)UseMetadataCredentials + (size_t)(!SaKeyFile.empty())
-        + (size_t)(!UserName.empty() || !PasswordFile.empty() || DoNotAskForPassword)
-        + (size_t)(!Oauth2KeyFile.empty());
-
-    switch (explicitAuthMethodCount) {
-    case 1:
-        // Priority 1. Exactly one explicit auth method. Using it.
-        if (config.ParseResult->Has("token-file")) {
-            config.SecurityToken = ReadFromFile(TokenFile, "token");
-            config.ChosenAuthMethod = "token";
-            if (IsVerbose()) {
-                Cerr << "Using token from file provided with explicit option" << Endl;
-                config.ConnectionParams["token"].push_back({config.SecurityToken, "file provided with explicit --token-file option"});
-            }
-        } else if (Oauth2KeyFile) {
-            config.Oauth2KeyFile = Oauth2KeyFile;
-            config.ChosenAuthMethod = "oauth2-key-file";
-            if (IsVerbose()) {
-                Cerr << "Using oauth2 key file provided with --oauth2-key-file option" << Endl;
-                config.ConnectionParams["oauth2-key-file"].push_back({config.Oauth2KeyFile, "explicit --oauth2-key-file option"});
-            }
-        } else if (config.ParseResult->Has("iam-token-file")) {
-            config.SecurityToken = ReadFromFile(TokenFile, "token");
-            config.ChosenAuthMethod = "token";
-            if (IsVerbose()) {
-                Cerr << "Using IAM token from file provided with explicit option" << Endl;
-                config.ConnectionParams["token"].push_back({config.SecurityToken, "file provided with explicit --iam-token-file option"});
-            }
-        } else if (YCTokenFile) {
-            config.YCToken = ReadFromFile(YCTokenFile, "token");
-            config.ChosenAuthMethod = "yc-token";
-            if (IsVerbose()) {
-                Cerr << "Using Yandex.Cloud Passport token from file provided with --yc-token-file option" << Endl;
-                config.ConnectionParams["yc-token"].push_back({config.YCToken, "file provided with explicit --yc-token-file option"});
-            }
-        } else if (UseMetadataCredentials) {
-            config.ChosenAuthMethod = "use-metadata-credentials";
-            config.UseMetadataCredentials = true;
-            if (IsVerbose()) {
-                Cerr << "Using metadata service due to --use-metadata-credentials option" << Endl;
-                config.ConnectionParams["use-metadata-credentials"].push_back({"true", "explicit --use-metadata-credentials option"});
-            }
-        } else if (SaKeyFile) {
-            config.SaKeyFile = SaKeyFile;
-            config.ChosenAuthMethod = "sa-key-file";
-            if (IsVerbose()) {
-                Cerr << "Using service account key file provided with --sa-key-file option" << Endl;
-                config.ConnectionParams["sa-key-file"].push_back({config.SaKeyFile, "explicit --sa-key-file option"});
-            }
-        } else if (UserName || PasswordFile) {
-            if (UserName) {
-                config.StaticCredentials.User = UserName;
-                if (IsVerbose()) {
-                    Cerr << "Using user name provided with --user option" << Endl;
-                    config.ConnectionParams["user"].push_back({UserName, "explicit --user option"});
-                }
-            }
-            if (PasswordFile) {
-                config.StaticCredentials.Password = ReadFromFile(PasswordFile, "password", true);
-                if (config.StaticCredentials.Password.empty()) {
-                    DoNotAskForPassword = true;
-                }
-                if (IsVerbose()) {
-                    Cerr << "Using user password from file provided with --password-file option" << Endl;
-                    config.ConnectionParams["password"].push_back({TString{config.StaticCredentials.Password}, "file provided with explicit --password-file option"});
-                }
-            }
-            config.ChosenAuthMethod = "static-credentials";
-        }
-        IsAuthSet = true;
-        if (!IsVerbose()) {
-            break;
-        }
-    case 0:
-    {
-        // Priority 2. No explicit auth methods. Checking configuration profile given via --profile option.
-        if (GetCredentialsFromProfile(Profile, config, true) && !IsVerbose()) {
-            break;
-        }
-
-        // Priority 3. No auth methods from --profile either. Checking environment variables.
-        if (config.UseIamAuth) {
-            TString envIamToken = GetEnv("IAM_TOKEN");
-            if (!envIamToken.empty()) {
-                if (!IsAuthSet) {
-                    if (IsVerbose()) {
-                        Cerr << "Using iam token from IAM_TOKEN env variable" << Endl;
-                    }
-                    config.ChosenAuthMethod = "token";
-                    config.SecurityToken = envIamToken;
-                    IsAuthSet = true;
-                }
-                if (!IsVerbose()) {
-                    break;
-                }
-                config.ConnectionParams["token"].push_back({envIamToken, "IAM_TOKEN enviroment variable"});
-            }
-            TString envYcToken = GetEnv("YC_TOKEN");
-            if (!envYcToken.empty()) {
-                if (!IsAuthSet) {
-                    if (IsVerbose()) {
-                        Cerr << "Using Yandex.Cloud Passport token from YC_TOKEN env variable" << Endl;
-                    }
-                    config.ChosenAuthMethod = "yc-token";
-                    config.YCToken = envYcToken;
-                    IsAuthSet = true;
-                }
-                if (!IsVerbose()) {
-                    break;
-                }
-                config.ConnectionParams["yc-token"].push_back({envYcToken, "YC_TOKEN enviroment variable"});
-            }
-            if (GetEnv("USE_METADATA_CREDENTIALS") == "1") {
-                if (!IsAuthSet) {
-                    if (IsVerbose()) {
-                        Cerr << "Using metadata service due to USE_METADATA_CREDENTIALS=\"1\" env variable" << Endl;
-                    }
-                    config.ChosenAuthMethod = "use-metadata-credentials";
-                    config.UseMetadataCredentials = true;
-                    IsAuthSet = true;
-                }
-                if (!IsVerbose()) {
-                    break;
-                }
-                config.ConnectionParams["use-metadata-credentials"].push_back({"true", "USE_METADATA_CREDENTIALS enviroment variable"});
-            }
-            TString envSaKeyFile = GetEnv("SA_KEY_FILE");
-            if (!envSaKeyFile.empty()) {
-                if (!IsAuthSet) {
-                    if (IsVerbose()) {
-                        Cerr << "Using service account key file from SA_KEY_FILE env variable" << Endl;
-                    }
-                    config.ChosenAuthMethod = "sa-key-file";
-                    config.SaKeyFile = envSaKeyFile;
-                    IsAuthSet = true;
-                }
-                if (!IsVerbose()) {
-                    break;
-                }
-                config.ConnectionParams["sa-key-file"].push_back({envSaKeyFile, "SA_KEY_FILE enviroment variable"});
-            }
-        }
-        if (config.UseAccessToken) {
-            TString envYdbToken = GetEnv("YDB_TOKEN");
-            if (!envYdbToken.empty()) {
-                if (!IsAuthSet) {
-                    if (IsVerbose()) {
-                        Cerr << "Using access token from YDB_TOKEN env variable" << Endl;
-                    }
-                    config.ChosenAuthMethod = "token";
-                    config.SecurityToken = envYdbToken;
-                    IsAuthSet = true;
-                }
-                if (!IsVerbose()) {
-                    break;
-                }
-                config.ConnectionParams["token"].push_back({envYdbToken, "YDB_TOKEN enviroment variable"});
-            }
-        }
-        if (config.UseStaticCredentials) {
-            TString userName = GetEnv("YDB_USER");
-            bool hasStaticCredentials = false;
-            if (!userName.empty()) {
-                if (!IsAuthSet) {
-                    if (IsVerbose()) {
-                        Cerr << "Using user name from YDB_USER env variable" << Endl;
-                    }
-                    hasStaticCredentials = true;
-                    config.StaticCredentials.User = userName;
-                }
-                if (IsVerbose()) {
-                    config.ConnectionParams["user"].push_back({userName, "YDB_USER enviroment variable"});
-                }
-            }
-
-            TString password = GetEnv("YDB_PASSWORD");
-            if (!password.empty()) {
-                if (!IsAuthSet) {
-                    if (IsVerbose()) {
-                        Cerr << "Using user password from YDB_PASSWORD env variable" << Endl;
-                    }
-                    hasStaticCredentials = true;
-                    config.StaticCredentials.Password = password;
-                }
-                if (IsVerbose()) {
-                    config.ConnectionParams["password"].push_back({password, "YDB_PASSWORD enviroment variable"});
-                }
-            }
-            if (hasStaticCredentials) {
-                config.ChosenAuthMethod = "static-credentials";
-                IsAuthSet = true;
-            }
-            if (!IsVerbose() && (!userName.empty() || !password.empty())) {
-                break;
-            }
-        }
-
-        if (config.UseOauth2TokenExchange) {
-            TString envOauth2KeyFile = GetEnv("YDB_OAUTH2_KEY_FILE");
-            if (!envOauth2KeyFile.empty()) {
-                if (!IsAuthSet) {
-                    if (IsVerbose()) {
-                        Cerr << "Using oauth2 key file from YDB_OAUTH2_KEY_FILE env variable" << Endl;
-                    }
-                    config.ChosenAuthMethod = "oauth2-key-file";
-                    config.Oauth2KeyFile = envOauth2KeyFile;
-                    IsAuthSet = true;
-                }
-                if (!IsVerbose()) {
-                    break;
-                }
-                config.ConnectionParams["oauth2-key-file"].push_back({envOauth2KeyFile, "YDB_OAUTH2_KEY_FILE enviroment variable"});
-            }
-        }
-
-        // Priority 4. No auth methods from environment variables too. Checking active configuration profile.
-        // (if --profile option is not set)
-        if (GetCredentialsFromProfile(ProfileManager->GetActiveProfile(), config, false) && !IsVerbose()) {
-            break;
-        }
-
-        if (Settings.UseDefaultTokenFile.GetRef()) {
-            // Priority 5. No auth methods from active configuration profile. Checking default token file.
-            TString tokenFile = defaultTokenFile;
-            TString fileContent;
-            if (ReadFromFileIfExists(tokenFile, "default token", fileContent)) {
-                if (!IsAuthSet) {
-                    if (IsVerbose()) {
-                        Cerr << "Using auth token from default token file " << defaultTokenFile << Endl;
-                    }
-                    config.ChosenAuthMethod = "token";
-                    config.SecurityToken = fileContent;
-                }
-                if (IsVerbose()) {
-                    config.ConnectionParams["token"].push_back({fileContent, "default token file"});
-                }
-            } else {
-                if (!IsAuthSet && IsVerbose()) {
-                    Cerr << "No authentication methods were found. Going without authentication" << Endl;
-                }
-            }
-        }
-        break;
-    }
-    default:
-        TStringBuilder str;
-        str << explicitAuthMethodCount << " methods were provided via options:";
-        if (!TokenFile.empty()) {
-            str << " TokenFile (" << TokenFile << ")";
-        }
-        if (!YCTokenFile.empty()) {
-            str << " YCTokenFile (" << YCTokenFile << ")";
-        }
-        if (!SaKeyFile.empty()) {
-            str << " SaKeyFile (" << SaKeyFile << ")";
-        }
-        if (UseMetadataCredentials) {
-            str << " UseMetadataCredentials (true)";
-        }
-        if (Oauth2KeyFile) {
-            str << " OAuth2KeyFile (" << Oauth2KeyFile << ")";
-        }
-
-        MisuseErrors.push_back(TStringBuilder() << str << ". Choose exactly one of them");
-        return;
-    }
-
-    if (config.UseStaticCredentials) {
-        if (!config.StaticCredentials.User.empty()) {
-            if (config.StaticCredentials.Password.empty() && !DoNotAskForPassword) {
-                Cerr << "Enter password for user " << config.StaticCredentials.User << ": ";
-                config.StaticCredentials.Password = InputPassword();
-                if (IsVerbose()) {
-                    config.ConnectionParams["password"].push_back({TString{config.StaticCredentials.Password}, "standard input"});
-                }
-            }
-        } else {
-            if (!config.StaticCredentials.Password.empty()) {
-                MisuseErrors.push_back("User password was provided without user name");
-                return;
-            }
-        }
-    }
+    Y_UNUSED(config);
 }
 
 }

--- a/ydb/public/lib/ydb_cli/commands/ydb_root_common.cpp
+++ b/ydb/public/lib/ydb_cli/commands/ydb_root_common.cpp
@@ -323,7 +323,7 @@ void TClientCommandRootCommon::Config(TConfig& config) {
     NColorizer::TColors colors = NColorizer::AutoColors(Cout);
     stream << " [options...] <subcommand>" << Endl << Endl
         << colors.BoldColor() << "Subcommands" << colors.OldColor() << ":" << Endl;
-    RenderCommandsDescription(stream, colors);
+    RenderCommandDescription(stream, config.HelpCommandVerbosiltyLevel > 1, colors);
     stream << Endl << Endl << colors.BoldColor() << "Commands in " << colors.Red() << colors.BoldColor() <<  "admin" << colors.OldColor() << colors.BoldColor() << " subtree may treat global flags and profile differently, see corresponding help" << colors.OldColor() << Endl;
     opts.SetCmdLineDescr(stream.Str());
 

--- a/ydb/public/lib/ydb_cli/commands/ydb_root_common.h
+++ b/ydb/public/lib/ydb_cli/commands/ydb_root_common.h
@@ -36,7 +36,6 @@ public:
     void Config(TConfig& config) override;
     void ExtractParams(TConfig& config) override;
     void Parse(TConfig& config) override;
-    void ParseAddress(TConfig& config) override;
     void ParseCredentials(TConfig& config) override;
     void Validate(TConfig& config) override;
     int Run(TConfig& config) override;
@@ -46,17 +45,15 @@ protected:
 
 private:
     void ValidateSettings();
-    bool GetCredentialsFromProfile(std::shared_ptr<IProfile> profile, TConfig& config, bool explicitOption);
 
     void ParseProfile();
-    void ParseDatabase(TConfig& config);
+    void ParseAddress(TConfig&) override {}
     void ParseIamEndpoint(TConfig& config);
     void ParseCaCerts(TConfig& config) override;
     void ParseClientCert(TConfig& config) override;
-    void GetAddressFromString(TConfig& config, TString* result = nullptr);
-    bool ParseProtocolNoConfig(TString& message);
-    void GetCaCerts(TConfig& config);
-    void GetClientCert(TConfig& config);
+    void ParseStaticCredentials(TConfig& config);
+    static TString GetAddressFromString(const TString& address, bool* enableSsl = nullptr, std::vector<TString>* errors = nullptr);
+    static bool ParseProtocolNoConfig(TString& address, bool* enableSsl, TString& message);
     bool TryGetParamFromProfile(const TString& name, const std::shared_ptr<IProfile>& profile, bool explicitOption,
                                 std::function<bool(const TString&, const TString&, bool)> callback);
 
@@ -80,24 +77,14 @@ private:
 
     TString UserName;
     TString PasswordFile;
+    TString Password;
+    // Password from separate option
+    TString PasswordFileOption;
+    TString PasswordOption;
     bool DoNotAskForPassword = false;
 
-    bool UseMetadataCredentials = false;
-    TString YCToken;
-    TString YCTokenFile;
-    TString SaKeyFile;
-    TString IamEndpoint;
     const TClientSettings& Settings;
     TVector<TString> MisuseErrors;
-
-    TString Oauth2KeyFile;
-
-    bool IsAddressSet = false;
-    bool IsDatabaseSet = false;
-    bool IsIamEndpointSet = false;
-    bool IsCaCertsFileSet = false;
-    bool IsClientCertFileSet = false;
-    bool IsAuthSet = false;
 };
 
 }

--- a/ydb/public/lib/ydb_cli/commands/ydb_service_discovery.cpp
+++ b/ydb/public/lib/ydb_cli/commands/ydb_service_discovery.cpp
@@ -58,7 +58,7 @@ TCommandWhoAmI::TCommandWhoAmI()
 
 void TCommandWhoAmI::Config(TConfig& config) {
     TYdbSimpleCommand::Config(config);
-    config.Opts->AddLongOption('g', "groups", "With groups").NoArgument().SetFlag(&WithGroups);
+    config.Opts->AddLongOption('g', "groups", "With groups").StoreTrue(&WithGroups);
     config.SetFreeArgsNum(0);
 }
 

--- a/ydb/public/lib/ydb_cli/commands/ydb_service_export.cpp
+++ b/ydb/public/lib/ydb_cli/commands/ydb_service_export.cpp
@@ -128,7 +128,7 @@ void TCommandExportToYt::Config(TConfig& config) {
         .RequiredArgument("PROPERTY=VALUE,...");
 
     config.Opts->AddLongOption("exclude", "Pattern (PCRE) for paths excluded from export operation")
-        .RequiredArgument("STRING").Handler1T<TString>([this](const TString& arg) {
+        .RequiredArgument("STRING").Handler([this](const TString& arg) {
             ExclusionPatterns.emplace_back(TRegExMatch(arg));
         });
 
@@ -278,7 +278,7 @@ void TCommandExportToS3::Config(TConfig& config) {
         .RequiredArgument("PROPERTY=VALUE,...");
 
     config.Opts->AddLongOption("exclude", "Pattern (PCRE) for paths excluded from export operation")
-        .RequiredArgument("STRING").Handler1T<TString>([this](const TString& arg) {
+        .RequiredArgument("STRING").Handler([this](const TString& arg) {
             ExclusionPatterns.emplace_back(TRegExMatch(arg));
         });
 

--- a/ydb/public/lib/ydb_cli/commands/ydb_service_import.cpp
+++ b/ydb/public/lib/ydb_cli/commands/ydb_service_import.cpp
@@ -226,7 +226,7 @@ TCommandImportFromFile::TCommandImportFromFile()
 void TCommandImportFileBase::Config(TConfig& config) {
     TYdbCommand::Config(config);
 
-    config.Opts->SetTrailingArgTitle("<input files...>",
+    config.Opts->GetOpts().SetTrailingArgTitle("<input files...>",
             "One or more file paths to import from");
     config.Opts->AddLongOption("timeout", "Operation timeout. Operation should be executed on server within this timeout. "
             "There could also be a delay up to 200ms to receive timeout error from server")

--- a/ydb/public/lib/ydb_cli/commands/ydb_service_table.cpp
+++ b/ydb/public/lib/ydb_cli/commands/ydb_service_table.cpp
@@ -897,7 +897,7 @@ void TCommandExplain::Config(TConfig& config) {
     config.Opts->AddLongOption('t', "type", "Query type [data, scan, generic]")
         .RequiredArgument("[String]").DefaultValue("data").StoreResult(&QueryType);
     config.Opts->AddLongOption("analyze", "Run query and collect execution statistics")
-        .NoArgument().SetFlag(&Analyze);
+        .StoreTrue(&Analyze);
     config.Opts->AddLongOption("flame-graph", "Builds resource usage flame graph, based on analyze info")
             .RequiredArgument("PATH").StoreResult(&FlameGraphPath);
     config.Opts->AddLongOption("collect-diagnostics", "Collects diagnostics and saves it to file")
@@ -1080,13 +1080,13 @@ void TCommandReadTable::Config(TConfig& config) {
     TYdbCommand::Config(config);
 
     config.Opts->AddLongOption("ordered", "Result should be ordered by primary key")
-        .NoArgument().SetFlag(&Ordered);
+        .StoreTrue(&Ordered);
     config.Opts->AddLongOption("limit", "Limit result rows count")
         .RequiredArgument("NUM").StoreResult(&RowLimit);
     config.Opts->AddLongOption("columns", "Comma separated list of columns to read")
         .RequiredArgument("CSV").StoreResult(&Columns);
     config.Opts->AddLongOption("count-only", "Print only rows count")
-        .NoArgument().SetFlag(&CountOnly);
+        .StoreTrue(&CountOnly);
     config.Opts->AddLongOption("from", "Key prefix value to start read from.\n"
             "  Format should be a json-string containing array of elements representing a tuple - key prefix.\n"
             "  Option \"--input-format\" defines how to parse binary strings.\n"
@@ -1100,9 +1100,9 @@ void TCommandReadTable::Config(TConfig& config) {
             "  Same format as for \"--from\" option.")
         .RequiredArgument("JSON").StoreResult(&To);
     config.Opts->AddLongOption("from-exclusive", "Don't include the left border element into response")
-        .NoArgument().SetFlag(&FromExclusive);
+        .StoreTrue(&FromExclusive);
     config.Opts->AddLongOption("to-exclusive", "Don't include the right border element into response")
-        .NoArgument().SetFlag(&ToExclusive);
+        .StoreTrue(&ToExclusive);
 
     AddLegacyJsonInputFormats(config);
 
@@ -1376,7 +1376,7 @@ void TCommandAttributeAdd::Config(TConfig& config) {
     TYdbCommand::Config(config);
 
     config.Opts->AddLongOption("attribute", "[At least one] key=value pair(s) to add.")
-        .RequiredArgument("KEY=VALUE").KVHandler([&](TString key, TString value) {
+        .RequiredArgument("KEY=VALUE").GetOpt().KVHandler([&](TString key, TString value) {
             Attributes[key] = value;
         });
 
@@ -1411,7 +1411,7 @@ void TCommandAttributeDrop::Config(TConfig& config) {
     TYdbCommand::Config(config);
 
     config.Opts->AddLongOption("attributes", "Attribute keys to drop.")
-        .RequiredArgument("KEY,[KEY...]").SplitHandler(&AttributeKeys, ',');
+        .RequiredArgument("KEY,[KEY...]").GetOpt().SplitHandler(&AttributeKeys, ',');
 
     config.SetFreeArgsNum(1);
     SetFreeArgTitle(0, "<table path>", "Path to a table");
@@ -1450,7 +1450,7 @@ void TCommandTtlSet::Config(TConfig& config) {
     config.Opts->AddLongOption("column", "Name of date- or integral-type column to be used to calculate expiration threshold.")
         .RequiredArgument("NAME").StoreResult(&ColumnName);
     config.Opts->AddLongOption("expire-after", "Additional time that must pass since expiration threshold.")
-        .RequiredArgument("SECONDS").DefaultValue(0).Handler1T<TDuration::TValue>(0, [this](const TDuration::TValue& arg) {
+        .RequiredArgument("SECONDS").DefaultValue(0).GetOpt().Handler1T<TDuration::TValue>(0, [this](const TDuration::TValue& arg) {
             ExpireAfter = TDuration::Seconds(arg);
         });
 
@@ -1459,7 +1459,7 @@ void TCommandTtlSet::Config(TConfig& config) {
         << "Interpretation of the value stored in integral-type column." << Endl
         << "Allowed units: " << allowedUnits;
     config.Opts->AddLongOption("unit", unitHelp)
-        .RequiredArgument("STRING").Handler1T<TString>("", [this, allowedUnits](const TString& arg) {
+        .RequiredArgument("STRING").GetOpt().Handler1T<TString>("", [this, allowedUnits](const TString& arg) {
             if (!arg) {
                 return;
             }
@@ -1473,7 +1473,7 @@ void TCommandTtlSet::Config(TConfig& config) {
         });
 
     config.Opts->AddLongOption("run-interval", "[Advanced] How often to run cleanup operation on the same partition.")
-        .RequiredArgument("SECONDS").Handler1T<TDuration::TValue>([this](const TDuration::TValue& arg) {
+        .RequiredArgument("SECONDS").GetOpt().Handler1T<TDuration::TValue>([this](const TDuration::TValue& arg) {
             RunInterval = TDuration::Seconds(arg);
         });
 

--- a/ydb/public/lib/ydb_cli/commands/ydb_service_topic.cpp
+++ b/ydb/public/lib/ydb_cli/commands/ydb_service_topic.cpp
@@ -792,7 +792,8 @@ namespace NYdb::NConsoleClient {
             .StoreResult(&IdleTimeout_);
         config.Opts->AddLongOption("commit", "Commit messages after successful read")
             .Optional()
-            .StoreTrue(&Commit_);
+            .DefaultValue(false)
+            .StoreResult(&Commit_);
         config.Opts->AddLongOption("limit", "Limit on message count to read, 0 - unlimited. "
                                             "If avobe 0, processing stops when either topic is empty, or the specified limit reached. "
                                             "Must be above 0 for pretty output format."

--- a/ydb/public/lib/ydb_cli/commands/ydb_service_topic.cpp
+++ b/ydb/public/lib/ydb_cli/commands/ydb_service_topic.cpp
@@ -549,7 +549,7 @@ namespace NYdb::NConsoleClient {
         config.Opts->AddLongOption("starting-message-timestamp", "'Written_at' timestamp from which read is allowed. " TIMESTAMP_FORMAT_OPTION_DESCRIPTION)
             .RequiredArgument("TIMESTAMP")
             .Optional()
-            .Handler1T<TString>(TimestampOptionHandler(&StartingMessageTimestamp_));
+            .Handler(TimestampOptionHandler(&StartingMessageTimestamp_));
         config.Opts->AddLongOption("important", "Is consumer important")
             .Optional()
             .DefaultValue(false)
@@ -792,8 +792,7 @@ namespace NYdb::NConsoleClient {
             .StoreResult(&IdleTimeout_);
         config.Opts->AddLongOption("commit", "Commit messages after successful read")
             .Optional()
-            .DefaultValue(false)
-            .StoreResult(&Commit_);
+            .StoreTrue(&Commit_);
         config.Opts->AddLongOption("limit", "Limit on message count to read, 0 - unlimited. "
                                             "If avobe 0, processing stops when either topic is empty, or the specified limit reached. "
                                             "Must be above 0 for pretty output format."
@@ -802,15 +801,14 @@ namespace NYdb::NConsoleClient {
             .StoreResult(&Limit_);
         config.Opts->AddLongOption('w', "wait", "Wait indefinitely for a first message received. If not specified, command exits on empty topic returning no data to the output.")
             .Optional()
-            .NoArgument()
-            .StoreValue(&Wait_, true);
+            .StoreTrue(&Wait_);
         config.Opts->AddLongOption("timestamp", "'Written_at' timestamp from which messages will be read. If not specified, messages are read from the last commit point for the chosen consumer. " TIMESTAMP_FORMAT_OPTION_DESCRIPTION)
             .RequiredArgument("TIMESTAMP")
             .Optional()
-            .Handler1T<TString>(TimestampOptionHandler(&Timestamp_));
+            .Handler(TimestampOptionHandler(&Timestamp_));
         config.Opts->AddLongOption("partition-ids", "Comma separated list of partition ids to read from. If not specified, messages are read from all partitions. E.g. \"--partition-ids 0,1,10\"")
             .Optional()
-            .SplitHandler(&PartitionIds_, ',');
+            .GetOpt().SplitHandler(&PartitionIds_, ',');
 
         AddAllowedMetadataFields(config);
         AddTransform(config);
@@ -895,7 +893,7 @@ namespace NYdb::NConsoleClient {
                                      << "limit less and equal '0' or more than '500': '" << *Limit_ << "' was given";
         }
 
-        // validate partitions ids are specified, if no consumer is provided. no-consumer mode will be used. 
+        // validate partitions ids are specified, if no consumer is provided. no-consumer mode will be used.
         if (!Consumer_ && !PartitionIds_) {
             throw TMisuseException() << "Please specify either --consumer or --partition-ids to read without consumer";
         }

--- a/ydb/public/lib/ydb_cli/commands/ydb_service_topic.cpp
+++ b/ydb/public/lib/ydb_cli/commands/ydb_service_topic.cpp
@@ -795,7 +795,7 @@ namespace NYdb::NConsoleClient {
             .DefaultValue(false)
             .StoreResult(&Commit_);
         config.Opts->AddLongOption("limit", "Limit on message count to read, 0 - unlimited. "
-                                            "If avobe 0, processing stops when either topic is empty, or the specified limit reached. "
+                                            "If above 0, processing stops when either topic is empty, or the specified limit reached. "
                                             "Must be above 0 for pretty output format."
                                             "\nDefault is 10 for pretty format, unlimited for streaming formats.")
             .Optional()

--- a/ydb/public/lib/ydb_cli/commands/ydb_tools.cpp
+++ b/ydb/public/lib/ydb_cli/commands/ydb_tools.cpp
@@ -52,7 +52,7 @@ void TCommandDump::Config(TConfig& config) {
         .DefaultValue(".").StoreResult(&Path);
     config.Opts->AddLongOption("exclude", "Pattern(s) (PCRE) for paths excluded from dump."
             " Option can be used several times - one for each pattern.")
-        .RequiredArgument("STRING").Handler1T<TString>([this](const TString& arg) {
+        .RequiredArgument("STRING").Handler([this](const TString& arg) {
             ExclusionPatterns.emplace_back(TRegExMatch(arg));
         });
     config.Opts->AddLongOption('o', "output", "[Required] Path in a local filesystem to a directory to place dump into."
@@ -148,7 +148,7 @@ void TCommandRestore::Config(TConfig& config) {
 
     config.Opts->AddLongOption("restore-indexes", "Whether to restore indexes or not.")
         .DefaultValue(defaults.RestoreIndexes_).StoreResult(&RestoreIndexes);
-    
+
     config.Opts->AddLongOption("restore-acl", "Whether to restore ACL and owner or not.")
         .DefaultValue(defaults.RestoreACL_).StoreResult(&RestoreACL);
 
@@ -163,40 +163,40 @@ void TCommandRestore::Config(TConfig& config) {
 
     config.Opts->AddLongOption("bandwidth", "Limit data upload bandwidth, bytes per second (example: 2MiB).")
         .DefaultValue("no limit")
-        .Handler1T<TString>([this](const TString& arg) {
+        .Handler([this](const TString& arg) {
             UploadBandwidth = (arg == "no limit") ? "0" : arg;
         })
         .Hidden();
 
     config.Opts->AddLongOption("rps", "Limit requests per second (example: 100).")
         .DefaultValue("no limit")
-        .Handler1T<TString>([this](const TString& arg) {
+        .Handler([this](const TString& arg) {
             UploadRps = (arg == "no limit") ? "0" : arg;
         });
 
     config.Opts->AddLongOption("upload-batch-rows", "Limit upload batch size in rows (example: 1K)."
             " Not applicable in ImportData mode.")
         .DefaultValue("no limit")
-        .Handler1T<TString>([this](const TString& arg) {
+        .Handler([this](const TString& arg) {
             RowsPerRequest = (arg == "no limit") ? "0" : arg;
         });
 
     config.Opts->AddLongOption("upload-batch-rus", "Limit upload batch size in request units (example: 100)."
             " Not applicable in ImportData mode.")
         .DefaultValue("no limit")
-        .Handler1T<TString>([this](const TString& arg) {
+        .Handler([this](const TString& arg) {
             RequestUnitsPerRequest = (arg == "no limit") ? "0" : arg;
         });
 
     config.Opts->AddLongOption("upload-batch-bytes", "Limit upload batch size in bytes (example: 1MiB).")
         .DefaultValue("auto")
-        .Handler1T<TString>([this](const TString& arg) {
+        .Handler([this](const TString& arg) {
             BytesPerRequest = (arg == "auto") ? "0" : arg;
         });
 
     config.Opts->AddLongOption("in-flight", "Limit in-flight request count.")
         .DefaultValue("auto")
-        .Handler1T<TString>([this](const TString& arg) {
+        .Handler([this](const TString& arg) {
             InFlight = (arg == "auto") ? 0 : FromString<ui32>(arg);
         });
 

--- a/ydb/public/lib/ydb_cli/commands/ydb_workload.cpp
+++ b/ydb/public/lib/ydb_cli/commands/ydb_workload.cpp
@@ -336,8 +336,8 @@ TWorkloadCommandInit::TWorkloadCommandInit(NYdbWorkload::TWorkloadParams& params
 
 void TWorkloadCommandInit::Config(TConfig& config) {
     TWorkloadCommandBase::Config(config);
-    config.Opts->AddLongOption("clear", "Clear tables before init").NoArgument()
-        .Optional().StoreResult(&Clear, true);
+    config.Opts->AddLongOption("clear", "Clear tables before init")
+        .Optional().StoreTrue(&Clear);
 }
 
 TWorkloadCommandRun::TWorkloadCommandRun(NYdbWorkload::TWorkloadParams& params, const NYdbWorkload::IWorkloadQueryGenerator::TWorkloadType& workload)
@@ -356,7 +356,7 @@ int TWorkloadCommandRun::Run(TConfig& config) {
 void TWorkloadCommandRun::Config(TConfig& config) {
     TWorkloadCommand::Config(config);
     config.Opts->SetFreeArgsNum(0);
-    Params.ConfigureOpts(*config.Opts, NYdbWorkload::TWorkloadParams::ECommandType::Run, Type);
+    Params.ConfigureOpts(config.Opts->GetOpts(), NYdbWorkload::TWorkloadParams::ECommandType::Run, Type);
 }
 
 TWorkloadCommandBase::TWorkloadCommandBase(const TString& name, NYdbWorkload::TWorkloadParams& params, const NYdbWorkload::TWorkloadParams::ECommandType commandType, const TString& description, int type)
@@ -369,9 +369,9 @@ TWorkloadCommandBase::TWorkloadCommandBase(const TString& name, NYdbWorkload::TW
 void TWorkloadCommandBase::Config(TConfig& config) {
     TYdbCommand::Config(config);
     config.Opts->SetFreeArgsNum(0);
-    config.Opts->AddLongOption("dry-run", "Dry run").NoArgument()
-        .Optional().StoreResult(&DryRun, true);
-    Params.ConfigureOpts(*config.Opts, CommandType, Type);
+    config.Opts->AddLongOption("dry-run", "Dry run")
+        .Optional().StoreTrue(&DryRun);
+    Params.ConfigureOpts(config.Opts->GetOpts(), CommandType, Type);
 }
 
 int TWorkloadCommandBase::Run(TConfig& config) {
@@ -447,7 +447,7 @@ TWorkloadCommandRoot::TWorkloadCommandRoot(const TString& key)
 
 void TWorkloadCommandRoot::Config(TConfig& config) {
     TClientCommandTree::Config(config);
-    Params->ConfigureOpts(*config.Opts, NYdbWorkload::TWorkloadParams::ECommandType::Root, 0);
+    Params->ConfigureOpts(config.Opts->GetOpts(), NYdbWorkload::TWorkloadParams::ECommandType::Root, 0);
 }
 
 int TWorkloadCommandInit::DoRun(NYdbWorkload::IWorkloadQueryGenerator& workloadGen, TConfig& config) {

--- a/ydb/public/lib/ydb_cli/commands/ydb_workload_import.cpp
+++ b/ydb/public/lib/ydb_cli/commands/ydb_workload_import.cpp
@@ -38,7 +38,7 @@ TWorkloadCommandImport::TUploadParams::TUploadParams()
 
 void TWorkloadCommandImport::TUploadCommand::Config(TConfig& config) {
     TWorkloadCommandBase::Config(config);
-    Initializer->ConfigureOpts(*config.Opts);
+    Initializer->ConfigureOpts(config.Opts->GetOpts());
 }
 
 TWorkloadCommandImport::TUploadCommand::TUploadCommand(NYdbWorkload::TWorkloadParams& workloadParams, const TUploadParams& uploadParams, NYdbWorkload::TWorkloadDataInitializer::TPtr initializer)

--- a/ydb/public/lib/ydb_cli/common/client_command_options.cpp
+++ b/ydb/public/lib/ydb_cli/common/client_command_options.cpp
@@ -1,0 +1,762 @@
+#include "client_command_options.h"
+#include "profile_manager.h"
+
+#include <ydb/public/lib/ydb_cli/common/common.h>
+
+#include <library/cpp/colorizer/colors.h>
+#include <library/cpp/yaml/as/tstring.h>
+
+#include <util/string/strip.h>
+#include <util/string/subst.h>
+#include <util/system/env.h>
+
+namespace NYdb::NConsoleClient {
+
+TClientCommandOptions::TClientCommandOptions(NLastGetopt::TOpts opts)
+    : Opts(std::move(opts))
+{
+}
+
+void TClientCommandOptions::SetTitle(const TString& title) {
+    Opts.SetTitle(title);
+}
+
+TClientCommandOption& TClientCommandOptions::AddLongOption(const TString& name, const TString& help) {
+    return AddClientOption(Opts.AddLongOption(name, help));
+}
+
+TClientCommandOption& TClientCommandOptions::AddLongOption(char c, const TString& name, const TString& help) {
+    return AddClientOption(Opts.AddLongOption(c, name, help));
+}
+
+TClientCommandOption& TClientCommandOptions::AddCharOption(char c, const TString& help) {
+    return AddClientOption(Opts.AddCharOption(c, help));
+}
+
+TAuthMethodOption& TClientCommandOptions::AddAuthMethodOption(const TString& name, const TString& help) {
+    return AddAuthMethodClientOption(Opts.AddLongOption(name, help));
+}
+
+void TClientCommandOptions::AddAnonymousAuthMethodOption() {
+    ClientOpts.emplace_back(MakeIntrusive<TAnonymousAuthMethodOption>(this));
+}
+
+TClientCommandOption& TClientCommandOptions::AddClientOption(NLastGetopt::TOpt& opt) {
+    return *ClientOpts.emplace_back(MakeIntrusive<TClientCommandOption>(opt, this));
+}
+
+TAuthMethodOption& TClientCommandOptions::AddAuthMethodClientOption(NLastGetopt::TOpt& opt) {
+    return static_cast<TAuthMethodOption&>(*ClientOpts.emplace_back(MakeIntrusive<TAuthMethodOption>(opt, this)));
+}
+
+void TClientCommandOptions::SetCustomUsage(const TString& usage) {
+    Opts.SetCustomUsage(usage);
+}
+
+void TClientCommandOptions::SetCmdLineDescr(const TString& descr) {
+    Opts.SetCmdLineDescr(descr);
+}
+
+void TClientCommandOptions::SetFreeArgsNum(size_t count) {
+    Opts.SetFreeArgsNum(count);
+}
+
+void TClientCommandOptions::SetFreeArgsNum(size_t min, size_t max) {
+    Opts.SetFreeArgsNum(min, max);
+}
+
+void TClientCommandOptions::SetFreeArgsMin(size_t min) {
+    Opts.SetFreeArgsMin(min);
+}
+
+void TClientCommandOptions::SetFreeArgsMax(size_t max) {
+    Opts.SetFreeArgsMax(max);
+}
+
+void TClientCommandOptions::MutuallyExclusive(TStringBuf opt1, TStringBuf opt2) {
+    Opts.MutuallyExclusive(opt1, opt2);
+}
+
+void TClientCommandOptions::MutuallyExclusiveOpt(TClientCommandOption& opt1, TClientCommandOption& opt2) {
+    Opts.MutuallyExclusiveOpt(opt1.GetOpt(), opt2.GetOpt());
+}
+
+
+TClientCommandOption::TClientCommandOption(NLastGetopt::TOpt& opt, TClientCommandOptions* clientOptions)
+    : Opt(&opt)
+    , ClientOptions(clientOptions)
+    , Help(Opt->GetHelp())
+{
+}
+
+TClientCommandOption& TClientCommandOption::AdditionalHelpNotes(const TString& helpNotes) {
+    HelpNotes = helpNotes;
+    RebuildHelpMessage();
+    return *this;
+}
+
+TClientCommandOption& TClientCommandOption::NoArgument() {
+    Opt->NoArgument();
+    return *this;
+}
+
+TClientCommandOption& TClientCommandOption::RequiredArgument(const TString& title) {
+    Opt->RequiredArgument(title);
+    return *this;
+}
+
+TClientCommandOption& TClientCommandOption::Optional() {
+    Opt->Optional();
+    return *this;
+}
+
+TClientCommandOption& TClientCommandOption::Required() {
+    Opt->Required();
+    return *this;
+}
+
+TClientCommandOption& TClientCommandOption::HasArg(NLastGetopt::EHasArg hasArg) {
+    Opt->HasArg(hasArg);
+    return *this;
+}
+
+TClientCommandOption& TClientCommandOption::Hidden() {
+    Opt->Hidden();
+    return *this;
+}
+
+TClientCommandOption& TClientCommandOption::OptionalArgument(const TString& title) {
+    Opt->OptionalArgument(title);
+    return *this;
+}
+
+TClientCommandOption& TClientCommandOption::AddLongName(const TString& name) {
+    Opt->AddLongName(name);
+    return *this;
+}
+
+const NLastGetopt::EHasArg& TClientCommandOption::GetHasArg() const {
+    return Opt->GetHasArg();
+}
+
+TClientCommandOption& TClientCommandOption::StoreResult(TString* result) {
+    ValueSetter = [result](const TString& v) {
+        *result = v;
+    };
+    return SetHandler();
+}
+
+TClientCommandOption& TClientCommandOption::StoreTrue(bool* target) {
+    *target = false;
+    Opt->NoArgument();
+    ValueSetter = [target](const TString& v) {
+        if (!v) {
+            *target = true;
+        } else if (!TryFromString<bool>(v, *target)) {
+            *target = false;
+        }
+    };
+    return SetHandler();
+}
+
+TClientCommandOption& TClientCommandOption::StoreFilePath(TString* filePath) {
+    FilePath = filePath;
+    return *this;
+}
+
+TClientCommandOption& TClientCommandOption::Handler(THandler handler) {
+    ValueHandler = std::move(handler);
+    return SetHandler();
+}
+
+TClientCommandOption& TClientCommandOption::Validator(TValidator validator) {
+    ValidatorHandler = std::move(validator);
+    return SetHandler();
+}
+
+TClientCommandOption& TClientCommandOption::SetHandler() {
+    if (!HandlerIsSet) {
+        struct THandler : public NLastGetopt::IOptHandler {
+            THandler(TClientCommandOption* self)
+                : Self(self)
+            {
+            }
+
+            void HandleOpt(const NLastGetopt::TOptsParser* parser) override {
+                TString curVal(parser->CurValOrDef());
+                Self->HandlerImpl(std::move(curVal), Self->IsFileName, Self->HumanReadableFileName, EOptionValueSource::Explicit);
+            }
+
+            TClientCommandOption* Self;
+        };
+        Opt->Handler(new THandler(this));
+        HandlerIsSet = true;
+    }
+    return *this;
+}
+
+bool TClientCommandOption::HandlerImpl(TString value, bool isFileName, const TString& humanReadableFileName, EOptionValueSource valueSource) {
+    if (isFileName) {
+        TString path = value;
+        if (valueSource == EOptionValueSource::DefaultValue && !ReadFromFileIfExists(path, humanReadableFileName ? humanReadableFileName : path, value)) {
+            return false;
+        }
+        value = ReadFromFile(path, humanReadableFileName ? humanReadableFileName : path);
+        if (FilePath) {
+            *FilePath = std::move(path);
+        }
+    }
+    if (ValueHandler) {
+        ValueHandler(value);
+    }
+    if (ValueSetter) {
+        ValueSetter(value);
+    }
+    return true;
+}
+
+TClientCommandOption& TClientCommandOption::FileName(const TString& humanReadableFileName, bool fileName) {
+    HumanReadableFileName = humanReadableFileName;
+    IsFileName = fileName;
+    return *this;
+}
+
+TClientCommandOption& TClientCommandOption::Env(const TString& envName, bool isFileName, const TString& humanReadableFileName) {
+    EnvInfo.emplace_back(
+        TEnvInfo{
+            .EnvName = envName,
+            .IsFileName = isFileName,
+            .HumanReadableFileName = humanReadableFileName,
+        }
+    );
+    RebuildHelpMessage();
+    return *this;
+}
+
+TClientCommandOption& TClientCommandOption::ProfileParam(const TString& profileParamName) {
+    ProfileParamName = profileParamName;
+    CanParseFromProfile = true;
+    RebuildHelpMessage();
+    return *this;
+}
+
+TClientCommandOption& TClientCommandOption::SetSupportsProfile(bool supports) {
+    CanParseFromProfile = supports;
+    RebuildHelpMessage();
+    return *this;
+}
+
+TClientCommandOption& TClientCommandOption::LogToConnectionParams(const TString& paramName) {
+    ConnectionParamName = paramName;
+    return *this;
+}
+
+TClientCommandOption& TClientCommandOption::DocLink(const TString& link) {
+    Documentation = link;
+    return *this;
+}
+
+TClientCommandOption& TClientCommandOption::DefaultValue(const TString& defaultValue) {
+    DefaultOptionValue = defaultValue;
+    RebuildHelpMessage();
+    return *this;
+}
+
+void TClientCommandOption::RebuildHelpMessage() {
+    NColorizer::TColors& colors = NColorizer::AutoColors(Cout);
+    TStringBuilder helpMessage;
+    helpMessage << Help;
+    if (ClientOptions->HelpCommandVerbosiltyLevel <= 1 && DefaultOptionValue) {
+        helpMessage << " (default: " << colors.Cyan() << DefaultOptionValue << colors.OldColor() << ")";
+    }
+
+    bool multiline = false;
+    auto makeMultiline = [&]() {
+        if (multiline) {
+            return;
+        }
+        multiline = true;
+        if (!Help.EndsWith('.')) {
+            helpMessage << ".";
+        }
+        helpMessage << Endl;
+    };
+
+    TString indent = ClientOptions->HelpCommandVerbosiltyLevel >= 2 ? "  " : "";
+    if (Documentation) {
+        makeMultiline();
+        helpMessage << indent << "For more info go to: " << Documentation << Endl;
+    }
+    if (ClientOptions->HelpCommandVerbosiltyLevel >= 2) {
+        makeMultiline();
+        helpMessage << indent << "Definition priority:";
+        size_t currentPoint = 1;
+        helpMessage << Endl << indent << indent << currentPoint++ << ". This option";
+        if (CanParseFromProfile) {
+            helpMessage << Endl << indent << indent << currentPoint++ << ". Profile specified with --profile option";
+        }
+        for (const TEnvInfo& envInfo : EnvInfo) {
+            helpMessage << Endl << indent << indent << currentPoint++ << ". "
+                << colors.BoldColor() << envInfo.EnvName << colors.OldColor()
+                << " environment variable";
+        }
+        if (CanParseFromProfile) {
+            helpMessage << Endl << indent << indent << currentPoint++ << ". Active configuration profile";
+        }
+        if (DefaultOptionValue) {
+            helpMessage << Endl << indent << indent << currentPoint++ << ". Default value: " << colors.Cyan() << DefaultOptionValue << colors.OldColor();
+        }
+    } else {
+        if (!EnvInfo.empty()) {
+            makeMultiline();
+            helpMessage << indent << "Environment variable" << (EnvInfo.size() > 1 ? "s: " : ": ");
+            for (size_t i = 0; i < EnvInfo.size(); ++i) {
+                if (i) {
+                    helpMessage << ", ";
+                }
+                helpMessage << colors.BoldColor() << EnvInfo[i].EnvName << colors.OldColor();
+            }
+        }
+    }
+    if (HelpNotes) {
+        TString notes = Strip(HelpNotes);
+        SubstGlobal(notes, "\n", TStringBuilder() << "\n" << indent);
+        helpMessage << Endl << Endl;
+        helpMessage << indent << notes;
+    }
+    Opt->Help(helpMessage);
+}
+
+bool TClientCommandOption::TryParseFromProfile(const std::shared_ptr<IProfile>& profile, TString* parsedValue, std::vector<TString>* errors, bool parseOnly) const {
+    Y_UNUSED(errors, parseOnly);
+    if (profile && ProfileParamName && profile->Has(ProfileParamName)) {
+        TString value = profile->GetValue(ProfileParamName).as<TString>();
+        if (parsedValue) {
+            *parsedValue = value;
+        }
+        return true;
+    }
+    return false;
+}
+
+
+TAuthMethodOption::TAuthMethodOption(NLastGetopt::TOpt& opt, TClientCommandOptions* clientOptions)
+    : TClientCommandOption(opt, clientOptions)
+{
+}
+
+TAuthMethodOption& TAuthMethodOption::AuthMethod(const TString& methodName) {
+    AuthMethodName = methodName;
+    return *this;
+}
+
+TAuthMethodOption& TAuthMethodOption::AuthProfileParser(TProfileParser parser, const TString& authMethod) {
+    CanParseFromProfile = true;
+    ProfileParsers[authMethod ? authMethod : AuthMethodName] = std::move(parser);
+    return *this;
+}
+
+TAuthMethodOption& TAuthMethodOption::SimpleProfileDataParam(const TString& authMethod, bool isFileName) {
+    auto parser = [this, isFileName, authMethod](const YAML::Node& authData, TString* value, std::vector<TString>* errors, bool parseOnly) -> bool {
+        Y_UNUSED(errors, parseOnly);
+
+        const bool needData = GetHasArg() != NLastGetopt::NO_ARGUMENT;
+        if (!needData) {
+            if (value) {
+                *value = {};
+            }
+            return true;
+        }
+
+        if (!isFileName) {
+            if (value) {
+                *value = authData.as<TString>();
+            }
+            return true;
+        }
+
+        TString path = authData.as<TString>();
+        TString val = ReadFromFile(path, path);
+        if (value) {
+            *value = std::move(val);
+        }
+        return true;
+    };
+    return AuthProfileParser(std::move(parser), authMethod);
+}
+
+bool TAuthMethodOption::TryParseFromProfile(const std::shared_ptr<IProfile>& profile, TString* parsedValue, std::vector<TString>* errors, bool parseOnly) const {
+    if (!profile || !profile->Has("authentication")) {
+        return false;
+    }
+
+    YAML::Node authValue = profile->GetValue("authentication");
+    YAML::Node methodValue = authValue["method"];
+    if (!methodValue) {
+        if (errors) {
+            errors->push_back("Configuration profile has \"authentication\" but does not have \"method\" in it");
+        }
+        return false;
+    }
+
+    TString authMethod = methodValue.as<TString>();
+    const auto parser = ProfileParsers.find(authMethod);
+    if (parser == ProfileParsers.end()) {
+        return false;
+    }
+    return parser->second(authValue["data"], parsedValue, errors, parseOnly);
+}
+
+
+TAnonymousAuthMethodOption::TAnonymousAuthMethodOption(TClientCommandOptions* clientOptions)
+    : TAuthMethodOption(*this, clientOptions)
+{
+    TOpt::NoArgument();
+    AuthMethod("anonymous-auth");
+    SimpleProfileDataParam();
+}
+
+
+TOptionsParseResult::TOptionsParseResult(const TClientCommandOptions* options, int argc, const char** argv)
+    : ClientOptions(options)
+    , ParseFromCommandLineResult(&options->GetOpts(), argc, argv)
+{
+    for (const auto& clientOption : ClientOptions->ClientOpts) {
+        if (const auto* optResult = ParseFromCommandLineResult.FindOptParseResult(&clientOption->GetOpt())) {
+            Opts.emplace_back(clientOption, optResult);
+            if (dynamic_cast<const TAuthMethodOption*>(clientOption.Get())) {
+                AuthMethodOpts.push_back(Opts.size() - 1); // insert index
+            }
+        }
+    }
+}
+
+const TOptionParseResult* TOptionsParseResult::FindResult(const TClientCommandOption* opt) const {
+    for (const TOptionParseResult& result : Opts) {
+        if (result.GetOpt() == opt) {
+            return &result;
+        }
+    }
+    return nullptr;
+}
+
+const TOptionParseResult* TOptionsParseResult::FindResult(const TString& name) const {
+    for (const auto& opt : Opts) {
+        if (IsIn(opt.GetOpt()->GetOpt().GetLongNames(), name)) {
+            return &opt;
+        }
+    }
+    return nullptr;
+}
+
+const TOptionParseResult* TOptionsParseResult::FindResult(char name) const {
+    for (const auto& opt : Opts) {
+        if (IsIn(opt.GetOpt()->GetOpt().GetShortNames(), name)) {
+            return &opt;
+        }
+    }
+    return nullptr;
+}
+
+size_t TOptionsParseResult::GetFreeArgsPos() const {
+    return ParseFromCommandLineResult.GetFreeArgsPos();
+}
+
+size_t TOptionsParseResult::GetFreeArgCount() const {
+    return ParseFromCommandLineResult.GetFreeArgCount();
+}
+
+TVector<TString> TOptionsParseResult::GetFreeArgs() const {
+    return ParseFromCommandLineResult.GetFreeArgs();
+}
+
+bool TOptionsParseResult::Has(const TString& name, bool includeDefault) const {
+    const TOptionParseResult* result = FindResult(name);
+    if (!includeDefault && result && result->ValueSource == EOptionValueSource::DefaultValue) {
+        result = nullptr;
+    }
+    return result != nullptr;
+}
+
+bool TOptionsParseResult::Has(char name, bool includeDefault) const {
+    const TOptionParseResult* result = FindResult(name);
+    if (!includeDefault && result && result->ValueSource == EOptionValueSource::DefaultValue) {
+        result = nullptr;
+    }
+    return result != nullptr;
+}
+
+const TString& TOptionsParseResult::Get(const TString& name, bool includeDefault) const {
+    if (const TOptionParseResult* result = FindResult(name); result && (includeDefault || result->ValueSource != EOptionValueSource::DefaultValue)) {
+        return result->Values().back();
+    }
+    throw yexception() << "No \"" << name << "\" option";
+}
+
+std::vector<TString> TOptionsParseResult::LogConnectionParams(const TConnectionParamsLogger& logger) {
+    std::vector<TString> messages;
+    auto getProfileOpt = [&](const TIntrusivePtr<TClientCommandOption>& opt, const std::shared_ptr<IProfile>& profile) -> TString {
+        TString value;
+        if (opt->TryParseFromProfile(profile, &value, &messages, true)) {
+            return value;
+        }
+        return {};
+    };
+    auto processValue = [&](const TIntrusivePtr<TClientCommandOption>& opt, const TString& value, const TString& sourceDescription, bool validate) {
+        if (validate && opt->ValidatorHandler) {
+            if (std::vector<TString> msgs = opt->ValidatorHandler(value); !msgs.empty()) {
+                messages.insert(messages.end(), msgs.begin(), msgs.end());
+            }
+        }
+        logger(opt->ConnectionParamName, value, sourceDescription);
+    };
+    for (const TOptionParseResult& result : Opts) {
+        const TIntrusivePtr<TClientCommandOption>& opt = result.Opt;
+        if (opt->ConnectionParamName) {
+            // Log all available sources for current option
+            for (EOptionValueSource src = result.ValueSource; ; src = static_cast<EOptionValueSource>(static_cast<int>(src) + 1)) {
+                const bool validate = src != result.ValueSource; // We validate result in Validate() method
+                switch (src) {
+                case EOptionValueSource::Explicit: {
+                    // already have parsed in that source
+                    TStringBuilder txt;
+                    txt << "explicit";
+                    if (auto name = opt->GetOpt().GetLongNames()) {
+                        txt << " --" << name[0];
+                    } else if (auto shortNames = opt->GetOpt().GetShortNames()) {
+                        txt << " -" << shortNames[0];
+                    }
+                    txt << " option";
+                    for (const TString& value : result.OptValues) {
+                        processValue(opt, value, txt, validate);
+                    }
+                    break;
+                }
+                case EOptionValueSource::ExplicitProfile: {
+                    if (TString value = getProfileOpt(opt, ExplicitProfile)) {
+                        TStringBuilder txt;
+                        txt << "profile \"" << ExplicitProfile->GetName() << "\" from explicit --profile option";
+                        processValue(opt, value, txt, validate);
+                    }
+                    break;
+                }
+                case EOptionValueSource::ActiveProfile: {
+                    if (TString value = getProfileOpt(opt, ActiveProfile)) {
+                        TStringBuilder txt;
+                        txt << "active profile \"" << ActiveProfile->GetName() << "\"";
+                        processValue(opt, value, txt, validate);
+                    }
+                    break;
+                }
+                case EOptionValueSource::EnvironmentVariable: {
+                    for (const auto& envInfo : opt->EnvInfo) {
+                        if (TString value = GetEnv(envInfo.EnvName)) {
+                            TStringBuilder txt;
+                            txt << envInfo.EnvName << " enviroment variable";
+                            processValue(opt, value, txt, validate);
+                        }
+                    }
+                    break;
+                }
+                case EOptionValueSource::DefaultValue:
+                    if (opt->DefaultOptionValue) {
+                        processValue(opt, opt->DefaultOptionValue, "default value", validate);
+                    }
+                    break;
+                }
+                if (src == EOptionValueSource::DefaultValue) {
+                    break;
+                }
+            }
+        }
+    }
+
+    // Log chosen auth method
+    if (AuthMethodOpts.size() == 1) {
+        const auto& opt = Opts[AuthMethodOpts[0]];
+        Cerr << "Using auth method \"" << ChosenAuthMethod << "\"";
+        switch (opt.ValueSource) {
+        case EOptionValueSource::Explicit:
+            Cerr << " from explicit command line option ";
+            if (auto name = opt.Opt->GetOpt().GetLongNames()) {
+                Cerr << "--" << name[0];
+            } else if (auto shortNames = opt.Opt->GetOpt().GetShortNames()) {
+                Cerr << "-" << shortNames[0];
+            }
+            break;
+        case EOptionValueSource::ExplicitProfile:
+            Cerr << " from explicitly specified profile \"" << ExplicitProfile->GetName() << "\"";
+            break;
+        case EOptionValueSource::ActiveProfile:
+            Cerr << " from current active profile \"" << ActiveProfile->GetName() << "\"";
+            break;
+        case EOptionValueSource::EnvironmentVariable:
+            for (const auto& envInfo : opt.Opt->EnvInfo) {
+                if (TString value = GetEnv(envInfo.EnvName)) {
+                    TStringBuilder txt;
+                    Cerr << " from " << envInfo.EnvName << " enviroment variable";
+                    break;
+                }
+            }
+            break;
+        case EOptionValueSource::DefaultValue:
+            Cerr << " from default value \"" << opt.Opt->DefaultOptionValue << "\"";
+            break;
+        }
+        Cerr << Endl;
+    } else {
+        Cerr << "No authentication methods were found. Going without authentication" << Endl;
+    }
+
+    return messages;
+}
+
+std::vector<TString> TOptionsParseResult::ParseFromProfilesAndEnv(std::shared_ptr<IProfile> explicitProfile, std::shared_ptr<IProfile> activeProfile) {
+    ExplicitProfile = std::move(explicitProfile);
+    ActiveProfile = std::move(activeProfile);
+    std::vector<TString> errors;
+
+    auto applyOption = [&](const TIntrusivePtr<TClientCommandOption>& clientOption, const TString& value, bool isFileName, const TString& humanReadableFileName, EOptionValueSource valueSource) {
+        if (clientOption->HandlerImpl(value, isFileName, humanReadableFileName, valueSource)) { // returns false only when loading from default value from file
+            Opts.emplace_back(clientOption, value, valueSource);
+            if (dynamic_cast<const TAuthMethodOption*>(clientOption.Get())) {
+                AuthMethodOpts.push_back(Opts.size() - 1);
+            }
+            if (clientOption->ValidatorHandler) {
+                if (std::vector<TString> msgs = clientOption->ValidatorHandler(value); !msgs.empty()) {
+                    errors.insert(errors.end(), msgs.begin(), msgs.end());
+                }
+            }
+        }
+    };
+
+    for (const TIntrusivePtr<TClientCommandOption>& clientOption : ClientOptions->ClientOpts) {
+        if (FindResult(clientOption.Get())) {
+            continue;
+        }
+        const bool isAuthOption = dynamic_cast<const TAuthMethodOption*>(clientOption.Get()) != nullptr;
+        if (isAuthOption && !AuthMethodOpts.empty()) { // Parsed from command line or from profile
+            continue;
+        }
+
+        if (TString value; clientOption->TryParseFromProfile(ExplicitProfile, &value, &errors, false)) {
+            applyOption(clientOption, value, false, clientOption->HumanReadableFileName, EOptionValueSource::ExplicitProfile);
+            continue;
+        }
+        if (isAuthOption) {
+            continue;
+        }
+
+        bool envApplied = false;
+        for (const auto& envInfo : clientOption->EnvInfo) {
+            if (TString value = GetEnv(envInfo.EnvName)) {
+                applyOption(clientOption, value, envInfo.IsFileName, envInfo.HumanReadableFileName, EOptionValueSource::EnvironmentVariable);
+                envApplied = true;
+                break;
+            }
+        }
+        if (envApplied) {
+            continue;
+        }
+
+        if (ActiveProfile != ExplicitProfile) {
+            if (TString value; clientOption->TryParseFromProfile(ActiveProfile, &value, &errors, false)) {
+                applyOption(clientOption, value, false, clientOption->HumanReadableFileName, EOptionValueSource::ActiveProfile);
+                continue;
+            }
+        }
+
+        if (clientOption->DefaultOptionValue) {
+            applyOption(clientOption, clientOption->DefaultOptionValue, clientOption->IsFileName, clientOption->HumanReadableFileName, EOptionValueSource::DefaultValue);
+        }
+    }
+
+    if (AuthMethodOpts.empty()) { // have not parsed from command line and from explicit profile. Try from env
+        for (const TIntrusivePtr<TAuthMethodOption>& clientOption : ClientOptions->EnvAuthPriority) {
+            for (const auto& envInfo : clientOption->EnvInfo) {
+                if (TString value = GetEnv(envInfo.EnvName)) {
+                    applyOption(clientOption, value, envInfo.IsFileName, envInfo.HumanReadableFileName, EOptionValueSource::EnvironmentVariable);
+                    break;
+                }
+            }
+            if (!AuthMethodOpts.empty()) {
+                break;
+            }
+        }
+    }
+
+    if (AuthMethodOpts.empty()) { // try active profile
+        for (const TIntrusivePtr<TClientCommandOption>& clientOption : ClientOptions->ClientOpts) {
+            if (!dynamic_cast<const TAuthMethodOption*>(clientOption.Get())) {
+                continue;
+            }
+
+            if (ActiveProfile != ExplicitProfile) {
+                if (TString value; clientOption->TryParseFromProfile(ActiveProfile, &value, &errors, false)) {
+                    applyOption(clientOption, value, false, clientOption->HumanReadableFileName, EOptionValueSource::ActiveProfile);
+                    continue;
+                }
+            }
+
+            if (!AuthMethodOpts.empty()) {
+                break;
+            }
+        }
+    }
+
+    if (AuthMethodOpts.empty()) { // try default
+        for (const TIntrusivePtr<TClientCommandOption>& clientOption : ClientOptions->ClientOpts) {
+            if (!dynamic_cast<const TAuthMethodOption*>(clientOption.Get())) {
+                continue;
+            }
+
+            if (clientOption->DefaultOptionValue) {
+                applyOption(clientOption, clientOption->DefaultOptionValue, clientOption->IsFileName, clientOption->HumanReadableFileName, EOptionValueSource::DefaultValue);
+            }
+
+            if (!AuthMethodOpts.empty()) {
+                break;
+            }
+        }
+    }
+
+    if (AuthMethodOpts.size() == 1) {
+        ChosenAuthMethod = static_cast<const TAuthMethodOption*>(Opts[AuthMethodOpts[0]].Opt.Get())->GetAuthMethod();
+    }
+    return errors;
+}
+
+std::vector<TString> TOptionsParseResult::Validate() {
+    std::vector<TString> messages;
+    if (AuthMethodOpts.size() > 1) {
+        TStringBuilder err;
+        err << AuthMethodOpts.size() << " methods were provided via options:";
+        bool comma = false;
+        for (size_t method : AuthMethodOpts) {
+            if (comma) {
+                err << ",";
+            }
+            comma = true;
+            const TOptionParseResult& opt = Opts[method];
+            if (auto names = opt.Opt->GetOpt().GetLongNames()) {
+                err << " --" << names[0];
+            } else if (auto shortNames = opt.Opt->GetOpt().GetShortNames()) {
+                err << " -" << shortNames[0];
+            }
+        }
+        err << ". Choose exactly one of them";
+        messages.push_back(err);
+    }
+    for (const TOptionParseResult& result : Opts) {
+        if (result.Opt->ValidatorHandler) {
+            for (const TString& value : result.Values()) {
+                if (std::vector<TString> msgs = result.Opt->ValidatorHandler(value); !msgs.empty()) {
+                    messages.insert(messages.end(), msgs.begin(), msgs.end());
+                }
+            }
+        }
+    }
+    return messages;
+}
+
+} // namespace NYdb::NConsoleClient

--- a/ydb/public/lib/ydb_cli/common/client_command_options.h
+++ b/ydb/public/lib/ydb_cli/common/client_command_options.h
@@ -1,0 +1,403 @@
+#pragma once
+
+#include <library/cpp/getopt/last_getopt.h>
+
+namespace YAML {
+class Node;
+}
+
+namespace NYdb::NConsoleClient {
+
+class TClientCommandOption;
+class TAuthMethodOption;
+class TClientCommandOptions;
+class TOptionsParseResult;
+class IProfile;
+
+// Value source types in priority order
+enum class EOptionValueSource {
+    Explicit,                // Command line
+    ExplicitProfile,         // Profile that was set via command line
+    EnvironmentVariable,     // Env variable
+    ActiveProfile,           // Active profile
+    DefaultValue,            // Default value for option
+};
+
+// Options for YDB CLI that support additional
+// parsing features:
+// - parsing from environment variables;
+// - parsing from profile (for root options);
+// - features for control that only one of alternative options is set;
+// - features for control that alternative options or options that must be set together
+//     are set from one source (command line, env or profile).
+class TClientCommandOptions {
+public:
+    friend class TClientCommandOption;
+    friend class TOptionsParseResult;
+
+public:
+    TClientCommandOptions(NLastGetopt::TOpts opts);
+
+    // Current command title
+    void SetTitle(const TString& title);
+    void SetCustomUsage(const TString& usage);
+    void SetCmdLineDescr(const TString& descr);
+    void SetFreeArgsNum(size_t count);
+    void SetFreeArgsNum(size_t min, size_t max);
+    void SetFreeArgsMin(size_t min);
+    void SetFreeArgsMax(size_t max);
+    void MutuallyExclusive(TStringBuf opt1, TStringBuf opt2);
+    void MutuallyExclusiveOpt(TClientCommandOption& opt1, TClientCommandOption& opt2);
+
+    TClientCommandOption& AddLongOption(const TString& name, const TString& help = "");
+    TClientCommandOption& AddLongOption(char c, const TString& name, const TString& help = "");
+    TClientCommandOption& AddCharOption(char c, const TString& help = "");
+    TAuthMethodOption& AddAuthMethodOption(const TString& name, const TString& help);
+    void AddAnonymousAuthMethodOption();
+
+    const NLastGetopt::TOpts& GetOpts() const {
+        return Opts;
+    }
+
+    NLastGetopt::TOpts& GetOpts() {
+        return Opts;
+    }
+
+    void SetHelpCommandVerbosiltyLevel(size_t level) {
+        HelpCommandVerbosiltyLevel = level;
+    }
+
+    // Priority of parsing auth methods from env, from first to last.
+    // If first method is inited from env, others will not be tried.
+    template <class TAuthMethodOptionRef, class... T>
+    void SetAuthMethodsEnvPriority(TAuthMethodOptionRef& opt, T... args) {
+        SetAuthMethodsEnvPriority(opt);
+        SetAuthMethodsEnvPriority(args...);
+    }
+
+    void SetAuthMethodsEnvPriority(TAuthMethodOption& opt) {
+        EnvAuthPriority.emplace_back(&opt);
+    }
+
+    void SetAuthMethodsEnvPriority(TAuthMethodOption* opt) {
+        if (opt) {
+            EnvAuthPriority.emplace_back(opt);
+        }
+    }
+
+private:
+    TClientCommandOption& AddClientOption(NLastGetopt::TOpt& opt);
+    TAuthMethodOption& AddAuthMethodClientOption(NLastGetopt::TOpt& opt);
+
+private:
+    NLastGetopt::TOpts Opts;
+    std::vector<TIntrusivePtr<TClientCommandOption>> ClientOpts;
+    std::vector<TIntrusivePtr<TAuthMethodOption>> EnvAuthPriority;
+    size_t HelpCommandVerbosiltyLevel = 1;
+};
+
+// YDB client command option
+class TClientCommandOption : public TSimpleRefCount<TClientCommandOption> {
+    friend class TOptionsParseResult;
+
+public:
+    using THandler = std::function<void(const TString&)>;
+    using TValidator = std::function<std::vector<TString>(const TString&)>; // Returns list of messages with problems. Empty vector if OK
+
+public:
+    TClientCommandOption(NLastGetopt::TOpt& opt, TClientCommandOptions* clientOptions);
+
+    virtual ~TClientCommandOption() = default;
+
+    // Additional help notes after main help
+    TClientCommandOption& AdditionalHelpNotes(const TString& helpNotes);
+
+    TClientCommandOption& NoArgument();
+
+    TClientCommandOption& RequiredArgument(const TString& title = {});
+
+    TClientCommandOption& Optional();
+
+    TClientCommandOption& Required();
+
+    TClientCommandOption& HasArg(NLastGetopt::EHasArg hasArg);
+
+    TClientCommandOption& Hidden();
+
+    TClientCommandOption& OptionalArgument(const TString& title = {});
+
+    TClientCommandOption& AddLongName(const TString& name);
+
+    const NLastGetopt::EHasArg& GetHasArg() const;
+
+    // Store result. If option is file name, stores the contents of file in result.
+    TClientCommandOption& StoreResult(TString* result);
+
+    template <class T>
+    TClientCommandOption& StoreResult(T* result) {
+        ValueSetter = [result](const TString& v) {
+            *result = FromString<T>(v);
+        };
+        return SetHandler();
+    }
+
+    template <class T>
+    TClientCommandOption& StoreResult(TMaybe<T>* result) {
+        ValueSetter = [result](const TString& v) {
+            *result = FromString<T>(v);
+        };
+        return SetHandler();
+    }
+
+    template <class T>
+    TClientCommandOption& StoreResult(std::optional<T>* result) {
+        ValueSetter = [result](const TString& v) {
+            *result = FromString<T>(v);
+        };
+        return SetHandler();
+    }
+
+    TClientCommandOption& StoreTrue(bool* target);
+
+    template <class T, class V>
+    TClientCommandOption& StoreValue(T* target, V value) {
+        ValueSetter = [target, val = std::move(value)](const TString&) {
+            *target = val;
+        };
+        return SetHandler();
+    }
+
+    template <class TContainer>
+    TClientCommandOption& AppendTo(TContainer* cont) {
+        ValueSetter = [cont](const TString& v) {
+            cont->push_back(FromString<typename TContainer::value_type>(v));
+        };
+        return SetHandler();
+    }
+
+    template <class TContainer>
+    TClientCommandOption& InsertTo(TContainer* cont) {
+        ValueSetter = [cont](const TString& v) {
+            cont->insert(FromString<typename TContainer::value_type>(v));
+        };
+        return SetHandler();
+    }
+
+    template <typename T, class TFunc>
+    TClientCommandOption& StoreMappedResult(T* target, TFunc&& func) {
+        ValueSetter = [target, mapper = std::forward<TFunc>(func)](const TString& v) {
+            *target = mapper(v);
+        };
+        return SetHandler();
+    }
+
+    // For options taken from file content
+    // Stores source file path
+    TClientCommandOption& StoreFilePath(TString* filePath);
+
+    TClientCommandOption& Handler(THandler);
+    TClientCommandOption& Validator(TValidator);
+
+    // YDB CLI specific options
+
+    // This option means that its value must be read from file that is specified through command line.
+    // Sets file content as option result (see StoreResult).
+    TClientCommandOption& FileName(const TString& humanReadableFileName = {}, bool fileName = true);
+
+    // Alternative env variable for option.
+    // If isFileName is set, interprets current env variable as file name.
+    TClientCommandOption& Env(const TString& envName, bool isFileName, const TString& humanReadableFileName = {});
+
+    // Parse option from profile
+    TClientCommandOption& ProfileParam(const TString& profileParamName);
+
+    TClientCommandOption& SetSupportsProfile(bool supports = true);
+
+    // Log connection params at high verbosity level
+    TClientCommandOption& LogToConnectionParams(const TString& paramName);
+
+    // Doc link for help message
+    TClientCommandOption& DocLink(const TString& link);
+
+    TClientCommandOption& DefaultValue(const TString& defaultValue);
+
+    template <class TValue>
+    TClientCommandOption& DefaultValue(const TValue& defaultValue) {
+        return DefaultValue(ToString(defaultValue));
+    }
+
+    NLastGetopt::TOpt& GetOpt() {
+        return *Opt;
+    }
+
+    const NLastGetopt::TOpt& GetOpt() const {
+        return *Opt;
+    }
+
+protected:
+    TClientCommandOption& SetHandler();
+    bool HandlerImpl(TString value, bool isFileName, const TString& humanReadableFileName, EOptionValueSource valueSource);
+    void RebuildHelpMessage();
+
+    // Try parse from profile.
+    // if parsedValue is not null, set it with parsed value, if actual
+    virtual bool TryParseFromProfile(const std::shared_ptr<IProfile>& profile, TString* parsedValue, std::vector<TString>* errors, bool parseOnly) const;
+
+protected:
+    struct TEnvInfo {
+        TString EnvName;
+        bool IsFileName = false;
+        TString HumanReadableFileName;
+    };
+
+protected:
+    NLastGetopt::TOpt* Opt = nullptr;
+    TClientCommandOptions* ClientOptions = nullptr;
+    TString Help;
+    TString HelpNotes;
+    TValidator ValidatorHandler;
+    THandler ValueHandler;
+    THandler ValueSetter;
+    bool IsFileName = false;
+    TString HumanReadableFileName;
+    TString* FilePath = nullptr;
+    std::vector<TEnvInfo> EnvInfo;
+    TString DefaultOptionValue;
+    TString ProfileParamName;
+    bool CanParseFromProfile = false;
+    TString ConnectionParamName;
+    TString Documentation;
+    bool HandlerIsSet = false;
+};
+
+class TAuthMethodOption : public TClientCommandOption {
+public:
+    using TProfileParser = std::function<bool(const YAML::Node& authData, TString* value, std::vector<TString>* errors, bool parseOnly)>;
+public:
+    TAuthMethodOption(NLastGetopt::TOpt& opt, TClientCommandOptions* clientOptions);
+
+    // Auth method name that is used to parse from profile
+    TAuthMethodOption& AuthMethod(const TString& methodName);
+
+    // Add profile parser
+    // Default auth method name is taken from AuthMethod("...")
+    TAuthMethodOption& AuthProfileParser(TProfileParser, const TString& authMethod = {});
+
+    // Add profile parser from simple data profile param
+    // Treat data as string with option value
+    // Default auth method name is taken from AuthMethod("...")
+    TAuthMethodOption& SimpleProfileDataParam(const TString& authMethod = {}, bool isFileName = false);
+
+    const TString& GetAuthMethod() const {
+        return AuthMethodName;
+    }
+
+protected:
+    bool TryParseFromProfile(const std::shared_ptr<IProfile>& profile, TString* parsedValue, std::vector<TString>* errors, bool parseOnly) const override;
+
+protected:
+    TString AuthMethodName;
+    THashMap<TString, TProfileParser> ProfileParsers; // method -> parser
+};
+
+class TAnonymousAuthMethodOption : private NLastGetopt::TOpt, public TAuthMethodOption {
+public:
+    TAnonymousAuthMethodOption(TClientCommandOptions* clientOptions);
+};
+
+class TOptionParseResult {
+    friend class TOptionsParseResult;
+
+public:
+    TOptionParseResult(const TOptionParseResult&) = default;
+    TOptionParseResult(TOptionParseResult&&) = default;
+    TOptionParseResult(TIntrusivePtr<TClientCommandOption> opt, const NLastGetopt::TOptParseResult* result)
+        : Opt(std::move(opt))
+        , ParseFromCommandLineResult(result)
+        , ValueSource(EOptionValueSource::Explicit)
+    {
+        if (ParseFromCommandLineResult && !ParseFromCommandLineResult->Values().empty()) {
+            OptValues.assign(ParseFromCommandLineResult->Values().begin(), ParseFromCommandLineResult->Values().end());
+        }
+    }
+
+    TOptionParseResult(TIntrusivePtr<TClientCommandOption> opt, const TString& value, EOptionValueSource valueSource)
+        : Opt(std::move(opt))
+        , ValueSource(valueSource)
+    {
+        OptValues.emplace_back(std::move(value));
+    }
+
+    EOptionValueSource GetValueSource() const {
+        return ValueSource;
+    }
+
+    const std::vector<TString>& Values() const {
+        return OptValues;
+    }
+
+    size_t Count() const {
+        return OptValues.size();
+    }
+
+    const TClientCommandOption* GetOpt() const {
+        return Opt.Get();
+    }
+
+private:
+    TIntrusivePtr<TClientCommandOption> Opt;
+    const NLastGetopt::TOptParseResult* ParseFromCommandLineResult = nullptr;
+    EOptionValueSource ValueSource;
+    std::vector<TString> OptValues;
+};
+
+class TOptionsParseResult {
+    friend class TClientCommandOptions;
+
+public:
+    using TConnectionParamsLogger = std::function<void(const TString& /*paramName*/, const TString& /*value*/, const TString& /*sourceText*/)>;
+
+public:
+    TOptionsParseResult(const TClientCommandOptions* options, int argc, const char** argv);
+
+    // Parses from profile and env. Returns erros if they occur during parsing
+    std::vector<TString> ParseFromProfilesAndEnv(std::shared_ptr<IProfile> explicitProfile, std::shared_ptr<IProfile> activeProfile);
+
+    // Logging and validation
+    std::vector<TString> Validate(); // Validate current values
+    std::vector<TString> LogConnectionParams(const TConnectionParamsLogger& logger); // Check and log all connection params
+
+    const TOptionParseResult* FindResult(const TClientCommandOption* opt) const;
+    const TOptionParseResult* FindResult(const TString& name) const;
+    const TOptionParseResult* FindResult(char name) const;
+
+    size_t GetFreeArgsPos() const;
+
+    size_t GetFreeArgCount() const;
+
+    TVector<TString> GetFreeArgs() const;
+
+    bool Has(const TString& name, bool includeDefault = false) const;
+    bool Has(char name, bool includeDefault = false) const;
+
+    const TString& Get(const TString& name, bool includeDefault = true) const;
+
+    const NLastGetopt::TOptsParseResult& GetCommandLineParseResult() const {
+        return ParseFromCommandLineResult;
+    }
+
+    const TString& GetChosenAuthMethod() const {
+        return ChosenAuthMethod;
+    }
+
+private:
+    const TClientCommandOptions* ClientOptions = nullptr;
+    NLastGetopt::TOptsParseResult ParseFromCommandLineResult; // First parsing stage
+    std::vector<TOptionParseResult> Opts;
+    std::vector<size_t> AuthMethodOpts; // indexes
+    TString ChosenAuthMethod;
+    std::shared_ptr<IProfile> ExplicitProfile;
+    std::shared_ptr<IProfile> ActiveProfile;
+};
+
+} // namespace NYdb::NConsoleClient

--- a/ydb/public/lib/ydb_cli/common/command.h
+++ b/ydb/public/lib/ydb_cli/common/command.h
@@ -356,10 +356,12 @@ public:
         END
     };
 
-    void RenderOneCommandDescription(
+    virtual void RenderCommandDescription(
         TStringStream& stream,
+        bool renderTree,
         const NColorizer::TColors& colors = NColorizer::TColors(false),
-        RenderEntryType type = BEGIN
+        RenderEntryType type = BEGIN,
+        TString prefix = {}
     );
 
     void Hide();
@@ -394,10 +396,13 @@ public:
     void AddHiddenCommand(std::unique_ptr<TClientCommand> command);
     void AddDangerousCommand(std::unique_ptr<TClientCommand> command);
     virtual void Prepare(TConfig& config) override;
-    void RenderCommandsDescription(
+    void RenderCommandDescription(
         TStringStream& stream,
-        const NColorizer::TColors& colors = NColorizer::TColors(false)
-    );
+        bool renderTree,
+        const NColorizer::TColors& colors = NColorizer::TColors(false),
+        RenderEntryType type = BEGIN,
+        TString prefix = {}
+    ) override;
     virtual void SetFreeArgs(TConfig& config);
     bool HasSelectedCommand() const { return SelectedCommand; }
 

--- a/ydb/public/lib/ydb_cli/common/examples.cpp
+++ b/ydb/public/lib/ydb_cli/common/examples.cpp
@@ -46,8 +46,9 @@ TExampleSet TExampleSetBuilder::Build() {
 void TCommandWithExamples::AddExamplesOption(TClientCommand::TConfig& config) {
     config.Opts->AddLongOption("help-ex", "Print usage with examples")
         .HasArg(NLastGetopt::NO_ARGUMENT)
-        .IfPresentDisableCompletion()
-        .Handler(&NLastGetopt::PrintUsageAndExit);
+        .GetOpt()
+        .Handler(&NLastGetopt::PrintUsageAndExit)
+        .IfPresentDisableCompletion();
 }
 
 void TCommandWithExamples::AddOptionExamples(const TString& optionName, TExampleSet&& examples) {
@@ -85,7 +86,7 @@ void TCommandWithExamples::CheckExamples(const TClientCommand::TConfig& config) 
     }
 
     for (const auto& [optionName, examples] : OptionExamples) {
-        NLastGetopt::TOpt* opt = config.Opts->FindLongOption(optionName);
+        NLastGetopt::TOpt* opt = config.Opts->GetOpts().FindLongOption(optionName);
         if (!opt) {
             continue;
         }
@@ -108,7 +109,7 @@ void TCommandWithExamples::CheckExamples(const TClientCommand::TConfig& config) 
     if (CommandExamples.Examples.size()) {
         TStringStream descr;
         PrintExamples(descr, CommandExamples.Examples);
-        config.Opts->AddSection(CommandExamples.Title ? CommandExamples.Title
+        config.Opts->GetOpts().AddSection(CommandExamples.Title ? CommandExamples.Title
                 : (CommandExamples.Examples.size() == 1 ? "Example" : "Examples"),
             descr.Str());
     }

--- a/ydb/public/lib/ydb_cli/common/format.cpp
+++ b/ydb/public/lib/ydb_cli/common/format.cpp
@@ -102,7 +102,7 @@ bool TCommandWithFormat::HasOutput() {
     return false;
 }
 
-void TCommandWithInput::AddInputFormats(TClientCommand::TConfig& config, 
+void TCommandWithInput::AddInputFormats(TClientCommand::TConfig& config,
                                          const TVector<EDataFormat>& allowedFormats, EDataFormat defaultFormat) {
     TStringStream description;
     description << "Input format. Available options: ";
@@ -224,17 +224,17 @@ void TCommandWithInput::AddInputFileOption(TClientCommand::TConfig& config, bool
 
 // Deprecated
 void TCommandWithOutput::AddDeprecatedJsonOption(TClientCommand::TConfig& config, const TString& description) {
-    config.Opts->AddLongOption("json", description).NoArgument()
+    config.Opts->GetOpts().AddLongOption("json", description).NoArgument()
         .StoreValue(&OutputFormat, EDataFormat::Json).StoreValue(&DeprecatedOptionUsed, true)
         .Hidden();
 }
 
-void TCommandWithOutput::AddOutputFormats(TClientCommand::TConfig& config, 
+void TCommandWithOutput::AddOutputFormats(TClientCommand::TConfig& config,
                                     const TVector<EDataFormat>& allowedFormats, EDataFormat defaultFormat) {
     TStringStream description;
     description << "Output format. Available options: ";
     NColorizer::TColors colors = NColorizer::AutoColors(Cout);
-    Y_ABORT_UNLESS(std::find(allowedFormats.begin(), allowedFormats.end(), defaultFormat) != allowedFormats.end(), 
+    Y_ABORT_UNLESS(std::find(allowedFormats.begin(), allowedFormats.end(), defaultFormat) != allowedFormats.end(),
         "Couldn't find default output format %s in allowed formats", (TStringBuilder() << defaultFormat).c_str());
     for (const auto& format : allowedFormats) {
         auto findResult = FormatDescriptions.find(format);
@@ -518,7 +518,7 @@ TString ReplaceAll(TString str, const TString& from, const TString& to) {
     if (!from) {
         return str;
     }
-        
+
     size_t startPos = 0;
     while ((startPos = str.find(from, startPos)) != TString::npos) {
         str.replace(startPos, from.length(), to);
@@ -546,7 +546,7 @@ TString FormatPrettyTableDouble(TString stringValue) {
 
 
     stream << std::fixed << std::setprecision(3) << std::scientific << value;
-    return ToString(stream.str());   
+    return ToString(stream.str());
 }
 
 void TQueryPlanPrinter::PrintPrettyTableImpl(const NJson::TJsonValue& plan, TString& offset, TPrettyTable& table) {
@@ -557,7 +557,7 @@ void TQueryPlanPrinter::PrintPrettyTableImpl(const NJson::TJsonValue& plan, TStr
     NColorizer::TColors colors = NColorizer::AutoColors(Output);
     TStringBuf color;
     switch(offset.size() % 3) {
-        case 0: 
+        case 0:
             color = colors.LightRed();
             break;
         case 1:

--- a/ydb/public/lib/ydb_cli/common/parseable_struct.h
+++ b/ydb/public/lib/ydb_cli/common/parseable_struct.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "command.h"
+#include "client_command_options.h"
 
 #include <library/cpp/colorizer/colors.h>
 
@@ -17,20 +18,16 @@ namespace NConsoleClient {
 
 template <typename T>
 class TParseableStruct {
-    using TOpt = NLastGetopt::TOpt;
-    using TOptParseResult = NLastGetopt::TOptParseResult;
-    using TOptsParseResult = NLastGetopt::TOptsParseResult;
-
-    static const TOptParseResult* FindOptParseResult(const TOptsParseResult* parseResult, const TOpt* opt) {
-        return parseResult->FindOptParseResult(opt);
+    static const TOptionParseResult* FindOptParseResult(const TOptionsParseResult* parseResult, const TClientCommandOption* opt) {
+        return parseResult->FindResult(opt);
     }
 
-    static const TOptParseResult* FindOptParseResult(const TOptsParseResult* parseResult, const TString& name) {
-        return parseResult->FindLongOptParseResult(name);
+    static const TOptionParseResult* FindOptParseResult(const TOptionsParseResult* parseResult, const TString& name) {
+        return parseResult->FindResult(name);
     }
 
-    static const TOptParseResult* FindOptParseResult(const TOptsParseResult* parseResult, char c) {
-        return parseResult->FindCharOptParseResult(c);
+    static const TOptionParseResult* FindOptParseResult(const TOptionsParseResult* parseResult, char c) {
+        return parseResult->FindResult(c);
     }
 
     static T FromString(const char* data) {
@@ -82,8 +79,8 @@ public:
 
         TVector<T> result(Reserve(parseResult->Count()));
 
-        for (const char* value : parseResult->Values()) {
-            result.push_back(FromString(value));
+        for (const TString& value : parseResult->Values()) {
+            result.push_back(FromString(value.c_str()));
         }
 
         return result;

--- a/ydb/public/lib/ydb_cli/common/root.cpp
+++ b/ydb/public/lib/ydb_cli/common/root.cpp
@@ -19,27 +19,43 @@ void TClientCommandRootBase::Config(TConfig& config) {
     TimeRequests = false;
     ProgressRequests = false;
 
-    NLastGetopt::TOpts& opts = *config.Opts;
-    opts.AddLongOption('t', "time", "Show request execution time").NoArgument().SetFlag(&TimeRequests);
-    opts.AddLongOption('o', "progress", "Show progress of long requests").NoArgument().SetFlag(&ProgressRequests);
+    TClientCommandOptions& opts = *config.Opts;
+    opts.AddLongOption('t', "time", "Show request execution time").StoreTrue(&TimeRequests);
+    opts.AddLongOption('o', "progress", "Show progress of long requests").StoreTrue(&ProgressRequests);
     opts.AddLongOption("ca-file",
         "File containing PEM encoded root certificates for SSL/TLS connections.\n"
-        "If this parameter is empty, the default roots will be used.")
-        .RequiredArgument("PATH").StoreResult(&CaCertsFile);
+        "If this parameter is empty, the default roots will be used")
+        .FileName("CA certificates").ProfileParam("ca-file")
+        .LogToConnectionParams("ca-file")
+        .Env("YDB_CA_FILE", true, "CA certificates")
+        .RequiredArgument("PATH").StoreFilePath(&CaCertsFile).StoreResult(&config.CaCerts);
     opts.AddLongOption("client-cert-file",
-        "File containing client certificate for SSL/TLS connections (PKCS#12 or PEM-encoded).")
-        .RequiredArgument("PATH").StoreResult(&ClientCertFile);
+        "File containing client certificate for SSL/TLS connections (PKCS#12 or PEM-encoded)")
+        .FileName("Client certificate")
+        .LogToConnectionParams("client-cert-file")
+        .Env("YDB_CLIENT_CERT_FILE", true, "Client certificate")
+        .ProfileParam("client-cert-file")
+        .RequiredArgument("PATH").StoreFilePath(&ClientCertFile).StoreResult(&config.ClientCert);
     opts.AddLongOption("client-cert-key-file",
-        "File containing PEM encoded client certificate private key for SSL/TLS connections.")
-        .RequiredArgument("PATH").StoreResult(&ClientCertPrivateKeyFile);
+        "File containing PEM encoded client certificate private key for SSL/TLS connections")
+        .FileName("Client certificate private key")
+        .LogToConnectionParams("client-cert-key-file")
+        .Env("YDB_CLIENT_CERT_KEY_FILE", true, "Client certificate private key")
+        .ProfileParam("client-cert-key-file")
+        .RequiredArgument("PATH").StoreFilePath(&ClientCertPrivateKeyFile).StoreResult(&config.ClientCertPrivateKey);
     opts.AddLongOption("client-cert-key-password-file",
-        "File containing password for client certificate private key (if key is encrypted). "
-        "If key file is encrypted, but this option is not set, password will be asked interactively.")
-        .RequiredArgument("PATH").StoreResult(&ClientCertPrivateKeyPasswordFile);
+        "File containing password for client certificate private key (if key is encrypted).\n"
+        "If key file is encrypted, but this option is not set, password will be asked interactively")
+        .FileName("Client certificate private key password")
+        .LogToConnectionParams("client-cert-key-password-file")
+        .Env("YDB_CLIENT_CERT_KEY_PASSWORD", false)
+        .Env("YDB_CLIENT_CERT_KEY_PASSWORD_FILE", true, "Client certificate private key password")
+        .ProfileParam("client-cert-key-password-file")
+        .RequiredArgument("PATH").StoreFilePath(&ClientCertPrivateKeyPasswordFile).StoreResult(&config.ClientCertPrivateKeyPassword);
 
     opts.SetCustomUsage(config.ArgV[0]);
     config.SetFreeArgsMin(1);
-    opts.ArgPermutation_ = NLastGetopt::REQUIRE_ORDER;
+    opts.GetOpts().ArgPermutation_ = NLastGetopt::REQUIRE_ORDER;
 }
 
 void TClientCommandRootBase::SetCustomUsage(TConfig& config) {
@@ -93,35 +109,23 @@ bool TClientCommandRootBase::ParseProtocol(TConfig& config, TString& message) {
 }
 
 void TClientCommandRootBase::ParseCaCerts(TConfig& config) {
-    if (CaCertsFile.empty()) {
-        return;
-    }
-    if (!config.EnableSsl) {
+    if (!config.EnableSsl && config.CaCerts) {
         throw TMisuseException()
             << "\"ca-file\" option provided for a non-ssl connection. Use grpcs:// prefix for host to connect using SSL.";
     }
-    config.CaCerts = ReadFromFile(CaCertsFile, "CA certificates");
 }
 
 void TClientCommandRootBase::ParseClientCert(TConfig& config) {
-    if (ClientCertFile.empty()) {
-        return;
-    }
-    if (!config.EnableSsl) {
-        throw TMisuseException()
-            << "\"client-cert-file\" option provided for a non-ssl connection. Use grpcs:// prefix for host to connect using SSL.";
-    }
-    config.ClientCert = ReadFromFile(ClientCertFile, "Client certificate");
-    if (ClientCertPrivateKeyFile) {
-        config.ClientCertPrivateKey = ReadFromFile(ClientCertPrivateKeyFile, "Client certificate private key");
-    }
-    if (ClientCertPrivateKeyPasswordFile) {
-        config.ClientCertPrivateKeyPassword = ReadFromFile(ClientCertPrivateKeyPasswordFile, "Client certificate private key password");
+    if (!config.EnableSsl && config.ClientCert) {
+        TMisuseException()
+            << "\"client-cert-file\"/\"client-cert-key-file\"/\"client-cert-key-password-file\" options are provided for a non-ssl connection. Use grpcs:// prefix for host to connect using SSL.";
     }
 
-    // Convert certificates from PKCS#12 to PEM or encrypted private key to nonencrypted
-    // May ask for password
-    std::tie(config.ClientCert, config.ClientCertPrivateKey) = ConvertCertToPEM(config.ClientCert, config.ClientCertPrivateKey, config.ClientCertPrivateKeyPassword);
+    if (config.ClientCert) {
+        // Convert certificates from PKCS#12 to PEM or encrypted private key to nonencrypted
+        // May ask for password
+        std::tie(config.ClientCert, config.ClientCertPrivateKey) = ConvertCertToPEM(config.ClientCert, config.ClientCertPrivateKey, config.ClientCertPrivateKeyPassword);
+    }
 }
 
 void TClientCommandRootBase::ParseCredentials(TConfig& config) {

--- a/ydb/public/lib/ydb_cli/common/root.h
+++ b/ydb/public/lib/ydb_cli/common/root.h
@@ -14,6 +14,7 @@ public:
     bool TimeRequests;
     bool ProgressRequests;
     TString Address;
+    bool EnableSsl = true;
     TString Token;
     TString TokenFile;
     TString CaCertsFile;

--- a/ydb/public/lib/ydb_cli/common/ya.make
+++ b/ydb/public/lib/ydb_cli/common/ya.make
@@ -3,6 +3,7 @@ LIBRARY(common)
 SRCS(
     aws.cpp
     cert_format_converter.cpp
+    client_command_options.cpp
     command.cpp
     command_utils.cpp
     common.cpp

--- a/ydb/public/sdk/cpp/examples/secondary_index/secondary_index_list.cpp
+++ b/ydb/public/sdk/cpp/examples/secondary_index/secondary_index_list.cpp
@@ -246,7 +246,7 @@ int RunListSeries(TDriver& driver, const std::string& prefix, int argc, char** a
     uint64_t lastSeriesId = -1;
     uint64_t lastViews = -1;
 
-    opts.AddLongOption("by-views", "Sort by views").NoArgument().SetFlag(&byViews);
+    opts.AddLongOption("by-views", "Sort by views").StoreTrue(&byViews);
     opts.AddLongOption("limit", "Maximum number of rows").Optional().RequiredArgument("NUM")
         .StoreResult(&limit);
     opts.AddLongOption("last-id", "Resume from this last series id").Optional().RequiredArgument("NUM")


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

YDB CLI help message improvements. Different display for detailed help and brief help.

### Changelog category <!-- remove all except one -->

* Improvement

### Description for reviewers <!-- (optional) description for those who read this PR -->

Removed copy-paste style code for options handling. Instead wrote classes that are similar to command line options classes, but additionally can work with YDB CLI specific things like parsing from env variable, from explicitly specified and current active profile, doc link, prioritize auth method parsing from env etc.

Also there are improvements in help message display. Parsing sources and additional information are displayed automatically with one unified code that generates full help string.

