### PR TITLE
feat!: refactor simple queue to use QueryService

### DIFF
--- a/ydb/tests/compatibility/test_stress.py
+++ b/ydb/tests/compatibility/test_stress.py
@@ -107,8 +107,7 @@ class TestStress(MixedClusterFixture):
     @pytest.mark.parametrize("store_type", ["row", "column"])
     def test_simple_queue(self, store_type: str):
         with Workload(f"grpc://localhost:{self.cluster.nodes[1].grpc_port}", "/Root", 180, store_type) as workload:
-            for handle in workload.loop():
-                handle()
+            workload.start()
 
     @pytest.mark.parametrize("store_type", ["row", "column"])
     def test_kv(self, store_type):

--- a/ydb/tests/stress/simple_queue/__main__.py
+++ b/ydb/tests/stress/simple_queue/__main__.py
@@ -11,5 +11,4 @@ if __name__ == '__main__':
     parser.add_argument('--mode', default="row", choices=["row", "column"], help='STORE mode for CREATE TABLE')
     args = parser.parse_args()
     with Workload(args.endpoint, args.database, args.duration, args.mode) as workload:
-        for handle in workload.loop():
-            handle()
+        workload.start()

--- a/ydb/tests/stress/simple_queue/tests/test_workload.py
+++ b/ydb/tests/stress/simple_queue/tests/test_workload.py
@@ -22,5 +22,4 @@ class TestYdbWorkload(object):
     @pytest.mark.parametrize('mode', ['row', 'column'])
     def test(self, mode: str):
         with Workload(f'grpc://localhost:{self.cluster.nodes[1].grpc_port}', '/Root', 60, mode) as workload:
-            for handle in workload.loop():
-                handle()
+            workload.start()


### PR DESCRIPTION
### Changelog entry 
Workload simple_queue is moved to QuerySessionPool Some unsupported TableService methods were removed: start_read_table, read_table_chunk, start_scan_query, scan_query, chunk, copy_table


### Changelog category <!-- remove all except one -->

* Not for changelog (changelog entry is not required)

### Description for reviewers

Workload simple_queue is moved to QuerySessionPool Some unsupported TableService methods were removed: start_read_table, read_table_chunk, start_scan_query, scan_query, chunk, copy_table

Old methods corresponding to removed endpoints are removed. Added read_table with iterators to replace scan_table query

~~@iddqdex has mentioned that similar functions are already implemented in CLI and external workloads, maybe the simple_queue workload should be removed?~~