### PR TITLE
Additional CLI parameters for ydb debug latency

### DIFF
--- a/ydb/apps/ydb/CHANGELOG.md
+++ b/ydb/apps/ydb/CHANGELOG.md
@@ -8,6 +8,8 @@
 * Fixed return code of command `ydb workload * run --check-canonical` for the case when benchmark query results differ from canonical ones.
 * Fixed scheme error in `ydb admin cluster dump` when specifying a domain database.
 * Fixed unauthorized error in `ydb admin database restore` when multiple database admins are in dump.
+* Added `--min-inflight` to `ydb debug latency` command.
+* Added support for multiple `-p` (percentile) params in `ydb debug latency` command.
 
 ## 2.20.0 ##
 

--- a/ydb/public/lib/ydb_cli/commands/ydb_latency.h
+++ b/ydb/public/lib/ydb_cli/commands/ydb_latency.h
@@ -38,10 +38,11 @@ public:
 
 private:
     int IntervalSeconds;
+    int MinInflight;
     int MaxInflight;
     EFormat Format;
     TCommandPing::EPingKind RunKind;
-    double Percentile;
+    std::vector<double> Percentiles;
 
     std::unique_ptr<NDebug::TActorChainPingSettings> ChainConfig;
 };


### PR DESCRIPTION
* --min-inflight
* allow to specify multiple percentiles using multiple "-p" params

### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

Added additional CLI parameters for `ydb debug latency`:
* --min-inflight
* allow to specify multiple percentiles using multiple "-p" params

### Changelog category <!-- remove all except one -->

* Improvement

### Description for reviewers <!-- (optional) description for those who read this PR -->

...
