### PR TITLE
fix pk usage in writing v0 chunks

### DIFF
--- a/ydb/core/tx/columnshard/engines/storage/granule/granule.h
+++ b/ydb/core/tx/columnshard/engines/storage/granule/granule.h
@@ -212,7 +212,8 @@ public:
         OnAfterChangePortion(innerPortion, nullptr);
     }
 
-    void InsertPortionOnExecute(NTabletFlatExecutor::TTransactionContext& txc, const TPortionDataAccessor& portion) const;
+    void InsertPortionOnExecute(
+        NTabletFlatExecutor::TTransactionContext& txc, const TPortionDataAccessor& portion, const ui64 firstPKColumnId) const;
     void InsertPortionOnComplete(const TPortionDataAccessor& portion, IColumnEngine& engine);
 
     void CommitPortionOnExecute(
@@ -233,8 +234,8 @@ public:
         CommitPortionOnComplete(insertWriteId, engine);
     }
 
-    void CommitImmediateOnExecute(
-        NTabletFlatExecutor::TTransactionContext& txc, const TSnapshot& snapshot, const TPortionDataAccessor& portion) const;
+    void CommitImmediateOnExecute(NTabletFlatExecutor::TTransactionContext& txc, const TSnapshot& snapshot, const TPortionDataAccessor& portion,
+        const ui64 firstPKColumnId) const;
     void CommitImmediateOnComplete(const std::shared_ptr<TPortionInfo> portion, IColumnEngine& engine);
 
     std::vector<NStorageOptimizer::TTaskDescription> GetOptimizerTasksDescription() const {

--- a/ydb/core/tx/columnshard/normalizer/abstract/abstract.h
+++ b/ydb/core/tx/columnshard/normalizer/abstract/abstract.h
@@ -70,6 +70,7 @@ enum class ENormalizerSequentialId : ui32 {
     RestoreV1Chunks_V2,
     RestoreV2Chunks,
     CleanDeprecatedSnapshot,
+    RestoreV0ChunksMeta,
 
     MAX
 };

--- a/ydb/core/tx/columnshard/normalizer/portion/chunks_v0_meta.cpp
+++ b/ydb/core/tx/columnshard/normalizer/portion/chunks_v0_meta.cpp
@@ -1,0 +1,123 @@
+#include "chunks_v0_meta.h"
+#include "normalizer.h"
+
+#include <ydb/core/formats/arrow/size_calcer.h>
+#include <ydb/core/tx/columnshard/counters/portion_index.h>
+#include <ydb/core/tx/columnshard/data_accessor/manager.h>
+#include <ydb/core/tx/columnshard/engines/column_engine_logs.h>
+#include <ydb/core/tx/columnshard/engines/portions/data_accessor.h>
+#include <ydb/core/tx/columnshard/engines/portions/portion_info.h>
+#include <ydb/core/tx/columnshard/tables_manager.h>
+
+namespace NKikimr::NOlap {
+
+class TChunksV0MetaNormalizer::TNormalizerResult: public INormalizerChanges {
+    std::vector<TChunksV0MetaNormalizer::TChunkInfo> Chunks;
+    std::shared_ptr<THashMap<ui64, ISnapshotSchema::TPtr>> Schemas;
+
+public:
+    TNormalizerResult(std::vector<TChunksV0MetaNormalizer::TChunkInfo>&& chunks)
+        : Chunks(std::move(chunks)) {
+    }
+
+    bool ApplyOnExecute(NTabletFlatExecutor::TTransactionContext& txc, const TNormalizationController& /* normController */) const override {
+        using namespace NColumnShard;
+        NIceDb::TNiceDb db(txc.DB);
+
+        for (auto&& chunkInfo : Chunks) {
+            NKikimrTxColumnShard::TIndexColumnMeta metaProto = chunkInfo.GetMetaProto();
+            metaProto.MutablePortionMeta()->CopyFrom(chunkInfo.GetUpdate().GetPortionMeta());
+
+            const auto& key = chunkInfo.GetKey();
+
+            db.Table<Schema::IndexColumns>()
+                .Key(key.GetIndex(), key.GetGranule(), key.GetColumnId(), key.GetPlanStep(), key.GetTxId(), key.GetPortion(), key.GetChunk())
+                .Update(NIceDb::TUpdate<Schema::IndexColumns::Metadata>(metaProto.SerializeAsString()));
+        }
+        return true;
+    }
+
+    ui64 GetSize() const override {
+        return Chunks.size();
+    }
+};
+
+void TChunksV0MetaNormalizer::TChunkInfo::InitSchema(const NColumnShard::TTablesManager& tm) {
+    Schema = tm.GetPrimaryIndexSafe().GetVersionedIndex().GetSchemaVerified(NOlap::TSnapshot(Key.GetPlanStep(), Key.GetTxId()));
+}
+
+TConclusion<std::vector<INormalizerTask::TPtr>> TChunksV0MetaNormalizer::DoInit(
+    const TNormalizationController& controller, NTabletFlatExecutor::TTransactionContext& txc) {
+    using namespace NColumnShard;
+    NIceDb::TNiceDb db(txc.DB);
+
+    if (!AppDataVerified().ColumnShardConfig.GetColumnChunksV0Usage()) {
+        return std::vector<INormalizerTask::TPtr>();
+    }
+
+    bool ready = true;
+    ready = ready & Schema::Precharge<Schema::IndexColumns>(db, txc.DB.GetScheme());
+    ready = ready & Schema::Precharge<Schema::IndexPortions>(db, txc.DB.GetScheme());
+    if (!ready) {
+        return TConclusionStatus::Fail("Not ready");
+    }
+
+    TTablesManager tablesManager(controller.GetStoragesManager(), std::make_shared<NDataAccessorControl::TLocalManager>(nullptr),
+        std::make_shared<TSchemaObjectsCache>(), std::make_shared<TPortionIndexStats>(), 0);
+    if (!tablesManager.InitFromDB(db)) {
+        ACFL_TRACE("normalizer", "TChunksV0MetaNormalizer")("error", "can't initialize tables manager");
+        return TConclusionStatus::Fail("Can't load index");
+    }
+
+    std::vector<TChunkInfo> chunks;
+    {
+        auto rowset = db.Table<Schema::IndexColumns>().Select();
+        if (!rowset.IsReady()) {
+            return TConclusionStatus::Fail("Not ready");
+        }
+
+        while (!rowset.EndOfSet()) {
+            TColumnKey key;
+            key.Load(rowset);
+
+            TChunkInfo chunkInfo(std::move(key), rowset, &*DsGroupSelector, tablesManager);
+            if (chunkInfo.NormalizationRequired()) {
+                auto metadata = GetPortionMeta(TPortionKey(rowset.GetValue<Schema::IndexColumns::PathId>(), key.GetPortion()), db);
+                if (metadata.IsFail()) {
+                    return metadata;
+                }
+                chunkInfo.SetUpdate(metadata.DetachResult());
+                chunks.emplace_back(std::move(chunkInfo));
+            }
+
+            if (!rowset.Next()) {
+                return TConclusionStatus::Fail("Not ready");
+            }
+        }
+    }
+
+    std::vector<INormalizerTask::TPtr> tasks;
+    ACFL_INFO("normalizer", "TChunksV0MetaNormalizer")("message", TStringBuilder() << chunks.size() << " chunks found");
+    if (chunks.empty()) {
+        return tasks;
+    }
+
+    std::vector<TChunkInfo> package;
+    package.reserve(100);
+
+    for (auto&& chunk : chunks) {
+        package.emplace_back(chunk);
+        if (package.size() == 100) {
+            std::vector<TChunkInfo> local;
+            local.swap(package);
+            tasks.emplace_back(std::make_shared<TTrivialNormalizerTask>(std::make_shared<TNormalizerResult>(std::move(local))));
+        }
+    }
+
+    if (package.size() > 0) {
+        tasks.emplace_back(std::make_shared<TTrivialNormalizerTask>(std::make_shared<TNormalizerResult>(std::move(package))));
+    }
+    return tasks;
+}
+
+}   // namespace NKikimr::NOlap

--- a/ydb/core/tx/columnshard/normalizer/portion/chunks_v0_meta.h
+++ b/ydb/core/tx/columnshard/normalizer/portion/chunks_v0_meta.h
@@ -1,0 +1,155 @@
+#pragma once
+
+#include <ydb/core/tx/columnshard/columnshard_schema.h>
+#include <ydb/core/tx/columnshard/defs.h>
+#include <ydb/core/tx/columnshard/normalizer/abstract/abstract.h>
+
+namespace NKikimr::NColumnShard {
+class TTablesManager;
+}
+
+namespace NKikimr::NOlap {
+
+class TChunksV0MetaNormalizer: public TNormalizationController::INormalizerComponent {
+private:
+    using TBase = TNormalizationController::INormalizerComponent;
+
+    class TPortionKey {
+        YDB_READONLY(ui64, PathId, 0);
+        YDB_READONLY(ui64, PortionId, 0);
+
+    public:
+        TPortionKey(const ui64 pathId, const ui64 portionId)
+            : PathId(pathId)
+            , PortionId(portionId) {
+        }
+
+        auto operator<=>(const TPortionKey& other) const {
+            return std::tie(PathId, PortionId) <=> std::tie(other.PathId, other.PortionId);
+        }
+        operator size_t() const {
+            return CombineHashes(PathId, PortionId);
+        }
+    };
+
+    TConclusion<NKikimrTxColumnShard::TIndexPortionMeta> GetPortionMeta(const TPortionKey& key, NIceDb::TNiceDb& db) {
+        if (auto findMeta = PortionMetaCache.FindPtr(key)) {
+            return *findMeta;
+        }
+
+        auto rowset = db.Table<NColumnShard::Schema::IndexPortions>().Key(key.GetPathId(), key.GetPortionId()).Select();
+        if (!rowset.IsReady()) {
+            return TConclusionStatus::Fail("Not ready");
+        }
+        AFL_VERIFY(!rowset.EndOfSet());
+        NKikimrTxColumnShard::TIndexColumnMeta metaProto;
+        AFL_VERIFY(metaProto.ParseFromString(rowset.GetValue<NColumnShard::Schema::IndexPortions::Metadata>()));
+        auto emplaced = PortionMetaCache.emplace(key, metaProto.GetPortionMeta());
+        AFL_VERIFY(emplaced.second);
+        return emplaced.first->second;
+    }
+
+public:
+    static TString GetClassNameStatic() {
+        return ::ToString(ENormalizerSequentialId::RestoreV0ChunksMeta);
+    }
+
+    virtual std::optional<ENormalizerSequentialId> DoGetEnumSequentialId() const override {
+        return ENormalizerSequentialId::RestoreV0ChunksMeta;
+    }
+
+    virtual TString GetClassName() const override {
+        return GetClassNameStatic();
+    }
+
+    class TNormalizerResult;
+
+    class TColumnKey {
+        YDB_READONLY(ui64, Index, 0);
+        YDB_READONLY(ui64, Granule, 0);
+        YDB_READONLY(ui64, ColumnId, 0);
+        YDB_READONLY(ui64, PlanStep, 0);
+        YDB_READONLY(ui64, TxId, 0);
+        YDB_READONLY(ui64, Portion, 0);
+        YDB_READONLY(ui64, Chunk, 0);
+
+    public:
+        template <class TRowset>
+        void Load(TRowset& rowset) {
+            using namespace NColumnShard;
+            Index = rowset.template GetValue<Schema::IndexColumns::Index>();
+            Granule = rowset.template GetValue<Schema::IndexColumns::Granule>();
+            ColumnId = rowset.template GetValue<Schema::IndexColumns::ColumnIdx>();
+            PlanStep = rowset.template GetValue<Schema::IndexColumns::PlanStep>();
+            TxId = rowset.template GetValue<Schema::IndexColumns::TxId>();
+            Portion = rowset.template GetValue<Schema::IndexColumns::Portion>();
+            Chunk = rowset.template GetValue<Schema::IndexColumns::Chunk>();
+        }
+
+        bool operator<(const TColumnKey& other) const {
+            return std::make_tuple(Portion, Chunk, ColumnId) < std::make_tuple(other.Portion, other.Chunk, other.ColumnId);
+        }
+    };
+
+    class TUpdate {
+    private:
+        YDB_READONLY_DEF(NKikimrTxColumnShard::TIndexPortionMeta, PortionMeta);
+
+    public:
+        TUpdate() = default;
+        TUpdate(NKikimrTxColumnShard::TIndexPortionMeta&& portionMeta)
+            : PortionMeta(std::move(portionMeta)) {
+        }
+    };
+
+    class TChunkInfo {
+        YDB_READONLY_DEF(TColumnKey, Key);
+        YDB_READONLY_DEF(ui64, PathId);
+        TColumnChunkLoadContext CLContext;
+        ISnapshotSchema::TPtr Schema;
+
+        YDB_ACCESSOR_DEF(TUpdate, Update);
+
+        void InitSchema(const NColumnShard::TTablesManager& tm);
+
+    public:
+        template <class TSource>
+        TChunkInfo(TColumnKey&& key, const TSource& rowset, const IBlobGroupSelector* dsGroupSelector,
+            const NColumnShard::TTablesManager& tablesManager)
+            : Key(std::move(key))
+            , PathId(rowset.template GetValue<NColumnShard::Schema::IndexColumns::PathId>())
+            , CLContext(rowset, dsGroupSelector) {
+            InitSchema(tablesManager);
+        }
+
+        const NKikimrTxColumnShard::TIndexColumnMeta& GetMetaProto() const {
+            return CLContext.GetMetaProto();
+        }
+
+        bool NormalizationRequired() const {
+            return Key.GetColumnId() == Schema->GetIndexInfo().GetPKFirstColumnId() && Key.GetChunk() == 0 &&
+                   !CLContext.GetMetaProto().HasPortionMeta();
+        }
+
+        bool operator<(const TChunkInfo& other) const {
+            return Key < other.Key;
+        }
+    };
+
+    static inline INormalizerComponent::TFactory::TRegistrator<TChunksV0MetaNormalizer> Registrator =
+        INormalizerComponent::TFactory::TRegistrator<TChunksV0MetaNormalizer>(GetClassNameStatic());
+
+public:
+    TChunksV0MetaNormalizer(const TNormalizationController::TInitContext& info)
+        : TBase(info)
+        , DsGroupSelector(std::make_shared<NColumnShard::TBlobGroupSelector>(info.GetStorageInfo())) {
+    }
+
+    virtual TConclusion<std::vector<INormalizerTask::TPtr>> DoInit(
+        const TNormalizationController& controller, NTabletFlatExecutor::TTransactionContext& txc) override;
+
+private:
+    std::shared_ptr<NColumnShard::TBlobGroupSelector> DsGroupSelector;
+    THashMap<TPortionKey, NKikimrTxColumnShard::TIndexPortionMeta> PortionMetaCache;
+};
+}   // namespace NKikimr::NOlap

--- a/ydb/core/tx/columnshard/normalizer/portion/ya.make
+++ b/ydb/core/tx/columnshard/normalizer/portion/ya.make
@@ -13,7 +13,7 @@ SRCS(
     GLOBAL restore_v2_chunks.cpp
     GLOBAL leaked_blobs.cpp
     GLOBAL clean_deprecated_snapshot.cpp
-
+    GLOBAL chunks_v0_meta.cpp
 )
 
 PEERDIR(


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

Fix a bug in writing chunk metadata that makes older versions incompatible with 24-4-analytics. #17791

### Changelog category <!-- remove all except one -->

* Bugfix 

### Description for reviewers <!-- (optional) description for those who read this PR -->

...
