### PR TITLE
Add YDB CLI config/config.yaml file to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -90,5 +90,5 @@ bin/config.json
 # handy for local junk, which is not intended to appear in the repo
 junk/
 
-# YDB CLI configuration file
+# YDB CLI configuration file location is `~/ydb/config/config.yaml`
 config/config.yaml

--- a/.gitignore
+++ b/.gitignore
@@ -89,3 +89,6 @@ bin/config.json
 
 # handy for local junk, which is not intended to appear in the repo
 junk/
+
+# YDB CLI configuration file
+config/config.yaml


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

...

### Changelog category <!-- remove all except one -->

* Not for changelog (changelog entry is not required)

### Description for reviewers <!-- (optional) description for those who read this PR -->

YDB CLI writes its config to `~/ydb/config/config.yaml`, but I've checked out ydb repo in my home folder
