### PR TITLE
Add tests for diff processing in perf

### DIFF
--- a/ydb/tests/functional/tpc/medium/test_clickbench.py
+++ b/ydb/tests/functional/tpc/medium/test_clickbench.py
@@ -1,4 +1,3 @@
-import os
 import ydb.tests.olap.load.lib.clickbench as clickbench
 import yatest.common
 from ydb.tests.functional.tpc.lib.conftest import FunctionalTestBase
@@ -6,11 +5,11 @@ from ydb.tests.functional.tpc.lib.conftest import FunctionalTestBase
 
 class TestClickbench(clickbench.TestClickbench, FunctionalTestBase):
     iterations: int = 1
+    verify_data: bool = False
 
     @classmethod
     def setup_class(cls) -> None:
         cls.setup_cluster()
         cls.run_cli(['workload', 'clickbench', '-p', 'olap_yatests/clickbench/hits', 'init', '--store=column'])
         cls.run_cli(['workload', 'clickbench', '-p', 'olap_yatests/clickbench/hits', 'import', 'files', '--input', yatest.common.source_path("ydb/tests/functional/clickbench/data/hits.csv")])
-        os.environ['NO_VERIFY_DATA_CLICKBENCH'] = '1'
         clickbench.TestClickbench.setup_class()

--- a/ydb/tests/functional/tpc/medium/test_clickbench.py
+++ b/ydb/tests/functional/tpc/medium/test_clickbench.py
@@ -12,4 +12,4 @@ class TestClickbench(clickbench.TestClickbench, FunctionalTestBase):
         cls.setup_cluster()
         cls.run_cli(['workload', 'clickbench', '-p', 'olap_yatests/clickbench/hits', 'init', '--store=column'])
         cls.run_cli(['workload', 'clickbench', '-p', 'olap_yatests/clickbench/hits', 'import', 'files', '--input', yatest.common.source_path("ydb/tests/functional/clickbench/data/hits.csv")])
-        clickbench.TestClickbench.setup_class()
+        super().setup_class()

--- a/ydb/tests/functional/tpc/medium/test_diff_processing.py
+++ b/ydb/tests/functional/tpc/medium/test_diff_processing.py
@@ -1,0 +1,76 @@
+from ydb.tests.olap.load.lib.tpch import TestTpch1 as Tpch1
+from ydb.tests.olap.load.lib.tpcds import TestTpcds1 as Tpcds1
+from ydb.tests.olap.load.lib.clickbench import TestClickbench as Clickbench
+from ydb.tests.functional.tpc.lib.conftest import FunctionalTestBase
+from ydb.tests.olap.lib.ydb_cli import CheckCanonicalPolicy
+import pytest
+
+
+EXPECTED_ERRORS = {
+    CheckCanonicalPolicy.NO: None.__class__,
+    CheckCanonicalPolicy.WARNING: Exception,
+    CheckCanonicalPolicy.ERROR: pytest.fail.Exception,
+}
+
+
+class TestTpchDiffProcessing(Tpch1, FunctionalTestBase):
+    iterations: int = 1
+    verify_data = False
+
+    @pytest.mark.parametrize('policy', EXPECTED_ERRORS.keys())
+    def test_tpch(self, policy):
+        self.check_canonical = policy
+        exc = None
+        try:
+            Tpch1.test_tpch(self, 1)
+        except BaseException as e:
+            exc = e
+        assert exc.__class__ == EXPECTED_ERRORS[policy]
+
+    @classmethod
+    def setup_class(cls) -> None:
+        cls.setup_cluster()
+        cls.run_cli(['workload', 'tpch', '-p', 'olap_yatests/tpch/s1', 'init', '--store=column'])
+        super().setup_class()
+
+
+class TestTpcdsDiffProcessing(Tpcds1, FunctionalTestBase):
+    iterations: int = 1
+    verify_data = False
+
+    @pytest.mark.parametrize('policy', EXPECTED_ERRORS.keys())
+    def test_tpcds(self, policy):
+        self.check_canonical = policy
+        exc = None
+        try:
+            Tpcds1.test_tpcds(self, 1)
+        except BaseException as e:
+            exc = e
+        assert exc.__class__ == EXPECTED_ERRORS[policy]
+
+    @classmethod
+    def setup_class(cls) -> None:
+        cls.setup_cluster()
+        cls.run_cli(['workload', 'tpcds', '-p', 'olap_yatests/tpcds/s1', 'init', '--store=column'])
+        super().setup_class()
+
+
+class TestClickbenchDiffProcessing(Clickbench, FunctionalTestBase):
+    iterations: int = 1
+    verify_data = False
+
+    @pytest.mark.parametrize('policy', EXPECTED_ERRORS.keys())
+    def test_clickbench(self, policy):
+        self.check_canonical = policy
+        exc = None
+        try:
+            Clickbench.test_clickbench(self, 1)
+        except BaseException as e:
+            exc = e
+        assert exc.__class__ == EXPECTED_ERRORS[policy]
+
+    @classmethod
+    def setup_class(cls) -> None:
+        cls.setup_cluster()
+        cls.run_cli(['workload', 'clickbench', '-p', 'olap_yatests/clickbench/hits', 'init', '--store=column'])
+        super().setup_class()

