### PR TITLE
Add option to the CMS to set the limit of FAULTY pdisks per node

### DIFF
--- a/ydb/core/cms/config.h
+++ b/ydb/core/cms/config.h
@@ -32,6 +32,7 @@ struct TCmsSentinelConfig {
     ui32 DataCenterRatio;
     ui32 RoomRatio;
     ui32 RackRatio;
+    ui32 MaxFaultyPDisksPerNode;
 
     TMaybeFail<EPDiskStatus> EvictVDisksStatus;
 
@@ -49,6 +50,7 @@ struct TCmsSentinelConfig {
         config.SetDataCenterRatio(DataCenterRatio);
         config.SetRoomRatio(RoomRatio);
         config.SetRackRatio(RackRatio);
+        config.SetMaxFaultyPDisksPerNode(MaxFaultyPDisksPerNode);
 
         SaveStateLimits(config);
         SaveEvictVDisksStatus(config);
@@ -68,6 +70,7 @@ struct TCmsSentinelConfig {
         DataCenterRatio = config.GetDataCenterRatio();
         RoomRatio = config.GetRoomRatio();
         RackRatio = config.GetRackRatio();
+        MaxFaultyPDisksPerNode = config.GetMaxFaultyPDisksPerNode();
 
         auto newStateLimits = LoadStateLimits(config);
         StateLimits.swap(newStateLimits);

--- a/ydb/core/cms/config.h
+++ b/ydb/core/cms/config.h
@@ -32,7 +32,7 @@ struct TCmsSentinelConfig {
     ui32 DataCenterRatio;
     ui32 RoomRatio;
     ui32 RackRatio;
-    ui32 MaxFaultyPDisksPerNode;
+    ui32 FaultyPDisksThresholdPerNode;
 
     TMaybeFail<EPDiskStatus> EvictVDisksStatus;
 
@@ -50,7 +50,7 @@ struct TCmsSentinelConfig {
         config.SetDataCenterRatio(DataCenterRatio);
         config.SetRoomRatio(RoomRatio);
         config.SetRackRatio(RackRatio);
-        config.SetMaxFaultyPDisksPerNode(MaxFaultyPDisksPerNode);
+        config.SetFaultyPDisksThresholdPerNode(FaultyPDisksThresholdPerNode);
 
         SaveStateLimits(config);
         SaveEvictVDisksStatus(config);
@@ -70,7 +70,7 @@ struct TCmsSentinelConfig {
         DataCenterRatio = config.GetDataCenterRatio();
         RoomRatio = config.GetRoomRatio();
         RackRatio = config.GetRackRatio();
-        MaxFaultyPDisksPerNode = config.GetMaxFaultyPDisksPerNode();
+        FaultyPDisksThresholdPerNode = config.GetFaultyPDisksThresholdPerNode();
 
         auto newStateLimits = LoadStateLimits(config);
         StateLimits.swap(newStateLimits);

--- a/ydb/core/cms/sentinel.cpp
+++ b/ydb/core/cms/sentinel.cpp
@@ -378,10 +378,10 @@ TClusterMap::TPDiskIDSet TGuardian::GetAllowedPDisks(const TClusterMap& all, TSt
                 if (changedCount > allowedCount) {
                     auto disallowedPdisks = disallowed | std::views::keys;
                     issuesBuilder
-                        << "Ignore state updates due to MaxFaultyPDisksPerNode" \
-                        << ": changed# " << changedCount \
-                        << ", total# " << currentCount \
-                        << ", allowed# " << allowedCount \
+                        << "Ignore state updates due to MaxFaultyPDisksPerNode"
+                        << ": changed# " << changedCount
+                        << ", total# " << currentCount
+                        << ", allowed# " << allowedCount
                         << ", affected pdisks# " << JoinSeq(", ", disallowedPdisks) << Endl;
                 }
             }

--- a/ydb/core/cms/sentinel_impl.h
+++ b/ydb/core/cms/sentinel_impl.h
@@ -53,7 +53,6 @@ public:
     void ApplyChanges(TString& reason);
     void ApplyChanges();
     EPDiskStatus GetStatus() const;
-    EPDiskStatus GetNewStatus() const;
     bool IsNewStatusGood() const;
 
     bool IsChangingAllowed() const;
@@ -155,11 +154,11 @@ public:
     TDistribution ByRoom;
     TDistribution ByRack;
     THashMap<TString, TNodeIDSet> NodeByRack;
-    TDistribution FaultyByNode;
+    TDistribution BadByNode;
 
     explicit TClusterMap(TSentinelState::TPtr state);
 
-    void AddPDisk(const TPDiskID& id, const EPDiskStatus status);
+    void AddPDisk(const TPDiskID& id, const bool inGoodState = true);
 
 }; // TClusterMap
 

--- a/ydb/core/cms/sentinel_impl.h
+++ b/ydb/core/cms/sentinel_impl.h
@@ -172,7 +172,7 @@ class TGuardian : public TClusterMap {
     }
 
 public:
-    explicit TGuardian(TSentinelState::TPtr state, ui32 dataCenterRatio = 100, ui32 roomRatio = 100, ui32 rackRatio = 100, ui32 maxFaultyPDisksPerNode = 0);
+    explicit TGuardian(TSentinelState::TPtr state, ui32 dataCenterRatio = 100, ui32 roomRatio = 100, ui32 rackRatio = 100, ui32 faultyPDisksThresholdPerNode = 0);
 
     TPDiskIDSet GetAllowedPDisks(const TClusterMap& all, TString& issues, TPDiskIgnoredMap& disallowed) const;
 
@@ -180,7 +180,7 @@ private:
     const ui32 DataCenterRatio;
     const ui32 RoomRatio;
     const ui32 RackRatio;
-    const ui32 MaxFaultyPDisksPerNode;
+    const ui32 FaultyPDisksThresholdPerNode;
 
 }; // TGuardian
 

--- a/ydb/core/cms/sentinel_impl.h
+++ b/ydb/core/cms/sentinel_impl.h
@@ -53,6 +53,7 @@ public:
     void ApplyChanges(TString& reason);
     void ApplyChanges();
     EPDiskStatus GetStatus() const;
+    EPDiskStatus GetNewStatus() const;
     bool IsNewStatusGood() const;
 
     bool IsChangingAllowed() const;
@@ -154,10 +155,11 @@ public:
     TDistribution ByRoom;
     TDistribution ByRack;
     THashMap<TString, TNodeIDSet> NodeByRack;
+    TDistribution FaultyByNode;
 
     explicit TClusterMap(TSentinelState::TPtr state);
 
-    void AddPDisk(const TPDiskID& id);
+    void AddPDisk(const TPDiskID& id, const EPDiskStatus status);
 
 }; // TClusterMap
 
@@ -171,7 +173,7 @@ class TGuardian : public TClusterMap {
     }
 
 public:
-    explicit TGuardian(TSentinelState::TPtr state, ui32 dataCenterRatio = 100, ui32 roomRatio = 100, ui32 rackRatio = 100);
+    explicit TGuardian(TSentinelState::TPtr state, ui32 dataCenterRatio = 100, ui32 roomRatio = 100, ui32 rackRatio = 100, ui32 maxFaultyPDisksPerNode = 0);
 
     TPDiskIDSet GetAllowedPDisks(const TClusterMap& all, TString& issues, TPDiskIgnoredMap& disallowed) const;
 
@@ -179,6 +181,7 @@ private:
     const ui32 DataCenterRatio;
     const ui32 RoomRatio;
     const ui32 RackRatio;
+    const ui32 MaxFaultyPDisksPerNode;
 
 }; // TGuardian
 

--- a/ydb/core/cms/sentinel_ut.cpp
+++ b/ydb/core/cms/sentinel_ut.cpp
@@ -414,7 +414,7 @@ Y_UNIT_TEST_SUITE(TSentinelBaseTests) {
         }
 
         for (const auto& kv : disallowed) {
-            UNIT_ASSERT(kv.second == NKikimrCms::TPDiskInfo::MAX_FAULTY_PER_NODE);
+            UNIT_ASSERT(kv.second == NKikimrCms::TPDiskInfo::TOO_MANY_FAULTY_PER_NODE);
             disallowedDisksByNode[kv.first.NodeId]++;
         }
 
@@ -601,7 +601,7 @@ Y_UNIT_TEST_SUITE(TSentinelTests) {
         for (auto wholeShelfFailure : {true, false}) {
             NKikimrCms::TCmsConfig config;
 
-            config.MutableSentinelConfig()->SetMaxFaultyPDisksPerNode(disksPerShelf - 1);
+            config.MutableSentinelConfig()->SetFaultyPDisksThresholdPerNode(disksPerShelf - 1);
             TTestEnv env(nodes, disksPerNode, config);
             env.SetLogPriority(NKikimrServices::CMS, NLog::PRI_ERROR);
 
@@ -660,7 +660,7 @@ Y_UNIT_TEST_SUITE(TSentinelTests) {
 
         NKikimrCms::TCmsConfig config;
 
-        config.MutableSentinelConfig()->SetMaxFaultyPDisksPerNode(disksPerShelf - 1);
+        config.MutableSentinelConfig()->SetFaultyPDisksThresholdPerNode(disksPerShelf - 1);
         TTestEnv env(nodes, disksPerNode, config);
         env.SetLogPriority(NKikimrServices::CMS, NLog::PRI_ERROR);
 

--- a/ydb/core/cms/sentinel_ut.cpp
+++ b/ydb/core/cms/sentinel_ut.cpp
@@ -331,9 +331,9 @@ Y_UNIT_TEST_SUITE(TSentinelBaseTests) {
                 const ui64 nodeId = node.second->NodeId;
                 const TPDiskID id(nodeId, 0);
 
-                all.AddPDisk(id, EPDiskStatus::ACTIVE);
+                all.AddPDisk(id);
                 if (changedCount[nodeId >> 32]++ < (nodesPerDataCenter / 2)) {
-                    changed.AddPDisk(id, EPDiskStatus::ACTIVE);
+                    changed.AddPDisk(id);
                     changedSet.insert(id);
                 }
             }
@@ -351,7 +351,7 @@ Y_UNIT_TEST_SUITE(TSentinelBaseTests) {
                 const TPDiskID id(nodeId, 0);
 
                 if (changedCount[nodeId >> 32]++ < ((nodesPerDataCenter / 2) + 1)) {
-                    changed.AddPDisk(id, EPDiskStatus::ACTIVE);
+                    changed.AddPDisk(id);
                     changedSet.insert(id);
                 }
             }
@@ -375,16 +375,14 @@ Y_UNIT_TEST_SUITE(TSentinelBaseTests) {
         GuardianDataCenterRatio(1, {3, 4, 5}, true);
     }
 
-    Y_UNIT_TEST(GuardianFaultyPDisks) {
-        ui32 shelvesPerNode = 2;
-        ui32 disksPerShelf = 28;
+    void GuardianBadPDisksByNode(ui32 shelvesPerNode, ui32 disksPerShelf, ui32 badDisks) {
         ui32 disksPerNode = shelvesPerNode * disksPerShelf;
+        ui32 maxFaultyDisksPerNode = disksPerShelf - 1;
 
         auto [state, sentinelState] = MockCmsState(1, 8, 1, disksPerNode, true, false);
         TClusterMap all(sentinelState);
-        // Setting max faulty disks per node to disksPerShelf - 1
-        // to not allow the whole shelf move.
-        TGuardian changed(sentinelState, 100, 100, 100, disksPerShelf - 1);
+
+        TGuardian changed(sentinelState, 100, 100, 100, maxFaultyDisksPerNode);
 
         const auto& nodes = state->ClusterInfo->AllNodes();
 
@@ -394,17 +392,12 @@ Y_UNIT_TEST_SUITE(TSentinelBaseTests) {
             for (ui32 i = 0; i < disksPerNode; i++) {
                 const TPDiskID id(nodeId, i);
     
-                if (i < disksPerShelf - 2) {
-                    all.AddPDisk(id, EPDiskStatus::FAULTY);
+                if (i < badDisks) {
+                    all.AddPDisk(id, false);
+                    changed.AddPDisk(id, false);
                 } else {
-                    all.AddPDisk(id, EPDiskStatus::ACTIVE);
+                    all.AddPDisk(id);
                 }
-            }
-
-            for (ui32 i = disksPerShelf - 1; i < disksPerNode; i++) {
-                const TPDiskID id(nodeId, i);
-    
-                changed.AddPDisk(id, EPDiskStatus::FAULTY);
             }
         }
 
@@ -427,8 +420,19 @@ Y_UNIT_TEST_SUITE(TSentinelBaseTests) {
 
         for (const auto& node : nodes) {
             const ui64 nodeId = node.second->NodeId;
-            UNIT_ASSERT_VALUES_EQUAL(allowedDisksByNode[nodeId], 1);
-            UNIT_ASSERT_VALUES_EQUAL(disallowedDisksByNode[nodeId], disksPerShelf);
+            if (badDisks <= maxFaultyDisksPerNode) {
+                UNIT_ASSERT_VALUES_EQUAL(allowedDisksByNode[nodeId], badDisks);
+                UNIT_ASSERT_VALUES_EQUAL(disallowedDisksByNode[nodeId], 0);
+            } else {
+                UNIT_ASSERT_VALUES_EQUAL(allowedDisksByNode[nodeId], 0);
+                UNIT_ASSERT_VALUES_EQUAL(disallowedDisksByNode[nodeId], badDisks);
+            }
+        }
+    }
+
+    Y_UNIT_TEST(GuardianFaultyPDisks) {
+        for (ui32 i = 0; i < 56; i++) {
+            GuardianBadPDisksByNode(2, 28, i);
         }
     }
 
@@ -448,9 +452,9 @@ Y_UNIT_TEST_SUITE(TSentinelBaseTests) {
                 for (ui16 pdiskId : xrange(numPDisks)) {
                     const TPDiskID id(nodeId, pdiskId);
 
-                    all.AddPDisk(id, EPDiskStatus::ACTIVE);
+                    all.AddPDisk(id);
                     if (changedCount[nodeId >> 16]++ < nodesPerRack * numPDisks / 2) {
-                        changed.AddPDisk(id, EPDiskStatus::ACTIVE);
+                        changed.AddPDisk(id);
                         changedSet.insert(id);
                     }
                 }
@@ -470,7 +474,7 @@ Y_UNIT_TEST_SUITE(TSentinelBaseTests) {
                     const TPDiskID id(nodeId, pdiskId);
 
                     if (changedCount[nodeId >> 16]++ < nodesPerRack * numPDisks / 2 + 1) {
-                        changed.AddPDisk(id, EPDiskStatus::ACTIVE);
+                        changed.AddPDisk(id);
                         changedSet.insert(id);
                     }
                 }
@@ -593,50 +597,100 @@ Y_UNIT_TEST_SUITE(TSentinelTests) {
         ui32 nodes = 2;
         ui32 disksPerShelf = 5;
         ui32 disksPerNode = 2 * disksPerShelf;
+
+        for (auto wholeShelfFailure : {true, false}) {
+            NKikimrCms::TCmsConfig config;
+
+            config.MutableSentinelConfig()->SetMaxFaultyPDisksPerNode(disksPerShelf - 1);
+            TTestEnv env(nodes, disksPerNode, config);
+            env.SetLogPriority(NKikimrServices::CMS, NLog::PRI_ERROR);
+
+            for (ui32 nodeIdx = 0; nodeIdx < nodes; ++nodeIdx) {
+                ui32 badDisks = wholeShelfFailure ? disksPerShelf : disksPerShelf / 2;
+
+                for (ui32 pdiskIdx = 0; pdiskIdx < badDisks - 1; ++pdiskIdx) {
+                    const TPDiskID id = env.PDiskId(nodeIdx, pdiskIdx);
+
+                    env.SetPDiskState({id}, FaultyStates[0]);
+                }
+
+                // Next disk (last badDisk)
+                const TPDiskID id = env.PDiskId(nodeIdx, badDisks);
+
+                bool targetSeenFaulty = false;
+
+                auto observerHolder = env.AddObserver<TEvBlobStorage::TEvControllerConfigRequest>([&](TEvBlobStorage::TEvControllerConfigRequest::TPtr& event) {
+                    const auto& request = event->Get()->Record;
+                    for (const auto& command : request.GetRequest().GetCommand()) {
+                        if (command.HasUpdateDriveStatus()) {
+                            const auto& update = command.GetUpdateDriveStatus();
+                            ui32 nodeId = update.GetHostKey().GetNodeId();
+                            ui32 pdiskId = update.GetPDiskId();
+
+                            if (id.NodeId == nodeId && id.DiskId == pdiskId) {
+                                if (update.GetStatus() == NKikimrBlobStorage::EDriveStatus::FAULTY) {
+                                    targetSeenFaulty = true;
+                                }
+                            }
+                        }
+                    }
+                });
+
+                for (ui32 i = 1; i < DefaultErrorStateLimit + 1; ++i) { // More than DefaultErrorStateLimit just to be sure
+                    env.SetPDiskState({id}, FaultyStates[0]);
+                }
+
+                env.SimulateSleep(TDuration::Minutes(5));
+
+                observerHolder.Remove();
+
+                if (wholeShelfFailure) {
+                    UNIT_ASSERT_C(!targetSeenFaulty, "Faulty state should not have been sent to BS controller because whole shelf failed");
+                } else {
+                    UNIT_ASSERT_C(targetSeenFaulty, "Faulty state should have been sent to BS controller");
+                }
+            }
+        }
+    }
+
+    Y_UNIT_TEST(PDiskFaultyGuardWithForced) {
+        ui32 nodes = 2;
+        ui32 disksPerShelf = 5;
+        ui32 disksPerNode = 2 * disksPerShelf;
+
         NKikimrCms::TCmsConfig config;
-        // Setting max faulty disks per node to disksPerShelf - 1
-        // to not allow the whole shelf move.
+
         config.MutableSentinelConfig()->SetMaxFaultyPDisksPerNode(disksPerShelf - 1);
         TTestEnv env(nodes, disksPerNode, config);
         env.SetLogPriority(NKikimrServices::CMS, NLog::PRI_ERROR);
 
-        for (ui32 nodeId = 0; nodeId < nodes; ++nodeId) {
-            for (ui32 pdiskId = 0; pdiskId < disksPerShelf - 1; ++pdiskId) {
-                const TPDiskID id = env.PDiskId(nodeId, pdiskId);
+        std::map<ui32, std::set<ui32>> faultyDisks;
 
-                for (ui32 i = 1; i < DefaultErrorStateLimit; ++i) {
-                    env.SetPDiskState({id}, FaultyStates[0]);
+        auto observerHolder = env.AddObserver<TEvBlobStorage::TEvControllerConfigRequest>([&](TEvBlobStorage::TEvControllerConfigRequest::TPtr& event) {
+            const auto& request = event->Get()->Record;
+            for (const auto& command : request.GetRequest().GetCommand()) {
+                if (command.HasUpdateDriveStatus()) {
+                    const auto& update = command.GetUpdateDriveStatus();
+                    ui32 nodeId = update.GetHostKey().GetNodeId();
+                    ui32 pdiskId = update.GetPDiskId();
+
+                    faultyDisks[nodeId].insert(pdiskId);
                 }
-
-                env.SetPDiskState({id}, FaultyStates[0], EPDiskStatus::FAULTY);
             }
+        });
 
-            const TPDiskID id = env.PDiskId(nodeId, disksPerShelf - 1);
-
-            auto observerHolder = env.AddObserver<TEvBlobStorage::TEvControllerConfigRequest>([&](TEvBlobStorage::TEvControllerConfigRequest::TPtr& event) {
-                const auto& request = event->Get()->Record;
-                for (const auto& command : request.GetRequest().GetCommand()) {
-                    if (command.HasUpdateDriveStatus()) {
-                        const auto& update = command.GetUpdateDriveStatus();
-                        ui32 nodeId = update.GetHostKey().GetNodeId();
-                        ui32 pdiskId = update.GetPDiskId();
-
-                        if (id.NodeId == nodeId && id.DiskId == pdiskId) {
-                            if (update.GetStatus() == NKikimrBlobStorage::EDriveStatus::FAULTY) {
-                                UNIT_FAIL("Faulty state should not be sent to BS controller as we already have set FAULTY to a whole shelf");
-                            }
-                        }
-                    }
-                }
-            });
-
-            for (ui32 i = 1; i < DefaultErrorStateLimit + 1; ++i) { // More than DefaultErrorStateLimit just to be sure
-                env.SetPDiskState({id}, FaultyStates[0]);
-            }
+        for (ui32 nodeIdx = 0; nodeIdx < nodes; ++nodeIdx) {
+            env.SetNodeFaulty(env.GetNodeId(nodeIdx), true);
 
             env.SimulateSleep(TDuration::Minutes(5));
+        }
 
-            observerHolder.Remove();
+        observerHolder.Remove();
+
+        for (ui32 nodeIdx = 0; nodeIdx < nodes; ++nodeIdx) {
+            ui32 nodeId = env.GetNodeId(nodeIdx);
+
+            UNIT_ASSERT_VALUES_EQUAL(faultyDisks[nodeId].size(), disksPerNode);
         }
     }
 

--- a/ydb/core/cms/sentinel_ut_helpers.h
+++ b/ydb/core/cms/sentinel_ut_helpers.h
@@ -83,7 +83,7 @@ class TTestEnv: public TCmsTestEnv {
     }
 
 public:
-    explicit TTestEnv(ui32 nodeCount, ui32 pdisks)
+    explicit TTestEnv(ui32 nodeCount, ui32 pdisks, const NKikimrCms::TCmsConfig &config = {})
         : TCmsTestEnv(nodeCount, pdisks)
     {
         SetLogPriority(NKikimrServices::CMS, NLog::PRI_DEBUG);
@@ -123,6 +123,7 @@ public:
         });
 
         State = new TCmsState;
+        State->Config.Deserialize(config);
         MockClusterInfo(State->ClusterInfo);
         State->CmsActorId = GetSender();
 

--- a/ydb/core/cms/sentinel_ut_helpers.h
+++ b/ydb/core/cms/sentinel_ut_helpers.h
@@ -168,6 +168,26 @@ public:
         return info->PDisks;
     }
 
+    void SetNodeFaulty(ui32 nodeId, bool faulty) {
+        if (faulty) {
+            auto v = TVector<NCms::TEvSentinel::TEvUpdateHostMarkers::THostMarkers>();
+            v.push_back({
+                .NodeId = nodeId,
+                .Markers = {NKikimrCms::EMarker::MARKER_DISK_FAULTY},
+            });
+
+            Send(new IEventHandle(Sentinel, TActorId(), new TEvSentinel::TEvUpdateHostMarkers(std::move(v))));
+        } else {
+            auto v = TVector<NCms::TEvSentinel::TEvUpdateHostMarkers::THostMarkers>();
+            v.push_back({
+                .NodeId = nodeId,
+                .Markers = {},
+            });
+
+            Send(new IEventHandle(Sentinel, TActorId(), new TEvSentinel::TEvUpdateHostMarkers(std::move(v))));
+        }
+    }
+
     void SetPDiskState(const TSet<TPDiskID>& pdisks, EPDiskState state) {
         SetPDiskStateImpl(pdisks, state);
 

--- a/ydb/core/protos/cms.proto
+++ b/ydb/core/protos/cms.proto
@@ -452,7 +452,14 @@ message TCmsConfig {
         optional uint32 DataCenterRatio = 10 [default = 50];
         optional uint32 RoomRatio = 11 [default = 70];
         optional uint32 RackRatio = 12 [default = 90];
-        optional uint32 MaxFaultyPDisksPerNode = 17 [default = 0];
+        // Similar to *Ratio settings, but specified in absolute numbers and applied per storage node.
+        // This limit helps prevent cascading overreaction when many disks go offline on a single host
+        // (due to disk shelf disconnection).
+        // If the number of FAULTY PDisks on a node — including those already FAULTY or about to be marked FAULTY —
+        // exceeds this threshold, no additional disks on the same node will be marked as FAULTY,
+        // except for those explicitly marked as FAULTY by the user via the replace devices command.
+        // If set to 0, this check is disabled.
+        optional uint32 FaultyPDisksThresholdPerNode = 17 [default = 0];
 
         optional bool DryRun = 13;
         repeated TStateLimit StateLimits = 14;
@@ -647,7 +654,7 @@ message TPDiskInfo {
         RATIO_BY_DATACENTER = 3;
         RATIO_BY_ROOM = 4;
         RATIO_BY_RACK = 5;
-        MAX_FAULTY_PER_NODE = 6;
+        TOO_MANY_FAULTY_PER_NODE = 6;
     }
 
     optional uint32 State = 1; // EPDiskState

--- a/ydb/core/protos/cms.proto
+++ b/ydb/core/protos/cms.proto
@@ -452,6 +452,7 @@ message TCmsConfig {
         optional uint32 DataCenterRatio = 10 [default = 50];
         optional uint32 RoomRatio = 11 [default = 70];
         optional uint32 RackRatio = 12 [default = 90];
+        optional uint32 MaxFaultyPDisksPerNode = 17 [default = 0];
 
         optional bool DryRun = 13;
         repeated TStateLimit StateLimits = 14;
@@ -646,6 +647,7 @@ message TPDiskInfo {
         RATIO_BY_DATACENTER = 3;
         RATIO_BY_ROOM = 4;
         RATIO_BY_RACK = 5;
+        MAX_FAULTY_PER_NODE = 6;
     }
 
     optional uint32 State = 1; // EPDiskState


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

Add `MaxFaultyPDisksPerNode` to CMS config, so that Sentinel could not exceed that number. This may be useful in case if a node with a large count of disks goes down but it is known that this node will be brought back in the near future. This way, we will not be moving many disks at once (which can be rather long in case of HDDs). If `MaxFaultyPDisksPerNode` is 0, then there is no limit.

### Changelog category <!-- remove all except one -->

* Experimental feature

### Description for reviewers <!-- (optional) description for those who read this PR -->

Self-heal detects unavailability of disks based on FAULTY status set by Sentinel and moves them out. Imagine a situation, where we have nodes with disk arrays attached, which contain 64 disks with 15TB or more of data on each. In such a configuration, a node or an array failure triggers too much data moving with weeks to reconcile without options to stop this process, while in fact the disks are operational, and the node or the shelve is likely to be restored much faster. So, to keep such a cluster in operational state self-heal should be disabled.

In this PR I introduce a way to control how many disks on one host local Self-Heal can restore. Forced FAULTY status should be respected and always allowed anyway, but is still counted. So if max faulty per node value is 10 and there are 10 faulty disks or faulty candidates (based on PDiskState) on a node (doesn't matter if they are forcefully FAULTY or this status was set by Sentinel), then another disk on this node can only become FAULTY if it was set by CMS forcefully.
