### PR TITLE
schemeshard: add notion and protection of system path names

### DIFF
--- a/ydb/core/kqp/proxy_service/kqp_script_executions_ut.cpp
+++ b/ydb/core/kqp/proxy_service/kqp_script_executions_ut.cpp
@@ -58,7 +58,7 @@ const TVector<NKikimrSchemeOp::TColumnDescription> EXTENDED_COLUMNS = {
     Col("col5", NScheme::NTypeIds::Interval)
 };
 
-const TVector<TString> TEST_TABLE_PATH = { ".test", "test_table" };
+const TVector<TString> TEST_TABLE_PATH = { "test", "test_table" };
 
 const TVector<TString> TEST_KEY_COLUMNS = {"col1"};
 
@@ -349,15 +349,18 @@ Y_UNIT_TEST_SUITE(TableCreation) {
 
         constexpr i32 requests = 2;
 
+        auto uniqueTablePath = TEST_TABLE_PATH;
         TVector<TActorId> edgeActors;
         for (i32 i = 0; i < requests; ++i) {
-            edgeActors.push_back(ydb.CreateTableInDbAsync(DEFAULT_COLUMNS, { ".test", "test_table" + ToString(i)}));
+            uniqueTablePath.back() = TEST_TABLE_PATH.back() + ToString(i);
+            edgeActors.push_back(ydb.CreateTableInDbAsync(DEFAULT_COLUMNS, uniqueTablePath));
         }
 
         ydb.WaitTableCreation(std::move(edgeActors));
 
         for(i32 i = 0; i < requests; i++) {
-            ydb.VerifyColumnsList({".test", "test_table" + ToString(i)});
+            uniqueTablePath.back() = TEST_TABLE_PATH.back() + ToString(i);
+            ydb.VerifyColumnsList(uniqueTablePath);
         }
     }
 
