### PR TITLE
YQL-19747 Revert MR #16570

### DIFF
--- a/ydb/public/lib/ydb_cli/commands/interactive/complete/yql_completer.cpp
+++ b/ydb/public/lib/ydb_cli/commands/interactive/complete/yql_completer.cpp
@@ -41,19 +41,8 @@ namespace NYdb::NConsoleClient {
     };
 
     IYQLCompleter::TPtr MakeYQLCompleter() {
-        NSQLTranslationV1::TLexers lexers;
-        lexers.Antlr4Pure = NSQLTranslationV1::MakeAntlr4PureLexerFactory();
-        lexers.Antlr4PureAnsi = NSQLTranslationV1::MakeAntlr4PureAnsiLexerFactory();
-
-        auto names = NSQLComplete::MakeDefaultNameSet();
-        NSQLComplete::INameService::TPtr service = MakeStaticNameService(std::move(names));
-
         return IYQLCompleter::TPtr(new TYQLCompleter(
-            NSQLComplete::MakeSqlCompletionEngine([lexers = std::move(lexers)](bool ansi) {
-                return NSQLTranslationV1::MakeLexer(
-                    lexers, ansi, /* antlr4 = */ true, 
-                    NSQLTranslationV1::ELexerFlavor::Pure);
-            }, std::move(service))));
+            NSQLComplete::MakeSqlCompletionEngine()));
     }
 
 } // namespace NYdb::NConsoleClient


### PR DESCRIPTION
This is for @pnv1 to fix GitHub to Arcadia sync.

The other better options to fix the build is to pass the `DefaultRanking` like we does at `sql/v1/complete`: https://github.com/ytsaurus/ytsaurus/blob/main/yql/essentials/sql/v1/complete/sql_complete.cpp#L125.

Just copy the code

```c++
    #include <yql/essentials/sql/v1/complete/name/static/ranking.h>

    ...

    ISqlCompletionEngine::TPtr MakeSqlCompletionEngine() {
        NSQLTranslationV1::TLexers lexers;
        lexers.Antlr4Pure = NSQLTranslationV1::MakeAntlr4PureLexerFactory();
        lexers.Antlr4PureAnsi = NSQLTranslationV1::MakeAntlr4PureAnsiLexerFactory();

        INameService::TPtr names = MakeStaticNameService(MakeDefaultNameSet(), MakeDefaultRanking());

        return MakeSqlCompletionEngine([lexers = std::move(lexers)](bool ansi) {
            return NSQLTranslationV1::MakeLexer(
                lexers, ansi, /* antlr4 = */ true,
                NSQLTranslationV1::ELexerFlavor::Pure);
        }, std::move(names));
    }
```

at `yql_completer.cpp` and 

```c++
IYQLCompleter::TPtr MakeYQLCompleter() {
  return IYQLCompleter::TPtr(new TYQLCompleter(MakeSqlCompletionEngine()));
}
```
