### PR TITLE
Split TLoginProvider::LoginUser to several methods

### DIFF
--- a/ydb/library/login/login.h
+++ b/ydb/library/login/login.h
@@ -68,7 +68,7 @@ public:
         TString ExternalAuth;
     };
 
-    struct TPassportCheckResult : TBasicResponse {
+    struct TPasswordCheckResult : TBasicResponse {
         enum class EStatus {
             UNSPECIFIED,
             SUCCESS,
@@ -80,7 +80,7 @@ public:
         EStatus Status = EStatus::UNSPECIFIED;
     };
 
-    struct TLoginUserResponse : TPassportCheckResult {
+    struct TLoginUserResponse : TPasswordCheckResult {
         TString Token;
         TString SanitizedToken; // Token for audit logs
     };
@@ -204,10 +204,10 @@ public:
     // Login
     TLoginUserResponse LoginUser(const TLoginUserRequest& request);
     // The next four methods are used (all together combined) when it's needed to separate hash verification which is quite cpu-intensive
-    bool NeedVerifyHash(const TLoginUserRequest& request, TPassportCheckResult* passportCheckResult, TString* passwordHash);
+    bool NeedVerifyHash(const TLoginUserRequest& request, TPasswordCheckResult* checkResult, TString* passwordHash);
     static bool VerifyHash(const TLoginUserRequest& request, const TString& passwordHash); // it's made static to be thread-safe
     void UpdateCache(const TLoginUserRequest& request, const TString& passwordHash, const bool isSuccessVerifying);
-    TLoginProvider::TLoginUserResponse LoginUser(const TLoginUserRequest& request, const TPassportCheckResult& passportCheckResult);
+    TLoginProvider::TLoginUserResponse LoginUser(const TLoginUserRequest& request, const TPasswordCheckResult& checkResult);
 
     TValidateTokenResponse ValidateToken(const TValidateTokenRequest& request);
 
@@ -255,8 +255,8 @@ private:
     bool ShouldUnlockAccount(const TSidRecord& sid) const;
     bool CheckPasswordOrHash(bool IsHashedPassword, const TString& user, const TString& password, TString& error) const;
     TSidRecord* GetUserSid(const TString& user);
-    bool FillNoKeys(TPassportCheckResult* result) const;
-    bool FillInvalidUser(const TSidRecord* sid, TPassportCheckResult* result) const;
+    bool FillNoKeys(TPasswordCheckResult* checkResult) const;
+    bool FillInvalidUser(const TSidRecord* sid, TPasswordCheckResult* checkResult) const;
 
 private:
     struct TImpl;

--- a/ydb/library/login/login.h
+++ b/ydb/library/login/login.h
@@ -68,7 +68,7 @@ public:
         TString ExternalAuth;
     };
 
-    struct TLoginUserResponse : TBasicResponse {
+    struct TPassportCheckResult : TBasicResponse {
         enum class EStatus {
             UNSPECIFIED,
             SUCCESS,
@@ -77,9 +77,12 @@ public:
             UNAVAILABLE_KEY
         };
 
+        EStatus Status = EStatus::UNSPECIFIED;
+    };
+
+    struct TLoginUserResponse : TPassportCheckResult {
         TString Token;
         TString SanitizedToken; // Token for audit logs
-        EStatus Status = EStatus::UNSPECIFIED;
     };
 
     struct TValidateTokenRequest : TBasicRequest {
@@ -201,10 +204,10 @@ public:
     // Login
     TLoginUserResponse LoginUser(const TLoginUserRequest& request);
     // The next four methods are used (all together combined) when it's needed to separate hash verification which is quite cpu-intensive
-    bool NeedVerifyHash(const TLoginUserRequest& request, TLoginUserResponse* response, TString* passwordHash);
+    bool NeedVerifyHash(const TLoginUserRequest& request, TPassportCheckResult* passportCheckResult, TString* passwordHash);
     static bool VerifyHash(const TLoginUserRequest& request, const TString& passwordHash); // it's made static to be thread-safe
     void UpdateCache(const TLoginUserRequest& request, const TString& passwordHash, const bool isSuccessVerifying);
-    void LoginUser(const TLoginUserRequest& request, TLoginUserResponse* response);
+    TLoginProvider::TLoginUserResponse LoginUser(const TLoginUserRequest& request, const TPassportCheckResult& passportCheckResult);
 
     TValidateTokenResponse ValidateToken(const TValidateTokenRequest& request);
 
@@ -252,8 +255,8 @@ private:
     bool ShouldUnlockAccount(const TSidRecord& sid) const;
     bool CheckPasswordOrHash(bool IsHashedPassword, const TString& user, const TString& password, TString& error) const;
     TSidRecord* GetUserSid(const TString& user);
-    bool FillNoKeys(TLoginUserResponse* response) const;
-    bool FillInvalidUser(const TSidRecord* sid, TLoginUserResponse* response) const;
+    bool FillNoKeys(TPassportCheckResult* result) const;
+    bool FillInvalidUser(const TSidRecord* sid, TPassportCheckResult* result) const;
 
 private:
     struct TImpl;

--- a/ydb/library/login/login.h
+++ b/ydb/library/login/login.h
@@ -197,7 +197,15 @@ public:
 
     bool IsLockedOut(const TSidRecord& user) const;
     TCheckLockOutResponse CheckLockOutUser(const TCheckLockOutRequest& request);
+
+    // Login
     TLoginUserResponse LoginUser(const TLoginUserRequest& request);
+    // The next four methods are used (all together combined) when it's needed to separate hash verification which is quite cpu-intensive
+    bool NeedVerifyHash(const TLoginUserRequest& request, TLoginUserResponse* response, TString* passwordHash);
+    static bool VerifyHash(const TLoginUserRequest& request, const TString& passwordHash); // it's made static to be thread-safe
+    void UpdateCache(const TLoginUserRequest& request, const TString& passwordHash, const bool isSuccessVerifying);
+    void LoginUser(const TLoginUserRequest& request, TLoginUserResponse* response);
+
     TValidateTokenResponse ValidateToken(const TValidateTokenRequest& request);
 
     TBasicResponse CreateUser(const TCreateUserRequest& request);
@@ -243,7 +251,11 @@ private:
     bool ShouldResetFailedAttemptCount(const TSidRecord& sid) const;
     bool ShouldUnlockAccount(const TSidRecord& sid) const;
     bool CheckPasswordOrHash(bool IsHashedPassword, const TString& user, const TString& password, TString& error) const;
+    TSidRecord* GetUserSid(const TString& user);
+    bool FillNoKeys(TLoginUserResponse* response) const;
+    bool FillInvalidUser(const TSidRecord* sid, TLoginUserResponse* response) const;
 
+private:
     struct TImpl;
     THolder<TImpl> Impl;
 


### PR DESCRIPTION
### Changelog category

* Not for changelog

### Description for reviewers
We need to move cpu-intensive part of LoginUser from SchemeShard local transaction to a new actor. Such cpu-intensive part is password hash verifying. After that LoginProvider would be accessible from different threads.
However it was not intended to work properly in multithread mode. To avoid races we split LoginUser method to retrieve VerifyHash part into a separate method. It's made static now and will be used in a new actor later.