### PR TITLE
Add commit version to datashard replies

### DIFF
--- a/ydb/core/protos/data_events.proto
+++ b/ydb/core/protos/data_events.proto
@@ -1,4 +1,5 @@
 import "ydb/library/actors/protos/actors.proto";
+import "ydb/core/protos/base.proto";
 import "ydb/core/protos/query_stats.proto";
 import "ydb/public/api/protos/ydb_issue_message.proto";
 
@@ -162,4 +163,7 @@ message TEvWriteResult {
 
     // Statistics
     optional NKikimrQueryStats.TTxStats TxStats = 13;
+
+    // Commit version when available
+    optional NKikimrProto.TRowVersion CommitVersion = 14;
 }

--- a/ydb/core/protos/tx_datashard.proto
+++ b/ydb/core/protos/tx_datashard.proto
@@ -647,6 +647,7 @@ message TEvProposeTransactionResult {
     optional bytes DataLastKey = 25; // Response data last key (for retries)
     reserved 26; // optional NKqpProto.TKqpStatsRun KqpRunStats = 26;
     optional NYql.NDqProto.TDqComputeActorStats ComputeActorStats = 27; // overall time + per-task statistics
+    optional NKikimrProto.TRowVersion CommitVersion = 28;
 }
 
 message TEvProposeTransactionRestart {

--- a/ydb/core/tx/datashard/datashard.h
+++ b/ydb/core/tx/datashard/datashard.h
@@ -619,6 +619,10 @@ namespace TEvDataShard {
         void SetStepOrderId(const std::pair<ui64, ui64>& stepOrderId) {
             Record.SetStep(stepOrderId.first);
             Record.SetOrderId(stepOrderId.second);
+            // Note: this method is used by schema operations where stepOrderId == commitVersion
+            auto* commitVersion = Record.MutableCommitVersion();
+            commitVersion->SetStep(stepOrderId.first);
+            commitVersion->SetTxId(stepOrderId.second);
         }
 
         void AddTxLock(ui64 lockId, ui64 shard, ui32 generation, ui64 counter, ui64 ssId, ui64 pathId, bool hasWrites) {

--- a/ydb/core/tx/datashard/execute_data_tx_unit.cpp
+++ b/ydb/core/tx/datashard/execute_data_tx_unit.cpp
@@ -342,6 +342,10 @@ void TExecuteDataTxUnit::ExecuteDataTx(TOperation::TPtr op,
 
     AddLocksToResult(op, ctx);
 
+    if (!guardLocks.LockTxId) {
+        writeVersion.ToProto(op->Result()->Record.MutableCommitVersion());
+    }
+
     Pipeline.AddCommittingOp(op);
 }
 

--- a/ydb/core/tx/datashard/execute_kqp_data_tx_unit.cpp
+++ b/ydb/core/tx/datashard/execute_kqp_data_tx_unit.cpp
@@ -384,6 +384,10 @@ EExecutionStatus TExecuteKqpDataTxUnit::Execute(TOperation::TPtr op, TTransactio
         // Note: may erase persistent locks, must be after we persist volatile tx
         AddLocksToResult(op, ctx);
 
+        if (!guardLocks.LockTxId) {
+            writeVersion.ToProto(op->Result()->Record.MutableCommitVersion());
+        }
+
         if (auto changes = std::move(dataTx->GetCollectedChanges())) {
             op->ChangeRecords() = std::move(changes);
         }

--- a/ydb/core/tx/datashard/execute_write_unit.cpp
+++ b/ydb/core/tx/datashard/execute_write_unit.cpp
@@ -471,6 +471,10 @@ public:
             // Note: may erase persistent locks, must be after we persist volatile tx
             AddLocksToResult(writeOp, ctx);
 
+            if (!guardLocks.LockTxId) {
+                writeVersion.ToProto(writeResult->Record.MutableCommitVersion());
+            }
+
             if (auto changes = std::move(userDb.GetCollectedChanges())) {
                 op->ChangeRecords() = std::move(changes);
             }


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

...

### Changelog category <!-- remove all except one -->

* Not for changelog (changelog entry is not required)

### Description for reviewers <!-- (optional) description for those who read this PR -->

This might allow kqp to add commit timestamp to transaction results in the future. Fixes #18340.