### PR TITLE
More functionality for the combiner performance test suite

### DIFF
--- a/ydb/core/kqp/tools/combiner_perf/bin/format_markdown.py
+++ b/ydb/core/kqp/tools/combiner_perf/bin/format_markdown.py
@@ -1,0 +1,219 @@
+#!/usr/bin/env python3
+
+import json
+import sys
+import collections
+import base64
+import argparse
+
+def gen_chart(ref_time, graph_time, llvm_time = None):
+    chars = '▏▎▍▌▋▊▉█'
+    fullwidth = chars[-2] # for separators between 1-second blocks
+
+    def draw_line(val, hue, title, comment):
+        val = val / 1000.0
+
+        if hue is None:
+            color = 'darkgray'
+        else:
+            color = f'hsl({hue} 80% 40%)'
+
+        out = f'<div style="color:{color};font-family:monospace;">'
+        if title:
+            out += f'<span style="width:4em;display:inline-block">{title}</span>'
+
+        for _ in range(int(val)):
+            out += fullwidth
+
+        remainder = int(round((val - int(val)) * 7.0))
+        if remainder > 0:
+            out += chars[remainder - 1]
+        if comment:
+            out += '&nbsp;'
+            out += comment
+        out += '</div>\n'
+
+        return out
+
+    out = ''
+    out += draw_line(ref_time, None, 'C++', None)
+
+    if ref_time == 0:
+        hue = None
+    else:
+        hue = 120 - int(120.0 * ((graph_time / ref_time) - 0.5) / 1.5) # Map [0.5, 2] -> [120, 0]
+        hue = max(0, min(hue, 120)) # clamp to the [0, 120] range; hue 0 = red, hue 120 = green
+
+    def add_colored_bar(ref_value, result_value, title):
+        if result_value:
+            shame_ratio = result_value / ref_value
+            comment = 'x %.1f' % shame_ratio
+        else:
+            comment = None
+        return draw_line(result_value, hue, title, comment)
+
+    out += add_colored_bar(ref_time, graph_time, 'Graph')
+    if llvm_time is not None:
+        out += add_colored_bar(ref_time, llvm_time, 'LLVM')
+
+    return out
+
+def sample_rows(sample):
+    return sample['rowsPerRun'] * sample['numRuns']
+
+def format_large_num(num):
+    if num >= 1000000:
+        sf = 1000000.0
+        suffix = 'M'
+    elif num >= 1000:
+        sf = 1000.0
+        suffix = 'K'
+    else:
+        sf = 1
+        suffix = ''
+
+    formatted = '%.02f' % (num / sf)
+    if '.' in formatted:
+        while formatted.endswith('0'):
+            formatted = formatted[:-1]
+        if formatted.endswith('.'):
+            formatted = formatted[:-1]
+    formatted += suffix
+    return formatted
+
+def format_time(ms):
+    if ms is None:
+        return ' '
+    return '%.2f' % (ms / 1000.0)
+
+def format_mem(bytez):
+    return '%.1f' % (bytez / (1024.0 * 1024.0))
+
+def do_merge_llvm(samples):
+    sorted_samples = sorted(samples, key=lambda sample: sample.get('llvm', False))
+    output_samples = []
+    index = {}
+
+    for sample in sorted_samples:
+        is_llvm = sample.get('llvm', False)
+        key = (sample['testName'], sample['numKeys'], sample_rows(sample), sample.get('spilling', False), sample.get('blockSize', 0), sample.get('combinerMemLimit', 0))
+        if key in index and not is_llvm:
+            raise Exception('Attempted to merge two non-LLVM result samples, key = %s' % repr(key))
+        if key not in index and is_llvm:
+            raise Exception('Non-LLVM result sample is missing, key = %s' % repr(key))
+
+        if is_llvm:
+            gen_time = sample['generatorTime']
+            result_time = sample['resultTime']
+            result_time_or_zero = result_time - gen_time if gen_time <= result_time else 0
+            index[key]['llvmCleanTime'] = result_time_or_zero
+        else:
+            index[key] = sample
+            output_samples.append(sample)
+
+    return output_samples
+
+def do_format(merge_llvm):
+    per_section = collections.defaultdict(list)
+
+    all_samples = []
+    for line in sys.stdin:
+        line = line.strip()
+        if not line:
+            continue
+        sample = json.loads(line)
+        all_samples.append(sample)
+
+    if merge_llvm:
+        all_samples = do_merge_llvm(all_samples)
+
+    for sample in all_samples:
+        section_name = (sample['testName'], sample_rows(sample), sample.get('llvm', False), sample.get('spilling', False), sample.get('blockSize', 0), sample.get('combinerMemLimit', 0))
+        per_section[section_name].append(sample)
+
+    for _, samples in per_section.items():
+        combiner_name = samples[0]['testName']
+        num_rows = sample_rows(samples[0])
+        num_rows_formatted = format_large_num(num_rows)
+
+        has_llvm_column = any(('llvmCleanTime' in sample for sample in samples))
+
+        traits = []
+        if samples[0].get('llvm', False):
+            traits.append('LLVM')
+        if samples[0].get('spilling', False):
+            traits.append('spilling')
+        if samples[0].get('blockSize', 0):
+            traits.append(f'{samples[0]["blockSize"]} rows per block')
+        memlimit = samples[0].get('combinerMemLimit', 0)
+        if memlimit and combiner_name == 'WideCombiner':
+            memlimit_formatted = format_mem(memlimit)
+            traits.append(f'{memlimit_formatted} MB RAM limit')
+        traits.append(f'{num_rows_formatted} input rows')
+        traits_str = ', '.join(traits)
+
+        own_times = []
+        for sample in samples:
+            own_times.append(sample['generatorTime'])
+        own_times.sort()
+        median_own_time = format_time(own_times[len(own_times) // 2])
+
+        print(f'##### {combiner_name}, {traits_str}\n')
+        print(f'Input generator elapsed time: {median_own_time}с\n')
+        print('::: html\n<table><tr>\n')
+        headers = [
+            'Shame ratio',
+            'Distinct keys',
+            'Graph time (s)',
+            'Reference C++ impl time (s)',
+        ]
+        if has_llvm_column:
+            headers += [
+                'LLVM time (s)',
+            ]
+        headers += [
+            'MaxRSS delta, MB',
+            'Bytes per key',
+        ]
+        print(''.join(['<th>%s</th>' % item for item in headers]) + '\n')
+
+        for sample in samples:
+            gen_time = sample['generatorTime']
+            result_time = sample['resultTime']
+            ref_time = sample['refTime']
+            result_time_or_zero = result_time - gen_time if gen_time <= result_time else 0
+            ref_time_or_zero = ref_time - gen_time if gen_time <= ref_time else 0
+            llvm_time_or_zero = sample.get('llvmCleanTime', None)
+
+            shame_ratio = 0
+            if ref_time_or_zero > 0:
+                shame_ratio = result_time_or_zero / ref_time_or_zero
+
+            cols = []
+            if llvm_time_or_zero is not None:
+                cols.append(gen_chart(ref_time_or_zero, result_time_or_zero, llvm_time_or_zero))
+            else:
+                cols.append(gen_chart(ref_time_or_zero, result_time_or_zero))
+
+            cols.append(format_large_num(sample['numKeys']))
+            cols.append(format_time(result_time_or_zero))
+            cols.append(format_time(ref_time_or_zero))
+            if has_llvm_column:
+                cols.append(format_time(llvm_time_or_zero))
+            cols.append(format_mem(sample['maxRssDelta']))
+            bytes_per_key = sample['maxRssDelta'] // sample['numKeys']
+
+            cols.append(str(bytes_per_key) if 0 < bytes_per_key < 10000 else ' ')
+            print('<tr>' + ''.join(['<td>%s</td>' % col for col in cols]) + '</tr>\n')
+
+        print('</table>\n:::\n')
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument('--separate-llvm', action='store_true')
+    args = parser.parse_args()
+
+    do_format(not args.separate_llvm)
+
+if __name__ == '__main__':
+    main()

--- a/ydb/core/kqp/tools/combiner_perf/bin/main.cpp
+++ b/ydb/core/kqp/tools/combiner_perf/bin/main.cpp
@@ -1,22 +1,28 @@
+#include <ydb/core/kqp/tools/combiner_perf/subprocess.h>
 #include <ydb/core/kqp/tools/combiner_perf/printout.h>
 #include <ydb/core/kqp/tools/combiner_perf/simple_last.h>
 #include <ydb/core/kqp/tools/combiner_perf/simple.h>
 #include <ydb/core/kqp/tools/combiner_perf/tpch_last.h>
 #include <ydb/core/kqp/tools/combiner_perf/simple_block.h>
 
+#include <library/cpp/getopt/last_getopt.h>
 #include <library/cpp/lfalloc/alloc_profiler/profiler.h>
+#include <library/cpp/json/json_writer.h>
 
+#include <util/string/cast.h>
+#include <util/generic/buffer.h>
 #include <util/stream/output.h>
 #include <util/stream/file.h>
 #include <util/string/printf.h>
 #include <util/system/compiler.h>
+
 
 using NKikimr::NMiniKQL::TRunParams;
 
 class TPrintingResultCollector : public TTestResultCollector
 {
 public:
-    virtual void SubmitTestNameAndParams(const TRunParams& runParams, const char* testName, const std::optional<bool> llvm, const std::optional<bool> spilling) override
+    virtual void SubmitMetrics(const TRunParams& runParams, const TRunResult& result, const char* testName, const std::optional<bool> llvm, const std::optional<bool> spilling) override
     {
         Cout << "------------------------------" << Endl;
         Cout << testName;
@@ -28,112 +34,92 @@ public:
         }
         Cout << Endl;
         Cout << "Data rows total: " << runParams.RowsPerRun << " x " << runParams.NumRuns << Endl;
-        Cout << (runParams.MaxKey + 1) << " distinct numeric keys" << Endl;
+        Cout << runParams.NumKeys << " distinct numeric keys" << Endl;
         Cout << "Block size: " << runParams.BlockSize << Endl;
         Cout << "Long strings: " << (runParams.LongStringKeys ? "yes" : "no") << Endl;
+        Cout << "Combiner mem limit: " << runParams.WideCombinerMemLimit << Endl;
         Cout << Endl;
-    }
 
-    virtual void SubmitTimings(const TDuration& graphTime, const TDuration& referenceTime, const std::optional<TDuration> streamTime) override
-    {
-        Cout << "Graph runtime is: " << graphTime << " vs. reference C++ implementation: " << referenceTime << Endl;
+        Cout << "Graph runtime is: " << result.ResultTime << " vs. reference C++ implementation: " << result.ReferenceTime << Endl;
 
-        if (streamTime.has_value()) {
-            Cout << "Input stream own iteration time: " << *streamTime << Endl;
-            Cout << "Graph time - stream own time = " << (*streamTime <= graphTime ? graphTime - *streamTime : TDuration::Zero()) << Endl;
-            Cout << "C++ implementation time - devnull time = " << (*streamTime <= referenceTime ? referenceTime - *streamTime : TDuration::Zero()) << Endl;
+        if (result.GeneratorTime) {
+            Cout << "Input stream own iteration time: " << result.GeneratorTime << Endl;
+            Cout << "Graph time - stream own time = "
+                 << (result.GeneratorTime <= result.ResultTime ? result.ResultTime - result.GeneratorTime : TDuration::Zero()) << Endl;
+            Cout << "C++ implementation time - devnull time = "
+                 << (result.GeneratorTime <= result.ReferenceTime ? result.ReferenceTime - result.GeneratorTime : TDuration::Zero()) << Endl;
+        }
+
+        if (result.MaxRSSDelta >= 0) {
+            Cout << "MaxRSS delta, kB: " << (result.MaxRSSDelta / 1024) << Endl;
+        }
+        if (result.ReferenceMaxRSSDelta >= 0) {
+            Cout << "MaxRSS delta, kB: " << (result.ReferenceMaxRSSDelta / 1024) << Endl;
         }
     }
 };
 
-class TWikiResultCollector : public TTestResultCollector
+class TJsonResultCollector : public TTestResultCollector
 {
 public:
-    TWikiResultCollector()
+    virtual void SubmitMetrics(const TRunParams& runParams, const TRunResult& result, const char* testName, const std::optional<bool> llvm, const std::optional<bool> spilling) override
     {
-        Cout << "#|" << Endl;
-        Cout << "|| Test name | LLVM | Spilling | RowsTotal | Distinct keys | Block size | Input stream own time (s) | Graph time - stream time (s) | C++ time - stream time (s) | Shame ratio ||" << Endl;
-    }
+        NJson::TJsonValue out;
 
-    ~TWikiResultCollector()
-    {
-        Cout << "|#" << Endl;
-    }
-
-    virtual void SubmitTestNameAndParams(const TRunParams& runParams, const char* testName, const std::optional<bool> llvm, const std::optional<bool> spilling) override
-    {
-        Cout << "|| ";
-        Cout << testName << " | ";
+        out["testName"] = testName;
         if (llvm.has_value()) {
-            Cout << (llvm.value() ? "+" : " ");
+            out["llvm"] = *llvm;
         }
-        Cout << " | ";
         if (spilling.has_value()) {
-            Cout << (spilling.value() ? "+" : " ");
+            out["spilling"] = *spilling;
         }
-        Cout << " | ";
-
-        Cout << (runParams.RowsPerRun * runParams.NumRuns) << " | " << (runParams.MaxKey + 1) << " | ";
+        out["rowsPerRun"] = runParams.RowsPerRun;
+        out["numRuns"] = runParams.NumRuns;
         if (TStringBuf(testName).Contains("Block")) {
-            Cout << runParams.BlockSize;
+            out["blockSize"] = runParams.BlockSize;
         }
-        Cout << " | ";
-    }
+        out["longStringKeys"] = runParams.LongStringKeys;
+        out["numKeys"] = runParams.NumKeys;
+        out["combinerMemLimit"] = runParams.WideCombinerMemLimit;
 
-    static TString FancyDuration(const TDuration duration)
-    {
-        const auto ms = duration.MilliSeconds();
-        if (!ms) {
-            return " ";
-        }
-        return Sprintf("%.2f", (ms / 1000.0));
-    }
+        out["generatorTime"] = result.GeneratorTime.MilliSeconds();
+        out["resultTime"] = result.ResultTime.MilliSeconds();
+        out["refTime"] = result.ReferenceTime.MilliSeconds();
+        out["maxRssDelta"] = result.MaxRSSDelta;
+        out["referenceMaxRssDelta"] = result.ReferenceMaxRSSDelta;
 
-    virtual void SubmitTimings(const TDuration& graphTime, const TDuration& referenceTime, const std::optional<TDuration> streamTime) override
-    {
-        TDuration streamTimeOrZero = (streamTime.has_value()) ? streamTime.value() : TDuration::Zero();
-        TDuration corrGraphTime = streamTimeOrZero <= graphTime ? graphTime - streamTimeOrZero : TDuration::Zero();
-        TDuration corrRefTime = streamTimeOrZero <= referenceTime ? referenceTime - streamTimeOrZero : TDuration::Zero();
-
-        TString diff;
-        if (corrRefTime.MilliSeconds() > 0) {
-            diff = Sprintf("%.2f", corrGraphTime.MilliSeconds() * 1.0 / corrRefTime.MilliSeconds());
-        }
-
-        Cout << FancyDuration(streamTimeOrZero) << " | " << FancyDuration(corrGraphTime) << " | " << FancyDuration(corrRefTime) << " | " << diff << " ||" << Endl;
+        Cout << NJson::WriteJson(out, false, false, false) << Endl;
         Cout.Flush();
     }
 };
 
-void DoFullPass(bool withSpilling)
+void DoFullPass(TRunParams runParams, bool withSpilling)
 {
     using namespace NKikimr::NMiniKQL;
 
-    TWikiResultCollector printout;
+    TJsonResultCollector printout;
 
-    TRunParams runParams;
-
-    runParams.NumRuns = 20;
-    runParams.RowsPerRun = 5'000'000;
-    runParams.MaxKey = 1'00 - 1;
-    runParams.LongStringKeys = false;
-
-    const std::vector<size_t> numKeys = {4u, 1000u, 100'000u, 200'000u};
+    // const std::vector<size_t> numKeys = {4u, 1000u, 100'000u, 1'000'000u, 10'000'000, 30'000'000};
+    // const std::vector<size_t> numKeys = {60'000'000, 120'000'000};
+    const std::vector<size_t> numKeys = {1'000'000u};
     const std::vector<size_t> blockSizes = {128u, 8192u};
 
     auto doSimple = [&printout, numKeys](const TRunParams& params) {
-        for (size_t keyCount : numKeys) {
-            auto runParams = params;
-            runParams.MaxKey = keyCount - 1;
-            RunTestSimple<false>(runParams, printout);
-            RunTestSimple<true>(runParams, printout);
+        for (size_t memLimit : {0ULL, 30ULL << 20}) {
+            for (size_t keyCount : numKeys) {
+                auto runParams = params;
+                runParams.NumKeys = keyCount;
+                runParams.WideCombinerMemLimit = memLimit;
+                RunTestSimple<false>(runParams, printout);
+                RunTestSimple<true>(runParams, printout);
+            }
         }
     };
 
     auto doSimpleLast = [&printout, &numKeys, withSpilling](const TRunParams& params) {
         for (size_t keyCount : numKeys) {
             auto runParams = params;
-            runParams.MaxKey = keyCount - 1;
+            runParams.NumKeys = keyCount;
             RunTestCombineLastSimple<false, false>(runParams, printout);
             RunTestCombineLastSimple<true, false>(runParams, printout);
             if (withSpilling) {
@@ -147,16 +133,58 @@ void DoFullPass(bool withSpilling)
         for (size_t keyCount : numKeys) {
             for (size_t blockSize : blockSizes) {
                 auto runParams = params;
-                runParams.MaxKey = keyCount - 1;
+                runParams.NumKeys = keyCount;
                 runParams.BlockSize = blockSize;
                 RunTestBlockCombineHashedSimple<false, false>(runParams, printout);
             }
         }
     };
 
+    Y_UNUSED(doBlockHashed, doSimple, doSimpleLast);
+
     doSimple(runParams);
     doSimpleLast(runParams);
     doBlockHashed(runParams);
+}
+
+enum class ETestType {
+    All,
+    SimpleCombiner,
+    SimpleLastCombiner,
+    BlockCombiner,
+};
+
+void DoSelectedTest(TRunParams params, ETestType testType, bool llvm, bool spilling)
+{
+    TJsonResultCollector printout;
+
+    if (testType == ETestType::SimpleCombiner) {
+        if (llvm) {
+            NKikimr::NMiniKQL::RunTestSimple<true>(params, printout);
+        } else {
+            NKikimr::NMiniKQL::RunTestSimple<false>(params, printout);
+        }
+    } else if (testType == ETestType::BlockCombiner) {
+        if (llvm) {
+            NKikimr::NMiniKQL::RunTestBlockCombineHashedSimple<true, false>(params, printout);
+        } else {
+            NKikimr::NMiniKQL::RunTestBlockCombineHashedSimple<false, false>(params, printout);
+        }
+    } else if (testType == ETestType::SimpleLastCombiner) {
+        if (spilling) {
+            if (llvm) {
+                NKikimr::NMiniKQL::RunTestCombineLastSimple<true, true>(params, printout);
+            } else {
+                NKikimr::NMiniKQL::RunTestCombineLastSimple<false, true>(params, printout);
+            }
+        } else {
+            if (llvm) {
+                NKikimr::NMiniKQL::RunTestCombineLastSimple<true, false>(params, printout);
+            } else {
+                NKikimr::NMiniKQL::RunTestCombineLastSimple<false, false>(params, printout);
+            }
+        }
+    }
 }
 
 int main(int argc, const char* argv[])
@@ -164,14 +192,120 @@ int main(int argc, const char* argv[])
     Y_UNUSED(argc);
     Y_UNUSED(argv);
 
+    TRunParams runParams;
+
+    runParams.NumAttempts = 1;
+    runParams.RowsPerRun = 10'000'000;
+    runParams.NumRuns = 1;
+    runParams.NumKeys = 1000;
+    runParams.LongStringKeys = false;
+    runParams.MeasureReferenceMemory = false;
+    runParams.BlockSize = 8192;
+    runParams.WideCombinerMemLimit = 0;
+
+    ETestType testType = ETestType::All;
+    bool spilling = false;
+    bool llvm = false;
+
+    NLastGetopt::TOpts options;
+    options.SetTitle("A sandbox to run combiners (and other compute nodes) while measuring performance/RAM usage");
+    options.AddHelpOption('h');
+    options.SetFreeArgsNum(0);
+
+    options.AddLongOption("rand-seed").RequiredArgument().StoreResult(&runParams.RandomSeed)
+        .Help("Random seed for the input dataset generator");
+    options.AddLongOption("num-attempts").RequiredArgument().StoreResult(&runParams.NumAttempts).DefaultValue(runParams.NumAttempts)
+        .Help("Number of time measurement runs to filter out random fluctuations");
+    options.AddLongOption("rows-per-run").RequiredArgument().StoreResult(&runParams.RowsPerRun).DefaultValue(runParams.RowsPerRun)
+        .Help("Rows per single loop of the input stream");
+    options.AddLongOption("run-count").RequiredArgument().StoreResult(&runParams.NumRuns).DefaultValue(runParams.NumRuns)
+        .Help("Number of loops of the input stream");
+    options.AddLongOption("num-keys").RequiredArgument().StoreResult(&runParams.NumKeys).DefaultValue(runParams.NumKeys)
+        .Help("Number of distinct keys in the input set (uniformly distributed)");
+    options.AddLongOption("long-string-keys").NoArgument().SetFlag(&runParams.LongStringKeys)
+        .Help("String keys are short and embedded by default; specify this option to use heap-allocated strings");
+    options.AddLongOption("measure-reference-ram").NoArgument().SetFlag(&runParams.MeasureReferenceMemory)
+        .Help("Do a separate run to measure the MaxRSS delta of a reference implementation");
+    options.AddLongOption("block-size").RequiredArgument().StoreResult(&runParams.BlockSize).DefaultValue(runParams.BlockSize)
+        .Help("Block size (rows = column height) for block operators, when applicable");
+    options.AddLongOption("mem-limit").RequiredArgument().StoreResult(&runParams.WideCombinerMemLimit).DefaultValue(runParams.WideCombinerMemLimit)
+        .Help("Memory limit for the wide combiner, in MB, or 0 to disable");
+
+    options.AddLongOption("sampler")
+        .Choices({"stringnum", "numnum"})
+        .RequiredArgument()
+        .Handler1([&](const NLastGetopt::TOptsParser* option) {
+            auto val = TStringBuf(option->CurVal());
+            if (val == "stringnum") {
+                runParams.SamplerType = NKikimr::NMiniKQL::ESamplerType::StringKeysUI64Values;
+            } else if (val == "numnum") {
+                runParams.SamplerType = NKikimr::NMiniKQL::ESamplerType::UI64KeysUI64Values;
+            }
+        })
+        .Help("Input data type: string key -> ui64 numeric value or ui64 numeric key -> ui64 numeric value");
+
+    options
+        .AddLongOption('t', "test")
+        .Choices({"combiner", "last-combiner", "block-combiner"})
+        .RequiredArgument("TEST_TYPE")
+        .Handler1([&](const NLastGetopt::TOptsParser* option) {
+            auto val = TStringBuf(option->CurVal());
+            if (val == "combiner") {
+                testType = ETestType::SimpleCombiner;
+            } else if (val == "last-combiner") {
+                testType = ETestType::SimpleLastCombiner;
+            } else if (val == "block-combiner") {
+                testType = ETestType::BlockCombiner;
+            } else {
+                ythrow yexception() << "Unknown test type: " << val;
+            }
+        })
+        .Help("Enable single test run mode");
+
+    options
+        .AddLongOption('m', "mode")
+        .Choices({"gen", "ref", "graph", "all"})
+        .DefaultValue("all")
+        .Handler1([&](const NLastGetopt::TOptsParser* option) {
+            auto val = TStringBuf(option->CurVal());
+            if (val == "gen") {
+                runParams.TestMode = NKikimr::NMiniKQL::ETestMode::GeneratorOnly;
+            } else if (val == "ref") {
+                runParams.TestMode = NKikimr::NMiniKQL::ETestMode::RefOnly;
+            } else if (val == "graph") {
+                runParams.TestMode = NKikimr::NMiniKQL::ETestMode::GraphOnly;
+            }
+        })
+        .Help("Specify partial test mode (gen = only generate input, ref = only run the reference implementation, graph = only run the compute graph implementation)");
+
+    options.AddLongOption("llvm").NoArgument().SetFlag(&llvm)
+        .Help("Enable LLVM for the single test mode, if applicable");
+    options.AddLongOption("spilling").NoArgument().SetFlag(&spilling)
+        .Help("Enable spilling for the single test mode, if applicable, or enable spilling tests in the full test suite");
+
+
+    NLastGetopt::TOptsParseResult parsedOptions(&options, argc, argv);
+
+    Y_ENSURE(runParams.NumKeys >= 1);
+    Y_ENSURE(runParams.NumKeys <= runParams.RowsPerRun);
+    Y_ENSURE(runParams.NumRuns >= 1);
+    Y_ENSURE(runParams.NumAttempts >= 1);
+    Y_ENSURE(runParams.BlockSize >= 1);
+
+    runParams.WideCombinerMemLimit <<= 20;
+
+    if (!runParams.RandomSeed.has_value()) {
+        runParams.RandomSeed = std::time(nullptr);
+    }
+
     if (false) {
         NAllocProfiler::StartAllocationSampling(true);
     }
 
-    constexpr int NumIterations = 1;
-
-    for (int i = 0; i < NumIterations; ++i) {
-        DoFullPass(false);
+    if (testType != ETestType::All) {
+        DoSelectedTest(runParams, testType, llvm, spilling);
+    } else {
+        DoFullPass(runParams, spilling);
     }
 
     if (false) {

--- a/ydb/core/kqp/tools/combiner_perf/bin/ya.make.memprofile
+++ b/ydb/core/kqp/tools/combiner_perf/bin/ya.make.memprofile
@@ -1,4 +1,5 @@
 PROGRAM(combiner_perf)
+ALLOCATOR(LF_DBG)
 
 YQL_LAST_ABI_VERSION()
 

--- a/ydb/core/kqp/tools/combiner_perf/preallocated_spiller.h
+++ b/ydb/core/kqp/tools/combiner_perf/preallocated_spiller.h
@@ -1,0 +1,120 @@
+#pragma once
+
+#include <yql/essentials/minikql/computation/mkql_spiller_factory.h>
+#include <yql/essentials/minikql/computation/mkql_spiller.h>
+
+#include <library/cpp/threading/future/core/future.h>
+
+#include <util/generic/buffer.h>
+#include <util/stream/buffer.h>
+
+#include <unordered_map>
+
+namespace NKikimr::NMiniKQL {
+
+// A clone of TMockSpiller/TMockSpillerFactory that can spill into a large preallocated buffer
+
+class TPreallocatedSpiller: public ISpiller{
+public:
+    TPreallocatedSpiller(TBuffer& dataStore)
+        : NextKey_(0)
+        , DataStore(dataStore)
+        , StoreStream(DataStore)
+    {
+        Storage_.rehash(128 * 4); // TODO: configurable
+    }
+
+    NThreading::TFuture<TKey> Put(NYql::TChunkedBuffer&& blob) override {
+        auto promise = NThreading::NewPromise<ISpiller::TKey>();
+
+        auto key = NextKey_;
+        NYql::TChunkedBuffer storageBuf;
+
+        Y_ENSURE(DataStore.Size() + blob.Size() < DataStore.Capacity());
+
+        const char* currPos = DataStore.Pos();
+
+        blob.CopyTo(StoreStream);
+        StoreStream.Flush();
+
+        Storage_[key] = NYql::TChunkedBuffer(TStringBuf(currPos, blob.Size()), nullptr);
+        PutSizes_.push_back(Storage_[key].Size());
+        NextKey_++;
+        promise.SetValue(key);
+
+        blob.Clear();
+
+        return promise.GetFuture();
+    }
+
+    NThreading::TFuture<std::optional<NYql::TChunkedBuffer>> Get(TKey key) override {
+        auto promise = NThreading::NewPromise<std::optional<NYql::TChunkedBuffer>>();
+        if (auto it = Storage_.find(key); it != Storage_.end()) {
+            promise.SetValue(it->second);
+        } else {
+            promise.SetValue(std::nullopt);
+        }
+
+        return promise.GetFuture();
+    }
+
+    NThreading::TFuture<std::optional<NYql::TChunkedBuffer>> Extract(TKey key) override {
+        auto promise = NThreading::NewPromise<std::optional<NYql::TChunkedBuffer>>();
+        if (auto it = Storage_.find(key); it != Storage_.end()) {
+            promise.SetValue(std::move(it->second));
+            Storage_.erase(it);
+        } else {
+            promise.SetValue(std::nullopt);
+        }
+
+        return promise.GetFuture();
+    }
+
+    NThreading::TFuture<void> Delete(TKey key) override {
+        auto promise = NThreading::NewPromise<void>();
+        promise.SetValue();
+        Storage_.erase(key);
+        return promise.GetFuture();
+    }
+
+    const std::vector<size_t>& GetPutSizes() const {
+        return PutSizes_;
+    }
+
+private:
+    ISpiller::TKey NextKey_;
+    std::unordered_map<ISpiller::TKey, NYql::TChunkedBuffer> Storage_;
+    std::vector<size_t> PutSizes_;
+    TBuffer& DataStore;
+    TBufferOutput StoreStream;
+};
+
+class TPreallocatedSpillerFactory : public ISpillerFactory
+{
+public:
+    TPreallocatedSpillerFactory()
+        : DataStore(4ULL << 30) // TODO: configure
+    {
+        // prefault the buffer
+        memset(DataStore.Data(), 0xFF, DataStore.Capacity());
+    }
+
+    void SetTaskCounters(const TIntrusivePtr<NYql::NDq::TSpillingTaskCounters>& /*spillingTaskCounters*/) override {
+    }
+
+    ISpiller::TPtr CreateSpiller() override {
+        auto new_spiller = std::make_shared<TPreallocatedSpiller>(DataStore);
+        Spillers_.push_back(new_spiller);
+        return new_spiller;
+    }
+
+    const std::vector<ISpiller::TPtr>& GetCreatedSpillers() const {
+        return Spillers_;
+    }
+
+private:
+    TBuffer DataStore;
+    std::vector<ISpiller::TPtr> Spillers_;
+};
+
+} // namespace NKikimr::NMiniKQL

--- a/ydb/core/kqp/tools/combiner_perf/printout.cpp
+++ b/ydb/core/kqp/tools/combiner_perf/printout.cpp
@@ -1,0 +1,39 @@
+#include "printout.h"
+
+#include <sys/resource.h>
+
+long GetMaxRSS()
+{
+    rusage usage;
+    if (getrusage(RUSAGE_SELF, &usage) != 0) {
+        ythrow yexception() << "getrusage failed with errno " << errno << Endl;
+    }
+    return usage.ru_maxrss;
+}
+
+long GetMaxRSSDelta(const long prevMaxRss)
+{
+    long maxRss = GetMaxRSS();
+
+    if (maxRss <= 0 || prevMaxRss <= 0 || maxRss < prevMaxRss) {
+        ythrow yexception() << "Bad maxRSS measurement, before: " << prevMaxRss << ", after: " << maxRss << Endl;        
+    }
+
+#if defined (_darwin_)
+    constexpr const long factor = 1ull;
+#else
+    constexpr const long factor = 1024ull;
+#endif
+
+    return (maxRss - prevMaxRss) * factor;
+}
+
+void MergeRunResults(const TRunResult& src, TRunResult& dst)
+{
+    dst.ResultTime = Min(src.ResultTime, dst.ResultTime);
+    dst.GeneratorTime = Min(src.GeneratorTime, dst.GeneratorTime);
+    dst.ReferenceTime = Min(src.ReferenceTime, dst.ReferenceTime);
+
+    dst.MaxRSSDelta = Max(src.MaxRSSDelta, dst.MaxRSSDelta);
+    dst.ReferenceMaxRSSDelta = Max(src.ReferenceMaxRSSDelta, dst.ReferenceMaxRSSDelta);
+}

--- a/ydb/core/kqp/tools/combiner_perf/printout.h
+++ b/ydb/core/kqp/tools/combiner_perf/printout.h
@@ -2,14 +2,44 @@
 
 #include "run_params.h"
 
+#include <util/ysaveload.h>
 #include <util/datetime/base.h>
 #include <optional>
 
+struct TRunResult
+{
+    TDuration GeneratorTime = TDuration::Zero();
+    TDuration ResultTime = TDuration::Zero();
+    TDuration ReferenceTime = TDuration::Zero();
+    size_t MaxRSSDelta = 0;
+    size_t ReferenceMaxRSSDelta = 0;
+
+    TRunResult()
+    {
+    }
+
+    TRunResult(TDuration generatorTime, TDuration resultTime, TDuration referenceTime, size_t maxRSSDelta, size_t referenceMaxRSSDelta = -1)
+        : GeneratorTime(generatorTime)
+        , ResultTime(resultTime)
+        , ReferenceTime(referenceTime)
+        , MaxRSSDelta(maxRSSDelta)
+        , ReferenceMaxRSSDelta(referenceMaxRSSDelta)
+    {
+    }
+
+    Y_SAVELOAD_DEFINE(GeneratorTime, ResultTime, ReferenceTime, MaxRSSDelta, ReferenceMaxRSSDelta);
+};
+
+void MergeRunResults(const TRunResult& src, TRunResult& dst);
+
 class TTestResultCollector {
 public:
-    virtual void SubmitTestNameAndParams(const NKikimr::NMiniKQL::TRunParams& runParams, const char* testName, const std::optional<bool> llvm = {}, const std::optional<bool> spilling = {}) = 0;
-
-    virtual void SubmitTimings(const TDuration& graphTime, const TDuration& referenceTime, const std::optional<TDuration> streamTime = {}) = 0;
+    virtual void SubmitMetrics(const NKikimr::NMiniKQL::TRunParams& runParams, const TRunResult& result, const char* testName, const std::optional<bool> llvm = {}, const std::optional<bool> spilling = {}) = 0;
 
     virtual ~TTestResultCollector() {};
 };
+
+// ru_maxrss from rusage, converted to bytes
+long GetMaxRSS();
+
+long GetMaxRSSDelta(const long prevMaxRss);

--- a/ydb/core/kqp/tools/combiner_perf/run_params.h
+++ b/ydb/core/kqp/tools/combiner_perf/run_params.h
@@ -1,16 +1,35 @@
 #pragma once
 
 #include <util/system/defaults.h>
+#include <optional>
 
 namespace NKikimr {
 namespace NMiniKQL {
 
+enum class ETestMode {
+    Full = 0,
+    GeneratorOnly,
+    RefOnly,
+    GraphOnly,
+};
+
+enum class ESamplerType {
+    StringKeysUI64Values,
+    UI64KeysUI64Values,
+};
+
 struct TRunParams {
+    ETestMode TestMode = ETestMode::Full;
+    ESamplerType SamplerType = ESamplerType::StringKeysUI64Values;
+    std::optional<ui64> RandomSeed;
+    int NumAttempts = 0;
     size_t RowsPerRun = 0;
     size_t NumRuns = 0;
-    size_t MaxKey = 0; // for numeric keys, the range is [0..MaxKey]
-    size_t BlockSize = 5000;
+    size_t NumKeys = 0; // for numeric keys, the range is [0..NumKeys-1]
+    size_t BlockSize = 0;
+    size_t WideCombinerMemLimit = 0;
     bool LongStringKeys = false;
+    bool MeasureReferenceMemory = false;
 };
 
 }

--- a/ydb/core/kqp/tools/combiner_perf/simple.cpp
+++ b/ydb/core/kqp/tools/combiner_perf/simple.cpp
@@ -3,39 +3,36 @@
 #include "factories.h"
 #include "streams.h"
 #include "printout.h"
+#include "subprocess.h"
 
 #include <yql/essentials/minikql/comp_nodes/ut/mkql_computation_node_ut.h>
 #include <yql/essentials/minikql/computation/mkql_computation_node_holders.h>
 #include <yql/essentials/minikql/comp_nodes/mkql_factories.h>
 #include <yql/essentials/minikql/computation/mock_spiller_factory_ut.h>
+#include <yql/essentials/utils/log/log.h>
 
 #include <library/cpp/testing/unittest/registar.h>
 
 #include <util/system/compiler.h>
 
+
 namespace NKikimr {
 namespace NMiniKQL {
 
+namespace {
+
 template<bool LLVM>
-void RunTestSimple(const TRunParams& params, TTestResultCollector& printout)
+THolder<IComputationGraph> BuildGraph(TSetup<LLVM>& setup, IDataSampler& sampler, size_t memLimit)
 {
-    TSetup<LLVM> setup(GetPerfTestFactory());
-
-    printout.SubmitTestNameAndParams(params, __func__, LLVM);
-
-    TString64DataSampler sampler(params.RowsPerRun, params.MaxKey, params.NumRuns, params.LongStringKeys);
-    // or T6464DataSampler sampler(numSamples, maxKey, numIters); -- maybe make selectable from params
-    Cerr << "Sampler type: " << sampler.Describe() << Endl;
-
     TProgramBuilder& pb = *setup.PgmBuilder;
 
     const auto streamItemType = pb.NewMultiType({sampler.GetKeyType(pb), pb.NewDataType(NUdf::TDataType<ui64>::Id)});
     const auto streamType = pb.NewStreamType(streamItemType);
     const auto streamCallable = TCallableBuilder(pb.GetTypeEnvironment(), "TestList", streamType).Build();
 
-    const auto pgmReturn = pb.Collect(pb.NarrowMap(pb.WideCombiner(
+    const auto pgmReturn = pb.FromFlow(pb.WideCombiner(
         pb.ToFlow(TRuntimeNode(streamCallable, false)),
-        0ULL,
+        memLimit,
         [&](TRuntimeNode::TList items) -> TRuntimeNode::TList { return { items.front() }; },
         [&](TRuntimeNode::TList, TRuntimeNode::TList items) -> TRuntimeNode::TList { return { items.back() } ; },
         [&](TRuntimeNode::TList, TRuntimeNode::TList items, TRuntimeNode::TList state) -> TRuntimeNode::TList {
@@ -43,40 +40,139 @@ void RunTestSimple(const TRunParams& params, TTestResultCollector& printout)
         },
         [&](TRuntimeNode::TList keys, TRuntimeNode::TList state) -> TRuntimeNode::TList {
             return {keys.front(), state.front()};
-        }),
-        [&](TRuntimeNode::TList items) { return pb.NewTuple(items); }
-    ));
+        }));
 
-    const auto graph = setup.BuildGraph(pgmReturn, {streamCallable});
-
-    // Measure the input stream run time
-    const auto devnullStream = sampler.MakeStream(graph->GetHolderFactory());
-    const auto devnullStart = TInstant::Now();
-    {
-        NUdf::TUnboxedValue columns[2];
-        while (devnullStream->WideFetch(columns, 2) == NUdf::EFetchStatus::Ok) {
-        }
-    }
-    const auto devnullTime = TInstant::Now() - devnullStart;
-
-    // Reference implementation (sum via an std::unordered_map)
-    auto referenceStream = sampler.MakeStream(graph->GetHolderFactory());
-    const auto t = TInstant::Now();
-    sampler.ComputeReferenceResult(*referenceStream);
-    const auto cppTime = TInstant::Now() - t;
-
-    // Compute graph implementation
+    auto graph = setup.BuildGraph(pgmReturn, {streamCallable});
     auto myStream = NUdf::TUnboxedValuePod(sampler.MakeStream(graph->GetHolderFactory()).Release());
     graph->GetEntryPoint(0, true)->SetValue(graph->GetContext(), std::move(myStream));
 
-    const auto graphTimeStart = TInstant::Now();
-    const auto& value = graph->GetValue();
-    const auto graphTime = TInstant::Now() - graphTimeStart;
+    return graph;
+}
 
-    // Verification
-    sampler.VerifyComputedValueVsReference(value);
+template<bool LLVM>
+TRunResult RunTestOverGraph(const TRunParams& params, const bool needsVerification, const bool measureReferenceMemory)
+{
+    TSetup<LLVM> setup(GetPerfTestFactory());
 
-    printout.SubmitTimings(graphTime, cppTime, devnullTime);
+    NYql::NLog::InitLogger("cerr", false);
+
+    THolder<IDataSampler> sampler = CreateWideSamplerFromParams(params);
+    Cerr << "Sampler type: " << sampler->Describe() << Endl;
+
+    auto measureGraphTime = [&](auto& computeGraphPtr) {
+        // Compute node implementation
+
+        Cerr << "Compute graph result" << Endl;
+        const auto graphTimeStart = TInstant::Now();
+        size_t lineCount = CountWideStreamOutputs<2>(computeGraphPtr->GetValue());
+        Cerr << lineCount << Endl;
+
+        return TInstant::Now() - graphTimeStart;
+    };
+
+    auto measureRefTime = [&](auto& computeGraphPtr, IDataSampler& sampler) {
+        // Reference implementation (sum via an std::unordered_map)
+
+        Cerr << "Compute reference result" << Endl;
+        auto referenceStream = sampler.MakeStream(computeGraphPtr->GetHolderFactory());
+        const auto cppTimeStart = TInstant::Now();
+        sampler.ComputeReferenceResult(*referenceStream);
+
+        return TInstant::Now() - cppTimeStart;
+    };
+
+    auto graphRun1 = BuildGraph(setup, *sampler, params.WideCombinerMemLimit);
+
+    TRunResult result;
+
+    if (measureReferenceMemory || params.TestMode == ETestMode::RefOnly) {
+        long maxRssBefore = GetMaxRSS();
+        result.ReferenceTime = measureRefTime(graphRun1, *sampler);
+        result.ReferenceMaxRSSDelta = GetMaxRSSDelta(maxRssBefore);
+        return result;
+    }
+
+    if (params.TestMode == ETestMode::GraphOnly || params.TestMode == ETestMode::Full) {
+        long maxRssBefore = GetMaxRSS();
+        result.ResultTime = measureGraphTime(graphRun1);
+        result.MaxRSSDelta = GetMaxRSSDelta(maxRssBefore);
+
+        if (params.TestMode == ETestMode::GraphOnly) {
+            return result;
+        }
+    }
+
+    if (params.TestMode == ETestMode::GeneratorOnly || params.TestMode == ETestMode::Full) {
+        // Measure the input stream run time
+        Cerr << "Generator run" << Endl;
+        const auto devnullStream = sampler->MakeStream(graphRun1->GetHolderFactory());
+        const auto devnullStart = TInstant::Now();
+        {
+            NUdf::TUnboxedValue columns[2];
+            while (devnullStream->WideFetch(columns, 2) == NUdf::EFetchStatus::Ok) {
+            }
+        }
+        result.GeneratorTime = TInstant::Now() - devnullStart;
+
+        if (params.TestMode == ETestMode::GeneratorOnly) {
+            return result;
+        }
+    }
+
+    result.ReferenceTime = measureRefTime(graphRun1, *sampler);
+
+    // Verification (re-run the graph again but actually collect the output values into a map)
+    if (needsVerification) {
+        Cerr << "Compute and verify the graph result" << Endl;
+        auto graphRun2 = BuildGraph(setup, *sampler, params.WideCombinerMemLimit);
+        {
+            sampler->VerifyStreamVsReference(graphRun2->GetValue());
+        }
+    }
+
+    return result;
+}
+
+}
+
+template<bool LLVM>
+void RunTestSimple(const TRunParams& params, TTestResultCollector& printout)
+{
+    std::optional<TRunResult> finalResult;
+
+    Cerr << "======== " << __func__ << ", keys: " << params.NumKeys << ", llvm: " << LLVM << ", mem limit: " << params.WideCombinerMemLimit << Endl;
+
+    if (params.NumAttempts <= 1 && !params.MeasureReferenceMemory) {
+        finalResult = RunTestOverGraph<LLVM>(params, true, false);
+    }
+    else {
+        for (int i = 1; i <= params.NumAttempts; ++i) {
+            Cerr << "------ Run " << i << " of " << params.NumAttempts << Endl;
+
+            const bool needsVerification = (i == 1);
+
+            TRunResult runResult = RunForked([&]() {
+                return RunTestOverGraph<LLVM>(params, needsVerification, false);
+            });
+
+            if (finalResult.has_value()) {
+                MergeRunResults(runResult, *finalResult);
+            } else {
+                finalResult.emplace(runResult);
+            }
+        }
+    }
+
+    if (params.MeasureReferenceMemory) {
+        Cerr << "------ Reference memory measurement run" << Endl;
+        TRunResult runResult = RunForked([&]() {
+            return RunTestOverGraph<LLVM>(params, false, true);
+        });
+        Y_ENSURE(finalResult.has_value());
+        finalResult->ReferenceMaxRSSDelta = runResult.ReferenceMaxRSSDelta;
+    }
+
+    printout.SubmitMetrics(params, *finalResult, "WideCombiner", LLVM);
 }
 
 template void RunTestSimple<false>(const TRunParams& params, TTestResultCollector& printout);

--- a/ydb/core/kqp/tools/combiner_perf/simple_block.cpp
+++ b/ydb/core/kqp/tools/combiner_perf/simple_block.cpp
@@ -3,6 +3,7 @@
 #include "factories.h"
 #include "streams.h"
 #include "printout.h"
+#include "subprocess.h"
 
 #include <yql/essentials/minikql/comp_nodes/ut/mkql_computation_node_ut.h>
 #include <yql/essentials/minikql/computation/mkql_computation_node_holders.h>
@@ -22,79 +23,19 @@
 namespace NKikimr {
 namespace NMiniKQL {
 
-template<typename K>
-void UpdateMapFromBlocks(const NUdf::TUnboxedValue& key, const NUdf::TUnboxedValue& value, std::unordered_map<K, ui64>& result);
-
-template<>
-void UpdateMapFromBlocks(const NUdf::TUnboxedValue& key, const NUdf::TUnboxedValue& value, std::unordered_map<ui64, ui64>& result)
-{
-    auto datumKey = TArrowBlock::From(key).GetDatum();
-    auto datumValue = TArrowBlock::From(value).GetDatum();
-    UNIT_ASSERT(datumKey.is_array());
-    UNIT_ASSERT(datumValue.is_array());
-
-    const auto ui64keys = datumKey.template array_as<arrow::UInt64Array>();
-    const auto ui64values = datumValue.template array_as<arrow::UInt64Array>();
-    UNIT_ASSERT(!!ui64keys);
-    UNIT_ASSERT(!!ui64values);
-    UNIT_ASSERT_VALUES_EQUAL(ui64keys->length(), ui64values->length());
-
-    const size_t length = ui64keys->length();
-    for (size_t i = 0; i < length; ++i) {
-        result[ui64keys->Value(i)] += ui64values->Value(i);
-    }
-}
-
-template<>
-void UpdateMapFromBlocks(const NUdf::TUnboxedValue& key, const NUdf::TUnboxedValue& value, std::unordered_map<std::string, ui64>& result)
-{
-    auto datumKey = TArrowBlock::From(key).GetDatum();
-    auto datumValue = TArrowBlock::From(value).GetDatum();
-    UNIT_ASSERT(datumKey.is_arraylike());
-    UNIT_ASSERT(datumValue.is_array());
-
-    const auto ui64values = datumValue.template array_as<arrow::UInt64Array>();
-    UNIT_ASSERT(!!ui64values);
-
-    int64_t valueOffset = 0;
-
-    for (const auto& chunk : datumKey.chunks()) {
-        auto* barray = dynamic_cast<arrow::BinaryArray*>(chunk.get());
-        UNIT_ASSERT(barray != nullptr);
-        for (int64_t i = 0; i < barray->length(); ++i) {
-            auto key = barray->GetString(i);
-            auto val = ui64values->Value(valueOffset);
-            result[key] += val;
-            ++valueOffset;
-        }
-    }
-}
-
-
-template<typename TStream, typename TMap>
-void CalcRefResult(TStream& refStream, TMap& refResult)
-{
-    NUdf::TUnboxedValue columns[3];
-
-    while (refStream->WideFetch(columns, 3) == NUdf::EFetchStatus::Ok) {
-        UpdateMapFromBlocks(columns[0], columns[1], refResult);
-    }
-}
-
+namespace {
 
 template<bool LLVM, bool Spilling>
-void RunTestBlockCombineHashedSimple(const TRunParams& params, TTestResultCollector& printout)
+TRunResult RunTestOverGraph(const TRunParams& params, const bool measureReferenceMemory)
 {
     TSetup<LLVM, Spilling> setup(GetPerfTestFactory());
 
-    printout.SubmitTestNameAndParams(params, __func__, LLVM, Spilling);
-
-    auto samples = MakeKeyedString64Samples(params.RowsPerRun, params.MaxKey, false);
+    auto sampler = CreateBlockSamplerFromParams(params);
 
     TProgramBuilder& pb = *setup.PgmBuilder;
 
-    auto keyBaseType = pb.NewDataType(NUdf::TDataType<char*>::Id);
-    auto valueBaseType = pb.NewDataType(NUdf::TDataType<ui64>::Id);
+    auto keyBaseType = sampler->BuildKeyType(*setup.Env);
+    auto valueBaseType = sampler->BuildValueType(*setup.Env);
     auto keyBlockType = pb.NewBlockType(keyBaseType, TBlockType::EShape::Many);
     auto valueBlockType = pb.NewBlockType(valueBaseType, TBlockType::EShape::Many);
     auto blockSizeType = pb.NewDataType(NUdf::TDataType<ui64>::Id);
@@ -105,6 +46,7 @@ void RunTestBlockCombineHashedSimple(const TRunParams& params, TTestResultCollec
     const auto streamResultType = pb.NewStreamType(streamResultItemType);
     const auto streamCallable = TCallableBuilder(pb.GetTypeEnvironment(), "TestList", streamType).Build();
 
+    // TODO: This should be generated in the sampler
     ui32 keys[] = {0};
     TAggInfo aggs[] = {
         TAggInfo{
@@ -112,6 +54,7 @@ void RunTestBlockCombineHashedSimple(const TRunParams& params, TTestResultCollec
             .ArgsColumns = {1u},
         }
     };
+
     auto pgmReturn = pb.Collect(pb.NarrowMap(pb.ToFlow(
         pb.BlockCombineHashed(
             TRuntimeNode(streamCallable, false),
@@ -122,81 +65,122 @@ void RunTestBlockCombineHashedSimple(const TRunParams& params, TTestResultCollec
         )),
         [&](TRuntimeNode::TList items) -> TRuntimeNode { return pb.NewTuple(items); } // NarrowMap handler
     ));
-    const auto graph = setup.BuildGraph(pgmReturn, {streamCallable});
 
-    auto streamMaker = [&]() -> auto {
-        return std::unique_ptr<TBlockKVStream<std::string, ui64>>(new TBlockKVStream<std::string, ui64>(
-            graph->GetContext(),
-            samples,
-            params.NumRuns,
-            params.BlockSize,
-            {keyBaseType, valueBaseType}
-        ));
+    auto measureGraphTime = [&](auto& computeGraphPtr, NUdf::TUnboxedValue& resultList) {
+        // Compute graph implementation
+        auto stream = NUdf::TUnboxedValuePod(sampler->MakeStream(computeGraphPtr->GetContext()).Release());
+        computeGraphPtr->GetEntryPoint(0, true)->SetValue(computeGraphPtr->GetContext(), std::move(stream));
+        const auto graphStart = TInstant::Now();
+        resultList = computeGraphPtr->GetValue();
+        return TInstant::Now() - graphStart;
     };
 
-    // Compute results directly from raw samples to test the input stream implementation
-    std::unordered_map<std::string, ui64> rawResult;
-    for (const auto& tuple : samples) {
-        rawResult[tuple.first] += (tuple.second * params.NumRuns);
+    auto measureRefTime = [&](auto& computeGraphPtr) {
+        // Reference implementation (sum via an std::unordered_map)
+        const auto cppStart = TInstant::Now();
+        sampler->ComputeReferenceResult(computeGraphPtr->GetContext());
+        return TInstant::Now() - cppStart;
+    };
+
+    auto measureGeneratorTime = [&](auto& computeGraphPtr) {
+        // Generator-only loop
+        const auto devnullStreamPtr = sampler->MakeStream(computeGraphPtr->GetContext());
+        auto& devnullStream = *devnullStreamPtr;
+        size_t numBlocks = 0;
+        const auto timeStart = TInstant::Now();
+        {
+            NUdf::TUnboxedValue columns[3];
+            while (devnullStream.WideFetch(columns, 3) == NUdf::EFetchStatus::Ok) {
+                ++numBlocks;
+            }
+        }
+        auto timeEnd = TInstant::Now();
+        Cerr << "Blocks generated: " << numBlocks << Endl;
+        return timeEnd - timeStart;
+    };
+
+    const auto graph = setup.BuildGraph(pgmReturn, {streamCallable});
+
+    TRunResult result;
+
+    if (measureReferenceMemory || params.TestMode == ETestMode::RefOnly) {
+        long maxRssBefore = GetMaxRSS();
+        result.ReferenceTime = measureRefTime(graph);
+        result.ReferenceMaxRSSDelta = GetMaxRSSDelta(maxRssBefore);
+        return result;
     }
 
-    // Measure the input stream run time
-    const auto devnullStream = streamMaker();
-    const auto devnullStart = TInstant::Now();
-    {
-        NUdf::TUnboxedValue columns[3];
-        while (devnullStream->WideFetch(columns, 3) == NUdf::EFetchStatus::Ok) {
+    NUdf::TUnboxedValue resultList;
+
+    if (params.TestMode == ETestMode::GraphOnly || params.TestMode == ETestMode::Full) {
+        long maxRssBefore = GetMaxRSS();
+        result.ResultTime = measureGraphTime(graph, resultList);
+        result.MaxRSSDelta = GetMaxRSSDelta(maxRssBefore);
+        if (params.TestMode == ETestMode::GraphOnly) {
+            return result;
         }
     }
-    const auto devnullTime = TInstant::Now() - devnullStart;
 
-    // Reference implementation (sum via an std::unordered_map)
-    std::unordered_map<std::string, ui64> refResult;
-    const auto refStream = streamMaker();
-    const auto cppStart = TInstant::Now();
-    CalcRefResult(refStream, refResult);
-    const auto cppTime = TInstant::Now() - cppStart;
-
-    // Verify the reference stream implementation against the raw samples
-    UNIT_ASSERT_VALUES_EQUAL(refResult.size(), rawResult.size());
-    for (const auto& tuple : rawResult) {
-        auto otherIt = refResult.find(tuple.first);
-        UNIT_ASSERT(otherIt != refResult.end());
-        UNIT_ASSERT_VALUES_EQUAL(tuple.second, otherIt->second);
+    // Measure the input stream own run time
+    if (params.TestMode == ETestMode::GeneratorOnly || params.TestMode == ETestMode::Full) {
+        result.GeneratorTime = measureGeneratorTime(graph);
+        if (params.TestMode == ETestMode::GeneratorOnly) {
+            return result;
+        }
     }
 
-    // Compute graph implementation
-    auto stream = NUdf::TUnboxedValuePod(streamMaker().release());
-    graph->GetEntryPoint(0, true)->SetValue(graph->GetContext(), std::move(stream));
-    const auto graphStart = TInstant::Now();
-    const auto& resultList = graph->GetValue();
-    const auto graphTime = TInstant::Now() - graphStart;
+    result.ReferenceTime = measureRefTime(graph);
 
-    size_t numResultItems = resultList.GetListLength();
-    Cerr << "Result block count: " << numResultItems << Endl;
+    // Compute results directly from raw samples
+    sampler->ComputeRawResult();
 
-    // Verification
-    std::unordered_map<std::string, ui64> graphResult;
+    // Verify the reference result against the raw samples to test the input stream implementation
+    sampler->VerifyReferenceResultAgainstRaw();
 
-    const auto ptr = resultList.GetElements();
-    for (size_t i = 0ULL; i < numResultItems; ++i) {
-        UNIT_ASSERT(ptr[i].GetListLength() >= 2);
+    // Verify the compute graph result value against the reference implementation
+    sampler->VerifyGraphResultAgainstReference(resultList);
 
-        const auto elements = ptr[i].GetElements();
+    return result;
+}
 
-        UpdateMapFromBlocks(elements[0], elements[1], graphResult);
+}
+
+
+template<bool LLVM, bool Spilling>
+void RunTestBlockCombineHashedSimple(const TRunParams& params, TTestResultCollector& printout)
+{
+    std::optional<TRunResult> finalResult;
+
+    Cerr << "======== " << __func__ << ", keys: " << params.NumKeys << ", block size: " << params.BlockSize << ", llvm: " << LLVM << Endl;
+
+    if (params.NumAttempts <= 1 && !params.MeasureReferenceMemory) {
+        finalResult = RunTestOverGraph<LLVM, Spilling>(params, false);
+    } else {
+        for (int i = 1; i <= params.NumAttempts; ++i) {
+            Cerr << "------ : run " << i << " of " << params.NumAttempts << Endl;
+
+            TRunResult runResult = RunForked([&]() {
+                return RunTestOverGraph<LLVM, Spilling>(params, false);
+            });
+
+            if (finalResult.has_value()) {
+                MergeRunResults(runResult, *finalResult);
+            } else {
+                finalResult.emplace(runResult);
+            }
+        }
     }
 
-    UNIT_ASSERT_VALUES_EQUAL(refResult.size(), graphResult.size());
-    for (const auto& tuple : refResult) {
-        auto graphIt = graphResult.find(tuple.first);
-        UNIT_ASSERT(graphIt != graphResult.end());
-        UNIT_ASSERT_VALUES_EQUAL(tuple.second, graphIt->second);
+    if (params.MeasureReferenceMemory) {
+        Cerr << "------ Reference memory measurement run" << Endl;
+        TRunResult runResult = RunForked([&]() {
+            return RunTestOverGraph<LLVM, Spilling>(params, true);
+        });
+        Y_ENSURE(finalResult.has_value());
+        finalResult->ReferenceMaxRSSDelta = runResult.ReferenceMaxRSSDelta;
     }
 
-    Cerr << "Graph time raw: " << graphTime << Endl;
-    Cerr << "CPP time raw: " << cppTime << Endl;
-    printout.SubmitTimings(graphTime, cppTime, devnullTime);
+    printout.SubmitMetrics(params, *finalResult, "BlockCombineHashed", LLVM, Spilling);
 }
 
 template void RunTestBlockCombineHashedSimple<false, false>(const TRunParams& params, TTestResultCollector& printout);

--- a/ydb/core/kqp/tools/combiner_perf/simple_last.cpp
+++ b/ydb/core/kqp/tools/combiner_perf/simple_last.cpp
@@ -1,71 +1,31 @@
 #include "simple_last.h"
 
 #include "factories.h"
-#include "converters.h"
+#include "subprocess.h"
 #include "streams.h"
 #include "printout.h"
+#include "preallocated_spiller.h"
 
 #include <yql/essentials/minikql/comp_nodes/ut/mkql_computation_node_ut.h>
 #include <yql/essentials/minikql/computation/mkql_computation_node_holders.h>
 #include <yql/essentials/minikql/comp_nodes/mkql_factories.h>
-#include <yql/essentials/minikql/computation/mock_spiller_factory_ut.h>
+#include <yql/essentials/utils/log/log.h>
 
 #include <library/cpp/testing/unittest/registar.h>
 
 #include <util/system/compiler.h>
+#include <util/stream/file.h>
+
+#include <sys/wait.h>
 
 namespace NKikimr {
 namespace NMiniKQL {
 
-template<bool LLVM, bool Spilling>
-void RunTestCombineLastSimple(const TRunParams& params, TTestResultCollector& printout)
+namespace {
+
+TDuration MeasureGeneratorTime(IComputationGraph& graph, const IDataSampler& sampler)
 {
-    TSetup<LLVM, Spilling> setup(GetPerfTestFactory());
-
-    printout.SubmitTestNameAndParams(params, __func__, LLVM, Spilling);
-
-    const size_t numSamples = params.RowsPerRun;
-    const size_t numIters = params.NumRuns; // Will process numSamples * numIters items
-    const size_t maxKey = params.MaxKey; // maxKey + 1 distinct keys, each key multiplied by 64 for some reason
-
-    TString64DataSampler sampler(numSamples, maxKey, numIters, params.LongStringKeys);
-    // or T6464DataSampler sampler(numSamples, maxKey, numIters); -- maybe make selectable from params
-    Cerr << "Sampler type: " << sampler.Describe() << Endl;
-
-    TProgramBuilder& pb = *setup.PgmBuilder;
-
-    const auto streamItemType = pb.NewMultiType({sampler.GetKeyType(pb), pb.NewDataType(NUdf::TDataType<ui64>::Id)});
-    const auto streamType = pb.NewStreamType(streamItemType);
-    const auto streamCallable = TCallableBuilder(pb.GetTypeEnvironment(), "TestList", streamType).Build();
-
-    /*
-    flow: generate a flow of wide MultiType values (uint64 { key, value } pairs) from the input stream
-    extractor: get key from an item
-    init: initialize the state with the item value
-    update: state += value (why AggrAdd though?)
-    finish: return key + state
-    */
-    const auto pgmReturn = pb.Collect(pb.NarrowMap(
-        WideLastCombiner<Spilling>(
-            pb,
-            pb.ToFlow(TRuntimeNode(streamCallable, false)),
-            [&](TRuntimeNode::TList items) -> TRuntimeNode::TList { return {items.front()}; }, // extractor
-            [&](TRuntimeNode::TList, TRuntimeNode::TList items) -> TRuntimeNode::TList { return {items.back()}; }, // init
-            [&](TRuntimeNode::TList, TRuntimeNode::TList items, TRuntimeNode::TList state) -> TRuntimeNode::TList {
-                return {pb.AggrAdd(state.front(), items.back())};
-            }, // update
-            [&](TRuntimeNode::TList keys, TRuntimeNode::TList state) -> TRuntimeNode::TList { return {keys.front(), state.front()}; } // finish
-        ), // NarrowMap flow
-        [&](TRuntimeNode::TList items) -> TRuntimeNode { return pb.NewTuple(items); } // NarrowMap handler
-    ));
-
-    const auto graph = setup.BuildGraph(pgmReturn, {streamCallable});
-    if (Spilling) {
-        graph->GetContext().SpillerFactory = std::make_shared<TMockSpillerFactory>();
-    }
-
-    // Measure the input stream run time
-    const auto devnullStream = sampler.MakeStream(graph->GetHolderFactory());
+    const auto devnullStream = sampler.MakeStream(graph.GetHolderFactory());
     const auto devnullStart = TInstant::Now();
     {
         NUdf::TUnboxedValue columns[2];
@@ -73,25 +33,180 @@ void RunTestCombineLastSimple(const TRunParams& params, TTestResultCollector& pr
         }
     }
     const auto devnullTime = TInstant::Now() - devnullStart;
+    return devnullTime;
+}
 
-    // Reference implementation (sum via an std::unordered_map)
-    auto referenceStream = sampler.MakeStream(graph->GetHolderFactory());
-    const auto t = TInstant::Now();
-    sampler.ComputeReferenceResult(*referenceStream);
-    const auto cppTime = TInstant::Now() - t;
+template<bool LLVM, bool Spilling>
+THolder<IComputationGraph> BuildGraph(TSetup<LLVM, Spilling>& setup, std::shared_ptr<ISpillerFactory> spillerFactory, IDataSampler& sampler)
+{
+    TProgramBuilder& pb = *setup.PgmBuilder;
 
-    // Compute graph implementation
+    const auto streamItemType = pb.NewMultiType({sampler.GetKeyType(pb), pb.NewDataType(NUdf::TDataType<ui64>::Id)});
+    const auto streamType = pb.NewStreamType(streamItemType);
+    const auto streamCallable = TCallableBuilder(pb.GetTypeEnvironment(), "TestList", streamType).Build();
+
+    /*
+    flow: generate a flow of wide MultiType values ({ key, value } pairs) from the input stream
+    extractor: get key from an item
+    init: initialize the state with the item value
+    update: state += value
+    finish: return key + state
+    */
+    const auto pgmReturn = pb.FromFlow(WideLastCombiner<Spilling>(
+        pb,
+        pb.ToFlow(TRuntimeNode(streamCallable, false)),
+        [&](TRuntimeNode::TList items) -> TRuntimeNode::TList { return {items.front()}; }, // extractor
+        [&](TRuntimeNode::TList, TRuntimeNode::TList items) -> TRuntimeNode::TList { return {items.back()}; }, // init
+        [&](TRuntimeNode::TList, TRuntimeNode::TList items, TRuntimeNode::TList state) -> TRuntimeNode::TList {
+            return {pb.AggrAdd(state.front(), items.back())};
+        }, // update
+        [&](TRuntimeNode::TList keys, TRuntimeNode::TList state) -> TRuntimeNode::TList { return {keys.front(), state.front()}; } // finish
+    ));
+
+    auto graph = setup.BuildGraph(pgmReturn, {streamCallable});
+    if (Spilling) {
+        graph->GetContext().SpillerFactory = spillerFactory;
+    }
+
     auto myStream = NUdf::TUnboxedValuePod(sampler.MakeStream(graph->GetHolderFactory()).Release());
     graph->GetEntryPoint(0, true)->SetValue(graph->GetContext(), std::move(myStream));
 
-    const auto t1 = TInstant::Now();
-    const auto& value = graph->GetValue();
-    const auto graphTime = TInstant::Now() - t1;
+    return graph;
+}
 
-    // Verification
-    sampler.VerifyComputedValueVsReference(value);
+template<bool LLVM, bool Spilling>
+TRunResult RunTestOverGraph(const TRunParams& params, const bool needsVerification, const bool measureReferenceMemory)
+{
+    TSetup<LLVM, Spilling> setup(GetPerfTestFactory());
 
-    printout.SubmitTimings(graphTime, cppTime, devnullTime);
+    NYql::NLog::InitLogger("cerr", false);
+
+    THolder<IDataSampler> sampler = CreateWideSamplerFromParams(params);
+    Cerr << "Sampler type: " << sampler->Describe() << Endl;
+
+    std::shared_ptr<ISpillerFactory> spillerFactory = Spilling ? std::make_shared<TPreallocatedSpillerFactory>() : nullptr;
+
+    auto measureGraphTime = [&](auto& computeGraphPtr) {
+        // Compute node implementation
+
+        Cerr << "Compute graph result" << Endl;
+        const auto graphTimeStart = TInstant::Now();
+        size_t lineCount = CountWideStreamOutputs<2>(computeGraphPtr->GetValue());
+        Cerr << lineCount << Endl;
+
+        return TInstant::Now() - graphTimeStart;
+    };
+
+    auto measureRefTime = [&](auto& computeGraphPtr, IDataSampler& sampler) {
+        // Reference implementation (sum via an std::unordered_map)
+
+        Cerr << "Compute reference result" << Endl;
+        auto referenceStream = sampler.MakeStream(computeGraphPtr->GetHolderFactory());
+        const auto cppTimeStart = TInstant::Now();
+        sampler.ComputeReferenceResult(*referenceStream);
+
+        return TInstant::Now() - cppTimeStart;
+    };
+
+    auto graphRun1 = BuildGraph(setup, spillerFactory, *sampler);
+
+    TRunResult result;
+
+    if (measureReferenceMemory || params.TestMode == ETestMode::RefOnly) {
+        long maxRssBefore = GetMaxRSS();
+        result.ReferenceTime = measureRefTime(graphRun1, *sampler);
+        result.ReferenceMaxRSSDelta = GetMaxRSSDelta(maxRssBefore);
+        return result;
+    }
+
+    if (params.TestMode == ETestMode::GraphOnly || params.TestMode == ETestMode::Full) {
+        long maxRssBefore = GetMaxRSS();
+        Cerr << "Raw MaxRSS before: " << maxRssBefore << Endl;
+        result.ResultTime = measureGraphTime(graphRun1);
+        result.MaxRSSDelta = GetMaxRSSDelta(maxRssBefore);
+
+        Cerr << "Raw MaxRSS after: " << GetMaxRSS() << Endl;
+        Cerr << "MaxRSS delta, bytes: " << result.MaxRSSDelta << Endl;
+
+        if (params.TestMode == ETestMode::GraphOnly) {
+            return result;
+        }
+
+        if (spillerFactory) {
+            for (const auto& spiller : static_cast<const TPreallocatedSpillerFactory*>(spillerFactory.get())->GetCreatedSpillers()) {
+                const auto& putSizes = static_cast<TPreallocatedSpiller*>(spiller.get())->GetPutSizes();
+                size_t allocSize = 0;
+                for (const auto size : putSizes) {
+                    allocSize += size;
+                }
+                Cerr << "Spiller: " << putSizes.size() << " allocations, " << allocSize / (1024*1024) << " MB total size" << Endl;
+            }
+        }
+    }
+
+    if (params.TestMode == ETestMode::GeneratorOnly || params.TestMode == ETestMode::Full) {
+        // Measure the input stream run time
+
+        Cerr << "Generator run" << Endl;
+        result.GeneratorTime = MeasureGeneratorTime(*graphRun1, *sampler);
+
+        if (params.TestMode == ETestMode::GeneratorOnly) {
+            return result;
+        }
+    }
+
+    result.ReferenceTime = measureRefTime(graphRun1, *sampler);
+
+    // Verification (re-run the graph again but actually collect the output values into a map)
+    if (needsVerification) {
+        spillerFactory = Spilling ? std::make_shared<TMockSpillerFactory>() : nullptr;
+        Cerr << "Compute and verify the graph result" << Endl;
+        auto graphRun2 = BuildGraph(setup, spillerFactory, *sampler);
+        sampler->VerifyStreamVsReference(graphRun2->GetValue());
+    }
+
+    return result;
+}
+
+}
+
+template<bool LLVM, bool Spilling>
+void RunTestCombineLastSimple(const TRunParams& params, TTestResultCollector& printout)
+{
+    std::optional<TRunResult> finalResult;
+
+    Cerr << "======== " << __func__ << ", keys: " << params.NumKeys << ", llvm: " << LLVM << ", spilling: " << Spilling << Endl;
+
+    if (params.NumAttempts <= 1 && !params.MeasureReferenceMemory) {
+        finalResult = RunTestOverGraph<LLVM, Spilling>(params, true, false);
+    }
+    else {
+        for (int i = 1; i <= params.NumAttempts; ++i) {
+            Cerr << "------ Run " << i << " of " << params.NumAttempts << Endl;
+
+            const bool needsVerification = (i == 1);
+            TRunResult runResult = RunForked([&]() {
+                return RunTestOverGraph<LLVM, Spilling>(params, needsVerification, false);
+            });
+
+            if (finalResult.has_value()) {
+                MergeRunResults(runResult, *finalResult);
+            } else {
+                finalResult.emplace(runResult);
+            }
+        }
+    }
+
+    if (params.MeasureReferenceMemory) {
+        Cerr << "------ Reference memory measurement run" << Endl;
+        TRunResult runResult = RunForked([&]() {
+            return RunTestOverGraph<LLVM, Spilling>(params, false, true);
+        });
+        Y_ENSURE(finalResult.has_value());
+        finalResult->ReferenceMaxRSSDelta = runResult.ReferenceMaxRSSDelta;
+    }
+
+    printout.SubmitMetrics(params, *finalResult, "WideLastCombiner", LLVM, Spilling);
 }
 
 template void RunTestCombineLastSimple<false, false>(const TRunParams& params, TTestResultCollector& printout);

--- a/ydb/core/kqp/tools/combiner_perf/streams.cpp
+++ b/ydb/core/kqp/tools/combiner_perf/streams.cpp
@@ -1,47 +1,263 @@
 #include "streams.h"
 
+#include <contrib/libs/apache/arrow/cpp/src/arrow/type_fwd.h>
+#include <contrib/libs/apache/arrow/cpp/src/arrow/array/array_primitive.h>
+#include <contrib/libs/apache/arrow/cpp/src/arrow/chunked_array.h>
+#include <contrib/libs/apache/arrow/cpp/src/arrow/array.h>
+
 namespace NKikimr {
 namespace NMiniKQL {
 
-T6464Samples MakeKeyed6464Samples(const size_t numSamples, const unsigned int maxKey) {
+T6464Samples MakeKeyed6464Samples(const ui64 seed, const size_t numSamples, const unsigned int maxKey) {
     std::default_random_engine eng;
-    std::uniform_int_distribution<unsigned int> keys(0, maxKey);
     std::uniform_int_distribution<uint64_t> unif(0, 100000.0);
+
+    size_t currKey = 0;
 
     T6464Samples samples(numSamples);
 
-    eng.seed(std::time(nullptr));
+    eng.seed(seed);
     std::generate(samples.begin(), samples.end(),
         [&]() -> auto {
-            return std::make_pair<uint64_t, uint64_t>(keys(eng), unif(eng));
+            if (currKey > maxKey) {
+                currKey = 0;
+            }
+            return std::make_pair<ui64, ui64>(currKey++, unif(eng));
         }
     );
+
+    std::shuffle(samples.begin(), samples.end(), eng);
 
     return samples;
 }
 
-TString64Samples MakeKeyedString64Samples(const size_t numSamples, const unsigned int maxKey, const bool longStrings) {
+TString64Samples MakeKeyedString64Samples(const ui64 seed, const size_t numSamples, const unsigned int maxKey, const bool longStrings) {
     std::default_random_engine eng;
-    std::uniform_int_distribution<unsigned int> keys(0, maxKey);
     std::uniform_int_distribution<uint64_t> unif(0, 100000.0);
+
+    size_t currKey = 0;
 
     TString64Samples samples(numSamples);
 
-    eng.seed(std::time(nullptr));
+    eng.seed(seed);
     std::generate(samples.begin(), samples.end(),
         [&]() -> auto {
-            auto key = keys(eng);
+            auto key = (currKey++);
+            if (currKey > maxKey) {
+                currKey = 0;
+            }
             std::string strKey;
             if (!longStrings) {
                 strKey = std::string(ToString(key));
             } else {
-                strKey = Sprintf("%07u.%07u.%07u.", key, key, key);
+                strKey = Sprintf("%08u.%08u.%08u.", key, key, key);
             }
-            return std::make_pair<std::string, uint64_t>(std::move(strKey), unif(eng));
+            return std::make_pair<std::string, ui64>(std::move(strKey), unif(eng));
         }
     );
 
+    std::shuffle(samples.begin(), samples.end(), eng);
+
     return samples;
+}
+
+THolder<IDataSampler> CreateWideSamplerFromParams(const TRunParams& params)
+{
+    Y_ENSURE(params.RandomSeed.has_value());
+
+    switch (params.SamplerType) {
+    case ESamplerType::StringKeysUI64Values:
+        return MakeHolder<TString64DataSampler>(*params.RandomSeed, params.RowsPerRun, params.NumKeys - 1, params.NumRuns, params.LongStringKeys);
+    case ESamplerType::UI64KeysUI64Values:
+        return MakeHolder<T6464DataSampler>(*params.RandomSeed, params.RowsPerRun, params.NumKeys - 1, params.NumRuns);
+    }
+}
+
+template<typename K>
+void UpdateMapFromBlocks(const NUdf::TUnboxedValue& key, const NUdf::TUnboxedValue& value, std::unordered_map<K, ui64>& result);
+
+template<>
+void UpdateMapFromBlocks(const NUdf::TUnboxedValue& key, const NUdf::TUnboxedValue& value, std::unordered_map<ui64, ui64>& result)
+{
+    auto datumKey = TArrowBlock::From(key).GetDatum();
+    auto datumValue = TArrowBlock::From(value).GetDatum();
+    UNIT_ASSERT(datumKey.is_array());
+    UNIT_ASSERT(datumValue.is_array());
+
+    const auto ui64keys = datumKey.template array_as<arrow::UInt64Array>();
+    const auto ui64values = datumValue.template array_as<arrow::UInt64Array>();
+    UNIT_ASSERT(!!ui64keys);
+    UNIT_ASSERT(!!ui64values);
+    UNIT_ASSERT_VALUES_EQUAL(ui64keys->length(), ui64values->length());
+
+    const size_t length = ui64keys->length();
+    for (size_t i = 0; i < length; ++i) {
+        result[ui64keys->Value(i)] += ui64values->Value(i);
+    }
+}
+
+template<>
+void UpdateMapFromBlocks(const NUdf::TUnboxedValue& key, const NUdf::TUnboxedValue& value, std::unordered_map<std::string, ui64>& result)
+{
+    auto datumKey = TArrowBlock::From(key).GetDatum();
+    auto datumValue = TArrowBlock::From(value).GetDatum();
+    UNIT_ASSERT(datumKey.is_arraylike());
+    UNIT_ASSERT(datumValue.is_array());
+
+    const auto ui64values = datumValue.template array_as<arrow::UInt64Array>();
+    UNIT_ASSERT(!!ui64values);
+
+    int64_t valueOffset = 0;
+
+    for (const auto& chunk : datumKey.chunks()) {
+        auto* barray = dynamic_cast<arrow::BinaryArray*>(chunk.get());
+        UNIT_ASSERT(barray != nullptr);
+        for (int64_t i = 0; i < barray->length(); ++i) {
+            auto key = barray->GetString(i);
+            auto val = ui64values->Value(valueOffset);
+            result[key] += val;
+            ++valueOffset;
+        }
+    }
+}
+
+
+template<typename T>
+TType* GetVerySimpleDataType(const TTypeEnvironment& env)
+{
+    return TDataType::Create(NUdf::TDataType<T>::Id, env);
+}
+
+template<>
+TType* GetVerySimpleDataType<std::string>(const TTypeEnvironment& env)
+{
+    return TDataType::Create(NUdf::TDataType<char*>::Id, env);
+}
+
+template<typename K, typename V>
+class TBlockSampler : public IBlockSampler
+{
+    using TSamples = TBlockKVStream<K, V>::TSamples;
+
+public:
+    // TODO: Also store the TTypeEnvironment& and K/V TTypes? It's shared between multiple stream runs.
+
+    TBlockSampler(const TRunParams& params, TSamples&& samples)
+        : Samples(std::move(samples))
+        , NumIters(params.NumRuns)
+        , BlockSize(params.BlockSize)
+    {
+    }
+
+    THolder<IWideStream> MakeStream(const TComputationContext& ctx) const override
+    {
+        std::vector<TType*> types {BuildKeyType(ctx.TypeEnv), BuildValueType(ctx.TypeEnv)};
+        return MakeHolder<TBlockKVStream<K, V>>(
+            ctx,
+            Samples,
+            NumIters,
+            BlockSize,
+            std::move(types)
+        );
+    }
+
+    TType* BuildKeyType(const TTypeEnvironment& env) const override
+    {
+        return GetVerySimpleDataType<K>(env);
+    }
+
+    TType* BuildValueType(const TTypeEnvironment& env) const override
+    {
+        return GetVerySimpleDataType<V>(env);
+    }
+
+    void ComputeRawResult() override
+    {
+        Y_ENSURE(RawResult.empty());
+
+        for (const auto& tuple : Samples) {
+            RawResult[tuple.first] += (tuple.second * NumIters);
+        }
+    }
+
+    void ComputeReferenceResult(TComputationContext& ctx) override
+    {
+        Y_ENSURE(RefResult.empty());
+
+        const THolder<IWideStream> refStreamPtr = MakeStream(ctx);
+        IWideStream& refStream = *refStreamPtr;
+
+        NUdf::TUnboxedValue columns[3];
+
+        while (refStream.WideFetch(columns, 3) == NUdf::EFetchStatus::Ok) {
+            UpdateMapFromBlocks(columns[0], columns[1], RefResult);
+        }
+    }
+
+    void VerifyReferenceResultAgainstRaw() override
+    {
+        Y_ENSURE(!RefResult.empty());
+        Y_ENSURE(!RawResult.empty());
+
+        // TODO: Replace UNIT_ASSERTS with something else, or actually set up the unit test thread context
+        UNIT_ASSERT_VALUES_EQUAL(RefResult.size(), RawResult.size());
+        for (const auto& tuple : RawResult) {
+            auto otherIt = RefResult.find(tuple.first);
+            UNIT_ASSERT(otherIt != RefResult.end());
+            UNIT_ASSERT_VALUES_EQUAL(tuple.second, otherIt->second);
+        }
+    }
+
+    void VerifyGraphResultAgainstReference(const NUdf::TUnboxedValue& blockList) override
+    {
+        Y_ENSURE(!RefResult.empty());
+
+        size_t numResultItems = blockList.GetListLength();
+        Cerr << "Result block count: " << numResultItems << Endl;
+
+        std::unordered_map<K, V> graphResult;
+
+        const auto ptr = blockList.GetElements();
+        for (size_t i = 0ULL; i < numResultItems; ++i) {
+            // TODO: Replace UNIT_ASSERTS with something else, or actually set up the unit test thread context
+            UNIT_ASSERT(ptr[i].GetListLength() >= 2);
+
+            const auto elements = ptr[i].GetElements();
+
+            UpdateMapFromBlocks(elements[0], elements[1], graphResult);
+        }
+
+        UNIT_ASSERT_VALUES_EQUAL(RefResult.size(), graphResult.size());
+        for (const auto& tuple : RefResult) {
+            auto graphIt = graphResult.find(tuple.first);
+            UNIT_ASSERT(graphIt != graphResult.end());
+            UNIT_ASSERT_VALUES_EQUAL(tuple.second, graphIt->second);
+        }
+    }
+
+private:
+    TSamples Samples;
+    size_t NumIters;
+    size_t BlockSize;
+
+    std::unordered_map<K, V> RawResult;
+    std::unordered_map<K, V> RefResult;
+};
+
+THolder<IBlockSampler> CreateBlockSamplerFromParams(const TRunParams& params)
+{
+    Y_ENSURE(params.RandomSeed.has_value());
+
+    switch(params.SamplerType) {
+    case ESamplerType::StringKeysUI64Values:
+        return MakeHolder<TBlockSampler<std::string, ui64>>(
+            params,
+            MakeKeyedString64Samples(*params.RandomSeed, params.RowsPerRun, params.NumKeys - 1, params.LongStringKeys));
+    case ESamplerType::UI64KeysUI64Values:
+        return MakeHolder<TBlockSampler<ui64, ui64>>(
+            params,
+            MakeKeyed6464Samples(*params.RandomSeed, params.RowsPerRun, params.NumKeys - 1));
+    }
 }
 
 }

--- a/ydb/core/kqp/tools/combiner_perf/subprocess.cpp
+++ b/ydb/core/kqp/tools/combiner_perf/subprocess.cpp
@@ -1,0 +1,45 @@
+#include "subprocess.h"
+
+#include <util/stream/output.h>
+#include <util/stream/pipe.h>
+#include <util/stream/buffer.h>
+#include <util/generic/buffer.h>
+#include <sys/resource.h>
+#include <sys/wait.h>
+
+TRunResult RunForked(TRunPayload payload)
+{
+    Cout.Flush();
+    Cerr.Flush();
+
+    TPipeHandle sender;
+    TPipeHandle receiver;
+    TPipeHandle::Pipe(receiver, sender);
+
+    pid_t pid = fork();
+    if (pid > 0) {
+        int status = 0;
+        while (waitpid(pid, &status, 0) < 0 && errno == EINTR) {
+        }
+        if (status != 0) {
+            ythrow yexception() << "A forked test has crashed with exit code " << status;
+        }
+
+        sender.Close();
+
+        TPipedInput inf(receiver);
+        TRunResult payloadResult;
+        payloadResult.Load(&inf);
+        return payloadResult;
+    }
+    else if (pid < 0) {
+        ythrow yexception() << "Failed to fork the test: " << errno;
+    }
+
+    receiver.Close();
+    TRunResult result = payload();
+    TPipedOutput outf(sender);
+    result.Save(&outf);
+    outf.Finish();
+    std::exit(0);
+}

--- a/ydb/core/kqp/tools/combiner_perf/subprocess.h
+++ b/ydb/core/kqp/tools/combiner_perf/subprocess.h
@@ -1,0 +1,9 @@
+#pragma once
+
+#include "printout.h"
+
+#include <functional>
+
+using TRunPayload = std::function<TRunResult()>;
+
+TRunResult RunForked(TRunPayload payload);

--- a/ydb/core/kqp/tools/combiner_perf/tpch_last.cpp
+++ b/ydb/core/kqp/tools/combiner_perf/tpch_last.cpp
@@ -46,21 +46,20 @@ std::vector<std::tuple<ui64, std::string, std::string, double, double, double, d
 }
 
 
-const std::vector<std::tuple<ui64, std::string, std::string, double, double, double, double>> TpchSamples = MakeTpchSamples();
-
-
 template<bool LLVM, bool Spilling>
 void RunTestLastTpch()
 {
     TSetup<LLVM, Spilling> setup(GetPerfTestFactory());
 
-    Cerr << "tpc-h sample has " << TpchSamples.size() << " rows" << Endl;
+    const std::vector<std::tuple<ui64, std::string, std::string, double, double, double, double>> tpchSamples = MakeTpchSamples();
+
+    Cerr << "tpc-h sample has " << tpchSamples.size() << " rows" << Endl;
 
     struct TPairHash { size_t operator()(const std::pair<std::string_view, std::string_view>& p) const { return CombineHashes(std::hash<std::string_view>()(p.first), std::hash<std::string_view>()(p.second)); } };
 
     std::unordered_map<std::pair<std::string_view, std::string_view>, std::pair<ui64, std::array<double, 5U>>, TPairHash> expects;
     const auto t = TInstant::Now();
-    for (auto& sample : TpchSamples) {
+    for (auto& sample : tpchSamples) {
         if (std::get<0U>(sample) <= TpchDateBorder) {
             const auto& ins = expects.emplace(std::pair<std::string_view, std::string_view>{std::get<1U>(sample), std::get<2U>(sample)}, std::pair<ui64, std::array<double, 5U>>{0ULL, {0., 0., 0., 0., 0.}});
             auto& item = ins.first->second;

--- a/ydb/core/kqp/tools/combiner_perf/ya.make
+++ b/ydb/core/kqp/tools/combiner_perf/ya.make
@@ -43,9 +43,11 @@ ENDIF()
 SRCS(
     converters.cpp
     factories.cpp
+    printout.cpp
     simple.cpp
     simple_block.cpp
     simple_last.cpp
+    subprocess.cpp
     streams.cpp
     tpch_last.cpp
 )


### PR DESCRIPTION
- JSON output and markdown formatter
- MaxRSS delta measurements
- Optional: multiple run attempts (each attempt runs in its own "clean" subprocess)
- Optional: measure RAM usage of the reference implementation
- Spiller factory with buffer preallocation
- LastCombiner tests with spilling
- Command line options and the ability to run singular tests (a large-ish test suite runs by default)

Single test example: `./combiner_perf -t block-combiner -m graph` to only run the compute graph, or `./combiner_perf -t block-combiner -m graph` to only generate input (see -h for configurable options such as the test scale, block size, etc.)

### Changelog category <!-- remove all except one -->

* Not for changelog (changelog entry is not required)
