### PR TITLE
[docs] backport #18177 to stable-25-1

### DIFF
--- a/ydb/docs/en/core/public-materials/_includes/conferences/2024/coscup.md
+++ b/ydb/docs/en/core/public-materials/_includes/conferences/2024/coscup.md
@@ -4,7 +4,7 @@
 
 PostgreSQL is an implementation of SQL standard with one of the most vibrant ecosystems around it. To leverage all the tools and libraries that already know how to work with PostgreSQL, emerging database management systems that bring something new to the market need to learn how to mimic PostgreSQL. In this talk at [COSCUP 2024](https://coscup.org/2024/en/session/XZ98GN) [{{ team.blinkov.name }}]({{ team.blinkov.profile }}) ({{ team.blinkov.position }}) explores possible approaches to this and related trade-offs, as well as reasoning why YDB chose a unique approach to bring serializable consistency and seamless scalability to the PostgreSQL ecosystem.
 
-@[YouTube](https://youtu.be/84t_6jV2m5E?si=z3YrrRaCvifSo6JN)
+{% include [no_video](../../no_video.md) %}
 
 The presentation is suitable for people interested in trade-offs during implementation of PostgreSQL-compatible DBMS.
 


### PR DESCRIPTION
Backports changes from:
* #18177

to `stable-25-1`.

### Changelog category <!-- remove all except one -->

* Documentation (changelog entry is not required)
