### PR TITLE
Fix debug verify in case of session termination without XDC.

### DIFF
--- a/ydb/library/actors/interconnect/interconnect_zc_processor.cpp
+++ b/ydb/library/actors/interconnect/interconnect_zc_processor.cpp
@@ -383,8 +383,10 @@ public:
     }
 
     void Terminate(std::unique_ptr<NActors::TEventHolderPool>&& pool, TIntrusivePtr<NInterconnect::TStreamSocket> socket, const NActors::TActorContext &ctx) override {
-        // must be registered on the same mailbox!
-        ctx.RegisterWithSameMailbox(new TGuardActor(Uncompleted, Confirmed, std::move(Delayed), socket, std::move(pool)));
+        if (!Delayed.empty()) {
+            // must be registered on the same mailbox!
+            ctx.RegisterWithSameMailbox(new TGuardActor(Uncompleted, Confirmed, std::move(Delayed), socket, std::move(pool)));
+        }
     }
 private:
     const ui64 Uncompleted;


### PR DESCRIPTION
### Changelog entry 
TGuardActor should be launched only in case of uncompleted ZC transfers.
https://github.com/ydb-platform/ydb/issues/17820


### Changelog category 
* Bugfix 


