### PR TITLE
viewer: change auth for whoami and capabilities handlers

### DIFF
--- a/ydb/core/viewer/viewer.cpp
+++ b/ydb/core/viewer/viewer.cpp
@@ -83,6 +83,18 @@ public:
                 .UseAuth = false,
             });
             mon->RegisterActorPage({
+                .RelPath = "viewer/whoami",
+                .ActorSystem = ctx.ActorSystem(),
+                .ActorId = ctx.SelfID,
+                .UseAuth = false,
+            });
+            mon->RegisterActorPage({
+                .RelPath = "viewer/json/whoami",
+                .ActorSystem = ctx.ActorSystem(),
+                .ActorId = ctx.SelfID,
+                .UseAuth = false,
+            });
+            mon->RegisterActorPage({
                 .Title = "Viewer",
                 .RelPath = "viewer/v2",
                 .ActorSystem = ctx.ActorSystem(),

--- a/ydb/core/viewer/viewer.cpp
+++ b/ydb/core/viewer/viewer.cpp
@@ -101,6 +101,12 @@ public:
                 .UseAuth = false,
             });
             mon->RegisterActorPage({
+                .Title = "Viewer",
+                .RelPath = "viewer/v2",
+                .ActorSystem = ctx.ActorSystem(),
+                .ActorId = ctx.SelfID,
+            });
+            mon->RegisterActorPage({
                 .Title = "Monitoring",
                 .RelPath = "monitoring",
                 .ActorSystem = ctx.ActorSystem(),

--- a/ydb/core/viewer/viewer.cpp
+++ b/ydb/core/viewer/viewer.cpp
@@ -83,22 +83,22 @@ public:
                 .UseAuth = false,
             });
             mon->RegisterActorPage({
+                .RelPath = "viewer/json/capabilities", // temporary handling of old paths
+                .ActorSystem = ctx.ActorSystem(),
+                .ActorId = ctx.SelfID,
+                .UseAuth = false,
+            });
+            mon->RegisterActorPage({
                 .RelPath = "viewer/whoami",
                 .ActorSystem = ctx.ActorSystem(),
                 .ActorId = ctx.SelfID,
                 .UseAuth = false,
             });
             mon->RegisterActorPage({
-                .RelPath = "viewer/json/whoami",
+                .RelPath = "viewer/json/whoami", // temporary handling of old paths
                 .ActorSystem = ctx.ActorSystem(),
                 .ActorId = ctx.SelfID,
                 .UseAuth = false,
-            });
-            mon->RegisterActorPage({
-                .Title = "Viewer",
-                .RelPath = "viewer/v2",
-                .ActorSystem = ctx.ActorSystem(),
-                .ActorId = ctx.SelfID,
             });
             mon->RegisterActorPage({
                 .Title = "Monitoring",


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

viewer: change auth for `whoami` and `capabilities` handlers

### Changelog category <!-- remove all except one -->

* User Interface

### Description for reviewers <!-- (optional) description for those who read this PR -->
Changing auth for `whoami` is required for database list dispaying