### PR TITLE
Copy table should not check feature flags for columns types

### DIFF
--- a/ydb/core/tx/schemeshard/schemeshard__operation_copy_table.cpp
+++ b/ydb/core/tx/schemeshard/schemeshard__operation_copy_table.cpp
@@ -578,10 +578,12 @@ public:
 
         const NScheme::TTypeRegistry* typeRegistry = AppData()->TypeRegistry;
         const TSchemeLimits& limits = domainInfo->GetSchemeLimits();
+        // Copy table should not check feature flags for columns types.
+        // If the types in original table are created then they should be allowed in destination table.
         const TTableInfo::TCreateAlterDataFeatureFlags featureFlags = {
-            .EnableTablePgTypes = AppData()->FeatureFlags.GetEnableTablePgTypes(),
-            .EnableTableDatetime64 = AppData()->FeatureFlags.GetEnableTableDatetime64(),
-            .EnableParameterizedDecimal = AppData()->FeatureFlags.GetEnableParameterizedDecimal(),        
+            .EnableTablePgTypes = true,
+            .EnableTableDatetime64 = true,
+            .EnableParameterizedDecimal = true,
             };
         TTableInfo::TAlterDataPtr alterData = TTableInfo::CreateAlterData(nullptr, schema, *typeRegistry,
             limits, *domainInfo, featureFlags, errStr, LocalSequences);


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

Copy table should not check feature flags for columns types. If the types in original table are created then they should be allowed in destination table.

### Changelog category <!-- remove all except one -->

* Bugfix 

### Description for reviewers <!-- (optional) description for those who read this PR -->

...
