### PR TITLE
#9056 Complete column names in YDB CLI

### DIFF
--- a/ydb/apps/ydb/CHANGELOG.md
+++ b/ydb/apps/ydb/CHANGELOG.md
@@ -1,3 +1,4 @@
+* Added trivial columns completion in interactive mode.
 * Added the "ydb tools infer csv" command to generate a `CREATE TABLE` SQL query from a CSV file with data.
 * Fix inline hints
 * Added named expressions completion in interactive mode, cache schema responses.

--- a/ydb/public/lib/ydb_cli/commands/interactive/complete/ya.make
+++ b/ydb/public/lib/ydb_cli/commands/interactive/complete/ya.make
@@ -12,6 +12,7 @@ PEERDIR(
     yql/essentials/sql/v1/complete/name/object
     yql/essentials/sql/v1/complete/name/object/simple
     yql/essentials/sql/v1/complete/name/object/simple/cached
+    yql/essentials/sql/v1/complete/name/service/impatient
     yql/essentials/sql/v1/complete/name/service/schema
     yql/essentials/sql/v1/complete/name/service/static
     yql/essentials/sql/v1/complete/name/service/union

--- a/ydb/public/lib/ydb_cli/commands/interactive/complete/ydb_schema.cpp
+++ b/ydb/public/lib/ydb_cli/commands/interactive/complete/ydb_schema.cpp
@@ -1,6 +1,7 @@
 #include "ydb_schema.h"
 
 #include <ydb/public/lib/ydb_cli/commands/ydb_command.h>
+#include <ydb/public/sdk/cpp/include/ydb-cpp-sdk/client/table/table.h>
 
 #include <yql/essentials/sql/v1/complete/name/object/simple/schema.h>
 
@@ -32,6 +33,23 @@ namespace NYdb::NConsoleClient {
                 .Apply([this, folder](auto f) { return this->Convert(folder, f.ExtractValue()); });
         }
 
+        NThreading::TFuture<TMaybe<NSQLComplete::TTableDetails>>
+        DescribeTable(const TString& /* cluster */, const TString& path) const override {
+            auto promise = NThreading::NewPromise<TMaybe<NSQLComplete::TTableDetails>>();
+            NTable::TTableClient(Driver_)
+                .GetSession(NTable::TCreateSessionSettings())
+                .Apply([this, path, promise](auto f) mutable {
+                    static_cast<NTable::TCreateSessionResult>(f.ExtractValue())
+                        .GetSession()
+                        .DescribeTable(Qualified(path))
+                        .Apply([this, path, promise](auto f) mutable {
+                            NTable::TDescribeTableResult result = f.ExtractValue();
+                            promise.SetValue(Convert(path, std::move(result)));
+                        });
+                });
+            return promise;
+        }
+
     private:
         TString Qualified(TString folder) const {
             if (!folder.StartsWith('/')) {
@@ -45,7 +63,7 @@ namespace NYdb::NConsoleClient {
             if (!result.IsSuccess()) {
                 if (IsVerbose_) {
                     Cerr << "ListDirectory('" << folder << "') failed: "
-                         << result.GetIssues().ToOneLineString();
+                         << result.GetIssues().ToOneLineString() << Endl;
                 }
                 return {};
             }
@@ -109,6 +127,22 @@ namespace NYdb::NConsoleClient {
                 default:
                     return "Unknown";
             }
+        }
+
+        TMaybe<NSQLComplete::TTableDetails> Convert(TString path, NTable::TDescribeTableResult result) const {
+            if (!result.IsSuccess()) {
+                if (IsVerbose_) {
+                    Cerr << "DescribeTable('" << path << "') failed: "
+                         << result.GetIssues().ToOneLineString() << Endl;
+                }
+                return Nothing();
+            }
+
+            NSQLComplete::TTableDetails details;
+            for (TColumn column : result.GetTableDescription().GetColumns()) {
+                details.Columns.emplace_back(std::move(column.Name));
+            }
+            return details;
         }
 
         TDriver Driver_;

--- a/ydb/public/lib/ydb_cli/commands/interactive/complete/yql_completer.cpp
+++ b/ydb/public/lib/ydb_cli/commands/interactive/complete/yql_completer.cpp
@@ -116,6 +116,7 @@ namespace NYdb::NConsoleClient {
                 case NSQLComplete::ECandidateKind::TableName:
                     return Color.identifier.quoted;
                 case NSQLComplete::ECandidateKind::BindingName:
+                case NSQLComplete::ECandidateKind::ColumnName:
                     return Color.identifier.variable;
                 default:
                     return replxx::Replxx::Color::DEFAULT;

--- a/ydb/public/lib/ydb_cli/commands/interactive/line_reader.cpp
+++ b/ydb/public/lib/ydb_cli/commands/interactive/line_reader.cpp
@@ -73,7 +73,7 @@ TLineReader::TLineReader(std::string prompt, std::string historyFilePath, TClien
         return YQLCompleter->ApplyHeavy(Rx.get_state().text(), prefix, contextLen);
     });
 
-    Rx.set_hint_delay(500);
+    Rx.set_hint_delay(100);
     Rx.set_hint_callback([this](const std::string& prefix, int& contextLen, TColor&) {
         return YQLCompleter->ApplyLight(Rx.get_state().text(), prefix, contextLen);
     });


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

### Changelog category <!-- remove all except one -->

* Not for changelog (changelog entry is not required)

### Description for reviewers <!-- (optional) description for those who read this PR -->

Complete column names in YDB CLI

Implemented `DescribeTable` using the YDB Client. Now supported only `SELECT a| FROM table_name`. `SELECT | FROM table_name` is not working because of current limitations of the completion engine (it interprets `FROM` as a column name and then fails to parse a table name after from), so at least one letter of column name is required. Also `SELECT p.a| FROM table_name AS p` is working. 

- Related to `YQL-19747`
- Related to https://github.com/ydb-platform/ydb/issues/9056
