### PR TITLE
Fixed a backward compatibility issue for PQv0

### DIFF
--- a/ydb/core/persqueue/read_balancer__balancing.cpp
+++ b/ydb/core/persqueue/read_balancer__balancing.cpp
@@ -552,6 +552,7 @@ std::unique_ptr<TEvPersQueue::TEvReleasePartition> TPartitionFamily::MakeEvRelea
     auto& r = res->Record;
 
     r.SetSession(Session->SessionName);
+    r.SetCount(1);
     r.SetTopic(Topic());
     r.SetPath(TopicPath());
     r.SetGeneration(TabletGeneration());

--- a/ydb/core/protos/pqconfig.proto
+++ b/ydb/core/protos/pqconfig.proto
@@ -653,7 +653,7 @@ message TReleasePartition {
     optional uint64 Generation = 2;
     optional string Session = 3;
     optional string ClientId = 4;
-    reserved 5; // optional uint32 Count = 5;
+    optional uint32 Count = 5;
     optional NActorsProto.TActorId PipeClient = 6;
     optional uint32 Group = 7;
     optional string Path = 8;


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

The balancing of the read session was broken if storage nodes have the version 24-4 and dynamic node have the version 25-1

### Changelog category <!-- remove all except one -->

* Bugfix 

### Description for reviewers <!-- (optional) description for those who read this PR -->

LBREQUESTS-4384
