### PR TITLE
Scheme cache sysview path type processing

### DIFF
--- a/ydb/core/protos/sys_view_types.proto
+++ b/ydb/core/protos/sys_view_types.proto
@@ -4,4 +4,36 @@ option java_package = "ru.yandex.kikimr.proto";
 
 enum ESysViewType {
     EPartitionStats = 1;
+    ENodes = 2;
+    ETopQueriesByDurationOneMinute = 3;
+    ETopQueriesByDurationOneHour = 4;
+    ETopQueriesByReadBytesOneMinute = 5;
+    ETopQueriesByReadBytesOneHour = 6;
+    ETopQueriesByCpuTimeOneMinute = 7;
+    ETopQueriesByCpuTimeOneHour = 8;
+    ETopQueriesByRequestUnitsOneMinute = 9;
+    ETopQueriesByRequestUnitsOneHour = 10;
+    EQuerySessions = 11;
+    EPDisks = 12;
+    EVSlots = 13;
+    EGroups = 14;
+    EStoragePools = 15;
+    EStorageStats = 16;
+    ETablets = 17;
+    EQueryMetricsOneMinute = 18;
+    ETopPartitionsByCpuOneMinute = 19;
+    ETopPartitionsByCpuOneHour = 20;
+    ETopPartitionsByTliOneMinute = 21;
+    ETopPartitionsByTliOneHour = 22;
+    EResourcePoolClassifiers = 23;
+    EResourcePools = 24;
+    EAuthUsers = 25;
+    EAuthGroups = 26;
+    EAuthGroupMembers = 27;
+    EAuthOwners = 28;
+    EAuthPermissions = 29;
+    EAuthEffectivePermissions = 30;
+    EPgTables = 31;
+    EInformationSchemaTables = 32;
+    EPgClass = 33;
 }

--- a/ydb/core/sys_view/common/schema.cpp
+++ b/ydb/core/sys_view/common/schema.cpp
@@ -3,6 +3,10 @@
 #include <ydb/core/base/appdata.h>
 #include <yql/essentials/parser/pg_catalog/catalog.h>
 
