### PR TITLE
#9056 Auto-insert closing bracket in YDB CLI

### DIFF
--- a/ydb/apps/ydb/CHANGELOG.md
+++ b/ydb/apps/ydb/CHANGELOG.md
@@ -1,3 +1,4 @@
+* Brackets are now inserted in pairs in YDB CLI interactive mode
 * Added `--scale` option to `ydb workload tpch init` and `ydb workload tpcds init` commands. Sets the percentage of the benchmark's data size and workload to use, relative to full scale.
 * Added "--no-discovery" option. It allows to skip discovery and use user provided endpoint to connect to YDB cluster.
 * Added `--retries` to `ydb workload <clickbenh|tpch|tpcds> run` command.


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

Brackets are now inserted in pairs in YDB CLI interactive mode

### Changelog category <!-- remove all except one -->

* Not for changelog (changelog entry is not required)

### Description for reviewers <!-- (optional) description for those who read this PR -->

- [x] Group `Replxx` setup statements by functionality.
- [x] Auto-insert a closing bracket. It should improve UX and also improves a code completion as the lexer fails on ``` SELECT * FROM `| ``` and therefore we can't complete anything, but ``` SELECT * FROM `|` ``` is OK here we can complete a table name.

---

- Related to https://github.com/ydb-platform/ydb/issues/9056
- Related to `YQL-19747`
- Related to https://github.com/vityaman/ydb/issues/14
