### PR TITLE
allow configuration of CS wakeup interval

### DIFF
--- a/ydb/core/protos/config.proto
+++ b/ydb/core/protos/config.proto
@@ -1924,6 +1924,7 @@ message TColumnShardConfig {
     optional bool AlterObjectEnabled = 39 [default = false];
     optional EJsonDoubleOutOfRangeHandlingPolicy DoubleOutOfRangeHandling = 40 [default = REJECT];
     optional bool PortionMetaV0Usage = 41 [default = true];
+    optional uint32 PeriodicWakeupActivationPeriodMs = 42 [default = 60000];
 }
 
 message TSchemeShardConfig {

--- a/ydb/core/tx/columnshard/columnshard_impl.h
+++ b/ydb/core/tx/columnshard/columnshard_impl.h
@@ -133,7 +133,6 @@ struct TSettings {
 
     static constexpr ui32 MAX_INDEXATIONS_TO_SKIP = 16;
     static constexpr TDuration GuaranteeIndexationInterval = TDuration::Seconds(10);
-    static constexpr TDuration DefaultPeriodicWakeupActivationPeriod = TDuration::Seconds(60);
     static constexpr TDuration DefaultStatsReportInterval = TDuration::Seconds(10);
     static constexpr i64 GuaranteeIndexationStartBytesLimit = (i64)5 * 1024 * 1024 * 1024;
 

--- a/ydb/core/tx/columnshard/hooks/abstract/abstract.cpp
+++ b/ydb/core/tx/columnshard/hooks/abstract/abstract.cpp
@@ -10,7 +10,7 @@ TDuration ICSController::GetGuaranteeIndexationInterval() const {
 }
 
 TDuration ICSController::GetPeriodicWakeupActivationPeriod() const {
-    const TDuration defaultValue = NColumnShard::TSettings::DefaultPeriodicWakeupActivationPeriod;
+    const TDuration defaultValue = TDuration::MilliSeconds(GetConfig().GetPeriodicWakeupActivationPeriodMs());
     return DoGetPeriodicWakeupActivationPeriod(defaultValue);
 }
 


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

...

### Changelog category <!-- remove all except one -->

* Not for changelog (changelog entry is not required)

### Description for reviewers <!-- (optional) description for those who read this PR -->

Добавлен параметр PeriodicWakeupActivationPeriod, чтобы Python тесты могли выполняться не за 5 минут, а за 1 минуту
