### PR TITLE
Refactoring in `ydb tools restore` code

### DIFF
--- a/ydb/public/lib/ydb_cli/dump/restore_impl.cpp
+++ b/ydb/public/lib/ydb_cli/dump/restore_impl.cpp
@@ -793,7 +793,7 @@ TRestoreResult TRestoreClient::RestoreDatabaseImpl(const TString& fsPath, const 
     }
 
     if (settings.WithContent_) {
-        auto restoreResult = RestoreFolder(fsPath, dbPath, {}, {});
+        auto restoreResult = RestoreFolder(fsPath, dbPath, {}, { { dbPath, ESchemeEntryType::SubDomain } });
         if (auto result = DelayedRestoreManager.RestoreDelayed(); !result.IsSuccess()) {
             restoreResult = result;
         }

--- a/ydb/public/lib/ydb_cli/dump/restore_impl.cpp
+++ b/ydb/public/lib/ydb_cli/dump/restore_impl.cpp
@@ -17,8 +17,10 @@
 #include <ydb/public/lib/ydb_cli/dump/util/view_utils.h>
 #include <yql/essentials/public/issue/yql_issue.h>
 
+#include <library/cpp/json/json_writer.h>
 #include <library/cpp/threading/future/core/future.h>
 
+#include <util/folder/iterator.h>
 #include <util/generic/deque.h>
 #include <util/generic/guid.h>
 #include <util/generic/hash.h>
@@ -33,19 +35,18 @@
 
 #include <google/protobuf/text_format.h>
 
-#include <format>
-
 namespace NYdb::NDump {
 
 using namespace NCms;
 using namespace NConsoleClient;
 using namespace NImport;
 using namespace NOperation;
+using namespace NPrivate;
 using namespace NRateLimiter;
 using namespace NScheme;
 using namespace NTable;
-using namespace NTopic;
 using namespace NThreading;
+using namespace NTopic;
 
 extern const char DOC_API_TABLE_VERSION_ATTR[] = "__document_api_version";
 extern const char DOC_API_REQUEST_TYPE[] = "_document_api_request";
@@ -455,13 +456,14 @@ TRestoreResult TRestoreClient::Restore(const TString& fsPath, const TString& dbP
         return Result<TRestoreResult>(dbBasePath, EStatus::SCHEME_ERROR, "Can not list existing directory");
     }
 
-    THashSet<TString> oldEntries;
+    THashMap<TString, ESchemeEntryType> oldEntries;
     for (const auto& entry : oldDirectoryList.Entries) {
-        oldEntries.insert(TString{entry.Name});
+        oldEntries.emplace(TString{entry.Name}, entry.Type);
     }
 
     // restore
-    auto restoreResult = RestoreFolder(fsPath, dbPath, "", settings, oldEntries);
+    auto restoreResult = Result<TRestoreResult>();
+    restoreResult = RestoreFolder(fsPath, dbPath, settings, oldEntries);
     if (auto result = DelayedRestoreManager.RestoreDelayed(); !result.IsSuccess()) {
         restoreResult = result;
     }
@@ -791,7 +793,7 @@ TRestoreResult TRestoreClient::RestoreDatabaseImpl(const TString& fsPath, const 
     }
 
     if (settings.WithContent_) {
-        auto restoreResult = RestoreFolder(fsPath, dbPath, "", {}, {});
+        auto restoreResult = RestoreFolder(fsPath, dbPath, {}, {});
         if (auto result = DelayedRestoreManager.RestoreDelayed(); !result.IsSuccess()) {
             restoreResult = result;
         }
@@ -883,109 +885,156 @@ TRestoreResult TRestoreClient::RestoreCluster(const TString& fsPath, const TRest
     return result;
 }
 
+namespace {
+
+    TVector<ESchemeEntryType> GetSchemeEntryTypes(const TFsPath& path) {
+        TVector<ESchemeEntryType> types;
+
+        if (IsFileExists(path.Child(NFiles::TableScheme().FileName))) {
+            types.emplace_back(ESchemeEntryType::Table);
+        }
+
+        if (IsFileExists(path.Child(NFiles::CreateView().FileName))) {
+            types.emplace_back(ESchemeEntryType::View);
+        }
+
+        if (IsFileExists(path.Child(NFiles::CreateTopic().FileName))) {
+            types.emplace_back(ESchemeEntryType::Topic);
+        }
+
+        if (IsFileExists(path.Child(NFiles::CreateCoordinationNode().FileName))) {
+            types.emplace_back(ESchemeEntryType::CoordinationNode);
+        }
+
+        if (IsFileExists(path.Child(NFiles::CreateAsyncReplication().FileName))) {
+            types.emplace_back(ESchemeEntryType::Replication);
+        }
+
+        if (IsFileExists(path.Child(NFiles::CreateExternalDataSource().FileName))) {
+            types.emplace_back(ESchemeEntryType::ExternalDataSource);
+        }
+
+        if (IsFileExists(path.Child(NFiles::CreateExternalTable().FileName))) {
+            types.emplace_back(ESchemeEntryType::ExternalTable);
+        }
+
+        if (IsFileExists(path.Child(NFiles::Empty().FileName))) {
+            types.emplace_back(ESchemeEntryType::Directory);
+        }
+
+        return types;
+    }
+
+    TString GetDbPath(const TFsPath& fsPath, const TFsPath& fsBackupRoot, const TString& dbRestoreRoot) {
+        return JoinFsPaths(dbRestoreRoot, fsPath.RelativeTo(fsBackupRoot));
+    }
+
+    TRestoreResult ListBackupEntries(const TFsPath& fsBackupRoot, const TString& dbRestoreRoot, TVector<TFsBackupEntry>& backupEntries) {
+        TDirIterator backupIterator(fsBackupRoot);
+        for (auto* file = backupIterator.Next(); file; file = backupIterator.Next()) {
+            if (file->fts_info == FTS_D) {
+                TFsPath fsPath(file->fts_path);
+
+                if (fsPath.Child(NFiles::Incomplete().FileName).Exists()) {
+                    return Result<TRestoreResult>(EStatus::BAD_REQUEST,
+                        TStringBuilder() << "There is incomplete file in folder: " << fsPath.GetPath().Quote()
+                    );
+                }
+
+                const auto types = GetSchemeEntryTypes(fsPath);
+
+                if (types.empty()) {
+                    TVector<TFsPath> children;
+                    if (fsPath.List(children); children.empty()) {
+                        return Result<TRestoreResult>(fsPath, EStatus::BAD_REQUEST,
+                            TStringBuilder() << "Empty folder without the special \"" << NFiles::Empty().FileName << "\" marker file."
+                        );
+                    }
+                    // intermediate folder
+                    backupEntries.emplace_back(fsPath, GetDbPath(fsPath, fsBackupRoot, dbRestoreRoot), ESchemeEntryType::Directory);
+                } else if (types.size() == 1) {
+                    backupEntries.emplace_back(fsPath, GetDbPath(fsPath, fsBackupRoot, dbRestoreRoot), types.front());
+                    if (types.front() != ESchemeEntryType::Directory) {
+                        backupIterator.Skip(file);
+                    }
+                } else {
+                    return Result<TRestoreResult>(fsPath, EStatus::BAD_REQUEST,
+                        "A single backup folder cannot contain multiple scheme object definitions."
+                    );
+                }
+            }
+        }
+
+        return Result<TRestoreResult>();
+    }
+
+}
+
 TRestoreResult TRestoreClient::RestoreFolder(
-        const TFsPath& fsPath,
+        const TFsPath& fsBackupRoot,
         const TString& dbRestoreRoot,
-        const TString& dbPathRelativeToRestoreRoot,
         const TRestoreSettings& settings,
-        const THashSet<TString>& oldEntries)
+        const THashMap<TString, ESchemeEntryType>& oldEntries)
 {
-    const TString dbPath = dbRestoreRoot + dbPathRelativeToRestoreRoot;
-
-    LOG_D("Restore folder " << fsPath.GetPath().Quote() << " to " << dbPath.Quote());
-
-    if (!fsPath) {
-        return Result<TRestoreResult>(EStatus::BAD_REQUEST, "Folder is not specified");
+    TVector<TFsBackupEntry> backupEntries;
+    if (auto result = ListBackupEntries(fsBackupRoot, dbRestoreRoot, backupEntries); !result.IsSuccess()) {
+        return result;
     }
+    LOG_D("List of entries in the backup: [ " << JoinSeq(", ",
+        std::views::transform(backupEntries,
+            [](const TFsBackupEntry& entry) {
+                NJson::TJsonMap json;
+                json["type"] = TStringBuilder() << entry.Type;
+                json["path"] = entry.FsPath.GetPath();
+                return NJson::WriteJson(json, false);
+            }
+        )) << " ]"
+    );
 
-    if (!fsPath.Exists()) {
-        return Result<TRestoreResult>(EStatus::BAD_REQUEST,
-            TStringBuilder() << "Specified folder does not exist: " << fsPath.GetPath());
-    }
-
-    if (!fsPath.IsDirectory()) {
-        return Result<TRestoreResult>(EStatus::BAD_REQUEST,
-            TStringBuilder() << "Specified folder is not a directory: " << fsPath.GetPath());
-    }
-
-    if (auto error = ErrorOnIncomplete(fsPath)) {
-        return *error;
-    }
-
-    const TString objectDbPath = Join('/', dbPath, fsPath.GetName());
-
-    if (IsFileExists(fsPath.Child(NFiles::TableScheme().FileName))) {
-        return RestoreTable(fsPath, objectDbPath, settings, oldEntries.contains(objectDbPath));
-    }
-
-    if (IsFileExists(fsPath.Child(NFiles::CreateView().FileName))) {
-        DelayedRestoreManager.Add(ESchemeEntryType::View, fsPath, dbRestoreRoot, dbPathRelativeToRestoreRoot, settings, oldEntries.contains(objectDbPath));
-        return Result<TRestoreResult>();
-    }
-
-    if (IsFileExists(fsPath.Child(NFiles::CreateTopic().FileName))) {
-        return RestoreTopic(fsPath, objectDbPath, settings, oldEntries.contains(objectDbPath));
-    }
-
-    if (IsFileExists(fsPath.Child(NFiles::CreateCoordinationNode().FileName))) {
-        return RestoreCoordinationNode(fsPath, objectDbPath, settings, oldEntries.contains(objectDbPath));
-    }
-
-    if (IsFileExists(fsPath.Child(NFiles::CreateAsyncReplication().FileName))) {
-        return RestoreReplication(fsPath, dbRestoreRoot, dbPathRelativeToRestoreRoot, settings, oldEntries.contains(objectDbPath));
-    }
-
-    if (IsFileExists(fsPath.Child(NFiles::CreateExternalDataSource().FileName))) {
-        return RestoreExternalDataSource(fsPath, objectDbPath, settings, oldEntries.contains(objectDbPath));
-    }
-
-    if (IsFileExists(fsPath.Child(NFiles::CreateExternalTable().FileName))) {
-        DelayedRestoreManager.Add(ESchemeEntryType::ExternalTable, fsPath, objectDbPath, settings, oldEntries.contains(objectDbPath));
-        return Result<TRestoreResult>();
-    }
-
-    if (IsFileExists(fsPath.Child(NFiles::Empty().FileName))) {
-        return RestoreEmptyDir(fsPath, objectDbPath, settings, oldEntries.contains(objectDbPath));
-    }
-
-    TMaybe<TRestoreResult> result;
-
-    TVector<TFsPath> children;
-    fsPath.List(children);
-    for (const auto& child : children) {
-        const TString childDbPath = Join('/', dbPath, child.GetName());
-        if (IsFileExists(child.Child(NFiles::TableScheme().FileName))) {
-            result = RestoreTable(child, childDbPath, settings, oldEntries.contains(childDbPath));
-        } else if (IsFileExists(child.Child(NFiles::Empty().FileName))) {
-            result = RestoreEmptyDir(child, childDbPath, settings, oldEntries.contains(childDbPath));
-        } else if (IsFileExists(child.Child(NFiles::CreateView().FileName))) {
-            DelayedRestoreManager.Add(ESchemeEntryType::View, child, dbRestoreRoot, Join('/', dbPathRelativeToRestoreRoot, child.GetName()), settings, oldEntries.contains(childDbPath));
-        } else if (IsFileExists(child.Child(NFiles::CreateTopic().FileName))) {
-            result = RestoreTopic(child, childDbPath, settings, oldEntries.contains(childDbPath));
-        } else if (IsFileExists(child.Child(NFiles::CreateCoordinationNode().FileName))) {
-            result = RestoreCoordinationNode(child, childDbPath, settings, oldEntries.contains(childDbPath));
-        } else if (IsFileExists(child.Child(NFiles::CreateAsyncReplication().FileName))) {
-            result = RestoreReplication(child, dbRestoreRoot, Join('/', dbPathRelativeToRestoreRoot, child.GetName()), settings, oldEntries.contains(childDbPath));
-        } else if (IsFileExists(child.Child(NFiles::CreateExternalDataSource().FileName))) {
-            result = RestoreExternalDataSource(child, childDbPath, settings, oldEntries.contains(childDbPath));
-        } else if (IsFileExists(child.Child(NFiles::CreateExternalTable().FileName))) {
-            DelayedRestoreManager.Add(ESchemeEntryType::ExternalTable, child, childDbPath, settings, oldEntries.contains(childDbPath));
-        } else if (child.IsDirectory()) {
-            result = RestoreFolder(child, dbRestoreRoot, Join('/', dbPathRelativeToRestoreRoot, child.GetName()), settings, oldEntries);
+    for (const auto& [fsPath, dbPath, type] : backupEntries) {
+        if (type == ESchemeEntryType::Directory && oldEntries.contains(dbPath)) {
+            continue;
         }
-
-        if (result.Defined() && !result->IsSuccess()) {
-            return *result;
+        Y_ENSURE(dbPath.StartsWith(dbRestoreRoot), "dbPath must be built by appending a relative path to dbRestoreRoot");
+        if (auto result = Restore(type, fsPath, dbRestoreRoot, dbPath.substr(dbRestoreRoot.size()), settings, oldEntries.contains(dbPath), true); !result.IsSuccess()) {
+            return result;
         }
     }
 
-    const bool dbPathExists = oldEntries.contains(dbPath);
-    if (!result.Defined() && !dbPathExists) {
-        // This situation arises when all the children of the file system path are scheme objects with a delayed restoration.
-        return RestoreEmptyDir(fsPath, dbPath, settings, dbPathExists);
+    return Result<TRestoreResult>();
+}
+
+TRestoreResult TRestoreClient::Restore(NScheme::ESchemeEntryType type, const TFsPath& fsPath, const TString& dbRestoreRoot, const TString& dbPathRelativeToRestoreRoot, const TRestoreSettings& settings, bool isAlreadyExisting, bool delay) {
+    const auto dbPath = dbRestoreRoot + dbPathRelativeToRestoreRoot;
+    switch (type) {
+        case ESchemeEntryType::Directory:
+            return RestoreEmptyDir(fsPath, dbPath, settings, isAlreadyExisting);
+        case ESchemeEntryType::Table:
+            return RestoreTable(fsPath, dbPath, settings, isAlreadyExisting);
+        case ESchemeEntryType::Topic:
+            return RestoreTopic(fsPath, dbPath, settings, isAlreadyExisting);
+        case ESchemeEntryType::View:
+            if (delay) {
+                DelayedRestoreManager.Add(ESchemeEntryType::View, fsPath, dbRestoreRoot, dbPathRelativeToRestoreRoot, settings, isAlreadyExisting);
+                return Result<TRestoreResult>();
+            }
+            return RestoreView(fsPath, dbRestoreRoot, dbPathRelativeToRestoreRoot, settings, isAlreadyExisting);
+        case ESchemeEntryType::CoordinationNode:
+            return RestoreCoordinationNode(fsPath, dbPath, settings, isAlreadyExisting);
+        case ESchemeEntryType::ExternalTable:
+            if (delay) {
+                DelayedRestoreManager.Add(ESchemeEntryType::ExternalTable, fsPath, dbPath, settings, isAlreadyExisting);
+                return Result<TRestoreResult>();
+            }
+            return RestoreExternalTable(fsPath, dbPath, settings, isAlreadyExisting);
+        case ESchemeEntryType::ExternalDataSource:
+            return RestoreExternalDataSource(fsPath, dbPath, settings, isAlreadyExisting);
+        case ESchemeEntryType::Replication:
+            return RestoreReplication(fsPath, dbRestoreRoot, dbPathRelativeToRestoreRoot, settings, isAlreadyExisting);
+        default:
+            ythrow TBadArgumentException() << "Attempting to restore an unexpected object from: " << fsPath << ", type: " << type;
     }
 
-    return RestorePermissions(fsPath, dbPath, settings, dbPathExists);
 }
 
 TRestoreResult TRestoreClient::RestoreView(

--- a/ydb/public/lib/ydb_cli/dump/restore_impl.cpp
+++ b/ydb/public/lib/ydb_cli/dump/restore_impl.cpp
@@ -1046,10 +1046,6 @@ TRestoreResult TRestoreClient::RestoreView(
 {
     LOG_D("Process " << fsPath.GetPath().Quote());
 
-    if (auto error = ErrorOnIncomplete(fsPath)) {
-        return *error;
-    }
-
     const TString dbPath = dbRestoreRoot + dbPathRelativeToRestoreRoot;
     LOG_I("Restore view " << fsPath.GetPath().Quote() << " to " << dbPath.Quote());
 
@@ -1090,10 +1086,6 @@ TRestoreResult TRestoreClient::RestoreTopic(
     bool isAlreadyExisting)
 {
     LOG_D("Process " << fsPath.GetPath().Quote());
-
-    if (auto error = ErrorOnIncomplete(fsPath)) {
-        return *error;
-    }
 
     LOG_I("Restore topic " << fsPath.GetPath().Quote() << " to " << dbPath.Quote());
 
@@ -1147,10 +1139,6 @@ TRestoreResult TRestoreClient::RestoreReplication(
 {
     LOG_D("Process " << fsPath.GetPath().Quote());
 
-    if (auto error = ErrorOnIncomplete(fsPath)) {
-        return *error;
-    }
-
     const TString dbPath = dbRestoreRoot + dbPathRelativeToRestoreRoot;
     LOG_I("Restore async replication " << fsPath.GetPath().Quote() << " to " << dbPath.Quote());
 
@@ -1192,10 +1180,6 @@ TRestoreResult TRestoreClient::RestoreRateLimiter(
     const TString& rateLimiterPath)
 {
     LOG_D("Process " << fsPath.GetPath().Quote());
-
-    if (auto error = ErrorOnIncomplete(fsPath)) {
-        return *error;
-    }
 
     const auto request = ReadRateLimiterCreationRequest(fsPath, Log.get());
     auto result = CreateRateLimiter(RateLimiterClient, coordinationNodePath, rateLimiterPath, request);
@@ -1250,10 +1234,6 @@ TRestoreResult TRestoreClient::RestoreCoordinationNode(
 {
     LOG_D("Process " << fsPath.GetPath().Quote());
 
-    if (auto error = ErrorOnIncomplete(fsPath)) {
-        return *error;
-    }
-
     LOG_I("Restore coordination node " << fsPath.GetPath().Quote() << " to " << dbPath.Quote());
 
     if (settings.DryRun_) {
@@ -1283,10 +1263,6 @@ TRestoreResult TRestoreClient::RestoreExternalDataSource(
     bool isAlreadyExisting)
 {
     LOG_D("Process " << fsPath.GetPath().Quote());
-
-    if (auto error = ErrorOnIncomplete(fsPath)) {
-        return *error;
-    }
 
     LOG_I("Restore external data source " << fsPath.GetPath().Quote() << " to " << dbPath.Quote());
 
@@ -1327,10 +1303,6 @@ TRestoreResult TRestoreClient::RestoreExternalTable(
 {
     LOG_D("Process " << fsPath.GetPath().Quote());
 
-    if (auto error = ErrorOnIncomplete(fsPath)) {
-        return *error;
-    }
-
     LOG_I("Restore external table " << fsPath.GetPath().Quote() << " to " << dbPath.Quote());
 
     if (settings.DryRun_) {
@@ -1364,10 +1336,6 @@ TRestoreResult TRestoreClient::RestoreTable(
         bool isAlreadyExisting)
 {
     LOG_D("Process " << fsPath.GetPath().Quote());
-
-    if (auto error = ErrorOnIncomplete(fsPath)) {
-        return *error;
-    }
 
     auto scheme = ReadTableScheme(fsPath, Log.get());
     auto dumpedDesc = TableDescriptionFromProto(scheme);
@@ -1720,9 +1688,6 @@ TRestoreResult TRestoreClient::RestoreIndexes(const TString& dbPath, const TTabl
 
 TRestoreResult TRestoreClient::RestoreChangefeeds(const TFsPath& fsPath, const TString& dbPath) {
     LOG_D("Process " << fsPath.GetPath().Quote());
-    if (auto error = ErrorOnIncomplete(fsPath)) {
-        return *error;
-    }
 
     auto changefeedProto = ReadChangefeedDescription(fsPath, Log.get());
     auto topicProto = ReadTopicDescription(fsPath, Log.get());
@@ -1794,10 +1759,6 @@ TRestoreResult TRestoreClient::RestorePermissions(
         const TRestoreSettings& settings,
         bool isAlreadyExisting)
 {
-    if (auto error = ErrorOnIncomplete(fsPath)) {
-        return *error;
-    }
-
     if (!settings.RestoreACL_) {
         return Result<TRestoreResult>();
     }
@@ -1816,10 +1777,6 @@ TRestoreResult TRestoreClient::RestoreEmptyDir(
         bool isAlreadyExisting)
 {
     LOG_D("Process " << fsPath.GetPath().Quote());
-
-    if (auto error = ErrorOnIncomplete(fsPath)) {
-        return *error;
-    }
 
     LOG_I("Restore empty directory " << fsPath.GetPath().Quote() << " to " << dbPath.Quote());
 

--- a/ydb/public/lib/ydb_cli/dump/restore_impl.h
+++ b/ydb/public/lib/ydb_cli/dump/restore_impl.h
@@ -182,7 +182,12 @@ struct TFsBackupEntry {
     TString DbPath;
     NScheme::ESchemeEntryType Type;
 
-    TFsBackupEntry(const TFsPath& path, TString&& dbPath, NScheme::ESchemeEntryType type) : FsPath(path), DbPath(std::move(dbPath)), Type(type) {}
+    TFsBackupEntry(const TFsPath& path, TString&& dbPath, NScheme::ESchemeEntryType type)
+        : FsPath(path)
+        , DbPath(std::move(dbPath))
+        , Type(type)
+    {
+    }
 };
 
 } // NPrivate

--- a/ydb/public/lib/ydb_cli/dump/restore_impl.h
+++ b/ydb/public/lib/ydb_cli/dump/restore_impl.h
@@ -182,8 +182,8 @@ struct TFsBackupEntry {
     TString DbPath;
     NScheme::ESchemeEntryType Type;
 
-    TFsBackupEntry(const TFsPath& path, TString&& dbPath, NScheme::ESchemeEntryType type)
-        : FsPath(path)
+    TFsBackupEntry(const TFsPath& fsPath, TString&& dbPath, NScheme::ESchemeEntryType type)
+        : FsPath(fsPath)
         , DbPath(std::move(dbPath))
         , Type(type)
     {

--- a/ydb/public/lib/ydb_cli/dump/restore_impl.h
+++ b/ydb/public/lib/ydb_cli/dump/restore_impl.h
@@ -172,15 +172,23 @@ public:
     TRestoreResult RestoreDelayed();
 
     template <typename... Args>
-    void Add(NScheme::ESchemeEntryType type, Args&&... args) {
-        Calls.emplace_back(type, std::forward<Args>(args)...);
+    void Add(Args&&... args) {
+        Calls.emplace_back(std::forward<Args>(args)...);
     }
+};
+
+struct TFsBackupEntry {
+    TFsPath FsPath;
+    TString DbPath;
+    NScheme::ESchemeEntryType Type;
+
+    TFsBackupEntry(const TFsPath& path, TString&& dbPath, NScheme::ESchemeEntryType type) : FsPath(path), DbPath(std::move(dbPath)), Type(type) {}
 };
 
 } // NPrivate
 
 class TRestoreClient {
-    TRestoreResult RestoreFolder(const TFsPath& fsPath, const TString& dbRestoreRoot, const TString& dbPathRelativeToRestoreRoot, const TRestoreSettings& settings, const THashSet<TString>& oldEntries);
+    TRestoreResult RestoreFolder(const TFsPath& fsBackupRoot, const TString& dbRestoreRoot, const TRestoreSettings& settings, const THashMap<TString, NScheme::ESchemeEntryType>& oldEntries);
     TRestoreResult RestoreEmptyDir(const TFsPath& fsPath, const TString& dbPath, const TRestoreSettings& settings, bool isAlreadyExisting);
     TRestoreResult RestoreTable(const TFsPath& fsPath, const TString& dbPath, const TRestoreSettings& settings, bool isAlreadyExisting);
     TRestoreResult RestoreView(const TFsPath& fsPath, const TString& dbRestoreRoot, const TString& dbPathRelativeToRestoreRoot, const TRestoreSettings& settings, bool isAlreadyExisting);
@@ -220,6 +228,7 @@ class TRestoreClient {
         ui32 dataFilesCount);
 
     TRestoreResult CheckSecretExistence(const TString& secretName);
+    TRestoreResult Restore(NScheme::ESchemeEntryType type, const TFsPath& fsPath, const TString& dbRestoreRoot, const TString& dbPathRelativeToRestoreRoot, const TRestoreSettings& settings, bool isAlreadyExisting, bool delay);
 
 public:
     explicit TRestoreClient(const TDriver& driver, const std::shared_ptr<TLog>& log);

--- a/ydb/public/lib/ydb_cli/dump/util/util.cpp
+++ b/ydb/public/lib/ydb_cli/dump/util/util.cpp
@@ -1,6 +1,8 @@
 #include "util.h"
 
+#include <ydb/public/api/protos/ydb_table.pb.h>
 #include <ydb/public/lib/ydb_cli/common/retry_func.h>
+#include <ydb/public/sdk/cpp/include/ydb-cpp-sdk/client/proto/accessor.h>
 
 namespace NYdb::NDump {
 
@@ -21,6 +23,29 @@ TStatus DescribeTable(TTableClient& tableClient, const TString& path, TMaybe<TTa
     };
 
     return tableClient.RetryOperationSync(func, TRetryOperationSettings().Idempotent(true));
+}
+
+TStatus DescribeExternalDataSource(TTableClient& client, const TString& path, Ydb::Table::DescribeExternalDataSourceResult& out) {
+    auto status = client.RetryOperationSync([&](NTable::TSession session) {
+        auto result = session.DescribeExternalDataSource(path).ExtractValueSync();
+        if (result.IsSuccess()) {
+            out = TProtoAccessor::GetProto(result.GetExternalDataSourceDescription());
+        }
+        return result;
+    });
+    return status;
+}
+
+TStatus DescribeReplication(NReplication::TReplicationClient& client, const TString& path, TMaybe<NReplication::TReplicationDescription>& out) {
+    out.Clear();
+
+    auto status = NConsoleClient::RetryFunction([&]() {
+        return client.DescribeReplication(path).ExtractValueSync();
+    });
+    if (status.IsSuccess()) {
+        out = status.GetReplicationDescription();
+    }
+    return status;
 }
 
 TDescribePathResult DescribePath(TSchemeClient& schemeClient, const TString& path, const TDescribePathSettings& settings) {

--- a/ydb/public/lib/ydb_cli/dump/util/util.h
+++ b/ydb/public/lib/ydb_cli/dump/util/util.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <ydb/public/sdk/cpp/include/ydb-cpp-sdk/client/cms/cms.h>
+#include <ydb/public/sdk/cpp/include/ydb-cpp-sdk/client/draft/ydb_replication.h>
 #include <ydb/public/sdk/cpp/include/ydb-cpp-sdk/client/scheme/scheme.h>
 #include <ydb/public/sdk/cpp/include/ydb-cpp-sdk/client/table/table.h>
 #include <ydb/public/sdk/cpp/include/ydb-cpp-sdk/client/types/status/status.h>
@@ -41,6 +42,8 @@ inline TResult Result(const TString& path, TStatus&& status) {
 }
 
 TStatus DescribeTable(NTable::TTableClient& tableClient, const TString& path, TMaybe<NTable::TTableDescription>& out);
+TStatus DescribeExternalDataSource(NTable::TTableClient& tableClient, const TString& path, Ydb::Table::DescribeExternalDataSourceResult& out);
+TStatus DescribeReplication(NReplication::TReplicationClient& replicationClient, const TString& path, TMaybe<NReplication::TReplicationDescription>& out);
 
 NScheme::TDescribePathResult DescribePath(
     NScheme::TSchemeClient& schemeClient,

--- a/ydb/services/ydb/backup_ut/ydb_backup_ut.cpp
+++ b/ydb/services/ydb/backup_ut/ydb_backup_ut.cpp
@@ -1462,7 +1462,7 @@ void TestPrimitiveType(
 
 Y_UNIT_TEST_SUITE(BackupRestore) {
     auto CreateBackupLambda(const TDriver& driver, const TFsPath& fsPath, const TString& dbPath = "/Root") {
-        return [&]() {
+        return [=, &driver]() {
             NDump::TClient backupClient(driver);
             const auto result = backupClient.Dump(dbPath, fsPath, NDump::TDumpSettings().Database(dbPath));
             UNIT_ASSERT_C(result.IsSuccess(), result.GetIssues().ToString());
@@ -1470,7 +1470,7 @@ Y_UNIT_TEST_SUITE(BackupRestore) {
     }
 
     auto CreateRestoreLambda(const TDriver& driver, const TFsPath& fsPath, const TString& dbPath = "/Root") {
-        return [&]() {
+        return [=, &driver]() {
             NDump::TClient backupClient(driver);
             const auto result = backupClient.Restore(fsPath, dbPath);
             UNIT_ASSERT_C(result.IsSuccess(), result.GetIssues().ToString());
@@ -2369,7 +2369,7 @@ Y_UNIT_TEST_SUITE(BackupRestoreS3) {
     const TString DefaultS3Prefix = "";
 
     auto CreateBackupLambda(const TDriver& driver, ui16 s3Port, const TString& source = "/Root") {
-        return [&, s3Port]() {
+        return [=, &driver]() {
             const auto clientSettings = TCommonClientSettings().Database(source);
             TSchemeClient schemeClient(driver, clientSettings);
             NExport::TExportClient exportClient(driver, clientSettings);
@@ -2402,7 +2402,7 @@ Y_UNIT_TEST_SUITE(BackupRestoreS3) {
 
     // to do: implement source item list expansion
     auto CreateRestoreLambda(const TDriver& driver, ui16 s3Port, const TVector<TString>& sourceItems, const TString& destinationPrefix = "/Root") {
-        return [&, s3Port]() {
+        return [=, &driver]() {
             const auto clientSettings = TCommonClientSettings().Database(destinationPrefix);
             NImport::TImportClient importClient(driver, clientSettings);
             NOperation::TOperationClient operationClient(driver, clientSettings);


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

### Changelog category <!-- remove all except one -->

* Not for changelog (changelog entry is not required)

### Description for reviewers <!-- (optional) description for those who read this PR -->

Change the way we process the backup folder on disk:
- Previously we have restored the objects while traversing the backup folder.
- Currently we traverse the backup folder, collect all the necessary information about the scheme objects located in the backup folder and only then start to restore them.

This refactoring should simplify the code (at least it reduced code duplication in the RestoreFolder function) and allow us to implement the `--replace` option which requires prior knowledge of scheme objects in the backup.

Issues:
- https://github.com/ydb-platform/ydb/issues/15410