+namespace {
+    using NKikimrSysView::ESysViewType;
+}
+
 namespace NKikimr {
 namespace NSysView {
 
@@ -170,6 +174,11 @@ public:
         return view ? TMaybe<TSchema>(*view) : Nothing();
     }
 
+    TMaybe<TSchema> GetSystemViewSchema(ESysViewType viewType) const override final {
+        const TSchema* view = SystemViews.FindPtr(viewType);
+        return view ? TMaybe<TSchema>(*view) : Nothing();
+    }
+
     TVector<TString> GetSystemViewNames(ETarget target) const override {
         TVector<TString> result;
         switch (target) {
@@ -210,9 +219,10 @@ public:
 
 private:
     void RegisterPgTablesSystemViews() {
-        auto registerView = [&](TStringBuf tableName, const TVector<Schema::PgColumn>& columns) {
+        auto registerView = [&](TStringBuf tableName, ESysViewType type, const TVector<Schema::PgColumn>& columns) {
             auto& dsv  = DomainSystemViews[tableName];
             auto& sdsv = SubDomainSystemViews[tableName];
+            auto& sv = SystemViews[type];
             for (const auto& column : columns) {
                 dsv.Columns[column._ColumnId + 1] = TSysTables::TTableColumnInfo(
                     column._ColumnName, column._ColumnId + 1, column._ColumnTypeInfo, "", -1
@@ -220,31 +230,39 @@ private:
                 sdsv.Columns[column._ColumnId + 1] = TSysTables::TTableColumnInfo(
                     column._ColumnName, column._ColumnId + 1, column._ColumnTypeInfo, "", -1
                 );
+                sv.Columns[column._ColumnId + 1] = TSysTables::TTableColumnInfo(
+                    column._ColumnName, column._ColumnId + 1, column._ColumnTypeInfo, "", -1
+                );
             }
         };
         registerView(
             PgTablesName,
+            ESysViewType::EPgTables,
             Singleton<Schema::PgTablesSchemaProvider>()->GetColumns(PgTablesName)
         );
         registerView(
             InformationSchemaTablesName,
+            ESysViewType::EInformationSchemaTables,
             Singleton<Schema::PgTablesSchemaProvider>()->GetColumns(InformationSchemaTablesName)
         );
         registerView(
             PgClassName,
+            ESysViewType::EPgClass,
             Singleton<Schema::PgTablesSchemaProvider>()->GetColumns(PgClassName)
         );
     }
 
     template <typename Table>
-    void RegisterSystemView(const TStringBuf& name) {
+    void RegisterSystemView(const TStringBuf& name, ESysViewType type) {
         TSchemaFiller<Table>::Fill(DomainSystemViews[name]);
         TSchemaFiller<Table>::Fill(SubDomainSystemViews[name]);
+        TSchemaFiller<Table>::Fill(SystemViews[type]);
     }
 
     template <typename Table>
-    void RegisterDomainSystemView(const TStringBuf& name) {
+    void RegisterDomainSystemView(const TStringBuf& name, ESysViewType type) {
         TSchemaFiller<Table>::Fill(DomainSystemViews[name]);
+        TSchemaFiller<Table>::Fill(SystemViews[type]);
     }
 
     template <typename Table>
@@ -258,29 +276,29 @@ private:
     }
 
     void RegisterSystemViews() {
-        RegisterSystemView<Schema::PartitionStats>(PartitionStatsName);
+        RegisterSystemView<Schema::PartitionStats>(PartitionStatsName, ESysViewType::EPartitionStats);
 
-        RegisterSystemView<Schema::Nodes>(NodesName);
+        RegisterSystemView<Schema::Nodes>(NodesName, ESysViewType::ENodes);
 
-        RegisterSystemView<Schema::QueryStats>(TopQueriesByDuration1MinuteName);
-        RegisterSystemView<Schema::QueryStats>(TopQueriesByDuration1HourName);
-        RegisterSystemView<Schema::QueryStats>(TopQueriesByReadBytes1MinuteName);
-        RegisterSystemView<Schema::QueryStats>(TopQueriesByReadBytes1HourName);
-        RegisterSystemView<Schema::QueryStats>(TopQueriesByCpuTime1MinuteName);
-        RegisterSystemView<Schema::QueryStats>(TopQueriesByCpuTime1HourName);
-        RegisterSystemView<Schema::QueryStats>(TopQueriesByRequestUnits1MinuteName);
-        RegisterSystemView<Schema::QueryStats>(TopQueriesByRequestUnits1HourName);
-        RegisterSystemView<Schema::QuerySessions>(QuerySessions);
+        RegisterSystemView<Schema::QueryStats>(TopQueriesByDuration1MinuteName, ESysViewType::ETopQueriesByDurationOneMinute);
+        RegisterSystemView<Schema::QueryStats>(TopQueriesByDuration1HourName, ESysViewType::ETopQueriesByDurationOneHour);
+        RegisterSystemView<Schema::QueryStats>(TopQueriesByReadBytes1MinuteName, ESysViewType::ETopQueriesByReadBytesOneMinute);
+        RegisterSystemView<Schema::QueryStats>(TopQueriesByReadBytes1HourName, ESysViewType::ETopQueriesByReadBytesOneHour);
+        RegisterSystemView<Schema::QueryStats>(TopQueriesByCpuTime1MinuteName, ESysViewType::ETopQueriesByCpuTimeOneMinute);
+        RegisterSystemView<Schema::QueryStats>(TopQueriesByCpuTime1HourName, ESysViewType::ETopQueriesByCpuTimeOneHour);
+        RegisterSystemView<Schema::QueryStats>(TopQueriesByRequestUnits1MinuteName, ESysViewType::ETopQueriesByRequestUnitsOneMinute);
+        RegisterSystemView<Schema::QueryStats>(TopQueriesByRequestUnits1HourName, ESysViewType::ETopQueriesByRequestUnitsOneHour);
+        RegisterSystemView<Schema::QuerySessions>(QuerySessions, ESysViewType::EQuerySessions);
 
-        RegisterDomainSystemView<Schema::PDisks>(PDisksName);
-        RegisterDomainSystemView<Schema::VSlots>(VSlotsName);
-        RegisterDomainSystemView<Schema::Groups>(GroupsName);
-        RegisterDomainSystemView<Schema::StoragePools>(StoragePoolsName);
-        RegisterDomainSystemView<Schema::StorageStats>(StorageStatsName);
+        RegisterDomainSystemView<Schema::PDisks>(PDisksName, ESysViewType::EPDisks);
+        RegisterDomainSystemView<Schema::VSlots>(VSlotsName, ESysViewType::EVSlots);
+        RegisterDomainSystemView<Schema::Groups>(GroupsName, ESysViewType::EGroups);
+        RegisterDomainSystemView<Schema::StoragePools>(StoragePoolsName, ESysViewType::EStoragePools);
+        RegisterDomainSystemView<Schema::StorageStats>(StorageStatsName, ESysViewType::EStorageStats);
 
-        RegisterDomainSystemView<Schema::Tablets>(TabletsName);
+        RegisterDomainSystemView<Schema::Tablets>(TabletsName, ESysViewType::ETablets);
 
-        RegisterSystemView<Schema::QueryMetrics>(QueryMetricsName);
+        RegisterSystemView<Schema::QueryMetrics>(QueryMetricsName, ESysViewType::EQueryMetricsOneMinute);
 
         RegisterOlapStoreSystemView<Schema::PrimaryIndexStats>(StorePrimaryIndexStatsName);
         RegisterOlapStoreSystemView<Schema::PrimaryIndexPortionStats>(StorePrimaryIndexPortionStatsName);
@@ -291,24 +309,24 @@ private:
         RegisterColumnTableSystemView<Schema::PrimaryIndexGranuleStats>(TablePrimaryIndexGranuleStatsName);
         RegisterColumnTableSystemView<Schema::PrimaryIndexOptimizerStats>(TablePrimaryIndexOptimizerStatsName);
 
-        RegisterSystemView<Schema::TopPartitions>(TopPartitionsByCpu1MinuteName);
-        RegisterSystemView<Schema::TopPartitions>(TopPartitionsByCpu1HourName);
-        RegisterSystemView<Schema::TopPartitionsTli>(TopPartitionsByTli1MinuteName);
-        RegisterSystemView<Schema::TopPartitionsTli>(TopPartitionsByTli1HourName);
+        RegisterSystemView<Schema::TopPartitions>(TopPartitionsByCpu1MinuteName, ESysViewType::ETopPartitionsByCpuOneMinute);
+        RegisterSystemView<Schema::TopPartitions>(TopPartitionsByCpu1HourName, ESysViewType::ETopPartitionsByCpuOneHour);
+        RegisterSystemView<Schema::TopPartitionsTli>(TopPartitionsByTli1MinuteName, ESysViewType::ETopPartitionsByTliOneMinute);
+        RegisterSystemView<Schema::TopPartitionsTli>(TopPartitionsByTli1HourName, ESysViewType::ETopPartitionsByTliOneHour);
 
         RegisterPgTablesSystemViews();
 
-        RegisterSystemView<Schema::ResourcePoolClassifiers>(ResourcePoolClassifiersName);
-        RegisterSystemView<Schema::ResourcePools>(ResourcePoolsName);
+        RegisterSystemView<Schema::ResourcePoolClassifiers>(ResourcePoolClassifiersName, ESysViewType::EResourcePoolClassifiers);
+        RegisterSystemView<Schema::ResourcePools>(ResourcePoolsName, ESysViewType::EResourcePools);
 
         {
             using namespace NAuth;
-            RegisterSystemView<Schema::AuthUsers>(UsersName);
-            RegisterSystemView<Schema::AuthGroups>(NAuth::GroupsName);
-            RegisterSystemView<Schema::AuthGroupMembers>(GroupMembersName);
-            RegisterSystemView<Schema::AuthOwners>(OwnersName);
-            RegisterSystemView<Schema::AuthPermissions>(PermissionsName);
-            RegisterSystemView<Schema::AuthPermissions>(EffectivePermissionsName);
+            RegisterSystemView<Schema::AuthUsers>(UsersName, ESysViewType::EAuthUsers);
+            RegisterSystemView<Schema::AuthGroups>(NAuth::GroupsName, ESysViewType::EAuthGroups);
+            RegisterSystemView<Schema::AuthGroupMembers>(GroupMembersName, ESysViewType::EAuthGroupMembers);
+            RegisterSystemView<Schema::AuthOwners>(OwnersName, ESysViewType::EAuthOwners);
+            RegisterSystemView<Schema::AuthPermissions>(PermissionsName, ESysViewType::EAuthPermissions);
+            RegisterSystemView<Schema::AuthPermissions>(EffectivePermissionsName, ESysViewType::EAuthEffectivePermissions);
         }
     }
 
@@ -317,6 +335,7 @@ private:
     THashMap<TString, TSchema> SubDomainSystemViews;
     THashMap<TString, TSchema> OlapStoreSystemViews;
     THashMap<TString, TSchema> ColumnTableSystemViews;
+    THashMap<ESysViewType, TSchema> SystemViews;
 };
 
 class TSystemViewRewrittenResolver : public ISystemViewResolver {
@@ -344,6 +363,11 @@ public:
         Y_UNUSED(target);
         const TSchema* view = SystemViews.FindPtr(viewName);
         return view ? TMaybe<TSchema>(*view) : Nothing();
+    }
+
+    TMaybe<TSchema> GetSystemViewSchema(ESysViewType sysViewType) const override final {
+        Y_UNUSED(sysViewType);
+        return Nothing();
     }
 
     TVector<TString> GetSystemViewNames(ETarget target) const override {

--- a/ydb/core/sys_view/common/schema.h
+++ b/ydb/core/sys_view/common/schema.h
@@ -2,6 +2,7 @@
 
 #include "path.h"
 
+#include <ydb/core/protos/sys_view_types.pb.h>
 #include <ydb/core/tablet_flat/flat_cxx_database.h>
 #include <ydb/core/tx/locks/sys_tables.h>
 #include <yql/essentials/parser/pg_catalog/catalog.h>
@@ -826,6 +827,8 @@ public:
     virtual bool IsSystemViewPath(const TVector<TString>& path, TSystemViewPath& sysViewPath) const = 0;
 
     virtual TMaybe<TSchema> GetSystemViewSchema(const TStringBuf viewName, ETarget target) const = 0;
+
+    virtual TMaybe<TSchema> GetSystemViewSchema(NKikimrSysView::ESysViewType viewType) const = 0;
 
     virtual bool IsSystemView(const TStringBuf viewName) const = 0;
 

--- a/ydb/core/tx/scheme_cache/scheme_cache.h
+++ b/ydb/core/tx/scheme_cache/scheme_cache.h
@@ -316,6 +316,11 @@ struct TSchemeCacheNavigate {
         NKikimrSchemeOp::TBackupCollectionDescription Description;
     };
 
+    struct TSysViewInfo : public TAtomicRefCount<TSysViewInfo> {
+        EKind Kind = KindUnknown;
+        NKikimrSchemeOp::TSysViewDescription Description;
+    };
+
     struct TEntry {
         enum class ERequestType : ui8 {
             ByPath,
@@ -370,6 +375,7 @@ struct TSchemeCacheNavigate {
         TIntrusiveConstPtr<TViewInfo> ViewInfo;
         TIntrusiveConstPtr<TResourcePoolInfo> ResourcePoolInfo;
         TIntrusiveConstPtr<TBackupCollectionInfo> BackupCollectionInfo;
+        TIntrusiveConstPtr<TSysViewInfo> SysViewInfo;
 
         TString ToString() const;
         TString ToString(const NScheme::TTypeRegistry& typeRegistry) const;

--- a/ydb/core/tx/schemeshard/ut_sysview/ut_sysview.cpp
+++ b/ydb/core/tx/schemeshard/ut_sysview/ut_sysview.cpp
@@ -110,7 +110,7 @@ Y_UNIT_TEST_SUITE(TSchemeShardSysViewTest) {
         TestCreateSysView(runtime, ++txId, "/MyRoot/.sys",
                           R"(
                              Name: "new_sys_view"
-                             Type: EPartitionStats
+                             Type: ENodes
                             )",
                           {EStatus::StatusSchemeError, EStatus::StatusAlreadyExists});
         env.TestWaitNotification(runtime, txId);
@@ -136,7 +136,7 @@ Y_UNIT_TEST_SUITE(TSchemeShardSysViewTest) {
         AsyncCreateSysView(runtime, ++txId, "/MyRoot/.sys",
                            R"(
                               Name: "sys_view_2"
-                              Type: EPartitionStats
+                              Type: ENodes
                              )");
 
         TestModificationResult(runtime, txId - 1);
@@ -151,7 +151,7 @@ Y_UNIT_TEST_SUITE(TSchemeShardSysViewTest) {
         {
             const auto describeResult = DescribePath(runtime, "/MyRoot/.sys/sys_view_2");
             TestDescribeResult(describeResult, {NLs::Finished, NLs::IsSysView});
-            ExpectEqualSysViewDescription(describeResult, "sys_view_2", ESysViewType::EPartitionStats);
+            ExpectEqualSysViewDescription(describeResult, "sys_view_2", ESysViewType::ENodes);
         }
     }
 


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

- Added sys view path type processing in SchemeCache
- Added storing sys views schemas by sys view type in SystemViewResolver class

### Changelog category <!-- remove all except one -->

* Not for changelog (changelog entry is not required)

### Description for reviewers <!-- (optional) description for those who read this PR -->
