### PR TITLE
IGNIETFERRO-1955:  do not rely on implementation-dependent allocator friendship behaviour

### DIFF
--- a/ydb/public/lib/ydb_cli/common/pretty_table.cpp
+++ b/ydb/public/lib/ydb_cli/common/pretty_table.cpp
@@ -173,7 +173,7 @@ void TPrettyTable::TRow::PrintFreeText(IOutputStream& o, size_t width) const {
 }
 
 TPrettyTable::TRow& TPrettyTable::AddRow() {
-    return Rows.emplace_back(Columns);
+    return Rows.emplace_back(TRow{Columns});
 }
 
 static void PrintDelim(IOutputStream& o, const TVector<size_t>& widths,

--- a/ydb/public/lib/ydb_cli/common/pretty_table.h
+++ b/ydb/public/lib/ydb_cli/common/pretty_table.h
@@ -32,7 +32,6 @@ class TPrettyTable {
 public:
     class TRow {
         friend class TPrettyTable;
-        friend class std::allocator<TRow>; // for emplace_back()
 
         // header row ctor
         explicit TRow(const TVector<TString>& columnNames) {
@@ -91,7 +90,7 @@ public:
         , Config(config)
     {
         if (Config.Header) {
-            Rows.emplace_back(columnNames);
+            Rows.emplace_back(TRow{columnNames});
         }
     }
 


### PR DESCRIPTION

### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

class TPrettyTable: improve compliance with the C++20 standard.

### Changelog category <!-- remove all except one -->

* Improvement 

### Description for reviewers <!-- (optional) description for those who read this PR -->

Declaring `std::allocator` as a friend was never guaranteed to work. Even if it worked on some implementations, the standard did not promise that the implementation would not be altered in a way that would cause the code to fail. And now, due to changes made to `std::allocator_traits` in C++20, it is just wrong, since `std::allocator` no longer creates objects and doesn't even have a `construct` method.

For example, this code cannot be compiled with the modern version of libc++ STL library. See list of build errors: https://nda.ya.ru/t/ne-kn2lx7Cy2fS