### PR TITLE
Use other env variables for internal breakpad and switch it on in ydbd (#17282)

### DIFF
--- a/ydb/apps/ydbd/ya.make
+++ b/ydb/apps/ydbd/ya.make
@@ -69,7 +69,7 @@ PEERDIR(
     yql/essentials/udfs/common/url_base
     yql/essentials/udfs/common/yson2
     yql/essentials/udfs/logs/dsv
-#    ydb/library/breakpad 
+    ydb/library/breakpad 
     ydb/public/sdk/cpp/client/ydb_persqueue_public/codecs
 )
 

--- a/ydb/library/breakpad/minidumps.cpp
+++ b/ydb/library/breakpad/minidumps.cpp
@@ -7,7 +7,7 @@
 class TMinidumper {
 public:
     TMinidumper() {
-        if(const char* path = getenv("BREAKPAD_MINIDUMPS_PATH")) {
+        if(const char* path = getenv("INTERNAL_BREAKPAD_MINIDUMPS_PATH")) {
             using namespace google_breakpad;
             Handler = MakeHolder<ExceptionHandler>(MinidumpDescriptor(path), nullptr, DumpCallback, nullptr, true, -1, true);
         }
@@ -15,7 +15,7 @@ public:
 
 private:
     static bool DumpCallback(const google_breakpad::MinidumpDescriptor& descriptor, void* /*context*/, bool succeeded) {
-        if (char* script = getenv("BREAKPAD_MINIDUMPS_SCRIPT")) {
+        if (char* script = getenv("INTERNAL_BREAKPAD_MINIDUMPS_SCRIPT")) {
             if (auto pid = fork()) {
                 waitpid(pid, 0, 0);
             } else {

--- a/ydb/tests/functional/minidumps/test_break.py
+++ b/ydb/tests/functional/minidumps/test_break.py
@@ -6,7 +6,7 @@ from ydb.tests.library.harness.kikimr_runner import KiKiMR
 def test_create_minidump():
     dump_path = os.path.join(yatest.common.tempfile.gettempdir(), 'dumps1')
     os.makedirs(dump_path, exist_ok=True)
-    os.environ['BREAKPAD_MINIDUMPS_PATH'] = dump_path
+    os.environ['INTERNAL_BREAKPAD_MINIDUMPS_PATH'] = dump_path
     cluster = KiKiMR()
     cluster.start()
     for node in cluster.nodes.values():
@@ -31,8 +31,8 @@ def test_minidump_script():
             'echo $SUCCESS >${PATH}.success\n'
         )
     os.chmod(script_path, 0o777)
-    os.environ['BREAKPAD_MINIDUMPS_SCRIPT'] = script_path
-    os.environ['BREAKPAD_MINIDUMPS_PATH'] = dump_path
+    os.environ['INTERNAL_BREAKPAD_MINIDUMPS_SCRIPT'] = script_path
+    os.environ['INTERNAL_BREAKPAD_MINIDUMPS_PATH'] = dump_path
     cluster = KiKiMR()
     cluster.start()
     for node in cluster.nodes.values():

--- a/ydb/tests/functional/minidumps/ya.make
+++ b/ydb/tests/functional/minidumps/ya.make
@@ -3,7 +3,7 @@ IF (OS_LINUX AND NOT SANITIZER_TYPE)
 PY3TEST()
 
 TEST_SRCS(
-#    test_break.py
+    test_break.py
 )
 
 SIZE(MEDIUM)


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

Cherry-pick https://github.com/ydb-platform/ydb/commit/68489d0839fb4e98a7d573508c0bdee7d1dc066c

### Changelog category <!-- remove all except one -->

* New feature

### Description for reviewers <!-- (optional) description for those who read this PR -->

...
