### PR TITLE
CI: fix seaching existed `Update muted_ya` PR

### DIFF
--- a/.github/scripts/create_or_update_pr.py
+++ b/.github/scripts/create_or_update_pr.py
@@ -3,9 +3,11 @@ import os
 import argparse
 from github import Github
 
+
 def read_body_from_file(file_path):
     with open(file_path, 'r') as file:
         return file.read()
+
 
 def get_body_content(body_input):
     """Determines if the body content is a file path or direct text."""
@@ -16,51 +18,60 @@ def get_body_content(body_input):
         print(f"Body content will be taken directly: '{body_input}.'")
         return body_input
 
+
 def create_or_update_pr(args, repo):
     current_pr = None
     pr_number = None
     body = get_body_content(args.body)
 
-    # Check for an existing PR
-    existing_prs = repo.get_pulls(head=args.branch_for_pr, base=args.base_branch, state='open')
-    for pr in existing_prs:
-        if pr.base.ref == args.base_branch and pr.head.ref == args.branch_for_pr:
-            current_pr = pr
-            break
+    owner = repo.owner.login
+    head_format = f"{owner}:{args.branch_for_pr}"
+
+    print(f"Searching for PR with head branch '{head_format}' and base branch '{args.base_branch}'")
+
+    existing_prs = repo.get_pulls(head=head_format, base=args.base_branch, state='open')
+
+    if existing_prs.totalCount > 0:
+        current_pr = existing_prs[0]
+        print(f"Found existing PR #{current_pr.number}: {current_pr.title}")
+
     if current_pr:
-        print(f"Existing PR found. Updating PR #{current_pr.number}.")
+        print(f"Updating existing PR #{current_pr.number}.")
         current_pr.edit(title=args.title, body=body)
+        print(f"PR #{current_pr.number} updated successfully.")
     else:
-        print("No existing PR found. Creating a new PR.")
-        current_pr = repo.create_pull(title=args.title, body=body, head=args.branch_for_pr, base=args.base_branch)
+        print(f"No existing PR found. Creating a new PR from '{args.branch_for_pr}' to '{args.base_branch}'.")
+        try:
+            current_pr = repo.create_pull(title=args.title, body=body, head=args.branch_for_pr, base=args.base_branch)
+            print(f"New PR #{current_pr.number} created successfully.")
+        except Exception as e:
+            print(f"Error creating PR: {str(e)}")
+            raise
 
     pr_number = current_pr.number
-    if os.environ['GITHUB_OUTPUT']:
+    if 'GITHUB_OUTPUT' in os.environ and os.environ['GITHUB_OUTPUT']:
         with open(os.environ['GITHUB_OUTPUT'], 'a') as gh_out:
             print(f"pr_number={pr_number}", file=gh_out)
 
-    print(f"PR created or updated successfully. PR number: {pr_number}")
+    print(f"PR operation completed. PR number: {pr_number}")
+    return pr_number
+
 
 def append_to_pr_body(args, repo):
     body_to_append = get_body_content(args.body)
-    
-    pr = None
-    if args.pr_number:
-        pr = repo.get_pull(args.pr_number)
-    else:
-        existing_prs = repo.get_pulls(head=args.branch_for_pr, base=args.base_branch, state='open')
-        for p in existing_prs:
-            if p.base.ref == args.base_branch and p.head.ref == args.branch_for_pr:
-                pr = p
-                break
+
+    print(f"Looking for PR by number: {args.pr_number}")
+    pr = repo.get_pull(args.pr_number)
 
     if pr:
         print(f"Appending to PR #{pr.number}.")
         current_body = pr.body or ""
         new_body = current_body + "\n\n" + body_to_append
         pr.edit(body=new_body)
+        print(f"PR #{pr.number} body updated successfully.")
     else:
         print("No matching pull request found to append body.")
+
 
 if __name__ == '__main__':
     parser = argparse.ArgumentParser(description='Operate on a GitHub Pull Request')

--- a/.github/scripts/create_or_update_pr.py
+++ b/.github/scripts/create_or_update_pr.py
@@ -49,8 +49,9 @@ def create_or_update_pr(args, repo):
             raise
 
     pr_number = current_pr.number
-    if 'GITHUB_OUTPUT' in os.environ and os.environ['GITHUB_OUTPUT']:
-        with open(os.environ['GITHUB_OUTPUT'], 'a') as gh_out:
+    github_output = os.environ.get('GITHUB_OUTPUT')
+    if github_output:
+        with open(github_output, 'a') as gh_out:
             print(f"pr_number={pr_number}", file=gh_out)
 
     print(f"PR operation completed. PR number: {pr_number}")

--- a/.github/scripts/create_or_update_pr.py
+++ b/.github/scripts/create_or_update_pr.py
@@ -41,12 +41,8 @@ def create_or_update_pr(args, repo):
         print(f"PR #{current_pr.number} updated successfully.")
     else:
         print(f"No existing PR found. Creating a new PR from '{args.branch_for_pr}' to '{args.base_branch}'.")
-        try:
-            current_pr = repo.create_pull(title=args.title, body=body, head=args.branch_for_pr, base=args.base_branch)
-            print(f"New PR #{current_pr.number} created successfully.")
-        except Exception as e:
-            print(f"Error creating PR: {str(e)}")
-            raise
+        current_pr = repo.create_pull(title=args.title, body=body, head=args.branch_for_pr, base=args.base_branch)
+        print(f"New PR #{current_pr.number} created successfully.")
 
     pr_number = current_pr.number
     github_output = os.environ.get('GITHUB_OUTPUT')


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

исправлена ошибка при которой открытые pr на Update muted_ya не обновлялись, а закрывались

Причина - особенности работы git api, при поиске надо было в имени ветки передавать также овнера ( ydb-platform) , хотя, казалось бы, работаем с обьектом репозитория и чисто имени ветки должно было быть достаточно

[Вот](https://github.com/ydb-platform/ydb/pull/17917#issuecomment-2842639273) пример PR где поиск сработал и описание обновилось

### Changelog category <!-- remove all except one -->


* Not for changelog (changelog entry is not required)

### Description for reviewers <!-- (optional) description for those who read this PR -->

...
