### PR TITLE
`--replace` option for `ydb tools restore`

### DIFF
--- a/ydb/apps/ydb/CHANGELOG.md
+++ b/ydb/apps/ydb/CHANGELOG.md
@@ -1,3 +1,4 @@
+* Add `--replace` option to `ydb tools restore` command. If enabled, scheme objects present in the backup would be dropped before restoring.
 * Added date range parameters (--date-to, --date-from to support uniform PK distribution) for ydb workload log run operations including bulk_upsert, insert, and upsert
 * Do not save to local backups destination tables of `ASYNC REPLICATION` and its changefeeds. It prevents duplication of changefeeds and reduces the amount of space the backup takes on disk.
 * Fix `ydb operation get` not working for running operations.

--- a/ydb/public/lib/ydb_cli/commands/ydb_tools.cpp
+++ b/ydb/public/lib/ydb_cli/commands/ydb_tools.cpp
@@ -211,6 +211,15 @@ void TCommandRestore::Config(TConfig& config) {
             " with secondary indexes, make sure it's not already present in the scheme.")
         .StoreTrue(&UseImportData);
 
+    config.Opts->AddLongOption("replace", "Remove existing objects from the database that match those in the backup before restoration."
+        " Objects present in the backup but missing in the database are restored as usual; removal is skipped."
+        " If both --replace and --verify-existence are specified, restoration stops with an error when the first such object is found.")
+        .StoreTrue(&Replace);
+
+    config.Opts->AddLongOption("verify-existence", "Use with --replace to report an error if an object in the backup is missing from the database"
+        " instead of silently skipping its removal.")
+        .StoreTrue(&VerifyExistence);
+
     config.Opts->MutuallyExclusive("bandwidth", "rps");
     config.Opts->MutuallyExclusive("import-data", "bulk-upsert");
     config.Opts->MutuallyExclusive("import-data", "upload-batch-rows");
