### PR TITLE
Add root user attribute to keep gizmo resource id

### DIFF
--- a/ydb/core/grpc_services/grpc_request_check_actor.h
+++ b/ydb/core/grpc_services/grpc_request_check_actor.h
@@ -57,7 +57,9 @@ inline TVector<TEvTicketParser::TEvAuthorizeTicket::TEntry> GetEntriesForAuthAnd
 		};
 		return entries;
 	} else if (accessServiceType == "Nebius_v1") {
-		TVector<TString> permissions = {"ydb.clusters.get", "ydb.clusters.monitor", "ydb.clusters.manage"};
+        static const auto permissions = NKikimr::TEvTicketParser::TEvAuthorizeTicket::ToPermissions({
+            "ydb.clusters.get", "ydb.clusters.monitor", "ydb.clusters.manage"
+        });
 		auto it = std::find_if(rootAttributes.begin(), rootAttributes.end(),
 		[](const std::pair<TString, TString>& p) {
 			return p.first == "container_id";
@@ -66,7 +68,7 @@ inline TVector<TEvTicketParser::TEvAuthorizeTicket::TEntry> GetEntriesForAuthAnd
 			return {};
 		}
 		return {
-			{NKikimr::TEvTicketParser::TEvAuthorizeTicket::ToPermissions(permissions), {{"gizmo_id", it->second}}}
+			{permissions, {{"gizmo_id", it->second}}}
 		};
 	} else {
 		return {};

--- a/ydb/core/grpc_services/grpc_request_check_actor.h
+++ b/ydb/core/grpc_services/grpc_request_check_actor.h
@@ -51,28 +51,28 @@ inline TVector<TEvTicketParser::TEvAuthorizeTicket::TEntry> GetEntriesForAuthAnd
 
     const TString& accessServiceType = AppData()->AuthConfig.GetAccessServiceType();
 
-	if (accessServiceType == "Yandex_v2") {
-		static const TVector<NKikimr::TEvTicketParser::TEvAuthorizeTicket::TEntry> entries = {
-			{NKikimr::TEvTicketParser::TEvAuthorizeTicket::ToPermissions({"ydb.developerApi.get", "ydb.developerApi.update"}), {{"gizmo_id", "gizmo"}}}
-		};
-		return entries;
-	} else if (accessServiceType == "Nebius_v1") {
+    if (accessServiceType == "Yandex_v2") {
+        static const TVector<NKikimr::TEvTicketParser::TEvAuthorizeTicket::TEntry> entries = {
+            {NKikimr::TEvTicketParser::TEvAuthorizeTicket::ToPermissions({"ydb.developerApi.get", "ydb.developerApi.update"}), {{"gizmo_id", "gizmo"}}}
+        };
+        return entries;
+    } else if (accessServiceType == "Nebius_v1") {
         static const auto permissions = NKikimr::TEvTicketParser::TEvAuthorizeTicket::ToPermissions({
             "ydb.clusters.get", "ydb.clusters.monitor", "ydb.clusters.manage"
         });
-		auto it = std::find_if(rootAttributes.begin(), rootAttributes.end(),
-		[](const std::pair<TString, TString>& p) {
-			return p.first == "container_id";
-		});
-		if (it == rootAttributes.end()) {
-			return {};
-		}
-		return {
-			{permissions, {{"gizmo_id", it->second}}}
-		};
-	} else {
-		return {};
-	}
+        auto it = std::find_if(rootAttributes.begin(), rootAttributes.end(),
+        [](const std::pair<TString, TString>& p) {
+            return p.first == "container_id";
+        });
+        if (it == rootAttributes.end()) {
+            return {};
+        }
+        return {
+            {permissions, {{"gizmo_id", it->second}}}
+        };
+    } else {
+        return {};
+    }
 }
 
 template <typename TEvent>

--- a/ydb/core/grpc_services/grpc_request_proxy.cpp
+++ b/ydb/core/grpc_services/grpc_request_proxy.cpp
@@ -181,7 +181,6 @@ private:
 
         TString databaseName;
         const TDatabaseInfo* database = nullptr;
-        TVector<std::pair<TString, TString>> rootAttributes;
         bool skipResourceCheck = false;
         // do not check connect rights for the deprecated requests without database
         // remove this along with AllowYdbRequestsWithoutDatabase flag
@@ -225,21 +224,28 @@ private:
                 }
                 return;
             }
