### PR TITLE
Remove large-tests tags

### DIFF
--- a/ydb/tests/large.inc
+++ b/ydb/tests/large.inc
@@ -2,11 +2,8 @@ TAG(
     ya:fat
     sb:ttl=1
     sb:logs_ttl=1
-    ya:large_tests_on_ya_make_2
 )
 
 IF (ARCADIA_SANDBOX_SINGLESLOT)
     TAG(ya:large_tests_on_single_slots)
-ELSE()
-    TAG(ya:large_tests_on_multi_slots)
 ENDIF()


### PR DESCRIPTION
Remove ya:large_tests_on_multi_slots and ya:large_tests_on_ya_make_2 tags
- These tags are no longer processed  
- Their behavior became the default