### PR TITLE
Use ExtDateType data type flag instead of BigDateType in KQP

### DIFF
--- a/ydb/core/kqp/opt/physical/predicate_collector.cpp
+++ b/ydb/core/kqp/opt/physical/predicate_collector.cpp
@@ -89,14 +89,14 @@ bool IsMemberColumn(const TExprBase& node, const TExprNode* lambdaArg) {
 bool IsGoodTypeForArithmeticPushdown(const TTypeAnnotationNode& type, bool allowOlapApply) {
     const auto fatures = NUdf::GetDataTypeInfo(RemoveOptionality(type).Cast<TDataExprType>()->GetSlot()).Features;
     return NUdf::EDataTypeFeatures::NumericType & fatures
-        || (allowOlapApply && (NUdf::EDataTypeFeatures::BigDateType & fatures) && !(NUdf::EDataTypeFeatures::TzDateType & fatures));
+        || (allowOlapApply && (NUdf::EDataTypeFeatures::ExtDateType & fatures) && !(NUdf::EDataTypeFeatures::TzDateType & fatures));
 }
 
 bool IsGoodTypeForComparsionPushdown(const TTypeAnnotationNode& type, bool allowOlapApply) {
     const auto fatures = NUdf::GetDataTypeInfo(RemoveOptionality(type).Cast<TDataExprType>()->GetSlot()).Features;
     return (NUdf::EDataTypeFeatures::CanCompare  & fatures)
         && (((NUdf::EDataTypeFeatures::NumericType | NUdf::EDataTypeFeatures::StringType) & fatures) ||
-            (allowOlapApply && (NUdf::EDataTypeFeatures::BigDateType & fatures) && !(NUdf::EDataTypeFeatures::TzDateType & fatures)));
+            (allowOlapApply && (NUdf::EDataTypeFeatures::ExtDateType & fatures) && !(NUdf::EDataTypeFeatures::TzDateType & fatures)));
 }
 
 [[maybe_unused]]


### PR DESCRIPTION
The new flag was introduced in `yql/essentials/public/udf/udf_data_type.h` in scope of 3fdf248 to respect the naming from the docs (i.e. _extended_ date types vs _big_ date types). This patch replaces `EDataTypeFeatures::BigDateType` with `EDataTypeFeatures::ExtDateType` all over the KQP sources.

### Changelog category

* Not for changelog (changelog entry is not required)
