### PR TITLE
Support bidirectional assimilation

### DIFF
--- a/ydb/core/base/blobstorage.h
+++ b/ydb/core/base/blobstorage.h
@@ -2505,18 +2505,23 @@ struct TEvBlobStorage {
         std::optional<ui64> SkipBlocksUpTo;
         std::optional<std::tuple<ui64, ui8>> SkipBarriersUpTo;
         std::optional<TLogoBlobID> SkipBlobsUpTo;
+        bool IgnoreDecommitState;
+        bool Reverse;
 
         TEvAssimilate(TCloneEventPolicy, const TEvAssimilate& origin)
             : SkipBlocksUpTo(origin.SkipBlocksUpTo)
             , SkipBarriersUpTo(origin.SkipBarriersUpTo)
             , SkipBlobsUpTo(origin.SkipBlobsUpTo)
+            , Reverse(origin.Reverse)
         {}
 
         TEvAssimilate(std::optional<ui64> skipBlocksUpTo, std::optional<std::tuple<ui64, ui8>> skipBarriersUpTo,
-                std::optional<TLogoBlobID> skipBlobsUpTo)
+                std::optional<TLogoBlobID> skipBlobsUpTo, bool ignoreDecommitState, bool reverse)
             : SkipBlocksUpTo(skipBlocksUpTo)
             , SkipBarriersUpTo(skipBarriersUpTo)
             , SkipBlobsUpTo(skipBlobsUpTo)
