### PR TITLE
Another fixture

### DIFF
--- a/ydb/tests/compatibility/test_export_s3.py
+++ b/ydb/tests/compatibility/test_export_s3.py
@@ -6,53 +6,17 @@ import yatest
 import os
 import json
 import sys
-from ydb.tests.library.harness.kikimr_runner import KiKiMR
-from ydb.tests.library.harness.kikimr_config import KikimrConfigGenerator
-from ydb.tests.library.harness.param_constants import kikimr_driver_path
-from ydb.tests.library.common.types import Erasure
 from ydb.tests.oss.ydb_sdk_import import ydb
+from ydb.tests.library.compatibility.fixtures import MixedClusterFixture
 
 
-last_stable_binary_path = yatest.common.binary_path("ydb/tests/library/compatibility/binaries/ydbd-last-stable")
-current_binary_path = kikimr_driver_path()
-
-all_binary_combinations = [
-    [current_binary_path],
-    [last_stable_binary_path],
-    [current_binary_path, last_stable_binary_path],
-]
-all_binary_combinations_ids = [
-    "current",
-    "last_stable",
-    "current_and_last_stable",
-]
-
-
-class TestExportS3(object):
-    @pytest.fixture(autouse=True, params=all_binary_combinations, ids=all_binary_combinations_ids)
-    def setup(self, request):
-        self.all_binary_paths = request.param
-        self.config = KikimrConfigGenerator(
-            erasure=Erasure.MIRROR_3_DC,
-            binary_paths=self.all_binary_paths,
-        )
-
-        self.cluster = KiKiMR(self.config)
-        self.cluster.start()
-        self.endpoint = "grpc://%s:%s" % ('localhost', self.cluster.nodes[1].port)
+class TestExportS3(MixedClusterFixture):
+    @pytest.fixture(autouse=True)
+    def setup(self):
         output_path = yatest.common.test_output_path()
         self.output_f = open(os.path.join(output_path, "out.log"), "w")
         self.s3_config = self.setup_s3()
-
-        self.driver = ydb.Driver(
-            ydb.DriverConfig(
-                database='/Root',
-                endpoint=self.endpoint
-            )
-        )
-        self.driver.wait()
-        yield
-        self.cluster.stop()
+        yield from self.setup_cluster()
 
     @staticmethod
     def setup_s3():

--- a/ydb/tests/compatibility/test_stress.py
+++ b/ydb/tests/compatibility/test_stress.py
@@ -5,30 +5,15 @@ import pytest
 
 import yatest
 
-from ydb.tests.library.harness.kikimr_runner import KiKiMR
-from ydb.tests.library.harness.kikimr_config import KikimrConfigGenerator
-from ydb.tests.library.harness.param_constants import kikimr_driver_path
-from ydb.tests.library.common.types import Erasure
 from ydb.tests.stress.simple_queue.workload import Workload
+from ydb.tests.library.compatibility.fixtures import MixedClusterFixture
 
-last_stable_binary_path = yatest.common.binary_path("ydb/tests/library/compatibility/binaries/ydbd-last-stable")
-current_binary_path = kikimr_driver_path()
-
-all_binary_combinations = [
-    [last_stable_binary_path],
-    [current_binary_path],
-    [last_stable_binary_path, current_binary_path],
-]
-all_binary_combinations_ids = ["last_stable", "current", "mixed"]
-
-
-class TestStress(object):
-    @pytest.fixture(autouse=True, params=all_binary_combinations, ids=all_binary_combinations_ids)
-    def setup(self, request):
-        binary_paths = request.param
-        self.config = KikimrConfigGenerator(
-            erasure=Erasure.MIRROR_3_DC,
-            binary_paths=binary_paths,
+class TestStress(MixedClusterFixture):
+    @pytest.fixture(autouse=True)
+    def setup(self):
+        output_path = yatest.common.test_output_path()
+        self.output_f = open(os.path.join(output_path, "out.log"), "w")
+        yield from self.setup_cluster(
             # uncomment for 64 datetime in tpc-h/tpc-ds
             # extra_feature_flags={"enable_table_datetime64": True},
 
@@ -36,14 +21,6 @@ class TestStress(object):
                 'disabled_on_scheme_shard': False,
             },
         )
