### PR TITLE
Add PDisk Move command

### DIFF
--- a/ydb/apps/dstool/lib/commands.py
+++ b/ydb/apps/dstool/lib/commands.py
@@ -7,6 +7,7 @@ import ydb.apps.dstool.lib.dstool_cmd_pdisk_list as pdisk_list
 import ydb.apps.dstool.lib.dstool_cmd_pdisk_stop as pdisk_stop
 import ydb.apps.dstool.lib.dstool_cmd_pdisk_restart as pdisk_restart
 import ydb.apps.dstool.lib.dstool_cmd_pdisk_readonly as pdisk_readonly
+import ydb.apps.dstool.lib.dstool_cmd_pdisk_move as pdisk_move
 
 import ydb.apps.dstool.lib.dstool_cmd_vdisk_evict as vdisk_evict
 import ydb.apps.dstool.lib.dstool_cmd_vdisk_list as vdisk_list
@@ -52,13 +53,13 @@ modules = [
     pool_list, pool_create_virtual,
     group_check, group_decommit, group_show_blob_info, group_show_storage_efficiency, group_show_usage_by_tablets,
     group_state, group_take_snapshot, group_add, group_list, group_virtual_create, group_virtual_cancel,
-    pdisk_add_by_serial, pdisk_remove_by_serial, pdisk_set, pdisk_list, pdisk_stop, pdisk_restart, pdisk_readonly,
+    pdisk_add_by_serial, pdisk_remove_by_serial, pdisk_set, pdisk_list, pdisk_stop, pdisk_restart, pdisk_readonly, pdisk_move,
     vdisk_evict, vdisk_list, vdisk_set_read_only, vdisk_remove_donor, vdisk_wipe, vdisk_compact, device_list,
 ]
 
 default_structure = [
     ('device', ['list']),
-    ('pdisk', ['add-by-serial', 'remove-by-serial', 'set', 'list', 'stop', 'restart', 'readonly']),
+    ('pdisk', ['add-by-serial', 'remove-by-serial', 'set', 'list', 'stop', 'restart', 'readonly', 'move']),
     ('vdisk', ['evict', 'list', 'set-read-only', 'remove-donor', 'wipe', 'compact']),
     ('group', ['add', 'check', 'decommit', ('show', ['blob-info', 'storage-efficiency', 'usage-by-tablets']), 'state', 'take-snapshot', 'list', ('virtual', ['create', 'cancel'])]),
     ('pool', ['list', ('create', ['virtual'])]),

--- a/ydb/apps/dstool/lib/dstool_cmd_pdisk_move.py
+++ b/ydb/apps/dstool/lib/dstool_cmd_pdisk_move.py
@@ -11,9 +11,9 @@ def add_options(p):
     common.add_ignore_vslot_quotas_option(p)
     common.add_basic_format_options(p)
     p.add_argument('--source-pdisk', '-s', type=str, required=True,
-                   help='Source PDisk in the format <fqdn>;<path> (e.g. "node1;pdisk1")')
+                   help='Source PDisk in the format nodeId:pdiskId (e.g. "1:1000")')
     p.add_argument('--destination-pdisk', '-d', type=str, required=True,
-                   help='Destination PDisk in the format <fqdn>;<path> (e.g. "node2;pdisk2")')
+                   help='Destination PDisk in the format nodeId:pdiskId (e.g. "2:1000")')
 
 
 def create_request(args, source_pdisk, target_pdisk):

--- a/ydb/apps/dstool/lib/dstool_cmd_pdisk_move.py
+++ b/ydb/apps/dstool/lib/dstool_cmd_pdisk_move.py
@@ -38,8 +38,6 @@ def is_successful_response(response):
 
 
 def do(args):
-    base_config = common.fetch_base_config()
-
     assert not args.dry_run, '--dry-run is not supported for this command'
 
     src = args.source_pdisk

