### PR TITLE
stable-25-1: cross version tpc-h test

### DIFF
--- a/ydb/apps/ydb/CHANGELOG.md
+++ b/ydb/apps/ydb/CHANGELOG.md
@@ -1,3 +1,5 @@
+* Added `--retries` to `ydb workload <clickbenh|tpch|tpcds> run` command.
+* Added `--partition-size` param to `ydb workload <clickbench/tpcds/tpch> init`.
 * Fixed return code of command `ydb workload * run --check-canonical` for the case when benchmark query results differ from canonical ones.
 * Added support for dual configuration mode in the `ydb admin cluster config fetch` command, allowing it to handle separate cluster and storage config sections.
 * Add options for client certificates in SSL/TLS connections.

--- a/ydb/library/workload/benchmark_base/workload.h
+++ b/ydb/library/workload/benchmark_base/workload.h
@@ -32,6 +32,7 @@ public:
     YDB_READONLY(TString, StringType, "Utf8");
     YDB_READONLY(TString, DateType, "Date32");
     YDB_READONLY(TString, TimestampType, "Timestamp64");
+    YDB_READONLY(ui64, PartitionSizeMb, 2000);
 };
 
 class TWorkloadGeneratorBase : public IWorkloadQueryGenerator {

--- a/ydb/public/lib/ydb_cli/commands/benchmark_utils.h
+++ b/ydb/public/lib/ydb_cli/commands/benchmark_utils.h
@@ -82,14 +82,15 @@ struct TQueryBenchmarkSettings {
     TQueryBenchmarkDeadline Deadline;
     std::optional<TString> PlanFileName;
     bool WithProgress = false;
+    NYdb::NRetry::TRetryOperationSettings RetrySettings;
 };
 
 TString FullTablePath(const TString& database, const TString& table);
 bool HasCharsInString(const TString& str);
 TQueryBenchmarkResult Execute(const TString & query, NTable::TTableClient & client, const TQueryBenchmarkSettings& settings);
 TQueryBenchmarkResult Execute(const TString & query, NQuery::TQueryClient & client, const TQueryBenchmarkSettings& settings);
-TQueryBenchmarkResult Explain(const TString & query, NTable::TTableClient & client, const TQueryBenchmarkDeadline& deadline);
-TQueryBenchmarkResult Explain(const TString & query, NQuery::TQueryClient & client, const TQueryBenchmarkDeadline& deadline);
+TQueryBenchmarkResult Explain(const TString & query, NTable::TTableClient & client, const TQueryBenchmarkSettings& settings);
+TQueryBenchmarkResult Explain(const TString & query, NQuery::TQueryClient & client, const TQueryBenchmarkSettings& settings);
 NJson::TJsonValue GetQueryLabels(ui32 queryId);
 NJson::TJsonValue GetSensorValue(TStringBuf sensor, TDuration& value, ui32 queryId);
 NJson::TJsonValue GetSensorValue(TStringBuf sensor, double value, ui32 queryId);

--- a/ydb/public/lib/ydb_cli/commands/ydb_benchmark.h
+++ b/ydb/public/lib/ydb_cli/commands/ydb_benchmark.h
@@ -6,7 +6,7 @@ namespace NYdb::NConsoleClient {
 
 namespace BenchmarkUtils {
     class TQueryBenchmarkResult;
-    struct TQueryBenchmarkDeadline;
+    struct TQueryBenchmarkSettings;
 }
 
 class TWorkloadCommandBenchmark final: public TWorkloadCommandBase {
@@ -30,7 +30,7 @@ private:
     int RunBench(TClient* client, NYdbWorkload::IWorkloadQueryGenerator& workloadGen);
     void SavePlans(const BenchmarkUtils::TQueryBenchmarkResult& res, ui32 queryNum, const TStringBuf name) const;
     void PrintResult(const BenchmarkUtils::TQueryBenchmarkResult& res, IOutputStream& out, const std::string& expected) const;
-    BenchmarkUtils::TQueryBenchmarkDeadline GetDeadline() const;
+    BenchmarkUtils::TQueryBenchmarkSettings GetBenchmarkSettings(bool withProgress) const;
 
 private:
     EQueryExecutor QueryExecuterType = EQueryExecutor::Generic;
@@ -47,6 +47,7 @@ private:
     TDuration GlobalTimeout = TDuration::Zero();
     TDuration RequestTimeout = TDuration::Zero();
     TInstant GlobalDeadline = TInstant::Max();
+    NYdb::NRetry::TRetryOperationSettings RetrySettings;
 };
 
 }

--- a/ydb/tests/functional/benchmarks_init/canondata/test_init.TestClickbenchInit.test_s1_row/s1_row
+++ b/ydb/tests/functional/benchmarks_init/canondata/test_init.TestClickbenchInit.test_s1_row/s1_row
@@ -110,6 +110,8 @@ CREATE TABLE `/Root/db/Root/db/clickbench/s1` (
     PRIMARY KEY (CounterID, EventDate, UserID, EventTime, WatchID)
 )
 WITH (
+    STORE = ROW,
+    AUTO_PARTITIONING_PARTITION_SIZE_MB = 2000, 
     AUTO_PARTITIONING_MIN_PARTITIONS_COUNT = 128
 );
 

--- a/ydb/tests/functional/benchmarks_init/canondata/test_init.TestTpcdsInit.test_s1_row/s1_row
+++ b/ydb/tests/functional/benchmarks_init/canondata/test_init.TestTpcdsInit.test_s1_row/s1_row
@@ -18,6 +18,8 @@ CREATE TABLE `/Root/db/Root/db/tpcds/s1/customer_address` (
     PRIMARY KEY (ca_address_sk)
 )
 WITH (
+    STORE = ROW,
+    AUTO_PARTITIONING_PARTITION_SIZE_MB = 2000, 
     AUTO_PARTITIONING_MIN_PARTITIONS_COUNT = 64
 );
 
@@ -34,6 +36,8 @@ CREATE TABLE `/Root/db/Root/db/tpcds/s1/customer_demographics` (
     PRIMARY KEY (cd_demo_sk)
 )
 WITH (
+    STORE = ROW,
+    AUTO_PARTITIONING_PARTITION_SIZE_MB = 2000, 
     AUTO_PARTITIONING_MIN_PARTITIONS_COUNT = 64
 );
 
@@ -69,6 +73,8 @@ CREATE TABLE `/Root/db/Root/db/tpcds/s1/date_dim` (
     PRIMARY KEY (d_date_sk)
 )
 WITH (
+    STORE = ROW,
+    AUTO_PARTITIONING_PARTITION_SIZE_MB = 2000, 
     AUTO_PARTITIONING_MIN_PARTITIONS_COUNT = 64
 );
 
@@ -90,6 +96,8 @@ CREATE TABLE `/Root/db/Root/db/tpcds/s1/warehouse` (
     PRIMARY KEY (w_warehouse_sk)
 )
 WITH (
+    STORE = ROW,
+    AUTO_PARTITIONING_PARTITION_SIZE_MB = 2000, 
     AUTO_PARTITIONING_MIN_PARTITIONS_COUNT = 64
 );
 
@@ -103,6 +111,8 @@ CREATE TABLE `/Root/db/Root/db/tpcds/s1/ship_mode` (
     PRIMARY KEY (sm_ship_mode_sk)
 )
 WITH (
+    STORE = ROW,
+    AUTO_PARTITIONING_PARTITION_SIZE_MB = 2000, 
     AUTO_PARTITIONING_MIN_PARTITIONS_COUNT = 64
 );
 
@@ -120,6 +130,8 @@ CREATE TABLE `/Root/db/Root/db/tpcds/s1/time_dim` (
     PRIMARY KEY (t_time_sk)
 )
 WITH (
+    STORE = ROW,
+    AUTO_PARTITIONING_PARTITION_SIZE_MB = 2000, 
     AUTO_PARTITIONING_MIN_PARTITIONS_COUNT = 64
 );
 
@@ -130,6 +142,8 @@ CREATE TABLE `/Root/db/Root/db/tpcds/s1/reason` (
     PRIMARY KEY (r_reason_sk)
 )
 WITH (
+    STORE = ROW,
+    AUTO_PARTITIONING_PARTITION_SIZE_MB = 2000, 
     AUTO_PARTITIONING_MIN_PARTITIONS_COUNT = 64
 );
 
@@ -140,6 +154,8 @@ CREATE TABLE `/Root/db/Root/db/tpcds/s1/income_band` (
     PRIMARY KEY (ib_income_band_sk)
 )
 WITH (
+    STORE = ROW,
+    AUTO_PARTITIONING_PARTITION_SIZE_MB = 2000, 
     AUTO_PARTITIONING_MIN_PARTITIONS_COUNT = 64
 );
 
@@ -169,6 +185,8 @@ CREATE TABLE `/Root/db/Root/db/tpcds/s1/item` (
     PRIMARY KEY (i_item_sk)
 )
 WITH (
+    STORE = ROW,
+    AUTO_PARTITIONING_PARTITION_SIZE_MB = 2000, 
     AUTO_PARTITIONING_MIN_PARTITIONS_COUNT = 64
 );
 
@@ -205,6 +223,8 @@ CREATE TABLE `/Root/db/Root/db/tpcds/s1/store` (
     PRIMARY KEY (s_store_sk)
 )
 WITH (
+    STORE = ROW,
+    AUTO_PARTITIONING_PARTITION_SIZE_MB = 2000, 
     AUTO_PARTITIONING_MIN_PARTITIONS_COUNT = 64
 );
 
@@ -243,6 +263,8 @@ CREATE TABLE `/Root/db/Root/db/tpcds/s1/call_center` (
     PRIMARY KEY (cc_call_center_sk)
 )
 WITH (
+    STORE = ROW,
+    AUTO_PARTITIONING_PARTITION_SIZE_MB = 2000, 
     AUTO_PARTITIONING_MIN_PARTITIONS_COUNT = 64
 );
 
@@ -268,6 +290,8 @@ CREATE TABLE `/Root/db/Root/db/tpcds/s1/customer` (
     PRIMARY KEY (c_customer_sk)
 )
 WITH (
+    STORE = ROW,
+    AUTO_PARTITIONING_PARTITION_SIZE_MB = 2000, 
     AUTO_PARTITIONING_MIN_PARTITIONS_COUNT = 64
 );
 
@@ -301,6 +325,8 @@ CREATE TABLE `/Root/db/Root/db/tpcds/s1/web_site` (
     PRIMARY KEY (web_site_sk)
 )
 WITH (
+    STORE = ROW,
+    AUTO_PARTITIONING_PARTITION_SIZE_MB = 2000, 
     AUTO_PARTITIONING_MIN_PARTITIONS_COUNT = 64
 );
 
@@ -328,6 +354,8 @@ CREATE TABLE `/Root/db/Root/db/tpcds/s1/store_returns` (
     PRIMARY KEY (sr_item_sk, sr_ticket_number)
 )
 WITH (
+    STORE = ROW,
+    AUTO_PARTITIONING_PARTITION_SIZE_MB = 2000, 
     AUTO_PARTITIONING_MIN_PARTITIONS_COUNT = 64
 );
 
@@ -340,6 +368,8 @@ CREATE TABLE `/Root/db/Root/db/tpcds/s1/household_demographics` (
     PRIMARY KEY (hd_demo_sk)
 )
 WITH (
+    STORE = ROW,
+    AUTO_PARTITIONING_PARTITION_SIZE_MB = 2000, 
     AUTO_PARTITIONING_MIN_PARTITIONS_COUNT = 64
 );
 
@@ -361,6 +391,8 @@ CREATE TABLE `/Root/db/Root/db/tpcds/s1/web_page` (
     PRIMARY KEY (wp_web_page_sk)
 )
 WITH (
+    STORE = ROW,
+    AUTO_PARTITIONING_PARTITION_SIZE_MB = 2000, 
     AUTO_PARTITIONING_MIN_PARTITIONS_COUNT = 64
 );
 
@@ -387,6 +419,8 @@ CREATE TABLE `/Root/db/Root/db/tpcds/s1/promotion` (
     PRIMARY KEY (p_promo_sk)
 )
 WITH (
+    STORE = ROW,
+    AUTO_PARTITIONING_PARTITION_SIZE_MB = 2000, 
     AUTO_PARTITIONING_MIN_PARTITIONS_COUNT = 64
 );
 
@@ -403,6 +437,8 @@ CREATE TABLE `/Root/db/Root/db/tpcds/s1/catalog_page` (
     PRIMARY KEY (cp_catalog_page_sk)
 )
 WITH (
+    STORE = ROW,
+    AUTO_PARTITIONING_PARTITION_SIZE_MB = 2000, 
     AUTO_PARTITIONING_MIN_PARTITIONS_COUNT = 64
 );
 
@@ -414,6 +450,8 @@ CREATE TABLE `/Root/db/Root/db/tpcds/s1/inventory` (
     PRIMARY KEY (inv_date_sk, inv_item_sk, inv_warehouse_sk)
 )
 WITH (
+    STORE = ROW,
+    AUTO_PARTITIONING_PARTITION_SIZE_MB = 2000, 
     AUTO_PARTITIONING_MIN_PARTITIONS_COUNT = 64
 );
 
@@ -448,6 +486,8 @@ CREATE TABLE `/Root/db/Root/db/tpcds/s1/catalog_returns` (
     PRIMARY KEY (cr_item_sk, cr_order_number)
 )
 WITH (
+    STORE = ROW,
+    AUTO_PARTITIONING_PARTITION_SIZE_MB = 2000, 
     AUTO_PARTITIONING_MIN_PARTITIONS_COUNT = 64
 );
 
@@ -479,6 +519,8 @@ CREATE TABLE `/Root/db/Root/db/tpcds/s1/web_returns` (
     PRIMARY KEY (wr_item_sk, wr_order_number)
 )
 WITH (
+    STORE = ROW,
+    AUTO_PARTITIONING_PARTITION_SIZE_MB = 2000, 
     AUTO_PARTITIONING_MIN_PARTITIONS_COUNT = 64
 );
 
@@ -520,6 +562,8 @@ CREATE TABLE `/Root/db/Root/db/tpcds/s1/web_sales` (
     PRIMARY KEY (ws_item_sk, ws_order_number)
 )
 WITH (
+    STORE = ROW,
+    AUTO_PARTITIONING_PARTITION_SIZE_MB = 2000, 
     AUTO_PARTITIONING_MIN_PARTITIONS_COUNT = 64
 );
 
@@ -561,6 +605,8 @@ CREATE TABLE `/Root/db/Root/db/tpcds/s1/catalog_sales` (
     PRIMARY KEY (cs_item_sk, cs_order_number)
 )
 WITH (
+    STORE = ROW,
+    AUTO_PARTITIONING_PARTITION_SIZE_MB = 2000, 
     AUTO_PARTITIONING_MIN_PARTITIONS_COUNT = 64
 );
 
@@ -591,6 +637,8 @@ CREATE TABLE `/Root/db/Root/db/tpcds/s1/store_sales` (
     PRIMARY KEY (ss_item_sk, ss_ticket_number)
 )
 WITH (
+    STORE = ROW,
+    AUTO_PARTITIONING_PARTITION_SIZE_MB = 2000, 
     AUTO_PARTITIONING_MIN_PARTITIONS_COUNT = 64
 );
 

--- a/ydb/tests/functional/benchmarks_init/canondata/test_init.TestTpchInit.test_s1_row/s1_row
+++ b/ydb/tests/functional/benchmarks_init/canondata/test_init.TestTpchInit.test_s1_row/s1_row
@@ -13,6 +13,8 @@ CREATE TABLE `/Root/db/Root/db/tpch/s1/customer` (
     PRIMARY KEY (c_custkey)
 )
 WITH (
+    STORE = ROW,
+    AUTO_PARTITIONING_PARTITION_SIZE_MB = 2000, 
     AUTO_PARTITIONING_MIN_PARTITIONS_COUNT = 64
 );
 
@@ -36,6 +38,8 @@ CREATE TABLE `/Root/db/Root/db/tpch/s1/lineitem` (
     PRIMARY KEY (l_orderkey, l_linenumber)
 )
 WITH (
+    STORE = ROW,
+    AUTO_PARTITIONING_PARTITION_SIZE_MB = 2000, 
     AUTO_PARTITIONING_MIN_PARTITIONS_COUNT = 64
 );
 
@@ -47,6 +51,8 @@ CREATE TABLE `/Root/db/Root/db/tpch/s1/nation` (
     PRIMARY KEY (n_nationkey)
 )
 WITH (
+    STORE = ROW,
+    AUTO_PARTITIONING_PARTITION_SIZE_MB = 2000, 
     AUTO_PARTITIONING_MIN_PARTITIONS_COUNT = 1
 );
 
@@ -63,6 +69,8 @@ CREATE TABLE `/Root/db/Root/db/tpch/s1/orders` (
     PRIMARY KEY (o_orderkey)
 )
 WITH (
+    STORE = ROW,
+    AUTO_PARTITIONING_PARTITION_SIZE_MB = 2000, 
     AUTO_PARTITIONING_MIN_PARTITIONS_COUNT = 64
 );
 
@@ -79,6 +87,8 @@ CREATE TABLE `/Root/db/Root/db/tpch/s1/part` (
     PRIMARY KEY (p_partkey)
 )
 WITH (
+    STORE = ROW,
+    AUTO_PARTITIONING_PARTITION_SIZE_MB = 2000, 
     AUTO_PARTITIONING_MIN_PARTITIONS_COUNT = 64
 );
 
@@ -91,6 +101,8 @@ CREATE TABLE `/Root/db/Root/db/tpch/s1/partsupp` (
     PRIMARY KEY (ps_partkey, ps_suppkey)
 )
 WITH (
+    STORE = ROW,
+    AUTO_PARTITIONING_PARTITION_SIZE_MB = 2000, 
     AUTO_PARTITIONING_MIN_PARTITIONS_COUNT = 64
 );
 
@@ -101,6 +113,8 @@ CREATE TABLE `/Root/db/Root/db/tpch/s1/region` (
     PRIMARY KEY (r_regionkey)
 )
 WITH (
+    STORE = ROW,
+    AUTO_PARTITIONING_PARTITION_SIZE_MB = 2000, 
     AUTO_PARTITIONING_MIN_PARTITIONS_COUNT = 1
 );
 
@@ -115,6 +129,8 @@ CREATE TABLE `/Root/db/Root/db/tpch/s1/supplier` (
     PRIMARY KEY (s_suppkey)
 )
 WITH (
+    STORE = ROW,
+    AUTO_PARTITIONING_PARTITION_SIZE_MB = 2000, 
     AUTO_PARTITIONING_MIN_PARTITIONS_COUNT = 64
 );
 

--- a/ydb/tests/functional/compatibility/test_stress.py
+++ b/ydb/tests/functional/compatibility/test_stress.py
@@ -1,0 +1,365 @@
+# -*- coding: utf-8 -*-
+import os
+
+import pytest
+
+import yatest
+
+from ydb.tests.library.harness.kikimr_runner import KiKiMR
+from ydb.tests.library.harness.kikimr_config import KikimrConfigGenerator
+from ydb.tests.library.harness.param_constants import kikimr_driver_path
+from ydb.tests.library.common.types import Erasure
+from ydb.tests.stress.simple_queue.workload import Workload
+
+last_stable_binary_path = yatest.common.binary_path("ydb/tests/library/compatibility/ydbd-last-stable")
+current_binary_path = kikimr_driver_path()
+
+all_binary_combinations = [
+    [last_stable_binary_path],
+    [current_binary_path],
+    [last_stable_binary_path, current_binary_path],
+]
+all_binary_combinations_ids = ["last_stable", "current", "mixed"]
+
+
+class TestStress(object):
+    @pytest.fixture(autouse=True, params=all_binary_combinations, ids=all_binary_combinations_ids)
+    def setup(self, request):
+        binary_paths = request.param
+        self.config = KikimrConfigGenerator(
+            erasure=Erasure.MIRROR_3_DC,
+            binary_paths=binary_paths,
+            # uncomment for 64 datetime in tpc-h/tpc-ds
+            # extra_feature_flags={"enable_table_datetime64": True},
+        )
+
+        self.cluster = KiKiMR(self.config)
+        self.cluster.start()
+        self.endpoint = "%s:%s" % (self.cluster.nodes[1].host, self.cluster.nodes[1].port)
+        output_path = yatest.common.test_output_path()
+        self.output_f = open(os.path.join(output_path, "out.log"), "w")
+        yield
+        self.cluster.stop()
+
+    def get_command_prefix_log(self, subcmds: list[str], path: str) -> list[str]:
+        return (
+            [
+                yatest.common.binary_path(os.getenv("YDB_CLI_BINARY")),
+                "--verbose",
+                "--endpoint",
+                "grpc://localhost:%d" % self.cluster.nodes[1].grpc_port,
+                "--database=/Root",
+                "workload",
+                "log",
+            ]
+            + subcmds
+            + ["--path", path]
+        )
+
+    def set_auto_partitioning_size_mb(self, path, size_mb):
+        yatest.common.execute(
+            [
+                yatest.common.binary_path(os.getenv("YDB_CLI_BINARY")),
+                "--verbose",
+                "--endpoint",
+                "grpc://localhost:%d" % self.cluster.nodes[1].grpc_port,
+                "--database=/Root",
+                "sql", "-s",
+                "ALTER TABLE `{}` SET (AUTO_PARTITIONING_PARTITION_SIZE_MB={})".format(path, size_mb),
+            ],
+            stdout=self.output_f,
+            stderr=self.output_f,
+        )
+
+    @pytest.mark.parametrize("store_type", ["row"])
+    def test_log(self, store_type):
+        timeout_scale = 60
+
+        upload_commands = [
+            # bulk upsert workload
+            self.get_command_prefix_log(subcmds=["run", "bulk_upsert"], path=store_type)
+            + ["--seconds", str(timeout_scale), "--threads", "10", "--rows", "2000"],
+            # upsert workload
+            self.get_command_prefix_log(subcmds=["run", "upsert"], path=store_type)
+            + ["--seconds", str(timeout_scale), "--threads", "10"],
+            # insert workload
+            self.get_command_prefix_log(subcmds=["run", "insert"], path=store_type)
+            + ["--seconds", str(timeout_scale), "--threads", "10"],
+        ]
+        # init
+        yatest.common.execute(
+            self.get_command_prefix_log(subcmds=["init"], path=store_type)
+            + [
+                "--store",
+                store_type,
+                "--min-partitions",
+                "100",
+                "--partition-size",
+                "10",
+                "--auto-partition",
+                "0",
+                "--ttl",
+                "10",
+            ],
+            stdout=self.output_f,
+            stderr=self.output_f,
+        )
+
+        yatest.common.execute(
+            self.get_command_prefix_log(subcmds=["import", "--bulk-size", "1000", "-t", "1", "generator"], path=store_type),
+            stdout=self.output_f,
+            stderr=self.output_f,
+            wait=True,
+        )
+        select = yatest.common.execute(
+            self.get_command_prefix_log(subcmds=["run", "select"], path=store_type)
+            + [
+                "--client-timeout",
+                "10000",
+                "--threads",
+                "10",
+                "--seconds",
+                str(timeout_scale * len(upload_commands)),
+            ],
+            wait=False,
+            stdout=self.output_f,
+            stderr=self.output_f,
+        )
+
+        for i, command in enumerate(upload_commands):
+            yatest.common.execute(
+                command,
+                wait=True,
+                stdout=self.output_f,
+                stderr=self.output_f,
+            )
+
+        select.wait()
+
+    @pytest.mark.skip(reason="Too huge logs")
+    @pytest.mark.parametrize("mode", ["row"])
+    def test_simple_queue(self, mode: str):
+        with Workload(f"grpc://localhost:{self.cluster.nodes[1].grpc_port}", "/Root", 180, mode) as workload:
+            for handle in workload.loop():
+                handle()
+
+    @pytest.mark.parametrize("store_type", ["row"])
+    def test_kv(self, store_type):
+        init_command_prefix = [
+            yatest.common.binary_path(os.getenv("YDB_CLI_BINARY")),
+            "--verbose",
+            "--endpoint",
+            "grpc://localhost:%d" % self.cluster.nodes[1].grpc_port,
+            "--database=/Root",
+            "workload",
+            "kv",
+            "init",
+            "--min-partitions",
+            "10",
+            "--partition-size",
+            "10",
+            "--auto-partition",
+            "0",
+            "--init-upserts",
+            "0",
+            "--cols",
+            "5",
+            "--int-cols",
+            "2",
+            "--key-cols",
+            "3",
+        ]
+
+        run_command_prefix = [
+            yatest.common.binary_path(os.getenv("YDB_CLI_BINARY")),
+            "--verbose",
+            "--endpoint",
+            "grpc://localhost:%d" % self.cluster.nodes[1].grpc_port,
+            "--database=/Root",
+            "workload",
+            "kv",
+            "run",
+            "mixed",
+            "--seconds",
+            "180",
+            "--threads",
+            "10",
+            "--cols",
+            "5",
+            "--len",
+            "200",
+            "--int-cols",
+            "2",
+            "--key-cols",
+            "3",
+        ]
+
+        init_command = init_command_prefix
+        init_command.extend(
+            [
+                "--path",
+                store_type,
+                "--store",
+                store_type,
+            ]
+        )
+        run_command = run_command_prefix
+        run_command.extend(
+            [
+                "--path",
+                store_type,
+            ]
+        )
+        yatest.common.execute(init_command, wait=True, stdout=self.output_f, stderr=self.output_f)
+        yatest.common.execute(run_command, wait=True, stdout=self.output_f, stderr=self.output_f)
+
+    @pytest.mark.parametrize("store_type", ["row"])
+    def test_tpch1(self, store_type):
+        init_command = [
+            yatest.common.binary_path(os.getenv("YDB_CLI_BINARY")),
+            "--verbose",
+            "--endpoint",
+            "grpc://localhost:%d" % self.cluster.nodes[1].grpc_port,
+            "--database=/Root",
+            "workload",
+            "tpch",
+            "-p",
+            "tpch",
+            "init",
+            "--store={}".format(store_type),
+            "--datetime",  # use 32 bit dates instead of 64 (not supported in 24-4)
+        ]
+        import_command = [
+            yatest.common.binary_path(os.getenv("YDB_CLI_BINARY")),
+            "--verbose",
+            "--endpoint",
+            "grpc://localhost:%d" % self.cluster.nodes[1].grpc_port,
+            "--database=/Root",
+            "workload",
+            "tpch",
+            "-p",
+            "tpch",
+            "import",
+            "generator",
+            "--scale=1",
+        ]
+        run_command = [
+            yatest.common.binary_path(os.getenv("YDB_CLI_BINARY")),
+            "--verbose",
+            "--endpoint",
+            "grpc://localhost:%d" % self.cluster.nodes[1].grpc_port,
+            "--database=/Root",
+            "workload",
+            "tpch",
+            "-p",
+            "tpch",
+            "run",
+            "--scale=1",
+            "--exclude",
+            # not working for row tables
+            "17",
+            "--check-canonical",
+        ]
+
+        yatest.common.execute(init_command, wait=True, stdout=self.output_f, stderr=self.output_f)
+
+        # make tables distributed across nodes
+        tables = [
+            "lineitem",
+            "nation",
+            "orders",
+            "part",
+            "partsupp",
+            "region",
+            "supplier",
+        ]
+        for table in tables:
+            self.set_auto_partitioning_size_mb("tpch/{}".format(table), 25)
+
+        yatest.common.execute(import_command, wait=True, stdout=self.output_f, stderr=self.output_f)
+        yatest.common.execute(run_command, wait=True, stdout=self.output_f, stderr=self.output_f)
+
+    @pytest.mark.skip(reason="Not stabilized yet")
+    @pytest.mark.parametrize("store_type", ["row"])
+    def test_tpcds1(self, store_type):
+        init_command = [
+            yatest.common.binary_path(os.getenv("YDB_CLI_BINARY")),
+            "--verbose",
+            "--endpoint",
+            "grpc://localhost:%d" % self.cluster.nodes[1].grpc_port,
+            "--database=/Root",
+            "workload",
+            "tpcds",
+            "-p",
+            "tpcds",
+
+            "init",
+            "--store={}".format(store_type),
+            "--datetime",  # use 32 bit dates instead of 64 (not supported in 24-4)
+        ]
+        import_command = [
+            yatest.common.binary_path(os.getenv("YDB_CLI_BINARY")),
+            "--verbose",
+            "--endpoint",
+            "grpc://localhost:%d" % self.cluster.nodes[1].grpc_port,
+            "--database=/Root",
+            "workload",
+            "tpcds",
+            "-p",
+            "tpcds",
+            "import",
+            "generator",
+            "--scale=1",
+        ]
+        run_command = [
+            yatest.common.binary_path(os.getenv("YDB_CLI_BINARY")),
+            "--verbose",
+            "--endpoint",
+            "grpc://localhost:%d" % self.cluster.nodes[1].grpc_port,
+            "--database=/Root",
+            "workload",
+            "tpcds",
+            "-p",
+            "tpcds",
+            "run",
+            "--scale=1",
+            "--check-canonical",
+            "--exclude",
+            # not working for row tables
+            "5,7,14,18,22,23,24,26,27,31,33,39,46,51,54,56,58,60,61,64,66,67,68,72,75,77,78,79,80,93",
+        ]
+
+        yatest.common.execute(init_command, wait=True, stdout=self.output_f, stderr=self.output_f)
+
+        # make table distributed across nodes
+        tables = [
+            "call_center",
+            "catalog_page",
+            "catalog_returns",
+            "catalog_sales",
+            "customer",
+            "customer_demographics",
+            "date_dim",
+            "household_demographics",
+            "income_band",
+            "inventory",
+            "item",
+            "promotion",
+            "reason",
+            "ship_mode",
+            "store",
+            "store_returns",
+            "store_sales",
+            "time_dim",
+            "warehouse",
+            "web_page",
+            "web_returns",
+            "web_sales",
+            "web_site",
+        ]
+
+        for table in tables:
+            self.set_auto_partitioning_size_mb("tpcds/{}".format(table), 25)
+
+        yatest.common.execute(import_command, wait=True, stdout=self.output_f, stderr=self.output_f)
+        yatest.common.execute(run_command, wait=True, stdout=self.output_f, stderr=self.output_f)

--- a/ydb/tests/functional/compatibility/test_stress.py
+++ b/ydb/tests/functional/compatibility/test_stress.py
@@ -56,21 +56,6 @@ class TestStress(object):
             + ["--path", path]
         )
 