-
-        self.cluster = KiKiMR(self.config)
-        self.cluster.start()
-        self.endpoint = "%s:%s" % (self.cluster.nodes[1].host, self.cluster.nodes[1].port)
-        output_path = yatest.common.test_output_path()
-        self.output_f = open(os.path.join(output_path, "out.log"), "w")
-        yield
-        self.cluster.stop()
 
     def get_command_prefix_log(self, subcmds: list[str], path: str) -> list[str]:
         return (

--- a/ydb/tests/compatibility/test_stress.py
+++ b/ydb/tests/compatibility/test_stress.py
@@ -8,6 +8,7 @@ import yatest
 from ydb.tests.stress.simple_queue.workload import Workload
 from ydb.tests.library.compatibility.fixtures import MixedClusterFixture
 
+
 class TestStress(MixedClusterFixture):
     @pytest.fixture(autouse=True)
     def setup(self):

--- a/ydb/tests/library/compatibility/fixtures.py
+++ b/ydb/tests/library/compatibility/fixtures.py
@@ -83,6 +83,7 @@ all_binary_combinations_ids_mixed = [
     "current_and_last_stable",
 ]
 
+
 class MixedClusterFixture:
     @pytest.fixture(autouse=True, params=all_binary_combinations_mixed, ids=all_binary_combinations_ids_mixed)
     def base_setup(self, request):

--- a/ydb/tests/library/compatibility/fixtures.py
+++ b/ydb/tests/library/compatibility/fixtures.py
@@ -12,13 +12,13 @@ from ydb.tests.oss.ydb_sdk_import import ydb
 last_stable_binary_path = yatest.common.binary_path("ydb/tests/library/compatibility/binaries/ydbd-last-stable")
 current_binary_path = kikimr_driver_path()
 
-all_binary_combinations = [
+all_binary_combinations_restart = [
     [[last_stable_binary_path], [current_binary_path]],
     [[last_stable_binary_path], [last_stable_binary_path, current_binary_path]],
     [[current_binary_path], [last_stable_binary_path]],
     [[current_binary_path], [current_binary_path]],
 ]
-all_binary_combinations_ids = [
+all_binary_combinations_ids_restart = [
     "last_stable_to_current",
     "last_stable_to_current_mixed",
     "current_to_last_stable",
@@ -27,7 +27,7 @@ all_binary_combinations_ids = [
 
 
 class RestartToAnotherVersionFixture:
-    @pytest.fixture(autouse=True, params=all_binary_combinations, ids=all_binary_combinations_ids)
+    @pytest.fixture(autouse=True, params=all_binary_combinations_restart, ids=all_binary_combinations_ids_restart)
     def base_setup(self, request):
         self.current_binary_paths_index = 0
         self.all_binary_paths = request.param
@@ -70,3 +70,41 @@ class RestartToAnotherVersionFixture:
         # without sleep there are errors like
         # ydb.issues.Unavailable: message: "Failed to resolve tablet: 72075186224037909 after several retries." severity: 1 (server_code: 400050)
         time.sleep(60)
+
+
+all_binary_combinations_mixed = [
+    [current_binary_path],
+    [last_stable_binary_path],
+    [current_binary_path, last_stable_binary_path],
+]
+all_binary_combinations_ids_mixed = [
+    "current",
+    "last_stable",
+    "current_and_last_stable",
+]
+
+class MixedClusterFixture:
+    @pytest.fixture(autouse=True, params=all_binary_combinations_mixed, ids=all_binary_combinations_ids_mixed)
+    def base_setup(self, request):
+        self.all_binary_paths = request.param
+
+    def setup_cluster(self, **kwargs):
+        self.config = KikimrConfigGenerator(
+            erasure=Erasure.MIRROR_3_DC,
+            binary_paths=self.all_binary_paths,
+            **kwargs,
+        )
+
+        self.cluster = KiKiMR(self.config)
+        self.cluster.start()
+        self.endpoint = "grpc://%s:%s" % ('localhost', self.cluster.nodes[1].port)
+
+        self.driver = ydb.Driver(
+            ydb.DriverConfig(
+                database='/Root',
+                endpoint=self.endpoint
+            )
+        )
+        self.driver.wait()
+        yield
+        self.cluster.stop()


### PR DESCRIPTION
This PR introduces a new fixture(MixedClusterFixture) to streamline binary combination configurations and cluster setup across compatibility tests. It allow to setup mixed (main + 25-1) cluster for testing