--- a/ydb/apps/dstool/lib/dstool_cmd_pdisk_move.py
+++ b/ydb/apps/dstool/lib/dstool_cmd_pdisk_move.py
@@ -1,0 +1,66 @@
+import ydb.apps.dstool.lib.common as common
+import sys
+
+description = 'Move PDisk'
+
+
+def add_options(p):
+    common.add_pdisk_select_options(p)
+    common.add_ignore_degraded_group_check_option(p)
+    common.add_ignore_failure_model_group_check_option(p)
+    common.add_ignore_vslot_quotas_option(p)
+    common.add_basic_format_options(p)
+    p.add_argument('--source-pdisk', '-s', type=str, required=True,
+                   help='Source PDisk in the format <fqdn>;<path> (e.g. "node1;pdisk1")')
+    p.add_argument('--destination-pdisk', '-d', type=str, required=True,
+                   help='Destination PDisk in the format <fqdn>;<path> (e.g. "node2;pdisk2")')
+
+
+def create_request(args, source_pdisk, target_pdisk):
+    request = common.create_bsc_request(args)
+    cmd = request.Command.add().MovePDisk
+
+    cmd.SourcePDisk.TargetPDiskId.NodeId = int(source_pdisk.split(';')[0])
+    cmd.SourcePDisk.TargetPDiskId.PDiskId = int(source_pdisk.split(';')[1])
+
+    cmd.DestinationPDisk.TargetPDiskId.NodeId = int(target_pdisk.split(';')[0])
+    cmd.DestinationPDisk.TargetPDiskId.PDiskId = int(target_pdisk.split(';')[1])
+
+    return request
+
+
+def perform_request(request):
+    return common.invoke_bsc_request(request)
+
+
+def is_successful_response(response):
+    return common.is_successful_bsc_response(response)
+
+
+def do(args):
+    base_config = common.fetch_base_config()
+
+    assert not args.dry_run, '--dry-run is not supported for this command'
+
+    src = args.source_pdisk
+    if src is None:
+        common.print_status(args, success=False, error_reason='Source PDisk is not specified')
+        sys.exit(1)
+
+    dst = args.destination_pdisk
+    if dst is None:
+        common.print_status(args, success=False, error_reason='Destination PDisk is not specified')
+        sys.exit(1)
+
+    success = True
+    error_reason = ''
+
+    request = create_request(args, src, dst)
+    response = perform_request(request)
+    if not is_successful_response(response):
+        success = False
+        error_reason += 'Request has failed: \n{0}\n{1}\n'.format(request, response)
+
+    common.print_status(args, success, error_reason)
+    if not success:
+        sys.exit(1)