-    def set_auto_partitioning_size_mb(self, path, size_mb):
-        yatest.common.execute(
-            [
-                yatest.common.binary_path(os.getenv("YDB_CLI_BINARY")),
-                "--verbose",
-                "--endpoint",
-                "grpc://localhost:%d" % self.cluster.nodes[1].grpc_port,
-                "--database=/Root",
-                "sql", "-s",
-                "ALTER TABLE `{}` SET (AUTO_PARTITIONING_PARTITION_SIZE_MB={})".format(path, size_mb),
-            ],
-            stdout=self.output_f,
-            stderr=self.output_f,
-        )
-
     @pytest.mark.parametrize("store_type", ["row"])
     def test_log(self, store_type):
         timeout_scale = 60
@@ -228,6 +213,7 @@ class TestStress(object):
             "init",
             "--store={}".format(store_type),
             "--datetime",  # use 32 bit dates instead of 64 (not supported in 24-4)
+            "--partition-size=25",
         ]
         import_command = [
             yatest.common.binary_path(os.getenv("YDB_CLI_BINARY")),
@@ -262,20 +248,6 @@ class TestStress(object):
         ]
 
         yatest.common.execute(init_command, wait=True, stdout=self.output_f, stderr=self.output_f)
-
-        # make tables distributed across nodes
-        tables = [
-            "lineitem",
-            "nation",
-            "orders",
-            "part",
-            "partsupp",
-            "region",
-            "supplier",
-        ]
-        for table in tables:
-            self.set_auto_partitioning_size_mb("tpch/{}".format(table), 25)
-
         yatest.common.execute(import_command, wait=True, stdout=self.output_f, stderr=self.output_f)
         yatest.common.execute(run_command, wait=True, stdout=self.output_f, stderr=self.output_f)
 
