### PR TITLE
Bridge Mode in CMS: Ignore proxy groups

### DIFF
--- a/ydb/core/cms/info_collector.cpp
+++ b/ydb/core/cms/info_collector.cpp
@@ -318,7 +318,9 @@ void TInfoCollector::Handle(TEvBlobStorage::TEvControllerConfigResponse::TPtr& e
         }
 
         for (const auto& group : record.GetStatus(0).GetBaseConfig().GetGroup()) {
-            Info->AddBSGroup(group);
+            if (!group.GetIsProxyGroup()) {
+                Info->AddBSGroup(group);
+            }
         }
 
         MaybeReplyAndDie();

--- a/ydb/core/mind/bscontroller/config.cpp
+++ b/ydb/core/mind/bscontroller/config.cpp
@@ -1105,6 +1105,13 @@ namespace NKikimr::NBsController {
             pb->SetOperatingStatus(status.OperatingStatus);
             pb->SetExpectedStatus(status.ExpectedStatus);
 
+            if (group.BridgeGroupInfo) {
+                NKikimrBlobStorage::TGroupInfo groupInfoPb;
+                bool success = groupInfoPb.ParseFromString(*group.BridgeGroupInfo);
+                Y_DEBUG_ABORT_UNLESS(success);
+                pb->SetIsProxyGroup(groupInfoPb.BridgeGroupIdsSize() != 0);
+            }
+            
             if (group.DecommitStatus != NKikimrBlobStorage::TGroupDecommitStatus::NONE || group.VirtualGroupState) {
                 auto *vgi = pb->MutableVirtualGroupInfo();
                 if (group.VirtualGroupState) {

--- a/ydb/core/protos/blobstorage_config.proto
+++ b/ydb/core/protos/blobstorage_config.proto
@@ -714,6 +714,7 @@ message TBaseConfig {
         TGroupStatus.E ExpectedStatus = 9; // status based not only on operational report, but on PDisk status and plans too
         TVirtualGroupInfo VirtualGroupInfo = 10;
         uint32 GroupSizeInUnits = 11;
+        bool IsProxyGroup = 12;
     }
     message TNode {
         uint32 NodeId = 1;


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

...

### Changelog category <!-- remove all except one -->

* Not for changelog (changelog entry is not required)

### Description for reviewers <!-- (optional) description for those who read this PR -->

Вмержить после: https://github.com/ydb-platform/ydb/pull/20135

Проставляю для `NKikimrBlobStorage::TBaseConfig::TGroup` признак `IsProxyGroup`, означающий, что группа будет проигнорирована при проверках в CMS, соотвественно, в информацию о кластере ее не добавляю
