### PR TITLE
Add audit logging on `create tenant` database in console tablet

### DIFF
--- a/ydb/core/client/server/msgbus_server_console.cpp
+++ b/ydb/core/client/server/msgbus_server_console.cpp
@@ -78,6 +78,7 @@ public:
             auto request = MakeHolder<TEvConsole::TEvCreateTenantRequest>();
             request->Record.CopyFrom(Request.GetCreateTenantRequest());
             request->Record.SetUserToken(TBase::GetSerializedToken());
+            request->Record.SetPeerName(TBase::GetPeerName());
             NTabletPipe::SendData(ctx, ConsolePipe, request.Release());
         } else if (Request.HasGetConfigRequest()) {
             auto request = MakeHolder<TEvConsole::TEvGetConfigRequest>();

--- a/ydb/core/cms/console/console__create_tenant.cpp
+++ b/ydb/core/cms/console/console__create_tenant.cpp
@@ -65,6 +65,8 @@ public:
 
         auto &rec = Request->Get()->Record.GetRequest();
         auto &token = Request->Get()->Record.GetUserToken();
+        auto &peer = Request->Get()->Record.GetPeerName();
+
         LOG_DEBUG_S(ctx, NKikimrServices::CMS_TENANTS, "TTxCreateTenant: "
                     << Request->Get()->Record.ShortDebugString());
 
@@ -121,7 +123,7 @@ public:
             attrNames.insert(key);
         }
 
-        Tenant = new TTenant(path, TTenant::CREATING_POOLS, token);
+        Tenant = new TTenant(path, TTenant::CREATING_POOLS, token, peer);
 
         Tenant->IsExternalSubdomain = Self->FeatureFlags.GetEnableExternalSubdomains();
         Tenant->IsExternalHive = Self->FeatureFlags.GetEnableExternalHive();

--- a/ydb/core/cms/console/console__remove_tenant.cpp
+++ b/ydb/core/cms/console/console__remove_tenant.cpp
@@ -47,6 +47,8 @@ public:
 
         auto &rec = Request->Get()->Record.GetRequest();
         auto &token = Request->Get()->Record.GetUserToken();
+        auto &peer = Request->Get()->Record.GetPeerName();
+
         LOG_DEBUG_S(ctx, NKikimrServices::CMS_TENANTS, "TTxRemoveTenant: "
                     << Request->Get()->Record.ShortDebugString());
 
@@ -79,6 +81,7 @@ public:
 
         Self->DbUpdateTenantState(Tenant, TTenant::REMOVING_SUBDOMAIN, txc, ctx);
         Self->DbUpdateTenantUserToken(Tenant, token, txc, ctx);
+        Self->DbUpdateTenantPeerName(Tenant, peer, txc, ctx);
 
         return true;
     }

