### PR TITLE
#9056 Fix inline hints in YDB CLI

### DIFF
--- a/ydb/apps/ydb/CHANGELOG.md
+++ b/ydb/apps/ydb/CHANGELOG.md
@@ -1,3 +1,4 @@
+* Disable inline hints
 * Added named expressions completion in interactive mode, cache schema responses.
 * Added processing of special values `null`, `/dev/null`, `stdout`, `cout`, `console`, `stderr` and `cerr` of `--output` option in `ydb workload * run` command.
 * Fixed bug when `ydb wokrload` commands did not work with absolute paths.

--- a/ydb/apps/ydb/CHANGELOG.md
+++ b/ydb/apps/ydb/CHANGELOG.md
@@ -1,4 +1,4 @@
-* Disable inline hints
+* Fix inline hints
 * Added named expressions completion in interactive mode, cache schema responses.
 * Added processing of special values `null`, `/dev/null`, `stdout`, `cout`, `console`, `stderr` and `cerr` of `--output` option in `ydb workload * run` command.
 * Fixed bug when `ydb wokrload` commands did not work with absolute paths.

--- a/ydb/public/lib/ydb_cli/commands/interactive/complete/yql_completer.cpp
+++ b/ydb/public/lib/ydb_cli/commands/interactive/complete/yql_completer.cpp
@@ -41,6 +41,7 @@ namespace NYdb::NConsoleClient {
             for (auto& candidate : Apply(text, prefix, contextLen, /* light = */ true)) {
                 hints.emplace_back(std::move(candidate.text()));
             }
+            hints.emplace_back("");
             return hints;
         }
 
@@ -79,6 +80,7 @@ namespace NYdb::NConsoleClient {
             const size_t prefixLen = candidate.Content.length() - candidate.CursorShift;
             candidate.Content.resize(prefixLen);
 
+            Y_ENSURE(!candidate.Content.empty());
             const auto back = candidate.Content.back();
             if (
                 !(candidate.Kind == NSQLComplete::ECandidateKind::FolderName ||

--- a/ydb/public/lib/ydb_cli/commands/interactive/complete/yql_completer.cpp
+++ b/ydb/public/lib/ydb_cli/commands/interactive/complete/yql_completer.cpp
@@ -41,7 +41,7 @@ namespace NYdb::NConsoleClient {
             for (auto& candidate : Apply(text, prefix, contextLen, /* light = */ true)) {
                 hints.emplace_back(std::move(candidate.text()));
             }
-            hints.emplace_back("");
+            hints.emplace_back(""); // Disable inline hints
             return hints;
         }
 

--- a/ydb/public/lib/ydb_cli/commands/interactive/line_reader.cpp
+++ b/ydb/public/lib/ydb_cli/commands/interactive/line_reader.cpp
@@ -82,14 +82,14 @@ TLineReader::TLineReader(std::string prompt, std::string historyFilePath, TClien
         YQLHighlighter->Apply(text, colors);
     });
 
-    Rx.bind_key(replxx::Replxx::KEY::control('N'), [&](char32_t code) { 
-        return Rx.invoke(replxx::Replxx::ACTION::HISTORY_NEXT, code); 
+    Rx.bind_key(replxx::Replxx::KEY::control('N'), [&](char32_t code) {
+        return Rx.invoke(replxx::Replxx::ACTION::HISTORY_NEXT, code);
     });
-    Rx.bind_key(replxx::Replxx::KEY::control('P'), [&](char32_t code) { 
-        return Rx.invoke(replxx::Replxx::ACTION::HISTORY_PREVIOUS, code); 
+    Rx.bind_key(replxx::Replxx::KEY::control('P'), [&](char32_t code) {
+        return Rx.invoke(replxx::Replxx::ACTION::HISTORY_PREVIOUS, code);
     });
-    Rx.bind_key(replxx::Replxx::KEY::control('D'), [](char32_t) { 
-        return replxx::Replxx::ACTION_RESULT::BAIL; 
+    Rx.bind_key(replxx::Replxx::KEY::control('D'), [](char32_t) {
+        return replxx::Replxx::ACTION_RESULT::BAIL;
     });
     Rx.bind_key(replxx::Replxx::KEY::control('J'), [&](char32_t code) {
         return Rx.invoke(replxx::Replxx::ACTION::COMMIT_LINE, code);


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

Fix inline hints in YDB CLI

### Changelog category <!-- remove all except one -->

* Not for changelog (changelog entry is not required)

### Description for reviewers <!-- (optional) description for those who read this PR -->

Added an empty hint to disable inline hints when completed token does not match with an only candidate. This happens when we assist user by adding a backtick at the start automatically, so such cases happened:

![image](https://github.com/user-attachments/assets/3f200c24-7328-49d6-a63b-93515707214c)

Now hints works well.

![image](https://github.com/user-attachments/assets/2e944151-3bc3-47ed-bd6f-dd1f1b14c5be)

![image](https://github.com/user-attachments/assets/e8c04e99-a105-45e9-b5d0-2b927a614716)

---

- Related to `YQL-19747`
- Related to https://github.com/ydb-platform/ydb/issues/9056
