### PR TITLE
Don't report PDisk.State for disconnected PDisks in SysView

### DIFF
--- a/ydb/core/mind/bscontroller/disk_metrics.cpp
+++ b/ydb/core/mind/bscontroller/disk_metrics.cpp
@@ -107,6 +107,7 @@ void TBlobStorageController::Handle(TEvBlobStorage::TEvControllerUpdateDiskStatu
                 }
             }
             pdisk->UpdateOperational(true);
+            SysViewChangedPDisks.insert(pdiskId);
         } else if (const auto it = StaticPDisks.find(pdiskId); it != StaticPDisks.end()) {
             it->second.PDiskMetrics = m;
         } else {

--- a/ydb/core/mind/bscontroller/sys_view.cpp
+++ b/ydb/core/mind/bscontroller/sys_view.cpp
@@ -310,7 +310,9 @@ void CopyInfo(NKikimrSysView::TPDiskInfo* info, const THolder<TBlobStorageContro
     }
     info->SetAvailableSize(pDiskInfo->Metrics.GetAvailableSize());
     info->SetTotalSize(pDiskInfo->Metrics.GetTotalSize());
-    info->SetState(NKikimrBlobStorage::TPDiskState::E_Name(pDiskInfo->Metrics.GetState()));
+    if (auto s = pDiskInfo->Metrics.GetState(); pDiskInfo->Operational || s != NKikimrBlobStorage::TPDiskState::Normal) {
+        info->SetState(NKikimrBlobStorage::TPDiskState::E_Name(s));
+    }
     info->SetStatusV2(NKikimrBlobStorage::EDriveStatus_Name(pDiskInfo->Status));
     if (pDiskInfo->StatusTimestamp != TInstant::Zero()) {
         info->SetStatusChangeTimestamp(pDiskInfo->StatusTimestamp.GetValue());


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

Don't report PDisk.State for disconnected PDisks in SysView

### Changelog category <!-- remove all except one -->

* Not for changelog (changelog entry is not required)

### Description for reviewers <!-- (optional) description for those who read this PR -->

BSC would not report PDisk State for disconnected PDisks now.
