### PR TITLE
Support for distconf explicit configuring of state storage and static groups

### DIFF
--- a/ydb/core/blobstorage/nodewarden/distconf_invoke_static_group.cpp
+++ b/ydb/core/blobstorage/nodewarden/distconf_invoke_static_group.cpp
@@ -8,6 +8,9 @@ namespace NKikimr::NStorage {
         if (!RunCommonChecks()) {
             return;
         }
+        if (cmd.GetFromSelfHeal() && !Self->StorageConfig->GetSelfManagementConfig().GetAutomaticStaticGroupManagement()) {
+            return FinishWithError(TResult::ERROR, "operation forbidden: automatic static group management disabled");
+        }
 
         bool found = false;
         const TVDiskID vdiskId = VDiskIDFromVDiskID(cmd.GetVDiskId());

--- a/ydb/core/blobstorage/nodewarden/node_warden_impl.cpp
+++ b/ydb/core/blobstorage/nodewarden/node_warden_impl.cpp
@@ -1540,6 +1540,15 @@ bool NKikimr::NStorage::DeriveStorageConfig(const NKikimrConfig::TAppConfig& app
                     break;
                 }
             }
+
+#define UPDATE_EXPLICIT_CONFIG(NAME) \
+            if (domains.HasExplicit##NAME##Config()) { \
+                config->Mutable##NAME##Config()->CopyFrom(domains.GetExplicit##NAME##Config()); \
+            }
+
+            UPDATE_EXPLICIT_CONFIG(StateStorage)
+            UPDATE_EXPLICIT_CONFIG(StateStorageBoard)
+            UPDATE_EXPLICIT_CONFIG(SchemeBoard)
         }
     }
 

--- a/ydb/core/mind/bscontroller/self_heal.cpp
+++ b/ydb/core/mind/bscontroller/self_heal.cpp
@@ -158,6 +158,7 @@ namespace NKikimr::NBsController {
                 VDiskIDFromVDiskID(*VDiskToReplace, cmd->MutableVDiskId());
                 cmd->SetConvertToDonor(DonorMode);
                 cmd->SetIsSelfHealReasonDecommit(IsSelfHealReasonDecommit);
+                cmd->SetFromSelfHeal(true);
                 Send(MakeBlobStorageNodeWardenID(SelfId().NodeId()), ev.release());
                 return;
             }

--- a/ydb/core/protos/blobstorage_distributed_config.proto
+++ b/ydb/core/protos/blobstorage_distributed_config.proto
@@ -167,6 +167,7 @@ message TEvNodeConfigInvokeOnRoot {
         bool IgnoreDegradedGroupsChecks = 5;
         bool IgnoreVSlotQuotaCheck = 6;
         bool IsSelfHealReasonDecommit = 7;
+        bool FromSelfHeal = 8;
     }
 
     // Regenerate configuration so the slain VDisk is no more reported as DESTROY one in the list.

--- a/ydb/core/protos/config.proto
+++ b/ydb/core/protos/config.proto
@@ -278,6 +278,11 @@ message TDomainsConfig {
     repeated TNamedCompactionPolicy NamedCompactionPolicy = 5;
     optional TSecurityConfig SecurityConfig = 6;
     optional bool ForbidImplicitStoragePools = 7 [default = true];
+
+    // then these configs are set, they override the default StateStorage config for each kind of entity
+    optional TStateStorage ExplicitStateStorageConfig = 8;
+    optional TStateStorage ExplicitStateStorageBoardConfig = 9;
+    optional TStateStorage ExplicitSchemeBoardConfig = 10;
 }
 
 message TBlobStorageConfig {
@@ -343,6 +348,10 @@ message TSelfManagementConfig {
     // some extra settings
     optional bool AutomaticBoxManagement = 21 [default = true]; // invoke BSC DefineHostConfig/DefineBox automatically
     optional bool AutomaticBootstrap = 22; // whether bootstrap should be performed automatically; PROHIBITED for production
+    optional bool AutomaticStaticGroupManagement = 23; // whether distconf/SelfHeal can change static group on its behalf
+    optional bool AutomaticStateStorageManagement = 24; // the same for state storage
+    optional bool AutomaticStateStorageBoardManagement = 25; // the same for state storage board
+    optional bool AutomaticSchemeBoardManagement = 26; // the same for scheme board
 }
 
 message TBlobStorageFormatConfig {


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

Support for distconf explicit configuring of state storage and static groups

### Changelog category <!-- remove all except one -->

* Not for changelog (changelog entry is not required)

### Description for reviewers <!-- (optional) description for those who read this PR -->

Stub for configuration files to support distconf explicit setting of state storage and static blobstorage configurations
through "cluster config replace" mechanism.
