### PR TITLE
Don't allow replication to overconsume space on PDisk

### DIFF
--- a/ydb/core/blobstorage/pdisk/mock/pdisk_mock.cpp
+++ b/ydb/core/blobstorage/pdisk/mock/pdisk_mock.cpp
@@ -3,6 +3,7 @@
 #include <ydb/core/util/stlog.h>
 #include <ydb/core/util/interval_set.h>
 
+#include <ydb/core/blobstorage/pdisk/blobstorage_pdisk_quota_record.h>
 #include <ydb/core/blobstorage/pdisk/blobstorage_pdisk_util_space_color.h>
 
 namespace NKikimr {
@@ -50,7 +51,12 @@ struct TPDiskMockState::TImpl {
     NPDisk::EDeviceType DeviceType;
     std::optional<TRcBuf> Metadata;
 
-    TImpl(ui32 nodeId, ui32 pdiskId, ui64 pdiskGuid, ui64 size, ui32 chunkSize, bool isDiskReadOnly, NPDisk::EDeviceType deviceType)
+    ESpaceColorPolicy SpaceColorPolicy;
+    std::shared_ptr<NPDisk::TQuotaRecord> ChunkSharedQuota;
+    double Occupancy = 0;
+
+    TImpl(ui32 nodeId, ui32 pdiskId, ui64 pdiskGuid, ui64 size, ui32 chunkSize, bool isDiskReadOnly, NPDisk::EDeviceType deviceType,
+            ESpaceColorPolicy spaceColorPolicy)
         : NodeId(nodeId)
         , PDiskId(pdiskId)
         , PDiskGuid(pdiskGuid)
@@ -62,7 +68,20 @@ struct TPDiskMockState::TImpl {
         , NextFreeChunk(1)
         , StatusFlags(NPDisk::TStatusFlags{})
         , DeviceType(deviceType)
-    {}
+        , SpaceColorPolicy(spaceColorPolicy)
+    {
+        switch (SpaceColorPolicy) {
+            case ESpaceColorPolicy::SharedQuota: {
+                ChunkSharedQuota = std::make_shared<NPDisk::TQuotaRecord>();
+                // 13% for CYAN is default value in prod
+                ChunkSharedQuota->ForceHardLimit(TotalChunks, NPDisk::TColorLimits::MakeChunkLimits(130));
+                break;
+            }
+            case ESpaceColorPolicy::None: 
+            default:
+                break;
+        }
+    }
 
     TImpl(const TImpl&) = default;
 
@@ -73,6 +92,25 @@ struct TPDiskMockState::TImpl {
     void AdjustFreeChunks() {
         for (auto it = FreeChunks.end(); it != FreeChunks.begin() && *--it == NextFreeChunk - 1; it = FreeChunks.erase(it)) {
             --NextFreeChunk;
+        }
+    }
+
+    void UpdateStatusFlags(i64 chunksDelta) {
+        switch (SpaceColorPolicy) {
+            case ESpaceColorPolicy::SharedQuota: {
+                NKikimrBlobStorage::TPDiskSpaceColor::E newColor =
+                        ChunkSharedQuota->EstimateSpaceColor(chunksDelta, &Occupancy);
+                if (chunksDelta < 0) {
+                    ChunkSharedQuota->Release(-chunksDelta);
+                } else if (chunksDelta > 0) {
+                    ChunkSharedQuota->ForceAllocate(chunksDelta);
+                }
+                SetStatusFlags(SpaceColorToStatusFlag(newColor));
+                break;
+            }
+            case ESpaceColorPolicy::None: 
+            default:
+                break;
         }
     }
 
@@ -88,7 +126,9 @@ struct TPDiskMockState::TImpl {
             to.ReservedChunks.insert(FreeChunks.extract(it));
         }
 
-        Y_VERIFY(chunkIdx != TotalChunks);
+        Y_ABORT_UNLESS(chunkIdx != TotalChunks);
+
+        UpdateStatusFlags(1);
         return chunkIdx;
     }
 
@@ -172,6 +212,8 @@ struct TPDiskMockState::TImpl {
         for (const TChunkIdx chunkIdx : owner.ReservedChunks) {
             owner.ChunkData.erase(chunkIdx);
         }
+
+        UpdateStatusFlags(-(i64)owner.ReservedChunks.size());
         FreeChunks.merge(owner.ReservedChunks);
         AdjustFreeChunks();
     }
@@ -188,7 +230,9 @@ struct TPDiskMockState::TImpl {
         Y_VERIFY(num);
         owner.ChunkData.erase(chunkIdx);
         const bool inserted = FreeChunks.insert(chunkIdx).second;
-        Y_VERIFY(inserted);
+        Y_ABORT_UNLESS(inserted);
+
+        UpdateStatusFlags(-1);
         AdjustFreeChunks();
     }
 
@@ -286,8 +330,9 @@ struct TPDiskMockState::TImpl {
 };
 
 TPDiskMockState::TPDiskMockState(ui32 nodeId, ui32 pdiskId, ui64 pdiskGuid, ui64 size, ui32 chunkSize, bool isDiskReadOnly,
-        NPDisk::EDeviceType deviceType)
-    : TPDiskMockState(std::make_unique<TImpl>(nodeId, pdiskId, pdiskGuid, size, chunkSize, isDiskReadOnly, deviceType))
+        NPDisk::EDeviceType deviceType, ESpaceColorPolicy spaceColorPolicy)
+    : TPDiskMockState(std::make_unique<TImpl>(nodeId, pdiskId, pdiskGuid, size, chunkSize, isDiskReadOnly, deviceType,
+            spaceColorPolicy))
 {}
 
 TPDiskMockState::TPDiskMockState(std::unique_ptr<TImpl>&& impl)
@@ -475,6 +520,8 @@ public:
                 break;
             } else {
                 owner.Slain = true;
+                Impl.UpdateStatusFlags(-(i64)owner.ReservedChunks.size());
+                Impl.UpdateStatusFlags(-(i64)owner.CommittedChunks.size());
                 Impl.FreeChunks.merge(owner.ReservedChunks);
                 Impl.FreeChunks.merge(owner.CommittedChunks);
                 Impl.AdjustFreeChunks();
@@ -676,6 +723,7 @@ public:
                 for (ui32 i = 0; i < msg->SizeChunks; ++i) {
                     res->ChunkIds.push_back(Impl.AllocateChunk(*owner));
                 }
+                res->StatusFlags = GetStatusFlags();
                 PDISK_MOCK_LOG(DEBUG, PDM10, "sending TEvChunkReserveResult", (Msg, res->ToString()));
             }
         }
