### PR TITLE
Added processing sys view path type in GRPC handlers

### DIFF
--- a/ydb/core/grpc_services/rpc_kh_describe.cpp
+++ b/ydb/core/grpc_services/rpc_kh_describe.cpp
@@ -228,7 +228,7 @@ private:
     void ResolveShards(const NActors::TActorContext& ctx) {
         auto& entry = ResolveNamesResult->ResultSet.front();
 
-        if (entry.TableId.IsSystemView()) {
+        if (entry.TableId.IsSystemView() || entry.Kind == NSchemeCache::TSchemeCacheNavigate::KindSysView) {
             // Add fake shard for sys view
             auto* p = Result.add_partitions();
             p->set_tablet_id(1);

--- a/ydb/core/grpc_services/rpc_read_columns.cpp
+++ b/ydb/core/grpc_services/rpc_read_columns.cpp
@@ -230,9 +230,9 @@ private:
                                   ctx);
         }
 
-        if (ResolveNamesResult->ResultSet.front().TableId.IsSystemView()) {
+        if (entry.TableId.IsSystemView() || entry.Kind == NSchemeCache::TSchemeCacheNavigate::KindSysView) {
             return ScanSystemView(ctx);
-        } if (TryParseLocalDbPath(ResolveNamesResult->ResultSet.front().Path)) {
+        } if (TryParseLocalDbPath(entry.Path)) {
             return ScanLocalDbTable(ctx);
         } else {
             return ResolveShards(ctx);

--- a/ydb/core/grpc_services/rpc_read_rows.cpp
+++ b/ydb/core/grpc_services/rpc_read_rows.cpp
@@ -385,7 +385,7 @@ public:
         OwnerId = entry.Self->Info.GetSchemeshardId();
         TableId = entry.Self->Info.GetPathId();
 
-        if (entry.TableId.IsSystemView()) {
+        if (entry.TableId.IsSystemView() || entry.Kind == NSchemeCache::TSchemeCacheNavigate::KindSysView) {
             return ReplyWithError(Ydb::StatusIds::SCHEME_ERROR,
                 Sprintf("Table '%s' is a system view. ReadRows is not supported.", GetTable().c_str()));
         }
@@ -592,7 +592,7 @@ public:
             }
             case NScheme::NTypeIds::Decimal: {
                 return NYdb::TTypeBuilder().Decimal(NYdb::TDecimalType(
-                        typeInfo.GetDecimalType().GetPrecision(), 
+                        typeInfo.GetDecimalType().GetPrecision(),
                         typeInfo.GetDecimalType().GetScale()))
                     .Build();
             }

--- a/ydb/public/api/protos/ydb_scheme.proto
+++ b/ydb/public/api/protos/ydb_scheme.proto
@@ -67,6 +67,7 @@ message Entry {
         VIEW = 20;
         RESOURCE_POOL = 21;
         TRANSFER = 23;
+        SYS_VIEW = 24;
     }
 
     // Name of scheme entry (dir2 of /dir1/dir2)


### PR DESCRIPTION
This PR is one from the row to support new system view path type all around YDB.
In previous PRs I added this new type. In the future we want to remove SystemViewInfo field from TableId and use the kind of Navigate entry to process only system view paths.
In this PR:
- updated conditions where we check whether the Navigate entry is system view or not
- added new Entry type in ydb_scheme proto to support describe path and table RPC requests
