### PR TITLE
25-1-1: Don't try checking for merge when operation limit already exceeded

### DIFF
--- a/ydb/core/tx/schemeshard/schemeshard__table_stats.cpp
+++ b/ydb/core/tx/schemeshard/schemeshard__table_stats.cpp
@@ -421,9 +421,11 @@ bool TTxStoreTableStats::PersistSingleStats(const TPathId& pathId,
     const TTableIndexInfo* index = Self->Indexes.Value(pathElement->ParentPathId, nullptr).Get();
     const TTableInfo* mainTableForIndex = Self->GetMainTableForIndex(pathId);
 
+    TString errStr;
     const auto forceShardSplitSettings = Self->SplitSettings.GetForceShardSplitSettings();
     TVector<TShardIdx> shardsToMerge;
     if ((!index || index->State == NKikimrSchemeOp::EIndexStateReady)
+        && Self->CheckInFlightLimit(NKikimrSchemeOp::ESchemeOpSplitMergeTablePartitions, errStr)
         && table->CheckCanMergePartitions(Self->SplitSettings, forceShardSplitSettings, shardIdx, shardsToMerge, mainTableForIndex)
     ) {
         TTxId txId = Self->GetCachedTxId(ctx);


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

Avoid expensive table merge checks when operation inflight limits have already been exceeded. Fixes #18473.

### Changelog category <!-- remove all except one -->

* Bugfix 

### Description for reviewers <!-- (optional) description for those who read this PR -->

It was observed that SchemeShard sometimes starts taking too much cpu when processing shard statistics, which causes it to lag. Since merge needs to check multiple neighbours, when multiple shards hit go below the threshold we could repeatedly try to accumulate many shards, only to fail since other split/merge operations are already inflight. Avoid this expensive code path when the limit has already been exceeded.

Merges #18475.