### PR TITLE
[stable-25-1-1] start kafka port by default in local ydb (#19194)

### DIFF
--- a/.github/docker/Dockerfile
+++ b/.github/docker/Dockerfile
@@ -44,6 +44,7 @@ COPY --from=builder \
 EXPOSE ${GRPC_TLS_PORT:-2135}
 EXPOSE ${GRPC_PORT:-2136}
 EXPOSE ${MON_PORT:-8765}
+EXPOSE ${YDB_KAFKA_PROXY_PORT:-9092}
 
 HEALTHCHECK --start-period=60s --interval=1s CMD sh ./health_check
 

--- a/.github/docker/files/initialize_local_ydb
+++ b/.github/docker/files/initialize_local_ydb
@@ -7,6 +7,7 @@ export YDB_GRPC_ENABLE_TLS="true"
 export GRPC_TLS_PORT=${GRPC_TLS_PORT:-2135}
 export GRPC_PORT=${GRPC_PORT:-2136}
 export YDB_GRPC_TLS_DATA_PATH="/ydb_certs"
+export YDB_KAFKA_PROXY_PORT=${YDB_KAFKA_PROXY_PORT:-9092}
 
 # Start local_ydb tool. Pass additional arguments for local_ydb
 /local_ydb deploy --ydb-working-dir /ydb_data --ydb-binary-path /ydbd --fixed-ports --dont-use-log-files "$@";


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

Enable kafka port in local-ydb docker container

### Changelog category <!-- remove all except one -->

* Improvement

### Description for reviewers <!-- (optional) description for those who read this PR -->

https://github.com/ydb-platform/ydb/issues/11005

cherry-pick:
- a412b1e937e4268eff149538f919a074617b00c0
