### PR TITLE
Add MaintenanceStatus to evict VDisks from PDisk for long term maintenance

### DIFF
--- a/ydb/core/blobstorage/ut_blobstorage/self_heal.cpp
+++ b/ydb/core/blobstorage/ut_blobstorage/self_heal.cpp
@@ -1,4 +1,5 @@
 #include <ydb/core/blobstorage/ut_blobstorage/lib/env.h>
+#include <util/system/compiler.h>
 
 Y_UNIT_TEST_SUITE(SelfHeal) {
     void TestReassignThrottling() {
@@ -64,4 +65,149 @@ Y_UNIT_TEST_SUITE(SelfHeal) {
     Y_UNIT_TEST(ReassignThrottling) {
         TestReassignThrottling();
     }
+
+    struct TPDiskStatus {
+        NKikimrBlobStorage::EDriveStatus DriveStatus = NKikimrBlobStorage::ACTIVE;
+        NKikimrBlobStorage::TMaintenanceStatus::E MaintenanceStatus = NKikimrBlobStorage::TMaintenanceStatus::NO_REQUEST;
+    };
+
+    using TPDisks = std::vector<TPDiskStatus>;
+
+    constexpr TPDiskStatus Active = TPDiskStatus{
+        .DriveStatus = NKikimrBlobStorage::ACTIVE,
+        .MaintenanceStatus = NKikimrBlobStorage::TMaintenanceStatus::NO_REQUEST,
+    };
+
+    constexpr TPDiskStatus Inactive = TPDiskStatus{
+        .DriveStatus = NKikimrBlobStorage::INACTIVE,
+        .MaintenanceStatus = NKikimrBlobStorage::TMaintenanceStatus::NO_REQUEST,
+    };
+
+    constexpr TPDiskStatus Faulty = TPDiskStatus{
+        .DriveStatus = NKikimrBlobStorage::FAULTY,
+        .MaintenanceStatus = NKikimrBlobStorage::TMaintenanceStatus::NO_REQUEST,
+    };
+
+    constexpr TPDiskStatus ActiveMaintenance = TPDiskStatus{
+        .DriveStatus = NKikimrBlobStorage::ACTIVE,
+        .MaintenanceStatus = NKikimrBlobStorage::TMaintenanceStatus::LONG_TERM_MAINTENANCE_PLANNED,
+    };
+
+    constexpr TPDiskStatus InactiveMaintenance = TPDiskStatus{
+        .DriveStatus = NKikimrBlobStorage::INACTIVE,
+        .MaintenanceStatus = NKikimrBlobStorage::TMaintenanceStatus::LONG_TERM_MAINTENANCE_PLANNED,
+    };
+
+    constexpr TPDiskStatus FaultyMaintenance = TPDiskStatus{
+        .DriveStatus = NKikimrBlobStorage::FAULTY,
+        .MaintenanceStatus = NKikimrBlobStorage::TMaintenanceStatus::LONG_TERM_MAINTENANCE_PLANNED,
+    };
+
+    void TestMaintenanceRequest(TBlobStorageGroupType erasure, TPDisks pdisks) {
+        Y_UNUSED(Inactive);
+
+        const ui32 groupSize = erasure.BlobSubgroupSize();
+        Y_VERIFY(pdisks.size() == groupSize, "bad argument");
+
+        TEnvironmentSetup env({
+            .NodeCount = erasure.BlobSubgroupSize(),
+            .Erasure = erasure,
+        });
+
+        env.CreateBoxAndPool(2, 1);
+        env.Sim(TDuration::Minutes(1));
+
+        env.UpdateSettings(false, true, false); // disable self-heal
+
+        auto base = env.FetchBaseConfig();
+        UNIT_ASSERT_VALUES_EQUAL(base.GroupSize(), 1);
+
+        std::optional<TBlobStorageGroupInfo::TTopology> topology;
+        if (erasure.GetErasure() == TBlobStorageGroupType::Erasure4Plus2Block) {
+            topology.emplace(erasure, 1, 8, 1, true);
+        } else if (erasure.GetErasure() == TBlobStorageGroupType::ErasureMirror3dc) {
+            topology.emplace(erasure, 3, 3, 1, true);
+        }
+
+        std::vector<TPDiskId> orderNumberToPDiskId(groupSize);
+        std::unordered_map<TPDiskId, ui32> pdiskIdToOrderNumber;
+
+        auto updateMapping = [&](const NKikimrBlobStorage::TBaseConfig& base) {
+            pdiskIdToOrderNumber.clear();
+            for (const auto& vslot : base.GetVSlot()) {
+                TVDiskIdShort vdiskIdShort(vslot.GetFailRealmIdx(), vslot.GetFailDomainIdx(), vslot.GetVDiskIdx());
+                ui32 orderNumber = topology->GetOrderNumber(vdiskIdShort);
+                TPDiskId pdiskId(vslot.GetVSlotId().GetNodeId(), vslot.GetVSlotId().GetPDiskId());
+                orderNumberToPDiskId[orderNumber] = pdiskId;
+                pdiskIdToOrderNumber[pdiskId] = orderNumber;
+            }
+    
+            for (ui32 orderNumber = 0; orderNumber < groupSize; ++orderNumber) {
+                TPDiskId pdiskId = orderNumberToPDiskId[orderNumber];
+                TPDiskStatus pdiskStatus = pdisks[orderNumber];
+                NKikimrBlobStorage::TConfigRequest request;
+                auto* cmd = request.AddCommand()->MutableUpdateDriveStatus();
+                cmd->MutableHostKey()->SetNodeId(pdiskId.NodeId);
+                cmd->SetPDiskId(pdiskId.PDiskId);
+                cmd->SetStatus(pdiskStatus.DriveStatus);
+                cmd->SetMaintenanceStatus(pdiskStatus.MaintenanceStatus);
+                auto res = env.Invoke(request);
+                UNIT_ASSERT_C(res.GetSuccess(), res.GetErrorDescription());
+                UNIT_ASSERT_C(res.GetStatus(0).GetSuccess(), res.GetStatus(0).GetErrorDescription());
+            }
+        };
+
+        updateMapping(base);
+
+        // check statuses
+        base = env.FetchBaseConfig();
+        for (const auto& pdisk : base.GetPDisk()) {
+            TPDiskId pdiskId(pdisk.GetNodeId(), pdisk.GetPDiskId());
+            const auto it = pdiskIdToOrderNumber.find(pdiskId);
+            if (it != pdiskIdToOrderNumber.end()) {
+                ui32 orderNumber = it->second;
+                const TPDiskStatus& expectedStatus = pdisks[orderNumber];
+                UNIT_ASSERT(pdisk.GetDriveStatus() == expectedStatus.DriveStatus);
+                UNIT_ASSERT(pdisk.GetMaintenanceStatus() == expectedStatus.MaintenanceStatus);
+            } else {
+                UNIT_ASSERT(pdisk.GetDriveStatus() == NKikimrBlobStorage::ACTIVE);
+                UNIT_ASSERT(pdisk.GetMaintenanceStatus() == NKikimrBlobStorage::TMaintenanceStatus::NO_REQUEST);
+            }
+        }
+
+        env.UpdateSettings(true, true, false); // enable self-heal
+        env.Sim(TDuration::Minutes(180));
+
+        base = env.FetchBaseConfig();
+        updateMapping(base);
+
+        for (const auto& pdisk : base.GetPDisk()) {
+            TPDiskId pdiskId(pdisk.GetNodeId(), pdisk.GetPDiskId());
+            const auto it = pdiskIdToOrderNumber.find(pdiskId);
+            if (it != pdiskIdToOrderNumber.end()) {
+                UNIT_ASSERT(pdisk.GetDriveStatus() == NKikimrBlobStorage::ACTIVE);
+                UNIT_ASSERT(pdisk.GetMaintenanceStatus() == NKikimrBlobStorage::TMaintenanceStatus::NO_REQUEST);
+            }
+        }
+    }
+
+#define SELF_HEAL_MAINTENANCE_TEST(name, erasure, pdisks)                           \
+    Y_UNIT_TEST(Test##name##erasure) {                                              \
+        TestMaintenanceRequest(TBlobStorageGroupType::Erasure##erasure, pdisks);    \
+    }
+
+    SELF_HEAL_MAINTENANCE_TEST(OneMaintenanceRequest, Mirror3dc, TPDisks({ Active, Active, Active, ActiveMaintenance, Active, Active, Active, Active, Active }));
+    SELF_HEAL_MAINTENANCE_TEST(OneMaintenanceRequest, 4Plus2Block, TPDisks({ Active, Active, ActiveMaintenance, Active, Active, Active, Active, Active }));
+
+    SELF_HEAL_MAINTENANCE_TEST(ThreeMaintenanceRequests, Mirror3dc, TPDisks({ Active, ActiveMaintenance, Active, ActiveMaintenance, Active, Active, Active, ActiveMaintenance, Active }));
+    SELF_HEAL_MAINTENANCE_TEST(ThreeMaintenanceRequests, 4Plus2Block, TPDisks({ ActiveMaintenance, ActiveMaintenance, ActiveMaintenance, Active, Active, Active, Active, Active }));
+
+    SELF_HEAL_MAINTENANCE_TEST(TwoMaintenanceRequestsOneFaulty, Mirror3dc, TPDisks({ Active, ActiveMaintenance, Active, ActiveMaintenance, Active, Active, Active, Faulty, Active }));
+    SELF_HEAL_MAINTENANCE_TEST(TwoMaintenanceRequestsOneFaulty, 4Plus2Block, TPDisks({ Faulty, ActiveMaintenance, ActiveMaintenance, Active, Active, Active, Active, Active }));
+
+    SELF_HEAL_MAINTENANCE_TEST(OneInactiveMaintenanceRequestOneMaintenanceRequest, Mirror3dc, TPDisks({ Active, Active, Active, Active, Active, InactiveMaintenance, Active, ActiveMaintenance, Active }));
+    SELF_HEAL_MAINTENANCE_TEST(OneInactiveMaintenanceRequestOneMaintenanceRequest, 4Plus2Block, TPDisks({ ActiveMaintenance, Active, Active, Active, Active, Active, InactiveMaintenance, Active }));
+
+    SELF_HEAL_MAINTENANCE_TEST(OneFaultyMaintenanceRequestOneMaintenanceRequest, Mirror3dc, TPDisks({ Active, Active, Active, Active, Active, FaultyMaintenance, Active, ActiveMaintenance, Active }));
+    SELF_HEAL_MAINTENANCE_TEST(OneFaultyMaintenanceRequestOneMaintenanceRequest, 4Plus2Block, TPDisks({ ActiveMaintenance, Active, Active, Active, Active, Active, FaultyMaintenance, Active }));
 }

--- a/ydb/core/mind/bscontroller/cmds_drive_status.cpp
+++ b/ydb/core/mind/bscontroller/cmds_drive_status.cpp
@@ -45,6 +45,12 @@ namespace NKikimr::NBsController {
             }
         }
 
+        if (const auto mr = cmd.GetMaintenanceStatus();
+            mr != NKikimrBlobStorage::TMaintenanceStatus::NOT_SET &&
+            mr != pdisk->MaintenanceStatus) {
+            pdisk->MaintenanceStatus = mr;
+        }
+
         if (fitGroups) {
             for (const auto& [id, slot] : pdisk->VSlotsOnPDisk) {
                 if (slot->Group) {

--- a/ydb/core/mind/bscontroller/config.cpp
+++ b/ydb/core/mind/bscontroller/config.cpp
@@ -1004,6 +1004,7 @@ namespace NKikimr::NBsController {
             pb->SetExpectedSerial(pdisk.ExpectedSerial);
             pb->SetLastSeenSerial(pdisk.LastSeenSerial);
             pb->SetReadOnly(pdisk.Mood == TPDiskMood::ReadOnly);
+            pb->SetMaintenanceStatus(pdisk.MaintenanceStatus);
         }
 
         void TBlobStorageController::Serialize(NKikimrBlobStorage::TVSlotId *pb, TVSlotId id) {

--- a/ydb/core/mind/bscontroller/config_fit_pdisks.cpp
+++ b/ydb/core/mind/bscontroller/config_fit_pdisks.cpp
@@ -328,7 +328,8 @@ namespace NKikimr {
                             NKikimrBlobStorage::EDriveStatus::ACTIVE, /* statusTimestamp */ TInstant::Zero(),
                             NKikimrBlobStorage::EDecommitStatus::DECOMMIT_NONE, NBsController::TPDiskMood::Normal,
                             disk.Serial, disk.LastSeenSerial, disk.LastSeenPath, staticSlotUsage,
-                            true /* assume shred completed for this disk */);
+                            true /* assume shred completed for this disk */,
+                            NKikimrBlobStorage::TMaintenanceStatus::NO_REQUEST);
 
                     // Set PDiskId and Guid in DrivesSerials
                     if (auto info = state.DrivesSerials.FindForUpdate(disk.Serial)) {

--- a/ydb/core/mind/bscontroller/impl.h
+++ b/ydb/core/mind/bscontroller/impl.h
@@ -354,6 +354,8 @@ public:
 
         bool ShredInProgress = false; // set to true when shredding is started for this disk
 
+        NKikimrBlobStorage::TMaintenanceStatus::E MaintenanceStatus;
+
         template<typename T>
         static void Apply(TBlobStorageController* /*controller*/, T&& callback) {
             static TTableAdapter<Table, TPDiskInfo,
@@ -371,7 +373,8 @@ public:
                     Table::LastSeenSerial,
                     Table::LastSeenPath,
                     Table::DecommitStatus,
-                    Table::ShredComplete
+                    Table::ShredComplete,
+                    Table::MaintenanceStatus
                 > adapter(
                     &TPDiskInfo::Path,
                     &TPDiskInfo::Kind,
@@ -387,7 +390,8 @@ public:
                     &TPDiskInfo::LastSeenSerial,
                     &TPDiskInfo::LastSeenPath,
                     &TPDiskInfo::DecommitStatus,
-                    &TPDiskInfo::ShredComplete
+                    &TPDiskInfo::ShredComplete,
+                    &TPDiskInfo::MaintenanceStatus
                 );
             callback(&adapter);
         }
@@ -410,7 +414,8 @@ public:
                    const TString& lastSeenSerial,
                    const TString& lastSeenPath,
                    ui32 staticSlotUsage,
-                   bool shredComplete)
+                   bool shredComplete,
+                   NKikimrBlobStorage::TMaintenanceStatus::E maintenanceStatus)
             : HostId(hostId)
             , Path(path)
             , Kind(kind)
@@ -429,6 +434,7 @@ public:
             , LastSeenSerial(lastSeenSerial)
             , LastSeenPath(lastSeenPath)
             , StaticSlotUsage(staticSlotUsage)
+            , MaintenanceStatus(maintenanceStatus)
         {
             ExtractConfig(defaultMaxSlots);
         }
@@ -471,7 +477,8 @@ public:
         bool ShouldBeSettledBySelfHeal() const {
             return Status == NKikimrBlobStorage::EDriveStatus::FAULTY
                 || Status == NKikimrBlobStorage::EDriveStatus::TO_BE_REMOVED
-                || DecommitStatus == NKikimrBlobStorage::EDecommitStatus::DECOMMIT_IMMINENT;
+                || DecommitStatus == NKikimrBlobStorage::EDecommitStatus::DECOMMIT_IMMINENT
+                || MaintenanceStatus == NKikimrBlobStorage::TMaintenanceStatus::LONG_TERM_MAINTENANCE_PLANNED;
         }
 
         bool IsSelfHealReasonDecommit() const {
@@ -495,7 +502,8 @@ public:
         }
 
         bool AcceptsNewSlots() const {
-            return Status == NKikimrBlobStorage::EDriveStatus::ACTIVE;
+            return Status == NKikimrBlobStorage::EDriveStatus::ACTIVE
+                && MaintenanceStatus != NKikimrBlobStorage::TMaintenanceStatus::LONG_TERM_MAINTENANCE_PLANNED;
         }
 
         bool Decommitted() const {

--- a/ydb/core/mind/bscontroller/load_everything.cpp
+++ b/ydb/core/mind/bscontroller/load_everything.cpp
@@ -343,7 +343,7 @@ public:
                     Self->DefaultMaxSlots, disks.GetValue<T::Status>(), disks.GetValue<T::Timestamp>(),
                     disks.GetValue<T::DecommitStatus>(), disks.GetValue<T::Mood>(), disks.GetValue<T::ExpectedSerial>(),
                     disks.GetValue<T::LastSeenSerial>(), disks.GetValue<T::LastSeenPath>(), staticSlotUsage,
-                    disks.GetValueOrDefault<T::ShredComplete>());
+                    disks.GetValueOrDefault<T::ShredComplete>(), disks.GetValueOrDefault<T::MaintenanceStatus>());
 
                 if (!disks.Next())
                     return false;

--- a/ydb/core/mind/bscontroller/scheme.h
+++ b/ydb/core/mind/bscontroller/scheme.h
@@ -43,11 +43,12 @@ struct Schema : NIceDb::Schema {
         struct DecommitStatus : Column<17, NScheme::NTypeIds::Uint32> { using Type = NKikimrBlobStorage::EDecommitStatus; static constexpr Type Default = Type::DECOMMIT_NONE; };
         struct Mood : Column<18, NScheme::NTypeIds::Uint8> { using Type = TPDiskMood::EValue; static constexpr Type Default = Type::Normal; };
         struct ShredComplete : Column<19, NScheme::NTypeIds::Bool> { static constexpr Type Default = true; };
+        struct MaintenanceStatus : Column<20, NScheme::NTypeIds::Uint8> { using Type = NKikimrBlobStorage::TMaintenanceStatus::E; static constexpr Type Default = NKikimrBlobStorage::TMaintenanceStatus::NO_REQUEST; };
 
         using TKey = TableKey<NodeID, PDiskID>; // order is important
         using TColumns = TableColumns<NodeID, PDiskID, Path, Category, Guid, SharedWithOs, ReadCentric, NextVSlotId,
               Status, Timestamp, PDiskConfig, ExpectedSerial, LastSeenSerial, LastSeenPath, DecommitStatus, Mood,
-              ShredComplete>;
+              ShredComplete, MaintenanceStatus>;
     };
 
     struct Group : Table<4> {

--- a/ydb/core/mind/bscontroller/self_heal.cpp
+++ b/ydb/core/mind/bscontroller/self_heal.cpp
@@ -283,7 +283,7 @@ namespace NKikimr::NBsController {
         const ui64 TabletId;
         TActorId ControllerId;
         THashMap<TGroupId, TGroupRecord> Groups;
-        TIntrusiveList<TGroupRecord, TWithFaultyDisks> GroupsWithFaultyDisks;
+        TIntrusiveList<TGroupRecord, TWithFaultyDisks> GroupsWithVDisksToReassign;
         TIntrusiveList<TGroupRecord, TWithInvalidLayout> GroupsWithInvalidLayout;
         std::unordered_set<TGroupId> UnreassignableGroups;
         std::shared_ptr<std::atomic_uint64_t> UnreassignableGroupsCount;
@@ -355,7 +355,7 @@ namespace NKikimr::NBsController {
 
                     const auto [it, inserted] = Groups.try_emplace(groupId, groupId);
                     auto& g = it->second;
-                    bool hasFaultyDisks = false;
+                    bool hasVDisksToReassign = false;
                     
                     g.Content = std::move(*data);
 
@@ -366,15 +366,15 @@ namespace NKikimr::NBsController {
                     ui32 numVDisksPerFailDomain = 0;
 
                     for (const auto& [vdiskId, vdisk] : g.Content.VDisks) {
-                        hasFaultyDisks |= vdisk.Faulty;
+                        hasVDisksToReassign |= vdisk.RequiresReassignment;
                         numFailRealms = Max<ui32>(numFailRealms, 1 + vdiskId.FailRealm);
                         numFailDomainsPerFailRealm = Max<ui32>(numFailDomainsPerFailRealm, 1 + vdiskId.FailDomain);
                         numVDisksPerFailDomain = Max<ui32>(numVDisksPerFailDomain, 1 + vdiskId.VDisk);
                     }
-                    if (hasFaultyDisks) {
-                        GroupsWithFaultyDisks.PushBack(&g);
+                    if (hasVDisksToReassign) {
+                        GroupsWithVDisksToReassign.PushBack(&g);
                     } else {
-                        GroupsWithFaultyDisks.Remove(&g);
+                        GroupsWithVDisksToReassign.Remove(&g);
                     }
 
                     Y_ABORT_UNLESS(numFailRealms && numFailDomainsPerFailRealm && numVDisksPerFailDomain);
@@ -437,7 +437,7 @@ namespace NKikimr::NBsController {
         void CheckGroups() {
             const TMonotonic now = TActivationContext::Monotonic();
 
-            for (TGroupRecord& group : GroupsWithFaultyDisks) {
+            for (TGroupRecord& group : GroupsWithVDisksToReassign) {
                 if (group.ReassignStatus != EReassignStatus::NotNeeded || now < group.NextRetryTimestamp) {
                     continue; // reassign is already enqueued
                 }
@@ -458,7 +458,7 @@ namespace NKikimr::NBsController {
 
                     bool allDisksAreFullyOperational = true;
                     for (const auto& [vdiskId, vdisk] : group.Content.VDisks) {
-                        if (vdisk.Bad || vdisk.Faulty || !IsReady(vdisk, now)) {
+                        if (vdisk.UnavailabilityRisk || vdisk.RequiresReassignment || !IsReady(vdisk, now)) {
                             // don't sanitize groups with non-operational or replicating disks
                             allDisksAreFullyOperational = false;
                             break;
@@ -536,7 +536,7 @@ namespace NKikimr::NBsController {
             // so, first we check that we have no replicating or starting disk in the group; but we allow one
             // semi-replicated disk to prevent selfheal blocking
             TBlobStorageGroupInfo::TGroupVDisks failedByReadiness(topology);
-            TBlobStorageGroupInfo::TGroupVDisks failedByBadness(topology);
+            TBlobStorageGroupInfo::TGroupVDisks failedByUnavailabilityRisk(topology);
             ui32 numReplicatingWithPhantomsOnly = 0;
             for (const auto& [vdiskId, vdisk] : content.VDisks) {
                 switch (vdisk.VDiskStatus) {
@@ -556,16 +556,16 @@ namespace NKikimr::NBsController {
                 if (!IsReady(vdisk, now)) {
                     failedByReadiness |= {topology, vdiskId};
                 }
-                if (vdisk.Bad) {
-                    failedByBadness |= {topology, vdiskId};
+                if (vdisk.UnavailabilityRisk) {
+                    failedByUnavailabilityRisk |= {topology, vdiskId};
                 }
             }
 
             const auto& checker = topology->GetQuorumChecker();
-            const auto failed = failedByReadiness | failedByBadness; // assume disks marked as Bad may become non-ready any moment now
+            const auto failed = failedByReadiness | failedByUnavailabilityRisk;
 
             for (const auto& [vdiskId, vdisk] : content.VDisks) {
-                if (vdisk.Faulty) {
+                if (vdisk.RequiresReassignment) {
                     const auto newFailed = failed | TBlobStorageGroupInfo::TGroupVDisks(topology, vdiskId);
                     if (!checker.CheckFailModelForGroup(newFailed)) {
                         continue; // healing this disk would break the group
@@ -697,8 +697,8 @@ namespace NKikimr::NBsController {
                         ss << "{";
                         ss << vdiskId;
                         ss << (IsReady(vdisk, now) ? " Ready" : " NotReady");
-                        ss << (vdisk.Faulty ? " Faulty" : "");
-                        ss << (vdisk.Bad ? " IsBad" : "");
+                        ss << (vdisk.RequiresReassignment ? " RequiresReassignment" : "");
+                        ss << (vdisk.UnavailabilityRisk ? " UnavailabilityRisk" : "");
                         ss << (vdisk.Decommitted ? " Decommitted" : "");
                         ss << "}";
                     }
@@ -795,10 +795,14 @@ namespace NKikimr::NBsController {
                         out << "Broken groups";
                     }
                     DIV_CLASS("panel-body") {
+                        out << "Legend:" << Endl;
+                        out << "<strong>VDisk requires reassignment</strong>" << Endl;
+                        out << "<font color='red'>VDisk is considered unreliable</font>" << Endl;
+
                         TABLE_CLASS("table-sortable table") {
                             TABLEHEAD() {
                                 ui32 numCols = 0;
-                                for (const TGroupRecord& group : GroupsWithFaultyDisks) {
+                                for (const TGroupRecord& group : GroupsWithVDisksToReassign) {
                                     numCols = Max<ui32>(numCols, group.Content.VDisks.size());
                                 }
 
@@ -810,7 +814,7 @@ namespace NKikimr::NBsController {
                                 }
                             }
                             TABLEBODY() {
-                                for (const TGroupRecord& group : GroupsWithFaultyDisks) {
+                                for (const TGroupRecord& group : GroupsWithVDisksToReassign) {
                                     TABLER() {
                                         out << "<td rowspan='2'><a href='?TabletID=" << TabletId
                                             << "&page=GroupDetail&GroupId=" << group.GroupId << "'>"
@@ -831,17 +835,17 @@ namespace NKikimr::NBsController {
                                         for (const auto& [vdiskId, vdisk] : group.Content.VDisks) {
                                             TABLED() {
                                                 const auto& l = vdisk.Location;
-                                                if (vdisk.Faulty) {
+                                                if (vdisk.RequiresReassignment) {
                                                     out << "<strong>";
                                                 }
-                                                if (vdisk.Bad) {
+                                                if (vdisk.UnavailabilityRisk) {
                                                     out << "<font color='red'>";
                                                 }
                                                 out << "[" << l.NodeId << ":" << l.PDiskId << ":" << l.VSlotId << "]";
-                                                if (vdisk.Bad) {
+                                                if (vdisk.UnavailabilityRisk) {
                                                     out << "</font>";
                                                 }
-                                                if (vdisk.Faulty) {
+                                                if (vdisk.RequiresReassignment) {
                                                     out << "</strong>";
                                                 }
                                             }
@@ -939,17 +943,17 @@ namespace NKikimr::NBsController {
                                         for (const auto& [vdiskId, vdisk] : group.Content.VDisks) {
                                             TABLED() {
                                                 const auto& l = vdisk.Location;
-                                                if (vdisk.Faulty) {
+                                                if (vdisk.RequiresReassignment) {
                                                     out << "<strong>";
                                                 }
-                                                if (vdisk.Bad) {
+                                                if (vdisk.UnavailabilityRisk) {
                                                     out << "<font color='red'>";
                                                 }
                                                 out << "[" << l.NodeId << ":" << l.PDiskId << ":" << l.VSlotId << "]";
-                                                if (vdisk.Bad) {
+                                                if (vdisk.UnavailabilityRisk) {
                                                     out << "</font>";
                                                 }
-                                                if (vdisk.Faulty) {
+                                                if (vdisk.RequiresReassignment) {
                                                     out << "</strong>";
                                                 }
                                             }
@@ -1001,35 +1005,35 @@ namespace NKikimr::NBsController {
                 continue;
             }
 
-            const TGroupInfo *p = state ? state->Groups.Find(groupId) : FindGroup(groupId);
-            Y_ABORT_UNLESS(p);
+            const TGroupInfo *groupInfo = state ? state->Groups.Find(groupId) : FindGroup(groupId);
+            Y_ABORT_UNLESS(groupInfo);
 
-            group->Generation = p->Generation;
-            group->Type = TBlobStorageGroupType(p->ErasureSpecies);
+            group->Generation = groupInfo->Generation;
+            group->Type = TBlobStorageGroupType(groupInfo->ErasureSpecies);
 
-            if (auto it = geomCache.find(p->StoragePoolId); it != geomCache.end()) {
+            if (auto it = geomCache.find(groupInfo->StoragePoolId); it != geomCache.end()) {
                 group->Geometry = it->second;
             } else {
                 const TMap<TBoxStoragePoolId, TStoragePoolInfo>& storagePools = state
                     ? state->StoragePools.Get()
                     : StoragePools;
-                const auto spIt = storagePools.find(p->StoragePoolId);
+                const auto spIt = storagePools.find(groupInfo->StoragePoolId);
                 Y_ABORT_UNLESS(spIt != storagePools.end());
                 group->Geometry = std::make_unique<TGroupGeometryInfo>(group->Type, spIt->second.GetGroupGeometry());
-                geomCache.emplace(p->StoragePoolId, group->Geometry);
+                geomCache.emplace(groupInfo->StoragePoolId, group->Geometry);
             }
 
-            for (const TVSlotInfo *slot : p->VDisksInGroup) {
+            for (const TVSlotInfo *slot : groupInfo->VDisksInGroup) {
                 group->VDisks[slot->GetVDiskId()] = {
-                    slot->VSlotId,
-                    slot->PDisk->ShouldBeSettledBySelfHeal(),
-                    slot->PDisk->BadInTermsOfSelfHeal(),
-                    slot->PDisk->Decommitted(),
-                    slot->PDisk->IsSelfHealReasonDecommit(),
-                    slot->OnlyPhantomsRemain,
-                    slot->IsReady,
-                    TMonotonic::Zero(),
-                    slot->GetStatus(),
+                    .Location = slot->VSlotId,
+                    .RequiresReassignment = slot->PDisk->ShouldBeSettledBySelfHeal(),
+                    .UnavailabilityRisk = slot->PDisk->BadInTermsOfSelfHeal(),
+                    .Decommitted =  slot->PDisk->Decommitted(),
+                    .IsSelfHealReasonDecommit = slot->PDisk->IsSelfHealReasonDecommit(),
+                    .OnlyPhantomsRemain = slot->OnlyPhantomsRemain,
+                    .IsReady = slot->IsReady,
+                    .ReadySince = TMonotonic::Zero(),
+                    .VDiskStatus = slot->GetStatus(),
                 };
             }
         }

--- a/ydb/core/mind/bscontroller/self_heal.h
+++ b/ydb/core/mind/bscontroller/self_heal.h
@@ -12,8 +12,8 @@ namespace NKikimr::NBsController {
         struct TGroupContent {
             struct TVDiskInfo {
                 TVSlotId Location;
-                bool Faulty;
-                bool Bad;
+                bool RequiresReassignment;
+                bool UnavailabilityRisk;
                 bool Decommitted;
                 bool IsSelfHealReasonDecommit;
                 bool OnlyPhantomsRemain;

--- a/ydb/core/mind/bscontroller/ut_selfheal/self_heal_actor_ut.cpp
+++ b/ydb/core/mind/bscontroller/ut_selfheal/self_heal_actor_ut.cpp
@@ -65,11 +65,11 @@ TEvControllerUpdateSelfHealInfo::TGroupContent Convert(const TIntrusivePtr<TBlob
     for (ui32 i = 0; i < info->GetTotalVDisksNum(); ++i) {
         auto& x = res.VDisks[info->GetVDiskId(i)];
         x.Location = {1, 1000 + i, 1000};
-        x.Faulty = x.Bad = faultyIndexes.count(i);
+        x.RequiresReassignment = x.UnavailabilityRisk = faultyIndexes.count(i);
         x.Decommitted = false;
         x.IsSelfHealReasonDecommit = false;
         x.OnlyPhantomsRemain = false;
-        x.IsReady = !x.Faulty;
+        x.IsReady = !x.UnavailabilityRisk;
         x.ReadySince = TMonotonic::Zero();
         x.VDiskStatus = i < status.size() ? status[i] : E::READY;
     }

--- a/ydb/core/protos/blobstorage_config.proto
+++ b/ydb/core/protos/blobstorage_config.proto
@@ -225,6 +225,15 @@ message TSerialManagementStage {
     }
 }
 
+// set by CMS
+message TMaintenanceStatus {
+    enum E {
+        NOT_SET = 0;                        // unset status, default value
+        NO_REQUEST = 1;                     // no active maintenance request
+        LONG_TERM_MAINTENANCE_PLANNED = 2;  // maintence requested, VDisks should be moved asynchronously from PDisk
+    }
+}
+
 message TUpdateDriveStatus {
     THostKey HostKey = 1; // host on which we are looking for the drive
     string Path = 2; // absolute path to the device as enlisted in PDisk configuration
@@ -233,6 +242,7 @@ message TUpdateDriveStatus {
     string Serial = 5; // may be set instead of path and PDiskId to identify PDisk
     uint64 StatusChangeTimestamp = 6; // used only in return of ReadDriveStatus
     EDecommitStatus DecommitStatus = 7;
+    TMaintenanceStatus.E MaintenanceStatus = 8;
 }
 
 message TReadDriveStatus {
@@ -648,6 +658,7 @@ message TBaseConfig {
         string ExpectedSerial = 17;
         string LastSeenSerial = 18;
         bool ReadOnly = 19;
+        TMaintenanceStatus.E MaintenanceStatus = 20; 
     }
     message TVSlot {
         message TDonorDisk {

--- a/ydb/tests/functional/scheme_tests/canondata/tablet_scheme_tests.TestTabletSchemes.test_tablet_schemes_flat_bs_controller_/flat_bs_controller.schema
+++ b/ydb/tests/functional/scheme_tests/canondata/tablet_scheme_tests.TestTabletSchemes.test_tablet_schemes_flat_bs_controller_/flat_bs_controller.schema
@@ -258,24 +258,9 @@
         ],
         "ColumnsAdded": [
             {
-                "ColumnId": 17,
-                "ColumnName": "DecommitStatus",
-                "ColumnType": "Uint32"
-            },
-            {
-                "ColumnId": 18,
-                "ColumnName": "Mood",
-                "ColumnType": "Byte"
-            },
-            {
                 "ColumnId": 1,
                 "ColumnName": "NodeID",
                 "ColumnType": "Uint32"
-            },
-            {
-                "ColumnId": 19,
-                "ColumnName": "ShredComplete",
-                "ColumnType": "Bool"
             },
             {
                 "ColumnId": 2,
@@ -341,16 +326,33 @@
                 "ColumnId": 16,
                 "ColumnName": "LastSeenPath",
                 "ColumnType": "String"
+            },
+            {
+                "ColumnId": 17,
+                "ColumnName": "DecommitStatus",
+                "ColumnType": "Uint32"
+            },
+            {
+                "ColumnId": 18,
+                "ColumnName": "Mood",
+                "ColumnType": "Byte"
+            },
+            {
+                "ColumnId": 19,
+                "ColumnName": "ShredComplete",
+                "ColumnType": "Bool"
+            },
+            {
+                "ColumnId": 20,
+                "ColumnName": "MaintenanceStatus",
+                "ColumnType": "Byte"
             }
         ],
         "ColumnsDropped": [],
         "ColumnFamilies": {
             "0": {
                 "Columns": [
-                    17,
-                    18,
                     1,
-                    19,
                     2,
                     3,
                     4,
@@ -363,7 +365,11 @@
                     13,
                     14,
                     15,
-                    16
+                    16,
+                    17,
+                    18,
+                    19,
+                    20
                 ],
                 "RoomID": 0,
                 "Codec": 0,


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

Add new PDisk status to BSC, which allows to reassign VDisks from PDisk via SelfHeal without considering VDisk erroneous. Intended to be used instead of FAULTY status when node is taken to long term maintenance.

### Changelog category <!-- remove all except one -->

* New feature
