### PR TITLE
The serialized TEvReadSet takes up a lot of memory

### DIFF
--- a/ydb/core/persqueue/pq_impl.cpp
+++ b/ydb/core/persqueue/pq_impl.cpp
@@ -667,6 +667,11 @@ void TPersQueue::HandleTransactionsReadResponse(NKikimrClient::TResponse&& resp,
         (resp.ReadRangeResultSize() == 1) &&
         (resp.HasSetExecutorFastLogPolicyResult()) &&
         (resp.GetSetExecutorFastLogPolicyResult().GetStatus() == NKikimrProto::OK);
+    if (!ok) {
+        PQ_LOG_ERROR_AND_DIE("Transactions read error: " << resp.ShortDebugString());
+        return;
+    }
+
     const auto& result = resp.GetReadRangeResult(0);
     auto status = result.GetStatus();
     if (status != NKikimrProto::OVERRUN &&

--- a/ydb/core/persqueue/pq_impl.cpp
+++ b/ydb/core/persqueue/pq_impl.cpp
@@ -2955,13 +2955,8 @@ void TPersQueue::RestartPipe(ui64 tabletId, const TActorContext& ctx)
         }
 
         for (const auto& message : tx->GetBindedMsgs(tabletId)) {
-            auto event = std::make_unique<TEvTxProcessing::TEvReadSet>(message->Record.GetStep(),
-                                                                       message->Record.GetTxId(),
-                                                                       message->Record.GetTabletSource(),
-                                                                       message->Record.GetTabletDest(),
-                                                                       message->Record.GetTabletProducer(),
-                                                                       message->Record.GetReadSet(),
-                                                                       message->Record.GetSeqno());
+            auto event = std::make_unique<TEvTxProcessing::TEvReadSet>();
+            event->Record = message;
             PipeClientCache->Send(ctx, tabletId, event.release());
         }
     }

--- a/ydb/core/persqueue/pq_impl.cpp
+++ b/ydb/core/persqueue/pq_impl.cpp
@@ -2945,20 +2945,6 @@ void TPersQueue::Handle(TEvTabletPipe::TEvClientDestroyed::TPtr& ev, const TActo
     RestartPipe(ev->Get()->TabletId, ctx);
 }
 