@@ -367,17 +370,20 @@ Y_UNIT_TEST_SUITE(TableCreation) {
         constexpr i32 tables = 2;
         constexpr i32 requests = 20;
 
+        auto uniqueTablePath = TEST_TABLE_PATH;
         TVector<TActorId> edgeActors;
         for (i32 i = 0; i < tables; ++i) {
-            for (i32 j = 0; j < requests; ++j){
-                edgeActors.push_back(ydb.CreateTableInDbAsync(DEFAULT_COLUMNS, { ".test", "test_table" + ToString(i)}));
+            uniqueTablePath.back() = TEST_TABLE_PATH.back() + ToString(i);
+            for (i32 j = 0; j < requests; ++j) {
+                edgeActors.push_back(ydb.CreateTableInDbAsync(DEFAULT_COLUMNS, uniqueTablePath));
             }
         }
 
         ydb.WaitTableCreation(std::move(edgeActors));
 
         for(i32 i = 0; i < tables; i++) {
-            ydb.VerifyColumnsList({".test", "test_table" + ToString(i)});
+            uniqueTablePath.back() = TEST_TABLE_PATH.back() + ToString(i);
+            ydb.VerifyColumnsList(uniqueTablePath);
         }
     }
 

--- a/ydb/core/protos/feature_flags.proto
+++ b/ydb/core/protos/feature_flags.proto
@@ -213,4 +213,5 @@ message TFeatureFlags {
     optional bool EnableAddUniqueIndex = 187 [default = false];
     optional bool EnableSharedMetadataAccessorCache = 188 [default = true, deprecated = true];
     optional bool RequireDbPrefixInSecretName = 189 [default = false];
+    optional bool EnableSystemNamesProtection = 190 [default = false];
 }

--- a/ydb/core/sys_view/ut_kqp.cpp
+++ b/ydb/core/sys_view/ut_kqp.cpp
@@ -3578,6 +3578,12 @@ ALTER OBJECT `/Root/test_show_create` (TYPE TABLE) SET (ACTION = UPSERT_OPTIONS,
     Y_UNIT_TEST(SystemViewFailOps) {
         TTestEnv env;
 
+        // Make AdministrationAllowedSIDs non-empty to deny anonymous user cluster admin privilege.
+        // All requests here are made anonymously, effectively making all requests run with admin rights.
+        // That can cause side effects, especially when dealing with system reserved names.
+        // Using an authorized non-admin user helps avoid these side effects.
+        env.GetServer().GetRuntime()->GetAppData().AdministrationAllowedSIDs.push_back("thou-shalt-not-pass");
+
         TTableClient client(env.GetDriver());
         auto session = client.CreateSession().GetValueSync().GetSession();
 

--- a/ydb/core/testlib/basics/feature_flags.h
+++ b/ydb/core/testlib/basics/feature_flags.h
@@ -79,6 +79,7 @@ public:
     FEATURE_FLAG_SETTER(EnableShowCreate)
     FEATURE_FLAG_SETTER(EnableLocalDBBtreeIndex)
     FEATURE_FLAG_SETTER(EnableSharedMetadataAccessorCache)
+    FEATURE_FLAG_SETTER(EnableSystemNamesProtection)
 
     #undef FEATURE_FLAG_SETTER
 };

--- a/ydb/core/tx/schemeshard/olap/operations/create_store.cpp
+++ b/ydb/core/tx/schemeshard/olap/operations/create_store.cpp
@@ -377,7 +377,7 @@ public:
 
             if (checks) {
                 checks
-                    .IsValidLeafName()
+                    .IsValidLeafName(context.UserToken.Get())
                     .DepthLimit()
                     .PathsLimit()
                     .DirChildrenLimit()

--- a/ydb/core/tx/schemeshard/olap/operations/create_table.cpp
+++ b/ydb/core/tx/schemeshard/olap/operations/create_table.cpp
@@ -665,7 +665,7 @@ public:
 
             if (checks) {
                 checks
-                    .IsValidLeafName()
+                    .IsValidLeafName(context.UserToken.Get())
                     .DepthLimit()
                     .PathsLimit()
                     .ShardsLimit(storeInfo ? 0 : shardsCount)

--- a/ydb/core/tx/schemeshard/schemeshard__op_traits.cpp
+++ b/ydb/core/tx/schemeshard/schemeshard__op_traits.cpp
@@ -1,0 +1,157 @@
+#include <ydb/core/protos/schemeshard/operations.pb.h>
+
+#include "schemeshard__op_traits.h"
+
+
+namespace NKikimr::NSchemeShard {
+
+enum EOperationClass {
+    Create = 0,
+    Alter,
+    Drop,
+    Other,
+    Unknown
+};
+
+EOperationClass GetOperationClass(NKikimrSchemeOp::EOperationType op) {
+    switch (op) {
+        // Simple operations that create paths
+        case NKikimrSchemeOp::EOperationType::ESchemeOpMkDir:
+        case NKikimrSchemeOp::EOperationType::ESchemeOpCreateTable:
+        case NKikimrSchemeOp::EOperationType::ESchemeOpCreatePersQueueGroup:
+        case NKikimrSchemeOp::EOperationType::ESchemeOpCreateSubDomain:
+        case NKikimrSchemeOp::EOperationType::ESchemeOpCreateRtmrVolume:
+        case NKikimrSchemeOp::EOperationType::ESchemeOpCreateBlockStoreVolume:
+        case NKikimrSchemeOp::EOperationType::ESchemeOpCreateKesus:
+        case NKikimrSchemeOp::EOperationType::ESchemeOpCreateSolomonVolume:
+        case NKikimrSchemeOp::EOperationType::ESchemeOpCreateIndexedTable:
+        case NKikimrSchemeOp::EOperationType::ESchemeOpCreateTableIndex:
+        case NKikimrSchemeOp::EOperationType::ESchemeOpCreateExtSubDomain:
+        case NKikimrSchemeOp::EOperationType::ESchemeOpCreateFileStore:
+        case NKikimrSchemeOp::EOperationType::ESchemeOpCreateColumnStore:
+        case NKikimrSchemeOp::EOperationType::ESchemeOpCreateColumnTable:
+        case NKikimrSchemeOp::EOperationType::ESchemeOpCreateCdcStream:
+        case NKikimrSchemeOp::EOperationType::ESchemeOpMoveTable:
+        case NKikimrSchemeOp::EOperationType::ESchemeOpMoveTableIndex:
+        case NKikimrSchemeOp::EOperationType::ESchemeOpCreateSequence:
+        case NKikimrSchemeOp::EOperationType::ESchemeOpCreateReplication:
+        case NKikimrSchemeOp::EOperationType::ESchemeOpCreateBlobDepot:
+        case NKikimrSchemeOp::EOperationType::ESchemeOpCreateExternalTable:
+        case NKikimrSchemeOp::EOperationType::ESchemeOpMoveIndex:
+        case NKikimrSchemeOp::EOperationType::ESchemeOpCreateExternalDataSource:
+        case NKikimrSchemeOp::EOperationType::ESchemeOpCreateView:
+        case NKikimrSchemeOp::EOperationType::ESchemeOpCreateResourcePool:
+        case NKikimrSchemeOp::EOperationType::ESchemeOpCreateContinuousBackup:
+        case NKikimrSchemeOp::EOperationType::ESchemeOpCreateBackupCollection:
+        case NKikimrSchemeOp::EOperationType::ESchemeOpMoveSequence:
+        case NKikimrSchemeOp::EOperationType::ESchemeOpCreateTransfer:
+        case NKikimrSchemeOp::EOperationType::ESchemeOpCreateSysView:
+            return EOperationClass::Create;
+
+        // Simple operations that drop paths
+        case NKikimrSchemeOp::EOperationType::ESchemeOpDropTable:
+        case NKikimrSchemeOp::EOperationType::ESchemeOpDropPersQueueGroup:
+        case NKikimrSchemeOp::EOperationType::ESchemeOpRmDir:
+        case NKikimrSchemeOp::EOperationType::ESchemeOpDropSubDomain:
+        case NKikimrSchemeOp::EOperationType::ESchemeOpDropBlockStoreVolume:
+        case NKikimrSchemeOp::EOperationType::ESchemeOpDropKesus:
+        case NKikimrSchemeOp::EOperationType::ESchemeOpForceDropSubDomain:
+        case NKikimrSchemeOp::EOperationType::ESchemeOpDropSolomonVolume:
+        case NKikimrSchemeOp::EOperationType::ESchemeOpForceDropUnsafe:
+        case NKikimrSchemeOp::EOperationType::ESchemeOpDropTableIndex:
+        case NKikimrSchemeOp::EOperationType::ESchemeOpForceDropExtSubDomain:
+        case NKikimrSchemeOp::EOperationType::ESchemeOpDropLock:
+        case NKikimrSchemeOp::EOperationType::ESchemeOpDropIndex:
+        case NKikimrSchemeOp::EOperationType::ESchemeOpDropTableIndexAtMainTable:
+        case NKikimrSchemeOp::EOperationType::ESchemeOpDropFileStore:
+        case NKikimrSchemeOp::EOperationType::ESchemeOpDropColumnStore:
+        case NKikimrSchemeOp::EOperationType::ESchemeOpDropColumnTable:
+        case NKikimrSchemeOp::EOperationType::ESchemeOpDropCdcStream:
+        case NKikimrSchemeOp::EOperationType::ESchemeOpDropSequence:
+        case NKikimrSchemeOp::EOperationType::ESchemeOpDropReplication:
+        case NKikimrSchemeOp::EOperationType::ESchemeOpDropBlobDepot:
+        case NKikimrSchemeOp::EOperationType::ESchemeOpDropView:
+        case NKikimrSchemeOp::EOperationType::ESchemeOpDropResourcePool:
+        case NKikimrSchemeOp::EOperationType::ESchemeOpDropExternalTable:
+        case NKikimrSchemeOp::EOperationType::ESchemeOpDropExternalDataSource:
+        case NKikimrSchemeOp::EOperationType::ESchemeOpDropContinuousBackup:
+        case NKikimrSchemeOp::EOperationType::ESchemeOpDropBackupCollection:
+        case NKikimrSchemeOp::EOperationType::ESchemeOpDropTransfer:
+        case NKikimrSchemeOp::EOperationType::ESchemeOpDropTransferCascade:
+        case NKikimrSchemeOp::EOperationType::ESchemeOpDropSysView:
+            return EOperationClass::Drop;
+
+        // Simple operations that alter paths
+        case NKikimrSchemeOp::EOperationType::ESchemeOpAlterTable:
+        case NKikimrSchemeOp::EOperationType::ESchemeOpAlterPersQueueGroup:
+        case NKikimrSchemeOp::EOperationType::ESchemeOpModifyACL:
+        case NKikimrSchemeOp::EOperationType::ESchemeOpAlterBlockStoreVolume:
+        case NKikimrSchemeOp::EOperationType::ESchemeOpAlterKesus:
+        case NKikimrSchemeOp::EOperationType::ESchemeOpAlterSubDomain:
+        case NKikimrSchemeOp::EOperationType::ESchemeOpAlterUserAttributes:
+        case NKikimrSchemeOp::EOperationType::ESchemeOpAlterExtSubDomain:
+        case NKikimrSchemeOp::EOperationType::ESchemeOpAlterTableIndex:
+        case NKikimrSchemeOp::EOperationType::ESchemeOpAlterSolomonVolume:
+        case NKikimrSchemeOp::EOperationType::ESchemeOpAlterFileStore:
+        case NKikimrSchemeOp::EOperationType::ESchemeOpAlterColumnStore:
+        case NKikimrSchemeOp::EOperationType::ESchemeOpAlterColumnTable:
+        case NKikimrSchemeOp::EOperationType::ESchemeOpAlterCdcStream:
+        case NKikimrSchemeOp::EOperationType::ESchemeOpAlterSequence:
+        case NKikimrSchemeOp::EOperationType::ESchemeOpAlterReplication:
+        case NKikimrSchemeOp::EOperationType::ESchemeOpAlterBlobDepot:
+        case NKikimrSchemeOp::EOperationType::ESchemeOpAlterExternalTable:
+        case NKikimrSchemeOp::EOperationType::ESchemeOpAlterExternalDataSource:
+        case NKikimrSchemeOp::EOperationType::ESchemeOpAlterView:
+        case NKikimrSchemeOp::EOperationType::ESchemeOpAlterResourcePool:
+        case NKikimrSchemeOp::EOperationType::ESchemeOpAlterContinuousBackup:
+        case NKikimrSchemeOp::EOperationType::ESchemeOpAlterBackupCollection:
+        case NKikimrSchemeOp::EOperationType::ESchemeOpAlterTransfer:
+            return EOperationClass::Alter;
+
+        // Compound or special operations
+        case NKikimrSchemeOp::EOperationType::ESchemeOpCreateConsistentCopyTables:
+        case NKikimrSchemeOp::EOperationType::ESchemeOpSplitMergeTablePartitions:
+        case NKikimrSchemeOp::EOperationType::ESchemeOpBackup:
+        case NKikimrSchemeOp::EOperationType::ESchemeOpAssignBlockStoreVolume:
+        case NKikimrSchemeOp::EOperationType::ESchemeOp_DEPRECATED_35:
+        case NKikimrSchemeOp::EOperationType::ESchemeOpUpgradeSubDomain:
+        case NKikimrSchemeOp::EOperationType::ESchemeOpUpgradeSubDomainDecision:
+        case NKikimrSchemeOp::EOperationType::ESchemeOpCreateIndexBuild:
+        case NKikimrSchemeOp::EOperationType::ESchemeOpInitiateBuildIndexMainTable:
+        case NKikimrSchemeOp::EOperationType::ESchemeOpCreateLock:
+        case NKikimrSchemeOp::EOperationType::ESchemeOpApplyIndexBuild:
+        case NKikimrSchemeOp::EOperationType::ESchemeOpFinalizeBuildIndexMainTable:
+        case NKikimrSchemeOp::EOperationType::ESchemeOpFinalizeBuildIndexImplTable:
+        case NKikimrSchemeOp::EOperationType::ESchemeOpInitiateBuildIndexImplTable:
+        case NKikimrSchemeOp::EOperationType::ESchemeOpCancelIndexBuild:
+        case NKikimrSchemeOp::EOperationType::ESchemeOpRestore:
+        case NKikimrSchemeOp::EOperationType::ESchemeOpAlterLogin:
+        case NKikimrSchemeOp::EOperationType::ESchemeOpCreateCdcStreamImpl:
+        case NKikimrSchemeOp::EOperationType::ESchemeOpCreateCdcStreamAtTable:
+        case NKikimrSchemeOp::EOperationType::ESchemeOpAlterCdcStreamImpl:
+        case NKikimrSchemeOp::EOperationType::ESchemeOpAlterCdcStreamAtTable:
+        case NKikimrSchemeOp::EOperationType::ESchemeOpDropCdcStreamImpl:
+        case NKikimrSchemeOp::EOperationType::ESchemeOpDropCdcStreamAtTable:
+        case NKikimrSchemeOp::EOperationType::ESchemeOpDropReplicationCascade:
+        case NKikimrSchemeOp::EOperationType::ESchemeOpAlterExtSubDomainCreateHive:
+        case NKikimrSchemeOp::EOperationType::ESchemeOpCreateColumnBuild:
+        case NKikimrSchemeOp::EOperationType::ESchemeOpRestoreMultipleIncrementalBackups:
+        case NKikimrSchemeOp::EOperationType::ESchemeOpRestoreIncrementalBackupAtTable:
+        case NKikimrSchemeOp::EOperationType::ESchemeOpBackupBackupCollection:
+        case NKikimrSchemeOp::EOperationType::ESchemeOpBackupIncrementalBackupCollection:
+        case NKikimrSchemeOp::EOperationType::ESchemeOpRestoreBackupCollection:
+        case NKikimrSchemeOp::EOperationType::ESchemeOpCreateLongIncrementalRestoreOp:
+        case NKikimrSchemeOp::EOperationType::ESchemeOpChangePathState:
+            return EOperationClass::Other;
+
+        // intentionally no default -- to trigger [-Werror,-Wswitch] compile error on any new entry not handled here
+    }
+
+    return EOperationClass::Unknown;
+}
+
+bool IsCreatePathOperation(NKikimrSchemeOp::EOperationType op) {
+    return (GetOperationClass(op) == EOperationClass::Create);
+}
+
+}  // namespace NKikimr::NSchemeShard

--- a/ydb/core/tx/schemeshard/schemeshard__op_traits.h
+++ b/ydb/core/tx/schemeshard/schemeshard__op_traits.h
@@ -5,6 +5,7 @@
 #include "schemeshard_path.h"
 
 #include <ydb/core/protos/flat_scheme_op.pb.h>
+#include <ydb/core/protos/flat_scheme_op.pb.h>
 
 #include <util/generic/map.h>
 #include <util/generic/string.h>
@@ -232,4 +233,6 @@ bool Rewrite(TTraits traits, TTxTransaction& tx) {
     return false;
 }
 
-}// namespace NKikimr::NSchemeShard
+bool IsCreatePathOperation(NKikimrSchemeOp::EOperationType op);
+
+}  // namespace NKikimr::NSchemeShard

--- a/ydb/core/tx/schemeshard/schemeshard__op_traits.h
+++ b/ydb/core/tx/schemeshard/schemeshard__op_traits.h
@@ -5,7 +5,6 @@
 #include "schemeshard_path.h"
 
 #include <ydb/core/protos/flat_scheme_op.pb.h>
-#include <ydb/core/protos/flat_scheme_op.pb.h>
 
 #include <util/generic/map.h>
 #include <util/generic/string.h>
@@ -172,6 +171,13 @@ struct TSchemeTxTraits<NKikimrSchemeOp::EOperationType::ESchemeOpRestoreBackupCo
     : public TSchemeTxTraitsFallback
 {
     constexpr inline static bool CreateAdditionalDirs = true;
+};
+
+template <>
+struct TSchemeTxTraits<NKikimrSchemeOp::EOperationType::ESchemeOpCreateSequence>
+    : public TSchemeTxTraitsFallback
+{
+    constexpr inline static bool CreateDirsFromName = true;
 };
 
 template <>

--- a/ydb/core/tx/schemeshard/schemeshard__operation.cpp
+++ b/ydb/core/tx/schemeshard/schemeshard__operation.cpp
@@ -868,10 +868,6 @@ bool CreateDirs(const TTxTransaction& tx, const TPath& parentPath, TPath path, T
                 .NotResolved();
         }
 
-        if (checks) {
-            checks.IsValidLeafName();
-        }
-
         if (!checks) {
             result.Status = checks.GetStatus();
             result.Reason = checks.GetError();
@@ -962,10 +958,6 @@ TOperation::TSplitTransactionsResult TOperation::SplitIntoTransactions(const TTx
                 checks
                     .NotEmpty()
                     .NotResolved();
-            }
-
-            if (checks && !exists) {
-                checks.IsValidLeafName();
             }
 
             if (!checks) {

--- a/ydb/core/tx/schemeshard/schemeshard__operation.cpp
+++ b/ydb/core/tx/schemeshard/schemeshard__operation.cpp
@@ -91,14 +91,6 @@ struct TSchemeShard::TTxOperationProposeCancelTx: public NTabletFlatExecutor::TT
     }
 };
 
-NKikimrScheme::TEvModifySchemeTransaction GetRecordForPrint(const NKikimrScheme::TEvModifySchemeTransaction& record) {
-    auto recordForPrint = record;
-    if (record.HasUserToken()) {
-        recordForPrint.SetUserToken("***hide token***");
-    }
-    return recordForPrint;
-}
-
 bool TSchemeShard::ProcessOperationParts(
     const TVector<ISubOperation::TPtr>& parts,
     const TTxId& txId,

--- a/ydb/core/tx/schemeshard/schemeshard__operation_alter_external_data_source.cpp
+++ b/ydb/core/tx/schemeshard/schemeshard__operation_alter_external_data_source.cpp
@@ -91,18 +91,13 @@ class TAlterExternalDataSource : public TSubOperation {
     }
 
     static bool IsDestinationPathValid(const THolder<TProposeResponse>& result,
-                                       const TPath& dstPath,
-                                       const TString& acl) {
+                                       const TPath& dstPath) {
         const auto checks = dstPath.Check();
         checks.IsAtLocalSchemeShard()
             .IsResolved()
             .NotUnderDeleting()
             .FailOnWrongType(TPathElement::EPathType::EPathTypeExternalDataSource)
-            .IsValidLeafName()
-            .DepthLimit()
-            .PathsLimit()
-            .DirChildrenLimit()
-            .IsValidACL(acl);
+            ;
 
         if (!checks) {
             result->SetError(checks.GetStatus(), checks.GetError());
@@ -179,15 +174,11 @@ class TAlterExternalDataSource : public TSubOperation {
         const TOperationContext& context,
         NIceDb::TNiceDb& db,
         const TPathElement::TPtr& externalDataSourcePath,
-        const TExternalDataSourceInfo::TPtr& externalDataSourceInfo,
-        const TString& acl) const {
+        const TExternalDataSourceInfo::TPtr& externalDataSourceInfo) const {
         const auto& externalDataSourcePathId = externalDataSourcePath->PathId;
 
         context.SS->ExternalDataSources[externalDataSourcePathId] = externalDataSourceInfo;
 
-        if (!acl.empty()) {
-            externalDataSourcePath->ApplyACL(acl);
-        }
         context.SS->PersistPath(db, externalDataSourcePathId);
 
         context.SS->PersistExternalDataSource(db,
@@ -226,10 +217,9 @@ public:
         RETURN_RESULT_UNLESS(NExternalDataSource::IsParentPathValid(
             result, parentPath, Transaction, /* isCreate */ false));
 
-        const TString acl   = Transaction.GetModifyACL().GetDiffACL();
         const TPath dstPath = parentPath.Child(name);
 
-        RETURN_RESULT_UNLESS(IsDestinationPathValid(result, dstPath, acl));
+        RETURN_RESULT_UNLESS(IsDestinationPathValid(result, dstPath));
         RETURN_RESULT_UNLESS(IsApplyIfChecksPassed(result, context));
         RETURN_RESULT_UNLESS(IsDescriptionValid(result, externalDataSourceDescription, context.SS->ExternalSourceFactory));
 
@@ -271,7 +261,7 @@ public:
         AdvanceTransactionStateToPropose(context, db);
 
         PersistExternalDataSource(
-            context, db, externalDataSource, externalDataSourceInfo, acl);
+            context, db, externalDataSource, externalDataSourceInfo);
 
         IncParentDirAlterVersionWithRepublishSafeWithUndo(OperationId,
                                                           dstPath,

--- a/ydb/core/tx/schemeshard/schemeshard__operation_alter_resource_pool.cpp
+++ b/ydb/core/tx/schemeshard/schemeshard__operation_alter_resource_pool.cpp
@@ -82,17 +82,13 @@ class TAlterResourcePool : public TSubOperation {
         }
     }
 
-    static bool IsDestinationPathValid(const THolder<TProposeResponse>& result, const TPath& dstPath, const TString& acl) {
+    static bool IsDestinationPathValid(const THolder<TProposeResponse>& result, const TPath& dstPath) {
         const auto checks = dstPath.Check();
         checks.IsAtLocalSchemeShard()
             .IsResolved()
             .NotUnderDeleting()
             .FailOnWrongType(TPathElement::EPathType::EPathTypeResourcePool)
-            .IsValidLeafName()
-            .DepthLimit()
-            .PathsLimit()
-            .DirChildrenLimit()
-            .IsValidACL(acl);
+            ;
 
         if (!checks) {
             result->SetError(checks.GetStatus(), checks.GetError());
@@ -140,8 +136,7 @@ public:
         RETURN_RESULT_UNLESS(NResourcePool::IsParentPathValid(result, parentPath));
 
         const TPath& dstPath = parentPath.Child(name);
-        const TString& acl = Transaction.GetModifyACL().GetDiffACL();
-        RETURN_RESULT_UNLESS(IsDestinationPathValid(result, dstPath, acl));
+        RETURN_RESULT_UNLESS(IsDestinationPathValid(result, dstPath));
         RETURN_RESULT_UNLESS(NResourcePool::IsApplyIfChecksPassed(Transaction, result, context));
         RETURN_RESULT_UNLESS(NResourcePool::IsDescriptionValid(result, resourcePoolDescription));
 
@@ -158,7 +153,7 @@ public:
 
         NIceDb::TNiceDb db(context.GetDB());
         NResourcePool::AdvanceTransactionStateToPropose(OperationId, context, db);
-        NResourcePool::PersistResourcePool(OperationId, context, db, resourcePool, resourcePoolInfo, acl);
+        NResourcePool::PersistResourcePool(OperationId, context, db, resourcePool, resourcePoolInfo, /* acl */ TString());
 
         IncParentDirAlterVersionWithRepublishSafeWithUndo(OperationId, dstPath, context.SS, context.OnComplete);
 

--- a/ydb/core/tx/schemeshard/schemeshard__operation_blob_depot.cpp
+++ b/ydb/core/tx/schemeshard/schemeshard__operation_blob_depot.cpp
@@ -281,7 +281,7 @@ namespace NKikimr::NSchemeShard {
 
                     if (checks) {
                         checks
-                            .IsValidLeafName()
+                            .IsValidLeafName(context.UserToken.Get())
                             .DepthLimit()
                             .PathsLimit()
                             .DirChildrenLimit()

--- a/ydb/core/tx/schemeshard/schemeshard__operation_common_resource_pool.h
+++ b/ydb/core/tx/schemeshard/schemeshard__operation_common_resource_pool.h
@@ -32,6 +32,6 @@ void RegisterParentPathDependencies(const TOperationId& operationId, const TOper
 
 void AdvanceTransactionStateToPropose(const TOperationId& operationId, const TOperationContext& context, NIceDb::TNiceDb& db);
 
-void PersistResourcePool(const TOperationId& operationId, const TOperationContext& context, NIceDb::TNiceDb& db, const TPathElement::TPtr& resourcePoolPath, const TResourcePoolInfo::TPtr& resourcePoolInfo, const TString& acll);
+void PersistResourcePool(const TOperationId& operationId, const TOperationContext& context, NIceDb::TNiceDb& db, const TPathElement::TPtr& resourcePoolPath, const TResourcePoolInfo::TPtr& resourcePoolInfo, const TString& acl);
 
 }  // namespace NKikimr::NSchemeShard::NResourcePool

--- a/ydb/core/tx/schemeshard/schemeshard__operation_copy_sequence.cpp
+++ b/ydb/core/tx/schemeshard/schemeshard__operation_copy_sequence.cpp
@@ -625,7 +625,7 @@ public:
             }
 
             if (checks) {
-                checks.IsValidLeafName();
+                checks.IsValidLeafName(context.UserToken.Get());
 
                 if (!parentPath->IsTable()) {
                     checks.DepthLimit();

--- a/ydb/core/tx/schemeshard/schemeshard__operation_copy_table.cpp
+++ b/ydb/core/tx/schemeshard/schemeshard__operation_copy_table.cpp
@@ -445,7 +445,7 @@ public:
                 }
 
                 checks
-                    .IsValidLeafName()
+                    .IsValidLeafName(context.UserToken.Get())
                     .IsTheSameDomain(srcPath)
                     .PathShardsLimit(maxShardsToCreate)
                     .IsValidACL(acl);

--- a/ydb/core/tx/schemeshard/schemeshard__operation_create_backup_collection.cpp
+++ b/ydb/core/tx/schemeshard/schemeshard__operation_create_backup_collection.cpp
@@ -149,7 +149,7 @@ public:
 
             if (checks) {
                 checks
-                    .IsValidLeafName()
+                    .IsValidLeafName(context.UserToken.Get())
                     .DepthLimit()
                     .PathsLimit()
                     .DirChildrenLimit()

--- a/ydb/core/tx/schemeshard/schemeshard__operation_create_bsv.cpp
+++ b/ydb/core/tx/schemeshard/schemeshard__operation_create_bsv.cpp
@@ -244,7 +244,7 @@ public:
 
             if (checks) {
                 checks
-                    .IsValidLeafName()
+                    .IsValidLeafName(context.UserToken.Get())
                     .DepthLimit()
                     .PathsLimit()
                     .DirChildrenLimit()

--- a/ydb/core/tx/schemeshard/schemeshard__operation_create_build_index.cpp
+++ b/ydb/core/tx/schemeshard/schemeshard__operation_create_build_index.cpp
@@ -60,7 +60,7 @@ TVector<ISubOperation::TPtr> CreateBuildIndex(TOperationId opId, const TTxTransa
 
         // TODO(mbkkt) less than necessary for vector index
         checks
-            .IsValidLeafName()
+            .IsValidLeafName(context.UserToken.Get())
             .PathsLimit(2) // index and impl-table
             .DirChildrenLimit();
 

--- a/ydb/core/tx/schemeshard/schemeshard__operation_create_cdc_stream.cpp
+++ b/ydb/core/tx/schemeshard/schemeshard__operation_create_cdc_stream.cpp
@@ -166,7 +166,7 @@ public:
 
             if (checks) {
                 checks
-                    .IsValidLeafName()
+                    .IsValidLeafName(context.UserToken.Get())
                     .PathsLimit()
                     .DirChildrenLimit();
             }
@@ -772,7 +772,7 @@ void DoCreateStream(
 
 namespace {
 
-ISubOperation::TPtr RejectOnCdcChecks(const TOperationId& opId, const TPath& streamPath, const bool acceptExisted) {
+ISubOperation::TPtr RejectOnCdcChecks(const TOperationContext& context, const TOperationId& opId, const TPath& streamPath, const bool acceptExisted) {
     const auto checks = streamPath.Check();
     checks
         .IsAtLocalSchemeShard();
@@ -790,7 +790,7 @@ ISubOperation::TPtr RejectOnCdcChecks(const TOperationId& opId, const TPath& str
 
     if (checks) {
         checks
-            .IsValidLeafName()
+            .IsValidLeafName(context.UserToken.Get())
             .PathsLimit()
             .DirChildrenLimit();
     }
@@ -871,6 +871,7 @@ bool FillBoundaries(const TTableInfo& table, const NKikimrSchemeOp::TCreateCdcSt
 } // anonymous
 
 std::variant<TStreamPaths, ISubOperation::TPtr> DoNewStreamPathChecks(
+    const TOperationContext& context,
     const TOperationId& opId,
     const TPath& workingDirPath,
     const TString& tableName,
@@ -884,7 +885,7 @@ std::variant<TStreamPaths, ISubOperation::TPtr> DoNewStreamPathChecks(
     }
 
     const auto streamPath = tablePath.Child(streamName);
-    if (auto reject = RejectOnCdcChecks(opId, streamPath, acceptExisted)) {
+    if (auto reject = RejectOnCdcChecks(context, opId, streamPath, acceptExisted)) {
         return reject;
     }
 
@@ -925,7 +926,7 @@ TVector<ISubOperation::TPtr> CreateNewCdcStream(TOperationId opId, const TTxTran
     const auto& streamName = streamDesc.GetName();
     const auto workingDirPath = TPath::Resolve(tx.GetWorkingDir(), context.SS);
 
-    const auto checksResult = DoNewStreamPathChecks(opId, workingDirPath, tableName, streamName, acceptExisted);
+    const auto checksResult = DoNewStreamPathChecks(context, opId, workingDirPath, tableName, streamName, acceptExisted);
     if (std::holds_alternative<ISubOperation::TPtr>(checksResult)) {
         return {std::get<ISubOperation::TPtr>(checksResult)};
     }

--- a/ydb/core/tx/schemeshard/schemeshard__operation_create_cdc_stream.h
+++ b/ydb/core/tx/schemeshard/schemeshard__operation_create_cdc_stream.h
@@ -15,6 +15,7 @@ struct TStreamPaths {
 };
 
 std::variant<TStreamPaths, ISubOperation::TPtr> DoNewStreamPathChecks(
+    const TOperationContext& context,
     const TOperationId& opId,
     const TPath& workingDirPath,
     const TString& tableName,

--- a/ydb/core/tx/schemeshard/schemeshard__operation_create_continuous_backup.cpp
+++ b/ydb/core/tx/schemeshard/schemeshard__operation_create_continuous_backup.cpp
@@ -25,7 +25,7 @@ TVector<ISubOperation::TPtr> CreateNewContinuousBackup(TOperationId opId, const 
     const auto& cbOp = tx.GetCreateContinuousBackup();
     const auto& tableName = cbOp.GetTableName();
 
-    const auto checksResult = NCdc::DoNewStreamPathChecks(opId, workingDirPath, tableName, NBackup::CB_CDC_STREAM_NAME, acceptExisted);
+    const auto checksResult = NCdc::DoNewStreamPathChecks(context, opId, workingDirPath, tableName, NBackup::CB_CDC_STREAM_NAME, acceptExisted);
     if (std::holds_alternative<ISubOperation::TPtr>(checksResult)) {
         return {std::get<ISubOperation::TPtr>(checksResult)};
     }

--- a/ydb/core/tx/schemeshard/schemeshard__operation_create_external_data_source.cpp
+++ b/ydb/core/tx/schemeshard/schemeshard__operation_create_external_data_source.cpp
@@ -95,6 +95,7 @@ class TCreateExternalDataSource : public TSubOperation {
     }
 
     static bool IsDestinationPathValid(const THolder<TProposeResponse>& result,
+                                const TOperationContext& context,
                                 const TPath& dstPath,
                                 const TString& acl,
                                 bool acceptExisted) {
@@ -113,7 +114,7 @@ class TCreateExternalDataSource : public TSubOperation {
 
         if (checks) {
             checks
-                .IsValidLeafName()
+                .IsValidLeafName(context.UserToken.Get())
                 .DepthLimit()
                 .PathsLimit()
                 .DirChildrenLimit()
@@ -249,7 +250,7 @@ public:
         const TString acl = Transaction.GetModifyACL().GetDiffACL();
         TPath dstPath     = parentPath.Child(name);
 
-        RETURN_RESULT_UNLESS(IsDestinationPathValid(result, dstPath, acl, acceptExisted));
+        RETURN_RESULT_UNLESS(IsDestinationPathValid(result, context, dstPath, acl, acceptExisted));
         RETURN_RESULT_UNLESS(IsApplyIfChecksPassed(result, context));
         RETURN_RESULT_UNLESS(IsDescriptionValid(result,
                                                 externalDataSourceDescription,

--- a/ydb/core/tx/schemeshard/schemeshard__operation_create_external_table.cpp
+++ b/ydb/core/tx/schemeshard/schemeshard__operation_create_external_table.cpp
@@ -126,6 +126,7 @@ private:
     }
 
     static bool IsDestinationPathValid(const THolder<TProposeResponse>& result,
+                                       const TOperationContext& context,
                                        const TPath& dstPath,
                                        const TString& acl,
                                        bool acceptExisted) {
@@ -144,7 +145,7 @@ private:
 
         if (checks) {
             checks
-                .IsValidLeafName()
+                .IsValidLeafName(context.UserToken.Get())
                 .DepthLimit()
                 .PathsLimit()
                 .DirChildrenLimit()
@@ -316,7 +317,7 @@ public:
         const TString acl = Transaction.GetModifyACL().GetDiffACL();
         TPath dstPath     = parentPath.Child(name);
         RETURN_RESULT_UNLESS(IsDestinationPathValid(
-            result, dstPath, acl, acceptExisted));
+            result, context, dstPath, acl, acceptExisted));
 
         const auto dataSourcePath =
             TPath::Resolve(externalTableDescription.GetDataSourcePath(), context.SS);

--- a/ydb/core/tx/schemeshard/schemeshard__operation_create_extsubdomain.cpp
+++ b/ydb/core/tx/schemeshard/schemeshard__operation_create_extsubdomain.cpp
@@ -113,7 +113,7 @@ public:
 
             if (checks) {
                 checks
-                    .IsValidLeafName()
+                    .IsValidLeafName(context.UserToken.Get())
                     .DepthLimit()
                     .PathsLimit() //check capacity on root Domain
                     .DirChildrenLimit()

--- a/ydb/core/tx/schemeshard/schemeshard__operation_create_fs.cpp
+++ b/ydb/core/tx/schemeshard/schemeshard__operation_create_fs.cpp
@@ -335,7 +335,7 @@ THolder<TProposeResponse> TCreateFileStore::Propose(
 
         if (checks) {
             checks
-                .IsValidLeafName()
+                .IsValidLeafName(context.UserToken.Get())
                 .DepthLimit()
                 .PathsLimit()
                 .DirChildrenLimit()

--- a/ydb/core/tx/schemeshard/schemeshard__operation_create_index.cpp
+++ b/ydb/core/tx/schemeshard/schemeshard__operation_create_index.cpp
@@ -178,7 +178,7 @@ public:
             if (checks) {
                 checks
                     .PathsLimit()
-                    .IsValidLeafName()
+                    .IsValidLeafName(context.UserToken.Get())
                     .IsValidACL(acl);
             }
 

--- a/ydb/core/tx/schemeshard/schemeshard__operation_create_indexed_table.cpp
+++ b/ydb/core/tx/schemeshard/schemeshard__operation_create_indexed_table.cpp
@@ -75,7 +75,7 @@ TVector<ISubOperation::TPtr> CreateIndexedTable(TOperationId nextId, const TTxTr
     TPath baseTablePath = workingDir.Child(baseTableDescription.GetName());
     {
         TString msg = "invalid table name: ";
-        if(!baseTablePath.IsValidLeafName(msg)) {
+        if(!baseTablePath.IsValidLeafName(context.UserToken.Get(), msg)) {
             return {CreateReject(nextId, NKikimrScheme::EStatus::StatusSchemeError, msg)};
         }
     }
@@ -137,7 +137,7 @@ TVector<ISubOperation::TPtr> CreateIndexedTable(TOperationId nextId, const TTxTr
         TPath indexPath = baseTablePath.Child(indexName);
         {
             TString msg = "invalid table index name: ";
-            if (!indexPath.IsValidLeafName(msg)) {
+            if (!indexPath.IsValidLeafName(context.UserToken.Get(), msg)) {
                 return {CreateReject(nextId, NKikimrScheme::EStatus::StatusSchemeError, msg)};
             }
         }
@@ -164,7 +164,7 @@ TVector<ISubOperation::TPtr> CreateIndexedTable(TOperationId nextId, const TTxTr
         TPath sequencePath = baseTablePath.Child(sequenceName);
         {
             TString msg = "invalid sequence name: ";
-            if (!sequencePath.IsValidLeafName(msg)) {
+            if (!sequencePath.IsValidLeafName(context.UserToken.Get(), msg)) {
                 return {CreateReject(nextId, NKikimrScheme::EStatus::StatusSchemeError, msg)};
             }
         }

--- a/ydb/core/tx/schemeshard/schemeshard__operation_create_kesus.cpp
+++ b/ydb/core/tx/schemeshard/schemeshard__operation_create_kesus.cpp
@@ -351,7 +351,7 @@ public:
 
             if (checks) {
                 checks
-                    .IsValidLeafName()
+                    .IsValidLeafName(context.UserToken.Get())
                     .DepthLimit()
                     .PathsLimit()
                     .DirChildrenLimit()

--- a/ydb/core/tx/schemeshard/schemeshard__operation_create_pq.cpp
+++ b/ydb/core/tx/schemeshard/schemeshard__operation_create_pq.cpp
@@ -357,7 +357,7 @@ public:
 
             if (checks) {
                 checks
-                    .IsValidLeafName()
+                    .IsValidLeafName(context.UserToken.Get())
                     .DepthLimit()
                     .PathsLimit()
                     .DirChildrenLimit()

--- a/ydb/core/tx/schemeshard/schemeshard__operation_create_replication.cpp
+++ b/ydb/core/tx/schemeshard/schemeshard__operation_create_replication.cpp
@@ -393,7 +393,7 @@ public:
 
             if (checks) {
                 checks
-                    .IsValidLeafName()
+                    .IsValidLeafName(context.UserToken.Get())
                     .DepthLimit()
                     .PathsLimit()
                     .DirChildrenLimit()

--- a/ydb/core/tx/schemeshard/schemeshard__operation_create_resource_pool.cpp
+++ b/ydb/core/tx/schemeshard/schemeshard__operation_create_resource_pool.cpp
@@ -88,7 +88,7 @@ class TCreateResourcePool : public TSubOperation {
         }
     }
 
-    static bool IsDestinationPathValid(const THolder<TProposeResponse>& result, const TPath& dstPath, const TString& acl, bool acceptExisted) {
+    static bool IsDestinationPathValid(const THolder<TProposeResponse>& result, const TOperationContext& context, const TPath& dstPath, const TString& acl, bool acceptExisted) {
         const auto checks = dstPath.Check();
         checks.IsAtLocalSchemeShard();
         if (dstPath.IsResolved()) {
@@ -104,7 +104,7 @@ class TCreateResourcePool : public TSubOperation {
 
         if (checks) {
             checks
-                .IsValidLeafName()
+                .IsValidLeafName(context.UserToken.Get())
                 .DepthLimit()
                 .PathsLimit()
                 .DirChildrenLimit()
@@ -163,7 +163,7 @@ public:
 
         TPath dstPath = parentPath.Child(name);
         const TString& acl = Transaction.GetModifyACL().GetDiffACL();
-        RETURN_RESULT_UNLESS(IsDestinationPathValid(result, dstPath, acl, !Transaction.GetFailOnExist()));
+        RETURN_RESULT_UNLESS(IsDestinationPathValid(result, context, dstPath, acl, !Transaction.GetFailOnExist()));
         RETURN_RESULT_UNLESS(NResourcePool::IsApplyIfChecksPassed(Transaction, result, context));
         RETURN_RESULT_UNLESS(NResourcePool::IsDescriptionValid(result, resourcePoolDescription));
 

--- a/ydb/core/tx/schemeshard/schemeshard__operation_create_rtmr.cpp
+++ b/ydb/core/tx/schemeshard/schemeshard__operation_create_rtmr.cpp
@@ -266,7 +266,7 @@ public:
 
             if (checks) {
                 checks
-                    .IsValidLeafName()
+                    .IsValidLeafName(context.UserToken.Get())
                     .DepthLimit()
                     .PathsLimit()
                     .DirChildrenLimit()

--- a/ydb/core/tx/schemeshard/schemeshard__operation_create_sequence.cpp
+++ b/ydb/core/tx/schemeshard/schemeshard__operation_create_sequence.cpp
@@ -440,7 +440,7 @@ public:
             }
 
             if (checks) {
-                checks.IsValidLeafName();
+                checks.IsValidLeafName(context.UserToken.Get());
 
                 if (!parentPath->IsTable()) {
                     checks.DepthLimit();

--- a/ydb/core/tx/schemeshard/schemeshard__operation_create_sequence.cpp
+++ b/ydb/core/tx/schemeshard/schemeshard__operation_create_sequence.cpp
@@ -1,6 +1,7 @@
 #include "schemeshard__operation_common.h"
 #include "schemeshard__operation_part.h"
 #include "schemeshard_impl.h"
+#include "schemeshard__op_traits.h"
 
 #include <ydb/core/mind/hive/hive.h>
 #include <ydb/core/tx/sequenceshard/public/events.h>
@@ -599,6 +600,30 @@ public:
 };
 
 }
+
+using TTag = TSchemeTxTraits<NKikimrSchemeOp::EOperationType::ESchemeOpCreateSequence>;
+
+namespace NOperation {
+
+template <>
+std::optional<TString> GetTargetName<TTag>(
+    TTag,
+    const TTxTransaction& tx)
+{
+    return tx.GetSequence().GetName();
+}
+
+template <>
+bool SetName<TTag>(
+    TTag,
+    TTxTransaction& tx,
+    const TString& name)
+{
+    tx.MutableSequence()->SetName(name);
+    return true;
+}
+
+} // namespace NOperation
 
 ISubOperation::TPtr CreateNewSequence(TOperationId id, const TTxTransaction& tx) {
     return MakeSubOperation<TCreateSequence>(id ,tx);

--- a/ydb/core/tx/schemeshard/schemeshard__operation_create_solomon.cpp
+++ b/ydb/core/tx/schemeshard/schemeshard__operation_create_solomon.cpp
@@ -301,7 +301,7 @@ public:
 
             if (checks) {
                 checks
-                    .IsValidLeafName()
+                    .IsValidLeafName(context.UserToken.Get())
                     .DepthLimit()
                     .PathsLimit()
                     .DirChildrenLimit()

--- a/ydb/core/tx/schemeshard/schemeshard__operation_create_subdomain.cpp
+++ b/ydb/core/tx/schemeshard/schemeshard__operation_create_subdomain.cpp
@@ -145,7 +145,7 @@ public:
 
             if (checks) {
                 checks
-                    .IsValidLeafName()
+                    .IsValidLeafName(context.UserToken.Get())
                     .DepthLimit()
                     .PathsLimit() //check capacity on root Domain
                     .DirChildrenLimit()

--- a/ydb/core/tx/schemeshard/schemeshard__operation_create_sysview.cpp
+++ b/ydb/core/tx/schemeshard/schemeshard__operation_create_sysview.cpp
@@ -158,7 +158,7 @@ public:
 
             if (checks) {
                 checks
-                    .IsValidLeafName()
+                    .IsValidLeafName(context.UserToken.Get())
                     .DepthLimit()
                     .PathsLimit()
                     .DirChildrenLimit()

--- a/ydb/core/tx/schemeshard/schemeshard__operation_create_table.cpp
+++ b/ydb/core/tx/schemeshard/schemeshard__operation_create_table.cpp
@@ -497,7 +497,7 @@ public:
                 }
 
                 checks
-                    .IsValidLeafName()
+                    .IsValidLeafName(context.UserToken.Get())
                     .PathsLimit()
                     .DirChildrenLimit()
                     .IsValidACL(acl);

--- a/ydb/core/tx/schemeshard/schemeshard__operation_create_view.cpp
+++ b/ydb/core/tx/schemeshard/schemeshard__operation_create_view.cpp
@@ -161,7 +161,7 @@ public:
 
             if (checks) {
                 checks
-                    .IsValidLeafName()
+                    .IsValidLeafName(context.UserToken.Get())
                     .DepthLimit()
                     .PathsLimit()
                     .DirChildrenLimit()

--- a/ydb/core/tx/schemeshard/schemeshard__operation_mkdir.cpp
+++ b/ydb/core/tx/schemeshard/schemeshard__operation_mkdir.cpp
@@ -172,7 +172,7 @@ public:
 
             if (checks) {
                 checks
-                    .IsValidLeafName()
+                    .IsValidLeafName(context.UserToken.Get())
                     .IsValidACL(acl);
             }
 

--- a/ydb/core/tx/schemeshard/schemeshard__operation_move_sequence.cpp
+++ b/ydb/core/tx/schemeshard/schemeshard__operation_move_sequence.cpp
@@ -891,7 +891,7 @@ public:
             if (checks) {
                 checks
                     .DepthLimit()
-                    .IsValidLeafName()
+                    .IsValidLeafName(context.UserToken.Get())
                     .IsTheSameDomain(srcPath)
                     .DirChildrenLimit()
                     .IsValidACL(acl);

--- a/ydb/core/tx/schemeshard/schemeshard__operation_move_table.cpp
+++ b/ydb/core/tx/schemeshard/schemeshard__operation_move_table.cpp
@@ -748,7 +748,7 @@ public:
             if (checks) {
                 checks
                     .DepthLimit()
-                    .IsValidLeafName();
+                    .IsValidLeafName(context.UserToken.Get());
             }
 
             if (!checks) {

--- a/ydb/core/tx/schemeshard/schemeshard__operation_move_table_index.cpp
+++ b/ydb/core/tx/schemeshard/schemeshard__operation_move_table_index.cpp
@@ -458,7 +458,7 @@ public:
             if (checks) {
                 checks
                     .DepthLimit()
-                    .IsValidLeafName();
+                    .IsValidLeafName(context.UserToken.Get());
             }
 
             if (!checks) {

--- a/ydb/core/tx/schemeshard/schemeshard_build_index__create.cpp
+++ b/ydb/core/tx/schemeshard/schemeshard_build_index__create.cpp
@@ -116,7 +116,11 @@ public:
                 }
 
                 checks
-                    .IsValidLeafName()
+                    //NOTE: empty userToken here means that index is forbidden from getting a name
+                    // thats system reserved or starts with a system reserved prefix.
+                    // Even an cluster admin or the system inself will not be able to force a reserved name for this index.
+                    // If that will become an issue at some point, then a real userToken should be passed here.
+                    .IsValidLeafName(/*userToken*/ nullptr)
                     .PathsLimit(2) // index and impl-table
                     .DirChildrenLimit();
 

--- a/ydb/core/tx/schemeshard/schemeshard_import__create.cpp
+++ b/ydb/core/tx/schemeshard/schemeshard_import__create.cpp
@@ -88,7 +88,10 @@ bool ValidateDstPath(const TString& dstPath, TSchemeShard* ss, TString& explain)
 
     if (checks) {
         checks
-            .IsValidLeafName()
+            //NOTE: using TSystemUsers::Metadata() here allows restoration of paths with system-reserved names/prefixes.
+            // Reason is, that these names aren't being created anew but were legitimate elsewhere or
+            // at some other point in time, blocking them now would create unnecessary problems.
+            .IsValidLeafName(&NACLib::TSystemUsers::Metadata())
             .DepthLimit()
             .PathsLimit();
 
@@ -1011,7 +1014,7 @@ private:
         if (!msg.Success) {
             return CancelAndPersist(db, importInfo, msg.ItemIdx, msg.Error, "cannot get scheme");
         }
-        
+
         if (IsCreatedByQuery(item)) {
             // Send the creation query to KQP to prepare.
             const auto database = GetDatabase(*Self);

--- a/ydb/core/tx/schemeshard/schemeshard_path.h
+++ b/ydb/core/tx/schemeshard/schemeshard_path.h
@@ -8,6 +8,12 @@
 
 #include <util/generic/maybe.h>
 
+namespace NACLib {
+
+class TUserToken;
+
+}
+
 namespace NKikimr::NSchemeShard {
 
 class TSchemeShard;
@@ -85,7 +91,7 @@ public:
         const TChecker& FailOnWrongType(TPathElement::EPathType expectedType) const;
         const TChecker& FailOnExist(const TSet<TPathElement::EPathType>& expectedTypes, bool acceptAlreadyExist) const;
         const TChecker& FailOnExist(TPathElement::EPathType expectedType, bool acceptAlreadyExist) const;
-        const TChecker& IsValidLeafName(EStatus status = EStatus::StatusSchemeError) const;
+        const TChecker& IsValidLeafName(const NACLib::TUserToken* userToken, EStatus status = EStatus::StatusSchemeError) const;
         const TChecker& DepthLimit(ui64 delta = 0, EStatus status = EStatus::StatusSchemeError) const;
         const TChecker& PathsLimit(ui64 delta = 1, EStatus status = EStatus::StatusResourceExhausted) const;
         const TChecker& DirChildrenLimit(ui64 delta = 1, EStatus status = EStatus::StatusResourceExhausted) const;
@@ -182,7 +188,7 @@ public:
     ui32 Depth() const;
     ui64 Shards() const;
     const TString& LeafName() const;
-    bool IsValidLeafName(TString& explain) const;
+    bool IsValidLeafName(const NACLib::TUserToken* userToken, TString& explain) const;
     TString GetEffectiveACL() const;
     ui64 GetEffectiveACLVersion() const;
     bool IsLocked() const;

--- a/ydb/core/tx/schemeshard/schemeshard_system_names.cpp
+++ b/ydb/core/tx/schemeshard/schemeshard_system_names.cpp
@@ -1,0 +1,121 @@
+#include <util/string/builder.h>
+
+#include <ydb/library/aclib/aclib.h>
+#include <ydb/core/base/auth.h>
+
+#include "schemeshard_system_names.h"
+
+
+namespace NKikimr::NSchemeShard {
+
+// ReservedNames and ReservedPrefixes are the lists of names and prefixes
+// that are reserved exclusively for the system's use.
+//
+//NOTE: Updates to the both lists are regulated by the project committee and must be explicitly approved.
+//
+const TVector<TString> ReservedNames = {
+    // Database, column store or a column table can have the directory with the system- or meta- data.
+    //TODO: real name are taken from the config NKikimr::NMetadata::NProvider::TConfig
+    ".metadata",
+
+    // Database has this place for the system views.
+    // (Feature flag EnableSystemViews manages it's use.)
+    ".sys",
+
+    // Database has this directory for keeping kqp-session bound temporary objects (tables etc)
+    ".tmp",
+
+    // Database has this directory for keeping backups and backup related objects
+    ".backups",
+};
+const TVector<TString> ReservedPrefixes = {
+    ".",
+    "__ydb",
+};
+
+// Temporary exceptions from the ReservedNames (note: no prefix exceptions).
+// The goal is to have no exceptions.
+const TVector<TString> ReservedNamesExceptions = {
+    // external agent checking liveness of the database creates this directory
+    ".sys_health",
+    // sqs/yqm employs schema dirs and objects starting with the dot
+    ".AtomicCounter",
+    ".Events",
+    ".FIFO",
+    ".Queues",
+    ".Quoter",
+    ".RemovedQueues",
+    ".Settings",
+    ".STD",
+};
+
+bool CheckReservedNameImpl(const TString& name, bool isSystemUser, bool isAdministrator, TString& explain) {
+    // System reserved names can't be created by ordinary users.
+    // They can only be created:
+    // - by the system itself
+    // - by the admin (allowing amendments if necessary)
+    const bool nameIsReserved = [&name]() {
+        auto it = std::find(ReservedNames.begin(), ReservedNames.end(), name);
+        return (it != ReservedNames.end());
+    }();
+    if (nameIsReserved && !(isSystemUser || isAdministrator)) {
+        explain += TStringBuilder()
+            << "path part '" << name << "', name is reserved by the system: '" << name << "'"
+            << "(subject: system user " << isSystemUser << ", cluster admin " << isAdministrator << ")";
+        return false;
+    }
+
+    // Temporary exceptions from the ReservedNames.
+    const bool nameIsException = [&name]() {
+        auto it = std::find(ReservedNamesExceptions.begin(), ReservedNamesExceptions.end(), name);
+        return (it != ReservedNamesExceptions.end());
+    }();
+    if (nameIsException) {
+        return true;
+    }
+
+    // Names that aren't reserved but start with a reserved prefix can't be created at all,
+    // not even by admins or the system.
+    // Such names must be explicitly added to the ReservedNames list before creation is possible.
+    const auto prefixFound = std::find_if(ReservedPrefixes.begin(), ReservedPrefixes.end(), [&name](const auto& prefix) {
+        return name.StartsWith(prefix);
+    });
+    if (!nameIsReserved && (prefixFound != ReservedPrefixes.end())) {
+        explain += TStringBuilder()
+            << "path part '" << name << "', prefix is reserved by the system: '" << *prefixFound << "'";
+        return false;
+    }
+
+    return true;
+}
+
+bool IsSystemUser(const NACLib::TUserToken* userToken) {
+    return userToken && userToken->IsSystemUser();
+}
+
+bool CheckReservedName(const TString& name, const NACLib::TUserToken* userToken, const TVector<TString>& allowedSids, TString& explain) {
+    return CheckReservedNameImpl(name, IsSystemUser(userToken), IsTokenAllowed(userToken, allowedSids), explain);
+}
+
+bool CheckReservedName(const TString& name, const TAppData* appData, const NACLib::TUserToken* userToken, TString& explain) {
+    return CheckReservedNameImpl(name, IsSystemUser(userToken), IsAdministrator(appData, userToken), explain);
+}
+
+}  // namespace NKikimr::NSchemeShard
+
+
+// For tests
+namespace NSchemeShardUT_Private {
+
+const TVector<TString>& GetReservedNames() {
+    return NKikimr::NSchemeShard::ReservedNames;
+}
+const TVector<TString>& GetReservedPrefixes() {
+    return NKikimr::NSchemeShard::ReservedPrefixes;
+}
+const TVector<TString>& GetReservedNamesExceptions() {
+    return NKikimr::NSchemeShard::ReservedNamesExceptions;
+}
+
+}  // namespace NSchemeShardUT_Private
+

--- a/ydb/core/tx/schemeshard/schemeshard_system_names.h
+++ b/ydb/core/tx/schemeshard/schemeshard_system_names.h
@@ -1,0 +1,17 @@
+#pragma once
+
+#include <util/generic/vector.h>
+#include <util/generic/string.h>
+
+#include <ydb/core/base/appdata_fwd.h>
+
+namespace NACLib {
+class TUserToken;
+}  // namespace NACLib
+
+namespace NKikimr::NSchemeShard {
+
+bool CheckReservedName(const TString& name, const NACLib::TUserToken* userToken, const TVector<TString>& adminSids, TString& explain);
+bool CheckReservedName(const TString& name, const TAppData* appData, const NACLib::TUserToken* userToken, TString& explain);
+
+}  // namespace NKikimr::NSchemeShard

--- a/ydb/core/tx/schemeshard/ut_helpers/helpers.cpp
+++ b/ydb/core/tx/schemeshard/ut_helpers/helpers.cpp
@@ -498,6 +498,34 @@ namespace NSchemeShardUT_Private {
         TestModificationResults(runtime, txId, expectedResults);
     }
 
+    // copy and rename *MoveTable* family
+    //TODO: generalize all Move* stuff
+    TEvSchemeShard::TEvModifySchemeTransaction* MoveSequenceRequest(ui64 txId, const TString& src, const TString& dst, ui64 schemeShard, const TApplyIf& applyIf) {
+        auto tx = MakeHolder<TEvSchemeShard::TEvModifySchemeTransaction>(txId, schemeShard);
+        auto transaction = tx->Record.AddTransaction();
+        transaction->SetOperationType(NKikimrSchemeOp::EOperationType::ESchemeOpMoveSequence);
+        SetApplyIf(*transaction, applyIf);
+
+        auto descr = transaction->MutableMoveSequence();
+        descr->SetSrcPath(src);
+        descr->SetDstPath(dst);
+
+        return tx.Release();
+    }
+
+    void AsyncMoveSequence(TTestActorRuntime& runtime, ui64 txId, const TString& src, const TString& dst, ui64 schemeShard) {
+        AsyncSend(runtime, schemeShard, MoveSequenceRequest(txId, src, dst, schemeShard));
+    }
+
+    void TestMoveSequence(TTestActorRuntime& runtime, ui64 txId, const TString& src, const TString& dst, const TVector<TExpectedResult>& expectedResults) {
+        TestMoveSequence(runtime, TTestTxConfig::SchemeShard, txId, src, dst, expectedResults);
+    }
+
+    void TestMoveSequence(TTestActorRuntime& runtime, ui64 schemeShard, ui64 txId, const TString& src, const TString& dst, const TVector<TExpectedResult>& expectedResults) {
+        AsyncMoveSequence(runtime, txId, src, dst, schemeShard);
+        TestModificationResults(runtime, txId, expectedResults);
+    }
+
     TEvSchemeShard::TEvModifySchemeTransaction* LockRequest(ui64 txId, const TString &parentPath, const TString& name) {
         THolder<TEvSchemeShard::TEvModifySchemeTransaction> evTx = MakeHolder<TEvSchemeShard::TEvModifySchemeTransaction>(txId, TTestTxConfig::SchemeShard);
         auto transaction = evTx->Record.AddTransaction();

--- a/ydb/core/tx/schemeshard/ut_helpers/helpers.h
+++ b/ydb/core/tx/schemeshard/ut_helpers/helpers.h
@@ -122,6 +122,7 @@ namespace NSchemeShardUT_Private {
             : Status(status)
             , ReasonFragment(reasonFragment)
         {}
+        bool operator==(const TExpectedResult&) const = default;
     };
 
     ////////// modification results

--- a/ydb/core/tx/schemeshard/ut_helpers/helpers.h
+++ b/ydb/core/tx/schemeshard/ut_helpers/helpers.h
@@ -370,6 +370,12 @@ namespace NSchemeShardUT_Private {
     void TestMoveIndex(TTestActorRuntime& runtime, ui64 txId, const TString& tablePath, const TString& srcMove, const TString& dstMove, bool allowOverwrite, const TVector<TExpectedResult>& expectedResults = {NKikimrScheme::StatusAccepted});
     void TestMoveIndex(TTestActorRuntime& runtime, ui64 schemeShard, ui64 txId, const TString& tablePath, const TString& srcMove, const TString& dstMove, bool allowOverwrite, const TVector<TExpectedResult>& expectedResults = {NKikimrScheme::StatusAccepted});
 
+    // move sequence
+    TEvTx* MoveSequenceRequest(ui64 txId, const TString& srcPath, const TString& dstPath, ui64 schemeShard = TTestTxConfig::SchemeShard, const TApplyIf& applyIf = {});
+    void AsyncMoveSequence(TTestActorRuntime& runtime, ui64 txId, const TString& srcPath, const TString& dstPath, ui64 schemeShard = TTestTxConfig::SchemeShard);
+    void TestMoveSequence(TTestActorRuntime& runtime, ui64 txId, const TString& srcMove, const TString& dstMove, const TVector<TExpectedResult>& expectedResults = {NKikimrScheme::StatusAccepted});
+    void TestMoveSequence(TTestActorRuntime& runtime, ui64 schemeShard, ui64 txId, const TString& srcMove, const TString& dstMove, const TVector<TExpectedResult>& expectedResults = {NKikimrScheme::StatusAccepted});
+
     // locks
     TEvTx* LockRequest(ui64 txId, const TString &parentPath, const TString& name);
     void AsyncLock(TTestActorRuntime& runtime, ui64 schemeShard, ui64 txId, const TString& parentPath, const TString& name);

--- a/ydb/core/tx/schemeshard/ut_helpers/test_env.cpp
+++ b/ydb/core/tx/schemeshard/ut_helpers/test_env.cpp
@@ -618,6 +618,7 @@ NSchemeShardUT_Private::TTestEnv::TTestEnv(TTestActorRuntime& runtime, const TTe
     app.SetEnableTopicTransfer(opts.EnableTopicTransfer_);
     app.SetEnablePermissionsExport(opts.EnablePermissionsExport_);
     app.SetEnableLocalDBBtreeIndex(opts.EnableLocalDBBtreeIndex_);
+    app.SetEnableSystemNamesProtection(opts.EnableSystemNamesProtection_);
 
     app.ColumnShardConfig.SetDisabledOnSchemeShard(false);
 

--- a/ydb/core/tx/schemeshard/ut_helpers/test_env.h
+++ b/ydb/core/tx/schemeshard/ut_helpers/test_env.h
@@ -79,6 +79,7 @@ namespace NSchemeShardUT_Private {
         OPTION(std::optional<bool>, EnableChecksumsExport, std::nullopt);
         OPTION(std::optional<bool>, EnableLocalDBBtreeIndex, std::nullopt);
         OPTION(TVector<TIntrusivePtr<NFake::TProxyDS>>, DSProxies, {});
+        OPTION(std::optional<bool>, EnableSystemNamesProtection, std::nullopt);
 
         #undef OPTION
     };

--- a/ydb/core/tx/schemeshard/ut_system_names/ut_system_names.cpp
+++ b/ydb/core/tx/schemeshard/ut_system_names/ut_system_names.cpp
@@ -1,0 +1,999 @@
+#include <ydb/core/tx/schemeshard/ut_helpers/helpers.h>
+#include <ydb/core/protos/schemeshard/operations.pb.h>
+#include <ydb/core/tx/schemeshard/schemeshard__op_traits.h>  // for IsCreatePathOperation
+
+#include <ydb/core/tx/schemeshard/schemeshard_system_names.h>
+
+
+using namespace NSchemeShardUT_Private;  // for helpers.h *Requests() methods
+
+using SetupFlagsMethod = void (*)(TTestEnvOptions& options);
+using SetupObjectsMethod = void (*)(TTestActorRuntime& runtime, ui64 txId, const TString& workingDir);
+using CreateRequestMethod = TEvSchemeShard::TEvModifySchemeTransaction* (*)(const TString& workingDir, const TString& path);
+
+struct TCreatePathOp {
+    NKikimrSchemeOp::EOperationType Type;
+    SetupFlagsMethod SetupFlags = nullptr;
+    SetupObjectsMethod SetupObjects = nullptr;
+    CreateRequestMethod CreateRequest;
+};
+
+// CreatePathOperations must contain an entry for every scheme operation that create path.
+//
+//
+// For any type, .CreateRequest method should return TEvModifySchemeTransaction,
+// complete enough to be able to create object of that type, and no more.
+// The goal is to create object, not use it, no fancy specs required.
+//
+// There are useful *Request() methods that build TEvModifySchemeTransaction from
+// a description of respective TModifyScheme field formatted in a protobuf text format.
+// (*Request() are defined in ydb/core/tx/schemeshard/ut_helpers/helpers.{h,cpp}, mostly by the GENERIC_HELPERS macros).
+//
+// .SetupFlags -- auxiliary method to set feature flags required to enable object creation of the type
+// .SetupObjects -- auxiliary method to create prerequisite objects needed for target object creation
+//
+const std::vector<TCreatePathOp> CreatePathOperations({
+    {
+        .Type = NKikimrSchemeOp::EOperationType::ESchemeOpMkDir,
+        .CreateRequest = [](const TString& workingDir, const TString& path) {
+            return MkDirRequest(0 /* txId */, workingDir, path);
+        }
+    },
+    {
+        .Type = NKikimrSchemeOp::EOperationType::ESchemeOpCreateTable,
+        .CreateRequest = [](const TString& workingDir, const TString& path) {
+            const TString modifyScheme = Sprintf(
+                R"(
+                    Name: "%s"
+                    Columns { Name: "key"   Type: "Uint64" }
+                    Columns { Name: "value" Type: "Uint64" }
+                    KeyColumnNames: ["key"]
+                )",
+                path.c_str()
+            );
+            return CreateTableRequest(0 /* txId */, workingDir, modifyScheme);
+        }
+    },
+    {
+        // This is special as here ESchemeOpCreateIndexedTable is used to
+        // test creation of table index object and not table itself.
+        .Type = NKikimrSchemeOp::EOperationType::ESchemeOpCreateIndexedTable,
+        .CreateRequest = [](const TString& workingDir, const TString& path) {
+            auto parts = SplitPath(path);
+            const auto basename = parts.back();
+            parts.back() = "table";
+            const auto dirname = JoinPath(parts);
+            const TString modifyScheme = Sprintf(
+                R"(
+                    TableDescription {
+                        Name: "%s"
+                        Columns { Name: "key"   Type: "Uint64" }
+                        Columns { Name: "value" Type: "Uint64" }
+                        KeyColumnNames: ["key"]
+                    }
+                    IndexDescription {
+                        Name: "%s"
+                        KeyColumnNames: ["value"]
+                    }
+                )",
+                dirname.c_str(),
+                basename.c_str()
+            );
+            return CreateIndexedTableRequest(0 /* txId */, workingDir, modifyScheme);
+        }
+    },
+    {
+        // index creation is already tested with ESchemeOpCreateIndexedTable
+        .Type = NKikimrSchemeOp::EOperationType::ESchemeOpCreateTableIndex,
+        .CreateRequest = nullptr,
+    },
+    {
+        .Type = NKikimrSchemeOp::EOperationType::ESchemeOpCreateCdcStream,
+        //TODO: proper check
+        .CreateRequest = nullptr,
+        // .SetupObjects = [](TTestActorRuntime& runtime, ui64 txId, const TString& workingDir) {
+        //     const TString modifyScheme = Sprintf(
+        //         R"(
+        //             Name: "table"
+        //             Columns { Name: "key"   Type: "Uint64" }
+        //             Columns { Name: "value" Type: "Uint64" }
+        //             KeyColumnNames: ["key"]
+        //         )"
+        //     );
+        //     return TestCreateTable(runtime, txId, workingDir, modifyScheme);
+        // },
+        // .CreateRequest = [](const TString& workingDir, const TString& path) {
+        //     const TString modifyScheme = Sprintf(
+        //         R"(
+        //             TableName: "%s"
+        //             StreamDescription: {
+        //                 Name: "%s"
+        //                 Mode: ECdcStreamModeKeysOnly
+        //                 Format: ECdcStreamFormatProto
+        //             }
+        //         )",
+        //         path.c_str()
+        //     );
+        //     return CreateCdcStreamRequest(0 /* txId */, workingDir, modifyScheme);
+        // }
+    },
+    {
+        .Type = NKikimrSchemeOp::EOperationType::ESchemeOpMoveTable,
+        //TODO: proper check
+        .CreateRequest = nullptr,
+        // .SetupObjects = XXX,
+        // .CreateRequest = [](const TString& workingDir, const TString& path) {
+        //     const TString modifyScheme = Sprintf(
+        //         R"(
+        //             Name: "%s"
+        //             ColumnShardCount: 1
+        //             Schema {
+        //                 Columns { Name: "timestamp" Type: "Timestamp" NotNull: true }
+        //                 Columns { Name: "key1" Type: "Uint32" }
+        //                 KeyColumnNames: [ "timestamp" ]
+        //             }
+        //         )",
+        //         path.c_str()
+        //     );
+        //     return MoveTableRequest(0 /* txId */, workingDir, modifyScheme);
+        // }
+    },
+    {
+        .Type = NKikimrSchemeOp::EOperationType::ESchemeOpMoveTableIndex,
+        //TODO: proper check
+        .CreateRequest = nullptr,
+    },
+    {
+        .Type = NKikimrSchemeOp::EOperationType::ESchemeOpMoveIndex,
+        //TODO: proper check
+        .CreateRequest = nullptr,
+    },
+    {
+        .Type = NKikimrSchemeOp::EOperationType::ESchemeOpCreateRtmrVolume,
+        .CreateRequest = [](const TString& workingDir, const TString& path) {
+            const TString modifyScheme = Sprintf(
+                R"(
+                    Name: "%s"
+                    PartitionsCount: 0
+                )",
+                path.c_str()
+            );
+            return CreateRtmrVolumeRequest(0 /* txId */, workingDir, modifyScheme);
+        }
+    },
+    {
+        .Type = NKikimrSchemeOp::EOperationType::ESchemeOpCreateKesus,
+        .CreateRequest = [](const TString& workingDir, const TString& path) {
+            const TString modifyScheme = Sprintf(
+                R"(
+                    Name: "%s"
+                )",
+                path.c_str()
+            );
+            return CreateKesusRequest(0 /* txId */, workingDir, modifyScheme);
+        }
+    },
+    {
+        .Type = NKikimrSchemeOp::EOperationType::ESchemeOpCreateSolomonVolume,
+        .CreateRequest = [](const TString& workingDir, const TString& path) {
+            const TString modifyScheme = Sprintf(
+                R"(
+                    Name: "%s"
+                    PartitionCount: 1
+                )",
+                path.c_str()
+            );
+            return CreateSolomonRequest(0 /* txId */, workingDir, modifyScheme);
+        }
+    },
+    {
+        .Type = NKikimrSchemeOp::EOperationType::ESchemeOpCreateColumnStore,
+        .CreateRequest = [](const TString& workingDir, const TString& path) {
+            const TString modifyScheme = Sprintf(
+                R"(
+                    Name: "%s"
+                    ColumnShardCount: 1
+                    SchemaPresets {
+                        Name: "default"
+                        Schema {
+                            Columns { Name: "timestamp" Type: "Timestamp" NotNull: true }
+                            Columns { Name: "data" Type: "Utf8" }
+                            KeyColumnNames: "timestamp"
+                        }
+                    }
+                )",
+                path.c_str()
+            );
+            return CreateOlapStoreRequest(0 /* txId */, workingDir, modifyScheme);
+        }
+    },
+    {
+        .Type = NKikimrSchemeOp::EOperationType::ESchemeOpCreateSubDomain,
+        .CreateRequest = [](const TString& workingDir, const TString& path) {
+            const TString modifyScheme = Sprintf(
+                R"(
+                    Name: "%s"
+                )",
+                path.c_str()
+            );
+            return CreateSubDomainRequest(0 /* txId */, workingDir, modifyScheme);
+        }
+    },
+    {
+        .Type = NKikimrSchemeOp::EOperationType::ESchemeOpCreateExtSubDomain,
+        .CreateRequest = [](const TString& workingDir, const TString& path) {
+            const TString modifyScheme = Sprintf(
+                R"(
+                    Name: "%s"
+                )",
+                path.c_str()
+            );
+            return CreateExtSubDomainRequest(0 /* txId */, workingDir, modifyScheme);
+        }
+    },
+    {
+        .Type = NKikimrSchemeOp::EOperationType::ESchemeOpCreatePersQueueGroup,
+        .CreateRequest = [](const TString& workingDir, const TString& path) {
+            const TString modifyScheme = Sprintf(
+                R"(
+                    Name: "%s"
+                    TotalGroupCount: 1
+                    PartitionPerTablet: 1
+                    PQTabletConfig: {
+                        PartitionConfig {
+                            LifetimeSeconds: 10
+                        }
+                    }
+                )",
+                path.c_str()
+            );
+            return CreatePQGroupRequest(0 /* txId */, workingDir, modifyScheme);
+        }
+    },
+    {
+        .Type = NKikimrSchemeOp::EOperationType::ESchemeOpCreateFileStore,
+        .CreateRequest = [](const TString& workingDir, const TString& path) {
+            const TString modifyScheme = Sprintf(
+                R"(
+                    Name: "%s"
+                    Config {
+                        BlockSize: 4096
+                        BlocksCount: 4096
+                        ExplicitChannelProfiles {
+                            PoolKind: "pool-kind-1"
+                        }
+                    }
+                )",
+                path.c_str()
+            );
+            return CreateFileStoreRequest(0 /* txId */, workingDir, modifyScheme);
+        }
+    },
+    {
+        .Type = NKikimrSchemeOp::EOperationType::ESchemeOpCreateBlockStoreVolume,
+        .CreateRequest = [](const TString& workingDir, const TString& path) {
+            const TString modifyScheme = Sprintf(
+                R"(
+                    Name: "%s"
+                    VolumeConfig {
+                        BlockSize: 4096
+                        Partitions: [{
+                            BlockCount: 1
+                        }]
+                        ExplicitChannelProfiles {
+                            PoolKind: "pool-kind-1"
+                        }
+                    }
+                )",
+                path.c_str()
+            );
+            return CreateBlockStoreVolumeRequest(0 /* txId */, workingDir, modifyScheme);
+        }
+    },
+    {
+        .Type = NKikimrSchemeOp::EOperationType::ESchemeOpCreateColumnTable,
+        .CreateRequest = [](const TString& workingDir, const TString& path) {
+            const TString modifyScheme = Sprintf(
+                R"(
+                    Name: "%s"
+                    ColumnShardCount: 1
+                    Schema {
+                        Columns { Name: "timestamp" Type: "Timestamp" NotNull: true }
+                        Columns { Name: "key1" Type: "Uint32" }
+                        KeyColumnNames: [ "timestamp" ]
+                    }
+                )",
+                path.c_str()
+            );
+            return CreateColumnTableRequest(0 /* txId */, workingDir, modifyScheme);
+        }
+    },
+    {
+        .Type = NKikimrSchemeOp::EOperationType::ESchemeOpCreateSequence,
+        .CreateRequest = [](const TString& workingDir, const TString& path) {
+            const TString modifyScheme = Sprintf(
+                R"(
+                    Name: "%s"
+                )",
+                path.c_str()
+            );
+            return CreateSequenceRequest(0 /* txId */, workingDir, modifyScheme);
+        }
+    },
+    {
+        //TODO: proper check
+        .Type = NKikimrSchemeOp::EOperationType::ESchemeOpMoveSequence,
+        // .SetupObjects = [](TTestActorRuntime& runtime, ui64 txId, const TString& workingDir) {
+        //     TestCreateSequence(runtime, txId, workingDir, R"(
+        //         Name: "prepare-sequence"
+        //     )");
+        // },
+        // .CreateRequest = [](const TString& workingDir, const TString& path) {
+        //     return MoveSequenceRequest(0 /* txId */, JoinPath({workingDir, "prepare-sequence"}), JoinPath({workingDir, path}));
+        // }
+    },
+    {
+        .Type = NKikimrSchemeOp::EOperationType::ESchemeOpCreateExternalDataSource,
+        .CreateRequest = [](const TString& workingDir, const TString& path) {
+            const TString modifyScheme = Sprintf(
+                R"(
+                    Name: "%s"
+                    SourceType: "ObjectStorage"
+                    Location: "https://s3.cloud.net/my_bucket"
+                    Auth {
+                        None {
+                        }
+                    }
+                )",
+                path.c_str()
+            );
+            return CreateExternalDataSourceRequest(0 /* txId */, workingDir, modifyScheme);
+        }
+    },
+    {
+        .Type = NKikimrSchemeOp::EOperationType::ESchemeOpCreateExternalTable,
+        .SetupObjects = [](TTestActorRuntime& runtime, ui64 txId, const TString& workingDir) {
+            TestCreateExternalDataSource(runtime, txId, workingDir, R"(
+                Name: "prepare-external-data-source"
+                SourceType: "ObjectStorage"
+                Location: "https://s3.cloud.net/my_bucket"
+                Auth {
+                    None {
+                    }
+                }
+            )");
+        },
+        .CreateRequest = [](const TString& workingDir, const TString& path) {
+            const TString modifyScheme = Sprintf(
+                R"(
+                    Name: "%s"
+                    SourceType: "General"
+                    DataSourcePath: "%s/prepare-external-data-source"
+                    Location: "/"
+                    Columns { Name: "key" Type: "Uint64" }
+                )",
+                path.c_str(),
+                workingDir.c_str()
+            );
+            return CreateExternalTableRequest(0 /* txId */, workingDir, modifyScheme);
+        }
+    },
+    {
+        .Type = NKikimrSchemeOp::EOperationType::ESchemeOpCreateView,
+        .CreateRequest = [](const TString& workingDir, const TString& path) {
+            const TString modifyScheme = Sprintf(
+                R"(
+                    Name: "%s"
+                    QueryText: "query"
+                )",
+                path.c_str()
+            );
+            return CreateViewRequest(0 /* txId */, workingDir, modifyScheme);
+        }
+    },
+    {
+        .Type = NKikimrSchemeOp::EOperationType::ESchemeOpCreateReplication,
+        .CreateRequest = [](const TString& workingDir, const TString& path) {
+            const TString modifyScheme = Sprintf(
+                R"(
+                    Name: "%s"
+                )",
+                path.c_str()
+            );
+            return CreateReplicationRequest(0 /* txId */, workingDir, modifyScheme);
+        }
+    },
+    {
+        .Type = NKikimrSchemeOp::EOperationType::ESchemeOpCreateBlobDepot,
+        //TODO: proper check
+        .CreateRequest = nullptr,
+    },
+    {
+        .Type = NKikimrSchemeOp::EOperationType::ESchemeOpCreateContinuousBackup,
+        //TODO: proper check
+        .CreateRequest = nullptr,
+    },
+    {
+        .Type = NKikimrSchemeOp::EOperationType::ESchemeOpCreateResourcePool,
+        //TODO: proper check
+        .CreateRequest = nullptr,
+        // .CreateRequest = [](const TString& workingDir, const TString& path) {
+        //     const TString modifyScheme = Sprintf(
+        //         R"(
+        //             Name: "%s"
+        //         )",
+        //         path.c_str()
+        //     );
+        //     return CreateResourcePoolRequest(0 /* txId */, workingDir, modifyScheme);
+        // }
+    },
+    {
+        .Type = NKikimrSchemeOp::EOperationType::ESchemeOpCreateBackupCollection,
+        //TODO: proper check
+        .CreateRequest = nullptr,
+        // .CreateRequest = [](const TString& workingDir, const TString& path) {
+        //     const TString modifyScheme = Sprintf(
+        //         R"(
+        //             Name: "%s"
+        //         )",
+        //         path.c_str()
+        //     );
+        //     return CreateBackupCollectionRequest(0 /* txId */, workingDir, modifyScheme);
+        // }
+    },
+    {
+        .Type = NKikimrSchemeOp::EOperationType::ESchemeOpCreateTransfer,
+        //TODO: proper check
+        .CreateRequest = nullptr,
+        // .SetupFlags = [](TTestEnvOptions& options) {
+        //     options.EnableTopicTransfer(true);
+        // },
+        // .CreateRequest = [](const TString& workingDir, const TString& path) {
+        //     const TString modifyScheme = Sprintf(
+        //         R"(
+        //             Name: "%s"
+        //         )",
+        //         path.c_str()
+        //     );
+        //     return CreateTransferRequest(0 /* txId */, workingDir, modifyScheme);
+        // }
+    },
+    {
+        .Type = NKikimrSchemeOp::EOperationType::ESchemeOpCreateSysView,
+        //TODO: proper check
+        .CreateRequest = nullptr,
+        // .CreateRequest = [](const TString& workingDir, const TString& path) {
+        //     const TString modifyScheme = Sprintf(
+        //         R"(
+        //             Name: "%s"
+        //         )",
+        //         path.c_str()
+        //     );
+        //     return CreateSysViewRequest(0 /* txId */, workingDir, modifyScheme);
+        // }
+    },
+
+    //NOTE: ADD NEW ENTRY ABOVE THIS LINE
+});
+
+
+namespace NSchemeShardUT_Private {
+
+const TVector<TString>& GetReservedNames();
+const TVector<TString>& GetReservedPrefixes();
+const TVector<TString>& GetReservedNamesExceptions();
+
+}  // namespace NSchemeShardUT_Private
+
+// for UNIT_ASSERT_VALUES_EQUAL on NKikimrSchemeOp::EOperationType values
+template<>
+inline void Out<NKikimrSchemeOp::EOperationType>(IOutputStream& o, NKikimrSchemeOp::EOperationType x) {
+    o << NKikimrSchemeOp::EOperationType_Name(x);
+}
+
+using namespace NKikimr;
+using namespace NSchemeShard;
+using namespace NSchemeShardUT_Private;
+
+enum class EExpectedResult : bool {
+    FORBIDDEN = false,
+    ALLOWED = true
+};
+
+
+Y_UNIT_TEST_SUITE(TSchemeShardSysNamesCore) {
+
+    //NOTE: Any update to the name list must be approved by the project committee.
+    Y_UNIT_TEST(NameListIsUnchanged) {
+        TVector<TString> entries = {
+            ".metadata",
+            ".sys",
+            ".tmp",
+            ".backups",
+        };
+        for (const auto& i : GetReservedNames()) {
+            auto found = std::find(entries.begin(), entries.end(), i);
+            UNIT_ASSERT_C((found != entries.end()), TStringBuilder()
+                << "Unexpected system name: '" << i << "'. Please note that updates to the list of reserved system names MUST be explicitly approved."
+            );
+        }
+    }
+
+    Y_UNIT_TEST(PrefixListIsUnchanged) {
+        TVector<TString> entries = {
+            ".",
+            "__ydb",
+        };
+        for (const auto& i : GetReservedPrefixes()) {
+            auto found = std::find(entries.begin(), entries.end(), i);
+            UNIT_ASSERT_C((found != entries.end()), TStringBuilder()
+                << "Unexpected system name prefix: '" << i << "'. Please note that updates the list of reserved system prefixes MUST be explicitly approved."
+            );
+        }
+    }
+
+    Y_UNIT_TEST(ExceptionsListIsUnchanged) {
+        TVector<TString> entries = {
+            ".sys_health",
+            ".AtomicCounter",
+            ".Events",
+            ".FIFO",
+            ".Queues",
+            ".Quoter",
+            ".RemovedQueues",
+            ".Settings",
+            ".STD",
+        };
+        for (const auto& i : GetReservedNamesExceptions()) {
+            auto found = std::find(entries.begin(), entries.end(), i);
+            UNIT_ASSERT_C((found != entries.end()), TStringBuilder()
+                << "Unexpected exception from system names: '" << i << "'. Please note that updates the list of exceptions from the reserved system names MUST be explicitly approved."
+            );
+        }
+    }
+
+    void TestSystemNames(const NACLib::TUserToken* userToken, const TVector<TString>& adminSids, EExpectedResult expected) {
+        const TString user = (userToken ? userToken->GetUserSID() : "anonymous");
+        for (const auto& i : GetReservedNames()) {
+            TString reasonAccum;
+            bool result = CheckReservedName(i, userToken, adminSids, reasonAccum);
+            if (!result) {
+                UNIT_ASSERT_STRING_CONTAINS(reasonAccum, "name is reserved by the system");
+            }
+            UNIT_ASSERT_VALUES_EQUAL_C(result, bool(expected), TStringBuilder()
+                << "Wrong result for name '" << i << "', user '" << user << "', error '" << reasonAccum << "'"
+            );
+        }
+    }
+
+    static const TVector<TString> AdminSids = {
+        "admin-user@builtin",
+        "admin-group@builtin"
+    };
+
+    Y_UNIT_TEST(SystemNamesForbiddenForAnonymousUser) {
+        TestSystemNames(nullptr, AdminSids, EExpectedResult::FORBIDDEN);
+    }
+
+    Y_UNIT_TEST(SystemNamesForbiddenForOrdinaryUser) {
+        NACLib::TUserToken userToken("user1@builtin", /* groups */ {});
+        TestSystemNames(&userToken, AdminSids, EExpectedResult::FORBIDDEN);
+    }
+
+    Y_UNIT_TEST(SystemNamesAllowedForAdminUser) {
+        NACLib::TUserToken userToken("admin-user@builtin", /* groups */ {});
+        TestSystemNames(&userToken, AdminSids, EExpectedResult::ALLOWED);
+    }
+
+    Y_UNIT_TEST(SystemNamesAllowedForAdminGroup) {
+        NACLib::TUserToken userToken("user1@builtin", /* groups */ {"admin-group@builtin"});
+        TestSystemNames(&userToken, AdminSids, EExpectedResult::ALLOWED);
+    }
+
+    Y_UNIT_TEST(SystemNamesAllowedForSystemUser) {
+        NACLib::TUserToken userToken("metadata@system", /* groups */ {});
+        TestSystemNames(&userToken, AdminSids, EExpectedResult::ALLOWED);
+    }
+
+    // And there is no such thing as a system group
+
+    void TestSystemPrefixes(const NACLib::TUserToken* userToken, const TVector<TString>& adminSids, EExpectedResult expected) {
+        const TString user = (userToken ? userToken->GetUserSID() : "anonymous");
+        // test use of system prefixes as:
+        // - a whole names
+        // - as prefixes to longer names
+        TVector<TString> names = GetReservedPrefixes();
+        for (const auto& i : GetReservedPrefixes()) {
+            names.push_back(i + "-user-name");
+        }
+        for (const auto& i : names) {
+            TString error;
+            bool result = CheckReservedName(i, userToken, adminSids, error);
+            if (!result) {
+                UNIT_ASSERT_STRING_CONTAINS(error, "prefix is reserved by the system");
+            }
+            UNIT_ASSERT_VALUES_EQUAL_C(result, bool(expected), TStringBuilder()
+                << "Wrong result for prefix '" << i << "', user '" << user << "', error '" << error << "'"
+            );
+        }
+    }
+
+    Y_UNIT_TEST(SystemPrefixesForbiddenForAnonymousUser) {
+        TestSystemPrefixes(nullptr, AdminSids, EExpectedResult::FORBIDDEN);
+    }
+
+    Y_UNIT_TEST(SystemPrefixesForbiddenForOrdinaryUser) {
+        NACLib::TUserToken userToken("user1@builtin", /* groups */ {});
+        TestSystemPrefixes(&userToken, AdminSids, EExpectedResult::FORBIDDEN);
+    }
+
+    Y_UNIT_TEST(SystemPrefixesForbiddenForAdminUser) {
+        NACLib::TUserToken userToken("admin-user@builtin", /* groups */ {});
+        TestSystemPrefixes(&userToken, AdminSids, EExpectedResult::FORBIDDEN);
+    }
+
+    Y_UNIT_TEST(SystemPrefixesForbiddenForAdminGroup) {
+        NACLib::TUserToken userToken("user1@builtin", /* groups */ {"admin-group@builtin"});
+        TestSystemPrefixes(&userToken, AdminSids, EExpectedResult::FORBIDDEN);
+    }
+
+    Y_UNIT_TEST(SystemPrefixesForbiddenForSystemUser) {
+        NACLib::TUserToken userToken("metadata@system", /* groups */ {});
+        TestSystemPrefixes(&userToken, AdminSids, EExpectedResult::FORBIDDEN);
+    }
+
+    void TestSystemNamesExceptions(const NACLib::TUserToken* userToken, const TVector<TString>& adminSids, EExpectedResult expected) {
+        const TString user = (userToken ? userToken->GetUserSID() : "anonymous");
+        for (const auto& i : GetReservedNamesExceptions()) {
+            TString reasonAccum;
+            bool result = CheckReservedName(i, userToken, adminSids, reasonAccum);
+            UNIT_ASSERT_VALUES_EQUAL_C(result, bool(expected), TStringBuilder()
+                << "Wrong result for name exception'" << i << "', user '" << user << "', error '" << reasonAccum << "'"
+            );
+        }
+    }
+
+    Y_UNIT_TEST(SystemNamesExceptionsAllowedForAnonymousUser) {
+        TestSystemNamesExceptions(nullptr, AdminSids, EExpectedResult::ALLOWED);
+    }
+
+    Y_UNIT_TEST(SystemNamesExceptionsAllowedForOrdinaryUser) {
+        NACLib::TUserToken userToken("user1@builtin", /* groups */ {});
+        TestSystemNamesExceptions(&userToken, AdminSids, EExpectedResult::ALLOWED);
+    }
+
+    Y_UNIT_TEST(SystemNamesExceptionsAllowedForAdminUser) {
+        NACLib::TUserToken userToken("admin-user@builtin", /* groups */ {});
+        TestSystemNamesExceptions(&userToken, AdminSids, EExpectedResult::ALLOWED);
+    }
+
+    Y_UNIT_TEST(SystemNamesExceptionsAllowedForAdminGroup) {
+        NACLib::TUserToken userToken("user1@builtin", /* groups */ {"admin-group@builtin"});
+        TestSystemNamesExceptions(&userToken, AdminSids, EExpectedResult::ALLOWED);
+    }
+
+    Y_UNIT_TEST(SystemNamesExceptionsAllowedForSystemUser) {
+        NACLib::TUserToken userToken("metadata@system", /* groups */ {});
+        TestSystemNamesExceptions(&userToken, AdminSids, EExpectedResult::ALLOWED);
+    }
+}
+
+
+void ChangeOwner(TTestActorRuntime& runtime, ui64 txId, const TString& path, const TString& targetSid) {
+    TestModifyACL(runtime, txId, ToString(ExtractParent(path)), ToString(ExtractBase(path)), "", targetSid);
+}
+
+void UpdateCreateOp(NSchemeShard::TEvSchemeShard::TEvModifySchemeTransaction* ev, ui64 txId, const TString& subject) {
+    NKikimrScheme::TEvModifySchemeTransaction& t = ev->Record;
+    t.SetTxId(txId);
+    t.SetTabletId(TTestTxConfig::SchemeShard);
+    if (subject) {
+        NACLib::TUserToken userToken(subject, /* groups */ {});
+        t.SetUserToken(userToken.SerializeAsString());
+    }
+}
+
+void TestCreateOp(TTestActorRuntime& runtime, ui64 txId, auto*ev, const TVector<TExpectedResult>& expected) {
+    AsyncSend(runtime, TTestTxConfig::SchemeShard, ev);
+    TestModificationResults(runtime, txId, expected);
+}
+
+
+Y_UNIT_TEST_SUITE(TSchemeShardSysNames) {
+
+    //NOTE: This test guards against forgetting to add system names protection test here
+    // when adding a new scheme operation that create paths
+    Y_UNIT_TEST(CreateOpsAreCovered) {
+        std::vector<NKikimrSchemeOp::EOperationType> all;
+        {
+            const auto* d = NKikimrSchemeOp::EOperationType_descriptor();
+            for (int i = 0; i < d->value_count(); ++i) {
+                auto op = NKikimrSchemeOp::EOperationType(d->value(i)->number());
+                if (IsCreatePathOperation(op)) {
+                    all.push_back(op);
+                }
+            }
+            std::sort(all.begin(), all.end());
+        }
+        std::vector<NKikimrSchemeOp::EOperationType> covered;
+        {
+            for (const auto& op : CreatePathOperations) {
+                covered.push_back(op.Type);
+            }
+            std::sort(covered.begin(), covered.end());
+        }
+
+        std::vector<NKikimrSchemeOp::EOperationType> delta;
+        std::set_difference(
+            all.begin(), all.end(),
+            covered.begin(), covered.end(),
+            std::back_inserter(delta)
+        );
+
+        UNIT_ASSERT_VALUES_EQUAL_C(delta, std::vector<NKikimrSchemeOp::EOperationType>(),
+            "No system names protection tests for indicated create operation(s). "
+            "Check if new create operation was added without adding support for it here"
+            // Look for definition of CreatePathOperations
+        );
+    }
+
+    enum class EAccessLevel {
+        Anonymous,
+        User,
+        DatabaseAdmin,
+        ClusterAdmin,
+        SystemUser,
+    };
+
+    const TString UserName = "ordinary-user@builtin";
+    const TString DatabaseAdminName = "db-admin@builtin";
+    const TString ClusterAdminName = "cluster-admin@builtin";
+    const TString SystemUserName = "metadata@system";
+
+    TString BuiltinSubjectSid(EAccessLevel level) {
+        switch (level) {
+            case EAccessLevel::Anonymous:
+                return "";
+            case EAccessLevel::User:
+                return UserName;
+            case EAccessLevel::DatabaseAdmin:
+                return DatabaseAdminName;
+            case EAccessLevel::ClusterAdmin:
+                return ClusterAdminName;
+            case EAccessLevel::SystemUser:
+                return SystemUserName;
+        }
+    }
+
+    // dimensions:
+    // + reserved: whole name or prefix
+    // + object: dir, subdomain, table, topic, sequence etc
+    // + position in path: leaf or intermediary
+    // + operation: ordinary create, index building, restore from backup etc
+    // + subject: cluster admin, database admin, ordinary user, anonymous user, system
+
+    void SystemNamesProtect(
+            NUnitTest::TTestContext&,
+            const TCreatePathOp& op,
+            bool EnableSystemNamesProtection,
+            bool EnableDatabaseAdmin,
+            EAccessLevel level,
+            EExpectedResult expectedNameResult,
+            EExpectedResult expectedPrefixResult
+        ) {
+        TTestBasicRuntime runtime;
+        auto opts = TTestEnvOptions()
+            .EnableSystemNamesProtection(EnableSystemNamesProtection)
+            .EnableDatabaseAdmin(EnableDatabaseAdmin)
+        ;
+        if (op.SetupFlags) {
+            op.SetupFlags(opts);
+        }
+        TTestEnv env(runtime, opts);
+
+        // Make AdministrationAllowedSIDs not empty to deny all users cluster admin privilege
+        runtime.GetAppData().AdministrationAllowedSIDs.push_back("thou-shalt-not-pass");
+
+        const TString rootDir = "/MyRoot";
+        const TString subjectSid = BuiltinSubjectSid(level);
+        ui64 txId = 100;
+
+        // Make subject a proper cluster admin, if requested
+        if (level == EAccessLevel::ClusterAdmin) {
+            runtime.GetAppData().AdministrationAllowedSIDs.push_back(subjectSid);
+        }
+
+        // Make subject a proper database admin (by transfer the database ownership to them), if requested
+        if (level == EAccessLevel::DatabaseAdmin) {
+            ChangeOwner(runtime, ++txId, rootDir, subjectSid);
+        }
+
+        const TVector<TExpectedResult> resultSuccess({{NKikimrScheme::StatusAccepted}});
+        const TVector<TExpectedResult> resultErrorName({{NKikimrScheme::StatusSchemeError, "name is reserved by the system"}});
+        const TVector<TExpectedResult> resultErrorPrefix({{NKikimrScheme::StatusSchemeError, "prefix is reserved by the system"}});
+
+        ui32 counter = 0;
+        auto unique = [&counter](const TString& name) {
+            return name + ToString(counter++);
+        };
+        auto test = [&](const TCreatePathOp& op, const TString& path, const TVector<TExpectedResult>& expected) {
+            const auto& [type, _, setupObjects, createEvent] = op;
+
+            // make unique directory for each test to avoid conflicts
+            const TString uniqueName = unique(NKikimrSchemeOp::EOperationType_Name(type));
+            TestMkDir(runtime, ++txId, rootDir, uniqueName, resultSuccess);
+            env.TestWaitNotification(runtime, txId);
+
+            const TString uniqueWD = JoinPath({rootDir, uniqueName});
+            if (setupObjects) {
+                setupObjects(runtime, ++txId, uniqueWD);
+                env.TestWaitNotification(runtime, txId);
+            }
+            auto* ev = createEvent(uniqueWD, path);
+            UpdateCreateOp(ev, ++txId, subjectSid);
+            TestCreateOp(runtime, txId, ev, expected);
+
+            if (expected == resultSuccess) {
+                env.TestWaitNotification(runtime, txId);
+            }
+        };
+
+        const auto expectedResultForName = (expectedNameResult == EExpectedResult::ALLOWED ? resultSuccess : resultErrorName);
+        const auto expectedResultForPrefix = (EnableSystemNamesProtection == false ? resultSuccess : resultErrorPrefix);
+
+        Cerr << "TEST: SystemNames, ReservedNames size " << GetReservedNames().size() << Endl;
+        Cerr << "TEST: SystemNames, ReservedPrefix size " << GetReservedPrefixes().size() << Endl;
+
+        const auto& typeName = NKikimrSchemeOp::EOperationType_Name(op.Type);
+
+        // Protected cases, ordinary create, whole name
+        {
+            for (const auto& name : GetReservedNames()) {
+                // special case of .sys protection before the times of general system names protection
+                auto& expected = (EnableSystemNamesProtection == false && name == ".sys") ? resultErrorName : expectedResultForName;
+
+                Cerr << "TEST: SystemNames, test " << typeName << ", whole name " << name
+                    << ", should be " << (expected == resultSuccess ? "ALLOWED" : "FORBIDDEN")
+                    << Endl;
+
+                test(op, name, expected);
+
+                test(op, JoinPath({"good", name}), expected);
+                test(op, JoinPath({name, "good"}), expected);
+
+                test(op, JoinPath({"good", "good", name}), expected);
+                test(op, JoinPath({"good", name, "good"}), expected);
+                test(op, JoinPath({name, "good", "good"}), expected);
+            }
+        }
+
+        // Protected cases, ordinary create, prefix
+        {
+            auto& expected = expectedResultForPrefix;
+            // test system prefixes themselves (except single '.')
+            // and user provided names with the system prefixes
+            TVector<TString> names;
+            for (const auto& i : GetReservedPrefixes()) {
+                if (!EnableSystemNamesProtection && i == ".") {
+                    continue;
+                }
+                names.push_back(i);
+            }
+            for (const auto& i : GetReservedPrefixes()) {
+                names.push_back(i + "-user-name");
+            }
+
+            for (const auto& name : names) {
+                Cerr << "TEST: SystemNames, test type " << typeName << ", name with prefix " << name
+                    << ", should be " << (expectedPrefixResult == EExpectedResult::ALLOWED ? "ALLOWED" : "FORBIDDEN")
+                    << Endl;
+
+                test(op, name, expected);
+
+                test(op, JoinPath({"good", name}), expected);
+                test(op, JoinPath({name, "good"}), expected);
+
+                test(op, JoinPath({"good", "good", name}), expected);
+                test(op, JoinPath({"good", name, "good"}), expected);
+                test(op, JoinPath({name, "good", "good"}), expected);
+            }
+        }
+
+        // Positive cases
+        {
+            const auto prevTxId = txId;
+            auto& expected = resultSuccess;
+            test(op, "good", expected);
+            test(op, JoinPath({"good", "good"}), expected);
+            test(op, JoinPath({"good", "good", "good"}), expected);
+            env.TestWaitNotification(runtime, xrange(prevTxId + 1, txId));
+        }
+
+    }
+
+    struct TProtectTestCase {
+        EAccessLevel SubjectLevel;
+        bool EnableSystemNamesProtection = false;
+        bool EnableDatabaseAdmin = false;
+        EExpectedResult ReservedName = EExpectedResult::FORBIDDEN;
+        EExpectedResult ReservedPrefix = EExpectedResult::FORBIDDEN;
+    };
+    static const std::vector<TProtectTestCase> ParameterizedTests = {
+        // anonymous is the same as ordinary user
+        { .SubjectLevel = EAccessLevel::Anonymous, .EnableSystemNamesProtection = false, .EnableDatabaseAdmin = false, .ReservedName = EExpectedResult::ALLOWED },
+        { .SubjectLevel = EAccessLevel::Anonymous, .EnableSystemNamesProtection = true, .EnableDatabaseAdmin = false, .ReservedName = EExpectedResult::FORBIDDEN },
+        { .SubjectLevel = EAccessLevel::Anonymous, .EnableSystemNamesProtection = true, .EnableDatabaseAdmin = true, .ReservedName = EExpectedResult::FORBIDDEN },
+
+        // ordinary user forbidden to use any reserved system names|prefixes
+        { .SubjectLevel = EAccessLevel::User, .EnableSystemNamesProtection = false, .EnableDatabaseAdmin = false, .ReservedName = EExpectedResult::ALLOWED },
+        { .SubjectLevel = EAccessLevel::User, .EnableSystemNamesProtection = true, .EnableDatabaseAdmin = false, .ReservedName = EExpectedResult::FORBIDDEN },
+        { .SubjectLevel = EAccessLevel::User, .EnableSystemNamesProtection = true, .EnableDatabaseAdmin = true, .ReservedName = EExpectedResult::FORBIDDEN },
+
+        // database admin have no special power above ordinary user
+        { .SubjectLevel = EAccessLevel::DatabaseAdmin, .EnableSystemNamesProtection = false, .EnableDatabaseAdmin = false, .ReservedName = EExpectedResult::ALLOWED },
+        { .SubjectLevel = EAccessLevel::DatabaseAdmin, .EnableSystemNamesProtection = true, .EnableDatabaseAdmin = false, .ReservedName = EExpectedResult::FORBIDDEN },
+        { .SubjectLevel = EAccessLevel::DatabaseAdmin, .EnableSystemNamesProtection = true, .EnableDatabaseAdmin = true, .ReservedName = EExpectedResult::FORBIDDEN },
+
+        // cluster admin can fix (recreate) system objects with reserved names
+        { .SubjectLevel = EAccessLevel::ClusterAdmin, .EnableSystemNamesProtection = false, .EnableDatabaseAdmin = false, .ReservedName = EExpectedResult::ALLOWED },
+        { .SubjectLevel = EAccessLevel::ClusterAdmin, .EnableSystemNamesProtection = true, .EnableDatabaseAdmin = false, .ReservedName = EExpectedResult::ALLOWED },
+        { .SubjectLevel = EAccessLevel::ClusterAdmin, .EnableSystemNamesProtection = true, .EnableDatabaseAdmin = true, .ReservedName = EExpectedResult::ALLOWED },
+
+        // system can create objects without limitations
+        { .SubjectLevel = EAccessLevel::SystemUser, .EnableSystemNamesProtection = false, .EnableDatabaseAdmin = false, .ReservedName = EExpectedResult::ALLOWED, .ReservedPrefix = EExpectedResult::ALLOWED },
+        { .SubjectLevel = EAccessLevel::SystemUser, .EnableSystemNamesProtection = true, .EnableDatabaseAdmin = false, .ReservedName = EExpectedResult::ALLOWED, .ReservedPrefix = EExpectedResult::ALLOWED },
+        { .SubjectLevel = EAccessLevel::SystemUser, .EnableSystemNamesProtection = true, .EnableDatabaseAdmin = true, .ReservedName = EExpectedResult::ALLOWED, .ReservedPrefix = EExpectedResult::ALLOWED },
+    };
+    struct TTestRegistrationSystemNamesProtect {
+        TTestRegistrationSystemNamesProtect() {
+            static std::vector<TString> TestNames;
+
+            const auto subject = [](EAccessLevel level){
+                switch (level) {
+                    case EAccessLevel::Anonymous:
+                        return "anonymous";
+                    case EAccessLevel::User:
+                        return "ordinaryuser";
+                    case EAccessLevel::DatabaseAdmin:
+                        return "dbadmin";
+                    case EAccessLevel::ClusterAdmin:
+                        return "clusteradmin";
+                    case EAccessLevel::SystemUser:
+                        return "system";
+                }
+            };
+
+            for (const auto& op : CreatePathOperations) {
+                const auto& typeName = NKikimrSchemeOp::EOperationType_Name(op.Type);
+
+                // skip specially marked entries
+                if (op.CreateRequest == nullptr) {
+                    continue;
+                }
+
+                for (const auto& entry : ParameterizedTests) {
+                    TestNames.emplace_back(TStringBuilder() << typeName
+                        << "-" << (entry.EnableSystemNamesProtection ? "Protect" : "NoProtect")
+                        << "-" << (entry.EnableDatabaseAdmin ? "DbAdmin" : "NoDbAdmin")
+                        << "-" << subject(entry.SubjectLevel)
+                    );
+
+                    TCurrentTest::AddTest(TestNames.back().c_str(), std::bind(
+                            SystemNamesProtect,
+                            std::placeholders::_1,
+                            op,
+                            entry.EnableSystemNamesProtection,
+                            entry.EnableDatabaseAdmin,
+                            entry.SubjectLevel,
+                            entry.ReservedName,
+                            entry.ReservedPrefix
+                        ),
+                        /*forceFork*/ false
+                    );
+                }
+            }
+        }
+    };
+    static TTestRegistrationSystemNamesProtect testRegistrationSystemNamesProtect;
+
+}

--- a/ydb/core/tx/schemeshard/ut_system_names/ya.make
+++ b/ydb/core/tx/schemeshard/ut_system_names/ya.make
@@ -1,0 +1,30 @@
+UNITTEST_FOR(ydb/core/tx/schemeshard)
+
+FORK_SUBTESTS()
+
+IF (WITH_VALGRIND)
+    SPLIT_FACTOR(40)
+ENDIF()
+
+SIZE(MEDIUM)
+
+PEERDIR(
+    library/cpp/getopt
+    library/cpp/regex/pcre
+    library/cpp/svnversion
+    ydb/core/kqp/ut/common
+    ydb/core/testlib/pg
+    ydb/core/tx
+    ydb/core/tx/schemeshard/ut_helpers
+    yql/essentials/public/udf/service/exception_policy
+)
+
+YQL_LAST_ABI_VERSION()
+
+SRCS(
+    ut_system_names.cpp
+    # ../schemeshard_system_names.cpp
+    # ../schemeshard_system_names.h
+)
+
+END()

--- a/ydb/core/tx/schemeshard/ut_sysview/ut_sysview.cpp
+++ b/ydb/core/tx/schemeshard/ut_sysview/ut_sysview.cpp
@@ -1,9 +1,6 @@
 #include <ydb/core/protos/sys_view_types.pb.h>
 #include <ydb/core/tx/schemeshard/ut_helpers/helpers.h>
 
-namespace NKikimr::NSchemeShard {
-    extern bool isSysDirCreateAllowed;
-}
 namespace {
 
     using namespace NSchemeShardUT_Private;
@@ -20,26 +17,14 @@ namespace {
         UNIT_ASSERT(sysViewDescription.GetType() == sysViewType);
         UNIT_ASSERT_VALUES_EQUAL(TPathId::FromProto(sysViewDescription.GetSourceObject()), sourceObjectPathId);
     }
-
-    class TSysDirCreateGuard : public TNonCopyable {
-    public:
-        TSysDirCreateGuard() {
-            NKikimr::NSchemeShard::isSysDirCreateAllowed = true;
-        }
-
-        ~TSysDirCreateGuard() {
-            NKikimr::NSchemeShard::isSysDirCreateAllowed = false;
-        }
-    };
 }
 
 Y_UNIT_TEST_SUITE(TSchemeShardSysViewTest) {
     Y_UNIT_TEST(CreateSysView) {
         TTestBasicRuntime runtime;
-        TTestEnv env(runtime);
+        TTestEnv env(runtime, TTestEnvOptions().EnableSystemNamesProtection(true));
         ui64 txId = 100;
 
-        TSysDirCreateGuard sysDirCreateGuard;
         TestMkDir(runtime, ++txId, "/MyRoot", ".sys");
         env.TestWaitNotification(runtime, txId);
 
@@ -72,10 +57,9 @@ Y_UNIT_TEST_SUITE(TSchemeShardSysViewTest) {
 
     Y_UNIT_TEST(DropSysView) {
         TTestBasicRuntime runtime;
-        TTestEnv env(runtime);
+        TTestEnv env(runtime, TTestEnvOptions().EnableSystemNamesProtection(true));
         ui64 txId = 100;
 
-        TSysDirCreateGuard sysDirCreateGuard;
         TestMkDir(runtime, ++txId, "/MyRoot", ".sys");
         env.TestWaitNotification(runtime, txId);
         TestCreateSysView(runtime, ++txId, "/MyRoot/.sys",
@@ -97,10 +81,9 @@ Y_UNIT_TEST_SUITE(TSchemeShardSysViewTest) {
 
     Y_UNIT_TEST(CreateExistingSysView) {
         TTestBasicRuntime runtime;
-        TTestEnv env(runtime);
+        TTestEnv env(runtime, TTestEnvOptions().EnableSystemNamesProtection(true));
         ui64 txId = 100;
 
-        TSysDirCreateGuard sysDirCreateGuard;
         TestMkDir(runtime, ++txId, "/MyRoot", ".sys");
         env.TestWaitNotification(runtime, txId);
 
@@ -128,10 +111,9 @@ Y_UNIT_TEST_SUITE(TSchemeShardSysViewTest) {
 
     Y_UNIT_TEST(AsyncCreateDifferentSysViews) {
         TTestBasicRuntime runtime;
-        TTestEnv env(runtime);
+        TTestEnv env(runtime, TTestEnvOptions().EnableSystemNamesProtection(true));
         ui64 txId = 100;
 
-        TSysDirCreateGuard sysDirCreateGuard;
         TestMkDir(runtime, ++txId, "/MyRoot", ".sys");
         env.TestWaitNotification(runtime, txId);
 
@@ -168,10 +150,9 @@ Y_UNIT_TEST_SUITE(TSchemeShardSysViewTest) {
 
     Y_UNIT_TEST(AsyncCreateDirWithSysView) {
         TTestBasicRuntime runtime;
-        TTestEnv env(runtime);
+        TTestEnv env(runtime, TTestEnvOptions().EnableSystemNamesProtection(true));
         ui64 txId = 100;
 
-        TSysDirCreateGuard sysDirCreateGuard;
         AsyncMkDir(runtime, ++txId, "/MyRoot", ".sys");
         AsyncCreateSysView(runtime, ++txId, "/MyRoot/.sys",
                            R"(
@@ -194,10 +175,9 @@ Y_UNIT_TEST_SUITE(TSchemeShardSysViewTest) {
 
     Y_UNIT_TEST(AsyncCreateSameSysView) {
         TTestBasicRuntime runtime;
-        TTestEnv env(runtime);
+        TTestEnv env(runtime, TTestEnvOptions().EnableSystemNamesProtection(true));
         ui64 txId = 100;
 
-        TSysDirCreateGuard sysDirCreateGuard;
         TestMkDir(runtime, ++txId, "/MyRoot", ".sys");
         env.TestWaitNotification(runtime, txId);
 
@@ -227,10 +207,9 @@ Y_UNIT_TEST_SUITE(TSchemeShardSysViewTest) {
 
     Y_UNIT_TEST(AsyncDropSameSysView) {
         TTestBasicRuntime runtime;
-        TTestEnv env(runtime);
+        TTestEnv env(runtime, TTestEnvOptions().EnableSystemNamesProtection(true));
         ui64 txId = 100;
 
-        TSysDirCreateGuard sysDirCreateGuard;
         TestMkDir(runtime, ++txId, "/MyRoot", ".sys");
         env.TestWaitNotification(runtime, txId);
         TestCreateSysView(runtime, ++txId, "/MyRoot/.sys",
@@ -255,10 +234,9 @@ Y_UNIT_TEST_SUITE(TSchemeShardSysViewTest) {
 
     Y_UNIT_TEST(ReadOnlyMode) {
         TTestBasicRuntime runtime;
-        TTestEnv env(runtime);
+        TTestEnv env(runtime, TTestEnvOptions().EnableSystemNamesProtection(true));
         ui64 txId = 100;
 
-        TSysDirCreateGuard sysDirCreateGuard;
         TestMkDir(runtime, ++txId, "/MyRoot", ".sys");
         env.TestWaitNotification(runtime, txId);
         SetSchemeshardReadOnlyMode(runtime, true);
@@ -289,10 +267,9 @@ Y_UNIT_TEST_SUITE(TSchemeShardSysViewTest) {
 
     Y_UNIT_TEST(EmptyName) {
         TTestBasicRuntime runtime;
-        TTestEnv env(runtime);
+        TTestEnv env(runtime, TTestEnvOptions().EnableSystemNamesProtection(true));
         ui64 txId = 100;
 
-        TSysDirCreateGuard sysDirCreateGuard;
         TestMkDir(runtime, ++txId, "/MyRoot", ".sys");
         env.TestWaitNotification(runtime, txId);
 

--- a/ydb/core/tx/schemeshard/ut_sysview_reboots/ut_sysview_reboots.cpp
+++ b/ydb/core/tx/schemeshard/ut_sysview_reboots/ut_sysview_reboots.cpp
@@ -1,34 +1,15 @@
 #include <ydb/core/tx/schemeshard/ut_helpers/helpers.h>
 
-namespace NKikimr::NSchemeShard {
-    extern bool isSysDirCreateAllowed;
-}
 
-namespace {
-
-    using namespace NSchemeShardUT_Private;
-    using NKikimrScheme::EStatus;
-
-    class TSysDirCreateGuard : public TNonCopyable {
-    public:
-        TSysDirCreateGuard() {
-            NKikimr::NSchemeShard::isSysDirCreateAllowed = true;
-        }
-
-        ~TSysDirCreateGuard() {
-            NKikimr::NSchemeShard::isSysDirCreateAllowed = false;
-        }
-    };
-
-}
+using namespace NSchemeShardUT_Private;  // for helpers.h's Test*() methods
 
 Y_UNIT_TEST_SUITE(TSchemeShardSysViewTestReboots) {
     Y_UNIT_TEST(CreateSysViewWithReboots) {
         TTestWithReboots t;
+        t.GetTestEnvOptions().EnableSystemNamesProtection(true);
         t.Run([&](TTestActorRuntime& runtime, bool& activeZone) {
             {
                 TInactiveZone inactive(activeZone);
-                TSysDirCreateGuard sysDirCreateGuard;
                 TestMkDir(runtime, ++t.TxId, "/MyRoot", ".sys");
                 t.TestEnv->TestWaitNotification(runtime, t.TxId);
             }
@@ -50,10 +31,10 @@ Y_UNIT_TEST_SUITE(TSchemeShardSysViewTestReboots) {
 
     Y_UNIT_TEST(DropSysViewWithReboots) {
         TTestWithReboots t;
+        t.GetTestEnvOptions().EnableSystemNamesProtection(true);
         t.Run([&](TTestActorRuntime& runtime, bool& activeZone) {
             {
                 TInactiveZone inactive(activeZone);
-                TSysDirCreateGuard sysDirCreateGuard;
                 TestMkDir(runtime, ++t.TxId, "/MyRoot", ".sys");
                 t.TestEnv->TestWaitNotification(runtime, t.TxId);
                 TestCreateSysView(runtime, ++t.TxId, "/MyRoot/.sys",

--- a/ydb/core/tx/schemeshard/ya.make
+++ b/ydb/core/tx/schemeshard/ya.make
@@ -52,6 +52,7 @@ RECURSE_FOR_TESTS(
     ut_stats
     ut_subdomain
     ut_subdomain_reboots
+    ut_system_names
     ut_sysview
     ut_sysview_reboots
     ut_topic_splitmerge
@@ -92,6 +93,8 @@ SRCS(
     schemeshard__op_traits.h
     schemeshard__operation.cpp
     schemeshard__operation.h
+    schemeshard__op_traits.cpp
+    schemeshard__op_traits.h
     schemeshard__operation_alter_bsv.cpp
     schemeshard__operation_alter_cdc_stream.cpp
     schemeshard__operation_alter_continuous_backup.cpp
@@ -262,6 +265,8 @@ SRCS(
     schemeshard_shard_deleter.h
     schemeshard_svp_migration.cpp
     schemeshard_svp_migration.h
+    schemeshard_system_names.cpp
+    schemeshard_system_names.h
     schemeshard_tx_infly.h
     schemeshard_types.cpp
     schemeshard_types.h


### PR DESCRIPTION
New feature flag `enable_system_names_protection` prohibits users from creating paths with names reserved for current or future system use.

YDB exclusively reserves names like `.sys`, `.metadata`, `.tmp`, `.backups` etc. and any names starting with prefixes `.` and `__ydb` for its own use.

More details, reasoning and behavior in:
- #11673 

Also introduces safeguards against carelessly using reserved names in future code.

Special tests verify that:

- New scheme create operations include protection for reserved names
- Modifications to the reserved name registry will not go unnoticed

The latter is designed to protect well-meaning developers from careless actions.
YDB developers must obtain explicit consent from the project committee to add new names to the reserved list.