--- a/ydb/tests/functional/tpc/medium/ya.make
+++ b/ydb/tests/functional/tpc/medium/ya.make
@@ -3,6 +3,7 @@ ENV(YDB_HARD_MEMORY_LIMIT_BYTES="107374182400")
 
 TEST_SRCS(
     test_clickbench.py
+    test_diff_processing.py
     test_tpch.py
 )
 

--- a/ydb/tests/olap/load/lib/clickbench.py
+++ b/ydb/tests/olap/load/lib/clickbench.py
@@ -14,7 +14,7 @@ class TestClickbench(LoadSuiteBase):
 
     @classmethod
     def do_setup_class(cls):
-        if getenv('NO_VERIFY_DATA', '0') == '1' or getenv('NO_VERIFY_DATA_CLICKBENCH', '0') == '1':
+        if not cls.verify_data or getenv('NO_VERIFY_DATA', '0') == '1' or getenv('NO_VERIFY_DATA_CLICKBENCH', '0') == '1':
             return
 
         cls.check_tables_size(folder=None, tables={'clickbench/hits': 99997497})

--- a/ydb/tests/olap/load/lib/conftest.py
+++ b/ydb/tests/olap/load/lib/conftest.py
@@ -36,6 +36,7 @@ class LoadSuiteBase:
     query_settings: dict[int, LoadSuiteBase.QuerySettings] = {}
     scale: Optional[int] = None
     query_prefix: str = get_external_param('query-prefix', '')
+    verify_data: bool = True
 
     @classmethod
     def suite(cls) -> str:

--- a/ydb/tests/olap/load/lib/tpcds.py
+++ b/ydb/tests/olap/load/lib/tpcds.py
@@ -11,7 +11,7 @@ class TpcdsSuiteBase(LoadSuiteBase):
     workload_type: WorkloadType = WorkloadType.TPC_DS
     iterations: int = 3
     tables_size: dict[str, int] = {}
-    check_canonical: bool = CheckCanonicalPolicy.ERROR
+    check_canonical: CheckCanonicalPolicy = CheckCanonicalPolicy.ERROR
 
     @classmethod
     def _get_tables_size(cls) -> dict[str, int]:
@@ -36,7 +36,7 @@ class TpcdsSuiteBase(LoadSuiteBase):
 
     @classmethod
     def do_setup_class(cls):
-        if getenv('NO_VERIFY_DATA', '0') == '1' or getenv('NO_VERIFY_DATA_TPCH', '0') == '1' or getenv(f'NO_VERIFY_DATA_TPCH_{cls.scale}'):
+        if not cls.verify_data or getenv('NO_VERIFY_DATA', '0') == '1' or getenv('NO_VERIFY_DATA_TPCH', '0') == '1' or getenv(f'NO_VERIFY_DATA_TPCH_{cls.scale}'):
             return
         cls.check_tables_size(folder=cls._get_path(False), tables=cls._get_tables_size())
 

--- a/ydb/tests/olap/load/lib/tpch.py
+++ b/ydb/tests/olap/load/lib/tpch.py
@@ -12,7 +12,7 @@ class TpchSuiteBase(LoadSuiteBase):
     iterations: int = 3
     tables_size: dict[str, int] = {}
     skip_tests: list = []
-    check_canonical: bool = CheckCanonicalPolicy.ERROR
+    check_canonical: CheckCanonicalPolicy = CheckCanonicalPolicy.ERROR
 
     @classmethod
     def _get_tables_size(cls) -> dict[str, int]:
@@ -38,7 +38,7 @@ class TpchSuiteBase(LoadSuiteBase):
 
     @classmethod
     def do_setup_class(cls):
-        if getenv('NO_VERIFY_DATA', '0') == '1' or getenv('NO_VERIFY_DATA_TPCH', '0') == '1' or getenv(f'NO_VERIFY_DATA_TPCH_{cls.scale}'):
+        if not cls.verify_data or getenv('NO_VERIFY_DATA', '0') == '1' or getenv('NO_VERIFY_DATA_TPCH', '0') == '1' or getenv(f'NO_VERIFY_DATA_TPCH_{cls.scale}'):
             return
         cls.check_tables_size(folder=cls._get_path(False), tables=cls._get_tables_size())
 


### PR DESCRIPTION
https://github.com/ydb-platform/ydb/issues/16258

В перфоманс-тестировании у нас есть случай, когда запросы проходят, но их результаты отличаются от тех, которые мы ожидаем, такое событие называется дифф. На этот случай предусмотрены различные политики поведения тестов:
  * `CheckCanonicalPolicy.NO` - не проверять
  * `CheckCanonicalPolicy.WARNING` - воспринимать как замечание
  * `CheckCanonicalPolicy.ERROR` - воспринимать как ошибку

В зависимости от выбранной политики (для сьюта или отдельного запроса) при диффе бросается то или иное исключение, или не бросается вовсе, в зависимости от этого в отчете кейс красится определенным цветом.

В данном PR тесты на то, что логика работы с диффами соответствует ожиданиям. Мы создаем таблицы для бенчмарков, но не заполняем их данными, соответственно ответы получаются отличные от ожидаемых. Проверяем какие исключения выбрасываются в зависимости от политики.