### PR TITLE
Dev compatibility tests 2

### DIFF
--- a/ydb/tests/functional/compatibility/test_compatibility.py
+++ b/ydb/tests/functional/compatibility/test_compatibility.py
@@ -153,7 +153,7 @@ class TestCompatibility(object):
                     "create table `sample_table` (id Uint64, value Uint64, payload Utf8, income Decimal(22,9), PRIMARY KEY(id)) WITH (AUTO_PARTITIONING_BY_SIZE = ENABLED, AUTO_PARTITIONING_PARTITION_SIZE_MB = 1);"
                     )
     
-    def log_node_versions(self):
+    def log_nodes_version(self):
         for node_id, node in enumerate(self.cluster.nodes.values()):
             node.get_config_version()
             get_version_command = [
@@ -190,8 +190,8 @@ class TestCompatibility(object):
             version_id = None
             
         self.cluster.change_node_version(version_id=version_id)
-        time.sleep(180)
-        self.log_node_versions()
+        time.sleep(60)
+        self.log_nodes_version()
     
     def log_database_scheme(self):
         for node_id, node in enumerate(self.cluster.nodes.values()):
@@ -208,21 +208,7 @@ class TestCompatibility(object):
             ]
             yatest.common.execute(get_scheme_command, wait=True, stdout=self.output_f, stderr=self.output_f)
     
-    def log_nodes_version(self):
-        for node_id, node in enumerate(self.cluster.nodes.values()):
-            node.get_config_version()
-            get_version_command = [
-                yatest.common.binary_path(os.getenv("YDB_CLI_BINARY")),
-                "--verbose",
-                "-e",
-                "grpc://localhost:%d" % node.grpc_port,
-                "-d"
-                "/Root",
-                "scheme",
-                "ls"
- 
-            ]
-            yatest.common.execute(get_version_command, wait=True, stdout=self.output_f, stderr=self.output_f)
+   
     
     @pytest.mark.parametrize("version_change_to", ['combined','next_version'])
     def test_simple(self,version_change_to):

--- a/ydb/tests/functional/compatibility/test_compatibility.py
+++ b/ydb/tests/functional/compatibility/test_compatibility.py
@@ -87,7 +87,7 @@ class TestCompatibility(object):
     
     def read_update_data(self, iteration_count=1):
         session = ydb.retry_operation_sync(lambda: self.driver.table_client.session().create())
-        self.log_node_versions()
+        self.log_nodes_version()
         with ydb.SessionPool(self.driver, size=1) as pool:
             with pool.checkout() as session:
                 id_ = 0

--- a/ydb/tests/functional/compatibility/test_compatibility.py
+++ b/ydb/tests/functional/compatibility/test_compatibility.py
@@ -1,46 +1,75 @@
 # -*- coding: utf-8 -*-
 import boto3
-
-import os
-
+import time
+import pytest
+import logging
 import yatest
+import os
 from ydb.tests.library.harness.kikimr_runner import KiKiMR
 from ydb.tests.library.harness.kikimr_config import KikimrConfigGenerator
 from ydb.tests.library.harness.param_constants import kikimr_driver_path
 from ydb.tests.library.common.types import Erasure
 from ydb.tests.oss.ydb_sdk_import import ydb
 
+from decimal import Decimal
+
+
+last_stable_binary_path = yatest.common.binary_path("ydb/tests/library/compatibility/ydbd-last-stable")
+prev_stable_binary_path = yatest.common.binary_path("ydb/tests/library/compatibility/ydbd-prev-stable")
+current_binary_path = kikimr_driver_path()
+
+all_binary_combinations = [
+    [current_binary_path, last_stable_binary_path],
+    [current_binary_path, prev_stable_binary_path],
+    [last_stable_binary_path, current_binary_path],
+    [prev_stable_binary_path, current_binary_path],
+    [prev_stable_binary_path, last_stable_binary_path],
+    [last_stable_binary_path, prev_stable_binary_path],
+]
+all_binary_combinations_ids = [
+    "current_to_last_stable",
+    "current_to_prev_stable",
+    "last_stable_to_current",
+    "prev_stable_to_current",
+    "prev_stable_to_last_stable",
+    "last_stable_to_prev_stable"
+    ]
+
+logger = logging.getLogger(__name__)
 
 class TestCompatibility(object):
