### PR TITLE
Used default value of EnableSystemViews feature flag in SchemeShard ut tests

### DIFF
--- a/ydb/core/tx/schemeshard/ut_base/ut_base.cpp
+++ b/ydb/core/tx/schemeshard/ut_base/ut_base.cpp
@@ -6674,7 +6674,7 @@ Y_UNIT_TEST_SUITE(TSchemeShardTest) {
         env.TestWaitNotification(runtime, txId);
         TestDescribeResult(DescribePath(runtime, "/MyRoot/PQGroup5", true), {
             NLs::CheckPartCount("PQGroup5", 2, 1, 2, 2),
-        });        
+        });
     }
 
     Y_UNIT_TEST(AlterPersQueueGroupWithKeySchema) {
@@ -9533,7 +9533,7 @@ Y_UNIT_TEST_SUITE(TSchemeShardTest) {
         // case 2: add partition
         TestAlterSolomon(runtime, ++txId, "/MyRoot", R"(
             Name: "Solomon"
-            PartitionCount: 2    
+            PartitionCount: 2
             StorageConfig {
                 Channel {
                     PreferredPoolKind: "pool-kind-1"
@@ -10079,7 +10079,7 @@ Y_UNIT_TEST_SUITE(TSchemeShardTest) {
 
     Y_UNIT_TEST(RejectSystemViewPath) {
         TTestBasicRuntime runtime;
-        TTestEnv env(runtime, 4, true, &CreateFlatTxSchemeShard, true);
+        TTestEnv env(runtime, TTestEnvOptions().EnableSystemViews(true));
         ui64 txId = 100;
 
         TestCreateTable(runtime, ++txId, "/MyRoot",

--- a/ydb/core/tx/schemeshard/ut_data_erasure/ut_data_erasure.cpp
+++ b/ydb/core/tx/schemeshard/ut_data_erasure/ut_data_erasure.cpp
@@ -16,7 +16,6 @@ namespace {
         TTestEnv env(runtime, TTestEnvOptions()
             .NChannels(4)
             .EnablePipeRetries(true)
-            .EnableSystemViews(false)
             .DSProxies(dsProxies));
 
         runtime.SetLogPriority(NKikimrServices::TX_PROXY, NLog::PRI_DEBUG);

--- a/ydb/core/tx/schemeshard/ut_helpers/test_env.cpp
+++ b/ydb/core/tx/schemeshard/ut_helpers/test_env.cpp
@@ -592,7 +592,7 @@ NSchemeShardUT_Private::TTestEnv::TTestEnv(TTestActorRuntime& runtime, const TTe
     app.FeatureFlags.SetEnableTableDatetime64(true);
     app.FeatureFlags.SetEnableVectorIndex(true);
     app.FeatureFlags.SetEnableColumnStore(true);
-    app.FeatureFlags.SetEnableStrictAclCheck(opts.EnableStrictAclCheck_);    
+    app.FeatureFlags.SetEnableStrictAclCheck(opts.EnableStrictAclCheck_);
     app.SetEnableMoveIndex(opts.EnableMoveIndex_);
     app.SetEnableChangefeedInitialScan(opts.EnableChangefeedInitialScan_);
     app.SetEnableNotNullDataColumns(opts.EnableNotNullDataColumns_);
@@ -713,11 +713,10 @@ NSchemeShardUT_Private::TTestEnv::TTestEnv(TTestActorRuntime& runtime, const TTe
 }
 
 NSchemeShardUT_Private::TTestEnv::TTestEnv(TTestActorRuntime &runtime, ui32 nchannels, bool enablePipeRetries,
-        NSchemeShardUT_Private::TTestEnv::TSchemeShardFactory ssFactory, bool enableSystemViews)
+        NSchemeShardUT_Private::TTestEnv::TSchemeShardFactory ssFactory)
     : TTestEnv(runtime, TTestEnvOptions()
         .NChannels(nchannels)
-        .EnablePipeRetries(enablePipeRetries)
-        .EnableSystemViews(enableSystemViews), ssFactory)
+        .EnablePipeRetries(enablePipeRetries), ssFactory)
 {
 }
 

--- a/ydb/core/tx/schemeshard/ut_helpers/test_env.h
+++ b/ydb/core/tx/schemeshard/ut_helpers/test_env.h
@@ -101,7 +101,7 @@ namespace NSchemeShardUT_Private {
         static bool ENABLE_SCHEMESHARD_LOG;
 
         TTestEnv(TTestActorRuntime& runtime, ui32 nchannels = 4, bool enablePipeRetries = true,
-            TSchemeShardFactory ssFactory = &CreateFlatTxSchemeShard, bool enableSystemViews = false);
+            TSchemeShardFactory ssFactory = &CreateFlatTxSchemeShard);
         TTestEnv(TTestActorRuntime& runtime, const TTestEnvOptions& opts,
             TSchemeShardFactory ssFactory = &CreateFlatTxSchemeShard, std::shared_ptr<NKikimr::NDataShard::IExportFactory> dsExportFactory = {});
 


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

Updated default behavior of SchemeShard test environment.
Used default value of EnableSystemViews feature flag instead of redefined in the constructor.

### Changelog category <!-- remove all except one -->

* Not for changelog (changelog entry is not required)

### Description for reviewers <!-- (optional) description for those who read this PR -->
