### PR TITLE
ydb_configure, new features, part 6

### DIFF
--- a/ydb/tools/cfg/base.py
+++ b/ydb/tools/cfg/base.py
@@ -410,10 +410,7 @@ class ClusterDetailsProvider(object):
         if body:
             return str(body)
 
-        hostname = host_description.get("name", host_description.get("host"))
-        port = host_description.get("port", host_description.get("ic_port", DEFAULT_INTERCONNECT_PORT))
-
-        return str(self._host_info_provider.get_body(hostname, port))
+        return str(self._host_info_provider.get_body(host_description.get("name", host_description.get("host"))))
 
     def _collect_drives_info(self, host_description):
         host_config_id = host_description.get("host_config_id", None)

--- a/ydb/tools/cfg/base.py
+++ b/ydb/tools/cfg/base.py
@@ -293,7 +293,12 @@ class ClusterDetailsProvider(object):
             self._host_info_provider = walle.NopHostsInformationProvider()
 
         self.__translated_storage_pools_deprecated = None
+
         self.use_new_style_kikimr_cfg = self.__cluster_description.get("use_new_style_kikimr_cfg", use_new_style_cfg)
+        self.use_new_style_config_yaml = self.__cluster_description.get("use_new_style_config_yaml", False)
+        if self.use_new_style_config_yaml:
+            self.use_new_style_kikimr_cfg = True
+
         self.need_generate_app_config = self.__cluster_description.get("need_generate_app_config", False)
         self.need_txt_files = self.__cluster_description.get("need_txt_files", True)
         self.use_auto_config = self.__cluster_description.get("use_auto_config", False)
@@ -404,7 +409,11 @@ class ClusterDetailsProvider(object):
         body = host_description.get("location", {}).get("body", None)
         if body:
             return str(body)
-        return str(self._host_info_provider.get_body(host_description.get("name", host_description.get("host"))))
+
+        hostname = host_description.get("name", host_description.get("host"))
+        port = host_description.get("port", host_description.get("ic_port", DEFAULT_INTERCONNECT_PORT))
+
+        return str(self._host_info_provider.get_body(hostname, port))
 
     def _collect_drives_info(self, host_description):
         host_config_id = host_description.get("host_config_id", None)
@@ -578,15 +587,15 @@ class ClusterDetailsProvider(object):
         )
 
     @property
-    def __coordinators_count_optimal(self):
+    def coordinators_count_optimal(self):
         return min(5, max(1, len(self.hosts) / 4 + 1))
 
     @property
-    def __mediators_count_optimal(self):
+    def mediators_count_optimal(self):
         return min(5, max(1, len(self.hosts) / 4 + 1))
 
     @property
-    def __allocators_count_optimal(self):
+    def allocators_count_optimal(self):
         return min(5, max(1, len(self.hosts) / 4 + 1))
 
     @property