@@ -848,7 +896,7 @@ public:
         auto res = std::make_unique<NPDisk::TEvCheckSpaceResult>(NKikimrProto::OK, GetStatusFlags(),
             Impl.GetNumFreeChunks(), Impl.TotalChunks, Impl.TotalChunks - Impl.GetNumFreeChunks(),
             Impl.Owners.size(), TString());
-        res->Occupancy = (double)res->UsedChunks / res->TotalChunks;
+        res->Occupancy = GetOccupancy();
         Impl.FindOwner(msg, res); // to ensure correct owner/round
         Send(ev->Sender, res.release());
     }
@@ -884,6 +932,12 @@ public:
 
     NPDisk::TStatusFlags GetStatusFlags() {
         return Impl.StatusFlags;
+    }
+
+    double GetOccupancy() {
+        return (Impl.Occupancy == 0)
+            ? ((double)(Impl.TotalChunks - Impl.GetNumFreeChunks()) / Impl.TotalChunks)
+            : Impl.Occupancy;
     }
 
     void ErrorHandle(NPDisk::TEvYardInit::TPtr &ev) {

--- a/ydb/core/blobstorage/pdisk/mock/pdisk_mock.h
+++ b/ydb/core/blobstorage/pdisk/mock/pdisk_mock.h
@@ -18,11 +18,18 @@ namespace NKikimr {
         friend class TPDiskMockActor;
 
     public:
+        enum class ESpaceColorPolicy {
+            None = 0,
+            SharedQuota,
+        };
+
+    public:
         using TPtr = TIntrusivePtr<TPDiskMockState>;
 
     public:
         TPDiskMockState(ui32 nodeId, ui32 pdiskId, ui64 pdiskGuid, ui64 size, ui32 chunkSize = 128 << 20,
-                bool isDiskReadOnly = false, NPDisk::EDeviceType deviceType = NPDisk::EDeviceType::DEVICE_TYPE_NVME);
+                bool isDiskReadOnly = false, NPDisk::EDeviceType deviceType = NPDisk::EDeviceType::DEVICE_TYPE_NVME,
+                ESpaceColorPolicy spaceColorPolicy = ESpaceColorPolicy::None);
         TPDiskMockState(std::unique_ptr<TImpl>&& impl);
         ~TPDiskMockState();
 

--- a/ydb/core/blobstorage/ut_blobstorage/lib/env.h
+++ b/ydb/core/blobstorage/ut_blobstorage/lib/env.h
@@ -57,6 +57,7 @@ struct TEnvironmentSetup {
         const ui32 ReplMaxQuantumBytes = 0;
         const ui32 ReplMaxDonorNotReadyCount = 0;
         const ui64 PDiskSize = 10_TB;
+        const ui64 PDiskChunkSize = 0;
         const bool TrackSharedQuotaInPDiskMock = false;
     };
 
@@ -75,10 +76,11 @@ struct TEnvironmentSetup {
             const auto key = std::make_pair(nodeId, pdiskId);
             TIntrusivePtr<TPDiskMockState>& state = Env.PDiskMockStates[key];
             if (!state) {
+                ui64 chunkSize = Env.Settings.PDiskChunkSize ? Env.Settings.PDiskChunkSize : cfg->ChunkSize;
                 TPDiskMockState::ESpaceColorPolicy spaceColorPolicy = Env.Settings.TrackSharedQuotaInPDiskMock
                         ? TPDiskMockState::ESpaceColorPolicy::SharedQuota
                         : TPDiskMockState::ESpaceColorPolicy::None;
-                state.Reset(new TPDiskMockState(nodeId, pdiskId, cfg->PDiskGuid, Env.Settings.PDiskSize, cfg->ChunkSize,
+                state.Reset(new TPDiskMockState(nodeId, pdiskId, cfg->PDiskGuid, Env.Settings.PDiskSize, chunkSize,
                         cfg->ReadOnly, Env.Settings.DiskType, spaceColorPolicy));
             }
             const TActorId& actorId = ctx.Register(CreatePDiskMockActor(state), TMailboxType::HTSwap, poolId);

--- a/ydb/core/blobstorage/ut_blobstorage/ut_helpers.h
+++ b/ydb/core/blobstorage/ut_blobstorage/ut_helpers.h
@@ -275,7 +275,8 @@ public:
         Env->CreateBoxAndPool(1, 1);
         Env->Sim(TDuration::Minutes(1));
 
-        BaseConfig = Env->FetchBaseConfig();
+        FetchBaseConfig();
+
         UNIT_ASSERT_VALUES_EQUAL(BaseConfig.GroupSize(), 1);
         const auto& group = BaseConfig.GetGroup(0);
         GroupId = group.GetGroupId();
@@ -283,6 +284,10 @@ public:
 
     void AllocateEdgeActor() {
         Edge = Env->Runtime->AllocateEdgeActor(NodeCount);
+    }
+
+    void FetchBaseConfig() {
+        BaseConfig = Env->FetchBaseConfig();
     }
 
     TAutoPtr<TEventHandle<TEvBlobStorage::TEvStatusResult>> GetGroupStatus(ui32 groupId) {
@@ -298,24 +303,92 @@ public:
         GetGroupStatus(GroupId);
     }
 
-    std::vector<TLogoBlobID> WriteCompressedData(ui32 groupId, ui64 totalSize, ui64 blobSize, ui64 tabletId = 5000,
-            ui32 channel = 1, ui32 generation = 1, ui32 step = 1) {
+public:
+    struct TDataProfile {
+    public:
+        enum class ECookieStrategy {
+            SimpleIncrement = 0,
+            WithSamePlacement,
+        };
+
+        enum class EContentType {
+            Zeros = 0,
+            RepetitivePattern,
+        };
+
+    public:
+        ui32 GroupId;
+        ui64 TotalSize;
+        ui64 BlobSize;
+        EContentType ContentType = EContentType::Zeros;
+
+        TDuration DelayBetweenPuts = TDuration::Zero();
+
+        // must be specified when using ECookieStrategy::WithSamePlacement
+        std::optional<TBlobStorageGroupType> Erasure = std::nullopt;
+
+        ui64 TabletId = 5000;
+        ui32 Channel = 1;
+        ui32 Generation = 1;
+        ui32 Step = 1;
+        ECookieStrategy CookieStrategy = ECookieStrategy::SimpleIncrement;
+
+    public:
+        ui64 NextCookie(ui64 prevCookie) const {
+            switch (CookieStrategy) {
+                case TDataProfile::ECookieStrategy::SimpleIncrement:
+                    return ++prevCookie;
+                case TDataProfile::ECookieStrategy::WithSamePlacement: {
+                    ui64 originalHash = TLogoBlobID(TabletId, Generation, Step, Channel, BlobSize, prevCookie).Hash();
+                    while (prevCookie < TLogoBlobID::MaxCookie) {
+                        TLogoBlobID next(TabletId, Generation, Step, Channel, BlobSize, ++prevCookie);
+                        if (next.Hash() % Erasure->BlobSubgroupSize() == originalHash % Erasure->BlobSubgroupSize()) {
+                            return prevCookie;
+                        }
+                    }
+                }
+                default:
+                    Y_FAIL();
+            }
+        }
+    };
+
+    std::vector<TLogoBlobID> WriteCompressedData(TDataProfile profile) {
         std::vector<TLogoBlobID> blobs;
 
         static ui64 cookie = 0;
 
-        for (ui64 size = 0; size < totalSize; size += blobSize) {
-            blobs.emplace_back(tabletId, generation, step, channel, blobSize, ++cookie);
+        for (ui64 size = 0; size < profile.TotalSize; size += profile.BlobSize) {
+            cookie = profile.NextCookie(cookie);
+            blobs.emplace_back(profile.TabletId, profile.Generation, profile.Step, profile.Channel,
+                    profile.BlobSize, cookie);
 
             Env->Runtime->WrapInActorContext(Edge, [&] {
-                TString data(blobSize, '\0');
-                SendToBSProxy(Edge, groupId, new TEvBlobStorage::TEvPut(blobs.back(), data, TInstant::Max()),
+                TString data;
+
+                switch (profile.ContentType) {
+                    case TDataProfile::EContentType::Zeros:
+                        data = TString(profile.BlobSize, '\0');
+                        break;
+                    case TDataProfile::EContentType::RepetitivePattern:
+                        data = MakeData(profile.BlobSize);
+                        break;
+                    default:
+                        Y_FAIL();
+                }
+
+                SendToBSProxy(Edge, profile.GroupId, new TEvBlobStorage::TEvPut(blobs.back(), data, TInstant::Max()),
                         NKikimrBlobStorage::TabletLog);
             });
 
             auto res = Env->WaitForEdgeActorEvent<TEvBlobStorage::TEvPutResult>(
                     Edge, false, TInstant::Max());
+            // Cerr << "Write data " << size << " " << res->Get()->ToString()<< Endl;
             UNIT_ASSERT(res->Get()->Status == NKikimrProto::OK);
+
+            if (profile.DelayBetweenPuts != TDuration::Zero()) {
+                Env->Sim(profile.DelayBetweenPuts);
+            }
         }
         return blobs;
     }

--- a/ydb/core/blobstorage/ut_blobstorage/ut_replication/ya.make
+++ b/ydb/core/blobstorage/ut_blobstorage/ut_replication/ya.make
@@ -9,6 +9,7 @@ INCLUDE(${ARCADIA_ROOT}/ydb/tests/large.inc)
 SRCS(
     replication.cpp
     replication_huge.cpp
+    ut_helpers.cpp
 )
 
 PEERDIR(

--- a/ydb/core/blobstorage/vdisk/repl/blobstorage_hullreplwritesst.h
+++ b/ydb/core/blobstorage/vdisk/repl/blobstorage_hullreplwritesst.h
@@ -38,6 +38,27 @@ namespace NKikimr {
             ERROR,                 // something gone wrong, further operation impossible
         };
 
+        static TString StateToString(EState state) {
+            switch (state) {
+            case EState::INVALID:
+                return "INVALID";
+            case EState::STOPPED:
+                return "STOPPED";
+            case EState::PDISK_MESSAGE_PENDING:
+                return "PDISK_MESSAGE_PENDING";
+            case EState::NOT_READY:
+                return "NOT_READY";
+            case EState::COLLECT:
+                return "COLLECT";
+            case EState::COMMIT_PENDING:
+                return "COMMIT_PENDING";
+            case EState::WAITING_FOR_COMMIT:
+                return "WAITING_FOR_COMMIT";
+            case EState::ERROR:
+                return "ERROR";
+            }
+        }
+
         enum class EOutputState {
             INVALID,
             INTERMEDIATE_CHUNK,

--- a/ydb/core/blobstorage/vdisk/repl/blobstorage_repl.cpp
+++ b/ydb/core/blobstorage/vdisk/repl/blobstorage_repl.cpp
@@ -104,6 +104,7 @@ namespace NKikimr {
                         PARAM_V(CommitDuration);
                         PARAM_V(OtherDuration);
                         PARAM_V(PhantomDuration);
+                        PARAM_V(OutOfSpaceDelayDuration);
                     }
                     GROUP("VDisk Stats") {
                         PARAM_V(ProxyStat->VDiskReqs);

--- a/ydb/core/blobstorage/vdisk/repl/blobstorage_repl.h
+++ b/ydb/core/blobstorage/vdisk/repl/blobstorage_repl.h
@@ -162,6 +162,7 @@ namespace NKikimr {
             TDuration CommitDuration;
             TDuration OtherDuration;
             TDuration PhantomDuration;
+            TDuration OutOfSpaceDelayDuration;
 
             std::unique_ptr<NRepl::TProxyStat> ProxyStat;
 

--- a/ydb/core/blobstorage/vdisk/repl/blobstorage_replrecoverymachine.h
+++ b/ydb/core/blobstorage/vdisk/repl/blobstorage_replrecoverymachine.h
@@ -19,6 +19,7 @@ namespace NKikimr {
             COMMIT,
             OTHER,
             PHANTOM,
+            OUT_OF_SPACE_DELAY,
             COUNT
         };
 
@@ -46,6 +47,7 @@ namespace NKikimr {
                 replInfo.CommitDuration = Durations[static_cast<ui32>(ETimeState::COMMIT)];
                 replInfo.OtherDuration = Durations[static_cast<ui32>(ETimeState::OTHER)];
                 replInfo.PhantomDuration = Durations[static_cast<ui32>(ETimeState::PHANTOM)];
+                replInfo.OutOfSpaceDelayDuration = Durations[static_cast<ui32>(ETimeState::OUT_OF_SPACE_DELAY)];
             }
 
         private:


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

Previously replication didn't handle StatusFlags from PDisk properly and didn't stop when available space was running low. Because of this, space was consumed until VDisk and corresponding storage group became read-only. With this change, replication will postpone on YELLOW_STOP color flag and resume after a certain delay if enough space is available.

https://github.com/ydb-platform/ydb/issues/13608

### Changelog category <!-- remove all except one -->
* Bugfix
