### PR TITLE
fix detecting finished sources

### DIFF
--- a/ydb/core/kqp/ut/olap/aggregations_ut.cpp
+++ b/ydb/core/kqp/ut/olap/aggregations_ut.cpp
@@ -481,6 +481,22 @@ Y_UNIT_TEST_SUITE(KqpOlapAggregations) {
         TestAggregations({ testCase });
     }
 
+    Y_UNIT_TEST(Aggregation_ResultTL_FilterL_Limit2_Simple) {
+        TAggregationTestCase testCase;
+        testCase
+            .SetQuery(R"(
+                SELECT
+                    timestamp, level
+                FROM `/Root/olapStore/olapTable`
+                WHERE level = 2
+                LIMIT 2
+            )")
+            .AddExpectedPlanOptions("KqpOlapFilter")
+            .MutableLimitChecker()
+            .SetExpectedLimit(2);
+        TestAggregations({ testCase }, TKikimrSettings().SetColumnShardReaderClassName("SIMPLE"));
+    }
+
     Y_UNIT_TEST(Aggregation_ResultTL_FilterL_OrderT_Limit2) {
         TAggregationTestCase testCase;
         testCase.SetQuery(R"(

--- a/ydb/core/kqp/ut/olap/helpers/aggregation.cpp
+++ b/ydb/core/kqp/ut/olap/helpers/aggregation.cpp
@@ -6,9 +6,8 @@
 
 namespace NKikimr::NKqp {
 
-void TestAggregationsBase(const std::vector<TAggregationTestCase>& cases) {
-    auto settings = TKikimrSettings()
-        .SetWithSampleTables(false);
+void TestAggregationsBase(const std::vector<TAggregationTestCase>& cases, const TKikimrSettings& settingsExt) {
+    auto settings = TKikimrSettings(settingsExt).SetWithSampleTables(false);
     TKikimrRunner kikimr(settings);
 
     TLocalHelper(kikimr).CreateTestOlapTable();
@@ -132,8 +131,8 @@ void TestTableWithNulls(const std::vector<TAggregationTestCase>& cases, const bo
     }
 }
 
-void TestAggregations(const std::vector<TAggregationTestCase>& cases) {
-    TestAggregationsBase(cases);
+void TestAggregations(const std::vector<TAggregationTestCase>& cases, const TKikimrSettings& settings) {
+    TestAggregationsBase(cases, settings);
     TestAggregationsInternal(cases);
 }
 

--- a/ydb/core/kqp/ut/olap/helpers/aggregation.h
+++ b/ydb/core/kqp/ut/olap/helpers/aggregation.h
@@ -207,11 +207,11 @@ void CheckPlanForAggregatePushdown(
     }
 }
 
-void TestAggregationsBase(const std::vector<TAggregationTestCase>& cases);
+void TestAggregationsBase(const std::vector<TAggregationTestCase>& cases, const TKikimrSettings& settings = Default<TKikimrSettings>());
 
 void TestAggregationsInternal(const std::vector<TAggregationTestCase>& cases);
 
-void TestAggregations(const std::vector<TAggregationTestCase>& cases);
+void TestAggregations(const std::vector<TAggregationTestCase>& cases, const TKikimrSettings& settings = Default<TKikimrSettings>());
 
 template <typename TClient>
 auto StreamExecuteQuery(const TAggregationTestCase& testCase, TClient& client) {

--- a/ydb/core/tx/columnshard/engines/reader/simple_reader/iterator/source.h
+++ b/ydb/core/tx/columnshard/engines/reader/simple_reader/iterator/source.h
@@ -64,15 +64,12 @@ public:
     std::partial_ordering Compare(const TReplaceKeyAdapter& item) const {
         AFL_VERIFY(Reverse == item.Reverse);
         const std::partial_ordering result = Value.Compare(item.Value);
-        if (result == std::partial_ordering::equivalent) {
-            return std::partial_ordering::equivalent;
-        } else if (result == std::partial_ordering::less) {
+        if (result == std::partial_ordering::less) {
             return Reverse ? std::partial_ordering::greater : std::partial_ordering::less;
         } else if (result == std::partial_ordering::greater) {
             return Reverse ? std::partial_ordering::less : std::partial_ordering::greater;
         } else {
-            AFL_VERIFY(false);
-            return std::partial_ordering::less;
+            return result;
         }
     }
 

--- a/ydb/library/formats/arrow/replace_key.h
+++ b/ydb/library/formats/arrow/replace_key.h
@@ -310,8 +310,8 @@ public:
 
     template <bool NotNull = false>
     std::partial_ordering Compare(const TComparablePosition& pos) const {
-        AFL_VERIFY(pos.Positions.size() == Positions.size());
-        for (ui32 i = 0; i < Positions.size(); ++i) {
+        const ui64 numPositions = Min(pos.Positions.size(), Positions.size());
+        for (ui32 i = 0; i < numPositions; ++i) {
             AFL_VERIFY(Arrays[i]->type()->id() == pos.Arrays[i]->type()->id());
             const std::partial_ordering cmpResult =
                 TComparator::TypedCompare<NotNull>(*Arrays[i], Positions[i], *pos.Arrays[i], pos.Positions[i]);
@@ -319,7 +319,11 @@ public:
                 return cmpResult;
             }
         }
-        return std::partial_ordering::equivalent;
+        if (pos.Positions.size() == Positions.size()) {
+            return std::partial_ordering::equivalent;
+        } else {
+            return std::partial_ordering::unordered;
+        }
     }
 
     template <bool NotNull = false>


### PR DESCRIPTION
Поддержал сравнение TReplaceKeyAdapter с разным количеством полей, чтобы сравнивать границы новых источников с отрезками завершённых источников, для которых не известны точные границы PK.