### PR TITLE
[stable-25-1] Distconfig fixes part 2

### DIFF
--- a/ydb/core/blobstorage/base/blobstorage_console_events.h
+++ b/ydb/core/blobstorage/base/blobstorage_console_events.h
@@ -77,14 +77,9 @@ namespace NKikimr {
             NKikimrBlobStorage::TEvControllerReplaceConfigRequest, EvControllerReplaceConfigRequest> {
         TEvControllerReplaceConfigRequest() = default;
 
-        TEvControllerReplaceConfigRequest(
-            std::optional<TString> clusterYaml,
-            std::optional<TString> storageYaml,
-            std::optional<bool> switchDedicatedStorageSection,
-            bool dedicatedConfigMode,
-            bool allowUnknownFields,
-            bool bypassMetadataChecks) {
-
+        TEvControllerReplaceConfigRequest(std::optional<TString> clusterYaml, std::optional<TString> storageYaml,
+                std::optional<bool> switchDedicatedStorageSection, bool dedicatedConfigMode, bool allowUnknownFields,
+                bool bypassMetadataChecks, bool enableConfigV2, bool disableConfigV2) {
             if (clusterYaml) {
                 Record.SetClusterYaml(*clusterYaml);
             }
@@ -97,6 +92,11 @@ namespace NKikimr {
             Record.SetDedicatedConfigMode(dedicatedConfigMode);
             Record.SetAllowUnknownFields(allowUnknownFields);
             Record.SetBypassMetadataChecks(bypassMetadataChecks);
+            if (enableConfigV2) {
+                Record.SetSwitchEnableConfigV2(true);
+            } else if (disableConfigV2) {
+                Record.SetSwitchEnableConfigV2(false);
+            }
         }
 
         TString ToString() const override {

--- a/ydb/core/blobstorage/nodewarden/distconf_console.cpp
+++ b/ydb/core/blobstorage/nodewarden/distconf_console.cpp
@@ -213,7 +213,7 @@ namespace NKikimr::NStorage {
         if (!fetched) { // fill in 'to-be-fetched' version of config with version incremented by one
             try {
                 auto metadata = NYamlConfig::GetMainMetadata(yaml);
-                metadata.Cluster = metadata.Cluster.value_or("unknown"); // TODO: fix this
+                metadata.Cluster = metadata.Cluster.value_or(AppData()->ClusterName);
                 metadata.Version = metadata.Version.value_or(0) + 1;
                 temp = NYamlConfig::ReplaceMetadata(yaml, metadata);
             } catch (const std::exception& ex) {

--- a/ydb/core/blobstorage/nodewarden/distconf_invoke_storage_config.cpp
+++ b/ydb/core/blobstorage/nodewarden/distconf_invoke_storage_config.cpp
@@ -45,6 +45,22 @@ namespace NKikimr::NStorage {
         NewYaml = request.HasYAML() ? std::make_optional(request.GetYAML()) : std::nullopt;
         NewStorageYaml = request.HasStorageYAML() ? std::make_optional(request.GetStorageYAML()) : std::nullopt;
 
+        // check if we are really changing something?
+        if (NewYaml == Self->MainConfigYaml) {
+            NewYaml.reset();
+        }
+        if (NewStorageYaml == Self->StorageConfigYaml) {
+            NewStorageYaml.reset();
+        }
+        if (!NewYaml && !NewStorageYaml) {
+            if (request.HasSwitchDedicatedStorageSection()) {
+                return FinishWithError(TResult::ERROR, "switching dedicated storage section mode without providing any new config");
+            } else {
+                // finish this request prematurely: no configs are actually changed
+                return Finish(Sender, SelfId(), PrepareResult(TResult::OK, std::nullopt).release(), 0, Cookie);
+            }
+        }
+
         // start deriving a config from current one
         TString state;
         NKikimrBlobStorage::TStorageConfig config(*Self->StorageConfig);
@@ -64,6 +80,10 @@ namespace NKikimr::NStorage {
                     throw yexception() << "missing or invalid kind provided";
                 }
                 version = metadata["version"].GetUIntegerRobust();
+                if (metadata.Has("cluster") && metadata["cluster"] != AppData()->ClusterName) {
+                    throw yexception() << "cluster name mismatch: provided# " << metadata["cluster"]
+                        << " expected# " << AppData()->ClusterName;
+                }
 
                 state = TStringBuilder() << "validating " << expectedKind << " config section";
                 if (!json.Has("config") || !json["config"].IsMap()) {

--- a/ydb/core/blobstorage/nodewarden/distconf_invoke_storage_config.cpp
+++ b/ydb/core/blobstorage/nodewarden/distconf_invoke_storage_config.cpp
@@ -13,20 +13,17 @@ namespace NKikimr::NStorage {
     void TInvokeRequestHandlerActor::FetchStorageConfig(bool manual, bool fetchMain, bool fetchStorage) {
         if (!Self->StorageConfig) {
             FinishWithError(TResult::ERROR, "no agreed StorageConfig");
-        } else if (!Self->MainConfigFetchYaml) {
+        } else if (!Self->MainConfigYaml) {
             FinishWithError(TResult::ERROR, "no stored YAML for storage config");
         } else {
             auto ev = PrepareResult(TResult::OK, std::nullopt);
             auto *record = &ev->Record;
             auto *res = record->MutableFetchStorageConfig();
             if (fetchMain) {
-                res->SetYAML(Self->MainConfigFetchYaml);
+                res->SetYAML(Self->MainConfigYaml);
             }
             if (fetchStorage && Self->StorageConfigYaml) {
-                auto metadata = NYamlConfig::GetStorageMetadata(*Self->StorageConfigYaml);
-                metadata.Cluster = metadata.Cluster.value_or("unknown"); // TODO: fix this
-                metadata.Version = metadata.Version.value_or(0) + 1;
-                res->SetStorageYAML(NYamlConfig::ReplaceMetadata(*Self->StorageConfigYaml, metadata));
+                res->SetStorageYAML(*Self->StorageConfigYaml);
             }
 
             if (manual) {

--- a/ydb/core/cms/console/console_configs_manager.cpp
+++ b/ydb/core/cms/console/console_configs_manager.cpp
@@ -56,7 +56,7 @@ void TConfigsManager::ReplaceMainConfigMetadata(const TString &config, bool forc
     try {
         if (!force) {
             auto metadata = NYamlConfig::GetMainMetadata(config);
-            opCtx.Cluster = metadata.Cluster.value_or(TString("unknown"));
+            opCtx.Cluster = metadata.Cluster.value_or(ClusterName);
             opCtx.Version = metadata.Version.value_or(0);
         } else {
             opCtx.Cluster = ClusterName;

--- a/ydb/core/grpc_services/rpc_config.cpp
+++ b/ydb/core/grpc_services/rpc_config.cpp
@@ -232,7 +232,9 @@ public:
             shim.SwitchDedicatedStorageSection,
             shim.DedicatedConfigMode,
             request->allow_unknown_fields() || request->bypass_checks(),
-            request->bypass_checks());
+            request->bypass_checks(),
+            false /* TODO: implement */,
+            false /* TODO: implement */);
     }
 
 private:

--- a/ydb/core/mind/bscontroller/bsc.cpp
+++ b/ydb/core/mind/bscontroller/bsc.cpp
@@ -442,7 +442,7 @@ void TBlobStorageController::Handle(TEvBlobStorage::TEvControllerDistconfRequest
 
             // commit it
             Execute(CreateTxCommitConfig(std::move(yamlConfig), std::make_optional(std::move(storageYaml)), std::nullopt,
-                expectedStorageYamlConfigVersion, std::exchange(h, {})));
+                expectedStorageYamlConfigVersion, std::exchange(h, {}), std::nullopt));
             break;
         }
 

--- a/ydb/core/mind/bscontroller/console_interaction.cpp
+++ b/ydb/core/mind/bscontroller/console_interaction.cpp
@@ -387,17 +387,16 @@ namespace NKikimr::NBsController {
             response->Record.SetErrorReason("configuration is locked by distconf");
         } else if (Self.StorageYamlConfig) {
             if (record.GetDedicatedStorageSection()) {
-                // TODO(alexvru): increment generation
                 response->Record.SetStorageYaml(*Self.StorageYamlConfig);
             }
             if (record.GetDedicatedClusterSection() && Self.YamlConfig) {
                 const auto& [yaml, configVersion, yamlReturnedByFetch] = *Self.YamlConfig;
-                response->Record.SetClusterYaml(yamlReturnedByFetch);
+                response->Record.SetClusterYaml(yaml);
             }
         } else {
             if (!record.GetDedicatedClusterSection() && !record.GetDedicatedStorageSection() && Self.YamlConfig) {
                 const auto& [yaml, configVersion, yamlReturnedByFetch] = *Self.YamlConfig;
-                response->Record.SetClusterYaml(yamlReturnedByFetch);
+                response->Record.SetClusterYaml(yaml);
             }
         }
         auto h = std::make_unique<IEventHandle>(ev->Sender, Self.SelfId(), response.release(), 0, ev->Cookie);

--- a/ydb/core/mind/bscontroller/console_interaction.h
+++ b/ydb/core/mind/bscontroller/console_interaction.h
@@ -47,18 +47,20 @@ namespace NKikimr::NBsController {
         bool NeedRetrySession = false;
         bool Working = false;
         bool CommitInProgress = false;
+        std::optional<bool> SwitchEnableConfigV2;
+        TEvBlobStorage::TEvControllerReplaceConfigRequest::TPtr PendingReplaceRequest;
 
         std::optional<TString> PendingYamlConfig;
         bool AllowUnknownFields = false;
-
         std::optional<std::optional<TString>> PendingStorageYamlConfig;
+        std::optional<ui64> ExpectedYamlConfigVersion;
 
         void MakeCommitToConsole(TString& config, ui32 configVersion);
         void MakeGetBlock();
         void MakeRetrySession();
 
         void IssueGRpcResponse(NKikimrBlobStorage::TEvControllerReplaceConfigResponse::EStatus status,
-            std::optional<TString> errorReason = std::nullopt);
+            std::optional<TString> errorReason = std::nullopt, bool disabledConfigV2 = false);
     };
 
 }

--- a/ydb/core/mind/bscontroller/impl.h
+++ b/ydb/core/mind/bscontroller/impl.h
@@ -1562,6 +1562,7 @@ private:
     bool AllowMultipleRealmsOccupation = true;
     bool StorageConfigObtained = false;
     bool Loaded = false;
+    bool EnableConfigV2 = false;
     std::shared_ptr<TControlWrapper> EnableSelfHealWithDegraded;
 
     struct TLifetimeToken {};
@@ -1980,7 +1981,8 @@ private:
         std::optional<std::optional<TString>>&& storageYamlConfig,
         std::optional<NKikimrBlobStorage::TStorageConfig>&& storageConfig,
         std::optional<ui64> expectedStorageYamlConfigVersion,
-        std::unique_ptr<IEventHandle> handle);
+        std::unique_ptr<IEventHandle> handle,
+        std::optional<bool> switchEnableConfigV2);
 
     struct TVDiskAvailabilityTiming {
         TVSlotId VSlotId;

--- a/ydb/core/mind/bscontroller/load_everything.cpp
+++ b/ydb/core/mind/bscontroller/load_everything.cpp
@@ -109,6 +109,7 @@ public:
                 if (state.HaveValue<T::ShredState>()) {
                     Self->ShredState.OnLoad(state.GetValue<T::ShredState>());
                 }
+                Self->EnableConfigV2 = state.GetValue<T::EnableConfigV2>();
             }
         }
 
@@ -472,14 +473,6 @@ public:
             }
         }
 
-        // primitive garbage collection for obsolete metrics
-        for (const auto& key : pdiskMetricsToDelete) {
-            db.Table<Schema::PDiskMetrics>().Key(key).Delete();
-        }
-        for (const auto& key : vdiskMetricsToDelete) {
-            db.Table<Schema::VDiskMetrics>().Key(key).Delete();
-        }
-
         // apply storage pool stats
         std::unordered_map<TBoxStoragePoolId, ui64> allocatedSizeMap;
         for (const auto& [vslotId, slot] : Self->VSlots) {
@@ -521,6 +514,14 @@ public:
         // calculate group status for all groups
         for (auto& [id, group] : Self->GroupMap) {
             group->CalculateGroupStatus();
+        }
+
+        // primitive garbage collection for obsolete metrics
+        for (const auto& key : pdiskMetricsToDelete) {
+            db.Table<Schema::PDiskMetrics>().Key(key).Delete();
+        }
+        for (const auto& key : vdiskMetricsToDelete) {
+            db.Table<Schema::VDiskMetrics>().Key(key).Delete();
         }
 
         return true;

--- a/ydb/core/mind/bscontroller/migrate.cpp
+++ b/ydb/core/mind/bscontroller/migrate.cpp
@@ -171,6 +171,14 @@ class TBlobStorageController::TTxMigrate : public TTransactionBase<TBlobStorageC
         }
     };
 
+    class TTxUpdateEnableConfigV2 : public TTxBase {
+    public:
+        bool Execute(TTransactionContext& txc) override {
+            NIceDb::TNiceDb(txc.DB).Table<Schema::State>().Key(true).Update<Schema::State::EnableConfigV2>(true);
+            return true;
+        }
+    };
+
     TDeque<THolder<TTxBase>> Queue;
 
 public:
@@ -231,6 +239,10 @@ public:
         Queue.emplace_back(new TTxDropDriveStatus);
     
         Queue.emplace_back(new TTxUpdateCompatibilityInfo);
+
+        if (!hasInstanceId) {
+            Queue.emplace_back(new TTxUpdateEnableConfigV2);
+        }
 
         return true;
     }

--- a/ydb/core/mind/bscontroller/scheme.h
+++ b/ydb/core/mind/bscontroller/scheme.h
@@ -114,6 +114,7 @@ struct Schema : NIceDb::Schema {
         struct ShredState : Column<26, NScheme::NTypeIds::String> {};
         struct StorageYamlConfig : Column<27, NScheme::NTypeIds::String> {};
         struct ExpectedStorageYamlConfigVersion : Column<28, NScheme::NTypeIds::Uint64> {};
+        struct EnableConfigV2 : Column<29, NScheme::NTypeIds::Bool> { static constexpr Type Default = false; };
 
         using TKey = TableKey<FixedKey>;
         using TColumns = TableColumns<FixedKey, NextGroupID, SchemaVersion, NextOperationLogIndex, DefaultMaxSlots,
@@ -121,7 +122,7 @@ struct Schema : NIceDb::Schema {
               PDiskSpaceMarginPromille, GroupReserveMin, GroupReservePart, MaxScrubbedDisksAtOnce, PDiskSpaceColorBorder,
               GroupLayoutSanitizer, NextVirtualGroupId, AllowMultipleRealmsOccupation, CompatibilityInfo,
               UseSelfHealLocalPolicy, TryToRelocateBrokenDisksLocallyFirst, YamlConfig, ShredState, StorageYamlConfig,
-              ExpectedStorageYamlConfigVersion>;
+              ExpectedStorageYamlConfigVersion, EnableConfigV2>;
     };
 
     struct VSlot : Table<5> {

--- a/ydb/core/protos/blobstorage.proto
+++ b/ydb/core/protos/blobstorage.proto
@@ -1448,6 +1448,7 @@ message TEvControllerReplaceConfigRequest {
     optional bool SkipConsoleValidation = 5;
     optional bool SwitchDedicatedStorageSection = 6;
     optional bool DedicatedConfigMode = 7;
+    optional bool SwitchEnableConfigV2 = 10; // if set, overrides EnableConfigV2 field in BSC
     // console flags
     optional bool AllowUnknownFields = 8;
     optional bool BypassMetadataChecks = 9;
@@ -1466,6 +1467,7 @@ message TEvControllerReplaceConfigResponse {
     }
     optional EStatus Status = 1;
     optional string ErrorReason = 2;
+    optional bool DisabledConfigV2 = 3; // set along with InvalidRequest when Configuration V2 is disabled and BSC can't process this query
 }
 
 message TEvControllerValidateConfigRequest {
@@ -1510,6 +1512,7 @@ message TEvControllerFetchConfigResponse {
     optional string ClusterYaml = 1;
     optional string StorageYaml = 2;
     optional string ErrorReason = 3;
+    optional bool DisabledConfigV2 = 4;
 }
 
 message TEvControllerDistconfRequest {

--- a/ydb/public/lib/ydb_cli/commands/ydb_dynamic_config.cpp
+++ b/ydb/public/lib/ydb_cli/commands/ydb_dynamic_config.cpp
@@ -110,7 +110,7 @@ int TCommandConfigFetch::Run(TConfig& config) {
     auto result = client.FetchAllConfigs(settings).GetValueSync();
 
     // if the new Config API is not supported, fallback to the old DynamicConfig API
-    if (result.GetStatus() == EStatus::CLIENT_CALL_UNIMPLEMENTED) {
+    if (result.GetStatus() == EStatus::CLIENT_CALL_UNIMPLEMENTED || result.GetStatus() == EStatus::UNSUPPORTED) {
         auto client = NYdb::NDynamicConfig::TDynamicConfigClient(*driver);
         auto result = client.GetConfig().GetValueSync();
         NStatusHelpers::ThrowOnErrorOrPrintIssues(result);
@@ -212,7 +212,7 @@ void TCommandConfigReplace::Parse(TConfig& config) {
         ythrow yexception() << "Must specify non-empty -f (--filename)";
     }
 
-   const auto configStr = Filename == "-" ? Cin.ReadAll() : TFileInput(Filename).ReadAll();
+    const auto configStr = Filename == "-" ? Cin.ReadAll() : TFileInput(Filename).ReadAll();
 
     DynamicConfig = configStr;
 
@@ -244,7 +244,7 @@ int TCommandConfigReplace::Run(TConfig& config) {
 
     auto status = client.ReplaceConfig(DynamicConfig, settings).GetValueSync();
 
-    if (status.GetStatus() == EStatus::CLIENT_CALL_UNIMPLEMENTED) {
+    if (status.GetStatus() == EStatus::CLIENT_CALL_UNIMPLEMENTED || status.GetStatus() == EStatus::UNSUPPORTED) {
         Cerr << "Warning: Fallback to DynamicConfig API" << Endl;
 
         auto client = NYdb::NDynamicConfig::TDynamicConfigClient(*driver);

--- a/ydb/services/config/bsconfig_ut.cpp
+++ b/ydb/services/config/bsconfig_ut.cpp
@@ -297,13 +297,12 @@ config:
     port: 12001
     host_config_id: 2
 )";
-        TString yamlConfigExpected = SubstGlobalCopy(yamlConfig, "version: 0", "version: 1");
         ReplaceConfig(server.GetChannel(), yamlConfig, std::nullopt, std::nullopt, false);
         std::optional<TString> yamlConfigFetched, storageYamlConfigFetched;
         FetchConfig(server.GetChannel(), false, false, yamlConfigFetched, storageYamlConfigFetched);
         UNIT_ASSERT(yamlConfigFetched);
         UNIT_ASSERT(!storageYamlConfigFetched);
-        UNIT_ASSERT_VALUES_EQUAL(yamlConfigExpected, *yamlConfigFetched);
+        UNIT_ASSERT_VALUES_EQUAL(yamlConfig, *yamlConfigFetched);
     }
 
     Y_UNIT_TEST(FetchConfig) {

--- a/ydb/tests/functional/config/test_config_with_metadata.py
+++ b/ydb/tests/functional/config/test_config_with_metadata.py
@@ -193,7 +193,6 @@ class TestKiKiMRStoreConfigDir(AbstractKiKiMRTest):
 
         for node in self.cluster.nodes.values():
             node_config = node.read_node_config()
-            node_config['metadata']['version'] = get_config_version(yaml.dump(node_config)) + 1
             assert_that(
                 yaml.dump(yaml.safe_load(fetched_config), sort_keys=True) ==
                 yaml.dump(yaml.safe_load(yaml.dump(node_config)), sort_keys=True)

--- a/ydb/tests/functional/scheme_tests/canondata/tablet_scheme_tests.TestTabletSchemes.test_tablet_schemes_flat_bs_controller_/flat_bs_controller.schema
+++ b/ydb/tests/functional/scheme_tests/canondata/tablet_scheme_tests.TestTabletSchemes.test_tablet_schemes_flat_bs_controller_/flat_bs_controller.schema
@@ -7,6 +7,11 @@
         ],
         "ColumnsAdded": [
             {
+                "ColumnId": 29,
+                "ColumnName": "EnableConfigV2",
+                "ColumnType": "Bool"
+            },
+            {
                 "ColumnId": 1,
                 "ColumnName": "FixedKey",
                 "ColumnType": "Bool"
@@ -141,6 +146,7 @@
         "ColumnFamilies": {
             "0": {
                 "Columns": [
+                    29,
                     1,
                     2,
                     4,


### PR DESCRIPTION
- Add EnableConfigV2 option to allow enabling/disabling v2 configuration for migration purposes (#16066)
- Fix metadata handling in BSC, distconf and Console (#16246)
- Support idempotent configuration change and check cluster name when replacing config (#16280)

### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

...

### Changelog category <!-- remove all except one -->

* New feature
* Experimental feature
* Improvement
* Performance improvement
* User Interface
* Bugfix 
* Backward incompatible change
* Documentation (changelog entry is not required)
* Not for changelog (changelog entry is not required)

### Description for reviewers <!-- (optional) description for those who read this PR -->

...
