### PR TITLE
Add EnableConfigV2 option to allow enabling/disabling v2 configuration for migration purposes

### DIFF
--- a/ydb/core/blobstorage/base/blobstorage_console_events.h
+++ b/ydb/core/blobstorage/base/blobstorage_console_events.h
@@ -77,14 +77,9 @@ namespace NKikimr {
             NKikimrBlobStorage::TEvControllerReplaceConfigRequest, EvControllerReplaceConfigRequest> {
         TEvControllerReplaceConfigRequest() = default;
 
-        TEvControllerReplaceConfigRequest(
-            std::optional<TString> clusterYaml,
-            std::optional<TString> storageYaml,
-            std::optional<bool> switchDedicatedStorageSection,
-            bool dedicatedConfigMode,
-            bool allowUnknownFields,
-            bool bypassMetadataChecks) {
-
+        TEvControllerReplaceConfigRequest(std::optional<TString> clusterYaml, std::optional<TString> storageYaml,
+                std::optional<bool> switchDedicatedStorageSection, bool dedicatedConfigMode, bool allowUnknownFields,
+                bool bypassMetadataChecks, bool enableConfigV2, bool disableConfigV2) {
             if (clusterYaml) {
                 Record.SetClusterYaml(*clusterYaml);
             }
@@ -97,6 +92,11 @@ namespace NKikimr {
             Record.SetDedicatedConfigMode(dedicatedConfigMode);
             Record.SetAllowUnknownFields(allowUnknownFields);
             Record.SetBypassMetadataChecks(bypassMetadataChecks);
+            if (enableConfigV2) {
+                Record.SetSwitchEnableConfigV2(true);
+            } else if (disableConfigV2) {
+                Record.SetSwitchEnableConfigV2(false);
+            }
         }
 
         TString ToString() const override {

--- a/ydb/core/grpc_services/rpc_config.cpp
+++ b/ydb/core/grpc_services/rpc_config.cpp
@@ -232,7 +232,9 @@ public:
             shim.SwitchDedicatedStorageSection,
             shim.DedicatedConfigMode,
             request->allow_unknown_fields() || request->bypass_checks(),
-            request->bypass_checks());
+            request->bypass_checks(),
+            false /* TODO: implement */,
+            false /* TODO: implement */);
     }
 
 private:

--- a/ydb/core/mind/bscontroller/bsc.cpp
+++ b/ydb/core/mind/bscontroller/bsc.cpp
@@ -463,7 +463,7 @@ void TBlobStorageController::Handle(TEvBlobStorage::TEvControllerDistconfRequest
 
             // commit it
             Execute(CreateTxCommitConfig(std::move(yamlConfig), std::make_optional(std::move(storageYaml)), std::nullopt,
-                expectedStorageYamlConfigVersion, std::exchange(h, {})));
+                expectedStorageYamlConfigVersion, std::exchange(h, {}), std::nullopt));
             break;
         }
 

--- a/ydb/core/mind/bscontroller/console_interaction.h
+++ b/ydb/core/mind/bscontroller/console_interaction.h
@@ -47,18 +47,20 @@ namespace NKikimr::NBsController {
         bool NeedRetrySession = false;
         bool Working = false;
         bool CommitInProgress = false;
+        std::optional<bool> SwitchEnableConfigV2;
+        TEvBlobStorage::TEvControllerReplaceConfigRequest::TPtr PendingReplaceRequest;
 
         std::optional<TString> PendingYamlConfig;
         bool AllowUnknownFields = false;
-
         std::optional<std::optional<TString>> PendingStorageYamlConfig;
+        std::optional<ui64> ExpectedYamlConfigVersion;
 
         void MakeCommitToConsole(TString& config, ui32 configVersion);
         void MakeGetBlock();
         void MakeRetrySession();
 
         void IssueGRpcResponse(NKikimrBlobStorage::TEvControllerReplaceConfigResponse::EStatus status,
-            std::optional<TString> errorReason = std::nullopt);
+            std::optional<TString> errorReason = std::nullopt, bool disabledConfigV2 = false);
     };
 
 }

--- a/ydb/core/mind/bscontroller/impl.h
+++ b/ydb/core/mind/bscontroller/impl.h
@@ -1571,6 +1571,7 @@ private:
     bool AllowMultipleRealmsOccupation = true;
     bool StorageConfigObtained = false;
     bool Loaded = false;
+    bool EnableConfigV2 = false;
     std::shared_ptr<TControlWrapper> EnableSelfHealWithDegraded;
 
     struct TLifetimeToken {};
