### PR TITLE
Drop event buffer after parsing, better type safety

### DIFF
--- a/ydb/core/kqp/common/events/query.h
+++ b/ydb/core/kqp/common/events/query.h
@@ -295,8 +295,8 @@ public:
         return Record.SerializeToZeroCopyStream(chunker);
     }
 
-    static NActors::IEventBase* Load(TEventSerializedData* data) {
-        auto pbEv = THolder<TEvQueryRequestRemote>(static_cast<TEvQueryRequestRemote*>(TEvQueryRequestRemote::Load(data)));
+    static TEvQueryRequest* Load(const TEventSerializedData* data) {
+        auto pbEv = THolder<TEvQueryRequestRemote>(TEvQueryRequestRemote::Load(data));
         auto req = new TEvQueryRequest();
         req->Record.Swap(&pbEv->Record);
         return req;

--- a/ydb/core/kqp/compute_actor/kqp_compute_events.h
+++ b/ydb/core/kqp/compute_actor/kqp_compute_events.h
@@ -110,8 +110,8 @@ struct TEvScanData: public NActors::TEventLocal<TEvScanData, TKqpComputeEvents::
     }
 
 
-    static NActors::IEventBase* Load(TEventSerializedData* data) {
-        auto pbEv = THolder<TEvRemoteScanData>(static_cast<TEvRemoteScanData*>(TEvRemoteScanData::Load(data)));
+    static TEvScanData* Load(const TEventSerializedData* data) {
+        auto pbEv = THolder<TEvRemoteScanData>(TEvRemoteScanData::Load(data));
         auto ev = MakeHolder<TEvScanData>(pbEv->Record.GetScanId(), pbEv->Record.GetGeneration());
 
         ev->CpuTime = TDuration::MicroSeconds(pbEv->Record.GetCpuTimeUs());
@@ -220,8 +220,8 @@ struct TEvKqpCompute {
             return Remote->SerializeToArcadiaStream(chunker);
         }
 
-        static NActors::IEventBase* Load(TEventSerializedData* data) {
-            auto pbEv = THolder<TEvRemoteScanDataAck>(static_cast<TEvRemoteScanDataAck *>(TEvRemoteScanDataAck::Load(data)));
+        static TEvScanDataAck* Load(const TEventSerializedData* data) {
+            auto pbEv = THolder<TEvRemoteScanDataAck>(TEvRemoteScanDataAck::Load(data));
             ui32 maxChunksCount = Max<ui32>();
             if (pbEv->Record.HasMaxChunksCount()) {
                 maxChunksCount = pbEv->Record.GetMaxChunksCount();

--- a/ydb/core/tx/datashard/datashard.cpp
+++ b/ydb/core/tx/datashard/datashard.cpp
@@ -4779,9 +4779,8 @@ TString TEvDataShard::TEvRead::ToString() const {
     return ss.Str();
 }
 
-NActors::IEventBase* TEvDataShard::TEvRead::Load(TEventSerializedData* data) {
-    auto* base = TBase::Load(data);
-    auto* event = static_cast<TEvRead*>(base);
+TEvDataShard::TEvRead* TEvDataShard::TEvRead::Load(const TEventSerializedData* data) {
+    TEvRead* event = TBase::Load(data);
     auto& record = event->Record;
 
     event->Keys.reserve(record.KeysSize());
@@ -4794,7 +4793,7 @@ NActors::IEventBase* TEvDataShard::TEvRead::Load(TEventSerializedData* data) {
         event->Ranges.emplace_back(range);
     }
 
-    return base;
+    return event;
 }
 
 // really ugly hacky, because Record is not mutable and calling members are const
@@ -4833,9 +4832,8 @@ TString TEvDataShard::TEvReadResult::ToString() const {
     return ss.Str();
 }
 
-NActors::IEventBase* TEvDataShard::TEvReadResult::Load(TEventSerializedData* data) {
-    auto* base = TBase::Load(data);
-    auto* event = static_cast<TEvReadResult*>(base);
+TEvDataShard::TEvReadResult* TEvDataShard::TEvReadResult::Load(const TEventSerializedData* data) {
+    TEvReadResult* event = TBase::Load(data);
     auto& record = event->Record;
 
     if (record.HasArrowBatch()) {
@@ -4852,7 +4850,7 @@ NActors::IEventBase* TEvDataShard::TEvReadResult::Load(TEventSerializedData* dat
         record.ClearCellVec();
     }
 
-    return base;
+    return event;
 }
 
 void TEvDataShard::TEvReadResult::FillRecord() {

--- a/ydb/core/tx/datashard/datashard.h
+++ b/ydb/core/tx/datashard/datashard.h
@@ -955,7 +955,7 @@ namespace TEvDataShard {
             return TBase::SerializeToArcadiaStream(chunker);
         }
 
-        static NActors::IEventBase* Load(TEventSerializedData* data);
+        static TEvRead* Load(const TEventSerializedData* data);
 
     private:
         void FillRecord();
@@ -1001,7 +1001,7 @@ namespace TEvDataShard {
             return TBase::SerializeToArcadiaStream(chunker);
         }
 
-        static NActors::IEventBase* Load(TEventSerializedData* data);
+        static TEvReadResult* Load(const TEventSerializedData* data);
 
         size_t GetRowsCount() const {
             return Record.GetRowCount();

--- a/ydb/library/actors/core/actor_benchmark_helper.h
+++ b/ydb/library/actors/core/actor_benchmark_helper.h
@@ -74,10 +74,9 @@ struct TActorBenchmark {
         Follower
     };
 
-    struct TEvOwnedPing : TEvents::TEvPing {
+    struct TEvOwnedPing : TEventLocal<TEvOwnedPing, TEvents::TEvPing::EventType> {
         TEvOwnedPing(TActorId owner)
-            : TEvPing()
-            , Owner(owner)
+            : Owner(owner)
         {}
 
         TActorId Owner;

--- a/ydb/library/actors/core/event.cpp
+++ b/ydb/library/actors/core/event.cpp
@@ -9,6 +9,8 @@ namespace NActors {
         Max<ui64>(), Max<ui64>()
     };
 
+    const TEventSerializedData IEventHandle::EmptyBuffer;
+
     TString IEventHandle::GetTypeName() const {
         return HasEvent() ? TypeName(*(const_cast<IEventHandle*>(this)->GetBase())) : TypeName(*this);
     }

--- a/ydb/library/actors/core/event_local.h
+++ b/ydb/library/actors/core/event_local.h
@@ -20,10 +20,6 @@ namespace NActors {
         bool IsSerializable() const override {
             return false;
         }
-
-        static IEventBase* Load(TEventSerializedData*) {
-            Y_ENSURE(false, "Loading of local event " << TypeName<TEv>() << " type " << TEventType);
-        }
     };
 
 }

--- a/ydb/library/actors/core/event_pb.h
+++ b/ydb/library/actors/core/event_pb.h
@@ -202,8 +202,9 @@ namespace NActors {
             return CalculateSerializedSizeImpl(Payload, Record.ByteSize());
         }
 
-        static IEventBase* Load(TEventSerializedData *input) {
-            THolder<TEventPBBase> ev(new TEv());
+        static TEv* Load(const TEventSerializedData *input) {
+            THolder<TEv> holder(new TEv());
+            TEventPBBase* ev = holder.Get();
             if (!input->GetSize()) {
                 Y_ENSURE(ev->Record.ParseFromString(TString()),
                     "Failed to parse protobuf event type " << TEventType << " class " << TypeName(ev->Record));
@@ -222,7 +223,7 @@ namespace NActors {
                 }
             }
             ev->CachedByteSize = input->GetSize();
-            return ev.Release();
+            return holder.Release();
         }
 
         size_t GetCachedByteSize() const {

--- a/ydb/library/actors/core/event_simple_non_local.h
+++ b/ydb/library/actors/core/event_simple_non_local.h
@@ -21,7 +21,7 @@ namespace NActors {
             return true;
         }
 
-        static IEventBase* Load(TEventSerializedData*) {
+        static TEv* Load(const TEventSerializedData*) {
             return new TEv();
         }
     };

--- a/ydb/library/actors/core/events.h
+++ b/ydb/library/actors/core/events.h
@@ -75,7 +75,7 @@ namespace NActors {
                 return Blob.size();
             }
 
-            static IEventBase* Load(TEventSerializedData* bufs) noexcept {
+            static TEvBlob* Load(const TEventSerializedData* bufs) noexcept {
                 return new TEvBlob(bufs->GetString());
             }
 
@@ -163,7 +163,7 @@ namespace NActors {
 
             TString ToStringHeader() const override;
             bool SerializeToArcadiaStream(TChunkSerializer *serializer) const override;
-            static IEventBase* Load(TEventSerializedData* bufs);
+            static TEvUndelivered* Load(const TEventSerializedData* bufs);
             bool IsSerializable() const override;
 
             ui32 CalculateSerializedSize() const override { return 2 * sizeof(ui32); }

--- a/ydb/library/actors/core/events_undelivered.cpp
+++ b/ydb/library/actors/core/events_undelivered.cpp
@@ -29,7 +29,7 @@ namespace NActors {
         return true;
     }
 
-    IEventBase* TEvents::TEvUndelivered::Load(TEventSerializedData* bufs) {
+    TEvents::TEvUndelivered* TEvents::TEvUndelivered::Load(const TEventSerializedData* bufs) {
         TString str = bufs->GetString();
         Y_ENSURE(str.size() == (sizeof(ui32) + sizeof(ui32)));
         const char* p = str.data();

--- a/ydb/library/actors/core/mon.cpp
+++ b/ydb/library/actors/core/mon.cpp
@@ -53,7 +53,7 @@ namespace NActors::NMon {
         return ExtendedQuery ? static_cast<HTTP_METHOD>(ExtendedQuery->GetMethod()) : Method;
     }
 
-    IEventBase* TEvRemoteHttpInfo::Load(TEventSerializedData* bufs) {
+    TEvRemoteHttpInfo* TEvRemoteHttpInfo::Load(const TEventSerializedData* bufs) {
         TString s = bufs->GetString();
         if (s.size() && s[0] == '\0') {
             TRope::TConstIterator iter = bufs->GetBeginIter();

--- a/ydb/library/actors/core/mon.h
+++ b/ydb/library/actors/core/mon.h
@@ -115,7 +115,7 @@ namespace NActors {
                 return true;
             }
 
-            static IEventBase* Load(TEventSerializedData* bufs);
+            static TEvRemoteHttpInfo* Load(const TEventSerializedData* bufs);
         };
 
         struct TEvRemoteHttpInfoRes: public NActors::TEventBase<TEvRemoteHttpInfoRes, RemoteHttpInfoRes> {
@@ -145,7 +145,7 @@ namespace NActors {
                 return true;
             }
 
-            static IEventBase* Load(TEventSerializedData* bufs) {
+            static TEvRemoteHttpInfoRes* Load(const TEventSerializedData* bufs) {
                 return new TEvRemoteHttpInfoRes(bufs->GetString());
             }
         };
@@ -177,7 +177,7 @@ namespace NActors {
                 return true;
             }
 
-            static IEventBase* Load(TEventSerializedData* bufs) {
+            static TEvRemoteJsonInfoRes* Load(const TEventSerializedData* bufs) {
                 return new TEvRemoteJsonInfoRes(bufs->GetString());
             }
         };
@@ -209,7 +209,7 @@ namespace NActors {
                 return true;
             }
 
-            static IEventBase* Load(TEventSerializedData* bufs) {
+            static TEvRemoteBinaryInfoRes* Load(const TEventSerializedData* bufs) {
                 return new TEvRemoteBinaryInfoRes(bufs->GetString());
             }
         };

--- a/ydb/library/actors/core/ut/event_pb_payload_ut.cpp
+++ b/ydb/library/actors/core/ut/event_pb_payload_ut.cpp
@@ -66,7 +66,7 @@ Y_UNIT_TEST_SUITE(TEventProtoWithPayload) {
         }
         UNIT_ASSERT_VALUES_EQUAL(chunkerRes, ser);
 
-        THolder<IEventBase> ev2 = THolder(TEventTo::Load(buffers.Get()));
+        THolder<TEventTo> ev2 = THolder(TEventTo::Load(buffers.Get()));
         TEventTo& msg2 = static_cast<TEventTo&>(*ev2);
         UNIT_ASSERT_VALUES_EQUAL(msg2.Record.GetMeta(), msg.Record.GetMeta());
         UNIT_ASSERT_EQUAL(msg2.GetPayload(msg2.Record.GetPayloadId(0)), msg.GetPayload(msg.Record.GetPayloadId(0)));
@@ -142,7 +142,7 @@ Y_UNIT_TEST_SUITE(TEventProtoWithPayload) {
 
         // deserialize
         auto data = MakeIntrusive<TEventSerializedData>(ser1, TEventSerializationInfo{});
-        THolder<TEvMessageWithPayloadPreSerialized> parsedEvent(static_cast<TEvMessageWithPayloadPreSerialized*>(TEvMessageWithPayloadPreSerialized::Load(data.Get())));
+        THolder<TEvMessageWithPayloadPreSerialized> parsedEvent(TEvMessageWithPayloadPreSerialized::Load(data.Get()));
         UNIT_ASSERT_VALUES_EQUAL(parsedEvent->PreSerializedData, ""); // this field is empty after deserialization
         auto& record = parsedEvent->GetRecord();
         UNIT_ASSERT_VALUES_EQUAL(record.GetMeta(), msg.GetMeta());

--- a/ydb/library/actors/core/ut/mon_ut.cpp
+++ b/ydb/library/actors/core/ut/mon_ut.cpp
@@ -19,7 +19,7 @@ Y_UNIT_TEST_SUITE(ActorSystemMon) {
         const bool success = ev->SerializeToArcadiaStream(&ser);
         Y_ABORT_UNLESS(success);
         auto buffer = ser.Release(ev->CreateSerializationInfo());
-        std::unique_ptr<TEvRemoteHttpInfo> restored(dynamic_cast<TEvRemoteHttpInfo*>(TEvRemoteHttpInfo::Load(buffer.Get())));
+        std::unique_ptr<TEvRemoteHttpInfo> restored(TEvRemoteHttpInfo::Load(buffer.Get()));
         UNIT_ASSERT(restored->Query == ev->Query);
         UNIT_ASSERT(restored->Query.size());
         UNIT_ASSERT(restored->Query[0] == '\0');

--- a/ydb/library/yql/dq/actors/dq.h
+++ b/ydb/library/yql/dq/actors/dq.h
@@ -70,14 +70,13 @@ struct TEvDq {
             return issues;
         }
 
-        static IEventBase* Load(NActors::TEventSerializedData *input) {
+        static TEvAbortExecution* Load(const NActors::TEventSerializedData *input) {
             auto result = NActors::TEventPB<TEvAbortExecution, NDqProto::TEvAbortExecution, TDqEvents::EvAbortExecution>::Load(input);
             if (result) {
-                auto evAbort = reinterpret_cast<TEvAbortExecution *>(result);
-                auto dqStatus = evAbort->Record.GetStatusCode();
-                auto ydbStatus = evAbort->Record.GetYdbStatusCode();
+                auto dqStatus = result->Record.GetStatusCode();
+                auto ydbStatus = result->Record.GetYdbStatusCode();
                 if (dqStatus == NYql::NDqProto::StatusIds::UNSPECIFIED && ydbStatus != Ydb::StatusIds::STATUS_CODE_UNSPECIFIED) {
-                    evAbort->Record.SetStatusCode(YdbStatusToDqStatus(ydbStatus));
+                    result->Record.SetStatusCode(YdbStatusToDqStatus(ydbStatus));
                 }
             }
             return result;


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

...

### Changelog category <!-- remove all except one -->

* Not for changelog (changelog entry is not required)

### Description for reviewers <!-- (optional) description for those who read this PR -->

Drop event buffer after parsing, to avoid unnecessary memory usage while events are in queues. Also improve type safety when loading events.