### PR TITLE
Make timeout on reestablishing sessions in BSQueue longer on high load

### DIFF
--- a/ydb/core/base/blobstorage.h
+++ b/ydb/core/base/blobstorage.h
@@ -762,6 +762,7 @@ struct TEvBlobStorage {
         EvQuerySyncToken,
         EvSyncToken,
         EvReleaseSyncToken,
+        EvBSQueueResetConnection, // for test purposes
 
         EvYardInitResult = EvPut + 9 * 512,                     /// 268 636 672
         EvLogResult,

--- a/ydb/core/blobstorage/backpressure/load_based_timeout.cpp
+++ b/ydb/core/blobstorage/backpressure/load_based_timeout.cpp
@@ -1,0 +1,32 @@
+#include "load_based_timeout.h"
+
+namespace NKikimr {
+
+TLoadBasedTimeoutManager::TLoadBasedTimeoutManager(TDuration minimumTimeout, TDuration timePerRequestInFlight)
+    : MinimumTimeout(minimumTimeout)
+    , TimePerRequestInFlight(timePerRequestInFlight)
+    , ActiveRequest(false)
+{}
+
+TDuration TLoadBasedTimeoutManager::GetTimeoutForNewRequest() {
+    // if there is active request we don't increment counter
+    ui32 delta = std::exchange(ActiveRequest, true) ? 0 : 1;
+    ui32 requestsInFlight = RequestsInFlight.fetch_add(delta) + delta;
+    return std::max(MinimumTimeout, TimePerRequestInFlight * requestsInFlight);
+}
+
+void TLoadBasedTimeoutManager::RequestCompleted() {
+    if (std::exchange(ActiveRequest, false)) {
+        ui32 prev = RequestsInFlight.fetch_sub(1);
+        Y_DEBUG_ABORT_UNLESS(prev > 0);
+    }
+}
+
+
+TLoadBasedTimeoutManager::~TLoadBasedTimeoutManager() {
+    RequestCompleted();
+}
+
+std::atomic<ui32> TLoadBasedTimeoutManager::RequestsInFlight = 0;
+
+} // namespace NKikimr

--- a/ydb/core/blobstorage/backpressure/load_based_timeout.h
+++ b/ydb/core/blobstorage/backpressure/load_based_timeout.h
@@ -1,0 +1,43 @@
+#include "defs.h"
+#include <algorithm>
+#include <atomic>
+
+namespace NKikimr {
+
+// We assume only one active request can be in flight
+class TLoadBasedTimeoutManager {
+public:
+    TLoadBasedTimeoutManager(TDuration minimumTimeout, TDuration timePerRequestInFlight)
+        : MinimumTimeout(minimumTimeout)
+        , TimePerRequestInFlight(timePerRequestInFlight)
+        , ActiveRequest(false)
+    {}
+
+    TDuration GetTimeoutForNewRequest() {
+        // if there is active request we don't increment counter
+        ui32 delta = std::exchange(ActiveRequest, true) ? 0 : 1;
+        ui32 requestsInFlight = RequestsInFlight.fetch_add(delta) + delta;
+        return std::max(MinimumTimeout, TimePerRequestInFlight * requestsInFlight);
+    }
+
+    void RequestCompleted() {
+        if (std::exchange(ActiveRequest, false)) {
+            ui32 prev = RequestsInFlight.fetch_sub(1);
+            Y_DEBUG_ABORT_UNLESS(prev > 0);
+        }
+    }
+
+    ~TLoadBasedTimeoutManager() {
+        RequestCompleted();
+    }
+
+private:
+    TDuration MinimumTimeout;
+    TDuration TimePerRequestInFlight;
+    static std::atomic<ui32> RequestsInFlight;
+    bool ActiveRequest;
+};
+
+std::atomic<ui32> TLoadBasedTimeoutManager::RequestsInFlight = 0;
+
+} // namespace NKikimr

--- a/ydb/core/blobstorage/backpressure/queue_backpressure_client.cpp
+++ b/ydb/core/blobstorage/backpressure/queue_backpressure_client.cpp
@@ -3,6 +3,7 @@
 #include "queue_backpressure_server.h"
 #include "unisched.h"
 #include "common.h"
+#include "load_based_timeout.h"
 
 //#define BSQUEUE_EVENT_COUNTERS 1
 
@@ -48,6 +49,10 @@ class TVDiskBackpressureClientActor : public TActorBootstrapped<TVDiskBackpressu
     TBlobStorageGroupType GType;
     TInstant ConnectionFailureTime;
 
+    constexpr static TDuration MinimumReconnectTimeout = TDuration::Seconds(1);
+    constexpr static TDuration ReconnectTimeoutPerRequest = TDuration::Seconds(1) / 100'000;
+    TLoadBasedTimeoutManager ReconnectTimeoutManager;
+
     enum class EState {
         INITIAL,
         CHECK_READINESS_SENT,
@@ -91,6 +96,7 @@ public:
         , InterconnectChannel(interconnectChannel)
         , Info(info)
         , GType(info->Type)
+        , ReconnectTimeoutManager(MinimumReconnectTimeout, ReconnectTimeoutPerRequest)
     {
         Y_ABORT_UNLESS(Info);
     }
@@ -503,7 +509,7 @@ private:
                     << " ConnectionFailureTime# " << ConnectionFailureTime);
             }
 
