### PR TITLE
ci: use stable diplodoc cli for docs upload

### DIFF
--- a/.github/workflows/docs_preview.yaml
+++ b/.github/workflows/docs_preview.yaml
@@ -25,6 +25,7 @@ jobs:
           storage-bucket: ${{ vars.DIPLODOC_STORAGE_BUCKET }}
           storage-access-key-id: ${{ secrets.DOCS_AWS_KEY_ID }}
           storage-secret-access-key: ${{ secrets.DOCS_AWS_SECRET_ACCESS_KEY }}
+          cli-version: stable
 
       - name: Comment message
         uses: diplodoc-platform/docs-message-action@v1


### PR DESCRIPTION
### Description for reviewers

Docs preview upload now uses the stable diplodoc cli version.