### PR TITLE
pass folder_id parameter to ticket parser

### DIFF
--- a/ydb/core/grpc_services/grpc_request_check_actor.h
+++ b/ydb/core/grpc_services/grpc_request_check_actor.h
@@ -68,7 +68,7 @@ inline TVector<TEvTicketParser::TEvAuthorizeTicket::TEntry> GetEntriesForAuthAnd
             return {};
         }
         return {
-            {permissions, {{"gizmo_id", it->second}}}
+            {permissions, {{"folder_id", it->second}}}
         };
     } else {
         return {};

--- a/ydb/core/security/ticket_parser_impl.h
+++ b/ydb/core/security/ticket_parser_impl.h
@@ -1696,8 +1696,6 @@ protected:
         sids.emplace_back(permission + '@' + AccessServiceDomain);
         if (const TString databaseId = record.GetAttributeValue(permission, "database_id"); databaseId) {
             sids.emplace_back(permission + '-' + databaseId + '@' + AccessServiceDomain);
-        } else if (const TString folderId = record.GetAttributeValue(permission, "folder_id"); folderId) {
-            sids.emplace_back(permission + '-' + folderId + '@' + AccessServiceDomain);
         }
         if (const TString gizmoId = record.GetAttributeValue(permission, "gizmo_id"); gizmoId) {
             sids.emplace_back(permission + '-' + gizmoId + '@' + AccessServiceDomain);

--- a/ydb/core/security/ticket_parser_impl.h
+++ b/ydb/core/security/ticket_parser_impl.h
@@ -474,13 +474,6 @@ private:
             AddNebiusResourcePath(pathsContainer, databaseId);
         }
 
-        // Use attribute "gizmo_id" as container id that contains cluster access resource
-        // IAM can link roles for cluster access resource
-        // Note: "gizmo_id" and "folder_id" are always sent in separate TEvAuthorizeTicket requests
-        if (const auto gizmoId = record.GetAttributeValue(permission, "gizmo_id"); gizmoId) {
-            SetNebiusContainerId(pathsContainer, gizmoId);
-        }
-
         // Use attribute "folder_id" as container id that contains our database
         // IAM can link roles for containers hierarchy
         if (const auto folderId = record.GetAttributeValue(permission, "folder_id"); folderId) {
@@ -1703,6 +1696,8 @@ protected:
         sids.emplace_back(permission + '@' + AccessServiceDomain);
         if (const TString databaseId = record.GetAttributeValue(permission, "database_id"); databaseId) {
             sids.emplace_back(permission + '-' + databaseId + '@' + AccessServiceDomain);
+        } else if (const TString folderId = record.GetAttributeValue(permission, "folder_id"); folderId) {
+            sids.emplace_back(permission + '-' + folderId + '@' + AccessServiceDomain);
         }
         if (const TString gizmoId = record.GetAttributeValue(permission, "gizmo_id"); gizmoId) {
             sids.emplace_back(permission + '-' + gizmoId + '@' + AccessServiceDomain);

--- a/ydb/core/security/ticket_parser_ut.cpp
+++ b/ydb/core/security/ticket_parser_ut.cpp
@@ -1671,8 +1671,11 @@ Y_UNIT_TEST_SUITE(TTicketParserTest) {
                                             {"monitoring.view"})), 0);
             result = runtime->GrabEdgeEvent<TEvTicketParser::TEvAuthorizeTicketResult>(handle);
             UNIT_ASSERT_C(result->Error.empty(), result->Error);
+            UNIT_ASSERT_VALUES_EQUAL_C(result->Token->GetGroupSIDs().size(), 4, result->Token->ShortDebugString());
+            UNIT_ASSERT_C(result->Token->IsExist("all-users@well-known"), result->Token->ShortDebugString());
             UNIT_ASSERT_C(result->Token->IsExist("monitoring.view@as"), result->Token->ShortDebugString());
             UNIT_ASSERT_C(result->Token->IsExist("monitoring.view-gizmo@as"), result->Token->ShortDebugString());
+            UNIT_ASSERT_C(result->Token->IsExist("user1@as"), result->Token->ShortDebugString());
         } else {
             // Authorization successful for cluster resource
             accessServiceMock.AllowedResourceIds.clear();
@@ -1683,8 +1686,10 @@ Y_UNIT_TEST_SUITE(TTicketParserTest) {
                                             {"monitoring.view"})), 0);
             result = runtime->GrabEdgeEvent<TEvTicketParser::TEvAuthorizeTicketResult>(handle);
             UNIT_ASSERT_C(result->Error.empty(), result->Error);
+            UNIT_ASSERT_VALUES_EQUAL_C(result->Token->GetGroupSIDs().size(), 3, result->Token->ShortDebugString());
+            UNIT_ASSERT_C(result->Token->IsExist("all-users@well-known"), result->Token->ShortDebugString());
             UNIT_ASSERT_C(result->Token->IsExist("monitoring.view@as"), result->Token->ShortDebugString());
-            UNIT_ASSERT_C(!result->Token->IsExist("monitoring.view-folder@as"), result->Token->ShortDebugString());
+            UNIT_ASSERT_C(result->Token->IsExist("user1@as"), result->Token->ShortDebugString());
         }
     }
 

