### PR TITLE
The writing time for blobs should not decrease

### DIFF
--- a/ydb/core/persqueue/events/internal.h
+++ b/ydb/core/persqueue/events/internal.h
@@ -57,6 +57,7 @@ namespace NPQ {
         TString Value;
         bool Cached;
         TKey Key;
+        ui64 CreationUnixTime = 0;
 
         TRequestedBlob() = delete;
 

--- a/ydb/core/persqueue/partition.cpp
+++ b/ydb/core/persqueue/partition.cpp
@@ -2229,32 +2229,32 @@ bool TPartition::TryAddDeleteHeadKeysToPersistRequest()
     return haveChanges;
 }
 
-//void TPartition::DumpKeyValueRequest(const NKikimrClient::TKeyValueRequest& request)
-//{
-//    DBGTRACE_LOG("=== DumpKeyValueRequest ===");
-//    DBGTRACE_LOG("--- delete ----------------");
-//    for (size_t i = 0; i < request.CmdDeleteRangeSize(); ++i) {
-//        const auto& cmd = request.GetCmdDeleteRange(i);
-//        const auto& range = cmd.GetRange();
-//        Y_UNUSED(range);
-//        DBGTRACE_LOG((range.GetIncludeFrom() ? '[' : '(') << range.GetFrom() <<
-//                     ", " <<
-//                     range.GetTo() << (range.GetIncludeTo() ? ']' : ')'));
-//    }
-//    DBGTRACE_LOG("--- write -----------------");
-//    for (size_t i = 0; i < request.CmdWriteSize(); ++i) {
-//        const auto& cmd = request.GetCmdWrite(i);
-//        Y_UNUSED(cmd);
-//        DBGTRACE_LOG(cmd.GetKey());
-//    }
-//    DBGTRACE_LOG("--- rename ----------------");
-//    for (size_t i = 0; i < request.CmdRenameSize(); ++i) {
-//        const auto& cmd = request.GetCmdRename(i);
-//        Y_UNUSED(cmd);
-//        DBGTRACE_LOG(cmd.GetOldKey() << ", " << cmd.GetNewKey());
-//    }
-//    DBGTRACE_LOG("===========================");
-//}
+void TPartition::DumpKeyValueRequest(const NKikimrClient::TKeyValueRequest& request)
+{
+    PQ_LOG_D("=== DumpKeyValueRequest ===");
+    PQ_LOG_D("--- delete ----------------");
+    for (size_t i = 0; i < request.CmdDeleteRangeSize(); ++i) {
+        const auto& cmd = request.GetCmdDeleteRange(i);
+        const auto& range = cmd.GetRange();
+        Y_UNUSED(range);
+        PQ_LOG_D((range.GetIncludeFrom() ? '[' : '(') << range.GetFrom() <<
+                 ", " <<
+                 range.GetTo() << (range.GetIncludeTo() ? ']' : ')'));
+    }
+    PQ_LOG_D("--- write -----------------");
+    for (size_t i = 0; i < request.CmdWriteSize(); ++i) {
+        const auto& cmd = request.GetCmdWrite(i);
+        Y_UNUSED(cmd);
+        PQ_LOG_D(cmd.GetKey() << ", " << cmd.GetCreationUnixTime());
+    }
+    PQ_LOG_D("--- rename ----------------");
+    for (size_t i = 0; i < request.CmdRenameSize(); ++i) {
+        const auto& cmd = request.GetCmdRename(i);
+        Y_UNUSED(cmd);
+        PQ_LOG_D(cmd.GetOldKey() << ", " << cmd.GetNewKey() << ", " << cmd.GetCreationUnixTime());
+    }
+    PQ_LOG_D("===========================");
+}
 
 //void TPartition::DumpZones(const char* file, unsigned line) const
 //{
