### PR TITLE
ci: set retry of asan to 1

### DIFF
--- a/.github/actions/test_ya/action.yml
+++ b/.github/actions/test_ya/action.yml
@@ -217,13 +217,16 @@ runs:
             params+=(
               --build "release" --sanitize="address"
             )
+            if [ -z $TEST_RETRY_COUNT ]; then
+              TEST_RETRY_COUNT=1
+            fi
             IS_TEST_RESULT_IGNORED=1
             ;;
           release-tsan)
             params+=(
               --build "release" --sanitize="thread"
             )
-            if [ $TEST_RETRY_COUNT -z ]; then
+            if [ -z $TEST_RETRY_COUNT ]; then
               TEST_RETRY_COUNT=1
             fi
             IS_TEST_RESULT_IGNORED=1
@@ -232,7 +235,7 @@ runs:
             params+=(
               --build "release" --sanitize="memory"
             )
-            if [ $TEST_RETRY_COUNT -z ]; then
+            if [ -z $TEST_RETRY_COUNT ]; then
               TEST_RETRY_COUNT=1
             fi
             IS_TEST_RESULT_IGNORED=1
@@ -245,7 +248,7 @@ runs:
 
         echo "IS_TEST_RESULT_IGNORED=$IS_TEST_RESULT_IGNORED" >> $GITHUB_ENV
 
-        if [ $TEST_RETRY_COUNT -z ]; then
+        if [ -z $TEST_RETRY_COUNT ]; then
           # default is 3 for ordinary build and 1 for sanitizer builds
           TEST_RETRY_COUNT=3
         fi


### PR DESCRIPTION
### Changelog category

* Not for changelog (changelog entry is not required)

### Description for reviewers

asan tests will run only once

Was able to check on some minor changes - [asan was triggered only once](https://github.com/ydb-platform/ydb/pull/20087#issuecomment-2999573061)

<img width="942" alt="image" src="https://github.com/user-attachments/assets/6cd630d6-ce5d-4820-a027-3771ae9c5baa" />


Closes: #19792 