### PR TITLE
provide database in schemecache request

### DIFF
--- a/ydb/core/client/server/msgbus_server_pq_metacache.cpp
+++ b/ydb/core/client/server/msgbus_server_pq_metacache.cpp
@@ -516,7 +516,11 @@ private:
         auto inserted = DescribeTopicsWaiters.insert(std::make_pair(reqId, waiter)).second;
         Y_ABORT_UNLESS(inserted);
 
+        TMaybe<TString> db = {};
+
         for (const auto& [path, database] : waiter->GetTopics()) {
+            if (!db) db = database;
+            if (*db != database) db = "";
             auto split = NKikimr::SplitPath(path);
             TSchemeCacheNavigate::TEntry entry;
             if (!split.empty()) {
@@ -529,8 +533,9 @@ private:
 
             schemeCacheRequest->ResultSet.emplace_back(std::move(entry));
         }
-
-        LOG_DEBUG_S(ctx, NKikimrServices::PQ_METACACHE, "send request for " << (waiter->Type == EWaiterType::DescribeAllTopics ? " all " : "") << waiter->GetTopics().size() << " topics, got " << DescribeTopicsWaiters.size() << " requests infly");
+        if (db) schemeCacheRequest->DatabaseName = *db;
+        LOG_DEBUG_S(ctx, NKikimrServices::PQ_METACACHE, "send request for " << (waiter->Type == EWaiterType::DescribeAllTopics ? " all " : "")
+                             << waiter->GetTopics().size() << " topics, got " << DescribeTopicsWaiters.size() << " requests infly, db = \"" << db << "\"");
 
         ctx.Send(SchemeCacheId, new TEvTxProxySchemeCache::TEvNavigateKeySet(schemeCacheRequest.release()));
     }

--- a/ydb/core/http_proxy/http_req.cpp
+++ b/ydb/core/http_proxy/http_req.cpp
@@ -1456,6 +1456,7 @@ namespace NKikimr::NHttpProxy {
             entry.Operation = NSchemeCache::TSchemeCacheNavigate::OpPath;
             entry.SyncVersion = false;
             schemeCacheRequest->ResultSet.emplace_back(entry);
+            schemeCacheRequest->DatabaseName = CanonizePath(DatabasePath);
             ctx.Send(MakeSchemeCacheID(), MakeHolder<TEvTxProxySchemeCache::TEvNavigateKeySet>(schemeCacheRequest.release()));
         }
 

--- a/ydb/core/kafka_proxy/actors/kafka_produce_actor.cpp
+++ b/ydb/core/kafka_proxy/actors/kafka_produce_actor.cpp
@@ -558,6 +558,8 @@ void TKafkaProduceActor::ProcessInitializationRequests(const TActorContext& ctx)
         request->ResultSet.emplace_back(entry);
     }
 
+    request->DatabaseName = CanonizePath(Context->DatabasePath);
+
     ctx.Send(MakeSchemeCacheID(), MakeHolder<TEvTxProxySchemeCache::TEvNavigateKeySet>(request.release()));
 }
 

--- a/ydb/services/datastreams/put_records_actor.h
+++ b/ydb/services/datastreams/put_records_actor.h
@@ -312,6 +312,7 @@ namespace NKikimr::NDataStreams::V1 {
         entry.Path = NKikimr::SplitPath(this->GetTopicPath());
         entry.Operation = NSchemeCache::TSchemeCacheNavigate::OpList;
         entry.SyncVersion = true;
+        schemeCacheRequest->DatabaseName = CanonizePath(this->Request_->GetDatabaseName().GetOrElse(""));
         schemeCacheRequest->ResultSet.emplace_back(entry);
         ctx.Send(MakeSchemeCacheID(), MakeHolder<TEvTxProxySchemeCache::TEvNavigateKeySet>(schemeCacheRequest.release()));
     }

--- a/ydb/services/persqueue_v1/actors/read_init_auth_actor.cpp
+++ b/ydb/services/persqueue_v1/actors/read_init_auth_actor.cpp
@@ -84,6 +84,7 @@ void TReadInitAndAuthActor::SendCacheNavigateRequest(const TActorContext& ctx, c
     entry.SyncVersion = true;
     entry.Operation = NSchemeCache::TSchemeCacheNavigate::OpPath;
     schemeCacheRequest->ResultSet.emplace_back(entry);
+    schemeCacheRequest->DatabaseName = AppData(ctx)->PQConfig.GetDatabase();
     LOG_DEBUG_S(ctx, NKikimrServices::PQ_READ_PROXY, PQ_LOG_PREFIX << " Send client acl request");
     ctx.Send(NewSchemeCache, new TEvTxProxySchemeCache::TEvNavigateKeySet(schemeCacheRequest.Release()));
 }

--- a/ydb/services/persqueue_v1/persqueue_compat_ut.cpp
+++ b/ydb/services/persqueue_v1/persqueue_compat_ut.cpp
@@ -42,10 +42,20 @@ public:
         Server->AnnoyingClient->CreateTopicNoLegacy(
                 "/Root/LbCommunal/account/topic2", 1, true, true, {}, {}, "account"
         );
-
         Server->AnnoyingClient->CreateTopicNoLegacy(
                 "/Root/LbCommunal/account/topic2-mirrored-from-dc2", 1, true, false, {}, {}, "account"
         );
+
+        Server->AnnoyingClient->MkDir("/Root", "LbCommunal");
+        Server->AnnoyingClient->MkDir("/Root/LbCommunal", "account2");
+        Server->AnnoyingClient->CreateTopicNoLegacy(
+                "/Root/LbCommunal/account2/topic3", 1, true, true, {}, {}, "account2"
+        );
+        Server->AnnoyingClient->CreateTopicNoLegacy(
+                "/Root/LbCommunal/account2/topic3-mirrored-from-dc2", 1, true, false, {}, {}, "account2"
+        );
+
+
         Server->AnnoyingClient->CreateConsumer("test-consumer");
         InitPQLib();
     }
@@ -153,6 +163,12 @@ Y_UNIT_TEST_SUITE(TPQCompatTest) {
             GetLocks({"account/topic1", "account/topic2"}, rs);
             rs->Close();
         }
+        {
+            auto rs = testServer.CreateReadSession({"account/topic1", "account/topic2", "account2/topic3"});
+            GetLocks({"account/topic1", "account/topic2", "account2/topic3"}, rs);
+            rs->Close();
+        }
+
     }
 
     Y_UNIT_TEST(BadTopics) {


### PR DESCRIPTION
Provide database name in schemecache request.
Without database name schemecache could answer with PathUnknown instead of Unavailable in some cases.
This leads to bug, described in KIKIMR-22718.

* Bugfix