### PR TITLE
Added support sys view path type to Viewer backend

### DIFF
--- a/ydb/core/viewer/protos/viewer.proto
+++ b/ydb/core/viewer/protos/viewer.proto
@@ -776,6 +776,7 @@ enum EAutocompleteType {
     view = 20;
     column = 21;
     index = 22;
+    sys_view = 23;
 }
 
 message TQueryAutocomplete {

--- a/ydb/core/viewer/viewer_autocomplete.h
+++ b/ydb/core/viewer/viewer_autocomplete.h
@@ -231,6 +231,8 @@ public:
                 return NKikimrViewer::file_store;
             case TNavigate::KindView:
                 return NKikimrViewer::view;
+            case TNavigate::KindSysView:
+                return NKikimrViewer::sys_view;
             default:
                 return NKikimrViewer::dir;
         }

--- a/ydb/core/viewer/viewer_describe.h
+++ b/ydb/core/viewer/viewer_describe.h
@@ -148,6 +148,8 @@ public:
                 return NKikimrSchemeOp::EPathTypeFileStore;
             case TNavigate::KindView:
                 return NKikimrSchemeOp::EPathTypeView;
+            case TNavigate::KindSysView:
+                return NKikimrSchemeOp::EPathTypeSysView;
             default:
                 return NKikimrSchemeOp::EPathTypeDir;
         }


### PR DESCRIPTION
This PR is one of series aimed to store sys view paths in SchemeShard.
To implement that system view path type was added and now we have to support it in Vewer backend acting like it's an ordinal table path.
