### PR TITLE
fix hc tests

### DIFF
--- a/ydb/core/health_check/health_check_ut.cpp
+++ b/ydb/core/health_check/health_check_ut.cpp
@@ -2050,6 +2050,10 @@ Y_UNIT_TEST_SUITE(THealthCheckTest) {
         TTestActorRuntime* runtime = server.GetRuntime();
         TActorId sender = runtime->AllocateEdgeActor();
 
+        // only have local on dynamic nodes
+        runtime->Send(new IEventHandle(MakeLocalID(runtime->GetNodeId(0)), sender, new TEvents::TEvPoisonPill()));
+        runtime->Send(new IEventHandle(MakeLocalID(runtime->GetNodeId(1)), sender, new TEvents::TEvPoisonPill()));
+
         server.SetupDynamicLocalService(2, "Root");
         server.StartPQTablets(1);
         server.DestroyDynamicLocalService(2);
@@ -2111,6 +2115,10 @@ Y_UNIT_TEST_SUITE(THealthCheckTest) {
         TTestActorRuntime* runtime = server.GetRuntime();
         runtime->SetLogPriority(NKikimrServices::HIVE, NActors::NLog::PRI_TRACE);
         TActorId sender = runtime->AllocateEdgeActor();
+
+        // only have local on dynamic nodes
+        runtime->Send(new IEventHandle(MakeLocalID(runtime->GetNodeId(0)), sender, new TEvents::TEvPoisonPill()));
+        runtime->Send(new IEventHandle(MakeLocalID(runtime->GetNodeId(1)), sender, new TEvents::TEvPoisonPill()));
 
 
         server.SetupDynamicLocalService(2, "Root");


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

...

### Changelog category <!-- remove all except one -->

* Not for changelog (changelog entry is not required)

### Description for reviewers <!-- (optional) description for those who read this PR -->

Удивительным образом в этих тестах раньше статические ноды не регистировались в хайве. Тесты этим пользовались, и когда это поведение пофиксилось(?), стали падать. Объяснение феномена кажется знает pixcc, он с ним ранее сталкивался. Сейчас тесты выстрелили в https://github.com/ydb-platform/ydb/pull/19377