### PR TITLE
Fix deprecated TCMalloc API usage

### DIFF
--- a/ydb/core/mon_alloc/tcmalloc.cpp
+++ b/ydb/core/mon_alloc/tcmalloc.cpp
@@ -586,7 +586,7 @@ class TTcMallocMonitor : public IAllocMonitor {
         TControlWrapper PageCacheReleaseRate;
 
         TControls()
-            : ProfileSamplingRate(tcmalloc::MallocExtension::GetProfileSamplingRate(),
+            : ProfileSamplingRate(tcmalloc::MallocExtension::GetProfileSamplingInterval(),
                 64 << 10, MaxSamplingRate)
             , GuardedSamplingRate(MaxSamplingRate,
                 64 << 10, MaxSamplingRate)
@@ -650,12 +650,12 @@ private:
     }
 
     void UpdateControls() {
-        tcmalloc::MallocExtension::SetProfileSamplingRate(Controls.ProfileSamplingRate);
+        tcmalloc::MallocExtension::SetProfileSamplingInterval(Controls.ProfileSamplingRate);
 
         if (Controls.GuardedSamplingRate != TControls::MaxSamplingRate) {
             tcmalloc::MallocExtension::ActivateGuardedSampling();
         }
-        tcmalloc::MallocExtension::SetGuardedSamplingRate(Controls.GuardedSamplingRate);
+        tcmalloc::MallocExtension::SetGuardedSamplingInterval(Controls.GuardedSamplingRate);
     }
 
     void ReleaseMemoryIfNecessary(TDuration interval) {


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

N/A

### Changelog category <!-- remove all except one -->

* Not for changelog (changelog entry is not required)

### Description for reviewers <!-- (optional) description for those who read this PR -->

TCMalloc renamed several functions from `XXXRate` to `XXXInterval`. This patch migrates known usages within YDB code.

