### PR TITLE
Fixed commit offset for pqv0 and pqv1 in federated logbroker

### DIFF
--- a/ydb/services/deprecated/persqueue_v0/grpc_pq_read_actor.cpp
+++ b/ydb/services/deprecated/persqueue_v0/grpc_pq_read_actor.cpp
@@ -1933,7 +1933,8 @@ void TPartitionActor::SendCommit(const ui64 readId, const ui64 offset, const TAc
         }
         NKikimr::NGRpcProxy::V1::TDistributedCommitHelper::TCommitInfo commit {.PartitionId = Partition, .Offset = (i64)offset, .KillReadSession = false, .OnlyCheckCommitedToFinish = false, .ReadSessionId = Session};
         commits.push_back(commit);
-        auto kqp = std::make_shared<NKikimr::NGRpcProxy::V1::TDistributedCommitHelper>(Database, InternalClientId, Topic->GetPrimaryPath(), commits, readId);
+        auto database = Database.empty() ? NKikimr::NPQ::GetDatabaseFromConfig(AppData(ctx)->PQConfig) : Database;
+        auto kqp = std::make_shared<NKikimr::NGRpcProxy::V1::TDistributedCommitHelper>(database, InternalClientId, Topic->GetPrimaryPath(), commits, readId);
         Kqps.emplace(readId, kqp);
 
         kqp->SendCreateSessionRequest(ctx);

--- a/ydb/services/deprecated/persqueue_v0/grpc_pq_read_actor.cpp
+++ b/ydb/services/deprecated/persqueue_v0/grpc_pq_read_actor.cpp
@@ -752,7 +752,6 @@ void TReadSessionActor::SendAuthRequest(const TActorContext& ctx) {
         CreateInitAndAuthActor(ctx);
         return;
     }
-    auto database = Database.empty() ? NKikimr::NPQ::GetDatabaseFromConfig(AppData(ctx)->PQConfig) : Database;
     Y_ABORT_UNLESS(TopicsList.IsValid);
     TVector<TDiscoveryConverterPtr> topics;
     for(const auto& t : TopicsList.Topics) {
@@ -801,7 +800,6 @@ void TReadSessionActor::HandleDescribeTopicsResponse(TEvDescribeTopicsResponse::
 }
 
 void TReadSessionActor::CreateInitAndAuthActor(const TActorContext& ctx) {
-    auto database = Database.empty() ? NKikimr::NPQ::GetDatabaseFromConfig(AppData(ctx)->PQConfig) : Database;
     AuthInitActor = ctx.Register(new V1::TReadInitAndAuthActor(
             ctx, ctx.SelfID, InternalClientId, Cookie, Session, PqMetaCache, NewSchemeCache, Counters, Token,
             TopicsList, TopicsHandler.GetLocalCluster()
@@ -1090,9 +1088,10 @@ void TReadSessionActor::Handle(TEvPersQueue::TEvLockPartition::TPtr& ev, const T
     auto it = TopicCounters.find(intName);
     Y_ABORT_UNLESS(it != TopicCounters.end());
 
+    auto database = jt->second.DbPath;
     IActor* partitionActor = new TPartitionActor(
             ctx.SelfID, InternalClientId, Cookie, Session, record.GetGeneration(),
-            record.GetStep(), jt->second.FullConverter, Database.empty() ? NKikimr::NPQ::GetDatabaseFromConfig(AppData(ctx)->PQConfig) : Database, record.GetPartition(), record.GetTabletId(), it->second,
+            record.GetStep(), jt->second.FullConverter, database, record.GetPartition(), record.GetTabletId(), it->second,
             ClientDC, jt->second.PartitionGraph->GetPartition(record.GetPartition())->AllParents
     );
 
@@ -1933,8 +1932,7 @@ void TPartitionActor::SendCommit(const ui64 readId, const ui64 offset, const TAc
         }
         NKikimr::NGRpcProxy::V1::TDistributedCommitHelper::TCommitInfo commit {.PartitionId = Partition, .Offset = (i64)offset, .KillReadSession = false, .OnlyCheckCommitedToFinish = false, .ReadSessionId = Session};
         commits.push_back(commit);
-        auto database = Database.empty() ? NKikimr::NPQ::GetDatabaseFromConfig(AppData(ctx)->PQConfig) : Database;
-        auto kqp = std::make_shared<NKikimr::NGRpcProxy::V1::TDistributedCommitHelper>(database, InternalClientId, Topic->GetPrimaryPath(), commits, readId);
+        auto kqp = std::make_shared<NKikimr::NGRpcProxy::V1::TDistributedCommitHelper>(Database, InternalClientId, Topic->GetPrimaryPath(), commits, readId);
         Kqps.emplace(readId, kqp);
 
         kqp->SendCreateSessionRequest(ctx);

--- a/ydb/services/persqueue_v1/actors/read_session_actor.cpp
+++ b/ydb/services/persqueue_v1/actors/read_session_actor.cpp
@@ -1278,7 +1278,7 @@ void TReadSessionActor<UseMigrationProtocol>::Handle(TEvPersQueue::TEvLockPartit
     }
 
     const auto& parentPartitions = partitionNode->AllParents;
-    const auto database = Request->GetDatabaseName().GetOrElse(AppData(ctx)->PQConfig.GetDatabase());
+    const auto database = topic.DbPath;
     const TActorId actorId = ctx.Register(new TPartitionActor(
         ctx.SelfID, ClientId, ClientPath, Cookie, Session, partitionId, record.GetGeneration(),
         record.GetStep(), record.GetTabletId(), it->second, CommitsDisabled, ClientDC, RangesMode,


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

Поправил коммит оффсетов сообщений топика при чтении в федеративных инсталляциях. До фикса пользователь получал ошибку "Unable to navigate:path: \'Root/logbroker-federation/--cut--/stable/guidance\' status: PathErrorUnknown\n" 
Сломали начиная с 25-1-2

### Changelog category <!-- remove all except one -->

* Bugfix 

### Description for reviewers <!-- (optional) description for those who read this PR -->

LOGBROKER-9732

Fixed Got error from subconsumer: { code: ERROR description: "Kqp error. Status# SCHEME_ERROR, <main>: Error: contrib/ydb/core/kqp/session_actor/kqp_session_actor.cpp:2847: Unable to navigate:path: \'Root/logbroker-federation/--cut--/stable/guidance\' status: PathErrorUnknown\n" }. Retryable: 1
