### PR TITLE
scheme: fix comparisons for keys of different length

### DIFF
--- a/ydb/core/formats/arrow/ut/ut_arrow.cpp
+++ b/ydb/core/formats/arrow/ut/ut_arrow.cpp
@@ -21,7 +21,7 @@ using TTypeId = NScheme::TTypeId;
 using TTypeInfo = NScheme::TTypeInfo;
 
 struct TDataRow {
-    static const TTypeInfo* MakeTypeInfos() {
+    static auto MakeTypeInfos() {
         static const TTypeInfo types[27] = {
             TTypeInfo(NTypeIds::Bool),
             TTypeInfo(NTypeIds::Int8),
@@ -649,11 +649,10 @@ Y_UNIT_TEST_SUITE(ArrowTest) {
 
         UNIT_ASSERT_VALUES_EQUAL(cellRows.size(), rowWriter.Rows.size());
 
+        const auto types_view = TDataRow::MakeYdbSchema() | std::views::values;
+        const auto types = std::vector<TTypeInfo>(types_view.begin(), types_view.end());
         for (size_t i = 0; i < rows.size(); ++i) {
-            UNIT_ASSERT(0 == CompareTypedCellVectors(
-                            cellRows[i].data(), rowWriter.Rows[i].data(),
-                            TDataRow::MakeTypeInfos(),
-                            cellRows[i].size(), rowWriter.Rows[i].size()));
+            UNIT_ASSERT(0 == CompareKeys(cellRows[i], rowWriter.Rows[i], types));
         }
     }
 

--- a/ydb/core/grpc_services/rpc_import_data.cpp
+++ b/ydb/core/grpc_services/rpc_import_data.cpp
@@ -367,8 +367,7 @@ class TImportDataRPC: public TRpcRequestActor<TImportDataRPC, TEvImportDataReque
             return true;
         }
 
-        const int cmp = CompareTypedCellVectors(prevKey->data(), key.data(),
-            KeyDesc->KeyColumnTypes.data(), prevKey->size(), key.size());
+        const int cmp = CompareKeys(*prevKey, key, KeyDesc->KeyColumnTypes);
         if (cmp <= 0) {
             return true;
         }

--- a/ydb/core/grpc_services/rpc_read_columns.cpp
+++ b/ydb/core/grpc_services/rpc_read_columns.cpp
@@ -402,9 +402,7 @@ private:
             TDbTupleRef rowKey(KeyColumnTypes.data(), row.data(), keyColumnCount);
 
             if (!skippedBeforeMinKey) {
-                int cmp = CompareTypedCellVectors(MinKey.GetCells().data(), rowKey.Cells().data(),
-                                                  KeyColumnTypes.data(),
-                                                  MinKey.GetCells().size(), rowKey.Cells().size());
+                int cmp = CompareKeys(MinKey.GetCells(), rowKey.Cells(), KeyColumnTypes);
 
                 // Skip rows before MinKey just in case (because currently sys view scan ignores key range)
                 if (cmp > 0 || (cmp == 0 && !MinKeyInclusive)) {

--- a/ydb/core/grpc_services/rpc_read_rows.cpp
+++ b/ydb/core/grpc_services/rpc_read_rows.cpp
@@ -312,14 +312,10 @@ public:
                 MaxKey = key;
             } else {
                 // For all next keys
-                if (CompareTypedCellVectors(key.data(), MinKey.data(),
-                                            KeyColumnTypes.data(),
-                                            key.size(), MinKey.size()) < 0)
+                if (CompareKeys(key, MinKey, KeyColumnTypes) < 0)
                 {
                     MinKey = key;
-                } else if (CompareTypedCellVectors(key.data(), MaxKey.data(),
-                                                   KeyColumnTypes.data(),
-                                                   key.size(), MaxKey.size()) > 0)
+                } else if (CompareKeys(key, MaxKey, KeyColumnTypes) > 0)
                 {
                     MaxKey = key;
                 }
@@ -592,7 +588,7 @@ public:
             }
             case NScheme::NTypeIds::Decimal: {
                 return NYdb::TTypeBuilder().Decimal(NYdb::TDecimalType(
-                        typeInfo.GetDecimalType().GetPrecision(), 
+                        typeInfo.GetDecimalType().GetPrecision(),
                         typeInfo.GetDecimalType().GetScale()))
                     .Build();
             }

--- a/ydb/core/scheme/scheme_tablecell.h
+++ b/ydb/core/scheme/scheme_tablecell.h
@@ -370,7 +370,17 @@ inline int CompareTypedCells(const TCell& a, const TCell& b, const NScheme::TTyp
     return 0;
 }
 
-// ATTENTION!!! return value is int!! (NOT just -1,0,1)
+// Low level cell vectors comparison.
+// Consider using higher level CompareKeys or CompareKeysPrefix.
+//
+// This function is suitable for comparing cell vectors representing table keys of equal size.
+// It is unsuitable for comparing table keys to key prefixes to range borders.
+// If actual cell vector lengths are not equal, result of the key comparison can be semantically incorrect.
+//
+// Compares up to `cnt` components of the given vectors, not taking into account remaining tails.
+//
+// NULL as a key component is considered equal to another NULL and less than non-NULL value.
+// NOTE: return value can be a full range int and NOT just [-1,0,1].
 template<class TTypeClass>
 inline int CompareTypedCellVectors(const TCell* a, const TCell* b, const TTypeClass* type, const ui32 cnt) {
     for (ui32 i = 0; i < cnt; ++i) {
@@ -381,22 +391,54 @@ inline int CompareTypedCellVectors(const TCell* a, const TCell* b, const TTypeCl
     return 0;
 }
 
-/// @warning Do not use this func to compare key with a range border. Partial key means it ends with Nulls here.
-// ATTENTION!!! return value is int!! (NOT just -1,0,1)
+// Low level cell vectors comparison.
+// Consider using higher level CompareKeys() or CompareKeysPrefix().
+//
+// This function is suitable for comparing cell vectors representing table keys,
+// key prefixes or partial keys (or range borders) -- vectors of potentially different sizes.
+//
+//  For range borders comparison consider using specialized scheme_borders.h:ComparePrefixBorders().
+//
+// Compares given vectors up to the length of the shorter one, then takes into account remaining tail.
+//
+// Absent tail components of the shorter key are considered +inf, so, greater than any value.
+// NULL as a key component is considered equal to another NULL and less than any non-NULL value.
+// NOTE: return value can be a full range int and NOT just [-1,0,1].
 template<class TTypeClass>
-inline int CompareTypedCellVectors(const TCell* a, const TCell* b, const TTypeClass* type, const ui32 cnt_a, const ui32 cnt_b) {
-    Y_ENSURE(cnt_b <= cnt_a);
-    ui32 i = 0;
-    for (; i < cnt_b; ++i) {
-        int cmpRes = CompareTypedCells(a[i], b[i], type[i]);
-        if (cmpRes != 0)
-            return cmpRes;
+inline int CompareTypedCellVectorsAsKeyPrefixes(const TCell* a, const TCell* b, const TTypeClass* type, const ui32 len_a, const ui32 len_b) {
+    const auto compareSize = std::min(len_a, len_b);
+    int cmp = CompareTypedCellVectors(a, b, type, compareSize);
+    if (cmp == 0 && len_a != len_b) {
+        // smaller key is filled with +inf => always bigger
+        cmp = (len_a < len_b) ? +1 : -1;
     }
-    for (; i < cnt_a; ++i) {
-        if (!a[i].IsNull())
-            return 1;
-    }
-    return 0;
+    return cmp;
+};
+
+template <class Container>
+concept CellVector = std::contiguous_iterator<typename Container::iterator>
+    && std::same_as<std::remove_cv_t<typename Container::value_type>, TCell>;
+
+template <class Container>
+concept TypeInfoVector = std::contiguous_iterator<typename Container::iterator>
+    && std::convertible_to<typename Container::value_type, NScheme::TTypeInfoOrder>;
+
+// Higher level wrapper for cell vectors comparison.
+//
+// Compares cell vectors as keys or key prefixes, vector lengths may differ.
+//
+// NOTE: return value can be a full range int and NOT just [-1,0,1].
+inline int CompareKeys(const CellVector auto& a, const CellVector auto& b, const TypeInfoVector auto& types) {
+    return CompareTypedCellVectorsAsKeyPrefixes(a.data(), b.data(), types.data(), a.size(), b.size());
+}
+
+// Higher level wrapper for cell vectors comparison.
+//
+// Compares prefixes of the cell vectors as keys or key prefixes, vector lengths may differ.
+//
+// NOTE: return value can be a full range int and NOT just [-1,0,1].
+inline int CompareKeysPrefix(const CellVector auto& a, const CellVector auto& b, const TypeInfoVector auto& types, const size_t limit) {
+    return CompareTypedCellVectorsAsKeyPrefixes(a.data(), b.data(), types.data(), std::min(a.size(), limit), std::min(b.size(), limit));
 }
 
 // TODO: use NYql ops when TCell and TUnboxedValuePod had merged

--- a/ydb/core/scheme/scheme_tablecell_ut.cpp
+++ b/ydb/core/scheme/scheme_tablecell_ut.cpp
@@ -2,6 +2,8 @@
 
 #include <library/cpp/testing/unittest/registar.h>
 #include <util/generic/vector.h>
+#include <util/generic/array_ref.h>
+#include <util/generic/deque.h>
 
 #include <yql/essentials/minikql/mkql_type_ops.h>
 
@@ -13,6 +15,7 @@ Y_UNIT_TEST_SUITE(Scheme) {
 
     namespace NTypeIds = NScheme::NTypeIds;
     using TTypeInfo = NScheme::TTypeInfo;
+    using TTypeInfoOrder = NScheme::TTypeInfoOrder;
 
     Y_UNIT_TEST(NullCell) {
         TCell nullCell;
@@ -185,24 +188,16 @@ Y_UNIT_TEST_SUITE(Scheme) {
         UNIT_ASSERT_VALUES_EQUAL(cells[9].AsBuf().data(), bigStrVal);
         UNIT_ASSERT_VALUES_EQUAL(cells[11].AsValue<i32>(), intVal);
 
-        UNIT_ASSERT_VALUES_EQUAL(CompareTypedCellVectors(vec.GetCells().data(), cells.data(),
-                                                         types.data(),
-                                                         vec.GetCells().size(), cells.size()),
-                                 0);
+        UNIT_ASSERT_VALUES_EQUAL(CompareKeys(vec.GetCells(), cells, types), 0);
 
         TSerializedCellVec vecCopy(vec);
 
-        UNIT_ASSERT_VALUES_EQUAL(CompareTypedCellVectors(vecCopy.GetCells().data(), cells.data(),
-                                                         types.data(),
-                                                         vecCopy.GetCells().size(), cells.size()),
-                                 0);
+        UNIT_ASSERT_VALUES_EQUAL(CompareKeys(vecCopy.GetCells(), cells, types), 0);
 
 
         TSerializedCellVec vec2(std::move(vecCopy));
 
-        UNIT_ASSERT_VALUES_EQUAL(CompareTypedCellVectors(vec2.GetCells().data(), cells.data(),
-                                                         types.data(),
-                                                         vec2.GetCells().size(), cells.size()),
+        UNIT_ASSERT_VALUES_EQUAL(CompareKeys(vec2.GetCells(), cells, types),
                                  0);
 
         TSerializedCellVec vec3;
@@ -216,9 +211,7 @@ Y_UNIT_TEST_SUITE(Scheme) {
         UNIT_ASSERT(vec3);
 
 
-        UNIT_ASSERT_VALUES_EQUAL(CompareTypedCellVectors(vec3.GetCells().data(), cells.data(),
-                                                         types.data(),
-                                                         vec3.GetCells().size(), cells.size()),
+        UNIT_ASSERT_VALUES_EQUAL(CompareKeys(vec3.GetCells(), cells, types),
                                  0);
 
         const int ITERATIONS = 1000;//10000000;
@@ -311,7 +304,7 @@ Y_UNIT_TEST_SUITE(Scheme) {
         UNIT_ASSERT_VALUES_EQUAL(matrix.GetCells().size(), cells.size());
         UNIT_ASSERT_VALUES_EQUAL(matrix.GetCells().size(), types.size());
 
-        UNIT_ASSERT_VALUES_EQUAL(CompareTypedCellVectors(matrix.GetCells().data(), cells.data(), types.data(), matrix.GetCells().size(), cells.size()), 0);
+        UNIT_ASSERT_VALUES_EQUAL(CompareKeys(matrix.GetCells(), cells, types), 0);
 
         UNIT_ASSERT_VALUES_EQUAL(hash, GetCellsHash(matrix.GetCells(), types));
     }
@@ -319,7 +312,7 @@ Y_UNIT_TEST_SUITE(Scheme) {
     Y_UNIT_TEST(TSerializedCellMatrix) {
         const ui32 rowCount = 10;
         const ui16 colCount = 6;
-        
+
         TVector<TCell> cells;
         TVector<TTypeInfo> types;
         TVector<TString> smallStrings;
@@ -472,8 +465,8 @@ Y_UNIT_TEST_SUITE(Scheme) {
 
         TArrayRef<const NScheme::TTypeId> yqlIds(NScheme::NTypeIds::YqlIds);
         for (NScheme::TTypeId typeId : yqlIds) {
-            NScheme::TTypeInfo typeInfo = typeId == NScheme::NTypeIds::Decimal ? 
-                NScheme::TTypeInfo(NScheme::TDecimalType::Default()) : 
+            NScheme::TTypeInfo typeInfo = typeId == NScheme::NTypeIds::Decimal ?
+                NScheme::TTypeInfo(NScheme::TDecimalType::Default()) :
                 NScheme::TTypeInfo(typeId);
             switch (typeId) {
             case NScheme::NTypeIds::Int8:
@@ -625,5 +618,44 @@ Y_UNIT_TEST_SUITE(Scheme) {
         appended.resize(1);
 
         UNIT_ASSERT(!TSerializedCellVec::UnsafeAppendCells(cells, appended));
+    }
+
+    Y_UNIT_TEST(CompareKeysSupportsContiguousContainers) {
+        ui64 intVal = 42;
+        const std::initializer_list<TCell> values = {TCell::Make(intVal), TCell::Make(intVal)};
+        const std::initializer_list<TTypeInfo> types = {TTypeInfo(NTypeIds::Uint64), TTypeInfo(NTypeIds::Uint64)};
+
+        // vectors
+        Y_UNUSED(CompareKeys(TVector<TCell>(values), TVector<TCell>(values), TVector<TTypeInfo>(types)));
+        Y_UNUSED(CompareKeys(std::vector<TCell>(values), std::vector<TCell>(values), std::vector<TTypeInfo>(types)));
+
+        // array and array refs
+        {
+            TVector<TCell> cells(values);
+            TVector<TTypeInfo> types_(types);
+            Y_UNUSED(CompareKeys(TArrayRef<TCell>(cells), TArrayRef<TCell>(cells), TArrayRef<TTypeInfo>(types_)));
+            Y_UNUSED(CompareKeys(std::span<TCell>(cells), std::span<TCell>(cells), std::span<TTypeInfo>(types_)));
+        }
+        {
+            const std::initializer_list<const TCell> values = {TCell::Make(intVal), TCell::Make(intVal)};
+            const std::initializer_list<const TTypeInfo> types = {TTypeInfo(NTypeIds::Uint64), TTypeInfo(NTypeIds::Uint64)};
+            Y_UNUSED(CompareKeys(TConstArrayRef<TCell>(values), TConstArrayRef<TCell>(values), TConstArrayRef<TTypeInfo>(types)));
+        }
+        {
+            std::array<TCell, 2> values = {TCell::Make(intVal), TCell::Make(intVal)};
+            std::array<TTypeInfo, 2> types = {TTypeInfo(NTypeIds::Uint64), TTypeInfo(NTypeIds::Uint64)};
+            Y_UNUSED(CompareKeys(values, values, types));
+        }
+
+        // TTypeInfoOrder and TypeInfo compatibility
+        {
+            const auto types = {TTypeInfoOrder(NTypeIds::Uint64), TTypeInfoOrder(NTypeIds::Uint64)};
+            Y_UNUSED(CompareKeys(TVector<TCell>(values), TVector<TCell>(values), TVector<TTypeInfoOrder>(types)));
+        }
+
+        // use of non-contiguous containers should result in compilation errors
+        // Y_UNUSED(CompareKeys(std::deque<TCell>(values), std::deque<TCell>(values), std::deque<TTypeInfo>(types)));
+        // Y_UNUSED(CompareKeys(std::list<TCell>(values), std::list<TCell>(values), std::list<TTypeInfo>(types)));
+
     }
 }

--- a/ydb/core/tablet_flat/flat_iterator_ops.h
+++ b/ydb/core/tablet_flat/flat_iterator_ops.h
@@ -13,16 +13,7 @@ struct TTableIterOps {
             TArrayRef<const TCell> a,
             TArrayRef<const TCell> b)
     {
-        if (int cmp = CompareTypedCellVectors(a.data(), b.data(), types.data(), Min(a.size(), b.size()))) {
-            return cmp;
-        }
-
-        if (a.size() != b.size()) {
-            // smaller key is filled with +inf => always bigger
-            return a.size() < b.size() ? +1 : -1;
-        }
-
-        return 0;
+        return NKikimr::CompareKeys(a, b, types);
     }
 
     static inline void MoveNext(TMemIter& it) {

--- a/ydb/core/tablet_flat/flat_table_part_ut.cpp
+++ b/ydb/core/tablet_flat/flat_table_part_ut.cpp
@@ -240,7 +240,7 @@ Y_UNIT_TEST_SUITE(TLegacy) {
 
     Y_UNIT_TEST(StatsIter) {
         TNullOutput devNull;
-        IOutputStream& dbgOut = devNull; //*/ Cerr;
+        IOutputStream& dbgOut = /**/devNull; //*/ Cerr;
 
         NScheme::TTypeRegistry typeRegistry;
 
@@ -316,6 +316,8 @@ Y_UNIT_TEST_SUITE(TLegacy) {
             stIter.Add(std::move(it2));
         }
 
+        const auto types = lay2.RowScheme()->Keys->Types;
+
         TSerializedCellVec prevKey;
         ui64 prevRowCount = 0;
         ui64 prevDataSize = 0;
@@ -331,7 +333,11 @@ Y_UNIT_TEST_SUITE(TLegacy) {
             dbgOut << DbgPrintTuple(key, typeRegistry)
                    << " " << stats.RowCount << " " << stats.DataSize.Size << Endl;
 
-            UNIT_ASSERT_C(CompareTypedCellVectors(key.Columns, prevKey.GetCells().data(), key.Types, key.ColumnCount, prevKey.GetCells().size()) > 0,
+            // all keys except the first empty prevKey have the same length
+            if (!prevKey) {
+                continue;
+            }
+            UNIT_ASSERT_C(CompareTypedCellVectors(key.Columns, prevKey.GetCells().data(), types.data(), types.size()) > 0,
                           "Keys must be sorted");
 
             UNIT_ASSERT(prevRowCount < stats.RowCount);

--- a/ydb/core/tablet_flat/test/libs/table/wrap_part.h
+++ b/ydb/core/tablet_flat/test/libs/table/wrap_part.h
@@ -25,7 +25,7 @@ namespace NTest {
             , Run(run)
         {
         }
-        
+
         TWrapPartImpl(const TPartEggs &eggs, TIntrusiveConstPtr<TSlices> slices = nullptr, bool defaults = true)
             : Eggs(eggs)
             , Scheme(eggs.Scheme)
@@ -156,11 +156,7 @@ namespace NTest {
             TDbTupleRef key = Iter->GetKey();
 
             if (StopKey) {
-                auto cmp = CompareTypedCellVectors(key.Cells().data(), StopKey.data(), Scheme->Keys->Types.data(), Min(key.Cells().size(), StopKey.size()));
-                if (cmp == 0 && key.Cells().size() != StopKey.size()) {
-                    // smaller key is filled with +inf => always bigger
-                    cmp = key.Cells().size() < StopKey.size() ? +1 : -1;
-                }
+                auto cmp = CompareKeys(key.Cells(), StopKey, Scheme->Keys->Types);
                 if (Direction == EDirection::Forward && cmp > 0 || Direction == EDirection::Reverse && cmp < 0) {
                    return EReady::Gone;
                 }

--- a/ydb/core/tablet_flat/ut/ut_stat.cpp
+++ b/ydb/core/tablet_flat/ut/ut_stat.cpp
@@ -26,7 +26,7 @@ namespace {
                 auto type = part->GetPageType(pageId, groupId);
                 if (type == EPage::DataPage) {
                     auto dataPage = NPage::TDataPage(page);
-                    
+
                     TouchedBytes += page->size();
                     if (groupId.IsMain()) {
                         TouchedRows += dataPage->Count;
@@ -129,52 +129,52 @@ Y_UNIT_TEST_SUITE(BuildStatsFlatIndex) {
 
     Y_UNIT_TEST(Single)
     {
-        auto subset = TMake(Mass0, PageConf(Mass0.Model->Scheme->Families.size(), WriteBTreeIndex)).Mixed(0, 1, TMixerOne{ });   
+        auto subset = TMake(Mass0, PageConf(Mass0.Model->Scheme->Families.size(), WriteBTreeIndex)).Mixed(0, 1, TMixerOne{ });
         CheckMixedIndex(*subset, 24000, 2106439, 25272);
     }
 
     Y_UNIT_TEST(Single_Slices)
     {
-        auto subset = TMake(Mass0, PageConf(Mass0.Model->Scheme->Families.size(), WriteBTreeIndex)).Mixed(0, 1, TMixerOne{ }, 0, 13);   
+        auto subset = TMake(Mass0, PageConf(Mass0.Model->Scheme->Families.size(), WriteBTreeIndex)).Mixed(0, 1, TMixerOne{ }, 0, 13);
         subset->Flatten.begin()->Slices->Describe(Cerr); Cerr << Endl;
         CheckMixedIndex(*subset, 12816, 1121048, 25272);
     }
 
     Y_UNIT_TEST(Single_History)
     {
-        auto subset = TMake(Mass0, PageConf(Mass0.Model->Scheme->Families.size(), WriteBTreeIndex)).Mixed(0, 1, TMixerOne{ }, 0.3);   
+        auto subset = TMake(Mass0, PageConf(Mass0.Model->Scheme->Families.size(), WriteBTreeIndex)).Mixed(0, 1, TMixerOne{ }, 0.3);
         CheckMixedIndex(*subset, 24000, 3547100, 49916);
     }
 
     Y_UNIT_TEST(Single_History_Slices)
     {
-        auto subset = TMake(Mass0, PageConf(Mass0.Model->Scheme->Families.size(), WriteBTreeIndex)).Mixed(0, 1, TMixerOne{ }, 0.3, 13);   
+        auto subset = TMake(Mass0, PageConf(Mass0.Model->Scheme->Families.size(), WriteBTreeIndex)).Mixed(0, 1, TMixerOne{ }, 0.3, 13);
         subset->Flatten.begin()->Slices->Describe(Cerr); Cerr << Endl;
         CheckMixedIndex(*subset, 9582, 1425198, 49916);
     }
 
     Y_UNIT_TEST(Single_Groups)
     {
-        auto subset = TMake(Mass1, PageConf(Mass1.Model->Scheme->Families.size(), WriteBTreeIndex)).Mixed(0, 1, TMixerOne{ });   
+        auto subset = TMake(Mass1, PageConf(Mass1.Model->Scheme->Families.size(), WriteBTreeIndex)).Mixed(0, 1, TMixerOne{ });
         CheckMixedIndex(*subset, 24000, 2460139, 13170);
     }
 
     Y_UNIT_TEST(Single_Groups_Slices)
     {
-        auto subset = TMake(Mass1, PageConf(Mass1.Model->Scheme->Families.size(), WriteBTreeIndex)).Mixed(0, 1, TMixerOne{ }, 0, 13);   
+        auto subset = TMake(Mass1, PageConf(Mass1.Model->Scheme->Families.size(), WriteBTreeIndex)).Mixed(0, 1, TMixerOne{ }, 0, 13);
         subset->Flatten.begin()->Slices->Describe(Cerr); Cerr << Endl;
         CheckMixedIndex(*subset, 10440, 1060798, 13170);
     }
 
     Y_UNIT_TEST(Single_Groups_History)
     {
-        auto subset = TMake(Mass1, PageConf(Mass1.Model->Scheme->Families.size(), WriteBTreeIndex)).Mixed(0, 1, TMixerOne{ }, 0.3);   
+        auto subset = TMake(Mass1, PageConf(Mass1.Model->Scheme->Families.size(), WriteBTreeIndex)).Mixed(0, 1, TMixerOne{ }, 0.3);
         CheckMixedIndex(*subset, 24000, 4054050, 29361);
     }
 
     Y_UNIT_TEST(Single_Groups_History_Slices)
     {
-        auto subset = TMake(Mass1, PageConf(Mass1.Model->Scheme->Families.size(), WriteBTreeIndex)).Mixed(0, 1, TMixerOne{ }, 0.3, 13);   
+        auto subset = TMake(Mass1, PageConf(Mass1.Model->Scheme->Families.size(), WriteBTreeIndex)).Mixed(0, 1, TMixerOne{ }, 0.3, 13);
         subset->Flatten.begin()->Slices->Describe(Cerr); Cerr << Endl;
         CheckMixedIndex(*subset, 13570, 2277890, 29361);
     }
@@ -225,13 +225,13 @@ Y_UNIT_TEST_SUITE(BuildStatsMixedIndex) {
 
     Y_UNIT_TEST(Single)
     {
-        auto subset = TMake(Mass0, PageConf(Mass0.Model->Scheme->Families.size(), WriteBTreeIndex)).Mixed(0, 1, TMixerOne{ });   
+        auto subset = TMake(Mass0, PageConf(Mass0.Model->Scheme->Families.size(), WriteBTreeIndex)).Mixed(0, 1, TMixerOne{ });
         CheckMixedIndex(*subset, 24000, 2106439, 49449);
     }
 
     Y_UNIT_TEST(Single_Slices)
     {
-        auto subset = TMake(Mass0, PageConf(Mass0.Model->Scheme->Families.size(), WriteBTreeIndex)).Mixed(0, 1, TMixerOne{ }, 0, 13);   
+        auto subset = TMake(Mass0, PageConf(Mass0.Model->Scheme->Families.size(), WriteBTreeIndex)).Mixed(0, 1, TMixerOne{ }, 0, 13);
         subset->Flatten.begin()->Slices->Describe(Cerr); Cerr << Endl;
         CheckMixedIndex(*subset, 12816, 1121048, 49449);
     }
@@ -244,33 +244,33 @@ Y_UNIT_TEST_SUITE(BuildStatsMixedIndex) {
 
     Y_UNIT_TEST(Single_History_Slices)
     {
-        auto subset = TMake(Mass0, PageConf(Mass0.Model->Scheme->Families.size(), WriteBTreeIndex)).Mixed(0, 1, TMixerOne{ }, 0.3, 13);   
+        auto subset = TMake(Mass0, PageConf(Mass0.Model->Scheme->Families.size(), WriteBTreeIndex)).Mixed(0, 1, TMixerOne{ }, 0.3, 13);
         subset->Flatten.begin()->Slices->Describe(Cerr); Cerr << Endl;
         CheckMixedIndex(*subset, 9582, 1425198, 81694);
     }
 
     Y_UNIT_TEST(Single_Groups)
     {
-        auto subset = TMake(Mass1, PageConf(Mass1.Model->Scheme->Families.size(), WriteBTreeIndex)).Mixed(0, 1, TMixerOne{ });   
+        auto subset = TMake(Mass1, PageConf(Mass1.Model->Scheme->Families.size(), WriteBTreeIndex)).Mixed(0, 1, TMixerOne{ });
         CheckMixedIndex(*subset, 24000, 2460139, 23760);
     }
 
     Y_UNIT_TEST(Single_Groups_Slices)
     {
-        auto subset = TMake(Mass1, PageConf(Mass1.Model->Scheme->Families.size(), WriteBTreeIndex)).Mixed(0, 1, TMixerOne{ }, 0, 13);   
+        auto subset = TMake(Mass1, PageConf(Mass1.Model->Scheme->Families.size(), WriteBTreeIndex)).Mixed(0, 1, TMixerOne{ }, 0, 13);
         subset->Flatten.begin()->Slices->Describe(Cerr); Cerr << Endl;
         CheckMixedIndex(*subset, 10440, 1060798, 23760);
     }
 
     Y_UNIT_TEST(Single_Groups_History)
     {
-        auto subset = TMake(Mass1, PageConf(Mass1.Model->Scheme->Families.size(), WriteBTreeIndex)).Mixed(0, 1, TMixerOne{ }, 0.3);   
+        auto subset = TMake(Mass1, PageConf(Mass1.Model->Scheme->Families.size(), WriteBTreeIndex)).Mixed(0, 1, TMixerOne{ }, 0.3);
         CheckMixedIndex(*subset, 24000, 4054050, 46562);
     }
 
     Y_UNIT_TEST(Single_Groups_History_Slices)
     {
-        auto subset = TMake(Mass1, PageConf(Mass1.Model->Scheme->Families.size(), WriteBTreeIndex)).Mixed(0, 1, TMixerOne{ }, 0.3, 13);   
+        auto subset = TMake(Mass1, PageConf(Mass1.Model->Scheme->Families.size(), WriteBTreeIndex)).Mixed(0, 1, TMixerOne{ }, 0.3, 13);
         subset->Flatten.begin()->Slices->Describe(Cerr); Cerr << Endl;
         CheckMixedIndex(*subset, 13570, 2277890, 46562);
     }
@@ -316,39 +316,39 @@ Y_UNIT_TEST_SUITE(BuildStatsMixedIndex) {
 
     Y_UNIT_TEST(Single_LowResolution)
     {
-        auto subset = TMake(Mass0, PageConf(Mass0.Model->Scheme->Families.size(), true, WriteBTreeIndex)).Mixed(0, 1, TMixerOne{ });   
+        auto subset = TMake(Mass0, PageConf(Mass0.Model->Scheme->Families.size(), true, WriteBTreeIndex)).Mixed(0, 1, TMixerOne{ });
         CheckMixedIndex(*subset, 24000, 2106439, 66674, 5310, 531050);
     }
 
     Y_UNIT_TEST(Single_Slices_LowResolution)
     {
-        auto subset = TMake(Mass0, PageConf(Mass0.Model->Scheme->Families.size(), true, WriteBTreeIndex)).Mixed(0, 1, TMixerOne{ }, 0, 13);   
+        auto subset = TMake(Mass0, PageConf(Mass0.Model->Scheme->Families.size(), true, WriteBTreeIndex)).Mixed(0, 1, TMixerOne{ }, 0, 13);
         subset->Flatten.begin()->Slices->Describe(Cerr); Cerr << Endl;
         CheckMixedIndex(*subset, 12816, 1121048, 66674, 5310, 531050);
     }
 
     Y_UNIT_TEST(Single_Groups_LowResolution)
     {
-        auto subset = TMake(Mass1, PageConf(Mass1.Model->Scheme->Families.size(), true, WriteBTreeIndex)).Mixed(0, 1, TMixerOne{ });   
+        auto subset = TMake(Mass1, PageConf(Mass1.Model->Scheme->Families.size(), true, WriteBTreeIndex)).Mixed(0, 1, TMixerOne{ });
         CheckMixedIndex(*subset, 24000, 2460139, 33541, 5310, 531050);
     }
 
     Y_UNIT_TEST(Single_Groups_Slices_LowResolution)
     {
-        auto subset = TMake(Mass1, PageConf(Mass1.Model->Scheme->Families.size(), true, WriteBTreeIndex)).Mixed(0, 1, TMixerOne{ }, 0, 13);   
+        auto subset = TMake(Mass1, PageConf(Mass1.Model->Scheme->Families.size(), true, WriteBTreeIndex)).Mixed(0, 1, TMixerOne{ }, 0, 13);
         subset->Flatten.begin()->Slices->Describe(Cerr); Cerr << Endl;
         CheckMixedIndex(*subset, 10440, 1060798, 33541, 5310, 531050);
     }
 
     Y_UNIT_TEST(Single_Groups_History_LowResolution)
     {
-        auto subset = TMake(Mass1, PageConf(Mass1.Model->Scheme->Families.size(), true, WriteBTreeIndex)).Mixed(0, 1, TMixerOne{ }, 0.3);   
+        auto subset = TMake(Mass1, PageConf(Mass1.Model->Scheme->Families.size(), true, WriteBTreeIndex)).Mixed(0, 1, TMixerOne{ }, 0.3);
         CheckMixedIndex(*subset, 24000, 4054050, 64742, 5310, 531050);
     }
 
     Y_UNIT_TEST(Single_Groups_History_Slices_LowResolution)
     {
-        auto subset = TMake(Mass1, PageConf(Mass1.Model->Scheme->Families.size(), true, WriteBTreeIndex)).Mixed(0, 1, TMixerOne{ }, 0.3, 13);   
+        auto subset = TMake(Mass1, PageConf(Mass1.Model->Scheme->Families.size(), true, WriteBTreeIndex)).Mixed(0, 1, TMixerOne{ }, 0.3, 13);
         subset->Flatten.begin()->Slices->Describe(Cerr); Cerr << Endl;
         CheckMixedIndex(*subset, 13570, 2234982 /* ~2277890 */, 64742, 5310, 531050);
     }
@@ -360,13 +360,13 @@ Y_UNIT_TEST_SUITE(BuildStatsBTreeIndex) {
 
     Y_UNIT_TEST(Single)
     {
-        auto subset = TMake(Mass0, PageConf(Mass0.Model->Scheme->Families.size(), WriteBTreeIndex)).Mixed(0, 1, TMixerOne{ });   
+        auto subset = TMake(Mass0, PageConf(Mass0.Model->Scheme->Families.size(), WriteBTreeIndex)).Mixed(0, 1, TMixerOne{ });
         CheckBTreeIndex(*subset, 24000, 2106439, 49449);
     }
 
     Y_UNIT_TEST(Single_Slices)
     {
-        auto subset = TMake(Mass0, PageConf(Mass0.Model->Scheme->Families.size(), WriteBTreeIndex)).Mixed(0, 1, TMixerOne{ }, 0, 13);   
+        auto subset = TMake(Mass0, PageConf(Mass0.Model->Scheme->Families.size(), WriteBTreeIndex)).Mixed(0, 1, TMixerOne{ }, 0, 13);
         subset->Flatten.begin()->Slices->Describe(Cerr); Cerr << Endl;
         CheckBTreeIndex(*subset, 12816, 1121048, 49449);
     }
@@ -379,33 +379,33 @@ Y_UNIT_TEST_SUITE(BuildStatsBTreeIndex) {
 
     Y_UNIT_TEST(Single_History_Slices)
     {
-        auto subset = TMake(Mass0, PageConf(Mass0.Model->Scheme->Families.size(), WriteBTreeIndex)).Mixed(0, 1, TMixerOne{ }, 0.3, 13);   
+        auto subset = TMake(Mass0, PageConf(Mass0.Model->Scheme->Families.size(), WriteBTreeIndex)).Mixed(0, 1, TMixerOne{ }, 0.3, 13);
         subset->Flatten.begin()->Slices->Describe(Cerr); Cerr << Endl;
         CheckBTreeIndex(*subset, 9582, 1425282, 81694);
     }
 
     Y_UNIT_TEST(Single_Groups)
     {
-        auto subset = TMake(Mass1, PageConf(Mass1.Model->Scheme->Families.size(), WriteBTreeIndex)).Mixed(0, 1, TMixerOne{ });   
+        auto subset = TMake(Mass1, PageConf(Mass1.Model->Scheme->Families.size(), WriteBTreeIndex)).Mixed(0, 1, TMixerOne{ });
         CheckBTreeIndex(*subset, 24000, 2460139, 23760);
     }
 
     Y_UNIT_TEST(Single_Groups_Slices)
     {
-        auto subset = TMake(Mass1, PageConf(Mass1.Model->Scheme->Families.size(), WriteBTreeIndex)).Mixed(0, 1, TMixerOne{ }, 0, 13);   
+        auto subset = TMake(Mass1, PageConf(Mass1.Model->Scheme->Families.size(), WriteBTreeIndex)).Mixed(0, 1, TMixerOne{ }, 0, 13);
         subset->Flatten.begin()->Slices->Describe(Cerr); Cerr << Endl;
         CheckBTreeIndex(*subset, 10440, 1060767, 23760);
     }
 
     Y_UNIT_TEST(Single_Groups_History)
     {
-        auto subset = TMake(Mass1, PageConf(Mass1.Model->Scheme->Families.size(), WriteBTreeIndex)).Mixed(0, 1, TMixerOne{ }, 0.3);   
+        auto subset = TMake(Mass1, PageConf(Mass1.Model->Scheme->Families.size(), WriteBTreeIndex)).Mixed(0, 1, TMixerOne{ }, 0.3);
         CheckBTreeIndex(*subset, 24000, 4054050, 46562);
     }
 
     Y_UNIT_TEST(Single_Groups_History_Slices)
     {
-        auto subset = TMake(Mass1, PageConf(Mass1.Model->Scheme->Families.size(), WriteBTreeIndex)).Mixed(0, 1, TMixerOne{ }, 0.3, 13);   
+        auto subset = TMake(Mass1, PageConf(Mass1.Model->Scheme->Families.size(), WriteBTreeIndex)).Mixed(0, 1, TMixerOne{ }, 0.3, 13);
         subset->Flatten.begin()->Slices->Describe(Cerr); Cerr << Endl;
         CheckBTreeIndex(*subset, 13570, 2273213, 46562);
     }
@@ -461,7 +461,7 @@ Y_UNIT_TEST_SUITE(BuildStatsHistogram) {
         for (auto &part : subset.Flatten) {
             TTestEnv env;
             auto index = CreateIndexIter(part.Part.Get(), &env, {});
-            Cerr << "  " << part->Label << " " << index->GetEndRowId() << " rows, " 
+            Cerr << "  " << part->Label << " " << index->GetEndRowId() << " rows, "
                 << IndexTools::CountMainPages(*part.Part) << " pages, "
                 << (part->IndexPages.HasBTree() ? part->IndexPages.GetBTree({}).LevelCount : -1) << " levels: ";
             for (ui32 sample : xrange(1u, samples + 1)) {
@@ -498,7 +498,7 @@ Y_UNIT_TEST_SUITE(BuildStatsHistogram) {
         NTest::TChecker<NTest::TWrapIter, TSubset> wrap(subset, { new TTouchEnv });
         auto env = wrap.GetEnv<TTouchEnv>();
         env->Faulty = false;
-        
+
         bytes = 0;
         rows = 0;
         wrap.Seek({}, ESeek::Lower);
@@ -509,7 +509,7 @@ Y_UNIT_TEST_SUITE(BuildStatsHistogram) {
             wrap.Next();
 
             if (wrap.GetReady() == EReady::Data && key.GetCells()) {
-                auto cmp = CompareTypedCellVectors(key.GetCells().data(), wrap->GetKey().Cells().data(), subset.Scheme->Keys->Types.data(), Min(key.GetCells().size(), wrap->GetKey().Cells().size()));
+                auto cmp = CompareKeys(key.GetCells(), wrap->GetKey().Cells(), subset.Scheme->Keys->Types);
                 if (cmp < 0) {
                     break;
                 }
@@ -649,7 +649,7 @@ Y_UNIT_TEST_SUITE(BuildStatsHistogram) {
     Y_UNIT_TEST(Single)
     {
         for (auto mode : {BTreeIndex, FlatIndex, MixedIndex}) {
-            auto subset = TMake(Mass2, PageConf(Mass2.Model->Scheme->Families.size(), mode)).Mixed(0, 1, TMixerOne{ });   
+            auto subset = TMake(Mass2, PageConf(Mass2.Model->Scheme->Families.size(), mode)).Mixed(0, 1, TMixerOne{ });
             Check(*subset, mode);
         }
     }
@@ -657,7 +657,7 @@ Y_UNIT_TEST_SUITE(BuildStatsHistogram) {
     Y_UNIT_TEST(Single_Slices)
     {
         for (auto mode : {BTreeIndex, FlatIndex, MixedIndex}) {
-            auto subset = TMake(Mass2, PageConf(Mass2.Model->Scheme->Families.size(), mode)).Mixed(0, 1, TMixerOne{ }, 0, 13);   
+            auto subset = TMake(Mass2, PageConf(Mass2.Model->Scheme->Families.size(), mode)).Mixed(0, 1, TMixerOne{ }, 0, 13);
             subset->Flatten.begin()->Slices->Describe(Cerr); Cerr << Endl;
             Check(*subset, mode);
         }
@@ -674,7 +674,7 @@ Y_UNIT_TEST_SUITE(BuildStatsHistogram) {
     Y_UNIT_TEST(Single_History_Slices)
     {
         for (auto mode : {BTreeIndex, FlatIndex, MixedIndex}) {
-            auto subset = TMake(Mass2, PageConf(Mass2.Model->Scheme->Families.size(), mode)).Mixed(0, 1, TMixerOne{ }, 0.3, 13);   
+            auto subset = TMake(Mass2, PageConf(Mass2.Model->Scheme->Families.size(), mode)).Mixed(0, 1, TMixerOne{ }, 0.3, 13);
             subset->Flatten.begin()->Slices->Describe(Cerr); Cerr << Endl;
             Check(*subset, mode);
         }
@@ -739,8 +739,8 @@ Y_UNIT_TEST_SUITE(BuildStatsHistogram) {
     Y_UNIT_TEST(Ten_Mixed_Log)
     {
         struct TMixer {
-            TMixer(ui32 buckets) 
-                : Buckets(buckets) 
+            TMixer(ui32 buckets)
+                : Buckets(buckets)
             {
             }
 
@@ -841,8 +841,8 @@ Y_UNIT_TEST_SUITE(BuildStatsHistogram) {
     Y_UNIT_TEST(Five_Five_Mixed)
     {
         struct TMixer {
-            TMixer(ui32 buckets) 
-                : Buckets(buckets) 
+            TMixer(ui32 buckets)
+                : Buckets(buckets)
             {
             }
 
@@ -952,7 +952,7 @@ Y_UNIT_TEST_SUITE(BuildStatsHistogram) {
     Y_UNIT_TEST(Single_Small_2_Levels)
     {
         for (auto mode : {BTreeIndex, FlatIndex, MixedIndex}) {
-            auto subset = TMake(Mass3, PageConf(Mass3.Model->Scheme->Families.size(), mode)).Mixed(0, 1, TMixerOne{ });   
+            auto subset = TMake(Mass3, PageConf(Mass3.Model->Scheme->Families.size(), mode)).Mixed(0, 1, TMixerOne{ });
             Check(*subset, mode, 1000);
         }
     }
@@ -960,7 +960,7 @@ Y_UNIT_TEST_SUITE(BuildStatsHistogram) {
     Y_UNIT_TEST(Single_Small_2_Levels_3_Buckets)
     {
         for (auto mode : {BTreeIndex, FlatIndex, MixedIndex}) {
-            auto subset = TMake(Mass3, PageConf(Mass3.Model->Scheme->Families.size(), mode)).Mixed(0, 1, TMixerOne{ });   
+            auto subset = TMake(Mass3, PageConf(Mass3.Model->Scheme->Families.size(), mode)).Mixed(0, 1, TMixerOne{ });
             Check(*subset, mode, 5, false);
         }
     }
@@ -972,7 +972,7 @@ Y_UNIT_TEST_SUITE(BuildStatsHistogram) {
             for (auto& group : conf.Groups) {
                 group.BTreeIndexNodeKeysMin = group.BTreeIndexNodeKeysMax = Max<ui32>();
             }
-            auto subset = TMake(Mass3, conf).Mixed(0, 1, TMixerOne{ });   
+            auto subset = TMake(Mass3, conf).Mixed(0, 1, TMixerOne{ });
             Check(*subset, mode, 1000);
         }
     }
@@ -984,7 +984,7 @@ Y_UNIT_TEST_SUITE(BuildStatsHistogram) {
             for (auto& group : conf.Groups) {
                 group.PageSize = group.PageRows = Max<ui32>();
             }
-            auto subset = TMake(Mass3, conf).Mixed(0, 1, TMixerOne{ });   
+            auto subset = TMake(Mass3, conf).Mixed(0, 1, TMixerOne{ });
             Check(*subset, mode, 1000, false);
         }
     }
@@ -992,7 +992,7 @@ Y_UNIT_TEST_SUITE(BuildStatsHistogram) {
     Y_UNIT_TEST(Three_Mixed_Small_2_Levels)
     {
         for (auto mode : {BTreeIndex, FlatIndex, MixedIndex}) {
-            auto subset = TMake(Mass3, PageConf(Mass3.Model->Scheme->Families.size(), mode)).Mixed(0, 3, TMixerRnd(3));   
+            auto subset = TMake(Mass3, PageConf(Mass3.Model->Scheme->Families.size(), mode)).Mixed(0, 3, TMixerRnd(3));
             Check(*subset, mode, 1000, false);
         }
     }
@@ -1000,7 +1000,7 @@ Y_UNIT_TEST_SUITE(BuildStatsHistogram) {
     Y_UNIT_TEST(Three_Mixed_Small_2_Levels_3_Buckets)
     {
         for (auto mode : {BTreeIndex, FlatIndex, MixedIndex}) {
-            auto subset = TMake(Mass3, PageConf(Mass3.Model->Scheme->Families.size(), mode)).Mixed(0, 3, TMixerRnd(3));   
+            auto subset = TMake(Mass3, PageConf(Mass3.Model->Scheme->Families.size(), mode)).Mixed(0, 3, TMixerRnd(3));
             Check(*subset, mode, 5, false);
         }
     }
@@ -1032,7 +1032,7 @@ Y_UNIT_TEST_SUITE(BuildStatsHistogram) {
     Y_UNIT_TEST(Three_Serial_Small_2_Levels)
     {
         for (auto mode : {BTreeIndex, FlatIndex, MixedIndex}) {
-            auto subset = TMake(Mass3, PageConf(Mass3.Model->Scheme->Families.size(), mode)).Mixed(0, 3, TMixerSeq(3, Mass3.Saved.Size()));   
+            auto subset = TMake(Mass3, PageConf(Mass3.Model->Scheme->Families.size(), mode)).Mixed(0, 3, TMixerSeq(3, Mass3.Saved.Size()));
             Check(*subset, mode, 1000, false);
         }
     }
@@ -1040,7 +1040,7 @@ Y_UNIT_TEST_SUITE(BuildStatsHistogram) {
     Y_UNIT_TEST(Three_Serial_Small_2_Levels_3_Buckets)
     {
         for (auto mode : {BTreeIndex, FlatIndex, MixedIndex}) {
-            auto subset = TMake(Mass3, PageConf(Mass3.Model->Scheme->Families.size(), mode)).Mixed(0, 3, TMixerSeq(3, Mass3.Saved.Size()));   
+            auto subset = TMake(Mass3, PageConf(Mass3.Model->Scheme->Families.size(), mode)).Mixed(0, 3, TMixerSeq(3, Mass3.Saved.Size()));
             Check(*subset, mode, 5, false);
         }
     }
@@ -1104,7 +1104,7 @@ Y_UNIT_TEST_SUITE(BuildStatsHistogram) {
             conf.WriteBTreeIndex = (mode == FlatIndex ? false : true);
 
             TAutoPtr<TSubset> subset = TMake(*mass, conf).Mixed(0, partsCount, TMixerRnd(partsCount), history ? 0.7 : 0);
-            
+
             Check(*subset, mode, 10, false);
         }
     }
@@ -1124,7 +1124,7 @@ Y_UNIT_TEST_SUITE(BuildStatsHistogram) {
             conf.WriteBTreeIndex = (mode == FlatIndex ? false : true);
 
             TAutoPtr<TSubset> subset = TMake(*mass, conf).Mixed(0, partsCount, TMixerRnd(partsCount));
-            
+
             Check(*subset, mode, 10, false, false);
         }
     }
@@ -1144,7 +1144,7 @@ Y_UNIT_TEST_SUITE(BuildStatsHistogram) {
             conf.WriteBTreeIndex = (mode == FlatIndex ? false : true);
 
             TAutoPtr<TSubset> subset = TMake(*mass, conf).Mixed(0, partsCount, TMixerSeq(partsCount, mass->Saved.Size()));
-            
+
             Check(*subset, mode, 10, false, false);
         }
     }

--- a/ydb/core/tx/schemeshard/schemeshard__table_stats_histogram.cpp
+++ b/ydb/core/tx/schemeshard/schemeshard__table_stats_histogram.cpp
@@ -140,20 +140,10 @@ TSerializedCellVec DoFindSplitKey(const TVector<std::pair<TSerializedCellVec, ui
     auto loIt = std::upper_bound(keysHist.begin(), keysHist.end(), total*0.1, fnValueLess);
     auto hiIt = std::upper_bound(keysHist.begin(), keysHist.end(), total*0.9, fnValueLess);
 
-    // compare histogram entries by key prefixes
+
+    // compare given length prefixes of histogram entries
     auto comparePrefix = [&keyColumnTypes] (const auto& entry1, const auto& entry2, const size_t prefixSize) {
-        const auto& key1cells = entry1.first.GetCells();
-        const auto clampedSize1 = std::min(key1cells.size(), prefixSize);
-
-        const auto& key2cells = entry2.first.GetCells();
-        const auto clampedSize2 = std::min(key2cells.size(), prefixSize);
-
-        int cmp = CompareTypedCellVectors(key1cells.data(), key2cells.data(), keyColumnTypes.data(), std::min(clampedSize1, clampedSize2));
-        if (cmp == 0 && clampedSize1 != clampedSize2) {
-            // smaller key prefix is filled with +inf => always bigger
-            cmp = (clampedSize1 < clampedSize2) ? +1 : -1;
-        }
-        return cmp;
+        return CompareKeysPrefix(entry1.first.GetCells(), entry2.first.GetCells(), keyColumnTypes, prefixSize);
     };
 
     // Check if half key is no equal to low and high keys
@@ -182,20 +172,10 @@ TSerializedCellVec ChooseSplitKeyByKeySample(const NKikimrTableStats::THistogram
         keysHist.emplace_back(std::make_pair(TSerializedCellVec(bucket.GetKey()), bucket.GetValue()));
     }
 
-    // compare histogram entries by keys
-    auto fnCmp = [&keyColumnTypes] (const auto& entry1, const auto& entry2) {
-        const auto& key1cells = entry1.first.GetCells();
-        const auto& key2cells = entry2.first.GetCells();
-        const auto minKeySize = std::min(key1cells.size(), key2cells.size());
-        int cmp = CompareTypedCellVectors(key1cells.data(), key2cells.data(), keyColumnTypes.data(), minKeySize);
-        if (cmp == 0 && key1cells.size() != key2cells.size()) {
-            // smaller key is filled with +inf => always bigger
-            cmp = (key1cells.size() < key2cells.size()) ? +1 : -1;
-        }
-        return cmp;
-    };
 
-    Sort(keysHist, [&fnCmp] (const auto& key1, const auto& key2) { return fnCmp(key1, key2) < 0; });
+    Sort(keysHist, [&keyColumnTypes] (const auto& entry1, const auto& entry2) {
+        return CompareKeys(entry1.first.GetCells(), entry2.first.GetCells(), keyColumnTypes) < 0;
+    });
 
     // The keys are now sorted. Next we convert the stats into a histogram by accumulating
     // stats for all previous keys at each key.
@@ -204,7 +184,7 @@ TSerializedCellVec ChooseSplitKeyByKeySample(const NKikimrTableStats::THistogram
         // Accumulate stats
         keysHist[i].second += keysHist[i-1].second;
 
-        if (fnCmp(keysHist[i], keysHist[last]) == 0) {
+        if (CompareKeys(keysHist[i].first.GetCells(), keysHist[last].first.GetCells(), keyColumnTypes) == 0) {
             // Merge equal keys
             keysHist[last].second = keysHist[i].second;
         } else {
@@ -441,10 +421,7 @@ bool TTxPartitionHistogram::Execute(TTransactionContext& txc, const TActorContex
 
         // Split key must not be less than the first key
         TSerializedCellVec lowestKey(histogram.GetBuckets(0).GetKey());
-        if (0 < CompareTypedCellVectors(lowestKey.GetCells().data(), splitKey.GetCells().data(),
-                                    keyColumnTypes.data(),
-                                    lowestKey.GetCells().size(), splitKey.GetCells().size()))
-        {
+        if (0 < CompareKeys(lowestKey.GetCells(), splitKey.GetCells(), keyColumnTypes)) {
             LOG_WARN_S(ctx, NKikimrServices::FLAT_TX_SCHEMESHARD,
                 "TTxPartitionHistogram Failed to find proper split key (less than first) for"
                 << " " << ToString(splitReason) << " " << splitReasonMsg

--- a/ydb/core/tx/tx_proxy/upload_rows_common_impl.h
+++ b/ydb/core/tx/tx_proxy/upload_rows_common_impl.h
@@ -396,14 +396,14 @@ private:
             if (!cp) {
                 return TConclusionStatus::Fail(Sprintf("Unknown column: %s", name.c_str()));
             }
-            i32 pgTypeMod = -1;            
+            i32 pgTypeMod = -1;
             const ui32 colId = *cp;
             auto& ci = *entry.Columns.FindPtr(colId);
 
             TString columnTypeName = NScheme::TypeName(ci.PType, ci.PTypeMod);
 
             const Ydb::Type& typeInProto = (*reqColumns)[pos].second;
-            
+
             TString parseProtoError;
             NScheme::TTypeInfoMod inTypeInfoMod;
             if (!NScheme::TypeInfoFromProto(typeInProto, inTypeInfoMod, parseProtoError)){
@@ -891,15 +891,9 @@ private:
                 MaxKey = serializedKey;
             } else {
                 // For all next keys
-                if (CompareTypedCellVectors(serializedKey.GetCells().data(), MinKey.GetCells().data(),
-                                            KeyColumnTypes.data(),
-                                            serializedKey.GetCells().size(), MinKey.GetCells().size()) < 0)
-                {
+                if (CompareKeys(serializedKey.GetCells(), MinKey.GetCells(), KeyColumnTypes) < 0) {
                     MinKey = serializedKey;
-                } else if (CompareTypedCellVectors(serializedKey.GetCells().data(), MaxKey.GetCells().data(),
-                                                   KeyColumnTypes.data(),
-                                                   serializedKey.GetCells().size(), MaxKey.GetCells().size()) > 0)
-                {
+                } else if (CompareKeys(serializedKey.GetCells(), MaxKey.GetCells(), KeyColumnTypes) > 0) {
                     MaxKey = serializedKey;
                 }
             }

--- a/ydb/library/yql/providers/ydb/actors/yql_ydb_read_actor.cpp
+++ b/ydb/library/yql/providers/ydb/actors/yql_ydb_read_actor.cpp
@@ -64,7 +64,7 @@ bool RangeFinished(const TString& lastReadKey, const TString& endKey, const TVec
         return false;
 
     const NKikimr::TSerializedCellVec last(lastReadKey), end(endKey);
-    return NKikimr::CompareTypedCellVectors(last.GetCells().data(), end.GetCells().data(), keyColumnTypes.data(), last.GetCells().size(), end.GetCells().size()) >= 0;
+    return NKikimr::CompareKeys(last.GetCells(), end.GetCells(), keyColumnTypes) >= 0;
 }
 
 } // namespace
@@ -113,7 +113,7 @@ private:
     void SaveState(const NDqProto::TCheckpoint&, TSourceState&) final {}
     void LoadState(const TSourceState&) final {}
     void CommitState(const NDqProto::TCheckpoint&) final {}
-    
+
     ui64 GetInputIndex() const final {
         return InputIndex;
     }

--- a/ydb/library/yql/providers/ydb/comp_nodes/yql_kik_scan.cpp
+++ b/ydb/library/yql/providers/ydb/comp_nodes/yql_kik_scan.cpp
@@ -41,7 +41,7 @@ bool RangeFinished(const TString& lastReadKey, const TString& endKey, const TVec
         return false;
 
     const NKikimr::TSerializedCellVec last(lastReadKey), end(endKey);
-    return NKikimr::CompareTypedCellVectors(last.GetCells().data(), end.GetCells().data(), keyColumnTypes.data(), last.GetCells().size(), end.GetCells().size()) >= 0;
+    return NKikimr::CompareKeys(last.GetCells(), end.GetCells(), keyColumnTypes) >= 0;
 }
 
 template<bool Async>

--- a/ydb/public/lib/experimental/ydb_clickhouse_internal.cpp
+++ b/ydb/public/lib/experimental/ydb_clickhouse_internal.cpp
@@ -138,10 +138,7 @@ bool RangeFinished(const TString& lastReadKey, const TString& endKey, const TVec
     NKikimr::TSerializedCellVec end(endKey);
     Y_ABORT_UNLESS(end.GetCells().size() <= keyColumnTypes.size());
 
-    int cmp = NKikimr::CompareTypedCellVectors(
-                last.GetCells().data(), end.GetCells().data(),
-                keyColumnTypes.data(),
-                last.GetCells().size(), end.GetCells().size());
+    int cmp = NKikimr::CompareKeys(last.GetCells(), end.GetCells(), keyColumnTypes);
 
     return cmp >= 0;
 }


### PR DESCRIPTION
`CompareTypedCellVectors()` overload, designed to compare cell vectors of different sizes, has a flaw: it's asymmetrical, allowing comparison of a full key to a shorter key prefix but not vice versa.

This wasn't a bug per se, but an intentional limitation that's easy to overlook. It caused the crash #13991, which #18201 addressed locally for the split/merge case.

This overload is used in multiple places -- creating potential for unsupported compare cases.

1. `ydb/core/scheme/scheme_tablecell.h`
    - replace flawed `CompareTypedCellVectors()` overload with a symmetric alternative
    - add higher-level wrappers `CompareKeys()` and `CompareKeysPrefix()` accepting contiguous containers instead of raw pointers
    - add tests for all of that

3. update instances where the flawed `CompareTypedCellVectors()` is called to use the new `CompareKeys*()` functions