### PR TITLE
Fix for CVE-2023-33460: Memory leak in yajl 2.1.0 with use of yajl_tree_parse function

### DIFF
--- a/contrib/libs/yajl/yajl_tree.c
+++ b/contrib/libs/yajl/yajl_tree.c
@@ -143,7 +143,7 @@ static yajl_val context_pop(context_t *ctx)
     ctx->stack = stack->next;
 
     v = stack->value;
-
+    free (stack->key);
     free (stack);
 
     return (v);
@@ -453,7 +453,14 @@ yajl_val yajl_tree_parse (const char *input,
                                         (const unsigned char *) input,
                                         strlen(input)));
         }
+        while(ctx.stack != NULL) {
+             yajl_val v = context_pop(&ctx);
+             yajl_tree_free(v);
+        }
         yajl_free (handle);
+        //If the requested memory is not released in time, it will cause memory leakage
+        if(ctx.root)
+            yajl_tree_free(ctx.root);
         return NULL;
     }
 


### PR DESCRIPTION
### Changelog entry 
...

### Changelog category
* Bugfix 

### Description for reviewers <!-- (optional) description for those who read this PR -->
This PR fixes a security vulnerability in yajl_tree_parse() that was cloned from yaml but did not receive the security patch. The original issue was reported and fixed under https://github.com/likema/yajl/commit/31531a6e6b5641398237ce15b7e62da02d975fc6.
This PR applies the same patch to eliminate the vulnerability.

References
https://github.com/advisories/GHSA-cqgm-m7h3-xgwm
https://nvd.nist.gov/vuln/detail/CVE-2023-33460
https://github.com/likema/yajl/commit/31531a6e6b5641398237ce15b7e62da02d975fc6
