### PR TITLE
fix: prevent NaN in thread pool stats

### DIFF
--- a/ydb/core/util/cpuinfo.cpp
+++ b/ydb/core/util/cpuinfo.cpp
@@ -108,18 +108,18 @@ std::vector<NKikimr::TSystemThreadsMonitor::TSystemThreadPoolInfo> NKikimr::TSys
         if (passedSeconds > 0.0) {
     	    info.MajorPageFaults = double(majorPageFaults) / passedSeconds;
     	    info.MinorPageFaults = double(minorPageFaults) / passedSeconds;
-	} else {
-    	    info.MajorPageFaults = 0;
-    	    info.MinorPageFaults = 0;
-	}
+        } else {
+            info.MajorPageFaults = 0.0;
+            info.MinorPageFaults = 0.0;
+        }
 
-	if (ticks > 0.0 && info.Threads > 0) {
-    	    info.SystemUsage = double(systemTime) / ticks / info.Threads;
-    	    info.UserUsage = double(userTime) / ticks / info.Threads;
-	} else {
-    	    info.SystemUsage = 0;
-    	    info.UserUsage = 0;
-	}
+        if (ticks > 0.0 && info.Threads > 0) {
+            info.SystemUsage = double(systemTime) / ticks / info.Threads;
+            info.UserUsage = double(userTime) / ticks / info.Threads;
+        } else {
+            info.SystemUsage = 0.0;
+            info.UserUsage = 0.0;
+        }
     }
     UpdateTime = now;
     return result;

--- a/ydb/core/util/cpuinfo.cpp
+++ b/ydb/core/util/cpuinfo.cpp
@@ -105,10 +105,21 @@ std::vector<NKikimr::TSystemThreadsMonitor::TSystemThreadPoolInfo> NKikimr::TSys
                 info.States.emplace_back(c, states[c]);
             }
         }
-        info.MajorPageFaults = double(majorPageFaults) / passedSeconds;
-        info.MinorPageFaults = double(minorPageFaults) / passedSeconds;
-        info.SystemUsage = double(systemTime) / ticks / info.Threads;
-        info.UserUsage = double(userTime) / ticks / info.Threads;
+        if (passedSeconds > 0.0) {
+    		info.MajorPageFaults = double(majorPageFaults) / passedSeconds;
+    		info.MinorPageFaults = double(minorPageFaults) / passedSeconds;
+		} else {
+    		info.MajorPageFaults = 0;
+    		info.MinorPageFaults = 0;
+		}
+
+		if (ticks > 0.0 && info.Threads > 0) {
+    		info.SystemUsage = double(systemTime) / ticks / info.Threads;
+    		info.UserUsage = double(userTime) / ticks / info.Threads;
+		} else {
+    		info.SystemUsage = 0;
+    		info.UserUsage = 0;
+		}
     }
     UpdateTime = now;
     return result;

--- a/ydb/core/util/cpuinfo.cpp
+++ b/ydb/core/util/cpuinfo.cpp
@@ -109,16 +109,16 @@ std::vector<NKikimr::TSystemThreadsMonitor::TSystemThreadPoolInfo> NKikimr::TSys
     	    info.MajorPageFaults = double(majorPageFaults) / passedSeconds;
     	    info.MinorPageFaults = double(minorPageFaults) / passedSeconds;
         } else {
-            info.MajorPageFaults = 0.0;
-            info.MinorPageFaults = 0.0;
+            info.MajorPageFaults = 0;
+            info.MinorPageFaults = 0;
         }
 
         if (ticks > 0.0 && info.Threads > 0) {
             info.SystemUsage = double(systemTime) / ticks / info.Threads;
             info.UserUsage = double(userTime) / ticks / info.Threads;
         } else {
-            info.SystemUsage = 0.0;
-            info.UserUsage = 0.0;
+            info.SystemUsage = 0.0f;
+            info.UserUsage = 0.0f;
         }
     }
     UpdateTime = now;

--- a/ydb/core/util/cpuinfo.cpp
+++ b/ydb/core/util/cpuinfo.cpp
@@ -106,20 +106,20 @@ std::vector<NKikimr::TSystemThreadsMonitor::TSystemThreadPoolInfo> NKikimr::TSys
             }
         }
         if (passedSeconds > 0.0) {
-    		info.MajorPageFaults = double(majorPageFaults) / passedSeconds;
-    		info.MinorPageFaults = double(minorPageFaults) / passedSeconds;
-		} else {
-    		info.MajorPageFaults = 0;
-    		info.MinorPageFaults = 0;
-		}
+    	    info.MajorPageFaults = double(majorPageFaults) / passedSeconds;
+    	    info.MinorPageFaults = double(minorPageFaults) / passedSeconds;
+	} else {
+    	    info.MajorPageFaults = 0;
+    	    info.MinorPageFaults = 0;
+	}
 
-		if (ticks > 0.0 && info.Threads > 0) {
-    		info.SystemUsage = double(systemTime) / ticks / info.Threads;
-    		info.UserUsage = double(userTime) / ticks / info.Threads;
-		} else {
-    		info.SystemUsage = 0;
-    		info.UserUsage = 0;
-		}
+	if (ticks > 0.0 && info.Threads > 0) {
+    	    info.SystemUsage = double(systemTime) / ticks / info.Threads;
+    	    info.UserUsage = double(userTime) / ticks / info.Threads;
+	} else {
+    	    info.SystemUsage = 0;
+    	    info.UserUsage = 0;
+	}
     }
     UpdateTime = now;
     return result;


