### PR TITLE
Add audit logging on `create tenant` database in console tablet

### DIFF
--- a/ydb/core/client/server/msgbus_server_console.cpp
+++ b/ydb/core/client/server/msgbus_server_console.cpp
@@ -78,6 +78,7 @@ public:
             auto request = MakeHolder<TEvConsole::TEvCreateTenantRequest>();
             request->Record.CopyFrom(Request.GetCreateTenantRequest());
             request->Record.SetUserToken(TBase::GetSerializedToken());
+            request->Record.SetPeerName(TBase::GetPeerName());
             NTabletPipe::SendData(ctx, ConsolePipe, request.Release());
         } else if (Request.HasGetConfigRequest()) {
             auto request = MakeHolder<TEvConsole::TEvGetConfigRequest>();

--- a/ydb/core/cms/console/console__create_tenant.cpp
+++ b/ydb/core/cms/console/console__create_tenant.cpp
@@ -65,6 +65,8 @@ public:
 
         auto &rec = Request->Get()->Record.GetRequest();
         auto &token = Request->Get()->Record.GetUserToken();
+        auto &peer = Request->Get()->Record.GetPeerName();
+
         LOG_DEBUG_S(ctx, NKikimrServices::CMS_TENANTS, "TTxCreateTenant: "
                     << Request->Get()->Record.ShortDebugString());
 
@@ -121,7 +123,7 @@ public:
             attrNames.insert(key);
         }
 
-        Tenant = new TTenant(path, TTenant::CREATING_POOLS, token);
+        Tenant = new TTenant(path, TTenant::CREATING_POOLS, token, peer);
 
         Tenant->IsExternalSubdomain = Self->FeatureFlags.GetEnableExternalSubdomains();
         Tenant->IsExternalHive = Self->FeatureFlags.GetEnableExternalHive();

--- a/ydb/core/cms/console/console__remove_tenant.cpp
+++ b/ydb/core/cms/console/console__remove_tenant.cpp
@@ -47,6 +47,8 @@ public:
 
         auto &rec = Request->Get()->Record.GetRequest();
         auto &token = Request->Get()->Record.GetUserToken();
+        auto &peer = Request->Get()->Record.GetPeerName();
+
         LOG_DEBUG_S(ctx, NKikimrServices::CMS_TENANTS, "TTxRemoveTenant: "
                     << Request->Get()->Record.ShortDebugString());
 
@@ -79,6 +81,7 @@ public:
 
         Self->DbUpdateTenantState(Tenant, TTenant::REMOVING_SUBDOMAIN, txc, ctx);
         Self->DbUpdateTenantUserToken(Tenant, token, txc, ctx);
+        Self->DbUpdateTenantPeerName(Tenant, peer, txc, ctx);
 
         return true;
     }

