### PR TITLE
Allow tablets to reboot on event parsing failure

### DIFF
--- a/ydb/library/actors/core/actorid.h
+++ b/ydb/library/actors/core/actorid.h
@@ -49,8 +49,8 @@ namespace NActors {
             Raw.N.NodeId = nodeId | (poolId << PoolIndexShift);
         }
 
-        explicit TActorId(ui32 nodeId, const TStringBuf& x) noexcept {
-            Y_ABORT_UNLESS(x.size() <= MaxServiceIDLength, "service id is too long");
+        explicit TActorId(ui32 nodeId, const TStringBuf& x) {
+            Y_ENSURE(x.size() <= MaxServiceIDLength, "service id is too long");
             Raw.N.LocalId = 0;
             Raw.N.Hint = 0;
             Raw.N.NodeId = nodeId | ServiceMask;

--- a/ydb/library/actors/core/actorsystem.cpp
+++ b/ydb/library/actors/core/actorsystem.cpp
@@ -204,10 +204,8 @@ namespace NActors {
             if (ev->HasBuffer()) {
                 CheckEventMemory(ev->GetChainBuffer());
             }
-            Y_ABORT_UNLESS(ev->Recipient == recipient,
-                "Event rewrite from %s to %s would be lost via interconnect",
-                ev->Recipient.ToString().c_str(),
-                recipient.ToString().c_str());
+            Y_ENSURE(ev->Recipient == recipient,
+                "Event rewrite from " << ev->Recipient << " to " << recipient << " would be lost via interconnect");
             recipient = InterconnectProxy(recpNodeId);
             ev->Rewrite(TEvInterconnect::EvForward, recipient);
         }

--- a/ydb/library/actors/core/event.h
+++ b/ydb/library/actors/core/event.h
@@ -88,8 +88,8 @@ namespace NActors {
 
         template <typename TEventType>
         TEventType* Get() {
-            if (Type != TEventType::EventType)
-                Y_ABORT("Event type %" PRIu32 " doesn't match the expected type %" PRIu32, Type, TEventType::EventType);
+            Y_ENSURE(Type == TEventType::EventType,
+                "Event type " << Type << " doesn't match the expected type " << TEventType::EventType);
 
             if (!Event) {
                 static TEventSerializedData empty;
@@ -100,7 +100,7 @@ namespace NActors {
                 return static_cast<TEventType*>(Event.Get());
             }
 
-            Y_ABORT("Failed to Load() event type %" PRIu32 " class %s", Type, TypeName<TEventType>().data());
+            Y_ENSURE(false, "Failed to Load() event type " << Type << " class " << TypeName<TEventType>());
         }
 
         template <typename T>
@@ -154,8 +154,8 @@ namespace NActors {
         }
 
         static ui32 MakeFlags(ui32 channel, TEventFlags flags) {
-            Y_ABORT_UNLESS(channel < (1 << ChannelBits));
-            Y_ABORT_UNLESS(flags < (1 << ChannelShift));
+            Y_ENSURE(channel < (1 << ChannelBits));
+            Y_ENSURE(flags < (1 << ChannelShift));
             return (flags | (channel << ChannelShift));
         }
 
@@ -405,7 +405,7 @@ namespace NActors {
         Y_ABORT("Local event " #eventType " is not serializable");       \
     }                                                                   \
     static IEventBase* Load(NActors::TEventSerializedData*) {           \
-        Y_ABORT("Local event " #eventType " has no load method");        \
+        Y_ENSURE(false, "Local event " #eventType " has no load method"); \
     }                                                                   \
     bool IsSerializable() const override {                              \
         return false;                                                   \

--- a/ydb/library/actors/core/event_load.h
+++ b/ydb/library/actors/core/event_load.h
@@ -93,7 +93,7 @@ namespace NActors {
         }
 
         TRope EraseBack(size_t count) {
-            Y_ABORT_UNLESS(count <= Rope.GetSize());
+            Y_ENSURE(count <= Rope.GetSize());
             TRope::TIterator iter = Rope.End();
             iter -= count;
             return Rope.Extract(iter, Rope.End());

--- a/ydb/library/actors/core/event_local.h
+++ b/ydb/library/actors/core/event_local.h
@@ -22,7 +22,7 @@ namespace NActors {
         }
 
         static IEventBase* Load(TEventSerializedData*) {
-            Y_ABORT("Loading of local event %s type %" PRIu32, TypeName<TEv>().data(), TEventType);
+            Y_ENSURE(false, "Loading of local event " << TypeName<TEv>() << " type " << TEventType);
         }
     };
 

--- a/ydb/library/actors/core/event_pb.cpp
+++ b/ydb/library/actors/core/event_pb.cpp
@@ -24,7 +24,7 @@ namespace NActors {
     }
 
     void TRopeStream::BackUp(int count) {
-        Y_ABORT_UNLESS(count <= TotalByteCount);
+        Y_ENSURE(count <= TotalByteCount);
         Iter -= count;
         TotalByteCount -= count;
     }
@@ -218,7 +218,7 @@ namespace NActors {
     }
 
     bool TAllocChunkSerializer::WriteAliasedRaw(const void*, int) {
-        Y_ABORT_UNLESS(false);
+        Y_ENSURE(false);
         return false;
     }
 
@@ -317,7 +317,7 @@ namespace NActors {
     {
         // check marker
         if (!iter.Valid() || (*iter.ContiguousData() != PayloadMarker && *iter.ContiguousData() != ExtendedPayloadMarker)) {
-            Y_ABORT("invalid event");
+            Y_ENSURE(false, "invalid event");
         }
 
         const bool dataIsSeparate = *iter.ContiguousData() == ExtendedPayloadMarker; // ropes go after sizes
@@ -336,7 +336,7 @@ namespace NActors {
         // parse number of payload ropes
         size_t numRopes = DeserializeNumber(iter, size);
         if (numRopes == Max<size_t>()) {
-            Y_ABORT("invalid event");
+            Y_ENSURE(false, "invalid event");
         }
         TStackVec<size_t, 16> ropeLens;
         if (dataIsSeparate) {
@@ -347,7 +347,7 @@ namespace NActors {
             // parse length of the rope
             const size_t len = DeserializeNumber(iter, size);
             if (len == Max<size_t>() || size < len) {
-                Y_ABORT("invalid event len# %zu size# %" PRIu64, len, size);
+                Y_ENSURE(false, "invalid event len# " << len << " size# " << size);
             }
             // extract the rope
             if (dataIsSeparate) {
@@ -404,8 +404,8 @@ namespace NActors {
                     total += section.Size;
                 }
                 size_t serialized = CalculateSerializedSizeImpl(payload, recordSize);
-                Y_ABORT_UNLESS(total == serialized, "total# %zu serialized# %zu byteSize# %zd payload.size# %zu", total,
-                    serialized, byteSize, payload.size());
+                Y_ENSURE(total == serialized, "total# " << total << " serialized# " << serialized
+                    << " byteSize# " << byteSize << " payload.size# " << payload.size());
 #endif
             }
 

--- a/ydb/library/actors/core/event_pb.h
+++ b/ydb/library/actors/core/event_pb.h
@@ -205,7 +205,8 @@ namespace NActors {
         static IEventBase* Load(TEventSerializedData *input) {
             THolder<TEventPBBase> ev(new TEv());
             if (!input->GetSize()) {
-                Y_PROTOBUF_SUPPRESS_NODISCARD ev->Record.ParseFromString(TString());
+                Y_ENSURE(ev->Record.ParseFromString(TString()),
+                    "Failed to parse protobuf event type " << TEventType << " class " << TypeName(ev->Record));
             } else {
                 TRope::TConstIterator iter = input->GetBeginIter();
                 ui64 size = input->GetSize();
@@ -217,7 +218,7 @@ namespace NActors {
                 // parse the protobuf
                 TRopeStream stream(iter, size);
                 if (!ev->Record.ParseFromZeroCopyStream(&stream)) {
-                    Y_ABORT("Failed to parse protobuf event type %" PRIu32 " class %s", TEventType, TypeName(ev->Record).data());
+                    Y_ENSURE(false, "Failed to parse protobuf event type " << TEventType << " class " << TypeName(ev->Record));
                 }
             }
             ev->CachedByteSize = input->GetSize();
@@ -257,7 +258,7 @@ namespace NActors {
         }
 
         const TRope& GetPayload(ui32 id) const {
-            Y_ABORT_UNLESS(id < Payload.size());
+            Y_ENSURE(id < Payload.size());
             return Payload[id];
         }
 

--- a/ydb/library/actors/core/events_undelivered.cpp
+++ b/ydb/library/actors/core/events_undelivered.cpp
@@ -31,7 +31,7 @@ namespace NActors {
 
     IEventBase* TEvents::TEvUndelivered::Load(TEventSerializedData* bufs) {
         TString str = bufs->GetString();
-        Y_ABORT_UNLESS(str.size() == (sizeof(ui32) + sizeof(ui32)));
+        Y_ENSURE(str.size() == (sizeof(ui32) + sizeof(ui32)));
         const char* p = str.data();
         const ui64 sourceType = ReadUnaligned<ui32>(p + 0);
         const ui64 reason = ReadUnaligned<ui32>(p + 4);


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

...

### Changelog category <!-- remove all except one -->

* Not for changelog (changelog entry is not required)

### Description for reviewers <!-- (optional) description for those who read this PR -->

Replace some Y_ABORTs with Y_ENSUREs in the actor system. This will allow tablets to reboot in very rare cases where event parsing fails (e.g. due to protocol mismatches).