### PR TITLE
Fix reading big messages in Kafka Proxy

### DIFF
--- a/ydb/core/kafka_proxy/kafka_connection.cpp
+++ b/ydb/core/kafka_proxy/kafka_connection.cpp
@@ -573,8 +573,6 @@ protected:
             ssize_t res = Buffer.flush();
             if (res < 0) {
                 ythrow yexception() << "Error during flush of the written to socket data. Error code: " << strerror(-res) << " (" << res << ")";
-            } else if (res == 0) {
-                ythrow yexception() << "Nothing was written during flush to the socket.";
             }
 
             KAFKA_LOG_D("Sent reply: ApiKey=" << header->RequestApiKey << ", Version=" << version << ", Correlation=" << responseHeader.CorrelationId <<  ", Size=" << size);

--- a/ydb/core/kafka_proxy/kafka_connection.cpp
+++ b/ydb/core/kafka_proxy/kafka_connection.cpp
@@ -570,7 +570,10 @@ protected:
             responseHeader.Write(writable, headerVersion);
             reply->Write(writable, version);
 
-            Buffer.flush();
+            ssize_t res = Buffer.flush();
+            if (res < 0) {
+                ythrow yexception() << "Error during flush of the written to socket data. Error code: " << strerror(-res) << " (" << res << ")" << ".";
+            }
 
             KAFKA_LOG_D("Sent reply: ApiKey=" << header->RequestApiKey << ", Version=" << version << ", Correlation=" << responseHeader.CorrelationId <<  ", Size=" << size);
         } catch(const yexception& e) {

--- a/ydb/core/kafka_proxy/kafka_connection.cpp
+++ b/ydb/core/kafka_proxy/kafka_connection.cpp
@@ -572,7 +572,9 @@ protected:
 
             ssize_t res = Buffer.flush();
             if (res < 0) {
-                ythrow yexception() << "Error during flush of the written to socket data. Error code: " << strerror(-res) << " (" << res << ")" << ".";
+                ythrow yexception() << "Error during flush of the written to socket data. Error code: " << strerror(-res) << " (" << res << ")";
+            } else if (res == 0) {
+                ythrow yexception() << "Nothing was written during flush to the socket.";
             }
 
             KAFKA_LOG_D("Sent reply: ApiKey=" << header->RequestApiKey << ", Version=" << version << ", Correlation=" << responseHeader.CorrelationId <<  ", Size=" << size);

--- a/ydb/core/kafka_proxy/kafka_messages_int.cpp
+++ b/ydb/core/kafka_proxy/kafka_messages_int.cpp
@@ -23,8 +23,6 @@ void TKafkaWritable::write(const char* val, size_t length) {
     ssize_t res = Buffer.write(val, length);
     if (res < 0) {
         ythrow yexception() << "Error during flush of the written to socket data. Error code: " << strerror(-res) << " (" << res << ")";
-    } else if (res == 0) {
-        ythrow yexception() << "Nothing was written during flush to the socket.";
     }
 }
 

--- a/ydb/core/kafka_proxy/kafka_messages_int.cpp
+++ b/ydb/core/kafka_proxy/kafka_messages_int.cpp
@@ -22,7 +22,9 @@ TKafkaWritable& TKafkaWritable::operator<<(const TKafkaUuid& val) {
 void TKafkaWritable::write(const char* val, size_t length) {
     ssize_t res = Buffer.write(val, length);
     if (res < 0) {
-        ythrow yexception() << "Error during flush of the written to socket data. Error code: " << strerror(-res) << " (" << res << ")" << ".";
+        ythrow yexception() << "Error during flush of the written to socket data. Error code: " << strerror(-res) << " (" << res << ")";
+    } else if (res == 0) {
+        ythrow yexception() << "Nothing was written during flush to the socket.";
     }
 }
 

--- a/ydb/core/kafka_proxy/kafka_messages_int.cpp
+++ b/ydb/core/kafka_proxy/kafka_messages_int.cpp
@@ -20,7 +20,10 @@ TKafkaWritable& TKafkaWritable::operator<<(const TKafkaUuid& val) {
 }
 
 void TKafkaWritable::write(const char* val, size_t length) {
-    Buffer.write(val, length);
+    ssize_t res = Buffer.write(val, length);
+    if (res < 0) {
+        ythrow yexception() << "Error during flush of the written to socket data. Error code: " << strerror(-res) << " (" << res << ")" << ".";
+    }
 }
 
 TKafkaReadable& TKafkaReadable::operator>>(TKafkaUuid& val) {

--- a/ydb/core/kafka_proxy/ut/ut_serialization.cpp
+++ b/ydb/core/kafka_proxy/ut/ut_serialization.cpp
@@ -648,7 +648,8 @@ Y_UNIT_TEST(RequestHeader_reference) {
                      0x65, 0x72, 0x2D, 0x31};
 
     TWritableBuf sb(nullptr, BUFFER_SIZE);
-    sb.write((char*)reference, sizeof(reference));
+    ssize_t res = sb.write((char*)reference, sizeof(reference));
+    UNIT_ASSERT_GE(res, 0);
 
     TKafkaReadable readable(sb.GetBuffer());
     TRequestHeaderData result;

--- a/ydb/core/raw_socket/sock_impl.h
+++ b/ydb/core/raw_socket/sock_impl.h
@@ -206,8 +206,8 @@ public:
     }
 
 private:
-    const ui32 MAX_RETRY_ATTEMPTS = 3;
-    const size_t MAX_SOCKET_BATCH_SIZE = 1 * 1024 * 1024; // 1 mb
+    static constexpr ui32 MAX_RETRY_ATTEMPTS = 3;
+    static constexpr size_t MAX_SOCKET_BATCH_SIZE = 1_MB;
     TSocketDescriptor* Socket;
     TBuffer Buffer;
 

--- a/ydb/core/raw_socket/sock_impl.h
+++ b/ydb/core/raw_socket/sock_impl.h
@@ -220,7 +220,7 @@ private:
                 continue;
             }
             
-              return res;
+            return res;
         }
 
        Y_UNREACHABLE();

