### PR TITLE
Vector Index Local KMeans with one scan

### DIFF
--- a/ydb/core/tx/datashard/datashard_ut_local_kmeans.cpp
+++ b/ydb/core/tx/datashard/datashard_ut_local_kmeans.cpp
@@ -848,6 +848,24 @@ Y_UNIT_TEST_SUITE (TTxDataShardLocalKMeansScan) {
                 "__ydb_parent = 74, key = 6, embedding = vv\3, data = six\n");
             recreate();
         }
+
+        {  // ParentFrom = 30 ParentTo = 31
+            auto [level, posting] = DoLocalKMeans(server, sender, 
+                30, 31, 111, 2,
+                NKikimrTxDataShard::EKMeansState::UPLOAD_BUILD_TO_BUILD, VectorIndexSettings::VECTOR_TYPE_UINT8, VectorIndexSettings::DISTANCE_MANHATTAN);
+            UNIT_ASSERT_VALUES_EQUAL(level, "");
+            UNIT_ASSERT_VALUES_EQUAL(posting, "");
+            recreate();
+        }
+
+        {  // ParentFrom = 100 ParentTo = 101
+            auto [level, posting] = DoLocalKMeans(server, sender, 
+                100, 101, 111, 2,
+                NKikimrTxDataShard::EKMeansState::UPLOAD_BUILD_TO_BUILD, VectorIndexSettings::VECTOR_TYPE_UINT8, VectorIndexSettings::DISTANCE_MANHATTAN);
+            UNIT_ASSERT_VALUES_EQUAL(level, "");
+            UNIT_ASSERT_VALUES_EQUAL(posting, "");
+            recreate();
+        }
     }
 }
 

--- a/ydb/core/tx/datashard/datashard_ut_prefix_kmeans.cpp
+++ b/ydb/core/tx/datashard/datashard_ut_prefix_kmeans.cpp
@@ -291,19 +291,6 @@ Y_UNIT_TEST_SUITE (TTxDataShardPrefixKMeansScan) {
             DoBadRequest(server, sender, ev, 2, VectorIndexSettings::VECTOR_TYPE_FLOAT,
                          VectorIndexSettings::METRIC_UNSPECIFIED);
         }
