### PR TITLE
Change MAX_BLOCK_SIZE constant for encrypted file deserializer to suit real export settings

### DIFF
--- a/ydb/core/backup/common/encryption.cpp
+++ b/ydb/core/backup/common/encryption.cpp
@@ -30,7 +30,7 @@ namespace {
 
 static constexpr size_t MAC_SIZE = 16;
 static constexpr size_t MAX_HEADER_SIZE = 16_KB; // Header does not contain much data
-static constexpr size_t MAX_BLOCK_SIZE = 30_MB; // Max block size must always be at least size of table row (~8 MB) serialized into text csv format.
+static constexpr size_t MAX_BLOCK_SIZE = 50_MB; // Max block size must always be at least size of table row (~8 MB) serialized into text csv format. // Real value is bound to 32 MB in TBackupTask.TScanSettings.BytesBatchSize setting.
 
 THashMap<TString, TString> AlgNames = {
     {"aes128gcm", "AES-128-GCM"},

--- a/ydb/core/backup/common/encryption_ut.cpp
+++ b/ydb/core/backup/common/encryption_ut.cpp
@@ -269,7 +269,7 @@ Y_UNIT_TEST_SUITE(EncryptedFileSerializerTest) {
         size_t blockSizePos = fileData.Size() - 20 /* last block with MAC */ - 16 /* MAC */ - srcText.size() - 4 /* sizeof(size) */;
         UNIT_ASSERT_LT(blockSizePos, fileData.Size() - 4);
         uint32_t* size = reinterpret_cast<uint32_t*>(fileData.Data() + blockSizePos);
-        *size = htonl(50_MB);
+        *size = htonl(51_MB);
         fileData.Resize(fileData.Size() + 4);
         {
             TEncryptedFileDeserializer deserializer(Key32);


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

...

### Changelog category <!-- remove all except one -->

* Not for changelog (changelog entry is not required)

### Description for reviewers <!-- (optional) description for those who read this PR -->

Real settings for block size are 32 MB (`NKikimrSchemeOp.TBackupTask.TScanSettings.BytesBatchSize` setting), so we need to make the constant bigger in order not to generate invalid encrypted files
