### PR TITLE
CI: fix update muted ya workflow + create issues for muted test

### DIFF
--- a/.github/workflows/create_issues_for_muted_tests.yml
+++ b/.github/workflows/create_issues_for_muted_tests.yml
@@ -1,11 +1,12 @@
 name: Create issues for muted tests
 
 on:
-  pull_request_target:
-    types: [review_submitted]
+  pull_request_review:
+    types:
+      - submitted
     branches:
       - main
-      - 'stable*'
+      - 'stable-*'
   workflow_dispatch:
     inputs:
         pr_number: 
@@ -21,7 +22,7 @@ jobs:
   create-issues-for-muted-tests:
     runs-on: ubuntu-latest
     if: |
-        (github.event_name == 'pull_request_target' && 
+        (github.event_name == 'pull_request_review' && 
         github.event.review.state == 'approved' && 
         contains(github.event.pull_request.labels.*.name, 'mute-unmute')) || 
         github.event_name == 'workflow_dispatch'

--- a/.github/workflows/update_muted_ya.yml
+++ b/.github/workflows/update_muted_ya.yml
@@ -2,7 +2,7 @@ name: Update Muted tests
 
 on:
   schedule:
-    - cron: "0 12 * * *"  # At 12-00 UTC every day
+    - cron: "0 6-20/2 * * *"  # Every 2 hours from 6:00 to 20:00 UTC
   workflow_dispatch:
     inputs:
       branches:
@@ -15,7 +15,7 @@ env:
   BRANCH_FOR_PR: update-muted-ya
   TITLE: "Update muted_ya.txt"
   REVIEWERS: "['ci']"
-  LABEL: mute-unmute
+  LABELS: "mute-unmute,not-for-changelog,ok-to-test"
   BUILD_TYPE: relwithdebinfo # Используем только один тип сборки
 
 jobs:
@@ -230,11 +230,12 @@ jobs:
               repo: context.repo.repo,
               body: completeBody
             });
-      
+            
+            const labelsToAdd = process.env.LABELS.split(',');
             github.rest.issues.addLabels({
               ...context.repo,
               issue_number: ${{ steps.create_or_update_pr.outputs.pr_number }},
-              labels: ['${{ env.LABEL }}']
+              labels: labelsToAdd
             });
 
       - name: Add reviewers

--- a/.github/workflows/update_muted_ya.yml
+++ b/.github/workflows/update_muted_ya.yml
@@ -248,3 +248,17 @@ jobs:
           pull_number: ${{ steps.create_or_update_pr.outputs.pr_number }}
           team_reviewers: ${{ env.REVIEWERS }}
           token: ${{ secrets.YDBOT_TOKEN }}
+      - name: Enable auto-merge
+        if: env.changes == 'true'
+        uses: actions/github-script@v7
+        with:
+          github-token: ${{ secrets.YDBOT_TOKEN }}
+          script: |
+            const pr = ${{ steps.create_or_update_pr.outputs.pr_number }};
+            await github.rest.pulls.update({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              pull_number: pr,
+              auto_merge: true
+            });
+


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

**create_issues_for_muted_tests.yml**
- Починил запуск при аппруве PR (заменил pull_request_target на pull_request_review) ( это оказалось не работает)
- Подправил шаблон веток с stable* на stable-*

**update_muted_ya.yml**
- Теперь запускается каждые 2 часа, но только с 6 до 21 по UTC (не будет шуметь ночью)
- Добавил метки not-for-changelog и ok-to-test чтобы точно проверки запустили
- У pr включается automerge

Теперь всё будет работать автоматически, без ручных действий (только ok на ревью)


### Changelog category <!-- remove all except one -->


* Not for changelog (changelog entry is not required)

### Description for reviewers <!-- (optional) description for those who read this PR -->

...
