### PR TITLE
25-1: TOptionsParseResult: throwing an exception in case of options parsing errors

### DIFF
--- a/ydb/public/lib/ydb_cli/common/command.cpp
+++ b/ydb/public/lib/ydb_cli/common/command.cpp
@@ -204,7 +204,7 @@ int TClientCommand::Process(TConfig& config) {
 }
 
 void TClientCommand::SaveParseResult(TConfig& config) {
-    ParseResult = std::make_shared<NLastGetopt::TOptsParseResult>(config.Opts, config.ArgC, config.ArgV);
+    ParseResult = std::make_shared<TCommandOptsParseResult>(config.Opts, config.ArgC, config.ArgV);
 }
 
 void TClientCommand::Prepare(TConfig& config) {

--- a/ydb/public/lib/ydb_cli/common/command.h
+++ b/ydb/public/lib/ydb_cli/common/command.h
@@ -326,7 +326,36 @@ public:
         }
     };
 
-    class TOptsParseOneLevelResult : public NLastGetopt::TOptsParseResult {
+    class TCommandOptsParseResult: public NLastGetopt::TOptsParseResult {
+    public:
+        TCommandOptsParseResult(const NLastGetopt::TOpts* options, int argc, const char* argv[]) {
+            Init(options, argc, argv);
+        }
+        TCommandOptsParseResult(const NLastGetopt::TOpts* options, int argc, char* argv[]) {
+            Init(options, argc, const_cast<const char**>(argv));
+        }
+        virtual ~TCommandOptsParseResult() = default;
+
+        void HandleError() const override {
+            if (ThrowOnParseError) {
+                throw;
+            }
+            NLastGetopt::TOptsParseResult::HandleError();
+        }
+
+    protected:
+        TCommandOptsParseResult() = default;
+
+        void Init(const NLastGetopt::TOpts* options, int argc, const char* argv[]) {
+            ThrowOnParseError = options->HasLongOption("throw-on-parse-error");
+            NLastGetopt::TOptsParseResult::Init(options, argc, argv);
+        }
+
+    private:
+        bool ThrowOnParseError = false;
+    };
+
+    class TOptsParseOneLevelResult : public TCommandOptsParseResult {
     public:
         TOptsParseOneLevelResult(TConfig& config);
     };


### PR DESCRIPTION
### Changelog entry

When a parsing error occurs, exit is called. This behavior is not always acceptable. For example, in the case of fuzzing testing, the process is completed. Added "throw-on-parse-error" option that allows to throw an exception instead of exiting the process.

### Changelog category

* Not for changelog (changelog entry is not required)

### Description for reviewers

PR in main #16575
