### PR TITLE
Add ddl to create an iceberg data source

### DIFF
--- a/ydb/core/external_sources/external_data_source.cpp
+++ b/ydb/core/external_sources/external_data_source.cpp
@@ -28,7 +28,7 @@ struct TExternalDataSource : public IExternalSource {
         return false;
     }
 
-    virtual TVector<TString> GetAuthMethods() const override {
+    virtual TVector<TString> GetAuthMethods(const TString&) const override {
         return AuthMethods;
     }
 

--- a/ydb/core/external_sources/external_data_source.cpp
+++ b/ydb/core/external_sources/external_data_source.cpp
@@ -28,7 +28,7 @@ struct TExternalDataSource : public IExternalSource {
         return false;
     }
 
-    virtual TVector<TString> GetAuthMethods(const TString&) const override {
+    virtual TVector<TString> GetAuthMethods() const override {
         return AuthMethods;
     }
 

--- a/ydb/core/external_sources/external_data_source_ut.cpp
+++ b/ydb/core/external_sources/external_data_source_ut.cpp
@@ -30,7 +30,7 @@ Y_UNIT_TEST_SUITE(ExternalDataSourceTest) {
 
     Y_UNIT_TEST(ValidateAuth) {
         auto source = CreateTestSource();
-        const auto authMethods = source->GetAuthMethods();
+        const auto authMethods = source->GetAuthMethods("");
         UNIT_ASSERT_VALUES_EQUAL(authMethods.size(), 2);
         UNIT_ASSERT_VALUES_EQUAL(authMethods[0], "auth1");
         UNIT_ASSERT_VALUES_EQUAL(authMethods[1], "auth2");

--- a/ydb/core/external_sources/external_data_source_ut.cpp
+++ b/ydb/core/external_sources/external_data_source_ut.cpp
@@ -30,7 +30,7 @@ Y_UNIT_TEST_SUITE(ExternalDataSourceTest) {
 
     Y_UNIT_TEST(ValidateAuth) {
         auto source = CreateTestSource();
-        const auto authMethods = source->GetAuthMethods("");
+        const auto authMethods = source->GetAuthMethods();
         UNIT_ASSERT_VALUES_EQUAL(authMethods.size(), 2);
         UNIT_ASSERT_VALUES_EQUAL(authMethods[0], "auth1");
         UNIT_ASSERT_VALUES_EQUAL(authMethods[1], "auth2");

--- a/ydb/core/external_sources/external_source.h
+++ b/ydb/core/external_sources/external_source.h
@@ -103,10 +103,9 @@ struct IExternalSource : public TThrRefBase {
     virtual TString GetName() const = 0;
 
     /*
-        List of auth methods supported by the source. The list can be set
-        conditionally based on a content
+        List of auth methods supported by the source
     */
-    virtual TVector<TString> GetAuthMethods(const TString& content) const = 0;
+    virtual TVector<TString> GetAuthMethods() const = 0;
 
     /*
         At the input, a string with the name of the content is passed,

--- a/ydb/core/external_sources/external_source.h
+++ b/ydb/core/external_sources/external_source.h
@@ -103,9 +103,10 @@ struct IExternalSource : public TThrRefBase {
     virtual TString GetName() const = 0;
 
     /*
-        List of auth methods supported by the source
+        List of auth methods supported by the source. The list can be set
+        conditionally based on a content
     */
-    virtual TVector<TString> GetAuthMethods() const = 0;
+    virtual TVector<TString> GetAuthMethods(const TString& content) const = 0;
 
     /*
         At the input, a string with the name of the content is passed,

--- a/ydb/core/external_sources/external_source_builder.cpp
+++ b/ydb/core/external_sources/external_source_builder.cpp
@@ -1,0 +1,204 @@
+#include "external_source_builder.h"
+#include "validation_functions.h"
+
+#include <ydb/core/protos/flat_scheme_op.pb.h>
+
+namespace NKikimr::NExternalSource {
+namespace {
+
+class TValidatedExternalDataSource final : public IExternalSource {
+public:
+    TValidatedExternalDataSource(
+        const TString& name, 
+        const std::vector<TExternalSourceBuilder::TAuthHolder>& authMethods, 
+        const std::unordered_map<TString, TExternalSourceBuilder::TConditionalValidator>& availableProperties, 
+        const std::vector<TRegExMatch>& hostnamePatterns)
+        : Name_(name)
+        , AuthMethodsForCheck_(authMethods)
+        , AvailableProperties_(availableProperties)
+        , HostnamePatterns_(hostnamePatterns)
+    {
+
+    }
+
+    virtual TString Pack(const NKikimrExternalSources::TSchema&,
+                         const NKikimrExternalSources::TGeneral&) const override {
+        ythrow TExternalSourceException() << "Internal error. Only external table supports pack operation";
+    }
+
+    virtual TString GetName() const override {
+        return Name_;
+    }
+
+    virtual bool HasExternalTable() const override {
+        return false;
+    }
+
+    virtual TVector<TString> GetAuthMethods(const TString& externalDataSourceDescription) const override {
+        NKikimrSchemeOp::TExternalDataSourceDescription proto;
+
+        if (!proto.ParseFromString(externalDataSourceDescription)) {
+            ythrow TExternalSourceException() 
+                << "Internal error. "
+                << "Couldn't parse protobuf with external data source description";
+        }
+
+        TVector<TString> rez;
+
+        for (auto a: AuthMethodsForCheck_) {
+            if (a.WhenToUseIt(proto.GetProperties().GetProperties())) {
+                rez.push_back(a.Auth);
+            }
+        }
+        
+        return rez;
+    }
+
+    virtual TMap<TString, TVector<TString>> GetParameters(const TString&) const override {
+        ythrow TExternalSourceException() << "Internal error. Only external table supports parameters";
+    }
+
+    virtual void ValidateExternalDataSource(const TString& externalDataSourceDescription) const override {
+        NKikimrSchemeOp::TExternalDataSourceDescription proto;
+
+        if (!proto.ParseFromString(externalDataSourceDescription)) {
+            ythrow TExternalSourceException() 
+                << "Internal error. "
+                << "Couldn't parse protobuf with external data source description";
+        }
+
+        auto properties = proto.GetProperties().GetProperties();
+        std::unordered_set<TString> validated;
+
+        for (const auto& [key, value]: properties) {
+            auto p = AvailableProperties_.find(key);
+
+            if (AvailableProperties_.end() == p) {
+                throw TExternalSourceException() << "Unsupported property: " << key;
+            }
+
+            // validate property value 
+            if (p->second.NeedToValidate(properties)) {
+                p->second.Validator(key, value);
+            }
+
+            validated.emplace(key);
+        }
+
+        // validate properties that has been left 
+        for (const auto& [prop, validator]: AvailableProperties_) {
+            if (validated.contains(prop)) {
+                continue;
+            }
+
+            if (validator.NeedToValidate(properties)) {
+                validator.Validator(prop, "");
+            }
+        }
+
+        ValidateHostname(HostnamePatterns_, proto.GetLocation());
+    }
+
+    virtual NThreading::TFuture<std::shared_ptr<TMetadata>> LoadDynamicMetadata(std::shared_ptr<TMetadata> meta) override {
+        return NThreading::MakeFuture(std::move(meta));
+    }
+
+    virtual bool CanLoadDynamicMetadata() const override {
+        return false;
+    }
+
+private: 
+    const TString Name_;
+    const std::vector<TExternalSourceBuilder::TAuthHolder> AuthMethodsForCheck_;
+    const std::unordered_map<TString, TExternalSourceBuilder::TConditionalValidator> AvailableProperties_;
+    const std::vector<TRegExMatch> HostnamePatterns_;
+};
+
+}
+
+TExternalSourceBuilder::TExternalSourceBuilder(const TString& name) 
+    : Name_(name)
+{
+}
+
+TExternalSourceBuilder& TExternalSourceBuilder::Auth(const TVector<TString>& authMethods, TCondition condition) {
+    for (auto a: authMethods) {
+        AuthMethodsForCheck_.push_back(TExternalSourceBuilder::TAuthHolder{a, condition});
+    }
+
+    return *this;
+}
+
+TExternalSourceBuilder& TExternalSourceBuilder::Property(TString name, TValidator validator, TCondition condition) {
+    AvailableProperties_.emplace(name, TExternalSourceBuilder::TConditionalValidator{validator, condition});
+    return *this;
+} 
+
+TExternalSourceBuilder& TExternalSourceBuilder::Properties(const TSet<TString>& availableProperties, TValidator validator, TCondition condition) {
+    for (auto p: availableProperties) {
+        Property(p, validator, condition);
+    }
+
+    return *this;
+}
+
+TExternalSourceBuilder& TExternalSourceBuilder::HostnamePattern(std::vector<TRegExMatch> pattern) {
+    HostnamePatterns_.insert(
+        HostnamePatterns_.end(), pattern.begin(), pattern.end());
+    return *this;
+}
+
+IExternalSource::TPtr TExternalSourceBuilder::Build() {
+    return MakeIntrusive<TValidatedExternalDataSource>(
+        std::move(Name_), std::move(AuthMethodsForCheck_), std::move(AvailableProperties_), std::move(HostnamePatterns_));
+}
+
+TCondition HasSettingCondition(const TString& p, const TString& v) {
+    auto fnc = [p, v](const ::google::protobuf::Map<TProtoStringType, TProtoStringType>& props) -> bool {
+        auto itr = props.find(p);
+        return props.end() != itr && v == itr->second;
+    };
+
+    return fnc;
+}
+
+TValidator RequiredValidator() {
+    auto fnc = [](const TString& name, const TString& value){
+        if (!value.empty()) {
+            return;
+        }
+
+        throw TExternalSourceException() << "required property: " << name << " is not set";
+    };
+
+    return fnc;
+}
+
+TValidator IsInListValidator(const std::unordered_set<TString>& values, bool required) {
+    auto join = [](const TString& a, const TString& b ){
+        return a.empty() ? b : a + ',' + b; 
+    };
+
+    auto str = std::accumulate(values.begin(), values.end(), TString{}, join);
+
+    auto f = [values, required, str](const TString& name, const TString& value){
+        if (value.empty() && required) {
+            throw TExternalSourceException() << " required property: " << name << " is not set";
+        }
+
+        if (value.empty()) {
+            return;
+        }
+
+        if (!values.contains(value)) {
+            throw TExternalSourceException() 
+                << " property: " << name 
+                << " has wrong value: " << value 
+                << " allowed values: " << str;
+        }
+    };
+
+    return f;
+}
+
+}

--- a/ydb/core/external_sources/external_source_builder.cpp
+++ b/ydb/core/external_sources/external_source_builder.cpp
@@ -81,7 +81,7 @@ public:
         auto properties = proto.GetProperties().GetProperties();
         std::unordered_set<TString> validatedProperties;
 
-        for (const auto& [key, value]: properties) {
+        for (const auto& [key, value] : properties) {
             auto p = AvailableProperties_.find(key);
 
             if (AvailableProperties_.end() == p) {
@@ -97,7 +97,7 @@ public:
         }
 
         // validate properties that has been left 
-        for (const auto& [property, validator]: AvailableProperties_) {
+        for (const auto& [property, validator] : AvailableProperties_) {
             if (validatedProperties.contains(property)) {
                 continue;
             }

--- a/ydb/core/external_sources/external_source_builder.h
+++ b/ydb/core/external_sources/external_source_builder.h
@@ -18,13 +18,15 @@ public:
     struct TAuthHolder {
         TString Auth;
 
-        TCondition WhenToUseIt;
+        // When auth has to be used
+        TCondition UseCondition;
     };
 
     struct TConditionalValidator {
         TValidator Validator;
 
-        TCondition NeedToValidate;
+        // When validator has to be applied
+        TCondition ApplyCondition;
     };
 
 public: 
@@ -60,7 +62,7 @@ public:
 
     TExternalSourceBuilder& Properties(const TSet<TString>& properties, TValidator validator, TCondition condition);
 
-    TExternalSourceBuilder& HostnamePattern(const std::vector<TRegExMatch>& pattern);
+    TExternalSourceBuilder& HostnamePatterns(const std::vector<TRegExMatch>& patterns);
 
     ///
     ///  Create external data source
@@ -113,4 +115,4 @@ TValidator GetRequiredValidator();
 ///
 TValidator GetIsInListValidator(const std::unordered_set<TString>& values, bool required);
 
-}
+} // NKikimr::NExternalSource

--- a/ydb/core/external_sources/external_source_builder.h
+++ b/ydb/core/external_sources/external_source_builder.h
@@ -1,0 +1,116 @@
+#pragma once 
+
+#include "external_source.h"
+
+#include <library/cpp/regex/pcre/regexp.h>
+#include <util/generic/set.h>
+
+namespace NKikimr::NExternalSource {
+
+typedef std::function<void(const TString&, const TString&)> TValidator;
+typedef std::function<bool(const ::google::protobuf::Map<TProtoStringType, TProtoStringType>&)> TCondition;
+
+///
+/// Builder to create an external data source with validations
+///
+class TExternalSourceBuilder {
+public:
+    struct TAuthHolder {
+        TString Auth;
+
+        TCondition WhenToUseIt;
+    };
+
+    struct TConditionalValidator {
+        TValidator Validator;
+
+        TCondition NeedToValidate;
+    };
+
+public: 
+    explicit TExternalSourceBuilder(const TString& name);
+
+    ~TExternalSourceBuilder() = default;
+
+    ///
+    /// Add auth methods which are returned from the "source" only if a condition is true. 
+    /// A condition is applied to source's ddl in @sa IExternalSource::GetAuthMethods
+    /// call.
+    /// 
+    TExternalSourceBuilder& Auth(const TVector<TString>& authMethods, TCondition condition);
+
+    inline TExternalSourceBuilder& Auth(const TVector<TString>& authMethods) {
+        return Auth(authMethods, [](const ::google::protobuf::Map<TProtoStringType, TProtoStringType>&){
+            return true;
+        });
+    }
+
+    ///
+    /// Add property which can be in a "source".
+    ///
+    /// @param name         name of a property
+    /// @param validator    validator which is applied to a property from a source's ddl 
+    ///                     in @sa IExternalSource::ValidateExternalDataSource call
+    /// @param condition    condition that defines to use validator or not, if condition returns true 
+    ///                     for source's ddl then validator is applied; otherwise, validator is skiped; 
+    ///                     condition is executed in @sa IExternalSource::ValidateExternalDataSource call 
+    ///                     before validator 
+    ///
+    TExternalSourceBuilder& Property(const TString name, TValidator validator, TCondition condition);
+
+    TExternalSourceBuilder& Properties(const TSet<TString>& properties, TValidator validator, TCondition condition);
+
+    TExternalSourceBuilder& HostnamePattern(std::vector<TRegExMatch> pattern);
+
+    ///
+    ///  Create external data source
+    ///
+    IExternalSource::TPtr Build();
+
+    inline TExternalSourceBuilder& Property(const TString name, TValidator validator) {
+        return Property(name, validator, [](const ::google::protobuf::Map<TProtoStringType, TProtoStringType>&){
+            return true;
+        });
+    }
+
+    inline TExternalSourceBuilder& Property(const TString name) {
+        return Property(name, [](const TString&, const TString&){});
+    }
+
+    inline TExternalSourceBuilder& Properties(const TSet<TString>& properties, TValidator validator) {
+        return Properties(properties, validator, [](const ::google::protobuf::Map<TProtoStringType, TProtoStringType>&){
+            return true;
+        });
+    }
+
+    inline TExternalSourceBuilder& Properties(const TSet<TString>& properties) {
+        return Properties(properties, [](const TString&, const TString&){});
+    }
+
+ private: 
+    TString Name_;
+    std::vector<TAuthHolder> AuthMethodsForCheck_;
+    std::unordered_map<TString, TConditionalValidator> AvailableProperties_;
+    std::vector<TRegExMatch> HostnamePatterns_;
+};
+
+///
+/// Create a condition that returns "true" if a source's ddl has 
+/// property "p" with value equals to "v"
+///  
+TCondition HasSettingCondition(const TString& p, const TString& v);
+
+/// 
+/// Create a validator which check that source's ddl has a property with non empty value  
+///  
+TValidator RequiredValidator();
+
+/// 
+/// Create a validator which check that source's ddl has a property with a value from list   
+///
+/// @param values       list of allowed values 
+/// @param required     allow property without value 
+///
+TValidator IsInListValidator(const std::unordered_set<TString>& values, bool required);
+
+}

--- a/ydb/core/external_sources/external_source_builder.h
+++ b/ydb/core/external_sources/external_source_builder.h
@@ -39,7 +39,7 @@ public:
     /// 
     TExternalSourceBuilder& Auth(const TVector<TString>& authMethods, TCondition condition);
 
-    inline TExternalSourceBuilder& Auth(const TVector<TString>& authMethods) {
+    TExternalSourceBuilder& Auth(const TVector<TString>& authMethods) {
         return Auth(authMethods, [](const ::google::protobuf::Map<TProtoStringType, TProtoStringType>&){
             return true;
         });

--- a/ydb/core/external_sources/external_source_builder.h
+++ b/ydb/core/external_sources/external_source_builder.h
@@ -60,30 +60,30 @@ public:
 
     TExternalSourceBuilder& Properties(const TSet<TString>& properties, TValidator validator, TCondition condition);
 
-    TExternalSourceBuilder& HostnamePattern(std::vector<TRegExMatch> pattern);
+    TExternalSourceBuilder& HostnamePattern(const std::vector<TRegExMatch>& pattern);
 
     ///
     ///  Create external data source
     ///
     IExternalSource::TPtr Build();
 
-    inline TExternalSourceBuilder& Property(const TString name, TValidator validator) {
+    TExternalSourceBuilder& Property(const TString name, TValidator validator) {
         return Property(name, validator, [](const ::google::protobuf::Map<TProtoStringType, TProtoStringType>&){
             return true;
         });
     }
 
-    inline TExternalSourceBuilder& Property(const TString name) {
+    TExternalSourceBuilder& Property(const TString name) {
         return Property(name, [](const TString&, const TString&){});
     }
 
-    inline TExternalSourceBuilder& Properties(const TSet<TString>& properties, TValidator validator) {
+    TExternalSourceBuilder& Properties(const TSet<TString>& properties, TValidator validator) {
         return Properties(properties, validator, [](const ::google::protobuf::Map<TProtoStringType, TProtoStringType>&){
             return true;
         });
     }
 
-    inline TExternalSourceBuilder& Properties(const TSet<TString>& properties) {
+    TExternalSourceBuilder& Properties(const TSet<TString>& properties) {
         return Properties(properties, [](const TString&, const TString&){});
     }
 
@@ -98,12 +98,12 @@ public:
 /// Create a condition that returns "true" if a source's ddl has 
 /// property "p" with value equals to "v"
 ///  
-TCondition HasSettingCondition(const TString& p, const TString& v);
+TCondition GetHasSettingCondition(const TString& p, const TString& v);
 
 /// 
 /// Create a validator which check that source's ddl has a property with non empty value  
 ///  
-TValidator RequiredValidator();
+TValidator GetRequiredValidator();
 
 /// 
 /// Create a validator which check that source's ddl has a property with a value from list   
@@ -111,6 +111,6 @@ TValidator RequiredValidator();
 /// @param values       list of allowed values 
 /// @param required     allow property without value 
 ///
-TValidator IsInListValidator(const std::unordered_set<TString>& values, bool required);
+TValidator GetIsInListValidator(const std::unordered_set<TString>& values, bool required);
 
 }

--- a/ydb/core/external_sources/external_source_builder_ut.cpp
+++ b/ydb/core/external_sources/external_source_builder_ut.cpp
@@ -7,22 +7,43 @@
 
 namespace NKikimr {
 
+namespace {
+
+class TTestFixture : public NUnitTest::TBaseFixture {
+public:
+    TTestFixture()
+    : Builder("Test")
+    , Props(*Proto.MutableProperties()->MutableProperties())
+    {
+    }
+
+public:
+    void SetUp(NUnitTest::TTestContext& ctx) override {
+        NUnitTest::TBaseFixture::SetUp(ctx);
+    }
+
+protected:
+    NExternalSource::TExternalSourceBuilder Builder;
+    NKikimrSchemeOp::TExternalDataSourceDescription Proto;
+    ::google::protobuf::Map<TProtoStringType, TProtoStringType>& Props;
+};
+
+}
+
 Y_UNIT_TEST_SUITE(ExternalSourceBuilderTest) {
 
-    Y_UNIT_TEST(ValidateName) {
-        auto source = NExternalSource::TExternalSourceBuilder("Test")
-            .Build();
-            
+    Y_UNIT_TEST_F(ValidateName, TTestFixture) {
+        auto source = Builder.Build();
         UNIT_ASSERT_VALUES_EQUAL(source->GetName(), "Test");
     }
 
     // Test returned auth methods when conditions are not set  
-    Y_UNIT_TEST(ValidateAuthWithoutCondition) {
-        auto source = NExternalSource::TExternalSourceBuilder("Test")
+    Y_UNIT_TEST_F(ValidateAuthWithoutCondition, TTestFixture) {
+        auto source = Builder
             .Auth({"auth1", "auth2"})
             .Build();
 
-        const auto authMethods = source->GetAuthMethods("");
+        const auto authMethods = source->GetAuthMethods();
 
         UNIT_ASSERT_VALUES_EQUAL(authMethods.size(), 2);
         UNIT_ASSERT_VALUES_EQUAL(authMethods[0], "auth1");
@@ -30,36 +51,22 @@ Y_UNIT_TEST_SUITE(ExternalSourceBuilderTest) {
     }
 
     // Test returned auth methods when conditions are set  
-    Y_UNIT_TEST(ValidateAuthWithCondition1) {
-        auto source = NExternalSource::TExternalSourceBuilder("Test")
+    Y_UNIT_TEST_F(ValidateAuthWithCondition1, TTestFixture) {
+        auto source = Builder
             .Auth(
                 {"auth1", "auth2"}, 
                 // check that ddl has "property1" equals to "value"
-                NExternalSource::HasSettingCondition("property1", "value")
+                NExternalSource::GetHasSettingCondition("property1", "value")
             )
             .Auth(
                 {"auth3", "auth4"}, 
                 // check that ddl has "property2" equals to "value"
-                NExternalSource::HasSettingCondition("property2", "value")
+                NExternalSource::GetHasSettingCondition("property2", "value")
             )
             .Build();
         
         // ddl without any value     
-        auto authMethods = source->GetAuthMethods("");
-        UNIT_ASSERT_VALUES_EQUAL(authMethods.size(), 0);
-
-        // ddl with "property1" equals to "value"    
-        NKikimrSchemeOp::TExternalDataSourceDescription proto;
-        proto.MutableProperties()->MutableProperties()->insert({"property1", "value"});            
-        authMethods = source->GetAuthMethods(proto.SerializeAsString());
-
-        UNIT_ASSERT_VALUES_EQUAL(authMethods.size(), 2);
-        UNIT_ASSERT_VALUES_EQUAL(authMethods[0], "auth1");
-        UNIT_ASSERT_VALUES_EQUAL(authMethods[1], "auth2");
-
-        // ddl with "property2" equals to "value"    
-        proto.MutableProperties()->MutableProperties()->insert({"property2", "value"});            
-        authMethods = source->GetAuthMethods(proto.SerializeAsString());
+        auto authMethods = source->GetAuthMethods();
 
         UNIT_ASSERT_VALUES_EQUAL(authMethods.size(), 4);
         UNIT_ASSERT_VALUES_EQUAL(authMethods[0], "auth1");
@@ -70,67 +77,63 @@ Y_UNIT_TEST_SUITE(ExternalSourceBuilderTest) {
 
     // Test validation when ddl has property which is not supported by source
     // i.e. source does not contain this property in a list of available properties 
-    Y_UNIT_TEST(ValidateUnsupportedField) {
+    Y_UNIT_TEST_F(ValidateUnsupportedField, TTestFixture) {
         // source has property "field"
-        auto source = NExternalSource::TExternalSourceBuilder("Test")
+        auto source = Builder
             .Property("field")
             .Build();
 
         // ddl with "field1"
-        NKikimrSchemeOp::TExternalDataSourceDescription proto;
-        proto.MutableProperties()->MutableProperties()->insert({"field1", "value"});
+        Props.insert({"field1", "value"});
         
         UNIT_ASSERT_EXCEPTION_CONTAINS(
-            source->ValidateExternalDataSource(proto.SerializeAsString()), 
+            source->ValidateExternalDataSource(Proto.SerializeAsString()), 
             NExternalSource::TExternalSourceException,
             "Unsupported property: field1"
         );
 
         // ddl with "field"
-        proto.MutableProperties()->MutableProperties()->clear();
-        proto.MutableProperties()->MutableProperties()->insert({"field", "value"});
-        UNIT_ASSERT_NO_EXCEPTION(source->ValidateExternalDataSource(proto.SerializeAsString()));
+        Props.clear();
+        Props.insert({"field", "value"});
+        UNIT_ASSERT_NO_EXCEPTION(source->ValidateExternalDataSource(Proto.SerializeAsString()));
     }
 
     // Test validation for non required property 
-    Y_UNIT_TEST(ValidateNonRequiredField) {
-        auto source = NExternalSource::TExternalSourceBuilder("Test")
+    Y_UNIT_TEST_F(ValidateNonRequiredField, TTestFixture) {
+        auto source = Builder
             .Property("field")
             .Build();
         
         // ddl without "field"
-        NKikimrSchemeOp::TExternalDataSourceDescription proto;
-        UNIT_ASSERT_NO_EXCEPTION(source->ValidateExternalDataSource(proto.SerializeAsString()));
+        UNIT_ASSERT_NO_EXCEPTION(source->ValidateExternalDataSource(Proto.SerializeAsString()));
 
         // ddl with "field"
-        proto.MutableProperties()->MutableProperties()->insert({"field", "value"});
-        UNIT_ASSERT_NO_EXCEPTION(source->ValidateExternalDataSource(proto.SerializeAsString()));
+        Props.insert({"field", "value"});
+        UNIT_ASSERT_NO_EXCEPTION(source->ValidateExternalDataSource(Proto.SerializeAsString()));
     }
     
     // Test validation for required property
-    Y_UNIT_TEST(ValidateRequiredField) {
-        auto source = NExternalSource::TExternalSourceBuilder("Test")
-            .Property("field", NExternalSource::RequiredValidator())
+    Y_UNIT_TEST_F(ValidateRequiredField, TTestFixture) {
+        auto source = Builder
+            .Property("field", NExternalSource::GetRequiredValidator())
             .Build();
-        
-        NKikimrSchemeOp::TExternalDataSourceDescription proto;
         
         // ddl without "field"
         UNIT_ASSERT_EXCEPTION_CONTAINS(
-            source->ValidateExternalDataSource(proto.SerializeAsString()), 
+            source->ValidateExternalDataSource(Proto.SerializeAsString()), 
             NExternalSource::TExternalSourceException,
             "required property: field is not set"
         );
 
         // ddl with "field"
-        proto.MutableProperties()->MutableProperties()->insert({"field", "value"});
-        UNIT_ASSERT_NO_EXCEPTION(source->ValidateExternalDataSource(proto.SerializeAsString()));
+        Props.insert({"field", "value"});
+        UNIT_ASSERT_NO_EXCEPTION(source->ValidateExternalDataSource(Proto.SerializeAsString()));
     }
 
     // Test validation for non required property with allowed list of values
-    Y_UNIT_TEST(ValidateNonRequiredFieldValues) {
-        auto source = NExternalSource::TExternalSourceBuilder("Test")
-            .Property("field", NExternalSource::IsInListValidator({"v1", "v2", "v3"}, false))
+    Y_UNIT_TEST_F(ValidateNonRequiredFieldValues, TTestFixture) {
+        auto source = Builder
+            .Property("field", NExternalSource::GetIsInListValidator({"v1", "v2", "v3"}, false))
             .Build();
         
         // ddl without "field"
@@ -138,73 +141,70 @@ Y_UNIT_TEST_SUITE(ExternalSourceBuilderTest) {
     }
 
     // Test validation for required property with allowed list of values
-    Y_UNIT_TEST(ValidateRequiredFieldValues) {
-        auto source = NExternalSource::TExternalSourceBuilder("Test")
-            .Property("field", NExternalSource::IsInListValidator({"v1", "v2", "v3"}, true))
+    Y_UNIT_TEST_F(ValidateRequiredFieldValues, TTestFixture) {
+        auto source = Builder
+            .Property("field", NExternalSource::GetIsInListValidator({"v1", "v2", "v3"}, true))
             .Build();
-        
-        NKikimrSchemeOp::TExternalDataSourceDescription proto;
         
         // ddl without "field"
         UNIT_ASSERT_EXCEPTION_CONTAINS(
-            source->ValidateExternalDataSource(proto.SerializeAsString()), 
+            source->ValidateExternalDataSource(Proto.SerializeAsString()), 
             NExternalSource::TExternalSourceException,
             "required property: field is not set"
         );
-        
+
         // ddl with "field" equals to value not in allowed list 
-        proto.MutableProperties()->MutableProperties()->insert({"field", "value"});
+        Props.insert({"field", "value"});
         UNIT_ASSERT_EXCEPTION_CONTAINS(
-            source->ValidateExternalDataSource(proto.SerializeAsString()), 
+            source->ValidateExternalDataSource(Proto.SerializeAsString()), 
             NExternalSource::TExternalSourceException,
             "property: field has wrong value: value allowed values: v3,v2,v1"
         );
 
         // ddl with "field" equals to "v1"
-        proto.MutableProperties()->MutableProperties()->clear();
-        proto.MutableProperties()->MutableProperties()->insert({"field", "v1"});
-        UNIT_ASSERT_NO_EXCEPTION(source->ValidateExternalDataSource(proto.SerializeAsString()));
+        Props.clear();
+        Props.insert({"field", "v1"});
+        UNIT_ASSERT_NO_EXCEPTION(source->ValidateExternalDataSource(Proto.SerializeAsString()));
 
         // ddl with "field" equals to "v2"
-        proto.MutableProperties()->MutableProperties()->clear();
-        proto.MutableProperties()->MutableProperties()->insert({"field", "v2"});
-        UNIT_ASSERT_NO_EXCEPTION(source->ValidateExternalDataSource(proto.SerializeAsString()));
+        Props.clear();
+        Props.insert({"field", "v2"});
+        UNIT_ASSERT_NO_EXCEPTION(source->ValidateExternalDataSource(Proto.SerializeAsString()));
 
         // ddl with "field" equals to "v3"
-        proto.MutableProperties()->MutableProperties()->clear();
-        proto.MutableProperties()->MutableProperties()->insert({"field", "v3"});
-        UNIT_ASSERT_NO_EXCEPTION(source->ValidateExternalDataSource(proto.SerializeAsString()));
+        Props.clear();
+        Props.insert({"field", "v3"});
+        UNIT_ASSERT_NO_EXCEPTION(source->ValidateExternalDataSource(Proto.SerializeAsString()));
 
     }
 
     // Test validation for required property with condition 
-    Y_UNIT_TEST(ValidateRequiredFieldOnCondition) {
-        auto source = NExternalSource::TExternalSourceBuilder("Test")
+    Y_UNIT_TEST_F(ValidateRequiredFieldOnCondition, TTestFixture) {
+        auto source = Builder
             .Property("field1")
             .Property(
                 "field", 
-                NExternalSource::RequiredValidator(), 
+                NExternalSource::GetRequiredValidator(), 
                 // apply validator if ddl has "field1" equals to "v"
-                NExternalSource::HasSettingCondition("field1", "v")
+                NExternalSource::GetHasSettingCondition("field1", "v")
             )
             .Build();
         
         // ddl without "field1"   
-        NKikimrSchemeOp::TExternalDataSourceDescription proto;
-        UNIT_ASSERT_NO_EXCEPTION(source->ValidateExternalDataSource(proto.SerializeAsString()));
+        UNIT_ASSERT_NO_EXCEPTION(source->ValidateExternalDataSource(Proto.SerializeAsString()));
 
         // ddl with "field1" but without "field"
-        proto.MutableProperties()->MutableProperties()->insert({"field1", "v"});
+        Props.insert({"field1", "v"});
 
         UNIT_ASSERT_EXCEPTION_CONTAINS(
-            source->ValidateExternalDataSource(proto.SerializeAsString()), 
+            source->ValidateExternalDataSource(Proto.SerializeAsString()), 
             NExternalSource::TExternalSourceException,
             "required property: field is not set"
         );
 
         // ddl with "field1" and "field"
-        proto.MutableProperties()->MutableProperties()->insert({"field", "q"});
-        UNIT_ASSERT_NO_EXCEPTION(source->ValidateExternalDataSource(proto.SerializeAsString()));
+        Props.insert({"field", "q"});
+        UNIT_ASSERT_NO_EXCEPTION(source->ValidateExternalDataSource(Proto.SerializeAsString()));
     }
 }
 

--- a/ydb/core/external_sources/external_source_builder_ut.cpp
+++ b/ydb/core/external_sources/external_source_builder_ut.cpp
@@ -84,7 +84,7 @@ Y_UNIT_TEST_SUITE(ExternalSourceBuilderTest) {
             .Build();
 
         // ddl with "field1"
-        Props.insert({"field1", "value"});
+        Props["field1"] = "value";
         
         UNIT_ASSERT_EXCEPTION_CONTAINS(
             source->ValidateExternalDataSource(Proto.SerializeAsString()), 
@@ -94,7 +94,7 @@ Y_UNIT_TEST_SUITE(ExternalSourceBuilderTest) {
 
         // ddl with "field"
         Props.clear();
-        Props.insert({"field", "value"});
+        Props["field"] = "value";
         UNIT_ASSERT_NO_EXCEPTION(source->ValidateExternalDataSource(Proto.SerializeAsString()));
     }
 
@@ -108,7 +108,7 @@ Y_UNIT_TEST_SUITE(ExternalSourceBuilderTest) {
         UNIT_ASSERT_NO_EXCEPTION(source->ValidateExternalDataSource(Proto.SerializeAsString()));
 
         // ddl with "field"
-        Props.insert({"field", "value"});
+        Props["field"] = "value";
         UNIT_ASSERT_NO_EXCEPTION(source->ValidateExternalDataSource(Proto.SerializeAsString()));
     }
     
@@ -126,7 +126,7 @@ Y_UNIT_TEST_SUITE(ExternalSourceBuilderTest) {
         );
 
         // ddl with "field"
-        Props.insert({"field", "value"});
+        Props["field"] = "value";
         UNIT_ASSERT_NO_EXCEPTION(source->ValidateExternalDataSource(Proto.SerializeAsString()));
     }
 
@@ -154,7 +154,7 @@ Y_UNIT_TEST_SUITE(ExternalSourceBuilderTest) {
         );
 
         // ddl with "field" equals to value not in allowed list 
-        Props.insert({"field", "value"});
+        Props["field"] = "value";
         UNIT_ASSERT_EXCEPTION_CONTAINS(
             source->ValidateExternalDataSource(Proto.SerializeAsString()), 
             NExternalSource::TExternalSourceException,
@@ -162,20 +162,16 @@ Y_UNIT_TEST_SUITE(ExternalSourceBuilderTest) {
         );
 
         // ddl with "field" equals to "v1"
-        Props.clear();
-        Props.insert({"field", "v1"});
+        Props["field"] = "v1";
         UNIT_ASSERT_NO_EXCEPTION(source->ValidateExternalDataSource(Proto.SerializeAsString()));
 
         // ddl with "field" equals to "v2"
-        Props.clear();
-        Props.insert({"field", "v2"});
+        Props["field"] = "v2";
         UNIT_ASSERT_NO_EXCEPTION(source->ValidateExternalDataSource(Proto.SerializeAsString()));
 
         // ddl with "field" equals to "v3"
-        Props.clear();
-        Props.insert({"field", "v3"});
+        Props["field"] = "v3";
         UNIT_ASSERT_NO_EXCEPTION(source->ValidateExternalDataSource(Proto.SerializeAsString()));
-
     }
 
     // Test validation for required property with condition 
@@ -194,7 +190,7 @@ Y_UNIT_TEST_SUITE(ExternalSourceBuilderTest) {
         UNIT_ASSERT_NO_EXCEPTION(source->ValidateExternalDataSource(Proto.SerializeAsString()));
 
         // ddl with "field1" but without "field"
-        Props.insert({"field1", "v"});
+        Props["field1"] = "v";
 
         UNIT_ASSERT_EXCEPTION_CONTAINS(
             source->ValidateExternalDataSource(Proto.SerializeAsString()), 
@@ -203,7 +199,7 @@ Y_UNIT_TEST_SUITE(ExternalSourceBuilderTest) {
         );
 
         // ddl with "field1" and "field"
-        Props.insert({"field", "q"});
+        Props["field"] = "q";
         UNIT_ASSERT_NO_EXCEPTION(source->ValidateExternalDataSource(Proto.SerializeAsString()));
     }
 }

--- a/ydb/core/external_sources/external_source_builder_ut.cpp
+++ b/ydb/core/external_sources/external_source_builder_ut.cpp
@@ -18,8 +18,8 @@ public:
     }
 
 public:
-    void SetUp(NUnitTest::TTestContext& ctx) override {
-        NUnitTest::TBaseFixture::SetUp(ctx);
+    void SetUp(NUnitTest::TTestContext& context) override {
+        NUnitTest::TBaseFixture::SetUp(context);
     }
 
 protected:
@@ -51,7 +51,7 @@ Y_UNIT_TEST_SUITE(ExternalSourceBuilderTest) {
     }
 
     // Test returned auth methods when conditions are set  
-    Y_UNIT_TEST_F(ValidateAuthWithCondition1, TTestFixture) {
+    Y_UNIT_TEST_F(ValidateAuthWithCondition, TTestFixture) {
         auto source = Builder
             .Auth(
                 {"auth1", "auth2"}, 
@@ -158,7 +158,7 @@ Y_UNIT_TEST_SUITE(ExternalSourceBuilderTest) {
         UNIT_ASSERT_EXCEPTION_CONTAINS(
             source->ValidateExternalDataSource(Proto.SerializeAsString()), 
             NExternalSource::TExternalSourceException,
-            "property: field has wrong value: value allowed values: v3,v2,v1"
+            "property: field has wrong value: value allowed values: v3, v2, v1"
         );
 
         // ddl with "field" equals to "v1"

--- a/ydb/core/external_sources/external_source_builder_ut.cpp
+++ b/ydb/core/external_sources/external_source_builder_ut.cpp
@@ -12,8 +12,8 @@ namespace {
 class TTestFixture : public NUnitTest::TBaseFixture {
 public:
     TTestFixture()
-    : Builder("Test")
-    , Props(*Proto.MutableProperties()->MutableProperties())
+        : Builder("Test")
+        , Props(*Proto.MutableProperties()->MutableProperties())
     {
     }
 

--- a/ydb/core/external_sources/external_source_builder_ut.cpp
+++ b/ydb/core/external_sources/external_source_builder_ut.cpp
@@ -1,0 +1,211 @@
+#include "external_source_builder.h"
+
+#include <library/cpp/testing/unittest/registar.h>
+#include <util/random/random.h>
+#include <ydb/core/protos/external_sources.pb.h>
+#include <ydb/core/protos/flat_scheme_op.pb.h>
+
+namespace NKikimr {
+
+Y_UNIT_TEST_SUITE(ExternalSourceBuilderTest) {
+
+    Y_UNIT_TEST(ValidateName) {
+        auto source = NExternalSource::TExternalSourceBuilder("Test")
+            .Build();
+            
+        UNIT_ASSERT_VALUES_EQUAL(source->GetName(), "Test");
+    }
+
+    // Test returned auth methods when conditions are not set  
+    Y_UNIT_TEST(ValidateAuthWithoutCondition) {
+        auto source = NExternalSource::TExternalSourceBuilder("Test")
+            .Auth({"auth1", "auth2"})
+            .Build();
+
+        const auto authMethods = source->GetAuthMethods("");
+
+        UNIT_ASSERT_VALUES_EQUAL(authMethods.size(), 2);
+        UNIT_ASSERT_VALUES_EQUAL(authMethods[0], "auth1");
+        UNIT_ASSERT_VALUES_EQUAL(authMethods[1], "auth2");
+    }
+
+    // Test returned auth methods when conditions are set  
+    Y_UNIT_TEST(ValidateAuthWithCondition1) {
+        auto source = NExternalSource::TExternalSourceBuilder("Test")
+            .Auth(
+                {"auth1", "auth2"}, 
+                // check that ddl has "property1" equals to "value"
+                NExternalSource::HasSettingCondition("property1", "value")
+            )
+            .Auth(
+                {"auth3", "auth4"}, 
+                // check that ddl has "property2" equals to "value"
+                NExternalSource::HasSettingCondition("property2", "value")
+            )
+            .Build();
+        
+        // ddl without any value     
+        auto authMethods = source->GetAuthMethods("");
+        UNIT_ASSERT_VALUES_EQUAL(authMethods.size(), 0);
+
+        // ddl with "property1" equals to "value"    
+        NKikimrSchemeOp::TExternalDataSourceDescription proto;
+        proto.MutableProperties()->MutableProperties()->insert({"property1", "value"});            
+        authMethods = source->GetAuthMethods(proto.SerializeAsString());
+
+        UNIT_ASSERT_VALUES_EQUAL(authMethods.size(), 2);
+        UNIT_ASSERT_VALUES_EQUAL(authMethods[0], "auth1");
+        UNIT_ASSERT_VALUES_EQUAL(authMethods[1], "auth2");
+
+        // ddl with "property2" equals to "value"    
+        proto.MutableProperties()->MutableProperties()->insert({"property2", "value"});            
+        authMethods = source->GetAuthMethods(proto.SerializeAsString());
+
+        UNIT_ASSERT_VALUES_EQUAL(authMethods.size(), 4);
+        UNIT_ASSERT_VALUES_EQUAL(authMethods[0], "auth1");
+        UNIT_ASSERT_VALUES_EQUAL(authMethods[1], "auth2");
+        UNIT_ASSERT_VALUES_EQUAL(authMethods[2], "auth3");
+        UNIT_ASSERT_VALUES_EQUAL(authMethods[3], "auth4");
+    }
+
+    // Test validation when ddl has property which is not supported by source
+    // i.e. source does not contain this property in a list of available properties 
+    Y_UNIT_TEST(ValidateUnsupportedField) {
+        // source has property "field"
+        auto source = NExternalSource::TExternalSourceBuilder("Test")
+            .Property("field")
+            .Build();
+
+        // ddl with "field1"
+        NKikimrSchemeOp::TExternalDataSourceDescription proto;
+        proto.MutableProperties()->MutableProperties()->insert({"field1", "value"});
+        
+        UNIT_ASSERT_EXCEPTION_CONTAINS(
+            source->ValidateExternalDataSource(proto.SerializeAsString()), 
+            NExternalSource::TExternalSourceException,
+            "Unsupported property: field1"
+        );
+
+        // ddl with "field"
+        proto.MutableProperties()->MutableProperties()->clear();
+        proto.MutableProperties()->MutableProperties()->insert({"field", "value"});
+        UNIT_ASSERT_NO_EXCEPTION(source->ValidateExternalDataSource(proto.SerializeAsString()));
+    }
+
+    // Test validation for non required property 
+    Y_UNIT_TEST(ValidateNonRequiredField) {
+        auto source = NExternalSource::TExternalSourceBuilder("Test")
+            .Property("field")
+            .Build();
+        
+        // ddl without "field"
+        NKikimrSchemeOp::TExternalDataSourceDescription proto;
+        UNIT_ASSERT_NO_EXCEPTION(source->ValidateExternalDataSource(proto.SerializeAsString()));
+
+        // ddl with "field"
+        proto.MutableProperties()->MutableProperties()->insert({"field", "value"});
+        UNIT_ASSERT_NO_EXCEPTION(source->ValidateExternalDataSource(proto.SerializeAsString()));
+    }
+    
+    // Test validation for required property
+    Y_UNIT_TEST(ValidateRequiredField) {
+        auto source = NExternalSource::TExternalSourceBuilder("Test")
+            .Property("field", NExternalSource::RequiredValidator())
+            .Build();
+        
+        NKikimrSchemeOp::TExternalDataSourceDescription proto;
+        
+        // ddl without "field"
+        UNIT_ASSERT_EXCEPTION_CONTAINS(
+            source->ValidateExternalDataSource(proto.SerializeAsString()), 
+            NExternalSource::TExternalSourceException,
+            "required property: field is not set"
+        );
+
+        // ddl with "field"
+        proto.MutableProperties()->MutableProperties()->insert({"field", "value"});
+        UNIT_ASSERT_NO_EXCEPTION(source->ValidateExternalDataSource(proto.SerializeAsString()));
+    }
+
+    // Test validation for non required property with allowed list of values
+    Y_UNIT_TEST(ValidateNonRequiredFieldValues) {
+        auto source = NExternalSource::TExternalSourceBuilder("Test")
+            .Property("field", NExternalSource::IsInListValidator({"v1", "v2", "v3"}, false))
+            .Build();
+        
+        // ddl without "field"
+        UNIT_ASSERT_NO_EXCEPTION(source->ValidateExternalDataSource(""));
+    }
+
+    // Test validation for required property with allowed list of values
+    Y_UNIT_TEST(ValidateRequiredFieldValues) {
+        auto source = NExternalSource::TExternalSourceBuilder("Test")
+            .Property("field", NExternalSource::IsInListValidator({"v1", "v2", "v3"}, true))
+            .Build();
+        
+        NKikimrSchemeOp::TExternalDataSourceDescription proto;
+        
+        // ddl without "field"
+        UNIT_ASSERT_EXCEPTION_CONTAINS(
+            source->ValidateExternalDataSource(proto.SerializeAsString()), 
+            NExternalSource::TExternalSourceException,
+            "required property: field is not set"
+        );
+        
+        // ddl with "field" equals to value not in allowed list 
+        proto.MutableProperties()->MutableProperties()->insert({"field", "value"});
+        UNIT_ASSERT_EXCEPTION_CONTAINS(
+            source->ValidateExternalDataSource(proto.SerializeAsString()), 
+            NExternalSource::TExternalSourceException,
+            "property: field has wrong value: value allowed values: v3,v2,v1"
+        );
+
+        // ddl with "field" equals to "v1"
+        proto.MutableProperties()->MutableProperties()->clear();
+        proto.MutableProperties()->MutableProperties()->insert({"field", "v1"});
+        UNIT_ASSERT_NO_EXCEPTION(source->ValidateExternalDataSource(proto.SerializeAsString()));
+
+        // ddl with "field" equals to "v2"
+        proto.MutableProperties()->MutableProperties()->clear();
+        proto.MutableProperties()->MutableProperties()->insert({"field", "v2"});
+        UNIT_ASSERT_NO_EXCEPTION(source->ValidateExternalDataSource(proto.SerializeAsString()));
+
+        // ddl with "field" equals to "v3"
+        proto.MutableProperties()->MutableProperties()->clear();
+        proto.MutableProperties()->MutableProperties()->insert({"field", "v3"});
+        UNIT_ASSERT_NO_EXCEPTION(source->ValidateExternalDataSource(proto.SerializeAsString()));
+
+    }
+
+    // Test validation for required property with condition 
+    Y_UNIT_TEST(ValidateRequiredFieldOnCondition) {
+        auto source = NExternalSource::TExternalSourceBuilder("Test")
+            .Property("field1")
+            .Property(
+                "field", 
+                NExternalSource::RequiredValidator(), 
+                // apply validator if ddl has "field1" equals to "v"
+                NExternalSource::HasSettingCondition("field1", "v")
+            )
+            .Build();
+        
+        // ddl without "field1"   
+        NKikimrSchemeOp::TExternalDataSourceDescription proto;
+        UNIT_ASSERT_NO_EXCEPTION(source->ValidateExternalDataSource(proto.SerializeAsString()));
+
+        // ddl with "field1" but without "field"
+        proto.MutableProperties()->MutableProperties()->insert({"field1", "v"});
+
+        UNIT_ASSERT_EXCEPTION_CONTAINS(
+            source->ValidateExternalDataSource(proto.SerializeAsString()), 
+            NExternalSource::TExternalSourceException,
+            "required property: field is not set"
+        );
+
+        // ddl with "field1" and "field"
+        proto.MutableProperties()->MutableProperties()->insert({"field", "q"});
+        UNIT_ASSERT_NO_EXCEPTION(source->ValidateExternalDataSource(proto.SerializeAsString()));
+    }
+}
+
+} // NKikimr

--- a/ydb/core/external_sources/external_source_factory.cpp
+++ b/ydb/core/external_sources/external_source_factory.cpp
@@ -80,7 +80,7 @@ IExternalSource::TPtr BuildIcebergSource(const std::vector<TRegExMatch>& hostnam
             GetRequiredValidator(),
             GetHasSettingCondition(CATALOG_TYPE,VALUE_HIVE)
         )
-        .HostnamePattern(hostnamePatternsRegEx)
+        .HostnamePatterns(hostnamePatternsRegEx)
         .Build();
 }
 

--- a/ydb/core/external_sources/iceberg_ddl_ut.cpp
+++ b/ydb/core/external_sources/iceberg_ddl_ut.cpp
@@ -19,7 +19,7 @@ public:
 
         auto s = ToString(NYql::EDatabaseType::Iceberg);
         auto f = NExternalSource::CreateExternalSourceFactory(
-            {}, nullptr,50000, nullptr, false, false, {s});
+            {}, nullptr, 50000, nullptr, false, false, {s});
 
         Source = f->GetOrCreate(s);
 

--- a/ydb/core/external_sources/iceberg_ddl_ut.cpp
+++ b/ydb/core/external_sources/iceberg_ddl_ut.cpp
@@ -14,7 +14,7 @@ namespace {
 class TTestFixture : public NUnitTest::TBaseFixture {
 public: 
     TTestFixture()
-    :  Props(*Proto.MutableProperties()->MutableProperties()) 
+        : Props(*Proto.MutableProperties()->MutableProperties())
     {
         using namespace NKikimr::NExternalSource::NIceberg;
 

--- a/ydb/core/external_sources/iceberg_ddl_ut.cpp
+++ b/ydb/core/external_sources/iceberg_ddl_ut.cpp
@@ -1,0 +1,78 @@
+#include "external_source_builder.h"
+#include "iceberg_fields.h"
+
+#include <library/cpp/testing/unittest/registar.h>
+#include <util/random/random.h>
+#include <ydb/core/external_sources/external_source_factory.h>
+#include <ydb/core/protos/external_sources.pb.h>
+#include <ydb/core/protos/flat_scheme_op.pb.h>
+
+namespace NKikimr {
+
+namespace {
+
+NExternalSource::IExternalSource::TPtr CreateTestSource(const std::vector<TString> hostnamePatterns = {}) {
+    auto s = ToString(NYql::EDatabaseType::Iceberg);
+    auto f = NExternalSource::CreateExternalSourceFactory(
+        hostnamePatterns,nullptr,50000, nullptr, false, false, {s});
+
+    return f->GetOrCreate(s);
+}
+
+}
+
+Y_UNIT_TEST_SUITE(IcebergDdlTest) {
+
+    // Test ddl for an iceberg table in s3 storage with the hive catalog 
+    Y_UNIT_TEST(HiveCatalogWithS3Test) {
+        auto source = CreateTestSource();
+
+        NKikimrSchemeOp::TExternalDataSourceDescription proto;
+        auto props = proto.MutableProperties()->MutableProperties();
+
+        props->emplace(Iceberg::Warehouse::Fields::TYPE, Iceberg::Warehouse::S3);
+        props->emplace(Iceberg::Warehouse::Fields::DB, "db");
+        props->emplace(Iceberg::Warehouse::Fields::S3_REGION, "region");
+        props->emplace(Iceberg::Warehouse::Fields::S3_ENDPOINT, "endpoint");
+        props->emplace(Iceberg::Warehouse::Fields::S3_URI, "uri");
+        props->emplace(Iceberg::Catalog::Fields::TYPE, Iceberg::Catalog::HIVE);
+        props->emplace(Iceberg::Catalog::Fields::HIVE_URI, "hive_uri");
+            
+        UNIT_ASSERT_NO_EXCEPTION(source->ValidateExternalDataSource(proto.SerializeAsString()));
+
+        auto authMethods = source->GetAuthMethods(proto.SerializeAsString());
+
+        UNIT_ASSERT_VALUES_EQUAL(authMethods.size(), 3);
+        UNIT_ASSERT_VALUES_EQUAL(authMethods[0], "BASIC");
+        UNIT_ASSERT_VALUES_EQUAL(authMethods[1], "TOKEN");
+        UNIT_ASSERT_VALUES_EQUAL(authMethods[2], "SERVICE_ACCOUNT");
+    }
+
+    // Test ddl for an iceberg table in s3 storage with the hadoop catalog 
+    Y_UNIT_TEST(HadoopCatalogWithS3Test) {
+        auto source = CreateTestSource();
+
+        NKikimrSchemeOp::TExternalDataSourceDescription proto;
+        auto props = proto.MutableProperties()->MutableProperties();
+
+        props->emplace(Iceberg::Warehouse::Fields::TYPE, Iceberg::Warehouse::S3);
+        props->emplace(Iceberg::Warehouse::Fields::DB, "db");
+        props->emplace(Iceberg::Warehouse::Fields::S3_REGION, "region");
+        props->emplace(Iceberg::Warehouse::Fields::S3_ENDPOINT, "endpoint");
+        props->emplace(Iceberg::Warehouse::Fields::S3_URI, "uri");
+        props->emplace(Iceberg::Catalog::Fields::TYPE, Iceberg::Catalog::HADOOP);
+            
+        UNIT_ASSERT_NO_EXCEPTION(source->ValidateExternalDataSource(proto.SerializeAsString()));
+
+        auto authMethods = source->GetAuthMethods(proto.SerializeAsString());
+
+        UNIT_ASSERT_VALUES_EQUAL(authMethods.size(), 3);
+        UNIT_ASSERT_VALUES_EQUAL(authMethods[0], "BASIC");
+        UNIT_ASSERT_VALUES_EQUAL(authMethods[1], "TOKEN");
+        UNIT_ASSERT_VALUES_EQUAL(authMethods[2], "SERVICE_ACCOUNT");
+
+    }
+ 
+}
+
+} // NKikimr

--- a/ydb/core/external_sources/iceberg_ddl_ut.cpp
+++ b/ydb/core/external_sources/iceberg_ddl_ut.cpp
@@ -14,14 +14,15 @@ namespace {
 class TTestFixture : public NUnitTest::TBaseFixture {
 public: 
     TTestFixture()
-    :  Props(*Proto.MutableProperties()->MutableProperties()) {
+    :  Props(*Proto.MutableProperties()->MutableProperties()) 
+    {
         using namespace NKikimr::NExternalSource::NIceberg;
 
-        auto s = ToString(NYql::EDatabaseType::Iceberg);
-        auto f = NExternalSource::CreateExternalSourceFactory(
-            {}, nullptr, 50000, nullptr, false, false, {s});
+        auto type = ToString(NYql::EDatabaseType::Iceberg);
+        auto factory = NExternalSource::CreateExternalSourceFactory(
+            {}, nullptr, 50000, nullptr, false, false, {type});
 
-        Source = f->GetOrCreate(s);
+        Source = factory->GetOrCreate(type);
 
         Props[WAREHOUSE_TYPE]         = VALUE_S3;
         Props[WAREHOUSE_DB]           = "db";
@@ -31,8 +32,8 @@ public:
     }
 
 public:
-    void SetUp(NUnitTest::TTestContext& ctx) override {
-        NUnitTest::TBaseFixture::SetUp(ctx);
+    void SetUp(NUnitTest::TTestContext& context) override {
+        NUnitTest::TBaseFixture::SetUp(context);
     }
 
 protected:
@@ -41,7 +42,7 @@ protected:
     ::google::protobuf::Map<TProtoStringType, TProtoStringType>& Props;
 };
 
-}
+} // unnamed
 
 Y_UNIT_TEST_SUITE(IcebergDdlTest) {
 

--- a/ydb/core/external_sources/iceberg_fields.h
+++ b/ydb/core/external_sources/iceberg_fields.h
@@ -1,0 +1,51 @@
+#pragma once 
+
+#include <util/generic/string.h>
+#include <util/generic/vector.h> 
+
+// Fields that belongs to a warehouse
+namespace Iceberg::Warehouse::Fields {
+
+const TString TYPE         = "warehouse_type";
+const TString S3_ENDPOINT  = "warehouse_s3_endpoint";
+const TString S3_URI       = "warehouse_s3_uri";
+const TString S3_REGION    = "warehouse_s3_region";
+const TString TLS          = "use_tls";
+const TString DB           = "database_name";
+
+}
+
+namespace Iceberg::Warehouse {
+
+const TString S3 = "s3";
+
+}
+
+// Fields that belongs to a catalog 
+namespace Iceberg::Catalog::Fields {
+
+const TString TYPE     = "catalog_type";
+const TString HIVE_URI = "catalog_hive_uri";
+
+}
+
+namespace Iceberg::Catalog {
+
+const TString HIVE   = "hive";
+const TString HADOOP = "hadoop";
+
+}
+
+namespace Iceberg {
+
+// List of fields which is pass to connector     
+const std::array<const TString, 6> FieldsToConnector = {
+    Iceberg::Warehouse::Fields::TYPE,
+    Iceberg::Warehouse::Fields::S3_ENDPOINT,
+    Iceberg::Warehouse::Fields::S3_REGION,
+    Iceberg::Warehouse::Fields::S3_URI,
+    Iceberg::Catalog::Fields::TYPE,
+    Iceberg::Catalog::Fields::HIVE_URI
+};
+
+}

--- a/ydb/core/external_sources/iceberg_fields.h
+++ b/ydb/core/external_sources/iceberg_fields.h
@@ -3,49 +3,33 @@
 #include <util/generic/string.h>
 #include <util/generic/vector.h> 
 
+namespace NKikimr::NExternalSource::NIceberg {
+
 // Fields that belongs to a warehouse
-namespace Iceberg::Warehouse::Fields {
+constexpr char WAREHOUSE_TYPE[]         = "warehouse_type";
+constexpr char WAREHOUSE_S3_ENDPOINT[]  = "warehouse_s3_endpoint";
+constexpr char WAREHOUSE_S3_URI[]       = "warehouse_s3_uri";
+constexpr char WAREHOUSE_S3_REGION[]    = "warehouse_s3_region";
+constexpr char WAREHOUSE_TLS[]          = "use_tls";
+constexpr char WAREHOUSE_DB[]           = "database_name";
 
-const TString TYPE         = "warehouse_type";
-const TString S3_ENDPOINT  = "warehouse_s3_endpoint";
-const TString S3_URI       = "warehouse_s3_uri";
-const TString S3_REGION    = "warehouse_s3_region";
-const TString TLS          = "use_tls";
-const TString DB           = "database_name";
+// Fields that belongs to a catalog
+constexpr char CATALOG_TYPE[]           = "catalog_type";
+constexpr char CATALOG_HIVE_URI[]       = "catalog_hive_uri";
 
-}
+// Some values 
+constexpr char VALUE_S3[]     = "s3";
+constexpr char VALUE_HIVE[]   = "hive";
+constexpr char VALUE_HADOOP[] = "hadoop";
 
-namespace Iceberg::Warehouse {
-
-const TString S3 = "s3";
-
-}
-
-// Fields that belongs to a catalog 
-namespace Iceberg::Catalog::Fields {
-
-const TString TYPE     = "catalog_type";
-const TString HIVE_URI = "catalog_hive_uri";
-
-}
-
-namespace Iceberg::Catalog {
-
-const TString HIVE   = "hive";
-const TString HADOOP = "hadoop";
-
-}
-
-namespace Iceberg {
-
-// List of fields which is pass to connector     
-const std::array<const TString, 6> FieldsToConnector = {
-    Iceberg::Warehouse::Fields::TYPE,
-    Iceberg::Warehouse::Fields::S3_ENDPOINT,
-    Iceberg::Warehouse::Fields::S3_REGION,
-    Iceberg::Warehouse::Fields::S3_URI,
-    Iceberg::Catalog::Fields::TYPE,
-    Iceberg::Catalog::Fields::HIVE_URI
+// List of fields which is pass to a connector
+constexpr std::array<const char*, 6> FieldsToConnector = {
+    WAREHOUSE_TYPE,
+    WAREHOUSE_S3_ENDPOINT,
+    WAREHOUSE_S3_REGION,
+    WAREHOUSE_S3_URI,
+    CATALOG_TYPE,
+    CATALOG_HIVE_URI
 };
 
-}
+} // NKikimr::NExternalSource::NIceberg

--- a/ydb/core/external_sources/object_storage.cpp
+++ b/ydb/core/external_sources/object_storage.cpp
@@ -89,7 +89,7 @@ struct TObjectStorageExternalSource : public IExternalSource {
         return true;
     }
 
-    virtual TVector<TString> GetAuthMethods(const TString&) const override {
+    virtual TVector<TString> GetAuthMethods() const override {
         return {"NONE", "SERVICE_ACCOUNT", "AWS"};
     }
 

--- a/ydb/core/external_sources/object_storage.cpp
+++ b/ydb/core/external_sources/object_storage.cpp
@@ -89,7 +89,7 @@ struct TObjectStorageExternalSource : public IExternalSource {
         return true;
     }
 
-    virtual TVector<TString> GetAuthMethods() const override {
+    virtual TVector<TString> GetAuthMethods(const TString&) const override {
         return {"NONE", "SERVICE_ACCOUNT", "AWS"};
     }
 

--- a/ydb/core/external_sources/ut/ya.make
+++ b/ydb/core/external_sources/ut/ya.make
@@ -8,6 +8,8 @@ PEERDIR(
 SRCS(
     object_storage_ut.cpp
     external_data_source_ut.cpp
+    external_source_builder_ut.cpp
+    iceberg_ddl_ut.cpp
 )
 
 END()

--- a/ydb/core/external_sources/ut/ya.make
+++ b/ydb/core/external_sources/ut/ya.make
@@ -6,10 +6,10 @@ PEERDIR(
 )
 
 SRCS(
-    object_storage_ut.cpp
     external_data_source_ut.cpp
     external_source_builder_ut.cpp
     iceberg_ddl_ut.cpp
+    object_storage_ut.cpp
 )
 
 END()

--- a/ydb/core/external_sources/ya.make
+++ b/ydb/core/external_sources/ya.make
@@ -2,6 +2,7 @@ LIBRARY()
 
 SRCS(
     external_data_source.cpp
+    external_source_builder.cpp
     external_source_factory.cpp
     object_storage.cpp
     validation_functions.cpp

--- a/ydb/core/kqp/gateway/behaviour/external_data_source/manager.cpp
+++ b/ydb/core/kqp/gateway/behaviour/external_data_source/manager.cpp
@@ -8,6 +8,7 @@
 #include <ydb/core/protos/schemeshard/operations.pb.h>
 
 #include <ydb/library/conclusion/generic/result.h>
+#include <ydb/core/external_sources/iceberg_fields.h>
 
 namespace NKikimr::NKqp {
 
@@ -91,7 +92,15 @@ TString GetOrEmpty(const NYql::TCreateObjectSettings& container, const TString& 
     };
 
     auto& featuresExtractor = settings.GetFeaturesExtractor();
+
     for (const auto& property: properties) {
+        if (const auto value = featuresExtractor.Extract(property)) {
+            externaDataSourceDesc.MutableProperties()->MutableProperties()->insert({property, *value});
+        }
+    }
+
+    // Iceberg properties for connector
+    for (const auto& property: Iceberg::FieldsToConnector) {
         if (const auto value = featuresExtractor.Extract(property)) {
             externaDataSourceDesc.MutableProperties()->MutableProperties()->insert({property, *value});
         }

--- a/ydb/core/kqp/gateway/behaviour/external_data_source/manager.cpp
+++ b/ydb/core/kqp/gateway/behaviour/external_data_source/manager.cpp
@@ -93,14 +93,14 @@ TString GetOrEmpty(const NYql::TCreateObjectSettings& container, const TString& 
 
     auto& featuresExtractor = settings.GetFeaturesExtractor();
 
-    for (const auto& property: properties) {
+    for (const auto& property : properties) {
         if (const auto value = featuresExtractor.Extract(property)) {
             externaDataSourceDesc.MutableProperties()->MutableProperties()->insert({property, *value});
         }
     }
 
     // Iceberg properties for connector
-    for (const auto& property: Iceberg::FieldsToConnector) {
+    for (const auto& property : NKikimr::NExternalSource::NIceberg::FieldsToConnector) {
         if (const auto value = featuresExtractor.Extract(property)) {
             externaDataSourceDesc.MutableProperties()->MutableProperties()->insert({property, *value});
         }

--- a/ydb/core/kqp/ut/federated_query/common/common.cpp
+++ b/ydb/core/kqp/ut/federated_query/common/common.cpp
@@ -2,7 +2,7 @@
 
 #include <library/cpp/testing/unittest/registar.h>
 #include <ydb/core/kqp/rm_service/kqp_rm_service.h>
-
+#include <ydb/public/sdk/cpp/include/ydb-cpp-sdk/client/types/credentials/credentials.h>
 namespace NKikimr::NKqp::NFederatedQueryTest {
     TString GetSymbolsString(char start, char end, const TString& skip) {
         TStringBuilder result;
@@ -54,7 +54,8 @@ namespace NKikimr::NKqp::NFederatedQueryTest {
         NYql::IDatabaseAsyncResolver::TPtr databaseAsyncResolver,
         std::optional<NKikimrConfig::TAppConfig> appConfig,
         std::shared_ptr<NYql::NDq::IS3ActorsFactory> s3ActorsFactory,
-        const TKikimrRunnerOptions& optionst)
+        const TKikimrRunnerOptions& optionst,
+        NYql::ISecuredServiceAccountCredentialsFactory::TPtr credentialsFactory)
     {
         NKikimrConfig::TFeatureFlags featureFlags;
         featureFlags.SetEnableExternalDataSources(true);
@@ -79,7 +80,7 @@ namespace NKikimr::NKqp::NFederatedQueryTest {
         auto federatedQuerySetupFactory = std::make_shared<TKqpFederatedQuerySetupFactoryMock>(
             httpGateway,
             connectorClient,
-            nullptr,
+            credentialsFactory,
             databaseAsyncResolver,
             appConfig->GetQueryServiceConfig().GetS3(),
             appConfig->GetQueryServiceConfig().GetGeneric(),

--- a/ydb/core/kqp/ut/federated_query/common/common.cpp
+++ b/ydb/core/kqp/ut/federated_query/common/common.cpp
@@ -3,6 +3,7 @@
 #include <library/cpp/testing/unittest/registar.h>
 #include <ydb/core/kqp/rm_service/kqp_rm_service.h>
 #include <ydb/public/sdk/cpp/include/ydb-cpp-sdk/client/types/credentials/credentials.h>
+
 namespace NKikimr::NKqp::NFederatedQueryTest {
     TString GetSymbolsString(char start, char end, const TString& skip) {
         TStringBuilder result;

--- a/ydb/core/kqp/ut/federated_query/common/common.h
+++ b/ydb/core/kqp/ut/federated_query/common/common.h
@@ -28,5 +28,6 @@ namespace NKikimr::NKqp::NFederatedQueryTest {
         NYql::IDatabaseAsyncResolver::TPtr databaseAsyncResolver = nullptr,
         std::optional<NKikimrConfig::TAppConfig> appConfig = std::nullopt,
         std::shared_ptr<NYql::NDq::IS3ActorsFactory> s3ActorsFactory = nullptr,
-        const TKikimrRunnerOptions& options = {});
+        const TKikimrRunnerOptions& options = {}, 
+        NYql::ISecuredServiceAccountCredentialsFactory::TPtr credentialsFactory = nullptr);
 } // namespace NKikimr::NKqp::NFederatedQueryTest

--- a/ydb/core/kqp/ut/federated_query/common/common.h
+++ b/ydb/core/kqp/ut/federated_query/common/common.h
@@ -28,6 +28,6 @@ namespace NKikimr::NKqp::NFederatedQueryTest {
         NYql::IDatabaseAsyncResolver::TPtr databaseAsyncResolver = nullptr,
         std::optional<NKikimrConfig::TAppConfig> appConfig = std::nullopt,
         std::shared_ptr<NYql::NDq::IS3ActorsFactory> s3ActorsFactory = nullptr,
-        const TKikimrRunnerOptions& options = {}, 
+        const TKikimrRunnerOptions& options = {},
         NYql::ISecuredServiceAccountCredentialsFactory::TPtr credentialsFactory = nullptr);
 } // namespace NKikimr::NKqp::NFederatedQueryTest

--- a/ydb/core/kqp/ut/federated_query/generic_ut/iceberg_ut_data.cpp
+++ b/ydb/core/kqp/ut/federated_query/generic_ut/iceberg_ut_data.cpp
@@ -1,0 +1,247 @@
+#include "iceberg_ut_data.h"
+
+#include <fmt/format.h>
+#include <ydb/core/external_sources/iceberg_fields.h>
+
+namespace NTestUtils {
+
+constexpr char VALUE_HIVE_URI[]     = "hive_uri";
+constexpr char VALUE_S3_URI[]       = "s3_uri";
+constexpr char VALUE_S3_ENDPOINT[]  = "s3_endpoint";
+constexpr char VALUE_S3_REGION[]    = "s3_region";
+
+constexpr char VALUE_IAM[]    = "IAM";
+
+struct TTestData {
+    TTestData(TIcebergTestData* data) 
+        : Credentials_(*Result_.mutable_credentials())
+        , Options_(*Result_.mutable_iceberg_options())
+        , Warehouse_(*Options_.mutable_warehouse())
+        , Catalog_(*Options_.mutable_catalog())
+    {
+        assert(data);
+
+        switch (data->Auth_.Type) {
+            case TIcebergTestData::AuthBasic: {
+                auto& auth = *Credentials_.mutable_basic();
+                auth.set_username(data->Auth_.Id);
+                auth.set_password(data->Auth_.Value);
+                break;
+            }
+            case TIcebergTestData::AuthSa:
+            case TIcebergTestData::AuthToken: {
+                auto& auth = *Credentials_.mutable_token();
+                auth.set_type(data->Auth_.Id);
+                auth.set_value(data->Auth_.Value);
+                break;
+            }
+        }
+
+        Result_.mutable_endpoint();
+        Result_.set_kind(::NYql::EGenericDataSourceKind::ICEBERG);
+        Result_.set_database(data->Database_);
+        Result_.set_use_tls(data->UseTls_);
+        Result_.set_protocol(::NYql::EGenericProtocol::NATIVE);
+
+        auto& s3 = *Warehouse_.mutable_s3();
+
+        s3.set_uri(VALUE_S3_URI);
+        s3.set_endpoint(VALUE_S3_ENDPOINT);
+        s3.set_region(VALUE_S3_REGION);
+    }
+
+    NYql::TGenericDataSourceInstance Result_;
+    NYql::TGenericCredentials& Credentials_;
+    NYql::TIcebergDataSourceOptions& Options_;
+    NYql::TIcebergWarehouse& Warehouse_;
+    NYql::TIcebergCatalog& Catalog_;
+};
+
+TIcebergTestData::TIcebergTestData(
+    TAuth auth,
+    const TString& dataSourceName, 
+    const TString& database, 
+    bool useTls)
+    : Auth_(auth)
+    , DataSourceName_(dataSourceName)
+    , Database_(database)
+    , UseTls_(useTls)
+{}
+
+NYql::TGenericDataSourceInstance TIcebergTestData::CreateDataSourceForHadoop() {
+    TTestData data(this);
+    data.Catalog_.mutable_hadoop();
+    return std::move(data.Result_);    
+}
+
+NYql::TGenericDataSourceInstance TIcebergTestData::CreateDataSourceForHive() {
+    TTestData data(this);
+    auto& hive = *data.Catalog_.mutable_hive();
+    hive.set_uri(VALUE_HIVE_URI);
+    return std::move(data.Result_);    
+}
+
+TString TIcebergTestData::CreateAuthSection() {
+    using namespace fmt::literals;
+
+    switch (Auth_.Type) {
+        case TIcebergTestData::AuthBasic:
+            return fmt::format(R"(
+                AUTH_METHOD="BASIC",
+                LOGIN="{login}",
+                PASSWORD_SECRET_NAME="{data_source_name}_p"
+            )",
+                "data_source_name"_a = DataSourceName_,
+                "login"_a            = Auth_.Id,
+                "password"_a         = Auth_.Value
+            );
+        case TIcebergTestData::AuthToken:
+            return fmt::format(R"(
+                AUTH_METHOD="TOKEN",
+                TOKEN_SECRET_NAME="{data_source_name}_p"
+            )",
+                "data_source_name"_a = DataSourceName_
+            );
+        case TIcebergTestData::AuthSa: 
+            return fmt::format(R"(
+                AUTH_METHOD="SERVICE_ACCOUNT",
+                SERVICE_ACCOUNT_ID="my_sa",
+                SERVICE_ACCOUNT_SECRET_NAME="{data_source_name}_p"
+            )",
+                "data_source_name"_a = DataSourceName_
+            );
+    };
+}
+
+TString TIcebergTestData::CreateQuery(const TString& catalogSection) {
+    using namespace fmt::literals;
+
+    return fmt::format(
+        R"(
+        CREATE OBJECT {data_source_name}_p (TYPE SECRET) WITH (value={secret});
+
+        CREATE EXTERNAL DATA SOURCE {data_source_name} WITH (
+            SOURCE_TYPE="{source_type}",
+            DATABASE_NAME="{database}",
+            WAREHOUSE_TYPE="{s3}",
+            WAREHOUSE_S3_REGION="{s3_region}",
+            WAREHOUSE_S3_ENDPOINT="{s3_endpoint}",
+            WAREHOUSE_S3_URI="{s3_uri}",
+            {auth_section},
+            {catalog_section},
+            USE_TLS="{use_tls}"
+        );
+    )",
+        "auth_section"_a     = CreateAuthSection(),
+        "s3"_a               = NKikimr::NExternalSource::NIceberg::VALUE_S3,
+        "s3_region"_a        = VALUE_S3_REGION,
+        "s3_endpoint"_a      = VALUE_S3_ENDPOINT,
+        "s3_uri"_a           = VALUE_S3_URI,
+        "data_source_name"_a = DataSourceName_,
+        "catalog_section"_a  = catalogSection,
+        "secret"_a           = Auth_.Value,
+        "use_tls"_a          = UseTls_ ? "TRUE" : "FALSE",
+        "source_type"_a      = ToString(NYql::EDatabaseType::Iceberg),
+        "database"_a         = Database_
+    );
+}
+
+void TIcebergTestData::ExecuteQuery(const std::shared_ptr<NKikimr::NKqp::TKikimrRunner>& kikimr, 
+                                    const TString& query)
+{
+    auto c = kikimr->GetTableClient();
+    auto session = c.CreateSession().GetValueSync().GetSession();
+    auto result = session.ExecuteSchemeQuery(query).GetValueSync();
+    UNIT_ASSERT_C(result.GetStatus() == NYdb::EStatus::SUCCESS, result.GetIssues().ToString());
+}
+
+
+void TIcebergTestData::ExecuteCreateHiveExternalDataSource(const std::shared_ptr<NKikimr::NKqp::TKikimrRunner>& kikimr) {
+    using namespace fmt::literals;
+
+    TString hiveCatalog = fmt::format(R"(
+        CATALOG_TYPE="{type}",
+        CATALOG_HIVE_URI="{uri}"
+    )",
+        "type"_a = NKikimr::NExternalSource::NIceberg::VALUE_HIVE, 
+        "uri"_a  = VALUE_HIVE_URI
+    );
+
+    ExecuteQuery(kikimr, CreateQuery(hiveCatalog));
+}
+
+void TIcebergTestData::ExecuteCreateHadoopExternalDataSource(const std::shared_ptr<NKikimr::NKqp::TKikimrRunner>& kikimr) {
+    using namespace fmt::literals;
+
+    TString hadoopCatalog = fmt::format(R"(
+        CATALOG_TYPE="{type}"
+    )",
+        "type"_a = NKikimr::NExternalSource::NIceberg::VALUE_HADOOP
+    );
+
+    ExecuteQuery(kikimr, CreateQuery(hadoopCatalog));
+}
+
+class TStaticCredentialsProvider : public NYdb::ICredentialsProvider {
+public:
+    TStaticCredentialsProvider(const TString& yqlToken)
+        : YqlToken_(yqlToken)
+    {}
+
+    std::string GetAuthInfo() const override {
+        return YqlToken_;
+    }
+
+    bool IsValid() const override {
+        return true;
+    }
+
+private:
+    std::string YqlToken_;
+};
+
+class TStaticCredentialsProviderFactory : public NYdb::ICredentialsProviderFactory {
+public:
+    TStaticCredentialsProviderFactory(const TString& yqlToken)
+        : YqlToken_(yqlToken)
+    {}
+
+    std::shared_ptr<NYdb::ICredentialsProvider> CreateProvider() const override {
+        return std::make_shared<TStaticCredentialsProvider>(YqlToken_);
+    }
+
+private:
+    TString YqlToken_;
+};
+
+class TStaticSecuredCredentialsFactory : public NYql::ISecuredServiceAccountCredentialsFactory {
+public:
+    TStaticSecuredCredentialsFactory(const TString& yqlToken)
+        : YqlToken_(yqlToken)
+    {}
+
+    std::shared_ptr<NYdb::ICredentialsProviderFactory> Create(const TString&, const TString&) override {
+        return std::make_shared<TStaticCredentialsProviderFactory>(YqlToken_);
+    }
+
+private:
+    TString YqlToken_;
+};
+
+TIcebergTestData CreateIcebergBasic(const TString& dataSourceName, const TString& database, const TString& userName, const TString& password){
+    return TIcebergTestData({TIcebergTestData::EAuthType::AuthBasic, userName, password}, dataSourceName, database, false);
+}
+
+TIcebergTestData CreateIcebergToken(const TString& dataSourceName, const TString& database, const TString& token) {
+    return TIcebergTestData({TIcebergTestData::EAuthType::AuthToken, VALUE_IAM , token}, dataSourceName, database, false);
+}
+
+TIcebergTestData CreateIcebergSa(const TString& dataSourceName, const TString& database, const TString& token) {
+    return TIcebergTestData({TIcebergTestData::EAuthType::AuthSa,VALUE_IAM, token}, dataSourceName, database, false);
+}
+
+std::shared_ptr<NYql::ISecuredServiceAccountCredentialsFactory> CreateCredentialProvider(const TString& token) {
+    return std::make_shared<TStaticSecuredCredentialsFactory>(token);
+}
+
+} // NTestUtils

--- a/ydb/core/kqp/ut/federated_query/generic_ut/iceberg_ut_data.cpp
+++ b/ydb/core/kqp/ut/federated_query/generic_ut/iceberg_ut_data.cpp
@@ -71,14 +71,14 @@ TIcebergTestData::TIcebergTestData(
 NYql::TGenericDataSourceInstance TIcebergTestData::CreateDataSourceForHadoop() {
     TTestData data(this);
     data.Catalog_.mutable_hadoop();
-    return std::move(data.Result_);    
+    return data.Result_;
 }
 
 NYql::TGenericDataSourceInstance TIcebergTestData::CreateDataSourceForHive() {
     TTestData data(this);
     auto& hive = *data.Catalog_.mutable_hive();
     hive.set_uri(VALUE_HIVE_URI);
-    return std::move(data.Result_);    
+    return data.Result_;
 }
 
 TString TIcebergTestData::CreateAuthSection() {

--- a/ydb/core/kqp/ut/federated_query/generic_ut/iceberg_ut_data.cpp
+++ b/ydb/core/kqp/ut/federated_query/generic_ut/iceberg_ut_data.cpp
@@ -10,7 +10,7 @@ constexpr char VALUE_S3_URI[]       = "s3_uri";
 constexpr char VALUE_S3_ENDPOINT[]  = "s3_endpoint";
 constexpr char VALUE_S3_REGION[]    = "s3_region";
 
-constexpr char VALUE_IAM[]    = "IAM";
+constexpr char VALUE_IAM[] = "IAM";
 
 struct TTestData {
     TTestData(TIcebergTestData* data) 

--- a/ydb/core/kqp/ut/federated_query/generic_ut/iceberg_ut_data.h
+++ b/ydb/core/kqp/ut/federated_query/generic_ut/iceberg_ut_data.h
@@ -1,0 +1,66 @@
+#pragma once 
+
+#include <yql/essentials/providers/common/proto/gateways_config.pb.h>
+#include <ydb/core/kqp/ut/common/kqp_ut_common.h>
+#include <ydb/library/yql/providers/generic/connector/libcpp/ut_helpers/defaults.h>
+
+namespace NTestUtils {
+
+struct TTestData;
+class TIcebergTestData final {
+    friend struct TTestData;
+
+public:    
+    enum EAuthType : int {
+        AuthBasic = 1,
+        AuthSa = 2,
+        AuthToken = 3
+    }; 
+
+    struct TAuth {
+        EAuthType Type;
+        TString Id;
+        TString Value;
+    };
+
+public:
+    explicit TIcebergTestData(TAuth auth, const TString& dataSourceName, const TString& database, bool UseTls);
+
+    NYql::TGenericDataSourceInstance CreateDataSourceForHadoop();
+
+    NYql::TGenericDataSourceInstance CreateDataSourceForHive();
+
+    void ExecuteCreateHiveExternalDataSource(const std::shared_ptr<NKikimr::NKqp::TKikimrRunner>& kikimr);
+
+    void ExecuteCreateHadoopExternalDataSource(const std::shared_ptr<NKikimr::NKqp::TKikimrRunner>& kikimr);
+
+private: 
+    TString CreateAuthSection();
+
+    TString CreateQuery(const TString& catalogSection);
+
+    void ExecuteQuery(const std::shared_ptr<NKikimr::NKqp::TKikimrRunner>& kikimr, const TString& query);
+
+private: 
+    const TAuth Auth_;
+    const TString DataSourceName_;
+    const TString Database_;
+    const bool UseTls_;
+};
+
+TIcebergTestData CreateIcebergBasic(const TString& dataSourceName = NYql::NConnector::NTest::DEFAULT_DATA_SOURCE_NAME, 
+                                    const TString& database = NYql::NConnector::NTest::DEFAULT_DATABASE, 
+                                    const TString& userName = NYql::NConnector::NTest::DEFAULT_LOGIN,
+                                    const TString& password = NYql::NConnector::NTest::DEFAULT_PASSWORD);
+
+TIcebergTestData CreateIcebergToken(const TString& dataSourceName = NYql::NConnector::NTest::DEFAULT_DATA_SOURCE_NAME, 
+                                    const TString& database = NYql::NConnector::NTest::DEFAULT_DATABASE, 
+                                    const TString& token = NYql::NConnector::NTest::DEFAULT_PASSWORD);
+
+TIcebergTestData CreateIcebergSa(const TString& dataSourceName = NYql::NConnector::NTest::DEFAULT_DATA_SOURCE_NAME, 
+                                 const TString& database = NYql::NConnector::NTest::DEFAULT_DATABASE, 
+                                 const TString& token = NYql::NConnector::NTest::DEFAULT_PASSWORD);
+
+std::shared_ptr<NYql::ISecuredServiceAccountCredentialsFactory> CreateCredentialProvider(const TString& token = NYql::NConnector::NTest::DEFAULT_PASSWORD);
+
+} // NTestUtils

--- a/ydb/core/kqp/ut/federated_query/generic_ut/iceberg_ut_data.h
+++ b/ydb/core/kqp/ut/federated_query/generic_ut/iceberg_ut_data.h
@@ -24,7 +24,7 @@ public:
     };
 
 public:
-    explicit TIcebergTestData(TAuth auth, const TString& dataSourceName, const TString& database, bool UseTls);
+    TIcebergTestData(TAuth auth, const TString& dataSourceName, const TString& database, bool UseTls);
 
     NYql::TGenericDataSourceInstance CreateDataSourceForHadoop();
 

--- a/ydb/core/kqp/ut/federated_query/generic_ut/kqp_generic_provider_ut.cpp
+++ b/ydb/core/kqp/ut/federated_query/generic_ut/kqp_generic_provider_ut.cpp
@@ -1,3 +1,5 @@
+#include "iceberg_ut_data.h"
+
 #include <ydb/core/kqp/ut/common/kqp_ut_common.h>
 #include <ydb/core/kqp/ut/federated_query/common/common.h>
 #include <yql/essentials/providers/common/structured_token/yql_token_builder.h>
@@ -36,6 +38,12 @@ namespace NKikimr::NKqp {
         PostgreSQL,
         ClickHouse,
         Ydb,
+        IcebergHiveBasic,
+        IcebergHiveSa,
+        IcebergHiveToken,
+        IcebergHadoopBasic,
+        IcebergHadoopSa,
+        IcebergHadoopToken,
     };
 
     NYql::TGenericDataSourceInstance MakeDataSourceInstance(EProviderType providerType) {
@@ -46,6 +54,18 @@ namespace NKikimr::NKqp {
                 return TConnectorClientMock::TClickHouseDataSourceInstanceBuilder<>().GetResult();
             case EProviderType::Ydb:
                 return TConnectorClientMock::TYdbDataSourceInstanceBuilder<>().GetResult();
+            case EProviderType::IcebergHiveBasic:
+                return NTestUtils::CreateIcebergBasic().CreateDataSourceForHive();
+            case EProviderType::IcebergHiveSa:
+                return NTestUtils::CreateIcebergSa().CreateDataSourceForHive();
+            case EProviderType::IcebergHiveToken:
+                return NTestUtils::CreateIcebergToken().CreateDataSourceForHive();
+            case EProviderType::IcebergHadoopBasic:
+                return NTestUtils::CreateIcebergBasic().CreateDataSourceForHadoop();
+            case EProviderType::IcebergHadoopSa:
+                return NTestUtils::CreateIcebergSa().CreateDataSourceForHadoop();
+            case EProviderType::IcebergHadoopToken:
+                return NTestUtils::CreateIcebergToken().CreateDataSourceForHadoop();
         }
     }
 
@@ -57,6 +77,24 @@ namespace NKikimr::NKqp {
                 return CreateClickHouseExternalDataSource(kikimr);
             case EProviderType::Ydb:
                 return CreateYdbExternalDataSource(kikimr);
+            case EProviderType::IcebergHiveBasic:
+                return NTestUtils::CreateIcebergBasic()
+                    .ExecuteCreateHiveExternalDataSource(kikimr);
+            case EProviderType::IcebergHiveSa:
+                return NTestUtils::CreateIcebergSa()
+                    .ExecuteCreateHiveExternalDataSource(kikimr);
+            case EProviderType::IcebergHiveToken:
+                return NTestUtils::CreateIcebergToken()
+                    .ExecuteCreateHiveExternalDataSource(kikimr);
+            case EProviderType::IcebergHadoopBasic:
+                return NTestUtils::CreateIcebergBasic()
+                    .ExecuteCreateHadoopExternalDataSource(kikimr);
+            case EProviderType::IcebergHadoopSa:
+                return NTestUtils::CreateIcebergSa()
+                    .ExecuteCreateHadoopExternalDataSource(kikimr);
+            case EProviderType::IcebergHadoopToken:
+                return NTestUtils::CreateIcebergToken()
+                    .ExecuteCreateHadoopExternalDataSource(kikimr);
         }
     }
 
@@ -65,15 +103,21 @@ namespace NKikimr::NKqp {
         NYql::TAttr dateTimeFormat;
         dateTimeFormat.SetName("DateTimeFormat");
         dateTimeFormat.SetValue("string");
-        appConfig.MutableQueryServiceConfig()->MutableGeneric()->MutableConnector()->SetUseSsl(false);
-        appConfig.MutableQueryServiceConfig()->MutableGeneric()->MutableConnector()->MutableEndpoint()->set_host("localhost");
-        appConfig.MutableQueryServiceConfig()->MutableGeneric()->MutableConnector()->MutableEndpoint()->set_port(1234);
-        appConfig.MutableQueryServiceConfig()->MutableGeneric()->MutableDefaultSettings()->Add(std::move(dateTimeFormat));
-        appConfig.MutableQueryServiceConfig()->AddAvailableExternalDataSources("ObjectStorage");
-        appConfig.MutableQueryServiceConfig()->AddAvailableExternalDataSources("ClickHouse");
-        appConfig.MutableQueryServiceConfig()->AddAvailableExternalDataSources("PostgreSQL");
-        appConfig.MutableQueryServiceConfig()->AddAvailableExternalDataSources("MySQL");
-        appConfig.MutableQueryServiceConfig()->AddAvailableExternalDataSources("Ydb");
+
+        auto& config = *appConfig.MutableQueryServiceConfig();
+        auto& connector = *config.MutableGeneric()->MutableConnector();
+
+        connector.SetUseSsl(false);
+        connector.MutableEndpoint()->set_host("localhost");
+        connector.MutableEndpoint()->set_port(1234);
+
+        config.MutableGeneric()->MutableDefaultSettings()->Add(std::move(dateTimeFormat));
+        config.AddAvailableExternalDataSources("ObjectStorage");
+        config.AddAvailableExternalDataSources("ClickHouse");
+        config.AddAvailableExternalDataSources("PostgreSQL");
+        config.AddAvailableExternalDataSources("MySQL");
+        config.AddAvailableExternalDataSources("Ydb");
+        config.AddAvailableExternalDataSources("Iceberg");
         return appConfig;
     }
 
@@ -105,7 +149,6 @@ namespace NKikimr::NKqp {
             auto clientMock = std::make_shared<TConnectorClientMock>();
 
             const NYql::TGenericDataSourceInstance dataSourceInstance = MakeDataSourceInstance(providerType);
-
             // step 1: DescribeTable
             // clang-format off
             clientMock->ExpectDescribeTable()
@@ -152,7 +195,8 @@ namespace NKikimr::NKqp {
             // run test
             auto appConfig = CreateDefaultAppConfig();
             auto s3ActorsFactory = NYql::NDq::CreateS3ActorsFactory();
-            auto kikimr = MakeKikimrRunner(false, clientMock, databaseAsyncResolverMock, appConfig, s3ActorsFactory);
+            auto kikimr = MakeKikimrRunner(false, clientMock, databaseAsyncResolverMock, appConfig, s3ActorsFactory,{}, 
+                NTestUtils::CreateCredentialProvider());
 
             CreateExternalDataSource(providerType, kikimr);
 
@@ -191,6 +235,30 @@ namespace NKikimr::NKqp {
 
         Y_UNIT_TEST(YdbManagedSelectAll) {
             TestSelectAllFields(EProviderType::Ydb);
+        }
+
+        Y_UNIT_TEST(IcebergHiveBasicSelectAll) {
+            TestSelectAllFields(EProviderType::IcebergHiveBasic);
+        }
+
+        Y_UNIT_TEST(IcebergHiveSaSelectAll) {
+            TestSelectAllFields(EProviderType::IcebergHiveSa);
+        }
+
+        Y_UNIT_TEST(IcebergHiveTokenSelectAll) {
+            TestSelectAllFields(EProviderType::IcebergHiveToken);
+        }
+
+        Y_UNIT_TEST(IcebergHadoopBasicSelectAll) {
+            TestSelectAllFields(EProviderType::IcebergHadoopBasic);
+        }
+
+        Y_UNIT_TEST(IcebergHadoopSaSelectAll) {
+            TestSelectAllFields(EProviderType::IcebergHadoopSa);
+        }
+
+        Y_UNIT_TEST(IcebergHadoopTokenSelectAll) {
+            TestSelectAllFields(EProviderType::IcebergHadoopToken);
         }
 
         void TestSelectConstant(EProviderType providerType) {
@@ -243,7 +311,8 @@ namespace NKikimr::NKqp {
             // run test
             auto appConfig = CreateDefaultAppConfig();
             auto s3ActorsFactory = NYql::NDq::CreateS3ActorsFactory();
-            auto kikimr = MakeKikimrRunner(false, clientMock, databaseAsyncResolverMock, appConfig, s3ActorsFactory);
+            auto kikimr = MakeKikimrRunner(false, clientMock, databaseAsyncResolverMock, appConfig, s3ActorsFactory, {}, 
+                NTestUtils::CreateCredentialProvider());
 
             CreateExternalDataSource(providerType, kikimr);
 
@@ -281,6 +350,30 @@ namespace NKikimr::NKqp {
 
         Y_UNIT_TEST(YdbManagedSelectConstant) {
             TestSelectConstant(EProviderType::Ydb);
+        }
+
+        Y_UNIT_TEST(IcebergHiveBasicSelectConstant) {
+            TestSelectConstant(EProviderType::IcebergHiveBasic);
+        }
+
+        Y_UNIT_TEST(IcebergHiveSaSelectConstant) {
+            TestSelectConstant(EProviderType::IcebergHiveSa);
+        }
+
+        Y_UNIT_TEST(IcebergHiveTokenSelectConstant) {
+            TestSelectConstant(EProviderType::IcebergHiveToken);
+        }
+
+        Y_UNIT_TEST(IcebergHadoopBasicSelectConstant) {
+            TestSelectConstant(EProviderType::IcebergHadoopBasic);
+        }
+
+        Y_UNIT_TEST(IcebergHadoopSaSelectConstant) {
+            TestSelectConstant(EProviderType::IcebergHadoopSa);
+        }
+
+        Y_UNIT_TEST(IcebergHadoopTokenSelectConstant) {
+            TestSelectConstant(EProviderType::IcebergHadoopToken);
         }
 
         void TestSelectCount(EProviderType providerType) {
@@ -333,7 +426,8 @@ namespace NKikimr::NKqp {
             // run test
             auto appConfig = CreateDefaultAppConfig();
             auto s3ActorsFactory = NYql::NDq::CreateS3ActorsFactory();
-            auto kikimr = MakeKikimrRunner(false, clientMock, databaseAsyncResolverMock, appConfig, s3ActorsFactory);
+            auto kikimr = MakeKikimrRunner(false, clientMock, databaseAsyncResolverMock, appConfig, s3ActorsFactory, {}, 
+                NTestUtils::CreateCredentialProvider());
 
             CreateExternalDataSource(providerType, kikimr);
 
@@ -367,6 +461,30 @@ namespace NKikimr::NKqp {
 
         Y_UNIT_TEST(YdbSelectCount) {
             TestSelectCount(EProviderType::Ydb);
+        }
+
+        Y_UNIT_TEST(IcebergHiveBasicSelectCount) {
+            TestSelectCount(EProviderType::IcebergHiveBasic);
+        }
+
+        Y_UNIT_TEST(IcebergHiveSaSelectCount) {
+            TestSelectCount(EProviderType::IcebergHiveSa);
+        }
+
+        Y_UNIT_TEST(IcebergHiveTokenSelectCount) {
+            TestSelectCount(EProviderType::IcebergHiveToken);
+        }
+
+        Y_UNIT_TEST(IcebergHadoopBasicSelectCount) {
+            TestSelectCount(EProviderType::IcebergHadoopBasic);
+        }
+
+        Y_UNIT_TEST(IcebergHadoopSaSelectCount) {
+            TestSelectCount(EProviderType::IcebergHadoopSa);
+        }
+
+        Y_UNIT_TEST(IcebergHadoopTokenSelectCount) {
+            TestSelectCount(EProviderType::IcebergHadoopToken);
         }
 
         void TestFilterPushdown(EProviderType providerType) {
@@ -442,7 +560,8 @@ namespace NKikimr::NKqp {
             // run test
             auto appConfig = CreateDefaultAppConfig();
             auto s3ActorsFactory = NYql::NDq::CreateS3ActorsFactory();
-            auto kikimr = MakeKikimrRunner(false, clientMock, databaseAsyncResolverMock, appConfig, s3ActorsFactory);
+            auto kikimr = MakeKikimrRunner(false, clientMock, databaseAsyncResolverMock, appConfig, s3ActorsFactory, {}, 
+                NTestUtils::CreateCredentialProvider());
 
             CreateExternalDataSource(providerType, kikimr);
 
@@ -480,12 +599,37 @@ namespace NKikimr::NKqp {
             TestFilterPushdown(EProviderType::Ydb);
         }
 
+        Y_UNIT_TEST(IcebergHiveBasicFilterPushdown) {
+            TestFilterPushdown(EProviderType::IcebergHiveBasic);
+        }
+
+        Y_UNIT_TEST(IcebergHiveSaFilterPushdown) {
+            TestFilterPushdown(EProviderType::IcebergHiveSa);
+        }
+
+        Y_UNIT_TEST(IcebergHiveTokenFilterPushdown) {
+            TestFilterPushdown(EProviderType::IcebergHiveToken);
+        }
+
+        Y_UNIT_TEST(IcebergHadoopBasicFilterPushdown) {
+            TestFilterPushdown(EProviderType::IcebergHadoopBasic);
+        }
+
+        Y_UNIT_TEST(IcebergHadoopSaFilterPushdown) {
+            TestFilterPushdown(EProviderType::IcebergHadoopSa);
+        }
+
+        Y_UNIT_TEST(IcebergHadoopTokenFilterPushdown) {
+            TestFilterPushdown(EProviderType::IcebergHadoopToken);
+        }
+
         void TestFailsOnIncorrectScriptExecutionOperation(const TString& operationId, const TString& fetchToken) {
             auto clientMock = std::make_shared<TConnectorClientMock>();
             auto databaseAsyncResolverMock = MakeDatabaseAsyncResolver(EProviderType::Ydb);
             auto appConfig = CreateDefaultAppConfig();
             auto s3ActorsFactory = NYql::NDq::CreateS3ActorsFactory();
-            auto kikimr = MakeKikimrRunner(false, clientMock, databaseAsyncResolverMock, appConfig, s3ActorsFactory);
+            auto kikimr = MakeKikimrRunner(false, clientMock, databaseAsyncResolverMock, appConfig, s3ActorsFactory, {}, 
+                NTestUtils::CreateCredentialProvider());
 
             // Create trash query
             NYdbGrpc::TGRpcClientLow clientLow;

--- a/ydb/core/kqp/ut/federated_query/generic_ut/ya.make
+++ b/ydb/core/kqp/ut/federated_query/generic_ut/ya.make
@@ -4,6 +4,8 @@ FORK_SUBTESTS()
 
 SRCS(
     kqp_generic_provider_ut.cpp
+    iceberg_ut_data.cpp
+    iceberg_ut_data.h
 )
 
 PEERDIR(

--- a/ydb/core/tx/schemeshard/schemeshard__operation_common_external_data_source.cpp
+++ b/ydb/core/tx/schemeshard/schemeshard__operation_common_external_data_source.cpp
@@ -52,7 +52,6 @@ bool ValidateProperties(const NKikimrSchemeOp::TExternalDataSourceProperties& pr
 
 bool ValidateAuth(const NKikimrSchemeOp::TAuth& auth,
                   const NExternalSource::IExternalSource::TPtr& source,
-                  const TString& data,
                   TString& errStr) {
     if (auth.ByteSizeLong() > MAX_PROTOBUF_SIZE) {
         errStr = Sprintf(
@@ -61,7 +60,7 @@ bool ValidateAuth(const NKikimrSchemeOp::TAuth& auth,
             auth.ByteSizeLong());
         return false;
     }
-    const auto availableAuthMethods = source->GetAuthMethods(data);
+    const auto availableAuthMethods = source->GetAuthMethods();
     switch (auth.identity_case()) {
         case NKikimrSchemeOp::TAuth::IDENTITY_NOT_SET: {
             errStr = "Authorization method isn't specified";
@@ -88,12 +87,11 @@ bool Validate(const NKikimrSchemeOp::TExternalDataSourceDescription& desc,
               TString& errStr) {
     try {
         const auto source = factory->GetOrCreate(desc.GetSourceType());
-        const auto data = desc.SerializeAsString();
-        source->ValidateExternalDataSource(data);
+        source->ValidateExternalDataSource(desc.SerializeAsString());
         return ValidateLocationAndInstallation(desc.GetLocation(),
                                                desc.GetInstallation(),
                                                errStr) &&
-               ValidateAuth(desc.GetAuth(), source, data, errStr) &&
+               ValidateAuth(desc.GetAuth(), source, errStr) &&
                ValidateProperties(desc.GetProperties(), errStr);
     } catch (...) {
         errStr = CurrentExceptionMessage();

--- a/ydb/library/yql/providers/common/db_id_async_resolver/database_type.cpp
+++ b/ydb/library/yql/providers/common/db_id_async_resolver/database_type.cpp
@@ -17,7 +17,8 @@ std::set<TString> GetAllExternalDataSourceTypes() {
         ToString(NYql::EDatabaseType::MsSQLServer),
         ToString(NYql::EDatabaseType::Oracle),
         ToString(NYql::EDatabaseType::Logging),
-        ToString(NYql::EDatabaseType::Solomon)
+        ToString(NYql::EDatabaseType::Solomon),
+        ToString(NYql::EDatabaseType::Iceberg)
     };
     return allTypes;
 }
@@ -35,11 +36,13 @@ EDatabaseType DatabaseTypeFromDataSourceKind(NYql::EGenericDataSourceKind dataSo
         case NYql::EGenericDataSourceKind::GREENPLUM:
             return EDatabaseType::Greenplum;
         case NYql::EGenericDataSourceKind::MS_SQL_SERVER:
-          return EDatabaseType::MsSQLServer;
+            return EDatabaseType::MsSQLServer;
         case NYql::EGenericDataSourceKind::ORACLE:
-          return EDatabaseType::Oracle;
+            return EDatabaseType::Oracle;
         case NYql::EGenericDataSourceKind::LOGGING:
-          return EDatabaseType::Logging;
+            return EDatabaseType::Logging;
+        case NYql::EGenericDataSourceKind::ICEBERG:
+            return EDatabaseType::Iceberg;
         default:
             ythrow yexception() << "Unknown data source kind: " << NYql::EGenericDataSourceKind_Name(dataSourceKind);
     }
@@ -48,21 +51,23 @@ EDatabaseType DatabaseTypeFromDataSourceKind(NYql::EGenericDataSourceKind dataSo
 NYql::EGenericDataSourceKind DatabaseTypeToDataSourceKind(EDatabaseType databaseType) {
     switch (databaseType) {
         case EDatabaseType::PostgreSQL:
-            return  NYql::EGenericDataSourceKind::POSTGRESQL;
+            return NYql::EGenericDataSourceKind::POSTGRESQL;
         case EDatabaseType::ClickHouse:
-            return  NYql::EGenericDataSourceKind::CLICKHOUSE;
+            return NYql::EGenericDataSourceKind::CLICKHOUSE;
         case EDatabaseType::Ydb:
-            return  NYql::EGenericDataSourceKind::YDB;
+            return NYql::EGenericDataSourceKind::YDB;
         case EDatabaseType::MySQL:
             return NYql::EGenericDataSourceKind::MYSQL;
         case EDatabaseType::Greenplum:
-            return  NYql::EGenericDataSourceKind::GREENPLUM;
+            return NYql::EGenericDataSourceKind::GREENPLUM;
         case EDatabaseType::MsSQLServer:
             return NYql::EGenericDataSourceKind::MS_SQL_SERVER;
         case EDatabaseType::Oracle:
             return NYql::EGenericDataSourceKind::ORACLE;
         case EDatabaseType::Logging:
             return NYql::EGenericDataSourceKind::LOGGING;
+        case EDatabaseType::Iceberg:
+            return NYql::EGenericDataSourceKind::ICEBERG;
         default:
             ythrow yexception() << "Unknown database type: " << ToString(databaseType);
     }

--- a/ydb/library/yql/providers/common/db_id_async_resolver/database_type.h
+++ b/ydb/library/yql/providers/common/db_id_async_resolver/database_type.h
@@ -18,7 +18,8 @@ enum class EDatabaseType {
     MsSQLServer,
     Oracle,
     Logging,
-    Solomon
+    Solomon,
+    Iceberg
 };
 
 std::set<TString> GetAllExternalDataSourceTypes();

--- a/ydb/library/yql/providers/generic/actors/yql_generic_provider_factories.cpp
+++ b/ydb/library/yql/providers/generic/actors/yql_generic_provider_factories.cpp
@@ -51,7 +51,8 @@ namespace NYql::NDq {
                  "GreenplumGeneric",
                  "MsSQLServerGeneric",
                  "OracleGeneric",
-                 "LoggingGeneric"}) {
+                 "LoggingGeneric",
+                 "IcebergGeneric"}) {
             factory.RegisterSource<NGeneric::TSource>(name, readActorFactory);
             factory.RegisterLookupSource<NGeneric::TLookupSource>(name, lookupActorFactory);
         }

--- a/ydb/library/yql/providers/generic/provider/yql_generic_cluster_config.cpp
+++ b/ydb/library/yql/providers/generic/provider/yql_generic_cluster_config.cpp
@@ -321,10 +321,10 @@ namespace NYql {
         }
 
         for (auto f : NKikimr::NExternalSource::NIceberg::FieldsToConnector) {
-            auto itr = properties.find(f);
+            auto it = properties.find(f);
 
-            if (properties.end() != itr) {
-                clusterConfig.MutableDataSourceOptions()->insert({f, itr->second});
+            if (properties.end() != it) {
+                clusterConfig.MutableDataSourceOptions()->insert({f, it->second});
             }
         }
     }

--- a/ydb/library/yql/providers/generic/provider/yql_generic_cluster_config.cpp
+++ b/ydb/library/yql/providers/generic/provider/yql_generic_cluster_config.cpp
@@ -8,6 +8,7 @@
 
 #include <yql/essentials/providers/common/proto/gateways_config.pb.h>
 #include <ydb/library/yql/providers/common/db_id_async_resolver/db_async_resolver.h>
+#include <ydb/core/external_sources/iceberg_fields.h>
 
 #include "yql_generic_cluster_config.h"
 
@@ -213,6 +214,7 @@ namespace NYql {
                 EGenericDataSourceKind::MYSQL,
                 EGenericDataSourceKind::MS_SQL_SERVER,
                 EGenericDataSourceKind::ORACLE,
+                EGenericDataSourceKind::ICEBERG
                 }, 
                clusterConfig.GetKind()
             )) {
@@ -290,6 +292,43 @@ namespace NYql {
         clusterConfig.mutable_datasourceoptions()->insert({"folder_id", TString(it->second)});
     }
 
+    ///
+    /// Extract token from properties and copy it to a cluster's config
+    ///
+    void ParseToken(const THashMap<TString, TString>& properties,
+        NYql::TGenericClusterConfig& clusterConfig) {
+        auto it = properties.find("token");
+
+        if (it == properties.cend()) {
+            return;
+        }
+
+        if (!it->second) {
+            return;
+        }
+
+        clusterConfig.SetToken(it->second);
+    }
+
+    ///
+    /// Fill properties for an iceberg data source
+    ///
+    void ParseIcebergFields(const THashMap<TString, TString>& properties,
+        NYql::TGenericClusterConfig& clusterConfig) {
+
+        if (clusterConfig.GetKind() != NYql::EGenericDataSourceKind::ICEBERG) {
+            return;
+        }
+
+        for (auto f: Iceberg::FieldsToConnector) {
+            auto itr = properties.find(f);
+
+            if (properties.end() != itr) {
+                clusterConfig.mutable_datasourceoptions()->insert({f, itr->second});
+            }
+        }
+    }
+
     using TProtoProperties = google::protobuf::Map<TProtoStringType, TProtoStringType>;
 
     TString GetPropertyWithDefault(const TProtoProperties& properties, const TString& key) {
@@ -317,7 +356,10 @@ namespace NYql {
         ParseProtocol(properties, clusterConfig);
         ParseServiceAccountId(properties, clusterConfig);
         ParseServiceAccountIdSignature(properties, clusterConfig);
+        ParseToken(properties, clusterConfig);
         ParseFolderId(properties, clusterConfig);
+
+        ParseIcebergFields(properties, clusterConfig);
 
         return clusterConfig;
     }

--- a/ydb/library/yql/providers/generic/provider/yql_generic_cluster_config.cpp
+++ b/ydb/library/yql/providers/generic/provider/yql_generic_cluster_config.cpp
@@ -320,11 +320,11 @@ namespace NYql {
             return;
         }
 
-        for (auto f: Iceberg::FieldsToConnector) {
+        for (auto f : NKikimr::NExternalSource::NIceberg::FieldsToConnector) {
             auto itr = properties.find(f);
 
             if (properties.end() != itr) {
-                clusterConfig.mutable_datasourceoptions()->insert({f, itr->second});
+                clusterConfig.MutableDataSourceOptions()->insert({f, itr->second});
             }
         }
     }

--- a/ydb/library/yql/providers/generic/provider/yql_generic_dq_integration.cpp
+++ b/ydb/library/yql/providers/generic/provider/yql_generic_dq_integration.cpp
@@ -38,6 +38,8 @@ namespace NYql {
                     return "OracleGeneric";
                 case NYql::EGenericDataSourceKind::LOGGING:
                     return "LoggingGeneric";
+                case NYql::EGenericDataSourceKind::ICEBERG:
+                    return "IcebergGeneric";
                 default:
                     throw yexception() << "Data source kind is unknown or not specified";
             }
@@ -217,10 +219,10 @@ namespace NYql {
                         }
                     }
 
-                    // Managed YDB (including YDB underlying Logging) supports access via IAM token.
+                    // Iceberg/Managed YDB (including YDB underlying Logging) supports access via IAM token.
                     // If exist, copy service account creds to obtain tokens during request execution phase.
                     // If exists, copy previously created token.
-                    if (IsIn({NYql::EGenericDataSourceKind::YDB, NYql::EGenericDataSourceKind::LOGGING}, clusterConfig.kind())) {
+                    if (IsIn({NYql::EGenericDataSourceKind::YDB, NYql::EGenericDataSourceKind::LOGGING, NYql::EGenericDataSourceKind::ICEBERG}, clusterConfig.kind())) {
                         source.SetServiceAccountId(clusterConfig.GetServiceAccountId());
                         source.SetServiceAccountIdSignature(clusterConfig.GetServiceAccountIdSignature());
                         source.SetToken(State_->Types->Credentials->FindCredentialContent(
@@ -276,6 +278,9 @@ namespace NYql {
                             break;
                         case NYql::EGenericDataSourceKind::LOGGING:
                             properties["SourceType"] = "Logging";
+                            break;
+                        case NYql::EGenericDataSourceKind::ICEBERG:
+                            properties["SourceType"] = "Iceberg";
                             break;
                         case NYql::EGenericDataSourceKind::DATA_SOURCE_KIND_UNSPECIFIED:
                             break;

--- a/ydb/library/yql/providers/generic/provider/yql_generic_load_meta.cpp
+++ b/ydb/library/yql/providers/generic/provider/yql_generic_load_meta.cpp
@@ -456,7 +456,7 @@ namespace NYql {
             }
         }
 
-        inline TString GetFieldValue(const ::google::protobuf::Map<TProtoStringType, 
+        TString GetFieldValue(const ::google::protobuf::Map<TProtoStringType,
                                      TProtoStringType>& cfg, TString field, TString err) {
             auto it = cfg.find(field);
 
@@ -471,45 +471,45 @@ namespace NYql {
         /// Fill options into DatSourceOptions specific for an iceberg data type
         ///
         void SetIcebergOptions(NYql::TIcebergDataSourceOptions& options, const TGenericClusterConfig& clusterConfig) {
+            using namespace NKikimr::NExternalSource::NIceberg;
             const auto cfg = clusterConfig.GetDataSourceOptions();
 
             auto wType = GetFieldValue(
-                cfg, Iceberg::Warehouse::Fields::TYPE, "Warehouse type is a required field");
+                cfg, WAREHOUSE_TYPE, "Warehouse type is a required field");
 
-            auto warehouse = options.mutable_warehouse();
-
-            // set warehouse options
-            if (Iceberg::Warehouse::S3 == wType) {
-                auto endpoint = GetFieldValue(
-                    cfg, Iceberg::Warehouse::Fields::S3_ENDPOINT, "S3 endpoint is a required field");
-
-                auto region = GetFieldValue(
-                    cfg, Iceberg::Warehouse::Fields::S3_REGION, "S3 region is a required field");
-
-                auto uri = GetFieldValue(
-                    cfg, Iceberg::Warehouse::Fields::S3_URI, "S3 uri is a required field");
-
-                warehouse->mutable_s3()->set_endpoint(endpoint);
-                warehouse->mutable_s3()->set_region(region);
-                warehouse->mutable_s3()->set_uri(uri);
-            } else {
+            if (VALUE_S3 != wType) {
                 throw yexception() << "Unexpected warehouse type: " << wType;
             }
 
-            auto cType = GetFieldValue(
-                cfg, Iceberg::Catalog::Fields::TYPE, "Catalog type is a required field");
+            auto endpoint = GetFieldValue(
+                cfg, WAREHOUSE_S3_ENDPOINT, "S3 endpoint is a required field");
 
-            auto catalog = options.mutable_catalog();
+            auto region = GetFieldValue(
+                cfg, WAREHOUSE_S3_REGION, "S3 region is a required field");
+
+            auto uri = GetFieldValue(
+                cfg, WAREHOUSE_S3_URI, "S3 uri is a required field");
+
+            auto& s3 = *options.mutable_warehouse()->mutable_s3();
+
+            s3.set_endpoint(endpoint);
+            s3.set_region(region);
+            s3.set_uri(uri);
+
+            auto cType = GetFieldValue(
+                cfg, CATALOG_TYPE, "Catalog type is a required field");
+
+            auto& catalog = *options.mutable_catalog();
 
             // set catalog options
-            if (Iceberg::Catalog::HADOOP == cType) {
+            if (VALUE_HADOOP == cType) {
                 // hadoop nothing yet
-                catalog->mutable_hadoop();
-            } else if (Iceberg::Catalog::HIVE == cType) {
+                catalog.mutable_hadoop();
+            } else if (VALUE_HIVE == cType) {
                 auto hiveUri = GetFieldValue(
-                    cfg, Iceberg::Catalog::Fields::HIVE_URI, "Hive uri is a required field");
+                    cfg, CATALOG_HIVE_URI, "Hive uri is a required field");
 
-                catalog->mutable_hive()->set_uri(hiveUri);
+                catalog.mutable_hive()->set_uri(hiveUri);
             } else {
                 throw yexception() << "Unexpected catalog type: " << cType;
             }

--- a/ydb/tests/tools/kqprun/configuration/app_config.conf
+++ b/ydb/tests/tools/kqprun/configuration/app_config.conf
@@ -97,6 +97,7 @@ QueryServiceConfig {
   AvailableExternalDataSources: "Oracle"
   AvailableExternalDataSources: "Logging"
   AvailableExternalDataSources: "Solomon"
+  AvailableExternalDataSources: "Iceberg"
 
   FileStorage {
     MaxFiles: 1000


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->
FQ: Add ability to create an external data sources for iceberg tables. 

### Changelog category <!-- remove all except one -->

* New feature

### Description for reviewers <!-- (optional) description for those who read this PR -->

The complete description is located on a wiki [page](https://wiki.yandex-team.ru/rtmapreduce/yql-streams-corner/connectors/lld-13-integracija-s-iceberg/). 
