### PR TITLE
Introduce Add and IsEmpty operations to Roaring UDF

### DIFF
--- a/ydb/library/yql/udfs/common/roaring/roaring.cpp
+++ b/ydb/library/yql/udfs/common/roaring/roaring.cpp
@@ -487,6 +487,61 @@ namespace {
         TSourcePosition Pos_;
     };
 
+    class TRoaringIsEmpty: public TBoxedValue {
+    public:
+        TRoaringIsEmpty(TSourcePosition pos)
+            : Pos_(pos)
+        {
+        }
+
+        static TStringRef Name() {
+            return TStringRef::Of("IsEmpty");
+        }
+
+    private:
+        TUnboxedValue Run(const IValueBuilder* valueBuilder,
+                          const TUnboxedValuePod* args) const override {
+            Y_UNUSED(valueBuilder);
+            try {
+                auto* left = GetBitmapFromArg(args[0]);
+
+                return TUnboxedValuePod(roaring_bitmap_is_empty(left));
+            } catch (const std::exception& e) {
+                UdfTerminate((TStringBuilder() << Pos_ << " " << e.what()).data());
+            }
+        }
+
+        TSourcePosition Pos_;
+    };
+
+    class TRoaringAdd: public TBoxedValue {
+    public:
+        TRoaringAdd(TSourcePosition pos)
+            : Pos_(pos)
+        {
+        }
+
+        static TStringRef Name() {
+            return TStringRef::Of("Add");
+        }
+
+    private:
+        TUnboxedValue Run(const IValueBuilder* valueBuilder,
+                          const TUnboxedValuePod* args) const override {
+            Y_UNUSED(valueBuilder);
+            try {
+                auto* bitmap = GetBitmapFromArg(args[0]);
+                roaring_bitmap_add(bitmap, args[1].Get<ui32>());
+
+                return args[0];
+            } catch (const std::exception& e) {
+                UdfTerminate((TStringBuilder() << Pos_ << " " << e.what()).data());
+            }
+        }
+
+        TSourcePosition Pos_;
+    };
+
     class TRoaringModule: public IUdfModule {
     public:
         class TMemoryHookInitializer {
@@ -687,6 +742,23 @@ namespace {
 
                     if (!typesOnly) {
                         builder.Implementation(new TRoaringIntersectWithBinary(builder.GetSourcePosition()));
+                    }
+                } else if (TRoaringIsEmpty::Name() == name) {
+                    builder.Returns<bool>()
+                        .Args()
+                        ->Add<TAutoMap<TResource<RoaringResourceName>>>();
+
+                    if (!typesOnly) {
+                        builder.Implementation(new TRoaringIsEmpty(builder.GetSourcePosition()));
+                    }
+                } else if (TRoaringAdd::Name() == name) {
+                    builder.Returns<TResource<RoaringResourceName>>()
+                        .Args()
+                        ->Add<TAutoMap<TResource<RoaringResourceName>>>()
+                        .Add<ui32>();
+
+                    if (!typesOnly) {
+                        builder.Implementation(new TRoaringAdd(builder.GetSourcePosition()));
                     }
                 } else {
                     TStringBuilder sb;

--- a/ydb/library/yql/udfs/common/roaring/roaring.cpp
+++ b/ydb/library/yql/udfs/common/roaring/roaring.cpp
@@ -598,15 +598,21 @@ namespace {
                 auto typesOnly = (flags & TFlags::TypesOnly);
 
                 if (TRoaringDeserialize::Name() == name) {
-                    builder.Returns<TResource<RoaringResourceName>>().Args()->Add<TAutoMap<char*>>();
+                    builder.Returns<TResource<RoaringResourceName>>()
+                        .OptionalArgs(1)
+                        .Args()
+                        ->Add<TAutoMap<char*>>()
+                        .Add<TOptional<ui32>>();
 
                     if (!typesOnly) {
                         builder.Implementation(new TRoaringDeserialize(builder.GetSourcePosition()));
                     }
                 } else if (TRoaringFromUint32List::Name() == name) {
                     builder.Returns<TResource<RoaringResourceName>>()
+                        .OptionalArgs(1)
                         .Args()
-                        ->Add<TListType<ui32>>();
+                        ->Add<TListType<ui32>>()
+                        .Add<TOptional<ui32>>();
 
                     if (!typesOnly) {
                         builder.Implementation(new TRoaringFromUint32List(builder.GetSourcePosition()));

--- a/ydb/library/yql/udfs/common/roaring/test/canondata/result.json
+++ b/ydb/library/yql/udfs/common/roaring/test/canondata/result.json
@@ -1,4 +1,9 @@
 {
+    "test.test[aggregation]": [
+        {
+            "uri": "file://test.test_aggregation_/results.txt"
+        }
+    ],
     "test.test[cardinality]": [
         {
             "uri": "file://test.test_cardinality_/results.txt"

--- a/ydb/library/yql/udfs/common/roaring/test/canondata/test.test_aggregation_/results.txt
+++ b/ydb/library/yql/udfs/common/roaring/test/canondata/test.test_aggregation_/results.txt
@@ -1,0 +1,48 @@
+[
+    {
+        "Write" = [
+            {
+                "Type" = [
+                    "ListType";
+                    [
+                        "StructType";
+                        [
+                            [
+                                "key";
+                                [
+                                    "DataType";
+                                    "String"
+                                ]
+                            ];
+                            [
+                                "column1";
+                                [
+                                    "ListType";
+                                    [
+                                        "DataType";
+                                        "Uint32"
+                                    ]
+                                ]
+                            ]
+                        ]
+                    ]
+                ];
+                "Data" = [
+                    [
+                        "baz";
+                        [
+                            "3"
+                        ]
+                    ];
+                    [
+                        "foo";
+                        [
+                            "1";
+                            "2"
+                        ]
+                    ]
+                ]
+            }
+        ]
+    }
+]

--- a/ydb/library/yql/udfs/common/roaring/test/canondata/test.test_intersect_/results.txt
+++ b/ydb/library/yql/udfs/common/roaring/test/canondata/test.test_intersect_/results.txt
@@ -656,5 +656,36 @@
                 ]
             }
         ]
+    };
+    {
+        "Write" = [
+            {
+                "Type" = [
+                    "ListType";
+                    [
+                        "StructType";
+                        [
+                            [
+                                "IntersectionIsEmpty";
+                                [
+                                    "OptionalType";
+                                    [
+                                        "DataType";
+                                        "Bool"
+                                    ]
+                                ]
+                            ]
+                        ]
+                    ]
+                ];
+                "Data" = [
+                    [
+                        [
+                            %true
+                        ]
+                    ]
+                ]
+            }
+        ]
     }
 ]

--- a/ydb/library/yql/udfs/common/roaring/test/canondata/test.test_serialize_deserialize_/results.txt
+++ b/ydb/library/yql/udfs/common/roaring/test/canondata/test.test_serialize_deserialize_/results.txt
@@ -257,5 +257,42 @@
                 ]
             }
         ]
+    };
+    {
+        "Write" = [
+            {
+                "Type" = [
+                    "ListType";
+                    [
+                        "StructType";
+                        [
+                            [
+                                "DeserializedListWithSomeParent";
+                                [
+                                    "OptionalType";
+                                    [
+                                        "ListType";
+                                        [
+                                            "DataType";
+                                            "Uint32"
+                                        ]
+                                    ]
+                                ]
+                            ]
+                        ]
+                    ]
+                ];
+                "Data" = [
+                    [
+                        [
+                            [
+                                "10";
+                                "567"
+                            ]
+                        ]
+                    ]
+                ]
+            }
+        ]
     }
 ]