@@ -296,6 +268,7 @@ class TestStress(object):
             "init",
             "--store={}".format(store_type),
             "--datetime",  # use 32 bit dates instead of 64 (not supported in 24-4)
+            "--partition-size=25",
         ]
         import_command = [
             yatest.common.binary_path(os.getenv("YDB_CLI_BINARY")),
@@ -330,36 +303,5 @@ class TestStress(object):
         ]
 
         yatest.common.execute(init_command, wait=True, stdout=self.output_f, stderr=self.output_f)
-
-        # make table distributed across nodes
-        tables = [
-            "call_center",
-            "catalog_page",
-            "catalog_returns",
-            "catalog_sales",
-            "customer",
-            "customer_demographics",
-            "date_dim",
-            "household_demographics",
-            "income_band",
-            "inventory",
-            "item",
-            "promotion",
-            "reason",
-            "ship_mode",
-            "store",
-            "store_returns",
-            "store_sales",
-            "time_dim",
-            "warehouse",
-            "web_page",
-            "web_returns",
-            "web_sales",
-            "web_site",
-        ]
-
-        for table in tables:
-            self.set_auto_partitioning_size_mb("tpcds/{}".format(table), 25)
-
         yatest.common.execute(import_command, wait=True, stdout=self.output_f, stderr=self.output_f)
         yatest.common.execute(run_command, wait=True, stdout=self.output_f, stderr=self.output_f)

