### PR TITLE
Fix 'domains_config' generation of default options

### DIFF
--- a/ydb/tools/cfg/base.py
+++ b/ydb/tools/cfg/base.py
@@ -639,6 +639,10 @@ class ClusterDetailsProvider(object):
         self.__cluster_description["domains"] = values
 
     @property
+    def domains_config_as_dict(self):
+        return self.__cluster_description["domains_config"]
+
+    @property
     def domains_config(self):
         domains_config_dict = self.__cluster_description.get("domains_config", {})
         if domains_config_dict == {}:

--- a/ydb/tools/cfg/static.py
+++ b/ydb/tools/cfg/static.py
@@ -1159,7 +1159,7 @@ class StaticConfigGenerator(object):
             'ssdencrypted': blobstorage_base3_pb2.EPDiskType.SSD,
             'rotencrypted': blobstorage_base3_pb2.EPDiskType.ROT,
         }
-        
+
         if pool_kind in diskTypeToProto:
             property.Type = diskTypeToProto[pool_kind]
 
@@ -1211,7 +1211,7 @@ class StaticConfigGenerator(object):
                     type_defined = True
 
             if not type_defined:
-                logger.warning(f"pdisk_filter.property.type missing for pool {pool.Kind}. This pool name is unknown, no default has been generated, specify type by hand") 
+                logger.warning(f"pdisk_filter.property.type missing for pool {pool.Kind}. This pool name is unknown, no default has been generated, specify type by hand")
 
         if not domain.DomainId:
             domain.DomainId = 1

--- a/ydb/tools/cfg/static.py
+++ b/ydb/tools/cfg/static.py
@@ -1200,7 +1200,6 @@ class StaticConfigGenerator(object):
             if not type_defined:
                 logger.warning(f"pdisk_filter.property.type missing for pool {pool.Kind}. This pool name is unknown, no default has been generated, specify type by hand")
 
-
     def __generate_domains_from_proto(self, domains_config, domains_config_dict):
         domains = domains_config.Domain
         if len(domains) > 1:

--- a/ydb/tools/cfg/static.py
+++ b/ydb/tools/cfg/static.py
@@ -1189,7 +1189,7 @@ class StaticConfigGenerator(object):
                         break
 
                 if not encryption_mode_0:
-                    raise RuntimeError(f"You named a storage pool '{pool.Kind}', but did not explicitly enable `pool_config.encryption_mode: 1`.")
+                    raise RuntimeError(f"You named a storage pool '{pool.Kind}', but did not explicitly enable `pool_config.encryption_mode: 1`. Either specify the value (0 or 1) or rename the pool")
 
             # Check disk type is specified for every pool
             type_defined = False

--- a/ydb/tools/cfg/static.py
+++ b/ydb/tools/cfg/static.py
@@ -1198,6 +1198,10 @@ class StaticConfigGenerator(object):
                 defaultPool.MergeFrom(pool)
                 pool.CopyFrom(defaultPool)
 
+        for pool in domain.StoragePoolTypes:
+            if 'encrypted' in pool.Kind and pool.EncryptionMode != 1:
+                raise RuntimeError(f"You named a storage pool '{pool.Kind}', but did not explicitly enable `pool_config.encryption_mode: 1`.")
+
         if not domain.DomainId:
             domain.DomainId = 1
         if not domain.PlanResolution:

--- a/ydb/tools/cfg/static.py
+++ b/ydb/tools/cfg/static.py
@@ -1162,6 +1162,9 @@ class StaticConfigGenerator(object):
 
         property.Type = diskTypeToProto[pool_kind]
 
+        if pool_kind in ['ssdencrypted', 'rotencrypted']:
+            pool_config.EncryptionMode = 1
+
         pool.PoolConfig.CopyFrom(pool_config)
         return pool
 

--- a/ydb/tools/cfg/static.py
+++ b/ydb/tools/cfg/static.py
@@ -1198,7 +1198,7 @@ class StaticConfigGenerator(object):
 
         for pool in domain.StoragePoolTypes:
             # Empirical check: if a pool has 'encrypted' in its name it probably should be encrypted
-            if 'encrypted' in pool.Kind and pool.PoolConfig.EncryptionMode != 1:
+            if 'encrypted' in pool.Kind and not pool.PoolConfig.EncryptionMode:
                 raise RuntimeError(f"You named a storage pool '{pool.Kind}', but did not explicitly enable `pool_config.encryption_mode: 1`.")
 
             # Check disk type is specified for every pool

--- a/ydb/tools/cfg/static.py
+++ b/ydb/tools/cfg/static.py
@@ -1163,9 +1163,6 @@ class StaticConfigGenerator(object):
         if pool_kind in diskTypeToProto:
             property.Type = diskTypeToProto[pool_kind]
 
-        if pool_kind in ['ssdencrypted', 'rotencrypted']:
-            pool_config.EncryptionMode = 1
-
         pool.PoolConfig.CopyFrom(pool_config)
         return pool
 


### PR DESCRIPTION
### Changelog category <!-- remove all except one -->

* Not for changelog (changelog entry is not required)

### Description for reviewers <!-- (optional) description for those who read this PR -->

- earlier we introduced a short specification for `domain_configs` in template:

```
domains_config:
  domain:
    - name: <domain_name>
      storage_pool_types:
        - kind: ssd
        - kind: rot
...
```

an important option `encryption_mode` was lost when generating all other defaults:

```
    domains_config:
      domain:
        - domain_id: 1
          name: dev
          plan_resolution: '10'
          scheme_root: '72057594046678944'
          ssid: [1]
          storage_pool_types:
            - kind: ssd
              pool_config:
                box_id: '1'
                encryption_mode: 1 # THIS ONE <<<<<<<<<<<<<<<<<<<<<<<
                erasure_species: mirror-3-dc
                kind: ssd
                pdisk_filter:
                  - property:
                      - {type: ssd}
                vdisk_kind: default
```

We only have encryption enabled on pools which are called `ssdencrypted` and `rotencrypted`. Encryption will be enabled explicitly on these pools only. 

Also, if you named your pool with "encrypted" as a substring, you will not be allowed to create such a pool without specifying "encryption_mode: 1".