### PR TITLE
CMS per-drive locks

### DIFF
--- a/ydb/core/cms/cluster_info.cpp
+++ b/ydb/core/cms/cluster_info.cpp
@@ -725,6 +725,8 @@ TSet<TLockableItem *> TClusterInfo::FindLockedItems(const NKikimrCms::TAction &a
 
             if (HasPDisk(device))
                 item = &PDiskRef(device);
+            else if (HasPDisk(action.GetHost(), device))
+                item = &PDiskRef(action.GetHost(), device);
             else if (HasVDisk(device))
                 item = &VDiskRef(device);
 

--- a/ydb/core/cms/cluster_info.h
+++ b/ydb/core/cms/cluster_info.h
@@ -978,6 +978,10 @@ private:
         return PDiskRef(id);
     }
 
+    TPDiskInfo &PDiskRef(const TString &hostName, const TString &path) {
+        return PDiskRef(HostNamePathToPDiskId(hostName, path));
+    }
+
     TVDiskInfo &VDiskRef(const TVDiskID &vdId) {
         Y_ABORT_UNLESS(HasVDisk(vdId));
         return *VDisks.find(vdId)->second;

--- a/ydb/core/cms/cms_maintenance_api_ut.cpp
+++ b/ydb/core/cms/cms_maintenance_api_ut.cpp
@@ -180,6 +180,56 @@ Y_UNIT_TEST_SUITE(TMaintenanceApiTest) {
         UNIT_ASSERT_VALUES_UNEQUAL(refreshResult.last_refresh_time().seconds(), createResult.last_refresh_time().seconds());
         UNIT_ASSERT_VALUES_UNEQUAL(refreshResult.last_refresh_time().nanos(), createResult.last_refresh_time().nanos());
     }
+
+    Y_UNIT_TEST(RequestReplaceDevicePDisk) {
+        std::function<void(Ydb::Maintenance::ActionScope_PDisk*, NCms::TPDiskID&)> pdiskIdFn = [](Ydb::Maintenance::ActionScope_PDisk* pdisk, NCms::TPDiskID& pdiskId) {
+            auto* id = pdisk->mutable_pdisk_id();
+            id->set_node_id(pdiskId.NodeId);
+            id->set_pdisk_id(pdiskId.DiskId);
+        };
+
+        std::function<void(Ydb::Maintenance::ActionScope_PDisk*, NCms::TPDiskID&)> pdiskLocationFn = [](Ydb::Maintenance::ActionScope_PDisk* pdisk, NCms::TPDiskID& pdiskId) {
+            auto* location = pdisk->mutable_pdisk_location();
+            location->set_host("::1"); // All nodes live on this host.
+            location->set_path("/" + std::to_string(pdiskId.NodeId) + "/pdisk-" + std::to_string(pdiskId.DiskId) + ".data");
+        };
+
+        // put both functions in vector, iterate over it and call each function
+        for (auto pdiskFn : {pdiskIdFn, pdiskLocationFn}) {
+            TTestEnvOpts envOpts(8);
+            envOpts.WithSentinel();
+
+            TCmsTestEnv env(envOpts);
+
+            auto req = std::make_unique<NKikimr::NCms::TEvCms::TEvCreateMaintenanceTaskRequest>();
+
+            Ydb::Maintenance::CreateMaintenanceTaskRequest* rec = req->Record.MutableRequest();
+
+            req->Record.SetUserSID("user");
+
+            auto* options = rec->mutable_task_options();
+            options->set_availability_mode(::Ydb::Maintenance::AVAILABILITY_MODE_STRONG);
+
+            auto* actionGroup = rec->add_action_groups();
+            auto* action = actionGroup->Addactions();
+            auto* lockAction = action->mutable_lock_action();
+
+            auto* scope = lockAction->mutable_scope();
+
+            auto* pdisk = scope->mutable_pdisk();
+            auto disk = env.PDiskId(0);
+            pdiskFn(pdisk, disk);
+            lockAction->mutable_duration()->set_seconds(60);
+
+            env.SendToCms(req.release());
+
+            auto response = env.GrabEdgeEvent<NCms::TEvCms::TEvMaintenanceTaskResponse>();
+
+            UNIT_ASSERT_VALUES_EQUAL(response->Record.GetStatus(), Ydb::StatusIds_StatusCode_SUCCESS);
+
+            env.CheckRequest("user", "user-r-1", false, NKikimrCms::TStatus::TStatus::WRONG_REQUEST);
+        }
+    }
 }
 
 } // namespace NKikimr::NCmsTest 

