### PR TITLE
Enable VDisk throttling report by default

### DIFF
--- a/ydb/core/protos/feature_flags.proto
+++ b/ydb/core/protos/feature_flags.proto
@@ -207,5 +207,5 @@ message TFeatureFlags {
     optional bool EnableEncryptedExport = 181 [default = false];
     optional bool EnableAlterDatabase = 182 [default = false];
     optional bool EnableExportAutoDropping = 183 [default = false];
-    optional bool EnableThrottlingReport = 184 [default = false];
+    optional bool EnableThrottlingReport = 184 [default = true];
 }


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

Enable VDisk throttling report by default

### Changelog category <!-- remove all except one -->

* Not for changelog (changelog entry is not required)

### Description for reviewers <!-- (optional) description for those who read this PR -->

This enables throttling reporting in VDiskMetrics by default in main and further stable branches.
