### PR TITLE
Set BSC LayoutCorrect default true

### DIFF
--- a/ydb/core/health_check/health_check.cpp
+++ b/ydb/core/health_check/health_check.cpp
@@ -1722,7 +1722,9 @@ public:
             auto& groupState = GroupState[groupId];
             groupState.ErasureSpecies = group.GetInfo().GetErasureSpeciesV2();
             groupState.Generation = group.GetInfo().GetGeneration();
-            groupState.LayoutCorrect = group.GetInfo().GetLayoutCorrect();
+            if (group.GetInfo().HasLayoutCorrect()) {
+                groupState.LayoutCorrect = group.GetInfo().GetLayoutCorrect();
+            }
             StoragePoolState[poolId].Groups.emplace(groupId);
         }
         for (const auto& vSlot : VSlots->Get()->Record.GetEntries()) {
@@ -2156,6 +2158,7 @@ public:
                                  TStringBuilder() << "Unknown PDisk state: " << statusString,
                                  ETags::PDiskState);
         }
+
         switch (status->number()) {
             case NKikimrBlobStorage::ACTIVE:
             case NKikimrBlobStorage::INACTIVE: {

--- a/ydb/core/health_check/health_check.cpp
+++ b/ydb/core/health_check/health_check.cpp
@@ -1722,9 +1722,7 @@ public:
             auto& groupState = GroupState[groupId];
             groupState.ErasureSpecies = group.GetInfo().GetErasureSpeciesV2();
             groupState.Generation = group.GetInfo().GetGeneration();
-            if (group.GetInfo().HasLayoutCorrect()) {
-                groupState.LayoutCorrect = group.GetInfo().GetLayoutCorrect();
-            }
+            groupState.LayoutCorrect = group.GetInfo().GetLayoutCorrect();
             StoragePoolState[poolId].Groups.emplace(groupId);
         }
         for (const auto& vSlot : VSlots->Get()->Record.GetEntries()) {
@@ -2158,7 +2156,6 @@ public:
                                  TStringBuilder() << "Unknown PDisk state: " << statusString,
                                  ETags::PDiskState);
         }
