### PR TITLE
Get SysView available types for each SourceObject type

### DIFF
--- a/ydb/core/sys_view/common/schema.cpp
+++ b/ydb/core/sys_view/common/schema.cpp
@@ -210,6 +210,19 @@ public:
         return result;
     }
 
+    const THashMap<TString, ESysViewType>& GetSystemViewsTypes(ETarget target) const override {
+        switch (target) {
+        case ETarget::Domain:
+            return DomainSystemViewTypes;
+        case ETarget::SubDomain:
+            return SubDomainSystemViewTypes;
+        case ETarget::OlapStore:
+            return OlapStoreSystemViewTypes;
+        case ETarget::ColumnTable:
+            return ColumnTableSystemViewTypes;
+        }
+    }
+
     bool IsSystemView(const TStringBuf viewName) const override final {
         return DomainSystemViews.contains(viewName) ||
             SubDomainSystemViews.contains(viewName) ||
@@ -221,7 +234,9 @@ private:
     void RegisterPgTablesSystemViews() {
         auto registerView = [&](TStringBuf tableName, ESysViewType type, const TVector<Schema::PgColumn>& columns) {
             auto& dsv  = DomainSystemViews[tableName];
+            DomainSystemViewTypes[tableName] = type;
             auto& sdsv = SubDomainSystemViews[tableName];
+            SubDomainSystemViewTypes[tableName] = type;
             auto& sv = SystemViews[type];
             for (const auto& column : columns) {
                 dsv.Columns[column._ColumnId + 1] = TSysTables::TTableColumnInfo(
@@ -255,13 +270,16 @@ private:
     template <typename Table>
     void RegisterSystemView(const TStringBuf& name, ESysViewType type) {
         TSchemaFiller<Table>::Fill(DomainSystemViews[name]);
+        DomainSystemViewTypes[name] = type;
         TSchemaFiller<Table>::Fill(SubDomainSystemViews[name]);
+        SubDomainSystemViewTypes[name] = type;
         TSchemaFiller<Table>::Fill(SystemViews[type]);
     }
 
     template <typename Table>
     void RegisterDomainSystemView(const TStringBuf& name, ESysViewType type) {
         TSchemaFiller<Table>::Fill(DomainSystemViews[name]);
+        DomainSystemViewTypes[name] = type;
         TSchemaFiller<Table>::Fill(SystemViews[type]);
     }
 
@@ -332,9 +350,13 @@ private:
 
 private:
     THashMap<TString, TSchema> DomainSystemViews;
+    THashMap<TString, ESysViewType> DomainSystemViewTypes;
     THashMap<TString, TSchema> SubDomainSystemViews;
+    THashMap<TString, ESysViewType> SubDomainSystemViewTypes;
     THashMap<TString, TSchema> OlapStoreSystemViews;
+    THashMap<TString, ESysViewType> OlapStoreSystemViewTypes;
     THashMap<TString, TSchema> ColumnTableSystemViews;
+    THashMap<TString, ESysViewType> ColumnTableSystemViewTypes;
     THashMap<ESysViewType, TSchema> SystemViews;
 };
 
@@ -375,12 +397,18 @@ public:
         return {};
     }
 
+    const THashMap<TString, ESysViewType>& GetSystemViewsTypes(ETarget target) const override {
+        Y_UNUSED(target);
+        return SystemViewTypes;
+    }
+
     bool IsSystemView(const TStringBuf viewName) const override final {
         return SystemViews.contains(viewName);
     }
 
 private:
     THashMap<TString, TSchema> SystemViews;
+    THashMap<TString, ESysViewType> SystemViewTypes;
 };
 
 ISystemViewResolver* CreateSystemViewResolver() {

--- a/ydb/core/sys_view/common/schema.h
+++ b/ydb/core/sys_view/common/schema.h
@@ -839,6 +839,8 @@ public:
     virtual bool IsSystemView(const TStringBuf viewName) const = 0;
 
     virtual TVector<TString> GetSystemViewNames(ETarget target) const = 0;
+
+    virtual const THashMap<TString, NKikimrSysView::ESysViewType>& GetSystemViewsTypes(ETarget target) const = 0;
 };
 
 ISystemViewResolver* CreateSystemViewResolver();


### PR DESCRIPTION
Splitting [the large PR](https://github.com/ydb-platform/ydb/pull/19377) of creating SysViews in SchemeShard
To create system view during SchemeShard init we have to collect actual list of available pairs <sysview type,  default sysview name> based on kind of the SourceObject.