-            ResetConnection(ctx, NKikimrProto::ERROR, "node disconnected", TDuration::Seconds(1));
+            ResetConnection(ctx, NKikimrProto::ERROR, "node disconnected", ReconnectTimeoutManager.GetTimeoutForNewRequest());
             Y_ABORT_UNLESS(!SessionId || SessionId == ev->Sender);
             SessionId = {};
         }
@@ -562,6 +568,8 @@ private:
             return; // we don't expect this message right now, or this is some race reply
         }
 
+        ReconnectTimeoutManager.RequestCompleted();
+
         const auto& record = ev->Get()->Record;
         if (record.GetStatus() != NKikimrProto::NOTREADY) {
             ExtraBlockChecksSupport = record.GetExtraBlockChecksSupport();
@@ -608,7 +616,7 @@ private:
             << " ConnectionFailureTime# " << ConnectionFailureTime);
 
         if (ev->Sender == RemoteVDisk) {
-            ResetConnection(ctx, NKikimrProto::ERROR, "event undelivered", TDuration::Seconds(1));
+            ResetConnection(ctx, NKikimrProto::ERROR, "event undelivered", ReconnectTimeoutManager.GetTimeoutForNewRequest());
         }
     }
 

--- a/ydb/core/blobstorage/backpressure/queue_backpressure_client.cpp
+++ b/ydb/core/blobstorage/backpressure/queue_backpressure_client.cpp
@@ -557,6 +557,11 @@ private:
         // 3. TEvUndelivered when message couldn't be delivered
     }
 
