### PR TITLE
Add GroupSizeInUnits and PDiskSlotSizeInUnits properties to blobstorage structures

### DIFF
--- a/ydb/apps/dstool/lib/dstool_cmd_group_list.py
+++ b/ydb/apps/dstool/lib/dstool_cmd_group_list.py
@@ -32,6 +32,7 @@ def do(args):
         'PoolId',
         'Generation',
         'ErasureSpecies',
+        'SizeInUnits',
         'ExpectedStatus',
         'OperatingStatus',
         'SeenOperational',
@@ -56,6 +57,7 @@ def do(args):
         'PoolName',
         'Generation',
         'ErasureSpecies',
+        'SizeInUnits',
         'OperatingStatus',
         'VDisks_TOTAL',
     ]
@@ -86,6 +88,7 @@ def do(args):
         group_stat['GroupId'] = group.GroupId
         group_stat['Generation'] = group.GroupGeneration
         group_stat['ErasureSpecies'] = group.ErasureSpecies
+        group_stat['SizeInUnits'] = group.GroupSizeInUnits
         group_stat['ExpectedStatus'] = kikimr_bsconfig.TGroupStatus.E.Name(group.ExpectedStatus)
         group_stat['OperatingStatus'] = kikimr_bsconfig.TGroupStatus.E.Name(group.OperatingStatus)
         group_stat['SeenOperational'] = group.SeenOperational

--- a/ydb/apps/dstool/lib/dstool_cmd_pdisk_list.py
+++ b/ydb/apps/dstool/lib/dstool_cmd_pdisk_list.py
@@ -31,6 +31,7 @@ def do(args):
         'Guid',
         'NumStaticSlots',
         'ExpectedSlotCount',
+        'SlotSizeInUnits',
         'PDiskConfig',
         'Usage',
         'UsedSize',
@@ -46,6 +47,7 @@ def do(args):
         'FQDN',
         'Path',
         'Type',
+        'SlotSizeInUnits',
         'Status',
         'DecommitStatus',
     ]
@@ -89,6 +91,7 @@ def do(args):
         row['Guid'] = pdisk.Guid
         row['NumStaticSlots'] = pdisk.NumStaticSlots
         row['ExpectedSlotCount'] = pdisk.ExpectedSlotCount
+        row['SlotSizeInUnits'] = pdisk.PDiskConfig.SlotSizeInUnits
         row['PDiskConfig'] = text_format.MessageToString(pdisk.PDiskConfig, as_one_line=True)
         row['AvailableSize'] = pdisk.PDiskMetrics.AvailableSize
         row['TotalSize'] = pdisk.PDiskMetrics.TotalSize

--- a/ydb/apps/dstool/lib/dstool_cmd_pool_list.py
+++ b/ydb/apps/dstool/lib/dstool_cmd_pool_list.py
@@ -75,6 +75,7 @@ def do(args):
         'PoolId',
         'ErasureSpecies',
         'Kind',
+        'DefaultGroupSizeInUnits',
         'VDiskKind',
         'Groups_TOTAL',
         'Groups_UNKNOWN',
@@ -103,6 +104,7 @@ def do(args):
         'PoolName',
         'ErasureSpecies',
         'Kind',
+        'DefaultGroupSizeInUnits',
         'Groups_TOTAL',
         'VDisks_TOTAL',
     ]
@@ -180,6 +182,7 @@ def do(args):
         row['PoolName'] = sp.Name
         row['ErasureSpecies'] = sp.ErasureSpecies
         row['Kind'] = sp.Kind
+        row['DefaultGroupSizeInUnits'] = sp.DefaultGroupSizeInUnits
         row['VDiskKind'] = sp.VDiskKind
         row['ItemConfigGeneration'] = sp.ItemConfigGeneration
 

--- a/ydb/apps/dstool/lib/dstool_cmd_vdisk_list.py
+++ b/ydb/apps/dstool/lib/dstool_cmd_vdisk_list.py
@@ -67,7 +67,7 @@ def do(args):
         'NodeId:PDiskId',
         'VSlotId',
         'VSlotStatus',
-        'GroupSizeInUnits'
+        'GroupSizeInUnits',
         'IsDonor',
         'ReadOnly',
     ]

--- a/ydb/apps/dstool/lib/dstool_cmd_vdisk_list.py
+++ b/ydb/apps/dstool/lib/dstool_cmd_vdisk_list.py
@@ -49,6 +49,8 @@ def do(args):
         'FailDomainIdx',
         'VDiskIdx',
         'VDiskKind',
+        'GroupSizeInUnits',
+        'PDiskSlotSizeInUnits',
         'Usage',
         'UsedSize',
         'AvailableSize',
@@ -65,6 +67,7 @@ def do(args):
         'NodeId:PDiskId',
         'VSlotId',
         'VSlotStatus',
