### PR TITLE
Fix INTERNAL_ERROR on not existing resource or coordination node in rate limiter

### DIFF
--- a/ydb/core/grpc_services/rpc_rate_limiter_api.cpp
+++ b/ydb/core/grpc_services/rpc_rate_limiter_api.cpp
@@ -178,7 +178,7 @@ protected:
     void Handle(TEvTxProxySchemeCache::TEvNavigateKeySetResult::TPtr& ev) {
         THolder<NSchemeCache::TSchemeCacheNavigate> navigate = std::move(ev->Get()->Request);
         if (navigate->ResultSet.size() != 1 || navigate->ErrorCount > 0) {
-            this->Reply(StatusIds::INTERNAL_ERROR, this->ActorContext());
+            this->Reply(StatusIds::SCHEME_ERROR, this->ActorContext());
             return;
         }
 
@@ -548,7 +548,7 @@ public:
         if (kesusError.GetStatus() == Ydb::StatusIds::SUCCESS) {
             Ydb::RateLimiter::DescribeResourceResult result;
             if (ev->Get()->Record.ResourcesSize() == 0) {
-                this->Reply(StatusIds::INTERNAL_ERROR, "No resource properties found.", NKikimrIssues::TIssuesIds::DEFAULT_ERROR, this->ActorContext());
+                this->Reply(StatusIds::SCHEME_ERROR, "No resource properties found.", NKikimrIssues::TIssuesIds::DEFAULT_ERROR, this->ActorContext());
                 return;
             }
             CopyProps(ev->Get()->Record.GetResources(0), *result.mutable_resource());


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

RateLimiter service: INTERNAL_ERROR replaced with SCHEME_ERROR when using not existing coordination nodes or resources.
https://github.com/ydb-platform/ydb/issues/16914

### Changelog category <!-- remove all except one -->

* Bugfix 

### Description for reviewers <!-- (optional) description for those who read this PR -->

...
