### PR TITLE
healthcheck segfault while retrying Whiteboard 

### DIFF
--- a/ydb/core/health_check/health_check.cpp
+++ b/ydb/core/health_check/health_check.cpp
@@ -1634,11 +1634,13 @@ public:
 
     void Handle(TEvWhiteboard::TEvSystemStateResponse::TPtr& ev) {
         TNodeId nodeId = ev.Get()->Cookie;
-        auto& nodeSystemState(NodeSystemState[nodeId]);
-        nodeSystemState.Set(std::move(ev));
-        for (NKikimrWhiteboard::TSystemStateInfo& state : *nodeSystemState->Record.MutableSystemStateInfo()) {
-            state.set_nodeid(nodeId);
-            MergedNodeSystemState[nodeId] = &state;
+        if (!NodeSystemState.count(nodeId)) {
+            auto& nodeSystemState(NodeSystemState[nodeId]);
+            nodeSystemState.Set(std::move(ev));
+            for (NKikimrWhiteboard::TSystemStateInfo& state : *nodeSystemState->Record.MutableSystemStateInfo()) {
+                state.set_nodeid(nodeId);
+                MergedNodeSystemState[nodeId] = &state;
+            }
         }
         RequestDone("TEvSystemStateResponse");
     }
@@ -2346,45 +2348,51 @@ public:
 
     void Handle(TEvWhiteboard::TEvVDiskStateResponse::TPtr& ev) {
         TNodeId nodeId = ev.Get()->Cookie;
-        auto& nodeVDiskState(NodeVDiskState[nodeId]);
-        nodeVDiskState.Set(std::move(ev));
-        for (NKikimrWhiteboard::TVDiskStateInfo& state : *nodeVDiskState->Record.MutableVDiskStateInfo()) {
-            state.set_nodeid(nodeId);
-            auto id = GetVDiskId(state.vdiskid());
-            MergedVDiskState[id] = &state;
+        if (!NodeVDiskState.count(nodeId)) {
+            auto& nodeVDiskState(NodeVDiskState[nodeId]);
+            nodeVDiskState.Set(std::move(ev));
+            for (NKikimrWhiteboard::TVDiskStateInfo& state : *nodeVDiskState->Record.MutableVDiskStateInfo()) {
+                state.set_nodeid(nodeId);
+                auto id = GetVDiskId(state.vdiskid());
+                MergedVDiskState[id] = &state;
+            }
         }
         RequestDone("TEvVDiskStateResponse");
     }
 
     void Handle(TEvWhiteboard::TEvPDiskStateResponse::TPtr& ev) {
         TNodeId nodeId = ev.Get()->Cookie;
-        auto& nodePDiskState(NodePDiskState[nodeId]);
-        nodePDiskState.Set(std::move(ev));
-        for (NKikimrWhiteboard::TPDiskStateInfo& state : *nodePDiskState->Record.MutablePDiskStateInfo()) {
-            state.set_nodeid(nodeId);
-            auto id = GetPDiskId(state);
-            MergedPDiskState[id] = &state;
+        if (!NodePDiskState.count(nodeId)) {
+            auto& nodePDiskState(NodePDiskState[nodeId]);
+            nodePDiskState.Set(std::move(ev));
+            for (NKikimrWhiteboard::TPDiskStateInfo& state : *nodePDiskState->Record.MutablePDiskStateInfo()) {
+                state.set_nodeid(nodeId);
+                auto id = GetPDiskId(state);
+                MergedPDiskState[id] = &state;
+            }
         }
         RequestDone("TEvPDiskStateResponse");
     }
 
     void Handle(TEvWhiteboard::TEvBSGroupStateResponse::TPtr& ev) {
         ui64 nodeId = ev.Get()->Cookie;
-        auto& nodeBSGroupState(NodeBSGroupState[nodeId]);
-        nodeBSGroupState.Set(std::move(ev));
-        for (NKikimrWhiteboard::TBSGroupStateInfo& state : *nodeBSGroupState->Record.MutableBSGroupStateInfo()) {
-            state.set_nodeid(nodeId);
-            TString storagePoolName = state.storagepoolname();
-            TGroupID groupId(state.groupid());
-            const NKikimrWhiteboard::TBSGroupStateInfo*& current(MergedBSGroupState[state.groupid()]);
-            if (current == nullptr || current->GetGroupGeneration() < state.GetGroupGeneration()) {
-                current = &state;
+        if (!NodeBSGroupState.count(nodeId)) {
+            auto& nodeBSGroupState(NodeBSGroupState[nodeId]);
+            nodeBSGroupState.Set(std::move(ev));
+            for (NKikimrWhiteboard::TBSGroupStateInfo& state : *nodeBSGroupState->Record.MutableBSGroupStateInfo()) {
+                state.set_nodeid(nodeId);
+                TString storagePoolName = state.storagepoolname();
+                TGroupID groupId(state.groupid());
+                const NKikimrWhiteboard::TBSGroupStateInfo*& current(MergedBSGroupState[state.groupid()]);
+                if (current == nullptr || current->GetGroupGeneration() < state.GetGroupGeneration()) {
+                    current = &state;
+                }
+                if (storagePoolName.empty() && groupId.ConfigurationType() != EGroupConfigurationType::Static) {
+                    continue;
+                }
+                StoragePoolStateByName[storagePoolName].Groups.emplace(state.groupid());
+                StoragePoolStateByName[storagePoolName].Name = storagePoolName;
             }
-            if (storagePoolName.empty() && groupId.ConfigurationType() != EGroupConfigurationType::Static) {
-                continue;
-            }
-            StoragePoolStateByName[storagePoolName].Groups.emplace(state.groupid());
-            StoragePoolStateByName[storagePoolName].Name = storagePoolName;
         }
         RequestDone("TEvBSGroupStateResponse");
     }


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

Fix segfault that could happen while retrying Whiteboard requests https://github.com/ydb-platform/ydb/issues/18145

### Changelog category <!-- remove all except one -->

* Bugfix 

### Description for reviewers <!-- (optional) description for those who read this PR -->

A segfault occurs when iterating over `nodeSystemState.poolstats()`.

Here, `nodeSystemState` is retrieved from `MergedNodeSystemState`, which stores raw pointers (`TSystemStateInfo*`).  
These pointers refer to objects inside `NodeSystemState`, which is intended to keep the pointed-to objects alive.

However, if an assignment is made to the same key in `NodeSystemState`, the old `TSystemStateInfo` object is destroyed,  
leaving the pointer in `MergedNodeSystemState` dangling.

**Possible scenario**

- HealthCheck starts send Whiteboard requests for static group.
- `TEvInterconnect::TEvNodeDisconnected` is received from one of the nodes; HealthCheck schedules a `TEvRetryNodeWhiteboard` without waiting for the first `SystemInfo` response.
- The first `SystemInfo` response arrives.
- `TEvRetryNodeWhiteboard` is processed, overwriting the value in `NodeSystemState`, leaving a dangling pointer in `MergedNodeSystemState`.
- The second `SystemInfo` response does not arrive in time; HealthCheck response formation begins.
- A segfault occurs during iteration over `nodeSystemState.poolstats()`.

