### PR TITLE
Properly handle index build result in KQP scheme query

### DIFF
--- a/ydb/core/kqp/executer_actor/kqp_scheme_executer.cpp
+++ b/ydb/core/kqp/executer_actor/kqp_scheme_executer.cpp
@@ -776,7 +776,25 @@ public:
     void Handle(NSchemeShard::TEvIndexBuilder::TEvGetResponse::TPtr& ev) {
         auto& record = ev->Get()->Record;
         LOG_D("Handle TEvIndexBuilder::TEvGetResponse: record# " << record.ShortDebugString());
-        return ReplyErrorAndDie(record.GetStatus(), record.MutableIssues());
+        if (record.GetStatus() != Ydb::StatusIds::SUCCESS) {
+            // Internal error: we made incorrect request to get status of index build operation
+            NYql::TIssues responseIssues;
+            NYql::IssuesFromMessage(record.GetIssues(), responseIssues);
+
+            NYql::TIssue issue(TStringBuilder() << "Failed to get index build status. Status: " << record.GetStatus());
+            for (const NYql::TIssue& i : responseIssues) {
+                issue.AddSubIssue(MakeIntrusive<NYql::TIssue>(i));
+            }
+
+            NYql::TIssues issues;
+            issues.AddIssue(std::move(issue));
+            return InternalError(issues);
+        }
+
+        NKikimrIndexBuilder::TIndexBuild& indexBuildResult = *record.MutableIndexBuild();
+        const Ydb::Table::IndexBuildState::State state = indexBuildResult.GetState();
+        const Ydb::StatusIds::StatusCode buildStatus = state == Ydb::Table::IndexBuildState::STATE_DONE ? Ydb::StatusIds::SUCCESS : Ydb::StatusIds::PRECONDITION_FAILED;
+        return ReplyErrorAndDie(buildStatus, indexBuildResult.MutableIssues());
     }
 
     template<typename TEv>


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

...

### Changelog category <!-- remove all except one -->

* Not for changelog (changelog entry is not required)

### Description for reviewers <!-- (optional) description for those who read this PR -->

Scheme queries returned success even if index had not been built. I fixed this issue. The corresponding tests can be made (and are already made) in the next PR https://github.com/ydb-platform/ydb/pull/20133 for unsuccessful unique index build.