### PR TITLE
24-4-4-hotfix: ReadTable and ReadRows RPC fixes (#15721, #15850)

### DIFF
--- a/ydb/core/grpc_services/rpc_read_rows.cpp
+++ b/ydb/core/grpc_services/rpc_read_rows.cpp
@@ -607,7 +607,11 @@ public:
         for (const auto& colMeta : RequestedColumnsMeta) {
             const auto type = getTypeFromColMeta(colMeta);
             auto* col = resultSet->Addcolumns();
-            *col->mutable_type() = NYdb::TProtoAccessor::GetProto(type);
+            if (colMeta.IsNotNullColumn || colMeta.Type.GetTypeId() == NScheme::NTypeIds::Pg) { // pg type in nullable itself
+                *col->mutable_type() = NYdb::TProtoAccessor::GetProto(type);
+            } else {
+                *col->mutable_type()->mutable_optional_type()->mutable_item() = NYdb::TProtoAccessor::GetProto(type);
+            }
             *col->mutable_name() = colMeta.Name;
         }
 
@@ -637,18 +641,41 @@ public:
                     }
                     case NScheme::NTypeIds::Decimal: {
                         using namespace NYql::NDecimal;
-    
-                        const auto loHi = cell.AsValue<std::pair<ui64, i64>>();
-                        Ydb::Value valueProto;
-                        valueProto.set_low_128(loHi.first);
-                        valueProto.set_high_128(loHi.second);
-                        const NYdb::TDecimalValue decimal(valueProto, 
-                            {static_cast<ui8>(colMeta.Type.GetDecimalType().GetPrecision()), static_cast<ui8>(colMeta.Type.GetDecimalType().GetScale())});
-                        vb.Decimal(decimal);
+
+                        NYdb::TDecimalType decimalType{
+                            static_cast<ui8>(colMeta.Type.GetDecimalType().GetPrecision()),
+                            static_cast<ui8>(colMeta.Type.GetDecimalType().GetScale())
+                        };
+
+                        if (cell.IsNull()) {
+                            vb.EmptyOptional(NYdb::TTypeBuilder().Decimal(decimalType).Build());
+                        } else {
+                            const auto loHi = cell.AsValue<std::pair<ui64, i64>>();
+                            Ydb::Value valueProto;
+                            valueProto.set_low_128(loHi.first);
+                            valueProto.set_high_128(loHi.second);
+                            if (colMeta.IsNotNullColumn) {
+                                vb.Decimal({valueProto, decimalType});
+                            } else {
+                                vb.BeginOptional();
+                                vb.Decimal({valueProto, decimalType});
+                                vb.EndOptional();
+                            }
+                        }
                         break;
                     }
                     default: {
-                        ProtoValueFromCell(vb, colMeta.Type, cell);
+                        if (cell.IsNull()) {
+                            vb.EmptyOptional((NYdb::EPrimitiveType)colMeta.Type.GetTypeId());
+                        } else {
+                            if (colMeta.IsNotNullColumn) {
+                                ProtoValueFromCell(vb, colMeta.Type, cell);
+                            } else {
+                                vb.BeginOptional();
+                                ProtoValueFromCell(vb, colMeta.Type, cell);
+                                vb.EndOptional();
+                            }
+                        }
                         break;
                     }
                     }
@@ -744,6 +771,7 @@ private:
             , Name(colInfo.Name)
             , Type(colInfo.PType)
             , PTypeMod(colInfo.PTypeMod)
+            , IsNotNullColumn(colInfo.IsNotNullColumn)
         {
         }
 
@@ -751,6 +779,7 @@ private:
         TString Name;
         NScheme::TTypeInfo Type;
         TString PTypeMod;
+        bool IsNotNullColumn;
     };
     TVector<TColumnMeta> RequestedColumnsMeta;
 

--- a/ydb/core/kqp/ut/opt/kqp_kv_ut.cpp
+++ b/ydb/core/kqp/ut/opt/kqp_kv_ut.cpp
@@ -151,11 +151,11 @@ Y_UNIT_TEST_SUITE(KqpKv) {
         auto res = FormatResultSetYson(selectResult.GetResultSet());
         CompareYson(R"(
             [
-                [1858343823u;0u;"abcde"];
-                [1921763476782200957u;1u;"abcde"];
-                [3843526951706058091u;2u;"abcde"];
-                [5765290426629915225u;3u;"abcde"];
-                [7687053901553772359u;4u;"abcde"]
+                [[1858343823u];[0u];["abcde"]];
+                [[1921763476782200957u];[1u];["abcde"]];
+                [[3843526951706058091u];[2u];["abcde"]];
+                [[5765290426629915225u];[3u];["abcde"]];
+                [[7687053901553772359u];[4u];["abcde"]]
             ]
         )", res);
     }