@@ -230,7 +239,9 @@ int TCommandRestore::Run(TConfig& config) {
         .RestoreACL(RestoreACL)
         .SkipDocumentTables(SkipDocumentTables)
         .SavePartialResult(SavePartialResult)
-        .RowsPerRequest(NYdb::SizeFromString(RowsPerRequest));
+        .RowsPerRequest(NYdb::SizeFromString(RowsPerRequest))
+        .Replace(Replace)
+        .VerifyExistence(VerifyExistence);
 
     if (InFlight) {
         settings.MaxInFlight(InFlight);

--- a/ydb/public/lib/ydb_cli/commands/ydb_tools.cpp
+++ b/ydb/public/lib/ydb_cli/commands/ydb_tools.cpp
@@ -277,6 +277,11 @@ int TCommandRestore::Run(TConfig& config) {
         settings.Mode(NDump::TRestoreSettings::EMode::ImportData);
     }
 
+    if (VerifyExistence && !Replace) {
+        throw TMisuseException()
+            << "the --verify-existence option must be used together with the --replace option";
+    }
+
     auto log = std::make_shared<TLog>(CreateLogBackend("cerr", TConfig::VerbosityLevelToELogPriority(config.VerbosityLevel)));
     log->SetFormatter(GetPrefixLogFormatter(""));
 

--- a/ydb/public/lib/ydb_cli/commands/ydb_tools.h
+++ b/ydb/public/lib/ydb_cli/commands/ydb_tools.h
@@ -61,6 +61,8 @@ private:
     bool RestoreACL = true;
     bool SkipDocumentTables = false;
     bool SavePartialResult = false;
+    bool Replace = false;
+    bool VerifyExistence = false;
     TString UploadBandwidth;
     TString UploadRps;
     TString RowsPerRequest;

--- a/ydb/public/lib/ydb_cli/common/recursive_remove.cpp
+++ b/ydb/public/lib/ydb_cli/common/recursive_remove.cpp
@@ -275,7 +275,7 @@ namespace NInternal {
         NCoordination::TClient& coordinationClient,
         const TRemoveDirectoryRecursiveSettings& settings
     ) {
-        return [&](const TSchemeEntry& entry) {
+        return [&, settings](const TSchemeEntry& entry) {
             return Remove(schemeClient, tableClient, topicClient, queryClient, coordinationClient, entry.Type, TString(entry.Name), settings.Prompt_, settings);
         };
     }

--- a/ydb/public/lib/ydb_cli/dump/dump.h
+++ b/ydb/public/lib/ydb_cli/dump/dump.h
@@ -101,6 +101,9 @@ struct TRestoreSettings: public TOperationRequestSettings<TRestoreSettings> {
     FLUENT_SETTING_DEFAULT(bool, RestoreACL, true);
     FLUENT_SETTING_DEFAULT(bool, SkipDocumentTables, false);
     FLUENT_SETTING_DEFAULT(bool, SavePartialResult, false);
+    FLUENT_SETTING_DEFAULT(bool, Replace, false);
+    // only makes sense when used together with the replace option
+    FLUENT_SETTING_DEFAULT(bool, VerifyExistence, false);
 
     FLUENT_SETTING_DEFAULT(ui64, MemLimit, 32_MB);
     FLUENT_SETTING_DEFAULT(ui64, RowsPerRequest, 0);

--- a/ydb/public/lib/ydb_cli/dump/restore_impl.cpp
+++ b/ydb/public/lib/ydb_cli/dump/restore_impl.cpp
@@ -995,7 +995,7 @@ namespace {
             || rhs == ESchemeEntryType::SubDomain && lhs == ESchemeEntryType::Directory;
     }
 
-    TStatus GetExternalTablesReferencingTheSource(TTableClient& client, const TString& path, TVector<TString>& references) {
+    TStatus GetExternalTablesReferencingSource(TTableClient& client, const TString& path, TVector<TString>& references) {
         references.clear();
 
         Ydb::Table::DescribeExternalDataSourceResult description;
@@ -1119,7 +1119,7 @@ TRestoreResult TRestoreClient::DropAndRestoreExternals(const TVector<TFsBackupEn
     for (size_t i : externalDataSources) {
         const auto& [fsPath, dbPath, type] = backupEntries[i];
         TVector<TString> references;
-        if (auto status = GetExternalTablesReferencingTheSource(TableClient, dbPath, references); !status.IsSuccess()) {
+        if (auto status = GetExternalTablesReferencingSource(TableClient, dbPath, references); !status.IsSuccess()) {
             return Result<TRestoreResult>(fsPath, std::move(status));
         }
         if (!AllOf(references, [&externalTables](const TString& dbPath) {

--- a/ydb/public/lib/ydb_cli/dump/restore_impl.cpp
+++ b/ydb/public/lib/ydb_cli/dump/restore_impl.cpp
@@ -17,6 +17,7 @@
 #include <ydb/public/lib/ydb_cli/dump/util/view_utils.h>
 #include <yql/essentials/public/issue/yql_issue.h>
 
+#include <library/cpp/json/json_reader.h>
 #include <library/cpp/json/json_writer.h>
 #include <library/cpp/threading/future/core/future.h>
 
@@ -425,6 +426,7 @@ TRestoreClient::TRestoreClient(const TDriver& driver, const std::shared_ptr<TLog
     , RateLimiterClient(driver)
     , QueryClient(driver)
     , CmsClient(driver)
+    , ReplicationClient(driver)
     , Log(log)
     , DriverConfig(driver.GetConfig())
 {
@@ -467,7 +469,15 @@ TRestoreResult TRestoreClient::Restore(const TString& fsPath, const TString& dbP
 
     // restore
     auto restoreResult = Result<TRestoreResult>();
-    restoreResult = RestoreFolder(fsPath, dbPath, settings, oldEntries);
+    if (settings.Replace_) {
+        if (settings.DryRun_) {
+            LOG_E("Combination of the dry run and the replace options is not supported yet.");
+            return Result<TRestoreResult>();
+        }
+        restoreResult = DropAndRestore(fsPath, dbPath, settings, oldEntries);
+    } else {
+        restoreResult = RestoreFolder(fsPath, dbPath, settings, oldEntries);
+    }
     if (auto result = DelayedRestoreManager.RestoreDelayed(); !result.IsSuccess()) {
         restoreResult = result;
     }
@@ -983,6 +993,48 @@ namespace {
         return out;
     }
 
+    bool TypesAreMatching(ESchemeEntryType lhs, ESchemeEntryType rhs) {
+        return lhs == rhs
+            || lhs == ESchemeEntryType::SubDomain && rhs == ESchemeEntryType::Directory
+            || rhs == ESchemeEntryType::SubDomain && lhs == ESchemeEntryType::Directory;
+    }
+
+    TStatus GetExternalTablesReferencingTheSource(TTableClient& client, const TString& path, TVector<TString>& references) {
+        references.clear();
+
+        Ydb::Table::DescribeExternalDataSourceResult description;
+        auto status = DescribeExternalDataSource(client, path, description);
+        if (!status.IsSuccess()) {
+            return status;
+        }
+        auto iteratorToReferences = description.properties().find("REFERENCES");
+        if (iteratorToReferences == description.properties().end()) {
+            return status;
+        }
+        auto items = NJson::ReadJsonFastTree(iteratorToReferences->second).GetArray();
+        references.reserve(items.size());
+        for (const auto& item : items) {
+            references.emplace_back(item.GetString());
+        }
+        return status;
+    }
+
+    TStatus GetReplicationSourceTables(NReplication::TReplicationClient& client, const TString& path, TVector<TString>& sources) {
+        sources.clear();
+
+        TMaybe<NReplication::TReplicationDescription> description;
+        auto status = DescribeReplication(client, path, description);
+        if (!status.IsSuccess()) {
+            return status;
+        }
+        const auto& items = description->GetItems();
+        sources.reserve(items.size());
+        for (const auto& item : items) {
+            sources.emplace_back(item.SrcPath);
+        }
+        return status;
+    }
+
 }
 
 TRestoreResult TRestoreClient::RestoreFolder(
@@ -1008,6 +1060,22 @@ TRestoreResult TRestoreClient::RestoreFolder(
     }
 
     return Result<TRestoreResult>();
+}
+
+TRestoreResult TRestoreClient::Drop(ESchemeEntryType type, const TString& path, bool verifyExistence) {
+    auto settings = TRemoveDirectoryRecursiveSettings().NotExistsIsOk(!verifyExistence);
+    auto remover = NInternal::CreateDefaultRemover(SchemeClient, TableClient, TopicClient, QueryClient, CoordinationNodeClient, settings);
+    TSchemeEntry entry;
+    entry.Type = type;
+    entry.Name = path;
+    TStatus result = remover(entry);
+
+    if (result.IsSuccess()) {
+        LOG_D("Dropped " << path.Quote());
+        return Result<TRestoreResult>();
+    }
+    LOG_E("Failed to drop " << path.Quote());
+    return Result<TRestoreResult>(path, std::move(result));
 }
 
 TRestoreResult TRestoreClient::Restore(NScheme::ESchemeEntryType type, const TFsPath& fsPath, const TString& dbRestoreRoot, const TString& dbPathRelativeToRestoreRoot, const TRestoreSettings& settings, bool isAlreadyExisting, bool delay) {
@@ -1045,6 +1113,192 @@ TRestoreResult TRestoreClient::Restore(NScheme::ESchemeEntryType type, const TFs
             ythrow TBadArgumentException() << "Attempting to restore an unexpected object from: " << fsPath << ", type: " << type;
     }
 
+}
+
+TRestoreResult TRestoreClient::DropAndRestoreExternals(const TVector<TFsBackupEntry>& backupEntries, const TVector<size_t>& externalDataSources, const THashMap<TString, size_t>& externalTables, const TRestoreSettings& settings) {
+    for (size_t i : externalDataSources) {
+        const auto& [fsPath, dbPath, type] = backupEntries[i];
+        TVector<TString> references;
+        if (auto status = GetExternalTablesReferencingTheSource(TableClient, dbPath, references); !status.IsSuccess()) {
+            return Result<TRestoreResult>(fsPath, std::move(status));
+        }
+        if (!AllOf(references, [&externalTables](const TString& dbPath) {
+            return externalTables.contains(dbPath);
+        })) {
+            return Result<TRestoreResult>(fsPath, EStatus::BAD_REQUEST,
+                "External data source cannot be replaced, because it is referenced by an external table that is not in the backup."
+            );
+        }
+    }
+
+    for (const auto& [dbPath, i] : externalTables) {
+        auto result = Drop(ESchemeEntryType::ExternalTable, dbPath, settings.VerifyExistence_);
+        if (!result.IsSuccess()) {
+            return result;
+        }
+    }
+    for (size_t i : externalDataSources) {
+        const auto& [fsPath, dbPath, type] = backupEntries[i];
+        if (auto result = Drop(type, dbPath, settings.VerifyExistence_); !result.IsSuccess()) {
+            return result;
+        }
+        if (auto result = RestoreExternalDataSource(fsPath, dbPath, settings, false); !result.IsSuccess()) {
+            return result;
+        }
+    }
+    for (const auto& [dbPath, i] : externalTables) {
+        const auto& fsPath = backupEntries[i].FsPath;
+        auto result = RestoreExternalTable(fsPath, dbPath, settings, false /* already exists */);
+        if (!result.IsSuccess()) {
+            return result;
+        }
+    }
+
+    return Result<TRestoreResult>();
+}
+
+TRestoreResult TRestoreClient::DropAndRestoreTablesAndDependents(const TVector<TFsBackupEntry>& backupEntries, const THashMap<TString, size_t>& tables, const TVector<size_t>& views, const THashMap<TString, size_t>& replications, const TString& dbRestoreRoot, const TRestoreSettings& settings, const THashMap<TString, ESchemeEntryType>& existingEntries) {
+    // to do: verify that no replication in the entire database (not just the restore root!) depends on the tables we are going to drop
+    for (const auto& [dbPath, type] : existingEntries) {
+        if (type == ESchemeEntryType::Replication && !replications.contains(dbPath)) {
+            // a replication that is not present in the backup, but present in the database
+            TVector<TString> sources;
+            if (auto status = GetReplicationSourceTables(ReplicationClient, dbPath, sources); !status.IsSuccess()) {
+                return status;
+            }
+            for (const auto& source : sources) {
+                if (tables.contains(source)) {
+                    return Result<TRestoreResult>(dbPath, EStatus::BAD_REQUEST,
+                        TStringBuilder() << "Cannot replace the table: " << source << ", because the replication: " << dbPath << " depends on it."
+                    );
+                }
+            }
+        }
+    }
+
+    for (size_t i : views) {
+        const auto& [fsPath, dbPath, type] = backupEntries[i];
+        if (auto result = Drop(type, dbPath, settings.VerifyExistence_); !result.IsSuccess()) {
+            return result;
+        }
+    }
+
+    for (const auto& [dbPath, i] : replications) {
+        if (auto result = Drop(ESchemeEntryType::Replication, dbPath, settings.VerifyExistence_); !result.IsSuccess()) {
+            return result;
+        }
+    }
+
+    // the main loop: tables are restored here
+    for (const auto& [_, i] : tables) {
+        const auto& [fsPath, dbPath, type] = backupEntries[i];
+        if (auto result = Drop(type, dbPath, settings.VerifyExistence_); !result.IsSuccess()) {
+            return result;
+        }
+        if (auto result = RestoreTable(fsPath, dbPath, settings, false); !result.IsSuccess()) {
+            return result;
+        }
+    }
+
+    for (const auto& [dbPath, i] : replications) {
+        const auto& fsPath = backupEntries[i].FsPath;
+        if (auto result = RestoreReplication(fsPath, dbRestoreRoot, dbPath.substr(dbRestoreRoot.size()), settings, false); !result.IsSuccess()) {
+            return result;
+        }
+    }
+
+    for (size_t i : views) {
+        const auto& [fsPath, dbPath, type] = backupEntries[i];
+        Y_ENSURE(dbPath.StartsWith(dbRestoreRoot), "dbPath must be built by appending a relative path to dbRestoreRoot");
+        // views might depend on other views, so we restore them with the help of a dedicated manager
+        DelayedRestoreManager.Add(type, fsPath, dbRestoreRoot, dbPath.substr(dbRestoreRoot.size()), settings, false);
+    }
+
+    return Result<TRestoreResult>();
+}
+
+TRestoreResult TRestoreClient::DropAndRestore(const TFsPath& fsBackupRoot, const TString& dbRestoreRoot, const TRestoreSettings& settings, const THashMap<TString, ESchemeEntryType>& existingEntries) {
+    TVector<TFsBackupEntry> backupEntries;
+    if (auto result = ListBackupEntries(fsBackupRoot, dbRestoreRoot, backupEntries); !result.IsSuccess()) {
+        return result;
+    }
+    LOG_D("List of entries in the backup: " << NJson::WriteJson(ConvertToJson(backupEntries), false));
+
+    // verify that types are matching
+    for (const auto& [fsPath, dbPath, type] : backupEntries) {
+        if (const auto* existingType = existingEntries.FindPtr(dbPath); existingType && !TypesAreMatching(*existingType, type)) {
+            return Result<TRestoreResult>(fsPath, EStatus::BAD_REQUEST,
+                TStringBuilder() << "Type mismatch: " << dbPath.Quote() << " already exists and has " << *existingType << " type."
+                    " It cannot be replaced with " << type << " from the backup."
+            );
+        }
+    }
+
+    TVector<size_t> directories;
+    THashMap<TString, size_t> tables;
+    TVector<size_t> views;
+    THashMap<TString, size_t> replications;
+    TVector<size_t> externalDataSources;
+    THashMap<TString, size_t> externalTables;
+
+    // scheme entries that do not require special handling (i.e. cannot have dependents)
+    TVector<size_t> regular;
+
+    for (size_t i = 0; i < backupEntries.size(); ++i) {
+        const auto& [fsPath, dbPath, type] = backupEntries[i];
+        switch (type) {
+            case ESchemeEntryType::Directory:
+                directories.emplace_back(i);
+                break;
+            case ESchemeEntryType::ExternalTable:
+                externalTables.emplace(dbPath, i);
+                break;
+            case ESchemeEntryType::ExternalDataSource:
+                externalDataSources.emplace_back(i);
+                break;
+            case ESchemeEntryType::Table:
+                tables.emplace(dbPath, i);
+                break;
+            case ESchemeEntryType::Replication:
+                replications.emplace(dbPath, i);
+                break;
+            case ESchemeEntryType::View:
+                views.emplace_back(i);
+                break;
+            default:
+                regular.emplace_back(i);
+                break;
+        }
+    }
+
+    for (size_t i : directories) {
+        const auto& [fsPath, dbPath, type] = backupEntries[i];
+        if (!existingEntries.contains(dbPath)) {
+            if (auto result = RestoreEmptyDir(fsPath, dbPath, settings, false); !result.IsSuccess()) {
+                return result;
+            }
+        }
+    }
+
+    if (auto result = DropAndRestoreExternals(backupEntries, externalDataSources, externalTables, settings); !result.IsSuccess()) {
+        return result;
+    }
+    if (auto result = DropAndRestoreTablesAndDependents(backupEntries, tables, views, replications, dbRestoreRoot, settings, existingEntries); !result.IsSuccess()) {
+        return result;
+    }
+
+    for (size_t i : regular) {
+        const auto& [fsPath, dbPath, type] = backupEntries[i];
+        if (auto result = Drop(type, dbPath, settings.VerifyExistence_); !result.IsSuccess()) {
+            return result;
+        }
+        Y_ENSURE(dbPath.StartsWith(dbRestoreRoot), "dbPath must be built by appending a relative path to dbRestoreRoot");
+        if (auto result = Restore(type, fsPath, dbRestoreRoot, dbPath.substr(dbRestoreRoot.size()), settings, false, false); !result.IsSuccess()) {
+            return result;
+        }
+    }
+
+    return Result<TRestoreResult>();
 }
 
 TRestoreResult TRestoreClient::RestoreView(

--- a/ydb/public/lib/ydb_cli/dump/restore_impl.h
+++ b/ydb/public/lib/ydb_cli/dump/restore_impl.h
@@ -4,6 +4,7 @@
 
 #include <ydb/public/sdk/cpp/include/ydb-cpp-sdk/client/cms/cms.h>
 #include <ydb/public/sdk/cpp/include/ydb-cpp-sdk/client/coordination/coordination.h>
+#include <ydb/public/sdk/cpp/include/ydb-cpp-sdk/client/draft/ydb_replication.h>
 #include <ydb/public/sdk/cpp/include/ydb-cpp-sdk/client/import/import.h>
 #include <ydb/public/sdk/cpp/include/ydb-cpp-sdk/client/operation/operation.h>
 #include <ydb/public/sdk/cpp/include/ydb-cpp-sdk/client/query/client.h>
@@ -233,7 +234,11 @@ class TRestoreClient {
         ui32 dataFilesCount);
 
     TRestoreResult CheckSecretExistence(const TString& secretName);
+    TRestoreResult Drop(NScheme::ESchemeEntryType type, const TString& path, bool verifyExistence);
     TRestoreResult Restore(NScheme::ESchemeEntryType type, const TFsPath& fsPath, const TString& dbRestoreRoot, const TString& dbPathRelativeToRestoreRoot, const TRestoreSettings& settings, bool isAlreadyExisting, bool delay);
+    TRestoreResult DropAndRestore(const TFsPath& fsPath, const TString& dbRestoreRoot, const TRestoreSettings& settings, const THashMap<TString, NScheme::ESchemeEntryType>& existingEntries);
+    TRestoreResult DropAndRestoreExternals(const TVector<NPrivate::TFsBackupEntry>& backupEntries, const TVector<size_t>& externalDataSources, const THashMap<TString, size_t>& externalTables, const TRestoreSettings& settings);
+    TRestoreResult DropAndRestoreTablesAndDependents(const TVector<NPrivate::TFsBackupEntry>& backupEntries, const THashMap<TString, size_t>& tables, const TVector<size_t>& views, const THashMap<TString, size_t>& replications, const TString& dbRestoreRoot, const TRestoreSettings& settings, const THashMap<TString, NScheme::ESchemeEntryType>& existingEntries);
 
 public:
     explicit TRestoreClient(const TDriver& driver, const std::shared_ptr<TLog>& log);
@@ -252,6 +257,7 @@ private:
     NRateLimiter::TRateLimiterClient RateLimiterClient;
     NQuery::TQueryClient QueryClient;
     NCms::TCmsClient CmsClient;
+    NReplication::TReplicationClient ReplicationClient;
     std::shared_ptr<TLog> Log;
     // Used to creating child drivers with different database settings.
     TDriverConfig DriverConfig;

--- a/ydb/public/lib/ydb_cli/dump/restore_impl.h
+++ b/ydb/public/lib/ydb_cli/dump/restore_impl.h
@@ -234,7 +234,7 @@ class TRestoreClient {
         ui32 dataFilesCount);
 
     TRestoreResult CheckSecretExistence(const TString& secretName);
-    TRestoreResult Drop(NScheme::ESchemeEntryType type, const TString& path, bool verifyExistence);
+    TRestoreResult Drop(NScheme::ESchemeEntryType type, const TString& path, const TRestoreSettings& settings);
     TRestoreResult Restore(NScheme::ESchemeEntryType type, const TFsPath& fsPath, const TString& dbRestoreRoot, const TString& dbPathRelativeToRestoreRoot, const TRestoreSettings& settings, bool isAlreadyExisting, bool delay);
     TRestoreResult DropAndRestore(const TFsPath& fsPath, const TString& dbRestoreRoot, const TRestoreSettings& settings, const THashMap<TString, NScheme::ESchemeEntryType>& existingEntries);
     TRestoreResult DropAndRestoreExternals(const TVector<NPrivate::TFsBackupEntry>& backupEntries, const TVector<size_t>& externalDataSources, const THashMap<TString, size_t>& externalTables, const TRestoreSettings& settings);

--- a/ydb/services/ydb/backup_ut/ydb_backup_ut.cpp
+++ b/ydb/services/ydb/backup_ut/ydb_backup_ut.cpp
@@ -2312,7 +2312,7 @@ Y_UNIT_TEST_SUITE(BackupRestore) {
 
         cleanup();
         TestReplicationSettingsArePreserved(endpoint, querySession, replicationClient,
-            CreateBackupLambda(driver, pathToBackup), CreateRestoreLambda(driver, pathToBackup, "/Root", restorationSettings), restorationSettings
+            CreateBackupLambda(driver, pathToBackup), CreateRestoreLambda(driver, pathToBackup, "/Root", restorationSettings), true, restorationSettings
         );
     }
 

--- a/ydb/services/ydb/backup_ut/ydb_backup_ut.cpp
+++ b/ydb/services/ydb/backup_ut/ydb_backup_ut.cpp
@@ -8,6 +8,7 @@
 #include <ydb/public/api/protos/ydb_rate_limiter.pb.h>
 #include <ydb/public/api/protos/ydb_table.pb.h>
 #include <ydb/public/lib/ydb_cli/common/recursive_list.h>
+#include <ydb/public/lib/ydb_cli/common/recursive_remove.h>
 #include <ydb/public/lib/ydb_cli/dump/dump.h>
 #include <ydb/public/lib/yson_value/ydb_yson_value.h>
 #include <ydb/public/sdk/cpp/include/ydb-cpp-sdk/client/coordination/coordination.h>
@@ -355,7 +356,7 @@ using TBackupFunction = std::function<void(void)>;
 using TRestoreFunction = std::function<void(void)>;
 
 void TestTableContentIsPreserved(
-    const char* table, TSession& session, TBackupFunction&& backup, TRestoreFunction&& restore
+    const char* table, TSession& session, TBackupFunction&& backup, TRestoreFunction&& restore, const NDump::TRestoreSettings& restorationSettings = {}
 ) {
     ExecuteDataDefinitionQuery(session, Sprintf(R"(
             CREATE TABLE `%s` (
@@ -384,10 +385,12 @@ void TestTableContentIsPreserved(
 
     backup();
 
-    ExecuteDataDefinitionQuery(session, Sprintf(R"(
-            DROP TABLE `%s`;
-        )", table
-    ));
+    if (!restorationSettings.Replace_) {
+        ExecuteDataDefinitionQuery(session, Sprintf(R"(
+                DROP TABLE `%s`;
+            )", table
+        ));
+    }
 
     restore();
     CompareResults(GetTableContent(session, table), originalContent);
@@ -721,7 +724,7 @@ void TestRestoreDirectory(const char* directory, TSchemeClient& client, TBackupF
 }
 
 void TestViewOutputIsPreserved(
-    const char* view, NQuery::TSession& session, TBackupFunction&& backup, TRestoreFunction&& restore
+    const char* view, NQuery::TSession& session, TBackupFunction&& backup, TRestoreFunction&& restore, const NDump::TRestoreSettings& restorationSettings = {}
 ) {
     constexpr const char* viewQuery = R"(
         SELECT 1 AS Key
@@ -739,11 +742,13 @@ void TestViewOutputIsPreserved(
 
     backup();
 
-    ExecuteQuery(session, Sprintf(R"(
-                DROP VIEW `%s`;
-            )", view
-        ), true
-    );
+    if (!restorationSettings.Replace_) {
+        ExecuteQuery(session, Sprintf(R"(
+                    DROP VIEW `%s`;
+                )", view
+            ), true
+        );
+    }
 
     restore();
     CompareResults(GetTableContent(session, view), originalContent);
@@ -938,7 +943,7 @@ void TestChangefeedAndTopicDescriptionsIsPreserved(
 
 void TestTopicSettingsArePreserved(
     const char* topic, NQuery::TSession& session, NTopic::TTopicClient& topicClient,
-    TBackupFunction&& backup, TRestoreFunction&& restore
+    TBackupFunction&& backup, TRestoreFunction&& restore, const NDump::TRestoreSettings& restorationSettings = {}
 ) {
     constexpr int minPartitions = 2;
     constexpr int maxPartitions = 5;
@@ -979,10 +984,12 @@ void TestTopicSettingsArePreserved(
 
     backup();
 
-    ExecuteQuery(session, Sprintf(R"(
-            DROP TOPIC `%s`;
-        )", topic
-    ), true);
+    if (!restorationSettings.Replace_) {
+        ExecuteQuery(session, Sprintf(R"(
+                DROP TOPIC `%s`;
+            )", topic
+        ), true);
+    }
 
     restore();
     checkDescription(DescribeTopic(topicClient, topic), DEBUG_HINT);
@@ -1010,7 +1017,8 @@ void TestCoordinationNodeSettingsArePreserved(
     const std::string& path,
     NCoordination::TClient& nodeClient,
     TBackupFunction&& backup,
-    TRestoreFunction&& restore
+    TRestoreFunction&& restore,
+    const NDump::TRestoreSettings& restorationSettings = {}
 ) {
     const auto settings = NCoordination::TCreateNodeSettings()
         .SelfCheckPeriod(TDuration::Seconds(2))
@@ -1032,7 +1040,9 @@ void TestCoordinationNodeSettingsArePreserved(
 
     backup();
 
-    DropCoordinationNode(nodeClient, path);
+    if (!restorationSettings.Replace_) {
+        DropCoordinationNode(nodeClient, path);
+    }
 
     restore();
     checkDescription(DescribeCoordinationNode(nodeClient, path), DEBUG_HINT);
@@ -1147,7 +1157,8 @@ void TestReplicationSettingsArePreserved(
         TReplicationClient& client,
         TBackupFunction&& backup,
         TRestoreFunction&& restore,
-        bool useSecret)
+        bool useSecret,
+        const NDump::TRestoreSettings& restorationSettings = {})
 {
     if (useSecret) {
         ExecuteQuery(session, "CREATE OBJECT `secret` (TYPE SECRET) WITH (value = 'root@builtin');", true);
@@ -1186,7 +1197,9 @@ void TestReplicationSettingsArePreserved(
     WaitReplicationInit(client, "/Root/replication");
     checkDescription();
     backup();
-    ExecuteQuery(session, "DROP ASYNC REPLICATION `/Root/replication` CASCADE;", true);
+    if (!restorationSettings.Replace_) {
+        ExecuteQuery(session, "DROP ASYNC REPLICATION `/Root/replication` CASCADE;", true);
+    }
     restore();
     WaitReplicationInit(client, "/Root/replication");
     checkDescription();
@@ -1199,7 +1212,7 @@ Ydb::Table::DescribeExternalDataSourceResult DescribeExternalDataSource(TSession
 }
 
 void TestExternalDataSourceSettingsArePreserved(
-    const char* path, TSession& tableSession, NQuery::TSession& querySession, TBackupFunction&& backup, TRestoreFunction&& restore
+    const char* path, TSession& tableSession, NQuery::TSession& querySession, TBackupFunction&& backup, TRestoreFunction&& restore, const NDump::TRestoreSettings& restorationSettings = {}
 ) {
     ExecuteQuery(querySession, Sprintf(R"(
                 CREATE EXTERNAL DATA SOURCE `%s` WITH (
@@ -1214,11 +1227,13 @@ void TestExternalDataSourceSettingsArePreserved(
 
     backup();
 
-    ExecuteQuery(querySession, Sprintf(R"(
-                DROP EXTERNAL DATA SOURCE `%s`;
-            )", path
-        ), true
-    );
+    if (!restorationSettings.Replace_) {
+        ExecuteQuery(querySession, Sprintf(R"(
+                    DROP EXTERNAL DATA SOURCE `%s`;
+                )", path
+            ), true
+        );
+    }
 
     restore();
     UNIT_ASSERT_VALUES_EQUAL(
@@ -1234,7 +1249,7 @@ Ydb::Table::DescribeExternalTableResult DescribeExternalTable(TSession& session,
 }
 
 void TestExternalTableSettingsArePreserved(
-    const char* path, const char* externalDataSource, TSession& tableSession, NQuery::TSession& querySession, TBackupFunction&& backup, TRestoreFunction&& restore
+    const char* path, const char* externalDataSource, TSession& tableSession, NQuery::TSession& querySession, TBackupFunction&& backup, TRestoreFunction&& restore, const NDump::TRestoreSettings& restorationSettings = {}
 ) {
     ExecuteQuery(querySession, Sprintf(R"(
                 CREATE EXTERNAL DATA SOURCE `%s` WITH (
@@ -1259,12 +1274,14 @@ void TestExternalTableSettingsArePreserved(
 
     backup();
 
-    ExecuteQuery(querySession, Sprintf(R"(
-                DROP EXTERNAL TABLE `%s`;
-                DROP EXTERNAL DATA SOURCE `%s`;
-            )", path, externalDataSource
-        ), true
-    );
+    if (!restorationSettings.Replace_) {
+        ExecuteQuery(querySession, Sprintf(R"(
+                    DROP EXTERNAL TABLE `%s`;
+                    DROP EXTERNAL DATA SOURCE `%s`;
+                )", path, externalDataSource
+            ), true
+        );
+    }
 
     restore();
     UNIT_ASSERT_VALUES_EQUAL(
@@ -1478,10 +1495,10 @@ Y_UNIT_TEST_SUITE(BackupRestore) {
         };
     }
 
-    auto CreateRestoreLambda(const TDriver& driver, const TFsPath& fsPath, const TString& dbPath = "/Root") {
+    auto CreateRestoreLambda(const TDriver& driver, const TFsPath& fsPath, const TString& dbPath = "/Root", const NDump::TRestoreSettings& settings = NDump::TRestoreSettings()) {
         return [=, &driver]() {
             NDump::TClient backupClient(driver);
-            const auto result = backupClient.Restore(fsPath, dbPath);
+            const auto result = backupClient.Restore(fsPath, dbPath, settings);
             UNIT_ASSERT_C(result.IsSuccess(), result.GetIssues().ToString());
         };
     }
@@ -2197,6 +2214,8 @@ Y_UNIT_TEST_SUITE(BackupRestore) {
                 break; // other projects
             default:
                 UNIT_FAIL("Client backup/restore were not implemented for this scheme object");
+                // please don't forget to add:
+                // - a dedicated TestReplaceRestoreOption test
         }
     }
 
@@ -2215,6 +2234,86 @@ Y_UNIT_TEST_SUITE(BackupRestore) {
             default:
                 UNIT_FAIL("Client backup/restore were not implemented for this index type");
         }
+    }
+
+    Y_UNIT_TEST(TestReplaceRestoreOption) {
+        NKikimrConfig::TAppConfig config;
+        config.MutableQueryServiceConfig()->AddAvailableExternalDataSources("ObjectStorage");
+        TKikimrWithGrpcAndRootSchema server(config);
+
+        server.GetRuntime()->GetAppData().FeatureFlags.SetEnableExternalDataSources(true);
+        server.GetRuntime()->SetLogPriority(NKikimrServices::TX_PROXY, NLog::EPriority::PRI_DEBUG);
+        server.GetRuntime()->SetLogPriority(NKikimrServices::FLAT_TX_SCHEMESHARD, NLog::EPriority::PRI_DEBUG);
+        server.GetRuntime()->SetLogPriority(NKikimrServices::REPLICATION_CONTROLLER, NLog::EPriority::PRI_DEBUG);
+
+        const auto endpoint = Sprintf("localhost:%u", server.GetPort());
+        auto driver = TDriver(TDriverConfig().SetEndpoint(endpoint).SetAuthToken("root@builtin"));
+
+        TTableClient tableClient(driver);
+        auto tableSession = tableClient.GetSession().ExtractValueSync().GetSession();
+        NQuery::TQueryClient queryClient(driver);
+        auto querySession = queryClient.GetSession().ExtractValueSync().GetSession();
+        NTopic::TTopicClient topicClient(driver);
+        TReplicationClient replicationClient(driver);
+        NCoordination::TClient nodeClient(driver);
+
+        TTempDir tempDir;
+        const auto& pathToBackup = tempDir.Path();
+
+        auto cleanup = [&pathToBackup, &driver] {
+            TVector<TFsPath> children;
+            pathToBackup.List(children);
+            for (auto& i : children) {
+                i.ForceDelete();
+            }
+
+            const auto settings = NConsoleClient::TRemoveDirectoryRecursiveSettings().RemoveSelf(false);
+            RemoveDirectoryRecursive(driver, "/Root", settings);
+        };
+
+        constexpr const char* table = "/Root/table";
+        constexpr const char* topic = "/Root/topic";
+        constexpr const char* view = "/Root/view";
+        constexpr const char* externalTable = "/Root/externalTable";
+        constexpr const char* externalDataSource = "/Root/externalDataSource";
+        const std::string kesus = "/Root/kesus";
+
+        const auto restorationSettings = NDump::TRestoreSettings().Replace(true);
+
+        cleanup();
+        TestTableContentIsPreserved(table, tableSession,
+            CreateBackupLambda(driver, pathToBackup), CreateRestoreLambda(driver, pathToBackup, "/Root", restorationSettings), restorationSettings
+        );
+
+        cleanup();
+        TestTopicSettingsArePreserved(topic, querySession, topicClient,
+            CreateBackupLambda(driver, pathToBackup), CreateRestoreLambda(driver, pathToBackup, "/Root", restorationSettings), restorationSettings
+        );
+
+        cleanup();
+        TestViewOutputIsPreserved(view, querySession,
+            CreateBackupLambda(driver, pathToBackup), CreateRestoreLambda(driver, pathToBackup, "/Root", restorationSettings), restorationSettings
+        );
+
+        cleanup();
+        TestExternalDataSourceSettingsArePreserved(externalDataSource, tableSession, querySession,
+            CreateBackupLambda(driver, pathToBackup), CreateRestoreLambda(driver, pathToBackup, "/Root", restorationSettings), restorationSettings
+        );
+
+        cleanup();
+        TestExternalTableSettingsArePreserved(externalTable, externalDataSource, tableSession, querySession,
+            CreateBackupLambda(driver, pathToBackup), CreateRestoreLambda(driver, pathToBackup, "/Root", restorationSettings), restorationSettings
+        );
+
+        cleanup();
+        TestCoordinationNodeSettingsArePreserved(kesus, nodeClient,
+            CreateBackupLambda(driver, pathToBackup), CreateRestoreLambda(driver, pathToBackup, "/Root", restorationSettings), restorationSettings
+        );
+
+        cleanup();
+        TestReplicationSettingsArePreserved(endpoint, querySession, replicationClient,
+            CreateBackupLambda(driver, pathToBackup), CreateRestoreLambda(driver, pathToBackup, "/Root", restorationSettings), restorationSettings
+        );
     }
 
     Y_UNIT_TEST(PrefixedVectorIndex) {

--- a/ydb/tests/functional/ydb_cli/test_ydb_backup.py
+++ b/ydb/tests/functional/ydb_cli/test_ydb_backup.py
@@ -4,7 +4,7 @@ from ydb.tests.library.harness.kikimr_runner import KiKiMR
 from ydb.tests.library.harness.kikimr_config import KikimrConfigGenerator
 from ydb.tests.oss.ydb_sdk_import import ydb
 
-from hamcrest import assert_that, is_, is_not, contains_inanyorder, has_items, equal_to
+from hamcrest import assert_that, is_, is_not, contains_inanyorder, has_items, equal_to, empty
 import enum
 import logging
 import os
@@ -1621,3 +1621,107 @@ class TestDatabaseBackupRestore(BaseTestMultipleClusterBackupInFiles):
         self.restore_driver.wait(timeout=10)
 
         self.restore_database_backup(input="database_backup")
+
+
+class TestRestoreReplaceOption(BaseTestBackupInFiles):
+    def ydb_cli(self, args):
+        try:
+            result = yatest.common.execute(
+                [
+                    backup_bin(),
+                    "-vvv",
+                    "--endpoint", "grpc://localhost:%d" % self.cluster.nodes[1].grpc_port,
+                    "--database", "/Root",
+                ]
+                + args
+            )
+            return True, result.std_out.decode("utf-8")
+
+        except yatest.common.process.ExecutionError as exception:
+            return False, exception.execution_result.std_err.decode("utf-8")
+
+    def delete_some_rows(self, session, table):
+        session.transaction().execute(
+            f"""
+            DELETE FROM `{table}` WHERE id == 2;
+            """,
+            commit_tx=True,
+        )
+
+    def test_table_replacement(self):
+        session = self.driver.table_client.session().create()
+
+        create_table_with_data(session, "table")
+
+        # Backup the table
+        backup_files_dir = output_path(self.test_name, "test_table_replacement", "backup_files_dir")
+        self.ydb_cli(["tools", "dump", "--path", ".", "--output", backup_files_dir])
+        assert_that(os.listdir(backup_files_dir), is_(["table"]))
+
+        # Restore the table
+        self.ydb_cli(["tools", "restore", "--path", "./restoration/point", "--input", backup_files_dir, "--dry-run"])
+        assert_that(
+            [child.name for child in self.driver.scheme_client.list_directory("/Root").children],
+            is_not(has_items("restoration")),
+        )
+        self.ydb_cli(["tools", "restore", "--path", "./restoration/point", "--input", backup_files_dir])
+        assert_that(
+            is_tables_the_same(session, self.driver.scheme_client, "/Root/table", "/Root/restoration/point/table"),
+            is_(True),
+        )
+
+        # Replace the table
+        self.delete_some_rows(session, "/Root/restoration/point/table")
+        self.ydb_cli(
+            ["tools", "restore", "--path", "./restoration/point", "--input", backup_files_dir, "--replace", "--dry-run"]
+        )
+        assert_that(
+            is_tables_the_same(session, self.driver.scheme_client, "/Root/table", "/Root/restoration/point/table"),
+            is_(False),
+        )
+        self.ydb_cli(["tools", "restore", "--path", "./restoration/point", "--input", backup_files_dir, "--replace"])
+        assert_that(
+            is_tables_the_same(session, self.driver.scheme_client, "/Root/table", "/Root/restoration/point/table"),
+            is_(True),
+        )
+
+        # Drop the folder
+        self.ydb_cli(["scheme", "rmdir", "--force", "--recursive", "./restoration/point"])
+
+        # Try to replace the table with the --verify-existence option turned on
+        assert_that(
+            self.ydb_cli(
+                [
+                    "tools",
+                    "restore",
+                    "--path", "./restoration/point",
+                    "--input", backup_files_dir,
+                    "--replace",
+                    "--verify-existence",
+                    "--dry-run",
+                ]
+            )[0],
+            equal_to(False),
+        )
+        assert_that(
+            self.ydb_cli(
+                [
+                    "tools",
+                    "restore",
+                    "--path", "./restoration/point",
+                    "--input", backup_files_dir,
+                    "--replace",
+                    "--verify-existence",
+                ]
+            )[0],
+            equal_to(False),
+        )
+
+        assert_that(
+            [child.name for child in self.driver.scheme_client.list_directory("/Root").children],
+            contains_inanyorder("table", "restoration", ".metadata", ".sys"),
+        )
+        assert_that(
+            [child.name for child in self.driver.scheme_client.list_directory("/Root/restoration").children],
+            empty()
+        )


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

### Changelog category <!-- remove all except one -->

* Not for changelog (changelog entry is not required)

### Description for reviewers <!-- (optional) description for those who read this PR -->

Add `--replace` option to `ydb tools restore`. Special care is taken for external data sources and replications since they might have dependents and need to be dropped carefully. You can read more about the algorithm in the [RFC](https://github.com/ydb-platform/ydb-rfc/blob/main/ydb-tools-restore-replace.md).

Note: changelog entry is not required since it is added differently for YDB CLI changes.