--- a/ydb/core/cms/cms_ut.cpp
+++ b/ydb/core/cms/cms_ut.cpp
@@ -459,6 +459,94 @@ Y_UNIT_TEST_SUITE(TCmsTest) {
                                               "vdisk-3-1-0-1-0", "vdisk-3-1-0-5-0"));
     }
 
+    Y_UNIT_TEST(RequestReplaceDevicePDisk)
+    {
+        auto opts = TTestEnvOpts(8, 8).WithSentinel().WithDynamicGroups();
+        TCmsTestEnv env(opts);
+
+        env.CheckPermissionRequest("user", false, false, false, true, TStatus::NO_SUCH_DEVICE,
+                                   MakeAction(TAction::REPLACE_DEVICES, "::1", 60000000, "/dev/bad/device/path"));
+
+        env.CheckPermissionRequest(
+            MakePermissionRequest(TRequestOptions("user", false, false, false),
+                    MakeAction(TAction::REPLACE_DEVICES, 1, 60000000, env.PDiskName(0, 1))
+                ),
+            TStatus::ALLOW
+        );
+    }
+
+    Y_UNIT_TEST(RequestReplaceDevicePDiskByPath)
+    {
+        auto opts = TTestEnvOpts(8, 8).WithSentinel().WithDynamicGroups();
+        TCmsTestEnv env(opts);
+
+        auto pdiskId = env.PDiskId(0, 0);
+
+        TString pdiskPath = "/" + std::to_string(pdiskId.NodeId) + "/pdisk-" + std::to_string(pdiskId.DiskId) + ".data";
+
+        env.CheckPermissionRequest(
+            MakePermissionRequest(TRequestOptions("user", false, false, false),
+                    MakeAction(TAction::REPLACE_DEVICES, "::1", 60000000, pdiskPath)
+                ),
+            TStatus::ALLOW
+        );
+    }
+
+    Y_UNIT_TEST(RequestReplacePDiskDoesntBreakGroup)
+    {
+        auto opts = TTestEnvOpts(8, 2).WithSentinel().WithDynamicGroups();
+        TCmsTestEnv env(opts);
+
+        {
+            auto pdiskId = env.PDiskId(0, 0);
+    
+            TString pdiskPath = "/" + std::to_string(pdiskId.NodeId) + "/pdisk-" + std::to_string(pdiskId.DiskId) + ".data";
+    
+            env.CheckPermissionRequest(
+                MakePermissionRequest(TRequestOptions("user", false, false, false),
+                        MakeAction(TAction::REPLACE_DEVICES, "::1", 60000000, pdiskPath)
+                    ),
+                TStatus::ALLOW
+            );
+        }
+
+        {
+            auto pdiskId = env.PDiskId(1, 0);
+    
+            TString pdiskPath = "/" + std::to_string(pdiskId.NodeId) + "/pdisk-" + std::to_string(pdiskId.DiskId) + ".data";
+    
+            env.CheckPermissionRequest(
+                MakePermissionRequest(TRequestOptions("user", false, false, false),
+                        MakeAction(TAction::REPLACE_DEVICES, "::1", 60000000, pdiskPath)
+                    ),
+                TStatus::DISALLOW_TEMP
+            );
+        }
+    }
+
+    Y_UNIT_TEST(RequestReplacePDiskConsecutiveWithDone)
+    {
+        auto opts = TTestEnvOpts(8, 2).WithSentinel().WithDynamicGroups();
+        TCmsTestEnv env(opts);
+
+        for (ui32 i = 0; i < 8; ++i) {
+            auto pdiskId = env.PDiskId(i, 0);
+    
+            TString pdiskPath = "/" + std::to_string(pdiskId.NodeId) + "/pdisk-" + std::to_string(pdiskId.DiskId) + ".data";
+    
+            auto rec = env.CheckPermissionRequest(
+                MakePermissionRequest(TRequestOptions("user", false, false, false),
+                        MakeAction(TAction::REPLACE_DEVICES, "::1", 60000000, pdiskPath)
+                    ),
+                TStatus::ALLOW
+            );
+
+            auto pid = rec.GetPermissions(0).GetId();
+
+            env.CheckDonePermission("user", pid);
+        }
+    }
+
     Y_UNIT_TEST(RequestReplaceManyDevicesOnOneNode)
     {
         TCmsTestEnv env(16, 3);

--- a/ydb/core/cms/cms_ut_common.cpp
+++ b/ydb/core/cms/cms_ut_common.cpp
@@ -238,7 +238,7 @@ public:
 };
 
 void GenerateExtendedInfo(TTestActorRuntime &runtime, NKikimrBlobStorage::TBaseConfig *config,
-        ui32 pdisks, ui32 vdiskPerPdisk = 4, const TNodeTenantsMap &tenants = {}, bool useMirror3dcErasure = false)
+        ui32 pdisks, ui32 vdiskPerPdisk = 4, const TNodeTenantsMap &tenants = {}, bool useMirror3dcErasure = false, bool createDynamicGroups = false)
 {   
     constexpr ui32 MIRROR_3DC_VDISKS_COUNT = 9;
     constexpr ui32 BLOCK_4_2_VDISKS_COUNT = 8;
@@ -256,7 +256,20 @@ void GenerateExtendedInfo(TTestActorRuntime &runtime, NKikimrBlobStorage::TBaseC
     ui32 maxOneGroupVdisksPerNode = useMirror3dcErasure && numNodes < MIRROR_3DC_VDISKS_COUNT ? 3 : 1;
 
     auto now = runtime.GetTimeProvider()->Now();
-    for (ui32 groupId = 0; groupId < numGroups; ++groupId) {
+
+    std::map<ui32, ui32> groupIdxToGroupId;
+
+    for (ui32 i = 0; i < numGroups; ++i) {
+        ui32 groupId;
+
+        if (createDynamicGroups) {
+            groupId = ((i % pdisks) == 0) ? i : (i | (1 << 31));
+        } else {
+            groupId = i;
+        }
+
+        groupIdxToGroupId[i] = groupId;
+
         auto &group = *config->AddGroup();
         group.SetGroupId(groupId);
         group.SetGroupGeneration(1);
@@ -301,10 +314,11 @@ void GenerateExtendedInfo(TTestActorRuntime &runtime, NKikimrBlobStorage::TBaseC
         for (ui32 pdiskIndex = 0; pdiskIndex < pdisks; ++pdiskIndex) {
             auto pdiskId = nodeId * pdisks + pdiskIndex;
             auto &pdisk = node.PDiskStateInfo[pdiskId];
+            TString pdiskPath = TStringBuilder() << "/" << nodeId << "/pdisk-" << pdiskId << ".data";
             pdisk.SetPDiskId(pdiskId);
             pdisk.SetCreateTime(now.GetValue());
             pdisk.SetChangeTime(now.GetValue());
-            pdisk.SetPath("/pdisk.data");
+            pdisk.SetPath(pdiskPath);
             pdisk.SetGuid(1);
             pdisk.SetAvailableSize(100ULL << 30);
             pdisk.SetTotalSize(200ULL << 30);
@@ -313,7 +327,7 @@ void GenerateExtendedInfo(TTestActorRuntime &runtime, NKikimrBlobStorage::TBaseC
             auto &pdiskConfig = *config->AddPDisk();
             pdiskConfig.SetNodeId(nodeId);
             pdiskConfig.SetPDiskId(pdiskId);
-            pdiskConfig.SetPath("/pdisk.data");
+            pdiskConfig.SetPath(pdiskPath);
             pdiskConfig.SetGuid(1);
             pdiskConfig.SetDriveStatus(NKikimrBlobStorage::ACTIVE);
 
@@ -323,11 +337,14 @@ void GenerateExtendedInfo(TTestActorRuntime &runtime, NKikimrBlobStorage::TBaseC
 
             for (ui8 vdiskIndex = 0; vdiskIndex < vdiskPerPdisk; ++vdiskIndex) {
                 ui32 vdiskId = pdiskIndex * vdiskPerPdisk + vdiskIndex;
-                ui32 groupId = groupShift + vdiskId / maxOneGroupVdisksPerNode;
+                ui32 groupIdx = groupShift + vdiskId / maxOneGroupVdisksPerNode;
 
-                if (groupId >= config->GroupSize()) {
+                if (groupIdx >= config->GroupSize()) {
                     break;
                 }
+
+                UNIT_ASSERT(groupIdxToGroupId.count(groupIdx));
+                ui32 groupId = groupIdxToGroupId[groupIdx];
 
                 ui32 failRealm = 0;
                 if (useMirror3dcErasure) {
@@ -339,7 +356,7 @@ void GenerateExtendedInfo(TTestActorRuntime &runtime, NKikimrBlobStorage::TBaseC
                 }
 
                 TVDiskID id = {
-                    (ui8)groupId,
+                    groupId,
                     1,
                     (ui8)failRealm,
                     (ui8)(nodeIndex % BLOCK_4_2_VDISKS_COUNT),
@@ -365,7 +382,7 @@ void GenerateExtendedInfo(TTestActorRuntime &runtime, NKikimrBlobStorage::TBaseC
                 vdiskConfig.SetFailDomainIdx(nodeIndex % BLOCK_4_2_VDISKS_COUNT);
                 vdiskConfig.SetVDiskIdx(vdiskId % maxOneGroupVdisksPerNode);
 
-                config->MutableGroup(groupId)->AddVSlotId()
+                config->MutableGroup(groupIdx)->AddVSlotId()
                     ->CopyFrom(vdiskConfig.GetVSlotId());
             }
         }
@@ -585,7 +602,7 @@ TCmsTestEnv::TCmsTestEnv(const TTestEnvOpts &options)
 
     TGuard<TMutex> guard(TFakeNodeWhiteboardService::Mutex);
     TFakeNodeWhiteboardService::Info.clear();
-    GenerateExtendedInfo(*this, config, options.VDisks, 4, options.Tenants, options.UseMirror3dcErasure);
+    GenerateExtendedInfo(*this, config, options.VDisks, 4, options.Tenants, options.UseMirror3dcErasure, options.EnableDynamicGroups);
 
     SetObserverFunc([](TAutoPtr<IEventHandle> &event) -> auto {
         if (event->GetTypeRewrite() == TEvBlobStorage::EvControllerConfigRequest
@@ -938,6 +955,39 @@ void TCmsTestEnv::CheckBSCUpdateRequests(std::set<ui32> expectedNodes,
     );
 }
 
+
+void TCmsTestEnv::CheckBSCUpdateDriveRequests(std::set<std::pair<ui32, ui32>> expectedDrives,
+                                         NKikimrBlobStorage::EDriveStatus expectedStatus)
+{
+    using TBSCRequests = std::map<NKikimrBlobStorage::EDriveStatus, std::set<std::pair<ui32, ui32>>>;
+
+    TBSCRequests expectedRequests = { {expectedStatus, expectedDrives} };
+    TBSCRequests actualRequests;
+
+    TDispatchOptions options;
+    options.FinalEvents.emplace_back([&](IEventHandle& ev) {
+        if (ev.GetTypeRewrite() == TEvBlobStorage::TEvControllerConfigRequest::EventType) {
+            const auto& request = ev.Get<TEvBlobStorage::TEvControllerConfigRequest>()->Record;
+            bool foundUpdateDriveCommand = false;
+            for (const auto& command : request.GetRequest().GetCommand()) {
+                if (command.HasUpdateDriveStatus()) {
+                    foundUpdateDriveCommand = true;
+                    const auto& update = command.GetUpdateDriveStatus();
+                    actualRequests[update.GetStatus()].insert(std::make_pair<ui32, ui32>(update.GetHostKey().GetNodeId(), update.GetPDiskId()));
+                }
+            }
+            return foundUpdateDriveCommand;
+        }
+        return false;
+    });
+    DispatchEvents(options, TDuration::Minutes(1));
+
+    UNIT_ASSERT_C(
+        actualRequests == expectedRequests,
+        TStringBuilder() << "Sentinel sent wrong update requests to BSC"
+    );
+}
+
 void TCmsTestEnv::CheckWalleStoreTaskIsFailed(NCms::TEvCms::TEvStoreWalleTask* req)
 {
     TString TaskId = req->Task.TaskId;
@@ -1244,7 +1294,7 @@ void TCmsTestEnv::EnableNoisyBSCPipe() {
 void TCmsTestEnv::RegenerateBSConfig(NKikimrBlobStorage::TBaseConfig *config, const TTestEnvOpts &opts) {
     TGuard<TMutex> guard(TFakeNodeWhiteboardService::Mutex);
     config->Clear();
-    GenerateExtendedInfo(*this, config, opts.VDisks, 4, opts.Tenants, opts.UseMirror3dcErasure);
+    GenerateExtendedInfo(*this, config, opts.VDisks, 4, opts.Tenants, opts.UseMirror3dcErasure, opts.EnableDynamicGroups);
 }
 
 } // namespace NCmsTest

--- a/ydb/core/cms/cms_ut_common.cpp
+++ b/ydb/core/cms/cms_ut_common.cpp
@@ -263,7 +263,8 @@ void GenerateExtendedInfo(TTestActorRuntime &runtime, NKikimrBlobStorage::TBaseC
         ui32 groupId;
 
         if (createDynamicGroups) {
-            groupId = ((i % pdisks) == 0) ? i : (i | (1 << 31));
+            TGroupID fullGroupId(i == 0 ? EGroupConfigurationType::Static : EGroupConfigurationType::Dynamic, 1, i);
+            groupId = fullGroupId.GetRaw();
         } else {
             groupId = i;
         }

--- a/ydb/core/cms/cms_ut_common.h
+++ b/ydb/core/cms/cms_ut_common.h
@@ -91,6 +91,7 @@ struct TTestEnvOpts {
     bool EnableSentinel;
     bool EnableCMSRequestPriorities;
     bool EnableSingleCompositeActionGroup;
+    bool EnableDynamicGroups;
 
     using TNodeLocationCallback = std::function<TNodeLocation(ui32)>;
     TNodeLocationCallback NodeLocationCallback;
@@ -112,6 +113,7 @@ struct TTestEnvOpts {
         , EnableSentinel(false)
         , EnableCMSRequestPriorities(true)
         , EnableSingleCompositeActionGroup(true)
+        , EnableDynamicGroups(false)
     {
     }
 
@@ -135,6 +137,10 @@ struct TTestEnvOpts {
         return *this;
     }
 
+    TTestEnvOpts& WithDynamicGroups() {
+        EnableDynamicGroups = true;
+        return *this;
+    }
 };
 
 class TCmsTestEnv : public TTestBasicRuntime {
@@ -333,6 +339,8 @@ public:
     }
 
     void CheckBSCUpdateRequests(std::set<ui32> expectedNodes, NKikimrBlobStorage::EDriveStatus expectedStatus);
+
+    void CheckBSCUpdateDriveRequests(std::set<std::pair<ui32, ui32>> expectedDrives, NKikimrBlobStorage::EDriveStatus expectedStatus);
 
     void CheckWalleStoreTaskIsFailed(NCms::TEvCms::TEvStoreWalleTask *req);
 

--- a/ydb/core/cms/cms_ut_common.h
+++ b/ydb/core/cms/cms_ut_common.h
@@ -340,8 +340,6 @@ public:
 
     void CheckBSCUpdateRequests(std::set<ui32> expectedNodes, NKikimrBlobStorage::EDriveStatus expectedStatus);
 
-    void CheckBSCUpdateDriveRequests(std::set<std::pair<ui32, ui32>> expectedDrives, NKikimrBlobStorage::EDriveStatus expectedStatus);
-
     void CheckWalleStoreTaskIsFailed(NCms::TEvCms::TEvStoreWalleTask *req);
 
     template <typename... Ts>

--- a/ydb/public/api/protos/draft/ydb_maintenance.proto
+++ b/ydb/public/api/protos/draft/ydb_maintenance.proto
@@ -96,9 +96,24 @@ message MaintenanceTaskOptions {
 
 // Used to describe the scope of a single action.
 message ActionScope {
+    message PDiskId {
+        uint32 node_id = 1;
+        uint32 pdisk_id = 2;
+    }
+    message PDiskLocation {
+        string host = 1 [(length).le = 255];
+        string path = 2 [(length).le = 255];
+    }
+    message PDisk {
+        oneof pdisk {
+            PDiskId pdisk_id = 1;
+            PDiskLocation pdisk_location = 2;
+        }
+    }
     oneof scope {
         uint32 node_id = 1;
         string host = 2 [(length).le = 255];
+        PDisk pdisk = 3;
     }
 }
 


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

Add support for CMS API to address single PDisk for REPLACE_DEVICES action. Since PDisks can be restarted, there is no need to lock and shutdown entire host.

### Changelog category <!-- remove all except one -->

* Experimental feature