### PR TITLE
Add --no-discovery option to YDB cli

### DIFF
--- a/ydb/apps/ydb/CHANGELOG.md
+++ b/ydb/apps/ydb/CHANGELOG.md
@@ -1,3 +1,4 @@
+* Added "--no-discovery" option. It allows to skip discovery and use user provided endpoint to connect to YDB cluster.
 * Added `--retries` to `ydb workload <clickbenh|tpch|tpcds> run` command.
 * Added `--partition-size` param to `ydb workload <clickbench/tpcds/tpch> init`.
 * Fixed bugs in `ydb scheme rmdir`: 1) do not try to delete subdomains, 2) order the deletion of external tables before the deletion of external data sources.

--- a/ydb/apps/ydb/ut/parse_command_line.cpp
+++ b/ydb/apps/ydb/ut/parse_command_line.cpp
@@ -284,6 +284,18 @@ Y_UNIT_TEST_SUITE(ParseOptionsTest) {
         );
     }
 
+    Y_UNIT_TEST_F(NoDiscoveryCommandLine, TCliTestFixture) {
+        RunCli(
+            {
+                "-v",
+                "-e", GetEndpoint(),
+                "-d", GetDatabase(),
+                "--no-discovery",
+                "scheme", "ls",
+            }
+        );
+    }
+
     Y_UNIT_TEST_F(EndpointAndDatabaseFromActiveProfile, TCliTestFixture) {
         TString profile = fmt::format(R"yaml(
         profiles:

--- a/ydb/public/lib/ydb_cli/commands/ydb_command.cpp
+++ b/ydb/public/lib/ydb_cli/commands/ydb_command.cpp
@@ -29,6 +29,8 @@ TDriverConfig TYdbCommand::CreateDriverConfig(TConfig& config) {
         driverConfig.UseSecureConnection(config.CaCerts);
     if (config.IsNetworkIntensive)
         driverConfig.SetNetworkThreadsNum(16);
+    if (config.SkipDiscovery)
+        driverConfig.SetDiscoveryMode(EDiscoveryMode::Off);
     driverConfig.UseClientCertificate(config.ClientCert, config.ClientCertPrivateKey);
 
     return driverConfig;

--- a/ydb/public/lib/ydb_cli/commands/ydb_root_common.cpp
+++ b/ydb/public/lib/ydb_cli/commands/ydb_root_common.cpp
@@ -155,6 +155,16 @@ void TClientCommandRootCommon::Config(TConfig& config) {
         .RequiredArgument("NAME").StoreResult(&ProfileName);
     opts.AddLongOption('y', "assume-yes", "Automatic yes to prompts; assume \"yes\" as answer to all prompts and run non-interactively")
         .Optional().StoreTrue(&config.AssumeYes);
+
+    if (config.HelpCommandVerbosiltyLevel >= 2) {
+        opts.AddLongOption("no-discovery", "Do not perform discovery (client balancing) for ydb cluster connection."
+            " If this option is set the user provided endpoint (by -e option) will be used to setup a connections")
+            .Optional().StoreTrue(&config.SkipDiscovery);
+    } else {
+        opts.AddLongOption("no-discovery")
+            .Optional().Hidden().StoreTrue(&config.SkipDiscovery);
+    }
+
     TClientCommandRootBase::Config(config);
 
     TAuthMethodOption* iamTokenAuth = nullptr;

--- a/ydb/public/lib/ydb_cli/common/command.h
+++ b/ydb/public/lib/ydb_cli/common/command.h
@@ -125,6 +125,7 @@ public:
 
         TMap<TString, TVector<TConnectionParam>> ConnectionParams;
         bool EnableSsl = false;
+        bool SkipDiscovery = false;
         bool IsNetworkIntensive = false;
         TString Oauth2KeyFile;
         TString Oauth2KeyParams;


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

"--no-discovery" option allows to skip discovery and use user provided endpoint to connect to YDB cluster.

### Changelog category <!-- remove all except one -->

* New feature


### Description for reviewers <!-- (optional) description for those who read this PR -->

In case where network of YDB has access outside only via some balancer client load balancing is not effective.
