### PR TITLE
Use Spilling in Hash Shuffle Connections on Join Inputs

### DIFF
--- a/ydb/core/kqp/compile_service/kqp_compile_actor.cpp
+++ b/ydb/core/kqp/compile_service/kqp_compile_actor.cpp
@@ -655,6 +655,7 @@ void ApplyServiceConfig(TKikimrConfiguration& kqpConfig, const TTableServiceConf
     kqpConfig.EnableSnapshotIsolationRW = serviceConfig.GetEnableSnapshotIsolationRW();
     kqpConfig.AllowMultiBroadcasts = serviceConfig.GetAllowMultiBroadcasts();
     kqpConfig.EnableNewRBO = serviceConfig.GetEnableNewRBO();
+    kqpConfig.EnableSpillingInHashJoinShuffleConnections = serviceConfig.GetEnableSpillingInHashJoinShuffleConnections();
 
     if (const auto limit = serviceConfig.GetResourceManager().GetMkqlHeavyProgramMemoryLimit()) {
         kqpConfig._KqpYqlCombinerMemoryLimit = std::max(1_GB, limit - (limit >> 2U));

--- a/ydb/core/kqp/compile_service/kqp_compile_service.cpp
+++ b/ydb/core/kqp/compile_service/kqp_compile_service.cpp
@@ -319,6 +319,7 @@ private:
         bool enableSnapshotIsolationRW = TableServiceConfig.GetEnableSnapshotIsolationRW();
 
         bool enableNewRBO = TableServiceConfig.GetEnableNewRBO();
+        bool enableSpillingInHashJoinShuffleConnections = TableServiceConfig.GetEnableSpillingInHashJoinShuffleConnections();
 
         TableServiceConfig.Swap(event.MutableConfig()->MutableTableServiceConfig());
         LOG_INFO(*TlsActivationContext, NKikimrServices::KQP_COMPILE_SERVICE, "Updated config");
@@ -353,7 +354,8 @@ private:
             TableServiceConfig.GetAllowMultiBroadcasts() != allowMultiBroadcasts ||
             TableServiceConfig.GetDefaultEnableShuffleElimination() != defaultEnableShuffleElimination ||
             TableServiceConfig.GetEnableQueryServiceSpilling() != enableSpilling ||
-            TableServiceConfig.GetEnableNewRBO() != enableNewRBO) 
+            TableServiceConfig.GetEnableNewRBO() != enableNewRBO ||
+            TableServiceConfig.GetEnableSpillingInHashJoinShuffleConnections() != enableSpillingInHashJoinShuffleConnections)
         {
 
             QueryCache->Clear();

--- a/ydb/core/kqp/executer_actor/kqp_tasks_graph.cpp
+++ b/ydb/core/kqp/executer_actor/kqp_tasks_graph.cpp
@@ -493,6 +493,7 @@ void BuildKqpStageChannels(TKqpTasksGraph& tasksGraph, TStageInfo& stageInfo,
                 break;
             case NKqpProto::TKqpPhyConnection::kHashShuffle: {
                 ui32 hashKind = NHashKind::EUndefined;
+                auto forceSpilling = input.GetHashShuffle().GetUseSpilling();
                 switch (input.GetHashShuffle().GetHashKindCase()) {
                     case NKqpProto::TKqpPhyCnHashShuffle::kHashV1: {
                         hashKind = NHashKind::EHashV1;
@@ -536,7 +537,8 @@ void BuildKqpStageChannels(TKqpTasksGraph& tasksGraph, TStageInfo& stageInfo,
                     input.GetHashShuffle().GetKeyColumns(),
                     enableSpilling,
                     log,
-                    hashKind
+                    hashKind,
+                    forceSpilling
                 );
                 break;
             }

--- a/ydb/core/kqp/provider/yql_kikimr_settings.h
+++ b/ydb/core/kqp/provider/yql_kikimr_settings.h
@@ -186,6 +186,7 @@ struct TKikimrConfiguration : public TKikimrSettings, public NCommon::TSettingDi
     bool FilterPushdownOverJoinOptionalSide = false;
     THashSet<TString> YqlCoreOptimizerFlags;
     bool EnableNewRBO = false;
+    bool EnableSpillingInHashJoinShuffleConnections = false;
 
     void SetDefaultEnabledSpillingNodes(const TString& node);
     ui64 GetEnabledSpillingNodes() const;

--- a/ydb/core/kqp/query_compiler/kqp_query_compiler.cpp
+++ b/ydb/core/kqp/query_compiler/kqp_query_compiler.cpp
@@ -1394,6 +1394,10 @@ private:
                 shuffleProto.MutableHashV1();
             }
 
+            if (Config->EnableSpillingInHashJoinShuffleConnections && shuffle.UseSpilling()) {
+                shuffleProto.SetUseSpilling(FromStringWithDefault<bool>(shuffle.UseSpilling().Cast().StringValue(), false));
+            }
+
             return;
         }
 

--- a/ydb/core/protos/kqp_physical.proto
+++ b/ydb/core/protos/kqp_physical.proto
@@ -261,6 +261,8 @@ message TKqpPhyCnHashShuffle {
         THashV1 HashV1 = 2;
         TColumnShardHashV1 ColumnShardHashV1 = 3;
     }
+
+    bool UseSpilling = 4;
 }
 
 message TKqpPhyCnBroadcast {

--- a/ydb/core/protos/table_service_config.proto
+++ b/ydb/core/protos/table_service_config.proto
@@ -387,4 +387,5 @@ message TTableServiceConfig {
     optional bool FilterPushdownOverJoinOptionalSide = 83 [ default = true ];
 
     optional bool EnableNewRBO = 84 [default = false];
+    optional bool EnableSpillingInHashJoinShuffleConnections = 85 [default = true];
 };

--- a/ydb/library/yql/dq/expr_nodes/dq_expr_nodes.json
+++ b/ydb/library/yql/dq/expr_nodes/dq_expr_nodes.json
@@ -168,7 +168,8 @@
         "Base": "TDqConnection",
         "Match": {"Type": "Callable", "Name": "DqCnHashShuffle"},
         "Children": [
-            {"Index": 1, "Name": "KeyColumns", "Type": "TCoAtomList"}
+            {"Index": 1, "Name": "KeyColumns", "Type": "TCoAtomList"},
+            {"Index": 2, "Name": "UseSpilling", "Type": "TCoAtom", "Optional": true}
         ]
     },
     {

--- a/ydb/library/yql/dq/opt/dq_opt_build.cpp
+++ b/ydb/library/yql/dq/opt/dq_opt_build.cpp
@@ -584,6 +584,7 @@ TDqPhyStage RebuildStageInputsAsWide(const TDqPhyStage& stage, TExprContext& ctx
                         .Stage(newStage)
                     .Build()
                     .KeyColumns(builder.Build().Value())
+                    .UseSpilling(shuffle.UseSpilling())
                     .Done().Ptr());
             } else if (conn.Maybe<TDqCnMerge>()) {
                 auto merge = conn.Maybe<TDqCnMerge>().Cast();

--- a/ydb/library/yql/dq/opt/dq_opt_join.cpp
+++ b/ydb/library/yql/dq/opt/dq_opt_join.cpp
@@ -1473,6 +1473,7 @@ TExprBase DqBuildHashJoin(const TDqJoin& join, EHashJoinMode mode, TExprContext&
             .KeyColumns()
                 .Add(keys)
                 .Build()
+            .UseSpilling().Build(true)
             .Done().Ptr();
     };
 

--- a/ydb/library/yql/dq/tasks/dq_connection_builder.h
+++ b/ydb/library/yql/dq/tasks/dq_connection_builder.h
@@ -105,7 +105,7 @@ void BuildUnionAllChannels(TGraph& graph, const NNodes::TDqPhyStage& stage, ui32
 template <typename TGraph, typename TKeyColumns>
 void BuildHashShuffleChannels(TGraph& graph, const typename TGraph::TStageInfoType& stageInfo, ui32 inputIndex,
     const typename TGraph::TStageInfoType& inputStageInfo, ui32 outputIndex, const TKeyColumns& keyColumns,
-    bool enableSpilling, const TChannelLogFunc& logFunc, ui32 hashKind = NHashKind::EHashV1)
+    bool enableSpilling, const TChannelLogFunc& logFunc, ui32 hashKind = NHashKind::EHashV1, bool forceSpilling = false)
 {
     for (auto& originTaskId : inputStageInfo.Tasks) {
         auto& originTask = graph.GetTask(originTaskId);
@@ -130,9 +130,8 @@ void BuildHashShuffleChannels(TGraph& graph, const typename TGraph::TStageInfoTy
             channel.DstStageId = stageInfo.Id;
             channel.DstTask = targetTask.Id;
             channel.DstInputIndex = inputIndex;
-            channel.InMemory = !enableSpilling || inputStageInfo.OutputsCount == 1;
+            channel.InMemory = !enableSpilling || (inputStageInfo.OutputsCount == 1 && !forceSpilling);
             taskOutput.Channels.push_back(channel.Id);
-
             auto& taskInput = targetTask.Inputs[inputIndex];
             taskInput.Channels.push_back(channel.Id);
 

--- a/ydb/library/yql/dq/type_ann/dq_type_ann.cpp
+++ b/ydb/library/yql/dq/type_ann/dq_type_ann.cpp
@@ -829,7 +829,7 @@ TStatus AnnotateDqCnMerge(const TExprNode::TPtr& node, TExprContext& ctx) {
 }
 
 TStatus AnnotateDqCnHashShuffle(const TExprNode::TPtr& input, TExprContext& ctx) {
-    if (!EnsureArgsCount(*input, 2, ctx)) {
+    if (!EnsureMinMaxArgsCount(*input, 2, 3, ctx)) {
         return TStatus::Error;
     }
 


### PR DESCRIPTION
Add FeatureFlag (default true) to use spilling (if available) in OutputChannels which are used as Join inputs to mitigate deadlocks on skewed data 

Fixes deadlock in #17886