### PR TITLE
25-1-1: views: enable by default

### DIFF
--- a/ydb/core/protos/feature_flags.proto
+++ b/ydb/core/protos/feature_flags.proto
@@ -134,7 +134,7 @@ message TFeatureFlags {
     optional bool EnableLocalDBBtreeIndex = 109 [default = false];
     optional bool EnablePDiskHighHDDInFlight = 110 [default = false];
     reserved 111; // UseVDisksBalancing
-    optional bool EnableViews = 112 [default = false];
+    optional bool EnableViews = 112 [default = true];
     optional bool EnableServerlessExclusiveDynamicNodes = 113 [default = false];
     optional bool EnableAccessServiceBulkAuthorization = 114 [default = false];
     optional bool EnableAddColumsWithDefaults = 115 [ default = false];


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

### Changelog category <!-- remove all except one -->

* Not for changelog

### Description for reviewers <!-- (optional) description for those who read this PR -->

Backports:
- https://github.com/ydb-platform/ydb/pull/14892

Enable creating, dropping and selecting from the views by default (i.e. switch the feature flag default state).

### Backport justification

The feature flag was already turned on and approved for [stable-24-4](https://github.com/ydb-platform/ydb/pull/14402/commits/8b872410cf7d56f96ed1a96eda9205178a2bbee6).
