### PR TITLE
Fix S3 buffer min bytes setting

### DIFF
--- a/ydb/core/tx/datashard/export_s3.h
+++ b/ydb/core/tx/datashard/export_s3.h
@@ -36,7 +36,8 @@ public:
         bufferSettings
             .WithColumns(Columns)
             .WithMaxRows(maxRows)
-            .WithMaxBytes(maxBytes);
+            .WithMaxBytes(maxBytes)
+            .WithMinBytes(minBytes); // S3 API returns EntityTooSmall error if file part is smaller that 5MB: https://docs.aws.amazon.com/AmazonS3/latest/API/API_CompleteMultipartUpload.html
         if (Task.GetEnableChecksums()) {
             bufferSettings.WithChecksum(TS3ExportBufferSettings::Sha256Checksum());
         }
@@ -46,7 +47,6 @@ public:
             break;
         case ECompressionCodec::Zstd:
             bufferSettings
-                .WithMinBytes(minBytes)
                 .WithCompression(TS3ExportBufferSettings::ZstdCompression(Task.GetCompression().GetLevel()));
             break;
         case ECompressionCodec::Invalid:

--- a/ydb/core/tx/datashard/export_s3_buffer.cpp
+++ b/ydb/core/tx/datashard/export_s3_buffer.cpp
@@ -45,6 +45,10 @@ public:
 
     TMaybe<TBuffer> Flush();
 
