### PR TITLE
ydb_configure features, part 5

### DIFF
--- a/ydb/tools/cfg/base.py
+++ b/ydb/tools/cfg/base.py
@@ -311,6 +311,7 @@ class ClusterDetailsProvider(object):
         self.immediate_controls_config = self.__cluster_description.get("immediate_controls_config")
         self.cms_config = self.__cluster_description.get("cms_config")
         self.pdisk_key_config = self.__cluster_description.get("pdisk_key_config", {})
+        self.selector_config = self.__cluster_description.get("selector_config", {})
         if not self.need_txt_files and not self.use_new_style_kikimr_cfg:
             assert "cannot remove txt files without new style kikimr cfg!"
 

--- a/ydb/tools/cfg/bin/__main__.py
+++ b/ydb/tools/cfg/bin/__main__.py
@@ -5,12 +5,10 @@ import os
 import sys
 from logging import config as logging_config
 
-import yaml
-
 from ydb.tools.cfg.configurator_setup import get_parser, parse_optional_arguments
 from ydb.tools.cfg.dynamic import DynamicConfigGenerator
 from ydb.tools.cfg.static import StaticConfigGenerator
-from ydb.tools.cfg.utils import write_to_file, backport
+from ydb.tools.cfg.utils import write_to_file, backport, load_yaml
 from ydb.tools.cfg.walle import NopHostsInformationProvider, WalleHostsInformationProvider
 from ydb.tools.cfg.k8s_api import K8sApiHostsInformationProvider
 
@@ -46,8 +44,7 @@ def cfg_generate(args):
     else:
         cfg_cls = StaticConfigGenerator
 
-    with open(args.cluster_description, "r") as yaml_template:
-        cluster_template = yaml.safe_load(yaml_template)
+    cluster_template = load_yaml(args.cluster_description)
 
     host_info_provider = NopHostsInformationProvider()
 

--- a/ydb/tools/cfg/static.py
+++ b/ydb/tools/cfg/static.py
@@ -631,7 +631,7 @@ class StaticConfigGenerator(object):
             'selector_config': [],
         }
 
