### PR TITLE
Add sys viewe test when account automaticaly unlock

### DIFF
--- a/ydb/core/sys_view/ut_common.cpp
+++ b/ydb/core/sys_view/ut_common.cpp
@@ -32,7 +32,7 @@ TTestEnv::TTestEnv(ui32 staticNodes, ui32 dynamicNodes, const TTestEnvSettings& 
 
     TVector<NKikimrKqp::TKqpSetting> kqpSettings;
 
-    NKikimrProto::TAuthConfig authConfig;
+    NKikimrProto::TAuthConfig authConfig = settings.AuthConfig;
     authConfig.SetUseBuiltinDomain(true);
     Settings = new Tests::TServerSettings(mbusPort, authConfig);
     Settings->SetDomainName("Root");

--- a/ydb/core/sys_view/ut_common.h
+++ b/ydb/core/sys_view/ut_common.h
@@ -23,6 +23,7 @@ struct TTestEnvSettings {
     bool EnableSVP = false;
     bool EnableForceFollowers = false;
     bool ShowCreateTable = false;
+    NKikimrProto::TAuthConfig AuthConfig;
 };
 
 class TTestEnv {

--- a/ydb/core/sys_view/ut_kqp.cpp
+++ b/ydb/core/sys_view/ut_kqp.cpp
@@ -3057,6 +3057,72 @@ WITH (
         }
     }
 
+    Y_UNIT_TEST(AuthUsers_LockUnlock) {
+        NKikimrProto::TAuthConfig authConfig;
+        auto accountLockout = authConfig.MutableAccountLockout();
+        accountLockout->SetAttemptResetDuration("3s");
+        TTestEnv env(1, 4, {.AuthConfig = authConfig});
+        SetupAuthEnvironment(env);
+
+        TTableClient client(env.GetDriver());
+
+        env.GetClient().CreateUser("/Root", "user1", "password1");
+        {
+            auto it = client.StreamExecuteScanQuery(R"(
+                SELECT Sid, IsEnabled, IsLockedOut, LastSuccessfulAttemptAt, LastFailedAttemptAt, FailedAttemptCount
+                FROM `Root/.sys/auth_users`
+            )").GetValueSync();
+
+            auto expected = R"([
+                [["user1"];[%true];[%false];#;#;[0u]];
+            ])";
+
+            NKqp::CompareYson(expected, NKqp::StreamResultToYson(it));
+        }
+
+
+        {
+            auto loginResult = env.GetClient().Login(*(env.GetServer().GetRuntime()), "user1", "password1");
+            UNIT_ASSERT_EQUAL(loginResult.GetError(), "");
+        }
+
+        {
+            for (size_t i = 0; i < 4; i++) {
+                auto loginResult = env.GetClient().Login(*(env.GetServer().GetRuntime()), "user1", "wrongPassword");
+                UNIT_ASSERT_EQUAL(loginResult.GetError(), "Invalid password");
+            }
+        }
+
+        {
+            auto it = client.StreamExecuteScanQuery(R"(
+                SELECT Sid, IsEnabled, IsLockedOut, FailedAttemptCount
+                FROM `Root/.sys/auth_users`
+            )").GetValueSync();
+
+            auto expected = R"([
+                [["user1"];[%true];[%true];[4u]];
+            ])";
+
+            NKqp::CompareYson(expected, NKqp::StreamResultToYson(it));
+        }
+
+        Sleep(TDuration::Seconds(5));
+
+        // Unlock after 5 seconds
+        {
+            auto it = client.StreamExecuteScanQuery(R"(
+                SELECT Sid, IsEnabled, IsLockedOut, FailedAttemptCount
+                FROM `Root/.sys/auth_users`
+            )").GetValueSync();
+
+            auto expected = R"([
+                [["user1"];[%true];[%false];[4u]];
+            ])";
+
+            NKqp::CompareYson(expected, NKqp::StreamResultToYson(it));
+        }
+    }
+
     Y_UNIT_TEST(AuthUsers_Access) {
         TTestEnv env;
         SetupAuthAccessEnvironment(env);


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

### Changelog category <!-- remove all except one -->

* Not for changelog (changelog entry is not required)

### Description for reviewers <!-- (optional) description for those who read this PR -->

Add test for check situation when account unlock and flag IsLockOut is false but AttemptsCount is not reset
