### PR TITLE
Add operation details in audit logging of operation 'MODIFY USER'

### DIFF
--- a/ydb/core/tx/schemeshard/schemeshard_audit_log.cpp
+++ b/ydb/core/tx/schemeshard/schemeshard_audit_log.cpp
@@ -119,7 +119,6 @@ void AuditLogModifySchemeOperation(const NKikimrSchemeOp::TModifyScheme& operati
         AUDIT_PART("sanitized_token", (!sanitizedToken.empty() ? sanitizedToken : EmptyValue))
         AUDIT_PART("database", (!databasePath.IsEmpty() ? databasePath.GetDomainPathString() : EmptyValue))
         AUDIT_PART("operation", logEntry.Operation)
-        AUDIT_PART("operation_details", logEntry.OperationDetails,!logEntry.OperationDetails.empty())
         AUDIT_PART("paths", RenderList(logEntry.Paths), !logEntry.Paths.empty())
         AUDIT_PART("status", GeneralStatus(status))
         AUDIT_PART("detailed_status", NKikimrScheme::EStatus_Name(status))
@@ -129,9 +128,9 @@ void AuditLogModifySchemeOperation(const NKikimrSchemeOp::TModifyScheme& operati
             AUDIT_PART(name, (!value.empty() ? value : EmptyValue))
         }
 
-        AUDIT_PART("cloud_id", cloud_id, !cloud_id.empty());
-        AUDIT_PART("folder_id", folder_id, !folder_id.empty());
-        AUDIT_PART("resource_id", database_id, !database_id.empty());
+        AUDIT_PART("cloud_id", cloud_id, !cloud_id.empty())
+        AUDIT_PART("folder_id", folder_id, !folder_id.empty())
+        AUDIT_PART("resource_id", database_id, !database_id.empty())
 
         // Additionally:
 
@@ -141,21 +140,23 @@ void AuditLogModifySchemeOperation(const NKikimrSchemeOp::TModifyScheme& operati
         // 1. explicit operation ESchemeOpModifyACL -- to modify ACL on a path
         // 2. ESchemeOpMkDir or ESchemeOpCreate* operations -- to set rights to newly created paths/entities
         // 3. ESchemeOpCopyTable -- to be checked against acl size limit, not to be applied in any way
-        AUDIT_PART("new_owner", logEntry.NewOwner, !logEntry.NewOwner.empty());
-        AUDIT_PART("acl_add", RenderList(logEntry.ACLAdd), !logEntry.ACLAdd.empty());
-        AUDIT_PART("acl_remove", RenderList(logEntry.ACLRemove), !logEntry.ACLRemove.empty());
+        AUDIT_PART("new_owner", logEntry.NewOwner, !logEntry.NewOwner.empty())
+        AUDIT_PART("acl_add", RenderList(logEntry.ACLAdd), !logEntry.ACLAdd.empty())
+        AUDIT_PART("acl_remove", RenderList(logEntry.ACLRemove), !logEntry.ACLRemove.empty())
 
         // AlterUserAttributes.
         // 1. explicit operation ESchemeOpAlterUserAttributes -- to modify user attributes on a path
         // 2. ESchemeOpMkDir or some ESchemeOpCreate* operations -- to set user attributes for newly created paths/entities
-        AUDIT_PART("user_attrs_add", RenderList(logEntry.UserAttrsAdd), !logEntry.UserAttrsAdd.empty());
-        AUDIT_PART("user_attrs_remove", RenderList(logEntry.UserAttrsRemove), !logEntry.UserAttrsRemove.empty());
+        AUDIT_PART("user_attrs_add", RenderList(logEntry.UserAttrsAdd), !logEntry.UserAttrsAdd.empty())
+        AUDIT_PART("user_attrs_remove", RenderList(logEntry.UserAttrsRemove), !logEntry.UserAttrsRemove.empty())
 
         // AlterLogin.
         // explicit operation ESchemeOpAlterLogin -- to modify user and groups
-        AUDIT_PART("login_user", logEntry.LoginUser);
-        AUDIT_PART("login_group", logEntry.LoginGroup);
-        AUDIT_PART("login_member", logEntry.LoginMember);
+        AUDIT_PART("login_user", logEntry.LoginUser)
+        AUDIT_PART("login_group", logEntry.LoginGroup)
+        AUDIT_PART("login_member", logEntry.LoginMember)
+
+        AUDIT_PART("login_modify_user_change", RenderList(logEntry.LoginModifyUserChange), logEntry.LoginModifyUserChange)
     );
 }
 