--- a/ydb/library/yql/udfs/common/roaring/test/canondata/test.test_union_/results.txt
+++ b/ydb/library/yql/udfs/common/roaring/test/canondata/test.test_union_/results.txt
@@ -150,5 +150,68 @@
                 ]
             }
         ]
+    };
+    {
+        "Write" = [
+            {
+                "Type" = [
+                    "ListType";
+                    [
+                        "StructType";
+                        [
+                            [
+                                "UnionIsNotEmpty";
+                                [
+                                    "OptionalType";
+                                    [
+                                        "DataType";
+                                        "Bool"
+                                    ]
+                                ]
+                            ]
+                        ]
+                    ]
+                ];
+                "Data" = [
+                    [
+                        [
+                            %false
+                        ]
+                    ]
+                ]
+            }
+        ]
+    };
+    {
+        "Write" = [
+            {
+                "Type" = [
+                    "ListType";
+                    [
+                        "StructType";
+                        [
+                            [
+                                "UnionViaAdd";
+                                [
+                                    "ListType";
+                                    [
+                                        "DataType";
+                                        "Uint32"
+                                    ]
+                                ]
+                            ]
+                        ]
+                    ]
+                ];
+                "Data" = [
+                    [
+                        [
+                            "10";
+                            "20"
+                        ]
+                    ]
+                ]
+            }
+        ]
     }
 ]

