### PR TITLE
Don't lose unpersisted read locks across restarts

### DIFF
--- a/ydb/core/tx/datashard/datashard__read_iterator.cpp
+++ b/ydb/core/tx/datashard/datashard__read_iterator.cpp
@@ -1889,6 +1889,11 @@ public:
             // We remember acquired lock for faster checking
             state.Lock = guardLocks.Lock;
 
+            // We may need to wait until previous lock changes are committed
+            if (state.Lock && state.Lock->IsPersisting()) {
+                hadWrites = true;
+            }
+
             if (!state.Lock) {
                 // We may fail to acquire an existing write lock
                 // This means our read result is potentially inconsistent

--- a/ydb/core/tx/datashard/datashard_ut_read_iterator.cpp
+++ b/ydb/core/tx/datashard/datashard_ut_read_iterator.cpp
@@ -4939,6 +4939,228 @@ Y_UNIT_TEST_SUITE(DataShardReadIteratorConsistency) {
         );
     }
 
+    Y_UNIT_TEST(WriteLockThenUncommittedReadUpgradeRetryAndRestart) {
+        TPortManager pm;
+        TServerSettings serverSettings(pm.GetPort(2134));
+        serverSettings.SetDomainName("Root")
+            .SetNodeCount(1)
+            .SetUseRealThreads(false);
+
+        // The bug requires restoring lock from persistent storage
+        serverSettings.FeatureFlags.SetEnableDataShardInMemoryStateMigration(false);
+
+        TServer::TPtr server = new TServer(serverSettings);
+
+        auto& runtime = *server->GetRuntime();
+        auto sender = runtime.AllocateEdgeActor();
+
+        runtime.SetLogPriority(NKikimrServices::TX_DATASHARD, NLog::PRI_TRACE);
+
+        InitRoot(server, sender);
+
+        TDisableDataShardLogBatching disableDataShardLogBatching;
+
+        THashMap<ui64, THashSet<TActorId>> shardPipes;
+        auto shardPipeConnectObserver = runtime.AddObserver<TEvTabletPipe::TEvClientConnected>([&](auto& ev) {
+            auto* msg = ev->Get();
+            if (msg->Status == NKikimrProto::OK) {
+                shardPipes[msg->TabletId].insert(ev->Sender);
+            }
+        });
+
+        UNIT_ASSERT_VALUES_EQUAL(
+            KqpSchemeExec(runtime, R"(
+                CREATE TABLE `/Root/table` (key int, value int, PRIMARY KEY (key));
+            )"),
+            "SUCCESS"
+        );
+
+        const auto shards = GetTableShards(server, sender, "/Root/table");
+        UNIT_ASSERT_VALUES_EQUAL(shards.size(), 1u);
+
+        ExecSQL(server, sender, R"(
+            UPSERT INTO `/Root/table` (key, value) VALUES
+                (1, 1001),
+                (2, 1002);
+        )");
+
+        TBlockEvents<TEvDataShard::TEvRead> blockedRead(runtime);
+
+        TString sessionId;
+        TString txId;
+        auto writeReadFuture = KqpSimpleBeginSend(runtime, sessionId, R"(
+            UPSERT INTO `/Root/table` (key, value) VALUES (3, 2003);
+            SELECT key, value FROM `/Root/table` ORDER BY key;
+        )");
+        runtime.WaitFor("blocked read", [&]{ return blockedRead.size() >= 1; });
+
+        TBlockEvents<TEvBlobStorage::TEvPut> blockedCommit(runtime, [&](const auto& ev) {
+            auto* msg = ev->Get();
+            if (msg->Id.TabletID() == shards.at(0) && msg->Id.Channel() == 0) {
+                return true;
+            }
+            return false;
+        });
+        blockedRead.Unblock();
+        runtime.SimulateSleep(TDuration::MilliSeconds(1));
+
+        // It's too difficult to make TEvRead across the network
+        // Fake disconnect by closing all known pipes instead
+        for (auto pipe : shardPipes[shards.at(0)]) {
+            runtime.Send(new IEventHandle(pipe, sender, new TEvents::TEvPoison), 0, true);
+        }
+        shardPipes[shards.at(0)].clear();
+
+        runtime.WaitFor("read retry", [&]{ return blockedRead.size() >= 1; });
+        blockedRead.Stop().Unblock();
+        runtime.SimulateSleep(TDuration::MilliSeconds(1));
+
+        // Force shard to restart by faking a blob storage error
+        blockedCommit.Stop();
+        for (auto& ev : blockedCommit) {
+            auto proxy = ev->Recipient;
+            ui32 groupId = GroupIDFromBlobStorageProxyID(proxy);
+            auto response = ev->Get()->MakeErrorResponse(NKikimrProto::ERROR, "Something went wrong", TGroupId::FromValue(groupId));
+            runtime.Send(new IEventHandle(ev->Sender, proxy, response.release()), 0, true);
+        }
+        blockedCommit.clear();
+
+        UNIT_ASSERT_VALUES_EQUAL(
+            KqpSimpleBeginWait(runtime, txId, std::move(writeReadFuture)),
+            "{ items { int32_value: 1 } items { int32_value: 1001 } }, "
+            "{ items { int32_value: 2 } items { int32_value: 1002 } }, "
+            "{ items { int32_value: 3 } items { int32_value: 2003 } }"
+        );
+
+        // Execute a concurrent query that conflicts with the read above
+        UNIT_ASSERT_VALUES_EQUAL(
+            KqpSimpleExec(runtime, R"(
+                UPSERT INTO `/Root/table` (key, value) VALUES (1, 3001);
+                SELECT key, value FROM `/Root/table` ORDER BY key;
+            )"),
+            "{ items { int32_value: 1 } items { int32_value: 3001 } }, "
+            "{ items { int32_value: 2 } items { int32_value: 1002 } }"
+        );
+
+        // It's not serializable for both transactions to commit
+        UNIT_ASSERT_VALUES_EQUAL(
+            KqpSimpleCommit(runtime, sessionId, txId, R"(SELECT 1)"),
+            "ERROR: ABORTED"
+        );
+    }
+
+    Y_UNIT_TEST(WriteLockThenUncommittedReadUpgradeRestartWithStateMigrationRetryAndRestartWithoutStateMigration) {
+        TPortManager pm;
+        TServerSettings serverSettings(pm.GetPort(2134));
+        serverSettings.SetDomainName("Root")
+            .SetNodeCount(1)
+            .SetUseRealThreads(false);
+
+        // This test requires state migration during the first restart
+        serverSettings.FeatureFlags.SetEnableDataShardInMemoryStateMigration(true);
+
+        TServer::TPtr server = new TServer(serverSettings);
+
+        auto& runtime = *server->GetRuntime();
+        auto sender = runtime.AllocateEdgeActor();
+
+        runtime.SetLogPriority(NKikimrServices::TX_DATASHARD, NLog::PRI_TRACE);
+
+        InitRoot(server, sender);
+
+        TDisableDataShardLogBatching disableDataShardLogBatching;
+
+        UNIT_ASSERT_VALUES_EQUAL(
+            KqpSchemeExec(runtime, R"(
+                CREATE TABLE `/Root/table` (key int, value int, PRIMARY KEY (key));
+            )"),
+            "SUCCESS"
+        );
+
+        const auto shards = GetTableShards(server, sender, "/Root/table");
+        UNIT_ASSERT_VALUES_EQUAL(shards.size(), 1u);
+
+        ExecSQL(server, sender, R"(
+            UPSERT INTO `/Root/table` (key, value) VALUES
+                (1, 1001),
+                (2, 1002);
+        )");
+
+        TBlockEvents<TEvDataShard::TEvRead> blockedRead(runtime);
+
+        TString sessionId;
+        TString txId;
+        auto writeReadFuture = KqpSimpleBeginSend(runtime, sessionId, R"(
+            UPSERT INTO `/Root/table` (key, value) VALUES (3, 2003);
+            SELECT key, value FROM `/Root/table` ORDER BY key;
+        )");
+        runtime.WaitFor("blocked read", [&]{ return blockedRead.size() >= 1; });
+
+        TBlockEvents<TEvBlobStorage::TEvPut> blockedCommit(runtime, [&](const auto& ev) {
+            auto* msg = ev->Get();
+            if (msg->Id.TabletID() == shards.at(0) && msg->Id.Channel() == 0) {
+                return true;
+            }
+            return false;
+        });
+        blockedRead.Unblock();
+        runtime.WaitFor("blocked commit", [&]{ return blockedCommit.size() >= 1; });
+
+        // Force shard to restart by faking a blob storage error
+        blockedCommit.Stop();
+        for (auto& ev : blockedCommit) {
+            auto proxy = ev->Recipient;
+            ui32 groupId = GroupIDFromBlobStorageProxyID(proxy);
+            auto response = ev->Get()->MakeErrorResponse(NKikimrProto::ERROR, "Something went wrong", TGroupId::FromValue(groupId));
+            runtime.Send(new IEventHandle(ev->Sender, proxy, response.release()), 0, true);
+        }
+        blockedCommit.clear();
+
+        runtime.WaitFor("read retry", [&]{ return blockedRead.size() >= 1; });
+        blockedRead.Stop().Unblock();
+
+        // Note: currently we mark restored ranges as unpersisted and will
+        // coincidentally persist them during read (since it's adding locks).
+        // This test should fail if we ever start to optimize duplicate ranges,
+        // in which case additional work will be needed.
+        UNIT_ASSERT_VALUES_EQUAL(
+            KqpSimpleBeginWait(runtime, txId, std::move(writeReadFuture)),
+            "{ items { int32_value: 1 } items { int32_value: 1001 } }, "
+            "{ items { int32_value: 2 } items { int32_value: 1002 } }, "
+            "{ items { int32_value: 3 } items { int32_value: 2003 } }"
+        );
+
+        TBlockEvents<TEvDataShard::TEvInMemoryStateRequest> blockedStateRequest(runtime);
+
+        Cerr << "... killing shard " << shards.at(0) << Endl;
+        runtime.SendToPipe(shards.at(0), sender, new TEvents::TEvPoison);
+        runtime.WaitFor("blocked state request", [&]{ return blockedStateRequest.size() >= 1; });
+
+        for (auto& ev : blockedStateRequest) {
+            Cerr << "... killing state actor " << ev->GetRecipientRewrite() << Endl;
+            runtime.Send(new IEventHandle(ev->GetRecipientRewrite(), sender, new TEvents::TEvPoison), 0, true);
+        }
+        blockedStateRequest.Stop().Unblock();
+
+        runtime.SimulateSleep(TDuration::MilliSeconds(1));
+
+        // Execute a concurrent query that conflicts with the read above
+        UNIT_ASSERT_VALUES_EQUAL(
+            KqpSimpleExec(runtime, R"(
+                UPSERT INTO `/Root/table` (key, value) VALUES (1, 3001);
+                SELECT key, value FROM `/Root/table` ORDER BY key;
+            )"),
+            "{ items { int32_value: 1 } items { int32_value: 3001 } }, "
+            "{ items { int32_value: 2 } items { int32_value: 1002 } }"
+        );
+
+        // It's not serializable for both transactions to commit
+        UNIT_ASSERT_VALUES_EQUAL(
+            KqpSimpleCommit(runtime, sessionId, txId, R"(SELECT 1)"),
+            "ERROR: ABORTED"
+        );
+    }
+
 }
 
 Y_UNIT_TEST_SUITE(DataShardReadIteratorLatency) {

--- a/ydb/core/tx/locks/locks.cpp
+++ b/ydb/core/tx/locks/locks.cpp
@@ -266,20 +266,22 @@ void TLockInfo::PersistRemoveLock(ILocksDb* db) {
     db->PersistRemoveLock(LockId);
 }
 
-void TLockInfo::PersistRanges(ILocksDb* db) {
+bool TLockInfo::PersistRanges(ILocksDb* db) {
     Y_ENSURE(IsPersistent());
+    bool changed = false;
     if (UnpersistedRanges) {
         for (const TPathId& pathId : ReadTables) {
-            PersistAddRange(pathId, ELockRangeFlags::Read, db);
+            changed |= PersistAddRange(pathId, ELockRangeFlags::Read, db);
         }
         for (const TPathId& pathId : WriteTables) {
-            PersistAddRange(pathId, ELockRangeFlags::Write, db);
+            changed |= PersistAddRange(pathId, ELockRangeFlags::Write, db);
         }
         UnpersistedRanges = false;
     }
+    return changed;
 }
 
-void TLockInfo::PersistAddRange(const TPathId& tableId, ELockRangeFlags flags, ILocksDb* db) {
+bool TLockInfo::PersistAddRange(const TPathId& tableId, ELockRangeFlags flags, ILocksDb* db) {
     Y_ENSURE(IsPersistent());
     Y_ENSURE(db, "Cannot persist ranges without a db");
     // We usually have a single range with flags, so linear search is ok
@@ -290,8 +292,9 @@ void TLockInfo::PersistAddRange(const TPathId& tableId, ELockRangeFlags flags, I
             range.Flags |= flags;
             if (range.Flags != prevFlags) {
                 db->PersistRangeFlags(LockId, range.Id, ui64(range.Flags));
+                return true;
             }
-            return;
+            return false;
         }
         maxId = Max(maxId, range.Id);
     }
@@ -300,11 +303,13 @@ void TLockInfo::PersistAddRange(const TPathId& tableId, ELockRangeFlags flags, I
     range.TableId = tableId;
     range.Flags = flags;
     db->PersistAddRange(LockId, range.Id, range.TableId, ui64(range.Flags));
+    return true;
 }
 
-void TLockInfo::AddConflict(TLockInfo* otherLock, ILocksDb* db) {
+bool TLockInfo::AddConflict(TLockInfo* otherLock, ILocksDb* db) {
     Y_ENSURE(this != otherLock, "Lock cannot conflict with itself");
     Y_ENSURE(LockId != otherLock->LockId, "Unexpected conflict between a pair of locks with the same id");
+    bool changed = false;
 
     auto& flags = ConflictLocks[otherLock];
     if (!(flags & ELockConflictFlags::BreakThemOnOurCommit)) {
@@ -315,22 +320,29 @@ void TLockInfo::AddConflict(TLockInfo* otherLock, ILocksDb* db) {
             // Any conflict between persistent locks is also persistent
             Y_ENSURE(db, "Cannot persist conflicts without a db");
             db->PersistAddConflict(LockId, otherLock->LockId);
+            changed = true;
         }
     }
+
+    return changed;
 }
 
-void TLockInfo::AddVolatileDependency(ui64 txId, ILocksDb* db) {
+bool TLockInfo::AddVolatileDependency(ui64 txId, ILocksDb* db) {
     Y_ENSURE(LockId != txId, "Unexpected volatile dependency between a lock and itself");
+    bool changed = false;
 
     if (VolatileDependencies.insert(txId).second && IsPersistent()) {
         Y_ENSURE(db, "Cannot persist dependencies without a db");
         db->PersistAddVolatileDependency(LockId, txId);
+        changed = true;
     }
+    return changed;
 }
 
-void TLockInfo::PersistConflicts(ILocksDb* db) {
+bool TLockInfo::PersistConflicts(ILocksDb* db) {
     Y_ENSURE(IsPersistent());
     Y_ENSURE(db, "Cannot persist conflicts without a db");
+    bool changed = false;
     for (auto& pr : ConflictLocks) {
         TLockInfo* otherLock = pr.first;
         if (!otherLock->IsPersistent()) {
@@ -339,14 +351,18 @@ void TLockInfo::PersistConflicts(ILocksDb* db) {
         }
         if (!!(pr.second & ELockConflictFlags::BreakThemOnOurCommit)) {
             db->PersistAddConflict(LockId, otherLock->LockId);
+            changed = true;
         }
         if (!!(pr.second & ELockConflictFlags::BreakUsOnTheirCommit)) {
             db->PersistAddConflict(otherLock->LockId, LockId);
+            changed = true;
         }
     }
     for (ui64 txId : VolatileDependencies) {
         db->PersistAddVolatileDependency(LockId, txId);
+        changed = true;
     }
+    return changed;
 }
 
 void TLockInfo::CleanupConflicts() {
@@ -480,7 +496,26 @@ void TLockInfo::SetFrozen(ILocksDb* db) {
     Flags |= ELockFlags::Frozen;
     if (db) {
         db->PersistLockFlags(LockId, ui64(Flags & ELockFlags::PersistentMask));
+        AddWaitPersistentCallback(db);
     }
+}
+
+void TLockInfo::AddWaitPersistentCallback(ILocksDb* db) {
+    ++WaitPersistentCounter;
+    db->OnPersistent([lock = TLockInfo::TPtr(this)]() {
+        --lock->WaitPersistentCounter;
+    });
+}
+
+void TLockInfo::AddWaitPersistentCallback(ILocksDb* db, TVector<TLockInfo::TPtr>&& locks) {
+    for (auto& lock : locks) {
+        ++lock->WaitPersistentCounter;
+    }
+    db->OnPersistent([locks = std::move(locks)]() {
+        for (auto& lock : locks) {
+            --lock->WaitPersistentCounter;
+        }
+    });
 }
 
 // TTableLocks
@@ -762,7 +797,7 @@ TLockInfo::TPtr TLockLocker::GetOrAddLock(ui64 lockId, ui32 lockNodeId) {
         return nullptr;
     }
 
-    TLockInfo::TPtr lock(new TLockInfo(this, lockId, lockNodeId));
+    TLockInfo::TPtr lock = MakeIntrusive<TLockInfo>(this, lockId, lockNodeId);
     Y_ENSURE(!lock->IsPersistent());
     Locks[lockId] = lock;
     if (lockNodeId) {
@@ -775,7 +810,7 @@ TLockInfo::TPtr TLockLocker::GetOrAddLock(ui64 lockId, ui32 lockNodeId) {
 TLockInfo::TPtr TLockLocker::AddLock(const ILocksDb::TLockRow& row) {
     Y_ENSURE(Locks.find(row.LockId) == Locks.end());
 
-    TLockInfo::TPtr lock(new TLockInfo(this, row));
+    TLockInfo::TPtr lock = MakeIntrusive<TLockInfo>(this, row);
     Y_ENSURE(lock->IsPersistent());
     Locks[row.LockId] = lock;
     if (row.LockNodeId) {
@@ -793,7 +828,7 @@ TLockInfo::TPtr TLockLocker::RestoreInMemoryLock(const ILocksDb::TLockRow& row) 
             // Since this lock is missing its commit must have failed
             return nullptr;
         }
-        TLockInfo::TPtr lock(new TLockInfo(this, row));
+        TLockInfo::TPtr lock = MakeIntrusive<TLockInfo>(this, row);
         Locks[row.LockId] = lock;
         if (row.LockNodeId) {
             PendingSubscribeLocks.emplace_back(row.LockId, row.LockNodeId);
@@ -1075,17 +1110,30 @@ std::pair<TVector<TSysLocks::TLock>, TVector<ui64>> TSysLocks::ApplyLocks() {
             counter = lock->GetCounter();
             Update->Lock = lock;
 
+            bool waitPersistent = false;
+            TVector<TLockInfo::TPtr> waitPersistentMore;
+
             if (lock->IsPersistent()) {
-                lock->PersistRanges(Db);
+                if (lock->PersistRanges(Db)) {
+                    waitPersistent = true;
+                }
             }
             for (auto& readConflictLock : Update->ReadConflictLocks) {
-                readConflictLock.AddConflict(lock.Get(), Db);
+                if (readConflictLock.AddConflict(lock.Get(), Db)) {
+                    waitPersistent = true;
+                    waitPersistentMore.emplace_back(&readConflictLock);
+                }
             }
             for (auto& writeConflictLock : Update->WriteConflictLocks) {
-                lock->AddConflict(&writeConflictLock, Db);
+                if (lock->AddConflict(&writeConflictLock, Db)) {
+                    waitPersistent = true;
+                    waitPersistentMore.emplace_back(&writeConflictLock);
+                }
             }
             for (ui64 txId : Update->VolatileDependencies) {
-                lock->AddVolatileDependency(txId, Db);
+                if (lock->AddVolatileDependency(txId, Db)) {
+                    waitPersistent = true;
+                }
             }
 
             if (lock->GetWriteTables() && !lock->IsPersistent()) {
@@ -1093,6 +1141,17 @@ std::pair<TVector<TSysLocks::TLock>, TVector<ui64>> TSysLocks::ApplyLocks() {
                 lock->PersistLock(Db);
                 // Persistent locks cannot expire
                 Locker.ExpireQueue.Remove(lock.Get());
+                // Make sure it tracks persistence progress
+                waitPersistent = true;
+            }
+
+            if (waitPersistent) {
+                if (waitPersistentMore.empty()) {
+                    lock->AddWaitPersistentCallback(Db);
+                } else {
+                    waitPersistentMore.push_back(lock);
+                    TLockInfo::AddWaitPersistentCallback(Db, std::move(waitPersistentMore));
+                }
             }
         }
     }

--- a/ydb/core/tx/locks/locks.h
+++ b/ydb/core/tx/locks/locks.h
@@ -75,6 +75,9 @@ public:
     // Persist volatile dependencies, i.e. which undecided transactions must be waited for on commit
     virtual void PersistAddVolatileDependency(ui64 lockId, ui64 txId) = 0;
     virtual void PersistRemoveVolatileDependency(ui64 lockId, ui64 txId) = 0;
+
+    // Schedules callback when changes are confirmed to be persistent
+    virtual void OnPersistent(std::function<void()> callback) = 0;
 };
 
 class TLocksDataShard {
@@ -349,11 +352,11 @@ public:
     void PersistBrokenLock(ILocksDb* db);
     void PersistRemoveLock(ILocksDb* db);
 
-    void PersistRanges(ILocksDb* db);
+    bool PersistRanges(ILocksDb* db);
 
-    void AddConflict(TLockInfo* otherLock, ILocksDb* db);
-    void AddVolatileDependency(ui64 txId, ILocksDb* db);
-    void PersistConflicts(ILocksDb* db);
+    bool AddConflict(TLockInfo* otherLock, ILocksDb* db);
+    bool AddVolatileDependency(ui64 txId, ILocksDb* db);
+    bool PersistConflicts(ILocksDb* db);
     void CleanupConflicts();
 
     void RestoreInMemoryState(const ILocksDb::TLockRow& lockRow);
@@ -393,6 +396,11 @@ public:
     bool IsFrozen() const { return !!(Flags & ELockFlags::Frozen); }
     void SetFrozen(ILocksDb* db = nullptr);
 
+    bool IsPersisting() const { return WaitPersistentCounter > 0; }
+    void AddWaitPersistentCallback(ILocksDb* db);
+
+    static void AddWaitPersistentCallback(ILocksDb* db, TVector<TLockInfo::TPtr>&& locks);
+
 private:
     void MakeShardLock();
     bool AddShardLock(const TPathId& pathId);
@@ -402,7 +410,7 @@ private:
     void SetBroken(TRowVersion at);
     void OnRemoved();
 
-    void PersistAddRange(const TPathId& tableId, ELockRangeFlags flags, ILocksDb* db);
+    bool PersistAddRange(const TPathId& tableId, ELockRangeFlags flags, ILocksDb* db);
 
 private:
     struct TPersistentRange {
@@ -434,6 +442,7 @@ private:
     TVector<TPersistentRange> PersistentRanges;
 
     ui64 LastOpId = 0;
+    ui64 WaitPersistentCounter = 0;
 };
 
 struct TTableLocksReadListTag {};

--- a/ydb/core/tx/locks/locks_db.h
+++ b/ydb/core/tx/locks/locks_db.h
@@ -198,6 +198,11 @@ public:
         HasChanges_ = true;
     }
 
+    // Schedules callback when changes are confirmed to be persistent
+    void OnPersistent(std::function<void()> callback) override {
+        DB.OnPersistent(std::move(callback));
+    }
+
 protected:
     TShard& Self;
     NTable::TDatabase& DB;


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

Don't allow conflicting read-write transactions to violate serializability after shard restarts. Fixes #18065.

### Changelog category <!-- remove all except one -->

* Bugfix 

### Description for reviewers <!-- (optional) description for those who read this PR -->

We could skip waiting for lock changes to persist in some cases, which could lead to non-serializable commits in case an earlier tablet commit failed.