### PR TITLE
Add skip_with_issue decorator

### DIFF
--- a/ydb/tests/example/test_example.py
+++ b/ydb/tests/example/test_example.py
@@ -72,7 +72,7 @@ class TestExample:
     @link_test_case("#999999998")  # test can be linked with test-case issue in github
     def test_linked_with_testcase(self):
         pass
-    
+
     @skip_with_issue("#999999999")  # test can be skipped with github issue
     def test_skipped_with_issue(self):
         pass

--- a/ydb/tests/example/test_example.py
+++ b/ydb/tests/example/test_example.py
@@ -2,11 +2,12 @@
 from ydb.tests.library.harness.kikimr_runner import KiKiMR
 from ydb.tests.library.harness.kikimr_config import KikimrConfigGenerator
 from ydb.tests.library.common.types import Erasure
+from ydb.tests.library.test_meta import skip_with_issue, link_test_case
 
 import ydb
 
 
-class TestExample(object):
+class TestExample:
     """
     Example for python test
     TODO: change description to yours
@@ -66,4 +67,12 @@ class TestExample(object):
         """
         There can be more than 1 test in the suite
         """
+        pass
+
+    @link_test_case("#999999998")  # test can be linked with test-case issue in github
+    def test_linked_with_testcase(self):
+        pass
+    
+    @skip_with_issue("#999999999")  # test can be skipped with github issue
+    def test_skipped_with_issue(self):
         pass

--- a/ydb/tests/example/ya.make
+++ b/ydb/tests/example/ya.make
@@ -13,6 +13,7 @@ DEPENDS(
 
 PEERDIR(
     ydb/tests/library
+    ydb/tests/library/test_meta
 )
 
 END()

--- a/ydb/tests/library/test_meta/__init__.py
+++ b/ydb/tests/library/test_meta/__init__.py
@@ -2,5 +2,6 @@ import pytest
 
 link_test_case = pytest.mark.test_case
 
+
 def skip_with_issue(issue_id):
     return pytest.mark.skip(reason=issue_id)

--- a/ydb/tests/library/test_meta/__init__.py
+++ b/ydb/tests/library/test_meta/__init__.py
@@ -1,3 +1,4 @@
 import pytest
 
 link_test_case = pytest.mark.test_case
+skip_with_issue = lambda id_: pytest.mark.skip(reason=id_)

--- a/ydb/tests/library/test_meta/__init__.py
+++ b/ydb/tests/library/test_meta/__init__.py
@@ -1,4 +1,4 @@
 import pytest
 
 link_test_case = pytest.mark.test_case
-skip_with_issue = lambda id_: pytest.mark.skip(reason=id_)
+skip_with_issue = lambda issue_id: pytest.mark.skip(reason=issue_id)

--- a/ydb/tests/library/test_meta/__init__.py
+++ b/ydb/tests/library/test_meta/__init__.py
@@ -1,4 +1,6 @@
 import pytest
 
 link_test_case = pytest.mark.test_case
-skip_with_issue = lambda issue_id: pytest.mark.skip(reason=issue_id)
+
+def skip_with_issue(issue_id):
+    return pytest.mark.skip(reason=issue_id)


### PR DESCRIPTION
This PR adds a new decorator, skip_with_issue, to allow tests to be skipped by referencing a GitHub issue

#16416