--- a/ydb/core/raw_socket/sock_impl.h
+++ b/ydb/core/raw_socket/sock_impl.h
@@ -211,7 +211,20 @@ private:
     TSocketDescriptor* Socket;
     TBuffer Buffer;
 
-    ssize_t Send(const char* data, size_t length) {
+ssize_t Send(const char* data, size_t length) {
+        ui32 retryAttemtpts = MAX_RETRY_ATTEMPTS;
+        while (true) {
+            ssize_t res = Socket->Send(data, length);
+            // retry 
+            if ((-res == EAGAIN || -res == EWOULDBLOCK || -res == EINTR) && retryAttemtpts--) {
+                continue;
+            }
+            
+              return res;
+        }
+
+       Y_UNREACHABLE();
+    }
         ui32 retryAttemtpts = MAX_RETRY_ATTEMPTS;
         while (retryAttemtpts > 0) {
             ssize_t res = Socket->Send(data, length);

--- a/ydb/core/raw_socket/sock_impl.h
+++ b/ydb/core/raw_socket/sock_impl.h
@@ -211,7 +211,7 @@ private:
     TSocketDescriptor* Socket;
     TBuffer Buffer;
 
-ssize_t Send(const char* data, size_t length) {
+    ssize_t Send(const char* data, size_t length) {
         ui32 retryAttemtpts = MAX_RETRY_ATTEMPTS;
         while (true) {
             ssize_t res = Socket->Send(data, length);
@@ -224,20 +224,6 @@ ssize_t Send(const char* data, size_t length) {
         }
 
        Y_UNREACHABLE();
-    }
-        ui32 retryAttemtpts = MAX_RETRY_ATTEMPTS;
-        while (retryAttemtpts > 0) {
-            ssize_t res = Socket->Send(data, length);
-            // retry 
-            if ( -res == EAGAIN || -res == EWOULDBLOCK || -res == EINTR) {
-                retryAttemtpts--;
-                continue;
-            } else {
-                return res;
-            }
-        }
-
-        return 0;
     }
 };
 

--- a/ydb/core/raw_socket/sock_impl.h
+++ b/ydb/core/raw_socket/sock_impl.h
@@ -222,8 +222,8 @@ private:
             
             return res;
         }
-
-       Y_UNREACHABLE();
+        
+        Y_UNREACHABLE();
     }
 };
 


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

Issue: https://github.com/ydb-platform/ydb/issues/18116

This PR fixes optimisation in `NKikimr::NRawSocket::TBufferedWriter`, that wrote the entire message directly to socket if message was larger than available space in buffer. When we wrote more than 6mb to socket with SSL enabled, it every time returned -11 (WAGAIN). 
As a quick fix, we replace sending of an entire message to socket with cutting this message into 1mb chunks and sending them to socket one by one. 

### Changelog category <!-- remove all except one -->

* Bugfix 

### Description for reviewers <!-- (optional) description for those who read this PR -->

...
