### PR TITLE
remove unneeded ANY join fallback for grace and streamlookup join

### DIFF
--- a/ydb/library/yql/dq/opt/dq_opt_join.cpp
+++ b/ydb/library/yql/dq/opt/dq_opt_join.cpp
@@ -242,11 +242,13 @@ TMaybe<TJoinInputDesc> BuildDqJoin(
         rightJoinKeyNames.emplace_back(rightColumnName);
     }
 
+    bool needAnyJoinFallback = linkSettings.JoinAlgo != EJoinAlgoType::StreamLookupJoin && (EHashJoinMode::Off == mode || EHashJoinMode::Map == mode);
+
     auto dqJoinBuilder =
         Build<TDqJoin>(ctx, joinTuple.Pos())
-            .LeftInput(BuildDqJoinInput(ctx, joinTuple.Pos(), left->Input, leftJoinKeys, leftAny))
+            .LeftInput(BuildDqJoinInput(ctx, joinTuple.Pos(), left->Input, leftJoinKeys, needAnyJoinFallback && leftAny))
             .LeftLabel(leftTableLabel)
-            .RightInput(BuildDqJoinInput(ctx, joinTuple.Pos(), right->Input, rightJoinKeys, rightAny))
+            .RightInput(BuildDqJoinInput(ctx, joinTuple.Pos(), right->Input, rightJoinKeys, needAnyJoinFallback && rightAny))
             .RightLabel(rightTableLabel)
             .JoinType(joinTuple.Type())
             .JoinKeys(joinKeysBuilder.Done())


### PR DESCRIPTION
regression by 7102e38a138198556c3dec40c409a8cbaa36d857

### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

...

### Changelog category <!-- remove all except one -->

* Not for changelog (changelog entry is not required)

### Description for reviewers <!-- (optional) description for those who read this PR -->

Before refactoring in 7102e38a slj/grace join was handled [here](https://github.com/ydb-platform/ydb/pull/14901/files#diff-c0ddb0b5fb28b66410f2cd8707d176264a0454bbcddc32cd8998b306f80566d5L279) with fallback disabled (`..., false)`)

Code can be refactored/simplified, this is just minimal change to fix hard error.
