### PR TITLE
Don't scan graph on repeative DqRecapture transform

### DIFF
--- a/ydb/library/yql/providers/dq/provider/yql_dq_recapture.cpp
+++ b/ydb/library/yql/providers/dq/provider/yql_dq_recapture.cpp
@@ -76,22 +76,24 @@ public:
                 return TStatus::Ok;
             }
 
-            Statistics_["DqAnalyzerOn"]++;
+            if (!State_->TypeCtx->DqCaptured) {
+                Statistics_["DqAnalyzerOn"]++;
 
-            bool good = true;
-            TNodeSet visited;
-            Scan(*input, ctx, good, visited);
+                bool good = true;
+                TNodeSet visited;
+                Scan(*input, ctx, good, visited);
 
-            if (good) {
-                Statistics_["DqAnalyzerOk"]++;
-            } else {
-                Statistics_["DqAnalyzerFail"] ++;
-            }
+                if (good) {
+                    Statistics_["DqAnalyzerOk"]++;
+                } else {
+                    Statistics_["DqAnalyzerFail"] ++;
+                }
 
-            if (!good) {
-                YQL_CLOG(DEBUG, ProviderDq) << "abort hidden";
-                State_->AbortHidden();
-                return TStatus::Ok;
+                if (!good) {
+                    YQL_CLOG(DEBUG, ProviderDq) << "abort hidden";
+                    State_->AbortHidden();
+                    return TStatus::Ok;
+                }
             }
         }
 


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

NDq::DqWrapIO() may require several runs to fully optimize graph. Don't validate graph again after initial validation and capturing DQ.

### Changelog category <!-- remove all except one -->

* Not for changelog (changelog entry is not required)


### Description for reviewers <!-- (optional) description for those who read this PR -->

...
