### PR TITLE
Check event serializability when running under memory sanitizer

### DIFF
--- a/ydb/library/actors/core/event_pb.cpp
+++ b/ydb/library/actors/core/event_pb.cpp
@@ -75,6 +75,7 @@ namespace NActors {
         Y_ABORT_UNLESS(!CancelFlag);
         Y_ABORT_UNLESS(!AbortFlag);
         Y_ABORT_UNLESS(size >= 0);
+        NSan::CheckMemIsInitialized(data, size);
         while (size) {
             if (const size_t bytesToAppend = Min<size_t>(size, SizeRemain)) {
                 const void *produce = data;
@@ -222,11 +223,15 @@ namespace NActors {
     }
 
     bool TAllocChunkSerializer::WriteRope(const TRope *rope) {
+        for (auto iter = rope->Begin(); iter.Valid(); iter.AdvanceToNextContiguousBlock()) {
+            NSan::CheckMemIsInitialized(iter.ContiguousData(), iter.ContiguousSize());
+        }
         Buffers->Append(TRope(*rope));
         return true;
     }
 
     bool TAllocChunkSerializer::WriteString(const TString *s) {
+        NSan::CheckMemIsInitialized(s->data(), s->size());
         Buffers->Append(*s);
         return true;
     }


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

Check event serializability when running under memory sanitizer

### Changelog category <!-- remove all except one -->

* Not for changelog (changelog entry is not required)

### Description for reviewers <!-- (optional) description for those who read this PR -->

Add extra hardening checks when running under msan.
