### PR TITLE
Add node interlace in TScore for group mapper (#13867)

### DIFF
--- a/ydb/core/mind/bscontroller/group_layout_checker.h
+++ b/ydb/core/mind/bscontroller/group_layout_checker.h
@@ -72,21 +72,25 @@ namespace NKikimr::NBsController {
             TEntityId RealmGroup;
             TEntityId Realm;
             TEntityId Domain;
+            TEntityId Device;
 
             TPDiskLayoutPosition() = default;
 
-            TPDiskLayoutPosition(TEntityId realmGroup, TEntityId realm, TEntityId domain)
+            TPDiskLayoutPosition(TEntityId realmGroup, TEntityId realm, TEntityId domain, TEntityId device)
                 : RealmGroup(realmGroup)
                 , Realm(realm)
                 , Domain(domain)
+                , Device(device)
             {}
 
             TPDiskLayoutPosition(TDomainMapper& mapper, const TNodeLocation& location, TPDiskId pdiskId, const TGroupGeometryInfo& geom) {
-                TStringStream realmGroup, realm, domain;
+                TStringStream realmGroup, realm, domain, device;
+                ui32 deviceLevelEnd = TNodeLocation::TKeys::E::Unit + 1;
                 const std::pair<int, TStringStream*> levels[] = {
                     {geom.GetRealmLevelBegin(), &realmGroup},
                     {Max(geom.GetRealmLevelEnd(), geom.GetDomainLevelBegin()), &realm},
-                    {Max(geom.GetRealmLevelEnd(), geom.GetDomainLevelEnd()), &domain}
+                    {Max(geom.GetRealmLevelEnd(), geom.GetDomainLevelEnd()), &domain},
+                    {Max(geom.GetRealmLevelEnd(), geom.GetDomainLevelEnd(), deviceLevelEnd), &device}
                 };
                 auto addLevel = [&](int key, const TString& value) {
                     for (const auto& [reference, stream] : levels) {
@@ -102,14 +106,15 @@ namespace NKikimr::NBsController {
                 RealmGroup = mapper(realmGroup.Str());
                 Realm = mapper(realm.Str());
                 Domain = mapper(domain.Str());
+                Device = mapper(device.Str());
             }
 
             TString ToString() const {
-                return TStringBuilder() << "{" << RealmGroup << "." << Realm << "." << Domain << "}";
+                return TStringBuilder() << "{" << RealmGroup << "." << Realm << "." << Domain << "." << Device << "}";
             }
 
             auto AsTuple() const {
-                return std::tie(RealmGroup, Realm, Domain);
+                return std::tie(RealmGroup, Realm, Domain, Device);
             }
 
             friend bool operator ==(const TPDiskLayoutPosition& x, const TPDiskLayoutPosition& y) {
@@ -124,12 +129,13 @@ namespace NKikimr::NBsController {
         struct TScore {
             ui32 RealmInterlace = 0;
             ui32 DomainInterlace = 0;
+            ui32 DeviceInterlace = 0;
             ui32 RealmGroupScatter = 0;
             ui32 RealmScatter = 0;
             ui32 DomainScatter = 0;
 
             auto AsTuple() const {
-                return std::make_tuple(RealmInterlace, DomainInterlace, RealmGroupScatter, RealmScatter, DomainScatter);
+                return std::make_tuple(RealmInterlace, DomainInterlace, DeviceInterlace, RealmGroupScatter, RealmScatter, DomainScatter);
             }
 
             bool BetterThan(const TScore& other) const {
@@ -141,12 +147,13 @@ namespace NKikimr::NBsController {
             }
 
             static TScore Max() {
-                return {::Max<ui32>(), ::Max<ui32>(), ::Max<ui32>(), ::Max<ui32>(), ::Max<ui32>()};
+                return {::Max<ui32>(), ::Max<ui32>(), ::Max<ui32>(), ::Max<ui32>(), ::Max<ui32>(), ::Max<ui32>()};
             }
 
             TString ToString() const {
                 return TStringBuilder() << "{RealmInterlace# " << RealmInterlace
                     << " DomainInterlace# " << DomainInterlace
+                    << " DeviceInterlace# " << DeviceInterlace
                     << " RealmGroupScatter# " << RealmGroupScatter
                     << " RealmScatter# " << RealmScatter
                     << " DomainScatter# " << DomainScatter
@@ -168,6 +175,8 @@ namespace NKikimr::NBsController {
             TStackVec<THashMap<TEntityId, ui32>, 32> NumDisksPerDomain;
             THashMap<TEntityId, ui32> NumDisksPerDomainTotal;
 
+            THashMap<TEntityId, ui32> NumDisksPerDevice;
+
             TGroupLayout(const TBlobStorageGroupInfo::TTopology& topology)
                 : Topology(topology)
                 , NumDisksInRealm(Topology.GetTotalFailRealmsNum())
@@ -187,6 +196,8 @@ namespace NKikimr::NBsController {
                 NumDisksInDomain[domainIdx] += value;
                 NumDisksPerDomain[domainIdx][pos.Domain] += value;
                 NumDisksPerDomainTotal[pos.Domain] += value;
+
+                NumDisksPerDevice[pos.Device] += value;
             }
 
             void AddDisk(const TPDiskLayoutPosition& pos, ui32 orderNumber) {
@@ -201,12 +212,18 @@ namespace NKikimr::NBsController {
                 const TVDiskIdShort vdisk = Topology.GetVDiskId(orderNumber);
                 const ui32 domainIdx = Topology.GetFailDomainOrderNumber(vdisk);
 
+                const auto& disksPerRealm = NumDisksPerRealm[vdisk.FailRealm][pos.Realm];
+                const auto& disksPerDomain = NumDisksPerDomain[domainIdx][pos.Domain];
+
+                const ui32 disksOnDevice = NumDisksPerDevice[pos.Device];
+
                 return {
-                    .RealmInterlace = NumDisksPerRealmTotal[pos.Realm] - NumDisksPerRealm[vdisk.FailRealm][pos.Realm],
-                    .DomainInterlace = NumDisksPerDomainTotal[pos.Domain] - NumDisksPerDomain[domainIdx][pos.Domain],
+                    .RealmInterlace = NumDisksPerRealmTotal[pos.Realm] - disksPerRealm,
+                    .DomainInterlace = NumDisksPerDomainTotal[pos.Domain] - disksPerDomain,
+                    .DeviceInterlace = disksOnDevice,
                     .RealmGroupScatter = NumDisks - NumDisksPerRealmGroup[pos.RealmGroup],
-                    .RealmScatter = NumDisksInRealm[vdisk.FailRealm] - NumDisksPerRealm[vdisk.FailRealm][pos.Realm],
-                    .DomainScatter = NumDisksInDomain[domainIdx] - NumDisksPerDomain[domainIdx][pos.Domain],
+                    .RealmScatter = NumDisksInRealm[vdisk.FailRealm] - disksPerRealm,
+                    .DomainScatter = NumDisksInDomain[domainIdx] - disksPerDomain,
                 };
             }
 

--- a/ydb/core/mind/bscontroller/group_mapper.cpp
+++ b/ydb/core/mind/bscontroller/group_mapper.cpp
@@ -390,7 +390,7 @@ namespace NKikimr::NBsController {
 
                 static std::pair<TPDiskLayoutPosition, TPDiskLayoutPosition> MakeRange(const TPDiskLayoutPosition& x, TEntityId& scope) {
                     scope = x.Domain;
-                    return {x, x};
+                    return {{x.RealmGroup, x.Realm, x.Domain, TEntityId::Min()}, {x.RealmGroup, x.Realm, x.Domain, TEntityId::Max()}};
                 }
             };
 
@@ -400,7 +400,7 @@ namespace NKikimr::NBsController {
 
                 static std::pair<TPDiskLayoutPosition, TPDiskLayoutPosition> MakeRange(const TPDiskLayoutPosition& x, TEntityId& scope) {
                     scope = x.Realm;
-                    return {{x.RealmGroup, x.Realm, TEntityId::Min()}, {x.RealmGroup, x.Realm, TEntityId::Max()}};
+                    return {{x.RealmGroup, x.Realm, TEntityId::Min(), TEntityId::Min()}, {x.RealmGroup, x.Realm, TEntityId::Max(), TEntityId::Max()}};
                 }
             };
 
@@ -410,7 +410,7 @@ namespace NKikimr::NBsController {
 
                 static std::pair<TPDiskLayoutPosition, TPDiskLayoutPosition> MakeRange(const TPDiskLayoutPosition& x, TEntityId& scope) {
                     scope = x.RealmGroup;
-                    return {{x.RealmGroup, TEntityId::Min(), TEntityId::Min()}, {x.RealmGroup, TEntityId::Max(), TEntityId::Max()}};
+                    return {{x.RealmGroup, TEntityId::Min(), TEntityId::Min(), TEntityId::Min()}, {x.RealmGroup, TEntityId::Max(), TEntityId::Max(), TEntityId::Max()}};
                 }
             };
 

--- a/ydb/core/mind/bscontroller/group_mapper_ut.cpp
+++ b/ydb/core/mind/bscontroller/group_mapper_ut.cpp
@@ -683,32 +683,6 @@ Y_UNIT_TEST_SUITE(TGroupMapperTest) {
         UNIT_ASSERT_EQUAL_C(TPDiskId(9, 1), newGroup[0][7][0], context.FormatGroup(newGroup));
     }
 
-    Y_UNIT_TEST(NonUniformClusterDifferentSlotsPerDisk) {
-        std::vector<std::tuple<ui32, ui32, ui32, ui32, ui32>> disks;
-        for (ui32 rack = 0; rack < 12; ++rack) {
-            disks.emplace_back(1, 1, rack, 1, 1);
-        }
-        std::random_shuffle(disks.begin(), disks.end());
-        TTestContext context(disks);
-        UNIT_ASSERT_VALUES_EQUAL((8 + 4), context.GetTotalDisks());
-        TGroupMapper mapper(TTestContext::CreateGroupGeometry(TBlobStorageGroupType::Erasure4Plus2Block));
-        context.PopulateGroupMapper(mapper, 8, {}, {}, std::nullopt, false);
-        for (ui32 i = 0; i < 16; ++i) {
-            Ctest << i << "/" << 16 << Endl;
-            TGroupMapper::TGroupDefinition group;
-            context.AllocateGroup(mapper, group);
-            context.CheckGroupErasure(group);
-        }
-        TVector<ui32> slots = context.GetSlots();
-        ui64 slots_total = 0;
-        for (ui32 numSlots : slots) {
-            slots_total += numSlots;
-            Ctest << "slots " << numSlots << " ";
-        }
-        Ctest << slots_total << Endl;
-        UNIT_ASSERT_VALUES_EQUAL(slots_total, 8 * 8 + 4 * 16);
-    }
-
     Y_UNIT_TEST(NonUniformCluster2) {
         std::vector<std::tuple<ui32, ui32, ui32, ui32, ui32>> disks;
         for (ui32 rack = 0, body = 0; rack < 12; ++rack) {

--- a/ydb/core/mind/bscontroller/group_mapper_ut.cpp
+++ b/ydb/core/mind/bscontroller/group_mapper_ut.cpp
@@ -592,10 +592,6 @@ Y_UNIT_TEST_SUITE(TGroupMapperTest) {
         TestBlock42(1);
     }
 
-    Y_UNIT_TEST(Block42_2disk) {
-        TestBlock42(2);
-    }
-
     Y_UNIT_TEST(Mirror3dc) {
         TTestContext context(6, 3, 3, 3, 3);
         TGroupMapper mapper(TTestContext::CreateGroupGeometry(TBlobStorageGroupType::ErasureMirror3dc));
@@ -611,6 +607,23 @@ Y_UNIT_TEST_SUITE(TGroupMapperTest) {
             UNIT_ASSERT_VALUES_EQUAL(9, numSlots);
         }
         context.CheckIfGroupsAreMappedCompact();
+    }
+
+    Y_UNIT_TEST(Mirror3dc3Nodes) {
+        // Each node has 3 disks.
+        TTestContext context(
+            {
+                {1, 1, 1, 1, 3},
+                {2, 1, 2, 1, 3},
+                {3, 1, 3, 1, 3},
+            }
+        );
+
+        TGroupMapper mapper(TTestContext::CreateGroupGeometry(TBlobStorageGroupType::ErasureMirror3dc, 3, 3, 1, 10, 20, 10, 256));
+        context.PopulateGroupMapper(mapper, 9);
+
+        TGroupMapper::TGroupDefinition group;
+        UNIT_ASSERT_UNEQUAL(0, context.AllocateGroup(mapper, group));
     }
 
     Y_UNIT_TEST(NonUniformCluster) {
@@ -635,6 +648,65 @@ Y_UNIT_TEST_SUITE(TGroupMapperTest) {
         for (ui32 numSlots : slots) {
             UNIT_ASSERT_VALUES_EQUAL(8, numSlots);
         }
+    }
+
+    Y_UNIT_TEST(InterlacedRacksWithoutInterlacedNodes) {
+        TTestContext context(
+            {
+                {1, 1, 1, 1, 1}, // node 1
+                {1, 1, 2, 2, 1},
+                {1, 1, 3, 3, 2}, // node 3 has two disks
+                {1, 1, 4, 4, 1},
+                {1, 1, 5, 5, 1},
+                {1, 1, 6, 6, 1},
+                {1, 1, 2, 7, 1}, // node 7 is in the same rack as node 2
+                {1, 1, 8, 8, 1},
+                {1, 1, 3, 9, 1}, // node 9 is in the same rack as node 3
+            }
+        );
+
+        TGroupMapper mapper(TTestContext::CreateGroupGeometry(TBlobStorageGroupType::Erasure4Plus2Block));
+        context.PopulateGroupMapper(mapper, 8);
+
+        TGroupMapper::TGroupDefinition group;
+        group.emplace_back(TVector<TVector<TPDiskId>>(8));
+        auto& g = group[0];
+
+        for (int i = 0; i < 8; i++) {
+            g[i].emplace_back(TPDiskId(i + 1, 1));
+        }
+
+        context.SetGroup(1, group);
+
+        TGroupMapper::TGroupDefinition newGroup = context.ReallocateGroup(mapper, 1, {TPDiskId(8, 1)});
+
+        UNIT_ASSERT_EQUAL_C(TPDiskId(9, 1), newGroup[0][7][0], context.FormatGroup(newGroup));
+    }
+
+    Y_UNIT_TEST(NonUniformClusterDifferentSlotsPerDisk) {
+        std::vector<std::tuple<ui32, ui32, ui32, ui32, ui32>> disks;
+        for (ui32 rack = 0; rack < 12; ++rack) {
+            disks.emplace_back(1, 1, rack, 1, 1);
+        }
+        std::random_shuffle(disks.begin(), disks.end());
+        TTestContext context(disks);
+        UNIT_ASSERT_VALUES_EQUAL((8 + 4), context.GetTotalDisks());
+        TGroupMapper mapper(TTestContext::CreateGroupGeometry(TBlobStorageGroupType::Erasure4Plus2Block));
+        context.PopulateGroupMapper(mapper, 8, {}, {}, std::nullopt, false);
+        for (ui32 i = 0; i < 16; ++i) {
+            Ctest << i << "/" << 16 << Endl;
+            TGroupMapper::TGroupDefinition group;
+            context.AllocateGroup(mapper, group);
+            context.CheckGroupErasure(group);
+        }
+        TVector<ui32> slots = context.GetSlots();
+        ui64 slots_total = 0;
+        for (ui32 numSlots : slots) {
+            slots_total += numSlots;
+            Ctest << "slots " << numSlots << " ";
+        }
+        Ctest << slots_total << Endl;
+        UNIT_ASSERT_VALUES_EQUAL(slots_total, 8 * 8 + 4 * 16);
     }
 
     Y_UNIT_TEST(NonUniformCluster2) {


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of changes introduced in this PR -->

Use -FreeSlots() as PickerScore in BSC to properly populate disks of unequal size

### Changelog category <!-- remove all except one -->

* Improvement

### Additional information

...
