### PR TITLE
Pass PathId of sys view source object From SchemeShard to KQP ScanActor

### DIFF
--- a/ydb/core/grpc_services/rpc_read_columns.cpp
+++ b/ydb/core/grpc_services/rpc_read_columns.cpp
@@ -316,16 +316,18 @@ private:
 
         {
             TTableRange range(MinKey.GetCells(), MinKeyInclusive, MaxKey.GetCells(), MaxKeyInclusive);
-            TMaybe<NKikimrSysView::ESysViewType> sysViewType;
+            TMaybe<NKikimrSysView::TSysViewDescription> sysViewInfo;
             const auto& entry = ResolveNamesResult->ResultSet.front();
             if (entry.Kind == NSchemeCache::TSchemeCacheNavigate::KindSysView) {
                 Y_ABORT_UNLESS(entry.SysViewInfo);
-                sysViewType = entry.SysViewInfo->Description.GetType();
+                sysViewInfo.ConstructInPlace();
+                sysViewInfo->SetType(entry.SysViewInfo->Description.GetType());
+                *sysViewInfo->MutableSourceObject() = entry.SysViewInfo->Description.GetSourceObject();
             }
             auto tableScanActor = NSysView::CreateSystemViewScan(ctx.SelfID, 0,
                 entry.TableId,
                 JoinPath(entry.Path),
-                sysViewType,
+                sysViewInfo,
                 range,
                 columns,
                 Request->GetInternalToken(),

--- a/ydb/core/kqp/common/kqp_resolve.h
+++ b/ydb/core/kqp/common/kqp_resolve.h
@@ -33,7 +33,7 @@ struct TTableConstInfo : public TAtomicRefCount<TTableConstInfo> {
     TVector<TString> KeyColumns;
     TVector<NScheme::TTypeInfo> KeyColumnTypes;
     ETableKind TableKind = ETableKind::Unknown;
-    TMaybe<NKikimrSysView::ESysViewType> SysViewType;
+    TMaybe<NKikimrSysView::TSysViewDescription> SysViewInfo;
     THashMap<TString, std::pair<TString, NYql::TKikimrPathId>> Sequences;
     THashMap<TString, Ydb::TypedValue> DefaultFromLiteral;
     bool IsBuildInProgress = false;
@@ -121,8 +121,8 @@ struct TTableConstInfo : public TAtomicRefCount<TTableConstInfo> {
                 YQL_ENSURE(false, "Unexpected phy table kind: " << (i64) phyTable.GetKind());
         }
 
-        if (phyTable.HasSysViewType()) {
-            SysViewType = static_cast<NKikimrSysView::ESysViewType>(phyTable.GetSysViewType());
+        if (phyTable.HasSysViewInfo()) {
+            SysViewInfo = phyTable.GetSysViewInfo();
         }
 
         for (const auto& [_, phyColumn] : phyTable.GetColumns()) {

--- a/ydb/core/kqp/compute_actor/kqp_pure_compute_actor.cpp
+++ b/ydb/core/kqp/compute_actor/kqp_pure_compute_actor.cpp
@@ -33,7 +33,7 @@ TKqpComputeActor::TKqpComputeActor(
         YQL_ENSURE(GetTask().GetMeta().UnpackTo(Meta.Get()), "Invalid task meta: " << GetTask().GetMeta().DebugString());
         YQL_ENSURE(Meta->GetReads().size() == 1);
         YQL_ENSURE(!Meta->GetReads()[0].GetKeyRanges().empty());
-        YQL_ENSURE(!Meta->GetTable().GetSysViewInfo().empty() || Meta->GetTable().HasSysViewType());
+        YQL_ENSURE(!Meta->GetTable().GetSysViewInfo().empty() || Meta->GetTable().HasSysViewInfo());
     }
 }
 
@@ -122,11 +122,11 @@ void TKqpComputeActor::DoBootstrap() {
         ScanData->TaskId = GetTask().GetId();
         ScanData->TableReader = CreateKqpTableReader(*ScanData, *ComputeCtx.StartTs, *ComputeCtx.InputConsumed);
 
-        TMaybe<NKikimrSysView::ESysViewType> sysViewType;
-        if (Meta->GetTable().HasSysViewType()) {
-            sysViewType = Meta->GetTable().GetSysViewType();
+        TMaybe<NKikimrSysView::TSysViewDescription> SysViewInfo;
+        if (Meta->GetTable().HasSysViewDescription()) {
+            SysViewInfo = Meta->GetTable().GetSysViewDescription();
         }
-        auto scanActor = NSysView::CreateSystemViewScan(SelfId(), 0, ScanData->TableId, ScanData->TablePath, sysViewType,
+        auto scanActor = NSysView::CreateSystemViewScan(SelfId(), 0, ScanData->TableId, ScanData->TablePath, SysViewInfo,
                                                         ranges, columns, UserToken, Database, reverse);
 
         if (!scanActor) {

--- a/ydb/core/kqp/executer_actor/kqp_tasks_graph.cpp
+++ b/ydb/core/kqp/executer_actor/kqp_tasks_graph.cpp
@@ -948,8 +948,8 @@ void FillTaskMeta(const TStageInfo& stageInfo, const TTask& task, NYql::NDqProto
         NKikimrTxDataShard::TKqpTransaction::TScanTaskMeta protoTaskMeta;
 
         FillTableMeta(stageInfo, protoTaskMeta.MutableTable());
-        if (stageInfo.Meta.TableConstInfo->SysViewType) {
-            protoTaskMeta.MutableTable()->SetSysViewType(*stageInfo.Meta.TableConstInfo->SysViewType);
+        if (stageInfo.Meta.TableConstInfo->SysViewInfo) {
+            *protoTaskMeta.MutableTable()->MutableSysViewDescription() = *stageInfo.Meta.TableConstInfo->SysViewInfo;
         }
 
         const auto& tableInfo = stageInfo.Meta.TableConstInfo;

--- a/ydb/core/kqp/gateway/kqp_metadata_loader.cpp
+++ b/ydb/core/kqp/gateway/kqp_metadata_loader.cpp
@@ -392,7 +392,9 @@ TTableMetadataResult GetSysViewMetadataResult(const NSchemeCache::TSchemeCacheNa
     }
 
     YQL_ENSURE(entry.SysViewInfo);
-    tableMeta->SysViewType = entry.SysViewInfo->Description.GetType();
+    auto& sysViewInfo = tableMeta->SysViewInfo.ConstructInPlace();
+    sysViewInfo.SetType(entry.SysViewInfo->Description.GetType());
+    *sysViewInfo.MutableSourceObject() = entry.SysViewInfo->Description.GetSourceObject();
 
     return result;
 }

--- a/ydb/core/kqp/provider/yql_kikimr_gateway.h
+++ b/ydb/core/kqp/provider/yql_kikimr_gateway.h
@@ -24,6 +24,7 @@
 #include <ydb/core/protos/kqp.pb.h>
 #include <ydb/core/protos/kqp_stats.pb.h>
 #include <ydb/core/protos/subdomains.pb.h>
+#include <ydb/core/protos/sys_view_types.pb.h>
 #include <ydb/core/protos/yql_translation_settings.pb.h>
 #include <ydb/core/scheme/scheme_types_proto.h>
 
@@ -488,7 +489,7 @@ struct TKikimrTableMetadata : public TThrRefBase {
     EKikimrTableKind Kind = EKikimrTableKind::Unspecified;
     ETableType TableType = ETableType::Table;
     EStoreType StoreType = EStoreType::Row;
-    TMaybe<NKikimrSysView::ESysViewType> SysViewType;
+    TMaybe<NKikimrSysView::TSysViewDescription> SysViewInfo;
     bool IsIndexImplTable = false;
 
     // If writes are disabled, query that writes to table must finish with error.

--- a/ydb/core/kqp/query_compiler/kqp_query_compiler.cpp
+++ b/ydb/core/kqp/query_compiler/kqp_query_compiler.cpp
@@ -179,8 +179,8 @@ void FillTable(const TKikimrTableMetadata& tableMeta, THashSet<TStringBuf>&& col
     FillTableId(tableMeta, *tableProto.MutableId());
     tableProto.SetKind(GetPhyTableKind(tableMeta.Kind));
 
-    if (tableMeta.SysViewType) {
-        tableProto.SetSysViewType(static_cast<ui32>(*tableMeta.SysViewType));
+    if (tableMeta.SysViewInfo) {
+        *tableProto.MutableSysViewInfo() = *tableMeta.SysViewInfo;
     }
 
     for (const auto& keyColumnName : tableMeta.KeyColumnNames) {

--- a/ydb/core/protos/flat_scheme_op.proto
+++ b/ydb/core/protos/flat_scheme_op.proto
@@ -2236,6 +2236,7 @@ message TExportMetadata {
 message TSysViewDescription {
     optional string Name = 1;
     optional NKikimrSysView.ESysViewType Type = 2;
+    optional NKikimrProto.TPathID SourceObject = 3;
 }
 
 message TLongIncrementalRestoreOp {

--- a/ydb/core/protos/kqp_physical.proto
+++ b/ydb/core/protos/kqp_physical.proto
@@ -10,6 +10,7 @@ import "ydb/library/mkql_proto/protos/minikql.proto";
 import "ydb/library/yql/dq/proto/dq_tasks.proto";
 import "ydb/public/api/protos/ydb_value.proto";
 import "ydb/core/protos/index_builder.proto";
+import "ydb/core/protos/sys_view_types.proto";
 
 message TKqpPhyExternalBinding {
 }
@@ -109,7 +110,7 @@ message TKqpPhyTable {
     EKqpPhyTableKind Kind = 2;
     map<uint32, TKqpPhyColumn> Columns = 3;
     repeated TKqpPhyColumnId KeyColumns = 4;
-    optional uint32 SysViewType = 5;           // NKikimrSysView::ESysViewType
+    optional NKikimrSysView.TSysViewDescription SysViewInfo = 5;
 }
 
 message TKqpPhyParamValue {

--- a/ydb/core/protos/sys_view_types.proto
+++ b/ydb/core/protos/sys_view_types.proto
@@ -1,3 +1,5 @@
+import "ydb/core/scheme/protos/pathid.proto";
+
 package NKikimrSysView;
 
 option java_package = "ru.yandex.kikimr.proto";
@@ -37,4 +39,9 @@ enum ESysViewType {
     EInformationSchemaTables = 32;
     EPgClass = 33;
     EShowCreate = 34;
+}
+
+message TSysViewDescription {
+    optional ESysViewType Type = 1;
+    optional NKikimrProto.TPathID SourceObject = 2;
 }

--- a/ydb/core/protos/tx_datashard.proto
+++ b/ydb/core/protos/tx_datashard.proto
@@ -153,7 +153,7 @@ message TKqpTransaction {
         // reserved 4
         optional string SysViewInfo = 5;
         optional uint32 TableKind = 6;      // NKikimr::NKqp::ETableKind
-        optional NKikimrSysView.ESysViewType SysViewType = 7;
+        optional NKikimrSysView.TSysViewDescription SysViewDescription = 7;
     }
 
     // Data-query task meta

--- a/ydb/core/sys_view/auth/auth_scan_base.h
+++ b/ydb/core/sys_view/auth/auth_scan_base.h
@@ -48,11 +48,12 @@ public:
         return NKikimrServices::TActivity::KQP_SYSTEM_VIEW_SCAN;
     }
 
-    TAuthScanBase(const NActors::TActorId& ownerId, ui32 scanId, const TTableId& tableId,
+    TAuthScanBase(const NActors::TActorId& ownerId, ui32 scanId,
+        const NKikimrSysView::TSysViewDescription& sysViewInfo,
         const TTableRange& tableRange, const TArrayRef<NMiniKQL::TKqpComputeContextBase::TColumn>& columns,
         TIntrusiveConstPtr<NACLib::TUserToken> userToken,
         bool requireUserAdministratorAccess, bool applyPathTableRange)
-        : TBase(ownerId, scanId, tableId, tableRange, columns)
+        : TBase(ownerId, scanId, sysViewInfo, tableRange, columns)
         , UserToken(std::move(userToken))
         , RequireUserAdministratorAccess(requireUserAdministratorAccess)
     {

--- a/ydb/core/sys_view/auth/group_members.cpp
+++ b/ydb/core/sys_view/auth/group_members.cpp
@@ -19,10 +19,11 @@ public:
     using TScanBase = TScanActorBase<TGroupMembersScan>;
     using TAuthBase = TAuthScanBase<TGroupMembersScan>;
 
-    TGroupMembersScan(const NActors::TActorId& ownerId, ui32 scanId, const TTableId& tableId,
+    TGroupMembersScan(const NActors::TActorId& ownerId, ui32 scanId,
+        const NKikimrSysView::TSysViewDescription& sysViewInfo,
         const TTableRange& tableRange, const TArrayRef<NMiniKQL::TKqpComputeContextBase::TColumn>& columns,
         TIntrusiveConstPtr<NACLib::TUserToken> userToken)
-        : TAuthBase(ownerId, scanId, tableId, tableRange, columns, std::move(userToken), true, false)
+        : TAuthBase(ownerId, scanId, sysViewInfo, tableRange, columns, std::move(userToken), true, false)
     {
     }
 
@@ -30,7 +31,7 @@ protected:
     void FillBatch(NKqp::TEvKqpCompute::TEvScanData& batch, const TNavigate::TEntry& entry) override {
         Y_ABORT_UNLESS(entry.Status == TNavigate::EStatus::Ok);
         Y_ABORT_UNLESS(CanonizePath(entry.Path) == TBase::TenantName);
-        
+
         TVector<std::pair<const TDomainInfo::TGroup*, const TString*>> memberships;
         for (const auto& group : entry.DomainInfo->Groups) {
             for (const auto& member : group.Members) {
@@ -69,11 +70,12 @@ protected:
     }
 };
 
-THolder<NActors::IActor> CreateGroupMembersScan(const NActors::TActorId& ownerId, ui32 scanId, const TTableId& tableId,
-    const TTableRange& tableRange, const TArrayRef<NMiniKQL::TKqpComputeContextBase::TColumn>& columns,
+THolder<NActors::IActor> CreateGroupMembersScan(const NActors::TActorId& ownerId, ui32 scanId,
+    const NKikimrSysView::TSysViewDescription& sysViewInfo, const TTableRange& tableRange,
+    const TArrayRef<NMiniKQL::TKqpComputeContextBase::TColumn>& columns,
     TIntrusiveConstPtr<NACLib::TUserToken> userToken)
 {
-    return MakeHolder<TGroupMembersScan>(ownerId, scanId, tableId, tableRange, columns, std::move(userToken));
+    return MakeHolder<TGroupMembersScan>(ownerId, scanId, sysViewInfo, tableRange, columns, std::move(userToken));
 }
 
 }

--- a/ydb/core/sys_view/auth/group_members.h
+++ b/ydb/core/sys_view/auth/group_members.h
@@ -2,13 +2,15 @@
 
 #include <ydb/core/kqp/runtime/kqp_compute.h>
 
+#include <ydb/core/protos/sys_view_types.pb.h>
 #include <ydb/library/actors/core/actor.h>
 #include <ydb/library/actors/core/actorid.h>
 
 namespace NKikimr::NSysView::NAuth {
 
-THolder<NActors::IActor> CreateGroupMembersScan(const NActors::TActorId& ownerId, ui32 scanId, const TTableId& tableId,
-    const TTableRange& tableRange, const TArrayRef<NMiniKQL::TKqpComputeContextBase::TColumn>& columns,
+THolder<NActors::IActor> CreateGroupMembersScan(const NActors::TActorId& ownerId, ui32 scanId,
+    const NKikimrSysView::TSysViewDescription& sysViewInfo, const TTableRange& tableRange,
+    const TArrayRef<NMiniKQL::TKqpComputeContextBase::TColumn>& columns,
     TIntrusiveConstPtr<NACLib::TUserToken> userToken);
 
 }

--- a/ydb/core/sys_view/auth/groups.cpp
+++ b/ydb/core/sys_view/auth/groups.cpp
@@ -19,10 +19,11 @@ public:
     using TScanBase = TScanActorBase<TGroupsScan>;
     using TAuthBase = TAuthScanBase<TGroupsScan>;
 
-    TGroupsScan(const NActors::TActorId& ownerId, ui32 scanId, const TTableId& tableId,
+    TGroupsScan(const NActors::TActorId& ownerId, ui32 scanId,
+        const NKikimrSysView::TSysViewDescription& sysViewInfo,
         const TTableRange& tableRange, const TArrayRef<NMiniKQL::TKqpComputeContextBase::TColumn>& columns,
         TIntrusiveConstPtr<NACLib::TUserToken> userToken)
-        : TAuthBase(ownerId, scanId, tableId, tableRange, columns, std::move(userToken), true, false)
+        : TAuthBase(ownerId, scanId, sysViewInfo, tableRange, columns, std::move(userToken), true, false)
     {
     }
 
@@ -40,7 +41,7 @@ protected:
         SortBatch(groups, [](const auto* left, const auto* right) {
             return left->Sid < right->Sid;
         });
-        
+
         TVector<TCell> cells(::Reserve(Columns.size()));
 
         for (const auto* group : groups) {
@@ -63,11 +64,12 @@ protected:
     }
 };
 
-THolder<NActors::IActor> CreateGroupsScan(const NActors::TActorId& ownerId, ui32 scanId, const TTableId& tableId,
-    const TTableRange& tableRange, const TArrayRef<NMiniKQL::TKqpComputeContextBase::TColumn>& columns,
+THolder<NActors::IActor> CreateGroupsScan(const NActors::TActorId& ownerId, ui32 scanId,
+    const NKikimrSysView::TSysViewDescription& sysViewInfo, const TTableRange& tableRange,
+    const TArrayRef<NMiniKQL::TKqpComputeContextBase::TColumn>& columns,
     TIntrusiveConstPtr<NACLib::TUserToken> userToken)
 {
-    return MakeHolder<TGroupsScan>(ownerId, scanId, tableId, tableRange, columns, std::move(userToken));
+    return MakeHolder<TGroupsScan>(ownerId, scanId, sysViewInfo, tableRange, columns, std::move(userToken));
 }
 
 }

--- a/ydb/core/sys_view/auth/groups.h
+++ b/ydb/core/sys_view/auth/groups.h
@@ -2,13 +2,15 @@
 
 #include <ydb/core/kqp/runtime/kqp_compute.h>
 
+#include <ydb/core/protos/sys_view_types.pb.h>
 #include <ydb/library/actors/core/actor.h>
 #include <ydb/library/actors/core/actorid.h>
 
 namespace NKikimr::NSysView::NAuth {
 
-THolder<NActors::IActor> CreateGroupsScan(const NActors::TActorId& ownerId, ui32 scanId, const TTableId& tableId,
-    const TTableRange& tableRange, const TArrayRef<NMiniKQL::TKqpComputeContextBase::TColumn>& columns,
+THolder<NActors::IActor> CreateGroupsScan(const NActors::TActorId& ownerId, ui32 scanId,
+    const NKikimrSysView::TSysViewDescription& sysViewInfo, const TTableRange& tableRange,
+    const TArrayRef<NMiniKQL::TKqpComputeContextBase::TColumn>& columns,
     TIntrusiveConstPtr<NACLib::TUserToken> userToken);
 
 }

--- a/ydb/core/sys_view/auth/owners.cpp
+++ b/ydb/core/sys_view/auth/owners.cpp
@@ -19,17 +19,18 @@ public:
     using TScanBase = TScanActorBase<TOwnersScan>;
     using TAuthBase = TAuthScanBase<TOwnersScan>;
 
-    TOwnersScan(const NActors::TActorId& ownerId, ui32 scanId, const TTableId& tableId,
+    TOwnersScan(const NActors::TActorId& ownerId, ui32 scanId,
+        const NKikimrSysView::TSysViewDescription& sysViewInfo,
         const TTableRange& tableRange, const TArrayRef<NMiniKQL::TKqpComputeContextBase::TColumn>& columns,
         TIntrusiveConstPtr<NACLib::TUserToken> userToken)
-        : TAuthBase(ownerId, scanId, tableId, tableRange, columns, std::move(userToken), false, true)
+        : TAuthBase(ownerId, scanId, sysViewInfo, tableRange, columns, std::move(userToken), false, true)
     {
     }
 
 protected:
     void FillBatch(NKqp::TEvKqpCompute::TEvScanData& batch, const TNavigate::TEntry& entry) override {
         Y_ABORT_UNLESS(entry.Status == TNavigate::EStatus::Ok);
-        
+
         TVector<TCell> cells(::Reserve(Columns.size()));
 
         auto entryPath = CanonizePath(entry.Path);
@@ -61,11 +62,12 @@ protected:
     }
 };
 
-THolder<NActors::IActor> CreateOwnersScan(const NActors::TActorId& ownerId, ui32 scanId, const TTableId& tableId,
-    const TTableRange& tableRange, const TArrayRef<NMiniKQL::TKqpComputeContextBase::TColumn>& columns,
+THolder<NActors::IActor> CreateOwnersScan(const NActors::TActorId& ownerId, ui32 scanId,
+    const NKikimrSysView::TSysViewDescription& sysViewInfo, const TTableRange& tableRange,
+    const TArrayRef<NMiniKQL::TKqpComputeContextBase::TColumn>& columns,
     TIntrusiveConstPtr<NACLib::TUserToken> userToken)
 {
-    return MakeHolder<TOwnersScan>(ownerId, scanId, tableId, tableRange, columns, std::move(userToken));
+    return MakeHolder<TOwnersScan>(ownerId, scanId, sysViewInfo, tableRange, columns, std::move(userToken));
 }
 
 }

--- a/ydb/core/sys_view/auth/owners.h
+++ b/ydb/core/sys_view/auth/owners.h
@@ -2,13 +2,15 @@
 
 #include <ydb/core/kqp/runtime/kqp_compute.h>
 
+#include <ydb/core/protos/sys_view_types.pb.h>
 #include <ydb/library/actors/core/actor.h>
 #include <ydb/library/actors/core/actorid.h>
 
 namespace NKikimr::NSysView::NAuth {
 
-THolder<NActors::IActor> CreateOwnersScan(const NActors::TActorId& ownerId, ui32 scanId, const TTableId& tableId,
-    const TTableRange& tableRange, const TArrayRef<NMiniKQL::TKqpComputeContextBase::TColumn>& columns,
+THolder<NActors::IActor> CreateOwnersScan(const NActors::TActorId& ownerId, ui32 scanId,
+    const NKikimrSysView::TSysViewDescription& sysViewInfo, const TTableRange& tableRange,
+    const TArrayRef<NMiniKQL::TKqpComputeContextBase::TColumn>& columns,
     TIntrusiveConstPtr<NACLib::TUserToken> userToken);
 
 }

--- a/ydb/core/sys_view/auth/permissions.cpp
+++ b/ydb/core/sys_view/auth/permissions.cpp
@@ -20,10 +20,11 @@ public:
     using TScanBase = TScanActorBase<TPermissionsScan>;
     using TAuthBase = TAuthScanBase<TPermissionsScan>;
 
-    TPermissionsScan(bool effective, const NActors::TActorId& ownerId, ui32 scanId, const TTableId& tableId,
+    TPermissionsScan(bool effective, const NActors::TActorId& ownerId, ui32 scanId,
+        const NKikimrSysView::TSysViewDescription& sysViewInfo,
         const TTableRange& tableRange, const TArrayRef<NMiniKQL::TKqpComputeContextBase::TColumn>& columns,
         TIntrusiveConstPtr<NACLib::TUserToken> userToken)
-        : TAuthBase(ownerId, scanId, tableId, tableRange, columns, std::move(userToken), false, true)
+        : TAuthBase(ownerId, scanId, sysViewInfo, tableRange, columns, std::move(userToken), false, true)
         , Effective(effective)
     {
     }
@@ -99,11 +100,13 @@ private:
     const bool Effective;
 };
 
-THolder<NActors::IActor> CreatePermissionsScan(bool effective, const NActors::TActorId& ownerId, ui32 scanId, const TTableId& tableId,
-    const TTableRange& tableRange, const TArrayRef<NMiniKQL::TKqpComputeContextBase::TColumn>& columns,
+THolder<NActors::IActor> CreatePermissionsScan(bool effective, const NActors::TActorId& ownerId, ui32 scanId,
+    const NKikimrSysView::TSysViewDescription& sysViewInfo, const TTableRange& tableRange,
+    const TArrayRef<NMiniKQL::TKqpComputeContextBase::TColumn>& columns,
     TIntrusiveConstPtr<NACLib::TUserToken> userToken)
 {
-    return MakeHolder<TPermissionsScan>(effective, ownerId, scanId, tableId, tableRange, columns, std::move(userToken));
+    return MakeHolder<TPermissionsScan>(effective, ownerId, scanId, sysViewInfo, tableRange, columns,
+        std::move(userToken));
 }
 
 }

--- a/ydb/core/sys_view/auth/permissions.h
+++ b/ydb/core/sys_view/auth/permissions.h
@@ -2,13 +2,15 @@
 
 #include <ydb/core/kqp/runtime/kqp_compute.h>
 
+#include <ydb/core/protos/sys_view_types.pb.h>
 #include <ydb/library/actors/core/actor.h>
 #include <ydb/library/actors/core/actorid.h>
 
 namespace NKikimr::NSysView::NAuth {
 
-THolder<NActors::IActor> CreatePermissionsScan(bool effective, const NActors::TActorId& ownerId, ui32 scanId, const TTableId& tableId,
-    const TTableRange& tableRange, const TArrayRef<NMiniKQL::TKqpComputeContextBase::TColumn>& columns,
+THolder<NActors::IActor> CreatePermissionsScan(bool effective, const NActors::TActorId& ownerId, ui32 scanId,
+    const NKikimrSysView::TSysViewDescription& sysViewInfo, const TTableRange& tableRange,
+    const TArrayRef<NMiniKQL::TKqpComputeContextBase::TColumn>& columns,
     TIntrusiveConstPtr<NACLib::TUserToken> userToken);
 
 }

--- a/ydb/core/sys_view/auth/users.cpp
+++ b/ydb/core/sys_view/auth/users.cpp
@@ -19,10 +19,11 @@ class TUsersScan : public TScanActorBase<TUsersScan> {
 public:
     using TBase = TScanActorBase<TUsersScan>;
 
-    TUsersScan(const NActors::TActorId& ownerId, ui32 scanId, const TTableId& tableId,
+    TUsersScan(const NActors::TActorId& ownerId, ui32 scanId,
+        const NKikimrSysView::TSysViewDescription& sysViewInfo,
         const TTableRange& tableRange, const TArrayRef<NMiniKQL::TKqpComputeContextBase::TColumn>& columns,
         TIntrusiveConstPtr<NACLib::TUserToken> userToken)
-        : TBase(ownerId, scanId, tableId, tableRange, columns)
+        : TBase(ownerId, scanId, sysViewInfo, tableRange, columns)
         , UserToken(std::move(userToken))
     {
     }
@@ -174,11 +175,12 @@ private:
     bool IsAdmin = false;
 };
 
-THolder<NActors::IActor> CreateUsersScan(const NActors::TActorId& ownerId, ui32 scanId, const TTableId& tableId,
-    const TTableRange& tableRange, const TArrayRef<NMiniKQL::TKqpComputeContextBase::TColumn>& columns,
+THolder<NActors::IActor> CreateUsersScan(const NActors::TActorId& ownerId, ui32 scanId,
+    const NKikimrSysView::TSysViewDescription& sysViewInfo, const TTableRange& tableRange,
+    const TArrayRef<NMiniKQL::TKqpComputeContextBase::TColumn>& columns,
     TIntrusiveConstPtr<NACLib::TUserToken> userToken)
 {
-    return MakeHolder<TUsersScan>(ownerId, scanId, tableId, tableRange, columns, std::move(userToken));
+    return MakeHolder<TUsersScan>(ownerId, scanId, sysViewInfo, tableRange, columns, std::move(userToken));
 }
 
 }

--- a/ydb/core/sys_view/auth/users.h
+++ b/ydb/core/sys_view/auth/users.h
@@ -2,13 +2,15 @@
 
 #include <ydb/core/kqp/runtime/kqp_compute.h>
 
+#include <ydb/core/protos/sys_view_types.pb.h>
 #include <ydb/library/actors/core/actor.h>
 #include <ydb/library/actors/core/actorid.h>
 
 namespace NKikimr::NSysView::NAuth {
 
-THolder<NActors::IActor> CreateUsersScan(const NActors::TActorId& ownerId, ui32 scanId, const TTableId& tableId,
-    const TTableRange& tableRange, const TArrayRef<NMiniKQL::TKqpComputeContextBase::TColumn>& columns,
+THolder<NActors::IActor> CreateUsersScan(const NActors::TActorId& ownerId, ui32 scanId,
+    const NKikimrSysView::TSysViewDescription& sysViewInfo, const TTableRange& tableRange,
+    const TArrayRef<NMiniKQL::TKqpComputeContextBase::TColumn>& columns,
     TIntrusiveConstPtr<NACLib::TUserToken> userToken);
 
 }

--- a/ydb/core/sys_view/common/processor_scan.h
+++ b/ydb/core/sys_view/common/processor_scan.h
@@ -25,14 +25,11 @@ public:
         return NKikimrServices::TActivity::KQP_SYSTEM_VIEW_SCAN;
     }
 
-    TProcessorScan(
-        const NActors::TActorId& ownerId,
-        ui32 scanId,
-        const TTableId& tableId,
-        const TTableRange& tableRange,
-        const TArrayRef<NMiniKQL::TKqpComputeContextBase::TColumn>& columns,
+    TProcessorScan(const NActors::TActorId& ownerId, ui32 scanId,
+        const NKikimrSysView::TSysViewDescription& sysViewInfo,
+        const TTableRange& tableRange, const TArrayRef<NMiniKQL::TKqpComputeContextBase::TColumn>& columns,
         NKikimrSysView::EStatsType type)
-        : TBase(ownerId, scanId, tableId, tableRange, columns)
+        : TBase(ownerId, scanId, sysViewInfo, tableRange, columns)
     {
         ConvertKeyRange<TRequest, T...>(Request, this->TableRange);
         Request.SetType(type);

--- a/ydb/core/sys_view/nodes/nodes.cpp
+++ b/ydb/core/sys_view/nodes/nodes.cpp
@@ -25,9 +25,10 @@ public:
         return NKikimrServices::TActivity::KQP_SYSTEM_VIEW_SCAN;
     }
 
-    TNodesScan(const NActors::TActorId& ownerId, ui32 scanId, const TTableId& tableId,
+    TNodesScan(const NActors::TActorId& ownerId, ui32 scanId,
+        const NKikimrSysView::TSysViewDescription& sysViewInfo,
         const TTableRange& tableRange, const TArrayRef<NMiniKQL::TKqpComputeContextBase::TColumn>& columns)
-        : TBase(ownerId, scanId, tableId, tableRange, columns)
+        : TBase(ownerId, scanId, sysViewInfo, tableRange, columns)
     {
         const auto& cellsFrom = TableRange.From.GetCells();
         if (cellsFrom.size() == 1 && !cellsFrom[0].IsNull()) {
@@ -274,10 +275,11 @@ private:
     THashMap<TNodeId, THolder<TEvWhiteboard::TEvSystemStateResponse>> WBSystemInfo;
 };
 
-THolder<NActors::IActor> CreateNodesScan(const NActors::TActorId& ownerId, ui32 scanId, const TTableId& tableId,
+THolder<NActors::IActor> CreateNodesScan(const NActors::TActorId& ownerId, ui32 scanId,
+    const NKikimrSysView::TSysViewDescription& sysViewInfo,
     const TTableRange& tableRange, const TArrayRef<NMiniKQL::TKqpComputeContextBase::TColumn>& columns)
 {
-    return MakeHolder<TNodesScan>(ownerId, scanId, tableId, tableRange, columns);
+    return MakeHolder<TNodesScan>(ownerId, scanId, sysViewInfo, tableRange, columns);
 }
 
 } // NSysView

--- a/ydb/core/sys_view/nodes/nodes.h
+++ b/ydb/core/sys_view/nodes/nodes.h
@@ -2,14 +2,16 @@
 
 #include <ydb/core/kqp/runtime/kqp_compute.h>
 
+#include <ydb/core/protos/sys_view_types.pb.h>
 #include <ydb/library/actors/core/actor.h>
 #include <ydb/library/actors/core/actorid.h>
 
 namespace NKikimr {
 namespace NSysView {
 
-THolder<NActors::IActor> CreateNodesScan(const NActors::TActorId& ownerId, ui32 scanId, const TTableId& tableId,
-    const TTableRange& tableRange, const TArrayRef<NMiniKQL::TKqpComputeContextBase::TColumn>& columns);
+THolder<NActors::IActor> CreateNodesScan(const NActors::TActorId& ownerId, ui32 scanId,
+    const NKikimrSysView::TSysViewDescription& sysViewInfo, const TTableRange& tableRange,
+    const TArrayRef<NMiniKQL::TKqpComputeContextBase::TColumn>& columns);
 
 } // NSysView
 } // NKikimr

--- a/ydb/core/sys_view/partition_stats/partition_stats.cpp
+++ b/ydb/core/sys_view/partition_stats/partition_stats.cpp
@@ -114,7 +114,7 @@ private:
                 tables.OverloadedByTli[pathId].swap(overloadedByTli);
             } else {
                 tables.OverloadedByTli.erase(pathId);
-            }            
+            }
 
             oldPartitions.swap(newPartitions);
             table.ShardIndices.swap(ev->Get()->ShardIndices);
@@ -184,7 +184,7 @@ private:
                     tables.OverloadedByTli.erase(pathId);
                 }
             }
-        }        
+        }
 
         if (followerStats.HasTtlStats()) {
             newStats.MutableTtlStats()->Swap(followerStats.MutableTtlStats());
@@ -430,7 +430,7 @@ private:
             ui32 FollowerId;
             ui64 LocksBroken;
         };
-        std::vector<TPartitionByTli> sortedByTli;        
+        std::vector<TPartitionByTli> sortedByTli;
 
         for (const auto& [pathId, overloadedFollowers] : domainTables.OverloadedByCpu) {
             for (const TFollowerStats& overloadedFollower : overloadedFollowers) {
@@ -445,7 +445,7 @@ private:
                 const auto& partition = table.Partitions.at(overloadedFollower.ShardIdx).FollowerStats.at(overloadedFollower.FollowerId);
                 sortedByTli.emplace_back(TPartitionByTli{pathId, overloadedFollower.ShardIdx, overloadedFollower.FollowerId, partition.GetLocksBroken()});
             }
-        }        
+        }
 
         std::sort(sortedByCpu.begin(), sortedByCpu.end(),
             [] (const auto& l, const auto& r) { return l.CPUCores > r.CPUCores; });
@@ -500,7 +500,7 @@ private:
             if (++count == TOP_PARTITIONS_COUNT) {
                 break;
             }
-        }        
+        }
 
         sendEvent->Record.SetTimeUs(nowUs);
 
@@ -595,9 +595,10 @@ public:
         return NKikimrServices::TActivity::KQP_SYSTEM_VIEW_SCAN;
     }
 
-    TPartitionStatsScan(const NActors::TActorId& ownerId, ui32 scanId, const TTableId& tableId,
+    TPartitionStatsScan(const NActors::TActorId& ownerId, ui32 scanId,
+        const NKikimrSysView::TSysViewDescription& sysViewInfo,
         const TTableRange& tableRange, const TArrayRef<NMiniKQL::TKqpComputeContextBase::TColumn>& columns)
-        : TBase(ownerId, scanId, tableId, tableRange, columns)
+        : TBase(ownerId, scanId, sysViewInfo, tableRange, columns)
     {
         auto extractKey = [] (NKikimrSysView::TPartitionStatsKey& key, const TConstArrayRef<TCell>& cells) {
             if (cells.size() > 0 && !cells[0].IsNull()) {
@@ -860,10 +861,11 @@ private:
     bool IncludePathColumn = false;
 };
 
-THolder<NActors::IActor> CreatePartitionStatsScan(const NActors::TActorId& ownerId, ui32 scanId, const TTableId& tableId,
+THolder<NActors::IActor> CreatePartitionStatsScan(const NActors::TActorId& ownerId, ui32 scanId,
+    const NKikimrSysView::TSysViewDescription& sysViewInfo,
     const TTableRange& tableRange, const TArrayRef<NMiniKQL::TKqpComputeContextBase::TColumn>& columns)
 {
-    return MakeHolder<TPartitionStatsScan>(ownerId, scanId, tableId, tableRange, columns);
+    return MakeHolder<TPartitionStatsScan>(ownerId, scanId, sysViewInfo, tableRange, columns);
 }
 
 } // NSysView

--- a/ydb/core/sys_view/partition_stats/partition_stats.h
+++ b/ydb/core/sys_view/partition_stats/partition_stats.h
@@ -2,6 +2,7 @@
 
 #include <ydb/core/kqp/runtime/kqp_compute.h>
 
+#include <ydb/core/protos/sys_view_types.pb.h>
 #include <ydb/library/actors/core/actor.h>
 #include <ydb/library/actors/core/actorid.h>
 
@@ -15,8 +16,9 @@ THolder<NActors::IActor> CreatePartitionStatsCollector(
     size_t batchSize = STATS_COLLECTOR_BATCH_SIZE,
     size_t pendingRequestsCount = STATS_COLLECTOR_QUEUE_SIZE_LIMIT);
 
-THolder<NActors::IActor> CreatePartitionStatsScan(const NActors::TActorId& ownerId, ui32 scanId, const TTableId& tableId,
-    const TTableRange& tableRange, const TArrayRef<NMiniKQL::TKqpComputeContextBase::TColumn>& columns);
+THolder<NActors::IActor> CreatePartitionStatsScan(const NActors::TActorId& ownerId, ui32 scanId,
+    const NKikimrSysView::TSysViewDescription& sysViewInfo, const TTableRange& tableRange,
+    const TArrayRef<NMiniKQL::TKqpComputeContextBase::TColumn>& columns);
 
 } // NSysView
 } // NKikimr

--- a/ydb/core/sys_view/partition_stats/top_partitions.cpp
+++ b/ydb/core/sys_view/partition_stats/top_partitions.cpp
@@ -115,8 +115,8 @@ struct TTopPartitionsByTliExtractorMap :
     }
 };
 
-THolder<NActors::IActor> CreateTopPartitionsByCpuScan(const NActors::TActorId& ownerId, ui32 scanId, const TTableId& tableId,
-    const ESysViewType sysViewType, const TTableRange& tableRange,
+THolder<NActors::IActor> CreateTopPartitionsByCpuScan(const NActors::TActorId& ownerId, ui32 scanId,
+    const NKikimrSysView::TSysViewDescription& sysViewInfo, const TTableRange& tableRange,
     const TArrayRef<NMiniKQL::TKqpComputeContextBase::TColumn>& columns)
 {
     using TTopPartitionsByCpuScan = TProcessorScan<
@@ -135,14 +135,14 @@ THolder<NActors::IActor> CreateTopPartitionsByCpuScan(const NActors::TActorId& o
         {ESysViewType::ETopPartitionsByCpuOneHour, NKikimrSysView::TOP_PARTITIONS_BY_CPU_ONE_HOUR},
     };
 
-    auto statusIter = nameToStatus.find(sysViewType);
+    auto statusIter = nameToStatus.find(sysViewInfo.GetType());
     Y_ABORT_UNLESS(statusIter != nameToStatus.end());
 
-    return MakeHolder<TTopPartitionsByCpuScan>(ownerId, scanId, tableId, tableRange, columns, statusIter->second);
+    return MakeHolder<TTopPartitionsByCpuScan>(ownerId, scanId, sysViewInfo, tableRange, columns, statusIter->second);
 }
 
-THolder<NActors::IActor> CreateTopPartitionsByTliScan(const NActors::TActorId& ownerId, ui32 scanId, const TTableId& tableId,
-    const ESysViewType sysViewType, const TTableRange& tableRange,
+THolder<NActors::IActor> CreateTopPartitionsByTliScan(const NActors::TActorId& ownerId, ui32 scanId,
+    const NKikimrSysView::TSysViewDescription& sysViewInfo, const TTableRange& tableRange,
     const TArrayRef<NMiniKQL::TKqpComputeContextBase::TColumn>& columns)
 {
     using TTopPartitionsByTliScan = TProcessorScan<
@@ -161,10 +161,10 @@ THolder<NActors::IActor> CreateTopPartitionsByTliScan(const NActors::TActorId& o
         {ESysViewType::ETopPartitionsByTliOneHour, NKikimrSysView::TOP_PARTITIONS_BY_TLI_ONE_HOUR},
     };
 
-    auto statusIter = nameToStatus.find(sysViewType);
+    auto statusIter = nameToStatus.find(sysViewInfo.GetType());
     Y_ABORT_UNLESS(statusIter != nameToStatus.end());
 
-    return MakeHolder<TTopPartitionsByTliScan>(ownerId, scanId, tableId, tableRange, columns, statusIter->second);
+    return MakeHolder<TTopPartitionsByTliScan>(ownerId, scanId, sysViewInfo, tableRange, columns, statusIter->second);
 }
 
 } // NKikimr::NSysView

--- a/ydb/core/sys_view/partition_stats/top_partitions.h
+++ b/ydb/core/sys_view/partition_stats/top_partitions.h
@@ -9,10 +9,10 @@
 namespace NKikimr::NSysView {
 
 THolder<NActors::IActor> CreateTopPartitionsByCpuScan(const NActors::TActorId& ownerId, ui32 scanId,
-    const TTableId& tableId, const NKikimrSysView::ESysViewType sysViewType, const TTableRange& tableRange,
+    const NKikimrSysView::TSysViewDescription& sysViewInfo, const TTableRange& tableRange,
     const TArrayRef<NMiniKQL::TKqpComputeContextBase::TColumn>& columns);
 
 THolder<NActors::IActor> CreateTopPartitionsByTliScan(const NActors::TActorId& ownerId, ui32 scanId,
-    const TTableId& tableId, const NKikimrSysView::ESysViewType sysViewType, const TTableRange& tableRange,
+    const NKikimrSysView::TSysViewDescription& sysViewInfo, const TTableRange& tableRange,
     const TArrayRef<NMiniKQL::TKqpComputeContextBase::TColumn>& columns);
 } // NKikimr::NSysView

--- a/ydb/core/sys_view/pg_tables/pg_tables.cpp
+++ b/ydb/core/sys_view/pg_tables/pg_tables.cpp
@@ -161,15 +161,15 @@ void TPgTablesScanBase::StateWork(TAutoPtr<IEventHandle>& ev) {
     }
 }
 
-TPgTablesScanBase::TPgTablesScanBase(
-    const NActors::TActorId &ownerId, ui32 scanId, const TTableId &tableId,
+TPgTablesScanBase::TPgTablesScanBase(const NActors::TActorId &ownerId, ui32 scanId,
+    const NKikimrSysView::TSysViewDescription& sysViewInfo,
     const TString& tablePath,
     const TTableRange &tableRange,
     const TArrayRef<NMiniKQL::TKqpComputeContextBase::TColumn> &columns,
     const TVector<Schema::PgColumn>& schemaColumns,
     THashMap<TString, TRowFiller>&& fillers,
     THashMap<TString, TStaticRowFiller>&& staticFillers)
-    : NKikimr::NSysView::TScanActorBase<TPgTablesScanBase>(ownerId, scanId, tableId, tableRange, columns),
+    : NKikimr::NSysView::TScanActorBase<TPgTablesScanBase>(ownerId, scanId, sysViewInfo, tableRange, columns),
       TablePath_(tablePath),
       SchemaColumns_(schemaColumns),
       Fillers_(std::move(fillers)),
@@ -177,14 +177,15 @@ TPgTablesScanBase::TPgTablesScanBase(
 
 
 TPgTablesScan::TPgTablesScan(
-    const NActors::TActorId &ownerId, ui32 scanId, const TTableId &tableId,
+    const NActors::TActorId &ownerId, ui32 scanId,
+    const NKikimrSysView::TSysViewDescription& sysViewInfo,
     const TString& tablePath,
     const TTableRange &tableRange,
     const TArrayRef<NMiniKQL::TKqpComputeContextBase::TColumn> &columns)
     : TPgTablesScanBase(
         ownerId,
         scanId,
-        tableId,
+        sysViewInfo,
         tablePath,
         tableRange,
         columns,
@@ -222,14 +223,15 @@ TPgTablesScan::TPgTablesScan(
         }) {}
 
 TInformationSchemaTablesScan::TInformationSchemaTablesScan(
-    const NActors::TActorId &ownerId, ui32 scanId, const TTableId &tableId,
+    const NActors::TActorId &ownerId, ui32 scanId,
+    const NKikimrSysView::TSysViewDescription& sysViewInfo,
     const TString& tablePath,
     const TTableRange &tableRange,
     const TArrayRef<NMiniKQL::TKqpComputeContextBase::TColumn> &columns)
     : TPgTablesScanBase(
         ownerId,
         scanId,
-        tableId,
+        sysViewInfo,
         tablePath,
         tableRange,
         columns,
@@ -252,14 +254,15 @@ TInformationSchemaTablesScan::TInformationSchemaTablesScan(
         }) {}
 
 TPgClassScan::TPgClassScan(
-    const NActors::TActorId &ownerId, ui32 scanId, const TTableId &tableId,
+    const NActors::TActorId &ownerId, ui32 scanId,
+    const NKikimrSysView::TSysViewDescription& sysViewInfo,
     const TString& tablePath,
     const TTableRange &tableRange,
     const TArrayRef<NMiniKQL::TKqpComputeContextBase::TColumn> &columns)
     : TPgTablesScanBase(
         ownerId,
         scanId,
-        tableId,
+        sysViewInfo,
         tablePath,
         tableRange,
         columns,
@@ -317,22 +320,25 @@ TPgClassScan::TPgClassScan(
     });
 }
 
-THolder<NActors::IActor> CreatePgTablesScan(const NActors::TActorId& ownerId, ui32 scanId, const TTableId& tableId, const TString& tablePath,
+THolder<NActors::IActor> CreatePgTablesScan(const NActors::TActorId& ownerId, ui32 scanId,
+    const NKikimrSysView::TSysViewDescription& sysViewInfo, const TString& tablePath,
     const TTableRange& tableRange, const TArrayRef<NMiniKQL::TKqpComputeContextBase::TColumn>& columns)
 {
-    return MakeHolder<TPgTablesScan>(ownerId, scanId, tableId, tablePath, tableRange, columns);
+    return MakeHolder<TPgTablesScan>(ownerId, scanId, sysViewInfo, tablePath, tableRange, columns);
 }
 
-THolder<NActors::IActor> CreateInformationSchemaTablesScan(const NActors::TActorId& ownerId, ui32 scanId, const TTableId& tableId, const TString& tablePath,
+THolder<NActors::IActor> CreateInformationSchemaTablesScan(const NActors::TActorId& ownerId, ui32 scanId,
+    const NKikimrSysView::TSysViewDescription& sysViewInfo, const TString& tablePath,
     const TTableRange& tableRange, const TArrayRef<NMiniKQL::TKqpComputeContextBase::TColumn>& columns)
 {
-    return MakeHolder<TInformationSchemaTablesScan>(ownerId, scanId, tableId, tablePath, tableRange, columns);
+    return MakeHolder<TInformationSchemaTablesScan>(ownerId, scanId, sysViewInfo, tablePath, tableRange, columns);
 }
 
-THolder<NActors::IActor> CreatePgClassScan(const NActors::TActorId& ownerId, ui32 scanId, const TTableId& tableId, const TString& tablePath,
+THolder<NActors::IActor> CreatePgClassScan(const NActors::TActorId& ownerId, ui32 scanId,
+    const NKikimrSysView::TSysViewDescription& sysViewInfo, const TString& tablePath,
     const TTableRange& tableRange, const TArrayRef<NMiniKQL::TKqpComputeContextBase::TColumn>& columns)
 {
-    return MakeHolder<TPgClassScan>(ownerId, scanId, tableId, tablePath, tableRange, columns);
+    return MakeHolder<TPgClassScan>(ownerId, scanId, sysViewInfo, tablePath, tableRange, columns);
 }
 
 } // NSysView

--- a/ydb/core/sys_view/pg_tables/pg_tables.h
+++ b/ydb/core/sys_view/pg_tables/pg_tables.h
@@ -26,7 +26,7 @@ public:
     TPgTablesScanBase(
         const NActors::TActorId& ownerId,
         ui32 scanId,
-        const TTableId& tableId,
+        const NKikimrSysView::TSysViewDescription& sysViewInfo,
         const TString& tablePath,
         const TTableRange& tableRange,
         const TArrayRef<NMiniKQL::TKqpComputeContextBase::TColumn>& columns,
@@ -48,29 +48,35 @@ protected:
 
 class TPgTablesScan : public TPgTablesScanBase {
 public:
-    TPgTablesScan(const NActors::TActorId& ownerId, ui32 scanId, const TTableId& tableId, const TString& tablePath,
+    TPgTablesScan(const NActors::TActorId& ownerId, ui32 scanId,
+        const NKikimrSysView::TSysViewDescription& sysViewInfo, const TString& tablePath,
         const TTableRange& tableRange, const TArrayRef<NMiniKQL::TKqpComputeContextBase::TColumn>& columns);
 };
 class TInformationSchemaTablesScan : public TPgTablesScanBase {
 public:
-    TInformationSchemaTablesScan(const NActors::TActorId& ownerId, ui32 scanId, const TTableId& tableId, const TString& tablePath,
+    TInformationSchemaTablesScan(const NActors::TActorId& ownerId, ui32 scanId,
+        const NKikimrSysView::TSysViewDescription& sysViewInfo, const TString& tablePath,
         const TTableRange& tableRange, const TArrayRef<NMiniKQL::TKqpComputeContextBase::TColumn>& columns);
 };
 
 class TPgClassScan : public TPgTablesScanBase {
 public:
-    TPgClassScan(const NActors::TActorId& ownerId, ui32 scanId, const TTableId& tableId, const TString& tablePath,
+    TPgClassScan(const NActors::TActorId& ownerId, ui32 scanId,
+        const NKikimrSysView::TSysViewDescription& sysViewInfo, const TString& tablePath,
         const TTableRange& tableRange, const TArrayRef<NMiniKQL::TKqpComputeContextBase::TColumn>& columns);
 private:
     THashMap<TString, ui32> namespaces;
     ui32 btreeAmOid;
 };
 
-THolder<NActors::IActor> CreatePgTablesScan(const NActors::TActorId& ownerId, ui32 scanId, const TTableId& tableId, const TString& tablePath,
+THolder<NActors::IActor> CreatePgTablesScan(const NActors::TActorId& ownerId, ui32 scanId,
+    const NKikimrSysView::TSysViewDescription& sysViewInfo, const TString& tablePath,
     const TTableRange& tableRange, const TArrayRef<NMiniKQL::TKqpComputeContextBase::TColumn>& columns);
-THolder<NActors::IActor> CreateInformationSchemaTablesScan(const NActors::TActorId& ownerId, ui32 scanId, const TTableId& tableId, const TString& tablePath,
+THolder<NActors::IActor> CreateInformationSchemaTablesScan(const NActors::TActorId& ownerId, ui32 scanId,
+    const NKikimrSysView::TSysViewDescription& sysViewInfo, const TString& tablePath,
     const TTableRange& tableRange, const TArrayRef<NMiniKQL::TKqpComputeContextBase::TColumn>& columns);
-THolder<NActors::IActor> CreatePgClassScan(const NActors::TActorId& ownerId, ui32 scanId, const TTableId& tableId, const TString& tablePath,
+THolder<NActors::IActor> CreatePgClassScan(const NActors::TActorId& ownerId, ui32 scanId,
+    const NKikimrSysView::TSysViewDescription& sysViewInfo, const TString& tablePath,
     const TTableRange& tableRange, const TArrayRef<NMiniKQL::TKqpComputeContextBase::TColumn>& columns);
 
 

--- a/ydb/core/sys_view/query_stats/query_metrics.cpp
+++ b/ydb/core/sys_view/query_stats/query_metrics.cpp
@@ -61,8 +61,9 @@ struct TQueryMetricsExtractorsMap :
     }
 };
 
-THolder<NActors::IActor> CreateQueryMetricsScan(const NActors::TActorId& ownerId, ui32 scanId, const TTableId& tableId,
-    const TTableRange& tableRange, const TArrayRef<NMiniKQL::TKqpComputeContextBase::TColumn>& columns)
+THolder<NActors::IActor> CreateQueryMetricsScan(const NActors::TActorId& ownerId, ui32 scanId,
+    const NKikimrSysView::TSysViewDescription& sysViewInfo, const TTableRange& tableRange,
+    const TArrayRef<NMiniKQL::TKqpComputeContextBase::TColumn>& columns)
 {
     using TQueryMetricsScan = TProcessorScan<
         NKikimrSysView::TQueryMetricsEntry,
@@ -75,7 +76,7 @@ THolder<NActors::IActor> CreateQueryMetricsScan(const NActors::TActorId& ownerId
         ui32
     >;
 
-    return MakeHolder<TQueryMetricsScan>(ownerId, scanId, tableId, tableRange, columns,
+    return MakeHolder<TQueryMetricsScan>(ownerId, scanId, sysViewInfo, tableRange, columns,
         NKikimrSysView::METRICS_ONE_MINUTE);
 }
 

--- a/ydb/core/sys_view/query_stats/query_metrics.h
+++ b/ydb/core/sys_view/query_stats/query_metrics.h
@@ -2,6 +2,7 @@
 
 #include <ydb/core/kqp/runtime/kqp_compute.h>
 
+#include <ydb/core/protos/sys_view_types.pb.h>
 #include <ydb/library/actors/core/actor.h>
 #include <ydb/library/actors/core/actorid.h>
 
@@ -9,7 +10,7 @@ namespace NKikimr {
 namespace NSysView {
 
 THolder<NActors::IActor> CreateQueryMetricsScan(const NActors::TActorId& ownerId, ui32 scanId,
-    const TTableId& tableId, const TTableRange& tableRange,
+    const NKikimrSysView::TSysViewDescription& sysViewInfo, const TTableRange& tableRange,
     const TArrayRef<NMiniKQL::TKqpComputeContextBase::TColumn>& columns);
 
 } // NSysView

--- a/ydb/core/sys_view/query_stats/query_stats.cpp
+++ b/ydb/core/sys_view/query_stats/query_stats.cpp
@@ -100,11 +100,12 @@ public:
         return NKikimrServices::TActivity::KQP_SYSTEM_VIEW_SCAN;
     }
 
-    TQueryStatsScan(const NActors::TActorId& ownerId, ui32 scanId, const TTableId& tableId,
+    TQueryStatsScan(const NActors::TActorId& ownerId, ui32 scanId,
+        const NKikimrSysView::TSysViewDescription& sysViewInfo,
         const TTableRange& tableRange, const TArrayRef<NMiniKQL::TKqpComputeContextBase::TColumn>& columns,
         NKikimrSysView::EStatsType statsType,
         ui64 bucketCount, const TDuration& bucketSize)
-        : TBase(ownerId, scanId, tableId, tableRange, columns)
+        : TBase(ownerId, scanId, sysViewInfo, tableRange, columns)
         , StatsType(statsType)
         , BucketRange(this->TableRange, bucketSize)
     {
@@ -507,40 +508,41 @@ private:
     NKikimrSysView::TEvGetQueryMetricsRequest Request;
 };
 
-THolder<NActors::IActor> CreateQueryStatsScan(const NActors::TActorId& ownerId, ui32 scanId, const TTableId& tableId,
-    const ESysViewType sysViewType, const TTableRange& tableRange, const TArrayRef<NMiniKQL::TKqpComputeContextBase::TColumn>& columns)
+THolder<NActors::IActor> CreateQueryStatsScan(const NActors::TActorId& ownerId, ui32 scanId,
+    const NKikimrSysView::TSysViewDescription& sysViewInfo, const TTableRange& tableRange,
+    const TArrayRef<NMiniKQL::TKqpComputeContextBase::TColumn>& columns)
 {
-    switch (sysViewType) {
+    switch (sysViewInfo.GetType()) {
     case ESysViewType::ETopQueriesByDurationOneMinute:
-        return MakeHolder<TQueryStatsScan<TDurationGreater>>(ownerId, scanId, tableId, tableRange, columns,
+        return MakeHolder<TQueryStatsScan<TDurationGreater>>(ownerId, scanId, sysViewInfo, tableRange, columns,
             NKikimrSysView::TOP_DURATION_ONE_MINUTE,
             ONE_MINUTE_BUCKET_COUNT, ONE_MINUTE_BUCKET_SIZE);
     case ESysViewType::ETopQueriesByDurationOneHour:
-        return MakeHolder<TQueryStatsScan<TDurationGreater>>(ownerId, scanId, tableId, tableRange, columns,
+        return MakeHolder<TQueryStatsScan<TDurationGreater>>(ownerId, scanId, sysViewInfo, tableRange, columns,
             NKikimrSysView::TOP_DURATION_ONE_HOUR,
             ONE_HOUR_BUCKET_COUNT, ONE_HOUR_BUCKET_SIZE);
     case ESysViewType::ETopQueriesByReadBytesOneMinute:
-        return MakeHolder<TQueryStatsScan<TReadBytesGreater>>(ownerId, scanId, tableId, tableRange, columns,
+        return MakeHolder<TQueryStatsScan<TReadBytesGreater>>(ownerId, scanId, sysViewInfo, tableRange, columns,
             NKikimrSysView::TOP_READ_BYTES_ONE_MINUTE,
             ONE_MINUTE_BUCKET_COUNT, ONE_MINUTE_BUCKET_SIZE);
     case ESysViewType::ETopQueriesByReadBytesOneHour:
-        return MakeHolder<TQueryStatsScan<TReadBytesGreater>>(ownerId, scanId, tableId, tableRange, columns,
+        return MakeHolder<TQueryStatsScan<TReadBytesGreater>>(ownerId, scanId, sysViewInfo, tableRange, columns,
             NKikimrSysView::TOP_READ_BYTES_ONE_HOUR,
             ONE_HOUR_BUCKET_COUNT, ONE_HOUR_BUCKET_SIZE);
     case ESysViewType::ETopQueriesByCpuTimeOneMinute:
-        return MakeHolder<TQueryStatsScan<TCpuTimeGreater>>(ownerId, scanId, tableId, tableRange, columns,
+        return MakeHolder<TQueryStatsScan<TCpuTimeGreater>>(ownerId, scanId, sysViewInfo, tableRange, columns,
             NKikimrSysView::TOP_CPU_TIME_ONE_MINUTE,
             ONE_MINUTE_BUCKET_COUNT, ONE_MINUTE_BUCKET_SIZE);
     case ESysViewType::ETopQueriesByCpuTimeOneHour:
-        return MakeHolder<TQueryStatsScan<TCpuTimeGreater>>(ownerId, scanId, tableId, tableRange, columns,
+        return MakeHolder<TQueryStatsScan<TCpuTimeGreater>>(ownerId, scanId, sysViewInfo, tableRange, columns,
             NKikimrSysView::TOP_CPU_TIME_ONE_HOUR,
             ONE_HOUR_BUCKET_COUNT, ONE_HOUR_BUCKET_SIZE);
     case ESysViewType::ETopQueriesByRequestUnitsOneMinute:
-        return MakeHolder<TQueryStatsScan<TRequestUnitsGreater>>(ownerId, scanId, tableId, tableRange, columns,
+        return MakeHolder<TQueryStatsScan<TRequestUnitsGreater>>(ownerId, scanId, sysViewInfo, tableRange, columns,
             NKikimrSysView::TOP_REQUEST_UNITS_ONE_MINUTE,
             ONE_MINUTE_BUCKET_COUNT, ONE_MINUTE_BUCKET_SIZE);
     case ESysViewType::ETopQueriesByRequestUnitsOneHour:
-        return MakeHolder<TQueryStatsScan<TRequestUnitsGreater>>(ownerId, scanId, tableId, tableRange, columns,
+        return MakeHolder<TQueryStatsScan<TRequestUnitsGreater>>(ownerId, scanId, sysViewInfo, tableRange, columns,
             NKikimrSysView::TOP_REQUEST_UNITS_ONE_HOUR,
             ONE_HOUR_BUCKET_COUNT, ONE_HOUR_BUCKET_SIZE);
     default:

--- a/ydb/core/sys_view/query_stats/query_stats.h
+++ b/ydb/core/sys_view/query_stats/query_stats.h
@@ -21,8 +21,8 @@ struct TQueryStatsBucketRange {
     explicit TQueryStatsBucketRange(const TSerializedTableRange& range, const TDuration& bucketSize);
 };
 
-THolder<NActors::IActor> CreateQueryStatsScan(const NActors::TActorId& ownerId, ui32 scanId, const TTableId& tableId,
-    const NKikimrSysView::ESysViewType sysViewType, const TTableRange& tableRange,
+THolder<NActors::IActor> CreateQueryStatsScan(const NActors::TActorId& ownerId, ui32 scanId,
+    const NKikimrSysView::TSysViewDescription& sysViewInfo, const TTableRange& tableRange,
     const TArrayRef<NMiniKQL::TKqpComputeContextBase::TColumn>& columns);
 
 } // NSysView

--- a/ydb/core/sys_view/resource_pool_classifiers/resource_pool_classifiers.cpp
+++ b/ydb/core/sys_view/resource_pool_classifiers/resource_pool_classifiers.cpp
@@ -32,10 +32,11 @@ public:
         return NKikimrServices::TActivity::KQP_SYSTEM_VIEW_SCAN;
     }
 
-    TResourcePoolClassifiersScan(const NActors::TActorId& ownerId, ui32 scanId, const TTableId& tableId,
-        const TTableRange& tableRange, const TArrayRef<NMiniKQL::TKqpComputeContextBase::TColumn>& columns, 
+    TResourcePoolClassifiersScan(const NActors::TActorId& ownerId, ui32 scanId,
+        const NKikimrSysView::TSysViewDescription& sysViewInfo,
+        const TTableRange& tableRange, const TArrayRef<NMiniKQL::TKqpComputeContextBase::TColumn>& columns,
         TIntrusiveConstPtr<NACLib::TUserToken> userToken, const TString& database, bool reverse)
-        : TBase(ownerId, scanId, tableId, tableRange, columns)
+        : TBase(ownerId, scanId, sysViewInfo, tableRange, columns)
         , UserToken(std::move(userToken))
         , Database(database)
         , Reverse(reverse)
@@ -114,7 +115,7 @@ private:
         };
         static TExtractorsMap extractors;
 
-        const auto& snapshot = ev->Get()->GetSnapshotAs<NKqp::TResourcePoolClassifierSnapshot>();        
+        const auto& snapshot = ev->Get()->GetSnapshotAs<NKqp::TResourcePoolClassifierSnapshot>();
         const auto& config = snapshot->GetResourcePoolClassifierConfigs();
         auto resourcePoolsIt = config.find(Database);
         if (resourcePoolsIt == config.end()) {
@@ -153,11 +154,13 @@ private:
     const bool Reverse;
 };
 
-THolder<NActors::IActor> CreateResourcePoolClassifiersScan(const NActors::TActorId& ownerId, ui32 scanId, const TTableId& tableId,
+THolder<NActors::IActor> CreateResourcePoolClassifiersScan(const NActors::TActorId& ownerId, ui32 scanId,
+    const NKikimrSysView::TSysViewDescription& sysViewInfo,
     const TTableRange& tableRange, const TArrayRef<NMiniKQL::TKqpComputeContextBase::TColumn>& columns,
     TIntrusiveConstPtr<NACLib::TUserToken> userToken, const TString& database, bool reverse)
 {
-    return MakeHolder<TResourcePoolClassifiersScan>(ownerId, scanId, tableId, tableRange, columns, std::move(userToken), database, reverse);
+    return MakeHolder<TResourcePoolClassifiersScan>(ownerId, scanId, sysViewInfo, tableRange, columns,
+        std::move(userToken), database, reverse);
 }
 
 } // NSysView

--- a/ydb/core/sys_view/resource_pool_classifiers/resource_pool_classifiers.h
+++ b/ydb/core/sys_view/resource_pool_classifiers/resource_pool_classifiers.h
@@ -2,14 +2,16 @@
 
 #include <ydb/core/kqp/runtime/kqp_compute.h>
 
+#include <ydb/core/protos/sys_view_types.pb.h>
 #include <ydb/library/actors/core/actor.h>
 #include <ydb/library/actors/core/actorid.h>
 
 namespace NKikimr {
 namespace NSysView {
 
-THolder<NActors::IActor> CreateResourcePoolClassifiersScan(const NActors::TActorId& ownerId, ui32 scanId, const TTableId& tableId,
-    const TTableRange& tableRange, const TArrayRef<NMiniKQL::TKqpComputeContextBase::TColumn>& columns,
+THolder<NActors::IActor> CreateResourcePoolClassifiersScan(const NActors::TActorId& ownerId, ui32 scanId,
+    const NKikimrSysView::TSysViewDescription& sysViewInfo, const TTableRange& tableRange,
+    const TArrayRef<NMiniKQL::TKqpComputeContextBase::TColumn>& columns,
     TIntrusiveConstPtr<NACLib::TUserToken> userToken, const TString& database, bool reverse);
 
 } // NSysView

--- a/ydb/core/sys_view/resource_pools/resource_pools.cpp
+++ b/ydb/core/sys_view/resource_pools/resource_pools.cpp
@@ -36,10 +36,11 @@ public:
         return NKikimrServices::TActivity::KQP_SYSTEM_VIEW_SCAN;
     }
 
-    TResourcePoolsScan(const NActors::TActorId& ownerId, ui32 scanId, const TTableId& tableId,
+    TResourcePoolsScan(const NActors::TActorId& ownerId, ui32 scanId,
+        const NKikimrSysView::TSysViewDescription& sysViewInfo,
         const TTableRange& tableRange, const TArrayRef<NMiniKQL::TKqpComputeContextBase::TColumn>& columns,
         TIntrusiveConstPtr<NACLib::TUserToken> userToken, const TString& database, bool reverse)
-        : TBase(ownerId, scanId, tableId, tableRange, columns)
+        : TBase(ownerId, scanId, sysViewInfo, tableRange, columns)
         , UserToken(std::move(userToken))
         , Database(database)
         , Reverse(reverse)
@@ -156,7 +157,7 @@ private:
                     return;
                 case NSchemeCache::TSchemeCacheNavigate::EStatus::Ok:
                     const auto& name = result.ResourcePoolInfo->Description.GetName();
-                    resourcePools[name] = result.ResourcePoolInfo;                    
+                    resourcePools[name] = result.ResourcePoolInfo;
             }
         }
 
@@ -248,10 +249,13 @@ private:
     const bool Reverse;
 };
 
-THolder<NActors::IActor> CreateResourcePoolsScan(const NActors::TActorId& ownerId, ui32 scanId, const TTableId& tableId,
-    const TTableRange& tableRange, const TArrayRef<NMiniKQL::TKqpComputeContextBase::TColumn>& columns, TIntrusiveConstPtr<NACLib::TUserToken> userToken, const TString& database, bool reverse)
+THolder<NActors::IActor> CreateResourcePoolsScan(const NActors::TActorId& ownerId, ui32 scanId,
+    const NKikimrSysView::TSysViewDescription& sysViewInfo, const TTableRange& tableRange,
+    const TArrayRef<NMiniKQL::TKqpComputeContextBase::TColumn>& columns,
+    TIntrusiveConstPtr<NACLib::TUserToken> userToken, const TString& database, bool reverse)
 {
-    return MakeHolder<TResourcePoolsScan>(ownerId, scanId, tableId, tableRange, columns, std::move(userToken), database, reverse);
+    return MakeHolder<TResourcePoolsScan>(ownerId, scanId, sysViewInfo, tableRange, columns,
+        std::move(userToken), database, reverse);
 }
 
 } // NSysView

--- a/ydb/core/sys_view/resource_pools/resource_pools.h
+++ b/ydb/core/sys_view/resource_pools/resource_pools.h
@@ -2,14 +2,17 @@
 
 #include <ydb/core/kqp/runtime/kqp_compute.h>
 
+#include <ydb/core/protos/sys_view_types.pb.h>
 #include <ydb/library/actors/core/actor.h>
 #include <ydb/library/actors/core/actorid.h>
 
 namespace NKikimr {
 namespace NSysView {
 
-THolder<NActors::IActor> CreateResourcePoolsScan(const NActors::TActorId& ownerId, ui32 scanId, const TTableId& tableId,
-    const TTableRange& tableRange, const TArrayRef<NMiniKQL::TKqpComputeContextBase::TColumn>& columns, TIntrusiveConstPtr<NACLib::TUserToken> userToken, const TString& database, bool reverse);
+THolder<NActors::IActor> CreateResourcePoolsScan(const NActors::TActorId& ownerId, ui32 scanId,
+    const NKikimrSysView::TSysViewDescription& sysViewInfo, const TTableRange& tableRange,
+    const TArrayRef<NMiniKQL::TKqpComputeContextBase::TColumn>& columns,
+    TIntrusiveConstPtr<NACLib::TUserToken> userToken, const TString& database, bool reverse);
 
 } // NSysView
 } // NKikimr

--- a/ydb/core/sys_view/scan.cpp
+++ b/ydb/core/sys_view/scan.cpp
@@ -93,7 +93,7 @@ public:
         ui32 scanId,
         const TTableId& tableId,
         const TString& tablePath,
-        const TMaybe<ESysViewType>& sysViewType,
+        const TMaybe<NKikimrSysView::TSysViewDescription>& sysViewInfo,
         TVector<TSerializedTableRange> ranges,
         const TArrayRef<NMiniKQL::TKqpComputeContextBase::TColumn>& columns,
         TIntrusiveConstPtr<NACLib::TUserToken> userToken,
@@ -104,7 +104,7 @@ public:
         , ScanId(scanId)
         , TableId(tableId)
         , TablePath(tablePath)
-        , SysViewType(sysViewType)
+        , SysViewInfo(sysViewInfo)
         , Ranges(std::move(ranges))
         , Columns(columns.begin(), columns.end())
         , UserToken(std::move(userToken))
@@ -143,7 +143,7 @@ public:
         if (!ScanActorId) {
             if (CurrentRange < Ranges.size()) {
                 auto actor = CreateSystemViewScan(
-                    SelfId(), ScanId, TableId, TablePath, SysViewType, Ranges[CurrentRange].ToTableRange(),
+                    SelfId(), ScanId, TableId, TablePath, SysViewInfo, Ranges[CurrentRange].ToTableRange(),
                     Columns, UserToken, Database, Reverse);
                 ScanActorId = Register(actor.Release());
                 CurrentRange += 1;
@@ -205,7 +205,7 @@ private:
     ui32 ScanId;
     TTableId TableId;
     TString TablePath;
-    const TMaybe<ESysViewType> SysViewType;
+    const TMaybe<NKikimrSysView::TSysViewDescription> SysViewInfo;
     TVector<TSerializedTableRange> Ranges;
     TVector<NMiniKQL::TKqpComputeContextBase::TColumn> Columns;
     const TIntrusiveConstPtr<NACLib::TUserToken> UserToken;
@@ -221,7 +221,7 @@ THolder<NActors::IActor> CreateSystemViewScan(
     ui32 scanId,
     const TTableId& tableId,
     const TString& tablePath,
-    const TMaybe<ESysViewType>& sysViewType,
+    const TMaybe<NKikimrSysView::TSysViewDescription>& sysViewInfo,
     TVector<TSerializedTableRange> ranges,
     const TArrayRef<NMiniKQL::TKqpComputeContextBase::TColumn>& columns,
     TIntrusiveConstPtr<NACLib::TUserToken> userToken,
@@ -229,10 +229,10 @@ THolder<NActors::IActor> CreateSystemViewScan(
     bool reverse
 ) {
     if (ranges.size() == 1) {
-        return CreateSystemViewScan(ownerId, scanId, tableId, tablePath, sysViewType, ranges[0].ToTableRange(),
+        return CreateSystemViewScan(ownerId, scanId, tableId, tablePath, sysViewInfo, ranges[0].ToTableRange(),
                                     columns, std::move(userToken), database, reverse);
     } else {
-        return MakeHolder<TSysViewRangesReader>(ownerId, scanId, tableId, tablePath, sysViewType, ranges,
+        return MakeHolder<TSysViewRangesReader>(ownerId, scanId, tableId, tablePath, sysViewInfo, ranges,
                                                 columns, std::move(userToken), database, reverse);
     }
 }
@@ -242,29 +242,30 @@ THolder<NActors::IActor> CreateSystemViewScan(
     ui32 scanId,
     const TTableId& tableId,
     const TString& tablePath,
-    const TMaybe<ESysViewType>& sysViewType,
+    const TMaybe<NKikimrSysView::TSysViewDescription>& sysViewInfo,
     const TTableRange& tableRange,
     const TArrayRef<NMiniKQL::TKqpComputeContextBase::TColumn>& columns,
     TIntrusiveConstPtr<NACLib::TUserToken> userToken,
     const TString& database,
     bool reverse
 ) {
-    ESysViewType systemViewType;
-    if (sysViewType) {
-        systemViewType = *sysViewType;
+    NKikimrSysView::TSysViewDescription sysViewDescription;
+    if (sysViewInfo) {
+        sysViewDescription = *sysViewInfo;
     } else {
         auto typesIt = SYS_VIEW_TYPES_MAP.find(tableId.SysViewInfo);
         Y_ABORT_UNLESS(typesIt != SYS_VIEW_TYPES_MAP.end());
-        systemViewType = typesIt->second;
+        sysViewDescription.SetType(typesIt->second);
+        *sysViewDescription.MutableSourceObject() = tableId.PathId.ToProto();
     }
 
-    switch (systemViewType) {
+    switch (sysViewDescription.GetType()) {
     case ESysViewType::EPartitionStats:
-        return CreatePartitionStatsScan(ownerId, scanId, tableId, tableRange, columns);
+        return CreatePartitionStatsScan(ownerId, scanId, sysViewDescription, tableRange, columns);
     case ESysViewType::ENodes:
-        return CreateNodesScan(ownerId, scanId, tableId, tableRange, columns);
+        return CreateNodesScan(ownerId, scanId, sysViewDescription, tableRange, columns);
     case ESysViewType::EQuerySessions:
-        return CreateSessionsScan(ownerId, scanId, tableId, tableRange, columns);
+        return CreateSessionsScan(ownerId, scanId, sysViewDescription, tableRange, columns);
     case ESysViewType::ETopQueriesByDurationOneMinute:
     case ESysViewType::ETopQueriesByDurationOneHour:
     case ESysViewType::ETopQueriesByReadBytesOneMinute:
@@ -273,52 +274,52 @@ THolder<NActors::IActor> CreateSystemViewScan(
     case ESysViewType::ETopQueriesByCpuTimeOneHour:
     case ESysViewType::ETopQueriesByRequestUnitsOneMinute:
     case ESysViewType::ETopQueriesByRequestUnitsOneHour:
-        return CreateQueryStatsScan(ownerId, scanId, tableId, systemViewType, tableRange, columns);
+        return CreateQueryStatsScan(ownerId, scanId, sysViewDescription, tableRange, columns);
     case ESysViewType::EPDisks:
-        return CreatePDisksScan(ownerId, scanId, tableId, tableRange, columns);
+        return CreatePDisksScan(ownerId, scanId, sysViewDescription, tableRange, columns);
     case ESysViewType::EVSlots:
-        return CreateVSlotsScan(ownerId, scanId, tableId, tableRange, columns);
+        return CreateVSlotsScan(ownerId, scanId, sysViewDescription, tableRange, columns);
     case ESysViewType::EGroups:
-        return CreateGroupsScan(ownerId, scanId, tableId, tableRange, columns);
+        return CreateGroupsScan(ownerId, scanId, sysViewDescription, tableRange, columns);
     case ESysViewType::EStoragePools:
-        return CreateStoragePoolsScan(ownerId, scanId, tableId, tableRange, columns);
+        return CreateStoragePoolsScan(ownerId, scanId, sysViewDescription, tableRange, columns);
     case ESysViewType::EStorageStats:
-        return CreateStorageStatsScan(ownerId, scanId, tableId, tableRange, columns);
+        return CreateStorageStatsScan(ownerId, scanId, sysViewDescription, tableRange, columns);
     case ESysViewType::ETablets:
-         return CreateTabletsScan(ownerId, scanId, tableId, tableRange, columns);
+         return CreateTabletsScan(ownerId, scanId, sysViewDescription, tableRange, columns);
     case ESysViewType::EQueryMetricsOneMinute:
-        return CreateQueryMetricsScan(ownerId, scanId, tableId, tableRange, columns);
+        return CreateQueryMetricsScan(ownerId, scanId, sysViewDescription, tableRange, columns);
     case ESysViewType::ETopPartitionsByCpuOneMinute:
     case ESysViewType::ETopPartitionsByCpuOneHour:
-        return CreateTopPartitionsByCpuScan(ownerId, scanId, tableId, systemViewType, tableRange, columns);
+        return CreateTopPartitionsByCpuScan(ownerId, scanId, sysViewDescription, tableRange, columns);
     case ESysViewType::ETopPartitionsByTliOneMinute:
     case ESysViewType::ETopPartitionsByTliOneHour:
-        return CreateTopPartitionsByTliScan(ownerId, scanId, tableId, systemViewType, tableRange, columns);
+        return CreateTopPartitionsByTliScan(ownerId, scanId, sysViewDescription, tableRange, columns);
     case ESysViewType::EPgTables:
-        return CreatePgTablesScan(ownerId, scanId, tableId, tablePath, tableRange, columns);
+        return CreatePgTablesScan(ownerId, scanId, sysViewDescription, tablePath, tableRange, columns);
     case ESysViewType::EInformationSchemaTables:
-        return CreateInformationSchemaTablesScan(ownerId, scanId, tableId, tablePath, tableRange, columns);
+        return CreateInformationSchemaTablesScan(ownerId, scanId, sysViewDescription, tablePath, tableRange, columns);
     case ESysViewType::EPgClass:
-        return CreatePgClassScan(ownerId, scanId, tableId, tablePath, tableRange, columns);
+        return CreatePgClassScan(ownerId, scanId, sysViewDescription, tablePath, tableRange, columns);
     case ESysViewType::EResourcePoolClassifiers:
-        return CreateResourcePoolClassifiersScan(ownerId, scanId, tableId, tableRange, columns,
+        return CreateResourcePoolClassifiersScan(ownerId, scanId, sysViewDescription, tableRange, columns,
                                                  std::move(userToken), database, reverse);
     case ESysViewType::EResourcePools:
-        return CreateResourcePoolsScan(ownerId, scanId, tableId, tableRange, columns, std::move(userToken), database, reverse);
+        return CreateResourcePoolsScan(ownerId, scanId, sysViewDescription, tableRange, columns, std::move(userToken), database, reverse);
     case ESysViewType::EAuthUsers:
-        return NAuth::CreateUsersScan(ownerId, scanId, tableId, tableRange, columns, std::move(userToken));
+        return NAuth::CreateUsersScan(ownerId, scanId, sysViewDescription, tableRange, columns, std::move(userToken));
     case ESysViewType::EAuthGroups:
-        return NAuth::CreateGroupsScan(ownerId, scanId, tableId, tableRange, columns, std::move(userToken));
+        return NAuth::CreateGroupsScan(ownerId, scanId, sysViewDescription, tableRange, columns, std::move(userToken));
     case ESysViewType::EAuthGroupMembers:
-        return NAuth::CreateGroupMembersScan(ownerId, scanId, tableId, tableRange, columns, std::move(userToken));
+        return NAuth::CreateGroupMembersScan(ownerId, scanId, sysViewDescription, tableRange, columns, std::move(userToken));
     case ESysViewType::EAuthOwners:
-        return NAuth::CreateOwnersScan(ownerId, scanId, tableId, tableRange, columns, std::move(userToken));
+        return NAuth::CreateOwnersScan(ownerId, scanId, sysViewDescription, tableRange, columns, std::move(userToken));
     case ESysViewType::EAuthPermissions:
     case ESysViewType::EAuthEffectivePermissions:
-        return NAuth::CreatePermissionsScan(systemViewType == ESysViewType::EAuthEffectivePermissions,
-                                            ownerId, scanId, tableId, tableRange, columns, std::move(userToken));
+        return NAuth::CreatePermissionsScan(sysViewDescription.GetType() == ESysViewType::EAuthEffectivePermissions,
+                                            ownerId, scanId, sysViewDescription, tableRange, columns, std::move(userToken));
     case ESysViewType::EShowCreate:
-        return CreateShowCreate(ownerId, scanId, tableId, tableRange, columns, database, std::move(userToken));
+        return CreateShowCreate(ownerId, scanId, sysViewDescription, tableRange, columns, database, std::move(userToken));
     default:
         return {};
     }

--- a/ydb/core/sys_view/scan.h
+++ b/ydb/core/sys_view/scan.h
@@ -9,12 +9,12 @@ namespace NKikimr {
 namespace NSysView {
 
 THolder<NActors::IActor> CreateSystemViewScan(const NActors::TActorId& ownerId, ui32 scanId, const TTableId& tableId,
-    const TString& tablePath, const TMaybe<NKikimrSysView::ESysViewType>& sysViewType, TVector<TSerializedTableRange> ranges,
+    const TString& tablePath, const TMaybe<NKikimrSysView::TSysViewDescription>& sysViewInfo, TVector<TSerializedTableRange> ranges,
     const TArrayRef<NMiniKQL::TKqpComputeContextBase::TColumn>& columns, TIntrusiveConstPtr<NACLib::TUserToken> userToken,
     const TString& database, bool reverse);
 
 THolder<NActors::IActor> CreateSystemViewScan(const NActors::TActorId& ownerId, ui32 scanId, const TTableId& tableId,
-    const TString& tablePath, const TMaybe<NKikimrSysView::ESysViewType>& sysViewType, const TTableRange& tableRange,
+    const TString& tablePath, const TMaybe<NKikimrSysView::TSysViewDescription>& sysViewInfo, const TTableRange& tableRange,
     const TArrayRef<NMiniKQL::TKqpComputeContextBase::TColumn>& columns, TIntrusiveConstPtr<NACLib::TUserToken> userToken,
     const TString& database, bool reverse);
 

--- a/ydb/core/sys_view/sessions/sessions.cpp
+++ b/ydb/core/sys_view/sessions/sessions.cpp
@@ -92,9 +92,10 @@ public:
         }
     };
 
-    TSessionsScan(const NActors::TActorId& ownerId, ui32 scanId, const TTableId& tableId,
+    TSessionsScan(const NActors::TActorId& ownerId, ui32 scanId,
+        const NKikimrSysView::TSysViewDescription& sysViewInfo,
         const TTableRange& tableRange, const TArrayRef<NMiniKQL::TKqpComputeContextBase::TColumn>& columns)
-        : TBase(ownerId, scanId, tableId, tableRange, columns)
+        : TBase(ownerId, scanId, sysViewInfo, tableRange, columns)
     {
         const auto& cellsFrom = TableRange.From.GetCells();
         if (cellsFrom.size() == 1 && !cellsFrom[0].IsNull()) {
@@ -294,10 +295,11 @@ private:
     NKikimrKqp::TEvListSessionsResponse LastResponse;
 };
 
-THolder<NActors::IActor> CreateSessionsScan(const NActors::TActorId& ownerId, ui32 scanId, const TTableId& tableId,
+THolder<NActors::IActor> CreateSessionsScan(const NActors::TActorId& ownerId, ui32 scanId,
+    const NKikimrSysView::TSysViewDescription& sysViewInfo,
     const TTableRange& tableRange, const TArrayRef<NMiniKQL::TKqpComputeContextBase::TColumn>& columns)
 {
-    return MakeHolder<TSessionsScan>(ownerId, scanId, tableId, tableRange, columns);
+    return MakeHolder<TSessionsScan>(ownerId, scanId, sysViewInfo, tableRange, columns);
 }
 
 } // NKikimr::NSysView

--- a/ydb/core/sys_view/sessions/sessions.h
+++ b/ydb/core/sys_view/sessions/sessions.h
@@ -2,14 +2,16 @@
 
 #include <ydb/core/kqp/runtime/kqp_compute.h>
 
+#include <ydb/core/protos/sys_view_types.pb.h>
 #include <ydb/library/actors/core/actor.h>
 #include <ydb/library/actors/core/actorid.h>
 
 namespace NKikimr {
 namespace NSysView {
 
-THolder<NActors::IActor> CreateSessionsScan(const NActors::TActorId& ownerId, ui32 scanId, const TTableId& tableId,
-    const TTableRange& tableRange, const TArrayRef<NMiniKQL::TKqpComputeContextBase::TColumn>& columns);
+THolder<NActors::IActor> CreateSessionsScan(const NActors::TActorId& ownerId, ui32 scanId,
+    const NKikimrSysView::TSysViewDescription& sysViewInfo, const TTableRange& tableRange,
+    const TArrayRef<NMiniKQL::TKqpComputeContextBase::TColumn>& columns);
 
 } // NSysView
 } // NKikimr

--- a/ydb/core/sys_view/show_create/show_create.cpp
+++ b/ydb/core/sys_view/show_create/show_create.cpp
@@ -58,10 +58,11 @@ public:
         return NKikimrServices::TActivity::KQP_SYSTEM_VIEW_SCAN;
     }
 
-    TShowCreate(const NActors::TActorId& ownerId, ui32 scanId, const TTableId& tableId,
+    TShowCreate(const NActors::TActorId& ownerId, ui32 scanId,
+        const NKikimrSysView::TSysViewDescription& sysViewInfo,
         const TTableRange& tableRange, const TArrayRef<NMiniKQL::TKqpComputeContextBase::TColumn>& columns,
         const TString& database, TIntrusiveConstPtr<NACLib::TUserToken> userToken)
-        : TBase(ownerId, scanId, tableId, tableRange, columns)
+        : TBase(ownerId, scanId, sysViewInfo, tableRange, columns)
         , Database(database)
         , UserToken(std::move(userToken))
     {
@@ -537,10 +538,13 @@ private:
 
 }
 
-THolder<NActors::IActor> CreateShowCreate(const NActors::TActorId& ownerId, ui32 scanId, const TTableId& tableId,
-    const TTableRange& tableRange, const TArrayRef<NMiniKQL::TKqpComputeContextBase::TColumn>& columns, const TString& database, TIntrusiveConstPtr<NACLib::TUserToken> userToken)
+THolder<NActors::IActor> CreateShowCreate(const NActors::TActorId& ownerId, ui32 scanId,
+    const NKikimrSysView::TSysViewDescription& sysViewInfo, const TTableRange& tableRange,
+    const TArrayRef<NMiniKQL::TKqpComputeContextBase::TColumn>& columns, const TString& database,
+    TIntrusiveConstPtr<NACLib::TUserToken> userToken)
 {
-    return MakeHolder<TShowCreate>(ownerId, scanId, tableId, tableRange, columns, database, std::move(userToken));
+    return MakeHolder<TShowCreate>(ownerId, scanId, sysViewInfo, tableRange, columns, database,
+        std::move(userToken));
 }
 
 } // NSysView

--- a/ydb/core/sys_view/show_create/show_create.h
+++ b/ydb/core/sys_view/show_create/show_create.h
@@ -2,14 +2,17 @@
 
 #include <ydb/core/kqp/runtime/kqp_compute.h>
 
+#include <ydb/core/protos/sys_view_types.pb.h>
 #include <ydb/library/actors/core/actor.h>
 #include <ydb/library/actors/core/actorid.h>
 
 namespace NKikimr {
 namespace NSysView {
 
-THolder<NActors::IActor> CreateShowCreate(const NActors::TActorId& ownerId, ui32 scanId, const TTableId& tableId,
-    const TTableRange& tableRange, const TArrayRef<NMiniKQL::TKqpComputeContextBase::TColumn>& columns, const TString& database, TIntrusiveConstPtr<NACLib::TUserToken> userToken);
+THolder<NActors::IActor> CreateShowCreate(const NActors::TActorId& ownerId, ui32 scanId,
+    const NKikimrSysView::TSysViewDescription& sysViewInfo, const TTableRange& tableRange,
+    const TArrayRef<NMiniKQL::TKqpComputeContextBase::TColumn>& columns, const TString& database,
+    TIntrusiveConstPtr<NACLib::TUserToken> userToken);
 
 } // NSysView
 } // NKikimr

--- a/ydb/core/sys_view/storage/groups.cpp
+++ b/ydb/core/sys_view/storage/groups.cpp
@@ -44,10 +44,11 @@ public:
     }
 
 };
-THolder<NActors::IActor> CreateGroupsScan(const NActors::TActorId& ownerId, ui32 scanId, const TTableId& tableId,
-    const TTableRange& tableRange, const TArrayRef<NMiniKQL::TKqpComputeContextBase::TColumn>& columns)
+THolder<NActors::IActor> CreateGroupsScan(const NActors::TActorId& ownerId, ui32 scanId,
+    const NKikimrSysView::TSysViewDescription& sysViewInfo, const TTableRange& tableRange,
+    const TArrayRef<NMiniKQL::TKqpComputeContextBase::TColumn>& columns)
 {
-    return MakeHolder<TGroupsScan>(ownerId, scanId, tableId, tableRange, columns);
+    return MakeHolder<TGroupsScan>(ownerId, scanId, sysViewInfo, tableRange, columns);
 }
 
 } // NKikimr::NSysView

--- a/ydb/core/sys_view/storage/groups.h
+++ b/ydb/core/sys_view/storage/groups.h
@@ -2,14 +2,16 @@
 
 #include <ydb/core/kqp/runtime/kqp_compute.h>
 
+#include <ydb/core/protos/sys_view_types.pb.h>
 #include <ydb/library/actors/core/actor.h>
 #include <ydb/library/actors/core/actorid.h>
 
 namespace NKikimr {
 namespace NSysView {
 
-THolder<NActors::IActor> CreateGroupsScan(const NActors::TActorId& ownerId, ui32 scanId, const TTableId& tableId,
-    const TTableRange& tableRange, const TArrayRef<NMiniKQL::TKqpComputeContextBase::TColumn>& columns);
+THolder<NActors::IActor> CreateGroupsScan(const NActors::TActorId& ownerId, ui32 scanId,
+    const NKikimrSysView::TSysViewDescription& sysViewInfo, const TTableRange& tableRange,
+    const TArrayRef<NMiniKQL::TKqpComputeContextBase::TColumn>& columns);
 
 } // NSysView
 } // NKikimr

--- a/ydb/core/sys_view/storage/pdisks.cpp
+++ b/ydb/core/sys_view/storage/pdisks.cpp
@@ -46,10 +46,11 @@ public:
     }
 };
 
-THolder<NActors::IActor> CreatePDisksScan(const NActors::TActorId& ownerId, ui32 scanId, const TTableId& tableId,
-    const TTableRange& tableRange, const TArrayRef<NMiniKQL::TKqpComputeContextBase::TColumn>& columns)
+THolder<NActors::IActor> CreatePDisksScan(const NActors::TActorId& ownerId, ui32 scanId,
+    const NKikimrSysView::TSysViewDescription& sysViewInfo, const TTableRange& tableRange,
+    const TArrayRef<NMiniKQL::TKqpComputeContextBase::TColumn>& columns)
 {
-    return MakeHolder<TPDisksScan>(ownerId, scanId, tableId, tableRange, columns);
+    return MakeHolder<TPDisksScan>(ownerId, scanId, sysViewInfo, tableRange, columns);
 }
 
 } // NKikimr::NSysView

--- a/ydb/core/sys_view/storage/pdisks.h
+++ b/ydb/core/sys_view/storage/pdisks.h
@@ -2,14 +2,16 @@
 
 #include <ydb/core/kqp/runtime/kqp_compute.h>
 
+#include <ydb/core/protos/sys_view_types.pb.h>
 #include <ydb/library/actors/core/actor.h>
 #include <ydb/library/actors/core/actorid.h>
 
 namespace NKikimr {
 namespace NSysView {
 
-THolder<NActors::IActor> CreatePDisksScan(const NActors::TActorId& ownerId, ui32 scanId, const TTableId& tableId,
-    const TTableRange& tableRange, const TArrayRef<NMiniKQL::TKqpComputeContextBase::TColumn>& columns);
+THolder<NActors::IActor> CreatePDisksScan(const NActors::TActorId& ownerId, ui32 scanId,
+    const NKikimrSysView::TSysViewDescription& sysViewInfo, const TTableRange& tableRange,
+    const TArrayRef<NMiniKQL::TKqpComputeContextBase::TColumn>& columns);
 
 } // NSysView
 } // NKikimr

--- a/ydb/core/sys_view/storage/storage_pools.cpp
+++ b/ydb/core/sys_view/storage/storage_pools.cpp
@@ -40,10 +40,11 @@ public:
     }
 };
 
-THolder<NActors::IActor> CreateStoragePoolsScan(const NActors::TActorId& ownerId, ui32 scanId, const TTableId& tableId,
-    const TTableRange& tableRange, const TArrayRef<NMiniKQL::TKqpComputeContextBase::TColumn>& columns)
+THolder<NActors::IActor> CreateStoragePoolsScan(const NActors::TActorId& ownerId, ui32 scanId,
+    const NKikimrSysView::TSysViewDescription& sysViewInfo, const TTableRange& tableRange,
+    const TArrayRef<NMiniKQL::TKqpComputeContextBase::TColumn>& columns)
 {
-    return MakeHolder<TStoragePoolsScan>(ownerId, scanId, tableId, tableRange, columns);
+    return MakeHolder<TStoragePoolsScan>(ownerId, scanId, sysViewInfo, tableRange, columns);
 }
 
 } // NKikimr::NSysView

--- a/ydb/core/sys_view/storage/storage_pools.h
+++ b/ydb/core/sys_view/storage/storage_pools.h
@@ -2,14 +2,16 @@
 
 #include <ydb/core/kqp/runtime/kqp_compute.h>
 
+#include <ydb/core/protos/sys_view_types.pb.h>
 #include <ydb/library/actors/core/actor.h>
 #include <ydb/library/actors/core/actorid.h>
 
 namespace NKikimr {
 namespace NSysView {
 
-THolder<NActors::IActor> CreateStoragePoolsScan(const NActors::TActorId& ownerId, ui32 scanId, const TTableId& tableId,
-    const TTableRange& tableRange, const TArrayRef<NMiniKQL::TKqpComputeContextBase::TColumn>& columns);
+THolder<NActors::IActor> CreateStoragePoolsScan(const NActors::TActorId& ownerId, ui32 scanId,
+    const NKikimrSysView::TSysViewDescription& sysViewInfo, const TTableRange& tableRange,
+    const TArrayRef<NMiniKQL::TKqpComputeContextBase::TColumn>& columns);
 
 } // NSysView
 } // NKikimr

--- a/ydb/core/sys_view/storage/storage_stats.cpp
+++ b/ydb/core/sys_view/storage/storage_stats.cpp
@@ -29,10 +29,11 @@ public:
     }
 };
 
-THolder<NActors::IActor> CreateStorageStatsScan(const NActors::TActorId& ownerId, ui32 scanId, const TTableId& tableId,
-    const TTableRange& tableRange, const TArrayRef<NMiniKQL::TKqpComputeContextBase::TColumn>& columns)
+THolder<NActors::IActor> CreateStorageStatsScan(const NActors::TActorId& ownerId, ui32 scanId,
+    const NKikimrSysView::TSysViewDescription& sysViewInfo, const TTableRange& tableRange,
+    const TArrayRef<NMiniKQL::TKqpComputeContextBase::TColumn>& columns)
 {
-    return MakeHolder<TStorageStatsScan>(ownerId, scanId, tableId, tableRange, columns);
+    return MakeHolder<TStorageStatsScan>(ownerId, scanId, sysViewInfo, tableRange, columns);
 }
 
 } // NKikimr::NSysView

--- a/ydb/core/sys_view/storage/storage_stats.h
+++ b/ydb/core/sys_view/storage/storage_stats.h
@@ -2,12 +2,14 @@
 
 #include <ydb/core/kqp/runtime/kqp_compute.h>
 
+#include <ydb/core/protos/sys_view_types.pb.h>
 #include <ydb/library/actors/core/actor.h>
 #include <ydb/library/actors/core/actorid.h>
 
 namespace NKikimr::NSysView {
 
-THolder<NActors::IActor> CreateStorageStatsScan(const NActors::TActorId& ownerId, ui32 scanId, const TTableId& tableId,
-    const TTableRange& tableRange, const TArrayRef<NMiniKQL::TKqpComputeContextBase::TColumn>& columns);
+THolder<NActors::IActor> CreateStorageStatsScan(const NActors::TActorId& ownerId, ui32 scanId,
+    const NKikimrSysView::TSysViewDescription& sysViewInfo, const TTableRange& tableRange,
+    const TArrayRef<NMiniKQL::TKqpComputeContextBase::TColumn>& columns);
 
 } // NKikimr::NSysView

--- a/ydb/core/sys_view/storage/vslots.cpp
+++ b/ydb/core/sys_view/storage/vslots.cpp
@@ -45,10 +45,11 @@ public:
     }
 };
 
-THolder<NActors::IActor> CreateVSlotsScan(const NActors::TActorId& ownerId, ui32 scanId, const TTableId& tableId,
-    const TTableRange& tableRange, const TArrayRef<NMiniKQL::TKqpComputeContextBase::TColumn>& columns)
+THolder<NActors::IActor> CreateVSlotsScan(const NActors::TActorId& ownerId, ui32 scanId,
+    const NKikimrSysView::TSysViewDescription& sysViewInfo, const TTableRange& tableRange,
+    const TArrayRef<NMiniKQL::TKqpComputeContextBase::TColumn>& columns)
 {
-    return MakeHolder<TVSlotsScan>(ownerId, scanId, tableId, tableRange, columns);
+    return MakeHolder<TVSlotsScan>(ownerId, scanId, sysViewInfo, tableRange, columns);
 }
 
 } // NKikimr::NSysView

--- a/ydb/core/sys_view/storage/vslots.h
+++ b/ydb/core/sys_view/storage/vslots.h
@@ -2,14 +2,16 @@
 
 #include <ydb/core/kqp/runtime/kqp_compute.h>
 
+#include <ydb/core/protos/sys_view_types.pb.h>
 #include <ydb/library/actors/core/actor.h>
 #include <ydb/library/actors/core/actorid.h>
 
 namespace NKikimr {
 namespace NSysView {
 
-THolder<NActors::IActor> CreateVSlotsScan(const NActors::TActorId& ownerId, ui32 scanId, const TTableId& tableId,
-    const TTableRange& tableRange, const TArrayRef<NMiniKQL::TKqpComputeContextBase::TColumn>& columns);
+THolder<NActors::IActor> CreateVSlotsScan(const NActors::TActorId& ownerId, ui32 scanId,
+    const NKikimrSysView::TSysViewDescription& sysViewInfo, const TTableRange& tableRange,
+    const TArrayRef<NMiniKQL::TKqpComputeContextBase::TColumn>& columns);
 
 } // NSysView
 } // NKikimr

--- a/ydb/core/sys_view/tablets/tablets.cpp
+++ b/ydb/core/sys_view/tablets/tablets.cpp
@@ -23,9 +23,10 @@ public:
         return NKikimrServices::TActivity::KQP_SYSTEM_VIEW_SCAN;
     }
 
-    TTabletsScan(const NActors::TActorId& ownerId, ui32 scanId, const TTableId& tableId,
+    TTabletsScan(const NActors::TActorId& ownerId, ui32 scanId,
+        const NKikimrSysView::TSysViewDescription& sysViewInfo,
         const TTableRange& tableRange, const TArrayRef<NMiniKQL::TKqpComputeContextBase::TColumn>& columns)
-        : TBase(ownerId, scanId, tableId, tableRange, columns)
+        : TBase(ownerId, scanId, sysViewInfo, tableRange, columns)
     {
     }
 
@@ -352,10 +353,11 @@ private:
     bool BatchRequested = false;
 };
 
-THolder<NActors::IActor> CreateTabletsScan(const NActors::TActorId& ownerId, ui32 scanId, const TTableId& tableId,
-    const TTableRange& tableRange, const TArrayRef<NMiniKQL::TKqpComputeContextBase::TColumn>& columns)
+THolder<NActors::IActor> CreateTabletsScan(const NActors::TActorId& ownerId, ui32 scanId,
+    const NKikimrSysView::TSysViewDescription& sysViewInfo, const TTableRange& tableRange,
+    const TArrayRef<NMiniKQL::TKqpComputeContextBase::TColumn>& columns)
 {
-    return MakeHolder<TTabletsScan>(ownerId, scanId, tableId, tableRange, columns);
+    return MakeHolder<TTabletsScan>(ownerId, scanId, sysViewInfo, tableRange, columns);
 }
 
 } // NKikimr::NSysView

--- a/ydb/core/sys_view/tablets/tablets.h
+++ b/ydb/core/sys_view/tablets/tablets.h
@@ -2,13 +2,15 @@
 
 #include <ydb/core/kqp/runtime/kqp_compute.h>
 
+#include <ydb/core/protos/sys_view_types.pb.h>
 #include <ydb/library/actors/core/actor.h>
 
 namespace NKikimr {
 namespace NSysView {
 
-THolder<NActors::IActor> CreateTabletsScan(const NActors::TActorId& ownerId, ui32 scanId, const TTableId& tableId,
-    const TTableRange& tableRange, const TArrayRef<NMiniKQL::TKqpComputeContextBase::TColumn>& columns);
+THolder<NActors::IActor> CreateTabletsScan(const NActors::TActorId& ownerId, ui32 scanId,
+    const NKikimrSysView::TSysViewDescription& sysViewInfo, const TTableRange& tableRange,
+    const TArrayRef<NMiniKQL::TKqpComputeContextBase::TColumn>& columns);
 
 } // NSysView
 } // NKikimr

--- a/ydb/core/tx/schemeshard/schemeshard_path_describer.cpp
+++ b/ydb/core/tx/schemeshard/schemeshard_path_describer.cpp
@@ -1123,9 +1123,13 @@ void TPathDescriber::DescribeSysView(const TActorContext&, TPathId pathId, TPath
     Y_ABORT_UNLESS(it, "SysView is not found");
     TSysViewInfo::TPtr sysViewInfo = *it;
 
+    const TPath sysViewPath = TPath::Init(pathId, Self);
+    const TPath sourceObjectPath = sysViewPath.Parent().Parent();
+
     auto entry = Result->Record.MutablePathDescription()->MutableSysViewDescription();
     entry->SetName(pathEl->Name);
     entry->SetType(sysViewInfo->Type);
+    sourceObjectPath.GetPathIdForDomain().ToProto(entry->MutableSourceObject());
 }
 
 static bool ConsiderAsDropped(const TPath& path) {

--- a/ydb/core/tx/schemeshard/ut_sysview/ut_sysview.cpp
+++ b/ydb/core/tx/schemeshard/ut_sysview/ut_sysview.cpp
@@ -11,13 +11,14 @@ namespace {
     using NKikimrSysView::ESysViewType;
 
     void ExpectEqualSysViewDescription(const NKikimrScheme::TEvDescribeSchemeResult& describeResult,
-                                       const TString& sysViewName,
-                                       const ESysViewType sysViewType) {
+        const TString& sysViewName, const ESysViewType sysViewType, const TPathId& sourceObjectPathId)
+    {
         UNIT_ASSERT(describeResult.HasPathDescription());
         UNIT_ASSERT(describeResult.GetPathDescription().HasSysViewDescription());
         const auto& sysViewDescription = describeResult.GetPathDescription().GetSysViewDescription();
         UNIT_ASSERT_VALUES_EQUAL(sysViewDescription.GetName(), sysViewName);
         UNIT_ASSERT(sysViewDescription.GetType() == sysViewType);
+        UNIT_ASSERT_VALUES_EQUAL(TPathId::FromProto(sysViewDescription.GetSourceObject()), sourceObjectPathId);
     }
 
     class TSysDirCreateGuard : public TNonCopyable {
@@ -51,8 +52,10 @@ Y_UNIT_TEST_SUITE(TSchemeShardSysViewTest) {
 
         {
             const auto describeResult = DescribePath(runtime, "/MyRoot/.sys/new_sys_view");
+            const auto& sysViewPath = describeResult.GetPathDescription().GetSelf();
+            const auto domainPathId = TPathId(sysViewPath.GetSchemeshardId(), 1);
             TestDescribeResult(describeResult, {NLs::Finished, NLs::IsSysView});
-            ExpectEqualSysViewDescription(describeResult, "new_sys_view", ESysViewType::EPartitionStats);
+            ExpectEqualSysViewDescription(describeResult, "new_sys_view", ESysViewType::EPartitionStats, domainPathId);
         }
 
         TActorId sender = runtime.AllocateEdgeActor();
@@ -60,8 +63,10 @@ Y_UNIT_TEST_SUITE(TSchemeShardSysViewTest) {
 
         {
             const auto describeResult = DescribePath(runtime, "/MyRoot/.sys/new_sys_view");
+            const auto& sysViewPath = describeResult.GetPathDescription().GetSelf();
+            const auto domainPathId = TPathId(sysViewPath.GetSchemeshardId(), 1);
             TestDescribeResult(describeResult, {NLs::Finished, NLs::IsSysView});
-            ExpectEqualSysViewDescription(describeResult, "new_sys_view", ESysViewType::EPartitionStats);
+            ExpectEqualSysViewDescription(describeResult, "new_sys_view", ESysViewType::EPartitionStats, domainPathId);
         }
     }
 
@@ -115,8 +120,10 @@ Y_UNIT_TEST_SUITE(TSchemeShardSysViewTest) {
                           {EStatus::StatusSchemeError, EStatus::StatusAlreadyExists});
         env.TestWaitNotification(runtime, txId);
         const auto describeResult = DescribePath(runtime, "/MyRoot/.sys/new_sys_view");
+        const auto& sysViewPath = describeResult.GetPathDescription().GetSelf();
+        const auto domainPathId = TPathId(sysViewPath.GetSchemeshardId(), 1);
         TestDescribeResult(describeResult, {NLs::Finished, NLs::IsSysView});
-        ExpectEqualSysViewDescription(describeResult, "new_sys_view", ESysViewType::EPartitionStats);
+        ExpectEqualSysViewDescription(describeResult, "new_sys_view", ESysViewType::EPartitionStats, domainPathId);
     }
 
     Y_UNIT_TEST(AsyncCreateDifferentSysViews) {
@@ -145,13 +152,17 @@ Y_UNIT_TEST_SUITE(TSchemeShardSysViewTest) {
 
         {
             const auto describeResult = DescribePath(runtime, "/MyRoot/.sys/sys_view_1");
+            const auto& sysViewPath = describeResult.GetPathDescription().GetSelf();
+            const auto domainPathId = TPathId(sysViewPath.GetSchemeshardId(), 1);
             TestDescribeResult(describeResult, {NLs::Finished, NLs::IsSysView});
-            ExpectEqualSysViewDescription(describeResult, "sys_view_1", ESysViewType::EPartitionStats);
+            ExpectEqualSysViewDescription(describeResult, "sys_view_1", ESysViewType::EPartitionStats, domainPathId);
         }
         {
             const auto describeResult = DescribePath(runtime, "/MyRoot/.sys/sys_view_2");
+            const auto& sysViewPath = describeResult.GetPathDescription().GetSelf();
+            const auto domainPathId = TPathId(sysViewPath.GetSchemeshardId(), 1);
             TestDescribeResult(describeResult, {NLs::Finished, NLs::IsSysView});
-            ExpectEqualSysViewDescription(describeResult, "sys_view_2", ESysViewType::ENodes);
+            ExpectEqualSysViewDescription(describeResult, "sys_view_2", ESysViewType::ENodes, domainPathId);
         }
     }
 
@@ -175,8 +186,10 @@ Y_UNIT_TEST_SUITE(TSchemeShardSysViewTest) {
         TestDescribeResult(DescribePath(runtime, "/MyRoot/.sys"), {NLs::Finished});
 
         const auto describeResult = DescribePath(runtime, "/MyRoot/.sys/new_sys_view");
+        const auto& sysViewPath = describeResult.GetPathDescription().GetSelf();
+        const auto domainPathId = TPathId(sysViewPath.GetSchemeshardId(), 1);
         TestDescribeResult(describeResult, {NLs::Finished, NLs::IsSysView});
-        ExpectEqualSysViewDescription(describeResult, "new_sys_view", ESysViewType::EPartitionStats);
+        ExpectEqualSysViewDescription(describeResult, "new_sys_view", ESysViewType::EPartitionStats, domainPathId);
     }
 
     Y_UNIT_TEST(AsyncCreateSameSysView) {
@@ -206,8 +219,10 @@ Y_UNIT_TEST_SUITE(TSchemeShardSysViewTest) {
         env.TestWaitNotification(runtime, {txId - 1, txId});
 
         const auto describeResult = DescribePath(runtime, "/MyRoot/.sys/new_sys_view");
+        const auto& sysViewPath = describeResult.GetPathDescription().GetSelf();
+        const auto domainPathId = TPathId(sysViewPath.GetSchemeshardId(), 1);
         TestDescribeResult(describeResult, {NLs::Finished, NLs::IsSysView});
-        ExpectEqualSysViewDescription(describeResult, "new_sys_view", ESysViewType::EPartitionStats);
+        ExpectEqualSysViewDescription(describeResult, "new_sys_view", ESysViewType::EPartitionStats, domainPathId);
     }
 
     Y_UNIT_TEST(AsyncDropSameSysView) {


### PR DESCRIPTION
Add-on PR for support materialized sys view paths in KQP.
To generate data for some sys views we have to know info about domain/subdomain that they belong to.
Virtual sys views contain PathId of their parent domain/subdomain in TableId, but materialized sys views don't.
To unify different approaches let's set a described object Id in SchemeShard Describe response and then pass through the pipeline.
