### PR TITLE
add overwrite option to ydb tools restore

### DIFF
--- a/ydb/apps/ydb/CHANGELOG.md
+++ b/ydb/apps/ydb/CHANGELOG.md
@@ -1,3 +1,4 @@
+* Added `--overwrite` option to `ydb tools restore`. When enabled, existing database objects that match those in the backup are removed before restoration.
 * Added "--no-discovery" option. It allows to skip discovery and use user provided endpoint to connect to YDB cluster.
 * Added `--retries` to `ydb workload <clickbenh|tpch|tpcds> run` command.
 * Added `--partition-size` param to `ydb workload <clickbench/tpcds/tpch> init`.

--- a/ydb/public/lib/ydb_cli/commands/ydb_tools.cpp
+++ b/ydb/public/lib/ydb_cli/commands/ydb_tools.cpp
@@ -211,6 +211,15 @@ void TCommandRestore::Config(TConfig& config) {
             " with secondary indexes, make sure it's not already present in the scheme.")
         .StoreTrue(&UseImportData);
 
+    config.Opts->AddLongOption("overwrite", "Remove existing objects from the database that match those in the backup before restoration."
+        " Objects present in the backup but missing in the database are restored as usual; removal is skipped."
+        " If both --overwrite and --verify-existence are specified, restoration stops with an error when the first such object is found.")
+        .StoreTrue(&Overwrite);
+
+    config.Opts->AddLongOption("verify-existence", "Use with --overwrite to report an error if an object in the backup is missing from the database"
+        " instead of silently skipping its removal.")
+        .StoreTrue(&VerifyExistence);
+
     config.Opts->MutuallyExclusive("bandwidth", "rps");
     config.Opts->MutuallyExclusive("import-data", "bulk-upsert");
     config.Opts->MutuallyExclusive("import-data", "upload-batch-rows");
@@ -230,7 +239,9 @@ int TCommandRestore::Run(TConfig& config) {
         .RestoreACL(RestoreACL)
         .SkipDocumentTables(SkipDocumentTables)
         .SavePartialResult(SavePartialResult)
-        .RowsPerRequest(NYdb::SizeFromString(RowsPerRequest));
+        .RowsPerRequest(NYdb::SizeFromString(RowsPerRequest))
+        .Overwrite(Overwrite)
+        .VerifyExistence(VerifyExistence);
 
     if (InFlight) {
         settings.MaxInFlight(InFlight);

--- a/ydb/public/lib/ydb_cli/commands/ydb_tools.h
+++ b/ydb/public/lib/ydb_cli/commands/ydb_tools.h
@@ -61,6 +61,8 @@ private:
     bool RestoreACL = true;
     bool SkipDocumentTables = false;
     bool SavePartialResult = false;
+    bool Overwrite = false;
+    bool VerifyExistence = false;
     TString UploadBandwidth;
     TString UploadRps;
     TString RowsPerRequest;

--- a/ydb/public/lib/ydb_cli/dump/dump.h
+++ b/ydb/public/lib/ydb_cli/dump/dump.h
@@ -101,6 +101,9 @@ struct TRestoreSettings: public TOperationRequestSettings<TRestoreSettings> {
     FLUENT_SETTING_DEFAULT(bool, RestoreACL, true);
     FLUENT_SETTING_DEFAULT(bool, SkipDocumentTables, false);
     FLUENT_SETTING_DEFAULT(bool, SavePartialResult, false);
+    FLUENT_SETTING_DEFAULT(bool, Overwrite, false);
+    // only makes sense when used together with the overwrite option
+    FLUENT_SETTING_DEFAULT(bool, VerifyExistence, false);
 
     FLUENT_SETTING_DEFAULT(ui64, MemLimit, 32_MB);
     FLUENT_SETTING_DEFAULT(ui64, RowsPerRequest, 0);

--- a/ydb/public/lib/ydb_cli/dump/restore_impl.h
+++ b/ydb/public/lib/ydb_cli/dump/restore_impl.h
@@ -220,6 +220,7 @@ class TRestoreClient {
         ui32 dataFilesCount);
 
     TRestoreResult CheckSecretExistence(const TString& secretName);
+    TRestoreResult Drop(NScheme::ESchemeEntryType type, const TString& path, bool isAlreadyExisting, bool verifyExistence);
 
 public:
     explicit TRestoreClient(const TDriver& driver, const std::shared_ptr<TLog>& log);


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

Added `--overwrite` option to ydb tools restore. When enabled, existing database objects that match those in the backup are removed before restoration.

### Changelog category <!-- remove all except one -->

* New feature

### Description for reviewers <!-- (optional) description for those who read this PR -->

Issues:
- https://github.com/ydb-platform/ydb/issues/15410
