### PR TITLE
YMQ: Use "name" label name instead of "sensor" for queue.total_count time series (25-1-1)

### DIFF
--- a/ydb/core/ymq/base/counters.cpp
+++ b/ydb/core/ymq/base/counters.cpp
@@ -537,7 +537,7 @@ void TFolderCounters::InitCounters() {
     InsertCounters();
     if (UserCounters.YmqCounters) {
         total_count.Init(
-            FolderCounters.YmqCounters, ELifetime::Expiring, EValueType::Absolute, DEFAULT_COUNTER_NAME,
+            FolderCounters.YmqCounters, ELifetime::Expiring, EValueType::Absolute, DEFAULT_YMQ_COUNTER_NAME,
             "queue.total_count",
             ELaziness::OnStart
         );
@@ -985,7 +985,7 @@ void TCloudAuthCounters::InitCounters(TIntrusivePtr<::NMonitoring::TDynamicCount
         for (size_t credentialType = 0; credentialType < NCloudAuth::ECredentialType::CredentialTypesCount; ++credentialType) {
             const auto credentialTypeStr = ToString(static_cast<NCloudAuth::ECredentialType>(credentialType));
             const auto actionAndCredentialCounters = actionCounters->GetSubgroup("credential_type", credentialTypeStr);
-            
+
             if (actionType == NCloudAuth::EActionType::Authorize) {
                 INIT_COUNTER_WITH_NAME(actionAndCredentialCounters, AuthorizeSuccess[credentialType], "Ok", ELifetime::Persistent, EValueType::Derivative, Lazy(*Cfg));
                 INIT_COUNTER_WITH_NAME(actionAndCredentialCounters, AuthorizeError[credentialType], "PermissionDenied", ELifetime::Persistent, EValueType::Derivative, Lazy(*Cfg));
@@ -1017,11 +1017,11 @@ void TMonitoringCounters::InitCounters() {
     INIT_COUNTER(MonitoringCounters, CleanupRemovedQueuesDone, ELifetime::Persistent, EValueType::Derivative, Lazy(Config));
     INIT_COUNTER(MonitoringCounters, CleanupRemovedQueuesRows, ELifetime::Persistent, EValueType::Derivative, Lazy(Config));
     INIT_COUNTER(MonitoringCounters, CleanupRemovedQueuesErrors, ELifetime::Persistent, EValueType::Derivative, Lazy(Config));
-    
-    
+
+
     INIT_COUNTER(MonitoringCounters, LocalLeaderStartInflight, ELifetime::Persistent, EValueType::Derivative, Lazy(Config));
     INIT_COUNTER(MonitoringCounters, LocalLeaderStartQueue, ELifetime::Persistent, EValueType::Derivative, Lazy(Config));
-    
+
     INIT_HISTOGRAM_COUNTER(MonitoringCounters, LocalLeaderStartAwaitMs, ELifetime::Expiring, DurationBucketsMs, ELaziness::OnDemand);
 }
 

--- a/ydb/tests/functional/sqs/cloud/test_yandex_cloud_mode.py
+++ b/ydb/tests/functional/sqs/cloud/test_yandex_cloud_mode.py
@@ -357,7 +357,7 @@ class TestSqsYandexCloudMode(get_test_with_sqs_tenant_installation(KikimrSqsTest
                 )
 
         def check_total_count(expected):
-            return check_counter({"sensor": "queue.total_count"}, expected)
+            return check_counter({"name": "queue.total_count"}, expected)
 
         def check_messages_sent(q_name, expected):
             return check_counter({"name": "queue.messages.sent_count_per_second", "queue": q_name}, expected)


### PR DESCRIPTION
### Changelog category <!-- remove all except one -->

* Not for changelog (changelog entry is not required)

### Description for reviewers <!-- (optional) description for those who read this PR -->

Use a proper name for the queue.total_count metric (the number of queues per folder id), so it is not filtered out by Unified Agent.

LOGBROKER-6529

https://github.com/ydb-platform/ydb/pull/16260