### PR TITLE
Use `/tmp` for temporary files when download binary by ydbd_slice instead `/home`

### DIFF
--- a/ydb/tools/ydbd_slice/nodes.py
+++ b/ydb/tools/ydbd_slice/nodes.py
@@ -170,7 +170,7 @@ class Nodes(object):
 
     def _download_sky(self, url, remote_path):
         self._logger.info(f"download from '{url}' to '{remote_path}'")
-        tmp_path = url.split(":")[-1]
+        tmp_path = f'/tmp/{url.split(":")[-1]}'
         script = (
             f'sky get -wu -d {tmp_path} {url} && '
             f'for FILE in `find {tmp_path} -name *.tgz -or -name *.tar`; do tar -C {tmp_path} -xf $FILE && rm $FILE; done && '
@@ -182,7 +182,7 @@ class Nodes(object):
     def _download_script(self, script, remote_path):
         user_script = script[len('script:'):]
         self._logger.info(f"download by script '{user_script}' to '{remote_path}'")
-        tmp_path = f'tmp_{random.randint(0, 100500)}'
+        tmp_path = f'/tmp/script_download_{random.randint(0, 100500)}'
         full_script = (
             f'mkdir -p {tmp_path} && cd {tmp_path} && '
             f'( {user_script} ) && cd - && '

--- a/ydb/tools/ydbd_slice/nodes.py
+++ b/ydb/tools/ydbd_slice/nodes.py
@@ -170,7 +170,7 @@ class Nodes(object):
 
     def _download_sky(self, url, remote_path):
         self._logger.info(f"download from '{url}' to '{remote_path}'")
-        tmp_path = f'/tmp/{url.split(":")[-1]}'
+        tmp_path = f'/tmp/sky_download_{url.split(":")[-1]}'
         script = (
             f'sky get -wu -d {tmp_path} {url} && '
             f'for FILE in `find {tmp_path} -name *.tgz -or -name *.tar`; do tar -C {tmp_path} -xf $FILE && rm $FILE; done && '


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

...

### Changelog category <!-- remove all except one -->

* Not for changelog (changelog entry is not required)

### Description for reviewers <!-- (optional) description for those who read this PR -->

Because `/home/robot-ydb` is not accessible to write to `robot-ydb` by default.
