### PR TITLE
Add client timeout histogram for grpc call metrics. (#16065)

### DIFF
--- a/ydb/library/actors/interconnect/interconnect_channel.h
+++ b/ydb/library/actors/interconnect/interconnect_channel.h
@@ -90,7 +90,7 @@ namespace NActors {
 
         void DropConfirmed(ui64 confirm, TEventHolderPool& pool);
 
-        bool FeedBuf(TTcpPacketOutTask& task, ui64 serial, ui64 *weightConsumed);
+        bool FeedBuf(TTcpPacketOutTask& task, ui64 serial);
 
         bool IsEmpty() const {
             return Queue.empty();
@@ -144,11 +144,11 @@ namespace NActors {
         template<bool External>
         bool SerializeEvent(TTcpPacketOutTask& task, TEventHolder& event, size_t *bytesSerialized);
 
-        bool FeedPayload(TTcpPacketOutTask& task, TEventHolder& event, ui64 *weightConsumed);
-        std::optional<bool> FeedInlinePayload(TTcpPacketOutTask& task, TEventHolder& event, ui64 *weightConsumed);
-        std::optional<bool> FeedExternalPayload(TTcpPacketOutTask& task, TEventHolder& event, ui64 *weightConsumed);
+        bool FeedPayload(TTcpPacketOutTask& task, TEventHolder& event);
+        std::optional<bool> FeedInlinePayload(TTcpPacketOutTask& task, TEventHolder& event);
+        std::optional<bool> FeedExternalPayload(TTcpPacketOutTask& task, TEventHolder& event);
 
-        bool FeedDescriptor(TTcpPacketOutTask& task, TEventHolder& event, ui64 *weightConsumed);
+        bool FeedDescriptor(TTcpPacketOutTask& task, TEventHolder& event);
 
         void AccountTraffic() {
             if (const ui64 amount = std::exchange(UnaccountedTraffic, 0)) {

--- a/ydb/library/actors/interconnect/interconnect_tcp_session.cpp
+++ b/ydb/library/actors/interconnect/interconnect_tcp_session.cpp
@@ -1005,8 +1005,11 @@ namespace NActors {
 
             // generate some data within this channel
             const ui64 netBefore = channel->GetBufferedAmountOfData();
-            ui64 gross = 0;
-            const bool eventDone = channel->FeedBuf(task, serial, &gross);
+            const ui32 grossBefore = task.GetDataSize();
+            const bool eventDone = channel->FeedBuf(task, serial);
+            const ui32 grossAfter = task.GetDataSize();
+            Y_DEBUG_ABORT_UNLESS(grossBefore <= grossAfter);
+            const ui32 gross = grossAfter - grossBefore;
             channel->UnaccountedTraffic += gross;
             const ui64 netAfter = channel->GetBufferedAmountOfData();
             Y_DEBUG_ABORT_UNLESS(netAfter <= netBefore); // net amount should shrink
@@ -1016,7 +1019,7 @@ namespace NActors {
             TotalOutputQueueSize -= net;
             Proxy->Metrics->SubOutputBuffersTotalSize(net);
             bytesGenerated += gross;
-            Y_DEBUG_ABORT_UNLESS(!!net == !!gross && gross >= net, "net# %" PRIu64 " gross# %" PRIu64, net, gross);
+            Y_DEBUG_ABORT_UNLESS(gross || !net, "net# %" PRIu64 " gross# %" PRIu32, net, gross);
 
             // return it back to queue or delete, depending on whether this channel is still working or not
             ChannelScheduler->FinishPick(gross, EqualizeCounter);

--- a/ydb/library/actors/interconnect/ut/channel_scheduler_ut.cpp
+++ b/ydb/library/actors/interconnect/ut/channel_scheduler_ut.cpp
@@ -59,8 +59,9 @@ Y_UNIT_TEST_SUITE(ChannelScheduler) {
             while (numEvents) {
                 TEventOutputChannel *channel = scheduler.PickChannelWithLeastConsumedWeight();
                 ui32 before = task.GetDataSize();
-                ui64 weightConsumed = 0;
-                numEvents -= channel->FeedBuf(task, 0, &weightConsumed);
+                ui64 weightConsumed = task.GetDataSize();
+                numEvents -= channel->FeedBuf(task, 0);
+                weightConsumed = task.GetDataSize() - weightConsumed;
                 ui32 after = task.GetDataSize();
                 Y_ABORT_UNLESS(after >= before);
                 scheduler.FinishPick(weightConsumed, 0);


### PR DESCRIPTION
In case of investigation problems with unexpected timeout response It is helpful to know actual timeout for grpc call from the server perspective

