### PR TITLE
overlapping portions test has been added

### DIFF
--- a/ydb/tests/library/harness/kikimr_config.py
+++ b/ydb/tests/library/harness/kikimr_config.py
@@ -163,6 +163,7 @@ class KikimrConfigGenerator(object):
             separate_node_configs=False,
             default_clusteradmin=None,
             enable_resource_pools=None,
+            grouped_memory_limiter_config=None,
     ):
         if extra_feature_flags is None:
             extra_feature_flags = []
@@ -353,6 +354,9 @@ class KikimrConfigGenerator(object):
 
         if column_shard_config:
             self.yaml_config["column_shard_config"] = column_shard_config
+
+        if grouped_memory_limiter_config:
+            self.yaml_config["grouped_memory_limiter_config"] = grouped_memory_limiter_config
 
         self.__build()
 

--- a/ydb/tests/olap/oom/overlapping_portions.py
+++ b/ydb/tests/olap/oom/overlapping_portions.py
@@ -66,7 +66,7 @@ class TestOverlappingPortions(object):
             timestamp_from_ms += current_chunk_size
             rows -= current_chunk_size
             assert rows >= 0
-    
+
     def write_and_check(self, table_path, count):
         ts_start = int(datetime.datetime.now().timestamp() * 1000000)
         for value in range(count):