+            , IgnoreDecommitState(ignoreDecommitState)
+            , Reverse(reverse)
         {}
 
         TString Print(bool /*isFull*/) const {
@@ -2525,17 +2530,16 @@ struct TEvBlobStorage {
 
         TString ToString() const {
             TStringStream str;
-            str << "TEvAssimilate {";
-            const char *prefix = "";
+            str << "TEvAssimilate {Reverse# " << Reverse;
             if (SkipBlocksUpTo) {
-                str << std::exchange(prefix, " ") << "SkipBlocksUpTo# " << *SkipBlocksUpTo;
+                str << " SkipBlocksUpTo# " << *SkipBlocksUpTo;
             }
             if (SkipBarriersUpTo) {
-                str << std::exchange(prefix, " " ) << "SkipBarriersUpTo# " << std::get<0>(*SkipBarriersUpTo)
-                    << ":" << int(std::get<1>(*SkipBarriersUpTo));
+                auto& [tabletId, channel] = *SkipBarriersUpTo;
+                str << " SkipBarriersUpTo# " << tabletId << ':' << channel;
             }
             if (SkipBlobsUpTo) {
-                str << std::exchange(prefix, " " ) << "SkipBlobsUpTo# ";
+                str << " SkipBlobsUpTo# ";
                 SkipBlobsUpTo->Out(str);
             }
             str << "}";

--- a/ydb/core/blob_depot/assimilator.cpp
+++ b/ydb/core/blob_depot/assimilator.cpp
@@ -199,7 +199,7 @@ namespace NKikimr::NBlobDepot {
             (SelfId, SelfId()));
         Y_ABORT_UNLESS(Self->Config.GetIsDecommittingGroup());
         SendToBSProxy(SelfId(), Self->Config.GetVirtualGroupId(), new TEvBlobStorage::TEvAssimilate(SkipBlocksUpTo,
-            SkipBarriersUpTo, SkipBlobsUpTo));
+            SkipBarriersUpTo, SkipBlobsUpTo, false, false));
     }
 
     void TAssimilator::Handle(TEvBlobStorage::TEvAssimilateResult::TPtr ev) {

--- a/ydb/core/blobstorage/ut_blobstorage/assimilation.cpp
+++ b/ydb/core/blobstorage/ut_blobstorage/assimilation.cpp
@@ -1,161 +1,216 @@
 #include <ydb/core/blobstorage/ut_blobstorage/lib/env.h>
 
+void RunAssimilationTest(bool reverse) {
+    TEnvironmentSetup env{{
+        .NodeCount = 8,
+        .Erasure = TBlobStorageGroupType::ErasureNone,
+    }};
+    auto& runtime = env.Runtime;
+    runtime->SetLogPriority(NKikimrServices::BS_PROXY_ASSIMILATE, NLog::PRI_DEBUG);
+
+    env.CreateBoxAndPool(1, 1);
+    env.Sim(TDuration::Seconds(30));
+    auto groups = env.GetGroups();
+    UNIT_ASSERT_VALUES_EQUAL(groups.size(), 1);
+    const TIntrusivePtr<TBlobStorageGroupInfo> info = env.GetGroupInfo(groups.front());
+
+    auto edge = runtime->AllocateEdgeActor(1, __FILE__, __LINE__);
+
+    THashMap<ui64, ui32> blocks;
+
+    using TBarrier = std::tuple<ui32, ui32, ui32, ui32>;
+    THashMap<std::pair<ui64, ui8>, std::pair<TBarrier, TBarrier>> barriers;
+
+    THashSet<TLogoBlobID> blobs;
+
+    size_t numBlocks = 1000 + RandomNumber(100'000u);
+    size_t numBarriers = 1000 + RandomNumber(100'000u);
+    size_t numBlobs = 1000 + RandomNumber(100'000u);
+
+    runtime->WrapInActorContext(edge, [&] {
+        for (size_t i = 0; i < numBlocks; ++i) {
+            const ui64 tabletId = 1 + i;
+            const ui32 generation = 1;
+            SendToBSProxy(edge, info->GroupID, new TEvBlobStorage::TEvBlock(tabletId, generation, TInstant::Max()));
+            blocks.emplace(tabletId, generation);
+        }
+
+        for (size_t i = 0; i < numBlobs; ++i) {
+            const ui64 tabletId = 1 + RandomNumber(10u);
+            TString data = TStringBuilder() << i;
+            TLogoBlobID id(tabletId, 2, 2, 0, data.size(), i);
+            SendToBSProxy(edge, info->GroupID, new TEvBlobStorage::TEvPut(id, data, TInstant::Max()));
+            blobs.emplace(id);
+        }
+
+        for (size_t i = 0; i < numBarriers; ++i) {
+            const ui64 tabletId = 11 + RandomNumber(100u);
+            const ui8 channel = 1;
+            const ui32 recordGen = 2;
+            const ui32 recordGenCounter = i;
+            const ui32 collectGen = 1 + i;
+            const ui32 collectStep = 1 + i;
+            const bool hard = RandomNumber(2u);
+            SendToBSProxy(edge, info->GroupID, new TEvBlobStorage::TEvCollectGarbage(tabletId, recordGen,
+                recordGenCounter, channel, true, collectGen, collectStep, nullptr, nullptr, TInstant::Max(),
+                false, hard));
+
+            auto& x = barriers[std::make_pair(tabletId, channel)];
+            (hard ? x.first : x.second) = {recordGen, recordGenCounter, collectGen, collectStep};
+        }
+    });
+
+    while (numBlocks || numBarriers || numBlobs) {
+        //Cerr << numBlocks << "/" << numBarriers << "/" << numBlobs << Endl;
+        auto ev = runtime->WaitForEdgeActorEvent({edge});
+        if (auto *p = ev->CastAsLocal<TEvBlobStorage::TEvBlockResult>()) {
+            UNIT_ASSERT_VALUES_EQUAL(p->Status, NKikimrProto::OK);
+            UNIT_ASSERT(numBlocks);
+            --numBlocks;
+        } else if (auto *p = ev->CastAsLocal<TEvBlobStorage::TEvCollectGarbageResult>()) {
+            UNIT_ASSERT_VALUES_EQUAL(p->Status, NKikimrProto::OK);
+            UNIT_ASSERT(numBarriers);
+            --numBarriers;
+        } else if (auto *p = ev->CastAsLocal<TEvBlobStorage::TEvPutResult>()) {
+            UNIT_ASSERT_VALUES_EQUAL(p->Status, NKikimrProto::OK);
+            UNIT_ASSERT(numBlobs);
+            --numBlobs;
+        } else {
+            UNIT_ASSERT(false);
+        }
+    }
+
+    THashMap<ui64, ui32> aBlocks;
+    THashMap<std::pair<ui64, ui8>, std::pair<TBarrier, TBarrier>> aBarriers;
+    THashSet<TLogoBlobID> aBlobs;
+
+    for (ui32 i = 0; i < info->GetTotalVDisksNum(); ++i) {
+        std::optional<ui64> lastBlock;
+        std::optional<std::pair<ui64, ui8>> lastBarrier;
+        std::optional<TLogoBlobID> lastBlob;
+
+        for (;;) {
+            const TActorId vdiskId = info->GetActorId(i);
+            const TActorId client = runtime->AllocateEdgeActor(vdiskId.NodeId(), __FILE__, __LINE__);
+            auto ev = std::make_unique<TEvBlobStorage::TEvVAssimilate>(info->GetVDiskId(i), lastBlock, lastBarrier,
+                lastBlob, true, reverse);
+            runtime->Send(new IEventHandle(vdiskId, client, ev.release()), vdiskId.NodeId());
+            auto res = env.WaitForEdgeActorEvent<TEvBlobStorage::TEvVAssimilateResult>(client);
+            const auto& record = res->Get()->Record;
+            UNIT_ASSERT_VALUES_EQUAL(record.GetStatus(), NKikimrProto::OK);
+            if (record.BlocksSize() + record.BarriersSize() + record.BlobsSize() == 0) {
+                break;
+            }
+            for (auto& item : record.GetBlocks()) {
+                UNIT_ASSERT(!lastBlock || (reverse ? item.GetTabletId() < *lastBlock : *lastBlock < item.GetTabletId()));
+                lastBlock.emplace(item.GetTabletId());
+                const auto [it, inserted] = aBlocks.emplace(item.GetTabletId(), item.GetBlockedGeneration());
+                UNIT_ASSERT_VALUES_EQUAL(it->second, item.GetBlockedGeneration());
+            }
+            for (auto& item : record.GetBarriers()) {
+                std::pair<ui64, ui8> key(item.GetTabletId(), item.GetChannel());
+                UNIT_ASSERT(!lastBarrier || (reverse ? key < *lastBarrier : *lastBarrier < key));
+                lastBarrier.emplace(key);
+                auto& b = aBarriers[key];
+                auto parse = [](const auto& what) -> TBarrier {
+                    return {what.GetRecordGeneration(), what.GetPerGenerationCounter(), what.GetCollectGeneration(),
+                        what.GetCollectStep()};
+                };
+                if (item.HasHard()) {
+                    b.first = parse(item.GetHard());
+                }
+                if (item.HasSoft()) {
+                    b.second = parse(item.GetSoft());
+                }
+            }
+
+            ui64 raw[3] = {0, 0, 0};
+            for (auto& item : record.GetBlobs()) {
+#define UNWRAP(X, INDEX) \
+                if (item.HasRaw##X()) { \
+                    raw[INDEX] = item.GetRaw##X(); \
+                } else if (item.HasDiff##X()) { \
+                    if (reverse) { \
+                        raw[INDEX] -= item.GetDiff##X(); \
+                    } else { \
+                        raw[INDEX] += item.GetDiff##X(); \
+                    } \
+                }
+                UNWRAP(X1, 0)
+                UNWRAP(X2, 1)
+                UNWRAP(X3, 2)
+#undef UNWRAP
+
+                UNIT_ASSERT(!lastBlob || (reverse ? TLogoBlobID(raw) < *lastBlob : *lastBlob < TLogoBlobID(raw)));
+                lastBlob.emplace(raw);
+
+                TIngress ingress(item.GetIngress());
+                if (const auto& p = ingress.LocalParts(info->Type); !p.Empty()) {
+                    aBlobs.emplace(*lastBlob);
+                }
+            }
+        }
+    }
+
+    UNIT_ASSERT_EQUAL(blocks, aBlocks);
+    UNIT_ASSERT_EQUAL(barriers, aBarriers);
+    UNIT_ASSERT_EQUAL(blobs, aBlobs);
+
+    std::optional<ui64> skipBlocksUpTo;
+    std::optional<std::tuple<ui64, ui8>> skipBarriersUpTo;
+    std::optional<TLogoBlobID> skipBlobsUpTo;
+
+    auto updateKey = [&](auto& skipUpTo, const auto& key) {
+        UNIT_ASSERT(!skipUpTo || (reverse ? key < *skipUpTo : *skipUpTo < key));
+        skipUpTo.emplace(key);
+    };
+
+    for (;;) {
+        runtime->WrapInActorContext(edge, [&] {
+            SendToBSProxy(edge, info->GroupID, new TEvBlobStorage::TEvAssimilate(skipBlocksUpTo, skipBarriersUpTo,
+                skipBlobsUpTo, true, reverse));
+        });
+        auto res = env.WaitForEdgeActorEvent<TEvBlobStorage::TEvAssimilateResult>(edge, false);
+        auto& m = *res->Get();
+        UNIT_ASSERT_VALUES_EQUAL(m.Status, NKikimrProto::OK);
+        if (m.Blocks.empty() && m.Barriers.empty() && m.Blobs.empty()) {
+            break;
+        }
+        for (const auto& item : m.Blocks) {
+            const auto it = aBlocks.find(item.TabletId);
+            UNIT_ASSERT(it != aBlocks.end());
+            UNIT_ASSERT(it->second == item.BlockedGeneration);
+            aBlocks.erase(it);
+            updateKey(skipBlocksUpTo, item.TabletId);
+        }
+        for (const auto& item : m.Barriers) {
+            const auto it = aBarriers.find(std::make_pair(item.TabletId, item.Channel));
+            UNIT_ASSERT(it != aBarriers.end());
+            UNIT_ASSERT(it->second == std::make_pair(
+                std::make_tuple(item.Hard.RecordGeneration, item.Hard.PerGenerationCounter, item.Hard.CollectGeneration, item.Hard.CollectStep),
+                std::make_tuple(item.Soft.RecordGeneration, item.Soft.PerGenerationCounter, item.Soft.CollectGeneration, item.Soft.CollectStep)
+            ));
+            aBarriers.erase(it);
+            updateKey(skipBarriersUpTo, std::make_tuple(item.TabletId, item.Channel));
+        }
+        for (const auto& item : m.Blobs) {
+            const auto it = aBlobs.find(item.Id);
+            UNIT_ASSERT(it != aBlobs.end());
+            aBlobs.erase(it);
+            updateKey(skipBlobsUpTo, item.Id);
+        }
+    }
+
+    UNIT_ASSERT(aBlocks.empty());
+    UNIT_ASSERT(aBarriers.empty());
+    UNIT_ASSERT(aBlobs.empty());
+}
+
 Y_UNIT_TEST_SUITE(VDiskAssimilation) {
     Y_UNIT_TEST(Test) {
-        TEnvironmentSetup env{{
-            .NodeCount = 8,
-            .Erasure = TBlobStorageGroupType::ErasureNone,
-        }};
-        auto& runtime = env.Runtime;
-
-        env.CreateBoxAndPool(1, 1);
-        env.Sim(TDuration::Seconds(30));
-        auto groups = env.GetGroups();
-        UNIT_ASSERT_VALUES_EQUAL(groups.size(), 1);
-        const TIntrusivePtr<TBlobStorageGroupInfo> info = env.GetGroupInfo(groups.front());
-
-        auto edge = runtime->AllocateEdgeActor(1, __FILE__, __LINE__);
-
-        THashMap<ui64, ui32> blocks;
-
-        using TBarrier = std::tuple<ui32, ui32, ui32, ui32>;
-        THashMap<std::pair<ui64, ui8>, std::pair<TBarrier, TBarrier>> barriers;
-
-        THashSet<TLogoBlobID> blobs;
-
-        size_t numBlocks = 1000 + RandomNumber(100'000u);
-        size_t numBarriers = 1000 + RandomNumber(100'000u);
-        size_t numBlobs = 1000 + RandomNumber(100'000u);
-
-        runtime->WrapInActorContext(edge, [&] {
-            for (size_t i = 0; i < numBlocks; ++i) {
-                const ui64 tabletId = 1 + i;
-                const ui32 generation = 1;
-                SendToBSProxy(edge, info->GroupID, new TEvBlobStorage::TEvBlock(tabletId, generation, TInstant::Max()));
-                blocks.emplace(tabletId, generation);
-            }
-
-            for (size_t i = 0; i < numBlobs; ++i) {
-                const ui64 tabletId = 1 + RandomNumber(10u);
-                TString data = TStringBuilder() << i;
-                TLogoBlobID id(tabletId, 2, 2, 0, data.size(), i);
-                SendToBSProxy(edge, info->GroupID, new TEvBlobStorage::TEvPut(id, data, TInstant::Max()));
-                blobs.emplace(id);
-            }
-
-            for (size_t i = 0; i < numBarriers; ++i) {
-                const ui64 tabletId = 11 + RandomNumber(100u);
-                const ui8 channel = 1;
-                const ui32 recordGen = 2;
-                const ui32 recordGenCounter = i;
-                const ui32 collectGen = 1 + i;
-                const ui32 collectStep = 1 + i;
-                const bool hard = RandomNumber(2u);
-                SendToBSProxy(edge, info->GroupID, new TEvBlobStorage::TEvCollectGarbage(tabletId, recordGen,
-                    recordGenCounter, channel, true, collectGen, collectStep, nullptr, nullptr, TInstant::Max(),
-                    false, hard));
-
-                auto& x = barriers[std::make_pair(tabletId, channel)];
-                (hard ? x.first : x.second) = {recordGen, recordGenCounter, collectGen, collectStep};
-            }
-        });
-
-        while (numBlocks || numBarriers || numBlobs) {
-            Cerr << numBlocks << "/" << numBarriers << "/" << numBlobs << Endl;
-            auto ev = runtime->WaitForEdgeActorEvent({edge});
-            if (auto *p = ev->CastAsLocal<TEvBlobStorage::TEvBlockResult>()) {
-                UNIT_ASSERT_VALUES_EQUAL(p->Status, NKikimrProto::OK);
-                UNIT_ASSERT(numBlocks);
-                --numBlocks;
-            } else if (auto *p = ev->CastAsLocal<TEvBlobStorage::TEvCollectGarbageResult>()) {
-                UNIT_ASSERT_VALUES_EQUAL(p->Status, NKikimrProto::OK);
-                UNIT_ASSERT(numBarriers);
-                --numBarriers;
-            } else if (auto *p = ev->CastAsLocal<TEvBlobStorage::TEvPutResult>()) {
-                UNIT_ASSERT_VALUES_EQUAL(p->Status, NKikimrProto::OK);
-                UNIT_ASSERT(numBlobs);
-                --numBlobs;
-            } else {
-                UNIT_ASSERT(false);
-            }
-        }
-
-        THashMap<ui64, ui32> aBlocks;
-        THashMap<std::pair<ui64, ui8>, std::pair<TBarrier, TBarrier>> aBarriers;
-        THashSet<TLogoBlobID> aBlobs;
-
-        for (ui32 i = 0; i < info->GetTotalVDisksNum(); ++i) {
-            std::optional<ui64> lastBlock;
-            std::optional<std::pair<ui64, ui8>> lastBarrier;
-            std::optional<TLogoBlobID> lastBlob;
-
-            for (;;) {
-                const TActorId vdiskId = info->GetActorId(i);
-                const TActorId client = runtime->AllocateEdgeActor(vdiskId.NodeId(), __FILE__, __LINE__);
-                auto ev = std::make_unique<TEvBlobStorage::TEvVAssimilate>(info->GetVDiskId(i), lastBlock, lastBarrier,
-                    lastBlob);
-                ev->Record.SetIgnoreDecommitState(true);
-                runtime->Send(new IEventHandle(vdiskId, client, ev.release()), vdiskId.NodeId());
-                auto res = env.WaitForEdgeActorEvent<TEvBlobStorage::TEvVAssimilateResult>(client);
-                const auto& record = res->Get()->Record;
-                UNIT_ASSERT_VALUES_EQUAL(record.GetStatus(), NKikimrProto::OK);
-                if (record.BlocksSize() + record.BarriersSize() + record.BlobsSize() == 0) {
-                    break;
-                }
-                for (auto& item : record.GetBlocks()) {
-                    UNIT_ASSERT(!lastBlock || *lastBlock < item.GetTabletId());
-                    lastBlock.emplace(item.GetTabletId());
-                    const auto [it, inserted] = aBlocks.emplace(item.GetTabletId(), item.GetBlockedGeneration());
-                    UNIT_ASSERT_VALUES_EQUAL(it->second, item.GetBlockedGeneration());
-                }
-                for (auto& item : record.GetBarriers()) {
-                    std::pair<ui64, ui8> key(item.GetTabletId(), item.GetChannel());
-                    UNIT_ASSERT(!lastBarrier || *lastBarrier < key);
-                    lastBarrier.emplace(key);
-                    auto& b = aBarriers[key];
-                    auto parse = [](const auto& what) -> TBarrier {
-                        return {what.GetRecordGeneration(), what.GetPerGenerationCounter(), what.GetCollectGeneration(),
-                            what.GetCollectStep()};
-                    };
-                    if (item.HasHard()) {
-                        b.first = parse(item.GetHard());
-                    }
-                    if (item.HasSoft()) {
-                        b.second = parse(item.GetSoft());
-                    }
-                }
-
-                ui64 raw[3] = {0, 0, 0};
-                for (auto& item : record.GetBlobs()) {
-                    if (item.HasRawX1()) {
-                        raw[0] = item.GetRawX1();
-                    } else if (item.HasDiffX1()) {
-                        raw[0] += item.GetDiffX1();
-                    }
-                    if (item.HasRawX2()) {
-                        raw[1] = item.GetRawX2();
-                    } else if (item.HasDiffX2()) {
-                        raw[1] += item.GetDiffX2();
-                    }
-                    if (item.HasRawX3()) {
-                        raw[2] = item.GetRawX3();
-                    } else if (item.HasDiffX3()) {
-                        raw[2] += item.GetDiffX3();
-                    }
-
-                    UNIT_ASSERT(!lastBlob || *lastBlob < TLogoBlobID(raw));
-                    lastBlob.emplace(raw);
-
-                    TIngress ingress(item.GetIngress());
-                    if (const auto& p = ingress.LocalParts(info->Type); !p.Empty()) {
-                        aBlobs.emplace(*lastBlob);
-                    }
-                }
-            }
-        }
-
-        UNIT_ASSERT_EQUAL(blocks, aBlocks);
-        UNIT_ASSERT_EQUAL(barriers, aBarriers);
-        UNIT_ASSERT_EQUAL(blobs, aBlobs);
+        RunAssimilationTest(false);
+    }
+    Y_UNIT_TEST(TestReverse) {
+        RunAssimilationTest(true);
     }
 }

--- a/ydb/core/blobstorage/vdisk/common/vdisk_events.h
+++ b/ydb/core/blobstorage/vdisk/common/vdisk_events.h
@@ -2725,7 +2725,8 @@ namespace NKikimr {
         TEvVAssimilate() = default;
 
         TEvVAssimilate(const TVDiskID& vdiskId, std::optional<ui64> skipBlocksUpTo,
-                std::optional<std::tuple<ui64, ui8>> skipBarriersUpTo, std::optional<TLogoBlobID> skipBlobsUpTo) {
+                std::optional<std::tuple<ui64, ui8>> skipBarriersUpTo, std::optional<TLogoBlobID> skipBlobsUpTo,
+                bool ignoreDecommitState, bool reverse) {
             VDiskIDFromVDiskID(vdiskId, Record.MutableVDiskID());
             if (skipBlocksUpTo) {
                 Record.SetSkipBlocksUpTo(*skipBlocksUpTo);
@@ -2737,6 +2738,12 @@ namespace NKikimr {
             }
             if (skipBlobsUpTo) {
                 LogoBlobIDFromLogoBlobID(*skipBlobsUpTo, Record.MutableSkipBlobsUpTo());
+            }
+            if (ignoreDecommitState) {
+                Record.SetIgnoreDecommitState(ignoreDecommitState);
+            }
+            if (reverse) {
+                Record.SetReverse(reverse);
             }
         }
     };

--- a/ydb/core/blobstorage/vdisk/hulldb/base/hullbase_block.h
+++ b/ydb/core/blobstorage/vdisk/hulldb/base/hullbase_block.h
@@ -37,6 +37,10 @@ namespace NKikimr {
             return TKeyBlock();
         }
 
+        static TKeyBlock Inf() {
+            return TKeyBlock(Max<ui64>());
+        }
+
         bool IsSameAs(const TKeyBlock& other) const {
             return TabletId == other.TabletId;
         }

--- a/ydb/core/blobstorage/vdisk/hulldb/base/hullbase_logoblob.h
+++ b/ydb/core/blobstorage/vdisk/hulldb/base/hullbase_logoblob.h
@@ -44,6 +44,12 @@ namespace NKikimr {
             return TKeyLogoBlob();
         }
 
+        static TKeyLogoBlob Inf() {
+            TKeyLogoBlob res;
+            std::ranges::fill(res.Raw, Max<ui64>());
+            return res;
+        }
+
         bool IsSameAs(const TKeyLogoBlob& other) const {
             TLogoBlobID x(LogoBlobID());
             TLogoBlobID y(other.LogoBlobID());

--- a/ydb/core/blobstorage/vdisk/hulldb/generic/hullds_idxsnap_it.h
+++ b/ydb/core/blobstorage/vdisk/hulldb/generic/hullds_idxsnap_it.h
@@ -70,17 +70,6 @@ namespace NKikimr {
         THeapIterator<TKey, TMemRec, IsForward> HeapIt;
         std::optional<TKey> CurrentKey;
 
-        void MergeAndAdvance() {
-            Merger.Clear();
-            if (HeapIt.Valid()) {
-                CurrentKey.emplace(HeapIt.GetCurKey());
-                HeapIt.PutToMergerAndAdvance(&Merger);
-                Merger.Finish();
-            } else {
-                CurrentKey.reset();
-            }
-        }
-
     public:
         TIndexBaseIterator(const THullCtxPtr &hullCtx, const TLevelIndexSnapshot<TKey, TMemRec> *levelSnap)
             : Merger(hullCtx->VCtx->Top->GType)
@@ -108,6 +97,17 @@ namespace NKikimr {
 
         const TMemRec &GetMemRec() const {
             return Merger.GetMemRec();
+        }
+
+        void MergeAndAdvance() {
+            Merger.Clear();
+            if (HeapIt.Valid()) {
+                CurrentKey.emplace(HeapIt.GetCurKey());
+                HeapIt.PutToMergerAndAdvance(&Merger);
+                Merger.Finish();
+            } else {
+                CurrentKey.reset();
+            }
         }
     };
     ////////////////////////////////////////////////////////////////////////////

--- a/ydb/core/protos/blobstorage.proto
+++ b/ydb/core/protos/blobstorage.proto
@@ -540,6 +540,7 @@ message TEvVAssimilate {
     optional NKikimrProto.TLogoBlobID SkipBlobsUpTo = 12; // the same behaviour
 
     optional bool IgnoreDecommitState = 13 [default = false]; // do not check if VDisk belongs to a being-decommitted group
+    optional bool Reverse = 14 [default = false]; // generate records in reverse order
 }
 
 message TEvVAssimilateResult {


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

Support bidirectional assimilation

### Changelog category <!-- remove all except one -->

* Not for changelog (changelog entry is not required)

### Description for reviewers <!-- (optional) description for those who read this PR -->

This patch allows running assimilation in reverse order for online VDisk with read-write support to make assimilation predictable. Intended to use for syncing piles in Bridge mode.
