### PR TITLE
Drop langver argument from TFunctionTypeInfoBuilder ctor

### DIFF
--- a/yql/essentials/minikql/comp_nodes/ut/mkql_udf_ut.cpp
+++ b/yql/essentials/minikql/comp_nodes/ut/mkql_udf_ut.cpp
@@ -16,8 +16,7 @@ template<typename TUdf>
 static TType* TweakUdfType(const NYql::NUdf::TStringRef& name, TType* userType,
                            const TTypeEnvironment& env)
 {
-    TFunctionTypeInfoBuilder typeInfoBuilder(NYql::UnknownLangVersion, env,
-                                             new TTypeInfoHelper(),
+    TFunctionTypeInfoBuilder typeInfoBuilder(env, new TTypeInfoHelper(),
                                              "", nullptr, {});
 
     // Obtain the callable type of the particular UDF.


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

Drop excess langver argument from `TFunctionTypeInfoBuilder` ctor in mkql_udf_ut.cpp.

### Changelog category <!-- remove all except one -->

* Bugfix

### Description for reviewers <!-- (optional) description for those who read this PR -->

Follows up #18954
