### PR TITLE
Fix stranded PDisk actor while using testlib

### DIFF
--- a/ydb/core/testlib/basics/helpers.cpp
+++ b/ydb/core/testlib/basics/helpers.cpp
@@ -46,16 +46,13 @@ namespace NKikimr {
     }
 
     struct TPDiskReplyChecker : IReplyChecker {
-        ~TPDiskReplyChecker()
-        {
-        }
-
-        void OnRequest(IEventHandle *request) override {
-            if (request->Type == TEvBlobStorage::EvMultiLog) {
-                NPDisk::TEvMultiLog *evLogs = request->Get<NPDisk::TEvMultiLog>();
-                LastLsn = evLogs->LsnSeg.Last;
+        bool OnRequest(IEventHandle *request) override {
+            if (const ui32 type = request->GetTypeRewrite(); type == TEvBlobStorage::EvMultiLog) {
+                LastLsn = request->Get<NPDisk::TEvMultiLog>()->LsnSeg.Last;
+                return true;
             } else {
                 LastLsn = {};
+                return type != TEvBlobStorage::EvConfigureScheduler;
             }
         }
 

--- a/ydb/library/actors/testlib/test_runtime.cpp
+++ b/ydb/library/actors/testlib/test_runtime.cpp
@@ -1978,7 +1978,6 @@ namespace NActors {
                 ctx.Send(GetForwardedEvent().Release());
             } else {
                 while (Context->Queue->Head()) {
-                    HasReply = false;
                     ctx.Send(GetForwardedEvent().Release());
                     int count = 100;
                     while (!HasReply && count > 0) {
@@ -1986,7 +1985,7 @@ namespace NActors {
                             Runtime->DispatchEvents(DelegateeOptions);
                         } catch (TEmptyEventQueueException&) {
                             count--;
-                            Cerr << "No reply" << Endl;
+                            Cerr << "No reply RequestType# " << RequestType << Endl;
                         }
                     }
 
@@ -1997,11 +1996,15 @@ namespace NActors {
 
         TAutoPtr<IEventHandle> GetForwardedEvent() {
             IEventHandle* ev = Context->Queue->Head();
-            ReplyChecker->OnRequest(ev);
+            RequestType = ev->GetTypeRewrite();
+            HasReply = !ReplyChecker->OnRequest(ev);
             TAutoPtr<IEventHandle> forwardedEv = ev->HasEvent()
                     ? new IEventHandle(Delegatee, ReplyId, ev->ReleaseBase().Release(), ev->Flags, ev->Cookie)
                     : new IEventHandle(ev->GetTypeRewrite(), ev->Flags, Delegatee, ReplyId, ev->ReleaseChainBuffer(), ev->Cookie);
 
+            if (HasReply) {
+                delete Context->Queue->Pop();
+            }
             return forwardedEv;
         }
     private:
@@ -2014,6 +2017,7 @@ namespace NActors {
         TDispatchOptions DelegateeOptions;
         TTestActorRuntimeBase* Runtime;
         THolder<IReplyChecker> ReplyChecker;
+        ui32 RequestType;
     };
 
     void TStrandingActorDecorator::TReplyActor::StateFunc(STFUNC_SIG) {

--- a/ydb/library/actors/testlib/test_runtime.h
+++ b/ydb/library/actors/testlib/test_runtime.h
@@ -856,12 +856,13 @@ namespace NActors {
 
     struct IReplyChecker {
         virtual ~IReplyChecker() {}
-        virtual void OnRequest(IEventHandle *request) = 0;
+        virtual bool OnRequest(IEventHandle *request) = 0;
         virtual bool IsWaitingForMoreResponses(IEventHandle *response) = 0;
     };
 
     struct TNoneReplyChecker : IReplyChecker {
-        void OnRequest(IEventHandle*) override {
+        bool OnRequest(IEventHandle*) override {
+            return false;
         }
 
         bool IsWaitingForMoreResponses(IEventHandle*) override {


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

Fix stranded PDisk actor while using testlib

### Changelog category <!-- remove all except one -->

* Not for changelog (changelog entry is not required)

### Description for reviewers <!-- (optional) description for those who read this PR -->

Implementation of stranded actors required at least one response per request for these actors. This patch fixes that behaviour, which sometimes led to unittest hanging during processing PDisk queries.
