### PR TITLE
[pq] restore rtmr/CT_PERS_QUEUE compatibility

### DIFF
--- a/ydb/library/yql/providers/pq/gateway/native/yql_pq_session.cpp
+++ b/ydb/library/yql/providers/pq/gateway/native/yql_pq_session.cpp
@@ -91,8 +91,7 @@ IPqGateway::TAsyncDescribeFederatedTopicResult TPqSession::DescribeFederatedTopi
 
     TString database = requestedDatabase;
     TString path = requestedPath;
-    if (config->GetClusterType() == TPqClusterConfig::CT_PERS_QUEUE) {
-        Y_ENSURE(requestedDatabase == "/Root", requestedDatabase);
+    if (config->GetClusterType() == TPqClusterConfig::CT_PERS_QUEUE && requestedDatabase == "/Root") {
         auto pos = requestedPath.find('/');
         Y_ENSURE(pos != TString::npos, "topic name is expected in format <account>/<path>");
         database = "/logbroker-federation/" + requestedPath.substr(0, pos);

--- a/ydb/library/yql/providers/pq/gateway/native/yql_pq_session.cpp
+++ b/ydb/library/yql/providers/pq/gateway/native/yql_pq_session.cpp
@@ -92,6 +92,8 @@ IPqGateway::TAsyncDescribeFederatedTopicResult TPqSession::DescribeFederatedTopi
     TString database = requestedDatabase;
     TString path = requestedPath;
     if (config->GetClusterType() == TPqClusterConfig::CT_PERS_QUEUE && requestedDatabase == "/Root") {
+        // RTMR compatibility
+        // It uses cluster specified in gateways.conf with ClusterType unset (CT_PERS_QUEUE by default) and default Database and its own read/write code
         auto pos = requestedPath.find('/');
         Y_ENSURE(pos != TString::npos, "topic name is expected in format <account>/<path>");
         database = "/logbroker-federation/" + requestedPath.substr(0, pos);

--- a/ydb/library/yql/providers/pq/gateway/native/yql_pq_session.cpp
+++ b/ydb/library/yql/providers/pq/gateway/native/yql_pq_session.cpp
@@ -83,12 +83,21 @@ NYdb::NDataStreams::V1::TDataStreamsClient& TPqSession::GetDsClient(const TStrin
     return ClusterDsClients.emplace(cluster, NYdb::NDataStreams::V1::TDataStreamsClient(YdbDriver, GetDsClientOptions(database, cfg, credentialsProviderFactory))).first->second;
 }
 
-IPqGateway::TAsyncDescribeFederatedTopicResult TPqSession::DescribeFederatedTopic(const TString& cluster, const TString& database, const TString& path, const TString& token) {
+IPqGateway::TAsyncDescribeFederatedTopicResult TPqSession::DescribeFederatedTopic(const TString& cluster, const TString& requestedDatabase, const TString& requestedPath, const TString& token) {
     const auto* config = ClusterConfigs->FindPtr(cluster);
     if (!config) {
         ythrow yexception() << "Pq cluster `" << cluster << "` does not exist";
     }
 
+    TString database = requestedDatabase;
+    TString path = requestedPath;
+    if (config->GetClusterType() == TPqClusterConfig::CT_PERS_QUEUE) {
+        Y_ENSURE(requestedDatabase == "/Root", requestedDatabase);
+        auto pos = requestedPath.find('/');
+        Y_ENSURE(pos != TString::npos, "topic name is expected in format <account>/<path>");
+        database = "/logbroker-federation/" + requestedPath.substr(0, pos);
+        path = requestedPath.substr(pos + 1);
+    }
     YQL_ENSURE(config->GetEndpoint(), "Can't describe topic `" << cluster << "`.`" << path << "`: no endpoint");
 
     std::shared_ptr<NYdb::ICredentialsProviderFactory> credentialsProviderFactory = CreateCredentialsProviderFactoryForStructuredToken(CredentialsFactory, token, config->GetAddBearerToToken());

--- a/ydb/library/yql/providers/pq/provider/yql_pq_dq_integration.cpp
+++ b/ydb/library/yql/providers/pq/provider/yql_pq_dq_integration.cpp
@@ -162,10 +162,9 @@ public:
                 srcDesc.SetClusterType(ToClusterType(clusterDesc->ClusterType));
                 auto topicPath = topic.Path().Value();
                 auto topicDatabase = topic.Database().Value();
-                if (clusterDesc->ClusterType == NYql::TPqClusterConfig::CT_PERS_QUEUE) {
+                if (clusterDesc->ClusterType == NYql::TPqClusterConfig::CT_PERS_QUEUE && topicDatabase == "/Root") {
                     auto pos = topicPath.find('/');
                     Y_ENSURE(pos != TStringBuf::npos);
-                    Y_ENSURE(topicDatabase == "/Root");
                     srcDesc.SetTopicPath(TString(topicPath.substr(pos + 1)));
                     srcDesc.SetDatabase("/logbroker-federation/" + TString(topicPath.substr(0, pos)));
                 } else {
@@ -285,10 +284,9 @@ public:
                 sinkDesc.SetClusterType(ToClusterType(clusterDesc->ClusterType));
                 auto topicPath = topic.Path().Value();
                 auto topicDatabase = topic.Database().Value();
-                if (clusterDesc->ClusterType == NYql::TPqClusterConfig::CT_PERS_QUEUE) {
+                if (clusterDesc->ClusterType == NYql::TPqClusterConfig::CT_PERS_QUEUE && topicDatabase == "/Root") {
                     auto pos = topicPath.find('/');
                     Y_ENSURE(pos != TStringBuf::npos);
-                    Y_ENSURE(topicDatabase == "/Root");
                     sinkDesc.SetTopicPath(TString(topicPath.substr(pos + 1)));
                     sinkDesc.SetDatabase("/logbroker-federation/" + TString(topicPath.substr(0, pos)));
                 } else {

--- a/ydb/library/yql/providers/pq/provider/yql_pq_dq_integration.cpp
+++ b/ydb/library/yql/providers/pq/provider/yql_pq_dq_integration.cpp
@@ -156,12 +156,22 @@ public:
                 TDqPqTopicSource topicSource = maybeTopicSource.Cast();
 
                 TPqTopic topic = topicSource.Topic();
-                srcDesc.SetTopicPath(TString(topic.Path().Value()));
-                srcDesc.SetDatabase(TString(topic.Database().Value()));
                 const TStringBuf cluster = topic.Cluster().Value();
                 const auto* clusterDesc = State_->Configuration->ClustersConfigurationSettings.FindPtr(cluster);
                 YQL_ENSURE(clusterDesc, "Unknown cluster " << cluster);
                 srcDesc.SetClusterType(ToClusterType(clusterDesc->ClusterType));
+                auto topicPath = topic.Path().Value();
+                auto topicDatabase = topic.Database().Value();
+                if (clusterDesc->ClusterType == NYql::TPqClusterConfig::CT_PERS_QUEUE) {
+                    auto pos = topicPath.find('/');
+                    Y_ENSURE(pos != TStringBuf::npos);
+                    Y_ENSURE(topicDatabase == "/Root");
+                    srcDesc.SetTopicPath(TString(topicPath.substr(pos + 1)));
+                    srcDesc.SetDatabase("/logbroker-federation/" + TString(topicPath.substr(0, pos)));
+                } else {
+                    srcDesc.SetTopicPath(TString(topicPath));
+                    srcDesc.SetDatabase(TString(topicDatabase));
+                }
                 srcDesc.SetDatabaseId(clusterDesc->DatabaseId);
 
                 const TStructExprType* fullRowType = topicSource.RowType().Ref().GetTypeAnn()->Cast<TTypeExprType>()->GetType()->Cast<TStructExprType>();
@@ -273,8 +283,18 @@ public:
                 const auto* clusterDesc = State_->Configuration->ClustersConfigurationSettings.FindPtr(cluster);
                 YQL_ENSURE(clusterDesc, "Unknown cluster " << cluster);
                 sinkDesc.SetClusterType(ToClusterType(clusterDesc->ClusterType));
-                sinkDesc.SetTopicPath(TString(topic.Path().Value()));
-                sinkDesc.SetDatabase(TString(topic.Database().Value()));
+                auto topicPath = topic.Path().Value();
+                auto topicDatabase = topic.Database().Value();
+                if (clusterDesc->ClusterType == NYql::TPqClusterConfig::CT_PERS_QUEUE) {
+                    auto pos = topicPath.find('/');
+                    Y_ENSURE(pos != TStringBuf::npos);
+                    Y_ENSURE(topicDatabase == "/Root");
+                    sinkDesc.SetTopicPath(TString(topicPath.substr(pos + 1)));
+                    sinkDesc.SetDatabase("/logbroker-federation/" + TString(topicPath.substr(0, pos)));
+                } else {
+                    sinkDesc.SetTopicPath(TString(topicPath));
+                    sinkDesc.SetDatabase(TString(topicDatabase));
+                }
 
                 size_t const settingsCount = topicSink.Settings().Size();
                 for (size_t i = 0; i < settingsCount; ++i) {


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

...

### Changelog category <!-- remove all except one -->

* Not for changelog (changelog entry is not required)

### Description for reviewers <!-- (optional) description for those who read this PR -->

Only needed for RTMR compatibility.
Actually, `dq_pq_{read,write}` are not used in rtmr, only discovery needs to be supported, they are changed to avoid confusing incompatibility