### PR TITLE
TOptionsParseResult: throwing an exception in case of options parsing errors

### DIFF
--- a/ydb/public/lib/ydb_cli/common/command.cpp
+++ b/ydb/public/lib/ydb_cli/common/command.cpp
@@ -120,7 +120,8 @@ std::shared_ptr<ICredentialsProviderFactory> TClientCommand::TConfig::GetSinglet
     return SingletonCredentialsProviderFactory;
 }
 
-TClientCommand::TOptsParseOneLevelResult::TOptsParseOneLevelResult(TConfig& config) {
+TClientCommand::TOptsParseOneLevelResult::TOptsParseOneLevelResult(TConfig& config)
+    : TCommandOptsParseResult(config.ThrowOnOptsParseError) {
     int _argc = 1;
     int levels = 1;
 
@@ -204,7 +205,7 @@ int TClientCommand::Process(TConfig& config) {
 }
 
 void TClientCommand::SaveParseResult(TConfig& config) {
-    ParseResult = std::make_shared<NLastGetopt::TOptsParseResult>(config.Opts, config.ArgC, config.ArgV);
+    ParseResult = std::make_shared<TCommandOptsParseResult>(config.Opts, config.ArgC, config.ArgV, config.ThrowOnOptsParseError);
 }
 
 void TClientCommand::Prepare(TConfig& config) {

--- a/ydb/public/lib/ydb_cli/common/command.h
+++ b/ydb/public/lib/ydb_cli/common/command.h
@@ -166,6 +166,8 @@ public:
         TCredentialsGetter CredentialsGetter;
         std::shared_ptr<ICredentialsProviderFactory> SingletonCredentialsProviderFactory = nullptr;
 
+        bool ThrowOnOptsParseError = false;
+
         TConfig(int argc, char** argv)
             : ArgC(argc)
             , ArgV(argv)
@@ -326,7 +328,30 @@ public:
         }
     };
 
-    class TOptsParseOneLevelResult : public NLastGetopt::TOptsParseResult {
+    class TCommandOptsParseResult: public NLastGetopt::TOptsParseResult {
+    public:
+        TCommandOptsParseResult(const NLastGetopt::TOpts* options, int argc, char* argv[], bool throwOnParseError)
+            : ThrowOnParseError(throwOnParseError) {
+            Init(options, argc, const_cast<const char**>(argv));
+        }
+        virtual ~TCommandOptsParseResult() = default;
+
+        void HandleError() const override {
+            if (ThrowOnParseError) {
+                throw;
+            }
+            NLastGetopt::TOptsParseResult::HandleError();
+        }
+
+    protected:
+        TCommandOptsParseResult(bool throwOnParseError)
+            : ThrowOnParseError(throwOnParseError) {}
+
+    private:
+        bool ThrowOnParseError = false;
+    };
+
+    class TOptsParseOneLevelResult : public TCommandOptsParseResult {
     public:
         TOptsParseOneLevelResult(TConfig& config);
     };


### PR DESCRIPTION
### Changelog entry

When a parsing error occurs, exit is called. This behavior is not always acceptable. For example, in the case of fuzzing testing, the process is completed. Added ThrowOnParseError option that allows to throw an exception instead of exiting the process.

### Changelog category

* Not for changelog (changelog entry is not required)

### Description for reviewers
