### PR TITLE
Disallow inconsistent reads with broken write locks

### DIFF
--- a/ydb/core/tx/datashard/datashard_user_db.cpp
+++ b/ydb/core/tx/datashard/datashard_user_db.cpp
@@ -339,7 +339,7 @@ void TDataShardUserDb::CommitChanges(const TTableId& tableId, ui64 lockId, const
         return;
     }
 
-    if (auto lock = Self.SysLocksTable().GetRawLock(lockId, TRowVersion::Min()); lock && !VolatileCommitOrdered) {
+    if (auto lock = Self.SysLocksTable().GetRawLock(lockId); lock && !VolatileCommitOrdered) {
         lock->ForAllVolatileDependencies([this](ui64 txId) {
             auto* info = Self.GetVolatileTxManager().FindByCommitTxId(txId);
             if (info && info->State != EVolatileTxState::Aborting) {

--- a/ydb/core/tx/datashard/read_iterator.h
+++ b/ydb/core/tx/datashard/read_iterator.h
@@ -173,6 +173,7 @@ public:
     ui64 LockId = 0;
     ui32 LockNodeId = 0;
     TLockInfo::TPtr Lock;
+    bool LockInconsistent = false;
 
     // note that will be always overwritten by values from request
     NKikimrDataEvents::EDataFormat Format = NKikimrDataEvents::FORMAT_CELLVEC;

--- a/ydb/core/tx/locks/locks.cpp
+++ b/ydb/core/tx/locks/locks.cpp
@@ -652,12 +652,18 @@ void TLockLocker::AddWriteLock(const TLockInfo::TPtr& lock, TIntrusiveList<TTabl
     }
 }
 
-TLockInfo::TPtr TLockLocker::GetLock(ui64 lockTxId, const TRowVersion& at) const {
+TLockInfo::TPtr TLockLocker::GetLock(ui64 lockTxId) const {
     auto it = Locks.find(lockTxId);
     if (it != Locks.end()) {
-        TLockInfo::TPtr lock = it->second;
-        if (!lock->IsBroken(at))
-            return lock;
+        return it->second;
+    }
+    return nullptr;
+}
+
+TLockInfo::TPtr TLockLocker::GetLock(ui64 lockTxId, const TRowVersion& at) const {
+    auto lock = GetLock(lockTxId);
+    if (lock && !lock->IsBroken(at)) {
+        return lock;
     }
     return nullptr;
 }

--- a/ydb/core/tx/locks/locks.h
+++ b/ydb/core/tx/locks/locks.h
@@ -577,6 +577,7 @@ public:
     void AddShardLock(const TLockInfo::TPtr& lock, TIntrusiveList<TTableLocks, TTableLocksReadListTag>& readTables);
     void AddWriteLock(const TLockInfo::TPtr& lock, TIntrusiveList<TTableLocks, TTableLocksWriteListTag>& writeTables);
 
+    TLockInfo::TPtr GetLock(ui64 lockTxId) const;
     TLockInfo::TPtr GetLock(ui64 lockTxId, const TRowVersion& at) const;
 
     ui64 LocksCount() const { return Locks.size(); }
@@ -916,14 +917,19 @@ public:
     ui64 LocksCount() const { return Locker.LocksCount(); }
     ui64 BrokenLocksCount() const { return Locker.BrokenLocksCount(); }
 
-    TLockInfo::TPtr GetRawLock(ui64 lockTxId, const TRowVersion& at = TRowVersion::Max()) const {
+    TLockInfo::TPtr GetRawLock(ui64 lockTxId) const {
+        return Locker.GetLock(lockTxId);
+    }
+
+    TLockInfo::TPtr GetRawLock(ui64 lockTxId, const TRowVersion& at) const {
         return Locker.GetLock(lockTxId, at);
     }
 
     bool IsBroken(ui64 lockTxId, const TRowVersion& at = TRowVersion::Max()) const {
-        TLockInfo::TPtr txLock = Locker.GetLock(lockTxId, at);
-        if (txLock)
+        TLockInfo::TPtr txLock = Locker.GetLock(lockTxId);
+        if (txLock) {
             return txLock->IsBroken(at);
+        }
         return true;
     }
 


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

Don't allow observing inconsistent results in some read-write transactions. Fixes #18064.

### Changelog category <!-- remove all except one -->

* Bugfix 

### Description for reviewers <!-- (optional) description for those who read this PR -->

It was possible to observe wild inconsistent results in some read-write transactions where conflicting writes overwrite and shadow previous uncommitted changes. Make sure transaction is aborted quickly instead.