### PR TITLE
Ignore signed compare for musl builds

### DIFF
--- a/ydb/library/actors/interconnect/ya.make
+++ b/ydb/library/actors/interconnect/ya.make
@@ -6,6 +6,11 @@ IF (PROFILE_MEMORY_ALLOCATIONS)
     CFLAGS(-DPROFILE_MEMORY_ALLOCATIONS)
 ENDIF()
 
+IF (MUSL)
+    # musl code for CMSG_NXTHDR is broken by this check
+    CFLAGS(-Wno-sign-compare)
+ENDIF()
+
 SRCS(
     channel_scheduler.h
     event_filter.h


### PR DESCRIPTION
Solved a problem of YDBREQUESTS-5568: musl builds are broken because of signed compare

* Bugfix

Error occured with build of some services:
```
...
contrib/ydb/library/actors/interconnect/interconnect_zc_processor.cpp:118:20: error: comparison of integers of different signs: 'unsigned long' and 'long' [-Werror,-Wsign-compare]
  118 |             cmsg = CMSG_NXTHDR(&msg, cmsg)) {
      |                    ^~~~~~~~~~~~~~~~~~~~~~~
contrib/libs/musl/include/sys/socket.h:358:44: note: expanded from macro 'CMSG_NXTHDR'
  358 |         __CMSG_LEN(cmsg) + sizeof(struct cmsghdr) >= __MHDR_END(mhdr) - (unsigned char *)(cmsg) \
      |         ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ ^  ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
1 error generated.
```

...
