### PR TITLE
Walle API adapter replace specific devices

### DIFF
--- a/ydb/core/cms/walle_api_handler.cpp
+++ b/ydb/core/cms/walle_api_handler.cpp
@@ -80,6 +80,10 @@ private:
         auto &hosts = map["hosts"].GetArray();
         for (auto &host : hosts)
             *request->Record.AddHosts() = host.GetString();
+        
+        auto &devices = map["devices"].GetArray();
+        for (auto &device : devices)
+            *request->Record.AddDevices() = device.GetString();
 
         const auto &params = http.GetParams();
         if (params.contains("dry_run"))
@@ -109,9 +113,15 @@ private:
         NJson::TJsonValue hosts(NJson::JSON_ARRAY);
         for (auto &host : resp.GetHosts())
             hosts.AppendValue(host);
+
+        NJson::TJsonValue devices(NJson::JSON_ARRAY);
+        for (auto &device : resp.GetDevices())
+            devices.AppendValue(device);
+
         NJson::TJsonValue map;
         map.InsertValue("id", resp.GetTaskId());
         map.InsertValue("hosts", hosts);
+        map.InsertValue("devices", devices);
         map.InsertValue("status", status);
         map.InsertValue("message", resp.GetStatus().GetReason());
 
@@ -147,12 +157,19 @@ private:
     void Reply(const TWalleListTasksResponse &resp, const TActorContext &ctx) {
         NJson::TJsonValue tasks(NJson::JSON_ARRAY);
         for (auto &task : resp.GetTasks()) {
+
             NJson::TJsonValue hosts(NJson::JSON_ARRAY);
             for (auto &host : task.GetHosts())
                 hosts.AppendValue(host);
+
+            NJson::TJsonValue devices(NJson::JSON_ARRAY);
+            for (auto &device : task.GetDevices())
+                devices.AppendValue(device);
+
             NJson::TJsonValue map;
             map.InsertValue("id", task.GetTaskId());
             map.InsertValue("hosts", hosts);
+            map.InsertValue("devices", devices);
             map.InsertValue("status", task.GetStatus());
 
             tasks.AppendValue(map);
@@ -199,9 +216,15 @@ private:
         NJson::TJsonValue hosts(NJson::JSON_ARRAY);
         for (auto &host : resp.GetTask().GetHosts())
             hosts.AppendValue(host);
+
+        NJson::TJsonValue devices(NJson::JSON_ARRAY);
+        for (auto &device : resp.GetTask().GetDevices())
+            devices.AppendValue(device);
+
         NJson::TJsonValue map;
         map.InsertValue("id", resp.GetTask().GetTaskId());
         map.InsertValue("hosts", hosts);
+        map.InsertValue("devices", devices);
         map.InsertValue("status", status);
         map.InsertValue("message", resp.GetStatus().GetReason());
 

--- a/ydb/core/cms/walle_create_task_adapter.cpp
+++ b/ydb/core/cms/walle_create_task_adapter.cpp
@@ -101,6 +101,52 @@ private:
         ReplyAndDie(Response, ctx);
     }
 
+    void HandleReplaceDevicesAction(const TClusterInfoPtr &cluster, 
+                                    TAutoPtr<TEvCms::TEvPermissionRequest> &request, 
+                                    ui64 duration, 
+                                    const TActorContext &ctx) {
+        auto &task = RequestEvent->Get()->Record;
+
+        if (task.DevicesSize() > 0) {
+            // Replace specified devices on the specified host.
+            if (task.HostsSize() != 1) {
+                ReplyWithErrorAndDie(TStatus::WRONG_REQUEST, "Exactly one host must be specified if \"devices\" are set", ctx);
+                return;
+            }
+            TString host = task.get_idx_hosts(0);
+            auto &action = *request->Record.AddActions();
+            action.SetHost(host);
+            action.SetType(TAction::REPLACE_DEVICES);
+            action.SetDuration(duration);
+
+            for (const auto& device : task.GetDevices())
+                *action.AddDevices() = device;
+        } else {
+            // Replace all devices on all provided hosts.
+            for (auto &host : task.GetHosts()) {
+                auto &action = *request->Record.AddActions();
+                action.SetHost(host);
+                action.SetType(TAction::REPLACE_DEVICES);
+                action.SetDuration(duration);
+                for (const auto node : cluster->HostNodes(host)) {
+                    for (auto &pdiskId : node->PDisks)
+                        *action.AddDevices() = cluster->PDisk(pdiskId).GetDeviceName();
+                }
+            }
+        }
+    }
+
+    void HandleGenericAction(TAutoPtr<TEvCms::TEvPermissionRequest> &cmsRequest, TAction::EType actionType, ui64 duration) {
+        auto &task = RequestEvent->Get()->Record;
+
+        for (auto &host : task.GetHosts()) {
+            auto &action = *cmsRequest->Record.AddActions();
+            action.SetHost(host);
+            action.SetType(actionType);
+            action.SetDuration(duration);
+        }
+    }
+
     void Handle(TEvCms::TEvGetClusterInfoResponse::TPtr &ev, const TActorContext &ctx) {
         if (ev->Get()->Info->IsOutdated()) {
             ReplyWithErrorAndDie(TStatus::ERROR_TEMP, "Cannot collect cluster info", ctx);
@@ -139,19 +185,15 @@ private:
             ReplyAndDie(resp.Release(), ctx);
             return;
         } else {
-            for (auto &host : task.GetHosts()) {
-                auto &action = *request->Record.AddActions();
-                action.SetHost(host);
-                action.SetType(*it->second);
-                // We always use infinite duration.
-                // Wall-E MUST delete processed tasks.
-                action.SetDuration(TDuration::Max().GetValue());
-                if (action.GetType() == TAction::REPLACE_DEVICES) {
-                    for (const auto node : cluster->HostNodes(host)) {
-                        for (auto &pdiskId : node->PDisks)
-                            *action.AddDevices() = cluster->PDisk(pdiskId).GetDeviceName();
-                    }
-                }
+            // We always use infinite duration.
+            // Wall-E MUST delete processed tasks.
+            ui64 duration = TDuration::Max().GetValue();
+
+            TAction::EType actionType = *it->second;
+            if (actionType == TAction::REPLACE_DEVICES) {
+                HandleReplaceDevicesAction(cluster, request, duration, ctx);
+            } else {
+                HandleGenericAction(request, actionType, duration);
             }
         }
 

--- a/ydb/core/cms/walle_create_task_adapter.cpp
+++ b/ydb/core/cms/walle_create_task_adapter.cpp
@@ -65,6 +65,7 @@ private:
         resp->Record.MutableStatus()->SetReason(err);
         resp->Record.SetTaskId(rec.GetTaskId());
         resp->Record.MutableHosts()->CopyFrom(rec.GetHosts());
+        resp->Record.MutableDevices()->CopyFrom(rec.GetDevices());
         ReplyAndDie(resp.Release(), ctx);
     }
 
@@ -81,6 +82,7 @@ private:
         Response->Record.MutableStatus()->CopyFrom(rec.GetStatus());
         Response->Record.SetTaskId(RequestEvent->Get()->Record.GetTaskId());
         Response->Record.MutableHosts()->CopyFrom(RequestEvent->Get()->Record.GetHosts());
+        Response->Record.MutableDevices()->CopyFrom(RequestEvent->Get()->Record.GetDevices());
 
         // In case of success or scheduled request we have to store
         // task information.
@@ -181,6 +183,7 @@ private:
             TAutoPtr<TEvCms::TEvWalleCreateTaskResponse> resp = new TEvCms::TEvWalleCreateTaskResponse;
             resp->Record.SetTaskId(task.GetTaskId());
             resp->Record.MutableHosts()->CopyFrom(task.GetHosts());
+            resp->Record.MutableDevices()->CopyFrom(task.GetDevices());
             resp->Record.MutableStatus()->SetCode(TStatus::OK);
             ReplyAndDie(resp.Release(), ctx);
             return;

--- a/ydb/core/cms/walle_list_tasks_adapter.cpp
+++ b/ydb/core/cms/walle_list_tasks_adapter.cpp
@@ -35,13 +35,21 @@ public:
             info.SetTaskId(task.TaskId);
             if (State->ScheduledRequests.contains(task.RequestId)) {
                 auto &req = State->ScheduledRequests.find(task.RequestId)->second;
-                for (auto &action : req.Request.GetActions())
+                for (auto &action : req.Request.GetActions()) {
                     *info.AddHosts() = action.GetHost();
+                    for (auto &device : action.GetDevices())
+                        *info.AddDevices() = device;
+                }
                 info.SetStatus("in-process");
             } else {
                 for (auto &id : task.Permissions) {
-                    if (State->Permissions.contains(id))
-                        *info.AddHosts() = State->Permissions.find(id)->second.Action.GetHost();
+                    if (State->Permissions.contains(id)) {
+                        const auto &action = State->Permissions.find(id)->second.Action;
+                        *info.AddHosts() = action.GetHost();
+
+                        for (auto &device : action.GetDevices())
+                            *info.AddDevices() = device;
+                    }
                 }
                 info.SetStatus("ok");
             }

--- a/ydb/core/protos/cms.proto
+++ b/ydb/core/protos/cms.proto
@@ -362,6 +362,7 @@ message TWalleCreateTaskResponse {
   optional TStatus Status = 1;
   optional string  TaskId = 2;
   repeated string  Hosts = 3;
+  repeated string  Devices = 4;
 }
 
 message TWalleListTasksRequest {
@@ -371,6 +372,7 @@ message TWalleTaskInfo {
   optional string TaskId = 1;
   repeated string Hosts = 2;
   optional string Status = 3;
+  repeated string Devices = 4;
 }
 
 message TWalleListTasksResponse {

--- a/ydb/core/protos/cms.proto
+++ b/ydb/core/protos/cms.proto
@@ -355,6 +355,7 @@ message TWalleCreateTaskRequest {
   optional string Action = 4;
   repeated string Hosts = 5;
   optional bool   DryRun = 6;
+  repeated string Devices = 7;
 }
 
 message TWalleCreateTaskResponse {


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->
Adds devices field to Walle request and response, so that Walle users can lock specific devices for replacement as opposed to locking whole node

### Changelog category <!-- remove all except one -->

* Experimental feature