### PR TITLE
Fix `-d /Root` in `ydb admin cluster dump`

### DIFF
--- a/ydb/apps/ydb/CHANGELOG.md
+++ b/ydb/apps/ydb/CHANGELOG.md
@@ -5,6 +5,7 @@
 * YDB CLI help message improvements. Different display for detailed help and brief help.
 * Support coordination nodes in `ydb scheme rmdir --recursive`.
 * Fixed return code of command `ydb workload * run --check-canonical` for the case when benchmark query results differ from canonical ones.
+* Fixed scheme error in `ydb admin cluster dump` when specifying a domain database.
 
 ## 2.20.0 ##
 

--- a/ydb/library/backup/backup.cpp
+++ b/ydb/library/backup/backup.cpp
@@ -1474,8 +1474,12 @@ void BackupCluster(const TDriver& driver, TFsPath folderPath) {
 
         BackupClusterRoot(driver, folderPath);
         auto databases = ListDatabases(driver);
+        TDriverConfig dbDriverCfg = driver.GetConfig();
         for (const auto& database : databases.GetPaths()) {
-            BackupDatabaseImpl(driver, TString(database), folderPath.Child("." + database), {
+            dbDriverCfg.SetDatabase(database);
+            TDriver dbDriver(dbDriverCfg);
+
+            BackupDatabaseImpl(dbDriver, TString(database), folderPath.Child("." + database), {
                 .WithRegularUsers = false,
                 .WithContent = false,
             });

--- a/ydb/tests/functional/ydb_cli/test_ydb_backup.py
+++ b/ydb/tests/functional/ydb_cli/test_ydb_backup.py
@@ -1299,7 +1299,14 @@ class TestRestoreNoData(BaseTestBackupInFiles):
 class BaseTestClusterBackupInFiles(object):
     @classmethod
     def setup_class(cls):
-        cls.cluster = KiKiMR(KikimrConfigGenerator(extra_feature_flags=["enable_resource_pools"]))
+        cls.cluster = KiKiMR(KikimrConfigGenerator(
+            extra_feature_flags=[
+                "enable_strict_acl_check",
+                "enable_strict_user_management",
+                "enable_database_admin"
+            ],
+            domain_login_only=False,
+        ))
         cls.cluster.start()
 
         cls.root_dir = "/Root"
@@ -1366,6 +1373,7 @@ class BaseTestClusterBackupInFiles(object):
     def create_cluster_backup(cls, expected_files, additional_args=[]):
         cls.create_backup(
             [
+                "--database", cls.root_dir,
                 "admin", "cluster", "dump",
             ],
             expected_files,

--- a/ydb/tests/library/harness/kikimr_config.py
+++ b/ydb/tests/library/harness/kikimr_config.py
@@ -165,6 +165,7 @@ class KikimrConfigGenerator(object):
             enable_resource_pools=None,
             grouped_memory_limiter_config=None,
             query_service_config=None,
+            domain_login_only=None,
     ):
         if extra_feature_flags is None:
             extra_feature_flags = []
@@ -348,6 +349,11 @@ class KikimrConfigGenerator(object):
 
         if auth_config_path:
             self.yaml_config["auth_config"] = _load_yaml_config(auth_config_path)
+
+        if domain_login_only is not None:
+            if "auth_config" not in self.yaml_config:
+                self.yaml_config["auth_config"] = dict()
+            self.yaml_config["auth_config"]["domain_login_only"] = domain_login_only
 
         if fq_config_path:
             self.yaml_config["federated_query_config"] = _load_yaml_config(fq_config_path)


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

Fixed scheme error in `ydb admin cluster dump` when specifying a domain database. https://github.com/ydb-platform/ydb/issues/16262

### Changelog category <!-- remove all except one -->

* Bugfix