### PR TITLE
Add cluster state history recording

### DIFF
--- a/ydb/core/blobstorage/nodewarden/distconf.cpp
+++ b/ydb/core/blobstorage/nodewarden/distconf.cpp
@@ -447,9 +447,14 @@ namespace NKikimr::NStorage {
         if (config->HasClusterState()) {
             auto fillInBridge = [&](auto *pb) -> std::optional<TString> {
                 auto& clusterState = config->GetClusterState();
+
+                // copy cluster state generation
+                pb->SetClusterStateGeneration(clusterState.GetGeneration());
+
                 if (!pb->RingGroupsSize() || pb->HasRing()) {
                     return "configuration has Ring field set or no RingGroups";
                 }
+
                 auto *groups = pb->MutableRingGroups();
                 for (int i = 0, count = groups->size(); i < count; ++i) {
                     auto *group = groups->Mutable(i);

--- a/ydb/core/blobstorage/nodewarden/distconf_generate.cpp
+++ b/ydb/core/blobstorage/nodewarden/distconf_generate.cpp
@@ -123,9 +123,18 @@ namespace NKikimr::NStorage {
         // generate initial cluster state, if needed
         if (Cfg->BridgeConfig) {
             auto *state = config->MutableClusterState();
+            state->SetGeneration(1);
             auto *piles = state->MutablePerPileState();
             for (size_t i = 0; i < Cfg->BridgeConfig->PilesSize(); ++i) {
                 piles->Add(NKikimrBridge::TClusterState::SYNCHRONIZED);
+            }
+
+            auto *history = config->MutableClusterStateHistory();
+            auto *entry = history->AddUnsyncedEntries();
+            entry->MutableClusterState()->CopyFrom(*state);
+            entry->SetOperationGuid(RandomNumber<ui64>());
+            for (size_t i = 0; i < Cfg->BridgeConfig->PilesSize(); ++i) {
+                entry->AddUnsyncedPiles(i);
             }
         }
 

--- a/ydb/core/blobstorage/nodewarden/distconf_mon.cpp
+++ b/ydb/core/blobstorage/nodewarden/distconf_mon.cpp
@@ -173,6 +173,25 @@ namespace NKikimr::NStorage {
                                 out << "<pre>";
                                 OutputPrettyMessage(out, *config);
                                 out << "</pre>";
+                                if (config->HasConfigComposite()) {
+                                    out << "<strong>config.yaml</strong><br/>";
+                                    TString yaml;
+                                    ui64 version;
+                                    TString fetchYaml;
+                                    auto error = DecomposeConfig(config->GetConfigComposite(), &yaml, &version, &fetchYaml);
+                                    if (error) {
+                                        out << "<strong>error: " << error << "</strong>";
+                                    } else {
+                                        out << "<pre>" << yaml << "</pre>";
+                                    }
+                                }
+                                if (config->HasCompressedStorageYaml()) {
+                                    TStringInput ss(config->GetCompressedStorageYaml());
+                                    TZstdDecompress zstd(&ss);
+                                    TString yaml = zstd.ReadAll();
+                                    out << "<strong>storage.yaml (size " << yaml.size() << ")</strong><br/><pre>"
+                                        << yaml << "</pre>";
+                                }
                             } else {
                                 out << "not defined";
                             }

--- a/ydb/core/blobstorage/nodewarden/distconf_validate.cpp
+++ b/ydb/core/blobstorage/nodewarden/distconf_validate.cpp
@@ -101,7 +101,7 @@ namespace NKikimr::NStorage {
                     return "sudden group ErasureSpecies change";
                 } else if (group.RingsSize() != currentGroup.RingsSize()) {
                     return "sudden group geometry change";
-                } else if (group.GetRings(0).FailDomainsSize() != currentGroup.GetRings(0).FailDomainsSize()) {
+                } else if (group.RingsSize() && group.GetRings(0).FailDomainsSize() != currentGroup.GetRings(0).FailDomainsSize()) {
                     return "sudden group geometry change";
                 }
                 groupInfo.erase(it);

--- a/ydb/core/config/init/init_impl.h
+++ b/ydb/core/config/init/init_impl.h
@@ -1328,10 +1328,10 @@ public:
     public:
         TAppConfigFieldsPreserver(NKikimrConfig::TAppConfig& appConfig) 
             : AppConfig(appConfig)
-            , ConfigDirPath(appConfig.GetConfigDirPath())
-            , StoredConfigYaml(appConfig.GetStoredConfigYaml())
-            , StartupConfigYaml(appConfig.GetStartupConfigYaml())
-            , StartupStorageYaml(appConfig.GetStartupStorageYaml())
+            , ConfigDirPath(appConfig.HasConfigDirPath() ? std::make_optional(appConfig.GetConfigDirPath()) : std::nullopt)
+            , StoredConfigYaml(appConfig.HasStoredConfigYaml() ? std::make_optional(appConfig.GetStoredConfigYaml()) : std::nullopt)
+            , StartupConfigYaml(appConfig.HasStartupConfigYaml() ? std::make_optional(appConfig.GetStartupConfigYaml()) : std::nullopt)
+            , StartupStorageYaml(appConfig.HasStartupStorageYaml() ? std::make_optional(appConfig.GetStartupStorageYaml()) : std::nullopt)
         {}
 
         ~TAppConfigFieldsPreserver() {
@@ -1348,6 +1348,7 @@ public:
                 AppConfig.SetStartupStorageYaml(*StartupStorageYaml);
             }
         }
+
     private:
         NKikimrConfig::TAppConfig& AppConfig;
         std::optional<TString> ConfigDirPath;

--- a/ydb/core/protos/blobstorage_distributed_config.proto
+++ b/ydb/core/protos/blobstorage_distributed_config.proto
@@ -36,6 +36,7 @@ message TStorageConfig { // contents of storage metadata
     optional bytes CompressedStorageYaml = 14; // compressed storage YAML config (if dual-config is enabled)
     optional uint64 ExpectedStorageYamlVersion = 15;
     NKikimrBridge.TClusterState ClusterState = 16; // for bridged clusters; not set for ordinary ones
+    NKikimrBridge.TClusterStateHistory ClusterStateHistory = 17; // history of unsynced state changes
 }
 
 message TPDiskMetadataRecord {

--- a/ydb/core/protos/bridge.proto
+++ b/ydb/core/protos/bridge.proto
@@ -12,4 +12,14 @@ message TClusterState {
     repeated EPileState PerPileState = 1; // a state for every realm, including primary
     uint32 PrimaryPile = 2; // the current primary (must be SYNCHRONIZED)
     uint32 PromotedPile = 3; // realm we are going to promote (must also be SYNCHRONIZED), or primary one
+    uint64 Generation = 4; // cluster state generation (which must be increasing strictly by one)
+}
+
+message TClusterStateHistory {
+    message TUnsyncedEntry {
+        TClusterState ClusterState = 1;
+        fixed64 OperationGuid = 2;
+        repeated uint32 UnsyncedPiles = 3; // a list of pile ids that did not refer to this entry; trimmed when empty
+    }
+    repeated TUnsyncedEntry UnsyncedEntries = 1; // entries stored in order of ascending Generation
 }

--- a/ydb/core/protos/config.proto
+++ b/ydb/core/protos/config.proto
@@ -213,6 +213,7 @@ message TDomainsConfig {
         optional uint32 StateStorageVersion = 3 [default = 0];
         repeated uint32 CompatibleVersions = 4;
         repeated TRing RingGroups = 5;
+        optional uint64 ClusterStateGeneration = 6; // generation from current ClusterState
     }
 
     message TStoragePoolType {


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

Add cluster state history recording

### Changelog category <!-- remove all except one -->

* Not for changelog (changelog entry is not required)

### Description for reviewers <!-- (optional) description for those who read this PR -->

This patch allows tracking of cluster state change history to allow correct recovery when piles get back online.