### PR TITLE
Refactor bridge mode info returned in TEvNodeWardenStorageConfig

### DIFF
--- a/ydb/core/base/bridge.h
+++ b/ydb/core/base/bridge.h
@@ -1,0 +1,28 @@
+#pragma once
+
+#include "defs.h"
+#include "blobstorage_common.h"
+
+#include <ydb/core/protos/bridge.pb.h>
+
+namespace NKikimr {
+
+    struct TBridgeInfo {
+        struct TPile {
+            TBridgePileId BridgePileId; // essentially an index into TBridgeInfo::Piles array
+            std::vector<ui32> StaticNodeIds; // a sorted set of static node ids belonging to this very pile
+            NKikimrBridge::TClusterState::EPileState State = {}; // state of this pile
+            bool IsPrimary = false; // is this pile selected as primary
+            bool IsBeingPromoted = false; // is this pile being promoted right now (and not the primary, but in sync with one)
+        };
+
+        THashMap<ui32, const TPile*> StaticNodeIdToPile; // node to pile map for static nodes
+        std::vector<TPile> Piles; // a vector of piles
+        const TPile *SelfNodePile = nullptr; // a reference to pile this node belongs to
+        const TPile *PrimaryPile = nullptr; // a reference to the primary pile
+        const TPile *BeingPromotedPile = nullptr; // a reference to the pile being promoted, or nullptr if none are promoted
+
+        using TPtr = std::shared_ptr<const TBridgeInfo>;
+    };
+
+} // NKikimr

--- a/ydb/core/blobstorage/base/blobstorage_events.cpp
+++ b/ydb/core/blobstorage/base/blobstorage_events.cpp
@@ -5,14 +5,13 @@ namespace NKikimr {
 
     TEvNodeWardenStorageConfig::TEvNodeWardenStorageConfig(const NKikimrBlobStorage::TStorageConfig& config,
             const NKikimrBlobStorage::TStorageConfig *proposedConfig, bool selfManagementEnabled,
-            bool isPrimary, bool isBeingPromoted)
+            TBridgeInfo::TPtr bridgeInfo)
         : Config(std::make_unique<NKikimrBlobStorage::TStorageConfig>(config))
         , ProposedConfig(proposedConfig
             ? std::make_unique<NKikimrBlobStorage::TStorageConfig>(*proposedConfig)
             : nullptr)
         , SelfManagementEnabled(selfManagementEnabled)
-        , IsPrimary(isPrimary)
-        , IsBeingPromoted(isBeingPromoted)
+        , BridgeInfo(std::move(bridgeInfo))
     {}
 
     TEvNodeWardenStorageConfig::~TEvNodeWardenStorageConfig()

--- a/ydb/core/blobstorage/base/blobstorage_events.h
+++ b/ydb/core/blobstorage/base/blobstorage_events.h
@@ -3,6 +3,7 @@
 
 #include "blobstorage_vdiskid.h"
 #include <ydb/core/base/blobstorage.h>
+#include <ydb/core/base/bridge.h>
 #include <ydb/core/blobstorage/groupinfo/blobstorage_groupinfo.h>
 #include <ydb/core/blobstorage/pdisk/blobstorage_pdisk_config.h>
 #include <ydb/core/blobstorage/pdisk/blobstorage_pdisk_defs.h>
@@ -583,12 +584,11 @@ namespace NKikimr {
         std::unique_ptr<NKikimrBlobStorage::TStorageConfig> Config;
         std::unique_ptr<NKikimrBlobStorage::TStorageConfig> ProposedConfig;
         bool SelfManagementEnabled;
-        bool IsPrimary; // if bridge mode is enabled
-        bool IsBeingPromoted; // if bridge mode is enabled
+        TBridgeInfo::TPtr BridgeInfo;
 
         TEvNodeWardenStorageConfig(const NKikimrBlobStorage::TStorageConfig& config,
                 const NKikimrBlobStorage::TStorageConfig *proposedConfig, bool selfManagementEnabled,
-                bool isPrimary, bool isBeingPromoted);
+                TBridgeInfo::TPtr bridgeInfo);
         ~TEvNodeWardenStorageConfig();
     };
 

