### PR TITLE
Check iter index access slice bounds in Reverse

### DIFF
--- a/ydb/core/tablet_flat/flat_part_iter.h
+++ b/ydb/core/tablet_flat/flat_part_iter.h
@@ -268,6 +268,12 @@ namespace NTable {
                 // The row we seek is on the prev page
 
                 RowId = Index.GetRowId() - 1;
+
+                if (RowId < BeginRowId) {
+                    // Row is outside of bounds
+                    return Exhausted();
+                }
+                
                 if (auto ready = Index.Prev(); ready != EReady::Data) {
                     return Terminate(ready);
                 }


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

...

### Changelog category <!-- remove all except one -->

* Not for changelog (changelog entry is not required)

### Description for reviewers <!-- (optional) description for those who read this PR -->

The same as in https://github.com/ydb-platform/ydb/issues/18151 but for reverse

Doesn't effect scans, but worth fixing