### PR TITLE
Use `uncaught_exceptions` instead of removed in c++20 `uncaught_exception`

### DIFF
--- a/ydb/core/ymq/http/xml_builder.cpp
+++ b/ydb/core/ymq/http/xml_builder.cpp
@@ -54,7 +54,7 @@ TXmlDocument::TXmlDocument(TXmlStringBuilder& builder)
 }
 
 TXmlDocument::~TXmlDocument() noexcept(false) {
-    const bool unwinding = std::uncaught_exception(); // TODO: use C++'17 std::uncaught_exceptions() func
+    const bool unwinding = std::uncaught_exceptions();
     if (!unwinding) {
         if (xmlTextWriterEndDocument((xmlTextWriterPtr)Builder.TextWriter) < 0) {
             ythrow TWriteXmlError() << "Failed to end xml document";
@@ -77,7 +77,7 @@ TXmlRecursiveElement::TXmlRecursiveElement(TXmlStringBuilder& builder, const cha
 }
 
 TXmlRecursiveElement::~TXmlRecursiveElement() noexcept(false) {
-    const bool unwinding = std::uncaught_exception(); // TODO: use C++'17 std::uncaught_exceptions() func
+    const bool unwinding = std::uncaught_exceptions();
     if (!unwinding) {
         if (xmlTextWriterEndElement((xmlTextWriterPtr)Builder.TextWriter) < 0) {
             ythrow TWriteXmlError() << "Failed to end xml element";

--- a/ydb/public/sdk/cpp/src/client/persqueue_public/ut/read_session_ut.cpp
+++ b/ydb/public/sdk/cpp/src/client/persqueue_public/ut/read_session_ut.cpp
@@ -595,7 +595,7 @@ TReadSessionImplTestSetup::TReadSessionImplTestSetup() {
 }
 
 TReadSessionImplTestSetup::~TReadSessionImplTestSetup() noexcept(false) {
-    if (!std::uncaught_exception()) { // Exiting from test successfully. Check additional expectations.
+    if (!std::uncaught_exceptions()) { // Exiting from test successfully. Check additional expectations.
         MockProcessorFactory->Wait();
         MockProcessor->Wait();
 


### PR DESCRIPTION
`std::uncaught_exception` has been removed in c++20 [link](https://en.cppreference.com/w/cpp/error/uncaught_exception)

...

### Changelog category <!-- remove all except one -->

* Not for changelog (changelog entry is not required)

### Description for reviewers <!-- (optional) description for those who read this PR -->

...