--- a/ydb/core/blobstorage/nodewarden/distconf.h
+++ b/ydb/core/blobstorage/nodewarden/distconf.h
@@ -175,8 +175,7 @@ namespace NKikimr::NStorage {
         const bool IsSelfStatic = false;
         TIntrusivePtr<TNodeWardenConfig> Cfg;
         bool SelfManagementEnabled = false;
-        bool IsPrimary = false;
-        bool IsBeingPromoted = false;
+        TBridgeInfo::TPtr BridgeInfo;
 
         // currently active storage config
         std::optional<NKikimrBlobStorage::TStorageConfig> StorageConfig;

--- a/ydb/core/blobstorage/nodewarden/node_warden_impl.h
+++ b/ydb/core/blobstorage/nodewarden/node_warden_impl.h
@@ -639,8 +639,7 @@ namespace NKikimr::NStorage {
 
         NKikimrBlobStorage::TStorageConfig StorageConfig;
         bool SelfManagementEnabled = false;
-        bool IsPrimary = false;
-        bool IsBeingPromoted = false;
+        TBridgeInfo::TPtr BridgeInfo;
         THashSet<TActorId> StorageConfigSubscribers;
 
         void Handle(TEvNodeWardenQueryStorageConfig::TPtr ev);

--- a/ydb/core/blobstorage/ut_blobstorage/lib/node_warden_mock_bsc.cpp
+++ b/ydb/core/blobstorage/ut_blobstorage/lib/node_warden_mock_bsc.cpp
@@ -226,7 +226,7 @@ void TNodeWardenMockActor::Handle(TEvBlobStorage::TEvControllerNodeServiceSetUpd
 }
 
 void TNodeWardenMockActor::Handle(TEvNodeWardenQueryStorageConfig::TPtr ev) {
-    Send(ev->Sender, new TEvNodeWardenStorageConfig(NKikimrBlobStorage::TStorageConfig(), nullptr, false, false, false));
+    Send(ev->Sender, new TEvNodeWardenStorageConfig(NKikimrBlobStorage::TStorageConfig(), nullptr, false, nullptr));
 }
 
 void TNodeWardenMockActor::HandleUnsubscribe(STATEFN_SIG) {

--- a/ydb/core/mind/bscontroller/ut_bscontroller/main.cpp
+++ b/ydb/core/mind/bscontroller/ut_bscontroller/main.cpp
@@ -243,7 +243,7 @@ struct TEnvironmentSetup {
             {}
 
             void Handle(TEvNodeWardenQueryStorageConfig::TPtr ev) {
-                Send(ev->Sender, new TEvNodeWardenStorageConfig(NKikimrBlobStorage::TStorageConfig(), nullptr, false, false, false));
+                Send(ev->Sender, new TEvNodeWardenStorageConfig(NKikimrBlobStorage::TStorageConfig(), nullptr, false, nullptr));
             }
 
             STATEFN(StateFunc) {

--- a/ydb/core/mind/bscontroller/ut_selfheal/node_warden_mock.h
+++ b/ydb/core/mind/bscontroller/ut_selfheal/node_warden_mock.h
@@ -180,7 +180,7 @@ public:
     }
 
     void Handle(TEvNodeWardenQueryStorageConfig::TPtr ev) {
-        Send(ev->Sender, new TEvNodeWardenStorageConfig(NKikimrBlobStorage::TStorageConfig(), nullptr, false, false, false));
+        Send(ev->Sender, new TEvNodeWardenStorageConfig(NKikimrBlobStorage::TStorageConfig(), nullptr, false, nullptr));
     }
 
     STRICT_STFUNC(StateFunc, {


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

Refactor bridge mode info returned in TEvNodeWardenStorageConfig

### Changelog category <!-- remove all except one -->

* Not for changelog (changelog entry is not required)

### Description for reviewers <!-- (optional) description for those who read this PR -->

This patch adds more convenient and unpacked structures to process bridge mode configuration and layout in different subsystems.
