### PR TITLE
Remove upload on page fault "optimization"

### DIFF
--- a/ydb/core/tx/datashard/local_kmeans.cpp
+++ b/ydb/core/tx/datashard/local_kmeans.cpp
@@ -247,12 +247,6 @@ public:
     EScan PageFault() final
     {
         LOG_T("PageFault " << Debug());
-
-        if (!ReadBuf.IsEmpty() && WriteBuf.IsEmpty()) {
-            ReadBuf.FlushTo(WriteBuf);
-            Upload(false);
-        }
-
         return EScan::Feed;
     }
 

--- a/ydb/core/tx/datashard/prefix_kmeans.cpp
+++ b/ydb/core/tx/datashard/prefix_kmeans.cpp
@@ -225,18 +225,12 @@ public:
             << " K: " << K << " Clusters: " << Clusters.size()
             << " State: " << State << " Round: " << Round << " / " << MaxRounds
             << " LevelBuf size: " << LevelBuf.Size() << " PostingBuf size: " << PostingBuf.Size() << " PrefixBuf size: " << PrefixBuf.Size()
-            << " UploadTable: " << UploadTable << " UploadBuf size: " << UploadBuf.Size();
+            << " UploadTable: " << UploadTable << " UploadBuf size: " << UploadBuf.Size() << " RetryCount: " << RetryCount;
     }
 
     EScan PageFault() final
     {
         LOG_T("PageFault " << Debug());
-
-        UploadInProgress()
-            || TryUpload(LevelBuf, LevelTable, LevelTypes, false)
-            || TryUpload(PostingBuf, PostingTable, PostingTypes, false)
-            || TryUpload(PrefixBuf, PrefixTable, PrefixTypes, false);
-
         return EScan::Feed;
     }
 
@@ -328,6 +322,8 @@ protected:
 
     void UploadImpl()
     {
+        LOG_D("Uploading " << Debug());
+
         Y_ASSERT(!UploadBuf.IsEmpty());
         Y_ASSERT(!Uploader);
         auto actor = NTxProxy::CreateUploadRowsInternal(

--- a/ydb/core/tx/datashard/reshuffle_kmeans.cpp
+++ b/ydb/core/tx/datashard/reshuffle_kmeans.cpp
@@ -178,12 +178,6 @@ public:
     EScan PageFault() final
     {
         LOG_T("PageFault " << Debug());
-
-        if (!ReadBuf.IsEmpty() && WriteBuf.IsEmpty()) {
-            ReadBuf.FlushTo(WriteBuf);
-            Upload(false);
-        }
-
         return EScan::Feed;
     }
 


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

...

### Changelog category <!-- remove all except one -->

* Not for changelog (changelog entry is not required)

### Description for reviewers <!-- (optional) description for those who read this PR -->

Each Seek leads to PageFault handling which trigger upload that works badly for small prefixes

For similarity with other searches disable in them too (profit is doubtful)
