### PR TITLE
Support for selectable hashmap implementation in the combiner_perf

### DIFF
--- a/ydb/core/kqp/tools/combiner_perf/bin/format_markdown.py
+++ b/ydb/core/kqp/tools/combiner_perf/bin/format_markdown.py
@@ -38,18 +38,14 @@ def gen_chart(ref_time, graph_time, llvm_time = None):
     out = ''
     out += draw_line(ref_time, None, 'C++', None)
 
-    if ref_time == 0:
-        hue = None
-    else:
-        hue = 120 - int(120.0 * ((graph_time / ref_time) - 0.5) / 1.5) # Map [0.5, 2] -> [120, 0]
-        hue = max(0, min(hue, 120)) # clamp to the [0, 120] range; hue 0 = red, hue 120 = green
-
     def add_colored_bar(ref_value, result_value, title):
+        hue = None
+        comment = None
         if result_value:
             shame_ratio = result_value / ref_value
             comment = 'x %.1f' % shame_ratio
-        else:
-            comment = None
+            hue = 120 - int(120.0 * (shame_ratio - 0.5) / 1.5) # Map [0.5, 2] -> [120, 0]
+            hue = max(0, min(hue, 120)) # clamp to the [0, 120] range; hue 0 = red, hue 120 = green
         return draw_line(result_value, hue, title, comment)
 
     out += add_colored_bar(ref_time, graph_time, 'Graph')
@@ -87,6 +83,8 @@ def format_time(ms):
     return '%.2f' % (ms / 1000.0)
 
 def format_mem(bytez):
+    if bytez is None:
+        return ' '
     return '%.1f' % (bytez / (1024.0 * 1024.0))
 
 def do_merge_llvm(samples):
@@ -173,7 +171,7 @@ def do_format(merge_llvm):
             ]
         headers += [
             'MaxRSS delta, MB',
-            'Bytes per key',
+            'Reference MaxRSS delta, MB',
         ]
         print(''.join(['<th>%s</th>' % item for item in headers]) + '\n')
 
@@ -201,9 +199,8 @@ def do_format(merge_llvm):
             if has_llvm_column:
                 cols.append(format_time(llvm_time_or_zero))
             cols.append(format_mem(sample['maxRssDelta']))
-            bytes_per_key = sample['maxRssDelta'] // sample['numKeys']
+            cols.append(format_mem(sample.get('referenceMaxRssDelta', None)))
 
-            cols.append(str(bytes_per_key) if 0 < bytes_per_key < 10000 else ' ')
             print('<tr>' + ''.join(['<td>%s</td>' % col for col in cols]) + '</tr>\n')
 
         print('</table>\n:::\n')

--- a/ydb/core/kqp/tools/combiner_perf/bin/main.cpp
+++ b/ydb/core/kqp/tools/combiner_perf/bin/main.cpp
@@ -101,7 +101,7 @@ void DoFullPass(TRunParams runParams, bool withSpilling)
 
     // const std::vector<size_t> numKeys = {4u, 1000u, 100'000u, 1'000'000u, 10'000'000, 30'000'000};
     // const std::vector<size_t> numKeys = {60'000'000, 120'000'000};
-    const std::vector<size_t> numKeys = {1'000'000u};
+    const std::vector<size_t> numKeys = {30'000'000u};
     const std::vector<size_t> blockSizes = {128u, 8192u};
 
     auto doSimple = [&printout, numKeys](const TRunParams& params) {

--- a/ydb/core/kqp/tools/combiner_perf/bin/main.cpp
+++ b/ydb/core/kqp/tools/combiner_perf/bin/main.cpp
@@ -99,9 +99,9 @@ void DoFullPass(TRunParams runParams, bool withSpilling)
 
     TJsonResultCollector printout;
 
-    // const std::vector<size_t> numKeys = {4u, 1000u, 100'000u, 1'000'000u, 10'000'000, 30'000'000};
+    const std::vector<size_t> numKeys = {4u, 1000u, 100'000u, 1'000'000u, 10'000'000};
     // const std::vector<size_t> numKeys = {60'000'000, 120'000'000};
-    const std::vector<size_t> numKeys = {30'000'000u};
+    //const std::vector<size_t> numKeys = {30'000'000u};
     const std::vector<size_t> blockSizes = {128u, 8192u};
 
     auto doSimple = [&printout, numKeys](const TRunParams& params) {
@@ -243,6 +243,19 @@ int main(int argc, const char* argv[])
             }
         })
         .Help("Input data type: string key -> ui64 numeric value or ui64 numeric key -> ui64 numeric value");
