### PR TITLE
Bridge Info in Info Collector CMS

### DIFF
--- a/ydb/core/cms/api_adapters.cpp
+++ b/ydb/core/cms/api_adapters.cpp
@@ -234,6 +234,8 @@ class TListClusterNodes: public TAdapterActor<
         } else {
             out.mutable_storage();
         }
+
+        out.set_pile_id(in.PileId);
     }
 
 public:

--- a/ydb/core/cms/cluster_info.cpp
+++ b/ydb/core/cms/cluster_info.cpp
@@ -361,6 +361,7 @@ void TClusterInfo::AddNode(const TEvInterconnect::TNodeInfo &info, const TActorC
     node->IcPort = info.Port;
     node->Location = info.Location;
     node->State = NKikimrCms::UNKNOWN;
+    node->PileId = NodeIdToPileId[info.NodeId];
 
     if (ctx) {
         const auto maxStaticNodeId = AppData(*ctx)->DynamicNameserviceConfig->MaxStaticNodeId;

--- a/ydb/core/cms/cluster_info.h
+++ b/ydb/core/cms/cluster_info.h
@@ -7,6 +7,7 @@
 #include "services.h"
 
 #include <ydb/core/base/blobstorage.h>
+#include <ydb/core/base/bridge.h>
 #include <ydb/core/base/statestorage.h>
 #include <ydb/core/blobstorage/base/blobstorage_vdiskid.h>
 #include <ydb/core/mind/tenant_pool.h>
@@ -344,6 +345,7 @@ public:
     TString PreviousTenant;
     TServices Services;
     TInstant StartTime;
+    ui32 PileId;
 
     TVector<TSimpleSharedPtr<INodesChecker>> NodeGroups;
 };
@@ -1042,6 +1044,9 @@ public:
 
     TIntrusiveConstPtr<TStateStorageInfo> StateStorageInfo;
     TVector<TStateStorageRingInfoPtr> StateStorageRings;
+
+    NKikimr::TBridgeInfo::TPtr BridgeInfo;
+    THashMap<ui32, ui32> NodeIdToPileId;
 };
 
 inline bool ActionRequiresHost(NKikimrCms::TAction::EType type) {

--- a/ydb/core/cms/cluster_info.h
+++ b/ydb/core/cms/cluster_info.h
@@ -1045,7 +1045,7 @@ public:
     TIntrusiveConstPtr<TStateStorageInfo> StateStorageInfo;
     TVector<TStateStorageRingInfoPtr> StateStorageRings;
 
-    NKikimr::TBridgeInfo::TPtr BridgeInfo;
+    std::vector<NKikimr::TBridgeInfo::TPile> Piles;
     THashMap<ui32, ui32> NodeIdToPileId;
 };
 

