### PR TITLE
Fix upper bound in logger components list

### DIFF
--- a/ydb/library/actors/core/log.cpp
+++ b/ydb/library/actors/core/log.cpp
@@ -220,7 +220,7 @@ namespace NActors {
                     }
                 }
                 TABLEBODY() {
-                    for (EComponent i = Settings->MinVal; i < Settings->MaxVal; i++) {
+                    for (EComponent i = Settings->MinVal; i <= Settings->MaxVal; i++) {
                         auto name = Settings->ComponentName(i);
                         if (!*name)
                             continue;


### PR DESCRIPTION
### Changelog category <!-- remove all except one -->

* Not for changelog (changelog entry is not required)

### Description for reviewers <!-- (optional) description for those who read this PR -->

Последнее значение в прото-енуме `EServiceKikimr` не показывалось в списке компонентов на страничке `/actors/logger`