+    void ConnectionResetReqeuested(const TActorContext& ctx) {
+        ResetConnection(ctx, NKikimrProto::ERROR, "connection reset requested",
+                ReconnectTimeoutManager.GetTimeoutForNewRequest());
+    }
+
     void HandleCheckReadiness(TEvBlobStorage::TEvVCheckReadinessResult::TPtr& ev, const TActorContext& ctx) {
         QLOG_INFO_S("BSQ17", "TEvVCheckReadinessResult"
             << " Cookie# " << ev->Cookie
@@ -951,6 +956,7 @@ private:
             HFunc(TEvBlobStorage::TEvVGetBarrierResult, HandleResponse)
 
             HFunc(TEvRequestReadiness, RequestReadiness)
+            CFunc(TEvBlobStorage::EvBSQueueResetConnection, ConnectionResetReqeuested)
             HFunc(TEvBlobStorage::TEvVCheckReadinessResult, HandleCheckReadiness)
             CFunc(TEvBlobStorage::EvVReadyNotify, HandleReadyNotify)
 

--- a/ydb/core/blobstorage/backpressure/queue_backpressure_client.h
+++ b/ydb/core/blobstorage/backpressure/queue_backpressure_client.h
@@ -46,6 +46,10 @@ namespace NKikimr {
         : public TEventLocal<TEvRequestProxyQueueState, TEvBlobStorage::EvRequestProxyQueueState>
     {};
 
+    struct TEvBSQueueResetConnection
+        : public TEventLocal<TEvBSQueueResetConnection, TEvBlobStorage::EvBSQueueResetConnection>
+    {};
+
     IActor* CreateVDiskBackpressureClient(const TIntrusivePtr<TBlobStorageGroupInfo>& info, TVDiskIdShort vdiskId,
         NKikimrBlobStorage::EVDiskQueueId queueId,const TIntrusivePtr<::NMonitoring::TDynamicCounters>& counters,
         const TBSProxyContextPtr& bspctx, const NBackpressure::TQueueClientId& clientId, const TString& queueName,

--- a/ydb/core/blobstorage/backpressure/ya.make
+++ b/ydb/core/blobstorage/backpressure/ya.make
@@ -16,6 +16,7 @@ SRCS(
     defs.h
     event.cpp
     event.h
+    load_based_timeout.cpp
     queue.cpp
     queue.h
     queue_backpressure_client.cpp

--- a/ydb/core/blobstorage/ut_blobstorage/backpressure.cpp
+++ b/ydb/core/blobstorage/ut_blobstorage/backpressure.cpp
@@ -1,0 +1,67 @@
+#include <ydb/core/blobstorage/ut_blobstorage/lib/env.h>
+
+#include "ut_helpers.h"
+
+#define Ctest Cnull
+
+Y_UNIT_TEST_SUITE(NodeDisconnected) {
+    Y_UNIT_TEST(BsQueueRetries) {
+        ui32 nodeCount = 8;
+        TEnvironmentSetup env{{
+            .NodeCount = nodeCount,
+            .Erasure = TBlobStorageGroupType::Erasure4Plus2Block
+        }};
+        env.CreateBoxAndPool(1, 1);
+        env.Sim(TDuration::Seconds(60));
+
+        std::vector<ui32> groups = env.GetGroups();
+        // ui32 groupId = groups.front();
+        Y_ABORT_UNLESS(groups.size() == 1);
+        TIntrusivePtr<TBlobStorageGroupInfo> info = env.GetGroupInfo(groups.front());
+
+        const ui32 queuesCount = 800'000;
+        ui32 orderNumber = 1;
+
+        TVDiskID vdiskId = info->GetVDiskId(orderNumber);
+        ui32 badNodeId = info->GetActorId(orderNumber).NodeId();
+        ui32 goodNodeId = nodeCount + 1 - badNodeId;
+        Y_VERIFY(badNodeId != goodNodeId);
+
+        TActorId edge = env.Runtime->AllocateEdgeActor(goodNodeId);
+
+        std::vector<TActorId> queues;
+
+        for (ui32 i = 0; i < queuesCount; ++i) {
+            queues.push_back(env.CreateQueueActor(vdiskId, NKikimrBlobStorage::PutTabletLog, i, goodNodeId));
+        }
+
+        ui32 ctr = 0;
+
+        for (const TActorId actorId : queues) {
+            env.Runtime->Send(new IEventHandle(actorId, edge, new TEvBSQueueResetConnection), edge.NodeId());
+        }
+
+        env.Sim(TDuration::Seconds(60));
+
+        env.Runtime->StopNode(badNodeId);
+
+        env.Runtime->FilterFunction = [&](ui32, std::unique_ptr<IEventHandle>& ev) {
+            if (ev->Type == TEvBlobStorage::TEvVCheckReadiness::EventType) {
+                ++ctr;
+            }
+            return true;
+        };
+
+        for (const TActorId actorId : queues) {
+            env.Runtime->Send(new IEventHandle(actorId, edge, new TEvBSQueueResetConnection), edge.NodeId());
+            // env.WaitForEdgeActorEvent<TEvBlobStorage::TEvVStatus>(edge, false, TInstant::Max());
+        }
+
+        const ui32 simSeconds = 60;
+
+        env.Sim(TDuration::Seconds(simSeconds));
+        Cerr << "CTR " << ctr << Endl;
+
+        UNIT_ASSERT(ctr < queuesCount * simSeconds / 10);
+    }
+}

--- a/ydb/core/blobstorage/ut_blobstorage/ya.make
+++ b/ydb/core/blobstorage/ut_blobstorage/ya.make
@@ -16,6 +16,7 @@ ENDIF()
 SRCS(
     acceleration.cpp
     assimilation.cpp
+    backpressure.cpp
     block_race.cpp
     counting_events.cpp
     deadlines.cpp


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

Increase timeout on BS_QUEUE reestablishing session when many actors try to reconnect simultaneously

### Changelog category <!-- remove all except one -->

* Improvement
