### PR TITLE
TLI system views

### DIFF
--- a/ydb/core/protos/sys_view.proto
+++ b/ydb/core/protos/sys_view.proto
@@ -47,6 +47,10 @@ message TPartitionStats {
 
     optional uint64 ByKeyFilterSize = 21;
     optional uint32 FollowerId = 22;
+
+    optional uint64 LocksAcquired = 23;
+    optional uint64 LocksWholeShard = 24;
+    optional uint64 LocksBroken = 25;
 }
 
 message TPartitionStatsResult {
@@ -133,8 +137,10 @@ enum EStatsType {
     METRICS_ONE_HOUR = 8;
     TOP_REQUEST_UNITS_ONE_MINUTE = 9;
     TOP_REQUEST_UNITS_ONE_HOUR = 10;
-    TOP_PARTITIONS_ONE_MINUTE = 11;
-    TOP_PARTITIONS_ONE_HOUR = 12;
+    TOP_PARTITIONS_BY_CPU_ONE_MINUTE = 11;
+    TOP_PARTITIONS_BY_CPU_ONE_HOUR = 12;
+    TOP_PARTITIONS_BY_TLI_ONE_MINUTE = 13;
+    TOP_PARTITIONS_BY_TLI_ONE_HOUR = 14;
 }
 
 message TEvGetQueryStats {
@@ -608,6 +614,9 @@ message TTopPartitionsInfo {
     optional uint64 IndexSize = 8;
     optional uint32 InFlightTxCount = 9;
     optional uint32 FollowerId = 10;
+    optional uint64 LocksAcquired = 11;
+    optional uint64 LocksWholeShard = 12;
+    optional uint64 LocksBroken = 13;
 }
 
 message TTopPartitionsEntry {
@@ -634,6 +643,7 @@ message TEvGetTopPartitionsResponse {
 
 // partitions stats collector -> SVP
 message TEvSendTopPartitions {
-    repeated TTopPartitionsInfo Partitions = 1;
+    repeated TTopPartitionsInfo PartitionsByCpu = 1;
+    repeated TTopPartitionsInfo PartitionsByTli = 3;
     optional uint64 TimeUs = 2;
 }

--- a/ydb/core/sys_view/common/schema.cpp
+++ b/ydb/core/sys_view/common/schema.cpp
@@ -291,8 +291,10 @@ private:
         RegisterColumnTableSystemView<Schema::PrimaryIndexGranuleStats>(TablePrimaryIndexGranuleStatsName);
         RegisterColumnTableSystemView<Schema::PrimaryIndexOptimizerStats>(TablePrimaryIndexOptimizerStatsName);
 
-        RegisterSystemView<Schema::TopPartitions>(TopPartitions1MinuteName);
-        RegisterSystemView<Schema::TopPartitions>(TopPartitions1HourName);
+        RegisterSystemView<Schema::TopPartitions>(TopPartitionsByCpu1MinuteName);
+        RegisterSystemView<Schema::TopPartitions>(TopPartitionsByCpu1HourName);
+        RegisterSystemView<Schema::TopPartitionsTli>(TopPartitionsByTli1MinuteName);
+        RegisterSystemView<Schema::TopPartitionsTli>(TopPartitionsByTli1HourName);
 
         RegisterPgTablesSystemViews();
 

--- a/ydb/core/sys_view/common/schema.h
+++ b/ydb/core/sys_view/common/schema.h
@@ -43,8 +43,11 @@ constexpr TStringBuf TablePrimaryIndexPortionStatsName = "primary_index_portion_
 constexpr TStringBuf TablePrimaryIndexGranuleStatsName = "primary_index_granule_stats";
 constexpr TStringBuf TablePrimaryIndexOptimizerStatsName = "primary_index_optimizer_stats";
 
-constexpr TStringBuf TopPartitions1MinuteName = "top_partitions_one_minute";
-constexpr TStringBuf TopPartitions1HourName = "top_partitions_one_hour";
+constexpr TStringBuf TopPartitionsByCpu1MinuteName = "top_partitions_one_minute";
+constexpr TStringBuf TopPartitionsByCpu1HourName = "top_partitions_one_hour";
+
+constexpr TStringBuf TopPartitionsByTli1MinuteName = "top_partitions_by_tli_one_minute";
+constexpr TStringBuf TopPartitionsByTli1HourName = "top_partitions_by_tli_one_hour";
 
 constexpr TStringBuf PgTablesName = "pg_tables";
 constexpr TStringBuf InformationSchemaTablesName = "tables";
@@ -93,6 +96,9 @@ struct Schema : NIceDb::Schema {
         struct LastTtlRowsProcessed : Column<25, NScheme::NTypeIds::Uint64> {};
         struct LastTtlRowsErased    : Column<26, NScheme::NTypeIds::Uint64> {};
         struct FollowerId           : Column<27, NScheme::NTypeIds::Uint32> {};
+        struct LocksAcquired        : Column<28, NScheme::NTypeIds::Uint64> {};
+        struct LocksWholeShard      : Column<29, NScheme::NTypeIds::Uint64> {};
+        struct LocksBroken          : Column<30, NScheme::NTypeIds::Uint64> {};
 
         using TKey = TableKey<OwnerId, PathId, PartIdx, FollowerId>;
         using TColumns = TableColumns<
@@ -122,7 +128,11 @@ struct Schema : NIceDb::Schema {
             LastTtlRunTime,
             LastTtlRowsProcessed,
             LastTtlRowsErased,
-            FollowerId>;
+            FollowerId,
+            LocksAcquired,
+            LocksWholeShard,
+            LocksBroken
+            >;
     };
 
     struct Nodes : Table<2> {
@@ -756,6 +766,36 @@ struct Schema : NIceDb::Schema {
             TotalCpuLimitPercentPerNode,
             QueryCpuLimitPercentPerNode,
             QueryMemoryLimitPercentPerNode>;
+    };
+
+    struct TopPartitionsTli : Table<23> {
+        struct IntervalEnd     : Column<1, NScheme::NTypeIds::Timestamp> {};
+        struct Rank            : Column<2, NScheme::NTypeIds::Uint32> {};
+        struct TabletId        : Column<3, NScheme::NTypeIds::Uint64> {};
+        struct Path            : Column<4, NScheme::NTypeIds::Utf8> {};
+        struct LocksAcquired   : Column<5, NScheme::NTypeIds::Uint64> {};
+        struct LocksWholeShard : Column<6, NScheme::NTypeIds::Uint64> {};
+        struct LocksBroken     : Column<7, NScheme::NTypeIds::Uint64> {};
+        struct NodeId          : Column<8, NScheme::NTypeIds::Uint32> {};
+        struct DataSize        : Column<9, NScheme::NTypeIds::Uint64> {};
+        struct RowCount        : Column<10, NScheme::NTypeIds::Uint64> {};
+        struct IndexSize       : Column<11, NScheme::NTypeIds::Uint64> {};
+        struct FollowerId      : Column<12, NScheme::NTypeIds::Uint32> {};
+
+        using TKey = TableKey<IntervalEnd, Rank>;
+        using TColumns = TableColumns<
+            IntervalEnd,
+            Rank,
+            TabletId,
+            Path,
+            LocksAcquired,
+            LocksWholeShard,
+            LocksBroken,
+            NodeId,
+            DataSize,
+            RowCount,
+            IndexSize,
+            FollowerId>;
     };
 };
 

--- a/ydb/core/sys_view/partition_stats/partition_stats.cpp
+++ b/ydb/core/sys_view/partition_stats/partition_stats.cpp
@@ -32,7 +32,8 @@ public:
         SVLOG_D("NSysView::TPartitionStatsCollector bootstrapped");
 
         if (AppData()->UsePartitionStatsCollectorForTests) {
-            OverloadedPartitionBound = 0.0;
+            OverloadedByCpuPartitionBound = 0.0;
+            OverloadedByTliPartitionBound = 0;
             ProcessOverloadedInterval = TDuration::Seconds(1);
         }
 
@@ -88,7 +89,7 @@ private:
 
             auto& oldPartitions = table.Partitions;
             std::unordered_map<TShardIdx, TPartitionStats> newPartitions;
-            std::set<TOverloadedFollower> overloaded;
+            std::set<TFollowerStats> overloadedByCpu, overloadedByTli;
 
             for (auto shardIdx : ev->Get()->ShardIndices) {
                 auto old = oldPartitions.find(shardIdx);
@@ -96,17 +97,24 @@ private:
                     newPartitions[shardIdx] = old->second;
 
                     for (const auto& followerStat: old->second.FollowerStats) {
-                        if (IsPartitionOverloaded(followerStat.second))
-                            overloaded.insert({shardIdx, followerStat.first});
+                        if (IsPartitionOverloadedByCpu(followerStat.second))
+                            overloadedByCpu.insert({shardIdx, followerStat.first});
+                        if (IsPartitionOverloadedByTli(followerStat.second))
+                            overloadedByTli.insert({shardIdx, followerStat.first});
                     }
                 }
             }
 
-            if (!overloaded.empty()) {
-                tables.Overloaded[pathId].swap(overloaded);
+            if (!overloadedByCpu.empty()) {
+                tables.OverloadedByCpu[pathId].swap(overloadedByCpu);
             } else {
-                tables.Overloaded.erase(pathId);
+                tables.OverloadedByCpu.erase(pathId);
             }
+            if (!overloadedByTli.empty()) {
+                tables.OverloadedByTli[pathId].swap(overloadedByTli);
+            } else {
+                tables.OverloadedByTli.erase(pathId);
+            }            
 
             oldPartitions.swap(newPartitions);
             table.ShardIndices.swap(ev->Get()->ShardIndices);
@@ -125,7 +133,8 @@ private:
 
         auto& tables = DomainTables[domainKey];
         tables.Stats.erase(pathId);
-        tables.Overloaded.erase(pathId);
+        tables.OverloadedByCpu.erase(pathId);
+        tables.OverloadedByTli.erase(pathId);
     }
 
     void Handle(TEvSysView::TEvSendPartitionStats::TPtr& ev) {
@@ -153,18 +162,29 @@ private:
 
         auto& followerStats = partitionStats.FollowerStats[followerId];
 
-        TOverloadedFollower overloadedFollower = {shardIdx, followerId};
-        if (IsPartitionOverloaded(newStats)) {
-            tables.Overloaded[pathId].insert(overloadedFollower);
+        TFollowerStats overloadedFollower = {shardIdx, followerId};
+        if (IsPartitionOverloadedByCpu(newStats)) {
+            tables.OverloadedByCpu[pathId].insert(overloadedFollower);
         } else {
-            auto overloadedFound = tables.Overloaded.find(pathId);
-            if (overloadedFound != tables.Overloaded.end()) {
+            auto overloadedFound = tables.OverloadedByCpu.find(pathId);
+            if (overloadedFound != tables.OverloadedByCpu.end()) {
                 overloadedFound->second.erase(overloadedFollower);
                 if (overloadedFound->second.empty()) {
-                    tables.Overloaded.erase(pathId);
+                    tables.OverloadedByCpu.erase(pathId);
                 }
             }
         }
+        if (IsPartitionOverloadedByTli(newStats)) {
+            tables.OverloadedByTli[pathId].insert(overloadedFollower);
+        } else {
+            auto overloadedFound = tables.OverloadedByTli.find(pathId);
+            if (overloadedFound != tables.OverloadedByTli.end()) {
+                overloadedFound->second.erase(overloadedFollower);
+                if (overloadedFound->second.empty()) {
+                    tables.OverloadedByTli.erase(pathId);
+                }
+            }
+        }        
 
         if (followerStats.HasTtlStats()) {
             newStats.MutableTtlStats()->Swap(followerStats.MutableTtlStats());
@@ -396,37 +416,54 @@ private:
         }
         auto& domainTables = domainFound->second;
 
-        struct TPartition {
+        struct TPartitionByCpu {
             TPathId PathId;
             TShardIdx ShardIdx;
             ui32 FollowerId;
             double CPUCores;
         };
-        std::vector<TPartition> sorted;
+        std::vector<TPartitionByCpu> sortedByCpu;
 
-        for (const auto& [pathId, overloadedFollowers] : domainTables.Overloaded) {
-            for (const TOverloadedFollower& overloadedFollower : overloadedFollowers) {
+        struct TPartitionByTli {
+            TPathId PathId;
+            TShardIdx ShardIdx;
+            ui32 FollowerId;
+            ui64 LocksBroken;
+        };
+        std::vector<TPartitionByTli> sortedByTli;        
+
+        for (const auto& [pathId, overloadedFollowers] : domainTables.OverloadedByCpu) {
+            for (const TFollowerStats& overloadedFollower : overloadedFollowers) {
                 const auto& table = domainTables.Stats[pathId];
                 const auto& partition = table.Partitions.at(overloadedFollower.ShardIdx).FollowerStats.at(overloadedFollower.FollowerId);
-                sorted.emplace_back(TPartition{pathId, overloadedFollower.ShardIdx, overloadedFollower.FollowerId, partition.GetCPUCores()});
+                sortedByCpu.emplace_back(TPartitionByCpu{pathId, overloadedFollower.ShardIdx, overloadedFollower.FollowerId, partition.GetCPUCores()});
             }
         }
+        for (const auto& [pathId, overloadedFollowers] : domainTables.OverloadedByTli) {
+            for (const TFollowerStats& overloadedFollower : overloadedFollowers) {
+                const auto& table = domainTables.Stats[pathId];
+                const auto& partition = table.Partitions.at(overloadedFollower.ShardIdx).FollowerStats.at(overloadedFollower.FollowerId);
+                sortedByTli.emplace_back(TPartitionByTli{pathId, overloadedFollower.ShardIdx, overloadedFollower.FollowerId, partition.GetLocksBroken()});
+            }
+        }        
 
-        std::sort(sorted.begin(), sorted.end(),
+        std::sort(sortedByCpu.begin(), sortedByCpu.end(),
             [] (const auto& l, const auto& r) { return l.CPUCores > r.CPUCores; });
+        std::sort(sortedByTli.begin(), sortedByTli.end(),
+            [] (const auto& l, const auto& r) { return l.LocksBroken > r.LocksBroken; });
 
         auto now = TActivationContext::Now();
         auto nowUs = now.MicroSeconds();
 
         size_t count = 0;
         auto sendEvent = MakeHolder<TEvSysView::TEvSendTopPartitions>();
-        for (const auto& entry : sorted) {
+        for (const auto& entry : sortedByCpu) {
             const auto& table = domainTables.Stats[entry.PathId];
             const auto& followerStats = table.Partitions.at(entry.ShardIdx).FollowerStats;
             const auto& partition = followerStats.at(entry.FollowerId);
             const auto& leaderPartition = followerStats.at(0);
 
-            auto* result = sendEvent->Record.AddPartitions();
+            auto* result = sendEvent->Record.AddPartitionsByCpu();
             result->SetTabletId(partition.GetTabletId());
             result->SetPath(table.Path);
             result->SetPeakTimeUs(nowUs);
@@ -442,11 +479,34 @@ private:
                 break;
             }
         }
+        for (const auto& entry : sortedByTli) {
+            const auto& table = domainTables.Stats[entry.PathId];
+            const auto& followerStats = table.Partitions.at(entry.ShardIdx).FollowerStats;
+            const auto& partition = followerStats.at(entry.FollowerId);
+            const auto& leaderPartition = followerStats.at(0);
+
+            auto* result = sendEvent->Record.AddPartitionsByTli();
+            result->SetTabletId(partition.GetTabletId());
+            result->SetPath(table.Path);
+            result->SetLocksAcquired(partition.GetLocksAcquired());
+            result->SetLocksWholeShard(partition.GetLocksWholeShard());
+            result->SetLocksBroken(partition.GetLocksBroken());
+            result->SetNodeId(partition.GetNodeId());
+            result->SetDataSize(leaderPartition.GetDataSize());
+            result->SetRowCount(leaderPartition.GetRowCount());
+            result->SetIndexSize(leaderPartition.GetIndexSize());
+            result->SetFollowerId(partition.GetFollowerId());
+
+            if (++count == TOP_PARTITIONS_COUNT) {
+                break;
+            }
+        }        
 
         sendEvent->Record.SetTimeUs(nowUs);
 
         SVLOG_D("NSysView::TPartitionStatsCollector: TEvProcessOverloaded "
-            << "top size# " << sorted.size()
+            << ", top size by CPU # " << sortedByCpu.size()
+            << ", top size by TLI # " << sortedByTli.size()
             << ", time# " << now);
 
         Send(MakePipePerNodeCacheID(false),
@@ -467,8 +527,11 @@ private:
         TBase::PassAway();
     }
 
-    bool IsPartitionOverloaded(const NKikimrSysView::TPartitionStats& stats) const {
-        return stats.GetCPUCores() >= OverloadedPartitionBound;
+    bool IsPartitionOverloadedByCpu(const NKikimrSysView::TPartitionStats& stats) const {
+        return stats.GetCPUCores() >= OverloadedByCpuPartitionBound;
+    }
+    bool IsPartitionOverloadedByTli(const NKikimrSysView::TPartitionStats& stats) const {
+        return stats.GetLocksBroken() >= OverloadedByTliPartitionBound;
     }
 
 private:
@@ -478,7 +541,8 @@ private:
     TPathId DomainKey;
     ui64 SysViewProcessorId = 0;
 
-    double OverloadedPartitionBound = 0.7;
+    double OverloadedByCpuPartitionBound = 0.7;
+    ui64 OverloadedByTliPartitionBound = 1;
     TDuration ProcessOverloadedInterval = TDuration::Seconds(15);
 
     typedef ui32 TFollowerId;
@@ -493,22 +557,23 @@ private:
         TString Path;
     };
 
-    struct TOverloadedFollower {
+    struct TFollowerStats {
         TShardIdx ShardIdx;
         TFollowerId FollowerId;
 
-        bool operator<(const TOverloadedFollower &other) const {
+        bool operator<(const TFollowerStats &other) const {
             return std::tie(ShardIdx, FollowerId) < std::tie(other.ShardIdx, other.FollowerId);
         }
 
-        bool operator==(const TOverloadedFollower &other) const {
+        bool operator==(const TFollowerStats &other) const {
             return std::tie(ShardIdx, FollowerId) == std::tie(other.ShardIdx, other.FollowerId);
         }
     };
 
     struct TDomainTables {
         std::map<TPathId, TTableStats> Stats;
-        std::unordered_map<TPathId, std::set<TOverloadedFollower>> Overloaded;
+        std::unordered_map<TPathId, std::set<TFollowerStats>> OverloadedByCpu;
+        std::unordered_map<TPathId, std::set<TFollowerStats>> OverloadedByTli;
     };
     std::unordered_map<TPathId, TDomainTables> DomainTables;
 
@@ -713,6 +778,15 @@ private:
                 }});
                 insert({TSchema::FollowerId::ColumnId, [] (const TPartitionStatsResult&, const TPartitionStats&, const TPartitionStats& stats) {
                     return TCell::Make<ui32>(stats.GetFollowerId());
+                }});
+                insert({TSchema::LocksAcquired::ColumnId, [] (const TPartitionStatsResult&, const TPartitionStats&, const TPartitionStats& stats) {
+                    return TCell::Make<ui64>(stats.GetLocksAcquired());
+                }});
+                insert({TSchema::LocksWholeShard::ColumnId, [] (const TPartitionStatsResult&, const TPartitionStats&, const TPartitionStats& stats) {
+                    return TCell::Make<ui64>(stats.GetLocksWholeShard());
+                }});
+                insert({TSchema::LocksBroken::ColumnId, [] (const TPartitionStatsResult&, const TPartitionStats&, const TPartitionStats& stats) {
+                    return TCell::Make<ui64>(stats.GetLocksBroken());
                 }});
             }
         };

--- a/ydb/core/sys_view/partition_stats/top_partitions.cpp
+++ b/ydb/core/sys_view/partition_stats/top_partitions.cpp
@@ -17,13 +17,13 @@ void SetField<1>(NKikimrSysView::TTopPartitionsKey& key, ui32 value) {
     key.SetRank(value);
 }
 
-struct TTopPartitionsExtractorMap :
+struct TTopPartitionsByCpuExtractorMap :
     public std::unordered_map<NTable::TTag, TExtractorFunc<NKikimrSysView::TTopPartitionsEntry>>
 {
     using S = Schema::TopPartitions;
     using E = NKikimrSysView::TTopPartitionsEntry;
 
-    TTopPartitionsExtractorMap() {
+    TTopPartitionsByCpuExtractorMap() {
         insert({S::IntervalEnd::ColumnId, [] (const E& entry) {
             return TCell::Make<ui64>(entry.GetKey().GetIntervalEndUs());
         }});
@@ -64,31 +64,101 @@ struct TTopPartitionsExtractorMap :
     }
 };
 
-THolder<NActors::IActor> CreateTopPartitionsScan(const NActors::TActorId& ownerId, ui32 scanId, const TTableId& tableId,
+struct TTopPartitionsByTliExtractorMap :
+    public std::unordered_map<NTable::TTag, TExtractorFunc<NKikimrSysView::TTopPartitionsEntry>>
+{
+    using S = Schema::TopPartitionsTli;
+    using E = NKikimrSysView::TTopPartitionsEntry;
+
+    TTopPartitionsByTliExtractorMap() {
+        insert({S::IntervalEnd::ColumnId, [] (const E& entry) {
+            return TCell::Make<ui64>(entry.GetKey().GetIntervalEndUs());
+        }});
+        insert({S::Rank::ColumnId, [] (const E& entry) {
+            return TCell::Make<ui32>(entry.GetKey().GetRank());
+        }});
+        insert({S::TabletId::ColumnId, [] (const E& entry) {
+            return TCell::Make<ui64>(entry.GetInfo().GetTabletId());
+        }});
+        insert({S::Path::ColumnId, [] (const E& entry) {
+            const auto& text = entry.GetInfo().GetPath();
+            return TCell(text.data(), text.size());
+        }});
+        insert({S::LocksAcquired::ColumnId, [] (const E& entry) {
+            return TCell::Make<ui64>(entry.GetInfo().GetLocksAcquired());
+        }});
+        insert({S::LocksWholeShard::ColumnId, [] (const E& entry) {
+            return TCell::Make<ui64>(entry.GetInfo().GetLocksWholeShard());
+        }});
+        insert({S::LocksBroken::ColumnId, [] (const E& entry) {
+            return TCell::Make<ui64>(entry.GetInfo().GetLocksBroken());
+        }});
+        insert({S::NodeId::ColumnId, [] (const E& entry) {
+            return TCell::Make<ui32>(entry.GetInfo().GetNodeId());
+        }});
+        insert({S::DataSize::ColumnId, [] (const E& entry) {
+            return TCell::Make<ui64>(entry.GetInfo().GetDataSize());
+        }});
+        insert({S::RowCount::ColumnId, [] (const E& entry) {
+            return TCell::Make<ui64>(entry.GetInfo().GetRowCount());
+        }});
+        insert({S::IndexSize::ColumnId, [] (const E& entry) {
+            return TCell::Make<ui64>(entry.GetInfo().GetIndexSize());
+        }});
+        insert({S::FollowerId::ColumnId, [] (const E& entry) {
+            return TCell::Make<ui32>(entry.GetInfo().GetFollowerId());
+        }});        
+    }
+};
+
+THolder<NActors::IActor> CreateTopPartitionsByCpuScan(const NActors::TActorId& ownerId, ui32 scanId, const TTableId& tableId,
     const TTableRange& tableRange, const TArrayRef<NMiniKQL::TKqpComputeContextBase::TColumn>& columns)
 {
-    using TTopPartitionsScan = TProcessorScan<
+    using TTopPartitionsByCpuScan = TProcessorScan<
         NKikimrSysView::TTopPartitionsEntry,
         NKikimrSysView::TEvGetTopPartitionsRequest,
         NKikimrSysView::TEvGetTopPartitionsResponse,
         TEvSysView::TEvGetTopPartitionsRequest,
         TEvSysView::TEvGetTopPartitionsResponse,
-        TTopPartitionsExtractorMap,
+        TTopPartitionsByCpuExtractorMap,
         ui64,
         ui32
     >;
 
-    auto viewName = tableId.SysViewInfo;
+    static const std::map<TStringBuf, NKikimrSysView::EStatsType> nameToStatus = {
+        {TopPartitionsByCpu1MinuteName, NKikimrSysView::TOP_PARTITIONS_BY_CPU_ONE_MINUTE},
+        {TopPartitionsByCpu1HourName, NKikimrSysView::TOP_PARTITIONS_BY_CPU_ONE_HOUR},
+    };
 
-    if (viewName == TopPartitions1MinuteName) {
-        return MakeHolder<TTopPartitionsScan>(ownerId, scanId, tableId, tableRange, columns,
-            NKikimrSysView::TOP_PARTITIONS_ONE_MINUTE);
+    auto statusIter = nameToStatus.find(tableId.SysViewInfo.ConstRef());
+    Y_ABORT_UNLESS(statusIter != nameToStatus.end());
 
-    } else if (viewName == TopPartitions1HourName) {
-        return MakeHolder<TTopPartitionsScan>(ownerId, scanId, tableId, tableRange, columns,
-            NKikimrSysView::TOP_PARTITIONS_ONE_HOUR);
-    }
-    return {};
+    return MakeHolder<TTopPartitionsByCpuScan>(ownerId, scanId, tableId, tableRange, columns, statusIter->second);
+}
+
+THolder<NActors::IActor> CreateTopPartitionsByTliScan(const NActors::TActorId& ownerId, ui32 scanId, const TTableId& tableId,
+    const TTableRange& tableRange, const TArrayRef<NMiniKQL::TKqpComputeContextBase::TColumn>& columns)
+{
+    using TTopPartitionsByTliScan = TProcessorScan<
+        NKikimrSysView::TTopPartitionsEntry,
+        NKikimrSysView::TEvGetTopPartitionsRequest,
+        NKikimrSysView::TEvGetTopPartitionsResponse,
+        TEvSysView::TEvGetTopPartitionsRequest,
+        TEvSysView::TEvGetTopPartitionsResponse,
+        TTopPartitionsByTliExtractorMap,
+        ui64,
+        ui32
+    >;
+
+    static const std::map<TStringBuf, NKikimrSysView::EStatsType> nameToStatus = {
+        {TopPartitionsByTli1MinuteName, NKikimrSysView::TOP_PARTITIONS_BY_TLI_ONE_MINUTE},
+        {TopPartitionsByTli1HourName, NKikimrSysView::TOP_PARTITIONS_BY_TLI_ONE_HOUR},
+    };
+
+    auto statusIter = nameToStatus.find(tableId.SysViewInfo.ConstRef());
+    Y_ABORT_UNLESS(statusIter != nameToStatus.end());
+
+    return MakeHolder<TTopPartitionsByTliScan>(ownerId, scanId, tableId, tableRange, columns, statusIter->second);
 }
 
 } // NKikimr::NSysView

--- a/ydb/core/sys_view/partition_stats/top_partitions.h
+++ b/ydb/core/sys_view/partition_stats/top_partitions.h
@@ -7,8 +7,11 @@
 
 namespace NKikimr::NSysView {
 
-THolder<NActors::IActor> CreateTopPartitionsScan(const NActors::TActorId& ownerId, ui32 scanId,
+THolder<NActors::IActor> CreateTopPartitionsByCpuScan(const NActors::TActorId& ownerId, ui32 scanId,
     const TTableId& tableId, const TTableRange& tableRange,
     const TArrayRef<NMiniKQL::TKqpComputeContextBase::TColumn>& columns);
 
+THolder<NActors::IActor> CreateTopPartitionsByTliScan(const NActors::TActorId& ownerId, ui32 scanId,
+    const TTableId& tableId, const TTableRange& tableRange,
+    const TArrayRef<NMiniKQL::TKqpComputeContextBase::TColumn>& columns);    
 } // NKikimr::NSysView

--- a/ydb/core/sys_view/processor/processor_impl.cpp
+++ b/ydb/core/sys_view/processor/processor_impl.cpp
@@ -186,12 +186,16 @@ void TSysViewProcessor::PersistPartitionResults(NIceDb::TNiceDb& db) {
     auto intervalEnd = IntervalEnd + TotalInterval;
 
     PersistPartitionTopResults<Schema::TopPartitionsOneMinute>(
-        db, PartitionTopMinute, TopPartitionsOneMinute, intervalEnd);
+        db, PartitionTopByCpuMinute, TopPartitionsByCpuOneMinute, intervalEnd);
+    PersistPartitionTopResults<Schema::TopPartitionsByTliOneMinute>(
+        db, PartitionTopByTliMinute, TopPartitionsByTliOneMinute, intervalEnd);
 
     auto hourEnd = EndOfHourInterval(intervalEnd);
 
     PersistPartitionTopResults<Schema::TopPartitionsOneHour>(
-        db, PartitionTopHour, TopPartitionsOneHour, hourEnd);
+        db, PartitionTopByCpuHour, TopPartitionsByCpuOneHour, hourEnd);
+    PersistPartitionTopResults<Schema::TopPartitionsByTliOneHour>(
+        db, PartitionTopByTliHour, TopPartitionsByTliOneHour, hourEnd);
 }
 
 void TSysViewProcessor::ScheduleAggregate() {
@@ -296,7 +300,8 @@ void TSysViewProcessor::Reset(NIceDb::TNiceDb& db, const TActorContext& ctx) {
     clearQueryTop(NKikimrSysView::TOP_CPU_TIME_ONE_MINUTE, ByCpuTimeMinute);
     clearQueryTop(NKikimrSysView::TOP_REQUEST_UNITS_ONE_MINUTE, ByRequestUnitsMinute);
 
-    clearPartitionTop(NKikimrSysView::TOP_PARTITIONS_ONE_MINUTE, PartitionTopMinute);
+    clearPartitionTop(NKikimrSysView::TOP_PARTITIONS_BY_CPU_ONE_MINUTE, PartitionTopByCpuMinute);
+    clearPartitionTop(NKikimrSysView::TOP_PARTITIONS_BY_TLI_ONE_MINUTE, PartitionTopByTliMinute);
 
     CurrentStage = COLLECT;
     PersistStage(db);
@@ -321,7 +326,8 @@ void TSysViewProcessor::Reset(NIceDb::TNiceDb& db, const TActorContext& ctx) {
     }
 
     if (partitionOldHourEnd != partitionNewHourEnd) {
-        clearPartitionTop(NKikimrSysView::TOP_PARTITIONS_ONE_HOUR, PartitionTopHour);
+        clearPartitionTop(NKikimrSysView::TOP_PARTITIONS_BY_CPU_ONE_HOUR, PartitionTopByCpuHour);
+        clearPartitionTop(NKikimrSysView::TOP_PARTITIONS_BY_TLI_ONE_HOUR, PartitionTopByTliHour);
     }
 
     SVLOG_D("[" << TabletID() << "] Reset: interval end# " << IntervalEnd);
@@ -341,8 +347,10 @@ void TSysViewProcessor::Reset(NIceDb::TNiceDb& db, const TActorContext& ctx) {
     CutHistory<Schema::TopByRequestUnitsOneMinute>(db, TopByRequestUnitsOneMinute, minuteHistorySize);
     CutHistory<Schema::TopByRequestUnitsOneHour>(db, TopByRequestUnitsOneHour, hourHistorySize);
 
-    CutHistory<Schema::TopPartitionsOneMinute>(db, TopPartitionsOneMinute, minuteHistorySize);
-    CutHistory<Schema::TopPartitionsOneHour>(db, TopPartitionsOneHour, hourHistorySize);
+    CutHistory<Schema::TopPartitionsOneMinute>(db, TopPartitionsByCpuOneMinute, minuteHistorySize);
+    CutHistory<Schema::TopPartitionsOneHour>(db, TopPartitionsByCpuOneHour, hourHistorySize);
+    CutHistory<Schema::TopPartitionsByTliOneMinute>(db, TopPartitionsByTliOneMinute, minuteHistorySize);
+    CutHistory<Schema::TopPartitionsByTliOneHour>(db, TopPartitionsByTliOneHour, hourHistorySize);
 }
 
 void TSysViewProcessor::SendRequests() {
@@ -506,11 +514,17 @@ void TSysViewProcessor::Reply(typename TRequest::TPtr& ev) {
     TMap* entries = nullptr;
     if constexpr (std::is_same<TEntry, NKikimrSysView::TTopPartitionsInfo>::value) {
         switch (record.GetType()) {
-            case NKikimrSysView::TOP_PARTITIONS_ONE_MINUTE:
-                entries = &TopPartitionsOneMinute;
+            case NKikimrSysView::TOP_PARTITIONS_BY_CPU_ONE_MINUTE:
+                entries = &TopPartitionsByCpuOneMinute;
                 break;
-            case NKikimrSysView::TOP_PARTITIONS_ONE_HOUR:
-                entries = &TopPartitionsOneHour;
+            case NKikimrSysView::TOP_PARTITIONS_BY_CPU_ONE_HOUR:
+                entries = &TopPartitionsByCpuOneHour;
+                break;
+            case NKikimrSysView::TOP_PARTITIONS_BY_TLI_ONE_MINUTE:
+                entries = &TopPartitionsByTliOneMinute;
+                break;
+            case NKikimrSysView::TOP_PARTITIONS_BY_TLI_ONE_HOUR:
+                entries = &TopPartitionsByTliOneHour;
                 break;
             default:
                 SVLOG_CRIT("[" << TabletID() << "] unexpected stats type: " << (size_t)record.GetType());
@@ -767,10 +781,14 @@ bool TSysViewProcessor::OnRenderAppHtmlPage(NMon::TEvRemoteHttpInfo::TPtr ev,
                     << "  Count: " << TopByRequestUnitsOneMinute.size() << Endl << Endl;
                 str << "TopByRequestUnitsOneHour" << Endl
                     << "  Count: " << TopByRequestUnitsOneHour.size() << Endl << Endl;
-                str << "TopPartitionsOneMinute" << Endl
-                    << "  Count: " << TopPartitionsOneMinute.size() << Endl << Endl;
-                str << "TopPartitionsOneHour" << Endl
-                    << "  Count: " << TopPartitionsOneHour.size() << Endl << Endl;
+                str << "TopPartitionsByCpuOneMinute" << Endl
+                    << "  Count: " << TopPartitionsByCpuOneMinute.size() << Endl << Endl;
+                str << "TopPartitionsByCpuOneHour" << Endl
+                    << "  Count: " << TopPartitionsByCpuOneHour.size() << Endl << Endl;
+                str << "TopPartitionsByTliOneMinute" << Endl
+                    << "  Count: " << TopPartitionsByTliOneMinute.size() << Endl << Endl;
+                str << "TopPartitionsByTliOneHour" << Endl
+                    << "  Count: " << TopPartitionsByTliOneHour.size() << Endl << Endl;
             }
         }
     }

--- a/ydb/core/sys_view/processor/processor_impl.h
+++ b/ydb/core/sys_view/processor/processor_impl.h
@@ -336,12 +336,16 @@ private:
     TResultStatsMap TopByRequestUnitsOneHour;
 
     // IntervalPartitionTops
-    TPartitionTop PartitionTopMinute;
-    TPartitionTop PartitionTopHour;
+    TPartitionTop PartitionTopByCpuMinute;
+    TPartitionTop PartitionTopByCpuHour;
+    TPartitionTop PartitionTopByTliMinute;
+    TPartitionTop PartitionTopByTliHour;
 
     // TopPartitions...
-    TResultPartitionsMap TopPartitionsOneMinute;
-    TResultPartitionsMap TopPartitionsOneHour;
+    TResultPartitionsMap TopPartitionsByCpuOneMinute;
+    TResultPartitionsMap TopPartitionsByCpuOneHour;
+    TResultPartitionsMap TopPartitionsByTliOneMinute;
+    TResultPartitionsMap TopPartitionsByTliOneHour;
 
     // limited queue of user requests
     static constexpr size_t PendingRequestsLimit = 5;

--- a/ydb/core/sys_view/processor/schema.h
+++ b/ydb/core/sys_view/processor/schema.h
@@ -119,6 +119,8 @@ struct TProcessorSchema : NIceDb::Schema {
 
     RESULT_PARTITION_TABLE(TopPartitionsOneMinute, 17)
     RESULT_PARTITION_TABLE(TopPartitionsOneHour, 18)
+    RESULT_PARTITION_TABLE(TopPartitionsByTliOneMinute, 20)
+    RESULT_PARTITION_TABLE(TopPartitionsByTliOneHour, 21)
 
 #undef RESULT_PARTITION_TABLE
 
@@ -141,7 +143,9 @@ struct TProcessorSchema : NIceDb::Schema {
         IntervalPartitionTops,
         IntervalPartitionFollowerTops,
         TopPartitionsOneMinute,
-        TopPartitionsOneHour
+        TopPartitionsOneHour,
+        TopPartitionsByTliOneMinute,
+        TopPartitionsByTliOneHour
     >;
 
     using TSettings = SchemaSettings<

--- a/ydb/core/sys_view/processor/tx_init.cpp
+++ b/ydb/core/sys_view/processor/tx_init.cpp
@@ -458,8 +458,8 @@ struct TSysViewProcessor::TTxInit : public TTxBase {
             std::sort(Self->PartitionTopByCpuHour.begin(), Self->PartitionTopByCpuHour.end(), compareByCpu);
 
             auto compareByTli = [] (const auto& l, const auto& r) {
-                return l->GetCPUCores() == r->GetCPUCores() ?
-                    l->GetTabletId() < r->GetTabletId() : l->GetCPUCores() > r->GetCPUCores();
+                return l->GetLocksBroken() == r->GetLocksBroken() ?
+                    l->GetTabletId() < r->GetTabletId() : l->GetLocksBroken() > r->GetLocksBroken();
             };
 
             std::sort(Self->PartitionTopByTliMinute.begin(), Self->PartitionTopByTliMinute.end(), compareByTli);

--- a/ydb/core/sys_view/processor/tx_init.cpp
+++ b/ydb/core/sys_view/processor/tx_init.cpp
@@ -101,11 +101,17 @@ struct TSysViewProcessor::TTxInit : public TTxBase {
                 Y_PROTOBUF_SUPPRESS_NODISCARD partition->ParseFromString(data);
 
                 switch ((NKikimrSysView::EStatsType)type) {
-                    case NKikimrSysView::TOP_PARTITIONS_ONE_MINUTE:
-                        Self->PartitionTopMinute.emplace_back(std::move(partition));
+                    case NKikimrSysView::TOP_PARTITIONS_BY_CPU_ONE_MINUTE:
+                        Self->PartitionTopByCpuMinute.emplace_back(std::move(partition));
                         break;
-                    case NKikimrSysView::TOP_PARTITIONS_ONE_HOUR:
-                        Self->PartitionTopHour.emplace_back(std::move(partition));
+                    case NKikimrSysView::TOP_PARTITIONS_BY_CPU_ONE_HOUR:
+                        Self->PartitionTopByCpuHour.emplace_back(std::move(partition));
+                        break;
+                    case NKikimrSysView::TOP_PARTITIONS_BY_TLI_ONE_MINUTE:
+                        Self->PartitionTopByTliMinute.emplace_back(std::move(partition));
+                        break;
+                    case NKikimrSysView::TOP_PARTITIONS_BY_TLI_ONE_HOUR:
+                        Self->PartitionTopByTliHour.emplace_back(std::move(partition));
                         break;
                     default:
                         SVLOG_CRIT("[" << Self->TabletID() << "] ignoring unexpected partition stats type: " << type);
@@ -428,29 +434,46 @@ struct TSysViewProcessor::TTxInit : public TTxBase {
 
         // IntervalPartitionTops
         {
-            Self->PartitionTopMinute.clear();
-            Self->PartitionTopMinute.reserve(TOP_PARTITIONS_COUNT);
-            Self->PartitionTopHour.clear();
-            Self->PartitionTopHour.reserve(TOP_PARTITIONS_COUNT);
+            Self->PartitionTopByCpuMinute.clear();
+            Self->PartitionTopByCpuMinute.reserve(TOP_PARTITIONS_COUNT);
+            Self->PartitionTopByCpuHour.clear();
+            Self->PartitionTopByCpuHour.reserve(TOP_PARTITIONS_COUNT);
+
+            Self->PartitionTopByTliMinute.clear();
+            Self->PartitionTopByTliMinute.reserve(TOP_PARTITIONS_COUNT);
+            Self->PartitionTopByTliHour.clear();
+            Self->PartitionTopByTliHour.reserve(TOP_PARTITIONS_COUNT);
 
             if (!LoadIntervalPartitionTops<Schema::IntervalPartitionTops>(db))
                 return false;
             if (!LoadIntervalPartitionTops<Schema::IntervalPartitionFollowerTops>(db))
                 return false;
 
-            auto compare = [] (const auto& l, const auto& r) {
+            auto compareByCpu = [] (const auto& l, const auto& r) {
                 return l->GetCPUCores() == r->GetCPUCores() ?
                     l->GetTabletId() < r->GetTabletId() : l->GetCPUCores() > r->GetCPUCores();
             };
 
-            std::sort(Self->PartitionTopMinute.begin(), Self->PartitionTopMinute.end(), compare);
-            std::sort(Self->PartitionTopHour.begin(), Self->PartitionTopHour.end(), compare);
+            std::sort(Self->PartitionTopByCpuMinute.begin(), Self->PartitionTopByCpuMinute.end(), compareByCpu);
+            std::sort(Self->PartitionTopByCpuHour.begin(), Self->PartitionTopByCpuHour.end(), compareByCpu);
+
+            auto compareByTli = [] (const auto& l, const auto& r) {
+                return l->GetCPUCores() == r->GetCPUCores() ?
+                    l->GetTabletId() < r->GetTabletId() : l->GetCPUCores() > r->GetCPUCores();
+            };
+
+            std::sort(Self->PartitionTopByTliMinute.begin(), Self->PartitionTopByTliMinute.end(), compareByTli);
+            std::sort(Self->PartitionTopByTliHour.begin(), Self->PartitionTopByTliHour.end(), compareByTli);
         }
 
         // TopPartitions...
-        if (!LoadPartitionResults<Schema::TopPartitionsOneMinute>(db, Self->TopPartitionsOneMinute))
+        if (!LoadPartitionResults<Schema::TopPartitionsOneMinute>(db, Self->TopPartitionsByCpuOneMinute))
             return false;
-        if (!LoadPartitionResults<Schema::TopPartitionsOneHour>(db, Self->TopPartitionsOneHour))
+        if (!LoadPartitionResults<Schema::TopPartitionsOneHour>(db, Self->TopPartitionsByCpuOneHour))
+            return false;
+        if (!LoadPartitionResults<Schema::TopPartitionsByTliOneMinute>(db, Self->TopPartitionsByTliOneMinute))
+            return false;
+        if (!LoadPartitionResults<Schema::TopPartitionsByTliOneHour>(db, Self->TopPartitionsByTliOneHour))
             return false;
 
         auto deadline = Self->IntervalEnd + Self->TotalInterval;

--- a/ydb/core/sys_view/scan.cpp
+++ b/ydb/core/sys_view/scan.cpp
@@ -243,12 +243,18 @@ THolder<NActors::IActor> CreateSystemViewScan(
         return CreateQueryMetricsScan(ownerId, scanId, tableId, tableRange, columns);
     }
 
-    if (tableId.SysViewInfo == TopPartitions1MinuteName ||
-        tableId.SysViewInfo == TopPartitions1HourName)
+    if (tableId.SysViewInfo == TopPartitionsByCpu1MinuteName ||
+        tableId.SysViewInfo == TopPartitionsByCpu1HourName)
     {
-        return CreateTopPartitionsScan(ownerId, scanId, tableId, tableRange, columns);
+        return CreateTopPartitionsByCpuScan(ownerId, scanId, tableId, tableRange, columns);
     }
 
+    if (tableId.SysViewInfo == TopPartitionsByTli1MinuteName ||
+        tableId.SysViewInfo == TopPartitionsByTli1HourName)
+    {
+        return CreateTopPartitionsByTliScan(ownerId, scanId, tableId, tableRange, columns);
+    }    
+    
     if (tableId.SysViewInfo == PgTablesName) {
         return CreatePgTablesScan(ownerId, scanId, tableId, tablePath, tableRange, columns);
     }

--- a/ydb/core/sys_view/ut_kqp.cpp
+++ b/ydb/core/sys_view/ut_kqp.cpp
@@ -122,6 +122,54 @@ void CreateRootTable(TTestEnv& env, ui64 partitionCount = 1, bool fillTable = fa
     }
 }
 
+void BreakLock(TSession& session, const TString& tableName) {
+    std::optional<TTransaction> tx1;
+
+    {  // tx0: write test data
+        auto result = session.ExecuteDataQuery(TStringBuilder() <<
+            "UPSERT INTO `" << tableName << "` (Key, Value) VALUES (55u, \"Fifty five\")",
+        TTxControl::BeginTx().CommitTx()).ExtractValueSync();
+        UNIT_ASSERT_VALUES_EQUAL_C(result.GetStatus(), EStatus::SUCCESS, result.GetIssues().ToString());
+    }
+
+    {  // tx0: read all data
+        auto result = session.ExecuteDataQuery(TStringBuilder() <<
+            "SELECT * FROM `" << tableName << "`",
+        TTxControl::BeginTx().CommitTx()).ExtractValueSync();
+        UNIT_ASSERT_VALUES_EQUAL_C(result.GetStatus(), EStatus::SUCCESS, result.GetIssues().ToString());
+    }
+
+    while (!tx1) {
+    // tx1: start reading
+        auto result = session.ExecuteDataQuery(TStringBuilder() <<
+            "SELECT * FROM `" << tableName << "` WHERE Key = 55u",
+        TTxControl::BeginTx()).ExtractValueSync();
+        UNIT_ASSERT_VALUES_EQUAL_C(result.GetStatus(), EStatus::SUCCESS, result.GetIssues().ToString());
+        TString yson = FormatResultSetYson(result.GetResultSet(0));
+        if (yson == "[]") {
+            continue;
+        }
+            
+        NKqp::CompareYson(R"([
+            [[55u];["Fifty five"]];
+        ])", yson);
+        tx1 = result.GetTransaction();
+        UNIT_ASSERT(tx1);
+    }
+
+    {  // tx2: write + commit
+        auto result = session.ExecuteDataQuery(TStringBuilder() <<
+            "UPSERT INTO `" << tableName << "` (Key, Value) VALUES (55u, \"NewValue1\")",
+        TTxControl::BeginTx().CommitTx()).ExtractValueSync();
+        UNIT_ASSERT_VALUES_EQUAL_C(result.GetStatus(), EStatus::SUCCESS, result.GetIssues().ToString());
+    }
+
+    {  // tx1: try to commit
+        auto result = tx1->Commit().ExtractValueSync();
+        UNIT_ASSERT_VALUES_EQUAL_C(result.GetStatus(), EStatus::SUCCESS, result.GetIssues().ToString());
+    }   
+}
+
 void SetupAuthEnvironment(TTestEnv& env) {
     env.GetServer().GetRuntime()->SetLogPriority(NKikimrServices::FLAT_TX_SCHEMESHARD, NLog::PRI_DEBUG);
     env.GetServer().GetRuntime()->SetLogPriority(NKikimrServices::SYSTEM_VIEWS, NLog::PRI_TRACE);
@@ -168,6 +216,47 @@ void CheckEmpty(TScanQueryPartIterator& it) {
 
     ])";
     NKqp::CompareYson(expected, NKqp::StreamResultToYson(it));
+}
+
+size_t GetRowCount(TTableClient& client, const TString& tableName, const TString& condition = {}) {
+    TStringBuilder query;
+    query << "SELECT * FROM `" << tableName << "`";
+    if (!condition.empty())
+        query << " WHERE " << condition;
+    auto it = client.StreamExecuteScanQuery(query).GetValueSync();
+    UNIT_ASSERT_C(it.IsSuccess(), it.GetIssues().ToString());
+    auto ysonString = NKqp::StreamResultToYson(it);
+    auto node = NYT::NodeFromYsonString(ysonString, ::NYson::EYsonType::Node);
+    UNIT_ASSERT(node.IsList());
+    return node.AsList().size();
+}
+
+ui64 GetIntervalEnd(TTableClient& client, const TString& name) {
+    TStringBuilder query;
+    query << "SELECT MAX(IntervalEnd) FROM `" << name << "`";
+    auto it = client.StreamExecuteScanQuery(query).GetValueSync();
+    UNIT_ASSERT_C(it.IsSuccess(), it.GetIssues().ToString());
+    auto ysonString = NKqp::StreamResultToYson(it);
+    auto node = NYT::NodeFromYsonString(ysonString, ::NYson::EYsonType::Node);
+    UNIT_ASSERT(node.IsList());
+    UNIT_ASSERT(node.AsList().size() == 1);
+    auto row = node.AsList()[0];
+    UNIT_ASSERT(row.IsList());
+    UNIT_ASSERT(row.AsList().size() == 1);
+    auto value = row.AsList()[0];
+    UNIT_ASSERT(value.IsList());
+    UNIT_ASSERT(value.AsList().size() == 1);
+    return value.AsList()[0].AsUint64();
+}
+
+void WaitForStats(TTableClient& client, const TString& tableName, const TString& condition = {}) {
+    size_t rowCount = 0;
+    for (size_t iter = 0; iter < 30; ++iter) {
+        if (rowCount = GetRowCount(client, tableName, condition))
+            break;
+        Sleep(TDuration::Seconds(5));
+    }
+    UNIT_ASSERT_GE(rowCount, 0);   
 }
 
 class TShowCreateTableChecker {
@@ -1556,6 +1645,36 @@ WITH (
         check.Uint64(1u); // LastTtlRowsErased
     }
 
+    Y_UNIT_TEST(PartitionStatsLocksFields) {
+        NDataShard::gDbStatsReportInterval = TDuration::Seconds(0);
+
+        TTestEnv env;
+        CreateRootTable(env, /* partitionCount */ 1, /* fillTable */ true);
+
+        TTableClient client(env.GetDriver());
+        auto session = client.CreateSession().GetValueSync().GetSession();
+     
+        BreakLock(session, "/Root/Table0");
+
+        WaitForStats(client, "/Root/.sys/partition_stats", "LocksBroken != 0");
+
+        auto it = client.StreamExecuteScanQuery(R"(
+            SELECT
+                LocksAcquired,
+                LocksWholeShard,
+                LocksBroken
+            FROM `/Root/.sys/partition_stats`;
+        )").GetValueSync();
+
+        UNIT_ASSERT_C(it.IsSuccess(), it.GetIssues().ToString());
+        auto ysonString = NKqp::StreamResultToYson(it);
+        TYsonFieldChecker check(ysonString, 3);
+
+        check.Uint64(1); // LocksAcquired
+        check.Uint64(0); // LocksWholeShard
+        check.Uint64(1); // LocksBroken
+    }    
+
     Y_UNIT_TEST(PartitionStatsFields) {
         NDataShard::gDbStatsReportInterval = TDuration::Seconds(0);
 
@@ -1611,13 +1730,16 @@ WITH (
                 TxRejectedByOutOfStorage,
                 TxRejectedByOverload,
                 FollowerId,
+                LocksAcquired,
+                LocksWholeShard,
+                LocksBroken,
                 UpdateTime
             FROM `/Root/.sys/partition_stats`;
         )").GetValueSync();
 
         UNIT_ASSERT_C(it.IsSuccess(), it.GetIssues().ToString());
         auto ysonString = NKqp::StreamResultToYson(it);
-        TYsonFieldChecker check(ysonString, 24);
+        TYsonFieldChecker check(ysonString, 27);
 
         check.Uint64GreaterOrEquals(nowUs); // AccessTime
         check.DoubleGreaterOrEquals(0.0); // CPUCores
@@ -1642,6 +1764,9 @@ WITH (
         check.Uint64(0u); // TxRejectedByOutOfStorage
         check.Uint64(0u); // TxRejectedByOverload
         check.Uint64(0u); // FollowerId
+        check.Uint64(0u); // LocksAcquired
+        check.Uint64(0u); // LocksWholeShard
+        check.Uint64(0u); // LocksBroken
         check.Uint64GreaterOrEquals(nowUs); // UpdateTime
     }
 
@@ -2031,38 +2156,7 @@ WITH (
         }
     }
 
-    size_t GetRowCount(TTableClient& client, const TString& tableName, const TString& condition = {}) {
-        TStringBuilder query;
-        query << "SELECT * FROM `" << tableName << "`";
-        if (!condition.empty())
-            query << " WHERE " << condition;
-        auto it = client.StreamExecuteScanQuery(query).GetValueSync();
-        UNIT_ASSERT_C(it.IsSuccess(), it.GetIssues().ToString());
-        auto ysonString = NKqp::StreamResultToYson(it);
-        auto node = NYT::NodeFromYsonString(ysonString, ::NYson::EYsonType::Node);
-        UNIT_ASSERT(node.IsList());
-        return node.AsList().size();
-    }
-
-    ui64 GetIntervalEnd(TTableClient& client, const TString& name) {
-        TStringBuilder query;
-        query << "SELECT MAX(IntervalEnd) FROM `" << name << "`";
-        auto it = client.StreamExecuteScanQuery(query).GetValueSync();
-        UNIT_ASSERT_C(it.IsSuccess(), it.GetIssues().ToString());
-        auto ysonString = NKqp::StreamResultToYson(it);
-        auto node = NYT::NodeFromYsonString(ysonString, ::NYson::EYsonType::Node);
-        UNIT_ASSERT(node.IsList());
-        UNIT_ASSERT(node.AsList().size() == 1);
-        auto row = node.AsList()[0];
-        UNIT_ASSERT(row.IsList());
-        UNIT_ASSERT(row.AsList().size() == 1);
-        auto value = row.AsList()[0];
-        UNIT_ASSERT(value.IsList());
-        UNIT_ASSERT(value.AsList().size() == 1);
-        return value.AsList()[0].AsUint64();
-    }
-
-    Y_UNIT_TEST(TopPartitionsFields) {
+    Y_UNIT_TEST(TopPartitionsByCpuFields) {
         NDataShard::gDbStatsReportInterval = TDuration::Seconds(0);
 
         auto nowUs = TInstant::Now().MicroSeconds();
@@ -2114,7 +2208,7 @@ WITH (
         check.Uint64(0); // InFlightTxCount
     }
 
-    Y_UNIT_TEST(TopPartitionsTables) {
+    Y_UNIT_TEST(TopPartitionsByCpuTables) {
         NDataShard::gDbStatsReportInterval = TDuration::Seconds(0);
 
         constexpr ui64 partitionCount = 5;
@@ -2144,7 +2238,7 @@ WITH (
         check("/Root/Tenant1/.sys/top_partitions_one_hour");
     }
 
-    Y_UNIT_TEST(TopPartitionsRanges) {
+    Y_UNIT_TEST(TopPartitionsByCpuRanges) {
         NDataShard::gDbStatsReportInterval = TDuration::Seconds(0);
 
         constexpr ui64 partitionCount = 5;
@@ -2225,7 +2319,7 @@ WITH (
         }
     }
 
-    Y_UNIT_TEST(TopPartitionsFollowers) {
+    Y_UNIT_TEST(TopPartitionsByCpuFollowers) {
         NDataShard::gDbStatsReportInterval = TDuration::Seconds(0);
 
         auto nowUs = TInstant::Now().MicroSeconds();
@@ -2398,6 +2492,58 @@ WITH (
             check.Uint64(0); // InFlightTxCount
             check.Uint64Greater(0); // FollowerId
         }
+    }
+
+    Y_UNIT_TEST(TopPartitionsByTliFields) {
+        NDataShard::gDbStatsReportInterval = TDuration::Seconds(0);
+
+        TTestEnv env(1, 4, {.EnableSVP = true});
+        CreateTenantsAndTables(env);
+
+        TTableClient client(env.GetDriver());
+        auto session = client.CreateSession().GetValueSync().GetSession();
+     
+        const TString tableName = "/Root/Tenant1/Table1";
+        const TString viewName = "/Root/Tenant1/.sys/top_partitions_by_tli_one_minute";
+
+        BreakLock(session, tableName);
+
+        WaitForStats(client, viewName, "LocksAcquired != 0");
+
+        ui64 intervalEnd = GetIntervalEnd(client, viewName);
+
+        TStringBuilder query;
+        query << R"(
+            SELECT
+                IntervalEnd,
+                Rank,
+                TabletId,
+                Path,
+                LocksAcquired,
+                LocksWholeShard,
+                LocksBroken,
+                NodeId,
+                DataSize,
+                RowCount,
+                IndexSize)"
+            << " FROM `" << viewName << "`"
+            << " WHERE IntervalEnd = CAST(" << intervalEnd << "ul as Timestamp)"
+            << " AND Path=\"" << tableName << "\"";
+        auto it = client.StreamExecuteScanQuery(query).GetValueSync();
+        UNIT_ASSERT_C(it.IsSuccess(), it.GetIssues().ToString());
+        auto ysonString = NKqp::StreamResultToYson(it);
+        TYsonFieldChecker check(ysonString, 11);
+        check.Uint64(intervalEnd); // IntervalEnd
+        check.Uint64(1); // Rank
+        check.Uint64Greater(0); // TabletId
+        check.String(tableName); // Path
+        check.Uint64GreaterOrEquals(1); // LocksAcquired
+        check.Uint64(0); // LocksWholeShard
+        check.Uint64GreaterOrEquals(1); // LocksBroken
+        check.Uint64Greater(0); // NodeId
+        check.Uint64Greater(0); // DataSize
+        check.Uint64(4); // RowCount
+        check.Uint64(0); // IndexSize
     }
 
     Y_UNIT_TEST(Describe) {
@@ -2580,8 +2726,7 @@ WITH (
             UNIT_ASSERT_VALUES_EQUAL(entry.Type, ESchemeEntryType::Directory);
 
             auto children = result.GetChildren();
-
-            UNIT_ASSERT_VALUES_EQUAL(children.size(), 31);
+            UNIT_ASSERT_VALUES_EQUAL(children.size(), 33);
 
             THashSet<TString> names;
             for (const auto& child : children) {

--- a/ydb/core/sys_view/ut_kqp.cpp
+++ b/ydb/core/sys_view/ut_kqp.cpp
@@ -2565,7 +2565,7 @@ WITH (
             const auto& columns = table.GetTableColumns();
             const auto& keyColumns = table.GetPrimaryKeyColumns();
 
-            UNIT_ASSERT_VALUES_EQUAL(columns.size(), 27);
+            UNIT_ASSERT_VALUES_EQUAL(columns.size(), 30);
             UNIT_ASSERT_STRINGS_EQUAL(columns[0].Name, "OwnerId");
             UNIT_ASSERT_STRINGS_EQUAL(FormatType(columns[0].Type), "Uint64?");
 
@@ -2745,7 +2745,7 @@ WITH (
 
             auto children = result.GetChildren();
 
-            UNIT_ASSERT_VALUES_EQUAL(children.size(), 25);
+            UNIT_ASSERT_VALUES_EQUAL(children.size(), 27);
 
             THashSet<TString> names;
             for (const auto& child : children) {

--- a/ydb/core/tx/schemeshard/schemeshard__init.cpp
+++ b/ydb/core/tx/schemeshard/schemeshard__init.cpp
@@ -2395,6 +2395,10 @@ struct TSchemeShard::TTxInit : public TTransactionBase<TSchemeShard> {
                 stats.FullCompactionTs = rowSet.GetValueOrDefault<Schema::TablePartitionStats::FullCompactionTs>();
                 stats.MemDataSize = rowSet.GetValueOrDefault<Schema::TablePartitionStats::MemDataSize>();
 
+                stats.LocksAcquired = rowSet.GetValueOrDefault<Schema::TablePartitionStats::LocksAcquired>();
+                stats.LocksWholeShard = rowSet.GetValueOrDefault<Schema::TablePartitionStats::LocksWholeShard>();
+                stats.LocksBroken = rowSet.GetValueOrDefault<Schema::TablePartitionStats::LocksBroken>();
+
                 tableInfo->UpdateShardStats(shardIdx, stats);
 
                 // note that we don't update shard metrics here, because we will always update

--- a/ydb/core/tx/schemeshard/schemeshard__table_stats.cpp
+++ b/ydb/core/tx/schemeshard/schemeshard__table_stats.cpp
@@ -84,6 +84,9 @@ auto TSchemeShard::BuildStatsForCollector(TPathId pathId, TShardIdx shardIdx, TT
     sysStats.SetPlannedTxCompleted(stats.PlannedTxCompleted);
     sysStats.SetTxRejectedByOverload(stats.TxRejectedByOverload);
     sysStats.SetTxRejectedBySpace(stats.TxRejectedBySpace);
+    sysStats.SetLocksAcquired(stats.LocksAcquired);
+    sysStats.SetLocksWholeShard(stats.LocksWholeShard);
+    sysStats.SetLocksBroken(stats.LocksBroken);
 
     if (nodeId) {
         sysStats.SetNodeId(*nodeId);
@@ -198,6 +201,10 @@ TPartitionStats TTxStoreTableStats::PrepareStats(const TActorContext& ctx,
     newStats.RowReads = tableStats.GetRowReads();
     newStats.RangeReads = tableStats.GetRangeReads();
     newStats.RangeReadRows = tableStats.GetRangeReadRows();
+
+    newStats.LocksAcquired = tableStats.GetLocksAcquired();
+    newStats.LocksWholeShard = tableStats.GetLocksWholeShard();
+    newStats.LocksBroken = tableStats.GetLocksBroken();
 
     TInstant now = AppData(ctx)->TimeProvider->Now();
     newStats.SetCurrentRawCpuUsage(tabletMetrics.GetCPU(), now);

--- a/ydb/core/tx/schemeshard/schemeshard_impl.cpp
+++ b/ydb/core/tx/schemeshard/schemeshard_impl.cpp
@@ -2601,7 +2601,11 @@ void TSchemeShard::PersistTablePartitionStats(NIceDb::TNiceDb& db, const TPathId
 
         NIceDb::TUpdate<Schema::TablePartitionStats::SearchHeight>(stats.SearchHeight),
         NIceDb::TUpdate<Schema::TablePartitionStats::FullCompactionTs>(stats.FullCompactionTs),
-        NIceDb::TUpdate<Schema::TablePartitionStats::MemDataSize>(stats.MemDataSize)
+        NIceDb::TUpdate<Schema::TablePartitionStats::MemDataSize>(stats.MemDataSize),
+
+        NIceDb::TUpdate<Schema::TablePartitionStats::LocksAcquired>(stats.LocksAcquired),
+        NIceDb::TUpdate<Schema::TablePartitionStats::LocksWholeShard>(stats.LocksWholeShard),
+        NIceDb::TUpdate<Schema::TablePartitionStats::LocksBroken>(stats.LocksBroken)
     );
 
     if (!stats.StoragePoolsStats.empty()) {

--- a/ydb/core/tx/schemeshard/schemeshard_info_types.cpp
+++ b/ydb/core/tx/schemeshard/schemeshard_info_types.cpp
@@ -1681,6 +1681,10 @@ void TTableInfo::SetPartitioning(TVector<TTableShardInfo>&& newPartitioning) {
     newAggregatedStats.RangeReads = Stats.Aggregated.RangeReads;
     newAggregatedStats.RangeReadRows = Stats.Aggregated.RangeReadRows;
 
+    newAggregatedStats.LocksAcquired = Stats.Aggregated.LocksAcquired;
+    newAggregatedStats.LocksWholeShard = Stats.Aggregated.LocksWholeShard;
+    newAggregatedStats.LocksBroken = Stats.Aggregated.LocksBroken;
+
     if (SplitOpsInFlight.empty()) {
         ExpectedPartitionCount = newPartitioning.size();
     }
@@ -1784,6 +1788,10 @@ void TTableAggregatedStats::UpdateShardStats(TShardIdx datashardIdx, const TPart
     Aggregated.WriteThroughput += (newStats.WriteThroughput - oldStats.WriteThroughput);
     Aggregated.ReadIops += (newStats.ReadIops - oldStats.ReadIops);
     Aggregated.WriteIops += (newStats.WriteIops - oldStats.WriteIops);
+
+    Aggregated.LocksAcquired += (newStats.LocksAcquired - oldStats.LocksAcquired);
+    Aggregated.LocksWholeShard += (newStats.LocksWholeShard - oldStats.LocksWholeShard);
+    Aggregated.LocksBroken += (newStats.LocksBroken - oldStats.LocksBroken);
 
     auto topUsage = oldStats.TopUsage.Update(newStats.TopUsage);
     oldStats = newStats;

--- a/ydb/core/tx/schemeshard/schemeshard_info_types.h
+++ b/ydb/core/tx/schemeshard/schemeshard_info_types.h
@@ -272,6 +272,10 @@ struct TPartitionStats {
     ui64 MemDataSize = 0;
     ui32 ShardState = NKikimrTxDataShard::Unknown;
 
+    ui64 LocksAcquired = 0;
+    ui64 LocksWholeShard = 0;
+    ui64 LocksBroken = 0;
+
     // True when PartOwners has parts from other tablets
     bool HasBorrowedData = false;
 

--- a/ydb/core/tx/schemeshard/schemeshard_path_describer.cpp
+++ b/ydb/core/tx/schemeshard/schemeshard_path_describer.cpp
@@ -42,6 +42,10 @@ static void FillTableStats(NKikimrTableStats::TTableStats* stats, const TPartiti
     stats->SetRangeReads(tableStats.RangeReads);
     stats->SetRangeReadRows(tableStats.RangeReadRows);
 
+    stats->SetLocksAcquired(tableStats.LocksAcquired);
+    stats->SetLocksWholeShard(tableStats.LocksWholeShard);
+    stats->SetLocksBroken(tableStats.LocksBroken);
+
     stats->SetPartCount(tableStats.PartCount);
     stats->SetHasSchemaChanges(tableStats.HasSchemaChanges);
 

--- a/ydb/core/tx/schemeshard/schemeshard_schema.h
+++ b/ydb/core/tx/schemeshard/schemeshard_schema.h
@@ -391,6 +391,10 @@ struct Schema : NIceDb::Schema {
 
         struct ByKeyFilterSize : Column<34, NScheme::NTypeIds::Uint64> {};
 
+        struct LocksAcquired : Column<35, NScheme::NTypeIds::Uint64> {};
+        struct LocksWholeShard : Column<36, NScheme::NTypeIds::Uint64> {};
+        struct LocksBroken : Column<37, NScheme::NTypeIds::Uint64> {};
+
         using TKey = TableKey<TableOwnerId, TableLocalId, PartitionId>;
         using TColumns = TableColumns<
             TableOwnerId,
@@ -426,7 +430,10 @@ struct Schema : NIceDb::Schema {
             FullCompactionTs,
             MemDataSize,
             StoragePoolsStats,
-            ByKeyFilterSize
+            ByKeyFilterSize,
+            LocksAcquired,
+            LocksWholeShard,
+            LocksBroken
         >;
     };
 

--- a/ydb/tests/functional/scheme_tests/canondata/tablet_scheme_tests.TestTabletSchemes.test_tablet_schemes_flat_schemeshard_/flat_schemeshard.schema
+++ b/ydb/tests/functional/scheme_tests/canondata/tablet_scheme_tests.TestTabletSchemes.test_tablet_schemes_flat_schemeshard_/flat_schemeshard.schema
@@ -7358,6 +7358,21 @@
                 "ColumnId": 34,
                 "ColumnName": "ByKeyFilterSize",
                 "ColumnType": "Uint64"
+            },
+            {
+                "ColumnId": 35,
+                "ColumnName": "LocksAcquired",
+                "ColumnType": "Uint64"
+            },
+            {
+                "ColumnId": 36,
+                "ColumnName": "LocksWholeShard",
+                "ColumnType": "Uint64"
+            },
+            {
+                "ColumnId": 37,
+                "ColumnName": "LocksBroken",
+                "ColumnType": "Uint64"
             }
         ],
         "ColumnsDropped": [],
@@ -7397,7 +7412,10 @@
                     31,
                     32,
                     33,
-                    34
+                    34,
+                    35,
+                    36,
+                    37
                 ],
                 "RoomID": 0,
                 "Codec": 0,


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

#### `partition_stats` system view
Add new cumulative fields to the existing `partition_stats` system view:
* `LocksAcquired` - the number of locks installed "per key range";
* `LocksWholeshard` - the number of installed locks "for the entire batch";
* `LocksBroken` - the number of broken locks.

#### `top_partitions_by_tli_one_*` system view
Add new `top_partitions_by_tli_one_hour` and `top_partitions_by_tli_one_minute` system views.

The views give out the top 10 partitions with a large number of broken locks.

### Changelog category <!-- remove all except one -->

* New feature

### Description for reviewers <!-- (optional) description for those who read this PR -->

...