### PR DESCRIPTION
ub_sanitizer нашел попытку преобразовать NaN в unsigned int 

```
/place/sandbox-data/tasks/8/8/3053489088/__FUSE/mount_path_85659d51-ce9b-4cfe-bbaa-40809fb5ff23/contrib/ydb/core/util/cpuinfo.cpp:108:32: runtime error: -nan is outside the range of representable values of type 'unsigned int'
    #0 0x35c666d6 in NKikimr::TSystemThreadsMonitor::GetThreadPools(TInstant) /-S/contrib/ydb/core/util/cpuinfo.cpp:108:32
    #1 0x35c0d648 in NKikimr::NNodeWhiteboard::TNodeWhiteboardService::Handle(TAutoPtr<NActors::TEventHandle<NKikimr::NNodeWhiteboard::TNodeWhiteboardService::TEvPrivate::TEvUpdateRuntimeStats>, TDelete>&, NActors::TActorContext const&) /-S/contrib/ydb/core/tablet/node_whiteboard.cpp:1152:43
    #2 0x35bfa08c in NKikimr::NNodeWhiteboard::TNodeWhiteboardService::StateFunc(TAutoPtr<NActors::IEventHandle, TDelete>&) /-S/contrib/ydb/core/tablet/node_whiteboard.cpp:526:5
    #3 0x16ebbd43 in NActors::IActor::Receive(TAutoPtr<NActors::IEventHandle, TDelete>&) /-S/contrib/ydb/library/actors/core/actor.cpp:280:13
    #4 0x331e74cb in NActors::TTestActorRuntimeBase::SendInternal(TAutoPtr<NActors::IEventHandle, TDelete>, unsigned int, bool) /-S/contrib/ydb/library/actors/testlib/test_runtime.cpp:1702:33
    #5 0x331dfe6a in NActors::TTestActorRuntimeBase::DispatchEventsInternal(NActors::TDispatchOptions const&, TInstant) /-S/contrib/ydb/library/actors/testlib/test_runtime.cpp:1295:45
    #6 0x331dd77e in NActors::TTestActorRuntimeBase::DispatchEvents(NActors::TDispatchOptions const&, TInstant) /-S/contrib/ydb/library/actors/testlib/test_runtime.cpp:1091:16
    #7 0x1203075c in NCloud::NStorage::(anonymous namespace)::BootHiveMock(NActors::TTestActorRuntime&, unsigned long, TIntrusivePtr<NCloud::NStorage::(anonymous namespace)::THiveMockState, TDefaultIntrusivePtrOps<NCloud::NStorage::(anonymous namespace)::THiveMockState>>, NCloud::NStorage::(anonymous namespace)::EExternalBootOptions) /-S/cloud/storage/core/libs/hive_proxy/hive_proxy_ut.cpp:415:17
    #8 0x11fe3d57 in NCloud::NStorage::(anonymous namespace)::TTestEnv::TTestEnv(NActors::TTestActorRuntime&, TBasicString<char, std::__y1::char_traits<char>>, bool, bool, bool) /-S/cloud/storage/core/libs/hive_proxy/hive_proxy_ut.cpp:447:9
    #9 0x11fef7e7 in NCloud::NStorage::NTestSuiteTHiveProxyTest::TTestCaseLockReconnected::Execute_(NUnitTest::TTestContext&) /-S/cloud/storage/core/libs/hive_proxy/hive_proxy_ut.cpp:909:18
    #10 0x1202d38f in NCloud::NStorage::NTestSuiteTHiveProxyTest::TCurrentTest::Execute()::'lambda'()::operator()() const /-S/cloud/storage/core/libs/hive_proxy/hive_proxy_ut.cpp:802:1
    #11 0x12545679 in NUnitTest::TTestBase::Run(std::__y1::function<void ()>, TBasicString<char, std::__y1::char_traits<char>> const&, char const*, bool) /-S/library/cpp/testing/unittest/registar.cpp:373:18
    #12 0x1202b74f in NCloud::NStorage::NTestSuiteTHiveProxyTest::TCurrentTest::Execute() /-S/cloud/storage/core/libs/hive_proxy/hive_proxy_ut.cpp:802:1
    #13 0x12547045 in NUnitTest::TTestFactory::Execute() /-S/library/cpp/testing/unittest/registar.cpp:494:19
    #14 0x1256700c in NUnitTest::RunMain(int, char**) /-S/library/cpp/testing/unittest/utmain.cpp:872:44
    #15 0x7f582a8d8082 in __libc_start_main (/lib/x86_64-linux-gnu/libc.so.6+0x24082) (BuildId: 1878e6b475720c7c51969e69ab2d276fae6d1dee)
    #16 0x1001f028 in _start (/tmp/3053489088/tmpscdMvC/build_root/fxqa/007ce8/cloud/storage/core/libs/hive_proxy/ut/cloud-storage-core-libs-hive_proxy-ut+0x1001f028) (BuildId: 6ff85f4ee4c5af508adb6bac1d7e58f9d8052d10)
SUMMARY: UndefinedBehaviorSanitizer: undefined-behavior /place/sandbox-data/tasks/8/8/3053489088/__FUSE/mount_path_85659d51-ce9b-4cfe-bbaa-40809fb5ff23/contrib/ydb/core/util/cpuinfo.cpp:108:32
```

### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->
https://github.com/ydb-platform/ydb/issues/17994
handle zero time delta to avoid NaN in thread metrics


### Changelog category <!-- remove all except one -->


* Bugfix  

### Description for reviewers <!-- (optional) description for those who read this PR -->

...