-    @classmethod
-    def setup_class(cls):
-        last_stable_path = yatest.common.binary_path("ydb/tests/library/compatibility/ydbd-last-stable")
-        binary_paths = [kikimr_driver_path(), last_stable_path]
-        cls.cluster = KiKiMR(KikimrConfigGenerator(erasure=Erasure.MIRROR_3_DC, binary_paths=binary_paths))
-        cls.cluster.start()
-        cls.endpoint = "%s:%s" % (
-            cls.cluster.nodes[1].host, cls.cluster.nodes[1].port
+    @pytest.fixture(autouse=True, params=all_binary_combinations, ids=all_binary_combinations_ids)
+    def setup(self, request):
+        binary_paths = request.param
+        self.config = KikimrConfigGenerator(
+            erasure=Erasure.MIRROR_3_DC,
+            binary_paths=binary_paths,
+            use_in_memory_pdisks=False,
+            # uncomment for 64 datetime in tpc-h/tpc-ds
+            # extra_feature_flags={"enable_table_datetime64": True},
+
+            column_shard_config={
+                'disabled_on_scheme_shard': False,
+            },
         )
-        cls.driver = ydb.Driver(
+
+        self.cluster = KiKiMR(self.config)
+        self.cluster.start(version_id=1)
+        self.endpoint = "grpc://%s:%s" % ('localhost', self.cluster.nodes[1].port)
+        output_path = yatest.common.test_output_path()
+        self.output_f = open(os.path.join(output_path, "out.log"), "w")
+        self.s3_config = self.setup_s3()
+
+        self.driver = ydb.Driver(
             ydb.DriverConfig(
                 database='/Root',
-                endpoint=cls.endpoint
+                endpoint=self.endpoint
             )
         )
-        cls.driver.wait()
-        output_path = yatest.common.test_output_path()
-        cls.output_f = open(os.path.join(output_path, "out.log"), "w")
-
-        cls.s3_config = cls.setup_s3()
-
-    @classmethod
-    def teardown_class(cls):
-        if hasattr(cls, 'driver'):
-            cls.driver.stop()
-
-        if hasattr(cls, 'cluster'):
-            cls.cluster.stop(kill=True)  # TODO fix
-
+        self.driver.wait()
+        yield
+        self.cluster.stop()
+        
     @staticmethod
     def setup_s3():
         s3_endpoint = os.getenv("S3_ENDPOINT")
@@ -55,19 +84,16 @@ class TestCompatibility(object):
         bucket.objects.all().delete()
 
         return s3_endpoint, s3_access_key, s3_secret_key, s3_bucket
-
-    def test_simple(self):
+    
+    def read_update_data(self, iteration_count=1):
         session = ydb.retry_operation_sync(lambda: self.driver.table_client.session().create())
-
+        self.log_node_versions()
         with ydb.SessionPool(self.driver, size=1) as pool:
             with pool.checkout() as session:
-                session.execute_scheme(
-                    "create table `sample_table` (id Uint64, value Uint64, payload Utf8, PRIMARY KEY(id)) WITH (AUTO_PARTITIONING_BY_SIZE = ENABLED, AUTO_PARTITIONING_PARTITION_SIZE_MB = 1);"
-                )
                 id_ = 0
 
                 upsert_count = 200
-                iteration_count = 1
+                iteration_count = iteration_count
                 for i in range(iteration_count):
                     rows = []
                     for j in range(upsert_count):
@@ -75,6 +101,8 @@ class TestCompatibility(object):
                         row["id"] = id_
                         row["value"] = 1
                         row["payload"] = "DEADBEEF" * 1024 * 16  # 128 kb
+                        row["income"] = Decimal("123.001").quantize(Decimal('0.000000000'))
+
                         rows.append(row)
                         id_ += 1
 
@@ -82,63 +110,148 @@ class TestCompatibility(object):
                     column_types.add_column("id", ydb.PrimitiveType.Uint64)
                     column_types.add_column("value", ydb.PrimitiveType.Uint64)
                     column_types.add_column("payload", ydb.PrimitiveType.Utf8)
+                    column_types.add_column("income", ydb.DecimalType())
                     self.driver.table_client.bulk_upsert(
                         "Root/sample_table", rows, column_types
                     )
 
-                query = "SELECT SUM(value) from sample_table"
-                result_sets = session.transaction().execute(
-                    query, commit_tx=True
-                )
-                for row in result_sets[0].rows:
+                query_body = "SELECT SUM(value) as sum_value from `sample_table`"
+                query = ydb.ScanQuery(query_body, {})
+                it = self.driver.table_client.scan_query(query)
+                result_set = []
+
+                while True:
+                    try:
+                        result = next(it)
+                        result_set = result_set + result.result_set.rows
+                    except StopIteration:
+                        break
+                
+                
+                for row in result_set:
                     print(" ".join([str(x) for x in list(row.values())]))
 
-                assert len(result_sets) == 1
-                assert len(result_sets[0].rows) == 1
-                result = list(result_sets[0].rows[0].values())
+                assert len(result_set) == 1
+                assert len(result_set[0]) == 1
+                result = list(result_set)
                 assert len(result) == 1
-                assert result[0] == upsert_count * iteration_count
-
-    def test_export(self):
-        s3_endpoint, s3_access_key, s3_secret_key, s3_bucket = self.s3_config
-
+                assert result[0]['sum_value'] == upsert_count * iteration_count
+    
+    def create_table_column(self):
         session = ydb.retry_operation_sync(lambda: self.driver.table_client.session().create())
-
-        for table_num in range(1, 6):
-            table_name = f"sample_table_{table_num}"
-
-            session.execute_scheme(
-                f"create table `{table_name}` (id Uint64, payload Utf8, PRIMARY KEY(id));"
-            )
-
-            query = f"""INSERT INTO `{table_name}` (id, payload) VALUES
-                (1, 'Payload 1 for table {table_num}'),
-                (2, 'Payload 2 for table {table_num}'),
-                (3, 'Payload 3 for table {table_num}'),
-                (4, 'Payload 4 for table {table_num}'),
-                (5, 'Payload 5 for table {table_num}');"""
-            session.transaction().execute(
-                query, commit_tx=True
-            )
-
-        export_command = [
-            yatest.common.binary_path(os.getenv("YDB_CLI_BINARY")),
-            "--verbose",
-            "--endpoint",
-            "grpc://localhost:%d" % self.cluster.nodes[1].grpc_port,
-            "--database=/Root",
-            "export",
-            "s3",
-            "--s3-endpoint",
-            s3_endpoint,
-            "--bucket",
-            s3_bucket,
-            "--access-key",
-            s3_access_key,
-            "--secret-key",
-            s3_secret_key,
-            "--item",
-            "src=/Root,dst=Root"
-        ]
-
-        yatest.common.execute(export_command, wait=True, stdout=self.output_f, stderr=self.output_f)
+        with ydb.SessionPool(self.driver, size=1) as pool:
+            with pool.checkout() as session:
+                session.execute_scheme(
+                    "create table `sample_table` (id Uint64 NOT NULL, value Uint64, payload Utf8, income Decimal(22,9), PRIMARY KEY(id)) WITH (STORE = COLUMN,AUTO_PARTITIONING_BY_SIZE = ENABLED, AUTO_PARTITIONING_PARTITION_SIZE_MB = 1);"
+                )
+    
+    def create_table_row(self):
+        session = ydb.retry_operation_sync(lambda: self.driver.table_client.session().create())
+        with ydb.SessionPool(self.driver, size=1) as pool:
+            with pool.checkout() as session:
+                session.execute_scheme(
+                    "create table `sample_table` (id Uint64, value Uint64, payload Utf8, income Decimal(22,9), PRIMARY KEY(id)) WITH (AUTO_PARTITIONING_BY_SIZE = ENABLED, AUTO_PARTITIONING_PARTITION_SIZE_MB = 1);"
+                    )
+    
+    def log_node_versions(self):
+        for node_id, node in enumerate(self.cluster.nodes.values()):
+            node.get_config_version()
+            get_version_command = [
+                yatest.common.binary_path(os.getenv("YDB_CLI_BINARY")),
+                "--verbose",
+                "--endpoint",
+                self.endpoint,
+                "--database=/Root",
+                "yql",
+                "--script",
+                f'select version() as node_{node_id}_version'
+            ]
+            yatest.common.execute(get_version_command, wait=True, stdout=self.output_f, stderr=self.output_f)
+    
+    def exec_query(self, query: str):
+        command = [
+                yatest.common.binary_path(os.getenv("YDB_CLI_BINARY")),
+                "--verbose",
+                "-e",
+                 self.endpoint,
+                "-d"
+                "/Root",
+                "yql",
+                "--script",
+                f"{query}"
+            ]
+        yatest.common.execute(command, wait=True, stdout=self.output_f, stderr=self.output_f)
+        
+    def change_cluster_version(self,new_version='next_version'):
+        version_id = None
+        if new_version == 'next_version':
+            version_id = 2
+        elif new_version == 'combined':
+            version_id = None
+            
+        self.cluster.change_node_version(version_id=version_id)
+        time.sleep(180)
+        self.log_node_versions()
+    
+    def log_database_scheme(self):
+        for node_id, node in enumerate(self.cluster.nodes.values()):
+            node.get_config_version()
+            get_scheme_command = [
+                yatest.common.binary_path(os.getenv("YDB_CLI_BINARY")),
+                "--verbose",
+                "-e",
+                self.endpoint,
+                "-d"
+                "/Root",
+                "scheme",
+                "ls"
+            ]
+            yatest.common.execute(get_scheme_command, wait=True, stdout=self.output_f, stderr=self.output_f)
+    
+    def log_nodes_version(self):
+        for node_id, node in enumerate(self.cluster.nodes.values()):
+            node.get_config_version()
+            get_version_command = [
+                yatest.common.binary_path(os.getenv("YDB_CLI_BINARY")),
+                "--verbose",
+                "-e",
+                "grpc://localhost:%d" % node.grpc_port,
+                "-d"
+                "/Root",
+                "scheme",
+                "ls"
+ 
+            ]
+            yatest.common.execute(get_version_command, wait=True, stdout=self.output_f, stderr=self.output_f)
+    
+    @pytest.mark.parametrize("version_change_to", ['combined','next_version'])
+    def test_simple(self,version_change_to):
+        self.create_table_row()
+        self.read_update_data()
+        self.exec_query('select count(*) from `sample_table`')
+        time.sleep(10)
+        self.log_nodes_version()
+        self.exec_query('select count(*) from `sample_table`')
+        
+        self.change_cluster_version(new_version=version_change_to)
+        
+        self.log_database_scheme()
+        self.exec_query('select count(*) from `sample_table`')
+        self.read_update_data(iteration_count=2)
+        self.exec_query('select count(*) from `sample_table`')
+    
+    @pytest.mark.parametrize("version_change_to", ['combined','next_version'])
+    def test_simple_column(self,version_change_to):
+        self.create_table_column()
+        self.read_update_data()
+        self.exec_query('select count(*) from `sample_table`')
+        time.sleep(10)
+        self.log_nodes_version()
+        self.exec_query('select count(*) from `sample_table`')
+        
+        self.change_cluster_version(new_version=version_change_to)
+        
+        self.log_database_scheme()
+        self.exec_query('select count(*) from `sample_table`')
+        self.read_update_data(iteration_count=2)
+        self.exec_query('select count(*) from `sample_table`')

--- a/ydb/tests/functional/compatibility/test_stress.py
+++ b/ydb/tests/functional/compatibility/test_stress.py
@@ -12,18 +12,14 @@ from ydb.tests.library.common.types import Erasure
 from ydb.tests.stress.simple_queue.workload import Workload
 
 last_stable_binary_path = yatest.common.binary_path("ydb/tests/library/compatibility/ydbd-last-stable")
-prev_stable_binary_path = yatest.common.binary_path("ydb/tests/library/compatibility/ydbd-prev-stable")
 current_binary_path = kikimr_driver_path()
 
 all_binary_combinations = [
-    [prev_stable_binary_path],
     [last_stable_binary_path],
     [current_binary_path],
     [last_stable_binary_path, current_binary_path],
-    [prev_stable_binary_path, last_stable_binary_path],
-    [prev_stable_binary_path, current_binary_path],
 ]
-all_binary_combinations_ids = ["prev_stable","last_stable", "current", "last_stable_to_current","prev_stable_to_last_stable","prev_stable_to_current"]
+all_binary_combinations_ids = ["last_stable", "current", "mixed"]
 
 
 class TestStress(object):
@@ -42,7 +38,7 @@ class TestStress(object):
         )
 
         self.cluster = KiKiMR(self.config)
-        self.cluster.start(version_id=1)
+        self.cluster.start()
         self.endpoint = "%s:%s" % (self.cluster.nodes[1].host, self.cluster.nodes[1].port)
         output_path = yatest.common.test_output_path()
         self.output_f = open(os.path.join(output_path, "out.log"), "w")
@@ -67,19 +63,7 @@ class TestStress(object):
     @pytest.mark.parametrize("store_type", ["row", "column"])
     def test_log(self, store_type):
         timeout_scale = 60
-        for node_id, node in enumerate(self.cluster.nodes.values()):
-            node.get_config_version()
-            get_version_command = [
-                yatest.common.binary_path(os.getenv("YDB_CLI_BINARY")),
-                "--verbose",
-                "--endpoint",
-                "grpc://localhost:%d" % node.grpc_port,
-                "--database=/Root",
-                "yql",
-                "--script",
-                f'select version() as node_{node_id}_version'
-            ]
-            yatest.common.execute(get_version_command, wait=True, stdout=self.output_f, stderr=self.output_f)
+
         upload_commands = [
             # bulk upsert workload
             self.get_command_prefix_log(subcmds=["run", "bulk_upsert"], path=store_type)
@@ -88,8 +72,8 @@ class TestStress(object):
             self.get_command_prefix_log(subcmds=["run", "upsert"], path=store_type)
             + ["--seconds", str(timeout_scale), "--threads", "10"],
             # insert workload
-            #self.get_command_prefix_log(subcmds=["run", "insert"], path=store_type)
-            #+ ["--seconds", str(timeout_scale), "--threads", "10"],
+            self.get_command_prefix_log(subcmds=["run", "insert"], path=store_type)
+            + ["--seconds", str(timeout_scale), "--threads", "10"],
         ]
         # init
         yatest.common.execute(
@@ -130,7 +114,7 @@ class TestStress(object):
             stdout=self.output_f,
             stderr=self.output_f,
         )
-        self.cluster.change_node_version(version_id=2)
+
         for i, command in enumerate(upload_commands):
             yatest.common.execute(
                 command,
@@ -140,19 +124,6 @@ class TestStress(object):
             )
 
         select.wait()
-        for node_id, node in enumerate(self.cluster.nodes.values()):
-            node.get_config_version()
-            get_version_command = [
-                yatest.common.binary_path(os.getenv("YDB_CLI_BINARY")),
-                "--verbose",
-                "--endpoint",
-                "grpc://localhost:%d" % node.grpc_port,
-                "--database=/Root",
-                "yql",
-                "--script",
-                f'select version() as node_{node_id}_version'
-            ]
-            yatest.common.execute(get_version_command, wait=True, stdout=self.output_f, stderr=self.output_f)
 
     @pytest.mark.skip(reason="Too huge logs")
     @pytest.mark.parametrize("store_type", ["row", "column"])

--- a/ydb/tests/functional/compatibility/test_stress.py
+++ b/ydb/tests/functional/compatibility/test_stress.py
@@ -12,14 +12,16 @@ from ydb.tests.library.common.types import Erasure
 from ydb.tests.stress.simple_queue.workload import Workload
 
 last_stable_binary_path = yatest.common.binary_path("ydb/tests/library/compatibility/ydbd-last-stable")
+prev_stable_binary_path = yatest.common.binary_path("ydb/tests/library/compatibility/ydbd-prev-stable")
 current_binary_path = kikimr_driver_path()
 
 all_binary_combinations = [
     [last_stable_binary_path],
     [current_binary_path],
     [last_stable_binary_path, current_binary_path],
+    [prev_stable_binary_path, last_stable_binary_path],
 ]
-all_binary_combinations_ids = ["last_stable", "current", "mixed"]
+all_binary_combinations_ids = ["last_stable", "current", "last_stable_to_current","stable_prev_to_last"]
 
 
 class TestStress(object):

--- a/ydb/tests/functional/compatibility/ya.make
+++ b/ydb/tests/functional/compatibility/ya.make
@@ -9,6 +9,7 @@ TEST_SRCS(
 )
 
 SIZE(LARGE)
+
 REQUIREMENTS(cpu:all)
 REQUIREMENTS(ram:all)
 INCLUDE(${ARCADIA_ROOT}/ydb/tests/large.inc)

--- a/ydb/tests/library/compatibility/downloader/__main__.py
+++ b/ydb/tests/library/compatibility/downloader/__main__.py
@@ -9,8 +9,18 @@ from botocore.client import Config
 AWS_ENDPOINT = "https://storage.yandexcloud.net"
 AWS_BUCKET = "ydb-builds"
 
+def download_files(s3_client, bucket, pairs):
+    for remote_src, local_dst in pairs:
+        s3_client.download_file(bucket, remote_src, local_dst)
+        # chmod +x
+        st = os.stat(local_dst)
+        os.chmod(local_dst, st.st_mode | stat.S_IEXEC)
 
 def main():
+    if len(sys.argv) % 2 != 1:
+        print("Usage: python __main__.py <remote_src1> <local_dst1> <remote_src2> <local_dst2> ...")
+        sys.exit(1)
+
     s3_client = boto3.client(
         service_name="s3",
         endpoint_url=AWS_ENDPOINT,
@@ -18,14 +28,9 @@ def main():
     )
 
     s3_bucket = AWS_BUCKET
-    remote_src = sys.argv[1]
-    local_dst = sys.argv[2]
-    s3_client.download_file(s3_bucket, remote_src, local_dst)
+    pairs = list(zip(sys.argv[1::2], sys.argv[2::2]))
 
-    # chmod +x
-    st = os.stat(local_dst)
-    os.chmod(local_dst, st.st_mode | stat.S_IEXEC)
-
+    download_files(s3_client, s3_bucket, pairs)
 
 if __name__ == "__main__":
     main()

--- a/ydb/tests/library/compatibility/ya.make
+++ b/ydb/tests/library/compatibility/ya.make
@@ -1,8 +1,8 @@
 UNION()
 
 RUN_PROGRAM(
-    ydb/tests/library/compatibility/downloader stable-25-1/release/ydbd ydbd-last-stable
-    OUT_NOAUTO ydbd-last-stable
+    ydb/tests/library/compatibility/downloader stable-25-1-1/release/ydbd ydbd-last-stable stable-24-4-4-hotfix/release/ydbd ydbd-prev-stable
+    OUT_NOAUTO ydbd-last-stable ydbd-prev-stable
 )
 
 END()


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

https://storage.yandexcloud.net/ydb-gh-logs/ydb-platform/ydb/Run%20tests/14541298600/ya-dev-compatibility-tests-2-x86-64/try_1/ya-test.html


# 24-4-4> mixed cluster 24-4-4+25-1-1

```
./ya make -ttt --build "relwithdebinfo" -F 'test_compatibility.py::TestCompatibility::test_simple_column[prev_stable_to_last_stable-combined]' ydb/tests/functional/compatibility
```

```
ydb/tests/functional/compatibility/test_compatibility.py:242: in test_simple_column
    self.read_update_data(iteration_count=2)
ydb/tests/functional/compatibility/test_compatibility.py:138: in read_update_data
    assert result[0]['sum_value'] == upsert_count * iteration_count
E   assert 738 ==
```
https://github.com/ydb-platform/ydb/issues/17462

# 25-1-1> 24-4-4



 ```
./ya make -ttt --build "relwithdebinfo" -F 'test_compatibility.py::TestCompatibility::test_simple_column[last_stable_to_prev_stable-next_version]' ydb/tests/functional/compatibility
```

```
VERIFY failed (2025-04-18T13:18:36.285203+0300): tablet_id=72075186224037889;event=initialize_shard;verification=indexInfoOptional;fline=column_engine_logs.cpp:167;
ydb/library/actors/core/log.cpp:747
~TVerifyFormattedRecordWriter(): requirement false failed
0. /-S/util/system/yassert.cpp:83: NPrivate::InternalPanicImpl(int, char const*, char const*, int, int, int, TBasicStringBuf<char, std::__y1::char_traits<char>>, char const*, unsigned long) @ 0xDE4234C
1. /-S/util/system/yassert.cpp:55: NPrivate::Panic(NPrivate::TStaticBuf const&, int, char const*, char const*, char const*, ...) @ 0xDE3D54B
2. /-S/ydb/library/actors/core/log.cpp:747: NActors::TVerifyFormattedRecordWriter::~TVerifyFormattedRecordWriter() @ 0xE993694
3. /-S/ydb/core/tx/columnshard/engines/column_engine_logs.cpp:167: NKikimr::NOlap::TColumnEngineForLogs::RegisterSchemaVersion(NKikimr::NOlap::TSnapshot const&, NKikimrSchemeOp::TColumnTableSchema const&) @ 0x1589AB94
4. /-S/ydb/core/tx/columnshard/engines/column_engine_logs.cpp:38: NKikimr::NOlap::TColumnEngineForLogs::TColumnEngineForLogs(unsigned long, std::__y1::shared_ptr<NKikimr::NOlap::IStoragesManager> const&, NKikimr::NOlap::TSnapshot const&, NKikimrSchemeOp::TColumnTableSchema const&) @ 0x1589817C
5. /-S/contrib/libs/cxxsupp/libcxx/include/__memory/unique_ptr.h:686: std::__y1::__unique_if<NKikimr::NOlap::TColumnEngineForLogs>::__unique_single std::__y1::make_unique[abi:v180000]<NKikimr::NOlap::TColumnEngineForLogs, unsigned long&, std::__y1::shared_ptr<NKikimr::NOlap::IStoragesManager>&, NKikimr::NOlap::TSnapshot, NKikimrSchemeOp::TColumnTableSchema const&>(unsigned long&, std::__y1::shared_ptr<NKikimr::NOlap::IStoragesManager>&, NKikimr::NOlap::TSnapshot&&, NKikimrSchemeOp::TColumnTableSchema const&) @ 0x15AF8859
6. /-S/ydb/core/tx/columnshard/tables_manager.cpp:179: NKikimr::NColumnShard::TTablesManager::InitFromDB(NKikimr::NIceDb::TNiceDb&) @ 0x15AF8859
7. /-S/ydb/core/tx/columnshard/normalizer/portion/normalizer.cpp:26: NKikimr::NOlap::TPortionsNormalizerBase::DoInit(NKikimr::NOlap::TNormalizationController const&, NKikimr::NTabletFlatExecutor::TTransactionContext&) @ 0x1597A617
8. /-S/ydb/core/tx/columnshard/normalizer/abstract/abstract.cpp:139: NKikimr::NOlap::TNormalizationController::INormalizerComponent::Init(NKikimr::NOlap::TNormalizationController const&, NKikimr::NTabletFlatExecutor::TTransactionContext&) @ 0x15976477
9. /-S/ydb/core/tx/columnshard/columnshard__init.cpp:288: NKikimr::NColumnShard::TTxUpdateSchema::Execute(NKikimr::NTabletFlatExecutor::TTransactionContext&, NActors::TActorContext const&) @ 0x15A60655
10. /-S/ydb/core/tablet_flat/flat_executor.cpp:1730: NKikimr::NTabletFlatExecutor::TExecutor::ExecuteTransaction(TAutoPtr<NKikimr::NTabletFlatExecutor::TSeat, TDelete>, NActors::TActorContext const&) @ 0x1020BA18
11. /-S/ydb/core/tablet_flat/flat_executor.cpp:2651: NKikimr::NTabletFlatExecutor::TExecutor::Handle(TAutoPtr<NActors::TEventHandle<NKikimr::NTabletFlatExecutor::TExecutor::TEvPrivate::TEvActivateExecution>, TDelete>&, NActors::TActorContext const&) @ 0x10217584
12. /-S/ydb/core/tablet_flat/flat_executor.cpp:3975: NKikimr::NTabletFlatExecutor::TExecutor::StateWork(TAutoPtr<NActors::IEventHandle, TDelete>&) @ 0x101FB75D
13. /-S/ydb/library/actors/core/executor_thread.cpp:251: NActors::TGenericExecutorThread::TProcessingResult NActors::TGenericExecutorThread::Execute<NActors::TMailboxTable::TReadAsFilledMailbox>(NActors::TMailboxTable::TReadAsFilledMailbox*, unsigned int, bool) @ 0xE979228
14. /-S/ydb/library/actors/core/executor_thread.cpp:441: NActors::TGenericExecutorThread::ProcessExecutorPool(NActors::IExecutorPool*)::$_0::operator()(unsigned int, bool) const @ 0xE96E442
15. /-S/ydb/library/actors/core/executor_thread.cpp:493: NActors::TGenericExecutorThread::ProcessExecutorPool(NActors::IExecutorPool*) @ 0xE96DE29
16. /-S/ydb/library/actors/core/executor_thread.cpp:524: NActors::TExecutorThread::ThreadProc() @ 0xE96EBC6
17. /-S/util/system/thread.cpp:244: (anonymous namespace)::TPosixThread::ThreadProxy(void*) @ 0xDE46589
18. /build/glibc-FcRMwW/glibc-2.31/nptl/pthread_create.c:477: start_thread @ 0x7FCBEDB57608
19. ../sysdeps/unix/sysv/linux/x86_64/clone.S:95: ?? @ 0x7FCBEDA77352
Daemon failed with message: Unexpectedly finished before stop.
Process exit_code = -6.
Stdout file name: 
/home/kirrysin/.ya/build/build_root/da7x/000008/ydb/tests/functional/compatibility/test-results/py3test/testing_out_stuff/test_compatibility.py.TestCompatibility.test_simple_column.last_stable_to_prev_stable/cluster/node_6/stdout
Stderr file name: 
/home/kirrysin/.ya/build/build_root/da7x/000008/ydb/tests/functional/compatibility/test-results/py3test/testing_out_stuff/test_compatibility.py.TestCompatibility.test_simple_column.last_stable_to_prev_stable/cluster/node_6/stderr
Stderr content:

GRpc memory quota was set but disabled due to issues with grpc quoter, to enable it use EnableGRpcMemoryQuota option
Current KQP shutdown state: spent 0 seconds, not started yet
FALLBACK_ACTOR_LOGGING;priority=WARN;component=332;fline=abstract.cpp:105;event=AbortEmergency;reason=TCompactedWriteController destructed with WriteIndexEv and WriteIndexEv->IndexChanges;prev_reason=;
FALLBACK_ACTOR_LOGGING;priority=WARN;component=332;fline=manager.cpp:51;message=aborted data locks manager;
FALLBACK_ACTOR_LOGGING;priority=WARN;component=332;fline=abstract.cpp:105;event=AbortEmergency;reason=TCompactedWriteController destructed with WriteIndexEv and WriteIndexEv->IndexChanges;prev_reason=;

Unknown grpc service "tablet_service" was not enabled!
```

https://github.com/ydb-platform/ydb/issues/17433

# all tests with main binary
```
2025-04-19 07:52:42,560 - DEBUG - ya.test - execute: Executing '('/home/runner/.ya/build/build_root/tzsz/000023/ydb/tests/library/compatibility/ydbd-last-stable', 'server', '--suppress-version-check', '--yaml-config=/home/runner/.ya/build/build_root/tzsz/000023/ydb/tests/functional/compatibility/test-results/py3test/testing_out_stuff/test_compatibility.py.TestCompatibility.test_simple.current_to_last_stable-combined/cluster/kikimr_configs/config.yaml', '--node=1', '--log-file-name=/home/runner/.ya/build/build_root/tzsz/000023/ydb/tests/functional/compatibility/test-results/py3test/testing_out_stuff/test_compatibility.py.TestCompatibility.test_simple.current_to_last_stable-combined/cluster/node_1/logfile_b9pp5d74.log', '--grpc-port=10135', '--mon-port=3882', '--ic-port=26449')' in '/home/runner/.ya/build/build_root/tzsz/000023/ydb/tests/functional/compatibility/test-results/py3test/testing_out_stuff/test_compatibility.py.TestCompatibility.test_simple.current_to_last_stable-combined/cluster/node_1' (no wait)
2025-04-19 07:52:42,561 - DEBUG - ya.test - execute: Command pid: 6651
2025-04-19 07:52:42,561 - INFO - ydb.tests.library.harness.kikimr_runner - start: Started node localhost:10135/1
2025-04-19 07:52:42,561 - DEBUG - ya.test - execute: Executing '('/home/runner/.ya/build/build_root/tzsz/000023/ydb/apps/ydbd/ydbd', 'server', '--suppress-version-check', '--yaml-config=/home/runner/.ya/build/build_root/tzsz/000023/ydb/tests/functional/compatibility/test-results/py3test/testing_out_stuff/test_compatibility.py.TestCompatibility.test_simple.current_to_last_stable-combined/cluster/kikimr_configs/config.yaml', '--node=2', '--log-file-name=/home/runner/.ya/build/build_root/tzsz/000023/ydb/tests/functional/compatibility/test-results/py3test/testing_out_stuff/test_compatibility.py.TestCompatibility.test_simple.current_to_last_stable-combined/cluster/node_2/logfile_j7v8prj1.log', '--grpc-port=2089', '--mon-port=2086', '--ic-port=20298')' in '/home/runner/.ya/build/build_root/tzsz/000023/ydb/tests/functional/compatibility/test-results/py3test/testing_out_stuff/test_compatibility.py.TestCompatibility.test_simple.current_to_last_stable-combined/cluster/node_2' (no wait)
2025-04-19 07:52:42,562 - DEBUG - ya.test - execute: Command pid: 6652
2025-04-19 07:52:42,563 - INFO - ydb.tests.library.harness.kikimr_runner - start: Started node localhost:2089/2
2025-04-19 07:52:42,563 - DEBUG - ya.test - execute: Executing '('/home/runner/.ya/build/build_root/tzsz/000023/ydb/tests/library/compatibility/ydbd-last-stable', 'server', '--suppress-version-check', '--yaml-config=/home/runner/.ya/build/build_root/tzsz/000023/ydb/tests/functional/compatibility/test-results/py3test/testing_out_stuff/test_compatibility.py.TestCompatibility.test_simple.current_to_last_stable-combined/cluster/kikimr_configs/config.yaml', '--node=3', '--log-file-name=/home/runner/.ya/build/build_root/tzsz/000023/ydb/tests/functional/compatibility/test-results/py3test/testing_out_stuff/test_compatibility.py.TestCompatibility.test_simple.current_to_last_stable-combined/cluster/node_3/logfile_j50ppnxu.log', '--grpc-port=18006', '--mon-port=13093', '--ic-port=11884')' in '/home/runner/.ya/build/build_root/tzsz/000023/ydb/tests/functional/compatibility/test-results/py3test/testing_out_stuff/test_compatibility.py.TestCompatibility.test_simple.current_to_last_stable-combined/cluster/node_3' (no wait)
2025-04-19 07:52:42,564 - DEBUG - ya.test - execute: Command pid: 6653
2025-04-19 07:52:42,564 - INFO - ydb.tests.library.harness.kikimr_runner - start: Started node localhost:18006/3
2025-04-19 07:52:42,565 - DEBUG - ya.test - execute: Executing '('/home/runner/.ya/build/build_root/tzsz/000023/ydb/apps/ydbd/ydbd', 'server', '--suppress-version-check', '--yaml-config=/home/runner/.ya/build/build_root/tzsz/000023/ydb/tests/functional/compatibility/test-results/py3test/testing_out_stuff/test_compatibility.py.TestCompatibility.test_simple.current_to_last_stable-combined/cluster/kikimr_configs/config.yaml', '--node=4', '--log-file-name=/home/runner/.ya/build/build_root/tzsz/000023/ydb/tests/functional/compatibility/test-results/py3test/testing_out_stuff/test_compatibility.py.TestCompatibility.test_simple.current_to_last_stable-combined/cluster/node_4/logfile_rh7h5jwb.log', '--grpc-port=17729', '--mon-port=23780', '--ic-port=5077')' in '/home/runner/.ya/build/build_root/tzsz/000023/ydb/tests/functional/compatibility/test-results/py3test/testing_out_stuff/test_compatibility.py.TestCompatibility.test_simple.current_to_last_stable-combined/cluster/node_4' (no wait)
2025-04-19 07:52:42,565 - DEBUG - ya.test - execute: Command pid: 6654
2025-04-19 07:52:42,566 - INFO - ydb.tests.library.harness.kikimr_runner - start: Started node localhost:17729/4
2025-04-19 07:52:42,566 - DEBUG - ya.test - execute: Executing '('/home/runner/.ya/build/build_root/tzsz/000023/ydb/tests/library/compatibility/ydbd-last-stable', 'server', '--suppress-version-check', '--yaml-config=/home/runner/.ya/build/build_root/tzsz/000023/ydb/tests/functional/compatibility/test-results/py3test/testing_out_stuff/test_compatibility.py.TestCompatibility.test_simple.current_to_last_stable-combined/cluster/kikimr_configs/config.yaml', '--node=5', '--log-file-name=/home/runner/.ya/build/build_root/tzsz/000023/ydb/tests/functional/compatibility/test-results/py3test/testing_out_stuff/test_compatibility.py.TestCompatibility.test_simple.current_to_last_stable-combined/cluster/node_5/logfile_u1wb7ygf.log', '--grpc-port=23352', '--mon-port=12047', '--ic-port=2986')' in '/home/runner/.ya/build/build_root/tzsz/000023/ydb/tests/functional/compatibility/test-results/py3test/testing_out_stuff/test_compatibility.py.TestCompatibility.test_simple.current_to_last_stable-combined/cluster/node_5' (no wait)
2025-04-19 07:52:42,567 - DEBUG - ya.test - execute: Command pid: 6655
2025-04-19 07:52:42,567 - INFO - ydb.tests.library.harness.kikimr_runner - start: Started node localhost:23352/5
2025-04-19 07:52:42,567 - DEBUG - ya.test - execute: Executing '('/home/runner/.ya/build/build_root/tzsz/000023/ydb/apps/ydbd/ydbd', 'server', '--suppress-version-check', '--yaml-config=/home/runner/.ya/build/build_root/tzsz/000023/ydb/tests/functional/compatibility/test-results/py3test/testing_out_stuff/test_compatibility.py.TestCompatibility.test_simple.current_to_last_stable-combined/cluster/kikimr_configs/config.yaml', '--node=6', '--log-file-name=/home/runner/.ya/build/build_root/tzsz/000023/ydb/tests/functional/compatibility/test-results/py3test/testing_out_stuff/test_compatibility.py.TestCompatibility.test_simple.current_to_last_stable-combined/cluster/node_6/logfile_jm8lc151.log', '--grpc-port=25745', '--mon-port=11386', '--ic-port=3742')' in '/home/runner/.ya/build/build_root/tzsz/000023/ydb/tests/functional/compatibility/test-results/py3test/testing_out_stuff/test_compatibility.py.TestCompatibility.test_simple.current_to_last_stable-combined/cluster/node_6' (no wait)
2025-04-19 07:52:42,568 - DEBUG - ya.test - execute: Command pid: 6656
2025-04-19 07:52:42,568 - INFO - ydb.tests.library.harness.kikimr_runner - start: Started node localhost:25745/6
2025-04-19 07:52:42,569 - DEBUG - ya.test - execute: Executing '('/home/runner/.ya/build/build_root/tzsz/000023/ydb/tests/library/compatibility/ydbd-last-stable', 'server', '--suppress-version-check', '--yaml-config=/home/runner/.ya/build/build_root/tzsz/000023/ydb/tests/functional/compatibility/test-results/py3test/testing_out_stuff/test_compatibility.py.TestCompatibility.test_simple.current_to_last_stable-combined/cluster/kikimr_configs/config.yaml', '--node=7', '--log-file-name=/home/runner/.ya/build/build_root/tzsz/000023/ydb/tests/functional/compatibility/test-results/py3test/testing_out_stuff/test_compatibility.py.TestCompatibility.test_simple.current_to_last_stable-combined/cluster/node_7/logfile_h92dxzpz.log', '--grpc-port=24549', '--mon-port=19803', '--ic-port=6503')' in '/home/runner/.ya/build/build_root/tzsz/000023/ydb/tests/functional/compatibility/test-results/py3test/testing_out_stuff/test_compatibility.py.TestCompatibility.test_simple.current_to_last_stable-combined/cluster/node_7' (no wait)
2025-04-19 07:52:42,570 - DEBUG - ya.test - execute: Command pid: 6657
2025-04-19 07:52:42,570 - INFO - ydb.tests.library.harness.kikimr_runner - start: Started node localhost:24549/7
2025-04-19 07:52:42,570 - DEBUG - ya.test - execute: Executing '('/home/runner/.ya/build/build_root/tzsz/000023/ydb/apps/ydbd/ydbd', 'server', '--suppress-version-check', '--yaml-config=/home/runner/.ya/build/build_root/tzsz/000023/ydb/tests/functional/compatibility/test-results/py3test/testing_out_stuff/test_compatibility.py.TestCompatibility.test_simple.current_to_last_stable-combined/cluster/kikimr_configs/config.yaml', '--node=8', '--log-file-name=/home/runner/.ya/build/build_root/tzsz/000023/ydb/tests/functional/compatibility/test-results/py3test/testing_out_stuff/test_compatibility.py.TestCompatibility.test_simple.current_to_last_stable-combined/cluster/node_8/logfile_vd_ahzla.log', '--grpc-port=7262', '--mon-port=2823', '--ic-port=30111')' in '/home/runner/.ya/build/build_root/tzsz/000023/ydb/tests/functional/compatibility/test-results/py3test/testing_out_stuff/test_compatibility.py.TestCompatibility.test_simple.current_to_last_stable-combined/cluster/node_8' (no wait)
2025-04-19 07:52:42,571 - DEBUG - ya.test - execute: Command pid: 6658
2025-04-19 07:52:42,571 - INFO - ydb.tests.library.harness.kikimr_runner - start: Started node localhost:7262/8
2025-04-19 07:52:42,572 - DEBUG - ya.test - execute: Executing '('/home/runner/.ya/build/build_root/tzsz/000023/ydb/tests/library/compatibility/ydbd-last-stable', 'server', '--suppress-version-check', '--yaml-config=/home/runner/.ya/build/build_root/tzsz/000023/ydb/tests/functional/compatibility/test-results/py3test/testing_out_stuff/test_compatibility.py.TestCompatibility.test_simple.current_to_last_stable-combined/cluster/kikimr_configs/config.yaml', '--node=9', '--log-file-name=/home/runner/.ya/build/build_root/tzsz/000023/ydb/tests/functional/compatibility/test-results/py3test/testing_out_stuff/test_compatibility.py.TestCompatibility.test_simple.current_to_last_stable-combined/cluster/node_9/logfile_h86b5zk9.log', '--grpc-port=11590', '--mon-port=18155', '--ic-port=28781')' in '/home/runner/.ya/build/build_root/tzsz/000023/ydb/tests/functional/compatibility/test-results/py3test/testing_out_stuff/test_compatibility.py.TestCompatibility.test_simple.current_to_last_stable-combined/cluster/node_9' (no wait)
2025-04-19 07:52:42,573 - DEBUG - ya.test - execute: Command pid: 6659
2025-04-19 07:52:42,573 - INFO - ydb.tests.library.harness.kikimr_runner - start: Started node localhost:11590/9
2025-04-19 07:52:43,875 - DEBUG - ydb.resolver.DiscoveryEndpointsResolver - context_resolve: Resolving endpoints for database /Root
2025-04-19 07:52:43,876 - DEBUG - ydb.connection - _prepare_call: RpcState(ListEndpoints, ab152d89-93d2-4a5d-bdb3-2196b3fedb66, localhost:10135): creating call state
2025-04-19 07:52:43,876 - DEBUG - ydb.connection - _log_request: RpcState(ListEndpoints, ab152d89-93d2-4a5d-bdb3-2196b3fedb66, localhost:10135): request = { database: "/Root" }
2025-04-19 07:52:43,878 - DEBUG - ydb.connection - _log_response: RpcState(ListEndpoints, ab152d89-93d2-4a5d-bdb3-2196b3fedb66, localhost:10135): response = { operation { ready: true status: UNAVAILABLE issues { message: "Database resolve failed with no certain result" issue_code: 200400 severity: 1 } } }
2025-04-19 07:52:43,878 - DEBUG - ydb.resolver.DiscoveryEndpointsResolver - _add_debug_details: Failed to resolve endpoints for database /Root. Endpoint: "localhost:10135". Error details:
 message: "Database resolve failed with no certain result" issue_code: 200400 severity: 1 (server_code: 400050)
2025-04-19 07:52:43,878 - INFO - ydb.connection - close: Closing channel for endpoint localhost:10135
```

### Changelog category <!-- remove all except one -->

* Not for changelog (changelog entry is not required)

### Description for reviewers <!-- (optional) description for those who read this PR -->

...