--- a/ydb/core/cms/console/console__scheme.h
+++ b/ydb/core/cms/console/console__scheme.h
@@ -52,6 +52,7 @@ struct Schema : NIceDb::Schema {
         struct IsExternalStatisticsAggregator : Column<28, NScheme::NTypeIds::Bool> {};
         struct IsExternalBackupController : Column<29, NScheme::NTypeIds::Bool> {};
         struct ScaleRecommenderPolicies : Column<30, NScheme::NTypeIds::String> {};
+        struct PeerName : Column<31, NScheme::NTypeIds::Utf8> {};
 
         using TKey = TableKey<Path>;
         using TColumns = TableColumns<Path, State, Coordinators, Mediators, PlanResolution,
@@ -59,7 +60,7 @@ struct Schema : NIceDb::Schema {
             Attributes, Generation, SchemeShardId, PathId, ErrorCode, IsExternalSubDomain, IsExternalHive,
             AreResourcesShared, SharedDomainSchemeShardId, SharedDomainPathId, IsExternalSysViewProcessor,
             SchemaOperationQuotas, CreateIdempotencyKey, AlterIdempotencyKey, DatabaseQuotas, IsExternalStatisticsAggregator,
-            IsExternalBackupController, ScaleRecommenderPolicies>;
+            IsExternalBackupController, ScaleRecommenderPolicies, PeerName>;
     };
 
     struct TenantPools : Table<3> {

--- a/ydb/core/cms/console/console_audit.cpp
+++ b/ydb/core/cms/console/console_audit.cpp
@@ -58,4 +58,36 @@ void AuditLogReplaceDatabaseConfigTransaction(
     );
 }
 
+void AuditLogBeginConfigureDatabase(
+    const TString& userSID,
+    const TString& sanitizedToken,
+    const TString& database)
+{
+    AUDIT_LOG(
+        AUDIT_PART("component", COMPONENT_NAME)
+        AUDIT_PART("subject", (!userSID.empty() ? userSID : EMPTY_VALUE))
+        AUDIT_PART("sanitized_token", (!sanitizedToken.empty() ? sanitizedToken : EMPTY_VALUE))
+        AUDIT_PART("database", (!database.empty() ? database : EMPTY_VALUE))
+        AUDIT_PART("status", TString("SUCCESS"))
+        AUDIT_PART("operation", TString("BEGIN INIT DATABASE CONFIG"))
+    );
+}
+
+void AuditLogEndConfigureDatabase(
+    const TString& userSID,
+    const TString& sanitizedToken,
+    const TString& database,
+    const TString& reason,
+    bool success)
+{
+    AUDIT_LOG(
+        AUDIT_PART("component", COMPONENT_NAME)
+        AUDIT_PART("subject", (!userSID.empty() ? userSID : EMPTY_VALUE))
+        AUDIT_PART("sanitized_token", (!sanitizedToken.empty() ? sanitizedToken : EMPTY_VALUE))
+        AUDIT_PART("database", (!database.empty() ? database : EMPTY_VALUE))
+        AUDIT_PART("status", TString(success ? "SUCCESS" : "ERROR"))
+        AUDIT_PART("reason", reason, !reason.empty())
+        AUDIT_PART("operation", TString("END INIT DATABASE CONFIG"))
+    );
+}
 } // namespace NKikimr::NConsole

--- a/ydb/core/cms/console/console_audit.cpp
+++ b/ydb/core/cms/console/console_audit.cpp
@@ -59,35 +59,85 @@ void AuditLogReplaceDatabaseConfigTransaction(
 }
 
 void AuditLogBeginConfigureDatabase(
+    const TString& peer,
     const TString& userSID,
     const TString& sanitizedToken,
     const TString& database)
 {
+    auto peerName = NKikimr::NAddressClassifier::ExtractAddress(peer);
+
     AUDIT_LOG(
         AUDIT_PART("component", COMPONENT_NAME)
+        AUDIT_PART("remote_address", (!peerName.empty() ? peerName : EMPTY_VALUE))
         AUDIT_PART("subject", (!userSID.empty() ? userSID : EMPTY_VALUE))
         AUDIT_PART("sanitized_token", (!sanitizedToken.empty() ? sanitizedToken : EMPTY_VALUE))
-        AUDIT_PART("database", (!database.empty() ? database : EMPTY_VALUE))
+        AUDIT_PART("database", database)
         AUDIT_PART("status", TString("SUCCESS"))
         AUDIT_PART("operation", TString("BEGIN INIT DATABASE CONFIG"))
     );
 }
 
 void AuditLogEndConfigureDatabase(
+    const TString& peer,
     const TString& userSID,
     const TString& sanitizedToken,
     const TString& database,
     const TString& reason,
     bool success)
 {
+    auto peerName = NKikimr::NAddressClassifier::ExtractAddress(peer);
+
     AUDIT_LOG(
         AUDIT_PART("component", COMPONENT_NAME)
+        AUDIT_PART("remote_address", (!peerName.empty() ? peerName : EMPTY_VALUE))
         AUDIT_PART("subject", (!userSID.empty() ? userSID : EMPTY_VALUE))
         AUDIT_PART("sanitized_token", (!sanitizedToken.empty() ? sanitizedToken : EMPTY_VALUE))
-        AUDIT_PART("database", (!database.empty() ? database : EMPTY_VALUE))
+        AUDIT_PART("database", database)
         AUDIT_PART("status", TString(success ? "SUCCESS" : "ERROR"))
         AUDIT_PART("reason", reason, !reason.empty())
         AUDIT_PART("operation", TString("END INIT DATABASE CONFIG"))
     );
 }
