### PR TITLE
fix timeout in test_alter_tiering

### DIFF
--- a/ydb/tests/olap/scenario/helpers/scenario_tests_helper.py
+++ b/ydb/tests/olap/scenario/helpers/scenario_tests_helper.py
@@ -434,7 +434,7 @@ class ScenarioTestHelper:
     @classmethod
     @allure.step('Execute scan query')
     def execute_scan_query(
-        cls, yql: str, expected_status: ydb.StatusCode | Set[ydb.StatusCode] = ydb.StatusCode.SUCCESS
+        cls, yql: str, expected_status: ydb.StatusCode | Set[ydb.StatusCode] = ydb.StatusCode.SUCCESS, timeout = 10
     ):
         """Run a scanning query on the tested database.
 
@@ -454,7 +454,7 @@ class ScenarioTestHelper:
 
         allure.attach(yql, 'request', allure.attachment_type.TEXT)
         it = cls._run_with_expected_status(
-            lambda: YdbCluster.get_ydb_driver().table_client.scan_query(yql), expected_status
+            lambda: YdbCluster.get_ydb_driver().table_client.scan_query(yql, settings=ydb.BaseRequestSettings().with_timeout(timeout)), expected_status
         )
         rows = None
         ret = None

--- a/ydb/tests/olap/scenario/helpers/scenario_tests_helper.py
+++ b/ydb/tests/olap/scenario/helpers/scenario_tests_helper.py
@@ -434,7 +434,7 @@ class ScenarioTestHelper:
     @classmethod
     @allure.step('Execute scan query')
     def execute_scan_query(
-        cls, yql: str, expected_status: ydb.StatusCode | Set[ydb.StatusCode] = ydb.StatusCode.SUCCESS, timeout = 10
+        cls, yql: str, expected_status: ydb.StatusCode | Set[ydb.StatusCode] = ydb.StatusCode.SUCCESS, timeout=10
     ):
         """Run a scanning query on the tested database.
 

--- a/ydb/tests/olap/scenario/test_alter_tiering.py
+++ b/ydb/tests/olap/scenario/test_alter_tiering.py
@@ -245,6 +245,7 @@ class TestAlterTiering(TieringTestBase):
             sth.execute_scan_query(
                 f'SELECT MIN(writer) FROM `{sth.get_full_path(table)}`',
                 expected_status=expected_scan_status,
+                timeout=duration.seconds
             )
 
     def _loop_set_ttl(


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

Fix flaky test_alter_tiering.py

### Changelog category <!-- remove all except one -->

* Not for changelog (changelog entry is not required)

### Description for reviewers <!-- (optional) description for those who read this PR -->

В тесте тиринга выполняется фуллскан; убрал требование, что он завершается за 10 секунд.
