### PR TITLE
Ability to skip compatibility tests via version

### DIFF
--- a/ydb/tests/compatibility/test_statistics.py
+++ b/ydb/tests/compatibility/test_statistics.py
@@ -124,6 +124,8 @@ class TestStatisticsTLI(RestartToAnotherVersionFixture):
 class TestStatisticsFollowersRollingUpdate(RollingUpgradeAndDowngradeFixture):
     @pytest.fixture(autouse=True, scope="function")
     def setup(self):
+        if min(self.versions) < (25, 1):
+            pytest.skip("Only available since 25-1")
 
         yield from self.setup_cluster(
             extra_feature_flags={

--- a/ydb/tests/library/compatibility/fixtures.py
+++ b/ydb/tests/library/compatibility/fixtures.py
@@ -14,14 +14,25 @@ current_binary_path = kikimr_driver_path()
 last_stable_binary_path = yatest.common.binary_path("ydb/tests/library/compatibility/binaries/ydbd-last-stable")
 prelast_stable_binary_path = yatest.common.binary_path("ydb/tests/library/compatibility/binaries/ydbd-prelast-stable")
 
+current_binary_version = (float("+inf"), )
+last_stable_version = None
+prelast_stable_version = None
+
 current_name = "current"
 last_stable_name = "last"
 if last_stable_binary_path is not None:  # in import_test yatest.common.binary_path returns None
     last_stable_name = open(yatest.common.binary_path("ydb/tests/library/compatibility/binaries/ydbd-last-stable-name")).read().strip()
+    last_stable_version = tuple((int(val) for val in last_stable_name.split("-")))
 prelast_stable_name = "prelast"
 if prelast_stable_binary_path:  # in import_test yatest.common.binary_path returns None
     prelast_stable_name = open(yatest.common.binary_path("ydb/tests/library/compatibility/binaries/ydbd-prelast-stable-name")).read().strip()
+    prelast_stable_version = tuple((int(val) for val in prelast_stable_name.split("-")))
 
+path_to_version = {
+    current_binary_path: current_binary_version,
+    last_stable_binary_path: last_stable_version,
+    prelast_stable_binary_path: prelast_stable_version,
+}
 
 all_binary_combinations_restart = [
     [[last_stable_binary_path], [current_binary_path]],
@@ -48,6 +59,7 @@ class RestartToAnotherVersionFixture:
     def base_setup(self, request):
         self.current_binary_paths_index = 0
         self.all_binary_paths = request.param
+        self.versions = list([path_to_version[path] for path in self.all_binary_paths])
 
     def setup_cluster(self, **kwargs):
         extra_feature_flags = kwargs.pop("extra_feature_flags", {})
@@ -111,6 +123,7 @@ class MixedClusterFixture:
     @pytest.fixture(autouse=True, params=all_binary_combinations_mixed, ids=all_binary_combinations_ids_mixed)
     def base_setup(self, request):
         self.all_binary_paths = request.param
+        self.versions = list([path_to_version[path] for path in self.all_binary_paths])
 
     def setup_cluster(self, **kwargs):
         self.config = KikimrConfigGenerator(
@@ -150,6 +163,7 @@ class RollingUpgradeAndDowngradeFixture:
     @pytest.fixture(autouse=True, params=all_binary_combinations_rolling, ids=all_binary_combinations_ids_rolling)
     def base_setup(self, request):
         self.all_binary_paths = request.param
+        self.versions = list([path_to_version[path] for path in self.all_binary_paths])
 
     def _wait_for_readiness(self):
         if self.recreate_driver:


### PR DESCRIPTION
This PR introduces the ability to skip compatibility tests based on the version of the binary under test.

[See](https://github.com/ydb-platform/ydb/issues/18603#issuecomment-2912026809)