### PR TITLE
Fixed operation id ProtoToString

### DIFF
--- a/ydb/public/sdk/cpp/src/library/operation_id/operation_id.cpp
+++ b/ydb/public/sdk/cpp/src/library/operation_id/operation_id.cpp
@@ -39,6 +39,8 @@ std::string ProtoToString(const Ydb::TOperationId& proto) {
     reflection.ListFields(proto, &fields);
     TStringStream res;
     switch (proto.kind()) {
+        case Ydb::TOperationId::UNUSED:
+            break;
         case Ydb::TOperationId::OPERATION_DDL:
         case Ydb::TOperationId::OPERATION_DML:
             res << "ydb://operation";


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

Fixed operation id ProtoToString. Empty operation id allowed in get scriptexec operation response (in case of NOT_FOUND error)

### Changelog category <!-- remove all except one -->

* Bugfix 

### Description for reviewers <!-- (optional) description for those who read this PR -->