### PR TITLE
Fix prefixed vector index with PK columns (#18196)

### DIFF
--- a/ydb/core/protos/tx_datashard.proto
+++ b/ydb/core/protos/tx_datashard.proto
@@ -1668,6 +1668,8 @@ message TEvPrefixKMeansRequest {
     optional uint32 PrefixColumns = 17;
 
     optional NKikimrIndexBuilder.TIndexBuildScanSettings ScanSettings = 18;
+
+    repeated string SourcePrimaryKeyColumns = 19;
 }
 
 message TEvPrefixKMeansResponse {

--- a/ydb/core/tx/datashard/build_index/kmeans_helper.cpp
+++ b/ydb/core/tx/datashard/build_index/kmeans_helper.cpp
@@ -45,51 +45,22 @@ void AddRowToLevel(TBufferData& buffer, TClusterId parent, TClusterId child, con
     buffer.AddRow(TSerializedCellVec{pk}, TSerializedCellVec::Serialize(data));
 }
 
-void AddRowMainToBuild(TBufferData& buffer, TClusterId parent, TArrayRef<const TCell> key, TArrayRef<const TCell> row) {
-    EnsureNoPostingParentFlag(parent);
+void AddRowToData(TBufferData& buffer, TClusterId parent, TArrayRef<const TCell> sourcePk,
+    TArrayRef<const TCell> dataColumns, TArrayRef<const TCell> origKey, bool isPostingLevel) {
+    if (isPostingLevel) {
+        parent = SetPostingParentFlag(parent);
+    } else {
+        EnsureNoPostingParentFlag(parent);
+    }
 
     std::array<TCell, 1> cells;
     cells[0] = TCell::Make(parent);
     auto pk = TSerializedCellVec::Serialize(cells);
-    TSerializedCellVec::UnsafeAppendCells(key, pk);
-    buffer.AddRow(TSerializedCellVec{std::move(pk)}, TSerializedCellVec::Serialize(row),
-        TSerializedCellVec{key});
-}
+    TSerializedCellVec::UnsafeAppendCells(sourcePk, pk);
 
-void AddRowMainToPosting(TBufferData& buffer, TClusterId parent, TArrayRef<const TCell> key, TArrayRef<const TCell> row, ui32 dataPos)
-{
-    parent = SetPostingParentFlag(parent);
-
-    std::array<TCell, 1> cells;
-    cells[0] = TCell::Make(parent);
-    auto pk = TSerializedCellVec::Serialize(cells);
-    TSerializedCellVec::UnsafeAppendCells(key, pk);
-    buffer.AddRow(TSerializedCellVec{std::move(pk)}, TSerializedCellVec::Serialize(row.Slice(dataPos)),
-        TSerializedCellVec{key});
-}
-
-void AddRowBuildToBuild(TBufferData& buffer, TClusterId parent, TArrayRef<const TCell> key, TArrayRef<const TCell> row, ui32 prefixColumns)
-{
-    EnsureNoPostingParentFlag(parent);
-
-    std::array<TCell, 1> cells;
-    cells[0] = TCell::Make(parent);
-    auto pk = TSerializedCellVec::Serialize(cells);
-    TSerializedCellVec::UnsafeAppendCells(key.Slice(prefixColumns), pk);
-    buffer.AddRow(TSerializedCellVec{std::move(pk)}, TSerializedCellVec::Serialize(row),
-        TSerializedCellVec{key});
-}
-
-void AddRowBuildToPosting(TBufferData& buffer, TClusterId parent, TArrayRef<const TCell> key, TArrayRef<const TCell> row, ui32 dataPos, ui32 prefixColumns)
-{
-    parent = SetPostingParentFlag(parent);
-
-    std::array<TCell, 1> cells;
-    cells[0] = TCell::Make(parent);
-    auto pk = TSerializedCellVec::Serialize(cells);
-    TSerializedCellVec::UnsafeAppendCells(key.Slice(prefixColumns), pk);
-    buffer.AddRow(TSerializedCellVec{std::move(pk)}, TSerializedCellVec::Serialize(row.Slice(dataPos)),
-        TSerializedCellVec{key});
+    buffer.AddRow(TSerializedCellVec{std::move(pk)},
+        TSerializedCellVec::Serialize(dataColumns),
+        TSerializedCellVec{origKey});
 }
 
 TTags MakeScanTags(const TUserTable& table, const TProtoStringType& embedding, 
@@ -114,12 +85,11 @@ TTags MakeScanTags(const TUserTable& table, const TProtoStringType& embedding,
 
 std::shared_ptr<NTxProxy::TUploadTypes> MakeOutputTypes(const TUserTable& table, NKikimrTxDataShard::EKMeansState uploadState,
     const TProtoStringType& embedding, const google::protobuf::RepeatedPtrField<TProtoStringType>& data,
-    ui32 prefixColumns)
+    const google::protobuf::RepeatedPtrField<TProtoStringType>& pkColumns)
 {
     auto types = GetAllTypes(table);
 
     auto result = std::make_shared<NTxProxy::TUploadTypes>();
-    result->reserve(1 + 1 + std::min((table.KeyColumnTypes.size() - prefixColumns) + data.size(), types.size()));
 
     Ydb::Type type;
     type.set_type_id(NTableIndex::ClusterIdType);
@@ -133,8 +103,14 @@ std::shared_ptr<NTxProxy::TUploadTypes> MakeOutputTypes(const TUserTable& table,
             types.erase(it);
         }
     };
-    for (const auto& column : table.KeyColumnIds | std::views::drop(prefixColumns)) {
-        addType(table.Columns.at(column).Name);
+    if (pkColumns.size()) {
+        for (const auto& column : pkColumns) {
+            addType(column);
+        }
+    } else {
+        for (const auto& column : table.KeyColumnIds) {
+            addType(table.Columns.at(column).Name);
+        }
     }
     switch (uploadState) {
         case NKikimrTxDataShard::EKMeansState::UPLOAD_MAIN_TO_BUILD:

--- a/ydb/core/tx/datashard/build_index/kmeans_helper.h
+++ b/ydb/core/tx/datashard/build_index/kmeans_helper.h
@@ -140,21 +140,16 @@ struct TMaxInnerProductSimilarity : TMetric<TCoord> {
 
 void AddRowToLevel(TBufferData& buffer, TClusterId parent, TClusterId child, const TString& embedding, bool isPostingLevel);
 
-void AddRowMainToBuild(TBufferData& buffer, TClusterId parent, TArrayRef<const TCell> key, TArrayRef<const TCell> row);
+void AddRowToData(TBufferData& buffer, TClusterId parent, TArrayRef<const TCell> sourcePk,
+    TArrayRef<const TCell> dataColumns, TArrayRef<const TCell> origKey, bool isPostingLevel);
 
-void AddRowMainToPosting(TBufferData& buffer, TClusterId parent, TArrayRef<const TCell> key, TArrayRef<const TCell> row, ui32 dataPos);
-
-void AddRowBuildToBuild(TBufferData& buffer, TClusterId parent, TArrayRef<const TCell> key, TArrayRef<const TCell> row, ui32 prefixColumns = 1);
-
-void AddRowBuildToPosting(TBufferData& buffer, TClusterId parent, TArrayRef<const TCell> key, TArrayRef<const TCell> row, ui32 dataPos, ui32 prefixColumns = 1);
-
-TTags MakeScanTags(const TUserTable& table, const TProtoStringType& embedding, 
+TTags MakeScanTags(const TUserTable& table, const TProtoStringType& embedding,
     const google::protobuf::RepeatedPtrField<TProtoStringType>& data, ui32& embeddingPos,
     ui32& dataPos, NTable::TTag& embeddingTag);
 
 std::shared_ptr<NTxProxy::TUploadTypes> MakeOutputTypes(const TUserTable& table, NKikimrTxDataShard::EKMeansState uploadState,
     const TProtoStringType& embedding, const google::protobuf::RepeatedPtrField<TProtoStringType>& data,
-    ui32 prefixColumns = 0);
+    const google::protobuf::RepeatedPtrField<TProtoStringType>& pkColumns = {});
 
 void MakeScan(auto& record, const auto& createScan, const auto& badRequest)
 {

--- a/ydb/core/tx/datashard/build_index/local_kmeans.cpp
+++ b/ydb/core/tx/datashard/build_index/local_kmeans.cpp
@@ -462,28 +462,28 @@ private:
     void FeedMainToBuild(TArrayRef<const TCell> key, TArrayRef<const TCell> row)
     {
         if (auto pos = Clusters.FindCluster(row, EmbeddingPos); pos) {
-            AddRowMainToBuild(*OutputBuf, Child + *pos, key, row);
+            AddRowToData(*OutputBuf, Child + *pos, key, row, key, false);
         }
     }
 
     void FeedMainToPosting(TArrayRef<const TCell> key, TArrayRef<const TCell> row)
     {
         if (auto pos = Clusters.FindCluster(row, EmbeddingPos); pos) {
-            AddRowMainToPosting(*OutputBuf, Child + *pos, key, row, DataPos);
+            AddRowToData(*OutputBuf, Child + *pos, key, row.Slice(DataPos), key, true);
         }
     }
 
     void FeedBuildToBuild(TArrayRef<const TCell> key, TArrayRef<const TCell> row)
     {
         if (auto pos = Clusters.FindCluster(row, EmbeddingPos); pos) {
-            AddRowBuildToBuild(*OutputBuf, Child + *pos, key, row);
+            AddRowToData(*OutputBuf, Child + *pos, key.Slice(1), row, key, false);
         }
     }
 
     void FeedBuildToPosting(TArrayRef<const TCell> key, TArrayRef<const TCell> row)
     {
         if (auto pos = Clusters.FindCluster(row, EmbeddingPos); pos) {
-            AddRowBuildToPosting(*OutputBuf, Child + *pos, key, row, DataPos);
+            AddRowToData(*OutputBuf, Child + *pos, key.Slice(1), row.Slice(DataPos), key, true);
         }
     }
 

--- a/ydb/core/tx/datashard/build_index/prefix_kmeans.cpp
+++ b/ydb/core/tx/datashard/build_index/prefix_kmeans.cpp
@@ -29,7 +29,7 @@ using namespace NKMeans;
  *
  * Request:
  * - The client sends TEvPrefixKMeansRequest with:
-*   - Child: base ID from which new cluster IDs are assigned within this request.
+ *   - Child: base ID from which new cluster IDs are assigned within this request.
  *     - Each prefix group processed will be assigned cluster IDs starting at Child + 1.
  *     - For a request with K clusters per prefix, the IDs used for the first prefix group are
  *       (Child + 1) to (Child + K), and the parent ID for these is Child.
@@ -93,6 +93,9 @@ protected:
 
     // FIXME: save PrefixRows as std::vector<std::pair<TSerializedCellVec, TSerializedCellVec>> to avoid parsing
     const ui32 PrefixColumns;
+    // for PrefixKMeans, original table's primary key columns are passed separately,
+    // because the prefix table contains them in a different order if they are both in PK and in the prefix
+    const ui32 DataColumnCount;
     TSerializedCellVec Prefix;
     TBufferData PrefixRows;
     bool IsFirstPrefixFeed = true;
@@ -126,10 +129,14 @@ public:
         , ResponseActorId{responseActorId}
         , Response{std::move(response)}
         , PrefixColumns{request.GetPrefixColumns()}
+        , DataColumnCount{(ui32)request.GetDataColumns().size()}
     {
         const auto& embedding = request.GetEmbeddingColumn();
-        const auto& data = request.GetDataColumns();
-        ScanTags = MakeScanTags(table, embedding, data, EmbeddingPos, DataPos, EmbeddingTag);
+        TVector<TString> data{request.GetDataColumns().begin(), request.GetDataColumns().end()};
+        for (auto & col: request.GetSourcePrimaryKeyColumns()) {
+            data.push_back(col);
+        }
+        ScanTags = MakeScanTags(table, embedding, {data.begin(), data.end()}, EmbeddingPos, DataPos, EmbeddingTag);
         Lead.To(ScanTags, {}, NTable::ESeek::Lower);
         {
             Ydb::Type type;
@@ -141,7 +148,11 @@ public:
             (*levelTypes)[2] = {NTableIndex::NTableVectorKmeansTreeIndex::CentroidColumn, type};
             LevelBuf = Uploader.AddDestination(request.GetLevelName(), std::move(levelTypes));
         }
-        OutputBuf = Uploader.AddDestination(request.GetOutputName(), MakeOutputTypes(table, UploadState, embedding, data, PrefixColumns));
+        {
+            auto outputTypes = MakeOutputTypes(table, UploadState, embedding,
+                {data.begin(), data.begin()+request.GetDataColumns().size()}, request.GetSourcePrimaryKeyColumns());
+            OutputBuf = Uploader.AddDestination(request.GetOutputName(), outputTypes);
+        }
         {
             auto types = GetAllTypes(table);
 
@@ -480,14 +491,14 @@ private:
     void FeedBuildToBuild(TArrayRef<const TCell> key, TArrayRef<const TCell> row)
     {
         if (auto pos = Clusters.FindCluster(row, EmbeddingPos); pos) {
-            AddRowBuildToBuild(*OutputBuf, Child + *pos, key, row, PrefixColumns);
+            AddRowToData(*OutputBuf, Child + *pos, row.Slice(DataPos+DataColumnCount), row.Slice(0, DataPos+DataColumnCount), key, false);
         }
     }
 
     void FeedBuildToPosting(TArrayRef<const TCell> key, TArrayRef<const TCell> row)
     {
         if (auto pos = Clusters.FindCluster(row, EmbeddingPos); pos) {
-            AddRowBuildToPosting(*OutputBuf, Child + *pos, key, row, DataPos, PrefixColumns);
+            AddRowToData(*OutputBuf, Child + *pos, row.Slice(DataPos+DataColumnCount), row.Slice(DataPos, DataColumnCount), key, true);
         }
     }
 
@@ -623,6 +634,14 @@ void TDataShard::HandleSafe(TEvDataShard::TEvPrefixKMeansRequest::TPtr& ev, cons
         }
         if (request.GetPrefixColumns() > userTable.KeyColumnIds.size()) {
             badRequest(TStringBuilder() << "Should not be requested on more than " << userTable.KeyColumnIds.size() << " prefix columns");
+        }
+        if (request.GetSourcePrimaryKeyColumns().size() == 0) {
+            badRequest("Request should include source primary key columns");
+        }
+        for (auto pkColumn : request.GetSourcePrimaryKeyColumns()) {
+            if (!tags.contains(pkColumn)) {
+                badRequest(TStringBuilder() << "Unknown source primary key column: " << pkColumn);
+            }
         }
 
         if (trySendBadRequest()) {

--- a/ydb/core/tx/datashard/build_index/reshuffle_kmeans.cpp
+++ b/ydb/core/tx/datashard/build_index/reshuffle_kmeans.cpp
@@ -308,28 +308,28 @@ private:
     void FeedMainToBuild(TArrayRef<const TCell> key, TArrayRef<const TCell> row)
     {
         if (auto pos = Clusters.FindCluster(row, EmbeddingPos); pos) {
-            AddRowMainToBuild(*OutputBuf, Child + *pos, key, row);
+            AddRowToData(*OutputBuf, Child + *pos, key, row, key, false);
         }
     }
 
     void FeedMainToPosting(TArrayRef<const TCell> key, TArrayRef<const TCell> row)
     {
         if (auto pos = Clusters.FindCluster(row, EmbeddingPos); pos) {
-            AddRowMainToPosting(*OutputBuf, Child + *pos, key, row, DataPos);
+            AddRowToData(*OutputBuf, Child + *pos, key, row.Slice(DataPos), key, true);
         }
     }
 
     void FeedBuildToBuild(TArrayRef<const TCell> key, TArrayRef<const TCell> row)
     {
         if (auto pos = Clusters.FindCluster(row, EmbeddingPos); pos) {
-            AddRowBuildToBuild(*OutputBuf, Child + *pos, key, row);
+            AddRowToData(*OutputBuf, Child + *pos, key.Slice(1), row, key, false);
         }
     }
 
     void FeedBuildToPosting(TArrayRef<const TCell> key, TArrayRef<const TCell> row)
     {
         if (auto pos = Clusters.FindCluster(row, EmbeddingPos); pos) {
-            AddRowBuildToPosting(*OutputBuf, Child + *pos, key, row, DataPos);
+            AddRowToData(*OutputBuf, Child + *pos, key.Slice(1), row.Slice(DataPos), key, true);
         }
     }
 };

--- a/ydb/core/tx/datashard/build_index/ut/ut_prefix_kmeans.cpp
+++ b/ydb/core/tx/datashard/build_index/ut/ut_prefix_kmeans.cpp
@@ -65,6 +65,9 @@ Y_UNIT_TEST_SUITE (TTxDataShardPrefixKMeansScan) {
 
         rec.SetEmbeddingColumn("embedding");
         rec.SetPrefixColumns(1);
+        rec.AddSourcePrimaryKeyColumns("key");
+
+        rec.SetPrefixName(kPrefixTable);
         
         rec.SetLevelName(kLevelTable);
         rec.SetOutputName(kPostingTable);
@@ -130,6 +133,7 @@ Y_UNIT_TEST_SUITE (TTxDataShardPrefixKMeansScan) {
                 rec.SetEmbeddingColumn("embedding");
                 rec.AddDataColumns("data");
                 rec.SetPrefixColumns(1);
+                rec.AddSourcePrimaryKeyColumns("key");
 
                 rec.SetPrefixName(kPrefixTable);
                 rec.SetLevelName(kLevelTable);
@@ -250,6 +254,10 @@ Y_UNIT_TEST_SUITE (TTxDataShardPrefixKMeansScan) {
         DoBadRequest(server, sender, [](NKikimrTxDataShard::TEvPrefixKMeansRequest& request) {
             TPathId(0, 0).ToProto(request.MutablePathId());
         }, "{ <main>: Error: Unknown table id: 0 }");
+
+        DoBadRequest(server, sender, [](NKikimrTxDataShard::TEvPrefixKMeansRequest& request) {
+            request.ClearSourcePrimaryKeyColumns();
+        }, "{ <main>: Error: Request should include source primary key columns }");
 
         DoBadRequest(server, sender, [](NKikimrTxDataShard::TEvPrefixKMeansRequest& request) {
             request.MutableSettings()->set_vector_type(VectorIndexSettings::VECTOR_TYPE_UNSPECIFIED);

--- a/ydb/core/tx/schemeshard/schemeshard_build_index__progress.cpp
+++ b/ydb/core/tx/schemeshard/schemeshard_build_index__progress.cpp
@@ -698,6 +698,10 @@ private:
         *ev->Record.MutableDataColumns() = {
             buildInfo.DataColumns.begin(), buildInfo.DataColumns.end()
         };
+        const auto& tableInfo = *Self->Tables.at(buildInfo.TablePathId);
+        for (ui32 keyPos: tableInfo.KeyColumnIds) {
+            ev->Record.AddSourcePrimaryKeyColumns(tableInfo.Columns.at(keyPos).Name);
+        }
 
         auto shardId = CommonFillRecord<false>(ev->Record, shardIdx, buildInfo);
         ev->Record.SetSeed(ui64(shardId));


### PR DESCRIPTION
### Changelog category

* Not for changelog (changelog entry is not required)

### Description for reviewers

When some columns of the prefix are also part of the primary key, prefix table PK isn't equal to `<prefix>+<pk>` anymore. But the previous implementation relies on that and constructs the subsequent build table PK by replacing `<prefix_count>` columns in the beginning of the prefix table PK with `__ydb_parent`.

The only correct way to fix it is to pass original table's PK column list in PrefixKMeansRequests explicitly. Then it can request them in scan tags in the right order and use them in the PK.