### PR TITLE
added create and drop scheme ops for sysview path type

### DIFF
--- a/ydb/core/protos/counters_schemeshard.proto
+++ b/ydb/core/protos/counters_schemeshard.proto
@@ -247,6 +247,10 @@ enum ESimpleCounters {
 
     COUNTER_TENANT_DATA_ERASURE_QUEUE_SIZE = 194          [(CounterOpts) = {Name: "TenantDataErasureQueueSize"}];
     COUNTER_TENANT_DATA_ERASURE_QUEUE_RUNNING = 195       [(CounterOpts) = {Name: "TenantDataErasureQueueRunning"}];
+
+    COUNTER_SYS_VIEW_COUNT = 196                    [(CounterOpts) = {Name: "SysViewCount"}];
+    COUNTER_IN_FLIGHT_OPS_TxCreateSysView = 197     [(CounterOpts) = {Name: "InFlightOps/CreateSysView"}];
+    COUNTER_IN_FLIGHT_OPS_TxDropSysView = 198       [(CounterOpts) = {Name: "InFlightOps/DropSysView"}];
 }
 
 enum ECumulativeCounters {
@@ -397,6 +401,9 @@ enum ECumulativeCounters {
 
     COUNTER_TENANT_DATA_ERASURE_OK = 117                   [(CounterOpts) = {Name: "TenantDataErasureOK"}];
     COUNTER_TENANT_DATA_ERASURE_TIMEOUT = 118              [(CounterOpts) = {Name: "TenantDataErasureTimeout"}];
+
+    COUNTER_FINISHED_OPS_TxCreateSysView = 119              [(CounterOpts) = {Name: "FinishedOps/CreateSysView"}];
+    COUNTER_FINISHED_OPS_TxDropSysView = 120                [(CounterOpts) = {Name: "FinishedOps/DropSysView"}];
 }
 
 enum EPercentileCounters {

--- a/ydb/core/protos/flat_scheme_op.proto
+++ b/ydb/core/protos/flat_scheme_op.proto
@@ -11,6 +11,7 @@ import "ydb/core/protos/replication.proto";
 import "ydb/core/protos/s3_settings.proto";
 import "ydb/core/protos/schemeshard/operations.proto";
 import "ydb/core/protos/subdomains.proto";
+import "ydb/core/protos/sys_view_types.proto";
 import "ydb/core/protos/table_stats.proto";
 import "ydb/core/protos/tablet.proto";
 import "ydb/core/protos/yql_translation_settings.proto";
@@ -1752,6 +1753,8 @@ message TModifyScheme {
 
     optional TMove MoveSequence = 77;
 
+    optional TSysViewDescription CreateSysView = 81;
+
     // Some entries are grouped by semantics, so are out of order
 }
 
@@ -1878,6 +1881,7 @@ message TPathVersion {
     optional uint64 ViewVersion = 29;
     optional uint64 ResourcePoolVersion = 30;
     optional uint64 BackupCollectionVersion = 31;
+    optional uint64 SysViewVersion = 32;
 }
 
 // Describes single path
@@ -1969,6 +1973,7 @@ message TPathDescription {
     optional TViewDescription ViewDescription = 29;
     optional TResourcePoolDescription ResourcePoolDescription = 30;
     optional TBackupCollectionDescription BackupCollectionDescription = 31;
+    optional TSysViewDescription SysViewDescription = 32;
 }
 
 // For persisting AlterTable Tx description in Schemeshard internal DB
@@ -2180,4 +2185,9 @@ message TExportMetadata {
     optional string CompressionAlgorithm = 2;
     optional string EncryptionAlgorithm = 3;
     optional bytes IV = 4;
+}
+
+message TSysViewDescription {
+    optional string Name = 1;
+    optional NKikimrSysView.ESysViewType Type = 2;
 }

--- a/ydb/core/protos/schemeshard/operations.proto
+++ b/ydb/core/protos/schemeshard/operations.proto
@@ -173,7 +173,10 @@ enum EOperationType {
     ESchemeOpAlterTransfer = 113;
     ESchemeOpDropTransfer = 114;
     ESchemeOpDropTransferCascade = 115;
-    
-    
+
+    // SysView
+    ESchemeOpCreateSysView = 116;
+    ESchemeOpDropSysView = 117;
+
     // Some entries are grouped by semantics, so are out of order
 }

--- a/ydb/core/protos/sys_view_types.proto
+++ b/ydb/core/protos/sys_view_types.proto
@@ -1,0 +1,7 @@
+package NKikimrSysView;
+
+option java_package = "ru.yandex.kikimr.proto";
+
+enum ESysViewType {
+    EPartitionStats = 1;
+}

--- a/ydb/core/protos/ya.make
+++ b/ydb/core/protos/ya.make
@@ -129,6 +129,7 @@ SRCS(
     stream.proto
     subdomains.proto
     sys_view.proto
+    sys_view_types.proto
     table_service_config.proto
     table_stats.proto
     tablet.proto

--- a/ydb/core/tx/schemeshard/schemeshard__init.cpp
+++ b/ydb/core/tx/schemeshard/schemeshard__init.cpp
@@ -1952,6 +1952,28 @@ struct TSchemeShard::TTxInit : public TTransactionBase<TSchemeShard> {
             }
         }
 
+        // Read SysViews
+        {
+            auto rowset = db.Table<Schema::SysView>().Range().Select();
+            if (!rowset.IsReady()) {
+                return false;
+            }
+
+            while (!rowset.EndOfSet()) {
+                TLocalPathId localPathId = rowset.GetValue<Schema::SysView::PathId>();
+                TPathId pathId(selfId, localPathId);
+
+                auto& sysView = Self->SysViews[pathId] = new TSysViewInfo();
+                sysView->AlterVersion = rowset.GetValue<Schema::SysView::AlterVersion>();
+                sysView->Type = rowset.GetValue<Schema::SysView::SysViewType>();
+                Self->IncrementPathDbRefCount(pathId);
+
+                if (!rowset.Next()) {
+                    return false;
+                }
+            }
+        }
+
         // Resorce Pool
         {
             auto rowset = db.Table<Schema::ResourcePool>().Range().Select();

--- a/ydb/core/tx/schemeshard/schemeshard__operation.cpp
+++ b/ydb/core/tx/schemeshard/schemeshard__operation.cpp
@@ -1262,6 +1262,12 @@ ISubOperation::TPtr TOperation::RestorePart(TTxState::ETxType txType, TTxState::
     case TTxState::ETxType::TxDropBackupCollection:
         return CreateDropBackupCollection(NextPartId(), txState);
 
+    // SysView
+    case TTxState::ETxType::TxCreateSysView:
+        return CreateNewSysView(NextPartId(), txState);
+    case TTxState::ETxType::TxDropSysView:
+        return CreateDropSysView(NextPartId(), txState);
+
     case TTxState::ETxType::TxInvalid:
         Y_UNREACHABLE();
     }
@@ -1560,6 +1566,12 @@ TVector<ISubOperation::TPtr> TDefaultOperationFactory::MakeOperationParts(
         return CreateBackupIncrementalBackupCollection(op.NextPartId(), tx, context);
     case NKikimrSchemeOp::EOperationType::ESchemeOpRestoreBackupCollection:
         return CreateRestoreBackupCollection(op.NextPartId(), tx, context);
+
+    // SysView
+    case NKikimrSchemeOp::EOperationType::ESchemeOpCreateSysView:
+        return {CreateNewSysView(op.NextPartId(), tx)};
+    case NKikimrSchemeOp::EOperationType::ESchemeOpDropSysView:
+        return {CreateDropSysView(op.NextPartId(), tx)};
     }
 
     Y_UNREACHABLE();

--- a/ydb/core/tx/schemeshard/schemeshard__operation_create_sysview.cpp
+++ b/ydb/core/tx/schemeshard/schemeshard__operation_create_sysview.cpp
@@ -1,0 +1,280 @@
+#include "schemeshard__operation_part.h"
+#include "schemeshard__operation_common.h"
+#include "schemeshard_impl.h"
+#include "schemeshard__op_traits.h"
+
+#define LOG_N(stream) LOG_NOTICE_S(context.Ctx, NKikimrServices::FLAT_TX_SCHEMESHARD, "[" << context.SS->SelfTabletId() << "] " << stream)
+#define LOG_I(stream) LOG_INFO_S  (context.Ctx, NKikimrServices::FLAT_TX_SCHEMESHARD, "[" << context.SS->SelfTabletId() << "] " << stream)
+#define LOG_D(stream) LOG_DEBUG_S (context.Ctx, NKikimrServices::FLAT_TX_SCHEMESHARD, "[" << context.SS->SelfTabletId() << "] " << stream)
+
+namespace {
+
+using namespace NKikimr;
+using namespace NSchemeShard;
+
+class TPropose : public TSubOperationState {
+    const TOperationId OperationId;
+
+    TString DebugHint() const override {
+        return TStringBuilder()
+            << "TCreateSysView::TPropose"
+            << ", opId: " << OperationId;
+    }
+
+public:
+    TPropose(TOperationId id)
+        : OperationId(id)
+    {}
+
+    bool ProgressState(TOperationContext& context) override {
+        LOG_I(DebugHint() << " ProgressState");
+
+        const auto* txState = context.SS->FindTx(OperationId);
+        Y_ABORT_UNLESS(txState);
+        Y_ABORT_UNLESS(txState->TxType == TTxState::TxCreateSysView);
+
+        context.OnComplete.ProposeToCoordinator(OperationId, txState->TargetPathId, TStepId(0));
+        return false;
+    }
+
+    bool HandleReply(TEvPrivate::TEvOperationPlan::TPtr& ev, TOperationContext& context) override {
+        const TStepId step = TStepId(ev->Get()->StepId);
+
+        LOG_I(DebugHint() << " HandleReply TEvPrivate::TEvOperationPlan"
+            << ", step: " << step
+        );
+
+        TTxState* txState = context.SS->FindTx(OperationId);
+        Y_ABORT_UNLESS(txState);
+        Y_ABORT_UNLESS(txState->TxType == TTxState::TxCreateSysView);
+
+        context.SS->TabletCounters->Simple()[COUNTER_SYS_VIEW_COUNT].Add(1);
+
+        const auto pathId = txState->TargetPathId;
+        auto path = TPath::Init(pathId, context.SS);
+
+        NIceDb::TNiceDb db(context.GetDB());
+
+        path.Base()->StepCreated = step;
+        context.SS->PersistCreateStep(db, pathId, step);
+
+        IncParentDirAlterVersionWithRepublish(OperationId, path, context);
+
+        context.SS->ChangeTxState(db, OperationId, TTxState::Done);
+        return true;
+    }
+};
+
+TSysViewInfo::TPtr CreateSysView(const NKikimrSchemeOp::TSysViewDescription& desc) {
+    TSysViewInfo::TPtr sysViewInfo = new TSysViewInfo;
+    sysViewInfo->AlterVersion = 1;
+    sysViewInfo->Type = desc.GetType();
+    return sysViewInfo;
+}
+
+class TCreateSysView : public TSubOperation {
+    static TTxState::ETxState NextState() {
+        return TTxState::Propose;
+    }
+
+    TTxState::ETxState NextState(TTxState::ETxState state) const override {
+        switch (state) {
+            case TTxState::Waiting:
+            case TTxState::Propose:
+                return TTxState::Done;
+            default:
+                return TTxState::Invalid;
+        }
+    }
+
+    TSubOperationState::TPtr SelectStateFunc(TTxState::ETxState state) override {
+        switch (state) {
+            case TTxState::Waiting:
+            case TTxState::Propose:
+                return MakeHolder<TPropose>(OperationId);
+            case TTxState::Done:
+                return MakeHolder<TDone>(OperationId);
+            default:
+                return nullptr;
+        }
+    }
+
+public:
+    using TSubOperation::TSubOperation;
+
+    THolder<TProposeResponse> Propose(const TString& owner, TOperationContext& context) override {
+        const TTabletId ssId = context.SS->SelfTabletId();
+
+        const TString& parentPathStr = Transaction.GetWorkingDir();
+        const auto& sysViewDescription = Transaction.GetCreateSysView();
+
+        const TString& name = sysViewDescription.GetName();
+
+        LOG_N("TCreateSysView Propose"
+            << ", path: " << parentPathStr << "/" << name
+            << ", opId: " << OperationId
+        );
+
+        LOG_D("TCreateSysView Propose"
+            << ", path: " << parentPathStr << "/" << name
+            << ", opId: " << OperationId
+            << ", sysViewDescription: " << sysViewDescription.ShortDebugString()
+        );
+
+        auto result = MakeHolder<TProposeResponse>(NKikimrScheme::StatusAccepted, ui64(OperationId.GetTxId()), ui64(ssId));
+
+        const auto parentPath = NSchemeShard::TPath::Resolve(parentPathStr, context.SS);
+        {
+            const auto checks = parentPath.Check();
+            checks
+                .NotUnderDomainUpgrade()
+                .IsAtLocalSchemeShard()
+                .IsResolved()
+                .NotDeleted()
+                .NotUnderDeleting()
+                .IsCommonSensePath()
+                .IsSysViewDirectory();
+
+            if (!checks) {
+                result->SetError(checks.GetStatus(), checks.GetError());
+                return result;
+            }
+        }
+
+        const TString acl = Transaction.GetModifyACL().GetDiffACL();
+
+        NSchemeShard::TPath dstPath = parentPath.Child(name);
+        {
+            const auto checks = dstPath.Check();
+            checks.IsAtLocalSchemeShard();
+            if (dstPath.IsResolved()) {
+                checks
+                    .NotUnderDeleting()
+                    .FailOnExist(TPathElement::EPathType::EPathTypeSysView, /* acceptAlreadyExist */ false);
+            } else {
+                checks
+                    .NotEmpty();
+            }
+
+            if (checks) {
+                checks
+                    .IsValidLeafName()
+                    .DepthLimit()
+                    .PathsLimit()
+                    .DirChildrenLimit()
+                    .IsValidACL(acl);
+            }
+
+            if (!checks) {
+                result->SetError(checks.GetStatus(), checks.GetError());
+                if (dstPath.IsResolved()) {
+                    result->SetPathCreateTxId(ui64(dstPath.Base()->CreateTxId));
+                    result->SetPathId(dstPath.Base()->PathId.LocalPathId);
+                }
+                return result;
+            }
+        }
+
+        TString errStr;
+        if (!context.SS->CheckApplyIf(Transaction, errStr)) {
+            result->SetError(NKikimrScheme::StatusPreconditionFailed, errStr);
+            return result;
+        }
+
+        if (!NKikimrSysView::ESysViewType_IsValid(sysViewDescription.GetType())) {
+            errStr = TStringBuilder()
+                << "error: unsupported system view type "
+                << static_cast<uint32_t>(sysViewDescription.GetType());
+            result->SetError(NKikimrScheme::StatusSchemeError, errStr);
+        }
+
+        auto guard = context.DbGuard();
+        const auto sysViewPathId = context.SS->AllocatePathId();
+        context.MemChanges.GrabNewPath(context.SS, sysViewPathId);
+        context.MemChanges.GrabPath(context.SS, parentPath->PathId);
+        context.MemChanges.GrabNewSysView(context.SS, sysViewPathId);
+        context.MemChanges.GrabNewTxState(context.SS, OperationId);
+
+        context.DbChanges.PersistPath(sysViewPathId);
+        context.DbChanges.PersistPath(parentPath->PathId);
+        context.DbChanges.PersistSysView(sysViewPathId);
+        context.DbChanges.PersistTxState(OperationId);
+
+        dstPath.MaterializeLeaf(owner, sysViewPathId);
+        dstPath.DomainInfo()->IncPathsInside(context.SS);
+        IncAliveChildrenSafeWithUndo(OperationId, parentPath, context); // for correct discard of ChildrenExist prop
+
+        result->SetPathId(sysViewPathId.LocalPathId);
+
+        TPathElement::TPtr sysViewPath = dstPath.Base();
+        sysViewPath->PathState = TPathElement::EPathState::EPathStateCreate;
+        sysViewPath->PathType = TPathElement::EPathType::EPathTypeSysView;
+        sysViewPath->CreateTxId = OperationId.GetTxId();
+        sysViewPath->LastTxId = OperationId.GetTxId();
+        if (!acl.empty()) {
+            sysViewPath->ApplyACL(acl);
+        }
+
+        TSysViewInfo::TPtr sysViewInfo = CreateSysView(sysViewDescription);
+        context.SS->SysViews[sysViewPathId] = sysViewInfo;
+
+        TTxState& txState = context.SS->CreateTx(OperationId, TTxState::TxCreateSysView, sysViewPathId);
+        txState.State = TTxState::Propose;
+        context.OnComplete.ActivateTx(OperationId);
+
+        if (parentPath.Base()->HasActiveChanges()) {
+            TTxId parentTxId = parentPath.Base()->PlannedToCreate() ? parentPath.Base()->CreateTxId : parentPath.Base()->LastTxId;
+            context.OnComplete.Dependence(parentTxId, OperationId.GetTxId());
+        }
+
+        SetState(NextState());
+        return result;
+    }
+
+    void AbortPropose(TOperationContext& context) override {
+        LOG_N("TCreateSysView AbortPropose"
+            << ", opId: " << OperationId
+        );
+    }
+
+    void AbortUnsafe(TTxId forceDropTxId, TOperationContext& context) override {
+        LOG_N("TCreateSysView AbortUnsafe"
+            << ", opId: " << OperationId
+            << ", forceDropId: " << forceDropTxId
+        );
+
+        context.OnComplete.DoneOperation(OperationId);
+    }
+};
+
+}
+
+namespace NKikimr::NSchemeShard {
+
+using TTag = TSchemeTxTraits<NKikimrSchemeOp::EOperationType::ESchemeOpCreateSysView>;
+
+namespace NOperation {
+
+template <>
+std::optional<TString> GetTargetName<TTag>(TTag, const TTxTransaction& tx) {
+    return tx.GetCreateSysView().GetName();
+}
+
+template <>
+bool SetName<TTag>(TTag, TTxTransaction& tx, const TString& name) {
+    tx.MutableCreateSysView()->SetName(name);
+    return true;
+}
+
+} // namespace NOperation
+
+ISubOperation::TPtr CreateNewSysView(TOperationId id, const TTxTransaction& tx) {
+    return MakeSubOperation<TCreateSysView>(id, tx);
+}
+
+ISubOperation::TPtr CreateNewSysView(TOperationId id, TTxState::ETxState state) {
+    Y_ABORT_UNLESS(state != TTxState::Invalid);
+    return MakeSubOperation<TCreateSysView>(id, state);
+}
+
+}

--- a/ydb/core/tx/schemeshard/schemeshard__operation_db_changes.cpp
+++ b/ydb/core/tx/schemeshard/schemeshard__operation_db_changes.cpp
@@ -104,6 +104,10 @@ void TStorageChanges::Apply(TSchemeShard* ss, NTabletFlatExecutor::TTransactionC
     for (const auto& [pathId, pqGroup] : AddPersQueueGroupAlter) {
         ss->PersistAddPersQueueGroupAlter(db, pathId, pqGroup);
     }
+
+    for (const auto& pId : SysViews) {
+        ss->PersistSysView(db, pId);
+    }
 }
 
 }

--- a/ydb/core/tx/schemeshard/schemeshard__operation_db_changes.h
+++ b/ydb/core/tx/schemeshard/schemeshard__operation_db_changes.h
@@ -40,6 +40,8 @@ class TStorageChanges: public TSimpleRefCount<TStorageChanges> {
     TDeque<TPathId> Sequences;
     TDeque<TPathId> AlterSequences;
 
+    TDeque<TPathId> SysViews;
+
     //PQ part
     TDeque<std::tuple<TPathId, TShardIdx, TTopicTabletInfo::TTopicPartitionInfo>> PersQueue;
     TDeque<std::pair<TPathId, TTopicInfo::TPtr>> PersQueueGroup;
@@ -126,6 +128,10 @@ public:
 
     void PersistSequence(const TPathId& pathId) {
         Sequences.push_back(pathId);
+    }
+
+    void PersistSysView(const TPathId& pathId) {
+        SysViews.emplace_back(pathId);
     }
 
     void Apply(TSchemeShard* ss, NTabletFlatExecutor::TTransactionContext &txc, const TActorContext &ctx);

--- a/ydb/core/tx/schemeshard/schemeshard__operation_drop_sysview.cpp
+++ b/ydb/core/tx/schemeshard/schemeshard__operation_drop_sysview.cpp
@@ -1,0 +1,215 @@
+#include "schemeshard__operation_common.h"
+#include "schemeshard__operation_part.h"
+#include "schemeshard_impl.h"
+
+#define LOG_N(stream) LOG_NOTICE_S(context.Ctx, NKikimrServices::FLAT_TX_SCHEMESHARD, "[" << context.SS->SelfTabletId() << "] " << stream)
+#define LOG_I(stream) LOG_INFO_S  (context.Ctx, NKikimrServices::FLAT_TX_SCHEMESHARD, "[" << context.SS->SelfTabletId() << "] " << stream)
+
+namespace {
+
+using namespace NKikimr;
+using namespace NSchemeShard;
+
+class TPropose : public TSubOperationState {
+    const TOperationId OperationId;
+
+    TString DebugHint() const override {
+        return TStringBuilder()
+            << "TDropSysView TPropose"
+            << ", opId: " << OperationId;
+    }
+
+public:
+    explicit TPropose(TOperationId id)
+        : OperationId(id)
+    { }
+
+    bool ProgressState(TOperationContext& context) override {
+        LOG_I(DebugHint() << " ProgressState");
+
+        const auto* txState = context.SS->FindTx(OperationId);
+        Y_ABORT_UNLESS(txState);
+        Y_ABORT_UNLESS(txState->TxType == TTxState::TxDropSysView);
+
+        context.OnComplete.ProposeToCoordinator(OperationId, txState->TargetPathId, TStepId(0));
+        return false;
+    }
+
+    bool HandleReply(TEvPrivate::TEvOperationPlan::TPtr& ev, TOperationContext& context) override {
+        const auto step = TStepId(ev->Get()->StepId);
+
+        LOG_I(DebugHint() << " HandleReply TEvOperationPlan"
+            << ", step: " << step
+        );
+
+        TTxState* txState = context.SS->FindTx(OperationId);
+        Y_ABORT_UNLESS(txState);
+        Y_ABORT_UNLESS(txState->TxType == TTxState::TxDropSysView);
+
+        TPathId pathId = txState->TargetPathId;
+        auto path = context.SS->PathsById.at(pathId);
+        auto parentDir = context.SS->PathsById.at(path->ParentPathId);
+
+        NIceDb::TNiceDb db(context.GetDB());
+
+        Y_ABORT_UNLESS(!path->Dropped());
+        path->SetDropped(step, OperationId.GetTxId());
+        context.SS->PersistDropStep(db, pathId, step, OperationId);
+        auto domainInfo = context.SS->ResolveDomainInfo(pathId);
+        domainInfo->DecPathsInside(context.SS);
+        DecAliveChildrenDirect(OperationId, parentDir, context); // for correct discard of ChildrenExist prop
+
+        context.SS->TabletCounters->Simple()[COUNTER_SYS_VIEW_COUNT].Sub(1);
+        context.SS->PersistRemoveSysView(db, pathId);
+
+        ++parentDir->DirAlterVersion;
+        context.SS->PersistPathDirAlterVersion(db, parentDir);
+        context.SS->ClearDescribePathCaches(parentDir);
+        context.SS->ClearDescribePathCaches(path);
+
+        if (!context.SS->DisablePublicationsOfDropping) {
+            context.OnComplete.PublishToSchemeBoard(OperationId, parentDir->PathId);
+            context.OnComplete.PublishToSchemeBoard(OperationId, pathId);
+        }
+
+        context.SS->ChangeTxState(db, OperationId, TTxState::Done);
+
+        return true;
+    }
+};
+
+class TDropSysView : public TSubOperation {
+    TTxState::ETxState NextState() const {
+        return TTxState::Propose;
+    }
+
+    TTxState::ETxState NextState(TTxState::ETxState state) const override {
+        switch (state) {
+        case TTxState::Propose:
+            return TTxState::Done;
+        default:
+            return TTxState::Invalid;
+        }
+    }
+
+    TSubOperationState::TPtr SelectStateFunc(TTxState::ETxState state) override {
+        switch (state) {
+        case TTxState::Propose:
+            return MakeHolder<TPropose>(OperationId);
+        case TTxState::Done:
+            return MakeHolder<TDone>(OperationId);
+        default:
+            return nullptr;
+        }
+    }
+
+public:
+    using TSubOperation::TSubOperation;
+
+    THolder<TProposeResponse> Propose(const TString&, TOperationContext& context) override {
+        const ui64 ssId = context.SS->TabletID();
+        const auto& drop = Transaction.GetDrop();
+
+        const TString& workingDir = Transaction.GetWorkingDir();
+        const TString& name = drop.GetName();
+
+        LOG_N("TDropSysView Propose"
+            << ", opId: " << OperationId
+            << ", path: " << workingDir << "/" << name
+        );
+
+        auto result = MakeHolder<TProposeResponse>(NKikimrScheme::StatusAccepted, ui64(OperationId.GetTxId()), ssId);
+
+        TPath path = drop.HasId()
+            ? TPath::Init(context.SS->MakeLocalId(drop.GetId()), context.SS)
+            : TPath::Resolve(workingDir, context.SS).Dive(name);
+        {
+            auto checks = path.Check();
+            checks
+                .NotEmpty()
+                .NotUnderDomainUpgrade()
+                .IsAtLocalSchemeShard()
+                .IsResolved()
+                .NotDeleted()
+                .NotUnderDeleting()
+                .IsSysView()
+                .NotUnderOperation();
+
+            if (!checks) {
+                result->SetError(checks.GetStatus(), checks.GetError());
+                if (path.IsResolved() &&
+                    path.Base()->IsSysView() &&
+                    (path.Base()->PlannedToDrop() || path.Base()->Dropped())
+                    ) {
+                    result->SetPathDropTxId(ui64(path.Base()->DropTxId));
+                    result->SetPathId(path.Base()->PathId.LocalPathId);
+                }
+                return result;
+            }
+        }
+
+        TSysViewInfo::TPtr sysView = context.SS->SysViews.Value(path->PathId, nullptr);
+        Y_ABORT_UNLESS(sysView);
+
+        TString errStr;
+        if (!context.SS->CheckApplyIf(Transaction, errStr)) {
+            result->SetError(NKikimrScheme::StatusPreconditionFailed, errStr);
+            return result;
+        }
+
+        const auto pathId = path.Base()->PathId;
+        result->SetPathId(pathId.LocalPathId);
+
+        auto guard = context.DbGuard();
+        context.MemChanges.GrabNewTxState(context.SS, OperationId);
+        context.MemChanges.GrabPath(context.SS, pathId);
+        context.MemChanges.GrabPath(context.SS, path->ParentPathId);
+
+        context.DbChanges.PersistPath(pathId);
+        context.DbChanges.PersistPath(path->ParentPathId);
+        context.DbChanges.PersistTxState(OperationId);
+
+        path.Base()->PathState = TPathElement::EPathState::EPathStateDrop;
+        path.Base()->DropTxId = OperationId.GetTxId();
+        path.Base()->LastTxId = OperationId.GetTxId();
+
+        TTxState& txState = context.SS->CreateTx(OperationId, TTxState::TxDropSysView, path.Base()->PathId);
+        txState.State = TTxState::Propose;
+        txState.MinStep = TStepId(1);
+
+        context.OnComplete.ActivateTx(OperationId);
+
+        SetState(NextState());
+        return result;
+    }
+
+    void AbortPropose(TOperationContext& context) override {
+        LOG_N("TDropSysView AbortPropose"
+            << ", opId: " << OperationId
+        );
+    }
+
+    void AbortUnsafe(TTxId forceDropTxId, TOperationContext& context) override {
+        LOG_N("TDropSysView AbortUnsafe"
+            << ", opId: " << OperationId
+            << ", txId: " << forceDropTxId
+        );
+
+        context.OnComplete.DoneOperation(OperationId);
+    }
+};
+
+}
+
+namespace NKikimr::NSchemeShard {
+
+ISubOperation::TPtr CreateDropSysView(TOperationId id, const TTxTransaction& tx) {
+    return MakeSubOperation<TDropSysView>(id, tx);
+}
+
+ISubOperation::TPtr CreateDropSysView(TOperationId id, TTxState::ETxState state) {
+    Y_ABORT_UNLESS(state != TTxState::Invalid);
+    return MakeSubOperation<TDropSysView>(id, state);
+}
+
+}

--- a/ydb/core/tx/schemeshard/schemeshard__operation_memory_changes.cpp
+++ b/ydb/core/tx/schemeshard/schemeshard__operation_memory_changes.cpp
@@ -120,6 +120,14 @@ void TMemoryChanges::GrabBackupCollection(TSchemeShard* ss, const TPathId& pathI
     Grab<TBackupCollectionInfo>(pathId, ss->BackupCollections, BackupCollections);
 }
 
+void TMemoryChanges::GrabNewSysView(TSchemeShard* ss, const TPathId& pathId) {
+    GrabNew(pathId, ss->SysViews, SysViews);
+}
+
+void TMemoryChanges::GrabSysView(TSchemeShard* ss, const TPathId& pathId) {
+    Grab<TSysViewInfo>(pathId, ss->SysViews, SysViews);
+}
+
 void TMemoryChanges::UnDo(TSchemeShard* ss) {
     // be aware of the order of grab & undo ops
     // stack is the best way to manage it right
@@ -265,6 +273,16 @@ void TMemoryChanges::UnDo(TSchemeShard* ss) {
             ss->ResourcePools.erase(id);
         }
         ResourcePools.pop();
+    }
+
+    while (SysViews) {
+        const auto& [id, elem] = SysViews.top();
+        if (elem) {
+            ss->SysViews[id] = elem;
+        } else {
+            ss->SysViews.erase(id);
+        }
+        SysViews.pop();
     }
 }
 

--- a/ydb/core/tx/schemeshard/schemeshard__operation_memory_changes.h
+++ b/ydb/core/tx/schemeshard/schemeshard__operation_memory_changes.h
@@ -61,6 +61,9 @@ class TMemoryChanges: public TSimpleRefCount<TMemoryChanges> {
     using TBackupCollectionState = std::pair<TPathId, TBackupCollectionInfo::TPtr>;
     TStack<TBackupCollectionState> BackupCollections;
 
+    using TSysViewState = std::pair<TPathId, TSysViewInfo::TPtr>;
+    TStack<TSysViewState> SysViews;
+
 public:
     ~TMemoryChanges() = default;
 
@@ -101,6 +104,9 @@ public:
     void GrabResourcePool(TSchemeShard* ss, const TPathId& pathId);
 
     void GrabBackupCollection(TSchemeShard* ss, const TPathId& pathId);
+
+    void GrabNewSysView(TSchemeShard* ss, const TPathId& pathId);
+    void GrabSysView(TSchemeShard* ss, const TPathId& pathId);
 
     void UnDo(TSchemeShard* ss);
 };

--- a/ydb/core/tx/schemeshard/schemeshard__operation_part.h
+++ b/ydb/core/tx/schemeshard/schemeshard__operation_part.h
@@ -676,5 +676,13 @@ TVector<ISubOperation::TPtr> CreateRestoreBackupCollection(TOperationId opId, co
 TVector<ISubOperation::TPtr> CreateBackupBackupCollection(TOperationId opId, const TTxTransaction& tx, TOperationContext& context);
 TVector<ISubOperation::TPtr> CreateBackupIncrementalBackupCollection(TOperationId opId, const TTxTransaction& tx, TOperationContext& context);
 
+// SysView
+// Create
+ISubOperation::TPtr CreateNewSysView(TOperationId id, const TTxTransaction& tx);
+ISubOperation::TPtr CreateNewSysView(TOperationId id, TTxState::ETxState state);
+// Drop
+ISubOperation::TPtr CreateDropSysView(TOperationId id, const TTxTransaction& tx);
+ISubOperation::TPtr CreateDropSysView(TOperationId id, TTxState::ETxState state);
+
 }
 }

--- a/ydb/core/tx/schemeshard/schemeshard__operation_upgrade_subdomain.cpp
+++ b/ydb/core/tx/schemeshard/schemeshard__operation_upgrade_subdomain.cpp
@@ -309,6 +309,7 @@ public:
             case NKikimrSchemeOp::EPathType::EPathTypeExternalDataSource:
             case NKikimrSchemeOp::EPathType::EPathTypeView:
             case NKikimrSchemeOp::EPathType::EPathTypeResourcePool:
+            case NKikimrSchemeOp::EPathType::EPathTypeSysView:
                 Y_ABORT_UNLESS(!path.Base()->IsRoot());
                 //no shards
                 break;
@@ -365,7 +366,6 @@ public:
             case NKikimrSchemeOp::EPathType::EPathTypeTransfer:
             case NKikimrSchemeOp::EPathType::EPathTypeBlobDepot:
             case NKikimrSchemeOp::EPathType::EPathTypeBackupCollection:
-            case NKikimrSchemeOp::EPathType::EPathTypeSysView:
                 Y_ABORT("UNIMPLEMENTED");
             case NKikimrSchemeOp::EPathType::EPathTypeInvalid:
                 Y_UNREACHABLE();

--- a/ydb/core/tx/schemeshard/schemeshard_audit_log_fragment.cpp
+++ b/ydb/core/tx/schemeshard/schemeshard_audit_log_fragment.cpp
@@ -272,6 +272,11 @@ TString DefineUserOperationName(const NKikimrSchemeOp::TModifyScheme& tx) {
         return "BACKUP INCREMENTAL";
     case NKikimrSchemeOp::EOperationType::ESchemeOpRestoreBackupCollection:
         return "RESTORE";
+    // system view
+    case NKikimrSchemeOp::EOperationType::ESchemeOpCreateSysView:
+        return "CREATE SYSTEM VIEW";
+    case NKikimrSchemeOp::EOperationType::ESchemeOpDropSysView:
+        return "DROP SYSTEM VIEW";
     }
     Y_ABORT("switch should cover all operation types");
 }
