### PR TITLE
Unify scan data bytes accounting with KQP in secondary index build

### DIFF
--- a/ydb/core/tx/datashard/build_index/secondary_index.cpp
+++ b/ydb/core/tx/datashard/build_index/secondary_index.cpp
@@ -357,8 +357,7 @@ private:
             // TODO(mbkkt) ReleaseBuffer isn't possible, we use LastUploadedKey for logging
             progress->Record.SetLastKeyAck(LastUploadedKey.GetBuffer());
             progress->Record.SetRowsDelta(WriteBuf.GetRows());
-            // TODO: use GetRowCellBytes method?
-            progress->Record.SetBytesDelta(WriteBuf.GetBufferBytes());
+            progress->Record.SetBytesDelta(WriteBuf.GetRowCellBytes());
             WriteBuf.Clear();
 
             progress->Record.SetStatus(NKikimrIndexBuilder::EBuildStatus::IN_PROGRESS);

--- a/ydb/core/tx/schemeshard/ut_index_build/ut_index_build.cpp
+++ b/ydb/core/tx/schemeshard/ut_index_build/ut_index_build.cpp
@@ -246,9 +246,9 @@ Y_UNIT_TEST_SUITE(IndexBuildTest) {
         auto descr = TestGetBuildIndex(runtime, tenantSchemeShard, "/MyRoot/ServerLessDB", txId);
         UNIT_ASSERT_VALUES_EQUAL(descr.GetIndexBuild().GetState(), Ydb::Table::IndexBuildState::STATE_DONE);
 
-        const TString meteringData = R"({"usage":{"start":0,"quantity":179,"finish":0,"unit":"request_unit","type":"delta"},"tags":{},"id":"106-72075186233409549-2-0-0-0-0-101-101-1818-1818","cloud_id":"CLOUD_ID_VAL","source_wt":0,"source_id":"sless-docapi-ydb-ss","resource_id":"DATABASE_ID_VAL","schema":"ydb.serverless.requests.v1","folder_id":"FOLDER_ID_VAL","version":"1.0.0"})";
-
-        UNIT_ASSERT_NO_DIFF(meteringMessages, meteringData + "\n");
+        // 101 rows, each: key:Uint32 (4 bytes), index:Uint32 (4 bytes) = 101 * 8 = 808 bytes
+        const TString meteringData = R"({"usage":{"start":0,"quantity":179,"finish":0,"unit":"request_unit","type":"delta"},"tags":{},"id":"106-72075186233409549-2-0-0-0-0-101-101-808-808","cloud_id":"CLOUD_ID_VAL","source_wt":0,"source_id":"sless-docapi-ydb-ss","resource_id":"DATABASE_ID_VAL","schema":"ydb.serverless.requests.v1","folder_id":"FOLDER_ID_VAL","version":"1.0.0"})";
+        UNIT_ASSERT_VALUES_EQUAL(meteringMessages, meteringData + "\n");
 
         TestDescribeResult(DescribePath(runtime, tenantSchemeShard, "/MyRoot/ServerLessDB/Table"),
                            {NLs::PathExist,


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

...

### Changelog category <!-- remove all except one -->

* Not for changelog (changelog entry is not required)

### Description for reviewers <!-- (optional) description for those who read this PR -->

### Before

- The cost of building a secondary index was previously calculated using `TSerializedCellVec::SerializedSize`, which adds 4 extra bytes per cell. This made the cost dependent on internal serialization details.

---

### After

To ensure consistency and transparency, index build costs are now always calculated as the sum of the underlying cell sizes—matching the [KQP implementation](https://github.com/ydb-platform/ydb/blob/7eb7f65de6e56384e8674155d61f975d4446d6d4/ydb/core/kqp/runtime/kqp_read_actor.cpp#L1237).

This approach:

- Aligns with our [documentation](https://yandex.cloud/en-ru/docs/ydb/pricing/ru-special)
- Removes cost dependency on internal serialization formats
- Produces results consistent with user expectations

#### Test Verification

To ensure consistent logic, the following test was performed:

1. **Created a sample table:**
    ```sql
    CREATE TABLE KeyValueTable (
        key Uint32,
        value Uint64,
        additional Utf8,
        PRIMARY KEY (key)
    );

    INSERT INTO KeyValueTable (key, value, additional) VALUES
        (1, 100, "a1"),
        (2, 200, "a2"),
        (3, 300, "a3"),
        (4, 400, "a4"),
        (5, 500, "a5"),
        (6, 600, "a6"),
        (7, 700, "a7"),
        (8, 800, "a8"),
        (9, 900, "a9"),
        (10, 1000, "a10");
    ```

2. **Built two indexes:**
    - `ALTER TABLE KeyValueTable ADD INDEX index_name_0 GLOBAL ON (value);`
    - `ALTER TABLE KeyValueTable ADD INDEX index_name_0_cov GLOBAL ON (value) COVER (additional);`

3. **Compared index build costs:**

   |                        | Upload Rows | Upload Bytes | Read Rows | Read Bytes |
   |------------------------|:-----------:|:------------:|:---------:|:----------:|
   | **Before (index 1)**   | 10          | 220          | 10        | 220        |
   | **Before (index 2)**   | 10          | 301          | 10        | 301        |
   | **After (index 1)**    | 10          | 120          | 10        | 120        |
   | **After (index 2)**    | 10          | 141          | 10        | 141        |

4. **Validated index table reads with `SELECT * FROM indexImplTable`:**
    - Index 1: `"ReadBytes":"120","ReadRows":"10"`
    - Index 2: `"ReadBytes":"141","ReadRows":"10"`

5. **Manual calculation of index data size:**
    - **Index 1:** 10 rows × (4 bytes for key + 8 bytes for value) = **120 bytes**
    - **Index 2:** 10 rows × (4 + 8) bytes, 9 rows × 2 bytes for `additional`, 1 row (last) × 3 bytes = **141 bytes**

---

#### Impact on Cost Calculation

Rules for IO cost calculation:

> **Number of disk reads:** The number of read records and 4 KB blocks is compared; the largest is selected. 4 KB block count = ceil(total bytes read / 4 KB).
>
> **Number of disk writes:** The number of written records and 1 KB blocks is compared; the largest is selected. 1 KB block count = ceil(total bytes written / 1 KB).

Below are comparisons for **1 KB block size (writes)** to demonstrate the effect.

##### When Cost Stays Unchanged

For typical workloads—tables with a few primitive columns per record—the cost remains the same:

- **Example: 100 integer cells (each 4 bytes)**
    - Total user data: 100 × 4 = 400 bytes
    - 1 KB blocks: ceil(400 / 1024) = 1 block
    - **Before (with +4 bytes/cell overhead):**
        - 100 × 8 = 800 bytes
        - ceil(800 / 1024) = 1 block
        - Cost: `max(100 cells, 1 block) = 100`
    - **After:**
        - 400 bytes = 1 block
        - Cost: `max(100 cells, 1 block) = 100`

**Cases with more than a dozen columns (hundreds or thousands per record) are rare.** For the vast majority of workloads, the cost stays exactly as before.

##### When Cost Changes (Many Columns)

A difference appears only for records with hundreds or thousands of cells:

- **Example: 300 integer cells (each 4 bytes)**
    - User data: 1,200 bytes
    - **Before:**  
        - Serialized: 2,400 bytes (300 × 8)
        - ceil(2,400/1024) = 3 blocks
        - Cost: `max(300, 3) = 300`
    - **After:**  
        - 1,200 bytes, ceil(1,200/1024) = 2 blocks
        - Cost: `max(300, 2) = 300`

##### When Cost Changes (Few Columns, Large Payloads)

Cost can also change for small column counts if each value is large (e.g., big strings/blobs)—especially near block boundaries:

- **Example where cost drops due to padding elimination (edge case):**
    - **5 columns, each 1,023 bytes**
        - User data: 5 × 1,023 = 5,115 bytes
        - 1 KB blocks: ceil(5,115 / 1,024) = 5 blocks
        - **Before:**  
            - (1,023+4)×5 = 5,135 bytes
            - ceil(5,135 / 1,024) = 6 blocks  
            - Cost: max(5, 6) = 6
        - **After:**  
            - 5,115 bytes = 5 blocks  
            - Cost: max(5, 5) = 5

---

**Summary:**  
- For most real-world tables (with few to a few dozen columns of typical small data sizes), cost is unchanged and still based on the number of cells.
- For rare wide tables, or records with very large cell values, reported cost now correctly matches user data size and may decrease due to removal of internal overhead—most noticeably near block boundaries.
- Change in cost is rare for typical workloads.

---

### Conclusion

This patch standardizes disk cost calculations for index builds by basing them solely on the actual size of user data, not internal serialization formats. As a result:

- **Consistency and Transparency:** Measurements now fully align with both KQP behavior and published documentation.
- **Fair Resource Usage:** Users are charged for the true size of their data, not hidden overheads.
- **Predictable Cost:** For almost all workloads—where tables have a modest number of columns—costs remain unchanged and are determined by cell count.
- **Rare Cost Changes:** Cost changes are rare and generally limited to unusual cases such as very wide tables or records with very large cell values. When cost does change, it decreases or becomes more accurate.
- **Documentation Alignment:** Usage and billing now fully align with external pricing and technical documentation.

Overall, this patch results in a clearer, fairer, and more predictable user experience when building or maintaining indexes in YDB, with actual cost changes being very rare in real-world scenarios.

