### PR TITLE
Limit SelfHeal reassign requests in-flight

### DIFF
--- a/ydb/core/blobstorage/ut_blobstorage/self_heal.cpp
+++ b/ydb/core/blobstorage/ut_blobstorage/self_heal.cpp
@@ -1,0 +1,67 @@
+#include <ydb/core/blobstorage/ut_blobstorage/lib/env.h>
+
+Y_UNIT_TEST_SUITE(SelfHeal) {
+    void TestReassignThrottling() {
+        const TBlobStorageGroupType erasure = TBlobStorageGroupType::ErasureMirror3dc;
+        const ui32 groupsCount = 32;
+
+        TEnvironmentSetup env({
+            .NodeCount = erasure.BlobSubgroupSize(),
+            .Erasure = erasure,
+        });
+
+        // create 2 pdisks per node to allow self-healings and 
+        // allocate groups
+        env.CreateBoxAndPool(2, groupsCount);
+        env.Sim(TDuration::Minutes(1));
+
+        auto base = env.FetchBaseConfig();
+        UNIT_ASSERT_VALUES_EQUAL(base.GroupSize(), groupsCount);
+
+        ui32 maxReassignsInFlight = 0;
+
+        std::set<TActorId> reassignersInFlight;
+
+        auto catchReassigns = [&](ui32 /*nodeId*/, std::unique_ptr<IEventHandle>& ev) { 
+            if (ev->GetTypeRewrite() == TEvBlobStorage::TEvControllerConfigRequest::EventType) {
+                const auto& request = ev->Get<TEvBlobStorage::TEvControllerConfigRequest>()->Record.GetRequest();
+                for (const auto& command : request.GetCommand()) {
+                    if (command.GetCommandCase() == NKikimrBlobStorage::TConfigRequest::TCommand::kReassignGroupDisk) {
+                        UNIT_ASSERT(!reassignersInFlight.contains(ev->Sender));
+                        reassignersInFlight.insert(ev->Sender);
+                        maxReassignsInFlight = std::max(maxReassignsInFlight, (ui32)reassignersInFlight.size());
+                    }
+                }
+            } else if (ev->GetTypeRewrite() == TEvBlobStorage::TEvControllerConfigResponse::EventType) {
+                auto it = reassignersInFlight.find(ev->Recipient);
+                if (it != reassignersInFlight.end()) {
+                    reassignersInFlight.erase(it);
+                }
+            }
+            return true;
+        };
+
+        env.Runtime->FilterFunction = catchReassigns;
+
+        auto pdisk = base.GetPDisk(0);
+        // set FAULTY status on the chosen PDisk
+        {
+            NKikimrBlobStorage::TConfigRequest request;
+            auto* cmd = request.AddCommand()->MutableUpdateDriveStatus();
+            cmd->MutableHostKey()->SetNodeId(pdisk.GetNodeId());
+            cmd->SetPDiskId(pdisk.GetPDiskId());
+            cmd->SetStatus(NKikimrBlobStorage::FAULTY);
+            auto res = env.Invoke(request);
+            UNIT_ASSERT_C(res.GetSuccess(), res.GetErrorDescription());
+            UNIT_ASSERT_C(res.GetStatus(0).GetSuccess(), res.GetStatus(0).GetErrorDescription());
+        }
+
+        env.Sim(TDuration::Minutes(15));
+
+        UNIT_ASSERT_C(maxReassignsInFlight == 1, "maxReassignsInFlight# " << maxReassignsInFlight);
+    }
+
+    Y_UNIT_TEST(ReassignThrottling) {
+        TestReassignThrottling();
+    }
+}

--- a/ydb/core/blobstorage/ut_blobstorage/ya.make
+++ b/ydb/core/blobstorage/ut_blobstorage/ya.make
@@ -41,6 +41,7 @@ SRCS(
     recovery.cpp
     sanitize_groups.cpp
     scrub_fast.cpp
+    self_heal.cpp
     shred.cpp
     snapshots.cpp
     space_check.cpp

--- a/ydb/core/mind/bscontroller/self_heal.cpp
+++ b/ydb/core/mind/bscontroller/self_heal.cpp
@@ -622,6 +622,8 @@ namespace NKikimr::NBsController {
         }
 
         void Handle(TEvReassignerDone::TPtr& ev) {
+            ActiveReassignerActorId = std::nullopt;
+
             if (const auto it = Groups.find(ev->Get()->GroupId); it != Groups.end()) {
                 auto& group = it->second;
                 group.ReassignStatus = EReassignStatus::NotNeeded;
@@ -646,6 +648,8 @@ namespace NKikimr::NBsController {
                 }
 
                 CheckGroups();
+            } else {
+                ProcessReassignQueues();
             }
         }
 

--- a/ydb/core/mind/bscontroller/self_heal.cpp
+++ b/ydb/core/mind/bscontroller/self_heal.cpp
@@ -622,9 +622,10 @@ namespace NKikimr::NBsController {
         }
 
         void Handle(TEvReassignerDone::TPtr& ev) {
-            ActiveReassignerActorId = std::nullopt;
+            Y_ABORT_UNLESS(ActiveReassignerActorId);
+            TActorId reassigner = *std::exchange(ActiveReassignerActorId, std::nullopt);
 
-            if (const auto it = Groups.find(ev->Get()->GroupId); it != Groups.end()) {
+            if (const auto it = Groups.find(ev->Get()->GroupId); it != Groups.end() && reassigner == ev->Sender) {
                 auto& group = it->second;
                 group.ReassignStatus = EReassignStatus::NotNeeded;
                 ProcessReassignQueues();


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

Don't allow SelfHeal actor to create more than 1 active ReassignerActor. This change will prevent SelfHeal from overloading BSC with ReassignItem requests thus causing DoS.

### Changelog category <!-- remove all except one -->

* Improvement
