### PR TITLE
YQL-19747 Use configurable completion engine factory method

### DIFF
--- a/ydb/public/lib/ydb_cli/commands/interactive/complete/ya.make
+++ b/ydb/public/lib/ydb_cli/commands/interactive/complete/ya.make
@@ -7,6 +7,8 @@ SRCS(
 PEERDIR(
     contrib/restricted/patched/replxx
     yql/essentials/sql/v1/complete
+    yql/essentials/sql/v1/lexer/antlr4_pure
+    yql/essentials/sql/v1/lexer/antlr4_pure_ansi
 )
 
 END()


### PR DESCRIPTION
Apply dependency inversion for a YDB CLI autocompletion. We need this at `sql/v1/complete` to get rid of lexer implementation dependencies.