+
+    options.AddLongOption("hashmap")
+        .Choices({"std", "absl"})
+        .RequiredArgument()
+        .Handler1([&](const NLastGetopt::TOptsParser* option) {
+            auto val = TStringBuf(option->CurVal());
+            if (val == "std") {
+                runParams.ReferenceHashType = NKikimr::NMiniKQL::EHashMapImpl::UnorderedMap;
+            } else {
+                runParams.ReferenceHashType = NKikimr::NMiniKQL::EHashMapImpl::Absl;
+            }
+        })
+        .Help("Hash map type (std::unordered_map or absl::dense_hash_map)");
 
     options
         .AddLongOption('t', "test")

--- a/ydb/core/kqp/tools/combiner_perf/bin/main.cpp
+++ b/ydb/core/kqp/tools/combiner_perf/bin/main.cpp
@@ -19,6 +19,20 @@
 
 using NKikimr::NMiniKQL::TRunParams;
 
+TStringBuf HashMapTypeName(NKikimr::NMiniKQL::EHashMapImpl implType)
+{
+    switch (implType) {
+    case NKikimr::NMiniKQL::EHashMapImpl::UnorderedMap:
+        return "std";
+    case NKikimr::NMiniKQL::EHashMapImpl::Absl:
+        return "absl";
+    case NKikimr::NMiniKQL::EHashMapImpl::YqlRobinHood:
+        return "robinhood";
+    default:
+        ythrow yexception() << "Unknown hashmap impl type";
+    }
+}
+
 class TPrintingResultCollector : public TTestResultCollector
 {
 public:
@@ -38,6 +52,7 @@ public:
         Cout << "Block size: " << runParams.BlockSize << Endl;
         Cout << "Long strings: " << (runParams.LongStringKeys ? "yes" : "no") << Endl;
         Cout << "Combiner mem limit: " << runParams.WideCombinerMemLimit << Endl;
+        Cout << "Hash map type: " << HashMapTypeName(runParams.ReferenceHashType) << Endl;
         Cout << Endl;
 
         Cout << "Graph runtime is: " << result.ResultTime << " vs. reference C++ implementation: " << result.ReferenceTime << Endl;
@@ -81,6 +96,7 @@ public:
         out["longStringKeys"] = runParams.LongStringKeys;
         out["numKeys"] = runParams.NumKeys;
         out["combinerMemLimit"] = runParams.WideCombinerMemLimit;
+        out["hashType"] = HashMapTypeName(runParams.ReferenceHashType);
 
         out["generatorTime"] = result.GeneratorTime.MilliSeconds();
         out["resultTime"] = result.ResultTime.MilliSeconds();
@@ -100,7 +116,7 @@ void DoFullPass(TRunParams runParams, bool withSpilling)
     TJsonResultCollector printout;
 
     const std::vector<size_t> numKeys = {4u, 1000u, 100'000u, 1'000'000u, 10'000'000};
-    // const std::vector<size_t> numKeys = {60'000'000, 120'000'000};
+    //const std::vector<size_t> numKeys = {60'000'000, 120'000'000};
     //const std::vector<size_t> numKeys = {30'000'000u};
     const std::vector<size_t> blockSizes = {128u, 8192u};
 
@@ -245,14 +261,18 @@ int main(int argc, const char* argv[])
         .Help("Input data type: string key -> ui64 numeric value or ui64 numeric key -> ui64 numeric value");
 
     options.AddLongOption("hashmap")
-        .Choices({"std", "absl"})
+        .Choices({"std", "absl", "robinhood"})
         .RequiredArgument()
         .Handler1([&](const NLastGetopt::TOptsParser* option) {
             auto val = TStringBuf(option->CurVal());
             if (val == "std") {
                 runParams.ReferenceHashType = NKikimr::NMiniKQL::EHashMapImpl::UnorderedMap;
-            } else {
+            } else if (val == "absl") {
                 runParams.ReferenceHashType = NKikimr::NMiniKQL::EHashMapImpl::Absl;
+            } else if (val == "robinhood") {
+                runParams.ReferenceHashType = NKikimr::NMiniKQL::EHashMapImpl::YqlRobinHood;
+            } else {
+                ythrow yexception() << "Unimplemented hash map type: " << val;
             }
         })
         .Help("Hash map type (std::unordered_map or absl::dense_hash_map)");
@@ -274,6 +294,10 @@ int main(int argc, const char* argv[])
             }
         })
         .Help("Enable single test run mode");
