### PR TITLE
Enable kafka port for local ydb container

### DIFF
--- a/.github/docker/Dockerfile
+++ b/.github/docker/Dockerfile
@@ -44,6 +44,7 @@ COPY --from=builder \
 EXPOSE ${GRPC_TLS_PORT:-2135}
 EXPOSE ${GRPC_PORT:-2136}
 EXPOSE ${MON_PORT:-8765}
+EXPOSE ${YDB_KAFKA_PROXY_PORT:-9092}
 
 HEALTHCHECK --start-period=60s --interval=1s CMD sh ./health_check
 

--- a/.github/docker/files/initialize_local_ydb
+++ b/.github/docker/files/initialize_local_ydb
@@ -8,6 +8,7 @@ export YDB_GRPC_ENABLE_TLS="true"
 export GRPC_TLS_PORT=${GRPC_TLS_PORT:-2135}
 export GRPC_PORT=${GRPC_PORT:-2136}
 export YDB_GRPC_TLS_DATA_PATH="/ydb_certs"
+export YDB_KAFKA_PROXY_PORT=${YDB_KAFKA_PROXY_PORT:-9092}
 
 /local_ydb deploy --ydb-working-dir /ydb_data --ydb-binary-path /ydbd --fixed-ports --dont-use-log-files;
 

--- a/ydb/public/tools/lib/cmds/__init__.py
+++ b/ydb/public/tools/lib/cmds/__init__.py
@@ -349,6 +349,10 @@ def deploy(arguments):
     if 'YDB_EXPERIMENTAL_PG' in os.environ:
         optionals['pg_compatible_expirement'] = True
 