+
+void AuditLogBeginRemoveDatabase(
+    const TString& peer,
+    const TString& userSID,
+    const TString& sanitizedToken,
+    const TString& database)
+{
+    auto peerName = NKikimr::NAddressClassifier::ExtractAddress(peer);
+
+    AUDIT_LOG(
+        AUDIT_PART("component", COMPONENT_NAME)
+        AUDIT_PART("remote_address", (!peerName.empty() ? peerName : EMPTY_VALUE))
+        AUDIT_PART("subject", (!userSID.empty() ? userSID : EMPTY_VALUE))
+        AUDIT_PART("sanitized_token", (!sanitizedToken.empty() ? sanitizedToken : EMPTY_VALUE))
+        AUDIT_PART("database", database)
+        AUDIT_PART("status", TString("SUCCESS"))
+        AUDIT_PART("operation", TString("BEGIN REMOVE DATABASE"))
+    );
+}
+
+void AuditLogEndRemoveDatabase(
+    const TString& peer,
+    const TString& userSID,
+    const TString& sanitizedToken,
+    const TString& database,
+    const TString& reason,
+    bool success)
+{
+    auto peerName = NKikimr::NAddressClassifier::ExtractAddress(peer);
+
+    AUDIT_LOG(
+        AUDIT_PART("component", COMPONENT_NAME)
+        AUDIT_PART("remote_address", (!peerName.empty() ? peerName : EMPTY_VALUE))
+        AUDIT_PART("subject", (!userSID.empty() ? userSID : EMPTY_VALUE))
+        AUDIT_PART("sanitized_token", (!sanitizedToken.empty() ? sanitizedToken : EMPTY_VALUE))
+        AUDIT_PART("database", database)
+        AUDIT_PART("status", TString(success ? "SUCCESS" : "ERROR"))
+        AUDIT_PART("reason", reason, !reason.empty())
+        AUDIT_PART("operation", TString("END REMOVE DATABASE"))
+    );
+}
+
 } // namespace NKikimr::NConsole

--- a/ydb/core/cms/console/console_audit.h
+++ b/ydb/core/cms/console/console_audit.h
@@ -23,4 +23,15 @@ void AuditLogReplaceDatabaseConfigTransaction(
     const TString& reason,
     bool success);
 
+void AuditLogBeginConfigureDatabase(
+    const TString& userSID,
+    const TString& sanitizedToken,
+    const TString& database);
+
+void AuditLogEndConfigureDatabase(
+    const TString& userSID,
+    const TString& sanitizedToken,
+    const TString& database,
+    const TString& reason,
+    bool success);
 } // namespace NKikimr::NConsole

--- a/ydb/core/cms/console/console_audit.h
+++ b/ydb/core/cms/console/console_audit.h
@@ -24,14 +24,31 @@ void AuditLogReplaceDatabaseConfigTransaction(
     bool success);
 
 void AuditLogBeginConfigureDatabase(
+    const TString& peer,
     const TString& userSID,
     const TString& sanitizedToken,
     const TString& database);
 
 void AuditLogEndConfigureDatabase(
+    const TString& peer,
     const TString& userSID,
     const TString& sanitizedToken,
     const TString& database,
     const TString& reason,
     bool success);
+
+void AuditLogBeginRemoveDatabase(
+    const TString& peer,
+    const TString& userSID,
+    const TString& sanitizedToken,
+    const TString& database);
+
+void AuditLogEndRemoveDatabase(
+    const TString& peer,
+    const TString& userSID,
+    const TString& sanitizedToken,
+    const TString& database,
+    const TString& reason,
+    bool success);
+
 } // namespace NKikimr::NConsole

--- a/ydb/core/cms/console/console_tenants_manager.cpp
+++ b/ydb/core/cms/console/console_tenants_manager.cpp
@@ -3207,6 +3207,19 @@ void TTenantsManager::DbUpdateTenantUserToken(TTenant::TPtr tenant,
         .Update(NIceDb::TUpdate<Schema::Tenants::UserToken>(userToken));
 }
 