-        if self.__cluster_details.use_auto_config:
+        if self.__cluster_details.use_auto_config or normalized_config.get('actor_system_config', {}).get('use_auto_config', False):
             dynconfig['selector_config'].append({
                 'description': 'actor system config for dynnodes',
                 'selector': {

--- a/ydb/tools/cfg/static.py
+++ b/ydb/tools/cfg/static.py
@@ -1158,7 +1158,9 @@ class StaticConfigGenerator(object):
         if not domain.SSId:
             domain.SSId.append(domain.DomainId)
 
-        self._configure_default_state_storage(domains_config, domain.DomainId)
+        if not domains_config.StateStorage:
+            self._configure_default_state_storage(domains_config, domain.DomainId)
+
         self.__proto_configs["domains.txt"] = domains_config
 
     def __generate_domains_from_old_domains_key(self):

--- a/ydb/tools/cfg/utils.py
+++ b/ydb/tools/cfg/utils.py
@@ -243,25 +243,26 @@ def need_generate_bs_config(template_bs_config):
 
 
 def determine_yaml_parsing(yaml_template_file):
-    with open(yaml_template_file, 'r') as file:
-        content = file.read()
-    return 'selector_config' in content
+    ruamel_yaml = YAML()
+    with open(yaml_template_file, "r") as yaml_template:
+        data = ruamel_yaml.load(yaml_template)
+        return data.get("use_alternative_yaml_parser", False)
 
 
 def load_yaml(yaml_template_file):
-    global old_yaml_handler
-    old_yaml_handler = determine_yaml_parsing(yaml_template_file)
+    global use_alternative_yaml_handler
+    use_alternative_yaml_handler = determine_yaml_parsing(yaml_template_file)
 
-    if old_yaml_handler:
-        with open(yaml_template_file, "r") as yaml_template:
-            return pyyaml.safe_load(yaml_template)
-    else:
+    if use_alternative_yaml_handler:
         ruamel_yaml = YAML()
 
         with open(yaml_template_file, "r") as yaml_template:
             data = ruamel_yaml.load(yaml_template)
 
         return data
+    else:
+        with open(yaml_template_file, "r") as yaml_template:
+            return pyyaml.safe_load(yaml_template)
 
 
 def sort_dict_recursively(obj):
@@ -274,9 +275,7 @@ def sort_dict_recursively(obj):
 
 
 def dump_yaml(data):
-    if old_yaml_handler:
-        return pyyaml.safe_dump(data, sort_keys=True, default_flow_style=False, indent=2)
-    else:
+    if use_alternative_yaml_handler:
         yaml = YAML()
 
         yaml.default_flow_style = False
@@ -288,3 +287,5 @@ def dump_yaml(data):
         stream = StringIO()
         yaml.dump(sorted_data, stream)
         return stream.getvalue()
+    else:
+        return pyyaml.safe_dump(data, sort_keys=True, default_flow_style=False, indent=2)

--- a/ydb/tools/cfg/utils.py
+++ b/ydb/tools/cfg/utils.py
@@ -3,11 +3,14 @@
 import os
 import random
 import string
-import yaml
+import yaml as pyyaml
 
 import six
 from google.protobuf import text_format, json_format
 from google.protobuf.pyext._message import FieldDescriptor
+
+from ruamel.yaml import YAML
+from io import StringIO
 
 from library.python import resource
 from ydb.tools.cfg import types
@@ -191,7 +194,7 @@ def wrap_parse_dict(dictionary, proto):
 # template file and dump it again, there will be a lot of meaningless diff
 # in formatting, which is undesirable.
 def backport(template_path, config_yaml, backported_sections):
-    config_data = yaml.safe_load(config_yaml)
+    config_data = pyyaml.safe_load(config_yaml)
 
     with open(template_path, 'r') as file:
         lines = file.readlines()
@@ -202,7 +205,7 @@ def backport(template_path, config_yaml, backported_sections):
         if section is None:
             raise KeyError(f"The key '{section_key}' was not found in config_yaml")
 
-        new_section_yaml = yaml.safe_dump({section_key: section}, default_flow_style=False).splitlines(True)
+        new_section_yaml = pyyaml.safe_dump({section_key: section}, default_flow_style=False).splitlines(True)
         new_section_yaml.append(os.linesep)
 
         start_index = None
@@ -237,3 +240,51 @@ def need_generate_bs_config(template_bs_config):
         return True
 
     return template_bs_config.get("service_set", {}).get("groups") is None
+
+
+def determine_yaml_parsing(yaml_template_file):
+    with open(yaml_template_file, 'r') as file:
+        content = file.read()
+    return 'selector_config' in content
+
+
+def load_yaml(yaml_template_file):
+    global old_yaml_handler
+    old_yaml_handler = determine_yaml_parsing(yaml_template_file)
+
+    if old_yaml_handler:
+        with open(yaml_template_file, "r") as yaml_template:
+            return pyyaml.safe_load(yaml_template)
+    else:
+        ruamel_yaml = YAML()
+
+        with open(yaml_template_file, "r") as yaml_template:
+            data = ruamel_yaml.load(yaml_template)
+
+        return data
+
+
+def sort_dict_recursively(obj):
+    if isinstance(obj, dict):
+        return dict(sorted((k, sort_dict_recursively(v)) for k, v in obj.items()))
+    elif isinstance(obj, list):
+        return [sort_dict_recursively(i) for i in obj]
+    else:
+        return obj
+
+
+def dump_yaml(data):
+    if old_yaml_handler:
+        return pyyaml.safe_dump(data, sort_keys=True, default_flow_style=False, indent=2)
+    else:
+        yaml = YAML()
+
+        yaml.default_flow_style = False
+        yaml.indent(mapping=2, sequence=4, offset=2)
+        yaml.sort_base_mapping_type_on_output = True
+
+        sorted_data = sort_dict_recursively(data)
+
+        stream = StringIO()
+        yaml.dump(sorted_data, stream)
+        return stream.getvalue()

--- a/ydb/tools/cfg/ya.make
+++ b/ydb/tools/cfg/ya.make
@@ -22,6 +22,7 @@ PEERDIR(
     contrib/python/jsonschema
     contrib/python/requests
     contrib/python/six
+    contrib/python/ruamel.yaml
     ydb/tools/cfg/walle
     ydb/tools/cfg/k8s_api
     library/cpp/resource


### PR DESCRIPTION
### Changelog category <!-- remove all except one -->

* Not for changelog (changelog entry is not required)

### Description for reviewers <!-- (optional) description for those who read this PR -->

New bunch of fixes and features for `ydb_configure`:

1. Alternative yaml parser is now available for parsing \ dumping. This is ⚠️ OPT-IN ⚠️  behaviour. New parser: supports `!inherit` and `!append` flags for selector configs and avoids unnecessary quoting of integers. Otherwise, it should produce zero diff with old config.I've set this to produce zero diff with the old parser AND it is explicitly opt-in behaviour. You have to specify at the top level of cluster template:
```yaml
use_alternative_yaml_parser: true
```

2. Because of the new parser, it is now possible to specify selector configs directly in cluster template:
```yaml
selector_config:
- description: cookie=<cookie-name>
  selector:
    tenant: /<domain-name>/<db-name>
  config:
    feature_flags: !inherit # this is now supported!
      enable_uuid_as_primary_key: true
      enable_implicit_query_parameter_types: true
      enable_not_null_data_columns: true
```

3. `domains_config` can now be specified very concisely:
```yaml
domains_config:
  domain:
    - name: <domain_name>
      storage_pool_types:
        - kind: ssd
        - kind: ssdencrypted
```

This will be expanded into:

```yaml
domains_config:
  disable_builtin_security: true
  domain:
  - domain_id: 1
    name: <domain_name>
    plan_resolution: '10'
    scheme_root: '72075186232723360'
    ssid:
    - 1
    storage_pool_types:
    - kind: ssd
      pool_config:
        box_id: '1'
        kind: ssd
        pdisk_filter:
        - property:
          - type: SSD
        vdisk_kind: Default
    - kind: ssdencrypted
      pool_config:
        box_id: '1'
        kind: ssdencrypted
        pdisk_filter:
        - property:
          - type: SSD
        vdisk_kind: Default
  state_storage: # this will depend on the rest of the cluster, of course
  - ring:
      node:
      - 1
      - 2
      - 4
      - 6
      - 8
      - 9
      - 12
      - 13
      nto_select: 5
    ssid: 1
```


It is possible to specify only the pools you need:
```yaml
domains_config:
  domain:
    - name: <domain_name>
      storage_pool_types:
        - kind: ssd
```

will get expanded into the same snippet as above, but with only one `ssd` pool instead of four.

4. Fix `dynconfig.yaml` specifics: node type `COMPUTE` will again be added as a selector to `dynconfig.yaml` 
```yaml
selector_config:
  - config:
      actor_system_config:
        cpu_count: 8
        node_type: COMPUTE
        use_auto_config: true
    description: actor system config for dynnodes
    selector:
      dynamic: true
```