### PR TITLE
Fix parsing INDEX GLOBAL (SYNC|ASYNC)

### DIFF
--- a/yql/essentials/sql/v1/sql_translation.cpp
+++ b/yql/essentials/sql/v1/sql_translation.cpp
@@ -662,23 +662,29 @@ bool TSqlTranslation::CreateTableIndex(const TRule_table_index& node, TVector<TI
             if (globalIndex.HasBlock2()) {
                 uniqIndex = true;
             }
+            bool sync = true;
             if (globalIndex.HasBlock3()) {
                 const TString token = to_lower(Ctx.Token(globalIndex.GetBlock3().GetToken1()));
                 if (token == "sync") {
-                    if (uniqIndex) {
-                        indexes.back().Type = TIndexDescription::EType::GlobalSyncUnique;
-                    } else {
-                        indexes.back().Type = TIndexDescription::EType::GlobalSync;
-                    }
+                    sync = true;
                 } else if (token == "async") {
-                    if (uniqIndex) {
-                        AltNotImplemented("unique", indexType);
-                        return false;
-                    }
-                    indexes.back().Type = TIndexDescription::EType::GlobalAsync;
+                    sync = false;
                 } else {
                     Y_ABORT("You should change implementation according to grammar changes");
                 }
+            }
+            if (sync) {
+                if (uniqIndex) {
+                    indexes.back().Type = TIndexDescription::EType::GlobalSyncUnique;
+                } else {
+                    indexes.back().Type = TIndexDescription::EType::GlobalSync;
+                }
+            } else {
+                if (uniqIndex) {
+                    AltNotImplemented("unique", indexType);
+                    return false;
+                }
+                indexes.back().Type = TIndexDescription::EType::GlobalAsync;
             }
         }
         break;

--- a/yql/essentials/sql/v1/sql_ut.cpp
+++ b/yql/essentials/sql/v1/sql_ut.cpp
@@ -2717,6 +2717,97 @@ Y_UNIT_TEST_SUITE(SqlParsingOnly) {
             "<main>:1:40: Error: local: alternative is not implemented yet: \\d+:\\d+: local_index\\n");
     }
 
