### PR TITLE
HTTP-command SendReadSet

### DIFF
--- a/ydb/core/persqueue/pq_impl.h
+++ b/ydb/core/persqueue/pq_impl.h
@@ -94,6 +94,7 @@ class TPersQueue : public NKeyValue::TKeyValueFlat {
 
     bool OnRenderAppHtmlPage(NMon::TEvRemoteHttpInfo::TPtr ev, const TActorContext& ctx) override;
     bool OnRenderAppHtmlPageTx(NMon::TEvRemoteHttpInfo::TPtr ev, const TActorContext& ctx);
+    bool OnSendReadSetToYourself(NMon::TEvRemoteHttpInfo::TPtr& ev, const TActorContext& ctx);
 
     void HandleDie(const TActorContext& ctx) override;
 

--- a/ydb/core/persqueue/pq_impl_app.cpp
+++ b/ydb/core/persqueue/pq_impl_app.cpp
@@ -228,6 +228,10 @@ bool TPersQueue::OnRenderAppHtmlPage(NMon::TEvRemoteHttpInfo::TPtr ev, const TAc
         return true;
     }
 
+    if (ev->Get()->Cgi().Has("SendReadSet")) {
+        return OnSendReadSetToYourself(ev, ctx);
+    }
+
     if (ev->Get()->Cgi().Has("kv")) {
         return TKeyValueFlat::OnRenderAppHtmlPage(ev, ctx);
     }

--- a/ydb/core/persqueue/pq_impl_app_sendreadset.cpp
+++ b/ydb/core/persqueue/pq_impl_app_sendreadset.cpp
@@ -1,0 +1,61 @@
+#include "pq_impl.h"
+
+namespace NKikimr::NPQ {
+
+TString MakeReadSetData(bool commit)
+{
+    NKikimrTx::TReadSetData data;
+    data.SetDecision(commit ? NKikimrTx::TReadSetData::DECISION_COMMIT : NKikimrTx::TReadSetData::DECISION_ABORT);
+
+    TString encoded;
+    Y_ABORT_UNLESS(data.SerializeToString(&encoded));
+
+    return encoded;
+}
+
+template <class T>
+TMaybe<T> GetParameter(NMon::TEvRemoteHttpInfo::TPtr& ev, const TString& name)
+{
+    if (!ev->Get()->Cgi().Has(name)) {
+        return Nothing();
+    }
+    return FromString<T>(ev->Get()->Cgi().Get(name));
+}
+
+bool TPersQueue::OnSendReadSetToYourself(NMon::TEvRemoteHttpInfo::TPtr& ev, const TActorContext& ctx)
+{
+    auto step = GetParameter<ui64>(ev, "step");
+    auto txId = GetParameter<ui64>(ev, "txId");
+    auto senderTablet = GetParameter<ui64>(ev, "senderTablet");
+    auto decision = GetParameter<TString>(ev, "decision");
+
+    if (!step.Defined() || !txId.Defined() || !senderTablet.Defined() || !decision.Defined()) {
+        ctx.Send(ev->Sender, new NMon::TEvRemoteJsonInfoRes(R"({"result":"expected step, txId, senderTablet and decision"})"));
+        return true;
+    }
+
+    auto* tx = GetTransaction(ctx, *txId);
+    if (!tx) {
+        ctx.Send(ev->Sender, new NMon::TEvRemoteJsonInfoRes(R"({"result":"unknown tx"})"));
+        return true;
+    }
+    if (tx->Step != *step) {
+        ctx.Send(ev->Sender, new NMon::TEvRemoteJsonInfoRes(R"({"result":"invalid step"})"));
+        return true;
+    }
+
+    auto event = std::make_unique<TEvTxProcessing::TEvReadSet>(*step,
+                                                               *txId,
+                                                               *senderTablet,
+                                                               TabletID(),
+                                                               *senderTablet,
+                                                               MakeReadSetData(*decision == "commit"),
+                                                               0);
+    ctx.Send(ctx.SelfID, std::move(event));
+
+    ctx.Send(ev->Sender, new NMon::TEvRemoteJsonInfoRes(R"({"result":"OK"})"));
+
+    return true;
+}
+
+}

--- a/ydb/core/persqueue/ya.make
+++ b/ydb/core/persqueue/ya.make
@@ -28,6 +28,7 @@ SRCS(
     pq.cpp
     pq_database.cpp
     pq_impl_app.cpp
+    pq_impl_app_sendreadset.cpp
     pq_impl.cpp
     pq_l2_cache.cpp
     pq_rl_helpers.cpp


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

Changes from #20115

An auxiliary HTTP handle for administrators. Allows you to emulate a tablet receiving a TEvReadSet PQ message from another tablet. It can be used to unlock a transaction in a PQ.

### Changelog category <!-- remove all except one -->

* Not for changelog (changelog entry is not required)

### Description for reviewers <!-- (optional) description for those who read this PR -->

...
