### PR TITLE
fixed CDC write to the autopartitioning topic

### DIFF
--- a/ydb/core/tx/datashard/change_exchange_split.cpp
+++ b/ydb/core/tx/datashard/change_exchange_split.cpp
@@ -360,19 +360,21 @@ class TCdcWorker
             const auto partitionId = partition.GetPartitionId();
             const auto tabletId = partition.GetTabletId();
 
-            auto it = Workers.find(partitionId);
-            if (NKikimrPQ::ETopicPartitionStatus::Active == partition.GetStatus()) {
-                if (it != Workers.end()) {
-                    workers.emplace(partitionId, it->second);
-                    Workers.erase(it);
-                } else {
-                    LOG_T("Register new worker"
-                        << ": partitionId# " << partitionId);
+            if (NKikimrPQ::ETopicPartitionStatus::Active != partition.GetStatus()) {
+                continue;
+            }
 
-                    const auto worker = Register(new TCdcPartitionWorker(SelfId(), partitionId, tabletId, SrcTabletId, DstTabletIds));
-                    workers.emplace(partitionId, worker);
-                    Pending.emplace(worker, partitionId);
-                }
+            auto it = Workers.find(partitionId);
+            if (it != Workers.end()) {
+                workers.emplace(partitionId, it->second);
+                Workers.erase(it);
+            } else {
+                LOG_T("Register new worker"
+                    << ": partitionId# " << partitionId);
+
+                const auto worker = Register(new TCdcPartitionWorker(SelfId(), partitionId, tabletId, SrcTabletId, DstTabletIds));
+                workers.emplace(partitionId, worker);
+                Pending.emplace(worker, partitionId);
             }
         }
 

--- a/ydb/core/tx/datashard/change_exchange_split.cpp
+++ b/ydb/core/tx/datashard/change_exchange_split.cpp
@@ -361,16 +361,18 @@ class TCdcWorker
             const auto tabletId = partition.GetTabletId();
 
             auto it = Workers.find(partitionId);
-            if (it != Workers.end()) {
-                workers.emplace(partitionId, it->second);
-                Workers.erase(it);
-            } else {
-                LOG_T("Register new worker"
-                    << ": partitionId# " << partitionId);
+            if (NKikimrPQ::ETopicPartitionStatus::Active == partition.GetStatus()) {
+                if (it != Workers.end()) {
+                    workers.emplace(partitionId, it->second);
+                    Workers.erase(it);
+                } else {
+                    LOG_T("Register new worker"
+                        << ": partitionId# " << partitionId);
 
-                const auto worker = Register(new TCdcPartitionWorker(SelfId(), partitionId, tabletId, SrcTabletId, DstTabletIds));
-                workers.emplace(partitionId, worker);
-                Pending.emplace(worker, partitionId);
+                    const auto worker = Register(new TCdcPartitionWorker(SelfId(), partitionId, tabletId, SrcTabletId, DstTabletIds));
+                    workers.emplace(partitionId, worker);
+                    Pending.emplace(worker, partitionId);
+                }
             }
         }
 


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

If the CDC stream was recorded in an auto-partitioned topic, then it could stop after several splits of the topic. In this case, modification of rows in the table would result in the error that the table is overloaded.

### Changelog category <!-- remove all except one -->

* Bugfix 

### Description for reviewers <!-- (optional) description for those who read this PR -->

LBREQUESTS-4468
