### PR TITLE
Remove encrypted deserializer state from logs

### DIFF
--- a/ydb/core/backup/common/proto/encrypted_file.proto
+++ b/ydb/core/backup/common/proto/encrypted_file.proto
@@ -1,6 +1,8 @@
 syntax = "proto3";
 option cc_enable_arenas = true;
 
+import "ydb/public/api/protos/annotations/sensitive.proto";
+
 package NKikimr.NBackup;
 
 message TExportEncryptedFileHeader {
@@ -11,7 +13,7 @@ message TExportEncryptedFileHeader {
 
 message TEncryptedFileDeserializerState {
     string EncryptionAlgorithm = 1;
-    bytes Key = 2;
+    bytes Key = 2 [(Ydb.sensitive) = true];
     bytes IV = 3;
     uint32 CurrentChunkNumber = 4;
     uint64 BytesProcessed = 5;

--- a/ydb/core/backup/common/proto/ya.make
+++ b/ydb/core/backup/common/proto/ya.make
@@ -1,5 +1,9 @@
 PROTO_LIBRARY()
 
+PEERDIR(
+    ydb/public/api/protos/annotations
+)
+
 SRCS(
     encrypted_file.proto
 )

--- a/ydb/core/protos/datashard_backup.proto
+++ b/ydb/core/protos/datashard_backup.proto
@@ -1,3 +1,5 @@
+import "ydb/public/api/protos/annotations/sensitive.proto";
+
 package NKikimrBackup;
 option java_package = "ru.yandex.kikimr.proto";
 
@@ -19,5 +21,5 @@ message TChecksumState {
 }
 
 message TS3DownloadState {
-    optional bytes EncryptedDeserializerState = 1;
+    optional bytes EncryptedDeserializerState = 1 [(Ydb.sensitive) = true]; // Contains secure key
 }

--- a/ydb/core/protos/ya.make
+++ b/ydb/core/protos/ya.make
@@ -180,6 +180,7 @@ PEERDIR(
     ydb/library/yql/dq/actors/protos
     ydb/library/yql/dq/proto
     ydb/public/api/protos
+    ydb/public/api/protos/annotations
     yql/essentials/core/file_storage/proto
     yql/essentials/core/issue/protos
     yql/essentials/providers/common/proto

--- a/ydb/core/tx/datashard/datashard_s3_download.cpp
+++ b/ydb/core/tx/datashard/datashard_s3_download.cpp
@@ -1,0 +1,26 @@
+#include "datashard_s3_download.h"
+
+#include <ydb/library/protobuf_printer/security_printer.h>
+
+#include <util/stream/output.h>
+
+namespace NKikimr {
+namespace NDataShard {
+
+void TS3Download::Out(IOutputStream& out) const {
+    out << "{"
+        << " DataETag: " << DataETag
+        << " ProcessedBytes: " << ProcessedBytes
+        << " WrittenBytes: " << WrittenBytes
+        << " WrittenRows: " << WrittenRows
+        << " ChecksumState: " << ChecksumState.ShortDebugString()
+        << " DownloadState: " << SecureDebugString(DownloadState) // Can hold secure encryption key
+    << " }";
+}
+
+} // namespace NDataShard
+} // namespace NKikimr
+
+Y_DECLARE_OUT_SPEC(, NKikimr::NDataShard::TS3Download, out, value) {
+    value.Out(out);
+}

--- a/ydb/core/tx/datashard/datashard_s3_download.h
+++ b/ydb/core/tx/datashard/datashard_s3_download.h
@@ -15,23 +15,8 @@ struct TS3Download {
     NKikimrBackup::TChecksumState ChecksumState;
     NKikimrBackup::TS3DownloadState DownloadState; // Can hold secure encryption key
 
-    void Out(IOutputStream& out) const {
-        auto downloadState = DownloadState;
-        downloadState.ClearEncryptedDeserializerState(); // Can hold secure encryption key
-        out << "{"
-            << " DataETag: " << DataETag
-            << " ProcessedBytes: " << ProcessedBytes
-            << " WrittenBytes: " << WrittenBytes
-            << " WrittenRows: " << WrittenRows
-            << " ChecksumState: " << ChecksumState.ShortDebugString()
-            << " DownloadState: " << downloadState.ShortDebugString()
-        << " }";
-    }
+    void Out(IOutputStream& out) const;
 };
 
 } // namespace NDataShard
 } // namespace NKikimr
-
-Y_DECLARE_OUT_SPEC(inline, NKikimr::NDataShard::TS3Download, out, value) {
-    value.Out(out);
-}

--- a/ydb/core/tx/datashard/datashard_s3_download.h
+++ b/ydb/core/tx/datashard/datashard_s3_download.h
@@ -13,16 +13,18 @@ struct TS3Download {
     ui64 WrittenBytes = 0;
     ui64 WrittenRows = 0;
     NKikimrBackup::TChecksumState ChecksumState;
-    NKikimrBackup::TS3DownloadState DownloadState;
+    NKikimrBackup::TS3DownloadState DownloadState; // Can hold secure encryption key
 
     void Out(IOutputStream& out) const {
+        auto downloadState = DownloadState;
+        downloadState.ClearEncryptedDeserializerState(); // Can hold secure encryption key
         out << "{"
             << " DataETag: " << DataETag
             << " ProcessedBytes: " << ProcessedBytes
             << " WrittenBytes: " << WrittenBytes
             << " WrittenRows: " << WrittenRows
             << " ChecksumState: " << ChecksumState.ShortDebugString()
-            << " DownloadState: " << DownloadState.ShortDebugString()
+            << " DownloadState: " << downloadState.ShortDebugString()
         << " }";
     }
 };

--- a/ydb/core/tx/datashard/ya.make
+++ b/ydb/core/tx/datashard/ya.make
@@ -116,6 +116,7 @@ SRCS(
     datashard_repl_offsets.cpp
     datashard_repl_offsets_client.cpp
     datashard_repl_offsets_server.cpp
+    datashard_s3_download.cpp
     datashard_s3_downloads.cpp
     datashard_s3_upload_rows.cpp
     datashard_s3_uploads.cpp
@@ -239,8 +240,6 @@ RESOURCE(
 
 PEERDIR(
     contrib/libs/zstd
-    ydb/library/actors/core
-    ydb/library/actors/http
     library/cpp/containers/absl_flat_hash
     library/cpp/containers/stack_vector
     library/cpp/digest/md5
@@ -272,15 +271,18 @@ PEERDIR(
     ydb/core/wrappers
     ydb/core/ydb_convert
     ydb/library/aclib
+    ydb/library/actors/core
+    ydb/library/actors/http
+    ydb/library/chunks_limiter
+    ydb/library/protobuf_printer
+    ydb/library/yql/dq/actors/compute
     yql/essentials/types/binary_json
     yql/essentials/types/dynumber
     yql/essentials/core/minsketch
     yql/essentials/parser/pg_wrapper/interface
     ydb/public/api/protos
-    ydb/library/yql/dq/actors/compute
     yql/essentials/parser/pg_wrapper/interface
     ydb/services/lib/sharding
-    ydb/library/chunks_limiter
     yql/essentials/types/uuid
     ydb/core/io_formats/cell_maker
 )


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

...

### Changelog category <!-- remove all except one -->

* Not for changelog (changelog entry is not required)

### Description for reviewers <!-- (optional) description for those who read this PR -->

Remove logging all the state, because encrypted file deserializer state contains secret key
