### PR TITLE
25-1: add followers support for secondary indexes (#17965)

### DIFF
--- a/ydb/core/kqp/ut/common/kqp_ut_common.cpp
+++ b/ydb/core/kqp/ut/common/kqp_ut_common.cpp
@@ -1508,6 +1508,36 @@ void WaitForZeroReadIterators(Tests::TServer& server, const TString& path) {
     UNIT_ASSERT_C(iterators == 0, "Unable to wait for proper read iterator count, it looks like cancelation doesn`t work (" << iterators << ")");
 }
 
+int GetCumulativeCounterValue(Tests::TServer& server, const TString& path, const TString& counterName) {
+    int result = 0;
+
+    TTestActorRuntime* runtime = server.GetRuntime();
+    auto sender = runtime->AllocateEdgeActor();
+    auto shards = GetTableShards(&server, sender, path);
+    UNIT_ASSERT_C(shards.size() > 0, "Table: " << path << " has no shards");
+
+    for (auto x : shards) {
+        runtime->SendToPipe(
+            x,
+            sender,
+            new TEvTablet::TEvGetCounters,
+            0,
+            GetPipeConfigWithRetries());
+
+        auto ev = runtime->GrabEdgeEvent<TEvTablet::TEvGetCountersResponse>(sender);
+        UNIT_ASSERT(ev);
+
+        const NKikimrTabletBase::TEvGetCountersResponse& resp = ev->Get()->Record;
+        for (const auto& counter : resp.GetTabletCounters().GetAppCounters().GetCumulativeCounters()) {
+            if (counter.GetName() == counterName) {
+                result += counter.GetValue();
+            }
+        }
+    }
+
+    return result;
+}
+
 NJson::TJsonValue SimplifyPlan(NJson::TJsonValue& opt, const TGetPlanParams& params) {
     if (auto ops = opt.GetMapSafe().find("Operators"); ops != opt.GetMapSafe().end()) {
         auto opName = ops->second.GetArraySafe()[0].GetMapSafe().at("Name").GetStringSafe();

--- a/ydb/core/kqp/ut/common/kqp_ut_common.h
+++ b/ydb/core/kqp/ut/common/kqp_ut_common.h
@@ -384,6 +384,7 @@ TVector<ui64> GetColumnTableShards(Tests::TServer* server, TActorId sender, cons
 
 void WaitForZeroSessions(const NKqp::TKqpCounters& counters);
 void WaitForZeroReadIterators(Tests::TServer& server, const TString& path);
+int GetCumulativeCounterValue(Tests::TServer& server, const TString& path, const TString& counterName);
 
 bool JoinOrderAndAlgosMatch(const TString& optimized, const TString& reference);
 

--- a/ydb/core/kqp/ut/common/kqp_ut_common.h
+++ b/ydb/core/kqp/ut/common/kqp_ut_common.h
@@ -386,6 +386,8 @@ void WaitForZeroSessions(const NKqp::TKqpCounters& counters);
 void WaitForZeroReadIterators(Tests::TServer& server, const TString& path);
 int GetCumulativeCounterValue(Tests::TServer& server, const TString& path, const TString& counterName);
 
+void CheckTableReads(NYdb::NTable::TSession& session, const TString& tableName, bool checkFollower, bool readsExpected);
+
 bool JoinOrderAndAlgosMatch(const TString& optimized, const TString& reference);
 
 struct TGetPlanParams {

--- a/ydb/core/kqp/ut/opt/kqp_ne_ut.cpp
+++ b/ydb/core/kqp/ut/opt/kqp_ne_ut.cpp
@@ -2334,112 +2334,75 @@ Y_UNIT_TEST_SUITE(KqpNewEngine) {
         }
     }
 
-    Y_UNIT_TEST(StaleRO) {
-        auto kikimr = DefaultKikimrRunner();
-        auto db = kikimr.GetTableClient();
-        auto session = db.CreateSession().GetValueSync().GetSession();
+    Y_UNIT_TEST_TWIN(StaleRO, EnableFollowers) {
+        auto settings = TKikimrSettings()
+            .SetEnableForceFollowers(EnableFollowers)
+            .SetWithSampleTables(false);
 
-        AssertSuccessResult(session.ExecuteSchemeQuery(R"(
-            --!syntax_v1
-            CREATE TABLE `FollowersKv` (
+        TKikimrRunner kikimr(settings);
+        auto tableClient = kikimr.GetTableClient();
+        auto queryClient = kikimr.GetQueryClient();
+        auto session = tableClient.CreateSession().GetValueSync().GetSession();
+
+        AssertSuccessResult(session.ExecuteSchemeQuery(Sprintf(Q_(R"(
+            CREATE TABLE `Table` (
                 Key Uint64,
                 Value String,
                 PRIMARY KEY (Key)
             )
             WITH (
-                PARTITION_AT_KEYS = (10, 20, 30),
-                READ_REPLICAS_SETTINGS = "ANY_AZ:1"
+                PARTITION_AT_KEYS = (10, 20, 30)
+                %s
             );
-        )").GetValueSync());
+        )").c_str(), EnableFollowers ? ", READ_REPLICAS_SETTINGS = \"ANY_AZ:3\"" : "")
+        ).GetValueSync());
 
-        AssertSuccessResult(session.ExecuteDataQuery(R"(
-            --!syntax_v1
-
-            REPLACE INTO `FollowersKv` (Key, Value) VALUES
+        AssertSuccessResult(session.ExecuteDataQuery(Q_(R"(
+            UPSERT INTO `Table` (Key, Value) VALUES
                 (1u, "One"),
                 (11u, "Two"),
                 (21u, "Three"),
                 (31u, "Four");
-        )", TTxControl::BeginTx().CommitTx()).GetValueSync());
+         )"), TTxControl::BeginTx().CommitTx()).GetValueSync());
 
-        kikimr.GetTestServer().GetRuntime()->SetLogPriority(NKikimrServices::KQP_EXECUTER, NActors::NLog::PRI_INFO);
-        kikimr.GetTestServer().GetRuntime()->SetLogPriority(NKikimrServices::PIPE_CLIENT, NActors::NLog::PRI_DEBUG);
-        //kikimr.GetTestServer().GetRuntime()->SetLogPriority(NKikimrServices::PIPE_SERVER, NActors::NLog::PRI_DEBUG);
 
-        // Followers immediate
-        auto result = session.ExecuteDataQuery(R"(
-            --!syntax_v1
-            SELECT * FROM FollowersKv WHERE Key = 21;
-        )", TTxControl::BeginTx(TTxSettings::StaleRO()).CommitTx()).ExtractValueSync();
-        AssertSuccessResult(result);
-        UNIT_ASSERT_UNEQUAL(0, GetCumulativeCounterValue(
-            kikimr.GetTestServer(),
-            "/Root/FollowersKv",
-            "DataShard/TxUpdateFollowerReadEdge/ExecuteCPUTime"
-        ));
+        auto checkRead = [&](const TString& query, const TString& expectedResult, const TString& tablePath) {
+            auto result = session.ExecuteDataQuery(query, TTxControl::BeginTx(TTxSettings::StaleRO()).CommitTx()).ExtractValueSync();
+            AssertSuccessResult(result);
+            CompareYson(expectedResult, FormatResultSetYson(result.GetResultSet(0)));
 
-        CompareYson(R"(
+            if (EnableFollowers) {
+                // from master - should NOT read
+                CheckTableReads(session, tablePath, false, false);
+                // from followers - should read
+                CheckTableReads(session, tablePath, true, true);
+            } else {
+                // from master - should read
+                CheckTableReads(session, tablePath, false, true);
+                // from followers - should NOT read
+                CheckTableReads(session, tablePath, true, false); 
+            }
+        };
+
+        // immediate
+        checkRead(Q_(R"(
+            SELECT * FROM Table WHERE Key = 21;
+        )"), R"(
             [
                 [[21u];["Three"]];
             ]
-        )", FormatResultSetYson(result.GetResultSet(0)));
+        )", "/Root/Table");
 
-        // Followers distributed
-        result = session.ExecuteDataQuery(R"(
-            --!syntax_v1
-            SELECT * FROM FollowersKv WHERE Value != "One" ORDER BY Key;
-        )", TTxControl::BeginTx(TTxSettings::StaleRO()).CommitTx()).ExtractValueSync();
-        AssertSuccessResult(result);
-        UNIT_ASSERT_UNEQUAL(0, GetCumulativeCounterValue(
-            kikimr.GetTestServer(),
-            "/Root/FollowersKv",
-            "DataShard/TxUpdateFollowerReadEdge/ExecuteCPUTime"
-        ));
-
-        CompareYson(R"(
+        // distributed
+        checkRead(Q_(R"(
+            SELECT * FROM Table WHERE Value != "One" ORDER BY Key;
+        )"), R"(
             [
                 [[11u];["Two"]];
                 [[21u];["Three"]];
                 [[31u];["Four"]];
             ]
-        )", FormatResultSetYson(result.GetResultSet(0)));
-
-        // No followers immediate
-        result = session.ExecuteDataQuery(R"(
-            --!syntax_v1
-            SELECT * FROM TwoShard WHERE Key = 2;
-        )", TTxControl::BeginTx(TTxSettings::StaleRO()).CommitTx()).ExtractValueSync();
-        AssertSuccessResult(result);
-        UNIT_ASSERT_EQUAL(0, GetCumulativeCounterValue(
-            kikimr.GetTestServer(),
-            "/Root/TwoShard",
-            "DataShard/TxUpdateFollowerReadEdge/ExecuteCPUTime"
-        ));
-
-        CompareYson(R"(
-            [
-                [[2u];["Two"];[0]];
-            ]
-        )", FormatResultSetYson(result.GetResultSet(0)));
-
-        // No followers distributed
-        result = session.ExecuteDataQuery(R"(
-            --!syntax_v1
-            SELECT * FROM TwoShard WHERE Value2 < 0 ORDER BY Key;
-        )", TTxControl::BeginTx(TTxSettings::StaleRO()).CommitTx()).ExtractValueSync();
-        AssertSuccessResult(result);
-
-        CompareYson(R"(
-            [
-                [[1u];["One"];[-1]];
-                [[4000000001u];["BigOne"];[-1]]
-            ]
-        )", FormatResultSetYson(result.GetResultSet(0)));
-        UNIT_ASSERT_EQUAL(0, GetCumulativeCounterValue(
-            kikimr.GetTestServer(),
-            "/Root/TwoShard",
-            "DataShard/TxUpdateFollowerReadEdge/ExecuteCPUTime"
-        ));
+        )", "/Root/Table");
     }
 
     Y_UNIT_TEST(StaleRO_Immediate) {
@@ -2465,13 +2428,15 @@ Y_UNIT_TEST_SUITE(KqpNewEngine) {
     }
 
     Y_UNIT_TEST_TWIN(StaleRO_IndexFollowers, EnableFollowers) {
-        auto kikimr = DefaultKikimrRunner();
+        auto settings = TKikimrSettings()
+            .SetEnableForceFollowers(EnableFollowers)
+            .SetWithSampleTables(false);
+        TKikimrRunner kikimr(settings);
         auto db = kikimr.GetTableClient();
         auto session = db.CreateSession().GetValueSync().GetSession();
 
-        AssertSuccessResult(session.ExecuteSchemeQuery(R"(
-            --!syntax_v1
-            CREATE TABLE `KeySubkey` (
+        AssertSuccessResult(session.ExecuteSchemeQuery(Q_(R"(
+            CREATE TABLE Table (
                 Key Uint64,
                 Subkey Uint64,
                 Value String,
@@ -2479,49 +2444,51 @@ Y_UNIT_TEST_SUITE(KqpNewEngine) {
                 PRIMARY KEY (Key, Subkey)
             );
 
-            ALTER TABLE `KeySubkey` ADD INDEX `idx` GLOBAL SYNC ON (`Key`, `Order`) COVER (`Value`);
-        )").GetValueSync());
+            ALTER TABLE Table ADD INDEX idx GLOBAL SYNC ON (Key, Order) COVER (Value);
+        )")).GetValueSync());
 
         if constexpr (EnableFollowers) {
-            AssertSuccessResult(session.ExecuteSchemeQuery(R"(
-                --!syntax_v1
-                ALTER TABLE `KeySubkey` ALTER INDEX `idx` SET READ_REPLICAS_SETTINGS "PER_AZ:1";
-            )").GetValueSync());
+            AssertSuccessResult(session.ExecuteSchemeQuery(Q_(R"(
+                ALTER TABLE Table ALTER INDEX idx SET READ_REPLICAS_SETTINGS "ANY_AZ:1";
+            )")).GetValueSync());
         }
 
-        AssertSuccessResult(session.ExecuteDataQuery(R"(
-            --!syntax_v1
-
-            REPLACE INTO `KeySubkey` (`Key`, `Subkey`, `Value`, `Order`) VALUES
+        AssertSuccessResult(session.ExecuteDataQuery(Q_(R"(
+            UPSERT INTO Table (Key, Subkey, Value, Order) VALUES
                 (1u, 2u, "One", 7u),
                 (1u, 3u, "Two", 4u),
                 (21u, 8u, "Three", 1u),
                 (31u, 0u, "Four", 8u);
-        )", TTxControl::BeginTx().CommitTx()).GetValueSync());
+        )"), TTxControl::BeginTx().CommitTx()).GetValueSync());
 
-        auto result = session.ExecuteDataQuery(R"(
-            --!syntax_v1
-            SELECT * FROM `KeySubkey` VIEW `idx` WHERE Key = 1 ORDER BY `Order`;
-        )", TTxControl::BeginTx(TTxSettings::StaleRO()).CommitTx()).ExtractValueSync();
+        auto result = session.ExecuteDataQuery(Q_(R"(
+            SELECT Key, Value FROM Table VIEW idx WHERE Key = 1 ORDER BY Order;
+        )"), TTxControl::BeginTx(TTxSettings::StaleRO()).CommitTx()).ExtractValueSync();
         AssertSuccessResult(result);
-
-        const auto FollowerCpuTime = GetCumulativeCounterValue(
-            kikimr.GetTestServer(),
-            "/Root/KeySubkey/idx/indexImplTable",
-            "DataShard/TxUpdateFollowerReadEdge/ExecuteCPUTime"
-        );
-        if constexpr (EnableFollowers) {
-            UNIT_ASSERT_UNEQUAL(0, FollowerCpuTime);
-        } else {
-            UNIT_ASSERT_EQUAL(0, FollowerCpuTime);
-        }
 
         CompareYson(R"(
             [
-                [[1u];[4u];[3u];["Two"]];
-                [[1u];[7u];[2u];["One"]];
+                [[1u];["Two"]];
+                [[1u];["One"]];
             ]
         )", FormatResultSetYson(result.GetResultSet(0)));
+
+        // from main master - should NOT read
+        CheckTableReads(session, "/Root/Table", false, false);
+        // from main followers - should NOT read
+        CheckTableReads(session, "/Root/Table", true, false);
+
+        if constexpr (EnableFollowers) {
+            // from index master - should NOT read
+            CheckTableReads(session, "/Root/Table/idx/indexImplTable", false, false);
+            // from index followers - should read
+            CheckTableReads(session, "/Root/Table/idx/indexImplTable", true, true);
+        } else {
+            // from index master - should read
+            CheckTableReads(session, "/Root/Table/idx/indexImplTable", false, true);
+            // from index followers - should NOT read
+            CheckTableReads(session, "/Root/Table/idx/indexImplTable", true, false);
+        }
     }
 
     Y_UNIT_TEST(ReadRangeWithParams) {

--- a/ydb/core/kqp/ut/sysview/kqp_sys_view_ut.cpp
+++ b/ydb/core/kqp/ut/sysview/kqp_sys_view_ut.cpp
@@ -719,6 +719,11 @@ order by SessionId;)", "%Y-%m-%d %H:%M:%S %Z", sessionsSet.front().GetId().data(
             ])", actual);
         }
 
+        // from master - should read
+        CheckTableReads(session, "/Root/Followers", false, true);
+        // from followers - should NOT read yet
+        CheckTableReads(session, "/Root/Followers", true, false);        
+
         Cerr << "... SELECT from follower" << Endl;
         {
             auto result = session.ExecuteDataQuery(R"(
@@ -733,6 +738,11 @@ order by SessionId;)", "%Y-%m-%d %H:%M:%S %Z", sessionsSet.front().GetId().data(
                 [[31u];["Four"]]
             ])", actual);
         }
+
+        // from master - should read
+        CheckTableReads(session, "/Root/Followers", false, true);
+        // from followers - should read
+        CheckTableReads(session, "/Root/Followers", true, true);
 
         for (size_t attempt = 0; attempt < 30; ++attempt)
         {

--- a/ydb/core/tx/schemeshard/schemeshard__operation_alter_table.cpp
+++ b/ydb/core/tx/schemeshard/schemeshard__operation_alter_table.cpp
@@ -751,7 +751,7 @@ TVector<ISubOperation::TPtr> CreateConsistentAlterTable(TOperationId id, const T
     if (!(IsAdministrator(AppData(), context.UserToken.Get()) && !AppData()->AdministrationAllowedSIDs.empty())
         && (!CheckAllowedFields(alter, {"Name", "PathId", "PartitionConfig", "ReplicationConfig", "IncrementalBackupConfig"})
             || (alter.HasPartitionConfig()
-                && !CheckAllowedFields(alter.GetPartitionConfig(), {"PartitioningPolicy"})
+                && !CheckAllowedFields(alter.GetPartitionConfig(), {"PartitioningPolicy", "FollowerCount", "FollowerGroups"})
             )
         )
     ) {

--- a/ydb/core/tx/schemeshard/schemeshard_utils.cpp
+++ b/ydb/core/tx/schemeshard/schemeshard_utils.cpp
@@ -136,8 +136,10 @@ NKikimrSchemeOp::TPartitionConfig PartitionConfigForIndexes(
     if (baseTablePartitionConfig.HasKeepSnapshotTimeout()) {
         result.SetKeepSnapshotTimeout(baseTablePartitionConfig.GetKeepSnapshotTimeout());
     }
+    if (indexTableDesc.GetPartitionConfig().FollowerGroupsSize()) {
+        result.MutableFollowerGroups()->CopyFrom(indexTableDesc.GetPartitionConfig().GetFollowerGroups());
+    }
     // skip repeated NKikimrStorageSettings.TStorageRoom StorageRooms = 17;
-    // skip optional NKikimrHive.TFollowerGroup FollowerGroup = 23;
 
     return result;
 }

--- a/ydb/core/ydb_convert/table_description.cpp
+++ b/ydb/core/ydb_convert/table_description.cpp
@@ -990,6 +990,7 @@ void FillGlobalIndexSettings(Ydb::Table::GlobalIndexSettings& settings,
     }
 
     FillPartitioningSettingsImpl(settings, indexImplTableDescription);
+    FillReadReplicasSettings(settings, indexImplTableDescription);
 }
 
 template <typename TYdbProto>
@@ -1574,6 +1575,11 @@ void FillReadReplicasSettings(Ydb::Table::DescribeTableResult& out,
 
 void FillReadReplicasSettings(Ydb::Table::CreateTableRequest& out,
         const NKikimrSchemeOp::TTableDescription& in) {
+    FillReadReplicasSettingsImpl(out, in);
+}
+
+void FillReadReplicasSettings(Ydb::Table::GlobalIndexSettings& out,
+    const NKikimrSchemeOp::TTableDescription& in) {
     FillReadReplicasSettingsImpl(out, in);
 }
 

--- a/ydb/core/ydb_convert/table_description.h
+++ b/ydb/core/ydb_convert/table_description.h
@@ -136,6 +136,8 @@ void FillReadReplicasSettings(Ydb::Table::DescribeTableResult& out,
     const NKikimrSchemeOp::TTableDescription& in);
 void FillReadReplicasSettings(Ydb::Table::CreateTableRequest& out,
     const NKikimrSchemeOp::TTableDescription& in);
+void FillReadReplicasSettings(Ydb::Table::GlobalIndexSettings& out,
+    const NKikimrSchemeOp::TTableDescription& in);
 
 // in
 bool FillTableDescription(NKikimrSchemeOp::TModifyScheme& out,

--- a/ydb/public/api/protos/ydb_table.proto
+++ b/ydb/public/api/protos/ydb_table.proto
@@ -58,6 +58,7 @@ message GlobalIndexSettings {
     }
     // Partitioning settings for the table that implements the index.
     PartitioningSettings partitioning_settings = 3;
+    ReadReplicasSettings read_replicas_settings = 4;
 }
 
 message VectorIndexSettings {

--- a/ydb/public/sdk/cpp/client/ydb_table/table.cpp
+++ b/ydb/public/sdk/cpp/client/ydb_table/table.cpp
@@ -359,23 +359,7 @@ class TTableDescription::TImpl {
         }
 
         // read replicas settings
-        if (proto.has_read_replicas_settings()) {
-            const auto settings = proto.read_replicas_settings();
-            switch (settings.settings_case()) {
-            case Ydb::Table::ReadReplicasSettings::kPerAzReadReplicasCount:
-                ReadReplicasSettings_ = TReadReplicasSettings(
-                    TReadReplicasSettings::EMode::PerAz,
-                    settings.per_az_read_replicas_count());
-                break;
-            case Ydb::Table::ReadReplicasSettings::kAnyAzReadReplicasCount:
-                ReadReplicasSettings_ = TReadReplicasSettings(
-                    TReadReplicasSettings::EMode::AnyAz,
-                    settings.any_az_read_replicas_count());
-                break;
-            default:
-                break;
-            }
-        }
+        ReadReplicasSettings_ = TReadReplicasSettings::FromProto(proto.read_replicas_settings());
     }
 
 public:
@@ -972,16 +956,7 @@ void TTableDescription::SerializeTo(Ydb::Table::CreateTableRequest& request) con
     }
 
     if (const auto& settings = Impl_->GetReadReplicasSettings()) {
-        switch (settings->GetMode()) {
-        case TReadReplicasSettings::EMode::PerAz:
-            request.mutable_read_replicas_settings()->set_per_az_read_replicas_count(settings->GetReadReplicasCount());
-            break;
-        case TReadReplicasSettings::EMode::AnyAz:
-            request.mutable_read_replicas_settings()->set_any_az_read_replicas_count(settings->GetReadReplicasCount());
-            break;
-        default:
-            break;
-        }
+        settings->SerializeTo(*request.mutable_read_replicas_settings());
     }
 }
 
@@ -1744,18 +1719,7 @@ static Ydb::Table::AlterTableRequest MakeAlterTableProtoRequest(
 
     if (settings.SetReadReplicasSettings_.Defined()) {
         const auto& replSettings = settings.SetReadReplicasSettings_.GetRef();
-        switch (replSettings.GetMode()) {
-        case TReadReplicasSettings::EMode::PerAz:
-            request.mutable_set_read_replicas_settings()->set_per_az_read_replicas_count(
-                replSettings.GetReadReplicasCount());
-            break;
-        case TReadReplicasSettings::EMode::AnyAz:
-            request.mutable_set_read_replicas_settings()->set_any_az_read_replicas_count(
-                replSettings.GetReadReplicasCount());
-            break;
-        default:
-            break;
-        }
+        replSettings.SerializeTo(*request.mutable_set_read_replicas_settings());
     }
 
     return request;
@@ -2347,6 +2311,34 @@ ui64 TIndexDescription::GetSizeBytes() const {
     return SizeBytes_;
 }
 
+TMaybe<TReadReplicasSettings> TReadReplicasSettings::FromProto(const Ydb::Table::ReadReplicasSettings& proto) {
+    switch (proto.settings_case()) {
+    case Ydb::Table::ReadReplicasSettings::kPerAzReadReplicasCount:
+        return TReadReplicasSettings(
+            TReadReplicasSettings::EMode::PerAz,
+            proto.per_az_read_replicas_count());
+    case Ydb::Table::ReadReplicasSettings::kAnyAzReadReplicasCount:
+        return TReadReplicasSettings(
+            TReadReplicasSettings::EMode::AnyAz,
+            proto.any_az_read_replicas_count());
+    default:
+        return { };
+    }
+}
+
+void TReadReplicasSettings::SerializeTo(Ydb::Table::ReadReplicasSettings& proto) const {
+    switch (GetMode()) {
+    case TReadReplicasSettings::EMode::PerAz:
+        proto.set_per_az_read_replicas_count(GetReadReplicasCount());
+        break;
+    case TReadReplicasSettings::EMode::AnyAz:
+        proto.set_any_az_read_replicas_count(GetReadReplicasCount());
+        break;
+    default:
+        break;
+    }
+}
+
 TGlobalIndexSettings TGlobalIndexSettings::FromProto(const Ydb::Table::GlobalIndexSettings& proto) {
     auto partitionsFromProto = [](const Ydb::Table::GlobalIndexSettings& proto) -> TUniformOrExplicitPartitions {
         switch (proto.partitions_case()) {
@@ -2361,7 +2353,8 @@ TGlobalIndexSettings TGlobalIndexSettings::FromProto(const Ydb::Table::GlobalInd
 
     return {
         .PartitioningSettings = TPartitioningSettings(proto.partitioning_settings()),
-        .Partitions = partitionsFromProto(proto)
+        .Partitions = partitionsFromProto(proto),
+        .ReadReplicasSettings = TReadReplicasSettings::FromProto(proto.read_replicas_settings())
     };
 }
 
@@ -2377,6 +2370,10 @@ void TGlobalIndexSettings::SerializeTo(Ydb::Table::GlobalIndexSettings& settings
         }
     };
     std::visit(std::move(variantVisitor), Partitions);
+
+    if (ReadReplicasSettings) {
+        ReadReplicasSettings->SerializeTo(*settings.mutable_read_replicas_settings());
+    }
 }
 
 TVectorIndexSettings TVectorIndexSettings::FromProto(const Ydb::Table::VectorIndexSettings& proto) {

--- a/ydb/public/sdk/cpp/client/ydb_table/table.h
+++ b/ydb/public/sdk/cpp/client/ydb_table/table.h
@@ -30,6 +30,7 @@ class GlobalIndexSettings;
 class VectorIndexSettings;
 class KMeansTreeSettings;
 class PartitioningSettings;
+class ReadReplicasSettings;
 class DateTypeColumnModeSettings;
 class TtlSettings;
 class TtlTier;
@@ -194,11 +195,33 @@ struct TExplicitPartitions {
     void SerializeTo(Ydb::Table::ExplicitPartitions& proto) const;
 };
 
+//! Represents table read replicas settings
+class TReadReplicasSettings {
+public:
+    enum class EMode {
+        PerAz = 0,
+        AnyAz = 1
+    };
+
+    TReadReplicasSettings(EMode mode, ui64 readReplicasCount);
+
+    EMode GetMode() const;
+    ui64 GetReadReplicasCount() const;
+
+    static TMaybe<TReadReplicasSettings> FromProto(const Ydb::Table::ReadReplicasSettings& proto);
+    void SerializeTo(Ydb::Table::ReadReplicasSettings& proto) const;
+
+private:
+    EMode Mode_;
+    ui64 ReadReplicasCount_;
+};
+
 struct TGlobalIndexSettings {
     using TUniformOrExplicitPartitions = std::variant<std::monostate, ui64, TExplicitPartitions>;
 
     TPartitioningSettings PartitioningSettings;
     TUniformOrExplicitPartitions Partitions;
+    TMaybe<TReadReplicasSettings> ReadReplicasSettings;
 
     static TGlobalIndexSettings FromProto(const Ydb::Table::GlobalIndexSettings& proto);
     void SerializeTo(Ydb::Table::GlobalIndexSettings& proto) const;
@@ -620,24 +643,6 @@ public:
 private:
     class TImpl;
     std::shared_ptr<TImpl> Impl_;
-};
-
-//! Represents table read replicas settings
-class TReadReplicasSettings {
-public:
-    enum class EMode {
-        PerAz = 0,
-        AnyAz = 1
-    };
-
-    TReadReplicasSettings(EMode mode, ui64 readReplicasCount);
-
-    EMode GetMode() const;
-    ui64 GetReadReplicasCount() const;
-
-private:
-    EMode Mode_;
-    ui64 ReadReplicasCount_;
 };
 
 struct TExplicitPartitions;

--- a/ydb/public/sdk/cpp/include/ydb-cpp-sdk/client/table/table.h
+++ b/ydb/public/sdk/cpp/include/ydb-cpp-sdk/client/table/table.h
@@ -30,6 +30,7 @@ class GlobalIndexSettings;
 class VectorIndexSettings;
 class KMeansTreeSettings;
 class PartitioningSettings;
+class ReadReplicasSettings;
 class DateTypeColumnModeSettings;
 class TtlSettings;
 class TtlTier;
@@ -199,11 +200,33 @@ struct TExplicitPartitions {
     void SerializeTo(Ydb::Table::ExplicitPartitions& proto) const;
 };
 
+//! Represents table read replicas settings
+class TReadReplicasSettings {
+public:
+    enum class EMode {
+        PerAz = 0,
+        AnyAz = 1
+    };
+
+    TReadReplicasSettings(EMode mode, uint64_t readReplicasCount);
+
+    EMode GetMode() const;
+    uint64_t GetReadReplicasCount() const;
+
+    static std::optional<TReadReplicasSettings> FromProto(const Ydb::Table::ReadReplicasSettings& proto);
+    void SerializeTo(Ydb::Table::ReadReplicasSettings& proto) const;
+
+private:
+    EMode Mode_;
+    uint64_t ReadReplicasCount_;
+};
+
 struct TGlobalIndexSettings {
     using TUniformOrExplicitPartitions = std::variant<std::monostate, uint64_t, TExplicitPartitions>;
 
     TPartitioningSettings PartitioningSettings;
     TUniformOrExplicitPartitions Partitions;
+    std::optional<TReadReplicasSettings> ReadReplicasSettings;
 
     static TGlobalIndexSettings FromProto(const Ydb::Table::GlobalIndexSettings& proto);
 
@@ -627,24 +650,6 @@ public:
 private:
     class TImpl;
     std::shared_ptr<TImpl> Impl_;
-};
-
-//! Represents table read replicas settings
-class TReadReplicasSettings {
-public:
-    enum class EMode {
-        PerAz = 0,
-        AnyAz = 1
-    };
-
-    TReadReplicasSettings(EMode mode, uint64_t readReplicasCount);
-
-    EMode GetMode() const;
-    uint64_t GetReadReplicasCount() const;
-
-private:
-    EMode Mode_;
-    uint64_t ReadReplicasCount_;
 };
 
 enum class EStoreType {

--- a/ydb/public/sdk/cpp/src/client/table/table.cpp
+++ b/ydb/public/sdk/cpp/src/client/table/table.cpp
@@ -359,23 +359,7 @@ class TTableDescription::TImpl {
         }
 
         // read replicas settings
-        if (proto.has_read_replicas_settings()) {
-            const auto settings = proto.read_replicas_settings();
-            switch (settings.settings_case()) {
-            case Ydb::Table::ReadReplicasSettings::kPerAzReadReplicasCount:
-                ReadReplicasSettings_ = TReadReplicasSettings(
-                    TReadReplicasSettings::EMode::PerAz,
-                    settings.per_az_read_replicas_count());
-                break;
-            case Ydb::Table::ReadReplicasSettings::kAnyAzReadReplicasCount:
-                ReadReplicasSettings_ = TReadReplicasSettings(
-                    TReadReplicasSettings::EMode::AnyAz,
-                    settings.any_az_read_replicas_count());
-                break;
-            default:
-                break;
-            }
-        }
+        ReadReplicasSettings_ = TReadReplicasSettings::FromProto(proto.read_replicas_settings());
     }
 
 public:
@@ -973,16 +957,7 @@ void TTableDescription::SerializeTo(Ydb::Table::CreateTableRequest& request) con
     }
 
     if (const auto& settings = Impl_->GetReadReplicasSettings()) {
-        switch (settings->GetMode()) {
-        case TReadReplicasSettings::EMode::PerAz:
-            request.mutable_read_replicas_settings()->set_per_az_read_replicas_count(settings->GetReadReplicasCount());
-            break;
-        case TReadReplicasSettings::EMode::AnyAz:
-            request.mutable_read_replicas_settings()->set_any_az_read_replicas_count(settings->GetReadReplicasCount());
-            break;
-        default:
-            break;
-        }
+        settings->SerializeTo(*request.mutable_read_replicas_settings());
     }
 }
 
@@ -1745,18 +1720,7 @@ static Ydb::Table::AlterTableRequest MakeAlterTableProtoRequest(
 
     if (settings.SetReadReplicasSettings_.has_value()) {
         const auto& replSettings = settings.SetReadReplicasSettings_.value();
-        switch (replSettings.GetMode()) {
-        case TReadReplicasSettings::EMode::PerAz:
-            request.mutable_set_read_replicas_settings()->set_per_az_read_replicas_count(
-                replSettings.GetReadReplicasCount());
-            break;
-        case TReadReplicasSettings::EMode::AnyAz:
-            request.mutable_set_read_replicas_settings()->set_any_az_read_replicas_count(
-                replSettings.GetReadReplicasCount());
-            break;
-        default:
-            break;
-        }
+        replSettings.SerializeTo(*request.mutable_set_read_replicas_settings());
     }
 
     return request;
@@ -2356,6 +2320,34 @@ uint64_t TIndexDescription::GetSizeBytes() const {
     return SizeBytes_;
 }
 
+std::optional<TReadReplicasSettings> TReadReplicasSettings::FromProto(const Ydb::Table::ReadReplicasSettings& proto) {
+    switch (proto.settings_case()) {
+    case Ydb::Table::ReadReplicasSettings::kPerAzReadReplicasCount:
+        return TReadReplicasSettings(
+            TReadReplicasSettings::EMode::PerAz,
+            proto.per_az_read_replicas_count());
+    case Ydb::Table::ReadReplicasSettings::kAnyAzReadReplicasCount:
+        return TReadReplicasSettings(
+            TReadReplicasSettings::EMode::AnyAz,
+            proto.any_az_read_replicas_count());
+    default:
+        return { };
+    }
+}
+
+void TReadReplicasSettings::SerializeTo(Ydb::Table::ReadReplicasSettings& proto) const {
+    switch (GetMode()) {
+    case TReadReplicasSettings::EMode::PerAz:
+        proto.set_per_az_read_replicas_count(GetReadReplicasCount());
+        break;
+    case TReadReplicasSettings::EMode::AnyAz:
+        proto.set_any_az_read_replicas_count(GetReadReplicasCount());
+        break;
+    default:
+        break;
+    }
+}
+
 TGlobalIndexSettings TGlobalIndexSettings::FromProto(const Ydb::Table::GlobalIndexSettings& proto) {
     auto partitionsFromProto = [](const Ydb::Table::GlobalIndexSettings& proto) -> TUniformOrExplicitPartitions {
         switch (proto.partitions_case()) {
@@ -2370,7 +2362,8 @@ TGlobalIndexSettings TGlobalIndexSettings::FromProto(const Ydb::Table::GlobalInd
 
     return {
         .PartitioningSettings = TPartitioningSettings(proto.partitioning_settings()),
-        .Partitions = partitionsFromProto(proto)
+        .Partitions = partitionsFromProto(proto),
+        .ReadReplicasSettings = TReadReplicasSettings::FromProto(proto.read_replicas_settings())
     };
 }
 
@@ -2386,6 +2379,10 @@ void TGlobalIndexSettings::SerializeTo(Ydb::Table::GlobalIndexSettings& settings
         }
     };
     std::visit(std::move(variantVisitor), Partitions);
+
+    if (ReadReplicasSettings) {
+        ReadReplicasSettings->SerializeTo(*settings.mutable_read_replicas_settings());
+    }
 }
 
 TVectorIndexSettings TVectorIndexSettings::FromProto(const Ydb::Table::VectorIndexSettings& proto) {


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

Add ability to enable followers (read replicas) for covered secondary indexes

### Changelog category <!-- remove all except one -->

* New feature

### Description for reviewers <!-- (optional) description for those who read this PR -->

KIKIMR-21403
