### PR TITLE
25-1: Ydb::StatusIds::TIMEOUT is a retryable error

### DIFF
--- a/ydb/core/tx/datashard/upload_stats.h
+++ b/ydb/core/tx/datashard/upload_stats.h
@@ -56,7 +56,10 @@ struct TUploadStatus {
     }
 
     bool IsRetriable() const {
-        return StatusCode == Ydb::StatusIds::UNAVAILABLE || StatusCode == Ydb::StatusIds::OVERLOADED;
+        return StatusCode == Ydb::StatusIds::UNAVAILABLE
+            || StatusCode == Ydb::StatusIds::OVERLOADED
+            || StatusCode == Ydb::StatusIds::TIMEOUT
+            ;
     }
 
     TString ToString() const {


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

I could help to build huge secondary indexes.

Ydb::StatusIds::TIMEOUT is a retryable error #16412

### Changelog category <!-- remove all except one -->

* Bugfix 

### Description for reviewers <!-- (optional) description for those who read this PR -->

...