+    size_t GetReadyOutputBytes() const {
+        return Buffer.Size();
+    }
+
 private:
     enum ECompressionResult {
         CONTINUE,
@@ -324,7 +328,11 @@ void TS3Buffer::Clear() {
 }
 
 bool TS3Buffer::IsFilled() const {
-    if (Buffer.Size() < MinBytes) {
+    size_t outputSize = Buffer.Size();
+    if (Compression) {
+        outputSize = Compression->GetReadyOutputBytes();
+    }
+    if (outputSize < MinBytes) {
         return false;
     }
 

--- a/ydb/core/tx/datashard/export_s3_buffer_ut.cpp
+++ b/ydb/core/tx/datashard/export_s3_buffer_ut.cpp
@@ -1,0 +1,112 @@
+#include "export_s3_buffer.h"
+#include <ydb/core/tx/datashard/export_scan.h>
+
+#include <library/cpp/testing/unittest/registar.h>
+
+#include <util/generic/array_ref.h>
+
+#ifndef KIKIMR_DISABLE_S3_OPS
+
+namespace NKikimr::NDataShard {
+
+class TExportS3BufferFixture : public NUnitTest::TBaseFixture {
+public:
+    void SetUp(NUnitTest::TTestContext&) override {
+        Columns[0] = TUserTable::TUserColumn(NScheme::TTypeInfo(NScheme::NTypeIds::Uint32), "", "key", true);
+        Columns[1] = TUserTable::TUserColumn(NScheme::TTypeInfo(NScheme::NTypeIds::String), "", "value", false);
+    }
+
+    TS3ExportBufferSettings& Settings() {
+        return S3ExportBufferSettings;
+    }
+
+    IExport::TTableColumns& TableColumns() {
+        return Columns;
+    }
+
+    NExportScan::IBuffer& Buffer() {
+        if (!S3ExportBuffer) {
+            TS3ExportBufferSettings settings = S3ExportBufferSettings;
+            settings.WithColumns(Columns);
+            S3ExportBuffer.Reset(CreateS3ExportBuffer(std::move(settings)));
+
+            TVector<ui32> tags;
+            tags.reserve(Columns.size());
+            for (auto&& [tag, _] : Columns) {
+                tags.push_back(tag);
+            }
+            S3ExportBuffer->ColumnsOrder(tags);
+        }
+        return *S3ExportBuffer;
+    }
+
+    bool CollectKeyValue(ui32 k, TStringBuf v) {
+        NTable::IScan::TRow row;
+        row.Init(2);
+        row.Set(0, NKikimr::NTable::ECellOp::Set, NKikimr::TCell::Make(k));
+        row.Set(1, NKikimr::NTable::ECellOp::Set, NKikimr::TCell(v.data(), v.size()));
+        return Buffer().Collect(row);
+    }
+
+    // Tests impl
+    void TestMinBufferSize(ui64 minBufferSize) {
+        for (ui32 i = 0; i < 100; ++i) {
+            UNIT_ASSERT(CollectKeyValue(i, "1111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111"));
+            NExportScan::IBuffer::TStats stats;
+            if (Buffer().IsFilled()) {
+                NActors::IEventBase* event = Buffer().PrepareEvent(false, stats);
+                UNIT_ASSERT(event);
+                auto* evBuffer = dynamic_cast<NKikimr::NDataShard::TEvExportScan::TEvBuffer<TBuffer>*>(event);
+                UNIT_ASSERT(evBuffer);
+                UNIT_ASSERT_GE_C(evBuffer->Buffer.Size(), minBufferSize, "Got buffer size " << evBuffer->Buffer.Size() << ". Iteration: " << i);
+            }
+        }
+    }
+
+public:
+    IExport::TTableColumns Columns;
+    TS3ExportBufferSettings S3ExportBufferSettings;
+    THolder<NExportScan::IBuffer> S3ExportBuffer;
+};
+
+Y_UNIT_TEST_SUITE_F(ExportS3BufferTest, TExportS3BufferFixture) {
+    Y_UNIT_TEST(MinBufferSize) {
+        ui64 minBufferSize = 5000;
+        Settings()
+            .WithMaxRows(2)
+            .WithMinBytes(minBufferSize)
+            .WithMaxBytes(1'000'000);
+
+        TestMinBufferSize(minBufferSize);
+    }
+
+    Y_UNIT_TEST(MinBufferSizeWithCompression) {
+        ui64 minBufferSize = 5000;
+        Settings()
+            .WithCompression(TS3ExportBufferSettings::ZstdCompression(20))
+            .WithMaxRows(2)
+            .WithMinBytes(minBufferSize)
+            .WithMaxBytes(1'000'000);
+
+        TestMinBufferSize(minBufferSize);
+    }
+
+    Y_UNIT_TEST(MinBufferSizeWithCompressionAndEncryption) {
+        ui64 minBufferSize = 5000;
+        Settings()
+            .WithCompression(TS3ExportBufferSettings::ZstdCompression(20))
+            .WithEncryption(TS3ExportBufferSettings::TEncryptionSettings()
+                .WithAlgorithm("AES-256-GCM")
+                .WithIV(NBackup::TEncryptionIV::Generate())
+                .WithKey(NBackup::TEncryptionKey("256 bit test symmetric key bytes")))
+            .WithMaxRows(2)
+            .WithMinBytes(minBufferSize)
+            .WithMaxBytes(1'000'000);
+
+        TestMinBufferSize(minBufferSize);
+    }
+}
+
+} // namespace NKikimr::NDataShard
+
+#endif // KIKIMR_DISABLE_S3_OPS

--- a/ydb/core/tx/datashard/ut_export/ya.make
+++ b/ydb/core/tx/datashard/ut_export/ya.make
@@ -1,0 +1,13 @@
+UNITTEST_FOR(ydb/core/tx/datashard)
+
+PEERDIR(
+    ydb/core/testlib/default
+)
+
+YQL_LAST_ABI_VERSION()
+
+SRCS(
+    export_s3_buffer_ut.cpp
+)
+
+END()

--- a/ydb/core/tx/datashard/ya.make
+++ b/ydb/core/tx/datashard/ya.make
@@ -313,6 +313,7 @@ RECURSE_FOR_TESTS(
     ut_compaction
     ut_data_cleanup
     ut_erase_rows
+    ut_export
     ut_external_blobs
     ut_followers
     ut_incremental_backup

--- a/ydb/core/tx/schemeshard/ut_export/ut_export.cpp
+++ b/ydb/core/tx/schemeshard/ut_export/ut_export.cpp
@@ -521,6 +521,7 @@ namespace {
                             backupTxId = record.GetTxId();
                             // hijack
                             schemeTx.MutableBackup()->MutableScanSettings()->SetRowsBatchSize(1);
+                            schemeTx.MutableBackup()->MutableS3Settings()->MutableLimits()->SetMinWriteBatchSize(1);
                             record.SetTxBody(schemeTx.SerializeAsString());
                         }
 
@@ -1665,6 +1666,7 @@ partitioning_settings {
 
                     if (schemeTx.HasBackup()) {
                         schemeTx.MutableBackup()->MutableScanSettings()->SetRowsBatchSize(1);
+                        schemeTx.MutableBackup()->MutableS3Settings()->MutableLimits()->SetMinWriteBatchSize(1);
                         record.SetTxBody(schemeTx.SerializeAsString());
                     }
 


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

Fix S3 export multipart upload: EntityTooSmall error
https://github.com/ydb-platform/ydb/issues/16873

### Changelog category <!-- remove all except one -->

* Bugfix 

### Description for reviewers <!-- (optional) description for those who read this PR -->

Fix MinBytes setting for export S3 buffer. It must process output bytes in order not to cause EntityTooSmall error while uploading parts to S3