### PR TITLE
[ci] create docs_notify_assignees.yaml

### DIFF
--- a/.github/workflows/docs_notify_assignees.yaml
+++ b/.github/workflows/docs_notify_assignees.yaml
@@ -1,0 +1,56 @@
+name: Notify documentation review assignees on new commits
+
+on:
+  pull_request:
+    # Fires on new commits and on label changes, so the job
+    # starts as soon as the label is added, then on every push.
+    types: [synchronize, labeled]
+
+permissions:
+  issues: write
+  pull-requests: read
+
+concurrency:
+  group: pr-${{ github.event.pull_request.number }}-doc-notify
+  cancel-in-progress: true
+
+jobs:
+  ping:
+    if: contains(github.event.pull_request.labels.*.name, 'documentation')
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/github-script@v7
+        with:
+          github-token: ${{ secrets.YDBOT_TOKEN }}
+          script: |
+            const pr        = context.payload.pull_request;
+            const assignees = pr.assignees.map(a => `@${a.login}`).join(' ');
+            if (!assignees) {
+              core.info('No assignees, nothing to ping.');
+              return;
+            }
+
+            // Check when the bot (this token) last commented
+            const { data: me } = await github.rest.users.getAuthenticated();
+            const { data: comments } = await github.rest.issues.listComments({
+              owner: context.repo.owner,
+              repo:  context.repo.repo,
+              issue_number: pr.number,
+              per_page: 1,
+              sort: 'created',
+              direction: 'desc'
+            });
+            const myLast = comments.find(c => c.user.login === me.login);
+
+            // Skip if commented recently enough
+            if (myLast && Date.now() - new Date(myLast.created_at) < 15 * 60 * 1000) {
+              core.info('Skip: already commented within 15 minutes.');
+              return;
+            }
+
+            await github.rest.issues.createComment({
+              owner: context.repo.owner,
+              repo:  context.repo.repo,
+              issue_number: pr.number,
+              body: `🔄 New commits pushed — ${assignees} please take another look.`
+            });


### PR DESCRIPTION
### Changelog category <!-- remove all except one -->

* Not for changelog (changelog entry is not required)

### Description for reviewers <!-- (optional) description for those who read this PR -->

Add a workflow to notify documentation review assignees about new changes.
