### PR TITLE
Added support sysview pathtype to cli and sdk

### DIFF
--- a/ydb/core/driver_lib/cli_base/cli_cmds_db.cpp
+++ b/ydb/core/driver_lib/cli_base/cli_cmds_db.cpp
@@ -283,6 +283,9 @@ public:
         case NKikimrSchemeOp::EPathTypeBackupCollection:
             type = "<backup collection>";
             break;
+        case NKikimrSchemeOp::EPathTypeSysView:
+            type = "<system view>";
+            break;
         default:
             type = "<unknown>";
             break;
@@ -313,7 +316,8 @@ public:
         Cout << id << type << name << owner << acl << Endl;
         if (Details) {
             switch(entry.GetPathType()) {
-            case NKikimrSchemeOp::EPathTypeTable: {
+            case NKikimrSchemeOp::EPathTypeTable:
+            case NKikimrSchemeOp::EPathTypeSysView: {
                 const NKikimrSchemeOp::TTableDescription& table(path.GetTable());
                 size_t szWidth = id.size() + type.size() + entry.GetName().size();
                 size_t szColumns[3] = {0, 0, 0};
@@ -497,6 +501,9 @@ public:
             break;
         case NKikimrSchemeOp::EPathTypeBackupCollection:
             type = "<backup collection>";
+            break;
+        case NKikimrSchemeOp::EPathTypeSysView:
+            type = "<system view>";
             break;
         default:
             type = "<unknown>";

--- a/ydb/public/lib/ydb_cli/commands/interactive/complete/ydb_schema.cpp
+++ b/ydb/public/lib/ydb_cli/commands/interactive/complete/ydb_schema.cpp
@@ -103,6 +103,8 @@ namespace NYdb::NConsoleClient {
                     return "View";
                 case NScheme::ESchemeEntryType::ResourcePool:
                     return "ResourcePool";
+                case NScheme::ESchemeEntryType::SysView:
+                    return "SysView";
                 case NScheme::ESchemeEntryType::Unknown:
                 default:
                     return "Unknown";

--- a/ydb/public/lib/ydb_cli/commands/ydb_service_scheme.cpp
+++ b/ydb/public/lib/ydb_cli/commands/ydb_service_scheme.cpp
@@ -286,6 +286,8 @@ int TCommandDescribe::PrintPathResponse(TDriver& driver, const NScheme::TDescrib
         return DescribeExternalDataSource(driver);
     case NScheme::ESchemeEntryType::ExternalTable:
         return DescribeExternalTable(driver);
+    case NScheme::ESchemeEntryType::SysView:
+        return DescribeTable(driver);
     default:
         return DescribeEntryDefault(entry);
     }

--- a/ydb/public/lib/ydb_cli/common/print_utils.cpp
+++ b/ydb/public/lib/ydb_cli/common/print_utils.cpp
@@ -46,6 +46,9 @@ void PrintSchemeEntry(IOutputStream& o, const NScheme::TSchemeEntry& entry, NCol
     case NScheme::ESchemeEntryType::ResourcePool:
         o << colors.LightWhite();
         break;
+    case NScheme::ESchemeEntryType::SysView:
+        o << colors.LightYellow();
+        break;
     default:
         o << colors.RedColor();
     }
@@ -106,6 +109,8 @@ TString EntryTypeToString(NScheme::ESchemeEntryType entry) {
         return "replication";
     case NScheme::ESchemeEntryType::ResourcePool:
         return "resource-pool";
+    case NScheme::ESchemeEntryType::SysView:
+        return "sys-view";
     case NScheme::ESchemeEntryType::Unknown:
     case NScheme::ESchemeEntryType::Sequence:
         return "unknown";

--- a/ydb/public/sdk/cpp/include/ydb-cpp-sdk/client/scheme/scheme.h
+++ b/ydb/public/sdk/cpp/include/ydb-cpp-sdk/client/scheme/scheme.h
@@ -50,6 +50,7 @@ enum class ESchemeEntryType : i32 {
     ExternalDataSource = 19,
     View = 20,
     ResourcePool = 21,
+    SysView = 22,
 };
 
 struct TVirtualTimestamp {

--- a/ydb/public/sdk/cpp/src/client/scheme/scheme.cpp
+++ b/ydb/public/sdk/cpp/src/client/scheme/scheme.cpp
@@ -109,6 +109,8 @@ static ESchemeEntryType ConvertProtoEntryType(::Ydb::Scheme::Entry::Type entry) 
         return ESchemeEntryType::View;
     case ::Ydb::Scheme::Entry::RESOURCE_POOL:
         return ESchemeEntryType::ResourcePool;
+    case ::Ydb::Scheme::Entry::SYS_VIEW:
+        return ESchemeEntryType::SysView;
     default:
         return ESchemeEntryType::Unknown;
     }


### PR DESCRIPTION
This is a part of the PR series aimed to support a new pathtype SystemView. Previously system views were treated like ordinal tables so for now we want to remain this behavior.
