### PR TITLE
Support pile identifiers for dynamic nodes too

### DIFF
--- a/ydb/core/base/appdata.cpp
+++ b/ydb/core/base/appdata.cpp
@@ -74,6 +74,7 @@ struct TAppData::TImpl {
     NKikimrConfig::THealthCheckConfig HealthCheckConfig;
     NKikimrConfig::TWorkloadManagerConfig WorkloadManagerConfig;
     NKikimrConfig::TQueryServiceConfig QueryServiceConfig;
+    NKikimrConfig::TBridgeConfig BridgeConfig;
 };
 
 TAppData::TAppData(
@@ -134,6 +135,7 @@ TAppData::TAppData(
     , HealthCheckConfig(Impl->HealthCheckConfig)
     , WorkloadManagerConfig(Impl->WorkloadManagerConfig)
     , QueryServiceConfig(Impl->QueryServiceConfig)
+    , BridgeConfig(&Impl->BridgeConfig)
     , KikimrShouldContinue(kikimrShouldContinue)
     , TracingConfigurator(MakeIntrusive<NJaegerTracing::TSamplingThrottlingConfigurator>(TimeProvider, RandomProvider))
 {}

--- a/ydb/core/base/appdata_fwd.h
+++ b/ydb/core/base/appdata_fwd.h
@@ -76,6 +76,7 @@ namespace NKikimrConfig {
     class THealthCheckConfig;
     class TWorkloadManagerConfig;
     class TQueryServiceConfig;
+    class TBridgeConfig;
 }
 
 namespace NKikimrReplication {
@@ -253,6 +254,7 @@ struct TAppData {
     NKikimrConfig::THealthCheckConfig& HealthCheckConfig;
     NKikimrConfig::TWorkloadManagerConfig& WorkloadManagerConfig;
     NKikimrConfig::TQueryServiceConfig& QueryServiceConfig;
+    NKikimrConfig::TBridgeConfig *BridgeConfig = nullptr;
     bool EnforceUserTokenRequirement = false;
     bool EnforceUserTokenCheckRequirement = false; // check token if it was specified
     bool AllowHugeKeyValueDeletes = true; // delete when all clients limit deletes per request

--- a/ydb/core/base/id_wrapper.h
+++ b/ydb/core/base/id_wrapper.h
@@ -28,7 +28,7 @@ public:
     TString ToString() const { return TStringBuilder() << Raw; }
 
     template<typename TProto>
-    void CopyToProto(TProto *message, void (TProto::*pfn)(T value)) {
+    void CopyToProto(TProto *message, void (TProto::*pfn)(T value)) const {
         std::invoke(pfn, message, Raw);
     }
 

--- a/ydb/core/blobstorage/nodewarden/distconf.cpp
+++ b/ydb/core/blobstorage/nodewarden/distconf.cpp
@@ -487,6 +487,9 @@ namespace NKikimr::NStorage {
                             return "can't determine correct pile state for ring group";
                         }
                         group->SetPileState(*state);
+                        if (*state != T::PRIMARY) { // TODO(alexvru): HACK!!!
+                            group->SetWriteOnly(true);
+                        }
                     } else {
                         return "bridge pile id is out of bounds";
                     }

--- a/ydb/core/config/init/init.cpp
+++ b/ydb/core/config/init/init.cpp
@@ -167,6 +167,9 @@ class TDefaultNodeBrokerClient
                         nodeInfo.SetName(TString{result.GetNodeName()});
                         outNodeName = result.GetNodeName();
                     }
+                    if (node.BridgePileId) {
+                        nodeInfo.SetBridgePileId(*node.BridgePileId);
+                    }
                 } else {
                     auto &info = *nsConfig.AddNode();
                     info.SetNodeId(node.NodeId);
@@ -175,6 +178,9 @@ class TDefaultNodeBrokerClient
                     info.SetHost(TString{node.Host});
                     info.SetInterconnectHost(TString{node.ResolveHost});
                     NConfig::CopyNodeLocation(info.MutableLocation(), node.Location);
+                    if (node.BridgePileId && appConfig.HasBridgeConfig()) {
+                        info.SetBridgePileName(appConfig.GetBridgeConfig().GetPiles(*node.BridgePileId).GetName());
+                    }
                 }
             }
         }
@@ -270,6 +276,9 @@ class TDefaultNodeBrokerClient
         result.FixedNodeId(settings.FixedNodeID);
         if (settings.Path) {
             result.Path(*settings.Path);
+        }
+        if (settings.BridgePileName) {
+            result.BridgePileName(*settings.BridgePileName);
         }
 
         auto loc = settings.Location;

