### PR TITLE
healthcheck: use State fiels from bsc response instead of StatusV2

### DIFF
--- a/ydb/core/health_check/health_check_ut.cpp
+++ b/ydb/core/health_check/health_check_ut.cpp
@@ -2373,7 +2373,7 @@ Y_UNIT_TEST_SUITE(THealthCheckTest) {
                     auto* x = reinterpret_cast<NSysView::TEvSysView::TEvGetPDisksResponse::TPtr*>(&ev);
                     auto& record = (*x)->Get()->Record;
                     for (auto& entry : *record.mutable_entries()) {
-                        entry.mutable_info()->set_statusv2("UNKNOWN_STATE?");
+                        entry.mutable_info()->set_state("UNKNOWN_STATE?");
                     }
                     break;
                 }


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

healthcheck: use State field from bsc response instead of StatusV2 to determine pdisk state

### Changelog category <!-- remove all except one -->

* Improvement

### Description for reviewers <!-- (optional) description for those who read this PR -->

Health check may report OK for a PDisk with INACTIVE CMS status, which is not always correct if the PDisk is actually dead.

Added a new field State to BSC information to improve determination of PDisk statuses. This is the same field used in fallback scenarios, allowing unified logic across all cases.