+
+    options.AddLongOption("no-verify").NoArgument().Handler0([&](){
+        runParams.EnableVerification = false;
+    });
 
     options
         .AddLongOption('m', "mode")
@@ -318,6 +342,7 @@ int main(int argc, const char* argv[])
     if (testType != ETestType::All) {
         DoSelectedTest(runParams, testType, llvm, spilling);
     } else {
+        runParams.AlwaysSubprocess = true;
         DoFullPass(runParams, spilling);
     }
 

--- a/ydb/core/kqp/tools/combiner_perf/converters.h
+++ b/ydb/core/kqp/tools/combiner_perf/converters.h
@@ -13,16 +13,16 @@ namespace NKikimr {
 namespace NMiniKQL {
 
 template<bool Embedded>
-void NativeToUnboxed(const ui64 value, NUdf::TUnboxedValue& result)
+void NativeToUnboxed(const ui64 value, NUdf::TUnboxedValuePod& result)
 {
     result = NUdf::TUnboxedValuePod(value);
 }
 
 template<bool Embedded>
-void NativeToUnboxed(const std::string& value, NUdf::TUnboxedValue& result)
+void NativeToUnboxed(const std::string& value, NUdf::TUnboxedValuePod& result)
 {
     if constexpr (Embedded) {
-        result = NUdf::TUnboxedValue::Embedded(value);
+        result = NUdf::TUnboxedValuePod::Embedded(value);
     } else {
         result = NUdf::TUnboxedValuePod(NUdf::TStringValue(value));
     }

--- a/ydb/core/kqp/tools/combiner_perf/hashmaps.h
+++ b/ydb/core/kqp/tools/combiner_perf/hashmaps.h
@@ -1,0 +1,136 @@
+// Hash map implementation wrappers
+
+#pragma once
+
+#include <yql/essentials/minikql/comp_nodes/mkql_rh_hash.h>
+#include <yql/essentials/public/udf/udf_value.h>
+
+#include <library/cpp/containers/absl_flat_hash/flat_hash_map.h>
+
+#include <unordered_map>
+
+namespace NKikimr {
+namespace NMiniKQL {
+
+template<typename K, typename V>
+struct TUnorderedMapImpl
+{
+    using TValueType = V;
+    using TMapType = std::unordered_map<K, V>;
+    constexpr static bool CustomOps = false;
+};
+
+template<typename K, typename V>
+struct TAbslMapImpl
+{
+    using TValueType = V;
+    using TMapType = absl::flat_hash_map<K, V>;
+    constexpr static bool CustomOps = false;
+};
+
+template<typename K, typename V, typename TEqualTo = std::equal_to<K>, typename THash = std::hash<K>>
+struct TRobinHoodMapImplBase
+{
+    // Warning: this implementation leaks long strings because it can't call destructors.
+    // Also it moves keys and values by simply copying bytes so take care.
+    using TValueType = V;
+    using TMapType = TRobinHoodHashFixedMap<K, V, TEqualTo, THash>;
+    constexpr static bool CustomOps = true;
+
+    static void AggregateByKey(TMapType& map, const K& key, const V& delta)
+    {
+        bool isNew = false;
+        auto ptr = map.Insert(key, isNew);
+        if (isNew) {
+            *(V*)map.GetMutablePayload(ptr) = delta;
+            map.CheckGrow();
+        } else {
+            *(V*)map.GetMutablePayload(ptr) += delta;
+        }
+    }
+
+    template<typename Callback>
+    static void IteratePairs(const TMapType& map, Callback&& callback)
+    {
+        // TODO: GetPayload and IsValid should be const
+        for (const char* iter = map.Begin(); iter != map.End(); map.Advance(iter)) {
+            if (!const_cast<TMapType&>(map).IsValid(iter)) {
+                continue;
+            }
+            const auto& key = map.GetKey(iter);
+            const auto& value = *(V*)(const_cast<TMapType&>(map)).GetPayload(iter);
+            callback(key, value);
+        }
+    }
+
+    static size_t Size(const TMapType& map)
+    {
+        return map.GetSize();
+    }
+};
+
+template<typename K, typename V>
+struct TRobinHoodMapImpl: public TRobinHoodMapImplBase<K, V>
+{
+};
+
+template<typename V>
+struct TRobinHoodMapImpl<std::string, V>
+{
+    using TValueType = V;
+
+    struct TEqualTo
+    {
+        bool operator()(const NYql::NUdf::TUnboxedValuePod& lhs, const NYql::NUdf::TUnboxedValuePod& rhs) {
+            return lhs.AsStringRef() == rhs.AsStringRef();
+        }
+    };
+
+    struct THash
+    {
+        absl::Hash<std::string_view> AbslHash;
+
+        size_t operator()(const NYql::NUdf::TUnboxedValuePod& val) {
+            auto result = AbslHash(val.AsStringRef());
+            return result;
+        }
+    };
+
+    using TBase = TRobinHoodMapImplBase<std::string, V>;
+    using TRealBase = TRobinHoodMapImplBase<NYql::NUdf::TUnboxedValuePod, V, TEqualTo, THash>;
+    using TMapType = TRealBase::TMapType;
+
+    constexpr static bool CustomOps = true;
+
+    static void AggregateByKey(TMapType& map, const std::string& key, const V& delta)
+    {
+        NYql::NUdf::TUnboxedValuePod ub = NYql::NUdf::TUnboxedValuePod::Embedded(NYql::NUdf::TStringRef(key));
+        TRealBase::AggregateByKey(map, ub, delta);
+    }
+
+    template<typename Callback>
+    static void IteratePairs(const TMapType& map, Callback&& callback)
+    {
+        TRealBase::IteratePairs(map, [callback](const NYql::NUdf::TUnboxedValuePod& k, const V& v) {
+            callback(std::string(k.AsStringRef()), v);
+        });
+    }
+
+    static size_t Size(const TMapType& map)
+    {
+        return TRealBase::Size(map);
+    }
+};
+
+template<typename TMapImpl>
+bool MapEmpty(const typename TMapImpl::TMapType& map)
+{
+    if constexpr (TMapImpl::CustomOps) {
+        return TMapImpl::Size(map) == 0;
+    } else {
+        return map.empty();
+    }
+}
+
+}
+}

--- a/ydb/core/kqp/tools/combiner_perf/printout.cpp
+++ b/ydb/core/kqp/tools/combiner_perf/printout.cpp
@@ -2,6 +2,10 @@
 
 #include <sys/resource.h>
 
+#if defined (_darwin_)
+#include <mach/mach.h>
+#endif
+
 long GetMaxRSS()
 {
     rusage usage;
@@ -16,7 +20,7 @@ long GetMaxRSSDelta(const long prevMaxRss)
     long maxRss = GetMaxRSS();
 
     if (maxRss <= 0 || prevMaxRss <= 0 || maxRss < prevMaxRss) {
-        ythrow yexception() << "Bad maxRSS measurement, before: " << prevMaxRss << ", after: " << maxRss << Endl;        
+        ythrow yexception() << "Bad maxRSS measurement, before: " << prevMaxRss << ", after: " << maxRss << Endl;
     }
 
 #if defined (_darwin_)
@@ -26,6 +30,39 @@ long GetMaxRSSDelta(const long prevMaxRss)
 #endif
 
     return (maxRss - prevMaxRss) * factor;
+}
+
+TDuration GetThreadCPUTime()
+{
+    ui64 us = 0;
+
+#if defined (_darwin_)
+    thread_basic_info_data_t info = {};
+    mach_msg_type_number_t info_count = THREAD_BASIC_INFO_COUNT;
+    kern_return_t kern_err = thread_info(
+        mach_thread_self(),
+        THREAD_BASIC_INFO,
+        (thread_info_t)&info,
+        &info_count
+    );
+    if (kern_err == KERN_SUCCESS) {
+        us = 1000000ULL * info.user_time.seconds + info.user_time.microseconds + 1000000ULL*info.system_time.seconds + info.system_time.microseconds;
+    }
+#else
+    us = ThreadCPUTime();
+#endif
+
+    if (!us) {
+        ythrow yexception() << "Failed to obtain thread CPU time";
+    }
+
+    return TDuration::MicroSeconds(us);
+}
+
+TDuration GetThreadCPUTimeDelta(const TDuration startTime)
+{
+    TDuration current = GetThreadCPUTime();
+    return current - startTime;
 }
 
 void MergeRunResults(const TRunResult& src, TRunResult& dst)

--- a/ydb/core/kqp/tools/combiner_perf/printout.h
+++ b/ydb/core/kqp/tools/combiner_perf/printout.h
@@ -40,6 +40,10 @@ public:
 };
 
 // ru_maxrss from rusage, converted to bytes
-long GetMaxRSS();
+long Y_NO_INLINE GetMaxRSS();
 
-long GetMaxRSSDelta(const long prevMaxRss);
+long Y_NO_INLINE GetMaxRSSDelta(const long prevMaxRss);
+
+TDuration Y_NO_INLINE GetThreadCPUTime();
+
+TDuration Y_NO_INLINE GetThreadCPUTimeDelta(const TDuration startTime);

--- a/ydb/core/kqp/tools/combiner_perf/run_params.h
+++ b/ydb/core/kqp/tools/combiner_perf/run_params.h
@@ -18,9 +18,15 @@ enum class ESamplerType {
     UI64KeysUI64Values,
 };
 
+enum class EHashMapImpl {
+    UnorderedMap,
+    Absl,
+};
+
 struct TRunParams {
     ETestMode TestMode = ETestMode::Full;
     ESamplerType SamplerType = ESamplerType::StringKeysUI64Values;
+    EHashMapImpl ReferenceHashType = EHashMapImpl::UnorderedMap;
     std::optional<ui64> RandomSeed;
     int NumAttempts = 0;
     size_t RowsPerRun = 0;

--- a/ydb/core/kqp/tools/combiner_perf/run_params.h
+++ b/ydb/core/kqp/tools/combiner_perf/run_params.h
@@ -35,6 +35,7 @@ struct TRunParams {
     size_t NumKeys = 0; // for numeric keys, the range is [0..NumKeys-1]
     size_t BlockSize = 0;
     size_t WideCombinerMemLimit = 0;
+    size_t NumAggregations = 1;
     bool LongStringKeys = false;
     bool MeasureReferenceMemory = false;
     bool AlwaysSubprocess = false;

--- a/ydb/core/kqp/tools/combiner_perf/run_params.h
+++ b/ydb/core/kqp/tools/combiner_perf/run_params.h
@@ -21,6 +21,7 @@ enum class ESamplerType {
 enum class EHashMapImpl {
     UnorderedMap,
     Absl,
+    YqlRobinHood,
 };
 
 struct TRunParams {
@@ -36,6 +37,8 @@ struct TRunParams {
     size_t WideCombinerMemLimit = 0;
     bool LongStringKeys = false;
     bool MeasureReferenceMemory = false;
+    bool AlwaysSubprocess = false;
+    bool EnableVerification = true;
 };
 
 }

--- a/ydb/core/kqp/tools/combiner_perf/simple.cpp
+++ b/ydb/core/kqp/tools/combiner_perf/simple.cpp
@@ -142,7 +142,7 @@ void RunTestSimple(const TRunParams& params, TTestResultCollector& printout)
 
     Cerr << "======== " << __func__ << ", keys: " << params.NumKeys << ", llvm: " << LLVM << ", mem limit: " << params.WideCombinerMemLimit << Endl;
 
-    if (params.NumAttempts <= 1 && !params.MeasureReferenceMemory) {
+    if (params.NumAttempts <= 1 && !params.MeasureReferenceMemory && !params.AlwaysSubprocess) {
         finalResult = RunTestOverGraph<LLVM>(params, true, false);
     }
     else {

--- a/ydb/core/kqp/tools/combiner_perf/simple.cpp
+++ b/ydb/core/kqp/tools/combiner_perf/simple.cpp
@@ -63,11 +63,11 @@ TRunResult RunTestOverGraph(const TRunParams& params, const bool needsVerificati
         // Compute node implementation
 
         Cerr << "Compute graph result" << Endl;
-        const auto graphTimeStart = TInstant::Now();
+        const auto graphTimeStart = GetThreadCPUTime();
         size_t lineCount = CountWideStreamOutputs<2>(computeGraphPtr->GetValue());
         Cerr << lineCount << Endl;
 
-        return TInstant::Now() - graphTimeStart;
+        return GetThreadCPUTimeDelta(graphTimeStart);
     };
 
     auto measureRefTime = [&](auto& computeGraphPtr, IDataSampler& sampler) {
@@ -75,10 +75,10 @@ TRunResult RunTestOverGraph(const TRunParams& params, const bool needsVerificati
 
         Cerr << "Compute reference result" << Endl;
         auto referenceStream = sampler.MakeStream(computeGraphPtr->GetHolderFactory());
-        const auto cppTimeStart = TInstant::Now();
+        const auto cppTimeStart = GetThreadCPUTime();
         sampler.ComputeReferenceResult(*referenceStream);
 
-        return TInstant::Now() - cppTimeStart;
+        return GetThreadCPUTimeDelta(cppTimeStart);
     };
 
     auto graphRun1 = BuildGraph(setup, *sampler, params.WideCombinerMemLimit);
@@ -106,13 +106,13 @@ TRunResult RunTestOverGraph(const TRunParams& params, const bool needsVerificati
         // Measure the input stream run time
         Cerr << "Generator run" << Endl;
         const auto devnullStream = sampler->MakeStream(graphRun1->GetHolderFactory());
-        const auto devnullStart = TInstant::Now();
+        const auto devnullStart = GetThreadCPUTime();
         {
             NUdf::TUnboxedValue columns[2];
             while (devnullStream->WideFetch(columns, 2) == NUdf::EFetchStatus::Ok) {
             }
         }
-        result.GeneratorTime = TInstant::Now() - devnullStart;
+        result.GeneratorTime = GetThreadCPUTimeDelta(devnullStart);
 
         if (params.TestMode == ETestMode::GeneratorOnly) {
             return result;

--- a/ydb/core/kqp/tools/combiner_perf/simple_block.cpp
+++ b/ydb/core/kqp/tools/combiner_perf/simple_block.cpp
@@ -153,7 +153,7 @@ void RunTestBlockCombineHashedSimple(const TRunParams& params, TTestResultCollec
 
     Cerr << "======== " << __func__ << ", keys: " << params.NumKeys << ", block size: " << params.BlockSize << ", llvm: " << LLVM << Endl;
 
-    if (params.NumAttempts <= 1 && !params.MeasureReferenceMemory) {
+    if (params.NumAttempts <= 1 && !params.MeasureReferenceMemory && !params.AlwaysSubprocess) {
         finalResult = RunTestOverGraph<LLVM, Spilling>(params, false);
     } else {
         for (int i = 1; i <= params.NumAttempts; ++i) {

--- a/ydb/core/kqp/tools/combiner_perf/simple_block.cpp
+++ b/ydb/core/kqp/tools/combiner_perf/simple_block.cpp
@@ -70,16 +70,16 @@ TRunResult RunTestOverGraph(const TRunParams& params, const bool measureReferenc
         // Compute graph implementation
         auto stream = NUdf::TUnboxedValuePod(sampler->MakeStream(computeGraphPtr->GetContext()).Release());
         computeGraphPtr->GetEntryPoint(0, true)->SetValue(computeGraphPtr->GetContext(), std::move(stream));
-        const auto graphStart = TInstant::Now();
+        const auto graphStart = GetThreadCPUTime();
         resultList = computeGraphPtr->GetValue();
-        return TInstant::Now() - graphStart;
+        return GetThreadCPUTimeDelta(graphStart);
     };
 
     auto measureRefTime = [&](auto& computeGraphPtr) {
         // Reference implementation (sum via an std::unordered_map)
-        const auto cppStart = TInstant::Now();
+        const auto cppStart = GetThreadCPUTime();
         sampler->ComputeReferenceResult(computeGraphPtr->GetContext());
-        return TInstant::Now() - cppStart;
+        return GetThreadCPUTimeDelta(cppStart);
     };
 
     auto measureGeneratorTime = [&](auto& computeGraphPtr) {
@@ -87,16 +87,16 @@ TRunResult RunTestOverGraph(const TRunParams& params, const bool measureReferenc
         const auto devnullStreamPtr = sampler->MakeStream(computeGraphPtr->GetContext());
         auto& devnullStream = *devnullStreamPtr;
         size_t numBlocks = 0;
-        const auto timeStart = TInstant::Now();
+        const auto timeStart = GetThreadCPUTime();
         {
             NUdf::TUnboxedValue columns[3];
             while (devnullStream.WideFetch(columns, 3) == NUdf::EFetchStatus::Ok) {
                 ++numBlocks;
             }
         }
-        auto timeEnd = TInstant::Now();
+        auto duration = GetThreadCPUTimeDelta(timeStart);
         Cerr << "Blocks generated: " << numBlocks << Endl;
-        return timeEnd - timeStart;
+        return duration;
     };
 
     const auto graph = setup.BuildGraph(pgmReturn, {streamCallable});

--- a/ydb/core/kqp/tools/combiner_perf/simple_last.cpp
+++ b/ydb/core/kqp/tools/combiner_perf/simple_last.cpp
@@ -90,11 +90,11 @@ TRunResult RunTestOverGraph(const TRunParams& params, const bool needsVerificati
         // Compute node implementation
 
         Cerr << "Compute graph result" << Endl;
-        const auto graphTimeStart = TInstant::Now();
+        const auto graphTimeStart = GetThreadCPUTime();
         size_t lineCount = CountWideStreamOutputs<2>(computeGraphPtr->GetValue());
         Cerr << lineCount << Endl;
 
-        return TInstant::Now() - graphTimeStart;
+        return GetThreadCPUTimeDelta(graphTimeStart);
     };
 
     auto measureRefTime = [&](auto& computeGraphPtr, IDataSampler& sampler) {
@@ -102,10 +102,10 @@ TRunResult RunTestOverGraph(const TRunParams& params, const bool needsVerificati
 
         Cerr << "Compute reference result" << Endl;
         auto referenceStream = sampler.MakeStream(computeGraphPtr->GetHolderFactory());
-        const auto cppTimeStart = TInstant::Now();
+        const auto cppTimeStart = GetThreadCPUTime();
         sampler.ComputeReferenceResult(*referenceStream);
 
-        return TInstant::Now() - cppTimeStart;
+        return GetThreadCPUTimeDelta(cppTimeStart);
     };
 
     auto graphRun1 = BuildGraph(setup, spillerFactory, *sampler);

--- a/ydb/core/kqp/tools/combiner_perf/simple_last.cpp
+++ b/ydb/core/kqp/tools/combiner_perf/simple_last.cpp
@@ -177,14 +177,14 @@ void RunTestCombineLastSimple(const TRunParams& params, TTestResultCollector& pr
 
     Cerr << "======== " << __func__ << ", keys: " << params.NumKeys << ", llvm: " << LLVM << ", spilling: " << Spilling << Endl;
 
-    if (params.NumAttempts <= 1 && !params.MeasureReferenceMemory) {
-        finalResult = RunTestOverGraph<LLVM, Spilling>(params, true, false);
+    if (params.NumAttempts <= 1 && !params.MeasureReferenceMemory && !params.AlwaysSubprocess) {
+        finalResult = RunTestOverGraph<LLVM, Spilling>(params, params.EnableVerification, false);
     }
     else {
         for (int i = 1; i <= params.NumAttempts; ++i) {
             Cerr << "------ Run " << i << " of " << params.NumAttempts << Endl;
 
-            const bool needsVerification = (i == 1);
+            const bool needsVerification = (i == 1) && params.EnableVerification;
             TRunResult runResult = RunForked([&]() {
                 return RunTestOverGraph<LLVM, Spilling>(params, needsVerification, false);
             });

--- a/ydb/core/kqp/tools/combiner_perf/simple_last.cpp
+++ b/ydb/core/kqp/tools/combiner_perf/simple_last.cpp
@@ -26,14 +26,13 @@ namespace {
 TDuration MeasureGeneratorTime(IComputationGraph& graph, const IDataSampler& sampler)
 {
     const auto devnullStream = sampler.MakeStream(graph.GetHolderFactory());
-    const auto devnullStart = TInstant::Now();
+    const auto devnullStart = GetThreadCPUTime();
     {
         NUdf::TUnboxedValue columns[2];
         while (devnullStream->WideFetch(columns, 2) == NUdf::EFetchStatus::Ok) {
         }
     }
-    const auto devnullTime = TInstant::Now() - devnullStart;
-    return devnullTime;
+    return GetThreadCPUTimeDelta(devnullStart);
 }
 
 template<bool LLVM, bool Spilling>

--- a/ydb/core/kqp/tools/combiner_perf/value_wrapper.h
+++ b/ydb/core/kqp/tools/combiner_perf/value_wrapper.h
@@ -1,0 +1,59 @@
+#pragma once
+
+#include <util/generic/string.h>
+#include <util/stream/output.h>
+#include <util/string/printf.h>
+
+#include <array>
+#include <string>
+
+namespace NKikimr {
+namespace NMiniKQL {
+
+// A simple wrapper for aggregate sums over both scalar values and tuples.
+// Just a statically-sized array for now.
+
+template<typename V, size_t Width>
+struct TValueWrapper: public std::array<V, Width>
+{
+    using TElement = V;
+    constexpr static const size_t ArrayWidth = Width;
+
+    TValueWrapper()
+        : std::array<V, Width>{}
+    {
+    };
+
+    TValueWrapper& operator+= (const TValueWrapper& rhs)
+    {
+        for (size_t i = 0; i < Width; ++i) {
+            (*this)[i] += rhs[i];
+        }
+        return *this;
+    }
+
+    static std::string Describe()
+    {
+        if constexpr (std::is_same_v<V, ui64>) {
+            return Sprintf("array<ui64, %lu>", Width);
+        } else if constexpr (std::is_same_v<V, std::string>) {
+            return Sprintf("array<string, %lu>", Width);
+        } else {
+            return Sprintf("array<?, %lu>", Width);
+        }
+    }
+};
+
+}
+}
+
+template<typename V, size_t Width>
+IOutputStream& operator << (IOutputStream& out Y_LIFETIME_BOUND, const NKikimr::NMiniKQL::TValueWrapper<V, Width>& wrapper) {
+    for (size_t i = 0; i < Width; ++i) {
+        if (i > 0) {
+            out << ", ";
+        }
+        out << wrapper[i];
+    }
+    return out;
+}


### PR DESCRIPTION
Also:
- change the timing method (use the thread CPU time)
- fix bar colors in the result chart, remove the "bytes per key" column from the formatted table

### Changelog category <!-- remove all except one -->

* Not for changelog (changelog entry is not required)
