### PR TITLE
Check state storage for each piles in bridge mode

### DIFF
--- a/ydb/core/cms/cluster_info.cpp
+++ b/ydb/core/cms/cluster_info.cpp
@@ -916,14 +916,10 @@ void TClusterInfo::MigrateOldInfo(TClusterInfoPtr old)
 void TClusterInfo::ApplyStateStorageInfo(TIntrusiveConstPtr<TStateStorageInfo> info) {
     StateStorageInfoReceived = true;
     Y_ABORT_UNLESS(info->RingGroups.size() > 0);
-    const ui64 rGroupSize = IsBridgeMode ? 1 : info->RingGroups.size();
+    const ui64 rGroupSize = IsBridgeMode ? info->RingGroups.size() : 1;
     StateStorageRings.resize(rGroupSize);
 
     for (ui64 rGroupId = 0; rGroupId < rGroupSize; ++rGroupId) {
-        // if not in bridge mode, then we don't need to add rings from extra groups
-        if (!IsBridgeMode && rGroupId > 0) {
-            break;
-        }
         auto& groupInfo = info->RingGroups[rGroupId];
         for (ui32 ringId = 0; ringId < groupInfo.Rings.size(); ++ringId) {
             auto &ring = groupInfo.Rings[ringId];

--- a/ydb/core/cms/cluster_info.cpp
+++ b/ydb/core/cms/cluster_info.cpp
@@ -916,22 +916,31 @@ void TClusterInfo::MigrateOldInfo(TClusterInfoPtr old)
 void TClusterInfo::ApplyStateStorageInfo(TIntrusiveConstPtr<TStateStorageInfo> info) {
     StateStorageInfoReceived = true;
     Y_ABORT_UNLESS(info->RingGroups.size() > 0);
-    auto& groupInfo = info->RingGroups[0];
-    for (ui32 ringId = 0; ringId < groupInfo.Rings.size(); ++ringId) {
-        auto &ring = groupInfo.Rings[ringId];
-        TStateStorageRingInfoPtr ringInfo = MakeIntrusive<TStateStorageRingInfo>();
-        ringInfo->RingId = ringId;
-        if (ring.IsDisabled)
-            ringInfo->SetDisabled();
+    const ui64 rGroupSize = IsBridgeMode ? 1 : info->RingGroups.size();
+    StateStorageRings.resize(rGroupSize);
 
-        for(auto replica : ring.Replicas) {
-            CheckNodeExistenceWithVerify(replica.NodeId());
-            ringInfo->AddNode(Nodes[replica.NodeId()]);
-            StateStorageReplicas.insert(replica.NodeId());
-            StateStorageNodeToRingId[replica.NodeId()] = ringId;
+    for (ui64 rGroupId = 0; rGroupId < rGroupSize; ++rGroupId) {
+        // if not in bridge mode, then we don't need to add rings from extra groups
+        if (!IsBridgeMode && rGroupId > 0) {
+            break;
         }
+        auto& groupInfo = info->RingGroups[rGroupId];
+        for (ui32 ringId = 0; ringId < groupInfo.Rings.size(); ++ringId) {
+            auto &ring = groupInfo.Rings[ringId];
+            TStateStorageRingInfoPtr ringInfo = MakeIntrusive<TStateStorageRingInfo>();
+            ringInfo->RingId = ringId;
+            if (ring.IsDisabled)
+                ringInfo->SetDisabled();
 
-        StateStorageRings.push_back(ringInfo);
+            for(auto replica : ring.Replicas) {
+                CheckNodeExistenceWithVerify(replica.NodeId());
+                ringInfo->AddNode(Nodes[replica.NodeId()]);
+                StateStorageReplicas.insert(replica.NodeId());
+                StateStorageNodeToRingId[replica.NodeId()] = ringId;
+            }
+
+            StateStorageRings[rGroupId].push_back(ringInfo);
+        }
     }
 }
 

--- a/ydb/core/cms/cluster_info.h
+++ b/ydb/core/cms/cluster_info.h
@@ -1043,10 +1043,11 @@ public:
     THashMap<NKikimrConfig::TBootstrap::ETabletType, TSimpleSharedPtr<TSysTabletsNodesCounter>> SysNodesCheckers;
 
     TIntrusiveConstPtr<TStateStorageInfo> StateStorageInfo;
-    TVector<TStateStorageRingInfoPtr> StateStorageRings;
+    TVector<TVector<TStateStorageRingInfoPtr>> StateStorageRings;
 
     std::vector<NKikimr::TBridgeInfo::TPile> Piles;
     THashMap<ui32, ui32> NodeIdToPileId;
+    bool IsBridgeMode = false;
 };
 
 inline bool ActionRequiresHost(NKikimrCms::TAction::EType type) {

--- a/ydb/core/cms/cms.cpp
+++ b/ydb/core/cms/cms.cpp
@@ -715,8 +715,7 @@ bool TCms::TryToLockStateStorageReplica(const TAction& action,
     }
 
     Y_ABORT_UNLESS(ClusterInfo->StateStorageInfo->RingGroups.size() > 0);
-    // If the cluster is not in Bridge Mode, then pileId = 0
-    const ui32 pileId = node.PileId;
+    const ui32 pileId = ClusterInfo->IsBridgeMode ? node.PileId : 0;
     const ui32 nToSelect = ClusterInfo->StateStorageInfo->RingGroups[pileId].NToSelect;
     const ui32 currentRing = ClusterInfo->GetRingId(node.NodeId);
     ui8 currentRingState = TStateStorageRingInfo::Unknown;
@@ -725,7 +724,7 @@ bool TCms::TryToLockStateStorageReplica(const TAction& action,
     ui32 disabledRings = 0;
     auto now = AppData(ctx)->TimeProvider->Now();
     TDuration duration = TDuration::MicroSeconds(action.GetDuration()) + opts.PermissionDuration;
-    for (auto ringInfo : ClusterInfo->StateStorageRings[node.PileId]) {
+    for (auto ringInfo : ClusterInfo->StateStorageRings[pileId]) {
         auto state = ringInfo->CountState(now, State->Config.DefaultRetryTime, duration);
         LOG_DEBUG_S(*TlsActivationContext, NKikimrServices::CMS, "Ring: " << ringInfo->RingId
                                                                  << "; State: " << TStateStorageRingInfo::RingStateToString(state));

--- a/ydb/core/cms/cms.cpp
+++ b/ydb/core/cms/cms.cpp
@@ -716,7 +716,7 @@ bool TCms::TryToLockStateStorageReplica(const TAction& action,
 
     Y_ABORT_UNLESS(ClusterInfo->StateStorageInfo->RingGroups.size() > 0);
     // If the cluster is not in Bridge Mode, then pileId = 0
-    const ui32 pileId = ClusterInfo->NodeIdToPileId[node.NodeId];
+    const ui32 pileId = node.PileId;
     const ui32 nToSelect = ClusterInfo->StateStorageInfo->RingGroups[pileId].NToSelect;
     const ui32 currentRing = ClusterInfo->GetRingId(node.NodeId);
     ui8 currentRingState = TStateStorageRingInfo::Unknown;
@@ -725,13 +725,7 @@ bool TCms::TryToLockStateStorageReplica(const TAction& action,
     ui32 disabledRings = 0;
     auto now = AppData(ctx)->TimeProvider->Now();
     TDuration duration = TDuration::MicroSeconds(action.GetDuration()) + opts.PermissionDuration;
-    for (auto ringInfo : ClusterInfo->StateStorageRings) {
-        Y_ABORT_UNLESS(ringInfo->Replicas.size() > 0);
-        // If the cluster is not in Bridge Mode, then it is always false
-        if (ClusterInfo->NodeIdToPileId[ringInfo->Replicas[0]->NodeId] != pileId) {
-            continue;
-        } 
-
+    for (auto ringInfo : ClusterInfo->StateStorageRings[node.PileId]) {
         auto state = ringInfo->CountState(now, State->Config.DefaultRetryTime, duration);
         LOG_DEBUG_S(*TlsActivationContext, NKikimrServices::CMS, "Ring: " << ringInfo->RingId
                                                                  << "; State: " << TStateStorageRingInfo::RingStateToString(state));

--- a/ydb/core/cms/cms.cpp
+++ b/ydb/core/cms/cms.cpp
@@ -715,8 +715,8 @@ bool TCms::TryToLockStateStorageReplica(const TAction& action,
     }
 
     Y_ABORT_UNLESS(ClusterInfo->StateStorageInfo->RingGroups.size() > 0);
-    const ui32 pileId = ClusterInfo->IsBridgeMode ? node.PileId : 0;
-    const ui32 nToSelect = ClusterInfo->StateStorageInfo->RingGroups[pileId].NToSelect;
+    const ui32 ringGroupId = ClusterInfo->IsBridgeMode ? node.PileId : 0;
+    const ui32 nToSelect = ClusterInfo->StateStorageInfo->RingGroups[ringGroupId].NToSelect;
     const ui32 currentRing = ClusterInfo->GetRingId(node.NodeId);
     ui8 currentRingState = TStateStorageRingInfo::Unknown;
     ui32 restartRings = 0;
@@ -724,7 +724,7 @@ bool TCms::TryToLockStateStorageReplica(const TAction& action,
     ui32 disabledRings = 0;
     auto now = AppData(ctx)->TimeProvider->Now();
     TDuration duration = TDuration::MicroSeconds(action.GetDuration()) + opts.PermissionDuration;
-    for (auto ringInfo : ClusterInfo->StateStorageRings[pileId]) {
+    for (auto ringInfo : ClusterInfo->StateStorageRings[ringGroupId]) {
         auto state = ringInfo->CountState(now, State->Config.DefaultRetryTime, duration);
         LOG_DEBUG_S(*TlsActivationContext, NKikimrServices::CMS, "Ring: " << ringInfo->RingId
                                                                  << "; State: " << TStateStorageRingInfo::RingStateToString(state));

--- a/ydb/core/cms/info_collector.cpp
+++ b/ydb/core/cms/info_collector.cpp
@@ -227,7 +227,7 @@ void TInfoCollector::Handle(TEvInterconnect::TEvNodesInfo::TPtr& ev) {
     RequestBridgeInfo();
 
     const auto& pileMap = ev->Get()->PileMap;
-    Info->IsBridgeMode = !!pileMap;
+    Info->IsBridgeMode = static_cast<bool>(pileMap);
     Info->NodeIdToPileId = FlipPileMap(pileMap);
     for (const auto& node : ev->Get()->Nodes) {
         Info->AddNode(node, &TlsActivationContext->AsActorContext());

--- a/ydb/core/cms/info_collector.cpp
+++ b/ydb/core/cms/info_collector.cpp
@@ -227,6 +227,7 @@ void TInfoCollector::Handle(TEvInterconnect::TEvNodesInfo::TPtr& ev) {
     RequestBridgeInfo();
 
     const auto& pileMap = ev->Get()->PileMap;
+    Info->IsBridgeMode = !!pileMap;
     Info->NodeIdToPileId = FlipPileMap(pileMap);
     for (const auto& node : ev->Get()->Nodes) {
         Info->AddNode(node, &TlsActivationContext->AsActorContext());


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

...

### Changelog category <!-- remove all except one -->

* Not for changelog (changelog entry is not required)

### Description for reviewers <!-- (optional) description for those who read this PR -->

`StateStorageRings` теперь двумерный вектор - по индексу `i` хранятся rings из `i`-ой ring groups. В проверках доступности state storage участвуют только rings из одной ring group (pile). Изменения обратно совместимы с версией до изменений