### PR TITLE
support async replication scheme object in recursive remove YDB CLI tool

### DIFF
--- a/ydb/public/lib/ydb_cli/common/recursive_remove.cpp
+++ b/ydb/public/lib/ydb_cli/common/recursive_remove.cpp
@@ -75,6 +75,10 @@ TStatus RemoveCoordinationNode(NCoordination::TClient& client, const TString& pa
     });
 }
 
+TStatus RemoveReplication(NQuery::TQueryClient& client, const TString& path, const TRemoveDirectorySettings& settings) {
+    return DropSchemeObject("ASYNC REPLICATION", client, path, settings);
+}
+
 NYdb::NIssue::TIssues MakeIssues(const TString& error) {
     NYdb::NIssue::TIssues issues;
     issues.AddIssue(NYdb::NIssue::TIssue(error));
@@ -161,6 +165,8 @@ TStatus Remove(
     case ESchemeEntryType::SubDomain:
         // continue silently
         return TStatus(EStatus::SUCCESS, {});
+    case ESchemeEntryType::Replication:
+        return Remove(&RemoveReplication, schemeClient, queryClient, type, path, prompt, settings);
 
     default:
         return TStatus(EStatus::UNSUPPORTED, MakeIssues(TStringBuilder()


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

### Changelog category <!-- remove all except one -->

* Not for changelog (changelog entry is not required)

### Description for reviewers <!-- (optional) description for those who read this PR -->

Issues:
- https://github.com/ydb-platform/ydb/issues/17279

This is just a minor improvement, I don't want to write separate tests for it (recursive remove does have a small test suite, but it is not comprehensive). The tests would be added in scope of the other ticket:
- https://github.com/ydb-platform/ydb/issues/15410

Overwrite option for `ydb tools dump` will call the same function that the recursive remove calls. The tests that will cover the `--overwrite` option would also cover the recursive remove of async replication.
