### PR TITLE
Add feature flags to switch between configs v1 and v2

### DIFF
--- a/ydb/core/grpc_services/rpc_config.cpp
+++ b/ydb/core/grpc_services/rpc_config.cpp
@@ -226,6 +226,8 @@ public:
 
         auto shim = ConvertConfigReplaceRequest(*request);
 
+        const auto& ff = AppData()->FeatureFlags;
+
         return std::make_unique<TEvBlobStorage::TEvControllerReplaceConfigRequest>(
             shim.MainConfig,
             shim.StorageConfig,
@@ -233,8 +235,8 @@ public:
             shim.DedicatedConfigMode,
             request->allow_unknown_fields() || request->bypass_checks(),
             request->bypass_checks(),
-            false /* TODO: implement */,
-            false /* TODO: implement */);
+            /*enableConfigV2=*/ ff.GetSwitchToConfigV2(),
+            /*disableConfigV2=*/ ff.GetSwitchToConfigV1());
     }
 
 private:

--- a/ydb/core/protos/feature_flags.proto
+++ b/ydb/core/protos/feature_flags.proto
@@ -202,4 +202,6 @@ message TFeatureFlags {
     optional bool EnableTabletRestartOnUnhandledExceptions = 176 [default = true];
     optional bool EnableKafkaTransactions = 177 [default = false];
     optional bool EnableLoginCache = 178 [default = false];
+    optional bool SwitchToConfigV2 = 179 [default = false];
+    optional bool SwitchToConfigV1 = 180 [default = false];
 }


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

Add feature flags to switch between configs v1 and v2

### Changelog category <!-- remove all except one -->

* Not for changelog (changelog entry is not required)

### Description for reviewers <!-- (optional) description for those who read this PR -->

Migration between configs v1 and v2 can be done through feature flags from now on.
