### PR TITLE
25-1-1: Fix method check in schemeshard actions

### DIFF
--- a/ydb/core/tx/schemeshard/schemeshard__monitoring.cpp
+++ b/ydb/core/tx/schemeshard/schemeshard__monitoring.cpp
@@ -1473,7 +1473,7 @@ private:
 
 private:
     void HandleAction(const TString& action, const TCgiParameters& cgi, const TActorContext& ctx) {
-        if (Ev->Get()->Method != HTTP_METHOD_POST) {
+        if (Ev->Get()->GetMethod() != HTTP_METHOD_POST) {
             SendBadRequest("Action requires a POST method", ctx);
             return;
         }


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

...

### Changelog category <!-- remove all except one -->

* Not for changelog (changelog entry is not required)

### Description for reviewers <!-- (optional) description for those who read this PR -->

Fix method check in SchemeShard actions, turns out event's `Method` field is always undefined, and tablets need to use the `GetMethod()` method.

Merges #17735.