### PR TITLE
HttpMonPage has been improved

### DIFF
--- a/ydb/core/tx/columnshard/columnshard_subdomain_path_id.h
+++ b/ydb/core/tx/columnshard/columnshard_subdomain_path_id.h
@@ -22,6 +22,7 @@ public:
     friend class TTxPersistSubDomainOutOfSpace;
     friend class TTxPersistSubDomainPathId;
     friend class NKikimr::NColumnShard::NLoading::TSpecialValuesInitializer;
+    friend class TTxMonitoring;
 
 public:
     TSpaceWatcher(TColumnShard* self)

--- a/ydb/core/tx/columnshard/columnshard_view.cpp
+++ b/ydb/core/tx/columnshard/columnshard_view.cpp
@@ -25,7 +25,42 @@ bool TTxMonitoring::Execute(TTransactionContext& txc, const TActorContext&) {
 }
 
 void TTxMonitoring::Complete(const TActorContext& ctx) {
-    ctx.Send(HttpInfoEvent->Sender, new NMon::TEvRemoteJsonInfoRes(JsonReport.GetStringRobust()));
+    std::map<std::pair<ui64, ui64>, NJson::TJsonValue> schemaVersions;
+    for (const auto& item: JsonReport["tables_manager"]["schema_versions"].GetArray()) {
+        auto& schemaVersion = schemaVersions[std::make_pair<ui64, ui64>(item["SinceStep"].GetInteger(), item["SinceTxId"].GetInteger())];
+        schemaVersion = item;
+    }
+    JsonReport["tables_manager"].EraseValue("schema_versions");
+    TStringStream html;
+    html << "<h3>Special Values</h3>";
+    html << "<b>CurrentSchemeShardId:</b> " << Self->CurrentSchemeShardId << "<br />";
+    html << "<b>ProcessingParams:</b> " << Self->ProcessingParams.value_or(NKikimrSubDomains::TProcessingParams{}).ShortDebugString() << "<br />";
+    html << "<b>LastPlannedStep:</b> " << Self->LastPlannedStep << "<br />";
+    html << "<b>LastPlannedTxId :</b> " << Self->LastPlannedTxId << "<br />";
+    html << "<b>LastSchemaSeqNoGeneration :</b> " << Self->LastSchemaSeqNo.Generation << "<br />";
+    html << "<b>LastSchemaSeqNoRound :</b> " << Self->LastSchemaSeqNo.Round << "<br />";
+    html << "<b>LastExportNumber :</b> " << Self->LastExportNo << "<br />";
+    html << "<b>OwnerPathId :</b> " << Self->OwnerPathId << "<br />";
+    html << "<b>Table/Store Path :</b> " << Self->OwnerPath << "<br />";
+    html << "<b>LastCompletedStep :</b> " << Self->LastCompletedTx.GetPlanStep() << "<br />";
+    html << "<b>LastCompletedTxId :</b> " << Self->LastCompletedTx.GetTxId() << "<br />";
+    html << "<b>LastNormalizerSequentialId :</b> " << Self->NormalizerController.GetLastSavedNormalizerId() << "<br />";
+    html << "<b>SubDomainLocalPathId :</b> " << Self->SpaceWatcher->SubDomainPathId.value_or(0) << "<br />";
+    html << "<b>SubDomainOutOfSpace :</b> " << Self->SpaceWatcher->SubDomainOutOfSpace << "<br />";
+    html << "<h3>Tables Manager</h3>";
+    html << "<h4>Status</h4>";
+    html << "<pre>" << JsonReport << "</pre><br />";
+    html << "<h4>Top 10 Versions</h4>";
+    int counter = 0;
+    for (const auto& [_, schemaVersion]: schemaVersions) {
+        html << counter;
+        html << "<pre>" << schemaVersion << "</pre><br />";
+
+        if (++counter == 10) {
+            break;
+        }
+    }
+    ctx.Send(HttpInfoEvent->Sender, new NMon::TEvRemoteHttpInfoRes(html.Str()));
 }
 
 bool TColumnShard::OnRenderAppHtmlPage(NMon::TEvRemoteHttpInfo::TPtr ev, const TActorContext& ctx) {

--- a/ydb/core/tx/columnshard/columnshard_view.cpp
+++ b/ydb/core/tx/columnshard/columnshard_view.cpp
@@ -32,7 +32,7 @@ void TTxMonitoring::Complete(const TActorContext& ctx) {
         schemaVersion = item;
     }
     size_t countVersions = std::min(10ul, schemaVersions.size());
-    if (const auto& countVersionsParam = cgi.Get("countVersions")) {
+    if (const auto& countVersionsParam = cgi.Get("CountVersions")) {
         try {
             countVersions = std::min(std::stoul(countVersionsParam), schemaVersions.size());
         } catch (...) {


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

Проблема в том что когда пытаются найти по tablet id путь к таблице или store, то кликают на таблетку, а затем в app для того чтобы получить информацию. В datashard сейчас отображается путь к таблетке, а в column shard было мало полезной информации. Сейчас это выглядит таким образом:

<img width="1211" alt="Screenshot 2025-03-18 at 18 47 01" src="https://github.com/user-attachments/assets/1064d6e1-d06d-4dc5-a404-f72609f1c99d" />


### Changelog category <!-- remove all except one -->

* Not for changelog (changelog entry is not required)

### Description for reviewers <!-- (optional) description for those who read this PR -->

...
