### PR TITLE
healthcheck: use State fiels from bsc response instead of StatusV2

### DIFF
--- a/ydb/core/health_check/health_check.cpp
+++ b/ydb/core/health_check/health_check.cpp
@@ -2151,7 +2151,7 @@ public:
         const auto& stateString = pDisk.GetState();
         const auto *descriptor = NKikimrBlobStorage::TPDiskState::E_descriptor();
         auto state = descriptor->FindValueByName(stateString);
-        if (!state) {;
+        if (!state) {
             context.ReportStatus(Ydb::Monitoring::StatusFlag::RED,
                                  TStringBuilder() << "Unknown PDisk state: " << stateString,
                                  ETags::PDiskState);
@@ -2159,7 +2159,8 @@ public:
             context.OverallStatus = Ydb::Monitoring::StatusFlag::ORANGE;
             return;
         }
-        switch (state->number()) {
+        auto stateEnum = static_cast<NKikimrBlobStorage::TPDiskState::E>(state->number());
+        switch (stateEnum) {
             case NKikimrBlobStorage::TPDiskState::Normal:
             case NKikimrBlobStorage::TPDiskState::Stopped:
                 context.ReportStatus(Ydb::Monitoring::StatusFlag::GREEN);
@@ -2287,7 +2288,8 @@ public:
             FillPDiskStatus(pDiskId, *storageVDiskStatus.mutable_pdisk(), {&context, "PDISK"});
         }
 
-        if (status->number() == NKikimrBlobStorage::ERROR) {
+        auto statusEnum = static_cast<NKikimrBlobStorage::EVDiskStatus>(status->number());
+        if (statusEnum == NKikimrBlobStorage::ERROR) {
             // the disk is not operational at all
             context.ReportStatus(Ydb::Monitoring::StatusFlag::RED, TStringBuilder() << "VDisk is not available", ETags::VDiskState,{ETags::PDiskState});
             storageVDiskStatus.set_overall(context.GetOverallStatus());
@@ -2303,7 +2305,11 @@ public:
             return;
         }
 
-        switch (status->number()) {
+        switch (statusEnum) {
+            case NKikimrBlobStorage::ERROR: {
+                // already handled above
+                break;
+            }
             case NKikimrBlobStorage::REPLICATING: { // the disk accepts queries, but not all the data was replicated
                 context.ReportStatus(Ydb::Monitoring::StatusFlag::BLUE, TStringBuilder() << "Replication in progress", ETags::VDiskState);
                 storageVDiskStatus.set_overall(context.GetOverallStatus());
@@ -2313,8 +2319,6 @@ public:
             case NKikimrBlobStorage::READY: { // the disk is fully operational and does not affect group fault tolerance
                 context.ReportStatus(Ydb::Monitoring::StatusFlag::GREEN);
             }
-            default:
-                break;
         }
 
         storageVDiskStatus.set_overall(context.GetOverallStatus());
@@ -2379,7 +2383,7 @@ public:
 
         if (pDiskInfo.HasState()) {
             switch (pDiskInfo.GetState()) {
-                case NKikimrBlobStorage::TPDiskState::Normal:
+                // case NKikimrBlobStorage::TPDiskState::Normal:
                 case NKikimrBlobStorage::TPDiskState::Stopped:
                     context.ReportStatus(Ydb::Monitoring::StatusFlag::GREEN);
                     break;

--- a/ydb/core/health_check/health_check_ut.cpp
+++ b/ydb/core/health_check/health_check_ut.cpp
@@ -2373,7 +2373,7 @@ Y_UNIT_TEST_SUITE(THealthCheckTest) {
                     auto* x = reinterpret_cast<NSysView::TEvSysView::TEvGetPDisksResponse::TPtr*>(&ev);
                     auto& record = (*x)->Get()->Record;
                     for (auto& entry : *record.mutable_entries()) {
-                        entry.mutable_info()->set_statusv2("UNKNOWN_STATE?");
+                        entry.mutable_info()->set_state("UNKNOWN_STATE?");
                     }
                     break;
                 }


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

healthcheck: use State field from bsc response instead of StatusV2 to determine pdisk state

### Changelog category <!-- remove all except one -->

* Improvement

### Description for reviewers <!-- (optional) description for those who read this PR -->

Health check may report OK for a PDisk with INACTIVE CMS status, which is not always correct if the PDisk is actually dead.

Added a new field State to BSC information to improve determination of PDisk statuses. This is the same field used in fallback scenarios, allowing unified logic across all cases.