--- a/ydb/tests/functional/compatibility/test_stress.py
+++ b/ydb/tests/functional/compatibility/test_stress.py
@@ -242,9 +242,10 @@ class TestStress(object):
             "run",
             "--scale=1",
             "--exclude",
-            # not working for row tables
-            "17",
+            "17",  # not working for row tables
             "--check-canonical",
+            "--retries",
+            "5",  # in row tables we have to retry query by design
         ]
 
         yatest.common.execute(init_command, wait=True, stdout=self.output_f, stderr=self.output_f)
@@ -300,6 +301,8 @@ class TestStress(object):
             "--exclude",
             # not working for row tables
             "5,7,14,18,22,23,24,26,27,31,33,39,46,51,54,56,58,60,61,64,66,67,68,72,75,77,78,79,80,93",
+            "--retries",
+            "5",  # in row tables we have to retry query by design
         ]
 
         yatest.common.execute(init_command, wait=True, stdout=self.output_f, stderr=self.output_f)

--- a/ydb/tests/functional/compatibility/ya.make
+++ b/ydb/tests/functional/compatibility/ya.make
@@ -1,21 +1,26 @@
 PY3TEST()
 ENV(YDB_DRIVER_BINARY="ydb/apps/ydbd/ydbd")
+ENV(YDB_CLI_BINARY="ydb/apps/ydb/ydb")
 
 TEST_SRCS(
     test_followers.py
     test_compatibility.py
+    test_stress.py
 )
 
 SIZE(LARGE)
+REQUIREMENTS(cpu:all)
 INCLUDE(${ARCADIA_ROOT}/ydb/tests/large.inc)
 
 DEPENDS(
+    ydb/apps/ydb
     ydb/apps/ydbd
     ydb/tests/library/compatibility
 )
 
 PEERDIR(
     ydb/tests/library
+    ydb/tests/stress/simple_queue/workload
 )
 
 END()


### PR DESCRIPTION
#15206
Кросс версионный тест: запускаем tpc-h на кластере с разными версиями (24-4 и 25-1), проверяем что результат соответсвует каноничному.

Тест в состоянии выявить проблему с изменением хеш таблицы ( https://github.com/ydb-platform/ydb/pull/4364 )

Черри-пики из 
#15548
#16458 
#16449  
#16499 