-//void TPersQueue::RestartPipe(ui64 tabletId, const TActorContext& ctx)
-//{
-//    for (ui64 txId : GetBindedTxs(tabletId)) {
-//        auto* tx = GetTransaction(ctx, txId);
-//        if (!tx) {
-//            continue;
-//        }
-//
-//        for (auto& message : tx->GetBindedMsgs(tabletId)) {
-//            PipeClientCache->Send(ctx, tabletId, message.Type, message.Data);
-//        }
-//    }
-//}
-
 void TPersQueue::RestartPipe(ui64 tabletId, const TActorContext& ctx)
 {
     for (ui64 txId : GetBindedTxs(tabletId)) {
@@ -4146,18 +4132,6 @@ void TPersQueue::SendEvProposeTransactionResult(const TActorContext& ctx,
              ")");
     ctx.Send(tx.SourceActor, std::move(result));
 }
-
-//void TPersQueue::SendToPipe(ui64 tabletId,
-//                            TDistributedTransaction& tx,
-//                            std::unique_ptr<IEventBase> event,
-//                            const TActorContext& ctx)
-//{
-//    Y_ABORT_UNLESS(event);
-//
-//    BindTxToPipe(tabletId, tx.TxId);
-//    tx.BindMsgToPipe(tabletId, *event);
-//    PipeClientCache->Send(ctx, tabletId, event.release());
-//}
 
 void TPersQueue::SendToPipe(ui64 tabletId,
                             TDistributedTransaction& tx,

--- a/ydb/core/persqueue/pq_impl.h
+++ b/ydb/core/persqueue/pq_impl.h
@@ -358,11 +358,22 @@ private:
     void EndWriteTabletState(const NKikimrClient::TResponse& resp,
                              const TActorContext& ctx);
 
+    void SendProposeTransactionResult(const TActorId& target,
+                                      ui64 txId,
+                                      NKikimrPQ::TEvProposeTransactionResult::EStatus status,
+                                      NKikimrPQ::TError::EKind kind,
+                                      const TString& reason,
+                                      const TActorContext& ctx);
     void SendProposeTransactionAbort(const TActorId& target,
                                      ui64 txId,
                                      NKikimrPQ::TError::EKind kind,
                                      const TString& reason,
                                      const TActorContext& ctx);
+    void SendProposeTransactionOverloaded(const TActorId& target,
+                                          ui64 txId,
+                                          NKikimrPQ::TError::EKind kind,
+                                          const TString& reason,
+                                          const TActorContext& ctx);
 
     void Handle(TEvPQ::TEvProposePartitionConfigResult::TPtr& ev, const TActorContext& ctx);
     void HandleDataTransaction(TAutoPtr<TEvPersQueue::TEvProposeTransaction> event,

--- a/ydb/core/persqueue/pq_impl.h
+++ b/ydb/core/persqueue/pq_impl.h
@@ -403,10 +403,6 @@ private:
 
     void ClearNewConfig();
 
-    //void SendToPipe(ui64 tabletId,
-    //                TDistributedTransaction& tx,
-    //                std::unique_ptr<IEventBase> event,
-    //                const TActorContext& ctx);
     void SendToPipe(ui64 tabletId,
                     TDistributedTransaction& tx,
                     std::unique_ptr<TEvTxProcessing::TEvReadSet> event,

--- a/ydb/core/persqueue/pq_impl.h
+++ b/ydb/core/persqueue/pq_impl.h
@@ -403,9 +403,13 @@ private:
 
     void ClearNewConfig();
 
+    //void SendToPipe(ui64 tabletId,
+    //                TDistributedTransaction& tx,
+    //                std::unique_ptr<IEventBase> event,
+    //                const TActorContext& ctx);
     void SendToPipe(ui64 tabletId,
                     TDistributedTransaction& tx,
-                    std::unique_ptr<IEventBase> event,
+                    std::unique_ptr<TEvTxProcessing::TEvReadSet> event,
                     const TActorContext& ctx);
 
     void InitTransactions(const NKikimrClient::TKeyValueResponse::TReadRangeResult& readRange,

--- a/ydb/core/persqueue/transaction.cpp
+++ b/ydb/core/persqueue/transaction.cpp
@@ -424,16 +424,6 @@ TString TDistributedTransaction::GetKey() const
     return GetTxKey(TxId);
 }
 
-//void TDistributedTransaction::BindMsgToPipe(ui64 tabletId, const IEventBase& event)
-//{
-//    Y_ABORT_UNLESS(event.IsSerializable());
-//
-//    TAllocChunkSerializer serializer;
-//    Y_ABORT_UNLESS(event.SerializeToArcadiaStream(&serializer));
-//    auto data = serializer.Release(event.CreateSerializationInfo());
-//    OutputMsgs[tabletId].emplace_back(event.Type(), std::move(data));
-//}
-
 void TDistributedTransaction::BindMsgToPipe(ui64 tabletId, const TEvTxProcessing::TEvReadSet& event)
 {
     auto copy = std::make_unique<TEvTxProcessing::TEvReadSet>(event.Record.GetStep(),
@@ -450,17 +440,6 @@ void TDistributedTransaction::UnbindMsgsFromPipe(ui64 tabletId)
 {
     OutputMsgs.erase(tabletId);
 }
-
-//auto TDistributedTransaction::GetBindedMsgs(ui64 tabletId) -> const TVector<TSerializedMessage>&
-//{
-//    if (auto p = OutputMsgs.find(tabletId); p != OutputMsgs.end()) {
-//        return p->second;
-//    }
-//
-//    static TVector<TSerializedMessage> empty;
-//
-//    return empty;
-//}
 
 auto TDistributedTransaction::GetBindedMsgs(ui64 tabletId) -> const TVector<TEvReadSetPtr>&
 {

--- a/ydb/core/persqueue/transaction.cpp
+++ b/ydb/core/persqueue/transaction.cpp
@@ -424,14 +424,26 @@ TString TDistributedTransaction::GetKey() const
     return GetTxKey(TxId);
 }
 
-void TDistributedTransaction::BindMsgToPipe(ui64 tabletId, const IEventBase& event)
-{
-    Y_ABORT_UNLESS(event.IsSerializable());
+//void TDistributedTransaction::BindMsgToPipe(ui64 tabletId, const IEventBase& event)
+//{
+//    Y_ABORT_UNLESS(event.IsSerializable());
+//
+//    TAllocChunkSerializer serializer;
+//    Y_ABORT_UNLESS(event.SerializeToArcadiaStream(&serializer));
+//    auto data = serializer.Release(event.CreateSerializationInfo());
+//    OutputMsgs[tabletId].emplace_back(event.Type(), std::move(data));
+//}
 
-    TAllocChunkSerializer serializer;
-    Y_ABORT_UNLESS(event.SerializeToArcadiaStream(&serializer));
-    auto data = serializer.Release(event.CreateSerializationInfo());
-    OutputMsgs[tabletId].emplace_back(event.Type(), std::move(data));
+void TDistributedTransaction::BindMsgToPipe(ui64 tabletId, const TEvTxProcessing::TEvReadSet& event)
+{
+    auto copy = std::make_unique<TEvTxProcessing::TEvReadSet>(event.Record.GetStep(),
+                                                              event.Record.GetTxId(),
+                                                              event.Record.GetTabletSource(),
+                                                              event.Record.GetTabletDest(),
+                                                              event.Record.GetTabletProducer(),
+                                                              event.Record.GetReadSet(),
+                                                              event.Record.GetSeqno());
+    OutputMsgs[tabletId].push_back(std::move(copy));
 }
 
 void TDistributedTransaction::UnbindMsgsFromPipe(ui64 tabletId)
@@ -439,13 +451,24 @@ void TDistributedTransaction::UnbindMsgsFromPipe(ui64 tabletId)
     OutputMsgs.erase(tabletId);
 }
 
-auto TDistributedTransaction::GetBindedMsgs(ui64 tabletId) -> const TVector<TSerializedMessage>&
+//auto TDistributedTransaction::GetBindedMsgs(ui64 tabletId) -> const TVector<TSerializedMessage>&
+//{
+//    if (auto p = OutputMsgs.find(tabletId); p != OutputMsgs.end()) {
+//        return p->second;
+//    }
+//
+//    static TVector<TSerializedMessage> empty;
+//
+//    return empty;
+//}
+
+auto TDistributedTransaction::GetBindedMsgs(ui64 tabletId) -> const TVector<TEvReadSetPtr>&
 {
     if (auto p = OutputMsgs.find(tabletId); p != OutputMsgs.end()) {
         return p->second;
     }
 
-    static TVector<TSerializedMessage> empty;
+    static TVector<TEvReadSetPtr> empty;
 
     return empty;
 }

--- a/ydb/core/persqueue/transaction.cpp
+++ b/ydb/core/persqueue/transaction.cpp
@@ -426,14 +426,7 @@ TString TDistributedTransaction::GetKey() const
 
 void TDistributedTransaction::BindMsgToPipe(ui64 tabletId, const TEvTxProcessing::TEvReadSet& event)
 {
-    auto copy = std::make_unique<TEvTxProcessing::TEvReadSet>(event.Record.GetStep(),
-                                                              event.Record.GetTxId(),
-                                                              event.Record.GetTabletSource(),
-                                                              event.Record.GetTabletDest(),
-                                                              event.Record.GetTabletProducer(),
-                                                              event.Record.GetReadSet(),
-                                                              event.Record.GetSeqno());
-    OutputMsgs[tabletId].push_back(std::move(copy));
+    OutputMsgs[tabletId].push_back(event.Record);
 }
 
 void TDistributedTransaction::UnbindMsgsFromPipe(ui64 tabletId)
@@ -441,13 +434,13 @@ void TDistributedTransaction::UnbindMsgsFromPipe(ui64 tabletId)
     OutputMsgs.erase(tabletId);
 }
 
-auto TDistributedTransaction::GetBindedMsgs(ui64 tabletId) -> const TVector<TEvReadSetPtr>&
+const TVector<NKikimrTx::TEvReadSet>& TDistributedTransaction::GetBindedMsgs(ui64 tabletId)
 {
     if (auto p = OutputMsgs.find(tabletId); p != OutputMsgs.end()) {
         return p->second;
     }
 
-    static TVector<TEvReadSetPtr> empty;
+    static TVector<NKikimrTx::TEvReadSet> empty;
 
     return empty;
 }

--- a/ydb/core/persqueue/transaction.h
+++ b/ydb/core/persqueue/transaction.h
@@ -97,13 +97,11 @@ struct TDistributedTransaction {
 
     TString LogPrefix() const;
 
-    using TEvReadSetPtr = std::unique_ptr<TEvTxProcessing::TEvReadSet>;
-
-    THashMap<ui64, TVector<TEvReadSetPtr>> OutputMsgs;
+    THashMap<ui64, TVector<NKikimrTx::TEvReadSet>> OutputMsgs;
 
     void BindMsgToPipe(ui64 tabletId, const TEvTxProcessing::TEvReadSet& event);
     void UnbindMsgsFromPipe(ui64 tabletId);
-    const TVector<TEvReadSetPtr>& GetBindedMsgs(ui64 tabletId);
+    const TVector<NKikimrTx::TEvReadSet>& GetBindedMsgs(ui64 tabletId);
 
     bool HasWriteOperations = false;
     size_t PredicateAcksCount = 0;

--- a/ydb/core/persqueue/transaction.h
+++ b/ydb/core/persqueue/transaction.h
@@ -97,26 +97,12 @@ struct TDistributedTransaction {
 
     TString LogPrefix() const;
 
-    //struct TSerializedMessage {
-    //    ui32 Type;
-    //    TIntrusivePtr<TEventSerializedData> Data;
-
-    //    TSerializedMessage(ui32 type, TIntrusivePtr<TEventSerializedData> data) :
-    //        Type(type),
-    //        Data(data)
-    //    {
-    //    }
-    //};
-
     using TEvReadSetPtr = std::unique_ptr<TEvTxProcessing::TEvReadSet>;
 
-    //THashMap<ui64, TVector<TSerializedMessage>> OutputMsgs;
     THashMap<ui64, TVector<TEvReadSetPtr>> OutputMsgs;
 
-    //void BindMsgToPipe(ui64 tabletId, const IEventBase& event);
     void BindMsgToPipe(ui64 tabletId, const TEvTxProcessing::TEvReadSet& event);
     void UnbindMsgsFromPipe(ui64 tabletId);
-    //const TVector<TSerializedMessage>& GetBindedMsgs(ui64 tabletId);
     const TVector<TEvReadSetPtr>& GetBindedMsgs(ui64 tabletId);
 
     bool HasWriteOperations = false;

--- a/ydb/core/persqueue/transaction.h
+++ b/ydb/core/persqueue/transaction.h
@@ -97,22 +97,27 @@ struct TDistributedTransaction {
 
     TString LogPrefix() const;
 
-    struct TSerializedMessage {
-        ui32 Type;
-        TIntrusivePtr<TEventSerializedData> Data;
+    //struct TSerializedMessage {
+    //    ui32 Type;
+    //    TIntrusivePtr<TEventSerializedData> Data;
 
-        TSerializedMessage(ui32 type, TIntrusivePtr<TEventSerializedData> data) :
-            Type(type),
-            Data(data)
-        {
-        }
-    };
+    //    TSerializedMessage(ui32 type, TIntrusivePtr<TEventSerializedData> data) :
+    //        Type(type),
+    //        Data(data)
+    //    {
+    //    }
+    //};
 
-    THashMap<ui64, TVector<TSerializedMessage>> OutputMsgs;
+    using TEvReadSetPtr = std::unique_ptr<TEvTxProcessing::TEvReadSet>;
 
-    void BindMsgToPipe(ui64 tabletId, const IEventBase& event);
+    //THashMap<ui64, TVector<TSerializedMessage>> OutputMsgs;
+    THashMap<ui64, TVector<TEvReadSetPtr>> OutputMsgs;
+
+    //void BindMsgToPipe(ui64 tabletId, const IEventBase& event);
+    void BindMsgToPipe(ui64 tabletId, const TEvTxProcessing::TEvReadSet& event);
     void UnbindMsgsFromPipe(ui64 tabletId);
-    const TVector<TSerializedMessage>& GetBindedMsgs(ui64 tabletId);
+    //const TVector<TSerializedMessage>& GetBindedMsgs(ui64 tabletId);
+    const TVector<TEvReadSetPtr>& GetBindedMsgs(ui64 tabletId);
 
     bool HasWriteOperations = false;
     size_t PredicateAcksCount = 0;

--- a/ydb/core/persqueue/ut/pqtablet_ut.cpp
+++ b/ydb/core/persqueue/ut/pqtablet_ut.cpp
@@ -2123,7 +2123,7 @@ Y_UNIT_TEST_F(Limit_On_The_Number_Of_Transactons, TPQTabletFixture)
     }
 
     size_t preparedCount = 0;
-    size_t abortedCount = 0;
+    size_t overloadedCount = 0;
 
     for (ui64 i = 0; i < 1002; ++i) {
         auto event = Ctx->Runtime->GrabEdgeEvent<TEvPersQueue::TEvProposeTransactionResult>();
@@ -2136,8 +2136,8 @@ Y_UNIT_TEST_F(Limit_On_The_Number_Of_Transactons, TPQTabletFixture)
         case NKikimrPQ::TEvProposeTransactionResult::PREPARED:
             ++preparedCount;
             break;
-        case NKikimrPQ::TEvProposeTransactionResult::ABORTED:
-            ++abortedCount;
+        case NKikimrPQ::TEvProposeTransactionResult::OVERLOADED:
+            ++overloadedCount;
             break;
         default:
             UNIT_FAIL("unexpected transaction status " << NKikimrPQ::TEvProposeTransactionResult_EStatus_Name(status));
@@ -2145,7 +2145,7 @@ Y_UNIT_TEST_F(Limit_On_The_Number_Of_Transactons, TPQTabletFixture)
     }
 
     UNIT_ASSERT_EQUAL(preparedCount, 1000);
-    UNIT_ASSERT_EQUAL(abortedCount, 2);
+    UNIT_ASSERT_EQUAL(overloadedCount, 2);
 }
 
 }

--- a/ydb/core/persqueue/ut/pqtablet_ut.cpp
+++ b/ydb/core/persqueue/ut/pqtablet_ut.cpp
@@ -2107,6 +2107,47 @@ Y_UNIT_TEST_F(TEvReadSet_For_A_Non_Existent_Tablet, TPQTabletFixture)
     WaitForTheTransactionToBeDeleted(txId);
 }
 
+Y_UNIT_TEST_F(Limit_On_The_Number_Of_Transactons, TPQTabletFixture)
+{
+    const ui64 mockTabletId = MakeTabletID(false, 22222);
+    const ui64 txId = 67890;
+
+    PQTabletPrepare({.partitions=1}, {}, *Ctx);
+
+    for (ui64 i = 0; i < 1002; ++i) {
+        SendProposeTransactionRequest({.TxId=txId + i,
+                                      .Senders={mockTabletId}, .Receivers={mockTabletId},
+                                      .TxOps={
+                                      {.Partition=0, .Consumer="user", .Begin=0, .End=0, .Path="/topic"},
+                                      }});
+    }
+
+    size_t preparedCount = 0;
+    size_t abortedCount = 0;
+
+    for (ui64 i = 0; i < 1002; ++i) {
+        auto event = Ctx->Runtime->GrabEdgeEvent<TEvPersQueue::TEvProposeTransactionResult>();
+        UNIT_ASSERT(event != nullptr);
+
+        UNIT_ASSERT(event->Record.HasStatus());
+
+        const auto status = event->Record.GetStatus();
+        switch (status) {
+        case NKikimrPQ::TEvProposeTransactionResult::PREPARED:
+            ++preparedCount;
+            break;
+        case NKikimrPQ::TEvProposeTransactionResult::ABORTED:
+            ++abortedCount;
+            break;
+        default:
+            UNIT_FAIL("unexpected transaction status " << NKikimrPQ::TEvProposeTransactionResult_EStatus_Name(status));
+        }
+    }
+
+    UNIT_ASSERT_EQUAL(preparedCount, 1000);
+    UNIT_ASSERT_EQUAL(abortedCount, 2);
+}
+
 }
 
 }


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

Issue #18290

The TEvReadSet message can be sent again. When it was first sent, it was serialized and stored as a string. It turned out that the serialized message takes up a lot of memory space. For transactions with a large number of participants, this takes up a lot of space.

I changed it so that a copy of the data is stored to create a TEvReadSet when resending.

### Changelog category <!-- remove all except one -->

* Bugfix 

### Description for reviewers <!-- (optional) description for those who read this PR -->

...
