### PR TITLE
25-1: security: database admin can not administer database admins - 2

### DIFF
--- a/ydb/core/base/local_user_token.cpp
+++ b/ydb/core/base/local_user_token.cpp
@@ -1,0 +1,22 @@
+#include <ydb/library/aclib/aclib.h>
+#include <ydb/library/login/login.h>
+#include <ydb/library/login/protos/login.pb.h>
+
+#include "local_user_token.h"
+
+namespace NKikimr {
+
+NACLib::TUserToken BuildLocalUserToken(const NLogin::TLoginProvider& loginProvider, const TString& user) {
+    const auto providerGroups = loginProvider.GetGroupsMembership(user);
+    const TVector<NACLib::TSID> groups(providerGroups.begin(), providerGroups.end());
+    //NOTE: TVector vs std::vector incompatibility between TUserToken and TLoginProvider
+    return NACLib::TUserToken(user, groups);
+}
+
+NACLib::TUserToken BuildLocalUserToken(const NLoginProto::TSecurityState& state, const TString& user) {
+    NLogin::TLoginProvider loginProvider;
+    loginProvider.UpdateSecurityState(state);
+    return BuildLocalUserToken(loginProvider, user);
+}
+
+}

--- a/ydb/core/base/local_user_token.h
+++ b/ydb/core/base/local_user_token.h
@@ -1,0 +1,23 @@
+#pragma once
+
+#include <util/generic/string.h>
+#include <ydb/library/aclib/aclib.h>
+
+
+namespace NLoginProto {
+class TSecurityState;
+}
+namespace NLogin {
+class TLoginProvider;
+}
+
+namespace NKikimr {
+
+// Recreates user token from local user login/sid and it's database login provider or security state.
+// Token should be used to determine access level only (e.g. cluster/database admin status),
+// and not for authentication.
+// See methods in ydb/core/base/auth.h.
+NACLib::TUserToken BuildLocalUserToken(const NLogin::TLoginProvider& loginProvider, const TString& user);
+NACLib::TUserToken BuildLocalUserToken(const NLoginProto::TSecurityState& state, const TString& user);
+
+}

--- a/ydb/core/base/ya.make
+++ b/ydb/core/base/ya.make
@@ -30,6 +30,8 @@ SRCS(
     group_stat.h
     hive.h
     interconnect_channels.h
+    local_user_token.cpp
+    local_user_token.h
     localdb.cpp
     localdb.h
     location.h

--- a/ydb/core/tx/schemeshard/schemeshard__login.cpp
+++ b/ydb/core/tx/schemeshard/schemeshard__login.cpp
@@ -1,6 +1,7 @@
 #include <ydb/library/security/util.h>
 #include <ydb/core/protos/auth.pb.h>
 #include <ydb/core/base/auth.h>
+#include <ydb/core/base/local_user_token.h>
 
 #include "schemeshard_impl.h"
 
@@ -89,10 +90,7 @@ struct TSchemeShard::TTxLogin : TSchemeShard::TRwTxBase {
 private:
     bool IsAdmin() const {
         const auto& user = Request->Get()->Record.GetUser();
-        const auto providerGroups = Self->LoginProvider.GetGroupsMembership(user);
-        const TVector<NACLib::TSID> groups(providerGroups.begin(), providerGroups.end());
-        const auto userToken = NACLib::TUserToken(user, groups);
-
+        const auto userToken = NKikimr::BuildLocalUserToken(Self->LoginProvider, user);
         return IsAdministrator(AppData(), &userToken);
     }
 

--- a/ydb/core/tx/schemeshard/schemeshard__operation_alter_login.cpp
+++ b/ydb/core/tx/schemeshard/schemeshard__operation_alter_login.cpp
@@ -5,6 +5,8 @@
 
 #include <ydb/library/security/util.h>
 #include <ydb/core/base/auth.h>
+#include <ydb/core/base/local_user_token.h>
+
 
 #include <ydb/core/protos/auth.pb.h>
 
@@ -293,7 +295,7 @@ public:
 
     NLogin::TLoginProvider::TBasicResponse CanRemoveSid(TOperationContext& context, const TString sid, const TString& sidType) {
         if (!AppData()->FeatureFlags.GetEnableStrictAclCheck()) {
-            return {}; 
+            return {};
         }
 
         auto subTree = context.SS->ListSubTree(context.SS->RootPathId(), context.Ctx);
@@ -316,9 +318,7 @@ public:
     }
 
     void AddIsUserAdmin(const TString& user, NLogin::TLoginProvider& loginProvider, TParts& additionalParts) {
-        const auto providerGroups = loginProvider.GetGroupsMembership(user);
-        const TVector<NACLib::TSID> groups(providerGroups.begin(), providerGroups.end());
-        const auto userToken = NACLib::TUserToken(user, groups);
+        const auto userToken = NKikimr::BuildLocalUserToken(loginProvider, user);
 
         if (IsAdministrator(AppData(), &userToken)) {
             additionalParts.emplace_back("login_user_level", "admin");

--- a/ydb/core/tx/tx_proxy/ya.make
+++ b/ydb/core/tx/tx_proxy/ya.make
@@ -51,6 +51,7 @@ PEERDIR(
     ydb/core/tx/tx_allocator
     ydb/core/tx/tx_allocator_client
     ydb/library/aclib
+    ydb/library/login
     ydb/library/mkql_proto/protos
     ydb/public/lib/base
 )

--- a/ydb/library/login/login.cpp
+++ b/ydb/library/login/login.cpp
@@ -329,7 +329,7 @@ TLoginProvider::TRemoveGroupResponse TLoginProvider::RemoveGroup(const TString& 
     return response;
 }
 
-std::vector<TString> TLoginProvider::GetGroupsMembership(const TString& member) {
+std::vector<TString> TLoginProvider::GetGroupsMembership(const TString& member) const {
     std::vector<TString> groups;
     std::unordered_set<TString> visited;
     std::deque<TString> queue;

--- a/ydb/library/login/login.h
+++ b/ydb/library/login/login.h
@@ -212,7 +212,7 @@ public:
     TLoginProvider(const TPasswordComplexity& passwordComplexity, const TAccountLockout::TInitializer& accountLockoutInitializer);
     ~TLoginProvider();
 
-    std::vector<TString> GetGroupsMembership(const TString& member);
+    std::vector<TString> GetGroupsMembership(const TString& member) const;
     static TString GetTokenAudience(const TString& token);
     static std::chrono::system_clock::time_point GetTokenExpiresAt(const TString& token);
     static TString SanitizeJwtToken(const TString& token);


### PR DESCRIPTION
Merge from `main`:
- 1d66589 -- https://github.com/ydb-platform/ydb/pull/16679

Database admin is not allowed to make changes to other database admins. Only cluster admins can.

Database admins:
- cannot change passwords or login blocking flags for other database admins
- cannot change their own login blocking flags
- can change their own passwords
