### PR TITLE
Disable write to unique index under construction

### DIFF
--- a/ydb/core/kqp/gateway/kqp_metadata_loader.cpp
+++ b/ydb/core/kqp/gateway/kqp_metadata_loader.cpp
@@ -130,7 +130,7 @@ void CheckWritesAreDisabled(const TIndexProto& indexes, NYql::TKikimrTableMetada
             if (disableReason) {
                 disableReason << ", ";
             }
-            disableReason << "Unique index " << index.GetName() << " is not ready";
+            disableReason << "Unique index " << index.GetName() << " is under construction";
         }
     }
 

--- a/ydb/core/kqp/gateway/kqp_metadata_loader.cpp
+++ b/ydb/core/kqp/gateway/kqp_metadata_loader.cpp
@@ -122,6 +122,24 @@ void IndexProtoToMetadata(const TIndexProto& indexes, NYql::TKikimrTableMetadata
     }
 }
 
+template<typename TIndexProto>
+void CheckWritesAreDisabled(const TIndexProto& indexes, NYql::TKikimrTableMetadataPtr tableMeta) {
+    TStringBuilder disableReason;
+    for (const NKikimrSchemeOp::TIndexDescription& index : indexes) {
+        if (index.GetType() == NKikimrSchemeOp::EIndexType::EIndexTypeGlobalUnique && index.GetState() != NKikimrSchemeOp::EIndexState::EIndexStateReady) {
+            if (disableReason) {
+                disableReason << ", ";
+            }
+            disableReason << "Unique index " << index.GetName() << " is not ready";
+        }
+    }
+
+    if (disableReason) {
+        tableMeta->WritesToTableAreDisabled = true;
+        tableMeta->DisableWritesReason = disableReason;
+    }
+}
+
 TString GetTypeName(const NScheme::TTypeInfoMod& typeInfoMod) {
     return NScheme::TypeName(typeInfoMod.TypeInfo, typeInfoMod.TypeMod);
 }
@@ -234,6 +252,9 @@ TTableMetadataResult GetTableMetadataResult(const NSchemeCache::TSchemeCacheNavi
     }
 
     IndexProtoToMetadata(entry.Indexes, tableMeta);
+
+    // Check if we have unique indexes that are not built
+    CheckWritesAreDisabled(entry.Indexes, tableMeta);
 
     return result;
 }

