### PR TITLE
Save import items count after getting it from schema mapping

### DIFF
--- a/ydb/core/tx/schemeshard/schemeshard_import.cpp
+++ b/ydb/core/tx/schemeshard/schemeshard_import.cpp
@@ -172,7 +172,8 @@ void TSchemeShard::PersistImportState(NIceDb::TNiceDb& db, const TImportInfo& im
         NIceDb::TUpdate<Schema::Imports::State>(static_cast<ui8>(importInfo.State)),
         NIceDb::TUpdate<Schema::Imports::Issue>(importInfo.Issue),
         NIceDb::TUpdate<Schema::Imports::StartTime>(importInfo.StartTime.Seconds()),
-        NIceDb::TUpdate<Schema::Imports::EndTime>(importInfo.EndTime.Seconds())
+        NIceDb::TUpdate<Schema::Imports::EndTime>(importInfo.EndTime.Seconds()),
+        NIceDb::TUpdate<Schema::Imports::Items>(importInfo.Items.size())
     );
 }
 


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

...

### Changelog category <!-- remove all except one -->

* Not for changelog (changelog entry is not required)

### Description for reviewers <!-- (optional) description for those who read this PR -->

We need to save save items count setting after we read SchemaMapping, because it changes items count
