### PR TITLE
overide message if zone down

### DIFF
--- a/ydb/core/health_check/health_check.cpp
+++ b/ydb/core/health_check/health_check.cpp
@@ -635,6 +635,11 @@ public:
         }
     }
 
+    struct TStorageUnitStats {
+        ui32 BadStatus = 0;
+        ui32 Disks = 0;
+    };
+
     TString FilterDatabase;
     THashMap<TSubDomainKey, TString> FilterDomainKey;
     TVector<TActorId> PipeClients;
@@ -661,6 +666,8 @@ public:
     std::optional<TRequestResponse<TEvNodeWardenStorageConfig>> NodeWardenStorageConfig;
     std::optional<TRequestResponse<TEvStateStorage::TEvBoardInfo>> DatabaseBoardInfo;
     THashSet<TNodeId> UnknownStaticGroups;
+    THashMap<TString, TStorageUnitStats> DataCenterStats;
+    THashMap<TString, TStorageUnitStats> RackStats;
 
     const NKikimrConfig::THealthCheckConfig& HealthCheckConfig;
 
@@ -1712,6 +1719,47 @@ public:
         }
     }
 
+    TString GetDataCenterId(TNodeId nodeId) {
+        auto it = MergedNodeInfo.find(nodeId);
+        if (it != MergedNodeInfo.end()) {
+            return it->second->Location.GetDataCenterId();
+        }
+        return {};
+    }
+
+    TString GetRackId(TNodeId nodeId) {
+        auto it = MergedNodeInfo.find(nodeId);
+        if (it != MergedNodeInfo.end()) {
+            if (it->second->Location.GetDataCenterId() && it->second->Location.GetRackId()) {
+                return it->second->Location.GetRackId() + " [" + it->second->Location.GetDataCenterId() + "]";
+            }
+        }
+        return {};
+    }
+
+    void AggregateStorageUnitStats() {
+        for (const auto& it : PDisksMap) {
+            auto nodeId = it.second->GetKey().GetNodeId();
+            auto dataCenter = GetDataCenterId(nodeId);
+            auto rack = GetRackId(nodeId);
+
+            if (dataCenter && rack) {
+                rack = dataCenter + "/" + rack;
+                DataCenterStats[dataCenter].Disks++;
+                RackStats[rack].Disks++;
+
+                const auto& statusString = it.second->GetInfo().GetStatusV2();
+                const auto *descriptor = NKikimrBlobStorage::EDriveStatus_descriptor();
+                auto status = descriptor->FindValueByName(statusString);
+
+                if (status->number() != NKikimrBlobStorage::ACTIVE) {
+                    DataCenterStats[dataCenter].BadStatus++;
+                    RackStats[rack].BadStatus++;
+                }
+            }
+        }
+    }
+
     void AggregateBSControllerState() {
         if (!HaveAllBSControllerInfo()) {
             return;
@@ -1740,6 +1788,7 @@ public:
         for (const auto& pDisk : PDisks->Get()->Record.GetEntries()) {
             auto pDiskId = GetPDiskId(pDisk.GetKey());
             PDisksMap.emplace(pDiskId, &pDisk);
+
         }
     }
 
@@ -2128,6 +2177,27 @@ public:
         return TStringBuilder() << pDiskKey.GetNodeId() << "-" << pDiskKey.GetPDiskId();
     }
 
