### PR TITLE
Made KQP tests robust to changes of PathIds

### DIFF
--- a/ydb/core/kqp/proxy_service/kqp_proxy_ut.cpp
+++ b/ydb/core/kqp/proxy_service/kqp_proxy_ut.cpp
@@ -567,7 +567,7 @@ Y_UNIT_TEST_SUITE(KqpProxy) {
 
             // Wait until KQP proxy is set up
             NYdb::EStatus scriptStatus;
-            NYdb::NQuery::TQueryClient client(connection);            
+            NYdb::NQuery::TQueryClient client(connection);
             do {
                 auto executeScrptsResult = client.ExecuteScript("SELECT 42").ExtractValueSync();
                 scriptStatus = executeScrptsResult.Status().GetStatus();
@@ -659,7 +659,8 @@ Y_UNIT_TEST_SUITE(KqpProxy) {
         checkCache(sharedTennant, sharedTennant, 1);
 
         const auto& serverlessTennant = ydb->GetSettings().GetServerlessTenantName();
-        checkCache(serverlessTennant, TStringBuilder() << ":4:" << serverlessTennant, 1);
+        const auto serverlessTenantPathId = ydb->GetServerlessTenantPathId();
+        checkCache(serverlessTennant, TStringBuilder() << ":" << serverlessTenantPathId << ":" << serverlessTennant, 1);
     }
 
 } // namspace NKqp

--- a/ydb/core/kqp/ut/olap/sys_view_ut.cpp
+++ b/ydb/core/kqp/ut/olap/sys_view_ut.cpp
@@ -36,7 +36,7 @@ Y_UNIT_TEST_SUITE(KqpOlapSysView) {
         {
             //check the store
             auto selectQuery = TString(R"(
-                SELECT PathId, TabletId, InternalPathId, 
+                SELECT PathId, TabletId, InternalPathId,
                 FROM `/Root/columnStore/.sys/store_primary_index_granule_stats`
             )");
 
@@ -63,7 +63,7 @@ Y_UNIT_TEST_SUITE(KqpOlapSysView) {
         {
             //check a table in the store
             auto selectQuery = TString(R"(
-                SELECT PathId, TabletId, InternalPathId, 
+                SELECT PathId, TabletId, InternalPathId,
                 FROM `/Root/columnStore/table2/.sys/primary_index_granule_stats`
             )");
 
@@ -99,7 +99,7 @@ Y_UNIT_TEST_SUITE(KqpOlapSysView) {
         UNIT_ASSERT_VALUES_EQUAL(tablets.size(), tableShardsCount);
         auto tableClient = kikimr.GetTableClient();
         auto selectQuery = TString(R"(
-            SELECT PathId, TabletId, InternalPathId, 
+            SELECT PathId, TabletId, InternalPathId,
             FROM `/Root/table/.sys/primary_index_granule_stats`
         )");
         auto rows = ExecuteScanQuery(tableClient, selectQuery, true);
@@ -129,6 +129,8 @@ Y_UNIT_TEST_SUITE(KqpOlapSysView) {
         auto csController = NYDBTest::TControllers::RegisterCSControllerGuard<NOlap::TWaitCompactionController>();
         auto helper = TLocalHelper(kikimr);
         helper.CreateTestOlapTable();
+        const auto describe = kikimr.GetTestClient().Describe(kikimr.GetTestServer().GetRuntime(), "/Root/olapStore/olapTable");
+        const auto tablePathId = describe.GetPathId();
         helper.SetForcedCompaction();
         for (ui64 i = 0; i < 100; ++i) {
             WriteTestData(kikimr, "/Root/olapStore/olapTable", 0, 1000000 + i * 10000, 1000);
@@ -147,9 +149,9 @@ Y_UNIT_TEST_SUITE(KqpOlapSysView) {
         auto rows = ExecuteScanQuery(tableClient, selectQuery);
 
         UNIT_ASSERT_VALUES_EQUAL(rows.size(), 3);
-        UNIT_ASSERT_VALUES_EQUAL(GetUint64(rows[0].at("PathId")), 3ull);
-        UNIT_ASSERT_VALUES_EQUAL(GetUint64(rows[1].at("PathId")), 3ull);
-        UNIT_ASSERT_VALUES_EQUAL(GetUint64(rows[2].at("PathId")), 3ull);
+        UNIT_ASSERT_VALUES_EQUAL(GetUint64(rows[0].at("PathId")), tablePathId);
+        UNIT_ASSERT_VALUES_EQUAL(GetUint64(rows[1].at("PathId")), tablePathId);
+        UNIT_ASSERT_VALUES_EQUAL(GetUint64(rows[2].at("PathId")), tablePathId);
         UNIT_ASSERT_VALUES_EQUAL(GetUtf8(rows[0].at("Kind")), "INSERTED");
         UNIT_ASSERT_VALUES_EQUAL(GetUtf8(rows[1].at("Kind")), "INSERTED");
         UNIT_ASSERT_VALUES_EQUAL(GetUtf8(rows[2].at("Kind")), "INSERTED");
@@ -168,7 +170,14 @@ Y_UNIT_TEST_SUITE(KqpOlapSysView) {
         auto csController = NYDBTest::TControllers::RegisterCSControllerGuard<NOlap::TWaitCompactionController>();
 
         TLocalHelper(kikimr).CreateTestOlapTable("olapTable_1");
+        auto describe = kikimr.GetTestClient().Describe(kikimr.GetTestServer().GetRuntime(), "/Root/olapStore/olapTable_1");
+        const auto tablePathId1 = describe.GetPathId();
+
         TLocalHelper(kikimr).CreateTestOlapTable("olapTable_2");
+        describe = kikimr.GetTestClient().Describe(kikimr.GetTestServer().GetRuntime(), "/Root/olapStore/olapTable_2");
+        const auto tablePathId2 = describe.GetPathId();
+
+
         for (ui64 i = 0; i < 10; ++i) {
             WriteTestData(kikimr, "/Root/olapStore/olapTable_1", 0, 1000000 + i * 10000, 1000);
             WriteTestData(kikimr, "/Root/olapStore/olapTable_2", 0, 1000000 + i * 10000, 2000);
@@ -188,8 +197,8 @@ Y_UNIT_TEST_SUITE(KqpOlapSysView) {
             auto rows = ExecuteScanQuery(tableClient, selectQuery);
 
             UNIT_ASSERT_VALUES_EQUAL(rows.size(), 3);
-            UNIT_ASSERT_VALUES_EQUAL(GetUint64(rows.front().at("PathId")), 3ull);
-            UNIT_ASSERT_VALUES_EQUAL(GetUint64(rows.back().at("PathId")), 3ull);
+            UNIT_ASSERT_VALUES_EQUAL(GetUint64(rows.front().at("PathId")), tablePathId1);
+            UNIT_ASSERT_VALUES_EQUAL(GetUint64(rows.back().at("PathId")), tablePathId1);
         }
         {
             auto selectQuery = TString(R"(
@@ -203,17 +212,17 @@ Y_UNIT_TEST_SUITE(KqpOlapSysView) {
             auto rows = ExecuteScanQuery(tableClient, selectQuery);
 
             UNIT_ASSERT_VALUES_EQUAL(rows.size(), 3);
-            UNIT_ASSERT_VALUES_EQUAL(GetUint64(rows.front().at("PathId")), 4ull);
-            UNIT_ASSERT_VALUES_EQUAL(GetUint64(rows.back().at("PathId")), 4ull);
+            UNIT_ASSERT_VALUES_EQUAL(GetUint64(rows.front().at("PathId")), tablePathId2);
+            UNIT_ASSERT_VALUES_EQUAL(GetUint64(rows.back().at("PathId")), tablePathId2);
         }
         {
-            auto selectQuery = TString(R"(
+            auto selectQuery = Sprintf(R"(
                 SELECT *
                 FROM `/Root/olapStore/olapTable_1/.sys/primary_index_stats`
                 WHERE
-                    PathId > UInt64("3")
+                    PathId > UInt64("%lu")
                 ORDER BY PathId, Kind, TabletId
-            )");
+            )", tablePathId1);
 
             auto rows = ExecuteScanQuery(tableClient, selectQuery);
 
@@ -528,6 +537,9 @@ Y_UNIT_TEST_SUITE(KqpOlapSysView) {
         TKikimrRunner kikimr(settings);
 
         TLocalHelper(kikimr.GetTestServer()).CreateTestOlapTable();
+        const auto describe = kikimr.GetTestClient().Describe(kikimr.GetTestServer().GetRuntime(), "/Root/olapStore/olapTable");
+        const auto tablePathId = describe.GetPathId();
+
         for (ui64 i = 0; i < 10; ++i) {
             WriteTestData(kikimr, "/Root/olapStore/olapTable", 0, 1000000 + i * 10000, 2000);
         }
@@ -546,9 +558,9 @@ Y_UNIT_TEST_SUITE(KqpOlapSysView) {
             auto rows = ExecuteScanQuery(tableClient, selectQuery);
 
             UNIT_ASSERT_VALUES_EQUAL(rows.size(), 4);
-            UNIT_ASSERT_VALUES_EQUAL(GetUint64(rows[0].at("PathId")), 3ull);
+            UNIT_ASSERT_VALUES_EQUAL(GetUint64(rows[0].at("PathId")), tablePathId);
             UNIT_ASSERT_VALUES_EQUAL(GetUtf8(rows[0].at("Kind")), "INSERTED");
-            UNIT_ASSERT_VALUES_EQUAL(GetUint64(rows[3].at("PathId")), 3ull);
+            UNIT_ASSERT_VALUES_EQUAL(GetUint64(rows[3].at("PathId")), tablePathId);
             UNIT_ASSERT_VALUES_EQUAL(GetUtf8(rows[3].at("Kind")), "INSERTED");
         }
         {
@@ -588,8 +600,16 @@ Y_UNIT_TEST_SUITE(KqpOlapSysView) {
         Tests::NCommon::TLoggerInit(kikimr).Initialize();
 
         TLocalHelper(kikimr).CreateTestOlapTable("olapTable_1");
+        auto describe = kikimr.GetTestClient().Describe(kikimr.GetTestServer().GetRuntime(), "/Root/olapStore/olapTable_1");
+        const auto tablePathId1 = describe.GetPathId();
+
         TLocalHelper(kikimr).CreateTestOlapTable("olapTable_2");
+        describe = kikimr.GetTestClient().Describe(kikimr.GetTestServer().GetRuntime(), "/Root/olapStore/olapTable_2");
+        const auto tablePathId2 = describe.GetPathId();
+
         TLocalHelper(kikimr).CreateTestOlapTable("olapTable_3");
+        describe = kikimr.GetTestClient().Describe(kikimr.GetTestServer().GetRuntime(), "/Root/olapStore/olapTable_3");
+        const auto tablePathId3 = describe.GetPathId();
 
         for (ui64 i = 0; i < 10; ++i) {
             WriteTestData(kikimr, "/Root/olapStore/olapTable_1", 0, 1000000 + i * 10000, 2000);
@@ -610,23 +630,23 @@ Y_UNIT_TEST_SUITE(KqpOlapSysView) {
         }
 
         {
-            auto selectQuery = TString(R"(
+            auto selectQuery = Sprintf(R"(
                 SELECT PathId, Kind, TabletId
                 FROM `/Root/olapStore/.sys/store_primary_index_stats`
                 WHERE
-                    PathId == UInt64("3") AND Activity == 1
+                    PathId == UInt64("%lu") AND Activity == 1
                 GROUP BY TabletId, PathId, Kind
                 ORDER BY TabletId, Kind
-            )");
+            )", tablePathId1);
 
             auto rows = ExecuteScanQuery(tableClient, selectQuery);
 
             UNIT_ASSERT_VALUES_EQUAL(rows.size(), 3);
-            UNIT_ASSERT_VALUES_EQUAL(GetUint64(rows[0].at("PathId")), 3ull);
+            UNIT_ASSERT_VALUES_EQUAL(GetUint64(rows[0].at("PathId")), tablePathId1);
             UNIT_ASSERT_VALUES_EQUAL(GetUtf8(rows[0].at("Kind")), "INSERTED");
-            UNIT_ASSERT_VALUES_EQUAL(GetUint64(rows[1].at("PathId")), 3ull);
+            UNIT_ASSERT_VALUES_EQUAL(GetUint64(rows[1].at("PathId")), tablePathId1);
             UNIT_ASSERT_VALUES_EQUAL(GetUtf8(rows[2].at("Kind")), "INSERTED");
-            UNIT_ASSERT_VALUES_EQUAL(GetUint64(rows[2].at("PathId")), 3ull);
+            UNIT_ASSERT_VALUES_EQUAL(GetUint64(rows[2].at("PathId")), tablePathId1);
             UNIT_ASSERT_VALUES_EQUAL(GetUtf8(rows[1].at("Kind")), "INSERTED");
         }
 
@@ -643,32 +663,32 @@ Y_UNIT_TEST_SUITE(KqpOlapSysView) {
 
             ui32 numExpected = 3 * 3;
             UNIT_ASSERT_VALUES_EQUAL(rows.size(), numExpected);
-            UNIT_ASSERT_VALUES_EQUAL(GetUint64(rows[0].at("PathId")), 5ull);
+            UNIT_ASSERT_VALUES_EQUAL(GetUint64(rows[0].at("PathId")), tablePathId3);
             UNIT_ASSERT_VALUES_EQUAL(GetUtf8(rows[0].at("Kind")), "INSERTED");
-            UNIT_ASSERT_VALUES_EQUAL(GetUint64(rows[numExpected - 1].at("PathId")), 3ull);
+            UNIT_ASSERT_VALUES_EQUAL(GetUint64(rows[numExpected - 1].at("PathId")), tablePathId1);
             UNIT_ASSERT_VALUES_EQUAL(GetUtf8(rows[numExpected - 1].at("Kind")), "INSERTED");
         }
 
         {
-            auto selectQuery = TString(R"(
+            auto selectQuery = Sprintf(R"(
                 SELECT PathId, Kind, TabletId
                 FROM `/Root/olapStore/.sys/store_primary_index_stats`
                 WHERE
-                    PathId > UInt64("0") AND PathId < UInt32("4")
-                    OR PathId > UInt64("4") AND PathId <= UInt64("5")
+                    PathId > UInt64("0") AND PathId < UInt32("%lu")
+                    OR PathId > UInt64("%lu") AND PathId <= UInt64("%lu")
                 GROUP BY PathId, Kind, TabletId
                 ORDER BY
                     PathId DESC, Kind DESC, TabletId DESC
                 ;
-            )");
+            )", tablePathId2, tablePathId2, tablePathId3);
 
             auto rows = ExecuteScanQuery(tableClient, selectQuery);
 
             ui32 numExpected = 2 * 3;
             UNIT_ASSERT_VALUES_EQUAL(rows.size(), numExpected);
-            UNIT_ASSERT_VALUES_EQUAL(GetUint64(rows[0].at("PathId")), 5ull);
+            UNIT_ASSERT_VALUES_EQUAL(GetUint64(rows[0].at("PathId")), tablePathId3);
             UNIT_ASSERT_VALUES_EQUAL(GetUtf8(rows[0].at("Kind")), "INSERTED");
-            UNIT_ASSERT_VALUES_EQUAL(GetUint64(rows[numExpected - 1].at("PathId")), 3ull);
+            UNIT_ASSERT_VALUES_EQUAL(GetUint64(rows[numExpected - 1].at("PathId")), tablePathId1);
             UNIT_ASSERT_VALUES_EQUAL(GetUtf8(rows[numExpected - 1].at("Kind")), "INSERTED");
         }
     }
@@ -748,9 +768,19 @@ Y_UNIT_TEST_SUITE(KqpOlapSysView) {
         TKikimrRunner kikimr(settings);
         auto csController = NYDBTest::TControllers::RegisterCSControllerGuard<NOlap::TWaitCompactionController>();
         TLocalHelper helper(kikimr.GetTestServer());
+
         helper.CreateTestOlapTable("olapTable_1");
+        auto describe = kikimr.GetTestClient().Describe(kikimr.GetTestServer().GetRuntime(), "/Root/olapStore/olapTable_1");
+        const auto tablePathId1 = describe.GetPathId();
+
         helper.CreateTestOlapTable("olapTable_2");
+        describe = kikimr.GetTestClient().Describe(kikimr.GetTestServer().GetRuntime(), "/Root/olapStore/olapTable_2");
+        const auto tablePathId2 = describe.GetPathId();
+
         helper.CreateTestOlapTable("olapTable_3");
+        describe = kikimr.GetTestClient().Describe(kikimr.GetTestServer().GetRuntime(), "/Root/olapStore/olapTable_3");
+        const auto tablePathId3 = describe.GetPathId();
+
         helper.SetForcedCompaction();
 
         for (ui64 i = 0; i < 100; ++i) {
@@ -793,9 +823,9 @@ Y_UNIT_TEST_SUITE(KqpOlapSysView) {
 
             auto rows = ExecuteScanQuery(tableClient, selectQuery);
             UNIT_ASSERT_VALUES_EQUAL(rows.size(), 3ull);
-            UNIT_ASSERT_VALUES_EQUAL(GetUint64(rows[0].at("PathId")), 3);
-            UNIT_ASSERT_VALUES_EQUAL(GetUint64(rows[1].at("PathId")), 4);
-            UNIT_ASSERT_VALUES_EQUAL(GetUint64(rows[2].at("PathId")), 5);
+            UNIT_ASSERT_VALUES_EQUAL(GetUint64(rows[0].at("PathId")), tablePathId1);
+            UNIT_ASSERT_VALUES_EQUAL(GetUint64(rows[1].at("PathId")), tablePathId2);
+            UNIT_ASSERT_VALUES_EQUAL(GetUint64(rows[2].at("PathId")), tablePathId3);
         }
 
         {
@@ -815,13 +845,13 @@ Y_UNIT_TEST_SUITE(KqpOlapSysView) {
 
             auto rows = ExecuteScanQuery(tableClient, selectQuery);
             UNIT_ASSERT_VALUES_EQUAL(rows.size(), 3ull);
-            UNIT_ASSERT_VALUES_EQUAL(GetUint64(rows[0].at("PathId")), 5);
-            UNIT_ASSERT_VALUES_EQUAL(GetUint64(rows[1].at("PathId")), 4);
-            UNIT_ASSERT_VALUES_EQUAL(GetUint64(rows[2].at("PathId")), 3);
+            UNIT_ASSERT_VALUES_EQUAL(GetUint64(rows[0].at("PathId")), tablePathId3);
+            UNIT_ASSERT_VALUES_EQUAL(GetUint64(rows[1].at("PathId")), tablePathId2);
+            UNIT_ASSERT_VALUES_EQUAL(GetUint64(rows[2].at("PathId")), tablePathId1);
         }
 
         {
-            auto selectQuery = TString(R"(
+            auto selectQuery = Sprintf(R"(
                 SELECT
                     PathId,
                     SUM(Rows) as rows,
@@ -829,19 +859,19 @@ Y_UNIT_TEST_SUITE(KqpOlapSysView) {
                     SUM(RawBytes) as bytes_raw
                 FROM `/Root/olapStore/.sys/store_primary_index_stats`
                 WHERE
-                    PathId == UInt64("3") AND Kind IN ('INSERTED', 'SPLIT_COMPACTED', 'COMPACTED')
+                    PathId == UInt64("%lu") AND Kind IN ('INSERTED', 'SPLIT_COMPACTED', 'COMPACTED')
                 GROUP BY PathId
                 ORDER BY rows DESC
                 LIMIT 10
-            )");
+            )", tablePathId1);
 
             auto rows = ExecuteScanQuery(tableClient, selectQuery);
             UNIT_ASSERT_VALUES_EQUAL(rows.size(), 1ull);
-            UNIT_ASSERT_VALUES_EQUAL(GetUint64(rows[0].at("PathId")), 3);
+            UNIT_ASSERT_VALUES_EQUAL(GetUint64(rows[0].at("PathId")), tablePathId1);
         }
 
         {
-            auto selectQuery = TString(R"(
+            auto selectQuery = Sprintf(R"(
                 SELECT
                     PathId,
                     SUM(Rows) as rows,
@@ -849,16 +879,16 @@ Y_UNIT_TEST_SUITE(KqpOlapSysView) {
                     SUM(RawBytes) as bytes_raw
                 FROM `/Root/olapStore/.sys/store_primary_index_stats`
                 WHERE
-                    PathId >= UInt64("4") AND Kind IN ('INSERTED', 'SPLIT_COMPACTED', 'COMPACTED')
+                    PathId >= UInt64("%lu") AND Kind IN ('INSERTED', 'SPLIT_COMPACTED', 'COMPACTED')
                 GROUP BY PathId
                 ORDER BY rows DESC
                 LIMIT 10
-            )");
+            )", tablePathId2);
 
             auto rows = ExecuteScanQuery(tableClient, selectQuery);
             UNIT_ASSERT_VALUES_EQUAL(rows.size(), 2ull);
-            UNIT_ASSERT_VALUES_EQUAL(GetUint64(rows[0].at("PathId")), 5);
-            UNIT_ASSERT_VALUES_EQUAL(GetUint64(rows[1].at("PathId")), 4);
+            UNIT_ASSERT_VALUES_EQUAL(GetUint64(rows[0].at("PathId")), tablePathId3);
+            UNIT_ASSERT_VALUES_EQUAL(GetUint64(rows[1].at("PathId")), tablePathId2);
         }
 
         {
@@ -901,8 +931,9 @@ Y_UNIT_TEST_SUITE(KqpOlapSysView) {
 
             auto rows = ExecuteScanQuery(tableClient, selectQuery);
             UNIT_ASSERT_VALUES_EQUAL(rows.size(), 3ull);
-            for (ui64 pathId = 3, row = 0; pathId <= 5; ++pathId, ++row) {
-                UNIT_ASSERT_VALUES_EQUAL(GetUint64(rows[row].at("PathId")), pathId);
+            const TVector<TLocalPathId> tablePaths{tablePathId1, tablePathId2, tablePathId3};
+            for (size_t i = 0; i < tablePaths.size(); ++i) {
+                UNIT_ASSERT_VALUES_EQUAL(GetUint64(rows[i].at("PathId")), tablePaths[i]);
             }
         }
     }

--- a/ydb/core/kqp/workload_service/ut/common/kqp_workload_service_ut_common.cpp
+++ b/ydb/core/kqp/workload_service/ut/common/kqp_workload_service_ut_common.cpp
@@ -307,12 +307,16 @@ private:
             Ydb::Cms::CreateDatabaseRequest request;
             SetupResourcesTenant(request, request.mutable_resources()->add_storage_units(), Settings_.GetDedicatedTenantName());
             Tenants_->CreateTenant(std::move(request));
+            const auto describeResult = Client_->Describe(GetRuntime(), Settings_.GetDedicatedTenantName());
+            DedicatedTenantPathId = describeResult.GetPathDescription().GetDomainDescription().GetDomainKey().GetPathId();
         }
 
         {  // Shared
             Ydb::Cms::CreateDatabaseRequest request;
             SetupResourcesTenant(request, request.mutable_shared_resources()->add_storage_units(), Settings_.GetSharedTenantName());
             Tenants_->CreateTenant(std::move(request));
+            const auto describeResult = Client_->Describe(GetRuntime(), Settings_.GetSharedTenantName());
+            SharedTenantPathId = describeResult.GetPathDescription().GetDomainDescription().GetDomainKey().GetPathId();
         }
 
         {  // Serverless
@@ -320,6 +324,8 @@ private:
             request.set_path(Settings_.GetServerlessTenantName());
             request.mutable_serverless_resources()->set_shared_database_path(Settings_.GetSharedTenantName());
             Tenants_->CreateTenant(std::move(request));
+            const auto describeResult = Client_->Describe(GetRuntime(), Settings_.GetServerlessTenantName());
+            ServerlessTenantPathId = describeResult.GetPathDescription().GetDomainDescription().GetDomainKey().GetPathId();
         }
     }
 
@@ -549,6 +555,18 @@ public:
         return Settings_;
     }
 
+    TLocalPathId GetDedicatedTenantPathId() const override {
+        return DedicatedTenantPathId;
+    }
+
+    TLocalPathId GetSharedTenantPathId() const override {
+        return SharedTenantPathId;
+    }
+
+    TLocalPathId GetServerlessTenantPathId() const override {
+        return ServerlessTenantPathId;
+    }
+
 private:
     void SetupDefaultSettings(TQueryRunnerSettings& settings, bool asyncExecution) const {
         UNIT_ASSERT_C(!settings.HangUpDuringExecution_ || asyncExecution, "Hang up during execution is not supported for sync queries");
@@ -614,6 +632,10 @@ private:
     std::unique_ptr<TClient> Client_;
     std::unique_ptr<TDriver> YdbDriver_;
     std::unique_ptr<TTenants> Tenants_;
+
+    TLocalPathId DedicatedTenantPathId;
+    TLocalPathId SharedTenantPathId;
+    TLocalPathId ServerlessTenantPathId;
 
     std::unique_ptr<NYdb::NTable::TTableClient> TableClient_;
     std::unique_ptr<NYdb::NTable::TSession> TableClientSession_;

--- a/ydb/core/kqp/workload_service/ut/common/kqp_workload_service_ut_common.h
+++ b/ydb/core/kqp/workload_service/ut/common/kqp_workload_service_ut_common.h
@@ -76,7 +76,7 @@ struct TYdbSetupSettings {
     FLUENT_SETTING_DEFAULT(bool, EnableMetadataObjectsOnServerless, true);
     FLUENT_SETTING_DEFAULT(bool, EnableExternalDataSourcesOnServerless, true);
     FLUENT_SETTING(NKikimrConfig::TWorkloadManagerConfig, WorkloadManagerConfig);
-    
+
 
     // Default pool settings
     FLUENT_SETTING_DEFAULT(TString, PoolId, "sample_pool_id");
@@ -127,6 +127,10 @@ public:
     virtual TTestActorRuntime* GetRuntime() const = 0;
     virtual const TYdbSetupSettings& GetSettings() const = 0;
     static void WaitFor(TDuration timeout, TString description, std::function<bool(TString&)> callback);
+
+    virtual TLocalPathId GetDedicatedTenantPathId() const = 0;
+    virtual TLocalPathId GetSharedTenantPathId() const = 0;
+    virtual TLocalPathId GetServerlessTenantPathId() const = 0;
 };
 
 // Test queries


### PR DESCRIPTION
These tests were sensitive to changes of PathIds, when number of initial paths in SchemeShard changed.
It's needed before adding meterialized system view in SchemeShard.