-
         switch (status->number()) {
             case NKikimrBlobStorage::ACTIVE:
             case NKikimrBlobStorage::INACTIVE: {

--- a/ydb/core/health_check/health_check_ut.cpp
+++ b/ydb/core/health_check/health_check_ut.cpp
@@ -2219,7 +2219,7 @@ Y_UNIT_TEST_SUITE(THealthCheckTest) {
         TestConfigUpdateNodeRestartsPerPeriod(runtime, sender, nodeRestarts / 5, nodeRestarts / 2, nodeId, Ydb::Monitoring::StatusFlag::ORANGE);
     }
 
-    Y_UNIT_TEST(LayoutIncorrect) {
+    void LayoutCorrectTest(std::optional<bool> layoutCorrect) {
         TPortManager tp;
         ui16 port = tp.GetPort(2134);
         ui16 grpcPort = tp.GetPort(2135);
@@ -2241,13 +2241,15 @@ Y_UNIT_TEST_SUITE(THealthCheckTest) {
                     auto* x = reinterpret_cast<NSysView::TEvSysView::TEvGetGroupsResponse::TPtr*>(&ev);
                     auto& record = (*x)->Get()->Record;
                     for (auto& entry : *record.mutable_entries()) {
-                        entry.mutable_info()->set_layoutcorrect(false);
+                        if (layoutCorrect.has_value()) {
+                            entry.mutable_info()->set_layoutcorrect(*layoutCorrect);
+                        } else {
+                            entry.mutable_info()->clear_layoutcorrect();
+                        }
                     }
-
                     break;
                 }
             }
-
             return TTestActorRuntime::EEventAction::PROCESS;
         };
         runtime.SetObserverFunc(observerFunc);
@@ -2258,32 +2260,59 @@ Y_UNIT_TEST_SUITE(THealthCheckTest) {
         runtime.Send(new IEventHandle(NHealthCheck::MakeHealthCheckID(), sender, request, 0));
         auto result = runtime.GrabEdgeEvent<NHealthCheck::TEvSelfCheckResult>(handle)->Result;
 
-        UNIT_ASSERT_VALUES_EQUAL(result.self_check_result(), Ydb::Monitoring::SelfCheck::MAINTENANCE_REQUIRED);
-        UNIT_ASSERT_VALUES_EQUAL(result.database_status_size(), 1);
-        const auto &database_status = result.database_status(0);
+        if (layoutCorrect.has_value() && !*layoutCorrect) {
+            UNIT_ASSERT_VALUES_EQUAL(result.self_check_result(), Ydb::Monitoring::SelfCheck::MAINTENANCE_REQUIRED);
+            UNIT_ASSERT_VALUES_EQUAL(result.database_status_size(), 1);
+            const auto &database_status = result.database_status(0);
 
-        UNIT_ASSERT_VALUES_EQUAL(database_status.overall(), Ydb::Monitoring::StatusFlag::ORANGE);
-        UNIT_ASSERT_VALUES_EQUAL(database_status.storage().overall(), Ydb::Monitoring::StatusFlag::ORANGE);
-        UNIT_ASSERT_VALUES_EQUAL(database_status.storage().pools().size(), 1);
-        UNIT_ASSERT_VALUES_EQUAL(database_status.storage().pools()[0].overall(), Ydb::Monitoring::StatusFlag::ORANGE);
-        UNIT_ASSERT_VALUES_EQUAL(database_status.storage().pools()[0].groups().size(), 1);
-        UNIT_ASSERT_VALUES_EQUAL(database_status.storage().pools()[0].groups()[0].overall(), Ydb::Monitoring::StatusFlag::ORANGE);
+            UNIT_ASSERT_VALUES_EQUAL(database_status.overall(), Ydb::Monitoring::StatusFlag::ORANGE);
+            UNIT_ASSERT_VALUES_EQUAL(database_status.storage().overall(), Ydb::Monitoring::StatusFlag::ORANGE);
+            UNIT_ASSERT_VALUES_EQUAL(database_status.storage().pools().size(), 1);
+            UNIT_ASSERT_VALUES_EQUAL(database_status.storage().pools()[0].overall(), Ydb::Monitoring::StatusFlag::ORANGE);
+            UNIT_ASSERT_VALUES_EQUAL(database_status.storage().pools()[0].groups().size(), 1);
+            UNIT_ASSERT_VALUES_EQUAL(database_status.storage().pools()[0].groups()[0].overall(), Ydb::Monitoring::StatusFlag::ORANGE);
 
-        for (const auto &issue_log : result.issue_log()) {
-            if (issue_log.level() == 1 && issue_log.type() == "DATABASE") {
-                UNIT_ASSERT_VALUES_EQUAL(issue_log.location().database().name(), "/Root");
-                UNIT_ASSERT_VALUES_EQUAL(issue_log.message(), "Database has storage issues");
-            } else if (issue_log.level() == 2 && issue_log.type() == "STORAGE") {
-                UNIT_ASSERT_VALUES_EQUAL(issue_log.location().database().name(), "/Root");
-                UNIT_ASSERT_VALUES_EQUAL(issue_log.message(), "Storage has no redundancy");
-            } else if (issue_log.level() == 3 && issue_log.type() == "STORAGE_POOL") {
-                UNIT_ASSERT_VALUES_EQUAL(issue_log.location().storage().pool().name(), "static");
-                UNIT_ASSERT_VALUES_EQUAL(issue_log.message(), "Pool has no redundancy");
-            } else if (issue_log.level() == 4 && issue_log.type() == "STORAGE_GROUP") {
-                UNIT_ASSERT_VALUES_EQUAL(issue_log.location().storage().pool().name(), "static");
-                UNIT_ASSERT_VALUES_EQUAL(issue_log.message(), "Group layout is incorrect");
+            for (const auto &issue_log : result.issue_log()) {
+                if (issue_log.level() == 1 && issue_log.type() == "DATABASE") {
+                    UNIT_ASSERT_VALUES_EQUAL(issue_log.location().database().name(), "/Root");
+                    UNIT_ASSERT_VALUES_EQUAL(issue_log.message(), "Database has storage issues");
+                } else if (issue_log.level() == 2 && issue_log.type() == "STORAGE") {
+                    UNIT_ASSERT_VALUES_EQUAL(issue_log.location().database().name(), "/Root");
+                    UNIT_ASSERT_VALUES_EQUAL(issue_log.message(), "Storage has no redundancy");
+                } else if (issue_log.level() == 3 && issue_log.type() == "STORAGE_POOL") {
+                    UNIT_ASSERT_VALUES_EQUAL(issue_log.location().storage().pool().name(), "static");
+                    UNIT_ASSERT_VALUES_EQUAL(issue_log.message(), "Pool has no redundancy");
+                } else if (issue_log.level() == 4 && issue_log.type() == "STORAGE_GROUP") {
+                    UNIT_ASSERT_VALUES_EQUAL(issue_log.location().storage().pool().name(), "static");
+                    UNIT_ASSERT_VALUES_EQUAL(issue_log.message(), "Group layout is incorrect");
+                }
             }
+        } else {
+            UNIT_ASSERT_VALUES_EQUAL(result.self_check_result(), Ydb::Monitoring::SelfCheck::GOOD);
+            UNIT_ASSERT_VALUES_EQUAL(result.database_status_size(), 1);
+            const auto &database_status = result.database_status(0);
+
+            UNIT_ASSERT_VALUES_EQUAL(database_status.overall(), Ydb::Monitoring::StatusFlag::GREEN);
+            UNIT_ASSERT_VALUES_EQUAL(database_status.storage().overall(), Ydb::Monitoring::StatusFlag::GREEN);
+            UNIT_ASSERT_VALUES_EQUAL(database_status.storage().pools().size(), 1);
+            UNIT_ASSERT_VALUES_EQUAL(database_status.storage().pools()[0].overall(), Ydb::Monitoring::StatusFlag::GREEN);
+            UNIT_ASSERT_VALUES_EQUAL(database_status.storage().pools()[0].groups().size(), 1);
+            UNIT_ASSERT_VALUES_EQUAL(database_status.storage().pools()[0].groups()[0].overall(), Ydb::Monitoring::StatusFlag::GREEN);
+
+            UNIT_ASSERT_VALUES_EQUAL(result.issue_log_size(), 0);
         }
+    }
+
+    Y_UNIT_TEST(LayoutIncorrect) {
+        LayoutCorrectTest(false);
+    }
+
+    Y_UNIT_TEST(LayoutCorrect) {
+        LayoutCorrectTest(true);
+    }
+
+    Y_UNIT_TEST(LayoutNoInfo) {
+        LayoutCorrectTest(std::nullopt);
     }
 }
 }

--- a/ydb/core/health_check/health_check_ut.cpp
+++ b/ydb/core/health_check/health_check_ut.cpp
@@ -2219,7 +2219,7 @@ Y_UNIT_TEST_SUITE(THealthCheckTest) {
         TestConfigUpdateNodeRestartsPerPeriod(runtime, sender, nodeRestarts / 5, nodeRestarts / 2, nodeId, Ydb::Monitoring::StatusFlag::ORANGE);
     }
 
-    void LayoutCorrectTest(std::optional<bool> layoutCorrect) {
+    void LayoutCorrectTest(bool layoutCorrect) {
         TPortManager tp;
         ui16 port = tp.GetPort(2134);
         ui16 grpcPort = tp.GetPort(2135);
@@ -2241,11 +2241,7 @@ Y_UNIT_TEST_SUITE(THealthCheckTest) {
                     auto* x = reinterpret_cast<NSysView::TEvSysView::TEvGetGroupsResponse::TPtr*>(&ev);
                     auto& record = (*x)->Get()->Record;
                     for (auto& entry : *record.mutable_entries()) {
-                        if (layoutCorrect.has_value()) {
-                            entry.mutable_info()->set_layoutcorrect(*layoutCorrect);
-                        } else {
-                            entry.mutable_info()->clear_layoutcorrect();
-                        }
+                        entry.mutable_info()->set_layoutcorrect(layoutCorrect);
                     }
                     break;
                 }
@@ -2260,7 +2256,17 @@ Y_UNIT_TEST_SUITE(THealthCheckTest) {
         runtime.Send(new IEventHandle(NHealthCheck::MakeHealthCheckID(), sender, request, 0));
         auto result = runtime.GrabEdgeEvent<NHealthCheck::TEvSelfCheckResult>(handle)->Result;
 
-        if (layoutCorrect.has_value() && !*layoutCorrect) {
+        if (layoutCorrect) {
+            UNIT_ASSERT_VALUES_EQUAL(result.self_check_result(), Ydb::Monitoring::SelfCheck::GOOD);
+            UNIT_ASSERT_VALUES_EQUAL(result.database_status_size(), 1);
+            const auto &database_status = result.database_status(0);
+
+            UNIT_ASSERT_VALUES_EQUAL(database_status.storage().overall(), Ydb::Monitoring::StatusFlag::GREEN);
+            UNIT_ASSERT_VALUES_EQUAL(database_status.storage().pools().size(), 1);
+            UNIT_ASSERT_VALUES_EQUAL(database_status.storage().pools()[0].overall(), Ydb::Monitoring::StatusFlag::GREEN);
+            UNIT_ASSERT_VALUES_EQUAL(database_status.storage().pools()[0].groups().size(), 1);
+            UNIT_ASSERT_VALUES_EQUAL(database_status.storage().pools()[0].groups()[0].overall(), Ydb::Monitoring::StatusFlag::GREEN);
+        } else {
             UNIT_ASSERT_VALUES_EQUAL(result.self_check_result(), Ydb::Monitoring::SelfCheck::MAINTENANCE_REQUIRED);
             UNIT_ASSERT_VALUES_EQUAL(result.database_status_size(), 1);
             const auto &database_status = result.database_status(0);
@@ -2275,7 +2281,6 @@ Y_UNIT_TEST_SUITE(THealthCheckTest) {
             for (const auto &issue_log : result.issue_log()) {
                 if (issue_log.level() == 1 && issue_log.type() == "DATABASE") {
                     UNIT_ASSERT_VALUES_EQUAL(issue_log.location().database().name(), "/Root");
-                    UNIT_ASSERT_VALUES_EQUAL(issue_log.message(), "Database has storage issues");
                 } else if (issue_log.level() == 2 && issue_log.type() == "STORAGE") {
                     UNIT_ASSERT_VALUES_EQUAL(issue_log.location().database().name(), "/Root");
                     UNIT_ASSERT_VALUES_EQUAL(issue_log.message(), "Storage has no redundancy");
@@ -2287,19 +2292,6 @@ Y_UNIT_TEST_SUITE(THealthCheckTest) {
                     UNIT_ASSERT_VALUES_EQUAL(issue_log.message(), "Group layout is incorrect");
                 }
             }
-        } else {
-            UNIT_ASSERT_VALUES_EQUAL(result.self_check_result(), Ydb::Monitoring::SelfCheck::GOOD);
-            UNIT_ASSERT_VALUES_EQUAL(result.database_status_size(), 1);
-            const auto &database_status = result.database_status(0);
-
-            UNIT_ASSERT_VALUES_EQUAL(database_status.overall(), Ydb::Monitoring::StatusFlag::GREEN);
-            UNIT_ASSERT_VALUES_EQUAL(database_status.storage().overall(), Ydb::Monitoring::StatusFlag::GREEN);
-            UNIT_ASSERT_VALUES_EQUAL(database_status.storage().pools().size(), 1);
-            UNIT_ASSERT_VALUES_EQUAL(database_status.storage().pools()[0].overall(), Ydb::Monitoring::StatusFlag::GREEN);
-            UNIT_ASSERT_VALUES_EQUAL(database_status.storage().pools()[0].groups().size(), 1);
-            UNIT_ASSERT_VALUES_EQUAL(database_status.storage().pools()[0].groups()[0].overall(), Ydb::Monitoring::StatusFlag::GREEN);
-
-            UNIT_ASSERT_VALUES_EQUAL(result.issue_log_size(), 0);
         }
     }
 
@@ -2309,10 +2301,6 @@ Y_UNIT_TEST_SUITE(THealthCheckTest) {
 
     Y_UNIT_TEST(LayoutCorrect) {
         LayoutCorrectTest(true);
-    }
-
-    Y_UNIT_TEST(LayoutNoInfo) {
-        LayoutCorrectTest(std::nullopt);
     }
 }
 }

--- a/ydb/core/protos/sys_view.proto
+++ b/ydb/core/protos/sys_view.proto
@@ -277,7 +277,7 @@ message TGroupInfo {
     // desired disk categories ?
     // down/persisted down ?
     // metrics ?
-    optional bool LayoutCorrect = 16; // is the group layout correct?
+    optional bool LayoutCorrect = 16 [default = true];  // is the group layout correct?
 }
 
 message TGroupEntry {


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

set a default value for `layoutCorrect`

### Changelog category <!-- remove all except one -->

* Bugfix 

### Description for reviewers <!-- (optional) description for those who read this PR -->

The scenario for HealthCheck was missed where `BSC`  may not set `layoutCorrect` in the response in older YDB versions. In this case, `layoutCorrect` will be read as false by default and healthcheck could report `bad layout` issues.
...