### PR TITLE
Merge recent PDisk fixes into stable-25-1

### DIFF
--- a/ydb/core/blobstorage/pdisk/blobstorage_pdisk_impl_log.cpp
+++ b/ydb/core/blobstorage/pdisk/blobstorage_pdisk_impl_log.cpp
@@ -155,7 +155,7 @@ void TPDisk::PrintLogChunksInfo(const TString& msg) {
         return str.Str();
     };
 
-    P_LOG(PRI_NOTICE, BPD01, "PrintLogChunksInfo " << msg, (LogChunks, debugPrint()));
+    P_LOG(PRI_DEBUG, BPD01, "PrintLogChunksInfo " << msg, (LogChunks, debugPrint()));
 }
 
 bool TPDisk::LogNonceJump(ui64 previousNonce) {

--- a/ydb/core/blobstorage/pdisk/blobstorage_pdisk_ut_env.h
+++ b/ydb/core/blobstorage/pdisk/blobstorage_pdisk_ut_env.h
@@ -117,6 +117,10 @@ public:
         return nullptr;
     }
 
+    TTestActorRuntime* GetRuntime() {
+        return Runtime.Get();
+    }
+
     void UpdateConfigRecreatePDisk(TIntrusivePtr<TPDiskConfig> cfg) {
         if (PDiskActor) {
             TestResponse<NPDisk::TEvYardControlResult>(

--- a/ydb/library/pdisk_io/aio.h
+++ b/ydb/library/pdisk_io/aio.h
@@ -102,7 +102,8 @@ enum class EIoResult : i64 {
     InvalidSequence = 14,       // aka EILSEQ:                  GetEvents
     // for broken disk's error-log: "READ_ERROR: The read data could not be recovered from the media"
     NoData = 15,                // aka ENODATA:                 GetEvents
-    RemoteIOError = 16          // aka EREMOTEIO:               GetEvents
+    RemoteIOError = 16,         // aka EREMOTEIO:               GetEvents
+    NoSpaceLeft = 17            // aka ENOSPC:                  GetEvents
 };
 
 struct TAsyncIoOperationResult {

--- a/ydb/library/pdisk_io/aio_linux.cpp
+++ b/ydb/library/pdisk_io/aio_linux.cpp
@@ -549,6 +549,7 @@ public:
                 case ENOSYS:    return EIoResult::FunctionNotImplemented;
                 case EILSEQ:    return EIoResult::InvalidSequence;
                 case ENODATA:   return EIoResult::NoData;
+                case ENOSPC:    return EIoResult::NoSpaceLeft;
                 default: Y_FAIL_S(PDiskInfo << " unexpected error in " << info << ", error# " << -ret
                                  << " strerror# " << strerror(-ret));
             }

--- a/ydb/library/pdisk_io/aio_linux.cpp
+++ b/ydb/library/pdisk_io/aio_linux.cpp
@@ -154,23 +154,33 @@ public:
     }
 
     EIoResult Destroy() override {
+        EIoResult result = EIoResult::Ok;
+
         int ret = io_destroy(IoContext);
         if (ret < 0) {
             switch (-ret) {
-                case EFAULT: return EIoResult::BadAddress;
-                case EINVAL: return EIoResult::InvalidArgument;
-                case ENOSYS: return EIoResult::FunctionNotImplemented;
-                default: Y_FAIL_S(PDiskInfo << " unexpected error in io_destroy, error# " << -ret
-                                 << " strerror# " << strerror(-ret));
+                case EFAULT: 
+                    result = EIoResult::BadAddress;
+                    break;
+                case EINVAL:
+                    result = EIoResult::InvalidArgument;
+                    break;
+                case ENOSYS:
+                    result = EIoResult::FunctionNotImplemented;
+                    break;
+                default: 
+                    Y_FAIL_S(PDiskInfo << " unexpected error in io_destroy, error# " << -ret << " strerror# " << strerror(-ret));
             }
         }
+
         if (File) {
             ret = File->Flock(LOCK_UN);
             Y_VERIFY_S(ret == 0, "Error in Flock(LOCK_UN), errno# " << errno << " strerror# " << strerror(errno));
             bool isOk = File->Close();
             Y_VERIFY_S(isOk, PDiskInfo << " error on file close, errno# " << errno << " strerror# " << strerror(errno));
         }
-        return EIoResult::Ok;
+
+        return result;
     }
 
     i64 GetEvents(ui64 minEvents, ui64 maxEvents, TAsyncIoOperationResult *events, TDuration timeout) override {


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

Handle PDisk stop event if PDisk is in error or init state
Decrease PrintLogChunksInfo logging priority NOTICE->DEBUG 
Add pdisk error handler for NoSpaceLeft(ENOSPC)

cherry-pick:
https://github.com/ydb-platform/ydb/commit/388fdf1192f8024dd9f8779dd70cb20f74bf896a
https://github.com/ydb-platform/ydb/commit/a03af29e549ec948408e85858e76126f5128aedf
https://github.com/ydb-platform/ydb/commit/cfede7fd10c5032b322bc335caff4d30c7674e6f

### Changelog category <!-- remove all except one -->

* Bugfix 

### Description for reviewers <!-- (optional) description for those who read this PR -->

...
