### PR TITLE
Passed and processed sys view type in KQP

### DIFF
--- a/ydb/core/grpc_services/rpc_read_columns.cpp
+++ b/ydb/core/grpc_services/rpc_read_columns.cpp
@@ -316,9 +316,16 @@ private:
 
         {
             TTableRange range(MinKey.GetCells(), MinKeyInclusive, MaxKey.GetCells(), MaxKeyInclusive);
+            TMaybe<NKikimrSysView::ESysViewType> sysViewType;
+            const auto& entry = ResolveNamesResult->ResultSet.front();
+            if (entry.Kind == NSchemeCache::TSchemeCacheNavigate::KindSysView) {
+                Y_ABORT_UNLESS(entry.SysViewInfo);
+                sysViewType = entry.SysViewInfo->Description.GetType();
+            }
             auto tableScanActor = NSysView::CreateSystemViewScan(ctx.SelfID, 0,
-                ResolveNamesResult->ResultSet.front().TableId,
-                JoinPath(ResolveNamesResult->ResultSet.front().Path),
+                entry.TableId,
+                JoinPath(entry.Path),
+                sysViewType,
                 range,
                 columns,
                 Request->GetInternalToken(),

--- a/ydb/core/kqp/common/kqp_resolve.h
+++ b/ydb/core/kqp/common/kqp_resolve.h
@@ -33,6 +33,7 @@ struct TTableConstInfo : public TAtomicRefCount<TTableConstInfo> {
     TVector<TString> KeyColumns;
     TVector<NScheme::TTypeInfo> KeyColumnTypes;
     ETableKind TableKind = ETableKind::Unknown;
+    TMaybe<NKikimrSysView::ESysViewType> SysViewType;
     THashMap<TString, std::pair<TString, NYql::TKikimrPathId>> Sequences;
     THashMap<TString, Ydb::TypedValue> DefaultFromLiteral;
     bool IsBuildInProgress = false;
@@ -118,6 +119,10 @@ struct TTableConstInfo : public TAtomicRefCount<TTableConstInfo> {
                 return;
             default:
                 YQL_ENSURE(false, "Unexpected phy table kind: " << (i64) phyTable.GetKind());
+        }
+
+        if (phyTable.HasSysViewType()) {
+            SysViewType = static_cast<NKikimrSysView::ESysViewType>(phyTable.GetSysViewType());
         }
 
         for (const auto& [_, phyColumn] : phyTable.GetColumns()) {

--- a/ydb/core/kqp/executer_actor/kqp_tasks_graph.cpp
+++ b/ydb/core/kqp/executer_actor/kqp_tasks_graph.cpp
@@ -939,6 +939,9 @@ void FillTaskMeta(const TStageInfo& stageInfo, const TTask& task, NYql::NDqProto
         NKikimrTxDataShard::TKqpTransaction::TScanTaskMeta protoTaskMeta;
 
         FillTableMeta(stageInfo, protoTaskMeta.MutableTable());
+        if (stageInfo.Meta.TableConstInfo->SysViewType) {
+            protoTaskMeta.MutableTable()->SetSysViewType(*stageInfo.Meta.TableConstInfo->SysViewType);
+        }
 
         const auto& tableInfo = stageInfo.Meta.TableConstInfo;
 

--- a/ydb/core/kqp/gateway/kqp_metadata_loader.cpp
+++ b/ydb/core/kqp/gateway/kqp_metadata_loader.cpp
@@ -327,6 +327,55 @@ TTableMetadataResult GetViewMetadataResult(
   return builtResult;
 }
 
+TTableMetadataResult GetSysViewMetadataResult(const NSchemeCache::TSchemeCacheNavigate::TEntry& entry,
+                                              const TString& cluster, const TString& sysViewName) {
+    TTableMetadataResult result;
+    result.SetSuccess();
+    result.Metadata = new NYql::TKikimrTableMetadata(cluster, sysViewName);
+
+    auto tableMeta = result.Metadata;
+    tableMeta->DoesExist = true;
+    tableMeta->PathId = NYql::TKikimrPathId(entry.TableId.PathId.OwnerId, entry.TableId.PathId.LocalPathId);
+    tableMeta->SysView = entry.TableId.SysViewInfo;
+    tableMeta->SchemaVersion = entry.TableId.SchemaVersion;
+    tableMeta->Kind = NYql::EKikimrTableKind::SysView;
+
+    tableMeta->Attributes = entry.Attributes;
+
+    std::map<ui32, TString, std::less<ui32>> keyColumns;
+    std::map<ui32, TString, std::less<ui32>> columnOrder;
+    for (const auto& [id, column] : entry.Columns) {
+        const bool notNull = entry.NotNullColumns.contains(column.Name);
+        const TString typeName = GetTypeName(NScheme::TTypeInfoMod{column.PType, column.PTypeMod});
+
+        tableMeta->Columns.emplace(
+            column.Name,
+            NYql::TKikimrColumnMetadata(column.Name, column.Id, typeName, notNull, column.PType, column.PTypeMod)
+        );
+
+        if (column.KeyOrder >= 0) {
+            keyColumns[column.KeyOrder] = column.Name;
+        }
+
+        columnOrder[column.Id] = column.Name;
+    }
+
+    tableMeta->KeyColumnNames.reserve(keyColumns.size());
+    for (const auto& columnName : std::views::values(keyColumns)) {
+        tableMeta->KeyColumnNames.push_back(columnName);
+    }
+
+    tableMeta->ColumnOrder.reserve(columnOrder.size());
+    for (const auto& columnName : std::views::values(columnOrder)) {
+        tableMeta->ColumnOrder.push_back(columnName);
+    }
+
+    YQL_ENSURE(entry.SysViewInfo);
+    tableMeta->SysViewType = entry.SysViewInfo->Description.GetType();
+
+    return result;
+}
+
 TTableMetadataResult GetLoadTableMetadataResult(const NSchemeCache::TSchemeCacheNavigate::TEntry& entry,
         const TString& cluster, const TString& mainCluster, const TString& tableName, std::optional<TString> queryName = std::nullopt) {
     using TResult = NYql::IKikimrGateway::TTableMetadataResult;
@@ -359,7 +408,8 @@ TTableMetadataResult GetLoadTableMetadataResult(const NSchemeCache::TSchemeCache
                      EKind::KindColumnTable,
                      EKind::KindExternalTable,
                      EKind::KindExternalDataSource,
-                     EKind::KindView}, entry.Kind));
+                     EKind::KindView,
+                     EKind::KindSysView}, entry.Kind));
 
     TTableMetadataResult result;
     switch (entry.Kind) {
@@ -371,6 +421,9 @@ TTableMetadataResult GetLoadTableMetadataResult(const NSchemeCache::TSchemeCache
             break;
         case EKind::KindView:
             result = GetViewMetadataResult(entry, cluster, tableName);
+            break;
+        case EKind::KindSysView:
+            result = GetSysViewMetadataResult(entry, cluster, tableName);
             break;
         default:
             result = GetTableMetadataResult(entry, cluster, tableName, queryName);

--- a/ydb/core/kqp/host/kqp_host.cpp
+++ b/ydb/core/kqp/host/kqp_host.cpp
@@ -1053,7 +1053,7 @@ private:
 
         for (const auto& operation : queryBlock.Operations()) {
             auto& tableData = SessionCtx->Tables().ExistingTable(operation.Cluster(), operation.Table());
-            if (tableData.Metadata->IsOlap() || !tableData.Metadata->SysView.empty()) {
+            if (tableData.Metadata->IsOlap() || tableData.Metadata->Kind == EKikimrTableKind::SysView) {
                 // Always use ScanQuery for queries with OLAP and system tables.
                 return true;
             }
@@ -1536,7 +1536,7 @@ private:
             return nullptr;
         }
 
-        if (SessionCtx->Config().EnableNewRBO) {  
+        if (SessionCtx->Config().EnableNewRBO) {
             return MakeIntrusive<TAsyncPrepareYqlResult>(compileResult.QueryExpr.Get(), ctx, *YqlTransformerNewRBO, SessionCtx->QueryPtr(),
                 query.Text, sqlVersion, TransformCtx, compileResult.KeepInCache, compileResult.CommandTagName, DataProvidersFinalizer);
         }

--- a/ydb/core/kqp/opt/logical/kqp_opt_log_helpers.cpp
+++ b/ydb/core/kqp/opt/logical/kqp_opt_log_helpers.cpp
@@ -67,7 +67,8 @@ TMaybe<TPrefixLookup> RewriteReadToPrefixLookup(TKqlReadTableBase read, TExprCon
         return {};
     }
 
-    if (!read.Table().SysView().Value().empty()) {
+    const auto& mainTableDesc = kqpCtx.Tables->ExistingTable(kqpCtx.Cluster, read.Table().Path().StringValue());
+    if (!read.Table().SysView().Value().empty() || mainTableDesc.Metadata->Kind == EKikimrTableKind::SysView) {
         // Can't lookup in system views
         return {};
     }
@@ -79,7 +80,6 @@ TMaybe<TPrefixLookup> RewriteReadToPrefixLookup(TKqlReadTableBase read, TExprCon
         lookupTable = read.Table().Path().StringValue();
     }
     const auto& rightTableDesc = kqpCtx.Tables->ExistingTable(kqpCtx.Cluster, lookupTable);
-    const auto& mainTableDesc = kqpCtx.Tables->ExistingTable(kqpCtx.Cluster, read.Table().Path().StringValue());
 
     auto from = read.Range().From();
     auto to = read.Range().To();
@@ -149,7 +149,8 @@ TMaybe<TPrefixLookup> RewriteReadToPrefixLookup(TKqlReadTableRangesBase read, TE
         return {};
     }
 
-    if (!read.Table().SysView().Value().empty()) {
+    const auto& mainTableDesc = kqpCtx.Tables->ExistingTable(kqpCtx.Cluster, read.Table().Path().StringValue());
+    if (!read.Table().SysView().Value().empty() || mainTableDesc.Metadata->Kind == EKikimrTableKind::SysView) {
         // Can't lookup in system views
         return {};
     }
@@ -176,7 +177,6 @@ TMaybe<TPrefixLookup> RewriteReadToPrefixLookup(TKqlReadTableRangesBase read, TE
         prefixSize = prompt.PointPrefixLen;
 
         const auto& rightTableDesc = kqpCtx.Tables->ExistingTable(kqpCtx.Cluster, lookupTable);
-        const auto& mainTableDesc = kqpCtx.Tables->ExistingTable(kqpCtx.Cluster, read.Table().Path().StringValue());
 
         TMaybeNode<TExprBase> rowsExpr;
         TMaybeNode<TCoLambda> filter;

--- a/ydb/core/kqp/provider/yql_kikimr_gateway.h
+++ b/ydb/core/kqp/provider/yql_kikimr_gateway.h
@@ -487,6 +487,7 @@ struct TKikimrTableMetadata : public TThrRefBase {
     EKikimrTableKind Kind = EKikimrTableKind::Unspecified;
     ETableType TableType = ETableType::Table;
     EStoreType StoreType = EStoreType::Row;
+    TMaybe<NKikimrSysView::ESysViewType> SysViewType;
     bool IsIndexImplTable = false;
 
     ui64 RecordsCount = 0;

--- a/ydb/core/kqp/query_compiler/kqp_query_compiler.cpp
+++ b/ydb/core/kqp/query_compiler/kqp_query_compiler.cpp
@@ -164,6 +164,10 @@ void FillTable(const TKikimrTableMetadata& tableMeta, THashSet<TStringBuf>&& col
     FillTableId(tableMeta, *tableProto.MutableId());
     tableProto.SetKind(GetPhyTableKind(tableMeta.Kind));
 
+    if (tableMeta.SysViewType) {
+        tableProto.SetSysViewType(static_cast<ui32>(*tableMeta.SysViewType));
+    }
+
     for (const auto& keyColumnName : tableMeta.KeyColumnNames) {
         auto keyColumn = tableMeta.Columns.FindPtr(keyColumnName);
         YQL_ENSURE(keyColumn);

--- a/ydb/core/protos/kqp_physical.proto
+++ b/ydb/core/protos/kqp_physical.proto
@@ -109,6 +109,7 @@ message TKqpPhyTable {
     EKqpPhyTableKind Kind = 2;
     map<uint32, TKqpPhyColumn> Columns = 3;
     repeated TKqpPhyColumnId KeyColumns = 4;
+    optional uint32 SysViewType = 5;           // NKikimrSysView::ESysViewType
 }
 
 message TKqpPhyParamValue {

--- a/ydb/core/protos/sys_view_types.proto
+++ b/ydb/core/protos/sys_view_types.proto
@@ -36,4 +36,5 @@ enum ESysViewType {
     EPgTables = 31;
     EInformationSchemaTables = 32;
     EPgClass = 33;
+    EShowCreate = 34;
 }

--- a/ydb/core/protos/tx_datashard.proto
+++ b/ydb/core/protos/tx_datashard.proto
@@ -13,6 +13,7 @@ import "ydb/core/protos/tx.proto";
 import "ydb/core/protos/flat_scheme_op.proto";
 import "ydb/core/protos/table_stats.proto";
 import "ydb/core/protos/subdomains.proto";
+import "ydb/core/protos/sys_view_types.proto";
 import "ydb/core/protos/query_stats.proto";
 import "ydb/public/api/protos/ydb_issue_message.proto";
 import "ydb/public/api/protos/ydb_status_codes.proto";
@@ -152,6 +153,7 @@ message TKqpTransaction {
         // reserved 4
         optional string SysViewInfo = 5;
         optional uint32 TableKind = 6;      // NKikimr::NKqp::ETableKind
+        optional NKikimrSysView.ESysViewType SysViewType = 7;
     }
 
     // Data-query task meta

--- a/ydb/core/sys_view/partition_stats/top_partitions.cpp
+++ b/ydb/core/sys_view/partition_stats/top_partitions.cpp
@@ -3,6 +3,10 @@
 #include <ydb/core/sys_view/common/events.h>
 #include <ydb/core/sys_view/common/processor_scan.h>
 
+namespace {
+    using NKikimrSysView::ESysViewType;
+}
+
 namespace NKikimr::NSysView {
 
 using namespace NActors;
@@ -60,7 +64,7 @@ struct TTopPartitionsByCpuExtractorMap :
         }});
         insert({S::FollowerId::ColumnId, [] (const E& entry) {
             return TCell::Make<ui32>(entry.GetInfo().GetFollowerId());
-        }});        
+        }});
     }
 };
 
@@ -107,12 +111,13 @@ struct TTopPartitionsByTliExtractorMap :
         }});
         insert({S::FollowerId::ColumnId, [] (const E& entry) {
             return TCell::Make<ui32>(entry.GetInfo().GetFollowerId());
-        }});        
+        }});
     }
 };
 
 THolder<NActors::IActor> CreateTopPartitionsByCpuScan(const NActors::TActorId& ownerId, ui32 scanId, const TTableId& tableId,
-    const TTableRange& tableRange, const TArrayRef<NMiniKQL::TKqpComputeContextBase::TColumn>& columns)
+    const ESysViewType sysViewType, const TTableRange& tableRange,
+    const TArrayRef<NMiniKQL::TKqpComputeContextBase::TColumn>& columns)
 {
     using TTopPartitionsByCpuScan = TProcessorScan<
         NKikimrSysView::TTopPartitionsEntry,
@@ -125,19 +130,20 @@ THolder<NActors::IActor> CreateTopPartitionsByCpuScan(const NActors::TActorId& o
         ui32
     >;
 
-    static const std::map<TStringBuf, NKikimrSysView::EStatsType> nameToStatus = {
-        {TopPartitionsByCpu1MinuteName, NKikimrSysView::TOP_PARTITIONS_BY_CPU_ONE_MINUTE},
-        {TopPartitionsByCpu1HourName, NKikimrSysView::TOP_PARTITIONS_BY_CPU_ONE_HOUR},
+    static const std::map<ESysViewType, NKikimrSysView::EStatsType> nameToStatus = {
+        {ESysViewType::ETopPartitionsByCpuOneMinute, NKikimrSysView::TOP_PARTITIONS_BY_CPU_ONE_MINUTE},
+        {ESysViewType::ETopPartitionsByCpuOneHour, NKikimrSysView::TOP_PARTITIONS_BY_CPU_ONE_HOUR},
     };
 
-    auto statusIter = nameToStatus.find(tableId.SysViewInfo.ConstRef());
+    auto statusIter = nameToStatus.find(sysViewType);
     Y_ABORT_UNLESS(statusIter != nameToStatus.end());
 
     return MakeHolder<TTopPartitionsByCpuScan>(ownerId, scanId, tableId, tableRange, columns, statusIter->second);
 }
 
 THolder<NActors::IActor> CreateTopPartitionsByTliScan(const NActors::TActorId& ownerId, ui32 scanId, const TTableId& tableId,
-    const TTableRange& tableRange, const TArrayRef<NMiniKQL::TKqpComputeContextBase::TColumn>& columns)
+    const ESysViewType sysViewType, const TTableRange& tableRange,
+    const TArrayRef<NMiniKQL::TKqpComputeContextBase::TColumn>& columns)
 {
     using TTopPartitionsByTliScan = TProcessorScan<
         NKikimrSysView::TTopPartitionsEntry,
@@ -150,12 +156,12 @@ THolder<NActors::IActor> CreateTopPartitionsByTliScan(const NActors::TActorId& o
         ui32
     >;
 
-    static const std::map<TStringBuf, NKikimrSysView::EStatsType> nameToStatus = {
-        {TopPartitionsByTli1MinuteName, NKikimrSysView::TOP_PARTITIONS_BY_TLI_ONE_MINUTE},
-        {TopPartitionsByTli1HourName, NKikimrSysView::TOP_PARTITIONS_BY_TLI_ONE_HOUR},
+    static const std::map<ESysViewType, NKikimrSysView::EStatsType> nameToStatus = {
+        {ESysViewType::ETopPartitionsByTliOneMinute, NKikimrSysView::TOP_PARTITIONS_BY_TLI_ONE_MINUTE},
+        {ESysViewType::ETopPartitionsByTliOneHour, NKikimrSysView::TOP_PARTITIONS_BY_TLI_ONE_HOUR},
     };
 
-    auto statusIter = nameToStatus.find(tableId.SysViewInfo.ConstRef());
+    auto statusIter = nameToStatus.find(sysViewType);
     Y_ABORT_UNLESS(statusIter != nameToStatus.end());
 
     return MakeHolder<TTopPartitionsByTliScan>(ownerId, scanId, tableId, tableRange, columns, statusIter->second);

--- a/ydb/core/sys_view/partition_stats/top_partitions.h
+++ b/ydb/core/sys_view/partition_stats/top_partitions.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <ydb/core/kqp/runtime/kqp_compute.h>
+#include <ydb/core/protos/sys_view_types.pb.h>
 
 #include <ydb/library/actors/core/actor.h>
 #include <ydb/library/actors/core/actorid.h>
@@ -8,10 +9,10 @@
 namespace NKikimr::NSysView {
 
 THolder<NActors::IActor> CreateTopPartitionsByCpuScan(const NActors::TActorId& ownerId, ui32 scanId,
-    const TTableId& tableId, const TTableRange& tableRange,
+    const TTableId& tableId, const NKikimrSysView::ESysViewType sysViewType, const TTableRange& tableRange,
     const TArrayRef<NMiniKQL::TKqpComputeContextBase::TColumn>& columns);
 
 THolder<NActors::IActor> CreateTopPartitionsByTliScan(const NActors::TActorId& ownerId, ui32 scanId,
-    const TTableId& tableId, const TTableRange& tableRange,
-    const TArrayRef<NMiniKQL::TKqpComputeContextBase::TColumn>& columns);    
+    const TTableId& tableId, const NKikimrSysView::ESysViewType sysViewType, const TTableRange& tableRange,
+    const TArrayRef<NMiniKQL::TKqpComputeContextBase::TColumn>& columns);
 } // NKikimr::NSysView

--- a/ydb/core/sys_view/query_stats/query_stats.cpp
+++ b/ydb/core/sys_view/query_stats/query_stats.cpp
@@ -17,6 +17,10 @@
 #include <ydb/library/actors/core/hfunc.h>
 #include <ydb/library/actors/core/log.h>
 
+namespace {
+    using NKikimrSysView::ESysViewType;
+}
+
 namespace NKikimr {
 namespace NSysView {
 
@@ -504,50 +508,44 @@ private:
 };
 
 THolder<NActors::IActor> CreateQueryStatsScan(const NActors::TActorId& ownerId, ui32 scanId, const TTableId& tableId,
-    const TTableRange& tableRange, const TArrayRef<NMiniKQL::TKqpComputeContextBase::TColumn>& columns)
+    const ESysViewType sysViewType, const TTableRange& tableRange, const TArrayRef<NMiniKQL::TKqpComputeContextBase::TColumn>& columns)
 {
-    auto viewName = tableId.SysViewInfo;
-
-    if (viewName == TopQueriesByDuration1MinuteName) {
+    switch (sysViewType) {
+    case ESysViewType::ETopQueriesByDurationOneMinute:
         return MakeHolder<TQueryStatsScan<TDurationGreater>>(ownerId, scanId, tableId, tableRange, columns,
             NKikimrSysView::TOP_DURATION_ONE_MINUTE,
             ONE_MINUTE_BUCKET_COUNT, ONE_MINUTE_BUCKET_SIZE);
-
-    } else if (viewName == TopQueriesByDuration1HourName) {
+    case ESysViewType::ETopQueriesByDurationOneHour:
         return MakeHolder<TQueryStatsScan<TDurationGreater>>(ownerId, scanId, tableId, tableRange, columns,
             NKikimrSysView::TOP_DURATION_ONE_HOUR,
             ONE_HOUR_BUCKET_COUNT, ONE_HOUR_BUCKET_SIZE);
-
-    } else if (viewName == TopQueriesByReadBytes1MinuteName) {
+    case ESysViewType::ETopQueriesByReadBytesOneMinute:
         return MakeHolder<TQueryStatsScan<TReadBytesGreater>>(ownerId, scanId, tableId, tableRange, columns,
             NKikimrSysView::TOP_READ_BYTES_ONE_MINUTE,
             ONE_MINUTE_BUCKET_COUNT, ONE_MINUTE_BUCKET_SIZE);
-
-    } else if (viewName == TopQueriesByReadBytes1HourName) {
+    case ESysViewType::ETopQueriesByReadBytesOneHour:
         return MakeHolder<TQueryStatsScan<TReadBytesGreater>>(ownerId, scanId, tableId, tableRange, columns,
             NKikimrSysView::TOP_READ_BYTES_ONE_HOUR,
             ONE_HOUR_BUCKET_COUNT, ONE_HOUR_BUCKET_SIZE);
-
-    } else if (viewName == TopQueriesByCpuTime1MinuteName) {
+    case ESysViewType::ETopQueriesByCpuTimeOneMinute:
         return MakeHolder<TQueryStatsScan<TCpuTimeGreater>>(ownerId, scanId, tableId, tableRange, columns,
             NKikimrSysView::TOP_CPU_TIME_ONE_MINUTE,
             ONE_MINUTE_BUCKET_COUNT, ONE_MINUTE_BUCKET_SIZE);
-
-    } else if (viewName == TopQueriesByCpuTime1HourName) {
+    case ESysViewType::ETopQueriesByCpuTimeOneHour:
         return MakeHolder<TQueryStatsScan<TCpuTimeGreater>>(ownerId, scanId, tableId, tableRange, columns,
             NKikimrSysView::TOP_CPU_TIME_ONE_HOUR,
             ONE_HOUR_BUCKET_COUNT, ONE_HOUR_BUCKET_SIZE);
-    } else if (viewName == TopQueriesByRequestUnits1MinuteName) {
+    case ESysViewType::ETopQueriesByRequestUnitsOneMinute:
         return MakeHolder<TQueryStatsScan<TRequestUnitsGreater>>(ownerId, scanId, tableId, tableRange, columns,
             NKikimrSysView::TOP_REQUEST_UNITS_ONE_MINUTE,
             ONE_MINUTE_BUCKET_COUNT, ONE_MINUTE_BUCKET_SIZE);
-
-    } else if (viewName == TopQueriesByRequestUnits1HourName) {
+    case ESysViewType::ETopQueriesByRequestUnitsOneHour:
         return MakeHolder<TQueryStatsScan<TRequestUnitsGreater>>(ownerId, scanId, tableId, tableRange, columns,
             NKikimrSysView::TOP_REQUEST_UNITS_ONE_HOUR,
             ONE_HOUR_BUCKET_COUNT, ONE_HOUR_BUCKET_SIZE);
+    default:
+        return {};
     }
-    return {};
 }
 
 } // NSysView

--- a/ydb/core/sys_view/query_stats/query_stats.h
+++ b/ydb/core/sys_view/query_stats/query_stats.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <ydb/core/kqp/runtime/kqp_compute.h>
+#include <ydb/core/protos/sys_view_types.pb.h>
 
 #include <ydb/library/actors/core/actor.h>
 #include <ydb/library/actors/core/actorid.h>
@@ -21,7 +22,8 @@ struct TQueryStatsBucketRange {
 };
 
 THolder<NActors::IActor> CreateQueryStatsScan(const NActors::TActorId& ownerId, ui32 scanId, const TTableId& tableId,
-    const TTableRange& tableRange, const TArrayRef<NMiniKQL::TKqpComputeContextBase::TColumn>& columns);
+    const NKikimrSysView::ESysViewType sysViewType, const TTableRange& tableRange,
+    const TArrayRef<NMiniKQL::TKqpComputeContextBase::TColumn>& columns);
 
 } // NSysView
 } // NKikimr

