### PR TITLE
fq/quota_manager: fix sigsegv by dereference of copied TAutoPtr

### DIFF
--- a/ydb/core/fq/libs/quota_manager/quota_manager.cpp
+++ b/ydb/core/fq/libs/quota_manager/quota_manager.cpp
@@ -261,23 +261,23 @@ private:
 
         if (it == subjectMap.end()) {
             ReadQuota(subjectType, subjectId,
-                [this, ev=ev](TReadQuotaExecuter& executer) {
+                [this, allowStaleUsage=ev->Get()->AllowStaleUsage, sender=ev->Sender, cookie=ev->Cookie](TReadQuotaExecuter& executer) {
                     // This block is executed in correct self-context, no locks/syncs required
                     auto& subjectMap = this->QuotaCacheMap[executer.State.SubjectType];
                     auto& cache = subjectMap[executer.State.SubjectId];
                     LOG_D(executer.State.SubjectType << "." << executer.State.SubjectId << ToString(cache.UsageMap) << " LOADED");
-                    CheckUsageMaybeReply(executer.State.SubjectType, executer.State.SubjectId, cache, ev);
+                    CheckUsageMaybeReply(executer.State.SubjectType, executer.State.SubjectId, cache, allowStaleUsage, sender, cookie);
                 }
             );
         } else {
-            CheckUsageMaybeReply(subjectType, subjectId, it->second, ev);
+            CheckUsageMaybeReply(subjectType, subjectId, it->second, ev->Get()->AllowStaleUsage, ev->Sender, ev->Cookie);
         }
     }
 
