### PR TITLE
added pdisk FAULTY BLUE status support

### DIFF
--- a/ydb/core/health_check/health_check_ut.cpp
+++ b/ydb/core/health_check/health_check_ut.cpp
@@ -732,10 +732,12 @@ Y_UNIT_TEST_SUITE(THealthCheckTest) {
         CheckHcResultHasIssuesWithStatus(result, "STORAGE_GROUP", Ydb::Monitoring::StatusFlag::RED, 1);
     }
 
-    Y_UNIT_TEST(YellowIssueReadyVDisksOnFaultyPDisks) {
+    Y_UNIT_TEST(BlueIssueReadyVDisksOnFaultyPDisks) {
         auto result = RequestHcWithVdisks(NKikimrBlobStorage::TGroupStatus::PARTIAL, TVDisks{3, {NKikimrBlobStorage::READY, NKikimrBlobStorage::FAULTY}});
         Cerr << result.ShortDebugString() << Endl;
-        CheckHcResultHasIssuesWithStatus(result, "STORAGE_GROUP", Ydb::Monitoring::StatusFlag::YELLOW, 1);
+        CheckHcResultHasIssuesWithStatus(result, "STORAGE_GROUP", Ydb::Monitoring::StatusFlag::BLUE, 1);
+        CheckHcResultHasIssuesWithStatus(result, "VDISK", Ydb::Monitoring::StatusFlag::BLUE, 1);
+        CheckHcResultHasIssuesWithStatus(result, "STORAGE_GROUP", Ydb::Monitoring::StatusFlag::YELLOW, 0);
         CheckHcResultHasIssuesWithStatus(result, "STORAGE_GROUP", Ydb::Monitoring::StatusFlag::ORANGE, 0);
         CheckHcResultHasIssuesWithStatus(result, "STORAGE_GROUP", Ydb::Monitoring::StatusFlag::RED, 0);
     }


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

Support `FAULTY` PDisk state as `BLUE`

### Changelog category <!-- remove all except one -->

* Improvement

### Description for reviewers <!-- (optional) description for those who read this PR -->

- Added fallback `BLUE` status for VDisk when PDisk is `BLUE` ("VDisk awaiting replication")
- Added `BLUE` status for the group when all is `GREEN` but some VDisks are in `BLUE` ("Group awaiting degration")
- Extended `REPLICATING` and `THROTTLING` VDisk states with PDiskState dependency