--- a/ydb/core/sys_view/scan.cpp
+++ b/ydb/core/sys_view/scan.cpp
@@ -33,6 +33,57 @@
 namespace NKikimr {
 namespace NSysView {
 
+namespace {
+    using NKikimrSysView::ESysViewType;
+
+    const THashMap<TStringBuf, ESysViewType> SYS_VIEW_TYPES_MAP = {
+        {PartitionStatsName, ESysViewType::EPartitionStats},
+        {NodesName, ESysViewType::ENodes},
+
+        {TopQueriesByDuration1MinuteName, ESysViewType::ETopQueriesByDurationOneMinute},
+        {TopQueriesByDuration1HourName, ESysViewType::ETopQueriesByDurationOneHour},
+        {TopQueriesByReadBytes1MinuteName, ESysViewType::ETopQueriesByReadBytesOneMinute},
+        {TopQueriesByReadBytes1HourName, ESysViewType::ETopQueriesByReadBytesOneHour},
+        {TopQueriesByCpuTime1MinuteName, ESysViewType::ETopQueriesByCpuTimeOneMinute},
+        {TopQueriesByCpuTime1HourName, ESysViewType::ETopQueriesByCpuTimeOneHour},
+        {TopQueriesByRequestUnits1MinuteName, ESysViewType::ETopQueriesByRequestUnitsOneMinute},
+        {TopQueriesByRequestUnits1HourName, ESysViewType::ETopQueriesByRequestUnitsOneHour},
+
+        {QuerySessions, ESysViewType::EQuerySessions},
+
+        {PDisksName, ESysViewType::EPDisks},
+        {VSlotsName, ESysViewType::EVSlots},
+        {GroupsName, ESysViewType::EGroups},
+        {StoragePoolsName, ESysViewType::EStoragePools},
+        {StorageStatsName, ESysViewType::EStorageStats},
+
+        {TabletsName, ESysViewType::ETablets},
+
+        {QueryMetricsName, ESysViewType::EQueryMetricsOneMinute},
+
+        {TopPartitionsByCpu1MinuteName, ESysViewType::ETopPartitionsByCpuOneMinute},
+        {TopPartitionsByCpu1HourName, ESysViewType::ETopPartitionsByCpuOneHour},
+        {TopPartitionsByTli1MinuteName, ESysViewType::ETopPartitionsByTliOneMinute},
+        {TopPartitionsByTli1HourName, ESysViewType::ETopPartitionsByTliOneHour},
+
+        {PgTablesName, ESysViewType::EPgTables},
+        {InformationSchemaTablesName, ESysViewType::EInformationSchemaTables},
+        {PgClassName, ESysViewType::EPgClass},
+
+        {ResourcePoolClassifiersName, ESysViewType::EResourcePoolClassifiers},
+        {ResourcePoolsName, ESysViewType::EResourcePools},
+
+        {NAuth::UsersName, ESysViewType::EAuthUsers},
+        {NAuth::GroupsName, ESysViewType::EAuthGroups},
+        {NAuth::GroupMembersName, ESysViewType::EAuthGroupMembers},
+        {NAuth::OwnersName, ESysViewType::EAuthOwners},
+        {NAuth::PermissionsName, ESysViewType::EAuthPermissions},
+        {NAuth::EffectivePermissionsName, ESysViewType::EAuthEffectivePermissions},
+
+        {ShowCreateName, ESysViewType::EShowCreate}
+    };
+}
+
 class TSysViewRangesReader : public TActor<TSysViewRangesReader> {
 public:
     using TBase = TActor<TSysViewRangesReader>;
@@ -42,6 +93,7 @@ public:
         ui32 scanId,
         const TTableId& tableId,
         const TString& tablePath,
+        const TMaybe<ESysViewType>& sysViewType,
         TVector<TSerializedTableRange> ranges,
         const TArrayRef<NMiniKQL::TKqpComputeContextBase::TColumn>& columns,
         TIntrusiveConstPtr<NACLib::TUserToken> userToken,
@@ -52,6 +104,7 @@ public:
         , ScanId(scanId)
         , TableId(tableId)
         , TablePath(tablePath)
+        , SysViewType(sysViewType)
         , Ranges(std::move(ranges))
         , Columns(columns.begin(), columns.end())
         , UserToken(std::move(userToken))
@@ -90,7 +143,7 @@ public:
         if (!ScanActorId) {
             if (CurrentRange < Ranges.size()) {
                 auto actor = CreateSystemViewScan(
-                    SelfId(), ScanId, TableId, TablePath, Ranges[CurrentRange].ToTableRange(),
+                    SelfId(), ScanId, TableId, TablePath, SysViewType, Ranges[CurrentRange].ToTableRange(),
                     Columns, UserToken, Database, Reverse);
                 ScanActorId = Register(actor.Release());
                 CurrentRange += 1;
@@ -152,6 +205,7 @@ private:
     ui32 ScanId;
     TTableId TableId;
     TString TablePath;
+    const TMaybe<ESysViewType> SysViewType;
     TVector<TSerializedTableRange> Ranges;
     TVector<NMiniKQL::TKqpComputeContextBase::TColumn> Columns;
     const TIntrusiveConstPtr<NACLib::TUserToken> UserToken;
@@ -167,6 +221,7 @@ THolder<NActors::IActor> CreateSystemViewScan(
     ui32 scanId,
     const TTableId& tableId,
     const TString& tablePath,
+    const TMaybe<ESysViewType>& sysViewType,
     TVector<TSerializedTableRange> ranges,
     const TArrayRef<NMiniKQL::TKqpComputeContextBase::TColumn>& columns,
     TIntrusiveConstPtr<NACLib::TUserToken> userToken,
@@ -174,9 +229,11 @@ THolder<NActors::IActor> CreateSystemViewScan(
     bool reverse
 ) {
     if (ranges.size() == 1) {
-        return CreateSystemViewScan(ownerId, scanId, tableId, tablePath, ranges[0].ToTableRange(), columns, std::move(userToken), database, reverse);
+        return CreateSystemViewScan(ownerId, scanId, tableId, tablePath, sysViewType, ranges[0].ToTableRange(),
+                                    columns, std::move(userToken), database, reverse);
     } else {
-        return MakeHolder<TSysViewRangesReader>(ownerId, scanId, tableId, tablePath, ranges, columns, std::move(userToken), database, reverse);
+        return MakeHolder<TSysViewRangesReader>(ownerId, scanId, tableId, tablePath, sysViewType, ranges,
+                                                columns, std::move(userToken), database, reverse);
     }
 }
 
@@ -185,121 +242,86 @@ THolder<NActors::IActor> CreateSystemViewScan(
     ui32 scanId,
     const TTableId& tableId,
     const TString& tablePath,
+    const TMaybe<ESysViewType>& sysViewType,
     const TTableRange& tableRange,
     const TArrayRef<NMiniKQL::TKqpComputeContextBase::TColumn>& columns,
     TIntrusiveConstPtr<NACLib::TUserToken> userToken,
     const TString& database,
     bool reverse
 ) {
-    if (tableId.SysViewInfo == PartitionStatsName) {
+    ESysViewType systemViewType;
+    if (sysViewType) {
+        systemViewType = *sysViewType;
+    } else {
+        auto typesIt = SYS_VIEW_TYPES_MAP.find(tableId.SysViewInfo);
+        Y_ABORT_UNLESS(typesIt != SYS_VIEW_TYPES_MAP.end());
+        systemViewType = typesIt->second;
+    }
+
+    switch (systemViewType) {
+    case ESysViewType::EPartitionStats:
         return CreatePartitionStatsScan(ownerId, scanId, tableId, tableRange, columns);
-    }
-
-    if (tableId.SysViewInfo == NodesName) {
+    case ESysViewType::ENodes:
         return CreateNodesScan(ownerId, scanId, tableId, tableRange, columns);
-    }
-
-    if (tableId.SysViewInfo == QuerySessions) {
+    case ESysViewType::EQuerySessions:
         return CreateSessionsScan(ownerId, scanId, tableId, tableRange, columns);
-    }
-
-    if (tableId.SysViewInfo == TopQueriesByDuration1MinuteName ||
-        tableId.SysViewInfo == TopQueriesByDuration1HourName ||
-        tableId.SysViewInfo == TopQueriesByReadBytes1MinuteName ||
-        tableId.SysViewInfo == TopQueriesByReadBytes1HourName ||
-        tableId.SysViewInfo == TopQueriesByCpuTime1MinuteName ||
-        tableId.SysViewInfo == TopQueriesByCpuTime1HourName ||
-        tableId.SysViewInfo == TopQueriesByRequestUnits1MinuteName ||
-        tableId.SysViewInfo == TopQueriesByRequestUnits1HourName)
-    {
-        return CreateQueryStatsScan(ownerId, scanId, tableId, tableRange, columns);
-    }
-
-    if (tableId.SysViewInfo == PDisksName) {
+    case ESysViewType::ETopQueriesByDurationOneMinute:
+    case ESysViewType::ETopQueriesByDurationOneHour:
+    case ESysViewType::ETopQueriesByReadBytesOneMinute:
+    case ESysViewType::ETopQueriesByReadBytesOneHour:
+    case ESysViewType::ETopQueriesByCpuTimeOneMinute:
+    case ESysViewType::ETopQueriesByCpuTimeOneHour:
+    case ESysViewType::ETopQueriesByRequestUnitsOneMinute:
+    case ESysViewType::ETopQueriesByRequestUnitsOneHour:
+        return CreateQueryStatsScan(ownerId, scanId, tableId, systemViewType, tableRange, columns);
+    case ESysViewType::EPDisks:
         return CreatePDisksScan(ownerId, scanId, tableId, tableRange, columns);
-    }
-
-    if (tableId.SysViewInfo == VSlotsName) {
+    case ESysViewType::EVSlots:
         return CreateVSlotsScan(ownerId, scanId, tableId, tableRange, columns);
-    }
-
-    if (tableId.SysViewInfo == GroupsName) {
+    case ESysViewType::EGroups:
         return CreateGroupsScan(ownerId, scanId, tableId, tableRange, columns);
-    }
-
-    if (tableId.SysViewInfo == StoragePoolsName) {
+    case ESysViewType::EStoragePools:
         return CreateStoragePoolsScan(ownerId, scanId, tableId, tableRange, columns);
-    }
-
-    if (tableId.SysViewInfo == StorageStatsName) {
+    case ESysViewType::EStorageStats:
         return CreateStorageStatsScan(ownerId, scanId, tableId, tableRange, columns);
-    }
-
-    if (tableId.SysViewInfo == TabletsName) {
-        return CreateTabletsScan(ownerId, scanId, tableId, tableRange, columns);
-    }
-
-    if (tableId.SysViewInfo == QueryMetricsName) {
+    case ESysViewType::ETablets:
+         return CreateTabletsScan(ownerId, scanId, tableId, tableRange, columns);
+    case ESysViewType::EQueryMetricsOneMinute:
         return CreateQueryMetricsScan(ownerId, scanId, tableId, tableRange, columns);
-    }
-
-    if (tableId.SysViewInfo == TopPartitionsByCpu1MinuteName ||
-        tableId.SysViewInfo == TopPartitionsByCpu1HourName)
-    {
-        return CreateTopPartitionsByCpuScan(ownerId, scanId, tableId, tableRange, columns);
-    }
-
-    if (tableId.SysViewInfo == TopPartitionsByTli1MinuteName ||
-        tableId.SysViewInfo == TopPartitionsByTli1HourName)
-    {
-        return CreateTopPartitionsByTliScan(ownerId, scanId, tableId, tableRange, columns);
-    }    
-    
-    if (tableId.SysViewInfo == PgTablesName) {
+    case ESysViewType::ETopPartitionsByCpuOneMinute:
+    case ESysViewType::ETopPartitionsByCpuOneHour:
+        return CreateTopPartitionsByCpuScan(ownerId, scanId, tableId, systemViewType, tableRange, columns);
+    case ESysViewType::ETopPartitionsByTliOneMinute:
+    case ESysViewType::ETopPartitionsByTliOneHour:
+        return CreateTopPartitionsByTliScan(ownerId, scanId, tableId, systemViewType, tableRange, columns);
+    case ESysViewType::EPgTables:
         return CreatePgTablesScan(ownerId, scanId, tableId, tablePath, tableRange, columns);
-    }
-
-    if (tableId.SysViewInfo == InformationSchemaTablesName) {
+    case ESysViewType::EInformationSchemaTables:
         return CreateInformationSchemaTablesScan(ownerId, scanId, tableId, tablePath, tableRange, columns);
-    }
-
-    if (tableId.SysViewInfo == PgClassName) {
+    case ESysViewType::EPgClass:
         return CreatePgClassScan(ownerId, scanId, tableId, tablePath, tableRange, columns);
-    }
-
-    if (tableId.SysViewInfo == ResourcePoolClassifiersName) {
-        return CreateResourcePoolClassifiersScan(ownerId, scanId, tableId, tableRange, columns, std::move(userToken), database, reverse);
-    }
-
-    if (tableId.SysViewInfo == ResourcePoolsName) {
+    case ESysViewType::EResourcePoolClassifiers:
+        return CreateResourcePoolClassifiersScan(ownerId, scanId, tableId, tableRange, columns,
+                                                 std::move(userToken), database, reverse);
+    case ESysViewType::EResourcePools:
         return CreateResourcePoolsScan(ownerId, scanId, tableId, tableRange, columns, std::move(userToken), database, reverse);
-    }
-
-    {
-        using namespace NAuth;
-        if (tableId.SysViewInfo == UsersName) {
-            return CreateUsersScan(ownerId, scanId, tableId, tableRange, columns, std::move(userToken));
-        }
-        if (tableId.SysViewInfo == NAuth::GroupsName) {
-            return NAuth::CreateGroupsScan(ownerId, scanId, tableId, tableRange, columns, std::move(userToken));
-        }
-        if (tableId.SysViewInfo == GroupMembersName) {
-            return NAuth::CreateGroupMembersScan(ownerId, scanId, tableId, tableRange, columns, std::move(userToken));
-        }
-        if (tableId.SysViewInfo == OwnersName) {
-            return NAuth::CreateOwnersScan(ownerId, scanId, tableId, tableRange, columns, std::move(userToken));
-        }
-        if (tableId.SysViewInfo == PermissionsName || tableId.SysViewInfo == EffectivePermissionsName) {
-            return NAuth::CreatePermissionsScan(tableId.SysViewInfo == EffectivePermissionsName,
-                ownerId, scanId, tableId, tableRange, columns, std::move(userToken));
-        }
-    }
-
-    if (tableId.SysViewInfo == ShowCreateName) {
+    case ESysViewType::EAuthUsers:
+        return NAuth::CreateUsersScan(ownerId, scanId, tableId, tableRange, columns, std::move(userToken));
+    case ESysViewType::EAuthGroups:
+        return NAuth::CreateGroupsScan(ownerId, scanId, tableId, tableRange, columns, std::move(userToken));
+    case ESysViewType::EAuthGroupMembers:
+        return NAuth::CreateGroupMembersScan(ownerId, scanId, tableId, tableRange, columns, std::move(userToken));
+    case ESysViewType::EAuthOwners:
+        return NAuth::CreateOwnersScan(ownerId, scanId, tableId, tableRange, columns, std::move(userToken));
+    case ESysViewType::EAuthPermissions:
+    case ESysViewType::EAuthEffectivePermissions:
+        return NAuth::CreatePermissionsScan(systemViewType == ESysViewType::EAuthEffectivePermissions,
+                                            ownerId, scanId, tableId, tableRange, columns, std::move(userToken));
+    case ESysViewType::EShowCreate:
         return CreateShowCreate(ownerId, scanId, tableId, tableRange, columns, database, std::move(userToken));
+    default:
+        return {};
     }
-
-    return {};
 }
 
 } // NSysView

--- a/ydb/core/sys_view/scan.h
+++ b/ydb/core/sys_view/scan.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <ydb/core/kqp/runtime/kqp_compute.h>
+#include <ydb/core/protos/sys_view_types.pb.h>
 
 #include <ydb/library/actors/core/actor.h>
 
@@ -8,12 +9,14 @@ namespace NKikimr {
 namespace NSysView {
 
 THolder<NActors::IActor> CreateSystemViewScan(const NActors::TActorId& ownerId, ui32 scanId, const TTableId& tableId,
-    const TString& tablePath, TVector<TSerializedTableRange> ranges, const TArrayRef<NMiniKQL::TKqpComputeContextBase::TColumn>& columns,
-    TIntrusiveConstPtr<NACLib::TUserToken> userToken, const TString& database, bool reverse);
+    const TString& tablePath, const TMaybe<NKikimrSysView::ESysViewType>& sysViewType, TVector<TSerializedTableRange> ranges,
+    const TArrayRef<NMiniKQL::TKqpComputeContextBase::TColumn>& columns, TIntrusiveConstPtr<NACLib::TUserToken> userToken,
+    const TString& database, bool reverse);
 
 THolder<NActors::IActor> CreateSystemViewScan(const NActors::TActorId& ownerId, ui32 scanId, const TTableId& tableId,
-    const TString& tablePath, const TTableRange& tableRange, const TArrayRef<NMiniKQL::TKqpComputeContextBase::TColumn>& columns,
-    TIntrusiveConstPtr<NACLib::TUserToken> userToken, const TString& database, bool reverse);
+    const TString& tablePath, const TMaybe<NKikimrSysView::ESysViewType>& sysViewType, const TTableRange& tableRange,
+    const TArrayRef<NMiniKQL::TKqpComputeContextBase::TColumn>& columns, TIntrusiveConstPtr<NACLib::TUserToken> userToken,
+    const TString& database, bool reverse);
 
 } // NSysView
 } // NKikimr


### PR DESCRIPTION
This PR is one of series aimed to add sys view path records in SchemeShard.
This records contains a sys view type which means what implementation of sys view has to be chosen.
To migrate from the string field SysViewInfo to enum value the next changes are needed:
- Fill table metadata for new sys view materialized path type
- Pass sys view type to KQP to fill a task meta (through table resolving and store in stage info)
- Translate string values represented sys view to enum values and choose implementation based on them