### PR TITLE
Add secondary index by revision.

### DIFF
--- a/ydb/apps/etcd_proxy/service/create.sql
+++ b/ydb/apps/etcd_proxy/service/create.sql
@@ -20,7 +20,8 @@ CREATE TABLE history
     `version` Int64 NOT NULL,
     `value` Bytes NOT NULL,
     `lease` Int64 NOT NULL,
-    PRIMARY KEY (`key`, `modified`)
+    PRIMARY KEY (`key`, `modified`),
+    INDEX `revision` GLOBAL ON (`modified`)
 )
 WITH (AUTO_PARTITIONING_BY_LOAD = ENABLED, AUTO_PARTITIONING_MIN_PARTITIONS_COUNT = 23, AUTO_PARTITIONING_PARTITION_SIZE_MB = 101);
 

--- a/ydb/apps/etcd_proxy/service/etcd_impl.cpp
+++ b/ydb/apps/etcd_proxy/service/etcd_impl.cpp
@@ -36,7 +36,7 @@ struct TOperation {
 
 void MakeSlice(const std::string_view& where, std::ostream& sql, NYdb::TParamsBuilder& params, size_t* paramsCounter = nullptr, const i64 revision = 0LL) {
     if (revision) {
-        sql << "select * from (select max_by(TableRow(), `modified`) from `history`" << where;
+        sql << "select * from (select max_by(TableRow(), `modified`) from `history` view `revision`" << where;
         sql << " and " << AddParam("Rev", params, revision, paramsCounter) << " >= `modified`";
         sql << " group by `key`) flatten columns where 0L < `version`";
     } else {
@@ -1102,7 +1102,7 @@ private:
 
     void MakeQueryWithParams(std::ostream& sql, NYdb::TParamsBuilder& params) final {
         sql << "$Trash = select c.key as key, c.modified as modified from `history` as c inner join (" << std::endl;
-        sql << "select max_by((`key`, `modified`), `modified`) as pair from `history`" << std::endl;
+        sql << "select max_by((`key`, `modified`), `modified`) as pair from `history` view `revision`" << std::endl;
         sql << "where `modified` < " << AddParam("Revision", params, KeyRevision) << " and 0L = `version` group by `key`" << std::endl;
         sql << ") as keys on keys.pair.0 = c.key where c.modified <= keys.pair.1;" << std::endl;
         sql << "delete from `history` on select * from $Trash;" << std::endl;

--- a/ydb/apps/etcd_proxy/service/etcd_watch.cpp
+++ b/ydb/apps/etcd_proxy/service/etcd_watch.cpp
@@ -172,7 +172,7 @@ private:
         std::ostringstream sql;
         sql << Stuff->TablePrefix;
         if (WithPrevious) {
-            sql << "select * from (select max_by(TableRow(), `modified`) from `history` where " << revName << " > `modified` and " << where.view() << " group by `key`) flatten columns union all" << std::endl;
+            sql << "select * from (select max_by(TableRow(), `modified`) from `history` view `revision` where " << revName << " > `modified` and " << where.view() << " group by `key`) flatten columns union all" << std::endl;
         }
         sql << "select * from `history` where " << revName << " <= `modified` and " << where.view() << " order by `modified` asc;" << std::endl;
 //      std::cout << std::endl << sql.view() << std::endl;


### PR DESCRIPTION
С этим изменением локально всё ok, но на кубер кластере я из всех запросов, пытавшихся использовать индекс получил отлуп вида:
CompactionRequest finished with errors: <main>: Error: Intermediate data materialization exceeded size limit (274237067 > 50331648). This usually happens when trying to write large amounts of data or to perform lookup by big collection of keys in single query. Consider using smaller batches of data., code: 2013
Это возможно как-то победить?