@@ -1989,7 +1990,8 @@ private:
         std::optional<std::optional<TString>>&& storageYamlConfig,
         std::optional<NKikimrBlobStorage::TStorageConfig>&& storageConfig,
         std::optional<ui64> expectedStorageYamlConfigVersion,
-        std::unique_ptr<IEventHandle> handle);
+        std::unique_ptr<IEventHandle> handle,
+        std::optional<bool> switchEnableConfigV2);
 
     struct TVDiskAvailabilityTiming {
         TVSlotId VSlotId;

--- a/ydb/core/mind/bscontroller/load_everything.cpp
+++ b/ydb/core/mind/bscontroller/load_everything.cpp
@@ -110,6 +110,7 @@ public:
                 if (state.HaveValue<T::ShredState>()) {
                     Self->ShredState.OnLoad(state.GetValue<T::ShredState>());
                 }
+                Self->EnableConfigV2 = state.GetValue<T::EnableConfigV2>();
             }
         }
 
@@ -473,14 +474,6 @@ public:
             }
         }
 
-        // primitive garbage collection for obsolete metrics
-        for (const auto& key : pdiskMetricsToDelete) {
-            db.Table<Schema::PDiskMetrics>().Key(key).Delete();
-        }
-        for (const auto& key : vdiskMetricsToDelete) {
-            db.Table<Schema::VDiskMetrics>().Key(key).Delete();
-        }
-
         // apply storage pool stats
         std::unordered_map<TBoxStoragePoolId, ui64> allocatedSizeMap;
         for (const auto& [vslotId, slot] : Self->VSlots) {
@@ -536,6 +529,14 @@ public:
                 }
                 return it->second;
             });
+        }
+
+        // primitive garbage collection for obsolete metrics
+        for (const auto& key : pdiskMetricsToDelete) {
+            db.Table<Schema::PDiskMetrics>().Key(key).Delete();
+        }
+        for (const auto& key : vdiskMetricsToDelete) {
+            db.Table<Schema::VDiskMetrics>().Key(key).Delete();
         }
 
         return true;

--- a/ydb/core/mind/bscontroller/migrate.cpp
+++ b/ydb/core/mind/bscontroller/migrate.cpp
@@ -171,6 +171,14 @@ class TBlobStorageController::TTxMigrate : public TTransactionBase<TBlobStorageC
         }
     };
 
+    class TTxUpdateEnableConfigV2 : public TTxBase {
+    public:
+        bool Execute(TTransactionContext& txc) override {
+            NIceDb::TNiceDb(txc.DB).Table<Schema::State>().Key(true).Update<Schema::State::EnableConfigV2>(true);
+            return true;
+        }
+    };
+
     TDeque<THolder<TTxBase>> Queue;
 
 public:
@@ -231,6 +239,10 @@ public:
         Queue.emplace_back(new TTxDropDriveStatus);
     
         Queue.emplace_back(new TTxUpdateCompatibilityInfo);
+
+        if (!hasInstanceId) {
+            Queue.emplace_back(new TTxUpdateEnableConfigV2);
+        }
 
         return true;
     }

