### PR TITLE
ydb tools restore fix: logical backup folder traversal (with symlinks), not physical

### DIFF
--- a/ydb/public/lib/ydb_cli/dump/restore_impl.cpp
+++ b/ydb/public/lib/ydb_cli/dump/restore_impl.cpp
@@ -952,7 +952,6 @@ namespace {
                         TStringBuilder() << "Backup folder must not contain duplicate paths to the same folder: "
                             << fsPath.GetPath().Quote()
                     );
-                    break;
                 }
 
                 if (fsPath.Child(NFiles::Incomplete().FileName).Exists()) {


### PR DESCRIPTION
\+ restore previous behaviour for the 1 backup entry case

### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

### Changelog category <!-- remove all except one -->

* Not for changelog (changelog entry is not required)

### Description for reviewers <!-- (optional) description for those who read this PR -->

Fix for the YDB import \#802
