### PR TITLE
Fix histogram counters calculation error due to implicit round down

### DIFF
--- a/ydb/core/blobstorage/vdisk/common/vdisk_histogram_latency.cpp
+++ b/ydb/core/blobstorage/vdisk/common/vdisk_histogram_latency.cpp
@@ -24,7 +24,7 @@ namespace NKikimr {
 
         void TLtcHisto::Collect(TDuration d, ui64 size) {
             if (Histo) {
-                Histo->Collect(d.MilliSeconds());
+                Histo->Collect(d.MillisecondsFloat());
             }
             if (size) {
                 ThroughputBytes->Add(size);
@@ -33,4 +33,3 @@ namespace NKikimr {
 
     } // NKikimr
 } // NKikimr
-

--- a/ydb/core/grpc_services/counters/counters.cpp
+++ b/ydb/core/grpc_services/counters/counters.cpp
@@ -232,7 +232,7 @@ public:
             *GetResponseCounterByStatus(status) += 1;
         }
 
-        Histo->Collect(requestDuration.MilliSeconds());
+        Histo->Collect(requestDuration.MillisecondsFloat());
     }
 
     NYdbGrpc::ICounterBlockPtr Clone() override {


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

currently all [0,1) value go to 0.5ms bucket since due to round down all these numbers become 0ms
[1, 2) go to 1ms bucket
and so on

fix this error by using double Collect function available in Histogram

### Changelog category <!-- remove all except one -->

* Bugfix 

### Description for reviewers <!-- (optional) description for those who read this PR -->

...