+    Y_UNIT_TEST(CreateTableAddIndexGlobalUnique) {
+        NYql::TAstParseResult result = SqlToYql(R"sql(USE plato;
+            CREATE TABLE table (
+                pk INT32 NOT NULL,
+                col String,
+                INDEX idx GLOBAL UNIQUE ON(col),
+                PRIMARY KEY (pk))
+                )sql");
+        UNIT_ASSERT_C(result.IsOk(), result.Issues.ToString());
+        UNIT_ASSERT(result.Root);
+
+        TVerifyLineFunc verifyLine = [](const TString& word, const TString& line) {
+            Y_UNUSED(word);
+            UNIT_ASSERT_STRING_CONTAINS(line, R"('indexType 'syncGlobalUnique)");
+        };
+
+        TWordCountHive elementStat({TString("\'indexName \'\"idx\"")});
+        VerifyProgram(result, elementStat, verifyLine);
+        UNIT_ASSERT_VALUES_EQUAL(1, elementStat["\'indexName \'\"idx\""]);
+    }
+
+    Y_UNIT_TEST(CreateTableAddIndexGlobalUniqueSync) {
+        NYql::TAstParseResult result = SqlToYql(R"sql(USE plato;
+            CREATE TABLE table (
+                pk INT32 NOT NULL,
+                col String,
+                INDEX idx GLOBAL UNIQUE SYNC ON(col),
+                PRIMARY KEY (pk))
+                )sql");
+        UNIT_ASSERT_C(result.IsOk(), result.Issues.ToString());
+        UNIT_ASSERT(result.Root);
+
+        TVerifyLineFunc verifyLine = [](const TString& word, const TString& line) {
+            Y_UNUSED(word);
+            UNIT_ASSERT_STRING_CONTAINS(line, R"('indexType 'syncGlobalUnique)");
+        };
+
+        TWordCountHive elementStat({TString("\'indexName \'\"idx\"")});
+        VerifyProgram(result, elementStat, verifyLine);
+        UNIT_ASSERT_VALUES_EQUAL(1, elementStat["\'indexName \'\"idx\""]);
+    }
+
+    Y_UNIT_TEST(CreateTableAddIndexGlobalUniqueAsync) {
+        ExpectFailWithFuzzyError(R"sql(USE plato;
+            CREATE TABLE table (
+                pk INT32 NOT NULL,
+                col String,
+                INDEX idx GLOBAL UNIQUE ASYNC ON(col),
+                PRIMARY KEY (pk))
+                )sql",
+            "<main>:5:41: Error: unique: alternative is not implemented yet: \\d+:\\d+: global_index\\n");
+    }
+
+    Y_UNIT_TEST(AlterTableAddIndexGlobalUnique) {
+        NYql::TAstParseResult result = SqlToYql(R"sql(USE plato;
+            ALTER TABLE table ADD INDEX idx GLOBAL UNIQUE ON(col))sql");
+        UNIT_ASSERT_C(result.IsOk(), result.Issues.ToString());
+        UNIT_ASSERT(result.Root);
+
+        TVerifyLineFunc verifyLine = [](const TString& word, const TString& line) {
+            Y_UNUSED(word);
+            UNIT_ASSERT_STRING_CONTAINS(line, R"('indexType 'syncGlobalUnique)");
+        };
+
+        TWordCountHive elementStat({TString("\'indexName \'\"idx\"")});
+        VerifyProgram(result, elementStat, verifyLine);
+        UNIT_ASSERT_VALUES_EQUAL(1, elementStat["\'indexName \'\"idx\""]);
+    }
+
+    Y_UNIT_TEST(AlterTableAddIndexGlobalUniqueSync) {
+        NYql::TAstParseResult result = SqlToYql(R"sql(USE plato;
+            ALTER TABLE table ADD INDEX idx GLOBAL UNIQUE SYNC ON(col))sql");
+        UNIT_ASSERT_C(result.IsOk(), result.Issues.ToString());
+        UNIT_ASSERT(result.Root);
+
+        TVerifyLineFunc verifyLine = [](const TString& word, const TString& line) {
+            Y_UNUSED(word);
+            UNIT_ASSERT_STRING_CONTAINS(line, R"('indexType 'syncGlobalUnique)");
+        };
+
+        TWordCountHive elementStat({TString("\'indexName \'\"idx\"")});
+        VerifyProgram(result, elementStat, verifyLine);
+        UNIT_ASSERT_VALUES_EQUAL(1, elementStat["\'indexName \'\"idx\""]);
+    }
+
+    Y_UNIT_TEST(AlterTableAddIndexGlobalUniqueAsync) {
+        ExpectFailWithFuzzyError(R"sql(USE plato;
+            ALTER TABLE table ADD INDEX idx GLOBAL UNIQUE ASYNC ON(col))sql",
+            "<main>:2:59: Error: unique: alternative is not implemented yet: \\d+:\\d+: global_index\\n");
+    }
+
     Y_UNIT_TEST(CreateTableAddIndexVector) {
         const auto result = SqlToYql(R"(USE plato;
             CREATE TABLE table (

--- a/yql/essentials/sql/v1/sql_ut_antlr4.cpp
+++ b/yql/essentials/sql/v1/sql_ut_antlr4.cpp
@@ -2959,6 +2959,97 @@ Y_UNIT_TEST_SUITE(SqlParsingOnly) {
             "<main>:1:40: Error: local: alternative is not implemented yet: \n");
     }
 
+    Y_UNIT_TEST(CreateTableAddIndexGlobalUnique) {
+        NYql::TAstParseResult result = SqlToYql(R"sql(USE plato;
+            CREATE TABLE table (
+                pk INT32 NOT NULL,
+                col String,
+                INDEX idx GLOBAL UNIQUE ON(col),
+                PRIMARY KEY (pk))
+                )sql");
+        UNIT_ASSERT_C(result.IsOk(), result.Issues.ToString());
+        UNIT_ASSERT(result.Root);
+
+        TVerifyLineFunc verifyLine = [](const TString& word, const TString& line) {
+            Y_UNUSED(word);
+            UNIT_ASSERT_STRING_CONTAINS(line, R"('indexType 'syncGlobalUnique)");
+        };
+
+        TWordCountHive elementStat({TString("\'indexName \'\"idx\"")});
+        VerifyProgram(result, elementStat, verifyLine);
+        UNIT_ASSERT_VALUES_EQUAL(1, elementStat["\'indexName \'\"idx\""]);
+    }
+
+    Y_UNIT_TEST(CreateTableAddIndexGlobalUniqueSync) {
+        NYql::TAstParseResult result = SqlToYql(R"sql(USE plato;
+            CREATE TABLE table (
+                pk INT32 NOT NULL,
+                col String,
+                INDEX idx GLOBAL UNIQUE SYNC ON(col),
+                PRIMARY KEY (pk))
+                )sql");
+        UNIT_ASSERT_C(result.IsOk(), result.Issues.ToString());
+        UNIT_ASSERT(result.Root);
+
+        TVerifyLineFunc verifyLine = [](const TString& word, const TString& line) {
+            Y_UNUSED(word);
+            UNIT_ASSERT_STRING_CONTAINS(line, R"('indexType 'syncGlobalUnique)");
+        };
+
+        TWordCountHive elementStat({TString("\'indexName \'\"idx\"")});
+        VerifyProgram(result, elementStat, verifyLine);
+        UNIT_ASSERT_VALUES_EQUAL(1, elementStat["\'indexName \'\"idx\""]);
+    }
+
+    Y_UNIT_TEST(CreateTableAddIndexGlobalUniqueAsync) {
+        ExpectFailWithError(R"sql(USE plato;
+            CREATE TABLE table (
+                pk INT32 NOT NULL,
+                col String,
+                INDEX idx GLOBAL UNIQUE ASYNC ON(col),
+                PRIMARY KEY (pk))
+                )sql",
+            "<main>:5:41: Error: unique: alternative is not implemented yet: \n");
+    }
+
+    Y_UNIT_TEST(AlterTableAddIndexGlobalUnique) {
+        NYql::TAstParseResult result = SqlToYql(R"sql(USE plato;
+            ALTER TABLE table ADD INDEX idx GLOBAL UNIQUE ON(col))sql");
+        UNIT_ASSERT_C(result.IsOk(), result.Issues.ToString());
+        UNIT_ASSERT(result.Root);
+
+        TVerifyLineFunc verifyLine = [](const TString& word, const TString& line) {
+            Y_UNUSED(word);
+            UNIT_ASSERT_STRING_CONTAINS(line, R"('indexType 'syncGlobalUnique)");
+        };
+
+        TWordCountHive elementStat({TString("\'indexName \'\"idx\"")});
+        VerifyProgram(result, elementStat, verifyLine);
+        UNIT_ASSERT_VALUES_EQUAL(1, elementStat["\'indexName \'\"idx\""]);
+    }
+
+    Y_UNIT_TEST(AlterTableAddIndexGlobalUniqueSync) {
+        NYql::TAstParseResult result = SqlToYql(R"sql(USE plato;
+            ALTER TABLE table ADD INDEX idx GLOBAL UNIQUE SYNC ON(col))sql");
+        UNIT_ASSERT_C(result.IsOk(), result.Issues.ToString());
+        UNIT_ASSERT(result.Root);
+
+        TVerifyLineFunc verifyLine = [](const TString& word, const TString& line) {
+            Y_UNUSED(word);
+            UNIT_ASSERT_STRING_CONTAINS(line, R"('indexType 'syncGlobalUnique)");
+        };
+
+        TWordCountHive elementStat({TString("\'indexName \'\"idx\"")});
+        VerifyProgram(result, elementStat, verifyLine);
+        UNIT_ASSERT_VALUES_EQUAL(1, elementStat["\'indexName \'\"idx\""]);
+    }
+
+    Y_UNIT_TEST(AlterTableAddIndexGlobalUniqueAsync) {
+        ExpectFailWithError(R"sql(USE plato;
+            ALTER TABLE table ADD INDEX idx GLOBAL UNIQUE ASYNC ON(col))sql",
+            "<main>:2:59: Error: unique: alternative is not implemented yet: \n");
+    }
+
     Y_UNIT_TEST(CreateTableAddIndexVector) {
         const auto result = SqlToYql(R"(USE plato;
             CREATE TABLE table (


### PR DESCRIPTION
* Changelog entry Type: fix
Component: yql

Fix parsing unique index type. There was an error that, if not specified explicitly (SYNC or ASYNC), index type remained with the default value GLOBAL SYNC, despite that it was explicitly specified as UNIQUE in query. https://github.com/ydb-platform/ydb/issues/17885

---

Pull Request resolved: https://github.com/ytsaurus/ytsaurus/pull/1287 commit_hash:60de1b723fb1229f2197087fe21db67c72ccbd13

(cherry picked from commit a3559d6fde15102e1c1731e4bf7ee5cb0040a59d)

### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

Fix parsing unique index type. There was an error that, if not specified explicitly (SYNC or ASYNC), index type remained with the default value GLOBAL SYNC, despite that it was explicitly specified as UNIQUE in query.
https://github.com/ydb-platform/ydb/issues/17885

### Changelog category <!-- remove all except one -->

* Bugfix 

### Description for reviewers <!-- (optional) description for those who read this PR -->

...
