### PR TITLE
Stream Join fix

### DIFF
--- a/ydb/core/kqp/runtime/kqp_stream_lookup_actor.cpp
+++ b/ydb/core/kqp/runtime/kqp_stream_lookup_actor.cpp
@@ -279,10 +279,11 @@ private:
     i64 GetAsyncInputData(NKikimr::NMiniKQL::TUnboxedValueBatch& batch, TMaybe<TInstant>&, bool& finished, i64 freeSpace) final {
         YQL_ENSURE(!batch.IsWide(), "Wide stream is not supported");
 
-        //if (/* resolve in progress */) {
-        //    batch.clear();
-        //    return 0;
-        //}
+        if (ResolveShardsInProgress) {
+            finished = false;
+            batch.clear();
+            return 0;
+        }
 
         auto replyResultStats = StreamLookupWorker->ReplyResult(batch, freeSpace);
         ReadRowsCount += replyResultStats.ReadRowsCount;
@@ -349,7 +350,7 @@ private:
     }
 
     void Handle(TEvTxProxySchemeCache::TEvResolveKeySetResult::TPtr& ev) {
-        ResoleShardsInProgress = false;
+        ResolveShardsInProgress = false;
         CA_LOG_D("TEvResolveKeySetResult was received for table: " << StreamLookupWorker->GetTablePath());
         if (ev->Get()->Request->ErrorCount > 0) {
             TString errorMsg = TStringBuilder() << "Failed to get partitioning for table: "
@@ -366,6 +367,8 @@ private:
         Partitioning = resultSet[0].KeyDescription->Partitioning;
 
         ProcessInputRows();
+
+        Send(ComputeActorId, new TEvNewAsyncInputDataArrived(InputIndex));
     }
 
     void Handle(TEvDataShard::TEvReadResult::TPtr& ev) {
@@ -534,7 +537,7 @@ private:
         if (!Partitioning) {
             LookupActorStateSpan.EndError("timeout exceeded");
             CA_LOG_D("Retry attempt to resolve shards for table: " << StreamLookupWorker->GetTablePath());
-            ResoleShardsInProgress = false;
+            ResolveShardsInProgress = false;
             ResolveTableShards();
         }
     }
@@ -675,7 +678,7 @@ private:
     }
 
     void ResolveTableShards() {
-        if (ResoleShardsInProgress) {
+        if (ResolveShardsInProgress) {
             return;
         }
 
@@ -685,7 +688,7 @@ private:
         }
 
         CA_LOG_D("Resolve shards for table: " << StreamLookupWorker->GetTablePath());
-        ResoleShardsInProgress = true;
+        ResolveShardsInProgress = true;
 
         Partitioning.reset();
 
@@ -761,7 +764,7 @@ private:
     ui64 ReadId = 0;
     size_t TotalRetryAttempts = 0;
     size_t TotalResolveShardsAttempts = 0;
-    bool ResoleShardsInProgress = false;
+    bool ResolveShardsInProgress = false;
 
     // stats
     ui64 ReadRowsCount = 0;

--- a/ydb/core/kqp/runtime/kqp_stream_lookup_actor.cpp
+++ b/ydb/core/kqp/runtime/kqp_stream_lookup_actor.cpp
@@ -279,6 +279,11 @@ private:
     i64 GetAsyncInputData(NKikimr::NMiniKQL::TUnboxedValueBatch& batch, TMaybe<TInstant>&, bool& finished, i64 freeSpace) final {
         YQL_ENSURE(!batch.IsWide(), "Wide stream is not supported");
 
+        //if (/* resolve in progress */) {
+        //    batch.clear();
+        //    return 0;
+        //}
+
         auto replyResultStats = StreamLookupWorker->ReplyResult(batch, freeSpace);
         ReadRowsCount += replyResultStats.ReadRowsCount;
         ReadBytesCount += replyResultStats.ReadBytesCount;

--- a/ydb/core/kqp/runtime/kqp_stream_lookup_actor.cpp
+++ b/ydb/core/kqp/runtime/kqp_stream_lookup_actor.cpp
@@ -536,7 +536,7 @@ private:
         CA_LOG_D("TEvSchemeCacheRequestTimeout was received, shards for table " << StreamLookupWorker->GetTablePath()
             << " was resolved: " << !!Partitioning);
 
-        if (ResolveShardsInProgress) {
+        if (!Partitioning) {
             LookupActorStateSpan.EndError("timeout exceeded");
             CA_LOG_D("Retry attempt to resolve shards for table: " << StreamLookupWorker->GetTablePath());
             ResolveShardsInProgress = false;

--- a/ydb/core/kqp/runtime/kqp_stream_lookup_actor.cpp
+++ b/ydb/core/kqp/runtime/kqp_stream_lookup_actor.cpp
@@ -281,7 +281,6 @@ private:
 
         if (ResolveShardsInProgress) {
             finished = false;
-            batch.clear();
             return 0;
         }
 

--- a/ydb/core/kqp/runtime/kqp_stream_lookup_worker.cpp
+++ b/ydb/core/kqp/runtime/kqp_stream_lookup_worker.cpp
@@ -663,7 +663,7 @@ public:
                 std::vector <std::pair<ui64, TOwnedTableRange>> partitions;
                 if (joinKey.size() < Settings.KeyColumns.size()) {
                     // build prefix range [[key_prefix, NULL, ..., NULL], [key_prefix, +inf, ..., +inf])
-                    std::vector <TCell> fromCells(Settings.KeyColumns.size());
+                    std::vector <TCell> fromCells(Settings.KeyColumns.size() - joinKey.size());
                     fromCells.insert(fromCells.begin(), joinKey.begin(), joinKey.end());
                     bool fromInclusive = true;
                     bool toInclusive = false;


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

...

### Changelog category <!-- remove all except one -->

* Not for changelog (changelog entry is not required)

### Description for reviewers <!-- (optional) description for those who read this PR -->

1) PendingLeftRowsByKey could be lost in following case:
 - After failed first read ResetRowsProcessing https://github.com/ydb-platform/ydb/blob/b4ad90c8def7e62fd4f2e18e8bc41ce802b3e75a/ydb/core/kqp/runtime/kqp_stream_lookup_worker.cpp#L814 was called and then new shards resolving was started. (Now PendingReads for left key is empty)
 - ReplyResult was called from GetAsyncInputData. This leads to erasing left key from PendingLeftRowsByKey https://github.com/ydb-platform/ydb/blob/b4ad90c8def7e62fd4f2e18e8bc41ce802b3e75a/ydb/core/kqp/runtime/kqp_stream_lookup_worker.cpp#L838
 - Thus BuildRequests can't find PendingLeftRowsByKey https://github.com/ydb-platform/ydb/blob/b4ad90c8def7e62fd4f2e18e8bc41ce802b3e75a/ydb/core/kqp/runtime/kqp_stream_lookup_worker.cpp#L711 for UnprocessedKeys https://github.com/ydb-platform/ydb/blob/b4ad90c8def7e62fd4f2e18e8bc41ce802b3e75a/ydb/core/kqp/runtime/kqp_stream_lookup_worker.cpp#L614

Solution: don't allow returing result before shards resolving was finished and new reads were generated.

2) Possible freeze
 - PendingReads for failed reads with filled last processed key were never cleared  https://github.com/ydb-platform/ydb/blob/b4ad90c8def7e62fd4f2e18e8bc41ce802b3e75a/ydb/core/kqp/runtime/kqp_stream_lookup_worker.cpp#L805 thus reads can't become completed https://github.com/ydb-platform/ydb/blob/b4ad90c8def7e62fd4f2e18e8bc41ce802b3e75a/ydb/core/kqp/runtime/kqp_stream_lookup_worker.cpp#L766
 