### PR TITLE
Fix duplicate rows in prefixed vector index when shard indexes are out of order, add a reboot test

### DIFF
--- a/ydb/core/tx/schemeshard/schemeshard_build_index__progress.cpp
+++ b/ydb/core/tx/schemeshard/schemeshard_build_index__progress.cpp
@@ -867,6 +867,10 @@ private:
         if (NoShardsAdded(buildInfo)) {
             AddAllShards(buildInfo);
         }
+        size_t i = 0;
+        for (auto& [shardIdx, shardStatus]: buildInfo.Shards) {
+            shardStatus.Index = i++;
+        }
         return SendToShards(buildInfo, [&](TShardIdx shardIdx) { SendPrefixKMeansRequest(shardIdx, buildInfo); }) &&
                buildInfo.DoneShards.size() == buildInfo.Shards.size();
     }
@@ -1428,7 +1432,7 @@ public:
                 LOG_D("shard " << x.ShardIdx << " range " << buildInfo.KMeans.RangeToDebugStr(shardRange));
                 buildInfo.AddParent(shardRange, x.ShardIdx);
             }
-            auto [it, emplaced] = buildInfo.Shards.emplace(x.ShardIdx, TIndexBuildInfo::TShardStatus{std::move(shardRange), "", buildInfo.Shards.size()});
+            auto [it, emplaced] = buildInfo.Shards.emplace(x.ShardIdx, TIndexBuildInfo::TShardStatus{std::move(shardRange), ""});
             Y_ENSURE(emplaced);
             shardRange.From = std::move(bound);
 