@@ -613,9 +622,9 @@ class ClusterDetailsProvider(object):
                 Domain(
                     domain_name=domain_name,
                     domain_id=domain.get("domain_id", domain_id),
-                    mediators=domain.get("mediators", self.__coordinators_count_optimal),
-                    coordinators=domain.get("coordinators", self.__mediators_count_optimal),
-                    allocators=domain.get("allocators", self.__allocators_count_optimal),
+                    mediators=domain.get("mediators", self.coordinators_count_optimal),
+                    coordinators=domain.get("coordinators", self.mediators_count_optimal),
+                    allocators=domain.get("allocators", self.allocators_count_optimal),
                     plan_resolution=domain.get("plan_resolution", DEFAULT_PLAN_RESOLUTION),
                     dynamic_slots=domain.get("dynamic_slots", 0),
                     storage_pool_kinds=storage_pool_kinds,

--- a/ydb/tools/cfg/k8s_api/k8s_api.py
+++ b/ydb/tools/cfg/k8s_api/k8s_api.py
@@ -58,6 +58,6 @@ class K8sApiHostsInformationProvider(HostsInformationProvider):
             return labels[self._k8s_dc_label]
         return ""
 
-    def get_body(self, hostname, port):
-        hash = hashlib.sha256(f'{hostname}:{port}'.encode())
+    def get_body(self, hostname):
+        hash = hashlib.sha256(hostname.encode())
         return int(hash.hexdigest(), 16) % (2**32)

--- a/ydb/tools/cfg/k8s_api/k8s_api.py
+++ b/ydb/tools/cfg/k8s_api/k8s_api.py
@@ -58,8 +58,6 @@ class K8sApiHostsInformationProvider(HostsInformationProvider):
             return labels[self._k8s_dc_label]
         return ""
 
-    def get_body(self, hostname):
-        # Just something for now, please present better ideas
-        hex_digest = hashlib.md5(hostname.encode()).hexdigest()
-        decimal_value = int(hex_digest, 16) % (1 << 31)
-        return decimal_value
+    def get_body(self, hostname, port):
+        hash = hashlib.sha256(f'{hostname}:{port}'.encode())
+        return int(hash.hexdigest(), 16) % (2**32)

--- a/ydb/tools/cfg/static.py
+++ b/ydb/tools/cfg/static.py
@@ -1389,8 +1389,6 @@ class StaticConfigGenerator(object):
                         for vdisk_location in fail_domain.VDiskLocations:
                             bs_group_node_ids.add(vdisk_location.NodeID)
 
-            print(bs_group_node_ids)
-
             state_storage_cfg.Ring.NToSelect = self.__n_to_select
             state_storage_cfg.Ring.Node.extend(bs_group_node_ids)
         else:

--- a/ydb/tools/cfg/static.py
+++ b/ydb/tools/cfg/static.py
@@ -668,9 +668,6 @@ class StaticConfigGenerator(object):
             for elem in self.__cluster_details.selector_config:
                 dynconfig['selector_config'].append(elem)
 
-            # blob_storage_config is not required in `dynconfig.yaml`
-            del dynconfig['config']['blob_storage_config']
-
         # emulate dumping ordered dict to yaml
         lines = []
         for key in ['metadata', 'config', 'allowed_labels', 'selector_config']:

--- a/ydb/tools/cfg/static.py
+++ b/ydb/tools/cfg/static.py
@@ -113,6 +113,7 @@ class StaticConfigGenerator(object):
             "immediate_controls_config.txt": None,
             "cms_config.txt": None,
             "audit_config.txt": None,
+            "kqpconfig.txt": None,
         }
         self.__optional_config_files = set(
             (
@@ -310,6 +311,16 @@ class StaticConfigGenerator(object):
     @property
     def actor_system_config_txt_enabled(self):
         return self.__proto_config("actor_system_config.txt").ByteSize() > 0
+
+    @property
+    def kqpconfig_txt(self):
+        return self.__proto_config("kqpconfig.txt",
+                                   config_pb2.TKQPConfig,
+                                   self.__cluster_details.get_service("kqpconfig"))
+
+    @property
+    def kqpconfig_txt_enabled(self):
+        return self.__proto_config("kqpconfig.txt").ByteSize() > 0
 
     @property
     def mbus_enabled(self):
@@ -692,7 +703,6 @@ class StaticConfigGenerator(object):
         app_config.LogConfig.CopyFrom(self.log_txt)
         if self.auth_txt.ByteSize() > 0:
             app_config.AuthConfig.CopyFrom(self.auth_txt)
-        app_config.KQPConfig.CopyFrom(self.kqp_txt)
         app_config.NameserviceConfig.CopyFrom(self.names_txt)
         app_config.GRpcConfig.CopyFrom(self.grpc_txt)
         app_config.InterconnectConfig.CopyFrom(self.ic_txt)
@@ -728,6 +738,12 @@ class StaticConfigGenerator(object):
         # New config.yaml style:
         if self.actor_system_config_txt_enabled:
             app_config.ActorSystemConfig.CopyFrom(self.actor_system_config_txt)
+
+        # Old template style:
+        app_config.KQPConfig.CopyFrom(self.kqp_txt)
+        # New config.yaml style:
+        if self.kqpconfig_txt_enabled:
+            app_config.KQPConfig.CopyFrom(self.kqpconfig_txt)
 
         # Old template style:
         if self.cms_txt.ByteSize() > 0:

--- a/ydb/tools/cfg/static.py
+++ b/ydb/tools/cfg/static.py
@@ -394,8 +394,12 @@ class StaticConfigGenerator(object):
 
         if self.__cluster_details.need_generate_app_config:
             all_configs["app_config.proto"] = utils.message_to_string(self.get_app_config())
-        all_configs["kikimr.cfg"] = self.kikimr_cfg
-        all_configs["dynamic_server.cfg"] = self.dynamic_server_common_args
+
+        # these files are obsolete and not generated with new style config.yaml
+        if not self.__cluster_details.use_new_style_config_yaml:
+            all_configs["kikimr.cfg"] = self.kikimr_cfg
+            all_configs["dynamic_server.cfg"] = self.dynamic_server_common_args
+
         normalized_config = self.get_normalized_config()
 
         all_configs["config.yaml"] = self.get_yaml_format_config(normalized_config)
@@ -1189,7 +1193,6 @@ class StaticConfigGenerator(object):
                                                                    self.__cluster_details.allocators_count_optimal)
 
         domains_config.HiveConfig.add(HiveUid=domain.DomainId, Hive=self.__tablet_types.FLAT_HIVE.tablet_id_for(0))
-
 
         if not domains_config.StateStorage:
             self._configure_default_state_storage(domains_config, domain.DomainId)

--- a/ydb/tools/cfg/static.py
+++ b/ydb/tools/cfg/static.py
@@ -1192,6 +1192,7 @@ class StaticConfigGenerator(object):
                                                                    self.__cluster_details.coordinators_count_optimal,
                                                                    self.__cluster_details.allocators_count_optimal)
 
