### PR TITLE
check nodes after test and restart they before one

### DIFF
--- a/ydb/tests/functional/tpc/large/ya.make
+++ b/ydb/tests/functional/tpc/large/ya.make
@@ -15,6 +15,7 @@ ENV(YDB_ENABLE_COLUMN_TABLES="true")
 ENV(YDB_DRIVER_BINARY="ydb/apps/ydbd/ydbd")
 ENV(YDB_CLI_BINARY="ydb/apps/ydb/ydb")
 ENV(NO_KUBER_LOGS="yes")
+ENV(WAIT_CLUSTER_ALIVE_TIMEOUT="60")
 
 PEERDIR(
     ydb/tests/functional/tpc/lib

--- a/ydb/tests/functional/tpc/lib/conftest.py
+++ b/ydb/tests/functional/tpc/lib/conftest.py
@@ -40,6 +40,21 @@ class FunctionalTestBase:
         cls.cluster.register_and_start_slots(db, count=YdbCluster.get_dyn_nodes_count())
         cls.cluster.wait_tenant_up(db)
 
+    def setup_method(self, method):
+        for node in self.cluster.nodes.values():
+            node.start()
+        for slot in self.cluster.slots.values():
+            slot.start()
+        self.cluster.wait_tenant_up(f'/{YdbCluster.ydb_database}')
+
+    def teardown_method(self, method):
+        for node in self.cluster.nodes.values():
+            if not node.is_alive():
+                node.stop()
+        for slot in self.cluster.slots.values():
+            if not slot.is_alive():
+                slot.stop()
+
     @classmethod
     def run_cli(cls, argv: list[str]) -> yatest.common.process._Execution:
         return yatest.common.execute(YdbCliHelper.get_cli_command() + argv)

--- a/ydb/tests/functional/tpc/medium/ya.make
+++ b/ydb/tests/functional/tpc/medium/ya.make
@@ -14,6 +14,7 @@ ENV(YDB_ENABLE_COLUMN_TABLES="true")
 ENV(YDB_DRIVER_BINARY="ydb/apps/ydbd/ydbd")
 ENV(YDB_CLI_BINARY="ydb/apps/ydb/ydb")
 ENV(NO_KUBER_LOGS="yes")
+ENV(WAIT_CLUSTER_ALIVE_TIMEOUT="60")
 
 PEERDIR(
     ydb/tests/functional/tpc/lib

--- a/ydb/tests/olap/lib/ydb_cli.py
+++ b/ydb/tests/olap/lib/ydb_cli.py
@@ -278,7 +278,7 @@ class YdbCliHelper:
 
         def process(self) -> YdbCliHelper.WorkloadRunResult:
             try:
-                wait_error = YdbCluster.wait_ydb_alive(YdbCluster.wait_ydb_alive(int(os.getenv('WAIT_CLUSTER_ALIVE_TIMEOUT', 20 * 60))), self.db_path)
+                wait_error = YdbCluster.wait_ydb_alive(int(os.getenv('WAIT_CLUSTER_ALIVE_TIMEOUT', 20 * 60)), self.db_path)
                 if wait_error is not None:
                     self.result.error_message = wait_error
                 else:

--- a/ydb/tests/olap/lib/ydb_cli.py
+++ b/ydb/tests/olap/lib/ydb_cli.py
@@ -278,7 +278,7 @@ class YdbCliHelper:
 
         def process(self) -> YdbCliHelper.WorkloadRunResult:
             try:
-                wait_error = YdbCluster.wait_ydb_alive(20 * 60, self.db_path)
+                wait_error = YdbCluster.wait_ydb_alive(YdbCluster.wait_ydb_alive(int(os.getenv('WAIT_CLUSTER_ALIVE_TIMEOUT', 20 * 60))), self.db_path)
                 if wait_error is not None:
                     self.result.error_message = wait_error
                 else:

--- a/ydb/tests/olap/load/lib/conftest.py
+++ b/ydb/tests/olap/load/lib/conftest.py
@@ -249,7 +249,7 @@ class LoadSuiteBase:
     @classmethod
     def setup_class(cls) -> None:
         start_time = time()
-        error = YdbCluster.wait_ydb_alive(20 * 60)
+        error = YdbCluster.wait_ydb_alive(int(os.getenv('WAIT_CLUSTER_ALIVE_TIMEOUT', 20 * 60)))
         tb = None
         if not error and hasattr(cls, 'do_setup_class'):
             try:


### PR DESCRIPTION
Если во время исполнения запроса нода ydb падает, то дальше её никто не поднимает. Все последующие запросы фейлятся. При этом диагностики упавшей ноды нет. 

Теперь так:
```
[fail] test_clickbench.py::TestClickbench::test_clickbench[16] [default-linux-x86_64-relwithdebinfo] (1.53s)
ydb/tests/olap/load/lib/clickbench.py:43: in test_clickbench
    self.run_workload_test(self.path, query_num)
ydb/tests/olap/load/lib/conftest.py:298: in run_workload_test
    self.process_query_result(result, query_num, qparams.iterations, True)
ydb/tests/olap/load/lib/conftest.py:245: in process_query_result
    raise exc
E   Failed: Iteration 0: <main>: Error: GRpc error: (14): Socket closed
E   
E   Node iddqd-ydb.vla.yp-c.yandex.net was restartedteardown failed:
ydb/tests/functional/tpc/lib/conftest.py:63: in teardown_method
    slot.stop()
ydb/tests/library/harness/kikimr_runner.py:208: in stop
    super(KiKiMRNode, self).stop()
ydb/tests/library/harness/daemon.py:189: in stop
    if not self.__check_can_launch_stop("stop"):
ydb/tests/library/harness/daemon.py:166: in __check_can_launch_stop
    raise DaemonError(
E   ydb.tests.library.harness.daemon.DaemonError: Daemon failed with message: Unexpectedly finished before stop.
E   Process exit_code = -11.
E   Stdout file name: 
E   /home/iddqd/git/ydb/ydb/tests/functional/tpc/medium/test-results/py3test/test_clickbench/testing_out_stuff/test_clickbench.py.TestClickbench.test_clickbench.10/cluster/slot_1/stdout
E   Stderr file name: 
E   /home/iddqd/git/ydb/ydb/tests/functional/tpc/medium/test-results/py3test/test_clickbench/testing_out_stuff/test_clickbench.py.TestClickbench.test_clickbench.10/cluster/slot_1/stderr
E   Stderr content:
E   
E   GRpc memory quota was set but disabled due to issues with grpc quoter, to enable it use EnableGRpcMemoryQuota option
Log: /home/iddqd/git/ydb/ydb/tests/functional/tpc/medium/test-results/py3test/test_clickbench/testing_out_stuff/test_clickbench.py.TestClickbench.test_clickbench.16.log
Logsdir: /home/iddqd/git/ydb/ydb/tests/functional/tpc/medium/test-results/py3test/test_clickbench/testing_out_stuff
------ FAIL: 9 - GOOD, 1 - FAIL ydb/tests/functional/tpc/medium

Total 1 suite:
        1 - FAIL
Total 10 tests:
        9 - GOOD
        1 - FAIL
Failed
```

Если на машине корки включены, то ещё и стек сразу будет