-        // TODO(mbkkt) For now all build_index, sample_k, build_columns, local_kmeans, prefix_kmeans doesn't really check this
-        // {
-        //     auto ev = std::make_unique<TEvDataShard::TEvPrefixKMeansRequest>();
-        //     auto snapshotCopy = snapshot;
-        //     snapshotCopy.Step++;
-        //     DoBadRequest(server, sender, ev);
-        // }
-        // {
-        //     auto ev = std::make_unique<TEvDataShard::TEvPrefixKMeansRequest>();
-        //     auto snapshotCopy = snapshot;
-        //     snapshotCopy.TxId++;
-        //     DoBadRequest(server, sender, ev);
-        // }
     }
 
     Y_UNIT_TEST (BuildToPosting) {

--- a/ydb/core/tx/datashard/local_kmeans.cpp
+++ b/ydb/core/tx/datashard/local_kmeans.cpp
@@ -393,7 +393,9 @@ class TLocalKMeansScan final: public TLocalKMeansScanBase, private TCalculation<
         Round = 0;
         K = InitK;
         State = EState::SAMPLE;
-        Lead.To(Prefix.GetCells(), NTable::ESeek::Upper); // seek to (prefix, inf)
+        Lead.Valid = true;
+        Lead.Key = TSerializedCellVec(Prefix.GetCells()); // seek to (prefix, inf)
+        Lead.Relation = NTable::ESeek::Upper;
         Prefix = {};
         IsFirstPrefixFeed = true;
         IsPrefixRowsValid = true;

--- a/ydb/core/tx/datashard/local_kmeans.cpp
+++ b/ydb/core/tx/datashard/local_kmeans.cpp
@@ -750,7 +750,7 @@ void TDataShard::HandleSafe(TEvDataShard::TEvLocalKMeansRequest::TPtr& ev, const
         TCell from, to;
         const auto range = CreateRangeFrom(userTable, parent, from, to);
         if (range.IsEmptyRange(userTable.KeyColumnTypes)) {
-            LOG_D("TEvLocalKMeansRequst " << request.GetId() << " parent " << parent << " is empty");
+            LOG_D("TEvLocalKMeansRequest " << request.GetId() << " parent " << parent << " is empty");
             continue;
         }
 

--- a/ydb/core/tx/datashard/prefix_kmeans.cpp
+++ b/ydb/core/tx/datashard/prefix_kmeans.cpp
@@ -153,6 +153,7 @@ public:
             (*LevelTypes)[2] = {NTableIndex::NTableVectorKmeansTreeIndex::CentroidColumn, type};
         }
         PostingTypes = MakeUploadTypes(table, UploadState, embedding, data, PrefixColumns);
+        // prefix types
         {
             auto types = GetAllTypes(table);
 

--- a/ydb/core/tx/datashard/prefix_kmeans.cpp
+++ b/ydb/core/tx/datashard/prefix_kmeans.cpp
@@ -101,7 +101,7 @@ protected:
     TAutoPtr<TEvDataShard::TEvPrefixKMeansResponse> Response;
 
     // FIXME: save PrefixRows as std::vector<std::pair<TSerializedCellVec, TSerializedCellVec>> to avoid parsing
-    ui32 PrefixColumns;
+    const ui32 PrefixColumns;
     TSerializedCellVec Prefix;
     TBufferData PrefixRows;
     bool IsFirstPrefixFeed = true;

--- a/ydb/core/tx/datashard/prefix_kmeans.cpp
+++ b/ydb/core/tx/datashard/prefix_kmeans.cpp
@@ -106,7 +106,7 @@ protected:
     TBufferData PrefixRows;
     bool IsFirstPrefixFeed = true;
     bool IsPrefixRowsValid = true;
-    
+
     bool IsExhausted = false;
 
 public:
@@ -798,6 +798,11 @@ void TDataShard::HandleSafe(TEvDataShard::TEvPrefixKMeansRequest::TPtr& ev, cons
 
     if (request.GetK() < 2) {
         badRequest("Should be requested partition on at least two rows");
+        return;
+    }
+
+    if (request.GetPrefixColumns() <= 0) {
+        badRequest("Should be requested on at least one prefix column");
         return;
     }
 

--- a/ydb/core/tx/datashard/reshuffle_kmeans.cpp
+++ b/ydb/core/tx/datashard/reshuffle_kmeans.cpp
@@ -189,8 +189,8 @@ protected:
             hFunc(TEvTxUserProxy::TEvUploadRowsResponse, Handle);
             cFunc(TEvents::TSystem::Wakeup, HandleWakeup);
             default:
-                LOG_E("TReshuffleKMeansScan: StateWork unexpected event type: " << ev->GetTypeRewrite() << " event: "
-                                                                                << ev->ToString() << " " << Debug());
+                LOG_E("StateWork unexpected event type: " << ev->GetTypeRewrite() 
+                    << " event: " << ev->ToString() << " " << Debug());
         }
     }
 

--- a/ydb/core/tx/datashard/sample_k.cpp
+++ b/ydb/core/tx/datashard/sample_k.cpp
@@ -180,7 +180,8 @@ private:
     STFUNC(StateWork) {
         switch (ev->GetTypeRewrite()) {
             default:
-                LOG_E("TSampleKScan: StateWork unexpected event type: " << ev->GetTypeRewrite() << " event: " << ev->ToString() << " " << Debug());
+                LOG_E("StateWork unexpected event type: " << ev->GetTypeRewrite() 
+                    << " event: " << ev->ToString() << " " << Debug());
         }
     }
 


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

...

### Changelog category <!-- remove all except one -->

* Not for changelog (changelog entry is not required)

### Description for reviewers <!-- (optional) description for those who read this PR -->

Do local k-means with only one scan

Tested on query

```
ALTER TABLE wikipedia
    ADD INDEX prefix_index2
    GLOBAL USING vector_kmeans_tree
    ON (wiki_id, embedding)
    WITH (similarity=inner_product, vector_type=float, vector_dimension=768, levels=2, clusters=128);
```

That previously gives OOM on 54gb nodes and now works around 30 seconds

For now keep `TPrefixKMeansScan` and `TLocalKMeansScan` separated, but made them as much similar as possible. They may be merged later.