+void TTenantsManager::DbUpdateTenantPeerName(TTenant::TPtr tenant,
+                                             const TString &peerName,
+                                             TTransactionContext &txc,
+                                             const TActorContext &ctx)
+{
+    LOG_TRACE_S(ctx, NKikimrServices::CMS_TENANTS,
+    "Update peerName in database for " << tenant->Path);
+
+    NIceDb::TNiceDb db(txc.DB);
+    db.Table<Schema::Tenants>().Key(tenant->Path)
+        .Update(NIceDb::TUpdate<Schema::Tenants::PeerName>(peerName));
+}
+
 void TTenantsManager::DbUpdateSubdomainVersion(TTenant::TPtr tenant,
                                                ui64 version,
                                                TTransactionContext &txc,

--- a/ydb/core/cms/console/console_tenants_manager.cpp
+++ b/ydb/core/cms/console/console_tenants_manager.cpp
@@ -728,7 +728,7 @@ public:
             );
         };
 
-        if (Action == GET_KEY) {
+        if (Action == CONFIGURE) {
             audit(AuditLogEndConfigureDatabase);
         } else if (Action == REMOVE) {
             audit(AuditLogEndRemoveDatabase);

--- a/ydb/core/cms/console/console_tenants_manager.cpp
+++ b/ydb/core/cms/console/console_tenants_manager.cpp
@@ -2302,7 +2302,6 @@ void TTenantsManager::DeleteTenantSubDomain(TTenant::TPtr tenant, const TActorCo
 
 void TTenantsManager::ProcessTenantActions(TTenant::TPtr tenant, const TActorContext &ctx)
 {
-    // ev->Get()->Record.GetPeerName()
     if (tenant->State == TTenant::CREATING_POOLS) {
         AllocateTenantPools(tenant, ctx);
     } else if (tenant->State == TTenant::CREATING_SUBDOMAIN) {

--- a/ydb/core/cms/console/console_tenants_manager.cpp
+++ b/ydb/core/cms/console/console_tenants_manager.cpp
@@ -848,15 +848,45 @@ public:
 
         if (Action == REMOVE) {
             switch (rec.GetStatus()) {
-            case NKikimrScheme::EStatus::StatusPathDoesNotExist:
+            case NKikimrScheme::EStatus::StatusPathDoesNotExist: {
+                AuditLogEndRemoveDatabase(
+                    Tenant->PeerName,
+                    Tenant->UserToken.GetUserSID(),
+                    Tenant->UserToken.GetSanitizedToken(),
+                    Tenant->Path,
+                    "Path does not exist",
+                    false
+                );
+        
                 ActionFinished(ctx);
                 break;
-            case NKikimrScheme::EStatus::StatusSuccess:
+            }
+            case NKikimrScheme::EStatus::StatusSuccess: {
+                AuditLogEndRemoveDatabase(
+                    Tenant->PeerName,
+                    Tenant->UserToken.GetUserSID(),
+                    Tenant->UserToken.GetSanitizedToken(),
+                    Tenant->Path,
+                    "",
+                    true
+                );
+
                 DropSubdomain(ctx);
                 break;
-            default:
+            }
+            default: {
+                AuditLogEndRemoveDatabase(
+                    Tenant->PeerName,
+                    Tenant->UserToken.GetUserSID(),
+                    Tenant->UserToken.GetSanitizedToken(),
+                    Tenant->Path,
+                    rec.GetReason(),
+                    false
+                );
+
                 ReplyAndDie(new TTenantsManager::TEvPrivate::TEvSubdomainFailed(Tenant, rec.GetReason()), ctx);
                 break;
+            }
             }
 
             return;
@@ -874,8 +904,8 @@ public:
                 Tenant->UserToken.GetUserSID(),
                 Tenant->UserToken.GetSanitizedToken(),
                 Tenant->Path,
-                "Resolve subdomain fail",
-                true
+                rec.GetReason(),
+                false
             );
 
             ReplyAndDie(new TTenantsManager::TEvPrivate::TEvSubdomainFailed(Tenant, rec.GetReason()), ctx);
@@ -896,8 +926,8 @@ public:
                 Tenant->UserToken.GetUserSID(),
                 Tenant->UserToken.GetSanitizedToken(),
                 Tenant->Path,
-                "Resolve subdomain fail",
-                true
+                "Path has invalid path type",
+                false
             );
 
             ReplyAndDie(new TTenantsManager::TEvPrivate::TEvSubdomainFailed(Tenant, "bad path type"), ctx);

--- a/ydb/core/cms/console/console_tenants_manager.h
+++ b/ydb/core/cms/console/console_tenants_manager.h
@@ -467,7 +467,8 @@ public:
 
         TTenant(const TString &path,
                 EState state,
-                const TString &token);
+                const TString &token,
+                const TString &peer);
 
         static bool IsConfiguringState(EState state);
         static bool IsCreatingState(EState state);
@@ -516,6 +517,8 @@ public:
         TString Issue;
         ui64 TxId;
         NACLib::TUserToken UserToken;
+        // Peer is remote-address of User, who created database. Used for audit logging.
+        const TString PeerName;
         // Subdomain version is incremented on each pool creation.
         ui64 SubdomainVersion;
         // Last subdomain version configured in SchemeShard.

--- a/ydb/core/cms/console/console_tenants_manager.h
+++ b/ydb/core/cms/console/console_tenants_manager.h
@@ -910,6 +910,10 @@ public:
                                  const TString &userToken,
                                  TTransactionContext &txc,
                                  const TActorContext &ctx);
+    void DbUpdateTenantPeerName(TTenant::TPtr tenant,
+                                 const TString &peerName,
+                                 TTransactionContext &txc,
+                                 const TActorContext &ctx);
     void DbUpdateSubdomainVersion(TTenant::TPtr tenant,
                                   ui64 version,
                                   TTransactionContext &txc,

--- a/ydb/core/grpc_services/rpc_cms.cpp
+++ b/ydb/core/grpc_services/rpc_cms.cpp
@@ -143,6 +143,7 @@ private:
         auto request = MakeHolder<TCmsRequest>();
         request->Record.MutableRequest()->CopyFrom(*this->GetProtoRequest());
         request->Record.SetUserToken(this->Request_->GetSerializedToken());
+        request->Record.SetPeerName(this->Request_->GetPeerName());
         NTabletPipe::SendData(ctx, CmsPipe, request.Release());
     }
 };

--- a/ydb/core/grpc_services/rpc_cms.cpp
+++ b/ydb/core/grpc_services/rpc_cms.cpp
@@ -77,6 +77,7 @@ private:
             auto request = MakeHolder<TEvConsole::TEvNotifyOperationCompletionRequest>();
             request->Record.MutableRequest()->set_id(response.operation().id());
             request->Record.SetUserToken(this->Request_->GetSerializedToken());
+            request->Record.SetPeerName(this->Request_->GetPeerName());
 
             NTabletPipe::SendData(ctx, CmsPipe, request.Release());
         } else {

--- a/ydb/core/protos/console_tenant.proto
+++ b/ydb/core/protos/console_tenant.proto
@@ -60,6 +60,7 @@ message TRemoveTenantResponse {
 message TGetOperationRequest {
     optional Ydb.Operations.GetOperationRequest Request = 1;
     optional bytes UserToken = 2;
+    optional string PeerName = 3;
 }
 
 message TGetOperationResponse {

--- a/ydb/core/protos/console_tenant.proto
+++ b/ydb/core/protos/console_tenant.proto
@@ -10,6 +10,7 @@ option java_package = "ru.yandex.kikimr.proto";
 message TCreateTenantRequest {
     optional Ydb.Cms.CreateDatabaseRequest Request = 1;
     optional bytes UserToken = 2;
+    optional string PeerName = 3;
 }
 
 message TCreateTenantResponse {
@@ -19,6 +20,7 @@ message TCreateTenantResponse {
 message TGetTenantStatusRequest {
     optional Ydb.Cms.GetDatabaseStatusRequest Request = 1;
     optional bytes UserToken = 2;
+    optional string PeerName = 3;
 }
 
 message TGetTenantStatusResponse {
@@ -28,6 +30,7 @@ message TGetTenantStatusResponse {
 message TAlterTenantRequest {
     optional Ydb.Cms.AlterDatabaseRequest Request = 1;
     optional bytes UserToken = 2;
+    optional string PeerName = 3;
 }
 
 message TAlterTenantResponse {
@@ -37,6 +40,7 @@ message TAlterTenantResponse {
 message TListTenantsRequest {
     optional Ydb.Cms.ListDatabasesRequest Request = 1;
     optional bytes UserToken = 2;
+    optional string PeerName = 3;
 }
 
 message TListTenantsResponse {
@@ -46,6 +50,7 @@ message TListTenantsResponse {
 message TRemoveTenantRequest {
     optional Ydb.Cms.RemoveDatabaseRequest Request = 1;
     optional bytes UserToken = 2;
+    optional string PeerName = 3;
 }
 
 message TRemoveTenantResponse {
@@ -64,6 +69,7 @@ message TGetOperationResponse {
 message TDescribeTenantOptionsRequest {
     optional Ydb.Cms.DescribeDatabaseOptionsRequest Request = 1;
     optional bytes UserToken = 2;
+    optional string PeerName = 3;
 }
 
 message TDescribeTenantOptionsResponse {

--- a/ydb/tests/functional/audit/test_auditlog.py
+++ b/ydb/tests/functional/audit/test_auditlog.py
@@ -474,3 +474,7 @@ def test_create_and_remove_tenant(ydb_cluster):
         ydb_cluster.unregister_and_stop_slots(database_nodes)
 
     print(capture_audit.captured, file=sys.stderr)
+    assert "BEGIN INIT DATABASE CONFIG" in capture_audit.captured
+    assert "END INIT DATABASE CONFIG" in capture_audit.captured
+    assert "BEGIN REMOVE DATABASE" in capture_audit.captured
+    assert "END REMOVE DATABASE" in capture_audit.captured

--- a/ydb/tests/functional/audit/test_auditlog.py
+++ b/ydb/tests/functional/audit/test_auditlog.py
@@ -455,7 +455,7 @@ def test_broken_dynconfig(ydb_cluster, prepared_test_env, pool_fixture, config_f
     assert cfg in capture_audit.captured
 
 
-def test_create_tenant(ydb_cluster):
+def test_create_and_remove_tenant(ydb_cluster):
     capture_audit = CaptureFileOutput(ydb_cluster.config.audit_file_path)
     print('AAA', capture_audit.filename, file=sys.stderr)
 

--- a/ydb/tests/functional/audit/test_auditlog.py
+++ b/ydb/tests/functional/audit/test_auditlog.py
@@ -453,3 +453,24 @@ def test_broken_dynconfig(ydb_cluster, prepared_test_env, pool_fixture, config_f
     print(capture_audit.captured, file=sys.stderr)
     cfg = json.dumps(config)
     assert cfg in capture_audit.captured
+
+
+def test_create_tenant(ydb_cluster):
+    capture_audit = CaptureFileOutput(ydb_cluster.config.audit_file_path)
+    print('AAA', capture_audit.filename, file=sys.stderr)
+
+    with capture_audit:
+        database = '/Root/users/database'
+        ydb_cluster.create_database(
+            database,
+            storage_pool_units_count={
+                'hdd': 1
+            }
+        )
+        database_nodes = ydb_cluster.register_and_start_slots(database, count=1)
+        ydb_cluster.wait_tenant_up(database)
+        time.sleep(1)
+        ydb_cluster.remove_database(database)
+        ydb_cluster.unregister_and_stop_slots(database_nodes)
+
+    print(capture_audit.captured, file=sys.stderr)


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

In cms/console/ add audit logging.

There are fields of BeginCreate:
1. Component = console
2. Subject
3. Sanitized_token
4. Database
5. Status = SUCCESS
6. Operation

In EndCreate there is `reason` field, because in this case status can be ERROR.

### Changelog category <!-- remove all except one -->

* Improvement