### PR TITLE
Fix rolling upgrade fixture

### DIFF
--- a/ydb/tests/library/compatibility/fixtures.py
+++ b/ydb/tests/library/compatibility/fixtures.py
@@ -196,6 +196,7 @@ class RollingUpgradeAndDowngradeFixture:
             erasure=Erasure.MIRROR_3_DC,
             binary_paths=[self.all_binary_paths[0]],
             use_in_memory_pdisks=False,
+            extra_feature_flags=extra_feature_flags,
             **kwargs,
         )
 


### PR DESCRIPTION
This PR fixes the rolling upgrade fixture by adding the forgotten extra_feature_flags parameter.

Adds the missing extra_feature_flags argument to the setup_cluster call.

#18548