### PR TITLE
Protobuf TMeteringStats

### DIFF
--- a/ydb/core/protos/index_builder.proto
+++ b/ydb/core/protos/index_builder.proto
@@ -147,6 +147,6 @@ message TEvUploadSampleKResponse {
     optional Ydb.StatusIds.StatusCode UploadStatus = 2;
     repeated Ydb.Issue.IssueMessage Issues = 3;
 
-    optional uint64 UploadRows = 4;
-    optional uint64 UploadBytes = 5;
+    reserved 4 to 5;
+    optional NKikimrIndexBuilder.TBillingStats BillingStats = 6;
 }

--- a/ydb/core/protos/index_builder.proto
+++ b/ydb/core/protos/index_builder.proto
@@ -28,7 +28,7 @@ message TIndexBuildScanSettings {
     optional uint32 MaxBatchRetries = 3 [ default = 50 ];
 }
 
-message TBillingStats {
+message TMeteringStats {
     optional uint64 UploadRows = 1;
     optional uint64 UploadBytes = 2;
     optional uint64 ReadRows = 3;
@@ -148,5 +148,5 @@ message TEvUploadSampleKResponse {
     repeated Ydb.Issue.IssueMessage Issues = 3;
 
     reserved 4 to 5;
-    optional NKikimrIndexBuilder.TBillingStats BillingStats = 6;
+    optional NKikimrIndexBuilder.TMeteringStats MeteringStats = 6;
 }

--- a/ydb/core/protos/index_builder.proto
+++ b/ydb/core/protos/index_builder.proto
@@ -28,6 +28,13 @@ message TIndexBuildScanSettings {
     optional uint32 MaxBatchRetries = 3 [ default = 50 ];
 }
 
+message TBillingStats {
+    optional uint64 UploadRows = 1;
+    optional uint64 UploadBytes = 2;
+    optional uint64 ReadRows = 3;
+    optional uint64 ReadBytes = 4;
+}
+
 message TIndexBuildSettings {
     optional string source_path = 1;
     optional Ydb.Table.TableIndex index = 2;

--- a/ydb/core/protos/tx_datashard.proto
+++ b/ydb/core/protos/tx_datashard.proto
@@ -1668,12 +1668,12 @@ message TEvRecomputeKMeansResponse {
     optional NKikimrIndexBuilder.EBuildStatus Status = 6;
     repeated Ydb.Issue.IssueMessage Issues = 7;
 
-    optional uint64 ReadRows = 8;
-    optional uint64 ReadBytes = 9;
-
     // recomputed clusters and cluster sizes (row counts for every cluster)
     repeated bytes Clusters = 10;
     repeated uint64 ClusterSizes = 11;
+
+    reserved 8 to 9;
+    optional NKikimrIndexBuilder.TMeteringStats MeteringStats = 12;
 }
 
 message TEvPrefixKMeansRequest {

--- a/ydb/core/protos/tx_datashard.proto
+++ b/ydb/core/protos/tx_datashard.proto
@@ -1516,14 +1516,14 @@ message TEvSampleKResponse {
     optional NKikimrIndexBuilder.EBuildStatus Status = 4;
     repeated Ydb.Issue.IssueMessage Issues = 5;
 
-    optional uint64 ReadRows = 6;
-    optional uint64 ReadBytes = 7;
-
     optional uint64 RequestSeqNoGeneration = 8;
     optional uint64 RequestSeqNoRound = 9;
 
     repeated uint64 Probabilities = 10;
     repeated bytes Rows = 11;
+
+    reserved 6 to 7;
+    optional NKikimrIndexBuilder.TBillingStats BillingStats = 12;
 }
 
 enum EKMeansState {
@@ -1583,10 +1583,8 @@ message TEvLocalKMeansResponse {
     optional NKikimrIndexBuilder.EBuildStatus Status = 6;
     repeated Ydb.Issue.IssueMessage Issues = 7;
 
-    optional uint64 UploadRows = 8;
-    optional uint64 UploadBytes = 9;
-    optional uint64 ReadRows = 10;
-    optional uint64 ReadBytes = 11;
+    reserved 8 to 11;
+    optional NKikimrIndexBuilder.TBillingStats BillingStats = 12;
 }
 
 message TEvReshuffleKMeansRequest {
@@ -1632,10 +1630,8 @@ message TEvReshuffleKMeansResponse {
     optional NKikimrIndexBuilder.EBuildStatus Status = 6;
     repeated Ydb.Issue.IssueMessage Issues = 7;
 
-    optional uint64 UploadRows = 8;
-    optional uint64 UploadBytes = 9;
-    optional uint64 ReadRows = 10;
-    optional uint64 ReadBytes = 11;
+    reserved 8 to 11;
+    optional NKikimrIndexBuilder.TBillingStats BillingStats = 12;
 }
 
 message TEvRecomputeKMeansRequest {
@@ -1726,10 +1722,8 @@ message TEvPrefixKMeansResponse {
     optional NKikimrIndexBuilder.EBuildStatus Status = 6;
     repeated Ydb.Issue.IssueMessage Issues = 7;
 
-    optional uint64 UploadRows = 8;
-    optional uint64 UploadBytes = 9;
-    optional uint64 ReadRows = 10;
-    optional uint64 ReadBytes = 11;
+    reserved 8 to 11;
+    optional NKikimrIndexBuilder.TBillingStats BillingStats = 12;
 }
 
 message TEvCdcStreamScanRequest {

--- a/ydb/core/protos/tx_datashard.proto
+++ b/ydb/core/protos/tx_datashard.proto
@@ -1523,7 +1523,7 @@ message TEvSampleKResponse {
     repeated bytes Rows = 11;
 
     reserved 6 to 7;
-    optional NKikimrIndexBuilder.TBillingStats BillingStats = 12;
+    optional NKikimrIndexBuilder.TMeteringStats MeteringStats = 12;
 }
 
 enum EKMeansState {
@@ -1584,7 +1584,7 @@ message TEvLocalKMeansResponse {
     repeated Ydb.Issue.IssueMessage Issues = 7;
 
     reserved 8 to 11;
-    optional NKikimrIndexBuilder.TBillingStats BillingStats = 12;
+    optional NKikimrIndexBuilder.TMeteringStats MeteringStats = 12;
 }
 
 message TEvReshuffleKMeansRequest {
@@ -1631,7 +1631,7 @@ message TEvReshuffleKMeansResponse {
     repeated Ydb.Issue.IssueMessage Issues = 7;
 
     reserved 8 to 11;
-    optional NKikimrIndexBuilder.TBillingStats BillingStats = 12;
+    optional NKikimrIndexBuilder.TMeteringStats MeteringStats = 12;
 }
 
 message TEvRecomputeKMeansRequest {
@@ -1723,7 +1723,7 @@ message TEvPrefixKMeansResponse {
     repeated Ydb.Issue.IssueMessage Issues = 7;
 
     reserved 8 to 11;
-    optional NKikimrIndexBuilder.TBillingStats BillingStats = 12;
+    optional NKikimrIndexBuilder.TMeteringStats MeteringStats = 12;
 }
 
 message TEvCdcStreamScanRequest {

--- a/ydb/core/tx/datashard/build_index/common_helper.h
+++ b/ydb/core/tx/datashard/build_index/common_helper.h
@@ -141,8 +141,9 @@ public:
             UploaderId = {};
         }
 
-        response.SetUploadRows(UploadRows);
-        response.SetUploadBytes(UploadBytes);
+        response.MutableBillingStats()->SetUploadRows(UploadRows);
+        response.MutableBillingStats()->SetUploadBytes(UploadBytes);
+
         if (status == NTable::EStatus::Exception) {
             response.SetStatus(NKikimrIndexBuilder::EBuildStatus::BUILD_ERROR);
         } else if (status != NTable::EStatus::Done) {

--- a/ydb/core/tx/datashard/build_index/common_helper.h
+++ b/ydb/core/tx/datashard/build_index/common_helper.h
@@ -141,8 +141,8 @@ public:
             UploaderId = {};
         }
 
-        response.MutableBillingStats()->SetUploadRows(UploadRows);
-        response.MutableBillingStats()->SetUploadBytes(UploadBytes);
+        response.MutableMeteringStats()->SetUploadRows(UploadRows);
+        response.MutableMeteringStats()->SetUploadBytes(UploadBytes);
 
         if (status == NTable::EStatus::Exception) {
             response.SetStatus(NKikimrIndexBuilder::EBuildStatus::BUILD_ERROR);

--- a/ydb/core/tx/datashard/build_index/local_kmeans.cpp
+++ b/ydb/core/tx/datashard/build_index/local_kmeans.cpp
@@ -170,8 +170,8 @@ public:
     TAutoPtr<IDestructable> Finish(EStatus status) final
     {
         auto& record = Response->Record;
-        record.SetReadRows(ReadRows);
-        record.SetReadBytes(ReadBytes);
+        record.MutableBillingStats()->SetReadRows(ReadRows);
+        record.MutableBillingStats()->SetReadBytes(ReadBytes);
 
         Uploader.Finish(record, status);
 

--- a/ydb/core/tx/datashard/build_index/local_kmeans.cpp
+++ b/ydb/core/tx/datashard/build_index/local_kmeans.cpp
@@ -170,8 +170,8 @@ public:
     TAutoPtr<IDestructable> Finish(EStatus status) final
     {
         auto& record = Response->Record;
-        record.MutableBillingStats()->SetReadRows(ReadRows);
-        record.MutableBillingStats()->SetReadBytes(ReadBytes);
+        record.MutableMeteringStats()->SetReadRows(ReadRows);
+        record.MutableMeteringStats()->SetReadBytes(ReadBytes);
 
         Uploader.Finish(record, status);
 

--- a/ydb/core/tx/datashard/build_index/prefix_kmeans.cpp
+++ b/ydb/core/tx/datashard/build_index/prefix_kmeans.cpp
@@ -203,8 +203,8 @@ public:
     TAutoPtr<IDestructable> Finish(EStatus status) final
     {
         auto& record = Response->Record;
-        record.SetReadRows(ReadRows);
-        record.SetReadBytes(ReadBytes);
+        record.MutableBillingStats()->SetReadRows(ReadRows);
+        record.MutableBillingStats()->SetReadBytes(ReadBytes);
 
         Uploader.Finish(record, status);
 

--- a/ydb/core/tx/datashard/build_index/prefix_kmeans.cpp
+++ b/ydb/core/tx/datashard/build_index/prefix_kmeans.cpp
@@ -203,8 +203,8 @@ public:
     TAutoPtr<IDestructable> Finish(EStatus status) final
     {
         auto& record = Response->Record;
-        record.MutableBillingStats()->SetReadRows(ReadRows);
-        record.MutableBillingStats()->SetReadBytes(ReadBytes);
+        record.MutableMeteringStats()->SetReadRows(ReadRows);
+        record.MutableMeteringStats()->SetReadBytes(ReadBytes);
 
         Uploader.Finish(record, status);
 

--- a/ydb/core/tx/datashard/build_index/recompute_kmeans.cpp
+++ b/ydb/core/tx/datashard/build_index/recompute_kmeans.cpp
@@ -107,8 +107,8 @@ public:
     TAutoPtr<IDestructable> Finish(EStatus status) final
     {
         auto& record = Response->Record;
-        record.SetReadRows(ReadRows);
-        record.SetReadBytes(ReadBytes);
+        record.MutableMeteringStats()->SetReadRows(ReadRows);
+        record.MutableMeteringStats()->SetReadBytes(ReadBytes);
 
         if (status == EStatus::Exception) {
             record.SetStatus(NKikimrIndexBuilder::EBuildStatus::BUILD_ERROR);

--- a/ydb/core/tx/datashard/build_index/reshuffle_kmeans.cpp
+++ b/ydb/core/tx/datashard/build_index/reshuffle_kmeans.cpp
@@ -142,8 +142,8 @@ public:
     TAutoPtr<IDestructable> Finish(EStatus status) final
     {
         auto& record = Response->Record;
-        record.MutableBillingStats()->SetReadRows(ReadRows);
-        record.MutableBillingStats()->SetReadBytes(ReadBytes);
+        record.MutableMeteringStats()->SetReadRows(ReadRows);
+        record.MutableMeteringStats()->SetReadBytes(ReadBytes);
 
         Uploader.Finish(record, status);
 

--- a/ydb/core/tx/datashard/build_index/reshuffle_kmeans.cpp
+++ b/ydb/core/tx/datashard/build_index/reshuffle_kmeans.cpp
@@ -142,8 +142,8 @@ public:
     TAutoPtr<IDestructable> Finish(EStatus status) final
     {
         auto& record = Response->Record;
-        record.SetReadRows(ReadRows);
-        record.SetReadBytes(ReadBytes);
+        record.MutableBillingStats()->SetReadRows(ReadRows);
+        record.MutableBillingStats()->SetReadBytes(ReadBytes);
 
         Uploader.Finish(record, status);
 

--- a/ydb/core/tx/datashard/build_index/sample_k.cpp
+++ b/ydb/core/tx/datashard/build_index/sample_k.cpp
@@ -153,8 +153,8 @@ public:
 
     TAutoPtr<IDestructable> Finish(EStatus status) final {
         auto& record = Response->Record;
-        record.MutableBillingStats()->SetReadRows(ReadRows);
-        record.MutableBillingStats()->SetReadBytes(ReadBytes);
+        record.MutableMeteringStats()->SetReadRows(ReadRows);
+        record.MutableMeteringStats()->SetReadBytes(ReadBytes);
 
         if (status == EStatus::Exception) {
             record.SetStatus(NKikimrIndexBuilder::EBuildStatus::BUILD_ERROR);

--- a/ydb/core/tx/datashard/build_index/sample_k.cpp
+++ b/ydb/core/tx/datashard/build_index/sample_k.cpp
@@ -153,8 +153,8 @@ public:
 
     TAutoPtr<IDestructable> Finish(EStatus status) final {
         auto& record = Response->Record;
-        record.SetReadRows(ReadRows);
-        record.SetReadBytes(ReadBytes);
+        record.MutableBillingStats()->SetReadRows(ReadRows);
+        record.MutableBillingStats()->SetReadBytes(ReadBytes);
 
         if (status == EStatus::Exception) {
             record.SetStatus(NKikimrIndexBuilder::EBuildStatus::BUILD_ERROR);

--- a/ydb/core/tx/schemeshard/schemeshard__monitoring.cpp
+++ b/ydb/core/tx/schemeshard/schemeshard__monitoring.cpp
@@ -869,9 +869,9 @@ private:
 
                 TString requestUnitsExplain;
                 ui64 requestUnits = TRUCalculator::Calculate(info.Processed, requestUnitsExplain);
-                str << "Processed: " << info.Processed << Endl
+                str << "Processed: " << info.Processed.ShortDebugString() << Endl
                     << "Request Units: " << requestUnits << " (" << requestUnitsExplain << ")" << Endl
-                    << "Billed: " << info.Billed << Endl;
+                    << "Billed: " << info.Billed.ShortDebugString() << Endl;
             }
 
             auto getKeyTypes = [&](TPathId pathId) {
@@ -956,7 +956,7 @@ private:
                                 str << Self->Generation() << ":" << status.SeqNoRound;
                             }
                             TABLED() {
-                                str << status.Processed;
+                                str << status.Processed.ShortDebugString();
                             }
                         }
                         str << "\n";

--- a/ydb/core/tx/schemeshard/schemeshard__monitoring.cpp
+++ b/ydb/core/tx/schemeshard/schemeshard__monitoring.cpp
@@ -850,26 +850,28 @@ private:
 
                     << "LockTxId: " << info.LockTxId << Endl
                     << "LockTxStatus: " << NKikimrScheme::EStatus_Name(info.LockTxStatus) << Endl
-                    << "LockTxDone                     " << (info.LockTxDone ? "DONE" : "not done") << Endl
+                    << "LockTxDone: " << (info.LockTxDone ? "DONE" : "not done") << Endl
 
                     << "InitiateTxId: " << info.InitiateTxId << Endl
                     << "InitiateTxStatus: " << NKikimrScheme::EStatus_Name(info.InitiateTxStatus) << Endl
-                    << "InitiateTxDone                 " << (info.InitiateTxDone ? "DONE" : "not done") << Endl
+                    << "InitiateTxDone: " << (info.InitiateTxDone ? "DONE" : "not done") << Endl
 
                     << "ApplyTxId: " << info.ApplyTxId << Endl
                     << "ApplyTxStatus: " << NKikimrScheme::EStatus_Name(info.ApplyTxStatus) << Endl
-                    << "ApplyTxDone                    " << (info.ApplyTxDone ? "DONE" : "not done") << Endl
+                    << "ApplyTxDone: " << (info.ApplyTxDone ? "DONE" : "not done") << Endl
 
                     << "UnlockTxId: " << info.UnlockTxId << Endl
                     << "UnlockTxStatus: " << NKikimrScheme::EStatus_Name(info.UnlockTxStatus) << Endl
-                    << "UnlockTxDone                   " << (info.UnlockTxDone ? "DONE" : "not done") << Endl
+                    << "UnlockTxDone: " << (info.UnlockTxDone ? "DONE" : "not done") << Endl
 
                     << "SnapshotStep: " << info.SnapshotStep << Endl
-                    << "SnapshotTxId: " << info.SnapshotTxId << Endl
+                    << "SnapshotTxId: " << info.SnapshotTxId << Endl;
 
-                    << "Processed: " << info.Processed << Endl
+                TString requestUnitsExplain;
+                ui64 requestUnits = TRUCalculator::Calculate(info.Processed, requestUnitsExplain);
+                str << "Processed: " << info.Processed << Endl
+                    << "Request Units: " << requestUnits << " (" << requestUnitsExplain << ")" << Endl
                     << "Billed: " << info.Billed << Endl;
-
             }
 
             auto getKeyTypes = [&](TPathId pathId) {

--- a/ydb/core/tx/schemeshard/schemeshard_billing_helpers.cpp
+++ b/ydb/core/tx/schemeshard/schemeshard_billing_helpers.cpp
@@ -6,6 +6,14 @@
 
 namespace NKikimr::NSchemeShard {
 
+void TBillingStatsCalculator::TryFixOldFormat(NKikimrIndexBuilder::TBillingStats& value) {
+    // old format: assign upload to read
+    if (value.GetReadRows() == 0 && value.GetUploadRows() != 0) {
+        value.SetReadRows(value.GetUploadRows());
+        value.SetReadBytes(value.GetUploadBytes());
+    }
+}
+
 ui64 TRUCalculator::ReadTable(ui64 bytes) {
     // The ReadTable operation lets you efficiently read large ranges of data from a table.
     // The request cost only depends on the amount of data read based on the rate of 128 RU per 1 MB.

--- a/ydb/core/tx/schemeshard/schemeshard_billing_helpers.cpp
+++ b/ydb/core/tx/schemeshard/schemeshard_billing_helpers.cpp
@@ -6,39 +6,27 @@
 
 namespace NKikimr::NSchemeShard {
 
-void TMeteringStatsCalculator::TryFixOldFormat(TMeteringStats& value) {
-    // old format: assign upload to read
-    if (value.GetReadRows() == 0 && value.GetUploadRows() != 0) {
-        value.SetReadRows(value.GetUploadRows());
-        value.SetReadBytes(value.GetUploadBytes());
-    }
+TMeteringStats operator + (const TMeteringStats& value, const TMeteringStats& other) {
+    TMeteringStats result = value;
+    result += other;
+    return result;
 }
 
-TMeteringStats TMeteringStatsCalculator::Zero() {
-    // this method the only purpose is to beautifully print zero stats instead of empty protobuf or with missing fields
-    TMeteringStats value;
-    value.SetUploadRows(0);
-    value.SetUploadBytes(0);
-    value.SetReadRows(0);
-    value.SetReadBytes(0);
-    return value;
+TMeteringStats operator - (const TMeteringStats& value, const TMeteringStats& other) {
+    TMeteringStats result = value;
+    result -= other;
+    return result;
 }
 
-bool TMeteringStatsCalculator::IsZero(TMeteringStats& value) {
-    return value.GetUploadRows() == 0
-        && value.GetUploadBytes() == 0
-        && value.GetReadRows() == 0
-        && value.GetReadBytes() == 0;
-}
-
-void TMeteringStatsCalculator::AddTo(TMeteringStats& value, const TMeteringStats& other) {
+TMeteringStats& operator += (TMeteringStats& value, const TMeteringStats& other) {
     value.SetUploadRows(value.GetUploadRows() + other.GetUploadRows());
     value.SetUploadBytes(value.GetUploadBytes() + other.GetUploadBytes());
     value.SetReadRows(value.GetReadRows() + other.GetReadRows());
     value.SetReadBytes(value.GetReadBytes() + other.GetReadBytes());
+    return value;
 }
 
-void TMeteringStatsCalculator::SubFrom(TMeteringStats& value, const TMeteringStats& other) {
+TMeteringStats& operator -= (TMeteringStats& value, const TMeteringStats& other) {
     const auto safeSub = [](ui64 x, ui64 y) {
         Y_ENSURE(x >= y);
         return x - y;
@@ -48,6 +36,32 @@ void TMeteringStatsCalculator::SubFrom(TMeteringStats& value, const TMeteringSta
     value.SetUploadBytes(safeSub(value.GetUploadBytes(), other.GetUploadBytes()));
     value.SetReadRows(safeSub(value.GetReadRows(), other.GetReadRows()));
     value.SetReadBytes(safeSub(value.GetReadBytes(), other.GetReadBytes()));
+    return value;
+}
+
+void TMeteringStatsHelper::TryFixOldFormat(TMeteringStats& value) {
+    // old format: assign upload to read
+    if (value.GetReadRows() == 0 && value.GetUploadRows() != 0) {
+        value.SetReadRows(value.GetUploadRows());
+        value.SetReadBytes(value.GetUploadBytes());
+    }
+}
+
+TMeteringStats TMeteringStatsHelper::ZeroValue() {
+    // this method the only purpose is to beautifully print zero stats instead of empty protobuf or with missing fields
+    TMeteringStats value;
+    value.SetUploadRows(0);
+    value.SetUploadBytes(0);
+    value.SetReadRows(0);
+    value.SetReadBytes(0);
+    return value;
+}
+
+bool TMeteringStatsHelper::IsZero(TMeteringStats& value) {
+    return value.GetUploadRows() == 0
+        && value.GetUploadBytes() == 0
+        && value.GetReadRows() == 0
+        && value.GetReadBytes() == 0;
 }
 
 ui64 TRUCalculator::ReadTable(ui64 bytes) {

--- a/ydb/core/tx/schemeshard/schemeshard_billing_helpers.cpp
+++ b/ydb/core/tx/schemeshard/schemeshard_billing_helpers.cpp
@@ -28,8 +28,11 @@ TMeteringStats& operator += (TMeteringStats& value, const TMeteringStats& other)
 
 TMeteringStats& operator -= (TMeteringStats& value, const TMeteringStats& other) {
     const auto safeSub = [](ui64 x, ui64 y) {
-        Y_ENSURE(x >= y);
-        return x - y;
+        if (Y_LIKELY(x >= y)) {
+            return x - y;
+        }
+        Y_ASSERT(false);
+        return 0ul;
     };
 
     value.SetUploadRows(safeSub(value.GetUploadRows(), other.GetUploadRows()));

--- a/ydb/core/tx/schemeshard/schemeshard_billing_helpers.cpp
+++ b/ydb/core/tx/schemeshard/schemeshard_billing_helpers.cpp
@@ -70,12 +70,12 @@ ui64 TRUCalculator::BulkUpsert(ui64 bytes, ui64 rows) {
 ui64 TRUCalculator::Calculate(const TMeteringStats& stats, TString& explain) {
     // The cost of building an index is the sum of the cost of ReadTable from the source table and BulkUpsert to the index table.
     // https://yandex.cloud/en-ru/docs/ydb/pricing/ru-special#secondary-index
-    ui64 readTableRU = TRUCalculator::ReadTable(stats.GetReadBytes());
-    ui64 bulkUpsertRU = TRUCalculator::BulkUpsert(stats.GetUploadBytes(), stats.GetUploadRows());
+    ui64 readTable = TRUCalculator::ReadTable(stats.GetReadBytes());
+    ui64 bulkUpsert = TRUCalculator::BulkUpsert(stats.GetUploadBytes(), stats.GetUploadRows());
     explain = TStringBuilder()
-        << "ReadTable: " << readTableRU
-        << ", BulkUpsert: " << bulkUpsertRU;
-    return readTableRU + bulkUpsertRU;
+        << "ReadTable: " << readTable
+        << ", BulkUpsert: " << bulkUpsert;
+    return readTable + bulkUpsert;
 }
 
 }

--- a/ydb/core/tx/schemeshard/schemeshard_billing_helpers.cpp
+++ b/ydb/core/tx/schemeshard/schemeshard_billing_helpers.cpp
@@ -6,39 +6,6 @@
 
 namespace NKikimr::NSchemeShard {
 
-TBillingStats::TBillingStats(ui64 uploadRows, ui64 uploadBytes, ui64 readRows, ui64 readBytes)
-    : UploadRows{uploadRows}
-    , UploadBytes{uploadBytes}
-    , ReadRows{readRows}
-    , ReadBytes{readBytes}
-{
-}
-
-TBillingStats TBillingStats::operator -(const TBillingStats &other) const {
-    Y_ENSURE(UploadRows >= other.UploadRows);
-    Y_ENSURE(UploadBytes >= other.UploadBytes);
-    Y_ENSURE(ReadRows >= other.ReadRows);
-    Y_ENSURE(ReadBytes >= other.ReadBytes);
-
-    return {UploadRows - other.UploadRows, UploadBytes - other.UploadBytes,
-            ReadRows - other.ReadRows, ReadBytes - other.ReadBytes};
-}
-
-TBillingStats TBillingStats::operator +(const TBillingStats &other) const {
-    return {UploadRows + other.UploadRows, UploadBytes + other.UploadBytes,
-            ReadRows + other.ReadRows, ReadBytes + other.ReadBytes};
-}
-
-TString TBillingStats::ToString() const {
-    return TStringBuilder()
-            << "{"
-            << " upload rows: " << UploadRows
-            << ", upload bytes: " << UploadBytes
-            << ", read rows: " << ReadRows
-            << ", read bytes: " << ReadBytes
-            << " }";
-}
-
 ui64 TRUCalculator::ReadTable(ui64 bytes) {
     // The ReadTable operation lets you efficiently read large ranges of data from a table.
     // The request cost only depends on the amount of data read based on the rate of 128 RU per 1 MB.
@@ -56,7 +23,7 @@ ui64 TRUCalculator::BulkUpsert(ui64 bytes, ui64 rows) {
     return (Max(rows, (bytes + 1_KB - 1) / 1_KB) + 1) / 2;
 }
 
-ui64 TRUCalculator::Calculate(const TBillingStats& stats) {
+ui64 TRUCalculator::Calculate(const NKikimrIndexBuilder::TBillingStats& stats) {
     // The cost of building an index is the sum of the cost of ReadTable from the source table and BulkUpsert to the index table.
     // https://yandex.cloud/en-ru/docs/ydb/pricing/ru-special#secondary-index
     return TRUCalculator::ReadTable(stats.GetReadBytes())

--- a/ydb/core/tx/schemeshard/schemeshard_billing_helpers.h
+++ b/ydb/core/tx/schemeshard/schemeshard_billing_helpers.h
@@ -5,15 +5,19 @@
 
 namespace NKikimr::NSchemeShard {
 
+using TBillingStats = NKikimrIndexBuilder::TBillingStats;
+
 struct TBillingStatsCalculator {
-    static void TryFixOldFormat(NKikimrIndexBuilder::TBillingStats& value);
-    static void AddTo(NKikimrIndexBuilder::TBillingStats& value, const NKikimrIndexBuilder::TBillingStats& other);
+    static void TryFixOldFormat(TBillingStats& value);
+    static bool IsZero(TBillingStats& value);
+    static void AddTo(TBillingStats& value, const TBillingStats& other);
+    static void SubFrom(TBillingStats& value, const TBillingStats& other);
 };
 
 struct TRUCalculator {
     static ui64 ReadTable(ui64 bytes);
     static ui64 BulkUpsert(ui64 bytes, ui64 rows);
-    static ui64 Calculate(const NKikimrIndexBuilder::TBillingStats& stats);
+    static ui64 Calculate(const TBillingStats& stats);
 };
 
 }

--- a/ydb/core/tx/schemeshard/schemeshard_billing_helpers.h
+++ b/ydb/core/tx/schemeshard/schemeshard_billing_helpers.h
@@ -5,19 +5,20 @@
 
 namespace NKikimr::NSchemeShard {
 
-using TBillingStats = NKikimrIndexBuilder::TBillingStats;
+using TMeteringStats = NKikimrIndexBuilder::TMeteringStats;
 
-struct TBillingStatsCalculator {
-    static void TryFixOldFormat(TBillingStats& value);
-    static bool IsZero(TBillingStats& value);
-    static void AddTo(TBillingStats& value, const TBillingStats& other);
-    static void SubFrom(TBillingStats& value, const TBillingStats& other);
+struct TMeteringStatsCalculator {
+    static void TryFixOldFormat(TMeteringStats& value);
+    static TMeteringStats Zero();
+    static bool IsZero(TMeteringStats& value);
+    static void AddTo(TMeteringStats& value, const TMeteringStats& other);
+    static void SubFrom(TMeteringStats& value, const TMeteringStats& other);
 };
 
 struct TRUCalculator {
     static ui64 ReadTable(ui64 bytes);
     static ui64 BulkUpsert(ui64 bytes, ui64 rows);
-    static ui64 Calculate(const TBillingStats& stats);
+    static ui64 Calculate(const TMeteringStats& stats);
 };
 
 }

--- a/ydb/core/tx/schemeshard/schemeshard_billing_helpers.h
+++ b/ydb/core/tx/schemeshard/schemeshard_billing_helpers.h
@@ -1,60 +1,18 @@
 #pragma once
 
 #include <ydb/core/metering/bill_record.h>
+#include <ydb/core/protos/index_builder.pb.h>
 
 namespace NKikimr::NSchemeShard {
 
-class TBillingStats {
-public:
-    TBillingStats() = default;
-    TBillingStats(const TBillingStats& other) = default;
-    TBillingStats& operator = (const TBillingStats& other) = default;
-
-    TBillingStats(ui64 uploadRows, ui64 uploadBytes, ui64 readRows, ui64 readBytes);
-
-    TBillingStats operator - (const TBillingStats& other) const;
-    TBillingStats& operator -= (const TBillingStats& other) {
-        return *this = *this - other;
-    }
-
-    TBillingStats operator + (const TBillingStats& other) const;
-    TBillingStats& operator += (const TBillingStats& other) {
-        return *this = *this + other;
-    }
-
-    bool operator == (const TBillingStats& other) const = default;
-
-    explicit operator bool () const {
-        return *this != TBillingStats{};
-    }
-
-    TString ToString() const;
-
-    ui64 GetUploadRows() const {
-        return UploadRows;
-    }
-    ui64 GetUploadBytes() const {
-        return UploadBytes;
-    }
-
-    ui64 GetReadRows() const {
-        return ReadRows;
-    }
-    ui64 GetReadBytes() const {
-        return ReadBytes;
-    }
-
-private:
-    ui64 UploadRows = 0;
-    ui64 UploadBytes = 0;
-    ui64 ReadRows = 0;
-    ui64 ReadBytes = 0;
+struct TBillingStatsCalculator {
+    static void AddTo(NKikimrIndexBuilder::TBillingStats& value, const NKikimrIndexBuilder::TBillingStats& other);
 };
 
 struct TRUCalculator {
     static ui64 ReadTable(ui64 bytes);
     static ui64 BulkUpsert(ui64 bytes, ui64 rows);
-    static ui64 Calculate(const TBillingStats& stats);
+    static ui64 Calculate(const NKikimrIndexBuilder::TBillingStats& stats);
 };
 
 }

--- a/ydb/core/tx/schemeshard/schemeshard_billing_helpers.h
+++ b/ydb/core/tx/schemeshard/schemeshard_billing_helpers.h
@@ -18,7 +18,7 @@ struct TMeteringStatsCalculator {
 struct TRUCalculator {
     static ui64 ReadTable(ui64 bytes);
     static ui64 BulkUpsert(ui64 bytes, ui64 rows);
-    static ui64 Calculate(const TMeteringStats& stats);
+    static ui64 Calculate(const TMeteringStats& stats, TString& explain);
 };
 
 }

--- a/ydb/core/tx/schemeshard/schemeshard_billing_helpers.h
+++ b/ydb/core/tx/schemeshard/schemeshard_billing_helpers.h
@@ -6,6 +6,7 @@
 namespace NKikimr::NSchemeShard {
 
 struct TBillingStatsCalculator {
+    static void TryFixOldFormat(NKikimrIndexBuilder::TBillingStats& value);
     static void AddTo(NKikimrIndexBuilder::TBillingStats& value, const NKikimrIndexBuilder::TBillingStats& other);
 };
 

--- a/ydb/core/tx/schemeshard/schemeshard_billing_helpers.h
+++ b/ydb/core/tx/schemeshard/schemeshard_billing_helpers.h
@@ -7,12 +7,15 @@ namespace NKikimr::NSchemeShard {
 
 using TMeteringStats = NKikimrIndexBuilder::TMeteringStats;
 
-struct TMeteringStatsCalculator {
+TMeteringStats operator + (const TMeteringStats& value, const TMeteringStats& other);
+TMeteringStats operator - (const TMeteringStats& value, const TMeteringStats& other);
+TMeteringStats& operator += (TMeteringStats& value, const TMeteringStats& other);
+TMeteringStats& operator -= (TMeteringStats& value, const TMeteringStats& other);
+
+struct TMeteringStatsHelper {
     static void TryFixOldFormat(TMeteringStats& value);
-    static TMeteringStats Zero();
+    static TMeteringStats ZeroValue();
     static bool IsZero(TMeteringStats& value);
-    static void AddTo(TMeteringStats& value, const TMeteringStats& other);
-    static void SubFrom(TMeteringStats& value, const TMeteringStats& other);
 };
 
 struct TRUCalculator {

--- a/ydb/core/tx/schemeshard/schemeshard_build_index__progress.cpp
+++ b/ydb/core/tx/schemeshard/schemeshard_build_index__progress.cpp
@@ -1857,11 +1857,6 @@ struct TSchemeShard::TIndexBuilder::TTxReplyRecomputeKMeans: public TTxShardRepl
         Self->PersistBuildIndexClustersUpdate(db, buildInfo);
     }
 
-    TBillingStats GetBillingStats() const override {
-        auto& record = Response->Get()->Record;
-        return {0, 0, record.GetReadRows(), record.GetReadBytes()};
-    }
-
     TString ResponseShortDebugString() const override {
         auto& record = Response->Get()->Record;
         return ToShortDebugString(record);

--- a/ydb/core/tx/schemeshard/schemeshard_build_index__progress.cpp
+++ b/ydb/core/tx/schemeshard/schemeshard_build_index__progress.cpp
@@ -1713,8 +1713,8 @@ public:
         NIceDb::TNiceDb db(txc.DB);
 
         auto stats = GetMeteringStats();
-        TMeteringStatsCalculator::AddTo(shardStatus.Processed, stats);
-        TMeteringStatsCalculator::AddTo(buildInfo.Processed, stats);
+        shardStatus.Processed += stats;
+        buildInfo.Processed += stats;
 
         NYql::TIssues issues;
         NYql::IssuesFromMessage(record.GetIssues(), issues);
@@ -1924,7 +1924,7 @@ public:
 
         NIceDb::TNiceDb db(txc.DB);
 
-        TMeteringStatsCalculator::AddTo(buildInfo.Processed, record.GetMeteringStats());
+        buildInfo.Processed += record.GetMeteringStats();
         // As long as we don't try to upload sample in parallel with requests to shards,
         // it's okay to persist Processed not incrementally
         Self->PersistBuildIndexProcessed(db, buildInfo);

--- a/ydb/core/tx/schemeshard/schemeshard_build_index__progress.cpp
+++ b/ydb/core/tx/schemeshard/schemeshard_build_index__progress.cpp
@@ -186,8 +186,8 @@ private:
         TAutoPtr<TEvIndexBuilder::TEvUploadSampleKResponse> response = new TEvIndexBuilder::TEvUploadSampleKResponse;
 
         response->Record.SetId(ui64(BuildId));
-        response->Record.SetUploadRows(UploadRows->size());
-        response->Record.SetUploadBytes(UploadBytes);
+        response->Record.MutableBillingStats()->SetUploadRows(UploadRows->size());
+        response->Record.MutableBillingStats()->SetUploadBytes(UploadBytes);
 
         UploadStatusToMessage(response->Record);
 
@@ -1713,8 +1713,8 @@ public:
         NIceDb::TNiceDb db(txc.DB);
 
         auto billingStats = GetBillingStats();
-        shardStatus.Processed += billingStats;
-        buildInfo.Processed += billingStats;
+        TBillingStatsCalculator::AddTo(shardStatus.Processed, billingStats);
+        TBillingStatsCalculator::AddTo(buildInfo.Processed, billingStats);
 
         NYql::TIssues issues;
         NYql::IssuesFromMessage(record.GetIssues(), issues);
@@ -1779,7 +1779,13 @@ public:
         Y_UNUSED(db, buildInfo);
     }
 
-    virtual TBillingStats GetBillingStats() const = 0;
+    virtual TBillingStats GetBillingStats() const {
+        auto& record = Response->Get()->Record;
+        if constexpr (requires { record.MutableBillingStats(); }) {
+            return record.GetBillingStats();
+        }
+        Y_ENSURE(false, "Should be overwritten");
+    }
 
     virtual TString ResponseShortDebugString() const {
         auto& record = Response->Get()->Record;
@@ -1822,11 +1828,6 @@ struct TSchemeShard::TIndexBuilder::TTxReplySampleK: public TTxShardReply<TEvDat
                 db.Table<Schema::KMeansTreeSample>().Key(buildInfo.Id, from).Delete();
             }
         }
-    }
-
-    TBillingStats GetBillingStats() const override {
-        auto& record = Response->Get()->Record;
-        return {0, 0, record.GetReadRows(), record.GetReadBytes()};
     }
 
     TString ResponseShortDebugString() const override {
@@ -1872,11 +1873,6 @@ struct TSchemeShard::TIndexBuilder::TTxReplyLocalKMeans: public TTxShardReply<TE
         : TTxShardReply(self, TIndexBuildId(response->Get()->Record.GetId()), response)
     {
     }
-
-    TBillingStats GetBillingStats() const override {
-        auto& record = Response->Get()->Record;
-        return {record.GetUploadRows(), record.GetUploadBytes(), record.GetReadRows(), record.GetReadBytes()};
-    }
 };
 
 struct TSchemeShard::TIndexBuilder::TTxReplyReshuffleKMeans: public TTxShardReply<TEvDataShard::TEvReshuffleKMeansResponse> {
@@ -1884,22 +1880,12 @@ struct TSchemeShard::TIndexBuilder::TTxReplyReshuffleKMeans: public TTxShardRepl
         : TTxShardReply(self, TIndexBuildId(response->Get()->Record.GetId()), response)
     {
     }
-
-    TBillingStats GetBillingStats() const override {
-        auto& record = Response->Get()->Record;
-        return {record.GetUploadRows(), record.GetUploadBytes(), record.GetReadRows(), record.GetReadBytes()};
-    }
 };
 
 struct TSchemeShard::TIndexBuilder::TTxReplyPrefixKMeans: public TTxShardReply<TEvDataShard::TEvPrefixKMeansResponse> {
     explicit TTxReplyPrefixKMeans(TSelf* self, TEvDataShard::TEvPrefixKMeansResponse::TPtr& response)
         : TTxShardReply(self, TIndexBuildId(response->Get()->Record.GetId()), response)
     {
-    }
-
-    TBillingStats GetBillingStats() const override {
-        auto& record = Response->Get()->Record;
-        return {record.GetUploadRows(), record.GetUploadBytes(), record.GetReadRows(), record.GetReadBytes()};
     }
 };
 
@@ -1938,8 +1924,7 @@ public:
 
         NIceDb::TNiceDb db(txc.DB);
 
-        TBillingStats stats{record.GetUploadRows(), record.GetUploadBytes(), 0, 0};
-        buildInfo.Processed += stats;
+        TBillingStatsCalculator::AddTo(buildInfo.Processed, record.GetBillingStats());
         // As long as we don't try to upload sample in parallel with requests to shards,
         // it's okay to persist Processed not incrementally
         Self->PersistBuildIndexProcessed(db, buildInfo);
@@ -2004,7 +1989,12 @@ struct TSchemeShard::TIndexBuilder::TTxReplyProgress: public TTxShardReply<TEvDa
         auto& record = Response->Get()->Record;
         // secondary index reads and writes almost the same amount of data
         // do not count them separately for simplicity
-        return {record.GetRowsDelta(), record.GetBytesDelta(), record.GetRowsDelta(), record.GetBytesDelta()};
+        TBillingStats result;
+        result.SetUploadRows(record.GetRowsDelta());
+        result.SetUploadBytes(record.GetBytesDelta());
+        result.SetReadRows(record.GetRowsDelta());
+        result.SetReadBytes(record.GetBytesDelta());
+        return result;
     }
 };
 

--- a/ydb/core/tx/schemeshard/schemeshard_build_index_tx_base.cpp
+++ b/ydb/core/tx/schemeshard/schemeshard_build_index_tx_base.cpp
@@ -96,7 +96,7 @@ void TSchemeShard::TIndexBuilder::TTxBase::ApplyBill(NTabletFlatExecutor::TTrans
         auto& billed = buildInfo.Billed;
 
         auto toBill = processed;
-        TBillingStatsCalculator::SubFrom(processed, billed);
+        TBillingStatsCalculator::SubFrom(toBill, billed);
         if (TBillingStatsCalculator::IsZero(toBill)) {
             continue;
         }
@@ -163,7 +163,7 @@ void TSchemeShard::TIndexBuilder::TTxBase::ApplyBill(NTabletFlatExecutor::TTrans
             .Usage(TBillRecord::RequestUnits(requestUnits, startPeriod, endPeriod))
             .ToString();
 
-        LOG_D("ApplyBill: made a bill"
+        LOG_N("ApplyBill: made a bill"
               << ", buildInfo: " << buildInfo
               << ", record: '" << billRecord << "'");
 

--- a/ydb/core/tx/schemeshard/schemeshard_build_index_tx_base.cpp
+++ b/ydb/core/tx/schemeshard/schemeshard_build_index_tx_base.cpp
@@ -163,9 +163,13 @@ void TSchemeShard::TIndexBuilder::TTxBase::ApplyBill(NTabletFlatExecutor::TTrans
             .Usage(TBillRecord::RequestUnits(requestUnits, startPeriod, endPeriod))
             .ToString();
 
-        LOG_N("ApplyBill: made a bill"
+        LOG_N("ApplyBill: make a bill, id#" << id
+              << ", toBill: " << toBill
+              << ", requestUnits: " << requestUnits
+              << ", ReadTableRU: " << TRUCalculator::ReadTable(toBill.GetReadBytes())
+              << ", BulkUpsertRU: " << TRUCalculator::BulkUpsert(toBill.GetUploadBytes(), toBill.GetUploadRows())
               << ", buildInfo: " << buildInfo
-              << ", record: '" << billRecord << "'");
+              << ", billRecord: " << billRecord);
 
         auto request = MakeHolder<NMetering::TEvMetering::TEvWriteMeteringJson>(std::move(billRecord));
         // send message at Complete stage

--- a/ydb/core/tx/schemeshard/schemeshard_build_index_tx_base.cpp
+++ b/ydb/core/tx/schemeshard/schemeshard_build_index_tx_base.cpp
@@ -95,9 +95,8 @@ void TSchemeShard::TIndexBuilder::TTxBase::ApplyBill(NTabletFlatExecutor::TTrans
         auto& processed = buildInfo.Processed;
         auto& billed = buildInfo.Billed;
 
-        auto toBill = processed;
-        TMeteringStatsCalculator::SubFrom(toBill, billed);
-        if (TMeteringStatsCalculator::IsZero(toBill)) {
+        auto toBill = processed - billed;
+        if (TMeteringStatsHelper::IsZero(toBill)) {
             continue;
         }
 
@@ -149,7 +148,7 @@ void TSchemeShard::TIndexBuilder::TTxBase::ApplyBill(NTabletFlatExecutor::TTrans
 
         NIceDb::TNiceDb db(txc.DB);
 
-        TMeteringStatsCalculator::AddTo(billed, toBill);
+        billed += toBill;
         Self->PersistBuildIndexBilled(db, buildInfo);
 
         TString requestUnitsExplain;

--- a/ydb/core/tx/schemeshard/schemeshard_build_index_tx_base.cpp
+++ b/ydb/core/tx/schemeshard/schemeshard_build_index_tx_base.cpp
@@ -96,8 +96,8 @@ void TSchemeShard::TIndexBuilder::TTxBase::ApplyBill(NTabletFlatExecutor::TTrans
         auto& billed = buildInfo.Billed;
 
         auto toBill = processed;
-        TBillingStatsCalculator::SubFrom(toBill, billed);
-        if (TBillingStatsCalculator::IsZero(toBill)) {
+        TMeteringStatsCalculator::SubFrom(toBill, billed);
+        if (TMeteringStatsCalculator::IsZero(toBill)) {
             continue;
         }
 
@@ -149,7 +149,7 @@ void TSchemeShard::TIndexBuilder::TTxBase::ApplyBill(NTabletFlatExecutor::TTrans
 
         NIceDb::TNiceDb db(txc.DB);
 
-        TBillingStatsCalculator::AddTo(billed, toBill);
+        TMeteringStatsCalculator::AddTo(billed, toBill);
         Self->PersistBuildIndexBilled(db, buildInfo);
 
         ui64 requestUnits = TRUCalculator::Calculate(toBill);

--- a/ydb/core/tx/schemeshard/schemeshard_build_index_tx_base.h
+++ b/ydb/core/tx/schemeshard/schemeshard_build_index_tx_base.h
@@ -29,7 +29,6 @@ private:
     void ApplyOnExecute(NTabletFlatExecutor::TTransactionContext& txc, const TActorContext& ctx);
     void ApplyOnComplete(const TActorContext& ctx);
     void ApplySchedule(const TActorContext& ctx);
-    ui64 RequestUnits(const TBillingStats& stats);
     void RoundPeriod(TInstant& start, TInstant& end);
     void ApplyBill(NTabletFlatExecutor::TTransactionContext& txc, const TActorContext& ctx);
     bool OnUnhandledExceptionSafe(TTransactionContext& txc, const TActorContext& ctx, const std::exception& exc);

--- a/ydb/core/tx/schemeshard/schemeshard_info_types.h
+++ b/ydb/core/tx/schemeshard/schemeshard_info_types.h
@@ -3905,25 +3905,15 @@ NProtoBuf::Timestamp SecondsToProtoTimeStamp(ui64 sec);
 
 }
 
-template <>
-inline void Out<NKikimr::NSchemeShard::TIndexBuildInfo::TShardStatus>
-    (IOutputStream& o, const NKikimr::NSchemeShard::TIndexBuildInfo::TShardStatus& info)
-{
-    o << info.ToString();
+Y_DECLARE_OUT_SPEC(inline, NKikimr::NSchemeShard::TIndexBuildInfo::TShardStatus, stream, value) {
+    stream << value.ToString();
 }
 
-template <>
-inline void Out<NKikimrIndexBuilder::TMeteringStats>
-    (IOutputStream& o, const NKikimrIndexBuilder::TMeteringStats& stats)
-{
-    o << stats.ShortDebugString();
+Y_DECLARE_OUT_SPEC(inline, NKikimrIndexBuilder::TMeteringStats, stream, value) {
+    stream << value.ShortDebugString();
 }
 
-template <>
-inline void Out<NKikimr::NSchemeShard::TIndexBuildInfo>
-    (IOutputStream& o, const NKikimr::NSchemeShard::TIndexBuildInfo& info)
-{
-
+Y_DECLARE_OUT_SPEC(inline, NKikimr::NSchemeShard::TIndexBuildInfo, o, info) {
     o << "TBuildInfo{";
     o << " IndexBuildId: " << info.Id;
     o << ", Uid: " << info.Uid;

--- a/ydb/core/tx/schemeshard/schemeshard_info_types.h
+++ b/ydb/core/tx/schemeshard/schemeshard_info_types.h
@@ -3639,25 +3639,21 @@ public:
             row.template GetValueOrDefault<Schema::IndexBuild::AlterMainTableTxDone>(
                 indexInfo->AlterMainTableTxDone);
 
-        auto& billed = indexInfo->Billed;
-        billed = {
-            row.template GetValueOrDefault<Schema::IndexBuild::UploadRowsBilled>(0),
-            row.template GetValueOrDefault<Schema::IndexBuild::UploadBytesBilled>(0),
-            row.template GetValueOrDefault<Schema::IndexBuild::ReadRowsBilled>(0),
-            row.template GetValueOrDefault<Schema::IndexBuild::ReadBytesBilled>(0),
-        };
-        if (billed.GetUploadRows() != 0 && billed.GetReadRows() == 0 && indexInfo->IsFillBuildIndex()) {
-            // old format: assign upload to read
-            billed.SetReadRows(billed.GetUploadRows());
-            billed.SetReadBytes(billed.GetUploadBytes());
+        indexInfo->Billed.SetUploadRows(row.template GetValueOrDefault<Schema::IndexBuild::UploadRowsBilled>(0));
+        indexInfo->Billed.SetUploadBytes(row.template GetValueOrDefault<Schema::IndexBuild::UploadBytesBilled>(0));
+        indexInfo->Billed.SetReadRows(row.template GetValueOrDefault<Schema::IndexBuild::ReadRowsBilled>(0));
+        indexInfo->Billed.SetReadBytes(row.template GetValueOrDefault<Schema::IndexBuild::ReadBytesBilled>(0));
+        if (indexInfo->IsFillBuildIndex()) {
+            TBillingStatsCalculator::TryFixOldFormat(indexInfo->Billed);
         }
 
-        indexInfo->Processed = {
-            row.template GetValueOrDefault<Schema::IndexBuild::UploadRowsProcessed>(0),
-            row.template GetValueOrDefault<Schema::IndexBuild::UploadBytesProcessed>(0),
-            row.template GetValueOrDefault<Schema::IndexBuild::ReadRowsProcessed>(0),
-            row.template GetValueOrDefault<Schema::IndexBuild::ReadBytesProcessed>(0),
-        };
+        indexInfo->Processed.SetUploadRows(row.template GetValueOrDefault<Schema::IndexBuild::UploadRowsProcessed>(0));
+        indexInfo->Processed.SetUploadBytes(row.template GetValueOrDefault<Schema::IndexBuild::UploadBytesProcessed>(0));
+        indexInfo->Processed.SetReadRows(row.template GetValueOrDefault<Schema::IndexBuild::ReadRowsProcessed>(0));
+        indexInfo->Processed.SetReadBytes(row.template GetValueOrDefault<Schema::IndexBuild::ReadBytesProcessed>(0));
+        if (indexInfo->IsFillBuildIndex()) {
+            TBillingStatsCalculator::TryFixOldFormat(indexInfo->Processed);
+        }
 
         // Restore the operation details: ImplTableDescriptions and SpecializedIndexDescription.
         if (row.template HaveValue<Schema::IndexBuild::CreationConfig>()) {

--- a/ydb/core/tx/schemeshard/schemeshard_info_types.h
+++ b/ydb/core/tx/schemeshard/schemeshard_info_types.h
@@ -3354,7 +3354,7 @@ public:
         Ydb::StatusIds::StatusCode UploadStatus = Ydb::StatusIds::STATUS_CODE_UNSPECIFIED;
         TString DebugMessage;
 
-        TBillingStats Processed;
+        TMeteringStats Processed = TMeteringStatsCalculator::Zero();
 
         TShardStatus(TSerializedTableRange range, TString lastKeyAck);
 
@@ -3384,8 +3384,8 @@ public:
     std::vector<TShardIdx> DoneShards;
     ui32 MaxInProgressShards = 32;
 
-    TBillingStats Processed;
-    TBillingStats Billed;
+    TMeteringStats Processed = TMeteringStatsCalculator::Zero();
+    TMeteringStats Billed = TMeteringStatsCalculator::Zero();
 
     struct TSample {
         struct TRow {
@@ -3644,7 +3644,7 @@ public:
         indexInfo->Billed.SetReadRows(row.template GetValueOrDefault<Schema::IndexBuild::ReadRowsBilled>(0));
         indexInfo->Billed.SetReadBytes(row.template GetValueOrDefault<Schema::IndexBuild::ReadBytesBilled>(0));
         if (indexInfo->IsFillBuildIndex()) {
-            TBillingStatsCalculator::TryFixOldFormat(indexInfo->Billed);
+            TMeteringStatsCalculator::TryFixOldFormat(indexInfo->Billed);
         }
 
         indexInfo->Processed.SetUploadRows(row.template GetValueOrDefault<Schema::IndexBuild::UploadRowsProcessed>(0));
@@ -3652,7 +3652,7 @@ public:
         indexInfo->Processed.SetReadRows(row.template GetValueOrDefault<Schema::IndexBuild::ReadRowsProcessed>(0));
         indexInfo->Processed.SetReadBytes(row.template GetValueOrDefault<Schema::IndexBuild::ReadBytesProcessed>(0));
         if (indexInfo->IsFillBuildIndex()) {
-            TBillingStatsCalculator::TryFixOldFormat(indexInfo->Processed);
+            TMeteringStatsCalculator::TryFixOldFormat(indexInfo->Processed);
         }
 
         // Restore the operation details: ImplTableDescriptions and SpecializedIndexDescription.
@@ -3721,9 +3721,9 @@ public:
         shardStatus.Processed.SetReadRows(row.template GetValueOrDefault<Schema::IndexBuildShardStatus::ReadRowsProcessed>(0));
         shardStatus.Processed.SetReadBytes(row.template GetValueOrDefault<Schema::IndexBuildShardStatus::ReadBytesProcessed>(0));
         if (IsFillBuildIndex()) {
-            TBillingStatsCalculator::TryFixOldFormat(shardStatus.Processed);
+            TMeteringStatsCalculator::TryFixOldFormat(shardStatus.Processed);
         }
-        TBillingStatsCalculator::AddTo(Processed, shardStatus.Processed);
+        TMeteringStatsCalculator::AddTo(Processed, shardStatus.Processed);
     }
 
     bool IsCancellationRequested() const {
@@ -3913,8 +3913,8 @@ inline void Out<NKikimr::NSchemeShard::TIndexBuildInfo::TShardStatus>
 }
 
 template <>
-inline void Out<NKikimrIndexBuilder::TBillingStats>
-    (IOutputStream& o, const NKikimrIndexBuilder::TBillingStats& stats)
+inline void Out<NKikimrIndexBuilder::TMeteringStats>
+    (IOutputStream& o, const NKikimrIndexBuilder::TMeteringStats& stats)
 {
     o << stats.ShortDebugString();
 }

--- a/ydb/core/tx/schemeshard/schemeshard_info_types.h
+++ b/ydb/core/tx/schemeshard/schemeshard_info_types.h
@@ -3354,7 +3354,7 @@ public:
         Ydb::StatusIds::StatusCode UploadStatus = Ydb::StatusIds::STATUS_CODE_UNSPECIFIED;
         TString DebugMessage;
 
-        TMeteringStats Processed = TMeteringStatsCalculator::Zero();
+        TMeteringStats Processed = TMeteringStatsHelper::ZeroValue();
 
         TShardStatus(TSerializedTableRange range, TString lastKeyAck);
 
@@ -3384,8 +3384,8 @@ public:
     std::vector<TShardIdx> DoneShards;
     ui32 MaxInProgressShards = 32;
 
-    TMeteringStats Processed = TMeteringStatsCalculator::Zero();
-    TMeteringStats Billed = TMeteringStatsCalculator::Zero();
+    TMeteringStats Processed = TMeteringStatsHelper::ZeroValue();
+    TMeteringStats Billed = TMeteringStatsHelper::ZeroValue();
 
     struct TSample {
         struct TRow {
@@ -3644,7 +3644,7 @@ public:
         indexInfo->Billed.SetReadRows(row.template GetValueOrDefault<Schema::IndexBuild::ReadRowsBilled>(0));
         indexInfo->Billed.SetReadBytes(row.template GetValueOrDefault<Schema::IndexBuild::ReadBytesBilled>(0));
         if (indexInfo->IsFillBuildIndex()) {
-            TMeteringStatsCalculator::TryFixOldFormat(indexInfo->Billed);
+            TMeteringStatsHelper::TryFixOldFormat(indexInfo->Billed);
         }
 
         indexInfo->Processed.SetUploadRows(row.template GetValueOrDefault<Schema::IndexBuild::UploadRowsProcessed>(0));
@@ -3652,7 +3652,7 @@ public:
         indexInfo->Processed.SetReadRows(row.template GetValueOrDefault<Schema::IndexBuild::ReadRowsProcessed>(0));
         indexInfo->Processed.SetReadBytes(row.template GetValueOrDefault<Schema::IndexBuild::ReadBytesProcessed>(0));
         if (indexInfo->IsFillBuildIndex()) {
-            TMeteringStatsCalculator::TryFixOldFormat(indexInfo->Processed);
+            TMeteringStatsHelper::TryFixOldFormat(indexInfo->Processed);
         }
 
         // Restore the operation details: ImplTableDescriptions and SpecializedIndexDescription.
@@ -3721,9 +3721,9 @@ public:
         shardStatus.Processed.SetReadRows(row.template GetValueOrDefault<Schema::IndexBuildShardStatus::ReadRowsProcessed>(0));
         shardStatus.Processed.SetReadBytes(row.template GetValueOrDefault<Schema::IndexBuildShardStatus::ReadBytesProcessed>(0));
         if (IsFillBuildIndex()) {
-            TMeteringStatsCalculator::TryFixOldFormat(shardStatus.Processed);
+            TMeteringStatsHelper::TryFixOldFormat(shardStatus.Processed);
         }
-        TMeteringStatsCalculator::AddTo(Processed, shardStatus.Processed);
+        Processed += shardStatus.Processed;
     }
 
     bool IsCancellationRequested() const {

--- a/ydb/core/tx/schemeshard/ut_helpers/helpers.cpp
+++ b/ydb/core/tx/schemeshard/ut_helpers/helpers.cpp
@@ -2010,6 +2010,14 @@ namespace NSchemeShardUT_Private {
         return event->Record;
     }
 
+    TString TestGetBuildIndexHtml(TTestActorRuntime& runtime, ui64 schemeShard, ui64 id) {
+        auto sender = runtime.AllocateEdgeActor();
+        auto httpRequest = std::make_unique<NActors::NMon::TEvRemoteHttpInfo>(TStringBuilder() << "/app?Page=BuildIndexInfo&BuildIndexId=" << id);
+        runtime.SendToPipe(schemeShard, sender, httpRequest.release(), 0, {});
+        auto httpResponse = runtime.GrabEdgeEventRethrow<NActors::NMon::TEvRemoteHttpInfoRes>(sender);
+        return httpResponse->Get()->Html;
+    }
+
     TEvIndexBuilder::TEvForgetRequest* ForgetBuildIndexRequest(const ui64 id, const TString &dbName, const ui64 buildIndexId) {
         return new TEvIndexBuilder::TEvForgetRequest(id, dbName, buildIndexId);
     }

--- a/ydb/core/tx/schemeshard/ut_helpers/helpers.h
+++ b/ydb/core/tx/schemeshard/ut_helpers/helpers.h
@@ -418,6 +418,7 @@ namespace NSchemeShardUT_Private {
     NKikimrIndexBuilder::TEvListResponse TestListBuildIndex(TTestActorRuntime& runtime, ui64 schemeShard, const TString &dbName);
     TEvIndexBuilder::TEvGetRequest* GetBuildIndexRequest(const TString& dbName, ui64 id);
     NKikimrIndexBuilder::TEvGetResponse TestGetBuildIndex(TTestActorRuntime& runtime, ui64 schemeShard, const TString &dbName, ui64 id);
+    TString TestGetBuildIndexHtml(TTestActorRuntime& runtime, ui64 schemeShard, ui64 id);
     TEvIndexBuilder::TEvForgetRequest* ForgetBuildIndexRequest(const ui64 id, const TString &dbName, const ui64 buildIndexId);
     NKikimrIndexBuilder::TEvForgetResponse TestForgetBuildIndex(TTestActorRuntime& runtime, const ui64 id, const ui64 schemeShard, const TString &dbName, const ui64 buildIndexId, Ydb::StatusIds::StatusCode expectedStatus = Ydb::StatusIds::SUCCESS);
 

--- a/ydb/core/tx/schemeshard/ut_index_build/ut_vector_index_build.cpp
+++ b/ydb/core/tx/schemeshard/ut_index_build/ut_vector_index_build.cpp
@@ -317,7 +317,7 @@ Y_UNIT_TEST_SUITE (VectorIndexBuildTest) {
         }
     }
 
-    Y_UNIT_TEST(Metering_CommonDB) {
+    Y_UNIT_TEST(CommonDB) {
         TTestBasicRuntime runtime;
         TTestEnv env(runtime);
         ui64 txId = 100;
@@ -425,7 +425,7 @@ Y_UNIT_TEST_SUITE (VectorIndexBuildTest) {
         UNIT_ASSERT_VALUES_EQUAL(meteringBlocker.size(), 0);
     }
 
-    Y_UNIT_TEST_FLAG(Metering_ServerLessDB, smallScanBuffer) {
+    Y_UNIT_TEST_FLAG(ServerLessDB, smallScanBuffer) {
         TTestBasicRuntime runtime;
         TTestEnv env(runtime);
         ui64 txId = 100;
@@ -471,12 +471,16 @@ Y_UNIT_TEST_SUITE (VectorIndexBuildTest) {
         ui64 uploadRows = 0, uploadBytes = 0, readRows = 0, readBytes = 0;
         ui64 expectedUploadRows = 0, expectedUploadBytes = 0, expectedReadRows = 0, expectedReadBytes = 0;
         auto logBillingStats = [&]() {
-            Cerr << "BillingStats: " << billingStats.ShortDebugString() << Endl;
+            Cerr << "BillingStats:"
+                << " uploadRows: " << uploadRows << " uploadBytes: " << uploadBytes
+                << " readRows: " << readRows << " readBytes: " << readBytes
+                << Endl;
         };
 
         TBlockEvents<TEvDataShard::TEvSampleKResponse> sampleKBlocker(runtime, [&](const auto& ev) {
             auto response = ev->Get()->Record;
-            TBillingStatsCalculator::AddTo(billingStats, *response.MutableBillingStats());
+            readRows += response.GetReadRows();
+            readBytes += response.GetReadBytes();
             return true;
         });
 
@@ -496,19 +500,26 @@ Y_UNIT_TEST_SUITE (VectorIndexBuildTest) {
 
         TBlockEvents<TEvIndexBuilder::TEvUploadSampleKResponse> uploadSampleKBlocker(runtime, [&](const auto& ev) {
             auto response = ev->Get()->Record;
-            TBillingStatsCalculator::AddTo(billingStats, *response.MutableBillingStats());
+            uploadRows += response.GetUploadRows();
+            uploadBytes += response.GetUploadBytes();
             return true;
         });
 
         TBlockEvents<TEvDataShard::TEvReshuffleKMeansResponse> reshuffleBlocker(runtime, [&](const auto& ev) {
             auto response = ev->Get()->Record;
-            TBillingStatsCalculator::AddTo(billingStats, *response.MutableBillingStats());
+            uploadRows += response.GetUploadRows();
+            uploadBytes += response.GetUploadBytes();
+            readRows += response.GetReadRows();
+            readBytes += response.GetReadBytes();
             return true;
         });
 
         TBlockEvents<TEvDataShard::TEvLocalKMeansResponse> localKMeansBlocker(runtime, [&](const auto& ev) {
             auto response = ev->Get()->Record;
-            TBillingStatsCalculator::AddTo(billingStats, *response.MutableBillingStats());
+            uploadRows += response.GetUploadRows();
+            uploadBytes += response.GetUploadBytes();
+            readRows += response.GetReadRows();
+            readBytes += response.GetReadBytes();
             return true;
         });
 
@@ -589,10 +600,11 @@ Y_UNIT_TEST_SUITE (VectorIndexBuildTest) {
 =======
             UNIT_ASSERT_VALUES_EQUAL(meteringBlocker[0]->Get()->MeteringJson, expectedBill.ToString());
 <<<<<<< HEAD
+<<<<<<< HEAD
 >>>>>>> d2fd957ba9d (Metering_ServerLessDB_Restarts)
-            previousBillId = newBillId;
 =======
->>>>>>> 436575d4f74 (Metering_ServerLessDB_Restarts)
+>>>>>>> b53802b554b (copy-paste main version)
+            previousBillId = newBillId;
             meteringBlocker.Unblock();
         }
 
@@ -606,22 +618,16 @@ Y_UNIT_TEST_SUITE (VectorIndexBuildTest) {
         expectedReadRows += tableRows;
         expectedReadBytes += tableBytes;
         logBillingStats();
-<<<<<<< HEAD
         UNIT_ASSERT_VALUES_EQUAL(uploadRows, expectedUploadRows);
         UNIT_ASSERT_VALUES_EQUAL(uploadBytes, expectedUploadBytes);
         UNIT_ASSERT_VALUES_EQUAL(readRows, expectedReadRows);
         UNIT_ASSERT_VALUES_EQUAL(readBytes, expectedReadBytes);
-=======
-        UNIT_ASSERT_VALUES_EQUAL(billingStats.GetUploadRows(), 204);
-        UNIT_ASSERT_VALUES_EQUAL(billingStats.GetUploadBytes(), 6748);
-        UNIT_ASSERT_VALUES_EQUAL(billingStats.GetReadRows(), 400);
-        UNIT_ASSERT_VALUES_EQUAL(billingStats.GetReadBytes(), 3600);
->>>>>>> c903f14f54b (fix rebase)
 
         for (ui32 shard = 0; shard < 4; shard++) {
             runtime.WaitFor("localKMeans", [&]{ return localKMeansBlocker.size(); });
             localKMeansBlocker.Unblock();
         }
+<<<<<<< HEAD
 
         // KMEANS writes build table once and forms at least K, at most K * K level rows
         // (depending on clustering uniformity; it's not so good on test data)
@@ -635,7 +641,14 @@ Y_UNIT_TEST_SUITE (VectorIndexBuildTest) {
         UNIT_ASSERT_VALUES_EQUAL(billingStats.GetUploadRows(), 420);
         UNIT_ASSERT_VALUES_EQUAL(billingStats.GetUploadBytes(), 11740);
         if (smallScanBuffer) {
-            // KMEANS reads build table 5 times (SAMPLE + KMEANS * 3 + UPLOAD):
+            // KMEANS reads build table 6 times (SAMPLE + KMEANS * 4 + UPLOAD):
+            expectedReadRows += tableRows * 6;
+            expectedReadBytes += buildBytes * 6;
+        // KMEANS writes build table once and forms K * K level rows:
+        expectedUploadRows += tableRows + K * K;
+        expectedUploadBytes += postingBytes + K * K * levelRowBytes;
+        if (smallScanBuffer) {
+            // KMEANS reads build table five times (SAMPLE + KMEANS * 3 + UPLOAD):
             expectedReadRows += tableRows * 5;
             expectedReadBytes += buildBytes * 5;
         } else {
@@ -683,150 +696,12 @@ Y_UNIT_TEST_SUITE (VectorIndexBuildTest) {
 =======
             UNIT_ASSERT_VALUES_EQUAL(meteringBlocker[0]->Get()->MeteringJson, expectedBill.ToString());
 <<<<<<< HEAD
+<<<<<<< HEAD
 >>>>>>> d2fd957ba9d (Metering_ServerLessDB_Restarts)
+=======
+>>>>>>> b53802b554b (copy-paste main version)
             previousBillId = newBillId;
             meteringBlocker.Stop().Unblock();
-=======
-            meteringBlocker.Stop().Unblock();
-        }
-    }
-
-    Y_UNIT_TEST_FLAG(Metering_ServerLessDB_Restarts, doRestarts) {
-        TTestBasicRuntime runtime;
-        TTestEnv env(runtime);
-        ui64 txId = 100;
-
-        runtime.SetLogPriority(NKikimrServices::TX_DATASHARD, NLog::PRI_TRACE);
-        runtime.SetLogPriority(NKikimrServices::BUILD_INDEX, NLog::PRI_TRACE);
-
-        ui64 tenantSchemeShard = 0;
-        TestCreateServerLessDb(runtime, env, txId, tenantSchemeShard);
-
-        TestCreateTable(runtime, tenantSchemeShard, ++txId, "/MyRoot/ServerLessDB", R"(
-            Name: "Table"
-            Columns { Name: "key"       Type: "Uint32" }
-            Columns { Name: "embedding" Type: "String" }
-            KeyColumnNames: ["key"]
-            SplitBoundary { KeyPrefix { Tuple { Optional { Uint32: 50 } } } }
-            SplitBoundary { KeyPrefix { Tuple { Optional { Uint32: 150 } } } }
-        )");
-        env.TestWaitNotification(runtime, txId, tenantSchemeShard);
-
-        // Write data directly into shards
-        WriteVectorTableRows(runtime, tenantSchemeShard, ++txId, "/MyRoot/ServerLessDB/Table", false, 0, 0, 50);
-        WriteVectorTableRows(runtime, tenantSchemeShard, ++txId, "/MyRoot/ServerLessDB/Table", false, 1, 50, 150);
-        WriteVectorTableRows(runtime, tenantSchemeShard, ++txId, "/MyRoot/ServerLessDB/Table", false, 2, 150, 200);
-
-        TBlockEvents<NMetering::TEvMetering::TEvWriteMeteringJson> meteringBlocker(runtime, [&](const auto& ev) {
-            Cerr << "TEvWriteMeteringJson " << ev->Get()->MeteringJson << Endl;
-            return true;
-        });
-
-        TBlockEvents<TEvDataShard::TEvReshuffleKMeansResponse> reshuffleBlocker(runtime, [&](const auto&) {
-            return true;
-        });
-
-        // Build vector index with max_shards_in_flight(1) to guarantee deterministic metering data
-        ui64 buildIndexTx = ++txId;
-        {
-            auto sender = runtime.AllocateEdgeActor();
-            auto request = CreateBuildIndexRequest(buildIndexTx, "/MyRoot/ServerLessDB", "/MyRoot/ServerLessDB/Table", TBuildIndexConfig{
-                "index1", NKikimrSchemeOp::EIndexTypeGlobalVectorKmeansTree, {"embedding"}, {}
-            });
-            auto settings = request->Record.MutableSettings();
-            settings->set_max_shards_in_flight(1);
-            settings->MutableScanSettings()->SetMaxBatchRows(1);
-            auto kmeansSettings = request->Record.MutableSettings()->mutable_index()->Mutableglobal_vector_kmeans_tree_index();
-            kmeansSettings->Mutablevector_settings()->Setlevels(2);
-            kmeansSettings->Mutablevector_settings()->Setclusters(4);
-            ForwardToTablet(runtime, tenantSchemeShard, sender, request);
-        }
-
-        runtime.WaitFor("reshuffle", [&]{ return reshuffleBlocker.size(); });
-        {
-            auto buildIndexHtml = TestGetBuildIndexHtml(runtime, tenantSchemeShard, buildIndexTx);
-            Cout << "BuildIndex 1 " << buildIndexHtml << Endl;
-            UNIT_ASSERT_STRING_CONTAINS(buildIndexHtml, "Processed: { upload rows: 4, upload bytes: 148, read rows: 200, read bytes: 1800 }");
-            UNIT_ASSERT_STRING_CONTAINS(buildIndexHtml, "Billed: { upload rows: 0, upload bytes: 0, read rows: 0, read bytes: 0 }");
-        }
-        runtime.WaitFor("metering", [&]{ return meteringBlocker.size(); });
-        {
-            // id format: [billed uploadRows-readRows-uploadBytes-readBytes] [processed uploadRows-readRows-uploadBytes-readBytes]
-            auto expectedBill = TBillRecord()
-                .Id("109-72075186233409549-2-0-0-0-0-4-200-148-1800")
-                .CloudId("CLOUD_ID_VAL").FolderId("FOLDER_ID_VAL").ResourceId("DATABASE_ID_VAL")
-                .SourceWt(TInstant::Seconds(10))
-                .Usage(TBillRecord::RequestUnits(130, TInstant::Seconds(0), TInstant::Seconds(10)));
-            UNIT_ASSERT_VALUES_EQUAL(meteringBlocker.size(), 1);
-            UNIT_ASSERT_VALUES_EQUAL(meteringBlocker[0]->Get()->MeteringJson, expectedBill.ToString());
-            meteringBlocker.Unblock();
-        }
-        if (doRestarts) {
-            RebootTablet(runtime, tenantSchemeShard, runtime.AllocateEdgeActor());
-        }
-        {
-            auto buildIndexHtml = TestGetBuildIndexHtml(runtime, tenantSchemeShard, buildIndexTx);
-            Cout << "BuildIndex 2 " << buildIndexHtml << Endl;
-            UNIT_ASSERT_STRING_CONTAINS(buildIndexHtml, "Processed: { upload rows: 4, upload bytes: 148, read rows: 200, read bytes: 1800 }");
-            UNIT_ASSERT_STRING_CONTAINS(buildIndexHtml, "Billed: { upload rows: 4, upload bytes: 148, read rows: 200, read bytes: 1800 }");
-        }
-
-        reshuffleBlocker.Unblock();
-        runtime.WaitFor("reshuffle", [&]{ return reshuffleBlocker.size(); });
-        {
-            auto buildIndexHtml = TestGetBuildIndexHtml(runtime, tenantSchemeShard, buildIndexTx);
-            Cout << "BuildIndex 3 " << buildIndexHtml << Endl;
-            UNIT_ASSERT_STRING_CONTAINS(buildIndexHtml, "Processed: { upload rows: 54, upload bytes: 1798, read rows: 250, read bytes: 2250 }");
-            UNIT_ASSERT_STRING_CONTAINS(buildIndexHtml, "Billed: { upload rows: 4, upload bytes: 148, read rows: 200, read bytes: 1800 }");
-            UNIT_ASSERT_STRING_CONTAINS(buildIndexHtml, "<td>{ upload rows: 50, upload bytes: 1650, read rows: 50, read bytes: 450 }</td>"); // shard 1 stats
-        }
-        runtime.WaitFor("metering", [&]{ return meteringBlocker.size(); });
-        {
-            // id format: [billed uploadRows-readRows-uploadBytes-readBytes] [processed uploadRows-readRows-uploadBytes-readBytes]
-            auto expectedBill = TBillRecord()
-                .Id("109-72075186233409549-2-4-200-148-1800-54-250-1798-2250")
-                .CloudId("CLOUD_ID_VAL").FolderId("FOLDER_ID_VAL").ResourceId("DATABASE_ID_VAL")
-                .SourceWt(TInstant::Seconds(20))
-                .Usage(TBillRecord::RequestUnits(153, TInstant::Seconds(10), TInstant::Seconds(20)));
-            UNIT_ASSERT_VALUES_EQUAL(meteringBlocker.size(), 1);
-            UNIT_ASSERT_VALUES_EQUAL(meteringBlocker[0]->Get()->MeteringJson, expectedBill.ToString());
-            meteringBlocker.Unblock();
-        }
-        if (doRestarts) {
-            RebootTablet(runtime, tenantSchemeShard, runtime.AllocateEdgeActor());
-        }
-        {
-            auto buildIndexHtml = TestGetBuildIndexHtml(runtime, tenantSchemeShard, buildIndexTx);
-            Cout << "BuildIndex 4 " << buildIndexHtml << Endl;
-            UNIT_ASSERT_STRING_CONTAINS(buildIndexHtml, "Processed: { upload rows: 54, upload bytes: 1798, read rows: 250, read bytes: 2250 }");
-            UNIT_ASSERT_STRING_CONTAINS(buildIndexHtml, "Billed: { upload rows: 54, upload bytes: 1798, read rows: 250, read bytes: 2250 }");
-            UNIT_ASSERT_STRING_CONTAINS(buildIndexHtml, "<td>{ upload rows: 50, upload bytes: 1650, read rows: 50, read bytes: 450 }</td>"); // shard 1 stats
-        }
-
-        reshuffleBlocker.Stop().Unblock();
-        env.TestWaitNotification(runtime, buildIndexTx, tenantSchemeShard);
-
-        runtime.WaitFor("metering", [&]{ return meteringBlocker.size(); });
-        {
-            // id format: [billed uploadRows-readRows-uploadBytes-readBytes] [processed uploadRows-readRows-uploadBytes-readBytes]
-            auto expectedBill = TBillRecord()
-                .CloudId("CLOUD_ID_VAL").FolderId("FOLDER_ID_VAL").ResourceId("DATABASE_ID_VAL")
-                .SourceWt(TInstant::Seconds(20))
-                .Usage(TBillRecord::RequestUnits(311, TInstant::Seconds(20), TInstant::Seconds(20)));
-            expectedBill.Id("109-72075186233409549-2-54-250-1798-2250-420-1400-11740-20600");
-            UNIT_ASSERT_VALUES_EQUAL(meteringBlocker.size(), 1);
-            UNIT_ASSERT_VALUES_EQUAL(meteringBlocker[0]->Get()->MeteringJson, expectedBill.ToString());
-            meteringBlocker.Stop().Unblock();
-        }
-        if (doRestarts) {
-            RebootTablet(runtime, tenantSchemeShard, runtime.AllocateEdgeActor());
-        }
-        {
-            auto buildIndexHtml = TestGetBuildIndexHtml(runtime, tenantSchemeShard, buildIndexTx);
-            Cout << "BuildIndex 5 " << buildIndexHtml << Endl;
-            UNIT_ASSERT_STRING_CONTAINS(buildIndexHtml, "Processed: { upload rows: 420, upload bytes: 11740, read rows: 1400, read bytes: 20600 }");
-            UNIT_ASSERT_STRING_CONTAINS(buildIndexHtml, "Billed: { upload rows: 420, upload bytes: 11740, read rows: 1400, read bytes: 20600 }");
->>>>>>> 436575d4f74 (Metering_ServerLessDB_Restarts)
         }
     }
 
@@ -1237,7 +1112,7 @@ Y_UNIT_TEST_SUITE (VectorIndexBuildTest) {
             );
             UNIT_ASSERT_STRING_CONTAINS(buildIndexOperation.DebugString(), "One of the shards report BUILD_ERROR");
             UNIT_ASSERT_STRING_CONTAINS(buildIndexOperation.DebugString(), "Error: Datashard test fail");
-            UNIT_ASSERT_STRING_CONTAINS(buildIndexOperation.DebugString(), "Processed: UploadRows: 0 UploadBytes: 0 ReadRows: 0 ReadBytes: 0");
+            UNIT_ASSERT_STRING_CONTAINS(buildIndexOperation.DebugString(), "Processed: { upload rows: 0, upload bytes: 0, read rows: 0, read bytes: 0 } }");
         }
 
         RebootTablet(runtime, TTestTxConfig::SchemeShard, runtime.AllocateEdgeActor());
@@ -1251,7 +1126,7 @@ Y_UNIT_TEST_SUITE (VectorIndexBuildTest) {
             );
             UNIT_ASSERT_STRING_CONTAINS(buildIndexOperation.DebugString(), "One of the shards report BUILD_ERROR");
             UNIT_ASSERT_STRING_CONTAINS(buildIndexOperation.DebugString(), "Error: Datashard test fail");
-            UNIT_ASSERT_STRING_CONTAINS(buildIndexOperation.DebugString(), "Processed: UploadRows: 0 UploadBytes: 0 ReadRows: 0 ReadBytes: 0");
+            UNIT_ASSERT_STRING_CONTAINS(buildIndexOperation.DebugString(), "Processed: { upload rows: 0, upload bytes: 0, read rows: 0, read bytes: 0 } }");
         }
     }
 }

--- a/ydb/core/tx/schemeshard/ut_index_build/ut_vector_index_build.cpp
+++ b/ydb/core/tx/schemeshard/ut_index_build/ut_vector_index_build.cpp
@@ -598,14 +598,7 @@ Y_UNIT_TEST_SUITE (VectorIndexBuildTest) {
         expectedBillingStats.SetUploadRows(expectedBillingStats.GetUploadRows() + level2clusters);
         expectedBillingStats.SetUploadBytes(expectedBillingStats.GetUploadBytes() + level2clusters * levelRowBytes);
         if (smallScanBuffer) {
-            // KMEANS reads build table 6 times (SAMPLE + KMEANS * 4 + UPLOAD):
-            expectedReadRows += tableRows * 6;
-            expectedReadBytes += buildBytes * 6;
-        // KMEANS writes build table once and forms K * K level rows:
-        expectedBillingStats.SetUploadRows(expectedBillingStats.GetUploadRows() + tableRows + K * K);
-        expectedBillingStats.SetUploadBytes(expectedBillingStats.GetUploadBytes() + postingBytes + K * K * levelRowBytes);
-        if (smallScanBuffer) {
-            // KMEANS reads build table five times (SAMPLE + KMEANS * 3 + UPLOAD):
+            // KMEANS reads build table 5 times (SAMPLE + KMEANS * 4 + UPLOAD):
             expectedBillingStats.SetReadRows(expectedBillingStats.GetReadRows() + tableRows * 5);
             expectedBillingStats.SetReadBytes(expectedBillingStats.GetReadBytes() +  buildBytes * 5);
         } else {
@@ -727,9 +720,9 @@ Y_UNIT_TEST_SUITE (VectorIndexBuildTest) {
         // SAMPLE reads table once, no writes:
         expectedBillingStats.SetReadRows(expectedBillingStats.GetReadRows() + tableRows);
         expectedBillingStats.SetReadBytes(expectedBillingStats.GetReadBytes() +  tableBytes);
-        // every RECOMPUTE round reads table once, no writes; there are 4 recompute rounds:
-        expectedBillingStats.SetReadRows(expectedBillingStats.GetReadRows() + tableRows * 4);
-        expectedBillingStats.SetReadBytes(expectedBillingStats.GetReadBytes() +  tableBytes * 4);
+        // every RECOMPUTE round reads table once, no writes; there are 3 recompute rounds:
+        expectedBillingStats.SetReadRows(expectedBillingStats.GetReadRows() + tableRows * 3);
+        expectedBillingStats.SetReadBytes(expectedBillingStats.GetReadBytes() +  tableBytes * 3);
         // upload SAMPLE writes K level rows, no reads:
         expectedBillingStats.SetUploadRows(expectedBillingStats.GetUploadRows() + K);
         expectedBillingStats.SetUploadBytes(expectedBillingStats.GetUploadBytes() + K * levelRowBytes);
@@ -834,9 +827,9 @@ Y_UNIT_TEST_SUITE (VectorIndexBuildTest) {
         // KMEANS writes build table once and forms K * K level rows:
         expectedBillingStats.SetUploadRows(expectedBillingStats.GetUploadRows() + tableRows + K * K);
         expectedBillingStats.SetUploadBytes(expectedBillingStats.GetUploadBytes() + postingBytes + K * K * levelRowBytes);
-        // KMEANS reads build table five times (SAMPLE + KMEANS * 3 + UPLOAD):
-        expectedBillingStats.SetReadRows(expectedBillingStats.GetReadRows() + tableRows * 6); // TODO: * 5
-        expectedBillingStats.SetReadBytes(expectedBillingStats.GetReadBytes() +  buildBytes * 6);
+        // KMEANS reads build table 5 times (SAMPLE + KMEANS * 3 + UPLOAD):
+        expectedBillingStats.SetReadRows(expectedBillingStats.GetReadRows() + tableRows * 5);
+        expectedBillingStats.SetReadBytes(expectedBillingStats.GetReadBytes() +  buildBytes * 5);
         {
             auto buildIndexHtml = TestGetBuildIndexHtml(runtime, tenantSchemeShard, buildIndexTx);
             Cout << "BuildIndex 5 " << buildIndexHtml << Endl;
@@ -1005,7 +998,6 @@ Y_UNIT_TEST_SUITE (VectorIndexBuildTest) {
         TTestBasicRuntime runtime;
         TTestEnv env(runtime);
         ui64 txId = 100;
-
         runtime.SetLogPriority(NKikimrServices::TX_DATASHARD, NLog::PRI_TRACE);
         runtime.SetLogPriority(NKikimrServices::BUILD_INDEX, NLog::PRI_TRACE);
 

--- a/ydb/core/tx/schemeshard/ut_index_build/ut_vector_index_build.cpp
+++ b/ydb/core/tx/schemeshard/ut_index_build/ut_vector_index_build.cpp
@@ -764,9 +764,9 @@ Y_UNIT_TEST_SUITE (VectorIndexBuildTest) {
         {
             auto buildIndexHtml = TestGetBuildIndexHtml(runtime, tenantSchemeShard, buildIndexTx);
             Cout << "BuildIndex 1 " << buildIndexHtml << Endl;
-            UNIT_ASSERT_STRING_CONTAINS(buildIndexHtml,  "Processed: { " + expectedBillingStats.ShortDebugString());
+            UNIT_ASSERT_STRING_CONTAINS(buildIndexHtml,  "Processed: " + expectedBillingStats.ShortDebugString());
             UNIT_ASSERT_STRING_CONTAINS(buildIndexHtml, "Request Units: 130 (ReadTable: 128, BulkUpsert: 2)");
-            UNIT_ASSERT_STRING_CONTAINS(buildIndexHtml,  "Billed: { " + billedStats.ShortDebugString());
+            UNIT_ASSERT_STRING_CONTAINS(buildIndexHtml,  "Billed: " + billedStats.ShortDebugString());
         }
         runtime.WaitFor("metering", [&]{ return meteringBlocker.size(); });
         {
@@ -792,9 +792,9 @@ Y_UNIT_TEST_SUITE (VectorIndexBuildTest) {
         {
             auto buildIndexHtml = TestGetBuildIndexHtml(runtime, tenantSchemeShard, buildIndexTx);
             Cout << "BuildIndex 2 " << buildIndexHtml << Endl;
-            UNIT_ASSERT_STRING_CONTAINS(buildIndexHtml,  "Processed: { " + expectedBillingStats.ShortDebugString());
+            UNIT_ASSERT_STRING_CONTAINS(buildIndexHtml,  "Processed: " + expectedBillingStats.ShortDebugString());
             UNIT_ASSERT_STRING_CONTAINS(buildIndexHtml, "Request Units: 130 (ReadTable: 128, BulkUpsert: 2)");
-            UNIT_ASSERT_STRING_CONTAINS(buildIndexHtml,  "Billed: { " + billedStats.ShortDebugString());
+            UNIT_ASSERT_STRING_CONTAINS(buildIndexHtml,  "Billed: " + billedStats.ShortDebugString());
         }
 
         reshuffleBlocker.Unblock();
@@ -809,10 +809,10 @@ Y_UNIT_TEST_SUITE (VectorIndexBuildTest) {
         {
             auto buildIndexHtml = TestGetBuildIndexHtml(runtime, tenantSchemeShard, buildIndexTx);
             Cout << "BuildIndex 3 " << buildIndexHtml << Endl;
-            UNIT_ASSERT_STRING_CONTAINS(buildIndexHtml,  "Processed: { " + expectedBillingStats.ShortDebugString());
+            UNIT_ASSERT_STRING_CONTAINS(buildIndexHtml,  "Processed: " + expectedBillingStats.ShortDebugString());
             UNIT_ASSERT_STRING_CONTAINS(buildIndexHtml, "Request Units: 155 (ReadTable: 128, BulkUpsert: 27)");
-            UNIT_ASSERT_STRING_CONTAINS(buildIndexHtml,  "Billed: { " + billedStats.ShortDebugString());
-            UNIT_ASSERT_STRING_CONTAINS(buildIndexHtml, "<td>{ " + shardReshuffleBillingStats.ShortDebugString());
+            UNIT_ASSERT_STRING_CONTAINS(buildIndexHtml,  "Billed: " + billedStats.ShortDebugString());
+            UNIT_ASSERT_STRING_CONTAINS(buildIndexHtml, "<td>" + shardReshuffleBillingStats.ShortDebugString());
         }
         runtime.WaitFor("metering", [&]{ return meteringBlocker.size(); });
         {
@@ -838,10 +838,10 @@ Y_UNIT_TEST_SUITE (VectorIndexBuildTest) {
         {
             auto buildIndexHtml = TestGetBuildIndexHtml(runtime, tenantSchemeShard, buildIndexTx);
             Cout << "BuildIndex 4 " << buildIndexHtml << Endl;
-            UNIT_ASSERT_STRING_CONTAINS(buildIndexHtml,  "Processed: { " + expectedBillingStats.ShortDebugString());
+            UNIT_ASSERT_STRING_CONTAINS(buildIndexHtml,  "Processed: " + expectedBillingStats.ShortDebugString());
             UNIT_ASSERT_STRING_CONTAINS(buildIndexHtml, "Request Units: 155 (ReadTable: 128, BulkUpsert: 27)");
-            UNIT_ASSERT_STRING_CONTAINS(buildIndexHtml,  "Billed: { " + billedStats.ShortDebugString());
-            UNIT_ASSERT_STRING_CONTAINS(buildIndexHtml, "<td>{ " + shardReshuffleBillingStats.ShortDebugString());
+            UNIT_ASSERT_STRING_CONTAINS(buildIndexHtml,  "Billed: " + billedStats.ShortDebugString());
+            UNIT_ASSERT_STRING_CONTAINS(buildIndexHtml, "<td>" + shardReshuffleBillingStats.ShortDebugString());
         }
 
         reshuffleBlocker.Stop().Unblock();
@@ -868,9 +868,9 @@ Y_UNIT_TEST_SUITE (VectorIndexBuildTest) {
         {
             auto buildIndexHtml = TestGetBuildIndexHtml(runtime, tenantSchemeShard, buildIndexTx);
             Cout << "BuildIndex 5 " << buildIndexHtml << Endl;
-            UNIT_ASSERT_STRING_CONTAINS(buildIndexHtml,  "Processed: { " + expectedBillingStats.ShortDebugString());
+            UNIT_ASSERT_STRING_CONTAINS(buildIndexHtml,  "Processed: " + expectedBillingStats.ShortDebugString());
             UNIT_ASSERT_STRING_CONTAINS(buildIndexHtml, "Request Units: 338 (ReadTable: 128, BulkUpsert: 210)");
-            UNIT_ASSERT_STRING_CONTAINS(buildIndexHtml,  "Billed: { " + expectedBillingStats.ShortDebugString());
+            UNIT_ASSERT_STRING_CONTAINS(buildIndexHtml,  "Billed: " + expectedBillingStats.ShortDebugString());
         }
         runtime.WaitFor("metering", [&]{ return meteringBlocker.size(); });
         {
@@ -896,9 +896,9 @@ Y_UNIT_TEST_SUITE (VectorIndexBuildTest) {
         {
             auto buildIndexHtml = TestGetBuildIndexHtml(runtime, tenantSchemeShard, buildIndexTx);
             Cout << "BuildIndex 6 " << buildIndexHtml << Endl;
-            UNIT_ASSERT_STRING_CONTAINS(buildIndexHtml,  "Processed: { " + expectedBillingStats.ShortDebugString());
+            UNIT_ASSERT_STRING_CONTAINS(buildIndexHtml,  "Processed: " + expectedBillingStats.ShortDebugString());
             UNIT_ASSERT_STRING_CONTAINS(buildIndexHtml, "Request Units: 338 (ReadTable: 128, BulkUpsert: 210)");
-            UNIT_ASSERT_STRING_CONTAINS(buildIndexHtml,  "Billed: { " + expectedBillingStats.ShortDebugString());
+            UNIT_ASSERT_STRING_CONTAINS(buildIndexHtml,  "Billed: " + expectedBillingStats.ShortDebugString());
         }
     }
 

--- a/ydb/core/tx/schemeshard/ut_index_build/ut_vector_index_build.cpp
+++ b/ydb/core/tx/schemeshard/ut_index_build/ut_vector_index_build.cpp
@@ -471,7 +471,7 @@ Y_UNIT_TEST_SUITE (VectorIndexBuildTest) {
         ui64 uploadRows = 0, uploadBytes = 0, readRows = 0, readBytes = 0;
         ui64 expectedUploadRows = 0, expectedUploadBytes = 0, expectedReadRows = 0, expectedReadBytes = 0;
         auto logBillingStats = [&]() {
-            Cerr << "BillingStats:" << billingStats.ShortDebugString() << Endl;
+            Cerr << "BillingStats: " << billingStats.ShortDebugString() << Endl;
         };
 
         TBlockEvents<TEvDataShard::TEvSampleKResponse> sampleKBlocker(runtime, [&](const auto& ev) {
@@ -599,15 +599,23 @@ Y_UNIT_TEST_SUITE (VectorIndexBuildTest) {
         expectedReadRows += tableRows;
         expectedReadBytes += tableBytes;
         logBillingStats();
+<<<<<<< HEAD
         UNIT_ASSERT_VALUES_EQUAL(uploadRows, expectedUploadRows);
         UNIT_ASSERT_VALUES_EQUAL(uploadBytes, expectedUploadBytes);
         UNIT_ASSERT_VALUES_EQUAL(readRows, expectedReadRows);
         UNIT_ASSERT_VALUES_EQUAL(readBytes, expectedReadBytes);
+=======
+        UNIT_ASSERT_VALUES_EQUAL(billingStats.GetUploadRows(), 204);
+        UNIT_ASSERT_VALUES_EQUAL(billingStats.GetUploadBytes(), 6748);
+        UNIT_ASSERT_VALUES_EQUAL(billingStats.GetReadRows(), 400);
+        UNIT_ASSERT_VALUES_EQUAL(billingStats.GetReadBytes(), 3600);
+>>>>>>> c903f14f54b (fix rebase)
 
         for (ui32 shard = 0; shard < 4; shard++) {
             runtime.WaitFor("localKMeans", [&]{ return localKMeansBlocker.size(); });
             localKMeansBlocker.Unblock();
         }
+
         // KMEANS writes build table once and forms at least K, at most K * K level rows
         // (depending on clustering uniformity; it's not so good on test data)
         expectedUploadRows += tableRows;
@@ -616,6 +624,9 @@ Y_UNIT_TEST_SUITE (VectorIndexBuildTest) {
         const ui64 level2clusters = uploadRows - expectedUploadRows;
         expectedUploadRows += level2clusters;
         expectedUploadBytes += level2clusters * levelRowBytes;
+        logBillingStats();
+        UNIT_ASSERT_VALUES_EQUAL(billingStats.GetUploadRows(), 420);
+        UNIT_ASSERT_VALUES_EQUAL(billingStats.GetUploadBytes(), 11740);
         if (smallScanBuffer) {
             // KMEANS reads build table 5 times (SAMPLE + KMEANS * 3 + UPLOAD):
             expectedReadRows += tableRows * 5;
@@ -1073,7 +1084,7 @@ Y_UNIT_TEST_SUITE (VectorIndexBuildTest) {
             );
             UNIT_ASSERT_STRING_CONTAINS(buildIndexOperation.DebugString(), "One of the shards report BUILD_ERROR");
             UNIT_ASSERT_STRING_CONTAINS(buildIndexOperation.DebugString(), "Error: Datashard test fail");
-            UNIT_ASSERT_STRING_CONTAINS(buildIndexOperation.DebugString(), "Processed: { upload rows: 0, upload bytes: 0, read rows: 0, read bytes: 0 } }");
+            UNIT_ASSERT_STRING_CONTAINS(buildIndexOperation.DebugString(), "Processed: UploadRows: 0 UploadBytes: 0 ReadRows: 0 ReadBytes: 0");
         }
 
         RebootTablet(runtime, TTestTxConfig::SchemeShard, runtime.AllocateEdgeActor());
@@ -1087,7 +1098,7 @@ Y_UNIT_TEST_SUITE (VectorIndexBuildTest) {
             );
             UNIT_ASSERT_STRING_CONTAINS(buildIndexOperation.DebugString(), "One of the shards report BUILD_ERROR");
             UNIT_ASSERT_STRING_CONTAINS(buildIndexOperation.DebugString(), "Error: Datashard test fail");
-            UNIT_ASSERT_STRING_CONTAINS(buildIndexOperation.DebugString(), "Processed: { upload rows: 0, upload bytes: 0, read rows: 0, read bytes: 0 } }");
+            UNIT_ASSERT_STRING_CONTAINS(buildIndexOperation.DebugString(), "Processed: UploadRows: 0 UploadBytes: 0 ReadRows: 0 ReadBytes: 0");
         }
     }
 }

--- a/ydb/core/tx/schemeshard/ut_index_build/ut_vector_index_build.cpp
+++ b/ydb/core/tx/schemeshard/ut_index_build/ut_vector_index_build.cpp
@@ -598,7 +598,7 @@ Y_UNIT_TEST_SUITE (VectorIndexBuildTest) {
         expectedBillingStats.SetUploadRows(expectedBillingStats.GetUploadRows() + level2clusters);
         expectedBillingStats.SetUploadBytes(expectedBillingStats.GetUploadBytes() + level2clusters * levelRowBytes);
         if (smallScanBuffer) {
-            // KMEANS reads build table 5 times (SAMPLE + KMEANS * 4 + UPLOAD):
+            // KMEANS reads build table 5 times (SAMPLE + KMEANS * 3 + UPLOAD):
             expectedBillingStats.SetReadRows(expectedBillingStats.GetReadRows() + tableRows * 5);
             expectedBillingStats.SetReadBytes(expectedBillingStats.GetReadBytes() +  buildBytes * 5);
         } else {

--- a/ydb/core/tx/schemeshard/ut_index_build/ut_vector_index_build.cpp
+++ b/ydb/core/tx/schemeshard/ut_index_build/ut_vector_index_build.cpp
@@ -742,6 +742,7 @@ Y_UNIT_TEST_SUITE (VectorIndexBuildTest) {
             auto buildIndexHtml = TestGetBuildIndexHtml(runtime, tenantSchemeShard, buildIndexTx);
             Cout << "BuildIndex 1 " << buildIndexHtml << Endl;
             UNIT_ASSERT_STRING_CONTAINS(buildIndexHtml, "Processed: { UploadRows: 4 UploadBytes: 84 ReadRows: 200 ReadBytes: 1800 }");
+            UNIT_ASSERT_STRING_CONTAINS(buildIndexHtml, "Request Units: 130 (ReadTable: 128, BulkUpsert: 2)");
             UNIT_ASSERT_STRING_CONTAINS(buildIndexHtml, "Billed: { UploadRows: 0 UploadBytes: 0 ReadRows: 0 ReadBytes: 0 }");
         }
         runtime.WaitFor("metering", [&]{ return meteringBlocker.size(); });
@@ -763,6 +764,7 @@ Y_UNIT_TEST_SUITE (VectorIndexBuildTest) {
             auto buildIndexHtml = TestGetBuildIndexHtml(runtime, tenantSchemeShard, buildIndexTx);
             Cout << "BuildIndex 2 " << buildIndexHtml << Endl;
             UNIT_ASSERT_STRING_CONTAINS(buildIndexHtml, "Processed: { UploadRows: 4 UploadBytes: 84 ReadRows: 200 ReadBytes: 1800 }");
+            UNIT_ASSERT_STRING_CONTAINS(buildIndexHtml, "Request Units: 130 (ReadTable: 128, BulkUpsert: 2)");
             UNIT_ASSERT_STRING_CONTAINS(buildIndexHtml, "Billed: { UploadRows: 4 UploadBytes: 84 ReadRows: 200 ReadBytes: 1800 }");
         }
 
@@ -794,6 +796,7 @@ Y_UNIT_TEST_SUITE (VectorIndexBuildTest) {
             auto buildIndexHtml = TestGetBuildIndexHtml(runtime, tenantSchemeShard, buildIndexTx);
             Cout << "BuildIndex 4 " << buildIndexHtml << Endl;
             UNIT_ASSERT_STRING_CONTAINS(buildIndexHtml, "Processed: { UploadRows: 54 UploadBytes: 934 ReadRows: 250 ReadBytes: 2250 }");
+            UNIT_ASSERT_STRING_CONTAINS(buildIndexHtml, "Request Units: 155 (ReadTable: 128, BulkUpsert: 27)");
             UNIT_ASSERT_STRING_CONTAINS(buildIndexHtml, "Billed: { UploadRows: 54 UploadBytes: 934 ReadRows: 250 ReadBytes: 2250 }");
             UNIT_ASSERT_STRING_CONTAINS(buildIndexHtml, "<td>{ UploadRows: 50 UploadBytes: 850 ReadRows: 50 ReadBytes: 450 }</td>"); // shard 1 stats
         }
@@ -820,6 +823,7 @@ Y_UNIT_TEST_SUITE (VectorIndexBuildTest) {
             auto buildIndexHtml = TestGetBuildIndexHtml(runtime, tenantSchemeShard, buildIndexTx);
             Cout << "BuildIndex 5 " << buildIndexHtml << Endl;
             UNIT_ASSERT_STRING_CONTAINS(buildIndexHtml, "Processed: { UploadRows: 420 UploadBytes: 6220 ReadRows: 1400 ReadBytes: 20600 }");
+            UNIT_ASSERT_STRING_CONTAINS(buildIndexHtml, "Request Units: 338 (ReadTable: 128, BulkUpsert: 210)");
             UNIT_ASSERT_STRING_CONTAINS(buildIndexHtml, "Billed: { UploadRows: 420 UploadBytes: 6220 ReadRows: 1400 ReadBytes: 20600 }");
         }
     }
@@ -1231,7 +1235,7 @@ Y_UNIT_TEST_SUITE (VectorIndexBuildTest) {
             );
             UNIT_ASSERT_STRING_CONTAINS(buildIndexOperation.DebugString(), "One of the shards report BUILD_ERROR");
             UNIT_ASSERT_STRING_CONTAINS(buildIndexOperation.DebugString(), "Error: Datashard test fail");
-            UNIT_ASSERT_STRING_CONTAINS(buildIndexOperation.DebugString(), "Processed: {  } }");
+            UNIT_ASSERT_STRING_CONTAINS(buildIndexOperation.DebugString(), "Processed: UploadRows: 0 UploadBytes: 0 ReadRows: 0 ReadBytes: 0");
         }
 
         RebootTablet(runtime, TTestTxConfig::SchemeShard, runtime.AllocateEdgeActor());
@@ -1245,7 +1249,7 @@ Y_UNIT_TEST_SUITE (VectorIndexBuildTest) {
             );
             UNIT_ASSERT_STRING_CONTAINS(buildIndexOperation.DebugString(), "One of the shards report BUILD_ERROR");
             UNIT_ASSERT_STRING_CONTAINS(buildIndexOperation.DebugString(), "Error: Datashard test fail");
-            UNIT_ASSERT_STRING_CONTAINS(buildIndexOperation.DebugString(), "Processed: {  } }");
+            UNIT_ASSERT_STRING_CONTAINS(buildIndexOperation.DebugString(), "Processed: UploadRows: 0 UploadBytes: 0 ReadRows: 0 ReadBytes: 0");
         }
     }
 }


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

...

### Changelog category <!-- remove all except one -->

* Not for changelog (changelog entry is not required)

### Description for reviewers <!-- (optional) description for those who read this PR -->

In order to simplify work with metering (previously billing) stats, store and pass them as protobuf.

It may be extended with new fields like 'CPU' easily later.

Also adds new metering test with restarts and shows detailed RU info on internal UI page.

~Some metering stats may be lost during rolling update for a short time, but it seems worthless to keep backward compatibility here (update time is short and build index operation is rare).~ UPD: does not effect secondary index so we are safe.
