### PR TITLE
Moved the parameter throw-on-parse-error from the options

### DIFF
--- a/ydb/public/lib/ydb_cli/common/client_command_options.cpp
+++ b/ydb/public/lib/ydb_cli/common/client_command_options.cpp
@@ -417,9 +417,9 @@ TAnonymousAuthMethodOption::TAnonymousAuthMethodOption(TClientCommandOptions* cl
 }
 
 
-TOptionsParseResult::TOptionsParseResult(const TClientCommandOptions* options, int argc, const char** argv)
+TOptionsParseResult::TOptionsParseResult(const TClientCommandOptions* options, int argc, const char** argv, bool throwOnParseError)
     : ClientOptions(options)
-    , ParseFromCommandLineResult(&options->GetOpts(), argc, argv)
+    , ParseFromCommandLineResult(&options->GetOpts(), argc, argv, throwOnParseError)
 {
     for (const auto& clientOption : ClientOptions->ClientOpts) {
         if (const auto* optResult = ParseFromCommandLineResult.FindOptParseResult(&clientOption->GetOpt())) {

--- a/ydb/public/lib/ydb_cli/common/client_command_options.h
+++ b/ydb/public/lib/ydb_cli/common/client_command_options.h
@@ -353,8 +353,8 @@ private:
 
 class TCommandOptsParseResult: public NLastGetopt::TOptsParseResult {
 public:
-    TCommandOptsParseResult(const NLastGetopt::TOpts* options, int argc, const char* argv[])
-        : ThrowOnParseError(options->HasLongOption("throw-on-parse-error")) {
+    TCommandOptsParseResult(const NLastGetopt::TOpts* options, int argc, const char* argv[], bool throwOnParseError = false)
+        : ThrowOnParseError(throwOnParseError) {
         Init(options, argc, argv);
     }
 
@@ -377,7 +377,7 @@ public:
     using TConnectionParamsLogger = std::function<void(const TString& /*paramName*/, const TString& /*value*/, const TString& /*sourceText*/)>;
 
 public:
-    TOptionsParseResult(const TClientCommandOptions* options, int argc, const char** argv);
+    TOptionsParseResult(const TClientCommandOptions* options, int argc, const char** argv, bool throwOnParseError = false);
 
     // Parses from profile and env. Returns erros if they occur during parsing
     std::vector<TString> ParseFromProfilesAndEnv(std::shared_ptr<IProfile> explicitProfile, std::shared_ptr<IProfile> activeProfile);

--- a/ydb/public/lib/ydb_cli/common/command.cpp
+++ b/ydb/public/lib/ydb_cli/common/command.cpp
@@ -161,7 +161,7 @@ std::pair<int, const char**> TClientCommand::TOptsParseOneLevelResult::GetArgv(T
 }
 
 TClientCommand::TOptsParseOneLevelResult::TOptsParseOneLevelResult(TConfig& config, std::pair<int, const char**> argv)
-    : TOptionsParseResult(config.Opts, argv.first, argv.second)
+    : TOptionsParseResult(config.Opts, argv.first, argv.second, config.ThrowOnOptsParseError)
 {
 }
 
@@ -236,7 +236,7 @@ int TClientCommand::Process(TConfig& config) {
 }
 
 void TClientCommand::SaveParseResult(TConfig& config) {
-    ParseResult = std::make_shared<TOptionsParseResult>(config.Opts, config.ArgC, (const char**)config.ArgV);
+    ParseResult = std::make_shared<TOptionsParseResult>(config.Opts, config.ArgC, (const char**)config.ArgV, config.ThrowOnOptsParseError);
 
     // Parse options from env and apply default parameters.
     // Parsing from profiles is only supported at high level commands and occure in ExtractParams() stage.

--- a/ydb/public/lib/ydb_cli/common/command.h
+++ b/ydb/public/lib/ydb_cli/common/command.h
@@ -170,6 +170,8 @@ public:
         TCredentialsGetter CredentialsGetter;
         std::shared_ptr<ICredentialsProviderFactory> SingletonCredentialsProviderFactory = nullptr;
 
+        bool ThrowOnOptsParseError = false;
+
         TConfig(int argc, char** argv)
             : ArgC(argc)
             , ArgV(argv)


### PR DESCRIPTION
### Changelog entry

Moved the parameter "throw-on-parse-error" from options to the constructors signature.

### Changelog category

* Not for changelog (changelog entry is not required)

### Description for reviewers

