### PR TITLE
Set BSC LayoutCorrect default true (#16940) - merge stable-25-1

### DIFF
--- a/ydb/core/protos/sys_view.proto
+++ b/ydb/core/protos/sys_view.proto
@@ -265,7 +265,7 @@ message TGroupInfo {
     // desired disk categories ?
     // down/persisted down ?
     // metrics ?
-    optional bool LayoutCorrect = 16; // is the group layout correct?
+    optional bool LayoutCorrect = 16 [default = true];  // is the group layout correct?
 }
 
 message TGroupEntry {


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

merge https://github.com/ydb-platform/ydb/pull/16940
set a default value for `layoutCorrect`

### Changelog category <!-- remove all except one -->

* Bugfix 

### Description for reviewers <!-- (optional) description for those who read this PR -->

The backward incompatibility scenario for HealthCheck (https://github.com/ydb-platform/ydb/pull/15743) was missed where `BSC`  may not set `layoutCorrect` in the response in older YDB versions. In this case, `layoutCorrect` will be read as false by default and healthcheck could report `bad layout` issues.
...