### PR TITLE
pq rd: fix use-after-free (with logbroker federation) (alternative)

### DIFF
--- a/ydb/library/yql/providers/pq/async_io/dq_pq_rd_read_actor.cpp
+++ b/ydb/library/yql/providers/pq/async_io/dq_pq_rd_read_actor.cpp
@@ -380,12 +380,12 @@ public:
         hFunc(TEvPrivate::TEvDescribeTopicResult, Handle);
     })
 
-    STRICT_STFUNC(IgnoreFunc, {
+    STRICT_STFUNC(IgnoreState, {
         // ignore all events except for retry queue
-        cFunc(NFq::TEvRowDispatcher::TEvCoordinatorChanged, Ignore);
+        sFunc(NFq::TEvRowDispatcher::TEvCoordinatorChanged, Ignore);
         hFunc(NFq::TEvRowDispatcher::TEvCoordinatorResult, ReplyNoSession);
         hFunc(NFq::TEvRowDispatcher::TEvNewDataArrived, ReplyNoSession);
-        hFunc(NFq::TEvRowDispatcher::TEvMessageBatch, ReplyNoSessionn);
+        hFunc(NFq::TEvRowDispatcher::TEvMessageBatch, ReplyNoSession);
         hFunc(NFq::TEvRowDispatcher::TEvStartSessionAck, ReplyNoSession);
         hFunc(NFq::TEvRowDispatcher::TEvSessionError, ReplyNoSession);
         hFunc(NFq::TEvRowDispatcher::TEvStatistics, ReplyNoSession);
@@ -400,19 +400,19 @@ public:
 
         // ignore all row dispatcher events
         hFunc(NFq::TEvRowDispatcher::TEvHeartbeat, ReplyNoSession);
-        cFunc(TEvPrivate::TEvPrintState, Ignore);
-        cFunc(TEvPrivate::TEvProcessState, Ignore);
-        cFunc(TEvPrivate::TEvNotifyCA, Ignore);
-        cFunc(TEvPrivate::TEvRefreshClusters, Ignore);
-        cFunc(TEvPrivate::TEvReceivedClusters, Ignore);
-        cFunc(TEvPrivate::TEvDescribeTopicResult, Ignore);
+        sFunc(TEvPrivate::TEvPrintState, Ignore);
+        sFunc(TEvPrivate::TEvProcessState, Ignore);
+        sFunc(TEvPrivate::TEvNotifyCA, Ignore);
+        sFunc(TEvPrivate::TEvRefreshClusters, Ignore);
+        sFunc(TEvPrivate::TEvReceivedClusters, Ignore);
+        sFunc(TEvPrivate::TEvDescribeTopicResult, Ignore);
     })
 
     void Ignore() {
     }
 
-    template <class TEvent>
-    void ReplyNoSession(TEvent::TPtr& ev) {
+    template <class TEventPtr>
+    void ReplyNoSession(TEventPtr& ev) {
         SendNoSession(ev->Sender, ev->Cookie);
     }
 
@@ -700,7 +700,7 @@ void TDqPqRdReadActor::StopSession(TSession& sessionInfo) {
 // IActor & IDqComputeActorAsyncInput
 void TDqPqRdReadActor::PassAway() { // Is called from Compute Actor
     SRC_LOG_I("PassAway");
-    Become(&TDqPqRdReadActor::IgnoreFunc);
+    Become(&TDqPqRdReadActor::IgnoreState);
     PrintInternalState();
     for (auto& [rowDispatcherActorId, sessionInfo] : Sessions) {
         StopSession(sessionInfo);

--- a/ydb/library/yql/providers/pq/async_io/dq_pq_rd_read_actor.cpp
+++ b/ydb/library/yql/providers/pq/async_io/dq_pq_rd_read_actor.cpp
@@ -382,7 +382,7 @@ public:
 
     STRICT_STFUNC(IgnoreState, {
         // ignore all events except for retry queue
-        sFunc(NFq::TEvRowDispatcher::TEvCoordinatorChanged, Ignore);
+        hFunc(NFq::TEvRowDispatcher::TEvCoordinatorChanged, IgnoreEvent);
         hFunc(NFq::TEvRowDispatcher::TEvCoordinatorResult, ReplyNoSession);
         hFunc(NFq::TEvRowDispatcher::TEvNewDataArrived, ReplyNoSession);
         hFunc(NFq::TEvRowDispatcher::TEvMessageBatch, ReplyNoSession);
@@ -400,19 +400,22 @@ public:
 
         // ignore all row dispatcher events
         hFunc(NFq::TEvRowDispatcher::TEvHeartbeat, ReplyNoSession);
-        sFunc(TEvPrivate::TEvPrintState, Ignore);
-        sFunc(TEvPrivate::TEvProcessState, Ignore);
-        sFunc(TEvPrivate::TEvNotifyCA, Ignore);
-        sFunc(TEvPrivate::TEvRefreshClusters, Ignore);
-        sFunc(TEvPrivate::TEvReceivedClusters, Ignore);
-        sFunc(TEvPrivate::TEvDescribeTopicResult, Ignore);
+        hFunc(TEvPrivate::TEvPrintState, IgnoreEvent);
+        hFunc(TEvPrivate::TEvProcessState, IgnoreEvent);
+        hFunc(TEvPrivate::TEvNotifyCA, IgnoreEvent);
+        hFunc(TEvPrivate::TEvRefreshClusters, IgnoreEvent);
+        hFunc(TEvPrivate::TEvReceivedClusters, IgnoreEvent);
+        hFunc(TEvPrivate::TEvDescribeTopicResult, IgnoreEvent);
     })
 
-    void Ignore() {
+    template <class TEventPtr>
+    void IgnoreEvent(TEventPtr& ev) {
+        SRC_LOG_D("Ignore " << typeid(TEventPtr).name() << " from " << ev->Sender);
     }
 
     template <class TEventPtr>
     void ReplyNoSession(TEventPtr& ev) {
+        SRC_LOG_D("Ignore (no session) " << typeid(TEventPtr).name() << " from " << ev->Sender);
         SendNoSession(ev->Sender, ev->Cookie);
     }
 

--- a/ydb/library/yql/providers/pq/async_io/dq_pq_rd_read_actor.cpp
+++ b/ydb/library/yql/providers/pq/async_io/dq_pq_rd_read_actor.cpp
@@ -213,7 +213,6 @@ private:
     // As main and child actors resides on same mailbox, their handlers are never concurrently executed
     // and can modify other side state
     TDqPqRdReadActor* Parent;
-    std::shared_ptr<bool> Alive;
     TString Cluster;
     const TString Token;
     TMaybe<NActors::TActorId> CoordinatorActorId;
@@ -379,9 +378,38 @@ public:
         hFunc(TEvPrivate::TEvRefreshClusters, Handle);
         hFunc(TEvPrivate::TEvReceivedClusters, Handle);
         hFunc(TEvPrivate::TEvDescribeTopicResult, Handle);
-
-        cFunc(TEvents::TEvPoisonPill::EventType, PassAway);
     })
+
+    STRICT_STFUNC(IgnoreFunc, {
+        // ignore all events except for retry queue
+        cFunc(NFq::TEvRowDispatcher::TEvCoordinatorChanged, Ignore);
+        cFunc(NFq::TEvRowDispatcher::TEvCoordinatorResult, Ignore);
+        cFunc(NFq::TEvRowDispatcher::TEvNewDataArrived, Ignore);
+        cFunc(NFq::TEvRowDispatcher::TEvMessageBatch, Ignore);
+        cFunc(NFq::TEvRowDispatcher::TEvStartSessionAck, Ignore);
+        cFunc(NFq::TEvRowDispatcher::TEvSessionError, Ignore);
+        cFunc(NFq::TEvRowDispatcher::TEvStatistics, Ignore);
+        cFunc(NFq::TEvRowDispatcher::TEvGetInternalStateRequest, Ignore);
+
+        hFunc(NActors::TEvents::TEvPong, Handle);
+        hFunc(TEvInterconnect::TEvNodeConnected, HandleConnected);
+        hFunc(TEvInterconnect::TEvNodeDisconnected, HandleDisconnected);
+        hFunc(NActors::TEvents::TEvUndelivered, Handle);
+        hFunc(NYql::NDq::TEvRetryQueuePrivate::TEvRetry, Handle);
+        hFunc(NYql::NDq::TEvRetryQueuePrivate::TEvEvHeartbeat, Handle);
+
+        // ignore all row dispatcher events
+        cFunc(NFq::TEvRowDispatcher::TEvHeartbeat, Ignore);
+        cFunc(TEvPrivate::TEvPrintState, Ignore);
+        cFunc(TEvPrivate::TEvProcessState, Ignore);
+        cFunc(TEvPrivate::TEvNotifyCA, Ignore);
+        cFunc(TEvPrivate::TEvRefreshClusters, Ignore);
+        cFunc(TEvPrivate::TEvReceivedClusters, Ignore);
+        cFunc(TEvPrivate::TEvDescribeTopicResult, Ignore);
+    })
+
+    void Ignore() {
+    }
 
     static constexpr char ActorName[] = "DQ_PQ_READ_ACTOR";
 
@@ -491,11 +519,9 @@ TDqPqRdReadActor::TDqPqRdReadActor(
     SRC_LOG_I("Start read actor, local row dispatcher " << LocalRowDispatcherActorId.ToString() << ", metadatafields: " << JoinSeq(',', SourceParams.GetMetadataFields())
         << ", partitions: " << JoinSeq(',', GetPartitionsToRead()));
     if (Parent != this) {
-        Alive = Parent->Alive;
         return;
     }
     State = EState::START_CLUSTER_DISCOVERY;
-    Alive = std::make_shared<bool>(true);
     const auto programBuilder = std::make_unique<TProgramBuilder>(typeEnv, *holderFactory.GetFunctionRegistry());
 
     // Parse output schema (expected struct output type)
@@ -669,16 +695,17 @@ void TDqPqRdReadActor::StopSession(TSession& sessionInfo) {
 // IActor & IDqComputeActorAsyncInput
 void TDqPqRdReadActor::PassAway() { // Is called from Compute Actor
     SRC_LOG_I("PassAway");
+    Become(&TDqPqRdReadActor::IgnoreFunc);
     PrintInternalState();
     for (auto& [rowDispatcherActorId, sessionInfo] : Sessions) {
         StopSession(sessionInfo);
     }
-    *Alive = false;
     for (auto& clusterState : Clusters) {
-        if (clusterState.Child == this) {
+        auto child = clusterState.Child;
+        if (child == this) {
             continue;
         }
-        Send(clusterState.ChildId, new NActors::TEvents::TEvPoison);
+        child->PassAway();
     }
     Clusters.clear();
     FederatedTopicClient.Reset();
@@ -747,9 +774,6 @@ std::vector<ui64> TDqPqRdReadActor::GetPartitionsToRead() const {
 }
 
 void TDqPqRdReadActor::Handle(NFq::TEvRowDispatcher::TEvStartSessionAck::TPtr& ev) {
-    if (!*Alive) {
-        return;
-    }
     const NYql::NDqProto::TMessageTransportMeta& meta = ev->Get()->Record.GetTransportMeta();
     SRC_LOG_I("Received TEvStartSessionAck from " << ev->Sender << ", seqNo " << meta.GetSeqNo() << ", ConfirmedSeqNo " << meta.GetConfirmedSeqNo() <<  ", generation " << ev->Cookie);
     Counters.StartSessionAck++;
@@ -762,9 +786,6 @@ void TDqPqRdReadActor::Handle(NFq::TEvRowDispatcher::TEvStartSessionAck::TPtr& e
 }
 
 void TDqPqRdReadActor::Handle(NFq::TEvRowDispatcher::TEvSessionError::TPtr& ev) {
-    if (!*Alive) {
-        return;
-    }
     const NYql::NDqProto::TMessageTransportMeta& meta = ev->Get()->Record.GetTransportMeta();
     SRC_LOG_I("Received TEvSessionError from " << ev->Sender << ", seqNo " << meta.GetSeqNo() << ", ConfirmedSeqNo " << meta.GetConfirmedSeqNo());
     Counters.SessionError++;
@@ -779,9 +800,6 @@ void TDqPqRdReadActor::Handle(NFq::TEvRowDispatcher::TEvSessionError::TPtr& ev) 
 }
 
 void TDqPqRdReadActor::Handle(NFq::TEvRowDispatcher::TEvStatistics::TPtr& ev) {
-    if (!*Alive) {
-        return;
-    }
     const NYql::NDqProto::TMessageTransportMeta& meta = ev->Get()->Record.GetTransportMeta();
     SRC_LOG_T("Received TEvStatistics from " << ev->Sender << ", seqNo " << meta.GetSeqNo() << ", ConfirmedSeqNo " << meta.GetConfirmedSeqNo() << " generation " << ev->Cookie);
     Counters.Statistics++;
@@ -816,18 +834,12 @@ void TDqPqRdReadActor::Handle(NFq::TEvRowDispatcher::TEvStatistics::TPtr& ev) {
 }
 
 void TDqPqRdReadActor::Handle(NFq::TEvRowDispatcher::TEvGetInternalStateRequest::TPtr& ev) {
-    if (!*Alive) {
-        return;
-    }
     auto response = std::make_unique<NFq::TEvRowDispatcher::TEvGetInternalStateResponse>();
     response->Record.SetInternalState(GetInternalState());
     Send(ev->Sender, response.release(), 0, ev->Cookie);
 }
 
 void TDqPqRdReadActor::Handle(NFq::TEvRowDispatcher::TEvNewDataArrived::TPtr& ev) {
-    if (!*Alive) {
-        return;
-    }
     auto partitionId = ev->Get()->Record.GetPartitionId();
     const NYql::NDqProto::TMessageTransportMeta& meta = ev->Get()->Record.GetTransportMeta();
     SRC_LOG_T("Received TEvNewDataArrived from " << ev->Sender << ", partition " << partitionId << ", seqNo " << meta.GetSeqNo() << ", ConfirmedSeqNo " << meta.GetConfirmedSeqNo() << " generation " << ev->Cookie);
@@ -848,9 +860,6 @@ void TDqPqRdReadActor::Handle(NFq::TEvRowDispatcher::TEvNewDataArrived::TPtr& ev
 }
 
 void TDqPqRdReadActor::Handle(const NYql::NDq::TEvRetryQueuePrivate::TEvRetry::TPtr& ev) {
-    if (!*Alive) {
-        return;
-    }
     SRC_LOG_T("Received TEvRetry, EventQueueId " << ev->Get()->EventQueueId);
     Counters.Retry++;
 
@@ -869,9 +878,6 @@ void TDqPqRdReadActor::Handle(const NYql::NDq::TEvRetryQueuePrivate::TEvRetry::T
 }
 
 void TDqPqRdReadActor::Handle(const NYql::NDq::TEvRetryQueuePrivate::TEvEvHeartbeat::TPtr& ev) {
-    if (!*Alive) {
-        return;
-    }
     SRC_LOG_T("TEvRetryQueuePrivate::TEvEvHeartbeat");
     Counters.PrivateHeartbeat++;
     auto readActorIt = ReadActorByEventQueueId.find(ev->Get()->EventQueueId);
@@ -894,18 +900,12 @@ void TDqPqRdReadActor::Handle(const NYql::NDq::TEvRetryQueuePrivate::TEvEvHeartb
 }
 
 void TDqPqRdReadActor::Handle(const NFq::TEvRowDispatcher::TEvHeartbeat::TPtr& ev) {
-    if (!*Alive) {
-        return;
-    }
     SRC_LOG_T("Received TEvHeartbeat from " << ev->Sender << ", generation " << ev->Cookie);
     Counters.Heartbeat++;
     FindAndUpdateSession(ev);
 }
 
 void TDqPqRdReadActor::Handle(NFq::TEvRowDispatcher::TEvCoordinatorChanged::TPtr& ev) {
-    if (!*Alive) {
-        return;
-    }
     SRC_LOG_D("TEvCoordinatorChanged, new coordinator " << ev->Get()->CoordinatorActorId);
     Counters.CoordinatorChanged++;
 
@@ -934,9 +934,6 @@ void TDqPqRdReadActor::ScheduleProcessState() {
 }
 
 void TDqPqRdReadActor::ReInit(const TString& reason) {
-    if (!*Alive) {
-        return;
-    }
     SRC_LOG_I("ReInit state, reason " << reason);
     Parent->Metrics.ReInit->Inc();
 
@@ -952,9 +949,6 @@ void TDqPqRdReadActor::Stop(NDqProto::StatusIds::StatusCode status, TIssues issu
 }
 
 void TDqPqRdReadActor::Handle(NFq::TEvRowDispatcher::TEvCoordinatorResult::TPtr& ev) {
-    if (!*Alive) {
-        return;
-    }
     SRC_LOG_I("Received TEvCoordinatorResult from " << ev->Sender.ToString() << ", cookie " << ev->Cookie);
     Counters.CoordinatorResult++;
     if (ev->Cookie != CoordinatorRequestCookie) {
@@ -974,9 +968,6 @@ void TDqPqRdReadActor::Handle(NFq::TEvRowDispatcher::TEvCoordinatorResult::TPtr&
 }
 
 void TDqPqRdReadActor::HandleConnected(TEvInterconnect::TEvNodeConnected::TPtr& ev) {
-    if (!*Alive) {
-        return;
-    }
     SRC_LOG_D("EvNodeConnected " << ev->Get()->NodeId);
     Counters.NodeConnected++;
     for (auto& [rowDispatcherActorId, sessionInfo] : Sessions) {
@@ -985,9 +976,6 @@ void TDqPqRdReadActor::HandleConnected(TEvInterconnect::TEvNodeConnected::TPtr& 
 }
 
 void TDqPqRdReadActor::HandleDisconnected(TEvInterconnect::TEvNodeDisconnected::TPtr& ev) {
-    if (!*Alive) {
-        return;
-    }
     SRC_LOG_D("TEvNodeDisconnected, node id " << ev->Get()->NodeId);
     Counters.NodeDisconnected++;
     for (auto& [rowDispatcherActorId, sessionInfo] : Sessions) {
@@ -999,9 +987,6 @@ void TDqPqRdReadActor::HandleDisconnected(TEvInterconnect::TEvNodeDisconnected::
 }
 
 void TDqPqRdReadActor::Handle(NActors::TEvents::TEvUndelivered::TPtr& ev) {
-    if (!*Alive) {
-        return;
-    }
     SRC_LOG_D("Received TEvUndelivered, " << ev->Get()->ToString() << " from " << ev->Sender.ToString() << ", reason " << ev->Get()->Reason << ", cookie " << ev->Cookie);
     Counters.Undelivered++;
     
@@ -1027,9 +1012,6 @@ void TDqPqRdReadActor::Handle(NActors::TEvents::TEvUndelivered::TPtr& ev) {
 }
 
 void TDqPqRdReadActor::Handle(NFq::TEvRowDispatcher::TEvMessageBatch::TPtr& ev) {
-    if (!*Alive) {
-        return;
-    }
     const NYql::NDqProto::TMessageTransportMeta& meta = ev->Get()->Record.GetTransportMeta();
     SRC_LOG_T("Received TEvMessageBatch from " << ev->Sender << ", seqNo " << meta.GetSeqNo() << ", ConfirmedSeqNo " << meta.GetConfirmedSeqNo() << " generation " << ev->Cookie);
     Counters.MessageBatch++;
@@ -1106,9 +1088,6 @@ void TDqPqRdReadActor::Handle(NActors::TEvents::TEvPong::TPtr& ev) {
 }
 
 void TDqPqRdReadActor::Handle(TEvPrivate::TEvPrintState::TPtr&) {
-    if (!*Alive) {
-        return;
-    }
     Counters.PrintState++;
     Schedule(TDuration::Seconds(PrintStatePeriodSec), new TEvPrivate::TEvPrintState());
     PrintInternalState();
@@ -1125,23 +1104,20 @@ void TDqPqRdReadActor::PrintInternalState() {
 TString TDqPqRdReadActor::GetInternalState() {
     TStringStream str;
     str << LogPrefix << "State:";
-    if (*Alive) {
-        str << " used buffer size " << Parent->ReadyBufferSizeBytes << " ready buffer event size " << Parent->ReadyBuffer.size()
-            << " InFlyAsyncInputData " << Parent->InFlyAsyncInputData;
-    }
-    str << " state " << static_cast<ui64>(State) << "\n";
-    str << "Counters: CoordinatorChanged " << Counters.CoordinatorChanged << " CoordinatorResult " << Counters.CoordinatorResult
+    str << " used buffer size " << Parent->ReadyBufferSizeBytes << " ready buffer event size " << Parent->ReadyBuffer.size()
+        << " state " << static_cast<ui64>(State)
+        << " InFlyAsyncInputData " << Parent->InFlyAsyncInputData
+        << "\n";
+    str << "Counters:"
+        << " CoordinatorChanged " << Counters.CoordinatorChanged << " CoordinatorResult " << Counters.CoordinatorResult
         << " MessageBatch " << Counters.MessageBatch << " StartSessionAck " << Counters.StartSessionAck << " NewDataArrived " << Counters.NewDataArrived
         << " SessionError " << Counters.SessionError << " Statistics " << Counters.Statistics << " NodeDisconnected " << Counters.NodeDisconnected
         << " NodeConnected " << Counters.NodeConnected << " Undelivered " << Counters.Undelivered << " Retry " << Counters.Retry
         << " PrivateHeartbeat " << Counters.PrivateHeartbeat << " SessionClosed " << Counters.SessionClosed << " Pong " << Counters.Pong
         << " Heartbeat " << Counters.Heartbeat << " PrintState " << Counters.PrintState << " ProcessState " << Counters.ProcessState
-        ;
-    if (*Alive) {
-        str << " GetAsyncInputData " << Counters.GetAsyncInputData
-            << " NotifyCA " << Parent->Counters.NotifyCA;
-    }
-    str << "\n";
+        << " GetAsyncInputData " << Counters.GetAsyncInputData
+        << " NotifyCA " << Parent->Counters.NotifyCA
+        << "\n";
     
     for (auto& [rowDispatcherActorId, sessionInfo] : Sessions) {
         str << " " << rowDispatcherActorId << " status " << static_cast<ui64>(sessionInfo.Status)
@@ -1165,9 +1141,6 @@ TString TDqPqRdReadActor::GetInternalState() {
 }
 
 void TDqPqRdReadActor::Handle(TEvPrivate::TEvProcessState::TPtr&) {
-    if (!*Alive) {
-        return;
-    }
     ProcessStateScheduled = false;
     Counters.ProcessState++;
     ProcessState();

--- a/ydb/library/yql/providers/pq/async_io/dq_pq_rd_read_actor.cpp
+++ b/ydb/library/yql/providers/pq/async_io/dq_pq_rd_read_actor.cpp
@@ -383,13 +383,13 @@ public:
     STRICT_STFUNC(IgnoreFunc, {
         // ignore all events except for retry queue
         cFunc(NFq::TEvRowDispatcher::TEvCoordinatorChanged, Ignore);
-        cFunc(NFq::TEvRowDispatcher::TEvCoordinatorResult, Ignore);
-        cFunc(NFq::TEvRowDispatcher::TEvNewDataArrived, Ignore);
-        cFunc(NFq::TEvRowDispatcher::TEvMessageBatch, Ignore);
-        cFunc(NFq::TEvRowDispatcher::TEvStartSessionAck, Ignore);
-        cFunc(NFq::TEvRowDispatcher::TEvSessionError, Ignore);
-        cFunc(NFq::TEvRowDispatcher::TEvStatistics, Ignore);
-        cFunc(NFq::TEvRowDispatcher::TEvGetInternalStateRequest, Ignore);
+        hFunc(NFq::TEvRowDispatcher::TEvCoordinatorResult, ReplyNoSession);
+        hFunc(NFq::TEvRowDispatcher::TEvNewDataArrived, ReplyNoSession);
+        hFunc(NFq::TEvRowDispatcher::TEvMessageBatch, ReplyNoSessionn);
+        hFunc(NFq::TEvRowDispatcher::TEvStartSessionAck, ReplyNoSession);
+        hFunc(NFq::TEvRowDispatcher::TEvSessionError, ReplyNoSession);
+        hFunc(NFq::TEvRowDispatcher::TEvStatistics, ReplyNoSession);
+        hFunc(NFq::TEvRowDispatcher::TEvGetInternalStateRequest, ReplyNoSession);
 
         hFunc(NActors::TEvents::TEvPong, Handle);
         hFunc(TEvInterconnect::TEvNodeConnected, HandleConnected);
@@ -399,7 +399,7 @@ public:
         hFunc(NYql::NDq::TEvRetryQueuePrivate::TEvEvHeartbeat, Handle);
 
         // ignore all row dispatcher events
-        cFunc(NFq::TEvRowDispatcher::TEvHeartbeat, Ignore);
+        hFunc(NFq::TEvRowDispatcher::TEvHeartbeat, ReplyNoSession);
         cFunc(TEvPrivate::TEvPrintState, Ignore);
         cFunc(TEvPrivate::TEvProcessState, Ignore);
         cFunc(TEvPrivate::TEvNotifyCA, Ignore);
@@ -409,6 +409,11 @@ public:
     })
 
     void Ignore() {
+    }
+
+    template <class TEvent>
+    void ReplyNoSession(TEvent::TPtr& ev) {
+        SendNoSession(ev->Sender, ev->Cookie);
     }
 
     static constexpr char ActorName[] = "DQ_PQ_READ_ACTOR";

--- a/ydb/library/yql/providers/pq/async_io/dq_pq_rd_read_actor.cpp
+++ b/ydb/library/yql/providers/pq/async_io/dq_pq_rd_read_actor.cpp
@@ -1120,7 +1120,7 @@ TString TDqPqRdReadActor::GetInternalState() {
         << " NodeConnected " << Counters.NodeConnected << " Undelivered " << Counters.Undelivered << " Retry " << Counters.Retry
         << " PrivateHeartbeat " << Counters.PrivateHeartbeat << " SessionClosed " << Counters.SessionClosed << " Pong " << Counters.Pong
         << " Heartbeat " << Counters.Heartbeat << " PrintState " << Counters.PrintState << " ProcessState " << Counters.ProcessState
-        << " GetAsyncInputData " << Counters.GetAsyncInputData
+        << " GetAsyncInputData " << Parent->Counters.GetAsyncInputData
         << " NotifyCA " << Parent->Counters.NotifyCA
         << "\n";
     


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

...

### Changelog category <!-- remove all except one -->

* Not for changelog (changelog entry is not required)

### Description for reviewers <!-- (optional) description for those who read this PR -->

Alternative to #17133: instead of checking in each function just switch state function after PassAway in main actor
