### PR TITLE
enable subscriptions in discovery

### DIFF
--- a/ydb/core/protos/feature_flags.proto
+++ b/ydb/core/protos/feature_flags.proto
@@ -120,7 +120,7 @@ message TFeatureFlags {
     optional bool EnableTopicSplitMerge = 95 [default = true];
     optional bool EnableChangefeedDynamoDBStreamsFormat = 96 [default = true];
     optional bool ForceColumnTablesCompositeMarks = 97 [default = false];
-    optional bool EnableSubscriptionsInDiscovery = 98 [default = false, (RequireRestart) = true];
+    optional bool EnableSubscriptionsInDiscovery = 98 [default = true, (RequireRestart) = true];
     optional bool EnableGetNodeLabels = 99 [default = false];
     optional bool EnableTopicMessageMeta = 100 [default = true];
     optional bool EnableIcNodeCache = 101 [default = true, (RequireRestart) = true];


### PR DESCRIPTION
### Changelog entry 

### Changelog category 

* Not for changelog (changelog entry is not required)

### Description for reviewers <!-- (optional) description for those who read this PR -->

feature was enabled on large prod clusters, so enable it by default.
