### PR TITLE
The PQ tablet loses its TEvReadSet (#17842)

### DIFF
--- a/ydb/core/persqueue/pq_impl.h
+++ b/ydb/core/persqueue/pq_impl.h
@@ -555,6 +555,11 @@ private:
     void ResendEvReadSetToReceiversForState(const TActorContext& ctx, NKikimrPQ::TTransaction::EState state);
 
     void DeleteSupportivePartitions(const TActorContext& ctx);
+
+    TDeque<TAutoPtr<IEventHandle>> PendingEvents;
+
+    void AddPendingEvent(IEventHandle* ev);
+    void ProcessPendingEvents();
 };
 
 


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

Changes from #17842 

The transaction has entered the EXECUTED state, but has not yet saved it to disk. If the tablet receives a TEvReadSet, it will send a TEvReadSetAck in response. TEvReadSetAck and it will delete the transaction. If the tablet restarts at this point, the transaction will remain in the WAIT_RS state.

The tablet should send TEvReadSetAck only after it saves the transaction status to disk.

Issue #17843

### Changelog category <!-- remove all except one -->

* Bugfix 

### Description for reviewers <!-- (optional) description for those who read this PR -->

...