+        domain.HiveUid.append(domain.DomainId)
         domains_config.HiveConfig.add(HiveUid=domain.DomainId, Hive=self.__tablet_types.FLAT_HIVE.tablet_id_for(0))
 
         if not domains_config.StateStorage:
@@ -1378,19 +1379,22 @@ class StaticConfigGenerator(object):
             state_storage_cfg.Ring.Node.extend(self.__cluster_details.state_storage_node_ids)
             return
 
+        selected_ids = []
         if self.__cluster_details.use_new_style_config_yaml:
-            blobstorage_config = self.__proto_config("bs.txt")
             # By default, we create a set of state storage nodes equal to a set of nodes
             # in static blobstorage groups.
-            bs_group_node_ids = set()
-            for group in blobstorage_config.ServiceSet.Groups:
-                for ring in group.Rings:
-                    for fail_domain in ring.FailDomains:
-                        for vdisk_location in fail_domain.VDiskLocations:
-                            bs_group_node_ids.add(vdisk_location.NodeID)
+            if self.__cluster_details.blob_storage_config:
+                blobstorage_config = self.__cluster_details.blob_storage_config
 
-            state_storage_cfg.Ring.NToSelect = self.__n_to_select
-            state_storage_cfg.Ring.Node.extend(bs_group_node_ids)
+                for group in blobstorage_config['service_set']['groups']:
+                    for ring in group['rings']:
+                        for fail_domain in ring['fail_domains']:
+                            for vdisk_location in fail_domain['vdisk_locations']:
+                                selected_ids.append(int(vdisk_location['node_id']))
+            else:
+                blobstorage_config = self.__proto_config("bs.txt")
+                for pdisk in blobstorage_config.ServiceSet.PDisks:
+                    selected_ids.append(pdisk.NodeID)
         else:
             rack_limit = 1
             dc_limit = None
@@ -1399,7 +1403,6 @@ class StaticConfigGenerator(object):
 
             occupied_dcs = collections.Counter()
             occupied_racks = collections.Counter()
-            selected_ids = []
             hosts_by_node_id = {node.node_id: node for node in self.__cluster_details.hosts}
             for node_id in self.__cluster_details.state_storage_node_ids:
                 node = hosts_by_node_id.get(node_id)
@@ -1415,11 +1418,11 @@ class StaticConfigGenerator(object):
                 occupied_dcs[node.datacenter] += 1
                 selected_ids.append(node.node_id)
 
-            if len(selected_ids) < self.__n_to_select:
-                raise RuntimeError("Unable to build valid quorum in state storage")
+        if len(selected_ids) < self.__n_to_select:
+            raise RuntimeError("Unable to build valid quorum in state storage")
 
-            state_storage_cfg.Ring.NToSelect = self.__n_to_select
-            state_storage_cfg.Ring.Node.extend(selected_ids)
+        state_storage_cfg.Ring.NToSelect = self.__n_to_select
+        state_storage_cfg.Ring.Node.extend(selected_ids)
 
     def __generate_log_txt(self):
         log_config = self.__cluster_details.log_config

--- a/ydb/tools/cfg/utils.py
+++ b/ydb/tools/cfg/utils.py
@@ -242,7 +242,7 @@ def need_generate_bs_config(template_bs_config):
     return template_bs_config.get("service_set", {}).get("groups") is None
 
 
-use_alternative_yaml_handler = False
+use_alternative_yaml_parser = False
 
 
 def determine_yaml_parsing(yaml_template_file):
@@ -253,10 +253,10 @@ def determine_yaml_parsing(yaml_template_file):
 
 
 def load_yaml(yaml_template_file):
-    global use_alternative_yaml_handler
-    use_alternative_yaml_handler = determine_yaml_parsing(yaml_template_file)
+    global use_alternative_yaml_parser
+    use_alternative_yaml_parser = determine_yaml_parsing(yaml_template_file)
 
-    if use_alternative_yaml_handler:
+    if use_alternative_yaml_parser:
         ruamel_yaml = YAML()
 
         with open(yaml_template_file, "r") as yaml_template:
