### PR TITLE
Delete garbage from decommissioned group while assimilating

### DIFF
--- a/ydb/core/blob_depot/agent/query.cpp
+++ b/ydb/core/blob_depot/agent/query.cpp
@@ -29,6 +29,10 @@ namespace NKikimr::NBlobDepot {
                 doForward = ev->Get<TEvBlobStorage::TEvRange>()->Decommission;
                 Y_ABORT_UNLESS(!doForward || !ev->Get<TEvBlobStorage::TEvRange>()->MustRestoreFirst);
                 break;
+
+            case TEvBlobStorage::EvCollectGarbage:
+                doForward = ev->Get<TEvBlobStorage::TEvCollectGarbage>()->Decommission;
+                break;
         }
 
         if (doForward) {

--- a/ydb/core/blob_depot/blob_depot_tablet.h
+++ b/ydb/core/blob_depot/blob_depot_tablet.h
@@ -335,6 +335,10 @@ namespace NKikimr::NBlobDepot {
             ui64 BlobsPutOk = 0;
             ui64 BlobsPutError = 0;
             ui32 CopyIteration = 0;
+            ui32 CollectGarbageInFlight = 0;
+            ui32 CollectGarbageQueue = 0;
+            ui32 CollectGarbageOK = 0;
+            ui32 CollectGarbageError = 0;
 
             void ToJson(NJson::TJsonValue& json, bool pretty) const;
         } AsStats;
@@ -343,6 +347,8 @@ namespace NKikimr::NBlobDepot {
 
         void StartGroupAssimilator();
         void OnUpdateDecommitState();
+
+        ui32 PerGenerationCounter = 1;
 
         ////////////////////////////////////////////////////////////////////////////////////////////////////////////////
         // Group metrics exchange

--- a/ydb/core/blob_depot/data.h
+++ b/ydb/core/blob_depot/data.h
@@ -761,6 +761,9 @@ namespace NKikimr::NBlobDepot {
         void ExecuteTxCommitAssimilatedBlob(std::vector<TAssimilatedBlobInfo>&& blobs, ui32 notifyEventType,
             TActorId parentId, ui64 cookie);
 
+        class TTxHardCollectAssimilatedBlobs;
+        void ExecuteTxHardCollectAssimilatedBlobs(ui64 tabletId, ui8 channel, TGenStep barrier, TActorId parentId);
+
         class TTxResolve;
         void ExecuteTxResolve(TEvBlobDepot::TEvResolve::TPtr ev, THashSet<TLogoBlobID>&& resolutionErrors = {});
 

--- a/ydb/core/blob_depot/mon_main.cpp
+++ b/ydb/core/blob_depot/mon_main.cpp
@@ -538,6 +538,10 @@ document.addEventListener("DOMContentLoaded", ready);
                             KEYVALUE_UP("Blobs read with error", "d.blobs_read_error", AsStats.BlobsReadError);
                             KEYVALUE_UP("Blobs put with OK", "d.blobs_put_ok", AsStats.BlobsPutOk);
                             KEYVALUE_UP("Blobs put with error", "d.blobs_put_error", AsStats.BlobsPutError);
+                            KEYVALUE_UP("CollectGarbage in flight", "d.collect_garbage_in_flight", AsStats.CollectGarbageInFlight);
+                            KEYVALUE_UP("CollectGarbage queue", "d.collect_garbage_queue", AsStats.CollectGarbageQueue);
+                            KEYVALUE_UP("CollectGarbage OK", "d.collect_garbage_ok", AsStats.CollectGarbageOK);
+                            KEYVALUE_UP("CollectGarbage error", "d.collect_garbage_error", AsStats.CollectGarbageError);
                         })
                     }
                 }

--- a/ydb/core/blob_depot/op_load.cpp
+++ b/ydb/core/blob_depot/op_load.cpp
@@ -38,6 +38,9 @@ namespace NKikimr::NBlobDepot {
                         if (table.HaveValue<Schema::Config::AssimilatorState>()) {
                             Self->AssimilatorState.emplace(table.GetValue<Schema::Config::AssimilatorState>());
                         }
+                        if (table.HaveValue<Schema::Config::PerGenerationCounter>()) {
+                            Self->PerGenerationCounter = table.GetValue<Schema::Config::PerGenerationCounter>();
+                        }
                     }
                 }
 

--- a/ydb/core/blob_depot/schema.h
+++ b/ydb/core/blob_depot/schema.h
@@ -20,13 +20,15 @@ namespace NKikimr::NBlobDepot {
             struct ConfigProtobuf : Column<2, NScheme::NTypeIds::String> {};
             struct DecommitState : Column<3, NScheme::NTypeIds::Uint32> { using Type = EDecommitState; static constexpr Type Default = EDecommitState::Default; };
             struct AssimilatorState : Column<4, NScheme::NTypeIds::String> {};
+            struct PerGenerationCounter : Column<5, NScheme::NTypeIds::Uint32> {};
 
             using TKey = TableKey<Key>;
             using TColumns = TableColumns<
                 Key,
                 ConfigProtobuf,
                 DecommitState,
-                AssimilatorState
+                AssimilatorState,
+                PerGenerationCounter
             >;
         };
 

--- a/ydb/core/protos/counters_blob_depot.proto
+++ b/ydb/core/protos/counters_blob_depot.proto
@@ -82,4 +82,5 @@ enum ETxTypes {
     TXTYPE_PROCESS_SCANNED_KEYS = 19 [(NKikimr.TxTypeOpts) = {Name: "TTxProcessScannedKeys"}];
     TXTYPE_DECOMMIT_BLOBS = 20 [(NKikimr.TxTypeOpts) = {Name: "TTxDecommitBlobs"}];
     TXTYPE_PREPARE = 21 [(NKikimr.TxTypeOpts) = {Name: "TTxPrepare"}];
+    TXTYPE_HARD_COLLECT_ASSIMILATED_BLOBS = 22 [(NKikimr.TxTypeOpts) = {Name: "TTxHardCollectAssimilatedBlobs"}];
 }


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

Delete garbage from decommissioned group while assimilating

### Changelog category <!-- remove all except one -->

* Not for changelog (changelog entry is not required)

### Description for reviewers <!-- (optional) description for those who read this PR -->

This commit allows BlobDepot to delete already assimilated blobs to prevent excessive storage usage. Otherwise group
being decommitted effectively doubles its space consumption.