--- a/ydb/core/tx/schemeshard/schemeshard_audit_log.cpp
+++ b/ydb/core/tx/schemeshard/schemeshard_audit_log.cpp
@@ -119,6 +119,7 @@ void AuditLogModifySchemeOperation(const NKikimrSchemeOp::TModifyScheme& operati
         AUDIT_PART("sanitized_token", (!sanitizedToken.empty() ? sanitizedToken : EmptyValue))
         AUDIT_PART("database", (!databasePath.IsEmpty() ? databasePath.GetDomainPathString() : EmptyValue))
         AUDIT_PART("operation", logEntry.Operation)
+        AUDIT_PART("operation_details", logEntry.OperationDetails,!logEntry.OperationDetails.empty())
         AUDIT_PART("paths", RenderList(logEntry.Paths), !logEntry.Paths.empty())
         AUDIT_PART("status", GeneralStatus(status))
         AUDIT_PART("detailed_status", NKikimrScheme::EStatus_Name(status))

--- a/ydb/core/tx/schemeshard/schemeshard_audit_log.cpp
+++ b/ydb/core/tx/schemeshard/schemeshard_audit_log.cpp
@@ -156,7 +156,7 @@ void AuditLogModifySchemeOperation(const NKikimrSchemeOp::TModifyScheme& operati
         AUDIT_PART("login_group", logEntry.LoginGroup)
         AUDIT_PART("login_member", logEntry.LoginMember)
 
-        AUDIT_PART("login_modify_user_change", RenderList(logEntry.LoginModifyUserChange), logEntry.LoginModifyUserChange)
+        AUDIT_PART("login_user_change", RenderList(logEntry.LoginUserChange), logEntry.LoginUserChange)
     );
 }
 