@@ -608,6 +613,12 @@ TVector<TString> ExtractChangingPaths(const NKikimrSchemeOp::TModifyScheme& tx) 
         break;
     case NKikimrSchemeOp::EOperationType::ESchemeOpRestoreBackupCollection:
         result.emplace_back(NKikimr::JoinPath({tx.GetWorkingDir(), tx.GetRestoreBackupCollection().GetName()}));
+        break;
+    case NKikimrSchemeOp::EOperationType::ESchemeOpCreateSysView:
+        result.emplace_back(NKikimr::JoinPath({tx.GetWorkingDir(), tx.GetCreateSysView().GetName()}));
+        break;
+    case NKikimrSchemeOp::EOperationType::ESchemeOpDropSysView:
+        result.emplace_back(NKikimr::JoinPath({tx.GetWorkingDir(), tx.GetDrop().GetName()}));
         break;
     }
 

--- a/ydb/core/tx/schemeshard/schemeshard_impl.h
+++ b/ydb/core/tx/schemeshard/schemeshard_impl.h
@@ -270,6 +270,7 @@ public:
     THashMap<TPathId, TViewInfo::TPtr> Views;
     THashMap<TPathId, TResourcePoolInfo::TPtr> ResourcePools;
     THashMap<TPathId, TBackupCollectionInfo::TPtr> BackupCollections;
