### PR TITLE
Stable-25-1: Customisation for ydbd path in e2e tests

### DIFF
--- a/ydb/core/kqp/tests/kikimr_tpch/ya.make
+++ b/ydb/core/kqp/tests/kikimr_tpch/ya.make
@@ -2,10 +2,9 @@ UNITTEST()
 
 ENV(YDB_HARD_MEMORY_LIMIT_BYTES="107374182400")
 INCLUDE(${ARCADIA_ROOT}/ydb/public/tools/ydb_recipe/recipe.inc)
-ENV(YDB_DRIVER_BINARY="ydb/apps/ydbd/ydbd")
+INCLUDE(${ARCADIA_ROOT}/ydb/tests/ydbd_dep.inc)
 
 DEPENDS(
-    ydb/apps/ydbd
     ydb/public/tools/ydb_recipe
     ydb/library/yql/udfs/common/datetime
     yql/essentials/udfs/common/datetime2

--- a/ydb/core/viewer/tests/ya.make
+++ b/ydb/core/viewer/tests/ya.make
@@ -1,11 +1,10 @@
 PY3TEST()
-ENV(YDB_DRIVER_BINARY="ydb/apps/ydbd/ydbd")
+INCLUDE(${ARCADIA_ROOT}/ydb/tests/ydbd_dep.inc)
 
 TEST_SRCS(test.py)
 
 SIZE(MEDIUM)
 DEPENDS(
-    ydb/apps/ydbd
 )
 
 PEERDIR(

--- a/ydb/tests/acceptance/ya.make
+++ b/ydb/tests/acceptance/ya.make
@@ -1,7 +1,7 @@
 # Various tests which we can't run in every pull request (because of instability/specific environment/execution time/etc)
 
 PY3TEST()
-ENV(YDB_DRIVER_BINARY="ydb/apps/ydbd/ydbd")
+INCLUDE(${ARCADIA_ROOT}/ydb/tests/ydbd_dep.inc)
 ENV(YDB_CLUSTER_YAML="ydb/tests/acceptance/cluster.yaml")
 
 TEST_SRCS(
@@ -13,7 +13,6 @@ SIZE(LARGE)
 
 DEPENDS(
     ydb/tests/tools/ydb_serializable
-    ydb/apps/ydbd
 )
 
 PEERDIR(

--- a/ydb/tests/example/ya.make
+++ b/ydb/tests/example/ya.make
@@ -1,5 +1,6 @@
 PY3TEST()
-ENV(YDB_DRIVER_BINARY="ydb/apps/ydbd/ydbd")
+
+INCLUDE(${ARCADIA_ROOT}/ydb/tests/ydbd_dep.inc)
 
 TEST_SRCS(
     test_example.py  # TODO: change file name to yours
@@ -7,9 +8,6 @@ TEST_SRCS(
 
 SIZE(MEDIUM)
 
-DEPENDS(
-    ydb/apps/ydbd
-)
 
 PEERDIR(
     ydb/tests/library

--- a/ydb/tests/functional/api/ya.make
+++ b/ydb/tests/functional/api/ya.make
@@ -3,7 +3,7 @@ PY3TEST()
 FORK_TEST_FILES()
 SIZE(MEDIUM)
 
-ENV(YDB_DRIVER_BINARY="ydb/apps/ydbd/ydbd")
+INCLUDE(${ARCADIA_ROOT}/ydb/tests/ydbd_dep.inc)
 ENV(YDB_HARD_MEMORY_LIMIT_BYTES="8000000000")
 
 TEST_SRCS(
@@ -20,7 +20,6 @@ TEST_SRCS(
 )
 
 DEPENDS(
-    ydb/apps/ydbd
 )
 
 PEERDIR(

--- a/ydb/tests/functional/audit/ya.make
+++ b/ydb/tests/functional/audit/ya.make
@@ -10,7 +10,7 @@ SPLIT_FACTOR(100)
 SIZE(MEDIUM)
 
 ENV(YDB_USE_IN_MEMORY_PDISKS=true)
-ENV(YDB_DRIVER_BINARY="ydb/apps/ydbd/ydbd")
+INCLUDE(${ARCADIA_ROOT}/ydb/tests/ydbd_dep.inc)
 
 TEST_SRCS(
     conftest.py
@@ -18,7 +18,6 @@ TEST_SRCS(
 )
 
 DEPENDS(
-    ydb/apps/ydbd
 )
 
 PEERDIR(

--- a/ydb/tests/functional/autoconfig/ya.make
+++ b/ydb/tests/functional/autoconfig/ya.make
@@ -1,6 +1,6 @@
 PY3TEST()
 
-ENV(YDB_DRIVER_BINARY="ydb/apps/ydbd/ydbd")
+INCLUDE(${ARCADIA_ROOT}/ydb/tests/ydbd_dep.inc)
 TEST_SRCS(
     test_actorsystem.py
 )
@@ -16,7 +16,6 @@ ENDIF()
 SPLIT_FACTOR(20)
 
 DEPENDS(
-    ydb/apps/ydbd
 )
 
 PEERDIR(

--- a/ydb/tests/functional/blobstorage/ya.make
+++ b/ydb/tests/functional/blobstorage/ya.make
@@ -1,6 +1,6 @@
 PY3TEST()
 
-ENV(YDB_DRIVER_BINARY="ydb/apps/ydbd/ydbd")
+INCLUDE(${ARCADIA_ROOT}/ydb/tests/ydbd_dep.inc)
 TEST_SRCS(
     test_pdisk_format_info.py
     test_replication.py
@@ -22,7 +22,6 @@ ENDIF()
 SPLIT_FACTOR(20)
 
 DEPENDS(
-    ydb/apps/ydbd
 )
 
 PEERDIR(

--- a/ydb/tests/functional/canonical/ya.make
+++ b/ydb/tests/functional/canonical/ya.make
@@ -12,9 +12,8 @@ ELSE()
     SIZE(MEDIUM)
 ENDIF()
 
-ENV(YDB_DRIVER_BINARY="ydb/apps/ydbd/ydbd")
+INCLUDE(${ARCADIA_ROOT}/ydb/tests/ydbd_dep.inc)
 DEPENDS(
-    ydb/apps/ydbd
 )
 
 

--- a/ydb/tests/functional/cms/ya.make
+++ b/ydb/tests/functional/cms/ya.make
@@ -23,9 +23,8 @@ ELSE()
 ENDIF()
 
 
-ENV(YDB_DRIVER_BINARY="ydb/apps/ydbd/ydbd")
+INCLUDE(${ARCADIA_ROOT}/ydb/tests/ydbd_dep.inc)
 DEPENDS(
-    ydb/apps/ydbd
 )
 
 PEERDIR(

--- a/ydb/tests/functional/compatibility/ya.make
+++ b/ydb/tests/functional/compatibility/ya.make
@@ -1,5 +1,5 @@
 PY3TEST()
-ENV(YDB_DRIVER_BINARY="ydb/apps/ydbd/ydbd")
+INCLUDE(${ARCADIA_ROOT}/ydb/tests/ydbd_dep.inc)
 ENV(YDB_CLI_BINARY="ydb/apps/ydb/ydb")
 
 FORK_TEST_FILES()
@@ -20,7 +20,6 @@ INCLUDE(${ARCADIA_ROOT}/ydb/tests/tools/s3_recipe/recipe.inc)
 
 DEPENDS(
     ydb/apps/ydb
-    ydb/apps/ydbd
     ydb/tests/library/compatibility
 )
 

--- a/ydb/tests/functional/config/ya.make
+++ b/ydb/tests/functional/config/ya.make
@@ -21,10 +21,7 @@ ELSE()
 ENDIF()
 
 
-ENV(YDB_DRIVER_BINARY="ydb/apps/ydbd/ydbd")
-DEPENDS(
-    ydb/apps/ydbd
-)
+INCLUDE(${ARCADIA_ROOT}/ydb/tests/ydbd_dep.inc)
 
 PEERDIR(
     ydb/tests/library

--- a/ydb/tests/functional/encryption/ya.make
+++ b/ydb/tests/functional/encryption/ya.make
@@ -1,6 +1,6 @@
 PY3TEST()
 
-ENV(YDB_DRIVER_BINARY="ydb/apps/ydbd/ydbd")
+INCLUDE(${ARCADIA_ROOT}/ydb/tests/ydbd_dep.inc)
 TEST_SRCS(
     test_encryption.py
 )
@@ -8,7 +8,6 @@ TEST_SRCS(
 SIZE(MEDIUM)
 
 DEPENDS(
-    ydb/apps/ydbd
 )
 
 PEERDIR(

--- a/ydb/tests/functional/hive/ya.make
+++ b/ydb/tests/functional/hive/ya.make
@@ -1,5 +1,5 @@
 PY3TEST()
-ENV(YDB_DRIVER_BINARY="ydb/apps/ydbd/ydbd")
+INCLUDE(${ARCADIA_ROOT}/ydb/tests/ydbd_dep.inc)
 TEST_SRCS(
     hive_matchers.py
     test_create_tablets.py
@@ -22,7 +22,6 @@ ELSE()
 ENDIF()
 
 DEPENDS(
-    ydb/apps/ydbd
 )
 
 PEERDIR(

--- a/ydb/tests/functional/large_serializable/ya.make
+++ b/ydb/tests/functional/large_serializable/ya.make
@@ -1,6 +1,6 @@
 IF (NOT SANITIZER_TYPE AND NOT WITH_VALGRIND)
 PY3TEST()
-ENV(YDB_DRIVER_BINARY="ydb/apps/ydbd/ydbd")
+INCLUDE(${ARCADIA_ROOT}/ydb/tests/ydbd_dep.inc)
 ENV(YDB_ERASURE=mirror_3_dc)
 ENV(YDB_USE_IN_MEMORY_PDISKS=true)
 
@@ -17,7 +17,6 @@ INCLUDE(${ARCADIA_ROOT}/ydb/tests/large.inc)
 
 DEPENDS(
     ydb/tests/tools/ydb_serializable
-    ydb/apps/ydbd
 )
 
 PEERDIR(

--- a/ydb/tests/functional/limits/ya.make
+++ b/ydb/tests/functional/limits/ya.make
@@ -1,6 +1,6 @@
 PY3TEST()
 
-ENV(YDB_DRIVER_BINARY="ydb/apps/ydbd/ydbd")
+INCLUDE(${ARCADIA_ROOT}/ydb/tests/ydbd_dep.inc)
 TEST_SRCS(
     test_schemeshard_limits.py
 )
@@ -12,7 +12,6 @@ ENDIF()
 SIZE(MEDIUM)
 
 DEPENDS(
-    ydb/apps/ydbd
 )
 
 PEERDIR(

--- a/ydb/tests/functional/minidumps/ya.make
+++ b/ydb/tests/functional/minidumps/ya.make
@@ -8,14 +8,13 @@ TEST_SRCS(
 
 SIZE(MEDIUM)
 
-ENV(YDB_DRIVER_BINARY="ydb/apps/ydbd/ydbd")
+INCLUDE(${ARCADIA_ROOT}/ydb/tests/ydbd_dep.inc)
 
 PEERDIR(
     ydb/tests/library
 )
 
 DEPENDS(
-    ydb/apps/ydbd
 )
 
 

--- a/ydb/tests/functional/postgresql/ya.make
+++ b/ydb/tests/functional/postgresql/ya.make
@@ -5,13 +5,12 @@ DATA(
 )
 
 DEPENDS(
-    ydb/apps/ydbd
     ydb/tests/functional/postgresql/psql
 )
 
 
 ENV(PYTHONWARNINGS="ignore")
-ENV(YDB_DRIVER_BINARY="ydb/apps/ydbd/ydbd")
+INCLUDE(${ARCADIA_ROOT}/ydb/tests/ydbd_dep.inc)
 ENV(YDB_TABLE_ENABLE_PREPARED_DDL=true)
 ENV(YDB_USE_IN_MEMORY_PDISKS=true)
 ENV(YDB_ALLOCATE_PGWIRE_PORT=true)

--- a/ydb/tests/functional/query_cache/ya.make
+++ b/ydb/tests/functional/query_cache/ya.make
@@ -1,6 +1,6 @@
 PY3TEST()
 
-ENV(YDB_DRIVER_BINARY="ydb/apps/ydbd/ydbd")
+INCLUDE(${ARCADIA_ROOT}/ydb/tests/ydbd_dep.inc)
 TEST_SRCS(
     test_query_cache.py
 )
@@ -8,7 +8,6 @@ TEST_SRCS(
 SIZE(MEDIUM)
 
 DEPENDS(
-    ydb/apps/ydbd
 )
 
 PEERDIR(

--- a/ydb/tests/functional/rename/ya.make
+++ b/ydb/tests/functional/rename/ya.make
@@ -1,6 +1,6 @@
 PY3TEST()
 
-ENV(YDB_DRIVER_BINARY="ydb/apps/ydbd/ydbd")
+INCLUDE(${ARCADIA_ROOT}/ydb/tests/ydbd_dep.inc)
 PY_SRCS (
     conftest.py
     common.py
@@ -27,7 +27,6 @@ ELSE()
 ENDIF()
 
 DEPENDS(
-    ydb/apps/ydbd
 )
 
 PEERDIR(

--- a/ydb/tests/functional/restarts/ya.make
+++ b/ydb/tests/functional/restarts/ya.make
@@ -17,9 +17,8 @@ ELSE()
     SIZE(MEDIUM)
 ENDIF()
 
-ENV(YDB_DRIVER_BINARY="ydb/apps/ydbd/ydbd")
+INCLUDE(${ARCADIA_ROOT}/ydb/tests/ydbd_dep.inc)
 DEPENDS(
-    ydb/apps/ydbd
 )
 
 PEERDIR(

--- a/ydb/tests/functional/scheme_shard/ya.make
+++ b/ydb/tests/functional/scheme_shard/ya.make
@@ -1,5 +1,5 @@
 PY3TEST()
-ENV(YDB_DRIVER_BINARY="ydb/apps/ydbd/ydbd")
+INCLUDE(${ARCADIA_ROOT}/ydb/tests/ydbd_dep.inc)
 
 TEST_SRCS(
     test_copy_ops.py
@@ -10,7 +10,6 @@ TEST_SRCS(
 SIZE(MEDIUM)
 
 DEPENDS(
-    ydb/apps/ydbd
 )
 
 PEERDIR(

--- a/ydb/tests/functional/scheme_tests/ya.make
+++ b/ydb/tests/functional/scheme_tests/ya.make
@@ -1,5 +1,5 @@
 PY3TEST()
-ENV(YDB_DRIVER_BINARY="ydb/apps/ydbd/ydbd")
+INCLUDE(${ARCADIA_ROOT}/ydb/tests/ydbd_dep.inc)
 TEST_SRCS(
     tablet_scheme_tests.py
 )
@@ -7,7 +7,6 @@ TEST_SRCS(
 SIZE(MEDIUM)
 
 DEPENDS(
-    ydb/apps/ydbd
 )
 
 DATA(

--- a/ydb/tests/functional/script_execution/ya.make
+++ b/ydb/tests/functional/script_execution/ya.make
@@ -1,6 +1,6 @@
 PY3TEST()
 
-ENV(YDB_DRIVER_BINARY="ydb/apps/ydbd/ydbd")
+INCLUDE(${ARCADIA_ROOT}/ydb/tests/ydbd_dep.inc)
 
 PEERDIR(
     ydb/public/api/protos
@@ -11,7 +11,6 @@ PEERDIR(
 )
 
 DEPENDS(
-    ydb/apps/ydbd
 )
 
 TEST_SRCS(

--- a/ydb/tests/functional/serverless/ya.make
+++ b/ydb/tests/functional/serverless/ya.make
@@ -14,9 +14,8 @@ ENDIF()
 
 SIZE(MEDIUM)
 
-ENV(YDB_DRIVER_BINARY="ydb/apps/ydbd/ydbd")
+INCLUDE(${ARCADIA_ROOT}/ydb/tests/ydbd_dep.inc)
 DEPENDS(
-    ydb/apps/ydbd
 )
 
 PEERDIR(

--- a/ydb/tests/functional/sqs/cloud/ya.make
+++ b/ydb/tests/functional/sqs/cloud/ya.make
@@ -6,7 +6,7 @@ TEST_SRCS(
     test_yandex_cloud_queue_counters.py
 )
 
-ENV(YDB_DRIVER_BINARY="ydb/apps/ydbd/ydbd")
+INCLUDE(${ARCADIA_ROOT}/ydb/tests/ydbd_dep.inc)
 
 IF (SANITIZER_TYPE == "thread")
     SIZE(LARGE)
@@ -17,7 +17,6 @@ ELSE()
 ENDIF()
 
 DEPENDS(
-    ydb/apps/ydbd
 )
 
 PEERDIR(

--- a/ydb/tests/functional/sqs/common/ya.make
+++ b/ydb/tests/functional/sqs/common/ya.make
@@ -1,5 +1,5 @@
 PY3TEST()
-ENV(YDB_DRIVER_BINARY="ydb/apps/ydbd/ydbd")
+INCLUDE(${ARCADIA_ROOT}/ydb/tests/ydbd_dep.inc)
 ENV(YDB_USE_IN_MEMORY_PDISKS=true)
 
 TEST_SRCS(
@@ -26,7 +26,6 @@ ELSE()
 ENDIF()
 
 DEPENDS(
-    ydb/apps/ydbd
 )
 
 PEERDIR(

--- a/ydb/tests/functional/sqs/large/ya.make
+++ b/ydb/tests/functional/sqs/large/ya.make
@@ -1,5 +1,5 @@
 PY3TEST()
-ENV(YDB_DRIVER_BINARY="ydb/apps/ydbd/ydbd")
+INCLUDE(${ARCADIA_ROOT}/ydb/tests/ydbd_dep.inc)
 ENV(YDB_USE_IN_MEMORY_PDISKS=true)
 
 TEST_SRCS(
@@ -15,7 +15,6 @@ ELSE()
 ENDIF()
 
 DEPENDS(
-    ydb/apps/ydbd
 )
 
 PEERDIR(

--- a/ydb/tests/functional/sqs/merge_split_common_table/fifo/ya.make
+++ b/ydb/tests/functional/sqs/merge_split_common_table/fifo/ya.make
@@ -1,5 +1,5 @@
 PY3TEST()
-ENV(YDB_DRIVER_BINARY="ydb/apps/ydbd/ydbd")
+INCLUDE(${ARCADIA_ROOT}/ydb/tests/ydbd_dep.inc)
 ENV(YDB_USE_IN_MEMORY_PDISKS=true)
 
 TEST_SRCS(
@@ -15,7 +15,6 @@ ELSE()
 ENDIF()
 
 DEPENDS(
-    ydb/apps/ydbd
 )
 
 PEERDIR(

--- a/ydb/tests/functional/sqs/merge_split_common_table/std/ya.make
+++ b/ydb/tests/functional/sqs/merge_split_common_table/std/ya.make
@@ -1,5 +1,5 @@
 PY3TEST()
-ENV(YDB_DRIVER_BINARY="ydb/apps/ydbd/ydbd")
+INCLUDE(${ARCADIA_ROOT}/ydb/tests/ydbd_dep.inc)
 
 TEST_SRCS(
     test.py
@@ -14,7 +14,6 @@ ELSE()
 ENDIF()
 
 DEPENDS(
-    ydb/apps/ydbd
 )
 
 PEERDIR(

--- a/ydb/tests/functional/sqs/messaging/ya.make
+++ b/ydb/tests/functional/sqs/messaging/ya.make
@@ -1,5 +1,5 @@
 PY3TEST()
-ENV(YDB_DRIVER_BINARY="ydb/apps/ydbd/ydbd")
+INCLUDE(${ARCADIA_ROOT}/ydb/tests/ydbd_dep.inc)
 
 TEST_SRCS(
     test_generic_messaging.py
@@ -16,7 +16,6 @@ ELSE()
 ENDIF()
 
 DEPENDS(
-    ydb/apps/ydbd
 )
 
 PEERDIR(

--- a/ydb/tests/functional/sqs/multinode/ya.make
+++ b/ydb/tests/functional/sqs/multinode/ya.make
@@ -1,5 +1,5 @@
 PY3TEST()
-ENV(YDB_DRIVER_BINARY="ydb/apps/ydbd/ydbd")
+INCLUDE(${ARCADIA_ROOT}/ydb/tests/ydbd_dep.inc)
 
 TEST_SRCS(
     test_multinode_cluster.py
@@ -14,7 +14,6 @@ ELSE()
 ENDIF()
 
 DEPENDS(
-    ydb/apps/ydbd
 )
 
 PEERDIR(

--- a/ydb/tests/functional/sqs/with_quotas/ya.make
+++ b/ydb/tests/functional/sqs/with_quotas/ya.make
@@ -1,5 +1,5 @@
 PY3TEST()
-ENV(YDB_DRIVER_BINARY="ydb/apps/ydbd/ydbd")
+INCLUDE(${ARCADIA_ROOT}/ydb/tests/ydbd_dep.inc)
 ENV(YDB_USE_IN_MEMORY_PDISKS=true)
 
 TEST_SRCS(
@@ -15,7 +15,6 @@ ELSE()
 ENDIF()
 
 DEPENDS(
-    ydb/apps/ydbd
 )
 
 PEERDIR(

--- a/ydb/tests/functional/suite_tests/ya.make
+++ b/ydb/tests/functional/suite_tests/ya.make
@@ -1,6 +1,6 @@
 IF (NOT SANITIZER_TYPE AND NOT WITH_VALGRIND)
     PY3TEST()
-    ENV(YDB_DRIVER_BINARY="ydb/apps/ydbd/ydbd")
+    INCLUDE(${ARCADIA_ROOT}/ydb/tests/ydbd_dep.inc)
     ENV(YDB_ENABLE_COLUMN_TABLES="true")
     ENV(USE_IN_MEMORY_PDISKS=true)
     TEST_SRCS(
@@ -15,8 +15,7 @@ IF (NOT SANITIZER_TYPE AND NOT WITH_VALGRIND)
 
 
     DEPENDS(
-        ydb/apps/ydbd
-    )
+        )
 
     DATA (
         arcadia/ydb/tests/functional/suite_tests/postgres

--- a/ydb/tests/functional/tenants/ya.make
+++ b/ydb/tests/functional/tenants/ya.make
@@ -1,6 +1,6 @@
 PY3TEST()
 
-ENV(YDB_DRIVER_BINARY="ydb/apps/ydbd/ydbd")
+INCLUDE(${ARCADIA_ROOT}/ydb/tests/ydbd_dep.inc)
 
 TEST_SRCS(
     conftest.py
@@ -22,7 +22,6 @@ SPLIT_FACTOR(20)
 INCLUDE(${ARCADIA_ROOT}/ydb/tests/library/flavours/flavours_deps.inc)
 
 DEPENDS(
-    ydb/apps/ydbd
 )
 
 PEERDIR(

--- a/ydb/tests/functional/tpc/large/ya.make
+++ b/ydb/tests/functional/tpc/large/ya.make
@@ -12,7 +12,7 @@ TAG(ya:fat)
 REQUIREMENTS(ram:16)
 
 ENV(YDB_ENABLE_COLUMN_TABLES="true")
-ENV(YDB_DRIVER_BINARY="ydb/apps/ydbd/ydbd")
+INCLUDE(${ARCADIA_ROOT}/ydb/tests/ydbd_dep.inc)
 ENV(YDB_CLI_BINARY="ydb/apps/ydb/ydb")
 ENV(NO_KUBER_LOGS="yes")
 
@@ -22,7 +22,6 @@ PEERDIR(
 
 DEPENDS(
     ydb/apps/ydb
-    ydb/apps/ydbd
 )
 
 FORK_TEST_FILES()

--- a/ydb/tests/functional/tpc/medium/ya.make
+++ b/ydb/tests/functional/tpc/medium/ya.make
@@ -11,7 +11,7 @@ SIZE(MEDIUM)
 REQUIREMENTS(ram:16)
 
 ENV(YDB_ENABLE_COLUMN_TABLES="true")
-ENV(YDB_DRIVER_BINARY="ydb/apps/ydbd/ydbd")
+INCLUDE(${ARCADIA_ROOT}/ydb/tests/ydbd_dep.inc)
 ENV(YDB_CLI_BINARY="ydb/apps/ydb/ydb")
 ENV(NO_KUBER_LOGS="yes")
 
@@ -21,7 +21,6 @@ PEERDIR(
 
 DEPENDS(
     ydb/apps/ydb
-    ydb/apps/ydbd
 )
 
 DATA(

--- a/ydb/tests/functional/ttl/ya.make
+++ b/ydb/tests/functional/ttl/ya.make
@@ -4,11 +4,10 @@ TEST_SRCS(
     test_ttl.py
 )
 
-ENV(YDB_DRIVER_BINARY="ydb/apps/ydbd/ydbd")
+INCLUDE(${ARCADIA_ROOT}/ydb/tests/ydbd_dep.inc)
 SIZE(MEDIUM)
 
 DEPENDS(
-    ydb/apps/ydbd
 )
 
 PEERDIR(

--- a/ydb/tests/functional/wardens/ya.make
+++ b/ydb/tests/functional/wardens/ya.make
@@ -1,12 +1,11 @@
 PY3TEST()
-ENV(YDB_DRIVER_BINARY="ydb/apps/ydbd/ydbd")
+INCLUDE(${ARCADIA_ROOT}/ydb/tests/ydbd_dep.inc)
 
 TEST_SRCS(
     test_liveness_wardens.py
 )
 
 DEPENDS(
-    ydb/apps/ydbd
 )
 
 PEERDIR(

--- a/ydb/tests/functional/ydb_cli/ya.make
+++ b/ydb/tests/functional/ydb_cli/ya.make
@@ -11,7 +11,7 @@ TEST_SRCS(
     test_ydb_sql.py
 )
 
-ENV(YDB_DRIVER_BINARY="ydb/apps/ydbd/ydbd")
+INCLUDE(${ARCADIA_ROOT}/ydb/tests/ydbd_dep.inc)
 ENV(YDB_CLI_BINARY="ydb/apps/ydb/ydb")
 ENV(YDB_ENABLE_COLUMN_TABLES="true")
 
@@ -23,7 +23,6 @@ ELSE()
 ENDIF()
 
 DEPENDS(
-    ydb/apps/ydbd
     ydb/apps/ydb
 )
 

--- a/ydb/tests/library/ut/ya.make
+++ b/ydb/tests/library/ut/ya.make
@@ -1,9 +1,8 @@
 PY3TEST()
 
-ENV(YDB_DRIVER_BINARY="ydb/apps/ydbd/ydbd")
+INCLUDE(${ARCADIA_ROOT}/ydb/tests/ydbd_dep.inc)
 
 DEPENDS(
-    ydb/apps/ydbd
 )
 
 PEERDIR(

--- a/ydb/tests/olap/scenario/ya.make
+++ b/ydb/tests/olap/scenario/ya.make
@@ -12,10 +12,9 @@ PY3TEST()
         test_alter_compression.py
     )
 
-    ENV(YDB_DRIVER_BINARY="ydb/apps/ydbd/ydbd")
+    INCLUDE(${ARCADIA_ROOT}/ydb/tests/ydbd_dep.inc)
     DEPENDS(
-        ydb/apps/ydbd
-    )
+        )
 
     PEERDIR(
         contrib/python/allure-pytest

--- a/ydb/tests/olap/ttl_tiering/ya.make
+++ b/ydb/tests/olap/ttl_tiering/ya.make
@@ -1,5 +1,5 @@
 PY3TEST()
-ENV(YDB_DRIVER_BINARY="ydb/apps/ydbd/ydbd")
+INCLUDE(${ARCADIA_ROOT}/ydb/tests/ydbd_dep.inc)
 ENV(MOTO_SERVER_PATH="contrib/python/moto/bin/moto_server")
 ENV(YDB_ADDITIONAL_LOG_CONFIGS="TX_TIERING:DEBUG")
 
@@ -24,7 +24,6 @@ PEERDIR(
 )
 
 DEPENDS(
-    ydb/apps/ydbd
     contrib/python/moto/bin
 )
 

--- a/ydb/tests/olap/ya.make
+++ b/ydb/tests/olap/ya.make
@@ -1,5 +1,5 @@
 PY3TEST()
-    ENV(YDB_DRIVER_BINARY="ydb/apps/ydbd/ydbd")
+    INCLUDE(${ARCADIA_ROOT}/ydb/tests/ydbd_dep.inc)
     ENV(YDB_CLI_BINARY="ydb/apps/ydb/ydb")
     ENV(YDB_ENABLE_COLUMN_TABLES="true")
 
@@ -16,8 +16,7 @@ PY3TEST()
 
     DEPENDS(
         ydb/apps/ydb
-        ydb/apps/ydbd
-    )
+        )
 
     PEERDIR(
     ydb/tests/library

--- a/ydb/tests/postgres_integrations/go-libpq/ya.make
+++ b/ydb/tests/postgres_integrations/go-libpq/ya.make
@@ -41,10 +41,9 @@ ELSE()
 ENDIF()
 
 
-ENV(YDB_DRIVER_BINARY="ydb/apps/ydbd/ydbd")
+INCLUDE(${ARCADIA_ROOT}/ydb/tests/ydbd_dep.inc)
 ENV(YDB_ALLOCATE_PGWIRE_PORT="true")
 DEPENDS(
-    ydb/apps/ydbd
 )
 
 TEST_SRCS(

--- a/ydb/tests/sql/large/ya.make
+++ b/ydb/tests/sql/large/ya.make
@@ -1,5 +1,5 @@
 PY3TEST()
-ENV(YDB_DRIVER_BINARY="ydb/apps/ydbd/ydbd")
+INCLUDE(${ARCADIA_ROOT}/ydb/tests/ydbd_dep.inc)
 ENV(MOTO_SERVER_PATH="contrib/python/moto/bin/moto_server")
 ENV(YDB_ADDITIONAL_LOG_CONFIGS="TX_TIERING:DEBUG")
 
@@ -20,7 +20,6 @@ INCLUDE(${ARCADIA_ROOT}/ydb/tests/large.inc)
 
 DEPENDS(
     ydb/apps/ydb
-    ydb/apps/ydbd
     ydb/tests/sql/lib
     contrib/python/moto/bin
 )

--- a/ydb/tests/sql/lib/ya.make
+++ b/ydb/tests/sql/lib/ya.make
@@ -1,6 +1,4 @@
 PY3_LIBRARY()
-ENV(YDB_DRIVER_BINARY="ydb/apps/ydbd/ydbd")
-ENV(MOTO_SERVER_PATH="contrib/python/moto/bin/moto_server")
 
 PY_SRCS(
     test_base.py

--- a/ydb/tests/sql/ya.make
+++ b/ydb/tests/sql/ya.make
@@ -1,5 +1,5 @@
 PY3TEST()
-ENV(YDB_DRIVER_BINARY="ydb/apps/ydbd/ydbd")
+INCLUDE(${ARCADIA_ROOT}/ydb/tests/ydbd_dep.inc)
 ENV(YDB_ENABLE_COLUMN_TABLES="true")
 
 TEST_SRCS(
@@ -12,7 +12,6 @@ SIZE(MEDIUM)
 
 DEPENDS(
     ydb/apps/ydb
-    ydb/apps/ydbd
     ydb/tests/sql/lib
 )
 

--- a/ydb/tests/stress/kv/tests/ya.make
+++ b/ydb/tests/stress/kv/tests/ya.make
@@ -1,6 +1,6 @@
 IF (NOT WITH_VALGRIND)
 PY3TEST()
-ENV(YDB_DRIVER_BINARY="ydb/apps/ydbd/ydbd")
+INCLUDE(${ARCADIA_ROOT}/ydb/tests/ydbd_dep.inc)
 ENV(YDB_CLI_BINARY="ydb/apps/ydb/ydb")
 ENV(YDB_ERASURE=mirror_3_dc)
 ENV(YDB_USE_IN_MEMORY_PDISKS=true)
@@ -16,7 +16,6 @@ ENDIF()
 SIZE(MEDIUM)
 
 DEPENDS(
-    ydb/apps/ydbd
     ydb/apps/ydb
 )
 

--- a/ydb/tests/stress/log/tests/ya.make
+++ b/ydb/tests/stress/log/tests/ya.make
@@ -1,5 +1,5 @@
 PY3TEST()
-ENV(YDB_DRIVER_BINARY="ydb/apps/ydbd/ydbd")
+INCLUDE(${ARCADIA_ROOT}/ydb/tests/ydbd_dep.inc)
 ENV(YDB_CLI_BINARY="ydb/apps/ydb/ydb")
 
 TEST_SRCS(
@@ -10,7 +10,6 @@ SIZE(MEDIUM)
 REQUIREMENTS(ram:32)
 
 DEPENDS(
-    ydb/apps/ydbd
     ydb/apps/ydb
 )
 

--- a/ydb/tests/stress/olap_workload/tests/ya.make
+++ b/ydb/tests/stress/olap_workload/tests/ya.make
@@ -1,5 +1,5 @@
 PY3TEST()
-ENV(YDB_DRIVER_BINARY="ydb/apps/ydbd/ydbd")
+INCLUDE(${ARCADIA_ROOT}/ydb/tests/ydbd_dep.inc)
 ENV(YDB_ENABLE_COLUMN_TABLES="true")
 
 TEST_SRCS(
@@ -13,7 +13,6 @@ ENDIF()
 SIZE(MEDIUM)
 
 DEPENDS(
-    ydb/apps/ydbd
 )
 
 PEERDIR(

--- a/ydb/tests/stress/oltp_workload/tests/ya.make
+++ b/ydb/tests/stress/oltp_workload/tests/ya.make
@@ -1,5 +1,5 @@
 PY3TEST()
-ENV(YDB_DRIVER_BINARY="ydb/apps/ydbd/ydbd")
+INCLUDE(${ARCADIA_ROOT}/ydb/tests/ydbd_dep.inc)
 
 TEST_SRCS(
     test_workload.py
@@ -12,7 +12,6 @@ ENDIF()
 SIZE(MEDIUM)
 
 DEPENDS(
-    ydb/apps/ydbd
 )
 
 PEERDIR(

--- a/ydb/tests/stress/simple_queue/tests/ya.make
+++ b/ydb/tests/stress/simple_queue/tests/ya.make
@@ -1,5 +1,5 @@
 PY3TEST()
-ENV(YDB_DRIVER_BINARY="ydb/apps/ydbd/ydbd")
+INCLUDE(${ARCADIA_ROOT}/ydb/tests/ydbd_dep.inc)
 
 TEST_SRCS(
     test_workload.py
@@ -12,7 +12,6 @@ ENDIF()
 SIZE(MEDIUM)
 
 DEPENDS(
-    ydb/apps/ydbd
 )
 
 PEERDIR(

--- a/ydb/tests/stress/transfer/tests/ya.make
+++ b/ydb/tests/stress/transfer/tests/ya.make
@@ -1,6 +1,6 @@
 IF (NOT WITH_VALGRIND)
 PY3TEST()
-ENV(YDB_DRIVER_BINARY="ydb/apps/ydbd/ydbd")
+INCLUDE(${ARCADIA_ROOT}/ydb/tests/ydbd_dep.inc)
 ENV(YDB_CLI_BINARY="ydb/apps/ydb/ydb")
 ENV(YDB_ERASURE=mirror_3_dc)
 ENV(YDB_USE_IN_MEMORY_PDISKS=true)
@@ -17,7 +17,6 @@ ENDIF()
 SIZE(MEDIUM)
 
 DEPENDS(
-    ydb/apps/ydbd
     ydb/apps/ydb
     ydb/tests/stress/transfer
 )

--- a/ydb/tests/tools/nemesis/ut/ya.make
+++ b/ydb/tests/tools/nemesis/ut/ya.make
@@ -1,7 +1,7 @@
 SUBSCRIBER(g:kikimr)
 
 PY3TEST()
-ENV(YDB_DRIVER_BINARY="ydb/apps/ydbd/ydbd")
+INCLUDE(${ARCADIA_ROOT}/ydb/tests/ydbd_dep.inc)
 
 TEST_SRCS(
     test_disk.py
@@ -12,7 +12,6 @@ SIZE(MEDIUM)
 
 
 DEPENDS(
-    ydb/apps/ydbd
 )
 
 PEERDIR(

--- a/ydb/tests/ydbd_dep.inc
+++ b/ydb/tests/ydbd_dep.inc
@@ -1,0 +1,17 @@
+# This file incapsulates logic for ydbd dependency in tests
+
+IF (DEFINED YDB_DRIVER_BINARY_PREBUILT)  # useful to test arbitrary prebuilt ydbd
+    SET(YDB_DRIVER_BINARY ${YDB_DRIVER_BINARY_PREBUILT})
+ELSEIF(DEFINED YDB_DRIVER_BINARY)  # custom in-source ydbd
+    SET(YDB_DRIVER_BINARY ${YDB_DRIVER_BINARY})
+    DEPENDS(
+        ${YDB_DRIVER_BINARY}/..
+    )
+ELSE()  # default ydbd from current source tree
+    SET(YDB_DRIVER_BINARY "ydb/apps/ydbd/ydbd")
+    DEPENDS(
+        ydb/apps/ydbd
+    )
+ENDIF()
+
+ENV(YDB_DRIVER_BINARY=${YDB_DRIVER_BINARY})


### PR DESCRIPTION
cherry pick #19869 

Add customisation for ydbd binary in e2e tests

2 possible customizations are possible:

`-DYDB_DRIVER_BINARY_PREBUILT=/some/absolute/path/ydbd`
`-DYDB_DRIVER_BINARY=ydb/apps/custom_ydbd/ydbd`