### PR TITLE
configure scan range in CS merger

### DIFF
--- a/ydb/core/formats/arrow/reader/batch_iterator.h
+++ b/ydb/core/formats/arrow/reader/batch_iterator.h
@@ -50,12 +50,13 @@ public:
     }
 
     template <class TDataContainer>
-    TBatchIterator(std::shared_ptr<TDataContainer> batch, std::shared_ptr<NArrow::TColumnFilter> filter,
-        const std::vector<std::string>& keyColumns, const std::vector<std::string>& dataColumns, const bool reverseSort, const std::vector<std::string>& versionColumnNames)
+    TBatchIterator(std::shared_ptr<TDataContainer> batch, const ui64 position, const ui64 recordsCount, std::shared_ptr<NArrow::TColumnFilter> filter,
+        const std::vector<std::string>& keyColumns, const std::vector<std::string>& dataColumns, const bool reverseSort,
+        const std::vector<std::string>& versionColumnNames)
         : ControlPointFlag(false)
-        , KeyColumns(batch, 0, keyColumns, dataColumns, reverseSort)
-        , VersionColumns(batch, 0, versionColumnNames, {}, false)
-        , RecordsCount(batch->num_rows())
+        , KeyColumns(batch, position, recordsCount, keyColumns, dataColumns, reverseSort)
+        , VersionColumns(batch, position, recordsCount, versionColumnNames, {}, false)
+        , RecordsCount(recordsCount)
         , ReverseSortKff(reverseSort ? -1 : 1)
         , Filter(filter) {
         Y_ABORT_UNLESS(KeyColumns.InitPosition(GetFirstPosition()));

--- a/ydb/core/formats/arrow/reader/merger.h
+++ b/ydb/core/formats/arrow/reader/merger.h
@@ -79,13 +79,23 @@ public:
 
     template <class TDataContainer>
     void AddSource(const std::shared_ptr<TDataContainer>& batch, const std::shared_ptr<NArrow::TColumnFilter>& filter) {
-        if (!batch || !batch->num_rows()) {
+        if (!batch) {
+            return;
+        }
+        return AddSource(batch, 0, batch->num_rows(), filter);
+    }
+
+    template <class TDataContainer>
+    void AddSource(const std::shared_ptr<TDataContainer>& batch, const ui64 position, const ui64 recordsCount,
+        const std::shared_ptr<NArrow::TColumnFilter>& filter) {
+        if (recordsCount == position) {
             return;
         }
 //        Y_DEBUG_ABORT_UNLESS(NArrow::IsSorted(batch, SortSchema));
         const bool isDenyFilter = filter && filter->IsTotalDenyFilter();
         auto filterImpl = (!filter || filter->IsTotalAllowFilter()) ? nullptr : filter;
-        SortHeap.Push(TBatchIterator(batch, filterImpl, SortSchema->field_names(), (!isDenyFilter && DataSchema) ? DataSchema->field_names() : std::vector<std::string>(), Reverse, VersionColumnNames));
+        SortHeap.Push(TBatchIterator(batch, position, recordsCount, filterImpl, SortSchema->field_names(),
+            (!isDenyFilter && DataSchema) ? DataSchema->field_names() : std::vector<std::string>(), Reverse, VersionColumnNames));
     }
 
     bool IsEmpty() const {

--- a/ydb/core/formats/arrow/rows/view.cpp
+++ b/ydb/core/formats/arrow/rows/view.cpp
@@ -40,7 +40,7 @@ std::partial_ordering TSimpleRow::CompareNotNull(const TSimpleRow& item) const {
 }
 
 NMerger::TSortableBatchPosition TSimpleRow::BuildSortablePosition(const bool reverse /*= false*/) const {
-    return NMerger::TSortableBatchPosition(ToBatch(), 0, reverse);
+    return NMerger::TSortableBatchPosition(ToBatch(), 0, 1, reverse);
 }
 
 TSimpleRow TSimpleRowContent::Build(const std::shared_ptr<arrow::Schema>& schema) const {

--- a/ydb/core/formats/arrow/special_keys.cpp
+++ b/ydb/core/formats/arrow/special_keys.cpp
@@ -78,7 +78,7 @@ TMinMaxSpecialKeys::TMinMaxSpecialKeys(std::shared_ptr<arrow::RecordBatch> batch
     Y_ABORT_UNLESS(batch->num_rows());
     Y_ABORT_UNLESS(schema);
 
-    NMerger::TRWSortableBatchPosition record(batch, 0, schema->field_names(), {}, false);
+    NMerger::TRWSortableBatchPosition record(batch, 0, batch->num_rows(), schema->field_names(), {}, false);
     std::optional<NMerger::TCursor> minValue;
     std::optional<NMerger::TCursor> maxValue;
     while (true) {

--- a/ydb/core/formats/arrow/ut/ut_reader.cpp
+++ b/ydb/core/formats/arrow/ut/ut_reader.cpp
@@ -40,7 +40,7 @@ Y_UNIT_TEST_SUITE(SortableBatchPosition) {
             UNIT_ASSERT(batchBuilder->Flush(&search).ok());
         }
 
-        NMerger::TSortableBatchPosition searchPosition(search, 0, false);
+        NMerger::TSortableBatchPosition searchPosition(search, 0, search->num_rows(), false);
         {
             auto findPosition = NMerger::TSortableBatchPosition::FindBound(data, searchPosition, false, std::nullopt);
             UNIT_ASSERT(!!findPosition);

--- a/ydb/core/tx/columnshard/engines/predicate/container.cpp
+++ b/ydb/core/tx/columnshard/engines/predicate/container.cpp
@@ -189,8 +189,8 @@ NArrow::TColumnFilter TPredicateContainer::BuildFilter(const std::shared_ptr<NAr
         return NArrow::TColumnFilter::BuildAllowFilter();
     }
     auto sortingFields = Object->Batch->schema()->field_names();
-    auto position = NArrow::NMerger::TRWSortableBatchPosition(data, 0, sortingFields, {}, false);
-    const auto border = NArrow::NMerger::TSortableBatchPosition(Object->Batch, 0, sortingFields, {}, false);
+    auto position = NArrow::NMerger::TRWSortableBatchPosition(data, 0, data->num_rows(), sortingFields, {}, false);
+    const auto border = NArrow::NMerger::TSortableBatchPosition(Object->Batch, 0, Object->Batch->num_rows(), sortingFields, {}, false);
     const bool needUppedBound = CompareType == NArrow::ECompareType::LESS_OR_EQUAL || CompareType == NArrow::ECompareType::GREATER;
     const auto findBound = position.FindBound(position, 0, data->GetRecordsCount() - 1, border, needUppedBound);
     const ui64 rowsBeforeBound = findBound ? findBound->GetPosition() : data->GetRecordsCount();

--- a/ydb/core/tx/columnshard/engines/reader/common_reader/constructor/read_metadata.cpp
+++ b/ydb/core/tx/columnshard/engines/reader/common_reader/constructor/read_metadata.cpp
@@ -72,7 +72,8 @@ std::set<ui32> TReadMetadata::GetPKColumnIds() const {
 }
 
 NArrow::NMerger::TSortableBatchPosition TReadMetadata::BuildSortedPosition(const NArrow::TSimpleRow& key) const {
-    return NArrow::NMerger::TSortableBatchPosition(key.ToBatch(), 0, GetReplaceKey()->field_names(), {}, IsDescSorted());
+    std::shared_ptr<arrow::RecordBatch> batch = key.ToBatch();
+    return NArrow::NMerger::TSortableBatchPosition(key.ToBatch(), 0, batch->num_rows(), GetReplaceKey()->field_names(), {}, IsDescSorted());
 }
 
 void TReadMetadata::DoOnReadFinished(NColumnShard::TColumnShard& owner) const {

--- a/ydb/core/tx/columnshard/engines/reader/simple_reader/iterator/sync_points/limit.h
+++ b/ydb/core/tx/columnshard/engines/reader/simple_reader/iterator/sync_points/limit.h
@@ -60,7 +60,7 @@ private:
             , Delta(Reverse ? -1 : 1) {
             AFL_VERIFY(Source);
             auto batch = Source->GetStart().GetValue().ToBatch();
-            SortableRecord = std::make_shared<NArrow::NMerger::TRWSortableBatchPosition>(batch, 0, Reverse);
+            SortableRecord = std::make_shared<NArrow::NMerger::TRWSortableBatchPosition>(batch, 0, batch->num_rows(), Reverse);
         }
 
         TSourceIterator(const std::vector<std::shared_ptr<NArrow::NAccessor::IChunkedArray>>& arrs,
@@ -77,7 +77,7 @@ private:
             auto prefixSchema = Source->GetSourceSchema()->GetIndexInfo().GetReplaceKeyPrefix(arrs.size());
             auto copyArrs = arrs;
             auto batch = std::make_shared<NArrow::TGeneralContainer>(prefixSchema->fields(), std::move(copyArrs));
-            SortableRecord = std::make_shared<NArrow::NMerger::TRWSortableBatchPosition>(batch, Start, Reverse);
+            SortableRecord = std::make_shared<NArrow::NMerger::TRWSortableBatchPosition>(batch, Start, batch->num_rows(), Reverse);
             IsValidFlag = ShiftWithFilter();
         }
 

--- a/ydb/core/tx/columnshard/engines/storage/optimizer/lbuckets/planner/optimizer.h
+++ b/ydb/core/tx/columnshard/engines/storage/optimizer/lbuckets/planner/optimizer.h
@@ -774,8 +774,8 @@ public:
         , Counters(counters)
         , Others(Counters, GetCommonFreshnessCheckDuration()) {
         if (MainPortion) {
-            NArrow::NMerger::TSortableBatchPosition sBatchPosition(
-                MainPortion->IndexKeyStart().ToBatch(), 0, pkSchema->field_names(), {}, false);
+            std::shared_ptr<arrow::RecordBatch> batch = MainPortion->IndexKeyStart().ToBatch();
+            NArrow::NMerger::TSortableBatchPosition sBatchPosition(batch, 0, batch->num_rows(), pkSchema->field_names(), {}, false);
             StartPos = std::move(sBatchPosition);
             Counters->PortionsAlone->AddPortion(MainPortion);
         }
@@ -904,16 +904,16 @@ public:
         auto result = std::make_shared<NCompaction::TGeneralCompactColumnEngineChanges>(granule, portions, saverContext);
         if (MainPortion) {
             NArrow::NMerger::TSortableBatchPosition pos(
-                MainPortion->IndexKeyStart().ToBatch(), 0, primaryKeysSchema->field_names(), {}, false);
+                MainPortion->IndexKeyStart().ToBatch(), 0, 1, primaryKeysSchema->field_names(), {}, false);
             result->AddCheckPoint(pos, false);
         }
         if (!nextBorder && MainPortion && !forceMergeForTests) {
             NArrow::NMerger::TSortableBatchPosition pos(
-                MainPortion->IndexKeyEnd().ToBatch(), 0, primaryKeysSchema->field_names(), {}, false);
+                MainPortion->IndexKeyEnd().ToBatch(), 0, 1, primaryKeysSchema->field_names(), {}, false);
             result->AddCheckPoint(pos, true);
         }
         if (stopPoint) {
-            NArrow::NMerger::TSortableBatchPosition pos(stopPoint->ToBatch(), 0, primaryKeysSchema->field_names(), {}, false);
+            NArrow::NMerger::TSortableBatchPosition pos(stopPoint->ToBatch(), 0, 1, primaryKeysSchema->field_names(), {}, false);
             result->AddCheckPoint(pos, false);
         }
         return result;

--- a/ydb/core/tx/columnshard/operations/batch_builder/builder.cpp
+++ b/ydb/core/tx/columnshard/operations/batch_builder/builder.cpp
@@ -66,8 +66,8 @@ void TBuildBatchesTask::DoExecute(const std::shared_ptr<ITask>& /*taskPtr*/) {
                 auto conclusion = Context.GetActualSchema()->BuildDefaultBatch(Context.GetActualSchema()->GetIndexInfo().ArrowSchema(), 1, true);
                 AFL_VERIFY(!conclusion.IsFail())("error", conclusion.GetErrorMessage());
                 auto batchDefault = conclusion.DetachResult();
-                NArrow::NMerger::TSortableBatchPosition pos(
-                    batchDefault, 0, batchDefault->schema()->field_names(), batchDefault->schema()->field_names(), false);
+                NArrow::NMerger::TSortableBatchPosition pos(batchDefault, 0, batchDefault->num_rows(), batchDefault->schema()->field_names(),
+                    batchDefault->schema()->field_names(), false);
                 merger = std::make_shared<TUpdateMerger>(batch, Context.GetActualSchema(),
                     insertionConclusion.IsSuccess() ? "" : insertionConclusion.GetErrorMessage(), pos);
                 break;

--- a/ydb/core/tx/columnshard/operations/batch_builder/merger.cpp
+++ b/ydb/core/tx/columnshard/operations/batch_builder/merger.cpp
@@ -17,7 +17,7 @@ NKikimr::TConclusionStatus IMerger::Finish() {
 
 NKikimr::TConclusionStatus IMerger::AddExistsDataOrdered(const std::shared_ptr<arrow::Table>& data) {
     AFL_VERIFY(data);
-    NArrow::NMerger::TRWSortableBatchPosition existsPosition(data, 0, Schema->GetPKColumnNames(),
+    NArrow::NMerger::TRWSortableBatchPosition existsPosition(data, 0, data->num_rows(), Schema->GetPKColumnNames(),
         Schema->GetIndexInfo().GetColumnSTLNames(false), false);
     bool exsistFinished = !existsPosition.InitPosition(0);
     while (!IncomingFinished && !exsistFinished) {

--- a/ydb/core/tx/columnshard/operations/batch_builder/merger.h
+++ b/ydb/core/tx/columnshard/operations/batch_builder/merger.h
@@ -19,7 +19,7 @@ protected:
     bool IncomingFinished = false;
 public:
     IMerger(const NArrow::TContainerWithIndexes<arrow::RecordBatch>& incoming, const std::shared_ptr<ISnapshotSchema>& actualSchema)
-        : IncomingPosition(incoming.GetContainer(), 0, actualSchema->GetPKColumnNames(), incoming->schema()->field_names(), false)
+        : IncomingPosition(incoming.GetContainer(), 0, incoming.GetContainer()->num_rows(), actualSchema->GetPKColumnNames(), incoming->schema()->field_names(), false)
         , Schema(actualSchema)
         , IncomingData(incoming) {
         IncomingFinished = !IncomingPosition.InitPosition(0);


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

Чтобы в менеджере дубликатов мёрджить отрезки ключей, не сохраняя отрезки в памяти, в TMergePartialStream поддержана настройка отрезка строк в источнике.

### Changelog category <!-- remove all except one -->

* Not for changelog (changelog entry is not required)

### Description for reviewers <!-- (optional) description for those who read this PR -->

...
