### PR TITLE
Fix `ydb operation get` not working for running operations (#17001)

### DIFF
--- a/ydb/apps/ydb/CHANGELOG.md
+++ b/ydb/apps/ydb/CHANGELOG.md
@@ -1,3 +1,4 @@
+* Fix `ydb operation get` not working for running operations.
 * Improved `ydb import file` commands to support files with BOM (Byte Order Mark).
 * Brackets are now inserted in pairs in YDB CLI interactive mode
 * Added `--scale` option to `ydb workload tpch init` and `ydb workload tpcds init` commands. Sets the percentage of the benchmark's data size and workload to use, relative to full scale.

--- a/ydb/public/lib/ydb_cli/commands/ydb_service_operation.cpp
+++ b/ydb/public/lib/ydb_cli/commands/ydb_service_operation.cpp
@@ -18,15 +18,14 @@ namespace {
     template <typename T>
     int GetOperation(NOperation::TOperationClient& client, const TOperationId& id, EDataFormat format) {
         T operation = client.Get<T>(id).GetValueSync();
+        PrintOperation(operation, format);
+        if (!operation.Ready()) {
+            return EXIT_SUCCESS;
+        }
         switch (operation.Status().GetStatus()) {
         case EStatus::SUCCESS:
-            PrintOperation(operation, format);
             return EXIT_SUCCESS;
-        case EStatus::CANCELLED:
-            PrintOperation(operation, format);
-            return EXIT_FAILURE;
         default:
-            ThrowOnError(operation);
             return EXIT_FAILURE;
         }
     }


### PR DESCRIPTION
### Changelog entry

Fix `ydb operation get` not working for running operations (#17001)

### Changelog category

* Bugfix 

### Description for reviewers

For running operations, status is empty and ready is false, so the code explicitly skipped them and didn't print anything