### PR TITLE
Make lazy server start for backup tests in order to quickly list tests

### DIFF
--- a/ydb/services/ydb/backup_ut/encrypted_backup_ut.cpp
+++ b/ydb/services/ydb/backup_ut/encrypted_backup_ut.cpp
@@ -5,11 +5,11 @@ using namespace NYdb;
 template <bool encryptionEnabled>
 class TBackupEncryptionParamsValidationTestFixture : public TS3BackupTestFixture {
 public:
-    TBackupEncryptionParamsValidationTestFixture() {
-        Server.GetRuntime()->GetAppData().FeatureFlags.SetEnableEncryptedExport(encryptionEnabled);
-    }
+    TBackupEncryptionParamsValidationTestFixture() = default;
 
     void SetUp(NUnitTest::TTestContext& /* context */) override {
+        Server().GetRuntime()->GetAppData().FeatureFlags.SetEnableEncryptedExport(encryptionEnabled);
+
         auto res = YdbQueryClient().ExecuteQuery(R"sql(
             CREATE TABLE `/Root/ExportParamsValidation/dir1/Table1` (
                 Key Uint32 NOT NULL,

--- a/ydb/services/ydb/backup_ut/s3_backup_test_base.h
+++ b/ydb/services/ydb/backup_ut/s3_backup_test_base.h
@@ -15,24 +15,10 @@
 
 class TS3BackupTestFixture : public NUnitTest::TBaseFixture {
 protected:
-    TS3BackupTestFixture()
-        : S3Port(Server.GetPortManager().GetPort())
-        , S3Mock(NKikimr::NWrappers::NTestHelpers::TS3Mock::TSettings(S3Port))
-    {
-        UNIT_ASSERT_C(S3Mock.Start(), S3Mock.GetError());
-        auto& runtime = *Server.GetRuntime();
-        runtime.SetLogPriority(NKikimrServices::TX_PROXY, NLog::EPriority::PRI_TRACE);
-        runtime.SetLogPriority(NKikimrServices::EXPORT, NLog::EPriority::PRI_TRACE);
-        runtime.SetLogPriority(NKikimrServices::IMPORT, NLog::EPriority::PRI_TRACE);
-        runtime.SetLogPriority(NKikimrServices::FLAT_TX_SCHEMESHARD, NLog::EPriority::PRI_TRACE);
-        runtime.GetAppData().FeatureFlags.SetEnableViews(true);
-        runtime.GetAppData().FeatureFlags.SetEnableViewExport(true);
-        runtime.GetAppData().FeatureFlags.SetEnableEncryptedExport(true);
-        runtime.GetAppData().DataShardExportFactory = &DataShardExportFactory;
-    }
+    TS3BackupTestFixture() = default;
 
-    TString YdbConnectionString() const {
-        return TStringBuilder() << "localhost:" << Server.GetPort() << "/?database=/Root";
+    TString YdbConnectionString() {
+        return TStringBuilder() << "localhost:" << Server().GetPort() << "/?database=/Root";
     }
 
     NYdb::TDriverConfig& YdbDriverConfig() {
@@ -70,6 +56,37 @@ protected:
 
 #undef YDB_SDK_CLIENT
 
+    NKikimr::NWrappers::NTestHelpers::TS3Mock& S3Mock() {
+        if (!S3Mock_) {
+            S3Port_ = Server().GetPortManager().GetPort();
+            S3Mock_.ConstructInPlace(NKikimr::NWrappers::NTestHelpers::TS3Mock::TSettings(S3Port_));
+            UNIT_ASSERT_C(S3Mock_->Start(), S3Mock_->GetError());
+        }
+        return *S3Mock_;
+    }
+
+    ui16 S3Port() {
+        S3Mock();
+        return S3Port_;
+    }
+
+    NYdb::TKikimrWithGrpcAndRootSchema& Server() {
+        if (!Server_) {
+            Server_.ConstructInPlace();
+
+            auto& runtime = *Server_->GetRuntime();
+            runtime.SetLogPriority(NKikimrServices::TX_PROXY, NLog::EPriority::PRI_TRACE);
+            runtime.SetLogPriority(NKikimrServices::EXPORT, NLog::EPriority::PRI_TRACE);
+            runtime.SetLogPriority(NKikimrServices::IMPORT, NLog::EPriority::PRI_TRACE);
+            runtime.SetLogPriority(NKikimrServices::FLAT_TX_SCHEMESHARD, NLog::EPriority::PRI_TRACE);
+            runtime.GetAppData().FeatureFlags.SetEnableViews(true);
+            runtime.GetAppData().FeatureFlags.SetEnableViewExport(true);
+            runtime.GetAppData().FeatureFlags.SetEnableEncryptedExport(true);
+            runtime.GetAppData().DataShardExportFactory = &DataShardExportFactory;
+        }
+        return *Server_;
+    }
+
     template<typename TOp>
     void WaitOp(TMaybe<NYdb::TOperation>& op) {
         int attempt = 200;
@@ -104,7 +121,7 @@ protected:
     NYdb::NExport::TExportToS3Settings MakeExportSettings(const TString& sourcePath, const TString& destinationPrefix) {
         NYdb::NExport::TExportToS3Settings exportSettings;
         exportSettings
-            .Endpoint(TStringBuilder() << "localhost:" << S3Port)
+            .Endpoint(TStringBuilder() << "localhost:" << S3Port())
             .Bucket("test_bucket")
             .Scheme(NYdb::ES3Scheme::HTTP)
             .AccessKey("test_key")
@@ -121,7 +138,7 @@ protected:
     NYdb::NImport::TImportFromS3Settings MakeImportSettings(const TString& sourcePrefix, const TString& destinationPath) {
         NYdb::NImport::TImportFromS3Settings importSettings;
         importSettings
-            .Endpoint(TStringBuilder() << "localhost:" << S3Port)
+            .Endpoint(TStringBuilder() << "localhost:" << S3Port())
             .Bucket("test_bucket")
             .Scheme(NYdb::ES3Scheme::HTTP)
             .AccessKey("test_key")
@@ -137,7 +154,7 @@ protected:
 
     void ValidateS3FileList(const TSet<TString>& paths, const TString& prefix = {}) {
         TSet<TString> keys;
-        for (const auto& [key, _] : S3Mock.GetData()) {
+        for (const auto& [key, _] : S3Mock().GetData()) {
             if (!prefix || key.StartsWith(prefix)) {
                 keys.insert(key);
             }
@@ -177,11 +194,11 @@ protected:
         return l;
     }
 
-protected:
+private:
     TDataShardExportFactory DataShardExportFactory;
-    NYdb::TKikimrWithGrpcAndRootSchema Server;
-    const ui16 S3Port;
-    NKikimr::NWrappers::NTestHelpers::TS3Mock S3Mock;
+    TMaybe<NYdb::TKikimrWithGrpcAndRootSchema> Server_;
+    ui16 S3Port_ = 0;
+    TMaybe<NKikimr::NWrappers::NTestHelpers::TS3Mock> S3Mock_;
     TMaybe<NYdb::TDriverConfig> DriverConfig;
     TMaybe<NYdb::TDriver> Driver;
 };


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

...

### Changelog category <!-- remove all except one -->

* Not for changelog (changelog entry is not required)

### Description for reviewers <!-- (optional) description for those who read this PR -->

Unittest library has a "feature": it calls Fixture constructor (https://github.com/ydb-platform/ydb/blob/main/ydb/services/ydb/backup_ut/s3_backup_test_base.h#L182) during tests listing (for each listed test in the tool). So in backup tests case they run server many times before even running these tests. It causes long delays, especially for ASAN tests.