### PR TITLE
Fix stats collection for long tasks

### DIFF
--- a/ydb/core/kqp/executer_actor/kqp_executer_stats.cpp
+++ b/ydb/core/kqp/executer_actor/kqp_executer_stats.cpp
@@ -942,8 +942,10 @@ void TQueryExecutionStats::AddComputeActorStats(ui32 /* nodeId */, NYql::NDqProt
         // TODO(ilezhankin): investigate - for some reason `task.FinishTimeMs` may be large (or small?)
         //      enough to result in an enormous duration - triggering the "long tasks" mode.
 
-        auto taskDuration = TDuration::MilliSeconds(task.GetFinishTimeMs() > task.GetStartTimeMs()
-            ? task.GetFinishTimeMs() - task.GetStartTimeMs() : 0);
+        auto taskDuration = TDuration::MilliSeconds(
+            task.GetStartTimeMs() != 0 && task.GetFinishTimeMs() >= task.GetStartTimeMs()
+            ? task.GetFinishTimeMs() - task.GetStartTimeMs()
+            : 0);
         auto& longestTaskDuration = LongestTaskDurations[task.GetStageId()];
         if (taskDuration > Max(collectLongTaskStatsTimeout, longestTaskDuration)) {
             CollectStatsByLongTasks = true;
@@ -1089,8 +1091,10 @@ void TQueryExecutionStats::AddDatashardStats(NYql::NDqProto::TDqComputeActorStat
 
         // checking whether the task is long
 
-        auto taskDuration = TDuration::MilliSeconds(task.GetFinishTimeMs() > task.GetStartTimeMs()
-            ? task.GetFinishTimeMs() - task.GetStartTimeMs() : 0);
+        auto taskDuration = TDuration::MilliSeconds(
+            task.GetStartTimeMs() != 0 && task.GetFinishTimeMs() >= task.GetStartTimeMs()
+            ? task.GetFinishTimeMs() - task.GetStartTimeMs()
+            : 0);
         auto& longestTaskDuration = LongestTaskDurations[task.GetStageId()];
         if (taskDuration > Max(collectLongTaskStatsTimeout, longestTaskDuration)) {
             CollectStatsByLongTasks = true;

--- a/ydb/core/kqp/executer_actor/kqp_executer_stats.cpp
+++ b/ydb/core/kqp/executer_actor/kqp_executer_stats.cpp
@@ -942,7 +942,8 @@ void TQueryExecutionStats::AddComputeActorStats(ui32 /* nodeId */, NYql::NDqProt
         // TODO(ilezhankin): investigate - for some reason `task.FinishTimeMs` may be large (or small?)
         //      enough to result in an enormous duration - triggering the "long tasks" mode.
 
-        auto taskDuration = TDuration::MilliSeconds(task.GetFinishTimeMs() - task.GetStartTimeMs());
+        auto taskDuration = TDuration::MilliSeconds(task.GetFinishTimeMs() > task.GetStartTimeMs()
+            ? task.GetFinishTimeMs() - task.GetStartTimeMs() : 0);
         auto& longestTaskDuration = LongestTaskDurations[task.GetStageId()];
         if (taskDuration > Max(collectLongTaskStatsTimeout, longestTaskDuration)) {
             CollectStatsByLongTasks = true;
@@ -1088,7 +1089,8 @@ void TQueryExecutionStats::AddDatashardStats(NYql::NDqProto::TDqComputeActorStat
 
         // checking whether the task is long
 
-        auto taskDuration = TDuration::MilliSeconds(task.GetFinishTimeMs() - task.GetStartTimeMs());
+        auto taskDuration = TDuration::MilliSeconds(task.GetFinishTimeMs() > task.GetStartTimeMs()
+            ? task.GetFinishTimeMs() - task.GetStartTimeMs() : 0);
         auto& longestTaskDuration = LongestTaskDurations[task.GetStageId()];
         if (taskDuration > Max(collectLongTaskStatsTimeout, longestTaskDuration)) {
             CollectStatsByLongTasks = true;


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

### Changelog category <!-- remove all except one -->

* Not for changelog (changelog entry is not required)

### Description for reviewers <!-- (optional) description for those who read this PR -->

Some short tasks could be considered long and cause heavy profile stats collection.