### PR TITLE
issue-17863: added file name and line number to log

### DIFF
--- a/ydb/core/blob_depot/types.h
+++ b/ydb/core/blob_depot/types.h
@@ -292,7 +292,7 @@ namespace NKikimr::NBlobDepot {
                 NJson::TJsonWriter __json(&__stream, false); \
                 ::NKikimr::NStLog::TMessage<MARKER>("", 0, #MARKER)STLOG_PARAMS(__VA_ARGS__).WriteToJson(__json) << TEXT; \
             } \
-            ::NActors::MemLogAdapter(ctx, priority, component, __stream.Str()); \
+            ::NActors::MemLogAdapter(ctx, priority, component, __FILE_NAME__, __LINE__, __stream.Str()); \
         }; \
     } while (false)
 

--- a/ydb/core/blobstorage/vdisk/common/vdisk_log.h
+++ b/ydb/core/blobstorage/vdisk/common/vdisk_log.h
@@ -35,7 +35,13 @@ namespace NKikimr {
     ////////////////////////////////////////////////////////////////////////////
     class ILoggerCtx {
     public:
-        virtual void DeliverLogMessage(NLog::EPriority mPriority, NLog::EComponent mComponent, TString &&str, bool json) = 0;
+        virtual void DeliverLogMessage(
+            NLog::EPriority mPriority,
+            NLog::EComponent mComponent,
+            const char* fileName,
+            ui64 lineNumber,
+            TString&& str,
+            bool json) = 0;
         virtual NActors::NLog::TSettings* LoggerSettings() = 0;
         virtual ~ILoggerCtx() = default;
     };
@@ -49,8 +55,22 @@ namespace NKikimr {
             : ActorSystem(as)
         {}
 
-        void DeliverLogMessage(NLog::EPriority mPriority, NLog::EComponent mComponent, TString &&str, bool json) override {
-            ::NActors::DeliverLogMessage(*ActorSystem, mPriority, mComponent, std::move(str), json);
+        void DeliverLogMessage(
+            NLog::EPriority mPriority,
+            NLog::EComponent mComponent,
+            const char* fileName,
+            ui64 lineNumber,
+            TString&& str
+            bool json) override
+        {
+            ::NActors::DeliverLogMessage(
+                *ActorSystem,
+                mPriority,
+                mComponent,
+                fileName,
+                lineNumber,
+                std::move(str),
+                json);
         }
 
         virtual NActors::NLog::TSettings* LoggerSettings() override {
@@ -67,7 +87,16 @@ namespace NKikimr {
     public:
         TFakeLoggerCtx();
 
-        void DeliverLogMessage(NLog::EPriority mPriority, NLog::EComponent mComponent, TString &&str, bool /*json*/) override {
+        void DeliverLogMessage(
+            NLog::EPriority mPriority,
+            NLog::EComponent mComponent,
+            const char* fileName,
+            ui64 lineNumber,
+            TString&& str
+            bool /*json*/) override
+        {
+            Y_UNUSED(fileName);
+            Y_UNUSED(lineNumber);
             Y_UNUSED(mPriority);
             Y_UNUSED(mComponent);
             Y_UNUSED(str);
@@ -90,10 +119,18 @@ namespace NActors {
             NKikimr::ILoggerCtx& ctx,
             NLog::EPriority mPriority,
             NLog::EComponent mComponent,
-            TString &&str,
+            const char *fileName,
+            ui64 lineNumber,
+            TString &&str
             bool json)
     {
-        ctx.DeliverLogMessage(mPriority, mComponent, std::move(str), json);
+        ctx.DeliverLogMessage(
+            mPriority,
+            mComponent,
+            fileName,
+            lineNumber,
+            std::move(str),
+            json);
     }
 
 } // NActors

--- a/ydb/core/blobstorage/vdisk/common/vdisk_log.h
+++ b/ydb/core/blobstorage/vdisk/common/vdisk_log.h
@@ -60,7 +60,7 @@ namespace NKikimr {
             NLog::EComponent mComponent,
             const char* fileName,
             ui64 lineNumber,
-            TString&& str
+            TString&& str,
             bool json) override
         {
             ::NActors::DeliverLogMessage(
@@ -92,7 +92,7 @@ namespace NKikimr {
             NLog::EComponent mComponent,
             const char* fileName,
             ui64 lineNumber,
-            TString&& str
+            TString&& str,
             bool /*json*/) override
         {
             Y_UNUSED(fileName);
@@ -121,7 +121,7 @@ namespace NActors {
             NLog::EComponent mComponent,
             const char *fileName,
             ui64 lineNumber,
-            TString &&str
+            TString &&str,
             bool json)
     {
         ctx.DeliverLogMessage(

--- a/ydb/core/tx/ctor_logger.h
+++ b/ydb/core/tx/ctor_logger.h
@@ -48,7 +48,13 @@ public:
     }
 
     void WriteLog() {
-        ::NActors::MemLogAdapter(Ctx, Priority, Component, std::move(*StrStream));
+        ::NActors::MemLogAdapter(
+            Ctx,
+            Priority,
+            Component,
+            __FILE_NAME__,
+            __LINE__,
+            std::move(*StrStream));
     }
 };
 

--- a/ydb/core/util/stlog.h
+++ b/ydb/core/util/stlog.h
@@ -68,7 +68,7 @@ namespace NKikimr::NStLog {
         const auto component = [&]{ using namespace NKikimrServices; using namespace NActorsServices; return (COMP); }(); \
         if (IS_CTX_LOG_PRIORITY_ENABLED(ctx, priority, component, 0ull)) { \
             STLOG_STREAM(__stream, __VA_ARGS__); \
-            ::NActors::MemLogAdapter(ctx, priority, component, __FILE_NAME__, __LINE__, __stream.Str(), ::NKikimr::NStLog::OutputLogJson); \
+            ::NActors::MemLogAdapter(ctx, priority, component, nullptr, 0, __stream.Str(), ::NKikimr::NStLog::OutputLogJson); \
         }; \
     } while (false)
 

--- a/ydb/core/util/stlog.h
+++ b/ydb/core/util/stlog.h
@@ -68,7 +68,7 @@ namespace NKikimr::NStLog {
         const auto component = [&]{ using namespace NKikimrServices; using namespace NActorsServices; return (COMP); }(); \
         if (IS_CTX_LOG_PRIORITY_ENABLED(ctx, priority, component, 0ull)) { \
             STLOG_STREAM(__stream, __VA_ARGS__); \
-            ::NActors::MemLogAdapter(ctx, priority, component, __stream.Str(), ::NKikimr::NStLog::OutputLogJson); \
+            ::NActors::MemLogAdapter(ctx, priority, component, __FILE_NAME__, __LINE__, __stream.Str(), ::NKikimr::NStLog::OutputLogJson); \
         }; \
     } while (false)
 

--- a/ydb/library/actors/core/log.cpp
+++ b/ydb/library/actors/core/log.cpp
@@ -85,7 +85,14 @@ namespace NActors {
             TString formatted;
             vsprintf(formatted, c, params);
 
-            auto ok = OutputRecord(time, NLog::EPrio(priority), component, formatted, false);
+            auto ok = OutputRecord(
+                time,
+                NLog::EPrio(priority),
+                component,
+                __FILE_NAME__,
+                __LINE__,
+                formatted,
+                false);
             Y_UNUSED(ok);
             va_end(params);
         }
@@ -115,7 +122,15 @@ namespace NActors {
         if (ignoredCount > 0) {
             NLog::EPrio prio = LogBuffer.GetIgnoredHighestPrio();
             TString message = Sprintf("Logger overflow! Ignored %" PRIu64 "  log records with priority [%s] or lower!", ignoredCount, PriorityToString(prio));
-            if (!OutputRecord(ctx.Now(), NActors::NLog::EPrio::Error, Settings->LoggerComponent, message, false)) {
+            if (!OutputRecord(
+                    ctx.Now(),
+                    NActors::NLog::EPrio::Error,
+                    Settings->LoggerComponent,
+                    __FILE_NAME__,
+                    __LINE__,
+                    message,
+                    false))
+            {
                 BecomeDefunct();
             }
             LogBuffer.ClearIgnoredCount();
@@ -447,11 +462,25 @@ namespace NActors {
     constexpr size_t TimeBufSize = 512;
 
     bool TLoggerActor::OutputRecord(NLog::TEvLog *evLog) noexcept {
-        return OutputRecord(evLog->Stamp, evLog->Level.ToPrio(), evLog->Component, evLog->Line, evLog->Json);
+        return OutputRecord(
+            evLog->Stamp,
+            evLog->Level.ToPrio(),
+            evLog->Component,
+            evLog->FileName,
+            evLog->LineNumber,
+            evLog->Line,
+            evLog->Json);
     }
 
-    bool TLoggerActor::OutputRecord(TInstant time, NLog::EPrio priority, NLog::EComponent component,
-                                    const TString& formatted, bool json) noexcept try {
+    bool TLoggerActor::OutputRecord(
+        TInstant time,
+        NLog::EPrio priority,
+        NLog::EComponent component,
+        const char* fileName,
+        ui64 lineNumber,
+        const TString& formatted,
+        bool json) noexcept
+    try {
         const auto logPrio = ::ELogPriority(ui16(priority));
 
         char buf[TimeBufSize];
@@ -463,11 +492,15 @@ namespace NActors {
                 } else {
                     logRecord << time;
                 }
-                logRecord
-                    << Settings->MessagePrefix
-                    << " :" << Settings->ComponentName(component)
-                    << " "  << PriorityToString(priority)
-                    << ": " << formatted;
+
+                logRecord << Settings->MessagePrefix << " :"
+                          << Settings->ComponentName(component) << " "
+                          << PriorityToString(priority);
+
+                if (fileName) {
+                    logRecord << ": " << fileName << ":" << lineNumber;
+                }
+                logRecord << ": " << formatted;
                 LogBackend->WriteData(
                     TLogRecord(logPrio, logRecord.data(), logRecord.size()));
             } break;
@@ -508,6 +541,13 @@ namespace NActors {
                     .WriteString("KIKIMR")
                     .WriteKey("revision")
                     .WriteInt(GetProgramSvnRevision());
+
+                if (fileName) {
+                    TStringBuilder location;
+                    location << fileName << ":" << lineNumber;
+                    j.WriteKey("location").WriteString(location);
+                }
+
                 if (json) {
                     if (formatted && formatted.front() == '{' && formatted.back() == '}') {
                         j.UnsafeWritePair(TStringBuf(formatted.data() + 1, formatted.size() - 2));
@@ -736,7 +776,13 @@ namespace NActors {
 
     TFormattedRecordWriter::~TFormattedRecordWriter() {
         if (ActorContext) {
-            ::NActors::MemLogAdapter(*ActorContext, Priority, Component, TBase::GetResult());
+            ::NActors::MemLogAdapter(
+                *ActorContext,
+                Priority,
+                Component,
+                __FILE_NAME__,
+                __LINE__,
+                TBase::GetResult());
         } else {
             Cerr << "FALLBACK_ACTOR_LOGGING;priority=" << Priority << ";component=" << Component << ";" << TBase::GetResult() << Endl;
         }
@@ -764,7 +810,13 @@ namespace NActors {
     TEnsureFormattedRecordWriter::~TEnsureFormattedRecordWriter() noexcept(false) {
         const TString data = TBase::GetResult();
         if (NActors::TlsActivationContext) {
-            ::NActors::MemLogAdapter(NActors::TlsActivationContext->AsActorContext(), NLog::EPriority::PRI_ERROR, 0, data);
+            ::NActors::MemLogAdapter(
+                NActors::TlsActivationContext->AsActorContext(),
+                NLog::EPriority::PRI_ERROR,
+                0,
+                __FILE_NAME__,
+                __LINE__,
+                data);
         } else {
             Cerr << "FALLBACK_EXCEPTION_LOGGING;component=EXCEPTION;" << data << Endl;
         }

--- a/ydb/library/actors/core/log.h
+++ b/ydb/library/actors/core/log.h
@@ -50,7 +50,7 @@
     do {                                                                                                                       \
         if (IS_CTX_LOG_PRIORITY_ENABLED(actorCtxOrSystem, priority, component, sampleBy)) {                                    \
             ::NActors::MemLogAdapter(                                                                                          \
-                actorCtxOrSystem, priority, component, __VA_ARGS__);                                                           \
+                actorCtxOrSystem, priority, component, __FILE_NAME__, __LINE__, __VA_ARGS__);                                  \
         }                                                                                                                      \
     } while (0) /**/
 
@@ -60,7 +60,7 @@
             TStringBuilder logStringBuilder;                                                                                   \
             logStringBuilder << stream;                                                                                        \
             ::NActors::MemLogAdapter(                                                                                          \
-                actorCtxOrSystem, priority, component, std::move(logStringBuilder));                                           \
+                actorCtxOrSystem, priority, component, __FILE_NAME__, __LINE__, std::move(logStringBuilder));                  \
         }                                                                                                                      \
     } while (0) /**/
 
@@ -265,7 +265,14 @@ namespace NActors {
         void HandleMonInfo(NMon::TEvHttpInfo::TPtr& ev, const TActorContext& ctx);
         void HandleWakeup();
         [[nodiscard]] bool OutputRecord(NLog::TEvLog *evLog) noexcept;
-        [[nodiscard]] bool OutputRecord(TInstant time, NLog::EPrio priority, NLog::EComponent component, const TString& formatted, bool json) noexcept;
+        [[nodiscard]] bool OutputRecord(
+            TInstant time,
+            NLog::EPrio priority,
+            NLog::EComponent component,
+            const char* fileName,
+            ui64 lineNumber,
+            const TString& formatted,
+            bool json) noexcept;
         void RenderComponentPriorities(IOutputStream& str);
         void FlushLogBufferMessage();
         void WriteMessageStat(const NLog::TEvLog& ev);
@@ -342,12 +349,27 @@ namespace NActors {
     }
 
     template <typename TCtx>
-    inline void DeliverLogMessage(TCtx& ctx, NLog::EPriority mPriority, NLog::EComponent mComponent, TString &&str,
-            bool json = false)
+    inline void DeliverLogMessage(
+        TCtx& ctx,
+        NLog::EPriority mPriority,
+        NLog::EComponent mComponent,
+        const char* fileName,
+        ui64 lineNumber,
+        TString&& str,
+        bool json = false)
     {
         const NLog::TSettings *mSettings = ctx.LoggerSettings();
         TLoggerActor::Throttle(*mSettings);
-        ctx.Send(new IEventHandle(mSettings->LoggerActorId, TActorId(), new NLog::TEvLog(mPriority, mComponent, std::move(str), json)));
+        ctx.Send(new IEventHandle(
+            mSettings->LoggerActorId,
+            TActorId(),
+            new NLog::TEvLog(
+                mPriority,
+                mComponent,
+                fileName,
+                lineNumber,
+                std::move(str),
+                json)));
     }
 
     template <typename TCtx, typename... TArgs>
@@ -355,7 +377,10 @@ namespace NActors {
         TCtx& actorCtxOrSystem,
         NLog::EPriority mPriority,
         NLog::EComponent mComponent,
-        const char* format, TArgs&&... params) {
+        const char* fileName,
+        ui64 lineNumber,
+        const char* format,
+        TArgs&&... params) {
         TString Formatted;
 
 
@@ -366,7 +391,14 @@ namespace NActors {
         }
 
         MemLogWrite(Formatted.data(), Formatted.size(), true);
-        DeliverLogMessage(actorCtxOrSystem, mPriority, mComponent, std::move(Formatted), false);
+        DeliverLogMessage(
+            actorCtxOrSystem,
+            mPriority,
+            mComponent,
+            fileName,
+            lineNumber,
+            std::move(Formatted),
+            false);
     }
 
     template <typename TCtx>
@@ -374,11 +406,20 @@ namespace NActors {
         TCtx& actorCtxOrSystem,
         NLog::EPriority mPriority,
         NLog::EComponent mComponent,
+        const char* fileName,
+        ui64 lineNumber,
         const TString& str,
         bool json = false) {
 
         MemLogWrite(str.data(), str.size(), true);
-        DeliverLogMessage(actorCtxOrSystem, mPriority, mComponent, TString(str), json);
+        DeliverLogMessage(
+            actorCtxOrSystem,
+            mPriority,
+            mComponent,
+            fileName,
+            lineNumber,
+            TString(str),
+            json);
     }
 
     template <typename TCtx>
@@ -386,11 +427,20 @@ namespace NActors {
         TCtx& actorCtxOrSystem,
         NLog::EPriority mPriority,
         NLog::EComponent mComponent,
+        const char* fileName,
+        ui64 lineNumber,
         TString&& str,
         bool json = false) {
 
         MemLogWrite(str.data(), str.size(), true);
-        DeliverLogMessage(actorCtxOrSystem, mPriority, mComponent, std::move(str), json);
+        DeliverLogMessage(
+            actorCtxOrSystem,
+            mPriority,
+            mComponent,
+            fileName,
+            lineNumber,
+            std::move(str),
+            json);
     }
 
     class TRecordWriter: public TStringBuilder {
@@ -408,7 +458,13 @@ namespace NActors {
 
         ~TRecordWriter() {
             if (ActorContext) {
-                ::NActors::MemLogAdapter(*ActorContext, Priority, Component, *this);
+                ::NActors::MemLogAdapter(
+                    *ActorContext,
+                    Priority,
+                    Component,
+                    __FILE_NAME__,
+                    __LINE__,
+                    *this);
             } else {
                 Cerr << "FALLBACK_ACTOR_LOGGING;priority=" << Priority << ";component=" << Component << ";" << static_cast<const TStringBuilder&>(*this) << Endl;
             }

--- a/ydb/library/actors/core/log_iface.h
+++ b/ydb/library/actors/core/log_iface.h
@@ -119,9 +119,29 @@ namespace NActors {
             {
             }
 
+            TEvLog(
+                    EPriority prio,
+                    EComponent comp,
+                    const char* fileName,
+                    ui64 lineNumber,
+                    TString line,
+                    bool json,
+                    TInstant time = TInstant::Now())
+                : Stamp(time)
+                , Level(EPrio(prio))
+                , Component(comp)
+                , FileName(fileName)
+                , LineNumber(lineNumber)
+                , Line(std::move(line))
+                , Json(json)
+            {
+            }
+
             const TInstant Stamp = TInstant::Max();
             const TLevel Level;
             const EComponent Component = 0;
+            const char* FileName = nullptr;
+            const ui64 LineNumber = 0;
             TString Line;
             const bool Json;
         };

--- a/ydb/library/grpc/server/actors/logger.cpp
+++ b/ydb/library/grpc/server/actors/logger.cpp
@@ -28,7 +28,14 @@ protected:
         Y_DEBUG_ABORT_UNLESS(DoIsEnabled(p));
 
         const auto priority = static_cast<::NActors::NLog::EPriority>(p);
-        ::NActors::MemLogAdapter(ActorSystem_, priority, Component_, format, args);
+        ::NActors::MemLogAdapter(
+            ActorSystem_,
+            priority,
+            Component_,
+            __FILE_NAME__,
+            __LINE__,
+            format,
+            args);
     }
 
 private:


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

#17863 added file name and line number to logs

### Changelog category <!-- remove all except one -->

* Improvement

### Description for reviewers

Added file name and line number to the logs, so now the logs look like this

```
2025-04-29T10:58:11.403547Z :BLOCKSTORE_DISK_REGISTRY INFO: disk_registry_actor_secure_erase.cpp:421: [72075186224037888] Received SecureErase response: CleanDevices=3
2025-04-29T10:58:11.403611Z :BLOCKSTORE_DISK_REGISTRY INFO: disk_registry_actor_secure_erase.cpp:328: [72075186224037888] Filtered dirty devices: 3 -> 3
2025-04-29T10:58:14.480803Z :BLOCKSTORE_DISK_REGISTRY INFO: disk_registry_actor_secure_erase.cpp:436: [72075186224037888] Received CleanupDevices request: Devices=3
2025-04-29T10:58:14.489070Z :BLOCKSTORE_DISK_REGISTRY INFO: disk_registry_actor_secure_erase.cpp:421: [72075186224037888] Received SecureErase response: CleanDevices=3
```
and in json format:
```
{"@timestamp":"2025-04-29T10:57:24.926225Z","microseconds":1745924244926225,"host":"a7lel0n11u216j11uioh","cluster":"","priority":"NOTICE","npriority":5,"component":"CMS_CONFIGS","tag":"KIKIMR","revision":-1,"location":"log_settings_configurator.cpp:192","message":"TLogSettingsConfigurator: Priority for the component BS_SYNCJOB has been changed from NOTICE to ERROR"}
```
