### PR TITLE
Add client timeout histogram for grpc call metrics.

### DIFF
--- a/ydb/core/client/server/grpc_server.cpp
+++ b/ydb/core/client/server/grpc_server.cpp
@@ -303,7 +303,7 @@ private:
         if (Server->IncRequest()) {
 
             RequestSize = Request.ByteSize();
-            Counters->StartProcessing(RequestSize);
+            Counters->StartProcessing(RequestSize, TInstant::Max());
             RequestTimer.Reset();
             InProgress_ = true;
 

--- a/ydb/core/grpc_services/counters/counters.cpp
+++ b/ydb/core/grpc_services/counters/counters.cpp
@@ -117,6 +117,7 @@ private:
     ::NMonitoring::TDynamicCounters::TCounterPtr RequestsWithoutToken;
     ::NMonitoring::TDynamicCounters::TCounterPtr RequestsWithoutTls;
     ::NMonitoring::THistogramPtr Histo;
+    ::NMonitoring::THistogramPtr ClientTimeoutHisto;
 
 
     std::function<void()> InitFn;
@@ -190,7 +191,7 @@ public:
         *YdbCounters.ResponseBytes += responseSize;
     }
 
-    void StartProcessing(ui32 requestSize) override {
+    void StartProcessing(ui32 requestSize, TInstant deadline) override {
         InitOnce();
         TotalCounter->Inc();
         InflyCounter->Inc();
@@ -201,6 +202,15 @@ public:
         YdbCounters.RequestInflight->Inc();
         *YdbCounters.RequestBytes += requestSize;
         *YdbCounters.RequestInflightBytes += requestSize;
+        if (deadline != TInstant::Zero() && deadline != TInstant::Max()) {
+            auto now = TInstant::Now();
+            if (deadline > now) {
+                auto timeout = deadline - now;
+                ClientTimeoutHisto->Collect(timeout.MilliSeconds());
+            } else {
+                ClientTimeoutHisto->Collect(0);
+            }
+        }
     }
 
     void FinishProcessing(ui32 requestSize, ui32 responseSize, bool ok, ui32 status,
@@ -330,14 +340,24 @@ TYdbCounterBlock::TYdbCounterBlock(const ::NMonitoring::TDynamicCounterPtr& coun
         TotalCounter = subgroup->GetCounter("total", true);
         InflyCounter = subgroup->GetCounter("infly", false);
 
-        auto h = NMonitoring::ExplicitHistogram(
-            NMonitoring::TBucketBounds{
-                0.5, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10,
-                16, 20, 24, 28, 32, 36,
-                40, 50, 60, 70, 80, 90,
-                100, 200, 300, 400, 500,
-                1000, 5000, 10000, 20000, 60000});
-        Histo = subgroup->GetHistogram("LatencyMs", std::move(h));
+        {
+            auto h = NMonitoring::ExplicitHistogram(
+                NMonitoring::TBucketBounds{
+                    0.5, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10,
+                    16, 20, 24, 28, 32, 36,
+                    40, 50, 60, 70, 80, 90,
+                    100, 200, 300, 400, 500,
+                    1000, 5000, 10000, 20000, 60000});
+            Histo = subgroup->GetHistogram("LatencyMs", std::move(h));
+        }
+
+        {
+            auto h = NMonitoring::ExplicitHistogram(
+                NMonitoring::TBucketBounds{
+                    5, 10, 50, 100, 250, 500,
+                    1000, 5000, 10000, 20000, 60000});
+            ClientTimeoutHisto = subgroup->GetHistogram("TimeoutMs", std::move(h));
+        }
     };
 }
 
@@ -615,9 +635,9 @@ public:
         Db->CountResponseBytes(responseSize);
     }
 
-    void StartProcessing(ui32 requestSize) override {
-        Common->StartProcessing(requestSize);
-        Db->StartProcessing(requestSize);
+    void StartProcessing(ui32 requestSize, TInstant deadline) override {
+        Common->StartProcessing(requestSize, deadline);
+        Db->StartProcessing(requestSize, deadline);
     }
 
     void FinishProcessing(ui32 requestSize, ui32 responseSize, bool ok, ui32 status,

--- a/ydb/core/grpc_services/counters/counters.cpp
+++ b/ydb/core/grpc_services/counters/counters.cpp
@@ -354,7 +354,7 @@ TYdbCounterBlock::TYdbCounterBlock(const ::NMonitoring::TDynamicCounterPtr& coun
         {
             auto h = NMonitoring::ExplicitHistogram(
                 NMonitoring::TBucketBounds{
-                    5, 10, 50, 100, 250, 500,
+                    0, 5, 10, 50, 100, 250, 500,
                     1000, 5000, 10000, 20000, 60000});
             ClientTimeoutHisto = subgroup->GetHistogram("TimeoutMs", std::move(h));
         }

--- a/ydb/core/grpc_streaming/grpc_streaming.h
+++ b/ydb/core/grpc_streaming/grpc_streaming.h
@@ -247,7 +247,7 @@ private:
 
         if (IncRequest()) {
             if (Counters) {
-                Counters->StartProcessing(0);
+                Counters->StartProcessing(0, TInstant::Max());
             }
             Flags |= FlagStarted;
 

--- a/ydb/library/grpc/server/grpc_counters.cpp
+++ b/ydb/library/grpc/server/grpc_counters.cpp
@@ -23,7 +23,7 @@ private:
     void CountResponseBytes(ui32 /*responseSize*/) override {
     }
 
-    void StartProcessing(ui32 /*requestSize*/) override {
+    void StartProcessing(ui32 /*requestSize*/, TInstant /*deadline*/) override {
     }
 
     void FinishProcessing(

--- a/ydb/library/grpc/server/grpc_counters.h
+++ b/ydb/library/grpc/server/grpc_counters.h
@@ -13,7 +13,7 @@ struct ICounterBlock : public TThrRefBase {
     virtual void CountResourceExhausted() = 0;
     virtual void CountRequestBytes(ui32 requestSize) = 0;
     virtual void CountResponseBytes(ui32 responseSize) = 0;
-    virtual void StartProcessing(ui32 requestSize) = 0;
+    virtual void StartProcessing(ui32 requestSize, TInstant deadline) = 0;
     virtual void FinishProcessing(ui32 requestSize, ui32 responseSize, bool ok, ui32 status, TDuration requestDuration) = 0;
     virtual void CountRequestsWithoutDatabase() {}
     virtual void CountRequestsWithoutToken() {}
@@ -90,7 +90,7 @@ public:
         *ResponseBytes += responseSize;
     }
 
-    void StartProcessing(ui32 requestSize) override {
+    void StartProcessing(ui32 requestSize, TInstant /*deadline*/) override {
         TotalCounter->Inc();
         InflyCounter->Inc();
         *RequestBytes += requestSize;

--- a/ydb/library/grpc/server/grpc_request.h
+++ b/ydb/library/grpc/server/grpc_request.h
@@ -422,7 +422,7 @@ private:
         if (IncRequest()) {
             // Adjust counters.
             RequestSize = Request_->ByteSize();
-            Counters_->StartProcessing(RequestSize);
+            Counters_->StartProcessing(RequestSize, Deadline());
             RequestTimer.Reset();
 
             if (!SslServer()) {


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

In case of investigation problems with unexpected timeout response It is helpful to know actual timeout for grpc call from the server perspective

### Changelog category <!-- remove all except one -->


* Improvement

### Description for reviewers <!-- (optional) description for those who read this PR -->

...
