### PR TITLE
added a new path type for system views

### DIFF
--- a/ydb/core/protos/flat_scheme_op.proto
+++ b/ydb/core/protos/flat_scheme_op.proto
@@ -1814,6 +1814,7 @@ enum EPathType {
     EPathTypeResourcePool = 21;
     EPathTypeBackupCollection = 22;
     EPathTypeTransfer = 23;
+    EPathTypeSysView = 24;
 }
 
 enum EPathSubType {

--- a/ydb/core/tx/scheme_board/cache.cpp
+++ b/ydb/core/tx/scheme_board/cache.cpp
@@ -1623,6 +1623,7 @@ class TSchemeCache: public TMonitorableActor<TSchemeCache> {
                 Kind = TNavigate::KindBackupCollection;
                 FillInfo(Kind, BackupCollectionInfo, std::move(*pathDesc.MutableBackupCollectionDescription()));
                 break;
+            case NKikimrSchemeOp::EPathTypeSysView:
             case NKikimrSchemeOp::EPathTypeInvalid:
                 Y_DEBUG_ABORT("Invalid path type");
                 break;
@@ -1702,6 +1703,7 @@ class TSchemeCache: public TMonitorableActor<TSchemeCache> {
                     case NKikimrSchemeOp::EPathTypeBackupCollection:
                         ListNodeEntry->Children.emplace_back(name, pathId, TNavigate::KindBackupCollection);
                         break;
+                    case NKikimrSchemeOp::EPathTypeSysView:
                     case NKikimrSchemeOp::EPathTypeTableIndex:
                     case NKikimrSchemeOp::EPathTypeInvalid:
                         Y_DEBUG_ABORT("Invalid path type");

--- a/ydb/core/tx/scheme_cache/scheme_cache.h
+++ b/ydb/core/tx/scheme_cache/scheme_cache.h
@@ -194,6 +194,7 @@ struct TSchemeCacheNavigate {
         KindResourcePool = 22,
         KindBackupCollection = 23,
         KindTransfer = 24,
+        KindSysView = 25,
     };
 
     struct TListNodeEntry : public TAtomicRefCount<TListNodeEntry> {

--- a/ydb/core/tx/schemeshard/schemeshard__operation_upgrade_subdomain.cpp
+++ b/ydb/core/tx/schemeshard/schemeshard__operation_upgrade_subdomain.cpp
@@ -365,6 +365,7 @@ public:
             case NKikimrSchemeOp::EPathType::EPathTypeTransfer:
             case NKikimrSchemeOp::EPathType::EPathTypeBlobDepot:
             case NKikimrSchemeOp::EPathType::EPathTypeBackupCollection:
+            case NKikimrSchemeOp::EPathType::EPathTypeSysView:
                 Y_ABORT("UNIMPLEMENTED");
             case NKikimrSchemeOp::EPathType::EPathTypeInvalid:
                 Y_UNREACHABLE();

--- a/ydb/core/tx/schemeshard/schemeshard_impl.cpp
+++ b/ydb/core/tx/schemeshard/schemeshard_impl.cpp
@@ -1340,6 +1340,9 @@ bool TSchemeShard::CheckApplyIf(const NKikimrSchemeOp::TModifyScheme& scheme, TS
                         case NKikimrSchemeOp::EPathType::EPathTypeView:
                             actualVersion = pathVersion.GetViewVersion();
                             break;
+                        case NKikimrSchemeOp::EPathType::EPathTypeSysView:
+                            Y_ABORT("UNIMPLEMENTED");
+                            break;
                         default:
                             actualVersion = pathVersion.GetGeneralVersion();
                             break;
@@ -4469,6 +4472,7 @@ NKikimrSchemeOp::TPathVersion TSchemeShard::GetPathVersion(const TPath& path) co
                 break;
             }
 
+            case NKikimrSchemeOp::EPathType::EPathTypeSysView:
             case NKikimrSchemeOp::EPathType::EPathTypeInvalid: {
                 Y_UNREACHABLE();
             }
@@ -5333,6 +5337,7 @@ void TSchemeShard::UncountNode(TPathElement::TPtr node) {
     case TPathElement::EPathType::EPathTypeBackupCollection:
         TabletCounters->Simple()[COUNTER_BACKUP_COLLECTION_COUNT].Sub(1);
         break;
+    case TPathElement::EPathType::EPathTypeSysView:
     case TPathElement::EPathType::EPathTypeInvalid:
         Y_ABORT("impossible path type");
     }

--- a/ydb/core/tx/schemeshard/schemeshard_path_describer.cpp
+++ b/ydb/core/tx/schemeshard/schemeshard_path_describer.cpp
@@ -1278,6 +1278,7 @@ THolder<TEvSchemeShard::TEvDescribeSchemeResultBuilder> TPathDescriber::Describe
             DescribeDir(path);
             DescribeBackupCollection(base->PathId, base);
             break;
+        case NKikimrSchemeOp::EPathTypeSysView:
         case NKikimrSchemeOp::EPathTypeInvalid:
             Y_UNREACHABLE();
         }

--- a/ydb/core/viewer/browse.h
+++ b/ydb/core/viewer/browse.h
@@ -98,6 +98,8 @@ public:
             return NKikimrViewer::EObjectType::View;
         case NKikimrSchemeOp::EPathType::EPathTypeResourcePool:
             return NKikimrViewer::EObjectType::ResourcePool;
+        case NKikimrSchemeOp::EPathType::EPathTypeSysView:
+            return NKikimrViewer::EObjectType::SysView;
         case NKikimrSchemeOp::EPathType::EPathTypeExtSubDomain:
         case NKikimrSchemeOp::EPathType::EPathTypeTableIndex:
         case NKikimrSchemeOp::EPathType::EPathTypeInvalid:

--- a/ydb/core/viewer/protos/viewer.proto
+++ b/ydb/core/viewer/protos/viewer.proto
@@ -43,6 +43,7 @@ enum EObjectType {
     ExternalDataSource = 25;
     View = 26;
     ResourcePool = 27;
+    SysView = 28;
 }
 
 message TBrowseInfo {

--- a/ydb/public/lib/deprecated/kicli/kicli.h
+++ b/ydb/public/lib/deprecated/kicli/kicli.h
@@ -589,7 +589,8 @@ public:
         View,
         ResourcePool,
         BackupCollection,
-        Transfer
+        Transfer,
+        SysView,
     };
 
     TSchemaObject(TSchemaObject&&) = default;

--- a/ydb/public/lib/deprecated/kicli/schema.cpp
+++ b/ydb/public/lib/deprecated/kicli/schema.cpp
@@ -147,6 +147,7 @@ void TSchemaObject::Drop() {
     case EPathType::Unknown:
     case EPathType::SubDomain:
     case EPathType::RtmrVolume:
+    case EPathType::SysView:
         throw yexception() << "Wrong drop";
         break;
     }
@@ -241,6 +242,8 @@ static TSchemaObject::EPathType GetType(const NKikimrSchemeOp::TDirEntry& entry)
         return TSchemaObject::EPathType::ResourcePool;
     case NKikimrSchemeOp::EPathTypeBackupCollection:
         return TSchemaObject::EPathType::BackupCollection;
+    case NKikimrSchemeOp::EPathTypeSysView:
+        return TSchemaObject::EPathType::SysView;
     case NKikimrSchemeOp::EPathTypeTableIndex:
     case NKikimrSchemeOp::EPathTypeExtSubDomain:
     case NKikimrSchemeOp::EPathTypeCdcStream:

--- a/ydb/services/ydb/backup_ut/ydb_backup_ut.cpp
+++ b/ydb/services/ydb/backup_ut/ydb_backup_ut.cpp
@@ -2091,6 +2091,7 @@ Y_UNIT_TEST_SUITE(BackupRestore) {
             case EPathTypeInvalid:
             case EPathTypeBackupCollection:
             case EPathTypeBlobDepot:
+            case EPathTypeSysView:
                 break; // not applicable
             case EPathTypeRtmrVolume:
             case EPathTypeBlockStoreVolume:
@@ -2629,6 +2630,7 @@ Y_UNIT_TEST_SUITE(BackupRestoreS3) {
             case EPathTypeInvalid:
             case EPathTypeBackupCollection:
             case EPathTypeBlobDepot:
+            case EPathTypeSysView:
                 break; // not applicable
             case EPathTypeRtmrVolume:
             case EPathTypeBlockStoreVolume:


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

Added new enum values for system view paths in SchemeShard, SchemeCache, Viewer, KiCli.

### Changelog category <!-- remove all except one -->

* Not for changelog (changelog entry is not required)

### Description for reviewers <!-- (optional) description for those who read this PR -->

New enum values for system views. First part of changes for support materialized sys view paths.
