### PR TITLE
Allow to skip discovery routine in the C++ SDK for driver/client scope.

### DIFF
--- a/ydb/public/sdk/cpp/include/ydb-cpp-sdk/client/types/ydb.h
+++ b/ydb/public/sdk/cpp/include/ydb-cpp-sdk/client/types/ydb.h
@@ -16,7 +16,10 @@ enum class EDiscoveryMode {
     //! we got endpoint list. The error will be returned if the endpoint list
     //! is empty and discovery failed
     //! This method is a bit more "user friendly" but can produce additional hidden latency
-    Async
+    Async,
+    //! Do not perform discovery.
+    //! This option disables database discovery and allow to use user provided endpoint for grpc connections
+    Off
 };
 
 enum class EBalancingPolicy {

--- a/ydb/public/sdk/cpp/tests/unit/client/driver/driver_ut.cpp
+++ b/ydb/public/sdk/cpp/tests/unit/client/driver/driver_ut.cpp
@@ -184,7 +184,7 @@ Y_UNIT_TEST_SUITE(CppGrpcClientSimpleTest) {
         UNIT_ASSERT_VALUES_EQUAL(session.GetId(), "my-session-id");
     }
 
-    Y_UNIT_TEST(WithoutDiscovery) {
+    Y_UNIT_TEST(WithoutDiscoveryDriverLevel) {
         TPortManager pm;
 
         // Start our mock table service
@@ -208,4 +208,29 @@ Y_UNIT_TEST_SUITE(CppGrpcClientSimpleTest) {
         auto session = sessionResult.GetSession();
         UNIT_ASSERT_VALUES_EQUAL(session.GetId(), "my-session-id");
     }
+
+    Y_UNIT_TEST(WithoutDiscoveryClientLevel) {
+        TPortManager pm;
+
+        // Start our mock table service
+        TMockTableService tableService;
+        ui16 tablePort = pm.GetPort();
+        auto tableServer = StartGrpcServer(
+                TStringBuilder() << "127.0.0.1:" << tablePort,
+                tableService);
+
+        auto driver = TDriver(
+            TDriverConfig()
+                .SetEndpoint(TStringBuilder() << "localhost:" << tablePort)
+                .SetDatabase("/Root/My/DB"));
+        auto client = NTable::TTableClient(driver, TClientSettings().DiscoveryMode(EDiscoveryMode::Off));
+        auto sessionFuture = client.CreateSession();
+
+        UNIT_ASSERT(sessionFuture.Wait(TDuration::Seconds(10)));
+        auto sessionResult = sessionFuture.ExtractValueSync();
+        UNIT_ASSERT(sessionResult.IsSuccess());
+        auto session = sessionResult.GetSession();
+        UNIT_ASSERT_VALUES_EQUAL(session.GetId(), "my-session-id");
+    }
+
 }

--- a/ydb/public/sdk/cpp/tests/unit/client/driver/driver_ut.cpp
+++ b/ydb/public/sdk/cpp/tests/unit/client/driver/driver_ut.cpp
@@ -183,4 +183,29 @@ Y_UNIT_TEST_SUITE(CppGrpcClientSimpleTest) {
         auto session = sessionResult.GetSession();
         UNIT_ASSERT_VALUES_EQUAL(session.GetId(), "my-session-id");
     }
+
+    Y_UNIT_TEST(WithoutDiscovery) {
+        TPortManager pm;
+
+        // Start our mock table service
+        TMockTableService tableService;
+        ui16 tablePort = pm.GetPort();
+        auto tableServer = StartGrpcServer(
+                TStringBuilder() << "127.0.0.1:" << tablePort,
+                tableService);
+
+        auto driver = TDriver(
+            TDriverConfig()
+                .SetEndpoint(TStringBuilder() << "localhost:" << tablePort)
+                .SetDiscoveryMode(EDiscoveryMode::Off)
+                .SetDatabase("/Root/My/DB"));
+        auto client = NTable::TTableClient(driver);
+        auto sessionFuture = client.CreateSession();
+
+        UNIT_ASSERT(sessionFuture.Wait(TDuration::Seconds(10)));
+        auto sessionResult = sessionFuture.ExtractValueSync();
+        UNIT_ASSERT(sessionResult.IsSuccess());
+        auto session = sessionResult.GetSession();
+        UNIT_ASSERT_VALUES_EQUAL(session.GetId(), "my-session-id");
+    }
 }


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

in some cases (k8s clusters, other network LB solutions) we need to skip client balancer and use database endpoint to perform query.

Old way to do it - configure it for each request.

### Changelog category <!-- remove all except one -->

* New feature

### Description for reviewers <!-- (optional) description for those who read this PR -->

...
