### PR TITLE
dump: handle no auth replications correctly

### DIFF
--- a/ydb/library/backup/backup.cpp
+++ b/ydb/library/backup/backup.cpp
@@ -745,7 +745,9 @@ TString BuildCreateReplicationQuery(
             opts.push_back(BuildOption("PASSWORD_SECRET_NAME", Quote(params.GetStaticCredentials().PasswordSecretName)));
             break;
         case NReplication::TConnectionParams::ECredentials::OAuth:
-            opts.push_back(BuildOption("TOKEN_SECRET_NAME", Quote(params.GetOAuthCredentials().TokenSecretName)));
+            if (const auto& secret = params.GetOAuthCredentials().TokenSecretName; !secret.empty()) {
+                opts.push_back(BuildOption("TOKEN_SECRET_NAME", Quote(secret)));
+            }
             break;
     }
 


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

### Changelog category <!-- remove all except one -->

* Not for changelog (changelog entry is not required)

### Description for reviewers <!-- (optional) description for those who read this PR -->

`ASYNC REPLICATION` can be created without any secret token at all. This mode is supported only for the sake of easier test writing. No replication in production is going to have no secret token. However, it is worth supporting this mode in `ydb tools dump` so that we can write replication backup tests without secrets.

Issues:
- https://github.com/ydb-platform/ydb/issues/18358