+    if _is_env_option_enabled('YDB_KAFKA_API_ENABLED'):
+        kafka_api_port = int(os.environ.get("YDB_KAFKA_PROXY_PORT", "9092"))
+        optionals['kafka_api_port'] = kafka_api_port
+
     configuration = KikimrConfigGenerator(
         parse_erasure(arguments),
         arguments.ydb_binary_path,
@@ -542,3 +546,12 @@ def start_recipe(args):
 def stop_recipe(args):
     arguments = produce_arguments(args)
     cleanup(arguments)
+
+
+def _is_true_string(s):
+    s = s.upper()
+    return s in ['1', 'TRUE', 'YES', 'ON']
+
+
+def _is_env_option_enabled(name):
+    return _is_true_string(os.environ.get(name, "FALSE"))

--- a/ydb/public/tools/lib/cmds/__init__.py
+++ b/ydb/public/tools/lib/cmds/__init__.py
@@ -349,8 +349,8 @@ def deploy(arguments):
     if 'YDB_EXPERIMENTAL_PG' in os.environ:
         optionals['pg_compatible_expirement'] = True
 
-    if _is_env_option_enabled('YDB_KAFKA_API_ENABLED'):
-        kafka_api_port = int(os.environ.get("YDB_KAFKA_PROXY_PORT", "9092"))
+    kafka_api_port = int(os.environ.get("YDB_KAFKA_PROXY_PORT", "0"))
+    if kafka_api_port != 0:
         optionals['kafka_api_port'] = kafka_api_port
 
     configuration = KikimrConfigGenerator(
@@ -546,12 +546,3 @@ def start_recipe(args):
 def stop_recipe(args):
     arguments = produce_arguments(args)
     cleanup(arguments)
-
-
-def _is_true_string(s):
-    s = s.upper()
-    return s in ['1', 'TRUE', 'YES', 'ON']
-
-
-def _is_env_option_enabled(name):
-    return _is_true_string(os.environ.get(name, "FALSE"))

--- a/ydb/tests/library/harness/kikimr_config.py
+++ b/ydb/tests/library/harness/kikimr_config.py
@@ -166,6 +166,7 @@ class KikimrConfigGenerator(object):
             pg_compatible_expirement=False,
             generic_connector_config=None,  # typing.Optional[TGenericConnectorConfig]
             pgwire_port=None,
+            kafka_api_port=None,
     ):
         if extra_feature_flags is None:
             extra_feature_flags = []
@@ -429,6 +430,13 @@ class KikimrConfigGenerator(object):
 
             self.yaml_config["feature_flags"]["enable_external_data_sources"] = True
             self.yaml_config["feature_flags"]["enable_script_execution_operations"] = True
+
+        if kafka_api_port is not None:
+            kafka_proxy_config = dict()
+            kafka_proxy_config["enable_kafka_proxy"] = True
+            kafka_proxy_config["listening_port"] = kafka_api_port
+
+            self.yaml_config["kafka_proxy_config"] = kafka_proxy_config
 
     @property
     def pdisks_info(self):


### PR DESCRIPTION
- **Only members of ReleaseApprovers team can approve changes in this branch (#6323)**
- **Initial commit for stable-24-3 (#6321)**
- **fix query errors processing (#6441) (#6451)**
- **Merge #6398 #6405 from main into stable-24-3 (#6448)**
- **Fix test_db_counters test (#6436)**
- **24-3 Fix tests with EnableLocalDBBtreeIndex = false (#6391)**
- **24-3 Iterative B-Tree histograms builder (#6392)**
- **24-3 Obtain UsedTableMemory from private cache stats, include historic indexes size (#6400)**
- **revert 19bed6c19f373cc26a3b8d1d4e4d1ff1126a56ce (#6469)**
- **24-3: Fix bugs in coordinator state migration (#6460)**
- **Merge some fixes (#6490)**
- **set predicate-extract config default (#6456)**
- **24-3: Fix bugs in: change exchange split, removing schema snapshots & emitting of resolved timestamps (#6616)**
- **24.3: Fix null dereference in node broker (KIKIMR-21693) (#6516) (#6623)**
- **Use the whole TTableDescription to describe an indexImplTable in TIndexDescription (#6280) (#6450)**
- **Changed memory calculation for TEvFreeItems (merge from main #6625) (#6694)**
- **fix drain compatability (#6613) (#6716)**
- **fix neighbours count (#6409) (#6718)**
- **fix TabletsTotal counter (#6492) (#6717)**
- **do not trigger emergency balancer when all nodes have high usage (#6532) (#6720)**
- **24-3: schemeshard: preserialize Table.SplitBoundary for describe result (#6847)**
- **24-3: schemeshard: reject operations with too big local tx commit (#6760) (#6849)**
- **24-3: Fix read requirements on init (#6948)**
- **build: refresh Embedded UI (v6.11.0) (#6968)**
- **Extend DisabledOnSchemeShard FF for column tables on dedicated bases … (#6962)**
- **Merge Fix LWTrace leaking HTTP request string to HTML page (#7011) (#7014) (#7024)**
- **deprioritise system tablets in balancer (#6840) (#7047)**
- **use potential max thread count in local (#7050)**
- **merge memory limitations features and staff to stable-24-3 (#6803)**
- **Fix scope id handling (#7093)**
- **YQ-3345 support load cpu threshold (#6790)**
- **YQ WM fixed build errors (#7128)**
- **Disable modification in cs by default (#7161)**
- **CS improvements (#7013)**
- **Dont create delete flags column if not necessary (#7169)**
- **24-3: Enable/disable ssl connections, return connection_string in API (#7147)**
- **24-3: Check shard state at TTxCdcStreamEmitHeartbeats (#7148)**
- **24-3: Allow streams on index tables, replicate index tables (#7150)**
- **add autopartitioning by load (#7124)**
- **fix viewer redirects (#7103) (#7120)**
- **24-3 Freeze event spaces ids (#7192)**
- **Added metadata flag to track if stats for optimizer were loaded (#7190)**
- **fix compaction intervals construction (#7176) (#7208)**
- **add enable implicit params flag to table service config (#6943)**
- **24-3 Fix using uninitialized value error.  (#7224)**
- **24-3 [CBO] Warning FIX (#6420) (#7241)**
- **fix segfault and memory leaks in CS (#7288)**
- **24-3 Rescue asan tests (remove NO_EXPORT_DYNAMIC_SYMBOLS for them) (#7311)**
- **Enable sequences (#7297)**
- **YDB-7262 Add default permille ICB configuration for vdisk garbage compaction threshold (#7319)**
- **WM fixed bugs and performance (#7254)**
- **hotfix for hotkeys (#7425)**
- **Fix actor system usage after it was freed (#7316) (#7404)**
- **Disable vpatch 24-3 (#7320)**
- **PushLeftStage fix (#7349)**
- **Ignore stored GCBarrierPreparation (#7473)**
- **add config option to specify TTL for user logins (#7083) (#7486)**
- **fix for dead nodes always passing filter (#6912) (#7522)**
- **stable-24-3: Enable COUNT in view queries (#6820) (#7523)**
- **Fix trim duration (change microseconds to milliseconds) (#7302)**
- **24-3:  Sinks improvements (#6856)**
- **24-3: CTAS fixes (#6857)**
- **24-3: Datashard + Columnshard Reads (#6858)**
- **storage healthcheck fixes (#7212) (#7394)**
- **control inflight pings in hive (#6916) (#7238)**
- **Delete empty portions normalizer (#7596) (#7600)**
- **fix suspended read session of a topic (#7635)**
- **Allow logging AST with free arguments. (#7573) (#7653)**
- **YDB-2568 Enable match_recognize in ydb / stable-24-3 (#7540)**
- **24-3: Fix unexpected read iterator stream reset (#7710)**
- **Allow multiple join-broadcasts in single stage (#7556) (#7713)**
- **[Http] Reply with structured issues when client accepts json data (#7691)**
- **fix LockedPartitions without session (#7736)**
- **fix query id for recompilation (#7599)**
- **[CDC] Do not lose presition during float/double to json serialization… (#7737)**
- **Fix json float/double print format (#7572) (#7776)**
- **Double free when accessing .AsBoxed() on Pod with 0 refcount (#7659) (#7721)**
- **Fix segfault when UserToken == nullptr (#7849)**
- **Fix RU for kafka read (#7859)**
- **Fix optional columns (#7875)**
- **dont use cpu for not abortable chunks (#7865) (#7878)**
- **scan error processing on restore data (#7813) (#7877)**
- **fix frozing of write session (#7958)**
- **Fix cs perf yaem (#8005)**
- **allow to configure min alloc size (#7951) (#7996)**
- **enable  UUID pk for 24.3 (#8018)**
- **Merge Fix LWTrace leaking HTTP request string to HTML page (#7011) (#7014) (#7024)**
- **Enable DROP VIEW from a folder, bugfix (#8066) (#8079)**
- **Fix describe consumer (#8100)**
- **Enabled statistics in stable (#8107)**
- **24-3: Add basic dynconfig audit (#8155)**
- **return implicit query params type into feature flag (#8063)**
- **24-3: Allow to alter cdc topic's retention period (#8289)**
- **PgWire auth with ApiKey (#8283)**
- **24-3: Async replication: configurable default retention period (#8292)**
- **fix CORS headers (#8303) (#8313)**
- **24-3 Report index sizes by type (#8325)**
- **24-3: Add sensors to Node Broker (#8091) (#8311)**
- **asan fix**
- **ExecuteData set transaction mode always**
- **storage healthceck fixes (#8460)**
- **24-3: Enable CMS request priorities by default (#8380) (#8413)**
- **Merge stable 24 3 (#8545)**
- **[Ldap] Merge ldap fixes to stable 24-3 (#8326)**
- **24-3: Reset __async_replica attr after changing REPLICATION_MODE to NONE (#8620)**
- **Topics improvements for 24-3 (#8605)**
- **data query uses different local compute tasks param (24-3) (#8633)**
- **fixes applied to sessions sysview (#8667)**
- **Merge into 24-3. Add new INFO LOG message for groups which cannot be healed by SelfHeal (#8628)**
- **Column statistics (#8487)**
- **The race between `TEvProposeTransaction` and `TEvLockStatus` (#8517) (#8670)**
- **24-3: Add created_by to Operations API (#6463) (#8708)**
- **YQ-3491 support sql for resource pool classifiers (#7389)**
- **YQ-3492 support resource pool classifiers objects saving (#7491)**
- **YQ-3493 support resource pool classifiers kqp_proxy cache (#7688)**
- **YQ WM increase future wait timeout (#7780)**
- **YQ WM move resource pools into metadata folder (#7741)**
- **YQ-3556 move workload manager sensors under feature flag (#7768)**
- **YQ-3555 added validations on not existing for alter/drop object (#7757)**
- **Fixed sqs tests**
- **YQ WM fixed databse checking (#8251)**
- **YQ WM fixed cleanup table retries (#8369)**
- **YQ WM improved overload issues (#8437)**
- **Revert "Fix hash spreading in HashPartitionConsumer (#4364)" (#8752)**
- **24-3: auditlog: add logins (#8104)**
- **Fix initialization of explicit messages groups (#8739)**
- **Fix of ymq memory leak and fix of broken default-win-x86_64 build (#8740)**
- **Add EnablePgSyntax flag (#8765)**
- **24-3: auditlog: add exports/imports (#8751)**
- **EnablePgSyntax flag in fq/yt tests (#8793)**
- **fix(kqp): always take snapshot for queries with stream lookup (#8267) (#8327)**
- **Move blobstorageproxies actor services to different monitoring shard (#8815)**
- **merge 24-3: add ring queue config (#8780)**
- **Merging CBO into stable-24-3-8-analytics (#8819)**
- **fix analyze for serverless case (#8843)**
- **Merge 24-3. Fix ColorBorderOccupancy in PDisk (#8872)**
- **Fix erroneous finish on TDqInputMergeBlockStreamValue (#8834) (#8869)**
- **Fix 24-3 build, remove printing of unexisting field (#8897)**
- **24-3: Merge testlib improvements (#8875)**
- **24-3: Fix resolved timestamp emitted too early for some displaced upserts (#8870)**
- **Disallow disabling of topic autopartitioning (#8871)**
- **24-3: Fix use-after-free in CommittingOps tracking (#8925)**
- **restore old behaviour of mapping space disk issues to group issues (#8774)**
- **Fix reporting of initial VDisk status to SysView (#8853) (#8940)**
- **delete query from compile cache if it is existed during insert (#8537)**
- **Revert "Fix hash spreading in HashPartitionConsumer (#4364)" (#8980)**
- **[Stable 24 3 8 analytics] EvWrite & CTAS  (#8861)**
- **24-3: Always show table name in locks broken error (#8802)**
- **Fix interval multiplication overflow (#8188) (#8979)**
- **YQ-3597 disable metadata objects on serverless (#8922)**
- **YQ-3597 disable metadata objects on serverless (#8921)**
- **Default values for feature flags `EnablePQConfigTransactionsAtSchemeshard` and `EnableTopicServiceTx` (#8845)**
- **fix concurrent rw hash map (#9008) (#9039)**
- **Merge compute limits (#8923)**
- **24-3: auditlog: add logouts (#9052)**
- **YQ-3644 added validations for resource pool parametres (#8958)**
- **Fix cloudId for YMQ (#9088)**
- **Long domain name (#9109)**
- **24-3: Fix heartbeat emitter (#9113)**
- **Do not use autopartition settings when autopartitioning was disabled … (#9184)**
- **merge to 24-3: Fix harmonizer's work with shared threads (#9139)**
- **Backport everything about blocks and stats (#8972)**
- **24-3: schemeshard: fix crash on concurrent alter-extsubdomains (#9201)**
- **YQ-3658 added DisableExternalDataSourcesOnServerless feature flag (#9095)**
- **YQ-3658 added DisableExternalDataSourcesOnServerless feature flag (#9097)**
- **the `TEvTxCalcPredicate` message for the completed transaction (#8809) (#9225)**
- **unmute ydb/tests/functional/clickbench (#9250)**
- **Allow SelfHeal operation while in DEGRADED state (merge from main #8734) (#9224)**
- **Stable 24 3 8 analytics (#9022)**
- **The PQ tablet crashes after restarting (#9279)**
- **[24-3] Fixed CopyToChunked empty buffer error (#9358)**
- **Merge returning fixes 24-3 (#9351)**
- **Precompute all replicated connections if one is already precomputed (… (#9352)**
- **fix(kqp): pass lockNodeId to stream lookup actor (#9311)**
- **24-3: Pre-serialized bootstrap config (#9342)**
- **24-3: Do not lose ScanShards when altering (#9377)**
- **24-3: Limit inflight cross-database scheme requests in the replication controller (#9393)**
- **Fix configuration of ticket parser. Pass server certificates file path (#7445)**
- **Fix TNodeRegistrationResult (#7815)**
- **Support client cert in WhoAmI (#7816)**
- **Config option for node registration token (#7754)**
- **Support filter on DNS names in client cert authentication (#7797)**
- **Check client certificate/token when option EnforceUserTokenCheckRequirement is on (#7511)**
- **The `DescripeTopic` call with the `IncludeStats` flag freezes (#9392) (#9415)**
- **Ignore auto partitions fields if disabled to 24 3 (#9365)**
- **Read without consumer from fed fix to 24-3 (#9138)**
- **Change CODEOWNERS (#9406) (#9411)**
- **Optimize size of PQTabletConfig (#9375) (#9426)**
- **24-3: Forbid scheme ops on backup table (#9446)**
- **24-3: Filter out export directories (#9435)**
- **unmute ydb/tests/functional/clickbench (#9254) (#9417)**
- **[24-3-8] analytics: locks fixes & basic HTAP (#9117)**
- **Merge to 24-3: fix harmonizer logic with hoggish pools (#9477)**
- **delete query from queryIndex if error during insert (#9231) (#9495)**
- **24-3: Adjust change queue reserved capacity at Enqueue() (#9509)**
- **Stable cs to analytics (#9484)**
- **Fix pgwire auth (#9594)**
- **[KQP] Fix recursion problem when computing SimplifiedPlan  (#9519) (#9631)**
- **Revert 24-3: Revert #9477 #9139 (#9560)**
- **The consumer's generation number is not stored in the transaction (#9590) (#9619)**
- **Fix tx counters crash (#9514)**
- **Fixed join order unit test, broken by bad merge (#9631) (#9685)**
- **Merge to stable-24-3 missing commits for stream join (#9566)**
- **The `TEvProposePartitionConfig` message is sent only to the main partitions (#9599) (#9632)**
- **Support cancel after in rate limiter (#9486)**
- **Add permissions for describe of topic (#9562)**
- **Set ending_sequence_number for inactive partitions of datashard (#9636) (#9668)**
- **Merge ydbd binaries upload into stable-24-3 for testing purposes (#9710)**
- **fix wrong isolation level (#6568) (#9673)**
- **24-3: Setup sys locks in TTxApplyReplicationChanges (#9735)**
- **Topics alter fix to 24-3 (#9755)**
- **Support ydb dump for tables with serial types (#9757)**
- **YMQ fixes for 24-3 (#9646)**
- **Fix buggy IC setting leading to performance degradation (merge from main #9707) (#9721)**
- **Integrate stable-24-3-9-cs-2 into stable-24-3 (#9675)**
- **Capture TablePathPrefix (and other parts of the parser context) in CREATE VIEW (#8991) (#9780)**
- **Fix memory leak due to a misuse of AWS SDK (#9810)**
- **Views: throw a human-readable error in case of a missing WITH (security_invoker = true) #9320 (#9783)**
- **Restore indexes from backup with the original partitioning #7589 (#9815)**
- **24-3: NodeBroker: use deltas when returning recently added nodes (#9161)**
- **24-3: Fix EvWrite to release memory correctly (#9841)**
- **MEMBERNAME has been renamed to MEMBER_NAME (#9666) (#9827)**
- **[KQP] Multiset explain bug fix (#9866)**
- **Set EnableUniqConstraint by default (#8180) (#9806)**
- **Do not fill tables for prepared query on compilation failure (#8210) (#9910)**
- **[] Disable enable statistics by default (#9899)**
- **24-3: Fix GetAliveChildren with filter by type (#9934)**
- **[24-3] Fix leaky kind filters in configs dispatcher (#9952)**
- **recompilation with query id from compilation result (#9592)**
- **Add description of TImmediateControlsConfig.TBlobStorageControllerControls to CMS proto (#9756)**
- **fix potential GetStatistics hanging during rolling update; enable statistics by default (#9973)**
- **24-3: Add reason for pending action in maintenance public API (#3289) (#9965)**
- **24-3: parse topic's partitioning once and more efficiently, better handling of connection loss (#10028)**
- **24-3: Add evict vdisks for a rack (#9740) (#10031)**
- **24-3: schemeshard: fix enable_alter_database_create_hive_first mode (#10098)**
- **YMQ: a couple of fixes (for stable-24-3) (#10082)**
- **24-3: optimized batch processing in Topics (#10139)**
- **YMQ: fix ReceiveMessage with attributes (for stable-24-3) (#10144)**
- **UI updates for stable-24-3 (#9928)**
- **24-3: Add min delay before shutdown (#9688) (#10087)**
- **get rid of mkql results in scripting (#9997) (#10094)**
- **use sepecific timeout for generic queues (#6653) (#10221)**
- **YQ-3684 passed database id into workload manager and resource pool classifiers tables (#9610)**
- **Avoid removing empty message (#10167) (#10233)**
- **use sepecific timeout for generic queues (#6653) (#10223)**
- **Dynamic deadline for CS scan (#9520) (#10282)**
- **The PQ cache size for a node is 1GB (#7695) (#10290)**
- **Fix kafka produce codec to 24 3 (#10270)**
- **Viewer updates stable-24-3 v2 (#10332)**
- **24-3: Add disable evict vdisks option to config (#9812) (#10339)**
- **build: refresh Embedded UI (v6.25.0) (#10365)**
- **[24-3-analytics] CTAS & Sinks fixes (#10326)**
- **Replace codec to raw if not specified to 24 3 (#10382)**
- **Cs to stable (#10390)**
- **Fix move table with sequences (#10388)**
- **improve node deletion in hive (#7218) (#10393)**
- **[ldap] Prohibit requests with empty password (#10401)**
- **24-3: Describe VIEW for YDB CLI (#9513) (#10356)**
- **24-3: Disable merges for indexImplTables partitions when build is in progress (#10166) (#10355)**
- **Merge CBO + CBO-KQP improvements (#10400)**
- **Cherries from stable cs (#10446)**
- **Change CODEOWNERS (#10471)**
- **[ticket parser] Fix add to refresh queue when receive retryable error… (#10447)**
- **comment long tests (#10529)**
- **24-3: ImportData: consistent limits (#10526)**
- **Fix stucking donor queries (merge from main #10470) (#10555)**
- **disable spilling (#10583)**
- **Prefer indices aligned with order-by-limit  (#10589)**
- **Mitigate double notification of compiled pattern scenario (#10499) (#10530)**
- **Fix autopartitioning of topics with path that is not root of database (#10609)**
- **Relative time sensors and time series backport (#10640)**
- **fix CODEOWNERS**
- ** do not trigger dead tablet issue during creation of a lot of tablets… (#10398)**
- **24-3: Enable subqueries inside views (#10517) (#10632)**
- **24-3: Stop writing indexImplTables' split boundaries to backups  (#10680)**
- **Force precompute on returning effect inputs (#10695)**
- **24-3: Fix volatile transactions getting stuck after a restart (#10698)**
- **[log_backend] write tenant & cluster for UnifiedAgent log backend (#1… (#10731)**
- **24-3: Add counters for volatile transactions (#10747)**
- **24-3: Partition at decimal keys (#10696) (#10746)**
- **Kafka cdc and auto partitioning yql fixes 24 3 (#10757)**
- **Topics: Add User-Agent counters (#10794)**
- **Revert "24-3: Stop writing indexImplTables' split boundaries to backups  (#10680)" + a test (#10791)**
- **Statistics: portion of bug fixes (#10718)**
- **Single line backport to put Physical Stage IDs to plans (#10827)**
- **24-3: Index build: do not lose the requested partitioning settings of an indexImplTable in case of SchemeShard reboots (#10579) (#10634)**
- **fix use after free on follower deletion (#10850)**
- **24-3 Fix memory consumption restriction in stream RPC calls (#10758) (#10866)**
- **persqueue: fix user agent counters (for 24-3) (#10875)**
- **[Stable-24-3] Fixes for sinks (#10655)**
- ** [CBO] Merge transitive closure + cycles fixes in DPHyp  (#10857)**
- **Viewer updates stable 24-3 v3 (#10745)**
- **[stable-24-3] Shared Cache S3FIFO (#10911)**
- **Init counter for pqv0 read session (24-3) (#11001)**
- **bugfix for incorrect event scheduling when EnableStatistics is disabled (#11011)**
- **add viewer healthcheck path (#11019) - merge stable-24-3 (#11045)**
- **24-3: Fix excessive read latency during and after shard splits (#11061)**
- **24-3: Replication counters (#11081)**
- **Views: if exists / if not exists for DDL (#10831) (#11093)**
- **[KIKIMR-22131] Hot-fix for production: Y_ENSURE → Y_ASSERT (#11130)**
- **[24-3] Fix double PassAway call in Healthcheck actor (#11104)**
- **[24-3] Fix topic read crash (#11137)**
- **Fixed parsing decimals from string (#11017) (#11188)**
- **Fix VDisk replication token handling, add some extra checks and log points (merge from main #10371) (#11225)**
- **Fix issue #9461 with altering CDC streams (#11077) (#11184)**
- **introduce snapshot_ro isolation level (#11085) (#11252)**
- **Add feature flag to enable drive serial numbers discovery (merge from main #11183) (#11255)**
- **observability for tablet starts (#6584) (#11266)**
- **always delete nodes persistently in hive (#11272)**
- **fix waiting followers in dev ui (#10257) (#11267)**
- **Integrate HTAP changes to stable-24-3 (#10899)**
- **Drop the suffix after the first left parenthesis from UserAgent (stable-24-3) (#11259)**
- **ensure reads are sequential (#11280) (#11317)**
- **[24-3] Fix shard ranges sort (#11257) (#11376)**
- **Disable autopartitioning of topics for CDC (#11448)**
- **Stable-24-3: Reset pipeline in datashard init  (#11488)**
- **Fix failed unit tests after enabling the EnableColumnStatistics feature flag (#11409)**
- **[stable-24-3] Use node info from labels in configs dispatcher instead of tenant pool (#11491)**
- **24-3: Break persistent locks on scheme tx (#11525)**
- **[stable-24-3] Request DataShard compaction if scheme has been changed (#11532)**
- **24-3: auditlog: fix logging for unsuccessful ldap logins (#11492)**
- **24-3: Fix test (#11544)**
- **Remote address in audit log (#9460)**
- **Support pure json output for audit log (#10143)**
- **Sanitized token field for audit log (#9287)**
- **Fix: remove kqp config settings from audit/metering lib's resources (#11441)**
- **Audit log json envelope (#11466)**
- **Viewer updates stable 24 3 v4 (#11593)**
- **Fix #11186 (#11631)**
- **Fix sqs json api folder service token to 24 3 (#11640)**
- **Use GraceJoinCore instead of MapJoinCore (#11537)**
- **[24-3] Fix reads from many shards #11569 (#11658)**
- **SQS: Handle empty QueueUrl correctly (stable-24-3) (#11635)**
- **Dockerfile oss (cherry-pick to stable 24-3) (#11633)**
- **Fix UA meta session properties for log_config (cherry-pick to stable 24-3) (#11696)**
- **[stable-24-3] Add release into night build (#11785)**
- **SQS: Fix TimeoutCookie_ leak (stable-24-3) (#11770)**
- **Merge double accelerations into 24-3 (#11740)**
- **[KQP] Added join algo hint without CBO (#10740) (#11666)**
- **[stable-24-3] Fix release configuration support in nightly build (#11804)**
- **Set default MaxNumOfSlowDisks for HDD to 1 (#11807)**
- **do not use basic statistics if it is not fully gathered in schemeshard (#11291) (#11866)**
- **Add missing spilling commits (#11889)**
- **Improved Q9 by moving BuildFlatmapStage to a later stage and adding a Flatmap pushdown (#11860)**
- **[Stable-24-3] Remove old restriction: keys with Uint8 column values >127 are currently prohibited (#11886) (#11901)**
- **Fix overflow case in stream index lookup join (#11818) (#11822)**
- **[stable-24-3] fix test timeouts (#11958)**
- **24-3: Add fallback to ssl port on ydb driver init (#12004)**
- **24-3: Fix bulk operations breaking frozen locks (#12018)**
- **ticket parser: Add priority to access service requests (#11775)**
- **Store flag AuthorizeByCertificate to local db of node broker (#11315) (#11701)**
- **Fixed base statistics for global indexes (#11942) (#12037)**
- **Optimize HtmlApp for PQ tablet (#12056)**
- **Сlean trash on versions switching (#9679) (#11868)**
- **24-3: Allow to describe index table through ydb cli (#12116)**
- **Support read from timestamp for topics autopartitioning (#12125)**
- **fix stream lookup bytes calculation (#12026) (#12101)**
- **24-3: Make it possible to change in-memory setting for tables (#12139)**
- **avoid changing shardstate reads list during iteration (#12150) (#12170)**
- **Index chooser bug merge stable 24 3 (#12169)**
- **switch default channels mode to scalar in 24-3 (#12142)**
- **fix broken ut (#12224)**
- **Optimize CPU usage when read blob (#12153) (#12221)**
- **Fixed CBO Level 1 and Level 2 (#12321)**
- **[stable-24-3] remove clang14 (#12338)**
- **Dont consider prefix indices (#12315) (#12345)**
- **Merge stream lookup changes (#12292)**
- **[24-3] Fix CompareRanges & acl for sink (#12275)**
- **fix exception processing (#11728) (#12355)**
- **Optimize CPU usage when read blob (always use count limit) (#12381)**
- **fix time sync check (#12448)**
- **24-3: Add scale recommender for autoscaling (#12425)**
- **[merge to stable 24-3] nbs-issue-176: added EncryptedDataKey field to NKikimrBlockStore::TEncryptionDesc (#8482) (#12457)**
- **Merge to 24-3: Fix incorrect counter of inflight requests for get_storage_channel_status (#12488)**
- **merge to 24-3: fix multiplying multiput counters in dsproxy (#11264)**
- **Minidump processing improvements (cherry-pick to stable 24-3) (#12025)**
- **The value of `PQ/BytesWriteOK` for writing to a transaction (#12337) (#12477)**
- **Tests `TxUsage::WriteToTopic_Invalid_*` (#12475)**
- **AvgWriteBytes and transactions (#12474)**
- **Fix metrics of inactive partitions (#12543)**
- **Fix incorrect Uuid serialization for CDC. (#12587) (#12601)**
- **YMQ JSON API: send metering events (24-3) (#12635)**
- **Initialize YmqIsFifo (24-3) (#12718)**
- **Bugfix for alter consumers in pqrb (#12613) (#12713)**
- **24-3: Add `ListNodes` cache in `DynamicNameserver` (#12694) (#12747)**
- **Do not allow to jump from Zombie back to Execute state (#12784)**
- **24-3: Add simplified mirror-3dc support in CMS (#11190) (#11276)**
- **24-3: Fix disconnected proxies unexpectedly registering in kesus (#12807)**
- **24-3: Fix follower reads sometimes crashing during split (#12804)**
- **24-3: Abort volatile transactions during graceful restarts (#12808)**
- **Revert use of GraceJoinCore for map/broadcast by default (#12868)**
- **Fixed errors with transactions in the PQ tablet (#12884)**
- **24-3: Add a feature flag for disabling erase cache (#12951)**
- **24-3: Fix disabled use virtual addressing option for import from S3 (#9162) (#12915)**
- **24-3: Add db counters for uncommitted changes and suspicious commits (#12975)**
- **24-3: Fix an observer use-after-free in a datashard test (#13005)**
- **Don't omit precomputes in presense of a returning statement (#12965) (#13116)**
- **Delayed message loses `Sender` (#13066) (#13140)**
- **The tablet leaves executed transactions (#13134) (#13139)**
- **TxInFly and TxCompleteLag metrics for PQ (#13072) (#13141)**
- **24-3: KIKIMR-22120: Take partitioning description of copied table in s3 export (#13067) (#13222)**
- **Stable-24-3: Improve roaring UDF (#13218)**
- **stable-24-3: Add IsSystem flag to filestore config; support __filestore_space_limit_ssd_system limit in SchemeShard (#12693) (#13346)**
- **Parametrized decimal  (#11179)**
- **24-3: Fix uncommitted changes leak and clean them up on startup (#13448)**
- **24-3-15: Return default decimal if scheme proto is empty (#13554)**
- **Fix write in stable-24-3 (#13567)**
- **24-3: Avoid unnecessary ReadStep coordinator subscriptions (#13638)**
- **24-3: Configure minimum coordinator resolution with icb (#13747)**
- **fix dedup normalizer (#9849) (#13776)**
- **Revert "Improved Q9 by moving BuildFlatmapStage to a later stage and adding a Flatmap pushdown (#11860)" (#13774)**
- **24-3: ClickHouse Client optional type fix (#13815) (#13821)**
- **The values of PartNo must be added (#13914)**
- **24-3: Preliminary fix for erase cache consistency problems (#13944)**
- **[filestore] Allow 4G+ throttle values  (#13454) (#13738)**
- **Viewer updates v5 (stable-24-3-15-hotfix) (#13480)**
- **24-3-15-hotfix: KIKIMR-22120: Block table splits and merges during import from S3 (#13918) (#13918)**
- **Fix BS_QUEUE death (merge from main #14081) (#14095)**
- **24-3: Delete rows with decimal in PK (#14209)**
- **Disable distconf (#14171)**
- **fix redirects and tabletinfo filtering for serverless databases (#14221)**
- **Support PG types in schemeshard (#11023) (#14300)**
- **Support PG types in YT export (#8833) (#14303)**
- **Fix for Decimal PK in CDC (#14290)**
- **fix followers with query service (#14367)**
- **Stable-24-4: initial commits (#14402)**
- **24-4: Don't ack readsets too early on volatile tx abort (#14516)**
- **Remove compatibility with old NBS binaries (#14443)**
- **Check EnforceUserTokenRequirement together with RequireCredentialsInNewProtocol (and set the latter's default to false) (#14526)**
- **YMQ tags (#13396)**
- **Sync EvaluteExpr execution (#11801) (#14456)**
- **Compatibility for asynchronous compaction (#14569)**
- **Kafka fixes for 24 4 (#14641)**
- **followers update in 24-4 (#14811)**
- **Merge kafka-proxy improvements and fixes (#14805)**
- **24-4: Resource labels (#14850)**
- **Ingore basic scheme limits for internal operations (#14813) (#14921)**
- **24-4: Paths & shards quota & consumption metrics (#14954)**
- **Add support ydbd start from dynamic config (#14913)**
- **Workaround for batch processing of transactions (#14874) (#14950)**
- **enable index auto-choose by default 24-4 (#15033)**
- **24-4: Fix follower assertions on attach snapshot races (#15077)**
- **24-4: Fix RemoveSubscribedLock crash after DropTable (#15074)**
- **24-4: TDbResolver: store & resend original event (#15082)**
- **[stable-24-4] sync docs_release.yaml with main (#15169)**
- **At the start of a partition, the order of messages may change. (#15160) (#15194)**
- **If TMaybe is empty, get proper JSON value (#15172)**
- **Change MAX_REORDER_TX_KEYS from 100 to 1000 (24-4) (#15294)**
- **Fixed possible stop of reading from the topic partition (#15288) (#15308)**
- **Fix log message in GenerateCookie (#8890) (#15343)**
- **24-4: Add CleanupEC2MetadataClient() (#15382)**
- **24-4 Add BuildStats B-Tree detailed logging (#15352)**
- **YMQ: Update format of labels in search events (24-4) (#15426)**
- **24-4: Force oldest locks into shard locks due to range limits (#15473)**
- **fix inc4455 Do not keep portions for overlap detection (#15252) (#15486)**
- **Merge of important bugfixes for PQ read proxy & kafka proxy (#15457)**
- **Initializing the configuration of the partition (#15557) (#15576)**
- **24-4, VIEW: use parent context for query AST building (#15590)**
- **Refresh ldap token with error  (#15182) (#15460)**
- **24-4: handle follower dying while being promoted to leader (#15134) (#15668)**
- **24-4: check that we are not migrating tablets to ourselves (#15477) (#15666)**
- **24-4: fix safe operation check in hive (#15537) (#15664)**
- **24-4: increase logging around tablet unlocks (#14741) (#15669)**
- **Revert "Initializing the configuration of the partition (#15557) (#15576)" (#15827)**
- **24-1 Fix B-Tree histograms comparator result overflow (#15820)**
- **Revert "Refresh ldap token with error  (#15182) (#15460)" (#15835)**
- **Revert "24-4: Force oldest locks into shard locks due to range limits (#15473)" (#15851)**
- **Revert "24-4, VIEW: use parent context for query AST building" (#15833)**
- **Revert "24-4: Add CleanupEC2MetadataClient()" (#15832)**
- **24-4: Boost restore (#15837)**
- **provide database in schemecache request (#15941)**
- **Fix config delivery to quoter (#15847) (#15933)**
- **Fix group resolver bug (#13282) (#15921)**
- **Fix segfault in Group Layout Sanitizer (#15922)**
- **Add node interlace in TScore for group mapper (#15951)**
- **An empty list of consumers for the background partition (#15956)**
- **[KIKIMR-22131] Handle potential race in computation pattern cache (#15963)**
- **max timeout for FastRead (#15520) (#16164)**
- **Late messages `TEvProposeTransaction` (#16216) (#16270)**
- **YMQ: Use "name" label name instead of "sensor" for queue.total_count time series (24-4) (#16261)**
- **Fix kafka auth (#16351) (#16391)**
- **24-4: Storage billing labels (#16738)**
- **Read session param for CommitOffset RPC to 24-4 (#16697)**
- **The commit of a transaction in the SDK freezes (#17089)**
- **24-4: ReadTable and ReadRows RPC fixes (#15721, #15850) (#17332)**
- **24-4: Fix readrows RPC (#17426)**
- **[docs] update content to fix build and include recent refactorings (#17298)**
- **The PQ tablet does not receive a TEvTxCalcPredicateResult (#17497) (#17517)**
- **24-4: Support an emergency one-to-one split/merge in SchemeShard (#17655)**
- **24-4: Fix method check in schemeshard actions (#17738)**
- **Merge bugfixes 24 4  (#16685)**
- **[stable-24-4] sync docs_release.yaml with main after #17623 (#17783)**
- **The PQ tablet loses its TEvReadSet (#17842) (#17855)**
- **[docs] backport #17480 #17801 to stable-24-4 (#17840)**
- **badge template without issue number (#17788)**
- **Don't wait for TEvReadSetAck from non-existent tablets (#17913)**
- **[-] restore the value of counters**
- **fix sending big messages (#18079)**
- **Allow to send duplicates through TDedicatedPipePool**
- **healthcheck segfault while retrying Whiteboard  (#17836)**
- **Check iter index access slice bounds (#18213)**
- **Fix build index retry GetTimeoutBackouff**
- **[*] a copy of TEvReadSet is used instead of the serialized message**
- **[/] unused code**
- **[-] too many transactions**
- **[*] ABORTED -> OVERLOADED**
- **[*] use NKikimrTx::TEvReadSet**
- **[-] uninitialized value**
- **Fixed broken links**
- **Update public materials (#18219)**
- **Adding missing presets**
- **[docs] add DataLens integration (#18129)**
- **[docs] fix typo around DataLens (#18246)**
- **dev: C# ADO.NET Docs (#17202)**
- **[docs] fix connection-parameters.md in ADO.NET (#17465)**
- **[docs] reference for https://github.com/ydb-platform/ydb-mcp (#17900)**
- **Don't try checking for merge when operation limit already exceeded (#18475)**
- **Fix unknown fields problem in BSC**
- **fix error processing on program apply (#10814)**
- **Increase TotalCPU to avoid backup restore dead locks (#18545)**
- **fix auth flags check**
- **Fixed linter errors**
- **[docs] remove incorrect video from COSCUP 2024 (#18177)**
- **Fixed warnings**
- **Fixed an error**
- **[stable-24-4] temporary update redirects.yaml**
- **add LightOrangeGroups to CheckBlobstorageStatusResult (#19006)**
- **Added a video about Yandex PSP (#19042)**
- **Enable kafka api by env variable (#11892)**
- **use YDB_KAFKA_PROXY_PORT for enable kafka (#12242)**
- **start kafka port by default in local ydb (#19194)**

### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

...

### Changelog category <!-- remove all except one -->

* New feature
* Experimental feature
* Improvement
* Performance improvement
* User Interface
* Bugfix 
* Backward incompatible change
* Documentation (changelog entry is not required)
* Not for changelog (changelog entry is not required)

### Description for reviewers <!-- (optional) description for those who read this PR -->

...
