### PR TITLE
Fix ydb_configure generating dummy yaml

### DIFF
--- a/ydb/tools/cfg/utils.py
+++ b/ydb/tools/cfg/utils.py
@@ -241,7 +241,9 @@ def need_generate_bs_config(template_bs_config):
 
     return template_bs_config.get("service_set", {}).get("groups") is None
 
+
 use_alternative_yaml_handler = False
+
 
 def determine_yaml_parsing(yaml_template_file):
     ruamel_yaml = YAML()

--- a/ydb/tools/cfg/utils.py
+++ b/ydb/tools/cfg/utils.py
@@ -241,6 +241,7 @@ def need_generate_bs_config(template_bs_config):
 
     return template_bs_config.get("service_set", {}).get("groups") is None
 
+use_alternative_yaml_handler = False
 
 def determine_yaml_parsing(yaml_template_file):
     ruamel_yaml = YAML()
@@ -275,6 +276,8 @@ def sort_dict_recursively(obj):
 
 
 def dump_yaml(data):
+    global use_alternative_yaml_handler
+
     if use_alternative_yaml_handler:
         yaml = YAML()
 


### PR DESCRIPTION
### Changelog category <!-- remove all except one -->

* Not for changelog (changelog entry is not required)

### Description for reviewers <!-- (optional) description for those who read this PR -->

- there are some cases where `ydb_configure` does not read anything and just produces some dummy yaml. I broke that behavior introducing an undefined variable in https://github.com/ydb-platform/ydb/pull/16563. 
