### PR TITLE
Support bridge mode for BSC storage pools

### DIFF
--- a/ydb/core/base/bridge.h
+++ b/ydb/core/base/bridge.h
@@ -28,6 +28,18 @@ namespace NKikimr {
             Y_ABORT_UNLESS(bridgePileId.GetRawId() < Piles.size());
             return &Piles[bridgePileId.GetRawId()];
         }
+
+        const TPile *GetPileForNode(ui32 nodeId) const {
+            const auto it = StaticNodeIdToPile.find(nodeId);
+            return it != StaticNodeIdToPile.end() ? it->second : nullptr;
+        }
+
+        template<typename T>
+        void ForEachPile(T&& callback) const {
+            for (size_t i = 0; i < Piles.size(); ++i) {
+                callback(TBridgePileId::FromValue(i));
+            }
+        }
     };
 
 } // NKikimr

--- a/ydb/core/blobstorage/dsproxy/dsproxy_impl.h
+++ b/ydb/core/blobstorage/dsproxy/dsproxy_impl.h
@@ -429,6 +429,30 @@ public:
             default: return StateCommon(ev);
         }
     }
+
+    TActorId BridgeProxyId;
+
+    STFUNC(StateForward) {
+        switch (ev->GetTypeRewrite()) {
+            case TEvents::TSystem::Poison:
+                PassAway();
+                [[fallthrough]];
+            case TEvBlobStorage::EvConfigureProxy:
+            case TEvBlobStorage::EvPut:
+            case TEvBlobStorage::EvGet:
+            case TEvBlobStorage::EvGetBlock:
+            case TEvBlobStorage::EvBlock:
+            case TEvBlobStorage::EvDiscover:
+            case TEvBlobStorage::EvRange:
+            case TEvBlobStorage::EvCollectGarbage:
+            case TEvBlobStorage::EvStatus:
+            case TEvBlobStorage::EvPatch:
+            case TEvBlobStorage::EvAssimilate:
+            case TEvBlobStorage::EvCheckIntegrity:
+                TActivationContext::Send(IEventHandle::Forward(ev, BridgeProxyId));
+                break;
+        }
+    }
 };
 
 }

--- a/ydb/core/blobstorage/dsproxy/dsproxy_state.cpp
+++ b/ydb/core/blobstorage/dsproxy/dsproxy_state.cpp
@@ -1,6 +1,8 @@
 #include "dsproxy_impl.h"
 #include "dsproxy_monactor.h"
 
