### PR TITLE
Treat directories recursively in export API

### DIFF
--- a/ydb/core/tx/schemeshard/schemeshard_info_types.h
+++ b/ydb/core/tx/schemeshard/schemeshard_info_types.h
@@ -2835,6 +2835,11 @@ struct TExportInfo: public TSimpleRefCount<TExportInfo> {
 
     TString ToString() const;
 
+    template <typename TSettingsPB>
+    void SetSettings(const TSettingsPB& settingsPb) {
+        Settings = SerializeSettings(settingsPb);
+    }
+
 private:
     template <typename TSettingsPB>
     static TString SerializeSettings(const TSettingsPB& settings) {
@@ -3383,7 +3388,7 @@ struct TIndexBuildInfo: public TSimpleRefCount<TIndexBuildInfo> {
             return result;
         }
     };
-    
+
     TMap<TShardIdx, TShardStatus> Shards;
     TDeque<TShardIdx> ToUploadShards;
     THashSet<TShardIdx> InProgressShards;

--- a/ydb/core/tx/schemeshard/schemeshard_path.cpp
+++ b/ydb/core/tx/schemeshard/schemeshard_path.cpp
@@ -940,13 +940,7 @@ const TPath::TChecker& TPath::TChecker::IsSupportedInExports(EStatus status) con
         return *this;
     }
 
-    // Warning: scheme objects using YQL backups should only be allowed to be exported
-    // when we can be certain that the database will never be downgraded to a version
-    // which does not support the YQL export process. Otherwise, they will be considered as tables,
-    // and we might cause the process to be aborted.
-    if (Path.Base()->IsTable()
-        || (Path.Base()->IsView() && AppData()->FeatureFlags.GetEnableViewExport())
-    )  {
+    if (Path.IsSupportedInExports()) {
         return *this;
     }
 
@@ -1763,6 +1757,18 @@ bool TPath::IsTransfer() const {
     Y_ABORT_UNLESS(IsResolved());
 
     return Base()->IsTransfer();
+}
+
+bool TPath::IsSupportedInExports() const {
+    Y_ABORT_UNLESS(IsResolved());
+
+    // Warning: scheme objects using YQL backups should only be allowed to be exported
+    // when we can be certain that the database will never be downgraded to a version
+    // which does not support the YQL export process. Otherwise, they will be considered as tables,
+    // and we might cause the process to be aborted.
+    return (Base()->IsTable()
+        || (Base()->IsView() && AppData()->FeatureFlags.GetEnableViewExport())
+    );
 }
 
 ui32 TPath::Depth() const {

--- a/ydb/core/tx/schemeshard/schemeshard_path.h
+++ b/ydb/core/tx/schemeshard/schemeshard_path.h
@@ -177,6 +177,7 @@ public:
     bool IsSequence() const;
     bool IsReplication() const;
     bool IsTransfer() const;
+    bool IsSupportedInExports() const;
     ui32 Depth() const;
     ui64 Shards() const;
     const TString& LeafName() const;


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

...

### Changelog category <!-- remove all except one -->

* Not for changelog (changelog entry is not required)

### Description for reviewers <!-- (optional) description for those who read this PR -->

According to RFC: https://github.com/ydb-platform/ydb-rfc/blob/main/backup_encryption.md
If we got directory in export call, make a list of export items from it.
Visit only objects that are supported for export.
