### PR TITLE
Made SchemeShard tests robust to changing of PathIds

### DIFF
--- a/ydb/core/tx/schemeshard/ut_cdc_stream/ut_cdc_stream.cpp
+++ b/ydb/core/tx/schemeshard/ut_cdc_stream/ut_cdc_stream.cpp
@@ -1083,6 +1083,9 @@ Y_UNIT_TEST_SUITE(TCdcStreamTests) {
         )");
         env.TestWaitNotification(runtime, txId);
 
+        const auto describeResult = DescribePath(runtime, "/MyRoot/Shared");
+        const auto subDomainPathId = describeResult.GetPathId();
+
         TestAlterExtSubDomain(runtime, ++txId,  "/MyRoot", R"(
             Name: "Shared"
             StoragePools {
@@ -1107,9 +1110,9 @@ Y_UNIT_TEST_SUITE(TCdcStreamTests) {
             Name: "Serverless"
             ResourcesDomainKey {
                 SchemeShard: %lu
-                PathId: 2
+                PathId: %lu
             }
-        )", TTestTxConfig::SchemeShard));
+        )", TTestTxConfig::SchemeShard, subDomainPathId));
         env.TestWaitNotification(runtime, txId);
 
         TestAlterExtSubDomain(runtime, ++txId,  "/MyRoot", R"(
@@ -1928,6 +1931,9 @@ Y_UNIT_TEST_SUITE(TCdcStreamWithInitialScanTests) {
         )");
         env.TestWaitNotification(runtime, txId);
 
+        const auto describeResult = DescribePath(runtime, "/MyRoot/Shared");
+        const auto subDomainPathId = describeResult.GetPathId();
+
         TestAlterExtSubDomain(runtime, ++txId,  "/MyRoot", R"(
             Name: "Shared"
             StoragePools {
@@ -1958,9 +1964,9 @@ Y_UNIT_TEST_SUITE(TCdcStreamWithInitialScanTests) {
             Name: "Serverless"
             ResourcesDomainKey {
                 SchemeShard: %lu
-                PathId: 2
+                PathId: %lu
             }
-        )", TTestTxConfig::SchemeShard), attrs);
+        )", TTestTxConfig::SchemeShard, subDomainPathId), attrs);
         env.TestWaitNotification(runtime, txId);
 
         TestAlterExtSubDomain(runtime, ++txId,  "/MyRoot", R"(
@@ -2042,14 +2048,14 @@ Y_UNIT_TEST_SUITE(TCdcStreamWithInitialScanTests) {
                 runtime.DispatchEvents(opts);
             }
 
-            UNIT_ASSERT_STRINGS_EQUAL(meteringRecord, TBillRecord()
+            auto expectedBill = TBillRecord()
                 .Id("cdc_stream_scan-72075186233409549-3-72075186233409549-4")
                 .CloudId("CLOUD_ID_VAL")
                 .FolderId("FOLDER_ID_VAL")
                 .ResourceId("DATABASE_ID_VAL")
                 .SourceWt(TInstant::FromValue(0))
-                .Usage(TBillRecord::RequestUnits(1, TInstant::FromValue(0)))
-                .ToString());
+                .Usage(TBillRecord::RequestUnits(1, TInstant::FromValue(0)));
+            MeteringDataEqual(meteringRecord, expectedBill.ToString());
         } else {
             for (int i = 0; i < 10; ++i) {
                 env.SimulateSleep(runtime, TDuration::Seconds(1));

--- a/ydb/core/tx/schemeshard/ut_column_build/ut_column_build.cpp
+++ b/ydb/core/tx/schemeshard/ut_column_build/ut_column_build.cpp
@@ -19,6 +19,9 @@ Y_UNIT_TEST_SUITE(ColumnBuildTest) {
                                "Name: \"ResourceDB\"");
         env.TestWaitNotification(runtime, txId);
 
+        const auto describeResult = DescribePath(runtime, "/MyRoot/ResourceDB");
+        const auto subDomainPathId = describeResult.GetPathId();
+
         TestAlterExtSubDomain(runtime, ++txId,  "/MyRoot",
                               "StoragePools { "
                               "  Name: \"pool-1\" "
@@ -46,9 +49,9 @@ Y_UNIT_TEST_SUITE(ColumnBuildTest) {
             Name: "ServerLessDB"
             ResourcesDomainKey {
                 SchemeShard: %lu
-                PathId: 2
+                PathId: %lu
             }
-        )", TTestTxConfig::SchemeShard), attrs);
+        )", TTestTxConfig::SchemeShard, subDomainPathId), attrs);
         env.TestWaitNotification(runtime, txId);
 
         TString alterData = TStringBuilder()
@@ -125,6 +128,9 @@ Y_UNIT_TEST_SUITE(ColumnBuildTest) {
                                "Name: \"ResourceDB\"");
         env.TestWaitNotification(runtime, txId);
 
+        const auto describeResult = DescribePath(runtime, "/MyRoot/ResourceDB");
+        const auto subDomainPathId = describeResult.GetPathId();
+
         TestAlterExtSubDomain(runtime, ++txId,  "/MyRoot",
                               "StoragePools { "
                               "  Name: \"pool-1\" "
@@ -152,9 +158,9 @@ Y_UNIT_TEST_SUITE(ColumnBuildTest) {
             Name: "ServerLessDB"
             ResourcesDomainKey {
                 SchemeShard: %lu
-                PathId: 2
+                PathId: %lu
             }
-        )", TTestTxConfig::SchemeShard), attrs);
+        )", TTestTxConfig::SchemeShard, subDomainPathId), attrs);
         env.TestWaitNotification(runtime, txId);
 
         TString alterData = TStringBuilder()
@@ -219,7 +225,7 @@ Y_UNIT_TEST_SUITE(ColumnBuildTest) {
         defaultValue.mutable_value()->set_uint64_value(1111); // TODO: check invalid value
 
         TestBuildColumn(runtime, ++txId, tenantSchemeShard, "/MyRoot/ServerLessDB", "/MyRoot/ServerLessDB/Table", "ColumnValue", defaultValue, Ydb::StatusIds::SUCCESS);
-    
+
         auto listing = TestListBuildIndex(runtime, tenantSchemeShard, "/MyRoot/ServerLessDB");
         Y_ASSERT(listing.EntriesSize() == 1);
 
@@ -237,6 +243,9 @@ Y_UNIT_TEST_SUITE(ColumnBuildTest) {
         TestCreateExtSubDomain(runtime, ++txId,  "/MyRoot",
                                "Name: \"ResourceDB\"");
         env.TestWaitNotification(runtime, txId);
+
+        const auto describeResult = DescribePath(runtime, "/MyRoot/ResourceDB");
+        const auto subDomainPathId = describeResult.GetPathId();
 
         TestAlterExtSubDomain(runtime, ++txId,  "/MyRoot",
                               "StoragePools { "
@@ -265,9 +274,9 @@ Y_UNIT_TEST_SUITE(ColumnBuildTest) {
             Name: "ServerLessDB"
             ResourcesDomainKey {
                 SchemeShard: %lu
-                PathId: 2
+                PathId: %lu
             }
-        )", TTestTxConfig::SchemeShard), attrs);
+        )", TTestTxConfig::SchemeShard, subDomainPathId), attrs);
         env.TestWaitNotification(runtime, txId);
 
         TString alterData = TStringBuilder()
@@ -379,7 +388,7 @@ Y_UNIT_TEST_SUITE(ColumnBuildTest) {
         for (const auto& ev: delayedUpsertRows) {
             runtime.Send(ev);
         }
-    
+
         enabledCapture = false;
 
         auto listing = TestListBuildIndex(runtime, tenantSchemeShard, "/MyRoot/ServerLessDB");
@@ -388,7 +397,7 @@ Y_UNIT_TEST_SUITE(ColumnBuildTest) {
         env.TestWaitNotification(runtime, txId, tenantSchemeShard);
 
         auto descr = TestGetBuildIndex(runtime, tenantSchemeShard, "/MyRoot/ServerLessDB", txId);
-        Y_ASSERT(descr.GetIndexBuild().GetState() == Ydb::Table::IndexBuildState::STATE_DONE); 
+        Y_ASSERT(descr.GetIndexBuild().GetState() == Ydb::Table::IndexBuildState::STATE_DONE);
 
         for (ui32 delta = 50; delta < 101; ++delta) {
             UNIT_ASSERT(CheckLocalRowExists(runtime, TTestTxConfig::FakeHiveTablets + 6, "__user__Table", "key", 1 + delta));
@@ -407,6 +416,9 @@ Y_UNIT_TEST_SUITE(ColumnBuildTest) {
         TestCreateExtSubDomain(runtime, ++txId,  "/MyRoot",
                                "Name: \"ResourceDB\"");
         env.TestWaitNotification(runtime, txId);
+
+        const auto describeResult = DescribePath(runtime, "/MyRoot/ResourceDB");
+        const auto subDomainPathId = describeResult.GetPathId();
 
         TestAlterExtSubDomain(runtime, ++txId,  "/MyRoot",
                               "StoragePools { "
@@ -435,9 +447,9 @@ Y_UNIT_TEST_SUITE(ColumnBuildTest) {
             Name: "ServerLessDB"
             ResourcesDomainKey {
                 SchemeShard: %lu
-                PathId: 2
+                PathId: %lu
             }
-        )", TTestTxConfig::SchemeShard), attrs);
+        )", TTestTxConfig::SchemeShard, subDomainPathId), attrs);
         env.TestWaitNotification(runtime, txId);
 
         TString alterData = TStringBuilder()

--- a/ydb/core/tx/schemeshard/ut_compaction/ut_compaction.cpp
+++ b/ydb/core/tx/schemeshard/ut_compaction/ut_compaction.cpp
@@ -454,6 +454,9 @@ ui64 TestServerless(
     )");
     env.TestWaitNotification(runtime, txId);
 
+    const auto describeResult = DescribePath(runtime, "/MyRoot/Shared");
+    const auto subDomainPathId = describeResult.GetPathId();
+
     TestAlterExtSubDomain(runtime, ++txId, "/MyRoot", R"(
         PlanResolution: 50
         Coordinators: 1
@@ -482,9 +485,9 @@ ui64 TestServerless(
         Name: "User"
         ResourcesDomainKey {
             SchemeShard: %lu
-            PathId: 2
+            PathId: %lu
         }
-    )", schemeshardId), attrs);
+    )", schemeshardId, subDomainPathId), attrs);
     env.TestWaitNotification(runtime, txId);
 
     TestAlterExtSubDomain(runtime, ++txId, "/MyRoot", R"(

--- a/ydb/core/tx/schemeshard/ut_index_build/ut_index_build.cpp
+++ b/ydb/core/tx/schemeshard/ut_index_build/ut_index_build.cpp
@@ -248,7 +248,7 @@ Y_UNIT_TEST_SUITE(IndexBuildTest) {
 
         const TString meteringData = R"({"usage":{"start":0,"quantity":179,"finish":0,"unit":"request_unit","type":"delta"},"tags":{},"id":"106-72075186233409549-2-0-0-0-0-101-101-1818-1818","cloud_id":"CLOUD_ID_VAL","source_wt":0,"source_id":"sless-docapi-ydb-ss","resource_id":"DATABASE_ID_VAL","schema":"ydb.serverless.requests.v1","folder_id":"FOLDER_ID_VAL","version":"1.0.0"})";
 
-        UNIT_ASSERT_NO_DIFF(meteringMessages, meteringData + "\n");
+        MeteringDataEqual(meteringMessages, meteringData);
 
         TestDescribeResult(DescribePath(runtime, tenantSchemeShard, "/MyRoot/ServerLessDB/Table"),
                            {NLs::PathExist,

--- a/ydb/core/tx/schemeshard/ut_index_build/ut_vector_index_build.cpp
+++ b/ydb/core/tx/schemeshard/ut_index_build/ut_vector_index_build.cpp
@@ -567,7 +567,7 @@ Y_UNIT_TEST_SUITE (VectorIndexBuildTest) {
                 .SourceWt(TInstant::Seconds(10))
                 .Usage(TBillRecord::RequestUnits(130, TInstant::Seconds(0), TInstant::Seconds(10)));
             UNIT_ASSERT_VALUES_EQUAL(meteringBlocker.size(), 1);
-            UNIT_ASSERT_VALUES_EQUAL(meteringBlocker[0]->Get()->MeteringJson, expectedBill.ToString());
+            MeteringDataEqual(meteringBlocker[0]->Get()->MeteringJson, expectedBill.ToString());
             previousBillId = newBillId;
             meteringBlocker.Unblock();
         }
@@ -638,7 +638,7 @@ Y_UNIT_TEST_SUITE (VectorIndexBuildTest) {
                 .SourceWt(TInstant::Seconds(10))
                 .Usage(TBillRecord::RequestUnits(336, TInstant::Seconds(10), TInstant::Seconds(10)));
             UNIT_ASSERT_VALUES_EQUAL(meteringBlocker.size(), 1);
-            UNIT_ASSERT_VALUES_EQUAL(meteringBlocker[0]->Get()->MeteringJson, expectedBill.ToString());
+            MeteringDataEqual(meteringBlocker[0]->Get()->MeteringJson, expectedBill.ToString());
             previousBillId = newBillId;
             meteringBlocker.Stop().Unblock();
         }

--- a/ydb/core/tx/schemeshard/ut_olap/ut_olap.cpp
+++ b/ydb/core/tx/schemeshard/ut_olap/ut_olap.cpp
@@ -234,6 +234,7 @@ Y_UNIT_TEST_SUITE(TOlap) {
 
         TestLs(runtime, "/MyRoot/MyDir", false, NLs::PathExist);
 
+        const auto expectedTablePathId = GetNextLocalPathId(runtime, txId);
         TestCreateColumnTable(runtime, ++txId, "/MyRoot/MyDir", R"(
             Name: "MyTable"
             ColumnShardCount: 1
@@ -246,13 +247,13 @@ Y_UNIT_TEST_SUITE(TOlap) {
         )");
         env.TestWaitNotification(runtime, txId);
 
-        TestLsPathId(runtime, 4, NLs::PathStringEqual("/MyRoot/MyDir/MyTable"));
+        TestLsPathId(runtime, expectedTablePathId, NLs::PathStringEqual("/MyRoot/MyDir/MyTable"));
 
         TestDropColumnTable(runtime, ++txId, "/MyRoot/MyDir", "MyTable");
         env.TestWaitNotification(runtime, txId);
 
         TestLs(runtime, "/MyRoot/MyDir/MyTable", false, NLs::PathNotExist);
-        TestLsPathId(runtime, 4, NLs::PathStringEqual(""));
+        TestLsPathId(runtime, expectedTablePathId, NLs::PathStringEqual(""));
     }
 
     Y_UNIT_TEST(CreateTable) {
@@ -415,11 +416,12 @@ Y_UNIT_TEST_SUITE(TOlap) {
 
         const TString& olapSchema = defaultStoreSchema;
 
+        const auto expectedStorePathId = GetNextLocalPathId(runtime, txId);
         TestCreateOlapStore(runtime, ++txId, "/MyRoot", olapSchema);
         env.TestWaitNotification(runtime, txId);
 
         TestLs(runtime, "/MyRoot/OlapStore", false, NLs::PathExist);
-        TestLsPathId(runtime, 2, NLs::PathStringEqual("/MyRoot/OlapStore"));
+        TestLsPathId(runtime, expectedStorePathId, NLs::PathStringEqual("/MyRoot/OlapStore"));
 
         TestMkDir(runtime, ++txId, "/MyRoot/OlapStore", "MyDir");
         env.TestWaitNotification(runtime, txId);
@@ -431,16 +433,17 @@ Y_UNIT_TEST_SUITE(TOlap) {
             ColumnShardCount: 1
         )";
 
+        const auto expectedTablePathId = GetNextLocalPathId(runtime, txId);
         TestCreateColumnTable(runtime, ++txId, "/MyRoot/OlapStore/MyDir", tableSchema);
         env.TestWaitNotification(runtime, txId);
 
-        TestLsPathId(runtime, 4, NLs::PathStringEqual("/MyRoot/OlapStore/MyDir/ColumnTable"));
+        TestLsPathId(runtime, expectedTablePathId, NLs::PathStringEqual("/MyRoot/OlapStore/MyDir/ColumnTable"));
 
         TestDropColumnTable(runtime, ++txId, "/MyRoot/OlapStore/MyDir", "ColumnTable");
         env.TestWaitNotification(runtime, txId);
 
         TestLs(runtime, "/MyRoot/OlapStore/MyDir/ColumnTable", false, NLs::PathNotExist);
-        TestLsPathId(runtime, 4, NLs::PathStringEqual(""));
+        TestLsPathId(runtime, expectedTablePathId, NLs::PathStringEqual(""));
 
         TestDropOlapStore(runtime, ++txId, "/MyRoot", "OlapStore", {NKikimrScheme::StatusNameConflict});
         TestRmDir(runtime, ++txId, "/MyRoot/OlapStore", "MyDir");
@@ -450,7 +453,7 @@ Y_UNIT_TEST_SUITE(TOlap) {
         env.TestWaitNotification(runtime, txId);
 
         TestLs(runtime, "/MyRoot/OlapStore", false, NLs::PathNotExist);
-        TestLsPathId(runtime, 2, NLs::PathStringEqual(""));
+        TestLsPathId(runtime, expectedStorePathId, NLs::PathStringEqual(""));
     }
 
     Y_UNIT_TEST(CreateDropStandaloneTable) {
@@ -463,16 +466,17 @@ Y_UNIT_TEST_SUITE(TOlap) {
 
         TestLs(runtime, "/MyRoot/MyDir", false, NLs::PathExist);
 
+        auto expectedTablePathId = GetNextLocalPathId(runtime, txId);
         TestCreateColumnTable(runtime, ++txId, "/MyRoot/MyDir", defaultTableSchema);
         env.TestWaitNotification(runtime, txId);
 
-        TestLsPathId(runtime, 3, NLs::PathStringEqual("/MyRoot/MyDir/ColumnTable"));
+        TestLsPathId(runtime, expectedTablePathId, NLs::PathStringEqual("/MyRoot/MyDir/ColumnTable"));
 
         TestDropColumnTable(runtime, ++txId, "/MyRoot/MyDir", "ColumnTable");
         env.TestWaitNotification(runtime, txId);
 
         TestLs(runtime, "/MyRoot/MyDir/ColumnTable", false, NLs::PathNotExist);
-        TestLsPathId(runtime, 3, NLs::PathStringEqual(""));
+        TestLsPathId(runtime, expectedTablePathId, NLs::PathStringEqual(""));
 
         // PARTITION BY ()
 
@@ -493,6 +497,7 @@ Y_UNIT_TEST_SUITE(TOlap) {
             }
         )";
 
+        expectedTablePathId = GetNextLocalPathId(runtime, txId);
         TestCreateColumnTable(runtime, ++txId, "/MyRoot/MyDir", otherSchema);
         env.TestWaitNotification(runtime, txId);
 
@@ -510,13 +515,13 @@ Y_UNIT_TEST_SUITE(TOlap) {
             UNIT_ASSERT_VALUES_EQUAL(hashSharding.GetColumns()[1], "data");
         };
 
-        TestLsPathId(runtime, 4, checkFn);
+        TestLsPathId(runtime, expectedTablePathId, checkFn);
 
         TestDropColumnTable(runtime, ++txId, "/MyRoot/MyDir", "ColumnTable");
         env.TestWaitNotification(runtime, txId);
 
         TestLs(runtime, "/MyRoot/MyDir/ColumnTable", false, NLs::PathNotExist);
-        TestLsPathId(runtime, 4, NLs::PathStringEqual(""));
+        TestLsPathId(runtime, expectedTablePathId, NLs::PathStringEqual(""));
     }
 
     Y_UNIT_TEST(CreateDropStandaloneTableDefaultSharding) {
@@ -529,16 +534,17 @@ Y_UNIT_TEST_SUITE(TOlap) {
 
         TestLs(runtime, "/MyRoot/MyDir", false, NLs::PathExist);
 
+        auto expectedTablePathId = GetNextLocalPathId(runtime, txId);
         TestCreateColumnTable(runtime, ++txId, "/MyRoot/MyDir", defaultTableSchema);
         env.TestWaitNotification(runtime, txId);
 
-        TestLsPathId(runtime, 3, NLs::PathStringEqual("/MyRoot/MyDir/ColumnTable"));
+        TestLsPathId(runtime, expectedTablePathId, NLs::PathStringEqual("/MyRoot/MyDir/ColumnTable"));
 
         TestDropColumnTable(runtime, ++txId, "/MyRoot/MyDir", "ColumnTable");
         env.TestWaitNotification(runtime, txId);
 
         TestLs(runtime, "/MyRoot/MyDir/ColumnTable", false, NLs::PathNotExist);
-        TestLsPathId(runtime, 3, NLs::PathStringEqual(""));
+        TestLsPathId(runtime, expectedTablePathId, NLs::PathStringEqual(""));
 
         TString otherSchema = R"(
             Name: "ColumnTable"
@@ -551,6 +557,7 @@ Y_UNIT_TEST_SUITE(TOlap) {
             }
         )";
 
+        expectedTablePathId = GetNextLocalPathId(runtime, txId);
         TestCreateColumnTable(runtime, ++txId, "/MyRoot/MyDir", otherSchema);
         env.TestWaitNotification(runtime, txId);
 
@@ -571,13 +578,13 @@ Y_UNIT_TEST_SUITE(TOlap) {
             UNIT_ASSERT_VALUES_EQUAL(hashSharding.GetColumns()[1], "data");
         };
 
-        TestLsPathId(runtime, 4, checkFn);
+        TestLsPathId(runtime, expectedTablePathId, checkFn);
 
         TestDropColumnTable(runtime, ++txId, "/MyRoot/MyDir", "ColumnTable");
         env.TestWaitNotification(runtime, txId);
 
         TestLs(runtime, "/MyRoot/MyDir/ColumnTable", false, NLs::PathNotExist);
-        TestLsPathId(runtime, 4, NLs::PathStringEqual(""));
+        TestLsPathId(runtime, expectedTablePathId, NLs::PathStringEqual(""));
     }
 
     Y_UNIT_TEST(CreateTableTtl) {
@@ -873,17 +880,19 @@ Y_UNIT_TEST_SUITE(TOlap) {
 
         const TString& olapSchema = defaultStoreSchema;
 
+        const auto expectedStorePathId = GetNextLocalPathId(runtime, txId);
         TestCreateOlapStore(runtime, ++txId, "/MyRoot", olapSchema);
         env.TestWaitNotification(runtime, txId);
 
         TestLs(runtime, "/MyRoot/OlapStore", false, NLs::PathExist);
-        TestLsPathId(runtime, 2, NLs::PathStringEqual("/MyRoot/OlapStore"));
+        TestLsPathId(runtime, expectedStorePathId, NLs::PathStringEqual("/MyRoot/OlapStore"));
 
         TString tableSchema = R"(
             Name: "ColumnTable"
             ColumnShardCount: 1
         )";
 
+        const auto expectedTablePathId = GetNextLocalPathId(runtime, txId);
         TestCreateColumnTable(runtime, ++txId, "/MyRoot/OlapStore", tableSchema);
         env.TestWaitNotification(runtime, txId);
 
@@ -901,7 +910,7 @@ Y_UNIT_TEST_SUITE(TOlap) {
             UNIT_ASSERT_VALUES_EQUAL(record.GetPath(), "/MyRoot/OlapStore/ColumnTable");
         };
 
-        TestLsPathId(runtime, 3, checkFn);
+        TestLsPathId(runtime, expectedTablePathId, checkFn);
         UNIT_ASSERT(shardId);
         UNIT_ASSERT(pathId);
         UNIT_ASSERT(planStep.Val());
@@ -1048,17 +1057,19 @@ Y_UNIT_TEST_SUITE(TOlap) {
 
         const TString& olapSchema = defaultStoreSchema;
 
+        const auto expectedStorePathId = GetNextLocalPathId(runtime, txId);
         TestCreateOlapStore(runtime, ++txId, "/MyRoot/SomeDatabase", olapSchema);
         env.TestWaitNotification(runtime, txId);
 
         TestLs(runtime, "/MyRoot/SomeDatabase/OlapStore", false, NLs::PathExist);
-        TestLsPathId(runtime, 3, NLs::PathStringEqual("/MyRoot/SomeDatabase/OlapStore"));
+        TestLsPathId(runtime, expectedStorePathId, NLs::PathStringEqual("/MyRoot/SomeDatabase/OlapStore"));
 
         TString tableSchema = R"(
             Name: "ColumnTable"
             ColumnShardCount: 1
         )";
 
+        const auto expectedTablePathId = GetNextLocalPathId(runtime, txId);
         TestCreateColumnTable(runtime, ++txId, "/MyRoot/SomeDatabase/OlapStore", tableSchema);
         env.TestWaitNotification(runtime, txId);
 
@@ -1076,7 +1087,7 @@ Y_UNIT_TEST_SUITE(TOlap) {
             UNIT_ASSERT_VALUES_EQUAL(record.GetPath(), "/MyRoot/SomeDatabase/OlapStore/ColumnTable");
         };
 
-        TestLsPathId(runtime, 4, checkFn);
+        TestLsPathId(runtime, expectedTablePathId, checkFn);
         UNIT_ASSERT(shardId);
         UNIT_ASSERT(pathId);
         UNIT_ASSERT(planStep.Val());
@@ -1205,9 +1216,9 @@ Y_UNIT_TEST_SUITE(TOlapNaming) {
         TTestBasicRuntime runtime;
         TTestEnv env(runtime);
         ui64 txId = 100;
-        
+
         TVector<TString> notAllowedNames = {"mess age", "~!@#$%^&*()+=asdfa"};
-        
+
         for (const auto& colName: notAllowedNames) {
             TString tableSchema = Sprintf(tableSchemaFormat.c_str(), colName.c_str());
 

--- a/ydb/core/tx/schemeshard/ut_serverless/ut_serverless.cpp
+++ b/ydb/core/tx/schemeshard/ut_serverless/ut_serverless.cpp
@@ -22,6 +22,9 @@ Y_UNIT_TEST_SUITE(TSchemeShardServerLess) {
                                "Name: \"SharedDB\"");
         env.TestWaitNotification(runtime, txId);
 
+        const auto describeResult = DescribePath(runtime, "/MyRoot/SharedDB");
+        const auto subDomainPathId = describeResult.GetPathId();
+
         TestAlterExtSubDomain(runtime, ++txId,  "/MyRoot",
                               "StoragePools { "
                               "  Name: \"pool-1\" "
@@ -50,7 +53,7 @@ Y_UNIT_TEST_SUITE(TSchemeShardServerLess) {
                     && sharedHive != TTestTxConfig::Hive);
 
         TString createData = TStringBuilder()
-                << "ResourcesDomainKey { SchemeShard: " << TTestTxConfig::SchemeShard <<  " PathId: " << 2 << " } "
+                << "ResourcesDomainKey { SchemeShard: " << TTestTxConfig::SchemeShard <<  " PathId: " << subDomainPathId << " } "
                 << "Name: \"ServerLess0\"";
         TestCreateExtSubDomain(runtime, ++txId,  "/MyRoot", createData);
         env.TestWaitNotification(runtime, txId);
@@ -134,6 +137,9 @@ Y_UNIT_TEST_SUITE(TSchemeShardServerLess) {
                               "Name: \"ResourceDB\"");
         env.TestWaitNotification(runtime, txId);
 
+        const auto describeResult = DescribePath(runtime, "/MyRoot/ResourceDB");
+        const auto subDomainPathId = describeResult.GetPathId();
+
         TestAlterExtSubDomain(runtime, ++txId,  "/MyRoot",
                               "StoragePools { "
                               "  Name: \"pool-1\" "
@@ -155,7 +161,7 @@ Y_UNIT_TEST_SUITE(TSchemeShardServerLess) {
         runtime.UpdateCurrentTime(now);
 
         TString createData = TStringBuilder()
-                << "ResourcesDomainKey { SchemeShard: " << TTestTxConfig::SchemeShard <<  " PathId: " << 2 << " } "
+                << "ResourcesDomainKey { SchemeShard: " << TTestTxConfig::SchemeShard <<  " PathId: " << subDomainPathId << " } "
                 << "Name: \"ServerLessDB\"";
         TestCreateExtSubDomain(runtime, ++txId,  "/MyRoot", createData);
         env.TestWaitNotification(runtime, txId);
@@ -242,8 +248,7 @@ Y_UNIT_TEST_SUITE(TSchemeShardServerLess) {
 
         {
             TString meteringData = R"({"usage":{"start":1600452120,"quantity":59,"finish":1600452179,"type":"delta","unit":"byte*second"},"tags":{"ydb_size":13280},"id":"72057594046678944-3-1600452120-1600452179-13280","cloud_id":"CLOUD_ID_VAL","source_wt":1600452180,"source_id":"sless-docapi-ydb-storage","resource_id":"DATABASE_ID_VAL","schema":"ydb.serverless.v1","folder_id":"FOLDER_ID_VAL","version":"1.0.0"})";
-            meteringData += "\n";
-            UNIT_ASSERT_NO_DIFF(meteringMessages, meteringData);
+            MeteringDataEqual(meteringMessages, meteringData);
         }
 
         runtime.SetObserverFunc(prevObserver);
@@ -258,8 +263,7 @@ Y_UNIT_TEST_SUITE(TSchemeShardServerLess) {
 
         {
             TString meteringData = R"({"usage":{"start":1600452180,"quantity":59,"finish":1600452239,"type":"delta","unit":"byte*second"},"tags":{"ydb_size":0},"id":"72057594046678944-3-1600452180-1600452239-0","cloud_id":"CLOUD_ID_VAL","source_wt":1600452240,"source_id":"sless-docapi-ydb-storage","resource_id":"DATABASE_ID_VAL","schema":"ydb.serverless.v1","folder_id":"FOLDER_ID_VAL","version":"1.0.0"})";
-            meteringData += "\n";
-            UNIT_ASSERT_NO_DIFF(meteringMessages, meteringData);
+            MeteringDataEqual(meteringMessages, meteringData);
         }
     }
 
@@ -273,6 +277,9 @@ Y_UNIT_TEST_SUITE(TSchemeShardServerLess) {
             Name: "SharedDB"
         )");
         env.TestWaitNotification(runtime, txId);
+
+        const auto describeResult = DescribePath(runtime, "/MyRoot/SharedDB");
+        const auto subDomainPathId = describeResult.GetPathId();
 
         TestAlterExtSubDomain(runtime, ++txId,  "/MyRoot", R"(
             Name: "SharedDB"
@@ -292,9 +299,9 @@ Y_UNIT_TEST_SUITE(TSchemeShardServerLess) {
             Name: "ServerlessDB"
             ResourcesDomainKey {
                 SchemeShard: %lu
-                PathId: 2
+                PathId: %lu
             }
-        )", TTestTxConfig::SchemeShard));
+        )", TTestTxConfig::SchemeShard, subDomainPathId));
         env.TestWaitNotification(runtime, txId);
 
         TestAlterExtSubDomain(runtime, ++txId,  "/MyRoot", R"(
@@ -338,6 +345,9 @@ Y_UNIT_TEST_SUITE(TSchemeShardServerLess) {
             R"(Name: "SharedDB")"
         );
         env.TestWaitNotification(runtime, txId);
+
+        const auto describeResult = DescribePath(runtime, "/MyRoot/SharedDB");
+        const auto subDomainPathId = describeResult.GetPathId();
 
         TestAlterExtSubDomain(runtime, ++txId,  "/MyRoot",
             R"(
@@ -384,11 +394,11 @@ Y_UNIT_TEST_SUITE(TSchemeShardServerLess) {
             R"(
                 ResourcesDomainKey {
                     SchemeShard: %lu
-                    PathId: 2
+                    PathId: %lu
                 }
                 Name: "ServerLess0"
             )",
-            TTestTxConfig::SchemeShard
+            TTestTxConfig::SchemeShard, subDomainPathId
         );
         TestCreateExtSubDomain(runtime, ++txId,  "/MyRoot", createData);
         env.TestWaitNotification(runtime, txId);
@@ -457,6 +467,9 @@ Y_UNIT_TEST_SUITE(TSchemeShardServerLess) {
         );
         env.TestWaitNotification(runtime, txId);
 
+        const auto describeResult = DescribePath(runtime, "/MyRoot/SharedDB");
+        const auto subDomainPathId = describeResult.GetPathId();
+
         TestAlterExtSubDomain(runtime, ++txId,  "/MyRoot",
             R"(
                 StoragePools {
@@ -482,11 +495,11 @@ Y_UNIT_TEST_SUITE(TSchemeShardServerLess) {
             R"(
                 ResourcesDomainKey {
                     SchemeShard: %lu
-                    PathId: 2
+                    PathId: %lu
                 }
                 Name: "ServerLess0"
             )",
-            TTestTxConfig::SchemeShard
+            TTestTxConfig::SchemeShard, subDomainPathId
         );
         TestCreateExtSubDomain(runtime, ++txId,  "/MyRoot", createData);
         env.TestWaitNotification(runtime, txId);
@@ -538,6 +551,9 @@ Y_UNIT_TEST_SUITE(TSchemeShardServerLess) {
         );
         env.TestWaitNotification(runtime, txId);
 
+        const auto describeResult = DescribePath(runtime, "/MyRoot/SharedDB");
+        const auto subDomainPathId = describeResult.GetPathId();
+
         TestAlterExtSubDomain(runtime, ++txId,  "/MyRoot",
             R"(
                 StoragePools {
@@ -563,11 +579,11 @@ Y_UNIT_TEST_SUITE(TSchemeShardServerLess) {
             R"(
                 ResourcesDomainKey {
                     SchemeShard: %lu
-                    PathId: 2
+                    PathId: %lu
                 }
                 Name: "ServerLess0"
             )",
-            TTestTxConfig::SchemeShard
+            TTestTxConfig::SchemeShard, subDomainPathId
         );
         TestCreateExtSubDomain(runtime, ++txId,  "/MyRoot", createData);
         env.TestWaitNotification(runtime, txId);


### PR DESCRIPTION
Many SchemeShard tests rely on PathIds of created object so after changing the number of initial paths tests become failed.
Have to fix it, getting a PathId during tests. 
