### PR TITLE
[GraceJoin] Skip reading input when output is guaranteed to be empty

### DIFF
--- a/yql/essentials/minikql/comp_nodes/mkql_grace_join_imp.h
+++ b/yql/essentials/minikql/comp_nodes/mkql_grace_join_imp.h
@@ -10,6 +10,50 @@ namespace NKikimr {
 namespace NMiniKQL {
 namespace GraceJoin {
 
+// Determines whether the right input can be safely skipped when the left input is empty.
+// For certain join kinds, the result will always be empty if the left side is empty,
+// regardless of the content of the right side. In such cases, it's safe to avoid reading the right input entirely.
+constexpr bool ShouldSkipRightIfLeftEmpty(EJoinKind kind) {
+    switch (kind) {
+        case EJoinKind::Inner:
+        case EJoinKind::LeftOnly:
+        case EJoinKind::LeftSemi:
+        case EJoinKind::RightSemi:
+            return true;
+        case EJoinKind::RightOnly:
+        case EJoinKind::Left:
+        case EJoinKind::Right:
+        case EJoinKind::Exclusion:
+        case EJoinKind::Full:
+        case EJoinKind::SemiMask:
+        case EJoinKind::SemiSide:
+        case EJoinKind::Cross:
+            return false;
+    }
+}
+
+// Determines whether the left input can be safely skipped when the right input is empty.
+// For certain join kinds, the result will always be empty if the right side is empty,
+// regardless of the content of the left side. In such cases, it's safe to avoid reading the left input entirely.
+constexpr bool ShouldSkipLeftIfRightEmpty(EJoinKind kind) {
+    switch (kind) {
+        case EJoinKind::Inner:
+        case EJoinKind::RightOnly:
+        case EJoinKind::RightSemi:
+        case EJoinKind::LeftSemi:
+            return true;
+        case EJoinKind::Min:
+        case EJoinKind::Left:
+        case EJoinKind::Right:
+        case EJoinKind::Exclusion:
+        case EJoinKind::Full:
+        case EJoinKind::SemiMask:
+        case EJoinKind::SemiSide:
+        case EJoinKind::Cross:
+            return false;
+    }
+}
+
 class TTableBucketSpiller;
 #define GRACEJOIN_DEBUG DEBUG
 #define GRACEJOIN_TRACE TRACE


### PR DESCRIPTION
Adds early termination optimization for `GraceJoin`: if one side is empty and the join kind guarantees an empty result, the other side is no longer read.

Introduces two helpers:

* `ShouldSkipRightIfLeftEmpty`

* `ShouldSkipLeftIfRightEmpty`

Also adds unit tests covering all join kinds and empty input combinations.

Initial issue: <https://github.com/ydb-platform/ydb/issues/19797>
commit_hash:2683031df5b68c293536eacda05c8e79fc452d11

(cherry picked from commit 17991439b76e6a735563f320d80eecd472428f66)

### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

Adds early termination optimization for `GraceJoin`: if one side is empty and the join kind guarantees an empty result, the other side is no longer read.
...

### Changelog category <!-- remove all except one -->

* Performance improvement

### Description for reviewers <!-- (optional) description for those who read this PR -->

...
