### PR TITLE
Fail ScanFetcher on Registration (with CA) Timeout (#19900)

### DIFF
--- a/ydb/core/kqp/compute_actor/kqp_scan_fetcher_actor.h
+++ b/ydb/core/kqp/compute_actor/kqp_scan_fetcher_actor.h
@@ -189,6 +189,8 @@ private:
     std::set<ui32> TrackingNodes;
     ui32 MaxInFlight = 1024;
     bool IsAggregationRequest = false;
+    bool RegistrationFinished = false;
+    TInstant RegistrationStartTime;
 };
 
 }


### PR DESCRIPTION
Merge fix to prevent ScanFetcher leakage in case of fast ScanActor destroying