### PR TITLE
Support prefixed vector index search

### DIFF
--- a/ydb/core/kqp/opt/logical/kqp_opt_log_indexes.cpp
+++ b/ydb/core/kqp/opt/logical/kqp_opt_log_indexes.cpp
@@ -399,6 +399,66 @@ TExprBase DoRewriteIndexRead(const TReadMatch& read, TExprContext& ctx,
     }
 }
 
+auto NewLambdaFrom(TExprContext& ctx, TPositionHandle pos, TNodeOnNodeOwnedMap& replaces, const TExprNode& args, const TExprBase& body) {
+    const auto oldArgNodes = args.Children();
+    replaces.clear();
+    replaces.reserve(oldArgNodes.size());
+    TExprNode::TListType newArgNodes;
+    newArgNodes.reserve(oldArgNodes.size());
+    for (const auto& arg : oldArgNodes) {
+        auto newArg = ctx.ShallowCopy(*arg);
+        YQL_ENSURE(replaces.emplace(arg.Get(), newArg).second);
+        newArgNodes.emplace_back(std::move(newArg));
+    }
+    return TCoLambda{ctx.NewLambda(pos,
+        ctx.NewArguments(pos, std::move(newArgNodes)),
+        ctx.ReplaceNodes(TExprNode::TListType{body.Ptr()}, replaces))};
+}
+
+auto LevelLambdaFrom(
+    const TIndexDescription& indexDesc, TExprContext& ctx, TPositionHandle pos, TNodeOnNodeOwnedMap& replaces, 
+    const TExprNode& fromArgs, const TExprBase& fromBody)
+{
+    auto newLambda = NewLambdaFrom(ctx, pos, replaces, fromArgs, fromBody);
+    replaces.clear();
+    auto args = newLambda.Args().Ptr();
+
+    auto flatMap = newLambda.Body().Maybe<TCoFlatMap>();
+    if (!flatMap) {
+        auto apply = newLambda.Body().Cast<TCoApply>();
+        for (auto arg : apply.Args()) {
+            auto oldMember = arg.Maybe<TCoMember>();
+            if (oldMember && oldMember.Cast().Name().Value() == indexDesc.KeyColumns.back()) {
+                auto newMember = Build<TCoMember>(ctx, pos)
+                    .Name().Build(NTableIndex::NTableVectorKmeansTreeIndex::CentroidColumn)
+                    .Struct(oldMember.Cast().Struct())
+                .Done();
+                replaces.emplace(oldMember.Raw(), newMember.Ptr());
+                break;
+            }
+        }
+        return ctx.NewLambda(pos,
+            std::move(args),
+            ctx.ReplaceNodes(TExprNode::TListType{apply.Ptr()}, replaces));
+    }
+
+    auto apply = flatMap.Cast().Lambda().Body().Cast<TCoApply>();
+    for (auto arg : apply.Args()) {
+        if (arg.Ref().Type() == NYql::TExprNode::Argument) {
+            auto oldMember = flatMap.Cast().Input().Cast<TCoMember>();
+            auto newMember = Build<TCoMember>(ctx, pos)
+                .Name().Build(NTableIndex::NTableVectorKmeansTreeIndex::CentroidColumn)
+                .Struct(oldMember.Struct())
+            .Done();
+            replaces.emplace(arg.Raw(), newMember.Ptr());
+            break;
+        }
+    }
+    return ctx.NewLambda(pos,
+        std::move(args),
+        ctx.ReplaceNodes(TExprNode::TListType{apply.Ptr()}, replaces));
+}
+
 void RemapIdToParent(TExprContext& ctx, TPositionHandle pos, TExprNodePtr& read) {
     auto mapArg = Build<TCoArgument>(ctx, pos)
         .Name("mapArg")
@@ -421,8 +481,77 @@ void RemapIdToParent(TExprContext& ctx, TPositionHandle pos, TExprNodePtr& read)
     .Done().Ptr();    
 }
 
