### PR TITLE
Configure cluster access resource Id for Nebius_v1

### DIFF
--- a/ydb/core/protos/auth.proto
+++ b/ydb/core/protos/auth.proto
@@ -58,6 +58,7 @@ message TAuthConfig {
     optional string NodeRegistrationToken = 82 [default = "root@builtin", (Ydb.sensitive) = true];
     optional TPasswordComplexity PasswordComplexity = 83;
     optional TAccountLockout AccountLockout = 84;
+    optional string ClusterAccessResourceId = 85 [default = "gizmo"];
 }
 
 message TUserRegistryConfig {

--- a/ydb/core/security/ticket_parser_impl.h
+++ b/ydb/core/security/ticket_parser_impl.h
@@ -479,6 +479,12 @@ private:
         if (const auto folderId = record.GetAttributeValue(permission, "folder_id"); folderId) {
             AddNebiusContainerId(pathsContainer, folderId);
         }
+
+        // Use attribute "gizmo_id" as container id that contains cluster access resource
+        // IAM can link roles for cluster access resource
+        if (const auto gizmoId = record.GetAttributeValue(permission, "gizmo_id"); gizmoId) {
+            AddNebiusContainerId(pathsContainer, gizmoId);
+        }
     }
 
     template <typename TTokenRecord>

--- a/ydb/core/security/ticket_parser_ut.cpp
+++ b/ydb/core/security/ticket_parser_ut.cpp
@@ -1661,19 +1661,17 @@ Y_UNIT_TEST_SUITE(TTicketParserTest) {
         UNIT_ASSERT_C(result->Error.empty(), result->Error);
         UNIT_ASSERT_C(result->Token->IsExist("something.read-bbbb4554@as"), result->Token->ShortDebugString());
 
-        if constexpr (!IsNebiusAccessService<TAccessServiceMock>()) {
-            // Authorization successful for gizmo resource
-            accessServiceMock.AllowedResourceIds.clear();
-            accessServiceMock.AllowedResourceIds.emplace("gizmo");
-            runtime->Send(new IEventHandle(MakeTicketParserID(), sender, new TEvTicketParser::TEvAuthorizeTicket(
-                                            userToken,
-                                            {{"gizmo_id", "gizmo"}, },
-                                            {"monitoring.view"})), 0);
-            result = runtime->GrabEdgeEvent<TEvTicketParser::TEvAuthorizeTicketResult>(handle);
-            UNIT_ASSERT_C(result->Error.empty(), result->Error);
-            UNIT_ASSERT_C(result->Token->IsExist("monitoring.view@as"), result->Token->ShortDebugString());
-            UNIT_ASSERT_C(result->Token->IsExist("monitoring.view-gizmo@as"), result->Token->ShortDebugString());
-        }
+        // Authorization successful for gizmo resource
+        accessServiceMock.AllowedResourceIds.clear();
+        accessServiceMock.AllowedResourceIds.emplace("gizmo");
+        runtime->Send(new IEventHandle(MakeTicketParserID(), sender, new TEvTicketParser::TEvAuthorizeTicket(
+                                        userToken,
+                                        {{"gizmo_id", "gizmo"}, },
+                                        {"monitoring.view"})), 0);
+        result = runtime->GrabEdgeEvent<TEvTicketParser::TEvAuthorizeTicketResult>(handle);
+        UNIT_ASSERT_C(result->Error.empty(), result->Error);
+        UNIT_ASSERT_C(result->Token->IsExist("monitoring.view@as"), result->Token->ShortDebugString());
+        UNIT_ASSERT_C(result->Token->IsExist("monitoring.view-gizmo@as"), result->Token->ShortDebugString());
     }
 
     Y_UNIT_TEST(Authorization) {


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

new parameter in AuthConfig — ClusterAccessResourceId — for defining a new resource with new roles for `Nebius_v1`

### Changelog category <!-- remove all except one -->

* Improvement

### Description for reviewers <!-- (optional) description for those who read this PR -->

...
