### PR TITLE
Added options SO_REUSEPORT and SO_REUSEADDR for proxy ports (#17429)

### DIFF
--- a/ydb/core/driver_lib/run/kikimr_services_initializers.cpp
+++ b/ydb/core/driver_lib/run/kikimr_services_initializers.cpp
@@ -2758,6 +2758,7 @@ void TKafkaProxyServiceInitializer::InitializeServices(NActors::TActorSystemSetu
         settings.SslCertificatePem = Config.GetKafkaProxyConfig().GetSslCertificate();
         settings.CertificateFile = Config.GetKafkaProxyConfig().GetCert();
         settings.PrivateKeyFile = Config.GetKafkaProxyConfig().GetKey();
+        settings.TcpNotDelay = true;
 
         setup->LocalServices.emplace_back(
             NKafka::MakeKafkaDiscoveryCacheID(),

--- a/ydb/core/raw_socket/sock64.h
+++ b/ydb/core/raw_socket/sock64.h
@@ -129,6 +129,11 @@ protected:
         if (AF == AF_INET6) {
             SetSockOpt(s, SOL_SOCKET, IPV6_V6ONLY, (int)false);
         }
+        SetSockOpt(s, SOL_SOCKET, SO_REUSEADDR, (int)true);
+#ifdef SO_REUSEPORT
+        SetSockOpt(s, SOL_SOCKET, SO_REUSEPORT, (int)true);
+#endif
+
         TSocketHolder sock(s);
         sock.Swap(*this);
     }


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

fixed "Failed to set up listener on port 9092 errno# 98 (Address already in use)"

### Changelog category <!-- remove all except one -->

* Improvement


### Description for reviewers <!-- (optional) description for those who read this PR -->

...
