### PR TITLE
Add basic check for group names

### DIFF
--- a/ydb/core/tx/schemeshard/schemeshard__init_root.cpp
+++ b/ydb/core/tx/schemeshard/schemeshard__init_root.cpp
@@ -69,7 +69,7 @@ struct TSchemeShard::TTxInitRoot : public TSchemeShard::TRwTxBase {
             auto response = Self->LoginProvider.CreateGroup({
                 .Group = defaultGroup.GetName(),
                 .Options = {
-                    .CheckName = false
+                    .StrongCheckName = false
                 }
             });
             if (response.Error) {

--- a/ydb/library/login/login.h
+++ b/ydb/library/login/login.h
@@ -1,6 +1,5 @@
 #pragma once
 #include <optional>
-#include <map>
 #include <unordered_map>
 #include <unordered_set>
 #include <vector>
@@ -117,7 +116,7 @@ public:
 
     struct TCreateGroupRequest : TBasicRequest {
         struct TOptions {
-            bool CheckName = true;
+            bool StrongCheckName = true;
         };
 
         TString Group;
@@ -136,7 +135,7 @@ public:
 
     struct TRenameGroupRequest : TBasicRequest {
         struct TOptions {
-            bool CheckName = true;
+            bool StrongCheckName = true;
         };
 
         TString Group;
@@ -233,7 +232,9 @@ public:
 private:
     std::deque<TKeyRecord>::iterator FindKeyIterator(ui64 keyId);
     bool CheckSubjectExists(const TString& name, const ESidType::SidType& type);
-    static bool CheckAllowedName(const TString& name);
+    static bool StrongCheckAllowedName(const TString& name);
+    static bool BasicCheckAllowedName(const TString& name);
+    static bool CheckGroupNameAllowed(const bool strongCheckName, const TString& groupName);
 
     bool CheckLockoutByAttemptCount(const TSidRecord& sid) const;
     bool CheckLockout(const TSidRecord& sid) const;

--- a/ydb/library/login/login_ut.cpp
+++ b/ydb/library/login/login_ut.cpp
@@ -32,7 +32,6 @@ Y_UNIT_TEST_SUITE(Login) {
 
     Y_UNIT_TEST(TestNameIsNotAllowed1) {
         TLoginProvider provider;
-        //provider.RotateKeys();
         TLoginProvider::TCreateUserRequest request;
         request.User = "_USER_";
         request.Password = "password";
@@ -43,6 +42,18 @@ Y_UNIT_TEST_SUITE(Login) {
 
         request.User = "user";
         UNIT_ASSERT(!provider.CreateUser(request).Error);
+    }
+
+    Y_UNIT_TEST(TestDefaultGroupNamesAreAllowed) {
+        static const TVector<TString> DEFAULT_GROUP_NAMES = {
+            "ADMINS", "DATABASE-ADMINS", "ACCESS-ADMINS", "DDL-ADMINS",
+            "DATA-WRITERS", "DATA-READERS", "METADATA-READERS", "USERS"
+        };
+        TLoginProvider provider;
+        for (const auto& name : DEFAULT_GROUP_NAMES) {
+            const auto response = provider.CreateGroup({.Group = name, .Options = {.StrongCheckName = false}});
+            UNIT_ASSERT(!response.Error);
+        }
     }
 
     Y_UNIT_TEST(TestFailedLogin1) {


### PR DESCRIPTION
### Changelog entry 
Always make some checks for group names when creating or renaming them: they may consists of Latin letters in both cases, digits, underscore and hyphen.

### Changelog category 
* Improvement

### Description for reviewers
Affects on checks provided at the first launch of YDB https://ydb.tech/docs/ru/reference/configuration/security_config?version=main#security-bootstrap