@@ -2538,7 +2538,7 @@ void TPartition::CommitWriteOperations(TTransaction& t)
             PQ_LOG_D("add key " << k.Key.ToString());
             auto write = BlobEncoder.PartitionedBlob.Add(k.Key, k.Size);
             if (write && !write->Value.empty()) {
-                AddCmdWrite(write, PersistRequest.Get(), ctx);
+                AddCmdWrite(write, PersistRequest.Get(), 0, ctx);
                 BlobEncoder.CompactedKeys.emplace_back(write->Key, write->Value.size());
             }
             Parameters->CurOffset += k.Key.GetCount();

--- a/ydb/core/persqueue/partition.cpp
+++ b/ydb/core/persqueue/partition.cpp
@@ -2538,7 +2538,7 @@ void TPartition::CommitWriteOperations(TTransaction& t)
             PQ_LOG_D("add key " << k.Key.ToString());
             auto write = BlobEncoder.PartitionedBlob.Add(k.Key, k.Size);
             if (write && !write->Value.empty()) {
-                AddCmdWrite(write, PersistRequest.Get(), 0, ctx);
+                AddCmdWrite(write, PersistRequest.Get(), ctx);
                 BlobEncoder.CompactedKeys.emplace_back(write->Key, write->Value.size());
             }
             Parameters->CurOffset += k.Key.GetCount();

--- a/ydb/core/persqueue/partition.cpp
+++ b/ydb/core/persqueue/partition.cpp
@@ -2229,32 +2229,32 @@ bool TPartition::TryAddDeleteHeadKeysToPersistRequest()
     return haveChanges;
 }
 
-void TPartition::DumpKeyValueRequest(const NKikimrClient::TKeyValueRequest& request)
-{
-    PQ_LOG_D("=== DumpKeyValueRequest ===");
-    PQ_LOG_D("--- delete ----------------");
-    for (size_t i = 0; i < request.CmdDeleteRangeSize(); ++i) {
-        const auto& cmd = request.GetCmdDeleteRange(i);
-        const auto& range = cmd.GetRange();
-        Y_UNUSED(range);
-        PQ_LOG_D((range.GetIncludeFrom() ? '[' : '(') << range.GetFrom() <<
-                 ", " <<
-                 range.GetTo() << (range.GetIncludeTo() ? ']' : ')'));
-    }
-    PQ_LOG_D("--- write -----------------");
-    for (size_t i = 0; i < request.CmdWriteSize(); ++i) {
-        const auto& cmd = request.GetCmdWrite(i);
-        Y_UNUSED(cmd);
-        PQ_LOG_D(cmd.GetKey() << ", " << cmd.GetCreationUnixTime());
-    }
-    PQ_LOG_D("--- rename ----------------");
-    for (size_t i = 0; i < request.CmdRenameSize(); ++i) {
-        const auto& cmd = request.GetCmdRename(i);
-        Y_UNUSED(cmd);
-        PQ_LOG_D(cmd.GetOldKey() << ", " << cmd.GetNewKey() << ", " << cmd.GetCreationUnixTime());
-    }
-    PQ_LOG_D("===========================");
-}
+//void TPartition::DumpKeyValueRequest(const NKikimrClient::TKeyValueRequest& request)
+//{
+//    DBGTRACE_LOG("=== DumpKeyValueRequest ===");
+//    DBGTRACE_LOG("--- delete ----------------");
+//    for (size_t i = 0; i < request.CmdDeleteRangeSize(); ++i) {
+//        const auto& cmd = request.GetCmdDeleteRange(i);
+//        const auto& range = cmd.GetRange();
+//        Y_UNUSED(range);
+//        DBGTRACE_LOG((range.GetIncludeFrom() ? '[' : '(') << range.GetFrom() <<
+//                     ", " <<
+//                     range.GetTo() << (range.GetIncludeTo() ? ']' : ')'));
+//    }
+//    DBGTRACE_LOG("--- write -----------------");
+//    for (size_t i = 0; i < request.CmdWriteSize(); ++i) {
+//        const auto& cmd = request.GetCmdWrite(i);
+//        Y_UNUSED(cmd);
+//        DBGTRACE_LOG(cmd.GetKey());
+//    }
+//    DBGTRACE_LOG("--- rename ----------------");
+//    for (size_t i = 0; i < request.CmdRenameSize(); ++i) {
+//        const auto& cmd = request.GetCmdRename(i);
+//        Y_UNUSED(cmd);
+//        DBGTRACE_LOG(cmd.GetOldKey() << ", " << cmd.GetNewKey());
+//    }
+//    DBGTRACE_LOG("===========================");
+//}
 
 //void TPartition::DumpZones(const char* file, unsigned line) const
 //{

