### PR TITLE
Allow fetching extra sections through distconf to revert automatic configuration changes

### DIFF
--- a/ydb/core/blobstorage/nodewarden/distconf_invoke.h
+++ b/ydb/core/blobstorage/nodewarden/distconf_invoke.h
@@ -103,7 +103,7 @@ namespace NKikimr::NStorage {
             OTHER,
         } ControllerOp = EControllerOp::UNSET;
 
-        void FetchStorageConfig(bool manual, bool fetchMain, bool fetchStorage);
+        void FetchStorageConfig(bool fetchMain, bool fetchStorage, bool addExplicitMgmtSections, bool addV1);
         void ReplaceStorageConfig(const TQuery::TReplaceStorageConfig& request);
         void ReplaceStorageConfigResume(const std::optional<TString>& storageConfigYaml, ui64 expectedMainYamlVersion,
                 ui64 expectedStorageYamlVersion, bool enablingDistconf);

--- a/ydb/core/blobstorage/nodewarden/distconf_invoke_common.cpp
+++ b/ydb/core/blobstorage/nodewarden/distconf_invoke_common.cpp
@@ -115,7 +115,8 @@ namespace NKikimr::NStorage {
 
             case TQuery::kFetchStorageConfig: {
                 const auto& request = record.GetFetchStorageConfig();
-                return FetchStorageConfig(request.GetManual(), request.GetMainConfig(), request.GetStorageConfig());
+                return FetchStorageConfig(request.GetMainConfig(), request.GetStorageConfig(),
+                    request.GetAddExplicitConfigs(), request.GetAddSectionsForMigrationToV1());
             }
 
             case TQuery::kReplaceStorageConfig:

--- a/ydb/core/blobstorage/nodewarden/distconf_invoke_storage_config.cpp
+++ b/ydb/core/blobstorage/nodewarden/distconf_invoke_storage_config.cpp
@@ -4,18 +4,55 @@
 #include <ydb/core/mind/bscontroller/bsc.h>
 
 #include <ydb/library/yaml_config/yaml_config_parser.h>
+#include <ydb/library/yaml_config/util.h>
 #include <ydb/library/yaml_json/yaml_to_json.h>
+#include <library/cpp/protobuf/json/proto2json.h>
 
 namespace NKikimr::NStorage {
 
     using TInvokeRequestHandlerActor = TDistributedConfigKeeper::TInvokeRequestHandlerActor;
 
-    void TInvokeRequestHandlerActor::FetchStorageConfig(bool manual, bool fetchMain, bool fetchStorage) {
-        if (!Self->StorageConfig) {
-            FinishWithError(TResult::ERROR, "no agreed StorageConfig");
-        } else if (!Self->MainConfigYaml) {
-            FinishWithError(TResult::ERROR, "no stored YAML for storage config");
-        } else {
+    namespace {
+        YAML::Node Json2Yaml(const NJson::TJsonValue& json) {
+            YAML::Node res;
+
+            switch (json.GetType()) {
+                case NJson::JSON_UNDEFINED: return YAML::Node();
+                case NJson::JSON_NULL:      return YAML::Node(YAML::NodeType::Null);
+                case NJson::JSON_BOOLEAN:   return YAML::Node(json.GetBoolean());
+                case NJson::JSON_INTEGER:   return YAML::Node(json.GetInteger());
+                case NJson::JSON_DOUBLE:    return YAML::Node(json.GetDouble());
+                case NJson::JSON_STRING:    return YAML::Node(json.GetString());
+                case NJson::JSON_UINTEGER:  return YAML::Node(json.GetUInteger());
+
+                case NJson::JSON_MAP:
+                    res = YAML::Node(YAML::NodeType::Map);
+                    for (const auto& [key, value] : json.GetMap()) {
+                        res.force_insert(key, Json2Yaml(value));
+                    }
+                    return res;
+
+                case NJson::JSON_ARRAY:
+                    res = YAML::Node(YAML::NodeType::Sequence);
+                    for (const auto& item : json.GetArray()) {
+                        res.push_back(Json2Yaml(item));
+                    }
+                    return res;
+            }
+
+            Y_ABORT();
+        }
+    }
+
+    void TInvokeRequestHandlerActor::FetchStorageConfig(bool fetchMain, bool fetchStorage, bool addExplicitMgmtSections,
+            bool addV1) {
+        try {
+            if (!Self->StorageConfig) {
+                throw yexception() << "no agreed StorageConfig";
+            } else if (!Self->MainConfigYaml) {
+                throw yexception() << "no stored YAML for storage config";
+            }
+
             auto ev = PrepareResult(TResult::OK, std::nullopt);
             auto *record = &ev->Record;
             auto *res = record->MutableFetchStorageConfig();
@@ -26,11 +63,95 @@ namespace NKikimr::NStorage {
                 res->SetStorageYAML(*Self->StorageConfigYaml);
             }
 
-            if (manual) {
-                // add BlobStorageConfig, NameserviceConfig, DomainsConfig into main/storage config
+            if (addExplicitMgmtSections && addV1) {
+                throw yexception() << "can't provide both explicit sections and config suitable for downgrade to v1";
+            } else if (Self->StorageConfigYaml && addV1) {
+                throw yexception() << "can't downgrade to v1 when dedicated storage section is enabled";
+            } else if (addExplicitMgmtSections && Self->StorageConfigYaml && !fetchStorage) {
+                throw yexception() << "can't add explicit sections to storage config as it is not fetched";
+            }
+
+            auto enrich = [&](auto&& protobuf, auto&& callback) {
+                TString *yaml = nullptr;
+
+                if (res->HasStorageYAML()) {
+                    yaml = res->MutableStorageYAML();
+                } else if (res->HasYAML()) {
+                    yaml = res->MutableYAML();
+                } else {
+                    throw yexception() << "can't add explicit sections to main config as it is not fetched";
+                }
+
+                auto doc = NFyaml::TDocument::Parse(*yaml);
+
+                NJson::TJsonValue json;
+                NProtobufJson::Proto2Json(protobuf, json, NYamlConfig::GetProto2JsonConfig());
+                auto inserted = NFyaml::TDocument::Parse(YAML::Dump(Json2Yaml(json)));
+                callback(doc.Root(), inserted.Root().Copy(doc), doc);
+                *yaml = TString(doc.EmitToCharArray().get());
+            };
+
+            auto replace = [&](const char *section) {
+                return [section](auto rootNode, auto protoNode, auto& doc) {
+                    auto m = rootNode.Map().at("config").Map();
+                    if (auto ref = m.pair_at_opt(section)) {
+                        m.Remove(ref);
+                    }
+                    m.Append(doc.CreateScalar(section), protoNode);
+                };
+            };
+
+            if (addExplicitMgmtSections || addV1) { // add BlobStorageConfig (or replace existing one)
+                auto bsConfig = Self->StorageConfig->GetBlobStorageConfig();
+                bsConfig.ClearDefineHostConfig();
+                bsConfig.ClearDefineBox();
+                enrich(bsConfig, replace("blob_storage_config"));
+            }
+            if (addExplicitMgmtSections) {
+                auto callback = [&](const char *name) {
+                    return [name](auto rootNode, auto protoNode, auto& doc) {
+                        auto m = rootNode.Map().at("config").Map();
+                        if (!m.Has("domains_config")) {
+                            m.Append(doc.CreateScalar("domains_config"), doc.CreateMapping());
+                        }
+
+                        m = m["domains_config"].Map();
+                        if (auto ref = m.pair_at_opt(name)) {
+                            m.Remove(ref);
+                        }
+                        m.Append(doc.CreateScalar(name), protoNode);
+                    };
+                };
+                enrich(Self->StorageConfig->GetStateStorageConfig(), callback("explicit_state_storage_config"));
+                enrich(Self->StorageConfig->GetStateStorageBoardConfig(), callback("explicit_state_storage_board_config"));
+                enrich(Self->StorageConfig->GetSchemeBoardConfig(), callback("explicit_scheme_board_config"));
+            }
+            if (addV1) {
+                auto equals = google::protobuf::util::MessageDifferencer::Equals;
+                auto& sc = Self->StorageConfig;
+                auto& ssConfig = sc->GetStateStorageConfig();
+                auto& ssbConfig = sc->GetStateStorageBoardConfig();
+                auto& sbConfig = sc->GetSchemeBoardConfig();
+                if (equals(ssConfig, ssbConfig) && equals(ssConfig, sbConfig)) {
+                    NKikimrConfig::TDomainsConfig domains;
+                    domains.CopyFrom(AppData()->DomainsConfig);
+                    domains.ClearStateStorage();
+                    domains.AddStateStorage()->CopyFrom(ssConfig);
+                    for (int i = 0, count = domains.DomainSize(); i < count; ++i) {
+                        auto *dom = domains.MutableDomain(i);
+                        dom->ClearExplicitCoordinators();
+                        dom->ClearExplicitAllocators();
+                        dom->ClearExplicitMediators();
+                    }
+                    enrich(domains, replace("domains_config"));
+                } else {
+                    throw yexception() << "state storage, state storage board and scheme board configs are not equal";
+                }
             }
 
             Finish(Sender, SelfId(), ev.release(), 0, Cookie);
+        } catch (const yexception& ex) {
+            FinishWithError(TResult::ERROR, ex.what());
         }
     }
 

--- a/ydb/core/grpc_services/rpc_config.cpp
+++ b/ydb/core/grpc_services/rpc_config.cpp
@@ -381,7 +381,23 @@ public:
             issues.AddIssue("Only fetch mode \"all\" is supported now.");
             return false;
         }
-        return true;
+        switch (const auto& all = request.all(); all.config_transform_case()) {
+            case Ydb::Config::FetchConfigRequest::FetchModeAll::ConfigTransformCase::CONFIG_TRANSFORM_NOT_SET:
+            case Ydb::Config::FetchConfigRequest::FetchModeAll::ConfigTransformCase::kNone:
+                return true;
+
+            case Ydb::Config::FetchConfigRequest::FetchModeAll::ConfigTransformCase::kAddBlobStorageAndDomainsConfig:
+            case Ydb::Config::FetchConfigRequest::FetchModeAll::ConfigTransformCase::kAddExplicitSections:
+                RequireSelfManagement = true;
+                return true;
+
+            case Ydb::Config::FetchConfigRequest::FetchModeAll::ConfigTransformCase::kDetachStorageConfigSection:
+            case Ydb::Config::FetchConfigRequest::FetchModeAll::ConfigTransformCase::kAttachStorageConfigSection:
+                break; // we don't support them
+        }
+        status = Ydb::StatusIds::BAD_REQUEST;
+        issues.AddIssue("Unsupported config_transform specified.");
+        return false;
     }
 
     NACLib::EAccessRights GetRequiredAccessRights() const {
@@ -409,6 +425,18 @@ public:
             case Ydb::Config::FetchConfigRequest::ModeCase::kAll:
                 record->SetMainConfig(true);
                 record->SetStorageConfig(true);
+                switch (const auto& all = request.all(); all.config_transform_case()) {
+                    case Ydb::Config::FetchConfigRequest::FetchModeAll::ConfigTransformCase::kAddBlobStorageAndDomainsConfig:
+                        record->SetAddSectionsForMigrationToV1(true);
+                        break;
+
+                    case Ydb::Config::FetchConfigRequest::FetchModeAll::ConfigTransformCase::kAddExplicitSections:
+                        record->SetAddExplicitConfigs(true);
+                        break;
+
+                    default:
+                        break;
+                }
                 break;
 
             case Ydb::Config::FetchConfigRequest::ModeCase::kTarget:

--- a/ydb/core/grpc_services/rpc_config_base.h
+++ b/ydb/core/grpc_services/rpc_config_base.h
@@ -187,6 +187,9 @@ protected:
             auto ev = std::make_unique<NStorage::TEvNodeConfigInvokeOnRoot>();
             self->FillDistconfQuery(*ev);
             self->Send(MakeBlobStorageNodeWardenID(self->SelfId().NodeId()), ev.release());
+        } else if (RequireSelfManagement) {
+            self->Reply(Ydb::StatusIds::BAD_REQUEST, "operating self-management is required to fulfill this request",
+                NKikimrIssues::TIssuesIds::DEFAULT_ERROR, self->ActorContext());
         } else { // classic BSC
             CreatePipe();
         }
@@ -409,6 +412,9 @@ private:
     EState State = EState::UNKNOWN;
     TActorId BSCPipeClient;
     ui32 InterfaceVersion = 0;
+
+protected:
+    bool RequireSelfManagement = false;
 };
 
 } // namespace NKikimr::NGRpcService

--- a/ydb/core/protos/blobstorage_distributed_config.proto
+++ b/ydb/core/protos/blobstorage_distributed_config.proto
@@ -193,9 +193,11 @@ message TEvNodeConfigInvokeOnRoot {
     {}
 
     message TFetchStorageConfig {
-        bool Manual = 1; // when set to true, distconf returns conventional configuration
+        reserved 1;
         bool MainConfig = 2;
         bool StorageConfig = 3;
+        bool AddSectionsForMigrationToV1 = 5; // add sections so this config becomes suitable for migration to v1
+        bool AddExplicitConfigs = 4; // add explicit settings for all managed entities
     }
 
     message TReplaceStorageConfig {

--- a/ydb/library/fyamlcpp/fyamlcpp.cpp
+++ b/ydb/library/fyamlcpp/fyamlcpp.cpp
@@ -643,6 +643,21 @@ TNodeRef TDocument::Buildf(const char* content) {
     return TNodeRef(fy_node_build_from_string(Document_.get(), content, strlen(content)));
 }
 
+TNodeRef TDocument::CreateScalar(const TString& content) {
+    ENSURE_DOCUMENT_NOT_EMPTY(Document_);
+    return TNodeRef(fy_node_create_scalar_copy(Document_.get(), content.data(), content.size()));
+}
+
+TNodeRef TDocument::CreateMapping() {
+    ENSURE_DOCUMENT_NOT_EMPTY(Document_);
+    return TNodeRef(fy_node_create_mapping(Document_.get()));
+}
+
+TNodeRef TDocument::CreateSequence() {
+    ENSURE_DOCUMENT_NOT_EMPTY(Document_);
+    return TNodeRef(fy_node_create_sequence(Document_.get()));
+}
+
 void TDocument::Resolve() {
     ENSURE_DOCUMENT_NOT_EMPTY(Document_);
     if (fy_document_resolve(Document_.get()) != 0) {

--- a/ydb/library/fyamlcpp/fyamlcpp.h
+++ b/ydb/library/fyamlcpp/fyamlcpp.h
@@ -706,6 +706,10 @@ public:
 
     TNodeRef Buildf(const char* content);
 
+    TNodeRef CreateScalar(const TString& content);
+    TNodeRef CreateMapping();
+    TNodeRef CreateSequence();
+
     void Resolve();
 
     bool HasDirectives();

--- a/ydb/public/api/protos/ydb_config.proto
+++ b/ydb/public/api/protos/ydb_config.proto
@@ -114,7 +114,8 @@ message FetchConfigRequest {
     message FetchModeAll {
         // Use this option to somehow transform main config
         // Currently used to automatically derive detached StorageSection from MainConfig
-        //     or vice versa
+        //     or vice versa, and to add some internally-managed sections into config for
+        //     explicit user control
         oneof config_transform {
             // Optionally may be set to explicitly tell "do not transform anything"
             google.protobuf.Empty none = 1;
@@ -130,6 +131,13 @@ message FetchConfigRequest {
             // (MainConfig*, StorageConfig) -> (MainConfig)
             // MainConfig with asterisk means MainConfig with excluded storage-related sections
             google.protobuf.Empty attach_storage_config_section = 3;
+
+            // Fetch will return MainConfig with added blob_storage_config and domains_config sections in order to
+            //    downgrade to configuration v1.
+            google.protobuf.Empty add_blob_storage_and_domains_config = 4;
+
+            // Fetch will return MainConfig/StorageConfig with added blob_storage_config and explicit_* sections
+            google.protobuf.Empty add_explicit_sections = 5;
         }
     }
 

--- a/ydb/public/lib/ydb_cli/commands/ydb_dynamic_config.h
+++ b/ydb/public/lib/ydb_cli/commands/ydb_dynamic_config.h
@@ -64,6 +64,8 @@ private:
     bool AllowEmptyDatabase = false;
     bool DedicatedStorageSection = false;
     bool DedicatedClusterSection = false;
+    bool FetchInternalState = false;
+    bool FetchExplicitSections = false;
 };
 
 class TCommandConfigResolve : public TYdbReadOnlyCommand {

--- a/ydb/public/sdk/cpp/include/ydb-cpp-sdk/client/config/config.h
+++ b/ydb/public/sdk/cpp/include/ydb-cpp-sdk/client/config/config.h
@@ -21,10 +21,12 @@ enum class EFetchAllConfigsTransform {
     NONE,
     DETACH_STORAGE_CONFIG_SECTION,
     ATTACH_STORAGE_CONFIG_SECTION,
+    ADD_BLOB_STORAGE_AND_DOMAINS_CONFIG,
+    ADD_EXPLICIT_SECTIONS,
 };
 
 struct TFetchAllConfigsSettings : public NYdb::TOperationRequestSettings<TFetchAllConfigsSettings> {
-    FLUENT_SETTING(EFetchAllConfigsTransform, Transform);
+    FLUENT_SETTING_DEFAULT(EFetchAllConfigsTransform, Transform, EFetchAllConfigsTransform::NONE);
 };
 
 struct TBootstrapClusterSettings : public NYdb::TOperationRequestSettings<TBootstrapClusterSettings> {};

--- a/ydb/public/sdk/cpp/src/client/config/config.cpp
+++ b/ydb/public/sdk/cpp/src/client/config/config.cpp
@@ -68,7 +68,28 @@ public:
 
     TAsyncFetchConfigResult FetchAllConfigs(const TFetchAllConfigsSettings& settings = {}) {
         auto request = MakeOperationRequest<Ydb::Config::FetchConfigRequest>(settings);
-        request.mutable_all();
+        auto *all = request.mutable_all();
+        switch (settings.Transform_) {
+            case EFetchAllConfigsTransform::NONE:
+                all->mutable_none();
+                break;
+
+            case EFetchAllConfigsTransform::DETACH_STORAGE_CONFIG_SECTION:
+                all->mutable_detach_storage_config_section();
+                break;
+
+            case EFetchAllConfigsTransform::ATTACH_STORAGE_CONFIG_SECTION:
+                all->mutable_attach_storage_config_section();
+                break;
+
+            case EFetchAllConfigsTransform::ADD_BLOB_STORAGE_AND_DOMAINS_CONFIG:
+                all->mutable_add_blob_storage_and_domains_config();
+                break;
+
+            case EFetchAllConfigsTransform::ADD_EXPLICIT_SECTIONS:
+                all->mutable_add_explicit_sections();
+                break;
+        }
 
         auto promise = NThreading::NewPromise<TFetchConfigResult>();
 


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

Allow fetching extra sections through distconf to revert automatic configuration changes

### Changelog category <!-- remove all except one -->

* Not for changelog (changelog entry is not required)

### Description for reviewers <!-- (optional) description for those who read this PR -->

This adds option to enrich returned YAML with specific sections for explicit user management, without intervention of distconf/selfheal.
