### PR TITLE
Better BadRequest in index builders

### DIFF
--- a/ydb/core/protos/tx_datashard.proto
+++ b/ydb/core/protos/tx_datashard.proto
@@ -33,7 +33,7 @@ enum EDatashardState {
     Readonly = 3;
     Offline = 4;
     PreOffline = 5;     // Offline but waits for loaned snapshots to be returned and for SchemaChangedResult to be received
-    Frozen = 6; // Read only transactions are allowed. Scheme modification is forbiden
+    Frozen = 6; // Read only transactions are allowed. Scheme modification is forbidden
 
     // Split/Merge Src states
     SplitSrcWaitForNoTxInFlight = 101;    // Temporary state: split src waits for all Tx to finish and then starts splitting
@@ -1628,9 +1628,6 @@ message TEvReshuffleKMeansResponse {
     optional uint64 UploadBytes = 9;
     optional uint64 ReadRows = 10;
     optional uint64 ReadBytes = 11;
-
-    // TODO(mbkkt) implement slow-path (reliable-path)
-    // optional last written primary key
 }
 
 message TEvPrefixKMeansRequest {

--- a/ydb/core/protos/tx_datashard.proto
+++ b/ydb/core/protos/tx_datashard.proto
@@ -1424,14 +1424,14 @@ message TEvConditionalEraseRowsResponse {
 }
 
 message TEvBuildIndexCreateRequest {
-    optional uint64 BuildIndexId = 1;          // unique id of build index proccess
+    optional uint64 BuildIndexId = 1;          // unique id of build index process
 
     optional uint64 TabletId = 2;
     optional uint64 OwnerId = 3;
     optional uint64 PathId = 4;
 
     optional string TargetName = 5;
-    repeated string IndexColumns = 6;          // key columns that is needed to transer in terms of target table
+    repeated string IndexColumns = 6;          // key columns that is needed to transfer in terms of target table
 
     optional NKikimrTx.TKeyRange KeyRange = 7; // key range to transfer in term of source table
 

--- a/ydb/core/protos/tx_datashard.proto
+++ b/ydb/core/protos/tx_datashard.proto
@@ -1481,9 +1481,10 @@ message TEvSampleKRequest {
     optional NKikimrProto.TPathID PathId = 3;
 
     optional uint64 K = 4;
-    // For now we use tablet id as seed value, but it's not convinient for tests
+
     optional uint64 Seed = 5;
-    // We want to sample small instead of large probabilites
+
+    // We want to sample small instead of large probabilities
     // because size of message will be smaller (varint)
     optional uint64 MaxProbability = 6;
 

--- a/ydb/core/tx/datashard/build_index.cpp
+++ b/ydb/core/tx/datashard/build_index.cpp
@@ -515,50 +515,113 @@ void TDataShard::Handle(TEvDataShard::TEvBuildIndexCreateRequest::TPtr& ev, cons
 }
 
 void TDataShard::HandleSafe(TEvDataShard::TEvBuildIndexCreateRequest::TPtr& ev, const TActorContext& ctx) {
-    const auto& record = ev->Get()->Record;
-    TRowVersion rowVersion(record.GetSnapshotStep(), record.GetSnapshotTxId());
+    auto& request = ev->Get()->Record;
+    const ui64 id = request.GetBuildIndexId();
+    TRowVersion rowVersion(request.GetSnapshotStep(), request.GetSnapshotTxId());
+    TScanRecord::TSeqNo seqNo = {request.GetSeqNoGeneration(), request.GetSeqNoRound()};
 
-    LOG_N("Starting TBuildIndexScan " << record.ShortDebugString()
+    auto response = MakeHolder<TEvDataShard::TEvBuildIndexProgressResponse>();
+    response->Record.SetBuildIndexId(request.GetBuildIndexId());
+    response->Record.SetTabletId(TabletID());
+    response->Record.SetRequestSeqNoGeneration(seqNo.Generation);
+    response->Record.SetRequestSeqNoRound(seqNo.Round);
+
+    LOG_N("Starting TBuildIndexScan " << request.ShortDebugString()
         << " row version " << rowVersion);
 
     // Note: it's very unlikely that we have volatile txs before this snapshot
     if (VolatileTxManager.HasVolatileTxsAtSnapshot(rowVersion)) {
-        VolatileTxManager.AttachWaitingSnapshotEvent(rowVersion,
-                                                     std::unique_ptr<IEventHandle>(ev.Release()));
+        VolatileTxManager.AttachWaitingSnapshotEvent(rowVersion, std::unique_ptr<IEventHandle>(ev.Release()));
         return;
     }
 
-    TScanRecord::TSeqNo seqNo = {record.GetSeqNoGeneration(), record.GetSeqNoRound()};
     auto badRequest = [&](const TString& error) {
-        auto response = MakeHolder<TEvDataShard::TEvBuildIndexProgressResponse>();
-        response->Record.SetBuildIndexId(record.GetBuildIndexId());
-        response->Record.SetTabletId(TabletID());
-        response->Record.SetRequestSeqNoGeneration(seqNo.Generation);
-        response->Record.SetRequestSeqNoRound(seqNo.Round);
         response->Record.SetStatus(NKikimrIndexBuilder::EBuildStatus::BAD_REQUEST);
         auto issue = response->Record.AddIssues();
         issue->set_severity(NYql::TSeverityIds::S_ERROR);
         issue->set_message(error);
-        ctx.Send(ev->Sender, std::move(response));
+    };
+    auto trySendBadRequest = [&] {
+        if (response->Record.GetStatus() == NKikimrIndexBuilder::EBuildStatus::BAD_REQUEST) {
+            LOG_E("Rejecting TBuildIndexScan bad request " << request.ShortDebugString()
+                << " with response " << response->Record.ShortDebugString());
+            ctx.Send(ev->Sender, std::move(response));
+            return true;
+        } else {
+            return false;
+        }
     };
 
-    const ui64 buildIndexId = record.GetBuildIndexId();
-    const ui64 shardId = record.GetTabletId();
-    const auto tableId = TTableId(record.GetOwnerId(), record.GetPathId());
-
-    if (shardId != TabletID()) {
-        badRequest(TStringBuilder() << "Wrong shard " << shardId << " this is " << TabletID());
-        return;
+    // 1. Validating table and path existence
+    const auto tableId = TTableId(request.GetOwnerId(), request.GetPathId());
+    if (request.GetTabletId() != TabletID()) {
+        badRequest(TStringBuilder() << "Wrong shard " << request.GetTabletId() << " this is " << TabletID());
     }
-
+    if (!IsStateActive()) {
+        badRequest(TStringBuilder() << "Shard " << TabletID() << " is " << State << " and not ready for requests");
+    }
     if (!GetUserTables().contains(tableId.PathId.LocalPathId)) {
         badRequest(TStringBuilder() << "Unknown table id: " << tableId.PathId.LocalPathId);
+    }
+    if (trySendBadRequest()) {
+        return;
+    }
+    const auto& userTable = *GetUserTables().at(tableId.PathId.LocalPathId);
+
+    // 2. Validating request fields
+    if (!request.HasSnapshotStep() || !request.HasSnapshotTxId()) {
+        badRequest(TStringBuilder() << "Empty snapshot");
+    }
+    const TSnapshotKey snapshotKey(tableId.PathId, rowVersion.Step, rowVersion.TxId);
+    if (!SnapshotManager.FindAvailable(snapshotKey)) {
+        badRequest(TStringBuilder() << "Unknown snapshot for path id " << tableId.PathId.OwnerId << ":" << tableId.PathId.LocalPathId
+            << ", snapshot step is " << snapshotKey.Step << ", snapshot tx is " << snapshotKey.TxId);
+    }
+
+    TSerializedTableRange requestedRange;
+    requestedRange.Load(request.GetKeyRange());
+    auto scanRange = Intersect(userTable.KeyColumnTypes, requestedRange.ToTableRange(), userTable.Range.ToTableRange());
+    if (scanRange.IsEmptyRange(userTable.KeyColumnTypes)) {
+        badRequest(TStringBuilder() << " requested range doesn't intersect with table range"
+            << " requestedRange: " << DebugPrintRange(userTable.KeyColumnTypes, requestedRange.ToTableRange(), *AppData()->TypeRegistry)
+            << " tableRange: " << DebugPrintRange(userTable.KeyColumnTypes, userTable.Range.ToTableRange(), *AppData()->TypeRegistry)
+            << " scanRange: " << DebugPrintRange(userTable.KeyColumnTypes, scanRange, *AppData()->TypeRegistry));
+    }
+
+    if (!request.HasTargetName()) {
+        badRequest(TStringBuilder() << "Empty target table name");
+    }
+
+    auto tags = GetAllTags(userTable);
+    for (auto column : request.GetIndexColumns()) {
+        if (!tags.contains(column)) {
+            badRequest(TStringBuilder() << "Unknown index column: " << column);
+        }
+    }
+    for (auto column : request.GetDataColumns()) {
+        if (!tags.contains(column)) {
+            badRequest(TStringBuilder() << "Unknown data column: " << column);
+        }
+    }
+
+    if (trySendBadRequest()) {
         return;
     }
 
-    const auto& userTable = *GetUserTables().at(tableId.PathId.LocalPathId);
+    // 3. Creating scan
+    TAutoPtr<NTable::IScan> scan = CreateBuildIndexScan(id,
+        request.GetTargetName(),
+        seqNo,
+        request.GetTabletId(),
+        ev->Sender,
+        requestedRange,
+        request.GetIndexColumns(),
+        request.GetDataColumns(),
+        request.GetColumnBuildSettings(),
+        userTable,
+        request.GetScanSettings());
 
-    if (const auto* recCard = ScanManager.Get(buildIndexId)) {
+    if (const auto* recCard = ScanManager.Get(id)) {
         if (recCard->SeqNo == seqNo) {
             // do no start one more scan
             return;
@@ -567,63 +630,14 @@ void TDataShard::HandleSafe(TEvDataShard::TEvBuildIndexCreateRequest::TPtr& ev, 
         for (auto scanId : recCard->ScanIds) {
             CancelScan(userTable.LocalTid, scanId);
         }
-        ScanManager.Drop(buildIndexId);
-    }
-
-    TSerializedTableRange requestedRange;
-    requestedRange.Load(record.GetKeyRange());
-
-    auto scanRange = Intersect(userTable.KeyColumnTypes, requestedRange.ToTableRange(), userTable.Range.ToTableRange());
-
-    if (scanRange.IsEmptyRange(userTable.KeyColumnTypes)) {
-        badRequest(TStringBuilder() << " requested range doesn't intersect with table range"
-                                    << " requestedRange: " << DebugPrintRange(userTable.KeyColumnTypes, requestedRange.ToTableRange(), *AppData()->TypeRegistry)
-                                    << " tableRange: " << DebugPrintRange(userTable.KeyColumnTypes, userTable.Range.ToTableRange(), *AppData()->TypeRegistry)
-                                    << " scanRange: " << DebugPrintRange(userTable.KeyColumnTypes, scanRange, *AppData()->TypeRegistry));
-        return;
-    }
-
-    if (!record.HasSnapshotStep() || !record.HasSnapshotTxId()) {
-        badRequest(TStringBuilder() << " request doesn't have Shapshot Step or TxId");
-        return;
-    }
-
-    const TSnapshotKey snapshotKey(tableId.PathId, rowVersion.Step, rowVersion.TxId);
-    const TSnapshot* snapshot = SnapshotManager.FindAvailable(snapshotKey);
-    if (!snapshot) {
-        badRequest(TStringBuilder()
-                   << "no snapshot has been found"
-                   << " , path id is " << tableId.PathId.OwnerId << ":" << tableId.PathId.LocalPathId
-                   << " , snapshot step is " << snapshotKey.Step
-                   << " , snapshot tx is " << snapshotKey.TxId);
-        return;
-    }
-
-    if (!IsStateActive()) {
-        badRequest(TStringBuilder() << "Shard " << TabletID() << " is not ready for requests");
-        return;
+        ScanManager.Drop(id);
     }
 
     TScanOptions scanOpts;
     scanOpts.SetSnapshotRowVersion(rowVersion);
     scanOpts.SetResourceBroker("build_index", 10);
-
-    const auto scanId = QueueScan(userTable.LocalTid,
-                                  CreateBuildIndexScan(buildIndexId,
-                                                       record.GetTargetName(),
-                                                       seqNo,
-                                                       shardId,
-                                                       ev->Sender,
-                                                       requestedRange,
-                                                       record.GetIndexColumns(),
-                                                       record.GetDataColumns(),
-                                                       record.GetColumnBuildSettings(),
-                                                       userTable,
-                                                       record.GetScanSettings()),
-                                  0,
-                                  scanOpts);
-
-    ScanManager.Set(buildIndexId, seqNo).push_back(scanId);
+    const auto scanId = QueueScan(userTable.LocalTid, std::move(scan), 0, scanOpts);
+    ScanManager.Set(id, seqNo).push_back(scanId);
 }
 
 }

--- a/ydb/core/tx/datashard/datashard_ut_build_index.cpp
+++ b/ydb/core/tx/datashard/datashard_ut_build_index.cpp
@@ -19,8 +19,55 @@ using namespace NKikimr::NDataShard::NKqpHelpers;
 using namespace NSchemeShard;
 using namespace Tests;
 
+static const TString kMainTable = "/Root/table-1";
+static const TString kIndexTable = "/Root/table-2";
 
 Y_UNIT_TEST_SUITE(TTxDataShardBuildIndexScan) {
+
+    static void DoBadRequest(Tests::TServer::TPtr server, TActorId sender,
+        std::function<void(NKikimrTxDataShard::TEvBuildIndexCreateRequest&)> setupRequest,
+        TString expectedError, bool expectedErrorSubstring = false) 
+    {
+        auto &runtime = *server->GetRuntime();
+        auto snapshot = CreateVolatileSnapshot(server, {kMainTable});
+        TVector<ui64> datashards = GetTableShards(server, sender, kMainTable);
+        TTableId tableId = ResolveTableId(server, sender, kMainTable);
+
+        TStringBuilder data;
+        TString err;
+        UNIT_ASSERT(datashards.size() == 1);
+
+        auto ev = new TEvDataShard::TEvBuildIndexCreateRequest;
+        NKikimrTxDataShard::TEvBuildIndexCreateRequest& rec = ev->Record;
+        rec.SetBuildIndexId(1);
+
+        rec.SetTabletId(datashards[0]);
+        rec.SetOwnerId(tableId.PathId.OwnerId);
+        rec.SetPathId(tableId.PathId.LocalPathId);
+
+        rec.SetTargetName(kIndexTable);
+        rec.AddIndexColumns("value");
+        rec.AddIndexColumns("key");
+
+        rec.SetSnapshotTxId(snapshot.TxId);
+        rec.SetSnapshotStep(snapshot.Step);
+
+        setupRequest(rec);
+
+        runtime.SendToPipe(datashards[0], sender, ev, 0, GetPipeConfigWithRetries());
+
+        TAutoPtr<IEventHandle> handle;
+        auto reply = runtime.GrabEdgeEventRethrow<TEvDataShard::TEvBuildIndexProgressResponse>(handle);
+        UNIT_ASSERT_VALUES_EQUAL(reply->Record.GetStatus(), NKikimrIndexBuilder::EBuildStatus::BAD_REQUEST);
+        
+        NYql::TIssues issues;
+        NYql::IssuesFromMessage(reply->Record.GetIssues(), issues);
+        if (expectedErrorSubstring) {
+            UNIT_ASSERT_STRING_CONTAINS(issues.ToOneLineString(), expectedError);
+        } else {
+            UNIT_ASSERT_VALUES_EQUAL(issues.ToOneLineString(), expectedError);
+        }
+    }
 
     static void DoBuildIndex(Tests::TServer::TPtr server, TActorId sender,
                              const TString& tableFrom, const TString& tableTo,
@@ -90,6 +137,58 @@ Y_UNIT_TEST_SUITE(TTxDataShardBuildIndexScan) {
         CreateShardedTable(server, sender, root, name, opts);
     }
 
+    Y_UNIT_TEST(BadRequest) {
+        TPortManager pm;
+        TServerSettings serverSettings(pm.GetPort(2134));
+        serverSettings.SetDomainName("Root")
+            .SetUseRealThreads(false);
+
+        Tests::TServer::TPtr server = new TServer(serverSettings);
+        auto &runtime = *server->GetRuntime();
+        auto sender = runtime.AllocateEdgeActor();
+
+        runtime.SetLogPriority(NKikimrServices::TX_DATASHARD, NLog::PRI_DEBUG);
+        runtime.SetLogPriority(NKikimrServices::BUILD_INDEX, NLog::PRI_TRACE);
+
+        // Allow manipulating shadow data using normal schemeshard operations
+        runtime.GetAppData().AllowShadowDataInSchemeShardForTests = true;
+
+        InitRoot(server, sender);
+
+        CreateShardedTable(server, sender, "/Root", "table-1", 1, false);
+
+        DoBadRequest(server, sender, [](NKikimrTxDataShard::TEvBuildIndexCreateRequest& request) {
+            request.SetTabletId(0);
+        }, TStringBuilder() << "{ <main>: Error: Wrong shard 0 this is " << GetTableShards(server, sender, kMainTable)[0] << " }");
+        DoBadRequest(server, sender, [](NKikimrTxDataShard::TEvBuildIndexCreateRequest& request) {
+            request.SetPathId(0);
+        }, "{ <main>: Error: Unknown table id: 0 }");
+
+        DoBadRequest(server, sender, [](NKikimrTxDataShard::TEvBuildIndexCreateRequest& request) {
+            request.SetSnapshotStep(request.GetSnapshotStep() + 1);
+        }, "Error: Unknown snapshot", true);
+        DoBadRequest(server, sender, [](NKikimrTxDataShard::TEvBuildIndexCreateRequest& request) {
+            request.SetSnapshotTxId(request.GetSnapshotTxId() + 1);
+        }, "Error: Unknown snapshot", true);
+
+        DoBadRequest(server, sender, [](NKikimrTxDataShard::TEvBuildIndexCreateRequest& request) {
+            request.ClearTargetName();
+        }, "{ <main>: Error: Empty target table name }");
+
+        DoBadRequest(server, sender, [](NKikimrTxDataShard::TEvBuildIndexCreateRequest& request) {
+            request.AddIndexColumns("some");
+        }, "{ <main>: Error: Unknown index column: some }");
+        DoBadRequest(server, sender, [](NKikimrTxDataShard::TEvBuildIndexCreateRequest& request) {
+            request.AddDataColumns("some");
+        }, "{ <main>: Error: Unknown data column: some }");
+
+        // test multiple issues:
+        DoBadRequest(server, sender, [](NKikimrTxDataShard::TEvBuildIndexCreateRequest& request) {
+            request.AddIndexColumns("some1");
+            request.AddDataColumns("some2");
+        }, "[ { <main>: Error: Unknown index column: some1 } { <main>: Error: Unknown data column: some2 } ]");
+    }
+
     Y_UNIT_TEST(RunScan) {
         TPortManager pm;
         TServerSettings serverSettings(pm.GetPort(2134));
@@ -101,6 +200,7 @@ Y_UNIT_TEST_SUITE(TTxDataShardBuildIndexScan) {
         auto sender = runtime.AllocateEdgeActor();
 
         runtime.SetLogPriority(NKikimrServices::TX_DATASHARD, NLog::PRI_DEBUG);
+        runtime.SetLogPriority(NKikimrServices::BUILD_INDEX, NLog::PRI_TRACE);
 
         // Allow manipulating shadow data using normal schemeshard operations
         runtime.GetAppData().AllowShadowDataInSchemeShardForTests = true;
@@ -114,12 +214,12 @@ Y_UNIT_TEST_SUITE(TTxDataShardBuildIndexScan) {
 
         CreateShardedTableForIndex(server, sender, "/Root", "table-2", 1, false);
 
-        auto snapshot = CreateVolatileSnapshot(server, { "/Root/table-1" });
+        auto snapshot = CreateVolatileSnapshot(server, { kMainTable });
 
-        DoBuildIndex(server, sender, "/Root/table-1", "/Root/table-2", snapshot, NKikimrIndexBuilder::EBuildStatus::DONE);
+        DoBuildIndex(server, sender, kMainTable, kIndexTable, snapshot, NKikimrIndexBuilder::EBuildStatus::DONE);
 
         // Writes to shadow data should not be visible yet
-        auto data = ReadShardedTable(server, "/Root/table-2");
+        auto data = ReadShardedTable(server, kIndexTable);
         UNIT_ASSERT_VALUES_EQUAL(data, "");
 
         // Alter table: disable shadow data and change compaction policy
@@ -128,7 +228,7 @@ Y_UNIT_TEST_SUITE(TTxDataShardBuildIndexScan) {
         WaitTxNotification(server, AsyncAlterAndDisableShadow(server, "/Root", "table-2", policy.Get()));
 
         // Shadow data must be visible now
-        auto data2 = ReadShardedTable(server, "/Root/table-2");
+        auto data2 = ReadShardedTable(server, kIndexTable);
         UNIT_ASSERT_VALUES_EQUAL(data2,
                                  "value = 100, key = 1\n"
                                  "value = 300, key = 3\n"
@@ -147,6 +247,7 @@ Y_UNIT_TEST_SUITE(TTxDataShardBuildIndexScan) {
         auto sender = runtime.AllocateEdgeActor();
 
         runtime.SetLogPriority(NKikimrServices::TX_DATASHARD, NLog::PRI_DEBUG);
+        runtime.SetLogPriority(NKikimrServices::BUILD_INDEX, NLog::PRI_TRACE);
         runtime.SetLogPriority(NKikimrServices::FLAT_TX_SCHEMESHARD, NLog::PRI_TRACE);
         runtime.SetLogPriority(NKikimrServices::TABLET_EXECUTOR, NLog::PRI_DEBUG);
 
@@ -166,26 +267,26 @@ Y_UNIT_TEST_SUITE(TTxDataShardBuildIndexScan) {
             return runtime.FindActorName(event->Sender) == "FLAT_SCHEMESHARD_ACTOR";
         });
 
-        auto snapshot = CreateVolatileSnapshot(server, { "/Root/table-1" });
+        auto snapshot = CreateVolatileSnapshot(server, { kMainTable });
 
-        DoBuildIndex(server, sender, "/Root/table-1", "/Root/table-2", snapshot, NKikimrIndexBuilder::EBuildStatus::DONE);
+        DoBuildIndex(server, sender, kMainTable, kIndexTable, snapshot, NKikimrIndexBuilder::EBuildStatus::DONE);
 
         // Writes to shadow data should not be visible yet
-        auto data = ReadShardedTable(server, "/Root/table-2");
+        auto data = ReadShardedTable(server, kIndexTable);
         UNIT_ASSERT_VALUES_EQUAL(data, "");
 
         // Split index
-        auto shards1 = GetTableShards(server, sender, "/Root/table-2");
+        auto shards1 = GetTableShards(server, sender, kIndexTable);
         UNIT_ASSERT_VALUES_EQUAL(shards1.size(), 1u);
 
         // Split would fail otherwise :(
         SetSplitMergePartCountLimit(server->GetRuntime(), -1);
 
         auto senderSplit = runtime.AllocateEdgeActor();
-        ui64 txId = AsyncSplitTable(server, senderSplit, "/Root/table-2", shards1.at(0), 300);
+        ui64 txId = AsyncSplitTable(server, senderSplit, kIndexTable, shards1.at(0), 300);
         WaitTxNotification(server, senderSplit, txId);
 
-        auto shards2 = GetTableShards(server, sender, "/Root/table-2");
+        auto shards2 = GetTableShards(server, sender, kIndexTable);
         UNIT_ASSERT_VALUES_EQUAL(shards2.size(), 2u);
 
         for (auto shardIndex : xrange(2u)) {
@@ -198,7 +299,7 @@ Y_UNIT_TEST_SUITE(TTxDataShardBuildIndexScan) {
             // Note: datashard always adds current shard to part owners, even if there are no parts
             UNIT_ASSERT_VALUES_EQUAL(owners, (THashSet<ui64>{shards1.at(0), shards2.at(shardIndex)}));
             
-            auto tableId = ResolveTableId(server, sender, "/Root/table-2");
+            auto tableId = ResolveTableId(server, sender, kIndexTable);
             auto result = CompactBorrowed(runtime, shards2.at(shardIndex), tableId);
             // Cerr << "Compact result " << result.DebugString() << Endl;
             UNIT_ASSERT_VALUES_EQUAL(result.GetTabletId(), shards2.at(shardIndex));
@@ -219,7 +320,7 @@ Y_UNIT_TEST_SUITE(TTxDataShardBuildIndexScan) {
         WaitTxNotification(server, AsyncAlterAndDisableShadow(server, "/Root", "table-2", policy.Get()));
 
         // Shadow data must be visible now
-        auto data2 = ReadShardedTable(server, "/Root/table-2");
+        auto data2 = ReadShardedTable(server, kIndexTable);
         UNIT_ASSERT_VALUES_EQUAL(data2,
                                  "value = 100, key = 1\n"
                                  "value = 200, key = 2\n"

--- a/ydb/core/tx/datashard/datashard_ut_local_kmeans.cpp
+++ b/ydb/core/tx/datashard/datashard_ut_local_kmeans.cpp
@@ -20,11 +20,11 @@ static constexpr const char* kMainTable = "/Root/table-main";
 static constexpr const char* kLevelTable = "/Root/table-level";
 static constexpr const char* kPostingTable = "/Root/table-posting";
 
-Y_UNIT_TEST_SUITE (TTxDataShardLocalKMeansScan) {
+Y_UNIT_TEST_SUITE(TTxDataShardLocalKMeansScan) {
+
     static void DoBadRequest(Tests::TServer::TPtr server, TActorId sender,
-                             std::unique_ptr<TEvDataShard::TEvLocalKMeansRequest> & ev, size_t dims = 2,
-                             VectorIndexSettings::VectorType type = VectorIndexSettings::VECTOR_TYPE_FLOAT,
-                             VectorIndexSettings::Metric metric = VectorIndexSettings::DISTANCE_COSINE)
+        std::function<void(NKikimrTxDataShard::TEvLocalKMeansRequest&)> setupRequest,
+        TString expectedError, bool expectedErrorSubstring = false)
     {
         auto id = sId.fetch_add(1, std::memory_order_relaxed);
         auto& runtime = *server->GetRuntime();
@@ -36,56 +36,55 @@ Y_UNIT_TEST_SUITE (TTxDataShardLocalKMeansScan) {
         TString err;
         UNIT_ASSERT(datashards.size() == 1);
 
-        for (auto tid : datashards) {
-            auto& rec = ev->Record;
-            rec.SetId(1);
+        auto ev = std::make_unique<TEvDataShard::TEvLocalKMeansRequest>();
+        auto& rec = ev->Record;
+        rec.SetId(1);
 
-            rec.SetSeqNoGeneration(id);
-            rec.SetSeqNoRound(1);
+        rec.SetSeqNoGeneration(id);
+        rec.SetSeqNoRound(1);
 
-            if (!rec.HasTabletId()) {
-                rec.SetTabletId(tid);
-            }
-            if (!rec.HasPathId()) {
-                tableId.PathId.ToProto(rec.MutablePathId());
-            }
+        rec.SetTabletId(datashards[0]);
+        tableId.PathId.ToProto(rec.MutablePathId());
 
-            rec.SetSnapshotTxId(snapshot.TxId);
-            rec.SetSnapshotStep(snapshot.Step);
+        rec.SetSnapshotTxId(snapshot.TxId);
+        rec.SetSnapshotStep(snapshot.Step);
 
-            VectorIndexSettings settings;
-            settings.set_vector_dimension(dims);
-            settings.set_vector_type(type);
-            settings.set_metric(metric);
-            *rec.MutableSettings() = settings;
+        VectorIndexSettings settings;
+        settings.set_vector_dimension(2);
+        settings.set_vector_type(VectorIndexSettings::VECTOR_TYPE_FLOAT);
+        settings.set_metric(VectorIndexSettings::DISTANCE_COSINE);
+        *rec.MutableSettings() = settings;
 
-            if (!rec.HasK()) {
-                rec.SetK(2);
-            }
-            rec.SetSeed(1337);
+        rec.SetK(2);
+        rec.SetSeed(1337);
 
-            rec.SetUpload(NKikimrTxDataShard::EKMeansState::UPLOAD_MAIN_TO_POSTING);
+        rec.SetUpload(NKikimrTxDataShard::EKMeansState::UPLOAD_MAIN_TO_POSTING);
 
-            rec.SetNeedsRounds(3);
+        rec.SetNeedsRounds(3);
 
-            rec.SetParentFrom(0);
-            rec.SetParentTo(0);
-            rec.SetChild(1);
+        rec.SetParentFrom(0);
+        rec.SetParentTo(0);
+        rec.SetChild(1);
 
-            if (rec.HasEmbeddingColumn()) {
-                rec.ClearEmbeddingColumn();
-            } else {
-                rec.SetEmbeddingColumn("embedding");
-            }
+        rec.SetEmbeddingColumn("embedding");
 
-            rec.SetLevelName(kLevelTable);
-            rec.SetPostingName(kPostingTable);
+        rec.SetLevelName(kLevelTable);
+        rec.SetPostingName(kPostingTable);
 
-            runtime.SendToPipe(tid, sender, ev.release(), 0, GetPipeConfigWithRetries());
+        setupRequest(rec);
 
-            TAutoPtr<IEventHandle> handle;
-            auto reply = runtime.GrabEdgeEventRethrow<TEvDataShard::TEvLocalKMeansResponse>(handle);
-            UNIT_ASSERT_VALUES_EQUAL(reply->Record.GetStatus(), NKikimrIndexBuilder::EBuildStatus::BAD_REQUEST);
+        runtime.SendToPipe(datashards[0], sender, ev.release(), 0, GetPipeConfigWithRetries());
+
+        TAutoPtr<IEventHandle> handle;
+        auto reply = runtime.GrabEdgeEventRethrow<TEvDataShard::TEvLocalKMeansResponse>(handle);
+        UNIT_ASSERT_VALUES_EQUAL(reply->Record.GetStatus(), NKikimrIndexBuilder::EBuildStatus::BAD_REQUEST);
+        
+        NYql::TIssues issues;
+        NYql::IssuesFromMessage(reply->Record.GetIssues(), issues);
+        if (expectedErrorSubstring) {
+            UNIT_ASSERT_STRING_CONTAINS(issues.ToOneLineString(), expectedError);
+        } else {
+            UNIT_ASSERT_VALUES_EQUAL(issues.ToOneLineString(), expectedError);
         }
     }
 
@@ -233,78 +232,73 @@ Y_UNIT_TEST_SUITE (TTxDataShardLocalKMeansScan) {
 
         InitRoot(server, sender);
 
-        CreateShardedTable(server, sender, "/Root", "table-main", 1);
+        TShardedTableOptions options;
+        options.EnableOutOfOrder(true); // TODO(mbkkt) what is it?
+        options.Shards(1);
+        CreateMainTable(server, sender, options);
 
-        {
-            auto ev = std::make_unique<TEvDataShard::TEvLocalKMeansRequest>();
-            auto& rec = ev->Record;
+        DoBadRequest(server, sender, [](NKikimrTxDataShard::TEvLocalKMeansRequest& request) {
+            request.SetTabletId(0);
+        }, TStringBuilder() << "{ <main>: Error: Wrong shard 0 this is " << GetTableShards(server, sender, kMainTable)[0] << " }");
+        DoBadRequest(server, sender, [](NKikimrTxDataShard::TEvLocalKMeansRequest& request) {
+            TPathId(0, 0).ToProto(request.MutablePathId());
+        }, "{ <main>: Error: Unknown table id: 0 }");
 
-            rec.SetK(0);
-            DoBadRequest(server, sender, ev);
-        }
-        {
-            auto ev = std::make_unique<TEvDataShard::TEvLocalKMeansRequest>();
-            auto& rec = ev->Record;
+        DoBadRequest(server, sender, [](NKikimrTxDataShard::TEvLocalKMeansRequest& request) {
+            request.SetSnapshotStep(request.GetSnapshotStep() + 1);
+        }, "Error: Unknown snapshot", true);
+        DoBadRequest(server, sender, [](NKikimrTxDataShard::TEvLocalKMeansRequest& request) {
+            request.SetSnapshotTxId(request.GetSnapshotTxId() + 1);
+        }, "Error: Unknown snapshot", true);
 
-            rec.SetK(1);
-            DoBadRequest(server, sender, ev);
-        }
-        {
-            auto ev = std::make_unique<TEvDataShard::TEvLocalKMeansRequest>();
-            auto& rec = ev->Record;
+        DoBadRequest(server, sender, [](NKikimrTxDataShard::TEvLocalKMeansRequest& request) {
+            request.MutableSettings()->set_vector_type(VectorIndexSettings::VECTOR_TYPE_UNSPECIFIED);
+        }, "{ <main>: Error: Wrong vector type }");
+        DoBadRequest(server, sender, [](NKikimrTxDataShard::TEvLocalKMeansRequest& request) {
+            request.MutableSettings()->set_vector_type(VectorIndexSettings::VECTOR_TYPE_BIT);
+        }, "{ <main>: Error: TODO(mbkkt) bit vector type is not supported }");
+        DoBadRequest(server, sender, [](NKikimrTxDataShard::TEvLocalKMeansRequest& request) {
+            request.MutableSettings()->set_metric(VectorIndexSettings::METRIC_UNSPECIFIED);
+        }, "{ <main>: Error: Wrong similarity }");
 
-            rec.SetEmbeddingColumn("some");
-            DoBadRequest(server, sender, ev);
-        }
-        {
-            auto ev = std::make_unique<TEvDataShard::TEvLocalKMeansRequest>();
-            auto& rec = ev->Record;
+        DoBadRequest(server, sender, [](NKikimrTxDataShard::TEvLocalKMeansRequest& request) {
+            request.SetUpload(NKikimrTxDataShard::UNSPECIFIED);
+        }, "{ <main>: Error: Wrong upload }");
+        DoBadRequest(server, sender, [](NKikimrTxDataShard::TEvLocalKMeansRequest& request) {
+            request.SetUpload(NKikimrTxDataShard::SAMPLE);
+        }, "{ <main>: Error: Wrong upload }");
 
-            rec.SetTabletId(0);
-            DoBadRequest(server, sender, ev);
-        }
-        {
-            auto ev = std::make_unique<TEvDataShard::TEvLocalKMeansRequest>();
-            auto& rec = ev->Record;
+        DoBadRequest(server, sender, [](NKikimrTxDataShard::TEvLocalKMeansRequest& request) {
+            request.SetK(0);
+        }, "{ <main>: Error: Should be requested partition on at least two rows }");
+        DoBadRequest(server, sender, [](NKikimrTxDataShard::TEvLocalKMeansRequest& request) {
+            request.SetK(1);
+        }, "{ <main>: Error: Should be requested partition on at least two rows }");
 
-            TPathId(0, 0).ToProto(rec.MutablePathId());
-            DoBadRequest(server, sender, ev);
-        }
-        {
-            auto ev = std::make_unique<TEvDataShard::TEvLocalKMeansRequest>();
+        DoBadRequest(server, sender, [](NKikimrTxDataShard::TEvLocalKMeansRequest& request) {
+            request.SetParentFrom(100);
+            request.SetParentTo(99);
+        }, "{ <main>: Error: Parent from 100 should be less or equal to parent to 99 }");
 
-            DoBadRequest(server, sender, ev, 0);
-        }
-        {
-            auto ev = std::make_unique<TEvDataShard::TEvLocalKMeansRequest>();
+        DoBadRequest(server, sender, [](NKikimrTxDataShard::TEvLocalKMeansRequest& request) {
+            request.ClearLevelName();
+        }, "{ <main>: Error: Empty level table name }");
+        DoBadRequest(server, sender, [](NKikimrTxDataShard::TEvLocalKMeansRequest& request) {
+            request.ClearPostingName();
+        }, "{ <main>: Error: Empty posting table name }");
 
-            // TODO(mbkkt) bit vector not supported for now
-            DoBadRequest(server, sender, ev, 2, VectorIndexSettings::VECTOR_TYPE_BIT);
-        }
-        {
-            auto ev = std::make_unique<TEvDataShard::TEvLocalKMeansRequest>();
+        DoBadRequest(server, sender, [](NKikimrTxDataShard::TEvLocalKMeansRequest& request) {
+            request.SetEmbeddingColumn("some");
+        }, "{ <main>: Error: Unknown embedding column: some }");
+        DoBadRequest(server, sender, [](NKikimrTxDataShard::TEvLocalKMeansRequest& request) {
+            request.AddDataColumns("some");
+        }, "{ <main>: Error: Unknown data column: some }");
 
-            DoBadRequest(server, sender, ev, 2, VectorIndexSettings::VECTOR_TYPE_UNSPECIFIED);
-        }
-        {
-            auto ev = std::make_unique<TEvDataShard::TEvLocalKMeansRequest>();
-
-            DoBadRequest(server, sender, ev, 2, VectorIndexSettings::VECTOR_TYPE_FLOAT,
-                         VectorIndexSettings::METRIC_UNSPECIFIED);
-        }
-        // TODO(mbkkt) For now all build_index, sample_k, build_columns, local_kmeans doesn't really check this
-        // {
-        //     auto ev = std::make_unique<TEvDataShard::TEvLocalKMeansRequest>();
-        //     auto snapshotCopy = snapshot;
-        //     snapshotCopy.Step++;
-        //     DoBadRequest(server, sender, ev);
-        // }
-        // {
-        //     auto ev = std::make_unique<TEvDataShard::TEvLocalKMeansRequest>();
-        //     auto snapshotCopy = snapshot;
-        //     snapshotCopy.TxId++;
-        //     DoBadRequest(server, sender, ev);
-        // }
+        // test multiple issues:
+        DoBadRequest(server, sender, [](NKikimrTxDataShard::TEvLocalKMeansRequest& request) {
+            request.SetK(1);
+            request.SetEmbeddingColumn("some");
+        }, "[ { <main>: Error: Should be requested partition on at least two rows } { <main>: Error: Unknown embedding column: some } ]");
     }
 
     Y_UNIT_TEST (MainToPosting) {

--- a/ydb/core/tx/datashard/datashard_ut_local_kmeans.cpp
+++ b/ydb/core/tx/datashard/datashard_ut_local_kmeans.cpp
@@ -16,9 +16,9 @@ using Ydb::Table::VectorIndexSettings;
 using namespace NTableIndex::NTableVectorKmeansTreeIndex;
 
 static std::atomic<ui64> sId = 1;
-static constexpr const char* kMainTable = "/Root/table-main";
-static constexpr const char* kLevelTable = "/Root/table-level";
-static constexpr const char* kPostingTable = "/Root/table-posting";
+static const TString kMainTable = "/Root/table-main";
+static const TString kLevelTable = "/Root/table-level";
+static const TString kPostingTable = "/Root/table-posting";
 
 Y_UNIT_TEST_SUITE(TTxDataShardLocalKMeansScan) {
 
@@ -166,7 +166,7 @@ Y_UNIT_TEST_SUITE(TTxDataShardLocalKMeansScan) {
         return {std::move(level), std::move(posting)};
     }
 
-    static void DropTable(Tests::TServer::TPtr server, TActorId sender, const char* name)
+    static void DropTable(Tests::TServer::TPtr server, TActorId sender, const TString& name)
     {
         ui64 txId = AsyncDropTable(server, sender, "/Root", name);
         WaitTxNotification(server, sender, txId);
@@ -205,8 +205,7 @@ Y_UNIT_TEST_SUITE(TTxDataShardLocalKMeansScan) {
         CreateShardedTable(server, sender, "/Root", "table-posting", options);
     }
 
-    static void CreateBuildTable(Tests::TServer::TPtr server, TActorId sender, TShardedTableOptions options,
-                                 const char* name)
+    static void CreateBuildTable(Tests::TServer::TPtr server, TActorId sender, TShardedTableOptions options, const TString& name)
     {
         options.AllowSystemColumnNames(true);
         options.Columns({

--- a/ydb/core/tx/datashard/kmeans_helper.cpp
+++ b/ydb/core/tx/datashard/kmeans_helper.cpp
@@ -125,9 +125,11 @@ MakeUploadTypes(const TUserTable& table, NKikimrTxDataShard::EKMeansState upload
             for (const auto& column : data) {
                 addType(column);
             }
-        } break;
+            break;
+        }
         default:
-            Y_UNREACHABLE();
+            Y_ASSERT(false);
+
     }
     return uploadTypes;
 }

--- a/ydb/core/tx/datashard/kmeans_helper.h
+++ b/ydb/core/tx/datashard/kmeans_helper.h
@@ -224,11 +224,6 @@ MakeUploadTypes(const TUserTable& table, NKikimrTxDataShard::EKMeansState upload
 
 void MakeScan(auto& record, const auto& createScan, const auto& badRequest)
 {
-    if (!record.HasEmbeddingColumn()) {
-        badRequest("Should be specified embedding column");
-        return;
-    }
-
     const auto& settings = record.GetSettings();
     if (settings.vector_dimension() < 1) {
         badRequest("Dimension of vector should be at least one");

--- a/ydb/core/tx/datashard/local_kmeans.cpp
+++ b/ydb/core/tx/datashard/local_kmeans.cpp
@@ -791,14 +791,14 @@ void TDataShard::HandleSafe(TEvDataShard::TEvLocalKMeansRequest::TPtr& ev, const
         badRequest(TStringBuilder() << "Wrong shard " << request.GetTabletId() << " this is " << TabletID());
     }
     if (!IsStateActive()) {
-        badRequest(TStringBuilder() << "Shard " << TabletID() << " is not ready for requests");
+        badRequest(TStringBuilder() << "Shard " << TabletID() << " is " << State << " and not ready for requests");
     }
     const auto pathId = TPathId::FromProto(request.GetPathId());
     const auto* userTableIt = GetUserTables().FindPtr(pathId.LocalPathId);
     if (!userTableIt) {
         badRequest(TStringBuilder() << "Unknown table id: " << pathId.LocalPathId);
-        auto sent = trySendBadRequest();
-        Y_ENSURE(sent);
+    }
+    if (trySendBadRequest()) {
         return;
     }
     const auto& userTable = **userTableIt;

--- a/ydb/core/tx/datashard/local_kmeans.cpp
+++ b/ydb/core/tx/datashard/local_kmeans.cpp
@@ -845,7 +845,7 @@ void TDataShard::HandleSafe(TEvDataShard::TEvLocalKMeansRequest::TPtr& ev, const
         lead.To(range.From, NTable::ESeek::Upper);
         lead.Until(range.To, true);
     }
-    
+
     if (!request.HasLevelName()) {
         badRequest(TStringBuilder() << "Empty level table name");
     }

--- a/ydb/core/tx/datashard/prefix_kmeans.cpp
+++ b/ydb/core/tx/datashard/prefix_kmeans.cpp
@@ -777,14 +777,14 @@ void TDataShard::HandleSafe(TEvDataShard::TEvPrefixKMeansRequest::TPtr& ev, cons
         badRequest(TStringBuilder() << "Wrong shard " << request.GetTabletId() << " this is " << TabletID());
     }
     if (!IsStateActive()) {
-        badRequest(TStringBuilder() << "Shard " << TabletID() << " is not ready for requests");
+        badRequest(TStringBuilder() << "Shard " << TabletID() << " is " << State << " and not ready for requests");
     }
     const auto pathId = TPathId::FromProto(request.GetPathId());
     const auto* userTableIt = GetUserTables().FindPtr(pathId.LocalPathId);
     if (!userTableIt) {
         badRequest(TStringBuilder() << "Unknown table id: " << pathId.LocalPathId);
-        auto sent = trySendBadRequest();
-        Y_ENSURE(sent);
+    }
+    if (trySendBadRequest()) {
         return;
     }
     const auto& userTable = **userTableIt;

--- a/ydb/core/tx/datashard/reshuffle_kmeans.cpp
+++ b/ydb/core/tx/datashard/reshuffle_kmeans.cpp
@@ -38,6 +38,7 @@ protected:
 
     TLead Lead;
 
+    ui64 TabletId = 0;
     ui64 BuildId = 0;
 
     ui64 ReadRows = 0;
@@ -78,7 +79,7 @@ public:
         return NKikimrServices::TActivity::RESHUFFLE_KMEANS_SCAN_ACTOR;
     }
 
-    TReshuffleKMeansScanBase(const TUserTable& table, TLead&& lead,
+    TReshuffleKMeansScanBase(ui64 tabletId, const TUserTable& table, TLead&& lead,
                              const NKikimrTxDataShard::TEvReshuffleKMeansRequest& request,
                              const TActorId& responseActorId,
                              TAutoPtr<TEvDataShard::TEvReshuffleKMeansResponse>&& response)
@@ -88,6 +89,7 @@ public:
         , K{static_cast<ui32>(request.ClustersSize())}
         , UploadState{request.GetUpload()}
         , Lead{std::move(lead)}
+        , TabletId(tabletId)
         , BuildId{request.GetId()}
         , Clusters{request.GetClusters().begin(), request.GetClusters().end()}
         , TargetTable{request.GetPostingName()}
@@ -156,7 +158,11 @@ public:
         }
         NYql::IssuesToMessage(UploadStatus.Issues, record.MutableIssues());
 
-        LOG_N("Finish " << Debug() << " " << Response->Record.ShortDebugString());
+        if (Response->Record.GetStatus() == NKikimrIndexBuilder::DONE) {
+            LOG_N("Done " << Debug() << " " << Response->Record.ShortDebugString());
+        } else {
+            LOG_E("Failed " << Debug() << " " << Response->Record.ShortDebugString());
+        }
         Send(ResponseActorId, Response.Release());
 
         Driver = nullptr;
@@ -171,7 +177,8 @@ public:
 
     TString Debug() const
     {
-        return TStringBuilder() << "TReshuffleKMeansScan Id: " << BuildId << " Parent: " << Parent << " Child: " << Child
+        return TStringBuilder() << "TReshuffleKMeansScan TabletId: " << TabletId << " Id: " << BuildId
+            << " Parent: " << Parent << " Child: " << Child
             << " Target: " << TargetTable << " K: " << K << " Clusters: " << Clusters.size()
             << " ReadBuf size: " << ReadBuf.Size() << " WriteBuf size: " << WriteBuf.Size();
     }
@@ -276,9 +283,9 @@ protected:
 template <typename TMetric>
 class TReshuffleKMeansScan final: public TReshuffleKMeansScanBase, private TCalculation<TMetric> {
 public:
-    TReshuffleKMeansScan(const TUserTable& table, TLead&& lead, NKikimrTxDataShard::TEvReshuffleKMeansRequest& request,
+    TReshuffleKMeansScan(ui64 tabletId, const TUserTable& table, TLead&& lead, NKikimrTxDataShard::TEvReshuffleKMeansRequest& request,
                          const TActorId& responseActorId, TAutoPtr<TEvDataShard::TEvReshuffleKMeansResponse>&& response)
-        : TReshuffleKMeansScanBase{table, std::move(lead), request, responseActorId, std::move(response)}
+        : TReshuffleKMeansScanBase{tabletId, table, std::move(lead), request, responseActorId, std::move(response)}
     {
         this->Dimensions = request.GetSettings().vector_dimension();
         LOG_I("Create " << Debug());
@@ -390,7 +397,8 @@ void TDataShard::HandleSafe(TEvDataShard::TEvReshuffleKMeansRequest::TPtr& ev, c
     response->Record.SetRequestSeqNoGeneration(seqNo.Generation);
     response->Record.SetRequestSeqNoRound(seqNo.Round);
 
-    LOG_N("Starting TReshuffleKMeansScan " << request.ShortDebugString()
+    LOG_N("Starting TReshuffleKMeansScan TabletId: " << TabletID() 
+        << " " << request.ShortDebugString()
         << " row version " << rowVersion);
 
     // Note: it's very unlikely that we have volatile txs before this snapshot
@@ -407,7 +415,8 @@ void TDataShard::HandleSafe(TEvDataShard::TEvReshuffleKMeansRequest::TPtr& ev, c
     };
     auto trySendBadRequest = [&] {
         if (response->Record.GetStatus() == NKikimrIndexBuilder::EBuildStatus::BAD_REQUEST) {
-            LOG_E("Rejecting TReshuffleKMeansScan bad request " << request.ShortDebugString()
+            LOG_E("Rejecting TReshuffleKMeansScan bad request TabletId: " << TabletID()
+                << " " << request.ShortDebugString()
                 << " with response " << response->Record.ShortDebugString());
             ctx.Send(ev->Sender, std::move(response));
             return true;
@@ -482,7 +491,7 @@ void TDataShard::HandleSafe(TEvDataShard::TEvReshuffleKMeansRequest::TPtr& ev, c
     TAutoPtr<NTable::IScan> scan;
     auto createScan = [&]<typename T> {
         scan = new TReshuffleKMeansScan<T>{
-            userTable, CreateLeadFrom(range), request, ev->Sender, std::move(response),
+            TabletID(), userTable, CreateLeadFrom(range), request, ev->Sender, std::move(response),
         };
     };
     MakeScan(request, createScan, badRequest);

--- a/ydb/core/tx/datashard/sample_k.cpp
+++ b/ydb/core/tx/datashard/sample_k.cpp
@@ -323,6 +323,7 @@ void TDataShard::HandleSafe(TEvDataShard::TEvSampleKRequest::TPtr& ev, const TAc
         return;
     }
 
+    // 3. Creating scan
     TAutoPtr<NTable::IScan> scan = new TSampleKScan(userTable,
         request, ev->Sender, std::move(response),
         requestedRange);

--- a/ydb/core/tx/datashard/sample_k.cpp
+++ b/ydb/core/tx/datashard/sample_k.cpp
@@ -60,26 +60,21 @@ public:
         return NKikimrServices::TActivity::SAMPLE_K_SCAN_ACTOR;
     }
 
-    TSampleKScan(TAutoPtr<TEvDataShard::TEvSampleKResponse>&& response,
-                 const TActorId& responseActorId,
-                 const TSerializedTableRange& range,
-                 ui64 k,
-                 ui64 seed,
-                 ui64 maxProbability,
-                 TProtoColumnsCRef columns,
-                 const TUserTable& tableInfo)
+    TSampleKScan(const TUserTable& table, NKikimrTxDataShard::TEvSampleKRequest& request,
+                 const TActorId& responseActorId, TAutoPtr<TEvDataShard::TEvSampleKResponse>&& response,
+                 const TSerializedTableRange& range)
         : TActor(&TThis::StateWork)
         , Response(std::move(response))
         , ResponseActorId(responseActorId)
-        , ScanTags(BuildTags(tableInfo, columns))
-        , KeyTypes(tableInfo.KeyColumnTypes)
-        , TableRange(tableInfo.Range)
+        , ScanTags(BuildTags(table, request.GetColumns()))
+        , KeyTypes(table.KeyColumnTypes)
+        , TableRange(table.Range)
         , RequestedRange(range)
-        , K(k)
-        , BuildId(Response->Record.GetId())
-        , MaxProbability(maxProbability)
-        , Rng(seed) {
-        Y_ASSERT(MaxProbability != 0);
+        , K(request.GetK())
+        , BuildId(request.GetId())
+        , MaxProbability(request.GetMaxProbability())
+        , Rng(request.GetSeed()) 
+    {
         LOG_I("Create " << Debug());
     }
 
@@ -231,50 +226,106 @@ void TDataShard::Handle(TEvDataShard::TEvSampleKRequest::TPtr& ev, const TActorC
 }
 
 void TDataShard::HandleSafe(TEvDataShard::TEvSampleKRequest::TPtr& ev, const TActorContext& ctx) {
-    const auto& record = ev->Get()->Record;
-    const bool needsSnapshot = record.HasSnapshotStep() || record.HasSnapshotTxId();
-    TRowVersion rowVersion(record.GetSnapshotStep(), record.GetSnapshotTxId());
-    if (!needsSnapshot) {
-        rowVersion = GetMvccTxVersion(EMvccTxMode::ReadOnly);
-    }
-
-    // Note: it's very unlikely that we have volatile txs before this snapshot
-    if (VolatileTxManager.HasVolatileTxsAtSnapshot(rowVersion)) {
-        VolatileTxManager.AttachWaitingSnapshotEvent(rowVersion,
-                                                     std::unique_ptr<IEventHandle>(ev.Release()));
-        return;
-    }
-    const ui64 id = record.GetId();
+    auto& request = ev->Get()->Record;
+    const ui64 id = request.GetId();
+    auto rowVersion = request.HasSnapshotStep() || request.HasSnapshotTxId()
+        ? TRowVersion(request.GetSnapshotStep(), request.GetSnapshotTxId())
+        : GetMvccTxVersion(EMvccTxMode::ReadOnly);
+    TScanRecord::TSeqNo seqNo = {request.GetSeqNoGeneration(), request.GetSeqNoRound()};
 
     auto response = MakeHolder<TEvDataShard::TEvSampleKResponse>();
     response->Record.SetId(id);
     response->Record.SetTabletId(TabletID());
-
-    TScanRecord::TSeqNo seqNo = {record.GetSeqNoGeneration(), record.GetSeqNoRound()};
     response->Record.SetRequestSeqNoGeneration(seqNo.Generation);
     response->Record.SetRequestSeqNoRound(seqNo.Round);
+
+    LOG_N("Starting TSampleKScan " << request.ShortDebugString()
+        << " row version " << rowVersion);
+
+    // Note: it's very unlikely that we have volatile txs before this snapshot
+    if (VolatileTxManager.HasVolatileTxsAtSnapshot(rowVersion)) {
+        VolatileTxManager.AttachWaitingSnapshotEvent(rowVersion, std::unique_ptr<IEventHandle>(ev.Release()));
+        return;
+    }
 
     auto badRequest = [&](const TString& error) {
         response->Record.SetStatus(NKikimrIndexBuilder::EBuildStatus::BAD_REQUEST);
         auto issue = response->Record.AddIssues();
         issue->set_severity(NYql::TSeverityIds::S_ERROR);
         issue->set_message(error);
-        ctx.Send(ev->Sender, std::move(response));
+    };
+    auto trySendBadRequest = [&] {
+        if (response->Record.GetStatus() == NKikimrIndexBuilder::EBuildStatus::BAD_REQUEST) {
+            LOG_E("Rejecting TSampleKScan bad request " << request.ShortDebugString()
+                << " with response " << response->Record.ShortDebugString());
+            ctx.Send(ev->Sender, std::move(response));
+            return true;
+        } else {
+            return false;
+        }
     };
 
-    if (const ui64 shardId = record.GetTabletId(); shardId != TabletID()) {
-        badRequest(TStringBuilder() << "Wrong shard " << shardId << " this is " << TabletID());
-        return;
+    // 1. Validating table and path existence
+    if (request.GetTabletId() != TabletID()) {
+        badRequest(TStringBuilder() << "Wrong shard " << request.GetTabletId() << " this is " << TabletID());
     }
-
-    const auto pathId = TPathId::FromProto(record.GetPathId());
+    if (!IsStateActive()) {
+        badRequest(TStringBuilder() << "Shard " << TabletID() << " is " << State << " and not ready for requests");
+    }
+    const auto pathId = TPathId::FromProto(request.GetPathId());
     const auto* userTableIt = GetUserTables().FindPtr(pathId.LocalPathId);
     if (!userTableIt) {
         badRequest(TStringBuilder() << "Unknown table id: " << pathId.LocalPathId);
+    }
+    if (trySendBadRequest()) {
         return;
     }
-    Y_ENSURE(*userTableIt);
     const auto& userTable = **userTableIt;
+
+    // 2. Validating request fields
+    if (request.HasSnapshotStep() || request.HasSnapshotTxId()) {
+        const TSnapshotKey snapshotKey(pathId, rowVersion.Step, rowVersion.TxId);
+        if (!SnapshotManager.FindAvailable(snapshotKey)) {
+            badRequest(TStringBuilder() << "Unknown snapshot for path id " << pathId.OwnerId << ":" << pathId.LocalPathId
+                << ", snapshot step is " << snapshotKey.Step << ", snapshot tx is " << snapshotKey.TxId);
+        }
+    }
+
+    if (request.GetK() < 1) {
+        badRequest("Should be requested on at least one row");
+    }
+
+    if (request.GetMaxProbability() <= 0) {
+        badRequest("Max probability should be positive");
+    }
+
+    TSerializedTableRange requestedRange;
+    requestedRange.Load(request.GetKeyRange());
+    auto scanRange = Intersect(userTable.KeyColumnTypes, requestedRange.ToTableRange(), userTable.Range.ToTableRange());
+    if (scanRange.IsEmptyRange(userTable.KeyColumnTypes)) {
+        badRequest(TStringBuilder() << " requested range doesn't intersect with table range"
+            << " requestedRange: " << DebugPrintRange(userTable.KeyColumnTypes, requestedRange.ToTableRange(), *AppData()->TypeRegistry)
+            << " tableRange: " << DebugPrintRange(userTable.KeyColumnTypes, userTable.Range.ToTableRange(), *AppData()->TypeRegistry)
+            << " scanRange: " << DebugPrintRange(userTable.KeyColumnTypes, scanRange, *AppData()->TypeRegistry));
+    }
+
+    if (request.ColumnsSize() < 1) {
+        badRequest("Should be requested at least one column");
+    }
+    auto tags = GetAllTags(userTable);
+    for (auto column : request.GetColumns()) {
+        if (!tags.contains(column)) {
+            badRequest(TStringBuilder() << "Unknown column: " << column);
+        }
+    }
+
+    if (trySendBadRequest()) {
+        return;
+    }
+
+    TAutoPtr<NTable::IScan> scan = new TSampleKScan(userTable,
+        request, ev->Sender, std::move(response),
+        requestedRange);
 
     if (const auto* recCard = ScanManager.Get(id)) {
         if (recCard->SeqNo == seqNo) {
@@ -288,61 +339,10 @@ void TDataShard::HandleSafe(TEvDataShard::TEvSampleKRequest::TPtr& ev, const TAc
         ScanManager.Drop(id);
     }
 
-    TSerializedTableRange requestedRange;
-    requestedRange.Load(record.GetKeyRange());
-
-    auto scanRange = Intersect(userTable.KeyColumnTypes, requestedRange.ToTableRange(), userTable.Range.ToTableRange());
-
-    if (scanRange.IsEmptyRange(userTable.KeyColumnTypes)) {
-        badRequest(TStringBuilder() << " requested range doesn't intersect with table range"
-                                    << " requestedRange: " << DebugPrintRange(userTable.KeyColumnTypes, requestedRange.ToTableRange(), *AppData()->TypeRegistry)
-                                    << " tableRange: " << DebugPrintRange(userTable.KeyColumnTypes, userTable.Range.ToTableRange(), *AppData()->TypeRegistry)
-                                    << " scanRange: " << DebugPrintRange(userTable.KeyColumnTypes, scanRange, *AppData()->TypeRegistry));
-        return;
-    }
-
-    const TSnapshotKey snapshotKey(pathId, rowVersion.Step, rowVersion.TxId);
-    if (needsSnapshot && !SnapshotManager.FindAvailable(snapshotKey)) {
-        badRequest(TStringBuilder()
-                   << "no snapshot has been found"
-                   << " , path id is " << pathId.OwnerId << ":" << pathId.LocalPathId
-                   << " , snapshot step is " << snapshotKey.Step
-                   << " , snapshot tx is " << snapshotKey.TxId);
-        return;
-    }
-
-    if (!IsStateActive()) {
-        badRequest(TStringBuilder() << "Shard " << TabletID() << " is not ready for requests");
-        return;
-    }
-
-    if (record.GetK() < 1) {
-        badRequest("Should be requested at least single row");
-        return;
-    }
-
-    if (record.ColumnsSize() < 1) {
-        badRequest("Should be requested at least single column");
-        return;
-    }
-
     TScanOptions scanOpts;
     scanOpts.SetSnapshotRowVersion(rowVersion);
     scanOpts.SetResourceBroker("build_index", 10); // TODO(mbkkt) Should be different group?
-
-    const auto scanId = QueueScan(userTable.LocalTid,
-                                  new TSampleKScan(
-                                      std::move(response),
-                                      ev->Sender,
-                                      requestedRange,
-                                      record.GetK(),
-                                      record.GetSeed(),
-                                      record.GetMaxProbability(),
-                                      record.GetColumns(),
-                                      userTable),
-                                  0,
-                                  scanOpts);
-
+    const auto scanId = QueueScan(userTable.LocalTid, std::move(scan), 0, scanOpts);
     ScanManager.Set(id, seqNo).push_back(scanId);
 }
 


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

...

### Changelog category <!-- remove all except one -->

* Not for changelog (changelog entry is not required)

### Description for reviewers <!-- (optional) description for those who read this PR -->

Fixed issues:
- return all validation errors instead of the first one
    - Instead of meaningless `Error: Unknown table id: 11`
    - We now have `<main>: Error: Shard 72075186224061923 is PreOffline and not ready for requests <main>: Error: Unknown table id: 21`
- do not cancel existing scans if we'd reply with bad request
- log bad request response
- fix tests, previously sometimes didn't check anything
- added missing validations