--- a/ydb/core/cms/console/console__scheme.h
+++ b/ydb/core/cms/console/console__scheme.h
@@ -52,6 +52,7 @@ struct Schema : NIceDb::Schema {
         struct IsExternalStatisticsAggregator : Column<28, NScheme::NTypeIds::Bool> {};
         struct IsExternalBackupController : Column<29, NScheme::NTypeIds::Bool> {};
         struct ScaleRecommenderPolicies : Column<30, NScheme::NTypeIds::String> {};
+        struct PeerName : Column<31, NScheme::NTypeIds::Utf8> {};
 
         using TKey = TableKey<Path>;
         using TColumns = TableColumns<Path, State, Coordinators, Mediators, PlanResolution,
@@ -59,7 +60,7 @@ struct Schema : NIceDb::Schema {
             Attributes, Generation, SchemeShardId, PathId, ErrorCode, IsExternalSubDomain, IsExternalHive,
             AreResourcesShared, SharedDomainSchemeShardId, SharedDomainPathId, IsExternalSysViewProcessor,
             SchemaOperationQuotas, CreateIdempotencyKey, AlterIdempotencyKey, DatabaseQuotas, IsExternalStatisticsAggregator,
-            IsExternalBackupController, ScaleRecommenderPolicies>;
+            IsExternalBackupController, ScaleRecommenderPolicies, PeerName>;
     };
 
     struct TenantPools : Table<3> {

--- a/ydb/core/cms/console/console_audit.cpp
+++ b/ydb/core/cms/console/console_audit.cpp
@@ -58,4 +58,86 @@ void AuditLogReplaceDatabaseConfigTransaction(
     );
 }
 
+void AuditLogBeginConfigureDatabase(
+    const TString& peer,
+    const TString& userSID,
+    const TString& sanitizedToken,
+    const TString& database)
+{
+    auto peerName = NKikimr::NAddressClassifier::ExtractAddress(peer);
+
+    AUDIT_LOG(
+        AUDIT_PART("component", COMPONENT_NAME)
+        AUDIT_PART("remote_address", (!peerName.empty() ? peerName : EMPTY_VALUE))
+        AUDIT_PART("subject", (!userSID.empty() ? userSID : EMPTY_VALUE))
+        AUDIT_PART("sanitized_token", (!sanitizedToken.empty() ? sanitizedToken : EMPTY_VALUE))
+        AUDIT_PART("database", database)
+        AUDIT_PART("status", TString("SUCCESS"))
+        AUDIT_PART("operation", TString("BEGIN INIT DATABASE CONFIG"))
+    );
+}
+
+void AuditLogEndConfigureDatabase(
+    const TString& peer,
+    const TString& userSID,
+    const TString& sanitizedToken,
+    const TString& database,
+    const TString& reason,
+    bool success)
+{
+    auto peerName = NKikimr::NAddressClassifier::ExtractAddress(peer);
+
+    AUDIT_LOG(
+        AUDIT_PART("component", COMPONENT_NAME)
+        AUDIT_PART("remote_address", (!peerName.empty() ? peerName : EMPTY_VALUE))
+        AUDIT_PART("subject", (!userSID.empty() ? userSID : EMPTY_VALUE))
+        AUDIT_PART("sanitized_token", (!sanitizedToken.empty() ? sanitizedToken : EMPTY_VALUE))
+        AUDIT_PART("database", database)
+        AUDIT_PART("status", TString(success ? "SUCCESS" : "ERROR"))
+        AUDIT_PART("reason", reason, !reason.empty())
+        AUDIT_PART("operation", TString("END INIT DATABASE CONFIG"))
+    );
+}
+
+void AuditLogBeginRemoveDatabase(
+    const TString& peer,
+    const TString& userSID,
+    const TString& sanitizedToken,
+    const TString& database)
+{
+    auto peerName = NKikimr::NAddressClassifier::ExtractAddress(peer);
+
+    AUDIT_LOG(
+        AUDIT_PART("component", COMPONENT_NAME)
+        AUDIT_PART("remote_address", (!peerName.empty() ? peerName : EMPTY_VALUE))
+        AUDIT_PART("subject", (!userSID.empty() ? userSID : EMPTY_VALUE))
+        AUDIT_PART("sanitized_token", (!sanitizedToken.empty() ? sanitizedToken : EMPTY_VALUE))
+        AUDIT_PART("database", database)
+        AUDIT_PART("status", TString("SUCCESS"))
+        AUDIT_PART("operation", TString("BEGIN REMOVE DATABASE"))
+    );
+}
+
+void AuditLogEndRemoveDatabase(
+    const TString& peer,
+    const TString& userSID,
+    const TString& sanitizedToken,
+    const TString& database,
+    const TString& reason,
+    bool success)
+{
+    auto peerName = NKikimr::NAddressClassifier::ExtractAddress(peer);
+
+    AUDIT_LOG(
+        AUDIT_PART("component", COMPONENT_NAME)
+        AUDIT_PART("remote_address", (!peerName.empty() ? peerName : EMPTY_VALUE))
+        AUDIT_PART("subject", (!userSID.empty() ? userSID : EMPTY_VALUE))
+        AUDIT_PART("sanitized_token", (!sanitizedToken.empty() ? sanitizedToken : EMPTY_VALUE))
+        AUDIT_PART("database", database)
+        AUDIT_PART("status", TString(success ? "SUCCESS" : "ERROR"))
+        AUDIT_PART("reason", reason, !reason.empty())
+        AUDIT_PART("operation", TString("END REMOVE DATABASE"))
+    );
+}
+
 } // namespace NKikimr::NConsole

--- a/ydb/core/cms/console/console_audit.h
+++ b/ydb/core/cms/console/console_audit.h
@@ -23,4 +23,32 @@ void AuditLogReplaceDatabaseConfigTransaction(
     const TString& reason,
     bool success);
 
