### PR TITLE
Fail when unable to get rack\dc info about hosts

### DIFF
--- a/ydb/tools/cfg/bin/__main__.py
+++ b/ydb/tools/cfg/bin/__main__.py
@@ -64,9 +64,6 @@ def cfg_generate(args):
     if walle_enabled and k8s_enabled:
         raise RuntimeError("you specified 'use_walle: True' and 'k8s_settings.use: True', please select a single host info provider")
 
-    if not walle_enabled and not k8s_enabled:
-        logger.warning("you didn't specify any host info provider (neither walle nor k8s). Make sure you know what you are doing")
-
     generator = cfg_cls(cluster_template, args.binary_path, args.output_dir, host_info_provider=host_info_provider, **kwargs)
 
     all_configs = generator.get_all_configs()

--- a/ydb/tools/cfg/walle/walle.py
+++ b/ydb/tools/cfg/walle/walle.py
@@ -3,7 +3,6 @@
 import os
 import requests
 import threading
-import zlib
 import json
 import time
 
@@ -34,15 +33,13 @@ class NopHostsInformationProvider(HostsInformationProvider):
         pass
 
     def get_rack(self, hostname):
-        return hostname
+        raise RuntimeError(f"failed to get rack info for {hostname}. Specify one way: walle provider, k8s provider or explicit host.location.rack")
 
     def get_datacenter(self, hostname):
-        # Keep DC name short, because of
-        # BAD_REQUEST (nameservice validator: node 1 has data center in Wall-E location longer than 4 symbols)
-        return "FAKE"
+        raise RuntimeError(f"failed to get datacenter info for {hostname}. Specify one way: walle provider, k8s provider or explicit host.location.datacenter")
 
     def get_body(self, hostname):
-        return zlib.crc32(hostname.encode())
+        raise RuntimeError(f"failed to get body info for {hostname}. Specify one way: walle provider, k8s provider or explicit host.location.body")
 
 
 class WalleHostsInformationProvider(HostsInformationProvider):


### PR DESCRIPTION
### Changelog category <!-- remove all except one -->

* Not for changelog (changelog entry is not required)

### Description for reviewers <!-- (optional) description for those who read this PR -->

There are three ways to supply host, rack and body information for the `hosts` field: k8s provider, walle provider and directly specifying the values in config.yaml. Previously we allowed fake values to be generated when none of these methods worked for a particular host. Now we fail immediately, this must not happen in production. 