### PR TITLE
ydbd admin bs disk obliterate - improvement

### DIFF
--- a/ydb/core/blobstorage/pdisk/blobstorage_pdisk_tools.cpp
+++ b/ydb/core/blobstorage/pdisk/blobstorage_pdisk_tools.cpp
@@ -256,8 +256,8 @@ void ObliterateDisk(TString path) {
     for (ui64 i=0; i<GB_BLOCKS; ++i) {
         f.Pwrite(zeros.data(), NPDisk::FormatSectorSize, (i64)(writePos + (i * NPDisk::FormatSectorSize)));
     }
-    f.Flush();
 #endif
+    f.Flush();
 }
 
 } // NKikimr

--- a/ydb/core/blobstorage/pdisk/blobstorage_pdisk_tools.cpp
+++ b/ydb/core/blobstorage/pdisk/blobstorage_pdisk_tools.cpp
@@ -249,7 +249,7 @@ void ObliterateDisk(TString path) {
 
     TVector<ui8> zeros(NPDisk::FormatSectorSize * NPDisk::ReplicationFactor, 0);
     f.Pwrite(zeros.data(), zeros.size(), 0);
-#if defined(YDB_DISABLE_PDISK_ENCRYPTION)
+#ifdef DISABLE_PDISK_ENCRYPTION
     // for non-encrypted pdisks the trailing gigabyte has to be cleared
     constexpr ui64 GB_BLOCKS = GB_BYTES / NPDisk::FormatSectorSize;
     ui64 writePos = diskSizeBytes - GB_BYTES;

--- a/ydb/core/blobstorage/pdisk/blobstorage_pdisk_tools.cpp
+++ b/ydb/core/blobstorage/pdisk/blobstorage_pdisk_tools.cpp
@@ -244,7 +244,8 @@ void ObliterateDisk(TString path) {
 
     constexpr size_t portionSize = NPDisk::FormatSectorSize * NPDisk::ReplicationFactor;
     if (diskSizeBytes <= portionSize) {
-        ythrow TFileError() << "illegal size " << diskSizeBytes << " for device " << path;
+        ythrow yexception() << "file is too small to be the YDB storage device, path# " << path.Quote() <<
+            " diskSizeBytes# " << diskSizeBytes;
     }
 
     TVector<ui8> zeros(portionSize, 0);

--- a/ydb/core/blobstorage/pdisk/blobstorage_pdisk_tools.cpp
+++ b/ydb/core/blobstorage/pdisk/blobstorage_pdisk_tools.cpp
@@ -243,7 +243,6 @@ void ObliterateDisk(TString path) {
     DetectFileParameters(path, diskSizeBytes, isBlockDevice);
 
     constexpr ui64 GB_BYTES = 4096L * 262144L;
-    constexpr ui64 GB_BLOCKS = GB_BYTES / NPDisk::FormatSectorSize;
     if (diskSizeBytes <= GB_BYTES) {
         ythrow TFileError() << "illegal size " << diskSizeBytes << " for device " << path;
     }
@@ -252,6 +251,7 @@ void ObliterateDisk(TString path) {
     f.Pwrite(zeros.data(), zeros.size(), 0);
 #if defined(YDB_DISABLE_PDISK_ENCRYPTION)
     // for non-encrypted pdisks the trailing gigabyte has to be cleared
+    constexpr ui64 GB_BLOCKS = GB_BYTES / NPDisk::FormatSectorSize;
     ui64 writePos = diskSizeBytes - GB_BYTES;
     for (ui64 i=0; i<GB_BLOCKS; ++i) {
         f.Pwrite(zeros.data(), NPDisk::FormatSectorSize, (i64)(writePos + (i * NPDisk::FormatSectorSize)));

--- a/ydb/core/blobstorage/pdisk/blobstorage_pdisk_tools.h
+++ b/ydb/core/blobstorage/pdisk/blobstorage_pdisk_tools.h
@@ -37,7 +37,7 @@ struct TPDiskInfo {
     TVector<TSectorInfo> SectorInfo;
 };
 
-// Throws TFileError in case of errors
+// Throws yexception in case of errors
 void ObliterateDisk(TString path);
 
 void FormatPDisk(TString path, ui64 diskSizeBytes, ui32 sectorSizeBytes, ui32 userAccessibleChunkSizeBytes,

--- a/ydb/core/driver_lib/cli_utils/cli_cmds_disk.cpp
+++ b/ydb/core/driver_lib/cli_utils/cli_cmds_disk.cpp
@@ -207,7 +207,7 @@ public:
     virtual int Run(TConfig&) override {
         try {
             ObliterateDisk(Path);
-        } catch (TFileError& e) {
+        } catch (const yexception& e) {
             Cerr << "Error, what# " << e.what() << Endl;
             return 1;
         }


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

The "obliterate" command has been improved:
* an error is returned if non-existing device or file is passed as the parameter, instead of creating a new small file and succeeding
* an error is returned if the file or device is too small to be the YDB storage device

### Changelog category <!-- remove all except one -->

* Improvement

### Description for reviewers <!-- (optional) description for those who read this PR -->

...