--- a/ydb/core/security/ticket_parser_ut.cpp
+++ b/ydb/core/security/ticket_parser_ut.cpp
@@ -1661,17 +1661,31 @@ Y_UNIT_TEST_SUITE(TTicketParserTest) {
         UNIT_ASSERT_C(result->Error.empty(), result->Error);
         UNIT_ASSERT_C(result->Token->IsExist("something.read-bbbb4554@as"), result->Token->ShortDebugString());
 
-        // Authorization successful for cluster resource
-        accessServiceMock.AllowedResourceIds.clear();
-        accessServiceMock.AllowedResourceIds.emplace("folder");
-        runtime->Send(new IEventHandle(MakeTicketParserID(), sender, new TEvTicketParser::TEvAuthorizeTicket(
-                                        userToken,
-                                        {{"folder_id", "folder"}, },
-                                        {"monitoring.view"})), 0);
-        result = runtime->GrabEdgeEvent<TEvTicketParser::TEvAuthorizeTicketResult>(handle);
-        UNIT_ASSERT_C(result->Error.empty(), result->Error);
-        UNIT_ASSERT_C(result->Token->IsExist("monitoring.view@as"), result->Token->ShortDebugString());
-        UNIT_ASSERT_C(result->Token->IsExist("monitoring.view-folder@as"), result->Token->ShortDebugString());
+        if constexpr (!IsNebiusAccessService<TAccessServiceMock>()) {
+            // Authorization successful for gizmo resource
+            accessServiceMock.AllowedResourceIds.clear();
+            accessServiceMock.AllowedResourceIds.emplace("gizmo");
+            runtime->Send(new IEventHandle(MakeTicketParserID(), sender, new TEvTicketParser::TEvAuthorizeTicket(
+                                            userToken,
+                                            {{"gizmo_id", "gizmo"}, },
+                                            {"monitoring.view"})), 0);
+            result = runtime->GrabEdgeEvent<TEvTicketParser::TEvAuthorizeTicketResult>(handle);
+            UNIT_ASSERT_C(result->Error.empty(), result->Error);
+            UNIT_ASSERT_C(result->Token->IsExist("monitoring.view@as"), result->Token->ShortDebugString());
+            UNIT_ASSERT_C(result->Token->IsExist("monitoring.view-gizmo@as"), result->Token->ShortDebugString());
+        } else {
+            // Authorization successful for cluster resource
+            accessServiceMock.AllowedResourceIds.clear();
+            accessServiceMock.AllowedResourceIds.emplace("folder");
+            runtime->Send(new IEventHandle(MakeTicketParserID(), sender, new TEvTicketParser::TEvAuthorizeTicket(
+                                            userToken,
+                                            {{"folder_id", "folder"}, },
+                                            {"monitoring.view"})), 0);
+            result = runtime->GrabEdgeEvent<TEvTicketParser::TEvAuthorizeTicketResult>(handle);
+            UNIT_ASSERT_C(result->Error.empty(), result->Error);
+            UNIT_ASSERT_C(result->Token->IsExist("monitoring.view@as"), result->Token->ShortDebugString());
+            UNIT_ASSERT_C(!result->Token->IsExist("monitoring.view-folder@as"), result->Token->ShortDebugString());
+        }
     }
 
     Y_UNIT_TEST(Authorization) {

--- a/ydb/core/security/ticket_parser_ut.cpp
+++ b/ydb/core/security/ticket_parser_ut.cpp
@@ -1661,17 +1661,17 @@ Y_UNIT_TEST_SUITE(TTicketParserTest) {
         UNIT_ASSERT_C(result->Error.empty(), result->Error);
         UNIT_ASSERT_C(result->Token->IsExist("something.read-bbbb4554@as"), result->Token->ShortDebugString());
 
-        // Authorization successful for gizmo resource
+        // Authorization successful for cluster resource
         accessServiceMock.AllowedResourceIds.clear();
-        accessServiceMock.AllowedResourceIds.emplace("gizmo");
+        accessServiceMock.AllowedResourceIds.emplace("folder");
         runtime->Send(new IEventHandle(MakeTicketParserID(), sender, new TEvTicketParser::TEvAuthorizeTicket(
                                         userToken,
-                                        {{"gizmo_id", "gizmo"}, },
+                                        {{"folder_id", "folder"}, },
                                         {"monitoring.view"})), 0);
         result = runtime->GrabEdgeEvent<TEvTicketParser::TEvAuthorizeTicketResult>(handle);
         UNIT_ASSERT_C(result->Error.empty(), result->Error);
         UNIT_ASSERT_C(result->Token->IsExist("monitoring.view@as"), result->Token->ShortDebugString());
-        UNIT_ASSERT_C(result->Token->IsExist("monitoring.view-gizmo@as"), result->Token->ShortDebugString());
+        UNIT_ASSERT_C(result->Token->IsExist("monitoring.view-folder@as"), result->Token->ShortDebugString());
     }
 
     Y_UNIT_TEST(Authorization) {


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

pass folder_id parameter to ticket parser

### Changelog category <!-- remove all except one -->

* Improvement

### Description for reviewers <!-- (optional) description for those who read this PR -->

— this is needed for consistency with other parameters we use.
An example of permissions a user can get on a storage node if the folder_id user attribute is set at the root:
```
tenantuseraccount-e0tg829s16770fh6qkha6@as
ydb.tables.select@as
ydb.databases.connect@as
ydb.databases.create@as
ydb.clusters.monitor@as
ydb.databases.list@as
ydb.clusters.manage@as
ydb.clusters.get@as
ydb.schemas.getMetadata@as
all-users@well-known
```
