### PR TITLE
Support export encryption for changefeeds

### DIFF
--- a/ydb/core/backup/common/metadata.h
+++ b/ydb/core/backup/common/metadata.h
@@ -36,6 +36,11 @@ struct TFullBackupMetadata : TSimpleRefCount<TFullBackupMetadata> {
     TString StoragePath;
 };
 
+struct TChangefeedMetadata {
+    TString ExportPrefix;
+    TString Name;
+};
+
 class TMetadata {
 public:
     TMetadata() = default;
@@ -47,6 +52,8 @@ public:
     void SetVersion(ui64 version);
     bool HasVersion() const;
     ui64 GetVersion() const;
+    void AddChangefeed(const TChangefeedMetadata& changefeed);
+    const TMaybe<std::vector<TChangefeedMetadata>>& GetChangefeeds() const;
 
     TString Serialize() const;
     static TMetadata Deserialize(const TString& metadata);
@@ -54,6 +61,7 @@ private:
     TString ConsistencyKey;
     TMap<TVirtualTimestamp, TFullBackupMetadata::TPtr> FullBackups;
     TMap<TVirtualTimestamp, TLogMetadata::TPtr> Logs;
+    TMaybe<std::vector<TChangefeedMetadata>> Changefeeds;
     TMaybeFail<ui64> Version;
 };
 

