### PR TITLE
Add dependents to the public external data source description

### DIFF
--- a/ydb/core/protos/flat_scheme_op.proto
+++ b/ydb/core/protos/flat_scheme_op.proto
@@ -2082,6 +2082,7 @@ message TExternalDataSourceDescription {
     optional TAuth Auth = 7;
     optional TExternalDataSourceProperties Properties = 8;
     optional bool ReplaceIfExists = 9;
+    optional TExternalTableReferences References = 10;
 }
 
 message TViewDescription {

--- a/ydb/core/tx/schemeshard/schemeshard_info_types.h
+++ b/ydb/core/tx/schemeshard/schemeshard_info_types.h
@@ -3384,7 +3384,7 @@ struct TIndexBuildInfo: public TSimpleRefCount<TIndexBuildInfo> {
             return result;
         }
     };
-    
+
     TMap<TShardIdx, TShardStatus> Shards;
     TDeque<TShardIdx> ToUploadShards;
     THashSet<TShardIdx> InProgressShards;
@@ -3822,6 +3822,7 @@ struct TExternalDataSourceInfo: TSimpleRefCount<TExternalDataSourceInfo> {
         proto.SetInstallation(Installation);
         proto.MutableAuth()->CopyFrom(Auth);
         proto.MutableProperties()->CopyFrom(Properties);
+        proto.MutableReferences()->CopyFrom(ExternalTableReferences);
     }
 };
 


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

Add the list of dependent scheme objects (external tables, column tables) to the description of an external data source.

### Changelog category <!-- remove all except one -->

* New feature

### Description for reviewers <!-- (optional) description for those who read this PR -->

Issues:
- https://github.com/ydb-platform/ydb/issues/17910
- https://github.com/ydb-platform/ydb/issues/15410 (the feature added in this PR was needed for the `--replace` option)

For reference:
- external table references are [filled](https://github.com/ydb-platform/ydb/blob/7e2dece5bc21974ba5ef3bb796c4af81675771ce/ydb/core/tx/schemeshard/schemeshard__operation_create_external_table.cpp#L261) when the external table is created
- they have already been a part of the persistent external data source [description](https://github.com/ydb-platform/ydb/blob/7e2dece5bc21974ba5ef3bb796c4af81675771ce/ydb/core/tx/schemeshard/schemeshard_impl.cpp#L3056), we just haven't returned them on the describe requests