### PR TITLE
Switch from Y_ABORT_UNLESS to Y_ENSURE in ydb/core/tablet_flat

### DIFF
--- a/ydb/core/tablet_flat/defs.h
+++ b/ydb/core/tablet_flat/defs.h
@@ -51,7 +51,7 @@ namespace NTable {
          */
         ui64 ToCounter() const {
             const auto value = Value;
-            Y_ABORT_UNLESS(value >= 0);
+            Y_ENSURE(value >= 0);
             return value;
         }
 

--- a/ydb/core/tablet_flat/flat_abi_check.h
+++ b/ydb/core/tablet_flat/flat_abi_check.h
@@ -12,10 +12,11 @@ namespace NTable {
         void Check(ui32 tail, ui32 head, const char *label) const
         {
             if (tail > head) {
-                Y_Fail(label << " ABI [" << tail << ", " << head << "]"
-                        << " label is invalid");
+                Y_TABLET_ERROR(
+                    label << " ABI [" << tail << ", " << head << "]"
+                    << " label is invalid");
             } else if (head < ui32(EVol::Tail) || tail > ui32(EVol::Edge)) {
-                Y_Fail(
+                Y_TABLET_ERROR(
                     "NTable read ABI [" << ui32(EVol::Tail) << ", "
                     << ui32(EVol::Edge) << "] is incompatible with ABI"
                     << " [" << tail << ", " << head << "] of " << label

--- a/ydb/core/tablet_flat/flat_bio_actor.cpp
+++ b/ydb/core/tablet_flat/flat_bio_actor.cpp
@@ -1,6 +1,7 @@
 #include "flat_bio_actor.h"
 #include "flat_bio_events.h"
 #include "flat_bio_stats.h"
+#include "util_fmt_abort.h"
 #include "util_fmt_logger.h"
 
 #include <ydb/core/base/blobstorage.h>
@@ -41,7 +42,7 @@ void TBlockIO::Inbox(TEventHandlePtr &eh)
             Handle(eh->Cookie, { ptr, size_t(ev->ResponseSz) });
         }
     } else if (auto *ev = eh->CastAsLocal<NBlockIO::TEvFetch>()) {
-        Y_ABORT_UNLESS(!Owner, "TBlockIO actor now can hanle only one request");
+        Y_ENSURE(!Owner, "TBlockIO actor now can hanle only one request");
 
         Owner = eh->Sender;
         Bootstrap(ev->Priority, ev->Fetch);
@@ -50,7 +51,7 @@ void TBlockIO::Inbox(TEventHandlePtr &eh)
     } else if (eh->CastAsLocal<TEvents::TEvPoison>()) {
         PassAway();
     } else {
-        Y_ABORT("Page collection blocks IO actor got an unexpected event");
+        Y_TABLET_ERROR("Page collection blocks IO actor got an unexpected event");
     }
 }
 
@@ -59,7 +60,7 @@ void TBlockIO::Bootstrap(EPriority priority, TAutoPtr<NPageCollection::TFetch> o
     Origin = origin;
     Priority = priority;
 
-    Y_ABORT_UNLESS(Origin->Pages, "Got TFetch request without pages list");
+    Y_ENSURE(Origin->Pages, "Got TFetch request without pages list");
 
     PagesToBlobsConverter = new TPagesToBlobsConverter(*Origin->PageCollection, Origin->Pages);
 
@@ -102,8 +103,9 @@ void TBlockIO::Dispatch()
             auto &brick = PagesToBlobsConverter->Queue[more.From + on];
             auto glob = Origin->PageCollection->Glob(brick.Blob);
 
-            if ((group = (on ? group : glob.Group)) != glob.Group)
-                Y_ABORT("Cannot handle different groups in one request");
+            if ((group = (on ? group : glob.Group)) != glob.Group) {
+                Y_TABLET_ERROR("Cannot handle different groups in one request");
+            }
 
             query[on].Id = glob.Logo;
             query[on].Shift = brick.Skip;
@@ -135,7 +137,7 @@ void TBlockIO::Dispatch()
             << " bricks in " << Pending << " reads, " << BlockStates.size() <<  "p req";
     }
 
-    Y_ABORT_UNLESS(PagesToBlobsConverter->Complete(), "NPageCollection::TPagesToBlobsConverter cooked incomplete loads");
+    Y_ENSURE(PagesToBlobsConverter->Complete(), "NPageCollection::TPagesToBlobsConverter cooked incomplete loads");
 }
 
 void TBlockIO::Handle(ui32 base, TArrayRef<TLoaded> items)
@@ -160,7 +162,7 @@ void TBlockIO::Handle(ui32 base, TArrayRef<TLoaded> items)
         const auto &brick = PagesToBlobsConverter->Queue[base + (&piece - &items[0])];
 
         auto& state = BlockStates.at(brick.Slot);
-        Y_ABORT_UNLESS(state.Data.size() - state.Offset >= piece.Buffer.size());
+        Y_ENSURE(state.Data.size() - state.Offset >= piece.Buffer.size());
         piece.Buffer.begin().ExtractPlainDataAndAdvance(state.Data.mutable_data() + state.Offset, piece.Buffer.size());
         state.Offset += piece.Buffer.size();
     }
@@ -171,7 +173,7 @@ void TBlockIO::Handle(ui32 base, TArrayRef<TLoaded> items)
     size_t index = 0;
     for (ui32 pageId : Origin->Pages) {
         auto& state = BlockStates.at(index++);
-        Y_ABORT_UNLESS(state.Offset == state.Data.size());
+        Y_ENSURE(state.Offset == state.Data.size());
         if (Origin->PageCollection->Verify(pageId, state.Data)) {
             continue;
         } else if (auto logl = Logger->Log(ELnLev::Crit)) {

--- a/ydb/core/tablet_flat/flat_bloom_hash.h
+++ b/ydb/core/tablet_flat/flat_bloom_hash.h
@@ -31,7 +31,7 @@ namespace NBloom {
 
         inline TStringBuf Get(ui32 len) const
         {
-            Y_ABORT_UNLESS(len > 0 && len <= Offsets.size());
+            Y_ENSURE(len > 0 && len <= Offsets.size());
 
             return { Buffer.data(), Buffer.data() + Offsets[len - 1] };
         }

--- a/ydb/core/tablet_flat/flat_bloom_writer.h
+++ b/ydb/core/tablet_flat/flat_bloom_writer.h
@@ -28,20 +28,20 @@ namespace NBloom {
     public:
         TEstimator(float error)
         {
-            Y_ABORT_UNLESS(error > 0. && error < 1.,
+            Y_ENSURE(error > 0. && error < 1.,
                 "Invalid error estimation, should be in (0, 1)");
 
             double log2err = Log2(error);
 
             Amp = -1.44 * log2err;
-            Y_ABORT_UNLESS(Amp < 256., "Too high rows amplification factor");
+            Y_ENSURE(Amp < 256., "Too high rows amplification factor");
 
             HashCount = Min(ui64(Max<ui16>()), ui64(ceil(-log2err)));
         }
 
         ui64 Bits(ui64 rows) const
         {
-            Y_ABORT_UNLESS(!(rows >> 54),
+            Y_ENSURE(!(rows >> 54),
                 "Too many rows, probably an invalid value passed");
 
             return ((Max(ui64(ceil(Amp * rows)), ui64(1)) + 63) >> 6) << 6;
@@ -64,7 +64,7 @@ namespace NBloom {
             TEstimator estimator(error);
             Hashes = estimator.Hashes();
             Items = estimator.Bits(rows);
-            Y_ABORT_UNLESS(Hashes && Items);
+            Y_ENSURE(Hashes && Items);
 
             Reset();
         }
@@ -94,8 +94,8 @@ namespace NBloom {
 
             Array = { TDeref<ui64>::At(*out, 0), size_t(Items >> 6) };
 
-            Y_ABORT_UNLESS(size_t(*out) % sizeof(ui64) == 0, "Invalid aligment");
-            Y_ABORT_UNLESS(TDeref<char>::At(Array.end(), 0) == Raw.mutable_end());
+            Y_ENSURE(size_t(*out) % sizeof(ui64) == 0, "Invalid aligment");
+            Y_ENSURE(TDeref<char>::At(Array.end(), 0) == Raw.mutable_end());
 
             std::fill(Array.begin(), Array.end(), 0);
         }

--- a/ydb/core/tablet_flat/flat_boot_alter.h
+++ b/ydb/core/tablet_flat/flat_boot_alter.h
@@ -5,6 +5,7 @@
 #include "flat_boot_blobs.h"
 #include "flat_dbase_apply.h"
 #include "logic_alter_main.h"
+#include "util_fmt_abort.h"
 
 #include <ydb/core/util/pb.h>
 #include <util/generic/xrange.h>
@@ -38,8 +39,9 @@ namespace NBoot {
         {
             auto *load = step->ConsumeAs<TLoadBlobs>(Pending);
 
-            if (load->Cookie < Skip || load->Cookie - Skip >= Queue.size())
-                Y_ABORT("Got TLoadBlobs result cookie out of queue range");
+            if (load->Cookie < Skip || load->Cookie - Skip >= Queue.size()) {
+                Y_TABLET_ERROR("Got TLoadBlobs result cookie out of queue range");
+            }
 
             Queue.at(load->Cookie - Skip).Body = load->Plain();
 
@@ -55,7 +57,7 @@ namespace NBoot {
                 ++Skip, Queue.pop_front();
             }
 
-            Y_ABORT_UNLESS(Queue || !Pending, "TAlter boot actor has lost entries");
+            Y_ENSURE(Queue || !Pending, "TAlter boot actor has lost entries");
 
             if (!Queue) {
                 Env->Finish(this);

--- a/ydb/core/tablet_flat/flat_boot_back.h
+++ b/ydb/core/tablet_flat/flat_boot_back.h
@@ -80,7 +80,7 @@ namespace NBoot {
             const ui64 stamp = TTxStamp(edge.GetGeneration(), edge.GetStep());
             const NTable::TEpoch epoch(edge.HasHead() ? edge.GetHead() : 0);
 
-            Y_ABORT_UNLESS(stamp != Max<ui64>(), "Undefined TxStamp of snapshot");
+            Y_ENSURE(stamp != Max<ui64>(), "Undefined TxStamp of snapshot");
 
             auto &last = Edges[edge.GetTable()];
 

--- a/ydb/core/tablet_flat/flat_boot_blobs.h
+++ b/ydb/core/tablet_flat/flat_boot_blobs.h
@@ -21,11 +21,6 @@ namespace NBoot {
         TLoadBlobs() = default;
         TLoadBlobs(IStep *owner, NPageCollection::TLargeGlobId largeGlobId, ui64 cookie);
 
-        ~TLoadBlobs()
-        {
-            Y_ABORT_UNLESS(!RefCount(), "TLoadBlobs is still referenced somewhere");
-        }
-
         void Start() override { }
 
         void Feed(TLogoBlobID blobId, TString body)

--- a/ydb/core/tablet_flat/flat_boot_bundle.h
+++ b/ydb/core/tablet_flat/flat_boot_bundle.h
@@ -7,6 +7,7 @@
 #include "flat_sausage_packet.h"
 #include "flat_part_loader.h"
 #include "flat_dbase_naked.h"
+#include "util_fmt_abort.h"
 
 #include <util/generic/xrange.h>
 
@@ -52,7 +53,7 @@ namespace NBoot {
 
         bool HandleBio(NSharedCache::TEvResult &msg) override
         {
-            Y_ABORT_UNLESS(Loader, "PageCollections loader got un unexpected pages fetch");
+            Y_ENSURE(Loader, "PageCollections loader got un unexpected pages fetch");
 
             LeftReads -= 1;
 
@@ -75,11 +76,11 @@ namespace NBoot {
             auto *load = step->ConsumeAs<TLoadBlobs>(LeftMetas);
 
             if (Loader) {
-                Y_ABORT("Got an unexpected load blobs result");
+                Y_TABLET_ERROR("Got an unexpected load blobs result");
             } else if (load->Cookie >= PageCollections.size()) {
-                Y_ABORT("Got blobs load step with an invalid cookie");
+                Y_TABLET_ERROR("Got blobs load step with an invalid cookie");
             } else if (PageCollections[load->Cookie]) {
-                Y_ABORT("Page collection is already loaded at room %zu", load->Cookie);
+                Y_TABLET_ERROR("Page collection is already loaded at room " << load->Cookie);
             } else {
                 auto *pack = new NPageCollection::TPageCollection(load->LargeGlobId, load->PlainData());
 

--- a/ydb/core/tablet_flat/flat_boot_cookie.h
+++ b/ydb/core/tablet_flat/flat_boot_cookie.h
@@ -41,7 +41,7 @@ namespace NBoot {
         TCookie(EType type, EIdx index, ui32 sub)
             : Raw((ui32(type) << OffType) | (ui32(index) << OffIdx) | sub)
         {
-            Y_ABORT_UNLESS(sub <= MaskSub, "TCookue sub value is out of capacity");
+            Y_ENSURE(sub <= MaskSub, "TCookue sub value is out of capacity");
         }
 
         EType Type() const { return EType((Raw & MaskType) >> OffType); }

--- a/ydb/core/tablet_flat/flat_boot_env.h
+++ b/ydb/core/tablet_flat/flat_boot_env.h
@@ -19,6 +19,7 @@ namespace NBoot {
 
         ~TRoot()
         {
+            // FIXME: we shouldn't rely on TIntrusivePtr refcount
             Y_ABORT_UNLESS(RefCount() == 1, "Boot env shouldn't be deleted by TIntrusivePtr");
         }
 
@@ -73,16 +74,16 @@ namespace NBoot {
 
         void Start(TIntrusivePtr<IStep> step) override
         {
-            Y_ABORT_UNLESS(step->Env == nullptr, "IStep is already fired");
-            Y_ABORT_UNLESS(step->Owner, "Start called on step without an owner");
+            Y_ENSURE(step->Env == nullptr, "IStep is already fired");
+            Y_ENSURE(step->Owner, "Start called on step without an owner");
 
             Queue.emplace_back(EOp::Start, std::move(step));
         }
 
         void Finish(TIntrusivePtr<IStep> step) override
         {
-            Y_ABORT_UNLESS(step, "Finish called without a step");
-            Y_ABORT_UNLESS(step->Owner, "Finish called on step without an owner");
+            Y_ENSURE(step, "Finish called without a step");
+            Y_ENSURE(step->Owner, "Finish called on step without an owner");
 
             Queue.emplace_back(EOp::Finish, std::move(step));
         }

--- a/ydb/core/tablet_flat/flat_boot_gclog.h
+++ b/ydb/core/tablet_flat/flat_boot_gclog.h
@@ -4,6 +4,7 @@
 #include "flat_boot_back.h"
 #include "flat_boot_blobs.h"
 #include "flat_bio_events.h"
+#include "util_fmt_abort.h"
 
 #include <ydb/core/util/pb.h>
 #include <library/cpp/blockcodecs/codecs.h>
@@ -39,8 +40,9 @@ namespace NBoot {
         {
             auto *load = step->ConsumeAs<TLoadBlobs>(Pending);
 
-            if (load->Cookie < Skip || load->Cookie - Skip >= Queue.size())
-                Y_ABORT("Got TLoadBlobs result cookie out of queue range");
+            if (load->Cookie < Skip || load->Cookie - Skip >= Queue.size()) {
+                Y_TABLET_ERROR("Got TLoadBlobs result cookie out of queue range");
+            }
 
             Queue.at(load->Cookie - Skip).Body = load->Plain();
 
@@ -59,7 +61,7 @@ namespace NBoot {
                 ++Skip, Queue.pop_front();
             }
 
-            Y_ABORT_UNLESS(Queue || !Pending, "TGCLog boot actor has lost entries");
+            Y_ENSURE(Queue || !Pending, "TGCLog boot actor has lost entries");
 
             if (!Queue) {
                 Env->Finish(this);

--- a/ydb/core/tablet_flat/flat_boot_iface.h
+++ b/ydb/core/tablet_flat/flat_boot_iface.h
@@ -65,7 +65,7 @@ namespace NBoot {
             , Logic(owner->Logic)
             , Back(owner->Back)
         {
-            Y_ABORT_UNLESS(Owner != this, "Boot IStep Cannot be on its own");
+            Y_ENSURE(Owner != this, "Boot IStep Cannot be on its own");
         }
 
         virtual ~IStep() = default;
@@ -74,12 +74,12 @@ namespace NBoot {
 
         virtual bool HandleBio(NSharedCache::TEvResult&)
         {
-            Y_ABORT("Boot IStep got an unhandled NSharedCache::TEvResult event");
+            Y_TABLET_ERROR("Boot IStep got an unhandled NSharedCache::TEvResult event");
         }
 
         virtual void HandleStep(TIntrusivePtr<IStep>)
         {
-            Y_ABORT("Boot IStep got an unhandled child step result");
+            Y_TABLET_ERROR("Boot IStep got an unhandled child step result");
         }
 
         template<typename TStep, typename ... TArgs>
@@ -104,7 +104,7 @@ namespace NBoot {
             if (typeid(*this) == typeid(TStep)) {
                 return static_cast<TStep*>(this);
             } else if (require) {
-                Y_ABORT("Cannot cast IStep to particular unit");
+                Y_TABLET_ERROR("Cannot cast IStep to particular unit");
             } else {
                 return nullptr;
             }

--- a/ydb/core/tablet_flat/flat_boot_lease.cpp
+++ b/ydb/core/tablet_flat/flat_boot_lease.cpp
@@ -63,8 +63,8 @@ public:
 
     void Handle(TEvents::TEvUndelivered::TPtr& ev) {
         auto* msg = ev->Get();
-        Y_ABORT_UNLESS(ev->Sender == LeaseHolder);
-        Y_ABORT_UNLESS(msg->SourceType == TEvTablet::TEvDropLease::EventType);
+        Y_ENSURE(ev->Sender == LeaseHolder);
+        Y_ENSURE(msg->SourceType == TEvTablet::TEvDropLease::EventType);
         if (msg->Reason == TEvents::TEvUndelivered::ReasonActorUnknown) {
             // We have proved lease holder no longer exists
             return Finish();

--- a/ydb/core/tablet_flat/flat_boot_loans.h
+++ b/ydb/core/tablet_flat/flat_boot_loans.h
@@ -4,6 +4,7 @@
 #include "flat_boot_back.h"
 #include "flat_boot_blobs.h"
 #include "flat_executor_borrowlogic.h"
+#include "util_fmt_abort.h"
 
 #include <ydb/core/util/pb.h>
 #include <library/cpp/blockcodecs/codecs.h>
@@ -39,8 +40,9 @@ namespace NBoot {
         {
             auto *load = step->ConsumeAs<TLoadBlobs>(Pending);
 
-            if (load->Cookie < Skip || load->Cookie - Skip >= Queue.size())
-                Y_ABORT("Got TLoadBlobs result cookie out of queue range");
+            if (load->Cookie < Skip || load->Cookie - Skip >= Queue.size()) {
+                Y_TABLET_ERROR("Got TLoadBlobs result cookie out of queue range");
+            }
 
             Queue.at(load->Cookie - Skip).Body = load->Plain();
 
@@ -56,7 +58,7 @@ namespace NBoot {
                 ++Skip, Queue.pop_front();
             }
 
-            Y_ABORT_UNLESS(Queue || !Pending, "TLoans boot actor has lost entries");
+            Y_ENSURE(Queue || !Pending, "TLoans boot actor has lost entries");
 
             if (!Queue) {
                 Env->Finish(this);

--- a/ydb/core/tablet_flat/flat_boot_oven.h
+++ b/ydb/core/tablet_flat/flat_boot_oven.h
@@ -4,6 +4,7 @@
 #include "util_fmt_abort.h"
 #include "flat_sausage_grind.h"
 #include "flat_boot_cookie.h"
+#include "util_fmt_abort.h"
 #include <ydb/core/base/blobstorage.h>
 
 namespace NKikimr {
@@ -47,7 +48,7 @@ namespace NBoot {
                 if (one.Channel == 0) {
                     /* Zero channel is reserved for system tablet activity */
                 } else if (group == NPageCollection::TLargeGlobId::InvalidGroup) {
-                    Y_Fail(
+                    Y_TABLET_ERROR(
                         "Leader{" << Tablet << ":" << Gen << "} got reserved"
                         << " InvalidGroup value for channel " << one.Channel);
 
@@ -70,7 +71,7 @@ namespace NBoot {
             const auto mask = ui64(1) << unsigned(idx);
 
             if (std::exchange(Issued, Issued | mask) & mask) {
-                Y_Fail("Cookies cookieRange EIdx" << ui32(idx) << " is resued");
+                Y_TABLET_ERROR("Cookies cookieRange EIdx" << ui32(idx) << " is resued");
             }
         }
 

--- a/ydb/core/tablet_flat/flat_boot_redo.h
+++ b/ydb/core/tablet_flat/flat_boot_redo.h
@@ -6,6 +6,7 @@
 #include "flat_bio_events.h"
 #include "flat_dbase_naked.h"
 #include "flat_executor_txloglogic.h"
+#include "util_fmt_abort.h"
 #include "util_fmt_flat.h"
 
 #include <util/generic/xrange.h>
@@ -50,8 +51,9 @@ namespace NBoot {
         {
             auto *load = step->ConsumeAs<TLoadBlobs>(Pending);
 
-            if (load->Cookie < Skip || load->Cookie - Skip >= Queue.size())
-                Y_ABORT("Got TLoadBlobs result cookie out of queue range");
+            if (load->Cookie < Skip || load->Cookie - Skip >= Queue.size()) {
+                Y_TABLET_ERROR("Got TLoadBlobs result cookie out of queue range");
+            }
 
             Queue.at(load->Cookie - Skip).Body = load->Plain();
 
@@ -73,7 +75,7 @@ namespace NBoot {
                 ++Skip, Queue.pop_front();
             }
 
-            Y_ABORT_UNLESS(Queue || !Pending, "TRedo boot actor has lost entries");
+            Y_ENSURE(Queue || !Pending, "TRedo boot actor has lost entries");
 
             if (!Queue) {
                 Env->Finish(this);

--- a/ydb/core/tablet_flat/flat_boot_switch.h
+++ b/ydb/core/tablet_flat/flat_boot_switch.h
@@ -152,7 +152,7 @@ namespace NBoot {
                         }
                     }
 
-                    Y_ABORT_UNLESS(one.LargeGlobIds.size(), "Part bundle has no page collections");
+                    Y_ENSURE(one.LargeGlobIds.size(), "Part bundle has no page collections");
 
                     if (bundle.HasLegacy())
                         one.Legacy = bundle.GetLegacy();
@@ -248,13 +248,12 @@ namespace NBoot {
         }
 
         void InitTable(ui32 table) {
-            Y_ABORT_UNLESS(table != Max<ui32>(), "Invalid table id in switch");
+            Y_ENSURE(table != Max<ui32>(), "Invalid table id in switch");
             if (Table == Max<ui32>()) {
                 Table = table;
             } else {
-                Y_ABORT_UNLESS(Table == table,
-                    "Inconsistent table id in switch (have %" PRIu32 ", new %" PRIu32 ")",
-                    Table, table);
+                Y_ENSURE(Table == table,
+                    "Inconsistent table id in switch (have " << Table << ", new " << table << ")");
             }
         }
 

--- a/ydb/core/tablet_flat/flat_boot_util.h
+++ b/ydb/core/tablet_flat/flat_boot_util.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include "util_fmt_abort.h"
+
 #include <util/system/yassert.h>
 #include <util/generic/ylimits.h>
 
@@ -48,8 +50,7 @@ namespace NBoot {
         TLeft& operator +=(size_t inc)
         {
             if (Value > Max<decltype(Value)>() - inc) {
-
-                Y_ABORT("TLeft counter is overflowed");
+                Y_TABLET_ERROR("TLeft counter is overflowed");
             }
 
             Value += inc;
@@ -59,7 +60,7 @@ namespace NBoot {
 
         TLeft& operator -=(size_t dec)
         {
-            Y_ABORT_UNLESS(Value >= dec, "TLeft counter is underflowed");
+            Y_ENSURE(Value >= dec, "TLeft counter is underflowed");
 
             Value -= dec;
 

--- a/ydb/core/tablet_flat/flat_boot_warm.h
+++ b/ydb/core/tablet_flat/flat_boot_warm.h
@@ -53,13 +53,13 @@ namespace NBoot {
             auto *load = step->ConsumeAs<TLoadBlobs>(Pending);
 
             size_t index = load->Cookie >> 32;
-            Y_ABORT_UNLESS(index < States.size());
+            Y_ENSURE(index < States.size());
             auto& state = States[index];
-            Y_ABORT_UNLESS(state.Pending > 0);
+            Y_ENSURE(state.Pending > 0);
 
             ui32 page = ui32(load->Cookie);
-            Y_ABORT_UNLESS(page < state.Pages.size());
-            Y_ABORT_UNLESS(!state.Pages[page].Data);
+            Y_ENSURE(page < state.Pages.size());
+            Y_ENSURE(!state.Pages[page].Data);
 
             state.Pages[page].PageId = page;
             state.Pages[page].Data = load->PlainData();

--- a/ydb/core/tablet_flat/flat_comp_gen.cpp
+++ b/ydb/core/tablet_flat/flat_comp_gen.cpp
@@ -32,7 +32,7 @@ struct TGenCompactionStrategy::TPartAggregator {
     ui64 PartEpochCount = 0;
 
     TPartAggregator& Add(const TPartInfo& part) {
-        Y_ABORT_UNLESS(part.Epoch != TEpoch::Max(),
+        Y_ENSURE(part.Epoch != TEpoch::Max(),
             "Unexpected part with an infinite epoch found");
         Stats += part.Stats;
         StatsPerTablet[part.Label.TabletID()] += part.Stats;
@@ -90,7 +90,7 @@ struct TGenCompactionStrategy::TExtraState {
 };
 
 TGenCompactionStrategy::TPartInfo& TGenCompactionStrategy::TGeneration::PushFront(TPartView partView) {
-    Y_ABORT_UNLESS(TakenHeadParts == 0,
+    Y_ENSURE(TakenHeadParts == 0,
         "Attempting to prepend part to generation that has taken head parts");
 
     if (Parts.empty() || Parts.front().Epoch != partView->Epoch) {
@@ -105,7 +105,7 @@ TGenCompactionStrategy::TPartInfo& TGenCompactionStrategy::TGeneration::PushFron
 }
 
 TGenCompactionStrategy::TPartInfo& TGenCompactionStrategy::TGeneration::PushBack(TPartView partView) {
-    Y_ABORT_UNLESS(CompactingTailParts == 0,
+    Y_ENSURE(CompactingTailParts == 0,
         "Attempting to append part to generation that has compacting tail parts");
 
     if (Parts.empty() || Parts.back().Epoch != partView->Epoch) {
@@ -113,7 +113,7 @@ TGenCompactionStrategy::TPartInfo& TGenCompactionStrategy::TGeneration::PushBack
         ++PartEpochCount;
     } else if (Parts.size() == TakenHeadParts) {
         // The end of taken head is no longer an epoch edge
-        Y_ABORT_UNLESS(TakenHeadPartEpochCount > 0);
+        Y_ENSURE(TakenHeadPartEpochCount > 0);
         --TakenHeadPartEpochCount;
     }
 
@@ -124,7 +124,7 @@ TGenCompactionStrategy::TPartInfo& TGenCompactionStrategy::TGeneration::PushBack
 }
 
 void TGenCompactionStrategy::TGeneration::PopFront() {
-    Y_ABORT_UNLESS(Parts.size() > CompactingTailParts,
+    Y_ENSURE(Parts.size() > CompactingTailParts,
         "Attempting to remove part crossing compacting tail parts");
 
     bool wasTaken = TakenHeadParts > 0;
@@ -134,7 +134,7 @@ void TGenCompactionStrategy::TGeneration::PopFront() {
     Stats -= front.Stats;
     StatsPerTablet[front.Label.TabletID()] -= front.Stats;
     if (wasTaken) {
-        Y_ABORT_UNLESS(TakenHeadBackingSize >= front.Stats.BackingSize);
+        Y_ENSURE(TakenHeadBackingSize >= front.Stats.BackingSize);
         TakenHeadBackingSize -= front.Stats.BackingSize;
         --TakenHeadParts;
     }
@@ -143,16 +143,16 @@ void TGenCompactionStrategy::TGeneration::PopFront() {
     if (Parts.empty() || Parts.front().Epoch != epoch) {
         // We just removed an epoch edge
         if (wasTaken) {
-            Y_ABORT_UNLESS(TakenHeadPartEpochCount > 0);
+            Y_ENSURE(TakenHeadPartEpochCount > 0);
             --TakenHeadPartEpochCount;
         }
-        Y_ABORT_UNLESS(PartEpochCount > 0);
+        Y_ENSURE(PartEpochCount > 0);
         --PartEpochCount;
     }
 }
 
 void TGenCompactionStrategy::TGeneration::PopBack() {
-    Y_ABORT_UNLESS(Parts.size() > TakenHeadParts,
+    Y_ENSURE(Parts.size() > TakenHeadParts,
         "Attempting to remove part crossing taken head parts");
 
     bool wasCompacting = CompactingTailParts > 0;
@@ -168,7 +168,7 @@ void TGenCompactionStrategy::TGeneration::PopBack() {
 
     if (Parts.empty() || Parts.front().Epoch != epoch) {
         // We just removed an epoch edge
-        Y_ABORT_UNLESS(PartEpochCount > 0);
+        Y_ENSURE(PartEpochCount > 0);
         --PartEpochCount;
     } else if (Parts.size() == TakenHeadParts) {
         // The end of taken head is now an epoch edge
@@ -197,7 +197,7 @@ TGenCompactionStrategy::~TGenCompactionStrategy()
 }
 
 void TGenCompactionStrategy::Start(TCompactionState state) {
-    Y_ABORT_UNLESS(!Policy, "Strategy has already been started");
+    Y_ENSURE(!Policy, "Strategy has already been started");
 
     const auto* scheme = Backend->TableScheme(Table);
 
@@ -207,7 +207,7 @@ void TGenCompactionStrategy::Start(TCompactionState state) {
     for (auto& partView : Backend->TableParts(Table)) {
         auto label = partView->Label;
         ui32 level = state.PartLevels.Value(partView->Label, 255);
-        Y_ABORT_UNLESS(level > 0 && level <= Generations.size() || level == 255);
+        Y_ENSURE(level > 0 && level <= Generations.size() || level == 255);
         auto& parts = level == 255 ? FinalParts : Generations.at(level - 1).Parts;
         parts.emplace_back(std::move(partView));
         KnownParts[label] = level;
@@ -216,7 +216,7 @@ void TGenCompactionStrategy::Start(TCompactionState state) {
     for (auto& part : Backend->TableColdParts(Table)) {
         auto label = part->Label;
         ui32 level = state.PartLevels.Value(part->Label, 255);
-        Y_ABORT_UNLESS(level > 0 && level <= Generations.size() || level == 255);
+        Y_ENSURE(level > 0 && level <= Generations.size() || level == 255);
         ColdParts.emplace_back(std::move(part));
         KnownParts[label] = level;
     }
@@ -228,7 +228,7 @@ void TGenCompactionStrategy::Start(TCompactionState state) {
             gen.Parts.sort();
 
             // Verify epoch is decreasing from level to level
-            Y_ABORT_UNLESS(gen.Parts.front().Epoch <= lastEpoch);
+            Y_ENSURE(gen.Parts.front().Epoch <= lastEpoch);
             lastEpoch = gen.Parts.back().Epoch;
 
             agg.Add(gen.Parts);
@@ -265,13 +265,13 @@ void TGenCompactionStrategy::Stop() {
             case EState::Pending:
             case EState::PendingBackground: {
                 // The task is scheduled, make sure to cancel it
-                Y_ABORT_UNLESS(gen.Task.TaskId != 0);
+                Y_ENSURE(gen.Task.TaskId != 0);
                 Broker->CancelTask(gen.Task.TaskId);
                 break;
             }
             case EState::Compacting: {
                 // Compaction is running, cancel it
-                Y_ABORT_UNLESS(gen.Task.CompactionId != 0);
+                Y_ENSURE(gen.Task.CompactionId != 0);
                 Backend->CancelCompaction(gen.Task.CompactionId);
                 break;
             }
@@ -288,12 +288,12 @@ void TGenCompactionStrategy::Stop() {
         case EState::Pending:
         case EState::PendingBackground:
             // The task is scheduled, make sure to cancel it
-            Y_ABORT_UNLESS(FinalState.Task.TaskId != 0);
+            Y_ENSURE(FinalState.Task.TaskId != 0);
             Broker->CancelTask(FinalState.Task.TaskId);
             break;
         case EState::Compacting:
             // Compaction is running, cancel it
-            Y_ABORT_UNLESS(FinalState.Task.CompactionId != 0);
+            Y_ENSURE(FinalState.Task.CompactionId != 0);
             Backend->CancelCompaction(FinalState.Task.CompactionId);
             break;
     }
@@ -324,10 +324,10 @@ void TGenCompactionStrategy::ReflectSchema() {
 
     TString err;
     bool ok = NLocalDb::ValidateCompactionPolicyChange(*Policy, *scheme->CompactionPolicy, err);
-    Y_ABORT_UNLESS(ok, "table %s id %u: %s", scheme->Name.data(), scheme->Id, err.data());
+    Y_ENSURE(ok, "Cannot change compaction policy for table " << scheme->Name << " id " << scheme->Id << ": " << err);
 
     Policy = scheme->CompactionPolicy;
-    Y_ABORT_UNLESS(Generations.size() <= Policy->Generations.size(), "Cannot currently shrink the number of generations");
+    Y_ENSURE(Generations.size() <= Policy->Generations.size(), "Cannot currently shrink the number of generations");
     Generations.resize(Policy->Generations.size());
 
     // Recheck all generations
@@ -381,7 +381,7 @@ void TGenCompactionStrategy::UpdateCompactions() {
 }
 
 ui64 TGenCompactionStrategy::BeginMemCompaction(TTaskId taskId, TSnapEdge edge, ui64 forcedCompactionId) {
-    Y_ABORT_UNLESS(MemCompactionId == 0, "Unexpected concurrent mem compaction requests");
+    Y_ENSURE(MemCompactionId == 0, "Unexpected concurrent mem compaction requests");
 
     TExtraState extra;
     if (forcedCompactionId == 0 && !Policy->Generations.empty() && ForcedState == EForcedState::None && edge.Head == TEpoch::Max()) {
@@ -393,7 +393,7 @@ ui64 TGenCompactionStrategy::BeginMemCompaction(TTaskId taskId, TSnapEdge edge, 
         edge,
         /* generation */ 0,
         extra);
-    Y_ABORT_UNLESS(MemCompactionId != 0);
+    Y_ENSURE(MemCompactionId != 0);
 
     if (forcedCompactionId != 0) {
         // We remember the last forced mem compaction we have started
@@ -416,8 +416,8 @@ bool TGenCompactionStrategy::ScheduleBorrowedCompaction() {
     for (const auto& pr : KnownParts) {
         if (pr.first.TabletID() != ownerTabletId) {
             hasBorrowed = true;
-            Y_ABORT_UNLESS(pr.second == 255,
-                "Borrowed part %s not in final parts", pr.first.ToString().c_str());
+            Y_ENSURE(pr.second == 255,
+                "Borrowed part " << pr.first << " not in final parts");
         }
     }
 
@@ -443,28 +443,28 @@ TCompactionChanges TGenCompactionStrategy::CompactionFinished(
 {
     auto* params = CheckedCast<TGenCompactionParams*>(rawParams.Get());
     ui32 generation = params->Generation;
-    Y_ABORT_UNLESS(generation <= Generations.size() || generation == 255, "Unexpected CompactionFinished generation");
+    Y_ENSURE(generation <= Generations.size() || generation == 255, "Unexpected CompactionFinished generation");
     if (auto logl = Logger->Log(NUtil::ELnLev::Debug)) {
         logl << "TGenCompactionStrategy CompactionFinished for " << Backend->OwnerTabletId()
             << ": compaction " << compactionId << ", generation " << generation;
     }
 
     if (generation == 0) {
-        Y_ABORT_UNLESS(compactionId == MemCompactionId,
+        Y_ENSURE(compactionId == MemCompactionId,
             "Unexpected CompactionFinished for gen 0");
         MemCompactionId = 0;
     } else if (generation == 255) {
-        Y_ABORT_UNLESS(FinalState.State == EState::Compacting);
-        Y_ABORT_UNLESS(compactionId == FinalState.Task.CompactionId,
-            "Unexpected CompactionFinished for gen %" PRIu32, generation);
+        Y_ENSURE(FinalState.State == EState::Compacting);
+        Y_ENSURE(compactionId == FinalState.Task.CompactionId,
+            "Unexpected CompactionFinished for gen " << generation);
         FinalState.State = EState::Free;
         FinalState.Task.TaskId = 0;
         FinalState.Task.CompactionId = 0;
     } else {
         auto& gen = Generations[generation - 1];
-        Y_ABORT_UNLESS(gen.State == EState::Compacting);
-        Y_ABORT_UNLESS(compactionId == gen.Task.CompactionId,
-            "Unexpected CompactionFinished for gen %" PRIu32, generation);
+        Y_ENSURE(gen.State == EState::Compacting);
+        Y_ENSURE(compactionId == gen.Task.CompactionId,
+            "Unexpected CompactionFinished for gen " << generation);
         gen.State = EState::Free;
         gen.Task.TaskId = 0;
         gen.Task.CompactionId = 0;
@@ -478,24 +478,24 @@ TCompactionChanges TGenCompactionStrategy::CompactionFinished(
 
     if (compactionId == FinalCompactionId || generation == 255) {
         // All taken cold parts must match our list of cold parts
-        Y_ABORT_UNLESS(params->ColdParts.size() <= FinalCompactionTaken);
+        Y_ENSURE(params->ColdParts.size() <= FinalCompactionTaken);
         for (auto& part : params->ColdParts) {
-            Y_ABORT_UNLESS(!ColdParts.empty());
+            Y_ENSURE(!ColdParts.empty());
             auto& front = ColdParts.front();
-            Y_ABORT_UNLESS(front->Label == part->Label);
+            Y_ENSURE(front->Label == part->Label);
             KnownParts.erase(front->Label);
             ColdParts.pop_front();
             --FinalCompactionTaken;
         }
         params->ColdParts.clear();
         // All taken final parts must be at the tail of our source parts
-        Y_ABORT_UNLESS(sourceParts.size() >= FinalCompactionTaken);
+        Y_ENSURE(sourceParts.size() >= FinalCompactionTaken);
         auto partStart = sourceParts.end() - FinalCompactionTaken;
         auto partEnd = sourceParts.end();
         for (auto partIt = partStart; partIt != partEnd; ++partIt) {
-            Y_ABORT_UNLESS(!FinalParts.empty());
+            Y_ENSURE(!FinalParts.empty());
             auto& front = FinalParts.front();
-            Y_ABORT_UNLESS(front.Label == (*partIt)->Label);
+            Y_ENSURE(front.Label == (*partIt)->Label);
             KnownParts.erase(front.Label);
             FinalParts.pop_front();
             --FinalCompactionTaken;
@@ -513,19 +513,19 @@ TCompactionChanges TGenCompactionStrategy::CompactionFinished(
         if (nextGen.TakenHeadParts != 0) {
             // This compaction has taken parts from the head of the next generation
             // These parts are expected to be at the tail of our source parts
-            Y_ABORT_UNLESS(sourceParts.size() >= nextGen.TakenHeadParts);
+            Y_ENSURE(sourceParts.size() >= nextGen.TakenHeadParts);
             auto partStart = sourceParts.end() - nextGen.TakenHeadParts;
             auto partEnd = sourceParts.end();
             for (auto partIt = partStart; partIt != partEnd; ++partIt) {
-                Y_ABORT_UNLESS(!nextGen.Parts.empty());
+                Y_ENSURE(!nextGen.Parts.empty());
                 auto& front = nextGen.Parts.front();
-                Y_ABORT_UNLESS(front.Label == (*partIt)->Label);
+                Y_ENSURE(front.Label == (*partIt)->Label);
                 KnownParts.erase(front.Label);
                 nextGen.PopFront();
             }
-            Y_ABORT_UNLESS(nextGen.TakenHeadParts == 0);
-            Y_ABORT_UNLESS(nextGen.TakenHeadBackingSize == 0);
-            Y_ABORT_UNLESS(nextGen.TakenHeadPartEpochCount == 0);
+            Y_ENSURE(nextGen.TakenHeadParts == 0);
+            Y_ENSURE(nextGen.TakenHeadBackingSize == 0);
+            Y_ENSURE(nextGen.TakenHeadPartEpochCount == 0);
             sourceParts.erase(partStart, partEnd);
             checkNeeded[generation] = true;
         }
@@ -535,7 +535,7 @@ TCompactionChanges TGenCompactionStrategy::CompactionFinished(
 
     if (generation == 0) {
         // This was a memtable compaction, we don't expect anything else
-        Y_ABORT_UNLESS(sourceParts.empty());
+        Y_ENSURE(sourceParts.empty());
 
         // Check if we just finished the last forced mem compaction
         if (ForcedMemCompactionId && compactionId == ForcedMemCompactionId) {
@@ -549,10 +549,10 @@ TCompactionChanges TGenCompactionStrategy::CompactionFinished(
         }
     } else if (generation == 255) {
         // This was a final parts compaction, we don't expect anything else
-        Y_ABORT_UNLESS(sourceParts.empty());
+        Y_ENSURE(sourceParts.empty());
     } else {
         ui32 sourceIndex = generation - 1;
-        Y_ABORT_UNLESS(sourceIndex < Generations.size());
+        Y_ENSURE(sourceIndex < Generations.size());
 
         if (ForcedState == EForcedState::Compacting && ForcedGeneration == generation) {
             ForcedState = EForcedState::None;
@@ -562,19 +562,18 @@ TCompactionChanges TGenCompactionStrategy::CompactionFinished(
         while (sourceParts) {
             auto& sourcePart = sourceParts.back();
             auto& sourceGen = Generations[sourceIndex];
-            Y_ABORT_UNLESS(sourceGen.Parts);
+            Y_ENSURE(sourceGen.Parts);
             auto& part = sourceGen.Parts.back();
-            Y_ABORT_UNLESS(part.Label == sourcePart->Label,
-                "Failed at gen=%u, sourceIndex=%u, headTaken=%lu",
-                generation, sourceIndex, sourceGen.TakenHeadParts);
-            Y_ABORT_UNLESS(sourceGen.CompactingTailParts > 0);
+            Y_ENSURE(part.Label == sourcePart->Label,
+                "Failed at gen=" << generation << ", sourceIndex=" << sourceIndex << ", headTaken=" << sourceGen.TakenHeadParts);
+            Y_ENSURE(sourceGen.CompactingTailParts > 0);
             KnownParts.erase(part.Label);
             sourceGen.PopBack();
             sourceParts.pop_back();
             checkNeeded[sourceIndex] = true;
         }
 
-        Y_ABORT_UNLESS(sourceParts.empty());
+        Y_ENSURE(sourceParts.empty());
 
         // Recheck compacted generation, it's free and may need a new compaction
         checkNeeded[generation - 1] = true;
@@ -665,13 +664,13 @@ TCompactionChanges TGenCompactionStrategy::CompactionFinished(
         } else {
             auto& newGen = Generations[target];
             if (target < generation) {
-                Y_ABORT_UNLESS(!newGen.Parts || result->Epoch <= newGen.Parts.back().Epoch);
+                Y_ENSURE(!newGen.Parts || result->Epoch <= newGen.Parts.back().Epoch);
                 for (auto it = newParts.begin(); it != newParts.end(); ++it) {
                     auto& partView = *it;
                     newGen.PushBack(std::move(partView));
                 }
             } else {
-                Y_ABORT_UNLESS(!newGen.Parts || result->Epoch >= newGen.Parts.front().Epoch);
+                Y_ENSURE(!newGen.Parts || result->Epoch >= newGen.Parts.front().Epoch);
                 for (auto it = newParts.rbegin(); it != newParts.rend(); ++it) {
                     auto& partView = *it;
                     newGen.PushFront(std::move(partView));
@@ -686,7 +685,7 @@ TCompactionChanges TGenCompactionStrategy::CompactionFinished(
     UpdateStats();
 
     if (forcedCompactionContinue) {
-        Y_ABORT_UNLESS(target < Generations.size());
+        Y_ENSURE(target < Generations.size());
         ForcedState = EForcedState::Pending;
         ForcedGeneration = target + 1;
         checkNeeded[target] = true;
@@ -735,20 +734,20 @@ void TGenCompactionStrategy::OnForcedGenCompactionDone() {
 }
 
 void TGenCompactionStrategy::PartMerged(TPartView partView, ui32 level) {
-    Y_ABORT_UNLESS(level == 255, "Unexpected level of the merged part");
+    Y_ENSURE(level == 255, "Unexpected level of the merged part");
 
     const auto label = partView->Label;
 
     // Remove the old part data from our model (since it may have been changed)
     if (KnownParts.contains(label)) {
-        Y_ABORT_UNLESS(KnownParts[label] == level, "Borrowed part cannot be moved between levels");
-        Y_ABORT_UNLESS(FinalCompactionId == 0 || FinalCompactionTaken == 0,
+        Y_ENSURE(KnownParts[label] == level, "Borrowed part cannot be moved between levels");
+        Y_ENSURE(FinalCompactionId == 0 || FinalCompactionTaken == 0,
             "Borrowed part attaching while final compaction is in progress");
 
         // Inefficient, but this case shouldn't happen in practice, since we
         // don't allow a diamond shaped split/merge sequence in datashards.
         for (auto it = ColdParts.begin(); it != ColdParts.end(); ++it) {
-            Y_ABORT_UNLESS((*it)->Label != label,
+            Y_ENSURE((*it)->Label != label,
                 "Cannot attach borrowed part, another cold part with the same label exists");
         }
         for (auto it = FinalParts.begin(); it != FinalParts.end(); ++it) {
@@ -778,10 +777,10 @@ void TGenCompactionStrategy::PartMerged(TPartView partView, ui32 level) {
 }
 
 void TGenCompactionStrategy::PartMerged(TIntrusiveConstPtr<TColdPart> part, ui32 level) {
-    Y_ABORT_UNLESS(level == 255, "Unexpected level of the merged part");
+    Y_ENSURE(level == 255, "Unexpected level of the merged part");
 
     const auto label = part->Label;
-    Y_ABORT_UNLESS(!KnownParts.contains(label),
+    Y_ENSURE(!KnownParts.contains(label),
         "Borrowed part attaching when another part with the same label exists");
 
     ColdParts.emplace_back(std::move(part));
@@ -897,8 +896,8 @@ void TGenCompactionStrategy::BeginGenCompaction(TTaskId taskId, ui32 generation)
 
     // Special mode for final parts compaction
     if (generation == 255) {
-        Y_ABORT_UNLESS(FinalState.State == EState::Pending);
-        Y_ABORT_UNLESS(FinalState.Task.TaskId == taskId);
+        Y_ENSURE(FinalState.State == EState::Pending);
+        Y_ENSURE(FinalState.Task.TaskId == taskId);
 
         auto cancelFinal = [&]() {
             Broker->FinishTask(taskId, EResourceStatus::Cancelled);
@@ -958,12 +957,12 @@ void TGenCompactionStrategy::BeginGenCompaction(TTaskId taskId, ui32 generation)
         return;
     }
 
-    Y_ABORT_UNLESS(generation > 0);
-    Y_ABORT_UNLESS(generation <= Generations.size());
+    Y_ENSURE(generation > 0);
+    Y_ENSURE(generation <= Generations.size());
 
     auto& gen = Generations[generation - 1];
-    Y_ABORT_UNLESS(gen.State == EState::Pending || gen.State == EState::PendingBackground);
-    Y_ABORT_UNLESS(gen.Task.TaskId == taskId);
+    Y_ENSURE(gen.State == EState::Pending || gen.State == EState::PendingBackground);
+    Y_ENSURE(gen.Task.TaskId == taskId);
 
     const bool forced = NeedToForceCompact(generation);
 
@@ -973,7 +972,7 @@ void TGenCompactionStrategy::BeginGenCompaction(TTaskId taskId, ui32 generation)
 
         gen.State = EState::Free;
 
-        Y_ABORT_UNLESS(!forced, "Unexpected cancellation of a forced compaction");
+        Y_ENSURE(!forced, "Unexpected cancellation of a forced compaction");
     };
 
     if (DesiredMode(generation) == EDesiredMode::None) {
@@ -1002,14 +1001,14 @@ void TGenCompactionStrategy::BeginGenCompaction(TTaskId taskId, ui32 generation)
     if (forced) {
         // We have just started a forced compaction
         ForcedState = EForcedState::Compacting;
-        Y_ABORT_UNLESS(ForcedGeneration == generation);
+        Y_ENSURE(ForcedGeneration == generation);
     }
 }
 
 void TGenCompactionStrategy::SubmitTask(
         TGenCompactionStrategy::TCompactionTask& task, TString type, ui32 priority, ui32 generation)
 {
-    Y_ABORT_UNLESS(task.TaskId == 0, "Task is already submitted");
+    Y_ENSURE(task.TaskId == 0, "Task is already submitted");
     if (auto logl = Logger->Log(NUtil::ELnLev::Debug)) {
         logl << "TGenCompactionStrategy SubmitTask for " << Backend->OwnerTabletId()
             << ": type " << type << ", priority " << priority << ", generation " << generation;
@@ -1036,7 +1035,7 @@ void TGenCompactionStrategy::SubmitTask(
 void TGenCompactionStrategy::UpdateTask(
         TGenCompactionStrategy::TCompactionTask& task, TString type, ui32 priority)
 {
-    Y_ABORT_UNLESS(task.TaskId != 0, "Task was not submitted");
+    Y_ENSURE(task.TaskId != 0, "Task was not submitted");
     task.Priority = priority;
 
     Broker->UpdateTask(
@@ -1051,8 +1050,8 @@ ui32 TGenCompactionStrategy::ComputeBackgroundPriority(
         const TCompactionPolicy::TGenerationPolicy& policy,
         TInstant now) const
 {
-    Y_ABORT_UNLESS(generation > 0);
-    Y_ABORT_UNLESS(generation <= Generations.size());
+    Y_ENSURE(generation > 0);
+    Y_ENSURE(generation <= Generations.size());
 
     if (NeedToForceCompact(generation)) {
         // This background compaction will be used for the forced compaction
@@ -1119,7 +1118,7 @@ void TGenCompactionStrategy::CheckOverload(ui32 generation) {
 }
 
 void TGenCompactionStrategy::CheckGeneration(ui32 generation) {
-    Y_ABORT_UNLESS(generation > 0);
+    Y_ENSURE(generation > 0);
 
     CheckOverload(generation);
 
@@ -1179,8 +1178,8 @@ void TGenCompactionStrategy::CheckGeneration(ui32 generation) {
 }
 
 TGenCompactionStrategy::EDesiredMode TGenCompactionStrategy::DesiredMode(ui32 generation) const {
-    Y_ABORT_UNLESS(generation > 0);
-    Y_ABORT_UNLESS(generation <= Generations.size());
+    Y_ENSURE(generation > 0);
+    Y_ENSURE(generation <= Generations.size());
 
     auto& gen = Generations[generation - 1];
     ui64 genSize = gen.Stats.BackingSize - gen.TakenHeadBackingSize;
@@ -1212,8 +1211,8 @@ TGenCompactionStrategy::EDesiredMode TGenCompactionStrategy::DesiredMode(ui32 ge
 // This is a simple heuristic that triggers compaction of borrowed parts (they all are at final level) on split dst
 // tablet after some updates happen after split.
 bool TGenCompactionStrategy::NeedToCompactAfterSplit(ui32 generation) const {
-    Y_ABORT_UNLESS(generation > 0);
-    Y_ABORT_UNLESS(generation <= Generations.size());
+    Y_ENSURE(generation > 0);
+    Y_ENSURE(generation <= Generations.size());
 
     // Last generation?
     if (generation != Generations.size())
@@ -1242,7 +1241,7 @@ ui64 TGenCompactionStrategy::PrepareCompaction(
         ui32 generation,
         TExtraState& extra)
 {
-    Y_ABORT_UNLESS(generation <= Generations.size() || generation == 255);
+    Y_ENSURE(generation <= Generations.size() || generation == 255);
     if (auto logl = Logger->Log(NUtil::ELnLev::Debug)) {
         logl << "TGenCompactionStrategy PrepareCompaction for " << Backend->OwnerTabletId()
             << ": task " << taskId << ", edge " << edge.Head << "/" << edge.TxStamp << ", generation " << generation;
@@ -1263,8 +1262,8 @@ ui64 TGenCompactionStrategy::PrepareCompaction(
         for (ui32 index : xrange(generation - 1, generation)) {
             auto& gen = Generations.at(index);
             size_t skip = first ? gen.TakenHeadParts : 0;
-            Y_ABORT_UNLESS(gen.TakenHeadParts == skip);
-            Y_ABORT_UNLESS(gen.CompactingTailParts == 0);
+            Y_ENSURE(gen.TakenHeadParts == skip);
+            Y_ENSURE(gen.CompactingTailParts == 0);
             for (auto& part : gen.Parts) {
                 if (skip > 0) {
                     --skip;
@@ -1281,20 +1280,20 @@ ui64 TGenCompactionStrategy::PrepareCompaction(
     // Extend with some parts from the next generation
     if (generation < Generations.size()) {
         auto& nextGen = Generations.at(generation);
-        Y_ABORT_UNLESS(nextGen.TakenHeadParts == 0);
-        Y_ABORT_UNLESS(nextGen.TakenHeadBackingSize == 0);
-        Y_ABORT_UNLESS(nextGen.TakenHeadPartEpochCount == 0);
+        Y_ENSURE(nextGen.TakenHeadParts == 0);
+        Y_ENSURE(nextGen.TakenHeadBackingSize == 0);
+        Y_ENSURE(nextGen.TakenHeadPartEpochCount == 0);
         if (extra.ExtrasAllowed() && !NeedToForceCompact(generation + 1)) {
-            Y_ABORT_UNLESS(nextGen.Parts.size() >= nextGen.CompactingTailParts);
+            Y_ENSURE(nextGen.Parts.size() >= nextGen.CompactingTailParts);
             size_t available = nextGen.Parts.size() - nextGen.CompactingTailParts;
             TEpoch lastEpoch = TEpoch::Max();
             for (auto& part : nextGen.Parts) {
-                Y_ABORT_UNLESS(part.Epoch != TEpoch::Max(),
+                Y_ENSURE(part.Epoch != TEpoch::Max(),
                     "Unexpected part with an infinite epoch found");
 
                 if (std::exchange(lastEpoch, part.Epoch) == part.Epoch) {
                     // The last part we grabbed wasn't an epoch edge
-                    Y_ABORT_UNLESS(nextGen.TakenHeadPartEpochCount > 0);
+                    Y_ENSURE(nextGen.TakenHeadPartEpochCount > 0);
                     --nextGen.TakenHeadPartEpochCount;
                 }
 
@@ -1314,7 +1313,7 @@ ui64 TGenCompactionStrategy::PrepareCompaction(
             }
         }
     } else {
-        Y_ABORT_UNLESS(generation == Generations.size() || generation == 255);
+        Y_ENSURE(generation == Generations.size() || generation == 255);
         for (auto& part : FinalParts) {
             params->Parts.emplace_back(part.PartView);
             extra.Add(part.Stats.BackingSize);
@@ -1351,7 +1350,7 @@ ui64 TGenCompactionStrategy::PrepareCompaction(
     }
 
     if (generation == Generations.size() || generation == 255) {
-        Y_ABORT_UNLESS(FinalCompactionId == 0, "Multiple final compactions not allowed");
+        Y_ENSURE(FinalCompactionId == 0, "Multiple final compactions not allowed");
         if (generation != 255) {
             FinalCompactionId = compactionId;
 
@@ -1363,7 +1362,7 @@ ui64 TGenCompactionStrategy::PrepareCompaction(
                     case EState::Pending:
                     case EState::PendingBackground:
                         // The task is scheduled, make sure to cancel it
-                        Y_ABORT_UNLESS(FinalState.Task.TaskId != 0);
+                        Y_ENSURE(FinalState.Task.TaskId != 0);
                         if (auto logl = Logger->Log(NUtil::ELnLev::Debug)) {
                             logl << "TGenCompactionStrategy PrepareCompaction for " << Backend->OwnerTabletId()
                                 << " cancel pending compaction " << FinalState.Task.CompactionId;
@@ -1372,7 +1371,7 @@ ui64 TGenCompactionStrategy::PrepareCompaction(
                         break;
                     case EState::Compacting:
                         // Compaction is running, cancel it
-                        Y_ABORT_UNLESS(FinalState.Task.CompactionId != 0);
+                        Y_ENSURE(FinalState.Task.CompactionId != 0);
                         if (auto logl = Logger->Log(NUtil::ELnLev::Debug)) {
                             logl << "TGenCompactionStrategy PrepareCompaction for " << Backend->OwnerTabletId()
                                 << " cancel running compaction " << FinalState.Task.CompactionId;

--- a/ydb/core/tablet_flat/flat_cxx_database.h
+++ b/ydb/core/tablet_flat/flat_cxx_database.h
@@ -102,100 +102,102 @@ public:
     }
 
     operator ui64() const {
-        Y_ABORT_UNLESS((Type() == NScheme::NTypeIds::Uint64
+        Y_ENSURE((Type() == NScheme::NTypeIds::Uint64
                   || Type() == NScheme::NTypeIds::Timestamp)
-                 && Size() == sizeof(ui64), "Data=%" PRIxPTR ", Type=%" PRIi64 ", Size=%" PRIi64, (ui64)Data(), (i64)Type(), (i64)Size());
+                 && Size() == sizeof(ui64), "Data=" << (const void*)Data() << ", Type=" << (i64)Type() << ", Size=" << (i64)Size());
         return ReadUnaligned<ui64>(reinterpret_cast<const ui64*>(Data()));
     }
 
     operator i64() const {
-        Y_ABORT_UNLESS((Type() == NScheme::NTypeIds::Int64
+        Y_ENSURE((Type() == NScheme::NTypeIds::Int64
                   || Type() == NScheme::NTypeIds::Interval
                   || Type() == NScheme::NTypeIds::Datetime64
                   || Type() == NScheme::NTypeIds::Timestamp64
                   || Type() == NScheme::NTypeIds::Interval64)
-                 && Size() == sizeof(i64), "Data=%" PRIxPTR ", Type=%" PRIi64 ", Size=%" PRIi64, (ui64)Data(), (i64)Type(), (i64)Size());
+                 && Size() == sizeof(i64), "Data=" << (const void*)Data() << ", Type=" << (i64)Type() << ", Size=" << (i64)Size());
         return ReadUnaligned<i64>(reinterpret_cast<const i64*>(Data()));
     }
 
     operator ui32() const {
-        Y_ABORT_UNLESS((Type() == NScheme::NTypeIds::Uint32
+        Y_ENSURE((Type() == NScheme::NTypeIds::Uint32
                   || Type() == NScheme::NTypeIds::Datetime)
-                 && Size() == sizeof(ui32), "Data=%" PRIxPTR ", Type=%" PRIi64 ", Size=%" PRIi64, (ui64)Data(), (i64)Type(), (i64)Size());
+                 && Size() == sizeof(ui32), "Data=" << (const void*)Data() << ", Type=" << (i64)Type() << ", Size=" << (i64)Size());
         ui32 value = ReadUnaligned<ui32>(reinterpret_cast<const ui32*>(Data()));
         return value;
     }
 
     operator i32() const {
-        Y_ABORT_UNLESS((Type() == NScheme::NTypeIds::Int32 
+        Y_ENSURE((Type() == NScheme::NTypeIds::Int32 
                   || Type() == NScheme::NTypeIds::Date32)
-                 && Size() == sizeof(i32), "Data=%" PRIxPTR ", Type=%" PRIi64 ", Size=%" PRIi64, (ui64)Data(), (i64)Type(), (i64)Size());
+                 && Size() == sizeof(i32), "Data=" << (const void*)Data() << ", Type=" << (i64)Type() << ", Size=" << (i64)Size());
         i32 value = ReadUnaligned<i32>(reinterpret_cast<const i32*>(Data()));
         return value;
     }
 
     operator ui16() const {
-        Y_ABORT_UNLESS(Type() == NScheme::NTypeIds::Date && Size() == sizeof(ui16), "Data=%" PRIxPTR ", Type=%" PRIi64 ", Size=%" PRIi64, (ui64)Data(), (i64)Type(), (i64)Size());
+        Y_ENSURE(Type() == NScheme::NTypeIds::Date && Size() == sizeof(ui16), "Data=" << (const void*)Data() << ", Type=" << (i64)Type() << ", Size=" << (i64)Size());
         ui16 value = ReadUnaligned<ui16>(reinterpret_cast<const ui16*>(Data()));
         return value;
     }
 
     operator ui8() const {
-        Y_ABORT_UNLESS(Type() == NScheme::NTypeIds::Byte && Size() == sizeof(ui8), "Data=%" PRIxPTR ", Type=%" PRIi64 ", Size=%" PRIi64, (ui64)Data(), (i64)Type(), (i64)Size());
+        Y_ENSURE(Type() == NScheme::NTypeIds::Byte && Size() == sizeof(ui8), "Data=" << (const void*)Data() << ", Type=" << (i64)Type() << ", Size=" << (i64)Size());
         ui8 value = *reinterpret_cast<const ui8*>(Data());
         return value;
     }
 
     operator bool() const {
-        Y_ABORT_UNLESS(Type() == NScheme::NTypeIds::Bool && Size() == sizeof(bool), "Data=%" PRIxPTR ", Type=%" PRIi64 ", Size=%" PRIi64, (ui64)Data(), (i64)Type(), (i64)Size());
+        Y_ENSURE(Type() == NScheme::NTypeIds::Bool && Size() == sizeof(bool), "Data=" << (const void*)Data() << ", Type=" << (i64)Type() << ", Size=" << (i64)Size());
         bool value = *reinterpret_cast<const bool*>(Data());
         return value;
     }
 
     operator double() const {
-        Y_ABORT_UNLESS(Type() == NScheme::NTypeIds::Double && Size() == sizeof(double), "Data=%" PRIxPTR ", Type=%" PRIi64 ", Size=%" PRIi64, (ui64)Data(), (i64)Type(), (i64)Size());
+        Y_ENSURE(Type() == NScheme::NTypeIds::Double && Size() == sizeof(double), "Data=" << (const void*)Data() << ", Type=" << (i64)Type() << ", Size=" << (i64)Size());
         double value = ReadUnaligned<double>(reinterpret_cast<const double*>(Data()));
         return value;
     }
 
     operator TActorId() const {
-        Y_ABORT_UNLESS((Type() == NScheme::NTypeIds::ActorId
+        Y_ENSURE((Type() == NScheme::NTypeIds::ActorId
                || Type() == NScheme::NTypeIds::String
                || Type() == NScheme::NTypeIds::String2m
-               || Type() == NScheme::NTypeIds::String4k) && Size() == sizeof(TActorId), "Data=%" PRIxPTR ", Type=%" PRIi64 ", Size=%" PRIi64, (ui64)Data(), (i64)Type(), (i64)Size());
+               || Type() == NScheme::NTypeIds::String4k) && Size() == sizeof(TActorId), "Data=" << (const void*)Data() << ", Type=" << (i64)Type() << ", Size=" << (i64)Size());
         return *reinterpret_cast<const TActorId*>(Data());
     }
 
     operator TString() const {
-        Y_ABORT_UNLESS(Type() == NScheme::NTypeIds::Utf8
+        Y_ENSURE(Type() == NScheme::NTypeIds::Utf8
                || Type() == NScheme::NTypeIds::String
                || Type() == NScheme::NTypeIds::String2m
-               || Type() == NScheme::NTypeIds::String4k, "Data=%" PRIxPTR ", Type=%" PRIi64 ", Size=%" PRIi64, (ui64)Data(), (i64)Type(), (i64)Size());
+               || Type() == NScheme::NTypeIds::String4k, "Data=" << (const void*)Data() << ", Type=" << (i64)Type() << ", Size=" << (i64)Size());
         return TString(reinterpret_cast<const char*>(Data()), Size());
     }
 
     operator TBuffer() const {
-        Y_ABORT_UNLESS(Type() == NScheme::NTypeIds::String
+        Y_ENSURE(Type() == NScheme::NTypeIds::String
                || Type() == NScheme::NTypeIds::String2m
-               || Type() == NScheme::NTypeIds::String4k, "Data=%" PRIxPTR ", Type=%" PRIi64 ", Size=%" PRIi64, (ui64)Data(), (i64)Type(), (i64)Size());
+               || Type() == NScheme::NTypeIds::String4k, "Data=" << (const void*)Data() << ", Type=" << (i64)Type() << ", Size=" << (i64)Size());
         return TBuffer(reinterpret_cast<const char*>(Data()), Size());
     }
 
     operator std::pair<ui64, ui64>() const {
-        Y_ABORT_UNLESS(Type() == NScheme::NTypeIds::PairUi64Ui64 && Size() == sizeof(std::pair<ui64, ui64>), "Data=%" PRIxPTR ", Type=%" PRIi64 ", Size=%" PRIi64, (ui64)Data(), (i64)Type(), (i64)Size());
+        Y_ENSURE(Type() == NScheme::NTypeIds::PairUi64Ui64 && Size() == sizeof(std::pair<ui64, ui64>),
+            "Data=" << (const void*)Data() << ", Type=" << (i64)Type() << ", Size=" << (i64)Size());
         return *reinterpret_cast<const std::pair<ui64, ui64>*>(Data());
     }
 
     operator std::pair<ui64, i64>() const {
-        Y_ABORT_UNLESS(Type() == NScheme::NTypeIds::Decimal && Size() == sizeof(std::pair<ui64, ui64>), "Data=%" PRIxPTR ", Type=%" PRIi64 ", Size=%" PRIi64, (ui64)Data(), (i64)Type(), (i64)Size());
+        Y_ENSURE(Type() == NScheme::NTypeIds::Decimal && Size() == sizeof(std::pair<ui64, ui64>),
+            "Data=" << (const void*)Data() << ", Type=" << (i64)Type() << ", Size=" << (i64)Size());
         return *reinterpret_cast<const std::pair<ui64, i64>*>(Data());
     }
 
     template <typename ElementType>
     operator TVector<ElementType>() const {
         static_assert(std::is_pod<ElementType>::value, "ElementType should be a POD type");
-        Y_ABORT_UNLESS(Type() == NScheme::NTypeIds::String || Type() == NScheme::NTypeIds::String4k || Type() == NScheme::NTypeIds::String2m);
-        Y_ABORT_UNLESS(Size() % sizeof(ElementType) == 0);
+        Y_ENSURE(Type() == NScheme::NTypeIds::String || Type() == NScheme::NTypeIds::String4k || Type() == NScheme::NTypeIds::String2m);
+        Y_ENSURE(Size() % sizeof(ElementType) == 0);
         std::size_t count = Size() / sizeof(ElementType);
         const ElementType *begin = reinterpret_cast<const ElementType*>(Data());
         const ElementType *end = begin + count;
@@ -205,8 +207,8 @@ public:
     template <typename ElementType>
     void ExtractArray(THashSet<ElementType> &container) const {
         static_assert(std::is_pod<ElementType>::value, "ElementType should be a POD type");
-        Y_ABORT_UNLESS(Type() == NScheme::NTypeIds::String || Type() == NScheme::NTypeIds::String4k || Type() == NScheme::NTypeIds::String2m);
-        Y_ABORT_UNLESS(Size() % sizeof(ElementType) == 0);
+        Y_ENSURE(Type() == NScheme::NTypeIds::String || Type() == NScheme::NTypeIds::String4k || Type() == NScheme::NTypeIds::String2m);
+        Y_ENSURE(Size() % sizeof(ElementType) == 0);
         const ElementType *begin = reinterpret_cast<const ElementType*>(Data());
         const ElementType *end = begin + Size() / sizeof(ElementType);
         container.resize(Size() / sizeof(ElementType));
@@ -311,7 +313,7 @@ public:
 //    TConvertValue(const TRawTypeValue& value)
 //        : Value(reinterpret_cast<const char*>(value.Data()), value.Size())
 //    {
-//        Y_ABORT_UNLESS(value.Type() == NScheme::NTypeIds::String || value.Type() == NScheme::NTypeIds::Utf8);
+//        Y_ENSURE(value.Type() == NScheme::NTypeIds::String || value.Type() == NScheme::NTypeIds::Utf8);
 //    }
 //
 //    operator TStringBuf() const {
@@ -454,12 +456,12 @@ struct TConvertValueFromRawTypeValueToProto {
     TConvertValueFromRawTypeValueToProto(const TRawTypeValue& value)
         : Value(value)
     {
-        Y_ABORT_UNLESS(value.Type() == NScheme::NTypeIds::String);
+        Y_ENSURE(value.Type() == NScheme::NTypeIds::String);
     }
 
     operator TargetType() const {
         TargetType msg;
-        Y_ABORT_UNLESS(msg.ParseFromArray(Value.Data(), Value.Size()));
+        Y_ENSURE(msg.ParseFromArray(Value.Data(), Value.Size()));
         return msg;
     }
 };
@@ -495,14 +497,14 @@ struct TConvertValue<ColumnType, TVector<VectorType>, TRawTypeValue> {
     TVector<VectorType> Value;
 
     TConvertValue(const TRawTypeValue& value) {
-        Y_ABORT_UNLESS(value.Type() == NScheme::NTypeIds::String);
-        Y_ABORT_UNLESS(value.Size() % sizeof(VectorType) == 0);
+        Y_ENSURE(value.Type() == NScheme::NTypeIds::String);
+        Y_ENSURE(value.Size() % sizeof(VectorType) == 0);
         const size_t count = value.Size() / sizeof(VectorType);
         Value.reserve(count);
         for (TUnalignedMemoryIterator<VectorType> it(value.Data(), value.Size()); !it.AtEnd(); it.Next()) {
             Value.emplace_back(it.Cur());
         }
-        Y_ABORT_UNLESS(Value.size() == count);
+        Y_ENSURE(Value.size() == count);
     }
 
     operator const TVector<VectorType>&() const {
@@ -550,7 +552,7 @@ struct TConvertValue<ColumnType, TStringBuf, TRawTypeValue> {
     TConvertValue(const TRawTypeValue& value)
         : Value(reinterpret_cast<const char*>(value.Data()), value.Size())
     {
-        Y_ABORT_UNLESS(value.Type() == NScheme::NTypeIds::String || value.Type() == NScheme::NTypeIds::Utf8);
+        Y_ENSURE(value.Type() == NScheme::NTypeIds::String || value.Type() == NScheme::NTypeIds::Utf8);
     }
 
     operator TStringBuf() const {

--- a/ydb/core/tablet_flat/flat_dbase_annex.h
+++ b/ydb/core/tablet_flat/flat_dbase_annex.h
@@ -46,7 +46,7 @@ namespace NTable {
 
         TResult Place(ui32 table, TTag, TArrayRef<const char> data) override
         {
-            Y_ABORT_UNLESS(Lookup(table) && data.size() >= Family->Large);
+            Y_ENSURE(Lookup(table) && data.size() >= Family->Large);
 
             auto blob = NPage::TLabelWrapper::Wrap(data, EPage::Opaque, 0);
 
@@ -67,7 +67,7 @@ namespace NTable {
                 Family = Scheme.DefaultFamilyFor(Table);
                 Room = Scheme.DefaultRoomFor(Table);
 
-                Y_ABORT_UNLESS(bool(Family) == bool(Room));
+                Y_ENSURE(bool(Family) == bool(Room));
             }
 
             return nullptr != Family; /* table may be created with data tx */

--- a/ydb/core/tablet_flat/flat_dbase_apply.cpp
+++ b/ydb/core/tablet_flat/flat_dbase_apply.cpp
@@ -1,4 +1,5 @@
 #include "flat_dbase_apply.h"
+#include "util_fmt_abort.h"
 
 #include <ydb/core/base/localdb.h>
 #include <ydb/core/scheme/scheme_types_proto.h>
@@ -86,7 +87,7 @@ bool TSchemeModifier::Apply(const TAlterRecord &delta)
 
         auto codec = delta.HasCodec() ? ECodec(delta.GetCodec()) :family.Codec;
 
-        Y_ABORT_UNLESS(ui32(codec) <= 1, "Invalid page encoding code value");
+        Y_ENSURE(ui32(codec) <= 1, "Invalid page encoding code value");
 
         // FIXME: for now these changes will affect old parts on boot only (see RequestInMemPagesForPartStore)
         bool ever = delta.HasInMemory() && delta.GetInMemory();
@@ -96,7 +97,7 @@ bool TSchemeModifier::Apply(const TAlterRecord &delta)
         ui32 small = delta.HasSmall() ? delta.GetSmall() : family.Small;
         ui32 large = delta.HasLarge() ? delta.GetLarge() : family.Large;
 
-        Y_ABORT_UNLESS(ui32(cache) <= 2, "Invalid pages cache policy value");
+        Y_ENSURE(ui32(cache) <= 2, "Invalid pages cache policy value");
         if (family.Cache != cache && cache == ECache::Ever) {
             ChangeTableSetting(table, tableInfo.PendingCacheEnable, true);
         }
@@ -177,7 +178,7 @@ bool TSchemeModifier::Apply(const TAlterRecord &delta)
     } else if (action == TAlterRecord::SetCompactionPolicy) {
         changes |= SetCompactionPolicy(table, delta.GetCompactionPolicy());
     } else {
-        Y_ABORT("unknown scheme delta record type");
+        Y_TABLET_ERROR("unknown scheme delta record type");
     }
 
     if (delta.HasTableId() && changes)
@@ -188,7 +189,7 @@ bool TSchemeModifier::Apply(const TAlterRecord &delta)
 bool TSchemeModifier::AddColumnToFamily(ui32 tid, ui32 cid, ui32 family)
 {
     auto* column = Scheme.GetColumnInfo(Table(tid), cid);
-    Y_ABORT_UNLESS(column);
+    Y_ENSURE(column);
 
     if (column->Family != family) {
         PreserveTable(tid);
@@ -216,9 +217,9 @@ bool TSchemeModifier::AddTable(const TString &name, ui32 id)
             }
             return out;
         };
-        Y_VERIFY_S(itName->second == id, describeFailure());
+        Y_ENSURE(itName->second == id, describeFailure());
         // Sanity check that this table really exists
-        Y_ABORT_UNLESS(it != Scheme.Tables.end() && it->second.Name == name);
+        Y_ENSURE(it != Scheme.Tables.end() && it->second.Name == name);
         return false;
     }
 
@@ -234,7 +235,7 @@ bool TSchemeModifier::AddTable(const TString &name, ui32 id)
 
     // Creating a new table
     auto pr = Scheme.Tables.emplace(id, TTable(name, id));
-    Y_ABORT_UNLESS(pr.second);
+    Y_ENSURE(pr.second);
     it = pr.first;
     Scheme.TableNames.emplace(name, id);
 
@@ -260,7 +261,7 @@ bool TSchemeModifier::DropTable(ui32 id)
 
 bool TSchemeModifier::AddColumn(ui32 tid, const TString &name, ui32 id, ui32 type, bool notNull, TCell null)
 {
-    Y_ABORT_UNLESS(!NScheme::NTypeIds::IsParametrizedType(type));
+    Y_ENSURE(!NScheme::NTypeIds::IsParametrizedType(type));
     return AddColumnWithTypeInfo(tid, name, id, type, {}, notNull, null);
 }
 
@@ -273,7 +274,7 @@ bool TSchemeModifier::AddColumnWithTypeInfo(ui32 tid, const TString &name, ui32 
 
     NScheme::TTypeInfo typeInfo;
     TString pgTypeMod;
-    Y_ABORT_UNLESS((bool)typeInfoProto == NScheme::NTypeIds::IsParametrizedType(type));
+    Y_ENSURE((bool)typeInfoProto == NScheme::NTypeIds::IsParametrizedType(type));
     switch ((NScheme::TTypeId)type) {
     case NScheme::NTypeIds::Pg: {
         auto typeInfoMod = NScheme::TypeInfoModFromProtoColumnType(type, &*typeInfoProto);
@@ -304,10 +305,10 @@ bool TSchemeModifier::AddColumnWithTypeInfo(ui32 tid, const TString &name, ui32 
             }
             return out;
         };
-        Y_VERIFY_S(itName->second == id, describeFailure());
+        Y_ENSURE(itName->second == id, describeFailure());
         // Sanity check that this column exists and types match
-        Y_ABORT_UNLESS(it != table->Columns.end() && it->second.Name == name);
-        Y_VERIFY_S(it->second.PType == typeInfo && it->second.PTypeMod == pgTypeMod,
+        Y_ENSURE(it != table->Columns.end() && it->second.Name == name);
+        Y_ENSURE(it->second.PType == typeInfo && it->second.PTypeMod == pgTypeMod,
             "Table " << tid << " '" << table->Name << "' column " << id << " '" << name
             << "' expected type " << NScheme::TypeName(typeInfo, pgTypeMod)
             << ", existing type " << NScheme::TypeName(it->second.PType, it->second.PTypeMod));
@@ -318,7 +319,7 @@ bool TSchemeModifier::AddColumnWithTypeInfo(ui32 tid, const TString &name, ui32 
 
     // We assume column is renamed when the same id already exists
     if (it != table->Columns.end()) {
-        Y_VERIFY_S(it->second.PType == typeInfo && it->second.PTypeMod == pgTypeMod,
+        Y_ENSURE(it->second.PType == typeInfo && it->second.PTypeMod == pgTypeMod,
             "Table " << tid << " '" << table->Name << "' column " << id << " '" << it->second.Name << "' renamed to '" << name << "'"
             << " with type " << NScheme::TypeName(typeInfo, pgTypeMod)
             << ", existing type " << NScheme::TypeName(it->second.PType, it->second.PTypeMod));
@@ -329,7 +330,7 @@ bool TSchemeModifier::AddColumnWithTypeInfo(ui32 tid, const TString &name, ui32 
     }
 
     auto pr = table->Columns.emplace(id, TColumn(name, id, typeInfo, pgTypeMod, notNull));
-    Y_ABORT_UNLESS(pr.second);
+    Y_ENSURE(pr.second);
     it = pr.first;
     table->ColumnNames.emplace(name, id);
 
@@ -355,7 +356,7 @@ bool TSchemeModifier::AddColumnToKey(ui32 tid, ui32 columnId)
 {
     auto *table = Table(tid);
     auto* column = Scheme.GetColumnInfo(table, columnId);
-    Y_ABORT_UNLESS(column);
+    Y_ENSURE(column);
 
     auto keyPos = std::find(table->KeyColumns.begin(), table->KeyColumns.end(), column->Id);
     if (keyPos == table->KeyColumns.end()) {

--- a/ydb/core/tablet_flat/flat_dbase_apply.h
+++ b/ydb/core/tablet_flat/flat_dbase_apply.h
@@ -49,7 +49,7 @@ namespace NTable {
         TTable* Table(ui32 tid) const
         {
             auto* table = Scheme.GetTableInfo(tid);
-            Y_ABORT_UNLESS(table, "Acccessing table that doesn't exist");
+            Y_ENSURE(table, "Acccessing table that doesn't exist");
             return table;
         }
 

--- a/ydb/core/tablet_flat/flat_dbase_scheme.cpp
+++ b/ydb/core/tablet_flat/flat_dbase_scheme.cpp
@@ -86,7 +86,7 @@ TAutoPtr<TSchemeChanges> TScheme::GetSnapshot() const {
 
 TAlter& TAlter::Merge(const TSchemeChanges &log)
 {
-    Y_ABORT_UNLESS(&Log != &log, "Cannot merge changes onto itself");
+    Y_ENSURE(&Log != &log, "Cannot merge changes onto itself");
 
     int added = log.DeltaSize();
     if (added > 0) {
@@ -122,7 +122,7 @@ TAlter& TAlter::DropTable(ui32 id)
 
 TAlter& TAlter::AddColumn(ui32 table, const TString& name, ui32 id, ui32 type, bool notNull, TCell null)
 {
-    Y_ABORT_UNLESS(!NScheme::NTypeIds::IsParametrizedType(type));
+    Y_ENSURE(!NScheme::NTypeIds::IsParametrizedType(type));
     return AddColumnWithTypeInfo(table, name, id, type, {}, notNull, null);
 }
 
@@ -139,7 +139,7 @@ TAlter& TAlter::AddColumnWithTypeInfo(ui32 table, const TString& name, ui32 id, 
     if (!null.IsNull())
         delta.SetDefault(null.Data(), null.Size());
 
-    Y_ABORT_UNLESS((bool)typeInfoProto == NScheme::NTypeIds::IsParametrizedType(type));
+    Y_ENSURE((bool)typeInfoProto == NScheme::NTypeIds::IsParametrizedType(type));
     if (typeInfoProto) {
         *delta.MutableColumnTypeInfo() = *typeInfoProto;
     }
@@ -216,7 +216,7 @@ TAlter& TAlter::SetFamilyBlobs(ui32 table, ui32 family, ui32 small, ui32 large)
 
 TAlter& TAlter::SetRoom(ui32 table, ui32 room, ui32 main, const TSet<ui32>& blobs, ui32 outer)
 {
-    Y_ABORT_UNLESS(!blobs.empty(), "Room must have at least one external blob channel");
+    Y_ENSURE(!blobs.empty(), "Room must have at least one external blob channel");
 
     auto *delta = Log.AddDelta();
 
@@ -363,7 +363,7 @@ TAlter& TAlter::ApplyLastRecord()
 {
     if (Sink) {
         int deltasCount = Log.DeltaSize();
-        Y_ABORT_UNLESS(deltasCount > 0);
+        Y_ENSURE(deltasCount > 0);
 
         if (!Sink->ApplyAlterRecord(Log.GetDelta(deltasCount - 1))) {
             Log.MutableDelta()->RemoveLast();

--- a/ydb/core/tablet_flat/flat_dbase_sz_env.h
+++ b/ydb/core/tablet_flat/flat_dbase_sz_env.h
@@ -18,7 +18,7 @@ namespace NTable {
 
         TResult Locate(const TMemTable*, ui64, ui32) override
         {
-            Y_ABORT("IPages::Locate(TMemTable*, ...) shouldn't be used here");
+            Y_TABLET_ERROR("IPages::Locate(TMemTable*, ...) shouldn't be used here");
         }
 
         TResult Locate(const TPart *part, ui64 ref, ELargeObj lob) override

--- a/ydb/core/tablet_flat/flat_exec_broker.cpp
+++ b/ydb/core/tablet_flat/flat_exec_broker.cpp
@@ -11,7 +11,7 @@ TBroker::TBroker(IOps* ops, TIntrusivePtr<TIdEmitter> emitter)
 { }
 
 TTaskId TBroker::SubmitTask(TString name, TResourceParams params, TResourceConsumer consumer) {
-    Y_ABORT_UNLESS(consumer, "Resource consumer cannot be null");
+    Y_ENSURE(consumer, "Resource consumer cannot be null");
     TTaskId taskId = Emitter->Do();
     Submitted[taskId].swap(consumer);
     SendToBroker(new TEvResourceBroker::TEvSubmitTask(

--- a/ydb/core/tablet_flat/flat_exec_memory.h
+++ b/ydb/core/tablet_flat/flat_exec_memory.h
@@ -278,7 +278,7 @@ namespace NTabletFlatExecutor {
 
         void AllocStatic(TSeat &seat, ui64 newLimit)
         {
-            Y_ABORT_UNLESS(newLimit >= seat.CurrentTxDataLimit + seat.MemoryTouched);
+            Y_ENSURE(newLimit >= seat.CurrentTxDataLimit + seat.MemoryTouched);
 
             Used.Static -= seat.CurrentMemoryLimit;
             seat.CurrentMemoryLimit = newLimit;
@@ -296,7 +296,7 @@ namespace NTabletFlatExecutor {
             if (seat.TaskId)
                 return;
 
-            Y_ABORT_UNLESS(seat.CurrentMemoryLimit >= hold);
+            Y_ENSURE(seat.CurrentMemoryLimit >= hold);
             ui64 release = seat.CurrentMemoryLimit - hold;
             Used.Static -= release;
 

--- a/ydb/core/tablet_flat/flat_exec_seat.cpp
+++ b/ydb/core/tablet_flat/flat_exec_seat.cpp
@@ -5,7 +5,7 @@ namespace NTabletFlatExecutor {
 
     void TSeat::Complete(const TActorContext& ctx, bool isRW) {
         if (Y_UNLIKELY(IsTerminated())) {
-            Y_ABORT_UNLESS(!isRW, "Terminating a read-write transaction");
+            Y_ENSURE(!isRW, "Terminating a read-write transaction");
             Self->Terminate(TerminationReason, ctx);
             Self->TxSpan.EndError("Terminated");
             return;

--- a/ydb/core/tablet_flat/flat_executor.cpp
+++ b/ydb/core/tablet_flat/flat_executor.cpp
@@ -23,6 +23,7 @@
 #include "flat_abi_evol.h"
 #include "probes.h"
 #include "shared_sausagecache.h"
+#include "util_fmt_abort.h"
 #include "util_fmt_desc.h"
 
 #include <ydb/core/base/appdata.h>
@@ -244,7 +245,7 @@ void TExecutor::RecreatePageCollectionsCache()
         while (it != TransactionWaitPads.end()) {
             it->second->WaitingSpan.EndOk();
             TSeat* seat = it->second->Seat;
-            Y_ABORT_UNLESS(seat->State == ESeatState::Waiting);
+            Y_ENSURE(seat->State == ESeatState::Waiting);
             seat->State = ESeatState::None;
             TransactionWaitPads.erase(it++);
 
@@ -362,11 +363,11 @@ void TExecutor::UpdateCompactions() {
 }
 
 void TExecutor::Handle(TEvTablet::TEvCheckBlobstorageStatusResult::TPtr &ev) {
-    Y_ABORT_UNLESS(HasYellowCheckInFly);
+    Y_ENSURE(HasYellowCheckInFly);
     HasYellowCheckInFly = false;
 
     const auto* info = Owner->Info();
-    Y_ABORT_UNLESS(info);
+    Y_ENSURE(info);
 
     TVector<ui32> lightYellowMoveGroups = std::move(ev->Get()->LightYellowMoveGroups);
     SortUnique(lightYellowMoveGroups);
@@ -411,16 +412,16 @@ void TExecutor::ActivateFollower(const TActorContext &ctx) {
     auto loadedState = BootLogic->ExtractState();
     BootLogic.Destroy();
 
-    Y_ABORT_UNLESS(Counters, "Expected to have Counters initialized during Boot processing");
+    Y_ENSURE(Counters, "Expected to have Counters initialized during Boot processing");
 
-    Y_ABORT_UNLESS(!GcLogic);
-    Y_ABORT_UNLESS(!LogicRedo);
-    Y_ABORT_UNLESS(!LogicAlter);
+    Y_ENSURE(!GcLogic);
+    Y_ENSURE(!LogicRedo);
+    Y_ENSURE(!LogicAlter);
 
     Database = loadedState->Database;
     BorrowLogic = loadedState->Loans;
 
-    Y_ABORT_UNLESS(!CompactionLogic);
+    Y_ENSURE(!CompactionLogic);
 
     ResourceMetrics = MakeHolder<NMetrics::TResourceMetrics>(Owner->TabletID(), FollowerId, Launcher);
 
@@ -454,7 +455,7 @@ void TExecutor::Active(const TActorContext &ctx) {
     auto loadedState = BootLogic->ExtractState();
     BootLogic.Destroy();
 
-    Y_ABORT_UNLESS(Counters, "Expected to have Counters initialized during Boot processing");
+    Y_ENSURE(Counters, "Expected to have Counters initialized during Boot processing");
 
     CommitManager = loadedState->CommitManager;
     Database = loadedState->Database;
@@ -548,7 +549,7 @@ void TExecutor::TranscriptBootOpResult(ui32 res, const TActorContext &ctx) {
 
         return Broken();
     default:
-        Y_ABORT("unknown boot result");
+        Y_TABLET_ERROR("unknown boot result");
     }
 }
 
@@ -567,13 +568,13 @@ void TExecutor::TranscriptFollowerBootOpResult(ui32 res, const TActorContext &ct
 
         return Broken();
     default:
-        Y_ABORT("unknown boot result");
+        Y_TABLET_ERROR("unknown boot result");
     }
 }
 
 std::unique_ptr<TSeat> TExecutor::RemoveTransaction(ui64 id) {
     auto it = Transactions.find(id);
-    Y_ABORT_UNLESS(it != Transactions.end(), "Cannot find transaction %" PRIu64, id);
+    Y_ENSURE(it != Transactions.end(), "Cannot find transaction " << id);
     auto res = std::move(it->second);
     res->State = ESeatState::Done;
     Transactions.erase(it);
@@ -624,7 +625,7 @@ void TExecutor::PlanTransactionActivation() {
     const ui64 limitTxInFly = Scheme().Executor.LimitInFlyTx;
     while (PendingQueue && (!limitTxInFly || (Stats->TxInFly - Stats->TxPending < limitTxInFly))) {
         TSeat* seat = PendingQueue.PopFront();
-        Y_ABORT_UNLESS(seat->State == ESeatState::Pending);
+        Y_ENSURE(seat->State == ESeatState::Pending);
         seat->State = ESeatState::None;
         seat->FinishPendingSpan();
         --Stats->TxPending;
@@ -650,7 +651,7 @@ void TExecutor::ActivateWaitingTransactions(TPrivatePageCache::TPage::TWaitQueue
             if (auto it = TransactionWaitPads.find(waitPad); it != TransactionWaitPads.end()) {
                 it->second->WaitingSpan.EndOk();
                 TSeat* seat = it->second->Seat;
-                Y_ABORT_UNLESS(seat->State == ESeatState::Waiting);
+                Y_ENSURE(seat->State == ESeatState::Waiting);
                 seat->State = ESeatState::None;
                 TransactionWaitPads.erase(it);
                 if (seat->Cancelled) {
@@ -660,7 +661,7 @@ void TExecutor::ActivateWaitingTransactions(TPrivatePageCache::TPage::TWaitQueue
                     EnqueueActivation(seat, activate);
                 }
             } else {
-                Y_Fail("Unexpected wait pad triggered");
+                Y_TABLET_ERROR("Unexpected wait pad triggered");
             }
         }
         if (cancelled && activate) {
@@ -721,7 +722,7 @@ void TExecutor::DropSingleCache(const TLogoBlobID &label)
     auto pageCollection = PrivatePageCache->GetPageCollection(label);
 
     ui64 stickySize = pageCollection->GetStickySize();
-    Y_ABORT_UNLESS(StickyPagesMemory >= stickySize);
+    Y_ENSURE(StickyPagesMemory >= stickySize);
     StickyPagesMemory -= stickySize;
 
     auto toActivate = PrivatePageCache->ForgetPageCollection(pageCollection);
@@ -803,11 +804,11 @@ TExecutorCaches TExecutor::CleanupState() {
     PostponedFollowerUpdates.clear();
     PendingPartSwitches.clear();
     ReadyPartSwitches = 0;
-    Y_ABORT_UNLESS(!LogicRedo);
+    Y_ENSURE(!LogicRedo);
     Database.Destroy();
-    Y_ABORT_UNLESS(!GcLogic);
-    Y_ABORT_UNLESS(!LogicAlter);
-    Y_ABORT_UNLESS(!CompactionLogic);
+    Y_ENSURE(!GcLogic);
+    Y_ENSURE(!LogicAlter);
+    Y_ENSURE(!CompactionLogic);
     BorrowLogic.Destroy();
     DataCleanupLogic.Destroy();
 
@@ -855,7 +856,7 @@ void TExecutor::Boot(TEvTablet::TEvBoot::TPtr &ev, const TActorContext &ctx) {
 }
 
 void TExecutor::FollowerBoot(TEvTablet::TEvFBoot::TPtr &ev, const TActorContext &ctx) {
-    Y_ABORT_UNLESS(CurrentStateFunc() == &TThis::StateInit
+    Y_ENSURE(CurrentStateFunc() == &TThis::StateInit
         || CurrentStateFunc() == &TThis::StateFollowerBoot
         || CurrentStateFunc() == &TThis::StateFollower);
 
@@ -896,10 +897,10 @@ void TExecutor::FollowerBoot(TEvTablet::TEvFBoot::TPtr &ev, const TActorContext 
 }
 
 void TExecutor::Restored(TEvTablet::TEvRestored::TPtr &ev, const TActorContext &ctx) {
-    Y_ABORT_UNLESS(CurrentStateFunc() == &TThis::StateBoot && BootLogic);
+    Y_ENSURE(CurrentStateFunc() == &TThis::StateBoot && BootLogic);
 
     TEvTablet::TEvRestored *msg = ev->Get();
-    Y_ABORT_UNLESS(Generation() == msg->Generation);
+    Y_ENSURE(Generation() == msg->Generation);
 
     const TExecutorBootLogic::EOpResult res = BootLogic->ReceiveRestored(ev);
     return TranscriptBootOpResult(res, ctx);
@@ -913,28 +914,28 @@ void TExecutor::DetachTablet() {
 
 void TExecutor::FollowerUpdate(THolder<TEvTablet::TFUpdateBody> upd) {
     if (BootLogic) {
-        Y_ABORT_UNLESS(CurrentStateFunc() == &TThis::StateFollowerBoot);
+        Y_ENSURE(CurrentStateFunc() == &TThis::StateFollowerBoot);
         PostponedFollowerUpdates.emplace_back(std::move(upd));
     } else if (PendingPartSwitches) {
-        Y_ABORT_UNLESS(CurrentStateFunc() == &TThis::StateFollower);
+        Y_ENSURE(CurrentStateFunc() == &TThis::StateFollower);
         PostponedFollowerUpdates.emplace_back(std::move(upd));
     } else {
-        Y_ABORT_UNLESS(CurrentStateFunc() == &TThis::StateFollower);
-        Y_ABORT_UNLESS(PostponedFollowerUpdates.empty());
+        Y_ENSURE(CurrentStateFunc() == &TThis::StateFollower);
+        Y_ENSURE(PostponedFollowerUpdates.empty());
         ApplyFollowerUpdate(std::move(upd));
     }
 }
 
 void TExecutor::FollowerAuxUpdate(TString upd) {
     if (BootLogic) {
-        Y_ABORT_UNLESS(CurrentStateFunc() == &TThis::StateFollowerBoot);
+        Y_ENSURE(CurrentStateFunc() == &TThis::StateFollowerBoot);
         PostponedFollowerUpdates.emplace_back(new TEvTablet::TFUpdateBody(std::move(upd)));
     } else if (PendingPartSwitches) {
-        Y_ABORT_UNLESS(CurrentStateFunc() == &TThis::StateFollower);
+        Y_ENSURE(CurrentStateFunc() == &TThis::StateFollower);
         PostponedFollowerUpdates.emplace_back(new TEvTablet::TFUpdateBody(std::move(upd)));
     } else {
-        Y_ABORT_UNLESS(CurrentStateFunc() == &TThis::StateFollower);
-        Y_ABORT_UNLESS(PostponedFollowerUpdates.empty());
+        Y_ENSURE(CurrentStateFunc() == &TThis::StateFollower);
+        Y_ENSURE(PostponedFollowerUpdates.empty());
         ApplyFollowerAuxUpdate(upd);
     }
 }
@@ -961,13 +962,13 @@ void TExecutor::FollowerDetached(ui32 totalFollowers) {
 }
 
 void TExecutor::FollowerSyncComplete() {
-    Y_ABORT_UNLESS(CurrentStateFunc() == &TThis::StateWork || CurrentStateFunc() == &TThis::StateBoot);
+    Y_ENSURE(CurrentStateFunc() == &TThis::StateWork || CurrentStateFunc() == &TThis::StateBoot);
     if (GcLogic)
         GcLogic->FollowersSyncComplete(false);
     else if (BootLogic)
         BootLogic->FollowersSyncComplete();
     else
-        Y_ABORT("must not happens");
+        Y_TABLET_ERROR("must not happens");
 }
 
 void TExecutor::FollowerGcApplied(ui32 step, TDuration followerSyncDelay) {
@@ -976,7 +977,7 @@ void TExecutor::FollowerGcApplied(ui32 step, TDuration followerSyncDelay) {
     }
 
     auto it = InFlyCompactionGcBarriers.find(step);
-    Y_ABORT_UNLESS(it != InFlyCompactionGcBarriers.end());
+    Y_ENSURE(it != InFlyCompactionGcBarriers.end());
     CheckCollectionBarrier(it->second);
     InFlyCompactionGcBarriers.erase(it);
 
@@ -1016,7 +1017,7 @@ void TExecutor::ApplyFollowerPostponedUpdates() {
 
 void TExecutor::ApplyFollowerUpdate(THolder<TEvTablet::TFUpdateBody> update) {
     if (update->Step <= Step0 || CommitManager) {
-        Y_Fail(
+        Y_TABLET_ERROR(
             NFmt::Do(*this) << " got unexpected follower update to Step "
             << update->Step << ", " << NFmt::If(CommitManager.Get()));
     }
@@ -1036,7 +1037,7 @@ void TExecutor::ApplyFollowerUpdate(THolder<TEvTablet::TFUpdateBody> update) {
     TVector<NPageCollection::TMemGlob> annex;
 
     if (update->EmbeddedBody) { // we embed only regular updates
-        Y_ABORT_UNLESS(update->References.empty());
+        Y_ENSURE(update->References.empty());
         dataUpdate = update->EmbeddedBody;
     } else {
         for (auto &xpair : update->References) {
@@ -1044,7 +1045,7 @@ void TExecutor::ApplyFollowerUpdate(THolder<TEvTablet::TFUpdateBody> update) {
             const TString &body = xpair.second;
 
             const NBoot::TCookie cookie(id.Cookie());
-            Y_ABORT_UNLESS(cookie.Type() == NBoot::TCookie::EType::Log);
+            Y_ENSURE(cookie.Type() == NBoot::TCookie::EType::Log);
 
             if (NBoot::TCookie::CookieRangeRaw().Has(cookie.Raw)) {
                 auto group = Owner->Info()->GroupFor(id.Channel(), id.Generation());
@@ -1077,7 +1078,7 @@ void TExecutor::ApplyFollowerUpdate(THolder<TEvTablet::TFUpdateBody> update) {
                 // ignore
                 break;
             default:
-                Y_ABORT("unsupported blob kind");
+                Y_TABLET_ERROR("unsupported blob kind");
             }
         }
     }
@@ -1117,8 +1118,8 @@ void TExecutor::ApplyFollowerUpdate(THolder<TEvTablet::TFUpdateBody> update) {
 
         if (update->AuxPayload) {
             const TString auxBody = NPageCollection::TSlicer::Lz4()->Decode(update->AuxPayload);
-            Y_ABORT_UNLESS(auxProto.ParseFromString(auxBody));
-            Y_ABORT_UNLESS(auxProto.BySwitchAuxSize() <= partSwitches.size());
+            Y_ENSURE(auxProto.ParseFromString(auxBody));
+            Y_ENSURE(auxProto.BySwitchAuxSize() <= partSwitches.size());
         }
 
         bool hadPendingPartSwitches = bool(PendingPartSwitches);
@@ -1131,7 +1132,7 @@ void TExecutor::ApplyFollowerUpdate(THolder<TEvTablet::TFUpdateBody> update) {
 
             const NKikimrExecutorFlat::TFollowerPartSwitchAux::TBySwitch *aux = nullptr;
             if (proto.HasIntroducedParts() || proto.HasIntroducedTxStatus()) {
-                Y_ABORT_UNLESS(nextAuxIdx < auxProto.BySwitchAuxSize());
+                Y_ENSURE(nextAuxIdx < auxProto.BySwitchAuxSize());
                 aux = &auxProto.GetBySwitchAux(nextAuxIdx++);
             }
 
@@ -1175,7 +1176,7 @@ void TExecutor::RequestFromSharedCache(TAutoPtr<NPageCollection::TFetch> fetch,
     NBlockIO::EPriority priority,
     EPageCollectionRequest requestCategory)
 {
-    Y_ABORT_UNLESS(fetch->Pages.size() > 0, "Got TFetch req w/o any page");
+    Y_ENSURE(fetch->Pages.size() > 0, "Got TFetch req w/o any page");
 
     Send(MakeSharedPageCacheId(), new NSharedCache::TEvRequest(
         priority,
@@ -1194,7 +1195,7 @@ void TExecutor::AddFollowerPartSwitch(
     partSwitch.Step = step;
 
     if (switchProto.HasIntroducedParts() && switchProto.GetIntroducedParts().BundlesSize()) {
-        Y_ABORT_UNLESS(aux && aux->HotBundlesSize() == switchProto.GetIntroducedParts().BundlesSize());
+        Y_ENSURE(aux && aux->HotBundlesSize() == switchProto.GetIntroducedParts().BundlesSize());
         for (auto x : xrange(aux->HotBundlesSize())) {
             NTable::TPartComponents c = TPageCollectionProtoHelper::MakePageCollectionComponents(aux->GetHotBundles(x));
             PrepareExternalPart(partSwitch, std::move(c));
@@ -1202,7 +1203,7 @@ void TExecutor::AddFollowerPartSwitch(
     }
 
     if (switchProto.HasIntroducedTxStatus()) {
-        Y_ABORT_UNLESS(aux && aux->HotTxStatusSize() == switchProto.GetIntroducedTxStatus().TxStatusSize());
+        Y_ENSURE(aux && aux->HotTxStatusSize() == switchProto.GetIntroducedTxStatus().TxStatusSize());
         for (const auto &x : aux->GetHotTxStatus()) {
             auto dataId = TLargeGlobIdProto::Get(x.GetDataId());
             auto epoch = NTable::TEpoch(x.GetEpoch());
@@ -1253,7 +1254,7 @@ void TExecutor::AddFollowerPartSwitch(
 }
 
 bool TExecutor::PrepareExternalPart(TPendingPartSwitch &partSwitch, NTable::TPartComponents &&pc) {
-    Y_ABORT_UNLESS(pc);
+    Y_ENSURE(pc);
 
     const ui32 tableId = partSwitch.TableId;
     const auto& dbScheme = Database->GetScheme();
@@ -1304,7 +1305,7 @@ bool TExecutor::PrepareExternalPart(TPendingPartSwitch &partSwitch, TPendingPart
 
     if (auto* stage = bundle.GetStage<TPendingPartSwitch::TLoaderStage>()) {
         if (auto fetch = stage->Loader.Run({.PreloadIndex = true, .PreloadData = PreloadTablesData.contains(partSwitch.TableId)})) {
-            Y_ABORT_UNLESS(fetch.size() == 1, "Cannot handle loads from more than one page collection");
+            Y_ENSURE(fetch.size() == 1, "Cannot handle loads from more than one page collection");
 
             for (auto req : fetch) {
                 stage->Fetching = req->PageCollection.Get();
@@ -1320,7 +1321,7 @@ bool TExecutor::PrepareExternalPart(TPendingPartSwitch &partSwitch, TPendingPart
         return false;
     }
 
-    Y_ABORT("Unexpected PrepareExternalPart called");
+    Y_TABLET_ERROR("Unexpected PrepareExternalPart called");
 }
 
 bool TExecutor::PrepareExternalTxStatus(
@@ -1353,7 +1354,7 @@ bool TExecutor::PrepareExternalTxStatus(TPendingPartSwitch &partSwitch, TPending
         return false;
     }
 
-    Y_ABORT("Unexpected PrepareExternalTxStatus call");
+    Y_TABLET_ERROR("Unexpected PrepareExternalTxStatus call");
 }
 
 void TExecutor::OnBlobLoaded(const TLogoBlobID& id, TString body, uintptr_t cookie) {
@@ -1372,25 +1373,25 @@ void TExecutor::OnBlobLoaded(const TLogoBlobID& id, TString body, uintptr_t cook
     for (auto& waiter : waiters) {
         if (auto* r = waiter.GetWaiter<TPendingPartSwitch::TNewBundleWaiter>()) {
             auto* stage = r->Bundle->GetStage<TPendingPartSwitch::TMetaStage>();
-            Y_ABORT_UNLESS(stage && !stage->Finished(),
-                "Loaded blob %s for a bundle in an unexpected state", id.ToString().c_str());
+            Y_ENSURE(stage && !stage->Finished(),
+                "Loaded blob " << id << " for a bundle in an unexpected state");
             if (stage->Accept(r->Loader, id, body)) {
-                Y_ABORT_UNLESS(stage->Finished());
+                Y_ENSURE(stage->Finished());
                 waiting |= PrepareExternalPart(partSwitch, *r->Bundle);
             }
             continue;
         }
         if (auto* r = waiter.GetWaiter<TPendingPartSwitch::TNewTxStatusWaiter>()) {
             auto* stage = r->TxStatus->GetStage<TPendingPartSwitch::TTxStatusLoadStage>();
-            Y_ABORT_UNLESS(stage && !stage->Finished(),
-                "Loaded blob %s for a tx status in an unexpected state", id.ToString().c_str());
+            Y_ENSURE(stage && !stage->Finished(),
+                "Loaded blob " << id << " for a tx status in an unexpected state");
             if (stage->Accept(id, body)) {
-                Y_ABORT_UNLESS(stage->Finished());
+                Y_ENSURE(stage->Finished());
                 waiting |= PrepareExternalTxStatus(partSwitch, *r->TxStatus);
             }
             continue;
         }
-        Y_ABORT("Loaded blob %s for an unsupported waiter", id.ToString().c_str());
+        Y_TABLET_ERROR("Loaded blob " << id << " for an unsupported waiter");
     }
 
     PendingBlobQueue.SendRequests(SelfId());
@@ -1508,7 +1509,7 @@ void TExecutor::ApplyExternalPartSwitch(TPendingPartSwitch &partSwitch) {
 
     for (auto &bundle : partSwitch.NewBundles) {
         auto* stage = bundle.GetStage<TPendingPartSwitch::TResultStage>();
-        Y_ABORT_UNLESS(stage && stage->PartView, "Missing bundle result in part switch");
+        Y_ENSURE(stage && stage->PartView, "Missing bundle result in part switch");
         AddCachesOfBundle(stage->PartView);
         if (stickyColumns) {
             RequestInMemPagesForPartStore(partSwitch.TableId, stage->PartView, stickyColumns);
@@ -1522,7 +1523,7 @@ void TExecutor::ApplyExternalPartSwitch(TPendingPartSwitch &partSwitch) {
     newTxStatus.reserve(partSwitch.NewTxStatus.size());
     for (auto &txStatus : partSwitch.NewTxStatus) {
         auto* stage = txStatus.GetStage<TPendingPartSwitch::TTxStatusResultStage>();
-        Y_ABORT_UNLESS(stage && stage->TxStatus, "Missing tx status result in part switch");
+        Y_ENSURE(stage && stage->TxStatus, "Missing tx status result in part switch");
         newTxStatus.push_back(std::move(stage->TxStatus));
     }
 
@@ -1530,9 +1531,8 @@ void TExecutor::ApplyExternalPartSwitch(TPendingPartSwitch &partSwitch) {
         NTable::TBundleSlicesMap updatedBundles;
         for (auto &change : partSwitch.Changed) {
             auto overlay = NTable::TOverlay::Decode(change.Legacy, change.Opaque);
-            Y_ABORT_UNLESS(overlay.Slices && *overlay.Slices,
-                "Change for bundle %s has unexpected empty slices",
-                change.Label.ToString().data());
+            Y_ENSURE(overlay.Slices && *overlay.Slices,
+                "Change for bundle " << change.Label << " has unexpected empty slices");
             updatedBundles[change.Label] = std::move(overlay.Slices);
         }
 
@@ -1560,12 +1560,12 @@ void TExecutor::ApplyExternalPartSwitch(TPendingPartSwitch &partSwitch) {
         auto subset = Database->PartSwitchSubset(partSwitch.TableId, partSwitch.Head, partSwitch.Leaving, partSwitch.LeavingTxStatus);
 
         if (partSwitch.Head != subset->Head) {
-            Y_ABORT("Follower table epoch head has diverged from leader");
+            Y_TABLET_ERROR("Follower table epoch head has diverged from leader");
         } else if (*subset && !subset->IsStickedToHead()) {
-            Y_ABORT("Follower table replace subset isn't sticked to head");
+            Y_TABLET_ERROR("Follower table replace subset isn't sticked to head");
         }
 
-        Y_ABORT_UNLESS(newColdParts.empty(), "Unexpected cold part at a follower");
+        Y_ENSURE(newColdParts.empty(), "Unexpected cold part at a follower");
         Database->Replace(partSwitch.TableId, *subset, std::move(newParts), std::move(newTxStatus));
 
         for (auto &gone : subset->Flatten)
@@ -1620,7 +1620,7 @@ void TExecutor::ApplyExternalPartSwitch(TPendingPartSwitch &partSwitch) {
             auto srcSubset = Database->PartSwitchSubset(sourceTable, NTable::TEpoch::Zero(), state.Bundles, { });
             TVector<NTable::TPartView> rebased(Reserve(srcSubset->Flatten.size()));
             for (const auto& partView : srcSubset->Flatten) {
-                Y_ABORT_UNLESS(!partView->TxIdStats, "Cannot move parts with uncommitted deltas");
+                Y_ENSURE(!partView->TxIdStats, "Cannot move parts with uncommitted deltas");
                 NTable::TEpoch epoch = state.BundleToEpoch.Value(partView->Label, partView->Epoch);
                 rebased.push_back(partView.CloneWithEpoch(epoch));
             }
@@ -1658,7 +1658,7 @@ TExecutor::TLeaseCommit* TExecutor::AttachLeaseCommit(TLogCommit* commit, bool f
 
         TString data;
         bool ok = proto.SerializeToString(&data);
-        Y_ABORT_UNLESS(ok);
+        Y_ENSURE(ok);
 
         commit->Metadata.emplace_back(ui32(NBoot::ELogCommitMeta::LeaseInfo), std::move(data));
         LeaseDurationUpdated = false;
@@ -1688,14 +1688,14 @@ TExecutor::TLeaseCommit* TExecutor::AttachLeaseCommit(TLogCommit* commit, bool f
 }
 
 TExecutor::TLeaseCommit* TExecutor::EnsureReadOnlyLease(TMonotonic at) {
-    Y_ABORT_UNLESS(Stats->IsActive && !Stats->IsFollower());
-    Y_ABORT_UNLESS(at >= LeaseEnd);
+    Y_ENSURE(Stats->IsActive && !Stats->IsFollower());
+    Y_ENSURE(at >= LeaseEnd);
 
     if (!LeaseEnabled) {
         // Automatically enable leases
         LeaseEnabled = true;
         LeaseDuration = Owner->ReadOnlyLeaseDuration();
-        Y_ABORT_UNLESS(LeaseDuration);
+        Y_ENSURE(LeaseDuration);
         LeaseDurationUpdated = true;
     }
 
@@ -1724,7 +1724,7 @@ TExecutor::TLeaseCommit* TExecutor::EnsureReadOnlyLease(TMonotonic at) {
 }
 
 void TExecutor::ConfirmReadOnlyLease(TMonotonic at) {
-    Y_ABORT_UNLESS(Stats->IsActive && !Stats->IsFollower());
+    Y_ENSURE(Stats->IsActive && !Stats->IsFollower());
     LeaseUsed = true;
 
     if (LeaseEnabled && at < LeaseEnd) {
@@ -1735,7 +1735,7 @@ void TExecutor::ConfirmReadOnlyLease(TMonotonic at) {
 }
 
 void TExecutor::ConfirmReadOnlyLease(TMonotonic at, std::function<void()> callback) {
-    Y_ABORT_UNLESS(Stats->IsActive && !Stats->IsFollower());
+    Y_ENSURE(Stats->IsActive && !Stats->IsFollower());
     LeaseUsed = true;
 
     if (LeaseEnabled && at < LeaseEnd) {
@@ -1820,7 +1820,7 @@ ui64 TExecutor::DoExecute(TAutoPtr<ITransaction> self, ETxMode mode) {
             return uniqId;
     }
 
-    Y_FAIL("Unimplemented transaction mode");
+    Y_TABLET_ERROR("Unimplemented transaction mode");
 }
 
 void TExecutor::Execute(TAutoPtr<ITransaction> self, const TActorContext &ctx) {
@@ -1853,19 +1853,19 @@ bool TExecutor::CancelTransaction(ui64 id) {
 
         case ESeatState::Active:
             ActivationQueue.Remove(seat);
-            Y_ABORT_UNLESS(ActivateTransactionWaiting > 0);
+            Y_ENSURE(ActivateTransactionWaiting > 0);
             --ActivateTransactionWaiting;
             break;
 
         case ESeatState::ActiveLow:
             ActivationLowQueue.Remove(seat);
-            Y_ABORT_UNLESS(ActivateLowTransactionWaiting > 0);
+            Y_ENSURE(ActivateLowTransactionWaiting > 0);
             --ActivateLowTransactionWaiting;
             break;
 
         case ESeatState::Pending:
             PendingQueue.Remove(seat);
-            Y_ABORT_UNLESS(Stats->TxPending > 0);
+            Y_ENSURE(Stats->TxPending > 0);
             --Stats->TxPending;
             break;
 
@@ -1975,14 +1975,14 @@ void TExecutor::ExecuteTransaction(TSeat* seat) {
         // Make sure transaction is properly destroyed
         RemoveTransaction(seat->UniqID);
     } else if (done) {
-        Y_ABORT_UNLESS(!txc.IsRescheduled());
-        Y_ABORT_UNLESS(!seat->RequestedMemory);
+        Y_ENSURE(!txc.IsRescheduled());
+        Y_ENSURE(!seat->RequestedMemory);
         seat->OnPersistent = std::move(prod.OnPersistent);
         CommitTransactionLog(RemoveTransaction(seat->UniqID), env, prod.Change, cpuTimer);
     } else {
-        Y_ABORT_UNLESS(!seat->CapturedMemory);
+        Y_ENSURE(!seat->CapturedMemory);
         if (!PrivatePageCache->GetStats().CurrentCacheMisses && !seat->RequestedMemory && !txc.IsRescheduled()) {
-            Y_Fail(NFmt::Do(*this) << " " << NFmt::Do(*seat) << " type "
+            Y_TABLET_ERROR(NFmt::Do(*this) << " " << NFmt::Do(*seat) << " type "
                     << NFmt::Do(*seat->Self) << " postponed w/o demands");
         }
         PostponeTransaction(seat, env, prod.Change, cpuTimer);
@@ -1994,7 +1994,7 @@ void TExecutor::ExecuteTransaction(TSeat* seat) {
 }
 
 void TExecutor::UnpinTransactionPages(TSeat &seat) {
-    Y_ABORT_UNLESS(TransactionPagesMemory >= seat.MemoryTouched);
+    Y_ENSURE(TransactionPagesMemory >= seat.MemoryTouched);
     TransactionPagesMemory -= seat.MemoryTouched;
 
     size_t unpinnedPages = 0;
@@ -2226,8 +2226,8 @@ void TExecutor::CommitTransactionLog(std::unique_ptr<TSeat> seat, TPageCollectio
             Counters->Simple()[TExecutorCounters::DB_TX_IN_FLY] = Stats->TxInFly;
         }
     } else {
-        Y_ABORT_UNLESS(!Stats->IsFollower());
-        Y_ABORT_UNLESS(!seat->IsTerminated(), "Read-write transactions cannot be terminated");
+        Y_ENSURE(!Stats->IsFollower());
+        Y_ENSURE(!seat->IsTerminated(), "Read-write transactions cannot be terminated");
 
         const bool allowBatching = Scheme().Executor.AllowLogBatching;
         const bool force = !allowBatching
@@ -2243,14 +2243,14 @@ void TExecutor::CommitTransactionLog(std::unique_ptr<TSeat> seat, TPageCollectio
 
         auto commitResult = LogicRedo->CommitRWTransaction(std::move(seat), *change, force);
 
-        Y_ABORT_UNLESS(!force || commitResult.Commit);
+        Y_ENSURE(!force || commitResult.Commit);
         auto *commit = commitResult.Commit.Get(); // could be nullptr
 
         for (auto& pr : env.MakeSnap) {
             const ui32 table = pr.first;
             auto& snap = pr.second;
 
-            Y_ABORT_UNLESS(snap.Epoch, "Table was not snapshotted");
+            Y_ENSURE(snap.Epoch, "Table was not snapshotted");
 
             for (auto &context: snap.Context) {
                 auto edge = NTable::TSnapEdge(change->Stamp - 1, *snap.Epoch);
@@ -2379,7 +2379,7 @@ void TExecutor::CommitTransactionLog(std::unique_ptr<TSeat> seat, TPageCollectio
             }
 
             TIntrusivePtr<TBarrier> barrier(new TBarrier(commit->Step));
-            Y_ABORT_UNLESS(InFlyCompactionGcBarriers.emplace(commit->Step, barrier).second);
+            Y_ENSURE(InFlyCompactionGcBarriers.emplace(commit->Step, barrier).second);
             GcLogic->HoldBarrier(barrier->Step);
         }
 
@@ -2396,7 +2396,7 @@ void TExecutor::CommitTransactionLog(std::unique_ptr<TSeat> seat, TPageCollectio
                     blobs of compacted bundles.
                  */
 
-                Y_Fail("Dropping snapshot in step " << result.Step << " is"
+                 Y_TABLET_ERROR("Dropping snapshot in step " << result.Step << " is"
                     << " unsafe, final tx Execute() step is " << commit->Step
                     << ", borrowed " << result.Bundles.size() << " bundles");
             }
@@ -2409,8 +2409,8 @@ void TExecutor::CommitTransactionLog(std::unique_ptr<TSeat> seat, TPageCollectio
                     auto srcSubset = Database->Subset(src, snap->SnapContext->Impl->Edge(src).Head, { }, { });
                     auto dstSubset = Database->Subset(dst, NTable::TEpoch::Max(), { }, { });
 
-                    Y_ABORT_UNLESS(srcSubset && dstSubset, "Unexpected failure to grab subsets");
-                    Y_ABORT_UNLESS(srcSubset->Frozen.empty(), "Unexpected frozen parts in src subset");
+                    Y_ENSURE(srcSubset && dstSubset, "Unexpected failure to grab subsets");
+                    Y_ENSURE(srcSubset->Frozen.empty(), "Unexpected frozen parts in src subset");
 
                     // Check scheme compatibility (it may have changed due to alter)
                     auto tableInfo = Database->GetScheme().Tables.FindPtr(src);
@@ -2443,7 +2443,7 @@ void TExecutor::CommitTransactionLog(std::unique_ptr<TSeat> seat, TPageCollectio
                     TVector<TLogoBlobID> labels;
                     TVector<NTable::TPartView> rebased(Reserve(srcSubset->Flatten.size()));
                     for (const NTable::TPartView& partView : srcSubset->Flatten) {
-                        Y_ABORT_UNLESS(!partView->TxIdStats, "Cannot move parts with uncommitted deltas");
+                        Y_ENSURE(!partView->TxIdStats, "Cannot move parts with uncommitted deltas");
                         if (srcEpoch != partView->Epoch) {
                             srcEpoch = partView->Epoch;
                             --dstEpoch;
@@ -2457,7 +2457,7 @@ void TExecutor::CommitTransactionLog(std::unique_ptr<TSeat> seat, TPageCollectio
 
                     const auto logicResult = CompactionLogic->RemovedParts(src, labels);
 
-                    Y_ABORT_UNLESS(!logicResult.Changes.SliceChanges, "Unexpected slice changes when removing parts");
+                    Y_ENSURE(!logicResult.Changes.SliceChanges, "Unexpected slice changes when removing parts");
 
                     if (logicResult.Changes.StateChanges) {
                         NKikimrExecutorFlat::TTablePartSwitch proto;
@@ -2522,7 +2522,7 @@ void TExecutor::CommitTransactionLog(std::unique_ptr<TSeat> seat, TPageCollectio
             partSwitch.TableId = loaned->LocalTableId;
             partSwitch.Step = commit->Step;
 
-            Y_ABORT_UNLESS(loaned->PartComponents.PageCollectionComponents, "Loaned PartComponents without any page collections");
+            Y_ENSURE(loaned->PartComponents.PageCollectionComponents, "Loaned PartComponents without any page collections");
 
             BorrowLogic->LoanBundle(
                 loaned->PartComponents.PageCollectionComponents.front().LargeGlobId.Lead, *loaned, commit);
@@ -2540,7 +2540,7 @@ void TExecutor::CommitTransactionLog(std::unique_ptr<TSeat> seat, TPageCollectio
 
                     LogicRedo->CutLog(loaned->LocalTableId, { stamp, epoch }, dummy);
 
-                    Y_ABORT_UNLESS(!dummy.Deleted && !dummy.Created);
+                    Y_ENSURE(!dummy.Deleted && !dummy.Created);
 
                     auto *sx = proto.MutableTableSnapshoted();
                     sx->SetTable(loaned->LocalTableId);
@@ -2584,7 +2584,7 @@ void TExecutor::CommitTransactionLog(std::unique_ptr<TSeat> seat, TPageCollectio
 
                     LogicRedo->CutLog(loaned->LocalTableId, { stamp, epoch }, dummy);
 
-                    Y_ABORT_UNLESS(!dummy.Deleted && !dummy.Created);
+                    Y_ENSURE(!dummy.Deleted && !dummy.Created);
 
                     auto *sx = proto.MutableTableSnapshoted();
                     sx->SetTable(loaned->LocalTableId);
@@ -2636,7 +2636,7 @@ void TExecutor::CommitTransactionLog(std::unique_ptr<TSeat> seat, TPageCollectio
             }
 
             TIntrusivePtr<TBarrier> barrier(new TBarrier(commit->Step));
-            Y_ABORT_UNLESS(InFlyCompactionGcBarriers.emplace(commit->Step, barrier).second);
+            Y_ENSURE(InFlyCompactionGcBarriers.emplace(commit->Step, barrier).second);
             GcLogic->HoldBarrier(barrier->Step);
         }
 
@@ -2649,7 +2649,7 @@ void TExecutor::CommitTransactionLog(std::unique_ptr<TSeat> seat, TPageCollectio
                     commit);
             }
             TIntrusivePtr<TBarrier> barrier(new TBarrier(commit->Step));
-            Y_ABORT_UNLESS(InFlyCompactionGcBarriers.emplace(commit->Step, barrier).second);
+            Y_ENSURE(InFlyCompactionGcBarriers.emplace(commit->Step, barrier).second);
             GcLogic->HoldBarrier(barrier->Step);
         }
 
@@ -2763,7 +2763,7 @@ void TExecutor::MakeLogSnapshot() {
 
         auto dumpTxStatus = [&](const TIntrusiveConstPtr<NTable::TTxStatusPart>& part) {
             const auto* txStatus = dynamic_cast<const NTable::TTxStatusPartStore*>(part.Get());
-            Y_ABORT_UNLESS(txStatus);
+            Y_ENSURE(txStatus);
             auto* p = snap.AddTxStatusParts();
             p->SetTable(tableId);
             auto* x = p->AddTxStatus();
@@ -2819,7 +2819,7 @@ void TExecutor::MakeLogSnapshot() {
 void TExecutor::Handle(TEvPrivate::TEvActivateExecution::TPtr &ev, const TActorContext &ctx) {
     Y_UNUSED(ev);
     Y_UNUSED(ctx);
-    Y_ABORT_UNLESS(ActivateTransactionInFlight > 0);
+    Y_ENSURE(ActivateTransactionInFlight > 0);
     ActivateTransactionInFlight--;
 
     if (!CanExecuteTransaction())
@@ -2827,9 +2827,9 @@ void TExecutor::Handle(TEvPrivate::TEvActivateExecution::TPtr &ev, const TActorC
 
     if (ActivationQueue) {
         TSeat* seat = ActivationQueue.PopFront();
-        Y_ABORT_UNLESS(seat->State == ESeatState::Active);
+        Y_ENSURE(seat->State == ESeatState::Active);
         seat->State = ESeatState::None;
-        Y_ABORT_UNLESS(ActivateTransactionWaiting > 0);
+        Y_ENSURE(ActivateTransactionWaiting > 0);
         ActivateTransactionWaiting--;
         seat->FinishEnqueuedSpan();
         ExecuteTransaction(seat);
@@ -2839,14 +2839,14 @@ void TExecutor::Handle(TEvPrivate::TEvActivateExecution::TPtr &ev, const TActorC
         // have more ActivateTransactionInFlight events that these waiting
         // transactions, so when we handle this event we must have at least
         // one transaction in queue.
-        Y_ABORT_UNLESS(ActivateTransactionWaiting == 0);
+        Y_ENSURE(ActivateTransactionWaiting == 0);
     }
 }
 
 void TExecutor::Handle(TEvPrivate::TEvActivateLowExecution::TPtr &ev, const TActorContext &ctx) {
     Y_UNUSED(ev);
     Y_UNUSED(ctx);
-    Y_ABORT_UNLESS(ActivateLowTransactionInFlight > 0);
+    Y_ENSURE(ActivateLowTransactionInFlight > 0);
     ActivateLowTransactionInFlight--;
 
     if (!CanExecuteTransaction())
@@ -2854,9 +2854,9 @@ void TExecutor::Handle(TEvPrivate::TEvActivateLowExecution::TPtr &ev, const TAct
 
     if (ActivationLowQueue) {
         TSeat* seat = ActivationLowQueue.PopFront();
-        Y_ABORT_UNLESS(seat->State == ESeatState::ActiveLow);
+        Y_ENSURE(seat->State == ESeatState::ActiveLow);
         seat->State = ESeatState::None;
-        Y_ABORT_UNLESS(ActivateLowTransactionWaiting > 0);
+        Y_ENSURE(ActivateLowTransactionWaiting > 0);
         ActivateLowTransactionWaiting--;
         seat->FinishEnqueuedSpan();
 
@@ -2868,14 +2868,14 @@ void TExecutor::Handle(TEvPrivate::TEvActivateLowExecution::TPtr &ev, const TAct
 
         ExecuteTransaction(seat);
     } else {
-        Y_ABORT_UNLESS(ActivateLowTransactionWaiting == 0);
+        Y_ENSURE(ActivateLowTransactionWaiting == 0);
     }
 }
 
 void TExecutor::Handle(TEvPrivate::TEvBrokenTransaction::TPtr &ev, const TActorContext &ctx) {
     Y_UNUSED(ev);
     Y_UNUSED(ctx);
-    Y_ABORT_UNLESS(BrokenTransaction);
+    Y_ENSURE(BrokenTransaction);
 
     return Broken();
 }
@@ -2884,7 +2884,7 @@ void TExecutor::Wakeup(TEvents::TEvWakeup::TPtr &ev, const TActorContext&) {
     if (ev->Get()->Tag == ui64(EWakeTag::Memory)) {
         Memory->RunMemoryGC();
     } else {
-        Y_Fail("Unknown TExecutor module wakeup tag " << ev->Get()->Tag);
+        Y_TABLET_ERROR("Unknown TExecutor module wakeup tag " << ev->Get()->Tag);
     }
 }
 
@@ -3023,7 +3023,7 @@ void TExecutor::Handle(TEvTablet::TEvDropLease::TPtr &ev, const TActorContext &c
 }
 
 void TExecutor::Handle(TEvPrivate::TEvLeaseExtend::TPtr &, const TActorContext &) {
-    Y_ABORT_UNLESS(LeaseExtendPending);
+    Y_ENSURE(LeaseExtendPending);
     LeaseExtendPending = false;
 
     if (!LeaseCommits.empty() || !LeaseEnabled || LeaseDropped) {
@@ -3062,7 +3062,7 @@ void TExecutor::Handle(TEvTablet::TEvCommitResult::TPtr &ev, const TActorContext
         return Broken();
     }
 
-    Y_ABORT_UNLESS(msg->Generation == Generation());
+    Y_ENSURE(msg->Generation == Generation());
     const ui32 step = msg->Step;
 
     TActiveTransactionZone activeTransaction(this);
@@ -3080,7 +3080,7 @@ void TExecutor::Handle(TEvTablet::TEvCommitResult::TPtr &ev, const TActorContext
 
     if (!LeaseCommits.empty()) {
         auto& l = LeaseCommits.front();
-        Y_ABORT_UNLESS(step <= l.Step);
+        Y_ENSURE(step <= l.Step);
         if (step == l.Step) {
             LeasePersisted = true;
             LeaseEnd = Max(LeaseEnd, l.LeaseEnd);
@@ -3141,7 +3141,7 @@ void TExecutor::Handle(TEvTablet::TEvCommitResult::TPtr &ev, const TActorContext
     case ECommit::Data:
         {
             auto it = InFlyCompactionGcBarriers.find(step);
-            Y_ABORT_UNLESS(it != InFlyCompactionGcBarriers.end());
+            Y_ENSURE(it != InFlyCompactionGcBarriers.end());
             // just check, real barrier release on follower gc ack
         }
 
@@ -3150,7 +3150,7 @@ void TExecutor::Handle(TEvTablet::TEvCommitResult::TPtr &ev, const TActorContext
     case ECommit::Misc:
         break;
     default:
-        Y_ABORT("unknown event cookie");
+        Y_TABLET_ERROR("unknown event cookie");
     }
 
     Database->UpdateApproximateFreeSharesByChannel(msg->ApproximateFreeSpaceShareByChannel);
@@ -3190,7 +3190,7 @@ void TExecutor::Handle(TEvResourceBroker::TEvResourceAllocated::TPtr &ev) {
     case TResource::ESource::Scan:
         return StartScan(msg->TaskId, cookie);
     default:
-        Y_ABORT("unexpected resource source");
+        Y_TABLET_ERROR("unexpected resource source");
     }
 }
 
@@ -3198,7 +3198,7 @@ void TExecutor::StartSeat(ui64 task, TResource *cookie_)
 {
     auto *cookie = CheckedCast<TMemory::TCookie*>(cookie_);
     TSeat* seat = cookie->Seat;
-    Y_ABORT_UNLESS(seat->State == ESeatState::Postponed);
+    Y_ENSURE(seat->State == ESeatState::Postponed);
     PostponedTransactions.Remove(seat);
     seat->State = ESeatState::None;
     Memory->AcquiredMemory(*seat, task);
@@ -3241,7 +3241,7 @@ THolder<TScanSnapshot> TExecutor::PrepareScanSnapshot(ui32 table, const NTable::
         }
 
         if (*subset) {
-            Y_VERIFY_S(subset->IsStickedToHead(),
+            Y_ENSURE(subset->IsStickedToHead(),
                 "Got table subset with unexpected head " << subset->Head
                 << " and epoch " << subset->Epoch());
         }
@@ -3371,13 +3371,13 @@ void TExecutor::UtilizeSubset(const NTable::TSubset &subset,
 
         seen.Sieve.back().MaterializeTo(commit->GcDelta.Deleted);
     } else if (seen.Sieve.size() != subset.Flatten.size()) {
-        Y_ABORT("Got an unexpected TSieve items count after compaction");
+        Y_TABLET_ERROR("Got an unexpected TSieve items count after compaction");
     }
 
     for (auto it : xrange(subset.Flatten.size())) {
         auto *partStore = subset.Flatten[it].As<const NTable::TPartStore>();
 
-        Y_ABORT_UNLESS(seen.Sieve[it].Blobs.Get() == partStore->Blobs.Get());
+        Y_ENSURE(seen.Sieve[it].Blobs.Get() == partStore->Blobs.Get());
 
         if (reusedBundles.contains(partStore->Label)) {
             // Delete only compacted large blobs at this moment
@@ -3400,14 +3400,14 @@ void TExecutor::UtilizeSubset(const NTable::TSubset &subset,
     for (auto it : xrange(subset.ColdParts.size())) {
         auto *part = subset.ColdParts[it].Get();
 
-        Y_ABORT_UNLESS(!reusedBundles.contains(part->Label));
+        Y_ENSURE(!reusedBundles.contains(part->Label));
 
         BorrowLogic->BundleCompacted(part->Label, commit);
     }
 
     for (auto it : xrange(subset.TxStatus.size())) {
         auto *partStore = dynamic_cast<const NTable::TTxStatusPartStore*>(subset.TxStatus[it].Get());
-        Y_ABORT_UNLESS(partStore, "Unexpected failure to cast TxStatus to an implementation type");
+        Y_ENSURE(partStore, "Unexpected failure to cast TxStatus to an implementation type");
 
         if (BorrowLogic->BundleCompacted(*partStore, commit)) {
             partStore->SaveAllBlobIdsTo(commit->GcDelta.Deleted);
@@ -3517,7 +3517,7 @@ void TExecutor::Handle(NOps::TEvResult *ops, TProdCompact *msg, bool cancelled) 
         // Some compactions (e.g. triggered by log overhead after many scans)
         // may have no TMemTable inputs, we still want to cut log since it's
         // effectively a snapshot.
-        Y_ABORT_UNLESS(msg->Params->Edge.Head > NTable::TEpoch::Zero());
+        Y_ENSURE(msg->Params->Edge.Head > NTable::TEpoch::Zero());
         LogicRedo->CutLog(tableId, { snapStamp, ops->Subset->Head }, commit->GcDelta);
         auto *sx = proto.MutableTableSnapshoted();
         sx->SetTable(tableId);
@@ -3525,7 +3525,7 @@ void TExecutor::Handle(NOps::TEvResult *ops, TProdCompact *msg, bool cancelled) 
         sx->SetStep(ExpandGenStepPair(snapStamp).second);
         sx->SetHead(ops->Subset->Head.ToProto());
     } else {
-        Y_ABORT_UNLESS(!hadFrozen, "Compacted frozen parts without correct head epoch");
+        Y_ENSURE(!hadFrozen, "Compacted frozen parts without correct head epoch");
     }
 
     if (results) {
@@ -3551,7 +3551,7 @@ void TExecutor::Handle(NOps::TEvResult *ops, TProdCompact *msg, bool cancelled) 
     if (newTxStatus) {
         for (const auto &txStatus : newTxStatus) {
             auto *partStore = dynamic_cast<const NTable::TTxStatusPartStore*>(txStatus.Get());
-            Y_ABORT_UNLESS(partStore);
+            Y_ENSURE(partStore);
             partStore->SaveAllBlobIdsTo(commit->GcDelta.Created);
         }
     }
@@ -3564,7 +3564,7 @@ void TExecutor::Handle(NOps::TEvResult *ops, TProdCompact *msg, bool cancelled) 
             totalGrow += NTable::TScreen::Sum(result.Growth);
         }
 
-        Y_ABORT_UNLESS(ops->Trace->Seen + totalGrow == totalBlobs);
+        Y_ENSURE(ops->Trace->Seen + totalGrow == totalBlobs);
 
         Counters->Cumulative()[TExecutorCounters::DB_ELOBS_ITEMS_GROW].Increment(totalGrow);
     }
@@ -3596,7 +3596,7 @@ void TExecutor::Handle(NOps::TEvResult *ops, TProdCompact *msg, bool cancelled) 
             }
         }
         for (auto &part: ops->Subset->ColdParts) {
-            Y_ABORT_UNLESS(!updatedSlices.contains(part->Label));
+            Y_ENSURE(!updatedSlices.contains(part->Label));
         }
 
         UtilizeSubset(*ops->Subset, *ops->Trace, std::move(reusedBundles), commit.Get());
@@ -3658,7 +3658,7 @@ void TExecutor::Handle(NOps::TEvResult *ops, TProdCompact *msg, bool cancelled) 
         p->SetTable(tableId);
         for (const auto &txStatus : newTxStatus) {
             auto *partStore = dynamic_cast<const NTable::TTxStatusPartStore*>(txStatus.Get());
-            Y_ABORT_UNLESS(partStore);
+            Y_ENSURE(partStore);
             {
                 auto *x = p->AddTxStatus();
                 TLargeGlobIdProto::Put(*x->MutableDataId(), partStore->GetDataId());
@@ -3686,7 +3686,7 @@ void TExecutor::Handle(NOps::TEvResult *ops, TProdCompact *msg, bool cancelled) 
 
     commit->FollowerAux = NPageCollection::TSlicer::Lz4()->Encode(aux.SerializeAsString());
 
-    Y_ABORT_UNLESS(InFlyCompactionGcBarriers.emplace(commit->Step, ops->Barrier).second);
+    Y_ENSURE(InFlyCompactionGcBarriers.emplace(commit->Step, ops->Barrier).second);
 
     DataCleanupLogic->OnCompleteCompaction(tableId, CompactionLogic->GetFinishedCompactionInfo(tableId));
 
@@ -3708,7 +3708,7 @@ void TExecutor::Handle(NOps::TEvResult *ops, TProdCompact *msg, bool cancelled) 
     for (auto &snap : logicResult.CompleteSnapshots) {
         if (snap->Impl->Complete(tableId, ops->Barrier)) {
             auto snapIt = WaitingSnapshots.find(snap.Get());
-            Y_ABORT_UNLESS(snapIt != WaitingSnapshots.end());
+            Y_ENSURE(snapIt != WaitingSnapshots.end());
             TIntrusivePtr<TTableSnapshotContext> snapCtxPtr = snapIt->second;
             WaitingSnapshots.erase(snapIt);
 
@@ -3943,10 +3943,11 @@ TString TExecutor::BorrowSnapshot(ui32 table, const TTableSnapshotContext &snap,
 {
     auto subset = Database->Subset(table, snap.Edge(table).Head, from, to);
 
-    if (subset == nullptr)
+    if (subset == nullptr) {
         return { }; /* Lack of required pages in cache, retry later */
+    }
 
-    Y_ABORT_UNLESS(!subset->Frozen, "Don't know how to borrow frozen parts");
+    Y_ENSURE(!subset->Frozen, "Don't know how to borrow frozen parts");
 
     NKikimrExecutorFlat::TDatabaseBorrowPart proto;
 
@@ -3970,7 +3971,7 @@ TString TExecutor::BorrowSnapshot(ui32 table, const TTableSnapshotContext &snap,
 
     for (const auto &part : subset->TxStatus) {
         const auto *txStatus = dynamic_cast<const NTable::TTxStatusPartStore*>(part.Get());
-        Y_ABORT_UNLESS(txStatus);
+        Y_ENSURE(txStatus);
         auto *x = proto.AddTxStatusParts();
         TLargeGlobIdProto::Put(*x->MutableDataId(), txStatus->GetDataId());
         x->SetEpoch(txStatus->Epoch.ToProto());
@@ -4007,7 +4008,7 @@ ui64 TExecutor::QueueScan(ui32 tableId, TAutoPtr<NTable::IScan> scan, ui64 cooki
     if (const auto* byId = std::get_if<TScanOptions::TSnapshotById>(&options.Snapshot)) {
         auto snapshotId = byId->SnapshotId;
         auto it = ScanSnapshots.find(snapshotId);
-        Y_VERIFY_S(it != ScanSnapshots.end(),
+        Y_ENSURE(it != ScanSnapshots.end(),
             NFmt::Do(*this)
                 << " QueueScan on table " << tableId
                 << " with unknown snapshot " << snapshotId);
@@ -4120,11 +4121,11 @@ void TExecutor::AllowBorrowedGarbageCompaction(ui32 tableId) {
 
 STFUNC(TExecutor::StateInit) {
     Y_UNUSED(ev);
-    Y_ABORT("must be no events before boot processing");
+    Y_TABLET_ERROR("must be no events before boot processing");
 }
 
 STFUNC(TExecutor::StateBoot) {
-    Y_ABORT_UNLESS(BootLogic);
+    Y_ENSURE(BootLogic);
     switch (ev->GetTypeRewrite()) {
         // N.B. must work during follower promotion to leader
         HFunc(TEvPrivate::TEvActivateExecution, Handle);
@@ -4192,7 +4193,7 @@ STFUNC(TExecutor::StateFollower) {
 }
 
 STFUNC(TExecutor::StateFollowerBoot) {
-    Y_ABORT_UNLESS(BootLogic);
+    Y_ENSURE(BootLogic);
     switch (ev->GetTypeRewrite()) {
         // N.B. must handle activities started before resync
         HFunc(TEvPrivate::TEvActivateExecution, Handle);
@@ -4220,7 +4221,7 @@ bool TExecutor::HasLoanedParts() const {
 }
 
 bool TExecutor::HasBorrowed(ui32 table, ui64 selfTabletId) const {
-    Y_VERIFY_S(Database, "Checking borrowers of table# " << table << " for tablet# " << selfTabletId);
+    Y_ENSURE(Database, "Checking borrowers of table# " << table << " for tablet# " << selfTabletId);
     return Database->HasBorrowed(table, selfTabletId);
 }
 
@@ -4432,7 +4433,7 @@ void TExecutor::UpdateConfig(TEvTablet::TEvUpdateConfig::TPtr &ev) {
 }
 
 void TExecutor::SendUserAuxUpdateToFollowers(TString upd, const TActorContext &ctx) {
-    Y_ABORT_UNLESS(Stats->IsActive && !Stats->IsFollower());
+    Y_ENSURE(Stats->IsActive && !Stats->IsFollower());
 
     NKikimrExecutorFlat::TFollowerAux proto;
     proto.SetUserAuxUpdate(std::move(upd));
@@ -4509,7 +4510,7 @@ TIntrusiveConstPtr<NTable::TRowScheme> TExecutor::RowScheme(ui32 table) const
 const NTable::TScheme::TTableInfo* TExecutor::TableScheme(ui32 table)
 {
     auto* info = Scheme().GetTableInfo(table);
-    Y_ABORT_UNLESS(info, "Unexpected request for schema of table %" PRIu32, table);
+    Y_ENSURE(info, "Unexpected request for schema of table " << table);
     return info;
 }
 
@@ -4522,7 +4523,7 @@ NTable::TPartView TExecutor::TablePart(ui32 table, const TLogoBlobID& label)
 {
     auto partView = Database->GetPartView(table, label);
     if (!partView) {
-        Y_Fail("Unexpected request for missing part " << label << " in table " << table);
+        Y_TABLET_ERROR("Unexpected request for missing part " << label << " in table " << table);
     }
     return partView;
 }
@@ -4591,7 +4592,7 @@ bool TExecutor::HasSchemaChanges(const NTable::TPartView& partView, const NTable
             const auto& family = tableInfo.Families.ValueRef(familyId, defaultFamilySettings); // Workaround for KIKIMR-17222
 
             const auto* schemeGroupRoom = tableInfo.Rooms.FindPtr(family.Room);
-            Y_ABORT_UNLESS(schemeGroupRoom, "Cannot find room %" PRIu32 " in table %" PRIu32, family.Room, tableInfo.Id);
+            Y_ENSURE(schemeGroupRoom, "Cannot find room " << family.Room << " in table " << tableInfo.Id);
 
             ui32 partGroupChannel = partView.Part->GetGroupChannel(NTable::NPage::TGroupId(index));
             if (partGroupChannel != schemeGroupRoom->Main) {
@@ -4665,7 +4666,7 @@ ui64 TExecutor::BeginCompaction(THolder<NTable::TCompactionParams> params)
         const auto& family = tableInfo->Families.ValueRef(familyId, defaultFamilySettings); // Workaround for KIKIMR-17222
 
         auto* room = tableInfo->Rooms.FindPtr(family.Room);
-        Y_ABORT_UNLESS(room, "Cannot find room %" PRIu32 " in table %" PRIu32, family.Room, table);
+        Y_ENSURE(room, "Cannot find room " << family.Room << " in table " << table);
 
         auto& pageGroup = comp->Layout.Groups.at(group);
         auto& writeGroup = comp->Writer.Groups.at(group);
@@ -4762,7 +4763,7 @@ bool TExecutor::CancelCompaction(ui64 compactionId)
 
 void TExecutor::RequestChanges(ui32 table)
 {
-    Y_ABORT_UNLESS(CompactionLogic);
+    Y_ENSURE(CompactionLogic);
 
     CompactionLogic->RequestChanges(table);
     PlanCompactionChangesActivation();
@@ -4862,8 +4863,8 @@ void TExecutor::ApplyCompactionChanges(
 
         for (const auto &sliceChange : changes.SliceChanges) {
             auto* current = pendingChanges.FindPtr(sliceChange.Label);
-            Y_ABORT_UNLESS(current, "[%" PRIu64 "] cannot apply changes to table %" PRIu32 " part %s: not found",
-                     TabletId(), tableId, sliceChange.Label.ToString().c_str());
+            Y_ENSURE(current, "[" << TabletId() << "] cannot apply changes to table " << tableId
+                << " part " << sliceChange.Label << ": not found");
 
             *current = NTable::TSlices::Replace(std::move(*current), sliceChange.NewSlices);
 

--- a/ydb/core/tablet_flat/flat_executor_bootlogic.cpp
+++ b/ydb/core/tablet_flat/flat_executor_bootlogic.cpp
@@ -50,6 +50,7 @@ TExecutorBootLogic::~TExecutorBootLogic()
 
     Steps->Execute(); /* should flush all jobs in internal queue */
 
+    // FIXME: we shouldn't do anything in the destructor
     Y_ABORT_UNLESS(Steps->Alone(), "Bootlogic is still has pending IStep()s");
 }
 
@@ -69,8 +70,8 @@ TExecutorBootLogic::EOpResult TExecutorBootLogic::ReceiveFollowerBoot(
         Steps->Spawn<NBoot::TStages>(std::move(msg->DependencyGraph), nullptr);
     } else {
         auto *update = msg->Update.Get();
-        Y_ABORT_UNLESS(update->IsSnapshot);
-        Y_ABORT_UNLESS(!update->NeedFollowerGcAck);
+        Y_ENSURE(update->IsSnapshot);
+        Y_ENSURE(!update->NeedFollowerGcAck);
 
         if (auto logl = Steps->Logger()->Log(ELnLev::Debug))
             logl
@@ -89,9 +90,9 @@ TExecutorBootLogic::EOpResult TExecutorBootLogic::ReceiveFollowerBoot(
         const auto span = NPageCollection::TGroupBlobsByCookie(logo).Do();
         const auto largeGlobId = NPageCollection::TGroupBlobsByCookie::ToLargeGlobId(span, GetBSGroupFor(logo[0]));
 
-        Y_ABORT_UNLESS(span.size() == update->References.size());
-        Y_ABORT_UNLESS(TCookie(logo[0].Cookie()).Type() == TCookie::EType::Log);
-        Y_ABORT_UNLESS(largeGlobId, "Cannot make TLargeGlobId for snapshot");
+        Y_ENSURE(span.size() == update->References.size());
+        Y_ENSURE(TCookie(logo[0].Cookie()).Type() == TCookie::EType::Log);
+        Y_ENSURE(largeGlobId, "Cannot make TLargeGlobId for snapshot");
 
         Steps->Spawn<NBoot::TStages>(nullptr, new NBoot::TBody{ largeGlobId, std::move(body) });
     }
@@ -162,12 +163,12 @@ void TExecutorBootLogic::LoadEntry(TIntrusivePtr<NBoot::TLoadBlobs> entry) {
             << NFmt::Do(State()) << " Loading " << NFmt::Do(entry->LargeGlobId);
     }
 
-    Y_ABORT_UNLESS(entry->LargeGlobId, "Support loads only of valid TLargeGlobId units");
-    Y_ABORT_UNLESS(entry->Blobs(), "Valid TLargeGlobId unit hasn't been expanded to blobs");
+    Y_ENSURE(entry->LargeGlobId, "Support loads only of valid TLargeGlobId units");
+    Y_ENSURE(entry->Blobs(), "Valid TLargeGlobId unit hasn't been expanded to blobs");
 
     const ui32 group = entry->LargeGlobId.Group;
 
-    Y_ABORT_UNLESS(group != NPageCollection::TLargeGlobId::InvalidGroup, "Got TLargeGlobId without BS group");
+    Y_ENSURE(group != NPageCollection::TLargeGlobId::InvalidGroup, "Got TLargeGlobId without BS group");
 
     for (const auto &blobId : entry->Blobs()) {
         EntriesToLoad[blobId] = entry;
@@ -178,7 +179,7 @@ void TExecutorBootLogic::LoadEntry(TIntrusivePtr<NBoot::TLoadBlobs> entry) {
 NBoot::TSpawned TExecutorBootLogic::LoadPages(NBoot::IStep *step, TAutoPtr<NPageCollection::TFetch> req) {
     auto success = Loads.insert(std::make_pair(req->PageCollection.Get(), step)).second;
 
-    Y_ABORT_UNLESS(success, "IPageCollection queued twice for loading");
+    Y_ENSURE(success, "IPageCollection queued twice for loading");
 
     Ops->Send(
         NSharedCache::MakeSharedPageCacheId(),
@@ -210,7 +211,7 @@ TExecutorBootLogic::EOpResult TExecutorBootLogic::CheckCompletion()
     if (LoadBlobQueue.SendRequests(SelfId))
         return OpResultContinue;
 
-    Y_ABORT_UNLESS(EntriesToLoad.empty());
+    Y_ENSURE(EntriesToLoad.empty());
 
     if (Steps && !Steps->Alone())
         return OpResultContinue;
@@ -247,8 +248,8 @@ void TExecutorBootLogic::OnBlobLoaded(const TLogoBlobID& id, TString body, uintp
 
     auto it = EntriesToLoad.find(id);
 
-    Y_ABORT_UNLESS(it != EntriesToLoad.end(),
-        "OnBlobLoaded with unexpected blob id %s", id.ToString().c_str());
+    Y_ENSURE(it != EntriesToLoad.end(),
+        "OnBlobLoaded with unexpected blob id " << id);
 
     auto entry = std::move(it->second);
 
@@ -301,7 +302,7 @@ TExecutorBootLogic::EOpResult TExecutorBootLogic::Receive(::NActors::IEventHandl
 }
 
 TAutoPtr<NBoot::TResult> TExecutorBootLogic::ExtractState() {
-    Y_ABORT_UNLESS(Result_->Database, "Looks like booting hasn't been done");
+    Y_ENSURE(Result_->Database, "Looks like booting hasn't been done");
     return Result_;
 }
 
@@ -312,8 +313,8 @@ void TExecutorBootLogic::Cancel() {
 }
 
 void TExecutorBootLogic::FollowersSyncComplete() {
-    Y_ABORT_UNLESS(Result_);
-    Y_ABORT_UNLESS(Result().GcLogic);
+    Y_ENSURE(Result_);
+    Y_ENSURE(Result().GcLogic);
     Result().GcLogic->FollowersSyncComplete(true);
 }
 

--- a/ydb/core/tablet_flat/flat_executor_borrowlogic.cpp
+++ b/ydb/core/tablet_flat/flat_executor_borrowlogic.cpp
@@ -98,14 +98,14 @@ bool TExecutorBorrowLogic::BundlePartiallyCompacted(
         if (info->BorrowInfo.Keep.size() != size) {
             std::sort(info->BorrowInfo.Keep.begin(), info->BorrowInfo.Keep.end());
             auto end = std::unique(info->BorrowInfo.Keep.begin(), info->BorrowInfo.Keep.end());
-            Y_ABORT_UNLESS(end == info->BorrowInfo.Keep.end(),
+            Y_ENSURE(end == info->BorrowInfo.Keep.end(),
                 "Unexpected duplicates in compacted blobs");
             KeepBytes += info->BorrowInfo.UpdateKeepBytes();
             haveChanges = true;
         }
     }
 
-    Y_ABORT_UNLESS(commit->WaitFollowerGcAck);
+    Y_ENSURE(commit->WaitFollowerGcAck);
 
     if (haveChanges) {
         StoreBorrowProto(metaId, *info, commit);
@@ -127,7 +127,7 @@ bool TExecutorBorrowLogic::BundleCompacted(
 
     // 1. if bundle borrowed - keep blobs non-collected
     if (info->BorrowInfo.FullBorrow) {
-        Y_ABORT_UNLESS(!info->BorrowInfo.HasKeep(bundle.BundleId()),
+        Y_ENSURE(!info->BorrowInfo.HasKeep(bundle.BundleId()),
             "Trying to compact the same page collection twice");
 
         if (SelfTabletId == metaId.TabletID()) {
@@ -136,7 +136,7 @@ bool TExecutorBorrowLogic::BundleCompacted(
 
             std::sort(info->BorrowInfo.Keep.begin(), info->BorrowInfo.Keep.end());
             auto end = std::unique(info->BorrowInfo.Keep.begin(), info->BorrowInfo.Keep.end());
-            Y_ABORT_UNLESS(end == info->BorrowInfo.Keep.end(),
+            Y_ENSURE(end == info->BorrowInfo.Keep.end(),
                 "Unexpected duplicates in compacted blobs");
             KeepBytes += info->BorrowInfo.UpdateKeepBytes();
         }
@@ -147,7 +147,7 @@ bool TExecutorBorrowLogic::BundleCompacted(
     }
 
     CheckLoanCompletion(metaId, *info, commit->Step);
-    Y_ABORT_UNLESS(commit->WaitFollowerGcAck);
+    Y_ENSURE(commit->WaitFollowerGcAck);
 
     // must be loaned or borrowed (otherwise would be not on list)
     // in this case - changes must be propagated to lender before cleanup
@@ -167,7 +167,7 @@ bool TExecutorBorrowLogic::BundleCompacted(
 
     // if bundle borrowed - keep blobs non-collected
     if (info->BorrowInfo.FullBorrow) {
-        Y_ABORT_UNLESS(!info->BorrowInfo.HasKeep(metaId),
+        Y_ENSURE(!info->BorrowInfo.HasKeep(metaId),
             "Trying to compact the same bundle twice");
 
         if (SelfTabletId == metaId.TabletID()) {
@@ -175,7 +175,7 @@ bool TExecutorBorrowLogic::BundleCompacted(
 
             std::sort(info->BorrowInfo.Keep.begin(), info->BorrowInfo.Keep.end());
             auto end = std::unique(info->BorrowInfo.Keep.begin(), info->BorrowInfo.Keep.end());
-            Y_ABORT_UNLESS(end == info->BorrowInfo.Keep.end(),
+            Y_ENSURE(end == info->BorrowInfo.Keep.end(),
                 "Unexpected duplicates in compacted blobs");
             KeepBytes += info->BorrowInfo.UpdateKeepBytes();
         }
@@ -186,7 +186,7 @@ bool TExecutorBorrowLogic::BundleCompacted(
     }
 
     CheckLoanCompletion(metaId, *info, commit->Step);
-    Y_ABORT_UNLESS(commit->WaitFollowerGcAck);
+    Y_ENSURE(commit->WaitFollowerGcAck);
 
     // must be loaned or borrowed (otherwise would be not on list)
     // in this case - changes must be propagated to lender before cleanup
@@ -199,7 +199,7 @@ bool TExecutorBorrowLogic::BundleCompacted(
     const TLogoBlobID &bundleId,
     TLogCommit *commit)
 {
-    Y_ABORT_UNLESS(SelfTabletId != bundleId.TabletID());
+    Y_ENSURE(SelfTabletId != bundleId.TabletID());
     TBorrowedPartInfo *info = BorrowedInfo.FindPtr(bundleId);
     if (info == nullptr)
         return true;
@@ -209,7 +209,7 @@ bool TExecutorBorrowLogic::BundleCompacted(
     }
 
     CheckLoanCompletion(bundleId, *info, commit->Step);
-    Y_ABORT_UNLESS(commit->WaitFollowerGcAck);
+    Y_ENSURE(commit->WaitFollowerGcAck);
 
     // must be loaned or borrowed (otherwise would be not on list)
     // in this case - changes must be propagated to lender before cleanup
@@ -228,14 +228,14 @@ void TExecutorBorrowLogic::BorrowBundle(
 
     TBorrowedPartInfo &storedInfo = storedInfoItPair.first->second;
 
-    Y_ABORT_UNLESS(!(storedInfo.LoanInfo.Lender && storedInfo.LoanInfo.Collected),
+    Y_ENSURE(!(storedInfo.LoanInfo.Lender && storedInfo.LoanInfo.Collected),
         "Sanity check: trying to borrow a compacted bundle");
 
     // It is possible to borrow partially compacted bundles, in which case
     // keep list might not be empty. However, if bundle has been fully
     // compacted keep list would contain bundleId and it is possible
     // to check for that.
-    Y_ABORT_UNLESS(!storedInfo.BorrowInfo.HasKeep(bundleId),
+    Y_ENSURE(!storedInfo.BorrowInfo.HasKeep(bundleId),
         "Sanity check: trying to borrow a compacted bundle");
 
     auto &fullBorrow = storedInfo.BorrowInfo.FullBorrow;
@@ -246,7 +246,7 @@ void TExecutorBorrowLogic::BorrowBundle(
 
     Sort(fullBorrow);
     // !!HACK: Allow to borrow the same bundle multiple times
-    //Y_ABORT_UNLESS(std::adjacent_find(fullBorrow.begin(), fullBorrow.end()) == fullBorrow.end());
+    //Y_ENSURE(std::adjacent_find(fullBorrow.begin(), fullBorrow.end()) == fullBorrow.end());
     fullBorrow.erase(std::unique(fullBorrow.begin(), fullBorrow.end()), fullBorrow.end());
 
     StoreBorrowProto(bundleId, storedInfo, commit);
@@ -258,9 +258,11 @@ void TExecutorBorrowLogic::LoanBundle(
     TLogCommit *commit)
 {
     auto storedInfoItPair = BorrowedInfo.insert(std::make_pair(bundleId, TBorrowedPartInfo()));
-    Y_ABORT_UNLESS(storedInfoItPair.second,
-        "must not back-borrow parts at %" PRIu64 " part owner %" PRIu64 " existing loan from %" PRIu64 " new loan from %" PRIu64,
-        SelfTabletId, bundleId.TabletID(), storedInfoItPair.first->second.LoanInfo.Lender, loaned.Lender);
+    Y_ENSURE(storedInfoItPair.second,
+        "must not back-borrow parts at " << SelfTabletId
+        << " part owner " << bundleId.TabletID()
+        << " existing loan from " << storedInfoItPair.first->second.LoanInfo.Lender
+        << " new loan from " << loaned.Lender);
     HasFlag = true;
 
     TBorrowedPartInfo &storedInfo = storedInfoItPair.first->second;
@@ -275,9 +277,11 @@ void TExecutorBorrowLogic::LoanTxStatus(
     TLogCommit *commit)
 {
     auto storedInfoItPair = BorrowedInfo.insert(std::make_pair(bundleId, TBorrowedPartInfo()));
-    Y_ABORT_UNLESS(storedInfoItPair.second,
-        "must not back-borrow parts at %" PRIu64 " part owner %" PRIu64 " existing loan from %" PRIu64 " new loan from %" PRIu64,
-        SelfTabletId, bundleId.TabletID(), storedInfoItPair.first->second.LoanInfo.Lender, loaned.Lender);
+    Y_ENSURE(storedInfoItPair.second,
+        "must not back-borrow parts at " << SelfTabletId
+        << " part owner " << bundleId.TabletID()
+        << " existing loan from " << storedInfoItPair.first->second.LoanInfo.Lender
+        << " new loan from " << loaned.Lender);
     HasFlag = true;
 
     TBorrowedPartInfo &storedInfo = storedInfoItPair.first->second;
@@ -403,7 +407,7 @@ void TExecutorBorrowLogic::UpdateBorrow(
         // if not local - must be loaned
         CheckLoanCompletion(metaInfoId, storedInfo, commit->Step);
         StoreBorrowProto(metaInfoId, storedInfo, commit);
-        Y_ABORT_UNLESS(commit->WaitFollowerGcAck);
+        Y_ENSURE(commit->WaitFollowerGcAck);
     }
 }
 
@@ -426,8 +430,8 @@ void TExecutorBorrowLogic::ConfirmUpdateLoan(
     //if (storedInfo.LoanInfo.Lender == 0) // already confirmed, nothing to update
     //    return;
 
-    Y_ABORT_UNLESS(storedInfo.LoanInfo.Collected, "must not stop loan for non-collected parts");
-    Y_ABORT_UNLESS(!storedInfo.BorrowInfo.FullBorrow, "must not stop loan for borrowed parts");
+    Y_ENSURE(storedInfo.LoanInfo.Collected, "must not stop loan for non-collected parts");
+    Y_ENSURE(!storedInfo.BorrowInfo.FullBorrow, "must not stop loan for borrowed parts");
 
     // todo: merge - in such case we could loan part from different lenders.
     // so naive approach would not work
@@ -453,7 +457,7 @@ void TExecutorBorrowLogic::RestoreFollowerBorrowedInfo(const TLogoBlobID &blobId
         storedInfo.LoanInfo.Lender = proto.GetLender();
 
         if (proto.StorageInfoSize() > 0) {
-            Y_ABORT_UNLESS(proto.StorageInfoSize() == 1);
+            Y_ENSURE(proto.StorageInfoSize() == 1);
             storedInfo.LoanInfo.StorageInfo = TabletStorageInfoFromProto(proto.GetStorageInfo(0));
             UpdateStorageInfo(storedInfo.LoanInfo.StorageInfo.Get());
         }
@@ -470,7 +474,7 @@ void TExecutorBorrowLogic::RestoreBorrowedInfo(const TLogoBlobID &blobId, const 
     TBorrowedPartInfo &storedInfo = storedInfoItPair.first->second;
 
     if (!storedInfoItPair.second) {
-        Y_ABORT_UNLESS(blobId > storedInfo.BorrowBlobId);
+        Y_ENSURE(blobId > storedInfo.BorrowBlobId);
         Garbage.push_back(storedInfo.BorrowBlobId);
         KeepBytes -= storedInfo.BorrowInfo.KeepBytes;
         storedInfo = TBorrowedPartInfo();
@@ -498,7 +502,7 @@ void TExecutorBorrowLogic::RestoreBorrowedInfo(const TLogoBlobID &blobId, const 
         storedInfo.LoanInfo.Lender = proto.GetLender();
 
         if (proto.StorageInfoSize() > 0) {
-            Y_ABORT_UNLESS(proto.StorageInfoSize() == 1);
+            Y_ENSURE(proto.StorageInfoSize() == 1);
             storedInfo.LoanInfo.StorageInfo = TabletStorageInfoFromProto(proto.GetStorageInfo(0));
             UpdateStorageInfo(storedInfo.LoanInfo.StorageInfo.Get());
         }

--- a/ydb/core/tablet_flat/flat_executor_compaction_logic.cpp
+++ b/ydb/core/tablet_flat/flat_executor_compaction_logic.cpp
@@ -2,6 +2,7 @@
 #include "flat_exec_broker.h"
 #include "flat_dbase_scheme.h"
 #include "flat_comp_create.h"
+#include "util_fmt_abort.h"
 
 #include <ydb/core/base/appdata.h>
 
@@ -37,7 +38,7 @@ TCompactionLogic::~TCompactionLogic()
 
 void TCompactionLogic::Start() {
     auto result = ReflectSchemeChanges();
-    Y_ABORT_UNLESS(!result.StrategyChanges);
+    Y_ENSURE(!result.StrategyChanges);
     State->Snapshots.clear();
 }
 
@@ -50,7 +51,7 @@ void TCompactionLogic::Stop() {
 
 TCompactionLogicState::TSnapshotState TCompactionLogic::SnapToLog(ui32 tableId) {
     auto* info = State->Tables.FindPtr(tableId);
-    Y_ABORT_UNLESS(info);
+    Y_ENSURE(info);
     TCompactionLogicState::TSnapshotState ret;
     ret.State = info->Strategy->SnapshotState();
     ret.Strategy = info->StrategyType;
@@ -83,7 +84,7 @@ void TCompactionLogic::UpdateCompactions()
 void TCompactionLogic::RequestChanges(ui32 table)
 {
     auto *tableInfo = State->Tables.FindPtr(table);
-    Y_ABORT_UNLESS(tableInfo);
+    Y_ENSURE(tableInfo);
     tableInfo->ChangesRequested = true;
 }
 
@@ -111,7 +112,7 @@ void TCompactionLogic::PrepareTableSnapshot(ui32 table, NTable::TSnapEdge edge, 
     Y_DEBUG_ABORT_UNLESS(tableInfo);
     TCompactionLogicState::TInMem &inMem = tableInfo->InMem;
 
-    Y_ABORT_UNLESS(edge.TxStamp != Max<ui64>(), "TxStamp of snapshot is undefined");
+    Y_ENSURE(edge.TxStamp != Max<ui64>(), "TxStamp of snapshot is undefined");
 
     tableInfo->SnapRequests.emplace_back(TCompactionLogicState::TSnapRequest(edge, snapContext));
 
@@ -236,7 +237,7 @@ TFinishedCompactionInfo TCompactionLogic::GetFinishedCompactionInfo(ui32 table) 
 
 void TCompactionLogic::AllowBorrowedGarbageCompaction(ui32 table) {
     auto *tableInfo = State->Tables.FindPtr(table);
-    Y_ABORT_UNLESS(tableInfo && tableInfo->Strategy, "Cannot AllowBorrowedGarbageCompaction for unexpected table %" PRIu32, table);
+    Y_ENSURE(tableInfo && tableInfo->Strategy, "Cannot AllowBorrowedGarbageCompaction for unexpected table " << table);
     tableInfo->AllowBorrowedGarbageCompaction = true;
     tableInfo->Strategy->AllowBorrowedGarbageCompaction();
 }
@@ -255,13 +256,13 @@ TReflectSchemeChangesResult TCompactionLogic::ReflectSchemeChanges()
         if (auto *policy = table.Policy.Get()) {
             TString err;
             bool ok = NLocalDb::ValidateCompactionPolicyChange(*policy, *info.CompactionPolicy, err);
-            Y_ABORT_UNLESS(ok, "table %s id %u: %s", info.Name.data(), info.Id, err.data());
+            Y_ENSURE(ok, "Cannot change compaction policy for table " << info.Name << " id " << info.Id << ": " << err);
         }
 
         table.Policy = info.CompactionPolicy;
 
         auto newStrategyType = scheme.CompactionStrategyFor(info.Id);
-        Y_ABORT_UNLESS(newStrategyType != NKikimrCompaction::CompactionStrategyUnset);
+        Y_ENSURE(newStrategyType != NKikimrCompaction::CompactionStrategyUnset);
 
         if (table.StrategyType != newStrategyType) {
             if (table.StrategyType != NKikimrCompaction::CompactionStrategyUnset) {
@@ -269,10 +270,10 @@ TReflectSchemeChangesResult TCompactionLogic::ReflectSchemeChanges()
                 StrategyChanging(table);
             }
 
-            Y_ABORT_UNLESS(!table.Strategy);
+            Y_ENSURE(!table.Strategy);
             table.StrategyType = newStrategyType;
             table.Strategy = CreateStrategy(info.Id, newStrategyType);
-            Y_ABORT_UNLESS(table.Strategy);
+            Y_ENSURE(table.Strategy);
 
             // Time to start the new strategy
             if (auto* snapshot = State->Snapshots.FindPtr(info.Id)) {
@@ -297,7 +298,7 @@ TReflectSchemeChangesResult TCompactionLogic::ReflectSchemeChanges()
                 MemTableMemoryConsumersCollection->Register(info.Id);
             }
         } else {
-            Y_ABORT_UNLESS(table.Strategy);
+            Y_ENSURE(table.Strategy);
             table.Strategy->ReflectSchema();
         }
     }
@@ -343,7 +344,7 @@ THolder<NTable::ICompactionStrategy> TCompactionLogic::CreateStrategy(
                     tableId, Backend, Broker, Time, Logger, TaskNameSuffix);
 
         default:
-            Y_ABORT("Unsupported strategy %s", NKikimrCompaction::ECompactionStrategy_Name(strategy).c_str());
+            Y_TABLET_ERROR("Unsupported strategy " << NKikimrCompaction::ECompactionStrategy_Name(strategy));
     }
 }
 
@@ -431,7 +432,7 @@ void TCompactionLogic::StrategyChanging(TCompactionLogicState::TTableInfo &table
 
 void TCompactionLogic::UpdateInMemStatsStep(ui32 table, ui32 steps, ui64 size) {
     auto *info = State->Tables.FindPtr(table);
-    Y_ABORT_UNLESS(info);
+    Y_ENSURE(info);
     auto &mem = info->InMem;
     mem.EstimatedSize = size;
     mem.Steps += steps;
@@ -448,7 +449,7 @@ void TCompactionLogic::UpdateInMemStatsStep(ui32 table, ui32 steps, ui64 size) {
 
 void TCompactionLogic::CheckInMemStats(ui32 table) {
     auto *info = State->Tables.FindPtr(table);
-    Y_ABORT_UNLESS(info);
+    Y_ENSURE(info);
     auto &mem = info->InMem;
 
     const auto &policy = *info->Policy;
@@ -534,12 +535,11 @@ void TCompactionLogic::UpdateLogUsage(const NRedo::TUsage &usage)
 bool TCompactionLogic::BeginMemTableCompaction(ui64 taskId, ui32 tableId)
 {
     TCompactionLogicState::TTableInfo *tableInfo = State->Tables.FindPtr(tableId);
-    Y_ABORT_UNLESS(tableInfo,
-        "Unexpected BeginMemTableCompaction(%" PRIu64 ", %" PRIu32 ") for a dropped table",
-        taskId, tableId);
+    Y_ENSURE(tableInfo,
+        "Unexpected BeginMemTableCompaction(" << taskId << ", " << tableId << ") for a dropped table");
 
     TCompactionLogicState::TInMem &inMem = tableInfo->InMem;
-    Y_ABORT_UNLESS(taskId == inMem.CompactionTask.TaskId);
+    Y_ENSURE(taskId == inMem.CompactionTask.TaskId);
 
     NTable::TSnapEdge edge;
 
@@ -558,7 +558,7 @@ bool TCompactionLogic::BeginMemTableCompaction(ui64 taskId, ui32 tableId)
         break;
 
     default:
-        Y_ABORT("Invalid inMem.State");
+        Y_TABLET_ERROR("Invalid inMem.State");
     }
 
     ui64 forcedCompactionId = 0;
@@ -596,11 +596,11 @@ TCompactionLogic::HandleCompaction(
     const auto edge = params->Edge;
 
     TCompactionLogicState::TTableInfo *tableInfo = State->Tables.FindPtr(tableId);
-    Y_ABORT_UNLESS(tableInfo, "Unexpected CompleteCompaction for a dropped table");
+    Y_ENSURE(tableInfo, "Unexpected CompleteCompaction for a dropped table");
 
     if (compactionId == tableInfo->InMem.CompactionTask.CompactionId) {
         TCompactionLogicState::TInMem &inMem = tableInfo->InMem;
-        Y_ABORT_UNLESS(params->TaskId == inMem.CompactionTask.TaskId);
+        Y_ENSURE(params->TaskId == inMem.CompactionTask.TaskId);
 
         switch (inMem.State) {
         case ECompactionState::Compaction:
@@ -610,8 +610,8 @@ TCompactionLogic::HandleCompaction(
             inMem.CompactionTask.CompactionId = 0;
             break;
         case ECompactionState::SnapshotCompaction:
-            Y_ABORT_UNLESS(tableInfo->SnapRequests);
-            Y_ABORT_UNLESS(edge == tableInfo->SnapRequests.front().Edge);
+            Y_ENSURE(tableInfo->SnapRequests);
+            Y_ENSURE(edge == tableInfo->SnapRequests.front().Edge);
             if (ret) {
                 ret->CompleteSnapshots.push_back(tableInfo->SnapRequests.front().Context);
                 tableInfo->SnapRequests.pop_front();
@@ -622,7 +622,7 @@ TCompactionLogic::HandleCompaction(
             inMem.CompactionTask.CompactionId = 0;
             break;
         default:
-            Y_ABORT("must not happens, state=%d", (int)inMem.State);
+            Y_TABLET_ERROR("must not happen, state=" << (int)inMem.State);
         }
 
         if (tableInfo->ForcedCompactionState == EForcedCompactionState::CompactingMem) {
@@ -690,13 +690,13 @@ TCompactionLogic::CancelledCompaction(
 
 void TCompactionLogic::BorrowedPart(ui32 tableId, NTable::TPartView partView) {
     auto *tableInfo = State->Tables.FindPtr(tableId);
-    Y_ABORT_UNLESS(tableInfo);
+    Y_ENSURE(tableInfo);
     tableInfo->Strategy->PartMerged(std::move(partView), 255);
 }
 
 void TCompactionLogic::BorrowedPart(ui32 tableId, TIntrusiveConstPtr<NTable::TColdPart> part) {
     auto *tableInfo = State->Tables.FindPtr(tableId);
-    Y_ABORT_UNLESS(tableInfo);
+    Y_ENSURE(tableInfo);
     tableInfo->Strategy->PartMerged(std::move(part), 255);
 }
 
@@ -706,7 +706,7 @@ ui32 TCompactionLogic::BorrowedPartLevel() {
 
 TTableCompactionChanges TCompactionLogic::RemovedParts(ui32 tableId, TArrayRef<const TLogoBlobID> parts) {
     auto *tableInfo = State->Tables.FindPtr(tableId);
-    Y_ABORT_UNLESS(tableInfo);
+    Y_ENSURE(tableInfo);
     TTableCompactionChanges ret;
     ret.Table = tableId;
     ret.Changes = tableInfo->Strategy->PartsRemoved(parts);
@@ -720,7 +720,7 @@ void TCompactionLogic::SubmitCompactionTask(ui32 table,
                                             ui32 priority,
                                             TCompactionLogicState::TCompactionTask &task)
 {
-    Y_ABORT_UNLESS(generation == 0, "Unexpected gen %" PRIu32 " in compaction logic", generation);
+    Y_ENSURE(generation == 0, "Unexpected gen " << generation << " in compaction logic");
 
     task.Priority = priority;
     task.SubmissionTimestamp = Time->Now();

--- a/ydb/core/tablet_flat/flat_executor_data_cleanup_logic.cpp
+++ b/ydb/core/tablet_flat/flat_executor_data_cleanup_logic.cpp
@@ -51,12 +51,12 @@ bool TDataCleanupLogic::TryStartCleanup(ui64 dataCleanupGeneration, const TActor
 }
 
 void TDataCleanupLogic::OnCompactionPrepared(ui32 tableId, ui64 compactionId) {
-    Y_ABORT_UNLESS(State == EDataCleanupState::PendingCompaction);
+    Y_ENSURE(State == EDataCleanupState::PendingCompaction);
     CompactingTables[tableId] = {tableId, compactionId};
 }
 
 void TDataCleanupLogic::WaitCompaction() {
-    Y_ABORT_UNLESS(State == EDataCleanupState::PendingCompaction);
+    Y_ENSURE(State == EDataCleanupState::PendingCompaction);
     if (CompactingTables.empty()) {
         State = EDataCleanupState::PendingFirstSnapshot;
     } else {

--- a/ydb/core/tablet_flat/flat_executor_database_ut.cpp
+++ b/ydb/core/tablet_flat/flat_executor_database_ut.cpp
@@ -5,6 +5,7 @@
 #include <ydb/core/tablet_flat/test/libs/exec/fuzzy.h>
 #include <library/cpp/testing/unittest/registar.h>
 #include "flat_database.h"
+#include "util_fmt_abort.h"
 
 #include <util/system/sanitizers.h>
 #include <util/system/valgrind.h>
@@ -68,7 +69,7 @@ public:
                 return Fuzzy.EraseRowTx(testDb, txc, table, key);
             };
         } else {
-            Y_ABORT("Random generator produced unexpected action value");
+            Y_TABLET_ERROR("Random generator produced unexpected action value");
         }
 
         QueueTx(func);
@@ -102,7 +103,7 @@ public:
     explicit TDbTestPlayerActor(const TVector<NFake::TFuncTx::TCall>& actions)
         : Actions(actions)
     {
-        Y_ABORT_UNLESS(actions.size(), "Have to pass at least one action");
+        Y_ENSURE(actions.size(), "Have to pass at least one action");
     }
 
     EDo Run() override
@@ -219,7 +220,7 @@ private:
     }
 
     ui64 RandomNumber(ui64 limit) {
-        Y_ABORT_UNLESS(limit > 0, "Invalid limit specified [0,%" PRIu64 ")", limit);
+        Y_ENSURE(limit > 0, "Invalid limit specified [0," << limit << ")");
         return RandomProvider->GenRand64() % limit;
     }
 
@@ -262,7 +263,7 @@ private:
         } else if (RowCount ==  Rows + 1) {
             QueueTx([this](ITestDb& testDb, TTransactionContext&){ TDbWrapper db(testDb); return this->DoFullScanTx(db); });
         } else if (RowCount > Rows + 1) {
-            Y_ABORT("Shouldn't request more task after EDo::Stop");
+            Y_TABLET_ERROR("Shouldn't request more tasks after EDo::Stop");
         }
 
         return RowCount <= Rows ? EDo::More : EDo::Stop;
@@ -330,7 +331,7 @@ private:
         } catch (NTable::TIteratorNotReady&) {
             Restarts++;
             Cerr << "Precharge restarts " << Restarts << " times" << Endl;
-            Y_ABORT_UNLESS(Restarts < 5, "Too many precharge restarts");
+            Y_ENSURE(Restarts < 5, "Too many precharge restarts");
             return false;
         }
 
@@ -341,11 +342,11 @@ private:
                 LastKey = it->GetValues().Columns[0].AsValue<ui32>();
             }
 
-            Y_ABORT_UNLESS(LastKey + 1 == RowCount /* incomplete read */);
+            Y_ENSURE(LastKey + 1 == RowCount /* incomplete read */);
 
             return true;
         } catch (NTable::TIteratorNotReady&) {
-            Y_ABORT_UNLESS(false, "All the data should be precharged");
+            Y_ENSURE(false, "All the data should be precharged");
         }
     }
 

--- a/ydb/core/tablet_flat/flat_executor_snapshot.cpp
+++ b/ydb/core/tablet_flat/flat_executor_snapshot.cpp
@@ -4,7 +4,7 @@ namespace NKikimr {
 namespace NTabletFlatExecutor {
 
 NTable::TSnapEdge TTableSnapshotContext::Edge(ui32 table) const {
-    Y_ABORT_UNLESS(Impl, "Snapshot context is not initialized");
+    Y_ENSURE(Impl, "Snapshot context is not initialized");
     return Impl->Edge(table);
 }
 

--- a/ydb/core/tablet_flat/flat_executor_snapshot.h
+++ b/ydb/core/tablet_flat/flat_executor_snapshot.h
@@ -44,7 +44,7 @@ namespace NTabletFlatExecutor {
             Get(table, EReady::Wait).Ready = EReady::Done;
             Holds.Barriers.push_back(barrier);
 
-            Y_ABORT_UNLESS(Pending, "Snapshot pending counter is out of sync");
+            Y_ENSURE(Pending, "Snapshot pending counter is out of sync");
 
             return --Pending == 0;
         }
@@ -59,7 +59,7 @@ namespace NTabletFlatExecutor {
         void Moved(ui32 src, ui32 dst)
         {
             Get(src, EReady::Done);
-            Y_ABORT_UNLESS(!Holds.Moved.contains(src), "Table moved multiple times");
+            Y_ENSURE(!Holds.Moved.contains(src), "Table moved multiple times");
             Holds.Moved[src] = dst;
         }
 
@@ -84,7 +84,7 @@ namespace NTabletFlatExecutor {
         TState& Get(ui32 table, EReady ready)
         {
             auto &state = Tables[table];
-            Y_ABORT_UNLESS(state.Ready == ready, "Table snapshot is not in state");
+            Y_ENSURE(state.Ready == ready, "Table snapshot is not in state");
             return state;
         }
 

--- a/ydb/core/tablet_flat/flat_executor_tx_env.cpp
+++ b/ydb/core/tablet_flat/flat_executor_tx_env.cpp
@@ -7,14 +7,14 @@ namespace NTabletFlatExecutor {
     void TPageCollectionTxEnv::MakeSnapshot(TIntrusivePtr<TTableSnapshotContext> snap)
     {
         auto tables = snap->TablesToSnapshot();
-        Y_ABORT_UNLESS(tables);
+        Y_ENSURE(tables);
 
         for (ui32 table : tables) {
             auto& entry = MakeSnap[table];
             entry.Context.push_back(snap);
             auto epoch = DB.TxSnapTable(table);
             if (entry.Epoch) {
-                Y_ABORT_UNLESS(*entry.Epoch == epoch, "Table snapshot changed unexpectedly");
+                Y_ENSURE(*entry.Epoch == epoch, "Table snapshot changed unexpectedly");
             } else {
                 entry.Epoch.emplace(epoch);
             }

--- a/ydb/core/tablet_flat/flat_executor_tx_env.h
+++ b/ydb/core/tablet_flat/flat_executor_tx_env.h
@@ -162,7 +162,7 @@ namespace NTabletFlatExecutor {
 
         void DropSnapshot(TIntrusivePtr<TTableSnapshotContext> snap) override
         {
-            Y_ABORT_UNLESS(!DropSnap, "only one snapshot per transaction");
+            Y_ENSURE(!DropSnap, "only one snapshot per transaction");
 
             DropSnap.Reset(new TBorrowSnap{ snap });
         }
@@ -186,7 +186,7 @@ namespace NTabletFlatExecutor {
             const ui32 source = proto.GetSourceTable();
 
             for (auto &part : proto.GetParts()) {
-                Y_ABORT_UNLESS(part.HasBundle(), "Cannot find attached hotdogs in borrow");
+                Y_ENSURE(part.HasBundle(), "Cannot find attached hotdogs in borrow");
 
                 LoanBundle.emplace_back(new TLoanBundle(source, tableId, lender,
                         TPageCollectionProtoHelper::MakePageCollectionComponents(part.GetBundle(), /* unsplit */ true)));
@@ -203,7 +203,7 @@ namespace NTabletFlatExecutor {
 
         void CleanupLoan(const TLogoId &bundle, ui64 from) override
         {
-            Y_ABORT_UNLESS(!DropSnap, "must not drop snapshot and update loan in same transaction");
+            Y_ENSURE(!DropSnap, "must not drop snapshot and update loan in same transaction");
             BorrowUpdates[bundle].StoppedLoans.push_back(from);
         }
 

--- a/ydb/core/tablet_flat/flat_executor_ut.cpp
+++ b/ydb/core/tablet_flat/flat_executor_ut.cpp
@@ -1,5 +1,6 @@
 #include "flat_dbase_sz_env.h"
 #include "flat_executor_ut_common.h"
+#include "util_fmt_abort.h"
 #include <ydb/core/base/counters.h>
 #include <ydb/core/testlib/actors/block_events.h>
 
@@ -174,7 +175,7 @@ namespace NTabletFlatExecutor {
         }
 
         const NTable::TSubset& Result() const {
-            Y_ABORT_UNLESS(Subset);
+            Y_ENSURE(Subset);
             return *Subset;
         }
 
@@ -220,8 +221,8 @@ namespace NTabletFlatExecutor {
             {
                 const ui32 table = Self->Tables.at(0);
                 Self->Subset = txc.DB.Subset(table, Self->Edge(table).Head, { }, { });
-                Y_ABORT_UNLESS(Self->Subset != nullptr);
-                Y_ABORT_UNLESS(Self->Subset->Frozen.empty());
+                Y_ENSURE(Self->Subset != nullptr);
+                Y_ENSURE(Self->Subset->Frozen.empty());
                 txc.Env.DropSnapshot(Self);
                 return true;
             }
@@ -309,7 +310,7 @@ private:
 
     EScan Feed(TArrayRef<const TCell> key, const TRow &) override
     {
-        Y_ABORT_UNLESS(key[0].AsValue<ui64>() == ExpectedRowId);
+        Y_ENSURE(key[0].AsValue<ui64>() == ExpectedRowId);
         ++ExpectedRowId;
         ++StoredRows;
         return EScan::Feed;
@@ -322,18 +323,18 @@ private:
 
     TAutoPtr<IDestructable> Finish(EAbort abort) override
     {
-        Y_ABORT_UNLESS((int)Abort == (int)abort);
+        Y_ENSURE((int)Abort == (int)abort);
 
         auto ctx = ActorContext();
         if (abort == EAbort::None) {
             if (ExpectedRows != StoredRows) {
                 Cerr << "Expected " << ExpectedRows << " rows but got " << StoredRows << Endl;
             }
-            Y_ABORT_UNLESS(ExpectedRows == StoredRows);
+            Y_ENSURE(ExpectedRows == StoredRows);
             if (ExpectedPageFaults != Max<ui64>() && ExpectedPageFaults != PageFaults) {
                 Cerr << "Expected " << ExpectedPageFaults << " page faults but got " << PageFaults << Endl;
             }
-            Y_ABORT_UNLESS(ExpectedPageFaults == Max<ui64>() || ExpectedPageFaults == PageFaults);
+            Y_ENSURE(ExpectedPageFaults == Max<ui64>() || ExpectedPageFaults == PageFaults);
         }
 
         Die(ctx);
@@ -481,7 +482,7 @@ class TTestFlatTablet : public TActor<TTestFlatTablet>, public TTabletExecutedFl
         Scan->ExpectedPageFaults = ev->Get()->ExpectedPageFaults;
         TScanOptions options;
         if (snap) {
-            Y_ABORT_UNLESS(ev->Get()->ReadVersion.IsMax(), "Cannot combine multiple snapshot techniques");
+            Y_ENSURE(ev->Get()->ReadVersion.IsMax(), "Cannot combine multiple snapshot techniques");
             options.SetSnapshotId(snap);
         } else if (!ev->Get()->ReadVersion.IsMax()) {
             options.SetSnapshotRowVersion(ev->Get()->ReadVersion);
@@ -702,7 +703,7 @@ Y_UNIT_TEST_SUITE(TFlatTableExecutor_Reschedule) {
     class TTxRollbackOnReschedule : public ITransaction {
     public:
         bool Execute(TTransactionContext& txc, const TActorContext&) override {
-            Y_ABORT_UNLESS(!Done);
+            Y_ENSURE(!Done);
 
             i64 keyId = 42;
 
@@ -717,7 +718,7 @@ Y_UNIT_TEST_SUITE(TFlatTableExecutor_Reschedule) {
                 if (ready == NTable::EReady::Page) {
                     return false;
                 }
-                Y_ABORT_UNLESS(ready == NTable::EReady::Gone);
+                Y_ENSURE(ready == NTable::EReady::Gone);
             }
 
             TString valueText = "value";
@@ -736,7 +737,7 @@ Y_UNIT_TEST_SUITE(TFlatTableExecutor_Reschedule) {
         }
 
         void Complete(const TActorContext& ctx) override {
-            Y_ABORT_UNLESS(Done);
+            Y_ENSURE(Done);
             ctx.Send(ctx.SelfID, new NFake::TEvReturn);
         }
 
@@ -1120,7 +1121,7 @@ Y_UNIT_TEST_SUITE(TFlatTableExecutor_ResourceProfile) {
                         match = true;
                     }
                 } else {
-                    Y_ABORT_UNLESS(!event.TaskType);
+                    Y_ENSURE(!event.TaskType);
                     match = true;
                 }
             }
@@ -1894,15 +1895,15 @@ Y_UNIT_TEST_SUITE(TFlatTableExecutor_ColumnGroups) {
                 }
 
                 ui64 key = it->Row().Get(0).AsValue<ui64>();
-                Y_ABORT_UNLESS(key == next,
-                    "Found key %" PRIu64 ", expected %" PRIu64, key, next);
+                Y_ENSURE(key == next,
+                    "Found key " << key << ", expected " << next);
 
                 ++next;
                 last = key;
             }
 
-            Y_ABORT_UNLESS(last == ToKey,
-                "Last key %" PRIu64 ", expected %" PRIu64, last, ToKey);
+            Y_ENSURE(last == ToKey,
+                "Last key " << last << ", expected " << ToKey);
 
             return true;
         }
@@ -2069,12 +2070,12 @@ Y_UNIT_TEST_SUITE(TFlatTableExecutor_CompressedSelectRows) {
             for (keyId = 1000000; keyId < 1000512; ++keyId) {
                 NTable::TRowState row;
                 auto ready = txc.DB.Select(TRowsModel::TableId, key, tags, row);
-                Y_ABORT_UNLESS(ready == NTable::EReady::Data);
-                Y_ABORT_UNLESS(row.GetRowState() == NTable::ERowOp::Upsert);
+                Y_ENSURE(ready == NTable::EReady::Data);
+                Y_ENSURE(row.GetRowState() == NTable::ERowOp::Upsert);
                 TStringBuf selected = row.Get(0).AsBuf();
-                Y_ABORT_UNLESS(selected.size() == 1024);
+                Y_ENSURE(selected.size() == 1024);
                 TString expected(1024, (char)keyId);
-                Y_ABORT_UNLESS(selected == expected);
+                Y_ENSURE(selected == expected);
             }
 
             return true;
@@ -2294,13 +2295,13 @@ Y_UNIT_TEST_SUITE(TFlatTableExecutor_VersionedRows) {
                 const auto& row = it->Row();
 
                 i64 key = row.Get(0).AsValue<i64>();
-                Y_VERIFY_S(key == expectedKey,
+                Y_ENSURE(key == expectedKey,
                     "Found key " << key << ", expected " << expectedKey << " at snapshot " << Snapshot);
 
                 TStringBuf selected = row.Get(1).AsBuf();
-                Y_ABORT_UNLESS(selected.size() == 1024);
+                Y_ENSURE(selected.size() == 1024);
                 TString expected(1024, (char)key);
-                Y_ABORT_UNLESS(selected == expected);
+                Y_ENSURE(selected == expected);
 
                 Y_DEBUG_ABORT_UNLESS(rit != KeysRanges.end());
                 if (++expectedKey == rit->second) {
@@ -2308,7 +2309,7 @@ Y_UNIT_TEST_SUITE(TFlatTableExecutor_VersionedRows) {
                 }
             }
 
-            Y_VERIFY_S(expectedKey == -1,
+            Y_ENSURE(expectedKey == -1,
                 "Expected key " << expectedKey << " not found at snapshot " << Snapshot);
 
             return true;
@@ -2929,7 +2930,7 @@ Y_UNIT_TEST_SUITE(TFlatTableExecutor_MoveTableData) {
                 // Alter destination and stop keeping erase markers
                 {
                     TCompactionPolicy policy = *scheme.GetTableInfo(dst)->CompactionPolicy;
-                    Y_ABORT_UNLESS(policy.KeepEraseMarkers);
+                    Y_ENSURE(policy.KeepEraseMarkers);
                     policy.KeepEraseMarkers = false;
                     txc.DB.Alter().SetCompactionPolicy(dst, policy);
                 }
@@ -3470,13 +3471,13 @@ Y_UNIT_TEST_SUITE(TFlatTableExecutor_Follower) {
         }
 
         void ReadyForSecondAttach() {
-            Y_ABORT_UNLESS(State == EState::Idle);
-            Y_ABORT_UNLESS(SnapshotCommitResult);
+            Y_ENSURE(State == EState::Idle);
+            Y_ENSURE(SnapshotCommitResult);
             State = EState::WaitForSecondAttach;
         }
 
         void UnblockSnapshot(TTestActorRuntimeBase& runtime) {
-            Y_ABORT_UNLESS(SnapshotCommitResult);
+            Y_ENSURE(SnapshotCommitResult);
             runtime.Send(SnapshotCommitResult.Release(), 0, true);
         }
     };
@@ -3609,11 +3610,11 @@ Y_UNIT_TEST_SUITE(TFlatTableExecutor_Follower) {
         }
 
         EScan Seek(TLead&, ui64) override {
-            Y_ABORT("unreachable");
+            Y_TABLET_ERROR("unreachable");
         }
 
         EScan Feed(TArrayRef<const TCell>, const TRow&) override {
-            Y_ABORT("unreachable");
+            Y_TABLET_ERROR("unreachable");
         }
 
         TAutoPtr<IDestructable> Finish(EAbort) override {
@@ -4045,8 +4046,8 @@ Y_UNIT_TEST_SUITE(TFlatTableExecutor_Cold) {
         bool Execute(TTransactionContext& txc, const TActorContext&) override {
             auto parts = txc.DB.GetTableParts(TRowsModel::TableId);
             auto coldParts = txc.DB.GetTableColdParts(TRowsModel::TableId);
-            Y_ABORT_UNLESS(parts.empty());
-            Y_ABORT_UNLESS(!coldParts.empty());
+            Y_ENSURE(parts.empty());
+            Y_ENSURE(!coldParts.empty());
             return true;
         }
 
@@ -4058,7 +4059,7 @@ Y_UNIT_TEST_SUITE(TFlatTableExecutor_Cold) {
     struct TTxCheckNoColdParts : public ITransaction {
         bool Execute(TTransactionContext& txc, const TActorContext&) override {
             auto coldParts = txc.DB.GetTableColdParts(TRowsModel::TableId);
-            Y_ABORT_UNLESS(coldParts.empty());
+            Y_ENSURE(coldParts.empty());
             return true;
         }
 
@@ -5438,13 +5439,14 @@ Y_UNIT_TEST_SUITE(TFlatTableExecutor_SnapshotWithCommits) {
             for (keyId = 1; keyId <= 104; ++keyId) {
                 NTable::TRowState row;
                 auto ready = txc.DB.Select(TRowsModel::TableId, key, tags, row);
-                if (ready == NTable::EReady::Page)
+                if (ready == NTable::EReady::Page) {
                     return false;
-                Y_VERIFY_S(ready == NTable::EReady::Data, "Failed to find key " << keyId);
-                Y_ABORT_UNLESS(row.GetRowState() == NTable::ERowOp::Upsert);
+                }
+                Y_ENSURE(ready == NTable::EReady::Data, "Failed to find key " << keyId);
+                Y_ENSURE(row.GetRowState() == NTable::ERowOp::Upsert);
                 TStringBuf selected = row.Get(0).AsBuf();
                 TString expected = "value";
-                Y_ABORT_UNLESS(selected == expected);
+                Y_ENSURE(selected == expected);
             }
 
             return true;
@@ -7207,32 +7209,32 @@ Y_UNIT_TEST_SUITE(TFlatTableExecutor_LowPriorityTxs) {
         env.SendSync(new NFake::TEvExecute{[&](auto*, const auto& ctx) {
             ctx.Send(ctx.SelfID, new NFake::TEvExecute{[&](auto* x, const auto& ctx) {
                 id1 = x->EnqueueLowPriority(new TSimpleTx(tx1));
-                Y_ABORT_UNLESS(tx1.Executed == 0);
+                Y_ENSURE(tx1.Executed == 0);
                 id2 = x->Enqueue(new TSimpleTx(tx2));
-                Y_ABORT_UNLESS(tx2.Executed == 0);
+                Y_ENSURE(tx2.Executed == 0);
                 id3 = x->Enqueue(new TSimpleTx(tx3));
-                Y_ABORT_UNLESS(tx3.Executed == 0);
+                Y_ENSURE(tx3.Executed == 0);
                 // Validate this new mailbox event is handled after tx3 is executed and destroyed, i.e. it's high priority
                 ctx.Send(ctx.SelfID, new NFake::TEvExecute{[&](auto*, const auto&) {
-                    Y_ABORT_UNLESS(tx3.Executed == 1);
-                    Y_ABORT_UNLESS(tx3.Destroyed == 1);
+                    Y_ENSURE(tx3.Executed == 1);
+                    Y_ENSURE(tx3.Destroyed == 1);
                 }});
             }});
             ctx.Send(ctx.SelfID, new NFake::TEvExecute{[&](auto* x, const auto&) {
-                Y_ABORT_UNLESS(id1 != 0);
-                Y_ABORT_UNLESS(tx1.Executed == 0);
-                Y_ABORT_UNLESS(tx1.Destroyed == 0);
+                Y_ENSURE(id1 != 0);
+                Y_ENSURE(tx1.Executed == 0);
+                Y_ENSURE(tx1.Destroyed == 0);
                 bool ok = x->CancelTransaction(id1);
-                Y_ABORT_UNLESS(ok);
-                Y_ABORT_UNLESS(tx1.Destroyed == 1);
+                Y_ENSURE(ok);
+                Y_ENSURE(tx1.Destroyed == 1);
             }});
             ctx.Send(ctx.SelfID, new NFake::TEvExecute{[&](auto* x, const auto&) {
-                Y_ABORT_UNLESS(id2 != 0);
-                Y_ABORT_UNLESS(tx2.Executed == 0);
-                Y_ABORT_UNLESS(tx2.Destroyed == 0);
+                Y_ENSURE(id2 != 0);
+                Y_ENSURE(tx2.Executed == 0);
+                Y_ENSURE(tx2.Destroyed == 0);
                 bool ok = x->CancelTransaction(id2);
-                Y_ABORT_UNLESS(ok);
-                Y_ABORT_UNLESS(tx2.Destroyed == 1);
+                Y_ENSURE(ok);
+                Y_ENSURE(tx2.Destroyed == 1);
             }});
             ctx.Send(ctx.SelfID, new NFake::TEvExecute{[&](auto*, const auto& ctx) {
                 ctx.Send(ctx.SelfID, new NFake::TEvExecute{[&](auto*, const auto& ctx) {
@@ -7253,19 +7255,19 @@ Y_UNIT_TEST_SUITE(TFlatTableExecutor_LowPriorityTxs) {
         env.SendSync(new NFake::TEvExecute{[&](auto*, const auto& ctx) {
             ctx.Send(ctx.SelfID, new NFake::TEvExecute{[&](auto* x, const auto& ctx) {
                 id1 = x->EnqueueLowPriority(new TSimpleTx(tx1));
-                Y_ABORT_UNLESS(tx1.Executed == 0);
+                Y_ENSURE(tx1.Executed == 0);
                 id2 = x->EnqueueLowPriority(new TSimpleTx(tx2));
-                Y_ABORT_UNLESS(tx2.Executed == 0);
+                Y_ENSURE(tx2.Executed == 0);
                 ctx.Send(ctx.SelfID, new NFake::TEvExecute{[&](auto*, const auto& ctx) {
-                    Y_ABORT_UNLESS(tx1.Executed == 1);
-                    Y_ABORT_UNLESS(tx1.Completed == 1);
-                    Y_ABORT_UNLESS(tx1.Destroyed == 1);
-                    Y_ABORT_UNLESS(tx2.Executed == 0);
-                    Y_ABORT_UNLESS(tx2.Destroyed == 0);
+                    Y_ENSURE(tx1.Executed == 1);
+                    Y_ENSURE(tx1.Completed == 1);
+                    Y_ENSURE(tx1.Destroyed == 1);
+                    Y_ENSURE(tx2.Executed == 0);
+                    Y_ENSURE(tx2.Destroyed == 0);
                     ctx.Send(ctx.SelfID, new NFake::TEvExecute{[&](auto*, const auto& ctx) {
-                        Y_ABORT_UNLESS(tx2.Executed == 1);
-                        Y_ABORT_UNLESS(tx2.Completed == 1);
-                        Y_ABORT_UNLESS(tx2.Destroyed == 1);
+                        Y_ENSURE(tx2.Executed == 1);
+                        Y_ENSURE(tx2.Completed == 1);
+                        Y_ENSURE(tx2.Destroyed == 1);
                         ctx.Send(ctx.SelfID, new NFake::TEvReturn);
                     }});
                 }});
@@ -7284,35 +7286,35 @@ Y_UNIT_TEST_SUITE(TFlatTableExecutor_LowPriorityTxs) {
         env.SendSync(new NFake::TEvExecute{[&](auto*, const auto& ctx) {
             ctx.Send(ctx.SelfID, new NFake::TEvExecute{[&](auto* x, const auto& ctx) {
                 id1 = x->EnqueueLowPriority(new TSimpleTx(tx1));
-                Y_ABORT_UNLESS(tx1.Executed == 0);
+                Y_ENSURE(tx1.Executed == 0);
                 id2 = x->EnqueueLowPriority(new TSimpleTx(tx2));
-                Y_ABORT_UNLESS(tx2.Executed == 0);
+                Y_ENSURE(tx2.Executed == 0);
                 // The next new mailbox event is supposed to execute after tx1 is executed, but before tx2
                 ctx.Send(ctx.SelfID, new NFake::TEvExecute{[&](auto* x, const auto& ctx) {
-                    Y_ABORT_UNLESS(tx1.Executed == 1);
-                    Y_ABORT_UNLESS(tx1.Destroyed == 1);
+                    Y_ENSURE(tx1.Executed == 1);
+                    Y_ENSURE(tx1.Destroyed == 1);
                     bool ok1 = x->CancelTransaction(id1);
-                    Y_ABORT_UNLESS(!ok1); // cannot cancel executed transaction
-                    Y_ABORT_UNLESS(tx2.Executed == 0);
-                    Y_ABORT_UNLESS(tx2.Destroyed == 0);
+                    Y_ENSURE(!ok1); // cannot cancel executed transaction
+                    Y_ENSURE(tx2.Executed == 0);
+                    Y_ENSURE(tx2.Destroyed == 0);
                     bool ok2 = x->CancelTransaction(id2);
-                    Y_ABORT_UNLESS(ok2);
-                    Y_ABORT_UNLESS(tx2.Executed == 0);
-                    Y_ABORT_UNLESS(tx2.Destroyed == 1);
+                    Y_ENSURE(ok2);
+                    Y_ENSURE(tx2.Executed == 0);
+                    Y_ENSURE(tx2.Destroyed == 1);
                     ctx.Send(ctx.SelfID, new NFake::TEvExecute{[&](auto*, const auto& ctx) {
                         ctx.Send(ctx.SelfID, new NFake::TEvReturn);
                     }});
                 }});
             }});
             ctx.Send(ctx.SelfID, new NFake::TEvExecute{[&](auto*, const auto&) {
-                Y_ABORT_UNLESS(id1 != 0);
-                Y_ABORT_UNLESS(tx1.Executed == 0);
-                Y_ABORT_UNLESS(tx1.Destroyed == 0);
+                Y_ENSURE(id1 != 0);
+                Y_ENSURE(tx1.Executed == 0);
+                Y_ENSURE(tx1.Destroyed == 0);
             }});
             ctx.Send(ctx.SelfID, new NFake::TEvExecute{[&](auto*, const auto&) {
-                Y_ABORT_UNLESS(id2 != 0);
-                Y_ABORT_UNLESS(tx2.Executed == 0);
-                Y_ABORT_UNLESS(tx2.Destroyed == 0);
+                Y_ENSURE(id2 != 0);
+                Y_ENSURE(tx2.Executed == 0);
+                Y_ENSURE(tx2.Destroyed == 0);
             }});
         }});
     }
@@ -7330,22 +7332,22 @@ Y_UNIT_TEST_SUITE(TFlatTableExecutor_LowPriorityTxs) {
                 id1 = x->EnqueueLowPriority(new TAllocatingTx(tx1));
                 id2 = x->EnqueueLowPriority(new TSimpleTx(tx2));
                 ctx.Send(ctx.SelfID, new NFake::TEvExecute{[&](auto* x, const auto& ctx) {
-                    Y_ABORT_UNLESS(tx1.Executed == 1);
-                    Y_ABORT_UNLESS(tx1.Destroyed == 0);
+                    Y_ENSURE(tx1.Executed == 1);
+                    Y_ENSURE(tx1.Destroyed == 0);
                     bool ok = x->CancelTransaction(id1);
-                    Y_ABORT_UNLESS(ok);
+                    Y_ENSURE(ok);
                     // Transaction is requesting more memory and cannot be destroyed
-                    Y_ABORT_UNLESS(tx1.Destroyed == 0);
+                    Y_ENSURE(tx1.Destroyed == 0);
                     ctx.Send(ctx.SelfID, new NFake::TEvExecute{[&](auto*, const auto&) {
-                        Y_ABORT_UNLESS(tx2.Executed == 1);
-                        Y_ABORT_UNLESS(tx2.Completed == 1);
-                        Y_ABORT_UNLESS(tx2.Destroyed == 1);
+                        Y_ENSURE(tx2.Executed == 1);
+                        Y_ENSURE(tx2.Completed == 1);
+                        Y_ENSURE(tx2.Destroyed == 1);
                     }});
                     ctx.Schedule(TDuration::MilliSeconds(1), new NFake::TEvExecute{[&](auto*, const auto& ctx) {
                         // We should observe tx1 destroyed eventually, not executing again
-                        Y_ABORT_UNLESS(tx1.Executed == 1);
-                        Y_ABORT_UNLESS(tx1.Completed == 0);
-                        Y_ABORT_UNLESS(tx1.Destroyed == 1);
+                        Y_ENSURE(tx1.Executed == 1);
+                        Y_ENSURE(tx1.Completed == 0);
+                        Y_ENSURE(tx1.Destroyed == 1);
                         ctx.Send(ctx.SelfID, new NFake::TEvReturn);
                     }});
                 }});

--- a/ydb/core/tablet_flat/flat_fwd_sieve.h
+++ b/ydb/core/tablet_flat/flat_fwd_sieve.h
@@ -57,7 +57,7 @@ namespace NFwd {
             const auto limit = Blobs ? Blobs->Total() : 0;
 
             for (ui64 seq = 0, off = 0; off <= Holes.size(); off++) {
-                Y_ABORT_UNLESS(off == Holes.size() || Holes.at(off).End <= limit);
+                Y_ENSURE(off == Holes.size() || Holes.at(off).End <= limit);
 
                 auto end = off < Holes.size() ? Holes[off].Begin : limit;
 

--- a/ydb/core/tablet_flat/flat_fwd_warmed.h
+++ b/ydb/core/tablet_flat/flat_fwd_warmed.h
@@ -37,8 +37,8 @@ namespace NFwd {
         {
             const auto &glob = memTable->GetBlobs()->Get(ref);
 
-            Y_ABORT_UNLESS(glob.Data, "External blob in TMemTable with no data");
-            Y_ABORT_UNLESS(!Blobs || ref >= Offset, "Unexpected ELargeObj reference");
+            Y_ENSURE(glob.Data, "External blob in TMemTable with no data");
+            Y_ENSURE(!Blobs || ref >= Offset, "Unexpected ELargeObj reference");
 
             bool omit = glob.Bytes() >= Edge && !TRowScheme::HasTag(Tags, tag);
 

--- a/ydb/core/tablet_flat/flat_iterator.h
+++ b/ydb/core/tablet_flat/flat_iterator.h
@@ -5,6 +5,7 @@
 #include "flat_row_remap.h"
 #include "flat_row_state.h"
 #include "flat_range_cache.h"
+#include "util_fmt_abort.h"
 
 #include <library/cpp/containers/stack_vector/stack_vec.h>
 
@@ -414,7 +415,7 @@ private:
 
     static TIteratorIndex IteratorIndexFromSize(size_t size) {
         TIteratorIndex index = size;
-        Y_ABORT_UNLESS(index == size, "Iterator index overflow");
+        Y_ENSURE(index == size, "Iterator index overflow");
         return index;
     }
 
@@ -552,7 +553,7 @@ inline void TTableIterBase<TIteratorOps>::Push(TAutoPtr<TRunIter> it)
 template<class TIteratorOps>
 inline void TTableIterBase<TIteratorOps>::StopBefore(TArrayRef<const TCell> key)
 {
-    Y_ABORT_UNLESS(!StopKey, "Using multiple stop keys not allowed");
+    Y_ENSURE(!StopKey, "Using multiple stop keys not allowed");
 
     if (Y_UNLIKELY(!key)) {
         return;
@@ -569,7 +570,7 @@ inline void TTableIterBase<TIteratorOps>::StopBefore(TArrayRef<const TCell> key)
 template<class TIteratorOps>
 inline void TTableIterBase<TIteratorOps>::StopAfter(TArrayRef<const TCell> key)
 {
-    Y_ABORT_UNLESS(!StopKey, "Using multiple stop keys not allowed");
+    Y_ENSURE(!StopKey, "Using multiple stop keys not allowed");
 
     if (Y_UNLIKELY(!key)) {
         return;
@@ -672,12 +673,12 @@ inline EReady TTableIterBase<TIteratorOps>::Turn()
                         break;
 
                     default:
-                        Y_ABORT("Unexpected EReady value");
+                        Y_TABLET_ERROR("Unexpected EReady value");
                 }
                 break;
             }
             default: {
-                Y_ABORT("Unexpected iterator type");
+                Y_TABLET_ERROR("Unexpected iterator type");
             }
         }
     }
@@ -764,7 +765,7 @@ inline TRowVersion TTableIterBase<TIteratorOps>::GetRowVersion() const
             return RunIters[ai.Index]->GetRowVersion();
         }
         default:
-            Y_ABORT("Unexpected iterator type");
+            Y_TABLET_ERROR("Unexpected iterator type");
     }
 }
 
@@ -833,7 +834,7 @@ inline EReady TTableIterBase<TIteratorOps>::Snap(TRowVersion rowVersion)
                 break;
             }
             default:
-                Y_ABORT("Unexpected iterator type");
+                Y_TABLET_ERROR("Unexpected iterator type");
         }
 
         // The last iterator becomes inactive
@@ -873,7 +874,7 @@ inline EReady TTableIterBase<TIteratorOps>::DoSkipUncommitted()
                 break;
             }
             default:
-                Y_ABORT("Unexpected iterator type");
+                Y_TABLET_ERROR("Unexpected iterator type");
         }
 
         // The last iterator becomes inactive
@@ -946,7 +947,7 @@ inline EReady TTableIterBase<TIteratorOps>::Apply()
                 break;
             }
             default:
-                Y_ABORT("Unexpected iterator type");
+                Y_TABLET_ERROR("Unexpected iterator type");
         }
 
         if (State.IsFinalized() || !committed)
@@ -984,7 +985,7 @@ inline void TTableIterBase<TIteratorOps>::InitLastKey(ERowOp op)
             break;
         }
         default: {
-            Y_ABORT("Unexpected iterator type");
+            Y_TABLET_ERROR("Unexpected iterator type");
         }
     }
 
@@ -1077,12 +1078,12 @@ inline bool TTableIterBase<TIteratorOps>::SeekInternal(TArrayRef<const TCell> ke
                         break;
 
                     default:
-                        Y_ABORT("Unexpected EReady value");
+                        Y_TABLET_ERROR("Unexpected EReady value");
                 }
                 break;
             }
             default: {
-                Y_ABORT("Unexpected iterator type");
+                Y_TABLET_ERROR("Unexpected iterator type");
             }
         }
     }

--- a/ydb/core/tablet_flat/flat_load_blob_queue.cpp
+++ b/ydb/core/tablet_flat/flat_load_blob_queue.cpp
@@ -161,7 +161,7 @@ bool TLoadBlobQueue::ProcessResult(TEvBlobStorage::TEvGetResult* msg) {
             return false;
         }
 
-        Y_ABORT_UNLESS(x->Shift == 0, "Got blob read result with non-zero offset");
+        Y_ENSURE(x->Shift == 0, "Got blob read result with non-zero offset");
 
         const auto p = Active.equal_range(x->Id);
         if (p.first == p.second) {
@@ -185,7 +185,7 @@ bool TLoadBlobQueue::ProcessResult(TEvBlobStorage::TEvGetResult* msg) {
                 items.push_back(it->second);
             }
             Active.erase(p.first, p.second);
-            Y_ABORT_UNLESS(items.size() > 1);
+            Y_ENSURE(items.size() > 1);
 
             size_t last = items.size() - 1;
             for (size_t i = 0; i < last; ++i) {

--- a/ydb/core/tablet_flat/flat_mem_blobs.h
+++ b/ydb/core/tablet_flat/flat_mem_blobs.h
@@ -47,7 +47,7 @@ namespace NMem {
 
         const NPageCollection::TMemGlob& Get(ui64 ref) const
         {
-            Y_ABORT_UNLESS(ref >= Head && ref < Tail(), "ELargeObj ref is out of cache");
+            Y_ENSURE(ref >= Head && ref < Tail(), "ELargeObj ref is out of cache");
 
             return Store[ref - Head];
         }
@@ -59,7 +59,7 @@ namespace NMem {
 
         ui64 Push(const NPageCollection::TGlobId& glob, TSharedData data)
         {
-            Y_ABORT_UNLESS(glob.Logo.BlobSize(), "Blob cannot have zero bytes");
+            Y_ENSURE(glob.Logo.BlobSize(), "Blob cannot have zero bytes");
 
             Store.emplace_back(glob, std::move(data));
             Bytes += glob.Logo.BlobSize();
@@ -72,7 +72,7 @@ namespace NMem {
         void Assign(TArrayRef<NPageCollection::TLoadedPage> pages)
         {
             for (auto &one : pages) {
-                Y_ABORT_UNLESS(one.PageId < Store.size());
+                Y_ENSURE(one.PageId < Store.size());
 
                 Store[one.PageId].Data = std::move(one.Data);
             }
@@ -82,12 +82,12 @@ namespace NMem {
         {
             if (count > 0) {
                 size_t currentSize = Store.size();
-                Y_ABORT_UNLESS(count <= currentSize);
+                Y_ENSURE(count <= currentSize);
                 Store.Enumerate(currentSize - count, currentSize, [pages](size_t, NPageCollection::TMemGlob& blob) {
-                    Y_ABORT_UNLESS(blob.GId.Logo.TabletID() == 0);
+                    Y_ENSURE(blob.GId.Logo.TabletID() == 0);
                     const ui32 ref = blob.GId.Logo.Cookie();
                     const auto& fixedBlob = pages.at(ref);
-                    Y_ABORT_UNLESS(fixedBlob.GId.Logo.TabletID() != 0);
+                    Y_ENSURE(fixedBlob.GId.Logo.TabletID() != 0);
                     blob.GId = fixedBlob.GId;
                 });
             }
@@ -97,7 +97,7 @@ namespace NMem {
         {
             if (count > 0) {
                 size_t currentSize = Store.size();
-                Y_ABORT_UNLESS(count <= currentSize);
+                Y_ENSURE(count <= currentSize);
                 Store.Enumerate(currentSize - count, currentSize, [this](size_t, NPageCollection::TMemGlob& blob) {
                     Bytes -= blob.GId.Logo.BlobSize();
                 });

--- a/ydb/core/tablet_flat/flat_mem_warm.cpp
+++ b/ydb/core/tablet_flat/flat_mem_warm.cpp
@@ -38,7 +38,7 @@ NMem::TTreeSnapshot TMemTable::Immediate() const {
 }
 
 void TMemTable::PrepareRollback() {
-    Y_ABORT_UNLESS(!RollbackState);
+    Y_ENSURE(!RollbackState);
     auto& state = RollbackState.emplace();
     state.Snapshot = Tree.Snapshot();
     state.OpsCount = OpsCount;
@@ -49,7 +49,7 @@ void TMemTable::PrepareRollback() {
 }
 
 void TMemTable::RollbackChanges() {
-    Y_ABORT_UNLESS(RollbackState);
+    Y_ENSURE(RollbackState);
     auto& state = *RollbackState;
     Tree.RollbackTo(state.Snapshot);
     state.Snapshot = { };
@@ -98,7 +98,7 @@ void TMemTable::RollbackChanges() {
 }
 
 void TMemTable::CommitChanges(TArrayRef<const TMemGlob> blobs) {
-    Y_ABORT_UNLESS(RollbackState);
+    Y_ENSURE(RollbackState);
     auto& state = *RollbackState;
     state.Snapshot = { };
     Tree.CollectGarbage();
@@ -109,7 +109,7 @@ void TMemTable::CommitChanges(TArrayRef<const TMemGlob> blobs) {
 }
 
 void TMemTable::CommitBlobs(TArrayRef<const TMemGlob> blobs) {
-    Y_ABORT_UNLESS(!RollbackState);
+    Y_ENSURE(!RollbackState);
     Blobs.Commit(Blobs.Size(), blobs);
 }
 

--- a/ydb/core/tablet_flat/flat_mem_warm.h
+++ b/ydb/core/tablet_flat/flat_mem_warm.h
@@ -9,6 +9,7 @@
 #include "flat_page_blobs.h"
 #include "flat_sausage_solid.h"
 #include "flat_table_committed.h"
+#include "util_fmt_abort.h"
 #include "util_pool.h"
 #include <ydb/core/scheme/scheme_tablecell.h>
 #include <ydb/core/scheme/scheme_type_id.h>
@@ -90,7 +91,7 @@ namespace NMem {
         explicit TTreeAllocatorState(size_t pageSize)
             : PageSize(pageSize)
         {
-            Y_ABORT_UNLESS(PageSize >= sizeof(TFreeItem));
+            Y_ENSURE(PageSize >= sizeof(TFreeItem));
         }
 
         ~TTreeAllocatorState() noexcept {
@@ -209,7 +210,7 @@ namespace NMem {
                 rop == ERowOp::Upsert || rop == ERowOp::Erase || rop == ERowOp::Reset,
                 "Unexpected row operation");
 
-            Y_ABORT_UNLESS(ops.size() < Max<ui16>(), "Too large update ops array");
+            Y_ENSURE(ops.size() < Max<ui16>(), "Too large update ops array");
 
             // Filter legacy empty values and re-order them in tag order
             ScratchUpdateTags.clear();
@@ -333,7 +334,7 @@ namespace NMem {
             }
 
             const size_t mergedSize = ScratchUpdateTags.size() + ScratchMergeTags.size();
-            Y_ABORT_UNLESS(mergedSize < Max<ui16>(), "Merged row update is too large");
+            Y_ENSURE(mergedSize < Max<ui16>(), "Merged row update is too large");
 
             auto *update = NewUpdate(mergedSize);
 
@@ -363,8 +364,10 @@ namespace NMem {
                 } else if (TCellOp::HaveNoPayload(ops[it].NormalizedCellOp())) {
                     /* Payloadless ECellOp types may have zero type value */
                 } else if (info->TypeInfo.GetTypeId() != ops[it].Value.Type()) {
-                    Y_ABORT("Got an unexpected column type %" PRIu16 " in cell update for tag %" PRIu32 " (expected %" PRIu16 ")",
-                        ops[it].Value.Type(), ops[it].Tag, info->TypeInfo.GetTypeId());
+                    Y_TABLET_ERROR(
+                        "Got an unexpected column type " << ops[it].Value.Type()
+                        << " in cell update for tag " << ops[it].Tag
+                        << " (expected " << info->TypeInfo.GetTypeId() << ")");
                 }
 
                 auto cell = ops[it].AsCell();
@@ -380,7 +383,7 @@ namespace NMem {
                     cell = TCell::Make<ui64>(ref);
 
                 } else if (ops[it].Op != ELargeObj::Inline) {
-                    Y_ABORT("Got an unexpected ELargeObj reference in update ops");
+                    Y_TABLET_ERROR("Got an unexpected ELargeObj reference in update ops");
                 } else if (!cell.IsInline()) {
                     cell = Clone(cell.Data(), cell.Size());
                 }

--- a/ydb/core/tablet_flat/flat_page_base.h
+++ b/ydb/core/tablet_flat/flat_page_base.h
@@ -277,7 +277,7 @@ struct TCompare {
         : Info(keys)
         , KeyCellDefaults(keyDefaults)
     {
-        Y_ABORT_UNLESS(KeyCellDefaults->size() >= Info.size());
+        Y_ENSURE(KeyCellDefaults->size() >= Info.size());
     }
 
     bool operator()(const TRecord &record, TCells key) const

--- a/ydb/core/tablet_flat/flat_page_bloom.h
+++ b/ydb/core/tablet_flat/flat_page_bloom.h
@@ -3,6 +3,7 @@
 #include "flat_page_label.h"
 #include "flat_bloom_hash.h"
 #include "util_deref.h"
+#include "util_fmt_abort.h"
 
 namespace NKikimr {
 namespace NTable {
@@ -29,12 +30,13 @@ namespace NPage {
         {
             const auto got = NPage::TLabelWrapper().Read(Raw, EPage::Bloom);
 
-            Y_ABORT_UNLESS(got == ECodec::Plain && got.Version == 0);
+            Y_ENSURE(got == ECodec::Plain && got.Version == 0);
 
             auto *header = TDeref<THeader>::At(got.Page.data(), 0);
 
-            if (sizeof(THeader) > got.Page.size())
-                Y_ABORT("NPage::TBloom header is out of its blob");
+            if (sizeof(THeader) > got.Page.size()) {
+                Y_TABLET_ERROR("NPage::TBloom header is out of its blob");
+            }
 
             auto *ptr = TDeref<ui64>::At(got.Page.data(), sizeof(THeader));
 
@@ -43,13 +45,13 @@ namespace NPage {
             Array = { ptr, (got.Page.size() - sizeof(THeader)) / sizeof(ui64) };
 
             if (Items == 0) {
-                Y_ABORT("NPage::TBloom page has zero items in index");
+                Y_TABLET_ERROR("NPage::TBloom page has zero items in index");
             } else if (Hashes == 0) {
-                Y_ABORT("NPage::TBloom page has zero hash count");
+                Y_TABLET_ERROR("NPage::TBloom page has zero hash count");
             } else if (ui64(Array.size()) << 6 != header->Items) {
-                Y_ABORT("Items in TBloom header isn't match with array");
+                Y_TABLET_ERROR("Items in TBloom header isn't match with array");
             } else if (header->Type != 0) {
-                Y_ABORT("NPage::TBloom page made with unknown hash type");
+                Y_TABLET_ERROR("NPage::TBloom page made with unknown hash type");
             }
         }
 

--- a/ydb/core/tablet_flat/flat_page_btree_index_writer.h
+++ b/ydb/core/tablet_flat/flat_page_btree_index_writer.h
@@ -23,10 +23,10 @@ namespace NKikimr::NTable::NPage {
             } else {
                 FixedKeySize = 0;
                 for (TPos pos : xrange(GroupInfo.KeyTypes.size())) {
-                    Y_ABORT_UNLESS(GroupInfo.ColsKeyIdx[pos].IsFixed);
+                    Y_ENSURE(GroupInfo.ColsKeyIdx[pos].IsFixed);
                     FixedKeySize += GroupInfo.ColsKeyIdx[pos].FixedSize;
                 }
-                Y_ABORT_UNLESS(FixedKeySize < TBtreeIndexNode::THeader::MaxFixedKeySize, "FixedKeySize is out of bounds");
+                Y_ENSURE(FixedKeySize < TBtreeIndexNode::THeader::MaxFixedKeySize, "FixedKeySize is out of bounds");
             }
         }
 
@@ -50,16 +50,16 @@ namespace NKikimr::NTable::NPage {
         }
 
         void AddChild(TChild child) {
-            Y_ABORT_UNLESS(child.GetErasedRowCount() == 0 || !IsShortChildFormat(), "Short format can't have ErasedRowCount");
+            Y_ENSURE(child.GetErasedRowCount() == 0 || !IsShortChildFormat(), "Short format can't have ErasedRowCount");
             Children.push_back(child);
         }
 
         void EnsureEmpty() {
-            Y_ABORT_UNLESS(!Keys);
-            Y_ABORT_UNLESS(!KeysSize);
-            Y_ABORT_UNLESS(!Children);
-            Y_ABORT_UNLESS(!Ptr);
-            Y_ABORT_UNLESS(!End);
+            Y_ENSURE(!Keys);
+            Y_ENSURE(!KeysSize);
+            Y_ENSURE(!Children);
+            Y_ENSURE(!Ptr);
+            Y_ENSURE(!End);
         }
 
         void Reset() {
@@ -71,7 +71,7 @@ namespace NKikimr::NTable::NPage {
         }
 
         TString SerializeKey(TCellsRef cells) {
-            Y_ABORT_UNLESS(cells.size() <= GroupInfo.KeyTypes.size());
+            Y_ENSURE(cells.size() <= GroupInfo.KeyTypes.size());
 
             TString buf;
             buf.ReserveAndResize(CalcKeySize(cells));
@@ -80,7 +80,7 @@ namespace NKikimr::NTable::NPage {
 
             PlaceKey(cells);
 
-            Y_ABORT_UNLESS(Ptr == End);
+            Y_ENSURE(Ptr == End);
             NSan::CheckMemIsInitialized(buf.data(), buf.size());
             Ptr = 0;
             End = 0;
@@ -89,8 +89,8 @@ namespace NKikimr::NTable::NPage {
         }
 
         TSharedData Finish() {
-            Y_ABORT_UNLESS(Keys.size());
-            Y_ABORT_UNLESS(Children.size() == Keys.size() + 1);
+            Y_ENSURE(Keys.size());
+            Y_ENSURE(Children.size() == Keys.size() + 1);
 
             size_t pageSize = CalcPageSize();
             TSharedData buf = TSharedData::Uninitialized(pageSize);
@@ -101,7 +101,7 @@ namespace NKikimr::NTable::NPage {
 
             auto &header = Place<THeader>();
             header.KeysCount = Keys.size();
-            Y_ABORT_UNLESS(KeysSize < Max<TPgSize>(), "KeysSize is out of bounds");
+            Y_ENSURE(KeysSize < Max<TPgSize>(), "KeysSize is out of bounds");
             header.KeysSize = KeysSize;
             header.IsShortChildFormat = IsShortChildFormat();
             header.FixedKeySize = FixedKeySize;
@@ -110,17 +110,17 @@ namespace NKikimr::NTable::NPage {
                 size_t keyOffset = Ptr - buf.mutable_begin() + sizeof(TRecordsEntry) * Keys.size();
                 for (const auto &key : Keys) {
                     auto &meta = Place<TRecordsEntry>();
-                    Y_ABORT_UNLESS(keyOffset < Max<TPgSize>(), "Key offset is out of bounds");
+                    Y_ENSURE(keyOffset < Max<TPgSize>(), "Key offset is out of bounds");
                     meta.Offset = keyOffset;
                     keyOffset += key.size();
                 }
-                Y_ABORT_UNLESS(Ptr == buf.mutable_begin() + sizeof(TLabel) + sizeof(THeader) + sizeof(TRecordsEntry) * Keys.size());
+                Y_ENSURE(Ptr == buf.mutable_begin() + sizeof(TLabel) + sizeof(THeader) + sizeof(TRecordsEntry) * Keys.size());
             }
 
             for (auto &key : Keys) {
                 PlaceBytes(std::move(key));
             }
-            Y_ABORT_UNLESS(Ptr == buf.mutable_begin() + 
+            Y_ENSURE(Ptr == buf.mutable_begin() + 
                 sizeof(TLabel) + sizeof(THeader) + 
                 (IsFixedFormat() ? 0 : sizeof(TRecordsEntry) * Keys.size()) + 
                 KeysSize);
@@ -132,7 +132,7 @@ namespace NKikimr::NTable::NPage {
             }
             Children.clear();
 
-            Y_ABORT_UNLESS(Ptr == End);
+            Y_ENSURE(Ptr == End);
             NSan::CheckMemIsInitialized(buf.data(), buf.size());
             Ptr = 0;
             End = 0;
@@ -188,10 +188,10 @@ namespace NKikimr::NTable::NPage {
         {
             if (IsFixedFormat()) {
                 for (TPos pos : xrange(cells.size())) {
-                    Y_ABORT_UNLESS(cells[pos], "Can't have null cells in fixed format");
+                    Y_ENSURE(cells[pos], "Can't have null cells in fixed format");
                     const auto &info = GroupInfo.ColsKeyIdx[pos];
-                    Y_ABORT_UNLESS(info.IsFixed, "Can't have non-fixed cells in fixed format");
-                    Y_ABORT_UNLESS(cells[pos].Size() == info.FixedSize, "invalid fixed cell size)");
+                    Y_ENSURE(info.IsFixed, "Can't have non-fixed cells in fixed format");
+                    Y_ENSURE(cells[pos].Size() == info.FixedSize, "invalid fixed cell size)");
                     memcpy(Advance(cells[pos].Size()), cells[pos].Data(), cells[pos].Size());
                 }
                 return;
@@ -231,7 +231,7 @@ namespace NKikimr::NTable::NPage {
         void PlaceCell(const TPartScheme::TColumn& info, TCell value, char* keyCellsPtr)
         {
             if (info.IsFixed) {
-                Y_ABORT_UNLESS(value.Size() == info.FixedSize, "invalid fixed cell size)");
+                Y_ENSURE(value.Size() == info.FixedSize, "invalid fixed cell size)");
                 memcpy(keyCellsPtr, value.Data(), value.Size());
             } else {
                 auto *ref = TDeref<TDataRef>::At(keyCellsPtr);
@@ -272,7 +272,7 @@ namespace NKikimr::NTable::NPage {
         char* Advance(size_t size)
         {
             auto newPtr = Ptr + size;
-            Y_ABORT_UNLESS(newPtr <= End);
+            Y_ENSURE(newPtr <= End);
             return std::exchange(Ptr, newPtr);
         }
 
@@ -306,7 +306,7 @@ namespace NKikimr::NTable::NPage {
             }
 
             TString PopKey() {
-                Y_ABORT_UNLESS(Keys);
+                Y_ENSURE(Keys);
                 TString key = std::move(Keys.front());
                 KeysSize -= key.size();
                 Keys.pop_front();
@@ -318,7 +318,7 @@ namespace NKikimr::NTable::NPage {
             }
 
             TChild PopChild() {
-                Y_ABORT_UNLESS(Children);
+                Y_ENSURE(Children);
                 TChild result = Children.front();
                 Children.pop_front();
                 return result;
@@ -354,9 +354,9 @@ namespace NKikimr::NTable::NPage {
             , NodeKeysMin(nodeKeysMin)
             , NodeKeysMax(nodeKeysMax)
         {
-            Y_ABORT_UNLESS(NodeTargetSize > 0);
-            Y_ABORT_UNLESS(NodeKeysMin > 0);
-            Y_ABORT_UNLESS(NodeKeysMax >= NodeKeysMin);
+            Y_ENSURE(NodeTargetSize > 0);
+            Y_ENSURE(NodeKeysMin > 0);
+            Y_ENSURE(NodeKeysMax >= NodeKeysMin);
         }
 
         TPgSize CalcSize(TCellsRef cells) const {
@@ -409,15 +409,15 @@ namespace NKikimr::NTable::NPage {
         TBtreeIndexMeta Finish(IPageWriter &pager) {
             for (ui32 levelIndex = 0; levelIndex < Levels.size(); levelIndex++) {
                 if (!Levels[levelIndex].GetKeysCount()) {
-                    Y_ABORT_UNLESS(Levels[levelIndex].GetChildrenCount() == 1, "Should be root");
-                    Y_ABORT_UNLESS(levelIndex + 1 == Levels.size(), "Should be root");
+                    Y_ENSURE(Levels[levelIndex].GetChildrenCount() == 1, "Should be root");
+                    Y_ENSURE(levelIndex + 1 == Levels.size(), "Should be root");
                     return {Levels[levelIndex].PopChild(), levelIndex, IndexSize};
                 }
 
                 DoFlush(levelIndex, pager, true);
             }
 
-            Y_ABORT_UNLESS(false, "Should have returned root");
+            Y_ENSURE(false, "Should have returned root");
         }
 
         void Reset() {
@@ -476,7 +476,7 @@ namespace NKikimr::NTable::NPage {
 
             if (levelIndex + 1 == Levels.size()) {
                 Levels.emplace_back();
-                Y_ABORT_UNLESS(Levels.size() < Max<ui32>(), "Levels size is out of bounds");
+                Y_ENSURE(Levels.size() < Max<ui32>(), "Levels size is out of bounds");
             }
             lastChild.PageId_ = pageId;
             Levels[levelIndex + 1].PushChild(lastChild);
@@ -485,11 +485,11 @@ namespace NKikimr::NTable::NPage {
             }
 
             if (last) {
-                Y_ABORT_UNLESS(!Levels[levelIndex].GetKeysCount());
-                Y_ABORT_UNLESS(!Levels[levelIndex].GetKeysSize());
-                Y_ABORT_UNLESS(!Levels[levelIndex].GetChildrenCount());
+                Y_ENSURE(!Levels[levelIndex].GetKeysCount());
+                Y_ENSURE(!Levels[levelIndex].GetKeysSize());
+                Y_ENSURE(!Levels[levelIndex].GetChildrenCount());
             } else {
-                Y_ABORT_UNLESS(Levels[levelIndex].GetKeysCount(), "Shouldn't leave empty levels");
+                Y_ENSURE(Levels[levelIndex].GetKeysCount(), "Shouldn't leave empty levels");
             }
         }
 

--- a/ydb/core/tablet_flat/flat_page_data.h
+++ b/ydb/core/tablet_flat/flat_page_data.h
@@ -203,12 +203,12 @@ namespace NPage {
                 const void* base = raw->data();
                 auto data = NPage::TLabelWrapper().Read(*raw, EPage::DataPage);
 
-                Y_ABORT_UNLESS(data.Version == 1, "Unknown EPage::DataPage version");
+                Y_ENSURE(data.Version == 1, "Unknown EPage::DataPage version");
 
                 if (data.Codec != ECodec::Plain) {
                     /* Compressed, should convert to regular page */
 
-                    Y_ABORT_UNLESS(data == ECodec::LZ4, "Only LZ4 encoding allowed");
+                    Y_ENSURE(data == ECodec::LZ4, "Only LZ4 encoding allowed");
 
                     Codec = Codec ? Codec : NBlockCodecs::Codec("lz4fast");
                     auto size = Codec->DecompressedLength(data.Page);

--- a/ydb/core/tablet_flat/flat_page_flat_index.h
+++ b/ydb/core/tablet_flat/flat_page_flat_index.h
@@ -65,11 +65,11 @@ namespace NPage {
             : Raw(std::move(raw))
         {
             const auto data = NPage::TLabelWrapper().Read(Raw, EPage::FlatIndex);
-            Y_ABORT_UNLESS(data == ECodec::Plain && (data.Version == 2 || data.Version == 3));
+            Y_ENSURE(data == ECodec::Plain && (data.Version == 2 || data.Version == 3));
 
             auto *recordsHeader = TDeref<const TRecordsHeader>::At(data.Page.data(), 0);
             auto count = recordsHeader->Count;
-            Y_ABORT_UNLESS(count >= 1u + (data.Version == 3 ? 1 : 0));
+            Y_ENSURE(count >= 1u + (data.Version == 3 ? 1 : 0));
 
             Page.Base = Raw.data();
             auto offsetsOffset = data.Page.size() - count * sizeof(TPgSize);

--- a/ydb/core/tablet_flat/flat_page_frames.h
+++ b/ydb/core/tablet_flat/flat_page_frames.h
@@ -3,6 +3,7 @@
 #include "flat_row_eggs.h"
 #include "flat_page_label.h"
 #include "util_deref.h"
+#include "util_fmt_abort.h"
 #include <algorithm>
 
 namespace NKikimr {
@@ -39,7 +40,7 @@ namespace NPage {
 
             ui32 AbsRef(const ui32 page) const
             {
-                Y_ABORT_UNLESS(Refer < 0 || page >= ui32(Refer));
+                Y_ENSURE(Refer < 0 || page >= ui32(Refer));
 
                 return page - Refer;
             }
@@ -72,26 +73,28 @@ namespace NPage {
             : Raw(std::move(raw))
             , End({ Max<TRowId>(), Max<ui16>(), 0, 0 })
         {
-            Y_ABORT_UNLESS(uintptr_t(Raw.data()) % alignof(TEntry) == 0);
+            Y_ENSURE(uintptr_t(Raw.data()) % alignof(TEntry) == 0);
 
             auto got = NPage::TLabelWrapper().Read(Raw, EPage::Frames);
 
-            Y_ABORT_UNLESS(got == ECodec::Plain && got.Version == 0);
-            Y_ABORT_UNLESS(got.Page.size() > sizeof(THeader), "Damaged page");
+            Y_ENSURE(got == ECodec::Plain && got.Version == 0);
+            Y_ENSURE(got.Page.size() > sizeof(THeader), "Damaged page");
 
             auto * const ptr = got.Page.data();
             auto hdr = TDeref<THeader>::At(ptr, 0);
 
-            if (hdr->Skip > got.Page.size())
-                Y_ABORT("NPage::TFrame header is out of its blob");
+            if (hdr->Skip > got.Page.size()) {
+                Y_TABLET_ERROR("NPage::TFrame header is out of its blob");
+            }
 
             Stats_.Rows = hdr->Rows;
             Stats_.Size = hdr->Size;
             Stats_.Tags = { TDeref<const ui32>::At(ptr, 24), hdr->Tags  };
             Stats_.Items = (got.Page.size() - hdr->Skip) / sizeof(TEntry);
 
-            if (hdr->Skip < sizeof(THeader) + Stats_.Tags.size() * sizeof(ui32))
-                Y_ABORT("Invalid NPage::TFrame meta info blob header");
+            if (hdr->Skip < sizeof(THeader) + Stats_.Tags.size() * sizeof(ui32)) {
+                Y_TABLET_ERROR("Invalid NPage::TFrame meta info blob header");
+            }
 
             Records = { TDeref<TEntry>::At(ptr, hdr->Skip) , Stats_.Items };
         }

--- a/ydb/core/tablet_flat/flat_page_gstat.h
+++ b/ydb/core/tablet_flat/flat_page_gstat.h
@@ -44,17 +44,17 @@ namespace NPage {
         {
             const auto got = NPage::TLabelWrapper().Read(Raw, EPage::GarbageStats);
 
-            Y_ABORT_UNLESS(got == ECodec::Plain && got.Version == 0);
+            Y_ENSURE(got == ECodec::Plain && got.Version == 0);
 
-            Y_ABORT_UNLESS(sizeof(THeader) <= got.Page.size(),
+            Y_ENSURE(sizeof(THeader) <= got.Page.size(),
                     "NPage::TGarbageStats header is out of blob bounds");
 
             auto* header = TDeref<THeader>::At(got.Page.data(), 0);
 
-            Y_ABORT_UNLESS(header->Type == 0,
+            Y_ENSURE(header->Type == 0,
                     "NPage::TGarbageStats header has an unsupported type");
 
-            Y_ABORT_UNLESS(sizeof(THeader) + header->Items * sizeof(TItem) <= got.Page.size(),
+            Y_ENSURE(sizeof(THeader) + header->Items * sizeof(TItem) <= got.Page.size(),
                     "NPage::TGarbageStats items are out of blob bounds");
 
             auto* ptr = TDeref<TItem>::At(got.Page.data(), sizeof(THeader));
@@ -228,7 +228,7 @@ namespace NPage {
                 item->Bytes_ = totalGarbage;
             }
 
-            Y_ABORT_UNLESS(*out == buf.mutable_end());
+            Y_ENSURE(*out == buf.mutable_end());
             NSan::CheckMemIsInitialized(buf.data(), buf.size());
 
             return buf;

--- a/ydb/core/tablet_flat/flat_page_label.cpp
+++ b/ydb/core/tablet_flat/flat_page_label.cpp
@@ -10,17 +10,17 @@ namespace NPage {
 
     TLabelWrapper::TResult TLabelWrapper::Read(TArrayRef<const char> raw, EPage type) const
     {
-        Y_ABORT_UNLESS(raw.size() >= sizeof(TLabel), "Page blob is too small to hold label");
+        Y_ENSURE(raw.size() >= sizeof(TLabel), "Page blob is too small to hold label");
 
         auto label = ReadUnaligned<TLabel>(raw.data());
 
-        Y_ABORT_UNLESS(label.Type == type || type == EPage::Undef,
+        Y_ENSURE(label.Type == type || type == EPage::Undef,
             "Page blob has an unexpected label type");
 
         if (Y_UNLIKELY(label.IsHuge())) {
-            Y_ABORT_UNLESS(raw.size() >= Max<ui32>(), "Page label huge page marker doesn't match data size");
+            Y_ENSURE(raw.size() >= Max<ui32>(), "Page label huge page marker doesn't match data size");
         } else {
-            Y_ABORT_UNLESS(label.Size == raw.size(), "Page label size doesn't match data size");
+            Y_ENSURE(label.Size == raw.size(), "Page label size doesn't match data size");
         }
 
         const ui16 version = label.Format & 0x7fff;
@@ -35,7 +35,7 @@ namespace NPage {
                 in-place crc (may be) or other pages common metadata.
              */
 
-            Y_ABORT_UNLESS(raw.size() >= sizeof(TLabel) + sizeof(TLabelExt), "Page extended label doesn't match data size");
+            Y_ENSURE(raw.size() >= sizeof(TLabel) + sizeof(TLabelExt), "Page extended label doesn't match data size");
 
             auto ext = ReadUnaligned<TLabelExt>(begin);
             codec = ext.Codec;
@@ -47,7 +47,7 @@ namespace NPage {
 
     TSharedData TLabelWrapper::Wrap(TArrayRef<const char> plain, EPage page, ui16 version)
     {
-        Y_ABORT_UNLESS(!(version >> 15), "Version can use only 15 bits");
+        Y_ENSURE(!(version >> 15), "Version can use only 15 bits");
 
         TSharedData blob = TSharedData::Uninitialized(plain.size() + 8);
 
@@ -62,7 +62,7 @@ namespace NPage {
 
     TString TLabelWrapper::WrapString(TArrayRef<const char> plain, EPage page, ui16 version)
     {
-        Y_ABORT_UNLESS(!(version >> 15), "Version can use only 15 bits");
+        Y_ENSURE(!(version >> 15), "Version can use only 15 bits");
 
         TString blob = TString::Uninitialized(plain.size() + 8);
 

--- a/ydb/core/tablet_flat/flat_page_other.h
+++ b/ydb/core/tablet_flat/flat_page_other.h
@@ -3,6 +3,7 @@
 #include "flat_page_frames.h"
 #include "flat_page_blobs.h"
 #include "flat_util_binary.h"
+#include "util_fmt_abort.h"
 
 #include <util/generic/vector.h>
 #include <util/generic/xrange.h>
@@ -28,15 +29,15 @@ namespace NPage {
             Tags.resize(TagsCount + (TagsCount & 1), 0);
             Cook.reserve(tags);
 
-            Y_ABORT_UNLESS(tags <= ui32(-Min<i16>()), "Too many column tags");
+            Y_ENSURE(tags <= ui32(-Min<i16>()), "Too many column tags");
         }
 
         void Put(TRowId row, ui16 tag, ui32 bytes)
         {
             if (row < Last && Last != Max<TRowId>()) {
-                Y_ABORT("Frame items have to follow sorted by row");
+                Y_TABLET_ERROR("Frame items have to follow sorted by row");
             } else if (tag >= TagsCount) {
-                Y_ABORT("Frame item component tag is out of range");
+                Y_TABLET_ERROR("Frame item component tag is out of range");
             } else if (Last != row) {
                 Flush();
             }
@@ -103,8 +104,8 @@ namespace NPage {
 
             out.Put(Tags).Put(Array);
 
-            Y_ABORT_UNLESS(*out == buf.mutable_end());
-            Y_ABORT_UNLESS(buf.size() % alignof(TEntry) == 0);
+            Y_ENSURE(*out == buf.mutable_end());
+            Y_ENSURE(buf.size() % alignof(TEntry) == 0);
             NSan::CheckMemIsInitialized(buf.data(), buf.size());
 
             return buf;
@@ -190,8 +191,8 @@ namespace NPage {
 
             out.Put(Globs);
 
-            Y_ABORT_UNLESS(*out == buf.mutable_end());
-            Y_ABORT_UNLESS(buf.size() % alignof(TEntry) == 0);
+            Y_ENSURE(*out == buf.mutable_end());
+            Y_ENSURE(buf.size() % alignof(TEntry) == 0);
             NSan::CheckMemIsInitialized(buf.data(), buf.size());
 
             return buf;

--- a/ydb/core/tablet_flat/flat_page_txidstat.h
+++ b/ydb/core/tablet_flat/flat_page_txidstat.h
@@ -43,14 +43,14 @@ namespace NPage {
         {
             const auto got = NPage::TLabelWrapper().Read(Raw, EPage::TxIdStats);
 
-            Y_ABORT_UNLESS(got == ECodec::Plain && got.Version == 0);
+            Y_ENSURE(got == ECodec::Plain && got.Version == 0);
 
-            Y_ABORT_UNLESS(sizeof(THeader) <= got.Page.size(),
+            Y_ENSURE(sizeof(THeader) <= got.Page.size(),
                     "NPage::TTxIdStatsPage header is out of page bounds");
 
             auto* header = TDeref<THeader>::At(got.Page.data(), 0);
 
-            Y_ABORT_UNLESS(sizeof(THeader) + header->ItemCount * sizeof(TItem) <= got.Page.size(),
+            Y_ENSURE(sizeof(THeader) + header->ItemCount * sizeof(TItem) <= got.Page.size(),
                     "NPage::TTxIdStatsPage items are out of page bounds");
 
             auto* ptr = TDeref<TItem>::At(got.Page.data(), sizeof(THeader));
@@ -128,7 +128,7 @@ namespace NPage {
                 item->Bytes_ = stats.Bytes;
             }
 
-            Y_ABORT_UNLESS(*out == buf.mutable_end());
+            Y_ENSURE(*out == buf.mutable_end());
             NSan::CheckMemIsInitialized(buf.data(), buf.size());
 
             return buf;

--- a/ydb/core/tablet_flat/flat_page_txstatus.h
+++ b/ydb/core/tablet_flat/flat_page_txstatus.h
@@ -49,9 +49,9 @@ namespace NPage {
         {
             const auto got = NPage::TLabelWrapper().Read(Raw, EPage::TxStatus);
 
-            Y_ABORT_UNLESS(got == ECodec::Plain && got.Version == 0);
+            Y_ENSURE(got == ECodec::Plain && got.Version == 0);
 
-            Y_ABORT_UNLESS(sizeof(THeader) <= got.Page.size(),
+            Y_ENSURE(sizeof(THeader) <= got.Page.size(),
                     "NPage::TTxStatusPage header is out of page bounds");
 
             const THeader* header = TDeref<THeader>::At(got.Page.data(), 0);
@@ -61,7 +61,7 @@ namespace NPage {
                     sizeof(TCommittedItem) * header->CommittedCount +
                     sizeof(TRemovedItem) * header->RemovedCount);
 
-            Y_ABORT_UNLESS(expectedSize <= got.Page.size(),
+            Y_ENSURE(expectedSize <= got.Page.size(),
                     "NPage::TTxStatusPage items are out of page bounds");
 
             const TCommittedItem* ptrCommitted = TDeref<TCommittedItem>::At(header + 1, 0);
@@ -165,7 +165,7 @@ namespace NPage {
             out.Put(CommittedItems);
             out.Put(RemovedItems);
 
-            Y_ABORT_UNLESS(*out == buf.mutable_end());
+            Y_ENSURE(*out == buf.mutable_end());
             NSan::CheckMemIsInitialized(buf.data(), buf.size());
 
             CommittedItems.clear();

--- a/ydb/core/tablet_flat/flat_part_charge_btree_index.h
+++ b/ydb/core/tablet_flat/flat_part_charge_btree_index.h
@@ -73,8 +73,8 @@ public:
         bool ready = true, overshot = true, hasValidRowsRange = Groups || IncludeHistory;
         const TRowId sliceBeginRowId = beginRowId, sliceEndRowId = endRowId;
         const auto& meta = Part->IndexPages.GetBTree({});
-        Y_ABORT_UNLESS(beginRowId < endRowId);
-        Y_ABORT_UNLESS(endRowId <= meta.GetRowCount());
+        Y_ENSURE(beginRowId < endRowId);
+        Y_ENSURE(endRowId <= meta.GetRowCount());
 
         if (Y_UNLIKELY(key1 && key2 && Compare(key1, key2, keyDefaults) > 0)) {
             key2 = key1; // will not go further than key1
@@ -223,8 +223,8 @@ public:
         bool ready = true, overshot = true, hasValidRowsRange = Groups || IncludeHistory;
         const TRowId sliceBeginRowId = beginRowId, sliceEndRowId = endRowId;
         const auto& meta = Part->IndexPages.GetBTree({});
-        Y_ABORT_UNLESS(beginRowId < endRowId);
-        Y_ABORT_UNLESS(endRowId <= meta.GetRowCount());
+        Y_ENSURE(beginRowId < endRowId);
+        Y_ENSURE(endRowId <= meta.GetRowCount());
 
         if (Y_UNLIKELY(key1 && key2 && Compare(key2, key1, keyDefaults) > 0)) {
             key2 = key1; // will not go further than key1

--- a/ydb/core/tablet_flat/flat_part_index_iter_bree_index.h
+++ b/ydb/core/tablet_flat/flat_part_index_iter_bree_index.h
@@ -36,14 +36,14 @@ class TPartGroupBtreeIndexIter : public IPartGroupIndexIter {
         }
 
         bool IsLastPos() const {
-            Y_ABORT_UNLESS(Node);
-            Y_ABORT_UNLESS(Pos);
+            Y_ENSURE(Node);
+            Y_ENSURE(Pos);
             return *Pos == Node->GetKeysCount();
         }
 
         bool IsFirstPos() const {
-            Y_ABORT_UNLESS(Node);
-            Y_ABORT_UNLESS(Pos);
+            Y_ENSURE(Node);
+            Y_ENSURE(Pos);
             return *Pos == 0;
         }
     };
@@ -178,7 +178,7 @@ public:
     }
 
     EReady Next() override {
-        Y_ABORT_UNLESS(!IsExhausted());
+        Y_ENSURE(!IsExhausted());
 
         if (Meta.LevelCount == 0) {
             return Exhaust();
@@ -204,12 +204,12 @@ public:
         }
 
         // State.back() points to the target data page
-        Y_ABORT_UNLESS(IsLeaf());
+        Y_ENSURE(IsLeaf());
         return EReady::Data;
     }
 
     EReady Prev() override {
-        Y_ABORT_UNLESS(!IsExhausted());
+        Y_ENSURE(!IsExhausted());
 
         if (Meta.LevelCount == 0) {
             return Exhaust();
@@ -235,7 +235,7 @@ public:
         }
 
         // State.back() points to the target data page
-        Y_ABORT_UNLESS(IsLeaf());
+        Y_ENSURE(IsLeaf());
         return EReady::Data;
     }
 
@@ -250,34 +250,34 @@ public:
     }
 
     TPageId GetPageId() const override {
-        Y_ABORT_UNLESS(IsLeaf());
+        Y_ENSURE(IsLeaf());
         return State.back().PageId;
     }
 
     TRowId GetRowId() const override {
-        Y_ABORT_UNLESS(IsLeaf());
+        Y_ENSURE(IsLeaf());
         return State.back().BeginRowId;
     }
 
     TRowId GetNextRowId() const override {
-        Y_ABORT_UNLESS(IsLeaf());
+        Y_ENSURE(IsLeaf());
         return State.back().EndRowId;
     }
 
     TPos GetKeyCellsCount() const override {
-        Y_ABORT_UNLESS(IsLeaf());
+        Y_ENSURE(IsLeaf());
         return State.back().BeginKey.Count();
     }
 
     TCell GetKeyCell(TPos index) const override {
-        Y_ABORT_UNLESS(IsLeaf());
+        Y_ENSURE(IsLeaf());
         return State.back().BeginKey.Iter().At(index);
     }
 
     void GetKeyCells(TSmallVec<TCell>& keyCells) const override {
         keyCells.clear();
 
-        Y_ABORT_UNLESS(IsLeaf());
+        Y_ENSURE(IsLeaf());
 
         auto iter = State.back().BeginKey.Iter();
         for (TPos pos : xrange(iter.Count())) {
@@ -312,7 +312,7 @@ private:
         }
 
         // State.back() points to the target data page
-        Y_ABORT_UNLESS(IsLeaf());
+        Y_ENSURE(IsLeaf());
         Y_DEBUG_ABORT_UNLESS(seek.BelongsTo(State.back()));
         return EReady::Data;
     }
@@ -341,7 +341,7 @@ private:
 
     void PushNextState(TRecIdx pos) {
         TNodeState& current = State.back();
-        Y_ABORT_UNLESS(pos < current.Node->GetChildrenCount(), "Should point to some child");
+        Y_ENSURE(pos < current.Node->GetChildrenCount(), "Should point to some child");
         current.Pos.emplace(pos);
 
         auto& child = current.Node->GetShortChild(pos);

--- a/ydb/core/tablet_flat/flat_part_index_iter_flat_index.h
+++ b/ydb/core/tablet_flat/flat_part_index_iter_flat_index.h
@@ -117,20 +117,20 @@ public:
     }
 
     TPageId GetPageId() const override {
-        Y_ABORT_UNLESS(Index);
-        Y_ABORT_UNLESS(Iter);
+        Y_ENSURE(Index);
+        Y_ENSURE(Iter);
         return Iter->GetPageId();
     }
 
     TRowId GetRowId() const override {
-        Y_ABORT_UNLESS(Index);
-        Y_ABORT_UNLESS(Iter);
+        Y_ENSURE(Index);
+        Y_ENSURE(Iter);
         return Iter->GetRowId();
     }
 
     TRowId GetNextRowId() const override {
-        Y_ABORT_UNLESS(Index);
-        Y_ABORT_UNLESS(Iter);
+        Y_ENSURE(Index);
+        Y_ENSURE(Iter);
         auto next = Iter + 1;
         return next
             ? next->GetRowId()
@@ -138,22 +138,22 @@ public:
     }
 
     TPos GetKeyCellsCount() const override {
-        Y_ABORT_UNLESS(Index);
-        Y_ABORT_UNLESS(Iter);
+        Y_ENSURE(Index);
+        Y_ENSURE(Iter);
         return GroupInfo.KeyTypes.size();
     }
 
     TCell GetKeyCell(TPos index) const override {
-        Y_ABORT_UNLESS(Index);
-        Y_ABORT_UNLESS(Iter);
+        Y_ENSURE(Index);
+        Y_ENSURE(Iter);
         return Iter.GetRecord()->Cell(GroupInfo.ColsKeyIdx[index]);
     }
 
     void GetKeyCells(TSmallVec<TCell>& keyCells) const override {
         keyCells.clear();
 
-        Y_ABORT_UNLESS(Index);
-        Y_ABORT_UNLESS(Iter);
+        Y_ENSURE(Index);
+        Y_ENSURE(Iter);
         
         auto record = Iter.GetRecord();
         for (auto index : xrange(GroupInfo.KeyTypes.size())) {
@@ -162,15 +162,15 @@ public:
     }
 
     const TRecord * GetRecord() const {
-        Y_ABORT_UNLESS(Index);
-        Y_ABORT_UNLESS(Iter);
+        Y_ENSURE(Index);
+        Y_ENSURE(Iter);
         return Iter.GetRecord();
     }
 
     // currently this method is needed for tests only, but it's worth to keep it for future optimizations
     const TRecord * GetLastRecord() const {
-        Y_ABORT_UNLESS(Index);
-        Y_ABORT_UNLESS(Iter, "Should be called only after SeekLast call");
+        Y_ENSURE(Index);
+        Y_ENSURE(Iter, "Should be called only after SeekLast call");
         return Index->GetLastKeyRecord();
     }
 

--- a/ydb/core/tablet_flat/flat_part_keys.h
+++ b/ydb/core/tablet_flat/flat_part_keys.h
@@ -91,11 +91,11 @@ namespace NTable {
                     return true;
                 }
 
-                Y_ABORT_UNLESS(Index->GetRowId() <= rowId, "SeekIndex invariant failure");
+                Y_ENSURE(Index->GetRowId() <= rowId, "SeekIndex invariant failure");
                 if (!LoadPage(Index->GetPageId())) {
                     return false;
                 }
-                Y_ABORT_UNLESS(Page.BaseRow() == Index->GetRowId(), "Index and data are out of sync");
+                Y_ENSURE(Page.BaseRow() == Index->GetRowId(), "Index and data are out of sync");
                 auto lastRowId = Page.BaseRow() + (Page->Count - 1);
                 if (lastRowId < rowId) {
                     // Row is out of range for this page
@@ -114,12 +114,12 @@ namespace NTable {
             if (hasLast == EReady::Page) {
                 return false;
             }
-            Y_ABORT_UNLESS(hasLast != EReady::Gone, "Unexpected failure to find the last index record");
+            Y_ENSURE(hasLast != EReady::Gone, "Unexpected failure to find the last index record");
 
             if (!LoadPage(Index->GetPageId())) {
                 return false;
             }
-            Y_ABORT_UNLESS(Page.BaseRow() == Index->GetRowId(), "Index and data are out of sync");
+            Y_ENSURE(Page.BaseRow() == Index->GetRowId(), "Index and data are out of sync");
             auto lastRowId = Page.BaseRow() + (Page->Count - 1);
             LoadRow(lastRowId);
             return true;
@@ -127,10 +127,10 @@ namespace NTable {
 
         bool LoadPage(TPageId pageId)
         {
-            Y_ABORT_UNLESS(pageId != Max<TPageId>(), "Unexpected seek to an invalid page id");
+            Y_ENSURE(pageId != Max<TPageId>(), "Unexpected seek to an invalid page id");
             if (PageId != pageId) {
                 if (auto* data = Env->TryGetPage(Part, pageId, {})) {
-                    Y_ABORT_UNLESS(Page.Set(data), "Unexpected failure to load data page");
+                    Y_ENSURE(Page.Set(data), "Unexpected failure to load data page");
                     PageId = pageId;
                 } else {
                     return false;
@@ -143,7 +143,7 @@ namespace NTable {
         {
             if (RowId != rowId) {
                 auto it = Page->Begin() + (rowId - Page.BaseRow());
-                Y_ABORT_UNLESS(it, "Unexpected failure to find row on the data page");
+                Y_ENSURE(it, "Unexpected failure to find row on the data page");
                 Key.clear();
                 for (const auto& info : Part->Scheme->Groups[0].ColsKeyData) {
                     Key.push_back(it->Cell(info));

--- a/ydb/core/tablet_flat/flat_part_outset.cpp
+++ b/ydb/core/tablet_flat/flat_part_outset.cpp
@@ -15,7 +15,7 @@ TEpoch TPartComponents::GetEpoch() const {
         return Epoch;
     }
 
-    Y_ABORT_UNLESS(PageCollectionComponents && PageCollectionComponents[0].Packet,
+    Y_ENSURE(PageCollectionComponents && PageCollectionComponents[0].Packet,
         "PartComponents has neither a known epoch, nor a parsed meta packet");
 
     return TLoader::GrabEpoch(*this);

--- a/ydb/core/tablet_flat/flat_part_overlay.cpp
+++ b/ydb/core/tablet_flat/flat_part_overlay.cpp
@@ -51,7 +51,7 @@ TString TOverlay::Encode() const
     NProto::TOverlay plain;
 
     if (Screen) {
-        Y_ABORT_UNLESS(Screen->Size() > 0,
+        Y_ENSURE(Screen->Size() > 0,
             "Cannot serialize a screen with 0 holes");
 
         Screen->Validate();
@@ -63,7 +63,7 @@ TString TOverlay::Encode() const
     }
 
     if (Slices) {
-        Y_ABORT_UNLESS(Slices->size() > 0,
+        Y_ENSURE(Slices->size() > 0,
             "Cannot serialize a run with 0 slices");
 
         Slices->Validate();
@@ -94,11 +94,11 @@ TOverlay TOverlay::Decode(TArrayRef<const char> opaque, TArrayRef<const char> op
         }
 
         if (!ok) {
-            Y_Fail("Failed to parse part overlay");
+            Y_TABLET_ERROR("Failed to parse part overlay");
         }
 
         if (plain.ScreenSize() & 1) {
-            Y_Fail("Overlay has invalid screen size " << plain.ScreenSize());
+            Y_TABLET_ERROR("Overlay has invalid screen size " << plain.ScreenSize());
         }
 
         TScreen::TVec holes;
@@ -143,23 +143,23 @@ void TOverlay::Validate() const
 
     while (screen) {
         if (!slices) {
-            Y_ABORT("Found screen hole [%lu,%lu) that has no matching slices", screen->Begin, screen->End);
+            Y_TABLET_ERROR("Found screen hole [" << screen->Begin << "," << screen->End << ") that has no matching slices");
         }
 
         if (screen->End == Max<TRowId>()) {
             if (slices.HasNext()) {
                 auto mid = *slices;
                 ++slices;
-                Y_ABORT("Found screen hole [%lu,+inf) that does not match slices [%lu,%lu) and [%lu,%lu)",
-                    screen->Begin, mid.Begin, mid.End, slices->Begin, slices->End);
+                Y_TABLET_ERROR("Found screen hole [" << screen->Begin << ",+inf) that does not match slices ["
+                    << mid.Begin << "," << mid.End << ") and [" << slices->Begin << "," << slices->End << ")");
             }
             if (screen->Begin != slices->Begin) {
-                Y_ABORT("Found screen hole [%lu,+inf) that does not match slice [%lu,%lu)",
-                    screen->Begin, slices->Begin, slices->End);
+                Y_TABLET_ERROR("Found screen hole [" << screen->Begin << ",+inf) that does not match slice ["
+                    << slices->Begin << "," << slices->End << ")");
             }
         } else if (!(*screen == *slices)) {
-            Y_ABORT("Found screen hole [%lu,%lu) that does not match slice [%lu,%lu)",
-                screen->Begin, screen->End, slices->Begin, slices->End);
+            Y_TABLET_ERROR("Found screen hole [" << screen->Begin << "," << screen->End << ") that does not match slice ["
+                << slices->Begin << "," << slices->End << ")");
         }
 
         ++screen;
@@ -167,7 +167,7 @@ void TOverlay::Validate() const
     }
 
     if (slices) {
-        Y_ABORT("Found slice [%lu,%lu) that has no matching screen holes", slices->Begin, slices->End);
+        Y_TABLET_ERROR("Found slice [" << slices->Begin << "," << slices->End << ") that has no matching screen holes");
     }
 }
 
@@ -176,19 +176,19 @@ void TOverlay::ApplyDelta(TArrayRef<const char> rawDelta)
     NProto::TOverlayDelta plain;
 
     if (!ParseFromStringNoSizeLimit(plain, rawDelta)) {
-        Y_Fail("Failed to parse overlay delta");
+        Y_TABLET_ERROR("Failed to parse overlay delta");
     }
 
     if (auto removedSlices = SlicesFromProto(plain.GetRemovedSlices())) {
         TIntrusiveConstPtr<TSlices> removed = new TSlices(std::move(removedSlices));
         if (!TSlices::SupersetByRowId(Slices, removed)) {
-            Y_Fail("Removing slices that are not a subset of existing slices");
+            Y_TABLET_ERROR("Removing slices that are not a subset of existing slices");
         }
 
         Slices = TSlices::Subtract(Slices, removed);
 
         if (Slices->empty()) {
-            Y_Fail("Removing slices produced an empty result");
+            Y_TABLET_ERROR("Removing slices produced an empty result");
         }
 
         Screen = Slices->ToScreen();
@@ -203,7 +203,7 @@ TString TOverlay::EncodeRemoveSlices(const TIntrusiveConstPtr<TSlices>& slices)
 {
     NProto::TOverlayDelta plain;
 
-    Y_ABORT_UNLESS(slices, "Cannot encode an empty remove slices");
+    Y_ENSURE(slices, "Cannot encode an empty remove slices");
 
     SlicesToProto(*slices, plain.MutableRemovedSlices());
 
@@ -216,7 +216,7 @@ TString TOverlay::EncodeChangeSlices(TConstArrayRef<TSlice> slices)
 {
     NProto::TOverlayDelta plain;
 
-    Y_ABORT_UNLESS(slices, "Cannot encode an empty change slices");
+    Y_ENSURE(slices, "Cannot encode an empty change slices");
 
     SlicesToProto(slices, plain.MutableChangedSlices());
 
@@ -233,7 +233,7 @@ TString TOverlay::MaybeUnsplitSlices(const TString& opaque, size_t maxSize)
 
     NProto::TOverlay proto;
     if (!ParseFromStringNoSizeLimit(proto, opaque)) {
-        Y_Fail("Unexpected failure to parse part overlay");
+        Y_TABLET_ERROR("Unexpected failure to parse part overlay");
     }
 
     TVector<TSlice> slices = SlicesFromProto(proto.GetSlices());
@@ -271,7 +271,7 @@ TString TOverlay::MaybeUnsplitSlices(const TString& opaque, size_t maxSize)
 
     TString modified;
     if (!proto.SerializeToString(&modified)) {
-        Y_Fail("Unexpected failure to serialize part overlay");
+        Y_TABLET_ERROR("Unexpected failure to serialize part overlay");
     }
 
     return modified;

--- a/ydb/core/tablet_flat/flat_part_scheme.h
+++ b/ydb/core/tablet_flat/flat_part_scheme.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "util_basics.h"
+#include "util_fmt_abort.h"
 #include "flat_page_iface.h"
 #include "flat_row_eggs.h"
 #include "flat_row_column.h"
@@ -105,7 +106,7 @@ namespace NTable {
 
         const TGroupInfo& GetLayout(NPage::TGroupId groupId) const
         {
-            Y_ABORT_UNLESS(groupId.Index < Groups.size(), "Group is out of range");
+            Y_ENSURE(groupId.Index < Groups.size(), "Group is out of range");
 
             if (groupId.Index == 0) {
                 return groupId.Historic ? HistoryGroup : Groups[0];

--- a/ydb/core/tablet_flat/flat_part_screen.h
+++ b/ydb/core/tablet_flat/flat_part_screen.h
@@ -2,6 +2,7 @@
 
 #include "flat_row_eggs.h"
 #include "util_basics.h"
+#include "util_fmt_abort.h"
 #include <util/generic/deque.h>
 #include <util/generic/vector.h>
 #include <util/generic/ptr.h>
@@ -64,7 +65,7 @@ namespace NTable {
 
             void Pass(TRowId ref)
             {
-                Y_ABORT_UNLESS(Tail <= ref, "Got page ref from the past");
+                Y_ENSURE(Tail <= ref, "Got page ref from the past");
 
                 if (Open != Max<TRowId>() && Tail != ref) {
                     auto begin = std::exchange(Open, Max<TRowId>());
@@ -137,7 +138,7 @@ namespace NTable {
 
         size_t Lookup(TRowId rowId, int dir) const
         {
-            Y_ABORT_UNLESS(dir == +1, "Only forward direction supported");
+            Y_ENSURE(dir == +1, "Only forward direction supported");
 
             auto less = [](TRowId rowId, const THole &hole) {
                 return rowId < hole.End;
@@ -165,7 +166,7 @@ namespace NTable {
         {
             TRowId last = 0;
             for (const auto &hole : Holes) {
-                Y_ABORT_UNLESS(std::exchange(last, hole.End) <= hole.Begin,
+                Y_ENSURE(std::exchange(last, hole.End) <= hole.Begin,
                     "Screen not sorted or has intersections");
             }
         }
@@ -198,7 +199,7 @@ namespace NTable {
                 sub.back() = hole.Cut(sub.back());
 
                 if (!sub.front() || !sub.back()) {
-                    Y_ABORT("Produced trival edges on screen cutting");
+                    Y_TABLET_ERROR("Produced trival edges on screen cutting");
                 }
 
                 return new TScreen(std::move(sub));
@@ -215,7 +216,7 @@ namespace NTable {
             } else if (two == nullptr || two->Size() == 0) {
                 return one;
             } else if (one->Bounds().Cut(two->Bounds())) {
-                Y_ABORT("Cannot join two intersecting screens");
+                Y_TABLET_ERROR("Cannot join two intersecting screens");
             } else if (one->Bounds().End > two->Bounds().Begin) {
                 std::swap(one, two);
             }

--- a/ydb/core/tablet_flat/flat_part_shrink.h
+++ b/ydb/core/tablet_flat/flat_part_shrink.h
@@ -38,7 +38,7 @@ namespace NTable {
         TShrink& Put(TArrayRef<const TPartView> all, TCells from, TCells to)
         {
             for (auto &partView: all) {
-                Y_ABORT_UNLESS(partView.Slices, "Shrink attempt on a part without slices");
+                Y_ENSURE(partView.Slices, "Shrink attempt on a part without slices");
 
                 if (!from && !to) /* [-inf, +inf) */ {
                     PartView.emplace_back(partView);

--- a/ydb/core/tablet_flat/flat_part_store.h
+++ b/ydb/core/tablet_flat/flat_part_store.h
@@ -27,7 +27,7 @@ public:
 
 private:
     static TLogoBlobID ExtractLabel(const TVector<NPageCollection::TLargeGlobId>& largeGlobIds) {
-        Y_ABORT_UNLESS(!largeGlobIds.empty());
+        Y_ENSURE(!largeGlobIds.empty());
         return largeGlobIds[0].Lead;
     }
 
@@ -75,7 +75,7 @@ public:
 
     ui64 GetPageSize(NPage::TPageId pageId, NPage::TGroupId groupId) const override
     {
-        Y_ABORT_UNLESS(groupId.Index < PageCollections.size());
+        Y_ENSURE(groupId.Index < PageCollections.size());
         return PageCollections[groupId.Index]->GetPageSize(pageId);
     }
 
@@ -88,20 +88,20 @@ public:
 
     NPage::EPage GetPageType(NPage::TPageId pageId, NPage::TGroupId groupId) const override
     {
-        Y_ABORT_UNLESS(groupId.Index < PageCollections.size());
+        Y_ENSURE(groupId.Index < PageCollections.size());
         return PageCollections[groupId.Index]->GetPageType(pageId);
     }
 
     ui8 GetGroupChannel(NPage::TGroupId groupId) const override
     {
-        Y_ABORT_UNLESS(groupId.Index < PageCollections.size());
+        Y_ENSURE(groupId.Index < PageCollections.size());
         return PageCollections[groupId.Index]->Id.Channel();
     }
 
     ui8 GetPageChannel(ELargeObj lob, ui64 ref) const override
     {
         if ((lob != ELargeObj::Extern && lob != ELargeObj::Outer) || (ref >> 32)) {
-            Y_Fail("Invalid ref ELargeObj{" << int(lob) << ", " << ref << "}");
+            Y_TABLET_ERROR("Invalid ref ELargeObj{" << int(lob) << ", " << ref << "}");
         }
 
         if (lob == ELargeObj::Extern) {
@@ -128,7 +128,7 @@ public:
     TCache* Locate(ELargeObj lob, ui64 ref) const
     {
         if ((lob != ELargeObj::Extern && lob != ELargeObj::Outer) || (ref >> 32)) {
-            Y_Fail("Invalid ref ELargeObj{" << int(lob) << ", " << ref << "}");
+            Y_TABLET_ERROR("Invalid ref ELargeObj{" << int(lob) << ", " << ref << "}");
         }
 
         return (lob == ELargeObj::Extern ? Pseudo : PageCollections.at(GroupsCount)).Get();
@@ -136,7 +136,7 @@ public:
 
     TAutoPtr<NPageCollection::TFetch> GetPages(ui32 room) const
     {
-        Y_ABORT_UNLESS(room < PageCollections.size());
+        Y_ENSURE(room < PageCollections.size());
 
         auto total = PageCollections[room]->PageCollection->Total();
 
@@ -163,7 +163,7 @@ public:
     {
         auto *part = partView.As<TPartStore>();
 
-        Y_ABORT_UNLESS(!partView || part, "Got an unexpected type of TPart part");
+        Y_ENSURE(!partView || part, "Got an unexpected type of TPart part");
 
         return part ? part->PageCollections : TArrayRef<const TIntrusivePtr<TCache>> { };
     }

--- a/ydb/core/tablet_flat/flat_redo_player.h
+++ b/ydb/core/tablet_flat/flat_redo_player.h
@@ -26,7 +26,7 @@ namespace NRedo {
                     return { std::exchange(On, On + size), size };
             }
 
-            Y_ABORT("Damaged or invalid plainfied db redo log");
+            Y_TABLET_ERROR("Damaged or invalid plainfied db redo log");
         }
 
     private:
@@ -83,7 +83,7 @@ namespace NRedo {
                     break;
             }
 
-            Y_ABORT("Unexpected rodo log chunk type");
+            Y_TABLET_ERROR("Unexpected rodo log chunk type");
         }
 
         void HandleLegacy(const TChunk_Legacy* label, const TArrayRef<const char> chunk)
@@ -111,14 +111,14 @@ namespace NRedo {
                     break;
             }
 
-            Y_ABORT("Unexpected rodo log legacy chunk type");
+            Y_TABLET_ERROR("Unexpected rodo log legacy chunk type");
         }
 
     private:
         void DoBegin(const TArrayRef<const char> chunk)
         {
             if (chunk.size() < sizeof(TEvBegin_v0)) {
-                Y_Fail("EvBegin event is tool small, " << chunk.size() << "b");
+                Y_TABLET_ERROR("EvBegin event is tool small, " << chunk.size() << "b");
             } else if (chunk.size() < sizeof(TEvBegin_v1)) {
                 auto *ev = reinterpret_cast<const TEvBegin_v0*>(chunk.data());
 
@@ -126,7 +126,7 @@ namespace NRedo {
             } else {
                 auto *ev = reinterpret_cast<const TEvBegin_v1*>(chunk.data());
 
-                Y_ABORT_UNLESS(ev->Serial > 0, "Invalid serial in EvBegin record");
+                Y_ENSURE(ev->Serial > 0, "Invalid serial in EvBegin record");
 
                 Base.DoBegin(ev->Tail, ev->Head, ev->Serial, ev->Stamp);
             }
@@ -134,7 +134,7 @@ namespace NRedo {
 
         void DoAnnex(const TArrayRef<const char> chunk)
         {
-            Y_ABORT_UNLESS(chunk.size() >= sizeof(TEvAnnex));
+            Y_ENSURE(chunk.size() >= sizeof(TEvAnnex));
 
             using TGlobId = TStdPad<NPageCollection::TGlobId>;
 
@@ -146,7 +146,7 @@ namespace NRedo {
 
         void DoFlush(const TArrayRef<const char> chunk)
         {
-            Y_ABORT_UNLESS(chunk.size() >= sizeof(TEvFlush));
+            Y_ENSURE(chunk.size() >= sizeof(TEvFlush));
 
             auto *ev = reinterpret_cast<const TEvFlush*>(chunk.begin());
 
@@ -238,7 +238,7 @@ namespace NRedo {
 
         void DoFlushLegacy(const TArrayRef<const char> chunk)
         {
-            Y_ABORT_UNLESS(chunk.size() >= sizeof(TEvFlush_Legacy));
+            Y_ENSURE(chunk.size() >= sizeof(TEvFlush_Legacy));
 
             auto *op = reinterpret_cast<const TEvFlush_Legacy*>(chunk.begin());
 
@@ -260,9 +260,9 @@ namespace NRedo {
 
         ui32 ReadValue(const char* buf, ui32 maxSz, TRawTypeValue& val)
         {
-            Y_ABORT_UNLESS(maxSz >= sizeof(TValue), "Buffer to small");
+            Y_ENSURE(maxSz >= sizeof(TValue), "Buffer to small");
             const TValue* vp = (const TValue*)buf;
-            Y_ABORT_UNLESS(maxSz >= sizeof(TValue) + vp->Size, "Value size execeeds the buffer size");
+            Y_ENSURE(maxSz >= sizeof(TValue) + vp->Size, "Value size execeeds the buffer size");
             val = vp->IsNull() ? TRawTypeValue() : TRawTypeValue(vp + 1, vp->Size, vp->TypeId);
             return sizeof(TValue) + vp->Size;
         }
@@ -282,13 +282,13 @@ namespace NRedo {
 
         ui32 ReadOneOp(const char* buf, ui32 maxSz, TUpdateOp& uo)
         {
-            Y_ABORT_UNLESS(maxSz >= sizeof(TUpdate), "Buffer to small");
+            Y_ENSURE(maxSz >= sizeof(TUpdate), "Buffer to small");
             const TUpdate* up = (const TUpdate*)buf;
-            Y_ABORT_UNLESS(maxSz >= sizeof(TUpdate) + up->Val.Size, "Value size execeeds the buffer size");
+            Y_ENSURE(maxSz >= sizeof(TUpdate) + up->Val.Size, "Value size execeeds the buffer size");
             bool null = TCellOp::HaveNoPayload(up->CellOp) || up->Val.IsNull();
             uo = TUpdateOp(up->Tag, up->CellOp, null ? TRawTypeValue() : TRawTypeValue(up + 1, up->Val.Size, up->Val.TypeId));
 
-            Y_ABORT_UNLESS(up->CellOp == ELargeObj::Inline || (up->CellOp == ELargeObj::Extern && up->Val.Size == sizeof(ui32)));
+            Y_ENSURE(up->CellOp == ELargeObj::Inline || (up->CellOp == ELargeObj::Extern && up->Val.Size == sizeof(ui32)));
 
             return sizeof(TUpdate) + up->Val.Size;
         }

--- a/ydb/core/tablet_flat/flat_redo_writer.h
+++ b/ydb/core/tablet_flat/flat_redo_writer.h
@@ -5,6 +5,7 @@
 #include "flat_util_binary.h"
 #include "flat_sausage_solid.h"
 #include "util_basics.h"
+#include "util_fmt_abort.h"
 
 #include <util/stream/buffer.h>
 #include <util/system/sanitizers.h>
@@ -71,8 +72,8 @@ namespace NRedo {
 
         TWriter& EvBegin(ui32 tail, ui32 head, ui64 serial, ui64 stamp)
         {
-            Y_ABORT_UNLESS(tail <= head, "Invalid ABI/API evolution span");
-            Y_ABORT_UNLESS(serial > 0, "Serial of EvBegin starts with 1");
+            Y_ENSURE(tail <= head, "Invalid ABI/API evolution span");
+            Y_ENSURE(serial > 0, "Serial of EvBegin starts with 1");
 
             const ui32 size = sizeof(TEvBegin_v1);
 
@@ -104,7 +105,7 @@ namespace NRedo {
         {
             using namespace  NUtil::NBin;
 
-            Y_ABORT_UNLESS(blobs.size() <= Max<ui32>(), "Too large blobs catalog");
+            Y_ENSURE(blobs.size() <= Max<ui32>(), "Too large blobs catalog");
 
             const ui32 size = sizeof(TEvAnnex) + SizeOf(blobs);
 
@@ -122,9 +123,9 @@ namespace NRedo {
         TWriter& EvUpdate(ui32 table, ERowOp rop, TRawVals key, TOpsRef ops, ERedo tag, ui32 tailSize, TCallback&& tailCallback)
         {
             if (TCellOp::HaveNoOps(rop) && ops) {
-                Y_ABORT("Given ERowOp cannot have update operations");
+                Y_TABLET_ERROR("Given ERowOp cannot have update operations");
             } else if (key.size() + ops.size() > Max<ui16>()) {
-                Y_ABORT("Too large key or too many operations in one ops");
+                Y_TABLET_ERROR("Too large key or too many operations in one ops");
             }
 
             const ui32 size = sizeof(TEvUpdate) + tailSize + CalcSize(key, ops);
@@ -228,7 +229,7 @@ namespace NRedo {
         {
             TotalSize += bytes;
 
-            Y_ABORT_UNLESS(Events.size() == TotalSize, "Got an inconsistent redo entry size");
+            Y_ENSURE(Events.size() == TotalSize, "Got an inconsistent redo entry size");
 
             return *this;
         }
@@ -273,18 +274,18 @@ namespace NRedo {
             for (const auto &one: ops) {
                 /* Log enty cannot represent this ECellOp types with payload */
 
-                Y_ABORT_UNLESS(!(one.Value && TCellOp::HaveNoPayload(one.Op)));
+                Y_ENSURE(!(one.Value && TCellOp::HaveNoPayload(one.Op)));
 
                 const ui16 type = one.Value.Type();
 
                 if (one.Value.IsEmpty()) {
                     // Log entry cannot recover null value type, since we
                     // store null values using a special 0 type id.
-                    Y_ABORT_UNLESS(type == 0, "Cannot write typed null values");
+                    Y_ENSURE(type == 0, "Cannot write typed null values");
                     // Null value cannot have ECellOp::Set as its op, since we
                     // don't have the necessary type id, instead we expect
                     // it to be either ECellOp::Null or ECellOp::Reset.
-                    Y_ABORT_UNLESS(one.Op != ECellOp::Set, "Cannot write ECellOp::Set with a null value");
+                    Y_ENSURE(one.Op != ECellOp::Set, "Cannot write ECellOp::Set with a null value");
                 }
 
                 Write(out, one.Op, one.Tag, type, one.Value.AsRef());

--- a/ydb/core/tablet_flat/flat_row_celled.h
+++ b/ydb/core/tablet_flat/flat_row_celled.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "flat_row_nulls.h"
+#include "util_fmt_abort.h"
 #include <util/generic/vector.h>
 #include <library/cpp/containers/stack_vector/stack_vec.h>
 
@@ -15,13 +16,13 @@ namespace NTable {
             , Storage(Size)
             , Cells(Storage.data())
         {
-            Y_ABORT_UNLESS(key.size() <= keyDefaults->size(), "Key is too large");
+            Y_ENSURE(key.size() <= keyDefaults->size(), "Key is too large");
 
             for (ui32 it = 0; it < Size; it++) {
                 if (it >= key.size()) {
                     Cells[it] = keyDefaults[it];
                 } else if (key[it] && key[it].Type() != keyDefaults.Types[it].GetTypeId()) {
-                    Y_ABORT("Key does not comply table schema");
+                    Y_TABLET_ERROR("Key does not comply table schema");
                 } else {
                     Cells[it] = TCell((char*)key[it].Data(), key[it].Size());
                 }
@@ -35,7 +36,7 @@ namespace NTable {
             , Storage(Size)
             , Cells(Storage.data())
         {
-            Y_ABORT_UNLESS(key.size() <= keyDefaults->size(), "Key is too large");
+            Y_ENSURE(key.size() <= keyDefaults->size(), "Key is too large");
 
             for (ui32 it = 0; it < Size; it++) {
                 if (it >= key.size()) {

--- a/ydb/core/tablet_flat/flat_row_misc.h
+++ b/ydb/core/tablet_flat/flat_row_misc.h
@@ -32,7 +32,7 @@ namespace NFmt {
             , Types(types)
             , Registry(reg)
         {
-            Y_ABORT_UNLESS(cells.size() == Types.size(), "Cells and types size missmatch");
+            Y_ENSURE(cells.size() == Types.size(), "Cells and types size missmatch");
         }
 
         TOut& Do(TOut &out) const

--- a/ydb/core/tablet_flat/flat_row_nulls.h
+++ b/ydb/core/tablet_flat/flat_row_nulls.h
@@ -2,6 +2,7 @@
 
 #include "flat_util_misc.h"
 #include "util_basics.h"
+#include "util_fmt_abort.h"
 
 #include <ydb/core/scheme/scheme_tablecell.h>
 #include <library/cpp/containers/stack_vector/stack_vec.h>
@@ -19,10 +20,10 @@ namespace NTable {
             : Types(types)
             , Defs(defs)
         {
-            Y_ABORT_UNLESS(Defs.size() > 0 && Defs.size() == Types.size());
+            Y_ENSURE(Defs.size() > 0 && Defs.size() == Types.size());
             for (size_t index = 0; index < Types.size(); ++index) {
                 if (auto error = NScheme::HasUnexpectedValueSize(Defs[index], Types[index])) {
-                    Y_ABORT("Column default at index %" PRISZT " validation failed: %s", index, error.c_str());
+                    Y_TABLET_ERROR("Column default at index " << index << " validation failed: " << error);
                 }
             }
         }
@@ -72,7 +73,7 @@ namespace NTable {
                 }
             }
 
-            Y_ABORT_UNLESS(data == raw + offD + tail);
+            Y_ENSURE(data == raw + offD + tail);
 
             return ::new(raw) TSelf(
                     { ptrT, types.size() },
@@ -118,7 +119,7 @@ namespace NTable {
                 TArrayRef<const TCell> defs)
             : TCellDefaults(types, defs)
         {
-            Y_ABORT_UNLESS(order.size() == 0);
+            Y_ENSURE(order.size() == 0);
         }
 
     public:
@@ -143,7 +144,7 @@ namespace NTable {
             : TCellDefaults(types, defs)
             , Types(order)
         {
-            Y_ABORT_UNLESS(Types.size() == TCellDefaults::Types.size());
+            Y_ENSURE(Types.size() == TCellDefaults::Types.size());
         }
 
     public:

--- a/ydb/core/tablet_flat/flat_row_remap.h
+++ b/ydb/core/tablet_flat/flat_row_remap.h
@@ -2,6 +2,7 @@
 
 #include "flat_row_eggs.h"
 #include "flat_row_scheme.h"
+#include "util_fmt_abort.h"
 
 #include <ydb/core/scheme/scheme_tablecell.h>
 #include <library/cpp/containers/stack_vector/stack_vec.h>
@@ -46,7 +47,7 @@ namespace NTable {
 
             for (TPos on = 0; on < tags.size(); on++) {
                 const auto *info = scheme.ColInfo(tags[on]);
-                Y_ABORT_UNLESS(info, "Column %" PRIu32 " does not exist", tags[on]);
+                Y_ENSURE(info, "Column " << tags[on] << " does not exist");
                 Types_[on] = info->TypeInfo;
 
                 CellDefaults_.emplace_back((*scheme.RowCellDefaults)[info->Pos]);
@@ -54,8 +55,9 @@ namespace NTable {
                 if (info->IsKey())
                     KeyPins_.push_back({ on, info->Key });
 
-                if (!Tag2Pos.insert(std::make_pair(tags[on], on)).second)
-                    Y_ABORT("Duplicated tag found in remap, isn't allowed");
+                if (!Tag2Pos.insert(std::make_pair(tags[on], on)).second) {
+                    Y_TABLET_ERROR("Duplicated tag found in remap, isn't allowed");
+                }
             }
         }
 

--- a/ydb/core/tablet_flat/flat_row_scheme.h
+++ b/ydb/core/tablet_flat/flat_row_scheme.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include "util_fmt_abort.h"
 #include "flat_row_column.h"
 #include "flat_row_nulls.h"
 #include "flat_table_column.h"
@@ -80,7 +81,7 @@ namespace NTable {
                 auto &col = *info.emplace(info.end());
 
                 auto familyIt = std::lower_bound(families.begin(), families.end(), meta.Family);
-                Y_ABORT_UNLESS(familyIt != families.end() && *familyIt == meta.Family);
+                Y_ENSURE(familyIt != families.end() && *familyIt == meta.Family);
 
                 col.Tag = meta.Id;
                 col.TypeInfo = meta.PType;
@@ -126,13 +127,13 @@ namespace NTable {
                 auto *other = scheme.ColInfo(col.Tag);
 
                 if (other == nullptr && col.IsKey()) {
-                    Y_ABORT_S("Table " << tableName << " key column " << col.Tag << " cannot be dropped");
+                    Y_TABLET_ERROR("Table " << tableName << " key column " << col.Tag << " cannot be dropped");
                 } else if (other == nullptr) {
                     /* It is ok to drop non-key columns */
                 } else if (col.TypeInfo != other->TypeInfo) {
-                    Y_ABORT_S("Table " << tableName << " column " << col.Tag << " cannot be altered with type " << col.TypeInfo.GetTypeId() << " -> " << other->TypeInfo.GetTypeId());
+                    Y_TABLET_ERROR("Table " << tableName << " column " << col.Tag << " cannot be altered with type " << col.TypeInfo.GetTypeId() << " -> " << other->TypeInfo.GetTypeId());
                 } else if (col.Key != other->Key) {
-                    Y_ABORT_S("Table " << tableName << " column " << col.Tag << " cannot be added to key or reordered " << col.Key << " -> " << other->Key);
+                    Y_TABLET_ERROR("Table " << tableName << " column " << col.Tag << " cannot be added to key or reordered " << col.Key << " -> " << other->Key);
 
                     /* Existing string columns can't be altered to keys as
                         they may hold external blobs references which is not
@@ -144,7 +145,7 @@ namespace NTable {
                 } else {
                     auto &null = (*scheme.RowCellDefaults)[other->Pos];
                     if (CompareTypedCells(null, (*RowCellDefaults)[col.Pos], col.TypeInfo))
-                        Y_ABORT_S("Table " << tableName << " column " << col.Tag << " existing default value cannot be altered");
+                        Y_TABLET_ERROR("Table " << tableName << " column " << col.Tag << " existing default value cannot be altered");
                 }
             }
         }

--- a/ydb/core/tablet_flat/flat_row_state.h
+++ b/ydb/core/tablet_flat/flat_row_state.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "flat_row_eggs.h"
+#include "util_fmt_abort.h"
 #include <ydb/core/scheme/scheme_tablecell.h>
 #include <library/cpp/containers/stack_vector/stack_vec.h>
 
@@ -52,7 +53,7 @@ namespace NTable {
 
         bool Touch(ERowOp op)
         {
-            Y_ABORT_UNLESS(!(Rop == ERowOp::Erase || Rop == ERowOp::Reset),
+            Y_ENSURE(!(Rop == ERowOp::Erase || Rop == ERowOp::Reset),
                 "Sequence for row state is already finalized");
 
             switch (op) {
@@ -64,13 +65,13 @@ namespace NTable {
                     Rop = (Rop == ERowOp::Absent ? ERowOp::Erase : ERowOp::Reset);
                     return false; /* current row shouldn't be processed */
                 default:
-                    Y_ABORT("Unexpected row rolling operation code: %" PRIu8, ui8(op));
+                    Y_TABLET_ERROR("Unexpected row rolling operation code: " << ui8(op));
             }
         }
 
         void Set(TPos on, TCellOp code, const TCell &cell)
         {
-            Y_ABORT_UNLESS(State[on] == ECellOp::Empty, "Updating cell that already has a value assigned");
+            Y_ENSURE(State[on] == ECellOp::Empty, "Updating cell that already has a value assigned");
 
             if (Y_UNLIKELY(code == ECellOp::Empty)) {
                 // Source column is not set, nothing to update
@@ -78,7 +79,7 @@ namespace NTable {
                 return;
             }
 
-            Y_ABORT_UNLESS(Left_ > 0, "Cells update counter is out of sync");
+            Y_ENSURE(Left_ > 0, "Cells update counter is out of sync");
             --Left_;
 
             if (Y_UNLIKELY(code == ECellOp::Reset)) {
@@ -102,7 +103,7 @@ namespace NTable {
         }
 
         void Merge(const TRowState& other) {
-            Y_ABORT_UNLESS(!(Rop == ERowOp::Erase || Rop == ERowOp::Reset),
+            Y_ENSURE(!(Rop == ERowOp::Erase || Rop == ERowOp::Reset),
                 "Sequence for row state is already finalized");
 
             if (Y_UNLIKELY(other.Rop == ERowOp::Absent)) {

--- a/ydb/core/tablet_flat/flat_sausage_align.h
+++ b/ydb/core/tablet_flat/flat_sausage_align.h
@@ -13,7 +13,7 @@ namespace NPageCollection {
         TBorder Lookup(ui64 offset, const ui64 sz) const
         {
             auto it = UpperBound(Steps.begin(), Steps.end(), offset);
-            Y_ABORT_UNLESS(it != Steps.end(), "Lookup span is out of borders");
+            Y_ENSURE(it != Steps.end(), "Lookup span is out of borders");
 
             const ui32 first = std::distance(Steps.begin(), it);
             const ui64 base = it == Steps.begin() ? 0 : *(it - 1);
@@ -24,7 +24,7 @@ namespace NPageCollection {
 
             while (Steps[last] < szoffset) {
                 lastOffset = Steps[last++];
-                Y_ABORT_UNLESS(last < Steps.size(), "Lookup span is out of borders");
+                Y_ENSURE(last < Steps.size(), "Lookup span is out of borders");
             }
 
             return

--- a/ydb/core/tablet_flat/flat_sausage_chop.h
+++ b/ydb/core/tablet_flat/flat_sausage_chop.h
@@ -41,7 +41,7 @@ namespace NPageCollection {
                 for (auto num : xrange(logo.size())) {
                     auto &base = logo[logo.size() - 1 == num ? num : 0];
 
-                    Y_ABORT_UNLESS(logo[num].BlobSize() == base.BlobSize());
+                    Y_ENSURE(logo[num].BlobSize() == base.BlobSize());
                 }
 
                 const ui32 bulk = (logo.size() - 1) * logo[0].BlobSize();

--- a/ydb/core/tablet_flat/flat_sausage_flow.h
+++ b/ydb/core/tablet_flat/flat_sausage_flow.h
@@ -2,6 +2,7 @@
 
 #include "flat_sausage_misc.h"
 #include "flat_sausage_solid.h"
+#include "util_fmt_abort.h"
 #include <util/generic/deque.h>
 
 namespace NKikimr {
@@ -76,7 +77,7 @@ namespace NPageCollection {
                     if (was == Glob.Group || was == TLargeGlobId::InvalidGroup) {
 
                     } else if (it != bound.Lo.Blob) {
-                        Y_ABORT("Page placed over different groups");
+                        Y_TABLET_ERROR("Page placed over different groups");
                     } else if (from < Queue.size()) {
                         /* Have to do each grow over the same group */
 

--- a/ydb/core/tablet_flat/flat_sausage_grind.h
+++ b/ydb/core/tablet_flat/flat_sausage_grind.h
@@ -37,20 +37,20 @@ namespace NPageCollection {
             , Slots(Max<ui8>(), Max<ui8>())
         {
             if ((cookieRange.Head & ~Mask) || (cookieRange.Tail & ~Mask)) {
-                Y_ABORT("CookieRange range can use only lower 24 bits");
+                Y_TABLET_ERROR("CookieRange range can use only lower 24 bits");
             } else if (cookieRange.Head > cookieRange.Tail) {
-                Y_ABORT("Invalid TLogoBlobID cookieRange capacity range");
+                Y_TABLET_ERROR("Invalid TLogoBlobID cookieRange capacity range");
             }
 
             for (auto &one: row) {
                 auto &place = Slots[one.Channel];
 
-                Y_ABORT_UNLESS(one.Channel != Max<ui8>(),
+                Y_ENSURE(one.Channel != Max<ui8>(),
                     "Channel cannot be set to Max<ui8>() value");
 
                 if (place != Max<ui8>()) {
                     /* Channel already associated with a group */
-                    Y_ABORT_UNLESS(Group[place] == one.Group,
+                    Y_ENSURE(Group[place] == one.Group,
                         "Channel assigned to different groups");
                     continue;
                 }
@@ -109,7 +109,7 @@ namespace NPageCollection {
         {
             auto slot = Slots[channel];
 
-            Y_ABORT_UNLESS(slot != Max<ui8>(), "Requested unknown channel");
+            Y_ENSURE(slot != Max<ui8>(), "Requested unknown channel");
 
             return slot;
         }
@@ -122,8 +122,9 @@ namespace NPageCollection {
 
             num += left;
 
-            if (num > Span || Span - num <= (Mask & value))
-                Y_Fail(NFmt::Do(*this) << " #" << slot << " was exhausted");
+            if (num > Span || Span - num <= (Mask & value)) {
+                Y_TABLET_ERROR(NFmt::Do(*this) << " #" << slot << " was exhausted");
+            }
 
             ui32 to = ((Mask & value) + num) | (gap ? Spacer : 0);
 
@@ -151,9 +152,9 @@ namespace NPageCollection {
         void Switch(const ui32 step, bool strict)
         {
             if (step == Max<ui32>()) {
-                Y_Fail(NFmt::Do(*this) << " is out of steps capacity");
+                Y_TABLET_ERROR(NFmt::Do(*this) << " is out of steps capacity");
             } else if (Step + (strict ? 1 : 0) > step && Step != Max<ui32>()) {
-                Y_Fail(
+                Y_TABLET_ERROR(
                     NFmt::Do(*this) << " got stuck on step switch to "
                     <<  step << ", " << (strict ? "strict" : "weak"));
             } else if (std::exchange(Step, step) != step) {

--- a/ydb/core/tablet_flat/flat_sausage_meta.cpp
+++ b/ydb/core/tablet_flat/flat_sausage_meta.cpp
@@ -9,9 +9,9 @@ TMeta::TMeta(TSharedData raw, ui32 group)
     : Raw(std::move(raw))
     , Group(group)
 {
-    Y_ABORT_UNLESS(Raw.size() >= sizeof(NPageCollection::THeader));
+    Y_ENSURE(Raw.size() >= sizeof(NPageCollection::THeader));
     Header = (const NPageCollection::THeader *)Raw.data();
-    Y_ABORT_UNLESS(Header->Magic == NPageCollection::Magic);
+    Y_ENSURE(Header->Magic == NPageCollection::Magic);
 
     if (Header->Pages == 0)
         return;
@@ -43,7 +43,7 @@ size_t TMeta::BackingSize() const noexcept
 
 TBorder TMeta::Bounds(ui32 begin, ui32 end) const
 {
-    Y_ABORT_UNLESS(begin <= end && Max(begin, end) < Header->Pages);
+    Y_ENSURE(begin <= end && Max(begin, end) < Header->Pages);
 
     const ui64 offset = (begin == 0) ? 0 : Index[begin - 1].Page;
 
@@ -52,9 +52,8 @@ TBorder TMeta::Bounds(ui32 begin, ui32 end) const
 
 TInfo TMeta::Page(ui32 page) const
 {
-    Y_ABORT_UNLESS(page < Header->Pages,
-            "Requested page %" PRIu32 " out of %" PRIu32 " total pages",
-            page, Header->Pages);
+    Y_ENSURE(page < Header->Pages,
+            "Requested page " << page << " out of " << Header->Pages << " total pages");
 
     return { GetPageSize(page), Extra[page].Type };
 }

--- a/ydb/core/tablet_flat/flat_sausage_packet.h
+++ b/ydb/core/tablet_flat/flat_sausage_packet.h
@@ -3,6 +3,7 @@
 #include "flat_sausage_meta.h"
 #include "flat_sausage_solid.h"
 #include "flat_sausage_gut.h"
+#include "util_fmt_abort.h"
 
 namespace NKikimr {
 namespace NPageCollection {
@@ -15,8 +16,9 @@ namespace NPageCollection {
             : LargeGlobId(largeGlobId)
             , Meta(std::move(raw), LargeGlobId.Group)
         {
-            if (!Meta.Raw || LargeGlobId.Bytes != Meta.Raw.size() || LargeGlobId.Group == TLargeGlobId::InvalidGroup)
-                Y_ABORT("Invalid TLargeGlobId of page collection meta blob");
+            if (!Meta.Raw || LargeGlobId.Bytes != Meta.Raw.size() || LargeGlobId.Group == TLargeGlobId::InvalidGroup) {
+                Y_TABLET_ERROR("Invalid TLargeGlobId of page collection meta blob");
+            }
         }
 
         const TLogoBlobID& Label() const noexcept override

--- a/ydb/core/tablet_flat/flat_sausage_record.h
+++ b/ydb/core/tablet_flat/flat_sausage_record.h
@@ -43,7 +43,7 @@ namespace NPageCollection {
 
         void PushInplace(ui32 page, TArrayRef<const char> body)
         {
-            Y_ABORT_UNLESS(Index && page == Index.size() - 1);
+            Y_ENSURE(Index && page == Index.size() - 1);
 
             Inbound.append(body.data(), body.size());
             Index.back().Inplace = Inbound.size();
@@ -77,7 +77,7 @@ namespace NPageCollection {
                 ptr += sizeof(crc);
             }
 
-            Y_ABORT_UNLESS(ptr == raw.mutable_end());
+            Y_ENSURE(ptr == raw.mutable_end());
             NSan::CheckMemIsInitialized(raw.data(), raw.size());
 
             Blobs.clear();

--- a/ydb/core/tablet_flat/flat_sausage_slicer.h
+++ b/ydb/core/tablet_flat/flat_sausage_slicer.h
@@ -1,7 +1,7 @@
 #pragma once
 
-#include "util_fmt_abort.h"
 #include "flat_sausage_grind.h"
+#include "util_fmt_abort.h"
 #include <ydb/core/base/tablet.h>
 #include <util/thread/singleton.h>
 #include <library/cpp/blockcodecs/codecs.h>
@@ -22,12 +22,12 @@ namespace NPageCollection {
         TGlobId One(TVector<TEvTablet::TLogEntryReference> &refs, TString body, bool lz4) const
         {
             if (body.size() > Block) {
-                Y_Fail(
+                Y_TABLET_ERROR(
                     "Cannot put " << body.size() << "b to "<< NFmt::Do(*CookieAllocator)
                     << " as single blob, block limit is " << Block << "b");
             }
 
-            Y_ABORT_UNLESS(body.size() < Block, "Too large blob to be a TGlobId");
+            Y_ENSURE(body.size() < Block, "Too large blob to be a TGlobId");
 
             if (lz4) std::exchange(body, Lz4()->Encode(body));
 
@@ -41,7 +41,7 @@ namespace NPageCollection {
         TLargeGlobId Do(TVector<TEvTablet::TLogEntryReference> &refs, TString body, bool lz4) const
         {
             if (body.size() >= Max<ui32>()) {
-                Y_Fail(
+                Y_TABLET_ERROR(
                     "Cannot put " << body.size() << "b to "<< NFmt::Do(*CookieAllocator)
                     << " as a TSloid, blob have to be less than 4GiB");
             }

--- a/ydb/core/tablet_flat/flat_sausage_solid.h
+++ b/ydb/core/tablet_flat/flat_sausage_solid.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include "util_fmt_abort.h"
+
 #include <ydb/core/base/logoblob.h>
 #include <ydb/library/actors/util/shared_data.h>
 
@@ -28,8 +30,8 @@ namespace NPageCollection {
             , Bytes(bytes)
             , Lead(lead)
         {
-            //Y_ABORT_UNLESS(Group != InvalidGroup, "Invalid TLargeGlobId storage group");
-            Y_ABORT_UNLESS(Lead && Lead.BlobSize() && Lead.BlobSize() <= Bytes);
+            //Y_ENSURE(Group != InvalidGroup, "Invalid TLargeGlobId storage group");
+            Y_ENSURE(Lead && Lead.BlobSize() && Lead.BlobSize() <= Bytes);
         }
 
         void Describe(IOutputStream &out) const
@@ -239,17 +241,17 @@ namespace NPageCollection {
                 if (Blobs[idx] != id) {
                     continue;
                 }
-                Y_ABORT_UNLESS(!Bodies[idx],
-                    "Apply blob %s multiple times", id.ToString().c_str());
-                Y_ABORT_UNLESS(id.BlobSize() == body.size(),
-                    "Apply blob %s and body size mismatch", id.ToString().c_str());
+                Y_ENSURE(!Bodies[idx],
+                    "Apply called for blob " << id << " multiple times");
+                Y_ENSURE(id.BlobSize() == body.size(),
+                    "Apply called for blob " << id << " with body size " << body.size());
                 // N.B. we store individual bodies to minimize upfront memory requirements
                 BytesLoaded += body.size();
                 Bodies[idx] = std::move(body);
                 return ++BlobsLoaded == Blobs.size();
             }
 
-            Y_ABORT("Apply unknown blob %s", id.ToString().c_str());
+            Y_TABLET_ERROR("Apply called for unknown blob " << id);
         }
 
         explicit operator bool() const {

--- a/ydb/core/tablet_flat/flat_sausage_writer.h
+++ b/ydb/core/tablet_flat/flat_sausage_writer.h
@@ -72,7 +72,7 @@ namespace NPageCollection {
             if (Buffer) {
                 auto glob = CookieAllocator.Do(Channel, Buffer.size());
 
-                Y_ABORT_UNLESS(glob.Group == Record.Group, "Unexpected BS group");
+                Y_ENSURE(glob.Group == Record.Group, "Unexpected BS group");
 
                 Blobs.emplace_back(glob, TakeBuffer());
                 Record.Push(glob.Logo);

--- a/ydb/core/tablet_flat/flat_sausagecache.h
+++ b/ydb/core/tablet_flat/flat_sausagecache.h
@@ -133,7 +133,7 @@ public:
         }
 
         void AddSticky(TPageId pageId, TSharedPageRef page) {
-            Y_ABORT_UNLESS(page.IsUsed());
+            Y_ENSURE(page.IsUsed());
             if (StickyPages.emplace(pageId, page).second) {
                 StickyPagesSize += TPinnedPageRef(page)->size();
             }

--- a/ydb/core/tablet_flat/flat_scan_feed.h
+++ b/ydb/core/tablet_flat/flat_scan_feed.h
@@ -5,6 +5,7 @@
 #include "flat_part_iface.h"
 #include "flat_iterator.h"
 #include "flat_table_subset.h"
+#include "util_fmt_abort.h"
 
 namespace NKikimr {
 namespace NTable {
@@ -68,10 +69,10 @@ namespace NTable {
                         return EReady::Gone;
 
                     case EScan::Reset:
-                        Y_ABORT("Unexpected EScan::Reset from IScan::Seek(...)");
+                        Y_TABLET_ERROR("Unexpected EScan::Reset from IScan::Seek(...)");
                 }
 
-                Y_ABORT("Unexpected EScan result from IScan::Seek(...)");
+                Y_TABLET_ERROR("Unexpected EScan result from IScan::Seek(...)");
             } else if (Seek()) {
                 return NotifyPageFault();
             } else {
@@ -201,9 +202,9 @@ namespace NTable {
                             break;
 
                         case EVersionState::SkipUncommitted:
-                            Y_ABORT("Unexpected callback state SkipUncommitted");
+                            Y_TABLET_ERROR("Unexpected callback state SkipUncommitted");
                         case EVersionState::SkipVersion:
-                            Y_ABORT("Unexpected callback state SkipVersion");
+                            Y_TABLET_ERROR("Unexpected callback state SkipVersion");
                     }
 
                     OnPause = (op == EScan::Sleep);
@@ -224,7 +225,7 @@ namespace NTable {
                             return EReady::Gone;
                     }
 
-                    Y_ABORT("Unexpected EScan result from IScan::Feed(...)");
+                    Y_TABLET_ERROR("Unexpected EScan result from IScan::Feed(...)");
                 }
             }
         }
@@ -277,7 +278,7 @@ namespace NTable {
                     return EReady::Gone;
             }
 
-            Y_ABORT("Unexpected EScan result from IScan::PageFault(...)");
+            Y_TABLET_ERROR("Unexpected EScan result from IScan::PageFault(...)");
         }
 
         EReady NotifyExhausted()
@@ -299,21 +300,21 @@ namespace NTable {
                     return EReady::Gone;
 
                 case EScan::Feed:
-                    Y_ABORT("Unexpected EScan::Feed from IScan::Exhausted(...)");
+                    Y_TABLET_ERROR("Unexpected EScan::Feed from IScan::Exhausted(...)");
             }
 
-            Y_ABORT("Unexpected EScan result from IScan::Exhausted(...)");
+            Y_TABLET_ERROR("Unexpected EScan result from IScan::Exhausted(...)");
         }
 
         bool Reset()
         {
             Seeks++;
 
-            Y_ABORT_UNLESS(Lead, "Cannot seek with invalid lead");
+            Y_ENSURE(Lead, "Cannot seek with invalid lead");
 
             auto keyDefaults = Subset.Scheme->Keys;
 
-            Y_ABORT_UNLESS(Lead.Key.GetCells().size() <= keyDefaults->Size(), "TLead key is too large");
+            Y_ENSURE(Lead.Key.GetCells().size() <= keyDefaults->Size(), "TLead key is too large");
 
             Iter = new TTableIter(Subset.Scheme.Get(), Lead.Tags, -1, SnapshotVersion, Subset.CommittedTransactions);
 
@@ -370,13 +371,13 @@ namespace NTable {
                 TVector<const TPartView*> parts;
                 parts.reserve(Subset.Flatten.size() + LoadedParts.size());
                 for (const auto& partView : Subset.Flatten) {
-                    Y_ABORT_UNLESS(partView.Part, "Missing part in subset");
-                    Y_ABORT_UNLESS(partView.Slices, "Missing part slices in subset");
+                    Y_ENSURE(partView.Part, "Missing part in subset");
+                    Y_ENSURE(partView.Slices, "Missing part slices in subset");
                     parts.push_back(&partView);
                 }
                 for (const auto& partView : LoadedParts) {
-                    Y_ABORT_UNLESS(partView.Part, "Missing part in subset");
-                    Y_ABORT_UNLESS(partView.Slices, "Missing part slices in subset");
+                    Y_ENSURE(partView.Part, "Missing part in subset");
+                    Y_ENSURE(partView.Slices, "Missing part slices in subset");
                     parts.push_back(&partView);
                 }
                 std::sort(parts.begin(), parts.end(),
@@ -425,7 +426,7 @@ namespace NTable {
                             break;
 
                         default:
-                            Y_ABORT("Unexpected Seek result");
+                            Y_TABLET_ERROR("Unexpected Seek result");
                     }
                 }
 

--- a/ydb/core/tablet_flat/flat_scan_iface.h
+++ b/ydb/core/tablet_flat/flat_scan_iface.h
@@ -1,9 +1,10 @@
 #pragma once
 
-#include "util_basics.h"
 #include "flat_scan_lead.h"
 #include "flat_row_eggs.h"
 #include "flat_row_scheme.h"
+#include "util_basics.h"
+#include "util_fmt_abort.h"
 
 namespace NKikimr {
 namespace NTable {
@@ -143,7 +144,7 @@ namespace NTable {
     class IVersionScan : public IScan {
     private:
         EScan Feed(TArrayRef<const TCell>, const TRow&) override final {
-            Y_ABORT("Unexpected unversioned call");
+            Y_TABLET_ERROR("Unexpected unversioned call");
         }
 
     public:

--- a/ydb/core/tablet_flat/flat_scan_lead.h
+++ b/ydb/core/tablet_flat/flat_scan_lead.h
@@ -24,7 +24,7 @@ namespace NTable {
 
         void Until(TArrayRef<const TCell> key, bool inclusive)
         {
-            Y_ABORT_UNLESS(Valid, "Until must be called after To");
+            Y_ENSURE(Valid, "Until must be called after To");
             StopKey = TSerializedCellVec(key);
             StopKeyInclusive = inclusive;
         }

--- a/ydb/core/tablet_flat/flat_stat_part.h
+++ b/ydb/core/tablet_flat/flat_stat_part.h
@@ -4,6 +4,7 @@
 #include "flat_part_laid.h"
 #include "flat_page_frames.h"
 #include "flat_stat_part_group_iter_iface.h"
+#include "util_fmt_abort.h"
 
 #include <library/cpp/containers/stack_vector/stack_vec.h>
 #include <util/draft/holder_vector.h>
@@ -90,7 +91,7 @@ public:
     }
 
     EReady Next(TDataStats& stats) {
-        Y_ABORT_UNLESS(IsValid());
+        Y_ENSURE(IsValid());
 
         LastRowId = Groups[0]->GetRowId();
         auto ready = Groups[0]->Next();
@@ -164,7 +165,7 @@ public:
     }
 
     TDbTupleRef GetCurrentKey() const {
-        Y_ABORT_UNLESS(KeyDefaults->BasicTypes().size() == CurrentKey.size());
+        Y_ENSURE(KeyDefaults->BasicTypes().size() == CurrentKey.size());
         return TDbTupleRef(KeyDefaults->BasicTypes().data(), CurrentKey.data(), CurrentKey.size());
     }
 
@@ -239,7 +240,7 @@ private:
                 stats.Add(rel.Size, channel);
                 ++prevPage;
             } else if (!rel.IsHead()) {
-                Y_ABORT("Got unaligned TFrames head record");
+                Y_TABLET_ERROR("Got unaligned TFrames head record");
             } else {
                 break;
             }

--- a/ydb/core/tablet_flat/flat_stat_part_group_btree_index.h
+++ b/ydb/core/tablet_flat/flat_stat_part_group_btree_index.h
@@ -115,7 +115,7 @@ public:
     }
 
     EReady Next() override {
-        Y_ABORT_UNLESS(IsValid());
+        Y_ENSURE(IsValid());
 
         NodeIndex++;
 
@@ -173,7 +173,7 @@ private:
     }
 
     const TNodeState& GetCurrentNode() const {
-        Y_ABORT_UNLESS(IsValid());
+        Y_ENSURE(IsValid());
         return Nodes[NodeIndex];
     }
 

--- a/ydb/core/tablet_flat/flat_stat_table.h
+++ b/ydb/core/tablet_flat/flat_stat_table.h
@@ -22,7 +22,7 @@ public:
     {}
 
     void Add(THolder<TStatsScreenedPartIterator> iterator) {
-        Y_ABORT_UNLESS(iterator->IsValid());
+        Y_ENSURE(iterator->IsValid());
         Iterators.PushBack(std::move(iterator));
         TStatsScreenedPartIterator* iteratorPtr = Iterators.back();
         Heap.push(iteratorPtr);
@@ -71,7 +71,7 @@ public:
     }
 
     TDbTupleRef GetCurrentKey() const {
-        Y_ABORT_UNLESS(!Heap.empty());
+        Y_ENSURE(!Heap.empty());
         return Heap.top()->GetCurrentKey();
     }
 
@@ -174,7 +174,7 @@ public:
 
         TString old = Sample[idx].first;
         auto oit = KeyRefCount.find(old);
-        Y_ABORT_UNLESS(oit != KeyRefCount.end());
+        Y_ENSURE(oit != KeyRefCount.end());
         --oit->second;
 
         // Delete the key if this was the last reference

--- a/ydb/core/tablet_flat/flat_stat_table_btree_index.cpp
+++ b/ydb/core/tablet_flat/flat_stat_table_btree_index.cpp
@@ -2,6 +2,7 @@
 #include "flat_table_subset.h"
 #include <util/stream/format.h>
 #include "flat_stat_table_btree_index.h"
+#include "util_fmt_abort.h"
 
 namespace NKikimr::NTable {
 
@@ -46,7 +47,7 @@ ui64 GetPrevDataSize(const TPart* part, TGroupId groupId, TRowId rowId, IPages* 
 }
 
 ui64 GetPrevHistoricDataSize(const TPart* part, TGroupId groupId, TRowId rowId, IPages* env, TRowId& historicRowId, bool& ready) {
-    Y_ABORT_UNLESS(groupId == TGroupId(0, true));
+    Y_ENSURE(groupId == TGroupId(0, true));
 
     auto& meta = part->IndexPages.GetBTree(groupId);
 
@@ -102,7 +103,7 @@ void AddBlobsSize(const TPart* part, TChanneledDataSize& stats, const TFrames* f
             stats.Add(rel.Size, channel);
             ++page;
         } else if (!rel.IsHead()) {
-            Y_ABORT("Got unaligned TFrames head record");
+            Y_TABLET_ERROR("Got unaligned TFrames head record");
         } else {
             break;
         }

--- a/ydb/core/tablet_flat/flat_stat_table_btree_index_histogram.cpp
+++ b/ydb/core/tablet_flat/flat_stat_table_btree_index_histogram.cpp
@@ -98,8 +98,8 @@ class TTableHistogramBuilderBtreeIndex {
                 State = ENodeState::Closed;
                 ui64 rowCount = GetRowCount();
                 ui64 dataSize = GetDataSize();
-                Y_ABORT_UNLESS(openedRowCount >= rowCount);
-                Y_ABORT_UNLESS(openedDataSize >= dataSize);
+                Y_ENSURE(openedRowCount >= rowCount);
+                Y_ENSURE(openedDataSize >= dataSize);
                 openedRowCount -= rowCount;
                 openedDataSize -= dataSize;
                 closedRowCount += rowCount;
@@ -119,8 +119,8 @@ class TTableHistogramBuilderBtreeIndex {
                 State = ENodeState::Ignored;
                 ui64 rowCount = GetRowCount();
                 ui64 dataSize = GetDataSize();
-                Y_ABORT_UNLESS(openedRowCount >= rowCount);
-                Y_ABORT_UNLESS(openedDataSize >= dataSize);
+                Y_ENSURE(openedRowCount >= rowCount);
+                Y_ENSURE(openedDataSize >= dataSize);
                 openedRowCount -= rowCount;
                 openedDataSize -= dataSize;
                 return true;
@@ -469,7 +469,7 @@ private:
                                 currentKeyRowCountOpens += node->GetRowCount();
                             }
                         }
-                        Y_ABORT_UNLESS(currentKeyRowCountOpens <= openedRowCount);
+                        Y_ENSURE(currentKeyRowCountOpens <= openedRowCount);
                         ui64 currentKeyPointerRowCount = closedRowCount + (openedRowCount - currentKeyRowCountOpens) / 2;
                         if ((stats.RowCountHistogram.empty() ? 0 : stats.RowCountHistogram.back().Value) < currentKeyPointerRowCount && currentKeyPointerRowCount < stats.RowCount) {
                             AddKey(stats.RowCountHistogram, currentKeyPointer.GetKey(), currentKeyPointerRowCount);
@@ -488,7 +488,7 @@ private:
                                 currentKeyDataSizeOpens += node->GetDataSize();
                             }
                         }
-                        Y_ABORT_UNLESS(currentKeyDataSizeOpens <= openedDataSize);
+                        Y_ENSURE(currentKeyDataSizeOpens <= openedDataSize);
                         ui64 currentKeyPointerDataSize = closedDataSize + (openedDataSize - currentKeyDataSizeOpens) / 2;
                         if ((stats.DataSizeHistogram.empty() ? 0 : stats.DataSizeHistogram.back().Value) < currentKeyPointerDataSize && currentKeyPointerDataSize < stats.DataSize.Size) {
                             AddKey(stats.DataSizeHistogram, currentKeyPointer.GetKey(), currentKeyPointerDataSize);
@@ -539,7 +539,7 @@ private:
     }
 
     bool TryLoadNode(const TNodeState& parent, const auto& addNode) {
-        Y_ABORT_UNLESS(parent.Level);
+        Y_ENSURE(parent.Level);
 
         auto page = Env->TryGetPage(parent.Part, parent.PageId, {});
         if (!page) {
@@ -590,12 +590,12 @@ private:
     }
 
     static int CompareKeys(const TCellsIterable& left_, const TCellsIterable& right_, const TKeyCellDefaults& keyDefaults) {
-        Y_ABORT_UNLESS(left_);
-        Y_ABORT_UNLESS(right_);
+        Y_ENSURE(left_);
+        Y_ENSURE(right_);
 
         auto left = left_.Iter(), right = right_.Iter();
         size_t end = Max(left.Count(), right.Count());
-        Y_ABORT_UNLESS(end <= keyDefaults.Size(), "Key schema is smaller than compared keys");
+        Y_ENSURE(end <= keyDefaults.Size(), "Key schema is smaller than compared keys");
         
         for (size_t pos = 0; pos < end; ++pos) {
             const auto& leftCell = pos < left.Count() ? left.Next() : keyDefaults.Defs[pos];

--- a/ydb/core/tablet_flat/flat_store_hotdog.cpp
+++ b/ydb/core/tablet_flat/flat_store_hotdog.cpp
@@ -53,12 +53,12 @@ void TPageCollectionProtoHelper::Do(TBundle *bundle, const TPartComponents &pc)
 
 void TPageCollectionProtoHelper::Do(TBundle *bundle, const NTable::TPartView &partView)
 {
-    Y_ABORT_UNLESS(partView, "Cannot make bundle dump from empty NTable::TPartView");
+    Y_ENSURE(partView, "Cannot make bundle dump from empty NTable::TPartView");
 
     auto *part = partView.As<NTable::TPartStore>();
 
-    Y_ABORT_UNLESS(part, "Cannot cast TPart to page collection backed up part");
-    Y_ABORT_UNLESS(part->Label == part->PageCollections[0]->PageCollection->Label());
+    Y_ENSURE(part, "Cannot cast TPart to page collection backed up part");
+    Y_ENSURE(part->Label == part->PageCollections[0]->PageCollection->Label());
 
     bundle->MutablePageCollections()->Reserve(part->PageCollections.size());
 
@@ -78,12 +78,12 @@ void TPageCollectionProtoHelper::Do(TBundle *bundle, const NTable::TPartView &pa
 
 void TPageCollectionProtoHelper::Do(TBundle *bundle, const TIntrusiveConstPtr<NTable::TColdPart> &part)
 {
-    Y_ABORT_UNLESS(part, "Cannot make bundle dump from empty NTable::TColdPart");
+    Y_ENSURE(part, "Cannot make bundle dump from empty NTable::TColdPart");
 
     auto *partStore = dynamic_cast<const NTable::TColdPartStore*>(part.Get());
 
-    Y_ABORT_UNLESS(partStore, "Cannot cast TColdPart to page collection backed up part");
-    Y_ABORT_UNLESS(partStore->Label == partStore->LargeGlobIds[0].Lead);
+    Y_ENSURE(partStore, "Cannot cast TColdPart to page collection backed up part");
+    Y_ENSURE(partStore->Label == partStore->LargeGlobIds[0].Lead);
 
     bundle->MutablePageCollections()->Reserve(partStore->LargeGlobIds.size());
 
@@ -128,7 +128,7 @@ NTable::TPartComponents TPageCollectionProtoHelper::MakePageCollectionComponents
     TVector<NTable::TPageCollectionComponents> components;
 
     for (auto &pageCollection: proto.GetPageCollections()) {
-        Y_ABORT_UNLESS(pageCollection.HasLargeGlobId(), "Got page collection without TLargeGlobId");
+        Y_ENSURE(pageCollection.HasLargeGlobId(), "Got page collection without TLargeGlobId");
 
         auto& item = components.emplace_back();
         item.LargeGlobId = TLargeGlobIdProto::Get(pageCollection.GetLargeGlobId());

--- a/ydb/core/tablet_flat/flat_store_solid.h
+++ b/ydb/core/tablet_flat/flat_store_solid.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "flat_sausage_solid.h"
+#include "util_fmt_abort.h"
 #include <ydb/core/tablet_flat/flat_executor.pb.h>
 #include <functional>
 
@@ -24,7 +25,7 @@ namespace NTabletFlatExecutor {
 
         static void Put(TProto &proto, const TLargeGlobId &largeGlobId)
         {
-            Y_ABORT_UNLESS(largeGlobId.Group != TLargeGlobId::InvalidGroup, "Please, set BS group");
+            Y_ENSURE(largeGlobId.Group != TLargeGlobId::InvalidGroup, "Please, set BS group");
 
             proto.SetGroup(largeGlobId.Group);
             proto.SetBytes(largeGlobId.Bytes);
@@ -41,7 +42,7 @@ namespace NTabletFlatExecutor {
 
         static TLargeGlobId Get(const TRep &rep, const TLookup &lookup)
         {
-            Y_ABORT_UNLESS(rep.size(), "TLargeGlobId accepts only non-empty sequence");
+            Y_ENSURE(rep.size(), "TLargeGlobId accepts only non-empty sequence");
 
             const auto lead = LogoBlobIDFromLogoBlobID(rep.Get(0));
             ui32 bytes = lead.BlobSize();
@@ -50,9 +51,9 @@ namespace NTabletFlatExecutor {
                 auto logo = LogoBlobIDFromLogoBlobID(rep.Get(it));
 
                 if (bytes > Max<ui32>() - logo.BlobSize())
-                    Y_ABORT("Got too large TLargeGlobId in ids sequence");
+                    Y_TABLET_ERROR("Got too large TLargeGlobId in ids sequence");
                 if (lead.Cookie() + it != logo.Cookie())
-                    Y_ABORT("Got an invalid sequence of logo ids");
+                    Y_TABLET_ERROR("Got an invalid sequence of logo ids");
 
                 bytes += logo.BlobSize();
             }

--- a/ydb/core/tablet_flat/flat_table.cpp
+++ b/ydb/core/tablet_flat/flat_table.cpp
@@ -27,7 +27,7 @@ TTable::~TTable() { }
 
 void TTable::PrepareRollback()
 {
-    Y_ABORT_UNLESS(!RollbackState);
+    Y_ENSURE(!RollbackState);
     auto& state = RollbackState.emplace(Epoch);
     state.Annexed = Annexed;
     state.Scheme = Scheme;
@@ -40,7 +40,7 @@ void TTable::PrepareRollback()
 
 void TTable::RollbackChanges()
 {
-    Y_ABORT_UNLESS(RollbackState, "PrepareRollback needed to rollback changes");
+    Y_ENSURE(RollbackState, "PrepareRollback needed to rollback changes");
     auto& state = *RollbackState;
 
     CommitOps.clear();
@@ -80,16 +80,16 @@ void TTable::RollbackChanges()
 
     if (Epoch != state.Epoch) {
         // We performed a snapshot, roll it back
-        Y_ABORT_UNLESS(MutableBackup, "Previous mem table missing");
+        Y_ENSURE(MutableBackup, "Previous mem table missing");
         Mutable = std::move(MutableBackup);
     } else if (!state.MutableExisted) {
         // New memtable doesn't need rollback
         Mutable = nullptr;
     } else if (state.MutableUpdated) {
-        Y_ABORT_UNLESS(Mutable, "Mutable was updated, but it is missing");
+        Y_ENSURE(Mutable, "Mutable was updated, but it is missing");
         Mutable->RollbackChanges();
     }
-    Y_ABORT_UNLESS(!MutableBackup);
+    Y_ENSURE(!MutableBackup);
 
     Epoch = state.Epoch;
     Annexed = state.Annexed;
@@ -104,7 +104,7 @@ void TTable::RollbackChanges()
 
 void TTable::CommitChanges(TArrayRef<const TMemGlob> blobs)
 {
-    Y_ABORT_UNLESS(RollbackState, "PrepareRollback needed to rollback changes");
+    Y_ENSURE(RollbackState, "PrepareRollback needed to rollback changes");
     auto& state = *RollbackState;
 
     for (auto& op : CommitOps) {
@@ -127,7 +127,7 @@ void TTable::CommitChanges(TArrayRef<const TMemGlob> blobs)
             Mutable->CommitBlobs(blobs);
         }
         // We performed a snapshot, move it to Frozen
-        Y_ABORT_UNLESS(MutableBackup, "Mem table snaphot missing");
+        Y_ENSURE(MutableBackup, "Mem table snaphot missing");
         Frozen.insert(MutableBackup);
         Stat_.FrozenWaste += MutableBackup->GetWastedMem();
         Stat_.FrozenSize += MutableBackup->GetUsedMem();
@@ -140,17 +140,17 @@ void TTable::CommitChanges(TArrayRef<const TMemGlob> blobs)
             Mutable->CommitBlobs(blobs);
         }
     } else if (state.MutableUpdated) {
-        Y_ABORT_UNLESS(Mutable, "Mutable was updated, but it is missing");
+        Y_ENSURE(Mutable, "Mutable was updated, but it is missing");
         Mutable->CommitChanges(blobs);
     }
-    Y_ABORT_UNLESS(!MutableBackup);
+    Y_ENSURE(!MutableBackup);
 
     RollbackState.reset();
 }
 
 void TTable::CommitNewTable(TArrayRef<const TMemGlob> blobs)
 {
-    Y_ABORT_UNLESS(!RollbackState, "CommitBlobs must only be used for new tables without rollback");
+    Y_ENSURE(!RollbackState, "CommitBlobs must only be used for new tables without rollback");
 
     if (Mutable && blobs) {
         Mutable->CommitBlobs(blobs);
@@ -164,7 +164,7 @@ void TTable::SetScheme(const TScheme::TTableInfo &table)
     Levels.Reset();
     ErasedKeysCache.Reset();
 
-    Y_ABORT_UNLESS(!Mutable && table.Columns);
+    Y_ENSURE(!Mutable && table.Columns);
 
     if (RollbackState) {
         // Make sure we don't populate erase cache with keys based on a schema
@@ -185,7 +185,7 @@ void TTable::SetScheme(const TScheme::TTableInfo &table)
     /* This restriction is required for external blobs inverted index, for
         details read NPage::TFrames and NFwd blobs cache implementation. */
 
-    Y_ABORT_UNLESS(Scheme->Cols.size() <= ui32(-Min<i16>()), "Too many columns in row");
+    Y_ENSURE(Scheme->Cols.size() <= ui32(-Min<i16>()), "Too many columns in row");
 
     EraseCacheEnabled = table.EraseCacheEnabled;
     EraseCacheConfig = { };
@@ -231,7 +231,7 @@ TAutoPtr<TSubset> TTable::CompactionSubset(TEpoch head, TArrayRef<const TLogoBlo
             continue;
         }
         auto* p = Flatten.FindPtr(token);
-        Y_VERIFY_S(p, "Cannot find part " << token);
+        Y_ENSURE(p, "Cannot find part " << token);
         subset->Flatten.push_back(*p);
     }
 
@@ -268,14 +268,14 @@ TAutoPtr<TSubset> TTable::PartSwitchSubset(TEpoch head, TArrayRef<const TLogoBlo
             continue;
         }
         auto* p = Flatten.FindPtr(token);
-        Y_VERIFY_S(p, "Cannot find part " << token);
+        Y_ENSURE(p, "Cannot find part " << token);
         subset->Flatten.push_back(*p);
     }
 
     subset->TxStatus.reserve(txStatus.size());
     for (const TLogoBlobID &token : txStatus) {
         auto* p = TxStatus.FindPtr(token);
-        Y_VERIFY_S(p, "Cannot find tx status " << token);
+        Y_ENSURE(p, "Cannot find tx status " << token);
         subset->TxStatus.push_back(*p);
     }
 
@@ -347,7 +347,7 @@ bool TTable::HasBorrowed(ui64 selfTabletId) const
 TAutoPtr<TSubset> TTable::ScanSnapshot(TRowVersion snapshot)
 {
     if (RollbackState) {
-        Y_ABORT_UNLESS(Epoch == RollbackState->Epoch &&
+        Y_ENSURE(Epoch == RollbackState->Epoch &&
             RollbackState->MutableExisted == bool(Mutable) &&
             !RollbackState->MutableUpdated,
             "Cannot take scan snapshot of a modified table");
@@ -390,7 +390,7 @@ TAutoPtr<TSubset> TTable::Unwrap()
 
     Replace(*subset, { }, { });
 
-    Y_ABORT_UNLESS(!(Flatten || Frozen || Mutable || TxStatus));
+    Y_ENSURE(!(Flatten || Frozen || Mutable || TxStatus));
 
     return subset;
 }
@@ -409,12 +409,12 @@ TBundleSlicesMap TTable::LookupSlices(TArrayRef<const TLogoBlobID> bundles) cons
 
 void TTable::ReplaceSlices(TBundleSlicesMap slices)
 {
-    Y_ABORT_UNLESS(!RollbackState, "Cannot perform this in a transaction");
+    Y_ENSURE(!RollbackState, "Cannot perform this in a transaction");
 
     for (auto &kv : slices) {
         auto it = Flatten.find(kv.first);
-        Y_ABORT_UNLESS(it != Flatten.end(), "Got an unknown TPart in ReplaceSlices");
-        Y_ABORT_UNLESS(kv.second && *kv.second, "Got an empty TPart in ReplaceSlices");
+        Y_ENSURE(it != Flatten.end(), "Got an unknown TPart in ReplaceSlices");
+        Y_ENSURE(kv.second && *kv.second, "Got an empty TPart in ReplaceSlices");
         it->second.Slices = std::move(kv.second);
         it->second.Screen = it->second.Slices->ToScreen();
     }
@@ -430,14 +430,14 @@ void TTable::Replace(
     TArrayRef<const TPartView> newParts,
     TArrayRef<const TIntrusiveConstPtr<TTxStatusPart>> newTxStatus)
 {
-    Y_ABORT_UNLESS(!RollbackState, "Cannot perform this in a transaction");
+    Y_ENSURE(!RollbackState, "Cannot perform this in a transaction");
 
     for (const auto& partView : newParts) {
-        Y_ABORT_UNLESS(partView, "Replace(...) shouldn't get empty parts");
-        Y_ABORT_UNLESS(!partView.Screen, "Replace(...) shouldn't get screened parts");
-        Y_ABORT_UNLESS(partView.Slices && *partView.Slices, "Got parts without slices");
+        Y_ENSURE(partView, "Replace(...) shouldn't get empty parts");
+        Y_ENSURE(!partView.Screen, "Replace(...) shouldn't get screened parts");
+        Y_ENSURE(partView.Slices && *partView.Slices, "Got parts without slices");
         if (Flatten.contains(partView->Label) || ColdParts.contains(partView->Label)) {
-            Y_Fail("Duplicate bundle " << partView->Label);
+            Y_TABLET_ERROR("Duplicate bundle " << partView->Label);
         }
     }
 
@@ -457,7 +457,7 @@ void TTable::Replace(
         removingOld = true;
         const auto found = Frozen.erase(memTable.MemTable);
 
-        Y_ABORT_UNLESS(found == 1, "Got an unknown TMemTable table in TSubset");
+        Y_ENSURE(found == 1, "Got an unknown TMemTable table in TSubset");
 
         NUtil::SubSafe(Stat_.FrozenWaste, memTable->GetWastedMem());
         NUtil::SubSafe(Stat_.FrozenSize, memTable->GetUsedMem());
@@ -467,7 +467,7 @@ void TTable::Replace(
         for (const auto &pr : memTable.MemTable->GetTxIdStats()) {
             const ui64 txId = pr.first;
             auto& count = TxDataRefs.at(txId);
-            Y_ABORT_UNLESS(count > 0);
+            Y_ENSURE(count > 0);
             if (0 == --count) {
                 checkTxDataRefs.push_back(txId);
             }
@@ -476,7 +476,7 @@ void TTable::Replace(
         for (const auto &pr : memTable.MemTable->GetCommittedTransactions()) {
             const ui64 txId = pr.first;
             auto& count = TxStatusRefs.at(txId);
-            Y_ABORT_UNLESS(count > 0);
+            Y_ENSURE(count > 0);
             if (0 == --count) {
                 checkTxStatusRefs.push_back(txId);
             }
@@ -484,7 +484,7 @@ void TTable::Replace(
 
         for (ui64 txId : memTable.MemTable->GetRemovedTransactions()) {
             auto& count = TxStatusRefs.at(txId);
-            Y_ABORT_UNLESS(count > 0);
+            Y_ENSURE(count > 0);
             if (0 == --count) {
                 checkTxStatusRefs.push_back(txId);
             }
@@ -493,25 +493,25 @@ void TTable::Replace(
 
     for (auto &part : subset.Flatten) {
         removingOld = true;
-        Y_ABORT_UNLESS(part.Slices && *part.Slices,
+        Y_ENSURE(part.Slices && *part.Slices,
             "Got an empty TPart subset in TSubset");
 
         auto it = Flatten.find(part->Label);
-        Y_ABORT_UNLESS(it != Flatten.end(), "Got an unknown TPart table in TSubset");
+        Y_ENSURE(it != Flatten.end(), "Got an unknown TPart table in TSubset");
         auto& existing = it->second;
 
-        Y_ABORT_UNLESS(existing.Slices && *existing.Slices,
+        Y_ENSURE(existing.Slices && *existing.Slices,
             "Existing table part has an unexpected empty bounds run");
 
         if (!TSlices::EqualByRowId(existing.Slices, part.Slices)) {
             if (!TSlices::SupersetByRowId(existing.Slices, part.Slices)) {
-                Y_Fail("Removing unexpected subset " << NFmt::Do(*part.Slices)
+                Y_TABLET_ERROR("Removing unexpected subset " << NFmt::Do(*part.Slices)
                     << " from existing " << NFmt::Do(*existing.Slices));
             }
 
             auto left = TSlices::Subtract(existing.Slices, part.Slices);
             if (left->empty()) {
-                Y_Fail("Empty result after removing " << NFmt::Do(*part.Slices)
+                Y_TABLET_ERROR("Empty result after removing " << NFmt::Do(*part.Slices)
                     << " from existing " << NFmt::Do(*existing.Slices));
             }
 
@@ -524,7 +524,7 @@ void TTable::Replace(
             for (const auto& item : existing->TxIdStats->GetItems()) {
                 const ui64 txId = item.GetTxId();
                 auto& count = TxDataRefs.at(txId);
-                Y_ABORT_UNLESS(count > 0);
+                Y_ENSURE(count > 0);
                 if (0 == --count) {
                     checkTxDataRefs.push_back(txId);
                 }
@@ -543,22 +543,22 @@ void TTable::Replace(
     for (auto &part : subset.ColdParts) {
         removingOld = true;
         auto it = ColdParts.find(part->Label);
-        Y_ABORT_UNLESS(it != ColdParts.end(), "Got an unknown TColdPart in TSubset");
+        Y_ENSURE(it != ColdParts.end(), "Got an unknown TColdPart in TSubset");
         ColdParts.erase(it);
     }
 
     for (auto& part : subset.TxStatus) {
         removingOld = true;
-        Y_ABORT_UNLESS(part, "Unexpected empty TTxStatusPart in TSubset");
+        Y_ENSURE(part, "Unexpected empty TTxStatusPart in TSubset");
 
         auto it = TxStatus.find(part->Label);
-        Y_ABORT_UNLESS(it != TxStatus.end());
+        Y_ENSURE(it != TxStatus.end());
         TxStatus.erase(it);
 
         for (auto& item : part->TxStatusPage->GetCommittedItems()) {
             const ui64 txId = item.GetTxId();
             auto& count = TxStatusRefs.at(txId);
-            Y_ABORT_UNLESS(count > 0);
+            Y_ENSURE(count > 0);
             if (0 == --count) {
                 checkTxStatusRefs.push_back(txId);
             }
@@ -566,7 +566,7 @@ void TTable::Replace(
         for (auto& item : part->TxStatusPage->GetRemovedItems()) {
             const ui64 txId = item.GetTxId();
             auto& count = TxStatusRefs.at(txId);
-            Y_ABORT_UNLESS(count > 0);
+            Y_ENSURE(count > 0);
             if (0 == --count) {
                 checkTxStatusRefs.push_back(txId);
             }
@@ -576,11 +576,11 @@ void TTable::Replace(
     for (const auto &partView : newParts) {
         addingNew = true;
         if (Mutable && partView->Epoch >= Mutable->Epoch) {
-            Y_Fail("Replace with " << NFmt::Do(*partView) << " after mutable epoch " << Mutable->Epoch);
+            Y_TABLET_ERROR("Replace with " << NFmt::Do(*partView) << " after mutable epoch " << Mutable->Epoch);
         }
 
         if (Frozen && partView->Epoch >= (*Frozen.begin())->Epoch) {
-            Y_Fail("Replace with " << NFmt::Do(*partView) << " after frozen epoch " << (*Frozen.begin())->Epoch);
+            Y_TABLET_ERROR("Replace with " << NFmt::Do(*partView) << " after frozen epoch " << (*Frozen.begin())->Epoch);
         }
 
         Epoch = Max(Epoch, partView->Epoch + 1);
@@ -590,17 +590,17 @@ void TTable::Replace(
 
     for (const auto& txStatus : newTxStatus) {
         if (Mutable && txStatus->Epoch >= Mutable->Epoch) {
-            Y_Fail("Replace with " << NFmt::Do(*txStatus) << " after mutable epoch " << Mutable->Epoch);
+            Y_TABLET_ERROR("Replace with " << NFmt::Do(*txStatus) << " after mutable epoch " << Mutable->Epoch);
         }
 
         if (Frozen && txStatus->Epoch >= (*Frozen.begin())->Epoch) {
-            Y_Fail("Replace with " << NFmt::Do(*txStatus) << " after frozen epoch " << (*Frozen.begin())->Epoch);
+            Y_TABLET_ERROR("Replace with " << NFmt::Do(*txStatus) << " after frozen epoch " << (*Frozen.begin())->Epoch);
         }
 
         Epoch = Max(Epoch, txStatus->Epoch + 1);
 
         auto res = TxStatus.emplace(txStatus->Label, txStatus);
-        Y_ABORT_UNLESS(res.second, "Unexpected failure to add a new TTxStatusPart");
+        Y_ENSURE(res.second, "Unexpected failure to add a new TTxStatusPart");
 
         for (auto& item : txStatus->TxStatusPage->GetCommittedItems()) {
             const ui64 txId = item.GetTxId();
@@ -614,7 +614,7 @@ void TTable::Replace(
 
     for (ui64 txId : checkTxDataRefs) {
         auto it = TxDataRefs.find(txId);
-        Y_ABORT_UNLESS(it != TxDataRefs.end());
+        Y_ENSURE(it != TxDataRefs.end());
         if (it->second == 0) {
             // Transaction no longer has any known rows
             TxDataRefs.erase(it);
@@ -628,7 +628,7 @@ void TTable::Replace(
 
     for (ui64 txId : checkTxStatusRefs) {
         auto it = TxStatusRefs.find(txId);
-        Y_ABORT_UNLESS(it != TxStatusRefs.end());
+        Y_ENSURE(it != TxStatusRefs.end());
         if (it->second == 0) {
             // This transaction no longer has any known status
             TxStatusRefs.erase(it);
@@ -655,17 +655,17 @@ void TTable::Replace(
 
 void TTable::Merge(TPartView partView)
 {
-    Y_ABORT_UNLESS(!RollbackState, "Cannot perform this in a transaction");
+    Y_ENSURE(!RollbackState, "Cannot perform this in a transaction");
 
-    Y_ABORT_UNLESS(partView, "Merge(...) shouldn't get empty part");
-    Y_ABORT_UNLESS(partView.Slices, "Merge(...) shouldn't get parts without slices");
+    Y_ENSURE(partView, "Merge(...) shouldn't get empty part");
+    Y_ENSURE(partView.Slices, "Merge(...) shouldn't get parts without slices");
 
     if (Mutable && partView->Epoch >= Mutable->Epoch) {
-        Y_Fail("Merge " << NFmt::Do(*partView) << " after mutable epoch " << Mutable->Epoch);
+        Y_TABLET_ERROR("Merge " << NFmt::Do(*partView) << " after mutable epoch " << Mutable->Epoch);
     }
 
     if (Frozen && partView->Epoch >= (*Frozen.begin())->Epoch) {
-        Y_Fail("Merge " << NFmt::Do(*partView) << " after frozen epoch " << (*Frozen.begin())->Epoch);
+        Y_TABLET_ERROR("Merge " << NFmt::Do(*partView) << " after frozen epoch " << (*Frozen.begin())->Epoch);
     }
 
     auto it = Flatten.find(partView->Label);
@@ -675,7 +675,7 @@ void TTable::Merge(TPartView partView)
 
         AddSafe(std::move(partView));
     } else if (it->second->Epoch != partView->Epoch) {
-        Y_ABORT("Got the same labeled parts with different epoch");
+        Y_TABLET_ERROR("Got the same labeled parts with different epoch");
     } else {
         Levels.Reset();
         it->second.Screen = TScreen::Join(it->second.Screen, partView.Screen);
@@ -689,23 +689,23 @@ void TTable::Merge(TPartView partView)
 
 void TTable::Merge(TIntrusiveConstPtr<TColdPart> part)
 {
-    Y_ABORT_UNLESS(!RollbackState, "Cannot perform this in a transaction");
+    Y_ENSURE(!RollbackState, "Cannot perform this in a transaction");
 
-    Y_ABORT_UNLESS(part, "Merge(...) shouldn't get empty parts");
+    Y_ENSURE(part, "Merge(...) shouldn't get empty parts");
 
     if (Mutable && part->Epoch >= Mutable->Epoch) {
-        Y_Fail("Merge " << NFmt::Do(*part) << " after mutable epoch " << Mutable->Epoch);
+        Y_TABLET_ERROR("Merge " << NFmt::Do(*part) << " after mutable epoch " << Mutable->Epoch);
     }
 
     if (Frozen && part->Epoch >= (*Frozen.begin())->Epoch) {
-        Y_Fail("Merge " << NFmt::Do(*part) << " after frozen epoch " << (*Frozen.begin())->Epoch);
+        Y_TABLET_ERROR("Merge " << NFmt::Do(*part) << " after frozen epoch " << (*Frozen.begin())->Epoch);
     }
 
     auto it = Flatten.find(part->Label);
-    Y_VERIFY_S(it == Flatten.end(), "Merge " << NFmt::Do(*part) << " when a loaded part already exists");
+    Y_ENSURE(it == Flatten.end(), "Merge " << NFmt::Do(*part) << " when a loaded part already exists");
 
     auto itCold = ColdParts.find(part->Label);
-    Y_VERIFY_S(itCold == ColdParts.end(), "Merge " << NFmt::Do(*part) << " when another cold part already exists");
+    Y_ENSURE(itCold == ColdParts.end(), "Merge " << NFmt::Do(*part) << " when another cold part already exists");
 
     const auto label = part->Label;
 
@@ -721,9 +721,9 @@ void TTable::Merge(TIntrusiveConstPtr<TColdPart> part)
 
 void TTable::Merge(TIntrusiveConstPtr<TTxStatusPart> txStatus)
 {
-    Y_ABORT_UNLESS(!RollbackState, "Cannot perform this in a transaction");
+    Y_ENSURE(!RollbackState, "Cannot perform this in a transaction");
 
-    Y_ABORT_UNLESS(txStatus, "Unexpected empty TTxStatusPart");
+    Y_ENSURE(txStatus, "Unexpected empty TTxStatusPart");
 
     for (auto& item : txStatus->TxStatusPage->GetCommittedItems()) {
         const ui64 txId = item.GetTxId();
@@ -753,17 +753,17 @@ void TTable::Merge(TIntrusiveConstPtr<TTxStatusPart> txStatus)
     }
 
     if (Mutable && txStatus->Epoch >= Mutable->Epoch) {
-        Y_Fail("Merge " << NFmt::Do(*txStatus) << " after mutable epoch " << Mutable->Epoch);
+        Y_TABLET_ERROR("Merge " << NFmt::Do(*txStatus) << " after mutable epoch " << Mutable->Epoch);
     }
 
     if (Frozen && txStatus->Epoch >= (*Frozen.begin())->Epoch) {
-        Y_Fail("Merge " << NFmt::Do(*txStatus) << " after frozen epoch " << (*Frozen.begin())->Epoch);
+        Y_TABLET_ERROR("Merge " << NFmt::Do(*txStatus) << " after frozen epoch " << (*Frozen.begin())->Epoch);
     }
 
     Epoch = Max(Epoch, txStatus->Epoch + 1);
 
     auto res = TxStatus.emplace(txStatus->Label, txStatus);
-    Y_ABORT_UNLESS(res.second, "Unexpected failure to add a new TTxStatusPart");
+    Y_ENSURE(res.second, "Unexpected failure to add a new TTxStatusPart");
 
     // Note: Merge is called when borrowing data, but new tx status may commit
     // or rollback some transactions, and erase cache already accounts for that
@@ -778,7 +778,7 @@ void TTable::MergeDone()
 const TLevels& TTable::GetLevels() const
 {
     if (!Levels) {
-        Y_ABORT_UNLESS(ColdParts.empty(), "Cannot construct Levels with cold parts");
+        Y_ENSURE(ColdParts.empty(), "Cannot construct Levels with cold parts");
         TVector<const TPartView*> parts; // TPartView* avoids expensive atomic ops
         parts.reserve(Flatten.size());
         for (const auto& kv : Flatten) {
@@ -813,7 +813,7 @@ ui64 TTable::GetSearchHeight() const
 
 TVector<TIntrusiveConstPtr<TMemTable>> TTable::GetMemTables() const
 {
-    Y_ABORT_UNLESS(!RollbackState, "Cannot perform this in a transaction");
+    Y_ENSURE(!RollbackState, "Cannot perform this in a transaction");
 
     TVector<TIntrusiveConstPtr<TMemTable>> vec(Frozen.begin(), Frozen.end());
 
@@ -829,12 +829,12 @@ TEpoch TTable::Snapshot()
         Annexed = Mutable->GetBlobs()->Tail();
 
         if (RollbackState) {
-            Y_ABORT_UNLESS(
+            Y_ENSURE(
                 RollbackState->Epoch == Mutable->Epoch &&
                 RollbackState->MutableExisted &&
                 !RollbackState->MutableUpdated,
                 "Cannot snapshot a modified table");
-            Y_ABORT_UNLESS(!MutableBackup, "Another mutable backup already exists");
+            Y_ENSURE(!MutableBackup, "Another mutable backup already exists");
             MutableBackup = std::move(Mutable);
         } else {
             Frozen.insert(Mutable);
@@ -847,7 +847,7 @@ TEpoch TTable::Snapshot()
         Mutable = nullptr; /* have to make new TMemTable on next update */
 
         if (++Epoch == TEpoch::Max()) {
-            Y_ABORT("Table epoch counter has reached infinity value");
+            Y_TABLET_ERROR("Table epoch counter has reached infinity value");
         }
     }
 
@@ -857,7 +857,7 @@ TEpoch TTable::Snapshot()
 void TTable::AddSafe(TPartView partView)
 {
     if (partView) {
-        Y_ABORT_UNLESS(partView->Epoch < Epoch, "Cannot add part above head epoch");
+        Y_ENSURE(partView->Epoch < Epoch, "Cannot add part above head epoch");
 
         Stat_.Parts.Add(partView);
         Stat_.PartsPerTablet[partView->Label.TabletID()].Add(partView);
@@ -880,7 +880,7 @@ void TTable::AddSafe(TPartView partView)
         }
 
         bool done = Flatten.emplace(partView->Label, std::move(partView)).second;
-        Y_ABORT_UNLESS(done);
+        Y_ENSURE(done);
     }
 }
 
@@ -945,7 +945,7 @@ EReady TTable::Precharge(TRawVals minKey_, TRawVals maxKey_, TTagsRef tags,
 
 void TTable::Update(ERowOp rop, TRawVals key, TOpsRef ops, TArrayRef<const TMemGlob> apart, TRowVersion rowVersion)
 {
-    Y_ABORT_UNLESS(!(ops && TCellOp::HaveNoOps(rop)), "Given ERowOp can't have ops");
+    Y_ENSURE(!(ops && TCellOp::HaveNoOps(rop)), "Given ERowOp can't have ops");
 
     if (ErasedKeysCache && rop != ERowOp::Erase) {
         const TCelled cells(key, *Scheme->Keys, true);
@@ -987,8 +987,8 @@ void TTable::AddTxDataRef(ui64 txId)
 void TTable::RemoveTxDataRef(ui64 txId)
 {
     auto it = TxDataRefs.find(txId);
-    Y_ABORT_UNLESS(it != TxDataRefs.end());
-    Y_ABORT_UNLESS(it->second > 0);
+    Y_ENSURE(it != TxDataRefs.end());
+    Y_ENSURE(it->second > 0);
     if (0 == --it->second) {
         // This was the last reference
         TxDataRefs.erase(it);
@@ -1026,8 +1026,8 @@ void TTable::AddTxStatusRef(ui64 txId)
 void TTable::RemoveTxStatusRef(ui64 txId)
 {
     auto it = TxStatusRefs.find(txId);
-    Y_ABORT_UNLESS(it != TxStatusRefs.end());
-    Y_ABORT_UNLESS(it->second > 0);
+    Y_ENSURE(it != TxStatusRefs.end());
+    Y_ENSURE(it->second > 0);
     if (0 == --it->second) {
         // This was the last reference
         TxStatusRefs.erase(it);
@@ -1204,7 +1204,7 @@ TAutoPtr<TTableIter> TTable::Iterate(TRawVals key_, TTagsRef tags, IPages* env, 
         const ITransactionMapPtr& visible,
         const ITransactionObserverPtr& observer) const
 {
-    Y_ABORT_UNLESS(ColdParts.empty(), "Cannot iterate with cold parts");
+    Y_ENSURE(ColdParts.empty(), "Cannot iterate with cold parts");
 
     const TCelled key(key_, *Scheme->Keys, false);
     const ui64 limit = seek == ESeek::Exact ? 1 : Max<ui64>();
@@ -1256,7 +1256,7 @@ TAutoPtr<TTableReverseIter> TTable::IterateReverse(TRawVals key_, TTagsRef tags,
         const ITransactionMapPtr& visible,
         const ITransactionObserverPtr& observer) const
 {
-    Y_ABORT_UNLESS(ColdParts.empty(), "Cannot iterate with cold parts");
+    Y_ENSURE(ColdParts.empty(), "Cannot iterate with cold parts");
 
     const TCelled key(key_, *Scheme->Keys, false);
     const ui64 limit = seek == ESeek::Exact ? 1 : Max<ui64>();
@@ -1310,8 +1310,8 @@ EReady TTable::Select(TRawVals key_, TTagsRef tags, IPages* env, TRowState& row,
                       const ITransactionMapPtr& visible,
                       const ITransactionObserverPtr& observer) const
 {
-    Y_ABORT_UNLESS(ColdParts.empty(), "Cannot select with cold parts");
-    Y_ABORT_UNLESS(key_.size() == Scheme->Keys->Types.size());
+    Y_ENSURE(ColdParts.empty(), "Cannot select with cold parts");
+    Y_ENSURE(key_.size() == Scheme->Keys->Types.size());
 
     const TCelled key(key_, *Scheme->Keys, false);
 
@@ -1358,7 +1358,7 @@ EReady TTable::Select(TRawVals key_, TTagsRef tags, IPages* env, TRowState& row,
     // Frozen are sorted by epoch, apply in reverse order
     for (auto pos = Frozen.rbegin(); !row.IsFinalized() && pos != Frozen.rend(); ++pos) {
         const auto& memTable = *pos;
-        Y_ABORT_UNLESS(lastEpoch > memTable->Epoch, "Ordering of epochs is incorrect");
+        Y_ENSURE(lastEpoch > memTable->Epoch, "Ordering of epochs is incorrect");
         lastEpoch = memTable->Epoch;
         if (auto it = TMemIter::Make(*memTable, memTable->Immediate(), key, ESeek::Exact, Scheme->Keys, &remap, env, EDirection::Forward)) {
             if (it->IsValid() && (snapshotFound || it->SkipToRowVersion(snapshot, stats, committed, observer, DecidedTransactions))) {
@@ -1384,7 +1384,7 @@ EReady TTable::Select(TRawVals key_, TTagsRef tags, IPages* env, TRowState& row,
                     it.SetBounds(pos->Slice);
                     auto res = it.Seek(key, ESeek::Exact);
                     if (res == EReady::Data) {
-                        Y_ABORT_UNLESS(lastEpoch > part->Epoch, "Ordering of epochs is incorrect");
+                        Y_ENSURE(lastEpoch > part->Epoch, "Ordering of epochs is incorrect");
                         lastEpoch = part->Epoch;
                         if (!snapshotFound) {
                             res = it.SkipToRowVersion(snapshot, stats, committed, observer, DecidedTransactions);
@@ -1447,7 +1447,7 @@ TSelectRowVersionResult TTable::SelectRowVersion(
         const ITransactionMapPtr& visible,
         const ITransactionObserverPtr& observer) const
 {
-    Y_ABORT_UNLESS(ColdParts.empty(), "Cannot select with cold parts");
+    Y_ENSURE(ColdParts.empty(), "Cannot select with cold parts");
 
     const TRemap remap(*Scheme, { });
 
@@ -1484,7 +1484,7 @@ TSelectRowVersionResult TTable::SelectRowVersion(
     // Frozen are sorted by epoch, apply in reverse order
     for (auto pos = Frozen.rbegin(); pos != Frozen.rend(); ++pos) {
         const auto& memTable = *pos;
-        Y_ABORT_UNLESS(lastEpoch > memTable->Epoch, "Ordering of epochs is incorrect");
+        Y_ENSURE(lastEpoch > memTable->Epoch, "Ordering of epochs is incorrect");
         lastEpoch = memTable->Epoch;
         if (auto it = TMemIter::Make(*memTable, memTable->Immediate(), key, ESeek::Exact, Scheme->Keys, &remap, env, EDirection::Forward)) {
             if (it->IsValid()) {
@@ -1508,7 +1508,7 @@ TSelectRowVersionResult TTable::SelectRowVersion(
                 it.SetBounds(pos->Slice);
                 auto res = it.Seek(key, ESeek::Exact);
                 if (res == EReady::Data && ready) {
-                    Y_ABORT_UNLESS(lastEpoch > part->Epoch, "Ordering of epochs is incorrect");
+                    Y_ENSURE(lastEpoch > part->Epoch, "Ordering of epochs is incorrect");
                     lastEpoch = part->Epoch;
                     if (auto rowVersion = it.SkipToCommitted(committed, observer)) {
                         return *rowVersion;

--- a/ydb/core/tablet_flat/flat_table_committed.h
+++ b/ydb/core/tablet_flat/flat_table_committed.h
@@ -263,12 +263,12 @@ namespace NTable {
         }
 
         ITransactionMap& operator*() const {
-            Y_ABORT_UNLESS(State_);
+            Y_ENSURE(State_);
             return *State_;
         }
 
         ITransactionMap* operator->() const {
-            Y_ABORT_UNLESS(State_);
+            Y_ENSURE(State_);
             return State_.Get();
         }
 

--- a/ydb/core/tablet_flat/flat_table_misc.cpp
+++ b/ydb/core/tablet_flat/flat_table_misc.cpp
@@ -8,7 +8,7 @@ namespace NTable {
     {
         const auto &data = memTable->GetBlobs()->Get(ref).Data;
 
-        Y_ABORT_UNLESS(data, "Got external blob in NMem::TBlobs with no data");
+        Y_ENSURE(data, "Got external blob in NMem::TBlobs with no data");
 
         return { true, &data };
     }

--- a/ydb/core/tablet_flat/flat_table_part.cpp
+++ b/ydb/core/tablet_flat/flat_table_part.cpp
@@ -38,7 +38,7 @@ TIntrusiveConstPtr<TPartScheme> TPartScheme::Parse(TArrayRef<const char> raw, bo
         auto got = NPage::TLabelWrapper().Read(raw, NPage::EPage::Schem2);
 
         // Version 1 may have non-zero group columns
-        Y_ABORT_UNLESS(got.Version == 0 || got.Version == 1, "Unknown EPage::Schem2 version");
+        Y_ENSURE(got.Version == 0 || got.Version == 1, "Unknown EPage::Schem2 version");
 
         raw = got.Page;
     }
@@ -68,7 +68,7 @@ TIntrusiveConstPtr<TPartScheme> TPartScheme::Parse(TArrayRef<const char> raw, bo
     for (size_t pos = 0; pos < proto.KeyTagsSize(); pos++) {
         auto it = byTag.find(proto.GetKeyTags(pos));
 
-        Y_ABORT_UNLESS(it != byTag.end(), "Cannot find key tag plain scheme");
+        Y_ENSURE(it != byTag.end(), "Cannot find key tag plain scheme");
 
         cols[it->second].Key = pos;
     }
@@ -147,7 +147,7 @@ void TPartScheme::InitGroup(TGroupInfo& group)
 
     for (auto& col : group.Columns) {
         if (col.IsKey()) {
-            Y_ABORT_UNLESS(col.Group == 0, "Key columns must be in the main column group");
+            Y_ENSURE(col.Group == 0, "Key columns must be in the main column group");
 
             group.ColsKeyData.push_back(col);
         }

--- a/ydb/core/tablet_flat/flat_table_part.h
+++ b/ydb/core/tablet_flat/flat_table_part.h
@@ -65,20 +65,20 @@ namespace NTable {
 
             const TBtreeIndexMeta& GetBTree(TGroupId groupId) const {
                 if (groupId.IsHistoric()) {
-                    Y_ABORT_UNLESS(groupId.Index < BTreeHistoric.size());
+                    Y_ENSURE(groupId.Index < BTreeHistoric.size());
                     return BTreeHistoric[groupId.Index];
                 } else {
-                    Y_ABORT_UNLESS(groupId.Index < BTreeGroups.size());
+                    Y_ENSURE(groupId.Index < BTreeGroups.size());
                     return BTreeGroups[groupId.Index];
                 }
             }
 
             TPageId GetFlat(TGroupId groupId) const {
                 if (groupId.IsHistoric()) {
-                    Y_ABORT_UNLESS(groupId.Index < FlatHistoric.size());
+                    Y_ENSURE(groupId.Index < FlatHistoric.size());
                     return FlatHistoric[groupId.Index];
                 } else {
-                    Y_ABORT_UNLESS(groupId.Index < FlatGroups.size());
+                    Y_ENSURE(groupId.Index < FlatGroups.size());
                     return FlatGroups[groupId.Index];
                 }
             }
@@ -126,12 +126,10 @@ namespace NTable {
             , MinRowVersion(params.MinRowVersion)
             , MaxRowVersion(params.MaxRowVersion)
         {
-            Y_ABORT_UNLESS(Scheme->Groups.size() == GroupsCount,
-                "Part has scheme with %" PRISZT " groups, but %" PRISZT " indexes",
-                Scheme->Groups.size(), GroupsCount);
-            Y_ABORT_UNLESS(!HistoricGroupsCount || HistoricGroupsCount == GroupsCount,
-                "Part has %" PRISZT " indexes, but %" PRISZT " historic indexes",
-                GroupsCount, HistoricGroupsCount);
+            Y_ENSURE(Scheme->Groups.size() == GroupsCount,
+                "Part has scheme with " << Scheme->Groups.size() << " groups, but " << GroupsCount << " indexes");
+            Y_ENSURE(!HistoricGroupsCount || HistoricGroupsCount == GroupsCount,
+                "Part has " << GroupsCount << " indexes, but " << HistoricGroupsCount << " historic indexes");
         }
 
         virtual ~TPart() = default;

--- a/ydb/core/tablet_flat/flat_util_misc.h
+++ b/ydb/core/tablet_flat/flat_util_misc.h
@@ -50,7 +50,7 @@ namespace NUtil {
     template <typename TVal>
     TVal SubSafe(TVal &val, TVal sub)
     {
-        Y_ABORT_UNLESS(val >= sub, "Counter is underflowed");
+        Y_ENSURE(val >= sub, "Counter is underflowed");
 
         return val -= Min(val, sub);
     }

--- a/ydb/core/tablet_flat/flat_writer_blocks.h
+++ b/ydb/core/tablet_flat/flat_writer_blocks.h
@@ -33,11 +33,6 @@ namespace NWriter {
         {
         }
 
-        ~TBlocks()
-        {
-            Y_ABORT_UNLESS(!Writer.Grab(), "Block writer still has some blobs");
-        }
-
         explicit operator bool() const noexcept
         {
             return Writer || Result.RegularPages || Result.StickyPages;
@@ -54,7 +49,7 @@ namespace NWriter {
                 Result.PageCollection = MakeIntrusiveConst<NPageCollection::TPageCollection>(largeGlobId, std::move(meta));
             }
 
-            Y_ABORT_UNLESS(!Writer, "Block writer is not empty after Finish");
+            Y_ENSURE(!Writer, "Block writer is not empty after Finish");
 
             return std::exchange(Result, {});
         }

--- a/ydb/core/tablet_flat/flat_writer_bundle.h
+++ b/ydb/core/tablet_flat/flat_writer_bundle.h
@@ -6,6 +6,7 @@
 #include "flat_writer_blocks.h"
 #include "util_basics.h"
 #include "util_channel.h"
+#include "util_fmt_abort.h"
 
 namespace NKikimr {
 namespace NTabletFlatExecutor {
@@ -26,7 +27,7 @@ namespace NWriter {
             , ChannelsShares(conf.ChannelsShares)
             , Banks(base, conf.Slots)
         {
-            Y_ABORT_UNLESS(Groups.size() >= 1, "There must be at least one page collection group");
+            Y_ENSURE(Groups.size() >= 1, "There must be at least one page collection group");
 
             const auto none = NTable::NPage::ECache::None;
 
@@ -40,11 +41,6 @@ namespace NWriter {
             Growth = new NTable::TScreen::TCook;
         }
 
-        ~TBundle()
-        {
-            Y_ABORT_UNLESS(!Blobs, "Bundle writer still has some blobs");
-        }
-
         TVector<NPageCollection::TGlob> GetBlobsToSave() noexcept
         {
             return std::exchange(Blobs, { });
@@ -53,7 +49,7 @@ namespace NWriter {
         TVector<TResult> Results()
         {
             for (auto &blocks : Blocks) {
-                Y_ABORT_UNLESS(!*blocks, "Bundle writer has unflushed data");
+                Y_ENSURE(!*blocks, "Bundle writer has unflushed data");
             }
 
             return std::move(Results_);
@@ -101,13 +97,13 @@ namespace NWriter {
                 if (auto written = Blocks[num]->Finish(); written.PageCollection) {
                     result.PageCollections.emplace_back(std::move(written));
                 } else if (num < Blocks.size() - 1) {
-                    Y_ABORT("Finish produced an empty main page collection");
+                    Y_TABLET_ERROR("Finish produced an empty main page collection");
                 }
 
-                Y_ABORT_UNLESS(!*Blocks[num], "Block writer has unexpected data");
+                Y_ENSURE(!*Blocks[num], "Block writer has unexpected data");
             }
 
-            Y_ABORT_UNLESS(result.PageCollections, "Finish produced no page collections");
+            Y_ENSURE(result.PageCollections, "Finish produced no page collections");
 
             result.Growth = Growth->Unwrap();
             result.Overlay = overlay;
@@ -115,7 +111,7 @@ namespace NWriter {
 
         NPageCollection::TCookieAllocator& CookieRange(ui32 cookieRange) override
         {
-            Y_ABORT_UNLESS(cookieRange == 0 || cookieRange == 1, "Invalid cookieRange requested");
+            Y_ENSURE(cookieRange == 0 || cookieRange == 1, "Invalid cookieRange requested");
 
             return cookieRange == 0 ? Banks.Meta : Banks.Data;
         }
@@ -141,11 +137,11 @@ namespace NWriter {
                 offset += chunk;
                 left -= chunk;
 
-                Y_ABORT_UNLESS(chunk && (chunk == block || left == 0));
+                Y_ENSURE(chunk && (chunk == block || left == 0));
             }
 
-            Y_ABORT_UNLESS(offset == body.size());
-            Y_ABORT_UNLESS(left == 0);
+            Y_ENSURE(offset == body.size());
+            Y_ENSURE(left == 0);
             return largeGlobId;
         }
 

--- a/ydb/core/tablet_flat/logic_redo_queue.h
+++ b/ydb/core/tablet_flat/logic_redo_queue.h
@@ -1,11 +1,12 @@
 #pragma once
 
-#include "util_fmt_flat.h"
 #include "flat_util_misc.h"
 #include "logic_redo_eggs.h"
 #include "logic_redo_entry.h"
 #include "logic_redo_table.h"
 #include "flat_exec_commit.h"
+#include "util_fmt_abort.h"
+#include "util_fmt_flat.h"
 #include <util/generic/hash.h>
 #include <util/generic/intrlist.h>
 #include <ydb/core/util/queue_inplace.h>
@@ -47,7 +48,7 @@ namespace NRedo {
         void Push(TEntry *entry)
         {
             if (bool(entry->Embedded) == bool(entry->LargeGlobId)) {
-                Y_Fail(NFmt::Do(*entry) << " has incorrect payload");
+                Y_TABLET_ERROR(NFmt::Do(*entry) << " has incorrect payload");
             }
 
             Log->Push(entry);
@@ -60,7 +61,7 @@ namespace NRedo {
                 const auto *edge = Edges.FindPtr(table);
 
                 if (edge && edge->TxStamp >= entry->Stamp) {
-                    Y_Fail(
+                    Y_TABLET_ERROR(
                         "Entry " << NFmt::Do(*entry) << " queued below table"
                         << table << " edge " << NFmt::TStamp(edge->TxStamp));
                 } else if (auto *over = Overhead[table].Push(table, entry)) {
@@ -68,13 +69,14 @@ namespace NRedo {
                 }
             }
 
-            if (entry->References == 0)
-                Y_Fail(NFmt::Do(*entry) << " has no effects on data");
+            if (entry->References == 0) {
+                Y_TABLET_ERROR(NFmt::Do(*entry) << " has no effects on data");
+            }
         }
 
         void Cut(ui32 table, NTable::TSnapEdge edge, TGCBlobDelta &gc)
         {
-            Y_ABORT_UNLESS(edge.TxStamp != Max<ui64>(), "Undefined TxStamp of edge");
+            Y_ENSURE(edge.TxStamp != Max<ui64>(), "Undefined TxStamp of edge");
 
             auto &cur = Edges[table];
 
@@ -116,7 +118,7 @@ namespace NRedo {
 
                     Push(entry.Release());
                 } else {
-                    Y_ABORT_UNLESS(entry->References == 0);
+                    Y_ENSURE(entry->References == 0);
                 }
             }
         }

--- a/ydb/core/tablet_flat/logic_redo_table.h
+++ b/ydb/core/tablet_flat/logic_redo_table.h
@@ -2,6 +2,7 @@
 
 #include "logic_redo_entry.h"
 #include "flat_exec_commit.h"
+#include "util_fmt_abort.h"
 #include <util/generic/deque.h>
 #include <util/generic/intrlist.h>
 
@@ -21,9 +22,9 @@ namespace NRedo {
         TOverhead* Push(ui32 table, TEntry* entry)
         {
             if (Trace && Trace.back() == entry) {
-                Y_Fail(NFmt::Do(*entry) << " is dublicated in table trace");
+                Y_TABLET_ERROR(NFmt::Do(*entry) << " is dublicated in table trace");
             } else if (Trace && entry->Stamp < Trace.back()->Stamp) {
-                Y_Fail(NFmt::Do(*entry) << " is in the past of table trace");
+                Y_TABLET_ERROR(NFmt::Do(*entry) << " is in the past of table trace");
             }
 
             Trace.emplace_back(entry);
@@ -45,7 +46,7 @@ namespace NRedo {
                     return stamp < entry->Stamp;
                 });
 
-            Y_ABORT_UNLESS(end != Trace.begin());
+            Y_ENSURE(end != Trace.begin());
 
             for (auto it = Trace.begin(); it != end; ++it) {
                 NUtil::SubSafe(Bytes, (*it)->BytesData());

--- a/ydb/core/tablet_flat/logic_snap_main.h
+++ b/ydb/core/tablet_flat/logic_snap_main.h
@@ -52,9 +52,10 @@ namespace NTabletFlatExecutor {
 
         void Confirm(ui32 step)
         {
-            if (Pending == 0 || Pending != step)
-                Y_Fail(
+            if (Pending == 0 || Pending != step) {
+                Y_TABLET_ERROR(
                     NFmt::Do(*this) << " got unexpected confirm for " << step);
+            }
 
             Pending = 0;
         }
@@ -62,7 +63,7 @@ namespace NTabletFlatExecutor {
         void MakeSnap(TSnap &snap, TLogCommit &commit, NUtil::ILogger *logger)
         {
             if (Pending != 0) {
-                Y_Fail(
+                Y_TABLET_ERROR(
                     NFmt::Do(*this) << " cannot make snap on " << commit.Step);
             }
 

--- a/ydb/core/tablet_flat/shared_cache_clock_pro_ut.cpp
+++ b/ydb/core/tablet_flat/shared_cache_clock_pro_ut.cpp
@@ -57,7 +57,7 @@ namespace {
 
         static void SetLocation(TPage* page, EClockProPageLocation location) {
             ui32 location_ = static_cast<ui32>(location);
-            Y_ABORT_UNLESS(location_ < (1 << 4));
+            Y_ENSURE(location_ < (1 << 4));
             page->CacheFlags1 = location_;
         }
 

--- a/ydb/core/tablet_flat/shared_cache_s3fifo.h
+++ b/ydb/core/tablet_flat/shared_cache_s3fifo.h
@@ -1,5 +1,6 @@
 #pragma once
 #include "defs.h"
+#include "util_fmt_abort.h"
 #include <ydb/core/util/cache_cache_iface.h>
 #include <ydb/library/yverify_stream/yverify_stream.h>
 #include <library/cpp/monlib/counters/counters.h>
@@ -130,7 +131,7 @@ public:
             case ES3FIFOPageLocation::None:
                 return Insert(page);
             default:
-                Y_ABORT("Unknown page location");
+                Y_TABLET_ERROR("Unknown page location");
         }
     }
 
@@ -146,7 +147,7 @@ public:
                 Erase(MainQueue, page);
                 break;
             default:
-                Y_ABORT("Unknown page location");
+                Y_TABLET_ERROR("Unknown page location");
         }
 
         TPageTraits::SetFrequency(page, 0);
@@ -246,10 +247,10 @@ private:
     }
 
     TPage* Pop(TQueue& queue) {
-        Y_ABORT_UNLESS(!queue.Queue.Empty());
-        Y_ABORT_UNLESS(TPageTraits::GetLocation(queue.Queue.Front()) == queue.Location);
-        Y_ABORT_UNLESS(queue.Count > 0);
-        Y_ABORT_UNLESS(queue.Size >= TPageTraits::GetSize(queue.Queue.Front()));
+        Y_ENSURE(!queue.Queue.Empty());
+        Y_ENSURE(TPageTraits::GetLocation(queue.Queue.Front()) == queue.Location);
+        Y_ENSURE(queue.Count > 0);
+        Y_ENSURE(queue.Size >= TPageTraits::GetSize(queue.Queue.Front()));
 
         TPage* page = queue.Queue.PopFront();
         queue.Count--;
@@ -260,7 +261,7 @@ private:
     }
 
     void Push(TQueue& queue, TPage* page) {
-        Y_ABORT_UNLESS(TPageTraits::GetLocation(page) == ES3FIFOPageLocation::None);
+        Y_ENSURE(TPageTraits::GetLocation(page) == ES3FIFOPageLocation::None);
 
         queue.Queue.PushBack(page);
         queue.Count++;
@@ -269,9 +270,9 @@ private:
     }
 
     void Erase(TQueue& queue, TPage* page) {
-        Y_ABORT_UNLESS(TPageTraits::GetLocation(page) == queue.Location);
-        Y_ABORT_UNLESS(queue.Count > 0);
-        Y_ABORT_UNLESS(queue.Size >= TPageTraits::GetSize(page));
+        Y_ENSURE(TPageTraits::GetLocation(page) == queue.Location);
+        Y_ENSURE(queue.Count > 0);
+        Y_ENSURE(queue.Size >= TPageTraits::GetSize(page));
 
         page->Unlink();
         queue.Count--;

--- a/ydb/core/tablet_flat/shared_cache_s3fifo_ut.cpp
+++ b/ydb/core/tablet_flat/shared_cache_s3fifo_ut.cpp
@@ -53,7 +53,7 @@ namespace {
 
         static void SetLocation(TPage* page, ES3FIFOPageLocation location) {
             ui32 location_ = static_cast<ui32>(location);
-            Y_ABORT_UNLESS(location_ < (1 << 4));
+            Y_ENSURE(location_ < (1 << 4));
             page->CacheFlags1 = location_;
         }
 
@@ -62,7 +62,7 @@ namespace {
         }
 
         static void SetFrequency(TPage* page, ui32 frequency) {
-            Y_ABORT_UNLESS(frequency < (1 << 4));
+            Y_ENSURE(frequency < (1 << 4));
             page->CacheFlags2 = frequency;
         }
     };

--- a/ydb/core/tablet_flat/shared_cache_switchable_ut.cpp
+++ b/ydb/core/tablet_flat/shared_cache_switchable_ut.cpp
@@ -37,7 +37,7 @@ namespace {
         }
 
         static void SetCacheId(TPage* page, ui32 id) {
-            Y_ABORT_UNLESS(id < (1 << 4));
+            Y_ENSURE(id < (1 << 4));
             page->CacheId = id;
         }
     };
@@ -103,9 +103,9 @@ namespace {
                 if (count != 0) result << ", ";
                 result << "{" << page->Id << " " << page->Size << "b}";
                 count++;
-                Y_ABORT_UNLESS(*Map.FindPtr(page->Id) == it);
+                Y_ENSURE(*Map.FindPtr(page->Id) == it);
             }
-            Y_ABORT_UNLESS(Map.size() == count);
+            Y_ENSURE(Map.size() == count);
             return result;
         }
     

--- a/ydb/core/tablet_flat/shared_handle.h
+++ b/ydb/core/tablet_flat/shared_handle.h
@@ -316,13 +316,13 @@ public:
         Drop();
     }
 
-    TSharedPageRef(const TSharedPageRef& ref) noexcept
+    TSharedPageRef(const TSharedPageRef& ref)
         : Handle(ref.Handle)
         , GCList(ref.GCList)
         , Used(false)
     {
         if (ref.Used) {
-            Y_ABORT_UNLESS(Use());
+            Y_ENSURE(Use());
         }
     }
 
@@ -332,13 +332,13 @@ public:
         , Used(std::exchange(ref.Used, false))
     { }
 
-    TSharedPageRef& operator=(const TSharedPageRef& ref) noexcept {
+    TSharedPageRef& operator=(const TSharedPageRef& ref) {
         if (this != &ref) {
             Drop();
             Handle = ref.Handle;
             GCList = ref.GCList;
             if (ref.Used) {
-                Y_ABORT_UNLESS(Use());
+                Y_ENSURE(Use());
             }
         }
 
@@ -446,8 +446,8 @@ public:
         : Data_(std::move(data))
     { }
 
-    explicit TPinnedPageRef(const TSharedPageRef& ref) noexcept {
-        Y_ABORT_UNLESS(ref.IsUsed(), "Cannot pin pages not marked as used");
+    explicit TPinnedPageRef(const TSharedPageRef& ref) {
+        Y_ENSURE(ref.IsUsed(), "Cannot pin pages not marked as used");
         Data_ = ref.GetHandle()->Pin();
         Handle_ = ref.GetHandle();
     }

--- a/ydb/core/tablet_flat/shared_page.h
+++ b/ydb/core/tablet_flat/shared_page.h
@@ -59,9 +59,9 @@ struct TPage
     }
 
     void EnsureNoCacheFlags() {
-        Y_VERIFY_S(CacheId == 0, "Unexpected page " << CacheId << " cache id");
-        Y_VERIFY_S(CacheFlags1 == 0, "Unexpected page " << CacheFlags1 << " cache flags 1");
-        Y_VERIFY_S(CacheFlags2 == 0, "Unexpected page " << CacheFlags2 << " cache flags 2");
+        Y_ENSURE(CacheId == 0, "Unexpected page " << CacheId << " cache id");
+        Y_ENSURE(CacheFlags1 == 0, "Unexpected page " << CacheFlags1 << " cache flags 1");
+        Y_ENSURE(CacheFlags2 == 0, "Unexpected page " << CacheFlags2 << " cache flags 2");
     }
 };
 

--- a/ydb/core/tablet_flat/tablet_flat_executed.cpp
+++ b/ydb/core/tablet_flat/tablet_flat_executed.cpp
@@ -44,7 +44,7 @@ IExecutor* TTabletExecutedFlat::CreateExecutor(const TActorContext &ctx) {
         IActor *executor = NFlatExecutorSetup::CreateExecutor(this, ctx.SelfID);
         const TActorId executorID = ctx.RegisterWithSameMailbox(executor);
         Executor0 = dynamic_cast<TExecutor *>(executor);
-        Y_ABORT_UNLESS(Executor0);
+        Y_ENSURE(Executor0);
 
         ITablet::ExecutorActorID = executorID;
     }
@@ -173,19 +173,19 @@ void TTabletExecutedFlat::HandleTabletDead(TEvTablet::TEvTabletDead::TPtr &ev, c
 }
 
 void TTabletExecutedFlat::HandleLocalMKQL(TEvTablet::TEvLocalMKQL::TPtr &ev, const TActorContext &ctx) {
-    Y_ABORT_UNLESS(Factory, "Need IMiniKQLFactory to execute MKQL query");
+    Y_ENSURE(Factory, "Need IMiniKQLFactory to execute MKQL query");
 
     Execute(Factory->Make(ev), ctx);
 }
 
 void TTabletExecutedFlat::HandleLocalSchemeTx(TEvTablet::TEvLocalSchemeTx::TPtr &ev, const TActorContext &ctx) {
-    Y_ABORT_UNLESS(Factory, "Need IMiniKQLFactory to execute scheme query");
+    Y_ENSURE(Factory, "Need IMiniKQLFactory to execute scheme query");
 
     Execute(Factory->Make(ev), ctx);
 }
 
 void TTabletExecutedFlat::HandleLocalReadColumns(TEvTablet::TEvLocalReadColumns::TPtr &ev, const TActorContext &ctx) {
-    Y_ABORT_UNLESS(Factory, "Need IMiniKQLFactory to execute read columns query");
+    Y_ENSURE(Factory, "Need IMiniKQLFactory to execute read columns query");
 
     Execute(Factory->Make(ev), ctx);
 }

--- a/ydb/core/tablet_flat/tablet_flat_executor.cpp
+++ b/ydb/core/tablet_flat/tablet_flat_executor.cpp
@@ -1,5 +1,6 @@
 #include "tablet_flat_executor.h"
 #include "flat_executor.h"
+#include "util_fmt_abort.h"
 
 namespace NKikimr {
 namespace NTabletFlatExecutor {
@@ -12,7 +13,7 @@ namespace NFlatExecutorSetup {
     void ITablet::SnapshotComplete(TIntrusivePtr<TTableSnapshotContext> snapContext, const TActorContext &ctx) {
         Y_UNUSED(snapContext);
         Y_UNUSED(ctx);
-        Y_ABORT("must be overriden if plan to use table snapshot completion");
+        Y_TABLET_ERROR("must be overriden if plan to use table snapshot completion");
     }
 
     void ITablet::CompactionComplete(ui32 tableId, const TActorContext &ctx) {

--- a/ydb/core/tablet_flat/tablet_flat_executor.h
+++ b/ydb/core/tablet_flat/tablet_flat_executor.h
@@ -2,6 +2,7 @@
 #include "defs.h"
 
 #include "flat_scan_iface.h"
+#include "util_fmt_abort.h"
 
 #include <ydb/core/base/tablet.h>
 #include <ydb/core/base/blobstorage.h>
@@ -136,7 +137,7 @@ public:
 
     void RequestMemory(ui64 bytes)
     {
-        Y_ABORT_UNLESS(!MemoryGCToken);
+        Y_ENSURE(!MemoryGCToken);
         RequestedMemory += bytes;
     }
 
@@ -160,16 +161,16 @@ public:
 
     TAutoPtr<TMemoryToken> HoldMemory(ui64 size)
     {
-        Y_ABORT_UNLESS(!MemoryGCToken);
-        Y_ABORT_UNLESS(size <= MemoryLimit);
-        Y_ABORT_UNLESS(size > 0);
+        Y_ENSURE(!MemoryGCToken);
+        Y_ENSURE(size <= MemoryLimit);
+        Y_ENSURE(size > 0);
         MemoryGCToken = new TMemoryGCToken(size, TaskId);
         return new TMemoryToken(MemoryGCToken);
     }
 
     void UseMemoryToken(TAutoPtr<TMemoryToken> token)
     {
-        Y_ABORT_UNLESS(!MemoryToken);
+        Y_ENSURE(!MemoryToken);
         MemoryToken = std::move(token);
     }
 
@@ -301,7 +302,7 @@ public:
     virtual bool Execute(TTransactionContext &txc, const TActorContext &ctx) = 0;
     virtual void Complete(const TActorContext &ctx) = 0;
     virtual void Terminate(ETerminationReason reason, const TActorContext &/*ctx*/) {
-        Y_ABORT("Unexpected transaction termination (reason %" PRIu32 ")", (ui32)reason);
+        Y_TABLET_ERROR("Unexpected transaction termination (reason " << (ui32)reason << ")");
     }
     virtual void ReleaseTxData(TTxMemoryProvider &/*provider*/, const TActorContext &/*ctx*/) {}
     virtual TTxType GetTxType() const { return UnknownTxType; }
@@ -527,7 +528,7 @@ namespace NFlatExecutorSetup {
             : TabletActorID(tablet)
             , TabletInfo(info)
         {
-            Y_ABORT_UNLESS(TTabletTypes::TypeInvalid != TabletInfo->TabletType);
+            Y_ENSURE(TTabletTypes::TypeInvalid != TabletInfo->TabletType);
         }
 
         TActorId ExecutorActorID;

--- a/ydb/core/tablet_flat/test/libs/exec/dummy.h
+++ b/ydb/core/tablet_flat/test/libs/exec/dummy.h
@@ -3,6 +3,7 @@
 #include "events.h"
 #include <ydb/core/base/tablet_pipe.h>
 #include <ydb/core/tablet_flat/tablet_flat_executed.h>
+#include <ydb/core/tablet_flat/util_fmt_abort.h>
 #include <ydb/library/actors/core/actor.h>
 #include <util/system/type_name.h>
 
@@ -46,7 +47,7 @@ namespace NFake {
         void Inbox(TEventHandlePtr &eh)
         {
             if (auto *ev = eh->CastAsLocal<NFake::TEvExecute>()) {
-                Y_ABORT_UNLESS(State == EState::Work, "Cannot handle TX now");
+                Y_ENSURE(State == EState::Work, "Cannot handle TX now");
 
                 for (auto& tx : ev->Txs) {
                     Execute(tx.Release(), this->ActorContext());
@@ -55,7 +56,7 @@ namespace NFake {
                     std::move(lambda)(Executor(), this->ActorContext());
                 }
             } else if (auto *ev = eh->CastAsLocal<NFake::TEvCompact>()) {
-                Y_ABORT_UNLESS(State == EState::Work, "Cannot handle compaction now");
+                Y_ENSURE(State == EState::Work, "Cannot handle compaction now");
 
                 if (ev->MemOnly) {
                     Executor()->CompactMemTable(ev->Table);
@@ -85,7 +86,7 @@ namespace NFake {
             } else if (eh->CastAsLocal<TEvTabletPipe::TEvServerDisconnected>()){
 
             } else if (!TTabletExecutedFlat::HandleDefaultEvents(eh, SelfId())) {
-                Y_Fail("Unexpected event " << eh->GetTypeName());
+                Y_TABLET_ERROR("Unexpected event " << eh->GetTypeName());
             }
         }
 
@@ -93,7 +94,7 @@ namespace NFake {
         {
             const auto &name = eh->GetTypeName();
 
-            Y_ABORT("Got unexpected event %s on tablet booting", name.c_str());
+            Y_TABLET_ERROR("Got unexpected event " << name << " on tablet booting");
         }
 
         void DefaultSignalTabletActive(const TActorContext&) override
@@ -107,7 +108,7 @@ namespace NFake {
                 SignalTabletActive(SelfId());
                 Send(Owner, new NFake::TEvReady(TabletID(), SelfId()));
             } else {
-                Y_ABORT("Received unexpected TExecutor activation");
+                Y_TABLET_ERROR("Received unexpected TExecutor activation");
             }
         }
 
@@ -140,7 +141,7 @@ namespace NFake {
             if (auto* snapContext = dynamic_cast<TDummySnapshotContext*>(rawSnapContext.Get())) {
                 Send(SelfId(), snapContext->OnFinished());
             } else {
-                Y_ABORT("Unsupported snapshot context");
+                Y_TABLET_ERROR("Unsupported snapshot context");
             }
         }
 

--- a/ydb/core/tablet_flat/test/libs/exec/fuzzy.h
+++ b/ydb/core/tablet_flat/test/libs/exec/fuzzy.h
@@ -135,7 +135,7 @@ namespace NFake {
     protected:
         bool RegisterTable(ui32 table)
         {
-            Y_ABORT_UNLESS(table < 8 * sizeof(Tables));
+            Y_ENSURE(table < 8 * sizeof(Tables));
 
             auto slot = Tables | (ui64(1) << table);
 

--- a/ydb/core/tablet_flat/test/libs/exec/leader.h
+++ b/ydb/core/tablet_flat/test/libs/exec/leader.h
@@ -2,10 +2,10 @@
 
 #include "world.h"
 #include "events.h"
-#include <ydb/core/tablet_flat/util_fmt_logger.h>
 #include <ydb/core/tablet_flat/util_fmt_abort.h>
-#include <ydb/core/tablet_flat/util_fmt_desc.h>
 #include <ydb/core/tablet_flat/util_fmt_basic.h>
+#include <ydb/core/tablet_flat/util_fmt_desc.h>
+#include <ydb/core/tablet_flat/util_fmt_logger.h>
 #include <ydb/library/actors/core/actor.h>
 
 namespace NKikimr {
@@ -28,7 +28,7 @@ namespace NFake {
             , Edge(head) /* Live until this runlevel exists */
             , Stopped(stopped)
         {
-             Y_ABORT_UNLESS(Edge < Levels.size(), "Out of runlevels slots");
+            Y_ENSURE(Edge < Levels.size(), "Out of runlevels slots");
         }
 
     private:
@@ -70,7 +70,7 @@ namespace NFake {
             } else if (eh->CastAsLocal<NFake::TEvTerm>()) {
 
             } else {
-                Y_Fail("Unexpected event " << eh->GetTypeName());
+                Y_TABLET_ERROR("Unexpected event " << eh->GetTypeName());
             }
         }
 
@@ -100,7 +100,7 @@ namespace NFake {
                 auto actor = Register(cmd.Actor.release(), cmd.MailboxType, 0);
                 auto result = Childs.emplace(actor, level);
 
-                Y_ABORT_UNLESS(result.second, "Cannot register same actor twice");
+                Y_ENSURE(result.second, "Cannot register same actor twice");
 
                 Levels[level].Left += 1, Total += 1, Head = Max(Head, level);
 

--- a/ydb/core/tablet_flat/test/libs/exec/logger.h
+++ b/ydb/core/tablet_flat/test/libs/exec/logger.h
@@ -3,6 +3,7 @@
 #include "world.h"
 
 #include <ydb/core/tablet_flat/util_basics.h>
+#include <ydb/core/tablet_flat/util_fmt_abort.h>
 #include <ydb/core/tablet_flat/util_fmt_line.h>
 #include <ydb/library/actors/core/actor.h>
 #include <ydb/library/actors/core/log_iface.h>
@@ -23,7 +24,7 @@ namespace NFake {
 
         void Put(TInstant stamp, ui32 level, EComp comp, TArrayRef<const char> line)
         {
-            Y_ABORT_UNLESS(line.size() < 8192 * 16, "Too large log line");
+            Y_ENSURE(line.size() < 8192 * 16, "Too large log line");
 
             static const char scaleMajor[] = "^^*CEWNIDT.";
             static const char scaleMinor[] = "0123456789.";
@@ -133,7 +134,7 @@ namespace NFake {
                     Send(TWorld::Where(EPath::Root), new NFake::TEvTerm);
 
             } else {
-                Y_ABORT("Test runtime env logger got an unknown event");
+                Y_TABLET_ERROR("Test runtime env logger got an unknown event");
             }
         }
 

--- a/ydb/core/tablet_flat/test/libs/exec/nanny.h
+++ b/ydb/core/tablet_flat/test/libs/exec/nanny.h
@@ -3,8 +3,9 @@
 #include "world.h"
 #include "events.h"
 #include "helper.h"
-#include <ydb/core/tablet_flat/util_fmt_logger.h>
 #include <ydb/core/tablet_flat/tablet_flat_executed.h>
+#include <ydb/core/tablet_flat/util_fmt_abort.h>
+#include <ydb/core/tablet_flat/util_fmt_logger.h>
 #include <ydb/core/tablet_flat/ut/flat_test_db.h>
 #include <ydb/core/tablet_flat/ut/flat_test_db_helpers.h>
 #include <ydb/library/actors/core/actor.h>
@@ -26,15 +27,10 @@ namespace NFake {
 
         }
 
-        ~TFuncTx()
-        {
-            Y_ABORT_UNLESS(Completed, "Destroying incomplted transaction");
-        }
-
     private:
         bool Execute(TTransactionContext &txc, const TActorContext&) override
         {
-            Y_ABORT_UNLESS(!Completed, "TFuncTx is already completed");
+            Y_ENSURE(!Completed, "TFuncTx is already completed");
 
             Local.SetDb(&txc.DB);
 
@@ -50,7 +46,7 @@ namespace NFake {
 
         void Complete(const TActorContext &ctx) override
         {
-            Y_ABORT_UNLESS(Completed, "Finalizing incomplteted transaction");
+            Y_ENSURE(Completed, "Complete called for unfinished transaction");
 
             ctx.Send(Owner, new NFake::TEvResult);
             Local.SetDb(nullptr);
@@ -134,18 +130,18 @@ namespace NFake {
             } else if (eh->CastAsLocal<TEvents::TEvPoison>()) {
                 DoSuicide();
             } else {
-                Y_Fail("Unexpected event " << eh->GetTypeName());
+                Y_TABLET_ERROR("Unexpected event " << eh->GetTypeName());
             }
         }
 
         void Handle(NFake::TEvReady &ev)
         {
             if (std::exchange(State, EDo::More) != EDo::Born) {
-                Y_ABORT("Got an unexpected TEvReady{ } event");
+                Y_TABLET_ERROR("Got an unexpected TEvReady{ } event");
             } else if (std::exchange(Tablet, ev.ActorId)) {
-                Y_ABORT("Child tablet actor is still alive");
+                Y_TABLET_ERROR("Child tablet actor is still alive");
             } else if (TxInFlight > 0) {
-                Y_ABORT("Just bron(rebooted) tablet has pending tx");
+                Y_TABLET_ERROR("Just bron(rebooted) tablet has pending tx");
             }
 
             QueueTx(CompareDbs);
@@ -153,20 +149,20 @@ namespace NFake {
 
         void Handle(NFake::TEvResult&)
         {
-            Y_ABORT_UNLESS(TxInFlight-- > 0, "Tx counter is underflowed");
+            Y_ENSURE(TxInFlight-- > 0, "Tx counter is underflowed");
 
             if (State == EDo::More) State = Run();
 
             if (TxInFlight > 0) {
                 /* Should wait for pending tx completion before tablet kill */
             } else if (State == EDo::Born) {
-                Y_ABORT_UNLESS(Tablet, "Tabled has been already restarted");
+                Y_ENSURE(Tablet, "Tabled has been already restarted");
 
                 Send(std::exchange(Tablet, { }), new TEvents::TEvPoison);
             } else if (State == EDo::Stop) {
                 Send(std::exchange(Tablet, { }), new TEvents::TEvPoison);
             } else {
-                Y_ABORT("TNanny actor cannot progress: no tx, no EDo");
+                Y_TABLET_ERROR("TNanny actor cannot progress: no tx, no EDo");
             }
         }
 

--- a/ydb/core/tablet_flat/test/libs/exec/owner.h
+++ b/ydb/core/tablet_flat/test/libs/exec/owner.h
@@ -9,8 +9,8 @@
 #include <ydb/core/base/tablet.h>
 #include <ydb/core/mind/local.h>
 #include <ydb/core/tablet/tablet_setup.h>
-#include <ydb/core/tablet_flat/util_fmt_logger.h>
 #include <ydb/core/tablet_flat/util_fmt_abort.h>
+#include <ydb/core/tablet_flat/util_fmt_logger.h>
 #include <library/cpp/testing/unittest/registar.h>
 
 namespace NKikimr {
@@ -31,7 +31,7 @@ namespace NFake {
             , Limit(Max(ui32(1), limit))
             , FollowerId(followerId)
         {
-            Y_ABORT_UNLESS(TTabletTypes::TypeInvalid != Info->TabletType);
+            Y_ENSURE(TTabletTypes::TypeInvalid != Info->TabletType);
         }
 
     private:
@@ -79,13 +79,13 @@ namespace NFake {
             } else if (eh->CastAsLocal<TEvTablet::TEvReady>()) {
 
             } else {
-                Y_Fail("Unexpected event " << eh->GetTypeName());
+                Y_TABLET_ERROR("Unexpected event " << eh->GetTypeName());
             }
         }
 
         void Start(const TActorContext &ctx)
         {
-            Y_ABORT_UNLESS(!Agent, "Tablet actor is already started");
+            Y_ENSURE(!Agent, "Tablet actor is already started");
 
             if (auto logl = Logger->Log(ELnLev::Debug)) {
                 logl
@@ -101,7 +101,7 @@ namespace NFake {
                 Agent = Setup->Follower(Info.Get(), SelfId(), ctx, FollowerId, profile);
             }
 
-            Y_ABORT_UNLESS(Agent, "Failed to start new tablet actor");
+            Y_ENSURE(Agent, "Failed to start new tablet actor");
 
             Borns += 1;
         }

--- a/ydb/core/tablet_flat/test/libs/exec/runner.h
+++ b/ydb/core/tablet_flat/test/libs/exec/runner.h
@@ -197,7 +197,7 @@ namespace NFake {
             const auto begin = ui32(NKikimrServices::EServiceKikimr_MIN);
             const auto end = ui32(NKikimrServices::EServiceKikimr_MAX) + 1;
 
-            Y_ABORT_UNLESS(end < 8192, "Looks like there is too many services");
+            Y_ENSURE(end < 8192, "Looks like there is too many services");
 
             TVector<TString> names(end);
 

--- a/ydb/core/tablet_flat/test/libs/exec/storage.h
+++ b/ydb/core/tablet_flat/test/libs/exec/storage.h
@@ -3,6 +3,7 @@
 #include "events.h"
 
 #include <ydb/core/tablet_flat/flat_sausage_solid.h>
+#include <ydb/core/tablet_flat/util_fmt_abort.h>
 #include <ydb/core/blobstorage/dsproxy/mock/model.h>
 #include <ydb/core/base/blobstorage.h>
 
@@ -84,7 +85,7 @@ namespace NFake {
 
                 PassAway();
             } else {
-                 Y_ABORT("DS proxy model got an unexpected event");
+                 Y_TABLET_ERROR("DS proxy model got an unexpected event");
             }
         }
 

--- a/ydb/core/tablet_flat/test/libs/exec/warden.h
+++ b/ydb/core/tablet_flat/test/libs/exec/warden.h
@@ -5,6 +5,7 @@
 #include <ydb/library/actors/core/actor.h>
 #include <ydb/core/base/blobstorage.h>
 #include <ydb/library/services/services.pb.h>
+#include <ydb/core/tablet_flat/util_fmt_abort.h>
 #include <ydb/core/tablet_flat/util_fmt_logger.h>
 #include <util/system/type_name.h>
 
@@ -30,10 +31,11 @@ namespace NFake {
         TWarden(ui32 groups)
             : ::NActors::IActorCallback(static_cast<TReceiveFunc>(&TWarden::Inbox), NKikimrServices::TActivity::FAKE_ENV_A)
         {
-             Y_ABORT_UNLESS(groups < State.size(), "Too many groups requested");
+            Y_ENSURE(groups < State.size(), "Too many groups requested");
 
-             for (auto group: xrange(groups))
+            for (auto group: xrange(groups)) {
                 State[group] = EState::Allow;
+            }
         }
 
     private:
@@ -62,7 +64,7 @@ namespace NFake {
                 } else if (State[group] == EState::Allow) {
                     State[group] = EState::Fired;
 
-                    Y_ABORT_UNLESS(++Alive <= State.size(), "Out of group states");
+                    Y_ENSURE(++Alive <= State.size(), "Out of group states");
 
                     StartGroup(group);
 
@@ -84,7 +86,7 @@ namespace NFake {
 
             } else if (eh->CastAsLocal<TEvents::TEvPoison>()) {
                 if (std::exchange(Shutting, true)) {
-                    Y_ABORT("Got double BS storage shut order");
+                    Y_TABLET_ERROR("Got double BS storage shut order");
                 } else if (auto logl = Logger->Log(ELnLev::Info))
                     logl << "Shut order, stopping " << Alive << " BS groups";
 
@@ -106,9 +108,9 @@ namespace NFake {
                 const auto group = eh->Cookie;
 
                 if (group >= State.size() || State[group] < EState::Fired) {
-                    Y_ABORT("Got an TEvGone event form unknown BS group");
+                    Y_TABLET_ERROR("Got an TEvGone event form unknown BS group");
                 } else if (!Shutting || State[group] != EState::Shut) {
-                    Y_ABORT("Got unexpected TEvGone from BS group mock");
+                    Y_TABLET_ERROR("Got unexpected TEvGone from BS group mock");
                 }
 
                 --Alive, State[group] = EState::Gone;
@@ -118,7 +120,7 @@ namespace NFake {
             } else if (eh->CastAsLocal<NFake::TEvTerm>()) {
 
             } else {
-                Y_ABORT("Got unexpected message");
+                Y_TABLET_ERROR("Got unexpected message");
             }
         }
 

--- a/ydb/core/tablet_flat/test/libs/rows/cook.h
+++ b/ydb/core/tablet_flat/test/libs/rows/cook.h
@@ -4,6 +4,7 @@
 #include "tails.h"
 
 #include <ydb/core/tablet_flat/flat_row_scheme.h>
+#include <ydb/core/tablet_flat/util_fmt_abort.h>
 
 namespace NKikimr {
 namespace NTable {
@@ -15,7 +16,6 @@ namespace NTest {
 
         ~TCookRow()
         {
-            Y_ABORT_UNLESS(!*row, "Cooked row hasn't been grabbed to TRow");
         }
 
         template<typename TVal>
@@ -25,7 +25,7 @@ namespace NTest {
             return *this;
         }
 
-        TRow operator *() noexcept
+        TRow&& operator *() noexcept
         {
             return std::move(row);
         }
@@ -39,7 +39,7 @@ namespace NTest {
         TSchemedCookRow(const TRowScheme &scheme, TPos skip = 0)
             : On(skip), Scheme(scheme) { }
 
-        inline TRow operator*() noexcept
+        inline TRow&& operator*() noexcept
         {
             return std::move(Row);
         }
@@ -47,7 +47,7 @@ namespace NTest {
         TSchemedCookRow& To(TPos to)
         {
             if (to < On || to >= Scheme.Cols.size()) {
-                Y_ABORT("TSchemedCookRow row builder skip position is out of range");
+                Y_TABLET_ERROR("TSchemedCookRow row builder skip position is out of range");
             }
 
             On = to;
@@ -58,7 +58,7 @@ namespace NTest {
         inline TSchemedCookRow& Col(const TVal &val, TArgs&&...args)
         {
             if (On >= Scheme.Cols.size()) {
-                Y_ABORT("NO more columns left in row scheme");
+                Y_TABLET_ERROR("NO more columns left in row scheme");
             } else {
                 Row.Do(Scheme.Cols[On++].Tag, val);
 

--- a/ydb/core/tablet_flat/test/libs/rows/heap.h
+++ b/ydb/core/tablet_flat/test/libs/rows/heap.h
@@ -64,7 +64,7 @@ namespace NTest {
 
         const TRow& operator[](size_t on) const
         {
-            Y_ABORT_UNLESS(on < Rows.size(), "Row index is out of hole scope");
+            Y_ENSURE(on < Rows.size(), "Row index is out of hole scope");
 
             return Rows[on];
         }

--- a/ydb/core/tablet_flat/test/libs/rows/layout.h
+++ b/ydb/core/tablet_flat/test/libs/rows/layout.h
@@ -5,6 +5,7 @@
 #include <ydb/core/tablet_flat/flat_row_remap.h>
 #include <ydb/core/tablet_flat/flat_table_column.h>
 #include <ydb/core/tablet_flat/flat_util_misc.h>
+#include <ydb/core/tablet_flat/util_fmt_abort.h>
 
 #include <util/generic/vector.h>
 
@@ -32,7 +33,7 @@ namespace NTest{
 
         TLayoutCook& Key(std::initializer_list<NTable::TTag> keys)
         {
-            Y_ABORT_UNLESS(!Scheme, "Keys are already assigned for layout cook");
+            Y_ENSURE(!Scheme, "Keys are already assigned for layout cook");
 
             TPos keyOrder = 0;
 
@@ -44,9 +45,9 @@ namespace NTest{
                 auto it = std::find_if(Cols.begin(), Cols.end(), pred);
 
                 if (it == Cols.end()) {
-                    Y_ABORT("Not all key tags found in columns registery");
+                    Y_TABLET_ERROR("Not all key tags found in columns registery");
                 } else if (it->KeyOrder != Max<NTable::TPos>()) {
-                    Y_ABORT("Non-unique key column tags supplied for layout");
+                    Y_TABLET_ERROR("Non-unique key column tags supplied for layout");
                 } else {
                     it->KeyOrder = keyOrder++;
                 }

--- a/ydb/core/tablet_flat/test/libs/rows/mass.h
+++ b/ydb/core/tablet_flat/test/libs/rows/mass.h
@@ -5,6 +5,7 @@
 
 #include <ydb/core/tablet_flat/flat_row_scheme.h>
 #include <ydb/core/tablet_flat/util_basics.h>
+#include <ydb/core/tablet_flat/util_fmt_abort.h>
 
 #include <util/random/mersenne.h>
 
@@ -67,7 +68,7 @@ namespace NTest {
             auto it = Model->Base(row);
 
             if (it > Saved.Size()) {
-                Y_ABORT("Last saved TMass row slot is out of store range");
+                Y_TABLET_ERROR("Last saved TMass row slot is out of store range");
             } else if (next) {
                 return it >= Saved.Size() ? nullptr : &Saved[it];
             } else if (hole) {

--- a/ydb/core/tablet_flat/test/libs/rows/rows.h
+++ b/ydb/core/tablet_flat/test/libs/rows/rows.h
@@ -93,7 +93,7 @@ namespace NTest {
 
         TRow& Do(NTable::TTag tag, ECellOp op)
         {
-            Y_ABORT_UNLESS(TCellOp::HaveNoPayload(op), "Allowed only payloadless ops");
+            Y_ENSURE(TCellOp::HaveNoPayload(op), "Allowed only payloadless ops");
 
             Cols.emplace_back(tag, 0, op);
 
@@ -176,7 +176,7 @@ namespace NTest {
                 Cols.back().Cell = { static_cast<const char*>(place), len };
             }
 
-            Y_ABORT_UNLESS(Cols.back().Cell.IsInline() == TCell::CanInline(len));
+            Y_ENSURE(Cols.back().Cell.IsInline() == TCell::CanInline(len));
 
             return *this;
         }

--- a/ydb/core/tablet_flat/test/libs/rows/tool.h
+++ b/ydb/core/tablet_flat/test/libs/rows/tool.h
@@ -69,7 +69,7 @@ namespace NTest {
                 TRawTypeValue raw(value.Cell.AsRef(), value.Type);
 
                 if (info->IsKey()) {
-                    Y_ABORT_UNLESS(value.Op == ECellOp::Set || value.Op == ECellOp::Null);
+                    Y_ENSURE(value.Op == ECellOp::Set || value.Op == ECellOp::Null);
 
                     if (info->Key >= Scheme.Keys->Size()) {
                         ythrow yexception()
@@ -85,7 +85,7 @@ namespace NTest {
                 }
             }
 
-            Y_ABORT_UNLESS(weak || foundKeyCols == Scheme.Keys->Size());
+            Y_ENSURE(weak || foundKeyCols == Scheme.Keys->Size());
 
             return pair;
         }

--- a/ydb/core/tablet_flat/test/libs/table/model/keys.h
+++ b/ydb/core/tablet_flat/test/libs/table/model/keys.h
@@ -2,6 +2,7 @@
 
 #include <ydb/core/tablet_flat/test/libs/rows/layout.h>
 #include <ydb/core/tablet_flat/test/libs/rows/mass.h>
+#include <ydb/core/tablet_flat/util_fmt_abort.h>
 
 #include <util/random/mersenne.h>
 #include <util/digest/city.h>
@@ -50,9 +51,9 @@ namespace NTest {
             auto *up = row.Get(NTable::TTag(8));
 
             if (up == nullptr || up->Type != NScheme::NTypeIds::Uint32) {
-                Y_ABORT("Probably got row not from the TMass instance");
+                Y_TABLET_ERROR("Probably got row not from the TMass instance");
             } else if (up->Cell.Size() != sizeof(ui32) || !up->Cell.Data()) {
-                Y_ABORT("Last saved tow reference TCell is invalid in TRow");
+                Y_TABLET_ERROR("Last saved tow reference TCell is invalid in TRow");
             } else {
                 return *reinterpret_cast<const ui32*>(up->Cell.Data());
             }

--- a/ydb/core/tablet_flat/test/libs/table/model/large.h
+++ b/ydb/core/tablet_flat/test/libs/table/model/large.h
@@ -3,6 +3,7 @@
 #include <ydb/core/tablet_flat/test/libs/rows/mass.h>
 #include <ydb/core/tablet_flat/test/libs/rows/cook.h>
 #include <ydb/core/tablet_flat/test/libs/rows/layout.h>
+#include <ydb/core/tablet_flat/util_fmt_abort.h>
 
 #include <util/random/mersenne.h>
 #include <array>
@@ -81,9 +82,9 @@ namespace NTest {
             auto *up = row.Get(NTable::TTag(2));
 
             if (up == nullptr || up->Type != NScheme::NTypeIds::Uint64) {
-                Y_ABORT("Probably got row not from the TMass instance");
+                Y_TABLET_ERROR("Probably got row not from the TMass instance");
             } else if (up->Cell.Size() != sizeof(ui64) || !up->Cell.Data()) {
-                Y_ABORT("Last saved tow reference TCell is invalid in TRow");
+                Y_TABLET_ERROR("Last saved tow reference TCell is invalid in TRow");
             } else {
                 return up->Cell.AsValue<ui64>();
             }
@@ -91,7 +92,7 @@ namespace NTest {
 
         void Check(TArrayRef<const ui64> rows) const override
         {
-            Y_ABORT_UNLESS(rows.size() == 1);
+            Y_ENSURE(rows.size() == 1);
 
             if (rows[0] != Sub[0]) {
                 throw

--- a/ydb/core/tablet_flat/test/libs/table/model/small.h
+++ b/ydb/core/tablet_flat/test/libs/table/model/small.h
@@ -2,6 +2,7 @@
 
 #include <ydb/core/tablet_flat/test/libs/rows/layout.h>
 #include <ydb/core/tablet_flat/test/libs/rows/mass.h>
+#include <ydb/core/tablet_flat/util_fmt_abort.h>
 
 #include <util/random/mersenne.h>
 
@@ -40,9 +41,9 @@ namespace NTest {
             auto *up = row.Get(NTable::TTag(1));
 
             if (up == nullptr || up->Type != NScheme::NTypeIds::Uint64) {
-                Y_ABORT("Probably got row not from the TMass instance");
+                Y_TABLET_ERROR("Probably got row not from the TMass instance");
             } else if (up->Cell.Size() != sizeof(ui64) || !up->Cell.Data()) {
-                Y_ABORT("Last saved tow reference TCell is invalid in TRow");
+                Y_TABLET_ERROR("Last saved tow reference TCell is invalid in TRow");
             } else {
                 return *reinterpret_cast<const ui64*>(up->Cell.Data());
             }

--- a/ydb/core/tablet_flat/test/libs/table/test_curtain.h
+++ b/ydb/core/tablet_flat/test/libs/table/test_curtain.h
@@ -30,7 +30,7 @@ namespace NTest {
 
         TRes Make(const TRowsHeap &heap, size_t offset, size_t len)
         {
-            Y_ABORT_UNLESS(offset < heap.Size(), "Hole offset is out of the heap");
+            Y_ENSURE(offset < heap.Size(), "Hole offset is out of the heap");
 
             const auto on = heap.begin() + offset;
 
@@ -71,9 +71,9 @@ namespace NTest {
             TRowId lastEnd = 0;
 
             for (const auto &hole : screen) {
-                Y_ABORT_UNLESS(lastEnd <= hole.Begin, "Screen is not sorted correctly");
-                Y_ABORT_UNLESS(first.Seek(hole.Begin) != EReady::Page);
-                Y_ABORT_UNLESS(last.Seek(hole.End) != EReady::Page);
+                Y_ENSURE(lastEnd <= hole.Begin, "Screen is not sorted correctly");
+                Y_ENSURE(first.Seek(hole.Begin) != EReady::Page);
+                Y_ENSURE(last.Seek(hole.End) != EReady::Page);
                 if (first.GetRowId() < last.GetRowId()) {
                     TArrayRef<const TCell> firstKey;
                     if (first.IsValid()) {

--- a/ydb/core/tablet_flat/test/libs/table/test_dummy.h
+++ b/ydb/core/tablet_flat/test/libs/table/test_dummy.h
@@ -2,6 +2,7 @@
 
 #include <ydb/core/tablet_flat/flat_part_iface.h>
 #include <ydb/core/tablet_flat/flat_table_misc.h>
+#include <ydb/core/tablet_flat/util_fmt_abort.h>
 
 namespace NKikimr {
 namespace NTable {
@@ -15,12 +16,12 @@ namespace NTable {
 
         TResult Locate(const TPart*, ui64, ELargeObj) override
         {
-            Y_ABORT("Dummy env cannot deal with storage");
+            Y_TABLET_ERROR("Dummy env cannot deal with storage");
         }
 
         const TSharedData* TryGetPage(const TPart*, TPageId, TGroupId) override
         {
-             Y_ABORT("Dummy env cannot deal with storage");
+             Y_TABLET_ERROR("Dummy env cannot deal with storage");
         }
     };
 

--- a/ydb/core/tablet_flat/test/libs/table/test_envs.h
+++ b/ydb/core/tablet_flat/test/libs/table/test_envs.h
@@ -89,7 +89,7 @@ namespace NTest {
         ~TFailEnv()
         {
             if (Touches == 0 || (Rate < 1. && Success == Touches)) {
-                Y_Fail("Fail env was touched " << Touches << " times w/o fails");
+                Y_ABORT_S("Fail env was touched " << Touches << " times w/o fails");
             }
         }
 
@@ -194,7 +194,7 @@ namespace NTest {
 
                 auto got = PageLoadingLogic->Get(this, pageId, type, lower);
 
-                Y_ABORT_UNLESS((Grow = got.Grow) || IndexFetch || GroupFetch || got.Page);
+                Y_ENSURE((Grow = got.Grow) || IndexFetch || GroupFetch || got.Page);
 
                 return { got.Need, got.Page };
             }
@@ -255,7 +255,7 @@ namespace NTest {
             auto* partStore = CheckedCast<const TPartStore*>(part);
 
             if ((lob != ELargeObj::Extern && lob != ELargeObj::Outer) || (ref >> 32)) {
-                Y_Fail("Invalid ref ELargeObj{" << int(lob) << ", " << ref << "}");
+                Y_TABLET_ERROR("Invalid ref ELargeObj{" << int(lob) << ", " << ref << "}");
             }
 
             const auto room = (lob == ELargeObj::Extern)
@@ -271,7 +271,7 @@ namespace NTest {
 
             auto* partStore = CheckedCast<const TPartStore*>(part);
 
-            Y_ABORT_UNLESS(groupId.Index < partStore->Store->GetGroupCount());
+            Y_ENSURE(groupId.Index < partStore->Store->GetGroupCount());
 
             auto type = partStore->GetPageType(pageId, groupId);
             if (groupId.IsMain() && IsIndexPage(type)) {
@@ -288,8 +288,8 @@ namespace NTest {
         {
             auto& partGroupQueues = PartGroupQueues[part];
 
-            Y_ABORT_UNLESS(queueIndex < partGroupQueues.size());
-            Y_ABORT_UNLESS(partGroupQueues[queueIndex]);
+            Y_ENSURE(queueIndex < partGroupQueues.size());
+            Y_ENSURE(partGroupQueues[queueIndex]);
 
             return *partGroupQueues[queueIndex];
         }
@@ -310,7 +310,7 @@ namespace NTest {
                     } else if (room == partStore->Store->GetExternRoom()) {
                         partGroupQueues.push_back(Settle(partStore, room, MakeExtern(partStore)));
                     } else {
-                        Y_ABORT("Don't know how to work with room %" PRIu32, room);
+                        Y_TABLET_ERROR("Don't know how to work with room " << room);
                     }
                 }
                 for (ui32 group : xrange(part->HistoricGroupsCount)) {
@@ -333,7 +333,7 @@ namespace NTest {
         THolder<NFwd::IPageLoadingLogic> MakeExtern(const TPartStore *part) const
         {
             if (auto &large = part->Large) {
-                Y_ABORT_UNLESS(part->Blobs, "Part has frames but not blobs");
+                Y_ENSURE(part->Blobs, "Part has frames but not blobs");
 
                 TVector<ui32> edges(large->Stats().Tags.size(), Edge);
 

--- a/ydb/core/tablet_flat/test/libs/table/test_iter.h
+++ b/ydb/core/tablet_flat/test/libs/table/test_iter.h
@@ -61,7 +61,7 @@ namespace NTest {
             auto *origin = std::exchange(Env, env).Release();
             auto *casted = dynamic_cast<TEnv*>(origin);
 
-            Y_ABORT_UNLESS(!origin || casted, "Cannot cast IPages to given env");
+            Y_ENSURE(!origin || casted, "Cannot cast IPages to given env");
 
             return casted;
         }
@@ -75,7 +75,7 @@ namespace NTest {
         TEnv* GetEnv() {
             auto *casted = dynamic_cast<TEnv*>(Env.Get());
 
-            Y_ABORT_UNLESS(!Env || casted, "Cannot cast IPages to given env");
+            Y_ENSURE(!Env || casted, "Cannot cast IPages to given env");
 
             return casted;
         }
@@ -222,7 +222,7 @@ namespace NTest {
 
         TChecker& Ver(TRowVersion rowVersion)
         {
-            Y_ABORT_UNLESS(Erased, "Working with versions needs Erased == true");
+            Y_ENSURE(Erased, "Working with versions needs Erased == true");
 
             for (Hoped = 0; Hoped < Retries; Hoped++) {
                 Ready = Wrap.SkipToRowVersion(rowVersion);

--- a/ydb/core/tablet_flat/test/libs/table/test_make.h
+++ b/ydb/core/tablet_flat/test/libs/table/test_make.h
@@ -8,6 +8,7 @@
 #include <ydb/core/tablet_flat/flat_mem_warm.h>
 #include <ydb/core/tablet_flat/flat_row_nulls.h>
 #include <ydb/core/tablet_flat/flat_table_subset.h>
+#include <ydb/core/tablet_flat/util_fmt_abort.h>
 
 #include <util/generic/xrange.h>
 
@@ -60,7 +61,7 @@ namespace NTest {
 
             void Ver(TRowVersion) override
             {
-                Y_ABORT("unsupported");
+                Y_TABLET_ERROR("unsupported");
             }
 
             TCooker Cooker;
@@ -127,7 +128,7 @@ namespace NTest {
                 if (auto *mem = dynamic_cast<TMem*>(one.Get())) {
                     auto table = mem->Cooker.Unwrap();
 
-                    Y_ABORT_UNLESS(table->GetRowCount(), "Got empty IBand");
+                    Y_ENSURE(table->GetRowCount(), "Got empty IBand");
 
                     subset->Frozen.emplace_back(std::move(table), table->Immediate());
                 } else if (auto *part_ = dynamic_cast<TPart*>(one.Get())) {
@@ -154,7 +155,7 @@ namespace NTest {
                     TOverlay{partView.Screen, partView.Slices}.Validate();
                     subset->Flatten.push_back(partView);
                 } else {
-                    Y_ABORT("Unknown IBand writer type, internal error");
+                    Y_TABLET_ERROR("Unknown IBand writer type, internal error");
                 }
             }
 

--- a/ydb/core/tablet_flat/test/libs/table/test_part.h
+++ b/ydb/core/tablet_flat/test/libs/table/test_part.h
@@ -98,7 +98,7 @@ namespace NTest {
             auto* partStore = CheckedCast<const TPartStore*>(part);
 
             if ((lob != ELargeObj::Extern && lob != ELargeObj::Outer) || (ref >> 32)) {
-                Y_Fail("Invalid ref ELargeObj{" << int(lob) << ", " << ref << "}");
+                Y_TABLET_ERROR("Invalid ref ELargeObj{" << int(lob) << ", " << ref << "}");
             }
 
             ui32 room = (lob == ELargeObj::Extern)
@@ -116,7 +116,7 @@ namespace NTest {
     private:
         const TSharedData* Get(const TPart *part, ui32 room, ui32 ref) const
         {
-            Y_ABORT_UNLESS(ref != Max<ui32>(), "Got invalid page reference");
+            Y_ENSURE(ref != Max<ui32>(), "Got invalid page reference");
 
             return CheckedCast<const TPartStore*>(part)->Store->GetPage(room, ref);
         }
@@ -130,7 +130,7 @@ namespace NTest {
 
         const TIntrusiveConstPtr<TPartStore>& Lone() const
         {
-            Y_ABORT_UNLESS(Parts.size() == 1, "Need egg with one part inside");
+            Y_ENSURE(Parts.size() == 1, "Need egg with one part inside");
 
             return Parts[0];
         }
@@ -159,9 +159,9 @@ namespace NTest {
             TTestEnv env;
             TPartGroupFlatIndexIter index(&part, &env, { });
 
-            Y_ABORT_UNLESS(index.Seek(0) == EReady::Data);
+            Y_ENSURE(index.Seek(0) == EReady::Data);
             for (TPageId p = 0; p < pageIndex; p++) {
-                Y_ABORT_UNLESS(index.Next() == EReady::Data);
+                Y_ENSURE(index.Next() == EReady::Data);
             }
 
             return index.GetRecord();
@@ -170,7 +170,7 @@ namespace NTest {
         inline const TPartGroupFlatIndexIter::TRecord * GetFlatLastRecord(const TPart& part) {
             TTestEnv env;
             TPartGroupFlatIndexIter index(&part, &env, { });
-            Y_ABORT_UNLESS(index.SeekLast() == EReady::Data);
+            Y_ENSURE(index.SeekLast() == EReady::Data);
             return index.GetLastRecord();
         }
 
@@ -182,7 +182,7 @@ namespace NTest {
             for (size_t i = 0; ; i++) {
                 auto ready = i == 0 ? index->Seek(0) : index->Next();
                 if (ready != EReady::Data) {
-                    Y_ABORT_UNLESS(ready != EReady::Page, "Unexpected page fault");
+                    Y_ENSURE(ready != EReady::Page, "Unexpected page fault");
                     break;
                 }
                 result++;
@@ -199,7 +199,7 @@ namespace NTest {
             for (size_t i = 0; ; i++) {
                 auto ready = i == 0 ? index->Seek(0) : index->Next();
                 if (ready != EReady::Data) {
-                    Y_ABORT_UNLESS(ready != EReady::Page, "Unexpected page fault");
+                    Y_ENSURE(ready != EReady::Page, "Unexpected page fault");
                     break;
                 }
                 result += part.GetPageSize(index->GetPageId(), groupId);
@@ -218,9 +218,9 @@ namespace NTest {
             TTestEnv env;
             auto index = CreateIndexIter(&part, &env, { });
 
-            Y_ABORT_UNLESS(index->Seek(0) == EReady::Data);
+            Y_ENSURE(index->Seek(0) == EReady::Data);
             for (TPageId p = 0; p < pageIndex; p++) {
-                Y_ABORT_UNLESS(index->Next() == EReady::Data);
+                Y_ENSURE(index->Next() == EReady::Data);
             }
 
             return index->GetPageId();
@@ -230,9 +230,9 @@ namespace NTest {
             TTestEnv env;
             auto index = CreateIndexIter(&part, &env, { });
 
-            Y_ABORT_UNLESS(index->Seek(0) == EReady::Data);
+            Y_ENSURE(index->Seek(0) == EReady::Data);
             for (TPageId p = 0; p < pageIndex; p++) {
-                Y_ABORT_UNLESS(index->Next() == EReady::Data);
+                Y_ENSURE(index->Next() == EReady::Data);
             }
 
             return index->GetRowId();
@@ -256,9 +256,9 @@ namespace NTest {
             TTestEnv env;
             auto index = CreateIndexIter(&part, &env, { });
 
-            Y_ABORT_UNLESS(index->Seek(0) == EReady::Data);
+            Y_ENSURE(index->Seek(0) == EReady::Data);
             for (TPageId p = 0; p < pageIndex; p++) {
-                Y_ABORT_UNLESS(index->Next() == EReady::Data);
+                Y_ENSURE(index->Next() == EReady::Data);
             }
 
             TVector<TCell> key;
@@ -271,8 +271,8 @@ namespace NTest {
 
         inline TSlice MakeSlice(const TPartStore& part, ui32 pageIndex1Inclusive, ui32 pageIndex2Exclusive) {
             auto mainPagesCount = CountMainPages(part);
-            Y_ABORT_UNLESS(pageIndex1Inclusive < pageIndex2Exclusive);
-            Y_ABORT_UNLESS(pageIndex2Exclusive <= mainPagesCount);
+            Y_ENSURE(pageIndex1Inclusive < pageIndex2Exclusive);
+            Y_ENSURE(pageIndex2Exclusive <= mainPagesCount);
             
             TSlice slice;
             slice.FirstInclusive = pageIndex1Inclusive > 0

--- a/ydb/core/tablet_flat/test/libs/table/test_steps.h
+++ b/ydb/core/tablet_flat/test/libs/table/test_steps.h
@@ -1,6 +1,7 @@
 #pragma once
 
-#include "util/string/builder.h"
+#include <util/generic/yexception.h>
+#include <util/string/builder.h>
 #include <util/system/yassert.h>
 #include <util/stream/output.h>
 
@@ -13,7 +14,7 @@ namespace NTest {
     public:
         TImpl& To(size_t seq)
         {
-            Y_ABORT_UNLESS(seq >= Seq, "Invalid sequence flow");
+            Y_ENSURE(seq >= Seq, "Invalid sequence flow");
 
             Seq = seq;
 

--- a/ydb/core/tablet_flat/test/libs/table/test_store.h
+++ b/ydb/core/tablet_flat/test/libs/table/test_store.h
@@ -6,6 +6,7 @@
 #include <ydb/core/tablet_flat/flat_sausage_misc.h>
 #include <ydb/core/tablet_flat/flat_util_binary.h>
 #include <ydb/core/tablet_flat/util_deref.h>
+#include <ydb/core/tablet_flat/util_fmt_abort.h>
 
 #include <util/generic/xrange.h>
 #include <array>
@@ -55,7 +56,7 @@ namespace NTest {
 
         const TSharedData* GetPage(ui32 room, ui32 page) const
         {
-            Y_ABORT_UNLESS(room < PageCollections.size(), "Room is out of bounds");
+            Y_ENSURE(room < PageCollections.size(), "Room is out of bounds");
 
             if (page == Max<TPageId>()) return nullptr;
 
@@ -64,21 +65,21 @@ namespace NTest {
 
         size_t GetPageSize(ui32 room, ui32 page) const
         {
-            Y_ABORT_UNLESS(room < PageCollections.size(), "Room is out of bounds");
+            Y_ENSURE(room < PageCollections.size(), "Room is out of bounds");
 
             return PageCollections.at(room).at(page).size();
         }
 
         NPage::EPage GetPageType(ui32 room, ui32 page) const
         {
-            Y_ABORT_UNLESS(room < PageCollections.size(), "Room is out of bounds");
+            Y_ENSURE(room < PageCollections.size(), "Room is out of bounds");
 
             return PageTypes.at(room).at(page);
         }
 
         TArrayRef<const TSharedData> PageCollectionArray(ui32 room) const
         {
-            Y_ABORT_UNLESS(room < PageCollections.size(), "Only regular rooms can be used as arr");
+            Y_ENSURE(room < PageCollections.size(), "Only regular rooms can be used as arr");
 
             return PageCollections[room];
         }
@@ -122,13 +123,13 @@ namespace NTest {
         TEggs LegacyEggs() const
         {
             if (PageCollectionPagesCount(MainPageCollection) == 0) {
-                Y_ABORT("Cannot construct an empty part");
+                Y_TABLET_ERROR("Cannot construct an empty part");
             }
 
-            Y_ABORT_UNLESS(!Rooted, "Legacy store must not be rooted");
-            Y_ABORT_UNLESS(Groups == 1, "Legacy store must have a single main group");
-            Y_ABORT_UNLESS(Indexes.size() == 1, "Legacy store must have a single index");
-            Y_ABORT_UNLESS(Scheme != Max<TPageId>(), "Legacy store is missing a scheme page");
+            Y_ENSURE(!Rooted, "Legacy store must not be rooted");
+            Y_ENSURE(Groups == 1, "Legacy store must have a single main group");
+            Y_ENSURE(Indexes.size() == 1, "Legacy store must have a single index");
+            Y_ENSURE(Scheme != Max<TPageId>(), "Legacy store is missing a scheme page");
 
             return {
                 Rooted,
@@ -151,11 +152,11 @@ namespace NTest {
             NUtil::NBin::TOut out(stream);
 
             if (Groups > 1) {
-                Y_ABORT("Cannot dump TStore with multiple column groups");
+                Y_TABLET_ERROR("Cannot dump TStore with multiple column groups");
             } else if (!PageCollections[MainPageCollection]) {
-                Y_ABORT("Cannot dump TStore with empty leader page collection");
+                Y_TABLET_ERROR("Cannot dump TStore with empty leader page collection");
             } else if (PageCollections[GetOuterRoom()] || PageCollections[GetExternRoom()]) {
-                Y_ABORT("TStore has auxillary rooms, cannot be dumped");
+                Y_TABLET_ERROR("TStore has auxillary rooms, cannot be dumped");
             }
 
             /* Dump pages as is, without any special markup as it already
@@ -166,7 +167,7 @@ namespace NTest {
             for (auto it: xrange(pages.size())) {
                 auto got = NPage::TLabelWrapper().Read(pages[it], EPage::Undef);
 
-                Y_ABORT_UNLESS(got.Page.end() == pages[it].end());
+                Y_ENSURE(got.Page.end() == pages[it].end());
 
                 out.Put(pages[it]);
             }
@@ -178,7 +179,7 @@ namespace NTest {
             NPage::TLabel label;
 
             while (auto got = in.Load(&label, sizeof(label))) {
-                Y_ABORT_UNLESS(got == sizeof(label), "Invalid pages stream");
+                Y_ENSURE(got == sizeof(label), "Invalid pages stream");
 
                 TSharedData to = TSharedData::Uninitialized(label.Size);
 
@@ -189,7 +190,7 @@ namespace NTest {
                 got = in.Load(begin,  to.mutable_end() - begin);
 
                 if (got + sizeof(NPage::TLabel) != label.Size) {
-                    Y_ABORT("Stausage loading stalled in middle of page");
+                    Y_TABLET_ERROR("Stausage loading stalled in middle of page");
                 } else if (label.Type == EPage::Scheme) {
                     /* Required for Read(Evolution < 16), hack for old style
                         scheme pages without leading label. It was ecoded in
@@ -208,7 +209,7 @@ namespace NTest {
 
         TPageId WriteOuter(TSharedData page)
         {
-            Y_ABORT_UNLESS(!Finished, "This store is already finished");
+            Y_ENSURE(!Finished, "This store is already finished");
 
             auto room = GetOuterRoom();
             TPageId pageId = PageCollections[room].size();
@@ -221,8 +222,8 @@ namespace NTest {
 
         TPageId Write(TSharedData page, EPage type, ui32 group)
         {
-            Y_ABORT_UNLESS(group < PageCollections.size() - 1, "Invalid column group");
-            Y_ABORT_UNLESS(!Finished, "This store is already finished");
+            Y_ENSURE(group < PageCollections.size() - 1, "Invalid column group");
+            Y_ENSURE(!Finished, "This store is already finished");
             NPageCollection::Checksum(page); /* will catch uninitialized values */
 
             if (type == EPage::DataPage) {
@@ -261,14 +262,14 @@ namespace NTest {
 
         void WriteInplace(TPageId page, TArrayRef<const char> body)
         {
-            Y_ABORT_UNLESS(page == Scheme);
+            Y_ENSURE(page == Scheme);
 
             Meta = TSharedData::Copy(body.data(), body.size());
         }
 
         NPageCollection::TGlobId WriteLarge(TSharedData data)
         {
-            Y_ABORT_UNLESS(!Finished, "This store is already finished");
+            Y_ENSURE(!Finished, "This store is already finished");
 
             auto room = GetExternRoom();
             TPageId pageId = PageCollections[room].size();
@@ -281,7 +282,7 @@ namespace NTest {
 
         void Finish()
         {
-            Y_ABORT_UNLESS(!Finished, "Cannot finish test store more than once");
+            Y_ENSURE(!Finished, "Cannot finish test store more than once");
             Finished = true;
         }
 

--- a/ydb/core/tablet_flat/test/libs/table/test_wreck.h
+++ b/ydb/core/tablet_flat/test/libs/table/test_wreck.h
@@ -48,7 +48,7 @@ namespace NTest {
                 DoPointReads(wrap), DoRangedScans(wrap, make, true);
 
             } else if (cache == EWreck::Forward) {
-                Y_ABORT_UNLESS(Direction == EDirection::Forward, "ForwardEnv may only be used with forward iteration");
+                Y_ENSURE(Direction == EDirection::Forward, "ForwardEnv may only be used with forward iteration");
 
                 TWrap wrap(eggs, { nullptr, 10 /* worst case: main, next, groups, blobs, plus b-tree index */, false }, std::forward<TArgs>(args)...);
 

--- a/ydb/core/tablet_flat/test/libs/table/wrap_dbase.h
+++ b/ydb/core/tablet_flat/test/libs/table/wrap_dbase.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <ydb/core/tablet_flat/flat_database.h>
+#include <ydb/core/tablet_flat/util_fmt_abort.h>
 
 namespace NKikimr {
 namespace NTable {
@@ -45,8 +46,9 @@ namespace NTest {
 
         EReady Seek(TRawVals key, ESeek seek)
         {
-            if (seek == ESeek::Upper && !key)
-                Y_ABORT("Cannot cast ESeek::Upper with empty key to ELookup");
+            if (seek == ESeek::Upper && !key) {
+                Y_TABLET_ERROR("Cannot cast ESeek::Upper with empty key to ELookup");
+            }
 
             TKeyRange range;
             range.MinKey = key;

--- a/ydb/core/tablet_flat/test/libs/table/wrap_iter.h
+++ b/ydb/core/tablet_flat/test/libs/table/wrap_iter.h
@@ -25,8 +25,8 @@ namespace NTest {
             TVector<const TPartView*> parts;
             parts.reserve(Flatten.size());
             for (auto &partView: Flatten) {
-                Y_ABORT_UNLESS(partView.Part, "Creating TWrapIter without a part");
-                Y_ABORT_UNLESS(partView.Slices, "Creating TWrapIter without slices");
+                Y_ENSURE(partView.Part, "Creating TWrapIter without a part");
+                Y_ENSURE(partView.Slices, "Creating TWrapIter without slices");
                 TOverlay{partView.Screen, partView.Slices}.Validate();
                 parts.push_back(&partView);
             }

--- a/ydb/core/tablet_flat/test/libs/table/wrap_part.h
+++ b/ydb/core/tablet_flat/test/libs/table/wrap_part.h
@@ -50,7 +50,7 @@ namespace NTest {
         {
             for (const auto &slice : slices) {
                 auto got = Run.FindInsertHint(part.Get(), slice);
-                Y_ABORT_UNLESS(got.second, "Unexpected slices intersection");
+                Y_ENSURE(got.second, "Unexpected slices intersection");
                 Run.Insert(got.first, part, slice);
             }
         }
@@ -96,7 +96,7 @@ namespace NTest {
             if (Ready == EReady::Data)
                 Ready = RollUp();
 
-            Y_ABORT_UNLESS(Ready != EReady::Data || Iter->IsValid());
+            Y_ENSURE(Ready != EReady::Data || Iter->IsValid());
 
             return Ready;
         }
@@ -110,14 +110,14 @@ namespace NTest {
             if (Ready == EReady::Data)
                 Ready = RollUp();
 
-            Y_ABORT_UNLESS(Ready != EReady::Data || Iter->IsValid());
+            Y_ENSURE(Ready != EReady::Data || Iter->IsValid());
 
             return Ready;
         }
 
         TRowVersion GetRowVersion() const
         {
-            Y_ABORT_UNLESS(Ready == EReady::Data);
+            Y_ENSURE(Ready == EReady::Data);
 
             return Iter->GetRowVersion();
         }
@@ -133,14 +133,14 @@ namespace NTest {
             } else if (EReady::Data == (Ready = DoIterNext()))
                 Ready = RollUp();
 
-            Y_ABORT_UNLESS(Ready != EReady::Data || Iter->IsValid());
+            Y_ENSURE(Ready != EReady::Data || Iter->IsValid());
 
             return Ready;
         }
 
         const TRowState& Apply()
         {
-            Y_ABORT_UNLESS(Ready == EReady::Data, "Row state isn't ready");
+            Y_ENSURE(Ready == EReady::Data, "Row state isn't ready");
 
             return State;
         }

--- a/ydb/core/tablet_flat/test/libs/table/wrap_select.h
+++ b/ydb/core/tablet_flat/test/libs/table/wrap_select.h
@@ -44,7 +44,7 @@ namespace NTest {
 
         EReady Seek(TRawVals key, ESeek seek)
         {
-            Y_ABORT_UNLESS(seek == ESeek::Exact, "Db Select(...) is a point lookup");
+            Y_ENSURE(seek == ESeek::Exact, "Db Select(...) is a point lookup");
 
             ITransactionMapPtr txMap;
             if (ReadTxId != 0 && Base.HasOpenTx(Table, ReadTxId)) {

--- a/ydb/core/tablet_flat/test/libs/table/wrap_warm.h
+++ b/ydb/core/tablet_flat/test/libs/table/wrap_warm.h
@@ -63,7 +63,7 @@ namespace NTest {
 
         const TRowState& Apply()
         {
-            Y_ABORT_UNLESS(*this, "Iterator isn't ready");
+            Y_ENSURE(*this, "Iterator isn't ready");
 
             return State;
         }

--- a/ydb/core/tablet_flat/test/tool/perf/do_iter.h
+++ b/ydb/core/tablet_flat/test/tool/perf/do_iter.h
@@ -43,7 +43,7 @@ namespace NPerf {
             Iter.Make(&Env);
             auto ready = Iter.Seek(key, seek);
 
-            Y_ABORT_UNLESS(ready != EReady::Page);
+            Y_ENSURE(ready != EReady::Page);
         }
 
         ui64 Scan(ui64 items, TSponge &aggr) override

--- a/ydb/core/tablet_flat/test/tool/perf/names.h
+++ b/ydb/core/tablet_flat/test/tool/perf/names.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "defs.h"
+#include <ydb/core/tablet_flat/util_fmt_abort.h>
 #include <ydb/core/tablet_flat/util_fmt_desc.h>
 #include <util/system/yassert.h>
 
@@ -23,7 +24,7 @@ namespace NFmt {
             if (sponge == ESponge::Fnv)   return "fnv";
             if (sponge == ESponge::Xor)   return "xor";
 
-            Y_ABORT("Unreachable code");
+            Y_TABLET_ERROR("Unreachable code");
         }
     };
 }

--- a/ydb/core/tablet_flat/test/tool/surg/main.cpp
+++ b/ydb/core/tablet_flat/test/tool/surg/main.cpp
@@ -210,7 +210,7 @@ namespace NTest {
         for (auto& bundle : part.GetBundles()) {
             Cerr << " | + bundle";
             for (auto& pageCollection : bundle.GetPageCollections()) {
-                Y_ABORT_UNLESS(pageCollection.HasLargeGlobId(), "Found a page collection without a largeGlobId");
+                Y_ENSURE(pageCollection.HasLargeGlobId(), "Found a page collection without a largeGlobId");
                 Cerr << " " << LogoBlobIDFromLogoBlobID(pageCollection.GetLargeGlobId().GetLead());
             }
             if (bundle.HasEpoch()) {

--- a/ydb/core/tablet_flat/ut/flat_comp_ut_common.h
+++ b/ydb/core/tablet_flat/ut/flat_comp_ut_common.h
@@ -34,7 +34,7 @@ public:
         const auto scn = DB.Head().Serial + 1;
         TTxStamp txStamp(Gen, ++Step);
         DB.SnapshotToLog(table, txStamp);
-        Y_ABORT_UNLESS(scn == DB.Head().Serial);
+        Y_ENSURE(scn == DB.Head().Serial);
         auto chg = DB.Head(table);
         return { txStamp, chg.Epoch };
     }
@@ -53,7 +53,7 @@ public:
 
     const TScheme::TTableInfo* TableScheme(ui32 table) override {
         auto* info = DB.GetScheme().GetTableInfo(table);
-        Y_ABORT_UNLESS(info, "Unexpected table");
+        Y_ENSURE(info, "Unexpected table");
         return info;
     }
 
@@ -63,7 +63,7 @@ public:
 
     TPartView TablePart(ui32 table, const TLogoBlobID& label) override {
         auto partView = DB.GetPartView(table, label);
-        Y_ABORT_UNLESS(partView, "Unexpected part %s", label.ToString().c_str());
+        Y_ENSURE(partView, "Unexpected part " << label);
         return partView;
     }
 
@@ -80,7 +80,7 @@ public:
     }
 
     ui64 BeginCompaction(THolder<TCompactionParams> params) override {
-        Y_ABORT_UNLESS(params);
+        Y_ENSURE(params);
         ui64 compactionId = NextCompactionId_++;
         StartedCompactions[compactionId] = std::move(params);
         return compactionId;
@@ -91,7 +91,7 @@ public:
     }
 
     void RequestChanges(ui32 table) override {
-        Y_ABORT_UNLESS(table == 1, "Unexpected table");
+        Y_ENSURE(table == 1, "Unexpected table");
         ChangesRequested_ = true;
     }
 
@@ -106,14 +106,14 @@ public:
     };
 
     TRunCompactionResult RunCompaction() {
-        Y_ABORT_UNLESS(StartedCompactions, "There are no started compactions");
+        Y_ENSURE(StartedCompactions, "There are no started compactions");
         ui64 compactionId = StartedCompactions.begin()->first;
         return RunCompaction(compactionId);
     }
 
     TRunCompactionResult RunCompaction(ui64 compactionId) {
         auto it = StartedCompactions.find(compactionId);
-        Y_ABORT_UNLESS(it != StartedCompactions.end());
+        Y_ENSURE(it != StartedCompactions.end());
         auto params = std::move(it->second);
         StartedCompactions.erase(it);
         auto result = RunCompaction(params.Get());
@@ -131,9 +131,9 @@ public:
         }
 
         // Note: we don't compact TxStatus in these tests
-        Y_ABORT_UNLESS(subset->TxStatus.empty());
+        Y_ENSURE(subset->TxStatus.empty());
 
-        Y_ABORT_UNLESS(!*subset || subset->IsStickedToHead());
+        Y_ENSURE(!*subset || subset->IsStickedToHead());
 
         const auto& scheme = DB.GetScheme();
         auto* family = scheme.DefaultFamilyFor(params->Table);
@@ -163,7 +163,7 @@ public:
         TVector<TPartView> parts(Reserve(eggs.Parts.size()));
         for (auto& part : eggs.Parts) {
             parts.push_back({ part, nullptr, part->Slices });
-            Y_ABORT_UNLESS(parts.back());
+            Y_ENSURE(parts.back());
         }
 
         DB.Replace(params->Table, *subset, parts, { });
@@ -183,7 +183,7 @@ public:
 
         for (auto& change : changes.SliceChanges) {
             auto partView = DB.GetPartView(table, change.Label);
-            Y_ABORT_UNLESS(partView, "Cannot find part %s", change.Label.ToString().c_str());
+            Y_ENSURE(partView, "Cannot find part " << change.Label);
             auto replaced = TSlices::Replace(partView.Slices, change.NewSlices);
             DB.ReplaceSlices(table, {{ change.Label, std::move(replaced) }});
         }

--- a/ydb/core/tablet_flat/ut/flat_test_db.h
+++ b/ydb/core/tablet_flat/ut/flat_test_db.h
@@ -4,6 +4,7 @@
 #include <ydb/core/tablet_flat/flat_database.h>
 #include <ydb/core/tablet_flat/flat_dbase_scheme.h>
 #include <ydb/core/tablet_flat/flat_update_op.h>
+#include <ydb/core/tablet_flat/util_fmt_abort.h>
 
 #include <library/cpp/testing/unittest/registar.h>
 
@@ -108,7 +109,7 @@ public:
 
     void Init(const TScheme& scheme) override {
         Y_UNUSED(scheme);
-        Y_ABORT_UNLESS("Not supported by flat db wrapper");
+        Y_ENSURE("Not supported by flat db wrapper");
     }
 
     const TScheme& GetScheme() const override {
@@ -117,7 +118,7 @@ public:
 
     TString FinishTransaction(bool commit) override {
         Y_UNUSED(commit);
-        Y_ABORT_UNLESS("Not supported by flat db wrapper");
+        Y_ENSURE("Not supported by flat db wrapper");
         return "42";
     }
 
@@ -344,9 +345,9 @@ private:
         const auto num = one.ColumnCount;
 
         if (num != two.ColumnCount) {
-            Y_ABORT("Got different key columns count");
+            Y_TABLET_ERROR("Got different key columns count");
         } else if (!std::equal(one.Types, one.Types + num, two.Types)) {
-            Y_ABORT("TDbTupleRef rows types vec are not the same");
+            Y_TABLET_ERROR("TDbTupleRef rows types vec are not the same");
         } else {
             return CompareTypedCellVectors(one.Columns, two.Columns, one.Types, num);
         }

--- a/ydb/core/tablet_flat/ut/flat_test_db_helpers.h
+++ b/ydb/core/tablet_flat/ut/flat_test_db_helpers.h
@@ -141,11 +141,11 @@ public:
     template<typename T>
     TDbRowUpdate& Set(TString tagName, const T& val) {
         const TScheme::TTableInfo* tableInfo = Scheme.GetTableInfo(GetRoot());
-        Y_ABORT_UNLESS(tableInfo, "Unknown table id %u", GetRoot());
+        Y_ENSURE(tableInfo, "Unknown table id " << GetRoot());
         const ui32* tagId = tableInfo->ColumnNames.FindPtr(tagName);
-        Y_ABORT_UNLESS(tagId, "Unknown column \"%s\" in table %u", tagName.data(), GetRoot());
+        Y_ENSURE(tagId, "Unknown column \"" << tagName << "\" in table " << GetRoot());
         const auto *colInfo = Scheme.GetColumnInfo(GetRoot(), *tagId);
-        Y_ABORT_UNLESS(colInfo, "Column info not found for table id %u, column id %u", GetRoot(), *tagId);
+        Y_ENSURE(colInfo, "Column info not found for table id " << GetRoot() << " column id " << *tagId);
         NScheme::TTypeId type = colInfo->PType.GetTypeId();
         TagOps[*tagId] = FromVal(type, val);
         return *this;
@@ -153,11 +153,11 @@ public:
 
     TDbRowUpdate& Erase(TString tagName) {
         const TScheme::TTableInfo* tableInfo = Scheme.GetTableInfo(GetRoot());
-        Y_ABORT_UNLESS(tableInfo, "Unknown table id %u", GetRoot());
+        Y_ENSURE(tableInfo, "Unknown table id " << GetRoot());
         const ui32* tagId = tableInfo->ColumnNames.FindPtr(tagName);
-        Y_ABORT_UNLESS(tagId, "Unknown column \"%s\" in table %u", tagName.data(), GetRoot());
+        Y_ENSURE(tagId, "Unknown column \"" << tagName << "\" in table " << GetRoot());
         const auto * colInfo = Scheme.GetColumnInfo(GetRoot(), *tagId);
-        Y_ABORT_UNLESS(colInfo, "Column info not found for table id %u, column id %u", GetRoot(), *tagId);
+        Y_ENSURE(colInfo, "Column info not found for table id " << GetRoot() << " column id " << *tagId);
         TagOps[*tagId] = MakeNull(ECellOp::Null);
         return *this;
     }
@@ -217,7 +217,7 @@ public:
 
     void Apply(const TDbRowUpdate& update) {
         TVector<TRawTypeValue> key;
-        Y_ABORT_UNLESS(!update.GetKey().empty());
+        Y_ENSURE(!update.GetKey().empty());
         for (const auto& col : update.GetKey()) {
             key.push_back(col.Get());
         }
@@ -232,7 +232,7 @@ public:
 
     void Apply(const TDbRowErase& erase) {
         TVector<TRawTypeValue> key;
-        Y_ABORT_UNLESS(!erase.GetKey().empty());
+        Y_ENSURE(!erase.GetKey().empty());
         for (const auto& col : erase.GetKey()) {
             key.push_back(col.Get());
         }

--- a/ydb/core/tablet_flat/ut/ut_btree_index_iter_charge.cpp
+++ b/ydb/core/tablet_flat/ut/ut_btree_index_iter_charge.cpp
@@ -6,6 +6,7 @@
 #include "test/libs/table/test_writer.h"
 #include "test/libs/table/wrap_part.h"
 #include <ydb/core/tablet_flat/test/libs/rows/layout.h>
+#include <ydb/core/tablet_flat/util_fmt_abort.h>
 #include <library/cpp/testing/unittest/registar.h>
 
 namespace NKikimr::NTable::NPage {
@@ -116,7 +117,7 @@ namespace {
             conf.Group(0).BTreeIndexNodeKeysMin = conf.Group(0).BTreeIndexNodeKeysMax = 2;
             break;
         default:
-            Y_Fail("Unknown levels");
+            Y_TABLET_ERROR("Unknown levels");
         }
 
         if (params.Groups) {

--- a/ydb/core/tablet_flat/ut/ut_charge.cpp
+++ b/ydb/core/tablet_flat/ut/ut_charge.cpp
@@ -185,7 +185,7 @@ namespace {
 
         void CheckPrechargeByKeys(ui32 lower, ui32 upper, ui64 items, TPageIdFlags flags, const TMap<TGroupId, TArr>& shouldPrecharge, bool reverse, TSet<std::pair<TGroupId, TPageId>> sticky) const
         {
-            Y_ABORT_UNLESS(lower < Mass.Saved.Size() && upper < Mass.Saved.Size());
+            Y_ENSURE(lower < Mass.Saved.Size() && upper < Mass.Saved.Size());
 
             bool fail(flags & TPageIdFlags::IfFail);
             TTouchEnv env(fail, sticky);
@@ -244,7 +244,7 @@ namespace {
 
         void CheckIterByKeys(ui32 lower, ui32 upper, ui64 items, const TMap<TGroupId, TArr>& precharged) const
         {
-            Y_ABORT_UNLESS(lower < Mass.Saved.Size() && upper < Mass.Saved.Size());
+            Y_ENSURE(lower < Mass.Saved.Size() && upper < Mass.Saved.Size());
 
             auto sticky = GetIndexPages();
             NTest::TCheckIter wrap(Eggs, { new TTouchEnv(false, sticky) });
@@ -280,7 +280,7 @@ namespace {
 
         void CheckIterByKeysReverse(ui32 lower, ui32 upper, ui64 items, const TMap<TGroupId, TArr>& precharged) const
         {
-            Y_ABORT_UNLESS(lower < Mass.Saved.Size() && upper < Mass.Saved.Size());
+            Y_ENSURE(lower < Mass.Saved.Size() && upper < Mass.Saved.Size());
 
             auto sticky = GetIndexPages();
             NTest::TCheckReverseIter wrap(Eggs, { new TTouchEnv(false, sticky) });
@@ -355,7 +355,7 @@ namespace {
                 for (size_t i = 0; ; i++) {
                     auto ready = i == 0 ? groupIndex->Seek(0) : groupIndex->Next();
                     if (ready != EReady::Data) {
-                        Y_ABORT_UNLESS(ready != EReady::Page);
+                        Y_ENSURE(ready != EReady::Page);
                         break;
                     }
                     absoluteId[absoluteId.size()] = groupIndex->GetPageId();

--- a/ydb/core/tablet_flat/ut/ut_compaction_multi.cpp
+++ b/ydb/core/tablet_flat/ut/ut_compaction_multi.cpp
@@ -57,7 +57,7 @@ Y_UNIT_TEST_SUITE(TCompactionMulti) {
             // Verify the last page contains a single row
             TTestEnv env;
             auto iter = CreateIndexIter(initialPart, &env, { });
-            Y_ABORT_UNLESS(iter->SeekLast() == EReady::Data, "Unexpected failure to find the last index page");
+            Y_ENSURE(iter->SeekLast() == EReady::Data, "Unexpected failure to find the last index page");
             auto count = iter->GetEndRowId() - iter->GetRowId();
             UNIT_ASSERT_C(count == 1, "Unexpected " << count << " rows on the last page");
         }

--- a/ydb/core/tablet_flat/ut/ut_forward.cpp
+++ b/ydb/core/tablet_flat/ut/ut_forward.cpp
@@ -150,7 +150,7 @@ namespace {
 
         ui64 AddToQueue(TPageId pageId, EPage type) override
         {
-            Y_ABORT_UNLESS(type == Part->GetPageType(pageId, { }));
+            Y_ENSURE(type == Part->GetPageType(pageId, { }));
 
             Queue.push_back(pageId);
 

--- a/ydb/core/tablet_flat/ut/ut_part.cpp
+++ b/ydb/core/tablet_flat/ut/ut_part.cpp
@@ -64,7 +64,7 @@ namespace {
                 Precharged[groupId].insert(pageId);
                 return NTest::TTestEnv::TryGetPage(part, pageId, groupId);
             } else {
-                Y_VERIFY_S(Precharged[groupId].count(pageId), "Requested page " << pageId << " should be precharged");
+                Y_ENSURE(Precharged[groupId].count(pageId), "Requested page " << pageId << " should be precharged");
                 return NTest::TTestEnv::TryGetPage(part, pageId, groupId);
             }
         }
@@ -664,7 +664,7 @@ Y_UNIT_TEST_SUITE(TPart) {
 
         TSubset subset(TEpoch::Zero(), cooked.Scheme);
         for (const auto &part : cooked.Parts) {
-            Y_ABORT_UNLESS(part->Slices, "Missing part slices");
+            Y_ENSURE(part->Slices, "Missing part slices");
             subset.Flatten.push_back({ part, nullptr, part->Slices });
         }
         for (int i = 1; i <= 1000; ++i) {

--- a/ydb/core/tablet_flat/ut/ut_screen.cpp
+++ b/ydb/core/tablet_flat/ut/ut_screen.cpp
@@ -6,6 +6,7 @@
 #include <ydb/core/tablet_flat/test/libs/table/test_writer.h>
 #include <ydb/core/tablet_flat/test/libs/table/test_curtain.h>
 #include <ydb/core/tablet_flat/test/libs/table/test_envs.h>
+#include <ydb/core/tablet_flat/util_fmt_abort.h>
 
 #include <library/cpp/testing/unittest/registar.h>
 
@@ -96,7 +97,7 @@ Y_UNIT_TEST_SUITE(TScreen) {
 
             auto cu0 = cook.Make(Mass0().Saved, 3, (7 + (len >> 1) - 3) >> 1);
             auto cu = cook.Make(Mass0().Saved, 7 + (len >> 1), 13 + len);
-            Y_ABORT_UNLESS(cu0.End != cu.Begin);
+            Y_ENSURE(cu0.End != cu.Begin);
 
             for (int joined = 0; joined < 2; ++joined) {
                 auto screen = joined ? TScreen::Join(cu0.Screen, cu.Screen) : cu.Screen;
@@ -166,7 +167,7 @@ Y_UNIT_TEST_SUITE(TScreen) {
                     iter.Seek(*it, ESeek::Lower).Is(EReady::Gone);
                     iter.Seek(*it, ESeek::Upper).Is(EReady::Gone);
                 } else {
-                    Y_ABORT("Got AnyOff row within the range");
+                    Y_TABLET_ERROR("Got AnyOff row within the range");
                 }
             }
         }

--- a/ydb/core/tablet_flat/ut/ut_slice_loader.cpp
+++ b/ydb/core/tablet_flat/ut/ut_slice_loader.cpp
@@ -9,6 +9,7 @@
 #include <ydb/core/tablet_flat/flat_part_keys.h>
 #include <ydb/core/tablet_flat/flat_sausage_gut.h>
 #include <ydb/core/tablet_flat/flat_store_hotdog.h>
+#include <ydb/core/tablet_flat/util_fmt_abort.h>
 #include <ydb/core/tablet_flat/util_fmt_desc.h>
 #include <ydb/core/tablet_flat/util_basics.h>
 
@@ -87,17 +88,17 @@ namespace {
 
         NPageCollection::TBorder Bounds(ui32) const override
         {
-            Y_ABORT("Unexpected Bounds(...) call");
+            Y_TABLET_ERROR("Unexpected Bounds(...) call");
         }
 
         NPageCollection::TGlobId Glob(ui32) const override
         {
-            Y_ABORT("Unexpected Glob(...) call");
+            Y_TABLET_ERROR("Unexpected Glob(...) call");
         }
 
         bool Verify(ui32, TArrayRef<const char>) const override
         {
-            Y_ABORT("Unexpected Verify(...) call");
+            Y_TABLET_ERROR("Unexpected Verify(...) call");
         }
 
         size_t BackingSize() const noexcept override
@@ -222,7 +223,7 @@ Y_UNIT_TEST_SUITE(TPartSliceLoader) {
             TTestEnv env;
             auto index = CreateIndexIter(&*Part0(), &env, { });
 
-            Y_ABORT_UNLESS(index->Seek(0) == EReady::Data);
+            Y_ENSURE(index->Seek(0) == EReady::Data);
             while (index->IsValid()) {
                 auto from = index->GetRowId();
                 auto to = Max<TRowId>();
@@ -247,7 +248,7 @@ Y_UNIT_TEST_SUITE(TPartSliceLoader) {
             TVector<TScreen::THole> holes;
             TTestEnv env;
             auto index = CreateIndexIter(&*Part0(), &env, { });
-            Y_ABORT_UNLESS(index->Seek(0) == EReady::Data);
+            Y_ENSURE(index->Seek(0) == EReady::Data);
             while (index->IsValid()) {
                 auto from = index->GetRowId();
                 auto to = Max<TRowId>();
@@ -274,7 +275,7 @@ Y_UNIT_TEST_SUITE(TPartSliceLoader) {
             TVector<TScreen::THole> holes;
             TTestEnv env;
             auto index = CreateIndexIter(&*Part0(), &env, { });
-            Y_ABORT_UNLESS(index->Seek(0) == EReady::Data);
+            Y_ENSURE(index->Seek(0) == EReady::Data);
             while (index->IsValid()) {
                 TRowId begin = index->GetRowId() + 1;
                 TRowId end;

--- a/ydb/core/tablet_flat/ut/ut_stat.cpp
+++ b/ydb/core/tablet_flat/ut/ut_stat.cpp
@@ -466,7 +466,7 @@ Y_UNIT_TEST_SUITE(BuildStatsHistogram) {
                 << (part->IndexPages.HasBTree() ? part->IndexPages.GetBTree({}).LevelCount : -1) << " levels: ";
             for (ui32 sample : xrange(1u, samples + 1)) {
                 TRowId rowId((index->GetEndRowId() - 1) * sample / samples);
-                Y_ABORT_UNLESS(index->Seek(rowId) == EReady::Data);
+                Y_ENSURE(index->Seek(rowId) == EReady::Data);
                 TSmallVec<TCell> keyCells;
                 index->GetKeyCells(keyCells);
                 Cerr << "(";
@@ -534,7 +534,7 @@ Y_UNIT_TEST_SUITE(BuildStatsHistogram) {
             for (auto c : subset.Scheme->Cols) {
                 tags.push_back(c.Tag);
             }
-            Y_ABORT_UNLESS(ChargeRange(&env, {}, key.GetCells(), run, keyDefaults, tags, 0, 0, true));
+            Y_ENSURE(ChargeRange(&env, {}, key.GetCells(), run, keyDefaults, tags, 0, 0, true));
         }
 
         bytes = env.TouchedBytes;

--- a/ydb/core/tablet_flat/ut/ut_versions.cpp
+++ b/ydb/core/tablet_flat/ut/ut_versions.cpp
@@ -57,7 +57,7 @@ namespace {
 
         for (auto &one: eggs) {
             for (const auto &part : one->Parts) {
-                Y_ABORT_UNLESS(part->Slices, "Missing part slices");
+                Y_ENSURE(part->Slices, "Missing part slices");
                 partView.push_back({ part, nullptr, part->Slices });
             }
         }

--- a/ydb/core/tablet_flat/util_channel.h
+++ b/ydb/core/tablet_flat/util_channel.h
@@ -6,6 +6,7 @@
 
 #include <util/generic/hash.h>
 #include <util/generic/vector.h>
+#include <util/generic/yexception.h>
 #include <util/random/random.h>
 
 namespace NKikimr {
@@ -44,7 +45,7 @@ namespace NUtil {
     }
 
     inline ui8 SelectChannel(const TVector<float>& normalizedShares, const TVector<ui8>& channels) {
-        Y_ABORT_UNLESS(normalizedShares.size() == channels.size(), "Normalized shares and channels sizes mismatch");
+        Y_ENSURE(normalizedShares.size() == channels.size(), "Normalized shares and channels sizes mismatch");
 
         if (channels.size() == 1) {
             return channels[0];

--- a/ydb/core/tablet_flat/util_fmt_abort.h
+++ b/ydb/core/tablet_flat/util_fmt_abort.h
@@ -1,41 +1,15 @@
 #pragma once
 
-#include <util/stream/str.h>
+#include <util/generic/yexception.h>
 #include <util/system/yassert.h>
-#include <util/system/src_root.h>
 
-namespace NKikimr {
-namespace NUtil {
+namespace NKikimr::NUtil {
 
-    class TFail : public TStringOutput {
+    class TTabletError : public yexception {
     public:
-        using TBuf = NPrivate::TStaticBuf;
-
-        TFail(TBuf fname, ui32 line, const char *func)
-            : TStringOutput(Raw)
-            , File(fname)
-            , Func(func)
-            , Line(line)
-        {
-            Raw.reserve(192);
-        }
-
-        [[noreturn]] ~TFail()
-        {
-            ::NPrivate::Panic(File, Line, Func, nullptr, "%s\n", Raw.data());
-        }
-
-    private:
-        const TBuf File;
-        const char *Func = nullptr;
-        const int Line = Max<int>();
-        TString Raw;
+        using yexception::yexception;
     };
 
-}
-}
+} // namespace NKikimr::NUtil
 
-#define Y_Fail_Detailed()\
-    NKikimr::NUtil::TFail logl(__SOURCE_FILE_IMPL__, __LINE__, __FUNCTION__)
-
-#define Y_Fail(stream) do{ Y_Fail_Detailed(); logl << stream; } while(false)
+#define Y_TABLET_ERROR(stream) do { ythrow ::NKikimr::NUtil::TTabletError() << stream; } while(false)

--- a/ydb/core/tablet_flat/util_fmt_logger.h
+++ b/ydb/core/tablet_flat/util_fmt_logger.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include "util_fmt_abort.h"
 #include "util_fmt_line.h"
 
 #include <ydb/core/base/appdata.h>
@@ -58,8 +59,9 @@ namespace NUtil {
 
             auto *ev = new NLog::TEvLog(stamp, ui32(level), Comp, line);
 
-            if (!Sys->Send(Path, ev))
-                Y_ABORT("Cannot send NLog::TEvLog to logger actor");
+            if (!Sys->Send(Path, ev)) {
+                Y_TABLET_ERROR("Cannot send NLog::TEvLog to logger actor");
+            }
         }
 
     private:

--- a/ydb/core/tablet_flat/util_pool.h
+++ b/ydb/core/tablet_flat/util_pool.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <util/generic/utility.h>
+#include <util/generic/yexception.h>
 #include <util/system/align.h>
 #include <util/system/yassert.h>
 #include <memory>
@@ -141,19 +142,19 @@ namespace NKikimr::NUtil {
         }
 
         void BeginTransaction() {
-            Y_ABORT_UNLESS(!RollbackState_);
+            Y_ENSURE(!RollbackState_);
             auto& state = RollbackState_.emplace();
             state.Chunk = Current;
             state.Ptr = Current->Ptr;
         }
 
         void CommitTransaction() {
-            Y_ABORT_UNLESS(RollbackState_);
+            Y_ENSURE(RollbackState_);
             RollbackState_.reset();
         }
 
         void RollbackTransaction() {
-            Y_ABORT_UNLESS(RollbackState_);
+            Y_ENSURE(RollbackState_);
             auto& state = *RollbackState_;
             DoRollback(state.Chunk, state.Ptr);
             RollbackState_.reset();
@@ -193,7 +194,7 @@ namespace NKikimr::NUtil {
         }
 
         TChunk* AddChunk(size_t size) {
-            Y_ABORT_UNLESS(!Current->Next);
+            Y_ENSURE(!Current->Next);
             size_t hint = Max(AlignUp<size_t>(sizeof(TChunk), PLATFORM_DATA_ALIGN) + size, Current->ChunkSize() + 1);
             TChunk* next = AllocateChunk(hint);
             Total_ += next->ChunkSize();
@@ -229,7 +230,7 @@ namespace NKikimr::NUtil {
                     Wasted_ -= nextWasted;
                     // Switch to the next chunk in the chain
                     chunk = chunk->Next;
-                    Y_ABORT_UNLESS(chunk, "Rollback cannot find current chunk in the chain");
+                    Y_ENSURE(chunk, "Rollback cannot find current chunk in the chain");
                     // Reset chunk and add it to stats as wasted/free space
                     nextUsed = chunk->Used();
                     nextWasted = chunk->Wasted();

--- a/ydb/core/tablet_flat/util_store.h
+++ b/ydb/core/tablet_flat/util_store.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include <util/generic/yexception.h>
+#include <util/system/yassert.h>
 #include <atomic>
 
 namespace NKikimr {
@@ -173,7 +175,7 @@ namespace NUtil {
          */
         void truncate(size_t new_size) {
             size_t prev_size = Count.load(std::memory_order_relaxed);
-            Y_ABORT_UNLESS(new_size <= prev_size);
+            Y_ENSURE(new_size <= prev_size);
 
             if (new_size < prev_size) {
                 auto* tail = Tail.load(std::memory_order_acquire);
@@ -224,13 +226,13 @@ namespace NUtil {
          */
         template<class TCallback>
         void Enumerate(size_t index, size_t endIndex, TCallback&& callback) {
-            Y_ABORT_UNLESS(index <= endIndex);
+            Y_ENSURE(index <= endIndex);
             if (index == endIndex) {
                 return;
             }
 
             size_t count = Count.load(std::memory_order_acquire);
-            Y_ABORT_UNLESS(endIndex <= count);
+            Y_ENSURE(endIndex <= count);
 
             auto* tail = Tail.load(std::memory_order_acquire);
             while (tail && index < tail->Offset) {


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

...

### Changelog category <!-- remove all except one -->

* Not for changelog (changelog entry is not required)

### Description for reviewers <!-- (optional) description for those who read this PR -->

This will improve process stability in the future. Note: Y_ENSURE cannot be used in destructors, since they are noexcept implicitly and cannot throw exceptions, so I moved those assertions out of destructors where possible. The boot logic currently uses assertions in destructors, which need a complex refactoring and out of scope of this PR.