### PR TITLE
Fixed port in test debugging

### DIFF
--- a/ydb/tests/library/harness/kikimr_port_allocator.py
+++ b/ydb/tests/library/harness/kikimr_port_allocator.py
@@ -146,6 +146,10 @@ class KikimrPortManagerPortAllocator(KikimrPortAllocatorInterface):
         self.__slots_allocators = []
 
     def get_node_port_allocator(self, node_index):
+        if os.environ.get("YDB_TEST_FIXED_PORT") is not None:
+            # suitable for debugging, don't use in production
+            if node_index == 1:
+                return KikimrFixedNodePortAllocator(0)
         while len(self.__nodes_allocators) <= node_index:
             self.__nodes_allocators.append(KikimrPortManagerNodePortAllocator(self.__port_manager))
         return self.__nodes_allocators[node_index]


### PR DESCRIPTION
This PR aims to support debugging tests by providing a fixed port allocator when the YDB_TEST_FIXED_PORT environment variable is set.