### PR TITLE
Switch SchemeShard from Y_ABORT to Y_ENSURE in vector index related files

### DIFF
--- a/ydb/core/tx/schemeshard/schemeshard__init.cpp
+++ b/ydb/core/tx/schemeshard/schemeshard__init.cpp
@@ -125,7 +125,7 @@ struct TSchemeShard::TTxInit : public TTransactionBase<TSchemeShard> {
 
         TPathId domainId = Self->RootPathId();
         if (pathId != Self->RootPathId()) {
-            Y_ENSURE(Self->PathsById.contains(parentPathId), "Parent path not found"
+            Y_VERIFY_S(Self->PathsById.contains(parentPathId), "Parent path not found"
                            << ", pathId: " << pathId
                            << ", parentPathId: " << parentPathId);
             auto parent = Self->PathsById.at(parentPathId);
@@ -203,7 +203,7 @@ struct TSchemeShard::TTxInit : public TTransactionBase<TSchemeShard> {
                 if (pathId.LocalPathId == 0) {
                     const auto name = rows.GetValue<Schema::Paths::Name>();
                     // Skip special incompatibility marker
-                    Y_ENSURE(parentPathId.LocalPathId == 0 && name == "/incompatible/",
+                    Y_VERIFY_S(parentPathId.LocalPathId == 0 && name == "/incompatible/",
                         "Unexpected row PathId# " << pathId << " ParentPathId# " << parentPathId << " Name# " << name);
 
                     if (!rows.Next()) {
@@ -379,7 +379,7 @@ struct TSchemeShard::TTxInit : public TTransactionBase<TSchemeShard> {
 
         if (const TString typeData = rowSet.template GetValueOrDefault<typename SchemaTable::ColTypeData>("")) {
             NKikimrProto::TTypeInfo protoType;
-            Y_ENSURE(ParseFromStringNoSizeLimit(protoType, typeData));
+            Y_ABORT_UNLESS(ParseFromStringNoSizeLimit(protoType, typeData));
             typeInfoMod = NScheme::TypeInfoModFromProtoColumnType(typeId, &protoType);
         } else {
             // Decimal column was created before SchemaTable::ColTypeData was filled with decimal params
@@ -1385,14 +1385,14 @@ struct TSchemeShard::TTxInit : public TTransactionBase<TSchemeShard> {
             if (pathRows) {
                 // read Root
                 TPathElement::TPtr rootPath = MakePathElement(pathRows.front());
-                Y_ENSURE(rootPath->PathId == Self->RootPathId());
-                Y_ENSURE(rootPath->ParentPathId == Self->RootPathId());
-                Y_ENSURE(rootPath->DomainPathId == Self->RootPathId());
+                Y_ABORT_UNLESS(rootPath->PathId == Self->RootPathId());
+                Y_ABORT_UNLESS(rootPath->ParentPathId == Self->RootPathId());
+                Y_ABORT_UNLESS(rootPath->DomainPathId == Self->RootPathId());
 
-                Y_ENSURE(!IsStartWithSlash(rootPath->Name));
+                Y_ABORT_UNLESS(!IsStartWithSlash(rootPath->Name));
                 Self->RootPathElements = SplitPath(rootPath->Name);
 
-                Y_ENSURE(!rootPath->StepDropped);
+                Y_ABORT_UNLESS(!rootPath->StepDropped);
                 Self->PathsById[rootPath->PathId] = rootPath;
 
                 pathRows.pop_front();
@@ -1403,9 +1403,9 @@ struct TSchemeShard::TTxInit : public TTransactionBase<TSchemeShard> {
             for (auto& rec: pathRows) {
                 TPathElement::TPtr path = MakePathElement(rec);
 
-                Y_ENSURE(path->PathId != Self->RootPathId());
+                Y_ABORT_UNLESS(path->PathId != Self->RootPathId());
 
-                Y_ENSURE(!Self->PathsById.contains(path->PathId), "Path already exists"
+                Y_VERIFY_S(!Self->PathsById.contains(path->PathId), "Path already exists"
                                << ", pathId: " << path->PathId);
 
                 TPathElement::TPtr parent = Self->PathsById.at(path->ParentPathId);
@@ -1461,11 +1461,11 @@ struct TSchemeShard::TTxInit : public TTransactionBase<TSchemeShard> {
                 TString name = std::get<1>(rec);
                 TString value = std::get<2>(rec);
 
-                Y_ENSURE(Self->PathsById.contains(pathId), "Unknown pathId: " << pathId);
+                Y_VERIFY_S(Self->PathsById.contains(pathId), "Unknown pathId: " << pathId);
                 auto pathElem = Self->PathsById.at(pathId);
 
-                Y_ENSURE(pathElem->UserAttrs);
-                Y_ENSURE(pathElem->UserAttrs->AlterVersion > 0);
+                Y_ABORT_UNLESS(pathElem->UserAttrs);
+                Y_ABORT_UNLESS(pathElem->UserAttrs->AlterVersion > 0);
                 pathElem->UserAttrs->Set(name, value);
             }
         }
@@ -1487,10 +1487,10 @@ struct TSchemeShard::TTxInit : public TTransactionBase<TSchemeShard> {
                 TString name = std::get<1>(rec);
                 TString value = std::get<2>(rec);
 
-                Y_ENSURE(Self->PathsById.contains(pathId), "Unknown pathId: " << pathId);
+                Y_VERIFY_S(Self->PathsById.contains(pathId), "Unknown pathId: " << pathId);
                 auto pathElem = Self->PathsById.at(pathId);
 
-                Y_ENSURE(pathElem->UserAttrs);
+                Y_ABORT_UNLESS(pathElem->UserAttrs);
                 if (pathElem->UserAttrs->AlterData == nullptr) {
                     pathElem->UserAttrs->AlterData = new TUserAttributes(pathElem->UserAttrs->AlterVersion + 1);
                 }
@@ -1533,13 +1533,13 @@ struct TSchemeShard::TTxInit : public TTransactionBase<TSchemeShard> {
                 TLocalPathId localPathId = rowset.GetValue<Schema::SubDomains::PathId>();
                 TPathId pathId(selfId, localPathId);
 
-                Y_ENSURE(Self->PathsById.contains(pathId), "Path doesn't exist, pathId: " << pathId);
+                Y_VERIFY_S(Self->PathsById.contains(pathId), "Path doesn't exist, pathId: " << pathId);
 
                 TPathElement::TPtr path = Self->PathsById.at(pathId);
-                Y_ENSURE(path->IsDomainRoot(), "Path is not a domain, pathId: " << pathId);
+                Y_VERIFY_S(path->IsDomainRoot(), "Path is not a domain, pathId: " << pathId);
 
                 if (!path->IsRoot() || !Self->IsDomainSchemeShard) {
-                    Y_ENSURE(!Self->SubDomains.contains(pathId));
+                    Y_ABORT_UNLESS(!Self->SubDomains.contains(pathId));
 
                     ui64 alterVersion = rowset.GetValue<Schema::SubDomains::AlterVersion>();
                     ui64 planResolution = rowset.GetValue<Schema::SubDomains::PlanResolution>();
@@ -1562,13 +1562,13 @@ struct TSchemeShard::TTxInit : public TTransactionBase<TSchemeShard> {
 
                     if (rowset.HaveValue<Schema::SubDomains::DeclaredSchemeQuotas>()) {
                         NKikimrSubDomains::TSchemeQuotas declaredSchemeQuotas;
-                        Y_ENSURE(ParseFromStringNoSizeLimit(declaredSchemeQuotas, rowset.GetValue<Schema::SubDomains::DeclaredSchemeQuotas>()));
+                        Y_ABORT_UNLESS(ParseFromStringNoSizeLimit(declaredSchemeQuotas, rowset.GetValue<Schema::SubDomains::DeclaredSchemeQuotas>()));
                         domainInfo->SetDeclaredSchemeQuotas(declaredSchemeQuotas);
                     }
 
                     if (rowset.HaveValue<Schema::SubDomains::DatabaseQuotas>()) {
                         Ydb::Cms::DatabaseQuotas databaseQuotas;
-                        Y_ENSURE(ParseFromStringNoSizeLimit(databaseQuotas, rowset.GetValue<Schema::SubDomains::DatabaseQuotas>()));
+                        Y_ABORT_UNLESS(ParseFromStringNoSizeLimit(databaseQuotas, rowset.GetValue<Schema::SubDomains::DatabaseQuotas>()));
                         domainInfo->SetDatabaseQuotas(databaseQuotas, Self);
                     }
 
@@ -1581,7 +1581,7 @@ struct TSchemeShard::TTxInit : public TTransactionBase<TSchemeShard> {
 
                     if (rowset.HaveValue<Schema::SubDomains::AuditSettings>()) {
                         NKikimrSubDomains::TAuditSettings value;
-                        Y_ENSURE(ParseFromStringNoSizeLimit(value, rowset.GetValue<Schema::SubDomains::AuditSettings>()));
+                        Y_ABORT_UNLESS(ParseFromStringNoSizeLimit(value, rowset.GetValue<Schema::SubDomains::AuditSettings>()));
                         domainInfo->SetAuditSettings(value);
                     }
 
@@ -1618,16 +1618,16 @@ struct TSchemeShard::TTxInit : public TTransactionBase<TSchemeShard> {
                         rowset.GetValue<Schema::SubDomainsAlterData::ResourcesDomainLocalPathId>());
                     if (resourcesDomainId && Self->IsDomainSchemeShard) {
                         // we cannot check that on TSS
-                        Y_ENSURE(Self->SubDomains.contains(resourcesDomainId), "Unknown ResourcesDomainId: " << resourcesDomainId);
+                        Y_VERIFY_S(Self->SubDomains.contains(resourcesDomainId), "Unknown ResourcesDomainId: " << resourcesDomainId);
                     }
 
-                    Y_ENSURE(Self->PathsById.contains(pathId), "Path doesn't exist, pathId: " << pathId);
+                    Y_VERIFY_S(Self->PathsById.contains(pathId), "Path doesn't exist, pathId: " << pathId);
                     TPathElement::TPtr path = Self->PathsById.at(pathId);
-                    Y_ENSURE(path->IsDomainRoot(), "Path is not a subdomain, pathId: " << pathId);
+                    Y_VERIFY_S(path->IsDomainRoot(), "Path is not a subdomain, pathId: " << pathId);
 
-                    Y_ENSURE(Self->SubDomains.contains(pathId));
+                    Y_ABORT_UNLESS(Self->SubDomains.contains(pathId));
                     auto subdomainInfo = Self->SubDomains[pathId];
-                    Y_ENSURE(!subdomainInfo->GetAlter());
+                    Y_ABORT_UNLESS(!subdomainInfo->GetAlter());
 
                     TSubDomainInfo::TPtr alter;
                     alter = new TSubDomainInfo(
@@ -1647,13 +1647,13 @@ struct TSchemeShard::TTxInit : public TTransactionBase<TSchemeShard> {
 
                     if (rowset.HaveValue<Schema::SubDomainsAlterData::DeclaredSchemeQuotas>()) {
                         NKikimrSubDomains::TSchemeQuotas declaredSchemeQuotas;
-                        Y_ENSURE(ParseFromStringNoSizeLimit(declaredSchemeQuotas, rowset.GetValue<Schema::SubDomainsAlterData::DeclaredSchemeQuotas>()));
+                        Y_ABORT_UNLESS(ParseFromStringNoSizeLimit(declaredSchemeQuotas, rowset.GetValue<Schema::SubDomainsAlterData::DeclaredSchemeQuotas>()));
                         alter->SetDeclaredSchemeQuotas(declaredSchemeQuotas);
                     }
 
                     if (rowset.HaveValue<Schema::SubDomainsAlterData::DatabaseQuotas>()) {
                         Ydb::Cms::DatabaseQuotas databaseQuotas;
-                        Y_ENSURE(ParseFromStringNoSizeLimit(databaseQuotas, rowset.GetValue<Schema::SubDomainsAlterData::DatabaseQuotas>()));
+                        Y_ABORT_UNLESS(ParseFromStringNoSizeLimit(databaseQuotas, rowset.GetValue<Schema::SubDomainsAlterData::DatabaseQuotas>()));
                         alter->SetDatabaseQuotas(databaseQuotas);
                     }
 
@@ -1694,7 +1694,7 @@ struct TSchemeShard::TTxInit : public TTransactionBase<TSchemeShard> {
                 }
 
                 if (auto resourcesDomainId = subDomain->GetResourcesDomainId()) {
-                    Y_ENSURE(Self->SubDomains.contains(resourcesDomainId), "Unknown ResourcesDomainId: " << resourcesDomainId);
+                    Y_VERIFY_S(Self->SubDomains.contains(resourcesDomainId), "Unknown ResourcesDomainId: " << resourcesDomainId);
                 }
 
                 if (!alter) {
@@ -1702,7 +1702,7 @@ struct TSchemeShard::TTxInit : public TTransactionBase<TSchemeShard> {
                 }
 
                 if (auto resourcesDomainId = alter->GetResourcesDomainId()) {
-                    Y_ENSURE(Self->SubDomains.contains(resourcesDomainId), "Unknown ResourcesDomainId: " << resourcesDomainId);
+                    Y_VERIFY_S(Self->SubDomains.contains(resourcesDomainId), "Unknown ResourcesDomainId: " << resourcesDomainId);
                 }
             }
         }
@@ -1719,7 +1719,7 @@ struct TSchemeShard::TTxInit : public TTransactionBase<TSchemeShard> {
                 TLocalShardIdx localShardIdx = rowset.GetValue<Schema::SubDomainShards::ShardIdx>();
                 TShardIdx shardIdx = Self->MakeLocalId(localShardIdx);
 
-                Y_ENSURE(Self->SubDomains.contains(pathId));
+                Y_ABORT_UNLESS(Self->SubDomains.contains(pathId));
                 Self->SubDomains[pathId]->AddPrivateShard(shardIdx);
 
                 if (!rowset.Next())
@@ -1738,9 +1738,9 @@ struct TSchemeShard::TTxInit : public TTransactionBase<TSchemeShard> {
                     TLocalShardIdx localShardIdx = rowset.GetValue<Schema::SubDomainShardsAlterData::ShardIdx>();
                     TShardIdx shardIdx = Self->MakeLocalId(localShardIdx);
 
-                    Y_ENSURE(Self->SubDomains.contains(pathId));
+                    Y_ABORT_UNLESS(Self->SubDomains.contains(pathId));
                     auto subdomainInfo = Self->SubDomains[pathId];
-                    Y_ENSURE(subdomainInfo->GetAlter());
+                    Y_ABORT_UNLESS(subdomainInfo->GetAlter());
                     subdomainInfo->GetAlter()->AddPrivateShard(shardIdx);
 
                     if (!rowset.Next())
@@ -1787,9 +1787,9 @@ struct TSchemeShard::TTxInit : public TTransactionBase<TSchemeShard> {
             for (const auto& rec: tableRows) {
                 TPathId pathId = std::get<0>(rec);
 
-                Y_ENSURE(Self->PathsById.contains(pathId), "Path doesn't exist, pathId: " << pathId);
-                Y_ENSURE(Self->PathsById.at(pathId)->IsTable(), "Path is not a table, pathId: " << pathId);
-                Y_ENSURE(Self->Tables.FindPtr(pathId) == nullptr, "Table duplicated in DB, pathId: " << pathId);
+                Y_VERIFY_S(Self->PathsById.contains(pathId), "Path doesn't exist, pathId: " << pathId);
+                Y_VERIFY_S(Self->PathsById.at(pathId)->IsTable(), "Path is not a table, pathId: " << pathId);
+                Y_VERIFY_S(Self->Tables.FindPtr(pathId) == nullptr, "Table duplicated in DB, pathId: " << pathId);
 
                 TTableInfo::TPtr tableInfo = new TTableInfo();
                 tableInfo->NextColumnId = std::get<1>(rec);
@@ -1799,7 +1799,7 @@ struct TSchemeShard::TTxInit : public TTransactionBase<TSchemeShard> {
                 if (partitionConfig) {
                     auto& config = tableInfo->MutablePartitionConfig();
                     bool parseOk = ParseFromStringNoSizeLimit(config, partitionConfig);
-                    Y_ENSURE(parseOk);
+                    Y_ABORT_UNLESS(parseOk);
 
                     if (config.ColumnFamiliesSize() > 1) {
                         // Fix any incorrect legacy config at load time
@@ -1818,7 +1818,7 @@ struct TSchemeShard::TTxInit : public TTransactionBase<TSchemeShard> {
                     tableInfo->AlterData->TableDescriptionFull = NKikimrSchemeOp::TTableDescription();
                     auto& tableDesc = tableInfo->AlterData->TableDescriptionFull.GetRef();
                     bool parseOk = ParseFromStringNoSizeLimit(tableDesc, alterTabletFull);
-                    Y_ENSURE(parseOk);
+                    Y_ABORT_UNLESS(parseOk);
 
                     if (tableDesc.HasPartitionConfig() &&
                         tableDesc.GetPartitionConfig().ColumnFamiliesSize() > 1)
@@ -1829,19 +1829,19 @@ struct TSchemeShard::TTxInit : public TTransactionBase<TSchemeShard> {
                 } else if (alterTabletDiff) {
                     tableInfo->InitAlterData();
                     bool parseOk = ParseFromStringNoSizeLimit(tableInfo->AlterData->TableDescriptionDiff, alterTabletDiff);
-                    Y_ENSURE(parseOk);
+                    Y_ABORT_UNLESS(parseOk);
                 }
 
                 tableInfo->PartitioningVersion = std::get<6>(rec);
 
                 if (const auto ttlSettings = std::get<7>(rec)) {
                     bool parseOk = ParseFromStringNoSizeLimit(tableInfo->MutableTTLSettings(), ttlSettings);
-                    Y_ENSURE(parseOk);
+                    Y_ABORT_UNLESS(parseOk);
                 }
 
                 if (const auto replicationConfig = std::get<9>(rec)) {
                     bool parseOk = ParseFromStringNoSizeLimit(tableInfo->MutableReplicationConfig(), replicationConfig);
-                    Y_ENSURE(parseOk);
+                    Y_ABORT_UNLESS(parseOk);
 
                     if (tableInfo->IsAsyncReplica()) {
                         Self->PathsById.at(pathId)->SetAsyncReplica(true);
@@ -1850,7 +1850,7 @@ struct TSchemeShard::TTxInit : public TTransactionBase<TSchemeShard> {
 
                 if (const auto incrementalBackupConfig = std::get<12>(rec)) {
                     bool parseOk = ParseFromStringNoSizeLimit(tableInfo->MutableIncrementalBackupConfig(), incrementalBackupConfig);
-                    Y_ENSURE(parseOk);
+                    Y_ABORT_UNLESS(parseOk);
 
                     if (tableInfo->IsIncrementalRestoreTable()) {
                         Self->PathsById.at(pathId)->SetIncrementalRestoreTable();
@@ -2047,9 +2047,9 @@ struct TSchemeShard::TTxInit : public TTransactionBase<TSchemeShard> {
                 auto notNull = std::get<11>(rec);
                 auto isBuildInProgress = std::get<12>(rec);
 
-                Y_ENSURE(Self->PathsById.contains(pathId), "Path doesn't exist, pathId: " << pathId);
-                Y_ENSURE(Self->PathsById.at(pathId)->IsTable() || Self->PathsById.at(pathId)->IsExternalTable(), "Path is not a table or external table, pathId: " << pathId);
-                Y_ENSURE(Self->Tables.FindPtr(pathId) || Self->ExternalTables.FindPtr(pathId), "Table or external table don't exist, pathId: " << pathId);
+                Y_VERIFY_S(Self->PathsById.contains(pathId), "Path doesn't exist, pathId: " << pathId);
+                Y_VERIFY_S(Self->PathsById.at(pathId)->IsTable() || Self->PathsById.at(pathId)->IsExternalTable(), "Path is not a table or external table, pathId: " << pathId);
+                Y_VERIFY_S(Self->Tables.FindPtr(pathId) || Self->ExternalTables.FindPtr(pathId), "Table or external table don't exist, pathId: " << pathId);
 
                 TTableInfo::TColumn colInfo(colName, colId, typeInfo, typeMod, notNull);
                 colInfo.KeyOrder = keyOrder;
@@ -2063,7 +2063,7 @@ struct TSchemeShard::TTxInit : public TTransactionBase<TSchemeShard> {
 
                 if (auto it = Self->Tables.find(pathId); it != Self->Tables.end()) {
                     TTableInfo::TPtr tableInfo = it->second;
-                    Y_ENSURE(colId < tableInfo->NextColumnId, "Column id should be less than NextColId"
+                    Y_VERIFY_S(colId < tableInfo->NextColumnId, "Column id should be less than NextColId"
                                 << ", columnId: " << colId
                                 << ", NextColId: " << tableInfo->NextColumnId);
 
@@ -2107,10 +2107,10 @@ struct TSchemeShard::TTxInit : public TTransactionBase<TSchemeShard> {
                 auto notNull = std::get<11>(rec);
                 auto isBuildInProgress = std::get<12>(rec);
 
-                Y_ENSURE(Self->PathsById.contains(pathId), "Path doesn't exist, pathId: " << pathId);
-                Y_ENSURE(Self->PathsById.at(pathId)->IsTable(), "Path is not a table, pathId: " << pathId);
+                Y_VERIFY_S(Self->PathsById.contains(pathId), "Path doesn't exist, pathId: " << pathId);
+                Y_VERIFY_S(Self->PathsById.at(pathId)->IsTable(), "Path is not a table, pathId: " << pathId);
 
-                Y_ENSURE(Self->Tables.FindPtr(pathId), "Table doesn't exist, pathId: " << pathId);
+                Y_VERIFY_S(Self->Tables.FindPtr(pathId), "Table doesn't exist, pathId: " << pathId);
 
                 TTableInfo::TPtr tableInfo = Self->Tables[pathId];
                 tableInfo->InitAlterData();
@@ -2161,7 +2161,7 @@ struct TSchemeShard::TTxInit : public TTransactionBase<TSchemeShard> {
                                 << ", TabletType: " << TTabletTypes::TypeToStr(std::get<4>(rec))
                                 << ", at schemeshard: " << Self->TabletID());
 
-                Y_ENSURE(!Self->ShardInfos.contains(idx));
+                Y_ABORT_UNLESS(!Self->ShardInfos.contains(idx));
                 TShardInfo& shard = Self->ShardInfos[idx];
 
                 shard.TabletID = std::get<1>(rec);
@@ -2171,7 +2171,7 @@ struct TSchemeShard::TTxInit : public TTransactionBase<TSchemeShard> {
 
                 Self->IncrementPathDbRefCount(shard.PathId);
 
-                Y_ENSURE(shard.TabletType != ETabletType::TypeInvalid, "upgrade schema was wrong");
+                Y_ABORT_UNLESS(shard.TabletType != ETabletType::TypeInvalid, "upgrade schema was wrong");
 
                 switch (shard.TabletType) {
                     case ETabletType::PersQueueReadBalancer:
@@ -2213,10 +2213,10 @@ struct TSchemeShard::TTxInit : public TTransactionBase<TSchemeShard> {
                 adoptedShard.PrevShardIdx = adoptedRowset.GetValue<Schema::AdoptedShards::PrevShardIdx>();
 
                 TShardInfo* shard = Self->ShardInfos.FindPtr(shardIdx);
-                Y_ENSURE(shard);
+                Y_ABORT_UNLESS(shard);
 
                 TTabletId tabletId = adoptedRowset.GetValue<Schema::AdoptedShards::TabletId>();
-                Y_ENSURE(shard->TabletID == InvalidTabletId || shard->TabletID == tabletId);
+                Y_ABORT_UNLESS(shard->TabletID == InvalidTabletId || shard->TabletID == tabletId);
                 shard->TabletID = tabletId;
 
                 if (!adoptedRowset.Next())
@@ -2250,8 +2250,8 @@ struct TSchemeShard::TTxInit : public TTransactionBase<TSchemeShard> {
 
                 if (tableId != prevTableId) {
                     if (prevTableId) {
-                        Y_ENSURE(!partitions.empty());
-                        Y_ENSURE(Self->Tables.contains(prevTableId));
+                        Y_ABORT_UNLESS(!partitions.empty());
+                        Y_ABORT_UNLESS(Self->Tables.contains(prevTableId));
                         TTableInfo::TPtr tableInfo = Self->Tables.at(prevTableId);
                         Self->SetPartitioning(prevTableId, tableInfo, std::move(partitions));
                         partitions.clear();
@@ -2283,8 +2283,8 @@ struct TSchemeShard::TTxInit : public TTransactionBase<TSchemeShard> {
             }
 
             if (prevTableId) {
-                Y_ENSURE(!partitions.empty());
-                Y_ENSURE(Self->Tables.contains(prevTableId));
+                Y_ABORT_UNLESS(!partitions.empty());
+                Y_ABORT_UNLESS(Self->Tables.contains(prevTableId));
                 TTableInfo::TPtr tableInfo = Self->Tables.at(prevTableId);
                 Self->SetPartitioning(prevTableId, tableInfo, std::move(partitions));
             }
@@ -2312,7 +2312,7 @@ struct TSchemeShard::TTxInit : public TTransactionBase<TSchemeShard> {
                     auto it = Self->Tables.find(shardInfo->PathId);
                     if (it != Self->Tables.end()) {
                         bool parseOk = ParseFromStringNoSizeLimit(it->second->PerShardPartitionConfig[shardIdx], data);
-                        Y_ENSURE(parseOk);
+                        Y_ABORT_UNLESS(parseOk);
                     }
                 }
             }
@@ -2334,7 +2334,7 @@ struct TSchemeShard::TTxInit : public TTransactionBase<TSchemeShard> {
 
                 if (tableId != prevTableId) {
                     if (prevTableId) {
-                        Y_ENSURE(Self->Tables.contains(prevTableId));
+                        Y_ABORT_UNLESS(Self->Tables.contains(prevTableId));
                         TTableInfo::TPtr tableInfo = Self->Tables.at(prevTableId);
                         if (!tableInfo->IsBackup && !tableInfo->IsShardsStatsDetached()) {
                             Self->ResolveDomainInfo(prevTableId)->AggrDiskSpaceUsage(Self, tableInfo->GetStats().Aggregated);
@@ -2344,14 +2344,14 @@ struct TSchemeShard::TTxInit : public TTransactionBase<TSchemeShard> {
                     prevTableId = tableId;
                 }
 
-                Y_ENSURE(Self->Tables.contains(tableId));
+                Y_ABORT_UNLESS(Self->Tables.contains(tableId));
                 TTableInfo::TPtr tableInfo = Self->Tables.at(tableId);
 
                 const ui64 partitionId = rowSet.GetValue<Schema::TablePartitionStats::PartitionId>();
-                Y_ENSURE(partitionId < tableInfo->GetPartitions().size());
+                Y_ABORT_UNLESS(partitionId < tableInfo->GetPartitions().size());
 
                 const TShardIdx shardIdx = tableInfo->GetPartitions()[partitionId].ShardIdx;
-                Y_ENSURE(shardIdx != InvalidShardIdx);
+                Y_ABORT_UNLESS(shardIdx != InvalidShardIdx);
 
                 if (Self->ShardInfos.contains(shardIdx)) {
                     const TShardInfo& shardInfo = Self->ShardInfos.at(shardIdx);
@@ -2372,7 +2372,7 @@ struct TSchemeShard::TTxInit : public TTransactionBase<TSchemeShard> {
                 stats.ByKeyFilterSize = rowSet.GetValue<Schema::TablePartitionStats::ByKeyFilterSize>();
                 if (rowSet.HaveValue<Schema::TablePartitionStats::StoragePoolsStats>()) {
                     NKikimrTableStats::TStoragePoolsStats protobufRepresentation;
-                    Y_ENSURE(ParseFromStringNoSizeLimit(
+                    Y_ABORT_UNLESS(ParseFromStringNoSizeLimit(
                             protobufRepresentation,
                             rowSet.GetValue<Schema::TablePartitionStats::StoragePoolsStats>()
                         )
@@ -2432,7 +2432,7 @@ struct TSchemeShard::TTxInit : public TTransactionBase<TSchemeShard> {
             }
 
             if (prevTableId) {
-                Y_ENSURE(Self->Tables.contains(prevTableId));
+                Y_ABORT_UNLESS(Self->Tables.contains(prevTableId));
                 TTableInfo::TPtr tableInfo = Self->Tables.at(prevTableId);
                 if (!tableInfo->IsBackup && !tableInfo->IsShardsStatsDetached()) {
                     Self->ResolveDomainInfo(prevTableId)->AggrDiskSpaceUsage(Self, tableInfo->GetStats().Aggregated);
@@ -2458,7 +2458,7 @@ struct TSchemeShard::TTxInit : public TTransactionBase<TSchemeShard> {
                 TString bindingData = std::get<2>(rec);
                 TString poolName = std::get<3>(rec);
 
-                Y_ENSURE(Self->ShardInfos.contains(shardIdx));
+                Y_ABORT_UNLESS(Self->ShardInfos.contains(shardIdx));
                 TShardInfo& shardInfo = Self->ShardInfos[shardIdx];
                 if (shardInfo.BindedChannels.size() <= channelId) {
                     shardInfo.BindedChannels.resize(channelId + 1);
@@ -2467,7 +2467,7 @@ struct TSchemeShard::TTxInit : public TTransactionBase<TSchemeShard> {
 
                 if (bindingData) {
                     bool parseOk = ParseFromStringNoSizeLimit(channelBind, bindingData);
-                    Y_ENSURE(parseOk);
+                    Y_ABORT_UNLESS(parseOk);
                 }
                 if (poolName) {
                     channelBind.SetStoragePoolName(poolName);
@@ -2493,7 +2493,7 @@ struct TSchemeShard::TTxInit : public TTransactionBase<TSchemeShard> {
                 pqGroup->TotalGroupCount = rowset.GetValueOrDefault<Schema::PersQueueGroups::TotalGroupCount>(0);
 
                 const bool ok = pqGroup->FillKeySchema(pqGroup->TabletConfig);
-                Y_ENSURE(ok);
+                Y_ABORT_UNLESS(ok);
 
                 Self->Topics[pathId] = pqGroup;
                 Self->IncrementPathDbRefCount(pathId);
@@ -2501,7 +2501,7 @@ struct TSchemeShard::TTxInit : public TTransactionBase<TSchemeShard> {
                 auto it = pqBalancers.find(pathId);
                 if (it != pqBalancers.end()) {
                     auto idx = it->second;
-                    Y_ENSURE(Self->ShardInfos.contains(idx));
+                    Y_ABORT_UNLESS(Self->ShardInfos.contains(idx));
                     const TShardInfo& shard = Self->ShardInfos.at(idx);
                     pqGroup->BalancerTabletID = shard.TabletID;
                     pqGroup->BalancerShardIdx = idx;
@@ -2561,8 +2561,8 @@ struct TSchemeShard::TTxInit : public TTransactionBase<TSchemeShard> {
                 }
 
                 auto it = Self->Topics.find(pathId);
-                Y_ENSURE(it != Self->Topics.end());
-                Y_ENSURE(it->second);
+                Y_ABORT_UNLESS(it != Self->Topics.end());
+                Y_ABORT_UNLESS(it->second);
                 TTopicInfo::TPtr pqGroup = it->second;
                 if (pqInfo->AlterVersion <= pqGroup->AlterVersion) {
                     ++pqGroup->TotalPartitionCount;
@@ -2605,10 +2605,10 @@ struct TSchemeShard::TTxInit : public TTransactionBase<TSchemeShard> {
                 alterData->BootstrapConfig = rowset.GetValue<Schema::PersQueueGroupAlters::BootstrapConfig>();
 
                 const bool ok = alterData->FillKeySchema(alterData->TabletConfig);
-                Y_ENSURE(ok);
+                Y_ABORT_UNLESS(ok);
 
                 auto it = Self->Topics.find(pathId);
-                Y_ENSURE(it != Self->Topics.end());
+                Y_ABORT_UNLESS(it != Self->Topics.end());
 
                 alterData->TotalPartitionCount = it->second->GetTotalPartitionCountWithAlter();
                 alterData->BalancerTabletID = it->second->BalancerTabletID;
@@ -2681,11 +2681,11 @@ struct TSchemeShard::TTxInit : public TTransactionBase<TSchemeShard> {
                 TPathId pathId(selfId, localPathId);
 
                 auto it = Self->RtmrVolumes.find(pathId);
-                Y_ENSURE(it != Self->RtmrVolumes.end());
-                Y_ENSURE(it->second);
+                Y_ABORT_UNLESS(it != Self->RtmrVolumes.end());
+                Y_ABORT_UNLESS(it->second);
 
                 auto partitionId = rowset.GetValue<Schema::RTMRPartitions::PartitionId>();
-                Y_ENSURE(partitionId.size() == sizeof(TGUID));
+                Y_ABORT_UNLESS(partitionId.size() == sizeof(TGUID));
 
                 TGUID guidId;
                 Copy(partitionId.cbegin(), partitionId.cend(), (char*)guidId.dw);
@@ -2736,8 +2736,8 @@ struct TSchemeShard::TTxInit : public TTransactionBase<TSchemeShard> {
                 TPathId pathId = Self->MakeLocalId(localPathId);
 
                 auto it = Self->SolomonVolumes.find(pathId);
-                Y_ENSURE(it != Self->SolomonVolumes.end());
-                Y_ENSURE(it->second);
+                Y_ABORT_UNLESS(it != Self->SolomonVolumes.end());
+                Y_ABORT_UNLESS(it->second);
 
                 ui64 partitionId = rowset.GetValue<Schema::SolomonPartitions::PartitionId>();
                 TLocalShardIdx localShardIdx = rowset.GetValue<Schema::SolomonPartitions::ShardId>();
@@ -2767,10 +2767,10 @@ struct TSchemeShard::TTxInit : public TTransactionBase<TSchemeShard> {
                                       rowset.GetValue<Schema::AlterSolomonVolumes::LocalPathId>());
                 ui64 version = rowset.GetValue<Schema::AlterSolomonVolumes::Version>();
 
-                Y_ENSURE(Self->SolomonVolumes.contains(pathId));
+                Y_ABORT_UNLESS(Self->SolomonVolumes.contains(pathId));
                 TSolomonVolumeInfo::TPtr solomon = Self->SolomonVolumes.at(pathId);
 
-                Y_ENSURE(solomon->AlterData == nullptr);
+                Y_ABORT_UNLESS(solomon->AlterData == nullptr);
                 solomon->AlterData = solomon->CreateAlter(version);
 
                 if (!rowset.Next())
@@ -2793,12 +2793,12 @@ struct TSchemeShard::TTxInit : public TTransactionBase<TSchemeShard> {
 
                 const ui64 partitionId = rowset.GetValue<Schema::AlterSolomonPartitions::PartitionId>();
 
-                Y_ENSURE(Self->SolomonVolumes.contains(pathId));
+                Y_ABORT_UNLESS(Self->SolomonVolumes.contains(pathId));
                 TSolomonVolumeInfo::TPtr solomon = Self->SolomonVolumes.at(pathId);
-                Y_ENSURE(solomon->AlterData);
+                Y_ABORT_UNLESS(solomon->AlterData);
 
                 if (solomon->Partitions.size() <= partitionId) {
-                    Y_ENSURE(!solomon->AlterData->Partitions.contains(shardIdx));
+                    Y_ABORT_UNLESS(!solomon->AlterData->Partitions.contains(shardIdx));
 
                     auto shardInfo = Self->ShardInfos.FindPtr(shardIdx);
                     if (shardInfo) {
@@ -2809,9 +2809,9 @@ struct TSchemeShard::TTxInit : public TTransactionBase<TSchemeShard> {
 
                 } else {
                     //old partition
-                    Y_ENSURE(solomon->AlterData->Partitions.contains(shardIdx));
-                    Y_ENSURE(solomon->AlterData->Partitions.at(shardIdx)->PartitionId == partitionId);
-                    Y_ENSURE(Self->ShardInfos.contains(shardIdx));
+                    Y_ABORT_UNLESS(solomon->AlterData->Partitions.contains(shardIdx));
+                    Y_ABORT_UNLESS(solomon->AlterData->Partitions.at(shardIdx)->PartitionId == partitionId);
+                    Y_ABORT_UNLESS(Self->ShardInfos.contains(shardIdx));
                 }
 
                 if (!rowset.Next())
@@ -2838,13 +2838,13 @@ struct TSchemeShard::TTxInit : public TTransactionBase<TSchemeShard> {
                 TTableIndexInfo::EState state = std::get<3>(rec);
                 auto description = std::get<4>(rec);
 
-                Y_ENSURE(Self->PathsById.contains(pathId), "Path doesn't exist, pathId: " << pathId);
+                Y_VERIFY_S(Self->PathsById.contains(pathId), "Path doesn't exist, pathId: " << pathId);
                 TPathElement::TPtr path = Self->PathsById.at(pathId);
-                Y_ENSURE(path->IsTableIndex(), "Path is not a table index"
+                Y_VERIFY_S(path->IsTableIndex(), "Path is not a table index"
                                << ", pathId: " << pathId
                                << ", path type: " << NKikimrSchemeOp::EPathType_Name(path->PathType));
 
-                Y_ENSURE(!Self->Indexes.contains(pathId));
+                Y_ABORT_UNLESS(!Self->Indexes.contains(pathId));
                 Self->Indexes[pathId] = new TTableIndexInfo(alterVersion, indexType, state, description);
                 Self->IncrementPathDbRefCount(pathId);
             }
@@ -2864,24 +2864,24 @@ struct TSchemeShard::TTxInit : public TTransactionBase<TSchemeShard> {
                     TTableIndexInfo::EState state = rowset.GetValue<Schema::TableIndexAlterData::State>();
                     auto description = rowset.GetValue<Schema::TableIndexAlterData::Description>();
 
-                    Y_ENSURE(Self->PathsById.contains(pathId), "Path doesn't exist, pathId: " << pathId);
+                    Y_VERIFY_S(Self->PathsById.contains(pathId), "Path doesn't exist, pathId: " << pathId);
                     TPathElement::TPtr path = Self->PathsById.at(pathId);
-                    Y_ENSURE(path->IsTableIndex(), "Path is not a table index, pathId: " << pathId);
+                    Y_VERIFY_S(path->IsTableIndex(), "Path is not a table index, pathId: " << pathId);
 
                     if (!Self->Indexes.contains(pathId)) {
                         Self->Indexes[pathId] = TTableIndexInfo::NotExistedYet(indexType);
                         Self->IncrementPathDbRefCount(pathId);
                     }
                     auto tableIndex = Self->Indexes.at(pathId);
-                    Y_ENSURE(tableIndex->AlterData == nullptr);
-                    Y_ENSURE(tableIndex->AlterVersion < alterVersion);
+                    Y_ABORT_UNLESS(tableIndex->AlterData == nullptr);
+                    Y_ABORT_UNLESS(tableIndex->AlterVersion < alterVersion);
                     tableIndex->AlterData = new TTableIndexInfo(alterVersion, indexType, state, description);
 
-                    Y_ENSURE(Self->PathsById.contains(path->ParentPathId), "Parent path is not found"
+                    Y_VERIFY_S(Self->PathsById.contains(path->ParentPathId), "Parent path is not found"
                                    << ", index pathId: " << pathId
                                    << ", parent pathId: " << path->ParentPathId);
                     TPathElement::TPtr parent = Self->PathsById.at(path->ParentPathId);
-                    Y_ENSURE(parent->IsTable(), "Parent path is not a table"
+                    Y_VERIFY_S(parent->IsTable(), "Parent path is not a table"
                                    << ", index pathId: " << pathId
                                    << ", parent pathId: " << path->ParentPathId);
 
@@ -2915,14 +2915,14 @@ struct TSchemeShard::TTxInit : public TTransactionBase<TSchemeShard> {
                 ui32 keyId = std::get<1>(rec);
                 TString keyName = std::get<2>(rec);
 
-                Y_ENSURE(Self->PathsById.contains(pathId), "Path doesn't exist, pathId: " << pathId);
+                Y_VERIFY_S(Self->PathsById.contains(pathId), "Path doesn't exist, pathId: " << pathId);
                 TPathElement::TPtr path = Self->PathsById.at(pathId);
-                Y_ENSURE(path->IsTableIndex(), "Path is not a table index, pathId: " << pathId);
+                Y_VERIFY_S(path->IsTableIndex(), "Path is not a table index, pathId: " << pathId);
 
-                Y_ENSURE(Self->Indexes.contains(pathId));
+                Y_ABORT_UNLESS(Self->Indexes.contains(pathId));
                 auto tableIndex = Self->Indexes.at(pathId);
 
-                Y_ENSURE(keyId == tableIndex->IndexKeys.size());
+                Y_ABORT_UNLESS(keyId == tableIndex->IndexKeys.size());
                 tableIndex->IndexKeys.emplace_back(keyName);
             }
 
@@ -2935,12 +2935,12 @@ struct TSchemeShard::TTxInit : public TTransactionBase<TSchemeShard> {
 
                 if (Self->PathsById.contains(pathId)) {
                     TPathElement::TPtr path = Self->PathsById.at(pathId);
-                    Y_ENSURE(path->IsTableIndex(), "Path is not a table index, pathId: " << pathId);
+                    Y_VERIFY_S(path->IsTableIndex(), "Path is not a table index, pathId: " << pathId);
 
                     if (Self->Indexes.contains(pathId)) {
                         auto tableIndex = Self->Indexes.at(pathId);
 
-                        Y_ENSURE(dataId == tableIndex->IndexDataColumns.size());
+                        Y_ABORT_UNLESS(dataId == tableIndex->IndexDataColumns.size());
                         tableIndex->IndexDataColumns.emplace_back(dataName);
                     } else {
                         leakedDataColumns.emplace_back(pathId, dataId);
@@ -2968,18 +2968,18 @@ struct TSchemeShard::TTxInit : public TTransactionBase<TSchemeShard> {
                     ui32 keyId = rowset.GetValue<Schema::TableIndexKeysAlterData::KeyId>();
                     TString keyName = rowset.GetValue<Schema::TableIndexKeysAlterData::KeyName>();
 
-                    Y_ENSURE(Self->PathsById.contains(pathId), "Path doesn't exist, pathId: " << pathId);
+                    Y_VERIFY_S(Self->PathsById.contains(pathId), "Path doesn't exist, pathId: " << pathId);
                     TPathElement::TPtr path = Self->PathsById.at(pathId);
-                    Y_ENSURE(path->IsTableIndex(), "Path is not a table index, pathId: " << pathId);
+                    Y_VERIFY_S(path->IsTableIndex(), "Path is not a table index, pathId: " << pathId);
 
-                    Y_ENSURE(Self->Indexes.contains(pathId));
+                    Y_ABORT_UNLESS(Self->Indexes.contains(pathId));
                     auto tableIndex = Self->Indexes.at(pathId);
 
-                    Y_ENSURE(tableIndex->AlterData != nullptr);
+                    Y_ABORT_UNLESS(tableIndex->AlterData != nullptr);
                     auto alterData = tableIndex->AlterData;
-                    Y_ENSURE(tableIndex->AlterVersion < alterData->AlterVersion);
+                    Y_ABORT_UNLESS(tableIndex->AlterVersion < alterData->AlterVersion);
 
-                    Y_ENSURE(keyId == alterData->IndexKeys.size());
+                    Y_ABORT_UNLESS(keyId == alterData->IndexKeys.size());
                     alterData->IndexKeys.emplace_back(keyName);
 
                     if (!rowset.Next())
@@ -3004,16 +3004,16 @@ struct TSchemeShard::TTxInit : public TTransactionBase<TSchemeShard> {
 
                     if (Self->PathsById.contains(pathId)) {
                         TPathElement::TPtr path = Self->PathsById.at(pathId);
-                        Y_ENSURE(path->IsTableIndex(), "Path is not a table index, pathId: " << pathId);
+                        Y_VERIFY_S(path->IsTableIndex(), "Path is not a table index, pathId: " << pathId);
 
                         if (Self->Indexes.contains(pathId)) {
                             auto tableIndex = Self->Indexes.at(pathId);
 
-                            Y_ENSURE(tableIndex->AlterData != nullptr);
+                            Y_ABORT_UNLESS(tableIndex->AlterData != nullptr);
                             auto alterData = tableIndex->AlterData;
-                            Y_ENSURE(tableIndex->AlterVersion < alterData->AlterVersion);
+                            Y_ABORT_UNLESS(tableIndex->AlterVersion < alterData->AlterVersion);
 
-                            Y_ENSURE(dataColId == alterData->IndexDataColumns.size());
+                            Y_ABORT_UNLESS(dataColId == alterData->IndexDataColumns.size());
                             alterData->IndexDataColumns.emplace_back(dataColName);
                         } else {
                            leakedDataColumnsAlterData.emplace_back(pathId, dataColId);
@@ -3051,19 +3051,19 @@ struct TSchemeShard::TTxInit : public TTransactionBase<TSchemeShard> {
                 auto awsRegion = rowset.GetValue<Schema::CdcStream::AwsRegion>();
                 auto state = rowset.GetValue<Schema::CdcStream::State>();
 
-                Y_ENSURE(Self->PathsById.contains(pathId), "Path doesn't exist, pathId: " << pathId);
+                Y_VERIFY_S(Self->PathsById.contains(pathId), "Path doesn't exist, pathId: " << pathId);
                 auto path = Self->PathsById.at(pathId);
 
-                Y_ENSURE(path->IsCdcStream(), "Path is not a cdc stream"
+                Y_VERIFY_S(path->IsCdcStream(), "Path is not a cdc stream"
                     << ", pathId: " << pathId
                     << ", path type: " << NKikimrSchemeOp::EPathType_Name(path->PathType));
 
-                Y_ENSURE(!Self->CdcStreams.contains(pathId));
+                Y_ABORT_UNLESS(!Self->CdcStreams.contains(pathId));
                 Self->CdcStreams[pathId] = new TCdcStreamInfo(alterVersion, mode, format, vt, rt, awsRegion, state);
                 Self->IncrementPathDbRefCount(pathId);
 
                 if (state == NKikimrSchemeOp::ECdcStreamStateScan) {
-                    Y_ENSURE(Self->PathsById.contains(path->ParentPathId), "Parent path is not found"
+                    Y_VERIFY_S(Self->PathsById.contains(path->ParentPathId), "Parent path is not found"
                         << ", cdc stream pathId: " << pathId
                         << ", parent pathId: " << path->ParentPathId);
                     CdcStreamScansToResume[path->ParentPathId].push_back(pathId);
@@ -3096,33 +3096,33 @@ struct TSchemeShard::TTxInit : public TTransactionBase<TSchemeShard> {
                 auto awsRegion = rowset.GetValue<Schema::CdcStreamAlterData::AwsRegion>();
                 auto state = rowset.GetValue<Schema::CdcStreamAlterData::State>();
 
-                Y_ENSURE(Self->PathsById.contains(pathId), "Path doesn't exist, pathId: " << pathId);
+                Y_VERIFY_S(Self->PathsById.contains(pathId), "Path doesn't exist, pathId: " << pathId);
                 auto path = Self->PathsById.at(pathId);
 
-                Y_ENSURE(path->IsCdcStream(), "Path is not a cdc stream"
+                Y_VERIFY_S(path->IsCdcStream(), "Path is not a cdc stream"
                     << ", pathId: " << pathId
                     << ", path type: " << NKikimrSchemeOp::EPathType_Name(path->PathType));
 
                 if (!Self->CdcStreams.contains(pathId)) {
-                    Y_ENSURE(alterVersion == 1);
+                    Y_ABORT_UNLESS(alterVersion == 1);
                     Self->CdcStreams[pathId] = TCdcStreamInfo::New(mode, format, vt, rt, awsRegion);
                     Self->IncrementPathDbRefCount(pathId);
                 }
 
                 auto stream = Self->CdcStreams.at(pathId);
-                Y_ENSURE(stream->AlterData == nullptr);
-                Y_ENSURE(stream->AlterVersion < alterVersion);
+                Y_ABORT_UNLESS(stream->AlterData == nullptr);
+                Y_ABORT_UNLESS(stream->AlterVersion < alterVersion);
                 stream->AlterData = new TCdcStreamInfo(alterVersion, mode, format, vt, rt, awsRegion, state);
 
-                Y_ENSURE(Self->PathsById.contains(path->ParentPathId), "Parent path is not found"
+                Y_VERIFY_S(Self->PathsById.contains(path->ParentPathId), "Parent path is not found"
                     << ", cdc stream pathId: " << pathId
                     << ", parent pathId: " << path->ParentPathId);
                 auto parent = Self->PathsById.at(path->ParentPathId);
 
-                Y_ENSURE(parent->IsTable(), "Parent path is not a table"
+                Y_VERIFY_S(parent->IsTable(), "Parent path is not a table"
                     << ", cdc stream pathId: " << pathId
                     << ", parent pathId: " << path->ParentPathId);
-                Y_ENSURE(Self->Tables.contains(path->ParentPathId), "Parent path is not found in Tables map"
+                Y_VERIFY_S(Self->Tables.contains(path->ParentPathId), "Parent path is not found in Tables map"
                     << ", cdc stream pathId: " << pathId
                     << ", parent pathId: " << path->ParentPathId);
 
@@ -3150,7 +3150,7 @@ struct TSchemeShard::TTxInit : public TTransactionBase<TSchemeShard> {
                 );
                 auto status = rowset.GetValue<Schema::CdcStreamScanShardStatus::Status>();
 
-                Y_ENSURE(Self->CdcStreams.contains(pathId), "Cdc stream not found"
+                Y_VERIFY_S(Self->CdcStreams.contains(pathId), "Cdc stream not found"
                     << ": pathId# " << pathId);
 
                 auto stream = Self->CdcStreams.at(pathId);
@@ -3180,7 +3180,7 @@ struct TSchemeShard::TTxInit : public TTransactionBase<TSchemeShard> {
                 TString name = rowset.GetValue<Schema::StoragePools::PoolName>();
                 TString kind = rowset.GetValue<Schema::StoragePools::PoolKind>();
 
-                Y_ENSURE(Self->SubDomains.contains(pathId));
+                Y_ABORT_UNLESS(Self->SubDomains.contains(pathId));
                 Self->SubDomains[pathId]->AddStoragePool(TStoragePool(name, kind));
 
                 if (!rowset.Next())
@@ -3200,9 +3200,9 @@ struct TSchemeShard::TTxInit : public TTransactionBase<TSchemeShard> {
                     TString name = rowset.GetValue<Schema::StoragePoolsAlterData::PoolName>();
                     TString kind = rowset.GetValue<Schema::StoragePoolsAlterData::PoolKind>();
 
-                    Y_ENSURE(Self->SubDomains.contains(pathId));
+                    Y_ABORT_UNLESS(Self->SubDomains.contains(pathId));
                     auto subdomainInfo = Self->SubDomains[pathId];
-                    Y_ENSURE(subdomainInfo->GetAlter());
+                    Y_ABORT_UNLESS(subdomainInfo->GetAlter());
                     subdomainInfo->GetAlter()->AddStoragePool(TStoragePool(name, kind));
 
                     if (!rowset.Next())
@@ -3215,7 +3215,7 @@ struct TSchemeShard::TTxInit : public TTransactionBase<TSchemeShard> {
         {
             for(auto item: Self->SubDomains) {
                 auto pathId = item.first;
-                Y_ENSURE(Self->PathsById.contains(pathId), "Unknown pathId: " << pathId);
+                Y_VERIFY_S(Self->PathsById.contains(pathId), "Unknown pathId: " << pathId);
                 auto pathItem = Self->PathsById.at(pathId);
                 if (pathItem->Dropped()) {
                     continue;
@@ -3249,7 +3249,7 @@ struct TSchemeShard::TTxInit : public TTransactionBase<TSchemeShard> {
                 {
                     auto cfg = rowset.GetValue<Schema::BlockStoreVolumes::VolumeConfig>();
                     bool parseOk = ParseFromStringNoSizeLimit(volume->VolumeConfig, cfg);
-                    Y_ENSURE(parseOk);
+                    Y_ABORT_UNLESS(parseOk);
                 }
                 volume->AlterVersion = rowset.GetValue<Schema::BlockStoreVolumes::AlterVersion>();
                 volume->MountToken = rowset.GetValue<Schema::BlockStoreVolumes::MountToken>();
@@ -3284,11 +3284,11 @@ struct TSchemeShard::TTxInit : public TTransactionBase<TSchemeShard> {
                 TShardIdx shardIdx = Self->MakeLocalId(localShardIdx);
 
                 auto it = Self->BlockStoreVolumes.find(pathId);
-                Y_ENSURE(it != Self->BlockStoreVolumes.end());
+                Y_ABORT_UNLESS(it != Self->BlockStoreVolumes.end());
                 TBlockStoreVolumeInfo::TPtr volume = it->second;
-                Y_ENSURE(volume);
+                Y_ABORT_UNLESS(volume);
                 TBlockStorePartitionInfo::TPtr& part = volume->Shards[shardIdx];
-                Y_ENSURE(!part);
+                Y_ABORT_UNLESS(!part);
                 part.Reset(new TBlockStorePartitionInfo());
                 part->PartitionId = rowset.GetValue<Schema::BlockStorePartitions::PartitionId>();
                 part->AlterVersion = rowset.GetValue<Schema::BlockStorePartitions::AlterVersion>();
@@ -3314,19 +3314,19 @@ struct TSchemeShard::TTxInit : public TTransactionBase<TSchemeShard> {
                 {
                     auto cfg = rowset.GetValue<Schema::BlockStoreVolumeAlters::VolumeConfig>();
                     bool parseOk = ParseFromStringNoSizeLimit(alterData->VolumeConfig, cfg);
-                    Y_ENSURE(parseOk);
+                    Y_ABORT_UNLESS(parseOk);
                 }
                 alterData->AlterVersion = rowset.GetValue<Schema::BlockStoreVolumeAlters::AlterVersion>();
                 alterData->DefaultPartitionCount = rowset.GetValue<Schema::BlockStoreVolumeAlters::PartitionCount>();
 
                 auto it = Self->BlockStoreVolumes.find(pathId);
-                Y_ENSURE(it != Self->BlockStoreVolumes.end());
+                Y_ABORT_UNLESS(it != Self->BlockStoreVolumes.end());
                 TBlockStoreVolumeInfo::TPtr volume = it->second;
-                Y_ENSURE(volume);
+                Y_ABORT_UNLESS(volume);
                 alterData->VolumeTabletId = volume->VolumeTabletId;
                 alterData->VolumeShardIdx = volume->VolumeShardIdx;
 
-                Y_ENSURE(!volume->AlterData);
+                Y_ABORT_UNLESS(!volume->AlterData);
                 volume->AlterData = std::move(alterData);
 
                 if (!rowset.Next())
@@ -3348,7 +3348,7 @@ struct TSchemeShard::TTxInit : public TTransactionBase<TSchemeShard> {
                 {
                     auto cfg = rowset.GetValue<Schema::FileStoreInfos::Config>();
                     bool parseOk = ParseFromStringNoSizeLimit(fs->Config, cfg);
-                    Y_ENSURE(parseOk);
+                    Y_ABORT_UNLESS(parseOk);
                     fs->Version = rowset.GetValueOrDefault<Schema::FileStoreInfos::Version>();
                 }
                 Self->FileStoreInfos[pathId] = fs;
@@ -3377,16 +3377,16 @@ struct TSchemeShard::TTxInit : public TTransactionBase<TSchemeShard> {
                     TPathId pathId(selfId, localPathId);
 
                     auto it = Self->FileStoreInfos.find(pathId);
-                    Y_ENSURE(it != Self->FileStoreInfos.end());
+                    Y_ABORT_UNLESS(it != Self->FileStoreInfos.end());
 
                     TFileStoreInfo::TPtr fs = it->second;
-                    Y_ENSURE(fs);
+                    Y_ABORT_UNLESS(fs);
 
                     {
                         fs->AlterConfig = MakeHolder<NKikimrFileStore::TConfig>();
                         auto cfg = rowset.GetValue<Schema::FileStoreAlters::Config>();
                         bool parseOk = ParseFromStringNoSizeLimit(*fs->AlterConfig, cfg);
-                        Y_ENSURE(parseOk);
+                        Y_ABORT_UNLESS(parseOk);
                         fs->AlterVersion = rowset.GetValue<Schema::FileStoreAlters::Version>();
                     }
 
@@ -3416,7 +3416,7 @@ struct TSchemeShard::TTxInit : public TTransactionBase<TSchemeShard> {
                 TKesusInfo::TPtr kesus = new TKesusInfo();
                 {
                     bool parseOk = ParseFromStringNoSizeLimit(kesus->Config, config);
-                    Y_ENSURE(parseOk);
+                    Y_ABORT_UNLESS(parseOk);
                     kesus->Version = version;
                 }
                 Self->KesusInfos[pathId] = kesus;
@@ -3450,13 +3450,13 @@ struct TSchemeShard::TTxInit : public TTransactionBase<TSchemeShard> {
                 const ui64& version = std::get<2>(rec);
 
                 auto it = Self->KesusInfos.find(pathId);
-                Y_ENSURE(it != Self->KesusInfos.end());
+                Y_ABORT_UNLESS(it != Self->KesusInfos.end());
                 TKesusInfo::TPtr kesus = it->second;
-                Y_ENSURE(kesus);
+                Y_ABORT_UNLESS(kesus);
                 {
                     kesus->AlterConfig.Reset(new Ydb::Coordination::Config);
                     bool parseOk = ParseFromStringNoSizeLimit(*kesus->AlterConfig, config);
-                    Y_ENSURE(parseOk);
+                    Y_ABORT_UNLESS(parseOk);
                     kesus->AlterVersion = version;
                 }
             }
@@ -3501,9 +3501,9 @@ struct TSchemeShard::TTxInit : public TTransactionBase<TSchemeShard> {
                 txState.NeedSyncHive = txInFlightRowset.GetValueOrDefault<Schema::TxInFlightV2::NeedSyncHive>(false);
 
                 if (txState.TxType == TTxState::TxCopyTable && txState.SourcePathId) {
-                    Y_ENSURE(txState.SourcePathId);
+                    Y_ABORT_UNLESS(txState.SourcePathId);
                     TPathElement::TPtr srcPath = Self->PathsById.at(txState.SourcePathId);
-                    Y_ENSURE(srcPath, "Null path element, pathId: " << txState.SourcePathId);
+                    Y_VERIFY_S(srcPath, "Null path element, pathId: " << txState.SourcePathId);
 
                     // CopyTable source must not be altered or dropped while the Tx is in progress
                     srcPath->PathState = TPathElement::EPathState::EPathStateCopying;
@@ -3511,9 +3511,9 @@ struct TSchemeShard::TTxInit : public TTransactionBase<TSchemeShard> {
                 }
 
                 if (txState.TxType == TTxState::TxMoveTable || txState.TxType == TTxState::TxMoveTableIndex || txState.TxType == TTxState::TxMoveSequence) {
-                    Y_ENSURE(txState.SourcePathId);
+                    Y_ABORT_UNLESS(txState.SourcePathId);
                     TPathElement::TPtr srcPath = Self->PathsById.at(txState.SourcePathId);
-                    Y_ENSURE(srcPath, "Null path element, pathId: " << txState.SourcePathId);
+                    Y_VERIFY_S(srcPath, "Null path element, pathId: " << txState.SourcePathId);
 
                     // Moving source must not be altered or dropped while the Tx is in progress
                     if (!srcPath->Dropped()) {
@@ -3523,22 +3523,22 @@ struct TSchemeShard::TTxInit : public TTransactionBase<TSchemeShard> {
                 }
 
                 if (txState.TxType == TTxState::TxCreateSubDomain) {
-                    Y_ENSURE(Self->SubDomains.contains(txState.TargetPathId));
+                    Y_ABORT_UNLESS(Self->SubDomains.contains(txState.TargetPathId));
                     auto subDomainInfo = Self->SubDomains.at(txState.TargetPathId);
                     if (txState.State <= TTxState::Propose) {
-                        Y_ENSURE(subDomainInfo->GetAlter());
+                        Y_ABORT_UNLESS(subDomainInfo->GetAlter());
                     }
                 } else if (txState.TxType == TTxState::TxSplitTablePartition || txState.TxType == TTxState::TxMergeTablePartition) {
-                    Y_ENSURE(!extraData.empty(), "Split Tx must have non-empty split description");
+                    Y_ABORT_UNLESS(!extraData.empty(), "Split Tx must have non-empty split description");
                     txState.SplitDescription = std::make_shared<NKikimrTxDataShard::TSplitMergeDescription>();
                     bool deserializeRes = ParseFromStringNoSizeLimit(*txState.SplitDescription, extraData);
-                    Y_ENSURE(deserializeRes);
+                    Y_ABORT_UNLESS(deserializeRes);
                     splitOpIds.push_back(operationId);
                 } else if (txState.TxType == TTxState::TxFinalizeBuildIndex) {
                     if (!extraData.empty()) {
                         txState.BuildIndexOutcome = std::make_shared<NKikimrSchemeOp::TBuildIndexOutcome>();
                         bool deserializeRes = ParseFromStringNoSizeLimit(*txState.BuildIndexOutcome, extraData);
-                        Y_ENSURE(deserializeRes);
+                        Y_ABORT_UNLESS(deserializeRes);
                     }
                 } else if (txState.TxType == TTxState::TxAlterTable) {
                     if (txState.State <= TTxState::Propose) {
@@ -3547,12 +3547,12 @@ struct TSchemeShard::TTxInit : public TTransactionBase<TSchemeShard> {
 
                         TPathId tablePathId = txState.TargetPathId;
 
-                        Y_ENSURE(Self->PathsById.contains(tablePathId), "Path doesn't exist, pathId: " << tablePathId);
-                        Y_ENSURE(Self->PathsById.at(tablePathId)->IsTable(), "Path is not a table, pathId: " << tablePathId);
-                        Y_ENSURE(Self->Tables.FindPtr(tablePathId), "Table doesn't exist, pathId: " << tablePathId);
+                        Y_VERIFY_S(Self->PathsById.contains(tablePathId), "Path doesn't exist, pathId: " << tablePathId);
+                        Y_VERIFY_S(Self->PathsById.at(tablePathId)->IsTable(), "Path is not a table, pathId: " << tablePathId);
+                        Y_VERIFY_S(Self->Tables.FindPtr(tablePathId), "Table doesn't exist, pathId: " << tablePathId);
 
                         // legacy, ???
-                        Y_ENSURE(Self->Tables.contains(tablePathId));
+                        Y_ABORT_UNLESS(Self->Tables.contains(tablePathId));
                         TTableInfo::TPtr tableInfo = Self->Tables.at(tablePathId);
                         tableInfo->InitAlterData();
                         tableInfo->DeserializeAlterExtraData(extraData);
@@ -3579,7 +3579,7 @@ struct TSchemeShard::TTxInit : public TTransactionBase<TSchemeShard> {
                 } else if (txState.TxType == TTxState::TxForceDropSubDomain || txState.TxType == TTxState::TxForceDropExtSubDomain) {
                     forceDropOpIds.push_back(operationId);
                 } else if (txState.TxType == TTxState::TxAlterUserAttributes) {
-                    Y_ENSURE(Self->PathsById.contains(txState.TargetPathId), "Unknown pathId: " << txState.TargetPathId);
+                    Y_VERIFY_S(Self->PathsById.contains(txState.TargetPathId), "Unknown pathId: " << txState.TargetPathId);
                     TPathElement::TPtr path = Self->PathsById.at(txState.TargetPathId);
                     if (!path->UserAttrs->AlterData) {
                         path->UserAttrs->AlterData = new TUserAttributes(path->UserAttrs->AlterVersion + 1);
@@ -3588,21 +3588,21 @@ struct TSchemeShard::TTxInit : public TTransactionBase<TSchemeShard> {
                     if (!extraData.empty()) {
                         NKikimrSchemeOp::TGenericTxInFlyExtraData proto;
                         bool deserializeRes = ParseFromStringNoSizeLimit(proto, extraData);
-                        Y_ENSURE(deserializeRes);
+                        Y_ABORT_UNLESS(deserializeRes);
                         txState.CdcPathId = TPathId::FromProto(proto.GetTxCopyTableExtraData().GetCdcPathId());
                     }
                 }
 
-                Y_ENSURE(txState.TxType != TTxState::TxInvalid);
-                Y_ENSURE(txState.State != TTxState::Invalid);
+                Y_ABORT_UNLESS(txState.TxType != TTxState::TxInvalid);
+                Y_ABORT_UNLESS(txState.State != TTxState::Invalid);
 
                 // Change path state (cause there's a transaction on it)
                 // It's possible to restore Create or Alter TX on dropped PathId. Preserve 'NotExists' state.
-                Y_ENSURE(Self->PathsById.contains(txState.TargetPathId), "No path element"
+                Y_VERIFY_S(Self->PathsById.contains(txState.TargetPathId), "No path element"
                                << ", txId: " << operationId.GetTxId()
                                << ", pathId: " << txState.TargetPathId);
                 TPathElement::TPtr path = Self->PathsById.at(txState.TargetPathId);
-                Y_ENSURE(path, "No path element for Tx: " <<  operationId.GetTxId() << ", pathId: " << txState.TargetPathId);
+                Y_VERIFY_S(path, "No path element for Tx: " <<  operationId.GetTxId() << ", pathId: " << txState.TargetPathId);
                 path->PathState = CalcPathState(txState.TxType, path->PathState);
 
                 if (path->PathState == TPathElement::EPathState::EPathStateDrop) {
@@ -3635,7 +3635,7 @@ struct TSchemeShard::TTxInit : public TTransactionBase<TSchemeShard> {
                 }
 
                 TOperation::TPtr operation = Self->Operations.at(operationId.GetTxId());
-                Y_ENSURE(operationId.GetSubTxId() == operation->Parts.size());
+                Y_ABORT_UNLESS(operationId.GetSubTxId() == operation->Parts.size());
                 TOperationContext context{Self, txc, ctx, OnComplete, MemChanges, DbChanges};
                 ISubOperation::TPtr part = operation->RestorePart(txState.TxType, txState.State, context);
                 ++(operation->PreparedParts);
@@ -3664,7 +3664,7 @@ struct TSchemeShard::TTxInit : public TTransactionBase<TSchemeShard> {
                 TTxState::ETxState operation = std::get<2>(rec);
 
                 TTxState* txState = Self->FindTx(operationId);
-                Y_ENSURE(txState, "There's shard for unknown Operation"
+                Y_VERIFY_S(txState, "There's shard for unknown Operation"
                                << ", shardIdx: " << shardIdx
                                << ", txId: " << operationId.GetTxId());
 
@@ -3685,7 +3685,7 @@ struct TSchemeShard::TTxInit : public TTransactionBase<TSchemeShard> {
                                        << ", TxState: " << TTxState::StateName(txState->State)
                                    );
                     } else {
-                        Y_ENSURE(Self->ShardInfos.contains(shardIdx), "Unknown shard"
+                        Y_VERIFY_S(Self->ShardInfos.contains(shardIdx), "Unknown shard"
                                        << ", shardIdx: " << shardIdx
                                        << ", txId: " << operationId.GetTxId()
                                        << ", TxType: " << TTxState::TypeName(txState->TxType)
@@ -3708,20 +3708,20 @@ struct TSchemeShard::TTxInit : public TTransactionBase<TSchemeShard> {
                         txState->TxType != TTxState::TxDropReplication &&
                         txState->TxType != TTxState::TxDropReplicationCascade)
                     {
-                        Y_ENSURE(txState->TxType == TTxState::TxCopyTable, "Only CopyTable Tx can have participating shards from a different table"
+                        Y_VERIFY_S(txState->TxType == TTxState::TxCopyTable, "Only CopyTable Tx can have participating shards from a different table"
                                        << ", txId: " << operationId.GetTxId()
                                        << ", targetPathId: " << txState->TargetPathId
                                        << ", shardIdx: " << shardIdx
                                        << ", shardPathId: " << Self->ShardInfos.at(shardIdx).PathId);
 
                         txState->SourcePathId = Self->ShardInfos.at(shardIdx).PathId;
-                        Y_ENSURE(txState->SourcePathId != InvalidPathId);
-                        Y_ENSURE(Self->PathsById.contains(txState->SourcePathId), "No source path element for Operation"
+                        Y_ABORT_UNLESS(txState->SourcePathId != InvalidPathId);
+                        Y_VERIFY_S(Self->PathsById.contains(txState->SourcePathId), "No source path element for Operation"
                                      << ", txId: " << operationId.GetTxId()
                                      << ", pathId: " << txState->SourcePathId);
 
                         TPathElement::TPtr srcPath = Self->PathsById.at(txState->SourcePathId);
-                        Y_ENSURE(srcPath, "Null path element, pathId: " << txState->SourcePathId);
+                        Y_VERIFY_S(srcPath, "Null path element, pathId: " << txState->SourcePathId);
 
                         // CopyTable source must not be altered or dropped while the Tx is in progress
                         srcPath->PathState = TPathElement::EPathState::EPathStateCopying;
@@ -3736,10 +3736,10 @@ struct TSchemeShard::TTxInit : public TTransactionBase<TSchemeShard> {
         for (TOperationId opId : splitOpIds) {
             THashMap<TShardIdx, TString> shardIdxToRangeEnd;
             TTxState* txState = Self->FindTx(opId);
-            Y_ENSURE(txState, "No txState for split/merge opId, txId: " << opId.GetTxId());
-            Y_ENSURE(txState->SplitDescription);
+            Y_VERIFY_S(txState, "No txState for split/merge opId, txId: " << opId.GetTxId());
+            Y_ABORT_UNLESS(txState->SplitDescription);
 
-            Y_ENSURE(Self->Tables.contains(txState->TargetPathId));
+            Y_ABORT_UNLESS(Self->Tables.contains(txState->TargetPathId));
             TTableInfo::TPtr tableInfo = Self->Tables.at(txState->TargetPathId);
             tableInfo->RegisterSplitMergeOp(opId, *txState);
 
@@ -3751,7 +3751,7 @@ struct TSchemeShard::TTxInit : public TTransactionBase<TSchemeShard> {
             }
             for (TTxState::TShardOperation& shardOp : txState->Shards) {
                 if (shardOp.Operation == TTxState::CreateParts) {
-                    Y_ENSURE(shardIdxToRangeEnd.contains(shardOp.Idx));
+                    Y_ABORT_UNLESS(shardIdxToRangeEnd.contains(shardOp.Idx));
                     shardOp.RangeEnd = shardIdxToRangeEnd.at(shardOp.Idx);
                 }
             }
@@ -3760,7 +3760,7 @@ struct TSchemeShard::TTxInit : public TTransactionBase<TSchemeShard> {
         //after all txs and splitTxs was loaded and processed, it is valid to initiate force drops
         for (TOperationId opId: forceDropOpIds) {
             TTxState* txState = Self->FindTx(opId);
-            Y_ENSURE(txState);
+            Y_ABORT_UNLESS(txState);
             auto paths = Self->ListSubTree(txState->TargetPathId, ctx);
             Self->MarkAsDropping(paths, opId.GetTxId(), ctx);
         }
@@ -3775,11 +3775,11 @@ struct TSchemeShard::TTxInit : public TTransactionBase<TSchemeShard> {
                 auto txId = txDependenciesRowset.GetValue<Schema::TxDependencies::TxId>();
                 auto dependentTxId = txDependenciesRowset.GetValue<Schema::TxDependencies::DependentTxId>();
 
-                Y_ENSURE(Self->Operations.contains(txId), "Parent operation is not found"
+                Y_VERIFY_S(Self->Operations.contains(txId), "Parent operation is not found"
                                                             << ", parent txId " << txId
                                                             << ", dependentTxId " << dependentTxId);
 
-                Y_ENSURE(Self->Operations.contains(dependentTxId), "Dependent operation is not found"
+                Y_VERIFY_S(Self->Operations.contains(dependentTxId), "Dependent operation is not found"
                                                                      << ", dependent txId:" << dependentTxId
                                                                      << ", parent txId " << txId);
 
@@ -3833,10 +3833,10 @@ struct TSchemeShard::TTxInit : public TTransactionBase<TSchemeShard> {
                 bool enablePermissions = std::get<9>(rec);
                 TString changefeedUnderlyingTopics = std::get<10>(rec);
 
-                Y_ENSURE(tableName.size() > 0);
+                Y_ABORT_UNLESS(tableName.size() > 0);
 
                 TTableInfo::TPtr tableInfo = Self->Tables.at(pathId);
-                Y_ENSURE(tableInfo.Get() != nullptr);
+                Y_ABORT_UNLESS(tableInfo.Get() != nullptr);
 
                 tableInfo->BackupSettings.SetTableName(tableName);
                 tableInfo->BackupSettings.SetNeedToBill(needToBill);
@@ -3846,27 +3846,27 @@ struct TSchemeShard::TTxInit : public TTransactionBase<TSchemeShard> {
 
                 if (ytSerializedSettings) {
                     auto settings = tableInfo->BackupSettings.MutableYTSettings();
-                    Y_ENSURE(ParseFromStringNoSizeLimit(*settings, ytSerializedSettings));
+                    Y_ABORT_UNLESS(ParseFromStringNoSizeLimit(*settings, ytSerializedSettings));
                 } else if (s3SerializedSettings) {
                     auto settings = tableInfo->BackupSettings.MutableS3Settings();
-                    Y_ENSURE(ParseFromStringNoSizeLimit(*settings, s3SerializedSettings));
+                    Y_ABORT_UNLESS(ParseFromStringNoSizeLimit(*settings, s3SerializedSettings));
                 } else {
                     Y_ABORT("Unknown settings");
                 }
 
                 if (scanSettings) {
                     auto settings = tableInfo->BackupSettings.MutableScanSettings();
-                    Y_ENSURE(ParseFromStringNoSizeLimit(*settings, scanSettings));
+                    Y_ABORT_UNLESS(ParseFromStringNoSizeLimit(*settings, scanSettings));
                 }
 
                 if (tableDesc) {
                     auto desc = tableInfo->BackupSettings.MutableTable();
-                    Y_ENSURE(ParseFromStringNoSizeLimit(*desc, tableDesc));
+                    Y_ABORT_UNLESS(ParseFromStringNoSizeLimit(*desc, tableDesc));
                 }
 
                 if (changefeedUnderlyingTopics) {
                     NKikimrSchemeOp::TChangefeedUnderlyingTopics wrapperOverTopics;
-                    Y_ENSURE(ParseFromStringNoSizeLimit(wrapperOverTopics, changefeedUnderlyingTopics));
+                    Y_ABORT_UNLESS(ParseFromStringNoSizeLimit(wrapperOverTopics, changefeedUnderlyingTopics));
                     for (const auto& topic : wrapperOverTopics.GetChangefeedUnderlyingTopics()) {
                         *tableInfo->BackupSettings.AddChangefeedUnderlyingTopics() = topic;
                     }
@@ -3892,8 +3892,8 @@ struct TSchemeShard::TTxInit : public TTransactionBase<TSchemeShard> {
                 auto task = rowSet.GetValue<Schema::RestoreTasks::Task>();
 
                 TTableInfo::TPtr tableInfo = Self->Tables.at(pathId);
-                Y_ENSURE(tableInfo.Get() != nullptr);
-                Y_ENSURE(ParseFromStringNoSizeLimit(tableInfo->RestoreSettings, task));
+                Y_ABORT_UNLESS(tableInfo.Get() != nullptr);
+                Y_ABORT_UNLESS(ParseFromStringNoSizeLimit(tableInfo->RestoreSettings, task));
 
                 LOG_DEBUG_S(ctx, NKikimrServices::FLAT_TX_SCHEMESHARD,
                             "Loaded restore task"
@@ -4064,7 +4064,7 @@ struct TSchemeShard::TTxInit : public TTransactionBase<TSchemeShard> {
             auto pathId = si.second.PathId;
             Self->TabletIdToShardIdx[tabletId] = shardIdx;
 
-            Y_ENSURE(Self->PathsById.contains(pathId));
+            Y_ABORT_UNLESS(Self->PathsById.contains(pathId));
             auto path = Self->PathsById.at(pathId); //path should't be dropped?
             path->IncShardsInside();
 
@@ -4190,9 +4190,9 @@ struct TSchemeShard::TTxInit : public TTransactionBase<TSchemeShard> {
                 auto tabletConfig = pqGroup->AlterData ? (pqGroup->AlterData->TabletConfig.empty() ? pqGroup->TabletConfig : pqGroup->AlterData->TabletConfig)
                                                        : pqGroup->TabletConfig;
                 NKikimrPQ::TPQTabletConfig config;
-                Y_ENSURE(!tabletConfig.empty());
+                Y_ABORT_UNLESS(!tabletConfig.empty());
                 bool parseOk = ParseFromStringNoSizeLimit(config, tabletConfig);
-                Y_ENSURE(parseOk);
+                Y_ABORT_UNLESS(parseOk);
 
                 const PQGroupReserve reserve(config, activePartitionDelta);
 
@@ -4378,13 +4378,13 @@ struct TSchemeShard::TTxInit : public TTransactionBase<TSchemeShard> {
 
                 while (!rowset.EndOfSet()) {
                     ui64 exportId = rowset.GetValue<Schema::ExportItems::ExportId>();
-                    Y_ENSURE(Self->Exports.contains(exportId), "Export not found"
+                    Y_VERIFY_S(Self->Exports.contains(exportId), "Export not found"
                                << ": exportId# " << exportId);
 
                     TExportInfo::TPtr exportInfo = Self->Exports.at(exportId);
 
                     ui32 itemIdx = rowset.GetValue<Schema::ExportItems::Index>();
-                    Y_ENSURE(itemIdx < exportInfo->Items.size(), "Invalid item's index"
+                    Y_VERIFY_S(itemIdx < exportInfo->Items.size(), "Invalid item's index"
                                << ": exportId# " << exportId
                                << ", itemIdx# " << itemIdx);
 
@@ -4430,7 +4430,7 @@ struct TSchemeShard::TTxInit : public TTransactionBase<TSchemeShard> {
                     TString peerName = rowset.GetValueOrDefault<Schema::Imports::PeerName>();
 
                     Ydb::Import::ImportFromS3Settings settings;
-                    Y_ENSURE(ParseFromStringNoSizeLimit(settings, rowset.GetValue<Schema::Imports::Settings>()));
+                    Y_ABORT_UNLESS(ParseFromStringNoSizeLimit(settings, rowset.GetValue<Schema::Imports::Settings>()));
 
                     TImportInfo::TPtr importInfo = new TImportInfo(id, uid, kind, settings, domainPathId, peerName);
 
@@ -4477,13 +4477,13 @@ struct TSchemeShard::TTxInit : public TTransactionBase<TSchemeShard> {
 
                 while (!rowset.EndOfSet()) {
                     ui64 importId = rowset.GetValue<Schema::ImportItems::ImportId>();
-                    Y_ENSURE(Self->Imports.contains(importId), "Import not found"
+                    Y_VERIFY_S(Self->Imports.contains(importId), "Import not found"
                                << ": importId# " << importId);
 
                     TImportInfo::TPtr importInfo = Self->Imports.at(importId);
 
                     ui32 itemIdx = rowset.GetValue<Schema::ImportItems::Index>();
-                    Y_ENSURE(itemIdx < importInfo->Items.size(), "Invalid item's index"
+                    Y_VERIFY_S(itemIdx < importInfo->Items.size(), "Invalid item's index"
                                << ": importId# " << importId
                                << ", itemIdx# " << itemIdx);
 
@@ -4494,7 +4494,7 @@ struct TSchemeShard::TTxInit : public TTransactionBase<TSchemeShard> {
 
                     if (rowset.HaveValue<Schema::ImportItems::Scheme>()) {
                         Ydb::Table::CreateTableRequest table;
-                        Y_ENSURE(ParseFromStringNoSizeLimit(table, rowset.GetValue<Schema::ImportItems::Scheme>()));
+                        Y_ABORT_UNLESS(ParseFromStringNoSizeLimit(table, rowset.GetValue<Schema::ImportItems::Scheme>()));
                         item.Table = table;
                     }
 
@@ -4504,7 +4504,7 @@ struct TSchemeShard::TTxInit : public TTransactionBase<TSchemeShard> {
 
                     if (rowset.HaveValue<Schema::ImportItems::PreparedCreationQuery>()) {
                         NKikimrSchemeOp::TModifyScheme preparedQuery;
-                        Y_ENSURE(ParseFromStringNoSizeLimit(
+                        Y_ABORT_UNLESS(ParseFromStringNoSizeLimit(
                             preparedQuery,
                             rowset.GetValue<Schema::ImportItems::PreparedCreationQuery>()
                         ));
@@ -4513,7 +4513,7 @@ struct TSchemeShard::TTxInit : public TTransactionBase<TSchemeShard> {
 
                     if (rowset.HaveValue<Schema::ImportItems::Permissions>()) {
                         Ydb::Scheme::ModifyPermissionsRequest permissions;
-                        Y_ENSURE(ParseFromStringNoSizeLimit(permissions, rowset.GetValue<Schema::ImportItems::Permissions>()));
+                        Y_ABORT_UNLESS(ParseFromStringNoSizeLimit(permissions, rowset.GetValue<Schema::ImportItems::Permissions>()));
                         item.Permissions = permissions;
                     }
 
@@ -4527,7 +4527,7 @@ struct TSchemeShard::TTxInit : public TTransactionBase<TSchemeShard> {
 
                     if (rowset.HaveValue<Schema::ImportItems::Topic>()) {
                         Ydb::Topic::CreateTopicRequest topic;
-                        Y_ENSURE(ParseFromStringNoSizeLimit(topic, rowset.GetValue<Schema::ImportItems::Topic>()));
+                        Y_ABORT_UNLESS(ParseFromStringNoSizeLimit(topic, rowset.GetValue<Schema::ImportItems::Topic>()));
                         item.Topic = topic;
                     }
 
@@ -4566,7 +4566,7 @@ struct TSchemeShard::TTxInit : public TTransactionBase<TSchemeShard> {
                     TIndexBuildInfo::TPtr indexInfo = TIndexBuildInfo::FromRow(rowset);
 
                     auto [it, emplaced] = Self->IndexBuilds.emplace(indexInfo->Id, indexInfo);
-                    Y_ENSURE(emplaced);
+                    Y_ABORT_UNLESS(emplaced);
                     if (indexInfo->Uid) {
                         // TODO(mbkkt) It also should be unique, but we're not sure.
                         Y_ASSERT(!Self->IndexBuildsByUid.contains(indexInfo->Uid));
@@ -4596,7 +4596,7 @@ struct TSchemeShard::TTxInit : public TTransactionBase<TSchemeShard> {
                 while (!rowset.EndOfSet()) {
                     TIndexBuildId id = rowset.GetValue<Schema::KMeansTreeProgress::Id>();
                     const auto* buildInfoPtr = Self->IndexBuilds.FindPtr(id);
-                    Y_ENSURE(buildInfoPtr, "BuildIndex not found: id# " << id);
+                    Y_VERIFY_S(buildInfoPtr, "BuildIndex not found: id# " << id);
                     auto& buildInfo = *buildInfoPtr->Get();
                     buildInfo.KMeans.Set(
                         rowset.GetValue<Schema::KMeansTreeProgress::Level>(),
@@ -4627,7 +4627,7 @@ struct TSchemeShard::TTxInit : public TTransactionBase<TSchemeShard> {
                 while (!rowset.EndOfSet()) {
                     TIndexBuildId id = rowset.GetValue<Schema::KMeansTreeSample::Id>();
                     const auto* buildInfoPtr = Self->IndexBuilds.FindPtr(id);
-                    Y_ENSURE(buildInfoPtr, "BuildIndex not found: id# " << id);
+                    Y_VERIFY_S(buildInfoPtr, "BuildIndex not found: id# " << id);
                     auto& buildInfo = *buildInfoPtr->Get();
                     buildInfo.Sample.Add(
                         rowset.GetValue<Schema::KMeansTreeSample::Probability>(),
@@ -4655,7 +4655,7 @@ struct TSchemeShard::TTxInit : public TTransactionBase<TSchemeShard> {
                 while (!rowset.EndOfSet()) {
                     TIndexBuildId id = rowset.GetValue<Schema::IndexBuildColumns::Id>();
                     const auto* buildInfoPtr = Self->IndexBuilds.FindPtr(id);
-                    Y_ENSURE(buildInfoPtr, "BuildIndex not found"
+                    Y_VERIFY_S(buildInfoPtr, "BuildIndex not found"
                                    << ": id# " << id);
                     auto& buildInfo = *buildInfoPtr->Get();
                     buildInfo.AddIndexColumnInfo(rowset);
@@ -4675,7 +4675,7 @@ struct TSchemeShard::TTxInit : public TTransactionBase<TSchemeShard> {
                 while (!rowset.EndOfSet()) {
                     TIndexBuildId id = rowset.GetValue<Schema::BuildColumnOperationSettings::Id>();
                     const auto* buildInfoPtr = Self->IndexBuilds.FindPtr(id);
-                    Y_ENSURE(buildInfoPtr, "BuildIndex not found"
+                    Y_VERIFY_S(buildInfoPtr, "BuildIndex not found"
                                    << ": id# " << id);
                     auto& buildInfo = *buildInfoPtr->Get();
                     buildInfo.AddBuildColumnInfo(rowset);
@@ -4696,7 +4696,7 @@ struct TSchemeShard::TTxInit : public TTransactionBase<TSchemeShard> {
                 while (!rowset.EndOfSet()) {
                     TIndexBuildId id = rowset.GetValue<Schema::IndexBuildShardStatus::Id>();
                     const auto* buildInfoPtr = Self->IndexBuilds.FindPtr(id);
-                    Y_ENSURE(buildInfoPtr, "BuildIndex not found"
+                    Y_VERIFY_S(buildInfoPtr, "BuildIndex not found"
                                    << ": id# " << id);
                     auto& buildInfo = *buildInfoPtr->Get();
                     buildInfo.AddShardStatus(rowset);
@@ -4749,7 +4749,7 @@ struct TSchemeShard::TTxInit : public TTransactionBase<TSchemeShard> {
 
                 while (!rowset.EndOfSet()) {
                     TTxId id = rowset.GetValue<Schema::SnapshotSteps::Id>();
-                    Y_ENSURE(Self->SnapshotTables.contains(id), "Snapshot not found"
+                    Y_VERIFY_S(Self->SnapshotTables.contains(id), "Snapshot not found"
                                    << ": id# " << id);
 
                     TStepId stepId = rowset.GetValue<Schema::SnapshotSteps::StepId>();
@@ -4804,9 +4804,9 @@ struct TSchemeShard::TTxInit : public TTransactionBase<TSchemeShard> {
                 TPathId pathId = Self->MakeLocalId(rowset.GetValue<Schema::OlapStores::PathId>());
                 ui64 alterVersion = rowset.GetValue<Schema::OlapStores::AlterVersion>();
                 NKikimrSchemeOp::TColumnStoreDescription description;
-                Y_ENSURE(description.ParseFromString(rowset.GetValue<Schema::OlapStores::Description>()));
+                Y_ABORT_UNLESS(description.ParseFromString(rowset.GetValue<Schema::OlapStores::Description>()));
                 NKikimrSchemeOp::TColumnStoreSharding sharding;
-                Y_ENSURE(sharding.ParseFromString(rowset.GetValue<Schema::OlapStores::Sharding>()));
+                Y_ABORT_UNLESS(sharding.ParseFromString(rowset.GetValue<Schema::OlapStores::Sharding>()));
 
                 TOlapStoreInfo::TPtr storeInfo = std::make_shared<TOlapStoreInfo>(alterVersion, std::move(sharding));
                 storeInfo->ParseFromLocalDB(description);
@@ -4831,15 +4831,15 @@ struct TSchemeShard::TTxInit : public TTransactionBase<TSchemeShard> {
                 TPathId pathId = Self->MakeLocalId(rowset.GetValue<Schema::OlapStoresAlters::PathId>());
                 ui64 alterVersion = rowset.GetValue<Schema::OlapStoresAlters::AlterVersion>();
                 NKikimrSchemeOp::TColumnStoreDescription description;
-                Y_ENSURE(description.ParseFromString(rowset.GetValue<Schema::OlapStoresAlters::Description>()));
+                Y_ABORT_UNLESS(description.ParseFromString(rowset.GetValue<Schema::OlapStoresAlters::Description>()));
                 NKikimrSchemeOp::TColumnStoreSharding sharding;
-                Y_ENSURE(sharding.ParseFromString(rowset.GetValue<Schema::OlapStoresAlters::Sharding>()));
+                Y_ABORT_UNLESS(sharding.ParseFromString(rowset.GetValue<Schema::OlapStoresAlters::Sharding>()));
                 TMaybe<NKikimrSchemeOp::TAlterColumnStore> alterBody;
                 if (rowset.HaveValue<Schema::OlapStoresAlters::AlterBody>()) {
-                    Y_ENSURE(alterBody.ConstructInPlace().ParseFromString(rowset.GetValue<Schema::OlapStoresAlters::AlterBody>()));
+                    Y_ABORT_UNLESS(alterBody.ConstructInPlace().ParseFromString(rowset.GetValue<Schema::OlapStoresAlters::AlterBody>()));
                 }
 
-                Y_ENSURE(Self->OlapStores.contains(pathId),
+                Y_VERIFY_S(Self->OlapStores.contains(pathId),
                     "Cannot load alter for olap store " << pathId);
 
                 TOlapStoreInfo::TPtr storeInfo = std::make_shared<TOlapStoreInfo>(alterVersion, std::move(sharding), std::move(alterBody));
@@ -4863,11 +4863,11 @@ struct TSchemeShard::TTxInit : public TTransactionBase<TSchemeShard> {
                 TPathId pathId = Self->MakeLocalId(rowset.GetValue<Schema::ColumnTables::PathId>());
                 ui64 alterVersion = rowset.GetValue<Schema::ColumnTables::AlterVersion>();
                 NKikimrSchemeOp::TColumnTableDescription description;
-                Y_ENSURE(description.ParseFromString(rowset.GetValue<Schema::ColumnTables::Description>()));
-                Y_ENSURE(description.MutableSharding()->ParseFromString(rowset.GetValue<Schema::ColumnTables::Sharding>()));
+                Y_ABORT_UNLESS(description.ParseFromString(rowset.GetValue<Schema::ColumnTables::Description>()));
+                Y_ABORT_UNLESS(description.MutableSharding()->ParseFromString(rowset.GetValue<Schema::ColumnTables::Sharding>()));
                 TMaybe<NKikimrSchemeOp::TColumnStoreSharding> storeSharding;
                 if (rowset.HaveValue<Schema::ColumnTables::StandaloneSharding>()) {
-                    Y_ENSURE(storeSharding.ConstructInPlace().ParseFromString(
+                    Y_ABORT_UNLESS(storeSharding.ConstructInPlace().ParseFromString(
                         rowset.GetValue<Schema::ColumnTables::StandaloneSharding>()));
                 }
 
@@ -4902,19 +4902,19 @@ struct TSchemeShard::TTxInit : public TTransactionBase<TSchemeShard> {
                 TPathId pathId = Self->MakeLocalId(rowset.GetValue<Schema::ColumnTablesAlters::PathId>());
                 ui64 alterVersion = rowset.GetValue<Schema::ColumnTablesAlters::AlterVersion>();
                 NKikimrSchemeOp::TColumnTableDescription description;
-                Y_ENSURE(description.ParseFromString(rowset.GetValue<Schema::ColumnTablesAlters::Description>()));
-                Y_ENSURE(description.MutableSharding()->ParseFromString(rowset.GetValue<Schema::ColumnTablesAlters::Sharding>()));
+                Y_ABORT_UNLESS(description.ParseFromString(rowset.GetValue<Schema::ColumnTablesAlters::Description>()));
+                Y_ABORT_UNLESS(description.MutableSharding()->ParseFromString(rowset.GetValue<Schema::ColumnTablesAlters::Sharding>()));
                 TMaybe<NKikimrSchemeOp::TAlterColumnTable> alterBody;
                 if (rowset.HaveValue<Schema::ColumnTablesAlters::AlterBody>()) {
-                    Y_ENSURE(alterBody.ConstructInPlace().ParseFromString(rowset.GetValue<Schema::ColumnTablesAlters::AlterBody>()));
+                    Y_ABORT_UNLESS(alterBody.ConstructInPlace().ParseFromString(rowset.GetValue<Schema::ColumnTablesAlters::AlterBody>()));
                 }
                 TMaybe<NKikimrSchemeOp::TColumnStoreSharding> storeSharding;
                 if (rowset.HaveValue<Schema::ColumnTablesAlters::StandaloneSharding>()) {
-                    Y_ENSURE(storeSharding.ConstructInPlace().ParseFromString(
+                    Y_ABORT_UNLESS(storeSharding.ConstructInPlace().ParseFromString(
                         rowset.GetValue<Schema::ColumnTablesAlters::StandaloneSharding>()));
                 }
 
-                Y_ENSURE(Self->ColumnTables.contains(pathId),
+                Y_VERIFY_S(Self->ColumnTables.contains(pathId),
                     "Cannot load alter for olap table " << pathId);
 
                 TColumnTableInfo::TPtr alterData = std::make_shared<TColumnTableInfo>(alterVersion,
@@ -4939,9 +4939,9 @@ struct TSchemeShard::TTxInit : public TTransactionBase<TSchemeShard> {
                 TPathId pathId = Self->MakeLocalId(rowset.GetValue<Schema::Sequences::PathId>());
                 ui64 alterVersion = rowset.GetValue<Schema::Sequences::AlterVersion>();
                 NKikimrSchemeOp::TSequenceDescription description;
-                Y_ENSURE(description.ParseFromString(rowset.GetValue<Schema::Sequences::Description>()));
+                Y_ABORT_UNLESS(description.ParseFromString(rowset.GetValue<Schema::Sequences::Description>()));
                 NKikimrSchemeOp::TSequenceSharding sharding;
-                Y_ENSURE(sharding.ParseFromString(rowset.GetValue<Schema::Sequences::Sharding>()));
+                Y_ABORT_UNLESS(sharding.ParseFromString(rowset.GetValue<Schema::Sequences::Sharding>()));
 
                 TSequenceInfo::TPtr sequenceInfo = new TSequenceInfo(alterVersion, std::move(description), std::move(sharding));
                 Self->Sequences[pathId] = sequenceInfo;
@@ -4964,12 +4964,12 @@ struct TSchemeShard::TTxInit : public TTransactionBase<TSchemeShard> {
                 TPathId pathId = Self->MakeLocalId(rowset.GetValue<Schema::SequencesAlters::PathId>());
                 ui64 alterVersion = rowset.GetValue<Schema::SequencesAlters::AlterVersion>();
                 NKikimrSchemeOp::TSequenceDescription description;
-                Y_ENSURE(description.ParseFromString(rowset.GetValue<Schema::SequencesAlters::Description>()));
+                Y_ABORT_UNLESS(description.ParseFromString(rowset.GetValue<Schema::SequencesAlters::Description>()));
                 NKikimrSchemeOp::TSequenceSharding sharding;
-                Y_ENSURE(sharding.ParseFromString(rowset.GetValue<Schema::SequencesAlters::Sharding>()));
+                Y_ABORT_UNLESS(sharding.ParseFromString(rowset.GetValue<Schema::SequencesAlters::Sharding>()));
 
                 TSequenceInfo::TPtr alterData = new TSequenceInfo(alterVersion, std::move(description), std::move(sharding));
-                Y_ENSURE(Self->Sequences.contains(pathId),
+                Y_VERIFY_S(Self->Sequences.contains(pathId),
                     "Cannot load alter for sequence " << pathId);
                 Self->Sequences[pathId]->AlterData = alterData;
 
@@ -4990,7 +4990,7 @@ struct TSchemeShard::TTxInit : public TTransactionBase<TSchemeShard> {
                 TPathId pathId = Self->MakeLocalId(rowset.GetValue<Schema::Replications::PathId>());
                 ui64 alterVersion = rowset.GetValue<Schema::Replications::AlterVersion>();
                 NKikimrSchemeOp::TReplicationDescription description;
-                Y_ENSURE(description.ParseFromString(rowset.GetValue<Schema::Replications::Description>()));
+                Y_ABORT_UNLESS(description.ParseFromString(rowset.GetValue<Schema::Replications::Description>()));
 
                 TReplicationInfo::TPtr replicationInfo = new TReplicationInfo(alterVersion, std::move(description));
                 Self->Replications[pathId] = replicationInfo;
@@ -5017,10 +5017,10 @@ struct TSchemeShard::TTxInit : public TTransactionBase<TSchemeShard> {
                 TPathId pathId = Self->MakeLocalId(rowset.GetValue<Schema::ReplicationsAlterData::PathId>());
                 ui64 alterVersion = rowset.GetValue<Schema::ReplicationsAlterData::AlterVersion>();
                 NKikimrSchemeOp::TReplicationDescription description;
-                Y_ENSURE(description.ParseFromString(rowset.GetValue<Schema::ReplicationsAlterData::Description>()));
+                Y_ABORT_UNLESS(description.ParseFromString(rowset.GetValue<Schema::ReplicationsAlterData::Description>()));
 
                 TReplicationInfo::TPtr alterData = new TReplicationInfo(alterVersion, std::move(description));
-                Y_ENSURE(Self->Replications.contains(pathId),
+                Y_VERIFY_S(Self->Replications.contains(pathId),
                     "Cannot load alter for replication " << pathId);
                 auto replicationInfo = Self->Replications.at(pathId);
 
@@ -5047,7 +5047,7 @@ struct TSchemeShard::TTxInit : public TTransactionBase<TSchemeShard> {
                 const ui64 alterVersion = rowset.GetValue<T::AlterVersion>();
                 NKikimrSchemeOp::TBlobDepotDescription description;
                 const bool success = description.ParseFromString(rowset.GetValue<T::Description>());
-                Y_ENSURE(success);
+                Y_ABORT_UNLESS(success);
 
                 auto blobDepot = MakeIntrusive<TBlobDepotInfo>(alterVersion, description);
                 Self->BlobDepots[pathId] = blobDepot;

--- a/ydb/core/tx/schemeshard/schemeshard_build_index__progress.cpp
+++ b/ydb/core/tx/schemeshard/schemeshard_build_index__progress.cpp
@@ -25,7 +25,7 @@ namespace NSchemeShard {
 // return count, parts, step
 static std::tuple<NTableIndex::TClusterId, NTableIndex::TClusterId, NTableIndex::TClusterId> ComputeKMeansBoundaries(const NSchemeShard::TTableInfo& tableInfo, const TIndexBuildInfo& buildInfo) {
     const auto& kmeans = buildInfo.KMeans;
-    Y_ASSERT(kmeans.K != 0);
+    Y_ENSURE(kmeans.K != 0);
     const auto count = kmeans.ChildCount();
     NTableIndex::TClusterId step = 1;
     auto parts = count;
@@ -86,9 +86,9 @@ public:
         LogPrefix = TStringBuilder()
             << "TUploadSampleK: BuildIndexId: " << BuildIndexId
             << " ResponseActorId: " << ResponseActorId;
-        Y_ASSERT(!Init.empty());
-        Y_ASSERT(Parent < Child);
-        Y_ASSERT(Child != 0);
+        Y_ENSURE(!Init.empty());
+        Y_ENSURE(Parent < Child);
+        Y_ENSURE(Child != 0);
     }
 
     static constexpr auto ActorActivityType() {
@@ -169,7 +169,7 @@ private:
         if (!Uploader) {
             return;
         }
-        Y_VERIFY_S(Uploader == ev->Sender,
+        Y_ENSURE(Uploader == ev->Sender,
                    LogPrefix << "Mismatch"
                              << " Uploader: " << Uploader.ToString()
                              << " ev->Sender: " << ev->Sender.ToString()
@@ -271,7 +271,7 @@ THolder<TEvSchemeShard::TEvModifySchemeTransaction> CreateIndexPropose(
 THolder<TEvSchemeShard::TEvModifySchemeTransaction> DropBuildPropose(
     TSchemeShard* ss, const TIndexBuildInfo& buildInfo)
 {
-    Y_ASSERT(buildInfo.IsBuildVectorIndex());
+    Y_ENSURE(buildInfo.IsBuildVectorIndex());
 
     auto propose = MakeHolder<TEvSchemeShard::TEvModifySchemeTransaction>(ui64(buildInfo.ApplyTxId), ss->TabletID());
     propose->Record.SetFailOnExist(true);
@@ -299,7 +299,7 @@ THolder<TEvSchemeShard::TEvModifySchemeTransaction> DropBuildPropose(
 THolder<TEvSchemeShard::TEvModifySchemeTransaction> CreateBuildPropose(
     TSchemeShard* ss, const TIndexBuildInfo& buildInfo)
 {
-    Y_ASSERT(buildInfo.IsBuildVectorIndex());
+    Y_ENSURE(buildInfo.IsBuildVectorIndex());
 
     auto propose = MakeHolder<TEvSchemeShard::TEvModifySchemeTransaction>(ui64(buildInfo.ApplyTxId), ss->TabletID());
     propose->Record.SetFailOnExist(true);
@@ -316,11 +316,11 @@ THolder<TEvSchemeShard::TEvModifySchemeTransaction> CreateBuildPropose(
         const auto& baseTableColumns = NTableIndex::ExtractInfo(tableInfo);
         auto indexKeys = NTableIndex::ExtractInfo(indexDesc);
         if (buildInfo.IsBuildPrefixedVectorIndex() && buildInfo.KMeans.Level != 1) {
-            Y_ASSERT(indexKeys.KeyColumns.size() >= 2);
+            Y_ENSURE(indexKeys.KeyColumns.size() >= 2);
             indexKeys.KeyColumns.erase(indexKeys.KeyColumns.begin(), indexKeys.KeyColumns.end() - 1);
         }
         implTableColumns = CalcTableImplDescription(buildInfo.IndexType, baseTableColumns, indexKeys);
-        Y_ABORT_UNLESS(indexKeys.KeyColumns.size() >= 1);
+        Y_ENSURE(indexKeys.KeyColumns.size() >= 1);
         implTableColumns.Columns.emplace(indexKeys.KeyColumns.back());
         modifyScheme.ClearInitiateIndexBuild();
         indexDataColumns = THashSet<TString>(buildInfo.DataColumns.begin(), buildInfo.DataColumns.end());
@@ -386,7 +386,7 @@ THolder<TEvSchemeShard::TEvModifySchemeTransaction> CreateBuildPropose(
 THolder<TEvSchemeShard::TEvModifySchemeTransaction> AlterMainTablePropose(
     TSchemeShard* ss, const TIndexBuildInfo& buildInfo)
 {
-    Y_ABORT_UNLESS(buildInfo.IsBuildColumns(), "Unknown operation kind while building AlterMainTablePropose");
+    Y_ENSURE(buildInfo.IsBuildColumns(), "Unknown operation kind while building AlterMainTablePropose");
 
     auto propose = MakeHolder<TEvSchemeShard::TEvModifySchemeTransaction>(ui64(buildInfo.AlterMainTableTxId), ss->TabletID());
     propose->Record.SetFailOnExist(true);
@@ -520,7 +520,7 @@ private:
         record.SetTabletId(ui64(shardId));
         if constexpr (WithSnapshot) {
             if (buildInfo.SnapshotTxId) {
-                Y_ASSERT(buildInfo.SnapshotStep);
+                Y_ENSURE(buildInfo.SnapshotStep);
                 record.SetSnapshotTxId(ui64(buildInfo.SnapshotTxId));
                 record.SetSnapshotStep(ui64(buildInfo.SnapshotStep));
             }
@@ -542,7 +542,7 @@ private:
     }
 
     void SendSampleKRequest(TShardIdx shardIdx, TIndexBuildInfo& buildInfo) {
-        Y_ASSERT(buildInfo.IsBuildVectorIndex());
+        Y_ENSURE(buildInfo.IsBuildVectorIndex());
         auto ev = MakeHolder<TEvDataShard::TEvSampleKRequest>();
         ev->Record.SetId(ui64(BuildId));
 
@@ -572,7 +572,7 @@ private:
     }
 
     void SendKMeansReshuffleRequest(TShardIdx shardIdx, TIndexBuildInfo& buildInfo) {
-        Y_ASSERT(buildInfo.IsBuildVectorIndex());
+        Y_ENSURE(buildInfo.IsBuildVectorIndex());
         auto ev = MakeHolder<TEvDataShard::TEvReshuffleKMeansRequest>();
         ev->Record.SetId(ui64(BuildId));
 
@@ -617,7 +617,7 @@ private:
     }
 
     void SendKMeansLocalRequest(TShardIdx shardIdx, TIndexBuildInfo& buildInfo) {
-        Y_ASSERT(buildInfo.IsBuildVectorIndex());
+        Y_ENSURE(buildInfo.IsBuildVectorIndex());
         auto ev = MakeHolder<TEvDataShard::TEvLocalKMeansRequest>();
         ev->Record.SetId(ui64(BuildId));
 
@@ -666,9 +666,9 @@ private:
     }
 
     void SendPrefixKMeansRequest(TShardIdx shardIdx, TIndexBuildInfo& buildInfo) {
-        Y_ASSERT(buildInfo.IsBuildPrefixedVectorIndex());
-        Y_ASSERT(buildInfo.KMeans.Parent == buildInfo.KMeans.ParentEnd());
-        Y_ASSERT(buildInfo.KMeans.Level == 2);
+        Y_ENSURE(buildInfo.IsBuildPrefixedVectorIndex());
+        Y_ENSURE(buildInfo.KMeans.Parent == buildInfo.KMeans.ParentEnd());
+        Y_ENSURE(buildInfo.KMeans.Level == 2);
 
         auto ev = MakeHolder<TEvDataShard::TEvPrefixKMeansRequest>();
         ev->Record.SetId(ui64(BuildId));
@@ -760,7 +760,7 @@ private:
     void SendUploadSampleKRequest(TIndexBuildInfo& buildInfo) {
         buildInfo.Sample.MakeStrictTop(buildInfo.KMeans.K);
         auto path = GetBuildPath(Self, buildInfo, NTableIndex::NTableVectorKmeansTreeIndex::LevelTable);
-        Y_ASSERT(buildInfo.Sample.Rows.size() <= buildInfo.KMeans.K);
+        Y_ENSURE(buildInfo.Sample.Rows.size() <= buildInfo.KMeans.K);
         auto actor = new TUploadSampleK(path.PathString(), !buildInfo.KMeans.NeedsAnotherLevel(),
             buildInfo.ScanSettings, Self->SelfId(), ui64(BuildId),
             buildInfo.Sample.Rows, buildInfo.KMeans.Parent, buildInfo.KMeans.Child);
@@ -862,7 +862,7 @@ private:
             AddAllShards(buildInfo);
         } else {
             auto it = buildInfo.Cluster2Shards.lower_bound(buildInfo.KMeans.Parent);
-            Y_ASSERT(it != buildInfo.Cluster2Shards.end());
+            Y_ENSURE(it != buildInfo.Cluster2Shards.end());
             if (it->second.Local == InvalidShardIdx) {
                 for (const auto& idx : it->second.Global) {
                     const auto& status = buildInfo.Shards.at(idx);
@@ -880,7 +880,7 @@ private:
         if (buildInfo.Cluster2Shards.empty()) {
             return false;
         }
-        Y_ASSERT(buildInfo.KMeans.Parent != 0);
+        Y_ENSURE(buildInfo.KMeans.Parent != 0);
         for (const auto& [to, state] : buildInfo.Cluster2Shards) {
             if (const auto& [from, local, global] = state; local != InvalidShardIdx) {
                 if (const auto* status = buildInfo.Shards.FindPtr(local)) {
@@ -890,7 +890,7 @@ private:
         }
         buildInfo.KMeans.State = TIndexBuildInfo::TKMeans::MultiLocal;
         buildInfo.Cluster2Shards.clear();
-        Y_ASSERT(buildInfo.InProgressShards.empty());
+        Y_ENSURE(buildInfo.InProgressShards.empty());
         return !buildInfo.ToUploadShards.empty();
     }
 
@@ -986,7 +986,7 @@ private:
             LOG_D("FillPrefixedVectorIndex DoneLevel " << buildInfo.DebugString());
 
             ClearDoneShards(txc, buildInfo);
-            Y_ASSERT(buildInfo.KMeans.State == TIndexBuildInfo::TKMeans::MultiLocal);
+            Y_ENSURE(buildInfo.KMeans.State == TIndexBuildInfo::TKMeans::MultiLocal);
             const bool needsAnotherLevel = buildInfo.KMeans.NextLevel();
             buildInfo.KMeans.State = TIndexBuildInfo::TKMeans::MultiLocal;
             if (buildInfo.KMeans.Level == 2) {
@@ -1078,14 +1078,14 @@ private:
         // About Level == 1, for now build index impl tables don't need snapshot,
         // because they're used only by build index
         if (buildInfo.KMeans.Level == 1 && !buildInfo.SnapshotTxId) {
-            Y_ABORT_UNLESS(!buildInfo.SnapshotStep);
-            Y_ABORT_UNLESS(Self->TablesWithSnapshots.contains(buildInfo.TablePathId));
-            Y_ABORT_UNLESS(Self->TablesWithSnapshots.at(buildInfo.TablePathId) == buildInfo.InitiateTxId);
+            Y_ENSURE(!buildInfo.SnapshotStep);
+            Y_ENSURE(Self->TablesWithSnapshots.contains(buildInfo.TablePathId));
+            Y_ENSURE(Self->TablesWithSnapshots.at(buildInfo.TablePathId) == buildInfo.InitiateTxId);
 
             buildInfo.SnapshotTxId = buildInfo.InitiateTxId;
-            Y_ABORT_UNLESS(buildInfo.SnapshotTxId);
+            Y_ENSURE(buildInfo.SnapshotTxId);
             buildInfo.SnapshotStep = Self->SnapshotsStepIds.at(buildInfo.SnapshotTxId);
-            Y_ABORT_UNLESS(buildInfo.SnapshotStep);
+            Y_ENSURE(buildInfo.SnapshotStep);
         }
         if (buildInfo.Shards.empty()) {
             NIceDb::TNiceDb db(txc.DB);
@@ -1102,7 +1102,7 @@ private:
             case TIndexBuildInfo::EBuildKind::BuildPrefixedVectorIndex:
                 return FillPrefixedVectorIndex(txc, buildInfo);
             default:
-                Y_ASSERT(false);
+                Y_ENSURE(false);
                 return true;
         }
     }
@@ -1115,7 +1115,7 @@ public:
 
     bool DoExecute(TTransactionContext& txc, const TActorContext& ctx) override {
         const auto* buildInfoPtr = Self->IndexBuilds.FindPtr(BuildId);
-        Y_ABORT_UNLESS(buildInfoPtr);
+        Y_ENSURE(buildInfoPtr);
         auto& buildInfo = *buildInfoPtr->Get();
 
         LOG_N("TTxBuildProgress: Execute: " << BuildId << " " << buildInfo.State);
@@ -1188,8 +1188,8 @@ public:
             break;
         }
         case TIndexBuildInfo::EState::DropBuild:
-            Y_ASSERT(buildInfo.IsBuildVectorIndex());
-            Y_ASSERT(buildInfo.KMeans.Level > 2);
+            Y_ENSURE(buildInfo.IsBuildVectorIndex());
+            Y_ENSURE(buildInfo.KMeans.Level > 2);
             if (buildInfo.ApplyTxId == InvalidTxId) {
                 AllocateTxId(BuildId);
             } else if (buildInfo.ApplyTxStatus == NKikimrScheme::StatusSuccess) {
@@ -1211,7 +1211,7 @@ public:
             }
             break;
         case TIndexBuildInfo::EState::CreateBuild:
-            Y_ASSERT(buildInfo.IsBuildVectorIndex());
+            Y_ENSURE(buildInfo.IsBuildVectorIndex());
             if (buildInfo.ApplyTxId == InvalidTxId) {
                 AllocateTxId(BuildId);
             } else if (buildInfo.ApplyTxStatus == NKikimrScheme::StatusSuccess) {
@@ -1236,7 +1236,7 @@ public:
             }
             break;
         case TIndexBuildInfo::EState::LockBuild:
-            Y_ASSERT(buildInfo.IsBuildVectorIndex());
+            Y_ENSURE(buildInfo.IsBuildVectorIndex());
             if (buildInfo.ApplyTxId == InvalidTxId) {
                 AllocateTxId(BuildId);
             } else if (buildInfo.ApplyTxStatus == NKikimrScheme::StatusSuccess) {
@@ -1364,10 +1364,10 @@ public:
     bool InitiateShards(NIceDb::TNiceDb& db, TIndexBuildInfo& buildInfo) {
         LOG_D("InitiateShards " << buildInfo.DebugString());
 
-        Y_ASSERT(buildInfo.Shards.empty());
-        Y_ASSERT(buildInfo.ToUploadShards.empty());
-        Y_ASSERT(buildInfo.InProgressShards.empty());
-        Y_ASSERT(buildInfo.DoneShards.empty());
+        Y_ENSURE(buildInfo.Shards.empty());
+        Y_ENSURE(buildInfo.ToUploadShards.empty());
+        Y_ENSURE(buildInfo.InProgressShards.empty());
+        Y_ENSURE(buildInfo.DoneShards.empty());
 
         TTableInfo::TPtr table;
         if (buildInfo.KMeans.Level == 1) {
@@ -1381,7 +1381,7 @@ public:
                 Progress(buildInfo.Id);
                 return false;
             }
-            Y_ASSERT(path.LockedBy() == buildInfo.LockTxId);
+            Y_ENSURE(path.LockedBy() == buildInfo.LockTxId);
         }
         auto tableColumns = NTableIndex::ExtractInfo(table); // skip dropped columns
         TSerializedTableRange shardRange = InfiniteRange(tableColumns.Keys.size());
@@ -1389,7 +1389,7 @@ public:
 
         buildInfo.Cluster2Shards.clear();
         for (const auto& x: table->GetPartitions()) {
-            Y_ABORT_UNLESS(Self->ShardInfos.contains(x.ShardIdx));
+            Y_ENSURE(Self->ShardInfos.contains(x.ShardIdx));
             TSerializedCellVec bound{x.EndOfRange};
             shardRange.To = bound;
             if (buildInfo.BuildKind == TIndexBuildInfo::EBuildKind::BuildVectorIndex) {
@@ -1397,7 +1397,7 @@ public:
                 buildInfo.AddParent(shardRange, x.ShardIdx);
             }
             auto [it, emplaced] = buildInfo.Shards.emplace(x.ShardIdx, TIndexBuildInfo::TShardStatus{std::move(shardRange), "", buildInfo.Shards.size()});
-            Y_ASSERT(emplaced);
+            Y_ENSURE(emplaced);
             shardRange.From = std::move(bound);
 
             Self->PersistBuildIndexUploadInitiate(db, BuildId, x.ShardIdx, it->second);
@@ -1525,7 +1525,7 @@ public:
         case TIndexBuildInfo::EState::Applying:
         case TIndexBuildInfo::EState::Unlocking:
         case TIndexBuildInfo::EState::Done:
-            Y_FAIL_S("Unreachable " << state);
+            Y_ENSURE(false, "Unreachable " << state);
         case TIndexBuildInfo::EState::Cancellation_Applying:
         case TIndexBuildInfo::EState::Cancellation_Unlocking:
         case TIndexBuildInfo::EState::Cancelled:
@@ -1598,16 +1598,16 @@ public:
                       << ", TIndexBuildInfo: " << buildInfo
                       << ", actual seqNo for the shard " << shardId << " (" << shardIdx << ") is: "  << Self->Generation() << ":" <<  shardStatus.SeqNoRound
                       << ", record: " << record.ShortDebugString());
-                Y_ABORT_UNLESS(actualSeqNo > recordSeqNo);
+                Y_ENSURE(actualSeqNo > recordSeqNo);
                 return true;
             }
 
             NIceDb::TNiceDb db(txc.DB);
             if (record.ProbabilitiesSize()) {
-                Y_ASSERT(record.RowsSize());
+                Y_ENSURE(record.RowsSize());
                 auto& probabilities = record.GetProbabilities();
                 auto& rows = *record.MutableRows();
-                Y_ASSERT(probabilities.size() == rows.size());
+                Y_ENSURE(probabilities.size() == rows.size());
                 auto& sample = buildInfo.Sample.Rows;
                 auto from = sample.size();
                 for (int i = 0; i != probabilities.size(); ++i) {
@@ -1680,7 +1680,7 @@ public:
         case TIndexBuildInfo::EState::Applying:
         case TIndexBuildInfo::EState::Unlocking:
         case TIndexBuildInfo::EState::Done:
-            Y_FAIL_S("Unreachable " << state);
+            Y_ENSURE(false, "Unreachable " << state);
         case TIndexBuildInfo::EState::Cancellation_Applying:
         case TIndexBuildInfo::EState::Cancellation_Unlocking:
         case TIndexBuildInfo::EState::Cancelled:
@@ -1746,7 +1746,7 @@ public:
                       << ", TIndexBuildInfo: " << buildInfo
                       << ", actual seqNo for the shard " << shardId << " (" << shardIdx << ") is: "  << Self->Generation() << ":" <<  shardStatus.SeqNoRound
                       << ", record: " << record.ShortDebugString());
-                Y_ABORT_UNLESS(actualSeqNo > recordSeqNo);
+                Y_ENSURE(actualSeqNo > recordSeqNo);
                 return true;
             }
 
@@ -1806,7 +1806,7 @@ public:
         case TIndexBuildInfo::EState::Applying:
         case TIndexBuildInfo::EState::Unlocking:
         case TIndexBuildInfo::EState::Done:
-            Y_FAIL_S("Unreachable " << state);
+            Y_ENSURE(false, "Unreachable " << state);
         case TIndexBuildInfo::EState::Cancellation_Applying:
         case TIndexBuildInfo::EState::Cancellation_Unlocking:
         case TIndexBuildInfo::EState::Cancelled:
@@ -1872,7 +1872,7 @@ public:
                       << ", TIndexBuildInfo: " << buildInfo
                       << ", actual seqNo for the shard " << shardId << " (" << shardIdx << ") is: "  << Self->Generation() << ":" <<  shardStatus.SeqNoRound
                       << ", record: " << record.ShortDebugString());
-                Y_ABORT_UNLESS(actualSeqNo > recordSeqNo);
+                Y_ENSURE(actualSeqNo > recordSeqNo);
                 return true;
             }
 
@@ -1931,7 +1931,7 @@ public:
         case TIndexBuildInfo::EState::Applying:
         case TIndexBuildInfo::EState::Unlocking:
         case TIndexBuildInfo::EState::Done:
-            Y_FAIL_S("Unreachable " << state);
+            Y_ENSURE(false, "Unreachable " << state);
         case TIndexBuildInfo::EState::Cancellation_Applying:
         case TIndexBuildInfo::EState::Cancellation_Unlocking:
         case TIndexBuildInfo::EState::Cancelled:
@@ -1997,7 +1997,7 @@ public:
                       << ", TIndexBuildInfo: " << buildInfo
                       << ", actual seqNo for the shard " << shardId << " (" << shardIdx << ") is: "  << Self->Generation() << ":" <<  shardStatus.SeqNoRound
                       << ", record: " << record.ShortDebugString());
-                Y_ABORT_UNLESS(actualSeqNo > recordSeqNo);
+                Y_ENSURE(actualSeqNo > recordSeqNo);
                 return true;
             }
 
@@ -2057,7 +2057,7 @@ public:
         case TIndexBuildInfo::EState::Applying:
         case TIndexBuildInfo::EState::Unlocking:
         case TIndexBuildInfo::EState::Done:
-            Y_FAIL_S("Unreachable " << state);
+            Y_ENSURE(false, "Unreachable " << state);
         case TIndexBuildInfo::EState::Cancellation_Applying:
         case TIndexBuildInfo::EState::Cancellation_Unlocking:
         case TIndexBuildInfo::EState::Cancelled:
@@ -2098,12 +2098,12 @@ public:
         LOG_D("TTxReply : TEvUploadSampleKResponse"
               << ", TIndexBuildInfo: " << buildInfo
               << ", record: " << record.ShortDebugString());
-        Y_ASSERT(buildInfo.IsBuildVectorIndex());
+        Y_ENSURE(buildInfo.IsBuildVectorIndex());
 
         switch (const auto state = buildInfo.State; state) {
         case TIndexBuildInfo::EState::Filling:
         {
-            Y_ABORT_UNLESS(buildInfo.Sample.State == TIndexBuildInfo::TSample::EState::Upload);
+            Y_ENSURE(buildInfo.Sample.State == TIndexBuildInfo::TSample::EState::Upload);
             NIceDb::TNiceDb db(txc.DB);
 
             TBillingStats stats{record.GetUploadRows(), record.GetUploadBytes(), 0, 0};
@@ -2140,7 +2140,7 @@ public:
         case TIndexBuildInfo::EState::Applying:
         case TIndexBuildInfo::EState::Unlocking:
         case TIndexBuildInfo::EState::Done:
-            Y_FAIL_S("Unreachable " << state);
+            Y_ENSURE(false, "Unreachable " << state);
         case TIndexBuildInfo::EState::Cancellation_Applying:
         case TIndexBuildInfo::EState::Cancellation_Unlocking:
         case TIndexBuildInfo::EState::Cancelled:
@@ -2204,7 +2204,7 @@ public:
                       << ", TIndexBuildInfo: " << buildInfo
                       << ", actual seqNo for the shard " << shardId << " (" << shardIdx << ") is: "  << Self->Generation() << ":" <<  shardStatus.SeqNoRound
                       << ", record: " << record.ShortDebugString());
-                Y_ABORT_UNLESS(actualSeqNo > recordSeqNo);
+                Y_ENSURE(actualSeqNo > recordSeqNo);
                 return true;
             }
 
@@ -2226,7 +2226,7 @@ public:
                                                          true,
                                                          true,
                                                          keyTypes);
-                    Y_VERIFY_S(cmp < 0,
+                    Y_ENSURE(cmp < 0,
                                "check that all LastKeyAcks are monotonously increase"
                                    << ", next: " << DebugPrintPoint(keyTypes, next.GetCells(), *AppData()->TypeRegistry)
                                    << ", prev: " << DebugPrintPoint(keyTypes, prev.GetCells(), *AppData()->TypeRegistry));
@@ -2294,7 +2294,7 @@ public:
         case TIndexBuildInfo::EState::Applying:
         case TIndexBuildInfo::EState::Unlocking:
         case TIndexBuildInfo::EState::Done:
-            Y_FAIL_S("Unreachable " << state);
+            Y_ENSURE(false, "Unreachable " << state);
         case TIndexBuildInfo::EState::Cancellation_Applying:
         case TIndexBuildInfo::EState::Cancellation_Unlocking:
         case TIndexBuildInfo::EState::Cancelled:
@@ -2331,7 +2331,7 @@ public:
 
         const auto buildId = *buildIdPtr;
         const auto* buildInfoPtr = Self->IndexBuilds.FindPtr(buildId);
-        Y_ABORT_UNLESS(buildInfoPtr);
+        Y_ENSURE(buildInfoPtr);
         auto& buildInfo = *buildInfoPtr->Get();
         LOG_I("TTxReply : TEvNotifyTxCompletionResult"
               << ", txId# " << txId
@@ -2346,7 +2346,7 @@ public:
         switch (state) {
         case TIndexBuildInfo::EState::AlterMainTable:
         {
-            Y_ABORT_UNLESS(txId == buildInfo.AlterMainTableTxId);
+            Y_ENSURE(txId == buildInfo.AlterMainTableTxId);
 
             buildInfo.AlterMainTableTxDone = true;
             Self->PersistBuildIndexAlterMainTableTxDone(db, buildInfo);
@@ -2354,7 +2354,7 @@ public:
         }
         case TIndexBuildInfo::EState::Locking:
         {
-            Y_ABORT_UNLESS(txId == buildInfo.LockTxId);
+            Y_ENSURE(txId == buildInfo.LockTxId);
 
             buildInfo.LockTxDone = true;
             Self->PersistBuildIndexLockTxDone(db, buildInfo);
@@ -2362,7 +2362,7 @@ public:
         }
         case TIndexBuildInfo::EState::Initiating:
         {
-            Y_ABORT_UNLESS(txId == buildInfo.InitiateTxId);
+            Y_ENSURE(txId == buildInfo.InitiateTxId);
 
             buildInfo.InitiateTxDone = true;
             Self->PersistBuildIndexInitiateTxDone(db, buildInfo);
@@ -2375,7 +2375,7 @@ public:
         case TIndexBuildInfo::EState::Cancellation_Applying:
         case TIndexBuildInfo::EState::Rejection_Applying:
         {
-            Y_VERIFY_S(txId == buildInfo.ApplyTxId, state);
+            Y_ENSURE(txId == buildInfo.ApplyTxId, state);
 
             buildInfo.ApplyTxDone = true;
             Self->PersistBuildIndexApplyTxDone(db, buildInfo);
@@ -2385,7 +2385,7 @@ public:
         case TIndexBuildInfo::EState::Cancellation_Unlocking:
         case TIndexBuildInfo::EState::Rejection_Unlocking:
         {
-            Y_VERIFY_S(txId == buildInfo.UnlockTxId, state);
+            Y_ENSURE(txId == buildInfo.UnlockTxId, state);
 
             buildInfo.UnlockTxDone = true;
             Self->PersistBuildIndexUnlockTxDone(db, buildInfo);
@@ -2397,7 +2397,7 @@ public:
         case TIndexBuildInfo::EState::Done:
         case TIndexBuildInfo::EState::Cancelled:
         case TIndexBuildInfo::EState::Rejected:
-            Y_FAIL_S("Unreachable " << state);
+            Y_ENSURE(false, "Unreachable " << state);
         }
 
         Progress(buildId);
@@ -2455,7 +2455,7 @@ public:
 
         const auto buildId = *buildIdPtr;
         const auto* buildInfoPtr = Self->IndexBuilds.FindPtr(buildId);
-        Y_ABORT_UNLESS(buildInfoPtr);
+        Y_ENSURE(buildInfoPtr);
         // We need this because we use buildInfo after EraseBuildInfo
         auto buildInfoPin = *buildInfoPtr;
         auto& buildInfo = *buildInfoPin;
@@ -2508,7 +2508,7 @@ public:
         switch (state) {
         case TIndexBuildInfo::EState::AlterMainTable:
         {
-            Y_ABORT_UNLESS(txId == buildInfo.AlterMainTableTxId);
+            Y_ENSURE(txId == buildInfo.AlterMainTableTxId);
 
             buildInfo.AlterMainTableTxStatus = record.GetStatus();
             Self->PersistBuildIndexAlterMainTableTxStatus(db, buildInfo);
@@ -2518,7 +2518,7 @@ public:
         }
         case TIndexBuildInfo::EState::Locking:
         {
-            Y_ABORT_UNLESS(txId == buildInfo.LockTxId);
+            Y_ENSURE(txId == buildInfo.LockTxId);
 
             buildInfo.LockTxStatus = record.GetStatus();
             Self->PersistBuildIndexLockTxStatus(db, buildInfo);
@@ -2528,7 +2528,7 @@ public:
         }
         case TIndexBuildInfo::EState::Initiating:
         {
-            Y_ABORT_UNLESS(txId == buildInfo.InitiateTxId);
+            Y_ENSURE(txId == buildInfo.InitiateTxId);
 
             buildInfo.InitiateTxStatus = record.GetStatus();
             Self->PersistBuildIndexInitiateTxStatus(db, buildInfo);
@@ -2542,7 +2542,7 @@ public:
         case TIndexBuildInfo::EState::Applying:
         case TIndexBuildInfo::EState::Rejection_Applying:
         {
-            Y_ABORT_UNLESS(txId == buildInfo.ApplyTxId);
+            Y_ENSURE(txId == buildInfo.ApplyTxId);
 
             buildInfo.ApplyTxStatus = record.GetStatus();
             Self->PersistBuildIndexApplyTxStatus(db, buildInfo);
@@ -2552,7 +2552,7 @@ public:
         }
         case TIndexBuildInfo::EState::Unlocking:
         {
-            Y_ABORT_UNLESS(txId == buildInfo.UnlockTxId);
+            Y_ENSURE(txId == buildInfo.UnlockTxId);
 
             buildInfo.UnlockTxStatus = record.GetStatus();
             Self->PersistBuildIndexUnlockTxStatus(db, buildInfo);
@@ -2562,7 +2562,7 @@ public:
         }
         case TIndexBuildInfo::EState::Cancellation_Applying:
         {
-            Y_ABORT_UNLESS(txId == buildInfo.ApplyTxId);
+            Y_ENSURE(txId == buildInfo.ApplyTxId);
 
             buildInfo.ApplyTxStatus = record.GetStatus();
             Self->PersistBuildIndexApplyTxStatus(db, buildInfo);
@@ -2572,7 +2572,7 @@ public:
         }
         case TIndexBuildInfo::EState::Cancellation_Unlocking:
         {
-            Y_ABORT_UNLESS(txId == buildInfo.UnlockTxId);
+            Y_ENSURE(txId == buildInfo.UnlockTxId);
 
             buildInfo.UnlockTxStatus = record.GetStatus();
             Self->PersistBuildIndexUnlockTxStatus(db, buildInfo);
@@ -2582,7 +2582,7 @@ public:
         }
         case TIndexBuildInfo::EState::Rejection_Unlocking:
         {
-            Y_ABORT_UNLESS(txId == buildInfo.UnlockTxId);
+            Y_ENSURE(txId == buildInfo.UnlockTxId);
 
             buildInfo.UnlockTxStatus = record.GetStatus();
             Self->PersistBuildIndexUnlockTxStatus(db, buildInfo);
@@ -2596,7 +2596,7 @@ public:
         case TIndexBuildInfo::EState::Done:
         case TIndexBuildInfo::EState::Cancelled:
         case TIndexBuildInfo::EState::Rejected:
-            Y_FAIL_S("Unreachable " << state);
+            Y_ENSURE(false, "Unreachable " << state);
         }
 
         Progress(buildId);
@@ -2623,7 +2623,7 @@ public:
               << ", txId# " << txId);
 
         const auto* buildInfoPtr = Self->IndexBuilds.FindPtr(buildId);
-        Y_ABORT_UNLESS(buildInfoPtr);
+        Y_ENSURE(buildInfoPtr);
         auto& buildInfo = *buildInfoPtr->Get();
 
         LOG_D("TTxReply : TEvAllocateResult"
@@ -2676,7 +2676,7 @@ public:
         case TIndexBuildInfo::EState::Done:
         case TIndexBuildInfo::EState::Cancelled:
         case TIndexBuildInfo::EState::Rejected:
-            Y_FAIL_S("Unreachable " << state);
+            Y_ENSURE(false, "Unreachable " << state);
         }
 
         Progress(buildId);

--- a/ydb/core/tx/schemeshard/schemeshard_info_types.cpp
+++ b/ydb/core/tx/schemeshard/schemeshard_info_types.cpp
@@ -297,7 +297,7 @@ TTableInfo::TAlterDataPtr TTableInfo::CreateAlterData(
 
     if (source) {
         for (const auto& col : source->Columns) {
-            Y_ABORT_UNLESS(col.first == col.second.Id);
+            Y_ENSURE(col.first == col.second.Id);
             // There could be columns with same name. Only one of them can be active.
             if (col.second.IsDropped())
                 continue;
@@ -717,7 +717,7 @@ void TTableInfo::ResetDescriptionCache() {
 }
 
 TVector<ui32> TTableInfo::FillDescriptionCache(TPathElement::TPtr pathInfo) {
-    Y_ABORT_UNLESS(pathInfo && pathInfo->IsTable());
+    Y_ENSURE(pathInfo && pathInfo->IsTable());
 
     TVector<ui32> keyColumnIds;
     for (auto& col : Columns) {
@@ -765,7 +765,7 @@ inline THashMap<ui32, size_t> DeduplicateRepeatedById(
     const TGetId& getId,
     const TPreferred& preferred)
 {
-    Y_ABORT_UNLESS(items, "Unexpected nullptr items");
+    Y_ENSURE(items, "Unexpected nullptr items");
 
     int size = items->size();
     THashMap<ui32, size_t> posById;
@@ -1381,7 +1381,7 @@ bool TPartitionConfigMerger::VerifyAlterParams(
     }
 
     if (wasStorageConfig) {
-        Y_ABORT_UNLESS(isStorageConfig); // by inherit logic
+        Y_ENSURE(isStorageConfig); // by inherit logic
 
         auto& srcStorage = *wasStorageConfig;
         auto& cfgStorage = *isStorageConfig;
@@ -1430,7 +1430,7 @@ bool TPartitionConfigMerger::VerifyAlterParams(
         const auto* srcFamily = srcFamilies.Value(family.GetId(), nullptr);
 
         if (srcFamily && srcFamily->HasStorageConfig()) {
-            Y_ABORT_UNLESS(family.HasStorageConfig()); // by inherit logic
+            Y_ENSURE(family.HasStorageConfig()); // by inherit logic
 
             const auto& srcStorage = srcFamily->GetStorageConfig();
             const auto& dstStorage = family.GetStorageConfig();
@@ -1504,7 +1504,7 @@ bool TPartitionConfigMerger::VerifyCommandOnFrozenTable(const NKikimrSchemeOp::T
 }
 
 void TTableInfo::FinishAlter() {
-    Y_ABORT_UNLESS(AlterData, "No alter data at Alter complete");
+    Y_ENSURE(AlterData, "No alter data at Alter complete");
     AlterVersion = AlterData->AlterVersion;
     NextColumnId = AlterData->NextColumnId;
     for (const auto& col : AlterData->Columns) {
@@ -1614,20 +1614,20 @@ void TTableInfo::FinishAlter() {
 
 #if 1 // legacy
 TString TTableInfo::SerializeAlterExtraData() const {
-    Y_ABORT_UNLESS(AlterData);
+    Y_ENSURE(AlterData);
     NKikimrSchemeOp::TAlterExtraData alterExtraData;
     alterExtraData.MutablePartitionConfig()->CopyFrom(AlterData->PartitionConfigDiff());
     TString str;
     bool serializeRes = alterExtraData.SerializeToString(&str);
-    Y_ABORT_UNLESS(serializeRes);
+    Y_ENSURE(serializeRes);
     return str;
 }
 
 void TTableInfo::DeserializeAlterExtraData(const TString& str) {
-    Y_ABORT_UNLESS(AlterData);
+    Y_ENSURE(AlterData);
     NKikimrSchemeOp::TAlterExtraData alterExtraData;
     bool deserializeRes = ParseFromStringNoSizeLimit(alterExtraData, str);
-    Y_ABORT_UNLESS(deserializeRes);
+    Y_ENSURE(deserializeRes);
     AlterData->PartitionConfigDiff().Swap(alterExtraData.MutablePartitionConfig());
 }
 #endif
@@ -1690,7 +1690,7 @@ void TTableInfo::SetPartitioning(TVector<TTableShardInfo>&& newPartitioning) {
     }
 
     if (Partitions.empty()) {
-        Y_ABORT_UNLESS(SplitOpsInFlight.empty());
+        Y_ENSURE(SplitOpsInFlight.empty());
     }
 
     Stats.PartitionStats.swap(newPartitionStats);
@@ -1817,11 +1817,11 @@ void TAggregatedStats::UpdateTableStats(TShardIdx shardIdx, const TPathId& pathI
 }
 
 void TTableInfo::RegisterSplitMergeOp(TOperationId opId, const TTxState& txState) {
-    Y_ABORT_UNLESS(txState.TxType == TTxState::TxSplitTablePartition || txState.TxType == TTxState::TxMergeTablePartition);
-    Y_ABORT_UNLESS(txState.SplitDescription);
+    Y_ENSURE(txState.TxType == TTxState::TxSplitTablePartition || txState.TxType == TTxState::TxMergeTablePartition);
+    Y_ENSURE(txState.SplitDescription);
 
     if (SplitOpsInFlight.empty()) {
-        Y_VERIFY_S(Partitions.size() == ExpectedPartitionCount,
+        Y_ENSURE(Partitions.size() == ExpectedPartitionCount,
                    "info "
                        << "ExpectedPartitionCount: " << ExpectedPartitionCount
                        << " Partitions.size(): " << Partitions.size());
@@ -1834,7 +1834,7 @@ void TTableInfo::RegisterSplitMergeOp(TOperationId opId, const TTxState& txState
         ExpectedPartitionCount -= srcCount;
     }
 
-    Y_ABORT_UNLESS(!SplitOpsInFlight.contains(opId));
+    Y_ENSURE(!SplitOpsInFlight.contains(opId));
     SplitOpsInFlight.emplace(opId);
     ShardsInSplitMergeByOpId.emplace(opId, TVector<TShardIdx>());
 
@@ -1847,8 +1847,8 @@ void TTableInfo::RegisterSplitMergeOp(TOperationId opId, const TTxState& txState
 bool TTableInfo::IsShardInSplitMergeOp(TShardIdx idx) const {
     if (ShardsInSplitMergeByShards.contains(idx)) {
         TOperationId opId = ShardsInSplitMergeByShards.at(idx);
-        Y_ABORT_UNLESS(ShardsInSplitMergeByOpId.contains(opId));
-        Y_ABORT_UNLESS(SplitOpsInFlight.contains(opId));
+        Y_ENSURE(ShardsInSplitMergeByOpId.contains(opId));
+        Y_ENSURE(SplitOpsInFlight.contains(opId));
     }
 
     return ShardsInSplitMergeByShards.contains(idx);
@@ -1856,7 +1856,7 @@ bool TTableInfo::IsShardInSplitMergeOp(TShardIdx idx) const {
 
 
 void TTableInfo::AbortSplitMergeOp(TOperationId opId) {
-    Y_ABORT_UNLESS(SplitOpsInFlight.contains(opId));
+    Y_ENSURE(SplitOpsInFlight.contains(opId));
     for (const auto& shardIdx: ShardsInSplitMergeByOpId.at(opId)) {
         ShardsInSplitMergeByShards.erase(shardIdx);
     }
@@ -1868,7 +1868,7 @@ void TTableInfo::FinishSplitMergeOp(TOperationId opId) {
     AbortSplitMergeOp(opId);
 
     if (SplitOpsInFlight.empty()) {
-        Y_VERIFY_S(Partitions.size() == ExpectedPartitionCount,
+        Y_ENSURE(Partitions.size() == ExpectedPartitionCount,
                    "info "
                        << "ExpectedPartitionCount: " << ExpectedPartitionCount
                        << " Partitions.size(): " << Partitions.size());
@@ -2161,7 +2161,7 @@ bool TExportInfo::AllItemsAreDropped() const {
 }
 
 void TExportInfo::AddNotifySubscriber(const TActorId &actorId) {
-    Y_ABORT_UNLESS(!IsFinished());
+    Y_ENSURE(!IsFinished());
     Subscribers.insert(actorId);
 }
 
@@ -2199,7 +2199,7 @@ bool TImportInfo::IsFinished() const {
 }
 
 void TImportInfo::AddNotifySubscriber(const TActorId &actorId) {
-    Y_ABORT_UNLESS(!IsFinished());
+    Y_ENSURE(!IsFinished());
     Subscribers.insert(actorId);
 }
 
@@ -2210,7 +2210,7 @@ TIndexBuildInfo::TShardStatus::TShardStatus(TSerializedTableRange range, TString
 {}
 
 void TIndexBuildInfo::SerializeToProto(TSchemeShard* ss, NKikimrSchemeOp::TIndexBuildConfig* result) const {
-    Y_ABORT_UNLESS(IsBuildIndex());
+    Y_ENSURE(IsBuildIndex());
     result->SetTable(TPath::Init(TablePathId, ss).PathString());
 
     auto& index = *result->MutableIndex();
@@ -2238,7 +2238,7 @@ void TIndexBuildInfo::SerializeToProto(TSchemeShard* ss, NKikimrSchemeOp::TIndex
 }
 
 void TIndexBuildInfo::SerializeToProto([[maybe_unused]] TSchemeShard* ss, NKikimrIndexBuilder::TColumnBuildSettings* result) const {
-    Y_ABORT_UNLESS(IsBuildColumns());
+    Y_ENSURE(IsBuildColumns());
     Y_ASSERT(!TargetName.empty());
     result->SetTable(TargetName);
     for(const auto& column : BuildColumns) {
@@ -2475,10 +2475,10 @@ TBillingStats::TBillingStats(ui64 readRows, ui64 readBytes, ui64 uploadRows, ui6
 }
 
 TBillingStats TBillingStats::operator -(const TBillingStats &other) const {
-    Y_ABORT_UNLESS(UploadRows >= other.UploadRows);
-    Y_ABORT_UNLESS(UploadBytes >= other.UploadBytes);
-    Y_ABORT_UNLESS(ReadRows >= other.ReadRows);
-    Y_ABORT_UNLESS(ReadBytes >= other.ReadBytes);
+    Y_ENSURE(UploadRows >= other.UploadRows);
+    Y_ENSURE(UploadBytes >= other.UploadBytes);
+    Y_ENSURE(ReadRows >= other.ReadRows);
+    Y_ENSURE(ReadBytes >= other.ReadBytes);
 
     return {UploadRows - other.UploadRows, UploadBytes - other.UploadBytes,
             ReadRows - other.ReadRows, ReadBytes - other.ReadBytes};

--- a/ydb/core/tx/schemeshard/schemeshard_info_types.h
+++ b/ydb/core/tx/schemeshard/schemeshard_info_types.h
@@ -622,7 +622,7 @@ public:
         // their storage config altered, so per-table and per-shard rooms
         // cannot diverge. These settings will eventually become dead weight,
         // only useful for ancient shards, after which may remove this code.
-        Y_ABORT_UNLESS(room.GetId() == 0);
+        Y_ENSURE(room.GetId() == 0);
         auto rooms = MutablePartitionConfig().MutableStorageRooms();
         rooms->Clear();
         rooms->Add()->CopyFrom(room);
@@ -638,8 +638,8 @@ public:
     }
 
     void PrepareAlter(TAlterDataPtr alterData) {
-        Y_ABORT_UNLESS(alterData, "No alter data at Alter prepare");
-        Y_ABORT_UNLESS(alterData->AlterVersion == AlterVersion + 1);
+        Y_ENSURE(alterData, "No alter data at Alter prepare");
+        Y_ENSURE(alterData->AlterVersion == AlterVersion + 1);
         AlterData = alterData;
     }
 
@@ -909,27 +909,27 @@ public:
 
     void AddInFlightCondErase(const TShardIdx& shardIdx) {
         const auto* shardInfo = GetScheduledCondEraseShard();
-        Y_ABORT_UNLESS(shardInfo && shardIdx == shardInfo->ShardIdx);
+        Y_ENSURE(shardInfo && shardIdx == shardInfo->ShardIdx);
 
         InFlightCondErase[shardIdx] = TActorId();
         CondEraseSchedule.pop();
     }
 
     void RescheduleCondErase(const TShardIdx& shardIdx) {
-        Y_ABORT_UNLESS(InFlightCondErase.contains(shardIdx));
+        Y_ENSURE(InFlightCondErase.contains(shardIdx));
 
         auto it = FindPartition(shardIdx);
-        Y_ABORT_UNLESS(it != Partitions.end());
+        Y_ENSURE(it != Partitions.end());
 
         CondEraseSchedule.push(it);
         InFlightCondErase.erase(shardIdx);
     }
 
     void ScheduleNextCondErase(const TShardIdx& shardIdx, const TInstant& now, const TDuration& next) {
-        Y_ABORT_UNLESS(InFlightCondErase.contains(shardIdx));
+        Y_ENSURE(InFlightCondErase.contains(shardIdx));
 
         auto it = FindPartition(shardIdx);
-        Y_ABORT_UNLESS(it != Partitions.end());
+        Y_ENSURE(it != Partitions.end());
 
         it->LastCondErase = now;
         it->NextCondErase = now + next;
@@ -1205,9 +1205,8 @@ struct TTopicInfo : TSimpleRefCount<TTopicInfo> {
     void UpdateSplitMergeGraph(const TTopicTabletInfo::TTopicPartitionInfo& partition) {
         for (const auto parent : partition.ParentPartitionIds) {
             auto it = Partitions.find(parent);
-            Y_ABORT_UNLESS(it != Partitions.end(),
-                     "Partition %" PRIu32 " has parent partition %" PRIu32 " which doesn't exists", partition.GroupId,
-                     parent);
+            Y_ENSURE(it != Partitions.end(),
+                     "Partition " << partition.GroupId << " has parent partition " << parent << " which doesn't exists");
             it->second->ChildPartitionIds.emplace(partition.PqId);
         }
     }
@@ -1237,8 +1236,8 @@ struct TTopicInfo : TSimpleRefCount<TTopicInfo> {
 
     ui32 ExpectedShardCount() const {
 
-        Y_ABORT_UNLESS(TotalPartitionCount);
-        Y_ABORT_UNLESS(MaxPartsPerTablet);
+        Y_ENSURE(TotalPartitionCount);
+        Y_ENSURE(MaxPartsPerTablet);
 
         ui32 partsPerTablet = MaxPartsPerTablet;
         ui32 pqTabletCount = TotalPartitionCount / partsPerTablet;
@@ -1273,19 +1272,19 @@ struct TTopicInfo : TSimpleRefCount<TTopicInfo> {
         NKikimrPQ::TPQTabletConfig tabletConfig;
         if (!TabletConfig.empty()) {
             bool parseOk = ParseFromStringNoSizeLimit(tabletConfig, TabletConfig);
-            Y_ABORT_UNLESS(parseOk, "Previously serialized pq tablet config cannot be parsed");
+            Y_ENSURE(parseOk, "Previously serialized pq tablet config cannot be parsed");
         }
         return tabletConfig;
     }
 
     void PrepareAlter(TTopicInfo::TPtr alterData) {
-        Y_ABORT_UNLESS(alterData, "No alter data at Alter prepare");
+        Y_ENSURE(alterData, "No alter data at Alter prepare");
         alterData->AlterVersion = AlterVersion + 1;
-        Y_ABORT_UNLESS(alterData->TotalGroupCount);
-        Y_ABORT_UNLESS(alterData->TotalPartitionCount);
-        Y_ABORT_UNLESS(0 < alterData->ActivePartitionCount && alterData->ActivePartitionCount <= alterData->TotalPartitionCount);
-        Y_ABORT_UNLESS(alterData->NextPartitionId);
-        Y_ABORT_UNLESS(alterData->MaxPartsPerTablet);
+        Y_ENSURE(alterData->TotalGroupCount);
+        Y_ENSURE(alterData->TotalPartitionCount);
+        Y_ENSURE(0 < alterData->ActivePartitionCount && alterData->ActivePartitionCount <= alterData->TotalPartitionCount);
+        Y_ENSURE(alterData->NextPartitionId);
+        Y_ENSURE(alterData->MaxPartsPerTablet);
         alterData->KeySchema = KeySchema;
         alterData->BalancerTabletID = BalancerTabletID;
         alterData->BalancerShardIdx = BalancerShardIdx;
@@ -1293,7 +1292,7 @@ struct TTopicInfo : TSimpleRefCount<TTopicInfo> {
     }
 
     void FinishAlter() {
-        Y_ABORT_UNLESS(AlterData, "No alter data at Alter complete");
+        Y_ENSURE(AlterData, "No alter data at Alter complete");
         TotalGroupCount = AlterData->TotalGroupCount;
         NextPartitionId = AlterData->NextPartitionId;
         TotalPartitionCount = AlterData->TotalPartitionCount;
@@ -1302,9 +1301,9 @@ struct TTopicInfo : TSimpleRefCount<TTopicInfo> {
         if (!AlterData->TabletConfig.empty())
             TabletConfig = std::move(AlterData->TabletConfig);
         ++AlterVersion;
-        Y_ABORT_UNLESS(BalancerTabletID == AlterData->BalancerTabletID || !HasBalancer());
-        Y_ABORT_UNLESS(AlterData->HasBalancer());
-        Y_ABORT_UNLESS(AlterData->BalancerShardIdx);
+        Y_ENSURE(BalancerTabletID == AlterData->BalancerTabletID || !HasBalancer());
+        Y_ENSURE(AlterData->HasBalancer());
+        Y_ENSURE(AlterData->BalancerShardIdx);
         KeySchema = AlterData->KeySchema;
         BalancerTabletID = AlterData->BalancerTabletID;
         BalancerShardIdx = AlterData->BalancerShardIdx;
@@ -1367,7 +1366,7 @@ struct TSolomonVolumeInfo: TSimpleRefCount<TSolomonVolumeInfo> {
     }
 
     TSolomonVolumeInfo::TPtr CreateAlter(ui64 version) const {
-        Y_ABORT_UNLESS(Version < version);
+        Y_ENSURE(Version < version);
         TSolomonVolumeInfo::TPtr alter = new TSolomonVolumeInfo(*this);
         alter->Version = version;
         return alter;
@@ -1472,12 +1471,12 @@ struct TSubDomainInfo: TSimpleRefCount<TSubDomainInfo> {
         ProcessingParams.SetVersion(other.GetVersion() + 1);
 
         if (planResolution) {
-            Y_ABORT_UNLESS(other.GetPlanResolution() == 0 || other.GetPlanResolution() == planResolution);
+            Y_ENSURE(other.GetPlanResolution() == 0 || other.GetPlanResolution() == planResolution);
             ProcessingParams.SetPlanResolution(planResolution);
         }
 
         if (timeCastBucketsMediator) {
-            Y_ABORT_UNLESS(other.GetTCB() == 0 || other.GetTCB() == timeCastBucketsMediator);
+            Y_ENSURE(other.GetTCB() == 0 || other.GetTCB() == timeCastBucketsMediator);
             ProcessingParams.SetTimeCastBucketsPerMediator(timeCastBucketsMediator);
         }
 
@@ -1511,18 +1510,18 @@ struct TSubDomainInfo: TSimpleRefCount<TSubDomainInfo> {
     }
 
     void SetVersion(ui64 version) {
-        Y_ABORT_UNLESS(ProcessingParams.GetVersion() < version);
+        Y_ENSURE(ProcessingParams.GetVersion() < version);
         ProcessingParams.SetVersion(version);
     }
 
     void SetAlter(TPtr alterData) {
-        Y_ABORT_UNLESS(alterData);
-        Y_ABORT_UNLESS(GetVersion() < alterData->GetVersion());
+        Y_ENSURE(alterData);
+        Y_ENSURE(GetVersion() < alterData->GetVersion());
         AlterData = alterData;
     }
 
     void SetStoragePools(TStoragePools& storagePools, ui64 subDomainVersion) {
-        Y_ABORT_UNLESS(GetVersion() < subDomainVersion);
+        Y_ENSURE(GetVersion() < subDomainVersion);
         StoragePools.swap(storagePools);
         ProcessingParams.SetVersion(subDomainVersion);
     }
@@ -1610,11 +1609,11 @@ struct TSubDomainInfo: TSimpleRefCount<TSubDomainInfo> {
     }
 
     void IncPathsInside(IQuotaCounters* counters, ui64 delta = 1, bool isBackup = false) {
-        Y_ABORT_UNLESS(Max<ui64>() - PathsInsideCount >= delta);
+        Y_ENSURE(Max<ui64>() - PathsInsideCount >= delta);
         PathsInsideCount += delta;
 
         if (isBackup) {
-            Y_ABORT_UNLESS(Max<ui64>() - BackupPathsCount >= delta);
+            Y_ENSURE(Max<ui64>() - BackupPathsCount >= delta);
             BackupPathsCount += delta;
         } else {
             counters->ChangePathCount(delta);
@@ -1622,11 +1621,11 @@ struct TSubDomainInfo: TSimpleRefCount<TSubDomainInfo> {
     }
 
     void DecPathsInside(IQuotaCounters* counters, ui64 delta = 1, bool isBackup = false) {
-        Y_VERIFY_S(PathsInsideCount >= delta, "PathsInsideCount: " << PathsInsideCount << " delta: " << delta);
+        Y_ENSURE(PathsInsideCount >= delta, "PathsInsideCount: " << PathsInsideCount << " delta: " << delta);
         PathsInsideCount -= delta;
 
         if (isBackup) {
-            Y_VERIFY_S(BackupPathsCount >= delta, "BackupPathsCount: " << BackupPathsCount << " delta: " << delta);
+            Y_ENSURE(BackupPathsCount >= delta, "BackupPathsCount: " << BackupPathsCount << " delta: " << delta);
             BackupPathsCount -= delta;
         } else {
             counters->ChangePathCount(-delta);
@@ -1642,12 +1641,12 @@ struct TSubDomainInfo: TSimpleRefCount<TSubDomainInfo> {
     }
 
     void IncPQPartitionsInside(ui64 delta = 1) {
-        Y_ABORT_UNLESS(Max<ui64>() - PQPartitionsInsideCount >= delta);
+        Y_ENSURE(Max<ui64>() - PQPartitionsInsideCount >= delta);
         PQPartitionsInsideCount += delta;
     }
 
     void DecPQPartitionsInside(ui64 delta = 1) {
-        Y_VERIFY_S(PQPartitionsInsideCount >= delta, "PQPartitionsInsideCount: " << PQPartitionsInsideCount << " delta: " << delta);
+        Y_ENSURE(PQPartitionsInsideCount >= delta, "PQPartitionsInsideCount: " << PQPartitionsInsideCount << " delta: " << delta);
         PQPartitionsInsideCount -= delta;
     }
 
@@ -1666,12 +1665,12 @@ struct TSubDomainInfo: TSimpleRefCount<TSubDomainInfo> {
     }
 
     void IncPQReservedStorage(ui64 delta = 1) {
-        Y_ABORT_UNLESS(Max<ui64>() - PQReservedStorage >= delta);
+        Y_ENSURE(Max<ui64>() - PQReservedStorage >= delta);
         PQReservedStorage += delta;
     }
 
     void DecPQReservedStorage(ui64 delta = 1) {
-        Y_VERIFY_S(PQReservedStorage >= delta, "PQReservedStorage: " << PQReservedStorage << " delta: " << delta);
+        Y_ENSURE(PQReservedStorage >= delta, "PQReservedStorage: " << PQReservedStorage << " delta: " << delta);
         PQReservedStorage -= delta;
     }
 
@@ -1691,7 +1690,7 @@ struct TSubDomainInfo: TSimpleRefCount<TSubDomainInfo> {
     }
 
     void ActualizeAlterData(const THashMap<TShardIdx, TShardInfo>& allShards, TInstant now, bool isExternal, IQuotaCounters* counters) {
-        Y_ABORT_UNLESS(AlterData);
+        Y_ENSURE(AlterData);
 
         AlterData->SetPathsInside(GetPathsInside());
         AlterData->InternalShards.swap(InternalShards);
@@ -1836,7 +1835,7 @@ struct TSubDomainInfo: TSimpleRefCount<TSubDomainInfo> {
 
     void RemoveInternalShard(TShardIdx shardIdx, IQuotaCounters* counters) {
         auto it = InternalShards.find(shardIdx);
-        Y_VERIFY_S(it != InternalShards.end(), "shardIdx: " << shardIdx);
+        Y_ENSURE(it != InternalShards.end(), "shardIdx: " << shardIdx);
         InternalShards.erase(it);
 
         if (BackupShards.contains(shardIdx)) {
@@ -1856,7 +1855,7 @@ struct TSubDomainInfo: TSimpleRefCount<TSubDomainInfo> {
 
     void RemoveSequenceShard(const TShardIdx& shardIdx) {
         auto it = SequenceShards.find(shardIdx);
-        Y_VERIFY_S(it != SequenceShards.end(), "shardIdx: " << shardIdx);
+        Y_ENSURE(it != SequenceShards.end(), "shardIdx: " << shardIdx);
         SequenceShards.erase(it);
     }
 
@@ -1865,7 +1864,7 @@ struct TSubDomainInfo: TSimpleRefCount<TSubDomainInfo> {
     }
 
     TTabletId GetCoordinator(TTxId txId) const {
-        Y_ABORT_UNLESS(IsSupportTransactions());
+        Y_ENSURE(IsSupportTransactions());
         return TTabletId(CoordinatorSelector->Select(ui64(txId)));
     }
 
@@ -1893,14 +1892,14 @@ struct TSubDomainInfo: TSimpleRefCount<TSubDomainInfo> {
 
         ProcessingParams.ClearSchemeShard();
         TVector<TTabletId> schemeshards = FilterPrivateTablets(ETabletType::SchemeShard, allShards);
-        Y_VERIFY_S(schemeshards.size() <= 1, "size was: " << schemeshards.size());
+        Y_ENSURE(schemeshards.size() <= 1, "size was: " << schemeshards.size());
         if (schemeshards.size()) {
             ProcessingParams.SetSchemeShard(ui64(schemeshards.front()));
         }
 
         ProcessingParams.ClearHive();
         TVector<TTabletId> hives = FilterPrivateTablets(ETabletType::Hive, allShards);
-        Y_VERIFY_S(hives.size() <= 1, "size was: " << hives.size());
+        Y_ENSURE(hives.size() <= 1, "size was: " << hives.size());
         if (hives.size()) {
             ProcessingParams.SetHive(ui64(hives.front()));
             SetSharedHive(InvalidTabletId); // set off shared hive when our own hive has found
@@ -1908,21 +1907,21 @@ struct TSubDomainInfo: TSimpleRefCount<TSubDomainInfo> {
 
         ProcessingParams.ClearSysViewProcessor();
         TVector<TTabletId> sysViewProcessors = FilterPrivateTablets(ETabletType::SysViewProcessor, allShards);
-        Y_VERIFY_S(sysViewProcessors.size() <= 1, "size was: " << sysViewProcessors.size());
+        Y_ENSURE(sysViewProcessors.size() <= 1, "size was: " << sysViewProcessors.size());
         if (sysViewProcessors.size()) {
             ProcessingParams.SetSysViewProcessor(ui64(sysViewProcessors.front()));
         }
 
         ProcessingParams.ClearStatisticsAggregator();
         TVector<TTabletId> statisticsAggregators = FilterPrivateTablets(ETabletType::StatisticsAggregator, allShards);
-        Y_VERIFY_S(statisticsAggregators.size() <= 1, "size was: " << statisticsAggregators.size());
+        Y_ENSURE(statisticsAggregators.size() <= 1, "size was: " << statisticsAggregators.size());
         if (statisticsAggregators.size()) {
             ProcessingParams.SetStatisticsAggregator(ui64(statisticsAggregators.front()));
         }
 
         ProcessingParams.ClearGraphShard();
         TVector<TTabletId> graphs = FilterPrivateTablets(ETabletType::GraphShard, allShards);
-        Y_VERIFY_S(graphs.size() <= 1, "size was: " << graphs.size());
+        Y_ENSURE(graphs.size() <= 1, "size was: " << graphs.size());
         if (graphs.size()) {
             ProcessingParams.SetGraphShard(ui64(graphs.front()));
         }
@@ -1931,8 +1930,8 @@ struct TSubDomainInfo: TSimpleRefCount<TSubDomainInfo> {
     void InitializeAsGlobal(NKikimrSubDomains::TProcessingParams&& processingParams) {
         InitiatedAsGlobal = true;
 
-        Y_ABORT_UNLESS(processingParams.GetPlanResolution());
-        Y_ABORT_UNLESS(processingParams.GetTimeCastBucketsPerMediator());
+        Y_ENSURE(processingParams.GetPlanResolution());
+        Y_ENSURE(processingParams.GetTimeCastBucketsPerMediator());
 
         ui64 version = ProcessingParams.GetVersion();
         ProcessingParams = std::move(processingParams);
@@ -1982,8 +1981,8 @@ struct TSubDomainInfo: TSimpleRefCount<TSubDomainInfo> {
         // Check if there was no change in declared quotas
         if (DeclaredSchemeQuotas) {
             TString prev, next;
-            Y_ABORT_UNLESS(DeclaredSchemeQuotas->SerializeToString(&prev));
-            Y_ABORT_UNLESS(declaredSchemeQuotas.SerializeToString(&next));
+            Y_ENSURE(DeclaredSchemeQuotas->SerializeToString(&prev));
+            Y_ENSURE(declaredSchemeQuotas.SerializeToString(&next));
             if (prev == next) {
                 return; // there was no change in quotas
             }
@@ -2093,7 +2092,7 @@ struct TSubDomainInfo: TSimpleRefCount<TSubDomainInfo> {
     }
 
     void SetServerlessComputeResourcesMode(EServerlessComputeResourcesMode serverlessComputeResourcesMode) {
-        Y_ABORT_UNLESS(serverlessComputeResourcesMode, "Can't set ServerlessComputeResourcesMode to unspecified");
+        Y_ENSURE(serverlessComputeResourcesMode, "Can't set ServerlessComputeResourcesMode to unspecified");
         ServerlessComputeResourcesMode = serverlessComputeResourcesMode;
     }
 
@@ -2197,7 +2196,7 @@ struct TBlockStoreVolumeInfo : public TSimpleRefCount<TBlockStoreVolumeInfo> {
     bool HasVolumeTablet() const { return VolumeTabletId != InvalidTabletId; }
 
     void PrepareAlter(TBlockStoreVolumeInfo::TPtr alterData) {
-        Y_ABORT_UNLESS(alterData, "No alter data at Alter preparation");
+        Y_ENSURE(alterData, "No alter data at Alter preparation");
         if (!alterData->DefaultPartitionCount) {
             alterData->DefaultPartitionCount =
                 CalculateDefaultPartitionCount(alterData->VolumeConfig);
@@ -2209,20 +2208,20 @@ struct TBlockStoreVolumeInfo : public TSimpleRefCount<TBlockStoreVolumeInfo> {
     }
 
     void ForgetAlter() {
-        Y_ABORT_UNLESS(AlterData, "No alter data at Alter rollback");
+        Y_ENSURE(AlterData, "No alter data at Alter rollback");
         AlterData.Reset();
     }
 
     void FinishAlter() {
-        Y_ABORT_UNLESS(AlterData, "No alter data at Alter completion");
+        Y_ENSURE(AlterData, "No alter data at Alter completion");
         DefaultPartitionCount = AlterData->DefaultPartitionCount;
         ExplicitChannelProfileCount = AlterData->ExplicitChannelProfileCount;
         VolumeConfig.CopyFrom(AlterData->VolumeConfig);
         ++AlterVersion;
-        Y_ABORT_UNLESS(AlterVersion == AlterData->AlterVersion);
-        Y_ABORT_UNLESS(VolumeTabletId == AlterData->VolumeTabletId || !HasVolumeTablet());
-        Y_ABORT_UNLESS(AlterData->HasVolumeTablet());
-        Y_ABORT_UNLESS(AlterData->VolumeShardIdx);
+        Y_ENSURE(AlterVersion == AlterData->AlterVersion);
+        Y_ENSURE(VolumeTabletId == AlterData->VolumeTabletId || !HasVolumeTablet());
+        Y_ENSURE(AlterData->HasVolumeTablet());
+        Y_ENSURE(AlterData->VolumeShardIdx);
         VolumeTabletId = AlterData->VolumeTabletId;
         VolumeShardIdx = AlterData->VolumeShardIdx;
         AlterData.Reset();
@@ -2241,12 +2240,12 @@ struct TBlockStoreVolumeInfo : public TSimpleRefCount<TBlockStoreVolumeInfo> {
             const auto& partInfo = *kv.second;
 
             auto itShard = allShards.find(shardIdx);
-            Y_VERIFY_S(itShard != allShards.end(), "No shard with shardIdx " << shardIdx);
+            Y_ENSURE(itShard != allShards.end(), "No shard with shardIdx " << shardIdx);
             TTabletId tabletId = itShard->second.TabletID;
 
             if (partInfo.AlterVersion <= AlterVersion) {
-                Y_ABORT_UNLESS(partInfo.PartitionId < DefaultPartitionCount,
-                    "Wrong PartitionId %" PRIu32, partInfo.PartitionId);
+                Y_ENSURE(partInfo.PartitionId < DefaultPartitionCount,
+                    "Wrong PartitionId " << partInfo.PartitionId);
                 TabletCache.Tablets[partInfo.PartitionId] = tabletId;
             }
         }
@@ -2254,7 +2253,7 @@ struct TBlockStoreVolumeInfo : public TSimpleRefCount<TBlockStoreVolumeInfo> {
         // Verify there are no missing tabletIds
         for (ui32 idx = 0; idx < TabletCache.Tablets.size(); ++idx) {
             TTabletId tabletId = TabletCache.Tablets[idx];
-            Y_VERIFY_S(tabletId, "Unassigned tabletId"
+            Y_ENSURE(tabletId, "Unassigned tabletId"
                            << " for partition " << idx
                            << " out of " << TabletCache.Tablets.size()
                            << " TabletCache.AlterVersion" << TabletCache.AlterVersion
@@ -2322,33 +2321,33 @@ struct TFileStoreInfo : public TSimpleRefCount<TFileStoreInfo> {
     ui64 AlterVersion = 0;
 
     void PrepareAlter(const NKikimrFileStore::TConfig& alterConfig) {
-        Y_ABORT_UNLESS(!AlterConfig);
-        Y_ABORT_UNLESS(!AlterVersion);
+        Y_ENSURE(!AlterConfig);
+        Y_ENSURE(!AlterVersion);
 
         AlterConfig = MakeHolder<NKikimrFileStore::TConfig>();
         AlterConfig->CopyFrom(alterConfig);
 
-        Y_ABORT_UNLESS(!AlterConfig->GetBlockSize());
+        Y_ENSURE(!AlterConfig->GetBlockSize());
         AlterConfig->SetBlockSize(Config.GetBlockSize());
 
         AlterVersion = Version + 1;
     }
 
     void ForgetAlter() {
-        Y_ABORT_UNLESS(AlterConfig);
-        Y_ABORT_UNLESS(AlterVersion);
+        Y_ENSURE(AlterConfig);
+        Y_ENSURE(AlterVersion);
 
         AlterConfig.Reset();
         AlterVersion = 0;
     }
 
     void FinishAlter() {
-        Y_ABORT_UNLESS(AlterConfig);
-        Y_ABORT_UNLESS(AlterVersion);
+        Y_ENSURE(AlterConfig);
+        Y_ENSURE(AlterVersion);
 
         Config.CopyFrom(*AlterConfig);
         ++Version;
-        Y_ABORT_UNLESS(Version == AlterVersion);
+        Y_ENSURE(Version == AlterVersion);
 
         ForgetAlter();
     }
@@ -2401,11 +2400,11 @@ struct TKesusInfo : public TSimpleRefCount<TKesusInfo> {
     ui64 AlterVersion = 0;
 
     void FinishAlter() {
-        Y_ABORT_UNLESS(AlterConfig, "No alter config at Alter completion");
-        Y_ABORT_UNLESS(AlterVersion, "No alter version at Alter completion");
+        Y_ENSURE(AlterConfig, "No alter config at Alter completion");
+        Y_ENSURE(AlterVersion, "No alter version at Alter completion");
         Config.CopyFrom(*AlterConfig);
         ++Version;
-        Y_ABORT_UNLESS(Version == AlterVersion);
+        Y_ENSURE(Version == AlterVersion);
         AlterConfig.Reset();
         AlterVersion = 0;
     }
@@ -2422,7 +2421,7 @@ struct TTableIndexInfo : public TSimpleRefCount<TTableIndexInfo> {
         , State(state)
     {
         if (type == NKikimrSchemeOp::EIndexType::EIndexTypeGlobalVectorKmeansTree) {
-            Y_ABORT_UNLESS(SpecializedIndexDescription.emplace<NKikimrSchemeOp::TVectorIndexKmeansTreeDescription>()
+            Y_ENSURE(SpecializedIndexDescription.emplace<NKikimrSchemeOp::TVectorIndexKmeansTreeDescription>()
                                .ParseFromString(description));
         }
     }
@@ -2435,7 +2434,7 @@ struct TTableIndexInfo : public TSimpleRefCount<TTableIndexInfo> {
     }
 
     TPtr GetNextVersion() const {
-        Y_ABORT_UNLESS(AlterData == nullptr);
+        Y_ENSURE(AlterData == nullptr);
         TPtr result = new TTableIndexInfo(*this);
         ++result->AlterVersion;
         return result;
@@ -2447,7 +2446,7 @@ struct TTableIndexInfo : public TSimpleRefCount<TTableIndexInfo> {
                 return TString{};
             } else {
                 TString str{v.SerializeAsString()};
-                Y_ABORT_UNLESS(!str.empty());
+                Y_ENSURE(!str.empty());
                 return str;
             }
         }, SpecializedIndexDescription);
@@ -2467,7 +2466,7 @@ struct TTableIndexInfo : public TSimpleRefCount<TTableIndexInfo> {
 
         TPtr alterData = result->CreateNextVersion();
         alterData->IndexKeys.assign(config.GetKeyColumnNames().begin(), config.GetKeyColumnNames().end());
-        Y_ABORT_UNLESS(!alterData->IndexKeys.empty());
+        Y_ENSURE(!alterData->IndexKeys.empty());
         alterData->IndexDataColumns.assign(config.GetDataColumnNames().begin(), config.GetDataColumnNames().end());
 
         alterData->State = config.HasState() ? config.GetState() : EState::EIndexStateReady;
@@ -2519,7 +2518,7 @@ struct TCdcStreamInfo : public TSimpleRefCount<TCdcStreamInfo> {
     TCdcStreamInfo(const TCdcStreamInfo&) = default;
 
     TPtr CreateNextVersion() {
-        Y_ABORT_UNLESS(AlterData == nullptr);
+        Y_ENSURE(AlterData == nullptr);
         TPtr result = new TCdcStreamInfo(*this);
         ++result->AlterVersion;
         this->AlterData = result;
@@ -2543,7 +2542,7 @@ struct TCdcStreamInfo : public TSimpleRefCount<TCdcStreamInfo> {
     }
 
     void FinishAlter() {
-        Y_ABORT_UNLESS(AlterData);
+        Y_ENSURE(AlterData);
 
         AlterVersion = AlterData->AlterVersion;
         Mode = AlterData->Mode;
@@ -2585,7 +2584,7 @@ struct TSequenceInfo : public TSimpleRefCount<TSequenceInfo> {
         NKikimrSchemeOp::TSequenceSharding&& sharding);
 
     TPtr CreateNextVersion() {
-        Y_ABORT_UNLESS(AlterData == nullptr);
+        Y_ENSURE(AlterData == nullptr);
         TPtr result = new TSequenceInfo(*this);
         ++result->AlterVersion;
         this->AlterData = result;
@@ -2617,7 +2616,7 @@ struct TReplicationInfo : public TSimpleRefCount<TReplicationInfo> {
     }
 
     TPtr CreateNextVersion() {
-        Y_ABORT_UNLESS(AlterData == nullptr);
+        Y_ENSURE(AlterData == nullptr);
 
         TPtr result = new TReplicationInfo(*this);
         ++result->AlterVersion;
@@ -2658,7 +2657,7 @@ struct TBlobDepotInfo : TSimpleRefCount<TBlobDepotInfo> {
     }
 
     TPtr CreateNextVersion() {
-        Y_ABORT_UNLESS(!AlterData);
+        Y_ENSURE(!AlterData);
         AlterData = MakeIntrusive<TBlobDepotInfo>(*this);
         ++AlterData->AlterVersion;
         return AlterData;
@@ -3069,7 +3068,7 @@ struct TIndexBuildInfo: public TSimpleRefCount<TIndexBuildInfo> {
             , NotNull(notNull)
             , FamilyName(familyName)
         {
-            Y_ABORT_UNLESS(DefaultFromLiteral.ParseFromString(serializedLiteral));
+            Y_ENSURE(DefaultFromLiteral.ParseFromString(serializedLiteral));
         }
 
         TColumnBuildInfo(const TString& name, const Ydb::TypedValue& defaultFromLiteral, bool notNull, const TString& familyName)
@@ -3211,7 +3210,7 @@ struct TIndexBuildInfo: public TSimpleRefCount<TIndexBuildInfo> {
         }
 
         void PrefixIndexDone(ui64 shards) {
-            Y_ABORT_UNLESS(NeedsAnotherLevel());
+            Y_ENSURE(NeedsAnotherLevel());
             State = MultiLocal;
             // There's two worst cases, but in both one shard contains TableSize rows
             // 1. all rows have unique prefix (*), in such case we need 1 id for each row (parent, id in prefix table)
@@ -3259,7 +3258,7 @@ struct TIndexBuildInfo: public TSimpleRefCount<TIndexBuildInfo> {
             return name;
         }
         TString ReadFrom() const {
-            Y_ASSERT(Level > 1);
+            Y_ENSURE(Level > 1);
             using namespace NTableIndex::NTableVectorKmeansTreeIndex;
             TString name = PostingTable;
             name += Level % 2 != 0 ? BuildSuffix1 : BuildSuffix0;
@@ -3285,9 +3284,9 @@ struct TIndexBuildInfo: public TSimpleRefCount<TIndexBuildInfo> {
                 }
                 return maxParent;
             }();
-            Y_VERIFY_DEBUG_S(minParent <= parentFrom, "minParent(" << minParent << ") > parentFrom(" << parentFrom << ") " << DebugString());
-            Y_VERIFY_DEBUG_S(parentFrom <= parentTo, "parentFrom(" << parentFrom << ") > parentTo(" << parentTo << ") " << DebugString());
-            Y_VERIFY_DEBUG_S(parentTo <= maxParent, "parentTo(" << parentTo << ") > maxParent(" << maxParent << ") " << DebugString());
+            Y_ENSURE(minParent <= parentFrom, "minParent(" << minParent << ") > parentFrom(" << parentFrom << ") " << DebugString());
+            Y_ENSURE(parentFrom <= parentTo, "parentFrom(" << parentFrom << ") > parentTo(" << parentTo << ") " << DebugString());
+            Y_ENSURE(parentTo <= maxParent, "parentTo(" << parentTo << ") > maxParent(" << maxParent << ") " << DebugString());
             return {parentFrom, parentTo};
         }
 
@@ -3467,12 +3466,12 @@ struct TIndexBuildInfo: public TSimpleRefCount<TIndexBuildInfo> {
 
     private:
         void MakeTop(ui64 k) {
-            Y_ASSERT(k > 0);
+            Y_ENSURE(k > 0);
             auto kth = Rows.begin() + k - 1;
             // TODO(mbkkt) use floyd rivest
             std::nth_element(Rows.begin(), kth, Rows.end());
             Rows.erase(kth + 1, Rows.end());
-            Y_ASSERT(kth->P < MaxProbability);
+            Y_ENSURE(kth->P < MaxProbability);
             MaxProbability = kth->P;
         }
     };
@@ -3527,7 +3526,7 @@ struct TIndexBuildInfo: public TSimpleRefCount<TIndexBuildInfo> {
                 EIndexColumnKind::KeyColumn);
         ui32 columnNo = row.template GetValue<Schema::IndexBuildColumns::ColumnNo>();
 
-        Y_VERIFY_S(columnNo == (IndexColumns.size() + DataColumns.size()),
+        Y_ENSURE(columnNo == (IndexColumns.size() + DataColumns.size()),
                    "Unexpected non contiguous column number# "
                        << columnNo << " indexColumns# "
                        << IndexColumns.size() << " dataColumns# "
@@ -3541,7 +3540,7 @@ struct TIndexBuildInfo: public TSimpleRefCount<TIndexBuildInfo> {
             DataColumns.push_back(columnName);
             break;
         default:
-            Y_FAIL_S("Unknown column kind# " << (int)columnKind);
+            Y_ENSURE(false, "Unknown column kind# " << (int)columnKind);
             break;
         }
     }
@@ -3573,7 +3572,7 @@ struct TIndexBuildInfo: public TSimpleRefCount<TIndexBuildInfo> {
         // Restore the operation details: ImplTableDescriptions and SpecializedIndexDescription.
         if (row.template HaveValue<Schema::IndexBuild::CreationConfig>()) {
             NKikimrSchemeOp::TIndexCreationConfig creationConfig;
-            Y_ABORT_UNLESS(creationConfig.ParseFromString(row.template GetValue<Schema::IndexBuild::CreationConfig>()));
+            Y_ENSURE(creationConfig.ParseFromString(row.template GetValue<Schema::IndexBuild::CreationConfig>()));
 
             auto& descriptions = *creationConfig.MutableIndexImplTableDescriptions();
             indexInfo->ImplTableDescriptions.reserve(descriptions.size());
@@ -3775,7 +3774,7 @@ struct TIndexBuildInfo: public TSimpleRefCount<TIndexBuildInfo> {
     }
 
     void AddNotifySubscriber(const TActorId& actorID) {
-        Y_ABORT_UNLESS(!IsFinished());
+        Y_ENSURE(!IsFinished());
         Subscribers.insert(actorID);
     }
 
@@ -3785,7 +3784,7 @@ struct TIndexBuildInfo: public TSimpleRefCount<TIndexBuildInfo> {
         if (IsBuildVectorIndex()) {
             const auto inProgress = InProgressShards.size();
             const auto toUpload = ToUploadShards.size();
-            Y_ASSERT(KMeans.Level != 0);
+            Y_ENSURE(KMeans.Level != 0);
             if (!KMeans.NeedsAnotherLevel() && !KMeans.NeedsAnotherParent()
                 && toUpload == 0 && inProgress == 0) {
                 return 100.f;


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

...

### Changelog category <!-- remove all except one -->

* Not for changelog (changelog entry is not required)

### Description for reviewers <!-- (optional) description for those who read this PR -->

Part of https://github.com/ydb-platform/ydb/issues/18648

It would take too long to analize which method in schemeshard_info_types are relevant to build index, so I changed the whole file
