### PR TITLE
Add configurable inflight limit for ReadRows gRPC call

### DIFF
--- a/ydb/core/driver_lib/run/run.cpp
+++ b/ydb/core/driver_lib/run/run.cpp
@@ -729,8 +729,8 @@ void TKikimrRunner::InitializeGRpc(const TKikimrRunConfig& runConfig) {
         }
 
         if (hasTableService) {
-            server.AddService(new NGRpcService::TGRpcYdbTableService(ActorSystem.Get(), Counters, grpcRequestProxies,
-                hasTableService.IsRlAllowed(), grpcConfig.GetHandlersPerCompletionQueue()));
+            server.AddService(new NGRpcService::TGRpcYdbTableService(ActorSystem.Get(), Counters, AppData->InFlightLimiterRegistry,
+                grpcRequestProxies, hasTableService.IsRlAllowed(), grpcConfig.GetHandlersPerCompletionQueue()));
         }
 
         if (hasClickhouseInternal) {

--- a/ydb/core/grpc_services/grpc_helper.cpp
+++ b/ydb/core/grpc_services/grpc_helper.cpp
@@ -6,7 +6,7 @@ namespace NGRpcService {
 //using namespace NActors;
 
 NYdbGrpc::IGRpcRequestLimiterPtr TCreateLimiterCB::operator()(const char* serviceName, const char* requestName, i64 limit) const {
-    TString fullName = TString(serviceName) + "_" + requestName;
+    TString fullName = "GRpcControls.RequestConfigs." + TString(serviceName) + "_" + requestName;
     return LimiterRegistry->RegisterRequestType(fullName, limit);
 }
 
@@ -34,7 +34,7 @@ NYdbGrpc::IGRpcRequestLimiterPtr TInFlightLimiterRegistry::RegisterRequestType(T
     TGuard<TMutex> g(Lock);
     if (!PerTypeLimiters.count(name)) {
         TControlWrapper control(limit, 0, 1000000);
-        Icb->RegisterSharedControl(control, name + "_MaxInFlight");
+        Icb->RegisterSharedControl(control, name + ".MaxInFlight");
         PerTypeLimiters[name] = new TRequestInFlightLimiter(control);
     }
 

--- a/ydb/core/protos/config.proto
+++ b/ydb/core/protos/config.proto
@@ -1427,7 +1427,20 @@ message TImmediateControlsConfig {
             DefaultValue: 0 }];
     }
 
-    optional TDataShardControls DataShardControls = 1;
+    message TGRpcControls {
+        message TRequestConfig {
+            optional uint64 MaxInFlight = 1 [(ControlOptions) = {
+                Description: "Max in flight requests",
+                MinValue: 0,
+                MaxValue: 1000000,
+                DefaultValue: 0
+            }];
+        }
+        map<string, TRequestConfig> RequestConfigs = 1;
+    }
+
+
+  optional TDataShardControls DataShardControls = 1;
     optional TTxLimitControls TxLimitControls = 2;
     optional TCoordinatorControls CoordinatorControls = 3;
     optional TSchemeShardControls SchemeShardControls = 4;
@@ -1437,6 +1450,7 @@ message TImmediateControlsConfig {
     optional TTabletControls TabletControls = 8;
     optional TDSProxyControls DSProxyControls = 9;
     optional TBlobStorageControllerControls BlobStorageControllerControls = 11;
+    optional TGRpcControls GRpcControls = 14;
 };
 
 message TMeteringConfig {

--- a/ydb/core/testlib/test_client.cpp
+++ b/ydb/core/testlib/test_client.cpp
@@ -374,7 +374,7 @@ namespace Tests {
         GRpcServer->AddService(new NGRpcService::TGRpcYdbExportService(system, counters, grpcRequestProxies[0], true));
         GRpcServer->AddService(new NGRpcService::TGRpcYdbImportService(system, counters, grpcRequestProxies[0], true));
         GRpcServer->AddService(new NGRpcService::TGRpcYdbSchemeService(system, counters, grpcRequestProxies[0], true));
-        GRpcServer->AddService(new NGRpcService::TGRpcYdbTableService(system, counters, grpcRequestProxies, true, 1));
+        GRpcServer->AddService(new NGRpcService::TGRpcYdbTableService(system, counters, appData.InFlightLimiterRegistry, grpcRequestProxies, true, 1));
         GRpcServer->AddService(new NGRpcService::TGRpcYdbScriptingService(system, counters, grpcRequestProxies[0], true));
         GRpcServer->AddService(new NGRpcService::TGRpcOperationService(system, counters, grpcRequestProxies[0], true));
         GRpcServer->AddService(new NGRpcService::V1::TGRpcPersQueueService(system, counters, NMsgBusProxy::CreatePersQueueMetaCacheV2Id(), grpcRequestProxies[0], true));

--- a/ydb/library/grpc/server/grpc_request.h
+++ b/ydb/library/grpc/server/grpc_request.h
@@ -605,8 +605,9 @@ public:
                  typename TBase::TStreamRequestCallback requestCallback,
                  const char* name,
                  TLoggerPtr logger,
-                 ICounterBlockPtr counters)
-        : TBase{server, service, cq, std::move(cb), std::move(requestCallback), name, std::move(logger), std::move(counters), nullptr}
+                 ICounterBlockPtr counters,
+                 IGRpcRequestLimiterPtr limiter = nullptr)
+        : TBase{server, service, cq, std::move(cb), std::move(requestCallback), name, std::move(logger), std::move(counters), std::move(limiter)}
     {
     }
 };

