### PR TITLE
Support Min/Max aggregation for partitioned stats (i.e. First/Last message timestamps)

### DIFF
--- a/ydb/core/kqp/executer_actor/kqp_executer_stats.h
+++ b/ydb/core/kqp/executer_actor/kqp_executer_stats.h
@@ -52,7 +52,15 @@ struct TPartitionedStats : public TTimeSeriesStats {
 
     void ResizeByTasks(ui32 taskCount);
     void ResizeByParts(ui32 partCount, ui32 taskCount);
-    void SetNonZero(ui32 taskIndex, ui32 partIndex, ui64 value, bool recordTimeSeries);
+    void SetNonZeroAggSum(ui32 taskIndex, ui32 partIndex, ui64 value, bool recordTimeSeries);
+    void SetNonZeroAggMin(ui32 taskIndex, ui32 partIndex, ui64 value, bool recordTimeSeries);
+    void SetNonZeroAggMax(ui32 taskIndex, ui32 partIndex, ui64 value, bool recordTimeSeries);
+};
+
+enum EPartitionedAggKind {
+    PartitionedAggSum,
+    PartitionedAggMin,
+    PartitionedAggMax,
 };
 
 struct TTimeMultiSeriesStats {
@@ -60,7 +68,7 @@ struct TTimeMultiSeriesStats {
     ui32 TaskCount = 0;
     ui32 PartCount = 0;
 
-    void SetNonZero(TPartitionedStats& stats, ui32 taskIndex, const TString& key, ui64 value, bool recordTimeSeries);
+    void SetNonZero(TPartitionedStats& stats, ui32 taskIndex, const TString& key, ui64 value, bool recordTimeSeries, EPartitionedAggKind aggKind);
 };
 
 struct TExternalStats : public TTimeMultiSeriesStats {


### PR DESCRIPTION
When we agggregate partitioned statistics (from different parts, i.e. when single shards send data through several read actors) we should support different aggregations functions, i.e.:

- FirstMessageMs should be aggregated by MIN
- LastMessageMs should be aggregated by MAX

Before this change, all aggregations were processed with SUM and result incorrect statistics

P.S. Also minor fix to assign HistorySampleCount and restore time series recordings is included