### PR TITLE
Use soft and hard limits for output [channel] backpressure

### DIFF
--- a/ydb/core/kqp/runtime/kqp_effects.cpp
+++ b/ydb/core/kqp/runtime/kqp_effects.cpp
@@ -15,8 +15,8 @@ public:
     TKqpApplyEffectsConsumer(NUdf::IApplyContext* applyCtx)
         : ApplyCtx(applyCtx) {}
 
-    bool IsFull() const override {
-        return false;
+    EDqFillLevel GetFillLevel() const override {
+        return NoLimit;
     }
 
     void Consume(NUdf::TUnboxedValue&& value) final {

--- a/ydb/core/kqp/runtime/kqp_output_stream.cpp
+++ b/ydb/core/kqp/runtime/kqp_output_stream.cpp
@@ -32,10 +32,15 @@ public:
         MKQL_ENSURE_S(KeyColumnTypes.size() == KeyColumnIndices.size());
 
         SortPartitions(Partitions, KeyColumnTypes, [](const auto& partition) { return partition.Range; });
+
+        Aggregator = std::make_shared<TDqFillAggregator>();
+        for (auto output : Outputs) {
+            output->SetFillAggregator(Aggregator);
+        }
     }
 
-    bool IsFull() const override {
-        return AnyOf(Outputs, [](const auto& output) { return output->IsFull(); });
+    EDqFillLevel GetFillLevel() const override {
+        return Aggregator->GetFillLevel();
     }
 
     void Consume(TUnboxedValue&& value) final {
@@ -67,6 +72,7 @@ private:
     TVector<TKqpRangePartition> Partitions;
     TVector<NScheme::TTypeInfo> KeyColumnTypes;
     TVector<ui32> KeyColumnIndices;
+    std::shared_ptr<TDqFillAggregator> Aggregator;
 };
 
 } // namespace

--- a/ydb/library/yql/dq/actors/compute/dq_async_compute_actor.cpp
+++ b/ydb/library/yql/dq/actors/compute/dq_async_compute_actor.cpp
@@ -367,7 +367,7 @@ private:
             if (channel) {
                 html << "DqOutputChannel.ChannelId: " << channel->GetChannelId() << "<br />";
                 html << "DqOutputChannel.ValuesCount: " << channel->GetValuesCount() << "<br />";
-                html << "DqOutputChannel.FillLevel: " << static_cast<ui32>(channel->UpdateFillLevel()) << "<br />";
+                html << "DqOutputChannel.FillLevel: " << static_cast<ui32>(channel->GetFillLevel()) << "<br />";
                 html << "DqOutputChannel.HasData: " << channel->HasData() << "<br />";
                 html << "DqOutputChannel.IsFinished: " << channel->IsFinished() << "<br />";
                 html << "DqInputChannel.OutputType: " << (channel->GetOutputType() ? channel->GetOutputType()->GetKindAsStr() : TString{"unknown"})  << "<br />";
@@ -399,7 +399,7 @@ private:
             if (info.Buffer || TaskRunnerStats.GetSink(id)) {
                 const auto& buffer = info.Buffer ? *info.Buffer : *TaskRunnerStats.GetSink(id);
                 html << "DqOutputBuffer.OutputIndex: " << buffer.GetOutputIndex() << "<br />";
-                // html << "DqOutputBuffer.FillLevel: " << static_cast<ui32>(buffer.UpdateFillLevel()) << "<br />";
+                html << "DqOutputBuffer.FillLevel: " << static_cast<ui32>(buffer.GetFillLevel()) << "<br />";
                 html << "DqOutputBuffer.OutputType: " << (buffer.GetOutputType() ? buffer.GetOutputType()->GetKindAsStr() : TString{"unknown"})  << "<br />";
                 html << "DqOutputBuffer.IsFinished: " << buffer.IsFinished() << "<br />";
                 html << "DqOutputBuffer.HasData: " << buffer.HasData() << "<br />";

--- a/ydb/library/yql/dq/actors/compute/dq_async_compute_actor.cpp
+++ b/ydb/library/yql/dq/actors/compute/dq_async_compute_actor.cpp
@@ -367,7 +367,7 @@ private:
             if (channel) {
                 html << "DqOutputChannel.ChannelId: " << channel->GetChannelId() << "<br />";
                 html << "DqOutputChannel.ValuesCount: " << channel->GetValuesCount() << "<br />";
-                html << "DqOutputChannel.IsFull: " << channel->IsFull() << "<br />";
+                html << "DqOutputChannel.FillLevel: " << static_cast<ui32>(channel->UpdateFillLevel()) << "<br />";
                 html << "DqOutputChannel.HasData: " << channel->HasData() << "<br />";
                 html << "DqOutputChannel.IsFinished: " << channel->IsFinished() << "<br />";
                 html << "DqInputChannel.OutputType: " << (channel->GetOutputType() ? channel->GetOutputType()->GetKindAsStr() : TString{"unknown"})  << "<br />";
@@ -399,7 +399,7 @@ private:
             if (info.Buffer || TaskRunnerStats.GetSink(id)) {
                 const auto& buffer = info.Buffer ? *info.Buffer : *TaskRunnerStats.GetSink(id);
                 html << "DqOutputBuffer.OutputIndex: " << buffer.GetOutputIndex() << "<br />";
-                html << "DqOutputBuffer.IsFull: " << buffer.IsFull() << "<br />";
+                // html << "DqOutputBuffer.FillLevel: " << static_cast<ui32>(buffer.UpdateFillLevel()) << "<br />";
                 html << "DqOutputBuffer.OutputType: " << (buffer.GetOutputType() ? buffer.GetOutputType()->GetKindAsStr() : TString{"unknown"})  << "<br />";
                 html << "DqOutputBuffer.IsFinished: " << buffer.IsFinished() << "<br />";
                 html << "DqOutputBuffer.HasData: " << buffer.HasData() << "<br />";

--- a/ydb/library/yql/dq/actors/compute/dq_sync_compute_actor_base.h
+++ b/ydb/library/yql/dq/actors/compute/dq_sync_compute_actor_base.h
@@ -54,6 +54,12 @@ protected:
     }
 
     void DoTerminateImpl() override {
+
+        if (TBase::State == NDqProto::COMPUTE_STATE_FAILURE) {
+            CA_LOG_E("******* Task Runner DEBUG: *******" << Endl
+                << TaskRunner->DebugString() << Endl);
+        }
+
         TaskRunner.Reset();
     }
 

--- a/ydb/library/yql/dq/actors/compute/dq_sync_compute_actor_base.h
+++ b/ydb/library/yql/dq/actors/compute/dq_sync_compute_actor_base.h
@@ -60,7 +60,7 @@ protected:
             if (stats.StartTs && TInstant::Now() - stats.StartTs > TDuration::Seconds(60)) {
                 auto taskRunnerDebugString = TaskRunner->GetOutputDebugString();
                 if (taskRunnerDebugString) {
-                    CA_LOG_E("TaskRunner->Output Debug String:" << Endl << taskRunnerDebugString << Endl);
+                    CA_LOG_E("TaskRunner->Output Debug String: " << taskRunnerDebugString);
                 }
             }
         }

--- a/ydb/library/yql/dq/runtime/dq_async_output.cpp
+++ b/ydb/library/yql/dq/runtime/dq_async_output.cpp
@@ -75,6 +75,10 @@ public:
         return PopStats;
     }
 
+    EDqFillLevel GetFillLevel() const override {
+        return FillLevel;
+    }
+
     EDqFillLevel UpdateFillLevel() override {
         auto result = EstimatedStoredBytes >= MaxStoredBytes ? HardLimit : NoLimit;
         if (FillLevel != result) {

--- a/ydb/library/yql/dq/runtime/dq_async_output.cpp
+++ b/ydb/library/yql/dq/runtime/dq_async_output.cpp
@@ -70,13 +70,25 @@ public:
     const TDqOutputStats& GetPushStats() const override {
         return PushStats;
     }
-    
+
     const TDqAsyncOutputBufferStats& GetPopStats() const override {
         return PopStats;
     }
 
-    bool IsFull() const override {
-        return EstimatedStoredBytes >= MaxStoredBytes;
+    EDqFillLevel UpdateFillLevel() override {
+        auto result = EstimatedStoredBytes >= MaxStoredBytes ? HardLimit : NoLimit;
+        if (FillLevel != result) {
+            if (Aggregator) {
+                Aggregator->UpdateCount(FillLevel, result);
+            }
+            FillLevel = result;
+        }
+        return result;
+    }
+
+    void SetFillAggregator(std::shared_ptr<TDqFillAggregator> aggregator) override {
+        Aggregator = aggregator;
+        Aggregator->AddCount(FillLevel);
     }
 
     void Push(NUdf::TUnboxedValue&& value) override {
@@ -265,22 +277,25 @@ private:
             PushStats.Resume();
         }
 
-        if (IsFull()) {
-            PopStats.TryPause();
-        }
+        auto fillLevel = UpdateFillLevel();
 
         if (PopStats.CollectFull()) {
+            if (fillLevel != NoLimit) {
+                PopStats.TryPause();
+            }
             PopStats.MaxMemoryUsage = std::max(PopStats.MaxMemoryUsage, EstimatedStoredBytes);
             PopStats.MaxRowsInMemory = std::max(PopStats.MaxRowsInMemory, Values.size());
         }
     }
 
     void ReportChunkOut(ui64 rows, ui64 bytes) {
+        auto fillLevel = UpdateFillLevel();
+
         if (PopStats.CollectBasic()) {
             PopStats.Bytes += bytes;
             PopStats.Rows += rows;
             PopStats.Chunks++;
-            if (!IsFull()) {
+            if (fillLevel == NoLimit) {
                 PopStats.Resume();
             }
         }
@@ -318,6 +333,8 @@ private:
     bool Finished = false;
     std::deque<TValueDesc> Values;
     ui64 EstimatedRowBytes = 0;
+    std::shared_ptr<TDqFillAggregator> Aggregator;
+    EDqFillLevel FillLevel = NoLimit;
 };
 
 } // namespace

--- a/ydb/library/yql/dq/runtime/dq_output.h
+++ b/ydb/library/yql/dq/runtime/dq_output.h
@@ -89,6 +89,7 @@ public:
     virtual const TDqOutputStats& GetPushStats() const = 0;
 
     // <| producer methods
+    virtual EDqFillLevel GetFillLevel() const = 0;
     virtual EDqFillLevel UpdateFillLevel() = 0;
     virtual void SetFillAggregator(std::shared_ptr<TDqFillAggregator> aggregator) = 0;
     // can throw TDqChannelStorageException

--- a/ydb/library/yql/dq/runtime/dq_output.h
+++ b/ydb/library/yql/dq/runtime/dq_output.h
@@ -71,6 +71,12 @@ struct TDqFillAggregator {
         }
         return Counts[static_cast<ui32>(SoftLimit)].load() ? SoftLimit : NoLimit;
     }
+
+    TString DebugString() {
+        return TStringBuilder() << "AGG: N=" << Counts[static_cast<ui32>(HardLimit)].load()
+            << " S=" << Counts[static_cast<ui32>(SoftLimit)].load()
+            << " H=" << Counts[static_cast<ui32>(HardLimit)].load();
+    }
 };
 
 class IDqOutput : public TSimpleRefCount<IDqOutput> {

--- a/ydb/library/yql/dq/runtime/dq_output.h
+++ b/ydb/library/yql/dq/runtime/dq_output.h
@@ -2,11 +2,12 @@
 
 #include <ydb/library/yql/dq/actors/protos/dq_events.pb.h>
 #include <yql/essentials/minikql/mkql_node.h>
+#include <yql/essentials/utils/yql_panic.h>
 
 #include <util/datetime/base.h>
 #include <util/generic/ptr.h>
 
-#include "dq_async_stats.h" 
+#include "dq_async_stats.h"
 
 namespace NYql {
 namespace NDqProto {
@@ -27,6 +28,51 @@ struct TDqOutputStats : public TDqAsyncStats {
     ui64 MaxRowsInMemory = 0;
 };
 
+enum EDqFillLevel {
+    NoLimit,
+    SoftLimit,
+    HardLimit
+};
+
+const constexpr ui32 FILL_COUNTERS_SIZE = 4u;
+
+struct TDqFillAggregator {
+
+    alignas(64) std::array<std::atomic<ui64>, FILL_COUNTERS_SIZE> Counts;
+
+    ui64 GetCount(EDqFillLevel level) {
+        ui32 index = static_cast<ui32>(level);
+        YQL_ENSURE(index < FILL_COUNTERS_SIZE);
+        return Counts[index].load();
+    }
+
+    void AddCount(EDqFillLevel level) {
+        ui32 index = static_cast<ui32>(level);
+        YQL_ENSURE(index < FILL_COUNTERS_SIZE);
+        Counts[index]++;
+    }
+
+    void UpdateCount(EDqFillLevel prevLevel, EDqFillLevel level) {
+        ui32 index1 = static_cast<ui32>(prevLevel);
+        ui32 index2 = static_cast<ui32>(level);
+        YQL_ENSURE(index1 < FILL_COUNTERS_SIZE && index2 < FILL_COUNTERS_SIZE);
+        if (index1 != index2) {
+            Counts[index1]--;
+            Counts[index2]++;
+        }
+    }
+
+    EDqFillLevel GetFillLevel() const {
+        if (Counts[static_cast<ui32>(HardLimit)].load()) {
+            return HardLimit;
+        }
+        if (Counts[static_cast<ui32>(NoLimit)].load()) {
+            return NoLimit;
+        }
+        return Counts[static_cast<ui32>(SoftLimit)].load() ? SoftLimit : NoLimit;
+    }
+};
+
 class IDqOutput : public TSimpleRefCount<IDqOutput> {
 public:
     using TPtr = TIntrusivePtr<IDqOutput>;
@@ -36,8 +82,8 @@ public:
     virtual const TDqOutputStats& GetPushStats() const = 0;
 
     // <| producer methods
-    [[nodiscard]]
-    virtual bool IsFull() const = 0;
+    virtual EDqFillLevel UpdateFillLevel() = 0;
+    virtual void SetFillAggregator(std::shared_ptr<TDqFillAggregator> aggregator) = 0;
     // can throw TDqChannelStorageException
     virtual void Push(NUdf::TUnboxedValue&& value) = 0;
     virtual void WidePush(NUdf::TUnboxedValue* values, ui32 count) = 0;

--- a/ydb/library/yql/dq/runtime/dq_output.h
+++ b/ydb/library/yql/dq/runtime/dq_output.h
@@ -57,8 +57,8 @@ struct TDqFillAggregator {
         ui32 index2 = static_cast<ui32>(level);
         YQL_ENSURE(index1 < FILL_COUNTERS_SIZE && index2 < FILL_COUNTERS_SIZE);
         if (index1 != index2) {
-            Counts[index1]--;
             Counts[index2]++;
+            Counts[index1]--;
         }
     }
 

--- a/ydb/library/yql/dq/runtime/dq_output.h
+++ b/ydb/library/yql/dq/runtime/dq_output.h
@@ -73,9 +73,10 @@ struct TDqFillAggregator {
     }
 
     TString DebugString() {
-        return TStringBuilder() << "AGG: N=" << Counts[static_cast<ui32>(HardLimit)].load()
+        return TStringBuilder() << "TDqFillAggregator { N=" << Counts[static_cast<ui32>(NoLimit)].load()
             << " S=" << Counts[static_cast<ui32>(SoftLimit)].load()
-            << " H=" << Counts[static_cast<ui32>(HardLimit)].load();
+            << " H=" << Counts[static_cast<ui32>(HardLimit)].load()
+            << " }";
     }
 };
 

--- a/ydb/library/yql/dq/runtime/dq_output_channel.cpp
+++ b/ydb/library/yql/dq/runtime/dq_output_channel.cpp
@@ -80,6 +80,10 @@ public:
         }
     }
 
+    EDqFillLevel GetFillLevel() const override {
+        return FillLevel;
+    }
+
     EDqFillLevel UpdateFillLevel() override {
         auto result = CalcFillLevel();
         if (FillLevel != result) {
@@ -109,7 +113,7 @@ public:
 
     // Try to split data before push to fulfill ChunkSizeLimit
     void DoPushSafe(NUdf::TUnboxedValue* values, ui32 width) {
-        YQL_ENSURE(UpdateFillLevel() != HardLimit);
+        YQL_ENSURE(GetFillLevel() != HardLimit);
 
         if (Finished) {
             return;

--- a/ydb/library/yql/dq/runtime/dq_output_channel.cpp
+++ b/ydb/library/yql/dq/runtime/dq_output_channel.cpp
@@ -72,20 +72,36 @@ public:
         return PopStats;
     }
 
-    [[nodiscard]]
-    bool IsFull() const override {
-        if (!Storage) {
-            return PackedDataSize + Packer.PackedSizeEstimate() >= MaxStoredBytes;
+    EDqFillLevel CalcFillLevel() const {
+        if (Storage) {
+            return FirstStoredId < NextStoredId ? (Storage->IsFull() ? HardLimit : SoftLimit) : NoLimit;
+        } else {
+            return PackedDataSize + Packer.PackedSizeEstimate() >= MaxStoredBytes ? HardLimit : NoLimit;
         }
-        return Storage->IsFull();
     }
 
-    virtual void Push(NUdf::TUnboxedValue&& value) override {
+    EDqFillLevel UpdateFillLevel() override {
+        auto result = CalcFillLevel();
+        if (FillLevel != result) {
+            if (Aggregator) {
+                Aggregator->UpdateCount(FillLevel, result);
+            }
+            FillLevel = result;
+        }
+        return result;
+    }
+
+    void SetFillAggregator(std::shared_ptr<TDqFillAggregator> aggregator) override {
+        Aggregator = aggregator;
+        Aggregator->AddCount(FillLevel);
+    }
+
+    void Push(NUdf::TUnboxedValue&& value) override {
         YQL_ENSURE(!OutputType->IsMulti());
         DoPushSafe(&value, 1);
     }
 
-    virtual void WidePush(NUdf::TUnboxedValue* values, ui32 width) override {
+    void WidePush(NUdf::TUnboxedValue* values, ui32 width) override {
         YQL_ENSURE(OutputType->IsMulti());
         YQL_ENSURE(Width == width);
         DoPushSafe(values, width);
@@ -93,7 +109,7 @@ public:
 
     // Try to split data before push to fulfill ChunkSizeLimit
     void DoPushSafe(NUdf::TUnboxedValue* values, ui32 width) {
-        YQL_ENSURE(!IsFull());
+        YQL_ENSURE(UpdateFillLevel() != HardLimit);
 
         if (Finished) {
             return;
@@ -194,11 +210,12 @@ public:
             LOG("Data spilled. Total rows spilled: " << SpilledChunkCount << ", bytesInMemory: " << (PackedDataSize + packerSize)); // FIXME with RowCount
         }
 
-        if (IsFull() || FirstStoredId < NextStoredId) {
-            PopStats.TryPause();
-        }
+        UpdateFillLevel();
 
         if (PopStats.CollectFull()) {
+            if (FillLevel != NoLimit) {
+                PopStats.TryPause();
+            }
             PopStats.MaxMemoryUsage = std::max(PopStats.MaxMemoryUsage, PackedDataSize + packerSize);
             PopStats.MaxRowsInMemory = std::max(PopStats.MaxRowsInMemory, PackedChunkCount);
         }
@@ -257,11 +274,13 @@ public:
 
         DLOG("Took " << data.RowCount() << " rows");
 
+        UpdateFillLevel();
+
         if (PopStats.CollectBasic()) {
             PopStats.Bytes += data.Size();
             PopStats.Rows += data.RowCount();
             PopStats.Chunks++; // pop chunks do not match push chunks
-            if (!IsFull() || FirstStoredId == NextStoredId) {
+            if (FillLevel == NoLimit) {
                 PopStats.Resume();
             }
         }
@@ -359,7 +378,7 @@ public:
             PopStats.Bytes += data.Size();
             PopStats.Rows += data.RowCount();
             PopStats.Chunks++;
-            if (!IsFull() || FirstStoredId == NextStoredId) {
+            if (UpdateFillLevel() == NoLimit) {
                 PopStats.Resume();
             }
         }
@@ -391,7 +410,7 @@ public:
     }
 
     ui64 Drop() override { // Drop channel data because channel was finished. Leave checkpoint because checkpoints keep going through channel after finishing channel data transfer.
-        ui64 rows = GetValuesCount();
+        ui64 chunks = GetValuesCount();
         Data.clear();
         Packer.Clear();
         PackedDataSize = 0;
@@ -401,7 +420,8 @@ public:
         PackerCurrentChunkCount = 0;
         PackerCurrentRowCount = 0;
         FirstStoredId = NextStoredId;
-        return rows;
+        UpdateFillLevel();
+        return chunks;
     }
 
     NKikimr::NMiniKQL::TType* GetOutputType() const override {
@@ -455,6 +475,8 @@ private:
 
     TMaybe<NDqProto::TWatermark> Watermark;
     TMaybe<NDqProto::TCheckpoint> Checkpoint;
+    std::shared_ptr<TDqFillAggregator> Aggregator;
+    EDqFillLevel FillLevel = NoLimit;
 };
 
 } // anonymous namespace

--- a/ydb/library/yql/dq/runtime/dq_output_channel_ut.cpp
+++ b/ydb/library/yql/dq/runtime/dq_output_channel_ut.cpp
@@ -328,7 +328,7 @@ void TestOverflow(TTestContext& ctx) {
         PushRow(ctx, std::move(row), ch);
         UNIT_FAIL("");
     } catch (yexception& e) {
-        UNIT_ASSERT(TString(e.what()).Contains("requirement UpdateFillLevel() != HardLimit failed"));
+        UNIT_ASSERT(TString(e.what()).Contains("requirement GetFillLevel() != HardLimit failed"));
     }
 }
 

--- a/ydb/library/yql/dq/runtime/dq_output_channel_ut.cpp
+++ b/ydb/library/yql/dq/runtime/dq_output_channel_ut.cpp
@@ -1,4 +1,6 @@
+#include <ydb/library/yql/dq/runtime/dq_columns_resolve.h>
 #include <ydb/library/yql/dq/runtime/dq_output_channel.h>
+#include <ydb/library/yql/dq/runtime/dq_output_consumer.h>
 #include <ydb/library/yql/dq/runtime/dq_transport.h>
 #include <ydb/library/yql/dq/runtime/ut/ut_helper.h>
 
@@ -13,6 +15,11 @@ using namespace NKikimr;
 using namespace NKikimr::NMiniKQL;
 using namespace NYql;
 using namespace NYql::NDq;
+
+template<>
+void Out<NYql::NDq::EDqFillLevel>(IOutputStream& os, const NYql::NDq::EDqFillLevel l) {
+    os << static_cast<ui32>(l);
+}
 
 namespace {
 
@@ -101,6 +108,21 @@ struct TTestContext {
         return result;
     }
 
+    TUnboxedValueBatch CreateVariantRow(ui32 value, ui32 varIndex) {
+        UNIT_ASSERT(!IsWide);
+        NUdf::TUnboxedValue* items;
+        auto row = Vb.NewArray(OutputType->GetMembersCount(), items);
+        items[0] = NUdf::TUnboxedValuePod(value);
+        items[1] = NUdf::TUnboxedValuePod((ui64) (value * value));
+        if (OutputType->GetMembersCount() == 3) {
+            items[2] = NMiniKQL::MakeString("***");
+        }
+        UNIT_ASSERT(row.TryMakeVariant(varIndex));
+        TUnboxedValueBatch result(OutputType);
+        result.emplace_back(std::move(row));
+        return result;
+    }
+
     TUnboxedValueBatch CreateBigRow(ui32 value, ui32 size) {
         if (IsWide) {
             TUnboxedValueBatch result(WideOutputType);
@@ -121,6 +143,21 @@ struct TTestContext {
         if (OutputType->GetMembersCount() == 3) {
             items[2] = NMiniKQL::MakeString(std::string(size, '*'));
         }
+        TUnboxedValueBatch result(OutputType);
+        result.emplace_back(std::move(row));
+        return result;
+    }
+
+    TUnboxedValueBatch CreateBigVariantRow(ui32 value, ui32 size, ui32 varIndex) {
+        UNIT_ASSERT(!IsWide);
+        NUdf::TUnboxedValue* items;
+        auto row = Vb.NewArray(OutputType->GetMembersCount(), items);
+        items[0] = NUdf::TUnboxedValuePod(value);
+        items[1] = NUdf::TUnboxedValuePod((ui64) (value * value));
+        if (OutputType->GetMembersCount() == 3) {
+            items[2] = NMiniKQL::MakeString(std::string(size, '*'));
+        }
+        UNIT_ASSERT(row.TryMakeVariant(varIndex));
         TUnboxedValueBatch result(OutputType);
         result.emplace_back(std::move(row));
         return result;
@@ -172,6 +209,15 @@ void PushRow(const TTestContext& ctx, TUnboxedValueBatch&& row, const IDqOutputC
     }
 }
 
+void ConsumeRow(const TTestContext& ctx, TUnboxedValueBatch&& row, const IDqOutputConsumer::TPtr& consumer) {
+    auto* values = row.Head();
+    if (ctx.IsWide) {
+        consumer->WideConsume(values, *row.Width());
+    } else {
+        consumer->Consume(std::move(*values));
+    }
+}
+
 void TestSingleRead(TTestContext& ctx) {
     TDqOutputChannelSettings settings;
     settings.MaxStoredBytes = 1000;
@@ -183,7 +229,7 @@ void TestSingleRead(TTestContext& ctx) {
 
     for (i32 i = 0; i < 10; ++i) {
         auto row = ctx.CreateRow(i);
-        UNIT_ASSERT(!ch->IsFull());
+        UNIT_ASSERT_VALUES_EQUAL(NoLimit, ch->UpdateFillLevel());
         PushRow(ctx, std::move(row), ch);
     }
 
@@ -221,7 +267,7 @@ void TestPartialRead(TTestContext& ctx) {
 
     for (i32 i = 0; i < 9; ++i) {
         auto row = ctx.CreateRow(i);
-        UNIT_ASSERT(!ch->IsFull());
+        UNIT_ASSERT_VALUES_EQUAL(NoLimit, ch->UpdateFillLevel());
         PushRow(ctx, std::move(row), ch);
     }
 
@@ -269,20 +315,20 @@ void TestOverflow(TTestContext& ctx) {
 
     for (i32 i = 0; i < 8; ++i) {
         auto row = ctx.CreateRow(i);
-        UNIT_ASSERT(!ch->IsFull());
+        UNIT_ASSERT_VALUES_EQUAL(NoLimit, ch->UpdateFillLevel());
         PushRow(ctx, std::move(row), ch);
     }
 
     UNIT_ASSERT_VALUES_EQUAL(8, ch->GetPushStats().Rows);
     UNIT_ASSERT_VALUES_EQUAL(0, ch->GetPopStats().Rows);
 
-    UNIT_ASSERT(ch->IsFull());
+    UNIT_ASSERT_VALUES_EQUAL(HardLimit, ch->UpdateFillLevel());
     try {
         auto row = ctx.CreateRow(100'500);
         PushRow(ctx, std::move(row), ch);
         UNIT_FAIL("");
     } catch (yexception& e) {
-        UNIT_ASSERT(TString(e.what()).Contains("requirement !IsFull() failed"));
+        UNIT_ASSERT(TString(e.what()).Contains("requirement UpdateFillLevel() != HardLimit failed"));
     }
 }
 
@@ -297,7 +343,7 @@ void TestPopAll(TTestContext& ctx) {
 
     for (i32 i = 0; i < 50; ++i) {
         auto row = ctx.CreateRow(i);
-        UNIT_ASSERT(!ch->IsFull());
+        UNIT_ASSERT_VALUES_EQUAL(NoLimit, ch->UpdateFillLevel());
         PushRow(ctx, std::move(row), ch);
     }
 
@@ -328,13 +374,13 @@ void TestBigRow(TTestContext& ctx) {
 
     {
         auto row = ctx.CreateRow(1);
-        UNIT_ASSERT(!ch->IsFull());
+        UNIT_ASSERT_VALUES_EQUAL(NoLimit, ch->UpdateFillLevel());
         PushRow(ctx, std::move(row), ch);
     }
     {
         for (ui32 i = 2; i < 10; ++i) {
             auto row = ctx.CreateBigRow(i, 10_MB);
-            UNIT_ASSERT(!ch->IsFull());
+            UNIT_ASSERT_VALUES_EQUAL(NoLimit, ch->UpdateFillLevel());
             PushRow(ctx, std::move(row), ch);
         }
     }
@@ -418,7 +464,7 @@ void TestSpillWithMockStorage(TTestContext& ctx) {
 
     for (i32 i = 0; i < 35; ++i) {
         auto row = ctx.CreateRow(i);
-        UNIT_ASSERT(!ch->IsFull());
+        UNIT_ASSERT_VALUES_UNEQUAL(HardLimit, ch->UpdateFillLevel());
         PushRow(ctx, std::move(row), ch);
     }
 
@@ -449,7 +495,7 @@ void TestSpillWithMockStorage(TTestContext& ctx) {
 
         for (i32 i = 100; i < 105; ++i) {
             auto row = ctx.CreateRow(i);
-            UNIT_ASSERT(!ch->IsFull());
+            UNIT_ASSERT_VALUES_EQUAL(NoLimit, ch->UpdateFillLevel());
             PushRow(ctx, std::move(row), ch);
         }
 
@@ -482,7 +528,7 @@ void TestOverflowWithMockStorage(TTestContext& ctx) {
 
     for (i32 i = 0; i < 42; ++i) {
         auto row = ctx.CreateRow(i);
-        UNIT_ASSERT(!ch->IsFull());
+        UNIT_ASSERT_VALUES_EQUAL(NoLimit, ch->UpdateFillLevel());
         PushRow(ctx, std::move(row), ch);
     }
 
@@ -510,7 +556,7 @@ void TestChunkSizeLimit(TTestContext& ctx) {
 
     for (i32 i = 0; i < 10; ++i) {
         auto row = ctx.CreateRow(i);
-        UNIT_ASSERT(!ch->IsFull());
+        UNIT_ASSERT_VALUES_EQUAL(NoLimit, ch->UpdateFillLevel());
         PushRow(ctx, std::move(row), ch);
     }
 
@@ -620,6 +666,229 @@ Y_UNIT_TEST(Spill) {
 Y_UNIT_TEST(Overflow) {
     TTestContext ctx(WIDE_CHANNEL, NDqProto::DATA_TRANSPORT_UV_PICKLE_1_0, true);
     TestOverflowWithMockStorage(ctx);
+}
+
+}
+
+void TestBackPressureInMemory(TTestContext& ctx, bool multi) {
+    TDqOutputChannelSettings settings;
+    settings.MaxStoredBytes = 100;
+    settings.MaxChunkBytes = 100;
+    settings.Level = TCollectStatsLevel::Profile;
+    settings.TransportVersion = ctx.TransportVersion;
+
+    TVector<IDqOutputChannel::TPtr> channels;
+
+    constexpr ui32 CHANNEL_BITS = 3;
+    constexpr ui32 CHANNEL_COUNT = 1 << CHANNEL_BITS;
+    constexpr ui32 MSG_PER_CHANNEL = 4;
+
+    for (ui32 i = 0; i < CHANNEL_COUNT; i++) {
+        auto channel = CreateDqOutputChannel(i, 1000, ctx.GetOutputType(), ctx.HolderFactory, settings, Log);
+        channels.emplace_back(channel);
+    }
+
+    TMaybe<ui8> minFillPercentage;
+    minFillPercentage = 100;
+    NDqProto::TTaskOutputHashPartition hashPartition;
+    IDqOutputConsumer::TPtr consumer;
+
+    if (multi) {
+        TVector<IDqOutputConsumer::TPtr> consumers;
+        {
+            TVector<IDqOutput::TPtr> outputs;
+            for (ui32 i = 0; i < CHANNEL_COUNT / 2; i++) {
+                outputs.emplace_back(channels[i]);
+            }
+            TVector<TColumnInfo> keyColumns;
+            keyColumns.emplace_back(GetColumnInfo(ctx.GetOutputType(), "x"));
+            consumers.emplace_back(CreateOutputHashPartitionConsumer(std::move(outputs), std::move(keyColumns), ctx.GetOutputType(), ctx.HolderFactory, minFillPercentage, hashPartition, nullptr));
+        }
+        {
+            TVector<IDqOutput::TPtr> outputs;
+            for (ui32 i = CHANNEL_COUNT / 2; i < CHANNEL_COUNT; i++) {
+                outputs.emplace_back(channels[i]);
+            }
+            TVector<TColumnInfo> keyColumns;
+            keyColumns.emplace_back(GetColumnInfo(ctx.GetOutputType(), "x"));
+            consumers.emplace_back(CreateOutputHashPartitionConsumer(std::move(outputs), std::move(keyColumns), ctx.GetOutputType(), ctx.HolderFactory, minFillPercentage, hashPartition, nullptr));
+        }
+        consumer = CreateOutputMultiConsumer(std::move(consumers));
+    } else {
+        TVector<IDqOutput::TPtr> outputs;
+        for (auto c : channels) {
+            outputs.emplace_back(c);
+        }
+        TVector<TColumnInfo> keyColumns;
+        keyColumns.emplace_back(GetColumnInfo(ctx.GetOutputType(), "0")); // index !!!
+        consumer = CreateOutputHashPartitionConsumer(std::move(outputs), std::move(keyColumns), ctx.GetOutputType(), ctx.HolderFactory, minFillPercentage, hashPartition, nullptr);
+    }
+
+
+    UNIT_ASSERT_VALUES_EQUAL(NoLimit, consumer->GetFillLevel());
+
+    for (ui32 i = 0; i < CHANNEL_COUNT * MSG_PER_CHANNEL; ++i) {
+        auto row = multi ? ctx.CreateVariantRow(i, (i >> (CHANNEL_BITS - 1)) & 1) : ctx.CreateRow(i);
+        ConsumeRow(ctx, std::move(row), consumer);
+        UNIT_ASSERT_VALUES_EQUAL(NoLimit, consumer->GetFillLevel());
+    }
+
+    for (auto c : channels) {
+        UNIT_ASSERT_VALUES_EQUAL(MSG_PER_CHANNEL, c->GetValuesCount());
+        UNIT_ASSERT_VALUES_EQUAL(NoLimit, c->UpdateFillLevel());
+    }
+
+    ui32 channel0 = 0;
+
+    {
+        auto row = multi ? ctx.CreateBigVariantRow(0, 10000, 0) : ctx.CreateBigRow(0, 10000);
+        ConsumeRow(ctx, std::move(row), consumer);
+
+        UNIT_ASSERT_VALUES_EQUAL(HardLimit, consumer->GetFillLevel());
+
+        for (ui32 i = 0; i < CHANNEL_COUNT; i ++) {
+            if (channels[i]->GetValuesCount() == MSG_PER_CHANNEL + 1) {
+                channel0 = i;
+                break;
+            }
+        }
+
+        UNIT_ASSERT_VALUES_EQUAL(HardLimit, channels[channel0]->UpdateFillLevel());
+    }
+
+    {
+        TDqSerializedBatch data;
+        UNIT_ASSERT(channels[channel0]->PopAll(data));
+
+        UNIT_ASSERT_VALUES_EQUAL(NoLimit, consumer->GetFillLevel());
+        UNIT_ASSERT_VALUES_EQUAL(NoLimit, channels[channel0]->UpdateFillLevel());
+        UNIT_ASSERT_VALUES_EQUAL(0, channels[channel0]->GetValuesCount());
+    }
+}
+
+void TestBackPressureWithSpilling(TTestContext& ctx, bool multi) {
+    TDqOutputChannelSettings settings;
+    settings.MaxStoredBytes = 100;
+    settings.MaxChunkBytes = 100;
+    settings.Level = TCollectStatsLevel::Profile;
+    settings.TransportVersion = ctx.TransportVersion;
+
+    TVector<IDqOutputChannel::TPtr> channels;
+
+    constexpr ui32 CHANNEL_BITS = 3;
+    constexpr ui32 CHANNEL_COUNT = 1 << CHANNEL_BITS;
+    constexpr ui32 MSG_PER_CHANNEL = 4;
+
+    for (ui32 i = 0; i < CHANNEL_COUNT; i++) {
+        // separate Storage for each channel is required
+        settings.ChannelStorage = MakeIntrusive<TMockChannelStorage>(100000ul);
+        auto channel = CreateDqOutputChannel(i, 1000, ctx.GetOutputType(), ctx.HolderFactory, settings, Log);
+        channels.emplace_back(channel);
+    }
+
+    TMaybe<ui8> minFillPercentage;
+    minFillPercentage = 100;
+    NDqProto::TTaskOutputHashPartition hashPartition;
+    IDqOutputConsumer::TPtr consumer;
+
+    if (multi) {
+        TVector<IDqOutputConsumer::TPtr> consumers;
+        {
+            TVector<IDqOutput::TPtr> outputs;
+            for (ui32 i = 0; i < CHANNEL_COUNT / 2; i++) {
+                outputs.emplace_back(channels[i]);
+            }
+            TVector<TColumnInfo> keyColumns;
+            keyColumns.emplace_back(GetColumnInfo(ctx.GetOutputType(), "x"));
+            consumers.emplace_back(CreateOutputHashPartitionConsumer(std::move(outputs), std::move(keyColumns), ctx.GetOutputType(), ctx.HolderFactory, minFillPercentage, hashPartition, nullptr));
+        }
+        {
+            TVector<IDqOutput::TPtr> outputs;
+            for (ui32 i = CHANNEL_COUNT / 2; i < CHANNEL_COUNT; i++) {
+                outputs.emplace_back(channels[i]);
+            }
+            TVector<TColumnInfo> keyColumns;
+            keyColumns.emplace_back(GetColumnInfo(ctx.GetOutputType(), "x"));
+            consumers.emplace_back(CreateOutputHashPartitionConsumer(std::move(outputs), std::move(keyColumns), ctx.GetOutputType(), ctx.HolderFactory, minFillPercentage, hashPartition, nullptr));
+        }
+        consumer = CreateOutputMultiConsumer(std::move(consumers));
+    } else {
+        TVector<IDqOutput::TPtr> outputs;
+        for (auto c : channels) {
+            outputs.emplace_back(c);
+        }
+        TVector<TColumnInfo> keyColumns;
+        keyColumns.emplace_back(GetColumnInfo(ctx.GetOutputType(), "0")); // index !!!
+        consumer = CreateOutputHashPartitionConsumer(std::move(outputs), std::move(keyColumns), ctx.GetOutputType(), ctx.HolderFactory, minFillPercentage, hashPartition, nullptr);
+    }
+
+    UNIT_ASSERT_VALUES_EQUAL(NoLimit, consumer->GetFillLevel());
+
+    for (ui32 i = 0; i < CHANNEL_COUNT * MSG_PER_CHANNEL; ++i) {
+        auto row = multi ? ctx.CreateVariantRow(i, (i >> (CHANNEL_BITS - 1)) & 1) : ctx.CreateRow(i);
+        ConsumeRow(ctx, std::move(row), consumer);
+        UNIT_ASSERT_VALUES_EQUAL(NoLimit, consumer->GetFillLevel());
+    }
+
+    for (auto c : channels) {
+        UNIT_ASSERT_VALUES_EQUAL(MSG_PER_CHANNEL, c->GetValuesCount());
+        UNIT_ASSERT_VALUES_EQUAL(NoLimit, c->UpdateFillLevel());
+    }
+
+    ui32 channel0 = 0;
+
+    {
+        auto row = multi ? ctx.CreateBigVariantRow(0, 10000, 0) : ctx.CreateBigRow(0, 10000);
+        ConsumeRow(ctx, std::move(row), consumer);
+
+        for (auto i = 0; i < 4; i ++) {
+            if (channels[i]->GetValuesCount() == 5) {
+                channel0 = i;
+                break;
+            }
+        }
+
+        UNIT_ASSERT_VALUES_EQUAL(SoftLimit, channels[channel0]->UpdateFillLevel());
+
+        for (ui32 i = 1; i < CHANNEL_COUNT; i ++) {
+            UNIT_ASSERT_VALUES_EQUAL(NoLimit, consumer->GetFillLevel());
+            auto row = multi ? ctx.CreateBigVariantRow(i, 10000, (i >> (CHANNEL_BITS - 1)) & 1) : ctx.CreateBigRow(i, 10000);
+            ConsumeRow(ctx, std::move(row), consumer);
+        }
+
+        UNIT_ASSERT_VALUES_EQUAL(SoftLimit, consumer->GetFillLevel());
+    }
+
+    {
+        TDqSerializedBatch data;
+        UNIT_ASSERT(channels[channel0]->PopAll(data));
+
+        UNIT_ASSERT_VALUES_EQUAL(NoLimit, consumer->GetFillLevel());
+        UNIT_ASSERT_VALUES_EQUAL(NoLimit, channels[channel0]->UpdateFillLevel());
+        UNIT_ASSERT_VALUES_EQUAL(0, channels[channel0]->GetValuesCount());
+    }
+}
+
+Y_UNIT_TEST_SUITE(HashShuffle) {
+
+Y_UNIT_TEST(BackPressureInMemory) {
+    TTestContext ctx(WIDE_CHANNEL, NDqProto::DATA_TRANSPORT_UV_PICKLE_1_0, true);
+    TestBackPressureInMemory(ctx, false);
+}
+
+Y_UNIT_TEST(BackPressureInMemoryMulti) {
+    TTestContext ctx(NARROW_CHANNEL, NDqProto::DATA_TRANSPORT_UV_PICKLE_1_0, true);
+    TestBackPressureInMemory(ctx, true);
+}
+
+Y_UNIT_TEST(BackPressureWithSpilling) {
+    TTestContext ctx(WIDE_CHANNEL, NDqProto::DATA_TRANSPORT_UV_PICKLE_1_0, true);
+    TestBackPressureWithSpilling(ctx, false);
+}
+
+Y_UNIT_TEST(BackPressureWithSpillingMulti) {
+    TTestContext ctx(NARROW_CHANNEL, NDqProto::DATA_TRANSPORT_UV_PICKLE_1_0, true);
+    TestBackPressureWithSpilling(ctx, true);
 }
 
 }

--- a/ydb/library/yql/dq/runtime/dq_output_consumer.cpp
+++ b/ydb/library/yql/dq/runtime/dq_output_consumer.cpp
@@ -307,11 +307,16 @@ public:
 
     TString DebugString() override {
         TStringBuilder builder;
-        builder << Aggregator->DebugString();
+        builder << Aggregator->DebugString() << " TDqOutputHashPartitionConsumer {";
         ui32 i = 0;
         for (auto output : Outputs) {
-            builder << " HASH C-" << i++ << ":" << static_cast<ui32>(output->UpdateFillLevel());
+            builder << " C" << i++ << ":" << static_cast<ui32>(output->UpdateFillLevel());
+            if (i >= 20) {
+                builder << "...";
+                break;
+            }
         }
+        builder << " }";
         return builder;
     }
 
@@ -445,11 +450,16 @@ private:
 
     TString DebugString() override {
         TStringBuilder builder;
-        builder << Aggregator->DebugString();
+        builder << Aggregator->DebugString() << " TDqOutputHashPartitionConsumerScalar {";
         ui32 i = 0;
         for (auto output : Outputs_) {
-            builder << " HASH C-" << i++ << ":" << static_cast<ui32>(output->UpdateFillLevel());
+            builder << " C" << i++ << ":" << static_cast<ui32>(output->UpdateFillLevel());
+            if (i >= 20) {
+                builder << "...";
+                break;
+            }
         }
+        builder << " }";
         return builder;
     }
 
@@ -577,11 +587,16 @@ private:
 
     TString DebugString() override {
         TStringBuilder builder;
-        builder << Aggregator->DebugString();
+        builder << Aggregator->DebugString() << " TDqOutputHashPartitionConsumerBlock {";
         ui32 i = 0;
         for (auto output : Outputs_) {
-            builder << " HASH C-" << i++ << ":" << static_cast<ui32>(output->UpdateFillLevel());
+            builder << " C" << i++ << ":" << static_cast<ui32>(output->UpdateFillLevel());
+            if (i >= 20) {
+                builder << "...";
+                break;
+            }
         }
+        builder << " }";
         return builder;
     }
 
@@ -785,11 +800,16 @@ public:
 
     TString DebugString() override {
         TStringBuilder builder;
-        builder << Aggregator->DebugString();
+        builder << Aggregator->DebugString() << " TDqOutputBroadcastConsumer {";
         ui32 i = 0;
         for (auto output : Outputs) {
-            builder << " BROADCAST C-" << i++ << ":" << static_cast<ui32>(output->UpdateFillLevel());
+            builder << " C" << i++ << ":" << static_cast<ui32>(output->UpdateFillLevel());
+            if (i >= 20) {
+                builder << "...";
+                break;
+            }
         }
+        builder << " }";
         return builder;
     }
 

--- a/ydb/library/yql/dq/runtime/dq_output_consumer.cpp
+++ b/ydb/library/yql/dq/runtime/dq_output_consumer.cpp
@@ -36,8 +36,20 @@ public:
         YQL_ENSURE(!Consumers.empty());
     }
 
-    bool IsFull() const override {
-        return AnyOf(Consumers, [](const auto& consumer) { return consumer->IsFull(); });
+    EDqFillLevel GetFillLevel() const override {
+        EDqFillLevel result = SoftLimit;
+        for (auto consumer : Consumers) {
+            switch(consumer->GetFillLevel()) {
+                case HardLimit:
+                    return HardLimit;
+                case SoftLimit:
+                    break;
+                case NoLimit:
+                    result = NoLimit;
+                    break;
+            }
+        }
+        return result;
     }
 
     void WideConsume(TUnboxedValue* values, ui32 count) override {
@@ -79,8 +91,8 @@ public:
     TDqOutputMapConsumer(IDqOutput::TPtr output)
         : Output(output) {}
 
-    bool IsFull() const override {
-        return Output->IsFull();
+    EDqFillLevel GetFillLevel() const override {
+        return Output->UpdateFillLevel();
     }
 
     void Consume(TUnboxedValue&& value) override {
@@ -256,29 +268,12 @@ private:
 template <typename THashFunc>
 class TDqOutputHashPartitionConsumer : public IDqOutputConsumer {
 private:
-    mutable bool IsWaitingFlag = false;
     mutable TUnboxedValue WaitingValue;
     mutable TUnboxedValueVector WideWaitingValues;
     mutable IDqOutput::TPtr OutputWaiting;
 protected:
-    void DrainWaiting() const {
-        if (Y_UNLIKELY(IsWaitingFlag)) {
-            if (OutputWaiting->IsFull()) {
-                return;
-            }
-            if (OutputWidth.Defined()) {
-                YQL_ENSURE(OutputWidth == WideWaitingValues.size());
-                OutputWaiting->WidePush(WideWaitingValues.data(), *OutputWidth);
-            } else {
-                OutputWaiting->Push(std::move(WaitingValue));
-            }
-            IsWaitingFlag = false;
-        }
-    }
-
     virtual bool DoTryFinish() override {
-        DrainWaiting();
-        return !IsWaitingFlag;
+        return true;
     }
 public:
     TDqOutputHashPartitionConsumer(
@@ -299,37 +294,27 @@ public:
         if (outputWidth.Defined()) {
             WideWaitingValues.resize(*outputWidth);
         }
+
+        Aggregator = std::make_shared<TDqFillAggregator>();
+        for (auto output : Outputs) {
+            output->SetFillAggregator(Aggregator);
+        }
     }
 
-    bool IsFull() const override {
-        DrainWaiting();
-        return IsWaitingFlag;
+    EDqFillLevel GetFillLevel() const override {
+        return Aggregator->GetFillLevel();
     }
 
     void Consume(TUnboxedValue&& value) final {
         YQL_ENSURE(!OutputWidth.Defined());
         ui32 partitionIndex = GetHashPartitionIndex(value);
-        if (Outputs[partitionIndex]->IsFull()) {
-            YQL_ENSURE(!IsWaitingFlag);
-            IsWaitingFlag = true;
-            OutputWaiting = Outputs[partitionIndex];
-            WaitingValue = std::move(value);
-        } else {
-            Outputs[partitionIndex]->Push(std::move(value));
-        }
+        Outputs[partitionIndex]->Push(std::move(value));
     }
 
     void WideConsume(TUnboxedValue* values, ui32 count) final {
         YQL_ENSURE(OutputWidth.Defined() && count == OutputWidth);
         ui32 partitionIndex = GetHashPartitionIndex(values);
-        if (Outputs[partitionIndex]->IsFull()) {
-            YQL_ENSURE(!IsWaitingFlag);
-            IsWaitingFlag = true;
-            OutputWaiting = Outputs[partitionIndex];
-            std::move(values, values + count, WideWaitingValues.data());
-        } else {
-            Outputs[partitionIndex]->WidePush(values, count);
-        }
+        Outputs[partitionIndex]->WidePush(values, count);
     }
 
     void Consume(NDqProto::TCheckpoint&& checkpoint) override {
@@ -409,6 +394,7 @@ private:
     TVector<NUdf::IHash::TPtr> ValueHashers;
     const TMaybe<ui32> OutputWidth;
     THashFunc HashFunc;
+    std::shared_ptr<TDqFillAggregator> Aggregator;
 };
 
 template <typename THashFunc>
@@ -436,11 +422,15 @@ public:
             Readers_.emplace_back(MakeBlockReader(TTypeInfoHelper(), blockType->GetItemType()));
             Hashers_.emplace_back(helper.MakeHasher(blockType->GetItemType()));
         }
+
+        Aggregator = std::make_shared<TDqFillAggregator>();
+        for (auto output : Outputs_) {
+            output->SetFillAggregator(Aggregator);
+        }
     }
 private:
-    bool IsFull() const final {
-        DrainWaiting();
-        return IsWaitingFlag_;
+    EDqFillLevel GetFillLevel() const override {
+        return Aggregator->GetFillLevel();
     }
 
     void Consume(TUnboxedValue&& value) final {
@@ -454,17 +444,7 @@ private:
         if (!inputBlockLen) {
             return;
         }
-
-        if (!Output_) {
-            Output_ = Outputs_[GetHashPartitionIndex(values)];
-        }
-        if (Output_->IsFull()) {
-            YQL_ENSURE(!IsWaitingFlag_);
-            IsWaitingFlag_ = true;
-            std::move(values, values + count, WaitingValues_.data());
-        } else {
-            Output_->WidePush(values, count);
-        }
+        Outputs_[GetHashPartitionIndex(values)]->WidePush(values, count);
     }
 
     void Consume(NDqProto::TCheckpoint&& checkpoint) override {
@@ -479,21 +459,8 @@ private:
         }
     }
 
-    void DrainWaiting() const {
-        if (Y_UNLIKELY(IsWaitingFlag_)) {
-            YQL_ENSURE(Output_);
-            if (Output_->IsFull()) {
-                return;
-            }
-            YQL_ENSURE(OutputWidth_ == WaitingValues_.size());
-            Output_->WidePush(WaitingValues_.data(), OutputWidth_);
-            IsWaitingFlag_ = false;
-        }
-    }
-
     bool DoTryFinish() final {
-        DrainWaiting();
-        return !IsWaitingFlag_;
+        return true;
     }
 
     template<typename T = THashFunc, typename std::enable_if<std::is_same<T, THashV1>::value, int>::type = 0>
@@ -531,10 +498,9 @@ private:
     const ui32 OutputWidth_;
     TVector<NUdf::IBlockItemHasher::TPtr> Hashers_;
     TVector<std::unique_ptr<IBlockReader>> Readers_;
-    IDqOutput::TPtr Output_;
-    mutable bool IsWaitingFlag_ = false;
     mutable TUnboxedValueVector WaitingValues_;
     THashFunc HashFunc;
+    std::shared_ptr<TDqFillAggregator> Aggregator;
 };
 
 template <typename THashFunc>
@@ -577,12 +543,16 @@ public:
             Readers_.emplace_back(MakeBlockReader(helper, blockType->GetItemType()));
             Hashers_.emplace_back(blockHelper.MakeHasher(blockType->GetItemType()));
         }
+
+        Aggregator = std::make_shared<TDqFillAggregator>();
+        for (auto output : Outputs_) {
+            output->SetFillAggregator(Aggregator);
+        }
     }
 
 private:
-    bool IsFull() const final {
-        DrainWaiting();
-        return IsWaitingFlag_;
+    EDqFillLevel GetFillLevel() const override {
+        return Aggregator->GetFillLevel();
     }
 
     void Consume(TUnboxedValue&& value) final {
@@ -591,7 +561,6 @@ private:
     }
 
     void WideConsume(TUnboxedValue values[], ui32 count) final {
-        YQL_ENSURE(!IsWaitingFlag_);
         YQL_ENSURE(count == OutputWidth_);
 
         const ui64 inputBlockLen = TArrowBlock::From(values[count - 1]).GetDatum().scalar_as<arrow::UInt64Scalar>().value;
@@ -647,13 +616,6 @@ private:
         while (!outputData.empty()) {
             bool hasData = false;
             for (size_t i = 0; i < Outputs_.size(); ++i) {
-                if (Outputs_[i]->IsFull()) {
-                    IsWaitingFlag_ = true;
-                    Y_ENSURE(OutputData_.empty());
-                    OutputData_ = std::move(outputData);
-                    return;
-                }
-
                 std::vector<arrow::Datum> chunk;
                 ui64 blockLen = 0;
                 if (outputData[i] && outputData[i]->Next(chunk, blockLen)) {
@@ -685,20 +647,8 @@ private:
         }
     }
 
-    void DrainWaiting() const {
-        if (Y_UNLIKELY(IsWaitingFlag_)) {
-            TVector<std::unique_ptr<TArgsDechunker>> outputData;
-            outputData.swap(OutputData_);
-            DoConsume(std::move(outputData));
-            if (OutputData_.empty()) {
-                IsWaitingFlag_ = false;
-            }
-        }
-    }
-
     bool DoTryFinish() final {
-        DrainWaiting();
-        return !IsWaitingFlag_;
+        return true;
     }
 
     template<typename T = THashFunc, typename std::enable_if<std::is_same<T, THashV1>::value, int>::type = 0>
@@ -781,10 +731,9 @@ private:
     TVector<std::unique_ptr<IBlockReader>> Readers_;
     TVector<std::unique_ptr<IArrayBuilder>> Builders_;
 
-    mutable bool IsWaitingFlag_ = false;
-
     NUdf::IPgBuilder* PgBuilder_;
     THashFunc HashFunc;
+    std::shared_ptr<TDqFillAggregator> Aggregator;
 };
 
 class TDqOutputBroadcastConsumer : public IDqOutputConsumer {
@@ -794,10 +743,14 @@ public:
         , OutputWidth(outputWidth)
         , Tmp(outputWidth.Defined() ? *outputWidth : 0u)
     {
+        Aggregator = std::make_shared<TDqFillAggregator>();
+        for (auto output : Outputs) {
+            output->SetFillAggregator(Aggregator);
+        }
     }
 
-    bool IsFull() const override {
-        return AnyOf(Outputs, [](const auto& output) { return output->IsFull(); });
+    EDqFillLevel GetFillLevel() const override {
+        return Aggregator->GetFillLevel();
     }
 
     void Consume(TUnboxedValue&& value) final {
@@ -832,6 +785,7 @@ private:
     TVector<IDqOutput::TPtr> Outputs;
     const TMaybe<ui32> OutputWidth;
     TUnboxedValueVector Tmp;
+    std::shared_ptr<TDqFillAggregator> Aggregator;
 };
 
 } // namespace

--- a/ydb/library/yql/dq/runtime/dq_output_consumer.cpp
+++ b/ydb/library/yql/dq/runtime/dq_output_consumer.cpp
@@ -305,6 +305,16 @@ public:
         return Aggregator->GetFillLevel();
     }
 
+    TString DebugString() override {
+        TStringBuilder builder;
+        builder << Aggregator->DebugString();
+        ui32 i = 0;
+        for (auto output : Outputs) {
+            builder << " HASH C-" << i++ << ":" << static_cast<ui32>(output->UpdateFillLevel());
+        }
+        return builder;
+    }
+
     void Consume(TUnboxedValue&& value) final {
         YQL_ENSURE(!OutputWidth.Defined());
         ui32 partitionIndex = GetHashPartitionIndex(value);
@@ -433,6 +443,16 @@ private:
         return Aggregator->GetFillLevel();
     }
 
+    TString DebugString() override {
+        TStringBuilder builder;
+        builder << Aggregator->DebugString();
+        ui32 i = 0;
+        for (auto output : Outputs_) {
+            builder << " HASH C-" << i++ << ":" << static_cast<ui32>(output->UpdateFillLevel());
+        }
+        return builder;
+    }
+
     void Consume(TUnboxedValue&& value) final {
         Y_UNUSED(value);
         YQL_ENSURE(false, "Consume() called on wide block stream");
@@ -553,6 +573,16 @@ public:
 private:
     EDqFillLevel GetFillLevel() const override {
         return Aggregator->GetFillLevel();
+    }
+
+    TString DebugString() override {
+        TStringBuilder builder;
+        builder << Aggregator->DebugString();
+        ui32 i = 0;
+        for (auto output : Outputs_) {
+            builder << " HASH C-" << i++ << ":" << static_cast<ui32>(output->UpdateFillLevel());
+        }
+        return builder;
     }
 
     void Consume(TUnboxedValue&& value) final {
@@ -751,6 +781,16 @@ public:
 
     EDqFillLevel GetFillLevel() const override {
         return Aggregator->GetFillLevel();
+    }
+
+    TString DebugString() override {
+        TStringBuilder builder;
+        builder << Aggregator->DebugString();
+        ui32 i = 0;
+        for (auto output : Outputs) {
+            builder << " BROADCAST C-" << i++ << ":" << static_cast<ui32>(output->UpdateFillLevel());
+        }
+        return builder;
     }
 
     void Consume(TUnboxedValue&& value) final {

--- a/ydb/library/yql/dq/runtime/dq_output_consumer.h
+++ b/ydb/library/yql/dq/runtime/dq_output_consumer.h
@@ -28,7 +28,7 @@ public:
         IsFinishingFlag = true;
         return DoTryFinish();
     }
-    virtual bool IsFull() const = 0;
+    virtual EDqFillLevel GetFillLevel() const = 0;
     virtual void Consume(NKikimr::NUdf::TUnboxedValue&& value) = 0;
     virtual void WideConsume(NKikimr::NUdf::TUnboxedValue values[], ui32 count) = 0;
     virtual void Consume(NDqProto::TCheckpoint&& checkpoint) = 0;

--- a/ydb/library/yql/dq/runtime/dq_output_consumer.h
+++ b/ydb/library/yql/dq/runtime/dq_output_consumer.h
@@ -36,6 +36,9 @@ public:
     bool IsFinishing() const {
         return IsFinishingFlag;
     }
+    virtual TString DebugString() {
+        return "";
+    }
 protected:
     virtual bool DoTryFinish() {
         return true;

--- a/ydb/library/yql/dq/runtime/dq_tasks_runner.cpp
+++ b/ydb/library/yql/dq/runtime/dq_tasks_runner.cpp
@@ -299,6 +299,22 @@ public:
         SpillerFactory = spillerFactory;
     }
 
+    TString DebugString() override {
+        if (!AllocatedHolder->Output) {
+            return "Output == nullptr";
+        } else {
+            TStringBuilder builder;
+            switch (AllocatedHolder->Output->GetFillLevel()) {
+                case NoLimit:   builder << "Output == NoLimit"; break;
+                case SoftLimit: builder << "Output == SoftLimit"; break;
+                case HardLimit: builder << "Output == HardLimit"; break;
+            }
+            builder << Endl;
+            builder << AllocatedHolder->Output->DebugString();
+            return builder;
+        }
+    }
+
     bool UseSeparatePatternAlloc(const TDqTaskSettings& taskSettings) const {
         return Context.PatternCache &&
             (Settings.OptLLVM == "OFF" || taskSettings.IsLLVMDisabled() || Settings.UseCacheForLLVM);

--- a/ydb/library/yql/dq/runtime/dq_tasks_runner.cpp
+++ b/ydb/library/yql/dq/runtime/dq_tasks_runner.cpp
@@ -303,8 +303,8 @@ public:
         if (AllocatedHolder->Output) {
             switch (AllocatedHolder->Output->GetFillLevel()) {
                 case NoLimit:   return "";
-                case SoftLimit: return TStringBuilder() << "Output == SoftLimit" << Endl << AllocatedHolder->Output->DebugString();
-                case HardLimit: return TStringBuilder() << "Output == HardLimit" << Endl << AllocatedHolder->Output->DebugString();
+                case SoftLimit: return TStringBuilder() << "Output.FillLimit == SoftLimit " << AllocatedHolder->Output->DebugString();
+                case HardLimit: return TStringBuilder() << "Output.FillLimit == HardLimit " << AllocatedHolder->Output->DebugString();
             }
         }
         return "";

--- a/ydb/library/yql/dq/runtime/dq_tasks_runner.cpp
+++ b/ydb/library/yql/dq/runtime/dq_tasks_runner.cpp
@@ -299,20 +299,15 @@ public:
         SpillerFactory = spillerFactory;
     }
 
-    TString DebugString() override {
-        if (!AllocatedHolder->Output) {
-            return "Output == nullptr";
-        } else {
-            TStringBuilder builder;
+    TString GetOutputDebugString() override {
+        if (AllocatedHolder->Output) {
             switch (AllocatedHolder->Output->GetFillLevel()) {
-                case NoLimit:   builder << "Output == NoLimit"; break;
-                case SoftLimit: builder << "Output == SoftLimit"; break;
-                case HardLimit: builder << "Output == HardLimit"; break;
+                case NoLimit:   return "";
+                case SoftLimit: return TStringBuilder() << "Output == SoftLimit" << Endl << AllocatedHolder->Output->DebugString();
+                case HardLimit: return TStringBuilder() << "Output == HardLimit" << Endl << AllocatedHolder->Output->DebugString();
             }
-            builder << Endl;
-            builder << AllocatedHolder->Output->DebugString();
-            return builder;
         }
+        return "";
     }
 
     bool UseSeparatePatternAlloc(const TDqTaskSettings& taskSettings) const {

--- a/ydb/library/yql/dq/runtime/dq_tasks_runner.cpp
+++ b/ydb/library/yql/dq/runtime/dq_tasks_runner.cpp
@@ -976,7 +976,7 @@ private:
         if (isWide) {
             wideBuffer.resize(AllocatedHolder->OutputWideType->GetElementsCount());
         }
-        while (!AllocatedHolder->Output->IsFull()) {
+        while (AllocatedHolder->Output->GetFillLevel() == NoLimit) {
             NUdf::TUnboxedValue value;
             NUdf::EFetchStatus fetchStatus;
             if (isWide) {

--- a/ydb/library/yql/dq/runtime/dq_tasks_runner.h
+++ b/ydb/library/yql/dq/runtime/dq_tasks_runner.h
@@ -455,6 +455,7 @@ public:
     virtual const NKikimr::NMiniKQL::TWatermark& GetWatermark() const = 0;
 
     virtual void SetSpillerFactory(std::shared_ptr<NKikimr::NMiniKQL::ISpillerFactory> spillerFactory) = 0;
+    virtual TString DebugString() = 0;
 };
 
 TIntrusivePtr<IDqTaskRunner> MakeDqTaskRunner(

--- a/ydb/library/yql/dq/runtime/dq_tasks_runner.h
+++ b/ydb/library/yql/dq/runtime/dq_tasks_runner.h
@@ -455,7 +455,7 @@ public:
     virtual const NKikimr::NMiniKQL::TWatermark& GetWatermark() const = 0;
 
     virtual void SetSpillerFactory(std::shared_ptr<NKikimr::NMiniKQL::ISpillerFactory> spillerFactory) = 0;
-    virtual TString DebugString() = 0;
+    virtual TString GetOutputDebugString() = 0;
 };
 
 TIntrusivePtr<IDqTaskRunner> MakeDqTaskRunner(

--- a/ydb/library/yql/providers/dq/task_runner/tasks_runner_pipe.cpp
+++ b/ydb/library/yql/providers/dq/task_runner/tasks_runner_pipe.cpp
@@ -1682,7 +1682,7 @@ public:
     void SetSpillerFactory(std::shared_ptr<ISpillerFactory>) override {
     }
 
-    TString DebugString() override {
+    TString GetOutputDebugString() override {
         return "";
     }
 

--- a/ydb/library/yql/providers/dq/task_runner/tasks_runner_pipe.cpp
+++ b/ydb/library/yql/providers/dq/task_runner/tasks_runner_pipe.cpp
@@ -1012,10 +1012,13 @@ public:
     }
 
     // <| producer methods
-    [[nodiscard]]
-    bool IsFull() const override {
+    EDqFillLevel UpdateFillLevel() override {
         ythrow yexception() << "unimplemented";
     };
+
+    void SetFillAggregator(std::shared_ptr<TDqFillAggregator>) override {
+        Y_ABORT("Unimplemented");
+    }
 
     // can throw TDqChannelStorageException
     void Push(NUdf::TUnboxedValue&& value) override {
@@ -1249,7 +1252,11 @@ public:
         Y_ABORT("Checkpoints are not supported");
     }
 
-    bool IsFull() const override {
+    EDqFillLevel UpdateFillLevel() override {
+        Y_ABORT("Unimplemented");
+    }
+
+    void SetFillAggregator(std::shared_ptr<TDqFillAggregator>) override {
         Y_ABORT("Unimplemented");
     }
 

--- a/ydb/library/yql/providers/dq/task_runner/tasks_runner_pipe.cpp
+++ b/ydb/library/yql/providers/dq/task_runner/tasks_runner_pipe.cpp
@@ -1682,6 +1682,10 @@ public:
     void SetSpillerFactory(std::shared_ptr<ISpillerFactory>) override {
     }
 
+    TString DebugString() override {
+        return "";
+    }
+
     void Prepare(const TDqTaskSettings& task, const TDqTaskRunnerMemoryLimits& memoryLimits,
         const IDqTaskRunnerExecutionContext& execCtx) override
     {

--- a/ydb/library/yql/providers/dq/task_runner/tasks_runner_pipe.cpp
+++ b/ydb/library/yql/providers/dq/task_runner/tasks_runner_pipe.cpp
@@ -1012,6 +1012,10 @@ public:
     }
 
     // <| producer methods
+    EDqFillLevel GetFillLevel() const override {
+        Y_ABORT("Unimplemented");
+    }
+
     EDqFillLevel UpdateFillLevel() override {
         ythrow yexception() << "unimplemented";
     };
@@ -1250,6 +1254,10 @@ public:
     bool Pop(NDqProto::TCheckpoint& checkpoint) override {
         Y_UNUSED(checkpoint);
         Y_ABORT("Checkpoints are not supported");
+    }
+
+    EDqFillLevel GetFillLevel() const override {
+        Y_ABORT("Unimplemented");
     }
 
     EDqFillLevel UpdateFillLevel() override {

--- a/ydb/tests/olap/load/lib/tpch.py
+++ b/ydb/tests/olap/load/lib/tpch.py
@@ -39,7 +39,8 @@ class TpchSuiteBase(LoadSuiteBase):
 
     @pytest.mark.parametrize('query_num', [i for i in range(1, 23)])
     def test_tpch(self, query_num: int):
-        if query_num in self.skip_tests:
+        # if query_num in self.skip_tests:
+        if query_num != 21:
             return
         self.run_workload_test(self._get_path(), query_num)
 
@@ -71,6 +72,7 @@ class TestTpch1000(TpchSuiteBase):
         'lineitem': 5999989709,
     }
     scale: int = 1000
+    iterations: int = 5
     timeout = max(TpchSuiteBase.timeout, 3600.)
 
 

--- a/ydb/tests/olap/load/lib/tpch.py
+++ b/ydb/tests/olap/load/lib/tpch.py
@@ -39,8 +39,7 @@ class TpchSuiteBase(LoadSuiteBase):
 
     @pytest.mark.parametrize('query_num', [i for i in range(1, 23)])
     def test_tpch(self, query_num: int):
-        # if query_num in self.skip_tests:
-        if query_num != 21:
+        if query_num in self.skip_tests:
             return
         self.run_workload_test(self._get_path(), query_num)
 
@@ -72,7 +71,6 @@ class TestTpch1000(TpchSuiteBase):
         'lineitem': 5999989709,
     }
     scale: int = 1000
-    iterations: int = 40
     timeout = max(TpchSuiteBase.timeout, 3600.)
 
 

--- a/ydb/tests/olap/load/lib/tpch.py
+++ b/ydb/tests/olap/load/lib/tpch.py
@@ -72,7 +72,7 @@ class TestTpch1000(TpchSuiteBase):
         'lineitem': 5999989709,
     }
     scale: int = 1000
-    iterations: int = 5
+    iterations: int = 40
     timeout = max(TpchSuiteBase.timeout, 3600.)
 
 


### PR DESCRIPTION
#17046 

Replaces binary logic for IDqOutput (Empty/Full) with ternary:

- NoLimit - output is ready to consume data
- SoftLimit - output has enought data to process but may consume more
- HardLimit - not free space available

NoLimit and HardLimit are approximate synonims for Empty and Full
SoftLimit is what reported from OutputChannel when it fills in-memory buffer and starts spilling

Also multi-outputs use following logic

- HardLimit when any of outputs has HardLimit
- NoLimit when at least any has NoLimit, others are SoftLimit or NoLimit 
- SoftLimit if all outputs are SoftLimit
- NoLimit it multi-output has 0 output (rare case)

TaskRunner produces new data only for output with NoLimit 

If TaskRunner terminates with ERROR in PendingOutput state, it will dump into log Output state like this:

```
2025-07-03T18:56:01.288404Z node 8 :KQP_COMPUTE ERROR: dq_sync_compute_actor_base.h:63: SelfId: [8:7522928828340404785:2524], TxId: 281474987750657, task: 33. Ctx: { SessionId : ydb://session/3?node_id=8&id=ZGMzOWE1ZjMtOWViYzE1NjktYmE3NGVjNmMtZjdiZDkzNTY=.  CustomerSuppliedId : .  TraceId : kqprun-2025-07-03T18:46:01.056931Z.  CurrentExecutionId : .  DatabaseId : /Root/tpch100.  PoolId : default.  Database : /Root/tpch100. }. TaskRunner->Output Debug String: Output.FillLimit == HardLimit TDqFillAggregator { N=15 S=0 H=1 } TDqOutputHashPartitionConsumer { C0:2 C1:0 C2:0 C3:0 C4:0 C5:0 C6:0 C7:0 C8:0 C9:0 C10:0 C11:0 C12:0 C13:0 C14:0 C15:0 }
2025-07-03T18:56:01.288456Z node 8 :KQP_COMPUTE ERROR: dq_sync_compute_actor_base.h:63: SelfId: [8:7522928828340404777:2520], TxId: 281474987750657, task: 13. Ctx: { SessionId : ydb://session/3?node_id=8&id=ZGMzOWE1ZjMtOWViYzE1NjktYmE3NGVjNmMtZjdiZDkzNTY=.  TraceId : kqprun-2025-07-03T18:46:01.056931Z.  CustomerSuppliedId : .  CurrentExecutionId : .  DatabaseId : /Root/tpch100.  PoolId : default.  Database : /Root/tpch100. }. TaskRunner->Output Debug String: Output.FillLimit == HardLimit TDqFillAggregator { N=3 S=0 H=1 } TDqOutputHashPartitionConsumerBlock { C0:2 C1:0 C2:0 C3:0 }
2025-07-03T18:56:01.288477Z node 8 :KQP_COMPUTE ERROR: dq_sync_compute_actor_base.h:63: SelfId: [8:7522928828340404787:2525], TxId: 281474987750657, task: 34. Ctx: { SessionId : ydb://session/3?node_id=8&id=ZGMzOWE1ZjMtOWViYzE1NjktYmE3NGVjNmMtZjdiZDkzNTY=.  CustomerSuppliedId : .  TraceId : kqprun-2025-07-03T18:46:01.056931Z.  CurrentExecutionId : .  DatabaseId : /Root/tpch100.  Database : /Root/tpch100.  PoolId : default. }. TaskRunner->Output Debug String: Output.FillLimit == HardLimit TDqFillAggregator { N=15 S=0 H=1 } TDqOutputHashPartitionConsumer { C0:0 C1:0 C2:0 C3:0 C4:0 C5:0 C6:0 C7:0 C8:0 C9:0 C10:0 C11:0 C12:0 C13:0 C14:2 C15:0 }
2025-07-03T18:56:01.288486Z node 8 :KQP_COMPUTE ERROR: dq_sync_compute_actor_base.h:63: SelfId: [8:7522928828340404788:2526], TxId: 281474987750657, task: 35. Ctx: { CustomerSuppliedId : .  SessionId : ydb://session/3?node_id=8&id=ZGMzOWE1ZjMtOWViYzE1NjktYmE3NGVjNmMtZjdiZDkzNTY=.  TraceId : kqprun-2025-07-03T18:46:01.056931Z.  CurrentExecutionId : .  DatabaseId : /Root/tpch100.  Database : /Root/tpch100.  PoolId : default. }. TaskRunner->Output Debug String: Output.FillLimit == HardLimit TDqFillAggregator { N=15 S=0 H=1 } TDqOutputHashPartitionConsumer { C0:0 C1:0 C2:0 C3:0 C4:0 C5:0 C6:2 C7:0 C8:0 C9:0 C10:0 C11:0 C12:0 C13:0 C14:0 C15:0 }
2025-07-03T18:56:01.288493Z node 8 :KQP_COMPUTE ERROR: dq_sync_compute_actor_base.h:63: SelfId: [8:7522928828340404779:2521], TxId: 281474987750657, task: 14. Ctx: { SessionId : ydb://session/3?node_id=8&id=ZGMzOWE1ZjMtOWViYzE1NjktYmE3NGVjNmMtZjdiZDkzNTY=.  CustomerSuppliedId : .  TraceId : kqprun-2025-07-03T18:46:01.056931Z.  CurrentExecutionId : .  DatabaseId : /Root/tpch100.  PoolId : default.  Database : /Root/tpch100. }. TaskRunner->Output Debug String: Output.FillLimit == HardLimit TDqFillAggregator { N=2 S=0 H=2 } TDqOutputHashPartitionConsumerBlock { C0:2 C1:0 C2:2 C3:0 }
2025-07-03T18:56:01.288602Z node 6 :KQP_COMPUTE ERROR: dq_sync_compute_actor_base.h:63: SelfId: [6:7522928828069045390:2506], TxId: 281474987750657, task: 9. Ctx: { CustomerSuppliedId : .  TraceId : kqprun-2025-07-03T18:46:01.056931Z.  SessionId : ydb://session/3?node_id=8&id=ZGMzOWE1ZjMtOWViYzE1NjktYmE3NGVjNmMtZjdiZDkzNTY=.  CurrentExecutionId : .  DatabaseId : /Root/tpch100.  PoolId : default.  Database : /Root/tpch100. }. TaskRunner->Output Debug String: Output.FillLimit == HardLimit TDqFillAggregator { N=3 S=0 H=1 } TDqOutputHashPartitionConsumerBlock { C0:0 C1:0 C2:0 C3:2 }
2025-07-03T18:56:01.288621Z node 2 :KQP_COMPUTE ERROR: dq_sync_compute_actor_base.h:63: SelfId: [2:7522928827589606417:2511], TxId: 281474987750657, task: 1. Ctx: { SessionId : ydb://session/3?node_id=8&id=ZGMzOWE1ZjMtOWViYzE1NjktYmE3NGVjNmMtZjdiZDkzNTY=.  TraceId : kqprun-2025-07-03T18:46:01.056931Z.  CustomerSuppliedId : .  CurrentExecutionId : .  DatabaseId : /Root/tpch100.  PoolId : default.  Database : /Root/tpch100. }. TaskRunner->Output Debug String: Output.FillLimit == HardLimit TDqFillAggregator { N=1 S=0 H=3 } TDqOutputHashPartitionConsumerBlock { C0:2 C1:2 C2:2 C3:0 }
2025-07-03T18:56:01.288686Z node 3 :KQP_COMPUTE ERROR: dq_sync_compute_actor_base.h:63: SelfId: [3:7522928829550634761:2509], TxId: 281474987750657, task: 4. Ctx: { CustomerSuppliedId : .  TraceId : kqprun-2025-07-03T18:46:01.056931Z.  SessionId : ydb://session/3?node_id=8&id=ZGMzOWE1ZjMtOWViYzE1NjktYmE3NGVjNmMtZjdiZDkzNTY=.  CurrentExecutionId : .  DatabaseId : /Root/tpch100.  PoolId : default.  Database : /Root/tpch100. }. TaskRunner->Output Debug String: Output.FillLimit == HardLimit TDqFillAggregator { N=1 S=0 H=3 } TDqOutputHashPartitionConsumerBlock { C0:2 C1:2 C2:2 C3:0 }
2025-07-03T18:56:01.288695Z node 7 :KQP_COMPUTE ERROR: dq_sync_compute_actor_base.h:63: SelfId: [7:7522928829459380728:2504], TxId: 281474987750657, task: 11. Ctx: { SessionId : ydb://session/3?node_id=8&id=ZGMzOWE1ZjMtOWViYzE1NjktYmE3NGVjNmMtZjdiZDkzNTY=.  CustomerSuppliedId : .  TraceId : kqprun-2025-07-03T18:46:01.056931Z.  CurrentExecutionId : .  DatabaseId : /Root/tpch100.  PoolId : default.  Database : /Root/tpch100. }. TaskRunner->Output Debug String: Output.FillLimit == HardLimit TDqFillAggregator { N=2 S=0 H=2 } TDqOutputHashPartitionConsumerBlock { C0:0 C1:0 C2:2 C3:2 }
2025-07-03T18:56:01.288511Z node 4 :KQP_COMPUTE ERROR: dq_sync_compute_actor_base.h:63: SelfId: [4:7522928829959585097:2579], TxId: 281474987750657, task: 5. Ctx: { SessionId : ydb://session/3?node_id=8&id=ZGMzOWE1ZjMtOWViYzE1NjktYmE3NGVjNmMtZjdiZDkzNTY=.  CustomerSuppliedId : .  TraceId : kqprun-2025-07-03T18:46:01.056931Z.  CurrentExecutionId : .  DatabaseId : /Root/tpch100.  Database : /Root/tpch100.  PoolId : default. }. TaskRunner->Output Debug String: Output.FillLimit == HardLimit TDqFillAggregator { N=2 S=0 H=2 } TDqOutputHashPartitionConsumerBlock { C0:0 C1:2 C2:2 C3:0 }
2025-07-03T18:56:01.288750Z node 7 :KQP_COMPUTE ERROR: dq_sync_compute_actor_base.h:63: SelfId: [7:7522928829459380730:2505], TxId: 281474987750657, task: 12. Ctx: { CustomerSuppliedId : .  SessionId : ydb://session/3?node_id=8&id=ZGMzOWE1ZjMtOWViYzE1NjktYmE3NGVjNmMtZjdiZDkzNTY=.  TraceId : kqprun-2025-07-03T18:46:01.056931Z.  CurrentExecutionId : .  DatabaseId : /Root/tpch100.  Database : /Root/tpch100.  PoolId : default. }. TaskRunner->Output Debug String: Output.FillLimit == HardLimit TDqFillAggregator { N=3 S=0 H=1 } TDqOutputHashPartitionConsumerBlock { C0:0 C1:0 C2:2 C3:0 }
2025-07-03T18:56:01.288663Z node 4 :KQP_COMPUTE ERROR: dq_sync_compute_actor_base.h:63: SelfId: [4:7522928829959585099:2580], TxId: 281474987750657, task: 6. Ctx: { TraceId : kqprun-2025-07-03T18:46:01.056931Z.  SessionId : ydb://session/3?node_id=8&id=ZGMzOWE1ZjMtOWViYzE1NjktYmE3NGVjNmMtZjdiZDkzNTY=.  CustomerSuppliedId : .  CurrentExecutionId : .  DatabaseId : /Root/tpch100.  Database : /Root/tpch100.  PoolId : default. }. TaskRunner->Output Debug String: Output.FillLimit == HardLimit TDqFillAggregator { N=2 S=0 H=2 } TDqOutputHashPartitionConsumerBlock { C0:0 C1:2 C2:0 C3:2 }
2025-07-03T18:56:01.288755Z node 9 :KQP_COMPUTE ERROR: dq_sync_compute_actor_base.h:63: SelfId: [9:7522928829317519594:2513], TxId: 281474987750657, task: 16. Ctx: { SessionId : ydb://session/3?node_id=8&id=ZGMzOWE1ZjMtOWViYzE1NjktYmE3NGVjNmMtZjdiZDkzNTY=.  TraceId : kqprun-2025-07-03T18:46:01.056931Z.  CustomerSuppliedId : .  CurrentExecutionId : .  DatabaseId : /Root/tpch100.  PoolId : default.  Database : /Root/tpch100. }. TaskRunner->Output Debug String: Output.FillLimit == HardLimit TDqFillAggregator { N=1 S=0 H=3 } TDqOutputHashPartitionConsumerBlock { C0:2 C1:2 C2:2 C3:0 }
2025-07-03T18:56:01.288689Z node 5 :KQP_COMPUTE ERROR: dq_sync_compute_actor_base.h:63: SelfId: [5:7522928827519923120:2513], TxId: 281474987750657, task: 7. Ctx: { CustomerSuppliedId : .  TraceId : kqprun-2025-07-03T18:46:01.056931Z.  SessionId : ydb://session/3?node_id=8&id=ZGMzOWE1ZjMtOWViYzE1NjktYmE3NGVjNmMtZjdiZDkzNTY=.  CurrentExecutionId : .  DatabaseId : /Root/tpch100.  PoolId : default.  Database : /Root/tpch100. }. TaskRunner->Output Debug String: Output.FillLimit == HardLimit TDqFillAggregator { N=3 S=0 H=1 } TDqOutputHashPartitionConsumerBlock { C0:0 C1:0 C2:0 C3:2 }
2025-07-03T18:56:01.288763Z node 3 :KQP_COMPUTE ERROR: dq_sync_compute_actor_base.h:63: SelfId: [3:7522928829550634759:2508], TxId: 281474987750657, task: 3. Ctx: { CustomerSuppliedId : .  TraceId : kqprun-2025-07-03T18:46:01.056931Z.  SessionId : ydb://session/3?node_id=8&id=ZGMzOWE1ZjMtOWViYzE1NjktYmE3NGVjNmMtZjdiZDkzNTY=.  CurrentExecutionId : .  DatabaseId : /Root/tpch100.  PoolId : default.  Database : /Root/tpch100. }. TaskRunner->Output Debug String: Output.FillLimit == HardLimit TDqFillAggregator { N=2 S=0 H=2 } TDqOutputHashPartitionConsumerBlock { C0:2 C1:0 C2:2 C3:0 }
2025-07-03T18:56:01.288720Z node 5 :KQP_COMPUTE ERROR: dq_sync_compute_actor_base.h:63: SelfId: [5:7522928827519923122:2514], TxId: 281474987750657, task: 8. Ctx: { CustomerSuppliedId : .  TraceId : kqprun-2025-07-03T18:46:01.056931Z.  SessionId : ydb://session/3?node_id=8&id=ZGMzOWE1ZjMtOWViYzE1NjktYmE3NGVjNmMtZjdiZDkzNTY=.  CurrentExecutionId : .  DatabaseId : /Root/tpch100.  Database : /Root/tpch100.  PoolId : default. }. TaskRunner->Output Debug String: Output.FillLimit == HardLimit TDqFillAggregator { N=3 S=0 H=1 } TDqOutputHashPartitionConsumerBlock { C0:0 C1:0 C2:0 C3:2 }
2025-07-03T18:56:01.288795Z node 6 :KQP_COMPUTE ERROR: dq_sync_compute_actor_base.h:63: SelfId: [6:7522928828069045392:2507], TxId: 281474987750657, task: 10. Ctx: { SessionId : ydb://session/3?node_id=8&id=ZGMzOWE1ZjMtOWViYzE1NjktYmE3NGVjNmMtZjdiZDkzNTY=.  CustomerSuppliedId : .  TraceId : kqprun-2025-07-03T18:46:01.056931Z.  CurrentExecutionId : .  DatabaseId : /Root/tpch100.  PoolId : default.  Database : /Root/tpch100. }. TaskRunner->Output Debug String: Output.FillLimit == HardLimit TDqFillAggregator { N=3 S=0 H=1 } TDqOutputHashPartitionConsumerBlock { C0:0 C1:0 C2:2 C3:0 }
2025-07-03T18:56:01.288863Z node 9 :KQP_COMPUTE ERROR: dq_sync_compute_actor_base.h:63: SelfId: [9:7522928829317519592:2512], TxId: 281474987750657, task: 15. Ctx: { TraceId : kqprun-2025-07-03T18:46:01.056931Z.  CustomerSuppliedId : .  SessionId : ydb://session/3?node_id=8&id=ZGMzOWE1ZjMtOWViYzE1NjktYmE3NGVjNmMtZjdiZDkzNTY=.  CurrentExecutionId : .  DatabaseId : /Root/tpch100.  Database : /Root/tpch100.  PoolId : default. }. TaskRunner->Output Debug String: Output.FillLimit == HardLimit TDqFillAggregator { N=2 S=0 H=2 } TDqOutputHashPartitionConsumerBlock { C0:2 C1:2 C2:0 C3:0 }
2025-07-03T18:56:01.288875Z node 2 :KQP_COMPUTE ERROR: dq_sync_compute_actor_base.h:63: SelfId: [2:7522928827589606419:2512], TxId: 281474987750657, task: 2. Ctx: { SessionId : ydb://session/3?node_id=8&id=ZGMzOWE1ZjMtOWViYzE1NjktYmE3NGVjNmMtZjdiZDkzNTY=.  TraceId : kqprun-2025-07-03T18:46:01.056931Z.  CustomerSuppliedId : .  CurrentExecutionId : .  DatabaseId : /Root/tpch100.  Database : /Root/tpch100.  PoolId : default. }. TaskRunner->Output Debug String: Output.FillLimit == HardLimit TDqFillAggregator { N=3 S=0 H=1 } TDqOutputHashPartitionConsumerBlock { C0:2 C1:0 C2:0 C3:0 }
2025-07-03T18:56:01.310101Z node 8 :KQP_COMPUTE ERROR: dq_sync_compute_actor_base.h:63: SelfId: [8:7522928828340404789:2527], TxId: 281474987750657, task: 36. Ctx: { TraceId : kqprun-2025-07-03T18:46:01.056931Z.  SessionId : ydb://session/3?node_id=8&id=ZGMzOWE1ZjMtOWViYzE1NjktYmE3NGVjNmMtZjdiZDkzNTY=.  CustomerSuppliedId : .  CurrentExecutionId : .  DatabaseId : /Root/tpch100.  PoolId : default.  Database : /Root/tpch100. }. TaskRunner->Output Debug String: Output.FillLimit == HardLimit TDqFillAggregator { N=15 S=0 H=1 } TDqOutputHashPartitionConsumer { C0:0 C1:0 C2:0 C3:0 C4:0 C5:0 C6:0 C7:0 C8:2 C9:0 C10:0 C11:0 C12:0 C13:0 C14:0 C15:0 }
```