### PR TITLE
Fix schemeshard's view tests

### DIFF
--- a/ydb/core/tx/schemeshard/ut_view/ut_view.cpp
+++ b/ydb/core/tx/schemeshard/ut_view/ut_view.cpp
@@ -20,7 +20,7 @@ Y_UNIT_TEST_SUITE(TSchemeShardViewTest) {
         TTestEnv env(runtime);
         ui64 txId = 100;
 
-        TestCreateView(runtime, txId++, "/MyRoot", R"(
+        TestCreateView(runtime, ++txId, "/MyRoot", R"(
                 Name: "MyView"
                 QueryText: "Some query"
             )"
@@ -39,7 +39,7 @@ Y_UNIT_TEST_SUITE(TSchemeShardViewTest) {
         TTestEnv env(runtime);
         ui64 txId = 100;
 
-        TestCreateView(runtime, txId++, "/MyRoot", R"(
+        TestCreateView(runtime, ++txId, "/MyRoot", R"(
                 Name: "MyView"
                 QueryText: "Some query"
             )"
@@ -147,7 +147,7 @@ Y_UNIT_TEST_SUITE(TSchemeShardViewTest) {
         TestModificationResults(runtime, txId - 1, expectedResults);
         TestModificationResults(runtime, txId, expectedResults);
 
-        env.TestWaitNotification(runtime, {txId - 1, txId});
+        env.TestWaitNotification(runtime, {txId - 2, txId - 1, txId});
         TestLs(runtime, "/MyRoot/MyView", false, NLs::PathNotExist);
     }
 


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

### Changelog category <!-- remove all except one -->

* Not for changelog (changelog entry is not required)

### Description for reviewers <!-- (optional) description for those who read this PR -->

Fix pretty old schemeshard's view tests that were waiting for the wrong txIds due to the `txId++` being used instead of the `++txId` to start a transaction.