--- a/ydb/core/persqueue/partition.h
+++ b/ydb/core/persqueue/partition.h
@@ -1004,6 +1004,9 @@ private:
                      TEvKeyValue::TEvRequest* request,
                      ui64 creationUnixTime,
                      const TActorContext& ctx);
+    void AddCmdWrite(const std::optional<TPartitionedBlob::TFormedBlobInfo>& newWrite,
+                     TEvKeyValue::TEvRequest* request,
+                     const TActorContext& ctx);
     void RenameFormedBlobs(const std::deque<TPartitionedBlob::TRenameFormedBlobInfo>& formedBlobs,
                            TProcessParametersBase& parameters,
                            ui32 curWrites,

--- a/ydb/core/persqueue/partition.h
+++ b/ydb/core/persqueue/partition.h
@@ -1002,6 +1002,7 @@ private:
 
     void AddCmdWrite(const std::optional<TPartitionedBlob::TFormedBlobInfo>& newWrite,
                      TEvKeyValue::TEvRequest* request,
+                     ui64 creationUnixTime,
                      const TActorContext& ctx);
     void RenameFormedBlobs(const std::deque<TPartitionedBlob::TRenameFormedBlobInfo>& formedBlobs,
                            TProcessParametersBase& parameters,
@@ -1052,6 +1053,8 @@ private:
     TInstant GetFirstUncompactedBlobTimestamp() const;
 
     void TryCorrectStartOffset(TMaybe<ui64> offset);
+
+    ui64 LastRequestedBlobCreationUnixTime = 0;
 };
 
 } // namespace NKikimr::NPQ

