### PR TITLE
25-1: tests/library: separate fixtures from harness

### DIFF
--- a/ydb/tests/functional/audit/conftest.py
+++ b/ydb/tests/functional/audit/conftest.py
@@ -2,4 +2,4 @@
 # but somehow it does not
 #
 # for ydb_{cluster, database, ...} fixture family
-pytest_plugins = 'ydb.tests.library.harness.ydb_fixtures'
+pytest_plugins = 'ydb.tests.library.fixtures'

--- a/ydb/tests/functional/audit/test_auditlog.py
+++ b/ydb/tests/functional/audit/test_auditlog.py
@@ -13,7 +13,7 @@ from ydb.tests.oss.ydb_sdk_import import ydb
 from ydb import Driver, DriverConfig, SessionPool
 from ydb.draft import DynamicConfigClient
 from ydb.tests.library.harness.util import LogLevels
-from ydb.tests.library.harness.ydb_fixtures import ydb_database_ctx
+from ydb.tests.library.fixtures import ydb_database_ctx
 
 logger = logging.getLogger(__name__)
 

--- a/ydb/tests/functional/audit/ya.make
+++ b/ydb/tests/functional/audit/ya.make
@@ -23,6 +23,7 @@ DEPENDS(
 
 PEERDIR(
     ydb/tests/library
+    ydb/tests/library/fixtures
     ydb/tests/oss/ydb_sdk_import
     ydb/public/sdk/python
 )

--- a/ydb/tests/functional/rename/conftest.py
+++ b/ydb/tests/functional/rename/conftest.py
@@ -2,4 +2,4 @@
 # but somehow it does not
 #
 # for ydb_{cluster, database, ...} fixture family
-pytest_plugins = 'ydb.tests.library.harness.ydb_fixtures'
+pytest_plugins = 'ydb.tests.library.fixtures'

--- a/ydb/tests/functional/rename/ya.make
+++ b/ydb/tests/functional/rename/ya.make
@@ -32,6 +32,7 @@ DEPENDS(
 
 PEERDIR(
     ydb/tests/library
+    ydb/tests/library/fixtures
     ydb/tests/oss/ydb_sdk_import
     ydb/public/sdk/python
     contrib/python/tornado/tornado-4

--- a/ydb/tests/functional/serverless/conftest.py
+++ b/ydb/tests/functional/serverless/conftest.py
@@ -9,7 +9,7 @@ import contextlib
 # but somehow it does not
 #
 # for ydb_{cluster, database, ...} fixture family
-pytest_plugins = 'ydb.tests.library.harness.ydb_fixtures'
+pytest_plugins = 'ydb.tests.library.fixtures'
 
 
 logger = logging.getLogger(__name__)

--- a/ydb/tests/functional/serverless/test_serverless.py
+++ b/ydb/tests/functional/serverless/test_serverless.py
@@ -57,7 +57,7 @@ def enable_alter_database_create_hive_first(request):
     return request.param
 
 
-# ydb_fixtures.ydb_cluster_configuration local override
+# fixtures.ydb_cluster_configuration local override
 @pytest.fixture(scope='module')
 def ydb_cluster_configuration(enable_alter_database_create_hive_first):
     conf = copy.deepcopy(CLUSTER_CONFIG)

--- a/ydb/tests/functional/serverless/ya.make
+++ b/ydb/tests/functional/serverless/ya.make
@@ -22,6 +22,7 @@ DEPENDS(
 PEERDIR(
     contrib/python/tornado/tornado-4
     ydb/tests/library
+    ydb/tests/library/fixtures
     ydb/tests/oss/ydb_sdk_import
     ydb/public/sdk/python
 )

--- a/ydb/tests/functional/tenants/conftest.py
+++ b/ydb/tests/functional/tenants/conftest.py
@@ -7,7 +7,7 @@ from ydb.tests.library.clients.kikimr_http_client import HiveClient
 # but somehow it does not
 #
 # for ydb_{cluster, database, ...} fixture family
-pytest_plugins = 'ydb.tests.library.harness.ydb_fixtures'
+pytest_plugins = 'ydb.tests.library.fixtures'
 
 
 @pytest.fixture(scope='module')

--- a/ydb/tests/functional/tenants/test_auth_system_views.py
+++ b/ydb/tests/functional/tenants/test_auth_system_views.py
@@ -49,7 +49,7 @@ CLUSTER_CONFIG = dict(
 )
 
 
-# ydb_fixtures.ydb_cluster_configuration local override
+# fixtures.ydb_cluster_configuration local override
 @pytest.fixture(scope='module')
 def ydb_cluster_configuration():
     conf = copy.deepcopy(CLUSTER_CONFIG)

--- a/ydb/tests/functional/tenants/test_db_counters.py
+++ b/ydb/tests/functional/tenants/test_db_counters.py
@@ -15,7 +15,7 @@ from ydb.tests.library.common.protobuf_ss import AlterTableRequest
 from ydb.tests.library.harness.kikimr_runner import KiKiMR
 from ydb.tests.library.harness.kikimr_config import KikimrConfigGenerator
 from ydb.tests.library.harness.util import LogLevels
-from ydb.tests.library.harness.ydb_fixtures import ydb_database_ctx
+from ydb.tests.library.fixtures import ydb_database_ctx
 from ydb.tests.library.matchers.response_matchers import ProtobufWithStatusMatcher
 from ydb.tests.oss.ydb_sdk_import import ydb
 

--- a/ydb/tests/functional/tenants/test_dynamic_tenants.py
+++ b/ydb/tests/functional/tenants/test_dynamic_tenants.py
@@ -50,7 +50,7 @@ def enable_alter_database_create_hive_first(request):
     return request.param
 
 
-# ydb_fixtures.ydb_cluster_configuration local override
+# fixtures.ydb_cluster_configuration local override
 @pytest.fixture(scope='module')
 def ydb_cluster_configuration(enable_alter_database_create_hive_first):
     conf = copy.deepcopy(CLUSTER_CONFIG)

--- a/ydb/tests/functional/tenants/test_tenants.py
+++ b/ydb/tests/functional/tenants/test_tenants.py
@@ -10,7 +10,7 @@ from hamcrest import assert_that, greater_than, is_, not_, none
 
 from ydb.tests.oss.ydb_sdk_import import ydb
 from ydb.tests.library.harness.util import LogLevels
-from ydb.tests.library.harness.ydb_fixtures import ydb_database_ctx
+from ydb.tests.library.fixtures import ydb_database_ctx
 
 
 logger = logging.getLogger(__name__)
@@ -45,7 +45,7 @@ def enable_alter_database_create_hive_first(request):
     return request.param
 
 
-# ydb_fixtures.ydb_cluster_configuration local override
+# fixtures.ydb_cluster_configuration local override
 @pytest.fixture(scope='module')
 def ydb_cluster_configuration(enable_alter_database_create_hive_first):
     conf = copy.deepcopy(CLUSTER_CONFIG)

--- a/ydb/tests/functional/tenants/test_users_groups_with_acl.py
+++ b/ydb/tests/functional/tenants/test_users_groups_with_acl.py
@@ -3,7 +3,7 @@
 import logging
 import pytest
 from ydb.tests.library.harness.kikimr_config import KikimrConfigGenerator
-from ydb.tests.library.harness.ydb_fixtures import ydb_database_ctx
+from ydb.tests.library.fixtures import ydb_database_ctx
 from ydb.tests.oss.ydb_sdk_import import ydb
 
 

--- a/ydb/tests/functional/tenants/ya.make
+++ b/ydb/tests/functional/tenants/ya.make
@@ -25,6 +25,7 @@ DEPENDS(
 PEERDIR(
     contrib/python/requests
     ydb/tests/library
+    ydb/tests/library/fixtures
     ydb/tests/library/clients
     ydb/tests/oss/ydb_sdk_import
     ydb/public/sdk/python

--- a/ydb/tests/functional/ydb_cli/conftest.py
+++ b/ydb/tests/functional/ydb_cli/conftest.py
@@ -2,4 +2,4 @@
 # but somehow it does not
 #
 # for ydb_{cluster, database, ...} fixture family
-pytest_plugins = 'ydb.tests.library.harness.ydb_fixtures'
+pytest_plugins = 'ydb.tests.library.fixtures'

--- a/ydb/tests/functional/ydb_cli/ya.make
+++ b/ydb/tests/functional/ydb_cli/ya.make
@@ -30,6 +30,7 @@ DEPENDS(
 PEERDIR(
     contrib/python/pyarrow
     ydb/tests/library
+    ydb/tests/library/fixtures
     ydb/tests/oss/canonical
     ydb/tests/oss/ydb_sdk_import
 )

--- a/ydb/tests/library/fixtures/__init__.py
+++ b/ydb/tests/library/fixtures/__init__.py
@@ -114,11 +114,7 @@ def _ydb_database(cluster, database_path_base, unique_name):
 
 @pytest.fixture(scope='function')
 def ydb_database(ydb_cluster, ydb_root, ydb_safe_test_name):
-    # FIXME: PY2 syntax compatibility quirk: "yield from" emulation
-    # Can't use py3 syntax here cause there are nasty dependencies on
-    # tests/library/harness from some py2-only code in some other repositories
-    for i in _ydb_database(ydb_cluster, ydb_root, ydb_safe_test_name):
-        yield i
+    yield from _ydb_database(ydb_cluster, ydb_root, ydb_safe_test_name)
 
 
 @pytest.fixture(scope='module')
@@ -126,9 +122,7 @@ def ydb_database_module_scope(ydb_cluster, ydb_root, request):
     # make unique database name from the test module name, ensuring that
     # it does not contains the dots
     unique_name = request.module.__name__.split('.')[-1]
-    # FIXME: PY2 syntax compatibility quirk: "yield from" emulation
-    for i in _ydb_database(ydb_cluster, ydb_root, unique_name):
-        yield i
+    yield from _ydb_database(ydb_cluster, ydb_root, unique_name)
 
 
 @pytest.fixture(scope='module')

--- a/ydb/tests/library/fixtures/ya.make
+++ b/ydb/tests/library/fixtures/ya.make
@@ -1,0 +1,12 @@
+PY3_LIBRARY()
+
+PY_SRCS(
+    __init__.py
+)
+
+PEERDIR(
+    ydb/tests/library
+    ydb/public/sdk/python
+)
+
+END()

--- a/ydb/tests/library/ya.make
+++ b/ydb/tests/library/ya.make
@@ -32,7 +32,6 @@ PY_SRCS(
     harness/param_constants.py
     harness/util.py
     harness/tls_tools.py
-    harness/ydb_fixtures.py
     matchers/__init__.py
     matchers/collection.py
     matchers/datashard_matchers.py


### PR DESCRIPTION
Depends on:
- https://github.com/ydb-platform/ydb/pull/15466

Merge from `main`:
- e4821cc -- https://github.com/ydb-platform/ydb/pull/15437

`ydb/tests/library/harness/ydb_fixtures` -> `ydb/tests/library/fixtures`.

Move module with pytest fixtures out of `ydb/tests/library/harness` and make it a separate (but dependent) library. Part of the `harness` (namely `ydbd` launching framework: `Daemon`, runner etc), is widely used outside of ydb tests, and some of that uses still require py2 compatibility (so that `harness` must run under py2).

ydb's own tests (`ydb/tests/functional`) are all pure py3, so requirement for the test fixtures to be py2 compatible is excessive.