### PR TITLE
Fix BuildIndex/Export/Import operation listing order

### DIFF
--- a/ydb/core/tx/schemeshard/schemeshard_build_index__list.cpp
+++ b/ydb/core/tx/schemeshard/schemeshard_build_index__list.cpp
@@ -43,28 +43,28 @@ public:
         const ui64 pageSize = Min(record.GetPageSize() ? Max(record.GetPageSize(), MinPageSize) : DefaultPageSize, MaxPageSize);
 
 
-        auto it = Self->IndexBuilds.begin();
+        auto it = Self->IndexBuilds.end();
         ui64 skip = (page - 1) * pageSize;
-        while ((it != Self->IndexBuilds.end()) && skip) {
+        while ((it != Self->IndexBuilds.begin()) && skip) {
+            --it;
             if (it->second->DomainPathId == domainPathId) {
                 --skip;
             }
-            ++it;
         }
 
         auto& respRecord = Response->Record;
         respRecord.SetStatus(Ydb::StatusIds::SUCCESS);
 
         ui64 size = 0;
-        while ((it != Self->IndexBuilds.end()) && size < pageSize) {
+        while ((it != Self->IndexBuilds.begin()) && size < pageSize) {
+            --it;
             if (it->second->DomainPathId == domainPathId) {
                 Fill(*respRecord.MutableEntries()->Add(), *it->second);
                 ++size;
             }
-            ++it;
         }
 
-        if (it == Self->IndexBuilds.end()) {
+        if (it == Self->IndexBuilds.begin()) {
             respRecord.SetNextPageToken("0");
         } else {
             respRecord.SetNextPageToken(ToString(page + 1));

--- a/ydb/core/tx/schemeshard/schemeshard_impl.h
+++ b/ydb/core/tx/schemeshard/schemeshard_impl.h
@@ -1241,7 +1241,7 @@ public:
     // } // NLongRunningCommon
 
     // namespace NExport {
-    THashMap<ui64, TExportInfo::TPtr> Exports;
+    TMap<ui64, TExportInfo::TPtr> Exports;
     THashMap<TString, TExportInfo::TPtr> ExportsByUid;
     THashMap<TTxId, std::pair<ui64, ui32>> TxIdToExport;
     THashMap<TTxId, THashSet<ui64>> TxIdToDependentExport;
@@ -1294,7 +1294,7 @@ public:
     // } // NExport
 
     // namespace NImport {
-    THashMap<ui64, TImportInfo::TPtr> Imports;
+    TMap<ui64, TImportInfo::TPtr> Imports;
     THashMap<TString, TImportInfo::TPtr> ImportsByUid;
     THashMap<TTxId, std::pair<ui64, ui32>> TxIdToImport;
     THashSet<TActorId> RunningImportSchemeGetters;
@@ -1365,7 +1365,7 @@ public:
     // namespace NIndexBuilder {
     TControlWrapper AllowDataColumnForIndexTable;
 
-    THashMap<TIndexBuildId, TIndexBuildInfo::TPtr> IndexBuilds;
+    TMap<TIndexBuildId, TIndexBuildInfo::TPtr> IndexBuilds;
     THashMap<TString, TIndexBuildInfo::TPtr> IndexBuildsByUid;
     THashMap<TTxId, TIndexBuildId> TxIdToIndexBuilds;
 

--- a/ydb/core/tx/schemeshard/schemeshard_xxport__get.h
+++ b/ydb/core/tx/schemeshard/schemeshard_xxport__get.h
@@ -20,7 +20,7 @@ struct TSchemeShard::TXxport::TTxGet: public TSchemeShard::TXxport::TTxBase {
     {
     }
 
-    bool DoExecuteImpl(const THashMap<ui64, typename TInfo::TPtr>& container, TTransactionContext&, const TActorContext&) {
+    bool DoExecuteImpl(const TMap<ui64, typename TInfo::TPtr>& container, TTransactionContext&, const TActorContext&) {
         const auto& request = Request->Get()->Record;
 
         auto response = MakeHolder<TEvResponse>();

--- a/ydb/core/tx/schemeshard/schemeshard_xxport__list.h
+++ b/ydb/core/tx/schemeshard/schemeshard_xxport__list.h
@@ -25,7 +25,7 @@ struct TSchemeShard::TXxport::TTxList: public TSchemeShard::TXxport::TTxBase {
     {
     }
 
-    bool DoExecuteImpl(const THashMap<ui64, typename TInfo::TPtr>& container, TTransactionContext&, const TActorContext&) {
+    bool DoExecuteImpl(const TMap<ui64, typename TInfo::TPtr>& container, TTransactionContext&, const TActorContext&) {
         const auto& record = Request->Get()->Record;
         const auto& request = record.GetRequest();
 
@@ -54,26 +54,26 @@ struct TSchemeShard::TXxport::TTxList: public TSchemeShard::TXxport::TTxBase {
 
         resp.SetStatus(Ydb::StatusIds::SUCCESS);
 
-        auto it = container.begin();
+        auto it = container.end();
         ui64 skip = (page - 1) * pageSize;
-        while (it != container.end() && skip) {
+        while (it != container.begin() && skip) {
+            --it;
             if (IsSameDomain(it->second, domainPathId) && it->second->Kind == kind) {
                 --skip;
             }
-            ++it;
         }
 
         ui64 size = 0;
-        while (it != container.end() && size < pageSize) {
+        while (it != container.begin() && size < pageSize) {
+            --it;
             if (IsSameDomain(it->second, domainPathId) && it->second->Kind == kind) {
                 Self->FromXxportInfo(*resp.MutableEntries()->Add(), it->second);
                 ++size;
             }
-            ++it;
         }
 
-        if (it == container.end()) {
-            resp.SetNextPageToken("1");
+        if (it == container.begin()) {
+            resp.SetNextPageToken("0");
         } else {
             resp.SetNextPageToken(ToString(page + 1));
         }

--- a/ydb/core/viewer/tests/canondata/result.json
+++ b/ydb/core/viewer/tests/canondata/result.json
@@ -4,11 +4,11 @@
         "text": "1\n"
     },
     "test.test_operations_list": {
-        "next_page_token": "1",
+        "next_page_token": "0",
         "status": "SUCCESS"
     },
     "test.test_operations_list_page": {
-        "next_page_token": "1",
+        "next_page_token": "0",
         "status": "SUCCESS"
     },
     "test.test_operations_list_page_bad": {


### PR DESCRIPTION
Return newest operations first instead of random ones (not exactly random, just picked from a hashmap).

### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

Fix BuildIndex/Export/Import operation listing order (#17817)

### Changelog category <!-- remove all except one -->

* Bugfix 
