### PR TITLE
25-1: Fix `-d /Root` in `ydb admin cluster dump` 

### DIFF
--- a/ydb/apps/ydb/CHANGELOG.md
+++ b/ydb/apps/ydb/CHANGELOG.md
@@ -16,6 +16,7 @@
 * Include topics in local backups (`ydb tools dump` and `ydb tools restore`). In this release, only the settings of the topics are retained; messages are not included in the backup.
 * Added `ydb admin cluster dump` and `ydb admin cluster restore` commands for dumping all cluster-level data
 * Added `ydb admin database dump` and `ydb admin database restore` commands for dumping all database-level data
+* Fixed scheme error in `ydb admin cluster dump` when specifying a domain database.
 
 ## 2.19.0 ##
 

--- a/ydb/library/backup/backup.cpp
+++ b/ydb/library/backup/backup.cpp
@@ -1476,8 +1476,12 @@ void BackupCluster(const TDriver& driver, TFsPath folderPath) {
 
         BackupClusterRoot(driver, folderPath);
         auto databases = ListDatabases(driver);
+        TDriverConfig dbDriverCfg = driver.GetConfig();
         for (const auto& database : databases.GetPaths()) {
-            BackupDatabaseImpl(driver, TString(database), folderPath.Child("." + database), {
+            dbDriverCfg.SetDatabase(database);
+            TDriver dbDriver(dbDriverCfg);
+
+            BackupDatabaseImpl(dbDriver, TString(database), folderPath.Child("." + database), {
                 .WithRegularUsers = false,
                 .WithContent = false,
             });

--- a/ydb/tests/functional/ydb_cli/test_ydb_backup.py
+++ b/ydb/tests/functional/ydb_cli/test_ydb_backup.py
@@ -1299,7 +1299,14 @@ class TestRestoreNoData(BaseTestBackupInFiles):
 class BaseTestClusterBackupInFiles(object):
     @classmethod
     def setup_class(cls):
-        cls.cluster = KiKiMR(KikimrConfigGenerator(extra_feature_flags=["enable_resource_pools"]))
+        cls.cluster = KiKiMR(KikimrConfigGenerator(
+            extra_feature_flags=[
+                "enable_strict_acl_check",
+                "enable_strict_user_management",
+                "enable_database_admin"
+            ],
+            domain_login_only=False,
+        ))
         cls.cluster.start()
 
         cls.root_dir = "/Root"
@@ -1366,6 +1373,7 @@ class BaseTestClusterBackupInFiles(object):
     def create_cluster_backup(cls, expected_files, additional_args=[]):
         cls.create_backup(
             [
+                "--database", cls.root_dir,
                 "admin", "cluster", "dump",
             ],
             expected_files,

--- a/ydb/tests/library/harness/kikimr_config.py
+++ b/ydb/tests/library/harness/kikimr_config.py
@@ -164,6 +164,7 @@ class KikimrConfigGenerator(object):
             separate_node_configs=False,
             default_clusteradmin=None,
             enable_resource_pools=None,
+            domain_login_only=None,
     ):
         if extra_feature_flags is None:
             extra_feature_flags = []
@@ -349,6 +350,11 @@ class KikimrConfigGenerator(object):
 
         if auth_config_path:
             self.yaml_config["auth_config"] = _load_yaml_config(auth_config_path)
+
+        if domain_login_only is not None:
+            if "auth_config" not in self.yaml_config:
+                self.yaml_config["auth_config"] = dict()
+            self.yaml_config["auth_config"]["domain_login_only"] = domain_login_only
 
         if fq_config_path:
             self.yaml_config["federated_query_config"] = _load_yaml_config(fq_config_path)


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

Fixed scheme error in `ydb admin cluster dump` when specifying a domain database. https://github.com/ydb-platform/ydb/issues/16262

### Changelog category <!-- remove all except one -->

* Bugfix

### Description for reviewers <!-- (optional) description for those who read this PR -->

Cherry-picked from #16943
