### PR TITLE
Unify scan data bytes accounting with KQP in vector index build

### DIFF
--- a/ydb/core/tx/datashard/buffer_data.h
+++ b/ydb/core/tx/datashard/buffer_data.h
@@ -38,10 +38,16 @@ public:
         LastKey = {};
     }
 
-    void AddRow(TSerializedCellVec&& rowKey, TString&& rowValue, TSerializedCellVec&& originalKey = {}) {
-        Rows->emplace_back(std::move(rowKey), std::move(rowValue));
+    void AddRow(TConstArrayRef<TCell> rowKey, TConstArrayRef<TCell> rowValue, TConstArrayRef<TCell> originalKey = {}) {
+        AddRow(rowKey, rowValue, TSerializedCellVec::Serialize(rowValue), originalKey);
+    }
+
+    void AddRow(TConstArrayRef<TCell> rowKey, TConstArrayRef<TCell> rowValue, TString&& rowValueSerialized,  TConstArrayRef<TCell> originalKey = {}) {
+        Y_UNUSED(rowValue);
+
+        Rows->emplace_back(TSerializedCellVec{rowKey}, std::move(rowValueSerialized));
         ByteSize += Rows->back().first.GetBuffer().size() + Rows->back().second.size();
-        LastKey = std::move(originalKey);
+        LastKey = TSerializedCellVec{originalKey};
     }
 
     bool IsEmpty() const {

--- a/ydb/core/tx/datashard/buffer_data.h
+++ b/ydb/core/tx/datashard/buffer_data.h
@@ -60,7 +60,7 @@ public:
         LastKey = TSerializedCellVec{originalKey};
     }
 
-    bool HasReachedLimits(const TIndexBuildScanSettings& scanSettings) {
+    bool HasReachedLimits(const TIndexBuildScanSettings& scanSettings) const {
         return Rows->size() > scanSettings.GetMaxBatchRows() || BufferBytes > scanSettings.GetMaxBatchBytes();
     }
 

--- a/ydb/core/tx/datashard/buffer_data.h
+++ b/ydb/core/tx/datashard/buffer_data.h
@@ -1,40 +1,51 @@
 #pragma once
 
-#include "ydb/core/scheme/scheme_tablecell.h"
-#include "ydb/core/tx/datashard/upload_stats.h"
-#include "ydb/core/tx/tx_proxy/upload_rows.h"
+#include "scan_common.h"
+#include <ydb/core/scheme/scheme_tablecell.h>
+#include <ydb/core/tx/tx_proxy/upload_rows.h>
 
 namespace NKikimr::NDataShard {
 
-class TBufferData: public IStatHolder, public TNonCopyable {
+// TODO: move to tx/datashard/build_index/
+class TBufferData: public TNonCopyable {
 public:
     TBufferData()
         : Rows{std::make_shared<NTxProxy::TUploadRows>()} {
-    }
-
-    ui64 GetRows() const override final {
-        return Rows->size();
     }
 
     std::shared_ptr<NTxProxy::TUploadRows> GetRowsData() const {
         return Rows;
     }
 
-    ui64 GetBytes() const override final {
-        return ByteSize;
+    ui64 GetRows() const {
+        return Rows->size();
+    }
+
+    bool IsEmpty() const {
+        return Rows->empty();
+    }
+
+    ui64 GetBufferBytes() const {
+        return BufferBytes;
+    }
+
+    ui64 GetRowCellBytes() const {
+        return RowCellBytes;
     }
 
     void FlushTo(TBufferData& other) {
         Y_ENSURE(this != &other);
         Y_ENSURE(other.IsEmpty());
         other.Rows.swap(Rows);
-        other.ByteSize = std::exchange(ByteSize, 0);
+        other.BufferBytes = std::exchange(BufferBytes, 0);
+        other.RowCellBytes = std::exchange(RowCellBytes, 0);
         other.LastKey = std::exchange(LastKey, {});
     }
 
     void Clear() {
         Rows->clear();
-        ByteSize = 0;
+        BufferBytes = 0;
+        RowCellBytes = 0;
         LastKey = {};
     }
 
@@ -43,23 +54,14 @@ public:
     }
 
     void AddRow(TConstArrayRef<TCell> rowKey, TConstArrayRef<TCell> rowValue, TString&& rowValueSerialized,  TConstArrayRef<TCell> originalKey = {}) {
-        Y_UNUSED(rowValue);
-
+        RowCellBytes += CountRowCellBytes(rowKey, rowValue);
         Rows->emplace_back(TSerializedCellVec{rowKey}, std::move(rowValueSerialized));
-        ByteSize += Rows->back().first.GetBuffer().size() + Rows->back().second.size();
+        BufferBytes += Rows->back().first.GetBuffer().size() + Rows->back().second.size();
         LastKey = TSerializedCellVec{originalKey};
     }
 
-    bool IsEmpty() const {
-        return Rows->empty();
-    }
-
-    size_t Size() const {
-        return Rows->size();
-    }
-
-    bool HasReachedLimits(size_t rowsLimit, ui64 bytesLimit) const {
-        return Rows->size() > rowsLimit || ByteSize > bytesLimit;
+    bool HasReachedLimits(const TIndexBuildScanSettings& scanSettings) {
+        return Rows->size() > scanSettings.GetMaxBatchRows() || BufferBytes > scanSettings.GetMaxBatchBytes();
     }
 
     auto&& ExtractLastKey() {
@@ -72,7 +74,8 @@ public:
 
 private:
     std::shared_ptr<NTxProxy::TUploadRows> Rows;
-    ui64 ByteSize = 0;
+    ui64 BufferBytes = 0;
+    ui64 RowCellBytes = 0;
     TSerializedCellVec LastKey;
 };
 

--- a/ydb/core/tx/datashard/build_index/kmeans_helper.cpp
+++ b/ydb/core/tx/datashard/build_index/kmeans_helper.cpp
@@ -42,7 +42,7 @@ void AddRowToLevel(TBufferData& buffer, TClusterId parent, TClusterId child, con
     std::array<TCell, 1> data;
     data[0] = TCell{embedding};
 
-    buffer.AddRow(TSerializedCellVec{pk}, TSerializedCellVec::Serialize(data));
+    buffer.AddRow(pk, data);
 }
 
 void AddRowToData(TBufferData& buffer, TClusterId parent, TArrayRef<const TCell> sourcePk,
@@ -53,14 +53,11 @@ void AddRowToData(TBufferData& buffer, TClusterId parent, TArrayRef<const TCell>
         EnsureNoPostingParentFlag(parent);
     }
 
-    std::array<TCell, 1> cells;
-    cells[0] = TCell::Make(parent);
-    auto pk = TSerializedCellVec::Serialize(cells);
-    TSerializedCellVec::UnsafeAppendCells(sourcePk, pk);
+    TVector<TCell> pk(::Reserve(sourcePk.size() + 1));
+    pk.push_back(TCell::Make(parent));
+    pk.insert(pk.end(), sourcePk.begin(), sourcePk.end());
 
-    buffer.AddRow(TSerializedCellVec{std::move(pk)},
-        TSerializedCellVec::Serialize(dataColumns),
-        TSerializedCellVec{origKey});
+    buffer.AddRow(pk, dataColumns, origKey);
 }
 
 TTags MakeScanTags(const TUserTable& table, const TProtoStringType& embedding, 

--- a/ydb/core/tx/datashard/build_index/local_kmeans.cpp
+++ b/ydb/core/tx/datashard/build_index/local_kmeans.cpp
@@ -226,7 +226,7 @@ public:
         // LOG_T("Feed " << Debug());
 
         ++ReadRows;
-        ReadBytes += CountBytes(key, row);
+        ReadBytes += CountRowCellBytes(key, *row);
 
         if (PrefixColumns && Prefix && !TCellVectorsEquals{}(Prefix.GetCells(), key.subspan(0, PrefixColumns))) {
             if (!FinishPrefix()) {
@@ -244,7 +244,7 @@ public:
 
         if (IsFirstPrefixFeed && IsPrefixRowsValid) {
             PrefixRows.AddRow(key, *row);
-            if (HasReachedLimits(PrefixRows, ScanSettings)) {
+            if (PrefixRows.HasReachedLimits(ScanSettings)) {
                 PrefixRows.Clear();
                 IsPrefixRowsValid = false;
             }
@@ -339,7 +339,7 @@ protected:
             IsFirstPrefixFeed = false;
 
             if (IsPrefixRowsValid) {
-                LOG_T("FinishPrefix not finished, manually feeding " << PrefixRows.Size() << " saved rows " << Debug());
+                LOG_T("FinishPrefix not finished, manually feeding " << PrefixRows.GetRows() << " saved rows " << Debug());
                 for (ui64 iteration = 0; ; iteration++) {
                     for (const auto& [key, row_] : *PrefixRows.GetRowsData()) {
                         TSerializedCellVec row(row_);

--- a/ydb/core/tx/datashard/build_index/local_kmeans.cpp
+++ b/ydb/core/tx/datashard/build_index/local_kmeans.cpp
@@ -243,7 +243,7 @@ public:
         }
 
         if (IsFirstPrefixFeed && IsPrefixRowsValid) {
-            PrefixRows.AddRow(TSerializedCellVec{key}, TSerializedCellVec::Serialize(*row));
+            PrefixRows.AddRow(key, *row);
             if (HasReachedLimits(PrefixRows, ScanSettings)) {
                 PrefixRows.Clear();
                 IsPrefixRowsValid = false;

--- a/ydb/core/tx/datashard/build_index/prefix_kmeans.cpp
+++ b/ydb/core/tx/datashard/build_index/prefix_kmeans.cpp
@@ -259,7 +259,7 @@ public:
         // LOG_T("Feed " << Debug());
 
         ++ReadRows;
-        ReadBytes += CountBytes(key, row);
+        ReadBytes += CountRowCellBytes(key, *row);
 
         if (Prefix && !TCellVectorsEquals{}(Prefix.GetCells(), key.subspan(0, PrefixColumns))) {
             if (!FinishPrefix()) {
@@ -281,7 +281,7 @@ public:
 
         if (IsFirstPrefixFeed && IsPrefixRowsValid) {
             PrefixRows.AddRow(key, *row);
-            if (HasReachedLimits(PrefixRows, ScanSettings)) {
+            if (PrefixRows.HasReachedLimits(ScanSettings)) {
                 PrefixRows.Clear();
                 IsPrefixRowsValid = false;
             }
@@ -385,7 +385,7 @@ protected:
             IsFirstPrefixFeed = false;
 
             if (IsPrefixRowsValid) {
-                LOG_T("FinishPrefix not finished, manually feeding " << PrefixRows.Size() << " saved rows " << Debug());
+                LOG_T("FinishPrefix not finished, manually feeding " << PrefixRows.GetRows() << " saved rows " << Debug());
                 for (ui64 iteration = 0; ; iteration++) {
                     for (const auto& [key, row_] : *PrefixRows.GetRowsData()) {
                         TSerializedCellVec row(row_);

--- a/ydb/core/tx/datashard/build_index/prefix_kmeans.cpp
+++ b/ydb/core/tx/datashard/build_index/prefix_kmeans.cpp
@@ -272,15 +272,15 @@ public:
             Prefix = TSerializedCellVec{key.subspan(0, PrefixColumns)};
 
             // write {Prefix..., Parent} row to PrefixBuf:
-            auto pk = TSerializedCellVec::Serialize(Prefix.GetCells());
-            std::array<TCell, 1> cells;
-            cells[0] = TCell::Make(Parent);
-            TSerializedCellVec::UnsafeAppendCells(cells, pk);
-            PrefixBuf->AddRow(TSerializedCellVec{std::move(pk)}, TSerializedCellVec::Serialize({}));
+            TVector<TCell> pk(::Reserve(Prefix.GetCells().size() + 1));
+            pk.insert(pk.end(), Prefix.GetCells().begin(), Prefix.GetCells().end());
+            pk.push_back(TCell::Make(Parent));
+
+            PrefixBuf->AddRow(pk, {});
         }
 
         if (IsFirstPrefixFeed && IsPrefixRowsValid) {
-            PrefixRows.AddRow(TSerializedCellVec{key}, TSerializedCellVec::Serialize(*row));
+            PrefixRows.AddRow(key, *row);
             if (HasReachedLimits(PrefixRows, ScanSettings)) {
                 PrefixRows.Clear();
                 IsPrefixRowsValid = false;

--- a/ydb/core/tx/datashard/build_index/reshuffle_kmeans.cpp
+++ b/ydb/core/tx/datashard/build_index/reshuffle_kmeans.cpp
@@ -200,7 +200,7 @@ public:
         // LOG_T("Feed " << Debug());
 
         ++ReadRows;
-        ReadBytes += CountBytes(key, row);
+        ReadBytes += CountRowCellBytes(key, *row);
 
         Feed(key, *row);
 

--- a/ydb/core/tx/datashard/build_index/sample_k.cpp
+++ b/ydb/core/tx/datashard/build_index/sample_k.cpp
@@ -125,7 +125,7 @@ public:
         // LOG_T("Feed " << Debug());
 
         ++ReadRows;
-        ReadBytes += CountBytes(key, row);
+        ReadBytes += CountRowCellBytes(key, *row);
 
         Sampler.Add([&row](){
             return TSerializedCellVec::Serialize(*row);

--- a/ydb/core/tx/datashard/build_index/secondary_index.cpp
+++ b/ydb/core/tx/datashard/build_index/secondary_index.cpp
@@ -357,7 +357,8 @@ private:
             // TODO(mbkkt) ReleaseBuffer isn't possible, we use LastUploadedKey for logging
             progress->Record.SetLastKeyAck(LastUploadedKey.GetBuffer());
             progress->Record.SetRowsDelta(WriteBuf.GetRows());
-            progress->Record.SetBytesDelta(WriteBuf.GetRowCellBytes());
+            // TODO: use GetRowCellBytes method?
+            progress->Record.SetBytesDelta(WriteBuf.GetBufferBytes());
             WriteBuf.Clear();
 
             progress->Record.SetStatus(NKikimrIndexBuilder::EBuildStatus::IN_PROGRESS);

--- a/ydb/core/tx/datashard/build_index/secondary_index.cpp
+++ b/ydb/core/tx/datashard/build_index/secondary_index.cpp
@@ -155,7 +155,7 @@ protected:
 
         addRow();
 
-        if (!HasReachedLimits(ReadBuf, ScanSettings)) {
+        if (!ReadBuf.HasReachedLimits(ScanSettings)) {
             return EScan::Feed;
         }
 
@@ -344,7 +344,7 @@ private:
         UploadStatus.Issues.AddIssues(ev->Get()->Issues);
 
         if (UploadStatus.IsSuccess()) {
-            Stats.Aggr(&WriteBuf);
+            Stats.Aggr(WriteBuf.GetRows(), WriteBuf.GetRowCellBytes());
             LastUploadedKey = WriteBuf.ExtractLastKey();
 
             //send progress
@@ -357,7 +357,7 @@ private:
             // TODO(mbkkt) ReleaseBuffer isn't possible, we use LastUploadedKey for logging
             progress->Record.SetLastKeyAck(LastUploadedKey.GetBuffer());
             progress->Record.SetRowsDelta(WriteBuf.GetRows());
-            progress->Record.SetBytesDelta(WriteBuf.GetBytes());
+            progress->Record.SetBytesDelta(WriteBuf.GetRowCellBytes());
             WriteBuf.Clear();
 
             progress->Record.SetStatus(NKikimrIndexBuilder::EBuildStatus::IN_PROGRESS);
@@ -365,7 +365,7 @@ private:
 
             this->Send(ProgressActorId, progress.Release());
 
-            if (HasReachedLimits(ReadBuf, ScanSettings)) {
+            if (ReadBuf.HasReachedLimits(ScanSettings)) {
                 ReadBuf.FlushTo(WriteBuf);
                 Upload();
             }

--- a/ydb/core/tx/datashard/build_index/secondary_index.cpp
+++ b/ydb/core/tx/datashard/build_index/secondary_index.cpp
@@ -288,8 +288,8 @@ public:
         return TStringBuilder() << "TBuildIndexScan TabletId: " << DataShardId << " Id: " << BuildIndexId
             << ", requested range: " << DebugPrintRange(KeyTypes, RequestedRange.ToTableRange(), *AppData()->TypeRegistry)
             << ", last acked point: " << DebugPrintPoint(KeyTypes, LastUploadedKey.GetCells(), *AppData()->TypeRegistry)
-            << Stats.ToString()
-            << UploadStatus.ToString();
+            << " " << Stats.ToString()
+            << " " << UploadStatus.ToString();
     }
 
     EScan PageFault() override {

--- a/ydb/core/tx/datashard/scan_common.cpp
+++ b/ydb/core/tx/datashard/scan_common.cpp
@@ -29,6 +29,8 @@ TColumnsTypes GetAllTypes(const TUserTable& tableInfo) {
     return result;
 }
 
+// amount of read data is calculated based only on row cells as it is done in KQP part
+// complex scan read bytes metric would be too hard to be explained for users
 ui64 CountBytes(TArrayRef<const TCell> key, const NTable::TRowState& row) {
     ui64 bytes = 0;
     for (auto& cell : key) {

--- a/ydb/core/tx/datashard/scan_common.cpp
+++ b/ydb/core/tx/datashard/scan_common.cpp
@@ -31,12 +31,12 @@ TColumnsTypes GetAllTypes(const TUserTable& tableInfo) {
 
 // amount of read data is calculated based only on row cells as it is done in KQP part
 // complex scan read bytes metric would be too hard to be explained for users
-ui64 CountBytes(TArrayRef<const TCell> key, const NTable::TRowState& row) {
+ui64 CountRowCellBytes(TConstArrayRef<TCell> key, TConstArrayRef<TCell> value) {
     ui64 bytes = 0;
     for (auto& cell : key) {
         bytes += cell.Size();
     }
-    for (auto& cell : *row) {
+    for (auto& cell : value) {
         bytes += cell.Size();
     }
     return bytes;

--- a/ydb/core/tx/datashard/scan_common.h
+++ b/ydb/core/tx/datashard/scan_common.h
@@ -1,7 +1,5 @@
 #pragma once
 
-#include "buffer_data.h"
-
 #include <ydb/core/protos/index_builder.pb.h>
 #include <ydb/public/api/protos/ydb_value.pb.h>
 #include <ydb/core/tablet_flat/flat_cxx_database.h>
@@ -86,19 +84,12 @@ using TColumnsTypes = THashMap<TString, NScheme::TTypeInfo>;
 
 TColumnsTypes GetAllTypes(const TUserTable& tableInfo);
 
-// TODO(mbkkt) unfortunately key can have same columns as row
-// I can detect this but maybe better
-// if IScan will provide for us "how much data did we read"?
-ui64 CountBytes(TArrayRef<const TCell> key, const NTable::TRowState& row);
+ui64 CountRowCellBytes(TConstArrayRef<TCell> key, TConstArrayRef<TCell> value);
 
 inline TDuration GetRetryWakeupTimeoutBackoff(ui32 attempt) {
     const ui32 maxBackoffExponent = 3;
 
     return TDuration::Seconds(1u << Min(attempt, maxBackoffExponent));
-}
-
-inline bool HasReachedLimits(const TBufferData& buffer, const TIndexBuildScanSettings& scanSettings) {
-    return  buffer.HasReachedLimits(scanSettings.GetMaxBatchRows(), scanSettings.GetMaxBatchBytes());
 }
 
 }

--- a/ydb/core/tx/schemeshard/schemeshard_build_index__progress.cpp
+++ b/ydb/core/tx/schemeshard/schemeshard_build_index__progress.cpp
@@ -1899,7 +1899,8 @@ struct TSchemeShard::TIndexBuilder::TTxReplyProgress: public TTxShardReply<TEvDa
 
     TBillingStats GetBillingStats() const override {
         auto& record = Response->Get()->Record;
-        // TODO(mbkkt) we should account uploads and reads separately
+        // secondary index reads and writes almost the same amount of data
+        // do not count them separately for simplicity
         return {record.GetRowsDelta(), record.GetBytesDelta(), record.GetRowsDelta(), record.GetBytesDelta()};
     }
 };

--- a/ydb/core/tx/schemeshard/schemeshard_build_index__progress.cpp
+++ b/ydb/core/tx/schemeshard/schemeshard_build_index__progress.cpp
@@ -52,14 +52,14 @@ protected:
 
     const TActorId ResponseActorId;
     const TIndexBuildId BuildId;
-    TIndexBuildInfo::TSample::TRows Init;
+    TIndexBuildInfo::TSample::TRows Sample;
 
     std::shared_ptr<NTxProxy::TUploadTypes> Types;
-    std::shared_ptr<NTxProxy::TUploadRows> Rows;
+    std::shared_ptr<NTxProxy::TUploadRows> UploadRows;
 
     TActorId Uploader;
     ui32 RetryCount = 0;
-    ui32 RowsBytes = 0;
+    ui32 UploadBytes = 0;
     const NTableIndex::TClusterId Parent = 0;
     NTableIndex::TClusterId Child = 0;
 
@@ -71,7 +71,7 @@ public:
                    const NKikimrIndexBuilder::TIndexBuildScanSettings& scanSettings,
                    const TActorId& responseActorId,
                    TIndexBuildId buildId,
-                   TIndexBuildInfo::TSample::TRows init,
+                   TIndexBuildInfo::TSample::TRows sample,
                    NTableIndex::TClusterId parent,
                    NTableIndex::TClusterId child)
         : TargetTable(std::move(targetTable))
@@ -79,14 +79,14 @@ public:
         , ScanSettings(scanSettings)
         , ResponseActorId(responseActorId)
         , BuildId(buildId)
-        , Init(std::move(init))
+        , Sample(std::move(sample))
         , Parent(parent)
         , Child(child)
     {
         LogPrefix = TStringBuilder()
             << "TUploadSampleK: BuildIndexId: " << BuildId
             << " ResponseActorId: " << ResponseActorId;
-        Y_ENSURE(!Init.empty());
+        Y_ENSURE(!Sample.empty());
         Y_ENSURE(Parent < Child);
         Y_ENSURE(Child != 0);
     }
@@ -109,12 +109,11 @@ public:
     }
 
     void Bootstrap() {
-        Rows = std::make_shared<NTxProxy::TUploadRows>();
-        Rows->reserve(Init.size());
+        UploadRows = std::make_shared<NTxProxy::TUploadRows>();
+        UploadRows->reserve(Sample.size());
         std::array<TCell, 2> pk;
         pk[0] = TCell::Make(Parent);
-        for (auto& [_, row] : Init) {
-            RowsBytes += row.size();
+        for (auto& [_, row] : Sample) {
             auto child = Child++;
             if (IsPostingLevel) {
                 child = SetPostingParentFlag(child);
@@ -123,11 +122,11 @@ public:
             }
             pk[1] = TCell::Make(child);
 
-            // TODO(mbkkt) we can avoid serialization of PrimaryKeys every iter
-            Rows->emplace_back(TSerializedCellVec{pk}, std::move(row));
+            TSerializedCellVec vec(row);
+            UploadBytes += NDataShard::CountRowCellBytes(pk, vec.GetCells());
+            UploadRows->emplace_back(TSerializedCellVec{pk}, std::move(row));
         }
-        Init = {}; // release memory
-        RowsBytes += Rows->size() * TSerializedCellVec::SerializedSize(pk);
+        Sample = {}; // release memory
 
         Types = std::make_shared<NTxProxy::TUploadTypes>(3);
         Ydb::Type type;
@@ -155,7 +154,7 @@ private:
     void HandleWakeup() {
         LOG_D("Retry upload " << Debug());
 
-        if (Rows) {
+        if (UploadRows) {
             Upload(true);
         }
     }
@@ -187,8 +186,8 @@ private:
         TAutoPtr<TEvIndexBuilder::TEvUploadSampleKResponse> response = new TEvIndexBuilder::TEvUploadSampleKResponse;
 
         response->Record.SetId(ui64(BuildId));
-        response->Record.SetUploadRows(Rows->size());
-        response->Record.SetUploadBytes(RowsBytes);
+        response->Record.SetUploadRows(UploadRows->size());
+        response->Record.SetUploadBytes(UploadBytes);
 
         UploadStatusToMessage(response->Record);
 
@@ -207,7 +206,7 @@ private:
             SelfId(),
             TargetTable,
             Types,
-            Rows,
+            UploadRows,
             NTxProxy::EUploadRowsMode::WriteToTableShadow, // TODO(mbkkt) is it fastest?
             true /*writeToPrivateTable*/,
             true /*writeToIndexImplTable*/);

--- a/ydb/core/tx/schemeshard/ut_index_build/ut_index_build.cpp
+++ b/ydb/core/tx/schemeshard/ut_index_build/ut_index_build.cpp
@@ -246,8 +246,8 @@ Y_UNIT_TEST_SUITE(IndexBuildTest) {
         auto descr = TestGetBuildIndex(runtime, tenantSchemeShard, "/MyRoot/ServerLessDB", txId);
         UNIT_ASSERT_VALUES_EQUAL(descr.GetIndexBuild().GetState(), Ydb::Table::IndexBuildState::STATE_DONE);
 
+        // 101 rows, each: key:Uint32 (4 bytes), index:Uint32 (4 bytes) = 101 * 8 = 808 bytes
         const TString meteringData = R"({"usage":{"start":0,"quantity":179,"finish":0,"unit":"request_unit","type":"delta"},"tags":{},"id":"106-72075186233409549-2-0-0-0-0-101-101-808-808","cloud_id":"CLOUD_ID_VAL","source_wt":0,"source_id":"sless-docapi-ydb-ss","resource_id":"DATABASE_ID_VAL","schema":"ydb.serverless.requests.v1","folder_id":"FOLDER_ID_VAL","version":"1.0.0"})";
-
         UNIT_ASSERT_NO_DIFF(meteringMessages, meteringData + "\n");
 
         TestDescribeResult(DescribePath(runtime, tenantSchemeShard, "/MyRoot/ServerLessDB/Table"),

--- a/ydb/core/tx/schemeshard/ut_index_build/ut_index_build.cpp
+++ b/ydb/core/tx/schemeshard/ut_index_build/ut_index_build.cpp
@@ -246,8 +246,8 @@ Y_UNIT_TEST_SUITE(IndexBuildTest) {
         auto descr = TestGetBuildIndex(runtime, tenantSchemeShard, "/MyRoot/ServerLessDB", txId);
         UNIT_ASSERT_VALUES_EQUAL(descr.GetIndexBuild().GetState(), Ydb::Table::IndexBuildState::STATE_DONE);
 
-        // 101 rows, each: key:Uint32 (4 bytes), index:Uint32 (4 bytes) = 101 * 8 = 808 bytes
-        const TString meteringData = R"({"usage":{"start":0,"quantity":179,"finish":0,"unit":"request_unit","type":"delta"},"tags":{},"id":"106-72075186233409549-2-0-0-0-0-101-101-808-808","cloud_id":"CLOUD_ID_VAL","source_wt":0,"source_id":"sless-docapi-ydb-ss","resource_id":"DATABASE_ID_VAL","schema":"ydb.serverless.requests.v1","folder_id":"FOLDER_ID_VAL","version":"1.0.0"})";
+        const TString meteringData = R"({"usage":{"start":0,"quantity":179,"finish":0,"unit":"request_unit","type":"delta"},"tags":{},"id":"106-72075186233409549-2-0-0-0-0-101-101-1818-1818","cloud_id":"CLOUD_ID_VAL","source_wt":0,"source_id":"sless-docapi-ydb-ss","resource_id":"DATABASE_ID_VAL","schema":"ydb.serverless.requests.v1","folder_id":"FOLDER_ID_VAL","version":"1.0.0"})";
+
         UNIT_ASSERT_NO_DIFF(meteringMessages, meteringData + "\n");
 
         TestDescribeResult(DescribePath(runtime, tenantSchemeShard, "/MyRoot/ServerLessDB/Table"),

--- a/ydb/core/tx/schemeshard/ut_index_build/ut_index_build.cpp
+++ b/ydb/core/tx/schemeshard/ut_index_build/ut_index_build.cpp
@@ -246,7 +246,7 @@ Y_UNIT_TEST_SUITE(IndexBuildTest) {
         auto descr = TestGetBuildIndex(runtime, tenantSchemeShard, "/MyRoot/ServerLessDB", txId);
         UNIT_ASSERT_VALUES_EQUAL(descr.GetIndexBuild().GetState(), Ydb::Table::IndexBuildState::STATE_DONE);
 
-        const TString meteringData = R"({"usage":{"start":0,"quantity":179,"finish":0,"unit":"request_unit","type":"delta"},"tags":{},"id":"106-72075186233409549-2-0-0-0-0-101-101-1818-1818","cloud_id":"CLOUD_ID_VAL","source_wt":0,"source_id":"sless-docapi-ydb-ss","resource_id":"DATABASE_ID_VAL","schema":"ydb.serverless.requests.v1","folder_id":"FOLDER_ID_VAL","version":"1.0.0"})";
+        const TString meteringData = R"({"usage":{"start":0,"quantity":179,"finish":0,"unit":"request_unit","type":"delta"},"tags":{},"id":"106-72075186233409549-2-0-0-0-0-101-101-808-808","cloud_id":"CLOUD_ID_VAL","source_wt":0,"source_id":"sless-docapi-ydb-ss","resource_id":"DATABASE_ID_VAL","schema":"ydb.serverless.requests.v1","folder_id":"FOLDER_ID_VAL","version":"1.0.0"})";
 
         UNIT_ASSERT_NO_DIFF(meteringMessages, meteringData + "\n");
 

--- a/ydb/core/tx/schemeshard/ut_index_build/ut_vector_index_build.cpp
+++ b/ydb/core/tx/schemeshard/ut_index_build/ut_vector_index_build.cpp
@@ -556,7 +556,7 @@ Y_UNIT_TEST_SUITE (VectorIndexBuildTest) {
         }
         logBillingStats();
         UNIT_ASSERT_VALUES_EQUAL(uploadRows, 204);
-        UNIT_ASSERT_VALUES_EQUAL(uploadBytes, 6748);
+        UNIT_ASSERT_VALUES_EQUAL(uploadBytes, 3548);
         UNIT_ASSERT_VALUES_EQUAL(readRows, 400);
         UNIT_ASSERT_VALUES_EQUAL(readBytes, 3600);
 
@@ -566,7 +566,7 @@ Y_UNIT_TEST_SUITE (VectorIndexBuildTest) {
         }
         logBillingStats();
         UNIT_ASSERT_VALUES_EQUAL(uploadRows, 420);
-        UNIT_ASSERT_VALUES_EQUAL(uploadBytes, 11740);
+        UNIT_ASSERT_VALUES_EQUAL(uploadBytes, 6284);
         if (smallScanBuffer) {
             UNIT_ASSERT_VALUES_EQUAL(readRows, 1400); // SAMPLE + KMEANS * 3 + UPLOAD = 5 scans
             UNIT_ASSERT_VALUES_EQUAL(readBytes, 20600);
@@ -599,9 +599,9 @@ Y_UNIT_TEST_SUITE (VectorIndexBuildTest) {
                 .SourceWt(TInstant::Seconds(10))
                 .Usage(TBillRecord::RequestUnits(336, TInstant::Seconds(10), TInstant::Seconds(10)));
             if (smallScanBuffer) {
-                expectedBill.Id("109-72075186233409549-2-4-200-148-1800-420-1400-11740-20600");
+                expectedBill.Id("109-72075186233409549-2-4-200-148-1800-420-1400-6284-20600");
             } else {
-                expectedBill.Id("109-72075186233409549-2-4-200-148-1800-420-600-11740-7000");
+                expectedBill.Id("109-72075186233409549-2-4-200-148-1800-420-600-6284-7000");
             }
             UNIT_ASSERT_VALUES_EQUAL(meteringBlocker.size(), 1);
             UNIT_ASSERT_VALUES_EQUAL(meteringBlocker[0]->Get()->MeteringJson, expectedBill.ToString());


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

...

### Changelog category <!-- remove all except one -->

* Not for changelog (changelog entry is not required)

### Description for reviewers <!-- (optional) description for those who read this PR -->

- Count amount of read and write data in scan builders as sum of cell sizes as it is done [in KQP](https://github.com/ydb-platform/ydb/blob/7eb7f65de6e56384e8674155d61f975d4446d6d4/ydb/core/kqp/runtime/kqp_read_actor.cpp#L1237)
- Resolves https://github.com/ydb-platform/ydb/issues/19648
