### PR TITLE
Materialized SysView paths

### DIFF
--- a/ydb/core/tx/scheme_board/cache.cpp
+++ b/ydb/core/tx/scheme_board/cache.cpp
@@ -1853,7 +1853,7 @@ class TSchemeCache: public TMonitorableActor<TSchemeCache> {
                 return SetError(context, entry, TNavigate::EStatus::LookupError);
             }
 
-            if (!entry.TableId.SysViewInfo.empty() && Kind != TNavigate::KindSysView) {
+            if (!entry.TableId.SysViewInfo.empty()) {
                 if (Kind == TNavigate::KindPath) {
                     auto split = SplitPath(Path);
                     if (split.size() == 1) {
@@ -1927,7 +1927,6 @@ class TSchemeCache: public TMonitorableActor<TSchemeCache> {
                 entry.Path = SplitPath(Path);
                 // update schema version
                 entry.TableId.SchemaVersion = SchemaVersion;
-
             }
 
             if (entry.Operation == TNavigate::OpList) {
@@ -2076,7 +2075,7 @@ class TSchemeCache: public TMonitorableActor<TSchemeCache> {
                 return SetError(context, entry, TResolve::EStatus::LookupError, TKeyDesc::EStatus::NotExists);
             }
 
-            if (!keyDesc.TableId.SysViewInfo.empty() && Kind != TNavigate::KindSysView) {
+            if (!keyDesc.TableId.SysViewInfo.empty()) {
                 if (Kind == TNavigate::KindPath) {
                     auto split = SplitPath(Path);
                     if (split.size() == 1) {
@@ -2683,6 +2682,42 @@ class TSchemeCache: public TMonitorableActor<TSchemeCache> {
         Register(CreateAccessChecker(context));
     }
 
+    template <>
+    void Complete<TNavigateContextPtr>(TNavigateContextPtr context) {
+        Counters.FinishRequest(Now() - context->CreatedAt);
+        if (context->HasSysViewEntries) {
+            auto& resultSet = context->Request->ResultSet;
+            auto& entriesFallbackInfo = context->EntriesFallbackInfo;
+            size_t eraseStartPos = 0;
+            for (size_t i = 0; i < resultSet.size(); ++i) {
+                if (entriesFallbackInfo[i].FallbackEntryIndex) {
+                    size_t fallbackEntryIndex = *entriesFallbackInfo[i].FallbackEntryIndex;
+                    if (resultSet[i].Status == TNavigate::EStatus::PathErrorUnknown) {
+                        entriesFallbackInfo[i].IsImplicit = true;
+                        entriesFallbackInfo[fallbackEntryIndex].IsImplicit = false;
+                    }
+                }
+
+                if (!entriesFallbackInfo[i].IsImplicit) {
+                    if (i != eraseStartPos) {
+                        std::swap(resultSet[eraseStartPos], resultSet[i]);
+                        std::swap(entriesFallbackInfo[eraseStartPos], entriesFallbackInfo[i]);
+                    }
+                    ++eraseStartPos;
+                } else {
+                    if (resultSet[i].Status != TNavigate::EStatus::Ok) {
+                        --context->Request->ErrorCount;
+                    }
+                }
+            }
+
+            resultSet.erase(resultSet.begin() + eraseStartPos, resultSet.end());
+            entriesFallbackInfo.erase(entriesFallbackInfo.begin() + eraseStartPos, entriesFallbackInfo.end());
+        }
+
+        Register(CreateAccessChecker(context));
+    }
+
     template <typename TContext, typename TEvent>
     TIntrusivePtr<TContext> MakeContext(TEvent& ev) const {
         TIntrusivePtr<TContext> context(new TContext(ev->Sender, ev->Cookie, ev->Get()->Request, Now()));
@@ -2696,6 +2731,16 @@ class TSchemeCache: public TMonitorableActor<TSchemeCache> {
         return context;
     }
 
+    // Note: Specific behavior for requests containing sys views paths
+    // For compatibility with virtual sys views paths (not migrated):
+    // - When an input entry contains a sys view path, a fallback entry is added to the ResultSet end
+    // - Info related to the fallback logic is stored in EntriesFallbackInfo vector in request context
+    // - EntriesFallbackInfo vector is synced with ResultSet
+    // - Fallback entry has IsImplicit flag and is filled with info about parent of '.sys' folder
+    // - Original entry stores index of corresponding fallback entry
+    // - After filling all entries: if sys view entry's path doesn't exist, use fallback entry and remove original;
+    // otherwise use original entry and remove fallback entry
+    // - This approach allows to avoid adding new handlers to SchemeCache actor and changing ProcessInFlight behavior
     void Handle(TEvTxProxySchemeCache::TEvNavigateKeySet::TPtr& ev) {
         SBC_LOG_D("Handle TEvTxProxySchemeCache::TEvNavigateKeySet"
             << ": self# " << SelfId()
@@ -2706,24 +2751,11 @@ class TSchemeCache: public TMonitorableActor<TSchemeCache> {
         }
 
         auto context = MakeContext<TNavigateContext>(ev);
-
-        for (size_t i = 0; i < context->Request->ResultSet.size(); ++i) {
-            auto& entry = context->Request->ResultSet[i];
+        auto& resultSet = context->Request->ResultSet;
+        for (size_t i = 0; i < resultSet.size(); ++i) {
+            auto& entry = resultSet[i];
 
             if (entry.RequestType == TNavigate::TEntry::ERequestType::ByPath) {
-                auto pathExtractor = [this](TNavigate::TEntry& entry) {
-                    NSysView::ISystemViewResolver::TSystemViewPath sysViewPath;
-                    if (AppData()->FeatureFlags.GetEnableSystemViews()
-                        && SystemViewResolver->IsSystemViewPath(entry.Path, sysViewPath))
-                    {
-                        entry.TableId.SysViewInfo = sysViewPath.ViewName;
-                        return CanonizePath(sysViewPath.Parent);
-                    }
-
-                    TString path = CanonizePath(entry.Path);
-                    return path ? path : TString("/");
-                };
-
                 auto tabletIdExtractor = [this](const TNavigate::TEntry& entry) {
                     if (entry.Path.empty()) {
                         return ui64(NSchemeShard::InvalidTabletId);
@@ -2737,7 +2769,38 @@ class TSchemeCache: public TMonitorableActor<TSchemeCache> {
                     return it->second;
                 };
 
-                HandleEntry(context, entry, i, pathExtractor, tabletIdExtractor);
+                NSysView::ISystemViewResolver::TSystemViewPath sysViewPath;
+                if (AppData()->FeatureFlags.GetEnableSystemViews() &&
+                    SystemViewResolver->IsSystemViewPath(entry.Path, sysViewPath)) {
+                    auto& fallbackEntryInfo = context->EntriesFallbackInfo[i];
+                    context->HasSysViewEntries = true;
+                    if (fallbackEntryInfo.IsImplicit) {
+                        entry.TableId.SysViewInfo = sysViewPath.ViewName;
+                        const auto parentCanonizedPath = CanonizePath(sysViewPath.Parent);
+                        auto pathExtractor = [&parentCanonizedPath](TNavigate::TEntry&) {
+                            return parentCanonizedPath;
+                        };
+
+                        HandleEntry(context, entry, i, pathExtractor, tabletIdExtractor);
+                    } else {
+                        fallbackEntryInfo.FallbackEntryIndex = resultSet.size();
+                        resultSet.push_back(entry);
+                        context->EntriesFallbackInfo.emplace_back(true, NothingObject);
+
+                        auto pathExtractor = [](TNavigate::TEntry& entry) {
+                            return CanonizePath(entry.Path);
+                        };
+
+                        HandleEntry(context, resultSet[i], i, pathExtractor, tabletIdExtractor);
+                    }
+                } else {
+                    auto pathExtractor = [](TNavigate::TEntry& entry) {
+                        TString path = CanonizePath(entry.Path);
+                        return path ? path : TString("/");
+                    };
+
+                    HandleEntry(context, entry, i, pathExtractor, tabletIdExtractor);
+                }
             } else {
                 auto pathExtractor = [](const TNavigate::TEntry& entry) {
                     return entry.TableId.PathId;

--- a/ydb/core/tx/scheme_board/cache.h
+++ b/ydb/core/tx/scheme_board/cache.h
@@ -17,12 +17,25 @@ namespace NSchemeCache {
         const TInstant CreatedAt;
         TIntrusivePtr<TDomainInfo> ResolvedDomainInfo; // resolved from DatabaseName
 
+        struct TEntryFallbackInfo {
+            bool IsImplicit = false;
+            TMaybe<size_t> FallbackEntryIndex;
+        };
+
+        // Vector implements fallback entry logic:
+        // - Each element corresponds to an entry from ResultSet
+        // - FallbackEntryIndex refers to the fallback entry
+        // - IsImplicit == true when the entry is a fallback entry
+        TVector<TEntryFallbackInfo> EntriesFallbackInfo;
+        bool HasSysViewEntries = false;
+
         TSchemeCacheNavigateContext(const TActorId& sender, ui64 cookie, TAutoPtr<TSchemeCacheNavigate> request, const TInstant& now = TInstant::Now())
             : Sender(sender)
             , Cookie(cookie)
             , WaitCounter(0)
             , Request(request)
             , CreatedAt(now)
+            , EntriesFallbackInfo(Request->ResultSet.size())
         {}
     };
 

--- a/ydb/core/tx/scheme_board/cache.h
+++ b/ydb/core/tx/scheme_board/cache.h
@@ -8,4 +8,40 @@ namespace NKikimr {
 
 IActor* CreateSchemeBoardSchemeCache(NSchemeCache::TSchemeCacheConfig* config);
 
+namespace NSchemeCache {
+    struct TSchemeCacheNavigateContext : TAtomicRefCount<TSchemeCacheNavigateContext>, TNonCopyable {
+        TActorId Sender;
+        ui64 Cookie;
+        ui64 WaitCounter;
+        TAutoPtr<TSchemeCacheNavigate> Request;
+        const TInstant CreatedAt;
+        TIntrusivePtr<TDomainInfo> ResolvedDomainInfo; // resolved from DatabaseName
+
+        TSchemeCacheNavigateContext(const TActorId& sender, ui64 cookie, TAutoPtr<TSchemeCacheNavigate> request, const TInstant& now = TInstant::Now())
+            : Sender(sender)
+            , Cookie(cookie)
+            , WaitCounter(0)
+            , Request(request)
+            , CreatedAt(now)
+        {}
+    };
+
+    struct TSchemeCacheRequestContext : TAtomicRefCount<TSchemeCacheRequestContext>, TNonCopyable {
+        TActorId Sender;
+        ui64 Cookie;
+        ui64 WaitCounter;
+        TAutoPtr<TSchemeCacheRequest> Request;
+        const TInstant CreatedAt;
+        TIntrusivePtr<TDomainInfo> ResolvedDomainInfo; // resolved from DatabaseName
+
+        TSchemeCacheRequestContext(const TActorId& sender, ui64 cookie, TAutoPtr<TSchemeCacheRequest> request, const TInstant& now = TInstant::Now())
+            : Sender(sender)
+            , Cookie(cookie)
+            , WaitCounter(0)
+            , Request(request)
+            , CreatedAt(now)
+        {}
+    }; // NSchemeCache
+}
+
 } // NKikimr

--- a/ydb/core/tx/scheme_cache/scheme_cache.h
+++ b/ydb/core/tx/scheme_cache/scheme_cache.h
@@ -469,40 +469,6 @@ struct TSchemeCacheRequest {
 
 }; // TSchemeCacheRequest
 
-struct TSchemeCacheRequestContext : TAtomicRefCount<TSchemeCacheRequestContext>, TNonCopyable {
-    TActorId Sender;
-    ui64 Cookie;
-    ui64 WaitCounter;
-    TAutoPtr<TSchemeCacheRequest> Request;
-    const TInstant CreatedAt;
-    TIntrusivePtr<TDomainInfo> ResolvedDomainInfo; // resolved from DatabaseName
-
-    TSchemeCacheRequestContext(const TActorId& sender, ui64 cookie, TAutoPtr<TSchemeCacheRequest> request, const TInstant& now = TInstant::Now())
-        : Sender(sender)
-        , Cookie(cookie)
-        , WaitCounter(0)
-        , Request(request)
-        , CreatedAt(now)
-    {}
-};
-
-struct TSchemeCacheNavigateContext : TAtomicRefCount<TSchemeCacheNavigateContext>, TNonCopyable {
-    TActorId Sender;
-    ui64 Cookie;
-    ui64 WaitCounter;
-    TAutoPtr<TSchemeCacheNavigate> Request;
-    const TInstant CreatedAt;
-    TIntrusivePtr<TDomainInfo> ResolvedDomainInfo; // resolved from DatabaseName
-
-    TSchemeCacheNavigateContext(const TActorId& sender, ui64 cookie, TAutoPtr<TSchemeCacheNavigate> request, const TInstant& now = TInstant::Now())
-        : Sender(sender)
-        , Cookie(cookie)
-        , WaitCounter(0)
-        , Request(request)
-        , CreatedAt(now)
-    {}
-};
-
 class TDescribeResult
     : public TAtomicRefCount<TDescribeResult>
     , public NKikimrScheme::TEvDescribeSchemeResult

--- a/ydb/core/tx/tx_proxy/describe.cpp
+++ b/ydb/core/tx/tx_proxy/describe.cpp
@@ -400,7 +400,7 @@ void TDescribeReq::Handle(TEvTxProxySchemeCache::TEvNavigateKeySetResult::TPtr &
 
     const auto& describePath = SchemeRequest->Ev->Get()->Record.GetDescribePath();
 
-    if (entry.TableId.IsSystemView() && entry.Kind != TNavigate::KindSysView) {
+    if (entry.TableId.IsSystemView()) {
         // don't go to schemeshard if entry describes sys view path and this path is virtual
         // for materialized sys view paths send the request to SchemeShard
         const auto& path = describePath.GetPath();


### PR DESCRIPTION
Added compatibility to Scheme Cache to work with materialized sys views paths

SchemeCache:
- Create a fallback entry for the sys view path
- The fallback entry is filled with info about virtual sys view path
- After filling all entries choose the fallback entry if original one is not filled
