### PR TITLE
refactor 'ydb scheme rmdir' implementation

### DIFF
--- a/ydb/apps/ydb/CHANGELOG.md
+++ b/ydb/apps/ydb/CHANGELOG.md
@@ -1,3 +1,4 @@
+* Fixed bugs in `ydb scheme rmdir`: 1) do not try to delete subdomains, 2) order the deletion of external tables before the deletion of external data sources.
 * YDB CLI help message improvements. Different display for detailed help and brief help.
 * Support coordination nodes in `ydb scheme rmdir --recursive`.
 * Fixed return code of command `ydb workload * run --check-canonical` for the case when benchmark query results differ from canonical ones.

--- a/ydb/library/backup/backup.cpp
+++ b/ydb/library/backup/backup.cpp
@@ -935,7 +935,7 @@ void RemoveClusterDirectory(const TDriver& driver, const TString& path) {
 
 void RemoveClusterDirectoryRecursive(const TDriver& driver, const TString& path) {
     LOG_I("Remove temporary directory " << path.Quote() << " in database");
-    TStatus status = NConsoleClient::RemoveDirectoryRecursive(driver, path, {});
+    TStatus status = NConsoleClient::RemoveDirectoryRecursive(driver, path);
     VerifyStatus(status, TStringBuilder() << "Remove temporary directory " << path.Quote() << " failed");
 }
 

--- a/ydb/library/backup/backup.cpp
+++ b/ydb/library/backup/backup.cpp
@@ -935,9 +935,7 @@ void RemoveClusterDirectory(const TDriver& driver, const TString& path) {
 
 void RemoveClusterDirectoryRecursive(const TDriver& driver, const TString& path) {
     LOG_I("Remove temporary directory " << path.Quote() << " in database");
-    NScheme::TSchemeClient schemeClient(driver);
-    NTable::TTableClient tableClient(driver);
-    TStatus status = NConsoleClient::RemoveDirectoryRecursive(schemeClient, tableClient, path, {}, true, false);
+    TStatus status = NConsoleClient::RemoveDirectoryRecursive(driver, path, {});
     VerifyStatus(status, TStringBuilder() << "Remove temporary directory " << path.Quote() << " failed");
 }
 

--- a/ydb/public/lib/ydb_cli/commands/ydb_service_scheme.cpp
+++ b/ydb/public/lib/ydb_cli/commands/ydb_service_scheme.cpp
@@ -87,12 +87,10 @@ int TCommandRemoveDirectory::Run(TConfig& config) {
     const auto settings = FillSettings(NScheme::TRemoveDirectorySettings());
 
     if (Recursive) {
-        NTable::TTableClient tableClient(driver);
-        NTopic::TTopicClient topicClient(driver);
-        NQuery::TQueryClient queryClient(driver);
-        NCoordination::TClient coordinationClient(driver);
-        const auto prompt = Prompt.GetOrElse(ERecursiveRemovePrompt::Once);
-        NStatusHelpers::ThrowOnErrorOrPrintIssues(RemoveDirectoryRecursive(schemeClient, tableClient, &topicClient, &queryClient, &coordinationClient, Path, prompt, settings));
+        const auto settings = TRemoveDirectoryRecursiveSettings()
+            .Prompt(Prompt.GetOrElse(ERecursiveRemovePrompt::Once))
+            .CreateProgressBar(true);
+        NStatusHelpers::ThrowOnErrorOrPrintIssues(RemoveDirectoryRecursive(driver, Path, settings));
     } else {
         if (Prompt) {
             if (!NConsoleClient::Prompt(*Prompt, Path, NScheme::ESchemeEntryType::Directory)) {

--- a/ydb/public/lib/ydb_cli/commands/ydb_workload.cpp
+++ b/ydb/public/lib/ydb_cli/commands/ydb_workload.cpp
@@ -389,7 +389,7 @@ int TWorkloadCommandBase::Run(TConfig& config) {
 
 void TWorkloadCommandBase::CleanTables(NYdbWorkload::IWorkloadQueryGenerator& workloadGen, TConfig& config) {
     auto pathsToDelete = workloadGen.GetCleanPaths();
-    TRemovePathRecursiveSettings settings;
+    TRemoveDirectoryRecursiveSettings settings;
     settings.NotExistsIsOk(true);
     for (const auto& path : pathsToDelete) {
         Cout << "Remove path " << path << "..."  << Endl;
@@ -397,7 +397,7 @@ void TWorkloadCommandBase::CleanTables(NYdbWorkload::IWorkloadQueryGenerator& wo
         if (DryRun) {
             Cout << "Remove " << fullPath << Endl;
         } else {
-            NStatusHelpers::ThrowOnErrorOrPrintIssues(RemovePathRecursive(*SchemeClient, *TableClient, TopicClient.Get(), QueryClient.Get(), nullptr, fullPath, ERecursiveRemovePrompt::Never, settings));
+            NStatusHelpers::ThrowOnErrorOrPrintIssues(RemovePathRecursive(*Driver.Get(), fullPath, settings));
         }
         Cout << "Remove path " << path << "...Ok"  << Endl;
     }

--- a/ydb/public/lib/ydb_cli/common/recursive_remove.cpp
+++ b/ydb/public/lib/ydb_cli/common/recursive_remove.cpp
@@ -273,6 +273,8 @@ namespace NInternal {
 
     bool MightHaveDependents(ESchemeEntryType type) {
         switch (type) {
+        // directories might contain external data sources, which might have dependent objects (i.e. external tables)
+        case ESchemeEntryType::Directory:
         case ESchemeEntryType::ExternalDataSource:
             return true;
         default:

--- a/ydb/public/lib/ydb_cli/common/recursive_remove.cpp
+++ b/ydb/public/lib/ydb_cli/common/recursive_remove.cpp
@@ -178,7 +178,7 @@ TStatus RemoveDirectoryRecursive(
     const TRemoveDirectoryRecursiveSettings& settings
 ) {
     const auto listingSettings = TRecursiveListSettings()
-        .Filter([&](const TSchemeEntry& entry) {
+        .Filter([](const TSchemeEntry& entry) {
             // explicitly skip subdomains
             return entry.Type != ESchemeEntryType::SubDomain;
         });

--- a/ydb/public/lib/ydb_cli/common/recursive_remove.cpp
+++ b/ydb/public/lib/ydb_cli/common/recursive_remove.cpp
@@ -1,5 +1,4 @@
 #include "interactive.h"
-#include "progress_bar.h"
 #include "recursive_remove.h"
 
 #include <ydb/public/lib/ydb_cli/common/recursive_list.h>
@@ -106,16 +105,17 @@ template <typename TClient, typename TSettings>
 using TRemoveFunc = TStatus(*)(TClient&, const TString&, const TSettings&);
 
 template <typename TClient, typename TSettings>
-TStatus Remove(TRemoveFunc<TClient, TSettings> func, TSchemeClient& schemeClient, TClient* client, const ESchemeEntryType type,
-        const TString& path, ERecursiveRemovePrompt prompt, const TRemoveDirectorySettings& settings)
-{
-    if (!client) {
-        return TStatus(EStatus::GENERIC_ERROR, MakeIssues(TStringBuilder()
-            << TypeName<TClient>() << " not specified"));
-    }
-
+TStatus Remove(
+    TRemoveFunc<TClient, TSettings> func,
+    TSchemeClient& schemeClient,
+    TClient& specializedClient,
+    const ESchemeEntryType type,
+    const TString& path,
+    ERecursiveRemovePrompt prompt,
+    const TRemoveDirectorySettings& settings
+) {
     if (Prompt(prompt, path, type, false)) {
-        auto status = func(*client, path, TSettings(settings));
+        auto status = func(specializedClient, path, TSettings(settings));
         if (status.GetStatus() == EStatus::SCHEME_ERROR && schemeClient.DescribePath(path).ExtractValueSync().GetStatus() == EStatus::SCHEME_ERROR) {
             Cerr << "WARNING: Couldn't delete path: \'" << path << "\'. It was probably already deleted in another process" << Endl;
             return TStatus(EStatus::SUCCESS, {});
@@ -127,12 +127,19 @@ TStatus Remove(TRemoveFunc<TClient, TSettings> func, TSchemeClient& schemeClient
 }
 
 TStatus Remove(
-    TSchemeClient& schemeClient, TTableClient* tableClient, TTopicClient* topicClient, NQuery::TQueryClient* queryClient, NCoordination::TClient* coordinationClient,
-    const ESchemeEntryType type, const TString& path, ERecursiveRemovePrompt prompt, const TRemoveDirectorySettings& settings)
-{
+    TSchemeClient& schemeClient,
+    TTableClient& tableClient,
+    TTopicClient& topicClient,
+    NQuery::TQueryClient& queryClient,
+    NCoordination::TClient& coordinationClient,
+    const ESchemeEntryType type,
+    const TString& path,
+    ERecursiveRemovePrompt prompt,
+    const TRemoveDirectorySettings& settings
+) {
     switch (type) {
     case ESchemeEntryType::Directory:
-        return Remove(&RemoveDirectory, schemeClient, &schemeClient, type, path, prompt, settings);
+        return Remove(&RemoveDirectory, schemeClient, schemeClient, type, path, prompt, settings);
 
     case ESchemeEntryType::ColumnStore:
         return Remove(&RemoveColumnStore, schemeClient, tableClient, type, path, prompt, settings);
@@ -151,6 +158,9 @@ TStatus Remove(
         return Remove(&RemoveView, schemeClient, queryClient, type, path, prompt, settings);
     case ESchemeEntryType::CoordinationNode:
         return Remove(&RemoveCoordinationNode, schemeClient, coordinationClient, type, path, prompt, settings);
+    case ESchemeEntryType::SubDomain:
+        // continue silently
+        return TStatus(EStatus::SUCCESS, {});
 
     default:
         return TStatus(EStatus::UNSUPPORTED, MakeIssues(TStringBuilder()
@@ -159,73 +169,63 @@ TStatus Remove(
 }
 
 TStatus RemoveDirectoryRecursive(
-        TSchemeClient& schemeClient,
-        TTableClient* tableClient,
-        TTopicClient* topicClient,
-        NQuery::TQueryClient* queryClient,
-        NCoordination::TClient* coordinationClient,
-        const TString& path,
-        ERecursiveRemovePrompt prompt,
-        const TRemoveDirectorySettings& settings,
-        bool removeSelf,
-        bool createProgressBar)
-{
-    auto recursiveListResult = RecursiveList(schemeClient, path, {}, removeSelf);
+    TSchemeClient& schemeClient,
+    TTableClient& tableClient,
+    TTopicClient& topicClient,
+    NQuery::TQueryClient& queryClient,
+    NCoordination::TClient& coordinationClient,
+    const TString& path,
+    const TRemoveDirectoryRecursiveSettings& settings
+) {
+    const auto listingSettings = TRecursiveListSettings()
+        .Filter([&](const TSchemeEntry& entry) {
+            // explicitly skip subdomains
+            return entry.Type != ESchemeEntryType::SubDomain;
+        });
+    auto recursiveListResult = RecursiveList(schemeClient, path, listingSettings, settings.RemoveSelf_);
     if (!recursiveListResult.Status.IsSuccess()) {
         return recursiveListResult.Status;
     }
 
-    if (prompt == ERecursiveRemovePrompt::Once) {
+    if (settings.Prompt_ == ERecursiveRemovePrompt::Once) {
         if (!Prompt(path, ESchemeEntryType::Directory)) {
             return TStatus(EStatus::SUCCESS, {});
         }
     }
 
-    std::unique_ptr<TProgressBar> bar;
-    if (createProgressBar) {
-        bar = std::make_unique<TProgressBar>(recursiveListResult.Entries.size());
-    }
-    // output order is: Root, Recursive(children)...
-    // we need to reverse it to delete recursively
-    for (auto it = recursiveListResult.Entries.rbegin(); it != recursiveListResult.Entries.rend(); ++it) {
-        if (auto result = Remove(schemeClient, tableClient, topicClient, queryClient, coordinationClient, it->Type, TString{it->Name}, prompt, settings); !result.IsSuccess()) {
-            return result;
-        }
-        if (createProgressBar) {
-            bar->AddProgress(1);
-        }
-    }
-
-    return TStatus(EStatus::SUCCESS, {});
+    // RecursiveList outputs elements in pre-order: root, recurse(children)...
+    // We need to reverse it to delete scheme objects before directories.
+    return RemovePathsRecursive(
+        schemeClient,
+        tableClient,
+        topicClient,
+        queryClient,
+        coordinationClient,
+        recursiveListResult.Entries.rbegin(),
+        recursiveListResult.Entries.rend(),
+        settings
+    );
 }
 
 TStatus RemoveDirectoryRecursive(
-        TSchemeClient& schemeClient,
-        TTableClient& tableClient,
-        const TString& path,
-        const TRemoveDirectorySettings& settings,
-        bool removeSelf,
-        bool createProgressBar)
-{
-    return RemoveDirectoryRecursive(schemeClient, &tableClient, nullptr, nullptr, nullptr, path, ERecursiveRemovePrompt::Never, settings, removeSelf, createProgressBar);
+    const TDriver& driver,
+    const TString& path,
+    const TRemoveDirectoryRecursiveSettings& settings
+) {
+    TSchemeClient schemeClient(driver);
+    TTableClient tableClient(driver);
+    TTopicClient topicClient(driver);
+    NQuery::TQueryClient queryClient(driver);
+    NCoordination::TClient coordinationClient(driver);
+    return RemoveDirectoryRecursive(schemeClient, tableClient, topicClient, queryClient, coordinationClient, path, settings);
 }
 
-TStatus RemoveDirectoryRecursive(
-        TSchemeClient& schemeClient,
-        TTableClient& tableClient,
-        TTopicClient* topicClient,
-        NQuery::TQueryClient* queryClient,
-        NCoordination::TClient* coordinationClient,
-        const TString& path,
-        ERecursiveRemovePrompt prompt,
-        const TRemoveDirectorySettings& settings,
-        bool removeSelf,
-        bool createProgressBar)
-{
-    return RemoveDirectoryRecursive(schemeClient, &tableClient, topicClient, queryClient, coordinationClient, path, prompt, settings, removeSelf, createProgressBar);
-}
-
-NYdb::TStatus RemovePathRecursive(NScheme::TSchemeClient& schemeClient, NTable::TTableClient& tableClient, NTopic::TTopicClient* topicClient, NQuery::TQueryClient* queryClient, NCoordination::TClient* coordinationClient, const TString& path, ERecursiveRemovePrompt prompt, const TRemovePathRecursiveSettings& settings /*= {}*/, bool createProgressBar /*= true*/) {
+TStatus RemovePathRecursive(
+    const TDriver& driver,
+    const TString& path,
+    const TRemoveDirectoryRecursiveSettings& settings
+) {
+    TSchemeClient schemeClient(driver);
     auto entity = schemeClient.DescribePath(path).ExtractValueSync();
     if (!entity.IsSuccess()) {
         if (settings.NotExistsIsOk_ && entity.GetStatus() == EStatus::SCHEME_ERROR && entity.GetIssues().ToString().find("Path not found") != TString::npos) {
@@ -233,12 +233,53 @@ NYdb::TStatus RemovePathRecursive(NScheme::TSchemeClient& schemeClient, NTable::
         }
         return entity;
     }
-    switch (entity.GetEntry().Type) {
-    case ESchemeEntryType::Directory:
-    case ESchemeEntryType::ColumnStore:
-        return RemoveDirectoryRecursive(schemeClient, tableClient, topicClient, queryClient, coordinationClient, path, prompt, settings, true, createProgressBar);
-    default:
-        return Remove(schemeClient, &tableClient, topicClient, queryClient, coordinationClient, entity.GetEntry().Type, path, prompt, settings);
-    }
+
+    TTableClient tableClient(driver);
+    TTopicClient topicClient(driver);
+    NQuery::TQueryClient queryClient(driver);
+    NCoordination::TClient coordinationClient(driver);
+    auto remover = NInternal::CreateDefaultRemover(schemeClient, tableClient, topicClient, queryClient, coordinationClient, settings);
+    return remover(entity.GetEntry());
 }
+
+TStatus RemovePathRecursive(
+    const TDriver& driver,
+    const TSchemeEntry& entry,
+    const TRemoveDirectoryRecursiveSettings& settings
+) {
+    TSchemeClient schemeClient(driver);
+    TTableClient tableClient(driver);
+    TTopicClient topicClient(driver);
+    NQuery::TQueryClient queryClient(driver);
+    NCoordination::TClient coordinationClient(driver);
+    auto remover = NInternal::CreateDefaultRemover(schemeClient, tableClient, topicClient, queryClient, coordinationClient, settings);
+    return remover(entry);
+}
+
+namespace NInternal {
+
+    TRemover CreateDefaultRemover(
+        NScheme::TSchemeClient& schemeClient,
+        NTable::TTableClient& tableClient,
+        NTopic::TTopicClient& topicClient,
+        NQuery::TQueryClient& queryClient,
+        NCoordination::TClient& coordinationClient,
+        const TRemoveDirectoryRecursiveSettings& settings
+    ) {
+        return [&](const TSchemeEntry& entry) {
+            return Remove(schemeClient, tableClient, topicClient, queryClient, coordinationClient, entry.Type, TString(entry.Name), settings.Prompt_, settings);
+        };
+    }
+
+    bool MightHaveDependents(ESchemeEntryType type) {
+        switch (type) {
+        case ESchemeEntryType::ExternalDataSource:
+            return true;
+        default:
+            return false;
+        }
+    }
+
+}
+
 }

--- a/ydb/public/lib/ydb_cli/common/recursive_remove.h
+++ b/ydb/public/lib/ydb_cli/common/recursive_remove.h
@@ -71,7 +71,7 @@ namespace NInternal {
     ) {
         TVector<const NScheme::TSchemeEntry*> entriesToRemoveInSecondPass;
         for (const NScheme::TSchemeEntry& entry : std::ranges::subrange(begin, end)) {
-            if (NInternal::MightHaveDependents(entry.Type)) {
+            if (MightHaveDependents(entry.Type)) {
                 entriesToRemoveInSecondPass.emplace_back(&entry);
                 continue;
             }

--- a/ydb/public/lib/ydb_cli/common/recursive_remove.h
+++ b/ydb/public/lib/ydb_cli/common/recursive_remove.h
@@ -1,10 +1,14 @@
 #pragma once
 
+#include "progress_bar.h"
+
 #include <ydb/public/sdk/cpp/include/ydb-cpp-sdk/client/coordination/coordination.h>
 #include <ydb/public/sdk/cpp/include/ydb-cpp-sdk/client/query/client.h>
 #include <ydb/public/sdk/cpp/include/ydb-cpp-sdk/client/scheme/scheme.h>
 #include <ydb/public/sdk/cpp/include/ydb-cpp-sdk/client/table/table.h>
 #include <ydb/public/sdk/cpp/include/ydb-cpp-sdk/client/topic/client.h>
+
+#include <ranges>
 
 namespace NYdb::NConsoleClient {
 
@@ -14,41 +18,106 @@ enum class ERecursiveRemovePrompt {
     Never,
 };
 
-struct TRemovePathRecursiveSettings : public NScheme::TRemoveDirectorySettings {
+struct TRemoveDirectoryRecursiveSettings : public NScheme::TRemoveDirectorySettings {
+    using TSelf = TRemoveDirectoryRecursiveSettings;
+
     FLUENT_SETTING_DEFAULT(bool, NotExistsIsOk, false);
+    FLUENT_SETTING_DEFAULT(bool, RemoveSelf, true);
+    FLUENT_SETTING_DEFAULT(bool, CreateProgressBar, false);
+    FLUENT_SETTING_DEFAULT(ERecursiveRemovePrompt, Prompt, ERecursiveRemovePrompt::Never);
 };
 
 bool Prompt(ERecursiveRemovePrompt mode, const TString& path, NScheme::ESchemeEntryType type, bool first = true);
 
 TStatus RemoveDirectoryRecursive(
-    NScheme::TSchemeClient& schemeClient,
-    NTable::TTableClient& tableClient,
+    const TDriver& driver,
     const TString& path,
-    const NScheme::TRemoveDirectorySettings& settings = {},
-    bool removeSelf = true,
-    bool createProgressBar = true);
-
-TStatus RemoveDirectoryRecursive(
-    NScheme::TSchemeClient& schemeClient,
-    NTable::TTableClient& tableClient,
-    NTopic::TTopicClient* topicClient,
-    NQuery::TQueryClient* queryClient,
-    NCoordination::TClient* coordinationClient,
-    const TString& path,
-    ERecursiveRemovePrompt prompt,
-    const NScheme::TRemoveDirectorySettings& settings = {},
-    bool removeSelf = true,
-    bool createProgressBar = true);
+    const TRemoveDirectoryRecursiveSettings& settings = {}
+);
 
 TStatus RemovePathRecursive(
+    const TDriver& driver,
+    const TString& path,
+    const TRemoveDirectoryRecursiveSettings& settings = {}
+);
+
+TStatus RemovePathRecursive(
+    const TDriver& driver,
+    const NScheme::TSchemeEntry& entry,
+    const TRemoveDirectoryRecursiveSettings& settings = {}
+);
+
+namespace NInternal {
+
+    using TRemover = std::function<TStatus(const NScheme::TSchemeEntry&)>;
+
+    TRemover CreateDefaultRemover(
+        NScheme::TSchemeClient& schemeClient,
+        NTable::TTableClient& tableClient,
+        NTopic::TTopicClient& topicClient,
+        NQuery::TQueryClient& queryClient,
+        NCoordination::TClient& coordinationClient,
+        const TRemoveDirectoryRecursiveSettings& settings
+    );
+
+    bool MightHaveDependents(NScheme::ESchemeEntryType type);
+
+    template <typename TIterator>
+    TStatus RemovePathsRecursive(
+        TIterator begin,
+        TIterator end,
+        TRemover& remover,
+        std::optional<TProgressBar> progressBar
+    ) {
+        TVector<const NScheme::TSchemeEntry*> entriesToRemoveInSecondPass;
+        for (const NScheme::TSchemeEntry& entry : std::ranges::subrange(begin, end)) {
+            if (NInternal::MightHaveDependents(entry.Type)) {
+                entriesToRemoveInSecondPass.emplace_back(&entry);
+                continue;
+            }
+            auto result = remover(entry);
+            if (!result.IsSuccess()) {
+                return result;
+            }
+            if (progressBar) {
+                progressBar->AddProgress(1);
+            }
+        }
+        for (const auto* entry : entriesToRemoveInSecondPass) {
+            auto result = remover(*entry);
+            if (!result.IsSuccess()) {
+                return result;
+            }
+            if (progressBar) {
+                progressBar->AddProgress(1);
+            }
+        }
+        return TStatus(EStatus::SUCCESS, {});
+    }
+
+}
+
+template <typename TIterator>
+TStatus RemovePathsRecursive(
     NScheme::TSchemeClient& schemeClient,
     NTable::TTableClient& tableClient,
-    NTopic::TTopicClient* topicClient,
-    NQuery::TQueryClient* queryClient,
-    NCoordination::TClient* coordinationClient,
-    const TString& path,
-    ERecursiveRemovePrompt prompt,
-    const TRemovePathRecursiveSettings& settings = {},
-    bool createProgressBar = true);
+    NTopic::TTopicClient& topicClient,
+    NQuery::TQueryClient& queryClient,
+    NCoordination::TClient& coordinationClient,
+    TIterator begin,
+    TIterator end,
+    const TRemoveDirectoryRecursiveSettings& settings = {},
+    // overloading of the remover is used only for tests
+    NInternal::TRemover&& remover = {}
+) {
+    if (!remover) {
+        remover = NInternal::CreateDefaultRemover(schemeClient, tableClient, topicClient, queryClient, coordinationClient, settings);
+    }
+    std::optional<TProgressBar> progressBar;
+    if (settings.CreateProgressBar_) {
+        progressBar = std::make_optional<TProgressBar>(end - begin);
+    }
+    return NInternal::RemovePathsRecursive(begin, end, remover, progressBar);
+}
 
 }

--- a/ydb/public/lib/ydb_cli/common/recursive_remove_ut.cpp
+++ b/ydb/public/lib/ydb_cli/common/recursive_remove_ut.cpp
@@ -1,0 +1,44 @@
+#include "recursive_remove.h"
+
+#include <library/cpp/testing/unittest/registar.h>
+
+using namespace NYdb;
+using namespace NConsoleClient;
+using namespace NScheme;
+
+namespace NYdb::NScheme {
+
+bool operator==(const TSchemeEntry& lhs, const TSchemeEntry& rhs) {
+    return std::make_pair(lhs.Name, lhs.Type) == std::make_pair(rhs.Name, rhs.Type);
+}
+
+}
+
+Y_UNIT_TEST_SUITE(RecursiveRemoveTests) {
+
+TSchemeEntry CreateSchemeEntry(ESchemeEntryType type) {
+    TSchemeEntry entry;
+    entry.Type = type;
+    entry.Name = TStringBuilder() << type;
+    return entry;
+}
+
+Y_UNIT_TEST(SecondPass) {
+    TVector<TSchemeEntry> entries = {
+        { CreateSchemeEntry(ESchemeEntryType::Table) },
+        { CreateSchemeEntry(ESchemeEntryType::ExternalDataSource) },
+        { CreateSchemeEntry(ESchemeEntryType::ExternalTable) }
+    };
+
+    TVector<TSchemeEntry> removedEntries;
+    NInternal::TRemover remover = [&removedEntries](const TSchemeEntry& entry) {
+        removedEntries.emplace_back(entry);
+        return TStatus(EStatus::SUCCESS, {});
+    };
+    NInternal::RemovePathsRecursive(entries.begin(), entries.end(), remover, std::nullopt);
+
+    std::swap(entries[1], entries[2]);
+    UNIT_ASSERT_VALUES_EQUAL(removedEntries, entries);
+}
+
+}

--- a/ydb/public/lib/ydb_cli/common/ut/ya.make
+++ b/ydb/public/lib/ydb_cli/common/ut/ya.make
@@ -2,9 +2,10 @@ UNITTEST_FOR(ydb/public/lib/ydb_cli/common)
 
 SRCS(
     cert_format_converter_ut.cpp
-    normalize_path_ut.cpp
     csv_parser_ut.cpp
+    normalize_path_ut.cpp
     pg_dump_parser_ut.cpp
+    recursive_remove_ut.cpp
 )
 
 END()

--- a/ydb/public/lib/ydb_cli/common/ya.make
+++ b/ydb/public/lib/ydb_cli/common/ya.make
@@ -47,6 +47,7 @@ PEERDIR(
     ydb/public/lib/json_value
     ydb/public/sdk/cpp/src/library/operation_id
     ydb/public/lib/yson_value
+    ydb/public/sdk/cpp/src/client/coordination
     ydb/public/sdk/cpp/src/client/draft
     ydb/public/sdk/cpp/src/client/query
     ydb/public/sdk/cpp/src/client/result

--- a/ydb/public/lib/ydb_cli/dump/restore_impl.cpp
+++ b/ydb/public/lib/ydb_cli/dump/restore_impl.cpp
@@ -34,7 +34,6 @@
 #include <google/protobuf/text_format.h>
 
 #include <format>
-#include <ranges>
 
 namespace NYdb::NDump {
 

--- a/ydb/tests/functional/ydb_cli/test_ydb_recursive_remove.py
+++ b/ydb/tests/functional/ydb_cli/test_ydb_recursive_remove.py
@@ -1,0 +1,91 @@
+from hamcrest import assert_that, only_contains
+import os
+import pytest
+
+import yatest
+
+CLUSTER_CONFIG = dict(extra_feature_flags=["enable_external_data_sources"])
+
+
+def bin_from_env(var):
+    if os.getenv(var):
+        return yatest.common.binary_path(os.getenv(var))
+    raise RuntimeError(f"{var} environment variable is not specified")
+
+
+def ydb_bin():
+    return bin_from_env("YDB_CLI_BINARY")
+
+
+def execute_ydb_cli_command(node, database, args, stdin=None):
+    execution = yatest.common.execute(
+        [ydb_bin(), "--endpoint", f"grpc://{node.host}:{node.grpc_port}", "--database", database] + args, stdin=stdin
+    )
+    return execution.std_out.decode("utf-8")
+
+
+def create_table(session, table):
+    session.execute_scheme(
+        f"""
+        CREATE TABLE `{table}` (key Int, value Utf8, PRIMARY KEY(key));
+        """
+    )
+
+
+def create_view(session, view, query="SELECT 42"):
+    session.execute_scheme(
+        f"""
+        CREATE VIEW `{view}` WITH security_invoker = TRUE AS {query};
+        """
+    )
+
+
+def create_external_data_source(session, external_data_source):
+    session.execute_scheme(
+        f"""
+        CREATE EXTERNAL DATA SOURCE `{external_data_source}` WITH (
+            SOURCE_TYPE="ObjectStorage",
+            LOCATION="192.168.1.1:8123",
+            AUTH_METHOD="NONE"
+        );
+        """
+    )
+
+
+def create_external_table(session, external_table, external_data_source):
+    session.execute_scheme(
+        f"""
+        CREATE EXTERNAL TABLE `{external_table}` (
+            key Utf8 NOT NULL,
+            value Utf8 NOT NULL
+        ) WITH (
+            DATA_SOURCE="{external_data_source}",
+            LOCATION="folder",
+            FORMAT="csv_with_names",
+            COMPRESSION="gzip"
+        );
+        """
+    )
+
+
+class TestRecursiveRemove:
+    @pytest.fixture(autouse=True, scope="function")
+    def init_test(self, tmp_path):
+        self.tmp_path = tmp_path
+
+    def test_various_scheme_objects(self, ydb_cluster, ydb_database, ydb_client, ydb_client_session):
+        database_path = ydb_database
+        driver = ydb_client(database_path)
+        session_pool = ydb_client_session(database_path)
+        with session_pool.checkout() as session:
+            create_table(session, "table")
+            create_view(session, "views/view")
+            create_external_data_source(session, "externals/data_source")
+            create_external_table(session, "externals/table", "externals/data_source")
+            execute_ydb_cli_command(
+                ydb_cluster.nodes[1], database_path, ["scheme", "rmdir", "--recursive", "--force", "."]
+            )
+            assert_that(
+                [child.name for child in driver.scheme_client.list_directory(database_path).children],
+                only_contains(".metadata", ".sys"),
+            )

--- a/ydb/tests/functional/ydb_cli/ya.make
+++ b/ydb/tests/functional/ydb_cli/ya.make
@@ -3,12 +3,13 @@ PY3TEST()
 TEST_SRCS(
     conftest.py
     test_ydb_backup.py
-    test_ydb_table.py
-    test_ydb_scripting.py
-    test_ydb_impex.py
     test_ydb_flame_graph.py
+    test_ydb_impex.py
+    test_ydb_recursive_remove.py
     test_ydb_scheme.py
+    test_ydb_scripting.py
     test_ydb_sql.py
+    test_ydb_table.py
 )
 
 ENV(YDB_DRIVER_BINARY="ydb/apps/ydbd/ydbd")


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

### Changelog category <!-- remove all except one -->

* Not for changelog (changelog entry is not required)

### Description for reviewers <!-- (optional) description for those who read this PR -->

refactoring + tests

Also fixed some bugs:
- We attempted deleting the subdomain if the `--path .` was specified, so the `ydb scheme rmdir` would always result in an error previously in this case.
- We haven't ordered the deletions of external data sources and external tables (the former must be deleted after the latter). It could have led to an error in `ydb scheme rmdir` if it got to the external data source first.
- Straight (non-reverse) order of scheme objects to remove on cleanup on failed restore. This prevented deletion of directories. We have received errors always in this case.

\+ deduplicated code by using the generic RemovePathRecursive on cleanup after a failed restore
