### PR TITLE
Added filling PathDescription for SysView path type in TxProxy

### DIFF
--- a/ydb/core/tx/tx_proxy/commitreq.cpp
+++ b/ydb/core/tx/tx_proxy/commitreq.cpp
@@ -209,7 +209,8 @@ private:
                     break;
             }
 
-            if (entry.KeyDescription->TableId.IsSystemView() ||
+            if ((entry.KeyDescription->TableId.IsSystemView() ||
+                 entry.Kind == NSchemeCache::TSchemeCacheNavigate::KindSysView) ||
                 TSysTables::IsSystemTable(entry.KeyDescription->TableId))
             {
                 const TString explanation = TStringBuilder()

--- a/ydb/core/tx/tx_proxy/datareq.cpp
+++ b/ydb/core/tx/tx_proxy/datareq.cpp
@@ -1498,7 +1498,7 @@ void TDataReq::Handle(TEvTxProxySchemeCache::TEvNavigateKeySetResult::TPtr &ev, 
     auto &res = resp->ResultSet[0];
     ReadTableRequest->TableId = res.TableId;
 
-    if (res.TableId.IsSystemView()) {
+    if (res.TableId.IsSystemView() || res.Kind == NSchemeCache::TSchemeCacheNavigate::KindSysView) {
         IssueManager.RaiseIssue(MakeIssue(NKikimrIssues::TIssuesIds::GENERIC_RESOLVE_ERROR,
             Sprintf("Table '%s' is a system view. Read table is not supported", ReadTableRequest->TablePath.data())));
         ReportStatus(TEvTxUserProxy::TEvProposeTransactionStatus::EStatus::ResolveError, NKikimrIssues::TStatusIds::SCHEME_ERROR, true, ctx);

--- a/ydb/core/tx/tx_proxy/read_table_impl.cpp
+++ b/ydb/core/tx/tx_proxy/read_table_impl.cpp
@@ -593,7 +593,7 @@ private:
         DomainInfo = res.DomainInfo;
         Y_ABORT_UNLESS(DomainInfo, "Missing DomainInfo in TEvNavigateKeySetResult");
 
-        if (TableId.IsSystemView() ||
+        if ((TableId.IsSystemView() || res.Kind == NSchemeCache::TSchemeCacheNavigate::KindSysView) ||
             TSysTables::IsSystemTable(TableId))
         {
             TString error = TStringBuilder()

--- a/ydb/core/tx/tx_proxy/resolvereq.cpp
+++ b/ydb/core/tx/tx_proxy/resolvereq.cpp
@@ -60,7 +60,8 @@ namespace {
         NSchemeCache::TDomainInfo::TPtr domainInfo;
 
         for (const auto& entry : Tables) {
-            if (entry.KeyDescription->TableId.IsSystemView() ||
+            if ((entry.KeyDescription->TableId.IsSystemView() ||
+                 entry.Kind == NSchemeCache::TSchemeCacheNavigate::KindSysView) ||
                 TSysTables::IsSystemTable(entry.KeyDescription->TableId))
             {
                 continue;
@@ -181,7 +182,7 @@ namespace {
                 auto& entry = resp->ResultSet[index];
 
                 table.TableId = entry.TableId;
-                table.IsColumnTable = (entry.Kind == NSchemeCache::TSchemeCacheNavigate::KindColumnTable);
+                table.Kind = entry.Kind;
 
                 TVector<NScheme::TTypeInfo> keyColumnTypes(entry.Columns.size());
                 TVector<TKeyDesc::TColumnOp> columns(entry.Columns.size());

--- a/ydb/core/tx/tx_proxy/resolvereq.h
+++ b/ydb/core/tx/tx_proxy/resolvereq.h
@@ -20,7 +20,7 @@ namespace NTxProxy {
         TSerializedCellVec ToValues;
         THolder<TKeyDesc> KeyDescription;
         NSchemeCache::TDomainInfo::TPtr DomainInfo;
-        bool IsColumnTable = false;
+        NSchemeCache::TSchemeCacheNavigate::EKind Kind;
     };
 
     using TResolveTableResponses = TVector<TResolveTableResponse>;

--- a/ydb/core/tx/tx_proxy/snapshotreq.cpp
+++ b/ydb/core/tx/tx_proxy/snapshotreq.cpp
@@ -287,17 +287,21 @@ public:
                     break;
             }
 
-            if (entry.KeyDescription->TableId.IsSystemView() && IgnoreSystemViews) {
+            if ((entry.KeyDescription->TableId.IsSystemView() ||
+                 entry.Kind == NSchemeCache::TSchemeCacheNavigate::KindSysView) &&
+                IgnoreSystemViews)
+            {
                 continue;
             }
 
-            if (entry.IsColumnTable) {
+            if (entry.Kind == NSchemeCache::TSchemeCacheNavigate::KindColumnTable) {
                 // OLAP tables don't create snapshots explicitly
                 hasColumnTable = true;
                 continue;
             }
 
-            if (entry.KeyDescription->TableId.IsSystemView() ||
+            if ((entry.KeyDescription->TableId.IsSystemView() ||
+                 entry.Kind == NSchemeCache::TSchemeCacheNavigate::KindSysView) ||
                 TSysTables::IsSystemTable(entry.KeyDescription->TableId))
             {
                 const TString explanation = TStringBuilder()
@@ -1311,16 +1315,20 @@ public:
         TxProxyMon->TxPrepareResolveHgram->Collect((WallClockResolved - WallClockResolveStarted).MicroSeconds());
 
         for (const auto& entry : msg->Tables) {
-            if (entry.KeyDescription->TableId.IsSystemView() && IgnoreSystemViews) {
+            if ((entry.KeyDescription->TableId.IsSystemView() ||
+                 entry.Kind == NSchemeCache::TSchemeCacheNavigate::KindSysView) &&
+                IgnoreSystemViews)
+            {
                 continue;
             }
 
-            if (entry.IsColumnTable) {
+            if (entry.Kind == NSchemeCache::TSchemeCacheNavigate::KindColumnTable) {
                 // OLAP tables don't create snapshots explicitly
                 continue;
             }
 
-            if (entry.KeyDescription->TableId.IsSystemView() ||
+            if ((entry.KeyDescription->TableId.IsSystemView() ||
+                 entry.Kind == NSchemeCache::TSchemeCacheNavigate::KindSysView) ||
                 TSysTables::IsSystemTable(entry.KeyDescription->TableId))
             {
                 const TString explanation = TStringBuilder()

--- a/ydb/core/tx/tx_proxy/upload_rows_common_impl.h
+++ b/ydb/core/tx/tx_proxy/upload_rows_common_impl.h
@@ -396,14 +396,14 @@ private:
             if (!cp) {
                 return TConclusionStatus::Fail(Sprintf("Unknown column: %s", name.c_str()));
             }
-            i32 pgTypeMod = -1;            
+            i32 pgTypeMod = -1;
             const ui32 colId = *cp;
             auto& ci = *entry.Columns.FindPtr(colId);
 
             TString columnTypeName = NScheme::TypeName(ci.PType, ci.PTypeMod);
 
             const Ydb::Type& typeInProto = (*reqColumns)[pos].second;
-            
+
             TString parseProtoError;
             NScheme::TTypeInfoMod inTypeInfoMod;
             if (!NScheme::TypeInfoFromProto(typeInProto, inTypeInfoMod, parseProtoError)){
@@ -593,7 +593,7 @@ private:
         TableKind = entry.Kind;
         const bool isColumnTable = (TableKind == NSchemeCache::TSchemeCacheNavigate::KindColumnTable);
 
-        if (entry.TableId.IsSystemView()) {
+        if (entry.TableId.IsSystemView() || entry.Kind == NSchemeCache::TSchemeCacheNavigate::KindSysView) {
             return ReplyWithError(Ydb::StatusIds::SCHEME_ERROR, "is not supported. Table is a system view", ctx);
         }
 


### PR DESCRIPTION
This is another PR from the series to support materialized system view path and store them in SchemeShard.
Virtual sys view paths don't have a record in SchemeShard therefore TxProxe fills their PathDescription based only SchemeCache response.
Materialized sys view paths do have SchemeShard record but that record doesn't contain info about a schema so we need to restore it after SchemeShard response in TxProxy.

Changes:
- TDescribeReq got new field - SystemViewResolver for resolving sys view schemas
- Passed forward requests about materialized sys view paths to SchemeShard
- Filled PathDescription with Table fields for sys views
- Processed SysView path kind in data operations (for further SysViewInfo replacement)