--- a/ydb/core/config/init/init.h
+++ b/ydb/core/config/init/init.h
@@ -119,6 +119,7 @@ struct TNodeRegistrationSettings {
     ui32 InterconnectPort;
     NActors::TNodeLocation Location;
     TString NodeRegistrationToken;
+    std::optional<TString> BridgePileName;
 };
 
 class INodeRegistrationResult {

--- a/ydb/core/config/init/init_impl.h
+++ b/ydb/core/config/init/init_impl.h
@@ -338,6 +338,7 @@ struct TCommonAppOptions {
     bool TcpEnabled = false;
     bool SuppressVersionCheck = false;
     EWorkload Workload = EWorkload::Hybrid;
+    TString BridgePileName;
 
     void RegisterCliOptions(NLastGetopt::TOpts& opts) {
         opts.AddLongOption("cluster-name", "which cluster this node belongs to")
@@ -371,6 +372,8 @@ struct TCommonAppOptions {
             .RequiredArgument("PORT").StoreResult(&NodeBrokerUseTls);
         opts.AddLongOption("node-address", "address for dynamic node")
             .RequiredArgument("ADDR").StoreResult(&NodeAddress);
+        opts.AddLongOption("bridge-pile-name", "pile name for bridged mode")
+            .RequiredArgument("PILE").StoreResult(&BridgePileName);
         opts.AddLongOption("node-host", "hostname for dynamic node")
             .RequiredArgument("NAME").StoreResult(&NodeHost);
         opts.AddLongOption("node-resolve-host", "resolve hostname for dynamic node")
@@ -1299,6 +1302,7 @@ public:
             cf.InterconnectPort,
             cf.CreateNodeLocation(),
             AppConfig.GetAuthConfig().GetNodeRegistrationToken(),
+            cf.BridgePileName ? std::make_optional(cf.BridgePileName) : std::nullopt,
         };
 
         auto result = NodeBrokerClient.RegisterDynamicNode(cf.GrpcSslSettings, addrs, settings, Env, Logger);

--- a/ydb/core/driver_lib/run/run.cpp
+++ b/ydb/core/driver_lib/run/run.cpp
@@ -1258,6 +1258,12 @@ void TKikimrRunner::InitializeAppData(const TKikimrRunConfig& runConfig)
         AppData->QueryServiceConfig = runConfig.AppConfig.GetQueryServiceConfig();
     }
 
+    if (runConfig.AppConfig.HasBridgeConfig()) {
+        AppData->BridgeConfig->CopyFrom(runConfig.AppConfig.GetBridgeConfig());
+    } else {
+        AppData->BridgeConfig = nullptr;
+    }
+
     // setup resource profiles
     AppData->ResourceProfiles = new TResourceProfiles;
     if (runConfig.AppConfig.GetBootstrapConfig().ResourceProfilesSize())

--- a/ydb/core/grpc_services/rpc_config.cpp
+++ b/ydb/core/grpc_services/rpc_config.cpp
@@ -458,7 +458,7 @@ public:
             // TODO: !imp error if empty
             auto& config = *result.add_config();
             auto& identity = *config.mutable_identity();
-            identity.set_version(*metadata.Version);
+            identity.set_version(metadata.Version.value_or(0));
             identity.set_cluster(AppData()->ClusterName);
             identity.mutable_main();
             config.set_config(conf);
@@ -469,7 +469,7 @@ public:
             // TODO: !imp error if empty
             auto& config = *result.add_config();
             auto& identity = *config.mutable_identity();
-            identity.set_version(*metadata.Version);
+            identity.set_version(metadata.Version.value_or(0));
             identity.set_cluster(AppData()->ClusterName);
             identity.mutable_storage();
             config.set_config(conf);

--- a/ydb/core/grpc_services/rpc_node_registration.cpp
+++ b/ydb/core/grpc_services/rpc_node_registration.cpp
@@ -8,7 +8,9 @@
 #include <ydb/core/base/appdata.h>
 #include <ydb/core/base/auth.h>
 #include <ydb/core/base/nameservice.h>
+#include <ydb/core/blobstorage/base/blobstorage_events.h>
 #include <ydb/core/mind/node_broker.h>
+#include <ydb/core/protos/config.pb.h>
 #include <ydb/core/protos/node_broker.pb.h>
 #include <ydb/public/api/protos/ydb_discovery.pb.h>
 
@@ -71,6 +73,9 @@ public:
             nodeBrokerRequest->Record.SetPath(request->path());
         }
         nodeBrokerRequest->Record.SetAuthorizedByCertificate(IsNodeAuthorizedByCertificate);
+        if (request->has_bridge_pile_name()) {
+            nodeBrokerRequest->Record.SetBridgePileName(request->bridge_pile_name());
+        }
 
         NTabletPipe::SendData(ctx, NodeBrokerPipe, nodeBrokerRequest.Release());
 
@@ -103,12 +108,29 @@ public:
 
         const TActorId nameserviceId = GetNameserviceActorId();
         ctx.Send(nameserviceId, new TEvInterconnect::TEvListNodes());
+        ctx.Send(MakeBlobStorageNodeWardenID(SelfId().NodeId()), new TEvNodeWardenQueryStorageConfig(false));
     }
 
     void Handle(TEvInterconnect::TEvNodesInfo::TPtr &ev, const TActorContext &ctx) {
+        EvNodesInfo = ev;
+        if (EvNodesInfo && EvNodeWardenStorageConfig) {
+            Finish(ctx);
+        }
+    }
+
+    void Handle(TEvNodeWardenStorageConfig::TPtr &ev, const TActorContext &ctx) {
+        EvNodeWardenStorageConfig = ev;
+        if (EvNodesInfo && EvNodeWardenStorageConfig) {
+            Finish(ctx);
+        }
+    }
+
+    void Finish(const TActorContext& ctx) {
         auto config = AppData()->DynamicNameserviceConfig;
 
-        for (const auto &node : ev->Get()->Nodes) {
+        auto& bridgeInfo = EvNodeWardenStorageConfig->Get()->BridgeInfo;
+
+        for (const auto &node : EvNodesInfo->Get()->Nodes) {
             // Copy static nodes only.
             if (!config || node.NodeId <= config->MaxStaticNodeId) {
                 auto &info = *Result.add_nodes();
@@ -120,6 +142,17 @@ public:
                 NActorsInterconnect::TNodeLocation location;
                 node.Location.Serialize(&location, true);
                 CopyNodeLocation(info.mutable_location(), location);
+                if (bridgeInfo) {
+                    auto& map = bridgeInfo->StaticNodeIdToPile;
+                    if (auto it = map.find(node.NodeId); it != map.end()) {
+                        it->second->BridgePileId.CopyToProto(&info, &std::decay_t<decltype(info)>::set_bridge_pile_id);
+                    } else {
+                        Y_DEBUG_ABORT("missing static node pile id");
+                    }
+                } else {
+                    // ensure no bridge mode is enabled
+                    Y_DEBUG_ABORT_UNLESS(!AppData()->BridgeConfig || !AppData()->BridgeConfig->PilesSize());
+                }
             }
         }
 
@@ -164,6 +197,7 @@ public:
             CFunc(TEvents::TEvUndelivered::EventType, Undelivered);
             HFunc(TEvNodeBroker::TEvRegistrationResponse, Handle);
             HFunc(TEvInterconnect::TEvNodesInfo, Handle);
+            HFunc(TEvNodeWardenStorageConfig, Handle);
             CFunc(TEvTabletPipe::EvClientDestroyed, Undelivered);
             HFunc(TEvTabletPipe::TEvClientConnected, Handle);
         }
@@ -187,6 +221,9 @@ private:
         dst->set_address(src.GetAddress());
         CopyNodeLocation(dst->mutable_location(), src.GetLocation());
         dst->set_expire(src.GetExpire());
+        if (src.HasBridgePileId()) {
+            dst->set_bridge_pile_id(src.GetBridgePileId());
+        }
     }
 
     static void CopyNodeLocation(NActorsInterconnect::TNodeLocation* dst, const Ydb::Discovery::NodeLocation& src) {
@@ -254,6 +291,8 @@ private:
     Ydb::StatusIds_StatusCode Status = Ydb::StatusIds::SUCCESS;
     TActorId NodeBrokerPipe;
     bool IsNodeAuthorizedByCertificate = false;
+    TEvInterconnect::TEvNodesInfo::TPtr EvNodesInfo;
+    TEvNodeWardenStorageConfig::TPtr EvNodeWardenStorageConfig;
 };
 
 void DoNodeRegistrationRequest(std::unique_ptr<IRequestOpCtx> p, const IFacilityProvider& f) {

--- a/ydb/core/mind/node_broker.cpp
+++ b/ydb/core/mind/node_broker.cpp
@@ -171,6 +171,9 @@ bool TNodeBroker::OnRenderAppHtmlPage(NMon::TEvRemoteHttpInfo::TPtr ev,
                     << "   AuthorizedByCertificate: " << (node.AuthorizedByCertificate ? "true" : "false") << Endl
                     << "   ServicedSubDomain: " << node.ServicedSubDomain << Endl
                     << "   SlotIndex: " << node.SlotIndex << Endl;
+                if (node.BridgePileId) {
+                    str << "   BridgePileId: " << *node.BridgePileId << Endl;
+                }
             }
             str << Endl;
 
@@ -476,6 +479,9 @@ void TNodeBroker::FillNodeInfo(const TNodeInfo &node,
     info.SetExpire(node.Expire.GetValue());
     node.Location.Serialize(info.MutableLocation(), false);
     FillNodeName(node.SlotIndex, info);
+    if (const auto& id = node.BridgePileId) {
+        id->CopyToProto(&info, &NKikimrNodeBroker::TNodeInfo::SetBridgePileId);
+    }
 }
 
 void TNodeBroker::FillNodeName(const std::optional<ui32> &slotIndex,
@@ -853,7 +859,8 @@ void TNodeBroker::TDirtyState::DbAddNode(const TNodeInfo &node,
                 << " expire=" << node.ExpirationString()
                 << " servicedsubdomain=" << node.ServicedSubDomain
                 << " slotindex=" << node.SlotIndex
-                << " authorizedbycertificate=" << (node.AuthorizedByCertificate ? "true" : "false"));
+                << " authorizedbycertificate=" << (node.AuthorizedByCertificate ? "true" : "false")
+                << " bridgePileId=" << (node.BridgePileId ? TString(TStringBuilder() << *node.BridgePileId) : "<none>"));
 
     NIceDb::TNiceDb db(txc.DB);
 
@@ -874,6 +881,11 @@ void TNodeBroker::TDirtyState::DbAddNode(const TNodeInfo &node,
         .Update<T::Location>(node.Location.GetSerializedLocation())
         .Update<T::ServicedSubDomain>(node.ServicedSubDomain)
         .Update<T::AuthorizedByCertificate>(node.AuthorizedByCertificate);
+
+    if (node.BridgePileId) {
+        db.Table<T>().Key(node.NodeId)
+            .Update<T::BridgePileId>(node.BridgePileId->GetRawId());
+    }
 
     if (node.SlotIndex.has_value()) {
         db.Table<T>().Key(node.NodeId)
@@ -1107,6 +1119,9 @@ TNodeBroker::TDbChanges TNodeBroker::TDirtyState::DbLoadNodes(auto &nodesRowset,
             }
             info.AuthorizedByCertificate = nodesRowset.template GetValue<Schema::Nodes::AuthorizedByCertificate>();
             info.State = expire > Epoch.Start ? ENodeState::Active : ENodeState::Expired;
+            if (nodesRowset.template HaveValue<Schema::Nodes::BridgePileId>()) {
+                info.BridgePileId.emplace(TBridgePileId::FromValue(nodesRowset.template GetValue<Schema::Nodes::BridgePileId>()));
+            }
             AddNode(info);
 
             LOG_DEBUG_S(ctx, NKikimrServices::NODE_BROKER,
@@ -1492,6 +1507,8 @@ void TNodeBroker::Handle(TEvNodeBroker::TEvRegistrationRequest::TPtr &ev,
         TActorId ReplyTo;
         NActors::TScopeId ScopeId;
         TSubDomainKey ServicedSubDomain;
+        std::optional<TBridgePileId> BridgePileId;
+        TString Error;
 
     public:
         static constexpr NKikimrServices::TActivity::EType ActorActivityType() {
@@ -1507,6 +1524,27 @@ void TNodeBroker::Handle(TEvNodeBroker::TEvRegistrationRequest::TPtr &ev,
             Become(&TThis::StateFunc);
 
             auto& record = Ev->Get()->Record;
+
+            if (record.HasBridgePileName()) {
+                if (AppData()->BridgeConfig && AppData()->BridgeConfig->PilesSize()) {
+                    const TString& name = record.GetBridgePileName();
+                    const auto& bridge = *AppData()->BridgeConfig;
+                    const auto& piles = bridge.GetPiles();
+                    for (int i = 0; i < piles.size(); ++i) {
+                        if (piles[i].GetName() == name) {
+                            BridgePileId.emplace(TBridgePileId::FromValue(i));
+                            break;
+                        }
+                    }
+                    if (!BridgePileId) {
+                        Error = TStringBuilder() << "Incorrect bridge pile name " << name;
+                    }
+                } else {
+                    Error = "Bridge pile specified while bridge mode is disabled";
+                }
+            } else if (AppData()->BridgeConfig && AppData()->BridgeConfig->PilesSize()) {
+                Error = "Bridge pile not specified while bridge mode is enabled";
+            }
 
             if (record.HasPath()) {
                 auto req = MakeHolder<NSchemeCache::TSchemeCacheNavigate>();
@@ -1557,7 +1595,8 @@ void TNodeBroker::Handle(TEvNodeBroker::TEvRegistrationRequest::TPtr &ev,
                 << ": scope id# " << ScopeIdToString(ScopeId)
                 << ": serviced subdomain# " << ServicedSubDomain);
 
-            Send(ReplyTo, new TEvPrivate::TEvResolvedRegistrationRequest(Ev, ScopeId, ServicedSubDomain));
+            Send(ReplyTo, new TEvPrivate::TEvResolvedRegistrationRequest(Ev, ScopeId, ServicedSubDomain, BridgePileId,
+                std::move(Error)));
             Die(ctx);
         }
 
@@ -1731,6 +1770,9 @@ TNodeBroker::TNodeInfo::TNodeInfo(ui32 nodeId, ENodeState state, ui64 version, c
     , ServicedSubDomain(schema.GetServicedSubDomain())
     , State(state)
     , Version(version)
+    , BridgePileId(schema.HasBridgePileId()
+        ? std::make_optional(TBridgePileId::FromProto(&schema, &TNodeInfoSchema::GetBridgePileId))
+        : std::nullopt)
 {}
 
 TNodeBroker::TNodeInfo::TNodeInfo(ui32 nodeId, ENodeState state, ui64 version)
@@ -1754,7 +1796,8 @@ bool TNodeBroker::TNodeInfo::EqualExceptVersion(const TNodeInfo &other) const
         && AuthorizedByCertificate == other.AuthorizedByCertificate
         && SlotIndex == other.SlotIndex
         && ServicedSubDomain == other.ServicedSubDomain
-        && State == other.State;
+        && State == other.State
+        && BridgePileId == other.BridgePileId;
 }
 
 TString TNodeBroker::TNodeInfo::IdString() const
@@ -1782,6 +1825,7 @@ TString TNodeBroker::TNodeInfo::ToString() const
         << ", Expire: " << ExpirationString()
         << ", Location: " << Location.ToString()
         << ", AuthorizedByCertificate: " << AuthorizedByCertificate
+        << ", BridgePileId: " << (BridgePileId ? TString(TStringBuilder() << *BridgePileId) : "<none>")
         << ", SlotIndex: " << SlotIndex
         << ", ServicedSubDomain: " << ServicedSubDomain
     << " }";
@@ -1802,6 +1846,9 @@ TNodeInfoSchema TNodeBroker::TNodeInfo::SerializeToSchema() const {
         serialized.SetSlotIndex(*SlotIndex);
     }
     serialized.SetAuthorizedByCertificate(AuthorizedByCertificate);
+    if (BridgePileId) {
+        BridgePileId->CopyToProto(&serialized, &TNodeInfoSchema::SetBridgePileId);
+    }
     return serialized;
 }
 

--- a/ydb/core/mind/node_broker__register_node.cpp
+++ b/ydb/core/mind/node_broker__register_node.cpp
@@ -16,6 +16,8 @@ public:
         , Event(resolvedEv->Get()->Request)
         , ScopeId(resolvedEv->Get()->ScopeId)
         , ServicedSubDomain(resolvedEv->Get()->ServicedSubDomain)
+        , BridgePileId(resolvedEv->Get()->BridgePileId)
+        , ResolveError(std::move(resolvedEv->Get()->Error))
         , NodeId(0)
         , ExtendLease(false)
         , FixNodeId(false)
@@ -84,6 +86,10 @@ public:
 
         Response = new TEvNodeBroker::TEvRegistrationResponse;
 
+        if (ResolveError) {
+            return Error(TStatus::WRONG_REQUEST, TStringBuilder() << ResolveError << " for " << host << ':' << port, ctx);
+        }
+
         if (rec.HasPath() && ScopeId == NActors::TScopeId()) {
             return Error(TStatus::ERROR,
                          TStringBuilder() << "Failed to resolve the database by its path. Perhaps the database " << rec.GetPath() << " does not exist",
@@ -118,6 +124,8 @@ public:
                 Self->Dirty.UpdateLocation(node, loc);
                 Self->Dirty.DbAddNode(node, txc);
                 SetLocation = true;
+            } else if (node.BridgePileId != node.BridgePileId) {
+                return Error(TStatus::WRONG_REQUEST, "Can't change bridge pile for the node", ctx);
             }
 
             if (!node.IsFixed() && rec.GetFixedNodeId()) {
@@ -162,6 +170,7 @@ public:
             Node->Expire = expire;
             Node->Version = Self->Dirty.Epoch.Version + 1;
             Node->State = ENodeState::Active;
+            Node->BridgePileId = BridgePileId;
 
             if (Self->EnableStableNodeNames) {
                 Node->ServicedSubDomain = ServicedSubDomain;
@@ -232,6 +241,8 @@ private:
     TEvNodeBroker::TEvRegistrationRequest::TPtr Event;
     const NActors::TScopeId ScopeId;
     const TSubDomainKey ServicedSubDomain;
+    const std::optional<TBridgePileId> BridgePileId;
+    TString ResolveError;
     TAutoPtr<TEvNodeBroker::TEvRegistrationResponse> Response;
     THolder<TNodeInfo> Node;
     ui32 NodeId;

--- a/ydb/core/mind/node_broker__scheme.h
+++ b/ydb/core/mind/node_broker__scheme.h
@@ -37,6 +37,7 @@ struct Schema : NIceDb::Schema {
         struct ServicedSubDomain : Column<13, NScheme::NTypeIds::String> { using Type = NKikimrSubDomains::TDomainKey; };
         struct SlotIndex : Column<14, NScheme::NTypeIds::Uint32> {};
         struct AuthorizedByCertificate : Column<15, NScheme::NTypeIds::Bool> {};
+        struct BridgePileId : Column<16, NScheme::NTypeIds::Uint32> {};
 
         using TKey = TableKey<ID>;
         using TColumns = TableColumns<
@@ -50,7 +51,8 @@ struct Schema : NIceDb::Schema {
             Location,
             ServicedSubDomain,
             SlotIndex,
-            AuthorizedByCertificate
+            AuthorizedByCertificate,
+            BridgePileId
         >;
     };
 

--- a/ydb/core/mind/node_broker_impl.h
+++ b/ydb/core/mind/node_broker_impl.h
@@ -66,15 +66,21 @@ public:
             TEvResolvedRegistrationRequest(
                     TEvNodeBroker::TEvRegistrationRequest::TPtr request,
                     NActors::TScopeId scopeId,
-                    TSubDomainKey servicedSubDomain)
+                    TSubDomainKey servicedSubDomain,
+                    std::optional<TBridgePileId> bridgePileId,
+                    TString error)
                 : Request(request)
                 , ScopeId(scopeId)
                 , ServicedSubDomain(servicedSubDomain)
+                , BridgePileId(bridgePileId)
+                , Error(std::move(error))
             {}
 
             TEvNodeBroker::TEvRegistrationRequest::TPtr Request;
             NActors::TScopeId ScopeId;
             TSubDomainKey ServicedSubDomain;
+            std::optional<TBridgePileId> BridgePileId;
+            TString Error;
         };
 
         struct TEvProcessSubscribersQueue : public TEventLocal<TEvProcessSubscribersQueue, EvProcessSubscribersQueue> {};
@@ -138,6 +144,7 @@ private:
         TSubDomainKey ServicedSubDomain;
         ENodeState State = ENodeState::Removed;
         ui64 Version = 0;
+        std::optional<TBridgePileId> BridgePileId;
     };
 
     // State changes to apply while moving to the next epoch.

--- a/ydb/core/protos/node_broker.proto
+++ b/ydb/core/protos/node_broker.proto
@@ -22,6 +22,7 @@ message TNodeInfo {
     optional NActorsInterconnect.TNodeLocation Location = 6;
     optional uint64 Expire = 7;
     optional string Name = 8;
+    optional uint32 BridgePileId = 9;
 }
 
 message TNodeInfoSchema {
@@ -35,6 +36,7 @@ message TNodeInfoSchema {
     optional NKikimrSubDomains.TDomainKey ServicedSubDomain = 8;
     optional uint32 SlotIndex = 9;
     optional bool AuthorizedByCertificate = 10;
+    optional uint32 BridgePileId = 11;
 }
 
 message TVersionInfo {
@@ -88,6 +90,7 @@ message TRegistrationRequest {
   optional bool FixedNodeId = 6;
   optional string Path = 7;
   optional bool AuthorizedByCertificate = 8;
+  optional string BridgePileName = 9;
 }
 
 message TRegistrationResponse {

--- a/ydb/public/api/protos/ydb_discovery.proto
+++ b/ydb/public/api/protos/ydb_discovery.proto
@@ -83,6 +83,7 @@ message NodeInfo {
     optional string address = 5;
     optional NodeLocation location = 6;
     optional uint64 expire = 7;
+    optional uint32 bridge_pile_id = 8;
 }
 
 message NodeRegistrationRequest {
@@ -94,6 +95,7 @@ message NodeRegistrationRequest {
     optional string domain_path = 6;
     optional bool fixed_node_id = 7;
     optional string path = 8;
+    optional string bridge_pile_name = 9;
 }
 
 message NodeRegistrationResult {

--- a/ydb/public/sdk/cpp/include/ydb-cpp-sdk/client/discovery/discovery.h
+++ b/ydb/public/sdk/cpp/include/ydb-cpp-sdk/client/discovery/discovery.h
@@ -48,6 +48,7 @@ struct TNodeRegistrationSettings : public TSimpleRequestSettings<TNodeRegistrati
     FLUENT_SETTING(std::string, DomainPath);
     FLUENT_SETTING_DEFAULT(bool, FixedNodeId, false);
     FLUENT_SETTING(std::string, Path);
+    FLUENT_SETTING(std::string, BridgePileName);
 };
 
 struct TEndpointInfo {
@@ -96,6 +97,7 @@ struct TNodeInfo {
     std::string Address;
     TNodeLocation Location;
     uint64_t Expire;
+    std::optional<uint32_t> BridgePileId;
 };
 
 class TNodeRegistrationResult : public TStatus {

--- a/ydb/public/sdk/cpp/src/client/discovery/discovery.cpp
+++ b/ydb/public/sdk/cpp/src/client/discovery/discovery.cpp
@@ -77,7 +77,8 @@ TNodeInfo::TNodeInfo(const Ydb::Discovery::NodeInfo& info)
     , Address(info.address())
     , Location(info.location())
     , Expire(info.expire())
-    {}
+    , BridgePileId(info.has_bridge_pile_id() ? std::make_optional(info.bridge_pile_id()) : std::nullopt)
+{}
 
 TNodeRegistrationResult::TNodeRegistrationResult(TStatus&& status, const Ydb::Discovery::NodeRegistrationResult& proto)
     : TStatus(std::move(status))
@@ -207,6 +208,9 @@ public:
         request.set_fixed_node_id(settings.FixedNodeId_);
         if (!settings.Path_.empty()) {
             request.set_path(TStringType{settings.Path_});
+        }
+        if (!settings.BridgePileName_.empty()) {
+            request.set_bridge_pile_name(TStringType{settings.BridgePileName_});
         }
 
         auto requestLocation = request.mutable_location();

--- a/ydb/tests/functional/config/test_distconf.py
+++ b/ydb/tests/functional/config/test_distconf.py
@@ -23,6 +23,14 @@ import ydb.public.api.protos.ydb_config_pb2 as config
 logger = logging.getLogger(__name__)
 
 
+def get_ring_group(request_config, config_name):
+    config = request_config[f"{config_name}Config"]
+    if "RingGroups" in config:
+        return config["RingGroups"][0]
+    else:
+        return config["Ring"]
+
+
 def value_for(key, tablet_id):
     return "Value: <key = {key}, tablet_id = {tablet_id}>".format(
         key=key, tablet_id=tablet_id)
@@ -330,7 +338,7 @@ class KiKiMRDistConfReassignStateStorageBaseTest(KiKiMRDistConfReassignStateStor
 class TestKiKiMRDistConfReassignStateStorageBadCases(KiKiMRDistConfReassignStateStorageBaseTest):
     def check_failed(self, req, message):
         resp = self.do_request(req)
-        assert_that(resp["ErrorReason"].startswith(message), {"Response": resp, "Expected": message})
+        assert_that(resp.get("ErrorReason", "").startswith(message), {"Response": resp, "Expected": message})
 
     def do_test(self, storageName):
         self.check_failed({"ReconfigStateStorage": {}}, "New configuration is not defined")
@@ -352,14 +360,18 @@ class TestKiKiMRDistConfReassignStateStorageBadCases(KiKiMRDistConfReassignState
                           f"New {storageName} configuration first RingGroup is writeOnly")
         self.check_failed({"ReconfigStateStorage": {f"{storageName}Config": {"RingGroups": [{"NToSelect": 1, "Ring": [{"RingGroupActorIdOffset": 2, "Node": [4]}]}]}}},
                           f"{storageName} RingGroupActorIdOffset should be used in ring group level, not ring")
-        defaultRingGroup = self.do_request_config()[f"{storageName}Config"]["Ring"]
-        self.check_failed({"ReconfigStateStorage": {f"{storageName}Config": {"RingGroups": [defaultRingGroup, {"NToSelect": 1, "Node": [defaultRingGroup["Node"][0]]}]}}},
-                          f"{storageName} replicas ActorId intersection, specify RingGroupActorIdOffset if you run multiple replicas on one node")
+        defaultRingGroup = get_ring_group(self.do_request_config(), storageName)
+        node = defaultRingGroup["Node"][0] if "Node" in defaultRingGroup else defaultRingGroup["Ring"][0]["Node"][0]
+        cmd = {"ReconfigStateStorage": {f"{storageName}Config": {"RingGroups": [
+            defaultRingGroup,
+            {"NToSelect": 1, "Ring": [{"Node": [node]}]}
+        ]}}}
+        self.check_failed(cmd, f"{storageName} replicas ActorId intersection, specify RingGroupActorIdOffset if you run multiple replicas on one node")
 
 
 class TestKiKiMRDistConfReassignStateStorageNoChanges(KiKiMRDistConfReassignStateStorageBaseTest):
     def do_test(self, configName):
-        defaultRingGroup = [self.do_request_config()[f"{configName}Config"]["Ring"]]
+        defaultRingGroup = [get_ring_group(self.do_request_config(), configName)]
         logger.info(self.do_load_and_test({"ReconfigStateStorage": {f"{configName}Config": {
                     "RingGroups": defaultRingGroup}}}))
         time.sleep(1)
@@ -368,7 +380,7 @@ class TestKiKiMRDistConfReassignStateStorageNoChanges(KiKiMRDistConfReassignStat
 
 class TestKiKiMRDistConfReassignStateStorage(KiKiMRDistConfReassignStateStorageBaseTest):
     def do_test(self, configName):
-        defaultRingGroup = [self.do_request_config()[f"{configName}Config"]["Ring"]]
+        defaultRingGroup = [get_ring_group(self.do_request_config(), configName)]
         newRingGroup = [{"WriteOnly": True, "NToSelect": 3, "Ring": [{"Node": [4]}, {"Node": [5]}, {"Node": [6]}]}]
         self.do_test_change_state_storage(defaultRingGroup, newRingGroup, configName)
         assert_eq(self.do_request_config()[f"{configName}Config"], {"Ring": newRingGroup[0]})
@@ -376,7 +388,7 @@ class TestKiKiMRDistConfReassignStateStorage(KiKiMRDistConfReassignStateStorageB
 
 class TestKiKiMRDistConfReassignStateStorageToTheSameConfig(KiKiMRDistConfReassignStateStorageBaseTest):
     def do_test(self, configName):
-        defaultRingGroup = [self.do_request_config()[f"{configName}Config"]["Ring"]]
+        defaultRingGroup = [get_ring_group(self.do_request_config(), configName)]
         newRingGroup = deepcopy(defaultRingGroup)
         newRingGroup[0]["RingGroupActorIdOffset"] = 1
         self.do_test_change_state_storage(defaultRingGroup, newRingGroup, configName)
@@ -385,7 +397,7 @@ class TestKiKiMRDistConfReassignStateStorageToTheSameConfig(KiKiMRDistConfReassi
 
 class TestKiKiMRDistConfReassignStateStorageReuseSameNodes(KiKiMRDistConfReassignStateStorageBaseTest):
     def do_test(self, configName):
-        defaultRingGroup = [self.do_request_config()[f"{configName}Config"]["Ring"]]
+        defaultRingGroup = [get_ring_group(self.do_request_config(), configName)]
         newRingGroup = deepcopy(defaultRingGroup)
         newRingGroup[0]["NToSelect"] = 3
         newRingGroup[0]["RingGroupActorIdOffset"] = 1
@@ -397,7 +409,7 @@ class TestKiKiMRDistConfReassignStateStorageMultipleRingGroup(KiKiMRDistConfReas
     number_of_tablets = 3
 
     def do_test(self, configName):
-        defaultRingGroup = [self.do_request_config()[f"{configName}Config"]["Ring"]]
+        defaultRingGroup = [get_ring_group(self.do_request_config(), configName)]
         newRingGroup = [
             {"NToSelect": 3, "Ring": [{"Node": [4]}, {"Node": [5]}, {"Node": [6]}]},
             {"NToSelect": 3, "Ring": [{"Node": [7]}, {"Node": [8]}, {"Node": [1]}]}


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

Support pile identifiers for dynamic nodes too

### Changelog category <!-- remove all except one -->

* New feature

### Description for reviewers <!-- (optional) description for those who read this PR -->

This patch allows binding dynamic nodes to specific piles when in bridge mode.