### PR TITLE
Don't detect deadlock with finished stages for false positive reasons

### DIFF
--- a/ydb/core/kqp/executer_actor/kqp_executer_stats.cpp
+++ b/ydb/core/kqp/executer_actor/kqp_executer_stats.cpp
@@ -609,7 +609,7 @@ bool TStageExecutionStats::IsDeadlocked(ui64 deadline) {
     }
 
     for (auto stat : InputStages) {
-        if (stat->CurrentWaitOutputTimeUs.MinValue < deadline && !stat->IsFinished()) {
+        if (stat->CurrentWaitOutputTimeUs.MinValue < deadline || stat->IsFinished()) {
             return false;
         }
     }


### PR DESCRIPTION
#17040 

Exclude Finished stages from deadlock detection. Currently they may trigger false positive checks (stats update races)

More reliable detection will be added after #17131