### PR TITLE
Output TDiskFormat.ChunkSize in MiB

### DIFF
--- a/ydb/core/blobstorage/pdisk/blobstorage_pdisk_data.h
+++ b/ydb/core/blobstorage/pdisk/blobstorage_pdisk_data.h
@@ -652,7 +652,7 @@ struct TDiskFormat {
         str << " MagicDataChunk: " << MagicDataChunk << x;
         str << " MagicSysLogChunk: " << MagicSysLogChunk << x;
         str << " MagicFormatChunk: " << MagicFormatChunk << x;
-        str << " ChunkSize: " << ChunkSize << " bytes (" << (ChunkSize / 1000000ull) << " MB)" << x;
+        str << " ChunkSize: " << ChunkSize << " bytes (" << (ChunkSize / 1048576ull) << " MiB)" << x;
         str << " SectorSize: " << SectorSize << x;
         str << " SysLogSectorCount: " << SysLogSectorCount << x;
         str << " SystemChunkCount: " << SystemChunkCount << x;


### PR DESCRIPTION
### Changelog category

* Not for changelog (changelog entry is not required)

### Description for reviewers <!-- (optional) description for those who read this PR -->

This change only affects Developer UI (PDisk page)

Before: `ChunkSize: 136314880 bytes (136 MB)`
After:  `ChunkSize: 136314880 bytes (128 MiB)`


