### PR TITLE
Improve UPDATE with sinks

### DIFF
--- a/ydb/core/kqp/opt/kqp_opt_kql.cpp
+++ b/ydb/core/kqp/opt/kqp_opt_kql.cpp
@@ -205,10 +205,6 @@ TExprNode::TPtr GetPgNotNullColumns(
 TExprNode::TPtr IsUpdateSetting(TExprContext& ctx, const TPositionHandle& pos) {
     return Build<TCoNameValueTupleList>(ctx, pos)
         .Add()
-            .Name().Build("Mode")
-            .Value<TCoAtom>().Build("update")
-        .Build()
-        .Add()
             .Name().Build("IsUpdate")
         .Build()
     .Done().Ptr();
@@ -474,8 +470,43 @@ TExprBase BuildUpdateOnTable(const TKiWriteTable& write, const TCoAtomList& inpu
 
 
 TExprBase BuildUpdateOnTableWithIndex(const TKiWriteTable& write, const TCoAtomList& inputColumns,
-    const TKikimrTableDescription& tableData, TExprContext& ctx)
+    const bool isSink, const TKikimrTableDescription& tableData, TExprContext& ctx)
 {
+    if (isSink) {
+        auto indexes = BuildSecondaryIndexVector(tableData, write.Pos(), ctx, nullptr,
+            [] (const TKikimrTableMetadata& meta, TPositionHandle pos, TExprContext& ctx) -> TExprBase {
+                return BuildTableMeta(meta, pos, ctx);
+            });
+
+        THashSet<TStringBuf> inputColumnsSet;
+        for (const auto& column : inputColumns) {
+            inputColumnsSet.emplace(column.Value());
+        }
+
+        const bool needToUpdateIndex = std::any_of(
+            std::begin(indexes), std::end(indexes),
+            [&] (const auto& index) {
+                return std::any_of(std::begin(index.second->KeyColumns), std::end(index.second->KeyColumns),
+                        [&] (const auto& column) { return !tableData.GetKeyColumnIndex(column) && inputColumnsSet.contains(column); })
+                   ||  std::any_of(std::begin(index.second->DataColumns), std::end(index.second->DataColumns),
+                        [&] (const auto& column) { return inputColumnsSet.contains(column); });
+            });
+
+        if (!needToUpdateIndex) {
+            // If indexes don't need to be updated, we can use update without lookup.
+            return Build<TKqlUpdateRows>(ctx, write.Pos())
+                .Table(BuildTableMeta(tableData, write.Pos(), ctx))
+                .Input<TKqpWriteConstraint>()
+                    .Input(write.Input())
+                    .Columns(GetPgNotNullColumns(tableData, write.Pos(), ctx))
+                .Build()
+                .Columns(inputColumns)
+                .ReturningColumns(write.ReturningColumns())
+                .Done();
+        }
+    }
+
+
     return Build<TKqlUpdateRowsIndex>(ctx, write.Pos())
         .Table(BuildTableMeta(tableData, write.Pos(), ctx))
         .Input<TKqpWriteConstraint>()
@@ -901,7 +932,7 @@ TExprBase WriteTableWithIndexUpdate(const TKiWriteTable& write, const TCoAtomLis
         case TYdbOperation::InsertRevert:
             return BuildInsertTableWithIndex(write, op == TYdbOperation::InsertAbort, inputColumns, autoincrement, isSink, tableData, ctx);
         case TYdbOperation::UpdateOn:
-            return BuildUpdateOnTableWithIndex(write, inputColumns, tableData, ctx);
+            return BuildUpdateOnTableWithIndex(write, inputColumns, isSink, tableData, ctx);
         case TYdbOperation::DeleteOn:
             return BuildDeleteTableWithIndex(write, tableData, ctx);
         default:

--- a/ydb/core/kqp/opt/kqp_opt_kql.cpp
+++ b/ydb/core/kqp/opt/kqp_opt_kql.cpp
@@ -218,7 +218,7 @@ TExprNode::TPtr IsConditionalUpdateSetting(TExprContext& ctx, const TPositionHan
     return Build<TCoNameValueTupleList>(ctx, pos)
         .Add()
             .Name().Build("Mode")
-            .Value<TCoAtom>().Build("update")
+            .Value<TCoAtom>().Build("upsert") // Rows were read from table, so we are sure that they exist.
         .Build()
         .Add()
             .Name().Build("IsUpdate")

--- a/ydb/core/kqp/ut/indexes/kqp_indexes_ut.cpp
+++ b/ydb/core/kqp/ut/indexes/kqp_indexes_ut.cpp
@@ -1210,17 +1210,18 @@ Y_UNIT_TEST_SUITE(KqpIndexes) {
                           .ExtractValueSync();
             UNIT_ASSERT(result.IsSuccess());
             auto& stats = NYdb::TProtoAccessor::GetProto(*result.GetStats());
-            UNIT_ASSERT_VALUES_EQUAL(stats.query_phases().size(), UseSink ? 3 : 4);
+            UNIT_ASSERT_VALUES_EQUAL(stats.query_phases().size(), UseSink ? 1 : 4);
 
-            int idx = 1;
+            int idx = UseSink ? 0 : 1;
 
             UNIT_ASSERT_VALUES_EQUAL(stats.query_phases(idx).table_access().size(), 1);
             // One read of main table
             UNIT_ASSERT_VALUES_EQUAL(stats.query_phases(idx).table_access(0).name(), "/Root/TestTable");
-            UNIT_ASSERT_VALUES_EQUAL(stats.query_phases(idx).table_access(0).reads().rows(), 1);
+            UNIT_ASSERT_VALUES_EQUAL(stats.query_phases(idx).table_access(0).reads().rows(), UseSink ? 0 : 1);
 
+            
             // One update of index table
-            idx += UseSink ? 1 : 2;
+            idx += UseSink ? 0 : 2;
             UNIT_ASSERT_VALUES_EQUAL(stats.query_phases(idx).table_access().size(), 1);
             UNIT_ASSERT_VALUES_EQUAL(stats.query_phases(idx).table_access(0).name(), "/Root/TestTable");
             UNIT_ASSERT_VALUES_EQUAL(stats.query_phases(idx).table_access(0).updates().rows(), 1);    
@@ -6204,7 +6205,7 @@ R"([[#;#;["Primary1"];[41u]];[["Secondary2"];[2u];["Primary2"];[42u]];[["Seconda
         UNIT_ASSERT_VALUES_EQUAL_C(result.GetStatus(), EStatus::SUCCESS, result.GetIssues().ToString());
 
         AssertTableStats(result, "/Root/TestTable", {
-            .ExpectedReads = 1,
+            .ExpectedReads = 0,
             .ExpectedUpdates = 1
         });
 
@@ -6558,10 +6559,7 @@ R"([[#;#;["Primary1"];[41u]];[["Secondary2"];[2u];["Primary2"];[42u]];[["Seconda
             NJson::ReadJsonTree(result.GetPlan(), &plan, true);
             auto table = plan["tables"][0];
             UNIT_ASSERT_VALUES_EQUAL(table["name"], "/Root/SecondaryKeys");
-            auto reads = table["reads"].GetArraySafe();
-            UNIT_ASSERT_VALUES_EQUAL(reads.size(), 1);
-            UNIT_ASSERT_VALUES_EQUAL(reads[0]["type"], "Lookup");
-            UNIT_ASSERT_VALUES_EQUAL(reads[0]["columns"].GetArraySafe().size(), 1);
+            UNIT_ASSERT(!table.Has("reads"));
         }
         {
             // Check that keys from involved index are in read columns
@@ -6638,10 +6636,7 @@ R"([[#;#;["Primary1"];[41u]];[["Secondary2"];[2u];["Primary2"];[42u]];[["Seconda
             NJson::ReadJsonTree(result.GetPlan(), &plan, true);
             auto table = plan["tables"][0];
             UNIT_ASSERT_VALUES_EQUAL(table["name"], "/Root/SecondaryWithDataColumns");
-            auto reads = table["reads"].GetArraySafe();
-            UNIT_ASSERT_VALUES_EQUAL(reads.size(), 1);
-            UNIT_ASSERT_VALUES_EQUAL(reads[0]["type"], "Lookup");
-            UNIT_ASSERT_VALUES_EQUAL(reads[0]["columns"].GetArraySafe().size(), 1);
+            UNIT_ASSERT(!table.Has("reads"));
         }
     }
 

--- a/ydb/tests/functional/canonical/canondata/test_sql.TestCanonicalFolder1.test_case_write_update.sql-plan_/write_update.sql.plan
+++ b/ydb/tests/functional/canonical/canondata/test_sql.TestCanonicalFolder1.test_case_write_update.sql-plan_/write_update.sql.plan
@@ -29,7 +29,7 @@
                         "Group",
                         "Name"
                     ],
-                    "type": "MultiUpdate"
+                    "type": "MultiUpsert"
                 }
             ]
         }


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

...

### Changelog category <!-- remove all except one -->

* Not for changelog (changelog entry is not required)

### Description for reviewers <!-- (optional) description for those who read this PR -->

Improve UPDATE with sinks

- Use UPSERT instead of UPDATE for previously read rows (UPDATE WHERE)
- Avoid lookup for UPDATE ON if secondary indexes weren't touched

