### PR TITLE
Merge viewer fixes Apr 29th

### DIFF
--- a/ydb/core/driver_lib/run/run.cpp
+++ b/ydb/core/driver_lib/run/run.cpp
@@ -475,6 +475,7 @@ void TKikimrRunner::InitializeMonitoring(const TKikimrRunConfig& runConfig, bool
         if (securityConfig.MonitoringAllowedSIDsSize() > 0) {
             monConfig.AllowedSIDs.assign(securityConfig.GetMonitoringAllowedSIDs().begin(), securityConfig.GetMonitoringAllowedSIDs().end());
         }
+        monConfig.AllowOrigin = appConfig.GetMonitoringConfig().GetAllowOrigin();
 
         if (ModuleFactories && ModuleFactories->MonitoringFactory) {
             Monitoring = ModuleFactories->MonitoringFactory(std::move(monConfig), appConfig);

--- a/ydb/core/mind/hive/hive_impl.cpp
+++ b/ydb/core/mind/hive/hive_impl.cpp
@@ -2065,9 +2065,18 @@ void THive::Handle(TEvHive::TEvRequestHiveNodeStats::TPtr& ev) {
                     }
                 }
             } else {
+                std::optional<TSubDomainKey> filterObjectDomain;
+                if (request.HasFilterTabletsByObjectDomain()) {
+                    filterObjectDomain = TSubDomainKey(request.GetFilterTabletsByObjectDomain());
+                }
                 for (const auto& [state, set] : node.Tablets) {
                     std::vector<ui32> tabletTypeToCount;
                     for (const TTabletInfo* tablet : set) {
+                        if (filterObjectDomain) {
+                            if (tablet->NodeFilter.ObjectDomain != *filterObjectDomain) {
+                                continue;
+                            }
+                        }
                         TTabletTypes::EType type = tablet->GetTabletType();
                         if (static_cast<size_t>(type) >= tabletTypeToCount.size()) {
                             tabletTypeToCount.resize(type + 1);
@@ -3523,7 +3532,7 @@ void THive::Handle(TEvPrivate::TEvUpdateFollowers::TPtr&) {
 
 void THive::MakeScaleRecommendation() {
     BLOG_D("[MSR] Started");
-    
+
     if (AreWeRootHive()) {
         return;
     }

--- a/ydb/core/mon/mon.cpp
+++ b/ydb/core/mon/mon.cpp
@@ -16,6 +16,7 @@
 #include <library/cpp/lwtrace/mon/mon_lwtrace.h>
 #include <ydb/library/actors/core/probes.h>
 #include <ydb/core/base/monitoring_provider.h>
+#include <ydb/core/util/wildcard.h>
 
 #include <library/cpp/monlib/service/pages/version_mon_page.h>
 #include <library/cpp/monlib/service/pages/mon_page.h>
@@ -403,7 +404,19 @@ public:
             type = "application/json";
         }
         NHttp::THeaders headers(request->Headers);
-        TString origin = TString(headers["Origin"]);
+        TString allowOrigin = AppData()->Mon->GetConfig().AllowOrigin;
+        TString requestOrigin = TString(headers["Origin"]);
+        TString origin;
+        if (allowOrigin) {
+            if (IsMatchesWildcards(requestOrigin, allowOrigin)) {
+                origin = requestOrigin;
+            } else {
+                Send(Event->Sender, new NHttp::TEvHttpProxy::TEvHttpOutgoingResponse(request->CreateResponseBadRequest("Invalid CORS origin")));
+                return PassAway();
+            }
+        } else if (requestOrigin) {
+            origin = requestOrigin;
+        }
         if (origin.empty()) {
             origin = "*";
         }

--- a/ydb/core/mon/mon.h
+++ b/ydb/core/mon/mon.h
@@ -40,6 +40,7 @@ public:
         TString Certificate;
         ui32 MaxRequestsPerSecond = 0;
         TDuration InactivityTimeout = TDuration::Minutes(2);
+        TString AllowOrigin;
     };
 
     TMon(TConfig config);
@@ -84,6 +85,10 @@ public:
             .Path = path,
             .Handler = handler
         });
+    }
+
+    const TConfig& GetConfig() const {
+        return Config;
     }
 
 protected:

--- a/ydb/core/protos/hive.proto
+++ b/ydb/core/protos/hive.proto
@@ -323,6 +323,7 @@ message TEvRequestHiveNodeStats {
     // The next 2 fields should always be used together
     optional uint64 FilterTabletsByPathId = 7;
     optional uint64 FilterTabletsBySchemeShardId = 8;
+    optional NKikimrSubDomains.TDomainKey FilterTabletsByObjectDomain = 9;
 }
 
 message THiveNodeStats {
@@ -616,7 +617,7 @@ message TScaleRecommenderPolicies {
     message TScaleRecommenderPolicy {
         message TTargetTrackingPolicy {
             oneof Target {
-                uint32 AverageCpuUtilizationPercent = 1; 
+                uint32 AverageCpuUtilizationPercent = 1;
             }
         }
 

--- a/ydb/core/protos/node_whiteboard.proto
+++ b/ydb/core/protos/node_whiteboard.proto
@@ -281,6 +281,16 @@ enum EConfigState {
     Outdated = 1;
 }
 
+message TSystemThreadInfo {
+    optional string Name = 1;
+    optional uint32 Threads = 2;
+    optional double SystemUsage = 3;
+    optional double UserUsage = 4;
+    optional uint32 MinorPageFaults = 5;
+    optional uint32 MajorPageFaults = 6;
+    map<string, uint32> States = 7;
+}
+
 message TSystemStateInfo {
     message TPoolStats {
         optional string Name = 1;
@@ -346,6 +356,8 @@ message TSystemStateInfo {
     optional uint32 CoresTotal = 40;
     optional float NetworkUtilization = 41;
     optional uint64 NetworkWriteThroughput = 42;
+    optional uint32 RealNumberOfCpus = 43; // number of cpus without cgroups limitations
+    repeated TSystemThreadInfo Threads = 44;
 }
 
 message TEvSystemStateRequest {

--- a/ydb/core/tablet/node_whiteboard.cpp
+++ b/ydb/core/tablet/node_whiteboard.cpp
@@ -721,6 +721,9 @@ protected:
         auto& endpoint = *SystemStateInfo.AddEndpoints();
         endpoint.SetName(ev->Get()->Name);
         endpoint.SetAddress(ev->Get()->Address);
+        std::sort(SystemStateInfo.MutableEndpoints()->begin(), SystemStateInfo.MutableEndpoints()->end(), [](const auto& a, const auto& b) {
+            return a.GetName() < b.GetName();
+        });
         SystemStateInfo.SetChangeTime(ctx.Now().MilliSeconds());
     }
 

--- a/ydb/core/tablet/node_whiteboard.cpp
+++ b/ydb/core/tablet/node_whiteboard.cpp
@@ -9,6 +9,7 @@
 #include <ydb/core/node_whiteboard/node_whiteboard.h>
 #include <ydb/core/base/nameservice.h>
 #include <ydb/core/base/counters.h>
+#include <ydb/core/util/cpuinfo.h>
 #include <ydb/core/util/tuples.h>
 
 #include <util/string/split.h>
@@ -46,6 +47,7 @@ public:
             SystemStateInfo.SetNodeName(nodeName);
         }
         SystemStateInfo.SetNumberOfCpus(NSystemInfo::NumberOfCpus());
+        SystemStateInfo.SetRealNumberOfCpus(NKikimr::RealNumberOfCpus());
         auto version = GetProgramRevision();
         if (!version.empty()) {
             SystemStateInfo.SetVersion(version);
@@ -56,8 +58,13 @@ public:
         SystemStateInfo.SetStartTime(ctx.Now().MilliSeconds());
         ctx.Send(ctx.SelfID, new TEvPrivate::TEvUpdateRuntimeStats());
 
-        auto group = NKikimr::GetServiceCounters(NKikimr::AppData()->Counters, "utils")
-            ->GetSubgroup("subsystem", "whiteboard");
+        auto utils = NKikimr::GetServiceCounters(NKikimr::AppData()->Counters, "utils");
+        UserTime = utils->GetCounter("Process/UserTime", true);
+        SysTime = utils->GetCounter("Process/SystemTime", true);
+        MinorPageFaults = utils->GetCounter("Process/MinorPageFaults", true);
+        MajorPageFaults = utils->GetCounter("Process/MajorPageFaults", true);
+        NumThreads = utils->GetCounter("Process/NumThreads", false);
+        auto group = utils->GetSubgroup("subsystem", "whiteboard");
         MaxClockSkewWithPeerUsCounter = group->GetCounter("MaxClockSkewWithPeerUs");
         MaxClockSkewPeerIdCounter = group->GetCounter("MaxClockSkewPeerId");
 
@@ -78,8 +85,19 @@ protected:
     NKikimrWhiteboard::TSystemStateInfo SystemStateInfo;
     THolder<NTracing::ITraceCollection> TabletIntrospectionData;
 
-    ::NMonitoring::TDynamicCounters::TCounterPtr MaxClockSkewWithPeerUsCounter;
-    ::NMonitoring::TDynamicCounters::TCounterPtr MaxClockSkewPeerIdCounter;
+    NMonitoring::TDynamicCounters::TCounterPtr MaxClockSkewWithPeerUsCounter;
+    NMonitoring::TDynamicCounters::TCounterPtr MaxClockSkewPeerIdCounter;
+    NMonitoring::TDynamicCounters::TCounterPtr UserTime;
+    ui64 SavedUserTime = 0;
+    NMonitoring::TDynamicCounters::TCounterPtr SysTime;
+    ui64 SavedSysTime = 0;
+    NMonitoring::TDynamicCounters::TCounterPtr MinorPageFaults;
+    ui64 SavedMinorPageFaults = 0;
+    NMonitoring::TDynamicCounters::TCounterPtr MajorPageFaults;
+    ui64 SavedMajorPageFaults = 0;
+    NMonitoring::TDynamicCounters::TCounterPtr NumThreads;
+
+    TSystemThreadsMonitor ThreadsMonitor;
 
     template <typename PropertyType>
     static ui64 GetDifference(PropertyType a, PropertyType b) {
@@ -1099,7 +1117,10 @@ protected:
     }
 
     void Handle(TEvPrivate::TEvUpdateRuntimeStats::TPtr &, const TActorContext &ctx) {
-        static constexpr TDuration UPDATE_PERIOD = TDuration::Seconds(15);
+        static constexpr int UPDATE_PERIOD_SECONDS = 15;
+        static constexpr TDuration UPDATE_PERIOD = TDuration::Seconds(UPDATE_PERIOD_SECONDS);
+        auto now = TActivationContext::Now();
+
         {
             NKikimrWhiteboard::TSystemStateInfo systemStatsUpdate;
             TVector<double> loadAverage = GetLoadAverage();
@@ -1107,7 +1128,7 @@ protected:
                 systemStatsUpdate.AddLoadAverage(d);
             }
             if (CheckedMerge(SystemStateInfo, systemStatsUpdate)) {
-                SystemStateInfo.SetChangeTime(ctx.Now().MilliSeconds());
+                SystemStateInfo.SetChangeTime(now.MilliSeconds());
             }
         }
 
@@ -1124,12 +1145,24 @@ protected:
             SystemStateInfo.SetNetworkUtilization(MaxNetworkUtilization);
             MaxNetworkUtilization = 0;
         }
-
         {
-            SystemStateInfo.SetNetworkWriteThroughput(SumNetworkWriteThroughput / UPDATE_PERIOD.Seconds());
+            SystemStateInfo.SetNetworkWriteThroughput(SumNetworkWriteThroughput / UPDATE_PERIOD_SECONDS);
             SumNetworkWriteThroughput = 0;
         }
-
+        auto threadPools = ThreadsMonitor.GetThreadPools(now);
+        SystemStateInfo.ClearThreads();
+        for (const auto& threadPool : threadPools) {
+            auto* threadInfo = SystemStateInfo.AddThreads();
+            threadInfo->SetName(threadPool.Name);
+            threadInfo->SetThreads(threadPool.Threads);
+            threadInfo->SetSystemUsage(threadPool.SystemUsage);
+            threadInfo->SetUserUsage(threadPool.UserUsage);
+            threadInfo->SetMajorPageFaults(threadPool.MajorPageFaults);
+            threadInfo->SetMinorPageFaults(threadPool.MinorPageFaults);
+            for (const auto& state : threadPool.States) {
+                threadInfo->MutableStates()->emplace(state.first, state.second);
+            }
+        }
         UpdateSystemState(ctx);
         ctx.Schedule(UPDATE_PERIOD, new TEvPrivate::TEvUpdateRuntimeStats());
     }

--- a/ydb/core/tx/schemeshard/schemeshard_path_describer.cpp
+++ b/ydb/core/tx/schemeshard/schemeshard_path_describer.cpp
@@ -176,7 +176,10 @@ void TPathDescriber::FillChildDescr(NKikimrSchemeOp::TDirEntry* descr, TPathElem
         descr->SetCreateStep(ui64(pathEl->StepCreated));
     }
 
-    descr->SetChildrenExist(pathEl->GetAliveChildren() > 0);
+    if (pathEl->PathType != NKikimrSchemeOp::EPathTypeSubDomain
+        && pathEl->PathType != NKikimrSchemeOp::EPathTypeExtSubDomain) {
+        descr->SetChildrenExist(pathEl->GetAliveChildren() > 0);
+    }
 
     if (pathEl->PathType == NKikimrSchemeOp::EPathTypePersQueueGroup) {
         auto it = Self->Topics.FindPtr(pathEl->PathId);

--- a/ydb/core/util/cpuinfo.cpp
+++ b/ydb/core/util/cpuinfo.cpp
@@ -8,6 +8,7 @@
 #include <util/string/ascii.h>
 #include <util/string/builder.h>
 #include <util/system/info.h>
+#include <sstream>
 
 size_t NKikimr::RealNumberOfCpus() {
     // copy-pasted from util/system/info.cpp

--- a/ydb/core/util/cpuinfo.cpp
+++ b/ydb/core/util/cpuinfo.cpp
@@ -1,0 +1,209 @@
+#include "cpuinfo.h"
+#include <cstdlib>
+#include <dirent.h>
+#include <fcntl.h>
+#include <fstream>
+#include <unistd.h>
+#include <unordered_set>
+#include <util/string/ascii.h>
+#include <util/string/builder.h>
+#include <util/system/info.h>
+
+size_t NKikimr::RealNumberOfCpus() {
+    // copy-pasted from util/system/info.cpp
+#if defined(_linux_)
+    unsigned ret;
+    int fd, nread, column;
+    char buf[512];
+    static const char matchstr[] = "processor\t:";
+
+    fd = open("/proc/cpuinfo", O_RDONLY);
+
+    if (fd == -1) {
+        abort();
+    }
+
+    column = 0;
+    ret = 0;
+
+    while (true) {
+        nread = read(fd, buf, sizeof(buf));
+
+        if (nread <= 0) {
+            break;
+        }
+
+        for (int i = 0; i < nread; ++i) {
+            const char ch = buf[i];
+
+            if (ch == '\n') {
+                column = 0;
+            } else if (column != -1) {
+                if (AsciiToLower(ch) == matchstr[column]) {
+                    ++column;
+
+                    if (column == sizeof(matchstr) - 1) {
+                        column = -1;
+                        ++ret;
+                    }
+                } else {
+                    column = -1;
+                }
+            }
+        }
+    }
+
+    if (ret == 0) {
+        abort();
+    }
+
+    close(fd);
+
+    return ret;
+#else
+    return NSystemInfo::NumberOfCpus();
+#endif
+}
+
+double TicksPerSec() {
+#ifdef _SC_CLK_TCK
+    return sysconf(_SC_CLK_TCK);
+#else
+    return 1;
+#endif
+}
+
+std::vector<NKikimr::TSystemThreadsMonitor::TSystemThreadPoolInfo> NKikimr::TSystemThreadsMonitor::GetThreadPools(TInstant now) {
+    UpdateSystemThreads(getpid());
+    std::vector<TSystemThreadPoolInfo> result;
+    result.reserve(NameToThreadIndex.size());
+    double passedSeconds = (now - UpdateTime).SecondsFloat();
+    double ticks = TicksPerSec() * passedSeconds;
+    for (const auto& [name, tids] : NameToThreadIndex) {
+        TSystemThreadPoolInfo& info = result.emplace_back();
+        info.Name = name;
+        info.Threads = tids.size();
+        ui64 majorPageFaults = 0;
+        ui64 minorPageFaults = 0;
+        ui64 systemTime = 0;
+        ui64 userTime = 0;
+        std::array<ui16, 256> states{};
+        for (pid_t tid : tids) {
+            const TSystemThreadPoolState& state = SystemThreads[tid];
+            majorPageFaults += state.DeltaMajorPageFaults;
+            minorPageFaults += state.DeltaMinorPageFaults;
+            systemTime += state.DeltaSystemTime;
+            userTime += state.DeltaUserTime;
+            if (state.State >= 'A' && state.State <= 'z') {
+                states[size_t(state.State)]++;
+            }
+        }
+        for (char c = 'A'; c <= 'z'; ++c) {
+            if (states[size_t(c)] > 0) {
+                info.States.emplace_back(c, states[c]);
+            }
+        }
+        info.MajorPageFaults = double(majorPageFaults) / passedSeconds;
+        info.MinorPageFaults = double(minorPageFaults) / passedSeconds;
+        info.SystemUsage = double(systemTime) / ticks / info.Threads;
+        info.UserUsage = double(userTime) / ticks / info.Threads;
+    }
+    UpdateTime = now;
+    return result;
+}
+
+void NKikimr::TSystemThreadsMonitor::UpdateSystemThreads(pid_t pid) {
+#if defined(_linux_)
+    NameToThreadIndex.clear();
+    std::string taskDir = "/proc/" + std::to_string(pid) + "/task";
+    DIR* dir = opendir(taskDir.c_str());
+    if (!dir) {
+        SystemThreads.clear();
+        return;
+    }
+    std::unordered_set<pid_t> currentThreads;
+    currentThreads.reserve(SystemThreads.size());
+    for (const auto& [tid, state] : SystemThreads) {
+        currentThreads.insert(tid);
+    }
+    struct dirent* entry;
+    while ((entry = readdir(dir)) != nullptr) {
+        if (entry->d_name[0] == '.') {
+            continue;  // skip '.' and '..'
+        }
+        pid_t tid = atoi(entry->d_name);
+        if (tid > 0) {
+            UpdateSystemThread(pid, tid);
+            currentThreads.erase(tid);
+        }
+    }
+    for (pid_t tid : currentThreads) {
+        SystemThreads.erase(tid);
+    }
+    closedir(dir);
+#else
+    Y_UNUSED(pid);
+#endif
+}
+
+void NKikimr::TSystemThreadsMonitor::UpdateSystemThread(pid_t pid, pid_t tid) {
+#if defined(_linux_)
+    TSystemThreadPoolState& state = SystemThreads[tid];
+    std::ifstream file("/proc/" + std::to_string(pid) + "/task/" + std::to_string(tid) + "/stat");
+    if (file) {
+        std::string line;
+        std::getline(file, line);
+        size_t name_start = line.find('(');
+        size_t name_end = line.find(')', name_start);
+        if (name_start == std::string::npos || name_end == std::string::npos) {
+            return;
+        }
+        std::string threadName = line.substr(name_start + 1, name_end - name_start - 1);
+        std::istringstream iss(line.substr(name_end + 2));
+        std::string ignore;
+        ui64 majorPageFaults;
+        ui64 minorPageFaults;
+        ui64 systemTime;
+        ui64 userTime;
+        iss >> state.State >> ignore >> ignore >> ignore >> ignore >> ignore >> ignore
+            >> minorPageFaults >> ignore >> majorPageFaults >> ignore >> userTime >> systemTime;
+        state.DeltaMajorPageFaults = majorPageFaults - state.MajorPageFaults;
+        state.DeltaMinorPageFaults = minorPageFaults - state.MinorPageFaults;
+        state.DeltaSystemTime = systemTime - state.SystemTime;
+        state.DeltaUserTime = userTime - state.UserTime;
+        state.MajorPageFaults = majorPageFaults;
+        state.MinorPageFaults = minorPageFaults;
+        state.SystemTime = systemTime;
+        state.UserTime = userTime;
+        //Cerr << threadName << " " << state.SystemTime << " " << state.UserTime << Endl;
+        std::string name = GetNormalizedThreadName(threadName);
+        NameToThreadIndex[name].push_back(tid);
+    }
+#else
+    Y_UNUSED(tid);
+#endif
+}
+
+std::string NKikimr::TSystemThreadsMonitor::GetNormalizedThreadName(const std::string& name) {
+    std::string result = name;
+    while (!result.empty() && (isdigit(result.back()) || result.back() == '-' || result.back() == ' ')) {
+        result.resize(result.size() - 1);
+    }
+    if (result.empty()) {
+        return name;
+    }
+    // some well-known hacks
+    if (result == "default-executo") {
+        result = "default-executor";
+    }
+    if (result == "resolver-execut") {
+        result = "resolver-executor";
+    }
+    if (result == "grpc_global_tim") {
+        result = "grpc_global_timer";
+    }
+    if (result == "kikimr.Schedule") {
+        result = "kikimr.Scheduler";
+    }
+    return result;
+}

--- a/ydb/core/util/cpuinfo.h
+++ b/ydb/core/util/cpuinfo.h
@@ -1,0 +1,49 @@
+#pragma once
+#include <cstddef>
+#include <sys/types.h>
+#include <map>
+#include <unordered_map>
+#include <util/datetime/base.h>
+#include <util/generic/string.h>
+
+namespace NKikimr {
+
+std::size_t RealNumberOfCpus();
+
+class TSystemThreadsMonitor {
+public:
+    struct TSystemThreadPoolInfo { // returned data per refresh per second
+        TString Name;
+        ui32 Threads;
+        float SystemUsage;
+        float UserUsage;
+        ui32 MajorPageFaults;
+        ui32 MinorPageFaults;
+        std::vector<std::pair<char, ui32>> States;
+    };
+
+    std::vector<TSystemThreadPoolInfo> GetThreadPools(TInstant now);
+
+private:
+    struct TSystemThreadPoolState { // stored state of a thread
+        char State;
+        ui64 SystemTime;
+        ui64 UserTime;
+        ui64 MajorPageFaults;
+        ui64 MinorPageFaults;
+        ui64 DeltaSystemTime;
+        ui64 DeltaUserTime;
+        ui64 DeltaMajorPageFaults;
+        ui64 DeltaMinorPageFaults;
+    };
+
+    std::unordered_map<pid_t, TSystemThreadPoolState> SystemThreads;
+    std::map<std::string, std::vector<pid_t>> NameToThreadIndex;
+    TInstant UpdateTime;
+
+    void UpdateSystemThreads(pid_t pid);
+    void UpdateSystemThread(pid_t pid, pid_t tid);
+    static std::string GetNormalizedThreadName(const std::string& name);
+};
+
+} // namespace NKikimr

--- a/ydb/core/util/ya.make
+++ b/ydb/core/util/ya.make
@@ -14,6 +14,8 @@ SRCS(
     console.cpp
     console.h
     counted_leaky_bucket.h
+    cpuinfo.cpp
+    cpuinfo.h
     defs.h
     event_priority_queue.h
     failure_injection.cpp

--- a/ydb/core/viewer/json_handlers_viewer.cpp
+++ b/ydb/core/viewer/json_handlers_viewer.cpp
@@ -256,7 +256,7 @@ void InitViewerHealthCheckJsonHandler(TJsonHandlers& handlers) {
 }
 
 void InitViewerNodesJsonHandler(TJsonHandlers& handlers) {
-    handlers.AddHandler("/viewer/nodes", new TJsonHandler<TJsonNodes>(TJsonNodes::GetSwagger()), 14);
+    handlers.AddHandler("/viewer/nodes", new TJsonHandler<TJsonNodes>(TJsonNodes::GetSwagger()), 15);
 }
 
 void InitViewerACLJsonHandler(TJsonHandlers &jsonHandlers) {

--- a/ydb/core/viewer/json_local_rpc.h
+++ b/ydb/core/viewer/json_local_rpc.h
@@ -130,8 +130,7 @@ public:
                 return false;
             }
         }
-        const auto& params(Event->Get()->Request.GetParams());
-        Params2Proto(params, request);
+        Params2Proto(Params, request);
         if (!ValidateRequest(request)) {
             return false;
         }

--- a/ydb/core/viewer/json_pipe_req.cpp
+++ b/ydb/core/viewer/json_pipe_req.cpp
@@ -897,6 +897,7 @@ void TViewerPipeClient::InitConfig(const TCgiParameters& params) {
     }
     if (!FromStringWithDefault<bool>(params.Get("ui64"), false)) {
         Proto2JsonConfig.StringifyNumbers = TProto2JsonConfig::EStringifyNumbersMode::StringifyInt64Always;
+        Proto2JsonConfig.StringifyNumbersRepeated = TProto2JsonConfig::EStringifyNumbersMode::StringifyInt64Always;
     }
     Proto2JsonConfig.MapAsObject = true;
     Proto2JsonConfig.ConvertAny = true;

--- a/ydb/core/viewer/json_pipe_req.cpp
+++ b/ydb/core/viewer/json_pipe_req.cpp
@@ -451,8 +451,16 @@ TViewerPipeClient::TRequestResponse<TEvHive::TEvResponseHiveNodeStats> TViewerPi
     TActorId pipeClient = ConnectTabletPipe(hiveId);
     auto response = MakeRequestToPipe<TEvHive::TEvResponseHiveNodeStats>(pipeClient, request, hiveId);
     if (response.Span) {
-        auto hive_id = "#" + ::ToString(hiveId);
-        response.Span.Attribute("hive_id", hive_id);
+        response.Span.Attribute("hive_id", TStringBuilder() << '#' << hiveId);
+        if (request->Record.GetFilterTabletsBySchemeShardId()) {
+            response.Span.Attribute("schemeshard_id", TStringBuilder() << '#' << request->Record.GetFilterTabletsBySchemeShardId());
+        }
+        if (request->Record.GetFilterTabletsByPathId()) {
+            response.Span.Attribute("path_id", TStringBuilder() << '#' << request->Record.GetFilterTabletsByPathId());
+        }
+        if (request->Record.HasFilterTabletsByObjectDomain()) {
+            response.Span.Attribute("object_domain", TStringBuilder() << TSubDomainKey(request->Record.GetFilterTabletsByObjectDomain()));
+        }
     }
     return response;
 }
@@ -737,6 +745,7 @@ THolder<NSchemeCache::TSchemeCacheNavigate> TViewerPipeClient::SchemeCacheNaviga
 ) {
     THolder<NSchemeCache::TSchemeCacheNavigate> request = MakeHolder<NSchemeCache::TSchemeCacheNavigate>();
     entry.RedirectRequired = false;
+    entry.ShowPrivatePath = true;
     entry.Operation = NSchemeCache::TSchemeCacheNavigate::EOp::OpPath;
     request->ResultSet.emplace_back(std::move(entry));
     return request;
@@ -763,6 +772,7 @@ TViewerPipeClient::TRequestResponse<TEvTxProxySchemeCache::TEvNavigateKeySetResu
     NSchemeCache::TSchemeCacheNavigate::TEntry entry;
     entry.Path = SplitPath(path);
     entry.RedirectRequired = false;
+    entry.ShowPrivatePath = true;
     entry.Operation = NSchemeCache::TSchemeCacheNavigate::EOp::OpPath;
     request->ResultSet.emplace_back(entry);
     auto response = MakeRequest<TEvTxProxySchemeCache::TEvNavigateKeySetResult>(MakeSchemeCacheID(), new TEvTxProxySchemeCache::TEvNavigateKeySet(request.Release()), 0 /*flags*/, cookie);
@@ -778,6 +788,7 @@ TViewerPipeClient::TRequestResponse<TEvTxProxySchemeCache::TEvNavigateKeySetResu
     entry.TableId.PathId = pathId;
     entry.RequestType = NSchemeCache::TSchemeCacheNavigate::TEntry::ERequestType::ByTableId;
     entry.RedirectRequired = false;
+    entry.ShowPrivatePath = true;
     entry.Operation = NSchemeCache::TSchemeCacheNavigate::EOp::OpPath;
     request->ResultSet.emplace_back(entry);
     auto response = MakeRequest<TEvTxProxySchemeCache::TEvNavigateKeySetResult>(MakeSchemeCacheID(), new TEvTxProxySchemeCache::TEvNavigateKeySet(request.Release()), 0 /*flags*/, cookie);
@@ -823,9 +834,10 @@ TViewerPipeClient::TRequestResponse<TEvTxProxySchemeCache::TEvNavigateKeySetResu
     return response;
 }
 
-void TViewerPipeClient::RequestTxProxyDescribe(const TString& path) {
+void TViewerPipeClient::RequestTxProxyDescribe(const TString& path, const NKikimrSchemeOp::TDescribeOptions& options) {
     THolder<TEvTxUserProxy::TEvNavigate> request(new TEvTxUserProxy::TEvNavigate());
     request->Record.MutableDescribePath()->SetPath(path);
+    request->Record.MutableDescribePath()->MutableOptions()->CopyFrom(options);
     if (Event && !Event->Get()->UserToken.empty()) {
         request->Record.SetUserToken(Event->Get()->UserToken);
     }

--- a/ydb/core/viewer/json_pipe_req.cpp
+++ b/ydb/core/viewer/json_pipe_req.cpp
@@ -5,6 +5,113 @@
 
 namespace NKikimr::NViewer {
 
+template<typename T>
+class TCachedResponseState {
+public:
+    static constexpr TDuration CACHE_STALE_PERIOD = TDuration::Seconds(30); // when we start to update cache
+    static constexpr TDuration CACHE_VALID_PERIOD = TDuration::Seconds(60); // when we are ok to get data from the cache
+
+    struct TResult {
+        std::shared_ptr<T> Data;
+        TDuration Age;
+    };
+
+    std::shared_ptr<T> GetFromCache(TDuration& cachedDataMaxAge, bool& needToUpdate) {
+        std::lock_guard lock(Mutex);
+        if (IsCacheValid()) {
+            LastAccessed = Now();
+            cachedDataMaxAge = std::max(cachedDataMaxAge, GetAge());
+            if (GetAge() >= CACHE_STALE_PERIOD && !UpdatingNow) {
+                needToUpdate = UpdatingNow = true;
+            }
+            return Response;
+        }
+        return {};
+    }
+
+    void UpdateCache(std::shared_ptr<T> response) {
+        std::lock_guard lock(Mutex);
+        Response = std::move(response);
+        LastModified = Now();
+        UpdatingNow = false;
+    }
+
+    void ClearOld() {
+        if (IsCacheOld()) {
+            std::lock_guard lock(Mutex);
+            if (IsCacheOld()) {
+                Response.reset();
+                UpdatingNow = false; // very simple solution ... we don't retry, we just wait and forget
+            }
+        }
+    }
+
+protected:
+    static TInstant Now() {
+        return TActivationContext::Now();
+    }
+
+    TDuration GetAge() const {
+        return Now() - LastModified;
+    }
+
+    bool IsCacheFresh() const {
+        return GetAge() < CACHE_VALID_PERIOD;
+    }
+
+    bool IsCacheValid() const {
+        return Response && IsCacheFresh();
+    }
+
+    bool IsCacheOld() const {
+        return Response && !IsCacheFresh();
+    }
+
+    std::mutex Mutex;
+    std::shared_ptr<T> Response;
+    TInstant LastModified;
+    TInstant LastAccessed;
+    bool UpdatingNow = false;
+};
+
+struct TViewerSharedCacheState {
+    TCachedResponseState<NSysView::TEvSysView::TEvGetGroupsResponse> StorageGroups;
+    TCachedResponseState<NSysView::TEvSysView::TEvGetStoragePoolsResponse> StoragePools;
+    TCachedResponseState<NSysView::TEvSysView::TEvGetVSlotsResponse> StorageVSlots;
+    TCachedResponseState<NSysView::TEvSysView::TEvGetPDisksResponse> StoragePDisks;
+    TCachedResponseState<NSysView::TEvSysView::TEvGetStorageStatsResponse> StorageStats;
+
+    void ClearOld() {
+        StorageGroups.ClearOld();
+        StoragePools.ClearOld();
+        StorageVSlots.ClearOld();
+        StoragePDisks.ClearOld();
+        StorageStats.ClearOld();
+    }
+};
+
+std::shared_ptr<TViewerSharedCacheState> IViewer::CreateSharedCacheState() {
+    return std::make_shared<TViewerSharedCacheState>();
+}
+
+void IViewer::DeleteOldSharedCacheData() {
+    SharedCacheState->ClearOld();
+}
+
+void IViewer::UpdateSharedCacheData(std::unique_ptr<TEvViewer::TEvUpdateSharedCacheTabletResponse> ev) {
+    std::visit(TOverloaded{
+        [&](const std::shared_ptr<NSysView::TEvSysView::TEvGetGroupsResponse>& r) { SharedCacheState->StorageGroups.UpdateCache(r); },
+        [&](const std::shared_ptr<NSysView::TEvSysView::TEvGetStoragePoolsResponse>& r) { SharedCacheState->StoragePools.UpdateCache(r); },
+        [&](const std::shared_ptr<NSysView::TEvSysView::TEvGetVSlotsResponse>& r) { SharedCacheState->StorageVSlots.UpdateCache(r); },
+        [&](const std::shared_ptr<NSysView::TEvSysView::TEvGetPDisksResponse>& r) { SharedCacheState->StoragePDisks.UpdateCache(r); },
+        [&](const std::shared_ptr<NSysView::TEvSysView::TEvGetStorageStatsResponse>& r) { SharedCacheState->StorageStats.UpdateCache(r); },
+    }, ev->Response);
+}
+
+void TViewerPipeClient::UpdateSharedCacheTablet(TTabletId tabletId, std::unique_ptr<IEventBase> request) {
+    Send(MakeViewerID(SelfId().NodeId()), new TEvViewer::TEvUpdateSharedCacheTabletRequest(tabletId, std::move(request)));
+}
+
 NTabletPipe::TClientConfig TViewerPipeClient::GetPipeClientConfig() {
     NTabletPipe::TClientConfig clientConfig;
     if (WithRetry) {
@@ -111,9 +218,9 @@ TActorId TViewerPipeClient::ConnectTabletPipe(NNodeWhiteboard::TTabletId tabletI
 }
 
 void TViewerPipeClient::SendEvent(std::unique_ptr<IEventHandle> event) {
-    if (DelayedRequests.empty() && Requests < MaxRequestsInFlight) {
+    if (DelayedRequests.empty() && DataRequests < MaxRequestsInFlight) {
         TActivationContext::Send(event.release());
-        ++Requests;
+        ++DataRequests;
     } else {
         DelayedRequests.push_back({
             .Event = std::move(event),
@@ -132,10 +239,10 @@ void TViewerPipeClient::SendRequestToPipe(TActorId pipe, IEventBase* ev, ui64 co
 }
 
 void TViewerPipeClient::SendDelayedRequests() {
-    while (!DelayedRequests.empty() && Requests < MaxRequestsInFlight) {
+    while (!DelayedRequests.empty() && DataRequests < MaxRequestsInFlight) {
         auto& request(DelayedRequests.front());
         TActivationContext::Send(request.Event.release());
-        ++Requests;
+        ++DataRequests;
         DelayedRequests.pop_front();
     }
 }
@@ -168,18 +275,18 @@ TString TViewerPipeClient::GetPath(TEvTxProxySchemeCache::TEvNavigateKeySetResul
     return GetPath(*ev->Get());
 }
 
-bool TViewerPipeClient::IsSuccess(const std::unique_ptr<TEvTxProxySchemeCache::TEvNavigateKeySetResult>& ev) {
-    return (ev->Request->ResultSet.size() > 0) && (std::find_if(ev->Request->ResultSet.begin(), ev->Request->ResultSet.end(),
+bool TViewerPipeClient::IsSuccess(const TEvTxProxySchemeCache::TEvNavigateKeySetResult& ev) {
+    return (ev.Request->ResultSet.size() > 0) && (std::find_if(ev.Request->ResultSet.begin(), ev.Request->ResultSet.end(),
         [](const auto& entry) {
             return entry.Status == NSchemeCache::TSchemeCacheNavigate::EStatus::Ok;
-        }) != ev->Request->ResultSet.end());
+        }) != ev.Request->ResultSet.end());
 }
 
-TString TViewerPipeClient::GetError(const std::unique_ptr<TEvTxProxySchemeCache::TEvNavigateKeySetResult>& ev) {
-    if (ev->Request->ResultSet.size() == 0) {
+TString TViewerPipeClient::GetError(const TEvTxProxySchemeCache::TEvNavigateKeySetResult& ev) {
+    if (ev.Request->ResultSet.size() == 0) {
         return "empty response";
     }
-    for (const auto& entry : ev->Request->ResultSet) {
+    for (const auto& entry : ev.Request->ResultSet) {
         if (entry.Status != NSchemeCache::TSchemeCacheNavigate::EStatus::Ok) {
             switch (entry.Status) {
                 case NSchemeCache::TSchemeCacheNavigate::EStatus::Ok:
@@ -203,19 +310,19 @@ TString TViewerPipeClient::GetError(const std::unique_ptr<TEvTxProxySchemeCache:
                 case NSchemeCache::TSchemeCacheNavigate::EStatus::AccessDenied:
                     return "AccessDenied";
                 default:
-                    return ::ToString(static_cast<int>(ev->Request->ResultSet.begin()->Status));
+                    return ::ToString(static_cast<int>(ev.Request->ResultSet.begin()->Status));
             }
         }
     }
     return "no error";
 }
 
-bool TViewerPipeClient::IsSuccess(const std::unique_ptr<TEvStateStorage::TEvBoardInfo>& ev) {
-    return ev->Status == TEvStateStorage::TEvBoardInfo::EStatus::Ok;
+bool TViewerPipeClient::IsSuccess(const TEvStateStorage::TEvBoardInfo& ev) {
+    return ev.Status == TEvStateStorage::TEvBoardInfo::EStatus::Ok;
 }
 
-TString TViewerPipeClient::GetError(const std::unique_ptr<TEvStateStorage::TEvBoardInfo>& ev) {
-    switch (ev->Status) {
+TString TViewerPipeClient::GetError(const TEvStateStorage::TEvBoardInfo& ev) {
+    switch (ev.Status) {
         case TEvStateStorage::TEvBoardInfo::EStatus::Unknown:
             return "Unknown";
         case TEvStateStorage::TEvBoardInfo::EStatus::Ok:
@@ -223,19 +330,19 @@ TString TViewerPipeClient::GetError(const std::unique_ptr<TEvStateStorage::TEvBo
         case TEvStateStorage::TEvBoardInfo::EStatus::NotAvailable:
             return "NotAvailable";
         default:
-            return ::ToString(static_cast<int>(ev->Status));
+            return ::ToString(static_cast<int>(ev.Status));
     }
 }
 
-bool TViewerPipeClient::IsSuccess(const std::unique_ptr<NSchemeShard::TEvSchemeShard::TEvDescribeSchemeResult>& ev) {
-    return ev->GetRecord().GetStatus() == NKikimrScheme::EStatus::StatusSuccess;
+bool TViewerPipeClient::IsSuccess(const NSchemeShard::TEvSchemeShard::TEvDescribeSchemeResult& ev) {
+    return ev.GetRecord().GetStatus() == NKikimrScheme::EStatus::StatusSuccess;
 }
 
-TString TViewerPipeClient::GetError(const std::unique_ptr<NSchemeShard::TEvSchemeShard::TEvDescribeSchemeResult>& ev) {
-    if (ev->GetRecord().HasReason()) {
-        return ev->GetRecord().GetReason();
+TString TViewerPipeClient::GetError(const NSchemeShard::TEvSchemeShard::TEvDescribeSchemeResult& ev) {
+    if (ev.GetRecord().HasReason()) {
+        return ev.GetRecord().GetReason();
     }
-    return NKikimrScheme::EStatus_Name(ev->GetRecord().GetStatus());
+    return NKikimrScheme::EStatus_Name(ev.GetRecord().GetStatus());
 }
 
 void TViewerPipeClient::RequestHiveDomainStats(NNodeWhiteboard::TTabletId hiveId) {
@@ -518,13 +625,41 @@ TViewerPipeClient::TRequestResponse<NSysView::TEvSysView::TEvGetVSlotsResponse> 
 TViewerPipeClient::TRequestResponse<NSysView::TEvSysView::TEvGetGroupsResponse> TViewerPipeClient::RequestBSControllerGroups() {
     TActorId pipeClient = ConnectTabletPipe(GetBSControllerId());
     auto request = std::make_unique<NSysView::TEvSysView::TEvGetGroupsRequest>();
-    return MakeRequestToPipe<NSysView::TEvSysView::TEvGetGroupsResponse>(pipeClient, request.release());
+    auto response = MakeRequestToPipe<NSysView::TEvSysView::TEvGetGroupsResponse>(pipeClient, request.release());
+    return response;
 }
 
+TViewerPipeClient::TRequestResponse<NSysView::TEvSysView::TEvGetGroupsResponse> TViewerPipeClient::MakeCachedRequestBSControllerGroups() {
+    if (UseCache && Viewer) {
+        bool needUpdate = false;
+        auto cachedData = Viewer->SharedCacheState->StorageGroups.GetFromCache(CachedDataMaxAge, needUpdate);
+        if (needUpdate) {
+            UpdateSharedCacheTablet(GetBSControllerId(), std::make_unique<NSysView::TEvSysView::TEvGetGroupsRequest>());
+        }
+        if (cachedData) {
+            return cachedData;
+        }
+    }
+    return RequestBSControllerGroups();
+}
 TViewerPipeClient::TRequestResponse<NSysView::TEvSysView::TEvGetStoragePoolsResponse> TViewerPipeClient::RequestBSControllerPools() {
     TActorId pipeClient = ConnectTabletPipe(GetBSControllerId());
     auto request = std::make_unique<NSysView::TEvSysView::TEvGetStoragePoolsRequest>();
     return MakeRequestToPipe<NSysView::TEvSysView::TEvGetStoragePoolsResponse>(pipeClient, request.release());
+}
+
+TViewerPipeClient::TRequestResponse<NSysView::TEvSysView::TEvGetStoragePoolsResponse> TViewerPipeClient::MakeCachedRequestBSControllerPools() {
+    if (UseCache && Viewer) {
+        bool needUpdate = false;
+        auto cachedData = Viewer->SharedCacheState->StoragePools.GetFromCache(CachedDataMaxAge, needUpdate);
+        if (needUpdate) {
+            UpdateSharedCacheTablet(GetBSControllerId(), std::make_unique<NSysView::TEvSysView::TEvGetStoragePoolsRequest>());
+        }
+        if (cachedData) {
+            return cachedData;
+        }
+    }
+    return RequestBSControllerPools();
 }
 
 TViewerPipeClient::TRequestResponse<NSysView::TEvSysView::TEvGetVSlotsResponse> TViewerPipeClient::RequestBSControllerVSlots() {
@@ -533,15 +668,57 @@ TViewerPipeClient::TRequestResponse<NSysView::TEvSysView::TEvGetVSlotsResponse> 
     return MakeRequestToPipe<NSysView::TEvSysView::TEvGetVSlotsResponse>(pipeClient, request.release());
 }
 
+TViewerPipeClient::TRequestResponse<NSysView::TEvSysView::TEvGetVSlotsResponse> TViewerPipeClient::MakeCachedRequestBSControllerVSlots() {
+    if (UseCache && Viewer) {
+        bool needUpdate = false;
+        auto cachedData = Viewer->SharedCacheState->StorageVSlots.GetFromCache(CachedDataMaxAge, needUpdate);
+        if (needUpdate) {
+            UpdateSharedCacheTablet(GetBSControllerId(), std::make_unique<NSysView::TEvSysView::TEvGetVSlotsRequest>());
+        }
+        if (cachedData) {
+            return cachedData;
+        }
+    }
+    return RequestBSControllerVSlots();
+}
+
 TViewerPipeClient::TRequestResponse<NSysView::TEvSysView::TEvGetPDisksResponse> TViewerPipeClient::RequestBSControllerPDisks() {
     TActorId pipeClient = ConnectTabletPipe(GetBSControllerId());
     auto request = std::make_unique<NSysView::TEvSysView::TEvGetPDisksRequest>();
     return MakeRequestToPipe<NSysView::TEvSysView::TEvGetPDisksResponse>(pipeClient, request.release());
 }
 
+TViewerPipeClient::TRequestResponse<NSysView::TEvSysView::TEvGetPDisksResponse> TViewerPipeClient::MakeCachedRequestBSControllerPDisks() {
+    if (UseCache && Viewer) {
+        bool needUpdate = false;
+        auto cachedData = Viewer->SharedCacheState->StoragePDisks.GetFromCache(CachedDataMaxAge, needUpdate);
+        if (needUpdate) {
+            UpdateSharedCacheTablet(GetBSControllerId(), std::make_unique<NSysView::TEvSysView::TEvGetPDisksRequest>());
+        }
+        if (cachedData) {
+            return cachedData;
+        }
+    }
+    return RequestBSControllerPDisks();
+}
+
 TViewerPipeClient::TRequestResponse<NSysView::TEvSysView::TEvGetStorageStatsResponse> TViewerPipeClient::RequestBSControllerStorageStats() {
     TActorId pipeClient = ConnectTabletPipe(GetBSControllerId());
     return MakeRequestToPipe<NSysView::TEvSysView::TEvGetStorageStatsResponse>(pipeClient, new NSysView::TEvSysView::TEvGetStorageStatsRequest());
+}
+
+TViewerPipeClient::TRequestResponse<NSysView::TEvSysView::TEvGetStorageStatsResponse> TViewerPipeClient::MakeCachedRequestBSControllerStorageStats() {
+    if (UseCache && Viewer) {
+        bool needUpdate = false;
+        auto cachedData = Viewer->SharedCacheState->StorageStats.GetFromCache(CachedDataMaxAge, needUpdate);
+        if (needUpdate) {
+            UpdateSharedCacheTablet(GetBSControllerId(), std::make_unique<NSysView::TEvSysView::TEvGetStorageStatsRequest>());
+        }
+        if (cachedData) {
+            return cachedData;
+        }
+    }
+    return RequestBSControllerStorageStats();
 }
 
 void TViewerPipeClient::RequestBSControllerPDiskUpdateStatus(const NKikimrBlobStorage::TUpdateDriveStatus& driveStatus, bool force) {
@@ -662,7 +839,7 @@ void TViewerPipeClient::RequestStateStorageEndpointsLookup(const TString& path) 
     RegisterWithSameMailbox(CreateBoardLookupActor(MakeEndpointsBoardPath(path),
                                                    SelfId(),
                                                    EBoardLookupMode::Second));
-    ++Requests;
+    ++DataRequests;
 }
 
 TViewerPipeClient::TRequestResponse<TEvStateStorage::TEvBoardInfo> TViewerPipeClient::MakeRequestStateStorageEndpointsLookup(const TString& path, ui64 cookie) {
@@ -673,7 +850,7 @@ TViewerPipeClient::TRequestResponse<TEvStateStorage::TEvBoardInfo> TViewerPipeCl
     if (response.Span) {
         response.Span.Attribute("path", path);
     }
-    ++Requests;
+    ++DataRequests;
     return response;
 }
 
@@ -684,7 +861,7 @@ void TViewerPipeClient::RequestStateStorageMetadataCacheEndpointsLookup(const TS
     RegisterWithSameMailbox(CreateBoardLookupActor(MakeDatabaseMetadataCacheBoardPath(path),
                                                    SelfId(),
                                                    EBoardLookupMode::Second));
-    ++Requests;
+    ++DataRequests;
 }
 
 std::vector<TNodeId> TViewerPipeClient::GetNodesFromBoardReply(const TEvStateStorage::TEvBoardInfo& ev) {
@@ -725,6 +902,7 @@ void TViewerPipeClient::InitConfig(const TCgiParameters& params) {
     Proto2JsonConfig.ConvertAny = true;
     Proto2JsonConfig.WriteNanAsString = true;
     Timeout = TDuration::MilliSeconds(FromStringWithDefault<ui32>(params.Get("timeout"), Timeout.MilliSeconds()));
+    UseCache = FromStringWithDefault<bool>(params.Get("use_cache"), UseCache);
 }
 
 void TViewerPipeClient::InitConfig(const TRequestSettings& settings) {
@@ -742,10 +920,10 @@ void TViewerPipeClient::ClosePipes() {
     PipeInfo.clear();
 }
 
-ui32 TViewerPipeClient::FailPipeConnect(NNodeWhiteboard::TTabletId tabletId) {
+i32 TViewerPipeClient::FailPipeConnect(NNodeWhiteboard::TTabletId tabletId) {
     auto itPipeInfo = PipeInfo.find(tabletId);
     if (itPipeInfo != PipeInfo.end()) {
-        ui32 requests = itPipeInfo->second.Requests;
+        i32 requests = itPipeInfo->second.Requests;
         NTabletPipe::CloseClient(SelfId(), itPipeInfo->second.PipeClient);
         PipeInfo.erase(itPipeInfo);
         return requests;
@@ -763,32 +941,28 @@ TRequestState TViewerPipeClient::GetRequest() const {
 }
 
 void TViewerPipeClient::ReplyAndPassAway(TString data, const TString& error) {
-    TString message = error;
-
-    if (Event) {
-        Send(Event->Sender, new NMon::TEvHttpInfoRes(data, 0, NMon::IEvHttpInfoRes::EContentType::Custom));
-    } else if (HttpEvent) {
-        auto response = HttpEvent->Get()->Request->CreateResponseString(data);
-        Send(HttpEvent->Sender, new NHttp::TEvHttpProxy::TEvHttpOutgoingResponse(response.Release()));
-    }
-
-    if (message.empty()) {
-        TStringBuf dataParser(data);
-        if (dataParser.NextTok(' ') == "HTTP/1.1") {
-            TStringBuf code = dataParser.NextTok(' ');
-            if (code.size() == 3 && code[0] != '2') {
-                message = dataParser.NextTok('\n');
+    if (!ReplySent) {
+        if (Event) {
+            Send(Event->Sender, new NMon::TEvHttpInfoRes(data, 0, NMon::IEvHttpInfoRes::EContentType::Custom));
+        } else if (HttpEvent) {
+            auto response = HttpEvent->Get()->Request->CreateResponseString(data);
+            Send(HttpEvent->Sender, new NHttp::TEvHttpProxy::TEvHttpOutgoingResponse(response.Release()));
+        }
+        ReplySent = true;
+        if (error) {
+            Error = error;
+        }
+        if (Error.empty()) {
+            TStringBuf dataParser(data);
+            if (dataParser.NextTok(' ') == "HTTP/1.1") {
+                TStringBuf code = dataParser.NextTok(' ');
+                if (code.size() == 3 && code[0] != '2') {
+                    Error = dataParser.NextTok('\n');
+                }
             }
         }
+        PassAway();
     }
-    if (Span) {
-        if (message) {
-            Span.EndError(message);
-        } else {
-            Span.EndOk();
-        }
-    }
-    PassAway();
 }
 
 TString TViewerPipeClient::GetHTTPOK(TString contentType, TString response, TInstant lastModified) {
@@ -844,22 +1018,22 @@ TString TViewerPipeClient::MakeForward(const std::vector<ui32>& nodes) {
     return Viewer->MakeForward(GetRequest(), nodes);
 }
 
-void TViewerPipeClient::RequestDone(ui32 requests) {
+void TViewerPipeClient::RequestDone(i32 requests) {
     if (requests == 0) {
         return;
     }
-    if (requests > Requests) {
-        BLOG_ERROR("Requests count mismatch: " << requests << " > " << Requests);
+    if (requests > DataRequests) {
+        BLOG_ERROR("Requests count mismatch: " << requests << " > " << DataRequests);
         if (Span) {
             Span.Event("Requests count mismatch");
         }
-        requests = Requests;
+        requests = DataRequests;
     }
-    Requests -= requests;
+    DataRequests -= requests;
     if (!DelayedRequests.empty()) {
         SendDelayedRequests();
     }
-    if (Requests == 0 && !PassedAway) {
+    if (DataRequests == 0 && !ReplySent) {
         ReplyAndPassAway();
     }
 }
@@ -875,6 +1049,11 @@ void TViewerPipeClient::Handle(TEvTabletPipe::TEvClientConnected::TPtr& ev) {
     }
 }
 
+void TViewerPipeClient::Handle(TEvTabletPipe::TEvClientDestroyed::TPtr& ev) {
+    ui32 requests = FailPipeConnect(ev->Get()->TabletId);
+    RequestDone(requests);
+}
+
 void TViewerPipeClient::HandleResolveResource(TEvTxProxySchemeCache::TEvNavigateKeySetResult::TPtr& ev) {
     if (ResourceNavigateResponse) {
         ResourceNavigateResponse->Set(std::move(ev));
@@ -883,7 +1062,7 @@ void TViewerPipeClient::HandleResolveResource(TEvTxProxySchemeCache::TEvNavigate
             SharedDatabase = CanonizePath(entry.Path);
             Direct |= (SharedDatabase == AppData()->TenantName);
             DatabaseBoardInfoResponse = MakeRequestStateStorageEndpointsLookup(SharedDatabase);
-            --Requests; // don't count this request
+            --DataRequests; // don't count this request
         } else {
             AddEvent("Failed to resolve database - shared database not found");
             Direct = true;
@@ -899,12 +1078,12 @@ void TViewerPipeClient::HandleResolveDatabase(TEvTxProxySchemeCache::TEvNavigate
             TSchemeCacheNavigate::TEntry& entry(DatabaseNavigateResponse->Get()->Request->ResultSet.front());
             if (entry.DomainInfo && entry.DomainInfo->ResourcesDomainKey && entry.DomainInfo->DomainKey != entry.DomainInfo->ResourcesDomainKey) {
                 ResourceNavigateResponse = MakeRequestSchemeCacheNavigate(TPathId(entry.DomainInfo->ResourcesDomainKey));
-                --Requests; // don't count this request
+                --DataRequests; // don't count this request
                 Become(&TViewerPipeClient::StateResolveResource);
             } else {
                 Database = CanonizePath(entry.Path);
                 DatabaseBoardInfoResponse = MakeRequestStateStorageEndpointsLookup(Database);
-                --Requests; // don't count this request
+                --DataRequests; // don't count this request
             }
         } else {
             AddEvent("Failed to resolve database - not found");
@@ -953,7 +1132,7 @@ STATEFN(TViewerPipeClient::StateResolveResource) {
 
 void TViewerPipeClient::RedirectToDatabase(const TString& database) {
     DatabaseNavigateResponse = MakeRequestSchemeCacheNavigate(database);
-    --Requests; // don't count this request
+    --DataRequests; // don't count this request
     Become(&TViewerPipeClient::StateResolveDatabase);
 }
 
@@ -972,8 +1151,13 @@ bool TViewerPipeClient::NeedToRedirect() {
 }
 
 void TViewerPipeClient::PassAway() {
+    AddEvent("PassAway");
     if (Span) {
-        Span.EndError("unterminated span");
+        if (Error) {
+            Span.EndError(Error);
+        } else {
+            Span.EndOk();
+        }
     }
     std::sort(SubscriptionNodeIds.begin(), SubscriptionNodeIds.end());
     SubscriptionNodeIds.erase(std::unique(SubscriptionNodeIds.begin(), SubscriptionNodeIds.end()), SubscriptionNodeIds.end());

--- a/ydb/core/viewer/json_pipe_req.cpp
+++ b/ydb/core/viewer/json_pipe_req.cpp
@@ -804,8 +804,7 @@ TViewerPipeClient::TRequestResponse<NSchemeShard::TEvSchemeShard::TEvDescribeSch
     request->Record.SetSchemeshardId(schemeShardId);
     request->Record.SetPath(path);
     request->Record.MutableOptions()->CopyFrom(options);
-    auto pipe = ConnectTabletPipe(schemeShardId);
-    auto response = MakeRequestToPipe<NSchemeShard::TEvSchemeShard::TEvDescribeSchemeResult>(pipe, request.release(), cookie);
+    auto response = MakeRequestToTablet<NSchemeShard::TEvSchemeShard::TEvDescribeSchemeResult>(schemeShardId, request.release(), cookie);
     if (response.Span) {
         response.Span.Attribute("path", path);
     }

--- a/ydb/core/viewer/json_pipe_req.cpp
+++ b/ydb/core/viewer/json_pipe_req.cpp
@@ -227,6 +227,17 @@ TString TViewerPipeClient::GetError(const std::unique_ptr<TEvStateStorage::TEvBo
     }
 }
 
+bool TViewerPipeClient::IsSuccess(const std::unique_ptr<NSchemeShard::TEvSchemeShard::TEvDescribeSchemeResult>& ev) {
+    return ev->GetRecord().GetStatus() == NKikimrScheme::EStatus::StatusSuccess;
+}
+
+TString TViewerPipeClient::GetError(const std::unique_ptr<NSchemeShard::TEvSchemeShard::TEvDescribeSchemeResult>& ev) {
+    if (ev->GetRecord().HasReason()) {
+        return ev->GetRecord().GetReason();
+    }
+    return NKikimrScheme::EStatus_Name(ev->GetRecord().GetStatus());
+}
+
 void TViewerPipeClient::RequestHiveDomainStats(NNodeWhiteboard::TTabletId hiveId) {
     TActorId pipeClient = ConnectTabletPipe(hiveId);
     THolder<TEvHive::TEvRequestHiveDomainStats> request = MakeHolder<TEvHive::TEvRequestHiveDomainStats>();

--- a/ydb/core/viewer/json_pipe_req.h
+++ b/ydb/core/viewer/json_pipe_req.h
@@ -204,6 +204,17 @@ protected:
         return response;
     }
 
+    template<typename TResponse>
+    TRequestResponse<TResponse> MakeRequestToTablet(TTabletId tabletId, IEventBase* ev, ui64 cookie = 0) {
+        TActorId pipe = ConnectTabletPipe(tabletId);
+        TRequestResponse<TResponse> response(Span.CreateChild(TComponentTracingLevels::THttp::Detailed, TypeName(*ev)));
+        if (response.Span) {
+            response.Span.Attribute("tablet_id", "#" + ::ToString(tabletId));
+        }
+        SendRequestToPipe(pipe, ev, cookie, response.Span.GetTraceId());
+        return response;
+    }
+
     template<typename TRequest>
     TRequestResponse<typename NNodeWhiteboard::WhiteboardResponse<TRequest>::Type> MakeWhiteboardRequest(TNodeId nodeId, TRequest* ev, ui32 flags = IEventHandle::FlagTrackDelivery | IEventHandle::FlagSubscribeOnSession) {
         TActorId whiteboardServiceId = NNodeWhiteboard::MakeNodeWhiteboardServiceId(nodeId);
@@ -240,6 +251,9 @@ protected:
 
     static bool IsSuccess(const std::unique_ptr<TEvStateStorage::TEvBoardInfo>& ev);
     static TString GetError(const std::unique_ptr<TEvStateStorage::TEvBoardInfo>& ev);
+
+    static bool IsSuccess(const std::unique_ptr<NSchemeShard::TEvSchemeShard::TEvDescribeSchemeResult>& ev);
+    static TString GetError(const std::unique_ptr<NSchemeShard::TEvSchemeShard::TEvDescribeSchemeResult>& ev);
 
     TRequestResponse<TEvHive::TEvResponseHiveDomainStats> MakeRequestHiveDomainStats(TTabletId hiveId);
     TRequestResponse<TEvHive::TEvResponseHiveStorageStats> MakeRequestHiveStorageStats(TTabletId hiveId);

--- a/ydb/core/viewer/json_pipe_req.h
+++ b/ydb/core/viewer/json_pipe_req.h
@@ -318,7 +318,7 @@ protected:
         const TString& path, bool showPrivate, ui32 access, ui64 cookie = 0);
 
     TRequestResponse<TEvViewer::TEvViewerResponse> MakeRequestViewer(TNodeId nodeId, TEvViewer::TEvViewerRequest* request, ui32 flags = 0);
-    void RequestTxProxyDescribe(const TString& path);
+    void RequestTxProxyDescribe(const TString& path, const NKikimrSchemeOp::TDescribeOptions& options = {});
     void RequestStateStorageEndpointsLookup(const TString& path);
     void RequestStateStorageMetadataCacheEndpointsLookup(const TString& path);
     TRequestResponse<TEvStateStorage::TEvBoardInfo> MakeRequestStateStorageEndpointsLookup(const TString& path, ui64 cookie = 0);

--- a/ydb/core/viewer/json_storage_base.h
+++ b/ydb/core/viewer/json_storage_base.h
@@ -159,7 +159,7 @@ public:
                 SendNodeRequests(nodeId);
             }
         }
-        if (Requests == 0) {
+        if (!WaitingForResponse()) {
             ReplyAndPassAway();
             return;
         }
@@ -439,7 +439,7 @@ public:
                 }
             }
         }
-        return Requests != 0;
+        return WaitingForResponse();
     }
 
     void CollectDiskInfo(bool needDonors) {

--- a/ydb/core/viewer/operation_list.h
+++ b/ydb/core/viewer/operation_list.h
@@ -23,6 +23,27 @@ public:
         AllowedMethods = {HTTP_METHOD_GET};
     }
 
+    bool ValidateRequest(Ydb::Operations::ListOperationsRequest& request) override {
+        if (!TBase::ValidateRequest(request)) {
+            return false;
+        }
+        ui64 offset = FromStringWithDefault<ui64>(Params.Get("offset"), 0);
+        ui64 limit = FromStringWithDefault<ui64>(Params.Get("limit"), 0);
+        if (offset >= 0 && limit > 0) {
+            if (offset % limit != 0) {
+                ReplyAndPassAway(GetHTTPBADREQUEST("text/plain", "offset must be a multiple of limit"));
+                return false;
+            }
+            if (limit > 100) {
+                ReplyAndPassAway(GetHTTPBADREQUEST("text/plain", "limit must be less than or equal to 100"));
+                return false;
+            }
+            request.set_page_size(limit);
+            request.set_page_token(std::to_string(offset / limit + 1));
+        }
+        return true;
+    }
+
     static YAML::Node GetSwagger() {
         YAML::Node node = YAML::Load(R"___(
             get:
@@ -42,7 +63,8 @@ public:
                         kind:
                           * `ss/backgrounds`
                           * `export`
-                          * `import`
+                          * `import/S3`
+                          * `import/YT`
                           * `buildindex`
                           * `scriptexec`
                     required: true
@@ -57,6 +79,16 @@ public:
                     description: page token
                     required: false
                     type: string
+                  - name: offset
+                    in: query
+                    description: offset. must be a multiple of limit
+                    required: false
+                    type: integer
+                  - name: limit
+                    in: query
+                    description: limit. must be less than or equal to 100
+                    required: false
+                    type: integer
                 responses:
                     200:
                         description: OK

--- a/ydb/core/viewer/protos/viewer.proto
+++ b/ydb/core/viewer/protos/viewer.proto
@@ -319,6 +319,7 @@ message TClusterInfo {
     string Name = 2;
     string Domain = 3;
     EFlag Overall = 5;
+    optional uint64 CachedDataMaxAge = 8;
     repeated string Problems = 9;
     uint32 NodesTotal = 10;
     uint32 NodesAlive = 11;
@@ -516,9 +517,10 @@ message TStorageGroupsInfo {
     optional bool NeedGroup = 7;
     optional bool NeedSort = 8;
     optional bool NeedLimit = 9;
-    repeated string Problems = 10;
-    repeated TStorageGroupInfo StorageGroups = 11;
-    repeated TStorageGroupGroup StorageGroupGroups = 12;
+    optional uint64 CachedDataMaxAge = 10;
+    repeated string Problems = 11;
+    repeated TStorageGroupInfo StorageGroups = 12;
+    repeated TStorageGroupGroup StorageGroupGroups = 13;
 }
 
 message TStorageUsageStats {
@@ -578,6 +580,7 @@ message TNodesInfo {
     optional bool NeedSort = 8;
     optional bool NeedLimit = 9;
     repeated string Problems = 10;
+    optional uint64 CachedDataMaxAge = 11;
     repeated TNodeInfo Nodes = 20;
     repeated TNodeGroup NodeGroups = 30;
     optional uint64 MaximumDisksPerNode = 50;

--- a/ydb/core/viewer/protos/viewer.proto
+++ b/ydb/core/viewer/protos/viewer.proto
@@ -561,6 +561,12 @@ message TNodeInfo {
     repeated NKikimrWhiteboard.TNodeStateInfo ReversePeers = 55;
 }
 
+message TNodeBatch {
+    repeated uint32 NodesToAskFor = 1;
+    repeated uint32 NodesToAskAbout = 2;
+    optional bool HasStaticNodes = 3;
+}
+
 message TNodesInfo {
     uint32 Version = 1;
     optional uint64 TotalNodes = 2;
@@ -578,6 +584,7 @@ message TNodesInfo {
     optional uint64 MaximumSlotsPerDisk = 51;
     optional bool NoDC = 60;
     optional bool NoRack = 61;
+    repeated TNodeBatch OriginalNodeBatches = 62;
 }
 
 enum ENodeType {

--- a/ydb/core/viewer/tests/canondata/result.json
+++ b/ydb/core/viewer/tests/canondata/result.json
@@ -1724,7 +1724,6 @@
                     },
                     {
                         "ACL": "",
-                        "ChildrenExist": false,
                         "CreateFinished": true,
                         "CreateStep": "not-zero-number-text",
                         "CreateTxId": "not-zero-number-text",
@@ -1738,7 +1737,6 @@
                     },
                     {
                         "ACL": "",
-                        "ChildrenExist": false,
                         "CreateFinished": true,
                         "CreateStep": "not-zero-number-text",
                         "CreateTxId": "not-zero-number-text",
@@ -1752,7 +1750,6 @@
                     },
                     {
                         "ACL": "",
-                        "ChildrenExist": false,
                         "CreateFinished": true,
                         "CreateStep": "not-zero-number-text",
                         "CreateTxId": "not-zero-number-text",
@@ -1980,7 +1977,6 @@
                 },
                 "Self": {
                     "ACL": "",
-                    "ChildrenExist": true,
                     "CreateFinished": true,
                     "CreateStep": "0",
                     "CreateTxId": "not-zero-number-text",
@@ -2061,7 +2057,6 @@
                 },
                 "Self": {
                     "ACL": "",
-                    "ChildrenExist": false,
                     "CreateFinished": true,
                     "CreateStep": "0",
                     "CreateTxId": "not-zero-number-text",
@@ -2158,7 +2153,6 @@
                 },
                 "Self": {
                     "ACL": "",
-                    "ChildrenExist": true,
                     "CreateFinished": true,
                     "CreateStep": "0",
                     "CreateTxId": "not-zero-number-text",

--- a/ydb/core/viewer/tests/canondata/result.json
+++ b/ydb/core/viewer/tests/canondata/result.json
@@ -507,58 +507,130 @@
         "TotalGroups": 5
     },
     "test.test_topic_data": {
+        "both_offset_and_ts": {
+            "status_code": 400,
+            "text": "Only read_timestamp or offset parameter may be specified, not both"
+        },
+        "no_partition": {
+            "status_code": 400,
+            "text": "Parameter 'partition' is necessary"
+        },
         "response_compressed": {
             "EndOffset": 21,
             "Messages": [
                 {
                     "Codec": 1,
+                    "CreateTimestamp": "not-zero-number",
                     "Message": "Y29tcHJlc3NlZC1tZXNzYWdlLTA=",
                     "Offset": 11,
                     "OriginalSize": 20,
+                    "ProducerId": "not-zero-number-text",
                     "SeqNo": 12,
-                    "StorageSize": 38
+                    "StorageSize": 38,
+                    "TimestampDiff": "not-zero-number",
+                    "WriteTimestamp": "not-zero-number"
                 },
                 {
                     "Codec": 1,
+                    "CreateTimestamp": "not-zero-number",
                     "Message": "Y29tcHJlc3NlZC1tZXNzYWdlLTE=",
                     "Offset": 12,
                     "OriginalSize": 20,
+                    "ProducerId": "not-zero-number-text",
                     "SeqNo": 13,
-                    "StorageSize": 38
+                    "StorageSize": 38,
+                    "TimestampDiff": "not-zero-number",
+                    "WriteTimestamp": "not-zero-number"
                 },
                 {
                     "Codec": 1,
+                    "CreateTimestamp": "not-zero-number",
                     "Message": "Y29tcHJlc3NlZC1tZXNzYWdlLTI=",
                     "Offset": 13,
                     "OriginalSize": 20,
+                    "ProducerId": "not-zero-number-text",
                     "SeqNo": 14,
-                    "StorageSize": 38
+                    "StorageSize": 38,
+                    "TimestampDiff": "not-zero-number",
+                    "WriteTimestamp": "not-zero-number"
                 },
                 {
                     "Codec": 1,
+                    "CreateTimestamp": "not-zero-number",
                     "Message": "Y29tcHJlc3NlZC1tZXNzYWdlLTM=",
                     "Offset": 14,
                     "OriginalSize": 20,
+                    "ProducerId": "not-zero-number-text",
                     "SeqNo": 15,
-                    "StorageSize": 38
+                    "StorageSize": 38,
+                    "TimestampDiff": "not-zero-number",
+                    "WriteTimestamp": "not-zero-number"
                 },
                 {
                     "Codec": 1,
+                    "CreateTimestamp": "not-zero-number",
                     "Message": "Y29tcHJlc3NlZC1tZXNzYWdlLTQ=",
                     "Offset": 15,
                     "OriginalSize": 20,
+                    "ProducerId": "not-zero-number-text",
                     "SeqNo": 16,
-                    "StorageSize": 38
+                    "StorageSize": 38,
+                    "TimestampDiff": "not-zero-number",
+                    "WriteTimestamp": "not-zero-number"
                 }
             ],
             "StartOffset": 0,
-            "Truncated": true
+            "Truncated": false
+        },
+        "response_last_offset": {
+            "EndOffset": 21,
+            "Messages": [
+                {
+                    "Codec": 0,
+                    "CreateTimestamp": "not-zero-number",
+                    "Message": "bWVzc2FnZS0w",
+                    "Offset": 0,
+                    "OriginalSize": 9,
+                    "ProducerId": "not-zero-number-text",
+                    "SeqNo": 1,
+                    "StorageSize": 9,
+                    "TimestampDiff": "not-zero-number",
+                    "WriteTimestamp": "not-zero-number"
+                },
+                {
+                    "Codec": 0,
+                    "CreateTimestamp": "not-zero-number",
+                    "Message": "bWVzc2FnZS0x",
+                    "Offset": 1,
+                    "OriginalSize": 9,
+                    "ProducerId": "not-zero-number-text",
+                    "SeqNo": 2,
+                    "StorageSize": 9,
+                    "TimestampDiff": "not-zero-number",
+                    "WriteTimestamp": "not-zero-number"
+                },
+                {
+                    "Codec": 0,
+                    "CreateTimestamp": "not-zero-number",
+                    "Message": "bWVzc2FnZS0y",
+                    "Offset": 2,
+                    "OriginalSize": 9,
+                    "ProducerId": "not-zero-number-text",
+                    "SeqNo": 3,
+                    "StorageSize": 9,
+                    "TimestampDiff": "not-zero-number",
+                    "WriteTimestamp": "not-zero-number"
+                }
+            ],
+            "StartOffset": 0,
+            "Truncated": false
         },
         "response_metadata": {
             "EndOffset": 21,
             "Messages": [
                 {
                     "Codec": 1,
+                    "CreateTimestamp": "not-zero-number",
                     "Message": "bWVzc2FnZV93aXRoX21ldGE=",
                     "MessageMetadata": [
                         {
@@ -572,23 +644,30 @@
                     ],
                     "Offset": 10,
                     "OriginalSize": 17,
+                    "ProducerId": "not-zero-number-text",
                     "SeqNo": 11,
-                    "StorageSize": 37
+                    "StorageSize": 37,
+                    "TimestampDiff": "not-zero-number",
+                    "WriteTimestamp": "not-zero-number"
                 }
             ],
             "StartOffset": 0,
-            "Truncated": true
+            "Truncated": false
         },
         "response_not_truncated": {
             "EndOffset": 21,
             "Messages": [
                 {
                     "Codec": 1,
+                    "CreateTimestamp": "not-zero-number",
                     "Message": "Y29tcHJlc3NlZC1tZXNzYWdlLTk=",
                     "Offset": 20,
                     "OriginalSize": 20,
+                    "ProducerId": "not-zero-number-text",
                     "SeqNo": 21,
-                    "StorageSize": 38
+                    "StorageSize": 38,
+                    "TimestampDiff": "not-zero-number",
+                    "WriteTimestamp": "not-zero-number"
                 }
             ],
             "StartOffset": 0,
@@ -599,50 +678,88 @@
             "Messages": [
                 {
                     "Codec": 0,
+                    "CreateTimestamp": "not-zero-number",
                     "Message": "bWVzc2FnZS0w",
                     "Offset": 0,
                     "OriginalSize": 9,
+                    "ProducerId": "not-zero-number-text",
                     "SeqNo": 1,
-                    "StorageSize": 9
+                    "StorageSize": 9,
+                    "TimestampDiff": "not-zero-number",
+                    "WriteTimestamp": "not-zero-number"
                 },
                 {
                     "Codec": 0,
+                    "CreateTimestamp": "not-zero-number",
                     "Message": "bWVzc2FnZS0x",
                     "Offset": 1,
                     "OriginalSize": 9,
+                    "ProducerId": "not-zero-number-text",
                     "SeqNo": 2,
-                    "StorageSize": 9
+                    "StorageSize": 9,
+                    "TimestampDiff": "not-zero-number",
+                    "WriteTimestamp": "not-zero-number"
                 },
                 {
                     "Codec": 0,
+                    "CreateTimestamp": "not-zero-number",
                     "Message": "bWVzc2FnZS0y",
                     "Offset": 2,
                     "OriginalSize": 9,
+                    "ProducerId": "not-zero-number-text",
                     "SeqNo": 3,
-                    "StorageSize": 9
+                    "StorageSize": 9,
+                    "TimestampDiff": "not-zero-number",
+                    "WriteTimestamp": "not-zero-number"
                 },
                 {
                     "Codec": 0,
+                    "CreateTimestamp": "not-zero-number",
                     "Message": "bWVzc2FnZS0z",
                     "Offset": 3,
                     "OriginalSize": 9,
+                    "ProducerId": "not-zero-number-text",
                     "SeqNo": 4,
-                    "StorageSize": 9
+                    "StorageSize": 9,
+                    "TimestampDiff": "not-zero-number",
+                    "WriteTimestamp": "not-zero-number"
                 },
                 {
                     "Codec": 0,
+                    "CreateTimestamp": "not-zero-number",
                     "Message": "bWVzc2FnZS00",
                     "Offset": 4,
                     "OriginalSize": 9,
+                    "ProducerId": "not-zero-number-text",
                     "SeqNo": 5,
-                    "StorageSize": 9
+                    "StorageSize": 9,
+                    "TimestampDiff": "not-zero-number",
+                    "WriteTimestamp": "not-zero-number"
+                }
+            ],
+            "StartOffset": 0,
+            "Truncated": false
+        },
+        "response_truncated": {
+            "EndOffset": 21,
+            "Messages": [
+                {
+                    "Codec": 1,
+                    "CreateTimestamp": "not-zero-number",
+                    "Message": "Y29tcHI=",
+                    "Offset": 20,
+                    "OriginalSize": 20,
+                    "ProducerId": "not-zero-number-text",
+                    "SeqNo": 21,
+                    "StorageSize": 38,
+                    "TimestampDiff": "not-zero-number",
+                    "WriteTimestamp": "not-zero-number"
                 }
             ],
             "StartOffset": 0,
             "Truncated": true
         }
     },
-
     "test.test_transfer_describe": {
         "connection_params": {
             "connection_string": "text",
@@ -2390,6 +2507,7 @@
                                 "Usage": "number"
                             }
                         ],
+                        "RealNumberOfCpus": 128,
                         "Roles": "not-empty-array",
                         "StartTime": "not-zero-number-text",
                         "SystemState": "Green",
@@ -2732,6 +2850,7 @@
                                 "Usage": "number"
                             }
                         ],
+                        "RealNumberOfCpus": 128,
                         "Roles": "not-empty-array",
                         "StartTime": "not-zero-number-text",
                         "SystemState": "Green",
@@ -2932,6 +3051,7 @@
                                 "Usage": "number"
                             }
                         ],
+                        "RealNumberOfCpus": 128,
                         "Roles": "not-empty-array",
                         "StartTime": "not-zero-number-text",
                         "SystemState": "Green",
@@ -2942,32 +3062,22 @@
                     },
                     "Tablets": [
                         {
-                            "Count": 4,
+                            "Count": 1,
                             "State": "Green",
                             "Type": "Coordinator"
                         },
                         {
-                            "Count": 1,
-                            "State": "Green",
-                            "Type": "Hive"
-                        },
-                        {
-                            "Count": 6,
+                            "Count": 3,
                             "State": "Green",
                             "Type": "Mediator"
                         },
                         {
-                            "Count": 2,
+                            "Count": 1,
                             "State": "Green",
                             "Type": "SchemeShard"
                         },
                         {
                             "Count": 1,
-                            "State": "Green",
-                            "Type": "StatisticsAggregator"
-                        },
-                        {
-                            "Count": 2,
                             "State": "Green",
                             "Type": "SysViewProcessor"
                         }
@@ -3132,6 +3242,7 @@
                                 "Usage": "number"
                             }
                         ],
+                        "RealNumberOfCpus": 128,
                         "Roles": "not-empty-array",
                         "StartTime": "not-zero-number-text",
                         "SystemState": "Green",
@@ -3142,7 +3253,7 @@
                     },
                     "Tablets": [
                         {
-                            "Count": 4,
+                            "Count": 3,
                             "State": "Green",
                             "Type": "Coordinator"
                         },
@@ -3152,12 +3263,12 @@
                             "Type": "Hive"
                         },
                         {
-                            "Count": 6,
+                            "Count": 3,
                             "State": "Green",
                             "Type": "Mediator"
                         },
                         {
-                            "Count": 2,
+                            "Count": 1,
                             "State": "Green",
                             "Type": "SchemeShard"
                         },
@@ -3167,7 +3278,7 @@
                             "Type": "StatisticsAggregator"
                         },
                         {
-                            "Count": 2,
+                            "Count": 1,
                             "State": "Green",
                             "Type": "SysViewProcessor"
                         }
@@ -4919,133 +5030,5 @@
     },
     "test.test_wait_for_cluster_ready": {
         "wait_good": true
-    },
-    "test.test_topic_data": {
-        "response_read": {
-            "Messages": [
-                {
-                    "Codec": 0, "StorageSize": 9, "SeqNo": 1, "Message": "bWVzc2FnZS0w", "OriginalSize": 9, "Offset": 0,
-                    "CreateTimestamp": "not-zero-number", "WriteTimestamp": "not-zero-number", "TimestampDiff": "not-zero-number", "ProducerId": "not-zero-number-text"
-                },
-                {
-                    "Codec": 0, "StorageSize": 9, "SeqNo": 2, "Message": "bWVzc2FnZS0x", "OriginalSize": 9, "Offset": 1,
-                    "CreateTimestamp": "not-zero-number", "WriteTimestamp": "not-zero-number", "TimestampDiff": "not-zero-number", "ProducerId": "not-zero-number-text"
-                },
-                {
-                    "Codec": 0, "StorageSize": 9, "SeqNo": 3, "Message": "bWVzc2FnZS0y", "OriginalSize": 9, "Offset": 2,
-                    "CreateTimestamp": "not-zero-number", "WriteTimestamp": "not-zero-number", "TimestampDiff": "not-zero-number", "ProducerId": "not-zero-number-text"
-                },
-                {
-                    "Codec": 0, "StorageSize": 9, "SeqNo": 4, "Message": "bWVzc2FnZS0z", "OriginalSize": 9, "Offset": 3,
-                    "CreateTimestamp": "not-zero-number", "WriteTimestamp": "not-zero-number", "TimestampDiff": "not-zero-number", "ProducerId": "not-zero-number-text"
-                },
-                {
-                    "Codec": 0, "StorageSize": 9, "SeqNo": 5, "Message": "bWVzc2FnZS00", "OriginalSize": 9, "Offset": 4,
-                    "CreateTimestamp": "not-zero-number", "WriteTimestamp": "not-zero-number", "TimestampDiff": "not-zero-number", "ProducerId": "not-zero-number-text"
-                }
-            ],
-            "StartOffset": 0,
-            "EndOffset": 21,
-            "Truncated": false
-        },
-        "response_truncated": {
-            "EndOffset": 21,
-            "Messages": [
-                {
-                    "Codec": 1,
-                    "CreateTimestamp": "not-zero-number",
-                    "Message": "Y29tcHI=",
-                    "Offset": 20,
-                    "OriginalSize": 20,
-                    "ProducerId": "not-zero-number-text",
-                    "SeqNo": 21,
-                    "StorageSize": 38,
-                    "TimestampDiff": "not-zero-number",
-                    "WriteTimestamp": "not-zero-number"
-                }
-            ],
-            "StartOffset": 0,
-            "Truncated": true
-        },
-        "response_last_offset": {
-            "Messages": [
-                {
-                    "Codec": 0, "StorageSize": 9, "SeqNo": 1, "Message": "bWVzc2FnZS0w", "OriginalSize": 9, "Offset": 0,
-                    "CreateTimestamp": "not-zero-number", "WriteTimestamp": "not-zero-number", "TimestampDiff": "not-zero-number", "ProducerId": "not-zero-number-text"
-                },
-                {
-                    "Codec": 0, "StorageSize": 9, "SeqNo": 2, "Message": "bWVzc2FnZS0x", "OriginalSize": 9, "Offset": 1,
-                    "CreateTimestamp": "not-zero-number", "WriteTimestamp": "not-zero-number", "TimestampDiff": "not-zero-number", "ProducerId": "not-zero-number-text"
-                },
-                {
-                    "Codec": 0, "StorageSize": 9, "SeqNo": 3, "Message": "bWVzc2FnZS0y", "OriginalSize": 9, "Offset": 2,
-                    "CreateTimestamp": "not-zero-number", "WriteTimestamp": "not-zero-number", "TimestampDiff": "not-zero-number", "ProducerId": "not-zero-number-text"
-                }
-            ],
-            "StartOffset": 0,
-            "EndOffset": 21,
-            "Truncated": false
-        },
-        "response_metadata": {
-            "Messages": [
-                {
-                    "Codec": 1, "StorageSize": 37, "SeqNo": 11,
-                    "MessageMetadata": [
-                        {"Value": "value1", "Key": "key1"},
-                        {"Value": "value2", "Key": "key2"}],
-                    "Message": "bWVzc2FnZV93aXRoX21ldGE=", "OriginalSize": 17, "Offset": 10,
-                    "CreateTimestamp": "not-zero-number", "WriteTimestamp": "not-zero-number", "TimestampDiff": "not-zero-number", "ProducerId": "not-zero-number-text"
-                }
-            ],
-            "StartOffset": 0,
-            "EndOffset": 21,
-            "Truncated": false
-        },
-        "response_compressed": {
-            "Messages": [
-                {
-                    "Codec": 1, "StorageSize": 38, "SeqNo": 12, "Message": "Y29tcHJlc3NlZC1tZXNzYWdlLTA=", "OriginalSize": 20, "Offset": 11,
-                    "CreateTimestamp": "not-zero-number", "WriteTimestamp": "not-zero-number", "TimestampDiff": "not-zero-number", "ProducerId": "not-zero-number-text"
-                },
-                {
-                    "Codec": 1, "StorageSize": 38, "SeqNo": 13, "Message": "Y29tcHJlc3NlZC1tZXNzYWdlLTE=", "OriginalSize": 20, "Offset": 12,
-                    "CreateTimestamp": "not-zero-number", "WriteTimestamp": "not-zero-number", "TimestampDiff": "not-zero-number", "ProducerId": "not-zero-number-text"
-                },
-                {
-                    "Codec": 1, "StorageSize": 38, "SeqNo": 14, "Message": "Y29tcHJlc3NlZC1tZXNzYWdlLTI=", "OriginalSize": 20, "Offset": 13,
-                    "CreateTimestamp": "not-zero-number", "WriteTimestamp": "not-zero-number", "TimestampDiff": "not-zero-number", "ProducerId": "not-zero-number-text"
-                },
-                {
-                    "Codec": 1, "StorageSize": 38, "SeqNo": 15, "Message": "Y29tcHJlc3NlZC1tZXNzYWdlLTM=", "OriginalSize": 20, "Offset": 14,
-                    "CreateTimestamp": "not-zero-number", "WriteTimestamp": "not-zero-number", "TimestampDiff": "not-zero-number", "ProducerId": "not-zero-number-text"
-                },
-                {
-                    "Codec": 1, "StorageSize": 38, "SeqNo": 16, "Message": "Y29tcHJlc3NlZC1tZXNzYWdlLTQ=", "OriginalSize": 20, "Offset": 15,
-                    "CreateTimestamp": "not-zero-number", "WriteTimestamp": "not-zero-number", "TimestampDiff": "not-zero-number", "ProducerId": "not-zero-number-text"
-                }
-            ],
-            "StartOffset": 0,
-            "EndOffset": 21,
-            "Truncated": false
-        },
-        "response_not_truncated": {
-            "Messages": [
-                {
-                    "Codec": 1, "StorageSize": 38, "SeqNo": 21, "Message": "Y29tcHJlc3NlZC1tZXNzYWdlLTk=",  "OriginalSize": 20, "Offset": 20,
-                    "CreateTimestamp": "not-zero-number", "WriteTimestamp": "not-zero-number", "TimestampDiff": "not-zero-number", "ProducerId": "not-zero-number-text"
-                }
-            ],
-            "StartOffset": 0,
-            "EndOffset": 21,
-            "Truncated": false
-        },
-        "no_partition": {
-            "status_code": 400,
-            "text": "Parameter 'partition' is necessary"
-        },
-        "both_offset_and_ts": {
-            "status_code": 400,
-            "text": "Only read_timestamp or offset parameter may be specified, not both"
-        }
     }
 }

--- a/ydb/core/viewer/viewer.cpp
+++ b/ydb/core/viewer/viewer.cpp
@@ -193,6 +193,7 @@ public:
                 }
             }
         }
+        Schedule(TDuration::Seconds(10), new TEvents::TEvWakeup());
     }
 
     const TKikimrRunConfig& GetKikimrRunConfig() const override {
@@ -384,11 +385,68 @@ private:
     ui32 CurrentMonitoringPort;
     TString CurrentWorkerName;
 
+    void Handle(TEvents::TEvWakeup::TPtr&) {
+        DeleteOldSharedCacheData();
+        Schedule(TDuration::Seconds(10), new TEvents::TEvWakeup());
+    }
+
+    std::unordered_map<TTabletId, TActorId> TabletPipes;
+
+    static NTabletPipe::TClientConfig GetPipeClientConfig() {
+        return {
+            .RetryPolicy = NTabletPipe::TClientRetryPolicy::WithRetries()
+        };
+    }
+
+    void Handle(TEvTabletPipe::TEvClientConnected::TPtr& ev) {
+        if (ev->Get()->Status != NKikimrProto::OK) {
+            TabletPipes.erase(ev->Get()->TabletId);
+        }
+    }
+
+    void Handle(TEvTabletPipe::TEvClientDestroyed::TPtr& ev) {
+        TabletPipes.erase(ev->Get()->TabletId);
+    }
+
+    void Handle(TEvViewer::TEvUpdateSharedCacheTabletRequest::TPtr& ev) {
+        auto itPipe = TabletPipes.find(ev->Get()->TabletId);
+        if (itPipe == TabletPipes.end()) {
+            auto pipe = NTabletPipe::CreateClient(SelfId(), ev->Get()->TabletId, GetPipeClientConfig());
+            itPipe = TabletPipes.emplace(ev->Get()->TabletId, RegisterWithSameMailbox(pipe)).first;
+        }
+        NTabletPipe::SendData(SelfId(), itPipe->second, ev->Get()->Request.release());
+    }
+
+    void Handle(TEvViewer::TEvUpdateSharedCacheTabletResponse::TPtr& ev) {
+        UpdateSharedCacheData(std::unique_ptr<TEvViewer::TEvUpdateSharedCacheTabletResponse>(ev->Release().Release()));
+    }
+
+    template<typename TEvent>
+    void HandleForUpdateSharedCacheData(TAutoPtr<TEventHandle<TEvent>>& ev) {
+        UpdateSharedCacheData(std::make_unique<TEvViewer::TEvUpdateSharedCacheTabletResponse>(std::shared_ptr<TEvent>(ev->Release().Release())));
+    }
+
+    void PassAway() override {
+        for (const auto& [tabletId, pipe] : TabletPipes) {
+            NTabletPipe::CloseClient(SelfId(), pipe);
+        }
+    }
+
     STFUNC(StateWork) {
         switch (ev->GetTypeRewrite()) {
             HFunc(NMon::TEvHttpInfo, Handle);
             hFunc(NHttp::TEvHttpProxy::TEvHttpIncomingRequest, Handle);
             hFunc(TEvViewer::TEvViewerRequest, Handle);
+            hFunc(TEvViewer::TEvUpdateSharedCacheTabletRequest, Handle);
+            hFunc(TEvViewer::TEvUpdateSharedCacheTabletResponse, Handle);
+            hFunc(TEvTabletPipe::TEvClientConnected, Handle);
+            hFunc(TEvTabletPipe::TEvClientDestroyed, Handle);
+            hFunc(NSysView::TEvSysView::TEvGetStoragePoolsResponse, HandleForUpdateSharedCacheData);
+            hFunc(NSysView::TEvSysView::TEvGetGroupsResponse, HandleForUpdateSharedCacheData);
+            hFunc(NSysView::TEvSysView::TEvGetVSlotsResponse, HandleForUpdateSharedCacheData);
+            hFunc(NSysView::TEvSysView::TEvGetPDisksResponse, HandleForUpdateSharedCacheData);
+            hFunc(NSysView::TEvSysView::TEvGetStorageStatsResponse, HandleForUpdateSharedCacheData);
+            hFunc(TEvents::TEvWakeup, Handle);
         }
     }
 

--- a/ydb/core/viewer/viewer.cpp
+++ b/ydb/core/viewer/viewer.cpp
@@ -727,11 +727,16 @@ IActor* CreateViewer(const TKikimrRunConfig& kikimrRunConfig) {
 }
 
 void TViewer::FillCORS(TStringBuilder& stream, const TRequestState& request) {
+    TString requestOrigin = request && request.HasHeader("Origin") ? request.GetHeader("Origin") : TString();
     TString origin;
     if (AllowOrigin) {
-        origin = AllowOrigin;
-    } else if (request && request.HasHeader("Origin")) {
-        origin = request.GetHeader("Origin");
+        if (IsMatchesWildcards(requestOrigin, AllowOrigin)) {
+            origin = requestOrigin;
+        } else {
+            return; // no CORS headers - no access
+        }
+    } else if (requestOrigin) {
+        origin = requestOrigin;
     }
     if (origin.empty()) {
         origin = "*";

--- a/ydb/core/viewer/viewer.h
+++ b/ydb/core/viewer/viewer.h
@@ -3,6 +3,7 @@
 #include <ydb/core/tablet/defs.h>
 #include <ydb/core/viewer/json/json.h>
 #include <ydb/core/viewer/protos/viewer.pb.h>
+#include <ydb/core/sys_view/common/events.h>
 #include <ydb/library/actors/core/actor.h>
 #include <ydb/library/actors/core/defs.h>
 #include <ydb/library/actors/core/event.h>
@@ -10,6 +11,8 @@
 #include <ydb-cpp-sdk/client/types/status/status.h>
 
 namespace NKikimr::NViewer {
+
+using TTabletId = ui64;
 
 inline TActorId MakeViewerID(ui32 node) {
     char x[12] = {'v','i','e','w','e','r'};
@@ -21,7 +24,8 @@ struct TEvViewer {
         // requests
         EvViewerRequest = EventSpaceBegin(TKikimrEvents::ES_VIEWER),
         EvViewerResponse,
-
+        EvUpdateSharedCacheTabletRequest,
+        EvUpdateSharedCacheTabletResponse,
         EvEnd
     };
 
@@ -33,6 +37,45 @@ struct TEvViewer {
 
     struct TEvViewerResponse : TEventPB<TEvViewerResponse, NKikimrViewer::TEvViewerResponse, EvViewerResponse> {
         TEvViewerResponse() = default;
+    };
+
+    struct TEvUpdateSharedCacheTabletRequest : TEventLocal<TEvUpdateSharedCacheTabletRequest, EvUpdateSharedCacheTabletRequest> {
+        TTabletId TabletId;
+        std::unique_ptr<IEventBase> Request;
+
+        TEvUpdateSharedCacheTabletRequest(TTabletId tabletId, std::unique_ptr<IEventBase> request)
+            : TabletId(tabletId)
+            , Request(std::move(request))
+        {}
+    };
+
+    struct TEvUpdateSharedCacheTabletResponse : TEventLocal<TEvUpdateSharedCacheTabletResponse, EvUpdateSharedCacheTabletResponse> {
+        std::variant<
+            std::shared_ptr<NSysView::TEvSysView::TEvGetGroupsResponse>,
+            std::shared_ptr<NSysView::TEvSysView::TEvGetStoragePoolsResponse>,
+            std::shared_ptr<NSysView::TEvSysView::TEvGetVSlotsResponse>,
+            std::shared_ptr<NSysView::TEvSysView::TEvGetPDisksResponse>,
+            std::shared_ptr<NSysView::TEvSysView::TEvGetStorageStatsResponse>> Response;
+
+        TEvUpdateSharedCacheTabletResponse(std::shared_ptr<NSysView::TEvSysView::TEvGetGroupsResponse> response)
+            : Response(std::move(response))
+        {}
+
+        TEvUpdateSharedCacheTabletResponse(std::shared_ptr<NSysView::TEvSysView::TEvGetStoragePoolsResponse> response)
+            : Response(std::move(response))
+        {}
+
+        TEvUpdateSharedCacheTabletResponse(std::shared_ptr<NSysView::TEvSysView::TEvGetVSlotsResponse> response)
+            : Response(std::move(response))
+        {}
+
+        TEvUpdateSharedCacheTabletResponse(std::shared_ptr<NSysView::TEvSysView::TEvGetPDisksResponse> response)
+            : Response(std::move(response))
+        {}
+
+        TEvUpdateSharedCacheTabletResponse(std::shared_ptr<NSysView::TEvSysView::TEvGetStorageStatsResponse> response)
+            : Response(std::move(response))
+        {}
     };
 };
 
@@ -137,6 +180,8 @@ struct TRequestState {
         return Request.index() != 0;
     }
 };
+
+struct TViewerSharedCacheState;
 
 class IViewer {
 public:
@@ -262,6 +307,11 @@ public:
 
     virtual NJson::TJsonValue GetCapabilities() = 0;
     virtual int GetCapabilityVersion(const TString& name) = 0;
+
+    void UpdateSharedCacheData(std::unique_ptr<TEvViewer::TEvUpdateSharedCacheTabletResponse> ev);
+    void DeleteOldSharedCacheData();
+    std::shared_ptr<TViewerSharedCacheState> CreateSharedCacheState();
+    std::shared_ptr<TViewerSharedCacheState> SharedCacheState = CreateSharedCacheState();
 };
 
 void SetupPQVirtualHandlers(IViewer* viewer);

--- a/ydb/core/viewer/viewer_capabilities.h
+++ b/ydb/core/viewer/viewer_capabilities.h
@@ -23,10 +23,21 @@ public:
 
     NJson::TJsonValue GetSettings() {
         NJson::TJsonValue json;
+
         NJson::TJsonValue& security(json["Security"]);
         security["IsTokenRequired"] = AppData()->EnforceUserTokenRequirement;
         security["UseLoginProvider"] = AppData()->AuthConfig.GetUseLoginProvider();
         security["DomainLoginOnly"] = AppData()->AuthConfig.GetDomainLoginOnly();
+
+        if (DatabaseNavigateResponse && DatabaseNavigateResponse->IsOk()) {
+            if (DatabaseNavigateResponse->Get()->Request && !DatabaseNavigateResponse->Get()->Request->ResultSet.empty()) {
+                NJson::TJsonValue& database(json["Database"]);
+                TSchemeCacheNavigate::TEntry& entry = DatabaseNavigateResponse->Get()->Request->ResultSet.front();
+                if (entry.DomainInfo) {
+                    database["GraphShardExists"] = entry.DomainInfo->Params.GetGraphShard() != 0;
+                }
+            }
+        }
         return json;
     }
 

--- a/ydb/core/viewer/viewer_cluster.h
+++ b/ydb/core/viewer/viewer_cluster.h
@@ -106,8 +106,8 @@ public:
     void Bootstrap() override {
         NodesInfoResponse = MakeRequest<TEvInterconnect::TEvNodesInfo>(GetNameserviceActorId(), new TEvInterconnect::TEvListNodes());
         NodeStateResponse = MakeWhiteboardRequest(TActivationContext::ActorSystem()->NodeId, new TEvWhiteboard::TEvNodeStateRequest());
-        PDisksResponse = RequestBSControllerPDisks();
-        StorageStatsResponse = RequestBSControllerStorageStats();
+        PDisksResponse = MakeCachedRequestBSControllerPDisks();
+        StorageStatsResponse = MakeCachedRequestBSControllerStorageStats();
         ListTenantsResponse = MakeRequestConsoleListTenants();
         if (AppData()->DomainsInfo && AppData()->DomainsInfo->Domain) {
             TIntrusivePtr<TDomainsInfo> domains = AppData()->DomainsInfo;
@@ -832,6 +832,9 @@ private:
         }
         for (const auto& [type, size] : ClusterInfo.GetMapStorageUsed()) {
             ClusterInfo.SetStorageUsed(ClusterInfo.GetStorageUsed() + size);
+        }
+        if (CachedDataMaxAge) {
+            ClusterInfo.SetCachedDataMaxAge(CachedDataMaxAge.MilliSeconds());
         }
         NKikimrWhiteboard::EFlag worstState = NKikimrWhiteboard::EFlag::Grey;
         ui64 worstNodes = 0;

--- a/ydb/core/viewer/viewer_cluster.h
+++ b/ydb/core/viewer/viewer_cluster.h
@@ -346,6 +346,7 @@ private:
         request->AddFieldsRequired(NKikimrWhiteboard::TSystemStateInfo::kCoresTotalFieldNumber);
         request->AddFieldsRequired(NKikimrWhiteboard::TSystemStateInfo::kNetworkUtilizationFieldNumber);
         request->AddFieldsRequired(NKikimrWhiteboard::TSystemStateInfo::kNetworkWriteThroughputFieldNumber);
+        request->AddFieldsRequired(NKikimrWhiteboard::TSystemStateInfo::kRealNumberOfCpusFieldNumber);
     }
 
     void InitTabletWhiteboardRequest(NKikimrWhiteboard::TEvTabletStateRequest* request) {

--- a/ydb/core/viewer/viewer_compute.h
+++ b/ydb/core/viewer/viewer_compute.h
@@ -160,7 +160,7 @@ public:
             RequestSchemeCacheNavigate(DomainPath);
         }
         RootHiveId = domains->GetHive();
-        if (Requests == 0) {
+        if (!WaitingForResponse()) {
             ReplyAndPassAway();
         }
 

--- a/ydb/core/viewer/viewer_describe.h
+++ b/ydb/core/viewer/viewer_describe.h
@@ -15,13 +15,10 @@ class TJsonDescribe : public TViewerPipeClient {
     using TThis = TJsonDescribe;
     using TBase = TViewerPipeClient;
     using TBase::ReplyAndPassAway;
-    TAutoPtr<TEvSchemeShard::TEvDescribeSchemeResult> SchemeShardResult;
-    TAutoPtr<TEvTxProxySchemeCache::TEvNavigateKeySetResult> CacheResult;
+    TRequestResponse<TEvSchemeShard::TEvDescribeSchemeResult> SchemeShardResult;
+    TRequestResponse<TEvTxProxySchemeCache::TEvNavigateKeySetResult> CacheResult;
     TAutoPtr<NKikimrViewer::TEvDescribeSchemeInfo> DescribeResult;
-    TJsonSettings JsonSettings;
-    ui32 Timeout = 0;
     bool ExpandSubElements = true;
-    int Requests = 0;
 
 public:
     TJsonDescribe(IViewer* viewer, NMon::TEvHttpInfo::TPtr& ev)
@@ -51,38 +48,36 @@ public:
         if (NeedToRedirect()) {
             return;
         }
-        const auto& params(Event->Get()->Request.GetParams());
-        JsonSettings.EnumAsNumbers = !FromStringWithDefault<bool>(params.Get("enums"), false);
-        JsonSettings.UI64AsString = !FromStringWithDefault<bool>(params.Get("ui64"), false);
-        Timeout = FromStringWithDefault<ui32>(params.Get("timeout"), 10000);
-        ExpandSubElements = FromStringWithDefault<ui32>(params.Get("subs"), ExpandSubElements);
-        InitConfig(params);
-
-        if (params.Has("schemeshard_id")) {
+        // for describe we keep old behavior where enums is false by default - for compatibility reasons
+        if (FromStringWithDefault<bool>(Params.Get("enums"), false)) {
+            Proto2JsonConfig.EnumMode = TProto2JsonConfig::EnumValueMode::EnumName;
+        } else {
+            Proto2JsonConfig.EnumMode = TProto2JsonConfig::EnumValueMode::EnumNumber;
+        }
+        ExpandSubElements = FromStringWithDefault<ui32>(Params.Get("subs"), ExpandSubElements);
+        if (Params.Has("schemeshard_id")) {
             THolder<TEvSchemeShard::TEvDescribeScheme> request = MakeHolder<TEvSchemeShard::TEvDescribeScheme>();
-            FillParams(&request->Record, params);
-            ui64 schemeShardId = FromStringWithDefault<ui64>(params.Get("schemeshard_id"));
-            SendRequestToPipe(ConnectTabletPipe(schemeShardId), request.Release());
+            FillParams(&request->Record, Params);
+            ui64 schemeShardId = FromStringWithDefault<ui64>(Params.Get("schemeshard_id"));
+            SchemeShardResult = MakeRequestToTablet<TEvSchemeShard::TEvDescribeSchemeResult>(schemeShardId, request.Release());
         } else {
             THolder<TEvTxUserProxy::TEvNavigate> request = MakeHolder<TEvTxUserProxy::TEvNavigate>();
-            FillParams(request->Record.MutableDescribePath(), params);
+            FillParams(request->Record.MutableDescribePath(), Params);
             request->Record.SetUserToken(Event->Get()->UserToken);
-            SendRequest(MakeTxProxyID(), request.Release());
+            SchemeShardResult = MakeRequest<TEvSchemeShard::TEvDescribeSchemeResult>(MakeTxProxyID(), request.Release());
         }
-        ++Requests;
 
-        if (params.Has("path")) {
+        if (Params.Has("path")) {
             TAutoPtr<NSchemeCache::TSchemeCacheNavigate> request(new NSchemeCache::TSchemeCacheNavigate());
             NSchemeCache::TSchemeCacheNavigate::TEntry entry;
             entry.Operation = NSchemeCache::TSchemeCacheNavigate::OpList;
             entry.SyncVersion = false;
-            entry.Path = SplitPath(params.Get("path"));
+            entry.Path = SplitPath(Params.Get("path"));
             request->ResultSet.emplace_back(entry);
-            SendRequest(MakeSchemeCacheID(), new TEvTxProxySchemeCache::TEvNavigateKeySet(request));
-            ++Requests;
+            CacheResult = MakeRequest<TEvTxProxySchemeCache::TEvNavigateKeySetResult>(MakeSchemeCacheID(), new TEvTxProxySchemeCache::TEvNavigateKeySet(request));
         }
 
-        Become(&TThis::StateRequestedDescribe, TDuration::MilliSeconds(Timeout), new TEvents::TEvWakeup());
+        Become(&TThis::StateRequestedDescribe, Timeout, new TEvents::TEvWakeup());
     }
 
     STATEFN(StateRequestedDescribe) {
@@ -95,27 +90,13 @@ public:
     }
 
     void Handle(TEvSchemeShard::TEvDescribeSchemeResult::TPtr& ev) {
-        SchemeShardResult = ev->Release();
-        if (SchemeShardResult->GetRecord().GetStatus() == NKikimrScheme::EStatus::StatusSuccess) {
-            ReplyAndPassAway();
-        } else {
-            RequestDone("TEvDescribeSchemeResult");
-        }
+        SchemeShardResult.Set(std::move(ev));
+        RequestDone();
     }
 
-    void Handle(TEvTxProxySchemeCache::TEvNavigateKeySetResult::TPtr &ev) {
-        CacheResult = ev->Release();
-        RequestDone("TEvNavigateKeySetResult");
-    }
-
-    void RequestDone(const char* name) {
-        --Requests;
-        if (Requests == 0) {
-            ReplyAndPassAway();
-        }
-        if (Requests < 0) {
-            BLOG_CRIT("Requests < 0 in RequestDone(" << name << ")");
-        }
+    void Handle(TEvTxProxySchemeCache::TEvNavigateKeySetResult::TPtr& ev) {
+        CacheResult.Set(std::move(ev));
+        RequestDone();
     }
 
     void FillDescription(NKikimrSchemeOp::TDirEntry* descr, ui64 schemeShardId) {
@@ -242,10 +223,10 @@ public:
     }
 
     void ReplyAndPassAway() override {
-        TStringStream json;
-        if (SchemeShardResult != nullptr && SchemeShardResult->GetRecord().GetStatus() == NKikimrScheme::EStatus::StatusSuccess) {
+        NJson::TJsonValue json;
+        if (SchemeShardResult.IsOk()) {
             DescribeResult = GetSchemeShardDescribeSchemeInfo();
-        } else if (CacheResult != nullptr) {
+        } else if (CacheResult.IsOk()) {
             NSchemeCache::TSchemeCacheNavigate *navigate = CacheResult->Request.Get();
             Y_ABORT_UNLESS(navigate->ResultSet.size() == 1);
             if (navigate->ErrorCount == 0) {
@@ -282,8 +263,7 @@ public:
             const auto *descriptor = NKikimrScheme::EStatus_descriptor();
             auto accessDeniedStatus = descriptor->FindValueByNumber(NKikimrScheme::StatusAccessDenied)->name();
             if (DescribeResult->GetStatus() == accessDeniedStatus) {
-                Send(Event->Sender, new NMon::TEvHttpInfoRes(Viewer->GetHTTPFORBIDDEN(Event->Get()), 0, NMon::IEvHttpInfoRes::EContentType::Custom));
-                PassAway();
+                ReplyAndPassAway(GetHTTPFORBIDDEN("text/plain", "Forbidden"));
                 return;
             }
             for (auto& child : *DescribeResult->MutablePathDescription()->MutableChildren()) {
@@ -294,16 +274,14 @@ public:
                     child.ClearParentPathId();
                 }
             }
-            TProtoToJson::ProtoToJson(json, *DescribeResult, JsonSettings);
+            Proto2Json(*DescribeResult, json);
             DecodeExternalTableContent(json);
-        } else {
-            json << "null";
         }
 
-        ReplyAndPassAway(GetHTTPOKJSON(json.Str()));
+        ReplyAndPassAway(GetHTTPOKJSON(json));
     }
 
-    void DecodeExternalTableContent(TStringStream& json) const {
+    void DecodeExternalTableContent(NJson::TJsonValue& json) const {
         if (!DescribeResult) {
             return;
         }
@@ -317,12 +295,10 @@ public:
             return;
         }
 
-        NExternalSource::IExternalSourceFactory::TPtr externalSourceFactory{NExternalSource::CreateExternalSourceFactory({})};
-        NJson::TJsonValue root;
+        NExternalSource::IExternalSourceFactory::TPtr externalSourceFactory{NExternalSource::CreateExternalSourceFactory({}, nullptr, 50000, nullptr, false, false, NYql::GetAllExternalDataSourceTypes())};
         const auto& sourceType = DescribeResult->GetPathDescription().GetExternalTableDescription().GetSourceType();
         try {
-            NJson::ReadJsonTree(json.Str(), &root);
-            root["PathDescription"]["ExternalTableDescription"].EraseValue("Content");
+            json["PathDescription"]["ExternalTableDescription"].EraseValue("Content");
             auto source = externalSourceFactory->GetOrCreate(sourceType);
             auto parameters = source->GetParameters(content);
             for (const auto& [key, items]: parameters) {
@@ -330,17 +306,11 @@ public:
                 for (const auto& item: items) {
                     array.AppendValue(item);
                 }
-                root["PathDescription"]["ExternalTableDescription"]["Content"][key] = array;
+                json["PathDescription"]["ExternalTableDescription"]["Content"][key] = array;
             }
         } catch (...) {
             BLOG_CRIT("Сan't unpack content for external table: " << sourceType << ", error: " << CurrentExceptionMessage());
         }
-        json.Clear();
-        json << root;
-    }
-
-    void HandleTimeout() {
-        ReplyAndPassAway(GetHTTPGATEWAYTIMEOUT());
     }
 
     static YAML::Node GetSwagger() {
@@ -369,6 +339,7 @@ public:
             .Name = "enums",
             .Description = "convert enums to strings",
             .Type = "boolean",
+            .Default = "false",
         });
         yaml.AddParameter({
             .Name = "ui64",

--- a/ydb/core/viewer/viewer_describe.h
+++ b/ydb/core/viewer/viewer_describe.h
@@ -295,7 +295,7 @@ public:
             return;
         }
 
-        NExternalSource::IExternalSourceFactory::TPtr externalSourceFactory{NExternalSource::CreateExternalSourceFactory({}, nullptr, 50000, nullptr, false, false, NYql::GetAllExternalDataSourceTypes())};
+        NExternalSource::IExternalSourceFactory::TPtr externalSourceFactory{NExternalSource::CreateExternalSourceFactory({})};
         const auto& sourceType = DescribeResult->GetPathDescription().GetExternalTableDescription().GetSourceType();
         try {
             json["PathDescription"]["ExternalTableDescription"].EraseValue("Content");

--- a/ydb/core/viewer/viewer_nodes.h
+++ b/ydb/core/viewer/viewer_nodes.h
@@ -2135,6 +2135,7 @@ public:
             request->MutableFieldsRequired()->CopyFrom(GetDefaultWhiteboardFields<NKikimrWhiteboard::TSystemStateInfo>());
             request->AddFieldsRequired(NKikimrWhiteboard::TSystemStateInfo::kCoresUsedFieldNumber);
             request->AddFieldsRequired(NKikimrWhiteboard::TSystemStateInfo::kCoresTotalFieldNumber);
+            request->AddFieldsRequired(NKikimrWhiteboard::TSystemStateInfo::kRealNumberOfCpusFieldNumber);
             if (FieldsRequired.test(+ENodeFields::MemoryDetailed)) {
                 request->AddFieldsRequired(NKikimrWhiteboard::TSystemStateInfo::kMemoryStatsFieldNumber);
             }

--- a/ydb/core/viewer/viewer_query.h
+++ b/ydb/core/viewer/viewer_query.h
@@ -472,17 +472,7 @@ private:
                     if (valueParser.IsNull()) {
                         jsonOptional = NJson::JSON_NULL;
                     } else {
-                        switch(valueParser.GetKind()) {
-                            case NYdb::TTypeParser::ETypeKind::Primitive:
-                                jsonOptional = ColumnPrimitiveValueToJsonValue(valueParser);
-                                break;
-                            case NYdb::TTypeParser::ETypeKind::Decimal:
-                                jsonOptional = valueParser.GetDecimal().ToString();
-                                break;
-                            default:
-                                jsonOptional = NJson::JSON_UNDEFINED;
-                                break;
-                        }
+                        jsonOptional = ColumnValueToJsonValue(valueParser);
                     }
                     valueParser.CloseOptional();
                     return jsonOptional;

--- a/ydb/core/viewer/viewer_query_old.h
+++ b/ydb/core/viewer/viewer_query_old.h
@@ -230,7 +230,7 @@ public:
             RequestStateStorageEndpointsLookup(Database); // to find some dynamic node and redirect query there
         }
 
-        if (Requests == 0) {
+        if (!WaitingForResponse()) {
             SendKpqProxyRequest();
         }
         Become(&TThis::StateWork, TDuration::MilliSeconds(Timeout), new TEvents::TEvWakeup());

--- a/ydb/core/viewer/viewer_tabletinfo.h
+++ b/ydb/core/viewer/viewer_tabletinfo.h
@@ -72,7 +72,7 @@ class TJsonTabletInfo : public TJsonWhiteboardRequest<TEvWhiteboard::TEvTabletSt
     using TThis = TJsonTabletInfo;
     THashMap<ui64, NKikimrTabletBase::TTabletTypes::EType> Tablets;
     std::unordered_map<ui64, TString> EndOfRangeKeyPrefix;
-    TTabletId HiveId;
+    TTabletId HiveId = 0;
     bool IsBase64Encode = true;
     NKikimr::TSubDomainKey FilterTenantId;
 
@@ -315,6 +315,8 @@ public:
                     if (domainDescription.GetProcessingParams().HasHive()) {
                         Tablets[pathDescription.GetDomainDescription().GetProcessingParams().GetHive()] = NKikimrTabletBase::TTabletTypes::Hive;
                         HiveId = domainDescription.GetProcessingParams().GetHive();
+                    } else {
+                        HiveId = domainDescription.GetSharedHive();
                     }
                     if (domainDescription.GetProcessingParams().HasGraphShard()) {
                         Tablets[pathDescription.GetDomainDescription().GetProcessingParams().GetGraphShard()] = NKikimrTabletBase::TTabletTypes::GraphShard;
@@ -383,6 +385,9 @@ public:
                     deadTablet->SetState(NKikimrWhiteboard::TTabletStateInfo::Dead);
                     deadTablet->SetType(tablet.second);
                     deadTablet->SetHiveId(HiveId);
+                    if (FilterTenantId) {
+                        deadTablet->MutableTenantId()->CopyFrom(FilterTenantId);
+                    }
                 }
             }
             result.SetResponseTime(response.GetResponseTime());

--- a/ydb/core/viewer/viewer_tabletinfo.h
+++ b/ydb/core/viewer/viewer_tabletinfo.h
@@ -123,7 +123,11 @@ public:
         if (params.Has("path")) {
             TBase::RequestSettings.Timeout = FromStringWithDefault<ui32>(params.Get("timeout"), 10000);
             IsBase64Encode = FromStringWithDefault<bool>(params.Get("base64"), IsBase64Encode);
-            RequestTxProxyDescribe(params.Get("path"));
+            NKikimrSchemeOp::TDescribeOptions options;
+            options.SetReturnBoundaries(true);
+            options.SetReturnIndexTableBoundaries(true);
+            options.SetShowPrivateTable(true);
+            RequestTxProxyDescribe(params.Get("path"), options);
             Become(&TThis::StateRequestedDescribe, TDuration::MilliSeconds(TBase::RequestSettings.Timeout), new TEvents::TEvWakeup());
         } else {
             TBase::Bootstrap();

--- a/ydb/core/viewer/viewer_tenantinfo.h
+++ b/ydb/core/viewer/viewer_tenantinfo.h
@@ -22,6 +22,8 @@ class TJsonTenantInfo : public TViewerPipeClient {
     std::optional<TRequestResponse<NConsole::TEvConsole::TEvListTenantsResponse>> ListTenantsResponse;
     std::unordered_map<TString, TRequestResponse<NConsole::TEvConsole::TEvGetTenantStatusResponse>> TenantStatusResponses;
     std::unordered_map<TString, TRequestResponse<TEvTxProxySchemeCache::TEvNavigateKeySetResult>> NavigateKeySetResult;
+    std::unordered_map<TString, TRequestResponse<NSchemeShard::TEvSchemeShard::TEvDescribeSchemeResult>> DescribeSchemeResult;
+    std::unordered_map<TTabletId, std::vector<TString>> DescribesBySchemeShard;
     std::unordered_map<TTabletId, TRequestResponse<TEvHive::TEvResponseHiveDomainStats>> HiveDomainStats;
     std::unordered_map<TTabletId, TRequestResponse<TEvHive::TEvResponseHiveStorageStats>> HiveStorageStats;
     std::unordered_map<TNodeId, TRequestResponse<TEvWhiteboard::TEvSystemStateResponse>> SystemStateResponse;
@@ -52,6 +54,7 @@ class TJsonTenantInfo : public TViewerPipeClient {
     bool MetadataCache = true;
     THashMap<TString, std::vector<TNodeId>> TenantNodes;
     TTabletId RootHiveId = 0;
+    TTabletId RootSchemeShardId = 0;
     TString RootId; // id of root domain (tenant)
     NKikimrViewer::TTenantInfo Result;
 
@@ -97,6 +100,15 @@ public:
         }
     }
 
+    TRequestResponse<NSchemeShard::TEvSchemeShard::TEvDescribeSchemeResult> MakeRequestSchemeShardDescribe(TTabletId schemeShardId, const TString& path) {
+        NKikimrSchemeOp::TDescribeOptions options;
+        options.SetReturnPartitioningInfo(false);
+        options.SetReturnPartitionConfig(false);
+        options.SetReturnChildren(false);
+        options.SetReturnRangeKey(false);
+        return TBase::MakeRequestSchemeShardDescribe(schemeShardId, path, options);
+    }
+
     void Bootstrap() override {
         if (NeedToRedirect()) {
             return;
@@ -120,6 +132,7 @@ public:
         TIntrusivePtr<TDomainsInfo> domains = AppData()->DomainsInfo;
         auto* domain = domains->GetDomain();
         DomainPath = "/" + domain->Name;
+        RootSchemeShardId = domain->SchemeRoot;
         TPathId rootPathId(domain->SchemeRoot, 1);
         RootId = GetDomainId(rootPathId);
         RootHiveId = domains->GetHive();
@@ -146,6 +159,8 @@ public:
         HiveDomainStats[RootHiveId] = MakeRequestHiveDomainStats(RootHiveId);
         if (Storage) {
             HiveStorageStats[RootHiveId] = MakeRequestHiveStorageStats(RootHiveId);
+            DescribeSchemeResult[DomainPath] = MakeRequestSchemeShardDescribe(RootSchemeShardId, DomainPath);
+            DescribesBySchemeShard[RootSchemeShardId].emplace_back(DomainPath);
         }
 
         Become(&TThis::StateCollectingInfo, TDuration::MilliSeconds(Timeout), new TEvents::TEvWakeup());
@@ -175,6 +190,7 @@ public:
             hFunc(TEvTabletPipe::TEvClientConnected, Handle);
             hFunc(TEvStateStorage::TEvBoardInfo, Handle);
             hFunc(NHealthCheck::TEvSelfCheckResultProto, Handle);
+            hFunc(TEvSchemeShard::TEvDescribeSchemeResult, Handle);
             cFunc(TEvents::TSystem::Wakeup, HandleTimeout);
         }
     }
@@ -200,6 +216,12 @@ public:
                 auto it = HiveStorageStats.find(ev->Get()->TabletId);
                 if (it != HiveStorageStats.end()) {
                     it->second.Error(error);
+                }
+            }
+            auto itDescribes = DescribesBySchemeShard.find(ev->Get()->TabletId);
+            if (itDescribes != DescribesBySchemeShard.end()) {
+                for (const TString& path : itDescribes->second) {
+                    DescribeSchemeResult[path].Error(error);
                 }
             }
         }
@@ -397,14 +419,19 @@ public:
             if (result.IsOk()) {
                 auto domainInfo = result.Get()->Request->ResultSet.begin()->DomainInfo;
                 TTabletId hiveId = domainInfo->Params.GetHive();
+                TTabletId schemeShardId = domainInfo->Params.GetSchemeShard();
                 if (hiveId) {
                     if (HiveDomainStats.count(hiveId) == 0) {
                         HiveDomainStats[hiveId] = MakeRequestHiveDomainStats(hiveId);
                     }
-                    if (Storage) {
-                        if (HiveStorageStats.count(hiveId) == 0) {
-                            HiveStorageStats[hiveId] = MakeRequestHiveStorageStats(hiveId);
-                        }
+                }
+                if (Storage) {
+                    if (hiveId && HiveStorageStats.count(hiveId) == 0) {
+                        HiveStorageStats[hiveId] = MakeRequestHiveStorageStats(hiveId);
+                    }
+                    if (schemeShardId && DescribeSchemeResult.count(path) == 0) {
+                        DescribeSchemeResult[path] = MakeRequestSchemeShardDescribe(schemeShardId, path);
+                        DescribesBySchemeShard[schemeShardId].emplace_back(path);
                     }
                 }
                 NKikimrViewer::TTenant& tenant = TenantBySubDomainKey[domainInfo->DomainKey];
@@ -420,6 +447,13 @@ public:
                     tenant.SetType(NKikimrViewer::Dedicated);
                 }
             }
+            RequestDone();
+        }
+    }
+
+    void Handle(NSchemeShard::TEvSchemeShard::TEvDescribeSchemeResult::TPtr& ev) {
+        TString path = ev->Get()->GetRecord().GetPath();
+        if (DescribeSchemeResult[path].Set(std::move(ev))) {
             RequestDone();
         }
     }
@@ -745,7 +779,6 @@ public:
                         }
                     }
 
-                    THashMap<NKikimrViewer::TStorageUsage::EType, ui64> tablesStorageByType;
                     THashMap<NKikimrViewer::TStorageUsage::EType, TStorageQuota> storageQuotasByType;
 
                     for (const auto& quota : tenant.GetDatabaseQuotas().storage_quotas()) {
@@ -755,42 +788,47 @@ public:
                         usage.HardQuota += quota.data_size_hard_quota();
                     }
 
-                    if (entry.DomainDescription) {
-                        for (const auto& poolUsage : entry.DomainDescription->Description.GetDiskSpaceUsage().GetStoragePoolsUsage()) {
+                    auto itDescribeScheme = DescribeSchemeResult.find(name);
+                    if (itDescribeScheme != DescribeSchemeResult.end() && itDescribeScheme->second.IsOk()) {
+                        const auto& record = itDescribeScheme->second.Get()->GetRecord();
+                        const auto& domainDescription(record.GetPathDescription().GetDomainDescription());
+                        THashMap<NKikimrViewer::TStorageUsage::EType, ui64> tablesStorageByType;
+
+                        for (const auto& poolUsage : domainDescription.GetDiskSpaceUsage().GetStoragePoolsUsage()) {
                             auto type = GetStorageType(poolUsage.GetPoolKind());
                             tablesStorageByType[type] += poolUsage.GetTotalSize();
                         }
 
-                        if (tablesStorageByType.empty() && entry.DomainDescription->Description.HasDiskSpaceUsage()) {
-                            tablesStorageByType[GuessStorageType(entry.DomainDescription->Description)] =
-                                entry.DomainDescription->Description.GetDiskSpaceUsage().GetTables().GetTotalSize()
-                                + entry.DomainDescription->Description.GetDiskSpaceUsage().GetTopics().GetDataSize();
+                        if (tablesStorageByType.empty() && domainDescription.HasDiskSpaceUsage()) {
+                            tablesStorageByType[GuessStorageType(domainDescription)] =
+                            domainDescription.GetDiskSpaceUsage().GetTables().GetTotalSize()
+                                + domainDescription.GetDiskSpaceUsage().GetTopics().GetDataSize();
                         }
 
                         if (storageQuotasByType.empty()) {
-                            auto& quotas = storageQuotasByType[GuessStorageType(entry.DomainDescription->Description)];
-                            quotas.HardQuota = entry.DomainDescription->Description.GetDatabaseQuotas().data_size_hard_quota();
-                            quotas.SoftQuota = entry.DomainDescription->Description.GetDatabaseQuotas().data_size_soft_quota();
+                            auto& quotas = storageQuotasByType[GuessStorageType(domainDescription)];
+                            quotas.HardQuota = domainDescription.GetDatabaseQuotas().data_size_hard_quota();
+                            quotas.SoftQuota = domainDescription.GetDatabaseQuotas().data_size_soft_quota();
                         }
-                    }
 
-                    for (const auto& [type, size] : tablesStorageByType) {
-                        auto it = storageQuotasByType.find(type);
-                        auto& tablesStorage = *tenant.AddTablesStorage();
-                        tablesStorage.SetType(type);
-                        tablesStorage.SetSize(size);
-                        if (it != storageQuotasByType.end()) {
-                            tablesStorage.SetLimit(it->second.SoftQuota);
-                            tablesStorage.SetSoftQuota(it->second.SoftQuota);
-                            tablesStorage.SetHardQuota(it->second.HardQuota);
+                        for (const auto& [type, size] : tablesStorageByType) {
+                            auto it = storageQuotasByType.find(type);
+                            auto& tablesStorage = *tenant.AddTablesStorage();
+                            tablesStorage.SetType(type);
+                            tablesStorage.SetSize(size);
+                            if (it != storageQuotasByType.end()) {
+                                tablesStorage.SetLimit(it->second.SoftQuota);
+                                tablesStorage.SetSoftQuota(it->second.SoftQuota);
+                                tablesStorage.SetHardQuota(it->second.HardQuota);
+                            }
                         }
-                    }
 
-                    for (const auto& [type, pr] : databaseStorageByType) {
-                        auto& databaseStorage = *tenant.AddDatabaseStorage();
-                        databaseStorage.SetType(type);
-                        databaseStorage.SetSize(pr.first);
-                        databaseStorage.SetLimit(pr.first + pr.second);
+                        for (const auto& [type, pr] : databaseStorageByType) {
+                            auto& databaseStorage = *tenant.AddDatabaseStorage();
+                            databaseStorage.SetType(type);
+                            databaseStorage.SetSize(pr.first);
+                            databaseStorage.SetLimit(pr.first + pr.second);
+                        }
                     }
                 }
 

--- a/ydb/core/viewer/viewer_tenantinfo.h
+++ b/ydb/core/viewer/viewer_tenantinfo.h
@@ -303,6 +303,7 @@ public:
         }
         request.AddFieldsRequired(NKikimrWhiteboard::TSystemStateInfo::kNetworkUtilizationFieldNumber);
         request.AddFieldsRequired(NKikimrWhiteboard::TSystemStateInfo::kNetworkWriteThroughputFieldNumber);
+        request.AddFieldsRequired(NKikimrWhiteboard::TSystemStateInfo::kRealNumberOfCpusFieldNumber);
     }
 
     void SendWhiteboardSystemStateRequest(const TNodeId nodeId) {

--- a/ydb/core/viewer/wb_req.h
+++ b/ydb/core/viewer/wb_req.h
@@ -154,7 +154,7 @@ public:
             }
         }
         SendNodeRequest(nodeIds);
-        if (TBase::Requests > 0) {
+        if (WaitingForResponse()) {
             TBase::Become(&TThis::StateRequestedNodeInfo);
         } else {
             ReplyAndPassAway();
@@ -190,7 +190,7 @@ public:
         }
         nodeIds.push_back(TBase::SelfId().NodeId());
         SendNodeRequest(nodeIds);
-        if (TBase::Requests > 0) {
+        if (WaitingForResponse() > 0) {
             TBase::Become(&TThis::StateRequestedNodeInfo);
         } else {
             ReplyAndPassAway();


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

fixes issue where not all tablets are shown for pers queue group on the tablets tab in diagnostics #15230
fixes issue with empty nodes groups for disconnected nodes #14992
fixes issue when tables storage is 0 #14180
fixes issue with nested databases are childless when navigating from domain #15256
fixes issue with unstable version numbers in /viewer/nodes handler #14827
fixes issue with long running queries are terminated because of inactivity on tcp socket #15866
adds diagnostics for long running queries https://github.com/ydb-platform/ydb-embedded-ui/issues/2017
adds statistics for long running queries #15884
fixes issue with not all follower tablets are shown on tablets tab #15988
fixes issue with long timings on BSC requests in a large cluster #15863
fixes issue with calculating load average on K8S nodes #15522
improves tracing for describe handler #16766
fixes issue with long time loading databases page on certain databases due to timeout on graph rendering #16895
fixes issue with no tablets shown for table index on tablets tab #17103
fixes issue with Optional<Struct> columns are always shown as NULLs #17226
fixes potential security issue with CORS headers #17670

### Changelog category <!-- remove all except one -->

* Bugfix 

### Description for reviewers <!-- (optional) description for those who read this PR -->

...