+    TString OverrideMessageIfZoneDown(const TNodeId nodeId, const TString& defaultMessage) {
+        auto dataCenter = GetDataCenterId(nodeId);
+        auto rack = GetRackId(nodeId);
+
+        if (dataCenter && rack) {
+            auto itDataCenter = DataCenterStats.find(dataCenter);
+            if (itDataCenter != DataCenterStats.end() && itDataCenter->second.Disks > 0
+                && itDataCenter->second.BadStatus > itDataCenter->second.Disks * 95 / 100) {
+                return TStringBuilder() << "95% of Zone " << dataCenter << " is unavailable";
+            }
+
+            rack = dataCenter + "/" + rack;
+            auto itRack = RackStats.find(rack);
+            if (itRack != RackStats.end() && itRack->second.Disks > 0
+                && itRack->second.BadStatus > itRack->second.Disks * 95 / 100) {
+                return TStringBuilder() << "95% of Rack " << rack << " is unavailable";
+            }
+        }
+        return defaultMessage;
+    }
+
     void FillPDiskStatus(const TString& pDiskId, Ydb::Monitoring::StoragePDiskStatus& storagePDiskStatus, TSelfCheckContext context) {
         context.Location.clear_database(); // PDisks are shared between databases
         context.Location.mutable_storage()->mutable_pool()->clear_name(); // PDisks are shared between pools
@@ -2153,7 +2223,7 @@ public:
         auto status = descriptor->FindValueByName(statusString);
         if (!status) {
             context.ReportStatus(Ydb::Monitoring::StatusFlag::RED,
-                                 TStringBuilder() << "Unknown PDisk state: " << statusString,
+                                 OverrideMessageIfZoneDown(itPDisk->second->GetKey().GetNodeId(), TStringBuilder() << "Unknown PDisk state: " << statusString),
                                  ETags::PDiskState);
         }
         switch (status->number()) {
@@ -2164,14 +2234,14 @@ public:
             }
             case NKikimrBlobStorage::FAULTY: {
                 context.ReportStatus(Ydb::Monitoring::StatusFlag::YELLOW,
-                                     TStringBuilder() << "PDisk state is " << statusString,
+                                     OverrideMessageIfZoneDown(itPDisk->second->GetKey().GetNodeId(), TStringBuilder() << "PDisk state is " << statusString),
                                      ETags::PDiskState);
                 break;
             }
             case NKikimrBlobStorage::BROKEN:
             case NKikimrBlobStorage::TO_BE_REMOVED: {
                 context.ReportStatus(Ydb::Monitoring::StatusFlag::RED,
-                                     TStringBuilder() << "PDisk state is " << statusString,
+                                     OverrideMessageIfZoneDown(itPDisk->second->GetKey().GetNodeId(), TStringBuilder() << "PDisk state is " << statusString),
                                      ETags::PDiskState);
                 break;
             }
@@ -2270,7 +2340,7 @@ public:
 
         if (status->number() == NKikimrBlobStorage::ERROR) {
             // the disk is not operational at all
-            context.ReportStatus(Ydb::Monitoring::StatusFlag::RED, TStringBuilder() << "VDisk is not available", ETags::VDiskState,{ETags::PDiskState});
+            context.ReportStatus(Ydb::Monitoring::StatusFlag::RED, OverrideMessageIfZoneDown(nodeId, TStringBuilder() << "VDisk is not available"), ETags::VDiskState,{ETags::PDiskState});
             storageVDiskStatus.set_overall(context.GetOverallStatus());
             return;
         }
@@ -2279,7 +2349,7 @@ public:
             // throttling is active
             auto message = TStringBuilder() << "VDisk is being throttled, rate "
                 << vSlotInfo.GetThrottlingRate() << " per mille";
-            context.ReportStatus(Ydb::Monitoring::StatusFlag::ORANGE, message, ETags::VDiskState);
+            context.ReportStatus(Ydb::Monitoring::StatusFlag::ORANGE, OverrideMessageIfZoneDown(nodeId, message), ETags::VDiskState);
             storageVDiskStatus.set_overall(context.GetOverallStatus());
             return;
         }
@@ -3193,6 +3263,7 @@ public:
         AggregateHiveInfo();
         AggregateHiveNodeStats();
         AggregateStoragePools();
+        AggregateStorageUnitStats();
 
         for (auto& [requestId, request] : TabletRequests.RequestsInFlight) {
             auto tabletId = request.TabletId;

--- a/ydb/core/health_check/health_check_ut.cpp
+++ b/ydb/core/health_check/health_check_ut.cpp
@@ -727,13 +727,14 @@ Y_UNIT_TEST_SUITE(THealthCheckTest) {
         CheckHcResultHasIssuesWithStatus(result, "PDISK", Ydb::Monitoring::StatusFlag::YELLOW, 3, "");
     }
 
-    Y_UNIT_TEST(OnlyDiskIssueOnFaultyPDisks) {
+    Y_UNIT_TEST(OnlyZoneIssueOnFaultyPDisks) {
         auto result = RequestHcWithVdisks(NKikimrBlobStorage::TGroupStatus::PARTIAL, TVDisks{3, {NKikimrBlobStorage::READY, NKikimrBlobStorage::FAULTY}});
         Cerr << result.ShortDebugString() << Endl;
         CheckHcResultHasIssuesWithStatus(result, "STORAGE_GROUP", Ydb::Monitoring::StatusFlag::YELLOW, 0);
         CheckHcResultHasIssuesWithStatus(result, "STORAGE_GROUP", Ydb::Monitoring::StatusFlag::ORANGE, 0);
         CheckHcResultHasIssuesWithStatus(result, "STORAGE_GROUP", Ydb::Monitoring::StatusFlag::RED, 0);
-        CheckHcResultHasIssuesWithStatus(result, "PDISK", Ydb::Monitoring::StatusFlag::YELLOW, 3, "");
+        CheckHcResultHasIssuesWithStatus(result, "ZONE", Ydb::Monitoring::StatusFlag::RED, 1, "");
+        CheckHcResultHasIssuesWithStatus(result, "PDISK", Ydb::Monitoring::StatusFlag::RED, 0, "");
     }
 
     /* HC currently infers group status on its own, so it's never unknown


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

Specify zone or rack in HealthCheck VDisk PDisk issues if they are unavailable

### Changelog category <!-- remove all except one -->

* Improvement

### Description for reviewers <!-- (optional) description for those who read this PR -->
CMS sets status to INACTIVE or FAULTY if a rack or data center goes down.
