### PR TITLE
whoami need UseAuth parameter to go to Ticket Parser

### DIFF
--- a/ydb/core/mon/mon.cpp
+++ b/ydb/core/mon/mon.cpp
@@ -1450,7 +1450,7 @@ NMonitoring::IMonPage* TMon::RegisterActorPage(TRegisterActorPageFields fields) 
         fields.PreTag,
         fields.ActorSystem,
         fields.ActorId,
-        fields.AllowedSIDs.Defined() ? *fields.AllowedSIDs : Config.AllowedSIDs,
+        (fields.AllowedSIDs || !fields.UseFallbackSIDs) ? fields.AllowedSIDs : Config.AllowedSIDs,
         fields.UseAuth ? Config.Authorizer : TRequestAuthorizer(),
         fields.MonServiceName);
     if (fields.Index) {

--- a/ydb/core/mon/mon.cpp
+++ b/ydb/core/mon/mon.cpp
@@ -1450,7 +1450,7 @@ NMonitoring::IMonPage* TMon::RegisterActorPage(TRegisterActorPageFields fields) 
         fields.PreTag,
         fields.ActorSystem,
         fields.ActorId,
-        fields.AllowedSIDs ? fields.AllowedSIDs : Config.AllowedSIDs,
+        fields.AllowedSIDs.Defined() ? *fields.AllowedSIDs : Config.AllowedSIDs,
         fields.UseAuth ? Config.Authorizer : TRequestAuthorizer(),
         fields.MonServiceName);
     if (fields.Index) {

--- a/ydb/core/mon/mon.h
+++ b/ydb/core/mon/mon.h
@@ -60,7 +60,7 @@ public:
         bool PreTag = false;
         TActorId ActorId;
         bool UseAuth = true;
-        TVector<TString> AllowedSIDs;
+        TMaybe<TVector<TString>> AllowedSIDs;
         bool SortPages = true;
         TString MonServiceName = "utils";
     };

--- a/ydb/core/mon/mon.h
+++ b/ydb/core/mon/mon.h
@@ -60,7 +60,8 @@ public:
         bool PreTag = false;
         TActorId ActorId;
         bool UseAuth = true;
-        TMaybe<TVector<TString>> AllowedSIDs;
+        TVector<TString> AllowedSIDs;
+        bool UseFallbackSIDs = true;
         bool SortPages = true;
         TString MonServiceName = "utils";
     };

--- a/ydb/core/viewer/viewer.cpp
+++ b/ydb/core/viewer/viewer.cpp
@@ -92,13 +92,15 @@ public:
                 .RelPath = "viewer/whoami",
                 .ActorSystem = ctx.ActorSystem(),
                 .ActorId = ctx.SelfID,
-                .UseAuth = false,
+                .UseAuth = true,
+                .AllowedSIDs = {},
             });
             mon->RegisterActorPage({
                 .RelPath = "viewer/json/whoami", // temporary handling of old paths
                 .ActorSystem = ctx.ActorSystem(),
                 .ActorId = ctx.SelfID,
-                .UseAuth = false,
+                .UseAuth = true,
+                .AllowedSIDs = {},
             });
             mon->RegisterActorPage({
                 .Title = "Viewer",

--- a/ydb/core/viewer/viewer.cpp
+++ b/ydb/core/viewer/viewer.cpp
@@ -93,14 +93,14 @@ public:
                 .ActorSystem = ctx.ActorSystem(),
                 .ActorId = ctx.SelfID,
                 .UseAuth = true,
-                .AllowedSIDs = {},
+                .AllowedSIDs = TVector<TString>{},
             });
             mon->RegisterActorPage({
                 .RelPath = "viewer/json/whoami", // temporary handling of old paths
                 .ActorSystem = ctx.ActorSystem(),
                 .ActorId = ctx.SelfID,
                 .UseAuth = true,
-                .AllowedSIDs = {},
+                .AllowedSIDs = TVector<TString>{},
             });
             mon->RegisterActorPage({
                 .Title = "Viewer",

--- a/ydb/core/viewer/viewer.cpp
+++ b/ydb/core/viewer/viewer.cpp
@@ -93,14 +93,14 @@ public:
                 .ActorSystem = ctx.ActorSystem(),
                 .ActorId = ctx.SelfID,
                 .UseAuth = true,
-                .AllowedSIDs = TVector<TString>{},
+                .UseFallbackSIDs = false,
             });
             mon->RegisterActorPage({
                 .RelPath = "viewer/json/whoami", // temporary handling of old paths
                 .ActorSystem = ctx.ActorSystem(),
                 .ActorId = ctx.SelfID,
                 .UseAuth = true,
-                .AllowedSIDs = TVector<TString>{},
+                .UseFallbackSIDs = false,
             });
             mon->RegisterActorPage({
                 .Title = "Viewer",


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

`/whoami` needs `UseAuth` parameter to go to Ticket Parser

### Changelog category <!-- remove all except one -->

* Bugfix 

### Description for reviewers <!-- (optional) description for those who read this PR -->

```
{"OriginalUserToken":"XXX-XXX.XXX-XXX-XXX","IsTokenRequired":true,
"GroupSIDs":["all-users@well-known","ydb.schemas.getMetadata@as","ydb.clusters.get@as",
"ydb.clusters.get-ydbui-e0tydb-testing-nebius-dev-container@as","ydb.clusters.manage@as",
"ydb.clusters.manage-ydbui-e0tydb-testing-nebius-dev-container@as","ydb.databases.list@as",
"ydb.clusters.monitor@as","ydb.clusters.monitor-ydbui-e0tydb-testing-nebius-dev-container@as","ydb.databases.create@as",
"ydb.databases.connect@as","ydb.tables.select@as","tenantuseraccount-XXX@as"],"IsAdministrationAllowed":true,
"IsViewerAllowed":true,"AuthType":"NebiusAccessService","IsMonitoringAllowed":true,"UserSID":"XXX-XXX@as"}
```