### PR TITLE
The PQ tablet does not receive a TEvTxCalcPredicateResult (#17497)

### DIFF
--- a/ydb/core/persqueue/partition.cpp
+++ b/ydb/core/persqueue/partition.cpp
@@ -2135,7 +2135,7 @@ void TPartition::AnswerCurrentReplies(const TActorContext& ctx)
 TPartition::EProcessResult TPartition::PreProcessUserActionOrTransaction(TSimpleSharedPtr<TTransaction>& t)
 {
     auto result = EProcessResult::Continue;
-    if (t->SupportivePartitionActor && !t->WriteInfo) { // Pending for write info
+    if (t->SupportivePartitionActor && !t->WriteInfo && !t->WriteInfoApplied) { // Pending for write info
         return EProcessResult::NotReady;
     }
     if (t->WriteInfo && !t->WriteInfoApplied) { //Recieved write info but not applied

--- a/ydb/core/persqueue/ut/partition_ut.cpp
+++ b/ydb/core/persqueue/ut/partition_ut.cpp
@@ -306,6 +306,15 @@ protected:
     void WaitForWriteError(ui64 cookie, NPersQueue::NErrorCode::EErrorCode errorCode);
     void WaitForDeletePartitionDone();
 
+    void SendCalcPredicate(ui64 step,
+                           ui64 txId,
+                           const TActorId& suppPartitionId);
+    void WaitForGetWriteInfoRequest();
+    void SendGetWriteInfoError(ui32 internalPartitionId,
+                               TString message,
+                               const TActorId& suppPartitionId);
+    void WaitForCalcPredicateResult(ui64 txId, bool predicate);
+
     TMaybe<TTestContext> Ctx;
     TMaybe<TFinalizer> Finalizer;
 
@@ -2379,6 +2388,47 @@ void TPartitionFixture::CmdChangeOwner(ui64 cookie, const TString& sourceId, TDu
     ownerCookie = event->Response->GetPartitionResponse().GetCmdGetOwnershipResult().GetOwnerCookie();
 }
 
+void TPartitionFixture::SendCalcPredicate(ui64 step,
+                                          ui64 txId,
+                                          const TActorId& suppPartitionId)
+{
+    SendCalcPredicate(step, txId, "", 0, 0, suppPartitionId);
+}
+
+void TPartitionFixture::WaitForGetWriteInfoRequest()
+{
+    auto event = Ctx->Runtime->GrabEdgeEvent<TEvPQ::TEvGetWriteInfoRequest>();
+    UNIT_ASSERT(event != nullptr);
+    //UNIT_ASSERT_VALUES_EQUAL(event->OriginalPartition, ActorId);
+}
+
+void TPartitionFixture::SendGetWriteInfoError(ui32 internalPartitionId,
+                                              TString message,
+                                              const TActorId& suppPartitionId)
+{
+    auto event = MakeHolder<TEvPQ::TEvGetWriteInfoError>(internalPartitionId,
+                                                         std::move(message));
+    //event->SupportivePartition = suppPartitionId;
+
+    Ctx->Runtime->SingleSys()->Send(new IEventHandle(ActorId, suppPartitionId, event.Release()));
+}
+
+void TPartitionFixture::WaitForCalcPredicateResult(ui64 txId, bool predicate)
+{
+    while (true) {
+        TAutoPtr<IEventHandle> handle;
+        auto events =
+            Ctx->Runtime->GrabEdgeEvents<TEvPQ::TEvTxCalcPredicateResult, TEvKeyValue::TEvRequest>(handle,
+                                                                                                   TDuration::Seconds(1));
+        if (std::get<TEvKeyValue::TEvRequest*>(events)) {
+            SendDiskStatusResponse(nullptr);
+        } else if (auto* event = std::get<TEvPQ::TEvTxCalcPredicateResult*>(events)) {
+            UNIT_ASSERT_VALUES_EQUAL(event->TxId, txId);
+            UNIT_ASSERT_VALUES_EQUAL(event->Predicate, predicate);
+            break;
+        }
+    }
+}
 
 Y_UNIT_TEST_F(ReserveSubDomainOutOfSpace, TPartitionFixture)
 {
@@ -3392,6 +3442,20 @@ Y_UNIT_TEST_F(The_DeletePartition_Message_Arrives_Before_The_ApproveWriteQuota_M
     WaitForWriteError(1, NPersQueue::NErrorCode::ERROR);
     WaitForDeletePartitionDone();
     WaitForWriteError(2, NPersQueue::NErrorCode::ERROR);
+}
+
+Y_UNIT_TEST_F(After_TEvGetWriteInfoError_Comes_TEvTxCalcPredicateResult, TPartitionFixture)
+{
+    const TPartitionId partitionId{1};
+    const ui64 step = 12345;
+    const ui64 txId = 67890;
+
+    CreatePartition({.Partition=partitionId});
+
+    SendCalcPredicate(step, txId, Ctx->Edge);
+    WaitForGetWriteInfoRequest();
+    SendGetWriteInfoError(31415, "error", Ctx->Edge);
+    WaitForCalcPredicateResult(txId, false);
 }
 
 } // End of suite


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

Moved changes from #17497

The SDK user writes messages to the topic in a transaction. It does not wait for confirmation that the messages have been recorded and calls Commit. The processing of this and the following transactions in the PQ tablet stops.

When processing the `UserActionAndTransactionEvents` queue, it was not taken into account that the `TEvGetWriteInfoError` message was received. As a result, the transaction remained at the head of the queue and blocked the processing of other operations.

Issue #17499

### Changelog category <!-- remove all except one -->

* Bugfix 

### Description for reviewers <!-- (optional) description for those who read this PR -->

...