--- a/ydb/services/ydb/ydb_table.cpp
+++ b/ydb/services/ydb/ydb_table.cpp
@@ -9,26 +9,31 @@ namespace NGRpcService {
 
 TGRpcYdbTableService::TGRpcYdbTableService(NActors::TActorSystem *system,
                                            TIntrusivePtr<::NMonitoring::TDynamicCounters> counters,
+                                            TIntrusivePtr<TInFlightLimiterRegistry> inFlightLimiterRegistry,
                                            const NActors::TActorId& proxyId,
                                            bool rlAllowed,
                                            size_t handlersPerCompletionQueue)
     : TGrpcServiceBase(system, counters, proxyId, rlAllowed)
     , HandlersPerCompletionQueue(Max(size_t{1}, handlersPerCompletionQueue))
+    , LimiterRegistry_(inFlightLimiterRegistry)
 {
 }
 
 TGRpcYdbTableService::TGRpcYdbTableService(NActors::TActorSystem *system,
                                            TIntrusivePtr<::NMonitoring::TDynamicCounters> counters,
+                                            TIntrusivePtr<TInFlightLimiterRegistry> inFlightLimiterRegistry,
                                            const TVector<NActors::TActorId>& proxies,
                                            bool rlAllowed,
                                            size_t handlersPerCompletionQueue)
     : TGrpcServiceBase(system, counters, proxies, rlAllowed)
     , HandlersPerCompletionQueue(Max(size_t{1}, handlersPerCompletionQueue))
+    , LimiterRegistry_(inFlightLimiterRegistry)
 {
 }
 
 void TGRpcYdbTableService::SetupIncomingRequests(NYdbGrpc::TLoggerPtr logger) {
     auto getCounterBlock = CreateCounterCb(Counters_, ActorSystem_);
+    auto getLimiter = CreateLimiterCb(LimiterRegistry_);
 
     size_t proxyCounter = 0;
 
@@ -60,23 +65,24 @@ void TGRpcYdbTableService::SetupIncomingRequests(NYdbGrpc::TLoggerPtr logger) {
         }                                                                                                             \
     }
 
-#define ADD_STREAM_REQUEST_LIMIT(NAME, IN, OUT, CB, LIMIT_TYPE, REQUEST_TYPE) \
-    for (size_t i = 0; i < HandlersPerCompletionQueue; ++i) {                                                         \
-        for (auto* cq: CQS) {                                                                                         \
-            MakeIntrusive<TGRpcRequest<Ydb::Table::IN, Ydb::Table::OUT, TGRpcYdbTableService>>                        \
-                (this, &Service_, cq,                                                                                 \
-                    [this, proxyCounter](NYdbGrpc::IRequestContextBase *ctx) {                                        \
-                        NGRpcService::ReportGrpcReqToMon(*ActorSystem_, ctx->GetPeer());                              \
-                        ActorSystem_->Send(GRpcProxies_[proxyCounter % GRpcProxies_.size()],                          \
-                            new TGrpcRequestNoOperationCall<Ydb::Table::IN, Ydb::Table::OUT>                          \
-                                (ctx, &CB, TRequestAuxSettings {                                                      \
-                                    .RlMode = RLSWITCH(TRateLimiterMode::LIMIT_TYPE),                                 \
-                                    .RequestType = NJaegerTracing::ERequestType::TABLE_##REQUEST_TYPE,                \
-                                }));                                                                                  \
-                    }, &Ydb::Table::V1::TableService::AsyncService::Request ## NAME,                                  \
-                    #NAME, logger, getCounterBlock("table", #NAME))->Run();                                           \
-            ++proxyCounter;                                                                                           \
-        }                                                                                                             \
+#define ADD_STREAM_REQUEST_LIMIT(NAME, IN, OUT, CB, LIMIT_TYPE, REQUEST_TYPE, USE_LIMITER) \
+    for (size_t i = 0; i < HandlersPerCompletionQueue; ++i) {                                                                           \
+        for (auto* cq: CQS) {                                                                                                           \
+            MakeIntrusive<TGRpcRequest<Ydb::Table::IN, Ydb::Table::OUT, TGRpcYdbTableService>>                                          \
+                (this, &Service_, cq,                                                                                                   \
+                    [this, proxyCounter](NYdbGrpc::IRequestContextBase *ctx) {                                                          \
+                        NGRpcService::ReportGrpcReqToMon(*ActorSystem_, ctx->GetPeer());                                                \
+                        ActorSystem_->Send(GRpcProxies_[proxyCounter % GRpcProxies_.size()],                                            \
+                            new TGrpcRequestNoOperationCall<Ydb::Table::IN, Ydb::Table::OUT>                                            \
+                                (ctx, &CB, TRequestAuxSettings {                                                                        \
+                                    .RlMode = RLSWITCH(TRateLimiterMode::LIMIT_TYPE),                                                   \
+                                    .RequestType = NJaegerTracing::ERequestType::TABLE_##REQUEST_TYPE,                                  \
+                                }));                                                                                                    \
+                    }, &Ydb::Table::V1::TableService::AsyncService::Request ## NAME,                                                    \
+                    #NAME, logger, getCounterBlock("table", #NAME),                                                                     \
+                    (USE_LIMITER ? getLimiter("TableService", #NAME, UNLIMITED_INFLIGHT) : nullptr))->Run();                         \
+        ++proxyCounter;                                                                                                                 \
+    }                                                                                                                                   \
     }
 
     ADD_REQUEST_LIMIT(CreateSession, DoCreateSessionRequest, Rps, CREATESESSION)
@@ -101,9 +107,9 @@ void TGRpcYdbTableService::SetupIncomingRequests(NYdbGrpc::TLoggerPtr logger) {
     ADD_REQUEST_LIMIT(ExecuteDataQuery, DoExecuteDataQueryRequest, Ru, EXECUTEDATAQUERY, Auditable)
     ADD_REQUEST_LIMIT(BulkUpsert, DoBulkUpsertRequest, Ru, BULKUPSERT, Auditable)
 
-    ADD_STREAM_REQUEST_LIMIT(StreamExecuteScanQuery, ExecuteScanQueryRequest, ExecuteScanQueryPartialResponse, DoExecuteScanQueryRequest, RuOnProgress, STREAMEXECUTESCANQUERY)
-    ADD_STREAM_REQUEST_LIMIT(StreamReadTable, ReadTableRequest, ReadTableResponse, DoReadTableRequest, RuOnProgress, STREAMREADTABLE)
-    ADD_STREAM_REQUEST_LIMIT(ReadRows, ReadRowsRequest, ReadRowsResponse, DoReadRowsRequest, Ru, READROWS)
+    ADD_STREAM_REQUEST_LIMIT(StreamExecuteScanQuery, ExecuteScanQueryRequest, ExecuteScanQueryPartialResponse, DoExecuteScanQueryRequest, RuOnProgress, STREAMEXECUTESCANQUERY, false)
+    ADD_STREAM_REQUEST_LIMIT(StreamReadTable, ReadTableRequest, ReadTableResponse, DoReadTableRequest, RuOnProgress, STREAMREADTABLE, false)
+    ADD_STREAM_REQUEST_LIMIT(ReadRows, ReadRowsRequest, ReadRowsResponse, DoReadRowsRequest, Ru, READROWS, true)
 
 #undef ADD_REQUEST_LIMIT
 #undef ADD_STREAM_REQUEST_LIMIT

--- a/ydb/services/ydb/ydb_table.h
+++ b/ydb/services/ydb/ydb_table.h
@@ -4,6 +4,7 @@
 #include <ydb/library/grpc/server/grpc_server.h>
 #include <ydb/public/api/grpc/ydb_table_v1.grpc.pb.h>
 #include <ydb/core/grpc_services/base/base_service.h>
+#include <ydb/core/grpc_services/grpc_helper.h>
 
 namespace NKikimr {
 namespace NGRpcService {
@@ -11,12 +12,14 @@ namespace NGRpcService {
 class TGRpcYdbTableService
     : public TGrpcServiceBase<Ydb::Table::V1::TableService>
 {
+    constexpr static i64 UNLIMITED_INFLIGHT = 0;
 public:
     using TGrpcServiceBase<Ydb::Table::V1::TableService>::TGrpcServiceBase;
 
     TGRpcYdbTableService(
         NActors::TActorSystem *system,
         TIntrusivePtr<::NMonitoring::TDynamicCounters> counters,
+        TIntrusivePtr<TInFlightLimiterRegistry> inFlightLimiterRegistry,
         const NActors::TActorId& proxyId,
         bool rlAllowed,
         size_t handlersPerCompletionQueue = 1);
@@ -24,6 +27,7 @@ public:
     TGRpcYdbTableService(
         NActors::TActorSystem *system,
         TIntrusivePtr<::NMonitoring::TDynamicCounters> counters,
+        TIntrusivePtr<TInFlightLimiterRegistry> inFlightLimiterRegistry,
         const TVector<NActors::TActorId>& proxies,
         bool rlAllowed,
         size_t handlersPerCompletionQueue);
@@ -33,6 +37,7 @@ private:
 
 private:
     const size_t HandlersPerCompletionQueue;
+    TIntrusivePtr<NGRpcService::TInFlightLimiterRegistry> LimiterRegistry_;
 };
 
 } // namespace NGRpcService


### PR DESCRIPTION
The limit is required to prevent dynnodes crashes by OOM when the network capacity is not enough to transport requested data to the client via ReadRows gRPC API.

The limit is configurable, default value is 0 (unlimited) for backward compatibility.

(cherry picked from commit 773d088e61c0a875d4af74d548f2c34eade56924)