### PR TITLE
Make legacy signatures for Digest UDF strict again

### DIFF
--- a/yql/essentials/udfs/common/digest/digest_udf.cpp
+++ b/yql/essentials/udfs/common/digest/digest_udf.cpp
@@ -64,6 +64,7 @@ namespace {
             // See YQL-19967 for more info.
             if (MKQL_RUNTIME_VERSION < 51U && typesOnly) {
                 builder.SimpleSignature<TResult(TAutoMap<char*>)>();
+                builder.IsStrict();
                 return true;
             }
 


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

Make legacy signatures for Digest UDF strict again (follows up f97455e).

### Changelog category <!-- remove all except one -->

* Bugfix 

### Description for reviewers <!-- (optional) description for those who read this PR -->

Follows up #18873