+#include <ydb/core/blobstorage/dsproxy/bridge/bridge.h>
+
 namespace NKikimr {
 
     void TBlobStorageGroupProxy::Handle5min(TAutoPtr<IEventHandle> ev) {
@@ -90,6 +92,15 @@ namespace NKikimr {
 
     void TBlobStorageGroupProxy::ApplyGroupInfo(TIntrusivePtr<TBlobStorageGroupInfo>&& info,
             TNodeLayoutInfoPtr nodeLayoutInfo, TIntrusivePtr<TStoragePoolCounters>&& counters) {
+        if (info && info->IsBridged()) {
+            const TActorId serviceId = MakeBlobStorageProxyID(info->GroupID);
+            BridgeProxyId = RegisterWithSameMailbox(CreateBridgeProxyActor(std::move(info)));
+            TActivationContext::ActorSystem()->RegisterLocalService(serviceId, BridgeProxyId);
+            Become(&TThis::StateForward);
+            ProcessInitQueue();
+            return;
+        }
+
         auto prevInfo = std::exchange(Info, std::move(info));
         if (Info) {
             if (Topology) {

--- a/ydb/core/blobstorage/groupinfo/blobstorage_groupinfo.cpp
+++ b/ydb/core/blobstorage/groupinfo/blobstorage_groupinfo.cpp
@@ -711,7 +711,8 @@ TIntrusivePtr<TBlobStorageGroupInfo> TBlobStorageGroupInfo::Parse(const NKikimrB
     auto erasure = (TBlobStorageGroupType::EErasureSpecies)group.GetErasureSpecies();
     TBlobStorageGroupType type(erasure);
     TBlobStorageGroupInfo::TTopology topology(type);
-    TBlobStorageGroupInfo::TDynamicInfo dyn(TGroupId::FromProto(&group, &NKikimrBlobStorage::TGroupInfo::GetGroupID), group.GetGroupGeneration());
+    TBlobStorageGroupInfo::TDynamicInfo dyn(TGroupId::FromProto(&group, &NKikimrBlobStorage::TGroupInfo::GetGroupID),
+        group.GetGroupGeneration());
     topology.FailRealms.resize(group.RingsSize());
     for (ui32 ringIdx = 0; ringIdx < group.RingsSize(); ++ringIdx) {
         const auto& realm = group.GetRings(ringIdx);

--- a/ydb/core/blobstorage/nodewarden/distconf_generate.cpp
+++ b/ydb/core/blobstorage/nodewarden/distconf_generate.cpp
@@ -486,7 +486,8 @@ namespace NKikimr::NStorage {
         };
 
         TString error;
-        if (!mapper.AllocateGroup(groupId.GetRawId(), groupDefinition, replacedDisks, forbid, requiredSpace, false, error)) {
+        if (!mapper.AllocateGroup(groupId.GetRawId(), groupDefinition, replacedDisks, forbid, requiredSpace, false, {},
+                error)) {
             throw TExConfigError() << "group allocation failed Error# " << error
                 << " groupDefinition# " << dumpGroupDefinition();
         }

--- a/ydb/core/driver_lib/cli_utils/cli_cmds_genconfig.cpp
+++ b/ydb/core/driver_lib/cli_utils/cli_cmds_genconfig.cpp
@@ -234,7 +234,7 @@ public:
 
         NBsController::TGroupMapper::TGroupDefinition group;
         TString error;
-        if (!mapper.AllocateGroup(0, group, {}, {}, 0, false, error)) {
+        if (!mapper.AllocateGroup(0, group, {}, {}, 0, false, {}, error)) {
             Cerr << "Can't allocate group: " << error << Endl;
             return EXIT_FAILURE;
         }

--- a/ydb/core/mind/bscontroller/bsc.cpp
+++ b/ydb/core/mind/bscontroller/bsc.cpp
@@ -66,6 +66,8 @@ bool TBlobStorageController::TGroupInfo::CalculateGroupStatus() {
     const TGroupStatus prev = Status;
     Status = {NKikimrBlobStorage::TGroupStatus::FULL, NKikimrBlobStorage::TGroupStatus::FULL};
 
+    // TODO(alexvru): bridge group status
+
     if ((VirtualGroupState == NKikimrBlobStorage::EVirtualGroupState::CREATE_FAILED ||
             VirtualGroupState == NKikimrBlobStorage::EVirtualGroupState::NEW) && VDisksInGroup.empty()) {
         Status.MakeWorst(NKikimrBlobStorage::TGroupStatus::DISINTEGRATED, NKikimrBlobStorage::TGroupStatus::DISINTEGRATED);
@@ -151,7 +153,11 @@ void TBlobStorageController::OnActivateExecutor(const TActorContext&) {
 }
 
 void TBlobStorageController::Handle(TEvNodeWardenStorageConfig::TPtr ev) {
+    const bool isFirstStorageConfig = !StorageConfig;
+    Y_DEBUG_ABORT_UNLESS(!isFirstStorageConfig || CurrentStateFunc() == &TThis::StateInit);
+
     StorageConfig = std::move(ev->Get()->Config);
+    BridgeInfo = std::move(ev->Get()->BridgeInfo);
     SelfManagementEnabled = ev->Get()->SelfManagementEnabled;
 
     auto prevStaticPDisks = std::exchange(StaticPDisks, {});
@@ -190,29 +196,27 @@ void TBlobStorageController::Handle(TEvNodeWardenStorageConfig::TPtr ev) {
     if (SelfManagementEnabled) {
         // assuming that in autoconfig mode HostRecords are managed by the distconf; we need to apply it here to
         // avoid race with box autoconfiguration and node list change
-        HostRecords = std::make_shared<THostRecordMap::element_type>(*StorageConfig);
-        if (SelfHealId) {
-            Send(SelfHealId, new TEvPrivate::TEvUpdateHostRecords(HostRecords));
-        }
-
-        ConsoleInteraction->Stop(); // distconf will handle the Console from now on
-    } else if (Loaded) {
-        ConsoleInteraction->Start(); // we control the Console now
+        SetHostRecords(std::make_shared<THostRecordMap::element_type>(*StorageConfig));
     }
 
-    if (!std::exchange(StorageConfigObtained, true)) { // this is the first time we get StorageConfig in this instance of BSC
-        if (SelfManagementEnabled) {
-            OnHostRecordsInitiate();
-        } else {
-            Send(GetNameserviceActorId(), new TEvInterconnect::TEvListNodes(true));
-        }
-    }
-
+    // switch console interaction state based on new information
     if (Loaded) {
-        ApplyStorageConfig();
+        if (SelfManagementEnabled) {
+            ConsoleInteraction->Stop(); // distconf manages the Console
+        } else {
+            ConsoleInteraction->Start(); // we manage the Console now
+        }
     }
 
-    PushStaticGroupsToSelfHeal();
+    if (!isFirstStorageConfig) {
+        // this isn't the first configuration change, we just update static groups information in self heal actor now
+        PushStaticGroupsToSelfHeal();
+    } else if (!SelfManagementEnabled) {
+        // this is the first time we get StorageConfig in this instance of BSC; tablet is not yet initialized, and
+        // self management is disabled, so we need to query nodes explicitly in the old way: through nameservice and
+        // Console tablet, which is the source of truth for this case
+        Send(GetNameserviceActorId(), new TEvInterconnect::TEvListNodes(true));
+    }
 }
 
 void TBlobStorageController::Handle(TEvents::TEvUndelivered::TPtr ev) {
@@ -519,19 +523,21 @@ void TBlobStorageController::Handle(TEvBlobStorage::TEvControllerUpdateGroupStat
 
 void TBlobStorageController::Handle(TEvInterconnect::TEvNodesInfo::TPtr &ev) {
     STLOG(PRI_DEBUG, BS_CONTROLLER, BSC01, "Handle TEvInterconnect::TEvNodesInfo");
-    if (!std::exchange(HostRecords, std::make_shared<THostRecordMap::element_type>(ev->Get()))) {
-        OnHostRecordsInitiate();
-    }
-    Send(SelfHealId, new TEvPrivate::TEvUpdateHostRecords(HostRecords));
+    SetHostRecords(std::make_shared<THostRecordMap::element_type>(ev->Get()));
 }
 
-void TBlobStorageController::OnHostRecordsInitiate() {
-    if (auto *appData = AppData()) {
-        if (appData->Icb) {
-            EnableSelfHealWithDegraded = std::make_shared<TControlWrapper>(0, 0, 1);
-            appData->Icb->RegisterSharedControl(*EnableSelfHealWithDegraded,
-                "BlobStorageControllerControls.EnableSelfHealWithDegraded");
-        }
+void TBlobStorageController::SetHostRecords(THostRecordMap hostRecords) {
+    if (std::exchange(HostRecords, std::move(hostRecords))) {
+        // we already had some host records, so this isn't the first time this function called
+        Send(SelfHealId, new TEvPrivate::TEvUpdateHostRecords(HostRecords));
+        return;
+    }
+
+    // there were no host records, this is the first call, so we must initialize SelfHeal now and start booting tablet
+    if (auto *appData = AppData(); appData && appData->Icb) {
+        EnableSelfHealWithDegraded = std::make_shared<TControlWrapper>(0, 0, 1);
+        appData->Icb->RegisterSharedControl(*EnableSelfHealWithDegraded,
+            "BlobStorageControllerControls.EnableSelfHealWithDegraded");
     }
     Y_ABORT_UNLESS(!SelfHealId);
     SelfHealId = Register(CreateSelfHealActor());

--- a/ydb/core/mind/bscontroller/config.h
+++ b/ydb/core/mind/bscontroller/config.h
@@ -124,6 +124,8 @@ namespace NKikimr {
 
             bool PushStaticGroupsToSelfHeal = false;
 
+            TBridgeInfo::TPtr BridgeInfo;
+
         public:
             TConfigState(TBlobStorageController &controller, const THostRecordMap &hostRecords, TInstant timestamp,
                     TMonotonic mono)
@@ -151,6 +153,7 @@ namespace NKikimr {
                 , StaticPDisks(controller.StaticPDisks)
                 , SerialManagementStage(&controller.SerialManagementStage)
                 , StoragePoolStat(*controller.StoragePoolStat)
+                , BridgeInfo(controller.BridgeInfo)
             {
                 Y_ABORT_UNLESS(HostRecords);
             }

--- a/ydb/core/mind/bscontroller/config_fit_groups.cpp
+++ b/ydb/core/mind/bscontroller/config_fit_groups.cpp
@@ -54,17 +54,15 @@ namespace NKikimr {
                 for (ui64 reserve = 0; reserve < min || (reserve - min) * 1000000 / Max<ui64>(1, total) < part; ++reserve, ++total) {
                     TGroupMapper::TGroupDefinition group;
                     try {
-                        AllocateOrSanitizeGroup(TGroupId::Zero(), group, {}, {}, 0, false, &TGroupGeometryInfo::AllocateGroup);
+                        AllocateOrSanitizeGroup(TGroupId::Zero(), group, {}, {}, 0, false, {},
+                            &TGroupGeometryInfo::AllocateGroup);
                     } catch (const TExFitGroupError&) {
                         throw TExError() << "group reserve constraint hit";
                     }
                 }
             }
 
-            void CreateGroup() {
-                ////////////////////////////////////////////////////////////////////////////////////////////
-                // ALLOCATE GROUP ID FOR THE NEW GROUP
-                ////////////////////////////////////////////////////////////////////////////////////////////
+            TGroupId AllocateGroupId() {
                 TGroupId groupId;
                 for (;;) {
                     // obtain group local id
@@ -86,6 +84,63 @@ namespace NKikimr {
                     }
                 }
 
+                return groupId;
+            }
+
+            void CreateGroup() {
+                if (StoragePool.BridgeMode) {
+                    const TGroupId mainGroupId = AllocateGroupId();
+
+                    TGroupInfo *groupInfo = State.Groups.ConstructInplaceNewEntry(
+                        mainGroupId,
+                        mainGroupId, /* id */
+                        1, /* generation */
+                        0, /* owner */
+                        TBlobStorageGroupType::ErasureNone, /* erasureSpecies */
+                        0, /* desiredPDiskCategory */
+                        NKikimrBlobStorage::TVDiskKind::Default, /* desiredVDiskCategory */
+                        0, /* encryptionMode */
+                        0, /* lifeCyclePhase */
+                        TString(), /* mainKeyId */
+                        TString(), /* encryptedGroupKey */
+                        mainGroupId.GetRawId(), /* groupKeyNonce */
+                        0, /* mainKeyVersion */
+                        false, /* down */
+                        false, /* seenOperational */
+                        0, /* groupSizeInUnits */
+                        StoragePoolId, /* storagePoolId */
+                        0, /* numFailRealms */
+                        0, /* numFailDomainsPerFailRealm */
+                        0); /* numVDisksPerFailDomain */
+
+                    // bind group to storage pool
+                    State.StoragePoolGroups.Unshare().emplace(StoragePoolId, mainGroupId);
+
+                    const TGroupSpecies species = groupInfo->GetGroupSpecies();
+                    auto& index = State.IndexGroupSpeciesToGroup.Unshare();
+                    index[species].push_back(mainGroupId);
+
+                    NKikimrBlobStorage::TGroupInfo mainGroup;
+                    const auto& bridgeInfo = State.BridgeInfo;
+                    Y_ABORT_UNLESS(bridgeInfo);
+                    bridgeInfo->ForEachPile([&](TBridgePileId bridgePileId) {
+                        const TGroupId groupId = CreateGroup(bridgePileId);
+                        groupId.CopyToProto(&mainGroup, &NKikimrBlobStorage::TGroupInfo::AddBridgeGroupIds);
+                    });
+
+                    const bool success = mainGroup.SerializeToString(&groupInfo->BridgeGroupInfo.ConstructInPlace());
+                    Y_DEBUG_ABORT_UNLESS(success);
+                } else {
+                    CreateGroup(std::nullopt); // regular single group
+                }
+            }
+
+            TGroupId CreateGroup(std::optional<TBridgePileId> bridgePileId) {
+                ////////////////////////////////////////////////////////////////////////////////////////////
+                // ALLOCATE GROUP ID FOR THE NEW GROUP
+                ////////////////////////////////////////////////////////////////////////////////////////////
+                TGroupId groupId = AllocateGroupId();
+
                 ////////////////////////////////////////////////////////////////////////////////////////////////
                 // CREATE MORE GROUPS
                 ////////////////////////////////////////////////////////////////////////////////////////////////
@@ -96,7 +151,8 @@ namespace NKikimr {
                     ExpectedSlotSize.pop_front();
                 }
                 ui32 groupSizeInUnits = StoragePool.DefaultGroupSizeInUnits;
-                AllocateOrSanitizeGroup(groupId, group, {}, {}, requiredSpace, false, &TGroupGeometryInfo::AllocateGroup);
+                AllocateOrSanitizeGroup(groupId, group, {}, {}, requiredSpace, false, bridgePileId,
+                    &TGroupGeometryInfo::AllocateGroup);
 
                 // scan all comprising PDisks for PDiskCategory
                 TMaybe<TPDiskCategory> desiredPDiskCategory;
@@ -134,6 +190,10 @@ namespace NKikimr {
                     groupKeyNonce, MainKeyVersion, false, false, groupSizeInUnits, StoragePoolId, Geometry.GetNumFailRealms(),
                     Geometry.GetNumFailDomainsPerFailRealm(), Geometry.GetNumVDisksPerFailDomain());
 
+                if (bridgePileId) {
+                    groupInfo->BridgePileId = *bridgePileId;
+                }
+
                 // bind group to storage pool
                 State.StoragePoolGroups.Unshare().emplace(StoragePoolId, groupId);
 
@@ -143,6 +203,8 @@ namespace NKikimr {
 
                 // create VSlots
                 CreateVSlotsForGroup(groupInfo, group, {});
+
+                return groupId;
             }
 
             void CheckExistingGroup(TGroupId groupId) {
@@ -153,6 +215,10 @@ namespace NKikimr {
                 if (!groupInfo) {
                     throw TExFitGroupError() << "GroupId# " << groupId << " not found";
                 }
+
+                std::optional<TBridgePileId> bridgePileId = groupInfo->BridgePileId
+                    ? std::make_optional(*groupInfo->BridgePileId)
+                    : std::nullopt;
 
                 TGroupMapper::TGroupDefinition group;
                 TGroupMapper::TGroupConstraintsDefinition softConstraints, hardConstraints;
@@ -308,7 +374,7 @@ namespace NKikimr {
                             STLOG(PRI_INFO, BS_CONTROLLER, BSCFG01, "Attempt to sanitize group layout", (GroupId, groupId));
                             // Use group layout sanitizing algorithm on direct requests or when initial group layout is invalid
                             auto result = AllocateOrSanitizeGroup(groupId, group, {}, std::move(forbid), requiredSpace,
-                                AllowUnusableDisks, &TGroupGeometryInfo::SanitizeGroup);
+                                AllowUnusableDisks, bridgePileId, &TGroupGeometryInfo::SanitizeGroup);
 
                             if (replacedSlots.empty()) {
                                 // update information about replaced disks
@@ -330,10 +396,10 @@ namespace NKikimr {
                             try {
                                 TGroupMapper::MergeTargetDiskConstraints(hardConstraints, softConstraints);
                                 AllocateOrSanitizeGroup(groupId, group, softConstraints, replacedDisks, std::move(forbid), requiredSpace,
-                                    AllowUnusableDisks, &TGroupGeometryInfo::AllocateGroup);
+                                    AllowUnusableDisks, bridgePileId, &TGroupGeometryInfo::AllocateGroup);
                             } catch (const TExFitGroupError& ex) {
                                 AllocateOrSanitizeGroup(groupId, group, hardConstraints, replacedDisks, std::move(forbid), requiredSpace,
-                                    AllowUnusableDisks, &TGroupGeometryInfo::AllocateGroup);
+                                    AllowUnusableDisks, bridgePileId, &TGroupGeometryInfo::AllocateGroup);
                             }
                         }
                         if (!IgnoreVSlotQuotaCheck) {
@@ -432,11 +498,28 @@ namespace NKikimr {
 
         private:
             template<typename T>
-            std::invoke_result_t<T, TGroupGeometryInfo&, TGroupMapper&, TGroupId, TGroupMapper::TGroupDefinition&, TGroupMapper::TGroupConstraintsDefinition&,
-                    const THashMap<TVDiskIdShort, TPDiskId>&, TGroupMapper::TForbiddenPDisks, i64> AllocateOrSanitizeGroup(
-                    TGroupId groupId, TGroupMapper::TGroupDefinition& group, TGroupMapper::TGroupConstraintsDefinition& constraints,
-                    const THashMap<TVDiskIdShort, TPDiskId>& replacedDisks, TGroupMapper::TForbiddenPDisks forbid,
-                    i64 requiredSpace, bool addExistingDisks, T&& func) {
+            using TAllocateOrSanitizeGroupResult = std::invoke_result_t<T,
+                TGroupGeometryInfo&,
+                TGroupMapper&,
+                TGroupId,
+                TGroupMapper::TGroupDefinition&,
+                TGroupMapper::TGroupConstraintsDefinition&,
+                const THashMap<TVDiskIdShort, TPDiskId>&,
+                TGroupMapper::TForbiddenPDisks,
+                i64,
+                std::optional<TBridgePileId>>;
+
+            template<typename T>
+            TAllocateOrSanitizeGroupResult<T> AllocateOrSanitizeGroup(
+                    TGroupId groupId,
+                    TGroupMapper::TGroupDefinition& group,
+                    TGroupMapper::TGroupConstraintsDefinition& constraints,
+                    const THashMap<TVDiskIdShort, TPDiskId>& replacedDisks,
+                    TGroupMapper::TForbiddenPDisks forbid,
+                    i64 requiredSpace,
+                    bool addExistingDisks,
+                    std::optional<TBridgePileId> bridgePileId,
+                    T&& func) {
                 if (!Mapper) {
                     Mapper.emplace(Geometry, StoragePool.RandomizeGroupMapping);
                     PopulateGroupMapper();
@@ -464,17 +547,23 @@ namespace NKikimr {
                         }
                     }
                 } unregister{*Mapper, removeQ};
-                return std::invoke(func, Geometry, *Mapper, groupId, group, constraints, replacedDisks, std::move(forbid), requiredSpace);
+                return std::invoke(func, Geometry, *Mapper, groupId, group, constraints, replacedDisks,
+                    std::move(forbid), requiredSpace, bridgePileId);
             }
 
             template<typename T>
-            std::invoke_result_t<T, TGroupGeometryInfo&, TGroupMapper&, TGroupId, TGroupMapper::TGroupDefinition&, TGroupMapper::TGroupConstraintsDefinition&,
-                    const THashMap<TVDiskIdShort, TPDiskId>&, TGroupMapper::TForbiddenPDisks, i64> AllocateOrSanitizeGroup(
-                    TGroupId groupId, TGroupMapper::TGroupDefinition& group,
-                    const THashMap<TVDiskIdShort, TPDiskId>& replacedDisks, TGroupMapper::TForbiddenPDisks forbid,
-                    i64 requiredSpace, bool addExistingDisks, T&& func) {
+            TAllocateOrSanitizeGroupResult<T> AllocateOrSanitizeGroup(
+                    TGroupId groupId,
+                    TGroupMapper::TGroupDefinition& group,
+                    const THashMap<TVDiskIdShort, TPDiskId>& replacedDisks,
+                    TGroupMapper::TForbiddenPDisks forbid,
+                    i64 requiredSpace,
+                    bool addExistingDisks,
+                    std::optional<TBridgePileId> bridgePileId,
+                    T&& func) {
                 TGroupMapper::TGroupConstraintsDefinition emptyConstraints;
-                return AllocateOrSanitizeGroup(groupId, group, emptyConstraints, replacedDisks, forbid, requiredSpace, addExistingDisks, func);
+                return AllocateOrSanitizeGroup(groupId, group, emptyConstraints, replacedDisks, forbid, requiredSpace,
+                    addExistingDisks, bridgePileId, func);
             }
 
             void PopulateGroupMapper() {
@@ -554,6 +643,15 @@ namespace NKikimr {
                     whyUnusable.append('D');
                 }
 
+                std::optional<TBridgePileId> bridgePileId;
+                if (const auto& bridgeInfo = State.BridgeInfo) {
+                    if (const TBridgeInfo::TPile *pile = bridgeInfo->GetPileForNode(id.NodeId)) {
+                        bridgePileId = pile->BridgePileId;
+                    } else {
+                        Y_DEBUG_ABORT_S("can't find pile for NodeId# " << id.NodeId);
+                    }
+                }
+
                 // register PDisk in the mapper
                 return Mapper->RegisterPDisk({
                     .PDiskId = id,
@@ -566,6 +664,7 @@ namespace NKikimr {
                     .Operational = info.Operational,
                     .Decommitted = info.Decommitted(),
                     .WhyUnusable = std::move(whyUnusable),
+                    .BridgePileId = bridgePileId,
                 });
             }
 

--- a/ydb/core/mind/bscontroller/group_geometry_info.h
+++ b/ydb/core/mind/bscontroller/group_geometry_info.h
@@ -83,12 +83,14 @@ namespace NKikimr::NBsController {
         ui32 GetDomainLevelBegin() const { return DomainLevelBegin; }
         ui32 GetDomainLevelEnd() const { return DomainLevelEnd; }
 
-        void AllocateGroup(TGroupMapper &mapper, TGroupId groupId, TGroupMapper::TGroupDefinition &group, TGroupMapper::TGroupConstraintsDefinition& constrainsts,
+        void AllocateGroup(TGroupMapper &mapper, TGroupId groupId, TGroupMapper::TGroupDefinition &group,
+                TGroupMapper::TGroupConstraintsDefinition& constrainsts,
                 const THashMap<TVDiskIdShort, TPDiskId>& replacedDisks, TGroupMapper::TForbiddenPDisks forbid,
-                i64 requiredSpace) const {
+                i64 requiredSpace, std::optional<TBridgePileId> bridgePileId) const {
             TString error;
             for (const bool requireOperational : {true, false}) {
-                if (mapper.AllocateGroup(groupId.GetRawId(), group, constrainsts, replacedDisks, forbid, requiredSpace, requireOperational, error)) {
+                if (mapper.AllocateGroup(groupId.GetRawId(), group, constrainsts, replacedDisks, forbid, requiredSpace,
+                        requireOperational, bridgePileId, error)) {
                     return;
                 }
             }
@@ -96,8 +98,10 @@ namespace NKikimr::NBsController {
         }
 
         // returns pair of previous VDisk and PDisk id's
-        std::pair<TVDiskIdShort, TPDiskId> SanitizeGroup(TGroupMapper &mapper, TGroupId groupId, TGroupMapper::TGroupDefinition &group, TGroupMapper::TGroupConstraintsDefinition&,
-                const THashMap<TVDiskIdShort, TPDiskId>& /*replacedDisks*/, TGroupMapper::TForbiddenPDisks forbid, i64 requiredSpace) const {
+        std::pair<TVDiskIdShort, TPDiskId> SanitizeGroup(TGroupMapper &mapper, TGroupId groupId,
+                TGroupMapper::TGroupDefinition &group, TGroupMapper::TGroupConstraintsDefinition&,
+                const THashMap<TVDiskIdShort, TPDiskId>& /*replacedDisks*/, TGroupMapper::TForbiddenPDisks forbid,
+                i64 requiredSpace, std::optional<TBridgePileId> bridgePileId) const {
             TString error;
             auto misplacedVDisks = mapper.FindMisplacedVDisks(group);
             if (misplacedVDisks.Disks.size() == 0) {
@@ -107,7 +111,7 @@ namespace NKikimr::NBsController {
                     for (const auto& replacedDisk : misplacedVDisks.Disks) {
                         TPDiskId pdiskId = group[replacedDisk.FailRealm][replacedDisk.FailDomain][replacedDisk.VDisk];
                         if (mapper.TargetMisplacedVDisk(groupId, group, replacedDisk, forbid, requiredSpace,
-                                requireOperational, error)) {
+                                requireOperational, bridgePileId, error)) {
                             return {replacedDisk, pdiskId};
                         }
                     }

--- a/ydb/core/mind/bscontroller/group_mapper.cpp
+++ b/ydb/core/mind/bscontroller/group_mapper.cpp
@@ -16,10 +16,12 @@ namespace NKikimr::NBsController {
             ui32 SkipToNextRealmGroup;
             ui32 SkipToNextRealm;
             ui32 SkipToNextDomain;
+            std::optional<TBridgePileId> BridgePileId;
 
-            TPDiskInfo(const TPDiskRecord& pdisk, TPDiskLayoutPosition position)
+            TPDiskInfo(const TPDiskRecord& pdisk, TPDiskLayoutPosition position, std::optional<TBridgePileId> bridgePileId)
                 : TPDiskRecord(pdisk)
                 , Position(std::move(position))
+                , BridgePileId(bridgePileId)
             {
                 std::sort(Groups.begin(), Groups.end());
             }
@@ -78,17 +80,20 @@ namespace NKikimr::NBsController {
             const i64 RequiredSpace;
             const bool RequireOperational;
             TForbiddenPDisks ForbiddenDisks;
+            const std::optional<TBridgePileId> BridgePileId;
             THashMap<ui32, unsigned> LocalityFactor;
             TGroupLayout GroupLayout;
             std::optional<TScore> WorstScore;
 
             TDiskManager(TImpl& self, const TGroupGeometryInfo& geom, i64 requiredSpace, bool requireOperational,
-                    TForbiddenPDisks forbiddenDisks, const THashMap<TVDiskIdShort, TPDiskId>& replacedDisks)
+                    TForbiddenPDisks forbiddenDisks, const THashMap<TVDiskIdShort, TPDiskId>& replacedDisks,
+                    std::optional<TBridgePileId> bridgePileId)
                 : Self(self)
                 , Topology(geom.GetType(), geom.GetNumFailRealms(), geom.GetNumFailDomainsPerFailRealm(), geom.GetNumVDisksPerFailDomain(), true)
                 , RequiredSpace(requiredSpace)
                 , RequireOperational(requireOperational)
                 , ForbiddenDisks(std::move(forbiddenDisks))
+                , BridgePileId(bridgePileId)
                 , GroupLayout(Topology)
             {
                 for (const auto& [vdiskId, pdiskId] : replacedDisks) {
@@ -159,6 +164,9 @@ namespace NKikimr::NBsController {
                     return false;
                 }
                 if (pdisk.SpaceAvailable < RequiredSpace) {
+                    return false;
+                }
+                if (BridgePileId && pdisk.BridgePileId != BridgePileId) {
                     return false;
                 }
                 return true;
@@ -301,12 +309,7 @@ namespace NKikimr::NBsController {
         };
 
         struct TAllocator : public TDiskManager {
-
-            TAllocator(TImpl& self, const TGroupGeometryInfo& geom, i64 requiredSpace, bool requireOperational,
-                    TForbiddenPDisks forbiddenDisks, const THashMap<TVDiskIdShort, TPDiskId>& replacedDisks)
-                : TDiskManager(self, geom, requiredSpace, requireOperational, forbiddenDisks, replacedDisks)
-            {
-            }
+            using TDiskManager::TDiskManager;
 
             bool FillInGroup(double maxScore, TUndoLog& undo, TGroup& group, const TGroupConstraints& constraints) {
                 // determine PDisks that fit our requirements (including score)
@@ -573,11 +576,7 @@ namespace NKikimr::NBsController {
             // pRealm -> {pDomain1, pDomain2, ... }
             // Cannot be a candidate, this domains are already placed correctly
 
-            TSanitizer(TImpl& self, const TGroupGeometryInfo& geom, i64 requiredSpace, bool requireOperational,
-                    TForbiddenPDisks forbiddenDisks, const THashMap<TVDiskIdShort, TPDiskId>& replacedDisks)
-                : TDiskManager(self, geom, requiredSpace, requireOperational, forbiddenDisks, replacedDisks)
-            {
-            }
+            using TDiskManager::TDiskManager;
 
             bool SetupNavigation(const TGroup& group) {
                 TPDiskByPosition matchingDisks = SetupMatchingDisks(::Max<double>());
@@ -863,7 +862,7 @@ namespace NKikimr::NBsController {
             // insert PDisk into specific map
             TPDisks::iterator it;
             bool inserted;
-            std::tie(it, inserted) = PDisks.try_emplace(pdisk.PDiskId, pdisk, p);
+            std::tie(it, inserted) = PDisks.try_emplace(pdisk.PDiskId, pdisk, p, pdisk.BridgePileId);
             if (inserted) {
                 PDiskByPosition.emplace_back(it->second.Position, &it->second);
                 Dirty = true;
@@ -926,6 +925,9 @@ namespace NKikimr::NBsController {
                     if (!pdisk->Operational) {
                         s << std::exchange(minus, "") << "o";
                     }
+                    if (pdisk->BridgePileId != diskManager.BridgePileId) {
+                        s << std::exchange(minus, "") << "p";
+                    }
                     if (diskManager.DiskIsUsable(*pdisk)) {
                         s << "+";
                     }
@@ -942,7 +944,7 @@ namespace NKikimr::NBsController {
 
         bool AllocateGroup(ui32 groupId, TGroupDefinition& groupDefinition, TGroupMapper::TGroupConstraintsDefinition& constraints,
                 const THashMap<TVDiskIdShort, TPDiskId>& replacedDisks, TForbiddenPDisks forbid, i64 requiredSpace, bool requireOperational,
-                TString& error) {
+                std::optional<TBridgePileId> bridgePileId, TString& error) {
             if (Dirty) {
                 std::sort(PDiskByPosition.begin(), PDiskByPosition.end());
                 Dirty = false;
@@ -955,7 +957,8 @@ namespace NKikimr::NBsController {
             }
 
             // fill in the allocation context
-            TAllocator allocator(*this, Geom, requiredSpace, requireOperational, std::move(forbid), replacedDisks);
+            TAllocator allocator(*this, Geom, requiredSpace, requireOperational, std::move(forbid), replacedDisks,
+                bridgePileId);
             TGroup group = allocator.ProcessExistingGroup(groupDefinition, error);
             TGroupConstraints groupConstraints = allocator.ProcessGroupConstraints(constraints);
             if (group.empty()) {
@@ -1030,7 +1033,7 @@ namespace NKikimr::NBsController {
                 return TMisplacedVDisks(EFailLevel::INCORRECT_LAYOUT, {}, "Incorrect group");
             }
 
-            TSanitizer sanitizer(*this, Geom, 0, false, {}, {});
+            TSanitizer sanitizer(*this, Geom, 0, false, {}, {}, {});
             TString error;
             TGroup group = sanitizer.ProcessExistingGroup(groupDefinition, error);
             if (group.empty()) {
@@ -1050,7 +1053,8 @@ namespace NKikimr::NBsController {
         }
 
         std::optional<TPDiskId> TargetMisplacedVDisk(ui32 groupId, TGroupDefinition& groupDefinition, TVDiskIdShort vdisk,
-                TForbiddenPDisks forbid, i64 requiredSpace, bool requireOperational, TString& error) {
+                TForbiddenPDisks forbid, i64 requiredSpace, bool requireOperational, std::optional<TBridgePileId> bridgePileId,
+                TString& error) {
             if (Dirty) {
                 std::sort(PDiskByPosition.begin(), PDiskByPosition.end());
                 Dirty = false;
@@ -1062,7 +1066,7 @@ namespace NKikimr::NBsController {
                 return std::nullopt;
             }
 
-            TSanitizer sanitizer(*this, Geom, requiredSpace, requireOperational, std::move(forbid), {});
+            TSanitizer sanitizer(*this, Geom, requiredSpace, requireOperational, std::move(forbid), {}, bridgePileId);
             TGroup group = sanitizer.ProcessExistingGroup(groupDefinition, error);
             if (group.empty()) {
                 error = "Empty group";
@@ -1145,14 +1149,18 @@ namespace NKikimr::NBsController {
     }
 
     bool TGroupMapper::AllocateGroup(ui32 groupId, TGroupDefinition& group, TGroupMapper::TGroupConstraintsDefinition& constraints,
-            const THashMap<TVDiskIdShort, TPDiskId>& replacedDisks, TForbiddenPDisks forbid, i64 requiredSpace, bool requireOperational, TString& error) {
-        return Impl->AllocateGroup(groupId, group, constraints, replacedDisks, std::move(forbid), requiredSpace, requireOperational, error);
+            const THashMap<TVDiskIdShort, TPDiskId>& replacedDisks, TForbiddenPDisks forbid, i64 requiredSpace, bool requireOperational,
+            std::optional<TBridgePileId> bridgePileId, TString& error) {
+        return Impl->AllocateGroup(groupId, group, constraints, replacedDisks, std::move(forbid), requiredSpace,
+            requireOperational, bridgePileId, error);
     }
 
     bool TGroupMapper::AllocateGroup(ui32 groupId, TGroupDefinition& group, const THashMap<TVDiskIdShort, TPDiskId>& replacedDisks,
-            TForbiddenPDisks forbid, i64 requiredSpace, bool requireOperational, TString& error) {
+            TForbiddenPDisks forbid, i64 requiredSpace, bool requireOperational, std::optional<TBridgePileId> bridgePileId,
+            TString& error) {
         TGroupMapper::TGroupConstraintsDefinition emptyConstraints;
-        return AllocateGroup(groupId, group, emptyConstraints, replacedDisks, std::move(forbid), requiredSpace, requireOperational, error);
+        return AllocateGroup(groupId, group, emptyConstraints, replacedDisks, std::move(forbid), requiredSpace,
+            requireOperational, bridgePileId, error);
     }
 
     TGroupMapper::TMisplacedVDisks TGroupMapper::FindMisplacedVDisks(const TGroupDefinition& group) {
@@ -1160,7 +1168,9 @@ namespace NKikimr::NBsController {
     }
 
     std::optional<TPDiskId> TGroupMapper::TargetMisplacedVDisk(TGroupId groupId, TGroupMapper::TGroupDefinition& group,
-            TVDiskIdShort vdisk, TForbiddenPDisks forbid, i64 requiredSpace, bool requireOperational, TString& error) {
-        return Impl->TargetMisplacedVDisk(groupId.GetRawId(), group, vdisk, std::move(forbid), requiredSpace, requireOperational, error);
+            TVDiskIdShort vdisk, TForbiddenPDisks forbid, i64 requiredSpace, bool requireOperational,
+            std::optional<TBridgePileId> bridgePileId, TString& error) {
+        return Impl->TargetMisplacedVDisk(groupId.GetRawId(), group, vdisk, std::move(forbid), requiredSpace,
+            requireOperational, bridgePileId, error);
     }
 } // NKikimr::NBsController

--- a/ydb/core/mind/bscontroller/group_mapper.h
+++ b/ydb/core/mind/bscontroller/group_mapper.h
@@ -63,6 +63,7 @@ namespace NKikimr {
                 const bool Operational;
                 const bool Decommitted;
                 TString WhyUnusable;
+                std::optional<TBridgePileId> BridgePileId;
             };
 
         public:
@@ -99,9 +100,11 @@ namespace NKikimr {
             // (1) and (2). That is, prefix gives us unique domains in which we can find realms to operate, while
             // prefix+infix part gives us distinct fail realms we can use while generating groups.
             bool AllocateGroup(ui32 groupId, TGroupDefinition& group, TGroupMapper::TGroupConstraintsDefinition& constraints,
-                const THashMap<TVDiskIdShort, TPDiskId>& replacedDisks, TForbiddenPDisks forbid, i64 requiredSpace, bool requireOperational, TString& error);
+                const THashMap<TVDiskIdShort, TPDiskId>& replacedDisks, TForbiddenPDisks forbid, i64 requiredSpace,
+                bool requireOperational, std::optional<TBridgePileId> bridgePileId, TString& error);
             bool AllocateGroup(ui32 groupId, TGroupDefinition& group, const THashMap<TVDiskIdShort, TPDiskId>& replacedDisks,
-                TForbiddenPDisks forbid, i64 requiredSpace, bool requireOperational, TString& error);
+                TForbiddenPDisks forbid, i64 requiredSpace, bool requireOperational, std::optional<TBridgePileId> bridgePileId,
+                TString& error);
 
             struct TMisplacedVDisks {
                 enum EFailLevel : ui32 {
@@ -132,7 +135,8 @@ namespace NKikimr {
             TMisplacedVDisks FindMisplacedVDisks(const TGroupDefinition& group);
 
             std::optional<TPDiskId> TargetMisplacedVDisk(TGroupId groupId, TGroupDefinition& group, TVDiskIdShort vdisk, 
-                TForbiddenPDisks forbid, i64 requiredSpace, bool requireOperational, TString& error);
+                TForbiddenPDisks forbid, i64 requiredSpace, bool requireOperational, std::optional<TBridgePileId> bridgePileId,
+                TString& error);
         };
 
     } // NBsController

--- a/ydb/core/mind/bscontroller/group_mapper_ut.cpp
+++ b/ydb/core/mind/bscontroller/group_mapper_ut.cpp
@@ -171,7 +171,7 @@ public:
     ui32 AllocateGroup(TGroupMapper& mapper, TGroupMapper::TGroupDefinition& group, bool allowFailure = false) {
         ui32 groupId = NextGroupId++;
         TString error;
-        bool success = mapper.AllocateGroup(groupId, group, {}, {}, 0, false, error);
+        bool success = mapper.AllocateGroup(groupId, group, {}, {}, 0, false, std::nullopt, error);
         if (!success && allowFailure) {
             return 0;
         }
@@ -216,7 +216,7 @@ public:
 
         TString error;
         bool success = mapper.AllocateGroup(groupId, group.Group, replacedDisks, std::move(forbid), 0,
-            requireOperational, error);
+            requireOperational, std::nullopt, error);
         if (!success) {
             Ctest << "error# " << error << Endl;
             if (allowError) {
@@ -298,7 +298,7 @@ public:
             status = ESanitizeResult::FAIL;
             for (auto vdisk : result.Disks) {
                 auto target = mapper.TargetMisplacedVDisk(TGroupId::FromValue(groupId), group.Group, vdisk,
-                    std::move(forbid), 0, requireOperational, error);
+                    std::move(forbid), 0, requireOperational, std::nullopt, error);
                 if (target) {
                     status = ESanitizeResult::SUCCESS;
                     if (movedDisk) {

--- a/ydb/core/mind/bscontroller/impl.h
+++ b/ydb/core/mind/bscontroller/impl.h
@@ -587,6 +587,8 @@ public:
 
         Table::GroupSizeInUnits::Type GroupSizeInUnits;
 
+        TMaybe<Table::BridgePileId::Type> BridgePileId;
+
         TMaybe<Table::VirtualGroupName::Type> VirtualGroupName;
         TMaybe<Table::VirtualGroupState::Type> VirtualGroupState;
         TMaybe<Table::HiveId::Type> HiveId;
@@ -596,6 +598,7 @@ public:
         TMaybe<Table::ErrorReason::Type> ErrorReason;
         TMaybe<Table::NeedAlter::Type> NeedAlter;
         std::optional<NKikimrBlobStorage::TGroupMetrics> GroupMetrics;
+        TMaybe<Table::BridgeGroupInfo::Type> BridgeGroupInfo;
 
         bool Down = false; // is group are down right now (not selectable)
         TVector<TIndirectReferable<TVSlotInfo>::TPtr> VDisksInGroup;
@@ -665,6 +668,7 @@ public:
                     Table::SeenOperational,
                     Table::DecommitStatus,
                     Table::GroupSizeInUnits,
+                    Table::BridgePileId,
                     Table::VirtualGroupName,
                     Table::VirtualGroupState,
                     Table::HiveId,
@@ -672,7 +676,8 @@ public:
                     Table::BlobDepotConfig,
                     Table::BlobDepotId,
                     Table::ErrorReason,
-                    Table::NeedAlter
+                    Table::NeedAlter,
+                    Table::BridgeGroupInfo
                 > adapter(
                     &TGroupInfo::Generation,
                     &TGroupInfo::Owner,
@@ -688,6 +693,7 @@ public:
                     &TGroupInfo::SeenOperational,
                     &TGroupInfo::DecommitStatus,
                     &TGroupInfo::GroupSizeInUnits,
+                    &TGroupInfo::BridgePileId,
                     &TGroupInfo::VirtualGroupName,
                     &TGroupInfo::VirtualGroupState,
                     &TGroupInfo::HiveId,
@@ -695,7 +701,8 @@ public:
                     &TGroupInfo::BlobDepotConfig,
                     &TGroupInfo::BlobDepotId,
                     &TGroupInfo::ErrorReason,
-                    &TGroupInfo::NeedAlter
+                    &TGroupInfo::NeedAlter,
+                    &TGroupInfo::BridgeGroupInfo
                 );
             callback(&adapter);
         }
@@ -1218,6 +1225,7 @@ public:
         TMaybe<ui64> PathItemId;
         bool RandomizeGroupMapping;
         Table::DefaultGroupSizeInUnits::Type DefaultGroupSizeInUnits;
+        Table::BridgeMode::Type BridgeMode = false;
 
         bool IsSameGeometry(const TStoragePoolInfo& other) const {
             return ErasureSpecies == other.ErasureSpecies
@@ -1321,6 +1329,7 @@ public:
                     Table::PathItemId,
                     Table::RandomizeGroupMapping,
                     Table::DefaultGroupSizeInUnits,
+                    Table::BridgeMode,
                     TInlineTable<TUserIds, Schema::BoxStoragePoolUser>,
                     TInlineTable<TPDiskFilters, Schema::BoxStoragePoolPDiskFilter>
                 > adapter(
@@ -1348,6 +1357,7 @@ public:
                     &TStoragePoolInfo::PathItemId,
                     &TStoragePoolInfo::RandomizeGroupMapping,
                     &TStoragePoolInfo::DefaultGroupSizeInUnits,
+                    &TStoragePoolInfo::BridgeMode,
                     &TStoragePoolInfo::UserIds,
                     &TStoragePoolInfo::PDiskFilters
                 );
@@ -1583,6 +1593,7 @@ private:
     bool DonorMode = false;
     TDuration ScrubPeriodicity;
     std::shared_ptr<const NKikimrBlobStorage::TStorageConfig> StorageConfig;
+    TBridgeInfo::TPtr BridgeInfo;
     bool SelfManagementEnabled = false;
     std::optional<TYamlConfig> YamlConfig;
     ui64 YamlConfigHash = 0;
@@ -1598,7 +1609,6 @@ private:
     bool StopGivingGroups = false;
     bool GroupLayoutSanitizerEnabled = false;
     bool AllowMultipleRealmsOccupation = true;
-    bool StorageConfigObtained = false;
     bool Loaded = false;
     bool EnableConfigV2 = false;
     std::shared_ptr<TControlWrapper> EnableSelfHealWithDegraded;
@@ -1866,7 +1876,7 @@ private:
 
     THostRecordMap HostRecords;
     void Handle(TEvInterconnect::TEvNodesInfo::TPtr &ev);
-    void OnHostRecordsInitiate();
+    void SetHostRecords(THostRecordMap hostRecords);
 
     void CommitMetrics();
 

--- a/ydb/core/mind/bscontroller/load_everything.cpp
+++ b/ydb/core/mind/bscontroller/load_everything.cpp
@@ -237,6 +237,8 @@ public:
                     group.NAME = groups.GetValue<T::NAME>(); \
                 }
 
+                OPTIONAL(BridgeGroupInfo)
+
                 OPTIONAL(VirtualGroupName)
                 OPTIONAL(VirtualGroupState)
                 OPTIONAL(HiveId)

--- a/ydb/core/mind/bscontroller/scheme.h
+++ b/ydb/core/mind/bscontroller/scheme.h
@@ -52,7 +52,7 @@ struct Schema : NIceDb::Schema {
     };
 
     struct Group : Table<4> {
-        struct ID : Column<1, NScheme::NTypeIds::Uint32> { using Type = TGroupId; static constexpr Type Default = TGroupId::Zero();}; // PK
+        struct ID : Column<1, NScheme::NTypeIds::Uint32> { using Type = TGroupId; static constexpr Type Default = TGroupId::Zero(); }; // PK
         struct Generation : Column<2, NScheme::NTypeIds::Uint32> {};
         struct ErasureSpecies : Column<3, NScheme::NTypeIds::Uint32> { using Type = TErasureType::EErasureSpecies; };
         struct Owner : Column<4, NScheme::NTypeIds::Uint64> {};
@@ -68,6 +68,7 @@ struct Schema : NIceDb::Schema {
         struct SeenOperational : Column<14, NScheme::NTypeIds::Bool> { static constexpr Type Default = false; };
         struct DecommitStatus : Column<15, NScheme::NTypeIds::Uint32> { using Type = NKikimrBlobStorage::TGroupDecommitStatus::E; };
         struct GroupSizeInUnits : Column<16, NScheme::NTypeIds::Uint32> { static constexpr Type Default = 0; };
+        struct BridgePileId : Column<17, NScheme::NTypeIds::Uint32> { using Type = TBridgePileId; };
 
         // VirtualGroup management code
         struct VirtualGroupName  : Column<112, NScheme::NTypeIds::Utf8>   {}; // unique name of the virtual group
@@ -79,12 +80,13 @@ struct Schema : NIceDb::Schema {
         struct ErrorReason       : Column<110, NScheme::NTypeIds::Utf8>   {}; // creation error reason
         struct NeedAlter         : Column<111, NScheme::NTypeIds::Bool>   {}; // did the BlobDepotConfig change?
         struct Metrics           : Column<114, NScheme::NTypeIds::String> {}; // for virtual groups only
+        struct BridgeGroupInfo   : Column<121, NScheme::NTypeIds::String> {}; // bridged group protobuf
 
         using TKey = TableKey<ID>;
         using TColumns = TableColumns<ID, Generation, ErasureSpecies, Owner, DesiredPDiskCategory, DesiredVDiskCategory,
               EncryptionMode, LifeCyclePhase, MainKeyId, EncryptedGroupKey, GroupKeyNonce, MainKeyVersion, Down,
-              SeenOperational, DecommitStatus, GroupSizeInUnits, VirtualGroupName, VirtualGroupState, HiveId, Database,
-              BlobDepotConfig, BlobDepotId, ErrorReason, NeedAlter, Metrics>;
+              SeenOperational, DecommitStatus, GroupSizeInUnits, BridgePileId, VirtualGroupName, VirtualGroupState,
+              HiveId, Database, BlobDepotConfig, BlobDepotId, ErrorReason, NeedAlter, Metrics, BridgeGroupInfo>;
     };
 
     struct State : Table<1> {
@@ -311,13 +313,16 @@ struct Schema : NIceDb::Schema {
         struct RandomizeGroupMapping : Column<25, NScheme::NTypeIds::Bool> { static constexpr Type Default = false; };
         // this value is only accounted when new groups are added to the pool
         struct DefaultGroupSizeInUnits : Column<26, NScheme::NTypeIds::Uint32> { static constexpr Type Default = 0; };
+        // does this storage pool work in bridge mode?
+        struct BridgeMode : Column<27, NScheme::NTypeIds::Bool> { static constexpr Type Default = false; };
 
         using TKey = TableKey<BoxId, StoragePoolId>;
 
         using TColumns = TableColumns<BoxId, StoragePoolId, Name, ErasureSpecies, RealmLevelBegin, RealmLevelEnd,
           DomainLevelBegin, DomainLevelEnd, NumFailRealms, NumFailDomainsPerFailRealm, NumVDisksPerFailDomain,
           VDiskKind, SpaceBytes, WriteIOPS, WriteBytesPerSecond, ReadIOPS, ReadBytesPerSecond, InMemCacheBytes,
-          Kind, NumGroups, Generation, EncryptionMode, SchemeshardId, PathItemId, RandomizeGroupMapping, DefaultGroupSizeInUnits>;
+          Kind, NumGroups, Generation, EncryptionMode, SchemeshardId, PathItemId, RandomizeGroupMapping,
+          DefaultGroupSizeInUnits, BridgeMode>;
     };
 
     struct BoxStoragePoolUser : Table<121> {

--- a/ydb/core/mind/bscontroller/select_groups.h
+++ b/ydb/core/mind/bscontroller/select_groups.h
@@ -23,7 +23,7 @@ namespace NKikimr {
                         for (TGroupId groupId : iter->second) {
                             const TGroupInfo *group = controller.FindGroup(groupId);
                             Y_DEBUG_ABORT_UNLESS(group);
-                            if (group && group->Listable()) {
+                            if (group && group->Listable() && !group->BridgePileId) {
                                 groups.push_back(group);
                             }
                         }
@@ -50,7 +50,7 @@ namespace NKikimr {
                         for (auto it = storagePoolGroups.lower_bound(id); it != storagePoolGroups.end() && it->first == id; ++it) {
                             const TGroupInfo *groupInfo = findGroupCallback(it->second);
                             Y_DEBUG_ABORT_UNLESS(groupInfo);
-                            if (groupInfo && groupInfo->Listable()) {
+                            if (groupInfo && groupInfo->Listable() && !groupInfo->BridgePileId) {
                                 groups.push_back(groupInfo);
                             }
                         }

--- a/ydb/core/mind/bscontroller/storage_stats_calculator.cpp
+++ b/ydb/core/mind/bscontroller/storage_stats_calculator.cpp
@@ -158,7 +158,7 @@ public:
                 TGroupMapper::TGroupDefinition group;
                 TString error;
                 std::deque<ui64> groupSizes;
-                while (mapper.AllocateGroup(groupSizes.size(), group, {}, {}, 0, false, error)) {
+                while (mapper.AllocateGroup(groupSizes.size(), group, {}, {}, 0, false, {}, error)) {
                     std::vector<TGroupDiskInfo> disks;
                     std::deque<NKikimrBlobStorage::TPDiskMetrics> pdiskMetrics;
                     std::deque<NKikimrBlobStorage::TVDiskMetrics> vdiskMetrics;

--- a/ydb/tests/functional/scheme_tests/canondata/tablet_scheme_tests.TestTabletSchemes.test_tablet_schemes_flat_bs_controller_/flat_bs_controller.schema
+++ b/ydb/tests/functional/scheme_tests/canondata/tablet_scheme_tests.TestTabletSchemes.test_tablet_schemes_flat_bs_controller_/flat_bs_controller.schema
@@ -423,6 +423,11 @@
                 "ColumnType": "Uint64"
             },
             {
+                "ColumnId": 121,
+                "ColumnName": "BridgeGroupInfo",
+                "ColumnType": "String"
+            },
+            {
                 "ColumnId": 5,
                 "ColumnName": "DesiredPDiskCategory",
                 "ColumnType": "Uint64"
@@ -488,6 +493,11 @@
                 "ColumnType": "Uint32"
             },
             {
+                "ColumnId": 17,
+                "ColumnName": "BridgePileId",
+                "ColumnType": "Uint32"
+            },
+            {
                 "ColumnId": 106,
                 "ColumnName": "BlobDepotConfig",
                 "ColumnType": "String"
@@ -532,6 +542,7 @@
                     3,
                     120,
                     4,
+                    121,
                     5,
                     6,
                     7,
@@ -545,6 +556,7 @@
                     102,
                     15,
                     16,
+                    17,
                     106,
                     109,
                     110,
@@ -709,6 +721,11 @@
                 "ColumnId": 26,
                 "ColumnName": "DefaultGroupSizeInUnits",
                 "ColumnType": "Uint32"
+            },
+            {
+                "ColumnId": 27,
+                "ColumnName": "BridgeMode",
+                "ColumnType": "Bool"
             }
         ],
         "ColumnsDropped": [],
@@ -740,7 +757,8 @@
                     23,
                     24,
                     25,
-                    26
+                    26,
+                    27
                 ],
                 "RoomID": 0,
                 "Codec": 0,


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

Support bridge mode for BSC storage pools

### Changelog category <!-- remove all except one -->

* Not for changelog (changelog entry is not required)

### Description for reviewers <!-- (optional) description for those who read this PR -->

This patch allows BSC managing bridged mode groups automatically. User still see pools as they expected them to see.
