### PR TITLE
Return breakpad variables and add compatibility info

### DIFF
--- a/ydb/core/driver_lib/version/version.cpp
+++ b/ydb/core/driver_lib/version/version.cpp
@@ -1,6 +1,7 @@
 #include <google/protobuf/text_format.h>
 #include <google/protobuf/util/message_differencer.h>
 #include <library/cpp/svnversion/svnversion.h>
+#include <library/cpp/resource/resource.h>
 #include <ydb/library/yverify_stream/yverify_stream.h>
 #include <ydb/core/viewer/json/json.h>
 #include "version.h"
@@ -729,6 +730,10 @@ TString TCompatibilityInfo::PrintHumanReadable(const NKikimrConfig::TCurrentComp
         str << "trunk";
     }
     str << "\n";
+
+    if (NResource::Has("interanal_breakpad_about")) {
+        str << "    HasInternalBreakpad: true" << Endl;
+    }
 
     // print common rule
     if (current->HasVersion() && current->GetVersion().HasYear() && current->GetVersion().HasMajor()) {

--- a/ydb/core/driver_lib/version/ya.make
+++ b/ydb/core/driver_lib/version/ya.make
@@ -10,6 +10,7 @@ PEERDIR(
     ydb/library/actors/interconnect
     library/cpp/monlib/service/pages
     library/cpp/svnversion
+    library/cpp/resource
     ydb/core/protos
     ydb/core/viewer/json
 )

--- a/ydb/library/breakpad/about.txt
+++ b/ydb/library/breakpad/about.txt
@@ -1,0 +1,1 @@
+Pluggable Google Breakpad

--- a/ydb/library/breakpad/dmp2stacks/ya.make
+++ b/ydb/library/breakpad/dmp2stacks/ya.make
@@ -1,0 +1,18 @@
+IF (OS_LINUX)
+
+PROGRAM()
+
+    PEERDIR (
+        contrib/libs/breakpad/src
+        contrib/libs/breakpad/src/client/linux
+        contrib/libs/llvm16/lib/DebugInfo/Symbolize
+        library/cpp/getopt
+    )
+
+    SRCS (
+        main.cpp
+    )
+
+END()
+
+ENDIF()

--- a/ydb/library/breakpad/minidumps.cpp
+++ b/ydb/library/breakpad/minidumps.cpp
@@ -7,7 +7,7 @@
 class TMinidumper {
 public:
     TMinidumper() {
-        if(const char* path = getenv("INTERNAL_BREAKPAD_MINIDUMPS_PATH")) {
+        if(const char* path = getenv("BREAKPAD_MINIDUMPS_PATH")) {
             using namespace google_breakpad;
             Handler = MakeHolder<ExceptionHandler>(MinidumpDescriptor(path), nullptr, DumpCallback, nullptr, true, -1, true);
         }
@@ -15,7 +15,7 @@ public:
 
 private:
     static bool DumpCallback(const google_breakpad::MinidumpDescriptor& descriptor, void* /*context*/, bool succeeded) {
-        if (char* script = getenv("INTERNAL_BREAKPAD_MINIDUMPS_SCRIPT")) {
+        if (char* script = getenv("BREAKPAD_MINIDUMPS_SCRIPT")) {
             if (auto pid = fork()) {
                 waitpid(pid, 0, 0);
             } else {

--- a/ydb/library/breakpad/ya.make
+++ b/ydb/library/breakpad/ya.make
@@ -9,6 +9,9 @@ IF (OS_LINUX)
     SRCS(
         GLOBAL minidumps.cpp
     )
+
+    RESOURCE(about.txt "interanal_breakpad_about")
+
 ENDIF()
 
 END()

--- a/ydb/tests/functional/minidumps/test_break.py
+++ b/ydb/tests/functional/minidumps/test_break.py
@@ -6,7 +6,7 @@ from ydb.tests.library.harness.kikimr_runner import KiKiMR
 def test_create_minidump():
     dump_path = os.path.join(yatest.common.tempfile.gettempdir(), 'dumps1')
     os.makedirs(dump_path, exist_ok=True)
-    os.environ['INTERNAL_BREAKPAD_MINIDUMPS_PATH'] = dump_path
+    os.environ['BREAKPAD_MINIDUMPS_PATH'] = dump_path
     cluster = KiKiMR()
     cluster.start()
     for node in cluster.nodes.values():
@@ -31,8 +31,8 @@ def test_minidump_script():
             'echo $SUCCESS >${PATH}.success\n'
         )
     os.chmod(script_path, 0o777)
-    os.environ['INTERNAL_BREAKPAD_MINIDUMPS_SCRIPT'] = script_path
-    os.environ['INTERNAL_BREAKPAD_MINIDUMPS_PATH'] = dump_path
+    os.environ['BREAKPAD_MINIDUMPS_SCRIPT'] = script_path
+    os.environ['BREAKPAD_MINIDUMPS_PATH'] = dump_path
     cluster = KiKiMR()
     cluster.start()
     for node in cluster.nodes.values():
@@ -46,3 +46,13 @@ def test_minidump_script():
     successes = list(filter(lambda x: x.endswith('.dmp.success'), files))
     assert len(dmps) == len(cluster.nodes)
     assert len(successes) == len(cluster.nodes)
+
+
+def test_compatibility_info():
+    res = yatest.common.subprocess.run(
+        [yatest.common.binary_path(os.getenv('YDB_DRIVER_BINARY')), '--compatibility-info'],
+        capture_output=True,
+        encoding='utf8',
+        check=True
+    )
+    assert res.stdout.find('HasInternalBreakpad: true') >= 0


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->
Add support off google breakpad inside ydbd. Now you can set minidumps path throw envar.
https://github.com/ydb-platform/ydb/issues/16468

### Changelog category <!-- remove all except one -->

* New feature

### Description for reviewers <!-- (optional) description for those who read this PR -->

...