--- a/ydb/apps/dstool/lib/ya.make
+++ b/ydb/apps/dstool/lib/ya.make
@@ -18,6 +18,7 @@ PY_SRCS(
     dstool_cmd_pdisk_restart.py
     dstool_cmd_pdisk_set.py
     dstool_cmd_pdisk_stop.py
+    dstool_cmd_pdisk_move.py
 
     dstool_cmd_vdisk_evict.py
     dstool_cmd_vdisk_list.py

--- a/ydb/core/blobstorage/nodewarden/node_warden_vdisk.cpp
+++ b/ydb/core/blobstorage/nodewarden/node_warden_vdisk.cpp
@@ -25,7 +25,10 @@ namespace NKikimr::NStorage {
         STLOG(PRI_INFO, BS_NODE, NW00, "PoisonLocalVDisk", (VDiskId, vdisk.GetVDiskId()), (VSlotId, vdisk.GetVSlotId()),
             (RuntimeData, vdisk.RuntimeData.has_value()));
 
+        bool vdiskRunning = false;
+
         if (vdisk.RuntimeData) {
+            vdiskRunning = true;
             vdisk.TIntrusiveListItem<TVDiskRecord, TGroupRelationTag>::Unlink();
             TActivationContext::Send(new IEventHandle(TEvents::TSystem::Poison, 0, vdisk.GetVDiskServiceId(), {}, nullptr, 0));
             vdisk.RuntimeData.reset();
@@ -50,7 +53,7 @@ namespace NKikimr::NStorage {
         vdisk.ScrubCookie = 0; // disable reception of Scrub messages from this disk
         vdisk.ScrubCookieForController = 0; // and from controller too
         vdisk.Status = NKikimrBlobStorage::EVDiskStatus::ERROR;
-        vdisk.ShutdownPending = true;
+        vdisk.ShutdownPending = vdiskRunning; // Shutdown pending only if VDisk was running before poison
         VDiskStatusChanged = true;
     }
 

--- a/ydb/core/blobstorage/pdisk/mock/pdisk_mock.cpp
+++ b/ydb/core/blobstorage/pdisk/mock/pdisk_mock.cpp
@@ -35,7 +35,7 @@ struct TPDiskMockState::TImpl {
 
     const ui32 NodeId;
     const ui32 PDiskId;
-    const ui64 PDiskGuid;
+    ui64 PDiskGuid;
     const ui64 Size;
     const ui32 ChunkSize;
     const ui32 TotalChunks;
@@ -930,6 +930,8 @@ public:
         bool restartAllowed = ev->Get()->RestartAllowed;
 
         if (restartAllowed) {
+            Become(&TThis::StateNormal);
+            Impl.StateErrorReason = "";
             Impl.IsDiskReadOnly = ev->Get()->Config->ReadOnly;
             Send(ev->Sender, new TEvBlobStorage::TEvNotifyWardenPDiskRestarted(Impl.PDiskId));
         }
@@ -1063,6 +1065,13 @@ public:
         Send(ev->Sender, new NPDisk::TEvWriteMetadataResult(NPDisk::EPDiskMetadataOutcome::OK, Impl.PDiskGuid), 0, ev->Cookie);
     }
 
+    void Handle(TEvMoveDrive::TPtr& ev) {
+        State = ev->Get()->State;
+        Impl.Blocks = State->Impl->Blocks;
+        Impl.Owners = State->Impl->Owners;
+        Impl.PDiskGuid = State->Impl->PDiskGuid;
+    }
+
     void HandleMoveToErrorState() {
         Impl.StateErrorReason = "Some error reason";
         Become(&TThis::StateError);
@@ -1095,6 +1104,7 @@ public:
         cFunc(TEvents::TSystem::Wakeup, ReportMetrics);
         hFunc(NPDisk::TEvReadMetadata, Handle);
         hFunc(NPDisk::TEvWriteMetadata, Handle);
+        hFunc(TEvMoveDrive, Handle);
 
         cFunc(EvBecomeError, HandleMoveToErrorState);
 
@@ -1117,6 +1127,8 @@ public:
         hFunc(NPDisk::TEvReadMetadata, ErrorHandle);
         hFunc(NPDisk::TEvWriteMetadata, ErrorHandle);
         hFunc(TEvBlobStorage::TEvAskWardenRestartPDiskResult, Handle);
+        hFunc(NPDisk::TEvYardControl, Handle);
+        hFunc(TEvMoveDrive, Handle);
 
         cFunc(TEvents::TSystem::Wakeup, ReportMetrics);
         cFunc(EvBecomeNormal, HandleMoveToNormalState);

--- a/ydb/core/blobstorage/pdisk/mock/pdisk_mock.h
+++ b/ydb/core/blobstorage/pdisk/mock/pdisk_mock.h
@@ -9,7 +9,8 @@ namespace NKikimr {
 
     enum EPDiskMockEvents {
         EvBecomeError = TEvBlobStorage::EvEnd + 1,
-        EvBecomeNormal
+        EvBecomeNormal,
+        EvReplaceData,
     };
 
     class TPDiskMockState : public TThrRefBase {
@@ -50,6 +51,14 @@ namespace NKikimr {
         void SetReadOnly(const TVDiskID& vDiskId, bool isReadOnly);
 
         bool IsDiskReadOnly() const;
+    };
+
+    struct TEvMoveDrive : TEventLocal<TEvMoveDrive, EvReplaceData> {
+        TIntrusivePtr<TPDiskMockState>& State;
+
+        TEvMoveDrive(TIntrusivePtr<TPDiskMockState>& state)
+            : State(state)
+        {}
     };
 
     IActor *CreatePDiskMockActor(TPDiskMockState::TPtr state);

--- a/ydb/core/blobstorage/ut_blobstorage/lib/env.h
+++ b/ydb/core/blobstorage/ut_blobstorage/lib/env.h
@@ -555,7 +555,7 @@ struct TEnvironmentSetup {
     }
 
     void CreateBoxAndPool(ui32 numDrivesPerNode = 0, ui32 numGroups = 0, ui32 numStorageNodes = 0,
-            NKikimrBlobStorage::EPDiskType pdiskType = NKikimrBlobStorage::EPDiskType::ROT) {
+            NKikimrBlobStorage::EPDiskType pdiskType = NKikimrBlobStorage::EPDiskType::ROT, const std::optional<NKikimrBlobStorage::TGroupGeometry>& geometry = std::nullopt) {
         NKikimrBlobStorage::TConfigRequest request;
 
         auto *cmd = request.AddCommand()->MutableDefineHostConfig();
@@ -590,6 +590,10 @@ struct TEnvironmentSetup {
         cmd2->AddPDiskFilter()->AddProperty()->SetType(pdiskType);
         if (Settings.Encryption) {
             cmd2->SetEncryptionMode(TBlobStorageGroupInfo::EEncryptionMode::EEM_ENC_V1);
+        }
+
+        if (geometry) {
+            cmd2->MutableGeometry()->CopyFrom(*geometry);
         }
 
         auto response = Invoke(request);

--- a/ydb/core/blobstorage/ut_blobstorage/move_pdisk.cpp
+++ b/ydb/core/blobstorage/ut_blobstorage/move_pdisk.cpp
@@ -1,0 +1,194 @@
+#include <ydb/core/blobstorage/base/blobstorage_events.h>
+#include <ydb/core/blobstorage/nodewarden/node_warden_impl.h>
+#include <ydb/core/blobstorage/ut_blobstorage/lib/env.h>
+
+Y_UNIT_TEST_SUITE(BSCMovePDisk) {
+
+    void WaitForPDiskStop(TEnvironmentSetup& env) {
+        TInstant barrier = env.Runtime->GetClock() + TDuration::Seconds(30);
+        bool gotPdiskStop = false;
+        env.Runtime->Sim([&] { return env.Runtime->GetClock() <= barrier && !gotPdiskStop; }, [&](IEventHandle &witnessedEvent) {
+            if (witnessedEvent.GetTypeRewrite() == NPDisk::TEvYardControl::EventType) {
+                auto *control = witnessedEvent.Get<NPDisk::TEvYardControl>();
+                if (control) {
+                    UNIT_ASSERT(control->Action == NPDisk::TEvYardControl::EAction::PDiskStop);
+                    gotPdiskStop = true;
+                }
+            }
+        });
+        UNIT_ASSERT(gotPdiskStop);
+    }
+
+    void WaitForPDiskRestart(TEnvironmentSetup& env) {
+        TInstant barrier = env.Runtime->GetClock() + TDuration::Seconds(30);
+        bool gotPdiskRestart = false;
+        env.Runtime->Sim([&] { return env.Runtime->GetClock() <= barrier && !gotPdiskRestart; }, [&](IEventHandle &witnessedEvent) {
+            if (witnessedEvent.GetTypeRewrite() == TEvBlobStorage::TEvAskWardenRestartPDiskResult::EventType) {
+                    gotPdiskRestart = true;
+            }
+        });
+        UNIT_ASSERT(gotPdiskRestart);
+    }
+
+    void PDiskMoveBasic(TBlobStorageGroupType::EErasureSpecies erasure, ui32 nodeCount, std::pair<ui32, ui32> newDiskId, ui32 numDrivesPerNode = 1) {
+        ui32 numDataCenters = erasure == TBlobStorageGroupType::EErasureSpecies::ErasureMirror3dc ? 3 : 1;
+
+        TEnvironmentSetup env({
+            .NodeCount = nodeCount,
+            .Erasure = erasure,
+            .NumDataCenters = numDataCenters,
+        });
+
+        env.UpdateSettings(false, false);
+
+        std::optional<NKikimrBlobStorage::TGroupGeometry> geometry;
+
+        if (erasure == TBlobStorageGroupType::EErasureSpecies::ErasureMirror3dc && nodeCount == 3) {
+            // Mirror3dc with 3 nodes is a special case, we need to set up the group geometry
+            NKikimrBlobStorage::TGroupGeometry g;
+            g.SetNumFailRealms(3);
+            g.SetNumFailDomainsPerFailRealm(3);
+            g.SetNumVDisksPerFailDomain(1);
+            g.SetRealmLevelBegin(10);
+            g.SetRealmLevelEnd(20);
+            g.SetDomainLevelBegin(10);
+            g.SetDomainLevelEnd(256);
+            geometry = g;
+        }
+
+        // Create multiple groups over our pdisks
+        env.CreateBoxAndPool(numDrivesPerNode, 4, 0, NKikimrBlobStorage::EPDiskType::ROT, geometry);
+
+        ui32 sourceNodeId = 1;
+        ui32 sourcePDiskId = 1000;
+
+        ui32 destinationNodeId = newDiskId.first;
+        ui32 destinationPDiskId = newDiskId.second;
+
+        {
+            // But move out all the vdisks from the destination pdisk
+            NKikimrBlobStorage::TConfigRequest request;
+            request.AddCommand()->MutableQueryBaseConfig();
+            auto response = env.Invoke(request);
+            UNIT_ASSERT(response.GetSuccess());
+            UNIT_ASSERT_VALUES_EQUAL(response.StatusSize(), 1);
+            auto& config = response.GetStatus(0).GetBaseConfig();
+
+            for (const auto& vslot : config.GetVSlot()) {
+                if (vslot.GetVSlotId().GetNodeId() != destinationNodeId ||
+                    vslot.GetVSlotId().GetPDiskId() != destinationPDiskId) {
+                    continue;
+                }
+                NKikimrBlobStorage::TConfigRequest request;
+                auto *cmd = request.AddCommand()->MutableReassignGroupDisk();
+                request.SetIgnoreDisintegratedGroupsChecks(true);
+                request.SetIgnoreDegradedGroupsChecks(true);
+                request.SetIgnoreGroupFailModelChecks(true);
+                cmd->SetGroupId(vslot.GetGroupId());
+                cmd->SetGroupGeneration(vslot.GetGroupGeneration());
+                cmd->SetFailRealmIdx(vslot.GetFailRealmIdx());
+                cmd->SetFailDomainIdx(vslot.GetFailDomainIdx());
+                cmd->SetVDiskIdx(vslot.GetVDiskIdx());
+                auto response = env.Invoke(request);
+                UNIT_ASSERT_C(response.GetSuccess(), response.GetErrorDescription());
+            }
+        }
+
+        auto groupId = env.GetGroups()[0];
+        TString data = TString::Uninitialized(1024);
+        memset(data.Detach(), 1, data.size());
+        TLogoBlobID id(1, 1, 1, 0, data.size(), 0);
+        env.PutBlob(groupId, id, data);
+
+        {
+            NKikimrBlobStorage::TConfigRequest request;
+
+            NKikimrBlobStorage::TStopPDisk* cmd = request.AddCommand()->MutableStopPDisk();
+            auto* pdiskId = cmd->MutableTargetPDiskId();
+            pdiskId->SetNodeId(destinationNodeId);
+            pdiskId->SetPDiskId(destinationPDiskId);
+
+            auto response = env.Invoke(request);
+
+            UNIT_ASSERT_C(response.GetSuccess(), "Should've stopped");
+
+            WaitForPDiskStop(env);
+        }
+
+        auto srcPDiskState = env.PDiskMockStates[std::make_pair(sourceNodeId, sourcePDiskId)];
+
+        {
+            TActorId edge = env.Runtime->AllocateEdgeActor(env.Settings.ControllerNodeId);
+            auto* evChangeState = new TEvMoveDrive(srcPDiskState);
+            TActorId destinationPDiskActorId = MakeBlobStoragePDiskID(destinationNodeId, destinationPDiskId);
+            env.Runtime->Send(new IEventHandle(destinationPDiskActorId, edge, evChangeState), destinationNodeId);
+        }
+        
+        {
+            NKikimrBlobStorage::TConfigRequest request;
+
+            NKikimrBlobStorage::TMovePDisk* cmd = request.AddCommand()->MutableMovePDisk();
+            request.SetIgnoreGroupFailModelChecks(true);
+
+            auto* sourcePdiskId = cmd->MutableSourcePDisk()->MutableTargetPDiskId();
+            sourcePdiskId->SetNodeId(sourceNodeId);
+            sourcePdiskId->SetPDiskId(sourcePDiskId);
+
+            auto* destinationPdiskId = cmd->MutableDestinationPDisk()->MutableTargetPDiskId();
+            destinationPdiskId->SetNodeId(destinationNodeId);
+            destinationPdiskId->SetPDiskId(destinationPDiskId);
+
+            auto response = env.Invoke(request);
+
+            UNIT_ASSERT(response.GetSuccess());
+        }
+
+        WaitForPDiskRestart(env);
+
+        {
+            NKikimrBlobStorage::TConfigRequest request;
+            request.SetIgnoreGroupFailModelChecks(true);
+
+            NKikimrBlobStorage::TRestartPDisk* cmd = request.AddCommand()->MutableRestartPDisk();
+            auto pdiskId = cmd->MutableTargetPDiskId();
+            pdiskId->SetNodeId(destinationNodeId);
+            pdiskId->SetPDiskId(destinationPDiskId);
+
+            auto response = env.Invoke(request);
+
+            UNIT_ASSERT_C(response.GetSuccess(), response.GetErrorDescription());
+        }
+
+        env.Sim(TDuration::Seconds(30));
+
+        {
+            TActorId edge = env.Runtime->AllocateEdgeActor(env.Settings.ControllerNodeId);
+            env.Runtime->WrapInActorContext(edge, [&] {
+                auto* ev = new TEvBlobStorage::TEvGet(id, 0, 0, TInstant::Max(), NKikimrBlobStorage::EGetHandleClass::FastRead);
+                SendToBSProxy(edge, groupId, ev);
+            });
+            auto ev = env.WaitForEdgeActorEvent<TEvBlobStorage::TEvGetResult>(edge);
+            auto res = ev->Get();
+            UNIT_ASSERT_VALUES_EQUAL(res->Status, NKikimrProto::OK);
+            TString readData = res->Responses->Buffer.ConvertToString();
+            UNIT_ASSERT_VALUES_EQUAL(readData, data);
+        }
+    }
+
+    Y_UNIT_TEST(PDiskMove_ErasureNone) {
+        PDiskMoveBasic(TBlobStorageGroupType::EErasureSpecies::ErasureNone, 2, {2, 1000});
+    }
+
+    Y_UNIT_TEST(PDiskMove_Block42) {
+        PDiskMoveBasic(TBlobStorageGroupType::EErasureSpecies::Erasure4Plus2Block, 9, {9, 1000});
+    }
+
+    Y_UNIT_TEST(PDiskMove_Mirror3dc) {
+        PDiskMoveBasic(TBlobStorageGroupType::EErasureSpecies::ErasureMirror3dc, 12, {4, 1000});
+    }
+
+    Y_UNIT_TEST(PDiskMove_Mirror3dc3Nodes) {
+        PDiskMoveBasic(TBlobStorageGroupType::EErasureSpecies::ErasureMirror3dc, 3, {1, 1003}, 4);
+    }
+
+}

--- a/ydb/core/blobstorage/ut_blobstorage/stop_pdisk.cpp
+++ b/ydb/core/blobstorage/ut_blobstorage/stop_pdisk.cpp
@@ -19,7 +19,6 @@ Y_UNIT_TEST_SUITE(BSCStopPDisk) {
         ui32 targetNodeId = it->first.first;
         ui32 targetPDiskId = it->first.second;
 
-        // However making the owner of a single good disk ReadOnly must be prohibited
         NKikimrBlobStorage::TConfigRequest request;
 
         NKikimrBlobStorage::TStopPDisk* cmd = request.AddCommand()->MutableStopPDisk();

--- a/ydb/core/blobstorage/ut_blobstorage/ut_move_pdisk/ya.make
+++ b/ydb/core/blobstorage/ut_blobstorage/ut_move_pdisk/ya.make
@@ -1,0 +1,15 @@
+UNITTEST_FOR(ydb/core/blobstorage/ut_blobstorage)
+
+    FORK_SUBTESTS()
+
+    SIZE(MEDIUM)
+
+    SRCS(
+        move_pdisk.cpp
+    )
+
+    PEERDIR(
+        ydb/core/blobstorage/ut_blobstorage/lib
+    )
+
+END()

--- a/ydb/core/mind/bscontroller/bsc.cpp
+++ b/ydb/core/mind/bscontroller/bsc.cpp
@@ -847,6 +847,7 @@ ui32 TBlobStorageController::GetEventPriority(IEventHandle *ev) {
                     case NKikimrBlobStorage::TConfigRequest::TCommand::kSetPDiskReadOnly:
                     case NKikimrBlobStorage::TConfigRequest::TCommand::kStopPDisk:
                     case NKikimrBlobStorage::TConfigRequest::TCommand::kGetInterfaceVersion:
+                    case NKikimrBlobStorage::TConfigRequest::TCommand::kMovePDisk:
                         return 2; // read-write commands go with higher priority as they are needed to keep cluster intact
 
                     case NKikimrBlobStorage::TConfigRequest::TCommand::kReadHostConfig:

--- a/ydb/core/mind/bscontroller/config.cpp
+++ b/ydb/core/mind/bscontroller/config.cpp
@@ -361,7 +361,7 @@ namespace NKikimr::NBsController {
                             disintegratedByExpectedStatus.push_back(overlay->first);
                             errors = true;
                         }
-                     }
+                    }
                 }
             }
 

--- a/ydb/core/mind/bscontroller/config.h
+++ b/ydb/core/mind/bscontroller/config.h
@@ -322,6 +322,7 @@ namespace NKikimr {
             void ExecuteStep(const NKikimrBlobStorage::TSetPDiskReadOnly& cmd, TStatus& status);
             void ExecuteStep(const NKikimrBlobStorage::TStopPDisk& cmd, TStatus& status);
             void ExecuteStep(const NKikimrBlobStorage::TGetInterfaceVersion& cmd, TStatus& status);
+            void ExecuteStep(const NKikimrBlobStorage::TMovePDisk& cmd, TStatus& status);
         };
 
     } // NBsController

--- a/ydb/core/mind/bscontroller/config_cmd.cpp
+++ b/ydb/core/mind/bscontroller/config_cmd.cpp
@@ -357,6 +357,7 @@ namespace NKikimr::NBsController {
                     HANDLE_COMMAND(SetPDiskReadOnly)
                     HANDLE_COMMAND(StopPDisk)
                     HANDLE_COMMAND(GetInterfaceVersion)
+                    HANDLE_COMMAND(MovePDisk)
 
                     case NKikimrBlobStorage::TConfigRequest::TCommand::kAddMigrationPlan:
                     case NKikimrBlobStorage::TConfigRequest::TCommand::kDeleteMigrationPlan:

--- a/ydb/core/protos/blobstorage_config.proto
+++ b/ydb/core/protos/blobstorage_config.proto
@@ -450,6 +450,15 @@ message TStopPDisk {
     }
 }
 
+message TMovePDisk {
+    message TPDisk {
+        NKikimrBlobStorage.TPDiskId TargetPDiskId = 1;
+        TPDiskLocation TargetPDiskLocation = 2;
+    }
+    TPDisk SourcePDisk = 1;
+    TPDisk DestinationPDisk = 2;
+}
+
 message TSetScrubPeriodicity {
     uint32 ScrubPeriodicity = 1; // in seconds; 0 = disable
 }
@@ -591,6 +600,7 @@ message TConfigRequest {
             TStopPDisk StopPDisk = 50;
             TGetInterfaceVersion GetInterfaceVersion = 51;
             TChangeGroupSizeInUnits ChangeGroupSizeInUnits = 52;
+            TMovePDisk MovePDisk = 53;
 
             // commands intended for internal use
             TReassignGroupDisk ReassignGroupDisk = 19;


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

Adds a command to move pdisk from one node to another, if both nodes have access to the underlying drive. This way we can skip data synchronization, since new disk will just use data of the "old" disk

### Changelog category <!-- remove all except one -->

* Experimental feature

### Description for reviewers <!-- (optional) description for those who read this PR -->

...