@@ -262,11 +262,11 @@ Y_UNIT_TEST_SUITE(KqpKv) {
             UNIT_ASSERT_C(selectResult.IsSuccess(), selectResult.GetIssues().ToString());
             auto res = FormatResultSetYson(selectResult.GetResultSet());
             CompareYson(R"([
-                [10u;0u;"abcde"];
-                [11u;1u;"abcde"];
-                [12u;2u;"abcde"];
-                [13u;3u;"abcde"];
-                [14u;4u;"abcde"]
+                [[10u];[0u];["abcde"]];
+                [[11u];[1u];["abcde"]];
+                [[12u];[2u];["abcde"]];
+                [[13u];[3u];["abcde"]];
+                [[14u];[4u];["abcde"]]
             ])", res);
         }
         {
@@ -363,7 +363,7 @@ Y_UNIT_TEST_SUITE(KqpKv) {
         UNIT_ASSERT_C(selectResult.IsSuccess(), selectResult.GetIssues().ToString());
 
         auto res = FormatResultSetYson(selectResult.GetResultSet());
-        CompareYson(Sprintf("[[%du;%du]]", valueToReturn_1, valueToReturn_2), res);
+        CompareYson(Sprintf("[[[%du];[%du]]]", valueToReturn_1, valueToReturn_2), res);
     }
 
     TVector<::ReadRowsPgParam> readRowsPgParams
@@ -729,9 +729,9 @@ Y_UNIT_TEST_SUITE(KqpKv) {
             auto res = FormatResultSetYson(selectResult.GetResultSet());
             CompareYson(R"(
                 [
-                    ["0.123456789";"0.123456789";"0.123456789";"0.123456789";0u];
-                    ["1.123456789";"1000.123456789";"10.123456789";"1000000.123456789";1u];
-                    ["2.123456789";"2000.123456789";"20.123456789";"2000000.123456789";2u]        
+                    [["0.123456789"];["0.123456789"];["0.123456789"];["0.123456789"];[0u]];
+                    [["1.123456789"];["1000.123456789"];["10.123456789"];["1000000.123456789"];[1u]];
+                    [["2.123456789"];["2000.123456789"];["20.123456789"];["2000000.123456789"];[2u]]        
                 ]
             )", res);
         }
@@ -749,8 +749,62 @@ Y_UNIT_TEST_SUITE(KqpKv) {
             auto selectResult = db.ReadRows("/Root/TestTable", keys.Build()).GetValueSync();
             UNIT_ASSERT_C(selectResult.IsSuccess(), selectResult.GetIssues().ToString());
             auto res = FormatResultSetYson(selectResult.GetResultSet());
-            CompareYson(R"([["inf";"inf";"inf";"inf";999999999u];])", res);
+            CompareYson(R"([[["inf"];["inf"];["inf"];["inf"];[999999999u]];])", res);
         }        
+    }
+
+    Y_UNIT_TEST(ReadRows_Nulls) {
+        auto settings = TKikimrSettings()
+            .SetWithSampleTables(false);
+        auto kikimr = TKikimrRunner{settings};
+        auto db = kikimr.GetTableClient();
+        auto session = db.CreateSession().GetValueSync().GetSession();
+
+        auto schemeResult = session.ExecuteSchemeQuery(R"(
+            CREATE TABLE TestTable (
+                Key Uint64,
+                Data Uint32,
+                Value Utf8,
+                PRIMARY KEY (Key)
+            );
+        )").GetValueSync();
+        UNIT_ASSERT_C(schemeResult.IsSuccess(), schemeResult.GetIssues().ToString());
+
+        NYdb::TValueBuilder rows;
+        rows.BeginList();
+        for (size_t i = 0; i < 5; ++i) {
+            rows.AddListItem()
+                .BeginStruct()
+                    .AddMember("Key").Uint64(i * 1921763474923857134ull + 1858343823)
+                .EndStruct();
+        }
+        rows.EndList();
+
+        auto upsertResult = db.BulkUpsert("/Root/TestTable", rows.Build()).GetValueSync();
+        UNIT_ASSERT_C(upsertResult.IsSuccess(), upsertResult.GetIssues().ToString());
+
+        NYdb::TValueBuilder keys;
+        keys.BeginList();
+        for (size_t i = 0; i < 5; ++i) {
+            keys.AddListItem()
+                .BeginStruct()
+                    .AddMember("Key").Uint64(i * 1921763474923857134ull + 1858343823)
+                .EndStruct();
+        }
+        keys.EndList();
+        auto selectResult = db.ReadRows("/Root/TestTable", keys.Build()).GetValueSync();
+        Cerr << "IsSuccess(): " << selectResult.IsSuccess() << " GetStatus(): " << selectResult.GetStatus() << Endl;
+        UNIT_ASSERT_C(selectResult.IsSuccess(), selectResult.GetIssues().ToString());
+        auto res = FormatResultSetYson(selectResult.GetResultSet());
+        CompareYson(R"(
+            [
+                [[1858343823u];#;#];
+                [[1921763476782200957u];#;#];
+                [[3843526951706058091u];#;#];
+                [[5765290426629915225u];#;#];
+                [[7687053901553772359u];#;#]
+            ]
+        )", res);
     }
 
 

--- a/ydb/core/tx/datashard/datashard_ut_read_table.cpp
+++ b/ydb/core/tx/datashard/datashard_ut_read_table.cpp
@@ -607,7 +607,41 @@ Y_UNIT_TEST_SUITE(DataShardReadTableSnapshots) {
 
         UNIT_ASSERT(table1state.IsError);
         UNIT_ASSERT_VALUES_EQUAL(table1state.LastResult, "ERROR: ExecError\n");
-    }    
+    }
+
+    Y_UNIT_TEST(ReadTableUUID) {
+        TPortManager pm;
+        TServerSettings serverSettings(pm.GetPort(2134));
+        serverSettings.SetDomainName("Root")
+            .SetUseRealThreads(false);
+
+        Tests::TServer::TPtr server = new TServer(serverSettings);
+        auto &runtime = *server->GetRuntime();
+        auto sender = runtime.AllocateEdgeActor();
+
+        runtime.SetLogPriority(NKikimrServices::TX_DATASHARD, NLog::PRI_TRACE);
+        runtime.SetLogPriority(NKikimrServices::TX_PROXY, NLog::PRI_DEBUG);
+
+        InitRoot(server, sender);
+
+        CreateShardedTable(server, sender, "/Root", "table-1",
+            TShardedTableOptions().Columns({
+                {"key", "Uuid", true, false},
+                {"value", "Uuid", false, false}
+            }));
+        auto shards = GetTableShards(server, sender, "/Root/table-1");
+
+        ExecSQL(server, sender, "UPSERT INTO `/Root/table-1` (key, value) VALUES "
+            "(Uuid('5e32442b-4613-40b7-8506-b14d86b74ef1'), Uuid('65d4d0aa-1612-4887-86dd-834e4cfc3df5')), "
+            "(Uuid('bbf1d45a-af5f-4939-b58a-2be39fd2f06e'), Uuid('710c9ea5-9fa2-4606-a35f-608d0556eb6f')), "
+            "(Uuid('303f21b5-3805-4133-b706-bfc0e071c528'), Uuid('522e048c-9b4b-4d38-8c89-3996cdaa1c8d'));");
+
+        auto table1 = TReadTableState(server, MakeReadTableSettings("/Root/table-1")).All();
+        UNIT_ASSERT_VALUES_EQUAL(table1,
+            "key = 5e32442b-4613-40b7-8506-b14d86b74ef1, value = 65d4d0aa-1612-4887-86dd-834e4cfc3df5\n"
+            "key = bbf1d45a-af5f-4939-b58a-2be39fd2f06e, value = 710c9ea5-9fa2-4606-a35f-608d0556eb6f\n"
+            "key = 303f21b5-3805-4133-b706-bfc0e071c528, value = 522e048c-9b4b-4d38-8c89-3996cdaa1c8d\n");
+    }
 
 } // Y_UNIT_TEST_SUITE(DataShardReadTableSnapshots)
 

--- a/ydb/core/tx/datashard/datashard_ut_read_table.h
+++ b/ydb/core/tx/datashard/datashard_ut_read_table.h
@@ -178,6 +178,9 @@ namespace NDataShardReadTableTest {
             case NYdb::EPrimitiveType::Timestamp:
                 out << parser.GetTimestamp();
                 break;
+            case NYdb::EPrimitiveType::Uuid:
+                out << parser.GetUuid().ToString();
+                break;
 
             default:
                 Y_ABORT("Unhandled");

--- a/ydb/core/tx/datashard/read_table_scan.cpp
+++ b/ydb/core/tx/datashard/read_table_scan.cpp
@@ -117,6 +117,7 @@ Y_FORCE_INLINE bool AddCell(TOutValue& row, NScheme::TTypeInfo type, const TCell
         val.set_bytes_value(cell.Data(), cell.Size());
         break;
     }
+    case NUdf::TDataType<NUdf::TUuid>::Id:
     case NUdf::TDataType<NUdf::TDecimal>::Id: {
         struct TCellData {
             ui64 Low;


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

- Fixed a bug in YDB UUID column handling in ReadTable RPC method #15697
- Fixed a bug in optional columns handling in ReadRows RPC method #15701

### Changelog category <!-- remove all except one -->

* Bugfix 

### Description for reviewers <!-- (optional) description for those who read this PR -->

Already merged in 25-1 (#16799)
- #15721
- #15850 -- this commit changes current ReadRows behavior (more in description in #15701)