--- a/ydb/library/yql/udfs/common/roaring/test/cases/aggregation.sql
+++ b/ydb/library/yql/udfs/common/roaring/test/cases/aggregation.sql
@@ -17,7 +17,7 @@ $filter_lambda = ($search, $doc_ids) -> {
 };
 
 $udaf = AggregationFactory("UDAF",
-    ($item, $_) -> (Roaring::FromUint32List(AsList(UNWRAP(CAST($item AS Uint32))))),
+    ($item, $parent) -> (Roaring::FromUint32List(AsList(UNWRAP(CAST($item AS Uint32)), $parent))),
     ($state, $item, $_) -> (Roaring::Add($state, UNWRAP(CAST($item AS Uint32)))),
     ($state1, $state2) -> (Roaring::Or($state1, $state2)),
     ($state) -> (Roaring::Uint32List($state)),

--- a/ydb/library/yql/udfs/common/roaring/test/cases/aggregation.sql
+++ b/ydb/library/yql/udfs/common/roaring/test/cases/aggregation.sql
@@ -1,0 +1,37 @@
+$t = (
+    SELECT
+        *
+    FROM
+        AS_TABLE([
+            <|id:1, key:"foo", value: "v1", docIds:[10u, 42u]|>,
+            <|id:2, key:"foo", value: "v2", docIds:[94u]|>,
+            <|id:3, key:"baz", value: "v3", docIds:[78u, 94u]|>
+            ]
+        )
+);
+
+$search = [42u, 94u];
+
+$filter_lambda = ($search, $doc_ids) -> {
+    return DictHasItems(SetIntersection(ToSet($search), ToSet($doc_ids)));
+};
+
+$udaf = AggregationFactory("UDAF",
+    ($item, $_) -> (Roaring::FromUint32List(AsList(UNWRAP(CAST($item AS Uint32))))),
+    ($state, $item, $_) -> (Roaring::Add($state, UNWRAP(CAST($item AS Uint32)))),
+    ($state1, $state2) -> (Roaring::Or($state1, $state2)),
+    ($state) -> (Roaring::Uint32List($state)),
+    ($state) -> (Roaring::Serialize($state)),
+    ($state) -> (Roaring::Deserialize($state)));
+
+SELECT
+    key,
+    AGGREGATE_BY(id, $udaf)
+FROM
+    $t
+WHERE
+    $filter_lambda($search, docIds)
+GROUP BY
+    key
+ORDER BY
+    key

--- a/ydb/library/yql/udfs/common/roaring/test/cases/aggregation.sql
+++ b/ydb/library/yql/udfs/common/roaring/test/cases/aggregation.sql
@@ -17,7 +17,7 @@ $filter_lambda = ($search, $doc_ids) -> {
 };
 
 $udaf = AggregationFactory("UDAF",
-    ($item, $parent) -> (Roaring::FromUint32List(AsList(UNWRAP(CAST($item AS Uint32)), $parent))),
+    ($item, $parent) -> (Roaring::FromUint32List(AsList(UNWRAP(CAST($item AS Uint32))), $parent)),
     ($state, $item, $_) -> (Roaring::Add($state, UNWRAP(CAST($item AS Uint32)))),
     ($state1, $state2) -> (Roaring::Or($state1, $state2)),
     ($state) -> (Roaring::Uint32List($state)),

--- a/ydb/library/yql/udfs/common/roaring/test/cases/intersect.sql
+++ b/ydb/library/yql/udfs/common/roaring/test/cases/intersect.sql
@@ -23,3 +23,5 @@ SELECT Roaring::Intersect(Roaring::Deserialize(right), NULL) AS IntersectNull1 F
 SELECT Roaring::IntersectWithBinary(Roaring::Deserialize(right), left) AS IntersectWithBinary FROM Input;
 SELECT Roaring::IntersectWithBinary(Roaring::Deserialize(right), NULL) AS IntersectWithBinaryNull FROM Input;
 SELECT Roaring::Intersect(Roaring::Deserialize(right), Roaring::FromUint32List(AsList(100500))) AS IntersectFalse FROM Input;
+
+SELECT Roaring::IsEmpty(Roaring::And(Roaring::Deserialize(right), Roaring::FromUint32List(AsList(100500)))) AS IntersectionIsEmpty FROM Input;

--- a/ydb/library/yql/udfs/common/roaring/test/cases/serialize_deserialize.sql
+++ b/ydb/library/yql/udfs/common/roaring/test/cases/serialize_deserialize.sql
@@ -19,3 +19,6 @@ SELECT Roaring::Uint32List(Roaring::FromUint32List(AsList(10, 567, 42))) AS Dese
 SELECT Roaring::Cardinality(Roaring::FromUint32List(ListCollect(ListFromRange(1u, 1000000u)))) AS LongList;
 
 SELECT Roaring::Cardinality(Roaring::FromUint32List(ListFromRange(1u, 1000000u))) AS LongLazyList;
+
+SELECT Roaring::Uint32List(Roaring::Deserialize(binaryString, 42u)) AS DeserializedListWithSomeParent
+FROM Input;

--- a/ydb/library/yql/udfs/common/roaring/test/cases/union.sql
+++ b/ydb/library/yql/udfs/common/roaring/test/cases/union.sql
@@ -4,3 +4,8 @@ SELECT Roaring::Uint32List(Roaring::OrWithBinary(Roaring::Deserialize(right), le
 SELECT Roaring::Uint32List(Roaring::Or(Roaring::Deserialize(left), Roaring::Deserialize(right), true)) AS OrListInplace FROM Input;
 SELECT Roaring::Uint32List(Roaring::OrWithBinary(Roaring::Deserialize(right), left, true)) AS OrWithBinaryListInplace FROM Input;
 
+SELECT Roaring::IsEmpty(Roaring::Or(Roaring::Deserialize(left), Roaring::Deserialize(right))) AS UnionIsNotEmpty FROM Input;
+
+
+SELECT Roaring::Uint32List(Roaring::Add(Roaring::FromUint32List(AsList(10)), 20)) AS UnionViaAdd;
+


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

`Add` operation allows building aggregation queries. For instance, constucting Roaring bitmap from intermediate `AGG_LIST` may be replaced with custom `UDAF` using `Add`, which may be more space efficient

`IsEmpty` just nice operation to have, allows skip costly check for cardinality equals to zero

### Changelog category <!-- remove all except one -->

* Improvement

### Description for reviewers <!-- (optional) description for those who read this PR -->