-    void CheckUsageMaybeReply(const TString& subjectType, const TString& subjectId, TQuotaCache& cache, const TEvQuotaService::TQuotaGetRequest::TPtr& ev) {
+    void CheckUsageMaybeReply(const TString& subjectType, const TString& subjectId, TQuotaCache& cache, bool allowStaleUsage, const TActorId& sender, ui64 cookie) {
         bool pended = false;
         auto& infoMap = QuotaInfoMap[subjectType];
-        if (!ev->Get()->AllowStaleUsage) {
+        if (!allowStaleUsage) {
             // Refresh usage
             for (auto& itUsage : cache.UsageMap) {
                 auto metricName = itUsage.first;
@@ -293,7 +293,7 @@ private:
                                 cachedUsage.RequestedAt = Now();
                             }
                             if (!pended) {
-                                cache.PendingUsageRequests.emplace(ev->Sender, ev->Cookie);
+                                cache.PendingUsageRequests.emplace(sender, cookie);
                                 pended = true;
                             }
                         }
@@ -303,16 +303,16 @@ private:
         }
 
         if (!pended) {
-            SendQuota(ev->Sender, ev->Cookie, subjectType, subjectId, cache);
-            cache.PendingUsageRequests.erase(ev->Sender);
+            SendQuota(sender, cookie, subjectType, subjectId, cache);
+            cache.PendingUsageRequests.erase(sender);
         }
     }
 
-    void ChangeLimitsAndReply(const TString& subjectType, const TString& subjectId, TQuotaCache& cache, const TEvQuotaService::TQuotaSetRequest::TPtr& ev) {
+    void ChangeLimitsAndReply(const TString& subjectType, const TString& subjectId, TQuotaCache& cache, const THashMap<TString, ui64> limits, const TActorId& sender, ui64 cookie) {
 
         auto pended = false;
         auto& infoMap = QuotaInfoMap[subjectType];
-        for (auto metricLimit : ev->Get()->Limits) {
+        for (auto metricLimit : limits) {
             auto& metricName = metricLimit.first;
 
             auto it = cache.UsageMap.find(metricName);
@@ -332,8 +332,8 @@ private:
 
                     if (info.QuotaController != NActors::TActorId{}) {
                         pended = true;
-                        cache.PendingLimitRequest = ev->Sender;
-                        cache.PendingLimitCookie = ev->Cookie;
+                        cache.PendingLimitRequest = sender;
+                        cache.PendingLimitCookie = cookie;
                         cache.PendingLimit.insert(metricName);
                         Send(info.QuotaController, new TEvQuotaService::TQuotaLimitChangeRequest(subjectType, subjectId, metricName, cached.Usage.Limit.Value, limit));
                         continue;
@@ -354,7 +354,7 @@ private:
             for (auto it : cache.UsageMap) {
                 response->Limits.emplace(it.first, it.second.Usage.Limit.Value);
             }
-            Send(ev->Sender, response.Release());
+            Send(sender, response.Release());
         }
     }
 
@@ -723,16 +723,16 @@ private:
         auto it = subjectMap.find(subjectId);
         if (it == subjectMap.end()) {
             ReadQuota(subjectType, subjectId,
-                [this, ev=ev](TReadQuotaExecuter& executer) {
+                [this, limits=ev->Get()->Limits, sender=ev->Sender, cookie=ev->Cookie](TReadQuotaExecuter& executer) {
                     // This block is executed in correct self-context, no locks/syncs required
                     auto& subjectMap = this->QuotaCacheMap[executer.State.SubjectType];
                     auto& cache = subjectMap[executer.State.SubjectId];
                     LOG_D(executer.State.SubjectType << "." << executer.State.SubjectId << ToString(cache.UsageMap) << " LOADED");
-                    ChangeLimitsAndReply(executer.State.SubjectType, executer.State.SubjectId, cache, ev);
+                    ChangeLimitsAndReply(executer.State.SubjectType, executer.State.SubjectId, cache, limits, sender, cookie);
                 }
             );
         } else {
-            ChangeLimitsAndReply(subjectType, subjectId, it->second, ev);
+            ChangeLimitsAndReply(subjectType, subjectId, it->second, ev->Get()->Limits, ev->Sender, ev->Cookie);
         }
     }
 

--- a/ydb/core/fq/libs/quota_manager/quota_manager.cpp
+++ b/ydb/core/fq/libs/quota_manager/quota_manager.cpp
@@ -308,7 +308,7 @@ private:
         }
     }
 
-    void ChangeLimitsAndReply(const TString& subjectType, const TString& subjectId, TQuotaCache& cache, const THashMap<TString, ui64> limits, const TActorId& sender, ui64 cookie) {
+    void ChangeLimitsAndReply(const TString& subjectType, const TString& subjectId, TQuotaCache& cache, const THashMap<TString, ui64>& limits, const TActorId& sender, ui64 cookie) {
 
         auto pended = false;
         auto& infoMap = QuotaInfoMap[subjectType];

--- a/ydb/core/fq/libs/quota_manager/quota_manager.cpp
+++ b/ydb/core/fq/libs/quota_manager/quota_manager.cpp
@@ -141,6 +141,7 @@ TString ToString(const THashMap<TString, TQuotaCachedUsage>& usageMap) {
 }
 
 class TQuotaManagementService : public NActors::TActorBootstrapped<TQuotaManagementService> {
+    using TLimits = decltype(TEvQuotaService::TQuotaSetRequest::Limits);
 public:
     TQuotaManagementService(
         const NConfig::TQuotasManagerConfig& config,
@@ -308,7 +309,7 @@ private:
         }
     }
 
-    void ChangeLimitsAndReply(const TString& subjectType, const TString& subjectId, TQuotaCache& cache, const THashMap<TString, ui64>& limits, const TActorId& sender, ui64 cookie) {
+    void ChangeLimitsAndReply(const TString& subjectType, const TString& subjectId, TQuotaCache& cache, const TLimits& limits, const TActorId& sender, ui64 cookie) {
 
         auto pended = false;
         auto& infoMap = QuotaInfoMap[subjectType];
@@ -723,7 +724,7 @@ private:
         auto it = subjectMap.find(subjectId);
         if (it == subjectMap.end()) {
             ReadQuota(subjectType, subjectId,
-                [this, limits=std::make_shared<THashMap<TString, ui64>>(std::move(ev->Get()->Limits)), sender=ev->Sender, cookie=ev->Cookie](TReadQuotaExecuter& executer) {
+                [this, limits=std::make_shared<TLimits>(std::move(ev->Get()->Limits)), sender=ev->Sender, cookie=ev->Cookie](TReadQuotaExecuter& executer) {
                     // This block is executed in correct self-context, no locks/syncs required
                     auto& subjectMap = this->QuotaCacheMap[executer.State.SubjectType];
                     auto& cache = subjectMap[executer.State.SubjectId];

--- a/ydb/core/fq/libs/quota_manager/quota_manager.cpp
+++ b/ydb/core/fq/libs/quota_manager/quota_manager.cpp
@@ -724,7 +724,7 @@ private:
         auto it = subjectMap.find(subjectId);
         if (it == subjectMap.end()) {
             ReadQuota(subjectType, subjectId,
-                [this, limits=std::make_shared<TLimits>(std::move(ev->Get()->Limits)), sender=ev->Sender, cookie=ev->Cookie](TReadQuotaExecuter& executer) {
+                [this, limits=std::move(std::make_shared<TLimits>(std::move(ev->Get()->Limits))), sender=ev->Sender, cookie=ev->Cookie](TReadQuotaExecuter& executer) {
                     // This block is executed in correct self-context, no locks/syncs required
                     auto& subjectMap = this->QuotaCacheMap[executer.State.SubjectType];
                     auto& cache = subjectMap[executer.State.SubjectId];

--- a/ydb/core/fq/libs/quota_manager/quota_manager.cpp
+++ b/ydb/core/fq/libs/quota_manager/quota_manager.cpp
@@ -724,12 +724,12 @@ private:
         auto it = subjectMap.find(subjectId);
         if (it == subjectMap.end()) {
             ReadQuota(subjectType, subjectId,
-                [this, limits=std::move(std::make_shared<TLimits>(std::move(ev->Get()->Limits))), sender=ev->Sender, cookie=ev->Cookie](TReadQuotaExecuter& executer) {
+                [this, limits=std::move(ev->Get()->Limits), sender=ev->Sender, cookie=ev->Cookie](TReadQuotaExecuter& executer) {
                     // This block is executed in correct self-context, no locks/syncs required
                     auto& subjectMap = this->QuotaCacheMap[executer.State.SubjectType];
                     auto& cache = subjectMap[executer.State.SubjectId];
                     LOG_D(executer.State.SubjectType << "." << executer.State.SubjectId << ToString(cache.UsageMap) << " LOADED");
-                    ChangeLimitsAndReply(executer.State.SubjectType, executer.State.SubjectId, cache, *limits, sender, cookie);
+                    ChangeLimitsAndReply(executer.State.SubjectType, executer.State.SubjectId, cache, limits, sender, cookie);
                 }
             );
         } else {

--- a/ydb/core/fq/libs/quota_manager/quota_manager.cpp
+++ b/ydb/core/fq/libs/quota_manager/quota_manager.cpp
@@ -723,12 +723,12 @@ private:
         auto it = subjectMap.find(subjectId);
         if (it == subjectMap.end()) {
             ReadQuota(subjectType, subjectId,
-                [this, limits=ev->Get()->Limits, sender=ev->Sender, cookie=ev->Cookie](TReadQuotaExecuter& executer) {
+                [this, limits=std::make_shared<THashMap<TString, ui64>>(std::move(ev->Get()->Limits)), sender=ev->Sender, cookie=ev->Cookie](TReadQuotaExecuter& executer) {
                     // This block is executed in correct self-context, no locks/syncs required
                     auto& subjectMap = this->QuotaCacheMap[executer.State.SubjectType];
                     auto& cache = subjectMap[executer.State.SubjectId];
                     LOG_D(executer.State.SubjectType << "." << executer.State.SubjectId << ToString(cache.UsageMap) << " LOADED");
-                    ChangeLimitsAndReply(executer.State.SubjectType, executer.State.SubjectId, cache, limits, sender, cookie);
+                    ChangeLimitsAndReply(executer.State.SubjectType, executer.State.SubjectId, cache, *limits, sender, cookie);
                 }
             );
         } else {


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

...

### Changelog category <!-- remove all except one -->

* Not for changelog (changelog entry is not required)

### Description for reviewers <!-- (optional) description for those who read this PR -->

ev is `TAutoPtr`, it is copied to `callback`, then `callback` copied (destroys `ev` in original copy), then original copy of `callback()` invoked, and sigsegv comes. YQ-4276.
