### PR TITLE
Compatibility: also test 25-1 + 24-4

### DIFF
--- a/ydb/tests/library/compatibility/binaries/downloader/__main__.py
+++ b/ydb/tests/library/compatibility/binaries/downloader/__main__.py
@@ -20,11 +20,15 @@ def main():
     s3_bucket = AWS_BUCKET
     remote_src = sys.argv[1]
     local_dst = sys.argv[2]
+    binary_name = sys.argv[3]
     s3_client.download_file(s3_bucket, remote_src, local_dst)
 
     # chmod +x
     st = os.stat(local_dst)
     os.chmod(local_dst, st.st_mode | stat.S_IEXEC)
+
+    with open(local_dst + "-name", "w") as f:
+        f.write(binary_name)
 
 
 if __name__ == "__main__":

--- a/ydb/tests/library/compatibility/binaries/ya.make
+++ b/ydb/tests/library/compatibility/binaries/ya.make
@@ -3,13 +3,13 @@ RECURSE(downloader)
 UNION()
 
 RUN_PROGRAM(
-    ydb/tests/library/compatibility/binaries/downloader stable-25-1/release/ydbd ydbd-last-stable
-    OUT_NOAUTO ydbd-last-stable
+    ydb/tests/library/compatibility/binaries/downloader stable-25-1/release/ydbd ydbd-last-stable 25-1
+    OUT_NOAUTO ydbd-last-stable ydbd-last-stable-name
 )
 
 RUN_PROGRAM(
-    ydb/tests/library/compatibility/binaries/downloader stable-24-4/release/ydbd ydbd-prelast-stable
-    OUT_NOAUTO ydbd-prelast-stable
+    ydb/tests/library/compatibility/binaries/downloader stable-24-4/release/ydbd ydbd-prelast-stable 24-4
+    OUT_NOAUTO ydbd-prelast-stable ydbd-prelast-stable-name
 )
 
 END()

--- a/ydb/tests/library/compatibility/fixtures.py
+++ b/ydb/tests/library/compatibility/fixtures.py
@@ -37,10 +37,9 @@ all_binary_combinations_ids_restart = [
     current_name + "_to_" + last_stable_name,
     current_name + "_to_" + current_name,
 
-
-    last_stable_name + "_to_" + current_name,
-    current_name + "_to_" + last_stable_name,
-    current_name + "_to_" + current_name,
+    prelast_stable_name + "_to_" + last_stable_name,
+    last_stable_name + "_to_" + prelast_stable_name,
+    last_stable_name + "_to_" + last_stable_name,
 ]
 
 

--- a/ydb/tests/library/compatibility/fixtures.py
+++ b/ydb/tests/library/compatibility/fixtures.py
@@ -14,6 +14,11 @@ current_binary_path = kikimr_driver_path()
 last_stable_binary_path = yatest.common.binary_path("ydb/tests/library/compatibility/binaries/ydbd-last-stable")
 prelast_stable_binary_path = yatest.common.binary_path("ydb/tests/library/compatibility/binaries/ydbd-prelast-stable")
 