@@ -277,20 +277,22 @@ def sort_dict_recursively(obj):
         return obj
 
 
-def dump_yaml(data):
-    global use_alternative_yaml_handler
+def dump_yaml(data, sort=True):
+    global use_alternative_yaml_parser
 
-    if use_alternative_yaml_handler:
+    if use_alternative_yaml_parser:
         yaml = YAML()
 
         yaml.default_flow_style = False
-        yaml.indent(mapping=2, sequence=4, offset=2)
+        yaml.indent(mapping=2, sequence=2, offset=0)
         yaml.sort_base_mapping_type_on_output = True
 
-        sorted_data = sort_dict_recursively(data)
-
         stream = StringIO()
-        yaml.dump(sorted_data, stream)
+
+        if sort:
+            data = sort_dict_recursively(data)
+
+        yaml.dump(data, stream)
         return stream.getvalue()
     else:
         return pyyaml.safe_dump(data, sort_keys=True, default_flow_style=False, indent=2)

--- a/ydb/tools/cfg/walle/walle.py
+++ b/ydb/tools/cfg/walle/walle.py
@@ -12,6 +12,7 @@ from abc import ABCMeta, abstractmethod
 
 from six.moves.urllib import parse
 
+
 class HostsInformationProvider:
     __metaclass__ = ABCMeta
 

--- a/ydb/tools/cfg/walle/walle.py
+++ b/ydb/tools/cfg/walle/walle.py
@@ -12,7 +12,6 @@ from abc import ABCMeta, abstractmethod
 
 from six.moves.urllib import parse
 
-
 class HostsInformationProvider:
     __metaclass__ = ABCMeta
 
@@ -25,7 +24,7 @@ class HostsInformationProvider:
         pass
 
     @abstractmethod
-    def get_body(hostname):
+    def get_body(hostname, port):
         pass
 
 
@@ -41,7 +40,7 @@ class NopHostsInformationProvider(HostsInformationProvider):
         # BAD_REQUEST (nameservice validator: node 1 has data center in Wall-E location longer than 4 symbols)
         return "FAKE"
 
-    def get_body(self, hostname):
+    def get_body(self, hostname, port):
         return zlib.crc32(hostname.encode())
 
 
@@ -103,5 +102,5 @@ class WalleHostsInformationProvider(HostsInformationProvider):
         short_dc_name = self._ask_location(hostname)["location"]["short_datacenter_name"]
         return short_dc_name if self._cloud_mode else short_dc_name.upper()
 
-    def get_body(self, hostname):
+    def get_body(self, hostname, port):
         return self._ask_location(hostname)["inv"]

--- a/ydb/tools/cfg/walle/walle.py
+++ b/ydb/tools/cfg/walle/walle.py
@@ -25,7 +25,7 @@ class HostsInformationProvider:
         pass
 
     @abstractmethod
-    def get_body(hostname, port):
+    def get_body(hostname):
         pass
 
 
@@ -41,7 +41,7 @@ class NopHostsInformationProvider(HostsInformationProvider):
         # BAD_REQUEST (nameservice validator: node 1 has data center in Wall-E location longer than 4 symbols)
         return "FAKE"
 
-    def get_body(self, hostname, port):
+    def get_body(self, hostname):
         return zlib.crc32(hostname.encode())
 
 
@@ -103,5 +103,5 @@ class WalleHostsInformationProvider(HostsInformationProvider):
         short_dc_name = self._ask_location(hostname)["location"]["short_datacenter_name"]
         return short_dc_name if self._cloud_mode else short_dc_name.upper()
 
-    def get_body(self, hostname, port):
+    def get_body(self, hostname):
         return self._ask_location(hostname)["inv"]


### PR DESCRIPTION
### Changelog category <!-- remove all except one -->

* Not for changelog (changelog entry is not required)

### Description for reviewers <!-- (optional) description for those who read this PR -->

0. New flag `use_new_style_config_yaml`. This flag is stronger than `use_new_style_kikimr_cfg`. False by default for backwards compatibility.
1. Bugfix in `state_storage` generation logic. If `use_new_style_config_yaml` is enabled and failure domain is `rack`, will only create as much nodes as there are in static blobstorage groups (8 or 9). Previously, it took all nodes and selected one node by rack, this resulted in dangerous state_storage setups (12 nodes, nto_select 5).
2. Bugfix in `domain_configs` default generation: `erasure_species` field is now correctly specified; also `ExplicitMediators`, `ExplicitCoordinators`, `ExplicitAllocators` and `HiveUid` fields are now propagated to `domains.txt`. 
3. `kikimr.cfg` and `dynamic_server.cfg` are not generated if `use_new_style_kikimr_cfg` is enabled. 