### PR TITLE
CLOUD_EVENTS format in audit config

### DIFF
--- a/ydb/core/audit/audit_log_impl.cpp
+++ b/ydb/core/audit/audit_log_impl.cpp
@@ -127,7 +127,7 @@ TString GetTxtLog(TInstant time, const TAuditLogParts& parts) {
 // For each new format, we need to register the audit event conversion function.
 // The size of AuditLogItemBuilders must be larger by one of the maximum value of the NKikimrConfig::TAuditConfig::EFormat enumeration.
 // The first value of AuditLogItemBuilders is a stub for the convenience of indexing by enumeration value.
-static std::vector<TAuditLogItemBuilder> AuditLogItemBuilders = { nullptr, GetJsonLog, GetTxtLog, GetJsonLogCompatibleLog, nullptr };
+static std::vector<TAuditLogItemBuilder> AuditLogItemBuilders = { nullptr, GetJsonLog, GetTxtLog, GetJsonLogCompatibleLog, nullptr, nullptr };
 
 // numbering enumeration starts from one
 static constexpr size_t DefaultAuditLogItemBuilder = static_cast<size_t>(NKikimrConfig::TAuditConfig::JSON);

--- a/ydb/core/protos/config.proto
+++ b/ydb/core/protos/config.proto
@@ -1715,7 +1715,7 @@ message TAuditConfig {
         TXT = 2;                        // Outputs audit log in format: "<time>: k1=v1, k2=v2, ..." where <time> is ISO 8601 format time string, k1, k2, ..., kn - fields of audit log message and v1, v2, ..., vn are their values
         JSON_LOG_COMPATIBLE = 3;        // Outputs audit log in format: "{"@timestamp": "<ISO 8601 time>", "@log_type": "audit", "k1": "v1", "k2": "v2", ...}" where @timestamp is ISO 8601 format time string, k1, k2, ..., kn - fields of audit log message and v1, v2, ..., vn are their values // Suitable for output both debug log and audit log to the same destination (stderr)
         FORMAT_4 = 4;                   // Reserved
-        YANDEX_CLOUD_EVENTS = 5;        // This format is used exclusively for Yandex.Cloud purposes. Using it for other purposes is pointless. If you still decide to use it, the format will be changed to JSON
+        YANDEX_CLOUD_EVENTS = 5;        // Reserved for Yandex.Cloud environment. Defaults to JSON elsewhere
     }
 
     message TStderrBackend {

--- a/ydb/core/protos/config.proto
+++ b/ydb/core/protos/config.proto
@@ -1711,10 +1711,11 @@ message TAuditConfig {
     // For each new format, we need to register the audit event conversion function
     // See  ydb/core/audit/audit_log_impl.cpp for details
     enum EFormat {
-        JSON = 1;                // Outputs audit log in format: "<time>: {"k1": "v1", "k2": "v2", ...}" where <time> is ISO 8601 format time string, k1, k2, ..., kn - fields of audit log message and v1, v2, ..., vn are their values
-        TXT = 2;                 // Outputs audit log in format: "<time>: k1=v1, k2=v2, ..." where <time> is ISO 8601 format time string, k1, k2, ..., kn - fields of audit log message and v1, v2, ..., vn are their values
-        JSON_LOG_COMPATIBLE = 3; // Outputs audit log in format: "{"@timestamp": "<ISO 8601 time>", "@log_type": "audit", "k1": "v1", "k2": "v2", ...}" where @timestamp is ISO 8601 format time string, k1, k2, ..., kn - fields of audit log message and v1, v2, ..., vn are their values // Suitable for output both debug log and audit log to the same destination (stderr)
-        FORMAT_4 = 4;        // Reserved
+        JSON = 1;                       // Outputs audit log in format: "<time>: {"k1": "v1", "k2": "v2", ...}" where <time> is ISO 8601 format time string, k1, k2, ..., kn - fields of audit log message and v1, v2, ..., vn are their values
+        TXT = 2;                        // Outputs audit log in format: "<time>: k1=v1, k2=v2, ..." where <time> is ISO 8601 format time string, k1, k2, ..., kn - fields of audit log message and v1, v2, ..., vn are their values
+        JSON_LOG_COMPATIBLE = 3;        // Outputs audit log in format: "{"@timestamp": "<ISO 8601 time>", "@log_type": "audit", "k1": "v1", "k2": "v2", ...}" where @timestamp is ISO 8601 format time string, k1, k2, ..., kn - fields of audit log message and v1, v2, ..., vn are their values // Suitable for output both debug log and audit log to the same destination (stderr)
+        FORMAT_4 = 4;                   // Reserved
+        YANDEX_CLOUD_EVENTS = 5;        // This format is used exclusively for Yandex.Cloud purposes. Using it for other purposes is pointless. If you still decide to use it, the format will be changed to JSON
     }
 
     message TStderrBackend {


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

Yandex.cloud and YDB-platform are closely related. In particular, for YMQ it is necessary to supply audit logs in the cloud events format. However, YDB has its own standardized format. For YMQ, it is implemented in this format.: https://github.com/ydb-platform/ydb/pull/18333. To transfer audit logs to the Cloud Events format, a separate mapper will be implemented. This pull request adds a new format type, CLOUD_EVENTS.

### Changelog category <!-- remove all except one -->

* New feature