### PR TITLE
Fix CMS verify on repeated lock if disk has no vdisks

### DIFF
--- a/ydb/core/cms/cms.cpp
+++ b/ydb/core/cms/cms.cpp
@@ -859,6 +859,12 @@ bool TCms::TryToLockPDisk(const TAction &action,
                           const TPDiskInfo &pdisk,
                           TErrorInfo &error) const
 {
+    TDuration duration = TDuration::MicroSeconds(action.GetDuration());
+    duration += opts.PermissionDuration;
+    
+    if (pdisk.IsLocked(error, State->Config.DefaultRetryTime, TActivationContext::Now(), duration))
+        return false;
+
     if (!TryToLockVDisks(action, opts, pdisk.VDisks, error))
         return false;
 


### PR DESCRIPTION
(cherry picked from commit 38bd36672192472b4a6383eb1e4c1516c15f0e53)