### PR TITLE
generic lookup: Reduce limit for MaxKeysInRequest to 100

### DIFF
--- a/ydb/library/yql/providers/generic/actors/yql_generic_lookup_actor.cpp
+++ b/ydb/library/yql/providers/generic/actors/yql_generic_lookup_actor.cpp
@@ -93,7 +93,7 @@ namespace NYql::NDq {
             , SelectResultType(MergeStructTypes(typeEnv, keyType, payloadType))
             , HolderFactory(holderFactory)
             , ColumnDestinations(CreateColumnDestination())
-            , MaxKeysInRequest(maxKeysInRequest)
+            , MaxKeysInRequest(std::min(maxKeysInRequest, size_t{100}))
             , RetryPolicy(
                     ILookupRetryPolicy::GetExponentialBackoffPolicy(
                         /* retryClassFunction */


### PR DESCRIPTION
Temporary hack to prevent too easily going out of query size limit. Temporary alternative hack: tweak config for all destination databases into: `TableQueryConfig { QueryLimitBytes: 262144 }` (With either it is still possible to go over limit with several long key field names).
Proper solution should be switch to `key IN $list` or `AsTuple(key1,key2,...) IN $ListOfTuples` (requires connector and connector protocol changes).

### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

...

### Changelog category <!-- remove all except one -->

* Not for changelog (changelog entry is not required)

### Description for reviewers <!-- (optional) description for those who read this PR -->

...
