### PR TITLE
Late messages `TEvProposeTransaction` (#16216)

### DIFF
--- a/ydb/core/persqueue/pq_impl.cpp
+++ b/ydb/core/persqueue/pq_impl.cpp
@@ -1685,7 +1685,7 @@ void TPersQueue::Handle(TEvPersQueue::TEvDropTablet::TPtr& ev, const TActorConte
 {
     PQ_LOG_D("Handle TEvPersQueue::TEvDropTablet");
 
-    auto& record = ev->Get()->Record;
+    const auto& record = ev->Get()->Record;
     ui64 txId = record.GetTxId();
 
     TChangeNotification stateRequest(ev->Sender, txId);
@@ -4560,6 +4560,31 @@ void TPersQueue::InitMediatorTimeCast(const TActorContext& ctx)
 
 bool TPersQueue::AllTransactionsHaveBeenProcessed() const
 {
+    bool existDataTx = false;
+    bool existPlannedConfigTx = false;
+    bool existUnplannedConfigTx = false;
+
+    for (const auto& [_, tx] : Txs) {
+        switch (tx.Kind) {
+        case NKikimrPQ::TTransaction::KIND_CONFIG:
+            ((tx.Step == Max<ui64>()) ? existUnplannedConfigTx : existPlannedConfigTx) = true;
+            break;
+        case NKikimrPQ::TTransaction::KIND_DATA:
+            existDataTx = true;
+            break;
+        case NKikimrPQ::TTransaction::KIND_UNKNOWN:
+            Y_ABORT_UNLESS(false);
+        }
+    }
+
+    if (existDataTx || existPlannedConfigTx) {
+        return false;
+    }
+
+    if (existUnplannedConfigTx) {
+        return true;
+    }
+
     return EvProposeTransactionQueue.empty() && Txs.empty();
 }
 


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

Move changes from PR #16216

The `PQ` tablet can receive the message `TEvPersQueue::TEvProposeTransaction` twice from the `SS`. For example, when there are delays in the operation of the `IC`. As a result, the `Drop Tablet` operation may hang in the `PQ` tablet.

Instructions for the DB administrator 
1. The PQ tablet can be found in the SS app.
2. In the PQ tablet application, you can find a key like `tx_9876543210`.
3. On one of the cluster hosts, run a command like `kikimr admin tablet 1234567890 key value request 'CmdDeleteRange { Range { From: "tx_9876543210" IncludeFrom: true To: "tx_9876543210" IncludeTo: true } }'`
4. Restart the PQ tablet.

#16218

### Changelog category <!-- remove all except one -->

* Bugfix 

### Description for reviewers <!-- (optional) description for those who read this PR -->

The `PQ` tablet allows the `DropTablet` operation only if it has an empty list of transactions, or there is a configuration transaction without a `PlanStep`.