+current_name = "current"
+last_stable_name = open(yatest.common.binary_path("ydb/tests/library/compatibility/binaries/ydbd-last-stable-name")).read().strip()
+prelast_stable_name = open(yatest.common.binary_path("ydb/tests/library/compatibility/binaries/ydbd-prelast-stable-name")).read().strip()
+
+
 all_binary_combinations_restart = [
     [[last_stable_binary_path], [current_binary_path]],
     [[current_binary_path], [last_stable_binary_path]],
@@ -24,13 +29,14 @@ all_binary_combinations_restart = [
     [[last_stable_binary_path], [last_stable_binary_path]],
 ]
 all_binary_combinations_ids_restart = [
-    "last_stable_to_current",
-    "current_to_last_stable",
-    "current_to_current",
+    last_stable_name + "_to_" + current_name,
+    current_name + "_to_" + last_stable_name,
+    current_name + "_to_" + current_name,
 
-    "prelast_stable_to_last_stable",
-    "last_stable_to_prelast_stable",
-    "last_stable_to_last_stable",
+
+    last_stable_name + "_to_" + current_name,
+    current_name + "_to_" + last_stable_name,
+    current_name + "_to_" + current_name,
 ]
 
 
@@ -91,10 +97,10 @@ all_binary_combinations_mixed = [
     [last_stable_binary_path, prelast_stable_binary_path],
 ]
 all_binary_combinations_ids_mixed = [
-    "current",
-    "last_stable",
-    "current_and_last_stable",
-    "last_stable_and_prelast_stable",
+    current_name,
+    last_stable_name,
+    current_name + "_and_" + last_stable_name,
+    last_stable_name + "_and_" + prelast_stable_name,
 ]
 
 
@@ -130,8 +136,8 @@ all_binary_combinations_rolling = [
     [prelast_stable_binary_path, last_stable_binary_path],
 ]
 all_binary_combinations_ids_rolling = [
-    "last_stable_to_current",
-    "prelast_stable_to_last_stable",
+    last_stable_name + "_to_" + current_name,
+    prelast_stable_name + "_to_" + last_stable_name,
 ]
 
 

--- a/ydb/tests/library/compatibility/fixtures.py
+++ b/ydb/tests/library/compatibility/fixtures.py
@@ -15,8 +15,12 @@ last_stable_binary_path = yatest.common.binary_path("ydb/tests/library/compatibi
 prelast_stable_binary_path = yatest.common.binary_path("ydb/tests/library/compatibility/binaries/ydbd-prelast-stable")
 
 current_name = "current"
-last_stable_name = open(yatest.common.binary_path("ydb/tests/library/compatibility/binaries/ydbd-last-stable-name")).read().strip()
-prelast_stable_name = open(yatest.common.binary_path("ydb/tests/library/compatibility/binaries/ydbd-prelast-stable-name")).read().strip()
+last_stable_name = None
+if last_stable_binary_path is not None:  # in import_test yatest.common.binary_path returns None
+    last_stable_name = open(yatest.common.binary_path("ydb/tests/library/compatibility/binaries/ydbd-last-stable-name")).read().strip()
+prelast_stable_name = None
+if prelast_stable_binary_path:  # in import_test yatest.common.binary_path returns None
+    prelast_stable_name = open(yatest.common.binary_path("ydb/tests/library/compatibility/binaries/ydbd-prelast-stable-name")).read().strip()
 
 
 all_binary_combinations_restart = [

--- a/ydb/tests/library/compatibility/fixtures.py
+++ b/ydb/tests/library/compatibility/fixtures.py
@@ -15,10 +15,10 @@ last_stable_binary_path = yatest.common.binary_path("ydb/tests/library/compatibi
 prelast_stable_binary_path = yatest.common.binary_path("ydb/tests/library/compatibility/binaries/ydbd-prelast-stable")
 
 current_name = "current"
-last_stable_name = None
+last_stable_name = "last"
 if last_stable_binary_path is not None:  # in import_test yatest.common.binary_path returns None
     last_stable_name = open(yatest.common.binary_path("ydb/tests/library/compatibility/binaries/ydbd-last-stable-name")).read().strip()
-prelast_stable_name = None
+prelast_stable_name = "prelast"
 if prelast_stable_binary_path:  # in import_test yatest.common.binary_path returns None
     prelast_stable_name = open(yatest.common.binary_path("ydb/tests/library/compatibility/binaries/ydbd-prelast-stable-name")).read().strip()
 


### PR DESCRIPTION
This PR expands compatibility testing by adding support for testing binaries 25-1 and 24-4 and updates parameter naming to improve clarity.

Introduces new binary paths and associated names for prelast stable versions.
Updates test fixtures and downloader scripts to accommodate the new arguments and binary naming.

#18603
