### PR TITLE
Less verbose dq log

### DIFF
--- a/ydb/library/yql/providers/dq/actors/task_controller_impl.h
+++ b/ydb/library/yql/providers/dq/actors/task_controller_impl.h
@@ -273,7 +273,7 @@ private:
         for (const auto& [k, v] : stat.Get()) {
             labels.clear();
             if (auto group = GroupForExport(stat, k, taskId, name, labels)) {
-                auto taskLevelCounter = labels.size() == 1 && labels.contains("Stage") && labels["Stage"] == "Total"; 
+                auto taskLevelCounter = labels.size() == 1 && labels.contains("Stage") && labels["Stage"] == "Total";
                 *group->GetCounter(name) = v.Sum;
                 if (ServiceCounters.PublicCounters && taskId == 0 && IsAggregatedStage(labels)) {
                     TString publicCounterName;
@@ -516,7 +516,7 @@ public:
         }
 
         for (const auto& [taskId, stageId] : Stages) {
-            TaskStat.SetCounter(TaskStat.GetCounterName("TaskRunner", 
+            TaskStat.SetCounter(TaskStat.GetCounterName("TaskRunner",
                 {{"Task", ToString(taskId)}, {"Stage", ToString(stageId)}}, "CpuTimeUs"), 0);
         }
 
@@ -564,7 +564,7 @@ private:
                 }
             }
 
-            YQL_CLOG(DEBUG, ProviderDq) << task.GetId() << " " << ev->Record.ShortDebugString();
+            YQL_CLOG(TRACE, ProviderDq) << task.GetId() << " " << ev->Record.ShortDebugString();
 
             Send(actorId, ev.Release());
         }


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

Prints too verbose log like this:
```
Update channels
2025-04-09 14:32:13.027 DEBUG dq(pid=319189, tid=0x00007F98173FF700) [DQ] task_controller_impl.h:567: {67f684b44f7f84252e1b3948} 1 Update { Id: 1 TransportVersion: DATA_TRANSPORT_OOB_FAST_PICKLE_1_0 SrcTaskId: 1 DstTaskId: 31 SrcEndpoint { ActorId { RawX1: 7491321066037786084 RawX2: 15655155817137 } } DstEndpoint { ActorId { RawX1: 7491321064325305450 RawX2: 15642270903108 } } CheckpointingMode: CHECKPOINTING_MODE_DISABLED SrcStageId: 16 DstStageId: 14 } Update { Id: 2 TransportVersion: DATA_TRANSPORT_OOB_FAST_PICKLE_1_0 SrcTaskId: 1 DstTaskId: 32 SrcEndpoint { ActorId { RawX1: 7491321066037786084 RawX2: 15655155817137 } } DstEndpoint { ActorId { RawX1: 7491321065892780160 RawX2: 15144054698795 } } CheckpointingMode: CHECKPOINTING_MODE_DISABLED SrcStageId: 16 DstStageId: 14 } Update { Id: 3 TransportVersion: DATA_TRANSPORT_OOB_FAST_PICKLE_1_0 SrcTaskId: 1 DstTaskId: 33 SrcEndpoint { ActorId { RawX1: 7491321066037786084 RawX2: 15655155817137 } } DstEndpoint { ActorId { RawX1: 7491321066827694911 RawX2: 15234249018388 } } CheckpointingMode: CHECKPOINTING_MODE_DISABLED SrcStageId: 16 DstStageId: 14 } Update { Id: 4 TransportVersion: DATA_TRANSPORT_OOB_FAST_PICKLE_1_0 SrcTaskId: 1 DstTaskId: 34 SrcEndpoint { ActorId { RawX1: 7491321066037786084 RawX2: 15655155817137 } } DstEndpoint { ActorId { RawX1: 7491321064325305453 RawX2: 15642270903105 } } CheckpointingMode: CHECKPOINTING_MODE_DISABLED SrcStageId: 16 DstStageId: 14 } Update { Id: 5 TransportVersion: DATA_TRANSPORT_OOB_FAST_PICKLE_1_0 SrcTaskId: 1 DstTaskId: 35 SrcEndpoint { ActorId { RawX1: 7491321066037786084 RawX2: 15655155817137 } } DstEndpoint { ActorId { RawX1: 7491321063492209929 RawX2: 15496242014863 } } CheckpointingMode: CHECKPOINTING_MODE_DISABLED SrcStageId: 16 DstStageId: 14 } Update { Id: 6 TransportVersion: DATA_TRANSPORT_OOB_FAST_PICKLE_1_0 SrcTaskId: 1 DstTaskId: 36 SrcEndpoint { ActorId { RawX1: 7491321066037786084 RawX2: 15655155817137 } } DstEndpoint { ActorId { RawX1: 7491321063757632490 RawX2: 15479062146277 } } CheckpointingMode: CHECKPOINTING_MODE_DISABLED SrcStageId: 16 DstStageId: 14 } Update { Id: 7 TransportVersion: DATA_TRANSPORT_OOB_FAST_PICKLE_1_0 SrcTaskId: 1 DstTaskId: 37 SrcEndpoint { ActorId { RawX1: 7491321066037786084 RawX2: 15655155817137 } } DstEndpoint { ActorId { RawX1: 7491321065892780165 RawX2: 15144054698850 } } CheckpointingMode: CHECKPOINTING_MODE_DISABLED SrcStageId: 16 DstStageId: 14 } Update { Id: 8 TransportVersion: DATA_TRANSPORT_OOB_FAST_PICKLE_1_0 SrcTaskId: 1 DstTaskId: 38 SrcEndpoint { ActorId { RawX1: 7491321066037786084 RawX2: 15655155817137 } } DstEndpoint { ActorId { RawX1: 7491321066827694915 RawX2: 15234249018390 } } CheckpointingMode: CHECKPOINTING_MODE_DISABLED SrcStageId: 16 DstStageId: 14 } Update { Id: 9 TransportVersion: DATA_TRANSPORT_OOB_FAST_PICKLE_1_0 SrcTaskId: 1 DstTaskId: 39 SrcEndpoint { ActorId { RawX1: 7491321066037786084 RawX2: 15655155817137 } } DstEndpoint { ActorId { RawX1: 7491321063492209932 RawX2: 15496242014864 } } CheckpointingMode: CHECKPOINTING_MODE_DISABLED SrcStageId: 16 DstStageId: 14 } Update { Id: 10 TransportVersion: DATA_TRANSPORT_OOB_FAST_PICKLE_1_0 SrcTaskId: 1 DstTaskId: 40 SrcEndpoint { ActorId { RawX1: 7491321066037786084 RawX2: 15655155817137 } } DstEndpoint { ActorId { RawX1: 7491321064325305456 RawX2: 15642270903100 } } CheckpointingMode: CHECKPOINTING_MODE_DISABLED SrcStageId: 16 DstStageId: 14 } Update { Id: 11 TransportVersion: DATA_TRANSPORT_OOB_FAST_PICKLE_1_0 SrcTaskId: 1 DstTaskId: 41 SrcEndpoint { ActorId { RawX1: 7491321066037786084 RawX2: 15655155817137 } } DstEndpoint { ActorId { RawX1: 7491321066090243711 RawX2: 15698105478310 } } CheckpointingMode: CHECKPOINTING_MODE_DISABLED SrcStageId: 16 DstStageId: 14 } Update { Id: 12 TransportVersion: DATA_TRANSPORT_OOB_FAST_PICKLE_1_0 SrcTaskId: 1 DstTaskId: 42 SrcEndpoint { ActorId { RawX1: 7491321066037786084 RawX2: 15655155817137 } } DstEndpoint { ActorId { RawX1: 7491321063757632493 RawX2: 15479062146278 } } CheckpointingMode: CHECKPOINTING_MODE_DISABLED SrcStageId: 16 DstStageId: 14 } Update { Id: 13 TransportVersion: DATA_TRANSPORT_OOB_FAST_PICKLE_1_0 SrcTaskId: 1 DstTaskId: 43 SrcEndpoint { ActorId { RawX1: 7491321066037786084 RawX2: 15655155817137 } } DstEndpoint { ActorId { RawX1: 7491321064325305458 RawX2: 15642270903077 } } CheckpointingMode: CHECKPOINTING_MODE_DISABLED SrcStageId: 16 DstStageId: 14 } Update { Id: 14 TransportVersion: DATA_TRANSPORT_OOB_FAST_PICKLE_1_0 SrcTaskId: 1 DstTaskId: 44 SrcEndpoint { ActorId { RawX1: 7491321066037786084 RawX2: 15655155817137 } } DstEndpoint { ActorId { RawX1: 7491321064750461867 RawX2: 15225659075386 } } CheckpointingMode: CHECKPOINTING_MODE_DISABLED SrcStageId: 16 DstStageId: 14 } Update { Id: 15 TransportVersion: DATA_TRANSPORT_OOB_FAST_PICKLE_1_0 SrcTaskId: 1 DstTaskId: 45 SrcEndpoint { ActorId { RawX1: 7491321066037786084 RawX2: 15655155817137 } } DstEndpoint { ActorId { RawX1: 7491321066090243713 RawX2: 15698105478311 } } CheckpointingMode: CHECKPOINTING_MODE_DISABLED SrcStageId: 16 DstStageId: 14 } Update { Id: 16 TransportVersion: DATA_TRANSPORT_OOB_FAST_PICKLE_1_0 SrcTaskId: 1 DstTaskId: 46 SrcEndpoint { ActorId { RawX1: 7491321066037786084 RawX2: 15655155817137 } } DstEndpoint { ActorId { RawX1: 7491321064325305459 RawX2: 15642270903102 } } CheckpointingMode: CHECKPOINTING_MODE_DISABLED SrcStageId: 16 DstStageId: 14 } Update { Id: 17 TransportVersion: DATA_TRANSPORT_OOB_FAST_PICKLE_1_0 SrcTaskId: 1 DstTaskId: 47 SrcEndpoint { ActorId { RawX1: 7491321066037786084 RawX2: 15655155817137 } } DstEndpoint { ActorId { RawX1: 7491321066090243716 RawX2: 15698105478312 } } CheckpointingMode: CHECKPOINTING_MODE_DISABLED SrcStageId: 16 DstStageId: 14 } Update { Id: 18 TransportVersion: DATA_TRANSPORT_OOB_FAST_PICKLE_1_0 SrcTaskId: 1 DstTaskId: 48 SrcEndpoint { ActorId { RawX1: 7491321066037786084 RawX2: 15655155817137 } } DstEndpoint { ActorId { RawX1: 7491321064763386628 RawX2: 15406047701722 } } CheckpointingMode: CHECKPOINTING_MODE_DISABLED SrcStageId: 16 DstStageId: 14 } Update { Id: 19 TransportVersion: DATA_TRANSPORT_OOB_FAST_PICKLE_1_0 SrcTaskId: 1 DstTaskId: 49 SrcEndpoint { ActorId { RawX1: 7491321066037786084 RawX2: 15655155817137 } } DstEndpoint { ActorId { RawX1: 7491321063757632495 RawX2: 15479062146279 } } CheckpointingMode: CHECKPOINTING_MODE_DISABLED SrcStageId: 16 DstStageId: 14 } Update { Id: 20 TransportVersion: DATA_TRANSPORT_OOB_FAST_PICKLE_1_0 SrcTaskId: 1 DstTaskId: 50 SrcEndpoint { ActorId { RawX1: 7491321066037786084 RawX2: 15655155817137 } } DstEndpoint { ActorId { RawX1: 7491321064325305460 RawX2: 15642270903098 } } CheckpointingMode: CHECKPOINTING_MODE_DISABLED SrcStageId: 16 DstStageId: 14 } Update { Id: 21 TransportVersion: DATA_TRANSPORT_OOB_FAST_PICKLE_1_0 SrcTaskId: 1 DstTaskId: 51 SrcEndpoint { ActorId { RawX1: 7491321066037786084 RawX2: 15655155817137 } } DstEndpoint { ActorId { RawX1: 7491321064750461870 RawX2: 15225659075387 } } CheckpointingMode: CHECKPOINTING_MODE_DISABLED SrcStageId: 16 DstStageId: 14 } Update { Id: 22 TransportVersion: DATA_TRANSPORT_OOB_FAST_PICKLE_1_0 SrcTaskId: 1 DstTaskId: 52 SrcEndpoint { ActorId { RawX1: 7491321066037786084 RawX2: 15655155817137 } } DstEndpoint { ActorId { RawX1: 7491321066090243720 RawX2: 15698105478313 } } CheckpointingMode: CHECKPOINTING_MODE_DISABLED SrcStageId: 16 DstStageId: 14 } Update { Id: 23 TransportVersion: DATA_TRANSPORT_OOB_FAST_PICKLE_1_0 SrcTaskId: 1 DstTaskId: 53 SrcEndpoint { ActorId { RawX1: 7491321066037786084 RawX2: 15655155817137 } } DstEndpoint { ActorId { RawX1: 7491321064763386630 RawX2: 15406047701723 } } CheckpointingMode: CHECKPOINTING_MODE_DISABLED SrcStageId: 16 DstStageId: 14 } Update { Id: 24 TransportVersion: DATA_TRANSPORT_OOB_FAST_PICKLE_1_0 SrcTaskId: 1 DstTaskId: 54 SrcEndpoint { ActorId { RawX1: 7491321066037786084 RawX2: 15655155817137 } } DstEndpoint { ActorId { RawX1: 7491321063757632499 RawX2: 15479062146280 } } CheckpointingMode: CHECKPOINTING_MODE_DISABLED SrcStageId: 16 DstStageId: 14 }
```

### Changelog category <!-- remove all except one -->

* Not for changelog (changelog entry is not required)

### Description for reviewers <!-- (optional) description for those who read this PR -->

...
