### PR TITLE
stable-25-1: Create simple counter to count success data erasure and timeouts in one iteration of data erasure (#18251)

### DIFF
--- a/ydb/core/tx/schemeshard/schemeshard__data_erasure_manager.h
+++ b/ydb/core/tx/schemeshard/schemeshard__data_erasure_manager.h
@@ -27,6 +27,9 @@ protected:
     ui64 Generation = 0;
     bool Running = false;
 
+    ui64 CounterDataErasureOk = 0;
+    ui64 CounterDataErasureTimeout = 0;
+
 public:
     TDataErasureManager(TSchemeShard* const schemeShard);
 


### PR DESCRIPTION

### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

...

### Changelog category <!-- remove all except one -->

* Not for changelog (changelog entry is not required)

### Description for reviewers <!-- (optional) description for those who read this PR -->

Create simple counter to count success data erasure and timeouts in one iteration of data erasure
