### PR TITLE
Round TPCH q3 revenue up to 0.001

### DIFF
--- a/ydb/library/benchmarks/queries/tpch/yql/q3.sql
+++ b/ydb/library/benchmarks/queries/tpch/yql/q3.sql
@@ -47,7 +47,7 @@ where
 
 select
     l_orderkey,
-    $round(sum(l_extendedprice * ($z1_12 - l_discount)), -2) as revenue,
+    $round(sum(l_extendedprice * ($z1_12 - l_discount)), -3) as revenue,
     o_orderdate,
     o_shippriority
 from


### PR DESCRIPTION
https://st.yandex-team.ru/YQL-19876
Двойное округление ломает аркадийные тесты, 3-я цифра после запятой в revenue чинит тесты