### PR TITLE
Fix for reading from column shard without specifying any columns

### DIFF
--- a/ydb/core/kqp/expr_nodes/kqp_expr_nodes.json
+++ b/ydb/core/kqp/expr_nodes/kqp_expr_nodes.json
@@ -124,8 +124,7 @@
             "Base": "TKqlReadTableRangesBase",
             "Match": {"Type": "CallableBase"},
             "Children": [
-                {"Index": 5, "Name": "Process", "Type": "TCoLambda"},
-                {"Index": 6, "Name": "DontOptimize", "Type": "TCoAtom", "Optional": true}
+                {"Index": 5, "Name": "Process", "Type": "TCoLambda"}
             ]
         },
         {

--- a/ydb/core/kqp/expr_nodes/kqp_expr_nodes.json
+++ b/ydb/core/kqp/expr_nodes/kqp_expr_nodes.json
@@ -124,7 +124,8 @@
             "Base": "TKqlReadTableRangesBase",
             "Match": {"Type": "CallableBase"},
             "Children": [
-                {"Index": 5, "Name": "Process", "Type": "TCoLambda"}
+                {"Index": 5, "Name": "Process", "Type": "TCoLambda"},
+                {"Index": 6, "Name": "DontOptimize", "Type": "TCoAtom", "Optional": true}
             ]
         },
         {

--- a/ydb/core/kqp/opt/logical/kqp_opt_log_extract.cpp
+++ b/ydb/core/kqp/opt/logical/kqp_opt_log_extract.cpp
@@ -157,8 +157,7 @@ TExprBase KqpApplyExtractMembersToReadOlapTable(TExprBase node, TExprContext& ct
 
     auto read = node.Cast<TKqpReadOlapTableRangesBase>();
 
-    const auto maybeDontOptimize = read.DontOptimize().Maybe<TCoAtom>();
-    if (maybeDontOptimize) {
+    if (read.Columns().Size() == 1) {
         return node;
     }
 

--- a/ydb/core/kqp/opt/logical/kqp_opt_log_extract.cpp
+++ b/ydb/core/kqp/opt/logical/kqp_opt_log_extract.cpp
@@ -157,6 +157,11 @@ TExprBase KqpApplyExtractMembersToReadOlapTable(TExprBase node, TExprContext& ct
 
     auto read = node.Cast<TKqpReadOlapTableRangesBase>();
 
+    const auto maybeDontOptimize = read.DontOptimize().Maybe<TCoAtom>();
+    if (maybeDontOptimize) {
+        return node;
+    }
+
     auto usedColumns = GetUsedColumns(read, read.Columns(), parentsMap, allowMultiUsage, ctx);
     if (!usedColumns) {
         return node;

--- a/ydb/core/kqp/opt/physical/kqp_opt_phy.cpp
+++ b/ydb/core/kqp/opt/physical/kqp_opt_phy.cpp
@@ -124,7 +124,10 @@ public:
         AddHandler(1, &TCoTake::Match, HNDL(PropagatePrecomuteTake<true>));
         AddHandler(1, &TCoFlatMap::Match, HNDL(PropagatePrecomuteFlatmap<true>));
         AddHandler(1, &TKqpWriteConstraint::Match, HNDL(BuildWriteConstraint<true>));
+        AddHandler(1, &TKqpWriteConstraint::Match, HNDL(BuildWriteConstraint<true>));
+        AddHandler(1, &TKqpReadOlapTableRanges::Match, HNDL(AddColumnForEmptyColumnsOlapRead));
 
+        
         AddHandler(2, &TDqStage::Match, HNDL(RewriteKqpReadTable));
         AddHandler(2, &TDqStage::Match, HNDL(RewriteKqpLookupTable));
         AddHandler(2, &TKqlUpsertRows::Match, HNDL(RewriteReturningUpsert));
@@ -525,6 +528,13 @@ protected:
     {
         TExprBase output = KqpBuildWriteConstraint(node, ctx, optCtx, *getParents(), IsGlobal);
         DumpAppliedRule("BuildWriteConstraint", node.Ptr(), output.Ptr(), ctx);
+        return output;
+    }
+
+    TMaybeNode<TExprBase> AddColumnForEmptyColumnsOlapRead(TExprBase node, TExprContext& ctx)
+    {
+        TExprBase output = KqpAddColumnForEmptyColumnsOlapRead(node, ctx, KqpCtx);
+        DumpAppliedRule("AddColumnForEmptyColumnsOlapRead", node.Ptr(), output.Ptr(), ctx);
         return output;
     }
 

--- a/ydb/core/kqp/opt/physical/kqp_opt_phy_olap_filter.cpp
+++ b/ydb/core/kqp/opt/physical/kqp_opt_phy_olap_filter.cpp
@@ -908,7 +908,6 @@ TExprBase KqpAddColumnForEmptyColumnsOlapRead(TExprBase node, TExprContext& ctx,
         .Settings(readOlap.Settings())
         .ExplainPrompt(readOlap.ExplainPrompt())
         .Process(readOlap.Process())
-        .DontOptimize(ctx.NewAtom(node.Pos(), "true"))
         .Done();
 }
 

--- a/ydb/core/kqp/opt/physical/kqp_opt_phy_olap_filter.cpp
+++ b/ydb/core/kqp/opt/physical/kqp_opt_phy_olap_filter.cpp
@@ -883,4 +883,33 @@ TExprBase KqpPushOlapFilter(TExprBase node, TExprContext& ctx, const TKqpOptimiz
 #endif
 }
 
+TExprBase KqpAddColumnForEmptyColumnsOlapRead(TExprBase node, TExprContext& ctx, const TKqpOptimizeContext& kqpCtx) {
+    if (!node.Maybe<TKqpReadOlapTableRanges>()) {
+        return node;
+    }
+
+    auto readOlap = node.Cast<TKqpReadOlapTableRanges>();
+    if (readOlap.Columns().Size()!=0) {
+        return node;
+    }
+
+    const auto& tableData = kqpCtx.Tables->ExistingTable(kqpCtx.Cluster, readOlap.Table().Path().Value());
+    auto keyColumns = tableData.Metadata->KeyColumnNames;
+
+    TVector<TExprNode::TPtr> newColumns;
+    newColumns.push_back(ctx.NewAtom(node.Pos(), keyColumns[0]));
+
+    return Build<TKqpReadOlapTableRanges>(ctx, node.Pos())
+        .Table(readOlap.Table())
+        .Ranges(readOlap.Ranges())
+        .Columns()
+            .Add(newColumns)
+            .Build()
+        .Settings(readOlap.Settings())
+        .ExplainPrompt(readOlap.ExplainPrompt())
+        .Process(readOlap.Process())
+        .DontOptimize(ctx.NewAtom(node.Pos(), "true"))
+        .Done();
+}
+
 } // namespace NKikimr::NKqp::NOpt

--- a/ydb/core/kqp/opt/physical/kqp_opt_phy_rules.h
+++ b/ydb/core/kqp/opt/physical/kqp_opt_phy_rules.h
@@ -67,6 +67,9 @@ NYql::NNodes::TExprBase KqpPropagatePrecomuteScalarRowset(NYql::NNodes::TExprBas
 NYql::NNodes::TExprBase KqpBuildWriteConstraint(NYql::NNodes::TExprBase node, NYql::TExprContext& ctx,
     NYql::IOptimizationContext& optCtx, const NYql::TParentsMap& parentsMap, bool allowStageMultiUsage);
 
+NYql::NNodes::TExprBase KqpAddColumnForEmptyColumnsOlapRead(NYql::NNodes::TExprBase node, NYql::TExprContext& ctx, 
+    const TKqpOptimizeContext& kqpCtx);
+
 bool AllowFuseJoinInputs(NYql::NNodes::TExprBase node);
 
 bool UseSource(const TKqpOptimizeContext& kqpCtx, const NYql::TKikimrTableDescription& tableDesc);

--- a/ydb/core/kqp/ut/olap/kqp_olap_ut.cpp
+++ b/ydb/core/kqp/ut/olap/kqp_olap_ut.cpp
@@ -341,22 +341,19 @@ Y_UNIT_TEST_SUITE(KqpOlap) {
 
         WriteTestData(kikimr, "/Root/olapStore/olapTable", 0, 1000000, 2);
 
-        auto client = kikimr.GetTableClient();
+        auto client = kikimr.GetQueryClient();
 
         Tests::NCommon::TLoggerInit(kikimr).Initialize();
 
         {
-            auto it = client.StreamExecuteScanQuery(R"(
+            auto it = client.ExecuteQuery(R"(
                 --!syntax_v1
 
                 SELECT 1
                 FROM `/Root/olapStore/olapTable`
-            )").GetValueSync();
+            )",NYdb::NQuery::TTxControl::NoTx(), NYdb::NQuery::TExecuteQuerySettings()).ExtractValueSync();
 
             UNIT_ASSERT_C(it.IsSuccess(), it.GetIssues().ToString());
-            TString result = StreamResultToYson(it);
-            Cout << result << Endl;
-            CompareYson(result, R"([[1];[1]])");
         }
     }
 

--- a/ydb/tests/functional/clickbench/canondata/test.test_plans_column_/queries-original-plan-column-0
+++ b/ydb/tests/functional/clickbench/canondata/test.test_plans_column_/queries-original-plan-column-0
@@ -79,7 +79,9 @@
                                                         "Inputs": [],
                                                         "Name": "TableFullScan",
                                                         "Path": "/local/clickbench/plans/column/hits",
-                                                        "ReadColumns": null,
+                                                        "ReadColumns": [
+                                                            "CounterID"
+                                                        ],
                                                         "ReadRanges": [
                                                             "CounterID (-\u221e, +\u221e)",
                                                             "EventDate (-\u221e, +\u221e)",
@@ -141,6 +143,9 @@
                     "name": "/local/clickbench/plans/column/hits",
                     "reads": [
                         {
+                            "columns": [
+                                "CounterID"
+                            ],
                             "scan_by": [
                                 "CounterID (-\u221e, +\u221e)",
                                 "EventDate (-\u221e, +\u221e)",


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

Fixed the problem of reading from a column shard table with no columns specified: https://github.com/ydb-platform/ydb/issues/15845
Currently reads from column shards in Generic Query mode are only supported if at least one column in read.
This will be fixed in the future, but the temporary fix is to leave one key column in the reads.
Ticket for column shards: https://github.com/ydb-platform/ydb/issues/16599

### Changelog category <!-- remove all except one -->

* Bugfix
### Description for reviewers <!-- (optional) description for those who read this PR -->

Fixed the problem of reading from a column shard table with no columns specified: https://github.com/ydb-platform/ydb/issues/15845
...
