### PR TITLE
Support scepterless operations in distconf for bridge mode

### DIFF
--- a/ydb/core/blobstorage/nodewarden/distconf.cpp
+++ b/ydb/core/blobstorage/nodewarden/distconf.cpp
@@ -281,11 +281,12 @@ namespace NKikimr::NStorage {
         Y_ABORT_UNLESS(!InitialConfig->GetFingerprint() || CheckFingerprint(*InitialConfig));
 
         if (Scepter) {
-            Y_ABORT_UNLESS(HasQuorum());
+            Y_ABORT_UNLESS(StorageConfig && HasQuorum(*StorageConfig));
             Y_ABORT_UNLESS(RootState != ERootState::INITIAL && RootState != ERootState::ERROR_TIMEOUT);
             Y_ABORT_UNLESS(!Binding);
         } else {
-            Y_ABORT_UNLESS(RootState == ERootState::INITIAL || RootState == ERootState::ERROR_TIMEOUT);
+            Y_ABORT_UNLESS(RootState == ERootState::INITIAL || RootState == ERootState::ERROR_TIMEOUT ||
+                ScepterlessOperationInProgress);
 
             // we can't have connection to the Console without being the root node
             Y_ABORT_UNLESS(!ConsolePipeId);

--- a/ydb/core/blobstorage/nodewarden/distconf_binding.cpp
+++ b/ydb/core/blobstorage/nodewarden/distconf_binding.cpp
@@ -64,7 +64,7 @@ namespace NKikimr::NStorage {
     void TDistributedConfigKeeper::IssueNextBindRequest() {
         Y_DEBUG_ABORT_UNLESS(IsSelfStatic);
         CheckRootNodeStatus();
-        if (RootState == ERootState::INITIAL && !Binding && AllBoundNodes.size() < NodeIds.size()) {
+        if (RootState == ERootState::INITIAL && !ScepterlessOperationInProgress && !Binding && AllBoundNodes.size() < NodeIds.size()) {
             const TMonotonic now = TActivationContext::Monotonic();
             TMonotonic closest;
             if (std::optional<ui32> nodeId = BindQueue.Pick(now, &closest)) {

--- a/ydb/core/blobstorage/nodewarden/distconf_fsm.cpp
+++ b/ydb/core/blobstorage/nodewarden/distconf_fsm.cpp
@@ -6,14 +6,15 @@ namespace NKikimr::NStorage {
     void TDistributedConfigKeeper::CheckRootNodeStatus() {
         Y_VERIFY_S(Binding ? (RootState == ERootState::INITIAL || RootState == ERootState::ERROR_TIMEOUT) && !Scepter :
             RootState == ERootState::INITIAL || RootState == ERootState::ERROR_TIMEOUT ? !Scepter :
-            static_cast<bool>(Scepter), "Binding# " << (Binding ? Binding->ToString() : "<null>")
-            << " RootState# " << RootState << " Scepter# " << (Scepter ? ToString(Scepter->Id) : "<null>"));
+            static_cast<bool>(Scepter) || ScepterlessOperationInProgress, "Binding# " << (Binding ? Binding->ToString() : "<null>")
+            << " RootState# " << RootState << " Scepter# " << (Scepter ? ToString(Scepter->Id) : "<null>")
+            << " ScepterlessOperationInProgress# " << ScepterlessOperationInProgress);
 
         if (Binding) { // can't become root node
             return;
         }
 
-        const bool hasQuorum = HasQuorum();
+        const bool hasQuorum = StorageConfig && HasQuorum(*StorageConfig);
 
         if (RootState == ERootState::INITIAL && hasQuorum) { // becoming root node
             Y_ABORT_UNLESS(!Scepter);
@@ -55,8 +56,10 @@ namespace NKikimr::NStorage {
         STLOG(PRI_NOTICE, BS_NODE, NWDC38, "SwitchToError", (RootState, RootState), (Reason, reason));
         if (Scepter) {
             UnbecomeRoot();
+            Scepter.reset();
+            ++ScepterCounter;
+            ScepterlessOperationInProgress = false;
         }
-        Scepter.reset();
         RootState = ERootState::ERROR_TIMEOUT;
         ErrorReason = reason;
         CurrentProposedStorageConfig.reset();
@@ -101,13 +104,13 @@ namespace NKikimr::NStorage {
         SwitchToError("incorrect response from peer");
     }
 
-    bool TDistributedConfigKeeper::HasQuorum() const {
+    bool TDistributedConfigKeeper::HasQuorum(const NKikimrBlobStorage::TStorageConfig& config) const {
         auto generateConnected = [&](auto&& callback) {
             for (const auto& [nodeId, node] : AllBoundNodes) {
                 callback(nodeId);
             }
         };
-        return StorageConfig && HasNodeQuorum(*StorageConfig, generateConnected);
+        return HasNodeQuorum(config, generateConnected);
     }
 
     void TDistributedConfigKeeper::ProcessCollectConfigs(TEvGather::TCollectConfigs *res) {

--- a/ydb/core/blobstorage/nodewarden/distconf_invoke.h
+++ b/ydb/core/blobstorage/nodewarden/distconf_invoke.h
@@ -8,10 +8,13 @@ namespace NKikimr::NStorage {
         TDistributedConfigKeeper* const Self;
         const std::weak_ptr<TLifetimeToken> LifetimeToken;
         const std::weak_ptr<TScepter> Scepter;
+        const ui64 ScepterCounter;
         std::unique_ptr<TEventHandle<TEvNodeConfigInvokeOnRoot>> Event;
         const TActorId Sender;
         const ui64 Cookie;
         const TActorId RequestSessionId;
+
+        bool IsScepterlessOperation = false;
 
         TActorId ParentId;
         ui32 WaitingReplyFromNode = 0;
@@ -29,6 +32,7 @@ namespace NKikimr::NStorage {
         TInvokeRequestHandlerActor(TDistributedConfigKeeper *self, std::unique_ptr<TEventHandle<TEvNodeConfigInvokeOnRoot>>&& ev);
 
         void Bootstrap(TActorId parentId);
+        bool IsScepterExpired() const;
 
         void Handle(TEvNodeConfigInvokeOnRootResult::TPtr ev);
 
@@ -122,6 +126,8 @@ namespace NKikimr::NStorage {
         // Bridge mode
 
         void SwitchBridgeClusterState(const NKikimrBridge::TClusterState& newClusterState);
+        NKikimrBlobStorage::TStorageConfig GetSwitchBridgeNewConfig(const NKikimrBridge::TClusterState& newClusterState);
+        bool CheckSwitchBridgeCommand();
 
         ////////////////////////////////////////////////////////////////////////////////////////////////////////////////
         // Configuration proposition

--- a/ydb/core/blobstorage/nodewarden/distconf_invoke_common.cpp
+++ b/ydb/core/blobstorage/nodewarden/distconf_invoke_common.cpp
@@ -12,6 +12,7 @@ namespace NKikimr::NStorage {
         : Self(self)
         , LifetimeToken(Self->LifetimeToken)
         , Scepter(Self->Scepter)
+        , ScepterCounter(Self->ScepterCounter)
         , Event(std::move(ev))
         , Sender(Event->Sender)
         , Cookie(Event->Cookie)
@@ -29,19 +30,30 @@ namespace NKikimr::NStorage {
         ParentId = parentId;
         Become(&TThis::StateFunc);
 
-        if (auto scepter = Scepter.lock()) {
+        if (Self->ScepterlessOperationInProgress) {
+            FinishWithError(TResult::ERROR, "an operation is already in progress");
+        } else if (Self->Binding) {
+            if (RequestSessionId) {
+                FinishWithError(TResult::ERROR, "no double-hop invokes allowed");
+            } else {
+                const ui32 root = Self->Binding->RootNodeId;
+                Send(MakeBlobStorageNodeWardenID(root), Event->Release(), IEventHandle::FlagSubscribeOnSession);
+                const auto [it, inserted] = Subscriptions.try_emplace(root);
+                Y_ABORT_UNLESS(inserted);
+                WaitingReplyFromNode = root;
+            }
+        } else if (!Scepter.expired() || CheckSwitchBridgeCommand()) {
+            if (Scepter.expired()) {
+                Self->ScepterlessOperationInProgress = IsScepterlessOperation = true;
+            }
             ExecuteQuery();
-        } else if (!Self->Binding) {
-            FinishWithError(TResult::NO_QUORUM, "no quorum obtained");
-        } else if (RequestSessionId) {
-            FinishWithError(TResult::ERROR, "no double-hop invokes allowed");
         } else {
-            const ui32 root = Self->Binding->RootNodeId;
-            Send(MakeBlobStorageNodeWardenID(root), Event->Release(), IEventHandle::FlagSubscribeOnSession);
-            const auto [it, inserted] = Subscriptions.try_emplace(root);
-            Y_ABORT_UNLESS(inserted);
-            WaitingReplyFromNode = root;
+            FinishWithError(TResult::NO_QUORUM, "no quorum obtained");
         }
+    }
+
+    bool TInvokeRequestHandlerActor::IsScepterExpired() const {
+        return Self->ScepterCounter != ScepterCounter;
     }
 
     void TInvokeRequestHandlerActor::Handle(TEvNodeConfigInvokeOnRootResult::TPtr ev) {
@@ -250,7 +262,9 @@ namespace NKikimr::NStorage {
             Y_ABORT_UNLESS(res->HasProposeStorageConfig());
             std::unique_ptr<TEvNodeConfigInvokeOnRootResult> ev;
 
-            const ERootState prevState = std::exchange(Self->RootState, ERootState::RELAX);
+            const ERootState prevState = std::exchange(Self->RootState, Self->Scepter
+                ? ERootState::RELAX
+                : ERootState::INITIAL);
             Y_ABORT_UNLESS(prevState == ERootState::IN_PROGRESS);
 
             if (auto error = Self->ProcessProposeStorageConfig(res->MutableProposeStorageConfig())) {
@@ -286,11 +300,11 @@ namespace NKikimr::NStorage {
             FinishWithError(TResult::ERROR, "no agreed StorageConfig");
         } else if (Self->CurrentProposedStorageConfig) {
             FinishWithError(TResult::ERROR, "config proposition request in flight");
-        } else if (Self->RootState != ERootState::RELAX) {
+        } else if (Self->RootState != (IsScepterlessOperation ? ERootState::INITIAL : ERootState::RELAX)) {
             FinishWithError(TResult::ERROR, "something going on with default FSM");
         } else if (auto error = ValidateConfig(*Self->StorageConfig)) {
             FinishWithError(TResult::ERROR, TStringBuilder() << "current config validation failed: " << *error);
-        } else if (Scepter.expired()) {
+        } else if (IsScepterExpired()) {
             FinishWithError(TResult::ERROR, "scepter lost during query execution");
         } else {
             return true;
@@ -319,6 +333,9 @@ namespace NKikimr::NStorage {
     }
 
     void TInvokeRequestHandlerActor::PassAway() {
+        if (IsScepterlessOperation && !IsScepterExpired()) {
+            Self->ScepterlessOperationInProgress = false;
+        }
         TActivationContext::Send(new IEventHandle(TEvents::TSystem::Gone, 0, ParentId, SelfId(), nullptr, 0));
         if (ControllerPipeId) {
             NTabletPipe::CloseAndForgetClient(SelfId(), ControllerPipeId);

--- a/ydb/core/blobstorage/nodewarden/distconf_invoke_storage_config.cpp
+++ b/ydb/core/blobstorage/nodewarden/distconf_invoke_storage_config.cpp
@@ -364,7 +364,7 @@ namespace NKikimr::NStorage {
                 return "incorrect CollectConfigs response";
             } else if (Self->CurrentProposedStorageConfig) {
                 FinishWithError(TResult::RACE, "config proposition request in flight");
-            } else if (Scepter.expired()) {
+            } else if (IsScepterExpired()) {
                 return "scepter lost during query execution";
             } else {
                 auto r = Self->ProcessCollectConfigs(res->MutableCollectConfigs(), std::nullopt);

--- a/ydb/core/blobstorage/nodewarden/distconf_mon.cpp
+++ b/ydb/core/blobstorage/nodewarden/distconf_mon.cpp
@@ -139,7 +139,7 @@ namespace NKikimr::NStorage {
                 {"direct_bound_nodes", getDirectBoundNodes()},
                 {"root_state", TString(TStringBuilder() << RootState)},
                 {"error_reason", ErrorReason},
-                {"has_quorum", HasQuorum()},
+                {"has_quorum", StorageConfig && HasQuorum(*StorageConfig)},
                 {"scepter", Scepter ? NJson::TJsonMap{
                     {"id", Scepter->Id},
                 } : NJson::TJsonValue{NJson::JSON_NULL}},
@@ -224,7 +224,7 @@ namespace NKikimr::NStorage {
                         if (ErrorReason) {
                            out << "ErrorReason: " << ErrorReason << "<br/>";
                         }
-                        out << "Quorum: " << (HasQuorum() ? "yes" : "no") << "<br/>";
+                        out << "Quorum: " << (StorageConfig && HasQuorum(*StorageConfig) ? "yes" : "no") << "<br/>";
                         out << "Scepter: " << (Scepter ? ToString(Scepter->Id) : "null") << "<br/>";
                     }
                 }

--- a/ydb/core/blobstorage/nodewarden/distconf_scatter_gather.cpp
+++ b/ydb/core/blobstorage/nodewarden/distconf_scatter_gather.cpp
@@ -11,8 +11,8 @@ namespace NKikimr::NStorage {
             (Binding, Binding), (Scepter, Scepter ? std::make_optional(Scepter->Id) : std::nullopt));
         Y_ABORT_UNLESS(!actorId && Binding && !Scepter // just forwarding what we got from binding
             || !actorId && !Binding && Scepter // initiating scatter task as a root node
-            || actorId && !Binding && Scepter); // query issued by InvokeOnRootNode machinery
-        const auto [it, inserted] = ScatterTasks.try_emplace(cookie, Binding, std::move(request), Scepter,
+            || actorId && !Binding && (Scepter || ScepterlessOperationInProgress)); // query issued by InvokeOnRootNode machinery
+        const auto [it, inserted] = ScatterTasks.try_emplace(cookie, Binding, std::move(request), ScepterCounter,
             actorId.value_or(TActorId()));
         Y_ABORT_UNLESS(inserted);
         TScatterTask& task = it->second;
@@ -70,7 +70,7 @@ namespace NKikimr::NStorage {
             task.Response.Swap(&ev->Record);
             Send(task.ActorId, ev.release());
         } else {
-            ProcessGather(task.Scepter.lock() == Scepter ? &task.Response : nullptr);
+            ProcessGather(task.ScepterCounter == ScepterCounter ? &task.Response : nullptr);
         }
     }
 


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

Support scepterless operations in distconf for bridge mode

### Changelog category <!-- remove all except one -->

* Not for changelog (changelog entry is not required)

### Description for reviewers <!-- (optional) description for those who read this PR -->

This patch allows distconf to correctly take down pile that is already not working (and thus not making up quorum).
