### PR TITLE
Implement ImportService.ListObjectsInS3Export on server side

### DIFF
--- a/ydb/core/backup/common/metadata.h
+++ b/ydb/core/backup/common/metadata.h
@@ -57,6 +57,10 @@ private:
     TMaybeFail<ui64> Version;
 };
 
+TString NormalizeItemPath(const TString& path);
+TString NormalizeItemPrefix(TString prefix);
+TString NormalizeExportPrefix(TString prefix);
+
 class TSchemaMapping {
 public:
     struct TItem {
@@ -67,6 +71,7 @@ public:
 
     TSchemaMapping() = default;
 
+    TString Serialize() const;
     bool Deserialize(const TString& jsonContent, TString& error);
 
 public:

--- a/ydb/core/backup/common/metadata_ut.cpp
+++ b/ydb/core/backup/common/metadata_ut.cpp
@@ -1,0 +1,35 @@
+#include "metadata.h"
+
+#include <library/cpp/testing/unittest/registar.h>
+
+namespace NKikimr::NBackup {
+
+Y_UNIT_TEST_SUITE(PathsNormalizationTest) {
+    Y_UNIT_TEST(NormalizeItemPath) {
+        UNIT_ASSERT_STRINGS_EQUAL(NormalizeItemPath("/a/b/c/"), "a/b/c");
+        UNIT_ASSERT_STRINGS_EQUAL(NormalizeItemPath("/"), "");
+        UNIT_ASSERT_STRINGS_EQUAL(NormalizeItemPath(""), "");
+        UNIT_ASSERT_STRINGS_EQUAL(NormalizeItemPath("//"), "");
+        UNIT_ASSERT_STRINGS_EQUAL(NormalizeItemPath("///a///b///"), "a/b");
+        UNIT_ASSERT_STRINGS_EQUAL(NormalizeItemPath("a/b/c"), "a/b/c");
+    }
+
+    Y_UNIT_TEST(NormalizeItemPrefix) {
+        UNIT_ASSERT_STRINGS_EQUAL(NormalizeItemPrefix("///a///b///c///"), "a///b///c");
+        UNIT_ASSERT_STRINGS_EQUAL(NormalizeItemPrefix("a///b///c"), "a///b///c");
+        UNIT_ASSERT_STRINGS_EQUAL(NormalizeItemPrefix("//"), "");
+        UNIT_ASSERT_STRINGS_EQUAL(NormalizeItemPrefix("/"), "");
+        UNIT_ASSERT_STRINGS_EQUAL(NormalizeItemPrefix(""), "");
+    }
+
+    Y_UNIT_TEST(NormalizeExportPrefix) {
+        UNIT_ASSERT_STRINGS_EQUAL(NormalizeExportPrefix("///a///"), "///a");
+        UNIT_ASSERT_STRINGS_EQUAL(NormalizeExportPrefix("a/"), "a");
+        UNIT_ASSERT_STRINGS_EQUAL(NormalizeExportPrefix("a"), "a");
+        UNIT_ASSERT_STRINGS_EQUAL(NormalizeExportPrefix("/prefix//"), "/prefix");
+        UNIT_ASSERT_STRINGS_EQUAL(NormalizeExportPrefix(""), "");
+        UNIT_ASSERT_STRINGS_EQUAL(NormalizeExportPrefix("/prefix"), "/prefix");
+    }
+}
+
+} // namespace NKikimr::NBackup

--- a/ydb/core/backup/common/ut/ya.make
+++ b/ydb/core/backup/common/ut/ya.make
@@ -2,6 +2,7 @@ UNITTEST_FOR(ydb/core/backup/common)
 
 SRCS(
     encryption_ut.cpp
+    metadata_ut.cpp
 )
 
 END()

--- a/ydb/core/grpc_services/rpc_list_objects_in_s3_export.cpp
+++ b/ydb/core/grpc_services/rpc_list_objects_in_s3_export.cpp
@@ -112,6 +112,8 @@ public:
 
         *request->Record.MutableOperationParams() = GetProtoRequest()->operation_params();
         *request->Record.MutableSettings() = GetProtoRequest()->settings();
+        request->Record.SetPageSize(GetProtoRequest()->page_size());
+        request->Record.SetPageToken(GetProtoRequest()->page_token());
 
         NTabletPipe::SendData(this->SelfId(), PipeClient, std::move(request), 0, Span_.GetTraceId());
     }

--- a/ydb/core/grpc_services/rpc_list_objects_in_s3_export.cpp
+++ b/ydb/core/grpc_services/rpc_list_objects_in_s3_export.cpp
@@ -1,0 +1,161 @@
+#include "service_import.h"
+#include "rpc_deferrable.h"
+
+#include <ydb/core/base/tablet_pipe.h>
+#include <ydb/core/grpc_services/base/base.h>
+#include <ydb/core/tx/scheme_cache/scheme_cache.h>
+#include <ydb/core/tx/schemeshard/schemeshard_import.h>
+#include <ydb/public/api/protos/ydb_import.pb.h>
+
+#define LOG_T(stream) LOG_TRACE_S(*TlsActivationContext, NKikimrServices::TX_PROXY, "[ListObjectsInS3Export] " << SelfId() << stream)
+#define LOG_D(stream) LOG_DEBUG_S(*TlsActivationContext, NKikimrServices::TX_PROXY, "[ListObjectsInS3Export] " << SelfId() << stream)
+#define LOG_I(stream) LOG_INFO_S(*TlsActivationContext, NKikimrServices::TX_PROXY, "[ListObjectsInS3Export] " << SelfId() << stream)
+#define LOG_N(stream) LOG_NOTICE_S(*TlsActivationContext, NKikimrServices::TX_PROXY, "[ListObjectsInS3Export] " << SelfId() << stream)
+#define LOG_W(stream) LOG_WARN_S(*TlsActivationContext, NKikimrServices::TX_PROXY, "[ListObjectsInS3Export] " << SelfId() << stream)
+#define LOG_E(stream) LOG_ERROR_S(*TlsActivationContext, NKikimrServices::TX_PROXY, "[ListObjectsInS3Export] " << SelfId() << stream)
+
+namespace NKikimr::NGRpcService {
+
+using TEvListObjectsInS3ExportRequest = TGrpcRequestOperationCall<Ydb::Import::ListObjectsInS3ExportRequest,
+    Ydb::Import::ListObjectsInS3ExportResponse>;
+
+class TListObjectsInS3ExportRPC: public TRpcOperationRequestActor<TListObjectsInS3ExportRPC, TEvListObjectsInS3ExportRequest> {
+public:
+    using TBase = TRpcOperationRequestActor<TListObjectsInS3ExportRPC, TEvListObjectsInS3ExportRequest>;
+    using TRpcOperationRequestActor<TListObjectsInS3ExportRPC, TEvListObjectsInS3ExportRequest>::TRpcOperationRequestActor;
+
+    STATEFN(StateFunc) {
+        switch (ev->GetTypeRewrite()) {
+            hFunc(NKikimr::NSchemeShard::TEvImport::TEvListObjectsInS3ExportResponse, Handle);
+            hFunc(TEvTxProxySchemeCache::TEvNavigateKeySetResult, Handle);
+
+            hFunc(TEvTabletPipe::TEvClientConnected, Handle);
+            hFunc(TEvTabletPipe::TEvClientDestroyed, Handle);
+        default:
+            return StateFuncBase(ev);
+        }
+    }
+
+    void Bootstrap() {
+        if (!Request_ || !Request_->GetDatabaseName()) {
+            return Reply(Ydb::StatusIds::BAD_REQUEST, "Database name is not specified", NKikimrIssues::TIssuesIds::YDB_API_VALIDATION_ERROR, NActors::TActivationContext::AsActorContext());
+        }
+
+        ResolveDatabase();
+
+        Become(&TListObjectsInS3ExportRPC::StateFunc);
+    }
+
+    void ResolveDatabase() {
+        LOG_D("Resolve database"
+            << ": name# " << Request_->GetDatabaseName());
+
+        auto request = MakeHolder<NSchemeCache::TSchemeCacheNavigate>();
+        request->DatabaseName = *Request_->GetDatabaseName();
+
+        auto& entry = request->ResultSet.emplace_back();
+        entry.Operation = NSchemeCache::TSchemeCacheNavigate::OpPath;
+        entry.Path = NKikimr::SplitPath(*Request_->GetDatabaseName());
+
+        Send(MakeSchemeCacheID(), new TEvTxProxySchemeCache::TEvNavigateKeySet(request.Release()));
+    }
+
+    void Handle(TEvTxProxySchemeCache::TEvNavigateKeySetResult::TPtr& ev) {
+        const auto& request = ev->Get()->Request;
+
+        LOG_D("Handle TEvTxProxySchemeCache::TEvNavigateKeySetResult"
+            << ": request# " << (request ? request->ToString(*AppData()->TypeRegistry) : "nullptr"));
+
+        if (request->ResultSet.empty()) {
+            return Reply(Ydb::StatusIds::SCHEME_ERROR, "Scheme error", NKikimrIssues::TIssuesIds::GENERIC_RESOLVE_ERROR, NActors::TActivationContext::AsActorContext());
+        }
+
+        const auto& entry = request->ResultSet.front();
+
+        if (request->ErrorCount > 0) {
+            switch (entry.Status) {
+            case NSchemeCache::TSchemeCacheNavigate::EStatus::Ok:
+                break;
+            case NSchemeCache::TSchemeCacheNavigate::EStatus::AccessDenied:
+                return Reply(Ydb::StatusIds::UNAUTHORIZED, "Access denied", NKikimrIssues::TIssuesIds::ACCESS_DENIED, NActors::TActivationContext::AsActorContext());
+            case NSchemeCache::TSchemeCacheNavigate::EStatus::RootUnknown:
+            case NSchemeCache::TSchemeCacheNavigate::EStatus::PathErrorUnknown:
+                return Reply(Ydb::StatusIds::SCHEME_ERROR, "Unknown database", NKikimrIssues::TIssuesIds::PATH_NOT_EXIST, NActors::TActivationContext::AsActorContext());
+            case NSchemeCache::TSchemeCacheNavigate::EStatus::LookupError:
+            case NSchemeCache::TSchemeCacheNavigate::EStatus::RedirectLookupError:
+                return Reply(Ydb::StatusIds::UNAVAILABLE, "Database lookup error", NKikimrIssues::TIssuesIds::RESOLVE_LOOKUP_ERROR, NActors::TActivationContext::AsActorContext());
+            default:
+                return Reply(Ydb::StatusIds::SCHEME_ERROR, "Scheme error", NKikimrIssues::TIssuesIds::GENERIC_RESOLVE_ERROR, NActors::TActivationContext::AsActorContext());
+            }
+        }
+
+        auto domainInfo = entry.DomainInfo;
+        if (!domainInfo) {
+            LOG_E("Got empty domain info");
+            return Reply(Ydb::StatusIds::INTERNAL_ERROR, "Internal error", NKikimrIssues::TIssuesIds::GENERIC_RESOLVE_ERROR, NActors::TActivationContext::AsActorContext());
+        }
+
+        SchemeShardId = domainInfo->ExtractSchemeShard();
+        SendRequestToSchemeShard();
+    }
+
+    void SendRequestToSchemeShard() {
+        LOG_D("Send request: schemeShardId# " << SchemeShardId);
+
+        if (!PipeClient) {
+            NTabletPipe::TClientConfig config;
+            config.RetryPolicy = {.RetryLimitCount = 3};
+            PipeClient = this->RegisterWithSameMailbox(NTabletPipe::CreateClient(this->SelfId(), SchemeShardId, config));
+        }
+
+        auto request = MakeHolder<NSchemeShard::TEvImport::TEvListObjectsInS3ExportRequest>();
+
+        *request->Record.MutableOperationParams() = GetProtoRequest()->operation_params();
+        *request->Record.MutableSettings() = GetProtoRequest()->settings();
+
+        NTabletPipe::SendData(this->SelfId(), PipeClient, std::move(request), 0, Span_.GetTraceId());
+    }
+
+    void Handle(NKikimr::NSchemeShard::TEvImport::TEvListObjectsInS3ExportResponse::TPtr& ev) {
+        const auto& record = ev->Get()->Record;
+
+        LOG_D("Handle TListObjectsInS3ExportRPC::TEvListObjectsInS3ExportResponse"
+            << ": record# " << record.ShortDebugString());
+
+        if (record.GetStatus() != Ydb::StatusIds::SUCCESS) {
+            return Reply(record.GetStatus(), record.GetIssues(), NActors::TActivationContext::AsActorContext());
+        } else {
+            return ReplyWithResult(record.GetStatus(), record.GetIssues(), record.GetResult(), NActors::TActivationContext::AsActorContext());
+        }
+    }
+
+    void Handle(TEvTabletPipe::TEvClientConnected::TPtr& ev) {
+        if (ev->Get()->Status != NKikimrProto::OK) {
+            DeliveryProblem();
+        }
+    }
+
+    void Handle(TEvTabletPipe::TEvClientDestroyed::TPtr&) {
+        DeliveryProblem();
+    }
+
+    void DeliveryProblem() {
+        LOG_W("Delivery problem");
+        Reply(Ydb::StatusIds::UNAVAILABLE, "Delivery problem", NKikimrIssues::TIssuesIds::DEFAULT_ERROR, NActors::TActivationContext::AsActorContext());
+    }
+
+    void PassAway() override {
+        NTabletPipe::CloseClient(this->SelfId(), PipeClient);
+        TBase::PassAway();
+    }
+
+private:
+    ui64 SchemeShardId = 0;
+    TActorId PipeClient;
+};
+
+void DoListObjectsInS3ExportRequest(std::unique_ptr<IRequestOpCtx> p, const IFacilityProvider& f) {
+    f.RegisterActor(new TListObjectsInS3ExportRPC(p.release()));
+}
+
+} // namespace NKikimr::NGRpcService

--- a/ydb/core/grpc_services/rpc_list_objects_in_s3_export.cpp
+++ b/ydb/core/grpc_services/rpc_list_objects_in_s3_export.cpp
@@ -7,12 +7,12 @@
 #include <ydb/core/tx/schemeshard/schemeshard_import.h>
 #include <ydb/public/api/protos/ydb_import.pb.h>
 
-#define LOG_T(stream) LOG_TRACE_S(*TlsActivationContext, NKikimrServices::TX_PROXY, "[ListObjectsInS3Export] " << SelfId() << stream)
-#define LOG_D(stream) LOG_DEBUG_S(*TlsActivationContext, NKikimrServices::TX_PROXY, "[ListObjectsInS3Export] " << SelfId() << stream)
-#define LOG_I(stream) LOG_INFO_S(*TlsActivationContext, NKikimrServices::TX_PROXY, "[ListObjectsInS3Export] " << SelfId() << stream)
-#define LOG_N(stream) LOG_NOTICE_S(*TlsActivationContext, NKikimrServices::TX_PROXY, "[ListObjectsInS3Export] " << SelfId() << stream)
-#define LOG_W(stream) LOG_WARN_S(*TlsActivationContext, NKikimrServices::TX_PROXY, "[ListObjectsInS3Export] " << SelfId() << stream)
-#define LOG_E(stream) LOG_ERROR_S(*TlsActivationContext, NKikimrServices::TX_PROXY, "[ListObjectsInS3Export] " << SelfId() << stream)
+#define LOG_T(stream) LOG_TRACE_S(*TlsActivationContext, NKikimrServices::TX_PROXY, "[ListObjectsInS3Export] " << SelfId() << " " << stream)
+#define LOG_D(stream) LOG_DEBUG_S(*TlsActivationContext, NKikimrServices::TX_PROXY, "[ListObjectsInS3Export] " << SelfId() << " " << stream)
+#define LOG_I(stream) LOG_INFO_S(*TlsActivationContext, NKikimrServices::TX_PROXY, "[ListObjectsInS3Export] " << SelfId() << " " << stream)
+#define LOG_N(stream) LOG_NOTICE_S(*TlsActivationContext, NKikimrServices::TX_PROXY, "[ListObjectsInS3Export] " << SelfId() << " " << stream)
+#define LOG_W(stream) LOG_WARN_S(*TlsActivationContext, NKikimrServices::TX_PROXY, "[ListObjectsInS3Export] " << SelfId() << " " << stream)
+#define LOG_E(stream) LOG_ERROR_S(*TlsActivationContext, NKikimrServices::TX_PROXY, "[ListObjectsInS3Export] " << SelfId() << " " << stream)
 
 namespace NKikimr::NGRpcService {
 

--- a/ydb/core/grpc_services/service_import.h
+++ b/ydb/core/grpc_services/service_import.h
@@ -9,6 +9,7 @@ class IRequestOpCtx;
 class IFacilityProvider;
 
 void DoImportFromS3Request(std::unique_ptr<IRequestOpCtx> p, const IFacilityProvider& f);
+void DoListObjectsInS3ExportRequest(std::unique_ptr<IRequestOpCtx> p, const IFacilityProvider& f);
 void DoImportDataRequest(std::unique_ptr<IRequestOpCtx> p, const IFacilityProvider& f);
 
 }

--- a/ydb/core/grpc_services/ya.make
+++ b/ydb/core/grpc_services/ya.make
@@ -60,6 +60,7 @@ SRCS(
     rpc_kh_describe.cpp
     rpc_kh_snapshots.cpp
     rpc_kqp_base.cpp
+    rpc_list_objects_in_s3_export.cpp
     rpc_list_operations.cpp
     rpc_load_rows.cpp
     rpc_log_store.cpp

--- a/ydb/core/protos/import.proto
+++ b/ydb/core/protos/import.proto
@@ -129,3 +129,14 @@ message TListImportsResponse {
 message TEvListImportsResponse {
     optional TListImportsResponse Response = 1;
 }
+
+message TEvListObjectsInS3ExportRequest {
+    optional Ydb.Operations.OperationParams OperationParams = 1;
+    optional Ydb.Import.ListObjectsInS3ExportSettings Settings = 2;
+}
+
+message TEvListObjectsInS3ExportResponse {
+    optional Ydb.StatusIds.StatusCode Status = 1;
+    repeated Ydb.Issue.IssueMessage Issues = 2;
+    optional Ydb.Import.ListObjectsInS3ExportResult Result = 3;
+}

--- a/ydb/core/protos/import.proto
+++ b/ydb/core/protos/import.proto
@@ -133,6 +133,8 @@ message TEvListImportsResponse {
 message TEvListObjectsInS3ExportRequest {
     optional Ydb.Operations.OperationParams OperationParams = 1;
     optional Ydb.Import.ListObjectsInS3ExportSettings Settings = 2;
+    optional int64 PageSize = 3;
+    optional string PageToken = 4;
 }
 
 message TEvListObjectsInS3ExportResponse {

--- a/ydb/core/tx/schemeshard/schemeshard_export__create.cpp
+++ b/ydb/core/tx/schemeshard/schemeshard_export__create.cpp
@@ -408,10 +408,7 @@ private:
             return true;
         }
 
-        TString commonDestinationPrefix = exportSettings.destination_prefix();
-        if (commonDestinationPrefix.back() == '/') {
-            commonDestinationPrefix.pop_back();
-        }
+        TString commonDestinationPrefix = NBackup::NormalizeExportPrefix(exportSettings.destination_prefix());
 
         TMaybe<NBackup::TEncryptionIV> iv;
         if (exportSettings.has_encryption_settings()) {
@@ -435,28 +432,20 @@ private:
             if (exportPath.StartsWith(sourcePathRoot)) {
                 exportPath = exportPath.substr(sourcePathRoot.size() + 1); // cut all prefix + '/'
             }
+            exportPath = NBackup::NormalizeItemPath(exportPath); // Path without leading slash
             schemaMappingItem.SetSourcePath(exportPath);
 
             TString destinationPrefix;
             if (!exportItem.destination_prefix().empty()) {
                 TString& itemPrefix = *exportItem.mutable_destination_prefix();
-                if (itemPrefix[0] == '/') {
-                    destinationPrefix = itemPrefix = itemPrefix.substr(1);
-                } else {
-                    destinationPrefix = itemPrefix;
-                }
-                if (itemPrefix.back() == '/') {
-                    itemPrefix.pop_back();
-                }
+                destinationPrefix = itemPrefix = NBackup::NormalizeItemPrefix(itemPrefix);
             } else {
                 std::stringstream itemPrefix;
                 if (exportSettings.has_encryption_settings()) {
                     // Anonymize object name in export
                     itemPrefix << std::setfill('0') << std::setw(3) << std::right << itemIndex;
                 } else {
-                    TStringBuf exportPathBuf = exportPath;
-                    exportPathBuf.SkipPrefix("/");
-                    itemPrefix << exportPathBuf;
+                    itemPrefix << exportPath;
                 }
                 destinationPrefix = itemPrefix.str();
             }

--- a/ydb/core/tx/schemeshard/schemeshard_export_uploaders.cpp
+++ b/ydb/core/tx/schemeshard/schemeshard_export_uploaders.cpp
@@ -2,6 +2,7 @@
 #include "schemeshard_export_uploaders.h"
 
 #include <ydb/core/backup/common/encryption.h>
+#include <ydb/core/backup/common/metadata.h>
 #include <ydb/core/protos/flat_scheme_op.pb.h>
 #include <ydb/core/tx/datashard/export_common.h>
 #include <ydb/core/tx/schemeshard/schemeshard_export_helpers.h>
@@ -494,34 +495,21 @@ private:
     }
 
     bool AddSchemaMappingJson() {
-        TString content;
-        TStringOutput ss(content);
-        NJson::TJsonWriter writer(&ss, false);
-
-        writer.OpenMap();
-        writer.WriteKey("exportedObjects");
-        writer.OpenMap();
+        NBackup::TSchemaMapping schemaMapping;
         for (const auto& item : ExportMetadata.GetSchemaMapping()) {
-            writer.WriteKey(item.GetSourcePath());
-            writer.OpenMap();
-            writer.Write("exportPrefix", item.GetDestinationPrefix());
-            if (item.HasIV()) {
-                writer.Write("iv", NBackup::TEncryptionIV::FromBinaryString(item.GetIV()).GetHexString());
-            }
-            writer.CloseMap();
+            schemaMapping.Items.emplace_back(NBackup::TSchemaMapping::TItem{
+                .ExportPrefix = item.GetDestinationPrefix(),
+                .ObjectPath = item.GetSourcePath(),
+                .IV = item.HasIV() ? TMaybe<NBackup::TEncryptionIV>(NBackup::TEncryptionIV::FromBinaryString(item.GetIV())) : Nothing()
+            });
         }
-        writer.CloseMap();
-        writer.CloseMap();
-
-        writer.Flush();
-        ss.Flush();
 
         TMaybe<NBackup::TEncryptionIV> iv;
         if (IV) {
             iv = NBackup::TEncryptionIV::Combine(*IV, NBackup::EBackupFileType::SchemaMapping, 0, 0);
         }
 
-        return AddFile("SchemaMapping/mapping.json", content, iv, Key);
+        return AddFile("SchemaMapping/mapping.json", schemaMapping.Serialize(), iv, Key);
     }
 
     void ProcessQueue() {

--- a/ydb/core/tx/schemeshard/schemeshard_impl.cpp
+++ b/ydb/core/tx/schemeshard/schemeshard_impl.cpp
@@ -4991,6 +4991,7 @@ void TSchemeShard::StateWork(STFUNC_SIG) {
         HFuncTraced(TEvImport::TEvCancelImportRequest, Handle);
         HFuncTraced(TEvImport::TEvForgetImportRequest, Handle);
         HFuncTraced(TEvImport::TEvListImportsRequest, Handle);
+        HFuncTraced(TEvImport::TEvListObjectsInS3ExportRequest, Handle);
         HFuncTraced(TEvPrivate::TEvImportSchemeReady, Handle);
         HFuncTraced(TEvPrivate::TEvImportSchemaMappingReady, Handle);
         HFuncTraced(TEvPrivate::TEvImportSchemeQueryResult, Handle);

--- a/ydb/core/tx/schemeshard/schemeshard_impl.h
+++ b/ydb/core/tx/schemeshard/schemeshard_impl.h
@@ -1364,6 +1364,7 @@ public:
     void Handle(TEvImport::TEvCancelImportRequest::TPtr& ev, const TActorContext& ctx);
     void Handle(TEvImport::TEvForgetImportRequest::TPtr& ev, const TActorContext& ctx);
     void Handle(TEvImport::TEvListImportsRequest::TPtr& ev, const TActorContext& ctx);
+    void Handle(TEvImport::TEvListObjectsInS3ExportRequest::TPtr& ev, const TActorContext& ctx);
     void Handle(TEvPrivate::TEvImportSchemeReady::TPtr& ev, const TActorContext& ctx);
     void Handle(TEvPrivate::TEvImportSchemaMappingReady::TPtr& ev, const TActorContext& ctx);
     void Handle(TEvPrivate::TEvImportSchemeQueryResult::TPtr& ev, const TActorContext& ctx);

--- a/ydb/core/tx/schemeshard/schemeshard_import.cpp
+++ b/ydb/core/tx/schemeshard/schemeshard_import.cpp
@@ -262,6 +262,13 @@ void TSchemeShard::Handle(TEvImport::TEvListImportsRequest::TPtr& ev, const TAct
     Execute(CreateTxListImports(ev), ctx);
 }
 
+void TSchemeShard::Handle(TEvImport::TEvListObjectsInS3ExportRequest::TPtr& ev, const TActorContext&) {
+    auto result = MakeHolder<TEvImport::TEvListObjectsInS3ExportResponse>();
+    result->Record.set_status(Ydb::StatusIds::UNSUPPORTED);
+    result->Record.add_issues()->set_message("UNSUPPORTED");
+    Send(ev->Sender, std::move(result));
+}
+
 void TSchemeShard::Handle(TEvPrivate::TEvImportSchemeReady::TPtr& ev, const TActorContext& ctx) {
     Execute(CreateTxProgressImport(ev), ctx);
 }

--- a/ydb/core/tx/schemeshard/schemeshard_import.cpp
+++ b/ydb/core/tx/schemeshard/schemeshard_import.cpp
@@ -1,6 +1,7 @@
 #include "schemeshard_import.h"
 #include "schemeshard_import_helpers.h"
 #include "schemeshard_impl.h"
+#include "schemeshard_import_getters.h"
 
 #include <util/generic/xrange.h>
 
@@ -263,10 +264,7 @@ void TSchemeShard::Handle(TEvImport::TEvListImportsRequest::TPtr& ev, const TAct
 }
 
 void TSchemeShard::Handle(TEvImport::TEvListObjectsInS3ExportRequest::TPtr& ev, const TActorContext&) {
-    auto result = MakeHolder<TEvImport::TEvListObjectsInS3ExportResponse>();
-    result->Record.set_status(Ydb::StatusIds::UNSUPPORTED);
-    result->Record.add_issues()->set_message("UNSUPPORTED");
-    Send(ev->Sender, std::move(result));
+    Register(CreateListObjectsInS3ExportGetter(std::move(ev)));
 }
 
 void TSchemeShard::Handle(TEvPrivate::TEvImportSchemeReady::TPtr& ev, const TActorContext& ctx) {

--- a/ydb/core/tx/schemeshard/schemeshard_import.h
+++ b/ydb/core/tx/schemeshard/schemeshard_import.h
@@ -19,6 +19,8 @@ struct TEvImport {
         EvForgetImportResponse,
         EvListImportsRequest,
         EvListImportsResponse,
+        EvListObjectsInS3ExportRequest,
+        EvListObjectsInS3ExportResponse,
 
         EvEnd
     };
@@ -161,6 +163,12 @@ struct TEvImport {
     };
 
     DECLARE_EVENT_CLASS(EvListImportsResponse) {
+    };
+
+    DECLARE_EVENT_CLASS(EvListObjectsInS3ExportRequest) {
+    };
+
+    DECLARE_EVENT_CLASS(EvListObjectsInS3ExportResponse) {
     };
 
 #undef DECLARE_EVENT_CLASS

--- a/ydb/core/tx/schemeshard/schemeshard_import_getters.cpp
+++ b/ydb/core/tx/schemeshard/schemeshard_import_getters.cpp
@@ -432,7 +432,7 @@ class TSchemeGetter: public TGetterFromS3<TSchemeGetter> {
         } else if (IsTopic(SchemeKey)) {
             Ydb::Topic::CreateTopicRequest request;
             if (!google::protobuf::TextFormat::ParseFromString(content, &request)) {
-                return Reply(false, "Cannot parse topic scheme");
+                return Reply(Ydb::StatusIds::BAD_REQUEST, "Cannot parse topic scheme");
             }
             item.Topic = request;
         } else if (!google::protobuf::TextFormat::ParseFromString(content, &item.Scheme)) {

--- a/ydb/core/tx/schemeshard/schemeshard_import_getters.cpp
+++ b/ydb/core/tx/schemeshard/schemeshard_import_getters.cpp
@@ -1056,6 +1056,10 @@ public:
                 return false;
             }
         }
+        if (NBackup::NormalizeExportPrefix(Request->Get()->Record.GetSettings().prefix()).empty()) {
+            Reply(Ydb::StatusIds::BAD_REQUEST, "Empty S3 prefix specified");
+            return false;
+        }
         return true;
     }
 

--- a/ydb/core/tx/schemeshard/schemeshard_import_getters.h
+++ b/ydb/core/tx/schemeshard/schemeshard_import_getters.h
@@ -2,6 +2,7 @@
 
 #include "defs.h"
 #include "schemeshard_info_types.h"
+#include "schemeshard_import.h"
 
 namespace NKikimr {
 namespace NSchemeShard {
@@ -9,6 +10,8 @@ namespace NSchemeShard {
 IActor* CreateSchemeGetter(const TActorId& replyTo, TImportInfo::TPtr importInfo, ui32 itemIdx, TMaybe<NBackup::TEncryptionIV> iv);
 
 IActor* CreateSchemaMappingGetter(const TActorId& replyTo, TImportInfo::TPtr importInfo);
+
+IActor* CreateListObjectsInS3ExportGetter(TEvImport::TEvListObjectsInS3ExportRequest::TPtr&& ev);
 
 } // NSchemeShard
 } // NKikimr

--- a/ydb/core/wrappers/s3_storage_config.h
+++ b/ydb/core/wrappers/s3_storage_config.h
@@ -26,6 +26,8 @@ private:
     static Aws::Auth::AWSCredentials CredentialsFromSettings(const NKikimrSchemeOp::TS3Settings& settings);
     static Aws::Client::ClientConfiguration ConfigFromSettings(const Ydb::Import::ImportFromS3Settings& settings);
     static Aws::Auth::AWSCredentials CredentialsFromSettings(const Ydb::Import::ImportFromS3Settings& settings);
+    static Aws::Client::ClientConfiguration ConfigFromSettings(const Ydb::Import::ListObjectsInS3ExportSettings& settings);
+    static Aws::Auth::AWSCredentials CredentialsFromSettings(const Ydb::Import::ListObjectsInS3ExportSettings& settings);
     static Aws::Client::ClientConfiguration ConfigFromSettings(const Ydb::Export::ExportToS3Settings& settings);
     static Aws::Auth::AWSCredentials CredentialsFromSettings(const Ydb::Export::ExportToS3Settings& settings);
 
@@ -46,6 +48,7 @@ public:
 
     TS3ExternalStorageConfig(const NKikimrSchemeOp::TS3Settings& settings);
     TS3ExternalStorageConfig(const Ydb::Import::ImportFromS3Settings& settings);
+    TS3ExternalStorageConfig(const Ydb::Import::ListObjectsInS3ExportSettings& settings);
     TS3ExternalStorageConfig(const Ydb::Export::ExportToS3Settings& settings);
     TS3ExternalStorageConfig(const Aws::Auth::AWSCredentials& credentials, const Aws::Client::ClientConfiguration& config, const TString& bucket);
 };

--- a/ydb/services/ydb/backup_ut/list_objects_in_s3_export_ut.cpp
+++ b/ydb/services/ydb/backup_ut/list_objects_in_s3_export_ut.cpp
@@ -1,0 +1,54 @@
+#include "s3_backup_test_base.h"
+
+#include <fmt/format.h>
+
+using namespace NYdb;
+using namespace fmt::literals;
+
+class TListObjectsInS3ExportTestFixture : public TS3BackupTestFixture {
+    void SetUp(NUnitTest::TTestContext& /* context */) override {
+        auto res = YdbQueryClient().ExecuteQuery(R"sql(
+            CREATE TABLE `/Root/Table0` (
+                key Uint32 NOT NULL,
+                value String,
+                PRIMARY KEY (key)
+            );
+
+            CREATE TABLE `/Root/dir1/Table1` (
+                key Uint32 NOT NULL,
+                value String,
+                PRIMARY KEY (key)
+            );
+
+            CREATE TABLE `/Root/dir1/dir2/Table2` (
+                key Uint32 NOT NULL,
+                value String,
+                PRIMARY KEY (key)
+            );
+        )sql", NQuery::TTxControl::NoTx()).GetValueSync();
+        UNIT_ASSERT_C(res.IsSuccess(), res.GetIssues().ToString());
+
+        // Empty dir
+        auto mkdir = YdbSchemeClient().MakeDirectory("/Root/dir1/dir2/dir3").GetValueSync();
+        UNIT_ASSERT_C(mkdir.IsSuccess(), mkdir.GetIssues().ToString());
+    }
+
+    void TearDown(NUnitTest::TTestContext& /* context */) override {
+    }
+};
+
+Y_UNIT_TEST_SUITE_F(ListObjectsInS3Export, TListObjectsInS3ExportTestFixture) {
+    Y_UNIT_TEST(ExportWithSchemaMapping) {
+        {
+            NExport::TExportToS3Settings exportSettings = MakeExportSettings("", "Prefix");
+            auto res = YdbExportClient().ExportToS3(exportSettings).GetValueSync();
+            WaitOpSuccess(res);
+        }
+
+        ValidateListObjectInS3Export({
+            {"Table0", "Table0"},
+            {"dir1/Table1", "dir1/Table1"},
+            {"dir1/dir2/Table2", "dir1/dir2/Table2"},
+        }, "Prefix");
+    }
+}

--- a/ydb/services/ydb/backup_ut/list_objects_in_s3_export_ut.cpp
+++ b/ydb/services/ydb/backup_ut/list_objects_in_s3_export_ut.cpp
@@ -1,4 +1,5 @@
 #include "s3_backup_test_base.h"
+#include <ydb/core/backup/common/metadata.h>
 
 #include <fmt/format.h>
 
@@ -91,14 +92,14 @@ Y_UNIT_TEST_SUITE_F(ListObjectsInS3Export, TListObjectsInS3ExportTestFixture) {
         listSettings
             .SymmetricKey("Cool random key!");
 
-        ValidateListObjectInS3Export({
-            {"001", "Table0"},
-            {"002", "dir1/Table1"},
-            {"003", "dir1/dir2/Table2"},
+        ValidateListObjectPathsInS3Export({
+            "Table0",
+            "dir1/Table1",
+            "dir1/dir2/Table2",
         }, listSettings);
     }
 
-    Y_UNIT_TEST(ExportWithEncryptionWrongKey) {
+    Y_UNIT_TEST(ExportWithWrongEncryptionKey) {
         {
             NExport::TExportToS3Settings exportSettings = MakeExportSettings("", "Prefix");
             exportSettings
@@ -114,10 +115,105 @@ Y_UNIT_TEST_SUITE_F(ListObjectsInS3Export, TListObjectsInS3ExportTestFixture) {
         listSettings
             .SymmetricKey("Cool and random)");
 
-        ValidateListObjectInS3Export({
-            {"001", "Table0"},
-            {"002", "dir1/Table1"},
-            {"003", "dir1/dir2/Table2"},
-        }, listSettings);
+        auto res = YdbImportClient().ListObjectsInS3Export(listSettings).GetValueSync();
+        UNIT_ASSERT_VALUES_EQUAL_C(res.GetStatus(), EStatus::BAD_REQUEST, "Status: " << res.GetStatus() << ". Issues: " << res.GetIssues().ToString());
+    }
+
+    Y_UNIT_TEST(PagingParameters) {
+        NBackup::TSchemaMapping schemaMapping;
+        constexpr size_t ItemsCount = 12000;
+        constexpr size_t ItemsPerFolder = ItemsCount / 5;
+        constexpr size_t ItemsPerSubfolder = ItemsPerFolder / 3;
+        for (size_t i = 0; i < ItemsCount; ++i) {
+            TStringBuilder objectPath;
+            objectPath << "Folder" << (i % 5) << "/Subfolder" << (i % 3) << "/Object" << i;
+            schemaMapping.Items.emplace_back(NBackup::TSchemaMapping::TItem{
+                .ExportPrefix = TStringBuilder() << "Prefix" << i,
+                .ObjectPath = objectPath,
+            });
+        }
+        S3Mock().GetData()["/test_bucket/Prefix/SchemaMapping/mapping.json"] = schemaMapping.Serialize();
+
+        // Without paging
+        {
+            NYdb::NImport::TListObjectsInS3ExportSettings listSettings = MakeListObjectsInS3ExportSettings("Prefix//");
+            auto res = YdbImportClient().ListObjectsInS3Export(listSettings).GetValueSync();
+            UNIT_ASSERT_C(res.IsSuccess(), "Status: " << res.GetStatus() << ". Issues: " << res.GetIssues().ToString());
+            UNIT_ASSERT_VALUES_EQUAL(res.GetItems().size(), ItemsCount);
+        }
+
+        // From beginning to the end
+        {
+            auto addItemsByFilter = [&](size_t expectedItemsCount, const TString& prefix1 = {}, const TString& prefix2 = {}) {
+                THashSet<TString> items;
+                i64 pageSize = 42;
+                TString nextPageToken;
+                do {
+                    NYdb::NImport::TListObjectsInS3ExportSettings listSettings = MakeListObjectsInS3ExportSettings("Prefix//");
+                    if (prefix1) {
+                        listSettings.AppendItem(NYdb::NImport::TListObjectsInS3ExportSettings::TItem{.Path = prefix1});
+                    }
+                    if (prefix2) {
+                        listSettings.AppendItem(NYdb::NImport::TListObjectsInS3ExportSettings::TItem{.Path = prefix2});
+                    }
+                    auto res = YdbImportClient().ListObjectsInS3Export(listSettings, pageSize, nextPageToken).GetValueSync();
+                    UNIT_ASSERT_C(res.IsSuccess(), "Status: " << res.GetStatus() << ". Issues: " << res.GetIssues().ToString());
+                    UNIT_ASSERT_GT(res.GetItems().size(), 0);
+                    UNIT_ASSERT_LE(res.GetItems().size(), static_cast<size_t>(pageSize));
+                    for (const auto& item : res.GetItems()) {
+                        UNIT_ASSERT_C(items.emplace(item.Path).second, "Duplicate item: {" << item.Prefix << ", " << item.Path << "}. Listing result: " << res);
+                    }
+
+                    ++pageSize; // just for fun
+                    nextPageToken = res.NextPageToken();
+                } while (!nextPageToken.empty());
+                UNIT_ASSERT_VALUES_EQUAL(items.size(), expectedItemsCount);
+            };
+
+            addItemsByFilter(ItemsCount);
+            addItemsByFilter(ItemsPerFolder, "/Folder2");
+            addItemsByFilter(ItemsPerSubfolder, "Folder1/Subfolder1//");
+            addItemsByFilter(ItemsPerSubfolder, "Folder1/Subfolder1//");
+            addItemsByFilter(1, "Folder0/Subfolder2//Object620");
+            addItemsByFilter(ItemsPerSubfolder + 1, "Folder0/Subfolder2//Object620", "Folder1/Subfolder1");
+            addItemsByFilter(1, "Folder0/Subfolder2//Object620", "Folder1/Subfolder"); // treat not as a prefix, but as a directory, so Subfolder don't match anything
+            addItemsByFilter(2, "Folder0/Subfolder2//Object620", "Folder1/Subfolder1/Object931");
+        }
+    }
+
+    Y_UNIT_TEST(ParametersValidation) {
+        {
+            NExport::TExportToS3Settings exportSettings = MakeExportSettings("", "Prefix//");
+            auto res = YdbExportClient().ExportToS3(exportSettings).GetValueSync();
+            WaitOpSuccess(res);
+        }
+
+        {
+            // No prefix
+            NYdb::NImport::TListObjectsInS3ExportSettings listSettings = MakeListObjectsInS3ExportSettings("");
+            auto res = YdbImportClient().ListObjectsInS3Export(listSettings).GetValueSync();
+            UNIT_ASSERT_VALUES_EQUAL_C(res.GetStatus(), EStatus::BAD_REQUEST, "Status: " << res.GetStatus() << ". Issues: " << res.GetIssues().ToString());
+        }
+
+        {
+            // Negative page size
+            NYdb::NImport::TListObjectsInS3ExportSettings listSettings = MakeListObjectsInS3ExportSettings("Prefix");
+            auto res = YdbImportClient().ListObjectsInS3Export(listSettings, -42).GetValueSync();
+            UNIT_ASSERT_VALUES_EQUAL_C(res.GetStatus(), EStatus::BAD_REQUEST, "Status: " << res.GetStatus() << ". Issues: " << res.GetIssues().ToString());
+        }
+
+        {
+            // Big page size
+            NYdb::NImport::TListObjectsInS3ExportSettings listSettings = MakeListObjectsInS3ExportSettings("Prefix");
+            auto res = YdbImportClient().ListObjectsInS3Export(listSettings, 100500).GetValueSync();
+            UNIT_ASSERT_VALUES_EQUAL_C(res.GetStatus(), EStatus::BAD_REQUEST, "Status: " << res.GetStatus() << ". Issues: " << res.GetIssues().ToString());
+        }
+
+        {
+            // Wrong page token
+            NYdb::NImport::TListObjectsInS3ExportSettings listSettings = MakeListObjectsInS3ExportSettings("Prefix");
+            auto res = YdbImportClient().ListObjectsInS3Export(listSettings, 42, "incorrect page token").GetValueSync();
+            UNIT_ASSERT_VALUES_EQUAL_C(res.GetStatus(), EStatus::BAD_REQUEST, "Status: " << res.GetStatus() << ". Issues: " << res.GetIssues().ToString());
+        }
     }
 }

--- a/ydb/services/ydb/backup_ut/list_objects_in_s3_export_ut.cpp
+++ b/ydb/services/ydb/backup_ut/list_objects_in_s3_export_ut.cpp
@@ -40,7 +40,7 @@ class TListObjectsInS3ExportTestFixture : public TS3BackupTestFixture {
 Y_UNIT_TEST_SUITE_F(ListObjectsInS3Export, TListObjectsInS3ExportTestFixture) {
     Y_UNIT_TEST(ExportWithSchemaMapping) {
         {
-            NExport::TExportToS3Settings exportSettings = MakeExportSettings("", "Prefix");
+            NExport::TExportToS3Settings exportSettings = MakeExportSettings("", "Prefix//");
             auto res = YdbExportClient().ExportToS3(exportSettings).GetValueSync();
             WaitOpSuccess(res);
         }

--- a/ydb/services/ydb/backup_ut/list_objects_in_s3_export_ut.cpp
+++ b/ydb/services/ydb/backup_ut/list_objects_in_s3_export_ut.cpp
@@ -51,4 +51,73 @@ Y_UNIT_TEST_SUITE_F(ListObjectsInS3Export, TListObjectsInS3ExportTestFixture) {
             {"dir1/dir2/Table2", "dir1/dir2/Table2"},
         }, "Prefix");
     }
+
+    Y_UNIT_TEST(ExportWithoutSchemaMapping) {
+        {
+            NExport::TExportToS3Settings exportSettings = MakeExportSettings("", "");
+            exportSettings
+                .AppendItem(NExport::TExportToS3Settings::TItem{.Src = "/Root/Table0", .Dst = "/Prefix/t0"})
+                .AppendItem(NExport::TExportToS3Settings::TItem{.Src = "/Root/dir1/Table1", .Dst = "/Prefix/d1/t1"})
+                .AppendItem(NExport::TExportToS3Settings::TItem{.Src = "/Root/dir1/dir2/Table2", .Dst = "/Prefix/d1/d2/t2"});
+            auto res = YdbExportClient().ExportToS3(exportSettings).GetValueSync();
+            WaitOpSuccess(res);
+        }
+
+        ValidateListObjectInS3Export({
+            {"t0", "t0"},
+            {"d1/t1", "d1/t1"},
+            {"d1/d2/t2", "d1/d2/t2"},
+        }, "Prefix");
+
+        ValidateListObjectInS3Export({
+            {"t1", "t1"},
+            {"d2/t2", "d2/t2"},
+        }, "Prefix/d1");
+    }
+
+    Y_UNIT_TEST(ExportWithEncryption) {
+        {
+            NExport::TExportToS3Settings exportSettings = MakeExportSettings("", "Prefix");
+            exportSettings
+                .SymmetricEncryption(NExport::TExportToS3Settings::TEncryptionAlgorithm::AES_128_GCM, "Cool random key!")
+                .AppendItem(NExport::TExportToS3Settings::TItem{.Src = "/Root/Table0"})
+                .AppendItem(NExport::TExportToS3Settings::TItem{.Src = "/dir1/Table1"})
+                .AppendItem(NExport::TExportToS3Settings::TItem{.Src = "dir1/dir2//Table2"});
+            auto res = YdbExportClient().ExportToS3(exportSettings).GetValueSync();
+            WaitOpSuccess(res);
+        }
+
+        NYdb::NImport::TListObjectsInS3ExportSettings listSettings = MakeListObjectsInS3ExportSettings("Prefix//");
+        listSettings
+            .SymmetricKey("Cool random key!");
+
+        ValidateListObjectInS3Export({
+            {"001", "Table0"},
+            {"002", "dir1/Table1"},
+            {"003", "dir1/dir2/Table2"},
+        }, listSettings);
+    }
+
+    Y_UNIT_TEST(ExportWithEncryptionWrongKey) {
+        {
+            NExport::TExportToS3Settings exportSettings = MakeExportSettings("", "Prefix");
+            exportSettings
+                .SymmetricEncryption(NExport::TExportToS3Settings::TEncryptionAlgorithm::AES_128_GCM, "Cool random key!")
+                .AppendItem(NExport::TExportToS3Settings::TItem{.Src = "/Root/Table0"})
+                .AppendItem(NExport::TExportToS3Settings::TItem{.Src = "/dir1/Table1"})
+                .AppendItem(NExport::TExportToS3Settings::TItem{.Src = "dir1/dir2//Table2"});
+            auto res = YdbExportClient().ExportToS3(exportSettings).GetValueSync();
+            WaitOpSuccess(res);
+        }
+
+        NYdb::NImport::TListObjectsInS3ExportSettings listSettings = MakeListObjectsInS3ExportSettings("Prefix//");
+        listSettings
+            .SymmetricKey("Cool and random)");
+
+        ValidateListObjectInS3Export({
+            {"001", "Table0"},
+            {"002", "dir1/Table1"},
+            {"003", "dir1/dir2/Table2"},
+        }, listSettings);
+    }
 }

--- a/ydb/services/ydb/backup_ut/s3_backup_test_base.h
+++ b/ydb/services/ydb/backup_ut/s3_backup_test_base.h
@@ -192,8 +192,7 @@ protected:
         }
     }
 
-    void ValidateListObjectInS3Export(const TSet<std::pair<TString /*prefix*/, TString /*path*/>>& paths, const TString& exportPrefix) {
-        NYdb::NImport::TListObjectsInS3ExportSettings listSettings = MakeListObjectsInS3ExportSettings(exportPrefix);
+    void ValidateListObjectInS3Export(const TSet<std::pair<TString /*prefix*/, TString /*path*/>>& paths, const NYdb::NImport::TListObjectsInS3ExportSettings& listSettings) {
         auto res = YdbImportClient().ListObjectsInS3Export(listSettings).GetValueSync();
         UNIT_ASSERT_C(res.IsSuccess(), "Status: " << res.GetStatus() << ". Issues: " << res.GetIssues().ToString());
 
@@ -204,6 +203,10 @@ protected:
         }
 
         UNIT_ASSERT_VALUES_EQUAL_C(pathsInResponse, paths, "Listing result: " << res);
+    }
+
+    void ValidateListObjectInS3Export(const TSet<std::pair<TString /*prefix*/, TString /*path*/>>& paths, const TString& exportPrefix) {
+        ValidateListObjectInS3Export(paths, MakeListObjectsInS3ExportSettings(exportPrefix));
     }
 
     TString DebugListDir(const TString& path) { // Debug listing for specified dir

--- a/ydb/services/ydb/backup_ut/s3_backup_test_base.h
+++ b/ydb/services/ydb/backup_ut/s3_backup_test_base.h
@@ -155,7 +155,7 @@ protected:
     NYdb::NImport::TListObjectsInS3ExportSettings MakeListObjectsInS3ExportSettings(const TString& prefix) {
         NYdb::NImport::TListObjectsInS3ExportSettings listSettings;
         listSettings
-            .Endpoint(TStringBuilder() << "localhost:" << S3Port)
+            .Endpoint(TStringBuilder() << "localhost:" << S3Port())
             .Bucket("test_bucket")
             .Scheme(NYdb::ES3Scheme::HTTP)
             .AccessKey("test_key")

--- a/ydb/services/ydb/backup_ut/s3_backup_test_base.h
+++ b/ydb/services/ydb/backup_ut/s3_backup_test_base.h
@@ -152,6 +152,20 @@ protected:
         return importSettings;
     }
 
+    NYdb::NImport::TListObjectsInS3ExportSettings MakeListObjectsInS3ExportSettings(const TString& prefix) {
+        NYdb::NImport::TListObjectsInS3ExportSettings listSettings;
+        listSettings
+            .Endpoint(TStringBuilder() << "localhost:" << S3Port)
+            .Bucket("test_bucket")
+            .Scheme(NYdb::ES3Scheme::HTTP)
+            .AccessKey("test_key")
+            .SecretKey("test_secret");
+        if (prefix) {
+            listSettings.Prefix(prefix);
+        }
+        return listSettings;
+    }
+
     void ValidateS3FileList(const TSet<TString>& paths, const TString& prefix = {}) {
         TSet<TString> keys;
         for (const auto& [key, _] : S3Mock().GetData()) {
@@ -176,6 +190,20 @@ protected:
             UNIT_ASSERT_C(!res.IsSuccess(), "Describe path \"" << path << "\" succeeded, but test expects that there is no such path");
             UNIT_ASSERT_C(res.GetStatus() == NYdb::EStatus::SCHEME_ERROR, "Wrong status for describe path \"" << path << "\": " << res.GetStatus());
         }
+    }
+
+    void ValidateListObjectInS3Export(const TSet<std::pair<TString /*prefix*/, TString /*path*/>>& paths, const TString& exportPrefix) {
+        NYdb::NImport::TListObjectsInS3ExportSettings listSettings = MakeListObjectsInS3ExportSettings(exportPrefix);
+        auto res = YdbImportClient().ListObjectsInS3Export(listSettings).GetValueSync();
+        UNIT_ASSERT_C(res.IsSuccess(), "Status: " << res.GetStatus() << ". Issues: " << res.GetIssues().ToString());
+
+        TSet<std::pair<TString, TString>> pathsInResponse;
+        for (const auto& item : res.GetItems()) {
+            bool inserted = pathsInResponse.emplace(item.Prefix, item.Path).second;
+            UNIT_ASSERT_C(inserted, "Duplicate item: {" << item.Prefix << ", " << item.Path << "}. Listing result: " << res);
+        }
+
+        UNIT_ASSERT_VALUES_EQUAL_C(pathsInResponse, paths, "Listing result: " << res);
     }
 
     TString DebugListDir(const TString& path) { // Debug listing for specified dir

--- a/ydb/services/ydb/backup_ut/ya.make
+++ b/ydb/services/ydb/backup_ut/ya.make
@@ -12,6 +12,7 @@ ENDIF()
 SRCS(
     backup_path_ut.cpp
     encrypted_backup_ut.cpp
+    list_objects_in_s3_export_ut.cpp
     ydb_backup_ut.cpp
 )
 

--- a/ydb/services/ydb/ydb_import.cpp
+++ b/ydb/services/ydb/ydb_import.cpp
@@ -24,6 +24,7 @@ void TGRpcYdbImportService::SetupIncomingRequests(NYdbGrpc::TLoggerPtr logger) {
         #NAME, logger, getCounterBlock("import", #NAME))->Run();
 
     ADD_REQUEST(ImportFromS3, ImportFromS3Request, ImportFromS3Response, DoImportFromS3Request);
+    ADD_REQUEST(ListObjectsInS3Export, ListObjectsInS3ExportRequest, ListObjectsInS3ExportResponse, DoListObjectsInS3ExportRequest);
     ADD_REQUEST(ImportData, ImportDataRequest, ImportDataResponse, DoImportDataRequest);
 
 #undef ADD_REQUEST


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

...

### Changelog category <!-- remove all except one -->

* Not for changelog (changelog entry is not required)

### Description for reviewers <!-- (optional) description for those who read this PR -->

There is a new API ImportService.ListObjectsInS3Export added according to RFC: https://github.com/ydb-platform/ydb-rfc/blob/main/backup_encryption.md
API was added in PR: https://github.com/ydb-platform/ydb/pull/18035
API was implemented on client side in C++ SDK in PR: https://github.com/ydb-platform/ydb/pull/18366
This PR implements ListObjectsInS3Export method on server side