### PR TITLE
Correct deadlock detection over finished tasks

### DIFF
--- a/ydb/core/kqp/executer_actor/kqp_executer_stats.cpp
+++ b/ydb/core/kqp/executer_actor/kqp_executer_stats.cpp
@@ -660,8 +660,15 @@ bool TStageExecutionStats::IsDeadlocked(ui64 deadline) {
     }
 
     for (auto stat : InputStages) {
-        if (stat->CurrentWaitOutputTimeUs.MinValue < deadline || stat->IsFinished()) {
-            return false;
+        if (stat->IsFinished()) {
+            auto finishTimeMs = ExportMaxStats(stat->FinishTimeMs);
+            if (stat->UpdateTimeMs < finishTimeMs || stat->UpdateTimeMs - finishTimeMs < deadline) {
+                return false;
+            }
+        } else {
+            if (stat->CurrentWaitOutputTimeUs.MinValue < deadline) {
+                return false;
+            }
         }
     }
     return true;

--- a/ydb/core/kqp/executer_actor/kqp_executer_stats.cpp
+++ b/ydb/core/kqp/executer_actor/kqp_executer_stats.cpp
@@ -661,8 +661,10 @@ bool TStageExecutionStats::IsDeadlocked(ui64 deadline) {
 
     for (auto stat : InputStages) {
         if (stat->IsFinished()) {
-            auto finishTimeMs = ExportMaxStats(stat->FinishTimeMs);
-            if (stat->UpdateTimeMs < finishTimeMs || stat->UpdateTimeMs - finishTimeMs < deadline) {
+            if (stat->MaxFinishTimeMs == 0) {
+                stat->MaxFinishTimeMs = ExportMaxStats(stat->FinishTimeMs);
+            }
+            if (stat->UpdateTimeMs < stat->MaxFinishTimeMs || stat->UpdateTimeMs - stat->MaxFinishTimeMs < deadline) {
                 return false;
             }
         } else {

--- a/ydb/core/kqp/executer_actor/kqp_executer_stats.h
+++ b/ydb/core/kqp/executer_actor/kqp_executer_stats.h
@@ -227,6 +227,7 @@ struct TStageExecutionStats {
     TMinStats CurrentWaitInputTimeUs;
     TMinStats CurrentWaitOutputTimeUs;
     ui64 UpdateTimeMs = 0;
+    ui64 MaxFinishTimeMs = 0;
 
     TTimeSeriesStats SpillingComputeBytes;
     TTimeSeriesStats SpillingChannelBytes;


### PR DESCRIPTION
Restore deadlock detection when downstream tasks have been finished.

It was false positive and cancelled in #17140, this PR restores detection in reliable way

#17040 