+    THashMap<TPathId, TSysViewInfo::TPtr> SysViews;
 
     TTempDirsState TempDirsState;
 
@@ -868,6 +869,10 @@ public:
     // BackupCollection
     void PersistBackupCollection(NIceDb::TNiceDb& db, TPathId pathId, const TBackupCollectionInfo::TPtr backupCollection);
     void PersistRemoveBackupCollection(NIceDb::TNiceDb& db, TPathId pathId);
+
+    // SysView
+    void PersistSysView(NIceDb::TNiceDb &db, TPathId pathId);
+    void PersistRemoveSysView(NIceDb::TNiceDb& db, TPathId pathId);
 
     TTabletId GetGlobalHive(const TActorContext& ctx) const;
 

--- a/ydb/core/tx/schemeshard/schemeshard_info_types.h
+++ b/ydb/core/tx/schemeshard/schemeshard_info_types.h
@@ -37,6 +37,7 @@
 #include <ydb/core/protos/filestore_config.pb.h>
 #include <ydb/core/protos/follower_group.pb.h>
 #include <ydb/core/protos/index_builder.pb.h>
+#include <ydb/core/protos/sys_view_types.pb.h>
 #include <ydb/core/protos/yql_translation_settings.pb.h>
 #include <ydb/public/api/protos/ydb_cms.pb.h>
 #include <ydb/public/api/protos/ydb_table.pb.h>
