### PR TITLE
Fix starting of S3 recipe

### DIFF
--- a/ydb/tests/tools/s3_recipe/__main__.py
+++ b/ydb/tests/tools/s3_recipe/__main__.py
@@ -18,7 +18,8 @@ def start(argv):
     logging.debug("Starting S3 recipe")
     pm = PortManager()
     port = pm.get_port()
-    url = "http://localhost:{port}".format(port=port)
+    url = "http://localhost:{port}".format(port=port)  # S3 libs require DNS name for S3 endpoint
+    check_url = "http://[::1]:{port}".format(port=port)
     cmd = [
         yatest.common.binary_path(MOTO_SERVER_PATH),
         "s3",
@@ -28,7 +29,7 @@ def start(argv):
 
     def is_s3_ready():
         try:
-            response = requests.get(url)
+            response = requests.get(check_url)
             response.raise_for_status()
             return True
         except requests.RequestException as err:


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

...

### Changelog category <!-- remove all except one -->

* Not for changelog (changelog entry is not required)

### Description for reviewers <!-- (optional) description for those who read this PR -->

S3 recipe starts server on ::1 address, but checks localhost, in which case for some reasons requests library tries to use IPV4 address and gets error: `Failed to establish a new connection: [Errno 111] Connection refused'))`.