### PR TITLE
Fix blobstorage's latency histogram counters calculation

### DIFF
--- a/library/cpp/monlib/dynamic_counters/counters.h
+++ b/library/cpp/monlib/dynamic_counters/counters.h
@@ -137,7 +137,7 @@ namespace NMonitoring {
             Visibility_ = vis;
         }
 
-        void Collect(i64 value) {
+        void Collect(double value) {
             Collector_->Collect(value);
         }
 

--- a/ydb/core/blobstorage/vdisk/common/vdisk_histogram_latency.cpp
+++ b/ydb/core/blobstorage/vdisk/common/vdisk_histogram_latency.cpp
@@ -24,7 +24,7 @@ namespace NKikimr {
 
         void TLtcHisto::Collect(TDuration d, ui64 size) {
             if (Histo) {
-                Histo->Collect(d.MilliSeconds());
+                Histo->Collect(d.MillisecondsFloat());
             }
             if (size) {
                 ThroughputBytes->Add(size);
@@ -33,4 +33,3 @@ namespace NKikimr {
 
     } // NKikimr
 } // NKikimr
-

--- a/ydb/core/grpc_services/counters/counters.cpp
+++ b/ydb/core/grpc_services/counters/counters.cpp
@@ -222,7 +222,7 @@ public:
             *GetResponseCounterByStatus(status) += 1;
         }
 
-        Histo->Collect(requestDuration.MilliSeconds());
+        Histo->Collect(requestDuration.MillisecondsFloat());
     }
 
     NYdbGrpc::ICounterBlockPtr Clone() override {

--- a/ydb/core/kqp/counters/kqp_counters.cpp
+++ b/ydb/core/kqp/counters/kqp_counters.cpp
@@ -325,27 +325,27 @@ void TKqpCountersBase::ReportQueryWithFullScan() {
 }
 
 void TKqpCountersBase::ReportQueryAffectedShards(ui64 shardsCount) {
-    QueryAffectedShardsCount->Collect(shardsCount > Max<i64>() ? Max<i64>() : static_cast<i64>(shardsCount));
+    QueryAffectedShardsCount->Collect(shardsCount);
 }
 
 void TKqpCountersBase::ReportQueryReadSets(ui64 readSetsCount) {
-    QueryReadSetsCount->Collect(readSetsCount > Max<i64>() ? Max<i64>() : static_cast<i64>(readSetsCount));
+    QueryReadSetsCount->Collect(readSetsCount);
 }
 
 void TKqpCountersBase::ReportQueryReadBytes(ui64 bytesCount) {
-    QueryReadBytes->Collect(bytesCount > Max<i64>() ? Max<i64>() : static_cast<i64>(bytesCount));
+    QueryReadBytes->Collect(bytesCount);
 }
 
 void TKqpCountersBase::ReportQueryReadRows(ui64 rowsCount) {
-    QueryReadRows->Collect(rowsCount > Max<i64>() ? Max<i64>() : static_cast<i64>(rowsCount));
+    QueryReadRows->Collect(rowsCount);
 }
 
 void TKqpCountersBase::ReportQueryMaxShardReplySize(ui64 replySize) {
-    QueryMaxShardReplySize->Collect(replySize > Max<i64>() ? Max<i64>() : static_cast<i64>(replySize));
+    QueryMaxShardReplySize->Collect(replySize);
 }
 
 void TKqpCountersBase::ReportQueryMaxShardProgramSize(ui64 programSize) {
-    QueryMaxShardProgramSize->Collect(programSize > Max<i64>() ? Max<i64>() : static_cast<i64>(programSize));
+    QueryMaxShardProgramSize->Collect(programSize);
 }
 
 void TKqpCountersBase::ReportResponseStatus(ui64 responseSize, Ydb::StatusIds::StatusCode ydbStatus) {


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

currently all [0,1) value go to 0.5ms bucket since due to round down all these numbers become 0ms
[1, 2) go to 1ms bucket and so on. Fix this error by using double Collect function available in THistogram

### Changelog category <!-- remove all except one -->

* Bugfix 

### Description for reviewers <!-- (optional) description for those who read this PR -->

...
