### PR TITLE
Reduce column count under santizer to reduce execution time

### DIFF
--- a/ydb/core/kqp/ut/olap/sparsed_ut.cpp
+++ b/ydb/core/kqp/ut/olap/sparsed_ut.cpp
@@ -10,6 +10,8 @@
 #include <ydb/core/wrappers/fake_storage.h>
 #include <ydb/core/tx/columnshard/blobs_action/common/const.h>
 
+#include <dlfcn.h>
+
 namespace NKikimr::NKqp {
 
 Y_UNIT_TEST_SUITE(KqpOlapSparsed) {
@@ -232,7 +234,14 @@ Y_UNIT_TEST_SUITE(KqpOlapSparsed) {
             FillCircle(0.4, 14000);
         }
 
+        static bool IsAsanEnabled() {
+            return (dlsym(RTLD_DEFAULT, "__asan_init") != nullptr);
+        }
+
         void ExecuteMultiColumn() {
+            if (IsAsanEnabled()) {
+                MultiColumnRepCount = 30;
+            }
             CSController->DisableBackground(NKikimr::NYDBTest::ICSController::EBackground::Indexation);
             CSController->DisableBackground(NKikimr::NYDBTest::ICSController::EBackground::Compaction);
             CSController->SetOverridePeriodicWakeupActivationPeriod(TDuration::MilliSeconds(100));

--- a/ydb/core/kqp/ut/olap/sparsed_ut.cpp
+++ b/ydb/core/kqp/ut/olap/sparsed_ut.cpp
@@ -10,8 +10,6 @@
 #include <ydb/core/wrappers/fake_storage.h>
 #include <ydb/core/tx/columnshard/blobs_action/common/const.h>
 
-#include <dlfcn.h>
-
 namespace NKikimr::NKqp {
 
 Y_UNIT_TEST_SUITE(KqpOlapSparsed) {
@@ -234,14 +232,10 @@ Y_UNIT_TEST_SUITE(KqpOlapSparsed) {
             FillCircle(0.4, 14000);
         }
 
-        static bool IsAsanEnabled() {
-            return (dlsym(RTLD_DEFAULT, "__asan_init") != nullptr);
-        }
-
         void ExecuteMultiColumn() {
-            if (IsAsanEnabled()) {
-                MultiColumnRepCount = 30;
-            }
+#ifdef address_sanitizer_enabled
+            MultiColumnRepCount = 30;
+#endif
             CSController->DisableBackground(NKikimr::NYDBTest::ICSController::EBackground::Indexation);
             CSController->DisableBackground(NKikimr::NYDBTest::ICSController::EBackground::Compaction);
             CSController->SetOverridePeriodicWakeupActivationPeriod(TDuration::MilliSeconds(100));


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

Create 30 groups of columns instead of 100 under asan to eliminate timeout

...

### Changelog category <!-- remove all except one -->


* Improvement


### Description for reviewers <!-- (optional) description for those who read this PR -->

...
