### PR TITLE
aclib: make constant naming patterns consistent

### DIFF
--- a/ydb/core/client/server/msgbus_server_node_registration.cpp
+++ b/ydb/core/client/server/msgbus_server_node_registration.cpp
@@ -39,7 +39,7 @@ public:
         if (!clientCertificates.empty()) {
             TBase::SetSecurityToken(TString(clientCertificates.front()));
         } else {
-            TBase::SetSecurityToken(BUILTIN_ACL_ROOT); // NBS compatibility
+            TBase::SetSecurityToken(BUILTIN_SID_ROOT); // NBS compatibility
         }
         TBase::SetPeerName(msg.GetPeerName());
     }

--- a/ydb/core/client/server/msgbus_server_pq_metarequest_ut.cpp
+++ b/ydb/core/client/server/msgbus_server_pq_metarequest_ut.cpp
@@ -742,7 +742,7 @@ public:
 
     NKikimrClient::TPersQueueRequest MakeValidRequest(ui64 topicsCount = 2) override {
         NKikimrClient::TPersQueueRequest persQueueRequest;
-        persQueueRequest.SetTicket("client_id@" BUILTIN_ACL_DOMAIN);
+        persQueueRequest.SetTicket("client_id@" AUTH_DOMAIN_BUILTIN);
 
         auto& req = *persQueueRequest.MutableMetaRequest()->MutableCmdGetTopicMetadata();
         req.AddTopic(topic1);
@@ -836,7 +836,7 @@ public:
 
     NKikimrClient::TPersQueueRequest MakeValidRequest(ui64 topicsCount = 2) override {
         NKikimrClient::TPersQueueRequest persQueueRequest;
-        persQueueRequest.SetTicket("client_id@" BUILTIN_ACL_DOMAIN);
+        persQueueRequest.SetTicket("client_id@" AUTH_DOMAIN_BUILTIN);
 
         auto& req = *persQueueRequest.MutableMetaRequest()->MutableCmdGetPartitionLocations();
         FillValidTopicRequest(*req.MutableTopicRequest(), topicsCount);
@@ -1002,7 +1002,7 @@ public:
 
     NKikimrClient::TPersQueueRequest MakeValidRequest(ui64 topicsCount = 2) override {
         NKikimrClient::TPersQueueRequest persQueueRequest;
-        persQueueRequest.SetTicket("client_id@" BUILTIN_ACL_DOMAIN);
+        persQueueRequest.SetTicket("client_id@" AUTH_DOMAIN_BUILTIN);
 
         auto& req = *persQueueRequest.MutableMetaRequest()->MutableCmdGetPartitionOffsets();
         FillValidTopicRequest(*req.MutableTopicRequest(), topicsCount);
@@ -1165,7 +1165,7 @@ public:
 
     NKikimrClient::TPersQueueRequest MakeValidRequest(ui64 topicsCount = 2) override {
         NKikimrClient::TPersQueueRequest persQueueRequest;
-        persQueueRequest.SetTicket("client_id@" BUILTIN_ACL_DOMAIN);
+        persQueueRequest.SetTicket("client_id@" AUTH_DOMAIN_BUILTIN);
 
         auto& req = *persQueueRequest.MutableMetaRequest()->MutableCmdGetPartitionStatus();
         FillValidTopicRequest(*req.MutableTopicRequest(), topicsCount);
@@ -1318,7 +1318,7 @@ public:
 
     NKikimrClient::TPersQueueRequest MakeValidRequest(ui64 topicsCount = 2) override {
         NKikimrClient::TPersQueueRequest persQueueRequest;
-        persQueueRequest.SetTicket("client_id@" BUILTIN_ACL_DOMAIN);
+        persQueueRequest.SetTicket("client_id@" AUTH_DOMAIN_BUILTIN);
 
         auto& req = *persQueueRequest.MutableMetaRequest()->MutableCmdGetReadSessionsInfo();
         req.SetClientId("client_id");
@@ -1422,7 +1422,7 @@ public:
             UNIT_ASSERT(resp->Record.GetMetaResponse().HasCmdGetReadSessionsInfoResult());
             auto perTopicResults = resp->Record.GetMetaResponse().GetCmdGetReadSessionsInfoResult().GetTopicResult();
             UNIT_ASSERT_VALUES_EQUAL(perTopicResults.size(), 2);
-            Cerr << "RESPONSE " << resp->Record.DebugString() << "\n"; 
+            Cerr << "RESPONSE " << resp->Record.DebugString() << "\n";
 
             {
                 const auto& topic1Result = perTopicResults.Get(0).GetTopic() == topic1 ? perTopicResults.Get(0) : perTopicResults.Get(1);

--- a/ydb/core/kqp/ut/scheme/kqp_scheme_ut.cpp
+++ b/ydb/core/kqp/ut/scheme/kqp_scheme_ut.cpp
@@ -1172,7 +1172,7 @@ Y_UNIT_TEST_SUITE(KqpScheme) {
                 Value String,
                 PRIMARY KEY (Key)
             )
-            )") 
+            )")
             + (СolumnTable ? TString("WITH (STORE = COLUMN)") : "");
             auto result = session.ExecuteSchemeQuery(query).GetValueSync();
             UNIT_ASSERT_VALUES_EQUAL_C(result.GetStatus(), EStatus::SUCCESS, result.GetIssues().ToString());
@@ -10640,11 +10640,11 @@ Y_UNIT_TEST_SUITE(KqpScheme) {
         result = session.ExecuteSchemeQuery(TStringBuilder() << R"(
             CREATE RESOURCE POOL CLASSIFIER MyResourcePoolClassifier WITH (
                 RESOURCE_POOL="test",
-                MEMBER_NAME=")" << BUILTIN_ACL_METADATA << R"("
+                MEMBER_NAME=")" << SYSTEM_SID_METADATA << R"("
             );)").GetValueSync();
         UNIT_ASSERT_VALUES_EQUAL(result.GetStatus(), EStatus::GENERIC_ERROR);
         UNIT_ASSERT_STRING_CONTAINS_C(result.GetIssues().ToString(),
-            TStringBuilder() << "Invalid resource pool classifier configuration, cannot create classifier for system user " << BUILTIN_ACL_METADATA,
+            TStringBuilder() << "Invalid resource pool classifier configuration, cannot create classifier for system user " << SYSTEM_SID_METADATA,
             result.GetIssues().ToString()
         );
     }

--- a/ydb/core/kqp/ut/scheme/kqp_secrets_ut.cpp
+++ b/ydb/core/kqp/ut/scheme/kqp_secrets_ut.cpp
@@ -28,7 +28,7 @@ struct TFakeTicketParserActor : public TActor<TFakeTicketParserActor> {
     )
 
     void Handle(TEvTicketParser::TEvAuthorizeTicket::TPtr& ev) {
-        Y_ABORT_UNLESS(ev->Get()->Ticket.EndsWith(BUILTIN_SYSTEM_DOMAIN));
+        Y_ABORT_UNLESS(ev->Get()->Ticket.EndsWith(AUTH_DOMAIN_SYSTEM));
         NACLib::TUserToken::TUserTokenInitFields args;
         args.UserSID = ev->Get()->Ticket;
         TIntrusivePtr<NACLib::TUserToken> userToken = MakeIntrusive<NACLib::TUserToken>(args);
@@ -163,7 +163,7 @@ Y_UNIT_TEST_SUITE(KqpSecrets) {
                 .SetEndpoint(ydb.GetEndpoint())
                 .SetDatabase(tenantPath));
 
-            auto queryClient = NYdb::NQuery::TQueryClient(*driver, NYdb::NQuery::TClientSettings().AuthToken("user@" BUILTIN_SYSTEM_DOMAIN));
+            auto queryClient = NYdb::NQuery::TQueryClient(*driver, NYdb::NQuery::TClientSettings().AuthToken("user@" AUTH_DOMAIN_SYSTEM));
             auto result = queryClient.ExecuteQuery("CREATE OBJECT `id` (TYPE SECRET) WITH (value=`minio`);", NYdb::NQuery::TTxControl::NoTx()).GetValueSync();
             UNIT_ASSERT_VALUES_EQUAL(result.GetStatus(), NYdb::EStatus::GENERIC_ERROR);
             UNIT_ASSERT_STRING_CONTAINS_C(result.GetIssues().ToOneLineString(), fmt::format("Secret name id must start with database name {db}", "db"_a = ExtractBase(tenantPath)), result.GetIssues().ToOneLineString());
@@ -178,7 +178,7 @@ Y_UNIT_TEST_SUITE(KqpSecrets) {
                 .SetEndpoint(ydb.GetEndpoint())
                 .SetDatabase(tenantPath));
 
-            auto queryClient = NYdb::NQuery::TQueryClient(*driver, NYdb::NQuery::TClientSettings().AuthToken("user@" BUILTIN_SYSTEM_DOMAIN));
+            auto queryClient = NYdb::NQuery::TQueryClient(*driver, NYdb::NQuery::TClientSettings().AuthToken("user@" AUTH_DOMAIN_SYSTEM));
             auto result = queryClient.ExecuteQuery(fmt::format("CREATE OBJECT `{db}id` (TYPE SECRET) WITH (value=`minio`);", "db"_a = ExtractBase(tenantPath)), NYdb::NQuery::TTxControl::NoTx()).GetValueSync();
             UNIT_ASSERT_VALUES_EQUAL_C(result.GetStatus(), NYdb::EStatus::SUCCESS, result.GetIssues().ToOneLineString());
         }

--- a/ydb/core/kqp/ut/service/kqp_qs_queries_ut.cpp
+++ b/ydb/core/kqp/ut/service/kqp_qs_queries_ut.cpp
@@ -985,7 +985,7 @@ Y_UNIT_TEST_SUITE(KqpQueryService) {
             .SetEnableResourcePools(true));
         auto db = kikimr.GetQueryClient();
 
-        const TString userSID = TStringBuilder() << "test@" << BUILTIN_ACL_DOMAIN;
+        const TString userSID = TStringBuilder() << "test@" << AUTH_DOMAIN_BUILTIN;
         const TString schemeSql = TStringBuilder() << R"(
             CREATE RESOURCE POOL MyPool WITH (
                 CONCURRENT_QUERY_LIMIT=0

--- a/ydb/core/kqp/workload_service/actors/scheme_actors.cpp
+++ b/ydb/core/kqp/workload_service/actors/scheme_actors.cpp
@@ -75,9 +75,9 @@ public:
             diffAcl.AddAccess(NACLib::EAccessType::Allow, useAccess, userSID);
         }
         diffAcl.AddAccess(NACLib::EAccessType::Allow, useAccess, AppData()->AllAuthenticatedUsers);
-        diffAcl.AddAccess(NACLib::EAccessType::Allow, useAccess, BUILTIN_ACL_ROOT);
+        diffAcl.AddAccess(NACLib::EAccessType::Allow, useAccess, BUILTIN_SID_ROOT);
 
-        auto token = MakeIntrusive<NACLib::TUserToken>(BUILTIN_ACL_METADATA, TVector<NACLib::TSID>{});
+        auto token = MakeIntrusive<NACLib::TUserToken>(SYSTEM_SID_METADATA, TVector<NACLib::TSID>{});
         Register(CreatePoolCreatorActor(SelfId(), Event->Get()->DatabaseId, Event->Get()->PoolId, NResourcePool::TPoolSettings(), token, diffAcl));
     }
 

--- a/ydb/core/kqp/workload_service/ut/common/kqp_workload_service_ut_common.cpp
+++ b/ydb/core/kqp/workload_service/ut/common/kqp_workload_service_ut_common.cpp
@@ -222,7 +222,7 @@ private:
     std::unordered_set<TActorId> RunningRequests;
 };
 
-// The only purpose is to allow BUILTIN_SYSTEM_DOMAIN users
+// The only purpose is to allow AUTH_DOMAIN_SYSTEM users
 struct TFakeTicketParserActor : public TActor<TFakeTicketParserActor> {
     TFakeTicketParserActor()
         : TActor<TFakeTicketParserActor>(&TFakeTicketParserActor::StateFunc)
@@ -233,7 +233,7 @@ struct TFakeTicketParserActor : public TActor<TFakeTicketParserActor> {
     )
 
     void Handle(TEvTicketParser::TEvAuthorizeTicket::TPtr& ev) {
-        Y_ABORT_UNLESS(ev->Get()->Ticket.EndsWith(BUILTIN_SYSTEM_DOMAIN));
+        Y_ABORT_UNLESS(ev->Get()->Ticket.EndsWith(AUTH_DOMAIN_SYSTEM));
         NACLib::TUserToken::TUserTokenInitFields args;
         args.UserSID = ev->Get()->Ticket;
         TIntrusivePtr<NACLib::TUserToken> userToken = MakeIntrusive<NACLib::TUserToken>(args);
@@ -344,7 +344,7 @@ private:
             .SetEndpoint(TStringBuilder() << "localhost:" << grpcPort)
             .SetDatabase(TStringBuilder() << "/" << Settings_.DomainName_));
 
-        TableClient_ = std::make_unique<NYdb::NTable::TTableClient>(*YdbDriver_, NYdb::NTable::TClientSettings().AuthToken("user@" BUILTIN_SYSTEM_DOMAIN));
+        TableClient_ = std::make_unique<NYdb::NTable::TTableClient>(*YdbDriver_, NYdb::NTable::TClientSettings().AuthToken("user@" AUTH_DOMAIN_SYSTEM));
         TableClientSession_ = std::make_unique<NYdb::NTable::TSession>(TableClient_->CreateSession().GetValueSync().GetSession());
 
         Tenants_ = std::make_unique<TTenants>(Server_);

--- a/ydb/core/kqp/workload_service/ut/common/kqp_workload_service_ut_common.h
+++ b/ydb/core/kqp/workload_service/ut/common/kqp_workload_service_ut_common.h
@@ -27,7 +27,7 @@ struct TQueryRunnerSettings {
     // Query settings
     FLUENT_SETTING_DEFAULT(ui32, NodeIndex, 0);
     FLUENT_SETTING_DEFAULT(std::optional<TString>, PoolId, std::nullopt);
-    FLUENT_SETTING_DEFAULT(TString, UserSID, "user@" BUILTIN_SYSTEM_DOMAIN);
+    FLUENT_SETTING_DEFAULT(TString, UserSID, "user@" AUTH_DOMAIN_SYSTEM);
     FLUENT_SETTING_DEFAULT(TVector<TString>, GroupSIDs, {});
     FLUENT_SETTING_DEFAULT(TString, Database, "");
 

--- a/ydb/core/kqp/workload_service/ut/kqp_workload_service_actors_ut.cpp
+++ b/ydb/core/kqp/workload_service/ut/kqp_workload_service_actors_ut.cpp
@@ -12,7 +12,7 @@ namespace {
 using namespace NWorkload;
 
 
-TEvPrivate::TEvFetchPoolResponse::TPtr FetchPool(TIntrusivePtr<IYdbSetup> ydb, const TString& poolId = "", const TString& userSID = "user@" BUILTIN_SYSTEM_DOMAIN) {
+TEvPrivate::TEvFetchPoolResponse::TPtr FetchPool(TIntrusivePtr<IYdbSetup> ydb, const TString& poolId = "", const TString& userSID = "user@" AUTH_DOMAIN_SYSTEM) {
     const auto& settings = ydb->GetSettings();
     auto runtime = ydb->GetRuntime();
     const auto& edgeActor = runtime->AllocateEdgeActor();
@@ -112,7 +112,7 @@ Y_UNIT_TEST_SUITE(KqpWorkloadServiceActors) {
         // Check default pool access
         TSampleQueries::TSelect42::CheckResult(ydb->ExecuteQuery(TSampleQueries::TSelect42::Query, settings.UserSID(userSID)));
         TSampleQueries::TSelect42::CheckResult(ydb->ExecuteQuery(TSampleQueries::TSelect42::Query, settings.UserSID(ydb->GetRuntime()->GetAppData().AllAuthenticatedUsers)));
-        TSampleQueries::TSelect42::CheckResult(ydb->ExecuteQuery(TSampleQueries::TSelect42::Query, settings.UserSID(BUILTIN_ACL_ROOT)));
+        TSampleQueries::TSelect42::CheckResult(ydb->ExecuteQuery(TSampleQueries::TSelect42::Query, settings.UserSID(BUILTIN_SID_ROOT)));
     }
 
     Y_UNIT_TEST(TestDefaultPoolAdminPermissions) {
@@ -181,7 +181,7 @@ Y_UNIT_TEST_SUITE(KqpWorkloadServiceSubscriptions) {
 
         const auto& securityObject = response->Get()->SecurityObject;
         UNIT_ASSERT_C(securityObject, "Security object not found");
-        UNIT_ASSERT_VALUES_EQUAL_C(securityObject->GetOwnerSID(), BUILTIN_ACL_ROOT, "Unexpected owner user SID");
+        UNIT_ASSERT_VALUES_EQUAL_C(securityObject->GetOwnerSID(), BUILTIN_SID_ROOT, "Unexpected owner user SID");
 
         return edgeActor;
     }

--- a/ydb/core/kqp/workload_service/ut/kqp_workload_service_ut.cpp
+++ b/ydb/core/kqp/workload_service/ut/kqp_workload_service_ut.cpp
@@ -225,7 +225,7 @@ Y_UNIT_TEST_SUITE(KqpWorkloadService) {
 
         auto settings = TQueryRunnerSettings().HangUpDuringExecution(true);
         auto hangingRequest = ydb->ExecuteQueryAsync(TSampleQueries::TSelect42::Query, settings);
-        ydb->WaitQueryExecution(hangingRequest);        
+        ydb->WaitQueryExecution(hangingRequest);
 
         auto delayedRequest = ydb->ExecuteQueryAsync(TSampleQueries::TSelect42::Query, settings);
         TSampleQueries::CheckCancelled(hangingRequest.GetResult());
@@ -739,7 +739,7 @@ Y_UNIT_TEST_SUITE(ResourcePoolClassifiersDdl) {
                 MEMBER_NAME=")" << settings.UserSID_ << R"("
             );
         )", TQueryRunnerSettings()
-            .UserSID(BUILTIN_ACL_METADATA)
+            .UserSID(SYSTEM_SID_METADATA)
             .Database(settings.Database_)
             .NodeIndex(settings.NodeIndex_)
             .PoolId(NResourcePool::DEFAULT_POOL_ID)

--- a/ydb/core/persqueue/ut/pq_ut.cpp
+++ b/ydb/core/persqueue/ut/pq_ut.cpp
@@ -611,7 +611,7 @@ Y_UNIT_TEST(TestCheckACL) {
 
         TAutoPtr<IEventHandle> handle;
         THolder<TEvPersQueue::TEvCheckACL> request(new TEvPersQueue::TEvCheckACL());
-        request->Record.SetToken(NACLib::TUserToken("client@" BUILTIN_ACL_DOMAIN, {}).SerializeAsString());
+        request->Record.SetToken(NACLib::TUserToken("client@" AUTH_DOMAIN_BUILTIN, {}).SerializeAsString());
         request->Record.SetOperation(NKikimrPQ::EOperation::READ_OP);
         request->Record.SetUser("client");
 
@@ -632,7 +632,7 @@ Y_UNIT_TEST(TestCheckACL) {
         UNIT_ASSERT(rec.GetAccess() == NKikimrPQ::EAccess::DENIED);
         UNIT_ASSERT_VALUES_EQUAL(rec.GetTopic(), TOPIC_NAME);
 
-        state->ACL.AddAccess(NACLib::EAccessType::Allow, NACLib::SelectRow, "client@" BUILTIN_ACL_DOMAIN);
+        state->ACL.AddAccess(NACLib::EAccessType::Allow, NACLib::SelectRow, "client@" AUTH_DOMAIN_BUILTIN);
 
         {
             TDispatchOptions options;
@@ -641,7 +641,7 @@ Y_UNIT_TEST(TestCheckACL) {
         }
 
         request.Reset(new TEvPersQueue::TEvCheckACL());
-        request->Record.SetToken(NACLib::TUserToken("client@" BUILTIN_ACL_DOMAIN, {}).SerializeAsString());
+        request->Record.SetToken(NACLib::TUserToken("client@" AUTH_DOMAIN_BUILTIN, {}).SerializeAsString());
         request->Record.SetUser("client");
         request->Record.SetOperation(NKikimrPQ::EOperation::READ_OP);
 
@@ -650,7 +650,7 @@ Y_UNIT_TEST(TestCheckACL) {
         auto& rec2 = result->Record;
         UNIT_ASSERT_C(rec2.GetAccess() == NKikimrPQ::EAccess::ALLOWED, rec2);
 
-        state->ACL.AddAccess(NACLib::EAccessType::Allow, NACLib::UpdateRow, "client@" BUILTIN_ACL_DOMAIN);
+        state->ACL.AddAccess(NACLib::EAccessType::Allow, NACLib::UpdateRow, "client@" AUTH_DOMAIN_BUILTIN);
 
         {
             TDispatchOptions options;
@@ -659,7 +659,7 @@ Y_UNIT_TEST(TestCheckACL) {
         }
 
         request.Reset(new TEvPersQueue::TEvCheckACL());
-        request->Record.SetToken(NACLib::TUserToken("client@" BUILTIN_ACL_DOMAIN, {}).SerializeAsString());
+        request->Record.SetToken(NACLib::TUserToken("client@" AUTH_DOMAIN_BUILTIN, {}).SerializeAsString());
         request->Record.SetUser("client");
         request->Record.SetOperation(NKikimrPQ::EOperation::WRITE_OP);
 
@@ -669,7 +669,7 @@ Y_UNIT_TEST(TestCheckACL) {
         UNIT_ASSERT(rec3.GetAccess() == NKikimrPQ::EAccess::ALLOWED);
 
         request.Reset(new TEvPersQueue::TEvCheckACL());
-        request->Record.SetToken(NACLib::TUserToken("client@" BUILTIN_ACL_DOMAIN, {}).SerializeAsString());
+        request->Record.SetToken(NACLib::TUserToken("client@" AUTH_DOMAIN_BUILTIN, {}).SerializeAsString());
         request->Record.SetUser("client2");
         request->Record.SetOperation(NKikimrPQ::EOperation::WRITE_OP);
 

--- a/ydb/core/persqueue/ut/ut_with_sdk/mirrorer_ut.cpp
+++ b/ydb/core/persqueue/ut/ut_with_sdk/mirrorer_ut.cpp
@@ -38,7 +38,7 @@ Y_UNIT_TEST_SUITE(TPersQueueMirrorer) {
         mirrorFrom.SetConsumer("some_user");
         mirrorFrom.SetSyncWriteTime(true);
         //mirrorFrom.SetDatabase("/Root");
-        //mirrorFrom.MutableCredentials()->SetOauthToken("test_user@" BUILTIN_ACL_DOMAIN);
+        //mirrorFrom.MutableCredentials()->SetOauthToken("test_user@" AUTH_DOMAIN_BUILTIN);
 
         server.AnnoyingClient->CreateTopic(
             dstTopicFullName,

--- a/ydb/core/resource_pools/resource_pool_classifier_settings_ut.cpp
+++ b/ydb/core/resource_pools/resource_pool_classifier_settings_ut.cpp
@@ -52,7 +52,7 @@ Y_UNIT_TEST_SUITE(ResourcePoolClassifierTest) {
 
     Y_UNIT_TEST(SettingsValidation) {
         TClassifierSettings settings;
-        settings.MemberName = BUILTIN_ACL_METADATA;
+        settings.MemberName = SYSTEM_SID_METADATA;
         UNIT_ASSERT_STRING_CONTAINS(*settings.Validate(), TStringBuilder() << "Invalid resource pool classifier configuration, cannot create classifier for system user " << settings.MemberName);
     }
 }

--- a/ydb/core/security/secure_request.h
+++ b/ydb/core/security/secure_request.h
@@ -132,7 +132,7 @@ public:
         if (!defaultUserSIDs.empty()) {
             return defaultUserSIDs.front();
         }
-        return BUILTIN_ACL_ROOT;
+        return BUILTIN_SID_ROOT;
     }
 
     TString GetSanitizedToken() const {

--- a/ydb/core/tx/schemeshard/schemeshard__init_root.cpp
+++ b/ydb/core/tx/schemeshard/schemeshard__init_root.cpp
@@ -103,7 +103,7 @@ struct TSchemeShard::TTxInitRoot : public TSchemeShard::TRwTxBase {
         }
 
         if (owner.empty()) {
-            owner = BUILTIN_ACL_ROOT;
+            owner = BUILTIN_SID_ROOT;
         }
 
         TPathElement::TPtr newPath = new TPathElement(Self->RootPathId(), Self->RootPathId(), Self->RootPathId(), joinedRootPath, owner);
@@ -208,7 +208,7 @@ struct TSchemeShard::TTxInitRootCompatibility : public TSchemeShard::TRwTxBase {
             return;
         }
 
-        if (root.Base()->Owner != BUILTIN_ACL_ROOT) {
+        if (root.Base()->Owner != BUILTIN_SID_ROOT) {
             OnComplete.Send(answerTo, reply.Release());
             return;
         }

--- a/ydb/core/tx/schemeshard/schemeshard__operation.cpp
+++ b/ydb/core/tx/schemeshard/schemeshard__operation.cpp
@@ -109,7 +109,7 @@ bool TSchemeShard::ProcessOperationParts(
     TOperationContext& context)
 {
     auto selfId = SelfTabletId();
-    const TString owner = record.HasOwner() ? record.GetOwner() : BUILTIN_ACL_ROOT;
+    const TString owner = record.HasOwner() ? record.GetOwner() : BUILTIN_SID_ROOT;
 
     if (parts.size() > 1) {
         // allow altering impl index tables as part of consistent operation

--- a/ydb/core/tx/schemeshard/schemeshard__operation_create_replication.cpp
+++ b/ydb/core/tx/schemeshard/schemeshard__operation_create_replication.cpp
@@ -437,7 +437,7 @@ public:
         parentPath.DomainInfo()->IncPathsInside(context.SS);
 
         if (desc.GetConfig().GetSrcConnectionParams().GetCredentialsCase() == NKikimrReplication::TConnectionParams::CREDENTIALS_NOT_SET) {
-            desc.MutableConfig()->MutableSrcConnectionParams()->MutableOAuthToken()->SetToken(BUILTIN_ACL_ROOT);
+            desc.MutableConfig()->MutableSrcConnectionParams()->MutableOAuthToken()->SetToken(BUILTIN_SID_ROOT);
         }
 
         if (desc.GetConfig().GetConsistencySettings().GetLevelCase() == NKikimrReplication::TConsistencySettings::LEVEL_NOT_SET) {

--- a/ydb/core/tx/tiering/fetcher.h
+++ b/ydb/core/tx/tiering/fetcher.h
@@ -97,7 +97,7 @@ private:
         }
 
         auto event = BuildSchemeCacheNavigateRequest(
-            std::move(splitPaths), MakeIntrusive<NACLib::TUserToken>(BUILTIN_ACL_METADATA, TVector<NACLib::TSID>{}));
+            std::move(splitPaths), MakeIntrusive<NACLib::TUserToken>(SYSTEM_SID_METADATA, TVector<NACLib::TSID>{}));
         Send(MakeSchemeCacheID(), new TEvTxProxySchemeCache::TEvNavigateKeySet(event.Release()), IEventHandle::FlagTrackDelivery);
     }
 

--- a/ydb/core/tx/tx_proxy/describe.cpp
+++ b/ydb/core/tx/tx_proxy/describe.cpp
@@ -72,7 +72,7 @@ class TDescribeReq : public TActor<TDescribeReq> {
         // TODO(xenoxeno): ?
         //descr->SetCreateTxId(0);
         //descr->SetCreateStep(0);
-        //descr->SetOwner(BUILTIN_ACL_ROOT);
+        //descr->SetOwner(BUILTIN_SID_ROOT);
     }
 
     void FillSystemViewDirEntry(NKikimrSchemeOp::TDirEntry* self, ui64 schemeShardId) {

--- a/ydb/library/aclib/aclib.cpp
+++ b/ydb/library/aclib/aclib.cpp
@@ -135,7 +135,7 @@ void TUserToken::AddGroupSID(const TSID& groupSID) {
 }
 
 bool TUserToken::IsSystemUser() const {
-    return GetUserSID().EndsWith("@" BUILTIN_SYSTEM_DOMAIN);
+    return GetUserSID().EndsWith("@" AUTH_DOMAIN_SYSTEM);
 }
 
 TSecurityObject::TSecurityObject(const NACLibProto::TSecurityObject& protoSecObj, bool isContainer)
@@ -385,7 +385,7 @@ bool TACL::HasAccess(const NACLib::TSID& sid) {
             return true;
         }
     }
-    
+
     return false;
 }
 
@@ -813,12 +813,12 @@ TString AccessRightsToString(ui32 accessRights) {
 }
 
 const NACLib::TUserToken& TSystemUsers::Metadata() {
-    static TUserToken GlobalMetadataUser = TUserToken(BUILTIN_ACL_METADATA, {});
+    static TUserToken GlobalMetadataUser = TUserToken(SYSTEM_SID_METADATA, {});
     return GlobalMetadataUser;
 }
 
 const NACLib::TUserToken& TSystemUsers::Tmp() {
-    static TUserToken GlobalTmpUser = TUserToken(BUILTIN_ACL_TMP, {});
+    static TUserToken GlobalTmpUser = TUserToken(SYSTEM_SID_TMP, {});
     return GlobalTmpUser;
 }
 

--- a/ydb/library/aclib/aclib.h
+++ b/ydb/library/aclib/aclib.h
@@ -6,13 +6,18 @@
 
 namespace NACLib {
 
-#define BUILTIN_ACL_DOMAIN "builtin"
-#define BUILTIN_ACL_ROOT "root@" BUILTIN_ACL_DOMAIN
-#define BUILTIN_ERROR_DOMAIN "error"
-#define BUILTIN_SYSTEM_DOMAIN "system"
+#define AUTH_DOMAIN_BUILTIN "builtin"
+#define AUTH_DOMAIN_ERROR "error"
+#define AUTH_DOMAIN_SYSTEM "system"
 
-#define BUILTIN_ACL_METADATA "metadata@" BUILTIN_SYSTEM_DOMAIN
-#define BUILTIN_ACL_TMP "tmp@" BUILTIN_SYSTEM_DOMAIN
+#define BUILTIN_SID_ROOT "root@" AUTH_DOMAIN_BUILTIN
+
+#define SYSTEM_SID_METADATA "metadata@" AUTH_DOMAIN_SYSTEM
+#define SYSTEM_SID_TMP "tmp@" AUTH_DOMAIN_SYSTEM
+
+// for backward compatibility
+#define BUILTIN_ACL_DOMAIN AUTH_DOMAIN_BUILTIN
+#define BUILTIN_ACL_ROOT BUILTIN_SID_ROOT
 
 class TUserToken;
 class TSystemUsers {
@@ -173,10 +178,5 @@ public:
 protected:
     bool IsContainer;
 };
-
-
-
-
-
 
 }

--- a/ydb/services/cms/cms_ut.cpp
+++ b/ydb/services/cms/cms_ut.cpp
@@ -382,13 +382,13 @@ Y_UNIT_TEST_SUITE(TGRpcCmsTest) {
         channel = grpc::CreateChannel("localhost:" + ToString(grpc), grpc::InsecureChannelCredentials());
 
         // create tenant
-        CheckCreateDatabase(server, channel, "/Root/users/user-1", false, true, BUILTIN_ACL_ROOT);
+        CheckCreateDatabase(server, channel, "/Root/users/user-1", false, true, BUILTIN_SID_ROOT);
 
         // Check owner
         {
             TClient client(*server.ServerSettings);
             auto resp = client.Ls("/Root/users/user-1");
-            UNIT_ASSERT_VALUES_EQUAL(resp->Record.GetPathDescription().GetSelf().GetOwner(), BUILTIN_ACL_ROOT);
+            UNIT_ASSERT_VALUES_EQUAL(resp->Record.GetPathDescription().GetSelf().GetOwner(), BUILTIN_SID_ROOT);
         }
     }
 
@@ -528,29 +528,29 @@ Y_UNIT_TEST_SUITE(TGRpcCmsTest) {
         {
             NACLib::TDiffACL acl;
             acl.AddAccess(NACLib::EAccessType::Allow, NACLib::GenericFull,
-                          "user-1@" BUILTIN_ACL_DOMAIN);
+                          "user-1@" AUTH_DOMAIN_BUILTIN);
             TClient client(*server.ServerSettings);
             client.ModifyACL("/", "Root", acl.SerializeAsString());
         }
 
         CheckCreateDatabase(server, channel, "/Root/users/user-1",
-                            false, true, "user-1@" BUILTIN_ACL_DOMAIN);
+                            false, true, "user-1@" AUTH_DOMAIN_BUILTIN);
 
         CheckRemoveDatabase(channel, "/Root/users/user-1",
-                            "user-2@" BUILTIN_ACL_DOMAIN,
+                            "user-2@" AUTH_DOMAIN_BUILTIN,
                             Ydb::StatusIds::UNAUTHORIZED);
 
         {
             NACLib::TDiffACL acl;
             acl.AddAccess(NACLib::EAccessType::Allow, NACLib::GenericFull,
-                          "user-2@" BUILTIN_ACL_DOMAIN);
+                          "user-2@" AUTH_DOMAIN_BUILTIN);
             TClient client(*server.ServerSettings);
             client.ModifyACL("/Root/users", "user-1", acl.SerializeAsString());
             client.RefreshPathCache(server.Server_->GetRuntime(), "/Root/users/user-1");
         }
 
         CheckRemoveDatabase(channel, "/Root/users/user-1",
-                            "user-2@" BUILTIN_ACL_DOMAIN);
+                            "user-2@" AUTH_DOMAIN_BUILTIN);
     }
 }
 

--- a/ydb/services/metadata/manager/fetch_database.cpp
+++ b/ydb/services/metadata/manager/fetch_database.cpp
@@ -67,7 +67,7 @@ private:
         auto event = NTableCreator::BuildSchemeCacheNavigateRequest(
             {{}},
             Database ? Database : AppData()->TenantName,
-            MakeIntrusive<NACLib::TUserToken>(BUILTIN_ACL_METADATA, TVector<NACLib::TSID>{})
+            MakeIntrusive<NACLib::TUserToken>(SYSTEM_SID_METADATA, TVector<NACLib::TSID>{})
         );
         event->ResultSet[0].Operation = NSchemeCache::TSchemeCacheNavigate::OpPath;
         Send(MakeSchemeCacheID(), new TEvTxProxySchemeCache::TEvNavigateKeySet(event.Release()), IEventHandle::FlagTrackDelivery);

--- a/ydb/services/persqueue_v1/persqueue_new_schemecache_ut.cpp
+++ b/ydb/services/persqueue_v1/persqueue_new_schemecache_ut.cpp
@@ -68,12 +68,12 @@ namespace NKikimr::NPersQueueTests {
                 NKikimrServices::FLAT_TX_SCHEMESHARD, NKikimrServices::PQ_METACACHE}
             );
             PrepareForGrpcNoDC(*server.AnnoyingClient);
-            server.AnnoyingClient->GrantConnect("topic1@" BUILTIN_ACL_DOMAIN);
+            server.AnnoyingClient->GrantConnect("topic1@" AUTH_DOMAIN_BUILTIN);
 
             TPQDataWriter writer("source1", server, DEFAULT_TOPIC_PATH);
 
-            writer.Write("/Root/account2/topic2", {"valuevaluevalue1"}, true, "topic1@" BUILTIN_ACL_DOMAIN);
-            writer.Write("/Root/PQ/account1/topic1", {"valuevaluevalue1"}, true, "topic1@" BUILTIN_ACL_DOMAIN);
+            writer.Write("/Root/account2/topic2", {"valuevaluevalue1"}, true, "topic1@" AUTH_DOMAIN_BUILTIN);
+            writer.Write("/Root/PQ/account1/topic1", {"valuevaluevalue1"}, true, "topic1@" AUTH_DOMAIN_BUILTIN);
 
             NYdb::TDriverConfig driverCfg;
 
@@ -84,13 +84,13 @@ namespace NKikimr::NPersQueueTests {
             auto ydbDriver = MakeHolder<NYdb::TDriver>(driverCfg);
 
 
-            ModifyTopicACL(ydbDriver.Get(), "/Root/account2/topic2", {{"topic1@" BUILTIN_ACL_DOMAIN, {"ydb.generic.write"}}});
-            ModifyTopicACL(ydbDriver.Get(), "/Root/PQ/account1/topic1", {{"topic1@" BUILTIN_ACL_DOMAIN, {"ydb.generic.write"}}});
+            ModifyTopicACL(ydbDriver.Get(), "/Root/account2/topic2", {{"topic1@" AUTH_DOMAIN_BUILTIN, {"ydb.generic.write"}}});
+            ModifyTopicACL(ydbDriver.Get(), "/Root/PQ/account1/topic1", {{"topic1@" AUTH_DOMAIN_BUILTIN, {"ydb.generic.write"}}});
 
-            writer.Write("/Root/account2/topic2", {"valuevaluevalue1"}, false, "topic1@" BUILTIN_ACL_DOMAIN);
+            writer.Write("/Root/account2/topic2", {"valuevaluevalue1"}, false, "topic1@" AUTH_DOMAIN_BUILTIN);
 
-            writer.Write("/Root/PQ/account1/topic1", {"valuevaluevalue1"}, false, "topic1@" BUILTIN_ACL_DOMAIN);
-            writer.Write("/Root/PQ/account1/topic1", {"valuevaluevalue2"}, false, "topic1@" BUILTIN_ACL_DOMAIN);
+            writer.Write("/Root/PQ/account1/topic1", {"valuevaluevalue1"}, false, "topic1@" AUTH_DOMAIN_BUILTIN);
+            writer.Write("/Root/PQ/account1/topic1", {"valuevaluevalue2"}, false, "topic1@" AUTH_DOMAIN_BUILTIN);
 
         }
 
@@ -106,7 +106,7 @@ namespace NKikimr::NPersQueueTests {
                      .SetLog(std::unique_ptr<TLogBackend>(CreateLogBackend("cerr", ELogPriority::TLOG_DEBUG).Release()))
                      .SetDatabase("/Root");
 
-            server.AnnoyingClient->GrantConnect("user1@" BUILTIN_ACL_DOMAIN);
+            server.AnnoyingClient->GrantConnect("user1@" AUTH_DOMAIN_BUILTIN);
 
             auto ydbDriver = MakeHolder<NYdb::TDriver>(driverCfg);
             auto persQueueClient = MakeHolder<NYdb::NPersQueue::TPersQueueClient>(*ydbDriver);
@@ -118,7 +118,7 @@ namespace NKikimr::NPersQueueTests {
                 UNIT_ASSERT(res.GetValue().IsSuccess());
             }
 
-            ModifyTopicACL(ydbDriver.Get(), "/Root/account2/topic2", {{"user1@" BUILTIN_ACL_DOMAIN, {"ydb.generic.read"}}});
+            ModifyTopicACL(ydbDriver.Get(), "/Root/account2/topic2", {{"user1@" AUTH_DOMAIN_BUILTIN, {"ydb.generic.read"}}});
 
             {
                 auto writer = CreateSimpleWriter(*ydbDriver, "/Root/account2/topic2", "123", 1);

--- a/ydb/services/persqueue_v1/ut/persqueue_common_tests.h
+++ b/ydb/services/persqueue_v1/ut/persqueue_common_tests.h
@@ -59,7 +59,7 @@ public:
     }
 
     TString GenerateValidToken(int i = 0) {
-        return "test_user_" + ToString(i) + "@" + BUILTIN_ACL_DOMAIN;
+        return "test_user_" + ToString(i) + "@" + AUTH_DOMAIN_BUILTIN;
     }
 
     // Auth* tests are for both authentication and authorization
@@ -220,8 +220,8 @@ public:
         TPersQueueV1TestServer server = CreateServer();
         SET_LOCALS;
         runtime->GetAppData().PQConfig.SetRequireCredentialsInNewProtocol(true);
-        const TString validToken = "test_user@" BUILTIN_ACL_DOMAIN;
-        // TODO: Why test fails with 'BUILTIN_ACL_DOMAIN' as domain in invalid token?
+        const TString validToken = "test_user@" AUTH_DOMAIN_BUILTIN;
+        // TODO: Why test fails with 'AUTH_DOMAIN_BUILTIN' as domain in invalid token?
         TVector<TString> invalidTokens = {TString(), "test_user", "test_user@invalid_domain"};
         server.ModifyTopicACLAndWait(server.GetFullTopicPath(), {{validToken, {"ydb.generic.write"}}});
 
@@ -253,9 +253,9 @@ public:
         TPersQueueV1TestServer server = CreateServer();
 
         const TString validToken = "test_user@"
-                                   BUILTIN_ACL_DOMAIN;
+                                   AUTH_DOMAIN_BUILTIN;
         const TString invalidToken = "test_user_2@"
-                                     BUILTIN_ACL_DOMAIN;
+                                     AUTH_DOMAIN_BUILTIN;
 
         server.ModifyTopicACL(server.GetFullTopicPath(), {{validToken, {"ydb.generic.write"}}});
 

--- a/ydb/services/persqueue_v1/ut/pq_data_writer.h
+++ b/ydb/services/persqueue_v1/ut/pq_data_writer.h
@@ -81,7 +81,7 @@ public:
 
         if (checkACL) {
             NACLib::TDiffACL acl;
-            acl.RemoveAccess(NACLib::EAccessType::Allow, NACLib::SelectRow, clientId + "@" BUILTIN_ACL_DOMAIN);
+            acl.RemoveAccess(NACLib::EAccessType::Allow, NACLib::SelectRow, clientId + "@" AUTH_DOMAIN_BUILTIN);
             Client.ModifyACL("/Root/PQ", "rt3.dc1--topic1", acl.SerializeAsString());
 
             Ydb::PersQueue::V1::MigrationStreamingReadClientMessage req;

--- a/ydb/services/ydb/ydb_register_node_ut.cpp
+++ b/ydb/services/ydb/ydb_register_node_ut.cpp
@@ -57,7 +57,7 @@ struct TKikimrServerForTestNodeRegistration : TBasicKikimrWithGrpcAndRootSchema<
         bool EnableDynamicNodeAuth = false;
         bool EnableWrongIdentity = false;
         bool SetNodeAuthValues = false;
-        std::vector<TString> RegisterNodeAllowedSids = {"DefaultClientAuth@cert", BUILTIN_ACL_ROOT};
+        std::vector<TString> RegisterNodeAllowedSids = {"DefaultClientAuth@cert", BUILTIN_SID_ROOT};
     };
 
     TKikimrServerForTestNodeRegistration(const TServerInitialization& serverInitialization)
@@ -180,7 +180,7 @@ Y_UNIT_TEST(ServerWithCertVerification_ClientWithCorrectCerts_EmptyAllowedSids) 
             .SetEndpoint(location);
 
         CheckGood(RegisterNode(config));
-        CheckGood(RegisterNode(config.SetAuthToken(BUILTIN_ACL_ROOT)));
+        CheckGood(RegisterNode(config.SetAuthToken(BUILTIN_SID_ROOT)));
         CheckAccessDenied(RegisterNode(config.SetAuthToken("wrong_token")), "Could not find correct token validator");
     }
     {
@@ -200,7 +200,7 @@ Y_UNIT_TEST(ServerWithCertVerification_ClientWithCorrectCerts_EmptyAllowedSids) 
             .SetEndpoint(location);
 
         CheckGood(RegisterNode(config));
-        CheckGood(RegisterNode(config.SetAuthToken(BUILTIN_ACL_ROOT)));
+        CheckGood(RegisterNode(config.SetAuthToken(BUILTIN_SID_ROOT)));
         CheckGood(RegisterNode(config.SetAuthToken("wrong_token")));
     }
 }
@@ -226,7 +226,7 @@ Y_UNIT_TEST(ServerWithCertVerification_ClientWithCorrectCerts) {
             .SetEndpoint(location);
 
         CheckGood(RegisterNode(config));
-        CheckGood(RegisterNode(config.SetAuthToken(BUILTIN_ACL_ROOT)));
+        CheckGood(RegisterNode(config.SetAuthToken(BUILTIN_SID_ROOT)));
         CheckAccessDenied(RegisterNode(config.SetAuthToken("wrong_token")), "Could not find correct token validator");
     }
     {
@@ -246,7 +246,7 @@ Y_UNIT_TEST(ServerWithCertVerification_ClientWithCorrectCerts) {
             .SetEndpoint(location);
 
         CheckGood(RegisterNode(config));
-        CheckGood(RegisterNode(config.SetAuthToken(BUILTIN_ACL_ROOT)));
+        CheckGood(RegisterNode(config.SetAuthToken(BUILTIN_SID_ROOT)));
         CheckGood(RegisterNode(config.SetAuthToken("wrong_token")));
     }
 }
@@ -272,7 +272,7 @@ Y_UNIT_TEST(ServerWithCertVerification_ClientWithCorrectCerts_AllowOnlyDefaultGr
             .SetEndpoint(location);
 
         CheckGood(RegisterNode(config));
-        CheckAccessDeniedRegisterNode(RegisterNode(config.SetAuthToken(BUILTIN_ACL_ROOT)), "Cannot authorize node. Access denied");
+        CheckAccessDeniedRegisterNode(RegisterNode(config.SetAuthToken(BUILTIN_SID_ROOT)), "Cannot authorize node. Access denied");
         CheckAccessDenied(RegisterNode(config.SetAuthToken("wrong_token")), "Could not find correct token validator");
     }
     {
@@ -292,7 +292,7 @@ Y_UNIT_TEST(ServerWithCertVerification_ClientWithCorrectCerts_AllowOnlyDefaultGr
             .SetEndpoint(location);
 
         CheckGood(RegisterNode(config));
-        CheckAccessDeniedRegisterNode(RegisterNode(config.SetAuthToken(BUILTIN_ACL_ROOT)), "Cannot authorize node. Access denied");
+        CheckAccessDeniedRegisterNode(RegisterNode(config.SetAuthToken(BUILTIN_SID_ROOT)), "Cannot authorize node. Access denied");
         CheckGood(RegisterNode(config.SetAuthToken("wrong_token")));
     }
 }
@@ -317,7 +317,7 @@ Y_UNIT_TEST(ServerWithIssuerVerification_ClientWithSameIssuer) {
             .SetEndpoint(location);
 
         CheckGood(RegisterNode(config));
-        CheckGood(RegisterNode(config.SetAuthToken(BUILTIN_ACL_ROOT)));
+        CheckGood(RegisterNode(config.SetAuthToken(BUILTIN_SID_ROOT)));
         CheckAccessDenied(RegisterNode(config.SetAuthToken("wrong_token")), "Could not find correct token validator");
     }
     {
@@ -336,7 +336,7 @@ Y_UNIT_TEST(ServerWithIssuerVerification_ClientWithSameIssuer) {
             .SetEndpoint(location);
 
         CheckGood(RegisterNode(config));
-        CheckGood(RegisterNode(config.SetAuthToken(BUILTIN_ACL_ROOT)));
+        CheckGood(RegisterNode(config.SetAuthToken(BUILTIN_SID_ROOT)));
         CheckGood(RegisterNode(config.SetAuthToken("wrong_token")));
     }
 }
@@ -361,7 +361,7 @@ Y_UNIT_TEST(ServerWithCertVerification_ClientProvidesEmptyClientCerts) {
             .SetEndpoint(location);
 
         CheckAccessDenied(RegisterNode(config), "Access denied without user token");
-        CheckGood(RegisterNode(config.SetAuthToken(BUILTIN_ACL_ROOT)));
+        CheckGood(RegisterNode(config.SetAuthToken(BUILTIN_SID_ROOT)));
         CheckAccessDenied(RegisterNode(config.SetAuthToken("wrong_token")), "Could not find correct token validator");
     }
     {
@@ -381,7 +381,7 @@ Y_UNIT_TEST(ServerWithCertVerification_ClientProvidesEmptyClientCerts) {
             .SetEndpoint(location);
 
         CheckGood(RegisterNode(config));
-        CheckGood(RegisterNode(config.SetAuthToken(BUILTIN_ACL_ROOT)));
+        CheckGood(RegisterNode(config.SetAuthToken(BUILTIN_SID_ROOT)));
         CheckGood(RegisterNode(config.SetAuthToken("wrong_token")));
     }
 }
@@ -404,7 +404,7 @@ Y_UNIT_TEST(ServerWithoutCertVerification_ClientProvidesCorrectCerts) {
             .SetEndpoint(location);
 
         CheckAccessDenied(RegisterNode(config), "Access denied without user token");
-        CheckGood(RegisterNode(config.SetAuthToken(BUILTIN_ACL_ROOT)));
+        CheckGood(RegisterNode(config.SetAuthToken(BUILTIN_SID_ROOT)));
         CheckAccessDenied(RegisterNode(config.SetAuthToken("wrong_token")), "Could not find correct token validator");
     }
     {
@@ -422,7 +422,7 @@ Y_UNIT_TEST(ServerWithoutCertVerification_ClientProvidesCorrectCerts) {
             .SetEndpoint(location);
 
         CheckGood(RegisterNode(config));
-        CheckGood(RegisterNode(config.SetAuthToken(BUILTIN_ACL_ROOT)));
+        CheckGood(RegisterNode(config.SetAuthToken(BUILTIN_SID_ROOT)));
         CheckGood(RegisterNode(config.SetAuthToken("wrong_token")));
     }
 }
@@ -445,7 +445,7 @@ Y_UNIT_TEST(ServerWithoutCertVerification_ClientProvidesEmptyClientCerts) {
             .SetEndpoint(location);
 
         CheckAccessDenied(RegisterNode(config), "Access denied without user token");
-        CheckGood(RegisterNode(config.SetAuthToken(BUILTIN_ACL_ROOT)));
+        CheckGood(RegisterNode(config.SetAuthToken(BUILTIN_SID_ROOT)));
         CheckAccessDenied(RegisterNode(config.SetAuthToken("wrong_token")), "Could not find correct token validator");
     }
     {
@@ -463,7 +463,7 @@ Y_UNIT_TEST(ServerWithoutCertVerification_ClientProvidesEmptyClientCerts) {
             .SetEndpoint(location);
 
         CheckGood(RegisterNode(config));
-        CheckGood(RegisterNode(config.SetAuthToken(BUILTIN_ACL_ROOT)));
+        CheckGood(RegisterNode(config.SetAuthToken(BUILTIN_SID_ROOT)));
         CheckGood(RegisterNode(config.SetAuthToken("wrong_token")));
     }
 }
@@ -489,7 +489,7 @@ Y_UNIT_TEST(ServerWithCertVerification_ClientProvideIncorrectCerts) {
             .SetEndpoint(location);
 
         CheckAccessDenied(RegisterNode(config), "Cannot create token from certificate. Client certificate failed verification");
-        CheckGood(RegisterNode(config.SetAuthToken(BUILTIN_ACL_ROOT)));
+        CheckGood(RegisterNode(config.SetAuthToken(BUILTIN_SID_ROOT)));
         CheckAccessDenied(RegisterNode(config.SetAuthToken("wrong_token")), "Could not find correct token validator");
     }
     {
@@ -510,7 +510,7 @@ Y_UNIT_TEST(ServerWithCertVerification_ClientProvideIncorrectCerts) {
             .SetEndpoint(location);
 
         CheckGood(RegisterNode(config));
-        CheckGood(RegisterNode(config.SetAuthToken(BUILTIN_ACL_ROOT)));
+        CheckGood(RegisterNode(config.SetAuthToken(BUILTIN_SID_ROOT)));
         CheckGood(RegisterNode(config.SetAuthToken("wrong_token")));
     }
 }
@@ -532,7 +532,7 @@ Y_UNIT_TEST(ServerWithCertVerification_ClientDoesNotProvideAnyCerts) {
 
         const TString expectedError = "failed to connect to all addresses";
         CheckAccessDenied(RegisterNode(config), expectedError);
-        CheckAccessDenied(RegisterNode(config.SetAuthToken(BUILTIN_ACL_ROOT)), expectedError);
+        CheckAccessDenied(RegisterNode(config.SetAuthToken(BUILTIN_SID_ROOT)), expectedError);
         CheckAccessDenied(RegisterNode(config.SetAuthToken("wrong_token")), expectedError);
     }
     {
@@ -551,7 +551,7 @@ Y_UNIT_TEST(ServerWithCertVerification_ClientDoesNotProvideAnyCerts) {
 
         const TString expectedError = "failed to connect to all addresses";
         CheckAccessDenied(RegisterNode(config), expectedError);
-        CheckAccessDenied(RegisterNode(config.SetAuthToken(BUILTIN_ACL_ROOT)), expectedError);
+        CheckAccessDenied(RegisterNode(config.SetAuthToken(BUILTIN_SID_ROOT)), expectedError);
         CheckAccessDenied(RegisterNode(config.SetAuthToken("wrong_token")), expectedError);
     }
 }
@@ -577,7 +577,7 @@ Y_UNIT_TEST(ServerWithCertVerification_ClientProvidesServerCerts) {
 
         const TString expectedError = "failed to connect to all addresses";
         CheckAccessDenied(RegisterNode(config), expectedError);
-        CheckAccessDenied(RegisterNode(config.SetAuthToken(BUILTIN_ACL_ROOT)), expectedError);
+        CheckAccessDenied(RegisterNode(config.SetAuthToken(BUILTIN_SID_ROOT)), expectedError);
         CheckAccessDenied(RegisterNode(config.SetAuthToken("wrong_token")), expectedError);
     }
     {
@@ -598,7 +598,7 @@ Y_UNIT_TEST(ServerWithCertVerification_ClientProvidesServerCerts) {
 
         const TString expectedError = "failed to connect to all addresses";
         CheckAccessDenied(RegisterNode(config), expectedError);
-        CheckAccessDenied(RegisterNode(config.SetAuthToken(BUILTIN_ACL_ROOT)), expectedError);
+        CheckAccessDenied(RegisterNode(config.SetAuthToken(BUILTIN_SID_ROOT)), expectedError);
         CheckAccessDenied(RegisterNode(config.SetAuthToken("wrong_token")), expectedError);
     }
 }
@@ -629,7 +629,7 @@ Y_UNIT_TEST(ServerWithCertVerification_ClientProvidesCorruptedCert) {
 
         const TString expectedError = "empty address list";
         CheckAccessDenied(RegisterNode(config), expectedError);
-        CheckAccessDenied(RegisterNode(config.SetAuthToken(BUILTIN_ACL_ROOT)), expectedError);
+        CheckAccessDenied(RegisterNode(config.SetAuthToken(BUILTIN_SID_ROOT)), expectedError);
         CheckAccessDenied(RegisterNode(config.SetAuthToken("wrong_token")), expectedError);
     }
     {
@@ -650,7 +650,7 @@ Y_UNIT_TEST(ServerWithCertVerification_ClientProvidesCorruptedCert) {
 
         const TString expectedError = "empty address list";
         CheckAccessDenied(RegisterNode(config), expectedError);
-        CheckAccessDenied(RegisterNode(config.SetAuthToken(BUILTIN_ACL_ROOT)), expectedError);
+        CheckAccessDenied(RegisterNode(config.SetAuthToken(BUILTIN_SID_ROOT)), expectedError);
         CheckAccessDenied(RegisterNode(config.SetAuthToken("wrong_token")), expectedError);
     }
 }
@@ -681,7 +681,7 @@ Y_UNIT_TEST(ServerWithCertVerification_ClientProvidesCorruptedPrivatekey) {
 
         const TString expectedError = "empty address list";
         CheckAccessDenied(RegisterNode(config), expectedError);
-        CheckAccessDenied(RegisterNode(config.SetAuthToken(BUILTIN_ACL_ROOT)), expectedError);
+        CheckAccessDenied(RegisterNode(config.SetAuthToken(BUILTIN_SID_ROOT)), expectedError);
         CheckAccessDenied(RegisterNode(config.SetAuthToken("wrong_token")), expectedError);
     }
     {
@@ -702,7 +702,7 @@ Y_UNIT_TEST(ServerWithCertVerification_ClientProvidesCorruptedPrivatekey) {
 
         const TString expectedError = "empty address list";
         CheckAccessDenied(RegisterNode(config), expectedError);
-        CheckAccessDenied(RegisterNode(config.SetAuthToken(BUILTIN_ACL_ROOT)), expectedError);
+        CheckAccessDenied(RegisterNode(config.SetAuthToken(BUILTIN_SID_ROOT)), expectedError);
         CheckAccessDenied(RegisterNode(config.SetAuthToken("wrong_token")), expectedError);
     }
 }
@@ -731,7 +731,7 @@ Y_UNIT_TEST(ServerWithCertVerification_ClientProvidesExpiredCert) {
 
         const TString expectedError = "failed to connect to all addresses";
         CheckAccessDenied(RegisterNode(config), expectedError);
-        CheckAccessDenied(RegisterNode(config.SetAuthToken(BUILTIN_ACL_ROOT)), expectedError);
+        CheckAccessDenied(RegisterNode(config.SetAuthToken(BUILTIN_SID_ROOT)), expectedError);
         CheckAccessDenied(RegisterNode(config.SetAuthToken("wrong_token")), expectedError);
     }
     {
@@ -755,7 +755,7 @@ Y_UNIT_TEST(ServerWithCertVerification_ClientProvidesExpiredCert) {
 
         const TString expectedError = "failed to connect to all addresses";
         CheckAccessDenied(RegisterNode(config), expectedError);
-        CheckAccessDenied(RegisterNode(config.SetAuthToken(BUILTIN_ACL_ROOT)), expectedError);
+        CheckAccessDenied(RegisterNode(config.SetAuthToken(BUILTIN_SID_ROOT)), expectedError);
         CheckAccessDenied(RegisterNode(config.SetAuthToken("wrong_token")), expectedError);
     }
 }
@@ -781,7 +781,7 @@ Y_UNIT_TEST(ServerWithOutCertVerification_ClientProvidesExpiredCert) {
             .SetEndpoint(location);
 
         CheckAccessDenied(RegisterNode(config), "Access denied without user token");
-        CheckGood(RegisterNode(config.SetAuthToken(BUILTIN_ACL_ROOT)));
+        CheckGood(RegisterNode(config.SetAuthToken(BUILTIN_SID_ROOT)));
         CheckAccessDenied(RegisterNode(config.SetAuthToken("wrong_token")), "Could not find correct token validator");
     }
     {
@@ -802,7 +802,7 @@ Y_UNIT_TEST(ServerWithOutCertVerification_ClientProvidesExpiredCert) {
             .SetEndpoint(location);
 
         CheckGood(RegisterNode(config));
-        CheckGood(RegisterNode(config.SetAuthToken(BUILTIN_ACL_ROOT)));
+        CheckGood(RegisterNode(config.SetAuthToken(BUILTIN_SID_ROOT)));
         CheckGood(RegisterNode(config.SetAuthToken("wrong_token")));
     }
 }
@@ -825,7 +825,7 @@ Y_UNIT_TEST(ServerWithCertVerification_ClientDoesNotProvideClientCerts) {
             .SetEndpoint(location);
 
         CheckAccessDenied(RegisterNode(config), "Access denied without user token");
-        CheckGood(RegisterNode(config.SetAuthToken(BUILTIN_ACL_ROOT)));
+        CheckGood(RegisterNode(config.SetAuthToken(BUILTIN_SID_ROOT)));
         CheckAccessDenied(RegisterNode(config.SetAuthToken("wrong_token")), "Could not find correct token validator");
     }
     {
@@ -844,7 +844,7 @@ Y_UNIT_TEST(ServerWithCertVerification_ClientDoesNotProvideClientCerts) {
             .SetEndpoint(location);
 
         CheckGood(RegisterNode(config));
-        CheckGood(RegisterNode(config.SetAuthToken(BUILTIN_ACL_ROOT)));
+        CheckGood(RegisterNode(config.SetAuthToken(BUILTIN_SID_ROOT)));
         CheckGood(RegisterNode(config.SetAuthToken("wrong_token")));
     }
 }
@@ -865,7 +865,7 @@ Y_UNIT_TEST(ServerWithoutCertVerification_ClientDoesNotProvideClientCerts) {
             .SetEndpoint(location);
 
         CheckAccessDenied(RegisterNode(config), "Access denied without user token");
-        CheckGood(RegisterNode(config.SetAuthToken(BUILTIN_ACL_ROOT)));
+        CheckGood(RegisterNode(config.SetAuthToken(BUILTIN_SID_ROOT)));
         CheckAccessDenied(RegisterNode(config.SetAuthToken("wrong_token")), "Could not find correct token validator");
     }
     {
@@ -882,7 +882,7 @@ Y_UNIT_TEST(ServerWithoutCertVerification_ClientDoesNotProvideClientCerts) {
             .SetEndpoint(location);
 
         CheckGood(RegisterNode(config));
-        CheckGood(RegisterNode(config.SetAuthToken(BUILTIN_ACL_ROOT)));
+        CheckGood(RegisterNode(config.SetAuthToken(BUILTIN_SID_ROOT)));
         CheckGood(RegisterNode(config.SetAuthToken("wrong_token")));
     }
 }
@@ -1007,7 +1007,7 @@ Y_UNIT_TEST(ServerWithCertVerification_ClientWithCorrectCerts_AccessDenied) {
         .EnforceUserToken = true,
         .EnableDynamicNodeAuth = true,
         .SetNodeAuthValues = true,
-        .RegisterNodeAllowedSids = {BUILTIN_ACL_ROOT}
+        .RegisterNodeAllowedSids = {BUILTIN_SID_ROOT}
     });
     ui16 grpc = server.GetPort();
     TString location = TStringBuilder() << "localhost:" << grpc;

--- a/ydb/tests/tools/fqrun/src/common.cpp
+++ b/ydb/tests/tools/fqrun/src/common.cpp
@@ -22,7 +22,7 @@ TExternalDatabase TExternalDatabase::Parse(const TString& optionValue, const TSt
     if (!result.Token) {
         result.Token = GetEnv(YQL_TOKEN_VARIABLE);
         if (!result.Token) {
-            result.Token = BUILTIN_ACL_ROOT;
+            result.Token = BUILTIN_SID_ROOT;
         }
     }
 

--- a/ydb/tests/tools/fqrun/src/fq_setup.cpp
+++ b/ydb/tests/tools/fqrun/src/fq_setup.cpp
@@ -60,8 +60,8 @@ private:
     NFq::NConfig::TConfig GetFqProxyConfig(ui32 grpcPort) const {
         auto fqConfig = Settings.AppConfig.GetFederatedQueryConfig();
 
-        fqConfig.MutableControlPlaneStorage()->AddSuperUsers(BUILTIN_ACL_ROOT);
-        fqConfig.MutablePrivateProxy()->AddGrantedUsers(BUILTIN_ACL_ROOT);
+        fqConfig.MutableControlPlaneStorage()->AddSuperUsers(BUILTIN_SID_ROOT);
+        fqConfig.MutablePrivateProxy()->AddGrantedUsers(BUILTIN_SID_ROOT);
 
         const TString endpoint = TStringBuilder() << "localhost:" << grpcPort;
         const TString database = NKikimr::CanonizePath(Settings.DomainName);
@@ -297,7 +297,7 @@ private:
 
     template <typename TRequest, typename TProto>
     std::unique_ptr<TRequest> GetControlPlaneRequest(const TProto& request, const TFqOptions& options) const {
-        return std::make_unique<TRequest>(TStringBuilder() << "yandexcloud://" << options.Scope, request, BUILTIN_ACL_ROOT, Settings.YqlToken ? Settings.YqlToken : "fqrun", TVector<TString>{});
+        return std::make_unique<TRequest>(TStringBuilder() << "yandexcloud://" << options.Scope, request, BUILTIN_SID_ROOT, Settings.YqlToken ? Settings.YqlToken : "fqrun", TVector<TString>{});
     }
 
     template <typename TRequest, typename TResponse, typename TProto>

--- a/ydb/tests/tools/kqprun/kqprun.cpp
+++ b/ydb/tests/tools/kqprun/kqprun.cpp
@@ -93,7 +93,7 @@ struct TExecutionOptions {
             .Action = NKikimrKqp::EQueryAction::QUERY_ACTION_EXECUTE,
             .TraceId = DefaultTraceId,
             .PoolId = "",
-            .UserSID = BUILTIN_ACL_ROOT,
+            .UserSID = BUILTIN_SID_ROOT,
             .Database = GetValue(0, Databases, TString()),
             .Timeout = TDuration::Zero()
         };
@@ -113,7 +113,7 @@ struct TExecutionOptions {
             .Action = GetScriptQueryAction(index),
             .TraceId = TStringBuilder() << GetValue(index, TraceIds, DefaultTraceId) << "-" << startTime.ToString(),
             .PoolId = GetValue(index, PoolIds, TString()),
-            .UserSID = GetValue(index, UserSIDs, TString(BUILTIN_ACL_ROOT)),
+            .UserSID = GetValue(index, UserSIDs, TString(BUILTIN_SID_ROOT)),
             .Database = GetValue(index, Databases, TString()),
             .Timeout = GetValue(index, Timeouts, TDuration::Zero()),
             .QueryId = queryId,

--- a/ydb/tests/tools/kqprun/src/actors.cpp
+++ b/ydb/tests/tools/kqprun/src/actors.cpp
@@ -43,7 +43,7 @@ public:
         hFunc(NKikimr::NKqp::TEvKqp::TEvQueryResponse, Handle);
         hFunc(NKikimr::NKqp::TEvKqpExecuter::TEvExecuterProgress, Handle);
     )
-    
+
     void Handle(NKikimr::NKqp::TEvKqpExecuter::TEvStreamData::TPtr& ev) {
         auto response = MakeHolder<NKikimr::NKqp::TEvKqpExecuter::TEvStreamDataAck>(ev->Get()->Record.GetSeqNo(), ev->Get()->Record.GetChannelId());
         response->Record.SetFreeSpace(ResultSizeLimit_);
@@ -133,7 +133,7 @@ public:
     TResourcesWaiterActor(NThreading::TPromise<void> promise, const TWaitResourcesSettings& settings)
         : Settings_(settings)
         , RetryPolicy_(IRetryPolicy::GetExponentialBackoffPolicy(
-            &TResourcesWaiterActor::Retryable, REFRESH_PERIOD, 
+            &TResourcesWaiterActor::Retryable, REFRESH_PERIOD,
             TDuration::MilliSeconds(100), TDuration::Seconds(1),
             std::numeric_limits<size_t>::max(), std::max(2 * REFRESH_PERIOD, Settings_.HealthCheckTimeout)
         ))
@@ -234,7 +234,7 @@ private:
 
     void StartScriptQuery() {
         auto event = MakeHolder<NKikimr::NKqp::TEvKqp::TEvScriptRequest>();
-        event->Record.SetUserToken(NACLib::TUserToken("", BUILTIN_ACL_ROOT, {}).SerializeAsString());
+        event->Record.SetUserToken(NACLib::TUserToken("", BUILTIN_SID_ROOT, {}).SerializeAsString());
 
         auto request = event->Record.MutableRequest();
         request->SetQuery("SELECT 42");
@@ -385,7 +385,7 @@ public:
 
 private:
     void FailAndPassAway(const TString& error) {
-        if (!OpenPromise_.HasValue()) {  
+        if (!OpenPromise_.HasValue()) {
             OpenPromise_.SetException(error);
         }
         ClosePromise_.SetException(error);


### PR DESCRIPTION
Standardize naming patterns for auth-domains and well-known SIDs.

Currently, names like `BUILTIN_ACL_DOMAIN` and `BUILTIN_DOMAIN_SYSTEM` are confusing as it's not immediately clear that both refer to auth-domains: elements of the same category.