### PR TITLE
fq: pq connections: don't propagate UseBearerForYdb for auth { token }

### DIFF
--- a/ydb/core/fq/libs/actors/clusters_from_connections.cpp
+++ b/ydb/core/fq/libs/actors/clusters_from_connections.cpp
@@ -53,7 +53,7 @@ void FillPqClusterConfig(NYql::TPqClusterConfig& clusterConfig,
     clusterConfig.SetDatabase(ds.database());
     clusterConfig.SetDatabaseId(ds.database_id());
     clusterConfig.SetUseSsl(ds.secure());
-    clusterConfig.SetAddBearerToToken(useBearerForYdb);
+    clusterConfig.SetAddBearerToToken(useBearerForYdb && ds.auth().identity_case() != FederatedQuery::IamAuth::kToken);
     clusterConfig.SetClusterType(TPqClusterConfig::CT_DATA_STREAMS);
     clusterConfig.SetSharedReading(ds.shared_reading());
     clusterConfig.SetReadGroup(readGroup);


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

...

### Changelog category <!-- remove all except one -->

* Not for changelog (changelog entry is not required)

### Description for reviewers <!-- (optional) description for those who read this PR -->

Why not in FillClusterAuth? Because it is only used for pq (and FillClusterAuth is used for other connection types)