--- a/ydb/core/tx/schemeshard/schemeshard_audit_log_fragment.cpp
+++ b/ydb/core/tx/schemeshard/schemeshard_audit_log_fragment.cpp
@@ -678,7 +678,7 @@ struct TChangeLogin {
     TString LoginUser;
     TString LoginGroup;
     TString LoginMember;
-    TVector<TString> LoginModifyUserChange;
+    TVector<TString> LoginUserChange;
 };
 
 TChangeLogin ExtractLoginChange(const NKikimrSchemeOp::TModifyScheme& tx) {
@@ -697,15 +697,15 @@ TChangeLogin ExtractLoginChange(const NKikimrSchemeOp::TModifyScheme& tx) {
                 result.LoginUser = modify.GetUser();
 
                 if (modify.HasPassword()) { // there is no difference beetwen password and password's hash
-                    result.LoginModifyUserChange.push_back("password");
+                    result.LoginUserChange.push_back("password");
                 }
 
                 if (modify.HasCanLogin() && modify.GetCanLogin()) {
-                    result.LoginModifyUserChange.push_back("unblocking");
+                    result.LoginUserChange.push_back("unblocking");
                 }
 
                 if (modify.HasCanLogin() && !modify.GetCanLogin()) {
-                    result.LoginModifyUserChange.push_back("blocking");
+                    result.LoginUserChange.push_back("blocking");
                 }
 
                 break;
@@ -759,7 +759,7 @@ namespace NKikimr::NSchemeShard {
 TAuditLogFragment MakeAuditLogFragment(const NKikimrSchemeOp::TModifyScheme& tx) {
     auto [aclAdd, aclRemove] = ExtractACLChange(tx);
     auto [userAttrsAdd, userAttrsRemove] = ExtractUserAttrChange(tx);
-    auto [loginUser, loginGroup, loginMember, loginModifyUserChange] = ExtractLoginChange(tx);
+    auto [loginUser, loginGroup, loginMember, loginUserChange] = ExtractLoginChange(tx);
 
     return {
         .Operation = DefineUserOperationName(tx),
@@ -772,7 +772,7 @@ TAuditLogFragment MakeAuditLogFragment(const NKikimrSchemeOp::TModifyScheme& tx)
         .LoginUser = loginUser,
         .LoginGroup = loginGroup,
         .LoginMember = loginMember,
-        .LoginModifyUserChange = loginModifyUserChange
+        .LoginUserChange = loginUserChange
     };
 }
 

--- a/ydb/core/tx/schemeshard/schemeshard_audit_log_fragment.h
+++ b/ydb/core/tx/schemeshard/schemeshard_audit_log_fragment.h
@@ -21,7 +21,7 @@ struct TAuditLogFragment {
     TString LoginUser;
     TString LoginGroup;
     TString LoginMember;
-    TVector<TString> LoginModifyUserChange;
+    TVector<TString> LoginUserChange;
 };
 
 TAuditLogFragment MakeAuditLogFragment(const NKikimrSchemeOp::TModifyScheme& tx);

--- a/ydb/core/tx/schemeshard/schemeshard_audit_log_fragment.h
+++ b/ydb/core/tx/schemeshard/schemeshard_audit_log_fragment.h
@@ -12,7 +12,6 @@ namespace NKikimr::NSchemeShard {
 
 struct TAuditLogFragment {
     TString Operation;
-    TString OperationDetails; // Currently in use only for MODIFY USER
     TVector<TString> Paths;
     TString NewOwner;
     TVector<TString> ACLAdd;
@@ -22,6 +21,7 @@ struct TAuditLogFragment {
     TString LoginUser;
     TString LoginGroup;
     TString LoginMember;
+    TVector<TString> LoginModifyUserChange;
 };
 
 TAuditLogFragment MakeAuditLogFragment(const NKikimrSchemeOp::TModifyScheme& tx);

--- a/ydb/core/tx/schemeshard/schemeshard_audit_log_fragment.h
+++ b/ydb/core/tx/schemeshard/schemeshard_audit_log_fragment.h
@@ -12,6 +12,7 @@ namespace NKikimr::NSchemeShard {
 
 struct TAuditLogFragment {
     TString Operation;
+    TString OperationDetails; // Currently in use only for MODIFY USER
     TVector<TString> Paths;
     TString NewOwner;
     TVector<TString> ACLAdd;

--- a/ydb/core/tx/schemeshard/ut_helpers/helpers.cpp
+++ b/ydb/core/tx/schemeshard/ut_helpers/helpers.cpp
@@ -2114,10 +2114,7 @@ namespace NSchemeShardUT_Private {
         return event->Record;
     }
 
-namespace
-{
-    template<typename TInitiator>
-    void ModifyUser(TTestActorRuntime& runtime, ui64 txId, const TString& database, TInitiator&& initiator) {
+    void ModifyUser(TTestActorRuntime& runtime, ui64 txId, const TString& database, std::function<void(::NKikimrSchemeOp::TLoginModifyUser*)>&& initiator) {
         auto modifyTx = std::make_unique<TEvSchemeShard::TEvModifySchemeTransaction>(txId, TTestTxConfig::SchemeShard);
         auto transaction = modifyTx->Record.AddTransaction();
         transaction->SetWorkingDir(database);
@@ -2131,7 +2128,6 @@ namespace
         TAutoPtr<IEventHandle> handle;
         [[maybe_unused]]auto event = runtime.GrabEdgeEvent<TEvSchemeShard::TEvModifySchemeTransactionResult>(handle); // wait()        
     }
-} // anonymous namespace    
 
     void ChangeIsEnabledUser(TTestActorRuntime& runtime, ui64 txId, const TString& database, const TString& user, bool isEnabled) {
         ModifyUser(runtime, txId, database, [user, isEnabled](auto* alterUser) {

--- a/ydb/core/tx/schemeshard/ut_helpers/helpers.cpp
+++ b/ydb/core/tx/schemeshard/ut_helpers/helpers.cpp
@@ -2114,7 +2114,10 @@ namespace NSchemeShardUT_Private {
         return event->Record;
     }
 
-    void ChangeIsEnabledUser(TTestActorRuntime& runtime, ui64 txId, const TString& database, const TString& user, bool isEnabled) {
+namespace
+{
+    template<typename TInitiator>
+    void ModifyUser(TTestActorRuntime& runtime, ui64 txId, const TString& database, TInitiator&& initiator) {
         auto modifyTx = std::make_unique<TEvSchemeShard::TEvModifySchemeTransaction>(txId, TTestTxConfig::SchemeShard);
         auto transaction = modifyTx->Record.AddTransaction();
         transaction->SetWorkingDir(database);
@@ -2122,12 +2125,34 @@ namespace NSchemeShardUT_Private {
 
         auto alterUser = transaction->MutableAlterLogin()->MutableModifyUser();
 
-        alterUser->SetUser(user);
-        alterUser->SetCanLogin(isEnabled);
+        initiator(alterUser);
 
         AsyncSend(runtime, TTestTxConfig::SchemeShard, modifyTx.release());
         TAutoPtr<IEventHandle> handle;
-        [[maybe_unused]]auto event = runtime.GrabEdgeEvent<TEvSchemeShard::TEvModifySchemeTransactionResult>(handle); // wait()
+        [[maybe_unused]]auto event = runtime.GrabEdgeEvent<TEvSchemeShard::TEvModifySchemeTransactionResult>(handle); // wait()        
+    }
+} // anonymous namespace    
+
+    void ChangeIsEnabledUser(TTestActorRuntime& runtime, ui64 txId, const TString& database, const TString& user, bool isEnabled) {
+        ModifyUser(runtime, txId, database, [user, isEnabled](auto* alterUser) {
+            alterUser->SetUser(std::move(user));
+            alterUser->SetCanLogin(isEnabled);
+        });
+    }
+
+    void ChangePasswordUser(TTestActorRuntime& runtime, ui64 txId, const TString& database, const TString& user, const TString& password) {
+        ModifyUser(runtime, txId, database, [user, password](auto* alterUser) {
+            alterUser->SetUser(std::move(user));
+            alterUser->SetPassword(std::move(password));
+        });
+    }
+
+    void ChangePasswordHashUser(TTestActorRuntime& runtime, ui64 txId, const TString& database, const TString& user, const TString& hash) {
+        ModifyUser(runtime, txId, database, [user, hash](auto* alterUser) {
+            alterUser->SetUser(std::move(user));
+            alterUser->SetPassword(std::move(hash));
+            alterUser->SetIsHashedPassword(true);
+        });
     }
 
     // class TFakeDataReq {

--- a/ydb/core/tx/schemeshard/ut_helpers/helpers.h
+++ b/ydb/core/tx/schemeshard/ut_helpers/helpers.h
@@ -551,6 +551,8 @@ namespace NSchemeShardUT_Private {
     NKikimrScheme::TEvLoginResult Login(TTestActorRuntime& runtime,
         const TString& user, const TString& password);
 
+    void ModifyUser(TTestActorRuntime& runtime, ui64 txId, const TString& database, std::function<void(::NKikimrSchemeOp::TLoginModifyUser*)>&& initiator);
+
     void ChangeIsEnabledUser(TTestActorRuntime& runtime, ui64 txId, const TString& database,
         const TString& user, bool isEnabled);
 

--- a/ydb/core/tx/schemeshard/ut_helpers/helpers.h
+++ b/ydb/core/tx/schemeshard/ut_helpers/helpers.h
@@ -554,6 +554,12 @@ namespace NSchemeShardUT_Private {
     void ChangeIsEnabledUser(TTestActorRuntime& runtime, ui64 txId, const TString& database,
         const TString& user, bool isEnabled);
 
+    void ChangePasswordUser(TTestActorRuntime& runtime, ui64 txId, const TString& database,
+        const TString& user, const TString& password);
+
+    void ChangePasswordHashUser(TTestActorRuntime& runtime, ui64 txId, const TString& database,
+        const TString& user, const TString& hash);
+    
     // Mimics data query to a single table with multiple partitions
     class TFakeDataReq {
     public:

--- a/ydb/core/tx/schemeshard/ut_login/ut_login.cpp
+++ b/ydb/core/tx/schemeshard/ut_login/ut_login.cpp
@@ -1825,7 +1825,7 @@ Y_UNIT_TEST_SUITE(TWebLoginService) {
             UNIT_ASSERT_STRING_CONTAINS(last, Sprintf("operation=%s", operation.c_str()));
 
             if (!details.empty()) {
-                UNIT_ASSERT_STRING_CONTAINS(last, Sprintf("login_modify_user_change=%s", render(details).c_str()));
+                UNIT_ASSERT_STRING_CONTAINS(last, Sprintf("login_user_change=%s", render(details).c_str()));
             }
 
             UNIT_ASSERT_STRING_CONTAINS(last, "component=schemeshard");


### PR DESCRIPTION
### Changelog entry

In schemeshard, we have audit_log_component, which outputs audit logs. There was not details of operation MODIFY(ALTER) USER. So, we need to know what this operation do. There are some ways:

1. Change the password (or hash);
2. Block user;
3. Unblock user.

This PR adds details into audit_log.

### Changelog category <!-- remove all except one -->

* Improvement