### PR TITLE
[WIP] http actor: add breaking tests

### DIFF
--- a/ydb/library/actors/http/http_ut.cpp
+++ b/ydb/library/actors/http/http_ut.cpp
@@ -351,7 +351,12 @@ Y_UNIT_TEST_SUITE(HttpProxy) {
         UNIT_ASSERT_STRINGS_EQUAL(httpResponseRedirect->Message, "Found");
         UNIT_ASSERT_STRING_CONTAINS(httpResponseRedirect->Headers, "Set-Cookie: cookie1=123456;");
         UNIT_ASSERT_STRING_CONTAINS(httpResponseRedirect->Headers, "Location: http://www.yandex.ru/data/url");
+    }
 
+    Y_UNIT_TEST(BasicRenderBigOutgoingResponse) {
+        NHttp::THttpIncomingRequestPtr request = new NHttp::THttpIncomingRequest();
+        EatWholeString(request, "GET /test HTTP/1.1\r\nHost: test\r\nSome-Header: 32344\r\n\r\n");
+        // There are limit on header size; first, try to keep inside limit
         for (ui32 testSize = NHttp::THttpOutgoingResponse::BUFFER_SIZE - 128; testSize < NHttp::THttpOutgoingResponse::BUFFER_SIZE + 32; ++testSize) {
             Cerr << testSize << Endl;
             NHttp::THttpOutgoingResponsePtr httpResponseBig = request->CreateIncompleteResponse("200", "OK");
@@ -360,6 +365,8 @@ Y_UNIT_TEST_SUITE(HttpProxy) {
                 TString value(maxHeaderSize/2, 'A');
                 httpResponseBig->Set("Header"+ToString(i), value);
             }
+            // ... and add message on the boundary
+            // (this used to fail before 7f87055b80b505431a9d7d56f94d67c9e0523b5d)
             TString value(testSize - httpResponseBig->Headers.size(), 'A');
             httpResponseBig->Set("Set-Cookie", "cookie1=" + value + ";");
             httpResponseBig->Set("Content-Type", "application/octet-stream");
@@ -369,11 +376,14 @@ Y_UNIT_TEST_SUITE(HttpProxy) {
             Cerr << (const void *) httpResponseBig->ContentType.Data() << Endl;
             Cerr << (const void *) (httpResponseBig->Headers.Data() + httpResponseBig->ContentType.Size()) << Endl;
             Cerr << (const void *) (httpResponseBig->ContentType.Data() + httpResponseBig->ContentType.Size()) << Endl;
+            // verify that ContentType is within boundary
+            // (note that comparing pointers that may belong to different allocations is UB, hence uintptr_t)
             UNIT_ASSERT_GE((uintptr_t)httpResponseBig->ContentType.Data(), (uintptr_t)(httpResponseBig->Headers.Data()));
             UNIT_ASSERT_LE((uintptr_t)httpResponseBig->ContentType.Data() + httpResponseBig->ContentType.Size(), (uintptr_t)httpResponseBig->Headers.Data() + httpResponseBig->Headers.Size());
             UNIT_ASSERT_STRINGS_EQUAL(httpResponseBig->ContentType, "application/octet-stream");
         }
 
+        // Then try with Set<>() instead of Set()
         for (ui32 testSize = NHttp::THttpOutgoingResponse::BUFFER_SIZE - 128; testSize < NHttp::THttpOutgoingResponse::BUFFER_SIZE + 32; ++testSize) {
             Cerr << testSize << Endl;
             NHttp::THttpOutgoingResponsePtr httpResponseBig = request->CreateIncompleteResponse("200", "OK");
@@ -396,6 +406,7 @@ Y_UNIT_TEST_SUITE(HttpProxy) {
             UNIT_ASSERT_STRINGS_EQUAL(httpResponseBig->ContentType, "application/octet-stream");
         }
 
+        // ... and finally cross MaxHeaderSize
         for (ui32 testSize = NHttp::THttpOutgoingResponse::BUFFER_SIZE - 256; testSize < NHttp::THttpOutgoingResponse::BUFFER_SIZE + 32; ++testSize) {
             Cerr << testSize << Endl;
             NHttp::THttpOutgoingResponsePtr httpResponseBig = request->CreateIncompleteResponse("200", "OK");


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

...

### Changelog category <!-- remove all except one -->

* Not for changelog (changelog entry is not required)

### Description for reviewers <!-- (optional) description for those who read this PR -->

Currently ONLY tests that trigger failures present.
There are several modes of failures:
- [x] partially formatted header may break Reparse (fixed by 7f87055b80b )
- [ ]  same bug in `Set<&Foo>(value)` is not fixed;
- [ ]  it is possible to produce unparseable headers;
- [ ] most likely there are more; code looks *extremely* fragile