+        'GroupSizeInUnits'
         'IsDonor',
         'ReadOnly',
     ]
@@ -109,6 +112,8 @@ def do(args):
             row['FailDomainIdx'] = vslot.FailDomainIdx
             row['VDiskIdx'] = vslot.VDiskIdx
             row['VDiskKind'] = vslot.VDiskKind
+            row['GroupSizeInUnits'] = group_map[group].GroupSizeInUnits
+            row['PDiskSlotSizeInUnits'] = pdisk.PDiskConfig.SlotSizeInUnits
             row['UsedSize'] = vslot.VDiskMetrics.AllocatedSize
             row['AvailableSize'] = vslot.VDiskMetrics.AvailableSize
             row['TotalSize'] = row['UsedSize'] + row['AvailableSize']

--- a/ydb/core/blobstorage/groupinfo/blobstorage_groupinfo.h
+++ b/ydb/core/blobstorage/groupinfo/blobstorage_groupinfo.h
@@ -343,13 +343,16 @@ public:
     explicit TBlobStorageGroupInfo(TBlobStorageGroupType gtype, ui32 numVDisksPerFailDomain = 1,
             ui32 numFailDomains = 0, ui32 numFailRealms = 1, const TVector<TActorId> *vdiskIds = nullptr,
             EEncryptionMode encryptionMode = EEM_ENC_V1, ELifeCyclePhase lifeCyclePhase = ELCP_IN_USE,
-            TCypherKey key = TCypherKey((const ui8*)"TestKey", 8), TGroupId groupId = TGroupId::Zero());
+            TCypherKey key = TCypherKey((const ui8*)"TestKey", 8), TGroupId groupId = TGroupId::Zero(),
+            ui32 groupSizeInUnits = 0u);
 
     TBlobStorageGroupInfo(std::shared_ptr<TTopology> topology, TDynamicInfo&& rti, TString storagePoolName,
-        TMaybe<TKikimrScopeId> acceptedScope, NPDisk::EDeviceType deviceType);
+        TMaybe<TKikimrScopeId> acceptedScope, NPDisk::EDeviceType deviceType,
+        ui32 groupSizeInUnits = 0u);
 
     TBlobStorageGroupInfo(TTopology&& topology, TDynamicInfo&& rti, TString storagePoolName,
-        TMaybe<TKikimrScopeId> acceptedScope = {}, NPDisk::EDeviceType deviceType = NPDisk::DEVICE_TYPE_UNKNOWN);
+        TMaybe<TKikimrScopeId> acceptedScope = {}, NPDisk::EDeviceType deviceType = NPDisk::DEVICE_TYPE_UNKNOWN,
+        ui32 groupSizeInUnits = 0u);
 
     TBlobStorageGroupInfo(const TIntrusivePtr<TBlobStorageGroupInfo>& info, const TVDiskID& vdiskId, const TActorId& actorId);
 
@@ -452,6 +455,8 @@ public:
     const ui32 GroupGeneration;
     // erasure primarily
     const TBlobStorageGroupType Type;
+    // the size to match PDisk.SlotSizeInUnits
+    ui32 GroupSizeInUnits;
     // virtual group BlobDepot tablet id
     std::optional<ui64> BlobDepotId;
     // assimilating group id

--- a/ydb/core/blobstorage/nodewarden/distconf_generate.cpp
+++ b/ydb/core/blobstorage/nodewarden/distconf_generate.cpp
@@ -424,11 +424,13 @@ namespace NKikimr::NStorage {
             }
 
             ui32 maxSlots = defaultMaxSlots;
+            ui32 slotSizeInUnits = 0;
             if (item.Record.HasPDiskConfig()) {
                 const auto& pdiskConfig = item.Record.GetPDiskConfig();
                 if (pdiskConfig.HasExpectedSlotCount()) {
                     maxSlots = pdiskConfig.GetExpectedSlotCount();
                 }
+                slotSizeInUnits = pdiskConfig.GetSlotSizeInUnits();
             }
 
             const bool pileFilter = !bridgePileId || allowedNodeIds.contains(pdiskId.NodeId);
