### PR TITLE
Fix segfault: copy, don't move reader/writer params

### DIFF
--- a/ydb/public/lib/ydb_cli/commands/topic_operations_scenario.cpp
+++ b/ydb/public/lib/ydb_cli/commands/topic_operations_scenario.cpp
@@ -234,7 +234,7 @@ void TTopicOperationsScenario::StartConsumerThreads(std::vector<std::future<void
                 .CommitMessages = CommitMessages
             };
 
-            threads.push_back(std::async([readerParams = std::move(readerParams)]() mutable { TTopicWorkloadReader::RetryableReaderLoop(readerParams); }));
+            threads.push_back(std::async([readerParams = std::move(readerParams)]() { TTopicWorkloadReader::RetryableReaderLoop(readerParams); }));
         }
     }
 
@@ -244,8 +244,8 @@ void TTopicOperationsScenario::StartConsumerThreads(std::vector<std::future<void
 }
 
 /*!
- * This method starts producers threads specified in -t option, that will write to topic in parallel. Every producer thread will create 
- * WriteSession for every partition in the topic and will write in partitions in round robin manner. 
+ * This method starts producers threads specified in -t option, that will write to topic in parallel. Every producer thread will create
+ * WriteSession for every partition in the topic and will write in partitions in round robin manner.
  * */
 void TTopicOperationsScenario::StartProducerThreads(std::vector<std::future<void>>& threads,
                                                     ui32 partitionCount,
@@ -284,7 +284,7 @@ void TTopicOperationsScenario::StartProducerThreads(std::vector<std::future<void
             .UseCpuTimestamp = UseCpuTimestamp
         };
 
-        threads.push_back(std::async([writerParams = std::move(writerParams)]() mutable { TTopicWorkloadWriterWorker::RetryableWriterLoop(writerParams); }));
+        threads.push_back(std::async([writerParams = std::move(writerParams)]() { TTopicWorkloadWriterWorker::RetryableWriterLoop(writerParams); }));
     }
 
     while (*count != ProducerThreadCount) {

--- a/ydb/public/lib/ydb_cli/commands/topic_workload/topic_workload_reader.cpp
+++ b/ydb/public/lib/ydb_cli/commands/topic_workload/topic_workload_reader.cpp
@@ -8,7 +8,7 @@
 
 using namespace NYdb::NConsoleClient;
 
-void TTopicWorkloadReader::RetryableReaderLoop(TTopicWorkloadReaderParams& params) {
+void TTopicWorkloadReader::RetryableReaderLoop(const TTopicWorkloadReaderParams& params) {
     const TInstant endTime = Now() + TDuration::Seconds(params.TotalSec + 3);
 
     while (!*params.ErrorFlag && Now() < endTime) {
@@ -20,7 +20,7 @@ void TTopicWorkloadReader::RetryableReaderLoop(TTopicWorkloadReaderParams& param
     }
 }
 
-void TTopicWorkloadReader::ReaderLoop(TTopicWorkloadReaderParams& params, TInstant endTime) {
+void TTopicWorkloadReader::ReaderLoop(const TTopicWorkloadReaderParams& params, TInstant endTime) {
     auto topicClient = std::make_unique<NYdb::NTopic::TTopicClient>(params.Driver);
     std::optional<TTransactionSupport> txSupport;
 
@@ -148,7 +148,7 @@ void TTopicWorkloadReader::ReaderLoop(TTopicWorkloadReaderParams& params, TInsta
 }
 
 std::vector<NYdb::NTopic::TReadSessionEvent::TEvent> TTopicWorkloadReader::GetEvents(NYdb::NTopic::IReadSession& readSession,
-                                                                                     TTopicWorkloadReaderParams& params,
+                                                                                     const TTopicWorkloadReaderParams& params,
                                                                                      std::optional<TTransactionSupport>& txSupport)
 {
     TVector<NYdb::NTopic::TReadSessionEvent::TEvent> events;
@@ -169,7 +169,7 @@ std::vector<NYdb::NTopic::TReadSessionEvent::TEvent> TTopicWorkloadReader::GetEv
     return readSession.GetEvents(settings);
 }
 
-void TTopicWorkloadReader::TryCommitTx(TTopicWorkloadReaderParams& params,
+void TTopicWorkloadReader::TryCommitTx(const TTopicWorkloadReaderParams& params,
                                        std::optional<TTransactionSupport>& txSupport,
                                        TInstant& commitTime,
                                        TVector<NYdb::NTopic::TReadSessionEvent::TStopPartitionSessionEvent>& stopPartitionSessionEvents)
@@ -186,7 +186,7 @@ void TTopicWorkloadReader::TryCommitTx(TTopicWorkloadReaderParams& params,
     commitTime += TDuration::MilliSeconds(params.CommitPeriodMs);
 }
 
-void TTopicWorkloadReader::TryCommitTableChanges(TTopicWorkloadReaderParams& params,
+void TTopicWorkloadReader::TryCommitTableChanges(const TTopicWorkloadReaderParams& params,
                                                  std::optional<TTransactionSupport>& txSupport)
 {
     if (txSupport->Rows.empty()) {

--- a/ydb/public/lib/ydb_cli/commands/topic_workload/topic_workload_reader.h
+++ b/ydb/public/lib/ydb_cli/commands/topic_workload/topic_workload_reader.h
@@ -39,20 +39,20 @@ namespace NYdb {
 
         class TTopicWorkloadReader {
         public:
-            static void RetryableReaderLoop(TTopicWorkloadReaderParams& params);
+            static void RetryableReaderLoop(const TTopicWorkloadReaderParams& params);
 
         private:
-            static void ReaderLoop(TTopicWorkloadReaderParams& params, TInstant endTime);
+            static void ReaderLoop(const TTopicWorkloadReaderParams& params, TInstant endTime);
 
             static std::vector<NYdb::NTopic::TReadSessionEvent::TEvent> GetEvents(NYdb::NTopic::IReadSession& readSession,
-                                                                                  TTopicWorkloadReaderParams& params,
+                                                                                  const TTopicWorkloadReaderParams& params,
                                                                                   std::optional<TTransactionSupport>& txSupport);
 
-            static void TryCommitTx(TTopicWorkloadReaderParams& params,
+            static void TryCommitTx(const TTopicWorkloadReaderParams& params,
                                     std::optional<TTransactionSupport>& txSupport,
                                     TInstant& commitTime,
                                     TVector<NYdb::NTopic::TReadSessionEvent::TStopPartitionSessionEvent>& stopPartitionSessionEvents);
-            static void TryCommitTableChanges(TTopicWorkloadReaderParams& params,
+            static void TryCommitTableChanges(const TTopicWorkloadReaderParams& params,
                                               std::optional<TTransactionSupport>& txSupport);
             static void GracefullShutdown(TVector<NYdb::NTopic::TReadSessionEvent::TStopPartitionSessionEvent>& stopPartitionSessionEvents);
         };

--- a/ydb/public/lib/ydb_cli/commands/topic_workload/topic_workload_writer.cpp
+++ b/ydb/public/lib/ydb_cli/commands/topic_workload/topic_workload_writer.cpp
@@ -219,7 +219,7 @@ void TTopicWorkloadWriterWorker::RetryableWriterLoop(const TTopicWorkloadWriterP
 }
 
 void TTopicWorkloadWriterWorker::WriterLoop(const TTopicWorkloadWriterParams& params, TInstant endTime) {
-    TTopicWorkloadWriterWorker writer(std::move(params));
+    TTopicWorkloadWriterWorker writer(params);
 
     if (params.UseTransactions) {
         writer.TxSupport.emplace(params.Driver, "", "");

--- a/ydb/public/lib/ydb_cli/commands/topic_workload/topic_workload_writer.cpp
+++ b/ydb/public/lib/ydb_cli/commands/topic_workload/topic_workload_writer.cpp
@@ -6,11 +6,9 @@
 
 using namespace NYdb::NConsoleClient;
 
-TTopicWorkloadWriterWorker::TTopicWorkloadWriterWorker(
-    TTopicWorkloadWriterParams&& params)
-    : Params(std::move(params))
+TTopicWorkloadWriterWorker::TTopicWorkloadWriterWorker(const TTopicWorkloadWriterParams& params)
+    : Params(params)
     , StatsCollector(Params.StatsCollector)
-
 {
     Producers = std::vector<std::shared_ptr<TTopicWorkloadWriterProducer>>();
     Producers.reserve(Params.PartitionCount);
@@ -19,7 +17,7 @@ TTopicWorkloadWriterWorker::TTopicWorkloadWriterWorker(
         // write to random partition, cause workload CLI tool can be launched in several instances
         // and they need to load test different partitions of the topic
         ui32 partitionId = (Params.PartitionSeed + i) % Params.PartitionCount;
-        
+
         Producers.push_back(CreateProducer(partitionId));
     }
 
@@ -39,7 +37,7 @@ void TTopicWorkloadWriterWorker::Close()
     CloseProducers();
 }
 
-void TTopicWorkloadWriterWorker::CloseProducers() 
+void TTopicWorkloadWriterWorker::CloseProducers()
 {
     for (auto producer : Producers) {
         producer->Close();
@@ -118,7 +116,7 @@ void TTopicWorkloadWriterWorker::Process(TInstant endTime) {
 
         if (writingAllowed && !WaitForCommitTx)
         {
-            TInstant createTimestamp = GetCreateTimestampForNextMessage(); 
+            TInstant createTimestamp = GetCreateTimestampForNextMessage();
             BytesWritten += Params.MessageSize;
 
             std::optional<NYdb::NTable::TTransaction> transaction;
@@ -159,7 +157,7 @@ void TTopicWorkloadWriterWorker::Process(TInstant endTime) {
 std::shared_ptr<TTopicWorkloadWriterProducer> TTopicWorkloadWriterWorker::CreateProducer(ui64 partitionId) {
     auto clock = NUnifiedAgent::TClock();
     if (!clock.Configured()) {
-        clock.Configure(); 
+        clock.Configure();
     }
     auto producerId = TGUID::CreateTimebased().AsGuidString();
 
@@ -170,7 +168,7 @@ std::shared_ptr<TTopicWorkloadWriterProducer> TTopicWorkloadWriterWorker::Create
             partitionId,
             std::move(clock)
     );
- 
+
     NYdb::NTopic::TWriteSessionSettings settings;
     settings.Codec((NYdb::NTopic::ECodec) Params.Codec);
     settings.Path(Params.TopicName);
@@ -206,7 +204,7 @@ size_t TTopicWorkloadWriterWorker::InflightMessagesSize() {
     return total;
 }
 
-void TTopicWorkloadWriterWorker::RetryableWriterLoop(TTopicWorkloadWriterParams& params) {
+void TTopicWorkloadWriterWorker::RetryableWriterLoop(const TTopicWorkloadWriterParams& params) {
     auto errorFlag = params.ErrorFlag;
 
     const TInstant endTime = Now() + TDuration::Seconds(params.TotalSec + 3);
@@ -220,7 +218,7 @@ void TTopicWorkloadWriterWorker::RetryableWriterLoop(TTopicWorkloadWriterParams&
     }
 }
 
-void TTopicWorkloadWriterWorker::WriterLoop(TTopicWorkloadWriterParams& params, TInstant endTime) {
+void TTopicWorkloadWriterWorker::WriterLoop(const TTopicWorkloadWriterParams& params, TInstant endTime) {
     TTopicWorkloadWriterWorker writer(std::move(params));
 
     if (params.UseTransactions) {
@@ -294,5 +292,5 @@ TInstant TTopicWorkloadWriterWorker::GetCreateTimestampForNextMessage() {
         return TInstant::Now();
     } else {
         return GetExpectedCurrMessageCreationTimestamp();
-    }    
+    }
 }

--- a/ydb/public/lib/ydb_cli/commands/topic_workload/topic_workload_writer.h
+++ b/ydb/public/lib/ydb_cli/commands/topic_workload/topic_workload_writer.h
@@ -44,11 +44,11 @@ namespace NYdb {
         class TTopicWorkloadWriterWorker {
         public:
             static const size_t GENERATED_MESSAGES_COUNT = 32;
-            static void RetryableWriterLoop(TTopicWorkloadWriterParams& params);
-            static void WriterLoop(TTopicWorkloadWriterParams& params, TInstant endTime);
+            static void RetryableWriterLoop(const TTopicWorkloadWriterParams& params);
+            static void WriterLoop(const TTopicWorkloadWriterParams& params, TInstant endTime);
             static std::vector<TString> GenerateMessages(size_t messageSize);
         private:
-            TTopicWorkloadWriterWorker(TTopicWorkloadWriterParams&& params);
+            TTopicWorkloadWriterWorker(const TTopicWorkloadWriterParams& params);
             ~TTopicWorkloadWriterWorker();
 
             void Close();


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

- Fix: in rare cases `workload topic write` command could segfault

### Changelog category <!-- remove all except one -->

* Bugfix 

### Description for reviewers <!-- (optional) description for those who read this PR -->

