### PR TITLE
Fix bug in prefix vector index creation

### DIFF
--- a/ydb/core/tx/schemeshard/schemeshard_utils.h
+++ b/ydb/core/tx/schemeshard/schemeshard_utils.h
@@ -150,6 +150,11 @@ bool CommonCheck(const TTableDesc& tableDesc, const NKikimrSchemeOp::TIndexCreat
         //We have already checked this in IsCompatibleIndex
         Y_ABORT_UNLESS(indexKeys.KeyColumns.size() >= 1);
 
+        if (indexKeys.KeyColumns.size() > 1 && !IsCompatibleKeyTypes(baseColumnTypes, implTableColumns, uniformTable, error)) {
+            status = NKikimrScheme::EStatus::StatusInvalidParameter;
+            return false;
+        }
+
         const TString& indexColumnName = indexKeys.KeyColumns.back();
         Y_ABORT_UNLESS(baseColumnTypes.contains(indexColumnName));
         auto typeInfo = baseColumnTypes.at(indexColumnName);


### PR DESCRIPTION
### Changelog category <!-- remove all except one -->

* Not for changelog (changelog entry is not required)

### Description for reviewers <!-- (optional) description for those who read this PR -->

We should check index creation parameters before real schemeshard opertions, otherwise will be crash-loop