### PR TITLE
Update muted_ya.txt

### DIFF
--- a/.github/config/muted_ya.txt
+++ b/.github/config/muted_ya.txt
@@ -80,7 +80,14 @@ ydb/tests/fq/yds test_mem_alloc.py.TestMemAlloc.test_join_alloc[v1]
 ydb/tests/fq/yds test_recovery.py.TestRecovery.test_ic_disconnection
 ydb/tests/fq/yds test_select_limit_db_id.py.TestSelectLimitWithDbId.test_select_same_with_id[v1-mvp_external_ydb_endpoint0]
 ydb/tests/fq/yds test_yds_bindings.py.TestBindings.test_yds_insert[v1]
+ydb/tests/functional/compatibility test_compatibility.py.TestCompatibility.test_simple
 ydb/tests/functional/compatibility test_followers.py.TestFollowersCompatibility.test_followers_compatability
+ydb/tests/functional/compatibility test_stress.py.TestStress.test_kv[last_stable-row]
+ydb/tests/functional/compatibility test_stress.py.TestStress.test_kv[mixed-row]
+ydb/tests/functional/compatibility test_stress.py.TestStress.test_log[last_stable-row]
+ydb/tests/functional/compatibility test_stress.py.TestStress.test_log[mixed-row]
+ydb/tests/functional/compatibility test_stress.py.TestStress.test_tpch1[current-row]
+ydb/tests/functional/compatibility test_stress.py.TestStress.test_tpch1[last_stable-row]
 ydb/tests/functional/hive test_drain.py.TestHive.test_drain_on_stop
 ydb/tests/functional/rename [test_rename.py */*] chunk chunk
 ydb/tests/functional/serializable sole chunk chunk
@@ -89,7 +96,6 @@ ydb/tests/functional/serverless test_serverless.py.test_database_with_disk_quota
 ydb/tests/functional/serverless test_serverless.py.test_database_with_disk_quotas[enable_alter_database_create_hive_first--true]
 ydb/tests/functional/suite_tests [test_sql_logic.py */*] chunk chunk
 ydb/tests/functional/suite_tests test_postgres.py.TestPGSQL.test_sql_suite[plan-jointest/join2.test]
-ydb/tests/functional/suite_tests test_sql_logic.py.TestSQLLogic.test_sql_suite[results-select3-13.test]
 ydb/tests/functional/tenants test_dynamic_tenants.py.test_create_and_drop_the_same_tenant2[enable_alter_database_create_hive_first--false]
 ydb/tests/functional/tenants test_dynamic_tenants.py.test_create_and_drop_the_same_tenant2[enable_alter_database_create_hive_first--true]
 ydb/tests/functional/tenants test_tenants.py.TestTenants.test_create_drop_create_table3[enable_alter_database_create_hive_first--false]
@@ -109,6 +115,7 @@ ydb/tests/functional/tpc/large test_tpcds.py.TestTpcdsS1.test_tpcds[86]
 ydb/tests/functional/tpc/large test_tpcds.py.TestTpcdsS1.test_tpcds[9]
 ydb/tests/functional/tpc/large test_tpch_spilling.py.TestTpchSpillingS10.test_tpch[7]
 ydb/tests/olap sole chunk chunk
+ydb/tests/olap test_quota_exhaustion.py.TestYdbWorkload.test_delete
 ydb/tests/olap/column_family/compression alter_compression.py.TestAlterCompression.test_all_supported_compression
 ydb/tests/olap/column_family/compression sole chunk chunk
 ydb/tests/olap/scenario sole chunk chunk


### PR DESCRIPTION
**Muted flaky: 10**

```
ydb/tests/functional/compatibility test_compatibility.py.TestCompatibility.test_simple # owner Unknown success_rate 0%, state Flaky, days in state 2, pass_count 0, fail count 3
ydb/tests/functional/compatibility test_stress.py.TestStress.test_kv[last_stable-row] # owner Unknown success_rate 0%, state Flaky, days in state 2, pass_count 0, fail count 3
ydb/tests/functional/compatibility test_stress.py.TestStress.test_kv[mixed-row] # owner Unknown success_rate 0%, state Flaky, days in state 2, pass_count 0, fail count 3
ydb/tests/functional/compatibility test_stress.py.TestStress.test_log[last_stable-row] # owner Unknown success_rate 0%, state Flaky, days in state 2, pass_count 0, fail count 3
ydb/tests/functional/compatibility test_stress.py.TestStress.test_log[mixed-row] # owner Unknown success_rate 0%, state Flaky, days in state 2, pass_count 0, fail count 3
ydb/tests/functional/compatibility test_stress.py.TestStress.test_tpch1[current-row] # owner Unknown success_rate 0%, state Flaky, days in state 3, pass_count 0, fail count 3
ydb/tests/functional/compatibility test_stress.py.TestStress.test_tpch1[last_stable-row] # owner Unknown success_rate 0%, state Flaky, days in state 3, pass_count 0, fail count 3
ydb/tests/functional/compatibility test_stress.py.TestStress.test_tpch1[mixed-row] # owner Unknown success_rate 0%, state Flaky, days in state 3, pass_count 0, fail count 3
ydb/tests/functional/suite_tests test_sql_logic.py.TestSQLLogic.test_sql_suite[results-select2-1.test] # owner TEAM:@ydb-platform/qp success_rate 66%, state Flaky, days in state 1, pass_count 10, fail count 5
ydb/tests/olap test_quota_exhaustion.py.TestYdbWorkload.test_delete # owner TEAM:@ydb-platform/cs success_rate 50%, state Flaky, days in state 3, pass_count 12, fail count 12
```

**Unmuted stable: 1**

```
ydb/tests/functional/suite_tests test_sql_logic.py.TestSQLLogic.test_sql_suite[results-select3-13.test] # owner TEAM:@ydb-platform/qp success_rate 100%, state Muted Stable days in state 16
```

