### PR TITLE
WaitInput/OutputTimes for Reads from CS

### DIFF
--- a/ydb/core/kqp/compute_actor/kqp_pure_compute_actor.cpp
+++ b/ydb/core/kqp/compute_actor/kqp_pure_compute_actor.cpp
@@ -119,7 +119,7 @@ void TKqpComputeActor::DoBootstrap() {
 
     if (ScanData) {
         ScanData->TaskId = GetTask().GetId();
-        ScanData->TableReader = CreateKqpTableReader(*ScanData, *ComputeCtx.StartTs, ComputeCtx.InputConsumed);
+        ScanData->TableReader = CreateKqpTableReader(*ScanData, *ComputeCtx.StartTs, *ComputeCtx.InputConsumed);
 
         auto scanActor = NSysView::CreateSystemViewScan(SelfId(), 0, ScanData->TableId, ScanData->TablePath, ranges, columns, UserToken, Database, reverse);
 

--- a/ydb/core/kqp/compute_actor/kqp_pure_compute_actor.cpp
+++ b/ydb/core/kqp/compute_actor/kqp_pure_compute_actor.cpp
@@ -119,7 +119,7 @@ void TKqpComputeActor::DoBootstrap() {
 
     if (ScanData) {
         ScanData->TaskId = GetTask().GetId();
-        ScanData->TableReader = CreateKqpTableReader(*ScanData);
+        ScanData->TableReader = CreateKqpTableReader(*ScanData, *ComputeCtx.StartTs, ComputeCtx.InputConsumed);
 
         auto scanActor = NSysView::CreateSystemViewScan(SelfId(), 0, ScanData->TableId, ScanData->TablePath, ranges, columns, UserToken, Database, reverse);
 

--- a/ydb/core/kqp/compute_actor/kqp_scan_compute_actor.cpp
+++ b/ydb/core/kqp/compute_actor/kqp_scan_compute_actor.cpp
@@ -279,7 +279,7 @@ void TKqpScanComputeActor::DoBootstrap() {
     ScanData = &ComputeCtx.GetTableScan(0);
 
     ScanData->TaskId = GetTask().GetId();
-    ScanData->TableReader = CreateKqpTableReader(*ScanData, *ComputeCtx.StartTs, ComputeCtx.InputConsumed);
+    ScanData->TableReader = CreateKqpTableReader(*ScanData, *ComputeCtx.StartTs, *ComputeCtx.InputConsumed);
     Become(&TKqpScanComputeActor::StateFunc);
 
     TBase::DoBoostrap();

--- a/ydb/core/kqp/compute_actor/kqp_scan_events.h
+++ b/ydb/core/kqp/compute_actor/kqp_scan_events.h
@@ -44,6 +44,7 @@ struct TEvScanExchange {
         YDB_READONLY(ui64, TabletId, 0);
         YDB_ACCESSOR_DEF(std::vector<ui32>, DataIndexes);
         YDB_READONLY_DEF(TLocksInfo, LocksInfo);
+        YDB_ACCESSOR_DEF(ui64, WaitOutputTimeUs);
     public:
         ui32 GetRowsCount() const {
             return ArrowBatch ? ArrowBatch->num_rows() : Rows.size();

--- a/ydb/core/kqp/executer_actor/kqp_executer_stats.cpp
+++ b/ydb/core/kqp/executer_actor/kqp_executer_stats.cpp
@@ -578,6 +578,8 @@ ui64 TStageExecutionStats::UpdateStats(const NYql::NDqProto::TDqTaskStats& taskS
                     index, key, partitionStat.GetFirstMessageMs(), false, EPartitionedAggKind::PartitionedAggMin);
                 asyncBufferStats.External.SetNonZero(asyncBufferStats.External.LastMessageMs,
                     index, key, partitionStat.GetLastMessageMs(), false, EPartitionedAggKind::PartitionedAggMax);
+                asyncBufferStats.External.SetNonZero(asyncBufferStats.External.WaitOutputTimeUs,
+                    index, key, partitionStat.GetWaitOutputTimeUs(), false, EPartitionedAggKind::PartitionedAggMax);
             }
         }
     }

--- a/ydb/core/kqp/executer_actor/kqp_executer_stats.h
+++ b/ydb/core/kqp/executer_actor/kqp_executer_stats.h
@@ -76,6 +76,7 @@ struct TExternalStats : public TTimeMultiSeriesStats {
     TPartitionedStats ExternalBytes;
     TPartitionedStats FirstMessageMs;
     TPartitionedStats LastMessageMs;
+    TPartitionedStats WaitOutputTimeUs;
 
     void Resize(ui32 taskCount);
     void SetHistorySampleCount(ui32 historySampleCount);

--- a/ydb/core/kqp/runtime/kqp_scan_data.h
+++ b/ydb/core/kqp/runtime/kqp_scan_data.h
@@ -167,9 +167,9 @@ public:
             return BatchReader->GetColumns();
         }
 
-        void UpdateStats(size_t rows, size_t bytes, TMaybe<ui64> shardId);
-        ui64 AddData(const TVector<TOwnedCellVec>& batch, TMaybe<ui64> shardId, const THolderFactory& holderFactory);
-        ui64 AddData(const TBatchDataAccessor& batch, TMaybe<ui64> shardId, const THolderFactory& holderFactory);
+        void UpdateStats(size_t rows, size_t bytes, TMaybe<ui64> shardId, ui64 waitOutputTime);
+        ui64 AddData(const TVector<TOwnedCellVec>& batch, TMaybe<ui64> shardId, const THolderFactory& holderFactory, ui64 waitOutputTime = 0);
+        ui64 AddData(const TBatchDataAccessor& batch, TMaybe<ui64> shardId, const THolderFactory& holderFactory, ui64 waitOutputTime = 0);
 
         bool IsEmpty() const {
             return BatchReader->IsEmpty();
@@ -203,10 +203,15 @@ public:
             ui64 ExternalBytes = 0;
             ui64 FirstMessageMs = 0;
             ui64 LastMessageMs = 0;
+            ui64 WaitOutputTimeUs = 0;
 
             TExternalStats() = default;
-            TExternalStats(ui64 externalRows, ui64 externalBytes, ui64 firstMessageMs, ui64 lastMessageMs)
-            : ExternalRows(externalRows), ExternalBytes(externalBytes), FirstMessageMs(firstMessageMs), LastMessageMs(lastMessageMs)
+            TExternalStats(ui64 externalRows, ui64 externalBytes, ui64 firstMessageMs, ui64 lastMessageMs, ui64 waitOutputTime)
+                : ExternalRows(externalRows)
+                , ExternalBytes(externalBytes)
+                , FirstMessageMs(firstMessageMs)
+                , LastMessageMs(lastMessageMs)
+                , WaitOutputTimeUs(waitOutputTime)
             {}
         };
 
@@ -412,7 +417,7 @@ private:
     TMap<ui32, TScanData> Scans;
 };
 
-TIntrusivePtr<IKqpTableReader> CreateKqpTableReader(TKqpScanComputeContext::TScanData& scanData);
+TIntrusivePtr<IKqpTableReader> CreateKqpTableReader(TKqpScanComputeContext::TScanData& scanData, TInstant& startTs, bool& inputConsumed);
 
 } // namespace NMiniKQL
 } // namespace NKikimr

--- a/ydb/library/yql/dq/runtime/dq_compute.h
+++ b/ydb/library/yql/dq/runtime/dq_compute.h
@@ -8,7 +8,7 @@ class TDqComputeContextBase : private TNonCopyable {
 public:
     virtual ~TDqComputeContextBase() = default;
 
-    bool InputConsumed = false;
+    bool* InputConsumed = nullptr;
     TInstant* StartTs = nullptr;
 };
 

--- a/ydb/library/yql/dq/runtime/dq_compute.h
+++ b/ydb/library/yql/dq/runtime/dq_compute.h
@@ -7,6 +7,9 @@ namespace NYql::NDq {
 class TDqComputeContextBase : private TNonCopyable {
 public:
     virtual ~TDqComputeContextBase() = default;
+
+    bool InputConsumed = false;
+    TInstant* StartTs = nullptr;
 };
 
 NKikimr::NMiniKQL::TComputationNodeFactory GetDqBaseComputeFactory(const TDqComputeContextBase* computeCtx);

--- a/ydb/public/lib/ydb_cli/common/plan2svg.cpp
+++ b/ydb/public/lib/ydb_cli/common/plan2svg.cpp
@@ -851,9 +851,6 @@ void TPlan::LoadStage(std::shared_ptr<TStage> stage, const NJson::TJsonValue& no
                         externalStage->EgressRows = std::make_shared<TSingleMetric>(ExternalRows, *externalRowsNode);
                         externalStage->Operators.front().OutputRows = std::make_shared<TSingleMetric>(OperatorOutputRows, *externalRowsNode);
                     }
-                    if (auto* wotNode = externalNode->GetValueByPath("ExternalRows")) {
-                        externalStage->WaitOutputTime = std::make_shared<TSingleMetric>(WaitOutputTime, *wotNode);
-                    }
                     if (auto* partitionCountNode = externalNode->GetValueByPath("PartitionCount")) {
                         externalStage->Tasks = partitionCountNode->GetIntegerSafe();
                     }
@@ -1784,27 +1781,6 @@ void TPlan::PrintSvg(ui64 maxTime, ui32 timelineDelta, ui32& offsetY, TStringBui
         }
 
         y0 += INTERNAL_HEIGHT + INTERNAL_GAP_Y;
-
-        if (s->External && s->EgressBytes && s->WaitOutputTime) {
-            auto firstMessage = s->EgressBytes->FirstMessage.Avg;
-            auto lastMessage = s->EgressBytes->LastMessage.Avg;
-            if (lastMessage > firstMessage) {
-                auto durationUs = (lastMessage - firstMessage) * 1000;
-                auto waitUs = s->WaitOutputTime->Details.Avg;
-                if (waitUs) {
-                    auto height = std::min<ui64>(s->Height, s->Height * waitUs / durationUs);
-                    background
-                        << "<g><title>";
-                        FormatTooltip(background, "Wait Output Time", s->WaitOutputTime.get(), FormatUsage);
-                    background
-                        << "</title>" << Endl
-                        << "  <rect x='" << Config.TaskLeft << "' y='" << s->OffsetY + offsetY
-                        << "' width='" << Config.TaskWidth << "' height='" << height
-                        << "' stroke-width='0' fill='" << Config.Palette.OutputLight << "'/>" << Endl
-                        << "</g>" << Endl;
-                }
-            }
-        }
 
         if (s->CpuTime) {
             TString tooltip;


### PR DESCRIPTION
Two things added:

1. WaitInputTime for task for reading with TKqpTableReader (it uses non standard binding to TaskRunner and should be integrated separately)
2. WaitOutputTime for "CS reads" (ScanFetcher). Seems not to be very truthful yet, so is not visualized in SVG