### PR TITLE
Extract password verification to a separate actor

### DIFF
--- a/ydb/core/protos/counters_schemeshard.proto
+++ b/ydb/core/protos/counters_schemeshard.proto
@@ -651,4 +651,6 @@ enum ETxTypes {
 
     TXTYPE_ADD_SHARDS_DATA_ERASURE = 98 [(TxTypeOpts) = {Name: "TxAddShardsDataErasure"}];
     TXTYPE_CANCEL_SHARDS_DATA_ERASURE = 99 [(TxTypeOpts) = {Name: "TxCancelShardsDataErasure"}];
+
+    TXTYPE_LOGIN_FINALIZE = 100 [(TxTypeOpts) = {Name: "TxLoginFinalize"}];
 }

--- a/ydb/core/tx/schemeshard/schemeshard__login.cpp
+++ b/ydb/core/tx/schemeshard/schemeshard__login.cpp
@@ -3,7 +3,6 @@
 #include <ydb/core/base/auth.h>
 #include <ydb/core/base/local_user_token.h>
 #include <ydb/core/protos/auth.pb.h>
-
 #include <ydb/library/login/login.h>
 #include <ydb/library/security/util.h>
 
@@ -66,14 +65,14 @@ struct TSchemeShard::TTxLogin : TSchemeShard::TRwTxBase {
         if (Self->LoginProvider.NeedVerifyHash(loginRequest, &Response, &passwordHash)) {
             ctx.Send(
                 Self->LoginHelper,
-                MakeHolder<TEvVerifyPassword>(loginRequest, Response, Request->Sender, passwordHash),
+                MakeHolder<TEvPrivate::TEvVerifyPassword>(loginRequest, Response, Request->Sender, passwordHash),
                 0,
                 Request->Cookie
             );
         } else {
             ctx.Send(
                 Self->SelfId(),
-                MakeHolder<TEvLoginFinalize>(loginRequest, Response, Request->Sender, "", /*needUpdateCache*/ false),
+                MakeHolder<TEvPrivate::TEvLoginFinalize>(loginRequest, Response, Request->Sender, "", /*needUpdateCache*/ false),
                 0,
                 Request->Cookie
             );

--- a/ydb/core/tx/schemeshard/schemeshard__login.cpp
+++ b/ydb/core/tx/schemeshard/schemeshard__login.cpp
@@ -4,18 +4,17 @@
 #include <ydb/core/base/local_user_token.h>
 #include <ydb/core/protos/auth.pb.h>
 
+#include <ydb/library/login/login.h>
 #include <ydb/library/security/util.h>
 
 namespace NKikimr {
 namespace NSchemeShard {
 
-using namespace NTabletFlatExecutor;
-
 struct TSchemeShard::TTxLogin : TSchemeShard::TRwTxBase {
     TEvSchemeShard::TEvLogin::TPtr Request;
     TPathId SubDomainPathId;
     bool NeedPublishOnComplete = false;
-    THolder<TEvSchemeShard::TEvLoginResult> Result = MakeHolder<TEvSchemeShard::TEvLoginResult>();
+    TString ErrMessage;
 
     TTxLogin(TSelf *self, TEvSchemeShard::TEvLogin::TPtr &ev)
         : TRwTxBase(self)
@@ -44,35 +43,41 @@ struct TSchemeShard::TTxLogin : TSchemeShard::TRwTxBase {
                     << " at schemeshard: " << Self->TabletID());
         NIceDb::TNiceDb db(txc.DB);
         if (Self->LoginProvider.IsItTimeToRotateKeys()) {
-            LOG_DEBUG_S(ctx, NKikimrServices::FLAT_TX_SCHEMESHARD, "TTxLogin RotateKeys at schemeshard: " << Self->TabletID());
-            std::vector<ui64> keysExpired;
-            std::vector<ui64> keysAdded;
-            Self->LoginProvider.RotateKeys(keysExpired, keysAdded);
-            SubDomainPathId = Self->GetCurrentSubDomainPathId();
-            TSubDomainInfo::TPtr domainPtr = Self->ResolveDomainInfo(SubDomainPathId);
-
-            // TODO(xenoxeno): optimize security state changes
-            domainPtr->UpdateSecurityState(Self->LoginProvider.GetSecurityState());
-            domainPtr->IncSecurityStateVersion();
-
-
-            Self->PersistSubDomainSecurityStateVersion(db, SubDomainPathId, *domainPtr);
-
-            for (ui64 keyId : keysExpired) {
-                db.Table<Schema::LoginKeys>().Key(keyId).Delete();
-            }
-            for (ui64 keyId : keysAdded) {
-                const auto* key = Self->LoginProvider.FindKey(keyId);
-                if (key) {
-                    db.Table<Schema::LoginKeys>().Key(keyId).Update<Schema::LoginKeys::KeyDataPEM, Schema::LoginKeys::ExpiresAt>(
-                        key->PublicKey, ToInstant(key->ExpiresAt).MilliSeconds());
-                }
-            }
-
+            RotateKeys(ctx, db);
             NeedPublishOnComplete = true;
         }
 
-        LoginAttempt(db, ctx);
+        const auto& loginRequest = GetLoginRequest();
+        if (!loginRequest.ExternalAuth) {
+            if (!AppData(ctx)->AuthConfig.GetEnableLoginAuthentication()) {
+                ErrMessage = "Login authentication is disabled";
+            } else {
+                CheckLockOutUserAndSetErrorIfAny(loginRequest.User, db);
+            }
+        }
+
+        if (ErrMessage) {
+            SendError();
+            return;
+        }
+
+        NLogin::TLoginProvider::TLoginUserResponse Response;
+        TString passwordHash;
+        if (Self->LoginProvider.NeedVerifyHash(loginRequest, &Response, &passwordHash)) {
+            ctx.Send(
+                Self->LoginHelper,
+                MakeHolder<TEvVerifyPassword>(loginRequest, Response, Request->Sender, passwordHash),
+                0,
+                Request->Cookie
+            );
+        } else {
+            ctx.Send(
+                Self->SelfId(),
+                MakeHolder<TEvLoginFinalize>(loginRequest, Response, Request->Sender, "", /*needUpdateCache*/ false),
+                0,
+                Request->Cookie
+            );
+        }
     }
 
     void DoComplete(const TActorContext &ctx) override {
@@ -82,63 +87,49 @@ struct TSchemeShard::TTxLogin : TSchemeShard::TRwTxBase {
 
         LOG_DEBUG_S(ctx, NKikimrServices::FLAT_TX_SCHEMESHARD,
                     "TTxLogin Complete"
-                    << ", result: " << Result->Record.ShortDebugString()
+                    << ", with " << (ErrMessage ? "error: " + ErrMessage : "no errors")
                     << ", at schemeshard: " << Self->TabletID());
-
-        ctx.Send(Request->Sender, std::move(Result), 0, Request->Cookie);
-    }
+}
 
 private:
-    bool IsAdmin() const {
-        const auto& user = Request->Get()->Record.GetUser();
-        const auto userToken = NKikimr::BuildLocalUserToken(Self->LoginProvider, user);
-        return IsAdministrator(AppData(), &userToken);
-    }
+    void RotateKeys(const TActorContext& ctx, NIceDb::TNiceDb& db) {
+        LOG_DEBUG_S(ctx, NKikimrServices::FLAT_TX_SCHEMESHARD, "TTxLogin RotateKeys at schemeshard: " << Self->TabletID());
+        std::vector<ui64> keysExpired;
+        std::vector<ui64> keysAdded;
+        Self->LoginProvider.RotateKeys(keysExpired, keysAdded);
+        SubDomainPathId = Self->GetCurrentSubDomainPathId();
+        TSubDomainInfo::TPtr domainPtr = Self->ResolveDomainInfo(SubDomainPathId);
 
-    void LoginAttempt(NIceDb::TNiceDb& db, const TActorContext& ctx) {
-        const auto& loginRequest = GetLoginRequest();
-        if (!loginRequest.ExternalAuth && !AppData(ctx)->AuthConfig.GetEnableLoginAuthentication()) {
-            Result->Record.SetError("Login authentication is disabled");
-            return;
-        }
-        if (loginRequest.ExternalAuth) {
-            HandleExternalAuth(loginRequest);
-        } else {
-            HandleLoginAuth(loginRequest, db);
-        }
-    }
+        // TODO(xenoxeno): optimize security state changes
+        domainPtr->UpdateSecurityState(Self->LoginProvider.GetSecurityState());
+        domainPtr->IncSecurityStateVersion();
 
-    void HandleExternalAuth(const NLogin::TLoginProvider::TLoginUserRequest& loginRequest) {
-        const NLogin::TLoginProvider::TLoginUserResponse loginResponse = Self->LoginProvider.LoginUser(loginRequest);
-        switch (loginResponse.Status) {
-        case NLogin::TLoginProvider::TLoginUserResponse::EStatus::SUCCESS: {
-            Result->Record.SetToken(loginResponse.Token);
-            Result->Record.SetSanitizedToken(loginResponse.SanitizedToken);
-            Result->Record.SetIsAdmin(IsAdmin());
-            break;
+        Self->PersistSubDomainSecurityStateVersion(db, SubDomainPathId, *domainPtr);
+
+        for (ui64 keyId : keysExpired) {
+            db.Table<Schema::LoginKeys>().Key(keyId).Delete();
         }
-        case NLogin::TLoginProvider::TLoginUserResponse::EStatus::INVALID_PASSWORD:
-        case NLogin::TLoginProvider::TLoginUserResponse::EStatus::INVALID_USER:
-        case NLogin::TLoginProvider::TLoginUserResponse::EStatus::UNAVAILABLE_KEY:
-        case NLogin::TLoginProvider::TLoginUserResponse::EStatus::UNSPECIFIED: {
-            Result->Record.SetError(loginResponse.Error);
-            break;
-        }
+        for (ui64 keyId : keysAdded) {
+            const auto* key = Self->LoginProvider.FindKey(keyId);
+            if (key) {
+                db.Table<Schema::LoginKeys>().Key(keyId).Update<Schema::LoginKeys::KeyDataPEM, Schema::LoginKeys::ExpiresAt>(
+                    key->PublicKey, ToInstant(key->ExpiresAt).MilliSeconds());
+            }
         }
     }
 
-    void HandleLoginAuth(const NLogin::TLoginProvider::TLoginUserRequest& loginRequest, NIceDb::TNiceDb& db) {
+    void CheckLockOutUserAndSetErrorIfAny(const TString& user, NIceDb::TNiceDb& db) {
         using namespace NLogin;
-        const TLoginProvider::TCheckLockOutResponse checkLockOutResponse = Self->LoginProvider.CheckLockOutUser({.User = loginRequest.User});
+        const TLoginProvider::TCheckLockOutResponse checkLockOutResponse = Self->LoginProvider.CheckLockOutUser({.User = user});
         switch (checkLockOutResponse.Status) {
             case TLoginProvider::TCheckLockOutResponse::EStatus::SUCCESS:
             case TLoginProvider::TCheckLockOutResponse::EStatus::INVALID_USER: {
-                Result->Record.SetError(checkLockOutResponse.Error);
+                ErrMessage = checkLockOutResponse.Error;
                 return;
             }
             case TLoginProvider::TCheckLockOutResponse::EStatus::RESET: {
-                const auto& sid = Self->LoginProvider.Sids[loginRequest.User];
-                db.Table<Schema::LoginSids>().Key(loginRequest.User).Update<Schema::LoginSids::FailedAttemptCount>(sid.FailedLoginAttemptCount);
+                const auto& sid = Self->LoginProvider.Sids[user];
+                db.Table<Schema::LoginSids>().Key(user).Update<Schema::LoginSids::FailedAttemptCount>(sid.FailedLoginAttemptCount);
                 break;
             }
             case TLoginProvider::TCheckLockOutResponse::EStatus::UNLOCKED:
@@ -146,32 +137,17 @@ private:
                 break;
             }
         }
+    }
 
-        const TLoginProvider::TLoginUserResponse loginResponse = Self->LoginProvider.LoginUser(loginRequest);
-        switch (loginResponse.Status) {
-        case TLoginProvider::TLoginUserResponse::EStatus::SUCCESS: {
-            const auto& sid = Self->LoginProvider.Sids[loginRequest.User];
-            db.Table<Schema::LoginSids>().Key(loginRequest.User).Update<Schema::LoginSids::LastSuccessfulAttempt,
-                                                                        Schema::LoginSids::FailedAttemptCount>(ToMicroSeconds(sid.LastSuccessfulLogin), sid.FailedLoginAttemptCount);
-            Result->Record.SetToken(loginResponse.Token);
-            Result->Record.SetSanitizedToken(loginResponse.SanitizedToken);
-            Result->Record.SetIsAdmin(IsAdmin());
-            break;
-        }
-        case TLoginProvider::TLoginUserResponse::EStatus::INVALID_PASSWORD: {
-            const auto& sid = Self->LoginProvider.Sids[loginRequest.User];
-            db.Table<Schema::LoginSids>().Key(loginRequest.User).Update<Schema::LoginSids::LastFailedAttempt,
-                                                                        Schema::LoginSids::FailedAttemptCount>(ToMicroSeconds(sid.LastFailedLogin), sid.FailedLoginAttemptCount);
-            Result->Record.SetError(loginResponse.Error);
-            break;
-        }
-        case NLogin::TLoginProvider::TLoginUserResponse::EStatus::INVALID_USER:
-        case NLogin::TLoginProvider::TLoginUserResponse::EStatus::UNAVAILABLE_KEY:
-        case NLogin::TLoginProvider::TLoginUserResponse::EStatus::UNSPECIFIED: {
-            Result->Record.SetError(loginResponse.Error);
-            break;
-        }
-        }
+    void SendError() {
+        THolder<TEvSchemeShard::TEvLoginResult> result = MakeHolder<TEvSchemeShard::TEvLoginResult>();
+        result->Record.SetError(ErrMessage);
+        Self->Send(
+            Request->Sender,
+            std::move(result),
+            0,
+            Request->Cookie
+        );
     }
 };
 

--- a/ydb/core/tx/schemeshard/schemeshard__login_finalize.cpp
+++ b/ydb/core/tx/schemeshard/schemeshard__login_finalize.cpp
@@ -1,0 +1,133 @@
+#include "schemeshard_impl.h"
+#include "schemeshard_login_helper.h"
+#include <ydb/library/security/util.h>
+#include <ydb/core/protos/auth.pb.h>
+#include <ydb/core/base/auth.h>
+#include <ydb/core/base/local_user_token.h>
+
+namespace NKikimr {
+namespace NSchemeShard {
+
+struct TSchemeShard::TTxLoginFinalize : TSchemeShard::TRwTxBase {
+private:
+    TEvLoginFinalize::TPtr LoginFinalizeEventPtr_;
+    TString ErrMessage;
+
+public:
+    TTxLoginFinalize(TSelf *self, TEvLoginFinalize::TPtr &ev)
+        : TRwTxBase(self)
+        , LoginFinalizeEventPtr_(std::move(ev))
+    {}
+
+    TTxType GetTxType() const override {
+        return TXTYPE_LOGIN_FINALIZE;
+    }
+
+    void DoExecute(TTransactionContext& txc, const TActorContext& ctx) override {
+        LOG_DEBUG_S(ctx, NKikimrServices::FLAT_TX_SCHEMESHARD,
+                    "TTxLoginFinalize Execute"
+                    << " at schemeshard: " << Self->TabletID());
+
+        const auto& event = *LoginFinalizeEventPtr_->Get();
+        if (event.NeedUpdateCache) {
+            const auto isSuccessVerifying =
+                event.CheckResult.Status == NLogin::TLoginProvider::TLoginUserResponse::EStatus::SUCCESS;
+            Self->LoginProvider.UpdateCache(
+                event.Request,
+                event.PasswordHash,
+                isSuccessVerifying
+            );
+        }
+        const auto response = Self->LoginProvider.LoginUser(event.Request, event.CheckResult);
+
+        if (!LoginFinalizeEventPtr_->Get()->Request.ExternalAuth) {
+            UpdateLoginSidsStats(response, txc);
+        }
+        if (!response.Error.empty()) {
+            ErrMessage = response.Error;
+            SendError(response.Error);
+            return;
+        }
+        FillResult(response);
+    }
+
+    void DoComplete(const TActorContext &ctx) override {
+        LOG_DEBUG_S(ctx, NKikimrServices::FLAT_TX_SCHEMESHARD,
+            "TTxLoginFinalize Completed"
+            << ", with " << (ErrMessage ? "error: " + ErrMessage : "no errors")
+            << " at schemeshard: " << Self->TabletID());
+    }
+
+private:
+    bool IsAdmin(const TString& user) const {
+        const auto userToken = NKikimr::BuildLocalUserToken(Self->LoginProvider, user);
+        return IsAdministrator(AppData(), &userToken);
+    }
+
+    void FillResult(const NLogin::TLoginProvider::TLoginUserResponse& response) {
+        THolder<TEvSchemeShard::TEvLoginResult> result = MakeHolder<TEvSchemeShard::TEvLoginResult>();
+        switch (response.Status) {
+        case NLogin::TLoginProvider::TLoginUserResponse::EStatus::SUCCESS: {
+            result->Record.SetToken(response.Token);
+            result->Record.SetSanitizedToken(response.SanitizedToken);
+            result->Record.SetIsAdmin(IsAdmin(LoginFinalizeEventPtr_->Get()->Request.User));
+            break;
+        }
+        case NLogin::TLoginProvider::TLoginUserResponse::EStatus::INVALID_PASSWORD:
+        case NLogin::TLoginProvider::TLoginUserResponse::EStatus::INVALID_USER:
+        case NLogin::TLoginProvider::TLoginUserResponse::EStatus::UNAVAILABLE_KEY:
+        case NLogin::TLoginProvider::TLoginUserResponse::EStatus::UNSPECIFIED: {
+            result->Record.SetError(response.Error);
+            break;
+        }
+        }
+        Self->Send(
+            LoginFinalizeEventPtr_->Get()->Source,
+            std::move(result),
+            0,
+            LoginFinalizeEventPtr_->Cookie
+        );
+    }
+
+    void SendError(const TString& error) {
+        THolder<TEvSchemeShard::TEvLoginResult> result = MakeHolder<TEvSchemeShard::TEvLoginResult>();
+        result->Record.SetError(error);
+        Self->Send(
+            LoginFinalizeEventPtr_->Get()->Source,
+            std::move(result),
+            0,
+            LoginFinalizeEventPtr_->Cookie
+        );
+    }
+
+    void UpdateLoginSidsStats(const NLogin::TLoginProvider::TLoginUserResponse& response, TTransactionContext& txc) {
+        NIceDb::TNiceDb db(txc.DB);
+        switch (response.Status) {
+        case NLogin::TLoginProvider::TLoginUserResponse::EStatus::SUCCESS: {
+            const auto& sid = Self->LoginProvider.Sids[LoginFinalizeEventPtr_->Get()->Request.User];
+            db.Table<Schema::LoginSids>()
+                .Key(LoginFinalizeEventPtr_->Get()->Request.User)
+                .Update<Schema::LoginSids::LastSuccessfulAttempt, Schema::LoginSids::FailedAttemptCount>(
+                    ToMicroSeconds(sid.LastSuccessfulLogin), sid.FailedLoginAttemptCount
+                );
+            break;
+        }
+        case NLogin::TLoginProvider::TLoginUserResponse::EStatus::INVALID_PASSWORD: {
+            const auto& sid = Self->LoginProvider.Sids[LoginFinalizeEventPtr_->Get()->Request.User];
+            db.Table<Schema::LoginSids>()
+                .Key(LoginFinalizeEventPtr_->Get()->Request.User)
+                .Update<Schema::LoginSids::LastFailedAttempt, Schema::LoginSids::FailedAttemptCount>(
+                        ToMicroSeconds(sid.LastFailedLogin), sid.FailedLoginAttemptCount
+                );
+        }
+        default:
+            break;
+        }
+    }
+};
+
+NTabletFlatExecutor::ITransaction* TSchemeShard::CreateTxLoginFinalize(TEvLoginFinalize::TPtr &ev) {
+    return new TTxLoginFinalize(this, ev);
+}
+
+}}

--- a/ydb/core/tx/schemeshard/schemeshard__login_finalize.cpp
+++ b/ydb/core/tx/schemeshard/schemeshard__login_finalize.cpp
@@ -1,5 +1,4 @@
 #include "schemeshard_impl.h"
-#include "schemeshard_login_helper.h"
 #include <ydb/library/security/util.h>
 #include <ydb/core/protos/auth.pb.h>
 #include <ydb/core/base/auth.h>
@@ -10,11 +9,11 @@ namespace NSchemeShard {
 
 struct TSchemeShard::TTxLoginFinalize : TSchemeShard::TRwTxBase {
 private:
-    TEvLoginFinalize::TPtr LoginFinalizeEventPtr;
+    TEvPrivate::TEvLoginFinalize::TPtr LoginFinalizeEventPtr;
     TString ErrMessage;
 
 public:
-    TTxLoginFinalize(TSelf *self, TEvLoginFinalize::TPtr &ev)
+    TTxLoginFinalize(TSelf *self, TEvPrivate::TEvLoginFinalize::TPtr &ev)
         : TRwTxBase(self)
         , LoginFinalizeEventPtr(std::move(ev))
     {}
@@ -90,7 +89,7 @@ private:
     }
 
     void SendError(const TString& error) {
-        THolder<TEvSchemeShard::TEvLoginResult> result = MakeHolder<TEvSchemeShard::TEvLoginResult>();
+        auto result = MakeHolder<TEvSchemeShard::TEvLoginResult>();
         result->Record.SetError(error);
         Self->Send(
             LoginFinalizeEventPtr->Get()->Source,
@@ -126,7 +125,7 @@ private:
     }
 };
 
-NTabletFlatExecutor::ITransaction* TSchemeShard::CreateTxLoginFinalize(TEvLoginFinalize::TPtr &ev) {
+NTabletFlatExecutor::ITransaction* TSchemeShard::CreateTxLoginFinalize(TEvPrivate::TEvLoginFinalize::TPtr &ev) {
     return new TTxLoginFinalize(this, ev);
 }
 

--- a/ydb/core/tx/schemeshard/schemeshard_impl.cpp
+++ b/ydb/core/tx/schemeshard/schemeshard_impl.cpp
@@ -1,4 +1,6 @@
 #include "schemeshard_impl.h"
+#include "schemeshard_login_helper.h"
+#include "schemeshard_svp_migration.h"
 
 #include "olap/bg_tasks/adapter/adapter.h"
 #include "olap/bg_tasks/events/global.h"
@@ -5135,7 +5137,7 @@ void TSchemeShard::StateWork(STFUNC_SIG) {
         HFuncTraced(TEvPrivate::TEvPersistTopicStats, Handle);
 
         HFuncTraced(TEvSchemeShard::TEvLogin, Handle);
-        HFuncTraced(TEvLoginFinalize, Handle);
+        HFuncTraced(TEvPrivate::TEvLoginFinalize, Handle);
         HFuncTraced(TEvSchemeShard::TEvListUsers, Handle);
 
         HFuncTraced(TEvDataShard::TEvProposeTransactionAttachResult, Handle);
@@ -7829,7 +7831,7 @@ void TSchemeShard::Handle(TEvSchemeShard::TEvLogin::TPtr &ev, const TActorContex
     Execute(CreateTxLogin(ev), ctx);
 }
 
-void TSchemeShard::Handle(TEvLoginFinalize::TPtr &ev, const TActorContext &ctx) {
+void TSchemeShard::Handle(TEvPrivate::TEvLoginFinalize::TPtr &ev, const TActorContext &ctx) {
     Execute(CreateTxLoginFinalize(ev), ctx);
 }
 

--- a/ydb/core/tx/schemeshard/schemeshard_impl.h
+++ b/ydb/core/tx/schemeshard/schemeshard_impl.h
@@ -1054,7 +1054,7 @@ public:
     struct TTxLogin;
     NTabletFlatExecutor::ITransaction* CreateTxLogin(TEvSchemeShard::TEvLogin::TPtr &ev);
     struct TTxLoginFinalize;
-    NTabletFlatExecutor::ITransaction* CreateTxLoginFinalize(TEvLoginFinalize::TPtr &ev);
+    NTabletFlatExecutor::ITransaction* CreateTxLoginFinalize(TEvPrivate::TEvLoginFinalize::TPtr &ev);
     struct TTxListUsers;
     NTabletFlatExecutor::ITransaction* CreateTxListUsers(TEvSchemeShard::TEvListUsers::TPtr &ev);
 
@@ -1247,7 +1247,7 @@ public:
     void Handle(NConsole::TEvConsole::TEvConfigNotificationRequest::TPtr &ev, const TActorContext &ctx);
 
     void Handle(TEvSchemeShard::TEvLogin::TPtr& ev, const TActorContext& ctx);
-    void Handle(TEvLoginFinalize::TPtr& ev, const TActorContext& ctx);
+    void Handle(TEvPrivate::TEvLoginFinalize::TPtr& ev, const TActorContext& ctx);
     void Handle(TEvSchemeShard::TEvListUsers::TPtr& ev, const TActorContext& ctx);
 
     void RestartPipeTx(TTabletId tabletId, const TActorContext& ctx);

--- a/ydb/core/tx/schemeshard/schemeshard_impl.h
+++ b/ydb/core/tx/schemeshard/schemeshard_impl.h
@@ -12,6 +12,7 @@
 #include "schemeshard_export.h"
 #include "schemeshard_import.h"
 #include "schemeshard_info_types.h"
+#include "schemeshard_login_helper.h"
 #include "schemeshard_path.h"
 #include "schemeshard_path_element.h"
 #include "schemeshard_private.h"
@@ -1052,6 +1053,8 @@ public:
 
     struct TTxLogin;
     NTabletFlatExecutor::ITransaction* CreateTxLogin(TEvSchemeShard::TEvLogin::TPtr &ev);
+    struct TTxLoginFinalize;
+    NTabletFlatExecutor::ITransaction* CreateTxLoginFinalize(TEvLoginFinalize::TPtr &ev);
     struct TTxListUsers;
     NTabletFlatExecutor::ITransaction* CreateTxListUsers(TEvSchemeShard::TEvListUsers::TPtr &ev);
 
@@ -1244,6 +1247,7 @@ public:
     void Handle(NConsole::TEvConsole::TEvConfigNotificationRequest::TPtr &ev, const TActorContext &ctx);
 
     void Handle(TEvSchemeShard::TEvLogin::TPtr& ev, const TActorContext& ctx);
+    void Handle(TEvLoginFinalize::TPtr& ev, const TActorContext& ctx);
     void Handle(TEvSchemeShard::TEvListUsers::TPtr& ev, const TActorContext& ctx);
 
     void RestartPipeTx(TTabletId tabletId, const TActorContext& ctx);
@@ -1564,6 +1568,8 @@ public:
     void SetShardsQuota(ui64 value) override;
 
     NLogin::TLoginProvider LoginProvider;
+    TActorId LoginHelper;
+
     THolder<TDataErasureManager> DataErasureManager = nullptr;
 
 private:

--- a/ydb/core/tx/schemeshard/schemeshard_login_helper.cpp
+++ b/ydb/core/tx/schemeshard/schemeshard_login_helper.cpp
@@ -1,9 +1,9 @@
 #include "schemeshard_login_helper.h"
 #include "schemeshard_private.h"
-#include <ydb/library/login/login.h>
 #include <ydb/library/actors/core/actor_bootstrapped.h>
-#include <ydb/library/actors/core/hfunc.h>
 #include <ydb/library/actors/core/events.h>
+#include <ydb/library/actors/core/hfunc.h>
+#include <ydb/library/login/login.h>
 
 namespace NKikimr::NSchemeShard {
 

--- a/ydb/core/tx/schemeshard/schemeshard_login_helper.cpp
+++ b/ydb/core/tx/schemeshard/schemeshard_login_helper.cpp
@@ -1,0 +1,55 @@
+#include "schemeshard_login_helper.h"
+#include <ydb/library/login/login.h>
+#include <ydb/library/actors/core/actor_bootstrapped.h>
+#include <ydb/library/actors/core/hfunc.h>
+#include <ydb/library/actors/core/events.h>
+
+namespace NKikimr::NSchemeShard {
+
+class TLoginHelper : public NActors::TActorBootstrapped<TLoginHelper> {
+public:
+    explicit TLoginHelper(const NLogin::TLoginProvider& loginProvider)
+        : LoginProvider_(loginProvider)
+    {}
+
+    void Bootstrap() {
+        Become(&TThis::StateWork);
+    }
+
+    STATEFN(StateWork) {
+        switch (ev->GetTypeRewrite()) {
+            hFunc(TEvVerifyPassword, VerifyPassword);
+            cFunc(NActors::TEvents::TEvPoison::EventType, PassAway);
+        }
+    }
+
+private:
+    void VerifyPassword(TEvVerifyPassword::TPtr& ev) {
+        const bool isSuccessVerifying = LoginProvider_.VerifyHash(ev->Get()->Request, ev->Get()->PasswordHash);
+        if (!isSuccessVerifying) {
+            ev->Get()->CheckResult.Status = NLogin::TLoginProvider::TLoginUserResponse::EStatus::INVALID_PASSWORD;
+            ev->Get()->CheckResult.Error = "Invalid password";
+        }
+        Send(
+            ev->Sender,
+            MakeHolder<TEvLoginFinalize>(
+                ev->Get()->Request,
+                ev->Get()->CheckResult,
+                ev->Get()->Source,
+                ev->Get()->PasswordHash,
+                /*needUpdateCache*/ true
+            ),
+            0,
+            ev->Cookie
+        );
+    }
+
+private:
+    const NLogin::TLoginProvider& LoginProvider_;
+};
+
+THolder<NActors::IActor> CreateLoginHelper(const NLogin::TLoginProvider& loginProvider) {
+    return MakeHolder<TLoginHelper>(loginProvider);
+}
+
+} // namespace NKikimr::NSchemeShard

--- a/ydb/core/tx/schemeshard/schemeshard_login_helper.h
+++ b/ydb/core/tx/schemeshard/schemeshard_login_helper.h
@@ -1,62 +1,12 @@
 #pragma once
 
 #include <ydb/library/actors/core/actor.h>
-#include <ydb/library/actors/core/event_local.h>
-#include <ydb/library/login/login.h>
+
+namespace NLogin {
+    class TLoginProvider;
+}
 
 namespace NKikimr::NSchemeShard {
-
-class TSchemeShard;
-
-enum EEvLogin {
-    EvVerifyPassword,
-    EvLoginFinalize,
-};
-
-struct TEvVerifyPassword : public NActors::TEventLocal<TEvVerifyPassword, EvVerifyPassword> {
-public:
-    TEvVerifyPassword(
-        const NLogin::TLoginProvider::TLoginUserRequest& request,
-        const NLogin::TLoginProvider::TPasswordCheckResult& checkResult,
-        const NActors::TActorId source,
-        const TString& passwordHash
-    )
-        : Request(request)
-        , CheckResult(checkResult)
-        , Source(source)
-        , PasswordHash(passwordHash)
-    {}
-
-public:
-    const NLogin::TLoginProvider::TLoginUserRequest Request;
-    NLogin::TLoginProvider::TPasswordCheckResult CheckResult;
-    const NActors::TActorId Source;
-    const TString PasswordHash;
-};
-
-struct TEvLoginFinalize : public NActors::TEventLocal<TEvLoginFinalize, EvLoginFinalize> {
-public:
-    TEvLoginFinalize(
-        const NLogin::TLoginProvider::TLoginUserRequest& request,
-        const NLogin::TLoginProvider::TPasswordCheckResult& checkResult,
-        const NActors::TActorId source,
-        const TString& passwordHash,
-        const bool needUpdateCache
-    )
-        : Request(request)
-        , CheckResult(checkResult)
-        , Source(source)
-        , PasswordHash(passwordHash)
-        , NeedUpdateCache(needUpdateCache)
-    {}
-
-public:
-    const NLogin::TLoginProvider::TLoginUserRequest Request;
-    const NLogin::TLoginProvider::TPasswordCheckResult CheckResult;
-    const NActors::TActorId Source;
-    const TString PasswordHash;
-    const bool NeedUpdateCache;
-};
 
 THolder<NActors::IActor> CreateLoginHelper(const NLogin::TLoginProvider& loginProvider);
 

--- a/ydb/core/tx/schemeshard/schemeshard_login_helper.h
+++ b/ydb/core/tx/schemeshard/schemeshard_login_helper.h
@@ -1,0 +1,63 @@
+#pragma once
+
+#include <ydb/library/actors/core/actor.h>
+#include <ydb/library/actors/core/event_local.h>
+#include <ydb/library/login/login.h>
+
+namespace NKikimr::NSchemeShard {
+
+class TSchemeShard;
+
+enum EEvLogin {
+    EvVerifyPassword,
+    EvLoginFinalize,
+};
+
+struct TEvVerifyPassword : public NActors::TEventLocal<TEvVerifyPassword, EvVerifyPassword> {
+public:
+    TEvVerifyPassword(
+        const NLogin::TLoginProvider::TLoginUserRequest& request,
+        const NLogin::TLoginProvider::TPasswordCheckResult& checkResult,
+        const NActors::TActorId source,
+        const TString& passwordHash
+    )
+        : Request(request)
+        , CheckResult(checkResult)
+        , Source(source)
+        , PasswordHash(passwordHash)
+    {}
+
+public:
+    const NLogin::TLoginProvider::TLoginUserRequest Request;
+    NLogin::TLoginProvider::TPasswordCheckResult CheckResult;
+    const NActors::TActorId Source;
+    const TString PasswordHash;
+};
+
+struct TEvLoginFinalize : public NActors::TEventLocal<TEvLoginFinalize, EvLoginFinalize> {
+public:
+    TEvLoginFinalize(
+        const NLogin::TLoginProvider::TLoginUserRequest& request,
+        const NLogin::TLoginProvider::TPasswordCheckResult& checkResult,
+        const NActors::TActorId source,
+        const TString& passwordHash,
+        const bool needUpdateCache
+    )
+        : Request(request)
+        , CheckResult(checkResult)
+        , Source(source)
+        , PasswordHash(passwordHash)
+        , NeedUpdateCache(needUpdateCache)
+    {}
+
+public:
+    const NLogin::TLoginProvider::TLoginUserRequest Request;
+    const NLogin::TLoginProvider::TPasswordCheckResult CheckResult;
+    const NActors::TActorId Source;
+    const TString PasswordHash;
+    const bool NeedUpdateCache;
+};
+
+THolder<NActors::IActor> CreateLoginHelper(const NLogin::TLoginProvider& loginProvider);
+
+} // namespace NKikimr::NSchemeShard

--- a/ydb/core/tx/schemeshard/schemeshard_private.h
+++ b/ydb/core/tx/schemeshard/schemeshard_private.h
@@ -7,6 +7,8 @@
 
 #include <ydb/library/actors/core/event_local.h>
 #include <ydb/library/actors/core/events.h>
+#include <ydb/library/login/login.h>
+#include <ydb/public/api/protos/ydb_status_codes.pb.h>
 
 #include <util/datetime/base.h>
 
@@ -45,6 +47,8 @@ namespace TEvPrivate {
         EvRunDataErasure,
         EvRunTenantDataErasure,
         EvAddNewShardToDataErasure,
+        EvVerifyPassword,
+        EvLoginFinalize,
         EvEnd
     };
 
@@ -274,6 +278,51 @@ namespace TEvPrivate {
         TEvAddNewShardToDataErasure(std::vector<TShardIdx>&& shards)
             : Shards(std::move(shards))
         {}
+    };
+
+    struct TEvVerifyPassword : public NActors::TEventLocal<TEvVerifyPassword, EvVerifyPassword> {
+    public:
+        TEvVerifyPassword(
+            const NLogin::TLoginProvider::TLoginUserRequest& request,
+            const NLogin::TLoginProvider::TPasswordCheckResult& checkResult,
+            const NActors::TActorId source,
+            const TString& passwordHash
+        )
+            : Request(request)
+            , CheckResult(checkResult)
+            , Source(source)
+            , PasswordHash(passwordHash)
+        {}
+
+    public:
+        const NLogin::TLoginProvider::TLoginUserRequest Request;
+        NLogin::TLoginProvider::TPasswordCheckResult CheckResult;
+        const NActors::TActorId Source;
+        const TString PasswordHash;
+    };
+
+    struct TEvLoginFinalize : public NActors::TEventLocal<TEvLoginFinalize, EvLoginFinalize> {
+    public:
+        TEvLoginFinalize(
+            const NLogin::TLoginProvider::TLoginUserRequest& request,
+            const NLogin::TLoginProvider::TPasswordCheckResult& checkResult,
+            const NActors::TActorId source,
+            const TString& passwordHash,
+            const bool needUpdateCache
+        )
+            : Request(request)
+            , CheckResult(checkResult)
+            , Source(source)
+            , PasswordHash(passwordHash)
+            , NeedUpdateCache(needUpdateCache)
+        {}
+
+    public:
+        const NLogin::TLoginProvider::TLoginUserRequest Request;
+        const NLogin::TLoginProvider::TPasswordCheckResult CheckResult;
+        const NActors::TActorId Source;
+        const TString PasswordHash;
+        const bool NeedUpdateCache;
     };
 }; // TEvPrivate
 

--- a/ydb/core/tx/schemeshard/schemeshard_private.h
+++ b/ydb/core/tx/schemeshard/schemeshard_private.h
@@ -8,7 +8,6 @@
 #include <ydb/library/actors/core/event_local.h>
 #include <ydb/library/actors/core/events.h>
 #include <ydb/library/login/login.h>
-#include <ydb/public/api/protos/ydb_status_codes.pb.h>
 
 #include <util/datetime/base.h>
 
@@ -297,7 +296,7 @@ namespace TEvPrivate {
     public:
         const NLogin::TLoginProvider::TLoginUserRequest Request;
         NLogin::TLoginProvider::TPasswordCheckResult CheckResult;
-        const NActors::TActorId Source;
+        const NActors::TActorId Source; // actorId of the initial schemeshard client which requested user login
         const TString PasswordHash;
     };
 
@@ -320,7 +319,7 @@ namespace TEvPrivate {
     public:
         const NLogin::TLoginProvider::TLoginUserRequest Request;
         const NLogin::TLoginProvider::TPasswordCheckResult CheckResult;
-        const NActors::TActorId Source;
+        const NActors::TActorId Source; // actorId of the initial schemeshard client which requested user login
         const TString PasswordHash;
         const bool NeedUpdateCache;
     };

--- a/ydb/core/tx/schemeshard/ut_helpers/helpers.cpp
+++ b/ydb/core/tx/schemeshard/ut_helpers/helpers.cpp
@@ -2130,6 +2130,22 @@ namespace NSchemeShardUT_Private {
         return event->Record;
     }
 
+    NKikimrScheme::TEvLoginResult LoginFinalize(
+        TTestActorRuntime& runtime,
+        const NLogin::TLoginProvider::TLoginUserRequest& request,
+        const NLogin::TLoginProvider::TPasswordCheckResult& checkResult,
+        const TString& passwordHash,
+        const bool needUpdateCache
+    ) {
+        TActorId sender = runtime.AllocateEdgeActor();
+        auto evLoginFinalize = new NKikimr::NSchemeShard::TEvLoginFinalize(request, checkResult, sender, passwordHash, needUpdateCache);
+        ForwardToTablet(runtime, TTestTxConfig::SchemeShard, sender, evLoginFinalize);
+        TAutoPtr<IEventHandle> handle;
+        auto event = runtime.GrabEdgeEvent<TEvSchemeShard::TEvLoginResult>(handle);
+        UNIT_ASSERT(event);
+        return event->Record;
+    }
+
     void ModifyUser(TTestActorRuntime& runtime, ui64 txId, const TString& database, std::function<void(::NKikimrSchemeOp::TLoginModifyUser*)>&& initiator) {
         auto modifyTx = std::make_unique<TEvSchemeShard::TEvModifySchemeTransaction>(txId, TTestTxConfig::SchemeShard);
         auto transaction = modifyTx->Record.AddTransaction();

--- a/ydb/core/tx/schemeshard/ut_helpers/helpers.cpp
+++ b/ydb/core/tx/schemeshard/ut_helpers/helpers.cpp
@@ -14,6 +14,7 @@
 #include <ydb/core/tx/data_events/events.h>
 #include <ydb/core/tx/data_events/payload_helper.h>
 #include <ydb/core/tx/schemeshard/schemeshard.h>
+#include <ydb/core/tx/schemeshard/schemeshard_private.h>
 #include <ydb/core/tx/sequenceproxy/sequenceproxy.h>
 #include <ydb/core/tx/tx_proxy/proxy.h>
 #include <ydb/core/util/pb.h>
@@ -2137,7 +2138,7 @@ namespace NSchemeShardUT_Private {
         const TString& passwordHash,
         const bool needUpdateCache
     ) {
-        const auto evLoginFinalize = new NKikimr::NSchemeShard::TEvLoginFinalize(
+        const auto evLoginFinalize = new NSchemeShard::TEvPrivate::TEvLoginFinalize(
             request, checkResult, runtime.AllocateEdgeActor(), passwordHash, needUpdateCache
         );
         AsyncSend(runtime, TTestTxConfig::SchemeShard, evLoginFinalize);

--- a/ydb/core/tx/schemeshard/ut_helpers/helpers.cpp
+++ b/ydb/core/tx/schemeshard/ut_helpers/helpers.cpp
@@ -2137,11 +2137,12 @@ namespace NSchemeShardUT_Private {
         const TString& passwordHash,
         const bool needUpdateCache
     ) {
-        TActorId sender = runtime.AllocateEdgeActor();
-        auto evLoginFinalize = new NKikimr::NSchemeShard::TEvLoginFinalize(request, checkResult, sender, passwordHash, needUpdateCache);
-        ForwardToTablet(runtime, TTestTxConfig::SchemeShard, sender, evLoginFinalize);
+        const auto evLoginFinalize = new NKikimr::NSchemeShard::TEvLoginFinalize(
+            request, checkResult, runtime.AllocateEdgeActor(), passwordHash, needUpdateCache
+        );
+        AsyncSend(runtime, TTestTxConfig::SchemeShard, evLoginFinalize);
         TAutoPtr<IEventHandle> handle;
-        auto event = runtime.GrabEdgeEvent<TEvSchemeShard::TEvLoginResult>(handle);
+        const auto event = runtime.GrabEdgeEvent<TEvSchemeShard::TEvLoginResult>(handle);
         UNIT_ASSERT(event);
         return event->Record;
     }

--- a/ydb/core/tx/schemeshard/ut_helpers/helpers.h
+++ b/ydb/core/tx/schemeshard/ut_helpers/helpers.h
@@ -14,8 +14,8 @@
 #include <ydb/core/tx/schemeshard/schemeshard_build_index.h>
 #include <ydb/core/tx/schemeshard/schemeshard_export.h>
 #include <ydb/core/tx/schemeshard/schemeshard_import.h>
-#include <ydb/core/tx/schemeshard/schemeshard_login_helper.h>
 #include <ydb/core/tx/schemeshard/schemeshard_types.h>
+#include <ydb/library/login/login.h>
 
 #include <yql/essentials/minikql/mkql_alloc.h>
 #include <yql/essentials/minikql/mkql_node_serialization.h>

--- a/ydb/core/tx/schemeshard/ut_helpers/helpers.h
+++ b/ydb/core/tx/schemeshard/ut_helpers/helpers.h
@@ -14,6 +14,7 @@
 #include <ydb/core/tx/schemeshard/schemeshard_build_index.h>
 #include <ydb/core/tx/schemeshard/schemeshard_export.h>
 #include <ydb/core/tx/schemeshard/schemeshard_import.h>
+#include <ydb/core/tx/schemeshard/schemeshard_login_helper.h>
 #include <ydb/core/tx/schemeshard/schemeshard_types.h>
 
 #include <yql/essentials/minikql/mkql_alloc.h>
@@ -564,6 +565,14 @@ namespace NSchemeShardUT_Private {
 
     NKikimrScheme::TEvLoginResult Login(TTestActorRuntime& runtime,
         const TString& user, const TString& password);
+
+    NKikimrScheme::TEvLoginResult LoginFinalize(
+        TTestActorRuntime& runtime,
+        const NLogin::TLoginProvider::TLoginUserRequest& request,
+        const NLogin::TLoginProvider::TPasswordCheckResult& checkResult,
+        const TString& passwordHash,
+        const bool needUpdateCache
+    );
 
     void ModifyUser(TTestActorRuntime& runtime, ui64 txId, const TString& database, std::function<void(::NKikimrSchemeOp::TLoginModifyUser*)>&& initiator);
 

--- a/ydb/core/tx/schemeshard/ut_login/ut_login.cpp
+++ b/ydb/core/tx/schemeshard/ut_login/ut_login.cpp
@@ -1895,6 +1895,7 @@ Y_UNIT_TEST_SUITE(TSchemeShardLoginFinalize) {
         const auto resultLogin = LoginFinalize(runtime, request, check, "", false);
         // public keys are filled after the first login
         UNIT_ASSERT_VALUES_EQUAL(resultLogin.error(), "No key to generate token");
+        UNIT_ASSERT_VALUES_EQUAL(resultLogin.token(), "");
     }
 
     Y_UNIT_TEST(InvalidPassword) {
@@ -1911,6 +1912,7 @@ Y_UNIT_TEST_SUITE(TSchemeShardLoginFinalize) {
         UNIT_ASSERT_VALUES_EQUAL(Login(runtime, "user1", "password1").error(), "");
         const auto resultLogin = LoginFinalize(runtime, request, check, "", false);
         UNIT_ASSERT_VALUES_EQUAL(resultLogin.error(), "Invalid password");
+        UNIT_ASSERT_VALUES_EQUAL(resultLogin.token(), "");
     }
 
     Y_UNIT_TEST(Success) {
@@ -1927,5 +1929,7 @@ Y_UNIT_TEST_SUITE(TSchemeShardLoginFinalize) {
         UNIT_ASSERT_VALUES_EQUAL(Login(runtime, "user1", "wrong-password1").error(), "Invalid password");
         const auto resultLogin = LoginFinalize(runtime, request, check, "", false);
         UNIT_ASSERT_VALUES_EQUAL(resultLogin.error(), "");
+        auto describe = DescribePath(runtime, TTestTxConfig::SchemeShard, "/MyRoot");
+        CheckToken(resultLogin.token(), describe, "user1");
     }
 }

--- a/ydb/core/tx/schemeshard/ya.make
+++ b/ydb/core/tx/schemeshard/ya.make
@@ -86,6 +86,7 @@ SRCS(
     schemeshard__init_schema.cpp
     schemeshard__list_users.cpp
     schemeshard__login.cpp
+    schemeshard__login_finalize.cpp
     schemeshard__make_access_database_no_inheritable.cpp
     schemeshard__monitoring.cpp
     schemeshard__notify.cpp
@@ -250,6 +251,8 @@ SRCS(
     schemeshard_import_scheme_query_executor.cpp
     schemeshard_info_types.cpp
     schemeshard_info_types.h
+    schemeshard_login_helper.cpp
+    schemeshard_login_helper.h
     schemeshard_path.cpp
     schemeshard_path.h
     schemeshard_path_describer.cpp

--- a/ydb/library/login/login.cpp
+++ b/ydb/library/login/login.cpp
@@ -539,8 +539,7 @@ TLoginProvider::TLoginUserResponse TLoginProvider::LoginUser(const TLoginUserReq
         }
 
         if (checkResult.Status == TLoginUserResponse::EStatus::INVALID_PASSWORD) {
-            response.Status = checkResult.Status;
-            response.Error = checkResult.Error;
+            response.FillInvalidPassword();
             sid->LastFailedLogin = std::chrono::system_clock::now();
             sid->FailedLoginAttemptCount++;
             return response;
@@ -599,8 +598,7 @@ TLoginProvider::TLoginUserResponse TLoginProvider::LoginUser(const TLoginUserReq
         const auto isSuccessVerifying = VerifyHash(request, passwordHash);
         UpdateCache(request, passwordHash, isSuccessVerifying);
         if (!isSuccessVerifying) {
-            checkResult.Status = TLoginUserResponse::EStatus::INVALID_PASSWORD;
-            checkResult.Error = "Invalid password";
+            checkResult.FillInvalidPassword();
         }
     }
     return LoginUser(request, checkResult);
@@ -847,8 +845,7 @@ bool TLoginProvider::TImpl::NeedVerifyHash(const TLruCache::TKey& key, TPassword
     }
 
     if (WrongPasswordsCache.Find(key) != WrongPasswordsCache.End()) {
-        checkResult->Status = TLoginUserResponse::EStatus::INVALID_PASSWORD;
-        checkResult->Error = "Invalid password";
+        checkResult->FillInvalidPassword();
         return false;
     }
 

--- a/ydb/library/login/login.h
+++ b/ydb/library/login/login.h
@@ -85,6 +85,16 @@ public:
             Status = TLoginUserResponse::EStatus::INVALID_PASSWORD;
             Error = "Invalid password";
         }
+
+        void FillUnavailableKey() {
+            Status = TLoginUserResponse::EStatus::UNAVAILABLE_KEY;
+            Error = "No key to generate token";
+        }
+
+        void FillInvalidUser(const TString& error) {
+            Status = TLoginUserResponse::EStatus::INVALID_USER;
+            Error = error;
+        }
     };
 
     struct TLoginUserResponse : TPasswordCheckResult {
@@ -262,7 +272,7 @@ private:
     bool ShouldUnlockAccount(const TSidRecord& sid) const;
     bool CheckPasswordOrHash(bool IsHashedPassword, const TString& user, const TString& password, TString& error) const;
     TSidRecord* GetUserSid(const TString& user);
-    bool FillNoKeys(TPasswordCheckResult* checkResult) const;
+    bool FillUnavailableKey(TPasswordCheckResult* checkResult) const;
     bool FillInvalidUser(const TSidRecord* sid, TPasswordCheckResult* checkResult) const;
 
 private:

--- a/ydb/library/login/login.h
+++ b/ydb/library/login/login.h
@@ -69,6 +69,7 @@ public:
     };
 
     struct TPasswordCheckResult : TBasicResponse {
+    public:
         enum class EStatus {
             UNSPECIFIED,
             SUCCESS,
@@ -78,6 +79,12 @@ public:
         };
 
         EStatus Status = EStatus::UNSPECIFIED;
+
+    public:
+        void FillInvalidPassword() {
+            Status = TLoginUserResponse::EStatus::INVALID_PASSWORD;
+            Error = "Invalid password";
+        }
     };
 
     struct TLoginUserResponse : TPasswordCheckResult {

--- a/ydb/library/login/login_ut.cpp
+++ b/ydb/library/login/login_ut.cpp
@@ -828,4 +828,20 @@ Y_UNIT_TEST_SUITE(Login) {
             UNIT_ASSERT(!loginResponse.Error);
         }
     }
+
+    Y_UNIT_TEST(NotIgnoreCheckErrors) {
+        TLoginProvider provider(TPasswordComplexity(), TAccountLockout::TInitializer(), [] () {return true;}, {});
+        provider.RotateKeys();
+
+        TLoginProvider::TPasswordCheckResult checkResult;
+        checkResult.FillUnavailableKey();
+        auto response = provider.LoginUser(TLoginProvider::TLoginUserRequest{}, checkResult);
+        UNIT_ASSERT_EQUAL(response.Status, checkResult.Status);
+        UNIT_ASSERT_EQUAL(response.Error, checkResult.Error);
+
+        checkResult.FillInvalidUser("bad user");
+        response = provider.LoginUser(TLoginProvider::TLoginUserRequest{}, checkResult);
+        UNIT_ASSERT_EQUAL(response.Status, checkResult.Status);
+        UNIT_ASSERT_EQUAL(response.Error, checkResult.Error);
+    }
 }


### PR DESCRIPTION
### Changelog entry
Password verification is extracted to a separate actor from `TSchemeShard` local transaction.

### Changelog category

* Performance improvement

### Description for reviewers
Existing `TTxLogin` transaction does not make all login actions now, but checks if password cache may be used for login verification. If hash check is needed, TEvVerifyPassword event is emitted and is handled in a new `TLoginHelper` actor. A new transaction `TTxLoginFinalize` is used for sending response on a `TEvLoginFinalize` event.