### PR TITLE
YDB CLI: make commiting disabled by default in topic read

### DIFF
--- a/ydb/public/lib/ydb_cli/commands/ydb_service_topic.cpp
+++ b/ydb/public/lib/ydb_cli/commands/ydb_service_topic.cpp
@@ -792,7 +792,7 @@ namespace NYdb::NConsoleClient {
             .StoreResult(&IdleTimeout_);
         config.Opts->AddLongOption("commit", "Commit messages after successful read")
             .Optional()
-            .DefaultValue(true)
+            .DefaultValue(false)
             .StoreResult(&Commit_);
         config.Opts->AddLongOption("limit", "Limit on message count to read, 0 - unlimited. "
                                             "If avobe 0, processing stops when either topic is empty, or the specified limit reached. "
@@ -808,7 +808,7 @@ namespace NYdb::NConsoleClient {
             .RequiredArgument("TIMESTAMP")
             .Optional()
             .Handler1T<TString>(TimestampOptionHandler(&Timestamp_));
-        config.Opts->AddLongOption("partition-ids", "Comma separated list of partition ids to read from. If not specified, messages are read from all partitions.")
+        config.Opts->AddLongOption("partition-ids", "Comma separated list of partition ids to read from. If not specified, messages are read from all partitions. E.g. \"--partition-ids 0,1,10\"")
             .Optional()
             .SplitHandler(&PartitionIds_, ',');
 


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

From now on reading topic without a consumer will not try to commit.

### Changelog category <!-- remove all except one -->

* Not for changelog

### Description for reviewers <!-- (optional) description for those who read this PR -->

...