+void VectorReadLevel(
+    const TIndexDescription& indexDesc, TExprContext& ctx, TPositionHandle pos, const TKqpOptimizeContext& kqpCtx, 
+    const TExprNodePtr& lambda, const TCoTopBase& top,
+    const TKqpTable& levelTable, const TCoAtomList& levelColumns, 
+    TExprNodePtr& read)
+{
+    const auto& settings = std::get<NKikimrKqp::TVectorIndexKmeansTreeDescription>(indexDesc.SpecializedIndexDescription)
+        .settings();
+    const auto clusters = std::max<ui32>(2, settings.clusters());
+    const auto levels = std::max<ui32>(1, settings.levels());
+    Y_ENSURE(levels >= 1);
+    const auto levelTop = std::min<ui32>(kqpCtx.Config->KMeansTreeSearchTopSize.Get().GetOrElse(1), clusters);
+
+    auto count = ctx.Builder(pos)
+        .Callable("Uint64").Atom(0, std::to_string(levelTop), TNodeFlags::Default).Seal()
+    .Build();
+
+    for (ui32 level = 1;; ++level) {
+        read = Build<TCoTop>(ctx, pos)
+            .Input(read)
+            .KeySelectorLambda(lambda)
+            .SortDirections(top.SortDirections())
+            .Count(count)
+        .Done().Ptr();
+
+        RemapIdToParent(ctx, pos, read);
+
+        if (level == levels) {
+            break;
+        }
+
+        read = Build<TKqlLookupTable>(ctx, pos)
+            .Table(levelTable)
+            .LookupKeys(read)
+            .Columns(levelColumns)
+        .Done().Ptr();
+    }
+}
+
+void VectorReadMain(
+    TExprContext& ctx, TPositionHandle pos,
+    const TKqpTable& postingTable, const TCoAtomList& postingColumns,
+    const TKqpTable& mainTable, const TCoAtomList& mainColumns,
+    TExprNodePtr& read)
+{
+    // TODO(mbkkt) handle covered index columns
+    read = Build<TKqlLookupTable>(ctx, pos)
+        .Table(postingTable)
+        .LookupKeys(read)
+        .Columns(postingColumns)
+    .Done().Ptr();
+
+    read = Build<TKqlLookupTable>(ctx, pos)
+        .Table(mainTable)
+        .LookupKeys(read)
+        .Columns(mainColumns)
+    .Done().Ptr();
+}
+
+void VectorTopMain(TExprContext& ctx, const TCoTopBase& top, TExprNodePtr& read) {
+    read = Build<TCoTopBase>(ctx, top.Pos())
+        .CallableName(top.Ref().Content())
+        .Input(read)
+        .KeySelectorLambda(ctx.DeepCopyLambda(top.KeySelectorLambda().Ref()))
+        .SortDirections(top.SortDirections())
+        .Count(top.Count())
+    .Done().Ptr();
+}
+
 TExprBase DoRewriteTopSortOverKMeansTree(
-    const TReadMatch& read, const TMaybeNode<TCoFlatMap>& flatMap, const TExprNode& lambdaArgs, const TExprBase& lambdaBody, const TCoTopBase& top,
+    const TReadMatch& match, const TMaybeNode<TCoFlatMap>& flatMap, const TExprNode& lambdaArgs, const TExprBase& lambdaBody, const TCoTopBase& top,
     TExprContext& ctx, const TKqpOptimizeContext& kqpCtx,
     const TKikimrTableDescription& tableDesc, const TIndexDescription& indexDesc, const TKikimrTableMetadata& implTable)
 {
@@ -434,90 +563,30 @@ TExprBase DoRewriteTopSortOverKMeansTree(
     YQL_ENSURE(postingTableDesc->Metadata->Name.EndsWith(NTableIndex::NTableVectorKmeansTreeIndex::PostingTable));
 
     // TODO(mbkkt) It's kind of strange that almost everything here have same position
-    const auto pos = read.Pos();
+    const auto pos = match.Pos();
 
-    auto levelTable = BuildTableMeta(*levelTableDesc->Metadata, pos, ctx);
-    auto postingTable = BuildTableMeta(*postingTableDesc->Metadata, pos, ctx);
-    auto mainTable = BuildTableMeta(*tableDesc.Metadata, pos, ctx);
+    const auto levelTable = BuildTableMeta(*levelTableDesc->Metadata, pos, ctx);
+    const auto postingTable = BuildTableMeta(*postingTableDesc->Metadata, pos, ctx);
+    const auto mainTable = BuildTableMeta(*tableDesc.Metadata, pos, ctx);
 
-    auto levelColumns = BuildKeyColumnsList(*levelTableDesc, pos, ctx,
+    const auto levelColumns = BuildKeyColumnsList(*levelTableDesc, pos, ctx,
             std::initializer_list<std::string_view>{NTableIndex::NTableVectorKmeansTreeIndex::IdColumn, NTableIndex::NTableVectorKmeansTreeIndex::CentroidColumn});
-    auto postingColumns = BuildKeyColumnsList(*postingTableDesc, pos, ctx, tableDesc.Metadata->KeyColumnNames);
-    const auto& mainColumns = read.Columns();
+    const auto postingColumns = BuildKeyColumnsList(*postingTableDesc, pos, ctx, tableDesc.Metadata->KeyColumnNames);
+    const auto& mainColumns = match.Columns();
+
+    TNodeOnNodeOwnedMap replaces;
+    const auto levelLambda = LevelLambdaFrom(indexDesc, ctx, pos, replaces, lambdaArgs, lambdaBody);
 
     // TODO(mbkkt) How to inline construction of these constants to construction of readLevel0?
-    auto fromValues = ctx.Builder(pos)
+    const auto fromValues = ctx.Builder(pos)
         .Callable(NTableIndex::ClusterIdTypeName).Atom(0, "0", TNodeFlags::Default).Seal()
     .Build();
-    auto toValues = ctx.Builder(pos)
+    const auto toValues = ctx.Builder(pos)
         .Callable(NTableIndex::ClusterIdTypeName).Atom(0, "1", TNodeFlags::Default).Seal()
     .Build();
 
-    auto levelLambda = [&] {
-        const auto oldArgNodes = lambdaArgs.Children();
-        TNodeOnNodeOwnedMap replaces(oldArgNodes.size());
-        TExprNode::TListType newArgNodes;
-        newArgNodes.reserve(oldArgNodes.size());
-        for (const auto& arg : oldArgNodes) {
-            auto newArg = ctx.ShallowCopy(*arg);
-            YQL_ENSURE(replaces.emplace(arg.Get(), newArg).second);
-            newArgNodes.emplace_back(std::move(newArg));
-        }
-        auto newLambda = TExprBase{ctx.NewLambda(pos,
-            ctx.NewArguments(pos, std::move(newArgNodes)),
-            ctx.ReplaceNodes(TExprNode::TListType{lambdaBody.Ptr()}, replaces))}
-        .Cast<TCoLambda>();
-        auto args = newLambda.Args().Ptr();
-        replaces.clear();
-        auto flatMap = newLambda.Body().Maybe<TCoFlatMap>();
-        if (!flatMap) {
-            auto apply = newLambda.Body().Cast<TCoApply>();
-            for (auto arg : apply.Args()) {
-                auto oldMember = arg.Maybe<TCoMember>();
-                if (oldMember && oldMember.Cast().Name().Value() == indexDesc.KeyColumns.back()) {
-                    auto newMember = Build<TCoMember>(ctx, pos)
-                        .Name().Build(NTableIndex::NTableVectorKmeansTreeIndex::CentroidColumn)
-                        .Struct(oldMember.Cast().Struct())
-                    .Done();
-                    replaces.emplace(oldMember.Raw(), newMember.Ptr());
-                    break;
-                }
-            }
-            return ctx.NewLambda(pos,
-                std::move(args),
-                ctx.ReplaceNodes(TExprNode::TListType{apply.Ptr()}, replaces));
-        }
-        auto apply = flatMap.Cast().Lambda().Body().Cast<TCoApply>();
-        for (auto arg : apply.Args()) {
-            if (arg.Ref().Type() == NYql::TExprNode::Argument) {
-                auto oldMember = flatMap.Cast().Input().Cast<TCoMember>();
-                auto newMember = Build<TCoMember>(ctx, pos)
-                    .Name().Build(NTableIndex::NTableVectorKmeansTreeIndex::CentroidColumn)
-                    .Struct(oldMember.Struct())
-                .Done();
-                replaces.emplace(arg.Raw(), newMember.Ptr());
-                break;
-            }
-        }
-        return ctx.NewLambda(pos,
-            std::move(args),
-            ctx.ReplaceNodes(TExprNode::TListType{apply.Ptr()}, replaces));
-    }();
-
-    ui32 level = 1;
-    const auto& settings = std::get<NKikimrKqp::TVectorIndexKmeansTreeDescription>(indexDesc.SpecializedIndexDescription)
-        .settings();
-    const auto clusters = std::max<ui32>(2, settings.clusters());
-    const auto levels = std::max<ui32>(1, settings.levels());
-    Y_ENSURE(level <= levels);
-    const auto levelTop = std::min<ui32>(kqpCtx.Config->KMeansTreeSearchTopSize.Get().GetOrElse(1), clusters);
-
-    auto count = ctx.Builder(pos)
-        .Callable("Uint64").Atom(0, std::to_string(levelTop), TNodeFlags::Default).Seal()
-    .Build();
-
     // TODO(mbkkt) Is it best way to do `SELECT FROM levelTable WHERE first_pk_column = 0`?
-    auto readLevel = Build<TKqlReadTable>(ctx, pos)
+    auto read = Build<TKqlReadTable>(ctx, pos)
         .Table(levelTable)
         .Range<TKqlKeyRange>()
             .From<TKqlKeyInc>()
@@ -528,74 +597,30 @@ TExprBase DoRewriteTopSortOverKMeansTree(
             .Build()
         .Build()
         .Columns(levelColumns)
-        .Settings(read.Settings())
+        .Settings(match.Settings())
     .Done().Ptr();
 
-    for (;; ++level) {
-        readLevel = Build<TCoTop>(ctx, pos)
-            .Input(readLevel)
-            .KeySelectorLambda(levelLambda)
-            .SortDirections(top.SortDirections())
-            .Count(count)
-        .Done().Ptr();
+    VectorReadLevel(indexDesc, ctx, pos, kqpCtx, levelLambda, top, levelTable, levelColumns, read);
 
-        RemapIdToParent(ctx, pos, readLevel);
-
-        if (level == levels) {
-            break;
-        }
-
-        readLevel = Build<TKqlLookupTable>(ctx, pos)
-            .Table(levelTable)
-            .LookupKeys(readLevel)
-            .Columns(levelColumns)
-        .Done().Ptr();
-    }
-
-    // TODO(mbkkt) handle covered index columns
-    auto postingRead = Build<TKqlLookupTable>(ctx, pos)
-        .Table(postingTable)
-        .LookupKeys(readLevel)
-        .Columns(postingColumns)
-    .Done().Ptr();
-
-    auto mainRead = Build<TKqlLookupTable>(ctx, pos)
-        .Table(mainTable)
-        .LookupKeys(postingRead)
-        .Columns(mainColumns)
-    .Done().Ptr();
+    VectorReadMain(ctx, pos, postingTable, postingColumns, mainTable, mainColumns, read);
 
     if (flatMap) {
-        mainRead = Build<TCoFlatMap>(ctx, flatMap.Cast().Pos())
-            .Input(mainRead)
+        read = Build<TCoFlatMap>(ctx, flatMap.Cast().Pos())
+            .Input(read)
             .Lambda(ctx.DeepCopyLambda(flatMap.Cast().Lambda().Ref()))
         .Done().Ptr();
     }
 
-    mainRead = Build<TCoTopBase>(ctx, top.Pos())
-        .CallableName(top.Ref().Content())
-        .Input(mainRead)
-        .KeySelectorLambda(ctx.DeepCopyLambda(top.KeySelectorLambda().Ref()))
-        .SortDirections(top.SortDirections())
-        .Count(top.Count())
-    .Done().Ptr();
+    VectorTopMain(ctx, top, read);
 
-    return TExprBase{mainRead};
+    return TExprBase{read};
 }
 
-TExprBase TryRewriteTopSortOverPrefixedKMeansTree(
-    TExprBase node,
-    const TReadMatch& read, const TMaybeNode<TCoFlatMap>& flatMap, const TExprNode& lambdaArgs, const TExprBase& lambdaBody, const TCoTopBase& top,
+TExprBase DoRewriteTopSortOverPrefixedKMeansTree(
+    const TReadMatch& match, const TCoFlatMap& flatMap, const TExprNode& lambdaArgs, const TExprBase& lambdaBody, const TCoTopBase& top,
     TExprContext& ctx, const TKqpOptimizeContext& kqpCtx,
     const TKikimrTableDescription& tableDesc, const TIndexDescription& indexDesc, const TKikimrTableMetadata& implTable)
 {
-    auto flatMapLambda = flatMap.Lambda();
-    auto maybeOptionalIf = flatMapLambda.Body().Maybe<TCoOptionalIf>();
-    if (!maybeOptionalIf) {
-        YQL_LOG(WARN) << "Cannot use prefixed vector index for " << top.Ref().Dump();
-        return node;
-    }
-
     Y_ASSERT(indexDesc.Type == TIndexDescription::EType::GlobalSyncVectorKMeansTree);
     Y_ASSERT(indexDesc.KeyColumns.size() > 1);
     const auto* levelTableDesc = &kqpCtx.Tables->ExistingTable(kqpCtx.Cluster, implTable.Name);
@@ -607,172 +632,71 @@ TExprBase TryRewriteTopSortOverPrefixedKMeansTree(
     YQL_ENSURE(prefixTableDesc->Metadata->Name.EndsWith(NTableIndex::NTableVectorKmeansTreeIndex::PrefixTable));
 
     // TODO(mbkkt) It's kind of strange that almost everything here have same position
-    const auto pos = read.Pos();
+    const auto pos = match.Pos();
 
-    auto levelTable = BuildTableMeta(*levelTableDesc->Metadata, pos, ctx);
-    auto postingTable = BuildTableMeta(*postingTableDesc->Metadata, pos, ctx);
-    auto prefixTable = BuildTableMeta(*prefixTableDesc->Metadata, pos, ctx);
-    auto mainTable = BuildTableMeta(*tableDesc.Metadata, pos, ctx);
+    const auto levelTable = BuildTableMeta(*levelTableDesc->Metadata, pos, ctx);
+    const auto postingTable = BuildTableMeta(*postingTableDesc->Metadata, pos, ctx);
+    const auto prefixTable = BuildTableMeta(*prefixTableDesc->Metadata, pos, ctx);
+    const auto mainTable = BuildTableMeta(*tableDesc.Metadata, pos, ctx);
 
-    auto levelColumns = BuildKeyColumnsList(*levelTableDesc, pos, ctx,
+    const auto levelColumns = BuildKeyColumnsList(*levelTableDesc, pos, ctx,
             std::initializer_list<std::string_view>{NTableIndex::NTableVectorKmeansTreeIndex::IdColumn, NTableIndex::NTableVectorKmeansTreeIndex::CentroidColumn});
-    auto postingColumns = BuildKeyColumnsList(*postingTableDesc, pos, ctx, tableDesc.Metadata->KeyColumnNames);
-    auto prefixColumns = [&] {
+    const auto postingColumns = BuildKeyColumnsList(*postingTableDesc, pos, ctx, tableDesc.Metadata->KeyColumnNames);
+    const auto prefixColumns = [&] {
         auto columns = indexDesc.KeyColumns;
         columns.back().assign(NTableIndex::NTableVectorKmeansTreeIndex::IdColumn);
         return BuildKeyColumnsList(*prefixTableDesc, pos, ctx, columns);
     }();
-    const auto& mainColumns = read.Columns();
+    const auto& mainColumns = match.Columns();
 
     TNodeOnNodeOwnedMap replaces;
-    auto newLambdaFrom = [&](const TExprNode& args, TExprNodePtr body) {
-        const auto oldArgNodes = args.Children();
-        replaces.clear();
-        replaces.reserve(oldArgNodes.size());
-        TExprNode::TListType newArgNodes;
-        newArgNodes.reserve(oldArgNodes.size());
-        for (const auto& arg : oldArgNodes) {
-            auto newArg = ctx.ShallowCopy(*arg);
-            YQL_ENSURE(replaces.emplace(arg.Get(), newArg).second);
-            newArgNodes.emplace_back(std::move(newArg));
-        }
-        return ctx.NewLambda(pos,
-            ctx.NewArguments(pos, std::move(newArgNodes)),
-            ctx.ReplaceNodes(TExprNode::TListType{body}, replaces));
-    };
     TMaybeNode<TCoLambda> mainLambda;
-    auto prefixLambda = [&] {
-        auto newLambda = TExprBase{newLambdaFrom(flatMapLambda.Cast().Args().Ref(), flatMapLambda.Cast().Body().Ptr())}.Cast<TCoLambda>();
+    const auto prefixLambda = [&] {
+        auto newLambda = NewLambdaFrom(ctx, pos, replaces, flatMap.Lambda().Args().Ref(), flatMap.Lambda().Body());
         auto optionalIf = newLambda.Body().Cast<TCoOptionalIf>();
         auto oldValue = optionalIf.Value().Maybe<TCoAsStruct>();
         if (!oldValue) {
             return newLambda.Ptr();
         }
         auto args = newLambda.Args();
-        //ctx.NewList(pos, {oldValue.Cast().Ptr()})
-        mainLambda = newLambdaFrom(args.Ref(), oldValue.Cast().Ptr());
+        mainLambda = NewLambdaFrom(ctx, pos, replaces, args.Ref(), oldValue.Cast());
+
         replaces.clear();
         replaces.emplace(oldValue.Raw(), args.Arg(0).Ptr());
         return ctx.NewLambda(pos,
             args.Ptr(),
             ctx.ReplaceNodes(TExprNode::TListType{optionalIf.Ptr()}, replaces));
     }();
-    auto levelLambda = [&] {
-        auto newLambda =  TExprBase{newLambdaFrom(lambdaArgs, lambdaBody.Ptr())}.Cast<TCoLambda>();
-        auto args = newLambda.Args().Ptr();
-        replaces.clear();
-        auto flatMap = newLambda.Body().Maybe<TCoFlatMap>();
-        if (!flatMap) {
-            auto apply = newLambda.Body().Cast<TCoApply>();
-            for (auto arg : apply.Args()) {
-                auto oldMember = arg.Maybe<TCoMember>();
-                if (oldMember && oldMember.Cast().Name().Value() == indexDesc.KeyColumns.back()) {
-                    auto newMember = Build<TCoMember>(ctx, pos)
-                        .Name().Build(NTableIndex::NTableVectorKmeansTreeIndex::CentroidColumn)
-                        .Struct(oldMember.Cast().Struct())
-                    .Done();
-                    replaces.emplace(oldMember.Raw(), newMember.Ptr());
-                    break;
-                }
-            }
-            return ctx.NewLambda(pos,
-                std::move(args),
-                ctx.ReplaceNodes(TExprNode::TListType{apply.Ptr()}, replaces));
-        }
-        auto apply = flatMap.Cast().Lambda().Body().Cast<TCoApply>();
-        for (auto arg : apply.Args()) {
-            if (arg.Ref().Type() == NYql::TExprNode::Argument) {
-                auto oldMember = flatMap.Cast().Input().Cast<TCoMember>();
-                auto newMember = Build<TCoMember>(ctx, pos)
-                    .Name().Build(NTableIndex::NTableVectorKmeansTreeIndex::CentroidColumn)
-                    .Struct(oldMember.Struct())
-                .Done();
-                replaces.emplace(arg.Raw(), newMember.Ptr());
-                break;
-            }
-        }
-        return ctx.NewLambda(pos,
-            std::move(args),
-            ctx.ReplaceNodes(TExprNode::TListType{apply.Ptr()}, replaces));
-    }();
+    const auto levelLambda = LevelLambdaFrom(indexDesc, ctx, pos, replaces, lambdaArgs, lambdaBody);
 
-    ui32 level = 1;
-    const auto& settings = std::get<NKikimrKqp::TVectorIndexKmeansTreeDescription>(indexDesc.SpecializedIndexDescription)
-        .settings();
-    const auto clusters = std::max<ui32>(2, settings.clusters());
-    const auto levels = std::max<ui32>(1, settings.levels());
-    Y_ENSURE(level <= levels);
-    const auto levelTop = std::min<ui32>(kqpCtx.Config->KMeansTreeSearchTopSize.Get().GetOrElse(1), clusters);
+    auto read = match.BuildRead(ctx, prefixTable, prefixColumns).Ptr();
 
-    auto count = ctx.Builder(pos)
-        .Callable("Uint64").Atom(0, std::to_string(levelTop), TNodeFlags::Default).Seal()
-    .Build();
-
-    auto readPrefix = read.BuildRead(ctx, prefixTable, prefixColumns).Ptr();
-
-    readPrefix = Build<TCoFlatMap>(ctx, flatMap.Cast().Pos())
-        .Input(readPrefix)
+    read = Build<TCoFlatMap>(ctx, pos)
+        .Input(read)
         .Lambda(prefixLambda)
     .Done().Ptr();
 
-    RemapIdToParent(ctx, pos, readPrefix);
+    RemapIdToParent(ctx, pos, read);
 
-    auto readLevel = Build<TKqlLookupTable>(ctx, pos)
+    read = Build<TKqlLookupTable>(ctx, pos)
         .Table(levelTable)
-        .LookupKeys(readPrefix)
+        .LookupKeys(read)
         .Columns(levelColumns)
     .Done().Ptr();
 
-    for (;; ++level) {
-        readLevel = Build<TCoTop>(ctx, pos)
-            .Input(readLevel)
-            .KeySelectorLambda(levelLambda)
-            .SortDirections(top.SortDirections())
-            .Count(count)
-        .Done().Ptr();
+    VectorReadLevel(indexDesc, ctx, pos, kqpCtx, levelLambda, top, levelTable, levelColumns, read);
 
-        RemapIdToParent(ctx, pos, readLevel);
-
-        if (level == levels) {
-            break;
-        }
-
-        readLevel = Build<TKqlLookupTable>(ctx, pos)
-            .Table(levelTable)
-            .LookupKeys(readLevel)
-            .Columns(levelColumns)
-        .Done().Ptr();
-    }
-
-    // TODO(mbkkt) handle covered index columns
-    auto postingRead = Build<TKqlLookupTable>(ctx, pos)
-        .Table(postingTable)
-        .LookupKeys(readLevel)
-        .Columns(postingColumns)
-    .Done().Ptr();
-
-    auto mainRead = Build<TKqlLookupTable>(ctx, pos)
-        .Table(mainTable)
-        .LookupKeys(postingRead)
-        .Columns(mainColumns)
-    .Done().Ptr();
+    VectorReadMain(ctx, pos, postingTable, postingColumns, mainTable, mainColumns, read);
 
     if (mainLambda) {
-        mainRead = Build<TCoMap>(ctx, flatMap.Cast().Pos())
-            .Input(mainRead)
+        read = Build<TCoMap>(ctx, flatMap.Pos())
+            .Input(read)
             .Lambda(mainLambda.Cast())
         .Done().Ptr();
     }
 
-    mainRead = Build<TCoTopBase>(ctx, top.Pos())
-        .CallableName(top.Ref().Content())
-        .Input(mainRead)
-        .KeySelectorLambda(ctx.DeepCopyLambda(top.KeySelectorLambda().Ref()))
-        .SortDirections(top.SortDirections())
-        .Count(top.Count())
-    .Done().Ptr();
-
-    return TExprBase{mainRead};
+    VectorTopMain(ctx, top, read);
+    return TExprBase{read};
 }
 
 } // namespace
@@ -1112,42 +1036,44 @@ TExprBase KqpRewriteTopSortOverIndexRead(const TExprBase& node, TExprContext& ct
     const auto indexName = readTableIndex.Index().Value();
     auto [implTable, indexDesc] = tableDesc.Metadata->GetIndex(indexName);
     if (indexDesc->Type == TIndexDescription::EType::GlobalSyncVectorKMeansTree) {
+        auto reject = [&] (std::string_view because) {
+            auto message = TStringBuilder{} << "Given predicate is not suitable for used index: " 
+                << indexName << ", because " << because << ", node dump:\n" << node.Ref().Dump();
+            TIssue issue{ctx.GetPosition(readTableIndex.Pos()), message};
+            SetIssueCode(EYqlIssueCode::TIssuesIds_EIssueCode_KIKIMR_WRONG_INDEX_USAGE, issue);
+            ctx.AddWarning(issue);
+            return node;
+        };
         const auto* lambdaArgs = topBase.KeySelectorLambda().Args().Raw();
         auto lambdaBody = topBase.KeySelectorLambda().Body();
         bool canUseVectorIndex = CanUseVectorIndex(*indexDesc, lambdaBody, topBase);
         if (indexDesc->KeyColumns.size() > 1) {
             if (!canUseVectorIndex) {
-                YQL_LOG(WARN) << "Cannot use prefixed vector index for " << topBase.Ref().Dump();
-                //  SELECT SomeDistance(...), ... FROM t VIEW i ... ORDER BY SomeDistance(...) LIMIT k
-                // is supported now
-                return node;
+                return reject("sorting doesn't call distance function, reference distance from projection not supported yet");
             }
-            return TryRewriteTopSortOverPrefixedKMeansTree(node,
-                                                           readTableIndex, maybeFlatMap, *lambdaArgs, lambdaBody, topBase,
-                                                           ctx, kqpCtx, tableDesc, *indexDesc, *implTable);
+            if (!maybeFlatMap.Lambda().Body().Maybe<TCoOptionalIf>()) {
+                return reject("only simple conditions supported for now");
+            }
+            return DoRewriteTopSortOverPrefixedKMeansTree(readTableIndex, maybeFlatMap.Cast(), *lambdaArgs, lambdaBody, topBase,
+                                                          ctx, kqpCtx, tableDesc, *indexDesc, *implTable);
         }
         if (!canUseVectorIndex) {
-            // responsible for
-            // SELECT SomeDistance(...) AS d, ... FROM t VIEW i ... ORDER BY d LIMIT k 
             auto argument = lambdaBody.Maybe<TCoMember>().Struct().Maybe<TCoArgument>();
             if (!argument) {
-                YQL_LOG(WARN) << "Cannot use vector index for " << topBase.Ref().Dump();
-                return node;
+                return reject("sorting doesn't contain distance");
             }
             auto asStruct = maybeFlatMap.Lambda().Body().Maybe<TCoJust>().Input().Maybe<TCoAsStruct>();
             if (!asStruct) {
-                YQL_LOG(WARN) << "Cannot use vector index for " << topBase.Ref().Dump();
-                return node;
+                return reject("only simple projection with distance referenced in sorting supported for now");
             }
 
-            // TODO(mbkkt) I think it shouldn't matter, but for my paranoia I will keep it for now
-            // In general I want to check that result of flat map used as argument for member access in top lambda
-            // But for some reason it starts to fail for same as tests queries in real-world
+            // TODO(mbkkt) I think variable name shouldn't matter, and I only need to check that result of FlatMap
+            // used as argument for member access in top lambda. The name should be same, and it's same in the tests
+            // and was same in real world, but for some reason recently it starts to fail in real-world, so I comment it out
             // const auto argumentName = argument.Cast().Name();
             // if (absl::c_none_of(maybeFlatMap.Cast().Lambda().Args(),
             //         [&](const TCoArgument& argument) { return argumentName == argument.Name(); })) {
-            //     YQL_LOG(WARN) << "Cannot use vector index for " << topBase.Ref().Dump();
-            //     return node;
+            //     return reject("...");
             // }
 
             const auto memberName = lambdaBody.Cast<TCoMember>().Name().Value();
@@ -1168,8 +1094,7 @@ TExprBase KqpRewriteTopSortOverIndexRead(const TExprBase& node, TExprContext& ct
                 break;
             }
             if (!canUseVectorIndex) {
-                YQL_LOG(WARN) << "Cannot use vector index for " << topBase.Ref().Dump();
-                return node;
+                return reject("neither projection nor sorting contain distance");
             }
             lambdaArgs = maybeFlatMap.Cast().Lambda().Args().Raw();
         }

--- a/ydb/core/kqp/ut/indexes/kqp_indexes_ut.cpp
+++ b/ydb/core/kqp/ut/indexes/kqp_indexes_ut.cpp
@@ -2207,18 +2207,24 @@ Y_UNIT_TEST_SUITE(KqpIndexes) {
     }
 
     void DoPositiveQueriesVectorIndex(TSession& session, const TString& mainQuery, const TString& indexQuery) {
-        // TODO(mbkkt) results are not precise so for now can differ between main and index
-        // But they're still should contains exactly 3 unique rows
+        auto toStr = [](const auto& rs) -> TString {
+            TStringBuilder b;
+            for (const auto& r : rs) {
+                b << r << ", ";
+            }
+            return b;
+        };
         auto mainResults = DoPositiveQueryVectorIndex(session, mainQuery);
-        UNIT_ASSERT_EQUAL(mainResults.size(), 3);
-        auto indexResults = DoPositiveQueryVectorIndex(session, indexQuery);
-        UNIT_ASSERT_EQUAL(indexResults.size(), 3);
-
         absl::c_sort(mainResults);
-        UNIT_ASSERT(std::unique(mainResults.begin(), mainResults.end()) == mainResults.end());
+        UNIT_ASSERT_EQUAL_C(mainResults.size(), 3, toStr(mainResults));
+        UNIT_ASSERT_C(std::unique(mainResults.begin(), mainResults.end()) == mainResults.end(), toStr(mainResults));
 
+        auto indexResults = DoPositiveQueryVectorIndex(session, indexQuery);
         absl::c_sort(indexResults);
-        UNIT_ASSERT(std::unique(indexResults.begin(), indexResults.end()) == indexResults.end());
+        UNIT_ASSERT_EQUAL_C(indexResults.size(), 3, toStr(indexResults));
+        UNIT_ASSERT_C(std::unique(indexResults.begin(), indexResults.end()) == indexResults.end(), toStr(indexResults));
+
+        UNIT_ASSERT_VALUES_EQUAL(mainResults, indexResults);
     }
 
     void DoPositiveQueriesVectorIndexOrderBy(
@@ -2227,7 +2233,7 @@ Y_UNIT_TEST_SUITE(KqpIndexes) {
         std::string_view direction,
         std::string_view left,
         std::string_view right) {
-        constexpr std::string_view target = "$target = \"\x67\x73\x03\";";
+        constexpr std::string_view target = "$target = \"\x67\x71\x03\";";
         std::string metric = std::format("Knn::{}({}, {})", function, left, right);
         // no metric in result
         {
@@ -2332,11 +2338,11 @@ Y_UNIT_TEST_SUITE(KqpIndexes) {
                 "(0, \"\x03\x30\x03\", \"0\"),"
                 "(1, \"\x13\x31\x03\", \"1\"),"
                 "(2, \"\x23\x32\x03\", \"2\"),"
-                "(3, \"\x33\x33\x03\", \"3\"),"
+                "(3, \"\x53\x33\x03\", \"3\"),"
                 "(4, \"\x43\x34\x03\", \"4\"),"
-                "(5, \"\x60\x60\x03\", \"5\"),"
-                "(6, \"\x61\x61\x03\", \"6\"),"
-                "(7, \"\x62\x62\x03\", \"7\"),"
+                "(5, \"\x50\x60\x03\", \"5\"),"
+                "(6, \"\x61\x11\x03\", \"6\"),"
+                "(7, \"\x12\x62\x03\", \"7\"),"
                 "(8, \"\x75\x76\x03\", \"8\"),"
                 "(9, \"\x76\x76\x03\", \"9\");"
             ));
@@ -2686,102 +2692,69 @@ Y_UNIT_TEST_SUITE(KqpIndexes) {
         DoPositiveQueriesVectorIndexOrderByCosine(session);
     }
 
-    std::vector<i64> DoPositiveQueryPrefixedVectorIndex(TSession& session, const TString& query) {
-        {
-            auto result = session.ExplainDataQuery(query).ExtractValueSync();
-            UNIT_ASSERT_C(result.IsSuccess(),
-                "Failed to explain: `" << query << "` with " << result.GetIssues().ToString());
-        }
-        {
-            auto result = session.ExecuteDataQuery(query,
-                TTxControl::BeginTx(TTxSettings::SerializableRW()).CommitTx()
-            ).ExtractValueSync();
-            UNIT_ASSERT_C(result.IsSuccess(),
-                "Failed to execute: `" << query << "` with " << result.GetIssues().ToString());
-
-            std::vector<i64> r;
-            auto sets = result.GetResultSets();
-            for (const auto& set : sets) {
-                TResultSetParser parser{set};
-                while (parser.TryNextRow()) {
-                    auto value = parser.GetValue("pk");
-                    UNIT_ASSERT_C(value.GetProto().has_int64_value(), value.GetProto().ShortUtf8DebugString());
-                    r.push_back(value.GetProto().int64_value());
-                }
-            }
-            return r;
-        }
-    }
-
-    void DoPositiveQueriesPrefixedVectorIndex(TSession& session, const TString& mainQuery, const TString& indexQuery) {
-        // TODO(mbkkt) results are not precise so for now can differ between main and index
-        // But they're still should contains exactly 3 unique rows
-        auto mainResults = DoPositiveQueryPrefixedVectorIndex(session, mainQuery);
-        UNIT_ASSERT_EQUAL(mainResults.size(), 3);
-        auto indexResults = DoPositiveQueryPrefixedVectorIndex(session, indexQuery);
-        UNIT_ASSERT_EQUAL(indexResults.size(), 3);
-
-        absl::c_sort(mainResults);
-        UNIT_ASSERT(std::unique(mainResults.begin(), mainResults.end()) == mainResults.end());
-
-        absl::c_sort(indexResults);
-        UNIT_ASSERT(std::unique(indexResults.begin(), indexResults.end()) == indexResults.end());
-    }
-
     void DoPositiveQueriesPrefixedVectorIndexOrderBy(
         TSession& session,
         std::string_view function,
         std::string_view direction,
         std::string_view left,
         std::string_view right) {
-        constexpr std::string_view target = "$target = \"\x67\x73\x03\";";
+        constexpr std::string_view init = 
+            "$target = \"\x67\x68\x03\";\n"
+            "$user = \"user_b\";";
         std::string metric = std::format("Knn::{}({}, {})", function, left, right);
         // no metric in result
         {
             const TString plainQuery(Q1_(std::format(R"({}
                 SELECT * FROM `/Root/TestTable`
+                WHERE user = $user
                 ORDER BY {} {}
                 LIMIT 3;
-            )", target, metric, direction)));
+            )", init, metric, direction)));
             const TString indexQuery(Q1_(std::format(R"(
                 pragma ydb.KMeansTreeSearchTopSize = "3";
                 {}
                 SELECT * FROM `/Root/TestTable` VIEW index
+                WHERE user = $user
                 ORDER BY {} {}
                 LIMIT 3;
-            )", target, metric, direction)));
-            DoPositiveQueriesPrefixedVectorIndex(session, plainQuery, indexQuery);
+            )", init, metric, direction)));
+            DoPositiveQueriesVectorIndex(session, plainQuery, indexQuery);
         }
         // metric in result
         {
             const TString plainQuery(Q1_(std::format(R"({}
                 SELECT {}, `/Root/TestTable`.* FROM `/Root/TestTable`
+                WHERE user = $user
                 ORDER BY {} {}
                 LIMIT 3;
-            )", target, metric, metric, direction)));
+            )", init, metric, metric, direction)));
             const TString indexQuery(Q1_(std::format(R"({}
                 pragma ydb.KMeansTreeSearchTopSize = "2";
                 SELECT {}, `/Root/TestTable`.* FROM `/Root/TestTable` VIEW index
+                WHERE user = $user
                 ORDER BY {} {}
                 LIMIT 3;
-            )", target, metric, metric, direction)));
-            DoPositiveQueriesPrefixedVectorIndex(session, plainQuery, indexQuery);
+            )", init, metric, metric, direction)));
+            DoPositiveQueriesVectorIndex(session, plainQuery, indexQuery);
         }
         // metric as result
-        {
+        // TODO(mbkkt) fix this behavior too
+        if constexpr (false) {
             const TString plainQuery(Q1_(std::format(R"({}
                 SELECT {} AS m, `/Root/TestTable`.* FROM `/Root/TestTable`
+                WHERE user = $user
                 ORDER BY m {}
                 LIMIT 3;
-            )", target, metric, direction)));
+            )", init, metric, direction)));
             const TString indexQuery(Q1_(std::format(R"(
                 pragma ydb.KMeansTreeSearchTopSize = "1";
                 {}
                 SELECT {} AS m, `/Root/TestTable`.* FROM `/Root/TestTable` VIEW index
+                WHERE user = $user
                 ORDER BY m {}
                 LIMIT 3;
-            )", target, metric, direction)));
-            DoPositiveQueriesPrefixedVectorIndex(session, plainQuery, indexQuery);
+            )", init, metric, direction)));
+            DoPositiveQueriesVectorIndex(session, plainQuery, indexQuery);
         }
     }
 
@@ -2827,8 +2800,8 @@ Y_UNIT_TEST_SUITE(KqpIndexes) {
                 .SetMinPartitionsCount(3)
             .EndPartitioningSettings();
             auto partitions = TExplicitPartitions{}
-                .AppendSplitPoints(TValueBuilder{}.BeginTuple().AddElement().OptionalInt64(4).EndTuple().Build())
-                .AppendSplitPoints(TValueBuilder{}.BeginTuple().AddElement().OptionalInt64(6).EndTuple().Build());
+                .AppendSplitPoints(TValueBuilder{}.BeginTuple().AddElement().OptionalInt64(40).EndTuple().Build())
+                .AppendSplitPoints(TValueBuilder{}.BeginTuple().AddElement().OptionalInt64(60).EndTuple().Build());
             tableBuilder.SetPartitionAtKeys(partitions);
             auto result = session.CreateTable("/Root/TestTable", tableBuilder.Build()).ExtractValueSync();
             UNIT_ASSERT_VALUES_EQUAL(result.IsTransportError(), false);
@@ -2838,38 +2811,38 @@ Y_UNIT_TEST_SUITE(KqpIndexes) {
         {
             const TString query1(Q_(R"(
                 UPSERT INTO `/Root/TestTable` (pk, user, emb, data) VALUES)"
-                "(0, \"user_a\", \"\x03\x30\x03\", \"0\"),"
-                "(1, \"user_a\", \"\x13\x31\x03\", \"1\"),"
-                "(2, \"user_a\", \"\x23\x32\x03\", \"2\"),"
-                "(3, \"user_a\", \"\x33\x33\x03\", \"3\"),"
-                "(4, \"user_a\", \"\x43\x34\x03\", \"4\"),"
-                "(5, \"user_a\", \"\x60\x60\x03\", \"5\"),"
-                "(6, \"user_a\", \"\x61\x61\x03\", \"6\"),"
-                "(7, \"user_a\", \"\x62\x62\x03\", \"7\"),"
-                "(8, \"user_a\", \"\x75\x76\x03\", \"8\"),"
-                "(9, \"user_a\", \"\x76\x76\x03\", \"9\"),"
+                "( 1, \"user_a\", \"\x03\x30\x03\", \"0\"),"
+                "(11, \"user_a\", \"\x13\x31\x03\", \"1\"),"
+                "(21, \"user_a\", \"\x23\x32\x03\", \"2\"),"
+                "(31, \"user_a\", \"\x53\x33\x03\", \"3\"),"
+                "(41, \"user_a\", \"\x43\x34\x03\", \"4\"),"
+                "(51, \"user_a\", \"\x50\x60\x03\", \"5\"),"
+                "(61, \"user_a\", \"\x61\x61\x03\", \"6\"),"
+                "(71, \"user_a\", \"\x12\x62\x03\", \"7\"),"
+                "(81, \"user_a\", \"\x75\x76\x03\", \"8\"),"
+                "(91, \"user_a\", \"\x76\x76\x03\", \"9\"),"
 
-                "(0, \"user_b\", \"\x03\x30\x03\", \"0\"),"
-                "(1, \"user_b\", \"\x13\x31\x03\", \"1\"),"
-                "(2, \"user_b\", \"\x23\x32\x03\", \"2\"),"
-                "(3, \"user_b\", \"\x33\x33\x03\", \"3\"),"
-                "(4, \"user_b\", \"\x43\x34\x03\", \"4\"),"
-                "(5, \"user_b\", \"\x60\x60\x03\", \"5\"),"
-                "(6, \"user_b\", \"\x61\x61\x03\", \"6\"),"
-                "(7, \"user_b\", \"\x62\x62\x03\", \"7\"),"
-                "(8, \"user_b\", \"\x75\x76\x03\", \"8\"),"
-                "(9, \"user_b\", \"\x76\x76\x03\", \"9\"),"
+                "( 2, \"user_b\", \"\x03\x30\x03\", \"0\"),"
+                "(12, \"user_b\", \"\x13\x31\x03\", \"1\"),"
+                "(22, \"user_b\", \"\x23\x32\x03\", \"2\"),"
+                "(32, \"user_b\", \"\x53\x33\x03\", \"3\"),"
+                "(42, \"user_b\", \"\x43\x34\x03\", \"4\"),"
+                "(52, \"user_b\", \"\x50\x60\x03\", \"5\"),"
+                "(62, \"user_b\", \"\x61\x61\x03\", \"6\"),"
+                "(72, \"user_b\", \"\x12\x62\x03\", \"7\"),"
+                "(82, \"user_b\", \"\x75\x76\x03\", \"8\"),"
+                "(92, \"user_b\", \"\x76\x76\x03\", \"9\"),"
 
-                "(0, \"user_c\", \"\x03\x30\x03\", \"0\"),"
-                "(1, \"user_c\", \"\x13\x31\x03\", \"1\"),"
-                "(2, \"user_c\", \"\x23\x32\x03\", \"2\"),"
-                "(3, \"user_c\", \"\x33\x33\x03\", \"3\"),"
-                "(4, \"user_c\", \"\x43\x34\x03\", \"4\"),"
-                "(5, \"user_c\", \"\x60\x60\x03\", \"5\"),"
-                "(6, \"user_c\", \"\x61\x61\x03\", \"6\"),"
-                "(7, \"user_c\", \"\x62\x62\x03\", \"7\"),"
-                "(8, \"user_c\", \"\x75\x76\x03\", \"8\"),"
-                "(9, \"user_c\", \"\x76\x76\x03\", \"9\");"
+                "( 3, \"user_c\", \"\x03\x30\x03\", \"0\"),"
+                "(13, \"user_c\", \"\x13\x31\x03\", \"1\"),"
+                "(23, \"user_c\", \"\x23\x32\x03\", \"2\"),"
+                "(33, \"user_c\", \"\x53\x33\x03\", \"3\"),"
+                "(43, \"user_c\", \"\x43\x34\x03\", \"4\"),"
+                "(53, \"user_c\", \"\x50\x60\x03\", \"5\"),"
+                "(63, \"user_c\", \"\x61\x61\x03\", \"6\"),"
+                "(73, \"user_c\", \"\x12\x62\x03\", \"7\"),"
+                "(83, \"user_c\", \"\x75\x76\x03\", \"8\"),"
+                "(93, \"user_c\", \"\x76\x76\x03\", \"9\");"
             ));
 
             auto result = session.ExecuteDataQuery(
@@ -2923,8 +2896,7 @@ Y_UNIT_TEST_SUITE(KqpIndexes) {
             UNIT_ASSERT_EQUAL(settings.Levels, 1);
             UNIT_ASSERT_EQUAL(settings.Clusters, 2);
         }
-        // TODO(mbkkt) enable it when kqp part will be ready
-        // DoPositiveQueriesPrefixedVectorIndexOrderByCosine(session);
+        DoPositiveQueriesPrefixedVectorIndexOrderByCosine(session);
     }
 
     Y_UNIT_TEST(PrefixedVectorIndexOrderByCosineSimilarityNotNullableLevel1) {
@@ -2969,8 +2941,7 @@ Y_UNIT_TEST_SUITE(KqpIndexes) {
             UNIT_ASSERT_EQUAL(settings.Levels, 1);
             UNIT_ASSERT_EQUAL(settings.Clusters, 2);
         }
-        // TODO(mbkkt) enable it when kqp part will be ready
-        // DoPositiveQueriesPrefixedVectorIndexOrderByCosine(session);
+        DoPositiveQueriesPrefixedVectorIndexOrderByCosine(session);
     }
 
     Y_UNIT_TEST(PrefixedVectorIndexOrderByCosineDistanceNullableLevel1) {
@@ -3107,8 +3078,7 @@ Y_UNIT_TEST_SUITE(KqpIndexes) {
             UNIT_ASSERT_EQUAL(settings.Levels, 2);
             UNIT_ASSERT_EQUAL(settings.Clusters, 2);
         }
-        // TODO(mbkkt) enable it when kqp part will be ready
-        // DoPositiveQueriesPrefixedVectorIndexOrderByCosine(session);
+        DoPositiveQueriesPrefixedVectorIndexOrderByCosine(session);
     }
 
     Y_UNIT_TEST(PrefixedVectorIndexOrderByCosineSimilarityNotNullableLevel2) {
@@ -3153,8 +3123,7 @@ Y_UNIT_TEST_SUITE(KqpIndexes) {
             UNIT_ASSERT_EQUAL(settings.Levels, 2);
             UNIT_ASSERT_EQUAL(settings.Clusters, 2);
         }
-        // TODO(mbkkt) enable it when kqp part will be ready
-        // DoPositiveQueriesPrefixedVectorIndexOrderByCosine(session);
+        DoPositiveQueriesPrefixedVectorIndexOrderByCosine(session);
     }
 
     Y_UNIT_TEST(PrefixedVectorIndexOrderByCosineDistanceNullableLevel2) {

--- a/ydb/core/kqp/ut/indexes/kqp_indexes_ut.cpp
+++ b/ydb/core/kqp/ut/indexes/kqp_indexes_ut.cpp
@@ -2986,8 +2986,7 @@ Y_UNIT_TEST_SUITE(KqpIndexes) {
             UNIT_ASSERT_EQUAL(settings.Levels, 1);
             UNIT_ASSERT_EQUAL(settings.Clusters, 2);
         }
-        // TODO(mbkkt) enable it when kqp part will be ready
-        // DoPositiveQueriesPrefixedVectorIndexOrderByCosine(session);
+        DoPositiveQueriesPrefixedVectorIndexOrderByCosine(session);
     }
 
     Y_UNIT_TEST(PrefixedVectorIndexOrderByCosineSimilarityNullableLevel1) {
@@ -3032,8 +3031,7 @@ Y_UNIT_TEST_SUITE(KqpIndexes) {
             UNIT_ASSERT_EQUAL(settings.Levels, 1);
             UNIT_ASSERT_EQUAL(settings.Clusters, 2);
         }
-        // TODO(mbkkt) enable it when kqp part will be ready
-        // DoPositiveQueriesPrefixedVectorIndexOrderByCosine(session);
+        DoPositiveQueriesPrefixedVectorIndexOrderByCosine(session);
     }
 
     Y_UNIT_TEST(PrefixedVectorIndexOrderByCosineDistanceNotNullableLevel2) {
@@ -3168,8 +3166,7 @@ Y_UNIT_TEST_SUITE(KqpIndexes) {
             UNIT_ASSERT_EQUAL(settings.Levels, 2);
             UNIT_ASSERT_EQUAL(settings.Clusters, 2);
         }
-        // TODO(mbkkt) enable it when kqp part will be ready
-        // DoPositiveQueriesPrefixedVectorIndexOrderByCosine(session);
+        DoPositiveQueriesPrefixedVectorIndexOrderByCosine(session);
     }
 
     Y_UNIT_TEST(PrefixedVectorIndexOrderByCosineSimilarityNullableLevel2) {
@@ -3214,8 +3211,7 @@ Y_UNIT_TEST_SUITE(KqpIndexes) {
             UNIT_ASSERT_EQUAL(settings.Levels, 2);
             UNIT_ASSERT_EQUAL(settings.Clusters, 2);
         }
-        // TODO(mbkkt) enable it when kqp part will be ready
-        // DoPositiveQueriesPrefixedVectorIndexOrderByCosine(session);
+        DoPositiveQueriesPrefixedVectorIndexOrderByCosine(session);
     }
 
     Y_UNIT_TEST(ExplainCollectFullDiagnostics) {


### PR DESCRIPTION
### Changelog category <!-- remove all except one -->

* Not for changelog (changelog entry is not required)

### Description for reviewers <!-- (optional) description for those who read this PR -->

for prefixed vector index

* works `SELECT SomeDistance(...) AS d, ... FROM t VIEW i ... WHERE ... ORDER BY SomeDistance(...) LIMIT k` for prefixed vector index
* `SELECT SomeDistance(...) AS d, ... FROM t VIEW i ... ORDER BY d LIMIT k` fixed for vector index
* `SELECT SomeDistance(...) AS d, ... FROM t VIEW i ... WHERE ... ORDER BY d LIMIT k`  is todo for vector index