+void AuditLogBeginConfigureDatabase(
+    const TString& peer,
+    const TString& userSID,
+    const TString& sanitizedToken,
+    const TString& database);
+
+void AuditLogEndConfigureDatabase(
+    const TString& peer,
+    const TString& userSID,
+    const TString& sanitizedToken,
+    const TString& database,
+    const TString& reason,
+    bool success);
+
+void AuditLogBeginRemoveDatabase(
+    const TString& peer,
+    const TString& userSID,
+    const TString& sanitizedToken,
+    const TString& database);
+
+void AuditLogEndRemoveDatabase(
+    const TString& peer,
+    const TString& userSID,
+    const TString& sanitizedToken,
+    const TString& database,
+    const TString& reason,
+    bool success);
+
 } // namespace NKikimr::NConsole

--- a/ydb/core/cms/console/console_tenants_manager.cpp
+++ b/ydb/core/cms/console/console_tenants_manager.cpp
@@ -1,5 +1,6 @@
 #include "console_tenants_manager.h"
 #include "console_impl.h"
+#include "console_audit.h"
 #include "http.h"
 #include "util.h"
 
@@ -618,6 +619,13 @@ public:
         BLOG_TRACE("TSubdomainManip(" << Tenant->Path << ") send subdomain creation cmd: "
                     << request->ToString());
 
+        AuditLogBeginConfigureDatabase(
+            Tenant->PeerName,
+            Tenant->UserToken.GetUserSID(),
+            Tenant->UserToken.GetSanitizedToken(),
+            Tenant->Path
+        );
+
         ctx.Send(MakeTxProxyID(), request.Release());
     }
 
@@ -642,6 +650,13 @@ public:
         BLOG_TRACE("TSubdomainManip(" << Tenant->Path << ") send subdomain drop cmd: "
                     << request->ToString());
 
+        AuditLogBeginRemoveDatabase(
+            Tenant->PeerName,
+            Tenant->UserToken.GetUserSID(),
+            Tenant->UserToken.GetSanitizedToken(),
+            Tenant->Path
+        );
+            
         ctx.Send(MakeTxProxyID(), request.Release());
     }
 
@@ -693,6 +708,32 @@ public:
                      const TActorContext &ctx)
     {
         BLOG_D("TSubdomainManip(" << Tenant->Path << ") reply with " << resp->ToString());
+
+        using TAuditFunc = decltype(AuditLogEndConfigureDatabase);
+        auto audit = [&](TAuditFunc auditFunc) {
+            bool isSuccess = (typeid(*resp) != typeid(TTenantsManager::TEvPrivate::TEvSubdomainFailed));
+
+            TString issue = "";
+            if (!isSuccess) {
+                issue = dynamic_cast<TTenantsManager::TEvPrivate::TEvSubdomainFailed*>(resp)->Issue;
+            }
+
+            auditFunc(
+                Tenant->PeerName,
+                Tenant->UserToken.GetUserSID(),
+                Tenant->UserToken.GetSanitizedToken(),
+                Tenant->Path,
+                issue,
+                isSuccess
+            );
+        };
+
+        if (Action == CONFIGURE) {
+            audit(AuditLogEndConfigureDatabase);
+        } else if (Action == REMOVE) {
+            audit(AuditLogEndRemoveDatabase);
+        }
+
         ctx.Send(OwnerId, resp);
         Die(ctx);
     }
@@ -874,6 +915,7 @@ public:
                         << Tenant->Path << " has invalid path type "
                         << NKikimrSchemeOp::EPathType_Name(pathType)
                         << " but expected " << NKikimrSchemeOp::EPathType_Name(expectedPathType));
+
             ReplyAndDie(new TTenantsManager::TEvPrivate::TEvSubdomainFailed(Tenant, "bad path type"), ctx);
             return;
         }
@@ -1416,7 +1458,9 @@ void TTenantsManager::TTenantsConfig::ParseComputationalUnits(const TUnitsCount 
 
 TTenantsManager::TTenant::TTenant(const TString &path,
                                   EState state,
-                                  const TString &token)
+                                  const TString &token,
+                                  const TString &peerName
+                                )
     : Path(path)
     , State(state)
     , Coordinators(3)