--- a/ydb/core/tx/datashard/export_s3_uploader.cpp
+++ b/ydb/core/tx/datashard/export_s3_uploader.cpp
@@ -40,6 +40,8 @@ using namespace NBackupRestoreTraits;
 struct TChangefeedExportDescriptions {
     const Ydb::Table::ChangefeedDescription ChangefeedDescription;
     const Ydb::Topic::DescribeTopicResult Topic;
+    TString Name;
+    TString Prefix;
 };
 
 class TS3Uploader: public TActorBootstrapped<TS3Uploader> {
@@ -241,12 +243,15 @@ class TS3Uploader: public TActorBootstrapped<TS3Uploader> {
         PutPermissions(Permissions.GetRef());
     }
 
-    void PutChangefeedDescription(const Ydb::Table::ChangefeedDescription& changefeed, const TString& changefeedName) {
-        PutMessage(changefeed, Settings.GetChangefeedKey(changefeedName), ChangefeedChecksum, &TThis::StateUploadChangefeed, Settings.EncryptionSettings.GetChangefeedIV());
-    }
-
-    const TString& GetCurrentChangefeedName() const {
-        return Changefeeds.at(IndexExportedChangefeed).ChangefeedDescription.Getname();
+    void PutChangefeedDescription(ui64 changefeedIndex) {
+        const auto& desc = Changefeeds[changefeedIndex];
+        PutMessage(
+            desc.ChangefeedDescription,
+            Settings.GetChangefeedKey(desc.Prefix),
+            ChangefeedChecksum,
+            &TThis::StateUploadChangefeed,
+            Settings.EncryptionSettings.GetChangefeedIV(static_cast<ui32>(changefeedIndex))
+        );
     }
 
     void UploadChangefeed() {
@@ -259,15 +264,22 @@ class TS3Uploader: public TActorBootstrapped<TS3Uploader> {
             this->Become(&TThis::StateUploadData);
             return;
         }
-        PutChangefeedDescription(Changefeeds[IndexExportedChangefeed].ChangefeedDescription, GetCurrentChangefeedName());
+        PutChangefeedDescription(IndexExportedChangefeed);
     }
 
-    void PutTopicDescription(const Ydb::Topic::DescribeTopicResult& topic, const TString& changefeedName) {
-        PutMessage(topic, Settings.GetTopicKey(changefeedName), TopicChecksum, &TThis::StateUploadTopic, Settings.EncryptionSettings.GetTopicIV());
+    void PutTopicDescription(ui64 changefeedIndex) {
+        const auto& desc = Changefeeds[changefeedIndex];
+        PutMessage(
+            desc.Topic,
+            Settings.GetTopicKey(desc.Prefix),
+            TopicChecksum,
+            &TThis::StateUploadTopic,
+            Settings.EncryptionSettings.GetChangefeedTopicIV(static_cast<ui32>(changefeedIndex))
+        );
     }
 
     void UploadTopic() {
-        PutTopicDescription(Changefeeds[IndexExportedChangefeed].Topic, GetCurrentChangefeedName());
+        PutTopicDescription(IndexExportedChangefeed);
     }
 
     void UploadMetadata() {
@@ -349,7 +361,8 @@ class TS3Uploader: public TActorBootstrapped<TS3Uploader> {
             UploadTopic();
         };
         if (EnableChecksums) {
-            TString checksumKey = ChecksumKey(Settings.GetChangefeedKey(GetCurrentChangefeedName()));
+            const auto& desc = Changefeeds[IndexExportedChangefeed];
+            TString checksumKey = ChecksumKey(Settings.GetChangefeedKey(desc.Prefix));
             UploadChecksum(std::move(ChangefeedChecksum), checksumKey, ChangefeedKeySuffix(false), nextStep);
         } else {
             nextStep();
@@ -372,7 +385,8 @@ class TS3Uploader: public TActorBootstrapped<TS3Uploader> {
             UploadChangefeed();
         };
         if (EnableChecksums) {
-            TString checksumKey = ChecksumKey(Settings.GetTopicKey(GetCurrentChangefeedName()));
+            const auto& desc = Changefeeds[IndexExportedChangefeed];
+            TString checksumKey = ChecksumKey(Settings.GetTopicKey(desc.Prefix));
             UploadChecksum(std::move(TopicChecksum), checksumKey, TopicKeySuffix(false), nextStep);
         } else {
             nextStep();
@@ -928,7 +942,12 @@ IActor* TS3Export::CreateUploader(const TActorId& dataShard, ui64 txId) const {
         ? GenYdbScheme(Columns, Task.GetTable())
         : Nothing();
 
-    TVector <TChangefeedExportDescriptions> changefeeds;
+    const bool encrypted = Task.HasEncryptionSettings();
+
+    TMetadata metadata;
+    metadata.SetVersion(Task.GetEnableChecksums() ? 1 : 0);
+
+    TVector<TChangefeedExportDescriptions> changefeeds;
     if (AppData()->FeatureFlags.GetEnableChangefeedsExport()) {
         const auto& persQueues = Task.GetChangefeedUnderlyingTopics();
         const auto& cdcStreams = Task.GetTable().GetTable().GetCdcStreams();
@@ -951,16 +970,27 @@ IActor* TS3Export::CreateUploader(const TActorId& dataShard, ui64 txId) const {
             topic.clear_self();
             topic.clear_topic_stats();
 
-            changefeeds.emplace_back(changefeed, topic);
+            auto& descr = changefeeds.emplace_back(changefeed, topic);
+            descr.Name = descr.ChangefeedDescription.name();
+            if (encrypted) {
+                // Anonymize changefeed name in export
+                std::stringstream prefix;
+                prefix << std::setfill('0') << std::setw(3) << std::right << (i + 1);
+                descr.Prefix = prefix.str();
+            } else {
+                descr.Prefix = descr.Name;
+            }
+
+            metadata.AddChangefeed(TChangefeedMetadata{
+                .ExportPrefix = descr.Prefix,
+                .Name = descr.Name,
+            });
         }
     }
 
     auto permissions = (Task.GetEnablePermissions() && Task.GetShardNum() == 0)
         ? GenYdbPermissions(Task.GetTable())
         : Nothing();
-
-    TMetadata metadata;
-    metadata.SetVersion(Task.GetEnableChecksums() ? 1 : 0);
 
     TFullBackupMetadata::TPtr backup = new TFullBackupMetadata{
         .SnapshotVts = TVirtualTimestamp(

--- a/ydb/core/tx/datashard/extstorage_usage_config.h
+++ b/ydb/core/tx/datashard/extstorage_usage_config.h
@@ -44,19 +44,19 @@ public:
             return GetIV(NBackup::EBackupFileType::Permissions);
         }
 
-        TMaybe<NBackup::TEncryptionIV> GetTopicIV() const {
-            return GetIV(NBackup::EBackupFileType::TableTopic);
+        TMaybe<NBackup::TEncryptionIV> GetChangefeedTopicIV(ui32 changefeedIndex) const {
+            return GetIV(NBackup::EBackupFileType::TableTopic, changefeedIndex);
         }
 
-        TMaybe<NBackup::TEncryptionIV> GetChangefeedIV() const {
-            return GetIV(NBackup::EBackupFileType::TableChangefeed);
+        TMaybe<NBackup::TEncryptionIV> GetChangefeedIV(ui32 changefeedIndex) const {
+            return GetIV(NBackup::EBackupFileType::TableChangefeed, changefeedIndex);
         }
 
     private:
-        TMaybe<NBackup::TEncryptionIV> GetIV(NBackup::EBackupFileType fileType) const {
+        TMaybe<NBackup::TEncryptionIV> GetIV(NBackup::EBackupFileType fileType, ui32 itemNumber = 0) const {
             TMaybe<NBackup::TEncryptionIV> iv;
             if (IV) {
-                iv = NBackup::TEncryptionIV::Combine(*IV, fileType, 0 /* backupItemNumber is already mixed in */, 0);
+                iv = NBackup::TEncryptionIV::Combine(*IV, fileType, itemNumber, 0);
             }
             return iv;
         }
@@ -118,12 +118,12 @@ public:
         return ObjectKeyPattern + '/' + NBackupRestoreTraits::PermissionsKeySuffix(EncryptionSettings.EncryptedBackup);
     }
 
-    inline TString GetTopicKey(const TString& changefeedName) const {
-        return TStringBuilder() << ObjectKeyPattern << '/'<< changefeedName << '/' << NBackupRestoreTraits::TopicKeySuffix(EncryptionSettings.EncryptedBackup);
+    inline TString GetTopicKey(const TString& changefeedPrefix) const {
+        return TStringBuilder() << ObjectKeyPattern << '/'<< changefeedPrefix << '/' << NBackupRestoreTraits::TopicKeySuffix(EncryptionSettings.EncryptedBackup);
     }
 
-     inline TString GetChangefeedKey(const TString& changefeedName) const {
-        return TStringBuilder() << ObjectKeyPattern << '/' << changefeedName << '/' << NBackupRestoreTraits::ChangefeedKeySuffix(EncryptionSettings.EncryptedBackup);
+     inline TString GetChangefeedKey(const TString& changefeedPrefix) const {
+        return TStringBuilder() << ObjectKeyPattern << '/' << changefeedPrefix << '/' << NBackupRestoreTraits::ChangefeedKeySuffix(EncryptionSettings.EncryptedBackup);
     }
 
     inline TString GetMetadataKey() const {

--- a/ydb/core/tx/datashard/extstorage_usage_config.h
+++ b/ydb/core/tx/datashard/extstorage_usage_config.h
@@ -56,7 +56,7 @@ public:
         TMaybe<NBackup::TEncryptionIV> GetIV(NBackup::EBackupFileType fileType, ui32 shardNumber = 0) const {
             TMaybe<NBackup::TEncryptionIV> iv;
             if (IV) {
-                iv = NBackup::TEncryptionIV::Combine(*IV, fileType, 0 /* backupItemNumber */, shardNumber);
+                iv = NBackup::TEncryptionIV::Combine(*IV, fileType, 0 /* backupItemNumber is already mixed in */, shardNumber);
             }
             return iv;
         }

--- a/ydb/core/tx/datashard/extstorage_usage_config.h
+++ b/ydb/core/tx/datashard/extstorage_usage_config.h
@@ -53,10 +53,10 @@ public:
         }
 
     private:
-        TMaybe<NBackup::TEncryptionIV> GetIV(NBackup::EBackupFileType fileType, ui32 itemNumber = 0) const {
+        TMaybe<NBackup::TEncryptionIV> GetIV(NBackup::EBackupFileType fileType, ui32 shardNumber = 0) const {
             TMaybe<NBackup::TEncryptionIV> iv;
             if (IV) {
-                iv = NBackup::TEncryptionIV::Combine(*IV, fileType, itemNumber, 0);
+                iv = NBackup::TEncryptionIV::Combine(*IV, fileType, 0 /* backupItemNumber */, shardNumber);
             }
             return iv;
         }
@@ -122,7 +122,7 @@ public:
         return TStringBuilder() << ObjectKeyPattern << '/'<< changefeedPrefix << '/' << NBackupRestoreTraits::TopicKeySuffix(EncryptionSettings.EncryptedBackup);
     }
 
-     inline TString GetChangefeedKey(const TString& changefeedPrefix) const {
+    inline TString GetChangefeedKey(const TString& changefeedPrefix) const {
         return TStringBuilder() << ObjectKeyPattern << '/' << changefeedPrefix << '/' << NBackupRestoreTraits::ChangefeedKeySuffix(EncryptionSettings.EncryptedBackup);
     }
 

--- a/ydb/core/tx/schemeshard/ut_export/ut_export.cpp
+++ b/ydb/core/tx/schemeshard/ut_export/ut_export.cpp
@@ -170,7 +170,7 @@ namespace {
                   UNIT_ASSERT(exportDirDesc.GetPathDescription().ChildrenSize() >= 1);
                   UNIT_ASSERT_EQUAL(exportDirDesc.GetPathDescription().GetChildren(0).GetName(), "0");
               }
-          } 
+          }
 
           UNIT_ASSERT(foundExportDir);
           UNIT_ASSERT(foundOriginalTable);
@@ -653,7 +653,7 @@ namespace {
           EnvOptions().EnablePermissionsExport(enablePermissions);
           Env();
           ui64 txId = 100;
-    
+
           TestCreatePQGroup(Runtime(), ++txId, "/MyRoot", R"(
               Name: "Topic"
               TotalGroupCount: 2
@@ -665,7 +665,7 @@ namespace {
               }
           )");
           Env().TestWaitNotification(Runtime(), txId);
-    
+
           auto request = Sprintf(R"(
               ExportToS3Settings {
                 endpoint: "localhost:%d"
@@ -676,11 +676,11 @@ namespace {
                 }
               }
           )", S3Port());
-    
+
           auto schemeshardId = TTestTxConfig::SchemeShard;
           TestExport(Runtime(), schemeshardId, ++txId, "/MyRoot", request, "", "", Ydb::StatusIds::SUCCESS);
           Env().TestWaitNotification(Runtime(), txId, schemeshardId);
-    
+
           TestGetExport(Runtime(), schemeshardId, txId, "/MyRoot", Ydb::StatusIds::SUCCESS);
           UNIT_ASSERT(HasS3File("/create_topic.pb"));
           UNIT_ASSERT_STRINGS_EQUAL(GetS3FileContent("/create_topic.pb"), R"(partitioning_settings {
@@ -705,7 +705,7 @@ supported_codecs {
 partition_write_speed_bytes_per_second: 50000000
 partition_write_burst_bytes: 50000000
 )");
-    
+
           if (enablePermissions) {
             UNIT_ASSERT(HasS3File("/permissions.pb"));
             UNIT_ASSERT_STRINGS_EQUAL(GetS3FileContent("/permissions.pb"), R"(actions {
@@ -713,7 +713,7 @@ partition_write_burst_bytes: 50000000
 }
 )");
           }
-        
+
         };
 
     protected:
@@ -2440,7 +2440,7 @@ partitioning_settings {
 
         const auto* metadataChecksum = S3Mock().GetData().FindPtr("/metadata.json.sha256");
         UNIT_ASSERT(metadataChecksum);
-        UNIT_ASSERT_VALUES_EQUAL(*metadataChecksum, "b72575244ae0cce8dffd45f3537d1e412bfe39de4268f4f85f529cb529870903 metadata.json");
+        UNIT_ASSERT_VALUES_EQUAL(*metadataChecksum, "843d475f20c5e337fdd3ef4e83b63081c182e26791cd891f7739be8b53167b1b metadata.json");
 
         const auto* schemeChecksum = S3Mock().GetData().FindPtr("/scheme.pb.sha256");
         UNIT_ASSERT(schemeChecksum);
@@ -2507,7 +2507,7 @@ partitioning_settings {
 
         const auto* metadataChecksum = S3Mock().GetData().FindPtr("/metadata.json.sha256");
         UNIT_ASSERT(metadataChecksum);
-        UNIT_ASSERT_VALUES_EQUAL(*metadataChecksum, "b72575244ae0cce8dffd45f3537d1e412bfe39de4268f4f85f529cb529870903 metadata.json");
+        UNIT_ASSERT_VALUES_EQUAL(*metadataChecksum, "843d475f20c5e337fdd3ef4e83b63081c182e26791cd891f7739be8b53167b1b metadata.json");
 
         const auto* schemeChecksum = S3Mock().GetData().FindPtr("/scheme.pb.sha256");
         UNIT_ASSERT(schemeChecksum);
@@ -2899,7 +2899,7 @@ attributes {
               }
             }
         )", S3Port());
-        
+
         Env();
         Runtime().GetAppData().FeatureFlags.SetEnableExportAutoDropping(false);
 


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

...

### Changelog category <!-- remove all except one -->

* Not for changelog (changelog entry is not required)

### Description for reviewers <!-- (optional) description for those who read this PR -->

Support changefeeds in export encryption:
- anonymizing names of changefeeds
- more relyable listing of changefeeds (we can't be able to simply delete one of changefeeds files)
- test