### PR TITLE
Report self node pile for dynamic nodes too

### DIFF
--- a/ydb/core/blobstorage/nodewarden/distconf.cpp
+++ b/ydb/core/blobstorage/nodewarden/distconf.cpp
@@ -120,6 +120,16 @@ namespace NKikimr::NStorage {
                     }
                 }
 
+                if (Cfg->DynamicNodeConfig && Cfg->DynamicNodeConfig->HasNodeInfo()) {
+                    if (const auto& nodeInfo = Cfg->DynamicNodeConfig->GetNodeInfo(); nodeInfo.HasBridgePileId()) {
+                        const ui32 pileId = nodeInfo.GetBridgePileId();
+                        Y_ABORT_UNLESS(pileId < bridgeInfo->Piles.size());
+                        bridgeInfo->SelfNodePile = &bridgeInfo->Piles[pileId];
+                    }
+                }
+
+                Y_ABORT_UNLESS(bridgeInfo->SelfNodePile);
+
                 Y_ABORT_UNLESS(state.PerPileStateSize() == Cfg->BridgeConfig->PilesSize());
                 for (size_t i = 0; i < state.PerPileStateSize(); ++i) {
                     auto& pile = bridgeInfo->Piles[i];

--- a/ydb/core/blobstorage/nodewarden/distconf_mon.cpp
+++ b/ydb/core/blobstorage/nodewarden/distconf_mon.cpp
@@ -160,6 +160,13 @@ namespace NKikimr::NStorage {
                     }
                     DIV_CLASS("panel-body") {
                         out << "Self-management enabled: " << (SelfManagementEnabled ? "yes" : "no") << "<br/>";
+                        out << "Self pile id: ";
+                        if (BridgeInfo) {
+                            out << BridgeInfo->SelfNodePile->BridgePileId;
+                        } else {
+                            out << "<none>";
+                        }
+                        out << "<br/>";
                     }
                 }
 

--- a/ydb/core/blobstorage/nodewarden/node_warden.h
+++ b/ydb/core/blobstorage/nodewarden/node_warden.h
@@ -23,6 +23,7 @@ namespace NKikimr {
         std::optional<NKikimrConfig::TDomainsConfig> DomainsConfig;
         std::optional<NKikimrConfig::TSelfManagementConfig> SelfManagementConfig;
         std::optional<NKikimrConfig::TBridgeConfig> BridgeConfig;
+        std::optional<NKikimrConfig::TDynamicNodeConfig> DynamicNodeConfig;
         TString ConfigDirPath;
         std::optional<NKikimrBlobStorage::TYamlConfig> YamlConfig;
         TString StartupConfigYaml;

--- a/ydb/core/driver_lib/run/kikimr_services_initializers.cpp
+++ b/ydb/core/driver_lib/run/kikimr_services_initializers.cpp
@@ -960,6 +960,9 @@ void TBSNodeWardenInitializer::InitializeServices(NActors::TActorSystemSetup* se
     if (Config.HasBridgeConfig()) {
         nodeWardenConfig->BridgeConfig.emplace(Config.GetBridgeConfig());
     }
+    if (Config.HasDynamicNodeConfig()) {
+        nodeWardenConfig->DynamicNodeConfig.emplace(Config.GetDynamicNodeConfig());
+    }
 
     if (Config.HasConfigDirPath()) {
         nodeWardenConfig->ConfigDirPath = Config.GetConfigDirPath();


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

Report self node pile for dynamic nodes too

### Changelog category <!-- remove all except one -->

* Not for changelog (changelog entry is not required)

### Description for reviewers <!-- (optional) description for those who read this PR -->

This patch allows reporting BridgePileId through SelfNodePile when checked on dynamic node too.
