### PR TITLE
Restored test checking quota exhaustion

### DIFF
--- a/.github/config/muted_ya.txt
+++ b/.github/config/muted_ya.txt
@@ -237,7 +237,6 @@ ydb/tests/functional/tpc/large test_tpcds.py.TestTpcdsS1.test_tpcds[86]
 ydb/tests/functional/tpc/large test_tpcds.py.TestTpcdsS1.test_tpcds[9]
 ydb/tests/functional/tpc/large test_tpch_spilling.py.TestTpchSpillingS10.test_tpch[7]
 ydb/tests/olap sole chunk chunk
-ydb/tests/olap test_quota_exhaustion.py.TestYdbWorkload.test_delete
 ydb/tests/olap/column_family/compression alter_compression.py.TestAlterCompression.test_all_supported_compression
 ydb/tests/olap/column_family/compression alter_compression.py.TestAlterCompression.test_availability_data
 ydb/tests/olap/column_family/compression sole chunk chunk

--- a/ydb/tests/olap/test_quota_exhaustion.py
+++ b/ydb/tests/olap/test_quota_exhaustion.py
@@ -65,6 +65,7 @@ class TestYdbWorkload(object):
     @link_test_case("#13529")
     def test(self):
         """As per https://github.com/ydb-platform/ydb/issues/13529"""
+        self.database_name = '/Root'
         session = self.make_session()
 
         # Overflow the database

--- a/ydb/tests/olap/test_quota_exhaustion.py
+++ b/ydb/tests/olap/test_quota_exhaustion.py
@@ -142,7 +142,7 @@ class TestYdbWorkload(object):
         self.cluster.register_and_start_slots(self.database_name, count=1)
         self.cluster.wait_tenant_up(self.database_name)
 
-        # Set soft and hard quotas to 6GB
+        # Set soft and hard quotas to 40 Mb
         self.alter_database_quotas(self.cluster.nodes[1], self.database_name, """
             data_size_hard_quota: 40000000
             data_size_soft_quota: 40000000
@@ -157,10 +157,11 @@ class TestYdbWorkload(object):
 
         # Check that deletion works at least first time
         self.delete_test_chunk(session, table_path, 0)
-        # ^ uncomment after fixing https://github.com/ydb-platform/ydb/issues/13808
 
         # Check that deletions will lead to overflow at some moment
         i = self.delete_until_overload(session, table_path)
 
         # Check that all DELETE statements are completed
         assert i == ROWS_CHUNKS_COUNT
+
+        # Writes enabling after data deletion will be checked in separate PR


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

This test checks that writing are disable after exceeding quota and deletions are always enabled

### Changelog category <!-- remove all except one -->

* New feature

### Description for reviewers <!-- (optional) description for those who read this PR -->

...