@@ -1429,6 +1473,7 @@ TTenantsManager::TTenant::TTenant(const TString &path,
     , ErrorCode(Ydb::StatusIds::STATUS_CODE_UNSPECIFIED)
     , TxId(0)
     , UserToken(token)
+    , PeerName(peerName)
     , SubdomainVersion(1)
     , ConfirmedSubdomain(0)
     , Generation(0)
@@ -2541,6 +2586,7 @@ void TTenantsManager::DbAddTenant(TTenant::TPtr tenant,
                 NIceDb::TUpdate<Schema::Tenants::Issue>(tenant->Issue),
                 NIceDb::TUpdate<Schema::Tenants::TxId>(tenant->TxId),
                 NIceDb::TUpdate<Schema::Tenants::UserToken>(tenant->UserToken.SerializeAsString()),
+                NIceDb::TUpdate<Schema::Tenants::PeerName>(tenant->PeerName),
                 NIceDb::TUpdate<Schema::Tenants::SubdomainVersion>(tenant->SubdomainVersion),
                 NIceDb::TUpdate<Schema::Tenants::ConfirmedSubdomain>(tenant->ConfirmedSubdomain),
                 NIceDb::TUpdate<Schema::Tenants::Attributes>(tenant->Attributes),
@@ -2649,6 +2695,7 @@ bool TTenantsManager::DbLoadState(TTransactionContext &txc, const TActorContext 
         ui32 timeCastBucketsPerMediator = tenantRowset.GetValue<Schema::Tenants::TimeCastBucketsPerMediator>();
         ui64 txId = tenantRowset.GetValue<Schema::Tenants::TxId>();
         TString userToken = tenantRowset.GetValue<Schema::Tenants::UserToken>();
+        TString peerName = tenantRowset.GetValue<Schema::Tenants::PeerName>();
         ui64 subdomainVersion = tenantRowset.GetValueOrDefault<Schema::Tenants::SubdomainVersion>(1);
         ui64 confirmedSubdomain = tenantRowset.GetValueOrDefault<Schema::Tenants::ConfirmedSubdomain>(0);
         NKikimrSchemeOp::TAlterUserAttributes attrs = tenantRowset.GetValueOrDefault<Schema::Tenants::Attributes>({});
@@ -2664,7 +2711,7 @@ bool TTenantsManager::DbLoadState(TTransactionContext &txc, const TActorContext 
         bool isExternalStatisticsAggregator = tenantRowset.GetValueOrDefault<Schema::Tenants::IsExternalStatisticsAggregator>(false);
         const bool areResourcesShared = tenantRowset.GetValueOrDefault<Schema::Tenants::AreResourcesShared>(false);
 
-        TTenant::TPtr tenant = new TTenant(path, state, userToken);
+        TTenant::TPtr tenant = new TTenant(path, state, userToken, peerName);
         tenant->Coordinators = coordinators;
         tenant->Mediators = mediators;
         tenant->PlanResolution = planResolution;
@@ -3134,6 +3181,19 @@ void TTenantsManager::DbUpdateTenantUserToken(TTenant::TPtr tenant,
     NIceDb::TNiceDb db(txc.DB);
     db.Table<Schema::Tenants>().Key(tenant->Path)
         .Update(NIceDb::TUpdate<Schema::Tenants::UserToken>(userToken));
+}
+
+void TTenantsManager::DbUpdateTenantPeerName(TTenant::TPtr tenant,
+                                             const TString &peerName,
+                                             TTransactionContext &txc,
+                                             const TActorContext &ctx)
+{
+    LOG_TRACE_S(ctx, NKikimrServices::CMS_TENANTS,
+    "Update peerName in database for " << tenant->Path);
+
+    NIceDb::TNiceDb db(txc.DB);
+    db.Table<Schema::Tenants>().Key(tenant->Path)
+        .Update(NIceDb::TUpdate<Schema::Tenants::PeerName>(peerName));
 }
 
 void TTenantsManager::DbUpdateSubdomainVersion(TTenant::TPtr tenant,

--- a/ydb/core/cms/console/console_tenants_manager.h
+++ b/ydb/core/cms/console/console_tenants_manager.h
@@ -467,7 +467,8 @@ public:
 
         TTenant(const TString &path,
                 EState state,
-                const TString &token);
+                const TString &token,
+                const TString &peer);
 
         static bool IsConfiguringState(EState state);
         static bool IsCreatingState(EState state);
@@ -516,6 +517,8 @@ public:
         TString Issue;
         ui64 TxId;
         NACLib::TUserToken UserToken;
+        // Peer is remote-address of User, who created database. Used for audit logging.
+        const TString PeerName;
         // Subdomain version is incremented on each pool creation.
         ui64 SubdomainVersion;
         // Last subdomain version configured in SchemeShard.
@@ -905,6 +908,10 @@ public:
                                  const TActorContext &ctx);
     void DbUpdateTenantUserToken(TTenant::TPtr tenant,
                                  const TString &userToken,
+                                 TTransactionContext &txc,
+                                 const TActorContext &ctx);
+    void DbUpdateTenantPeerName(TTenant::TPtr tenant,
+                                 const TString &peerName,
                                  TTransactionContext &txc,
                                  const TActorContext &ctx);
     void DbUpdateSubdomainVersion(TTenant::TPtr tenant,

--- a/ydb/core/grpc_services/rpc_cms.cpp
+++ b/ydb/core/grpc_services/rpc_cms.cpp
@@ -77,6 +77,7 @@ private:
             auto request = MakeHolder<TEvConsole::TEvNotifyOperationCompletionRequest>();
             request->Record.MutableRequest()->set_id(response.operation().id());
             request->Record.SetUserToken(this->Request_->GetSerializedToken());
+            request->Record.SetPeerName(this->Request_->GetPeerName());
 
             NTabletPipe::SendData(ctx, CmsPipe, request.Release());
         } else {
@@ -143,6 +144,7 @@ private:
         auto request = MakeHolder<TCmsRequest>();
         request->Record.MutableRequest()->CopyFrom(*this->GetProtoRequest());
         request->Record.SetUserToken(this->Request_->GetSerializedToken());
+        request->Record.SetPeerName(this->Request_->GetPeerName());
         NTabletPipe::SendData(ctx, CmsPipe, request.Release());
     }
 };

--- a/ydb/core/protos/console_tenant.proto
+++ b/ydb/core/protos/console_tenant.proto
@@ -10,6 +10,7 @@ option java_package = "ru.yandex.kikimr.proto";
 message TCreateTenantRequest {
     optional Ydb.Cms.CreateDatabaseRequest Request = 1;
     optional bytes UserToken = 2;
+    optional string PeerName = 3;
 }
 
 message TCreateTenantResponse {
@@ -19,6 +20,7 @@ message TCreateTenantResponse {
 message TGetTenantStatusRequest {
     optional Ydb.Cms.GetDatabaseStatusRequest Request = 1;
     optional bytes UserToken = 2;
+    optional string PeerName = 3;
 }
 
 message TGetTenantStatusResponse {
@@ -28,6 +30,7 @@ message TGetTenantStatusResponse {
 message TAlterTenantRequest {
     optional Ydb.Cms.AlterDatabaseRequest Request = 1;
     optional bytes UserToken = 2;
+    optional string PeerName = 3;
 }
 
 message TAlterTenantResponse {
@@ -37,6 +40,7 @@ message TAlterTenantResponse {
 message TListTenantsRequest {
     optional Ydb.Cms.ListDatabasesRequest Request = 1;
     optional bytes UserToken = 2;
+    optional string PeerName = 3;
 }
 
 message TListTenantsResponse {
@@ -46,6 +50,7 @@ message TListTenantsResponse {
 message TRemoveTenantRequest {
     optional Ydb.Cms.RemoveDatabaseRequest Request = 1;
     optional bytes UserToken = 2;
+    optional string PeerName = 3;
 }
 
 message TRemoveTenantResponse {
@@ -55,6 +60,7 @@ message TRemoveTenantResponse {
 message TGetOperationRequest {
     optional Ydb.Operations.GetOperationRequest Request = 1;
     optional bytes UserToken = 2;
+    optional string PeerName = 3;
 }
 
 message TGetOperationResponse {
@@ -64,6 +70,7 @@ message TGetOperationResponse {
 message TDescribeTenantOptionsRequest {
     optional Ydb.Cms.DescribeDatabaseOptionsRequest Request = 1;
     optional bytes UserToken = 2;
+    optional string PeerName = 3;
 }
 
 message TDescribeTenantOptionsResponse {


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

It is only cherr-pick commit about create/remove database audit logs in console's tablet.

You can read the description from original PR: https://github.com/ydb-platform/ydb/pull/18095

### Changelog category <!-- remove all except one -->

* Improvement
