### PR TITLE
Merge critical viewer fixes stable 25-1-2

### DIFF
--- a/ydb/core/tablet/node_whiteboard.cpp
+++ b/ydb/core/tablet/node_whiteboard.cpp
@@ -772,16 +772,12 @@ protected:
         }
     }
 
-    void UpdateSystemState(const TActorContext &ctx) {
+    void UpdateSystemState() {
         NKikimrWhiteboard::EFlag eFlag = NKikimrWhiteboard::EFlag::Green;
-        NKikimrWhiteboard::EFlag pDiskFlag = NKikimrWhiteboard::EFlag::Green;
-        ui32 yellowFlags = 0;
+        ui32 badDisks = 0;
         double maxDiskUsage = 0;
         for (const auto& pr : PDiskStateInfo) {
-            if (!pr.second.HasState()) {
-                pDiskFlag = std::max(pDiskFlag, NKikimrWhiteboard::EFlag::Yellow);
-                ++yellowFlags;
-            } else {
+            if (pr.second.HasState()) {
                 switch (pr.second.GetState()) {
                 case NKikimrBlobStorage::TPDiskState::InitialFormatReadError:
                 case NKikimrBlobStorage::TPDiskState::InitialSysLogReadError:
@@ -789,11 +785,9 @@ protected:
                 case NKikimrBlobStorage::TPDiskState::InitialCommonLogReadError:
                 case NKikimrBlobStorage::TPDiskState::InitialCommonLogParseError:
                 case NKikimrBlobStorage::TPDiskState::CommonLoggerInitError:
-                    pDiskFlag = std::max(pDiskFlag, NKikimrWhiteboard::EFlag::Red);
-                    break;
                 case NKikimrBlobStorage::TPDiskState::OpenFileError:
-                    pDiskFlag = std::max(pDiskFlag, NKikimrWhiteboard::EFlag::Yellow);
-                    ++yellowFlags;
+                    eFlag = std::max(eFlag, NKikimrWhiteboard::EFlag::Yellow);
+                    ++badDisks;
                     break;
                 default:
                     break;
@@ -801,13 +795,10 @@ protected:
             }
             if (pr.second.HasAvailableSize() && pr.second.GetTotalSize() != 0) {
                 double avail = (double)pr.second.GetAvailableSize() / pr.second.GetTotalSize();
-                if (avail <= 0.06) {
-                    pDiskFlag = std::max(pDiskFlag, NKikimrWhiteboard::EFlag::Red);
+                if (avail <= 0.04) {
+                    eFlag = std::max(eFlag, NKikimrWhiteboard::EFlag::Orange);
                 } else if (avail <= 0.08) {
-                    pDiskFlag = std::max(pDiskFlag, NKikimrWhiteboard::EFlag::Orange);
-                } else if (avail <= 0.15) {
-                    pDiskFlag = std::max(pDiskFlag, NKikimrWhiteboard::EFlag::Yellow);
-                    ++yellowFlags;
+                    eFlag = std::max(eFlag, NKikimrWhiteboard::EFlag::Yellow);
                 }
                 maxDiskUsage = std::max(maxDiskUsage, 1.0 - avail);
             }
@@ -815,29 +806,25 @@ protected:
         if (PDiskStateInfo.size() > 0) {
             SystemStateInfo.SetMaxDiskUsage(maxDiskUsage);
         }
-        if (pDiskFlag == NKikimrWhiteboard::EFlag::Yellow) {
-            switch (yellowFlags) {
-            case 1:
-                break;
-            case 2:
-                pDiskFlag = NKikimrWhiteboard::EFlag::Orange;
-                break;
-            case 3:
-                pDiskFlag = NKikimrWhiteboard::EFlag::Red;
-                break;
-            }
+        if (eFlag == NKikimrWhiteboard::EFlag::Yellow && badDisks > 1) {
+            eFlag = NKikimrWhiteboard::EFlag::Orange;
         }
-        eFlag = std::max(eFlag, pDiskFlag);
         for (const auto& pr : VDiskStateInfo) {
             eFlag = std::max(eFlag, pr.second.GetDiskSpace());
-            eFlag = std::max(eFlag, pr.second.GetSatisfactionRank().GetFreshRank().GetFlag());
-            eFlag = std::max(eFlag, pr.second.GetSatisfactionRank().GetLevelRank().GetFlag());
-        }
-        if (SystemStateInfo.HasMessageBusState()) {
-            eFlag = std::max(eFlag, SystemStateInfo.GetMessageBusState());
+            if (pr.second.GetDiskSpace() >= NKikimrWhiteboard::EFlag::Red) {
+                eFlag = std::max(eFlag, NKikimrWhiteboard::EFlag::Orange);
+            } else if (pr.second.GetDiskSpace() > NKikimrWhiteboard::EFlag::Green) {
+                eFlag = std::max(eFlag, NKikimrWhiteboard::EFlag::Yellow);
+            }
+            if (pr.second.GetSatisfactionRank().GetFreshRank().GetFlag() > NKikimrWhiteboard::EFlag::Green) {
+                eFlag = std::max(eFlag, NKikimrWhiteboard::EFlag::Yellow);
+            }
+            if (pr.second.GetSatisfactionRank().GetLevelRank().GetFlag() > NKikimrWhiteboard::EFlag::Green) {
+                eFlag = std::max(eFlag, NKikimrWhiteboard::EFlag::Yellow);
+            }
         }
         if (SystemStateInfo.HasGRpcState()) {
-            eFlag = std::max(eFlag, SystemStateInfo.GetGRpcState());
+            eFlag = std::max(eFlag, std::max(SystemStateInfo.GetGRpcState(), NKikimrWhiteboard::EFlag::Orange));
         }
         for (const auto& stats : SystemStateInfo.GetPoolStats()) {
             double usage = stats.GetUsage();
@@ -851,11 +838,18 @@ protected:
             } else  {
                 flag = NKikimrWhiteboard::EFlag::Green;
             }
-            eFlag = Max(eFlag, flag);
+            if (stats.GetName() == "User") {
+                flag = std::min(flag, NKikimrWhiteboard::EFlag::Orange);
+            } else if (stats.GetName() == "IO") {
+                flag = std::min(flag, NKikimrWhiteboard::EFlag::Yellow);
+            } else if (stats.GetName() == "Batch") {
+                flag = std::min(flag, NKikimrWhiteboard::EFlag::Green);
+            }
+            eFlag = std::max(eFlag, flag);
         }
         if (!SystemStateInfo.HasSystemState() || SystemStateInfo.GetSystemState() != eFlag) {
             SystemStateInfo.SetSystemState(eFlag);
-            SystemStateInfo.SetChangeTime(ctx.Now().MilliSeconds());
+            SystemStateInfo.SetChangeTime(TActivationContext::Now().MilliSeconds());
         }
     }
 
@@ -1163,7 +1157,7 @@ protected:
                 threadInfo->MutableStates()->emplace(state.first, state.second);
             }
         }
-        UpdateSystemState(ctx);
+        UpdateSystemState();
         ctx.Schedule(UPDATE_PERIOD, new TEvPrivate::TEvUpdateRuntimeStats());
     }
 

--- a/ydb/core/viewer/json_handlers_storage.cpp
+++ b/ydb/core/viewer/json_handlers_storage.cpp
@@ -4,7 +4,7 @@
 namespace NKikimr::NViewer {
 
 void InitStorageGroupsJsonHandler(TJsonHandlers& jsonHandlers) {
-    jsonHandlers.AddHandler("/storage/groups", new TJsonHandler<TStorageGroups>(TStorageGroups::GetSwagger()), 6);
+    jsonHandlers.AddHandler("/storage/groups", new TJsonHandler<TStorageGroups>(TStorageGroups::GetSwagger()), 7);
 }
 
 void InitStorageJsonHandlers(TJsonHandlers& jsonHandlers) {

--- a/ydb/core/viewer/json_handlers_viewer.cpp
+++ b/ydb/core/viewer/json_handlers_viewer.cpp
@@ -256,7 +256,7 @@ void InitViewerHealthCheckJsonHandler(TJsonHandlers& handlers) {
 }
 
 void InitViewerNodesJsonHandler(TJsonHandlers& handlers) {
-    handlers.AddHandler("/viewer/nodes", new TJsonHandler<TJsonNodes>(TJsonNodes::GetSwagger()), 15);
+    handlers.AddHandler("/viewer/nodes", new TJsonHandler<TJsonNodes>(TJsonNodes::GetSwagger()), 16);
 }
 
 void InitViewerACLJsonHandler(TJsonHandlers &jsonHandlers) {

--- a/ydb/core/viewer/tests/canondata/result.json
+++ b/ydb/core/viewer/tests/canondata/result.json
@@ -36,7 +36,7 @@
                         "PathId": "not-zero-number-text",
                         "SchemeShard": "not-zero-number-text"
                     },
-                    "Type": "PersQueue"
+                    "Type": "PersQueueReadBalancer"
                 },
                 {
                     "ChangeTime": "not-zero-number-text",
@@ -52,9 +52,307 @@
                         "PathId": "not-zero-number-text",
                         "SchemeShard": "not-zero-number-text"
                     },
-                    "Type": "PersQueueReadBalancer"
+                    "Type": "PersQueue"
                 }
             ]
+        }
+    },
+    "test.test_scheme_directory": {
+        "1-get": {
+            "children": [
+                {
+                    "created_at": {
+                        "plan_step": "not-zero-number-text",
+                        "tx_id": "not-zero-number-text"
+                    },
+                    "name": ".metadata",
+                    "owner": "metadata@system",
+                    "type": "DIRECTORY"
+                },
+                {
+                    "created_at": {
+                        "plan_step": "not-zero-number-text",
+                        "tx_id": "not-zero-number-text"
+                    },
+                    "name": "table1",
+                    "owner": "root@builtin",
+                    "type": "TABLE"
+                },
+                {
+                    "created_at": {
+                        "plan_step": "not-zero-number-text",
+                        "tx_id": "not-zero-number-text"
+                    },
+                    "name": "topic1",
+                    "owner": "root@builtin",
+                    "type": "TOPIC"
+                },
+                {
+                    "created_at": {},
+                    "name": ".sys",
+                    "type": "DIRECTORY"
+                }
+            ],
+            "self": {
+                "created_at": {
+                    "tx_id": "not-zero-number-text"
+                },
+                "effective_permissions": [
+                    {
+                        "permission_names": [
+                            "ydb.database.connect"
+                        ],
+                        "subject": "USERS"
+                    },
+                    {
+                        "permission_names": [
+                            "ydb.generic.list"
+                        ],
+                        "subject": "METADATA-READERS"
+                    },
+                    {
+                        "permission_names": [
+                            "ydb.granular.select_row"
+                        ],
+                        "subject": "DATA-READERS"
+                    },
+                    {
+                        "permission_names": [
+                            "ydb.tables.modify"
+                        ],
+                        "subject": "DATA-WRITERS"
+                    },
+                    {
+                        "permission_names": [
+                            "ydb.granular.create_directory",
+                            "ydb.granular.write_attributes",
+                            "ydb.granular.create_table",
+                            "ydb.granular.remove_schema",
+                            "ydb.granular.create_queue",
+                            "ydb.granular.alter_schema"
+                        ],
+                        "subject": "DDL-ADMINS"
+                    },
+                    {
+                        "permission_names": [
+                            "ydb.access.grant"
+                        ],
+                        "subject": "ACCESS-ADMINS"
+                    },
+                    {
+                        "permission_names": [
+                            "ydb.generic.manage"
+                        ],
+                        "subject": "DATABASE-ADMINS"
+                    }
+                ],
+                "name": "Root/dedicated_db",
+                "owner": "user1",
+                "type": "DATABASE"
+            }
+        },
+        "2-post": {
+            "ready": true,
+            "status": "SUCCESS"
+        },
+        "3-get": {
+            "children": [
+                {
+                    "created_at": {
+                        "plan_step": "not-zero-number-text",
+                        "tx_id": "not-zero-number-text"
+                    },
+                    "name": ".metadata",
+                    "owner": "metadata@system",
+                    "type": "DIRECTORY"
+                },
+                {
+                    "created_at": {
+                        "plan_step": "not-zero-number-text",
+                        "tx_id": "not-zero-number-text"
+                    },
+                    "name": "table1",
+                    "owner": "root@builtin",
+                    "type": "TABLE"
+                },
+                {
+                    "created_at": {
+                        "plan_step": "not-zero-number-text",
+                        "tx_id": "not-zero-number-text"
+                    },
+                    "name": "test_dir",
+                    "owner": "root@builtin",
+                    "type": "DIRECTORY"
+                },
+                {
+                    "created_at": {
+                        "plan_step": "not-zero-number-text",
+                        "tx_id": "not-zero-number-text"
+                    },
+                    "name": "topic1",
+                    "owner": "root@builtin",
+                    "type": "TOPIC"
+                },
+                {
+                    "created_at": {},
+                    "name": ".sys",
+                    "type": "DIRECTORY"
+                }
+            ],
+            "self": {
+                "created_at": {
+                    "tx_id": "not-zero-number-text"
+                },
+                "effective_permissions": [
+                    {
+                        "permission_names": [
+                            "ydb.database.connect"
+                        ],
+                        "subject": "USERS"
+                    },
+                    {
+                        "permission_names": [
+                            "ydb.generic.list"
+                        ],
+                        "subject": "METADATA-READERS"
+                    },
+                    {
+                        "permission_names": [
+                            "ydb.granular.select_row"
+                        ],
+                        "subject": "DATA-READERS"
+                    },
+                    {
+                        "permission_names": [
+                            "ydb.tables.modify"
+                        ],
+                        "subject": "DATA-WRITERS"
+                    },
+                    {
+                        "permission_names": [
+                            "ydb.granular.create_directory",
+                            "ydb.granular.write_attributes",
+                            "ydb.granular.create_table",
+                            "ydb.granular.remove_schema",
+                            "ydb.granular.create_queue",
+                            "ydb.granular.alter_schema"
+                        ],
+                        "subject": "DDL-ADMINS"
+                    },
+                    {
+                        "permission_names": [
+                            "ydb.access.grant"
+                        ],
+                        "subject": "ACCESS-ADMINS"
+                    },
+                    {
+                        "permission_names": [
+                            "ydb.generic.manage"
+                        ],
+                        "subject": "DATABASE-ADMINS"
+                    }
+                ],
+                "name": "Root/dedicated_db",
+                "owner": "user1",
+                "type": "DATABASE"
+            }
+        },
+        "4-delete": {
+            "ready": true,
+            "status": "SUCCESS"
+        },
+        "5-get": {
+            "children": [
+                {
+                    "created_at": {
+                        "plan_step": "not-zero-number-text",
+                        "tx_id": "not-zero-number-text"
+                    },
+                    "name": ".metadata",
+                    "owner": "metadata@system",
+                    "type": "DIRECTORY"
+                },
+                {
+                    "created_at": {
+                        "plan_step": "not-zero-number-text",
+                        "tx_id": "not-zero-number-text"
+                    },
+                    "name": "table1",
+                    "owner": "root@builtin",
+                    "type": "TABLE"
+                },
+                {
+                    "created_at": {
+                        "plan_step": "not-zero-number-text",
+                        "tx_id": "not-zero-number-text"
+                    },
+                    "name": "topic1",
+                    "owner": "root@builtin",
+                    "type": "TOPIC"
+                },
+                {
+                    "created_at": {},
+                    "name": ".sys",
+                    "type": "DIRECTORY"
+                }
+            ],
+            "self": {
+                "created_at": {
+                    "tx_id": "not-zero-number-text"
+                },
+                "effective_permissions": [
+                    {
+                        "permission_names": [
+                            "ydb.database.connect"
+                        ],
+                        "subject": "USERS"
+                    },
+                    {
+                        "permission_names": [
+                            "ydb.generic.list"
+                        ],
+                        "subject": "METADATA-READERS"
+                    },
+                    {
+                        "permission_names": [
+                            "ydb.granular.select_row"
+                        ],
+                        "subject": "DATA-READERS"
+                    },
+                    {
+                        "permission_names": [
+                            "ydb.tables.modify"
+                        ],
+                        "subject": "DATA-WRITERS"
+                    },
+                    {
+                        "permission_names": [
+                            "ydb.granular.create_directory",
+                            "ydb.granular.write_attributes",
+                            "ydb.granular.create_table",
+                            "ydb.granular.remove_schema",
+                            "ydb.granular.create_queue",
+                            "ydb.granular.alter_schema"
+                        ],
+                        "subject": "DDL-ADMINS"
+                    },
+                    {
+                        "permission_names": [
+                            "ydb.access.grant"
+                        ],
+                        "subject": "ACCESS-ADMINS"
+                    },
+                    {
+                        "permission_names": [
+                            "ydb.generic.manage"
+                        ],
+                        "subject": "DATABASE-ADMINS"
+                    }
+                ],
+                "name": "Root/dedicated_db",
+                "owner": "user1",
+                "type": "DATABASE"
+            }
         }
     },
     "test.test_storage_groups": {
@@ -334,7 +632,7 @@
                 ]
             },
             {
-                "AllocationUnits": "30",
+                "AllocationUnits": "32",
                 "Available": "not-zero-number-text",
                 "DiskSpaceUsage": "not-zero-number",
                 "ErasureSpecies": "none",
@@ -425,7 +723,7 @@
                 ]
             },
             {
-                "AllocationUnits": "48",
+                "AllocationUnits": "52",
                 "Available": "not-zero-number-text",
                 "DiskSpaceUsage": "not-zero-number",
                 "ErasureSpecies": "none",
@@ -539,7 +837,7 @@
                     "ProducerId": "not-zero-number-text",
                     "SeqNo": 12,
                     "StorageSize": 38,
-                    "TimestampDiff": "not-zero-number",
+                    "TimestampDiff": "number",
                     "WriteTimestamp": "not-zero-number"
                 },
                 {
@@ -551,7 +849,7 @@
                     "ProducerId": "not-zero-number-text",
                     "SeqNo": 13,
                     "StorageSize": 38,
-                    "TimestampDiff": "not-zero-number",
+                    "TimestampDiff": "number",
                     "WriteTimestamp": "not-zero-number"
                 },
                 {
@@ -563,7 +861,7 @@
                     "ProducerId": "not-zero-number-text",
                     "SeqNo": 14,
                     "StorageSize": 38,
-                    "TimestampDiff": "not-zero-number",
+                    "TimestampDiff": "number",
                     "WriteTimestamp": "not-zero-number"
                 },
                 {
@@ -575,7 +873,7 @@
                     "ProducerId": "not-zero-number-text",
                     "SeqNo": 15,
                     "StorageSize": 38,
-                    "TimestampDiff": "not-zero-number",
+                    "TimestampDiff": "number",
                     "WriteTimestamp": "not-zero-number"
                 },
                 {
@@ -587,7 +885,7 @@
                     "ProducerId": "not-zero-number-text",
                     "SeqNo": 16,
                     "StorageSize": 38,
-                    "TimestampDiff": "not-zero-number",
+                    "TimestampDiff": "number",
                     "WriteTimestamp": "not-zero-number"
                 }
             ],
@@ -606,7 +904,7 @@
                     "ProducerId": "not-zero-number-text",
                     "SeqNo": 1,
                     "StorageSize": 9,
-                    "TimestampDiff": "not-zero-number",
+                    "TimestampDiff": "number",
                     "WriteTimestamp": "not-zero-number"
                 },
                 {
@@ -618,7 +916,7 @@
                     "ProducerId": "not-zero-number-text",
                     "SeqNo": 2,
                     "StorageSize": 9,
-                    "TimestampDiff": "not-zero-number",
+                    "TimestampDiff": "number",
                     "WriteTimestamp": "not-zero-number"
                 },
                 {
@@ -630,7 +928,7 @@
                     "ProducerId": "not-zero-number-text",
                     "SeqNo": 3,
                     "StorageSize": 9,
-                    "TimestampDiff": "not-zero-number",
+                    "TimestampDiff": "number",
                     "WriteTimestamp": "not-zero-number"
                 }
             ],
@@ -659,7 +957,7 @@
                     "ProducerId": "not-zero-number-text",
                     "SeqNo": 11,
                     "StorageSize": 37,
-                    "TimestampDiff": "not-zero-number",
+                    "TimestampDiff": "number",
                     "WriteTimestamp": "not-zero-number"
                 }
             ],
@@ -678,7 +976,7 @@
                     "ProducerId": "not-zero-number-text",
                     "SeqNo": 21,
                     "StorageSize": 38,
-                    "TimestampDiff": "not-zero-number",
+                    "TimestampDiff": "number",
                     "WriteTimestamp": "not-zero-number"
                 }
             ],
@@ -697,7 +995,7 @@
                     "ProducerId": "not-zero-number-text",
                     "SeqNo": 1,
                     "StorageSize": 9,
-                    "TimestampDiff": "not-zero-number",
+                    "TimestampDiff": "number",
                     "WriteTimestamp": "not-zero-number"
                 },
                 {
@@ -709,7 +1007,7 @@
                     "ProducerId": "not-zero-number-text",
                     "SeqNo": 2,
                     "StorageSize": 9,
-                    "TimestampDiff": "not-zero-number",
+                    "TimestampDiff": "number",
                     "WriteTimestamp": "not-zero-number"
                 },
                 {
@@ -721,7 +1019,7 @@
                     "ProducerId": "not-zero-number-text",
                     "SeqNo": 3,
                     "StorageSize": 9,
-                    "TimestampDiff": "not-zero-number",
+                    "TimestampDiff": "number",
                     "WriteTimestamp": "not-zero-number"
                 },
                 {
@@ -733,7 +1031,7 @@
                     "ProducerId": "not-zero-number-text",
                     "SeqNo": 4,
                     "StorageSize": 9,
-                    "TimestampDiff": "not-zero-number",
+                    "TimestampDiff": "number",
                     "WriteTimestamp": "not-zero-number"
                 },
                 {
@@ -745,7 +1043,7 @@
                     "ProducerId": "not-zero-number-text",
                     "SeqNo": 5,
                     "StorageSize": 9,
-                    "TimestampDiff": "not-zero-number",
+                    "TimestampDiff": "number",
                     "WriteTimestamp": "not-zero-number"
                 }
             ],
@@ -764,7 +1062,7 @@
                     "ProducerId": "not-zero-number-text",
                     "SeqNo": 21,
                     "StorageSize": 38,
-                    "TimestampDiff": "not-zero-number",
+                    "TimestampDiff": "number",
                     "WriteTimestamp": "not-zero-number"
                 }
             ],
@@ -857,8 +1155,7 @@
                         ],
                         "AccessType": "Allow",
                         "InheritanceType": [
-                            "Object",
-                            "Container"
+                            "Inherit"
                         ],
                         "Subject": "USERS"
                     },
@@ -869,8 +1166,7 @@
                         ],
                         "AccessType": "Allow",
                         "InheritanceType": [
-                            "Object",
-                            "Container"
+                            "Inherit"
                         ],
                         "Subject": "METADATA-READERS"
                     },
@@ -880,8 +1176,7 @@
                         ],
                         "AccessType": "Allow",
                         "InheritanceType": [
-                            "Object",
-                            "Container"
+                            "Inherit"
                         ],
                         "Subject": "DATA-READERS"
                     },
@@ -892,8 +1187,7 @@
                         ],
                         "AccessType": "Allow",
                         "InheritanceType": [
-                            "Object",
-                            "Container"
+                            "Inherit"
                         ],
                         "Subject": "DATA-WRITERS"
                     },
@@ -908,8 +1202,7 @@
                         ],
                         "AccessType": "Allow",
                         "InheritanceType": [
-                            "Object",
-                            "Container"
+                            "Inherit"
                         ],
                         "Subject": "DDL-ADMINS"
                     },
@@ -919,8 +1212,7 @@
                         ],
                         "AccessType": "Allow",
                         "InheritanceType": [
-                            "Object",
-                            "Container"
+                            "Inherit"
                         ],
                         "Subject": "ACCESS-ADMINS"
                     },
@@ -931,8 +1223,7 @@
                         ],
                         "AccessType": "Allow",
                         "InheritanceType": [
-                            "Object",
-                            "Container"
+                            "Inherit"
                         ],
                         "Subject": "DATABASE-ADMINS"
                     }
@@ -944,8 +1235,7 @@
                         ],
                         "AccessType": "Allow",
                         "InheritanceType": [
-                            "Object",
-                            "Container"
+                            "Inherit"
                         ],
                         "Subject": "USERS"
                     },
@@ -956,8 +1246,7 @@
                         ],
                         "AccessType": "Allow",
                         "InheritanceType": [
-                            "Object",
-                            "Container"
+                            "Inherit"
                         ],
                         "Subject": "METADATA-READERS"
                     },
@@ -967,8 +1256,7 @@
                         ],
                         "AccessType": "Allow",
                         "InheritanceType": [
-                            "Object",
-                            "Container"
+                            "Inherit"
                         ],
                         "Subject": "DATA-READERS"
                     },
@@ -979,8 +1267,7 @@
                         ],
                         "AccessType": "Allow",
                         "InheritanceType": [
-                            "Object",
-                            "Container"
+                            "Inherit"
                         ],
                         "Subject": "DATA-WRITERS"
                     },
@@ -995,8 +1282,7 @@
                         ],
                         "AccessType": "Allow",
                         "InheritanceType": [
-                            "Object",
-                            "Container"
+                            "Inherit"
                         ],
                         "Subject": "DDL-ADMINS"
                     },
@@ -1006,8 +1292,7 @@
                         ],
                         "AccessType": "Allow",
                         "InheritanceType": [
-                            "Object",
-                            "Container"
+                            "Inherit"
                         ],
                         "Subject": "ACCESS-ADMINS"
                     },
@@ -1018,8 +1303,7 @@
                         ],
                         "AccessType": "Allow",
                         "InheritanceType": [
-                            "Object",
-                            "Container"
+                            "Inherit"
                         ],
                         "Subject": "DATABASE-ADMINS"
                     }
@@ -1037,8 +1321,7 @@
                         ],
                         "AccessType": "Allow",
                         "InheritanceType": [
-                            "Object",
-                            "Container"
+                            "Inherit"
                         ],
                         "Subject": "USERS"
                     },
@@ -1049,8 +1332,7 @@
                         ],
                         "AccessType": "Allow",
                         "InheritanceType": [
-                            "Object",
-                            "Container"
+                            "Inherit"
                         ],
                         "Subject": "METADATA-READERS"
                     },
@@ -1060,8 +1342,7 @@
                         ],
                         "AccessType": "Allow",
                         "InheritanceType": [
-                            "Object",
-                            "Container"
+                            "Inherit"
                         ],
                         "Subject": "DATA-READERS"
                     },
@@ -1072,8 +1353,7 @@
                         ],
                         "AccessType": "Allow",
                         "InheritanceType": [
-                            "Object",
-                            "Container"
+                            "Inherit"
                         ],
                         "Subject": "DATA-WRITERS"
                     },
@@ -1088,8 +1368,7 @@
                         ],
                         "AccessType": "Allow",
                         "InheritanceType": [
-                            "Object",
-                            "Container"
+                            "Inherit"
                         ],
                         "Subject": "DDL-ADMINS"
                     },
@@ -1099,8 +1378,7 @@
                         ],
                         "AccessType": "Allow",
                         "InheritanceType": [
-                            "Object",
-                            "Container"
+                            "Inherit"
                         ],
                         "Subject": "ACCESS-ADMINS"
                     },
@@ -1111,8 +1389,7 @@
                         ],
                         "AccessType": "Allow",
                         "InheritanceType": [
-                            "Object",
-                            "Container"
+                            "Inherit"
                         ],
                         "Subject": "DATABASE-ADMINS"
                     }
@@ -1124,8 +1401,7 @@
                         ],
                         "AccessType": "Allow",
                         "InheritanceType": [
-                            "Object",
-                            "Container"
+                            "Inherit"
                         ],
                         "Subject": "USERS"
                     },
@@ -1136,8 +1412,7 @@
                         ],
                         "AccessType": "Allow",
                         "InheritanceType": [
-                            "Object",
-                            "Container"
+                            "Inherit"
                         ],
                         "Subject": "METADATA-READERS"
                     },
@@ -1147,8 +1422,7 @@
                         ],
                         "AccessType": "Allow",
                         "InheritanceType": [
-                            "Object",
-                            "Container"
+                            "Inherit"
                         ],
                         "Subject": "DATA-READERS"
                     },
@@ -1159,8 +1433,7 @@
                         ],
                         "AccessType": "Allow",
                         "InheritanceType": [
-                            "Object",
-                            "Container"
+                            "Inherit"
                         ],
                         "Subject": "DATA-WRITERS"
                     },
@@ -1175,8 +1448,7 @@
                         ],
                         "AccessType": "Allow",
                         "InheritanceType": [
-                            "Object",
-                            "Container"
+                            "Inherit"
                         ],
                         "Subject": "DDL-ADMINS"
                     },
@@ -1186,8 +1458,7 @@
                         ],
                         "AccessType": "Allow",
                         "InheritanceType": [
-                            "Object",
-                            "Container"
+                            "Inherit"
                         ],
                         "Subject": "ACCESS-ADMINS"
                     },
@@ -1198,8 +1469,7 @@
                         ],
                         "AccessType": "Allow",
                         "InheritanceType": [
-                            "Object",
-                            "Container"
+                            "Inherit"
                         ],
                         "Subject": "DATABASE-ADMINS"
                     }
@@ -1217,8 +1487,7 @@
                         ],
                         "AccessType": "Allow",
                         "InheritanceType": [
-                            "Object",
-                            "Container"
+                            "Inherit"
                         ],
                         "Subject": "USERS"
                     },
@@ -1229,8 +1498,7 @@
                         ],
                         "AccessType": "Allow",
                         "InheritanceType": [
-                            "Object",
-                            "Container"
+                            "Inherit"
                         ],
                         "Subject": "METADATA-READERS"
                     },
@@ -1240,8 +1508,7 @@
                         ],
                         "AccessType": "Allow",
                         "InheritanceType": [
-                            "Object",
-                            "Container"
+                            "Inherit"
                         ],
                         "Subject": "DATA-READERS"
                     },
@@ -1252,8 +1519,7 @@
                         ],
                         "AccessType": "Allow",
                         "InheritanceType": [
-                            "Object",
-                            "Container"
+                            "Inherit"
                         ],
                         "Subject": "DATA-WRITERS"
                     },
@@ -1268,8 +1534,7 @@
                         ],
                         "AccessType": "Allow",
                         "InheritanceType": [
-                            "Object",
-                            "Container"
+                            "Inherit"
                         ],
                         "Subject": "DDL-ADMINS"
                     },
@@ -1279,8 +1544,7 @@
                         ],
                         "AccessType": "Allow",
                         "InheritanceType": [
-                            "Object",
-                            "Container"
+                            "Inherit"
                         ],
                         "Subject": "ACCESS-ADMINS"
                     },
@@ -1291,8 +1555,7 @@
                         ],
                         "AccessType": "Allow",
                         "InheritanceType": [
-                            "Object",
-                            "Container"
+                            "Inherit"
                         ],
                         "Subject": "DATABASE-ADMINS"
                     }
@@ -1304,8 +1567,7 @@
                         ],
                         "AccessType": "Allow",
                         "InheritanceType": [
-                            "Object",
-                            "Container"
+                            "Inherit"
                         ],
                         "Subject": "USERS"
                     },
@@ -1316,8 +1578,7 @@
                         ],
                         "AccessType": "Allow",
                         "InheritanceType": [
-                            "Object",
-                            "Container"
+                            "Inherit"
                         ],
                         "Subject": "METADATA-READERS"
                     },
@@ -1327,8 +1588,7 @@
                         ],
                         "AccessType": "Allow",
                         "InheritanceType": [
-                            "Object",
-                            "Container"
+                            "Inherit"
                         ],
                         "Subject": "DATA-READERS"
                     },
@@ -1339,8 +1599,7 @@
                         ],
                         "AccessType": "Allow",
                         "InheritanceType": [
-                            "Object",
-                            "Container"
+                            "Inherit"
                         ],
                         "Subject": "DATA-WRITERS"
                     },
@@ -1355,8 +1614,7 @@
                         ],
                         "AccessType": "Allow",
                         "InheritanceType": [
-                            "Object",
-                            "Container"
+                            "Inherit"
                         ],
                         "Subject": "DDL-ADMINS"
                     },
@@ -1366,8 +1624,7 @@
                         ],
                         "AccessType": "Allow",
                         "InheritanceType": [
-                            "Object",
-                            "Container"
+                            "Inherit"
                         ],
                         "Subject": "ACCESS-ADMINS"
                     },
@@ -1378,8 +1635,7 @@
                         ],
                         "AccessType": "Allow",
                         "InheritanceType": [
-                            "Object",
-                            "Container"
+                            "Inherit"
                         ],
                         "Subject": "DATABASE-ADMINS"
                     }
@@ -1397,8 +1653,7 @@
                         ],
                         "AccessType": "Allow",
                         "InheritanceType": [
-                            "Object",
-                            "Container"
+                            "Inherit"
                         ],
                         "Subject": "USERS"
                     },
@@ -1409,8 +1664,7 @@
                         ],
                         "AccessType": "Allow",
                         "InheritanceType": [
-                            "Object",
-                            "Container"
+                            "Inherit"
                         ],
                         "Subject": "METADATA-READERS"
                     },
@@ -1420,8 +1674,7 @@
                         ],
                         "AccessType": "Allow",
                         "InheritanceType": [
-                            "Object",
-                            "Container"
+                            "Inherit"
                         ],
                         "Subject": "DATA-READERS"
                     },
@@ -1432,8 +1685,7 @@
                         ],
                         "AccessType": "Allow",
                         "InheritanceType": [
-                            "Object",
-                            "Container"
+                            "Inherit"
                         ],
                         "Subject": "DATA-WRITERS"
                     },
@@ -1448,8 +1700,7 @@
                         ],
                         "AccessType": "Allow",
                         "InheritanceType": [
-                            "Object",
-                            "Container"
+                            "Inherit"
                         ],
                         "Subject": "DDL-ADMINS"
                     },
@@ -1459,8 +1710,7 @@
                         ],
                         "AccessType": "Allow",
                         "InheritanceType": [
-                            "Object",
-                            "Container"
+                            "Inherit"
                         ],
                         "Subject": "ACCESS-ADMINS"
                     },
@@ -1471,8 +1721,7 @@
                         ],
                         "AccessType": "Allow",
                         "InheritanceType": [
-                            "Object",
-                            "Container"
+                            "Inherit"
                         ],
                         "Subject": "DATABASE-ADMINS"
                     }
@@ -1484,8 +1733,7 @@
                         ],
                         "AccessType": "Allow",
                         "InheritanceType": [
-                            "Object",
-                            "Container"
+                            "Inherit"
                         ],
                         "Subject": "USERS"
                     },
@@ -1496,8 +1744,7 @@
                         ],
                         "AccessType": "Allow",
                         "InheritanceType": [
-                            "Object",
-                            "Container"
+                            "Inherit"
                         ],
                         "Subject": "METADATA-READERS"
                     },
@@ -1507,8 +1754,7 @@
                         ],
                         "AccessType": "Allow",
                         "InheritanceType": [
-                            "Object",
-                            "Container"
+                            "Inherit"
                         ],
                         "Subject": "DATA-READERS"
                     },
@@ -1519,8 +1765,7 @@
                         ],
                         "AccessType": "Allow",
                         "InheritanceType": [
-                            "Object",
-                            "Container"
+                            "Inherit"
                         ],
                         "Subject": "DATA-WRITERS"
                     },
@@ -1535,8 +1780,7 @@
                         ],
                         "AccessType": "Allow",
                         "InheritanceType": [
-                            "Object",
-                            "Container"
+                            "Inherit"
                         ],
                         "Subject": "DDL-ADMINS"
                     },
@@ -1546,8 +1790,7 @@
                         ],
                         "AccessType": "Allow",
                         "InheritanceType": [
-                            "Object",
-                            "Container"
+                            "Inherit"
                         ],
                         "Subject": "ACCESS-ADMINS"
                     },
@@ -1558,8 +1801,7 @@
                         ],
                         "AccessType": "Allow",
                         "InheritanceType": [
-                            "Object",
-                            "Container"
+                            "Inherit"
                         ],
                         "Subject": "DATABASE-ADMINS"
                     }
@@ -1569,6 +1811,295 @@
             }
         }
     },
+    "test.test_viewer_acl_write": [
+        {},
+        {
+            "Common": {
+                "ACL": [
+                    {
+                        "AccessRights": [
+                            "SelectRow",
+                            "ReadAttributes",
+                            "DescribeSchema"
+                        ],
+                        "AccessType": "Allow",
+                        "InheritanceType": [
+                            "Inherit"
+                        ],
+                        "Subject": "user1"
+                    }
+                ],
+                "EffectiveACL": [
+                    {
+                        "AccessRights": [
+                            "ConnectDatabase"
+                        ],
+                        "AccessType": "Allow",
+                        "InheritanceType": [
+                            "Inherit"
+                        ],
+                        "Subject": "USERS"
+                    },
+                    {
+                        "AccessRights": [
+                            "ReadAttributes",
+                            "DescribeSchema"
+                        ],
+                        "AccessType": "Allow",
+                        "InheritanceType": [
+                            "Inherit"
+                        ],
+                        "Subject": "METADATA-READERS"
+                    },
+                    {
+                        "AccessRights": [
+                            "SelectRow"
+                        ],
+                        "AccessType": "Allow",
+                        "InheritanceType": [
+                            "Inherit"
+                        ],
+                        "Subject": "DATA-READERS"
+                    },
+                    {
+                        "AccessRights": [
+                            "UpdateRow",
+                            "EraseRow"
+                        ],
+                        "AccessType": "Allow",
+                        "InheritanceType": [
+                            "Inherit"
+                        ],
+                        "Subject": "DATA-WRITERS"
+                    },
+                    {
+                        "AccessRights": [
+                            "WriteAttributes",
+                            "CreateDirectory",
+                            "CreateTable",
+                            "CreateQueue",
+                            "RemoveSchema",
+                            "AlterSchema"
+                        ],
+                        "AccessType": "Allow",
+                        "InheritanceType": [
+                            "Inherit"
+                        ],
+                        "Subject": "DDL-ADMINS"
+                    },
+                    {
+                        "AccessRights": [
+                            "GrantAccessRights"
+                        ],
+                        "AccessType": "Allow",
+                        "InheritanceType": [
+                            "Inherit"
+                        ],
+                        "Subject": "ACCESS-ADMINS"
+                    },
+                    {
+                        "AccessRights": [
+                            "CreateDatabase",
+                            "DropDatabase"
+                        ],
+                        "AccessType": "Allow",
+                        "InheritanceType": [
+                            "Inherit"
+                        ],
+                        "Subject": "DATABASE-ADMINS"
+                    },
+                    {
+                        "AccessRights": [
+                            "SelectRow",
+                            "ReadAttributes",
+                            "DescribeSchema"
+                        ],
+                        "AccessType": "Allow",
+                        "InheritanceType": [
+                            "Inherit"
+                        ],
+                        "Subject": "user1"
+                    }
+                ],
+                "Owner": "root@builtin",
+                "Path": "/Root/dedicated_db"
+            }
+        },
+        {},
+        {
+            "Common": {
+                "EffectiveACL": [
+                    {
+                        "AccessRights": [
+                            "ConnectDatabase"
+                        ],
+                        "AccessType": "Allow",
+                        "InheritanceType": [
+                            "Inherit"
+                        ],
+                        "Subject": "USERS"
+                    },
+                    {
+                        "AccessRights": [
+                            "ReadAttributes",
+                            "DescribeSchema"
+                        ],
+                        "AccessType": "Allow",
+                        "InheritanceType": [
+                            "Inherit"
+                        ],
+                        "Subject": "METADATA-READERS"
+                    },
+                    {
+                        "AccessRights": [
+                            "SelectRow"
+                        ],
+                        "AccessType": "Allow",
+                        "InheritanceType": [
+                            "Inherit"
+                        ],
+                        "Subject": "DATA-READERS"
+                    },
+                    {
+                        "AccessRights": [
+                            "UpdateRow",
+                            "EraseRow"
+                        ],
+                        "AccessType": "Allow",
+                        "InheritanceType": [
+                            "Inherit"
+                        ],
+                        "Subject": "DATA-WRITERS"
+                    },
+                    {
+                        "AccessRights": [
+                            "WriteAttributes",
+                            "CreateDirectory",
+                            "CreateTable",
+                            "CreateQueue",
+                            "RemoveSchema",
+                            "AlterSchema"
+                        ],
+                        "AccessType": "Allow",
+                        "InheritanceType": [
+                            "Inherit"
+                        ],
+                        "Subject": "DDL-ADMINS"
+                    },
+                    {
+                        "AccessRights": [
+                            "GrantAccessRights"
+                        ],
+                        "AccessType": "Allow",
+                        "InheritanceType": [
+                            "Inherit"
+                        ],
+                        "Subject": "ACCESS-ADMINS"
+                    },
+                    {
+                        "AccessRights": [
+                            "CreateDatabase",
+                            "DropDatabase"
+                        ],
+                        "AccessType": "Allow",
+                        "InheritanceType": [
+                            "Inherit"
+                        ],
+                        "Subject": "DATABASE-ADMINS"
+                    }
+                ],
+                "Owner": "root@builtin",
+                "Path": "/Root/dedicated_db"
+            }
+        },
+        {},
+        {
+            "Common": {
+                "EffectiveACL": [
+                    {
+                        "AccessRights": [
+                            "ConnectDatabase"
+                        ],
+                        "AccessType": "Allow",
+                        "InheritanceType": [
+                            "Inherit"
+                        ],
+                        "Subject": "USERS"
+                    },
+                    {
+                        "AccessRights": [
+                            "ReadAttributes",
+                            "DescribeSchema"
+                        ],
+                        "AccessType": "Allow",
+                        "InheritanceType": [
+                            "Inherit"
+                        ],
+                        "Subject": "METADATA-READERS"
+                    },
+                    {
+                        "AccessRights": [
+                            "SelectRow"
+                        ],
+                        "AccessType": "Allow",
+                        "InheritanceType": [
+                            "Inherit"
+                        ],
+                        "Subject": "DATA-READERS"
+                    },
+                    {
+                        "AccessRights": [
+                            "UpdateRow",
+                            "EraseRow"
+                        ],
+                        "AccessType": "Allow",
+                        "InheritanceType": [
+                            "Inherit"
+                        ],
+                        "Subject": "DATA-WRITERS"
+                    },
+                    {
+                        "AccessRights": [
+                            "WriteAttributes",
+                            "CreateDirectory",
+                            "CreateTable",
+                            "CreateQueue",
+                            "RemoveSchema",
+                            "AlterSchema"
+                        ],
+                        "AccessType": "Allow",
+                        "InheritanceType": [
+                            "Inherit"
+                        ],
+                        "Subject": "DDL-ADMINS"
+                    },
+                    {
+                        "AccessRights": [
+                            "GrantAccessRights"
+                        ],
+                        "AccessType": "Allow",
+                        "InheritanceType": [
+                            "Inherit"
+                        ],
+                        "Subject": "ACCESS-ADMINS"
+                    },
+                    {
+                        "AccessRights": [
+                            "CreateDatabase",
+                            "DropDatabase"
+                        ],
+                        "AccessType": "Allow",
+                        "InheritanceType": [
+                            "Inherit"
+                        ],
+                        "Subject": "DATABASE-ADMINS"
+                    }
+                ],
+                "Owner": "user1",
+                "Path": "/Root/dedicated_db"
+            }
+        }
+    ],
     "test.test_viewer_autocomplete": {
         "/Root": {
             "Result": {
@@ -1599,18 +2130,28 @@
             "Result": {
                 "Entities": [
                     {
+                        "Name": "table1",
+                        "Type": "table"
+                    },
+                    {
                         "Name": ".metadata",
                         "Type": "dir"
                     }
                 ],
-                "Total": 1
+                "Total": 2
             },
             "Success": true,
             "Version": 2
         },
         "/Root/serverless_db": {
             "Result": {
-                "Total": 0
+                "Entities": [
+                    {
+                        "Name": "table1",
+                        "Type": "table"
+                    }
+                ],
+                "Total": 1
             },
             "Success": true,
             "Version": 2
@@ -1619,11 +2160,15 @@
             "Result": {
                 "Entities": [
                     {
+                        "Name": "table1",
+                        "Type": "table"
+                    },
+                    {
                         "Name": ".metadata",
                         "Type": "dir"
                     }
                 ],
-                "Total": 1
+                "Total": 2
             },
             "Success": true,
             "Version": 2
@@ -1753,8 +2298,8 @@
         "Hosts": "2",
         "LoadAverage": "not-zero-number",
         "MapDataCenters": {
-            "1": 1,
-            "value": 2
+            "": 2,
+            "1": 1
         },
         "MapNodeRoles": {
             "Bootstrapper": 1,
@@ -1849,7 +2394,7 @@
                         "PathId": "not-zero-number-text",
                         "PathState": 2,
                         "PathType": 1,
-                        "SchemeshardId": "72075186232723360"
+                        "SchemeshardId": "72057594046678944"
                     },
                     {
                         "ACL": "",
@@ -1862,7 +2407,7 @@
                         "PathId": "not-zero-number-text",
                         "PathState": 2,
                         "PathType": 10,
-                        "SchemeshardId": "72075186232723360"
+                        "SchemeshardId": "72057594046678944"
                     },
                     {
                         "ACL": "",
@@ -1875,7 +2420,7 @@
                         "PathId": "not-zero-number-text",
                         "PathState": 3,
                         "PathType": 10,
-                        "SchemeshardId": "72075186232723360"
+                        "SchemeshardId": "72057594046678944"
                     },
                     {
                         "ACL": "",
@@ -1888,7 +2433,7 @@
                         "PathId": "not-zero-number-text",
                         "PathState": 2,
                         "PathType": 10,
-                        "SchemeshardId": "72075186232723360"
+                        "SchemeshardId": "72057594046678944"
                     },
                     {
                         "CreateFinished": true,
@@ -1896,14 +2441,14 @@
                         "CreateTxId": "0",
                         "Name": ".sys",
                         "PathType": 1,
-                        "SchemeshardId": "72075186232723360"
+                        "SchemeshardId": "72057594046678944"
                     }
                 ],
                 "DomainDescription": {
                     "DiskSpaceUsage": "not-empty-object",
                     "DomainKey": {
                         "PathId": "not-zero-number-text",
-                        "SchemeShard": "72075186232723360"
+                        "SchemeShard": "72057594046678944"
                     },
                     "PQPartitionsInside": "0",
                     "PQPartitionsLimit": "1000000",
@@ -1922,9 +2467,29 @@
                     },
                     "ResourcesDomainKey": {
                         "PathId": "not-zero-number-text",
-                        "SchemeShard": "72075186232723360"
+                        "SchemeShard": "72057594046678944"
                     },
-                    "SchemeShardId_Depricated": "72075186232723360",
+                    "SchemeLimits": {
+                        "ExtraPathSymbolsAllowed": "!\"#$%&'()*+,-.:;<=>?@[\\]^_`{|}~",
+                        "MaxAclBytesSize": "10240",
+                        "MaxChildrenInDir": "100000",
+                        "MaxColumnTableColumns": "10000",
+                        "MaxConsistentCopyTargets": "10000",
+                        "MaxDepth": "32",
+                        "MaxExports": "10",
+                        "MaxImports": "10",
+                        "MaxPQPartitions": "1000000",
+                        "MaxPathElementLength": "255",
+                        "MaxPaths": "10000",
+                        "MaxShards": "200000",
+                        "MaxShardsInPath": "35000",
+                        "MaxTableCdcStreams": "5",
+                        "MaxTableColumnNameLength": "255",
+                        "MaxTableColumns": "200",
+                        "MaxTableIndices": "20",
+                        "MaxTableKeyColumns": "30"
+                    },
+                    "SchemeShardId_Depricated": "72057594046678944",
                     "SecurityState": {
                         "Audience": "/Root",
                         "Sids": [
@@ -2022,11 +2587,11 @@
                     "PathSubType": 0,
                     "PathType": 1,
                     "PathVersion": "12",
-                    "SchemeshardId": "72075186232723360"
+                    "SchemeshardId": "72057594046678944"
                 }
             },
             "PathId": "not-zero-number-text",
-            "PathOwnerId": "72075186232723360",
+            "PathOwnerId": "72057594046678944",
             "Source": 1,
             "Status": "StatusSuccess"
         },
@@ -2045,8 +2610,22 @@
                         "Owner": "metadata@system",
                         "ParentPathId": "1",
                         "PathId": "not-zero-number-text",
-                        "PathState": 3,
+                        "PathState": 2,
                         "PathType": 1,
+                        "SchemeshardId": "72075186224037897"
+                    },
+                    {
+                        "ACL": "",
+                        "ChildrenExist": false,
+                        "CreateFinished": true,
+                        "CreateStep": "not-zero-number-text",
+                        "CreateTxId": "not-zero-number-text",
+                        "Name": "table1",
+                        "Owner": "root@builtin",
+                        "ParentPathId": "1",
+                        "PathId": "not-zero-number-text",
+                        "PathState": 3,
+                        "PathType": 2,
                         "SchemeshardId": "72075186224037897"
                     },
                     {
@@ -2062,12 +2641,12 @@
                     "DiskSpaceUsage": "not-empty-object",
                     "DomainKey": {
                         "PathId": "not-zero-number-text",
-                        "SchemeShard": "72075186232723360"
+                        "SchemeShard": "72057594046678944"
                     },
                     "PQPartitionsInside": "0",
                     "PQPartitionsLimit": "1000000",
                     "PathId_Depricated": "6",
-                    "PathsInside": "4",
+                    "PathsInside": "5",
                     "PathsLimit": "10000",
                     "ProcessingParams": {
                         "Coordinators": [
@@ -2089,13 +2668,33 @@
                     },
                     "ResourcesDomainKey": {
                         "PathId": "not-zero-number-text",
-                        "SchemeShard": "72075186232723360"
+                        "SchemeShard": "72057594046678944"
                     },
-                    "SchemeShardId_Depricated": "72075186232723360",
+                    "SchemeLimits": {
+                        "ExtraPathSymbolsAllowed": "!\"#$%&'()*+,-.:;<=>?@[\\]^_`{|}~",
+                        "MaxAclBytesSize": "10240",
+                        "MaxChildrenInDir": "100000",
+                        "MaxColumnTableColumns": "10000",
+                        "MaxConsistentCopyTargets": "10000",
+                        "MaxDepth": "32",
+                        "MaxExports": "10",
+                        "MaxImports": "10",
+                        "MaxPQPartitions": "1000000",
+                        "MaxPathElementLength": "255",
+                        "MaxPaths": "10000",
+                        "MaxShards": "200000",
+                        "MaxShardsInPath": "35000",
+                        "MaxTableCdcStreams": "5",
+                        "MaxTableColumnNameLength": "255",
+                        "MaxTableColumns": "200",
+                        "MaxTableIndices": "20",
+                        "MaxTableKeyColumns": "30"
+                    },
+                    "SchemeShardId_Depricated": "72057594046678944",
                     "SecurityState": {
                         "Audience": "/Root/dedicated_db"
                     },
-                    "ShardsInside": "10",
+                    "ShardsInside": "11",
                     "ShardsLimit": "200000",
                     "StoragePools": [
                         {
@@ -2117,7 +2716,7 @@
                     "PathState": 2,
                     "PathSubType": 0,
                     "PathType": 4,
-                    "PathVersion": "8",
+                    "PathVersion": "10",
                     "SchemeshardId": "72075186224037897"
                 }
             },
@@ -2132,6 +2731,20 @@
             "PathDescription": {
                 "Children": [
                     {
+                        "ACL": "",
+                        "ChildrenExist": false,
+                        "CreateFinished": true,
+                        "CreateStep": "not-zero-number-text",
+                        "CreateTxId": "not-zero-number-text",
+                        "Name": "table1",
+                        "Owner": "root@builtin",
+                        "ParentPathId": "1",
+                        "PathId": "not-zero-number-text",
+                        "PathState": 3,
+                        "PathType": 2,
+                        "SchemeshardId": "72075186224038899"
+                    },
+                    {
                         "CreateFinished": true,
                         "CreateStep": "0",
                         "CreateTxId": "0",
@@ -2144,12 +2757,12 @@
                     "DiskSpaceUsage": "not-empty-object",
                     "DomainKey": {
                         "PathId": "not-zero-number-text",
-                        "SchemeShard": "72075186232723360"
+                        "SchemeShard": "72057594046678944"
                     },
                     "PQPartitionsInside": "0",
                     "PQPartitionsLimit": "1000000",
                     "PathId_Depricated": "8",
-                    "PathsInside": "0",
+                    "PathsInside": "1",
                     "PathsLimit": "10000",
                     "ProcessingParams": {
                         "Coordinators": [
@@ -2167,14 +2780,34 @@
                     },
                     "ResourcesDomainKey": {
                         "PathId": "not-zero-number-text",
-                        "SchemeShard": "72075186232723360"
+                        "SchemeShard": "72057594046678944"
                     },
-                    "SchemeShardId_Depricated": "72075186232723360",
+                    "SchemeLimits": {
+                        "ExtraPathSymbolsAllowed": "!\"#$%&'()*+,-.:;<=>?@[\\]^_`{|}~",
+                        "MaxAclBytesSize": "10240",
+                        "MaxChildrenInDir": "100000",
+                        "MaxColumnTableColumns": "10000",
+                        "MaxConsistentCopyTargets": "10000",
+                        "MaxDepth": "32",
+                        "MaxExports": "10",
+                        "MaxImports": "10",
+                        "MaxPQPartitions": "1000000",
+                        "MaxPathElementLength": "255",
+                        "MaxPaths": "10000",
+                        "MaxShards": "200000",
+                        "MaxShardsInPath": "35000",
+                        "MaxTableCdcStreams": "5",
+                        "MaxTableColumnNameLength": "255",
+                        "MaxTableColumns": "200",
+                        "MaxTableIndices": "20",
+                        "MaxTableKeyColumns": "30"
+                    },
+                    "SchemeShardId_Depricated": "72057594046678944",
                     "SecurityState": {
                         "Audience": "/Root/serverless_db"
                     },
                     "ServerlessComputeResourcesMode": 1,
-                    "ShardsInside": "6",
+                    "ShardsInside": "7",
                     "ShardsLimit": "200000",
                     "SharedHive": "72075186224038889",
                     "StoragePools": [
@@ -2197,7 +2830,7 @@
                     "PathState": 2,
                     "PathSubType": 0,
                     "PathType": 4,
-                    "PathVersion": "4",
+                    "PathVersion": "6",
                     "SchemeshardId": "72075186224038899"
                 }
             },
@@ -2221,8 +2854,22 @@
                         "Owner": "metadata@system",
                         "ParentPathId": "1",
                         "PathId": "not-zero-number-text",
-                        "PathState": 3,
+                        "PathState": 2,
                         "PathType": 1,
+                        "SchemeshardId": "72075186224038898"
+                    },
+                    {
+                        "ACL": "",
+                        "ChildrenExist": false,
+                        "CreateFinished": true,
+                        "CreateStep": "not-zero-number-text",
+                        "CreateTxId": "not-zero-number-text",
+                        "Name": "table1",
+                        "Owner": "root@builtin",
+                        "ParentPathId": "1",
+                        "PathId": "not-zero-number-text",
+                        "PathState": 3,
+                        "PathType": 2,
                         "SchemeshardId": "72075186224038898"
                     },
                     {
@@ -2238,12 +2885,12 @@
                     "DiskSpaceUsage": "not-empty-object",
                     "DomainKey": {
                         "PathId": "not-zero-number-text",
-                        "SchemeShard": "72075186232723360"
+                        "SchemeShard": "72057594046678944"
                     },
                     "PQPartitionsInside": "0",
                     "PQPartitionsLimit": "1000000",
                     "PathId_Depricated": "7",
-                    "PathsInside": "4",
+                    "PathsInside": "5",
                     "PathsLimit": "10000",
                     "ProcessingParams": {
                         "Coordinators": [
@@ -2265,13 +2912,33 @@
                     },
                     "ResourcesDomainKey": {
                         "PathId": "not-zero-number-text",
-                        "SchemeShard": "72075186232723360"
+                        "SchemeShard": "72057594046678944"
                     },
-                    "SchemeShardId_Depricated": "72075186232723360",
+                    "SchemeLimits": {
+                        "ExtraPathSymbolsAllowed": "!\"#$%&'()*+,-.:;<=>?@[\\]^_`{|}~",
+                        "MaxAclBytesSize": "10240",
+                        "MaxChildrenInDir": "100000",
+                        "MaxColumnTableColumns": "10000",
+                        "MaxConsistentCopyTargets": "10000",
+                        "MaxDepth": "32",
+                        "MaxExports": "10",
+                        "MaxImports": "10",
+                        "MaxPQPartitions": "1000000",
+                        "MaxPathElementLength": "255",
+                        "MaxPaths": "10000",
+                        "MaxShards": "200000",
+                        "MaxShardsInPath": "35000",
+                        "MaxTableCdcStreams": "5",
+                        "MaxTableColumnNameLength": "255",
+                        "MaxTableColumns": "200",
+                        "MaxTableIndices": "20",
+                        "MaxTableKeyColumns": "30"
+                    },
+                    "SchemeShardId_Depricated": "72057594046678944",
                     "SecurityState": {
                         "Audience": "/Root/shared_db"
                     },
-                    "ShardsInside": "10",
+                    "ShardsInside": "11",
                     "ShardsLimit": "200000",
                     "StoragePools": [
                         {
@@ -2293,7 +2960,7 @@
                     "PathState": 2,
                     "PathSubType": 0,
                     "PathType": 4,
-                    "PathVersion": "8",
+                    "PathVersion": "10",
                     "SchemeshardId": "72075186224038898"
                 }
             },
@@ -2339,6 +3006,317 @@
     },
     "test.test_viewer_nodes": {
         "/Root": {
+            "FieldsAvailable": "0000000010000110111111100000111",
+            "FieldsRequired": "0000000000000000000000000000101",
+            "FoundNodes": "1",
+            "Nodes": [
+                {
+                    "NodeId": 1,
+                    "SystemState": {
+                        "ChangeTime": "not-zero-number-text",
+                        "CoresTotal": "not-zero-number",
+                        "CoresUsed": "not-zero-number",
+                        "Endpoints": [
+                            {
+                                "Address": "text",
+                                "Name": "grpc"
+                            },
+                            {
+                                "Address": "text",
+                                "Name": "http-mon"
+                            },
+                            {
+                                "Address": "text",
+                                "Name": "ic"
+                            }
+                        ],
+                        "Host": "text",
+                        "LoadAverage": "not-empty-array",
+                        "Location": {
+                            "DataCenter": "1",
+                            "Rack": "1",
+                            "Unit": "1"
+                        },
+                        "MaxDiskUsage": "not-zero-number",
+                        "MemoryLimit": "not-zero-number-text",
+                        "NodeId": 1,
+                        "NumberOfCpus": "not-zero-number",
+                        "PoolStats": [
+                            {
+                                "Limit": "not-zero-number",
+                                "Name": "System",
+                                "Threads": 2,
+                                "Usage": "number"
+                            },
+                            {
+                                "Limit": "not-zero-number",
+                                "Name": "User",
+                                "Threads": 3,
+                                "Usage": "number"
+                            },
+                            {
+                                "Limit": "not-zero-number",
+                                "Name": "Batch",
+                                "Threads": 2,
+                                "Usage": "number"
+                            },
+                            {
+                                "Limit": "not-zero-number",
+                                "Name": "IO",
+                                "Threads": 1,
+                                "Usage": "number"
+                            },
+                            {
+                                "Limit": "not-zero-number",
+                                "Name": "IC",
+                                "Threads": 1,
+                                "Usage": "number"
+                            }
+                        ],
+                        "RealNumberOfCpus": "not-zero-number",
+                        "Roles": "not-empty-array",
+                        "StartTime": "not-zero-number-text",
+                        "SystemState": "Green",
+                        "TotalSessions": "number"
+                    }
+                }
+            ],
+            "TotalNodes": "1"
+        },
+        "/Root/dedicated_db": {
+            "FieldsAvailable": "0000000010000110111111100000111",
+            "FieldsRequired": "0000000000000000000000000000101",
+            "FoundNodes": "1",
+            "Nodes": [
+                {
+                    "NodeId": 50000,
+                    "SystemState": {
+                        "ChangeTime": "not-zero-number-text",
+                        "CoresTotal": "not-zero-number",
+                        "CoresUsed": "not-zero-number",
+                        "Endpoints": [
+                            {
+                                "Address": "text",
+                                "Name": "grpc"
+                            },
+                            {
+                                "Address": "text",
+                                "Name": "http-mon"
+                            },
+                            {
+                                "Address": "text",
+                                "Name": "ic"
+                            }
+                        ],
+                        "Host": "text",
+                        "LoadAverage": "not-empty-array",
+                        "Location": {},
+                        "MemoryLimit": "not-zero-number-text",
+                        "NodeId": 50000,
+                        "NumberOfCpus": "not-zero-number",
+                        "PoolStats": [
+                            {
+                                "Limit": "not-zero-number",
+                                "Name": "System",
+                                "Threads": 2,
+                                "Usage": "number"
+                            },
+                            {
+                                "Limit": "not-zero-number",
+                                "Name": "User",
+                                "Threads": 3,
+                                "Usage": "number"
+                            },
+                            {
+                                "Limit": "not-zero-number",
+                                "Name": "Batch",
+                                "Threads": 2,
+                                "Usage": "number"
+                            },
+                            {
+                                "Limit": "not-zero-number",
+                                "Name": "IO",
+                                "Threads": 1,
+                                "Usage": "number"
+                            },
+                            {
+                                "Limit": "not-zero-number",
+                                "Name": "IC",
+                                "Threads": 1,
+                                "Usage": "number"
+                            }
+                        ],
+                        "RealNumberOfCpus": "not-zero-number",
+                        "Roles": "not-empty-array",
+                        "StartTime": "not-zero-number-text",
+                        "SystemState": "Green",
+                        "Tenants": [
+                            "/Root/dedicated_db"
+                        ],
+                        "TotalSessions": "number"
+                    }
+                }
+            ],
+            "TotalNodes": "1"
+        },
+        "/Root/serverless_db": {
+            "FieldsAvailable": "0000000010000110111111100000111",
+            "FieldsRequired": "0000000000000000000000000000101",
+            "FoundNodes": "1",
+            "Nodes": [
+                {
+                    "NodeId": 50001,
+                    "SystemState": {
+                        "ChangeTime": "not-zero-number-text",
+                        "CoresTotal": "not-zero-number",
+                        "CoresUsed": "not-zero-number",
+                        "Endpoints": [
+                            {
+                                "Address": "text",
+                                "Name": "grpc"
+                            },
+                            {
+                                "Address": "text",
+                                "Name": "http-mon"
+                            },
+                            {
+                                "Address": "text",
+                                "Name": "ic"
+                            }
+                        ],
+                        "Host": "text",
+                        "LoadAverage": "not-empty-array",
+                        "Location": {},
+                        "MemoryLimit": "not-zero-number-text",
+                        "NodeId": 50001,
+                        "NumberOfCpus": "not-zero-number",
+                        "PoolStats": [
+                            {
+                                "Limit": "not-zero-number",
+                                "Name": "System",
+                                "Threads": 2,
+                                "Usage": "number"
+                            },
+                            {
+                                "Limit": "not-zero-number",
+                                "Name": "User",
+                                "Threads": 3,
+                                "Usage": "number"
+                            },
+                            {
+                                "Limit": "not-zero-number",
+                                "Name": "Batch",
+                                "Threads": 2,
+                                "Usage": "number"
+                            },
+                            {
+                                "Limit": "not-zero-number",
+                                "Name": "IO",
+                                "Threads": 1,
+                                "Usage": "number"
+                            },
+                            {
+                                "Limit": "not-zero-number",
+                                "Name": "IC",
+                                "Threads": 1,
+                                "Usage": "number"
+                            }
+                        ],
+                        "RealNumberOfCpus": "not-zero-number",
+                        "Roles": "not-empty-array",
+                        "StartTime": "not-zero-number-text",
+                        "SystemState": "Green",
+                        "Tenants": [
+                            "/Root/shared_db"
+                        ],
+                        "TotalSessions": "number"
+                    }
+                }
+            ],
+            "Problems": [
+                "no-database-board-info"
+            ],
+            "TotalNodes": "1"
+        },
+        "/Root/shared_db": {
+            "FieldsAvailable": "0000000010000110111111100000111",
+            "FieldsRequired": "0000000000000000000000000000101",
+            "FoundNodes": "1",
+            "Nodes": [
+                {
+                    "NodeId": 50001,
+                    "SystemState": {
+                        "ChangeTime": "not-zero-number-text",
+                        "CoresTotal": "not-zero-number",
+                        "CoresUsed": "not-zero-number",
+                        "Endpoints": [
+                            {
+                                "Address": "text",
+                                "Name": "grpc"
+                            },
+                            {
+                                "Address": "text",
+                                "Name": "http-mon"
+                            },
+                            {
+                                "Address": "text",
+                                "Name": "ic"
+                            }
+                        ],
+                        "Host": "text",
+                        "LoadAverage": "not-empty-array",
+                        "Location": {},
+                        "MemoryLimit": "not-zero-number-text",
+                        "NodeId": 50001,
+                        "NumberOfCpus": "not-zero-number",
+                        "PoolStats": [
+                            {
+                                "Limit": "not-zero-number",
+                                "Name": "System",
+                                "Threads": 2,
+                                "Usage": "number"
+                            },
+                            {
+                                "Limit": "not-zero-number",
+                                "Name": "User",
+                                "Threads": 3,
+                                "Usage": "number"
+                            },
+                            {
+                                "Limit": "not-zero-number",
+                                "Name": "Batch",
+                                "Threads": 2,
+                                "Usage": "number"
+                            },
+                            {
+                                "Limit": "not-zero-number",
+                                "Name": "IO",
+                                "Threads": 1,
+                                "Usage": "number"
+                            },
+                            {
+                                "Limit": "not-zero-number",
+                                "Name": "IC",
+                                "Threads": 1,
+                                "Usage": "number"
+                            }
+                        ],
+                        "RealNumberOfCpus": "not-zero-number",
+                        "Roles": "not-empty-array",
+                        "StartTime": "not-zero-number-text",
+                        "SystemState": "Green",
+                        "Tenants": [
+                            "/Root/shared_db"
+                        ],
+                        "TotalSessions": "number"
+                    }
+                }
+            ],
+            "TotalNodes": "1"
+        }
+    },
+    "test.test_viewer_nodes_all": {
+        "/Root": {
             "FieldsAvailable": "1111111110111111111111111111111",
             "FieldsRequired": "1111111111111111111111111111111",
             "FoundNodes": "1",
@@ -2352,6 +3330,7 @@
                     "ConnectStatus": "Green",
                     "Connections": "not-zero-number",
                     "CpuUsage": "not-zero-number",
+                    "Database": "/Root",
                     "DiskSpaceUsage": "not-zero-number",
                     "NetworkUtilization": "number",
                     "NetworkUtilizationMax": "number",
@@ -2391,7 +3370,7 @@
                             "PeerNodeId": 50000,
                             "PingTimeUs": "text",
                             "ScopeId": {
-                                "X1": "72075186232723360",
+                                "X1": "72057594046678944",
                                 "X2": "6"
                             },
                             "Utilization": "number"
@@ -2408,7 +3387,7 @@
                             "PeerNodeId": 50001,
                             "PingTimeUs": "text",
                             "ScopeId": {
-                                "X1": "72075186232723360",
+                                "X1": "72057594046678944",
                                 "X2": "7"
                             },
                             "Utilization": "number"
@@ -2519,11 +3498,11 @@
                                 "Usage": "number"
                             }
                         ],
-                        "RealNumberOfCpus": 128,
+                        "RealNumberOfCpus": "not-zero-number",
                         "Roles": "not-empty-array",
                         "StartTime": "not-zero-number-text",
                         "SystemState": "Green",
-                        "TotalSessions": 0
+                        "TotalSessions": "number"
                     },
                     "UptimeSeconds": "number",
                     "VDisks": [
@@ -2756,7 +3735,7 @@
                             "PeerNodeId": 50001,
                             "PingTimeUs": "text",
                             "ScopeId": {
-                                "X1": "72075186232723360",
+                                "X1": "72057594046678944",
                                 "X2": "7"
                             },
                             "Utilization": "number"
@@ -2780,7 +3759,7 @@
                             "PeerNodeId": 50000,
                             "PingTimeUs": "text",
                             "ScopeId": {
-                                "X1": "72075186232723360",
+                                "X1": "72057594046678944",
                                 "X2": "6"
                             },
                             "Utilization": "number"
@@ -2797,7 +3776,7 @@
                             "PeerNodeId": 50000,
                             "PingTimeUs": "text",
                             "ScopeId": {
-                                "X1": "72075186232723360",
+                                "X1": "72057594046678944",
                                 "X2": "6"
                             },
                             "Utilization": "number"
@@ -2862,20 +3841,25 @@
                                 "Usage": "number"
                             }
                         ],
-                        "RealNumberOfCpus": 128,
+                        "RealNumberOfCpus": "not-zero-number",
                         "Roles": "not-empty-array",
                         "StartTime": "not-zero-number-text",
                         "SystemState": "Green",
                         "Tenants": [
                             "/Root/dedicated_db"
                         ],
-                        "TotalSessions": 0
+                        "TotalSessions": "number"
                     },
                     "Tablets": [
                         {
                             "Count": 3,
                             "State": "Green",
                             "Type": "Coordinator"
+                        },
+                        {
+                            "Count": 1,
+                            "State": "Green",
+                            "Type": "DataShard"
                         },
                         {
                             "Count": 1,
@@ -2957,7 +3941,7 @@
                             "PeerNodeId": 50000,
                             "PingTimeUs": "text",
                             "ScopeId": {
-                                "X1": "72075186232723360",
+                                "X1": "72057594046678944",
                                 "X2": "6"
                             },
                             "Utilization": "number"
@@ -2981,7 +3965,7 @@
                             "PeerNodeId": 50001,
                             "PingTimeUs": "text",
                             "ScopeId": {
-                                "X1": "72075186232723360",
+                                "X1": "72057594046678944",
                                 "X2": "7"
                             },
                             "Utilization": "number"
@@ -2998,7 +3982,7 @@
                             "PeerNodeId": 50001,
                             "PingTimeUs": "text",
                             "ScopeId": {
-                                "X1": "72075186232723360",
+                                "X1": "72057594046678944",
                                 "X2": "7"
                             },
                             "Utilization": "number"
@@ -3063,20 +4047,25 @@
                                 "Usage": "number"
                             }
                         ],
-                        "RealNumberOfCpus": 128,
+                        "RealNumberOfCpus": "not-zero-number",
                         "Roles": "not-empty-array",
                         "StartTime": "not-zero-number-text",
                         "SystemState": "Green",
                         "Tenants": [
                             "/Root/shared_db"
                         ],
-                        "TotalSessions": 0
+                        "TotalSessions": "number"
                     },
                     "Tablets": [
                         {
                             "Count": 1,
                             "State": "Green",
                             "Type": "Coordinator"
+                        },
+                        {
+                            "Count": 1,
+                            "State": "Green",
+                            "Type": "DataShard"
                         },
                         {
                             "Count": 3,
@@ -3148,7 +4137,7 @@
                             "PeerNodeId": 50000,
                             "PingTimeUs": "text",
                             "ScopeId": {
-                                "X1": "72075186232723360",
+                                "X1": "72057594046678944",
                                 "X2": "6"
                             },
                             "Utilization": "number"
@@ -3172,7 +4161,7 @@
                             "PeerNodeId": 50001,
                             "PingTimeUs": "text",
                             "ScopeId": {
-                                "X1": "72075186232723360",
+                                "X1": "72057594046678944",
                                 "X2": "7"
                             },
                             "Utilization": "number"
@@ -3189,7 +4178,7 @@
                             "PeerNodeId": 50001,
                             "PingTimeUs": "text",
                             "ScopeId": {
-                                "X1": "72075186232723360",
+                                "X1": "72057594046678944",
                                 "X2": "7"
                             },
                             "Utilization": "number"
@@ -3254,20 +4243,25 @@
                                 "Usage": "number"
                             }
                         ],
-                        "RealNumberOfCpus": 128,
+                        "RealNumberOfCpus": "not-zero-number",
                         "Roles": "not-empty-array",
                         "StartTime": "not-zero-number-text",
                         "SystemState": "Green",
                         "Tenants": [
                             "/Root/shared_db"
                         ],
-                        "TotalSessions": 0
+                        "TotalSessions": "number"
                     },
                     "Tablets": [
                         {
                             "Count": 3,
                             "State": "Green",
                             "Type": "Coordinator"
+                        },
+                        {
+                            "Count": 1,
+                            "State": "Green",
+                            "Type": "DataShard"
                         },
                         {
                             "Count": 1,
@@ -3299,6 +4293,239 @@
                 }
             ],
             "TotalNodes": "1"
+        }
+    },
+    "test.test_viewer_nodes_issue_14992": {
+        "response_group": {
+            "FieldsAvailable": "0000000110111110111111100000111",
+            "FieldsRequired": "0000000001100000010000000000101",
+            "FoundNodes": "3",
+            "MaximumDisksPerNode": "1",
+            "Nodes": [
+                {
+                    "NodeId": 1,
+                    "SystemState": {
+                        "ChangeTime": "not-zero-number-text",
+                        "CoresTotal": "not-zero-number",
+                        "CoresUsed": "not-zero-number",
+                        "Endpoints": [
+                            {
+                                "Address": "text",
+                                "Name": "grpc"
+                            },
+                            {
+                                "Address": "text",
+                                "Name": "http-mon"
+                            },
+                            {
+                                "Address": "text",
+                                "Name": "ic"
+                            }
+                        ],
+                        "Host": "text",
+                        "LoadAverage": "not-empty-array",
+                        "Location": {
+                            "DataCenter": "1",
+                            "Rack": "1",
+                            "Unit": "1"
+                        },
+                        "MaxDiskUsage": "not-zero-number",
+                        "MemoryLimit": "not-zero-number-text",
+                        "NodeId": 1,
+                        "NumberOfCpus": "not-zero-number",
+                        "PoolStats": [
+                            {
+                                "Limit": "not-zero-number",
+                                "Name": "System",
+                                "Threads": 2,
+                                "Usage": "number"
+                            },
+                            {
+                                "Limit": "not-zero-number",
+                                "Name": "User",
+                                "Threads": 3,
+                                "Usage": "number"
+                            },
+                            {
+                                "Limit": "not-zero-number",
+                                "Name": "Batch",
+                                "Threads": 2,
+                                "Usage": "number"
+                            },
+                            {
+                                "Limit": "not-zero-number",
+                                "Name": "IO",
+                                "Threads": 1,
+                                "Usage": "number"
+                            },
+                            {
+                                "Limit": "not-zero-number",
+                                "Name": "IC",
+                                "Threads": 1,
+                                "Usage": "number"
+                            }
+                        ],
+                        "RealNumberOfCpus": "not-zero-number",
+                        "Roles": "not-empty-array",
+                        "StartTime": "not-zero-number-text",
+                        "SystemState": "Green",
+                        "TotalSessions": "number"
+                    },
+                    "UptimeSeconds": "number"
+                },
+                {
+                    "NodeId": 50001,
+                    "SystemState": {
+                        "ChangeTime": "not-zero-number-text",
+                        "CoresTotal": "not-zero-number",
+                        "CoresUsed": "not-zero-number",
+                        "Endpoints": [
+                            {
+                                "Address": "text",
+                                "Name": "grpc"
+                            },
+                            {
+                                "Address": "text",
+                                "Name": "http-mon"
+                            },
+                            {
+                                "Address": "text",
+                                "Name": "ic"
+                            }
+                        ],
+                        "Host": "text",
+                        "LoadAverage": "not-empty-array",
+                        "Location": {},
+                        "MemoryLimit": "not-zero-number-text",
+                        "NodeId": 50001,
+                        "NumberOfCpus": "not-zero-number",
+                        "PoolStats": [
+                            {
+                                "Limit": "not-zero-number",
+                                "Name": "System",
+                                "Threads": 2,
+                                "Usage": "number"
+                            },
+                            {
+                                "Limit": "not-zero-number",
+                                "Name": "User",
+                                "Threads": 3,
+                                "Usage": "number"
+                            },
+                            {
+                                "Limit": "not-zero-number",
+                                "Name": "Batch",
+                                "Threads": 2,
+                                "Usage": "number"
+                            },
+                            {
+                                "Limit": "not-zero-number",
+                                "Name": "IO",
+                                "Threads": 1,
+                                "Usage": "number"
+                            },
+                            {
+                                "Limit": "not-zero-number",
+                                "Name": "IC",
+                                "Threads": 1,
+                                "Usage": "number"
+                            }
+                        ],
+                        "RealNumberOfCpus": "not-zero-number",
+                        "Roles": "not-empty-array",
+                        "StartTime": "not-zero-number-text",
+                        "SystemState": "Green",
+                        "Tenants": [
+                            "/Root/shared_db"
+                        ],
+                        "TotalSessions": "number"
+                    },
+                    "UptimeSeconds": "number"
+                },
+                {
+                    "NodeId": 50000,
+                    "SystemState": {
+                        "ChangeTime": "not-zero-number-text",
+                        "CoresTotal": "not-zero-number",
+                        "CoresUsed": "not-zero-number",
+                        "Endpoints": [
+                            {
+                                "Address": "text",
+                                "Name": "grpc"
+                            },
+                            {
+                                "Address": "text",
+                                "Name": "http-mon"
+                            },
+                            {
+                                "Address": "text",
+                                "Name": "ic"
+                            }
+                        ],
+                        "Host": "text",
+                        "LoadAverage": "not-empty-array",
+                        "Location": {},
+                        "MemoryLimit": "not-zero-number-text",
+                        "NodeId": 50000,
+                        "NumberOfCpus": "not-zero-number",
+                        "PoolStats": [
+                            {
+                                "Limit": "not-zero-number",
+                                "Name": "System",
+                                "Threads": 2,
+                                "Usage": "number"
+                            },
+                            {
+                                "Limit": "not-zero-number",
+                                "Name": "User",
+                                "Threads": 3,
+                                "Usage": "number"
+                            },
+                            {
+                                "Limit": "not-zero-number",
+                                "Name": "Batch",
+                                "Threads": 2,
+                                "Usage": "number"
+                            },
+                            {
+                                "Limit": "not-zero-number",
+                                "Name": "IO",
+                                "Threads": 1,
+                                "Usage": "number"
+                            },
+                            {
+                                "Limit": "not-zero-number",
+                                "Name": "IC",
+                                "Threads": 1,
+                                "Usage": "number"
+                            }
+                        ],
+                        "RealNumberOfCpus": "not-zero-number",
+                        "Roles": "not-empty-array",
+                        "StartTime": "not-zero-number-text",
+                        "SystemState": "Green",
+                        "Tenants": [
+                            "/Root/dedicated_db"
+                        ],
+                        "TotalSessions": "number"
+                    },
+                    "UptimeSeconds": "number"
+                }
+            ],
+            "TotalNodes": "3"
+        },
+        "response_group_by": {
+            "FieldsAvailable": "0000000110111110111111100000111",
+            "FieldsRequired": "0000000001100000010000000000101",
+            "FoundNodes": "3",
+            "MaximumDisksPerNode": "1",
+            "NodeGroups": [
+                {
+                    "GroupName": "up <10m",
+                    "NodeCount": "3"
+                }
+            ],
+            "TotalNodes": "3"
         }
     },
     "test.test_viewer_pdiskinfo": {
@@ -3343,7 +4570,7 @@
                     ]
                 }
             ],
-            "version": 8
+            "version": 9
         },
         "/Root/dedicated_db": {
             "result": [
@@ -3361,7 +4588,7 @@
                     ]
                 }
             ],
-            "version": 8
+            "version": 9
         },
         "/Root/serverless_db": {
             "result": [
@@ -3379,7 +4606,7 @@
                     ]
                 }
             ],
-            "version": 8
+            "version": 9
         },
         "/Root/shared_db": {
             "result": [
@@ -3397,7 +4624,224 @@
                     ]
                 }
             ],
-            "version": 8
+            "version": 9
+        }
+    },
+    "test.test_viewer_query_from_table": {
+        "/Root/dedicated_db": {
+            "result": [
+                {
+                    "columns": [
+                        {
+                            "name": "id",
+                            "type": "Int64?"
+                        },
+                        {
+                            "name": "name",
+                            "type": "Utf8?"
+                        }
+                    ],
+                    "rows": [
+                        [
+                            "1",
+                            "one"
+                        ],
+                        [
+                            "2",
+                            "two"
+                        ],
+                        [
+                            "3",
+                            "three"
+                        ]
+                    ]
+                }
+            ],
+            "version": 9
+        },
+        "/Root/serverless_db": {
+            "result": [
+                {
+                    "columns": [
+                        {
+                            "name": "id",
+                            "type": "Int64?"
+                        },
+                        {
+                            "name": "name",
+                            "type": "Utf8?"
+                        }
+                    ],
+                    "rows": [
+                        [
+                            "1",
+                            "one"
+                        ],
+                        [
+                            "2",
+                            "two"
+                        ],
+                        [
+                            "3",
+                            "three"
+                        ]
+                    ]
+                }
+            ],
+            "version": 9
+        },
+        "/Root/shared_db": {
+            "result": [
+                {
+                    "columns": [
+                        {
+                            "name": "id",
+                            "type": "Int64?"
+                        },
+                        {
+                            "name": "name",
+                            "type": "Utf8?"
+                        }
+                    ],
+                    "rows": [
+                        [
+                            "1",
+                            "one"
+                        ],
+                        [
+                            "2",
+                            "two"
+                        ],
+                        [
+                            "3",
+                            "three"
+                        ]
+                    ]
+                }
+            ],
+            "version": 9
+        }
+    },
+    "test.test_viewer_query_from_table_different_schemas": {
+        "classic": [
+            {
+                "id": "1",
+                "name": "one"
+            },
+            {
+                "id": "2",
+                "name": "two"
+            },
+            {
+                "id": "3",
+                "name": "three"
+            }
+        ],
+        "modern": {
+            "columns": [
+                {
+                    "name": "id",
+                    "type": "Int64?"
+                },
+                {
+                    "name": "name",
+                    "type": "Utf8?"
+                }
+            ],
+            "result": [
+                [
+                    "1",
+                    "one"
+                ],
+                [
+                    "2",
+                    "two"
+                ],
+                [
+                    "3",
+                    "three"
+                ]
+            ],
+            "version": 9
+        },
+        "multi": {
+            "result": [
+                {
+                    "columns": [
+                        {
+                            "name": "id",
+                            "type": "Int64?"
+                        },
+                        {
+                            "name": "name",
+                            "type": "Utf8?"
+                        }
+                    ],
+                    "rows": [
+                        [
+                            "1",
+                            "one"
+                        ],
+                        [
+                            "2",
+                            "two"
+                        ],
+                        [
+                            "3",
+                            "three"
+                        ]
+                    ]
+                }
+            ],
+            "version": 9
+        },
+        "ydb": {
+            "result": [
+                {
+                    "id": 1,
+                    "name": "one"
+                },
+                {
+                    "id": 2,
+                    "name": "two"
+                },
+                {
+                    "id": 3,
+                    "name": "three"
+                }
+            ],
+            "version": 9
+        },
+        "ydb2": {
+            "result": [
+                {
+                    "columns": [
+                        {
+                            "name": "id",
+                            "type": "Int64?"
+                        },
+                        {
+                            "name": "name",
+                            "type": "Utf8?"
+                        }
+                    ],
+                    "rows": [
+                        {
+                            "id": 1,
+                            "name": "one"
+                        },
+                        {
+                            "id": 2,
+                            "name": "two"
+                        },
+                        {
+                            "id": 3,
+                            "name": "three"
+                        }
+                    ]
+                }
+            ],
+            "version": 9
         }
     },
     "test.test_viewer_query_issue_13757": {
@@ -3420,7 +4864,7 @@
                     ]
                 }
             ],
-            "version": 8
+            "version": 9
         },
         "/Root/dedicated_db": {
             "result": [
@@ -3441,7 +4885,7 @@
                     ]
                 }
             ],
-            "version": 8
+            "version": 9
         },
         "/Root/serverless_db": {
             "result": [
@@ -3462,7 +4906,7 @@
                     ]
                 }
             ],
-            "version": 8
+            "version": 9
         },
         "/Root/shared_db": {
             "result": [
@@ -3483,7 +4927,7 @@
                     ]
                 }
             ],
-            "version": 8
+            "version": 9
         }
     },
     "test.test_viewer_query_issue_13945": {
@@ -3503,7 +4947,7 @@
                     ]
                 }
             ],
-            "version": 8
+            "version": 9
         },
         "/Root/dedicated_db": {
             "result": [
@@ -3521,7 +4965,7 @@
                     ]
                 }
             ],
-            "version": 8
+            "version": 9
         },
         "/Root/serverless_db": {
             "result": [
@@ -3539,7 +4983,7 @@
                     ]
                 }
             ],
-            "version": 8
+            "version": 9
         },
         "/Root/shared_db": {
             "result": [
@@ -3557,7 +5001,2018 @@
                     ]
                 }
             ],
-            "version": 8
+            "version": 9
+        }
+    },
+    "test.test_viewer_query_long": {
+        "execute_response": {
+            "execution_id": "text",
+            "operation_id": "text",
+            "result": [
+                {
+                    "columns": [
+                        {
+                            "name": "id",
+                            "type": "Int64?"
+                        },
+                        {
+                            "name": "name",
+                            "type": "Utf8?"
+                        }
+                    ],
+                    "rows": [
+                        [
+                            "1",
+                            "one"
+                        ],
+                        [
+                            "2",
+                            "two"
+                        ],
+                        [
+                            "3",
+                            "three"
+                        ]
+                    ]
+                }
+            ],
+            "version": 9
+        },
+        "fetch_by_execution_id": {
+            "execution_id": "text",
+            "result": [
+                {
+                    "columns": [
+                        {
+                            "name": "id",
+                            "type": "Int64?"
+                        },
+                        {
+                            "name": "name",
+                            "type": "Utf8?"
+                        }
+                    ],
+                    "rows": [
+                        [
+                            "1",
+                            "one"
+                        ],
+                        [
+                            "2",
+                            "two"
+                        ],
+                        [
+                            "3",
+                            "three"
+                        ]
+                    ]
+                }
+            ],
+            "version": 9
+        },
+        "fetch_by_operation_id": {
+            "execution_id": "text",
+            "operation_id": "text",
+            "result": [
+                {
+                    "columns": [
+                        {
+                            "name": "id",
+                            "type": "Int64?"
+                        },
+                        {
+                            "name": "name",
+                            "type": "Utf8?"
+                        }
+                    ],
+                    "rows": [
+                        [
+                            "1",
+                            "one"
+                        ],
+                        [
+                            "2",
+                            "two"
+                        ],
+                        [
+                            "3",
+                            "three"
+                        ]
+                    ]
+                }
+            ],
+            "version": 9
+        },
+        "fetch_error_no_id": {
+            "status_code": 400,
+            "text": "operation_id or execution_id required for fetch-long-query"
+        },
+        "fetch_invalid_operation_id": {
+            "status_code": 400,
+            "text": "operation_id or execution_id required for fetch-long-query"
+        }
+    },
+    "test.test_viewer_query_long_multipart": {
+        "execute_stream_response": {
+            "multipart_parts": [
+                {
+                    "exec_mode": "EXEC_MODE_EXECUTE",
+                    "exec_status": "EXEC_STATUS_STARTING",
+                    "execution_id": "text",
+                    "meta": {
+                        "event": "ScriptResponse"
+                    },
+                    "operation_id": "text",
+                    "status": "SUCCESS"
+                },
+                {
+                    "id": "text",
+                    "meta": {
+                        "event": "OperationResponse"
+                    },
+                    "metadata": {
+                        "exec_mode": "EXEC_MODE_EXECUTE",
+                        "exec_stats": {
+                            "query_plan": "{}"
+                        },
+                        "exec_status": "EXEC_STATUS_COMPLETED",
+                        "execution_id": "text",
+                        "result_sets_meta": [
+                            {
+                                "columns": [
+                                    {
+                                        "name": "id",
+                                        "type": {
+                                            "optional_type": {
+                                                "item": {
+                                                    "type_id": "INT64"
+                                                }
+                                            }
+                                        }
+                                    },
+                                    {
+                                        "name": "name",
+                                        "type": {
+                                            "optional_type": {
+                                                "item": {
+                                                    "type_id": "UTF8"
+                                                }
+                                            }
+                                        }
+                                    }
+                                ],
+                                "finished": true,
+                                "number_rows": "3"
+                            }
+                        ],
+                        "script_content": {
+                            "text": "SELECT * FROM table1 LIMIT 3;"
+                        }
+                    },
+                    "ready": true
+                },
+                {
+                    "meta": {
+                        "event": "StreamData",
+                        "result_index": 0,
+                        "seq_no": 0
+                    },
+                    "result": {
+                        "columns": [
+                            {
+                                "name": "id",
+                                "type": "Int64?"
+                            },
+                            {
+                                "name": "name",
+                                "type": "Utf8?"
+                            }
+                        ],
+                        "rows": [
+                            [
+                                "1",
+                                "one"
+                            ],
+                            [
+                                "2",
+                                "two"
+                            ],
+                            [
+                                "3",
+                                "three"
+                            ]
+                        ]
+                    }
+                }
+            ]
+        },
+        "fetch_error_stream_response": {
+            "status_code": 400,
+            "text": "operation_id or execution_id required for fetch-long-query"
+        },
+        "fetch_invalid_stream_response": {
+            "status_code": 400,
+            "text": "operation_id or execution_id required for fetch-long-query"
+        }
+    },
+    "test.test_viewer_storage_nodes": {
+        "/Root": {
+            "FieldsAvailable": "0000000110000110111111100000111",
+            "FieldsRequired": "0000000000000000000000000000111",
+            "FoundNodes": "1",
+            "MaximumSlotsPerDisk": "5",
+            "Nodes": [
+                {
+                    "NodeId": 1,
+                    "SystemState": {
+                        "ChangeTime": "not-zero-number-text",
+                        "CoresTotal": "not-zero-number",
+                        "CoresUsed": "not-zero-number",
+                        "Endpoints": [
+                            {
+                                "Address": "text",
+                                "Name": "grpc"
+                            },
+                            {
+                                "Address": "text",
+                                "Name": "http-mon"
+                            },
+                            {
+                                "Address": "text",
+                                "Name": "ic"
+                            }
+                        ],
+                        "Host": "text",
+                        "LoadAverage": "not-empty-array",
+                        "Location": {
+                            "DataCenter": "1",
+                            "Rack": "1",
+                            "Unit": "1"
+                        },
+                        "MaxDiskUsage": "not-zero-number",
+                        "MemoryLimit": "not-zero-number-text",
+                        "NodeId": 1,
+                        "NumberOfCpus": "not-zero-number",
+                        "PoolStats": [
+                            {
+                                "Limit": "not-zero-number",
+                                "Name": "System",
+                                "Threads": 2,
+                                "Usage": "number"
+                            },
+                            {
+                                "Limit": "not-zero-number",
+                                "Name": "User",
+                                "Threads": 3,
+                                "Usage": "number"
+                            },
+                            {
+                                "Limit": "not-zero-number",
+                                "Name": "Batch",
+                                "Threads": 2,
+                                "Usage": "number"
+                            },
+                            {
+                                "Limit": "not-zero-number",
+                                "Name": "IO",
+                                "Threads": 1,
+                                "Usage": "number"
+                            },
+                            {
+                                "Limit": "not-zero-number",
+                                "Name": "IC",
+                                "Threads": 1,
+                                "Usage": "number"
+                            }
+                        ],
+                        "RealNumberOfCpus": "not-zero-number",
+                        "Roles": "not-empty-array",
+                        "StartTime": "not-zero-number-text",
+                        "SystemState": "Green",
+                        "TotalSessions": "number"
+                    }
+                }
+            ],
+            "TotalNodes": "1"
+        },
+        "/Root/dedicated_db": {
+            "FieldsAvailable": "0000000110000110111111100000111",
+            "FieldsRequired": "0000000000000000000000000000111",
+            "FoundNodes": "1",
+            "MaximumSlotsPerDisk": "5",
+            "Nodes": [
+                {
+                    "NodeId": 1,
+                    "SystemState": {
+                        "ChangeTime": "not-zero-number-text",
+                        "CoresTotal": "not-zero-number",
+                        "CoresUsed": "not-zero-number",
+                        "Endpoints": [
+                            {
+                                "Address": "text",
+                                "Name": "grpc"
+                            },
+                            {
+                                "Address": "text",
+                                "Name": "http-mon"
+                            },
+                            {
+                                "Address": "text",
+                                "Name": "ic"
+                            }
+                        ],
+                        "Host": "text",
+                        "LoadAverage": "not-empty-array",
+                        "Location": {
+                            "DataCenter": "1",
+                            "Rack": "1",
+                            "Unit": "1"
+                        },
+                        "MaxDiskUsage": "not-zero-number",
+                        "MemoryLimit": "not-zero-number-text",
+                        "NodeId": 1,
+                        "NumberOfCpus": "not-zero-number",
+                        "PoolStats": [
+                            {
+                                "Limit": "not-zero-number",
+                                "Name": "System",
+                                "Threads": 2,
+                                "Usage": "number"
+                            },
+                            {
+                                "Limit": "not-zero-number",
+                                "Name": "User",
+                                "Threads": 3,
+                                "Usage": "number"
+                            },
+                            {
+                                "Limit": "not-zero-number",
+                                "Name": "Batch",
+                                "Threads": 2,
+                                "Usage": "number"
+                            },
+                            {
+                                "Limit": "not-zero-number",
+                                "Name": "IO",
+                                "Threads": 1,
+                                "Usage": "number"
+                            },
+                            {
+                                "Limit": "not-zero-number",
+                                "Name": "IC",
+                                "Threads": 1,
+                                "Usage": "number"
+                            }
+                        ],
+                        "RealNumberOfCpus": "not-zero-number",
+                        "Roles": "not-empty-array",
+                        "StartTime": "not-zero-number-text",
+                        "SystemState": "Green",
+                        "TotalSessions": "number"
+                    }
+                }
+            ],
+            "TotalNodes": "1"
+        },
+        "/Root/serverless_db": {
+            "FieldsAvailable": "0000000110000110111111100000111",
+            "FieldsRequired": "0000000000000000000000000000111",
+            "FoundNodes": "1",
+            "MaximumSlotsPerDisk": "5",
+            "Nodes": [
+                {
+                    "NodeId": 1,
+                    "SystemState": {
+                        "ChangeTime": "not-zero-number-text",
+                        "CoresTotal": "not-zero-number",
+                        "CoresUsed": "not-zero-number",
+                        "Endpoints": [
+                            {
+                                "Address": "text",
+                                "Name": "grpc"
+                            },
+                            {
+                                "Address": "text",
+                                "Name": "http-mon"
+                            },
+                            {
+                                "Address": "text",
+                                "Name": "ic"
+                            }
+                        ],
+                        "Host": "text",
+                        "LoadAverage": "not-empty-array",
+                        "Location": {
+                            "DataCenter": "1",
+                            "Rack": "1",
+                            "Unit": "1"
+                        },
+                        "MaxDiskUsage": "not-zero-number",
+                        "MemoryLimit": "not-zero-number-text",
+                        "NodeId": 1,
+                        "NumberOfCpus": "not-zero-number",
+                        "PoolStats": [
+                            {
+                                "Limit": "not-zero-number",
+                                "Name": "System",
+                                "Threads": 2,
+                                "Usage": "number"
+                            },
+                            {
+                                "Limit": "not-zero-number",
+                                "Name": "User",
+                                "Threads": 3,
+                                "Usage": "number"
+                            },
+                            {
+                                "Limit": "not-zero-number",
+                                "Name": "Batch",
+                                "Threads": 2,
+                                "Usage": "number"
+                            },
+                            {
+                                "Limit": "not-zero-number",
+                                "Name": "IO",
+                                "Threads": 1,
+                                "Usage": "number"
+                            },
+                            {
+                                "Limit": "not-zero-number",
+                                "Name": "IC",
+                                "Threads": 1,
+                                "Usage": "number"
+                            }
+                        ],
+                        "RealNumberOfCpus": "not-zero-number",
+                        "Roles": "not-empty-array",
+                        "StartTime": "not-zero-number-text",
+                        "SystemState": "Green",
+                        "TotalSessions": "number"
+                    }
+                }
+            ],
+            "Problems": [
+                "no-database-board-info"
+            ],
+            "TotalNodes": "1"
+        },
+        "/Root/shared_db": {
+            "FieldsAvailable": "0000000110000110111111100000111",
+            "FieldsRequired": "0000000000000000000000000000111",
+            "FoundNodes": "1",
+            "MaximumSlotsPerDisk": "5",
+            "Nodes": [
+                {
+                    "NodeId": 1,
+                    "SystemState": {
+                        "ChangeTime": "not-zero-number-text",
+                        "CoresTotal": "not-zero-number",
+                        "CoresUsed": "not-zero-number",
+                        "Endpoints": [
+                            {
+                                "Address": "text",
+                                "Name": "grpc"
+                            },
+                            {
+                                "Address": "text",
+                                "Name": "http-mon"
+                            },
+                            {
+                                "Address": "text",
+                                "Name": "ic"
+                            }
+                        ],
+                        "Host": "text",
+                        "LoadAverage": "not-empty-array",
+                        "Location": {
+                            "DataCenter": "1",
+                            "Rack": "1",
+                            "Unit": "1"
+                        },
+                        "MaxDiskUsage": "not-zero-number",
+                        "MemoryLimit": "not-zero-number-text",
+                        "NodeId": 1,
+                        "NumberOfCpus": "not-zero-number",
+                        "PoolStats": [
+                            {
+                                "Limit": "not-zero-number",
+                                "Name": "System",
+                                "Threads": 2,
+                                "Usage": "number"
+                            },
+                            {
+                                "Limit": "not-zero-number",
+                                "Name": "User",
+                                "Threads": 3,
+                                "Usage": "number"
+                            },
+                            {
+                                "Limit": "not-zero-number",
+                                "Name": "Batch",
+                                "Threads": 2,
+                                "Usage": "number"
+                            },
+                            {
+                                "Limit": "not-zero-number",
+                                "Name": "IO",
+                                "Threads": 1,
+                                "Usage": "number"
+                            },
+                            {
+                                "Limit": "not-zero-number",
+                                "Name": "IC",
+                                "Threads": 1,
+                                "Usage": "number"
+                            }
+                        ],
+                        "RealNumberOfCpus": "not-zero-number",
+                        "Roles": "not-empty-array",
+                        "StartTime": "not-zero-number-text",
+                        "SystemState": "Green",
+                        "TotalSessions": "number"
+                    }
+                }
+            ],
+            "TotalNodes": "1"
+        }
+    },
+    "test.test_viewer_storage_nodes_all": {
+        "/Root": {
+            "FieldsAvailable": "1111111110111111111111111111111",
+            "FieldsRequired": "1111111111111111111111111111111",
+            "FoundNodes": "1",
+            "MaximumDisksPerNode": "1",
+            "MaximumSlotsPerDisk": "5",
+            "Nodes": [
+                {
+                    "ClockSkewMaxUs": "text",
+                    "ClockSkewMinUs": "text",
+                    "ClockSkewUs": "text",
+                    "ConnectStatus": "Green",
+                    "Connections": "not-zero-number",
+                    "CpuUsage": "not-zero-number",
+                    "Database": "/Root",
+                    "DiskSpaceUsage": "not-zero-number",
+                    "NetworkUtilization": "number",
+                    "NetworkUtilizationMax": "number",
+                    "NetworkUtilizationMin": "number",
+                    "NodeId": 1,
+                    "PDisks": [
+                        {
+                            "AvailableSize": "text",
+                            "Category": "0",
+                            "ChangeTime": "not-zero-number-text",
+                            "Device": "Green",
+                            "EnforcedDynamicSlotSize": "not-zero-number-text",
+                            "Guid": "1",
+                            "LogTotalSize": "not-zero-number-text",
+                            "LogUsedSize": "not-zero-number-text",
+                            "NodeId": 1,
+                            "NumActiveSlots": 5,
+                            "PDiskId": 1,
+                            "Path": "SectorMap:1:64",
+                            "Realtime": "Green",
+                            "SerialNumber": "",
+                            "State": "Normal",
+                            "SystemSize": "not-zero-number-text",
+                            "TotalSize": "not-zero-number-text"
+                        }
+                    ],
+                    "Peers": [
+                        {
+                            "BytesWritten": "text",
+                            "ChangeTime": "not-zero-number-text",
+                            "ClockSkewUs": "text",
+                            "ConnectStatus": "Green",
+                            "ConnectTime": "not-zero-number-text",
+                            "Connected": true,
+                            "NodeId": 1,
+                            "PeerName": "text",
+                            "PeerNodeId": 50000,
+                            "PingTimeUs": "text",
+                            "ScopeId": {
+                                "X1": "72057594046678944",
+                                "X2": "6"
+                            },
+                            "Utilization": "number"
+                        },
+                        {
+                            "BytesWritten": "text",
+                            "ChangeTime": "not-zero-number-text",
+                            "ClockSkewUs": "text",
+                            "ConnectStatus": "Green",
+                            "ConnectTime": "not-zero-number-text",
+                            "Connected": true,
+                            "NodeId": 1,
+                            "PeerName": "text",
+                            "PeerNodeId": 50001,
+                            "PingTimeUs": "text",
+                            "ScopeId": {
+                                "X1": "72057594046678944",
+                                "X2": "7"
+                            },
+                            "Utilization": "number"
+                        }
+                    ],
+                    "PingTimeMaxUs": "text",
+                    "PingTimeMinUs": "text",
+                    "PingTimeUs": "text",
+                    "ReceiveThroughput": "text",
+                    "ReverseClockSkewUs": "text",
+                    "ReversePeers": [
+                        {
+                            "BytesWritten": "text",
+                            "ChangeTime": "not-zero-number-text",
+                            "ClockSkewUs": "text",
+                            "ConnectStatus": "Green",
+                            "ConnectTime": "not-zero-number-text",
+                            "Connected": true,
+                            "NodeId": 50000,
+                            "PeerName": "text",
+                            "PeerNodeId": 1,
+                            "PingTimeUs": "text",
+                            "ScopeId": {
+                                "X1": "0",
+                                "X2": "1"
+                            },
+                            "Utilization": "number"
+                        },
+                        {
+                            "BytesWritten": "text",
+                            "ChangeTime": "not-zero-number-text",
+                            "ClockSkewUs": "text",
+                            "ConnectStatus": "Green",
+                            "ConnectTime": "not-zero-number-text",
+                            "Connected": true,
+                            "NodeId": 50001,
+                            "PeerName": "text",
+                            "PeerNodeId": 1,
+                            "PingTimeUs": "text",
+                            "ScopeId": {
+                                "X1": "0",
+                                "X2": "1"
+                            },
+                            "Utilization": "number"
+                        }
+                    ],
+                    "ReversePingTimeUs": "text",
+                    "SendThroughput": "text",
+                    "SystemState": {
+                        "ChangeTime": "not-zero-number-text",
+                        "CoresTotal": "not-zero-number",
+                        "CoresUsed": "not-zero-number",
+                        "Endpoints": [
+                            {
+                                "Address": "text",
+                                "Name": "grpc"
+                            },
+                            {
+                                "Address": "text",
+                                "Name": "http-mon"
+                            },
+                            {
+                                "Address": "text",
+                                "Name": "ic"
+                            }
+                        ],
+                        "Host": "text",
+                        "LoadAverage": "not-empty-array",
+                        "Location": {
+                            "DataCenter": "1",
+                            "Rack": "1",
+                            "Unit": "1"
+                        },
+                        "MaxDiskUsage": "not-zero-number",
+                        "MemoryLimit": "not-zero-number-text",
+                        "MemoryStats": "not-empty-object",
+                        "NodeId": 1,
+                        "NumberOfCpus": "not-zero-number",
+                        "PoolStats": [
+                            {
+                                "Limit": "not-zero-number",
+                                "Name": "System",
+                                "Threads": 2,
+                                "Usage": "number"
+                            },
+                            {
+                                "Limit": "not-zero-number",
+                                "Name": "User",
+                                "Threads": 3,
+                                "Usage": "number"
+                            },
+                            {
+                                "Limit": "not-zero-number",
+                                "Name": "Batch",
+                                "Threads": 2,
+                                "Usage": "number"
+                            },
+                            {
+                                "Limit": "not-zero-number",
+                                "Name": "IO",
+                                "Threads": 1,
+                                "Usage": "number"
+                            },
+                            {
+                                "Limit": "not-zero-number",
+                                "Name": "IC",
+                                "Threads": 1,
+                                "Usage": "number"
+                            }
+                        ],
+                        "RealNumberOfCpus": "not-zero-number",
+                        "Roles": "not-empty-array",
+                        "StartTime": "not-zero-number-text",
+                        "SystemState": "Green",
+                        "TotalSessions": "number"
+                    },
+                    "UptimeSeconds": "number",
+                    "VDisks": [
+                        {
+                            "AllocatedSize": "0",
+                            "AvailableSize": "text",
+                            "ChangeTime": "not-zero-number-text",
+                            "DiskSpace": "Green",
+                            "FrontQueues": "Green",
+                            "Guid": "1",
+                            "HasUnreadableBlobs": false,
+                            "IncarnationGuid": "not-zero-number-text",
+                            "InstanceGuid": "not-zero-number-text",
+                            "Kind": "0",
+                            "NodeId": 1,
+                            "PDiskId": 1,
+                            "Replicated": true,
+                            "ReplicationProgress": 1,
+                            "ReplicationSecondsRemaining": 0,
+                            "SatisfactionRank": {
+                                "FreshRank": {
+                                    "Flag": "Green"
+                                },
+                                "LevelRank": {
+                                    "Flag": "Green"
+                                }
+                            },
+                            "StoragePoolName": "static",
+                            "VDiskId": {
+                                "Domain": 0,
+                                "GroupGeneration": 1,
+                                "GroupID": 0,
+                                "Ring": 0,
+                                "VDisk": 0
+                            },
+                            "VDiskSlotId": 0,
+                            "VDiskState": "OK"
+                        },
+                        {
+                            "AllocatedSize": "0",
+                            "AvailableSize": "text",
+                            "ChangeTime": "not-zero-number-text",
+                            "DiskSpace": "Green",
+                            "FrontQueues": "Green",
+                            "Guid": "1",
+                            "HasUnreadableBlobs": false,
+                            "IncarnationGuid": "not-zero-number-text",
+                            "InstanceGuid": "not-zero-number-text",
+                            "Kind": "0",
+                            "NodeId": 1,
+                            "PDiskId": 1,
+                            "Replicated": true,
+                            "ReplicationProgress": 1,
+                            "ReplicationSecondsRemaining": 0,
+                            "SatisfactionRank": {
+                                "FreshRank": {
+                                    "Flag": "Green"
+                                },
+                                "LevelRank": {
+                                    "Flag": "Green"
+                                }
+                            },
+                            "StoragePoolName": "dynamic_storage_pool:1",
+                            "VDiskId": {
+                                "Domain": 0,
+                                "GroupGeneration": 1,
+                                "GroupID": 2181038080,
+                                "Ring": 0,
+                                "VDisk": 0
+                            },
+                            "VDiskSlotId": 1000,
+                            "VDiskState": "OK"
+                        },
+                        {
+                            "AllocatedSize": "0",
+                            "AvailableSize": "text",
+                            "ChangeTime": "not-zero-number-text",
+                            "DiskSpace": "Green",
+                            "FrontQueues": "Green",
+                            "Guid": "1",
+                            "HasUnreadableBlobs": false,
+                            "IncarnationGuid": "not-zero-number-text",
+                            "InstanceGuid": "not-zero-number-text",
+                            "Kind": "0",
+                            "NodeId": 1,
+                            "PDiskId": 1,
+                            "Replicated": true,
+                            "ReplicationProgress": 1,
+                            "ReplicationSecondsRemaining": 0,
+                            "SatisfactionRank": {
+                                "FreshRank": {
+                                    "Flag": "Green"
+                                },
+                                "LevelRank": {
+                                    "Flag": "Green"
+                                }
+                            },
+                            "StoragePoolName": "dynamic_storage_pool:1",
+                            "VDiskId": {
+                                "Domain": 0,
+                                "GroupGeneration": 1,
+                                "GroupID": 2181038081,
+                                "Ring": 0,
+                                "VDisk": 0
+                            },
+                            "VDiskSlotId": 1001,
+                            "VDiskState": "OK"
+                        },
+                        {
+                            "AllocatedSize": "0",
+                            "AvailableSize": "text",
+                            "ChangeTime": "not-zero-number-text",
+                            "DiskSpace": "Green",
+                            "FrontQueues": "Green",
+                            "Guid": "1",
+                            "HasUnreadableBlobs": false,
+                            "IncarnationGuid": "not-zero-number-text",
+                            "InstanceGuid": "not-zero-number-text",
+                            "Kind": "0",
+                            "NodeId": 1,
+                            "PDiskId": 1,
+                            "Replicated": true,
+                            "ReplicationProgress": 1,
+                            "ReplicationSecondsRemaining": 0,
+                            "SatisfactionRank": {
+                                "FreshRank": {
+                                    "Flag": "Green"
+                                },
+                                "LevelRank": {
+                                    "Flag": "Green"
+                                }
+                            },
+                            "StoragePoolName": "/Root/dedicated_db:hdd",
+                            "VDiskId": {
+                                "Domain": 0,
+                                "GroupGeneration": 2,
+                                "GroupID": 2181038082,
+                                "Ring": 0,
+                                "VDisk": 0
+                            },
+                            "VDiskSlotId": 1002,
+                            "VDiskState": "OK"
+                        },
+                        {
+                            "AllocatedSize": "0",
+                            "AvailableSize": "text",
+                            "ChangeTime": "not-zero-number-text",
+                            "DiskSpace": "Green",
+                            "FrontQueues": "Green",
+                            "Guid": "1",
+                            "HasUnreadableBlobs": false,
+                            "IncarnationGuid": "not-zero-number-text",
+                            "InstanceGuid": "not-zero-number-text",
+                            "Kind": "0",
+                            "NodeId": 1,
+                            "PDiskId": 1,
+                            "Replicated": true,
+                            "ReplicationProgress": 1,
+                            "ReplicationSecondsRemaining": 0,
+                            "SatisfactionRank": {
+                                "FreshRank": {
+                                    "Flag": "Green"
+                                },
+                                "LevelRank": {
+                                    "Flag": "Green"
+                                }
+                            },
+                            "StoragePoolName": "/Root/shared_db:hdd",
+                            "VDiskId": {
+                                "Domain": 0,
+                                "GroupGeneration": 2,
+                                "GroupID": 2181038083,
+                                "Ring": 0,
+                                "VDisk": 0
+                            },
+                            "VDiskSlotId": 1003,
+                            "VDiskState": "OK"
+                        }
+                    ]
+                }
+            ],
+            "TotalNodes": "1"
+        },
+        "/Root/dedicated_db": {
+            "FieldsAvailable": "1111111110111111111111111111111",
+            "FieldsRequired": "1111111111111111111111111111111",
+            "FoundNodes": "1",
+            "MaximumDisksPerNode": "1",
+            "MaximumSlotsPerDisk": "5",
+            "Nodes": [
+                {
+                    "ClockSkewMaxUs": "text",
+                    "ClockSkewMinUs": "text",
+                    "ClockSkewUs": "text",
+                    "ConnectStatus": "Green",
+                    "Connections": "not-zero-number",
+                    "CpuUsage": "not-zero-number",
+                    "DiskSpaceUsage": "not-zero-number",
+                    "NetworkUtilization": "number",
+                    "NetworkUtilizationMax": "number",
+                    "NetworkUtilizationMin": "number",
+                    "NodeId": 1,
+                    "PDisks": [
+                        {
+                            "AvailableSize": "text",
+                            "Category": "0",
+                            "ChangeTime": "not-zero-number-text",
+                            "Device": "Green",
+                            "EnforcedDynamicSlotSize": "not-zero-number-text",
+                            "Guid": "1",
+                            "LogTotalSize": "not-zero-number-text",
+                            "LogUsedSize": "not-zero-number-text",
+                            "NodeId": 1,
+                            "NumActiveSlots": 5,
+                            "PDiskId": 1,
+                            "Path": "SectorMap:1:64",
+                            "Realtime": "Green",
+                            "SerialNumber": "",
+                            "State": "Normal",
+                            "SystemSize": "not-zero-number-text",
+                            "TotalSize": "not-zero-number-text"
+                        }
+                    ],
+                    "Peers": [
+                        {
+                            "BytesWritten": "text",
+                            "ChangeTime": "not-zero-number-text",
+                            "ClockSkewUs": "text",
+                            "ConnectStatus": "Green",
+                            "ConnectTime": "not-zero-number-text",
+                            "Connected": true,
+                            "NodeId": 1,
+                            "PeerName": "text",
+                            "PeerNodeId": 50000,
+                            "PingTimeUs": "text",
+                            "ScopeId": {
+                                "X1": "72057594046678944",
+                                "X2": "6"
+                            },
+                            "Utilization": "number"
+                        },
+                        {
+                            "BytesWritten": "text",
+                            "ChangeTime": "not-zero-number-text",
+                            "ClockSkewUs": "text",
+                            "ConnectStatus": "Green",
+                            "ConnectTime": "not-zero-number-text",
+                            "Connected": true,
+                            "NodeId": 1,
+                            "PeerName": "text",
+                            "PeerNodeId": 50001,
+                            "PingTimeUs": "text",
+                            "ScopeId": {
+                                "X1": "72057594046678944",
+                                "X2": "7"
+                            },
+                            "Utilization": "number"
+                        }
+                    ],
+                    "PingTimeMaxUs": "text",
+                    "PingTimeMinUs": "text",
+                    "PingTimeUs": "text",
+                    "ReceiveThroughput": "text",
+                    "ReverseClockSkewUs": "text",
+                    "ReversePeers": [
+                        {
+                            "BytesWritten": "text",
+                            "ChangeTime": "not-zero-number-text",
+                            "ClockSkewUs": "text",
+                            "ConnectStatus": "Green",
+                            "ConnectTime": "not-zero-number-text",
+                            "Connected": true,
+                            "NodeId": 50000,
+                            "PeerName": "text",
+                            "PeerNodeId": 1,
+                            "PingTimeUs": "text",
+                            "ScopeId": {
+                                "X1": "0",
+                                "X2": "1"
+                            },
+                            "Utilization": "number"
+                        },
+                        {
+                            "BytesWritten": "text",
+                            "ChangeTime": "not-zero-number-text",
+                            "ClockSkewUs": "text",
+                            "ConnectStatus": "Green",
+                            "ConnectTime": "not-zero-number-text",
+                            "Connected": true,
+                            "NodeId": 50001,
+                            "PeerName": "text",
+                            "PeerNodeId": 1,
+                            "PingTimeUs": "text",
+                            "ScopeId": {
+                                "X1": "0",
+                                "X2": "1"
+                            },
+                            "Utilization": "number"
+                        }
+                    ],
+                    "ReversePingTimeUs": "text",
+                    "SendThroughput": "text",
+                    "SystemState": {
+                        "ChangeTime": "not-zero-number-text",
+                        "CoresTotal": "not-zero-number",
+                        "CoresUsed": "not-zero-number",
+                        "Endpoints": [
+                            {
+                                "Address": "text",
+                                "Name": "grpc"
+                            },
+                            {
+                                "Address": "text",
+                                "Name": "http-mon"
+                            },
+                            {
+                                "Address": "text",
+                                "Name": "ic"
+                            }
+                        ],
+                        "Host": "text",
+                        "LoadAverage": "not-empty-array",
+                        "Location": {
+                            "DataCenter": "1",
+                            "Rack": "1",
+                            "Unit": "1"
+                        },
+                        "MaxDiskUsage": "not-zero-number",
+                        "MemoryLimit": "not-zero-number-text",
+                        "MemoryStats": "not-empty-object",
+                        "NodeId": 1,
+                        "NumberOfCpus": "not-zero-number",
+                        "PoolStats": [
+                            {
+                                "Limit": "not-zero-number",
+                                "Name": "System",
+                                "Threads": 2,
+                                "Usage": "number"
+                            },
+                            {
+                                "Limit": "not-zero-number",
+                                "Name": "User",
+                                "Threads": 3,
+                                "Usage": "number"
+                            },
+                            {
+                                "Limit": "not-zero-number",
+                                "Name": "Batch",
+                                "Threads": 2,
+                                "Usage": "number"
+                            },
+                            {
+                                "Limit": "not-zero-number",
+                                "Name": "IO",
+                                "Threads": 1,
+                                "Usage": "number"
+                            },
+                            {
+                                "Limit": "not-zero-number",
+                                "Name": "IC",
+                                "Threads": 1,
+                                "Usage": "number"
+                            }
+                        ],
+                        "RealNumberOfCpus": "not-zero-number",
+                        "Roles": "not-empty-array",
+                        "StartTime": "not-zero-number-text",
+                        "SystemState": "Green",
+                        "TotalSessions": "number"
+                    },
+                    "UptimeSeconds": "number",
+                    "VDisks": [
+                        {
+                            "AllocatedSize": "0",
+                            "AvailableSize": "text",
+                            "ChangeTime": "not-zero-number-text",
+                            "DiskSpace": "Green",
+                            "FrontQueues": "Green",
+                            "Guid": "1",
+                            "HasUnreadableBlobs": false,
+                            "IncarnationGuid": "not-zero-number-text",
+                            "InstanceGuid": "not-zero-number-text",
+                            "Kind": "0",
+                            "NodeId": 1,
+                            "PDiskId": 1,
+                            "Replicated": true,
+                            "ReplicationProgress": 1,
+                            "ReplicationSecondsRemaining": 0,
+                            "SatisfactionRank": {
+                                "FreshRank": {
+                                    "Flag": "Green"
+                                },
+                                "LevelRank": {
+                                    "Flag": "Green"
+                                }
+                            },
+                            "StoragePoolName": "static",
+                            "VDiskId": {
+                                "Domain": 0,
+                                "GroupGeneration": 1,
+                                "GroupID": 0,
+                                "Ring": 0,
+                                "VDisk": 0
+                            },
+                            "VDiskSlotId": 0,
+                            "VDiskState": "OK"
+                        },
+                        {
+                            "AllocatedSize": "0",
+                            "AvailableSize": "text",
+                            "ChangeTime": "not-zero-number-text",
+                            "DiskSpace": "Green",
+                            "FrontQueues": "Green",
+                            "Guid": "1",
+                            "HasUnreadableBlobs": false,
+                            "IncarnationGuid": "not-zero-number-text",
+                            "InstanceGuid": "not-zero-number-text",
+                            "Kind": "0",
+                            "NodeId": 1,
+                            "PDiskId": 1,
+                            "Replicated": true,
+                            "ReplicationProgress": 1,
+                            "ReplicationSecondsRemaining": 0,
+                            "SatisfactionRank": {
+                                "FreshRank": {
+                                    "Flag": "Green"
+                                },
+                                "LevelRank": {
+                                    "Flag": "Green"
+                                }
+                            },
+                            "StoragePoolName": "dynamic_storage_pool:1",
+                            "VDiskId": {
+                                "Domain": 0,
+                                "GroupGeneration": 1,
+                                "GroupID": 2181038080,
+                                "Ring": 0,
+                                "VDisk": 0
+                            },
+                            "VDiskSlotId": 1000,
+                            "VDiskState": "OK"
+                        },
+                        {
+                            "AllocatedSize": "0",
+                            "AvailableSize": "text",
+                            "ChangeTime": "not-zero-number-text",
+                            "DiskSpace": "Green",
+                            "FrontQueues": "Green",
+                            "Guid": "1",
+                            "HasUnreadableBlobs": false,
+                            "IncarnationGuid": "not-zero-number-text",
+                            "InstanceGuid": "not-zero-number-text",
+                            "Kind": "0",
+                            "NodeId": 1,
+                            "PDiskId": 1,
+                            "Replicated": true,
+                            "ReplicationProgress": 1,
+                            "ReplicationSecondsRemaining": 0,
+                            "SatisfactionRank": {
+                                "FreshRank": {
+                                    "Flag": "Green"
+                                },
+                                "LevelRank": {
+                                    "Flag": "Green"
+                                }
+                            },
+                            "StoragePoolName": "dynamic_storage_pool:1",
+                            "VDiskId": {
+                                "Domain": 0,
+                                "GroupGeneration": 1,
+                                "GroupID": 2181038081,
+                                "Ring": 0,
+                                "VDisk": 0
+                            },
+                            "VDiskSlotId": 1001,
+                            "VDiskState": "OK"
+                        },
+                        {
+                            "AllocatedSize": "0",
+                            "AvailableSize": "text",
+                            "ChangeTime": "not-zero-number-text",
+                            "DiskSpace": "Green",
+                            "FrontQueues": "Green",
+                            "Guid": "1",
+                            "HasUnreadableBlobs": false,
+                            "IncarnationGuid": "not-zero-number-text",
+                            "InstanceGuid": "not-zero-number-text",
+                            "Kind": "0",
+                            "NodeId": 1,
+                            "PDiskId": 1,
+                            "Replicated": true,
+                            "ReplicationProgress": 1,
+                            "ReplicationSecondsRemaining": 0,
+                            "SatisfactionRank": {
+                                "FreshRank": {
+                                    "Flag": "Green"
+                                },
+                                "LevelRank": {
+                                    "Flag": "Green"
+                                }
+                            },
+                            "StoragePoolName": "/Root/dedicated_db:hdd",
+                            "VDiskId": {
+                                "Domain": 0,
+                                "GroupGeneration": 2,
+                                "GroupID": 2181038082,
+                                "Ring": 0,
+                                "VDisk": 0
+                            },
+                            "VDiskSlotId": 1002,
+                            "VDiskState": "OK"
+                        },
+                        {
+                            "AllocatedSize": "0",
+                            "AvailableSize": "text",
+                            "ChangeTime": "not-zero-number-text",
+                            "DiskSpace": "Green",
+                            "FrontQueues": "Green",
+                            "Guid": "1",
+                            "HasUnreadableBlobs": false,
+                            "IncarnationGuid": "not-zero-number-text",
+                            "InstanceGuid": "not-zero-number-text",
+                            "Kind": "0",
+                            "NodeId": 1,
+                            "PDiskId": 1,
+                            "Replicated": true,
+                            "ReplicationProgress": 1,
+                            "ReplicationSecondsRemaining": 0,
+                            "SatisfactionRank": {
+                                "FreshRank": {
+                                    "Flag": "Green"
+                                },
+                                "LevelRank": {
+                                    "Flag": "Green"
+                                }
+                            },
+                            "StoragePoolName": "/Root/shared_db:hdd",
+                            "VDiskId": {
+                                "Domain": 0,
+                                "GroupGeneration": 2,
+                                "GroupID": 2181038083,
+                                "Ring": 0,
+                                "VDisk": 0
+                            },
+                            "VDiskSlotId": 1003,
+                            "VDiskState": "OK"
+                        }
+                    ]
+                }
+            ],
+            "TotalNodes": "1"
+        },
+        "/Root/serverless_db": {
+            "FieldsAvailable": "1111111110111111111111111111111",
+            "FieldsRequired": "1111111111111111111111111111111",
+            "FoundNodes": "1",
+            "MaximumDisksPerNode": "1",
+            "MaximumSlotsPerDisk": "5",
+            "Nodes": [
+                {
+                    "ClockSkewMaxUs": "text",
+                    "ClockSkewMinUs": "text",
+                    "ClockSkewUs": "text",
+                    "ConnectStatus": "Green",
+                    "Connections": "not-zero-number",
+                    "CpuUsage": "not-zero-number",
+                    "DiskSpaceUsage": "not-zero-number",
+                    "NetworkUtilization": "number",
+                    "NetworkUtilizationMax": "number",
+                    "NetworkUtilizationMin": "number",
+                    "NodeId": 1,
+                    "PDisks": [
+                        {
+                            "AvailableSize": "text",
+                            "Category": "0",
+                            "ChangeTime": "not-zero-number-text",
+                            "Device": "Green",
+                            "EnforcedDynamicSlotSize": "not-zero-number-text",
+                            "Guid": "1",
+                            "LogTotalSize": "not-zero-number-text",
+                            "LogUsedSize": "not-zero-number-text",
+                            "NodeId": 1,
+                            "NumActiveSlots": 5,
+                            "PDiskId": 1,
+                            "Path": "SectorMap:1:64",
+                            "Realtime": "Green",
+                            "SerialNumber": "",
+                            "State": "Normal",
+                            "SystemSize": "not-zero-number-text",
+                            "TotalSize": "not-zero-number-text"
+                        }
+                    ],
+                    "Peers": [
+                        {
+                            "BytesWritten": "text",
+                            "ChangeTime": "not-zero-number-text",
+                            "ClockSkewUs": "text",
+                            "ConnectStatus": "Green",
+                            "ConnectTime": "not-zero-number-text",
+                            "Connected": true,
+                            "NodeId": 1,
+                            "PeerName": "text",
+                            "PeerNodeId": 50000,
+                            "PingTimeUs": "text",
+                            "ScopeId": {
+                                "X1": "72057594046678944",
+                                "X2": "6"
+                            },
+                            "Utilization": "number"
+                        },
+                        {
+                            "BytesWritten": "text",
+                            "ChangeTime": "not-zero-number-text",
+                            "ClockSkewUs": "text",
+                            "ConnectStatus": "Green",
+                            "ConnectTime": "not-zero-number-text",
+                            "Connected": true,
+                            "NodeId": 1,
+                            "PeerName": "text",
+                            "PeerNodeId": 50001,
+                            "PingTimeUs": "text",
+                            "ScopeId": {
+                                "X1": "72057594046678944",
+                                "X2": "7"
+                            },
+                            "Utilization": "number"
+                        }
+                    ],
+                    "PingTimeMaxUs": "text",
+                    "PingTimeMinUs": "text",
+                    "PingTimeUs": "text",
+                    "ReceiveThroughput": "text",
+                    "ReverseClockSkewUs": "text",
+                    "ReversePeers": [
+                        {
+                            "BytesWritten": "text",
+                            "ChangeTime": "not-zero-number-text",
+                            "ClockSkewUs": "text",
+                            "ConnectStatus": "Green",
+                            "ConnectTime": "not-zero-number-text",
+                            "Connected": true,
+                            "NodeId": 50000,
+                            "PeerName": "text",
+                            "PeerNodeId": 1,
+                            "PingTimeUs": "text",
+                            "ScopeId": {
+                                "X1": "0",
+                                "X2": "1"
+                            },
+                            "Utilization": "number"
+                        },
+                        {
+                            "BytesWritten": "text",
+                            "ChangeTime": "not-zero-number-text",
+                            "ClockSkewUs": "text",
+                            "ConnectStatus": "Green",
+                            "ConnectTime": "not-zero-number-text",
+                            "Connected": true,
+                            "NodeId": 50001,
+                            "PeerName": "text",
+                            "PeerNodeId": 1,
+                            "PingTimeUs": "text",
+                            "ScopeId": {
+                                "X1": "0",
+                                "X2": "1"
+                            },
+                            "Utilization": "number"
+                        }
+                    ],
+                    "ReversePingTimeUs": "text",
+                    "SendThroughput": "text",
+                    "SystemState": {
+                        "ChangeTime": "not-zero-number-text",
+                        "CoresTotal": "not-zero-number",
+                        "CoresUsed": "not-zero-number",
+                        "Endpoints": [
+                            {
+                                "Address": "text",
+                                "Name": "grpc"
+                            },
+                            {
+                                "Address": "text",
+                                "Name": "http-mon"
+                            },
+                            {
+                                "Address": "text",
+                                "Name": "ic"
+                            }
+                        ],
+                        "Host": "text",
+                        "LoadAverage": "not-empty-array",
+                        "Location": {
+                            "DataCenter": "1",
+                            "Rack": "1",
+                            "Unit": "1"
+                        },
+                        "MaxDiskUsage": "not-zero-number",
+                        "MemoryLimit": "not-zero-number-text",
+                        "MemoryStats": "not-empty-object",
+                        "NodeId": 1,
+                        "NumberOfCpus": "not-zero-number",
+                        "PoolStats": [
+                            {
+                                "Limit": "not-zero-number",
+                                "Name": "System",
+                                "Threads": 2,
+                                "Usage": "number"
+                            },
+                            {
+                                "Limit": "not-zero-number",
+                                "Name": "User",
+                                "Threads": 3,
+                                "Usage": "number"
+                            },
+                            {
+                                "Limit": "not-zero-number",
+                                "Name": "Batch",
+                                "Threads": 2,
+                                "Usage": "number"
+                            },
+                            {
+                                "Limit": "not-zero-number",
+                                "Name": "IO",
+                                "Threads": 1,
+                                "Usage": "number"
+                            },
+                            {
+                                "Limit": "not-zero-number",
+                                "Name": "IC",
+                                "Threads": 1,
+                                "Usage": "number"
+                            }
+                        ],
+                        "RealNumberOfCpus": "not-zero-number",
+                        "Roles": "not-empty-array",
+                        "StartTime": "not-zero-number-text",
+                        "SystemState": "Green",
+                        "TotalSessions": "number"
+                    },
+                    "UptimeSeconds": "number",
+                    "VDisks": [
+                        {
+                            "AllocatedSize": "0",
+                            "AvailableSize": "text",
+                            "ChangeTime": "not-zero-number-text",
+                            "DiskSpace": "Green",
+                            "FrontQueues": "Green",
+                            "Guid": "1",
+                            "HasUnreadableBlobs": false,
+                            "IncarnationGuid": "not-zero-number-text",
+                            "InstanceGuid": "not-zero-number-text",
+                            "Kind": "0",
+                            "NodeId": 1,
+                            "PDiskId": 1,
+                            "Replicated": true,
+                            "ReplicationProgress": 1,
+                            "ReplicationSecondsRemaining": 0,
+                            "SatisfactionRank": {
+                                "FreshRank": {
+                                    "Flag": "Green"
+                                },
+                                "LevelRank": {
+                                    "Flag": "Green"
+                                }
+                            },
+                            "StoragePoolName": "static",
+                            "VDiskId": {
+                                "Domain": 0,
+                                "GroupGeneration": 1,
+                                "GroupID": 0,
+                                "Ring": 0,
+                                "VDisk": 0
+                            },
+                            "VDiskSlotId": 0,
+                            "VDiskState": "OK"
+                        },
+                        {
+                            "AllocatedSize": "0",
+                            "AvailableSize": "text",
+                            "ChangeTime": "not-zero-number-text",
+                            "DiskSpace": "Green",
+                            "FrontQueues": "Green",
+                            "Guid": "1",
+                            "HasUnreadableBlobs": false,
+                            "IncarnationGuid": "not-zero-number-text",
+                            "InstanceGuid": "not-zero-number-text",
+                            "Kind": "0",
+                            "NodeId": 1,
+                            "PDiskId": 1,
+                            "Replicated": true,
+                            "ReplicationProgress": 1,
+                            "ReplicationSecondsRemaining": 0,
+                            "SatisfactionRank": {
+                                "FreshRank": {
+                                    "Flag": "Green"
+                                },
+                                "LevelRank": {
+                                    "Flag": "Green"
+                                }
+                            },
+                            "StoragePoolName": "dynamic_storage_pool:1",
+                            "VDiskId": {
+                                "Domain": 0,
+                                "GroupGeneration": 1,
+                                "GroupID": 2181038080,
+                                "Ring": 0,
+                                "VDisk": 0
+                            },
+                            "VDiskSlotId": 1000,
+                            "VDiskState": "OK"
+                        },
+                        {
+                            "AllocatedSize": "0",
+                            "AvailableSize": "text",
+                            "ChangeTime": "not-zero-number-text",
+                            "DiskSpace": "Green",
+                            "FrontQueues": "Green",
+                            "Guid": "1",
+                            "HasUnreadableBlobs": false,
+                            "IncarnationGuid": "not-zero-number-text",
+                            "InstanceGuid": "not-zero-number-text",
+                            "Kind": "0",
+                            "NodeId": 1,
+                            "PDiskId": 1,
+                            "Replicated": true,
+                            "ReplicationProgress": 1,
+                            "ReplicationSecondsRemaining": 0,
+                            "SatisfactionRank": {
+                                "FreshRank": {
+                                    "Flag": "Green"
+                                },
+                                "LevelRank": {
+                                    "Flag": "Green"
+                                }
+                            },
+                            "StoragePoolName": "dynamic_storage_pool:1",
+                            "VDiskId": {
+                                "Domain": 0,
+                                "GroupGeneration": 1,
+                                "GroupID": 2181038081,
+                                "Ring": 0,
+                                "VDisk": 0
+                            },
+                            "VDiskSlotId": 1001,
+                            "VDiskState": "OK"
+                        },
+                        {
+                            "AllocatedSize": "0",
+                            "AvailableSize": "text",
+                            "ChangeTime": "not-zero-number-text",
+                            "DiskSpace": "Green",
+                            "FrontQueues": "Green",
+                            "Guid": "1",
+                            "HasUnreadableBlobs": false,
+                            "IncarnationGuid": "not-zero-number-text",
+                            "InstanceGuid": "not-zero-number-text",
+                            "Kind": "0",
+                            "NodeId": 1,
+                            "PDiskId": 1,
+                            "Replicated": true,
+                            "ReplicationProgress": 1,
+                            "ReplicationSecondsRemaining": 0,
+                            "SatisfactionRank": {
+                                "FreshRank": {
+                                    "Flag": "Green"
+                                },
+                                "LevelRank": {
+                                    "Flag": "Green"
+                                }
+                            },
+                            "StoragePoolName": "/Root/dedicated_db:hdd",
+                            "VDiskId": {
+                                "Domain": 0,
+                                "GroupGeneration": 2,
+                                "GroupID": 2181038082,
+                                "Ring": 0,
+                                "VDisk": 0
+                            },
+                            "VDiskSlotId": 1002,
+                            "VDiskState": "OK"
+                        },
+                        {
+                            "AllocatedSize": "0",
+                            "AvailableSize": "text",
+                            "ChangeTime": "not-zero-number-text",
+                            "DiskSpace": "Green",
+                            "FrontQueues": "Green",
+                            "Guid": "1",
+                            "HasUnreadableBlobs": false,
+                            "IncarnationGuid": "not-zero-number-text",
+                            "InstanceGuid": "not-zero-number-text",
+                            "Kind": "0",
+                            "NodeId": 1,
+                            "PDiskId": 1,
+                            "Replicated": true,
+                            "ReplicationProgress": 1,
+                            "ReplicationSecondsRemaining": 0,
+                            "SatisfactionRank": {
+                                "FreshRank": {
+                                    "Flag": "Green"
+                                },
+                                "LevelRank": {
+                                    "Flag": "Green"
+                                }
+                            },
+                            "StoragePoolName": "/Root/shared_db:hdd",
+                            "VDiskId": {
+                                "Domain": 0,
+                                "GroupGeneration": 2,
+                                "GroupID": 2181038083,
+                                "Ring": 0,
+                                "VDisk": 0
+                            },
+                            "VDiskSlotId": 1003,
+                            "VDiskState": "OK"
+                        }
+                    ]
+                }
+            ],
+            "TotalNodes": "1"
+        },
+        "/Root/shared_db": {
+            "FieldsAvailable": "1111111110111111111111111111111",
+            "FieldsRequired": "1111111111111111111111111111111",
+            "FoundNodes": "1",
+            "MaximumDisksPerNode": "1",
+            "MaximumSlotsPerDisk": "5",
+            "Nodes": [
+                {
+                    "ClockSkewMaxUs": "text",
+                    "ClockSkewMinUs": "text",
+                    "ClockSkewUs": "text",
+                    "ConnectStatus": "Green",
+                    "Connections": "not-zero-number",
+                    "CpuUsage": "not-zero-number",
+                    "DiskSpaceUsage": "not-zero-number",
+                    "NetworkUtilization": "number",
+                    "NetworkUtilizationMax": "number",
+                    "NetworkUtilizationMin": "number",
+                    "NodeId": 1,
+                    "PDisks": [
+                        {
+                            "AvailableSize": "text",
+                            "Category": "0",
+                            "ChangeTime": "not-zero-number-text",
+                            "Device": "Green",
+                            "EnforcedDynamicSlotSize": "not-zero-number-text",
+                            "Guid": "1",
+                            "LogTotalSize": "not-zero-number-text",
+                            "LogUsedSize": "not-zero-number-text",
+                            "NodeId": 1,
+                            "NumActiveSlots": 5,
+                            "PDiskId": 1,
+                            "Path": "SectorMap:1:64",
+                            "Realtime": "Green",
+                            "SerialNumber": "",
+                            "State": "Normal",
+                            "SystemSize": "not-zero-number-text",
+                            "TotalSize": "not-zero-number-text"
+                        }
+                    ],
+                    "Peers": [
+                        {
+                            "BytesWritten": "text",
+                            "ChangeTime": "not-zero-number-text",
+                            "ClockSkewUs": "text",
+                            "ConnectStatus": "Green",
+                            "ConnectTime": "not-zero-number-text",
+                            "Connected": true,
+                            "NodeId": 1,
+                            "PeerName": "text",
+                            "PeerNodeId": 50000,
+                            "PingTimeUs": "text",
+                            "ScopeId": {
+                                "X1": "72057594046678944",
+                                "X2": "6"
+                            },
+                            "Utilization": "number"
+                        },
+                        {
+                            "BytesWritten": "text",
+                            "ChangeTime": "not-zero-number-text",
+                            "ClockSkewUs": "text",
+                            "ConnectStatus": "Green",
+                            "ConnectTime": "not-zero-number-text",
+                            "Connected": true,
+                            "NodeId": 1,
+                            "PeerName": "text",
+                            "PeerNodeId": 50001,
+                            "PingTimeUs": "text",
+                            "ScopeId": {
+                                "X1": "72057594046678944",
+                                "X2": "7"
+                            },
+                            "Utilization": "number"
+                        }
+                    ],
+                    "PingTimeMaxUs": "text",
+                    "PingTimeMinUs": "text",
+                    "PingTimeUs": "text",
+                    "ReceiveThroughput": "text",
+                    "ReverseClockSkewUs": "text",
+                    "ReversePeers": [
+                        {
+                            "BytesWritten": "text",
+                            "ChangeTime": "not-zero-number-text",
+                            "ClockSkewUs": "text",
+                            "ConnectStatus": "Green",
+                            "ConnectTime": "not-zero-number-text",
+                            "Connected": true,
+                            "NodeId": 50000,
+                            "PeerName": "text",
+                            "PeerNodeId": 1,
+                            "PingTimeUs": "text",
+                            "ScopeId": {
+                                "X1": "0",
+                                "X2": "1"
+                            },
+                            "Utilization": "number"
+                        },
+                        {
+                            "BytesWritten": "text",
+                            "ChangeTime": "not-zero-number-text",
+                            "ClockSkewUs": "text",
+                            "ConnectStatus": "Green",
+                            "ConnectTime": "not-zero-number-text",
+                            "Connected": true,
+                            "NodeId": 50001,
+                            "PeerName": "text",
+                            "PeerNodeId": 1,
+                            "PingTimeUs": "text",
+                            "ScopeId": {
+                                "X1": "0",
+                                "X2": "1"
+                            },
+                            "Utilization": "number"
+                        }
+                    ],
+                    "ReversePingTimeUs": "text",
+                    "SendThroughput": "text",
+                    "SystemState": {
+                        "ChangeTime": "not-zero-number-text",
+                        "CoresTotal": "not-zero-number",
+                        "CoresUsed": "not-zero-number",
+                        "Endpoints": [
+                            {
+                                "Address": "text",
+                                "Name": "grpc"
+                            },
+                            {
+                                "Address": "text",
+                                "Name": "http-mon"
+                            },
+                            {
+                                "Address": "text",
+                                "Name": "ic"
+                            }
+                        ],
+                        "Host": "text",
+                        "LoadAverage": "not-empty-array",
+                        "Location": {
+                            "DataCenter": "1",
+                            "Rack": "1",
+                            "Unit": "1"
+                        },
+                        "MaxDiskUsage": "not-zero-number",
+                        "MemoryLimit": "not-zero-number-text",
+                        "MemoryStats": "not-empty-object",
+                        "NodeId": 1,
+                        "NumberOfCpus": "not-zero-number",
+                        "PoolStats": [
+                            {
+                                "Limit": "not-zero-number",
+                                "Name": "System",
+                                "Threads": 2,
+                                "Usage": "number"
+                            },
+                            {
+                                "Limit": "not-zero-number",
+                                "Name": "User",
+                                "Threads": 3,
+                                "Usage": "number"
+                            },
+                            {
+                                "Limit": "not-zero-number",
+                                "Name": "Batch",
+                                "Threads": 2,
+                                "Usage": "number"
+                            },
+                            {
+                                "Limit": "not-zero-number",
+                                "Name": "IO",
+                                "Threads": 1,
+                                "Usage": "number"
+                            },
+                            {
+                                "Limit": "not-zero-number",
+                                "Name": "IC",
+                                "Threads": 1,
+                                "Usage": "number"
+                            }
+                        ],
+                        "RealNumberOfCpus": "not-zero-number",
+                        "Roles": "not-empty-array",
+                        "StartTime": "not-zero-number-text",
+                        "SystemState": "Green",
+                        "TotalSessions": "number"
+                    },
+                    "UptimeSeconds": "number",
+                    "VDisks": [
+                        {
+                            "AllocatedSize": "0",
+                            "AvailableSize": "text",
+                            "ChangeTime": "not-zero-number-text",
+                            "DiskSpace": "Green",
+                            "FrontQueues": "Green",
+                            "Guid": "1",
+                            "HasUnreadableBlobs": false,
+                            "IncarnationGuid": "not-zero-number-text",
+                            "InstanceGuid": "not-zero-number-text",
+                            "Kind": "0",
+                            "NodeId": 1,
+                            "PDiskId": 1,
+                            "Replicated": true,
+                            "ReplicationProgress": 1,
+                            "ReplicationSecondsRemaining": 0,
+                            "SatisfactionRank": {
+                                "FreshRank": {
+                                    "Flag": "Green"
+                                },
+                                "LevelRank": {
+                                    "Flag": "Green"
+                                }
+                            },
+                            "StoragePoolName": "static",
+                            "VDiskId": {
+                                "Domain": 0,
+                                "GroupGeneration": 1,
+                                "GroupID": 0,
+                                "Ring": 0,
+                                "VDisk": 0
+                            },
+                            "VDiskSlotId": 0,
+                            "VDiskState": "OK"
+                        },
+                        {
+                            "AllocatedSize": "0",
+                            "AvailableSize": "text",
+                            "ChangeTime": "not-zero-number-text",
+                            "DiskSpace": "Green",
+                            "FrontQueues": "Green",
+                            "Guid": "1",
+                            "HasUnreadableBlobs": false,
+                            "IncarnationGuid": "not-zero-number-text",
+                            "InstanceGuid": "not-zero-number-text",
+                            "Kind": "0",
+                            "NodeId": 1,
+                            "PDiskId": 1,
+                            "Replicated": true,
+                            "ReplicationProgress": 1,
+                            "ReplicationSecondsRemaining": 0,
+                            "SatisfactionRank": {
+                                "FreshRank": {
+                                    "Flag": "Green"
+                                },
+                                "LevelRank": {
+                                    "Flag": "Green"
+                                }
+                            },
+                            "StoragePoolName": "dynamic_storage_pool:1",
+                            "VDiskId": {
+                                "Domain": 0,
+                                "GroupGeneration": 1,
+                                "GroupID": 2181038080,
+                                "Ring": 0,
+                                "VDisk": 0
+                            },
+                            "VDiskSlotId": 1000,
+                            "VDiskState": "OK"
+                        },
+                        {
+                            "AllocatedSize": "0",
+                            "AvailableSize": "text",
+                            "ChangeTime": "not-zero-number-text",
+                            "DiskSpace": "Green",
+                            "FrontQueues": "Green",
+                            "Guid": "1",
+                            "HasUnreadableBlobs": false,
+                            "IncarnationGuid": "not-zero-number-text",
+                            "InstanceGuid": "not-zero-number-text",
+                            "Kind": "0",
+                            "NodeId": 1,
+                            "PDiskId": 1,
+                            "Replicated": true,
+                            "ReplicationProgress": 1,
+                            "ReplicationSecondsRemaining": 0,
+                            "SatisfactionRank": {
+                                "FreshRank": {
+                                    "Flag": "Green"
+                                },
+                                "LevelRank": {
+                                    "Flag": "Green"
+                                }
+                            },
+                            "StoragePoolName": "dynamic_storage_pool:1",
+                            "VDiskId": {
+                                "Domain": 0,
+                                "GroupGeneration": 1,
+                                "GroupID": 2181038081,
+                                "Ring": 0,
+                                "VDisk": 0
+                            },
+                            "VDiskSlotId": 1001,
+                            "VDiskState": "OK"
+                        },
+                        {
+                            "AllocatedSize": "0",
+                            "AvailableSize": "text",
+                            "ChangeTime": "not-zero-number-text",
+                            "DiskSpace": "Green",
+                            "FrontQueues": "Green",
+                            "Guid": "1",
+                            "HasUnreadableBlobs": false,
+                            "IncarnationGuid": "not-zero-number-text",
+                            "InstanceGuid": "not-zero-number-text",
+                            "Kind": "0",
+                            "NodeId": 1,
+                            "PDiskId": 1,
+                            "Replicated": true,
+                            "ReplicationProgress": 1,
+                            "ReplicationSecondsRemaining": 0,
+                            "SatisfactionRank": {
+                                "FreshRank": {
+                                    "Flag": "Green"
+                                },
+                                "LevelRank": {
+                                    "Flag": "Green"
+                                }
+                            },
+                            "StoragePoolName": "/Root/dedicated_db:hdd",
+                            "VDiskId": {
+                                "Domain": 0,
+                                "GroupGeneration": 2,
+                                "GroupID": 2181038082,
+                                "Ring": 0,
+                                "VDisk": 0
+                            },
+                            "VDiskSlotId": 1002,
+                            "VDiskState": "OK"
+                        },
+                        {
+                            "AllocatedSize": "0",
+                            "AvailableSize": "text",
+                            "ChangeTime": "not-zero-number-text",
+                            "DiskSpace": "Green",
+                            "FrontQueues": "Green",
+                            "Guid": "1",
+                            "HasUnreadableBlobs": false,
+                            "IncarnationGuid": "not-zero-number-text",
+                            "InstanceGuid": "not-zero-number-text",
+                            "Kind": "0",
+                            "NodeId": 1,
+                            "PDiskId": 1,
+                            "Replicated": true,
+                            "ReplicationProgress": 1,
+                            "ReplicationSecondsRemaining": 0,
+                            "SatisfactionRank": {
+                                "FreshRank": {
+                                    "Flag": "Green"
+                                },
+                                "LevelRank": {
+                                    "Flag": "Green"
+                                }
+                            },
+                            "StoragePoolName": "/Root/shared_db:hdd",
+                            "VDiskId": {
+                                "Domain": 0,
+                                "GroupGeneration": 2,
+                                "GroupID": 2181038083,
+                                "Ring": 0,
+                                "VDisk": 0
+                            },
+                            "VDiskSlotId": 1003,
+                            "VDiskState": "OK"
+                        }
+                    ]
+                }
+            ],
+            "TotalNodes": "1"
         }
     },
     "test.test_viewer_sysinfo": {
@@ -3628,7 +7083,7 @@
                 "Tenants": [
                     "/Root/shared_db"
                 ],
-                "TotalSessions": 0
+                "TotalSessions": "number"
             },
             {
                 "ChangeTime": "not-zero-number-text",
@@ -3694,7 +7149,7 @@
                 "Tenants": [
                     "/Root/dedicated_db"
                 ],
-                "TotalSessions": 0
+                "TotalSessions": "number"
             },
             {
                 "ChangeTime": "not-zero-number-text",
@@ -3758,7 +7213,7 @@
                 "Roles": "not-empty-array",
                 "StartTime": "not-zero-number-text",
                 "SystemState": 1,
-                "TotalSessions": 0
+                "TotalSessions": "number"
             }
         ]
     },
@@ -3876,7 +7331,7 @@
                         "NodeId": 1,
                         "Overall": 1,
                         "State": 10,
-                        "TabletId": "72075186232723360",
+                        "TabletId": "72057594046678944",
                         "Type": 16
                     }
                 ]
@@ -3898,7 +7353,7 @@
                         "TabletId": "72075186224037888",
                         "TenantId": {
                             "PathId": "not-zero-number-text",
-                            "SchemeShard": "72075186232723360"
+                            "SchemeShard": "72057594046678944"
                         },
                         "Type": 14
                     },
@@ -3914,7 +7369,7 @@
                         "TabletId": "72075186224037889",
                         "TenantId": {
                             "PathId": "not-zero-number-text",
-                            "SchemeShard": "72075186232723360"
+                            "SchemeShard": "72057594046678944"
                         },
                         "Type": 5
                     },
@@ -3930,7 +7385,7 @@
                         "TabletId": "72075186224037890",
                         "TenantId": {
                             "PathId": "not-zero-number-text",
-                            "SchemeShard": "72075186232723360"
+                            "SchemeShard": "72057594046678944"
                         },
                         "Type": 5
                     },
@@ -3946,7 +7401,7 @@
                         "TabletId": "72075186224037891",
                         "TenantId": {
                             "PathId": "not-zero-number-text",
-                            "SchemeShard": "72075186232723360"
+                            "SchemeShard": "72057594046678944"
                         },
                         "Type": 32
                     },
@@ -3962,7 +7417,7 @@
                         "TabletId": "72075186224037892",
                         "TenantId": {
                             "PathId": "not-zero-number-text",
-                            "SchemeShard": "72075186232723360"
+                            "SchemeShard": "72057594046678944"
                         },
                         "Type": 5
                     },
@@ -3978,7 +7433,7 @@
                         "TabletId": "72075186224037893",
                         "TenantId": {
                             "PathId": "not-zero-number-text",
-                            "SchemeShard": "72075186232723360"
+                            "SchemeShard": "72057594046678944"
                         },
                         "Type": 13
                     },
@@ -3994,7 +7449,7 @@
                         "TabletId": "72075186224037894",
                         "TenantId": {
                             "PathId": "not-zero-number-text",
-                            "SchemeShard": "72075186232723360"
+                            "SchemeShard": "72057594046678944"
                         },
                         "Type": 40
                     },
@@ -4010,7 +7465,7 @@
                         "TabletId": "72075186224037895",
                         "TenantId": {
                             "PathId": "not-zero-number-text",
-                            "SchemeShard": "72075186232723360"
+                            "SchemeShard": "72057594046678944"
                         },
                         "Type": 13
                     },
@@ -4026,7 +7481,7 @@
                         "TabletId": "72075186224037896",
                         "TenantId": {
                             "PathId": "not-zero-number-text",
-                            "SchemeShard": "72075186232723360"
+                            "SchemeShard": "72057594046678944"
                         },
                         "Type": 13
                     },
@@ -4042,9 +7497,25 @@
                         "TabletId": "72075186224037897",
                         "TenantId": {
                             "PathId": "not-zero-number-text",
-                            "SchemeShard": "72075186232723360"
+                            "SchemeShard": "72057594046678944"
                         },
                         "Type": 16
+                    },
+                    {
+                        "ChangeTime": "not-zero-number-text",
+                        "FollowerId": 0,
+                        "Generation": 1,
+                        "HiveId": "72075186224037888",
+                        "Leader": true,
+                        "NodeId": 50000,
+                        "Overall": 1,
+                        "State": 10,
+                        "TabletId": "72075186224037898",
+                        "TenantId": {
+                            "PathId": "not-zero-number-text",
+                            "SchemeShard": "72057594046678944"
+                        },
+                        "Type": 18
                     }
                 ]
             },
@@ -4065,7 +7536,7 @@
                         "TabletId": "72075186224038899",
                         "TenantId": {
                             "PathId": "not-zero-number-text",
-                            "SchemeShard": "72075186232723360"
+                            "SchemeShard": "72057594046678944"
                         },
                         "Type": 16
                     },
@@ -4081,7 +7552,7 @@
                         "TabletId": "72075186224038900",
                         "TenantId": {
                             "PathId": "not-zero-number-text",
-                            "SchemeShard": "72075186232723360"
+                            "SchemeShard": "72057594046678944"
                         },
                         "Type": 13
                     },
@@ -4097,7 +7568,7 @@
                         "TabletId": "72075186224038901",
                         "TenantId": {
                             "PathId": "not-zero-number-text",
-                            "SchemeShard": "72075186232723360"
+                            "SchemeShard": "72057594046678944"
                         },
                         "Type": 5
                     },
@@ -4113,7 +7584,7 @@
                         "TabletId": "72075186224038902",
                         "TenantId": {
                             "PathId": "not-zero-number-text",
-                            "SchemeShard": "72075186232723360"
+                            "SchemeShard": "72057594046678944"
                         },
                         "Type": 5
                     },
@@ -4129,7 +7600,7 @@
                         "TabletId": "72075186224038903",
                         "TenantId": {
                             "PathId": "not-zero-number-text",
-                            "SchemeShard": "72075186232723360"
+                            "SchemeShard": "72057594046678944"
                         },
                         "Type": 5
                     },
@@ -4145,9 +7616,25 @@
                         "TabletId": "72075186224038904",
                         "TenantId": {
                             "PathId": "not-zero-number-text",
-                            "SchemeShard": "72075186232723360"
+                            "SchemeShard": "72057594046678944"
                         },
                         "Type": 32
+                    },
+                    {
+                        "ChangeTime": "not-zero-number-text",
+                        "FollowerId": 0,
+                        "Generation": 1,
+                        "HiveId": "72075186224038889",
+                        "Leader": true,
+                        "NodeId": 50001,
+                        "Overall": 1,
+                        "State": 10,
+                        "TabletId": "72075186224038906",
+                        "TenantId": {
+                            "PathId": "not-zero-number-text",
+                            "SchemeShard": "72057594046678944"
+                        },
+                        "Type": 18
                     }
                 ]
             },
@@ -4168,7 +7655,7 @@
                         "TabletId": "72075186224038889",
                         "TenantId": {
                             "PathId": "not-zero-number-text",
-                            "SchemeShard": "72075186232723360"
+                            "SchemeShard": "72057594046678944"
                         },
                         "Type": 14
                     },
@@ -4184,7 +7671,7 @@
                         "TabletId": "72075186224038890",
                         "TenantId": {
                             "PathId": "not-zero-number-text",
-                            "SchemeShard": "72075186232723360"
+                            "SchemeShard": "72057594046678944"
                         },
                         "Type": 40
                     },
@@ -4200,7 +7687,7 @@
                         "TabletId": "72075186224038891",
                         "TenantId": {
                             "PathId": "not-zero-number-text",
-                            "SchemeShard": "72075186232723360"
+                            "SchemeShard": "72057594046678944"
                         },
                         "Type": 5
                     },
@@ -4216,7 +7703,7 @@
                         "TabletId": "72075186224038892",
                         "TenantId": {
                             "PathId": "not-zero-number-text",
-                            "SchemeShard": "72075186232723360"
+                            "SchemeShard": "72057594046678944"
                         },
                         "Type": 5
                     },
@@ -4232,7 +7719,7 @@
                         "TabletId": "72075186224038893",
                         "TenantId": {
                             "PathId": "not-zero-number-text",
-                            "SchemeShard": "72075186232723360"
+                            "SchemeShard": "72057594046678944"
                         },
                         "Type": 32
                     },
@@ -4248,7 +7735,7 @@
                         "TabletId": "72075186224038894",
                         "TenantId": {
                             "PathId": "not-zero-number-text",
-                            "SchemeShard": "72075186232723360"
+                            "SchemeShard": "72057594046678944"
                         },
                         "Type": 13
                     },
@@ -4264,7 +7751,7 @@
                         "TabletId": "72075186224038895",
                         "TenantId": {
                             "PathId": "not-zero-number-text",
-                            "SchemeShard": "72075186232723360"
+                            "SchemeShard": "72057594046678944"
                         },
                         "Type": 13
                     },
@@ -4280,7 +7767,7 @@
                         "TabletId": "72075186224038896",
                         "TenantId": {
                             "PathId": "not-zero-number-text",
-                            "SchemeShard": "72075186232723360"
+                            "SchemeShard": "72057594046678944"
                         },
                         "Type": 13
                     },
@@ -4296,7 +7783,7 @@
                         "TabletId": "72075186224038897",
                         "TenantId": {
                             "PathId": "not-zero-number-text",
-                            "SchemeShard": "72075186232723360"
+                            "SchemeShard": "72057594046678944"
                         },
                         "Type": 5
                     },
@@ -4312,9 +7799,25 @@
                         "TabletId": "72075186224038898",
                         "TenantId": {
                             "PathId": "not-zero-number-text",
-                            "SchemeShard": "72075186232723360"
+                            "SchemeShard": "72057594046678944"
                         },
                         "Type": 16
+                    },
+                    {
+                        "ChangeTime": "not-zero-number-text",
+                        "FollowerId": 0,
+                        "Generation": 1,
+                        "HiveId": "72075186224038889",
+                        "Leader": true,
+                        "NodeId": 50001,
+                        "Overall": 1,
+                        "State": 10,
+                        "TabletId": "72075186224038905",
+                        "TenantId": {
+                            "PathId": "not-zero-number-text",
+                            "SchemeShard": "72057594046678944"
+                        },
+                        "Type": 18
                     }
                 ]
             }
@@ -4374,6 +7877,10 @@
                     },
                     {
                         "Count": 1,
+                        "Type": "DataShard"
+                    },
+                    {
+                        "Count": 1,
                         "Type": "Hive"
                     },
                     {
@@ -4402,6 +7909,10 @@
                         "Type": "Coordinator"
                     },
                     {
+                        "Count": 1,
+                        "Type": "DataShard"
+                    },
+                    {
                         "Count": 3,
                         "Type": "Mediator"
                     },
@@ -4421,6 +7932,10 @@
                     {
                         "Count": 3,
                         "Type": "Coordinator"
+                    },
+                    {
+                        "Count": 1,
+                        "Type": "DataShard"
                     },
                     {
                         "Count": 1,
@@ -4453,7 +7968,7 @@
                 "CoresTotal": "not-zero-number",
                 "CoresUsed": "not-zero-number",
                 "CreateTime": "not-zero-number-text",
-                "Id": "72075186232723360-1",
+                "Id": "72057594046678944-1",
                 "MemoryLimit": "not-zero-number-text",
                 "MemoryStats": {},
                 "Metrics": {},
@@ -4500,7 +8015,7 @@
                 "CoresTotal": "not-zero-number",
                 "CoresUsed": "not-zero-number",
                 "DatabaseQuotas": {},
-                "Id": "72075186232723360-6",
+                "Id": "72057594046678944-6",
                 "MemoryLimit": "not-zero-number-text",
                 "MemoryStats": {},
                 "Metrics": "not-empty-object",
@@ -4558,7 +8073,7 @@
                 "State": "RUNNING",
                 "StateStats": [
                     {
-                        "Count": 9,
+                        "Count": 10,
                         "VolatileState": "TABLET_VOLATILE_STATE_RUNNING"
                     }
                 ],
@@ -4567,16 +8082,16 @@
             {
                 "CoresUsed": "not-zero-number",
                 "DatabaseQuotas": {},
-                "Id": "72075186232723360-8",
+                "Id": "72057594046678944-8",
                 "Metrics": "not-empty-object",
                 "Name": "/Root/serverless_db",
                 "Overall": "Green",
                 "Owner": "root@builtin",
-                "ResourceId": "72075186232723360-7",
+                "ResourceId": "72057594046678944-7",
                 "State": "RUNNING",
                 "StateStats": [
                     {
-                        "Count": 6,
+                        "Count": 7,
                         "VolatileState": "TABLET_VOLATILE_STATE_RUNNING"
                     }
                 ],
@@ -4587,7 +8102,7 @@
                 "CoresTotal": "not-zero-number",
                 "CoresUsed": "not-zero-number",
                 "DatabaseQuotas": {},
-                "Id": "72075186232723360-7",
+                "Id": "72057594046678944-7",
                 "MemoryLimit": "not-zero-number-text",
                 "MemoryStats": {},
                 "Metrics": "not-empty-object",
@@ -4638,7 +8153,7 @@
                 "State": "RUNNING",
                 "StateStats": [
                     {
-                        "Count": 9,
+                        "Count": 10,
                         "VolatileState": "TABLET_VOLATILE_STATE_RUNNING"
                     }
                 ],
@@ -4654,7 +8169,7 @@
                     "CoresTotal": "not-zero-number",
                     "CoresUsed": "not-zero-number",
                     "CreateTime": "not-zero-number-text",
-                    "Id": "72075186232723360-1",
+                    "Id": "72057594046678944-1",
                     "MemoryLimit": "not-zero-number-text",
                     "MemoryStats": {},
                     "Metrics": {},
@@ -4705,7 +8220,7 @@
                     "CoresTotal": "not-zero-number",
                     "CoresUsed": "not-zero-number",
                     "DatabaseQuotas": {},
-                    "Id": "72075186232723360-6",
+                    "Id": "72057594046678944-6",
                     "MemoryLimit": "not-zero-number-text",
                     "MemoryStats": {},
                     "Metrics": "not-empty-object",
@@ -4763,7 +8278,7 @@
                     "State": "RUNNING",
                     "StateStats": [
                         {
-                            "Count": 9,
+                            "Count": 10,
                             "VolatileState": "TABLET_VOLATILE_STATE_RUNNING"
                         }
                     ],
@@ -4776,15 +8291,15 @@
                 {
                     "CoresUsed": "not-zero-number",
                     "DatabaseQuotas": {},
-                    "Id": "72075186232723360-8",
+                    "Id": "72057594046678944-8",
                     "Metrics": "not-empty-object",
                     "Name": "/Root/serverless_db",
                     "Owner": "root@builtin",
-                    "ResourceId": "72075186232723360-7",
+                    "ResourceId": "72057594046678944-7",
                     "State": "RUNNING",
                     "StateStats": [
                         {
-                            "Count": 6,
+                            "Count": 7,
                             "VolatileState": "TABLET_VOLATILE_STATE_RUNNING"
                         }
                     ],
@@ -4799,7 +8314,7 @@
                     "CoresTotal": "not-zero-number",
                     "CoresUsed": "not-zero-number",
                     "DatabaseQuotas": {},
-                    "Id": "72075186232723360-7",
+                    "Id": "72057594046678944-7",
                     "MemoryLimit": "not-zero-number-text",
                     "MemoryStats": {},
                     "Metrics": "not-empty-object",
@@ -4850,7 +8365,7 @@
                     "State": "RUNNING",
                     "StateStats": [
                         {
-                            "Count": 9,
+                            "Count": 10,
                             "VolatileState": "TABLET_VOLATILE_STATE_RUNNING"
                         }
                     ],

--- a/ydb/core/viewer/tests/canondata/result.json
+++ b/ydb/core/viewer/tests/canondata/result.json
@@ -3,18 +3,6 @@
         "status_code": 200,
         "text": "1\n"
     },
-    "test.test_operations_list": {
-        "next_page_token": "0",
-        "status": "SUCCESS"
-    },
-    "test.test_operations_list_page": {
-        "next_page_token": "0",
-        "status": "SUCCESS"
-    },
-    "test.test_operations_list_page_bad": {
-        "status_code": 400,
-        "text": "offset must be a multiple of limit"
-    },
     "test.test_pqrb_tablet": {
         "response_create_topic": {
             "version": "not-zero-number"
@@ -36,7 +24,7 @@
                         "PathId": "not-zero-number-text",
                         "SchemeShard": "not-zero-number-text"
                     },
-                    "Type": "PersQueueReadBalancer"
+                    "Type": "PersQueue"
                 },
                 {
                     "ChangeTime": "not-zero-number-text",
@@ -52,307 +40,9 @@
                         "PathId": "not-zero-number-text",
                         "SchemeShard": "not-zero-number-text"
                     },
-                    "Type": "PersQueue"
+                    "Type": "PersQueueReadBalancer"
                 }
             ]
-        }
-    },
-    "test.test_scheme_directory": {
-        "1-get": {
-            "children": [
-                {
-                    "created_at": {
-                        "plan_step": "not-zero-number-text",
-                        "tx_id": "not-zero-number-text"
-                    },
-                    "name": ".metadata",
-                    "owner": "metadata@system",
-                    "type": "DIRECTORY"
-                },
-                {
-                    "created_at": {
-                        "plan_step": "not-zero-number-text",
-                        "tx_id": "not-zero-number-text"
-                    },
-                    "name": "table1",
-                    "owner": "root@builtin",
-                    "type": "TABLE"
-                },
-                {
-                    "created_at": {
-                        "plan_step": "not-zero-number-text",
-                        "tx_id": "not-zero-number-text"
-                    },
-                    "name": "topic1",
-                    "owner": "root@builtin",
-                    "type": "TOPIC"
-                },
-                {
-                    "created_at": {},
-                    "name": ".sys",
-                    "type": "DIRECTORY"
-                }
-            ],
-            "self": {
-                "created_at": {
-                    "tx_id": "not-zero-number-text"
-                },
-                "effective_permissions": [
-                    {
-                        "permission_names": [
-                            "ydb.database.connect"
-                        ],
-                        "subject": "USERS"
-                    },
-                    {
-                        "permission_names": [
-                            "ydb.generic.list"
-                        ],
-                        "subject": "METADATA-READERS"
-                    },
-                    {
-                        "permission_names": [
-                            "ydb.granular.select_row"
-                        ],
-                        "subject": "DATA-READERS"
-                    },
-                    {
-                        "permission_names": [
-                            "ydb.tables.modify"
-                        ],
-                        "subject": "DATA-WRITERS"
-                    },
-                    {
-                        "permission_names": [
-                            "ydb.granular.create_directory",
-                            "ydb.granular.write_attributes",
-                            "ydb.granular.create_table",
-                            "ydb.granular.remove_schema",
-                            "ydb.granular.create_queue",
-                            "ydb.granular.alter_schema"
-                        ],
-                        "subject": "DDL-ADMINS"
-                    },
-                    {
-                        "permission_names": [
-                            "ydb.access.grant"
-                        ],
-                        "subject": "ACCESS-ADMINS"
-                    },
-                    {
-                        "permission_names": [
-                            "ydb.generic.manage"
-                        ],
-                        "subject": "DATABASE-ADMINS"
-                    }
-                ],
-                "name": "Root/dedicated_db",
-                "owner": "user1",
-                "type": "DATABASE"
-            }
-        },
-        "2-post": {
-            "ready": true,
-            "status": "SUCCESS"
-        },
-        "3-get": {
-            "children": [
-                {
-                    "created_at": {
-                        "plan_step": "not-zero-number-text",
-                        "tx_id": "not-zero-number-text"
-                    },
-                    "name": ".metadata",
-                    "owner": "metadata@system",
-                    "type": "DIRECTORY"
-                },
-                {
-                    "created_at": {
-                        "plan_step": "not-zero-number-text",
-                        "tx_id": "not-zero-number-text"
-                    },
-                    "name": "table1",
-                    "owner": "root@builtin",
-                    "type": "TABLE"
-                },
-                {
-                    "created_at": {
-                        "plan_step": "not-zero-number-text",
-                        "tx_id": "not-zero-number-text"
-                    },
-                    "name": "test_dir",
-                    "owner": "root@builtin",
-                    "type": "DIRECTORY"
-                },
-                {
-                    "created_at": {
-                        "plan_step": "not-zero-number-text",
-                        "tx_id": "not-zero-number-text"
-                    },
-                    "name": "topic1",
-                    "owner": "root@builtin",
-                    "type": "TOPIC"
-                },
-                {
-                    "created_at": {},
-                    "name": ".sys",
-                    "type": "DIRECTORY"
-                }
-            ],
-            "self": {
-                "created_at": {
-                    "tx_id": "not-zero-number-text"
-                },
-                "effective_permissions": [
-                    {
-                        "permission_names": [
-                            "ydb.database.connect"
-                        ],
-                        "subject": "USERS"
-                    },
-                    {
-                        "permission_names": [
-                            "ydb.generic.list"
-                        ],
-                        "subject": "METADATA-READERS"
-                    },
-                    {
-                        "permission_names": [
-                            "ydb.granular.select_row"
-                        ],
-                        "subject": "DATA-READERS"
-                    },
-                    {
-                        "permission_names": [
-                            "ydb.tables.modify"
-                        ],
-                        "subject": "DATA-WRITERS"
-                    },
-                    {
-                        "permission_names": [
-                            "ydb.granular.create_directory",
-                            "ydb.granular.write_attributes",
-                            "ydb.granular.create_table",
-                            "ydb.granular.remove_schema",
-                            "ydb.granular.create_queue",
-                            "ydb.granular.alter_schema"
-                        ],
-                        "subject": "DDL-ADMINS"
-                    },
-                    {
-                        "permission_names": [
-                            "ydb.access.grant"
-                        ],
-                        "subject": "ACCESS-ADMINS"
-                    },
-                    {
-                        "permission_names": [
-                            "ydb.generic.manage"
-                        ],
-                        "subject": "DATABASE-ADMINS"
-                    }
-                ],
-                "name": "Root/dedicated_db",
-                "owner": "user1",
-                "type": "DATABASE"
-            }
-        },
-        "4-delete": {
-            "ready": true,
-            "status": "SUCCESS"
-        },
-        "5-get": {
-            "children": [
-                {
-                    "created_at": {
-                        "plan_step": "not-zero-number-text",
-                        "tx_id": "not-zero-number-text"
-                    },
-                    "name": ".metadata",
-                    "owner": "metadata@system",
-                    "type": "DIRECTORY"
-                },
-                {
-                    "created_at": {
-                        "plan_step": "not-zero-number-text",
-                        "tx_id": "not-zero-number-text"
-                    },
-                    "name": "table1",
-                    "owner": "root@builtin",
-                    "type": "TABLE"
-                },
-                {
-                    "created_at": {
-                        "plan_step": "not-zero-number-text",
-                        "tx_id": "not-zero-number-text"
-                    },
-                    "name": "topic1",
-                    "owner": "root@builtin",
-                    "type": "TOPIC"
-                },
-                {
-                    "created_at": {},
-                    "name": ".sys",
-                    "type": "DIRECTORY"
-                }
-            ],
-            "self": {
-                "created_at": {
-                    "tx_id": "not-zero-number-text"
-                },
-                "effective_permissions": [
-                    {
-                        "permission_names": [
-                            "ydb.database.connect"
-                        ],
-                        "subject": "USERS"
-                    },
-                    {
-                        "permission_names": [
-                            "ydb.generic.list"
-                        ],
-                        "subject": "METADATA-READERS"
-                    },
-                    {
-                        "permission_names": [
-                            "ydb.granular.select_row"
-                        ],
-                        "subject": "DATA-READERS"
-                    },
-                    {
-                        "permission_names": [
-                            "ydb.tables.modify"
-                        ],
-                        "subject": "DATA-WRITERS"
-                    },
-                    {
-                        "permission_names": [
-                            "ydb.granular.create_directory",
-                            "ydb.granular.write_attributes",
-                            "ydb.granular.create_table",
-                            "ydb.granular.remove_schema",
-                            "ydb.granular.create_queue",
-                            "ydb.granular.alter_schema"
-                        ],
-                        "subject": "DDL-ADMINS"
-                    },
-                    {
-                        "permission_names": [
-                            "ydb.access.grant"
-                        ],
-                        "subject": "ACCESS-ADMINS"
-                    },
-                    {
-                        "permission_names": [
-                            "ydb.generic.manage"
-                        ],
-                        "subject": "DATABASE-ADMINS"
-                    }
-                ],
-                "name": "Root/dedicated_db",
-                "owner": "user1",
-                "type": "DATABASE"
-            }
         }
     },
     "test.test_storage_groups": {
@@ -632,7 +322,7 @@
                 ]
             },
             {
-                "AllocationUnits": "32",
+                "AllocationUnits": "30",
                 "Available": "not-zero-number-text",
                 "DiskSpaceUsage": "not-zero-number",
                 "ErasureSpecies": "none",
@@ -723,7 +413,7 @@
                 ]
             },
             {
-                "AllocationUnits": "52",
+                "AllocationUnits": "48",
                 "Available": "not-zero-number-text",
                 "DiskSpaceUsage": "not-zero-number",
                 "ErasureSpecies": "none",
@@ -837,7 +527,7 @@
                     "ProducerId": "not-zero-number-text",
                     "SeqNo": 12,
                     "StorageSize": 38,
-                    "TimestampDiff": "number",
+                    "TimestampDiff": "not-zero-number",
                     "WriteTimestamp": "not-zero-number"
                 },
                 {
@@ -849,7 +539,7 @@
                     "ProducerId": "not-zero-number-text",
                     "SeqNo": 13,
                     "StorageSize": 38,
-                    "TimestampDiff": "number",
+                    "TimestampDiff": "not-zero-number",
                     "WriteTimestamp": "not-zero-number"
                 },
                 {
@@ -861,7 +551,7 @@
                     "ProducerId": "not-zero-number-text",
                     "SeqNo": 14,
                     "StorageSize": 38,
-                    "TimestampDiff": "number",
+                    "TimestampDiff": "not-zero-number",
                     "WriteTimestamp": "not-zero-number"
                 },
                 {
@@ -873,7 +563,7 @@
                     "ProducerId": "not-zero-number-text",
                     "SeqNo": 15,
                     "StorageSize": 38,
-                    "TimestampDiff": "number",
+                    "TimestampDiff": "not-zero-number",
                     "WriteTimestamp": "not-zero-number"
                 },
                 {
@@ -885,7 +575,7 @@
                     "ProducerId": "not-zero-number-text",
                     "SeqNo": 16,
                     "StorageSize": 38,
-                    "TimestampDiff": "number",
+                    "TimestampDiff": "not-zero-number",
                     "WriteTimestamp": "not-zero-number"
                 }
             ],
@@ -904,7 +594,7 @@
                     "ProducerId": "not-zero-number-text",
                     "SeqNo": 1,
                     "StorageSize": 9,
-                    "TimestampDiff": "number",
+                    "TimestampDiff": "not-zero-number",
                     "WriteTimestamp": "not-zero-number"
                 },
                 {
@@ -916,7 +606,7 @@
                     "ProducerId": "not-zero-number-text",
                     "SeqNo": 2,
                     "StorageSize": 9,
-                    "TimestampDiff": "number",
+                    "TimestampDiff": "not-zero-number",
                     "WriteTimestamp": "not-zero-number"
                 },
                 {
@@ -928,7 +618,7 @@
                     "ProducerId": "not-zero-number-text",
                     "SeqNo": 3,
                     "StorageSize": 9,
-                    "TimestampDiff": "number",
+                    "TimestampDiff": "not-zero-number",
                     "WriteTimestamp": "not-zero-number"
                 }
             ],
@@ -957,7 +647,7 @@
                     "ProducerId": "not-zero-number-text",
                     "SeqNo": 11,
                     "StorageSize": 37,
-                    "TimestampDiff": "number",
+                    "TimestampDiff": "not-zero-number",
                     "WriteTimestamp": "not-zero-number"
                 }
             ],
@@ -976,7 +666,7 @@
                     "ProducerId": "not-zero-number-text",
                     "SeqNo": 21,
                     "StorageSize": 38,
-                    "TimestampDiff": "number",
+                    "TimestampDiff": "not-zero-number",
                     "WriteTimestamp": "not-zero-number"
                 }
             ],
@@ -995,7 +685,7 @@
                     "ProducerId": "not-zero-number-text",
                     "SeqNo": 1,
                     "StorageSize": 9,
-                    "TimestampDiff": "number",
+                    "TimestampDiff": "not-zero-number",
                     "WriteTimestamp": "not-zero-number"
                 },
                 {
@@ -1007,7 +697,7 @@
                     "ProducerId": "not-zero-number-text",
                     "SeqNo": 2,
                     "StorageSize": 9,
-                    "TimestampDiff": "number",
+                    "TimestampDiff": "not-zero-number",
                     "WriteTimestamp": "not-zero-number"
                 },
                 {
@@ -1019,7 +709,7 @@
                     "ProducerId": "not-zero-number-text",
                     "SeqNo": 3,
                     "StorageSize": 9,
-                    "TimestampDiff": "number",
+                    "TimestampDiff": "not-zero-number",
                     "WriteTimestamp": "not-zero-number"
                 },
                 {
@@ -1031,7 +721,7 @@
                     "ProducerId": "not-zero-number-text",
                     "SeqNo": 4,
                     "StorageSize": 9,
-                    "TimestampDiff": "number",
+                    "TimestampDiff": "not-zero-number",
                     "WriteTimestamp": "not-zero-number"
                 },
                 {
@@ -1043,7 +733,7 @@
                     "ProducerId": "not-zero-number-text",
                     "SeqNo": 5,
                     "StorageSize": 9,
-                    "TimestampDiff": "number",
+                    "TimestampDiff": "not-zero-number",
                     "WriteTimestamp": "not-zero-number"
                 }
             ],
@@ -1062,7 +752,7 @@
                     "ProducerId": "not-zero-number-text",
                     "SeqNo": 21,
                     "StorageSize": 38,
-                    "TimestampDiff": "number",
+                    "TimestampDiff": "not-zero-number",
                     "WriteTimestamp": "not-zero-number"
                 }
             ],
@@ -1155,7 +845,8 @@
                         ],
                         "AccessType": "Allow",
                         "InheritanceType": [
-                            "Inherit"
+                            "Object",
+                            "Container"
                         ],
                         "Subject": "USERS"
                     },
@@ -1166,7 +857,8 @@
                         ],
                         "AccessType": "Allow",
                         "InheritanceType": [
-                            "Inherit"
+                            "Object",
+                            "Container"
                         ],
                         "Subject": "METADATA-READERS"
                     },
@@ -1176,7 +868,8 @@
                         ],
                         "AccessType": "Allow",
                         "InheritanceType": [
-                            "Inherit"
+                            "Object",
+                            "Container"
                         ],
                         "Subject": "DATA-READERS"
                     },
@@ -1187,7 +880,8 @@
                         ],
                         "AccessType": "Allow",
                         "InheritanceType": [
-                            "Inherit"
+                            "Object",
+                            "Container"
                         ],
                         "Subject": "DATA-WRITERS"
                     },
@@ -1202,7 +896,8 @@
                         ],
                         "AccessType": "Allow",
                         "InheritanceType": [
-                            "Inherit"
+                            "Object",
+                            "Container"
                         ],
                         "Subject": "DDL-ADMINS"
                     },
@@ -1212,7 +907,8 @@
                         ],
                         "AccessType": "Allow",
                         "InheritanceType": [
-                            "Inherit"
+                            "Object",
+                            "Container"
                         ],
                         "Subject": "ACCESS-ADMINS"
                     },
@@ -1223,7 +919,8 @@
                         ],
                         "AccessType": "Allow",
                         "InheritanceType": [
-                            "Inherit"
+                            "Object",
+                            "Container"
                         ],
                         "Subject": "DATABASE-ADMINS"
                     }
@@ -1235,7 +932,8 @@
                         ],
                         "AccessType": "Allow",
                         "InheritanceType": [
-                            "Inherit"
+                            "Object",
+                            "Container"
                         ],
                         "Subject": "USERS"
                     },
@@ -1246,7 +944,8 @@
                         ],
                         "AccessType": "Allow",
                         "InheritanceType": [
-                            "Inherit"
+                            "Object",
+                            "Container"
                         ],
                         "Subject": "METADATA-READERS"
                     },
@@ -1256,7 +955,8 @@
                         ],
                         "AccessType": "Allow",
                         "InheritanceType": [
-                            "Inherit"
+                            "Object",
+                            "Container"
                         ],
                         "Subject": "DATA-READERS"
                     },
@@ -1267,7 +967,8 @@
                         ],
                         "AccessType": "Allow",
                         "InheritanceType": [
-                            "Inherit"
+                            "Object",
+                            "Container"
                         ],
                         "Subject": "DATA-WRITERS"
                     },
@@ -1282,7 +983,8 @@
                         ],
                         "AccessType": "Allow",
                         "InheritanceType": [
-                            "Inherit"
+                            "Object",
+                            "Container"
                         ],
                         "Subject": "DDL-ADMINS"
                     },
@@ -1292,7 +994,8 @@
                         ],
                         "AccessType": "Allow",
                         "InheritanceType": [
-                            "Inherit"
+                            "Object",
+                            "Container"
                         ],
                         "Subject": "ACCESS-ADMINS"
                     },
@@ -1303,7 +1006,8 @@
                         ],
                         "AccessType": "Allow",
                         "InheritanceType": [
-                            "Inherit"
+                            "Object",
+                            "Container"
                         ],
                         "Subject": "DATABASE-ADMINS"
                     }
@@ -1321,7 +1025,8 @@
                         ],
                         "AccessType": "Allow",
                         "InheritanceType": [
-                            "Inherit"
+                            "Object",
+                            "Container"
                         ],
                         "Subject": "USERS"
                     },
@@ -1332,7 +1037,8 @@
                         ],
                         "AccessType": "Allow",
                         "InheritanceType": [
-                            "Inherit"
+                            "Object",
+                            "Container"
                         ],
                         "Subject": "METADATA-READERS"
                     },
@@ -1342,7 +1048,8 @@
                         ],
                         "AccessType": "Allow",
                         "InheritanceType": [
-                            "Inherit"
+                            "Object",
+                            "Container"
                         ],
                         "Subject": "DATA-READERS"
                     },
@@ -1353,7 +1060,8 @@
                         ],
                         "AccessType": "Allow",
                         "InheritanceType": [
-                            "Inherit"
+                            "Object",
+                            "Container"
                         ],
                         "Subject": "DATA-WRITERS"
                     },
@@ -1368,7 +1076,8 @@
                         ],
                         "AccessType": "Allow",
                         "InheritanceType": [
-                            "Inherit"
+                            "Object",
+                            "Container"
                         ],
                         "Subject": "DDL-ADMINS"
                     },
@@ -1378,7 +1087,8 @@
                         ],
                         "AccessType": "Allow",
                         "InheritanceType": [
-                            "Inherit"
+                            "Object",
+                            "Container"
                         ],
                         "Subject": "ACCESS-ADMINS"
                     },
@@ -1389,7 +1099,8 @@
                         ],
                         "AccessType": "Allow",
                         "InheritanceType": [
-                            "Inherit"
+                            "Object",
+                            "Container"
                         ],
                         "Subject": "DATABASE-ADMINS"
                     }
@@ -1401,7 +1112,8 @@
                         ],
                         "AccessType": "Allow",
                         "InheritanceType": [
-                            "Inherit"
+                            "Object",
+                            "Container"
                         ],
                         "Subject": "USERS"
                     },
@@ -1412,7 +1124,8 @@
                         ],
                         "AccessType": "Allow",
                         "InheritanceType": [
-                            "Inherit"
+                            "Object",
+                            "Container"
                         ],
                         "Subject": "METADATA-READERS"
                     },
@@ -1422,7 +1135,8 @@
                         ],
                         "AccessType": "Allow",
                         "InheritanceType": [
-                            "Inherit"
+                            "Object",
+                            "Container"
                         ],
                         "Subject": "DATA-READERS"
                     },
@@ -1433,7 +1147,8 @@
                         ],
                         "AccessType": "Allow",
                         "InheritanceType": [
-                            "Inherit"
+                            "Object",
+                            "Container"
                         ],
                         "Subject": "DATA-WRITERS"
                     },
@@ -1448,7 +1163,8 @@
                         ],
                         "AccessType": "Allow",
                         "InheritanceType": [
-                            "Inherit"
+                            "Object",
+                            "Container"
                         ],
                         "Subject": "DDL-ADMINS"
                     },
@@ -1458,7 +1174,8 @@
                         ],
                         "AccessType": "Allow",
                         "InheritanceType": [
-                            "Inherit"
+                            "Object",
+                            "Container"
                         ],
                         "Subject": "ACCESS-ADMINS"
                     },
@@ -1469,7 +1186,8 @@
                         ],
                         "AccessType": "Allow",
                         "InheritanceType": [
-                            "Inherit"
+                            "Object",
+                            "Container"
                         ],
                         "Subject": "DATABASE-ADMINS"
                     }
@@ -1487,7 +1205,8 @@
                         ],
                         "AccessType": "Allow",
                         "InheritanceType": [
-                            "Inherit"
+                            "Object",
+                            "Container"
                         ],
                         "Subject": "USERS"
                     },
@@ -1498,7 +1217,8 @@
                         ],
                         "AccessType": "Allow",
                         "InheritanceType": [
-                            "Inherit"
+                            "Object",
+                            "Container"
                         ],
                         "Subject": "METADATA-READERS"
                     },
@@ -1508,7 +1228,8 @@
                         ],
                         "AccessType": "Allow",
                         "InheritanceType": [
-                            "Inherit"
+                            "Object",
+                            "Container"
                         ],
                         "Subject": "DATA-READERS"
                     },
@@ -1519,7 +1240,8 @@
                         ],
                         "AccessType": "Allow",
                         "InheritanceType": [
-                            "Inherit"
+                            "Object",
+                            "Container"
                         ],
                         "Subject": "DATA-WRITERS"
                     },
@@ -1534,7 +1256,8 @@
                         ],
                         "AccessType": "Allow",
                         "InheritanceType": [
-                            "Inherit"
+                            "Object",
+                            "Container"
                         ],
                         "Subject": "DDL-ADMINS"
                     },
@@ -1544,7 +1267,8 @@
                         ],
                         "AccessType": "Allow",
                         "InheritanceType": [
-                            "Inherit"
+                            "Object",
+                            "Container"
                         ],
                         "Subject": "ACCESS-ADMINS"
                     },
@@ -1555,7 +1279,8 @@
                         ],
                         "AccessType": "Allow",
                         "InheritanceType": [
-                            "Inherit"
+                            "Object",
+                            "Container"
                         ],
                         "Subject": "DATABASE-ADMINS"
                     }
@@ -1567,7 +1292,8 @@
                         ],
                         "AccessType": "Allow",
                         "InheritanceType": [
-                            "Inherit"
+                            "Object",
+                            "Container"
                         ],
                         "Subject": "USERS"
                     },
@@ -1578,7 +1304,8 @@
                         ],
                         "AccessType": "Allow",
                         "InheritanceType": [
-                            "Inherit"
+                            "Object",
+                            "Container"
                         ],
                         "Subject": "METADATA-READERS"
                     },
@@ -1588,7 +1315,8 @@
                         ],
                         "AccessType": "Allow",
                         "InheritanceType": [
-                            "Inherit"
+                            "Object",
+                            "Container"
                         ],
                         "Subject": "DATA-READERS"
                     },
@@ -1599,7 +1327,8 @@
                         ],
                         "AccessType": "Allow",
                         "InheritanceType": [
-                            "Inherit"
+                            "Object",
+                            "Container"
                         ],
                         "Subject": "DATA-WRITERS"
                     },
@@ -1614,7 +1343,8 @@
                         ],
                         "AccessType": "Allow",
                         "InheritanceType": [
-                            "Inherit"
+                            "Object",
+                            "Container"
                         ],
                         "Subject": "DDL-ADMINS"
                     },
@@ -1624,7 +1354,8 @@
                         ],
                         "AccessType": "Allow",
                         "InheritanceType": [
-                            "Inherit"
+                            "Object",
+                            "Container"
                         ],
                         "Subject": "ACCESS-ADMINS"
                     },
@@ -1635,7 +1366,8 @@
                         ],
                         "AccessType": "Allow",
                         "InheritanceType": [
-                            "Inherit"
+                            "Object",
+                            "Container"
                         ],
                         "Subject": "DATABASE-ADMINS"
                     }
@@ -1653,7 +1385,8 @@
                         ],
                         "AccessType": "Allow",
                         "InheritanceType": [
-                            "Inherit"
+                            "Object",
+                            "Container"
                         ],
                         "Subject": "USERS"
                     },
@@ -1664,7 +1397,8 @@
                         ],
                         "AccessType": "Allow",
                         "InheritanceType": [
-                            "Inherit"
+                            "Object",
+                            "Container"
                         ],
                         "Subject": "METADATA-READERS"
                     },
@@ -1674,7 +1408,8 @@
                         ],
                         "AccessType": "Allow",
                         "InheritanceType": [
-                            "Inherit"
+                            "Object",
+                            "Container"
                         ],
                         "Subject": "DATA-READERS"
                     },
@@ -1685,7 +1420,8 @@
                         ],
                         "AccessType": "Allow",
                         "InheritanceType": [
-                            "Inherit"
+                            "Object",
+                            "Container"
                         ],
                         "Subject": "DATA-WRITERS"
                     },
@@ -1700,7 +1436,8 @@
                         ],
                         "AccessType": "Allow",
                         "InheritanceType": [
-                            "Inherit"
+                            "Object",
+                            "Container"
                         ],
                         "Subject": "DDL-ADMINS"
                     },
@@ -1710,7 +1447,8 @@
                         ],
                         "AccessType": "Allow",
                         "InheritanceType": [
-                            "Inherit"
+                            "Object",
+                            "Container"
                         ],
                         "Subject": "ACCESS-ADMINS"
                     },
@@ -1721,7 +1459,8 @@
                         ],
                         "AccessType": "Allow",
                         "InheritanceType": [
-                            "Inherit"
+                            "Object",
+                            "Container"
                         ],
                         "Subject": "DATABASE-ADMINS"
                     }
@@ -1733,7 +1472,8 @@
                         ],
                         "AccessType": "Allow",
                         "InheritanceType": [
-                            "Inherit"
+                            "Object",
+                            "Container"
                         ],
                         "Subject": "USERS"
                     },
@@ -1744,7 +1484,8 @@
                         ],
                         "AccessType": "Allow",
                         "InheritanceType": [
-                            "Inherit"
+                            "Object",
+                            "Container"
                         ],
                         "Subject": "METADATA-READERS"
                     },
@@ -1754,7 +1495,8 @@
                         ],
                         "AccessType": "Allow",
                         "InheritanceType": [
-                            "Inherit"
+                            "Object",
+                            "Container"
                         ],
                         "Subject": "DATA-READERS"
                     },
@@ -1765,7 +1507,8 @@
                         ],
                         "AccessType": "Allow",
                         "InheritanceType": [
-                            "Inherit"
+                            "Object",
+                            "Container"
                         ],
                         "Subject": "DATA-WRITERS"
                     },
@@ -1780,7 +1523,8 @@
                         ],
                         "AccessType": "Allow",
                         "InheritanceType": [
-                            "Inherit"
+                            "Object",
+                            "Container"
                         ],
                         "Subject": "DDL-ADMINS"
                     },
@@ -1790,7 +1534,8 @@
                         ],
                         "AccessType": "Allow",
                         "InheritanceType": [
-                            "Inherit"
+                            "Object",
+                            "Container"
                         ],
                         "Subject": "ACCESS-ADMINS"
                     },
@@ -1801,7 +1546,8 @@
                         ],
                         "AccessType": "Allow",
                         "InheritanceType": [
-                            "Inherit"
+                            "Object",
+                            "Container"
                         ],
                         "Subject": "DATABASE-ADMINS"
                     }
@@ -1811,295 +1557,6 @@
             }
         }
     },
-    "test.test_viewer_acl_write": [
-        {},
-        {
-            "Common": {
-                "ACL": [
-                    {
-                        "AccessRights": [
-                            "SelectRow",
-                            "ReadAttributes",
-                            "DescribeSchema"
-                        ],
-                        "AccessType": "Allow",
-                        "InheritanceType": [
-                            "Inherit"
-                        ],
-                        "Subject": "user1"
-                    }
-                ],
-                "EffectiveACL": [
-                    {
-                        "AccessRights": [
-                            "ConnectDatabase"
-                        ],
-                        "AccessType": "Allow",
-                        "InheritanceType": [
-                            "Inherit"
-                        ],
-                        "Subject": "USERS"
-                    },
-                    {
-                        "AccessRights": [
-                            "ReadAttributes",
-                            "DescribeSchema"
-                        ],
-                        "AccessType": "Allow",
-                        "InheritanceType": [
-                            "Inherit"
-                        ],
-                        "Subject": "METADATA-READERS"
-                    },
-                    {
-                        "AccessRights": [
-                            "SelectRow"
-                        ],
-                        "AccessType": "Allow",
-                        "InheritanceType": [
-                            "Inherit"
-                        ],
-                        "Subject": "DATA-READERS"
-                    },
-                    {
-                        "AccessRights": [
-                            "UpdateRow",
-                            "EraseRow"
-                        ],
-                        "AccessType": "Allow",
-                        "InheritanceType": [
-                            "Inherit"
-                        ],
-                        "Subject": "DATA-WRITERS"
-                    },
-                    {
-                        "AccessRights": [
-                            "WriteAttributes",
-                            "CreateDirectory",
-                            "CreateTable",
-                            "CreateQueue",
-                            "RemoveSchema",
-                            "AlterSchema"
-                        ],
-                        "AccessType": "Allow",
-                        "InheritanceType": [
-                            "Inherit"
-                        ],
-                        "Subject": "DDL-ADMINS"
-                    },
-                    {
-                        "AccessRights": [
-                            "GrantAccessRights"
-                        ],
-                        "AccessType": "Allow",
-                        "InheritanceType": [
-                            "Inherit"
-                        ],
-                        "Subject": "ACCESS-ADMINS"
-                    },
-                    {
-                        "AccessRights": [
-                            "CreateDatabase",
-                            "DropDatabase"
-                        ],
-                        "AccessType": "Allow",
-                        "InheritanceType": [
-                            "Inherit"
-                        ],
-                        "Subject": "DATABASE-ADMINS"
-                    },
-                    {
-                        "AccessRights": [
-                            "SelectRow",
-                            "ReadAttributes",
-                            "DescribeSchema"
-                        ],
-                        "AccessType": "Allow",
-                        "InheritanceType": [
-                            "Inherit"
-                        ],
-                        "Subject": "user1"
-                    }
-                ],
-                "Owner": "root@builtin",
-                "Path": "/Root/dedicated_db"
-            }
-        },
-        {},
-        {
-            "Common": {
-                "EffectiveACL": [
-                    {
-                        "AccessRights": [
-                            "ConnectDatabase"
-                        ],
-                        "AccessType": "Allow",
-                        "InheritanceType": [
-                            "Inherit"
-                        ],
-                        "Subject": "USERS"
-                    },
-                    {
-                        "AccessRights": [
-                            "ReadAttributes",
-                            "DescribeSchema"
-                        ],
-                        "AccessType": "Allow",
-                        "InheritanceType": [
-                            "Inherit"
-                        ],
-                        "Subject": "METADATA-READERS"
-                    },
-                    {
-                        "AccessRights": [
-                            "SelectRow"
-                        ],
-                        "AccessType": "Allow",
-                        "InheritanceType": [
-                            "Inherit"
-                        ],
-                        "Subject": "DATA-READERS"
-                    },
-                    {
-                        "AccessRights": [
-                            "UpdateRow",
-                            "EraseRow"
-                        ],
-                        "AccessType": "Allow",
-                        "InheritanceType": [
-                            "Inherit"
-                        ],
-                        "Subject": "DATA-WRITERS"
-                    },
-                    {
-                        "AccessRights": [
-                            "WriteAttributes",
-                            "CreateDirectory",
-                            "CreateTable",
-                            "CreateQueue",
-                            "RemoveSchema",
-                            "AlterSchema"
-                        ],
-                        "AccessType": "Allow",
-                        "InheritanceType": [
-                            "Inherit"
-                        ],
-                        "Subject": "DDL-ADMINS"
-                    },
-                    {
-                        "AccessRights": [
-                            "GrantAccessRights"
-                        ],
-                        "AccessType": "Allow",
-                        "InheritanceType": [
-                            "Inherit"
-                        ],
-                        "Subject": "ACCESS-ADMINS"
-                    },
-                    {
-                        "AccessRights": [
-                            "CreateDatabase",
-                            "DropDatabase"
-                        ],
-                        "AccessType": "Allow",
-                        "InheritanceType": [
-                            "Inherit"
-                        ],
-                        "Subject": "DATABASE-ADMINS"
-                    }
-                ],
-                "Owner": "root@builtin",
-                "Path": "/Root/dedicated_db"
-            }
-        },
-        {},
-        {
-            "Common": {
-                "EffectiveACL": [
-                    {
-                        "AccessRights": [
-                            "ConnectDatabase"
-                        ],
-                        "AccessType": "Allow",
-                        "InheritanceType": [
-                            "Inherit"
-                        ],
-                        "Subject": "USERS"
-                    },
-                    {
-                        "AccessRights": [
-                            "ReadAttributes",
-                            "DescribeSchema"
-                        ],
-                        "AccessType": "Allow",
-                        "InheritanceType": [
-                            "Inherit"
-                        ],
-                        "Subject": "METADATA-READERS"
-                    },
-                    {
-                        "AccessRights": [
-                            "SelectRow"
-                        ],
-                        "AccessType": "Allow",
-                        "InheritanceType": [
-                            "Inherit"
-                        ],
-                        "Subject": "DATA-READERS"
-                    },
-                    {
-                        "AccessRights": [
-                            "UpdateRow",
-                            "EraseRow"
-                        ],
-                        "AccessType": "Allow",
-                        "InheritanceType": [
-                            "Inherit"
-                        ],
-                        "Subject": "DATA-WRITERS"
-                    },
-                    {
-                        "AccessRights": [
-                            "WriteAttributes",
-                            "CreateDirectory",
-                            "CreateTable",
-                            "CreateQueue",
-                            "RemoveSchema",
-                            "AlterSchema"
-                        ],
-                        "AccessType": "Allow",
-                        "InheritanceType": [
-                            "Inherit"
-                        ],
-                        "Subject": "DDL-ADMINS"
-                    },
-                    {
-                        "AccessRights": [
-                            "GrantAccessRights"
-                        ],
-                        "AccessType": "Allow",
-                        "InheritanceType": [
-                            "Inherit"
-                        ],
-                        "Subject": "ACCESS-ADMINS"
-                    },
-                    {
-                        "AccessRights": [
-                            "CreateDatabase",
-                            "DropDatabase"
-                        ],
-                        "AccessType": "Allow",
-                        "InheritanceType": [
-                            "Inherit"
-                        ],
-                        "Subject": "DATABASE-ADMINS"
-                    }
-                ],
-                "Owner": "user1",
-                "Path": "/Root/dedicated_db"
-            }
-        }
-    ],
     "test.test_viewer_autocomplete": {
         "/Root": {
             "Result": {
@@ -2130,28 +1587,18 @@
             "Result": {
                 "Entities": [
                     {
-                        "Name": "table1",
-                        "Type": "table"
-                    },
-                    {
                         "Name": ".metadata",
                         "Type": "dir"
                     }
                 ],
-                "Total": 2
+                "Total": 1
             },
             "Success": true,
             "Version": 2
         },
         "/Root/serverless_db": {
             "Result": {
-                "Entities": [
-                    {
-                        "Name": "table1",
-                        "Type": "table"
-                    }
-                ],
-                "Total": 1
+                "Total": 0
             },
             "Success": true,
             "Version": 2
@@ -2160,15 +1607,11 @@
             "Result": {
                 "Entities": [
                     {
-                        "Name": "table1",
-                        "Type": "table"
-                    },
-                    {
                         "Name": ".metadata",
                         "Type": "dir"
                     }
                 ],
-                "Total": 2
+                "Total": 1
             },
             "Success": true,
             "Version": 2
@@ -2298,8 +1741,8 @@
         "Hosts": "2",
         "LoadAverage": "not-zero-number",
         "MapDataCenters": {
-            "": 2,
-            "1": 1
+            "1": 1,
+            "value": 2
         },
         "MapNodeRoles": {
             "Bootstrapper": 1,
@@ -2394,7 +1837,7 @@
                         "PathId": "not-zero-number-text",
                         "PathState": 2,
                         "PathType": 1,
-                        "SchemeshardId": "72057594046678944"
+                        "SchemeshardId": "72075186232723360"
                     },
                     {
                         "ACL": "",
@@ -2407,7 +1850,7 @@
                         "PathId": "not-zero-number-text",
                         "PathState": 2,
                         "PathType": 10,
-                        "SchemeshardId": "72057594046678944"
+                        "SchemeshardId": "72075186232723360"
                     },
                     {
                         "ACL": "",
@@ -2420,7 +1863,7 @@
                         "PathId": "not-zero-number-text",
                         "PathState": 3,
                         "PathType": 10,
-                        "SchemeshardId": "72057594046678944"
+                        "SchemeshardId": "72075186232723360"
                     },
                     {
                         "ACL": "",
@@ -2433,7 +1876,7 @@
                         "PathId": "not-zero-number-text",
                         "PathState": 2,
                         "PathType": 10,
-                        "SchemeshardId": "72057594046678944"
+                        "SchemeshardId": "72075186232723360"
                     },
                     {
                         "CreateFinished": true,
@@ -2441,14 +1884,14 @@
                         "CreateTxId": "0",
                         "Name": ".sys",
                         "PathType": 1,
-                        "SchemeshardId": "72057594046678944"
+                        "SchemeshardId": "72075186232723360"
                     }
                 ],
                 "DomainDescription": {
                     "DiskSpaceUsage": "not-empty-object",
                     "DomainKey": {
                         "PathId": "not-zero-number-text",
-                        "SchemeShard": "72057594046678944"
+                        "SchemeShard": "72075186232723360"
                     },
                     "PQPartitionsInside": "0",
                     "PQPartitionsLimit": "1000000",
@@ -2467,29 +1910,9 @@
                     },
                     "ResourcesDomainKey": {
                         "PathId": "not-zero-number-text",
-                        "SchemeShard": "72057594046678944"
+                        "SchemeShard": "72075186232723360"
                     },
-                    "SchemeLimits": {
-                        "ExtraPathSymbolsAllowed": "!\"#$%&'()*+,-.:;<=>?@[\\]^_`{|}~",
-                        "MaxAclBytesSize": "10240",
-                        "MaxChildrenInDir": "100000",
-                        "MaxColumnTableColumns": "10000",
-                        "MaxConsistentCopyTargets": "10000",
-                        "MaxDepth": "32",
-                        "MaxExports": "10",
-                        "MaxImports": "10",
-                        "MaxPQPartitions": "1000000",
-                        "MaxPathElementLength": "255",
-                        "MaxPaths": "10000",
-                        "MaxShards": "200000",
-                        "MaxShardsInPath": "35000",
-                        "MaxTableCdcStreams": "5",
-                        "MaxTableColumnNameLength": "255",
-                        "MaxTableColumns": "200",
-                        "MaxTableIndices": "20",
-                        "MaxTableKeyColumns": "30"
-                    },
-                    "SchemeShardId_Depricated": "72057594046678944",
+                    "SchemeShardId_Depricated": "72075186232723360",
                     "SecurityState": {
                         "Audience": "/Root",
                         "Sids": [
@@ -2587,11 +2010,11 @@
                     "PathSubType": 0,
                     "PathType": 1,
                     "PathVersion": "12",
-                    "SchemeshardId": "72057594046678944"
+                    "SchemeshardId": "72075186232723360"
                 }
             },
             "PathId": "not-zero-number-text",
-            "PathOwnerId": "72057594046678944",
+            "PathOwnerId": "72075186232723360",
             "Source": 1,
             "Status": "StatusSuccess"
         },
@@ -2610,22 +2033,8 @@
                         "Owner": "metadata@system",
                         "ParentPathId": "1",
                         "PathId": "not-zero-number-text",
-                        "PathState": 2,
-                        "PathType": 1,
-                        "SchemeshardId": "72075186224037897"
-                    },
-                    {
-                        "ACL": "",
-                        "ChildrenExist": false,
-                        "CreateFinished": true,
-                        "CreateStep": "not-zero-number-text",
-                        "CreateTxId": "not-zero-number-text",
-                        "Name": "table1",
-                        "Owner": "root@builtin",
-                        "ParentPathId": "1",
-                        "PathId": "not-zero-number-text",
                         "PathState": 3,
-                        "PathType": 2,
+                        "PathType": 1,
                         "SchemeshardId": "72075186224037897"
                     },
                     {
@@ -2641,12 +2050,12 @@
                     "DiskSpaceUsage": "not-empty-object",
                     "DomainKey": {
                         "PathId": "not-zero-number-text",
-                        "SchemeShard": "72057594046678944"
+                        "SchemeShard": "72075186232723360"
                     },
                     "PQPartitionsInside": "0",
                     "PQPartitionsLimit": "1000000",
                     "PathId_Depricated": "6",
-                    "PathsInside": "5",
+                    "PathsInside": "4",
                     "PathsLimit": "10000",
                     "ProcessingParams": {
                         "Coordinators": [
@@ -2668,33 +2077,13 @@
                     },
                     "ResourcesDomainKey": {
                         "PathId": "not-zero-number-text",
-                        "SchemeShard": "72057594046678944"
+                        "SchemeShard": "72075186232723360"
                     },
-                    "SchemeLimits": {
-                        "ExtraPathSymbolsAllowed": "!\"#$%&'()*+,-.:;<=>?@[\\]^_`{|}~",
-                        "MaxAclBytesSize": "10240",
-                        "MaxChildrenInDir": "100000",
-                        "MaxColumnTableColumns": "10000",
-                        "MaxConsistentCopyTargets": "10000",
-                        "MaxDepth": "32",
-                        "MaxExports": "10",
-                        "MaxImports": "10",
-                        "MaxPQPartitions": "1000000",
-                        "MaxPathElementLength": "255",
-                        "MaxPaths": "10000",
-                        "MaxShards": "200000",
-                        "MaxShardsInPath": "35000",
-                        "MaxTableCdcStreams": "5",
-                        "MaxTableColumnNameLength": "255",
-                        "MaxTableColumns": "200",
-                        "MaxTableIndices": "20",
-                        "MaxTableKeyColumns": "30"
-                    },
-                    "SchemeShardId_Depricated": "72057594046678944",
+                    "SchemeShardId_Depricated": "72075186232723360",
                     "SecurityState": {
                         "Audience": "/Root/dedicated_db"
                     },
-                    "ShardsInside": "11",
+                    "ShardsInside": "10",
                     "ShardsLimit": "200000",
                     "StoragePools": [
                         {
@@ -2716,7 +2105,7 @@
                     "PathState": 2,
                     "PathSubType": 0,
                     "PathType": 4,
-                    "PathVersion": "10",
+                    "PathVersion": "8",
                     "SchemeshardId": "72075186224037897"
                 }
             },
@@ -2731,20 +2120,6 @@
             "PathDescription": {
                 "Children": [
                     {
-                        "ACL": "",
-                        "ChildrenExist": false,
-                        "CreateFinished": true,
-                        "CreateStep": "not-zero-number-text",
-                        "CreateTxId": "not-zero-number-text",
-                        "Name": "table1",
-                        "Owner": "root@builtin",
-                        "ParentPathId": "1",
-                        "PathId": "not-zero-number-text",
-                        "PathState": 3,
-                        "PathType": 2,
-                        "SchemeshardId": "72075186224038899"
-                    },
-                    {
                         "CreateFinished": true,
                         "CreateStep": "0",
                         "CreateTxId": "0",
@@ -2757,12 +2132,12 @@
                     "DiskSpaceUsage": "not-empty-object",
                     "DomainKey": {
                         "PathId": "not-zero-number-text",
-                        "SchemeShard": "72057594046678944"
+                        "SchemeShard": "72075186232723360"
                     },
                     "PQPartitionsInside": "0",
                     "PQPartitionsLimit": "1000000",
                     "PathId_Depricated": "8",
-                    "PathsInside": "1",
+                    "PathsInside": "0",
                     "PathsLimit": "10000",
                     "ProcessingParams": {
                         "Coordinators": [
@@ -2780,34 +2155,14 @@
                     },
                     "ResourcesDomainKey": {
                         "PathId": "not-zero-number-text",
-                        "SchemeShard": "72057594046678944"
+                        "SchemeShard": "72075186232723360"
                     },
-                    "SchemeLimits": {
-                        "ExtraPathSymbolsAllowed": "!\"#$%&'()*+,-.:;<=>?@[\\]^_`{|}~",
-                        "MaxAclBytesSize": "10240",
-                        "MaxChildrenInDir": "100000",
-                        "MaxColumnTableColumns": "10000",
-                        "MaxConsistentCopyTargets": "10000",
-                        "MaxDepth": "32",
-                        "MaxExports": "10",
-                        "MaxImports": "10",
-                        "MaxPQPartitions": "1000000",
-                        "MaxPathElementLength": "255",
-                        "MaxPaths": "10000",
-                        "MaxShards": "200000",
-                        "MaxShardsInPath": "35000",
-                        "MaxTableCdcStreams": "5",
-                        "MaxTableColumnNameLength": "255",
-                        "MaxTableColumns": "200",
-                        "MaxTableIndices": "20",
-                        "MaxTableKeyColumns": "30"
-                    },
-                    "SchemeShardId_Depricated": "72057594046678944",
+                    "SchemeShardId_Depricated": "72075186232723360",
                     "SecurityState": {
                         "Audience": "/Root/serverless_db"
                     },
                     "ServerlessComputeResourcesMode": 1,
-                    "ShardsInside": "7",
+                    "ShardsInside": "6",
                     "ShardsLimit": "200000",
                     "SharedHive": "72075186224038889",
                     "StoragePools": [
@@ -2830,7 +2185,7 @@
                     "PathState": 2,
                     "PathSubType": 0,
                     "PathType": 4,
-                    "PathVersion": "6",
+                    "PathVersion": "4",
                     "SchemeshardId": "72075186224038899"
                 }
             },
@@ -2854,22 +2209,8 @@
                         "Owner": "metadata@system",
                         "ParentPathId": "1",
                         "PathId": "not-zero-number-text",
-                        "PathState": 2,
-                        "PathType": 1,
-                        "SchemeshardId": "72075186224038898"
-                    },
-                    {
-                        "ACL": "",
-                        "ChildrenExist": false,
-                        "CreateFinished": true,
-                        "CreateStep": "not-zero-number-text",
-                        "CreateTxId": "not-zero-number-text",
-                        "Name": "table1",
-                        "Owner": "root@builtin",
-                        "ParentPathId": "1",
-                        "PathId": "not-zero-number-text",
                         "PathState": 3,
-                        "PathType": 2,
+                        "PathType": 1,
                         "SchemeshardId": "72075186224038898"
                     },
                     {
@@ -2885,12 +2226,12 @@
                     "DiskSpaceUsage": "not-empty-object",
                     "DomainKey": {
                         "PathId": "not-zero-number-text",
-                        "SchemeShard": "72057594046678944"
+                        "SchemeShard": "72075186232723360"
                     },
                     "PQPartitionsInside": "0",
                     "PQPartitionsLimit": "1000000",
                     "PathId_Depricated": "7",
-                    "PathsInside": "5",
+                    "PathsInside": "4",
                     "PathsLimit": "10000",
                     "ProcessingParams": {
                         "Coordinators": [
@@ -2912,33 +2253,13 @@
                     },
                     "ResourcesDomainKey": {
                         "PathId": "not-zero-number-text",
-                        "SchemeShard": "72057594046678944"
+                        "SchemeShard": "72075186232723360"
                     },
-                    "SchemeLimits": {
-                        "ExtraPathSymbolsAllowed": "!\"#$%&'()*+,-.:;<=>?@[\\]^_`{|}~",
-                        "MaxAclBytesSize": "10240",
-                        "MaxChildrenInDir": "100000",
-                        "MaxColumnTableColumns": "10000",
-                        "MaxConsistentCopyTargets": "10000",
-                        "MaxDepth": "32",
-                        "MaxExports": "10",
-                        "MaxImports": "10",
-                        "MaxPQPartitions": "1000000",
-                        "MaxPathElementLength": "255",
-                        "MaxPaths": "10000",
-                        "MaxShards": "200000",
-                        "MaxShardsInPath": "35000",
-                        "MaxTableCdcStreams": "5",
-                        "MaxTableColumnNameLength": "255",
-                        "MaxTableColumns": "200",
-                        "MaxTableIndices": "20",
-                        "MaxTableKeyColumns": "30"
-                    },
-                    "SchemeShardId_Depricated": "72057594046678944",
+                    "SchemeShardId_Depricated": "72075186232723360",
                     "SecurityState": {
                         "Audience": "/Root/shared_db"
                     },
-                    "ShardsInside": "11",
+                    "ShardsInside": "10",
                     "ShardsLimit": "200000",
                     "StoragePools": [
                         {
@@ -2960,7 +2281,7 @@
                     "PathState": 2,
                     "PathSubType": 0,
                     "PathType": 4,
-                    "PathVersion": "10",
+                    "PathVersion": "8",
                     "SchemeshardId": "72075186224038898"
                 }
             },
@@ -3006,317 +2327,6 @@
     },
     "test.test_viewer_nodes": {
         "/Root": {
-            "FieldsAvailable": "0000000010000110111111100000111",
-            "FieldsRequired": "0000000000000000000000000000101",
-            "FoundNodes": "1",
-            "Nodes": [
-                {
-                    "NodeId": 1,
-                    "SystemState": {
-                        "ChangeTime": "not-zero-number-text",
-                        "CoresTotal": "not-zero-number",
-                        "CoresUsed": "not-zero-number",
-                        "Endpoints": [
-                            {
-                                "Address": "text",
-                                "Name": "grpc"
-                            },
-                            {
-                                "Address": "text",
-                                "Name": "http-mon"
-                            },
-                            {
-                                "Address": "text",
-                                "Name": "ic"
-                            }
-                        ],
-                        "Host": "text",
-                        "LoadAverage": "not-empty-array",
-                        "Location": {
-                            "DataCenter": "1",
-                            "Rack": "1",
-                            "Unit": "1"
-                        },
-                        "MaxDiskUsage": "not-zero-number",
-                        "MemoryLimit": "not-zero-number-text",
-                        "NodeId": 1,
-                        "NumberOfCpus": "not-zero-number",
-                        "PoolStats": [
-                            {
-                                "Limit": "not-zero-number",
-                                "Name": "System",
-                                "Threads": 2,
-                                "Usage": "number"
-                            },
-                            {
-                                "Limit": "not-zero-number",
-                                "Name": "User",
-                                "Threads": 3,
-                                "Usage": "number"
-                            },
-                            {
-                                "Limit": "not-zero-number",
-                                "Name": "Batch",
-                                "Threads": 2,
-                                "Usage": "number"
-                            },
-                            {
-                                "Limit": "not-zero-number",
-                                "Name": "IO",
-                                "Threads": 1,
-                                "Usage": "number"
-                            },
-                            {
-                                "Limit": "not-zero-number",
-                                "Name": "IC",
-                                "Threads": 1,
-                                "Usage": "number"
-                            }
-                        ],
-                        "RealNumberOfCpus": "not-zero-number",
-                        "Roles": "not-empty-array",
-                        "StartTime": "not-zero-number-text",
-                        "SystemState": "Green",
-                        "TotalSessions": "number"
-                    }
-                }
-            ],
-            "TotalNodes": "1"
-        },
-        "/Root/dedicated_db": {
-            "FieldsAvailable": "0000000010000110111111100000111",
-            "FieldsRequired": "0000000000000000000000000000101",
-            "FoundNodes": "1",
-            "Nodes": [
-                {
-                    "NodeId": 50000,
-                    "SystemState": {
-                        "ChangeTime": "not-zero-number-text",
-                        "CoresTotal": "not-zero-number",
-                        "CoresUsed": "not-zero-number",
-                        "Endpoints": [
-                            {
-                                "Address": "text",
-                                "Name": "grpc"
-                            },
-                            {
-                                "Address": "text",
-                                "Name": "http-mon"
-                            },
-                            {
-                                "Address": "text",
-                                "Name": "ic"
-                            }
-                        ],
-                        "Host": "text",
-                        "LoadAverage": "not-empty-array",
-                        "Location": {},
-                        "MemoryLimit": "not-zero-number-text",
-                        "NodeId": 50000,
-                        "NumberOfCpus": "not-zero-number",
-                        "PoolStats": [
-                            {
-                                "Limit": "not-zero-number",
-                                "Name": "System",
-                                "Threads": 2,
-                                "Usage": "number"
-                            },
-                            {
-                                "Limit": "not-zero-number",
-                                "Name": "User",
-                                "Threads": 3,
-                                "Usage": "number"
-                            },
-                            {
-                                "Limit": "not-zero-number",
-                                "Name": "Batch",
-                                "Threads": 2,
-                                "Usage": "number"
-                            },
-                            {
-                                "Limit": "not-zero-number",
-                                "Name": "IO",
-                                "Threads": 1,
-                                "Usage": "number"
-                            },
-                            {
-                                "Limit": "not-zero-number",
-                                "Name": "IC",
-                                "Threads": 1,
-                                "Usage": "number"
-                            }
-                        ],
-                        "RealNumberOfCpus": "not-zero-number",
-                        "Roles": "not-empty-array",
-                        "StartTime": "not-zero-number-text",
-                        "SystemState": "Green",
-                        "Tenants": [
-                            "/Root/dedicated_db"
-                        ],
-                        "TotalSessions": "number"
-                    }
-                }
-            ],
-            "TotalNodes": "1"
-        },
-        "/Root/serverless_db": {
-            "FieldsAvailable": "0000000010000110111111100000111",
-            "FieldsRequired": "0000000000000000000000000000101",
-            "FoundNodes": "1",
-            "Nodes": [
-                {
-                    "NodeId": 50001,
-                    "SystemState": {
-                        "ChangeTime": "not-zero-number-text",
-                        "CoresTotal": "not-zero-number",
-                        "CoresUsed": "not-zero-number",
-                        "Endpoints": [
-                            {
-                                "Address": "text",
-                                "Name": "grpc"
-                            },
-                            {
-                                "Address": "text",
-                                "Name": "http-mon"
-                            },
-                            {
-                                "Address": "text",
-                                "Name": "ic"
-                            }
-                        ],
-                        "Host": "text",
-                        "LoadAverage": "not-empty-array",
-                        "Location": {},
-                        "MemoryLimit": "not-zero-number-text",
-                        "NodeId": 50001,
-                        "NumberOfCpus": "not-zero-number",
-                        "PoolStats": [
-                            {
-                                "Limit": "not-zero-number",
-                                "Name": "System",
-                                "Threads": 2,
-                                "Usage": "number"
-                            },
-                            {
-                                "Limit": "not-zero-number",
-                                "Name": "User",
-                                "Threads": 3,
-                                "Usage": "number"
-                            },
-                            {
-                                "Limit": "not-zero-number",
-                                "Name": "Batch",
-                                "Threads": 2,
-                                "Usage": "number"
-                            },
-                            {
-                                "Limit": "not-zero-number",
-                                "Name": "IO",
-                                "Threads": 1,
-                                "Usage": "number"
-                            },
-                            {
-                                "Limit": "not-zero-number",
-                                "Name": "IC",
-                                "Threads": 1,
-                                "Usage": "number"
-                            }
-                        ],
-                        "RealNumberOfCpus": "not-zero-number",
-                        "Roles": "not-empty-array",
-                        "StartTime": "not-zero-number-text",
-                        "SystemState": "Green",
-                        "Tenants": [
-                            "/Root/shared_db"
-                        ],
-                        "TotalSessions": "number"
-                    }
-                }
-            ],
-            "Problems": [
-                "no-database-board-info"
-            ],
-            "TotalNodes": "1"
-        },
-        "/Root/shared_db": {
-            "FieldsAvailable": "0000000010000110111111100000111",
-            "FieldsRequired": "0000000000000000000000000000101",
-            "FoundNodes": "1",
-            "Nodes": [
-                {
-                    "NodeId": 50001,
-                    "SystemState": {
-                        "ChangeTime": "not-zero-number-text",
-                        "CoresTotal": "not-zero-number",
-                        "CoresUsed": "not-zero-number",
-                        "Endpoints": [
-                            {
-                                "Address": "text",
-                                "Name": "grpc"
-                            },
-                            {
-                                "Address": "text",
-                                "Name": "http-mon"
-                            },
-                            {
-                                "Address": "text",
-                                "Name": "ic"
-                            }
-                        ],
-                        "Host": "text",
-                        "LoadAverage": "not-empty-array",
-                        "Location": {},
-                        "MemoryLimit": "not-zero-number-text",
-                        "NodeId": 50001,
-                        "NumberOfCpus": "not-zero-number",
-                        "PoolStats": [
-                            {
-                                "Limit": "not-zero-number",
-                                "Name": "System",
-                                "Threads": 2,
-                                "Usage": "number"
-                            },
-                            {
-                                "Limit": "not-zero-number",
-                                "Name": "User",
-                                "Threads": 3,
-                                "Usage": "number"
-                            },
-                            {
-                                "Limit": "not-zero-number",
-                                "Name": "Batch",
-                                "Threads": 2,
-                                "Usage": "number"
-                            },
-                            {
-                                "Limit": "not-zero-number",
-                                "Name": "IO",
-                                "Threads": 1,
-                                "Usage": "number"
-                            },
-                            {
-                                "Limit": "not-zero-number",
-                                "Name": "IC",
-                                "Threads": 1,
-                                "Usage": "number"
-                            }
-                        ],
-                        "RealNumberOfCpus": "not-zero-number",
-                        "Roles": "not-empty-array",
-                        "StartTime": "not-zero-number-text",
-                        "SystemState": "Green",
-                        "Tenants": [
-                            "/Root/shared_db"
-                        ],
-                        "TotalSessions": "number"
-                    }
-                }
-            ],
-            "TotalNodes": "1"
-        }
-    },
-    "test.test_viewer_nodes_all": {
-        "/Root": {
             "FieldsAvailable": "1111111110111111111111111111111",
             "FieldsRequired": "1111111111111111111111111111111",
             "FoundNodes": "1",
@@ -3330,7 +2340,6 @@
                     "ConnectStatus": "Green",
                     "Connections": "not-zero-number",
                     "CpuUsage": "not-zero-number",
-                    "Database": "/Root",
                     "DiskSpaceUsage": "not-zero-number",
                     "NetworkUtilization": "number",
                     "NetworkUtilizationMax": "number",
@@ -3370,7 +2379,7 @@
                             "PeerNodeId": 50000,
                             "PingTimeUs": "text",
                             "ScopeId": {
-                                "X1": "72057594046678944",
+                                "X1": "72075186232723360",
                                 "X2": "6"
                             },
                             "Utilization": "number"
@@ -3387,7 +2396,7 @@
                             "PeerNodeId": 50001,
                             "PingTimeUs": "text",
                             "ScopeId": {
-                                "X1": "72057594046678944",
+                                "X1": "72075186232723360",
                                 "X2": "7"
                             },
                             "Utilization": "number"
@@ -3498,11 +2507,11 @@
                                 "Usage": "number"
                             }
                         ],
-                        "RealNumberOfCpus": "not-zero-number",
+                        "RealNumberOfCpus": 128,
                         "Roles": "not-empty-array",
                         "StartTime": "not-zero-number-text",
                         "SystemState": "Green",
-                        "TotalSessions": "number"
+                        "TotalSessions": 0
                     },
                     "UptimeSeconds": "number",
                     "VDisks": [
@@ -3735,7 +2744,7 @@
                             "PeerNodeId": 50001,
                             "PingTimeUs": "text",
                             "ScopeId": {
-                                "X1": "72057594046678944",
+                                "X1": "72075186232723360",
                                 "X2": "7"
                             },
                             "Utilization": "number"
@@ -3759,7 +2768,7 @@
                             "PeerNodeId": 50000,
                             "PingTimeUs": "text",
                             "ScopeId": {
-                                "X1": "72057594046678944",
+                                "X1": "72075186232723360",
                                 "X2": "6"
                             },
                             "Utilization": "number"
@@ -3776,7 +2785,7 @@
                             "PeerNodeId": 50000,
                             "PingTimeUs": "text",
                             "ScopeId": {
-                                "X1": "72057594046678944",
+                                "X1": "72075186232723360",
                                 "X2": "6"
                             },
                             "Utilization": "number"
@@ -3841,25 +2850,20 @@
                                 "Usage": "number"
                             }
                         ],
-                        "RealNumberOfCpus": "not-zero-number",
+                        "RealNumberOfCpus": 128,
                         "Roles": "not-empty-array",
                         "StartTime": "not-zero-number-text",
                         "SystemState": "Green",
                         "Tenants": [
                             "/Root/dedicated_db"
                         ],
-                        "TotalSessions": "number"
+                        "TotalSessions": 0
                     },
                     "Tablets": [
                         {
                             "Count": 3,
                             "State": "Green",
                             "Type": "Coordinator"
-                        },
-                        {
-                            "Count": 1,
-                            "State": "Green",
-                            "Type": "DataShard"
                         },
                         {
                             "Count": 1,
@@ -3941,7 +2945,7 @@
                             "PeerNodeId": 50000,
                             "PingTimeUs": "text",
                             "ScopeId": {
-                                "X1": "72057594046678944",
+                                "X1": "72075186232723360",
                                 "X2": "6"
                             },
                             "Utilization": "number"
@@ -3965,7 +2969,7 @@
                             "PeerNodeId": 50001,
                             "PingTimeUs": "text",
                             "ScopeId": {
-                                "X1": "72057594046678944",
+                                "X1": "72075186232723360",
                                 "X2": "7"
                             },
                             "Utilization": "number"
@@ -3982,7 +2986,7 @@
                             "PeerNodeId": 50001,
                             "PingTimeUs": "text",
                             "ScopeId": {
-                                "X1": "72057594046678944",
+                                "X1": "72075186232723360",
                                 "X2": "7"
                             },
                             "Utilization": "number"
@@ -4047,25 +3051,20 @@
                                 "Usage": "number"
                             }
                         ],
-                        "RealNumberOfCpus": "not-zero-number",
+                        "RealNumberOfCpus": 128,
                         "Roles": "not-empty-array",
                         "StartTime": "not-zero-number-text",
                         "SystemState": "Green",
                         "Tenants": [
                             "/Root/shared_db"
                         ],
-                        "TotalSessions": "number"
+                        "TotalSessions": 0
                     },
                     "Tablets": [
                         {
                             "Count": 1,
                             "State": "Green",
                             "Type": "Coordinator"
-                        },
-                        {
-                            "Count": 1,
-                            "State": "Green",
-                            "Type": "DataShard"
                         },
                         {
                             "Count": 3,
@@ -4137,7 +3136,7 @@
                             "PeerNodeId": 50000,
                             "PingTimeUs": "text",
                             "ScopeId": {
-                                "X1": "72057594046678944",
+                                "X1": "72075186232723360",
                                 "X2": "6"
                             },
                             "Utilization": "number"
@@ -4161,7 +3160,7 @@
                             "PeerNodeId": 50001,
                             "PingTimeUs": "text",
                             "ScopeId": {
-                                "X1": "72057594046678944",
+                                "X1": "72075186232723360",
                                 "X2": "7"
                             },
                             "Utilization": "number"
@@ -4178,7 +3177,7 @@
                             "PeerNodeId": 50001,
                             "PingTimeUs": "text",
                             "ScopeId": {
-                                "X1": "72057594046678944",
+                                "X1": "72075186232723360",
                                 "X2": "7"
                             },
                             "Utilization": "number"
@@ -4243,25 +3242,20 @@
                                 "Usage": "number"
                             }
                         ],
-                        "RealNumberOfCpus": "not-zero-number",
+                        "RealNumberOfCpus": 128,
                         "Roles": "not-empty-array",
                         "StartTime": "not-zero-number-text",
                         "SystemState": "Green",
                         "Tenants": [
                             "/Root/shared_db"
                         ],
-                        "TotalSessions": "number"
+                        "TotalSessions": 0
                     },
                     "Tablets": [
                         {
                             "Count": 3,
                             "State": "Green",
                             "Type": "Coordinator"
-                        },
-                        {
-                            "Count": 1,
-                            "State": "Green",
-                            "Type": "DataShard"
                         },
                         {
                             "Count": 1,
@@ -4293,239 +3287,6 @@
                 }
             ],
             "TotalNodes": "1"
-        }
-    },
-    "test.test_viewer_nodes_issue_14992": {
-        "response_group": {
-            "FieldsAvailable": "0000000110111110111111100000111",
-            "FieldsRequired": "0000000001100000010000000000101",
-            "FoundNodes": "3",
-            "MaximumDisksPerNode": "1",
-            "Nodes": [
-                {
-                    "NodeId": 1,
-                    "SystemState": {
-                        "ChangeTime": "not-zero-number-text",
-                        "CoresTotal": "not-zero-number",
-                        "CoresUsed": "not-zero-number",
-                        "Endpoints": [
-                            {
-                                "Address": "text",
-                                "Name": "grpc"
-                            },
-                            {
-                                "Address": "text",
-                                "Name": "http-mon"
-                            },
-                            {
-                                "Address": "text",
-                                "Name": "ic"
-                            }
-                        ],
-                        "Host": "text",
-                        "LoadAverage": "not-empty-array",
-                        "Location": {
-                            "DataCenter": "1",
-                            "Rack": "1",
-                            "Unit": "1"
-                        },
-                        "MaxDiskUsage": "not-zero-number",
-                        "MemoryLimit": "not-zero-number-text",
-                        "NodeId": 1,
-                        "NumberOfCpus": "not-zero-number",
-                        "PoolStats": [
-                            {
-                                "Limit": "not-zero-number",
-                                "Name": "System",
-                                "Threads": 2,
-                                "Usage": "number"
-                            },
-                            {
-                                "Limit": "not-zero-number",
-                                "Name": "User",
-                                "Threads": 3,
-                                "Usage": "number"
-                            },
-                            {
-                                "Limit": "not-zero-number",
-                                "Name": "Batch",
-                                "Threads": 2,
-                                "Usage": "number"
-                            },
-                            {
-                                "Limit": "not-zero-number",
-                                "Name": "IO",
-                                "Threads": 1,
-                                "Usage": "number"
-                            },
-                            {
-                                "Limit": "not-zero-number",
-                                "Name": "IC",
-                                "Threads": 1,
-                                "Usage": "number"
-                            }
-                        ],
-                        "RealNumberOfCpus": "not-zero-number",
-                        "Roles": "not-empty-array",
-                        "StartTime": "not-zero-number-text",
-                        "SystemState": "Green",
-                        "TotalSessions": "number"
-                    },
-                    "UptimeSeconds": "number"
-                },
-                {
-                    "NodeId": 50001,
-                    "SystemState": {
-                        "ChangeTime": "not-zero-number-text",
-                        "CoresTotal": "not-zero-number",
-                        "CoresUsed": "not-zero-number",
-                        "Endpoints": [
-                            {
-                                "Address": "text",
-                                "Name": "grpc"
-                            },
-                            {
-                                "Address": "text",
-                                "Name": "http-mon"
-                            },
-                            {
-                                "Address": "text",
-                                "Name": "ic"
-                            }
-                        ],
-                        "Host": "text",
-                        "LoadAverage": "not-empty-array",
-                        "Location": {},
-                        "MemoryLimit": "not-zero-number-text",
-                        "NodeId": 50001,
-                        "NumberOfCpus": "not-zero-number",
-                        "PoolStats": [
-                            {
-                                "Limit": "not-zero-number",
-                                "Name": "System",
-                                "Threads": 2,
-                                "Usage": "number"
-                            },
-                            {
-                                "Limit": "not-zero-number",
-                                "Name": "User",
-                                "Threads": 3,
-                                "Usage": "number"
-                            },
-                            {
-                                "Limit": "not-zero-number",
-                                "Name": "Batch",
-                                "Threads": 2,
-                                "Usage": "number"
-                            },
-                            {
-                                "Limit": "not-zero-number",
-                                "Name": "IO",
-                                "Threads": 1,
-                                "Usage": "number"
-                            },
-                            {
-                                "Limit": "not-zero-number",
-                                "Name": "IC",
-                                "Threads": 1,
-                                "Usage": "number"
-                            }
-                        ],
-                        "RealNumberOfCpus": "not-zero-number",
-                        "Roles": "not-empty-array",
-                        "StartTime": "not-zero-number-text",
-                        "SystemState": "Green",
-                        "Tenants": [
-                            "/Root/shared_db"
-                        ],
-                        "TotalSessions": "number"
-                    },
-                    "UptimeSeconds": "number"
-                },
-                {
-                    "NodeId": 50000,
-                    "SystemState": {
-                        "ChangeTime": "not-zero-number-text",
-                        "CoresTotal": "not-zero-number",
-                        "CoresUsed": "not-zero-number",
-                        "Endpoints": [
-                            {
-                                "Address": "text",
-                                "Name": "grpc"
-                            },
-                            {
-                                "Address": "text",
-                                "Name": "http-mon"
-                            },
-                            {
-                                "Address": "text",
-                                "Name": "ic"
-                            }
-                        ],
-                        "Host": "text",
-                        "LoadAverage": "not-empty-array",
-                        "Location": {},
-                        "MemoryLimit": "not-zero-number-text",
-                        "NodeId": 50000,
-                        "NumberOfCpus": "not-zero-number",
-                        "PoolStats": [
-                            {
-                                "Limit": "not-zero-number",
-                                "Name": "System",
-                                "Threads": 2,
-                                "Usage": "number"
-                            },
-                            {
-                                "Limit": "not-zero-number",
-                                "Name": "User",
-                                "Threads": 3,
-                                "Usage": "number"
-                            },
-                            {
-                                "Limit": "not-zero-number",
-                                "Name": "Batch",
-                                "Threads": 2,
-                                "Usage": "number"
-                            },
-                            {
-                                "Limit": "not-zero-number",
-                                "Name": "IO",
-                                "Threads": 1,
-                                "Usage": "number"
-                            },
-                            {
-                                "Limit": "not-zero-number",
-                                "Name": "IC",
-                                "Threads": 1,
-                                "Usage": "number"
-                            }
-                        ],
-                        "RealNumberOfCpus": "not-zero-number",
-                        "Roles": "not-empty-array",
-                        "StartTime": "not-zero-number-text",
-                        "SystemState": "Green",
-                        "Tenants": [
-                            "/Root/dedicated_db"
-                        ],
-                        "TotalSessions": "number"
-                    },
-                    "UptimeSeconds": "number"
-                }
-            ],
-            "TotalNodes": "3"
-        },
-        "response_group_by": {
-            "FieldsAvailable": "0000000110111110111111100000111",
-            "FieldsRequired": "0000000001100000010000000000101",
-            "FoundNodes": "3",
-            "MaximumDisksPerNode": "1",
-            "NodeGroups": [
-                {
-                    "GroupName": "up <10m",
-                    "NodeCount": "3"
-                }
-            ],
-            "TotalNodes": "3"
         }
     },
     "test.test_viewer_pdiskinfo": {
@@ -4570,7 +3331,7 @@
                     ]
                 }
             ],
-            "version": 9
+            "version": 8
         },
         "/Root/dedicated_db": {
             "result": [
@@ -4588,7 +3349,7 @@
                     ]
                 }
             ],
-            "version": 9
+            "version": 8
         },
         "/Root/serverless_db": {
             "result": [
@@ -4606,7 +3367,7 @@
                     ]
                 }
             ],
-            "version": 9
+            "version": 8
         },
         "/Root/shared_db": {
             "result": [
@@ -4624,224 +3385,7 @@
                     ]
                 }
             ],
-            "version": 9
-        }
-    },
-    "test.test_viewer_query_from_table": {
-        "/Root/dedicated_db": {
-            "result": [
-                {
-                    "columns": [
-                        {
-                            "name": "id",
-                            "type": "Int64?"
-                        },
-                        {
-                            "name": "name",
-                            "type": "Utf8?"
-                        }
-                    ],
-                    "rows": [
-                        [
-                            "1",
-                            "one"
-                        ],
-                        [
-                            "2",
-                            "two"
-                        ],
-                        [
-                            "3",
-                            "three"
-                        ]
-                    ]
-                }
-            ],
-            "version": 9
-        },
-        "/Root/serverless_db": {
-            "result": [
-                {
-                    "columns": [
-                        {
-                            "name": "id",
-                            "type": "Int64?"
-                        },
-                        {
-                            "name": "name",
-                            "type": "Utf8?"
-                        }
-                    ],
-                    "rows": [
-                        [
-                            "1",
-                            "one"
-                        ],
-                        [
-                            "2",
-                            "two"
-                        ],
-                        [
-                            "3",
-                            "three"
-                        ]
-                    ]
-                }
-            ],
-            "version": 9
-        },
-        "/Root/shared_db": {
-            "result": [
-                {
-                    "columns": [
-                        {
-                            "name": "id",
-                            "type": "Int64?"
-                        },
-                        {
-                            "name": "name",
-                            "type": "Utf8?"
-                        }
-                    ],
-                    "rows": [
-                        [
-                            "1",
-                            "one"
-                        ],
-                        [
-                            "2",
-                            "two"
-                        ],
-                        [
-                            "3",
-                            "three"
-                        ]
-                    ]
-                }
-            ],
-            "version": 9
-        }
-    },
-    "test.test_viewer_query_from_table_different_schemas": {
-        "classic": [
-            {
-                "id": "1",
-                "name": "one"
-            },
-            {
-                "id": "2",
-                "name": "two"
-            },
-            {
-                "id": "3",
-                "name": "three"
-            }
-        ],
-        "modern": {
-            "columns": [
-                {
-                    "name": "id",
-                    "type": "Int64?"
-                },
-                {
-                    "name": "name",
-                    "type": "Utf8?"
-                }
-            ],
-            "result": [
-                [
-                    "1",
-                    "one"
-                ],
-                [
-                    "2",
-                    "two"
-                ],
-                [
-                    "3",
-                    "three"
-                ]
-            ],
-            "version": 9
-        },
-        "multi": {
-            "result": [
-                {
-                    "columns": [
-                        {
-                            "name": "id",
-                            "type": "Int64?"
-                        },
-                        {
-                            "name": "name",
-                            "type": "Utf8?"
-                        }
-                    ],
-                    "rows": [
-                        [
-                            "1",
-                            "one"
-                        ],
-                        [
-                            "2",
-                            "two"
-                        ],
-                        [
-                            "3",
-                            "three"
-                        ]
-                    ]
-                }
-            ],
-            "version": 9
-        },
-        "ydb": {
-            "result": [
-                {
-                    "id": 1,
-                    "name": "one"
-                },
-                {
-                    "id": 2,
-                    "name": "two"
-                },
-                {
-                    "id": 3,
-                    "name": "three"
-                }
-            ],
-            "version": 9
-        },
-        "ydb2": {
-            "result": [
-                {
-                    "columns": [
-                        {
-                            "name": "id",
-                            "type": "Int64?"
-                        },
-                        {
-                            "name": "name",
-                            "type": "Utf8?"
-                        }
-                    ],
-                    "rows": [
-                        {
-                            "id": 1,
-                            "name": "one"
-                        },
-                        {
-                            "id": 2,
-                            "name": "two"
-                        },
-                        {
-                            "id": 3,
-                            "name": "three"
-                        }
-                    ]
-                }
-            ],
-            "version": 9
+            "version": 8
         }
     },
     "test.test_viewer_query_issue_13757": {
@@ -4864,7 +3408,7 @@
                     ]
                 }
             ],
-            "version": 9
+            "version": 8
         },
         "/Root/dedicated_db": {
             "result": [
@@ -4885,7 +3429,7 @@
                     ]
                 }
             ],
-            "version": 9
+            "version": 8
         },
         "/Root/serverless_db": {
             "result": [
@@ -4906,7 +3450,7 @@
                     ]
                 }
             ],
-            "version": 9
+            "version": 8
         },
         "/Root/shared_db": {
             "result": [
@@ -4927,7 +3471,7 @@
                     ]
                 }
             ],
-            "version": 9
+            "version": 8
         }
     },
     "test.test_viewer_query_issue_13945": {
@@ -4947,7 +3491,7 @@
                     ]
                 }
             ],
-            "version": 9
+            "version": 8
         },
         "/Root/dedicated_db": {
             "result": [
@@ -4965,7 +3509,7 @@
                     ]
                 }
             ],
-            "version": 9
+            "version": 8
         },
         "/Root/serverless_db": {
             "result": [
@@ -4983,7 +3527,7 @@
                     ]
                 }
             ],
-            "version": 9
+            "version": 8
         },
         "/Root/shared_db": {
             "result": [
@@ -5001,2018 +3545,7 @@
                     ]
                 }
             ],
-            "version": 9
-        }
-    },
-    "test.test_viewer_query_long": {
-        "execute_response": {
-            "execution_id": "text",
-            "operation_id": "text",
-            "result": [
-                {
-                    "columns": [
-                        {
-                            "name": "id",
-                            "type": "Int64?"
-                        },
-                        {
-                            "name": "name",
-                            "type": "Utf8?"
-                        }
-                    ],
-                    "rows": [
-                        [
-                            "1",
-                            "one"
-                        ],
-                        [
-                            "2",
-                            "two"
-                        ],
-                        [
-                            "3",
-                            "three"
-                        ]
-                    ]
-                }
-            ],
-            "version": 9
-        },
-        "fetch_by_execution_id": {
-            "execution_id": "text",
-            "result": [
-                {
-                    "columns": [
-                        {
-                            "name": "id",
-                            "type": "Int64?"
-                        },
-                        {
-                            "name": "name",
-                            "type": "Utf8?"
-                        }
-                    ],
-                    "rows": [
-                        [
-                            "1",
-                            "one"
-                        ],
-                        [
-                            "2",
-                            "two"
-                        ],
-                        [
-                            "3",
-                            "three"
-                        ]
-                    ]
-                }
-            ],
-            "version": 9
-        },
-        "fetch_by_operation_id": {
-            "execution_id": "text",
-            "operation_id": "text",
-            "result": [
-                {
-                    "columns": [
-                        {
-                            "name": "id",
-                            "type": "Int64?"
-                        },
-                        {
-                            "name": "name",
-                            "type": "Utf8?"
-                        }
-                    ],
-                    "rows": [
-                        [
-                            "1",
-                            "one"
-                        ],
-                        [
-                            "2",
-                            "two"
-                        ],
-                        [
-                            "3",
-                            "three"
-                        ]
-                    ]
-                }
-            ],
-            "version": 9
-        },
-        "fetch_error_no_id": {
-            "status_code": 400,
-            "text": "operation_id or execution_id required for fetch-long-query"
-        },
-        "fetch_invalid_operation_id": {
-            "status_code": 400,
-            "text": "operation_id or execution_id required for fetch-long-query"
-        }
-    },
-    "test.test_viewer_query_long_multipart": {
-        "execute_stream_response": {
-            "multipart_parts": [
-                {
-                    "exec_mode": "EXEC_MODE_EXECUTE",
-                    "exec_status": "EXEC_STATUS_STARTING",
-                    "execution_id": "text",
-                    "meta": {
-                        "event": "ScriptResponse"
-                    },
-                    "operation_id": "text",
-                    "status": "SUCCESS"
-                },
-                {
-                    "id": "text",
-                    "meta": {
-                        "event": "OperationResponse"
-                    },
-                    "metadata": {
-                        "exec_mode": "EXEC_MODE_EXECUTE",
-                        "exec_stats": {
-                            "query_plan": "{}"
-                        },
-                        "exec_status": "EXEC_STATUS_COMPLETED",
-                        "execution_id": "text",
-                        "result_sets_meta": [
-                            {
-                                "columns": [
-                                    {
-                                        "name": "id",
-                                        "type": {
-                                            "optional_type": {
-                                                "item": {
-                                                    "type_id": "INT64"
-                                                }
-                                            }
-                                        }
-                                    },
-                                    {
-                                        "name": "name",
-                                        "type": {
-                                            "optional_type": {
-                                                "item": {
-                                                    "type_id": "UTF8"
-                                                }
-                                            }
-                                        }
-                                    }
-                                ],
-                                "finished": true,
-                                "number_rows": "3"
-                            }
-                        ],
-                        "script_content": {
-                            "text": "SELECT * FROM table1 LIMIT 3;"
-                        }
-                    },
-                    "ready": true
-                },
-                {
-                    "meta": {
-                        "event": "StreamData",
-                        "result_index": 0,
-                        "seq_no": 0
-                    },
-                    "result": {
-                        "columns": [
-                            {
-                                "name": "id",
-                                "type": "Int64?"
-                            },
-                            {
-                                "name": "name",
-                                "type": "Utf8?"
-                            }
-                        ],
-                        "rows": [
-                            [
-                                "1",
-                                "one"
-                            ],
-                            [
-                                "2",
-                                "two"
-                            ],
-                            [
-                                "3",
-                                "three"
-                            ]
-                        ]
-                    }
-                }
-            ]
-        },
-        "fetch_error_stream_response": {
-            "status_code": 400,
-            "text": "operation_id or execution_id required for fetch-long-query"
-        },
-        "fetch_invalid_stream_response": {
-            "status_code": 400,
-            "text": "operation_id or execution_id required for fetch-long-query"
-        }
-    },
-    "test.test_viewer_storage_nodes": {
-        "/Root": {
-            "FieldsAvailable": "0000000110000110111111100000111",
-            "FieldsRequired": "0000000000000000000000000000111",
-            "FoundNodes": "1",
-            "MaximumSlotsPerDisk": "5",
-            "Nodes": [
-                {
-                    "NodeId": 1,
-                    "SystemState": {
-                        "ChangeTime": "not-zero-number-text",
-                        "CoresTotal": "not-zero-number",
-                        "CoresUsed": "not-zero-number",
-                        "Endpoints": [
-                            {
-                                "Address": "text",
-                                "Name": "grpc"
-                            },
-                            {
-                                "Address": "text",
-                                "Name": "http-mon"
-                            },
-                            {
-                                "Address": "text",
-                                "Name": "ic"
-                            }
-                        ],
-                        "Host": "text",
-                        "LoadAverage": "not-empty-array",
-                        "Location": {
-                            "DataCenter": "1",
-                            "Rack": "1",
-                            "Unit": "1"
-                        },
-                        "MaxDiskUsage": "not-zero-number",
-                        "MemoryLimit": "not-zero-number-text",
-                        "NodeId": 1,
-                        "NumberOfCpus": "not-zero-number",
-                        "PoolStats": [
-                            {
-                                "Limit": "not-zero-number",
-                                "Name": "System",
-                                "Threads": 2,
-                                "Usage": "number"
-                            },
-                            {
-                                "Limit": "not-zero-number",
-                                "Name": "User",
-                                "Threads": 3,
-                                "Usage": "number"
-                            },
-                            {
-                                "Limit": "not-zero-number",
-                                "Name": "Batch",
-                                "Threads": 2,
-                                "Usage": "number"
-                            },
-                            {
-                                "Limit": "not-zero-number",
-                                "Name": "IO",
-                                "Threads": 1,
-                                "Usage": "number"
-                            },
-                            {
-                                "Limit": "not-zero-number",
-                                "Name": "IC",
-                                "Threads": 1,
-                                "Usage": "number"
-                            }
-                        ],
-                        "RealNumberOfCpus": "not-zero-number",
-                        "Roles": "not-empty-array",
-                        "StartTime": "not-zero-number-text",
-                        "SystemState": "Green",
-                        "TotalSessions": "number"
-                    }
-                }
-            ],
-            "TotalNodes": "1"
-        },
-        "/Root/dedicated_db": {
-            "FieldsAvailable": "0000000110000110111111100000111",
-            "FieldsRequired": "0000000000000000000000000000111",
-            "FoundNodes": "1",
-            "MaximumSlotsPerDisk": "5",
-            "Nodes": [
-                {
-                    "NodeId": 1,
-                    "SystemState": {
-                        "ChangeTime": "not-zero-number-text",
-                        "CoresTotal": "not-zero-number",
-                        "CoresUsed": "not-zero-number",
-                        "Endpoints": [
-                            {
-                                "Address": "text",
-                                "Name": "grpc"
-                            },
-                            {
-                                "Address": "text",
-                                "Name": "http-mon"
-                            },
-                            {
-                                "Address": "text",
-                                "Name": "ic"
-                            }
-                        ],
-                        "Host": "text",
-                        "LoadAverage": "not-empty-array",
-                        "Location": {
-                            "DataCenter": "1",
-                            "Rack": "1",
-                            "Unit": "1"
-                        },
-                        "MaxDiskUsage": "not-zero-number",
-                        "MemoryLimit": "not-zero-number-text",
-                        "NodeId": 1,
-                        "NumberOfCpus": "not-zero-number",
-                        "PoolStats": [
-                            {
-                                "Limit": "not-zero-number",
-                                "Name": "System",
-                                "Threads": 2,
-                                "Usage": "number"
-                            },
-                            {
-                                "Limit": "not-zero-number",
-                                "Name": "User",
-                                "Threads": 3,
-                                "Usage": "number"
-                            },
-                            {
-                                "Limit": "not-zero-number",
-                                "Name": "Batch",
-                                "Threads": 2,
-                                "Usage": "number"
-                            },
-                            {
-                                "Limit": "not-zero-number",
-                                "Name": "IO",
-                                "Threads": 1,
-                                "Usage": "number"
-                            },
-                            {
-                                "Limit": "not-zero-number",
-                                "Name": "IC",
-                                "Threads": 1,
-                                "Usage": "number"
-                            }
-                        ],
-                        "RealNumberOfCpus": "not-zero-number",
-                        "Roles": "not-empty-array",
-                        "StartTime": "not-zero-number-text",
-                        "SystemState": "Green",
-                        "TotalSessions": "number"
-                    }
-                }
-            ],
-            "TotalNodes": "1"
-        },
-        "/Root/serverless_db": {
-            "FieldsAvailable": "0000000110000110111111100000111",
-            "FieldsRequired": "0000000000000000000000000000111",
-            "FoundNodes": "1",
-            "MaximumSlotsPerDisk": "5",
-            "Nodes": [
-                {
-                    "NodeId": 1,
-                    "SystemState": {
-                        "ChangeTime": "not-zero-number-text",
-                        "CoresTotal": "not-zero-number",
-                        "CoresUsed": "not-zero-number",
-                        "Endpoints": [
-                            {
-                                "Address": "text",
-                                "Name": "grpc"
-                            },
-                            {
-                                "Address": "text",
-                                "Name": "http-mon"
-                            },
-                            {
-                                "Address": "text",
-                                "Name": "ic"
-                            }
-                        ],
-                        "Host": "text",
-                        "LoadAverage": "not-empty-array",
-                        "Location": {
-                            "DataCenter": "1",
-                            "Rack": "1",
-                            "Unit": "1"
-                        },
-                        "MaxDiskUsage": "not-zero-number",
-                        "MemoryLimit": "not-zero-number-text",
-                        "NodeId": 1,
-                        "NumberOfCpus": "not-zero-number",
-                        "PoolStats": [
-                            {
-                                "Limit": "not-zero-number",
-                                "Name": "System",
-                                "Threads": 2,
-                                "Usage": "number"
-                            },
-                            {
-                                "Limit": "not-zero-number",
-                                "Name": "User",
-                                "Threads": 3,
-                                "Usage": "number"
-                            },
-                            {
-                                "Limit": "not-zero-number",
-                                "Name": "Batch",
-                                "Threads": 2,
-                                "Usage": "number"
-                            },
-                            {
-                                "Limit": "not-zero-number",
-                                "Name": "IO",
-                                "Threads": 1,
-                                "Usage": "number"
-                            },
-                            {
-                                "Limit": "not-zero-number",
-                                "Name": "IC",
-                                "Threads": 1,
-                                "Usage": "number"
-                            }
-                        ],
-                        "RealNumberOfCpus": "not-zero-number",
-                        "Roles": "not-empty-array",
-                        "StartTime": "not-zero-number-text",
-                        "SystemState": "Green",
-                        "TotalSessions": "number"
-                    }
-                }
-            ],
-            "Problems": [
-                "no-database-board-info"
-            ],
-            "TotalNodes": "1"
-        },
-        "/Root/shared_db": {
-            "FieldsAvailable": "0000000110000110111111100000111",
-            "FieldsRequired": "0000000000000000000000000000111",
-            "FoundNodes": "1",
-            "MaximumSlotsPerDisk": "5",
-            "Nodes": [
-                {
-                    "NodeId": 1,
-                    "SystemState": {
-                        "ChangeTime": "not-zero-number-text",
-                        "CoresTotal": "not-zero-number",
-                        "CoresUsed": "not-zero-number",
-                        "Endpoints": [
-                            {
-                                "Address": "text",
-                                "Name": "grpc"
-                            },
-                            {
-                                "Address": "text",
-                                "Name": "http-mon"
-                            },
-                            {
-                                "Address": "text",
-                                "Name": "ic"
-                            }
-                        ],
-                        "Host": "text",
-                        "LoadAverage": "not-empty-array",
-                        "Location": {
-                            "DataCenter": "1",
-                            "Rack": "1",
-                            "Unit": "1"
-                        },
-                        "MaxDiskUsage": "not-zero-number",
-                        "MemoryLimit": "not-zero-number-text",
-                        "NodeId": 1,
-                        "NumberOfCpus": "not-zero-number",
-                        "PoolStats": [
-                            {
-                                "Limit": "not-zero-number",
-                                "Name": "System",
-                                "Threads": 2,
-                                "Usage": "number"
-                            },
-                            {
-                                "Limit": "not-zero-number",
-                                "Name": "User",
-                                "Threads": 3,
-                                "Usage": "number"
-                            },
-                            {
-                                "Limit": "not-zero-number",
-                                "Name": "Batch",
-                                "Threads": 2,
-                                "Usage": "number"
-                            },
-                            {
-                                "Limit": "not-zero-number",
-                                "Name": "IO",
-                                "Threads": 1,
-                                "Usage": "number"
-                            },
-                            {
-                                "Limit": "not-zero-number",
-                                "Name": "IC",
-                                "Threads": 1,
-                                "Usage": "number"
-                            }
-                        ],
-                        "RealNumberOfCpus": "not-zero-number",
-                        "Roles": "not-empty-array",
-                        "StartTime": "not-zero-number-text",
-                        "SystemState": "Green",
-                        "TotalSessions": "number"
-                    }
-                }
-            ],
-            "TotalNodes": "1"
-        }
-    },
-    "test.test_viewer_storage_nodes_all": {
-        "/Root": {
-            "FieldsAvailable": "1111111110111111111111111111111",
-            "FieldsRequired": "1111111111111111111111111111111",
-            "FoundNodes": "1",
-            "MaximumDisksPerNode": "1",
-            "MaximumSlotsPerDisk": "5",
-            "Nodes": [
-                {
-                    "ClockSkewMaxUs": "text",
-                    "ClockSkewMinUs": "text",
-                    "ClockSkewUs": "text",
-                    "ConnectStatus": "Green",
-                    "Connections": "not-zero-number",
-                    "CpuUsage": "not-zero-number",
-                    "Database": "/Root",
-                    "DiskSpaceUsage": "not-zero-number",
-                    "NetworkUtilization": "number",
-                    "NetworkUtilizationMax": "number",
-                    "NetworkUtilizationMin": "number",
-                    "NodeId": 1,
-                    "PDisks": [
-                        {
-                            "AvailableSize": "text",
-                            "Category": "0",
-                            "ChangeTime": "not-zero-number-text",
-                            "Device": "Green",
-                            "EnforcedDynamicSlotSize": "not-zero-number-text",
-                            "Guid": "1",
-                            "LogTotalSize": "not-zero-number-text",
-                            "LogUsedSize": "not-zero-number-text",
-                            "NodeId": 1,
-                            "NumActiveSlots": 5,
-                            "PDiskId": 1,
-                            "Path": "SectorMap:1:64",
-                            "Realtime": "Green",
-                            "SerialNumber": "",
-                            "State": "Normal",
-                            "SystemSize": "not-zero-number-text",
-                            "TotalSize": "not-zero-number-text"
-                        }
-                    ],
-                    "Peers": [
-                        {
-                            "BytesWritten": "text",
-                            "ChangeTime": "not-zero-number-text",
-                            "ClockSkewUs": "text",
-                            "ConnectStatus": "Green",
-                            "ConnectTime": "not-zero-number-text",
-                            "Connected": true,
-                            "NodeId": 1,
-                            "PeerName": "text",
-                            "PeerNodeId": 50000,
-                            "PingTimeUs": "text",
-                            "ScopeId": {
-                                "X1": "72057594046678944",
-                                "X2": "6"
-                            },
-                            "Utilization": "number"
-                        },
-                        {
-                            "BytesWritten": "text",
-                            "ChangeTime": "not-zero-number-text",
-                            "ClockSkewUs": "text",
-                            "ConnectStatus": "Green",
-                            "ConnectTime": "not-zero-number-text",
-                            "Connected": true,
-                            "NodeId": 1,
-                            "PeerName": "text",
-                            "PeerNodeId": 50001,
-                            "PingTimeUs": "text",
-                            "ScopeId": {
-                                "X1": "72057594046678944",
-                                "X2": "7"
-                            },
-                            "Utilization": "number"
-                        }
-                    ],
-                    "PingTimeMaxUs": "text",
-                    "PingTimeMinUs": "text",
-                    "PingTimeUs": "text",
-                    "ReceiveThroughput": "text",
-                    "ReverseClockSkewUs": "text",
-                    "ReversePeers": [
-                        {
-                            "BytesWritten": "text",
-                            "ChangeTime": "not-zero-number-text",
-                            "ClockSkewUs": "text",
-                            "ConnectStatus": "Green",
-                            "ConnectTime": "not-zero-number-text",
-                            "Connected": true,
-                            "NodeId": 50000,
-                            "PeerName": "text",
-                            "PeerNodeId": 1,
-                            "PingTimeUs": "text",
-                            "ScopeId": {
-                                "X1": "0",
-                                "X2": "1"
-                            },
-                            "Utilization": "number"
-                        },
-                        {
-                            "BytesWritten": "text",
-                            "ChangeTime": "not-zero-number-text",
-                            "ClockSkewUs": "text",
-                            "ConnectStatus": "Green",
-                            "ConnectTime": "not-zero-number-text",
-                            "Connected": true,
-                            "NodeId": 50001,
-                            "PeerName": "text",
-                            "PeerNodeId": 1,
-                            "PingTimeUs": "text",
-                            "ScopeId": {
-                                "X1": "0",
-                                "X2": "1"
-                            },
-                            "Utilization": "number"
-                        }
-                    ],
-                    "ReversePingTimeUs": "text",
-                    "SendThroughput": "text",
-                    "SystemState": {
-                        "ChangeTime": "not-zero-number-text",
-                        "CoresTotal": "not-zero-number",
-                        "CoresUsed": "not-zero-number",
-                        "Endpoints": [
-                            {
-                                "Address": "text",
-                                "Name": "grpc"
-                            },
-                            {
-                                "Address": "text",
-                                "Name": "http-mon"
-                            },
-                            {
-                                "Address": "text",
-                                "Name": "ic"
-                            }
-                        ],
-                        "Host": "text",
-                        "LoadAverage": "not-empty-array",
-                        "Location": {
-                            "DataCenter": "1",
-                            "Rack": "1",
-                            "Unit": "1"
-                        },
-                        "MaxDiskUsage": "not-zero-number",
-                        "MemoryLimit": "not-zero-number-text",
-                        "MemoryStats": "not-empty-object",
-                        "NodeId": 1,
-                        "NumberOfCpus": "not-zero-number",
-                        "PoolStats": [
-                            {
-                                "Limit": "not-zero-number",
-                                "Name": "System",
-                                "Threads": 2,
-                                "Usage": "number"
-                            },
-                            {
-                                "Limit": "not-zero-number",
-                                "Name": "User",
-                                "Threads": 3,
-                                "Usage": "number"
-                            },
-                            {
-                                "Limit": "not-zero-number",
-                                "Name": "Batch",
-                                "Threads": 2,
-                                "Usage": "number"
-                            },
-                            {
-                                "Limit": "not-zero-number",
-                                "Name": "IO",
-                                "Threads": 1,
-                                "Usage": "number"
-                            },
-                            {
-                                "Limit": "not-zero-number",
-                                "Name": "IC",
-                                "Threads": 1,
-                                "Usage": "number"
-                            }
-                        ],
-                        "RealNumberOfCpus": "not-zero-number",
-                        "Roles": "not-empty-array",
-                        "StartTime": "not-zero-number-text",
-                        "SystemState": "Green",
-                        "TotalSessions": "number"
-                    },
-                    "UptimeSeconds": "number",
-                    "VDisks": [
-                        {
-                            "AllocatedSize": "0",
-                            "AvailableSize": "text",
-                            "ChangeTime": "not-zero-number-text",
-                            "DiskSpace": "Green",
-                            "FrontQueues": "Green",
-                            "Guid": "1",
-                            "HasUnreadableBlobs": false,
-                            "IncarnationGuid": "not-zero-number-text",
-                            "InstanceGuid": "not-zero-number-text",
-                            "Kind": "0",
-                            "NodeId": 1,
-                            "PDiskId": 1,
-                            "Replicated": true,
-                            "ReplicationProgress": 1,
-                            "ReplicationSecondsRemaining": 0,
-                            "SatisfactionRank": {
-                                "FreshRank": {
-                                    "Flag": "Green"
-                                },
-                                "LevelRank": {
-                                    "Flag": "Green"
-                                }
-                            },
-                            "StoragePoolName": "static",
-                            "VDiskId": {
-                                "Domain": 0,
-                                "GroupGeneration": 1,
-                                "GroupID": 0,
-                                "Ring": 0,
-                                "VDisk": 0
-                            },
-                            "VDiskSlotId": 0,
-                            "VDiskState": "OK"
-                        },
-                        {
-                            "AllocatedSize": "0",
-                            "AvailableSize": "text",
-                            "ChangeTime": "not-zero-number-text",
-                            "DiskSpace": "Green",
-                            "FrontQueues": "Green",
-                            "Guid": "1",
-                            "HasUnreadableBlobs": false,
-                            "IncarnationGuid": "not-zero-number-text",
-                            "InstanceGuid": "not-zero-number-text",
-                            "Kind": "0",
-                            "NodeId": 1,
-                            "PDiskId": 1,
-                            "Replicated": true,
-                            "ReplicationProgress": 1,
-                            "ReplicationSecondsRemaining": 0,
-                            "SatisfactionRank": {
-                                "FreshRank": {
-                                    "Flag": "Green"
-                                },
-                                "LevelRank": {
-                                    "Flag": "Green"
-                                }
-                            },
-                            "StoragePoolName": "dynamic_storage_pool:1",
-                            "VDiskId": {
-                                "Domain": 0,
-                                "GroupGeneration": 1,
-                                "GroupID": 2181038080,
-                                "Ring": 0,
-                                "VDisk": 0
-                            },
-                            "VDiskSlotId": 1000,
-                            "VDiskState": "OK"
-                        },
-                        {
-                            "AllocatedSize": "0",
-                            "AvailableSize": "text",
-                            "ChangeTime": "not-zero-number-text",
-                            "DiskSpace": "Green",
-                            "FrontQueues": "Green",
-                            "Guid": "1",
-                            "HasUnreadableBlobs": false,
-                            "IncarnationGuid": "not-zero-number-text",
-                            "InstanceGuid": "not-zero-number-text",
-                            "Kind": "0",
-                            "NodeId": 1,
-                            "PDiskId": 1,
-                            "Replicated": true,
-                            "ReplicationProgress": 1,
-                            "ReplicationSecondsRemaining": 0,
-                            "SatisfactionRank": {
-                                "FreshRank": {
-                                    "Flag": "Green"
-                                },
-                                "LevelRank": {
-                                    "Flag": "Green"
-                                }
-                            },
-                            "StoragePoolName": "dynamic_storage_pool:1",
-                            "VDiskId": {
-                                "Domain": 0,
-                                "GroupGeneration": 1,
-                                "GroupID": 2181038081,
-                                "Ring": 0,
-                                "VDisk": 0
-                            },
-                            "VDiskSlotId": 1001,
-                            "VDiskState": "OK"
-                        },
-                        {
-                            "AllocatedSize": "0",
-                            "AvailableSize": "text",
-                            "ChangeTime": "not-zero-number-text",
-                            "DiskSpace": "Green",
-                            "FrontQueues": "Green",
-                            "Guid": "1",
-                            "HasUnreadableBlobs": false,
-                            "IncarnationGuid": "not-zero-number-text",
-                            "InstanceGuid": "not-zero-number-text",
-                            "Kind": "0",
-                            "NodeId": 1,
-                            "PDiskId": 1,
-                            "Replicated": true,
-                            "ReplicationProgress": 1,
-                            "ReplicationSecondsRemaining": 0,
-                            "SatisfactionRank": {
-                                "FreshRank": {
-                                    "Flag": "Green"
-                                },
-                                "LevelRank": {
-                                    "Flag": "Green"
-                                }
-                            },
-                            "StoragePoolName": "/Root/dedicated_db:hdd",
-                            "VDiskId": {
-                                "Domain": 0,
-                                "GroupGeneration": 2,
-                                "GroupID": 2181038082,
-                                "Ring": 0,
-                                "VDisk": 0
-                            },
-                            "VDiskSlotId": 1002,
-                            "VDiskState": "OK"
-                        },
-                        {
-                            "AllocatedSize": "0",
-                            "AvailableSize": "text",
-                            "ChangeTime": "not-zero-number-text",
-                            "DiskSpace": "Green",
-                            "FrontQueues": "Green",
-                            "Guid": "1",
-                            "HasUnreadableBlobs": false,
-                            "IncarnationGuid": "not-zero-number-text",
-                            "InstanceGuid": "not-zero-number-text",
-                            "Kind": "0",
-                            "NodeId": 1,
-                            "PDiskId": 1,
-                            "Replicated": true,
-                            "ReplicationProgress": 1,
-                            "ReplicationSecondsRemaining": 0,
-                            "SatisfactionRank": {
-                                "FreshRank": {
-                                    "Flag": "Green"
-                                },
-                                "LevelRank": {
-                                    "Flag": "Green"
-                                }
-                            },
-                            "StoragePoolName": "/Root/shared_db:hdd",
-                            "VDiskId": {
-                                "Domain": 0,
-                                "GroupGeneration": 2,
-                                "GroupID": 2181038083,
-                                "Ring": 0,
-                                "VDisk": 0
-                            },
-                            "VDiskSlotId": 1003,
-                            "VDiskState": "OK"
-                        }
-                    ]
-                }
-            ],
-            "TotalNodes": "1"
-        },
-        "/Root/dedicated_db": {
-            "FieldsAvailable": "1111111110111111111111111111111",
-            "FieldsRequired": "1111111111111111111111111111111",
-            "FoundNodes": "1",
-            "MaximumDisksPerNode": "1",
-            "MaximumSlotsPerDisk": "5",
-            "Nodes": [
-                {
-                    "ClockSkewMaxUs": "text",
-                    "ClockSkewMinUs": "text",
-                    "ClockSkewUs": "text",
-                    "ConnectStatus": "Green",
-                    "Connections": "not-zero-number",
-                    "CpuUsage": "not-zero-number",
-                    "DiskSpaceUsage": "not-zero-number",
-                    "NetworkUtilization": "number",
-                    "NetworkUtilizationMax": "number",
-                    "NetworkUtilizationMin": "number",
-                    "NodeId": 1,
-                    "PDisks": [
-                        {
-                            "AvailableSize": "text",
-                            "Category": "0",
-                            "ChangeTime": "not-zero-number-text",
-                            "Device": "Green",
-                            "EnforcedDynamicSlotSize": "not-zero-number-text",
-                            "Guid": "1",
-                            "LogTotalSize": "not-zero-number-text",
-                            "LogUsedSize": "not-zero-number-text",
-                            "NodeId": 1,
-                            "NumActiveSlots": 5,
-                            "PDiskId": 1,
-                            "Path": "SectorMap:1:64",
-                            "Realtime": "Green",
-                            "SerialNumber": "",
-                            "State": "Normal",
-                            "SystemSize": "not-zero-number-text",
-                            "TotalSize": "not-zero-number-text"
-                        }
-                    ],
-                    "Peers": [
-                        {
-                            "BytesWritten": "text",
-                            "ChangeTime": "not-zero-number-text",
-                            "ClockSkewUs": "text",
-                            "ConnectStatus": "Green",
-                            "ConnectTime": "not-zero-number-text",
-                            "Connected": true,
-                            "NodeId": 1,
-                            "PeerName": "text",
-                            "PeerNodeId": 50000,
-                            "PingTimeUs": "text",
-                            "ScopeId": {
-                                "X1": "72057594046678944",
-                                "X2": "6"
-                            },
-                            "Utilization": "number"
-                        },
-                        {
-                            "BytesWritten": "text",
-                            "ChangeTime": "not-zero-number-text",
-                            "ClockSkewUs": "text",
-                            "ConnectStatus": "Green",
-                            "ConnectTime": "not-zero-number-text",
-                            "Connected": true,
-                            "NodeId": 1,
-                            "PeerName": "text",
-                            "PeerNodeId": 50001,
-                            "PingTimeUs": "text",
-                            "ScopeId": {
-                                "X1": "72057594046678944",
-                                "X2": "7"
-                            },
-                            "Utilization": "number"
-                        }
-                    ],
-                    "PingTimeMaxUs": "text",
-                    "PingTimeMinUs": "text",
-                    "PingTimeUs": "text",
-                    "ReceiveThroughput": "text",
-                    "ReverseClockSkewUs": "text",
-                    "ReversePeers": [
-                        {
-                            "BytesWritten": "text",
-                            "ChangeTime": "not-zero-number-text",
-                            "ClockSkewUs": "text",
-                            "ConnectStatus": "Green",
-                            "ConnectTime": "not-zero-number-text",
-                            "Connected": true,
-                            "NodeId": 50000,
-                            "PeerName": "text",
-                            "PeerNodeId": 1,
-                            "PingTimeUs": "text",
-                            "ScopeId": {
-                                "X1": "0",
-                                "X2": "1"
-                            },
-                            "Utilization": "number"
-                        },
-                        {
-                            "BytesWritten": "text",
-                            "ChangeTime": "not-zero-number-text",
-                            "ClockSkewUs": "text",
-                            "ConnectStatus": "Green",
-                            "ConnectTime": "not-zero-number-text",
-                            "Connected": true,
-                            "NodeId": 50001,
-                            "PeerName": "text",
-                            "PeerNodeId": 1,
-                            "PingTimeUs": "text",
-                            "ScopeId": {
-                                "X1": "0",
-                                "X2": "1"
-                            },
-                            "Utilization": "number"
-                        }
-                    ],
-                    "ReversePingTimeUs": "text",
-                    "SendThroughput": "text",
-                    "SystemState": {
-                        "ChangeTime": "not-zero-number-text",
-                        "CoresTotal": "not-zero-number",
-                        "CoresUsed": "not-zero-number",
-                        "Endpoints": [
-                            {
-                                "Address": "text",
-                                "Name": "grpc"
-                            },
-                            {
-                                "Address": "text",
-                                "Name": "http-mon"
-                            },
-                            {
-                                "Address": "text",
-                                "Name": "ic"
-                            }
-                        ],
-                        "Host": "text",
-                        "LoadAverage": "not-empty-array",
-                        "Location": {
-                            "DataCenter": "1",
-                            "Rack": "1",
-                            "Unit": "1"
-                        },
-                        "MaxDiskUsage": "not-zero-number",
-                        "MemoryLimit": "not-zero-number-text",
-                        "MemoryStats": "not-empty-object",
-                        "NodeId": 1,
-                        "NumberOfCpus": "not-zero-number",
-                        "PoolStats": [
-                            {
-                                "Limit": "not-zero-number",
-                                "Name": "System",
-                                "Threads": 2,
-                                "Usage": "number"
-                            },
-                            {
-                                "Limit": "not-zero-number",
-                                "Name": "User",
-                                "Threads": 3,
-                                "Usage": "number"
-                            },
-                            {
-                                "Limit": "not-zero-number",
-                                "Name": "Batch",
-                                "Threads": 2,
-                                "Usage": "number"
-                            },
-                            {
-                                "Limit": "not-zero-number",
-                                "Name": "IO",
-                                "Threads": 1,
-                                "Usage": "number"
-                            },
-                            {
-                                "Limit": "not-zero-number",
-                                "Name": "IC",
-                                "Threads": 1,
-                                "Usage": "number"
-                            }
-                        ],
-                        "RealNumberOfCpus": "not-zero-number",
-                        "Roles": "not-empty-array",
-                        "StartTime": "not-zero-number-text",
-                        "SystemState": "Green",
-                        "TotalSessions": "number"
-                    },
-                    "UptimeSeconds": "number",
-                    "VDisks": [
-                        {
-                            "AllocatedSize": "0",
-                            "AvailableSize": "text",
-                            "ChangeTime": "not-zero-number-text",
-                            "DiskSpace": "Green",
-                            "FrontQueues": "Green",
-                            "Guid": "1",
-                            "HasUnreadableBlobs": false,
-                            "IncarnationGuid": "not-zero-number-text",
-                            "InstanceGuid": "not-zero-number-text",
-                            "Kind": "0",
-                            "NodeId": 1,
-                            "PDiskId": 1,
-                            "Replicated": true,
-                            "ReplicationProgress": 1,
-                            "ReplicationSecondsRemaining": 0,
-                            "SatisfactionRank": {
-                                "FreshRank": {
-                                    "Flag": "Green"
-                                },
-                                "LevelRank": {
-                                    "Flag": "Green"
-                                }
-                            },
-                            "StoragePoolName": "static",
-                            "VDiskId": {
-                                "Domain": 0,
-                                "GroupGeneration": 1,
-                                "GroupID": 0,
-                                "Ring": 0,
-                                "VDisk": 0
-                            },
-                            "VDiskSlotId": 0,
-                            "VDiskState": "OK"
-                        },
-                        {
-                            "AllocatedSize": "0",
-                            "AvailableSize": "text",
-                            "ChangeTime": "not-zero-number-text",
-                            "DiskSpace": "Green",
-                            "FrontQueues": "Green",
-                            "Guid": "1",
-                            "HasUnreadableBlobs": false,
-                            "IncarnationGuid": "not-zero-number-text",
-                            "InstanceGuid": "not-zero-number-text",
-                            "Kind": "0",
-                            "NodeId": 1,
-                            "PDiskId": 1,
-                            "Replicated": true,
-                            "ReplicationProgress": 1,
-                            "ReplicationSecondsRemaining": 0,
-                            "SatisfactionRank": {
-                                "FreshRank": {
-                                    "Flag": "Green"
-                                },
-                                "LevelRank": {
-                                    "Flag": "Green"
-                                }
-                            },
-                            "StoragePoolName": "dynamic_storage_pool:1",
-                            "VDiskId": {
-                                "Domain": 0,
-                                "GroupGeneration": 1,
-                                "GroupID": 2181038080,
-                                "Ring": 0,
-                                "VDisk": 0
-                            },
-                            "VDiskSlotId": 1000,
-                            "VDiskState": "OK"
-                        },
-                        {
-                            "AllocatedSize": "0",
-                            "AvailableSize": "text",
-                            "ChangeTime": "not-zero-number-text",
-                            "DiskSpace": "Green",
-                            "FrontQueues": "Green",
-                            "Guid": "1",
-                            "HasUnreadableBlobs": false,
-                            "IncarnationGuid": "not-zero-number-text",
-                            "InstanceGuid": "not-zero-number-text",
-                            "Kind": "0",
-                            "NodeId": 1,
-                            "PDiskId": 1,
-                            "Replicated": true,
-                            "ReplicationProgress": 1,
-                            "ReplicationSecondsRemaining": 0,
-                            "SatisfactionRank": {
-                                "FreshRank": {
-                                    "Flag": "Green"
-                                },
-                                "LevelRank": {
-                                    "Flag": "Green"
-                                }
-                            },
-                            "StoragePoolName": "dynamic_storage_pool:1",
-                            "VDiskId": {
-                                "Domain": 0,
-                                "GroupGeneration": 1,
-                                "GroupID": 2181038081,
-                                "Ring": 0,
-                                "VDisk": 0
-                            },
-                            "VDiskSlotId": 1001,
-                            "VDiskState": "OK"
-                        },
-                        {
-                            "AllocatedSize": "0",
-                            "AvailableSize": "text",
-                            "ChangeTime": "not-zero-number-text",
-                            "DiskSpace": "Green",
-                            "FrontQueues": "Green",
-                            "Guid": "1",
-                            "HasUnreadableBlobs": false,
-                            "IncarnationGuid": "not-zero-number-text",
-                            "InstanceGuid": "not-zero-number-text",
-                            "Kind": "0",
-                            "NodeId": 1,
-                            "PDiskId": 1,
-                            "Replicated": true,
-                            "ReplicationProgress": 1,
-                            "ReplicationSecondsRemaining": 0,
-                            "SatisfactionRank": {
-                                "FreshRank": {
-                                    "Flag": "Green"
-                                },
-                                "LevelRank": {
-                                    "Flag": "Green"
-                                }
-                            },
-                            "StoragePoolName": "/Root/dedicated_db:hdd",
-                            "VDiskId": {
-                                "Domain": 0,
-                                "GroupGeneration": 2,
-                                "GroupID": 2181038082,
-                                "Ring": 0,
-                                "VDisk": 0
-                            },
-                            "VDiskSlotId": 1002,
-                            "VDiskState": "OK"
-                        },
-                        {
-                            "AllocatedSize": "0",
-                            "AvailableSize": "text",
-                            "ChangeTime": "not-zero-number-text",
-                            "DiskSpace": "Green",
-                            "FrontQueues": "Green",
-                            "Guid": "1",
-                            "HasUnreadableBlobs": false,
-                            "IncarnationGuid": "not-zero-number-text",
-                            "InstanceGuid": "not-zero-number-text",
-                            "Kind": "0",
-                            "NodeId": 1,
-                            "PDiskId": 1,
-                            "Replicated": true,
-                            "ReplicationProgress": 1,
-                            "ReplicationSecondsRemaining": 0,
-                            "SatisfactionRank": {
-                                "FreshRank": {
-                                    "Flag": "Green"
-                                },
-                                "LevelRank": {
-                                    "Flag": "Green"
-                                }
-                            },
-                            "StoragePoolName": "/Root/shared_db:hdd",
-                            "VDiskId": {
-                                "Domain": 0,
-                                "GroupGeneration": 2,
-                                "GroupID": 2181038083,
-                                "Ring": 0,
-                                "VDisk": 0
-                            },
-                            "VDiskSlotId": 1003,
-                            "VDiskState": "OK"
-                        }
-                    ]
-                }
-            ],
-            "TotalNodes": "1"
-        },
-        "/Root/serverless_db": {
-            "FieldsAvailable": "1111111110111111111111111111111",
-            "FieldsRequired": "1111111111111111111111111111111",
-            "FoundNodes": "1",
-            "MaximumDisksPerNode": "1",
-            "MaximumSlotsPerDisk": "5",
-            "Nodes": [
-                {
-                    "ClockSkewMaxUs": "text",
-                    "ClockSkewMinUs": "text",
-                    "ClockSkewUs": "text",
-                    "ConnectStatus": "Green",
-                    "Connections": "not-zero-number",
-                    "CpuUsage": "not-zero-number",
-                    "DiskSpaceUsage": "not-zero-number",
-                    "NetworkUtilization": "number",
-                    "NetworkUtilizationMax": "number",
-                    "NetworkUtilizationMin": "number",
-                    "NodeId": 1,
-                    "PDisks": [
-                        {
-                            "AvailableSize": "text",
-                            "Category": "0",
-                            "ChangeTime": "not-zero-number-text",
-                            "Device": "Green",
-                            "EnforcedDynamicSlotSize": "not-zero-number-text",
-                            "Guid": "1",
-                            "LogTotalSize": "not-zero-number-text",
-                            "LogUsedSize": "not-zero-number-text",
-                            "NodeId": 1,
-                            "NumActiveSlots": 5,
-                            "PDiskId": 1,
-                            "Path": "SectorMap:1:64",
-                            "Realtime": "Green",
-                            "SerialNumber": "",
-                            "State": "Normal",
-                            "SystemSize": "not-zero-number-text",
-                            "TotalSize": "not-zero-number-text"
-                        }
-                    ],
-                    "Peers": [
-                        {
-                            "BytesWritten": "text",
-                            "ChangeTime": "not-zero-number-text",
-                            "ClockSkewUs": "text",
-                            "ConnectStatus": "Green",
-                            "ConnectTime": "not-zero-number-text",
-                            "Connected": true,
-                            "NodeId": 1,
-                            "PeerName": "text",
-                            "PeerNodeId": 50000,
-                            "PingTimeUs": "text",
-                            "ScopeId": {
-                                "X1": "72057594046678944",
-                                "X2": "6"
-                            },
-                            "Utilization": "number"
-                        },
-                        {
-                            "BytesWritten": "text",
-                            "ChangeTime": "not-zero-number-text",
-                            "ClockSkewUs": "text",
-                            "ConnectStatus": "Green",
-                            "ConnectTime": "not-zero-number-text",
-                            "Connected": true,
-                            "NodeId": 1,
-                            "PeerName": "text",
-                            "PeerNodeId": 50001,
-                            "PingTimeUs": "text",
-                            "ScopeId": {
-                                "X1": "72057594046678944",
-                                "X2": "7"
-                            },
-                            "Utilization": "number"
-                        }
-                    ],
-                    "PingTimeMaxUs": "text",
-                    "PingTimeMinUs": "text",
-                    "PingTimeUs": "text",
-                    "ReceiveThroughput": "text",
-                    "ReverseClockSkewUs": "text",
-                    "ReversePeers": [
-                        {
-                            "BytesWritten": "text",
-                            "ChangeTime": "not-zero-number-text",
-                            "ClockSkewUs": "text",
-                            "ConnectStatus": "Green",
-                            "ConnectTime": "not-zero-number-text",
-                            "Connected": true,
-                            "NodeId": 50000,
-                            "PeerName": "text",
-                            "PeerNodeId": 1,
-                            "PingTimeUs": "text",
-                            "ScopeId": {
-                                "X1": "0",
-                                "X2": "1"
-                            },
-                            "Utilization": "number"
-                        },
-                        {
-                            "BytesWritten": "text",
-                            "ChangeTime": "not-zero-number-text",
-                            "ClockSkewUs": "text",
-                            "ConnectStatus": "Green",
-                            "ConnectTime": "not-zero-number-text",
-                            "Connected": true,
-                            "NodeId": 50001,
-                            "PeerName": "text",
-                            "PeerNodeId": 1,
-                            "PingTimeUs": "text",
-                            "ScopeId": {
-                                "X1": "0",
-                                "X2": "1"
-                            },
-                            "Utilization": "number"
-                        }
-                    ],
-                    "ReversePingTimeUs": "text",
-                    "SendThroughput": "text",
-                    "SystemState": {
-                        "ChangeTime": "not-zero-number-text",
-                        "CoresTotal": "not-zero-number",
-                        "CoresUsed": "not-zero-number",
-                        "Endpoints": [
-                            {
-                                "Address": "text",
-                                "Name": "grpc"
-                            },
-                            {
-                                "Address": "text",
-                                "Name": "http-mon"
-                            },
-                            {
-                                "Address": "text",
-                                "Name": "ic"
-                            }
-                        ],
-                        "Host": "text",
-                        "LoadAverage": "not-empty-array",
-                        "Location": {
-                            "DataCenter": "1",
-                            "Rack": "1",
-                            "Unit": "1"
-                        },
-                        "MaxDiskUsage": "not-zero-number",
-                        "MemoryLimit": "not-zero-number-text",
-                        "MemoryStats": "not-empty-object",
-                        "NodeId": 1,
-                        "NumberOfCpus": "not-zero-number",
-                        "PoolStats": [
-                            {
-                                "Limit": "not-zero-number",
-                                "Name": "System",
-                                "Threads": 2,
-                                "Usage": "number"
-                            },
-                            {
-                                "Limit": "not-zero-number",
-                                "Name": "User",
-                                "Threads": 3,
-                                "Usage": "number"
-                            },
-                            {
-                                "Limit": "not-zero-number",
-                                "Name": "Batch",
-                                "Threads": 2,
-                                "Usage": "number"
-                            },
-                            {
-                                "Limit": "not-zero-number",
-                                "Name": "IO",
-                                "Threads": 1,
-                                "Usage": "number"
-                            },
-                            {
-                                "Limit": "not-zero-number",
-                                "Name": "IC",
-                                "Threads": 1,
-                                "Usage": "number"
-                            }
-                        ],
-                        "RealNumberOfCpus": "not-zero-number",
-                        "Roles": "not-empty-array",
-                        "StartTime": "not-zero-number-text",
-                        "SystemState": "Green",
-                        "TotalSessions": "number"
-                    },
-                    "UptimeSeconds": "number",
-                    "VDisks": [
-                        {
-                            "AllocatedSize": "0",
-                            "AvailableSize": "text",
-                            "ChangeTime": "not-zero-number-text",
-                            "DiskSpace": "Green",
-                            "FrontQueues": "Green",
-                            "Guid": "1",
-                            "HasUnreadableBlobs": false,
-                            "IncarnationGuid": "not-zero-number-text",
-                            "InstanceGuid": "not-zero-number-text",
-                            "Kind": "0",
-                            "NodeId": 1,
-                            "PDiskId": 1,
-                            "Replicated": true,
-                            "ReplicationProgress": 1,
-                            "ReplicationSecondsRemaining": 0,
-                            "SatisfactionRank": {
-                                "FreshRank": {
-                                    "Flag": "Green"
-                                },
-                                "LevelRank": {
-                                    "Flag": "Green"
-                                }
-                            },
-                            "StoragePoolName": "static",
-                            "VDiskId": {
-                                "Domain": 0,
-                                "GroupGeneration": 1,
-                                "GroupID": 0,
-                                "Ring": 0,
-                                "VDisk": 0
-                            },
-                            "VDiskSlotId": 0,
-                            "VDiskState": "OK"
-                        },
-                        {
-                            "AllocatedSize": "0",
-                            "AvailableSize": "text",
-                            "ChangeTime": "not-zero-number-text",
-                            "DiskSpace": "Green",
-                            "FrontQueues": "Green",
-                            "Guid": "1",
-                            "HasUnreadableBlobs": false,
-                            "IncarnationGuid": "not-zero-number-text",
-                            "InstanceGuid": "not-zero-number-text",
-                            "Kind": "0",
-                            "NodeId": 1,
-                            "PDiskId": 1,
-                            "Replicated": true,
-                            "ReplicationProgress": 1,
-                            "ReplicationSecondsRemaining": 0,
-                            "SatisfactionRank": {
-                                "FreshRank": {
-                                    "Flag": "Green"
-                                },
-                                "LevelRank": {
-                                    "Flag": "Green"
-                                }
-                            },
-                            "StoragePoolName": "dynamic_storage_pool:1",
-                            "VDiskId": {
-                                "Domain": 0,
-                                "GroupGeneration": 1,
-                                "GroupID": 2181038080,
-                                "Ring": 0,
-                                "VDisk": 0
-                            },
-                            "VDiskSlotId": 1000,
-                            "VDiskState": "OK"
-                        },
-                        {
-                            "AllocatedSize": "0",
-                            "AvailableSize": "text",
-                            "ChangeTime": "not-zero-number-text",
-                            "DiskSpace": "Green",
-                            "FrontQueues": "Green",
-                            "Guid": "1",
-                            "HasUnreadableBlobs": false,
-                            "IncarnationGuid": "not-zero-number-text",
-                            "InstanceGuid": "not-zero-number-text",
-                            "Kind": "0",
-                            "NodeId": 1,
-                            "PDiskId": 1,
-                            "Replicated": true,
-                            "ReplicationProgress": 1,
-                            "ReplicationSecondsRemaining": 0,
-                            "SatisfactionRank": {
-                                "FreshRank": {
-                                    "Flag": "Green"
-                                },
-                                "LevelRank": {
-                                    "Flag": "Green"
-                                }
-                            },
-                            "StoragePoolName": "dynamic_storage_pool:1",
-                            "VDiskId": {
-                                "Domain": 0,
-                                "GroupGeneration": 1,
-                                "GroupID": 2181038081,
-                                "Ring": 0,
-                                "VDisk": 0
-                            },
-                            "VDiskSlotId": 1001,
-                            "VDiskState": "OK"
-                        },
-                        {
-                            "AllocatedSize": "0",
-                            "AvailableSize": "text",
-                            "ChangeTime": "not-zero-number-text",
-                            "DiskSpace": "Green",
-                            "FrontQueues": "Green",
-                            "Guid": "1",
-                            "HasUnreadableBlobs": false,
-                            "IncarnationGuid": "not-zero-number-text",
-                            "InstanceGuid": "not-zero-number-text",
-                            "Kind": "0",
-                            "NodeId": 1,
-                            "PDiskId": 1,
-                            "Replicated": true,
-                            "ReplicationProgress": 1,
-                            "ReplicationSecondsRemaining": 0,
-                            "SatisfactionRank": {
-                                "FreshRank": {
-                                    "Flag": "Green"
-                                },
-                                "LevelRank": {
-                                    "Flag": "Green"
-                                }
-                            },
-                            "StoragePoolName": "/Root/dedicated_db:hdd",
-                            "VDiskId": {
-                                "Domain": 0,
-                                "GroupGeneration": 2,
-                                "GroupID": 2181038082,
-                                "Ring": 0,
-                                "VDisk": 0
-                            },
-                            "VDiskSlotId": 1002,
-                            "VDiskState": "OK"
-                        },
-                        {
-                            "AllocatedSize": "0",
-                            "AvailableSize": "text",
-                            "ChangeTime": "not-zero-number-text",
-                            "DiskSpace": "Green",
-                            "FrontQueues": "Green",
-                            "Guid": "1",
-                            "HasUnreadableBlobs": false,
-                            "IncarnationGuid": "not-zero-number-text",
-                            "InstanceGuid": "not-zero-number-text",
-                            "Kind": "0",
-                            "NodeId": 1,
-                            "PDiskId": 1,
-                            "Replicated": true,
-                            "ReplicationProgress": 1,
-                            "ReplicationSecondsRemaining": 0,
-                            "SatisfactionRank": {
-                                "FreshRank": {
-                                    "Flag": "Green"
-                                },
-                                "LevelRank": {
-                                    "Flag": "Green"
-                                }
-                            },
-                            "StoragePoolName": "/Root/shared_db:hdd",
-                            "VDiskId": {
-                                "Domain": 0,
-                                "GroupGeneration": 2,
-                                "GroupID": 2181038083,
-                                "Ring": 0,
-                                "VDisk": 0
-                            },
-                            "VDiskSlotId": 1003,
-                            "VDiskState": "OK"
-                        }
-                    ]
-                }
-            ],
-            "TotalNodes": "1"
-        },
-        "/Root/shared_db": {
-            "FieldsAvailable": "1111111110111111111111111111111",
-            "FieldsRequired": "1111111111111111111111111111111",
-            "FoundNodes": "1",
-            "MaximumDisksPerNode": "1",
-            "MaximumSlotsPerDisk": "5",
-            "Nodes": [
-                {
-                    "ClockSkewMaxUs": "text",
-                    "ClockSkewMinUs": "text",
-                    "ClockSkewUs": "text",
-                    "ConnectStatus": "Green",
-                    "Connections": "not-zero-number",
-                    "CpuUsage": "not-zero-number",
-                    "DiskSpaceUsage": "not-zero-number",
-                    "NetworkUtilization": "number",
-                    "NetworkUtilizationMax": "number",
-                    "NetworkUtilizationMin": "number",
-                    "NodeId": 1,
-                    "PDisks": [
-                        {
-                            "AvailableSize": "text",
-                            "Category": "0",
-                            "ChangeTime": "not-zero-number-text",
-                            "Device": "Green",
-                            "EnforcedDynamicSlotSize": "not-zero-number-text",
-                            "Guid": "1",
-                            "LogTotalSize": "not-zero-number-text",
-                            "LogUsedSize": "not-zero-number-text",
-                            "NodeId": 1,
-                            "NumActiveSlots": 5,
-                            "PDiskId": 1,
-                            "Path": "SectorMap:1:64",
-                            "Realtime": "Green",
-                            "SerialNumber": "",
-                            "State": "Normal",
-                            "SystemSize": "not-zero-number-text",
-                            "TotalSize": "not-zero-number-text"
-                        }
-                    ],
-                    "Peers": [
-                        {
-                            "BytesWritten": "text",
-                            "ChangeTime": "not-zero-number-text",
-                            "ClockSkewUs": "text",
-                            "ConnectStatus": "Green",
-                            "ConnectTime": "not-zero-number-text",
-                            "Connected": true,
-                            "NodeId": 1,
-                            "PeerName": "text",
-                            "PeerNodeId": 50000,
-                            "PingTimeUs": "text",
-                            "ScopeId": {
-                                "X1": "72057594046678944",
-                                "X2": "6"
-                            },
-                            "Utilization": "number"
-                        },
-                        {
-                            "BytesWritten": "text",
-                            "ChangeTime": "not-zero-number-text",
-                            "ClockSkewUs": "text",
-                            "ConnectStatus": "Green",
-                            "ConnectTime": "not-zero-number-text",
-                            "Connected": true,
-                            "NodeId": 1,
-                            "PeerName": "text",
-                            "PeerNodeId": 50001,
-                            "PingTimeUs": "text",
-                            "ScopeId": {
-                                "X1": "72057594046678944",
-                                "X2": "7"
-                            },
-                            "Utilization": "number"
-                        }
-                    ],
-                    "PingTimeMaxUs": "text",
-                    "PingTimeMinUs": "text",
-                    "PingTimeUs": "text",
-                    "ReceiveThroughput": "text",
-                    "ReverseClockSkewUs": "text",
-                    "ReversePeers": [
-                        {
-                            "BytesWritten": "text",
-                            "ChangeTime": "not-zero-number-text",
-                            "ClockSkewUs": "text",
-                            "ConnectStatus": "Green",
-                            "ConnectTime": "not-zero-number-text",
-                            "Connected": true,
-                            "NodeId": 50000,
-                            "PeerName": "text",
-                            "PeerNodeId": 1,
-                            "PingTimeUs": "text",
-                            "ScopeId": {
-                                "X1": "0",
-                                "X2": "1"
-                            },
-                            "Utilization": "number"
-                        },
-                        {
-                            "BytesWritten": "text",
-                            "ChangeTime": "not-zero-number-text",
-                            "ClockSkewUs": "text",
-                            "ConnectStatus": "Green",
-                            "ConnectTime": "not-zero-number-text",
-                            "Connected": true,
-                            "NodeId": 50001,
-                            "PeerName": "text",
-                            "PeerNodeId": 1,
-                            "PingTimeUs": "text",
-                            "ScopeId": {
-                                "X1": "0",
-                                "X2": "1"
-                            },
-                            "Utilization": "number"
-                        }
-                    ],
-                    "ReversePingTimeUs": "text",
-                    "SendThroughput": "text",
-                    "SystemState": {
-                        "ChangeTime": "not-zero-number-text",
-                        "CoresTotal": "not-zero-number",
-                        "CoresUsed": "not-zero-number",
-                        "Endpoints": [
-                            {
-                                "Address": "text",
-                                "Name": "grpc"
-                            },
-                            {
-                                "Address": "text",
-                                "Name": "http-mon"
-                            },
-                            {
-                                "Address": "text",
-                                "Name": "ic"
-                            }
-                        ],
-                        "Host": "text",
-                        "LoadAverage": "not-empty-array",
-                        "Location": {
-                            "DataCenter": "1",
-                            "Rack": "1",
-                            "Unit": "1"
-                        },
-                        "MaxDiskUsage": "not-zero-number",
-                        "MemoryLimit": "not-zero-number-text",
-                        "MemoryStats": "not-empty-object",
-                        "NodeId": 1,
-                        "NumberOfCpus": "not-zero-number",
-                        "PoolStats": [
-                            {
-                                "Limit": "not-zero-number",
-                                "Name": "System",
-                                "Threads": 2,
-                                "Usage": "number"
-                            },
-                            {
-                                "Limit": "not-zero-number",
-                                "Name": "User",
-                                "Threads": 3,
-                                "Usage": "number"
-                            },
-                            {
-                                "Limit": "not-zero-number",
-                                "Name": "Batch",
-                                "Threads": 2,
-                                "Usage": "number"
-                            },
-                            {
-                                "Limit": "not-zero-number",
-                                "Name": "IO",
-                                "Threads": 1,
-                                "Usage": "number"
-                            },
-                            {
-                                "Limit": "not-zero-number",
-                                "Name": "IC",
-                                "Threads": 1,
-                                "Usage": "number"
-                            }
-                        ],
-                        "RealNumberOfCpus": "not-zero-number",
-                        "Roles": "not-empty-array",
-                        "StartTime": "not-zero-number-text",
-                        "SystemState": "Green",
-                        "TotalSessions": "number"
-                    },
-                    "UptimeSeconds": "number",
-                    "VDisks": [
-                        {
-                            "AllocatedSize": "0",
-                            "AvailableSize": "text",
-                            "ChangeTime": "not-zero-number-text",
-                            "DiskSpace": "Green",
-                            "FrontQueues": "Green",
-                            "Guid": "1",
-                            "HasUnreadableBlobs": false,
-                            "IncarnationGuid": "not-zero-number-text",
-                            "InstanceGuid": "not-zero-number-text",
-                            "Kind": "0",
-                            "NodeId": 1,
-                            "PDiskId": 1,
-                            "Replicated": true,
-                            "ReplicationProgress": 1,
-                            "ReplicationSecondsRemaining": 0,
-                            "SatisfactionRank": {
-                                "FreshRank": {
-                                    "Flag": "Green"
-                                },
-                                "LevelRank": {
-                                    "Flag": "Green"
-                                }
-                            },
-                            "StoragePoolName": "static",
-                            "VDiskId": {
-                                "Domain": 0,
-                                "GroupGeneration": 1,
-                                "GroupID": 0,
-                                "Ring": 0,
-                                "VDisk": 0
-                            },
-                            "VDiskSlotId": 0,
-                            "VDiskState": "OK"
-                        },
-                        {
-                            "AllocatedSize": "0",
-                            "AvailableSize": "text",
-                            "ChangeTime": "not-zero-number-text",
-                            "DiskSpace": "Green",
-                            "FrontQueues": "Green",
-                            "Guid": "1",
-                            "HasUnreadableBlobs": false,
-                            "IncarnationGuid": "not-zero-number-text",
-                            "InstanceGuid": "not-zero-number-text",
-                            "Kind": "0",
-                            "NodeId": 1,
-                            "PDiskId": 1,
-                            "Replicated": true,
-                            "ReplicationProgress": 1,
-                            "ReplicationSecondsRemaining": 0,
-                            "SatisfactionRank": {
-                                "FreshRank": {
-                                    "Flag": "Green"
-                                },
-                                "LevelRank": {
-                                    "Flag": "Green"
-                                }
-                            },
-                            "StoragePoolName": "dynamic_storage_pool:1",
-                            "VDiskId": {
-                                "Domain": 0,
-                                "GroupGeneration": 1,
-                                "GroupID": 2181038080,
-                                "Ring": 0,
-                                "VDisk": 0
-                            },
-                            "VDiskSlotId": 1000,
-                            "VDiskState": "OK"
-                        },
-                        {
-                            "AllocatedSize": "0",
-                            "AvailableSize": "text",
-                            "ChangeTime": "not-zero-number-text",
-                            "DiskSpace": "Green",
-                            "FrontQueues": "Green",
-                            "Guid": "1",
-                            "HasUnreadableBlobs": false,
-                            "IncarnationGuid": "not-zero-number-text",
-                            "InstanceGuid": "not-zero-number-text",
-                            "Kind": "0",
-                            "NodeId": 1,
-                            "PDiskId": 1,
-                            "Replicated": true,
-                            "ReplicationProgress": 1,
-                            "ReplicationSecondsRemaining": 0,
-                            "SatisfactionRank": {
-                                "FreshRank": {
-                                    "Flag": "Green"
-                                },
-                                "LevelRank": {
-                                    "Flag": "Green"
-                                }
-                            },
-                            "StoragePoolName": "dynamic_storage_pool:1",
-                            "VDiskId": {
-                                "Domain": 0,
-                                "GroupGeneration": 1,
-                                "GroupID": 2181038081,
-                                "Ring": 0,
-                                "VDisk": 0
-                            },
-                            "VDiskSlotId": 1001,
-                            "VDiskState": "OK"
-                        },
-                        {
-                            "AllocatedSize": "0",
-                            "AvailableSize": "text",
-                            "ChangeTime": "not-zero-number-text",
-                            "DiskSpace": "Green",
-                            "FrontQueues": "Green",
-                            "Guid": "1",
-                            "HasUnreadableBlobs": false,
-                            "IncarnationGuid": "not-zero-number-text",
-                            "InstanceGuid": "not-zero-number-text",
-                            "Kind": "0",
-                            "NodeId": 1,
-                            "PDiskId": 1,
-                            "Replicated": true,
-                            "ReplicationProgress": 1,
-                            "ReplicationSecondsRemaining": 0,
-                            "SatisfactionRank": {
-                                "FreshRank": {
-                                    "Flag": "Green"
-                                },
-                                "LevelRank": {
-                                    "Flag": "Green"
-                                }
-                            },
-                            "StoragePoolName": "/Root/dedicated_db:hdd",
-                            "VDiskId": {
-                                "Domain": 0,
-                                "GroupGeneration": 2,
-                                "GroupID": 2181038082,
-                                "Ring": 0,
-                                "VDisk": 0
-                            },
-                            "VDiskSlotId": 1002,
-                            "VDiskState": "OK"
-                        },
-                        {
-                            "AllocatedSize": "0",
-                            "AvailableSize": "text",
-                            "ChangeTime": "not-zero-number-text",
-                            "DiskSpace": "Green",
-                            "FrontQueues": "Green",
-                            "Guid": "1",
-                            "HasUnreadableBlobs": false,
-                            "IncarnationGuid": "not-zero-number-text",
-                            "InstanceGuid": "not-zero-number-text",
-                            "Kind": "0",
-                            "NodeId": 1,
-                            "PDiskId": 1,
-                            "Replicated": true,
-                            "ReplicationProgress": 1,
-                            "ReplicationSecondsRemaining": 0,
-                            "SatisfactionRank": {
-                                "FreshRank": {
-                                    "Flag": "Green"
-                                },
-                                "LevelRank": {
-                                    "Flag": "Green"
-                                }
-                            },
-                            "StoragePoolName": "/Root/shared_db:hdd",
-                            "VDiskId": {
-                                "Domain": 0,
-                                "GroupGeneration": 2,
-                                "GroupID": 2181038083,
-                                "Ring": 0,
-                                "VDisk": 0
-                            },
-                            "VDiskSlotId": 1003,
-                            "VDiskState": "OK"
-                        }
-                    ]
-                }
-            ],
-            "TotalNodes": "1"
+            "version": 8
         }
     },
     "test.test_viewer_sysinfo": {
@@ -7083,7 +3616,7 @@
                 "Tenants": [
                     "/Root/shared_db"
                 ],
-                "TotalSessions": "number"
+                "TotalSessions": 0
             },
             {
                 "ChangeTime": "not-zero-number-text",
@@ -7149,7 +3682,7 @@
                 "Tenants": [
                     "/Root/dedicated_db"
                 ],
-                "TotalSessions": "number"
+                "TotalSessions": 0
             },
             {
                 "ChangeTime": "not-zero-number-text",
@@ -7213,7 +3746,7 @@
                 "Roles": "not-empty-array",
                 "StartTime": "not-zero-number-text",
                 "SystemState": 1,
-                "TotalSessions": "number"
+                "TotalSessions": 0
             }
         ]
     },
@@ -7331,7 +3864,7 @@
                         "NodeId": 1,
                         "Overall": 1,
                         "State": 10,
-                        "TabletId": "72057594046678944",
+                        "TabletId": "72075186232723360",
                         "Type": 16
                     }
                 ]
@@ -7353,7 +3886,7 @@
                         "TabletId": "72075186224037888",
                         "TenantId": {
                             "PathId": "not-zero-number-text",
-                            "SchemeShard": "72057594046678944"
+                            "SchemeShard": "72075186232723360"
                         },
                         "Type": 14
                     },
@@ -7369,7 +3902,7 @@
                         "TabletId": "72075186224037889",
                         "TenantId": {
                             "PathId": "not-zero-number-text",
-                            "SchemeShard": "72057594046678944"
+                            "SchemeShard": "72075186232723360"
                         },
                         "Type": 5
                     },
@@ -7385,7 +3918,7 @@
                         "TabletId": "72075186224037890",
                         "TenantId": {
                             "PathId": "not-zero-number-text",
-                            "SchemeShard": "72057594046678944"
+                            "SchemeShard": "72075186232723360"
                         },
                         "Type": 5
                     },
@@ -7401,7 +3934,7 @@
                         "TabletId": "72075186224037891",
                         "TenantId": {
                             "PathId": "not-zero-number-text",
-                            "SchemeShard": "72057594046678944"
+                            "SchemeShard": "72075186232723360"
                         },
                         "Type": 32
                     },
@@ -7417,7 +3950,7 @@
                         "TabletId": "72075186224037892",
                         "TenantId": {
                             "PathId": "not-zero-number-text",
-                            "SchemeShard": "72057594046678944"
+                            "SchemeShard": "72075186232723360"
                         },
                         "Type": 5
                     },
@@ -7433,7 +3966,7 @@
                         "TabletId": "72075186224037893",
                         "TenantId": {
                             "PathId": "not-zero-number-text",
-                            "SchemeShard": "72057594046678944"
+                            "SchemeShard": "72075186232723360"
                         },
                         "Type": 13
                     },
@@ -7449,7 +3982,7 @@
                         "TabletId": "72075186224037894",
                         "TenantId": {
                             "PathId": "not-zero-number-text",
-                            "SchemeShard": "72057594046678944"
+                            "SchemeShard": "72075186232723360"
                         },
                         "Type": 40
                     },
@@ -7465,7 +3998,7 @@
                         "TabletId": "72075186224037895",
                         "TenantId": {
                             "PathId": "not-zero-number-text",
-                            "SchemeShard": "72057594046678944"
+                            "SchemeShard": "72075186232723360"
                         },
                         "Type": 13
                     },
@@ -7481,7 +4014,7 @@
                         "TabletId": "72075186224037896",
                         "TenantId": {
                             "PathId": "not-zero-number-text",
-                            "SchemeShard": "72057594046678944"
+                            "SchemeShard": "72075186232723360"
                         },
                         "Type": 13
                     },
@@ -7497,25 +4030,9 @@
                         "TabletId": "72075186224037897",
                         "TenantId": {
                             "PathId": "not-zero-number-text",
-                            "SchemeShard": "72057594046678944"
+                            "SchemeShard": "72075186232723360"
                         },
                         "Type": 16
-                    },
-                    {
-                        "ChangeTime": "not-zero-number-text",
-                        "FollowerId": 0,
-                        "Generation": 1,
-                        "HiveId": "72075186224037888",
-                        "Leader": true,
-                        "NodeId": 50000,
-                        "Overall": 1,
-                        "State": 10,
-                        "TabletId": "72075186224037898",
-                        "TenantId": {
-                            "PathId": "not-zero-number-text",
-                            "SchemeShard": "72057594046678944"
-                        },
-                        "Type": 18
                     }
                 ]
             },
@@ -7536,7 +4053,7 @@
                         "TabletId": "72075186224038899",
                         "TenantId": {
                             "PathId": "not-zero-number-text",
-                            "SchemeShard": "72057594046678944"
+                            "SchemeShard": "72075186232723360"
                         },
                         "Type": 16
                     },
@@ -7552,7 +4069,7 @@
                         "TabletId": "72075186224038900",
                         "TenantId": {
                             "PathId": "not-zero-number-text",
-                            "SchemeShard": "72057594046678944"
+                            "SchemeShard": "72075186232723360"
                         },
                         "Type": 13
                     },
@@ -7568,7 +4085,7 @@
                         "TabletId": "72075186224038901",
                         "TenantId": {
                             "PathId": "not-zero-number-text",
-                            "SchemeShard": "72057594046678944"
+                            "SchemeShard": "72075186232723360"
                         },
                         "Type": 5
                     },
@@ -7584,7 +4101,7 @@
                         "TabletId": "72075186224038902",
                         "TenantId": {
                             "PathId": "not-zero-number-text",
-                            "SchemeShard": "72057594046678944"
+                            "SchemeShard": "72075186232723360"
                         },
                         "Type": 5
                     },
@@ -7600,7 +4117,7 @@
                         "TabletId": "72075186224038903",
                         "TenantId": {
                             "PathId": "not-zero-number-text",
-                            "SchemeShard": "72057594046678944"
+                            "SchemeShard": "72075186232723360"
                         },
                         "Type": 5
                     },
@@ -7616,25 +4133,9 @@
                         "TabletId": "72075186224038904",
                         "TenantId": {
                             "PathId": "not-zero-number-text",
-                            "SchemeShard": "72057594046678944"
+                            "SchemeShard": "72075186232723360"
                         },
                         "Type": 32
-                    },
-                    {
-                        "ChangeTime": "not-zero-number-text",
-                        "FollowerId": 0,
-                        "Generation": 1,
-                        "HiveId": "72075186224038889",
-                        "Leader": true,
-                        "NodeId": 50001,
-                        "Overall": 1,
-                        "State": 10,
-                        "TabletId": "72075186224038906",
-                        "TenantId": {
-                            "PathId": "not-zero-number-text",
-                            "SchemeShard": "72057594046678944"
-                        },
-                        "Type": 18
                     }
                 ]
             },
@@ -7655,7 +4156,7 @@
                         "TabletId": "72075186224038889",
                         "TenantId": {
                             "PathId": "not-zero-number-text",
-                            "SchemeShard": "72057594046678944"
+                            "SchemeShard": "72075186232723360"
                         },
                         "Type": 14
                     },
@@ -7671,7 +4172,7 @@
                         "TabletId": "72075186224038890",
                         "TenantId": {
                             "PathId": "not-zero-number-text",
-                            "SchemeShard": "72057594046678944"
+                            "SchemeShard": "72075186232723360"
                         },
                         "Type": 40
                     },
@@ -7687,7 +4188,7 @@
                         "TabletId": "72075186224038891",
                         "TenantId": {
                             "PathId": "not-zero-number-text",
-                            "SchemeShard": "72057594046678944"
+                            "SchemeShard": "72075186232723360"
                         },
                         "Type": 5
                     },
@@ -7703,7 +4204,7 @@
                         "TabletId": "72075186224038892",
                         "TenantId": {
                             "PathId": "not-zero-number-text",
-                            "SchemeShard": "72057594046678944"
+                            "SchemeShard": "72075186232723360"
                         },
                         "Type": 5
                     },
@@ -7719,7 +4220,7 @@
                         "TabletId": "72075186224038893",
                         "TenantId": {
                             "PathId": "not-zero-number-text",
-                            "SchemeShard": "72057594046678944"
+                            "SchemeShard": "72075186232723360"
                         },
                         "Type": 32
                     },
@@ -7735,7 +4236,7 @@
                         "TabletId": "72075186224038894",
                         "TenantId": {
                             "PathId": "not-zero-number-text",
-                            "SchemeShard": "72057594046678944"
+                            "SchemeShard": "72075186232723360"
                         },
                         "Type": 13
                     },
@@ -7751,7 +4252,7 @@
                         "TabletId": "72075186224038895",
                         "TenantId": {
                             "PathId": "not-zero-number-text",
-                            "SchemeShard": "72057594046678944"
+                            "SchemeShard": "72075186232723360"
                         },
                         "Type": 13
                     },
@@ -7767,7 +4268,7 @@
                         "TabletId": "72075186224038896",
                         "TenantId": {
                             "PathId": "not-zero-number-text",
-                            "SchemeShard": "72057594046678944"
+                            "SchemeShard": "72075186232723360"
                         },
                         "Type": 13
                     },
@@ -7783,7 +4284,7 @@
                         "TabletId": "72075186224038897",
                         "TenantId": {
                             "PathId": "not-zero-number-text",
-                            "SchemeShard": "72057594046678944"
+                            "SchemeShard": "72075186232723360"
                         },
                         "Type": 5
                     },
@@ -7799,25 +4300,9 @@
                         "TabletId": "72075186224038898",
                         "TenantId": {
                             "PathId": "not-zero-number-text",
-                            "SchemeShard": "72057594046678944"
+                            "SchemeShard": "72075186232723360"
                         },
                         "Type": 16
-                    },
-                    {
-                        "ChangeTime": "not-zero-number-text",
-                        "FollowerId": 0,
-                        "Generation": 1,
-                        "HiveId": "72075186224038889",
-                        "Leader": true,
-                        "NodeId": 50001,
-                        "Overall": 1,
-                        "State": 10,
-                        "TabletId": "72075186224038905",
-                        "TenantId": {
-                            "PathId": "not-zero-number-text",
-                            "SchemeShard": "72057594046678944"
-                        },
-                        "Type": 18
                     }
                 ]
             }
@@ -7877,10 +4362,6 @@
                     },
                     {
                         "Count": 1,
-                        "Type": "DataShard"
-                    },
-                    {
-                        "Count": 1,
                         "Type": "Hive"
                     },
                     {
@@ -7909,10 +4390,6 @@
                         "Type": "Coordinator"
                     },
                     {
-                        "Count": 1,
-                        "Type": "DataShard"
-                    },
-                    {
                         "Count": 3,
                         "Type": "Mediator"
                     },
@@ -7932,10 +4409,6 @@
                     {
                         "Count": 3,
                         "Type": "Coordinator"
-                    },
-                    {
-                        "Count": 1,
-                        "Type": "DataShard"
                     },
                     {
                         "Count": 1,
@@ -7968,7 +4441,7 @@
                 "CoresTotal": "not-zero-number",
                 "CoresUsed": "not-zero-number",
                 "CreateTime": "not-zero-number-text",
-                "Id": "72057594046678944-1",
+                "Id": "72075186232723360-1",
                 "MemoryLimit": "not-zero-number-text",
                 "MemoryStats": {},
                 "Metrics": {},
@@ -8015,7 +4488,7 @@
                 "CoresTotal": "not-zero-number",
                 "CoresUsed": "not-zero-number",
                 "DatabaseQuotas": {},
-                "Id": "72057594046678944-6",
+                "Id": "72075186232723360-6",
                 "MemoryLimit": "not-zero-number-text",
                 "MemoryStats": {},
                 "Metrics": "not-empty-object",
@@ -8073,7 +4546,7 @@
                 "State": "RUNNING",
                 "StateStats": [
                     {
-                        "Count": 10,
+                        "Count": 9,
                         "VolatileState": "TABLET_VOLATILE_STATE_RUNNING"
                     }
                 ],
@@ -8082,16 +4555,16 @@
             {
                 "CoresUsed": "not-zero-number",
                 "DatabaseQuotas": {},
-                "Id": "72057594046678944-8",
+                "Id": "72075186232723360-8",
                 "Metrics": "not-empty-object",
                 "Name": "/Root/serverless_db",
                 "Overall": "Green",
                 "Owner": "root@builtin",
-                "ResourceId": "72057594046678944-7",
+                "ResourceId": "72075186232723360-7",
                 "State": "RUNNING",
                 "StateStats": [
                     {
-                        "Count": 7,
+                        "Count": 6,
                         "VolatileState": "TABLET_VOLATILE_STATE_RUNNING"
                     }
                 ],
@@ -8102,7 +4575,7 @@
                 "CoresTotal": "not-zero-number",
                 "CoresUsed": "not-zero-number",
                 "DatabaseQuotas": {},
-                "Id": "72057594046678944-7",
+                "Id": "72075186232723360-7",
                 "MemoryLimit": "not-zero-number-text",
                 "MemoryStats": {},
                 "Metrics": "not-empty-object",
@@ -8153,7 +4626,7 @@
                 "State": "RUNNING",
                 "StateStats": [
                     {
-                        "Count": 10,
+                        "Count": 9,
                         "VolatileState": "TABLET_VOLATILE_STATE_RUNNING"
                     }
                 ],
@@ -8169,7 +4642,7 @@
                     "CoresTotal": "not-zero-number",
                     "CoresUsed": "not-zero-number",
                     "CreateTime": "not-zero-number-text",
-                    "Id": "72057594046678944-1",
+                    "Id": "72075186232723360-1",
                     "MemoryLimit": "not-zero-number-text",
                     "MemoryStats": {},
                     "Metrics": {},
@@ -8220,7 +4693,7 @@
                     "CoresTotal": "not-zero-number",
                     "CoresUsed": "not-zero-number",
                     "DatabaseQuotas": {},
-                    "Id": "72057594046678944-6",
+                    "Id": "72075186232723360-6",
                     "MemoryLimit": "not-zero-number-text",
                     "MemoryStats": {},
                     "Metrics": "not-empty-object",
@@ -8278,7 +4751,7 @@
                     "State": "RUNNING",
                     "StateStats": [
                         {
-                            "Count": 10,
+                            "Count": 9,
                             "VolatileState": "TABLET_VOLATILE_STATE_RUNNING"
                         }
                     ],
@@ -8291,15 +4764,15 @@
                 {
                     "CoresUsed": "not-zero-number",
                     "DatabaseQuotas": {},
-                    "Id": "72057594046678944-8",
+                    "Id": "72075186232723360-8",
                     "Metrics": "not-empty-object",
                     "Name": "/Root/serverless_db",
                     "Owner": "root@builtin",
-                    "ResourceId": "72057594046678944-7",
+                    "ResourceId": "72075186232723360-7",
                     "State": "RUNNING",
                     "StateStats": [
                         {
-                            "Count": 7,
+                            "Count": 6,
                             "VolatileState": "TABLET_VOLATILE_STATE_RUNNING"
                         }
                     ],
@@ -8314,7 +4787,7 @@
                     "CoresTotal": "not-zero-number",
                     "CoresUsed": "not-zero-number",
                     "DatabaseQuotas": {},
-                    "Id": "72057594046678944-7",
+                    "Id": "72075186232723360-7",
                     "MemoryLimit": "not-zero-number-text",
                     "MemoryStats": {},
                     "Metrics": "not-empty-object",
@@ -8365,7 +4838,7 @@
                     "State": "RUNNING",
                     "StateStats": [
                         {
-                            "Count": 10,
+                            "Count": 9,
                             "VolatileState": "TABLET_VOLATILE_STATE_RUNNING"
                         }
                     ],

--- a/ydb/core/viewer/viewer_nodes.h
+++ b/ydb/core/viewer/viewer_nodes.h
@@ -749,7 +749,8 @@ class TJsonNodes : public TViewerPipeClient {
     std::vector<TNodeBatch> OriginalNodeBatches;
     bool DumpOriginalNodeBatches = false;
 
-    TFieldsType FieldsRequired;
+    TFieldsType FieldsRequested; // fields that were requested by user
+    TFieldsType FieldsRequired; // fields that are required to calculate the response
     TFieldsType FieldsAvailable;
     const TFieldsType FieldsAll = TFieldsType().set();
     const TFieldsType FieldsNodeInfo = TFieldsType().set(+ENodeFields::NodeInfo)
@@ -1056,6 +1057,7 @@ public:
             NeedSort = false;
             NeedLimit = false;
         }
+        FieldsRequested = FieldsRequired; // no dependent fields
         for (auto field = +ENodeFields::NodeId; field != +ENodeFields::COUNT; ++field) {
             if (FieldsRequired.test(field)) {
                 auto itDependentFields = DependentFields.find(static_cast<ENodeFields>(field));
@@ -3168,33 +3170,33 @@ public:
                 if (FieldsAvailable.test(+ENodeFields::NodeInfo)) {
                     jsonNode.SetNodeId(node->GetNodeId());
                 }
-                if (node->Database) {
+                if (node->Database && FieldsRequested.test(+ENodeFields::Database)) {
                     jsonNode.SetDatabase(node->Database);
                 }
-                if (node->UptimeSeconds) {
+                if (node->UptimeSeconds && FieldsRequested.test(+ENodeFields::Uptime)) {
                     jsonNode.SetUptimeSeconds(*(node->UptimeSeconds));
                 }
                 if (node->Disconnected) {
                     jsonNode.SetDisconnected(node->Disconnected);
                 }
-                if (node->CpuUsage) {
+                if (node->CpuUsage && FieldsRequested.test(+ENodeFields::CPU)) {
                     jsonNode.SetCpuUsage(node->CpuUsage);
                 }
-                if (node->DiskSpaceUsage) {
+                if (node->DiskSpaceUsage && FieldsRequested.test(+ENodeFields::DiskSpaceUsage)) {
                     jsonNode.SetDiskSpaceUsage(node->DiskSpaceUsage);
                 }
-                if (FieldsAvailable.test(+ENodeFields::Connections)) {
+                if (FieldsAvailable.test(+ENodeFields::Connections) && FieldsRequested.test(+ENodeFields::Connections)) {
                     jsonNode.SetConnections(node->Connections);
                 }
-                if (FieldsAvailable.test(+ENodeFields::ConnectStatus)) {
+                if (FieldsAvailable.test(+ENodeFields::ConnectStatus) && FieldsRequested.test(+ENodeFields::ConnectStatus)) {
                     jsonNode.SetConnectStatus(GetViewerFlag(node->ConnectStatus));
                 }
-                if (FieldsAvailable.test(+ENodeFields::NetworkUtilization)) {
+                if (FieldsAvailable.test(+ENodeFields::NetworkUtilization) && FieldsRequested.test(+ENodeFields::NetworkUtilization)) {
                     jsonNode.SetNetworkUtilization(node->NetworkUtilization);
                     jsonNode.SetNetworkUtilizationMin(node->NetworkUtilizationMin);
                     jsonNode.SetNetworkUtilizationMax(node->NetworkUtilizationMax);
                 }
-                if (FieldsAvailable.test(+ENodeFields::ClockSkew)) {
+                if (FieldsAvailable.test(+ENodeFields::ClockSkew) && FieldsRequested.test(+ENodeFields::ClockSkew)) {
                     jsonNode.SetClockSkewUs(node->ClockSkewUs);
                     jsonNode.SetClockSkewMinUs(node->ClockSkewMinUs);
                     jsonNode.SetClockSkewMaxUs(node->ClockSkewMaxUs);
@@ -3202,7 +3204,7 @@ public:
                         jsonNode.SetReverseClockSkewUs(node->ReverseClockSkewUs);
                     }
                 }
-                if (FieldsAvailable.test(+ENodeFields::PingTime)) {
+                if (FieldsAvailable.test(+ENodeFields::PingTime) && FieldsRequested.test(+ENodeFields::PingTime)) {
                     jsonNode.SetPingTimeUs(node->PingTimeUs);
                     jsonNode.SetPingTimeMinUs(node->PingTimeMinUs);
                     jsonNode.SetPingTimeMaxUs(node->PingTimeMaxUs);
@@ -3210,16 +3212,16 @@ public:
                         jsonNode.SetReversePingTimeUs(node->ReversePingTimeUs);
                     }
                 }
-                if (FieldsAvailable.test(+ENodeFields::SendThroughput)) {
+                if (FieldsAvailable.test(+ENodeFields::SendThroughput) && FieldsRequested.test(+ENodeFields::SendThroughput)) {
                     jsonNode.SetSendThroughput(node->SendThroughput);
                 }
-                if (FieldsAvailable.test(+ENodeFields::ReceiveThroughput)) {
+                if (FieldsAvailable.test(+ENodeFields::ReceiveThroughput) && FieldsRequested.test(+ENodeFields::ReceiveThroughput)) {
                     jsonNode.SetReceiveThroughput(node->ReceiveThroughput);
                 }
-                if (FieldsAvailable.test(+ENodeFields::NodeInfo) || FieldsAvailable.test(+ENodeFields::SystemState)) {
+                if ((FieldsAvailable.test(+ENodeFields::NodeInfo) || FieldsAvailable.test(+ENodeFields::SystemState)) && FieldsRequested.test(+ENodeFields::SystemState)) {
                     *jsonNode.MutableSystemState() = std::move(node->SystemState);
                 }
-                if (FieldsAvailable.test(+ENodeFields::PDisks)) {
+                if (FieldsAvailable.test(+ENodeFields::PDisks) && FieldsRequested.test(+ENodeFields::PDisks)) {
                     std::sort(node->PDisks.begin(), node->PDisks.end(), [](const NKikimrWhiteboard::TPDiskStateInfo& a, const NKikimrWhiteboard::TPDiskStateInfo& b) {
                         return a.path() < b.path();
                     });
@@ -3227,7 +3229,7 @@ public:
                         (*jsonNode.AddPDisks()) = std::move(pDisk);
                     }
                 }
-                if (FieldsAvailable.test(+ENodeFields::VDisks)) {
+                if (FieldsAvailable.test(+ENodeFields::VDisks) && FieldsRequested.test(+ENodeFields::VDisks)) {
                     std::sort(node->VDisks.begin(), node->VDisks.end(), [](const NKikimrWhiteboard::TVDiskStateInfo& a, const NKikimrWhiteboard::TVDiskStateInfo& b) {
                         return VDiskIDFromVDiskID(a.vdiskid()) < VDiskIDFromVDiskID(b.vdiskid());
                     });
@@ -3235,7 +3237,7 @@ public:
                         (*jsonNode.AddVDisks()) = std::move(vDisk);
                     }
                 }
-                if (FieldsAvailable.test(+ENodeFields::Tablets)) {
+                if (FieldsAvailable.test(+ENodeFields::Tablets) && FieldsRequested.test(+ENodeFields::Tablets)) {
                     std::sort(node->Tablets.begin(), node->Tablets.end(), [](const NKikimrViewer::TTabletStateInfo& a, const NKikimrViewer::TTabletStateInfo& b) {
                         return a.type() < b.type();
                     });
@@ -3243,13 +3245,7 @@ public:
                         (*jsonNode.AddTablets()) = std::move(tablet);
                     }
                 }
-                if (FieldsAvailable.test(+ENodeFields::SendThroughput)) {
-                    jsonNode.SetSendThroughput(node->SendThroughput);
-                }
-                if (FieldsAvailable.test(+ENodeFields::ReceiveThroughput)) {
-                    jsonNode.SetReceiveThroughput(node->ReceiveThroughput);
-                }
-                if (FieldsRequired.test(+ENodeFields::Peers)) {
+                if (FieldsRequested.test(+ENodeFields::Peers)) {
                     std::sort(node->Peers.begin(), node->Peers.end(), [](const NKikimrWhiteboard::TNodeStateInfo& a, const NKikimrWhiteboard::TNodeStateInfo& b) {
                         return a.peernodeid() < b.peernodeid();
                     });
@@ -3257,7 +3253,7 @@ public:
                         (*jsonNode.AddPeers()) = std::move(peer);
                     }
                 }
-                if (FieldsRequired.test(+ENodeFields::ReversePeers)) {
+                if (FieldsRequested.test(+ENodeFields::ReversePeers)) {
                     std::sort(node->ReversePeers.begin(), node->ReversePeers.end(), [](const NKikimrWhiteboard::TNodeStateInfo& a, const NKikimrWhiteboard::TNodeStateInfo& b) {
                         return a.nodeid() < b.nodeid();
                     });
@@ -3274,7 +3270,13 @@ public:
             }
         }
         AddEvent("RenderingResult");
-        TBase::ReplyAndPassAway(GetHTTPOKJSON(json));
+        TStringStream jsonBody;
+        Proto2Json(json, jsonBody);
+        AddEvent("ResultRendered");
+        if (Span) {
+            Span.Attribute("result_size", TStringBuilder() << jsonBody.Size());
+        }
+        TBase::ReplyAndPassAway(GetHTTPOKJSON(jsonBody.Str()));
     }
 
     static YAML::Node GetSwagger() {


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

Make nodes less critical (to make cluster less critical), closes https://github.com/ydb-platform/ydb/issues/19676
Minimize returned data to avoid large responses, closes https://github.com/ydb-platform/ydb/issues/19810

### Changelog category <!-- remove all except one -->

* Bugfix 

### Description for reviewers <!-- (optional) description for those who read this PR -->

Нужно выкатить asap:
1. множественные жалобы пользователей (включая внешних) что текущее изменение вызывает панику при просмотре кластера.
2. в текущей версии если посмотреть закладку сеть на большом кластере, она может вернуть ответ в ~300MB что фактически убивает браузер.
