### PR TITLE
initial commit: DqHashCombine, DqHashAggregate

### DIFF
--- a/ydb/core/kqp/runtime/kqp_program_builder.cpp
+++ b/ydb/core/kqp/runtime/kqp_program_builder.cpp
@@ -149,7 +149,7 @@ bool RightJoinSideOptional(const TString& joinType) {
 } // namespace
 
 TKqpProgramBuilder::TKqpProgramBuilder(const TTypeEnvironment& env, const IFunctionRegistry& functionRegistry)
-    : TProgramBuilder(env, functionRegistry) {}
+    : TDqProgramBuilder(env, functionRegistry) {}
 
 TRuntimeNode TKqpProgramBuilder::KqpWideReadTable(const TTableId& tableId, const TKqpKeyRange& range,
     const TArrayRef<TKqpTableColumn>& columns)

--- a/ydb/core/kqp/runtime/kqp_program_builder.h
+++ b/ydb/core/kqp/runtime/kqp_program_builder.h
@@ -2,7 +2,7 @@
 
 #include <ydb/core/scheme_types/scheme_type_info.h>
 
-#include <yql/essentials/minikql/mkql_program_builder.h>
+#include <ydb/library/yql/dq/comp_nodes/dq_program_builder.h>
 
 namespace NKikimr {
 
@@ -44,7 +44,7 @@ struct TKqpKeyRanges {
     bool Reverse = false;
 };
 
-class TKqpProgramBuilder: public TProgramBuilder {
+class TKqpProgramBuilder: public TDqProgramBuilder {
 public:
     TKqpProgramBuilder(const TTypeEnvironment& env, const IFunctionRegistry& functionRegistry);
 

--- a/ydb/core/kqp/tools/combiner_perf/factories.cpp
+++ b/ydb/core/kqp/tools/combiner_perf/factories.cpp
@@ -1,14 +1,22 @@
 #include "factories.h"
 
 #include <yql/essentials/minikql/computation/mkql_computation_node_impl.h>
+#include <ydb/library/yql/dq/comp_nodes/dq_hash_combine.h>
+#include <ydb/library/yql/dq/comp_nodes/dq_hash_aggregate.h>
 
 namespace NKikimr {
 namespace NMiniKQL {
 
 TComputationNodeFactory GetPerfTestFactory(TComputationNodeFactory customFactory) {
     return [customFactory](TCallable& callable, const TComputationNodeFactoryContext& ctx) -> IComputationNode* {
-        if (callable.GetType()->GetName() == "TestList") {
+        if (callable.GetType()->GetName() == "TestList"sv) {
             return new TExternalComputationNode(ctx.Mutables);
+        }
+        else if (callable.GetType()->GetName() == "DqHashCombine"sv) {
+            return WrapDqHashCombine(callable, ctx);
+        }
+        else if (callable.GetType()->GetName() == "DqHashAggregate"sv) {
+            return WrapDqHashAggregate(callable, ctx);
         }
 
         return GetBuiltinFactory()(callable, ctx);

--- a/ydb/core/kqp/tools/combiner_perf/kqp_setup.h
+++ b/ydb/core/kqp/tools/combiner_perf/kqp_setup.h
@@ -1,0 +1,27 @@
+#include "factories.h"
+
+#include <ydb/core/kqp/runtime/kqp_program_builder.h>
+
+#include <yql/essentials/minikql/comp_nodes/ut/mkql_computation_node_ut.h>
+
+
+namespace NKikimr {
+namespace NMiniKQL {
+
+template<bool LLVM, bool Spilling = false>
+struct TKqpSetup: public TSetup<LLVM, Spilling>
+{
+    explicit TKqpSetup(TComputationNodeFactory nodeFactory = GetPerfTestFactory(), TVector<TUdfModuleInfo>&& modules = {})
+        : TSetup<LLVM, Spilling>(nodeFactory, std::move(modules))
+    {
+        this->PgmBuilder = MakeHolder<TKqpProgramBuilder>(*this->Env, *this->FunctionRegistry);
+    }
+
+    TKqpProgramBuilder& GetKqpBuilder()
+    {
+        return static_cast<TKqpProgramBuilder&>(*this->PgmBuilder);
+    }
+};
+
+}
+}

--- a/ydb/core/kqp/tools/combiner_perf/simple.cpp
+++ b/ydb/core/kqp/tools/combiner_perf/simple.cpp
@@ -4,6 +4,7 @@
 #include "streams.h"
 #include "printout.h"
 #include "subprocess.h"
+#include "kqp_setup.h"
 
 #include <yql/essentials/minikql/comp_nodes/ut/mkql_computation_node_ut.h>
 #include <yql/essentials/minikql/computation/mkql_computation_node_holders.h>
@@ -22,9 +23,9 @@ namespace NMiniKQL {
 namespace {
 
 template<bool LLVM>
-THolder<IComputationGraph> BuildGraph(TSetup<LLVM>& setup, IDataSampler& sampler, size_t memLimit)
+THolder<IComputationGraph> BuildGraph(TKqpSetup<LLVM>& setup, IDataSampler& sampler, size_t memLimit)
 {
-    TProgramBuilder& pb = *setup.PgmBuilder;
+    TKqpProgramBuilder& pb = setup.GetKqpBuilder();
 
     const auto streamItemType = pb.NewMultiType({sampler.GetKeyType(pb), pb.NewDataType(NUdf::TDataType<ui64>::Id)});
     const auto streamType = pb.NewStreamType(streamItemType);
@@ -52,7 +53,7 @@ THolder<IComputationGraph> BuildGraph(TSetup<LLVM>& setup, IDataSampler& sampler
 template<bool LLVM>
 TRunResult RunTestOverGraph(const TRunParams& params, const bool needsVerification, const bool measureReferenceMemory)
 {
-    TSetup<LLVM> setup(GetPerfTestFactory());
+    TKqpSetup<LLVM> setup(GetPerfTestFactory());
 
     NYql::NLog::InitLogger("cerr", false);
 

--- a/ydb/core/kqp/tools/combiner_perf/simple_last.cpp
+++ b/ydb/core/kqp/tools/combiner_perf/simple_last.cpp
@@ -5,6 +5,7 @@
 #include "streams.h"
 #include "printout.h"
 #include "preallocated_spiller.h"
+#include "kqp_setup.h"
 
 #include <yql/essentials/minikql/comp_nodes/ut/mkql_computation_node_ut.h>
 #include <yql/essentials/minikql/computation/mkql_computation_node_holders.h>
@@ -36,9 +37,9 @@ TDuration MeasureGeneratorTime(IComputationGraph& graph, const IDataSampler& sam
 }
 
 template<bool LLVM, bool Spilling>
-THolder<IComputationGraph> BuildGraph(TSetup<LLVM, Spilling>& setup, std::shared_ptr<ISpillerFactory> spillerFactory, IDataSampler& sampler)
+THolder<IComputationGraph> BuildGraph(TKqpSetup<LLVM, Spilling>& setup, std::shared_ptr<ISpillerFactory> spillerFactory, IDataSampler& sampler)
 {
-    TProgramBuilder& pb = *setup.PgmBuilder;
+    TKqpProgramBuilder& pb = setup.GetKqpBuilder();
 
     const auto streamItemType = pb.NewMultiType({sampler.GetKeyType(pb), pb.NewDataType(NUdf::TDataType<ui64>::Id)});
     const auto streamType = pb.NewStreamType(streamItemType);
@@ -76,7 +77,7 @@ THolder<IComputationGraph> BuildGraph(TSetup<LLVM, Spilling>& setup, std::shared
 template<bool LLVM, bool Spilling>
 TRunResult RunTestOverGraph(const TRunParams& params, const bool needsVerification, const bool measureReferenceMemory)
 {
-    TSetup<LLVM, Spilling> setup(GetPerfTestFactory());
+    TKqpSetup<LLVM, Spilling> setup(GetPerfTestFactory());
 
     NYql::NLog::InitLogger("cerr", false);
 

--- a/ydb/core/kqp/tools/combiner_perf/ya.make
+++ b/ydb/core/kqp/tools/combiner_perf/ya.make
@@ -21,6 +21,10 @@ PEERDIR(
 
     library/cpp/testing/unittest
 
+    ydb/core/kqp/runtime
+
+    ydb/library/yql/dq/comp_nodes
+
     contrib/libs/llvm16/lib/IR
     contrib/libs/llvm16/lib/ExecutionEngine/MCJIT
     contrib/libs/llvm16/lib/Linker

--- a/ydb/library/yql/dq/comp_nodes/dq_hash_aggregate.cpp
+++ b/ydb/library/yql/dq/comp_nodes/dq_hash_aggregate.cpp
@@ -1,0 +1,93 @@
+#include "dq_hash_aggregate.h"
+#include "dq_hash_operator_common.h"
+#include "dq_hash_operator_serdes.h"
+
+#include <yql/essentials/minikql/computation/mkql_computation_node.h>
+#include <yql/essentials/minikql/mkql_node_builder.h>
+#include <yql/essentials/minikql/mkql_node_cast.h>
+#include <yql/essentials/minikql/defs.h>
+
+namespace NKikimr {
+namespace NMiniKQL {
+
+namespace {
+
+
+class TDqHashAggregate: public TStatefulWideFlowComputationNode<TDqHashAggregate>
+{
+using TBaseComputation = TStatefulWideFlowComputationNode<TDqHashAggregate>;
+public:
+    TDqHashAggregate(
+        TComputationMutables& mutables,
+        IComputationWideFlowNode* flow,
+        NDqHashOperatorCommon::TCombinerNodes&& nodes,
+        const TMultiType* usedInputItemType,
+        TKeyTypes&& keyTypes,
+        const TMultiType* keyAndStateType,
+        bool allowSpilling)
+        : TBaseComputation(mutables, flow, EValueRepresentation::Boxed)
+        , Flow(flow)
+        , Nodes(std::move(nodes))
+        , KeyTypes(std::move(keyTypes))
+        , UsedInputItemType(usedInputItemType)
+        , KeyAndStateType(keyAndStateType)
+        , WideFieldsIndex(mutables.IncrementWideFieldsIndex(Nodes.ItemNodes.size()))
+        , AllowSpilling(allowSpilling)
+    {
+        Y_UNUSED(AllowSpilling, UsedInputItemType, KeyAndStateType);
+    }
+
+    EFetchResult DoCalculate(NUdf::TUnboxedValue& state, TComputationContext& ctx, NUdf::TUnboxedValue*const* output) const {
+        Y_UNUSED(state, ctx, output);
+        THROW yexception() << "Not implemented yet";
+    }
+
+private:
+    void RegisterDependencies() const final {
+        if (const auto flow = this->FlowDependsOn(Flow)) {
+            Nodes.RegisterDependencies(
+                [this, flow](IComputationNode* node){ this->DependsOn(flow, node); },
+                [this, flow](IComputationExternalNode* node){ this->Own(flow, node); }
+            );
+        }
+    }
+
+    IComputationWideFlowNode *const Flow;
+    const NDqHashOperatorCommon::TCombinerNodes Nodes;
+    const TKeyTypes KeyTypes;
+
+    const TMultiType* const UsedInputItemType;
+    const TMultiType* const KeyAndStateType;
+
+    const ui32 WideFieldsIndex;
+
+    const bool AllowSpilling;
+};
+
+}
+
+IComputationNode* WrapDqHashAggregate(TCallable& callable, const TComputationNodeFactoryContext& ctx) {
+    TDqHashOperatorParams params = ParseCommonDqHashOperatorParams(callable, ctx);
+
+    const auto flow = LocateNode(ctx.NodeLocator, callable, NDqHashOperatorParams::Flow);
+    auto* wideFlow = dynamic_cast<IComputationWideFlowNode*>(flow);
+    if (!wideFlow) {
+        THROW yexception() << "Expected wide flow.";
+    };
+
+    const TTupleLiteral* operatorParams = AS_VALUE(TTupleLiteral, callable.GetInput(NDqHashOperatorParams::OperatorParams));
+    const bool allowSpilling = AS_VALUE(TDataLiteral, operatorParams->GetValue(NDqHashOperatorParams::AggregateParamEnableSpilling))->AsValue().Get<bool>();
+
+    const auto inputType = AS_TYPE(TFlowType, callable.GetInput(NDqHashOperatorParams::Flow).GetStaticType());
+    const auto inputItemTypes = GetWideComponents(inputType);
+
+    return new TDqHashAggregate(ctx.Mutables, wideFlow, std::move(params.Nodes),
+        TMultiType::Create(inputItemTypes.size(), inputItemTypes.data(), ctx.Env),
+        std::move(params.KeyTypes),
+        TMultiType::Create(params.KeyAndStateItemTypes.size(),params.KeyAndStateItemTypes.data(), ctx.Env),
+        allowSpilling
+    );
+}
+
+}
+}

--- a/ydb/library/yql/dq/comp_nodes/dq_hash_aggregate.h
+++ b/ydb/library/yql/dq/comp_nodes/dq_hash_aggregate.h
@@ -1,0 +1,11 @@
+#pragma once
+
+#include <ydb/library/yql/dq/runtime/dq_compute.h>
+
+namespace NKikimr {
+namespace NMiniKQL {
+
+IComputationNode* WrapDqHashAggregate(TCallable& callable, const TComputationNodeFactoryContext& ctx);
+
+} // namespace NMiniKQL
+} // namespace NKikimr

--- a/ydb/library/yql/dq/comp_nodes/dq_hash_combine.cpp
+++ b/ydb/library/yql/dq/comp_nodes/dq_hash_combine.cpp
@@ -1,0 +1,67 @@
+#include "dq_hash_combine.h"
+#include "dq_hash_operator_common.h"
+#include "dq_hash_operator_serdes.h"
+
+#include <yql/essentials/minikql/computation/mkql_computation_node.h>
+#include <yql/essentials/minikql/mkql_node_builder.h>
+#include <yql/essentials/minikql/mkql_node_cast.h>
+#include <yql/essentials/minikql/defs.h>
+
+namespace NKikimr {
+namespace NMiniKQL {
+
+class TDqHashCombine: public TStatefulWideFlowComputationNode<TDqHashCombine>
+{
+using TBaseComputation = TStatefulWideFlowComputationNode<TDqHashCombine>;
+public:
+    TDqHashCombine(TComputationMutables& mutables, IComputationWideFlowNode* flow, NDqHashOperatorCommon::TCombinerNodes&& nodes, TKeyTypes&& keyTypes, ui64 memLimit)
+        : TBaseComputation(mutables, flow, EValueRepresentation::Boxed)
+        , Flow(flow)
+        , Nodes(std::move(nodes))
+        , KeyTypes(std::move(keyTypes))
+        , MemLimit(memLimit)
+        , WideFieldsIndex(mutables.IncrementWideFieldsIndex(Nodes.ItemNodes.size()))
+    {
+        Y_UNUSED(MemLimit);
+    }
+
+    EFetchResult DoCalculate(NUdf::TUnboxedValue& state, TComputationContext& ctx, NUdf::TUnboxedValue* const* output) const {
+        Y_UNUSED(state, ctx, output);
+        THROW yexception() << "Not implemented yet";
+    }
+private:
+    void RegisterDependencies() const final {
+        if (const auto flow = this->FlowDependsOn(Flow)) {
+            Nodes.RegisterDependencies(
+                [this, flow](IComputationNode* node){ this->DependsOn(flow, node); },
+                [this, flow](IComputationExternalNode* node){ this->Own(flow, node); }
+            );
+        }
+    }
+
+    IComputationWideFlowNode *const Flow;
+    const NDqHashOperatorCommon::TCombinerNodes Nodes;
+    const TKeyTypes KeyTypes;
+    const ui64 MemLimit;
+
+    const ui32 WideFieldsIndex;
+};
+
+IComputationNode* WrapDqHashCombine(TCallable& callable, const TComputationNodeFactoryContext& ctx) {
+    TDqHashOperatorParams params = ParseCommonDqHashOperatorParams(callable, ctx);
+
+    const auto flow = LocateNode(ctx.NodeLocator, callable, NDqHashOperatorParams::Flow);
+
+    auto* wideFlow = dynamic_cast<IComputationWideFlowNode*>(flow);
+    if (!wideFlow) {
+        THROW yexception() << "Expected wide flow.";
+    };
+
+    const TTupleLiteral* operatorParams = AS_VALUE(TTupleLiteral, callable.GetInput(NDqHashOperatorParams::OperatorParams));
+    const auto memLimit = AS_VALUE(TDataLiteral, operatorParams->GetValue(NDqHashOperatorParams::CombineParamMemLimit))->AsValue().Get<ui64>();
+
+    return new TDqHashCombine(ctx.Mutables, wideFlow, std::move(params.Nodes), std::move(params.KeyTypes), ui64(memLimit));
+}
+
+}
+}

--- a/ydb/library/yql/dq/comp_nodes/dq_hash_combine.h
+++ b/ydb/library/yql/dq/comp_nodes/dq_hash_combine.h
@@ -1,0 +1,11 @@
+#pragma once
+
+#include <ydb/library/yql/dq/runtime/dq_compute.h>
+
+namespace NKikimr {
+namespace NMiniKQL {
+
+IComputationNode* WrapDqHashCombine(TCallable& callable, const TComputationNodeFactoryContext& ctx);
+
+} // namespace NMiniKQL
+} // namespace NKikimr

--- a/ydb/library/yql/dq/comp_nodes/dq_hash_operator_common.cpp
+++ b/ydb/library/yql/dq/comp_nodes/dq_hash_operator_common.cpp
@@ -1,0 +1,12 @@
+#include "dq_hash_operator_common.h"
+
+namespace NKikimr {
+namespace NMiniKQL {
+namespace NDqHashOperatorCommon {
+
+TStatKey DqHashCombine_FlushesCount("DqHashCombine_FlushesCount", true);
+TStatKey DqHashCombine_MaxRowsCount("DqHashCombine_MaxRowsCount", false);
+
+}
+}
+}

--- a/ydb/library/yql/dq/comp_nodes/dq_hash_operator_common.h
+++ b/ydb/library/yql/dq/comp_nodes/dq_hash_operator_common.h
@@ -1,0 +1,113 @@
+#pragma once
+
+#include <yql/essentials/minikql/computation/mkql_computation_node.h>
+#include <yql/essentials/minikql/computation/mkql_computation_node_holders.h>
+
+#include <yql/essentials/minikql/comp_nodes/mkql_rh_hash.h>
+
+#include <yql/essentials/minikql/mkql_node_builder.h>
+#include <yql/essentials/minikql/mkql_node.h>
+#include <yql/essentials/minikql/mkql_node_cast.h>
+#include <yql/essentials/minikql/defs.h>
+
+namespace NKikimr {
+namespace NMiniKQL {
+namespace NDqHashOperatorCommon {
+
+extern TStatKey DqHashCombine_FlushesCount;
+extern TStatKey DqHashCombine_MaxRowsCount;
+
+using TDependsOn = std::function<void(IComputationNode*)>;
+using TOwn = std::function<void(IComputationExternalNode*)>;
+
+struct TCombinerNodes {
+    TComputationExternalNodePtrVector ItemNodes, KeyNodes, StateNodes, FinishNodes;
+    TComputationNodePtrVector KeyResultNodes, InitResultNodes, UpdateResultNodes, FinishResultNodes;
+
+    std::vector<bool> PasstroughtItems;
+
+    void BuildMaps() {
+        PasstroughtItems.resize(ItemNodes.size());
+        auto anyResults = KeyResultNodes;
+        anyResults.insert(anyResults.cend(), InitResultNodes.cbegin(), InitResultNodes.cend());
+        anyResults.insert(anyResults.cend(), UpdateResultNodes.cbegin(), UpdateResultNodes.cend());
+        const auto itemsOnResults = GetPasstroughtMap(ItemNodes, anyResults);
+        std::transform(itemsOnResults.cbegin(), itemsOnResults.cend(), PasstroughtItems.begin(), [](const TPasstroughtMap::value_type& v) { return v.has_value(); });
+    }
+
+    bool IsInputItemNodeUsed(size_t i) const {
+        return (ItemNodes[i]->GetDependencesCount() > 0U || PasstroughtItems[i]);
+    }
+
+    NUdf::TUnboxedValue* GetUsedInputItemNodePtrOrNull(TComputationContext& ctx, size_t i) const {
+        return IsInputItemNodeUsed(i) ?
+               &ItemNodes[i]->RefValue(ctx) :
+               nullptr;
+    }
+
+    void ExtractKey(TComputationContext& ctx, NUdf::TUnboxedValue** values, NUdf::TUnboxedValue* keys) const {
+        std::for_each(ItemNodes.cbegin(), ItemNodes.cend(), [&](IComputationExternalNode* item) {
+            if (const auto pointer = *values++)
+                item->SetValue(ctx, std::move(*pointer));
+        });
+        for (ui32 i = 0U; i < KeyNodes.size(); ++i) {
+            auto& key = KeyNodes[i]->RefValue(ctx);
+            *keys++ = key = KeyResultNodes[i]->GetValue(ctx);
+        }
+    }
+
+    void ConsumeRawData(TComputationContext& /*ctx*/, NUdf::TUnboxedValue* keys, NUdf::TUnboxedValue** from, NUdf::TUnboxedValue* to) const {
+        std::fill_n(keys, KeyResultNodes.size(), NUdf::TUnboxedValuePod());
+        for (ui32 i = 0U; i < ItemNodes.size(); ++i) {
+            if (from[i] && IsInputItemNodeUsed(i)) {
+                to[i] = std::move(*(from[i]));
+            }
+        }
+    }
+
+    void ExtractRawData(TComputationContext& ctx, NUdf::TUnboxedValue* from, NUdf::TUnboxedValue* keys) const {
+        for (ui32 i = 0U; i != ItemNodes.size(); ++i) {
+            if (IsInputItemNodeUsed(i)) {
+                ItemNodes[i]->SetValue(ctx, std::move(from[i]));
+            }
+        }
+        for (ui32 i = 0U; i < KeyNodes.size(); ++i) {
+            auto& key = KeyNodes[i]->RefValue(ctx);
+            *keys++ = key = KeyResultNodes[i]->GetValue(ctx);
+        }
+    }
+
+    void ProcessItem(TComputationContext& ctx, NUdf::TUnboxedValue* keys, NUdf::TUnboxedValue* state) const {
+        if (keys) {
+            std::fill_n(keys, KeyResultNodes.size(), NUdf::TUnboxedValuePod());
+            auto source = state;
+            std::for_each(StateNodes.cbegin(), StateNodes.cend(), [&](IComputationExternalNode* item){ item->SetValue(ctx, std::move(*source++)); });
+            std::transform(UpdateResultNodes.cbegin(), UpdateResultNodes.cend(), state, [&](IComputationNode* node) { return node->GetValue(ctx); });
+        } else {
+            std::transform(InitResultNodes.cbegin(), InitResultNodes.cend(), state, [&](IComputationNode* node) { return node->GetValue(ctx); });
+        }
+    }
+
+    void FinishItem(TComputationContext& ctx, NUdf::TUnboxedValue* state, NUdf::TUnboxedValue*const* output) const {
+        std::for_each(FinishNodes.cbegin(), FinishNodes.cend(), [&](IComputationExternalNode* item) { item->SetValue(ctx, std::move(*state++)); });
+        for (const auto node : FinishResultNodes)
+            if (const auto out = *output++)
+                *out = node->GetValue(ctx);
+    }
+
+    void RegisterDependencies(const TDependsOn& dependsOn, const TOwn& own) const {
+        std::for_each(ItemNodes.cbegin(), ItemNodes.cend(), own);
+        std::for_each(KeyNodes.cbegin(), KeyNodes.cend(), own);
+        std::for_each(StateNodes.cbegin(), StateNodes.cend(), own);
+        std::for_each(FinishNodes.cbegin(), FinishNodes.cend(), own);
+
+        std::for_each(KeyResultNodes.cbegin(), KeyResultNodes.cend(), dependsOn);
+        std::for_each(InitResultNodes.cbegin(), InitResultNodes.cend(), dependsOn);
+        std::for_each(UpdateResultNodes.cbegin(), UpdateResultNodes.cend(), dependsOn);
+        std::for_each(FinishResultNodes.cbegin(), FinishResultNodes.cend(), dependsOn);
+    }
+};
+
+}
+}
+}

--- a/ydb/library/yql/dq/comp_nodes/dq_hash_operator_serdes.cpp
+++ b/ydb/library/yql/dq/comp_nodes/dq_hash_operator_serdes.cpp
@@ -1,0 +1,73 @@
+#include "dq_hash_operator_serdes.h"
+
+namespace NKikimr {
+namespace NMiniKQL {
+
+using NDqHashOperatorCommon::IterateInputNodes;
+using NDqHashOperatorCommon::NodesFromInputTuple;
+using NDqHashOperatorCommon::ExternalNodesFromInputTuple;
+
+TDqHashOperatorParams ParseCommonDqHashOperatorParams(TCallable& callable, const TComputationNodeFactoryContext& ctx)
+{
+    MKQL_ENSURE(callable.GetInputsCount() >= 11U, "Expected more arguments.");
+
+    const auto inputType = AS_TYPE(TFlowType, callable.GetInput(NDqHashOperatorParams::Flow).GetStaticType());
+    const auto inputWidth = GetWideComponentsCount(inputType);
+    const auto outputWidth = GetWideComponentsCount(AS_TYPE(TFlowType, callable.GetType()->GetReturnType()));
+
+    const auto keysSize = AS_VALUE(TTupleLiteral, callable.GetInput(NDqHashOperatorParams::KeyArgs))->GetValuesCount();
+    const auto stateSize = AS_VALUE(TTupleLiteral, callable.GetInput(NDqHashOperatorParams::StateArgs))->GetValuesCount();
+
+    TDqHashOperatorParams result;
+
+    result.KeyTypes.reserve(keysSize);
+    result.KeyAndStateItemTypes.reserve(keysSize + stateSize);
+
+    // extract types of the getKey and getInitialState lambdas
+    IterateInputNodes(callable, NDqHashOperatorParams::GetKey, [&](TRuntimeNode rtNode) {
+        TType *type = rtNode.GetStaticType();
+        result.KeyAndStateItemTypes.push_back(type);
+        bool optional;
+        result.KeyTypes.emplace_back(*UnpackOptionalData(rtNode.GetStaticType(), optional)->GetDataSlot(), optional);
+    });
+    IterateInputNodes(callable, NDqHashOperatorParams::InitState, [&](TRuntimeNode rtNode) {
+        TType *type = rtNode.GetStaticType();
+        result.KeyAndStateItemTypes.push_back(type);
+    });
+
+    NDqHashOperatorCommon::TCombinerNodes& nodes = result.Nodes;
+
+    // extract result nodes of the all the input lambdas (getKey, initState, updateState, finish)
+    nodes.KeyResultNodes.reserve(keysSize);
+    NodesFromInputTuple(ctx, callable, NDqHashOperatorParams::GetKey, nodes.KeyResultNodes);
+
+    nodes.InitResultNodes.reserve(stateSize);
+    NodesFromInputTuple(ctx, callable, NDqHashOperatorParams::InitState, nodes.InitResultNodes);
+
+    nodes.UpdateResultNodes.reserve(stateSize);
+    NodesFromInputTuple(ctx, callable, NDqHashOperatorParams::UpdateState, nodes.UpdateResultNodes);
+
+    nodes.FinishResultNodes.reserve(outputWidth);
+    NodesFromInputTuple(ctx, callable, NDqHashOperatorParams::Finish, nodes.FinishResultNodes);
+
+    // extract arguments of the input lambdas (input row item args, key args, state args, keys+state arguments to the final output lambda)
+    nodes.KeyNodes.reserve(keysSize);
+    ExternalNodesFromInputTuple(ctx, callable, NDqHashOperatorParams::KeyArgs, nodes.KeyNodes);
+
+    nodes.StateNodes.reserve(stateSize);
+    ExternalNodesFromInputTuple(ctx, callable, NDqHashOperatorParams::StateArgs, nodes.StateNodes);
+
+    nodes.ItemNodes.reserve(inputWidth);
+    ExternalNodesFromInputTuple(ctx, callable, NDqHashOperatorParams::ItemArgs, nodes.ItemNodes);
+
+    nodes.FinishNodes.reserve(keysSize + stateSize);
+    ExternalNodesFromInputTuple(ctx, callable, NDqHashOperatorParams::FinishKeyArgs, nodes.FinishNodes);
+    ExternalNodesFromInputTuple(ctx, callable, NDqHashOperatorParams::FinishStateArgs, nodes.FinishNodes);
+
+    nodes.BuildMaps();
+
+    return result;
+}
+
+}
+}

--- a/ydb/library/yql/dq/comp_nodes/dq_hash_operator_serdes.h
+++ b/ydb/library/yql/dq/comp_nodes/dq_hash_operator_serdes.h
@@ -1,0 +1,89 @@
+#pragma once
+
+#include "dq_hash_operator_common.h"
+
+#include <yql/essentials/minikql/computation/mkql_computation_node.h>
+#include <yql/essentials/minikql/computation/mkql_computation_node_holders.h>
+
+#include <yql/essentials/minikql/mkql_node_builder.h>
+#include <yql/essentials/minikql/mkql_node.h>
+#include <yql/essentials/minikql/mkql_node_cast.h>
+#include <yql/essentials/minikql/defs.h>
+
+namespace NKikimr {
+namespace NMiniKQL {
+namespace NDqHashOperatorCommon {
+
+template<typename THandler>
+void IterateInputNodes(TCallable& callable, const ui32 inputIndex, THandler&& handler)
+{
+    auto rtNodeTuple = AS_VALUE(TTupleLiteral, callable.GetInput(inputIndex));
+    MKQL_ENSURE_S(rtNodeTuple != nullptr);
+    for (ui32 i = 0; i < rtNodeTuple->GetValuesCount(); ++i) {
+        handler(rtNodeTuple->GetValue(i));
+    }
+}
+
+template<typename TContainer>
+void NodesFromInputTuple(const TComputationNodeFactoryContext& ctx, TCallable& callable, const ui32 inputIndex, TContainer& container)
+{
+    IterateInputNodes(callable, inputIndex, [&](TRuntimeNode rtNode) {
+        auto nodePtr = rtNode.GetNode();
+        MKQL_ENSURE_S(nodePtr != nullptr);
+        auto locatedNode = ctx.NodeLocator(nodePtr, false);
+        MKQL_ENSURE_S(locatedNode != nullptr);
+        container.push_back(locatedNode);
+    });
+}
+
+template<typename TContainer>
+void ExternalNodesFromInputTuple(const TComputationNodeFactoryContext& ctx, TCallable& callable, const ui32 inputIndex, TContainer& container)
+{
+    IterateInputNodes(callable, inputIndex, [&](TRuntimeNode rtNode) {
+        auto nodePtr = rtNode.GetNode();
+        MKQL_ENSURE_S(nodePtr != nullptr);
+        auto locatedNode = dynamic_cast<IComputationExternalNode*>(ctx.NodeLocator(nodePtr, true));
+        MKQL_ENSURE_S(locatedNode != nullptr);
+        container.push_back(locatedNode);
+    });
+}
+
+} // namespace NDqHashOperatorCommon
+
+// Has to be consistent with TDqProgramBuilder::BuildCommonCombinerParams
+namespace NDqHashOperatorParams
+{
+    enum : ui32 {
+        Flow = 0,
+        OperatorParams = 1,
+        KeyArgs = 2,
+        StateArgs = 3,
+        ItemArgs = 4,
+        GetKey = 5,
+        InitState = 6,
+        UpdateState = 7,
+        FinishKeyArgs = 8,
+        FinishStateArgs = 9,
+        Finish = 10,
+    };
+
+    enum : ui32 {
+        CombineParamMemLimit = 0,
+    };
+
+    enum : ui32 {
+        AggregateParamEnableSpilling = 0,
+    };
+};
+
+struct TDqHashOperatorParams
+{
+    TKeyTypes KeyTypes;
+    std::vector<TType*> KeyAndStateItemTypes;
+    NDqHashOperatorCommon::TCombinerNodes Nodes;
+};
+
+TDqHashOperatorParams ParseCommonDqHashOperatorParams(TCallable& callable, const TComputationNodeFactoryContext& ctx);
+
+}
+}

--- a/ydb/library/yql/dq/comp_nodes/dq_program_builder.h
+++ b/ydb/library/yql/dq/comp_nodes/dq_program_builder.h
@@ -1,0 +1,27 @@
+#pragma once
+
+#include <yql/essentials/minikql/mkql_program_builder.h>
+
+namespace NKikimr {
+namespace NMiniKQL {
+
+class TDqProgramBuilder: public TProgramBuilder {
+public:
+    TDqProgramBuilder(const TTypeEnvironment& env, const IFunctionRegistry& functionRegistry);
+
+    TRuntimeNode DqHashCombine(TRuntimeNode flow, ui64 memLimit, const TWideLambda& keyExtractor, const TBinaryWideLambda& init, const TTernaryWideLambda& update, const TBinaryWideLambda& finish);
+    TRuntimeNode DqHashAggregate(TRuntimeNode flow, const bool spilling, const TWideLambda& keyExtractor, const TBinaryWideLambda& init, const TTernaryWideLambda& update, const TBinaryWideLambda& finish);
+
+protected:
+    TCallableBuilder BuildCommonCombinerParams(
+        const TStringBuf operatorName,
+        const TRuntimeNode operatorParams,
+        const TRuntimeNode flow,
+        const TProgramBuilder::TWideLambda& keyExtractor,
+        const TProgramBuilder::TBinaryWideLambda& init,
+        const TProgramBuilder::TTernaryWideLambda& update,
+        const TProgramBuilder::TBinaryWideLambda& finish);
+};
+
+} // namespace NMiniKQL
+} // namespace NKikimr

--- a/ydb/library/yql/dq/comp_nodes/ya.make
+++ b/ydb/library/yql/dq/comp_nodes/ya.make
@@ -3,12 +3,19 @@ LIBRARY()
 PEERDIR(
     ydb/library/actors/core
     ydb/library/yql/dq/actors/compute
+    ydb/library/yql/dq/runtime
+    yql/essentials/minikql/comp_nodes
     yql/essentials/minikql/computation
     yql/essentials/utils
 )
 
 SRCS(
     yql_common_dq_factory.cpp
+    dq_hash_aggregate.cpp
+    dq_hash_combine.cpp
+    dq_hash_operator_common.cpp
+    dq_hash_operator_serdes.cpp
+    dq_program_builder.cpp
 )
 
 YQL_LAST_ABI_VERSION()

--- a/ydb/library/yql/dq/comp_nodes/yql_common_dq_factory.cpp
+++ b/ydb/library/yql/dq/comp_nodes/yql_common_dq_factory.cpp
@@ -3,6 +3,8 @@
 #include <yql/essentials/minikql/computation/mkql_computation_node_holders.h>
 #include <ydb/library/actors/core/actor.h>
 #include <ydb/library/yql/dq/actors/compute/dq_compute_actor.h>
+#include <ydb/library/yql/dq/comp_nodes/dq_hash_combine.h>
+#include <ydb/library/yql/dq/comp_nodes/dq_hash_aggregate.h>
 
 namespace NYql {
 
@@ -47,7 +49,7 @@ private:
 TComputationNodeFactory GetCommonDqFactory() {
     return [] (TCallable& callable, const TComputationNodeFactoryContext& ctx) -> IComputationNode* {
             TStringBuf name = callable.GetType()->GetName();
-            if (name == "DqNotify") {
+            if (name == "DqNotify"sv) {
                 return new TDqNotify(ctx.Mutables);
             }
 


### PR DESCRIPTION
### Changelog category <!-- remove all except one -->

* Not for changelog (changelog entry is not required)

### Description for reviewers <!-- (optional) description for those who read this PR -->

Added stubs for two new hash aggregation operators to ydb/library/yql/dq/comp_nodes.
Runtime node serialization/deserialization works already, so you can instantiate compute nodes by calling Dq/KqpProgramBuilder methods. Actual operator implementations are no-ops though, and I still need to add WrapDqHashCombine/Aggregate to an appropriate callable factory (e.g. to yql_common_dq_factory.cpp).