### PR TITLE
Fix a subtle memory leak in SendImmediateWriteResult

### DIFF
--- a/ydb/core/tx/datashard/datashard.cpp
+++ b/ydb/core/tx/datashard/datashard.cpp
@@ -2522,10 +2522,11 @@ ui64 TDataShard::GetMaxObservedStep() const {
 }
 
 void TDataShard::SendImmediateWriteResult(
-        const TRowVersion& version, const TActorId& target, IEventBase* event, ui64 cookie,
+        const TRowVersion& version, const TActorId& target, IEventBase* eventRawPtr, ui64 cookie,
         const TActorId& sessionId,
         NWilson::TTraceId traceId)
 {
+    THolder<IEventBase> event(eventRawPtr);
     NWilson::TSpan span(TWilsonTablet::TabletDetailed, std::move(traceId), "Datashard.SendImmediateWriteResult", NWilson::EFlags::AUTO_END);
 
     const ui64 step = version.Step;
@@ -2537,9 +2538,9 @@ void TDataShard::SendImmediateWriteResult(
         if (Y_LIKELY(!InMemoryVarsFrozen) || version <= SnapshotManager.GetImmediateWriteEdgeReplied()) {
             SnapshotManager.PromoteImmediateWriteEdgeReplied(version);
             if (!sessionId) {
-                Send(target, event, 0, cookie, span.GetTraceId());
+                Send(target, event.Release(), 0, cookie, span.GetTraceId());
             } else {
-                SendViaSession(sessionId, target, SelfId(), event, 0, cookie, span.GetTraceId());
+                SendViaSession(sessionId, target, SelfId(), event.Release(), 0, cookie, span.GetTraceId());
             }
         } else {
             span.EndError("Dropped");
@@ -2550,7 +2551,7 @@ void TDataShard::SendImmediateWriteResult(
     MediatorDelayedReplies.emplace(
         std::piecewise_construct,
         std::forward_as_tuple(version),
-        std::forward_as_tuple(target, THolder<IEventBase>(event), cookie, sessionId, std::move(span)));
+        std::forward_as_tuple(target, std::move(event), cookie, sessionId, std::move(span)));
 
     // Try to subscribe to the next step, when needed
     if (MediatorTimeCastEntry && (MediatorTimeCastWaitingSteps.empty() || step < *MediatorTimeCastWaitingSteps.begin())) {


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

...

### Changelog category <!-- remove all except one -->

* Not for changelog (changelog entry is not required)

### Description for reviewers <!-- (optional) description for those who read this PR -->

There was a subtle edge case in SendImmediateWriteResult where we drop the result. Turned out this case was actually leaking the event.

Fixes #16657.