--- a/ydb/core/cms/cms.cpp
+++ b/ydb/core/cms/cms.cpp
@@ -1235,6 +1235,7 @@ void TCms::AddHostState(const TClusterInfoPtr &clusterInfo, const TNodeInfo &nod
     host->SetInterconnectPort(node.IcPort);
     host->SetTimestamp(timestamp.GetValue());
     host->SetStartTimeSeconds(node.StartTime.Seconds());
+    host->SetPileId(clusterInfo->NodeIdToPileId[node.NodeId]);
     node.Location.Serialize(host->MutableLocation(), false);
     for (auto marker : node.Markers) {
         host->AddMarkers(marker);

--- a/ydb/core/cms/cms.cpp
+++ b/ydb/core/cms/cms.cpp
@@ -1235,7 +1235,7 @@ void TCms::AddHostState(const TClusterInfoPtr &clusterInfo, const TNodeInfo &nod
     host->SetInterconnectPort(node.IcPort);
     host->SetTimestamp(timestamp.GetValue());
     host->SetStartTimeSeconds(node.StartTime.Seconds());
-    host->SetPileId(clusterInfo->NodeIdToPileId[node.NodeId]);
+    host->SetPileId(node.PileId);
     node.Location.Serialize(host->MutableLocation(), false);
     for (auto marker : node.Markers) {
         host->AddMarkers(marker);

--- a/ydb/core/cms/info_collector.cpp
+++ b/ydb/core/cms/info_collector.cpp
@@ -204,7 +204,7 @@ void TInfoCollector::Bootstrap() {
     Become(&TThis::StateWork);
 }
 
-using TPileMap = std::vector<std::vector<ui32>>;
+using TPileMap = TEvInterconnect::TEvNodesInfo::TPileMap;
 
 THashMap<ui32, ui32> FlipPileMap(const std::shared_ptr<const TPileMap> pileMap) {
     THashMap<ui32, ui32> result;
@@ -538,7 +538,7 @@ void TInfoCollector::Handle(TEvInterconnect::TEvNodeDisconnected::TPtr& ev) {
 }
 
 void TInfoCollector::RequestBridgeInfo() {
-    Send(MakeBlobStorageNodeWardenID(SelfId().NodeId()), new NKikimr::TEvNodeWardenQueryStorageConfig(true));
+    Send(MakeBlobStorageNodeWardenID(SelfId().NodeId()), new NKikimr::TEvNodeWardenQueryStorageConfig(false));
 }
 
 void TInfoCollector::Handle(NKikimr::TEvNodeWardenStorageConfig::TPtr& ev) {

--- a/ydb/core/cms/info_collector.cpp
+++ b/ydb/core/cms/info_collector.cpp
@@ -537,7 +537,7 @@ void TInfoCollector::RequestBridgeInfo() {
 
 void TInfoCollector::Handle(NKikimr::TEvNodeWardenStorageConfig::TPtr& ev) {
     const auto& bridgeInfo = ev->Get()->BridgeInfo;
-    Info->BridgeInfo = bridgeInfo;
+    Info->Piles = bridgeInfo->Piles;
 }
 
 IActor* CreateInfoCollector(const TActorId& client, const TDuration& timeout) {

--- a/ydb/core/cms/info_collector.cpp
+++ b/ydb/core/cms/info_collector.cpp
@@ -204,8 +204,14 @@ void TInfoCollector::Bootstrap() {
     Become(&TThis::StateWork);
 }
 
-THashMap<ui32, ui32> FlipPileMap(const auto pileMap) {
+using TPileMap = std::vector<std::vector<ui32>>;
+
+THashMap<ui32, ui32> FlipPileMap(const std::shared_ptr<const TPileMap> pileMap) {
     THashMap<ui32, ui32> result;
+
+    if (!pileMap)
+        return result;
+
     for (ui32 i = 0; i < pileMap->size(); ++i) {
         for (ui32 j : pileMap->at(i)) {
             result.emplace(j, i);
@@ -537,7 +543,8 @@ void TInfoCollector::RequestBridgeInfo() {
 
 void TInfoCollector::Handle(NKikimr::TEvNodeWardenStorageConfig::TPtr& ev) {
     const auto& bridgeInfo = ev->Get()->BridgeInfo;
-    Info->Piles = bridgeInfo->Piles;
+    if (bridgeInfo)
+        Info->Piles = bridgeInfo->Piles;
 }
 
 IActor* CreateInfoCollector(const TActorId& client, const TDuration& timeout) {

--- a/ydb/core/protos/cms.proto
+++ b/ydb/core/protos/cms.proto
@@ -78,6 +78,7 @@ message THostState {
   repeated EMarker       Markers = 8;
   optional NActorsInterconnect.TNodeLocation Location = 9;
   optional uint32        StartTimeSeconds = 10;
+  optional uint32        PileId = 11;
 }
 
 message TClusterState {

--- a/ydb/public/api/protos/draft/ydb_maintenance.proto
+++ b/ydb/public/api/protos/draft/ydb_maintenance.proto
@@ -46,6 +46,7 @@ message Node {
     // version defines YDB version for current Node.
     // For example, 'ydb-stable-24-1'.
     string version = 9;
+    uint32 pile_id = 10;
 }
 
 message ListClusterNodesRequest {


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

...

### Changelog category <!-- remove all except one -->

* Not for changelog (changelog entry is not required)

### Description for reviewers <!-- (optional) description for those who read this PR -->

Сохраняю два новых поля в cluster_info: `Piles`, `NodeIdToPileId`. 

`NodeIdToPileId`, как результат запроса `TEvInterconnect::TEvListNodes`;
`Piles`, как результат запроса `NKikimr::TEvNodeWardenQueryStorageConfig`;