--- a/ydb/core/kqp/provider/yql_kikimr_exec.cpp
+++ b/ydb/core/kqp/provider/yql_kikimr_exec.cpp
@@ -1842,6 +1842,8 @@ public:
                             const auto type = TString(columnTuple.Item(1).Cast<TCoAtom>().Value());
                             if (type == "syncGlobal") {
                                 add_index->mutable_global_index();
+                            } else if (type == "syncGlobalUnique") {
+                                add_index->mutable_global_unique_index();
                             } else if (type == "asyncGlobal") {
                                 add_index->mutable_global_async_index();
                             } else if (type == "globalVectorKmeansTree") {

--- a/ydb/core/kqp/provider/yql_kikimr_gateway.h
+++ b/ydb/core/kqp/provider/yql_kikimr_gateway.h
@@ -490,6 +490,10 @@ struct TKikimrTableMetadata : public TThrRefBase {
     TMaybe<NKikimrSysView::ESysViewType> SysViewType;
     bool IsIndexImplTable = false;
 
+    // If writes are disabled, query that writes to table must finish with error.
+    bool WritesToTableAreDisabled = false;
+    TString DisableWritesReason;
+
     ui64 RecordsCount = 0;
     ui64 DataSize = 0;
     ui64 MemorySize = 0;

--- a/ydb/core/kqp/provider/yql_kikimr_type_ann.cpp
+++ b/ydb/core/kqp/provider/yql_kikimr_type_ann.cpp
@@ -476,6 +476,15 @@ private:
             return TStatus::Error;
         }
 
+        if (table->Metadata->WritesToTableAreDisabled) {
+            NYql::TIssues issues;
+            issues.AddIssue(NYql::TIssue(ctx.GetPosition(node.Pos()),
+                TStringBuilder() << "Table " << table->Metadata->Name << " modification is disabled: "
+                    << table->Metadata->DisableWritesReason));
+            ctx.IssueManager.AddIssues(ctx.GetPosition(node.Pos()), issues);
+            return TStatus::Error;
+        }
+
         auto pos = ctx.GetPosition(node.Pos());
         if (auto maybeTuple = node.Input().Maybe<TExprList>()) {
             auto tuple = maybeTuple.Cast();

--- a/ydb/core/kqp/provider/yql_kikimr_type_ann.cpp
+++ b/ydb/core/kqp/provider/yql_kikimr_type_ann.cpp
@@ -476,15 +476,6 @@ private:
             return TStatus::Error;
         }
 
-        if (table->Metadata->WritesToTableAreDisabled) {
-            NYql::TIssues issues;
-            issues.AddIssue(NYql::TIssue(ctx.GetPosition(node.Pos()),
-                TStringBuilder() << "Table " << table->Metadata->Name << " modification is disabled: "
-                    << table->Metadata->DisableWritesReason));
-            ctx.IssueManager.AddIssues(ctx.GetPosition(node.Pos()), issues);
-            return TStatus::Error;
-        }
-
         auto pos = ctx.GetPosition(node.Pos());
         if (auto maybeTuple = node.Input().Maybe<TExprList>()) {
             auto tuple = maybeTuple.Cast();

--- a/ydb/core/kqp/ut/scheme/kqp_scheme_ut.cpp
+++ b/ydb/core/kqp/ut/scheme/kqp_scheme_ut.cpp
@@ -3376,11 +3376,16 @@ Y_UNIT_TEST_SUITE(KqpScheme) {
                 DELETE FROM `/Root/TestTable` WHERE Key = 2;
             )sql";
 
+            TString returningQuery = R"sql(
+                REPLACE INTO `/Root/TestTable` (Key, Value) VALUES (1, "1") RETURNING Key, Value;
+            )sql";
+
             auto modificationQueries = {
                 upsertQuery,
                 insertQuery,
                 updateQuery,
-                deleteQuery
+                deleteQuery,
+                returningQuery,
             };
 
             for (const TString& query : modificationQueries) {

--- a/ydb/core/protos/feature_flags.proto
+++ b/ydb/core/protos/feature_flags.proto
@@ -210,4 +210,5 @@ message TFeatureFlags {
     optional bool EnableThrottlingReport = 184 [default = true];
     optional bool EnableNodeBrokerDeltaProtocol = 185 [default = false];
     optional bool EnableAccessToIndexImplTables = 186 [default = false];
+    optional bool EnableAddUniqueIndex = 187 [default = false];
 }

--- a/ydb/core/tx/schemeshard/schemeshard_build_index__create.cpp
+++ b/ydb/core/tx/schemeshard/schemeshard_build_index__create.cpp
@@ -227,8 +227,14 @@ private:
             buildInfo.IndexType = NKikimrSchemeOp::EIndexType::EIndexTypeGlobalAsync;
             break;
         case Ydb::Table::TableIndex::TypeCase::kGlobalUniqueIndex:
-            explain = "unsupported index type to build";
-            return false;
+            if (AppData()->FeatureFlags.GetEnableAddUniqueIndex()) {
+                buildInfo.BuildKind = TIndexBuildInfo::EBuildKind::BuildSecondaryIndex;
+                buildInfo.IndexType = NKikimrSchemeOp::EIndexType::EIndexTypeGlobalUnique;
+                break;
+            } else {
+                explain = "unsupported index type to build";
+                return false;
+            }
         case Ydb::Table::TableIndex::TypeCase::kGlobalVectorKmeansTreeIndex: {
             buildInfo.BuildKind = index.index_columns().size() == 1
                 ? TIndexBuildInfo::EBuildKind::BuildVectorIndex


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

...

### Changelog category <!-- remove all except one -->

* Not for changelog (changelog entry is not required)

### Description for reviewers <!-- (optional) description for those who read this PR -->

This is the first stage of https://github.com/ydb-platform/ydb/issues/10468
I allowed (under a feature flag) alters that add unique index.
KQP gets information about tables and a new code checks if there are unique index in the table that is under construction.
If KQP sees that query modifies such a table, then it fails query compilation.