### PR TITLE
Add more SELECT iterations to udf compatibility test

### DIFF
--- a/ydb/tests/compatibility/udf/test_datetime2.py
+++ b/ydb/tests/compatibility/udf/test_datetime2.py
@@ -244,6 +244,14 @@ class TestDatetime2(MixedClusterFixture):
             self.q_parse()
         ]
 
+        """
+        UDFs are compiled once on the node that initially receives the request.
+        The compiled UDF is then propagated to all other nodes. Executing the query a single time only verifies
+        compatibility in one direction—either from old to new or from new to old. Performing multiple retries
+        increases the likelihood that the UDF will be compiled on both the old and new versions, thereby improving coverage of compatibility testing.
+
+        Additionally, a session pool always sends requests to the same node. To ensure distribution across nodes, the session pool is recreated for each SELECT request.
+        """
         for _ in range(10):
             with ydb.QuerySessionPool(self.driver) as session_pool:
                 for query in queries:

--- a/ydb/tests/compatibility/udf/test_datetime2.py
+++ b/ydb/tests/compatibility/udf/test_datetime2.py
@@ -230,20 +230,22 @@ class TestDatetime2(MixedClusterFixture):
             query = self.generate_insert()
             session_pool.execute_with_retries(query)
 
-            # ---------------- SELECT ------------------
-            queries = [
-                self.q_split(),
-                self.q_make(),
-                self.q_get(),
-                self.q_update(),
-                self.q_to_from(),
-                self.q_interval(),
-                self.q_start_end(),
-                self.q_shift(),
-                self.q_format(),
-                self.q_parse()
-            ]
+        # ---------------- SELECT ------------------
+        queries = [
+            self.q_split(),
+            self.q_make(),
+            self.q_get(),
+            self.q_update(),
+            self.q_to_from(),
+            self.q_interval(),
+            self.q_start_end(),
+            self.q_shift(),
+            self.q_format(),
+            self.q_parse()
+        ]
 
-            for query in queries:
-                result = session_pool.execute_with_retries(query)
-                assert len(result[0].rows) > 0
+        for _ in range(10):
+            with ydb.QuerySessionPool(self.driver) as session_pool:
+                for query in queries:
+                    result = session_pool.execute_with_retries(query)
+                    assert len(result[0].rows) > 0

--- a/ydb/tests/compatibility/udf/test_digest.py
+++ b/ydb/tests/compatibility/udf/test_digest.py
@@ -95,6 +95,8 @@ class TestDigest(MixedClusterFixture):
             query = self.generate_insert()
             session_pool.execute_with_retries(query)
 
-            query = self.q_digest()
-            result = session_pool.execute_with_retries(query)
-            assert len(result[0].rows) > 0
+        query = self.q_digest()
+        for _ in range(10):
+            with ydb.QuerySessionPool(self.driver) as session_pool:
+                result = session_pool.execute_with_retries(query)
+                assert len(result[0].rows) > 0

--- a/ydb/tests/compatibility/udf/test_digest.py
+++ b/ydb/tests/compatibility/udf/test_digest.py
@@ -96,6 +96,14 @@ class TestDigest(MixedClusterFixture):
             session_pool.execute_with_retries(query)
 
         query = self.q_digest()
+        """
+        UDFs are compiled once on the node that initially receives the request.
+        The compiled UDF is then propagated to all other nodes. Executing the query a single time only verifies
+        compatibility in one direction—either from old to new or from new to old. Performing multiple retries
+        increases the likelihood that the UDF will be compiled on both the old and new versions, thereby improving coverage of compatibility testing.
+
+        Additionally, a session pool always sends requests to the same node. To ensure distribution across nodes, the session pool is recreated for each SELECT request.
+        """
         for _ in range(10):
             with ydb.QuerySessionPool(self.driver) as session_pool:
                 result = session_pool.execute_with_retries(query)


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->
UDFs are compiled once on the node that initially receives the request. The compiled UDF is then propagated to all other nodes. Executing the query a single time only verifies compatibility in one direction—either from old to new or from new to old. Performing multiple retries increases the chance that the UDF will be compiled on both the old and new versions, thereby improving coverage of compatibility testing.

Additionally, a session pool always sends requests to the same node. To ensure distribution across nodes, the session pool is recreated for each SELECT request.
...

### Changelog category <!-- remove all except one -->


* Not for changelog (changelog entry is not required)

### Description for reviewers <!-- (optional) description for those who read this PR -->

...
