### PR TITLE
Fix compilation error darwin

### DIFF
--- a/ydb/core/ymq/actor/cloud_events/cloud_events.h
+++ b/ydb/core/ymq/actor/cloud_events/cloud_events.h
@@ -15,7 +15,7 @@ namespace NKikimr::NSQS {
 namespace NCloudEvents {
     class TEventIdGenerator {
     public:
-        static uint64_t Generate();
+        static ui64 Generate();
     };
 
     struct TEventInfo {


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

This Pull Request addresses a compilation error that was identified specifically in Darwin-build environments when working with cloud_events format in Yandex Message Queue. The issue emerged following the recent changes introduced in PR #18333 (https://github.com/ydb-platform/ydb/pull/18333).

The fix has been thoroughly tested on both Darwin and Linux environments to ensure that the cloud_events format functionality in Yandex Message Queue now works correctly across all supported platforms without compilation errors.

### Changelog category <!-- remove all except one -->

* Bugfix 
