### PR TITLE
Fix optimizer comparison when protobuf serializations are the same

### DIFF
--- a/ydb/core/tx/columnshard/engines/storage/optimizer/abstract/optimizer.h
+++ b/ydb/core/tx/columnshard/engines/storage/optimizer/abstract/optimizer.h
@@ -244,6 +244,9 @@ public:
 
     bool IsEqualTo(const std::shared_ptr<IOptimizerPlannerConstructor>& item) const {
         AFL_VERIFY(!!item);
+        if (GetClassName() != item->GetClassName()) {
+            return false;
+        }
         TProto selfProto;
         TProto itemProto;
         SerializeToProto(selfProto);


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

...

### Changelog category <!-- remove all except one -->

* Not for changelog (changelog entry is not required)

### Description for reviewers <!-- (optional) description for those who read this PR -->

Very minor: don't consider optimizers equal when the have different class names (but identical protobufs).