### PR TITLE
YDB FQ: enable pushdown of string types in Generic provider

### DIFF
--- a/ydb/library/yql/providers/generic/provider/yql_generic_physical_opt.cpp
+++ b/ydb/library/yql/providers/generic/provider/yql_generic_physical_opt.cpp
@@ -27,7 +27,13 @@ namespace NYql {
                 : NPushdown::TSettings(NLog::EComponent::ProviderGeneric)
             {
                 using EFlag = NPushdown::TSettings::EFeatureFlag;
-                Enable(EFlag::ExpressionAsPredicate | EFlag::ArithmeticalExpressions | EFlag::ImplicitConversionToInt64 | EFlag::DateTimeTypes | EFlag::TimestampCtor);
+                Enable(
+                    EFlag::ExpressionAsPredicate | 
+                    EFlag::ArithmeticalExpressions | 
+                    EFlag::ImplicitConversionToInt64 | 
+                    EFlag::DateTimeTypes |
+                    EFlag::TimestampCtor |
+                    EFlag::StringTypes);
             }
         };
 


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

* YDB FQ: enable pushdown of string types in Generic provider

### Changelog category <!-- remove all except one -->

* New feature

### Description for reviewers <!-- (optional) description for those who read this PR -->

...
