### PR TITLE
Fix KMeansTreeSample::Probability incorrectly saved as Row (#18236)

### DIFF
--- a/ydb/core/tx/schemeshard/schemeshard_build_index__progress.cpp
+++ b/ydb/core/tx/schemeshard/schemeshard_build_index__progress.cpp
@@ -1624,7 +1624,7 @@ public:
                 }
                 for (; from < sample.size(); ++from) {
                     db.Table<Schema::KMeansTreeSample>().Key(buildInfo.Id, from).Update(
-                        NIceDb::TUpdate<Schema::KMeansTreeSample::Row>(sample[from].P),
+                        NIceDb::TUpdate<Schema::KMeansTreeSample::Probability>(sample[from].P),
                         NIceDb::TUpdate<Schema::KMeansTreeSample::Data>(sample[from].Row)
                     );
                 }


### PR DESCRIPTION
### Changelog category

* Not for changelog 

### Description for reviewers

Test in PR #18724. I'd like to merge 3 bugfixes first and then the test for all 3.