@@ -439,6 +441,7 @@ namespace NKikimr::NStorage {
                 .Usable = item.Usable && pileFilter,
                 .NumSlots = item.UsedSlots,
                 .MaxSlots = maxSlots,
+                .SlotSizeInUnits = slotSizeInUnits,
                 .Groups{},
                 .SpaceAvailable = item.SpaceAvailable,
                 .Operational = true,

--- a/ydb/core/blobstorage/nodewarden/node_warden_vdisk.cpp
+++ b/ydb/core/blobstorage/nodewarden/node_warden_vdisk.cpp
@@ -248,6 +248,8 @@ namespace NKikimr::NStorage {
         vdiskConfig->BalancingEpochTimeout = TDuration::MilliSeconds(Cfg->BlobStorageConfig.GetVDiskBalancingConfig().GetEpochTimeoutMs());
         vdiskConfig->BalancingTimeToSleepIfNothingToDo = TDuration::Seconds(Cfg->BlobStorageConfig.GetVDiskBalancingConfig().GetSecondsToSleepIfNothingToDo());
 
+        vdiskConfig->GroupSizeInUnits = groupInfo->GroupSizeInUnits;
+
         // issue initial report to whiteboard before creating actor to avoid races
         Send(WhiteboardId, new NNodeWhiteboard::TEvWhiteboard::TEvVDiskStateUpdate(vdiskId, groupInfo->GetStoragePoolName(),
             vslotId.PDiskId, vslotId.VDiskSlotId, pdiskGuid, kind, donorMode, whiteboardInstanceGuid, std::move(donors)));

--- a/ydb/core/blobstorage/pdisk/blobstorage_pdisk_config.h
+++ b/ydb/core/blobstorage/pdisk/blobstorage_pdisk_config.h
@@ -137,6 +137,7 @@ struct TPDiskConfig : public TThrRefBase {
     bool UseSpdkNvmeDriver;
 
     ui64 ExpectedSlotCount = 0;
+    ui32 SlotSizeInUnits = 0;
 
     // Free chunk permille that triggers Cyan color (e.g. 100 is 10%). Between 130 (default) and 13.
     ui32 ChunkBaseLimit = 130;
@@ -316,6 +317,7 @@ struct TPDiskConfig : public TThrRefBase {
         str << " BufferPoolBufferCount# " << BufferPoolBufferCount << x;
         str << " MaxQueuedCompletionActions# " << MaxQueuedCompletionActions << x;
         str << " ExpectedSlotCount# " << ExpectedSlotCount << x;
+        str << " SlotSizeInUnits# " << SlotSizeInUnits << x;
 
         str << " ReserveLogChunksMultiplier# " << ReserveLogChunksMultiplier << x;
         str << " InsaneLogChunksMultiplier# " << InsaneLogChunksMultiplier << x;
@@ -423,7 +425,12 @@ struct TPDiskConfig : public TThrRefBase {
         if (cfg->HasPlainDataChunks()) {
             PlainDataChunks = cfg->GetPlainDataChunks();
         }
+
+        if (cfg->HasSlotSizeInUnits()) {
+            SlotSizeInUnits = cfg->GetSlotSizeInUnits();
+        }
     }
+
 };
 
 } // NKikimr

--- a/ydb/core/blobstorage/vdisk/common/vdisk_config.h
+++ b/ydb/core/blobstorage/vdisk/common/vdisk_config.h
@@ -222,6 +222,7 @@ namespace NKikimr {
         bool EnableVDiskCooldownTimeout;
         TControlWrapper EnableVPatch = true;
         bool UseActorSystemTimeInBSQueue = false;
+        ui32 GroupSizeInUnits = 0;
 
         ///////////// BALANCING SETTINGS ////////////////////
         bool BalancingEnableSend = false;

--- a/ydb/core/blobstorage/vdisk/skeleton/blobstorage_skeleton.cpp
+++ b/ydb/core/blobstorage/vdisk/skeleton/blobstorage_skeleton.cpp
@@ -2289,6 +2289,10 @@ namespace NKikimr {
                                     TABLED() {str << Config->BaseInfo.PDiskId;}
                                 }
                                 TABLER() {
+                                    TABLED() {str << "GroupSizeInUnits";}
+                                    TABLED() {str << Config->GroupSizeInUnits;}
+                                }
+                                TABLER() {
                                     TABLED() {str << "BlobStorage GroupId (decimal)";}
                                     TABLED() {str << GInfo->GroupID;}
                                 }

--- a/ydb/core/mind/bscontroller/cmds_storage_pool.cpp
+++ b/ydb/core/mind/bscontroller/cmds_storage_pool.cpp
@@ -93,6 +93,7 @@ namespace NKikimr::NBsController {
         storagePool.NumGroups = cmd.GetNumGroups();
         storagePool.EncryptionMode = cmd.GetEncryptionMode();
         storagePool.RandomizeGroupMapping = cmd.GetRandomizeGroupMapping();
+        storagePool.DefaultGroupSizeInUnits = cmd.GetDefaultGroupSizeInUnits();
 
         for (const auto &userId : cmd.GetUserId()) {
             storagePool.UserIds.emplace(boxId, storagePoolId, userId);

--- a/ydb/core/mind/bscontroller/config.cpp
+++ b/ydb/core/mind/bscontroller/config.cpp
@@ -396,7 +396,7 @@ namespace NKikimr::NBsController {
                 if (!degraded.empty()) {
                     msg << "Degraded GroupIds# " << FormatList(degraded) << ' ';
                     if (response) {
-                        for (const auto& id: degraded) { 
+                        for (const auto& id: degraded) {
                             response->MutableGroupsGetDegraded()->Add(id.GetRawId());
                         }
                     }
@@ -956,6 +956,7 @@ namespace NKikimr::NBsController {
             pb->SetKind(pool.Kind);
             pb->SetNumGroups(pool.NumGroups);
             pb->SetRandomizeGroupMapping(pool.RandomizeGroupMapping);
+            pb->SetDefaultGroupSizeInUnits(pool.DefaultGroupSizeInUnits);
 
             for (const auto &userId : pool.UserIds) {
                 pb->AddUserId(std::get<2>(userId));
@@ -1060,6 +1061,7 @@ namespace NKikimr::NBsController {
             pb->SetBoxId(std::get<0>(group.StoragePoolId));
             pb->SetStoragePoolId(std::get<1>(group.StoragePoolId));
             pb->SetSeenOperational(group.SeenOperational);
+            pb->SetGroupSizeInUnits(group.GroupSizeInUnits);
 
             const auto& status = group.Status;
             pb->SetOperatingStatus(status.OperatingStatus);
@@ -1187,6 +1189,8 @@ namespace NKikimr::NBsController {
             if (groupInfo.DecommitStatus != NKikimrBlobStorage::TGroupDecommitStatus::NONE) {
                 group->SetDecommitStatus(groupInfo.DecommitStatus);
             }
+
+            group->SetGroupSizeInUnits(groupInfo.GroupSizeInUnits);
         }
 
         void TBlobStorageController::SerializeSettings(NKikimrBlobStorage::TUpdateSettings *settings) {

--- a/ydb/core/mind/bscontroller/config_fit_groups.cpp
+++ b/ydb/core/mind/bscontroller/config_fit_groups.cpp
@@ -95,6 +95,7 @@ namespace NKikimr {
                     requiredSpace = ExpectedSlotSize.front();
                     ExpectedSlotSize.pop_front();
                 }
+                ui32 groupSizeInUnits = StoragePool.DefaultGroupSizeInUnits;
                 AllocateOrSanitizeGroup(groupId, group, {}, {}, requiredSpace, false, &TGroupGeometryInfo::AllocateGroup);
 
                 // scan all comprising PDisks for PDiskCategory
@@ -130,7 +131,7 @@ namespace NKikimr {
                 TGroupInfo *groupInfo = State.Groups.ConstructInplaceNewEntry(groupId, groupId, 1,
                     0, Geometry.GetErasure(), desiredPDiskCategory.GetOrElse(0), StoragePool.VDiskKind,
                     StoragePool.EncryptionMode.GetOrElse(0), lifeCyclePhase, mainKeyId, encryptedGroupKey,
-                    groupKeyNonce, MainKeyVersion, false, false, StoragePoolId, Geometry.GetNumFailRealms(),
+                    groupKeyNonce, MainKeyVersion, false, false, groupSizeInUnits, StoragePoolId, Geometry.GetNumFailRealms(),
                     Geometry.GetNumFailDomainsPerFailRealm(), Geometry.GetNumVDisksPerFailDomain());
 
                 // bind group to storage pool
@@ -429,7 +430,7 @@ namespace NKikimr {
                 State.CheckConsistency();
             }
 
-        private:            
+        private:
             template<typename T>
             std::invoke_result_t<T, TGroupGeometryInfo&, TGroupMapper&, TGroupId, TGroupMapper::TGroupDefinition&, TGroupMapper::TGroupConstraintsDefinition&,
                     const THashMap<TVDiskIdShort, TPDiskId>&, TGroupMapper::TForbiddenPDisks, i64> AllocateOrSanitizeGroup(

--- a/ydb/core/mind/bscontroller/group_mapper.h
+++ b/ydb/core/mind/bscontroller/group_mapper.h
@@ -57,6 +57,7 @@ namespace NKikimr {
                 const bool Usable;
                 ui32 NumSlots;
                 const ui32 MaxSlots;
+                const ui32 SlotSizeInUnits;
                 TStackVec<ui32, 16> Groups;
                 i64 SpaceAvailable;
                 const bool Operational;

--- a/ydb/core/mind/bscontroller/impl.h
+++ b/ydb/core/mind/bscontroller/impl.h
@@ -585,6 +585,8 @@ public:
 
         Table::DecommitStatus::Type DecommitStatus = NKikimrBlobStorage::TGroupDecommitStatus::NONE;
 
+        Table::GroupSizeInUnits::Type GroupSizeInUnits;
+
         TMaybe<Table::VirtualGroupName::Type> VirtualGroupName;
         TMaybe<Table::VirtualGroupState::Type> VirtualGroupState;
         TMaybe<Table::HiveId::Type> HiveId;
@@ -662,6 +664,7 @@ public:
                     Table::MainKeyVersion,
                     Table::SeenOperational,
                     Table::DecommitStatus,
+                    Table::GroupSizeInUnits,
                     Table::VirtualGroupName,
                     Table::VirtualGroupState,
                     Table::HiveId,
@@ -684,6 +687,7 @@ public:
                     &TGroupInfo::MainKeyVersion,
                     &TGroupInfo::SeenOperational,
                     &TGroupInfo::DecommitStatus,
+                    &TGroupInfo::GroupSizeInUnits,
                     &TGroupInfo::VirtualGroupName,
                     &TGroupInfo::VirtualGroupState,
                     &TGroupInfo::HiveId,
@@ -710,6 +714,7 @@ public:
                    Schema::Group::MainKeyVersion::Type mainKeyVersion,
                    Schema::Group::Down::Type down,
                    Schema::Group::SeenOperational::Type seenOperational,
+                   Schema::Group::GroupSizeInUnits::Type groupSizeInUnits,
                    TBoxStoragePoolId storagePoolId,
                    ui32 numFailRealms,
                    ui32 numFailDomainsPerFailRealm,
@@ -728,6 +733,7 @@ public:
             , MainKeyVersion(mainKeyVersion)
             , PersistedDown(down)
             , SeenOperational(seenOperational)
+            , GroupSizeInUnits(groupSizeInUnits)
             , Down(PersistedDown)
             , VDisksInGroup(numFailRealms * numFailDomainsPerFailRealm * numVDisksPerFailDomain)
             , StoragePoolId(storagePoolId)
@@ -1211,6 +1217,7 @@ public:
         TMaybe<ui64> SchemeshardId;
         TMaybe<ui64> PathItemId;
         bool RandomizeGroupMapping;
+        Table::DefaultGroupSizeInUnits::Type DefaultGroupSizeInUnits;
 
         bool IsSameGeometry(const TStoragePoolInfo& other) const {
             return ErasureSpecies == other.ErasureSpecies
@@ -1313,6 +1320,7 @@ public:
                     Table::SchemeshardId,
                     Table::PathItemId,
                     Table::RandomizeGroupMapping,
+                    Table::DefaultGroupSizeInUnits,
                     TInlineTable<TUserIds, Schema::BoxStoragePoolUser>,
                     TInlineTable<TPDiskFilters, Schema::BoxStoragePoolPDiskFilter>
                 > adapter(
@@ -1339,6 +1347,7 @@ public:
                     &TStoragePoolInfo::SchemeshardId,
                     &TStoragePoolInfo::PathItemId,
                     &TStoragePoolInfo::RandomizeGroupMapping,
+                    &TStoragePoolInfo::DefaultGroupSizeInUnits,
                     &TStoragePoolInfo::UserIds,
                     &TStoragePoolInfo::PDiskFilters
                 );

--- a/ydb/core/mind/bscontroller/impl.h
+++ b/ydb/core/mind/bscontroller/impl.h
@@ -340,6 +340,7 @@ public:
         ui32 ExpectedSlotCount = 0;
         bool HasExpectedSlotCount = false;
         ui32 NumActiveSlots = 0; // number of active VSlots created over this PDisk
+        ui32 SlotSizeInUnits = 0;
         TMap<Schema::VSlot::VSlotID::Type, TIndirectReferable<TVSlotInfo>::TPtr> VSlotsOnPDisk; // vslots over this PDisk
 
         bool Operational = false; // set to true when both containing node is connected and Operational is reported in Metrics
@@ -447,9 +448,14 @@ public:
             ExpectedSlotCount = defaultMaxSlots;
 
             NKikimrBlobStorage::TPDiskConfig pdiskConfig;
-            if (pdiskConfig.ParseFromString(PDiskConfig) && pdiskConfig.HasExpectedSlotCount()) {
-                ExpectedSlotCount = pdiskConfig.GetExpectedSlotCount();
-                HasExpectedSlotCount = true;
+            if (pdiskConfig.ParseFromString(PDiskConfig)) {
+                if (pdiskConfig.HasExpectedSlotCount()) {
+                    ExpectedSlotCount = pdiskConfig.GetExpectedSlotCount();
+                    HasExpectedSlotCount = true;
+                }
+                if (pdiskConfig.HasSlotSizeInUnits()) {
+                    SlotSizeInUnits = pdiskConfig.GetSlotSizeInUnits();
+                }
             }
         }
 

--- a/ydb/core/mind/bscontroller/load_everything.cpp
+++ b/ydb/core/mind/bscontroller/load_everything.cpp
@@ -219,6 +219,7 @@ public:
                                                    groups.GetValueOrDefault<T::MainKeyVersion>(),
                                                    groups.GetValueOrDefault<T::Down>(),
                                                    groups.GetValueOrDefault<T::SeenOperational>(),
+                                                   groups.GetValueOrDefault<T::GroupSizeInUnits>(),
                                                    storagePoolId,
                                                    std::get<0>(geom),
                                                    std::get<1>(geom),

--- a/ydb/core/mind/bscontroller/register_node.cpp
+++ b/ydb/core/mind/bscontroller/register_node.cpp
@@ -516,6 +516,7 @@ void TBlobStorageController::ReadVSlot(const TVSlotInfo& vslot, TEvBlobStorage::
     if (TGroupInfo *group = FindGroup(vslot.GroupId)) {
         const TStoragePoolInfo& info = StoragePools.at(group->StoragePoolId);
         vDisk->SetStoragePoolName(info.Name);
+        vDisk->SetGroupSizeInUnits(group->GroupSizeInUnits);
 
         const TVSlotFinder vslotFinder{[this](TVSlotId vslotId, auto&& callback) {
             if (const TVSlotInfo *vslot = FindVSlot(vslotId)) {

--- a/ydb/core/mind/bscontroller/scheme.h
+++ b/ydb/core/mind/bscontroller/scheme.h
@@ -310,7 +310,7 @@ struct Schema : NIceDb::Schema {
         // flag used to minimize correlation between groups and drives
         struct RandomizeGroupMapping : Column<25, NScheme::NTypeIds::Bool> { static constexpr Type Default = false; };
         // this value is only accounted when new groups are added to the pool
-        struct DefaultGroupSizeInUnits : Column<26, NScheme::NTypeIds::Int32> { static constexpr Type Default = 0; };
+        struct DefaultGroupSizeInUnits : Column<26, NScheme::NTypeIds::Uint32> { static constexpr Type Default = 0; };
 
         using TKey = TableKey<BoxId, StoragePoolId>;
 

--- a/ydb/core/mind/bscontroller/scheme.h
+++ b/ydb/core/mind/bscontroller/scheme.h
@@ -67,6 +67,7 @@ struct Schema : NIceDb::Schema {
         struct Down : Column<13, NScheme::NTypeIds::Bool> { static constexpr Type Default = false; };
         struct SeenOperational : Column<14, NScheme::NTypeIds::Bool> { static constexpr Type Default = false; };
         struct DecommitStatus : Column<15, NScheme::NTypeIds::Uint32> { using Type = NKikimrBlobStorage::TGroupDecommitStatus::E; };
+        struct GroupSizeInUnits : Column<16, NScheme::NTypeIds::Uint32> { static constexpr Type Default = 0; };
 
         // VirtualGroup management code
         struct VirtualGroupName  : Column<112, NScheme::NTypeIds::Utf8>   {}; // unique name of the virtual group
@@ -82,8 +83,8 @@ struct Schema : NIceDb::Schema {
         using TKey = TableKey<ID>;
         using TColumns = TableColumns<ID, Generation, ErasureSpecies, Owner, DesiredPDiskCategory, DesiredVDiskCategory,
               EncryptionMode, LifeCyclePhase, MainKeyId, EncryptedGroupKey, GroupKeyNonce, MainKeyVersion, Down,
-              SeenOperational, DecommitStatus, VirtualGroupName, VirtualGroupState, HiveId, Database, BlobDepotConfig,
-              BlobDepotId, ErrorReason, NeedAlter, Metrics>;
+              SeenOperational, DecommitStatus, GroupSizeInUnits, VirtualGroupName, VirtualGroupState, HiveId, Database,
+              BlobDepotConfig, BlobDepotId, ErrorReason, NeedAlter, Metrics>;
     };
 
     struct State : Table<1> {
@@ -308,13 +309,15 @@ struct Schema : NIceDb::Schema {
         struct PathItemId : Column<24, NScheme::NTypeIds::Uint64> {};
         // flag used to minimize correlation between groups and drives
         struct RandomizeGroupMapping : Column<25, NScheme::NTypeIds::Bool> { static constexpr Type Default = false; };
+        // this value is only accounted when new groups are added to the pool
+        struct DefaultGroupSizeInUnits : Column<26, NScheme::NTypeIds::Int32> { static constexpr Type Default = 0; };
 
         using TKey = TableKey<BoxId, StoragePoolId>;
 
         using TColumns = TableColumns<BoxId, StoragePoolId, Name, ErasureSpecies, RealmLevelBegin, RealmLevelEnd,
           DomainLevelBegin, DomainLevelEnd, NumFailRealms, NumFailDomainsPerFailRealm, NumVDisksPerFailDomain,
           VDiskKind, SpaceBytes, WriteIOPS, WriteBytesPerSecond, ReadIOPS, ReadBytesPerSecond, InMemCacheBytes,
-          Kind, NumGroups, Generation, EncryptionMode, SchemeshardId, PathItemId, RandomizeGroupMapping>;
+          Kind, NumGroups, Generation, EncryptionMode, SchemeshardId, PathItemId, RandomizeGroupMapping, DefaultGroupSizeInUnits>;
     };
 
     struct BoxStoragePoolUser : Table<121> {

--- a/ydb/core/mind/bscontroller/virtual_group.cpp
+++ b/ydb/core/mind/bscontroller/virtual_group.cpp
@@ -70,7 +70,7 @@ namespace NKikimr::NBsController {
         auto *group = Groups.ConstructInplaceNewEntry(TGroupId::FromValue(groupId.GetRaw()), TGroupId::FromValue(groupId.GetRaw()), 0u, 0u,
             TBlobStorageGroupType::ErasureNone, 0u, NKikimrBlobStorage::TVDiskKind::Default,
             pool.EncryptionMode.GetOrElse(TBlobStorageGroupInfo::EEM_NONE), TBlobStorageGroupInfo::ELCP_INITIAL,
-            TString(), TString(), 0u, 0u, false, false, storagePoolId, 0u, 0u, 0u);
+            TString(), TString(), 0u, 0u, false, false, 0u, storagePoolId, 0u, 0u, 0u);
 
         // bind group to storage pool
         ++pool.NumGroups;

--- a/ydb/core/protos/blobstorage.proto
+++ b/ydb/core/protos/blobstorage.proto
@@ -1037,6 +1037,7 @@ message TNodeWardenServiceSet {
         optional TDonorMode DonorMode = 9; // vdisk runs in read-only limited mode without interaction with other disks of group
         repeated TDonor Donors = 10; // a set of donor disks used to accelerate replication
         optional bool ReadOnly = 11;
+        optional uint32 GroupSizeInUnits = 12;
     }
 
     message TReplBrokerConfig {

--- a/ydb/core/protos/blobstorage.proto
+++ b/ydb/core/protos/blobstorage.proto
@@ -128,6 +128,7 @@ message TGroupInfo {
     optional uint64 BlobDepotId = 15; // if filled, then this is virtual group
     optional NKikimrBlobStorage.TGroupDecommitStatus.E DecommitStatus = 16;
     repeated uint32 BridgeGroupIds = 17; // filled in for common group when operating in bridge mode
+    optional uint32 GroupSizeInUnits = 18;
 }
 
 message TEvVPatchStart {

--- a/ydb/core/protos/blobstorage_config.proto
+++ b/ydb/core/protos/blobstorage_config.proto
@@ -152,7 +152,7 @@ message TDefineStoragePool {
     string Kind = 8; // kind of storage pool (user-defined)
     uint32 NumGroups = 9; // explicit number of groups to create
     repeated bytes UserId = 10; // allowed users
-    repeated TPDiskFilter PDiskFilter = 11; // matching PDisks
+    repeated TPDiskFilter PDiskFilter = 11; // matching PDisks (disjunction, i.e. multiple filters are logically ORed)
     TExistingGroups ExistingGroups = 12; // existing groups (used while migrating from old-style configuration)
     NActorsInterconnect.TScopeId ScopeId = 13; // scope id for the pool clients
     bool RandomizeGroupMapping = 14; // minimize correlation of groups and drives
@@ -163,6 +163,9 @@ message TDefineStoragePool {
 
     // encryption mode: 0 for none, 1 for the current mode (chacha8)
     uint32 EncryptionMode = 101;
+
+    // this value is only accounted when new groups are added to the pool
+    uint32 DefaultGroupSizeInUnits = 102;
 }
 
 message TReadStoragePool {
@@ -699,6 +702,7 @@ message TBaseConfig {
         TGroupStatus.E OperatingStatus = 8; // group status based on latest VDisk reports only
         TGroupStatus.E ExpectedStatus = 9; // status based not only on operational report, but on PDisk status and plans too
         TVirtualGroupInfo VirtualGroupInfo = 10;
+        uint32 GroupSizeInUnits = 11;
     }
     message TNode {
         uint32 NodeId = 1;

--- a/ydb/core/protos/blobstorage_pdisk_config.proto
+++ b/ydb/core/protos/blobstorage_pdisk_config.proto
@@ -95,4 +95,5 @@ message TPDiskConfig {
     optional uint32 CompletionThreadsCount = 2003;
     optional bool UseNoopScheduler = 2004;
     optional bool PlainDataChunks = 2005;
+    optional uint32 SlotSizeInUnits = 2006;
 };

--- a/ydb/library/yaml_config/protos/config.proto
+++ b/ydb/library/yaml_config/protos/config.proto
@@ -73,6 +73,7 @@ message TExtendedHostConfigDrive {
 
     optional NKikimrBlobStorage.TPDiskConfig PDiskConfig = 6 [(NMarkers.CopyTo) = "THostConfigDrive"];
     optional uint64 ExpectedSlotCount = 7;
+    optional uint32 SlotSizeInUnits = 8;
 }
 
 message THosts {

--- a/ydb/library/yaml_config/ut_transform/canondata/test_transform.TestYamlConfigTransformations.test_domains_config_dump_/multinode-missing-all.yaml.result.json
+++ b/ydb/library/yaml_config/ut_transform/canondata/test_transform.TestYamlConfigTransformations.test_domains_config_dump_/multinode-missing-all.yaml.result.json
@@ -1,1 +1,1 @@
-{"error": true, "stderr": "Terminating due to uncaught exception REDACTED    what() -> \"ydb/library/yaml_config/yaml_config_parser.cpp:881: Erasure species is not specified for storage pool type, id 0\"\n of type TWithBackTrace<yexception>\n"}
+{"error": true, "stderr": "Terminating due to uncaught exception REDACTED    what() -> \"ydb/library/yaml_config/yaml_config_parser.cpp:884: Erasure species is not specified for storage pool type, id 0\"\n of type TWithBackTrace<yexception>\n"}

--- a/ydb/library/yaml_config/ut_transform/canondata/test_transform.TestYamlConfigTransformations.test_domains_config_dump_/multinode-unmatched-types.yaml.result.json
+++ b/ydb/library/yaml_config/ut_transform/canondata/test_transform.TestYamlConfigTransformations.test_domains_config_dump_/multinode-unmatched-types.yaml.result.json
@@ -1,1 +1,1 @@
-{"error": true, "stderr": "Terminating due to uncaught exception REDACTED    what() -> \"ydb/library/yaml_config/yaml_config_parser.cpp:885: Disk type is not specified for storage pool type, id 0\"\n of type TWithBackTrace<yexception>\n"}
+{"error": true, "stderr": "Terminating due to uncaught exception REDACTED    what() -> \"ydb/library/yaml_config/yaml_config_parser.cpp:888: Disk type is not specified for storage pool type, id 0\"\n of type TWithBackTrace<yexception>\n"}

--- a/ydb/library/yaml_config/yaml_config_parser.cpp
+++ b/ydb/library/yaml_config/yaml_config_parser.cpp
@@ -637,6 +637,9 @@ namespace NKikimr::NYaml {
                     if (drive.HasExpectedSlotCount()) {
                         drive.MutablePDiskConfig()->SetExpectedSlotCount(drive.GetExpectedSlotCount());
                     }
+                    if (drive.HasSlotSizeInUnits()) {
+                        drive.MutablePDiskConfig()->SetSlotSizeInUnits(drive.GetSlotSizeInUnits());
+                    }
                 }
             }
         }

--- a/ydb/tests/functional/scheme_tests/canondata/tablet_scheme_tests.TestTabletSchemes.test_tablet_schemes_flat_bs_controller_/flat_bs_controller.schema
+++ b/ydb/tests/functional/scheme_tests/canondata/tablet_scheme_tests.TestTabletSchemes.test_tablet_schemes_flat_bs_controller_/flat_bs_controller.schema
@@ -473,13 +473,18 @@
                 "ColumnType": "Bool"
             },
             {
+                "ColumnId": 102,
+                "ColumnName": "VirtualGroupState",
+                "ColumnType": "Uint32"
+            },
+            {
                 "ColumnId": 15,
                 "ColumnName": "DecommitStatus",
                 "ColumnType": "Uint32"
             },
             {
-                "ColumnId": 102,
-                "ColumnName": "VirtualGroupState",
+                "ColumnId": 16,
+                "ColumnName": "GroupSizeInUnits",
                 "ColumnType": "Uint32"
             },
             {
@@ -537,8 +542,9 @@
                     12,
                     13,
                     14,
-                    15,
                     102,
+                    15,
+                    16,
                     106,
                     109,
                     110,
@@ -698,6 +704,11 @@
                 "ColumnId": 25,
                 "ColumnName": "RandomizeGroupMapping",
                 "ColumnType": "Bool"
+            },
+            {
+                "ColumnId": 26,
+                "ColumnName": "DefaultGroupSizeInUnits",
+                "ColumnType": "Uint32"
             }
         ],
         "ColumnsDropped": [],
@@ -728,7 +739,8 @@
                     22,
                     23,
                     24,
-                    25
+                    25,
+                    26
                 ],
                 "RoomID": 0,
                 "Codec": 0,


### PR DESCRIPTION
### Changelog category

* Not for changelog

### Description for reviewers

- Part 1 of #17357
- Related epic #16959 
- RFC: https://github.com/ydb-platform/ydb-rfc/blob/main/156_pdisks_of_different_sizes.md

This PR introduces 3 changes (see [commits](19160/commits)):

- Add PDisk.SlotSizeInUnits property
- Add GroupSizeInUnits property to bscontroller
- Add GroupSizeInUnits to NodeWardenServiceSet and VDisk skeleton

No logics is changed yet.