-
-            auto rootIt = Databases.find(RootDatabase);
-            if (rootIt != Databases.end() && rootIt->second.IsDatabaseReady()) {
-                const TDatabaseInfo* rootDb = &it->second;
-                if (rootDb && rootDb->SchemeBoardResult) {
-                    auto& schemeData = rootDb->SchemeBoardResult->DescribeSchemeResult;
-                    rootAttributes.reserve(schemeData.GetPathDescription().UserAttributesSize());
-                    for (const auto& attr : schemeData.GetPathDescription().GetUserAttributes()) {
-                        rootAttributes.emplace_back(std::make_pair(attr.GetKey(), attr.GetValue()));
-                    }
-                }
-            }
         }
 
         if (database) {
+            TVector<std::pair<TString, TString>> rootAttributes;
+            auto rootIt = Databases.find(RootDatabase);
+            if (rootIt == Databases.end() || !rootIt->second.IsDatabaseReady() || !rootIt->second.SchemeBoardResult) {
+                Counters->IncDatabaseUnavailableCounter();
+                const TString error = "Grpc proxy is not ready to accept request, root database unknown";
+                LOG_ERROR(ctx, NKikimrServices::GRPC_SERVER, error);
+                const auto issue = MakeIssue(NKikimrIssues::TIssuesIds::YDB_DB_NOT_READY, error);
+                requestBaseCtx->RaiseIssue(issue);
+                requestBaseCtx->ReplyWithYdbStatus(Ydb::StatusIds::UNAVAILABLE);
+                requestBaseCtx->FinishSpan();
+                return;
+            }
+
+            const auto& schemeData = rootIt->second.SchemeBoardResult->DescribeSchemeResult;
+            rootAttributes.reserve(schemeData.GetPathDescription().UserAttributesSize());
+            for (const auto& attr : schemeData.GetPathDescription().GetUserAttributes()) {
+                rootAttributes.emplace_back(std::make_pair(attr.GetKey(), attr.GetValue()));
+            }
+
             if (database->SchemeBoardResult) {
                 const auto& domain = database->SchemeBoardResult->DescribeSchemeResult.GetPathDescription().GetDomainDescription();
                 if (domain.HasResourcesDomainKey() && !skipResourceCheck && DynamicNode) {

--- a/ydb/core/grpc_services/grpc_request_proxy_simple.cpp
+++ b/ydb/core/grpc_services/grpc_request_proxy_simple.cpp
@@ -132,7 +132,7 @@ private:
 
         {
             TSchemeBoardEvents::TDescribeSchemeResult schemeData;
-            Register(CreateGrpcRequestCheckActor<TEvent>(SelfId(), schemeData, nullptr, event.Release(), Counters, false, this));
+            Register(CreateGrpcRequestCheckActor<TEvent>(SelfId(), schemeData, nullptr, event.Release(), Counters, false, {}, this));
             return;
         }
 

--- a/ydb/core/protos/auth.proto
+++ b/ydb/core/protos/auth.proto
@@ -58,7 +58,6 @@ message TAuthConfig {
     optional string NodeRegistrationToken = 82 [default = "root@builtin", (Ydb.sensitive) = true];
     optional TPasswordComplexity PasswordComplexity = 83;
     optional TAccountLockout AccountLockout = 84;
-    optional string ClusterAccessResourceId = 85 [default = "gizmo"];
 }
 
 message TUserRegistryConfig {

--- a/ydb/core/security/ticket_parser_impl.h
+++ b/ydb/core/security/ticket_parser_impl.h
@@ -462,7 +462,7 @@ private:
         pathsContainer->mutable_resource_path()->add_path()->set_id(id);
     }
 
-    static void AddNebiusContainerId(nebius::iam::v1::AuthorizeCheck* pathsContainer, const TString& id) {
+    static void SetNebiusContainerId(nebius::iam::v1::AuthorizeCheck* pathsContainer, const TString& id) {
         pathsContainer->set_container_id(id);
     }
 
@@ -474,17 +474,17 @@ private:
             AddNebiusResourcePath(pathsContainer, databaseId);
         }
 
+        // Use attribute "gizmo_id" as container id that contains cluster access resource
+        // IAM can link roles for cluster access resource
+        // Note: "gizmo_id" and "folder_id" are always sent in separate TEvAuthorizeTicket requests
+        if (const auto gizmoId = record.GetAttributeValue(permission, "gizmo_id"); gizmoId) {
+            SetNebiusContainerId(pathsContainer, gizmoId);
+        }
+
         // Use attribute "folder_id" as container id that contains our database
         // IAM can link roles for containers hierarchy
         if (const auto folderId = record.GetAttributeValue(permission, "folder_id"); folderId) {
-            AddNebiusContainerId(pathsContainer, folderId);
-        }
-
-        // Use attribute "gizmo_id" as container id that contains cluster access resource
-        // IAM can link roles for cluster access resource
-        // Note: "gizmo_id" and "folder_id" are always sent in separate TEvAuthorizeTicket requests.
-        if (const auto gizmoId = record.GetAttributeValue(permission, "gizmo_id"); gizmoId) {
-            AddNebiusContainerId(pathsContainer, gizmoId);
+            SetNebiusContainerId(pathsContainer, folderId);
         }
     }
 

--- a/ydb/core/security/ticket_parser_impl.h
+++ b/ydb/core/security/ticket_parser_impl.h
@@ -482,6 +482,7 @@ private:
 
         // Use attribute "gizmo_id" as container id that contains cluster access resource
         // IAM can link roles for cluster access resource
+        // Note: "gizmo_id" and "folder_id" are always sent in separate TEvAuthorizeTicket requests.
         if (const auto gizmoId = record.GetAttributeValue(permission, "gizmo_id"); gizmoId) {
             AddNebiusContainerId(pathsContainer, gizmoId);
         }


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

Store the access resource ID for cluster information as the `container_id` user attribute in the root database. Users can check permissions on this resource to access cluster-related information.

### Changelog category <!-- remove all except one -->

* Improvement

### Description for reviewers <!-- (optional) description for those who read this PR -->

This replaces the previous approach of storing the resource in configuration, as implemented in issue https://github.com/ydb-platform/ydb/pull/16614
For backward compatibility, if `container_id` is not present, its value is `gizmo.