### PR TITLE
Remove NYT::CreateStdErrLogger method from query_replay_yt

### DIFF
--- a/ydb/tools/query_replay_yt/main.cpp
+++ b/ydb/tools/query_replay_yt/main.cpp
@@ -235,6 +235,7 @@ static NYT::TTableSchema OutputSchema() {
 REGISTER_NAMED_MAPPER("Query replay mapper", TQueryReplayMapper);
 
 int main(int argc, const char** argv) {
+    NYT::TConfig::Get()->LogLevel = NYT::NLogLevel::Info;
     NYT::Initialize(argc, argv);
 
     TQueryReplayConfig config;
@@ -279,7 +280,6 @@ int main(int argc, const char** argv) {
     }
 
     auto client = NYT::CreateClient(config.Cluster);
-    NYT::SetLogger(NYT::CreateStdErrLogger(NYT::ILogger::ELevel::INFO));
 
     NYT::TMapOperationSpec spec;
     spec.AddInput<NYT::TNode>(config.SrcPath);


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

Remove `NYT::CreateStdErrLogger` since `NYT::Initialize` already sets up the logger.

### Changelog category <!-- remove all except one -->

* Not for changelog (changelog entry is not required)

### Description for reviewers <!-- (optional) description for those who read this PR -->

This PR refactors the existing logging setup by removing the use of `CreateStdErrLogger`, which will soon be obsolete. `NYT::Initialize`is already handling logger setup directly, making `CreateStdErrLogger` redundant. 

You probably have to set desired `LogLevel` config option before calling `NYT::Initialize`, if it is differs from the default (error) log level.
This change is also in alignment with the wider refactoring of the logging system within yt/cpp. Please refer to https://github.com/ytsaurus/ytsaurus/commit/8956fc5025b6d29502345c457fe160477c34436a
