### PR TITLE
#9056 Respect CompletedToken in YDB CLI

### DIFF
--- a/ydb/public/lib/ydb_cli/commands/interactive/complete/yql_completer.cpp
+++ b/ydb/public/lib/ydb_cli/commands/interactive/complete/yql_completer.cpp
@@ -7,6 +7,8 @@
 #include <yql/essentials/sql/v1/lexer/antlr4_pure/lexer.h>
 #include <yql/essentials/sql/v1/lexer/antlr4_pure_ansi/lexer.h>
 
+#include <util/charset/utf8.h>
+
 namespace NYdb::NConsoleClient {
 
     class TYQLCompleter: public IYQLCompleter {
@@ -19,11 +21,13 @@ namespace NYdb::NConsoleClient {
         {
         }
 
-        TCompletions Apply(const std::string& prefix, int& /* contextLen */) override {
+        TCompletions Apply(const std::string& prefix, int& contextLen) override {
             auto completion = Engine->Complete({
                 .Text = prefix,
                 .CursorPosition = prefix.length(),
             });
+
+            contextLen = GetNumberOfUTF8Chars(completion.CompletedToken.Content);
 
             replxx::Replxx::completions_t entries;
             for (auto& candidate : completion.Candidates) {


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

Respect CompletedToken in YDB CLI

### Changelog category <!-- remove all except one -->

* Not for changelog (changelog entry is not required)

### Description for reviewers <!-- (optional) description for those who read this PR -->

Before I relied on `NSQLComplete::WordBreakCharacters` and `Replxx::set_word_break_characters`, but it does not work with completion inside the `ID_QUOTED`, e.g. ``` `/local/.sys/tratata/` ``` -- here `.` is a `WordBreakCharacter`, but `contextLen` should be `".sys".size()`. This change will unblock me from changing `CompletedToken` computation strategy (current relies on `WordBreakCharacters` and therefore compatible).

---

- Related to https://github.com/ydb-platform/ydb/issues/9056
- Related to `YQL-19747`
- Related to https://github.com/vityaman/ydb/issues/14