@@ -3859,6 +3860,13 @@ struct TBackupCollectionInfo : TSimpleRefCount<TBackupCollectionInfo> {
 
     ui64 AlterVersion = 0;
     NKikimrSchemeOp::TBackupCollectionDescription Description;
+};
+
+struct TSysViewInfo : TSimpleRefCount<TSysViewInfo> {
+    using TPtr = TIntrusivePtr<TSysViewInfo>;
+
+    ui64 AlterVersion = 0;
+    NKikimrSysView::ESysViewType Type;
 };
 
 bool ValidateTtlSettings(const NKikimrSchemeOp::TTTLSettings& ttl,

--- a/ydb/core/tx/schemeshard/schemeshard_path.cpp
+++ b/ydb/core/tx/schemeshard/schemeshard_path.cpp
@@ -16,6 +16,8 @@ TPath::TChecker::TChecker(const TPath& path, const NCompat::TSourceLocation loca
 {
 }
 
+bool isSysDirCreateAllowed = false;  // TODO(n00bcracker): remove after giving permissions only for metadata@system
+
 TPath::TChecker::operator bool() const {
     return !Failed;
 }
@@ -578,6 +580,19 @@ const TPath::TChecker& TPath::TChecker::IsDirectory(EStatus status) const {
         << " (" << BasicPathInfo(Path.Base()) << ")");
 }
 
+const TPath::TChecker& TPath::TChecker::IsSysViewDirectory(EStatus status) const {
+    if (Failed) {
+        return *this;
+    }
+
+    if (Path.Base()->IsDirectory() && Path.Base()->Name == NSysView::SysPathName) {
+        return *this;
+    }
+
+    return Fail(status, TStringBuilder() << "path is not a .sys directory"
+        << " (" << BasicPathInfo(Path.Base()) << ")");
+}
+
 const TPath::TChecker& TPath::TChecker::IsRtmrVolume(EStatus status) const {
     if (Failed) {
         return *this;
@@ -1137,6 +1152,20 @@ const TPath::TChecker& TPath::TChecker::IsNameUniqGrandParentLevel(EStatus statu
     }
 
     return *this;
+}
+
+const TPath::TChecker& TPath::TChecker::IsSysView(EStatus status) const {
+    if (Failed) {
+        return *this;
+    }
+
+    if (Path.Base()->IsSysView()) {
+        return *this;
+    }
+
+    return Fail(status, TStringBuilder() << "path is not a system view"
+        << " (" << BasicPathInfo(Path.Base()) << ")"
+    );
 }
 
 TString TPath::TChecker::BasicPathInfo(TPathElement::TPtr element) const {
@@ -1803,7 +1832,8 @@ bool TPath::IsValidLeafName(TString& explain) const {
         return false;
     }
 
-    if (AppData()->FeatureFlags.GetEnableSystemViews() && leaf == NSysView::SysPathName) {
+    if (AppData()->FeatureFlags.GetEnableSystemViews() && !isSysDirCreateAllowed &&
+        leaf == NSysView::SysPathName) {
         explain += TStringBuilder()
             << "path part '" << NSysView::SysPathName << "' is reserved by the system";
         return false;

--- a/ydb/core/tx/schemeshard/schemeshard_path.h
+++ b/ydb/core/tx/schemeshard/schemeshard_path.h
@@ -78,6 +78,7 @@ public:
         const TChecker& IsCdcStream(EStatus status = EStatus::StatusNameConflict) const;
         const TChecker& IsLikeDirectory(EStatus status = EStatus::StatusPathIsNotDirectory) const;
         const TChecker& IsDirectory(EStatus status = EStatus::StatusPathIsNotDirectory) const;
+        const TChecker& IsSysViewDirectory(EStatus status = EStatus::StatusPathIsNotDirectory) const;
         const TChecker& IsRtmrVolume(EStatus status = EStatus::StatusNameConflict) const;
         const TChecker& IsTheSameDomain(const TPath& another, EStatus status = EStatus::StatusInvalidParameter) const;
         const TChecker& FailOnWrongType(const TSet<TPathElement::EPathType>& expectedTypes) const;
@@ -106,6 +107,7 @@ public:
         const TChecker& IsResourcePool(EStatus status = EStatus::StatusNameConflict) const;
         const TChecker& IsBackupCollection(EStatus status = EStatus::StatusNameConflict) const;
         const TChecker& IsSupportedInExports(EStatus status = EStatus::StatusNameConflict) const;
+        const TChecker& IsSysView(EStatus status = EStatus::StatusNameConflict) const;
     };
 
 public:

--- a/ydb/core/tx/schemeshard/schemeshard_path_describer.cpp
+++ b/ydb/core/tx/schemeshard/schemeshard_path_describer.cpp
@@ -1117,6 +1117,16 @@ void TPathDescriber::DescribeBackupCollection(TPathId pathId, TPathElement::TPtr
     entry->CopyFrom(backupCollectionInfo->Description);
 }
 
+void TPathDescriber::DescribeSysView(const TActorContext&, TPathId pathId, TPathElement::TPtr pathEl) {
+    auto it = Self->SysViews.FindPtr(pathId);
+    Y_ABORT_UNLESS(it, "SysView is not found");
+    TSysViewInfo::TPtr sysViewInfo = *it;
+
+    auto entry = Result->Record.MutablePathDescription()->MutableSysViewDescription();
+    entry->SetName(pathEl->Name);
+    entry->SetType(sysViewInfo->Type);
+}
+
 static bool ConsiderAsDropped(const TPath& path) {
     Y_ABORT_UNLESS(path.IsResolved());
 
@@ -1279,6 +1289,8 @@ THolder<TEvSchemeShard::TEvDescribeSchemeResultBuilder> TPathDescriber::Describe
             DescribeBackupCollection(base->PathId, base);
             break;
         case NKikimrSchemeOp::EPathTypeSysView:
+            DescribeSysView(ctx, base->PathId, base);
+            break;
         case NKikimrSchemeOp::EPathTypeInvalid:
             Y_UNREACHABLE();
         }

--- a/ydb/core/tx/schemeshard/schemeshard_path_describer.h
+++ b/ydb/core/tx/schemeshard/schemeshard_path_describer.h
@@ -48,6 +48,7 @@ class TPathDescriber {
     void DescribeView(const TActorContext&, TPathId pathId, TPathElement::TPtr pathEl);
     void DescribeResourcePool(TPathId pathId, TPathElement::TPtr pathEl);
     void DescribeBackupCollection(TPathId pathId, TPathElement::TPtr pathEl);
+    void DescribeSysView(const TActorContext&, TPathId pathId, TPathElement::TPtr pathEl);
 
 public:
     explicit TPathDescriber(TSchemeShard* self, NKikimrSchemeOp::TDescribePath&& params)

--- a/ydb/core/tx/schemeshard/schemeshard_path_element.cpp
+++ b/ydb/core/tx/schemeshard/schemeshard_path_element.cpp
@@ -227,6 +227,10 @@ bool TPathElement::IsView() const {
     return PathType == EPathType::EPathTypeView;
 }
 
+bool TPathElement::IsSysView() const {
+    return PathType == EPathType::EPathTypeSysView;
+}
+
 bool TPathElement::IsTemporary() const {
     return !!TempDirOwnerActorId;
 }

--- a/ydb/core/tx/schemeshard/schemeshard_path_element.h
+++ b/ydb/core/tx/schemeshard/schemeshard_path_element.h
@@ -136,6 +136,7 @@ public:
     bool IsExternalDataSource() const;
     bool IsIncrementalBackupTable() const;
     bool IsView() const;
+    bool IsSysView() const;
     bool IsTemporary() const;
     bool IsResourcePool() const;
     bool IsBackupCollection() const;

--- a/ydb/core/tx/schemeshard/schemeshard_schema.h
+++ b/ydb/core/tx/schemeshard/schemeshard_schema.h
@@ -4,6 +4,7 @@
 
 #include <ydb/core/base/table_index.h>
 #include <ydb/core/scheme/scheme_pathid.h>
+#include <ydb/core/protos/sys_view_types.pb.h>
 #include <ydb/core/protos/tx_datashard.pb.h>
 #include <ydb/core/protos/tx.pb.h>
 #include <ydb/public/api/protos/ydb_status_codes.pb.h>
@@ -2021,6 +2022,15 @@ struct Schema : NIceDb::Schema {
         >;
     };
 
+    struct SysView : Table<119> {
+        struct PathId : Column<1, NScheme::NTypeIds::Uint64> { using Type = TLocalPathId; };
+        struct AlterVersion : Column<2, NScheme::NTypeIds::Uint64> {};
+        struct SysViewType : Column<3, NScheme::NTypeIds::Uint32> { using Type = NKikimrSysView::ESysViewType; };
+
+        using TKey = TableKey<PathId>;
+        using TColumns = TableColumns<PathId, AlterVersion, SysViewType>;
+    };
+
     using TTables = SchemaTables<
         Paths,
         TxInFlight,
@@ -2137,7 +2147,8 @@ struct Schema : NIceDb::Schema {
         DataErasureGenerations,
         WaitingDataErasureTenants,
         TenantDataErasureGenerations,
-        WaitingDataErasureShards
+        WaitingDataErasureShards,
+        SysView
     >;
 
     static constexpr ui64 SysParam_NextPathId = 1;

--- a/ydb/core/tx/schemeshard/schemeshard_tx_infly.h
+++ b/ydb/core/tx/schemeshard/schemeshard_tx_infly.h
@@ -147,6 +147,8 @@ struct TTxState {
         item(TxAlterTransfer, 100) \
         item(TxDropTransfer, 101) \
         item(TxDropTransferCascade, 102) \
+        item(TxCreateSysView, 103) \
+        item(TxDropSysView, 104) \
 
     // TX_STATE_TYPE_ENUM
 
@@ -371,6 +373,7 @@ struct TTxState {
         case TxCreateContinuousBackup:
         case TxCreateResourcePool:
         case TxCreateBackupCollection:
+        case TxCreateSysView:
             return true;
         case TxInitializeBuildIndex: //this is more like alter
         case TxCreateCdcStreamAtTable:
@@ -410,6 +413,7 @@ struct TTxState {
         case TxDropContinuousBackup:
         case TxDropResourcePool:
         case TxDropBackupCollection:
+        case TxDropSysView:
             return false;
         case TxAlterPQGroup:
         case TxAlterTable:
@@ -486,6 +490,7 @@ struct TTxState {
         case TxDropContinuousBackup:
         case TxDropResourcePool:
         case TxDropBackupCollection:
+        case TxDropSysView:
             return true;
         case TxMkDir:
         case TxCreateTable:
@@ -525,6 +530,7 @@ struct TTxState {
         case TxCreateResourcePool:
         case TxRestoreIncrementalBackupAtTable:
         case TxCreateBackupCollection:
+        case TxCreateSysView:
             return false;
         case TxAlterPQGroup:
         case TxAlterTable:
@@ -604,6 +610,7 @@ struct TTxState {
         case TxDropExternalDataSource:
         case TxDropView:
         case TxDropResourcePool:
+        case TxDropSysView:
             return false;
         case TxMkDir:
         case TxCreateTable:
@@ -641,6 +648,7 @@ struct TTxState {
         case TxCreateResourcePool:
         case TxRestoreIncrementalBackupAtTable:
         case TxCreateBackupCollection:
+        case TxCreateSysView:
             return false;
         case TxAlterPQGroup:
         case TxAlterTable:
@@ -795,6 +803,8 @@ struct TTxState {
             case NKikimrSchemeOp::ESchemeOpCreateBackupCollection: return TxCreateBackupCollection;
             case NKikimrSchemeOp::ESchemeOpAlterBackupCollection: return TxAlterBackupCollection;
             case NKikimrSchemeOp::ESchemeOpDropBackupCollection: return TxDropBackupCollection;
+            case NKikimrSchemeOp::ESchemeOpCreateSysView: return TxCreateSysView;
+            case NKikimrSchemeOp::ESchemeOpDropSysView: return TxDropSysView;
             default: return TxInvalid;
         }
     }

--- a/ydb/core/tx/schemeshard/ut_helpers/helpers.cpp
+++ b/ydb/core/tx/schemeshard/ut_helpers/helpers.cpp
@@ -203,7 +203,7 @@ namespace NSchemeShardUT_Private {
 
     TEvSchemeShard::TEvModifySchemeTransaction* CreateModifyACLRequest(
         ui64 txId, ui64 schemeshard,
-        TString parentPath, TString name, 
+        TString parentPath, TString name,
         const TString& diffAcl, const TString& newOwner, const TApplyIf& applyIf
     )
     {
@@ -973,6 +973,11 @@ namespace NSchemeShardUT_Private {
     DROP_BY_PATH_ID_HELPERS(DropBackupCollection, NKikimrSchemeOp::EOperationType::ESchemeOpDropBackupCollection)
     GENERIC_HELPERS(BackupBackupCollection, NKikimrSchemeOp::EOperationType::ESchemeOpBackupBackupCollection, &NKikimrSchemeOp::TModifyScheme::MutableBackupBackupCollection)
     GENERIC_HELPERS(BackupIncrementalBackupCollection, NKikimrSchemeOp::EOperationType::ESchemeOpBackupIncrementalBackupCollection, &NKikimrSchemeOp::TModifyScheme::MutableBackupIncrementalBackupCollection)
+
+    // sysview
+    GENERIC_HELPERS(CreateSysView, NKikimrSchemeOp::EOperationType::ESchemeOpCreateSysView, &NKikimrSchemeOp::TModifyScheme::MutableCreateSysView)
+    GENERIC_HELPERS(DropSysView, NKikimrSchemeOp::EOperationType::ESchemeOpDropSysView, &NKikimrSchemeOp::TModifyScheme::MutableDrop)
+    DROP_BY_PATH_ID_HELPERS(DropSysView, NKikimrSchemeOp::EOperationType::ESchemeOpDropSysView)
 
     #undef DROP_BY_PATH_ID_HELPERS
     #undef GENERIC_WITH_ATTRS_HELPERS
@@ -2129,7 +2134,7 @@ namespace NSchemeShardUT_Private {
 
         AsyncSend(runtime, TTestTxConfig::SchemeShard, modifyTx.release());
         TAutoPtr<IEventHandle> handle;
-        [[maybe_unused]]auto event = runtime.GrabEdgeEvent<TEvSchemeShard::TEvModifySchemeTransactionResult>(handle); // wait()        
+        [[maybe_unused]]auto event = runtime.GrabEdgeEvent<TEvSchemeShard::TEvModifySchemeTransactionResult>(handle); // wait()
     }
 
     void ChangeIsEnabledUser(TTestActorRuntime& runtime, ui64 txId, const TString& database, const TString& user, bool isEnabled) {

--- a/ydb/core/tx/schemeshard/ut_helpers/helpers.h
+++ b/ydb/core/tx/schemeshard/ut_helpers/helpers.h
@@ -311,6 +311,11 @@ namespace NSchemeShardUT_Private {
     GENERIC_HELPERS(BackupBackupCollection);
     GENERIC_HELPERS(BackupIncrementalBackupCollection);
 
+    // sysview
+    GENERIC_HELPERS(CreateSysView);
+    GENERIC_HELPERS(DropSysView);
+    DROP_BY_PATH_ID_HELPERS(DropSysView);
+
     #undef DROP_BY_PATH_ID_HELPERS
     #undef GENERIC_WITH_ATTRS_HELPERS
     #undef GENERIC_HELPERS
@@ -536,7 +541,7 @@ namespace NSchemeShardUT_Private {
 
     void CreateAlterLoginCreateGroup(TTestActorRuntime& runtime, ui64 txId, const TString& database,
         const TString& group, const TVector<TExpectedResult>& expectedResults = {{NKikimrScheme::StatusSuccess}});
-    
+
     void CreateAlterLoginRemoveGroup(TTestActorRuntime& runtime, ui64 txId, const TString& database,
         const TString& group, const TVector<TExpectedResult>& expectedResults = {{NKikimrScheme::StatusSuccess}});
 
@@ -561,7 +566,7 @@ namespace NSchemeShardUT_Private {
 
     void ChangePasswordHashUser(TTestActorRuntime& runtime, ui64 txId, const TString& database,
         const TString& user, const TString& hash);
-    
+
     // Mimics data query to a single table with multiple partitions
     class TFakeDataReq {
     public:

--- a/ydb/core/tx/schemeshard/ut_helpers/ls_checks.cpp
+++ b/ydb/core/tx/schemeshard/ut_helpers/ls_checks.cpp
@@ -479,6 +479,13 @@ void IsBackupCollection(const NKikimrScheme::TEvDescribeSchemeResult& record) {
     UNIT_ASSERT_VALUES_EQUAL(selfPath.GetPathType(), NKikimrSchemeOp::EPathTypeBackupCollection);
 }
 
+void IsSysView(const NKikimrScheme::TEvDescribeSchemeResult& record) {
+    UNIT_ASSERT_VALUES_EQUAL(record.GetStatus(), NKikimrScheme::StatusSuccess);
+    const auto& pathDescr = record.GetPathDescription();
+    const auto& selfPath = pathDescr.GetSelf();
+    UNIT_ASSERT_VALUES_EQUAL(selfPath.GetPathType(), NKikimrSchemeOp::EPathTypeSysView);
+}
+
 TCheckFunc CheckColumns(const TString& name, const TSet<TString>& columns, const TSet<TString>& droppedColumns, const TSet<TString> keyColumns, bool strictCount) {
     return [=] (const NKikimrScheme::TEvDescribeSchemeResult& record) {
         UNIT_ASSERT(record.HasPathDescription());

--- a/ydb/core/tx/schemeshard/ut_helpers/ls_checks.h
+++ b/ydb/core/tx/schemeshard/ut_helpers/ls_checks.h
@@ -114,6 +114,7 @@ namespace NLs {
     void IsView(const NKikimrScheme::TEvDescribeSchemeResult& record);
     void IsResourcePool(const NKikimrScheme::TEvDescribeSchemeResult& record);
     void IsBackupCollection(const NKikimrScheme::TEvDescribeSchemeResult& record);
+    void IsSysView(const NKikimrScheme::TEvDescribeSchemeResult& record);
     TCheckFunc CheckColumns(const TString& name, const TSet<TString>& columns, const TSet<TString>& droppedColumns, const TSet<TString> keyColumns, bool strictCount = false);
     TCheckFunc CheckColumnType(const ui64 columnIndex, const TString& columnTypename);
     void CheckBoundaries(const NKikimrScheme::TEvDescribeSchemeResult& record);

--- a/ydb/core/tx/schemeshard/ut_sysview/ut_sysview.cpp
+++ b/ydb/core/tx/schemeshard/ut_sysview/ut_sysview.cpp
@@ -1,0 +1,292 @@
+#include <ydb/core/protos/sys_view_types.pb.h>
+#include <ydb/core/tx/schemeshard/ut_helpers/helpers.h>
+
+namespace NKikimr::NSchemeShard {
+    extern bool isSysDirCreateAllowed;
+}
+namespace {
+
+    using namespace NSchemeShardUT_Private;
+    using NKikimrScheme::EStatus;
+    using NKikimrSysView::ESysViewType;
+
+    void ExpectEqualSysViewDescription(const NKikimrScheme::TEvDescribeSchemeResult& describeResult,
+                                       const TString& sysViewName,
+                                       const ESysViewType sysViewType) {
+        UNIT_ASSERT(describeResult.HasPathDescription());
+        UNIT_ASSERT(describeResult.GetPathDescription().HasSysViewDescription());
+        const auto& sysViewDescription = describeResult.GetPathDescription().GetSysViewDescription();
+        UNIT_ASSERT_VALUES_EQUAL(sysViewDescription.GetName(), sysViewName);
+        UNIT_ASSERT(sysViewDescription.GetType() == sysViewType);
+    }
+
+    class TSysDirCreateGuard : public TNonCopyable {
+    public:
+        TSysDirCreateGuard() {
+            NKikimr::NSchemeShard::isSysDirCreateAllowed = true;
+        }
+
+        ~TSysDirCreateGuard() {
+            NKikimr::NSchemeShard::isSysDirCreateAllowed = false;
+        }
+    };
+}
+
+Y_UNIT_TEST_SUITE(TSchemeShardSysViewTest) {
+    Y_UNIT_TEST(CreateSysView) {
+        TTestBasicRuntime runtime;
+        TTestEnv env(runtime);
+        ui64 txId = 100;
+
+        TSysDirCreateGuard sysDirCreateGuard;
+        TestMkDir(runtime, ++txId, "/MyRoot", ".sys");
+        env.TestWaitNotification(runtime, txId);
+
+        TestCreateSysView(runtime, ++txId, "/MyRoot/.sys",
+                          R"(
+                             Name: "new_sys_view"
+                             Type: EPartitionStats
+                            )");
+        env.TestWaitNotification(runtime, txId);
+
+        {
+            const auto describeResult = DescribePath(runtime, "/MyRoot/.sys/new_sys_view");
+            TestDescribeResult(describeResult, {NLs::Finished, NLs::IsSysView});
+            ExpectEqualSysViewDescription(describeResult, "new_sys_view", ESysViewType::EPartitionStats);
+        }
+
+        TActorId sender = runtime.AllocateEdgeActor();
+        RebootTablet(runtime, TTestTxConfig::SchemeShard, sender);
+
+        {
+            const auto describeResult = DescribePath(runtime, "/MyRoot/.sys/new_sys_view");
+            TestDescribeResult(describeResult, {NLs::Finished, NLs::IsSysView});
+            ExpectEqualSysViewDescription(describeResult, "new_sys_view", ESysViewType::EPartitionStats);
+        }
+    }
+
+    Y_UNIT_TEST(DropSysView) {
+        TTestBasicRuntime runtime;
+        TTestEnv env(runtime);
+        ui64 txId = 100;
+
+        TSysDirCreateGuard sysDirCreateGuard;
+        TestMkDir(runtime, ++txId, "/MyRoot", ".sys");
+        env.TestWaitNotification(runtime, txId);
+        TestCreateSysView(runtime, ++txId, "/MyRoot/.sys",
+                          R"(
+                             Name: "new_sys_view"
+                             Type: EPartitionStats
+                            )");
+        env.TestWaitNotification(runtime, txId);
+        TestLs(runtime, "/MyRoot/.sys/new_sys_view", false, NLs::PathExist);
+
+        TestDropSysView(runtime, ++txId, "/MyRoot/.sys", "new_sys_view");
+        env.TestWaitNotification(runtime, txId);
+        TestLs(runtime, "/MyRoot/.sys/new_sys_view", false, NLs::PathNotExist);
+
+        TActorId sender = runtime.AllocateEdgeActor();
+        RebootTablet(runtime, TTestTxConfig::SchemeShard, sender);
+        TestLs(runtime, "/MyRoot/.sys/new_sys_view", false, NLs::PathNotExist);
+    }
+
+    Y_UNIT_TEST(CreateExistingSysView) {
+        TTestBasicRuntime runtime;
+        TTestEnv env(runtime);
+        ui64 txId = 100;
+
+        TSysDirCreateGuard sysDirCreateGuard;
+        TestMkDir(runtime, ++txId, "/MyRoot", ".sys");
+        env.TestWaitNotification(runtime, txId);
+
+        TestCreateSysView(runtime, ++txId, "/MyRoot/.sys",
+                          R"(
+                             Name: "new_sys_view"
+                             Type: EPartitionStats
+                            )");
+        env.TestWaitNotification(runtime, txId);
+        TestLs(runtime, "/MyRoot/.sys/new_sys_view", false, NLs::PathExist);
+
+        TestCreateSysView(runtime, ++txId, "/MyRoot/.sys",
+                          R"(
+                             Name: "new_sys_view"
+                             Type: EPartitionStats
+                            )",
+                          {EStatus::StatusSchemeError, EStatus::StatusAlreadyExists});
+        env.TestWaitNotification(runtime, txId);
+        const auto describeResult = DescribePath(runtime, "/MyRoot/.sys/new_sys_view");
+        TestDescribeResult(describeResult, {NLs::Finished, NLs::IsSysView});
+        ExpectEqualSysViewDescription(describeResult, "new_sys_view", ESysViewType::EPartitionStats);
+    }
+
+    Y_UNIT_TEST(AsyncCreateDifferentSysViews) {
+        TTestBasicRuntime runtime;
+        TTestEnv env(runtime);
+        ui64 txId = 100;
+
+        TSysDirCreateGuard sysDirCreateGuard;
+        TestMkDir(runtime, ++txId, "/MyRoot", ".sys");
+        env.TestWaitNotification(runtime, txId);
+
+        AsyncCreateSysView(runtime, ++txId, "/MyRoot/.sys",
+                           R"(
+                              Name: "sys_view_1"
+                              Type: EPartitionStats
+                             )");
+        AsyncCreateSysView(runtime, ++txId, "/MyRoot/.sys",
+                           R"(
+                              Name: "sys_view_2"
+                              Type: EPartitionStats
+                             )");
+
+        TestModificationResult(runtime, txId - 1);
+        TestModificationResult(runtime, txId);
+        env.TestWaitNotification(runtime, {txId - 1, txId});
+
+        {
+            const auto describeResult = DescribePath(runtime, "/MyRoot/.sys/sys_view_1");
+            TestDescribeResult(describeResult, {NLs::Finished, NLs::IsSysView});
+            ExpectEqualSysViewDescription(describeResult, "sys_view_1", ESysViewType::EPartitionStats);
+        }
+        {
+            const auto describeResult = DescribePath(runtime, "/MyRoot/.sys/sys_view_2");
+            TestDescribeResult(describeResult, {NLs::Finished, NLs::IsSysView});
+            ExpectEqualSysViewDescription(describeResult, "sys_view_2", ESysViewType::EPartitionStats);
+        }
+    }
+
+    Y_UNIT_TEST(AsyncCreateDirWithSysView) {
+        TTestBasicRuntime runtime;
+        TTestEnv env(runtime);
+        ui64 txId = 100;
+
+        TSysDirCreateGuard sysDirCreateGuard;
+        AsyncMkDir(runtime, ++txId, "/MyRoot", ".sys");
+        AsyncCreateSysView(runtime, ++txId, "/MyRoot/.sys",
+                           R"(
+                              Name: "new_sys_view"
+                              Type: EPartitionStats
+                             )");
+
+        TestModificationResult(runtime, txId - 1);
+        TestModificationResult(runtime, txId);
+        env.TestWaitNotification(runtime, {txId - 1, txId});
+
+        TestDescribeResult(DescribePath(runtime, "/MyRoot/.sys"), {NLs::Finished});
+
+        const auto describeResult = DescribePath(runtime, "/MyRoot/.sys/new_sys_view");
+        TestDescribeResult(describeResult, {NLs::Finished, NLs::IsSysView});
+        ExpectEqualSysViewDescription(describeResult, "new_sys_view", ESysViewType::EPartitionStats);
+    }
+
+    Y_UNIT_TEST(AsyncCreateSameSysView) {
+        TTestBasicRuntime runtime;
+        TTestEnv env(runtime);
+        ui64 txId = 100;
+
+        TSysDirCreateGuard sysDirCreateGuard;
+        TestMkDir(runtime, ++txId, "/MyRoot", ".sys");
+        env.TestWaitNotification(runtime, txId);
+
+        AsyncCreateSysView(runtime, ++txId, "/MyRoot/.sys",
+                           R"(
+                              Name: "new_sys_view"
+                              Type: EPartitionStats
+                             )");
+        AsyncCreateSysView(runtime, ++txId, "/MyRoot/.sys",
+                           R"(
+                              Name: "new_sys_view"
+                              Type: EPartitionStats
+                             )");
+        const TVector<TExpectedResult> expectedResults = {EStatus::StatusAccepted,
+                                                          EStatus::StatusMultipleModifications,
+                                                          EStatus::StatusAlreadyExists};
+        TestModificationResults(runtime, txId - 1, expectedResults);
+        TestModificationResults(runtime, txId, expectedResults);
+        env.TestWaitNotification(runtime, {txId - 1, txId});
+
+        const auto describeResult = DescribePath(runtime, "/MyRoot/.sys/new_sys_view");
+        TestDescribeResult(describeResult, {NLs::Finished, NLs::IsSysView});
+        ExpectEqualSysViewDescription(describeResult, "new_sys_view", ESysViewType::EPartitionStats);
+    }
+
+    Y_UNIT_TEST(AsyncDropSameSysView) {
+        TTestBasicRuntime runtime;
+        TTestEnv env(runtime);
+        ui64 txId = 100;
+
+        TSysDirCreateGuard sysDirCreateGuard;
+        TestMkDir(runtime, ++txId, "/MyRoot", ".sys");
+        env.TestWaitNotification(runtime, txId);
+        TestCreateSysView(runtime, ++txId, "/MyRoot/.sys",
+                          R"(
+                             Name: "new_sys_view"
+                             Type: EPartitionStats
+                            )");
+        env.TestWaitNotification(runtime, txId);
+        TestLs(runtime, "/MyRoot/.sys/new_sys_view", false, NLs::PathExist);
+
+        AsyncDropSysView(runtime, ++txId, "/MyRoot/.sys", "new_sys_view");
+        AsyncDropSysView(runtime, ++txId, "/MyRoot/.sys", "new_sys_view");
+        const TVector<TExpectedResult> expectedResults = {EStatus::StatusAccepted,
+                                                          EStatus::StatusMultipleModifications,
+                                                          EStatus::StatusPathDoesNotExist};
+        TestModificationResults(runtime, txId - 1, expectedResults);
+        TestModificationResults(runtime, txId, expectedResults);
+        env.TestWaitNotification(runtime, {txId - 1, txId});
+
+        TestLs(runtime, "/MyRoot/.sys/new_sys_view", false, NLs::PathNotExist);
+    }
+
+    Y_UNIT_TEST(ReadOnlyMode) {
+        TTestBasicRuntime runtime;
+        TTestEnv env(runtime);
+        ui64 txId = 100;
+
+        TSysDirCreateGuard sysDirCreateGuard;
+        TestMkDir(runtime, ++txId, "/MyRoot", ".sys");
+        env.TestWaitNotification(runtime, txId);
+        SetSchemeshardReadOnlyMode(runtime, true);
+        TActorId sender = runtime.AllocateEdgeActor();
+        RebootTablet(runtime, TTestTxConfig::SchemeShard, sender);
+
+        TestCreateSysView(runtime, ++txId, "/MyRoot/.sys",
+                          R"(
+                             Name: "new_sys_view"
+                             Type: EPartitionStats
+                            )",
+                          {{EStatus::StatusReadOnly}});
+        env.TestWaitNotification(runtime, txId);
+        TestLs(runtime, "/MyRoot/.sys/new_sys_view", false, NLs::PathNotExist);
+
+        SetSchemeshardReadOnlyMode(runtime, false);
+        sender = runtime.AllocateEdgeActor();
+        RebootTablet(runtime, TTestTxConfig::SchemeShard, sender);
+
+        TestCreateSysView(runtime, ++txId, "/MyRoot/.sys",
+                          R"(
+                             Name: "new_sys_view"
+                             Type: EPartitionStats
+                            )");
+        env.TestWaitNotification(runtime, txId);
+        TestLs(runtime, "/MyRoot/.sys/new_sys_view", false, NLs::PathExist);
+    }
+
+    Y_UNIT_TEST(EmptyName) {
+        TTestBasicRuntime runtime;
+        TTestEnv env(runtime);
+        ui64 txId = 100;
+
+        TSysDirCreateGuard sysDirCreateGuard;
+        TestMkDir(runtime, ++txId, "/MyRoot", ".sys");
+        env.TestWaitNotification(runtime, txId);
+
+        TestCreateSysView(runtime, ++txId, "/MyRoot/.sys",
+                          R"(
+                             Name: ""
+                             Type: EPartitionStats
+                            )",
+                          {{EStatus::StatusSchemeError, "error: path part shouldn't be empty"}});
+        env.TestWaitNotification(runtime, txId);
+    }
+}

--- a/ydb/core/tx/schemeshard/ut_sysview/ya.make
+++ b/ydb/core/tx/schemeshard/ut_sysview/ya.make
@@ -1,0 +1,18 @@
+UNITTEST_FOR(ydb/core/tx/schemeshard)
+
+FORK_SUBTESTS()
+
+SIZE(MEDIUM)
+
+PEERDIR(
+    ydb/core/testlib/basics/default
+    ydb/core/tx/schemeshard/ut_helpers
+)
+
+SRCS(
+    ut_sysview.cpp
+)
+
+YQL_LAST_ABI_VERSION()
+
+END()

--- a/ydb/core/tx/schemeshard/ut_sysview_reboots/ut_sysview_reboots.cpp
+++ b/ydb/core/tx/schemeshard/ut_sysview_reboots/ut_sysview_reboots.cpp
@@ -1,0 +1,77 @@
+#include <ydb/core/tx/schemeshard/ut_helpers/helpers.h>
+
+namespace NKikimr::NSchemeShard {
+    extern bool isSysDirCreateAllowed;
+}
+
+namespace {
+
+    using namespace NSchemeShardUT_Private;
+    using NKikimrScheme::EStatus;
+
+    class TSysDirCreateGuard : public TNonCopyable {
+    public:
+        TSysDirCreateGuard() {
+            NKikimr::NSchemeShard::isSysDirCreateAllowed = true;
+        }
+
+        ~TSysDirCreateGuard() {
+            NKikimr::NSchemeShard::isSysDirCreateAllowed = false;
+        }
+    };
+
+}
+
+Y_UNIT_TEST_SUITE(TSchemeShardSysViewTestReboots) {
+    Y_UNIT_TEST(CreateSysViewWithReboots) {
+        TTestWithReboots t;
+        t.Run([&](TTestActorRuntime& runtime, bool& activeZone) {
+            {
+                TInactiveZone inactive(activeZone);
+                TSysDirCreateGuard sysDirCreateGuard;
+                TestMkDir(runtime, ++t.TxId, "/MyRoot", ".sys");
+                t.TestEnv->TestWaitNotification(runtime, t.TxId);
+            }
+
+            TestCreateSysView(runtime, ++t.TxId, "/MyRoot/.sys",
+                              R"(
+                                 Name: "new_sys_view"
+                                 Type: EPartitionStats
+                                )");
+            t.TestEnv->TestWaitNotification(runtime, t.TxId);
+
+            {
+                TInactiveZone inactive(activeZone);
+                const auto describeResult = DescribePath(runtime, "/MyRoot/.sys/new_sys_view");
+                TestDescribeResult(describeResult, {NLs::Finished, NLs::IsSysView});
+            }
+        });
+    }
+
+    Y_UNIT_TEST(DropSysViewWithReboots) {
+        TTestWithReboots t;
+        t.Run([&](TTestActorRuntime& runtime, bool& activeZone) {
+            {
+                TInactiveZone inactive(activeZone);
+                TSysDirCreateGuard sysDirCreateGuard;
+                TestMkDir(runtime, ++t.TxId, "/MyRoot", ".sys");
+                t.TestEnv->TestWaitNotification(runtime, t.TxId);
+                TestCreateSysView(runtime, ++t.TxId, "/MyRoot/.sys",
+                                  R"(
+                                     Name: "new_sys_view"
+                                     Type: EPartitionStats
+                                    )");
+                t.TestEnv->TestWaitNotification(runtime, t.TxId);
+                TestLs(runtime, "/MyRoot/.sys/new_sys_view", false, NLs::PathExist);
+            }
+
+            TestDropSysView(runtime, ++t.TxId, "/MyRoot/.sys", "new_sys_view");
+            t.TestEnv->TestWaitNotification(runtime, t.TxId);
+
+            {
+                TInactiveZone inactive(activeZone);
+                TestLs(runtime, "/MyRoot/.sys/new_sys_view", false, NLs::PathNotExist);
+            }
+        });
+    }
+}

--- a/ydb/core/tx/schemeshard/ut_sysview_reboots/ya.make
+++ b/ydb/core/tx/schemeshard/ut_sysview_reboots/ya.make
@@ -1,0 +1,31 @@
+IF (NOT WITH_VALGRIND)
+    UNITTEST_FOR(ydb/core/tx/schemeshard)
+
+    FORK_SUBTESTS()
+
+    SPLIT_FACTOR(60)
+
+    IF (SANITIZER_TYPE OR WITH_VALGRIND)
+        SIZE(LARGE)
+        INCLUDE(${ARCADIA_ROOT}/ydb/tests/large.inc)
+        REQUIREMENTS(ram:12)
+    ELSE()
+        SIZE(MEDIUM)
+    ENDIF()
+
+    PEERDIR(
+        ydb/core/testlib/default
+        ydb/core/tx
+        ydb/core/tx/schemeshard/ut_helpers
+        yql/essentials/public/udf/service/exception_policy
+    )
+
+    YQL_LAST_ABI_VERSION()
+
+    SRCS(
+        ut_sysview_reboots.cpp
+    )
+
+
+END()
+ENDIF()

--- a/ydb/core/tx/schemeshard/ya.make
+++ b/ydb/core/tx/schemeshard/ya.make
@@ -50,6 +50,8 @@ RECURSE_FOR_TESTS(
     ut_stats
     ut_subdomain
     ut_subdomain_reboots
+    ut_sysview
+    ut_sysview_reboots
     ut_topic_splitmerge
     ut_transfer
     ut_ttl
@@ -150,6 +152,7 @@ SRCS(
     schemeshard__operation_create_sequence.cpp
     schemeshard__operation_create_solomon.cpp
     schemeshard__operation_create_subdomain.cpp
+    schemeshard__operation_create_sysview.cpp
     schemeshard__operation_create_table.cpp
     schemeshard__operation_create_view.cpp
     schemeshard__operation_db_changes.cpp
@@ -171,6 +174,7 @@ SRCS(
     schemeshard__operation_drop_sequence.cpp
     schemeshard__operation_drop_solomon.cpp
     schemeshard__operation_drop_subdomain.cpp
+    schemeshard__operation_drop_sysview.cpp
     schemeshard__operation_drop_table.cpp
     schemeshard__operation_drop_unsafe.cpp
     schemeshard__operation_drop_view.cpp

--- a/ydb/core/tx/tx_proxy/schemereq.cpp
+++ b/ydb/core/tx/tx_proxy/schemereq.cpp
@@ -166,6 +166,7 @@ struct TBaseSchemeReq: public TActorBootstrapped<TDerived> {
         case NKikimrSchemeOp::ESchemeOpDropExternalDataSource:
         case NKikimrSchemeOp::ESchemeOpDropView:
         case NKikimrSchemeOp::ESchemeOpDropResourcePool:
+        case NKikimrSchemeOp::ESchemeOpDropSysView:
             return *modifyScheme.MutableDrop()->MutableName();
 
         case NKikimrSchemeOp::ESchemeOpAlterTable:
@@ -404,6 +405,9 @@ struct TBaseSchemeReq: public TActorBootstrapped<TDerived> {
 
         case NKikimrSchemeOp::ESchemeOpRestoreBackupCollection:
             return *modifyScheme.MutableRestoreBackupCollection()->MutableName();
+
+        case NKikimrSchemeOp::ESchemeOpCreateSysView:
+            return *modifyScheme.MutableCreateSysView()->MutableName();
         }
     }
 
@@ -432,6 +436,7 @@ struct TBaseSchemeReq: public TActorBootstrapped<TDerived> {
         case NKikimrSchemeOp::ESchemeOpCreateView:
         case NKikimrSchemeOp::ESchemeOpCreateResourcePool:
         case NKikimrSchemeOp::ESchemeOpCreateBackupCollection:
+        case NKikimrSchemeOp::ESchemeOpCreateSysView:
             return true;
         default:
             return false;
@@ -940,6 +945,10 @@ struct TBaseSchemeReq: public TActorBootstrapped<TDerived> {
             }
             break;
         }
+        // TODO(n00bcracker): add processing after support on client side
+        case NKikimrSchemeOp::ESchemeOpCreateSysView:
+        case NKikimrSchemeOp::ESchemeOpDropSysView:
+            return false;
         case NKikimrSchemeOp::ESchemeOpCreateTableIndex:
         case NKikimrSchemeOp::ESchemeOpDropTableIndex:
         case NKikimrSchemeOp::ESchemeOp_DEPRECATED_35:

--- a/ydb/tests/functional/scheme_tests/canondata/tablet_scheme_tests.TestTabletSchemes.test_tablet_schemes_flat_schemeshard_/flat_schemeshard.schema
+++ b/ydb/tests/functional/scheme_tests/canondata/tablet_scheme_tests.TestTabletSchemes.test_tablet_schemes_flat_schemeshard_/flat_schemeshard.schema
@@ -8439,5 +8439,55 @@
                 ]
             }
         }
+    },
+    {
+        "TableId": 119,
+        "TableName": "SysView",
+        "TableKey": [
+            1
+        ],
+        "ColumnsAdded": [
+            {
+                "ColumnId": 1,
+                "ColumnName": "PathId",
+                "ColumnType": "Uint64"
+            },
+            {
+                "ColumnId": 2,
+                "ColumnName": "AlterVersion",
+                "ColumnType": "Uint64"
+            },
+            {
+                "ColumnId": 3,
+                "ColumnName": "SysViewType",
+                "ColumnType": "Uint32"
+            }
+        ],
+        "ColumnsDropped": [],
+        "ColumnFamilies": {
+            "0": {
+                "Columns": [
+                    1,
+                    2,
+                    3
+                ],
+                "RoomID": 0,
+                "Codec": 0,
+                "InMemory": false,
+                "Cache": 0,
+                "Small": 4294967295,
+                "Large": 4294967295
+            }
+        },
+        "Rooms": {
+            "0": {
+                "Main": 1,
+                "Outer": 1,
+                "Blobs": 1,
+                "ExternalBlobs": [
+                    1
+                ]
+            }
+        }
     }
 ]


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

- Added CREATE and DROP scheme operations for sys view paths
- Storing sys view path info in local DB
- Loading sys view paths from local DB during init stage
- Supported sys view path description operation
- Covered new operations with ut tests

### Changelog category <!-- remove all except one -->

* Not for changelog (changelog entry is not required)

### Description for reviewers <!-- (optional) description for those who read this PR -->