--- a/ydb/tests/olap/oom/overlapping_portions.py
+++ b/ydb/tests/olap/oom/overlapping_portions.py
@@ -22,7 +22,7 @@ class TestOverlappingPortions(object):
         ydb_path = yatest.common.build_path(os.environ.get("YDB_DRIVER_BINARY"))
         logger.info(yatest.common.execute([ydb_path, "-V"], wait=True).stdout.decode("utf-8"))
         config = KikimrConfigGenerator(
-            column_shard_config={"alter_object_enabled": True, "compaction_enabled": False},
+            column_shard_config={"compaction_enabled": False},
             grouped_memory_limiter_config={
                 "enabled": True,
                 "memory_limit": 100 * 1024 * 1024,
@@ -66,6 +66,17 @@ class TestOverlappingPortions(object):
             timestamp_from_ms += current_chunk_size
             rows -= current_chunk_size
             assert rows >= 0
+    
+    def write_and_check(self, table_path, count):
+        ts_start = int(datetime.datetime.now().timestamp() * 1000000)
+        for value in range(count):
+            self.write_data(table_path, ts_start, 100, value)
+
+        self.ydb_client.query(
+            f"""
+            select * from `{table_path}`
+            """
+        )
 
     @link_test_case("#15512")
     def test(self):
@@ -87,22 +98,7 @@ class TestOverlappingPortions(object):
             """
         )
 
-        ts_start = int(datetime.datetime.now().timestamp() * 1000000)
-        for value in range(1):
-            self.write_data(table_path, ts_start, 100, value)
-
-        self.ydb_client.query(
-            f"""
-            select * from `{table_path}`
-            """
-        )
-
-        for value in range(100):
-            self.write_data(table_path, ts_start, 100, value)
+        self.write_and_check(table_path, 1)
 
         with pytest.raises(ydb.issues.GenericError, match=r'.*cannot allocate memory.*'):
-            self.ydb_client.query(
-                f"""
-                select * from `{table_path}`
-                """
-            )
+            self.write_and_check(table_path, 100)

--- a/ydb/tests/olap/oom/overlapping_portions.py
+++ b/ydb/tests/olap/oom/overlapping_portions.py
@@ -1,0 +1,108 @@
+import datetime
+import logging
+import os
+import pytest
+import random
+import yatest.common
+import ydb
+
+from ydb.tests.library.harness.kikimr_config import KikimrConfigGenerator
+from ydb.tests.library.harness.kikimr_runner import KiKiMR
+from ydb.tests.library.test_meta import link_test_case
+from ydb.tests.olap.common.ydb_client import YdbClient
+
+logger = logging.getLogger(__name__)
+
+
+class TestOverlappingPortions(object):
+    test_name = "overlapping_portions"
+
+    @classmethod
+    def setup_class(cls):
+        ydb_path = yatest.common.build_path(os.environ.get("YDB_DRIVER_BINARY"))
+        logger.info(yatest.common.execute([ydb_path, "-V"], wait=True).stdout.decode("utf-8"))
+        config = KikimrConfigGenerator(
+            column_shard_config={"alter_object_enabled": True, "compaction_enabled": False},
+            grouped_memory_limiter_config={
+                "enabled": True,
+                "memory_limit": 100 * 1024 * 1024,
+                "hard_memory_limit": 100 * 1024 * 1024,
+            },
+        )
+        cls.cluster = KiKiMR(config)
+        cls.cluster.start()
+        node = cls.cluster.nodes[1]
+        cls.ydb_client = YdbClient(database=f"/{config.domain_name}", endpoint=f"grpc://{node.host}:{node.port}")
+        cls.ydb_client.wait_connection()
+
+    def write_data(
+        self,
+        table: str,
+        timestamp_from_ms: int,
+        rows: int,
+        value: int = 1,
+    ):
+        column_types = ydb.BulkUpsertColumns()
+        column_types.add_column("ts", ydb.PrimitiveType.Timestamp)
+        column_types.add_column("s", ydb.PrimitiveType.String)
+        column_types.add_column("val", ydb.PrimitiveType.Uint64)
+
+        chunk_size = 100
+        while rows:
+            current_chunk_size = min(chunk_size, rows)
+            data = [
+                {
+                    "ts": timestamp_from_ms + i,
+                    "s": random.randbytes(1024 * 10),
+                    "val": value,
+                }
+                for i in range(current_chunk_size)
+            ]
+            self.ydb_client.bulk_upsert(
+                table,
+                column_types,
+                data,
+            )
+            timestamp_from_ms += current_chunk_size
+            rows -= current_chunk_size
+            assert rows >= 0
+
+    @link_test_case("#15512")
+    def test(self):
+        test_dir = f"{self.ydb_client.database}/{self.test_name}"
+        table_path = f"{test_dir}/table"
+
+        self.ydb_client.query(
+            f"""
+            CREATE TABLE `{table_path}` (
+                ts Timestamp NOT NULL,
+                s String,
+                val Uint64,
+                PRIMARY KEY(ts),
+            )
+            WITH (
+                STORE = COLUMN,
+                AUTO_PARTITIONING_MIN_PARTITIONS_COUNT = 1
+            )
+            """
+        )
+
+        ts_start = int(datetime.datetime.now().timestamp() * 1000000)
+        for value in range(1):
+            self.write_data(table_path, ts_start, 100, value)
+
+        self.ydb_client.query(
+            f"""
+            select * from `{table_path}`
+            """
+        )
+
+        for value in range(100):
+            self.write_data(table_path, ts_start, 100, value)
+
+        with pytest.raises(ydb.issues.GenericError, match=r'.*cannot allocate memory.*'):
+            self.ydb_client.query(
+                f"""
+                select * from `{table_path}`
+                """
+            )

--- a/ydb/tests/olap/oom/ya.make
+++ b/ydb/tests/olap/oom/ya.make
@@ -1,0 +1,26 @@
+PY3TEST()
+ENV(YDB_DRIVER_BINARY="ydb/apps/ydbd/ydbd")
+
+FORK_TEST_FILES()
+
+TEST_SRCS(
+    overlapping_portions.py
+)
+
+SIZE(MEDIUM)
+
+PEERDIR(
+    ydb/tests/library
+    ydb/tests/library/test_meta
+    ydb/public/sdk/python
+    ydb/public/sdk/python/enable_v3_new_behavior
+    library/recipes/common
+    ydb/tests/olap/common
+)
+
+DEPENDS(
+    ydb/apps/ydbd
+)
+
+END()
+

--- a/ydb/tests/olap/ya.make
+++ b/ydb/tests/olap/ya.make
@@ -32,6 +32,7 @@ RECURSE(
     high_load
     lib
     load
+    oom
     s3_import
     scenario
     ttl_tiering


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

Если данные порций, необходимые для скана, не помещаются в память ноды, скан должен падать с понятной ошибкой и не должен случаться OOM.

1. Отключить компакшн
2. Много раз повторно записать один батч данных
3. Выполнить SELECT, по этим данным

### Changelog category <!-- remove all except one -->


* Not for changelog (changelog entry is not required)

### Description for reviewers <!-- (optional) description for those who read this PR -->

...
