### PR TITLE
Added explicit template instantiation

### DIFF
--- a/ydb/core/tablet/node_whiteboard.cpp
+++ b/ydb/core/tablet/node_whiteboard.cpp
@@ -1222,6 +1222,12 @@ template<typename TMessage>
     return defaultFields;
 }
 
+template google::protobuf::RepeatedField<int>
+GetDefaultWhiteboardFields<NKikimrWhiteboard::TSystemStateInfo>();
+
+template google::protobuf::RepeatedField<int>
+GetDefaultWhiteboardFields<NKikimrWhiteboard::TNodeStateInfo>();
+
 IActor* CreateNodeWhiteboardService() {
     return new TNodeWhiteboardService();
 }


### PR DESCRIPTION
Падает nbs сборка в ветке stable-24-3 под ub-sanitizer'ом

```

------- [LD] {default-linux-x86_64, release, usan, FAILED} $(B)/cloud/filestore/apps/vhost/filestore-vhost{, .debug}
|99.7%| [LD] {RESULT, FAILED} $(B)/cloud/filestore/apps/vhost/filestore-vhost{, .debug}
|99.7%| [TA] {RESULT, FAILED} $(B)/cloud/filestore/tests/client/test-results/py3test/{meta.json ... results_accumulator.log}
ld.lld: error: undefined symbol: google::protobuf::RepeatedField<int> NKikimr::NNodeWhiteboard::GetDefaultWhiteboardFields<NKikimrWhiteboard::TSystemStateInfo>()
>>> referenced by viewer_cluster.h:345 (/-S/contrib/ydb/core/viewer/viewer_cluster.h:345)
>>>               json_handlers_viewer.cpp.o:(NKikimr::NViewer::TJsonCluster::InitSystemWhiteboardRequest(NKikimrWhiteboard::TEvSystemStateRequest*)) in archive contrib/ydb/core/viewer/libydb-core-viewer.a
>>> referenced by viewer_tenantinfo.h:276 (/-S/contrib/ydb/core/viewer/viewer_tenantinfo.h:276)
>>>               json_handlers_viewer.cpp.o:(NKikimr::NViewer::TJsonTenantInfo::SendWhiteboardSystemStateRequest(unsigned int)) in archive contrib/ydb/core/viewer/libydb-core-viewer.a
>>> referenced by viewer_nodes.h:2052 (/-S/contrib/ydb/core/viewer/viewer_nodes.h:2052)
>>>               json_handlers_viewer.cpp.o:(void NKikimr::NViewer::TJsonNodes::InitWhiteboardRequest<NKikimrWhiteboard::TEvSystemStateRequest>(NKikimrWhiteboard::TEvSystemStateRequest*)) in archive contrib/ydb/core/viewer/libydb-core-viewer.a

ld.lld: error: undefined symbol: google::protobuf::RepeatedField<int> NKikimr::NNodeWhiteboard::GetDefaultWhiteboardFields<NKikimrWhiteboard::TNodeStateInfo>()
>>> referenced by viewer_nodes.h:2071 (/-S/contrib/ydb/core/viewer/viewer_nodes.h:2071)
>>>               json_handlers_viewer.cpp.o:(void NKikimr::NViewer::TJsonNodes::InitWhiteboardRequest<NKikimrWhiteboard::TEvNodeStateRequest>(NKikimrWhiteboard::TEvNodeStateRequest*)) in archive contrib/ydb/core/viewer/libydb-core-viewer.a
clang++: error: linker command failed with exit code 1 (use -v to see invocation)
```