### PR TITLE
Fix comp nodes logging in case when it's disabled

### DIFF
--- a/ydb/core/kqp/ut/runtime/kqp_scan_logging_ut.cpp
+++ b/ydb/core/kqp/ut/runtime/kqp_scan_logging_ut.cpp
@@ -1,5 +1,5 @@
-#include <contrib/ydb/core/kqp/ut/common/kqp_ut_common.h>
-#include <contrib/ydb/core/kqp/counters/kqp_counters.h>
+#include <ydb/core/kqp/ut/common/kqp_ut_common.h>
+#include <ydb/core/kqp/counters/kqp_counters.h>
 
 #include <util/system/fs.h>
 

--- a/ydb/core/kqp/ut/runtime/kqp_scan_logging_ut.cpp
+++ b/ydb/core/kqp/ut/runtime/kqp_scan_logging_ut.cpp
@@ -1,5 +1,5 @@
-#include <ydb/core/kqp/ut/common/kqp_ut_common.h>
-#include <ydb/core/kqp/counters/kqp_counters.h>
+#include <contrib/ydb/core/kqp/ut/common/kqp_ut_common.h>
+#include <contrib/ydb/core/kqp/counters/kqp_counters.h>
 
 #include <util/system/fs.h>
 
@@ -31,13 +31,15 @@ void FillTableWithData(NQuery::TQueryClient& db, ui64 numRows=300) {
     }
 }
 
-void RunTestForQuery(const std::string& query, const std::string& expectedLog) {
+void RunTestForQuery(const std::string& query, const std::string& expectedLog, bool enabledLogs) {
     TStringStream logsStream;
 
     Cerr << "cwd: " << NFs::CurrentWorkingDirectory() << Endl;
     TKikimrRunner kikimr(AppSettings(logsStream));
 
-    kikimr.GetTestServer().GetRuntime()->SetLogPriority(NKikimrServices::KQP_TASKS_RUNNER, NActors::NLog::PRI_DEBUG);
+    if (enabledLogs) {
+        kikimr.GetTestServer().GetRuntime()->SetLogPriority(NKikimrServices::KQP_TASKS_RUNNER, NActors::NLog::PRI_DEBUG);
+    }
 
     auto db = kikimr.GetQueryClient();
 
@@ -64,25 +66,27 @@ void RunTestForQuery(const std::string& query, const std::string& expectedLog) {
             break;
         }
     }
-    // TODO: Uncomment after: https://github.com/ydb-platform/ydb/issues/15597
-    Y_UNUSED(hasExpectedLog);
-    // UNIT_ASSERT(hasExpectedLog);
+
+    // TODO: remove this if after https://github.com/ydb-platform/ydb/issues/15597
+    if (!enabledLogs) {
+        UNIT_ASSERT(hasExpectedLog == enabledLogs);
+    }
 }
 
 } // anonymous namespace
 
 Y_UNIT_TEST_SUITE(KqpScanLogs) {
 
-Y_UNIT_TEST(WideCombine) {
+Y_UNIT_TEST_TWIN(WideCombine, EnabledLogs) {
     auto query = R"(
         --!syntax_v1
         select count(t.Key) from `/Root/KeyValue` as t group by t.Value
     )";
 
-    RunTestForQuery(query, "[WideCombine]");
+    RunTestForQuery(query, "[WideCombine]", EnabledLogs);
 }
 
-Y_UNIT_TEST(GraceJoin) {
+Y_UNIT_TEST_TWIN(GraceJoin, EnabledLogs) {
     auto query = R"(
         --!syntax_v1
         PRAGMA ydb.CostBasedOptimizationLevel='0';
@@ -92,7 +96,7 @@ Y_UNIT_TEST(GraceJoin) {
         order by t1.Value
     )";
 
-    RunTestForQuery(query, "[GraceJoin]");
+    RunTestForQuery(query, "[GraceJoin]", EnabledLogs);
 }
 
 

--- a/ydb/library/yql/dq/runtime/dq_tasks_runner.cpp
+++ b/ydb/library/yql/dq/runtime/dq_tasks_runner.cpp
@@ -264,9 +264,8 @@ public:
             logProviderFunc = [log=LogFunc](const NUdf::TStringRef& component, NUdf::ELogLevel level, const NUdf::TStringRef& message) {
                 log(TStringBuilder() << "[" << component << "][" << level << "]: " << message << "\n");
             };
+            ComputationLogProvider = NUdf::MakeLogProvider(std::move(logProviderFunc), NUdf::ELogLevel::Debug);
         }
-
-        ComputationLogProvider = NUdf::MakeLogProvider(std::move(logProviderFunc), NUdf::ELogLevel::Debug);
     }
 
     ~TDqTaskRunner() {


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->
There was a problem with git->arc and arc->git syncs. Because logger in dq_tasks_runner (merged in git) was incompatible with comp nodes logging (merged in arc). When logging is turned off, the logger should be nullptr. But initially it was done so that the logger would not be nullptr, but the logging function inside the logger was empty. Which led to std::bad_function_call exception during the sync.

Arc changes were reverted here: https://a.yandex-team.ru/review/8380329/commits

Exception bt: https://paste.yandex-team.ru/fb6d23ba-8c02-4d2b-b32c-e5cfcc877dbb
...

### Changelog category <!-- remove all except one -->

* Bugfix 


### Description for reviewers <!-- (optional) description for those who read this PR -->

...
