### PR TITLE
ticket parser: use folder_id attribute instead of containter_id

### DIFF
--- a/ydb/core/grpc_services/grpc_request_check_actor.h
+++ b/ydb/core/grpc_services/grpc_request_check_actor.h
@@ -62,13 +62,13 @@ inline TVector<TEvTicketParser::TEvAuthorizeTicket::TEntry> GetEntriesForAuthAnd
         });
         auto it = std::find_if(rootAttributes.begin(), rootAttributes.end(),
         [](const std::pair<TString, TString>& p) {
-            return p.first == "container_id";
+            return p.first == "folder_id";
         });
         if (it == rootAttributes.end()) {
             return {};
         }
         return {
-            {permissions, {{"gizmo_id", it->second}}}
+            {permissions, {{"folder_id", it->second}}}
         };
     } else {
         return {};

--- a/ydb/core/security/ticket_parser_impl.h
+++ b/ydb/core/security/ticket_parser_impl.h
@@ -474,13 +474,6 @@ private:
             AddNebiusResourcePath(pathsContainer, databaseId);
         }
 
-        // Use attribute "gizmo_id" as container id that contains cluster access resource
-        // IAM can link roles for cluster access resource
-        // Note: "gizmo_id" and "folder_id" are always sent in separate TEvAuthorizeTicket requests
-        if (const auto gizmoId = record.GetAttributeValue(permission, "gizmo_id"); gizmoId) {
-            SetNebiusContainerId(pathsContainer, gizmoId);
-        }
-
         // Use attribute "folder_id" as container id that contains our database
         // IAM can link roles for containers hierarchy
         if (const auto folderId = record.GetAttributeValue(permission, "folder_id"); folderId) {
@@ -1703,6 +1696,8 @@ protected:
         sids.emplace_back(permission + '@' + AccessServiceDomain);
         if (const TString databaseId = record.GetAttributeValue(permission, "database_id"); databaseId) {
             sids.emplace_back(permission + '-' + databaseId + '@' + AccessServiceDomain);
+        } else if (const TString folderId = record.GetAttributeValue(permission, "folder_id"); folderId) {
+            sids.emplace_back(permission + '-' + folderId + '@' + AccessServiceDomain);
         }
         if (const TString gizmoId = record.GetAttributeValue(permission, "gizmo_id"); gizmoId) {
             sids.emplace_back(permission + '-' + gizmoId + '@' + AccessServiceDomain);

--- a/ydb/core/security/ticket_parser_ut.cpp
+++ b/ydb/core/security/ticket_parser_ut.cpp
@@ -1661,17 +1661,17 @@ Y_UNIT_TEST_SUITE(TTicketParserTest) {
         UNIT_ASSERT_C(result->Error.empty(), result->Error);
         UNIT_ASSERT_C(result->Token->IsExist("something.read-bbbb4554@as"), result->Token->ShortDebugString());
 
-        // Authorization successful for gizmo resource
+        // Authorization successful for cluster resource
         accessServiceMock.AllowedResourceIds.clear();
-        accessServiceMock.AllowedResourceIds.emplace("gizmo");
+        accessServiceMock.AllowedResourceIds.emplace("folder");
         runtime->Send(new IEventHandle(MakeTicketParserID(), sender, new TEvTicketParser::TEvAuthorizeTicket(
                                         userToken,
-                                        {{"gizmo_id", "gizmo"}, },
+                                        {{"folder_id", "folder"}, },
                                         {"monitoring.view"})), 0);
         result = runtime->GrabEdgeEvent<TEvTicketParser::TEvAuthorizeTicketResult>(handle);
         UNIT_ASSERT_C(result->Error.empty(), result->Error);
         UNIT_ASSERT_C(result->Token->IsExist("monitoring.view@as"), result->Token->ShortDebugString());
-        UNIT_ASSERT_C(result->Token->IsExist("monitoring.view-gizmo@as"), result->Token->ShortDebugString());
+        UNIT_ASSERT_C(result->Token->IsExist("monitoring.view-folder@as"), result->Token->ShortDebugString());
     }
 
     Y_UNIT_TEST(Authorization) {


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

use folder_id attribute instead of containter_id

### Changelog category <!-- remove all except one -->

* Improvement

### Description for reviewers <!-- (optional) description for those who read this PR -->

...
