### PR TITLE
healthcheck vdisk use state2

### DIFF
--- a/ydb/core/health_check/health_check.cpp
+++ b/ydb/core/health_check/health_check.cpp
@@ -2131,17 +2131,7 @@ public:
     ui32 ParsePDiskStatusOrUnknown(const TString& statusString) {
         static const auto* descriptor = NKikimrBlobStorage::EDriveStatus_descriptor();
         const auto* valueDescriptor = descriptor->FindValueByName(statusString);
-        return valueDescriptor ? valueDescriptor->number() : NKikimrBlobStorage::EDriveStatus::UNKNOWN;
-    }
-
-    bool TryParsePDiskStatus(const TString& statusString, ui32& statusNumber) {
-        static const auto *descriptor = NKikimrBlobStorage::EDriveStatus_descriptor();
-        const auto* valueDescriptor = descriptor->FindValueByName(statusString);
-        if (!valueDescriptor) {
-            return false;
-        }
-        statusNumber = valueDescriptor->number();
-        return true;
+        return valueDescriptor ? valueDescriptor->number() : NKikimrBlobStorage::UNKNOWN;
     }
 
     void ReportPDiskState(NKikimrBlobStorage::TPDiskState::E stateEnum, TSelfCheckContext& context) {

--- a/ydb/core/health_check/health_check.cpp
+++ b/ydb/core/health_check/health_check.cpp
@@ -2194,7 +2194,7 @@ public:
         // If not set, fall back to pDisk.GetStatusV2() for backward compatibility.
         if (pDisk.HasState()) {
             const auto& stateString = pDisk.GetState();
-            const auto *descriptor = NKikimrBlobStorage::TPDiskState::E_descriptor();
+            const auto* descriptor = NKikimrBlobStorage::TPDiskState::E_descriptor();
             auto state = descriptor->FindValueByName(stateString);
             auto stateEnum = state ? static_cast<NKikimrBlobStorage::TPDiskState::E>(state->number()) : NKikimrBlobStorage::TPDiskState::Unknown;
             ReportPDiskState(stateEnum, context);

--- a/ydb/core/health_check/health_check.cpp
+++ b/ydb/core/health_check/health_check.cpp
@@ -2151,7 +2151,7 @@ public:
         const auto& stateString = pDisk.GetState();
         const auto *descriptor = NKikimrBlobStorage::TPDiskState::E_descriptor();
         auto state = descriptor->FindValueByName(stateString);
-        if (!state) {;
+        if (!state) {
             context.ReportStatus(Ydb::Monitoring::StatusFlag::RED,
                                  TStringBuilder() << "Unknown PDisk state: " << stateString,
                                  ETags::PDiskState);
@@ -2159,7 +2159,8 @@ public:
             context.OverallStatus = Ydb::Monitoring::StatusFlag::ORANGE;
             return;
         }
-        switch (state->number()) {
+        auto stateEnum = static_cast<NKikimrBlobStorage::TPDiskState::E>(state->number());
+        switch (stateEnum) {
             case NKikimrBlobStorage::TPDiskState::Normal:
             case NKikimrBlobStorage::TPDiskState::Stopped:
                 context.ReportStatus(Ydb::Monitoring::StatusFlag::GREEN);
@@ -2287,7 +2288,8 @@ public:
             FillPDiskStatus(pDiskId, *storageVDiskStatus.mutable_pdisk(), {&context, "PDISK"});
         }
 
-        if (status->number() == NKikimrBlobStorage::ERROR) {
+        auto statusEnum = static_cast<NKikimrBlobStorage::EVDiskStatus>(status->number());
+        if (statusEnum == NKikimrBlobStorage::ERROR) {
             // the disk is not operational at all
             context.ReportStatus(Ydb::Monitoring::StatusFlag::RED, TStringBuilder() << "VDisk is not available", ETags::VDiskState,{ETags::PDiskState});
             storageVDiskStatus.set_overall(context.GetOverallStatus());
@@ -2303,7 +2305,11 @@ public:
             return;
         }
 
-        switch (status->number()) {
+        switch (statusEnum) {
+            case NKikimrBlobStorage::ERROR: {
+                // already handled above
+                break;
+            }
             case NKikimrBlobStorage::REPLICATING: { // the disk accepts queries, but not all the data was replicated
                 context.ReportStatus(Ydb::Monitoring::StatusFlag::BLUE, TStringBuilder() << "Replication in progress", ETags::VDiskState);
                 storageVDiskStatus.set_overall(context.GetOverallStatus());
@@ -2313,8 +2319,6 @@ public:
             case NKikimrBlobStorage::READY: { // the disk is fully operational and does not affect group fault tolerance
                 context.ReportStatus(Ydb::Monitoring::StatusFlag::GREEN);
             }
-            default:
-                break;
         }
 
         storageVDiskStatus.set_overall(context.GetOverallStatus());
@@ -2379,7 +2383,7 @@ public:
 
         if (pDiskInfo.HasState()) {
             switch (pDiskInfo.GetState()) {
-                case NKikimrBlobStorage::TPDiskState::Normal:
+                // case NKikimrBlobStorage::TPDiskState::Normal:
                 case NKikimrBlobStorage::TPDiskState::Stopped:
                     context.ReportStatus(Ydb::Monitoring::StatusFlag::GREEN);
                     break;

--- a/ydb/core/health_check/health_check.cpp
+++ b/ydb/core/health_check/health_check.cpp
@@ -2215,21 +2215,6 @@ public:
             }
             auto stateEnum = static_cast<NKikimrBlobStorage::TPDiskState::E>(state->number());
             ReportPDiskState(stateEnum, context);
-
-            ui32 statusNumber;
-            if (!TryParsePDiskStatus(pDisk.GetStatusV2(), statusNumber)) {
-                context.ReportStatus(Ydb::Monitoring::StatusFlag::RED,
-                                    TStringBuilder() << "Unknown PDisk state: " << pDisk.GetStatusV2(),
-                                    ETags::PDiskState);
-                storagePDiskStatus.set_overall(context.GetOverallStatus());
-                context.OverallStatus = Ydb::Monitoring::StatusFlag::ORANGE;
-                return;
-            }
-            if (statusNumber == NKikimrBlobStorage::FAULTY) {
-                context.ReportStatus(Ydb::Monitoring::StatusFlag::RED,
-                                    TStringBuilder() << "PDisk state is " << pDisk.GetStatusV2(),
-                                    ETags::PDiskState);
-            }
         } else { // for backward compatibility
             ui32 statusNumber;
             if (!TryParsePDiskStatus(pDisk.GetStatusV2(), statusNumber)) {

--- a/ydb/core/health_check/health_check.cpp
+++ b/ydb/core/health_check/health_check.cpp
@@ -2151,7 +2151,7 @@ public:
         const auto& stateString = pDisk.GetState();
         const auto *descriptor = NKikimrBlobStorage::TPDiskState::E_descriptor();
         auto state = descriptor->FindValueByName(stateString);
-        if (!state) {;
+        if (!state) {
             context.ReportStatus(Ydb::Monitoring::StatusFlag::RED,
                                  TStringBuilder() << "Unknown PDisk state: " << stateString,
                                  ETags::PDiskState);
@@ -2159,7 +2159,8 @@ public:
             context.OverallStatus = Ydb::Monitoring::StatusFlag::ORANGE;
             return;
         }
-        switch (state->number()) {
+        auto stateEnum = static_cast<NKikimrBlobStorage::TPDiskState::E>(state->number());
+        switch (stateEnum) {
             case NKikimrBlobStorage::TPDiskState::Normal:
             case NKikimrBlobStorage::TPDiskState::Stopped:
                 context.ReportStatus(Ydb::Monitoring::StatusFlag::GREEN);
@@ -2287,7 +2288,8 @@ public:
             FillPDiskStatus(pDiskId, *storageVDiskStatus.mutable_pdisk(), {&context, "PDISK"});
         }
 
-        if (status->number() == NKikimrBlobStorage::ERROR) {
+        auto statusEnum = static_cast<NKikimrBlobStorage::EVDiskStatus>(status->number());
+        if (statusEnum == NKikimrBlobStorage::ERROR) {
             // the disk is not operational at all
             context.ReportStatus(Ydb::Monitoring::StatusFlag::RED, TStringBuilder() << "VDisk is not available", ETags::VDiskState,{ETags::PDiskState});
             storageVDiskStatus.set_overall(context.GetOverallStatus());
@@ -2303,7 +2305,11 @@ public:
             return;
         }
 
-        switch (status->number()) {
+        switch (statusEnum) {
+            case NKikimrBlobStorage::ERROR: {
+                // already handled above
+                break;
+            }
             case NKikimrBlobStorage::REPLICATING: { // the disk accepts queries, but not all the data was replicated
                 context.ReportStatus(Ydb::Monitoring::StatusFlag::BLUE, TStringBuilder() << "Replication in progress", ETags::VDiskState);
                 storageVDiskStatus.set_overall(context.GetOverallStatus());
@@ -2313,8 +2319,6 @@ public:
             case NKikimrBlobStorage::READY: { // the disk is fully operational and does not affect group fault tolerance
                 context.ReportStatus(Ydb::Monitoring::StatusFlag::GREEN);
             }
-            default:
-                break;
         }
 
         storageVDiskStatus.set_overall(context.GetOverallStatus());

--- a/ydb/core/health_check/health_check.cpp
+++ b/ydb/core/health_check/health_check.cpp
@@ -2163,7 +2163,7 @@ public:
             case E::Timeout:
             case E::NodeDisconnected:
                 context.ReportStatus(Ydb::Monitoring::StatusFlag::RED,
-                                    TStringBuilder() << "PDisk state is " << stateStr,
+                                    TStringBuilder() << "PDisk state is " << E::E_Name(stateEnum),
                                     ETags::PDiskState);
                 break;
         }

--- a/ydb/core/health_check/health_check.cpp
+++ b/ydb/core/health_check/health_check.cpp
@@ -2136,7 +2136,6 @@ public:
 
     void ReportPDiskState(NKikimrBlobStorage::TPDiskState::E stateEnum, TSelfCheckContext& context) {
         using E = NKikimrBlobStorage::TPDiskState;
-        const TString stateStr = E::E_Name(stateEnum);
 
         switch (stateEnum) {
             case E::Normal:

--- a/ydb/core/health_check/health_check_ut.cpp
+++ b/ydb/core/health_check/health_check_ut.cpp
@@ -71,7 +71,7 @@ Y_UNIT_TEST_SUITE(THealthCheckTest) {
     struct TTestVSlotInfo {
         std::optional<NKikimrBlobStorage::EVDiskStatus> Status;
         ui32 Generation = DEFAULT_GROUP_GENERATION;
-        NKikimrBlobStorage::TPDiskState::E PDiskState = NKikimrBlobStorage::TPDiskState::Normal;
+        std::optional<NKikimrBlobStorage::TPDiskState::E> PDiskState;
         NKikimrBlobStorage::EDriveStatus PDiskStatus = NKikimrBlobStorage::ACTIVE;
 
         TTestVSlotInfo(std::optional<NKikimrBlobStorage::EVDiskStatus> status = NKikimrBlobStorage::READY,
@@ -81,13 +81,13 @@ Y_UNIT_TEST_SUITE(THealthCheckTest) {
         {
         }
 
-        TTestVSlotInfo(NKikimrBlobStorage::EVDiskStatus status, NKikimrBlobStorage::TPDiskState::E pDiskState = NKikimrBlobStorage::TPDiskState::Normal)
+        TTestVSlotInfo(NKikimrBlobStorage::EVDiskStatus status, NKikimrBlobStorage::TPDiskState::E pDiskState)
             : Status(status)
             , PDiskState(pDiskState)
         {
         }
 
-        TTestVSlotInfo(NKikimrBlobStorage::EVDiskStatus status, NKikimrBlobStorage::EDriveStatus pDiskStatus)
+        TTestVSlotInfo(NKikimrBlobStorage::EVDiskStatus status, NKikimrBlobStorage::EDriveStatus pDiskStatus = NKikimrBlobStorage::ACTIVE)
             : Status(status)
             , PDiskStatus(pDiskStatus)
         {
@@ -250,7 +250,9 @@ Y_UNIT_TEST_SUITE(THealthCheckTest) {
             entry->mutable_key()->set_pdiskid(pdiskId);
             entry->mutable_info()->set_totalsize(totalSize);
             entry->mutable_info()->set_availablesize((1 - occupancy) * totalSize);
-            entry->mutable_info()->set_state(descriptorState->FindValueByNumber(vslot.PDiskState)->name());
+            if (vslot.PDiskState) {
+                entry->mutable_info()->set_state(descriptorState->FindValueByNumber(*vslot.PDiskState)->name());
+            }
             entry->mutable_info()->set_statusv2(descriptorStatusV2->FindValueByNumber(vslot.PDiskStatus)->name());
             ++pdiskId;
         }

--- a/ydb/core/health_check/health_check_ut.cpp
+++ b/ydb/core/health_check/health_check_ut.cpp
@@ -2373,7 +2373,7 @@ Y_UNIT_TEST_SUITE(THealthCheckTest) {
                     auto* x = reinterpret_cast<NSysView::TEvSysView::TEvGetPDisksResponse::TPtr*>(&ev);
                     auto& record = (*x)->Get()->Record;
                     for (auto& entry : *record.mutable_entries()) {
-                        entry.mutable_info()->set_statusv2("UNKNOWN_STATE?");
+                        entry.mutable_info()->set_state("UNKNOWN_STATE?");
                     }
                     break;
                 }

--- a/ydb/core/health_check/health_check_ut.cpp
+++ b/ydb/core/health_check/health_check_ut.cpp
@@ -573,7 +573,7 @@ Y_UNIT_TEST_SUITE(THealthCheckTest) {
         UNIT_ASSERT_VALUES_EQUAL_C(issuesCount, total, "Wrong issues count for " << type << " with expecting status " << expectingStatus);
     }
 
-     void StorageTest(ui64 usage, ui64 quota, ui64 storageIssuesNumber, Ydb::Monitoring::StatusFlag::Status status = Ydb::Monitoring::StatusFlag::GREEN) {
+    void StorageTest(ui64 usage, ui64 quota, ui64 storageIssuesNumber, Ydb::Monitoring::StatusFlag::Status status = Ydb::Monitoring::StatusFlag::GREEN) {
         TPortManager tp;
         ui16 port = tp.GetPort(2134);
         ui16 grpcPort = tp.GetPort(2135);

--- a/ydb/core/health_check/health_check_ut.cpp
+++ b/ydb/core/health_check/health_check_ut.cpp
@@ -748,12 +748,12 @@ Y_UNIT_TEST_SUITE(THealthCheckTest) {
     }
 
     Y_UNIT_TEST(OnlyDiskIssueOnInitialPDisks) {
-        auto result = RequestHcWithVdisks(NKikimrBlobStorage::TGroupStatus::PARTIAL, TVDisks{3, {NKikimrBlobStorage::READY, NKikimrBlobStorage::TPDiskState::Initial}});
+        auto result = RequestHcWithVdisks(NKikimrBlobStorage::TGroupStatus::PARTIAL, TVDisks{3, {NKikimrBlobStorage::READY, NKikimrBlobStorage::TPDiskState::DeviceIoError}});
         Cerr << result.ShortDebugString() << Endl;
         CheckHcResultHasIssuesWithStatus(result, "STORAGE_GROUP", Ydb::Monitoring::StatusFlag::YELLOW, 0);
         CheckHcResultHasIssuesWithStatus(result, "STORAGE_GROUP", Ydb::Monitoring::StatusFlag::ORANGE, 0);
         CheckHcResultHasIssuesWithStatus(result, "STORAGE_GROUP", Ydb::Monitoring::StatusFlag::RED, 0);
-        CheckHcResultHasIssuesWithStatus(result, "PDISK", Ydb::Monitoring::StatusFlag::YELLOW, 3, "");
+        CheckHcResultHasIssuesWithStatus(result, "PDISK", Ydb::Monitoring::StatusFlag::RED, 3, "");
     }
 
     Y_UNIT_TEST(OnlyDiskIssueOnFaultyPDisks) {
@@ -2411,11 +2411,10 @@ Y_UNIT_TEST_SUITE(THealthCheckTest) {
         bool pdiskIssueFoundInResult = false;
         for (const auto &issue_log : result.issue_log()) {
             if (issue_log.type() == "PDISK") {
-                UNIT_ASSERT_VALUES_EQUAL(issue_log.message(), "Unknown PDisk state: UNKNOWN_STATE?");
                 pdiskIssueFoundInResult = true;
             }
         }
-        UNIT_ASSERT(pdiskIssueFoundInResult);
+        UNIT_ASSERT(!pdiskIssueFoundInResult);
     }
 }
 }

--- a/ydb/core/health_check/health_check_ut.cpp
+++ b/ydb/core/health_check/health_check_ut.cpp
@@ -570,7 +570,7 @@ Y_UNIT_TEST_SUITE(THealthCheckTest) {
                 issuesCount++;
             }
         }
-        UNIT_ASSERT_VALUES_EQUAL(issuesCount, total);
+        UNIT_ASSERT_VALUES_EQUAL_C(issuesCount, total, "Wrong issues count for " << type << " with expecting status " << expectingStatus);
     }
 
      void StorageTest(ui64 usage, ui64 quota, ui64 storageIssuesNumber, Ydb::Monitoring::StatusFlag::Status status = Ydb::Monitoring::StatusFlag::GREEN) {
@@ -760,7 +760,7 @@ Y_UNIT_TEST_SUITE(THealthCheckTest) {
         CheckHcResultHasIssuesWithStatus(result, "STORAGE_GROUP", Ydb::Monitoring::StatusFlag::YELLOW, 0);
         CheckHcResultHasIssuesWithStatus(result, "STORAGE_GROUP", Ydb::Monitoring::StatusFlag::ORANGE, 0);
         CheckHcResultHasIssuesWithStatus(result, "STORAGE_GROUP", Ydb::Monitoring::StatusFlag::RED, 0);
-        CheckHcResultHasIssuesWithStatus(result, "PDISK", Ydb::Monitoring::StatusFlag::YELLOW, 3, "");
+        CheckHcResultHasIssuesWithStatus(result, "PDISK", Ydb::Monitoring::StatusFlag::RED, 3, "");
     }
 
     /* HC currently infers group status on its own, so it's never unknown


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

To avoid ambiguity, we switched to using the PDisk State from BSC info to determine the PDisk status instead of the PDisk status in CMS. It is already used in the healthcheck fallback logic and reflects the actual disk condition. We plan to make it the primary source for PDisk state in healthcheck.

### Changelog category <!-- remove all except one -->

* Improvement

### Description for reviewers <!-- (optional) description for those who read this PR -->

**motivation:**
- healthcheck may report OK for a PDisk with INACTIVE CMS status, which is not always correct if the PDisk is actually dead.
- added a new field State to BSC information to improve determination of PDisk statuses. This is the same field used in fallback scenarios, allowing unified logic across all cases.

**notes:**
- in case of missing state information, there is a fallback to statusV2.