--- a/ydb/core/tx/schemeshard/schemeshard_build_index__progress.cpp
+++ b/ydb/core/tx/schemeshard/schemeshard_build_index__progress.cpp
@@ -348,9 +348,9 @@ THolder<TEvSchemeShard::TEvModifySchemeTransaction> CreateBuildPropose(
         op.SetName(TString::Join(PostingTable, suffix));
         NTableIndex::FillIndexTableColumns(tableInfo->Columns, implTableColumns.Keys, implTableColumns.Columns, op);
         auto& policy = *resetPartitionsSettings();
-        const auto shards = tableInfo->GetShard2PartitionIdx().size();
-        policy.SetMinPartitionsCount(shards);
-        policy.SetMaxPartitionsCount(shards);
+        // Prevent merging partitions
+        policy.SetMinPartitionsCount(32768);
+        policy.SetMaxPartitionsCount(0);
 
         LOG_DEBUG_S((TlsActivationContext->AsActorContext()), NKikimrServices::BUILD_INDEX, 
             "CreateBuildPropose " << buildInfo.Id << " " << buildInfo.State << " " << propose->Record.ShortDebugString());

--- a/ydb/core/tx/schemeshard/schemeshard_info_types.cpp
+++ b/ydb/core/tx/schemeshard/schemeshard_info_types.cpp
@@ -2203,10 +2203,9 @@ void TImportInfo::AddNotifySubscriber(const TActorId &actorId) {
     Subscribers.insert(actorId);
 }
 
-TIndexBuildInfo::TShardStatus::TShardStatus(TSerializedTableRange range, TString lastKeyAck, size_t shardsCount)
+TIndexBuildInfo::TShardStatus::TShardStatus(TSerializedTableRange range, TString lastKeyAck)
     : Range(std::move(range))
     , LastKeyAck(std::move(lastKeyAck))
-    , Index(shardsCount)
 {}
 
 void TIndexBuildInfo::SerializeToProto(TSchemeShard* ss, NKikimrSchemeOp::TIndexBuildConfig* result) const {

--- a/ydb/core/tx/schemeshard/schemeshard_info_types.h
+++ b/ydb/core/tx/schemeshard/schemeshard_info_types.h
@@ -3345,7 +3345,7 @@ public:
         TSerializedTableRange Range;
         TString LastKeyAck;
         ui64 SeqNoRound = 0;
-        size_t Index = 0;  // size of Shards map before this element was added
+        size_t Index = 0; // used only in prefixed vector index: a unique number of shard in the list
 
         NKikimrIndexBuilder::EBuildStatus Status = NKikimrIndexBuilder::EBuildStatus::INVALID;
 
@@ -3354,7 +3354,7 @@ public:
 
         TBillingStats Processed;
 
-        TShardStatus(TSerializedTableRange range, TString lastKeyAck, size_t shardsCount);
+        TShardStatus(TSerializedTableRange range, TString lastKeyAck);
 
         TString ToString(TShardIdx shardIdx = InvalidShardIdx) const {
             TStringBuilder result;
@@ -3698,7 +3698,7 @@ public:
             AddParent(bound, shardIdx);
         }
         Shards.emplace(
-            shardIdx, TIndexBuildInfo::TShardStatus(std::move(bound), std::move(lastKeyAck), Shards.size()));
+            shardIdx, TIndexBuildInfo::TShardStatus(std::move(bound), std::move(lastKeyAck)));
         TIndexBuildInfo::TShardStatus &shardStatus = Shards.at(shardIdx);
 
         shardStatus.Status =

--- a/ydb/core/tx/schemeshard/ut_helpers/helpers.cpp
+++ b/ydb/core/tx/schemeshard/ut_helpers/helpers.cpp
@@ -2708,7 +2708,7 @@ namespace NSchemeShardUT_Private {
     }
 
     void WriteVectorTableRows(TTestActorRuntime& runtime, ui64 schemeShardId, ui64 txId, const TString & tablePath,
-        bool withPrefix, bool withValue, ui32 shard, ui32 min, ui32 max, std::vector<ui32> columnIds) {
+        ui32 shard, ui32 min, ui32 max, std::vector<ui32> columnIds) {
         TVector<TCell> cells;
         ui8 str[6] = { 0 };
         str[4] = (ui8)Ydb::Table::VectorIndexSettings::VECTOR_TYPE_UINT8;
@@ -2719,24 +2719,13 @@ namespace NSchemeShardUT_Private {
             str[3] = ((key+106)*47) % 256;
             cells.emplace_back(TCell::Make(key));
             cells.emplace_back(TCell((const char*)str, 5));
-            if (withPrefix) {
-                // optional prefix ui32 column
-                cells.emplace_back(TCell::Make(key % 17));
-            }
-            if (withValue) {
-                // optionally use the same value for an additional covered string column
-                cells.emplace_back(TCell((const char*)str, 5));
-            }
+            // optional prefix ui32 column
+            cells.emplace_back(TCell::Make(key % 17));
+            // optionally use the same value for an additional covered string column
+            cells.emplace_back(TCell((const char*)str, 5));
         }
         if (!columnIds.size()) {
-            columnIds.push_back(1);
-            columnIds.push_back(2);
-            if (withValue) {
-                columnIds.push_back(columnIds.size()+1);
-            }
-            if (withPrefix) {
-                columnIds.push_back(columnIds.size()+1);
-            }
+            columnIds = {1, 2, 3, 4};
         }
         TSerializedCellMatrix matrix(cells, max-min, columnIds.size());
         WriteOp(runtime, schemeShardId, txId, tablePath,

--- a/ydb/core/tx/schemeshard/ut_helpers/helpers.cpp
+++ b/ydb/core/tx/schemeshard/ut_helpers/helpers.cpp
@@ -1837,10 +1837,10 @@ namespace NSchemeShardUT_Private {
     }
 
     void AsyncBuildVectorIndex(TTestActorRuntime& runtime, ui64 id, ui64 schemeShard, const TString &dbName,
-                              const TString &src, const TString &name, TString column, TVector<TString> dataColumns)
+                              const TString &src, const TString &name, TVector<TString> columns, TVector<TString> dataColumns)
     {
         AsyncBuildIndex(runtime, id, schemeShard, dbName, src, TBuildIndexConfig{
-            name, NKikimrSchemeOp::EIndexTypeGlobalVectorKmeansTree, {column}, std::move(dataColumns)
+            name, NKikimrSchemeOp::EIndexTypeGlobalVectorKmeansTree, columns, std::move(dataColumns)
         });
     }
 
@@ -2707,7 +2707,7 @@ namespace NSchemeShardUT_Private {
         return CountRows(runtime, TTestTxConfig::SchemeShard, table);
     }
 
-    void WriteVectorTableRows(TTestActorRuntime& runtime, ui64 schemeShardId, ui64 txId, const TString & tablePath, bool withValue, ui32 shard, ui32 min, ui32 max) {
+    void WriteVectorTableRows(TTestActorRuntime& runtime, ui64 schemeShardId, ui64 txId, const TString & tablePath, bool withPrefix, bool withValue, ui32 shard, ui32 min, ui32 max) {
         TVector<TCell> cells;
         ui8 str[6] = { 0 };
         str[4] = (ui8)Ydb::Table::VectorIndexSettings::VECTOR_TYPE_UINT8;
@@ -2718,6 +2718,10 @@ namespace NSchemeShardUT_Private {
             str[3] = ((key+106)*47) % 256;
             cells.emplace_back(TCell::Make(key));
             cells.emplace_back(TCell((const char*)str, 5));
+            if (withPrefix) {
+                // optional prefix ui32 column
+                cells.emplace_back(TCell::Make(key % 17));
+            }
             if (withValue) {
                 // optionally use the same value for an additional covered string column
                 cells.emplace_back(TCell((const char*)str, 5));
@@ -2725,9 +2729,12 @@ namespace NSchemeShardUT_Private {
         }
         std::vector<ui32> columnIds{1, 2};
         if (withValue) {
-            columnIds.push_back(3);
+            columnIds.push_back(columnIds.size()+1);
         }
-        TSerializedCellMatrix matrix(cells, max-min, withValue ? 3 : 2);
+        if (withPrefix) {
+            columnIds.push_back(columnIds.size()+1);
+        }
+        TSerializedCellMatrix matrix(cells, max-min, columnIds.size());
         WriteOp(runtime, schemeShardId, txId, tablePath,
             shard, NKikimrDataEvents::TEvWrite::TOperation::OPERATION_UPSERT,
             columnIds, std::move(matrix), true);

--- a/ydb/core/tx/schemeshard/ut_helpers/helpers.cpp
+++ b/ydb/core/tx/schemeshard/ut_helpers/helpers.cpp
@@ -2707,7 +2707,8 @@ namespace NSchemeShardUT_Private {
         return CountRows(runtime, TTestTxConfig::SchemeShard, table);
     }
 
-    void WriteVectorTableRows(TTestActorRuntime& runtime, ui64 schemeShardId, ui64 txId, const TString & tablePath, bool withPrefix, bool withValue, ui32 shard, ui32 min, ui32 max) {
+    void WriteVectorTableRows(TTestActorRuntime& runtime, ui64 schemeShardId, ui64 txId, const TString & tablePath,
+        bool withPrefix, bool withValue, ui32 shard, ui32 min, ui32 max, std::vector<ui32> columnIds) {
         TVector<TCell> cells;
         ui8 str[6] = { 0 };
         str[4] = (ui8)Ydb::Table::VectorIndexSettings::VECTOR_TYPE_UINT8;
@@ -2727,12 +2728,15 @@ namespace NSchemeShardUT_Private {
                 cells.emplace_back(TCell((const char*)str, 5));
             }
         }
-        std::vector<ui32> columnIds{1, 2};
-        if (withValue) {
-            columnIds.push_back(columnIds.size()+1);
-        }
-        if (withPrefix) {
-            columnIds.push_back(columnIds.size()+1);
+        if (!columnIds.size()) {
+            columnIds.push_back(1);
+            columnIds.push_back(2);
+            if (withValue) {
+                columnIds.push_back(columnIds.size()+1);
+            }
+            if (withPrefix) {
+                columnIds.push_back(columnIds.size()+1);
+            }
         }
         TSerializedCellMatrix matrix(cells, max-min, columnIds.size());
         WriteOp(runtime, schemeShardId, txId, tablePath,

--- a/ydb/core/tx/schemeshard/ut_helpers/helpers.h
+++ b/ydb/core/tx/schemeshard/ut_helpers/helpers.h
@@ -662,7 +662,7 @@ namespace NSchemeShardUT_Private {
     ui32 CountRows(TTestActorRuntime& runtime, const TString& table);
 
     void WriteVectorTableRows(TTestActorRuntime& runtime, ui64 schemeShardId, ui64 txId, const TString & tablePath,
-        bool withPrefix, bool withValue, ui32 shard, ui32 min, ui32 max, std::vector<ui32> columnIds = {});
+        ui32 shard, ui32 min, ui32 max, std::vector<ui32> columnIds = {});
 
     void TestCreateServerLessDb(TTestActorRuntime& runtime, TTestEnv& env, ui64& txId, ui64& tenantSchemeShard);
 

--- a/ydb/core/tx/schemeshard/ut_helpers/helpers.h
+++ b/ydb/core/tx/schemeshard/ut_helpers/helpers.h
@@ -397,7 +397,7 @@ namespace NSchemeShardUT_Private {
     void AsyncBuildColumn(TTestActorRuntime& runtime, ui64 id, ui64 schemeShard, const TString &dbName, const TString &src, const TString& columnName, const Ydb::TypedValue& literal);
     void AsyncBuildIndex(TTestActorRuntime& runtime, ui64 id, ui64 schemeShard, const TString &dbName, const TString &src, const TBuildIndexConfig &cfg);
     void AsyncBuildIndex(TTestActorRuntime& runtime, ui64 id, ui64 schemeShard, const TString &dbName, const TString &src, const TString &name, TVector<TString> columns, TVector<TString> dataColumns = {});
-    void AsyncBuildVectorIndex(TTestActorRuntime& runtime, ui64 id, ui64 schemeShard, const TString &dbName, const TString &src, const TString &name, TString column, TVector<TString> dataColumns = {});
+    void AsyncBuildVectorIndex(TTestActorRuntime& runtime, ui64 id, ui64 schemeShard, const TString &dbName, const TString &src, const TString &name, TVector<TString> columns, TVector<TString> dataColumns = {});
     void TestBuildColumn(TTestActorRuntime& runtime, ui64 id, ui64 schemeShard, const TString &dbName,
         const TString &src, const TString& columnName, const Ydb::TypedValue& literal, Ydb::StatusIds::StatusCode expectedStatus);
     void TestBuildIndex(TTestActorRuntime& runtime, ui64 id, ui64 schemeShard, const TString &dbName, const TString &src, const TBuildIndexConfig &cfg, Ydb::StatusIds::StatusCode expectedStatus = Ydb::StatusIds::SUCCESS);
@@ -662,8 +662,8 @@ namespace NSchemeShardUT_Private {
     ui32 CountRows(TTestActorRuntime& runtime, const TString& table);
 
     void WriteVectorTableRows(TTestActorRuntime& runtime, ui64 schemeShardId, ui64 txId, const TString & tablePath,
-        bool withValue, ui32 shard, ui32 min, ui32 max);
-    
+        bool withPrefix, bool withValue, ui32 shard, ui32 min, ui32 max);
+
     void TestCreateServerLessDb(TTestActorRuntime& runtime, TTestEnv& env, ui64& txId, ui64& tenantSchemeShard);
 
 } //NSchemeShardUT_Private

--- a/ydb/core/tx/schemeshard/ut_helpers/helpers.h
+++ b/ydb/core/tx/schemeshard/ut_helpers/helpers.h
@@ -662,7 +662,7 @@ namespace NSchemeShardUT_Private {
     ui32 CountRows(TTestActorRuntime& runtime, const TString& table);
 
     void WriteVectorTableRows(TTestActorRuntime& runtime, ui64 schemeShardId, ui64 txId, const TString & tablePath,
-        bool withPrefix, bool withValue, ui32 shard, ui32 min, ui32 max);
+        bool withPrefix, bool withValue, ui32 shard, ui32 min, ui32 max, std::vector<ui32> columnIds = {});
 
     void TestCreateServerLessDb(TTestActorRuntime& runtime, TTestEnv& env, ui64& txId, ui64& tenantSchemeShard);
 

--- a/ydb/core/tx/schemeshard/ut_helpers/test_env.cpp
+++ b/ydb/core/tx/schemeshard/ut_helpers/test_env.cpp
@@ -1054,6 +1054,22 @@ NSchemeShardUT_Private::TTestWithReboots::TTestWithReboots(bool killOnCommit, NS
     TabletIds.push_back(datashard+6);
     TabletIds.push_back(datashard+7);
     TabletIds.push_back(datashard+8);
+
+    NoRebootEventTypes.insert(TEvSchemeShard::EvModifySchemeTransaction);
+    NoRebootEventTypes.insert(TEvSchemeShard::EvDescribeScheme);
+    NoRebootEventTypes.insert(TEvSchemeShard::EvNotifyTxCompletion);
+    NoRebootEventTypes.insert(TEvSchemeShard::EvMeasureSelfResponseTime);
+    NoRebootEventTypes.insert(TEvSchemeShard::EvWakeupToMeasureSelfResponseTime);
+    NoRebootEventTypes.insert(TEvTablet::EvLocalMKQL);
+    NoRebootEventTypes.insert(TEvFakeHive::EvSubscribeToTabletDeletion);
+    NoRebootEventTypes.insert(TEvSchemeShard::EvCancelTx);
+    NoRebootEventTypes.insert(TEvExport::EvCreateExportRequest);
+    NoRebootEventTypes.insert(TEvIndexBuilder::EvCreateRequest);
+    NoRebootEventTypes.insert(TEvIndexBuilder::EvGetRequest);
+    NoRebootEventTypes.insert(TEvIndexBuilder::EvCancelRequest);
+    NoRebootEventTypes.insert(TEvIndexBuilder::EvForgetRequest);
+    // without it, ut_vector_index_build_reboots test hangs on GetRequest on the very first reboot
+    NoRebootEventTypes.insert(TEvTablet::EvCommitResult);
 }
 
 void NSchemeShardUT_Private::TTestWithReboots::Run(std::function<void (TTestActorRuntime &, bool &)> testScenario) {
@@ -1088,9 +1104,10 @@ struct NSchemeShardUT_Private::TTestWithReboots::TFinalizer {
 };
 
 void NSchemeShardUT_Private::TTestWithReboots::RunWithTabletReboots(std::function<void (TTestActorRuntime &, bool &)> testScenario) {
-    RunTestWithReboots(TabletIds,
-                       [&]() {
-        return PassUserRequests;
+    RunTestWithReboots(TabletIds, [&]() {
+        return [this](TTestActorRuntimeBase& runtime, TAutoPtr<IEventHandle>& event) {
+            return PassUserRequests(runtime, event);
+        };
     },
     [&](const TString& dispatchName, std::function<void(TTestActorRuntime&)> setup, bool& activeZone) {
         TFinalizer finalizer(*this);
@@ -1104,7 +1121,9 @@ void NSchemeShardUT_Private::TTestWithReboots::RunWithTabletReboots(std::functio
 void NSchemeShardUT_Private::TTestWithReboots::RunWithPipeResets(std::function<void (TTestActorRuntime &, bool &)> testScenario) {
     RunTestWithPipeResets(TabletIds,
                           [&]() {
-        return PassUserRequests;
+        return [this](TTestActorRuntimeBase& runtime, TAutoPtr<IEventHandle>& event) {
+            return PassUserRequests(runtime, event);
+        };
     },
     [&](const TString& dispatchName, std::function<void(TTestActorRuntime&)> setup, bool& activeZone) {
         TFinalizer finalizer(*this);
@@ -1173,22 +1192,7 @@ void NSchemeShardUT_Private::TTestWithReboots::Finalize() {
 
 bool NSchemeShardUT_Private::TTestWithReboots::PassUserRequests(TTestActorRuntimeBase &runtime, TAutoPtr<IEventHandle> &event) {
     Y_UNUSED(runtime);
-    return event->Type == TEvSchemeShard::EvModifySchemeTransaction ||
-           event->Type == TEvSchemeShard::EvDescribeScheme ||
-           event->Type == TEvSchemeShard::EvNotifyTxCompletion ||
-           event->Type == TEvSchemeShard::EvMeasureSelfResponseTime ||
-           event->Type == TEvSchemeShard::EvWakeupToMeasureSelfResponseTime ||
-           event->Type == TEvTablet::EvLocalMKQL ||
-           event->Type == TEvFakeHive::EvSubscribeToTabletDeletion ||
-           event->Type == TEvSchemeShard::EvCancelTx ||
-           event->Type == TEvExport::EvCreateExportRequest ||
-           event->Type == TEvIndexBuilder::EvCreateRequest ||
-           event->Type == TEvIndexBuilder::EvGetRequest ||
-           event->Type == TEvIndexBuilder::EvCancelRequest ||
-           event->Type == TEvIndexBuilder::EvForgetRequest ||
-           // without it, ut_vector_index_build_reboots test hangs on GetRequest on the very first reboot
-           event->Type == TEvTablet::EvCommitResult
-        ;
+    return NoRebootEventTypes.contains(event->Type);
 }
 
 NSchemeShardUT_Private::TTestEnvOptions& NSchemeShardUT_Private::TTestWithReboots::GetTestEnvOptions() {

--- a/ydb/core/tx/schemeshard/ut_helpers/test_env.h
+++ b/ydb/core/tx/schemeshard/ut_helpers/test_env.h
@@ -171,6 +171,7 @@ namespace NSchemeShardUT_Private {
 
     public:
         TVector<ui64> TabletIds;
+        TSet<ui32> NoRebootEventTypes;
         THolder<TTestActorRuntime> Runtime;
         TTestEnvOptions EnvOpts;
         THolder<TTestEnv> TestEnv;
@@ -204,7 +205,7 @@ namespace NSchemeShardUT_Private {
     private:
         virtual TTestEnv* CreateTestEnv();
         // Make sure that user requests are not dropped
-        static bool PassUserRequests(TTestActorRuntimeBase& runtime, TAutoPtr<IEventHandle>& event);
+        bool PassUserRequests(TTestActorRuntimeBase& runtime, TAutoPtr<IEventHandle>& event);
 
     private:
         struct TFinalizer;

--- a/ydb/core/tx/schemeshard/ut_helpers/test_with_reboots.h
+++ b/ydb/core/tx/schemeshard/ut_helpers/test_with_reboots.h
@@ -38,4 +38,19 @@ public:
     template <typename T>                                   \
     void N(NUnitTest::TTestContext&)
 
+#define Y_UNIT_TEST_WITH_REBOOTS_FLAG(N, OPT)               \
+    template <typename T, bool OPT>                         \
+    void N(NUnitTest::TTestContext&);                       \
+    struct TTestRegistration##N {                           \
+        TTestRegistration##N() {                            \
+            TCurrentTest::AddTest(#N "-" #OPT "[TabletReboots]", static_cast<void (*)(NUnitTest::TTestContext&)>(&N<TTestWithTabletReboots, false>), false); \
+            TCurrentTest::AddTest(#N "-" #OPT "[PipeResets]", static_cast<void (*)(NUnitTest::TTestContext&)>(&N<TTestWithPipeResets, false>), false); \
+            TCurrentTest::AddTest(#N "+" #OPT "[TabletReboots]", static_cast<void (*)(NUnitTest::TTestContext&)>(&N<TTestWithTabletReboots, true>), false); \
+            TCurrentTest::AddTest(#N "+" #OPT "[PipeResets]", static_cast<void (*)(NUnitTest::TTestContext&)>(&N<TTestWithPipeResets, true>), false); \
+        }                                                   \
+    };                                                      \
+    static TTestRegistration##N testRegistration##N;        \
+    template <typename T, bool OPT>                         \
+    void N(NUnitTest::TTestContext&)
+
 }

--- a/ydb/core/tx/schemeshard/ut_index_build/ut_vector_index_build.cpp
+++ b/ydb/core/tx/schemeshard/ut_index_build/ut_vector_index_build.cpp
@@ -39,9 +39,9 @@ Y_UNIT_TEST_SUITE (VectorIndexBuildTest) {
         env.TestWaitNotification(runtime, txId, tenantSchemeShard);
 
         // Write data directly into shards
-        WriteVectorTableRows(runtime, tenantSchemeShard, ++txId, "/MyRoot/ServerLessDB/Table", false, 0, 0, 50);
-        WriteVectorTableRows(runtime, tenantSchemeShard, ++txId, "/MyRoot/ServerLessDB/Table", false, 1, 50, 150);
-        WriteVectorTableRows(runtime, tenantSchemeShard, ++txId, "/MyRoot/ServerLessDB/Table", false, 2, 150, 200);
+        WriteVectorTableRows(runtime, tenantSchemeShard, ++txId, "/MyRoot/ServerLessDB/Table", false, false, 0, 0, 50);
+        WriteVectorTableRows(runtime, tenantSchemeShard, ++txId, "/MyRoot/ServerLessDB/Table", false, false, 1, 50, 150);
+        WriteVectorTableRows(runtime, tenantSchemeShard, ++txId, "/MyRoot/ServerLessDB/Table", false, false, 2, 150, 200);
 
         TestDescribeResult(DescribePath(runtime, tenantSchemeShard, "/MyRoot/ServerLessDB/Table"),
                            {NLs::PathExist,
@@ -208,7 +208,7 @@ Y_UNIT_TEST_SUITE (VectorIndexBuildTest) {
         )");
         env.TestWaitNotification(runtime, txId, tenantSchemeShard);
 
-        WriteVectorTableRows(runtime, tenantSchemeShard, ++txId, "/MyRoot/CommonDB/Table", false, 0, 100, 300);
+        WriteVectorTableRows(runtime, tenantSchemeShard, ++txId, "/MyRoot/CommonDB/Table", false, false, 0, 100, 300);
 
         TestDescribeResult(DescribePath(runtime, tenantSchemeShard, "/MyRoot/CommonDB/Table"), {
             NLs::PathExist,
@@ -623,7 +623,7 @@ Y_UNIT_TEST_SUITE (VectorIndexBuildTest) {
         });
 
         const ui64 buildIndexTx = ++txId;
-        AsyncBuildVectorIndex(runtime, buildIndexTx, TTestTxConfig::SchemeShard, "/MyRoot", "/MyRoot/vectors", "index1", "embedding");
+        AsyncBuildVectorIndex(runtime, buildIndexTx, TTestTxConfig::SchemeShard, "/MyRoot", "/MyRoot/vectors", "index1", {"embedding"});
 
         runtime.WaitFor("block", [&]{ return blocked.size(); });
         blocked.Stop().Unblock();
@@ -687,7 +687,7 @@ Y_UNIT_TEST_SUITE (VectorIndexBuildTest) {
         }
 
         const ui64 buildIndexTx = ++txId;
-        AsyncBuildVectorIndex(runtime, buildIndexTx, TTestTxConfig::SchemeShard, "/MyRoot", "/MyRoot/vectors", "index1", "embedding");
+        AsyncBuildVectorIndex(runtime, buildIndexTx, TTestTxConfig::SchemeShard, "/MyRoot", "/MyRoot/vectors", "index1", {"embedding"});
 
         env.TestWaitNotification(runtime, buildIndexTx);
 
@@ -848,7 +848,7 @@ Y_UNIT_TEST_SUITE (VectorIndexBuildTest) {
         });
 
         const ui64 buildIndexTx = ++txId;
-        AsyncBuildVectorIndex(runtime, buildIndexTx, TTestTxConfig::SchemeShard, "/MyRoot", "/MyRoot/vectors", "index1", "embedding");
+        AsyncBuildVectorIndex(runtime, buildIndexTx, TTestTxConfig::SchemeShard, "/MyRoot", "/MyRoot/vectors", "index1", {"embedding"});
 
         runtime.WaitFor("block", [&]{ return blocked.size(); });
         blocked.Stop().Unblock();

--- a/ydb/core/tx/schemeshard/ut_index_build/ut_vector_index_build.cpp
+++ b/ydb/core/tx/schemeshard/ut_index_build/ut_vector_index_build.cpp
@@ -30,12 +30,14 @@ Y_UNIT_TEST_SUITE (VectorIndexBuildTest) {
             Name: "Table"
             Columns { Name: "key"       Type: "Uint32" }
             Columns { Name: "embedding" Type: "String" }
+            Columns { Name: "prefix"    Type: "Uint32" }
+            Columns { Name: "value"     Type: "String" }
             KeyColumnNames: ["key"]
         )");
         env.TestWaitNotification(runtime, txId, tenantSchemeShard);
 
         // Write data directly into shards
-        WriteVectorTableRows(runtime, tenantSchemeShard, ++txId, "/MyRoot/ServerLessDB/Table", false, false, 0, 0, 200);
+        WriteVectorTableRows(runtime, tenantSchemeShard, ++txId, "/MyRoot/ServerLessDB/Table", 0, 0, 200);
 
         TestDescribeResult(DescribePath(runtime, tenantSchemeShard, "/MyRoot/ServerLessDB/Table"),
             {NLs::PathExist, NLs::IndexesCount(0), NLs::PathVersionEqual(3)});
@@ -88,6 +90,8 @@ Y_UNIT_TEST_SUITE (VectorIndexBuildTest) {
             Name: "Table"
             Columns { Name: "key"       Type: "Uint32" }
             Columns { Name: "embedding" Type: "String" }
+            Columns { Name: "prefix"    Type: "Uint32" }
+            Columns { Name: "value"     Type: "String" }
             KeyColumnNames: ["key"]
         )");
         env.TestWaitNotification(runtime, txId, tenantSchemeShard);
@@ -105,7 +109,7 @@ Y_UNIT_TEST_SUITE (VectorIndexBuildTest) {
         )");
         env.TestWaitNotification(runtime, txId, tenantSchemeShard);
 
-        WriteVectorTableRows(runtime, tenantSchemeShard, ++txId, "/MyRoot/ServerLessDB/Table", false, false, 0, 0, 200, {1, 3});
+        WriteVectorTableRows(runtime, tenantSchemeShard, ++txId, "/MyRoot/ServerLessDB/Table", 0, 0, 200, {1, 5, 3, 4});
 
         TestBuildVectorIndex(runtime, ++txId, tenantSchemeShard, "/MyRoot/ServerLessDB", "/MyRoot/ServerLessDB/Table", "index2", "embedding");
         env.TestWaitNotification(runtime, txId, tenantSchemeShard);
@@ -129,6 +133,8 @@ Y_UNIT_TEST_SUITE (VectorIndexBuildTest) {
             Name: "Table"
             Columns { Name: "key"       Type: "Uint32" }
             Columns { Name: "embedding" Type: "String" }
+            Columns { Name: "prefix"    Type: "Uint32" }
+            Columns { Name: "value"     Type: "String" }
             KeyColumnNames: ["key"]
             SplitBoundary { KeyPrefix { Tuple { Optional { Uint32: 50 } } } }
             SplitBoundary { KeyPrefix { Tuple { Optional { Uint32: 150 } } } }
@@ -136,9 +142,9 @@ Y_UNIT_TEST_SUITE (VectorIndexBuildTest) {
         env.TestWaitNotification(runtime, txId, tenantSchemeShard);
 
         // Write data directly into shards
-        WriteVectorTableRows(runtime, tenantSchemeShard, ++txId, "/MyRoot/ServerLessDB/Table", false, false, 0, 0, 50);
-        WriteVectorTableRows(runtime, tenantSchemeShard, ++txId, "/MyRoot/ServerLessDB/Table", false, false, 1, 50, 150);
-        WriteVectorTableRows(runtime, tenantSchemeShard, ++txId, "/MyRoot/ServerLessDB/Table", false, false, 2, 150, 200);
+        WriteVectorTableRows(runtime, tenantSchemeShard, ++txId, "/MyRoot/ServerLessDB/Table", 0, 0, 50);
+        WriteVectorTableRows(runtime, tenantSchemeShard, ++txId, "/MyRoot/ServerLessDB/Table", 1, 50, 150);
+        WriteVectorTableRows(runtime, tenantSchemeShard, ++txId, "/MyRoot/ServerLessDB/Table", 2, 150, 200);
 
         TestDescribeResult(DescribePath(runtime, tenantSchemeShard, "/MyRoot/ServerLessDB/Table"),
             {NLs::PathExist, NLs::IndexesCount(0), NLs::PathVersionEqual(3)});
@@ -220,6 +226,7 @@ Y_UNIT_TEST_SUITE (VectorIndexBuildTest) {
             Columns { Name: "key"       Type: "Uint32" }
             Columns { Name: "embedding" Type: "String" }
             Columns { Name: "prefix"    Type: "Uint32" }
+            Columns { Name: "value"     Type: "String" }
             KeyColumnNames: ["key"]
             SplitBoundary { KeyPrefix { Tuple { Optional { Uint32: 50 } } } }
             SplitBoundary { KeyPrefix { Tuple { Optional { Uint32: 150 } } } }
@@ -227,9 +234,9 @@ Y_UNIT_TEST_SUITE (VectorIndexBuildTest) {
         env.TestWaitNotification(runtime, txId, tenantSchemeShard);
 
         // Write data directly into shards
-        WriteVectorTableRows(runtime, tenantSchemeShard, ++txId, "/MyRoot/ServerLessDB/Table", true, false, 0, 0, 50);
-        WriteVectorTableRows(runtime, tenantSchemeShard, ++txId, "/MyRoot/ServerLessDB/Table", true, false, 1, 50, 150);
-        WriteVectorTableRows(runtime, tenantSchemeShard, ++txId, "/MyRoot/ServerLessDB/Table", true, false, 2, 150, 200);
+        WriteVectorTableRows(runtime, tenantSchemeShard, ++txId, "/MyRoot/ServerLessDB/Table", 0, 0, 50);
+        WriteVectorTableRows(runtime, tenantSchemeShard, ++txId, "/MyRoot/ServerLessDB/Table", 1, 50, 150);
+        WriteVectorTableRows(runtime, tenantSchemeShard, ++txId, "/MyRoot/ServerLessDB/Table", 2, 150, 200);
 
         runtime.SetLogPriority(NKikimrServices::TX_DATASHARD, NLog::PRI_TRACE);
         runtime.SetLogPriority(NKikimrServices::BUILD_INDEX, NLog::PRI_TRACE);
@@ -345,11 +352,13 @@ Y_UNIT_TEST_SUITE (VectorIndexBuildTest) {
             Name: "Table"
             Columns { Name: "key"       Type: "Uint32" }
             Columns { Name: "embedding" Type: "String" }
+            Columns { Name: "prefix"    Type: "Uint32" }
+            Columns { Name: "value"     Type: "String" }
             KeyColumnNames: ["key"]
         )");
         env.TestWaitNotification(runtime, txId, tenantSchemeShard);
 
-        WriteVectorTableRows(runtime, tenantSchemeShard, ++txId, "/MyRoot/CommonDB/Table", false, false, 0, 100, 300);
+        WriteVectorTableRows(runtime, tenantSchemeShard, ++txId, "/MyRoot/CommonDB/Table", 0, 100, 300);
 
         TestDescribeResult(DescribePath(runtime, tenantSchemeShard, "/MyRoot/CommonDB/Table"), {
             NLs::PathExist,
@@ -432,6 +441,8 @@ Y_UNIT_TEST_SUITE (VectorIndexBuildTest) {
             Name: "Table"
             Columns { Name: "key"       Type: "Uint32" }
             Columns { Name: "embedding" Type: "String" }
+            Columns { Name: "prefix"    Type: "Uint32" }
+            Columns { Name: "value"     Type: "String" }
             KeyColumnNames: ["key"]
             SplitBoundary { KeyPrefix { Tuple { Optional { Uint32: 50 } } } }
             SplitBoundary { KeyPrefix { Tuple { Optional { Uint32: 150 } } } }
@@ -439,9 +450,9 @@ Y_UNIT_TEST_SUITE (VectorIndexBuildTest) {
         env.TestWaitNotification(runtime, txId, tenantSchemeShard);
 
         // Write data directly into shards
-        WriteVectorTableRows(runtime, tenantSchemeShard, ++txId, "/MyRoot/ServerLessDB/Table", false, false, 0, 0, 50);
-        WriteVectorTableRows(runtime, tenantSchemeShard, ++txId, "/MyRoot/ServerLessDB/Table", false, false, 1, 50, 150);
-        WriteVectorTableRows(runtime, tenantSchemeShard, ++txId, "/MyRoot/ServerLessDB/Table", false, false, 2, 150, 200);
+        WriteVectorTableRows(runtime, tenantSchemeShard, ++txId, "/MyRoot/ServerLessDB/Table", 0, 0, 50);
+        WriteVectorTableRows(runtime, tenantSchemeShard, ++txId, "/MyRoot/ServerLessDB/Table", 1, 50, 150);
+        WriteVectorTableRows(runtime, tenantSchemeShard, ++txId, "/MyRoot/ServerLessDB/Table", 2, 150, 200);
 
         TBlockEvents<NMetering::TEvMetering::TEvWriteMeteringJson> meteringBlocker(runtime, [&](const auto& ev) {
             Cerr << "TEvWriteMeteringJson " << ev->Get()->MeteringJson << Endl;

--- a/ydb/core/tx/schemeshard/ut_vector_index_build_reboots/ut_vector_index_build_reboots.cpp
+++ b/ydb/core/tx/schemeshard/ut_vector_index_build_reboots/ut_vector_index_build_reboots.cpp
@@ -1,3 +1,4 @@
+#include <ydb/core/tx/scheme_board/events_schemeshard.h>
 #include <ydb/core/tx/schemeshard/ut_helpers/helpers.h>
 #include <ydb/core/tx/schemeshard/ut_helpers/test_with_reboots.h>
 
@@ -14,6 +15,19 @@ Y_UNIT_TEST_SUITE(VectorIndexBuildTestReboots) {
         // and thus the vector index build process is never interrupted at all because there are no other
         // events to reboot on.
         T t(true /*killOnCommit*/);
+        // speed up the test:
+        // only check scheme shard reboots
+        t.TabletIds.clear();
+        t.TabletIds.push_back(t.SchemeShardTabletId);
+        // white list some more events
+        t.NoRebootEventTypes.insert(TEvSchemeShard::EvModifySchemeTransaction);
+        t.NoRebootEventTypes.insert(TSchemeBoardEvents::EvUpdateAck);
+        t.NoRebootEventTypes.insert(TEvSchemeShard::EvNotifyTxCompletionRegistered);
+        t.NoRebootEventTypes.insert(TEvTabletPipe::EvServerDisconnected);
+        t.NoRebootEventTypes.insert(TEvTabletPipe::EvServerConnected);
+        t.NoRebootEventTypes.insert(TEvTabletPipe::EvClientConnected);
+        t.NoRebootEventTypes.insert(TEvTabletPipe::EvClientDestroyed);
+        t.NoRebootEventTypes.insert(TEvDataShard::EvBuildIndexProgressResponse);
         t.Run([&](TTestActorRuntime& runtime, bool& activeZone) {
             {
                 TInactiveZone inactive(activeZone);

--- a/ydb/core/tx/schemeshard/ut_vector_index_build_reboots/ut_vector_index_build_reboots.cpp
+++ b/ydb/core/tx/schemeshard/ut_vector_index_build_reboots/ut_vector_index_build_reboots.cpp
@@ -32,25 +32,25 @@ Y_UNIT_TEST_SUITE(VectorIndexBuildTestReboots) {
             {
                 TInactiveZone inactive(activeZone);
 
-                TestCreateTable(runtime, ++t.TxId, "/MyRoot", Sprintf(R"(
+                TestCreateTable(runtime, ++t.TxId, "/MyRoot", R"(
                     Name: "dir/Table"
                     Columns { Name: "key"       Type: "Uint32" }
                     Columns { Name: "embedding" Type: "String" }
-                    %s
+                    Columns { Name: "prefix"    Type: "Uint32" }
                     Columns { Name: "value"     Type: "String" }
                     KeyColumnNames: ["key"]
                     SplitBoundary { KeyPrefix { Tuple { Optional { Uint32: 50 } } } }
                     SplitBoundary { KeyPrefix { Tuple { Optional { Uint32: 150 } } } }
                     SplitBoundary { KeyPrefix { Tuple { Optional { Uint32: 250 } } } }
                     SplitBoundary { KeyPrefix { Tuple { Optional { Uint32: 350 } } } }
-                )", (Prefixed ? "Columns { Name: \"prefix\" Type: \"Uint32\" }" : "")));
+                )");
                 t.TestEnv->TestWaitNotification(runtime, t.TxId);
 
-                WriteVectorTableRows(runtime, TTestTxConfig::SchemeShard, ++t.TxId, "/MyRoot/dir/Table", Prefixed, true, 0, 0, 50);
-                WriteVectorTableRows(runtime, TTestTxConfig::SchemeShard, ++t.TxId, "/MyRoot/dir/Table", Prefixed, true, 1, 50, 150);
-                WriteVectorTableRows(runtime, TTestTxConfig::SchemeShard, ++t.TxId, "/MyRoot/dir/Table", Prefixed, true, 2, 150, 250);
-                WriteVectorTableRows(runtime, TTestTxConfig::SchemeShard, ++t.TxId, "/MyRoot/dir/Table", Prefixed, true, 3, 250, 350);
-                WriteVectorTableRows(runtime, TTestTxConfig::SchemeShard, ++t.TxId, "/MyRoot/dir/Table", Prefixed, true, 4, 350, 400);
+                WriteVectorTableRows(runtime, TTestTxConfig::SchemeShard, ++t.TxId, "/MyRoot/dir/Table", 0, 0, 50);
+                WriteVectorTableRows(runtime, TTestTxConfig::SchemeShard, ++t.TxId, "/MyRoot/dir/Table", 1, 50, 150);
+                WriteVectorTableRows(runtime, TTestTxConfig::SchemeShard, ++t.TxId, "/MyRoot/dir/Table", 2, 150, 250);
+                WriteVectorTableRows(runtime, TTestTxConfig::SchemeShard, ++t.TxId, "/MyRoot/dir/Table", 3, 250, 350);
+                WriteVectorTableRows(runtime, TTestTxConfig::SchemeShard, ++t.TxId, "/MyRoot/dir/Table", 4, 350, 400);
             }
 
             const ui64 buildIndexId = ++t.TxId;


### PR DESCRIPTION
### Changelog category

* Not for changelog (changelog entry is not required)

### Description for reviewers

- Fixed #19683 and added a test for it with reproduction
- Added a reboot test for prefixed vector index #19561
- Whitelisted some events in vector index reboot tests to speed them up