--- a/ydb/core/persqueue/partition_compaction.cpp
+++ b/ydb/core/persqueue/partition_compaction.cpp
@@ -85,7 +85,7 @@ bool TPartition::ExecRequestForCompaction(TWriteMsg& p, TProcessParametersBase& 
     auto newWrite = CompactionBlobEncoder.PartitionedBlob.Add(std::move(blob));
 
     if (newWrite && !newWrite->Value.empty()) {
-        AddCmdWrite(newWrite, request, ctx);
+        AddCmdWrite(newWrite, request, LastRequestedBlobCreationUnixTime, ctx);
 
         PQ_LOG_D("Topic '" << TopicName() <<
                 "' partition " << Partition <<
@@ -266,6 +266,8 @@ void TPartition::BlobsForCompactionWereRead(const TVector<NPQ::TRequestedBlob>& 
     for (const auto& requestedBlob : blobs) {
         TMaybe<ui64> firstBlobOffset = requestedBlob.Offset;
 
+        LastRequestedBlobCreationUnixTime = requestedBlob.CreationUnixTime;
+
         for (TBlobIterator it(requestedBlob.Key, requestedBlob.Value); it.IsValid(); it.Next()) {
             TBatch batch = it.GetBatch();
             batch.Unpack();
@@ -305,6 +307,9 @@ void TPartition::BlobsForCompactionWereRead(const TVector<NPQ::TRequestedBlob>& 
     CompactionBlobEncoder.HeadCleared = parameters.HeadCleared;
 
     EndProcessWritesForCompaction(compactionRequest.Get(), ctx);
+
+    // for debugging purposes
+    DumpKeyValueRequest(compactionRequest->Record);
 
     ctx.Send(BlobCache, compactionRequest.Release(), 0, 0);
 }
@@ -468,6 +473,7 @@ void TPartition::AddNewCompactionWriteBlob(std::pair<TKey, ui32>& res, TEvKeyVal
     auto write = request->Record.AddCmdWrite();
     write->SetKey(key.Data(), key.Size());
     write->SetValue(valueD);
+    write->SetCreationUnixTime(LastRequestedBlobCreationUnixTime);
 
     bool isInline = key.IsHead() && valueD.size() < MAX_INLINE_SIZE;
 

--- a/ydb/core/persqueue/partition_compaction.cpp
+++ b/ydb/core/persqueue/partition_compaction.cpp
@@ -309,7 +309,7 @@ void TPartition::BlobsForCompactionWereRead(const TVector<NPQ::TRequestedBlob>& 
     EndProcessWritesForCompaction(compactionRequest.Get(), ctx);
 
     // for debugging purposes
-    DumpKeyValueRequest(compactionRequest->Record);
+    //DumpKeyValueRequest(compactionRequest->Record);
 
     ctx.Send(BlobCache, compactionRequest.Release(), 0, 0);
 }

--- a/ydb/core/persqueue/partition_write.cpp
+++ b/ydb/core/persqueue/partition_write.cpp
@@ -1012,7 +1012,6 @@ void TPartition::AddCmdWrite(const std::optional<TPartitionedBlob::TFormedBlobIn
     write->SetKey(newWrite->Key.Data(), newWrite->Key.Size());
     write->SetValue(newWrite->Value);
     if (creationUnixTime) {
-        PQ_LOG_D("newWrite->Key=" << newWrite->Key.ToString() << ", newWrite->WriteTimestamp=" << creationUnixTime);
         write->SetCreationUnixTime(creationUnixTime);
     }
     //Y_ABORT_UNLESS(newWrite->Key.IsFastWrite());
@@ -1413,47 +1412,47 @@ void TPartition::AddNewFastWriteBlob(std::pair<TKey, ui32>& res, TEvKeyValue::TE
     UpdateWriteBufferIsFullState(ctx.Now());
 }
 
-//void TPartition::AddNewWriteBlob(std::pair<TKey, ui32>& res, TEvKeyValue::TEvRequest* request, const TActorContext& ctx) {
-//    PQ_LOG_T("TPartition::AddNewWriteBlob.");
-//
-//    const auto& key = res.first;
-//    TString valueD = BlobEncoder.SerializeForKey(key, res.second, BlobEncoder.EndOffset, PendingWriteTimestamp);
-//
-//    auto write = request->Record.AddCmdWrite();
-//    write->SetKey(key.Data(), key.Size());
-//    write->SetValue(valueD);
-//
-//    bool isInline = key.HasSuffix() && valueD.size() < MAX_INLINE_SIZE;
-//
-//    if (isInline) {
-//        write->SetStorageChannel(NKikimrClient::TKeyValueRequest::INLINE);
-//    } else {
-//        auto channel = GetChannel(NextChannel(key.HasSuffix(), valueD.size()));
-//        write->SetStorageChannel(channel);
-//        write->SetTactic(AppData(ctx)->PQConfig.GetTactic());
-//    }
-//
-//    //Need to clear all compacted blobs
-//    const TKey& k = BlobEncoder.CompactedKeys.empty() ? key : BlobEncoder.CompactedKeys.front().first;
-//    ClearOldHead(k.GetOffset(), k.GetPartNo()); // schedule to delete the keys from the head
-//
-//    if (!key.HasSuffix()) {
-//        if (!BlobEncoder.DataKeysBody.empty() && BlobEncoder.CompactedKeys.empty()) {
-//            Y_ABORT_UNLESS(BlobEncoder.DataKeysBody.back().Key.GetOffset() + BlobEncoder.DataKeysBody.back().Key.GetCount() <= key.GetOffset(),
-//                "LAST KEY %s, HeadOffset %lu, NEWKEY %s", BlobEncoder.DataKeysBody.back().Key.ToString().c_str(), BlobEncoder.Head.Offset, key.ToString().c_str());
-//        }
-//        BlobEncoder.CompactedKeys.push_back(res);
-//        // BlobEncoder.ResetNewHead ???
-//        BlobEncoder.NewHead.Clear();
-//        BlobEncoder.NewHead.Offset = res.first.GetOffset() + res.first.GetCount();
-//        BlobEncoder.NewHead.PartNo = 0;
-//    } else {
-//        Y_ABORT_UNLESS(BlobEncoder.NewHeadKey.Size == 0);
-//        BlobEncoder.NewHeadKey = {key, res.second, CurrentTimestamp, 0, MakeBlobKeyToken(key.ToString())};
-//    }
-//    WriteCycleSize += write->GetValue().size();
-//    UpdateWriteBufferIsFullState(ctx.Now());
-//}
+void TPartition::AddNewWriteBlob(std::pair<TKey, ui32>& res, TEvKeyValue::TEvRequest* request, const TActorContext& ctx) {
+    PQ_LOG_T("TPartition::AddNewWriteBlob.");
+
+    const auto& key = res.first;
+    TString valueD = BlobEncoder.SerializeForKey(key, res.second, BlobEncoder.EndOffset, PendingWriteTimestamp);
+
+    auto write = request->Record.AddCmdWrite();
+    write->SetKey(key.Data(), key.Size());
+    write->SetValue(valueD);
+
+    bool isInline = key.HasSuffix() && valueD.size() < MAX_INLINE_SIZE;
+
+    if (isInline) {
+        write->SetStorageChannel(NKikimrClient::TKeyValueRequest::INLINE);
+    } else {
+        auto channel = GetChannel(NextChannel(key.HasSuffix(), valueD.size()));
+        write->SetStorageChannel(channel);
+        write->SetTactic(AppData(ctx)->PQConfig.GetTactic());
+    }
+
+    //Need to clear all compacted blobs
+    const TKey& k = BlobEncoder.CompactedKeys.empty() ? key : BlobEncoder.CompactedKeys.front().first;
+    ClearOldHead(k.GetOffset(), k.GetPartNo()); // schedule to delete the keys from the head
+
+    if (!key.HasSuffix()) {
+        if (!BlobEncoder.DataKeysBody.empty() && BlobEncoder.CompactedKeys.empty()) {
+            Y_ABORT_UNLESS(BlobEncoder.DataKeysBody.back().Key.GetOffset() + BlobEncoder.DataKeysBody.back().Key.GetCount() <= key.GetOffset(),
+                "LAST KEY %s, HeadOffset %lu, NEWKEY %s", BlobEncoder.DataKeysBody.back().Key.ToString().c_str(), BlobEncoder.Head.Offset, key.ToString().c_str());
+        }
+        BlobEncoder.CompactedKeys.push_back(res);
+        // BlobEncoder.ResetNewHead ???
+        BlobEncoder.NewHead.Clear();
+        BlobEncoder.NewHead.Offset = res.first.GetOffset() + res.first.GetCount();
+        BlobEncoder.NewHead.PartNo = 0;
+    } else {
+        Y_ABORT_UNLESS(BlobEncoder.NewHeadKey.Size == 0);
+        BlobEncoder.NewHeadKey = {key, res.second, CurrentTimestamp, 0, MakeBlobKeyToken(key.ToString())};
+    }
+    WriteCycleSize += write->GetValue().size();
+    UpdateWriteBufferIsFullState(ctx.Now());
+}
 
 void TPartition::SetDeadlinesForWrites(const TActorContext& ctx) {
     PQ_LOG_T("TPartition::SetDeadlinesForWrites.");

--- a/ydb/core/persqueue/partition_write.cpp
+++ b/ydb/core/persqueue/partition_write.cpp
@@ -1024,6 +1024,13 @@ void TPartition::AddCmdWrite(const std::optional<TPartitionedBlob::TFormedBlobIn
     WriteCycleSize += newWrite->Value.size();
 }
 
+void TPartition::AddCmdWrite(const std::optional<TPartitionedBlob::TFormedBlobInfo>& newWrite,
+                             TEvKeyValue::TEvRequest* request,
+                             const TActorContext& ctx)
+{
+    AddCmdWrite(newWrite, request, 0, ctx);
+}
+
 void TPartition::RenameFormedBlobs(const std::deque<TPartitionedBlob::TRenameFormedBlobInfo>& formedBlobs,
                                    TProcessParametersBase& parameters,
                                    ui32 curWrites,
@@ -1298,7 +1305,7 @@ bool TPartition::ExecRequest(TWriteMsg& p, ProcessParameters& parameters, TEvKey
 
     if (newWrite && !newWrite->Value.empty()) {
         newWrite->Key.SetFastWrite();
-        AddCmdWrite(newWrite, request, 0, ctx);
+        AddCmdWrite(newWrite, request, ctx);
 
         PQ_LOG_D("Topic '" << TopicName() <<
                 "' partition " << Partition <<

--- a/ydb/core/persqueue/read.h
+++ b/ydb/core/persqueue/read.h
@@ -205,6 +205,7 @@ namespace NPQ {
 
                         Y_ABORT_UNLESS(outBlobs[pos].Value.empty());
                         outBlobs[pos].Value = r->GetValue();
+                        outBlobs[pos].CreationUnixTime = r->GetCreationUnixTime();
                     } else {
                         LOG_ERROR_S(ctx, NKikimrServices::PERSQUEUE, "Got Error response " << r->GetStatus()
                                         << " for " << i << "'s blob from " << resp.ReadResultSize() << " blobs");

--- a/ydb/core/persqueue/ut/pq_ut.cpp
+++ b/ydb/core/persqueue/ut/pq_ut.cpp
@@ -2673,7 +2673,6 @@ Y_UNIT_TEST(The_Value_Of_CreationUnixTime_Must_Not_Decrease)
 
     TTestContext tc;
     TFinalizer finalizer(tc);
-    tc.EnableDetailedPQLog = true;
     tc.Prepare();
 
     // Turn off the asynchronous compactor
@@ -2713,11 +2712,9 @@ Y_UNIT_TEST(The_Value_Of_CreationUnixTime_Must_Not_Decrease)
     ui64 currentCreationUnixTime = 0;
     for (const auto& key : keys) {
         Y_ABORT_UNLESS(!key.empty());
-        if (key.front() != 'd') {
+        if (key.front() != TKeyPrefix::TypeData) {
             continue;
         }
-
-        Cerr << ">>> " << key << Endl;
 
         auto request = MakeHolder<TEvKeyValue::TEvRequest>();
         auto read = request->Record.AddCmdReadRange();
@@ -2739,8 +2736,6 @@ Y_UNIT_TEST(The_Value_Of_CreationUnixTime_Must_Not_Decrease)
                        ", result.CreationUnixTime=" << result->Record.GetReadRangeResult(0).GetPair(0).GetCreationUnixTime());
 
         currentCreationUnixTime = result->Record.GetReadRangeResult(0).GetPair(0).GetCreationUnixTime();
-
-        Cerr << result->Record << Endl;
     }
 }
 

--- a/ydb/core/persqueue/ut/pq_ut.cpp
+++ b/ydb/core/persqueue/ut/pq_ut.cpp
@@ -2673,7 +2673,7 @@ Y_UNIT_TEST(The_Value_Of_CreationUnixTime_Must_Not_Decrease)
 
     TTestContext tc;
     TFinalizer finalizer(tc);
-    //tc.EnableDetailedPQLog = true;
+    tc.EnableDetailedPQLog = true;
     tc.Prepare();
 
     // Turn off the asynchronous compactor


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

The writing time for blobs should not decrease. The asynchronous compact must explicitly set the blob creation time.

### Changelog category <!-- remove all except one -->

* Not for changelog (changelog entry is not required)

### Description for reviewers <!-- (optional) description for those who read this PR -->

...
