### PR TITLE
25-1-1 Fix B-Tree histograms comparator result overflow

### DIFF
--- a/ydb/core/tablet_flat/flat_page_btree_index.h
+++ b/ydb/core/tablet_flat/flat_page_btree_index.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <ydb/core/base/defs.h>
+#include <ydb/core/scheme/scheme_tablecell.h>
 #include <util/generic/bitmap.h>
 #include "flat_page_base.h"
 #include "flat_page_label.h"
@@ -280,6 +281,23 @@ namespace NKikimr::NTable::NPage {
             explicit operator bool() const noexcept
             {
                 return Count() > 0;
+            }
+
+            void Describe(IOutputStream& out, const TKeyCellDefaults& keyDefaults) const
+            {
+                out << '{';
+
+                auto iter = Iter();
+                for (TPos pos : xrange(iter.Count())) {
+                    if (pos != 0) {
+                        out << ", ";
+                    }
+                    TString value;
+                    DbgPrintValue(value, iter.Next(), keyDefaults.BasicTypes()[pos]);
+                    out << value;
+                }
+
+                out << '}';
             }
 
         private:

--- a/ydb/core/tablet_flat/flat_part_dump.cpp
+++ b/ydb/core/tablet_flat/flat_part_dump.cpp
@@ -281,7 +281,7 @@ namespace {
 
     void TDump::Key(TCellsRef key, const TPartScheme &scheme) noexcept
     {
-        Out << "(";
+        Out << "{";
 
         for (auto off : xrange(key.size())) {
             TString str;
@@ -291,7 +291,7 @@ namespace {
             Out << (off ? ", " : "") << str;
         }
 
-        Out << ")";
+        Out << "}";
     }
 
     void TDump::BTreeIndexNode(const TPart &part, NPage::TBtreeIndexNode::TChild meta, ui32 level) noexcept

--- a/ydb/core/tablet_flat/flat_part_slice.cpp
+++ b/ydb/core/tablet_flat/flat_part_slice.cpp
@@ -183,13 +183,22 @@ void TSlice::Describe(IOutputStream& out) const noexcept
 {
     out << (FirstInclusive ? '[' : '(');
     out << FirstRowId;
-    out << ',';
+    out << ", ";
     if (LastRowId != Max<TRowId>()) {
         out << LastRowId;
     } else {
         out << "+inf";
     }
     out << (LastInclusive ? ']' : ')');
+}
+
+void TSlice::Describe(IOutputStream& out, const TKeyCellDefaults& keyDefaults) const
+{
+    out << "{rows: ";
+    Describe(out);
+    out << " keys: ";
+    TBounds::Describe(out, keyDefaults);
+    out << "}";
 }
 
 void TSlices::Describe(IOutputStream& out) const noexcept
@@ -202,6 +211,20 @@ void TSlices::Describe(IOutputStream& out) const noexcept
         else
             out << ", ";
         bounds.Describe(out);
+    }
+    out << (first ? "}" : " }");
+}
+
+void TSlices::Describe(IOutputStream& out, const TKeyCellDefaults& keyDefaults) const
+{
+    bool first = true;
+    out << "{ ";
+    for (const auto& bounds : *this) {
+        if (first)
+            first = false;
+        else
+            out << ", ";
+        bounds.Describe(out, keyDefaults);
     }
     out << (first ? "}" : " }");
 }

--- a/ydb/core/tablet_flat/flat_part_slice.h
+++ b/ydb/core/tablet_flat/flat_part_slice.h
@@ -133,6 +133,7 @@ namespace NTable {
         }
 
         void Describe(IOutputStream& out) const noexcept;
+        void Describe(IOutputStream& out, const TKeyCellDefaults& keyDefaults) const;
 
         /**
          * Returns true if first row of a is less than first row of b
@@ -327,6 +328,8 @@ namespace NTable {
         }
 
         void Describe(IOutputStream& out) const noexcept;
+
+        void Describe(IOutputStream& out, const TKeyCellDefaults& keyDefaults) const;
 
         /**
          * Validate slices are correct, crash otherwise

--- a/ydb/core/tablet_flat/flat_part_writer.h
+++ b/ydb/core/tablet_flat/flat_part_writer.h
@@ -969,7 +969,7 @@ namespace NTable {
             
             TPos it;
             for (it = 0; it < Key.size(); it++) {
-                if (int cmp = CompareTypedCells(PrevPageLastKey[it], Key[it], layout.KeyTypes[it])) {
+                if (CompareTypedCells(PrevPageLastKey[it], Key[it], layout.KeyTypes[it]) != 0) {
                     break;
                 }
             }

--- a/ydb/core/tablet_flat/flat_stat_table.cpp
+++ b/ydb/core/tablet_flat/flat_stat_table.cpp
@@ -7,7 +7,9 @@
 namespace NKikimr {
 namespace NTable {
 
-bool BuildStats(const TSubset& subset, TStats& stats, ui64 rowCountResolution, ui64 dataSizeResolution, ui32 histogramBucketsCount, IPages* env, TBuildStatsYieldHandler yieldHandler) {
+bool BuildStats(const TSubset& subset, TStats& stats, ui64 rowCountResolution, ui64 dataSizeResolution, ui32 histogramBucketsCount, IPages* env, 
+    TBuildStatsYieldHandler yieldHandler, const TString& logPrefix)
+{
     stats.Clear();
 
     bool mixedIndex = false;
@@ -17,9 +19,17 @@ bool BuildStats(const TSubset& subset, TStats& stats, ui64 rowCountResolution, u
         }
     }
 
-    return mixedIndex
+    LOG_BUILD_STATS("starting for " << (mixedIndex ? "mixed" : "b-tree") << " index");
+
+    auto ready = mixedIndex
         ? BuildStatsMixedIndex(subset, stats, rowCountResolution, dataSizeResolution, env, yieldHandler)
-        : BuildStatsBTreeIndex(subset, stats, histogramBucketsCount, env, yieldHandler);
+        : BuildStatsBTreeIndex(subset, stats, histogramBucketsCount, env, yieldHandler, logPrefix);
+
+    LOG_BUILD_STATS("finished for " << (mixedIndex ? "mixed" : "b-tree") << " index"
+        << " ready: " << ready
+        << " stats: " << stats.ToString());
+
+    return ready;
 }
 
 void GetPartOwners(const TSubset& subset, THashSet<ui64>& partOwners) {

--- a/ydb/core/tablet_flat/flat_stat_table.h
+++ b/ydb/core/tablet_flat/flat_stat_table.h
@@ -7,6 +7,8 @@
 #include <util/generic/hash_set.h>
 
 #include <ydb/core/scheme/scheme_tablecell.h>
+#include <ydb/library/services/services.pb.h>
+#include <ydb/library/actors/core/log.h>
 
 namespace NKikimr {
 namespace NTable {
@@ -123,6 +125,16 @@ struct TStats {
         RowCountHistogram.swap(other.RowCountHistogram);
         DataSizeHistogram.swap(other.DataSizeHistogram);
     }
+
+    TString ToString() const noexcept {
+        return TStringBuilder() 
+            << "RowCount: " << RowCount
+            << " DataSize: " << DataSize.Size
+            << " IndexSize: " << IndexSize.Size
+            << " ByKeyFilterSize: " << ByKeyFilterSize
+            << " RowCountHistogram: " << RowCountHistogram.size()
+            << " DataSizeHistogram: " << DataSizeHistogram.size();
+    }
 };
 
 class TKeyAccessSample {
@@ -193,7 +205,27 @@ private:
 
 using TBuildStatsYieldHandler = std::function<void()>;
 
-bool BuildStats(const TSubset& subset, TStats& stats, ui64 rowCountResolution, ui64 dataSizeResolution, ui32 histogramBucketsCount, IPages* env, TBuildStatsYieldHandler yieldHandler);
+#ifndef NDEBUG
+#define LOG_BUILD_STATS(stream) \
+    do { \
+        if (auto actorContext = NActors::TlsActivationContext; actorContext) { \
+            LOG_TRACE_S(*actorContext, NKikimrServices::TABLET_STATS_BUILDER, logPrefix << stream); \
+        } else { \
+            Cerr << logPrefix << stream << Endl; \
+        } \
+    } while (0)
+#else
+#define LOG_BUILD_STATS(stream) \
+    do { \
+        if (auto actorContext = NActors::TlsActivationContext; actorContext) { \
+            LOG_TRACE_S(*actorContext, NKikimrServices::TABLET_STATS_BUILDER, logPrefix << stream); \
+        } \
+    } while (0)
+#endif
+
+bool BuildStats(const TSubset& subset, TStats& stats, ui64 rowCountResolution, ui64 dataSizeResolution, ui32 histogramBucketsCount, IPages* env, 
+    TBuildStatsYieldHandler yieldHandler, const TString& logPrefix = {});
+
 void GetPartOwners(const TSubset& subset, THashSet<ui64>& partOwners);
 
 }}

--- a/ydb/core/tablet_flat/flat_stat_table_btree_index.cpp
+++ b/ydb/core/tablet_flat/flat_stat_table_btree_index.cpp
@@ -1,5 +1,6 @@
 #include "flat_stat_table.h"
 #include "flat_table_subset.h"
+#include <util/stream/format.h>
 #include "flat_stat_table_btree_index.h"
 
 namespace NKikimr::NTable {
@@ -108,16 +109,21 @@ void AddBlobsSize(const TPart* part, TChanneledDataSize& stats, const TFrames* f
     }
 }
 
-bool AddDataSize(const TPartView& part, TStats& stats, IPages* env, TBuildStatsYieldHandler yieldHandler) {
+bool AddDataSize(const TPartView& part, TStats& stats, IPages* env, TBuildStatsYieldHandler yieldHandler, const TString& logPrefix) {
     bool ready = true;
 
     if (!part.Slices || part.Slices->empty()) {
         return true;
     }
 
+    auto logAddingGroup = [&](TGroupId groupId){
+        LOG_BUILD_STATS("adding group " << groupId << " " << part->IndexPages.GetBTree(groupId).ToString());
+    };
+
     if (part->GroupsCount) { // main group
         TGroupId groupId{};
         auto channel = part->GetGroupChannel(groupId);
+        logAddingGroup(groupId);
         
         for (const auto& slice : *part.Slices) {
             yieldHandler();
@@ -129,12 +135,16 @@ bool AddDataSize(const TPartView& part, TStats& stats, IPages* env, TBuildStatsY
             if (ready && endDataSize > beginDataSize) {
                 stats.DataSize.Add(endDataSize - beginDataSize, channel);
             }
+            LOG_BUILD_STATS("added slice [" << slice.BeginRowId() << ", " << slice.EndRowId() << ") data size "
+                << "(" << HumanReadableSize(endDataSize, SF_BYTES) << " - " << HumanReadableSize(beginDataSize, SF_BYTES) << ") => " << HumanReadableSize(stats.DataSize.Size, SF_BYTES));
 
             if (part->Small) {
                 AddBlobsSize(part.Part.Get(), stats.DataSize, part->Small.Get(), ELargeObj::Outer, slice.BeginRowId(), slice.EndRowId());
+                LOG_BUILD_STATS("added small blobs data size => " << HumanReadableSize(stats.DataSize.Size, SF_BYTES));
             }
             if (part->Large) {
                 AddBlobsSize(part.Part.Get(), stats.DataSize, part->Large.Get(), ELargeObj::Extern, slice.BeginRowId(), slice.EndRowId());
+                LOG_BUILD_STATS("added large blobs data size => " << HumanReadableSize(stats.DataSize.Size, SF_BYTES));
             }
         }
     }
@@ -142,6 +152,8 @@ bool AddDataSize(const TPartView& part, TStats& stats, IPages* env, TBuildStatsY
     for (ui32 groupIndex : xrange<ui32>(1, part->GroupsCount)) {
         TGroupId groupId{groupIndex};
         auto channel = part->GetGroupChannel(groupId);
+        logAddingGroup(groupId);
+
         for (const auto& slice : *part.Slices) {
             yieldHandler();
             
@@ -150,6 +162,8 @@ bool AddDataSize(const TPartView& part, TStats& stats, IPages* env, TBuildStatsY
             if (ready && endDataSize > beginDataSize) {
                 stats.DataSize.Add(endDataSize - beginDataSize, channel);
             }
+            LOG_BUILD_STATS("added slice [" << slice.BeginRowId() << ", " << slice.EndRowId() << ") data size "
+                << "(" << HumanReadableSize(endDataSize, SF_BYTES) << " - " << HumanReadableSize(beginDataSize, SF_BYTES) << ") => " << HumanReadableSize(stats.DataSize.Size, SF_BYTES));
         }
     }
 
@@ -158,6 +172,8 @@ bool AddDataSize(const TPartView& part, TStats& stats, IPages* env, TBuildStatsY
     if (part->HistoricGroupsCount) { // main historic group
         TGroupId groupId{0, true};
         auto channel = part->GetGroupChannel(groupId);
+        logAddingGroup(groupId);
+
         for (const auto& slice : *part.Slices) {
             yieldHandler();
             
@@ -169,6 +185,8 @@ bool AddDataSize(const TPartView& part, TStats& stats, IPages* env, TBuildStatsY
             if (ready && endDataSize > beginDataSize) {
                 stats.DataSize.Add(endDataSize - beginDataSize, channel);
             }
+            LOG_BUILD_STATS("added slice [" << slice.BeginRowId() << ", " << slice.EndRowId() << ") data size "
+                << "(" << HumanReadableSize(endDataSize, SF_BYTES) << " - " << HumanReadableSize(beginDataSize, SF_BYTES) << ") => " << HumanReadableSize(stats.DataSize.Size, SF_BYTES));
             if (readySlice && endRowId > beginRowId) {
                 historicSlices.emplace_back(beginRowId, endRowId);
             }
@@ -178,6 +196,8 @@ bool AddDataSize(const TPartView& part, TStats& stats, IPages* env, TBuildStatsY
     for (ui32 groupIndex : xrange<ui32>(1, part->HistoricGroupsCount)) {
         TGroupId groupId{groupIndex, true};
         auto channel = part->GetGroupChannel(groupId);
+        logAddingGroup(groupId);
+
         for (const auto& slice : historicSlices) {
             yieldHandler();
             
@@ -186,6 +206,8 @@ bool AddDataSize(const TPartView& part, TStats& stats, IPages* env, TBuildStatsY
             if (ready && endDataSize > beginDataSize) {
                 stats.DataSize.Add(endDataSize - beginDataSize, channel);
             }
+            LOG_BUILD_STATS("added slice [" << slice.first << ", " << slice.second << ") data size "
+                << "(" << HumanReadableSize(endDataSize, SF_BYTES) << " - " << HumanReadableSize(beginDataSize, SF_BYTES) << ") => " << HumanReadableSize(stats.DataSize.Size, SF_BYTES));
         }
     }
 
@@ -194,14 +216,15 @@ bool AddDataSize(const TPartView& part, TStats& stats, IPages* env, TBuildStatsY
 
 }
 
-bool BuildStatsBTreeIndex(const TSubset& subset, TStats& stats, ui32 histogramBucketsCount, IPages* env, TBuildStatsYieldHandler yieldHandler) {
+bool BuildStatsBTreeIndex(const TSubset& subset, TStats& stats, ui32 histogramBucketsCount, IPages* env, TBuildStatsYieldHandler yieldHandler, const TString& logPrefix) {
     stats.Clear();
 
     bool ready = true;
     for (const auto& part : subset.Flatten) {
+        LOG_BUILD_STATS("adding part " << part->Label.ToString() << " data size (" << HumanReadableSize(part->DataSize(), SF_BYTES) << " in total)");
         stats.IndexSize.Add(part->IndexesRawSize, part->Label.Channel());
         stats.ByKeyFilterSize += part->ByKey ? part->ByKey->Raw.size() : 0;
-        ready &= AddDataSize(part, stats, env, yieldHandler);
+        ready &= AddDataSize(part, stats, env, yieldHandler, logPrefix);
     }
 
     if (!ready) {
@@ -210,7 +233,7 @@ bool BuildStatsBTreeIndex(const TSubset& subset, TStats& stats, ui32 histogramBu
 
     ready &= BuildStatsHistogramsBTreeIndex(subset, stats, 
         stats.RowCount / histogramBucketsCount, stats.DataSize.Size / histogramBucketsCount, 
-        env, yieldHandler);
+        env, yieldHandler, logPrefix);
 
     return ready;
 }

--- a/ydb/core/tablet_flat/flat_stat_table_btree_index.h
+++ b/ydb/core/tablet_flat/flat_stat_table_btree_index.h
@@ -5,9 +5,11 @@
 
 namespace NKikimr::NTable {
 
-bool BuildStatsBTreeIndex(const TSubset& subset, TStats& stats, ui32 histogramBucketsCount, IPages* env, TBuildStatsYieldHandler yieldHandler);
+bool BuildStatsBTreeIndex(const TSubset& subset, TStats& stats, ui32 histogramBucketsCount, IPages* env,
+    TBuildStatsYieldHandler yieldHandler, const TString& logPrefix = "");
 
-bool BuildStatsHistogramsBTreeIndex(const TSubset& subset, TStats& stats, ui64 rowCountResolution, ui64 dataSizeResolution, IPages* env, TBuildStatsYieldHandler yieldHandler);
+bool BuildStatsHistogramsBTreeIndex(const TSubset& subset, TStats& stats, ui64 rowCountResolution, ui64 dataSizeResolution, IPages* env,
+    TBuildStatsYieldHandler yieldHandler, const TString& logPrefix = "");
 
 
 }

--- a/ydb/core/tablet_flat/flat_stat_table_btree_index_histogram.cpp
+++ b/ydb/core/tablet_flat/flat_stat_table_btree_index_histogram.cpp
@@ -48,7 +48,7 @@ class TTableHistogramBuilderBtreeIndex {
         {
         }
 
-        TString ToString() const noexcept {
+        TString ToString(const TKeyCellDefaults &keyDefaults) const {
             return TStringBuilder() 
                 << "Part: " << Part->Label.ToString()
                 << " PageId: " << PageId
@@ -57,8 +57,8 @@ class TTableHistogramBuilderBtreeIndex {
                 << " EndRowId: " << EndRowId
                 << " BeginDataSize: " << BeginDataSize
                 << " EndDataSize: " << EndDataSize
-                << " BeginKey: " << BeginKey.Count()
-                << " EndKey: " << EndKey.Count()
+                << " BeginKey: " << NFmt::Do(BeginKey, keyDefaults)
+                << " EndKey: " << NFmt::Do(EndKey, keyDefaults)
                 << " State: " << (ui32)State;
         }
 
@@ -130,15 +130,17 @@ class TTableHistogramBuilderBtreeIndex {
     };
 
     struct TEvent {
-        TCellsIterable Key;
-        bool IsBegin;
         TNodeState* Node;
+        bool IsBegin;
 
-        TString ToString() const noexcept {
+        TString ToString(const TKeyCellDefaults &keyDefaults) const {
             return TStringBuilder()
-                << Node->ToString()
-                << " IsBegin: " << IsBegin
-                << " Key: " << Key.Count();
+                << "IsBegin: " << IsBegin
+                << " " << Node->ToString(keyDefaults);
+        }
+
+        const TCellsIterable& GetKey() const {
+            return IsBegin ? Node->BeginKey : Node->EndKey;
         }
     };
 
@@ -149,7 +151,7 @@ class TTableHistogramBuilderBtreeIndex {
             return Compare(a, b) > 0;
         }
 
-        i8 Compare(const TEvent& a, const TEvent& b) const noexcept {
+        int Compare(const TEvent& a, const TEvent& b) const {
             // events go in order:
             // - Key = {}, IsBegin = true
             // - ...
@@ -161,13 +163,16 @@ class TTableHistogramBuilderBtreeIndex {
             // - ...
             // - Key = {}, IsBegin = false
 
-            if (a.Key && b.Key) { // compare by keys
-                auto cmp = CompareKeys(a.Key, b.Key, KeyDefaults);
+            // end goes before begin in order to 
+            // close previous node before open the next one
+
+            if (a.GetKey() && b.GetKey()) { // compare by keys
+                auto cmp = CompareKeys(a.GetKey(), b.GetKey(), KeyDefaults);
                 if (cmp != 0) {
                     return cmp;
                 }
                 // keys are the same, compare by begin flag, end events first:
-                return Compare(a.IsBegin ? 1 : -1, b.IsBegin ? 1 : -1);
+                return Compare(a.IsBegin ? +1 : -1, b.IsBegin ? +1 : -1);
             }
 
             // category = -1 for Key = { }, IsBegin = true
@@ -177,14 +182,14 @@ class TTableHistogramBuilderBtreeIndex {
         }
 
     private:
-        static i8 GetCategory(const TEvent& a) noexcept {
-            if (a.Key) {
+        static int GetCategory(const TEvent& a) {
+            if (a.GetKey()) {
                 return 0;
             }
             return a.IsBegin ? -1 : +1;
         }
 
-        static i8 Compare(i8 a, i8 b) noexcept {
+        static int Compare(int a, int b) {
             if (a < b) return -1;
             if (a > b) return +1;
             return 0;
@@ -226,6 +231,9 @@ public:
 
         for (auto index : xrange(Subset.Flatten.size())) {
             auto& part = Subset.Flatten[index];
+            if (part.Slices) {
+                LOG_BUILD_STATS("slicing part " << part->Label << ": " << NFmt::Do(*part.Slices, KeyDefaults));
+            }
             auto& meta = part->IndexPages.GetBTree({});
             TCellsIterable beginKey = EmptyKey;
             if (part.Slices && part.Slices->front().FirstKey.GetCells()) {
@@ -235,7 +243,7 @@ public:
             if (part.Slices && part.Slices->back().LastKey.GetCells()) {
                 endKey = MakeCellsIterableKey(part.Part.Get(), part.Slices->back().LastKey);
             }
-            LoadedStateNodes.emplace_back(part.Part.Get(), meta.GetPageId(), meta.LevelCount, 0, meta.GetRowCount(), 0, meta.GetDataSize(), beginKey, endKey);
+            LoadedStateNodes.emplace_back(part.Part.Get(), meta.GetPageId(), meta.LevelCount, 0, meta.GetRowCount(), 0, meta.GetTotalDataSize(), beginKey, endKey);
             ready &= SlicePart(*part.Slices, LoadedStateNodes.back());
         }
 
@@ -261,13 +269,13 @@ private:
         
         if (it == slices.end() || node.EndRowId <= it->BeginRowId() || it->EndRowId() <= node.BeginRowId) {
             // skip the node
-            LOG_BUILD_STATS("slicing node " << node.ToString() << " => skip");
+            LOG_BUILD_STATS("slicing node " << node.ToString(KeyDefaults) << " => skip");
             return true;
         }
 
         if (it->BeginRowId() <= node.BeginRowId && node.EndRowId <= it->EndRowId()) {
             // take the node
-            LOG_BUILD_STATS("slicing node " << node.ToString() << " => take");
+            LOG_BUILD_STATS("slicing node " << node.ToString(KeyDefaults) << " => take");
             AddFutureEvents(node);
             return true;
         }
@@ -278,17 +286,20 @@ private:
             // can't split, decide by node.EndRowId - 1
             // TODO: decide by non-empty slice and node intersection, but this requires size calculation changes too
             if (it->Has(node.EndRowId - 1)) {
-                LOG_BUILD_STATS("slicing node " << node.ToString() << " => take root");
+                LOG_BUILD_STATS("slicing node " << node.ToString(KeyDefaults) << " => take leaf");
+                // the slice may start after node begin, shift the node begin to make it more sensible
+                node.BeginRowId = it->BeginRowId();
+                node.BeginKey = MakeCellsIterableKey(node.Part, it->FirstKey);
                 AddFutureEvents(node);
             } else {
-                LOG_BUILD_STATS("slicing node " << node.ToString() << " => skip root");
+                LOG_BUILD_STATS("slicing node " << node.ToString(KeyDefaults) << " => skip leaf");
             }
             return true;
         }
 
         bool ready = true;
 
-        LOG_BUILD_STATS("slicing node " << node.ToString() << " => split");
+        LOG_BUILD_STATS("slicing node " << node.ToString(KeyDefaults) << " => split");
         const auto addNode = [&](TNodeState& child) {
             ready &= SlicePart(slices, child);
         };
@@ -341,10 +352,10 @@ private:
                 << " openedSortedByRowCount: " << openedSortedByRowCount.size()
                 << " openedSortedByDataSize: " << openedSortedByDataSize.size()
                 << " FutureEvents: " << FutureEvents.size()
-                << " currentKeyPointer: " << currentKeyPointer.ToString());
+                << " currentKeyPointer: " << currentKeyPointer.ToString(KeyDefaults));
 
             auto processEvent = [&](const TEvent& event) {
-                LOG_BUILD_STATS("processing event " << event.ToString());
+                LOG_BUILD_STATS("processing event " << event.ToString(KeyDefaults));
                 Y_DEBUG_ABORT_UNLESS(NodeEventKeyGreater.Compare(event, currentKeyPointer) <= 0, "Can't process future events");
                 if (event.IsBegin) {
                     if (event.Node->Open(openedRowCount, openedDataSize)) {
@@ -370,7 +381,7 @@ private:
                 // TODO: skip all closed nodes and don't process them here
                 // TODO: don't compare each node key and replace it with parentNode.Seek(currentKeyPointer)
                 auto cmp = NodeEventKeyGreater.Compare(event, currentKeyPointer);
-                LOG_BUILD_STATS("adding event " << (i32)cmp << " " << event.ToString());
+                LOG_BUILD_STATS("adding event " << (i32)cmp << " " << event.ToString(KeyDefaults));
                 if (cmp <= 0) { // event happened
                     processEvent(event);
                     if (cmp == 0) {
@@ -381,8 +392,8 @@ private:
                 }
             };
             const auto addNode = [&](TNodeState& node) {
-                addEvent(TEvent{node.BeginKey, true, &node});
-                addEvent(TEvent{node.EndKey, false, &node});
+                addEvent(TEvent{&node, true});
+                addEvent(TEvent{&node, false});
             };
 
             // may safely skip current key pointer and go further only if at the next iteration
@@ -395,7 +406,7 @@ private:
                 openedSortedByRowCount.pop();
 
                 LOG_BUILD_STATS("loading node by row count trigger"
-                    << node->ToString()
+                    << node->ToString(KeyDefaults)
                     << " closedRowCount: " << closedRowCount
                     << " openedRowCount: " << openedRowCount
                     << " nextHistogramRowCount: " << nextHistogramRowCount);
@@ -413,7 +424,7 @@ private:
                 openedSortedByDataSize.pop();
 
                 LOG_BUILD_STATS("loading node by data size trigger"
-                    << node->ToString()
+                    << node->ToString(KeyDefaults)
                     << " closedDataSize: " << closedDataSize
                     << " openedDataSize: " << openedDataSize
                     << " nextHistogramDataSize: " << nextHistogramDataSize);
@@ -439,7 +450,7 @@ private:
                 << " openedSortedByRowCount: " << openedSortedByRowCount.size()
                 << " openedSortedByDataSize: " << openedSortedByDataSize.size()
                 << " FutureEvents: " << FutureEvents.size()
-                << " currentKeyPointer: " << currentKeyPointer.ToString());
+                << " currentKeyPointer: " << currentKeyPointer.ToString(KeyDefaults));
 
             // add current key pointer to a histogram if we either:
             // - failed to split opened nodes and may exceed a next histogram bucket value (plus its gaps)
@@ -449,7 +460,7 @@ private:
             // - minus size of all nodes that start at current key pointer
             // - plus half of size of all ohter opened nodes (as they exact position is unknown)
             // also check that current key pointer value is > then last presented value in a histogram
-            if (currentKeyPointer.Key) {
+            if (currentKeyPointer.GetKey()) {
                 if (nextHistogramRowCount != Max<ui64>()) {
                     if (closedRowCount + openedRowCount > nextHistogramRowCount + RowCountResolutionGap || closedRowCount > nextHistogramRowCount - RowCountResolutionGap) {
                         ui64 currentKeyRowCountOpens = 0;
@@ -461,7 +472,7 @@ private:
                         Y_ABORT_UNLESS(currentKeyRowCountOpens <= openedRowCount);
                         ui64 currentKeyPointerRowCount = closedRowCount + (openedRowCount - currentKeyRowCountOpens) / 2;
                         if ((stats.RowCountHistogram.empty() ? 0 : stats.RowCountHistogram.back().Value) < currentKeyPointerRowCount && currentKeyPointerRowCount < stats.RowCount) {
-                            AddKey(stats.RowCountHistogram, currentKeyPointer.Key, currentKeyPointerRowCount);
+                            AddKey(stats.RowCountHistogram, currentKeyPointer.GetKey(), currentKeyPointerRowCount);
                             nextHistogramRowCount = Max(currentKeyPointerRowCount + 1, nextHistogramRowCount + RowCountResolution);
                             if (nextHistogramRowCount + RowCountResolutionGap > stats.RowCount) {
                                 nextHistogramRowCount = Max<ui64>();
@@ -480,7 +491,7 @@ private:
                         Y_ABORT_UNLESS(currentKeyDataSizeOpens <= openedDataSize);
                         ui64 currentKeyPointerDataSize = closedDataSize + (openedDataSize - currentKeyDataSizeOpens) / 2;
                         if ((stats.DataSizeHistogram.empty() ? 0 : stats.DataSizeHistogram.back().Value) < currentKeyPointerDataSize && currentKeyPointerDataSize < stats.DataSize.Size) {
-                            AddKey(stats.DataSizeHistogram, currentKeyPointer.Key, currentKeyPointerDataSize);
+                            AddKey(stats.DataSizeHistogram, currentKeyPointer.GetKey(), currentKeyPointerDataSize);
                             nextHistogramDataSize = Max(currentKeyPointerDataSize + 1, nextHistogramDataSize + DataSizeResolution);
                             if (nextHistogramDataSize + DataSizeResolutionGap > stats.DataSize.Size) {
                                 nextHistogramDataSize = Max<ui64>();
@@ -507,7 +518,7 @@ private:
         return true;
     }
 
-    void AddKey(THistogram& histogram, TCellsIterable& key, ui64 value) {
+    void AddKey(THistogram& histogram, const TCellsIterable& key, ui64 value) {
         TVector<TCell> keyCells;
 
         // add columns that are present in the part:
@@ -555,8 +566,14 @@ private:
     }
 
     void AddFutureEvents(TNodeState& node) {
-        FutureEvents.push(TEvent{node.BeginKey, true, &node});
-        FutureEvents.push(TEvent{node.EndKey, false, &node});
+        auto cmp = NodeEventKeyGreater.Compare(TEvent{&node, true}, TEvent{&node, false});
+        LOG_BUILD_STATS("adding node future events " << (i32)cmp << " " << node.ToString(KeyDefaults));
+        if (node.GetRowCount() > 1) {
+            Y_DEBUG_ABORT_UNLESS(cmp < 0);
+        }
+
+        FutureEvents.push(TEvent{&node, true});
+        FutureEvents.push(TEvent{&node, false});
     }
     
 private:

--- a/ydb/core/tablet_flat/ut/ut_btree_index_nodes.cpp
+++ b/ydb/core/tablet_flat/ut/ut_btree_index_nodes.cpp
@@ -99,7 +99,7 @@ namespace {
         dumpChild(node, 0);
 
         for (TRecIdx i : xrange(node.GetKeysCount())) {
-            Cerr << intend << " | > ";
+            Cerr << intend << " | > {";
 
             auto cells = node.GetKeyCellsIter(i, groupInfo.ColsKeyIdx);
             for (TPos pos : xrange(cells.Count())) {
@@ -111,7 +111,7 @@ namespace {
                 Cerr << (pos ? ", " : "") << str;
             }
 
-            Cerr << Endl;
+            Cerr << "}" << Endl;
             dumpChild(node, i + 1);
         }
 

--- a/ydb/core/tablet_flat/ut/ut_stat.cpp
+++ b/ydb/core/tablet_flat/ut/ut_stat.cpp
@@ -461,7 +461,7 @@ Y_UNIT_TEST_SUITE(BuildStatsHistogram) {
         for (auto &part : subset.Flatten) {
             TTestEnv env;
             auto index = CreateIndexIter(part.Part.Get(), &env, {});
-            Cerr << "  " << index->GetEndRowId() << " rows, " 
+            Cerr << "  " << part->Label << " " << index->GetEndRowId() << " rows, " 
                 << IndexTools::CountMainPages(*part.Part) << " pages, "
                 << (part->IndexPages.HasBTree() ? part->IndexPages.GetBTree({}).LevelCount : -1) << " levels: ";
             for (ui32 sample : xrange(1u, samples + 1)) {

--- a/ydb/core/tablet_flat/ya.make
+++ b/ydb/core/tablet_flat/ya.make
@@ -99,6 +99,8 @@ ENDIF()
 PEERDIR(
     contrib/libs/protobuf
     ydb/library/actors/util
+    ydb/library/actors/core
+    ydb/library/services
     library/cpp/containers/absl_flat_hash
     library/cpp/containers/intrusive_rb_tree
     library/cpp/containers/stack_vector

--- a/ydb/core/tx/datashard/datashard__stats.cpp
+++ b/ydb/core/tx/datashard/datashard__stats.cpp
@@ -113,7 +113,7 @@ public:
         auto msg = ev->Get();
 
         if (msg->Status != NKikimrProto::OK) {
-            LOG_ERROR_S(GetActorContext(), NKikimrServices::TX_DATASHARD, "Stats build failed at datashard "
+            LOG_ERROR_S(GetActorContext(), NKikimrServices::TABLET_STATS_BUILDER, "Failed to build at datashard "
                 << TabletId << ", for tableId " << TableId << " requested pages but got " << msg->Status);
             throw TExTableStatsError(ECode::FETCH_PAGE_FAILED, NKikimrProto::EReplyStatus_Name(msg->Status));
         }
@@ -165,15 +165,16 @@ private:
                 ObtainResources();
                 Spent->Alter(true); // resume measurement
             }
-        });
+        }, TStringBuilder() << "Building stats at datashard " << TabletId << ", for tableId " << TableId << ": ");
         
         Y_DEBUG_ABORT_UNLESS(IndexSize == ev->Stats.IndexSize.Size);
 
-        LOG_DEBUG_S(GetActorContext(), NKikimrServices::TX_DATASHARD, "BuildStats result at datashard " << TabletId << ", for tableId " << TableId
-            << ": RowCount " << ev->Stats.RowCount << ", DataSize " << ev->Stats.DataSize.Size << ", IndexSize " << ev->Stats.IndexSize.Size << ", PartCount " << ev->PartCount
+        LOG_INFO_S(GetActorContext(), NKikimrServices::TABLET_STATS_BUILDER, "Stats at datashard " << TabletId << ", for tableId " << TableId << ": "
+            << ev->Stats.ToString()
+            << " PartCount: " << ev->PartCount
             << (ev->PartOwners.size() > 1 || ev->PartOwners.size() == 1 && *ev->PartOwners.begin() != TabletId ? ", with borrowed parts" : "")
             << (ev->HasSchemaChanges ? ", with schema changes" : "")
-            << ", LoadedSize " << PagesSize << ", " << NFmt::Do(*Spent) << ", HistogramKeys " << ev->Stats.DataSizeHistogram.size());
+            << ", LoadedSize " << PagesSize << ", " << NFmt::Do(*Spent));
 
         Send(ReplyTo, ev.Release());
 
@@ -181,10 +182,12 @@ private:
     }
 
     void ProcessUnexpectedEvent(TAutoPtr<IEventHandle> ev) {
-        switch (const ui32 type = ev->GetTypeRewrite()) {
+        switch (ev->GetTypeRewrite()) {
             case TEvResourceBroker::EvTaskOperationError: {
                 const auto* msg = ev->CastAsLocal<TEvResourceBroker::TEvTaskOperationError>();
-                LOG_ERROR_S(GetActorContext(), NKikimrServices::TX_DATASHARD, "TEvResourceAllocated: " << msg->Status.Message);
+                LOG_ERROR_S(GetActorContext(), NKikimrServices::TABLET_STATS_BUILDER, "Failed to allocate resource" 
+                    << " error '" << msg->Status.Message << "'"
+                    << " at datashard " << TabletId << ", for tableId " << TableId);
                 throw TExTableStatsError(ECode::RESOURCE_ALLOCATION_FAILED, msg->Status.Message);
             }
 
@@ -361,18 +364,18 @@ void TDataShard::Handle(TEvPrivate::TEvAsyncTableStats::TPtr& ev, const TActorCo
     ui64 tableId = ev->Get()->TableId;
 
     if (!TableInfos.contains(tableId)) {
-        LOG_DEBUG_S(ctx, NKikimrServices::TX_DATASHARD, "BuildStats result dropped at datashard " << TabletID()
-            << ", built for tableId " << tableId << ", but table is gone (moved ot dropped)");
+        LOG_INFO_S(ctx, NKikimrServices::TABLET_STATS_BUILDER, "Result dropped at datashard " << TabletID() << ", for tableId " << tableId
+            << ", but table is gone (moved ot dropped)");
         return;
     }
 
-    LOG_DEBUG_S(ctx, NKikimrServices::TX_DATASHARD, "BuildStats result received at datashard " << TabletID() 
-        << ", for tableId " << tableId);
+    LOG_INFO_S(ctx, NKikimrServices::TABLET_STATS_BUILDER, "Result received at datashard " << TabletID() << ", for tableId " << tableId
+        << ": " << ev->Get()->Stats.ToString());
 
     const TUserTable& tableInfo = *TableInfos[tableId];
 
     if (!tableInfo.StatsUpdateInProgress) { // how can this happen?
-        LOG_ERROR(ctx, NKikimrServices::TX_DATASHARD, "Unexpected async stats update at datashard %" PRIu64, TabletID());
+        LOG_ERROR_S(ctx, NKikimrServices::TABLET_STATS_BUILDER, "Unexpected async stats update at datashard " << TabletID() << ", for tableId " << tableId);
     }
 
     tableInfo.Stats.DataStats = std::move(ev->Get()->Stats);
@@ -401,8 +404,7 @@ void TDataShard::Handle(TEvPrivate::TEvAsyncTableStats::TPtr& ev, const TActorCo
 
         LOG_ERROR_S(ctx, NKikimrServices::TX_DATASHARD, "Data size " << tableInfo.Stats.DataStats.DataSize.Size
             << " is higher than threshold of " << (i64)HighDataSizeReportThresholdBytes
-            << " at datashard: " << TabletID()
-            << " table: " << names
+            << " at datashard " << TabletID() << ", for tables " << names
             << " consider reconfiguring table partitioning settings");
     }
 }
@@ -412,8 +414,9 @@ void TDataShard::Handle(TEvPrivate::TEvTableStatsError::TPtr& ev, const TActorCo
 
     auto msg = ev->Get();
 
-    LOG_ERROR_S(ctx, NKikimrServices::TX_DATASHARD, "Stats rebuilt error '" << msg->Message 
-        << "', code: " << ui32(msg->Code) << ", datashard " << TabletID() << ", tableId " << msg->TableId);
+    LOG_ERROR_S(ctx, NKikimrServices::TABLET_STATS_BUILDER, "Stats rebuilt error '" << msg->Message 
+        << "', code: " << ui32(msg->Code) 
+        << " at datashard " << TabletID() << ", for tableId " << msg->TableId);
 
     auto it = TableInfos.find(msg->TableId);
     if (it != TableInfos.end()) {
@@ -493,8 +496,8 @@ public:
                 stats.SearchHeight = searchHeight;
                 stats.HasSchemaChanges = hasSchemaChanges;
 
-                LOG_DEBUG_S(ctx, NKikimrServices::TX_DATASHARD, "BuildStats skipped at datashard " << Self->TabletID() << ", for tableId " << tableId
-                    << ": RowCount " << stats.DataStats.RowCount << ", DataSize " << stats.DataStats.DataSize.Size << ", IndexSize " << stats.DataStats.IndexSize.Size << ", PartCount " << stats.PartCount
+                LOG_INFO_S(ctx, NKikimrServices::TABLET_STATS_BUILDER, "Skipped at datashard " << Self->TabletID() << ", for tableId " << tableId << ": "
+                    << stats.DataStats.ToString() << " PartCount " << stats.PartCount
                     << (stats.HasSchemaChanges ? ", with schema changes" : ""));
 
                 continue;
@@ -600,7 +603,7 @@ void TDataShard::UpdateTableStats(const TActorContext &ctx) {
 
     LastDbStatsUpdateTime = now;
 
-    LOG_DEBUG(ctx, NKikimrServices::TX_DATASHARD, "UpdateTableStats at datashard %" PRIu64, TabletID());
+    LOG_INFO_S(ctx, NKikimrServices::TABLET_STATS_BUILDER, "UpdateTableStats at datashard " << TabletID());
 
     Executor()->Execute(new TTxInitiateStatsUpdate(this), ctx);
 }
@@ -630,8 +633,8 @@ void TDataShard::CollectCpuUsage(const TActorContext &ctx) {
         ListTableNames(GetUserTables(), names);
 
         LOG_ERROR_S(ctx, NKikimrServices::TX_DATASHARD, "CPU usage " << cpuPercent
-                    << "% is higher than threshold of " << (i64)CpuUsageReportThresholdPercent
-                    << "% in-flight Tx: " << TxInFly()
+                    << " is higher than threshold of " << (i64)CpuUsageReportThresholdPercent
+                    << " in-flight Tx: " << TxInFly()
                     << " immediate Tx: " << ImmediateInFly()
                     << " readIterators: " << ReadIteratorsInFly()
                     << " at datashard: " << TabletID()

--- a/ydb/core/tx/datashard/datashard_ut_stats.cpp
+++ b/ydb/core/tx/datashard/datashard_ut_stats.cpp
@@ -82,6 +82,7 @@ Y_UNIT_TEST_SUITE(DataShardStats) {
         bool bTreeIndex = runtime.GetAppData().FeatureFlags.GetEnableLocalDBBtreeIndex();
 
         runtime.SetLogPriority(NKikimrServices::TX_DATASHARD, NLog::PRI_TRACE);
+        runtime.SetLogPriority(NKikimrServices::TABLET_STATS_BUILDER, NLog::PRI_TRACE);
         runtime.SetLogPriority(NKikimrServices::TABLET_SAUSAGECACHE, NLog::PRI_TRACE);
 
         InitRoot(server, sender);
@@ -144,6 +145,7 @@ Y_UNIT_TEST_SUITE(DataShardStats) {
         bool bTreeIndex = runtime.GetAppData().FeatureFlags.GetEnableLocalDBBtreeIndex();
 
         runtime.SetLogPriority(NKikimrServices::TX_DATASHARD, NLog::PRI_TRACE);
+        runtime.SetLogPriority(NKikimrServices::TABLET_STATS_BUILDER, NLog::PRI_TRACE);
 
         InitRoot(server, sender);
 
@@ -204,6 +206,7 @@ Y_UNIT_TEST_SUITE(DataShardStats) {
         bool bTreeIndex = runtime.GetAppData().FeatureFlags.GetEnableLocalDBBtreeIndex();
 
         runtime.SetLogPriority(NKikimrServices::TX_DATASHARD, NLog::PRI_TRACE);
+        runtime.SetLogPriority(NKikimrServices::TABLET_STATS_BUILDER, NLog::PRI_TRACE);
 
         InitRoot(server, sender);
 
@@ -270,6 +273,7 @@ Y_UNIT_TEST_SUITE(DataShardStats) {
         bool bTreeIndex = runtime.GetAppData().FeatureFlags.GetEnableLocalDBBtreeIndex();
 
         runtime.SetLogPriority(NKikimrServices::TX_DATASHARD, NLog::PRI_TRACE);
+        runtime.SetLogPriority(NKikimrServices::TABLET_STATS_BUILDER, NLog::PRI_TRACE);
 
         InitRoot(server, sender);
 
@@ -341,6 +345,7 @@ Y_UNIT_TEST_SUITE(DataShardStats) {
         auto sender = runtime.AllocateEdgeActor();
 
         runtime.SetLogPriority(NKikimrServices::TX_DATASHARD, NLog::PRI_TRACE);
+        runtime.SetLogPriority(NKikimrServices::TABLET_STATS_BUILDER, NLog::PRI_TRACE);
         runtime.SetLogPriority(NKikimrServices::TABLET_SAUSAGECACHE, NLog::PRI_TRACE);
 
         InitRoot(server, sender);
@@ -390,6 +395,7 @@ Y_UNIT_TEST_SUITE(DataShardStats) {
         auto sender = runtime.AllocateEdgeActor();
 
         runtime.SetLogPriority(NKikimrServices::TX_DATASHARD, NLog::PRI_TRACE);
+        runtime.SetLogPriority(NKikimrServices::TABLET_STATS_BUILDER, NLog::PRI_TRACE);
         runtime.SetLogPriority(NKikimrServices::TABLET_SAUSAGECACHE, NLog::PRI_TRACE);
 
         InitRoot(server, sender);
@@ -463,6 +469,7 @@ Y_UNIT_TEST_SUITE(DataShardStats) {
         auto sender = runtime.AllocateEdgeActor();
 
         runtime.SetLogPriority(NKikimrServices::TX_DATASHARD, NLog::PRI_TRACE);
+        runtime.SetLogPriority(NKikimrServices::TABLET_STATS_BUILDER, NLog::PRI_TRACE);
         runtime.SetLogPriority(NKikimrServices::TABLET_SAUSAGECACHE, NLog::PRI_TRACE);
 
         InitRoot(server, sender);
@@ -478,7 +485,7 @@ Y_UNIT_TEST_SUITE(DataShardStats) {
 
         CompactTable(runtime, shard1, tableId1, false);
 
-        runtime.WaitFor("blocked read", [&]{ return block.size(); });
+        runtime.WaitFor("blocked read", [&]{ return block.size(); }, TDuration::Seconds(10));
 
         block.Stop().Unblock();
 
@@ -507,6 +514,7 @@ Y_UNIT_TEST_SUITE(DataShardStats) {
         auto sender = runtime.AllocateEdgeActor();
         
         //runtime.SetLogPriority(NKikimrServices::TX_DATASHARD, NLog::PRI_TRACE);
+        // runtime.SetLogPriority(NKikimrServices::TABLET_STATS_BUILDER, NLog::PRI_TRACE);
 
         InitRoot(server, sender);
 
@@ -554,6 +562,7 @@ Y_UNIT_TEST_SUITE(DataShardStats) {
         auto sender = runtime.AllocateEdgeActor();
         
         runtime.SetLogPriority(NKikimrServices::TX_DATASHARD, NLog::PRI_TRACE);
+        runtime.SetLogPriority(NKikimrServices::TABLET_STATS_BUILDER, NLog::PRI_TRACE);
 
         InitRoot(server, sender);
 
@@ -641,6 +650,7 @@ Y_UNIT_TEST_SUITE(DataShardStats) {
         runtime.GetAppData().FeatureFlags.SetEnableLocalDBBtreeIndex(false);
 
         runtime.SetLogPriority(NKikimrServices::TX_DATASHARD, NLog::PRI_TRACE);
+        runtime.SetLogPriority(NKikimrServices::TABLET_STATS_BUILDER, NLog::PRI_TRACE);
 
         InitRoot(server, sender);
 
@@ -682,6 +692,7 @@ Y_UNIT_TEST_SUITE(DataShardStats) {
         runtime.GetAppData().FeatureFlags.SetEnableLocalDBBtreeIndex(false);
 
         runtime.SetLogPriority(NKikimrServices::TX_DATASHARD, NLog::PRI_TRACE);
+        runtime.SetLogPriority(NKikimrServices::TABLET_STATS_BUILDER, NLog::PRI_TRACE);
 
         InitRoot(server, sender);
 
@@ -736,6 +747,7 @@ Y_UNIT_TEST_SUITE(DataShardStats) {
         runtime.GetAppData().FeatureFlags.SetEnableLocalDBBtreeIndex(false);
 
         runtime.SetLogPriority(NKikimrServices::TX_DATASHARD, NLog::PRI_TRACE);
+        runtime.SetLogPriority(NKikimrServices::TABLET_STATS_BUILDER, NLog::PRI_TRACE);
 
         InitRoot(server, sender);
 
@@ -779,6 +791,7 @@ Y_UNIT_TEST_SUITE(DataShardStats) {
         runtime.GetAppData().FeatureFlags.SetEnableLocalDBBtreeIndex(false);
 
         runtime.SetLogPriority(NKikimrServices::TX_DATASHARD, NLog::PRI_TRACE);
+        runtime.SetLogPriority(NKikimrServices::TABLET_STATS_BUILDER, NLog::PRI_TRACE);
 
         InitRoot(server, sender);
 

--- a/ydb/library/services/services.proto
+++ b/ydb/library/services/services.proto
@@ -107,6 +107,7 @@ enum EServiceKikimr {
     OPS_BACKUP = 668;
     SAUSAGE_BIO = 669;
     FAKE_ENV = 670;
+    TABLET_STATS_BUILDER = 671;
 
     // PIPE section
     PIPE_CLIENT = 320;


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

Fixes invalid data shards histograms when `enable_local_dbbtree_index ` is enabled (#15235)

### Changelog category <!-- remove all except one -->

* Bugfix 

### Description for reviewers <!-- (optional) description for those who read this PR -->

Due to wrong cast int compare result to i8, we got a wrong events order

Also adds additional key logs, fixes typo with `GetDataSize`, adds error log in a case with bad histogram

#15720

Also includes #15353