--- a/ydb/core/mind/bscontroller/scheme.h
+++ b/ydb/core/mind/bscontroller/scheme.h
@@ -114,6 +114,7 @@ struct Schema : NIceDb::Schema {
         struct ShredState : Column<26, NScheme::NTypeIds::String> {};
         struct StorageYamlConfig : Column<27, NScheme::NTypeIds::String> {};
         struct ExpectedStorageYamlConfigVersion : Column<28, NScheme::NTypeIds::Uint64> {};
+        struct EnableConfigV2 : Column<29, NScheme::NTypeIds::Bool> { static constexpr Type Default = false; };
 
         using TKey = TableKey<FixedKey>;
         using TColumns = TableColumns<FixedKey, NextGroupID, SchemaVersion, NextOperationLogIndex, DefaultMaxSlots,
@@ -121,7 +122,7 @@ struct Schema : NIceDb::Schema {
               PDiskSpaceMarginPromille, GroupReserveMin, GroupReservePart, MaxScrubbedDisksAtOnce, PDiskSpaceColorBorder,
               GroupLayoutSanitizer, NextVirtualGroupId, AllowMultipleRealmsOccupation, CompatibilityInfo,
               UseSelfHealLocalPolicy, TryToRelocateBrokenDisksLocallyFirst, YamlConfig, ShredState, StorageYamlConfig,
-              ExpectedStorageYamlConfigVersion>;
+              ExpectedStorageYamlConfigVersion, EnableConfigV2>;
     };
 
     struct VSlot : Table<5> {

--- a/ydb/core/protos/blobstorage.proto
+++ b/ydb/core/protos/blobstorage.proto
@@ -1448,6 +1448,7 @@ message TEvControllerReplaceConfigRequest {
     optional bool SkipConsoleValidation = 5;
     optional bool SwitchDedicatedStorageSection = 6;
     optional bool DedicatedConfigMode = 7;
+    optional bool SwitchEnableConfigV2 = 10; // if set, overrides EnableConfigV2 field in BSC
     // console flags
     optional bool AllowUnknownFields = 8;
     optional bool BypassMetadataChecks = 9;
@@ -1466,6 +1467,7 @@ message TEvControllerReplaceConfigResponse {
     }
     optional EStatus Status = 1;
     optional string ErrorReason = 2;
+    optional bool DisabledConfigV2 = 3; // set along with InvalidRequest when Configuration V2 is disabled and BSC can't process this query
 }
 
 message TEvControllerValidateConfigRequest {
@@ -1510,6 +1512,7 @@ message TEvControllerFetchConfigResponse {
     optional string ClusterYaml = 1;
     optional string StorageYaml = 2;
     optional string ErrorReason = 3;
+    optional bool DisabledConfigV2 = 4;
 }
 
 message TEvControllerDistconfRequest {

--- a/ydb/public/lib/ydb_cli/commands/ydb_dynamic_config.cpp
+++ b/ydb/public/lib/ydb_cli/commands/ydb_dynamic_config.cpp
@@ -110,7 +110,7 @@ int TCommandConfigFetch::Run(TConfig& config) {
     auto result = client.FetchAllConfigs(settings).GetValueSync();
 
     // if the new Config API is not supported, fallback to the old DynamicConfig API
-    if (result.GetStatus() == EStatus::CLIENT_CALL_UNIMPLEMENTED) {
+    if (result.GetStatus() == EStatus::CLIENT_CALL_UNIMPLEMENTED || result.GetStatus() == EStatus::UNSUPPORTED) {
         auto client = NYdb::NDynamicConfig::TDynamicConfigClient(*driver);
         auto result = client.GetConfig().GetValueSync();
         NStatusHelpers::ThrowOnErrorOrPrintIssues(result);
@@ -212,7 +212,7 @@ void TCommandConfigReplace::Parse(TConfig& config) {
         ythrow yexception() << "Must specify non-empty -f (--filename)";
     }
 
-   const auto configStr = Filename == "-" ? Cin.ReadAll() : TFileInput(Filename).ReadAll();
+    const auto configStr = Filename == "-" ? Cin.ReadAll() : TFileInput(Filename).ReadAll();
 
     DynamicConfig = configStr;
 
@@ -244,7 +244,7 @@ int TCommandConfigReplace::Run(TConfig& config) {
 
     auto status = client.ReplaceConfig(DynamicConfig, settings).GetValueSync();
 
-    if (status.GetStatus() == EStatus::CLIENT_CALL_UNIMPLEMENTED) {
+    if (status.GetStatus() == EStatus::CLIENT_CALL_UNIMPLEMENTED || status.GetStatus() == EStatus::UNSUPPORTED) {
         Cerr << "Warning: Fallback to DynamicConfig API" << Endl;
 
         auto client = NYdb::NDynamicConfig::TDynamicConfigClient(*driver);

--- a/ydb/tests/functional/scheme_tests/canondata/tablet_scheme_tests.TestTabletSchemes.test_tablet_schemes_flat_bs_controller_/flat_bs_controller.schema
+++ b/ydb/tests/functional/scheme_tests/canondata/tablet_scheme_tests.TestTabletSchemes.test_tablet_schemes_flat_bs_controller_/flat_bs_controller.schema
@@ -7,6 +7,11 @@
         ],
         "ColumnsAdded": [
             {
+                "ColumnId": 29,
+                "ColumnName": "EnableConfigV2",
+                "ColumnType": "Bool"
+            },
+            {
                 "ColumnId": 1,
                 "ColumnName": "FixedKey",
                 "ColumnType": "Bool"
@@ -141,6 +146,7 @@
         "ColumnFamilies": {
             "0": {
                 "Columns": [
+                    29,
                     1,
                     2,
                     4,


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

Add EnableConfigV2 option to allow enabling/disabling v2 configuration for migration purposes

### Changelog category <!-- remove all except one -->

* Not for changelog (changelog entry is not required)

### Description for reviewers <!-- (optional) description for those who read this PR -->

Support for explicit migration between v1 and v2 configurations through BSC.
