### PR TITLE
Add pile guard for SelfHeal (Sentinel)

### DIFF
--- a/ydb/core/cms/api_adapters.cpp
+++ b/ydb/core/cms/api_adapters.cpp
@@ -235,7 +235,9 @@ class TListClusterNodes: public TAdapterActor<
             out.mutable_storage();
         }
 
-        out.set_pile_id(in.PileId);
+        if (in.PileId.Defined()) {
+            out.set_pile_id(*in.PileId);
+        }
     }
 
 public:

--- a/ydb/core/cms/cluster_info.cpp
+++ b/ydb/core/cms/cluster_info.cpp
@@ -361,7 +361,9 @@ void TClusterInfo::AddNode(const TEvInterconnect::TNodeInfo &info, const TActorC
     node->IcPort = info.Port;
     node->Location = info.Location;
     node->State = NKikimrCms::UNKNOWN;
-    node->PileId = NodeIdToPileId[info.NodeId];
+    if (auto it = NodeIdToPileId.find(info.NodeId); it != NodeIdToPileId.end()) {
+        node->PileId = it->second;
+    }
 
     if (ctx) {
         const auto maxStaticNodeId = AppData(*ctx)->DynamicNameserviceConfig->MaxStaticNodeId;

--- a/ydb/core/cms/cluster_info.h
+++ b/ydb/core/cms/cluster_info.h
@@ -345,7 +345,7 @@ public:
     TString PreviousTenant;
     TServices Services;
     TInstant StartTime;
-    ui32 PileId;
+    TMaybeFail<ui32> PileId;
 
     TVector<TSimpleSharedPtr<INodesChecker>> NodeGroups;
 };

--- a/ydb/core/cms/cms.cpp
+++ b/ydb/core/cms/cms.cpp
@@ -715,7 +715,7 @@ bool TCms::TryToLockStateStorageReplica(const TAction& action,
     }
 
     Y_ABORT_UNLESS(ClusterInfo->StateStorageInfo->RingGroups.size() > 0);
-    const ui32 ringGroupId = ClusterInfo->IsBridgeMode ? node.PileId : 0;
+    const ui32 ringGroupId = ClusterInfo->IsBridgeMode ? *node.PileId : 0;
     const ui32 nToSelect = ClusterInfo->StateStorageInfo->RingGroups[ringGroupId].NToSelect;
     const ui32 currentRing = ClusterInfo->GetRingId(node.NodeId);
     ui8 currentRingState = TStateStorageRingInfo::Unknown;

--- a/ydb/core/cms/cms.cpp
+++ b/ydb/core/cms/cms.cpp
@@ -1228,7 +1228,9 @@ void TCms::AddHostState(const TClusterInfoPtr &clusterInfo, const TNodeInfo &nod
     host->SetInterconnectPort(node.IcPort);
     host->SetTimestamp(timestamp.GetValue());
     host->SetStartTimeSeconds(node.StartTime.Seconds());
-    host->SetPileId(node.PileId);
+    if (node.PileId.Defined()) {
+        host->SetPileId(*node.PileId);
+    }
     node.Location.Serialize(host->MutableLocation(), false);
     for (auto marker : node.Markers) {
         host->AddMarkers(marker);

--- a/ydb/core/cms/cms.cpp
+++ b/ydb/core/cms/cms.cpp
@@ -714,8 +714,15 @@ bool TCms::TryToLockStateStorageReplica(const TAction& action,
         return true;
     }
 
-    Y_ABORT_UNLESS(ClusterInfo->StateStorageInfo->RingGroups.size() > 0);
-    const ui32 ringGroupId = ClusterInfo->IsBridgeMode ? *node.PileId : 0;
+    if (ClusterInfo->IsBridgeMode && node.PileId.Empty()) {
+        error.Code = TStatus::ERROR;
+        error.Reason = "Node doesn't belong to any pile in bridge mode";
+        error.Deadline = defaultDeadline;
+        return false;
+    }
+
+    const ui32 ringGroupId = node.PileId.GetOrElse(0);
+    Y_ABORT_UNLESS(ringGroupId < ClusterInfo->StateStorageInfo->RingGroups.size());
     const ui32 nToSelect = ClusterInfo->StateStorageInfo->RingGroups[ringGroupId].NToSelect;
     const ui32 currentRing = ClusterInfo->GetRingId(node.NodeId);
     ui8 currentRingState = TStateStorageRingInfo::Unknown;

--- a/ydb/core/cms/config.h
+++ b/ydb/core/cms/config.h
@@ -32,6 +32,7 @@ struct TCmsSentinelConfig {
     ui32 DataCenterRatio;
     ui32 RoomRatio;
     ui32 RackRatio;
+    ui32 PileRatio;
     ui32 FaultyPDisksThresholdPerNode;
 
     TMaybeFail<EPDiskStatus> EvictVDisksStatus;
@@ -50,6 +51,7 @@ struct TCmsSentinelConfig {
         config.SetDataCenterRatio(DataCenterRatio);
         config.SetRoomRatio(RoomRatio);
         config.SetRackRatio(RackRatio);
+        config.SetPileRatio(PileRatio);
         config.SetFaultyPDisksThresholdPerNode(FaultyPDisksThresholdPerNode);
 
         SaveStateLimits(config);
@@ -70,6 +72,7 @@ struct TCmsSentinelConfig {
         DataCenterRatio = config.GetDataCenterRatio();
         RoomRatio = config.GetRoomRatio();
         RackRatio = config.GetRackRatio();
+        PileRatio = config.GetPileRatio();
         FaultyPDisksThresholdPerNode = config.GetFaultyPDisksThresholdPerNode();
 
         auto newStateLimits = LoadStateLimits(config);

--- a/ydb/core/cms/sentinel_impl.h
+++ b/ydb/core/cms/sentinel_impl.h
@@ -111,6 +111,7 @@ private:
 struct TNodeInfo {
     TString Host;
     NActors::TNodeLocation Location;
+    TMaybeFail<ui32> PileId;
     THashSet<NKikimrCms::EMarker> Markers;
 
     bool HasFaultyMarker() const;
@@ -153,6 +154,7 @@ public:
     TDistribution ByDataCenter;
     TDistribution ByRoom;
     TDistribution ByRack;
+    TDistribution ByPile;
     THashMap<TString, TNodeIDSet> NodeByRack;
     TDistribution BadByNode;
 
@@ -172,7 +174,8 @@ class TGuardian : public TClusterMap {
     }
 
 public:
-    explicit TGuardian(TSentinelState::TPtr state, ui32 dataCenterRatio = 100, ui32 roomRatio = 100, ui32 rackRatio = 100, ui32 faultyPDisksThresholdPerNode = 0);
+    explicit TGuardian(TSentinelState::TPtr state, ui32 dataCenterRatio = 100, ui32 roomRatio = 100,
+                       ui32 rackRatio = 100, ui32 pileRatio = 100, ui32 faultyPDisksThresholdPerNode = 0);
 
     TPDiskIDSet GetAllowedPDisks(const TClusterMap& all, TString& issues, TPDiskIgnoredMap& disallowed) const;
 
@@ -180,6 +183,7 @@ private:
     const ui32 DataCenterRatio;
     const ui32 RoomRatio;
     const ui32 RackRatio;
+    const ui32 PileRatio;
     const ui32 FaultyPDisksThresholdPerNode;
 
 }; // TGuardian

--- a/ydb/core/cms/sentinel_ut.cpp
+++ b/ydb/core/cms/sentinel_ut.cpp
@@ -289,7 +289,7 @@ Y_UNIT_TEST_SUITE(TSentinelBaseTests) {
                     location.SetUnit(ToString(id));
 
                     state->ClusterInfo->AddNode(TEvInterconnect::TNodeInfo(id, name, name, name, 10000, TNodeLocation(location)), nullptr);
-                    sentinelState->Nodes[id] = NSentinel::TNodeInfo{name, NActors::TNodeLocation(location), {}};
+                    sentinelState->Nodes[id] = NSentinel::TNodeInfo{name, NActors::TNodeLocation(location), Nothing(), {}};
 
                     for (ui64 npdisk : xrange(pdisksPerNode)) {
                         NKikimrBlobStorage::TBaseConfig::TPDisk pdisk;
@@ -382,7 +382,7 @@ Y_UNIT_TEST_SUITE(TSentinelBaseTests) {
         auto [state, sentinelState] = MockCmsState(1, 8, 1, disksPerNode, true, false);
         TClusterMap all(sentinelState);
 
-        TGuardian changed(sentinelState, 100, 100, 100, maxFaultyDisksPerNode);
+        TGuardian changed(sentinelState, 100, 100, 100, 100, maxFaultyDisksPerNode);
 
         const auto& nodes = state->ClusterInfo->AllNodes();
 
@@ -591,6 +591,91 @@ Y_UNIT_TEST_SUITE(TSentinelTests) {
             // after pdisk becomes Normal
             env.SetPDiskState(pdisks, NKikimrBlobStorage::TPDiskState::Normal, EPDiskStatus::ACTIVE);
         }
+    }
+
+    Y_UNIT_TEST(PDiskPileGuardHalfPile) {
+        TTestEnv env(8, 4);
+        env.MockBridgeModePiles(2);
+
+        auto pdisks = env.PDisksForRandomPile();
+
+        // erase exactly half of pile
+        std::erase_if(pdisks, [&](TPDiskID id){ return id.NodeId - env.GetFirstNodeId() <= 4; });
+
+        // disks should become INACTIVE immediately after disk is broken
+        env.SetPDiskState(pdisks, ErrorStates[0], EPDiskStatus::INACTIVE);
+        for (ui32 i = 1; i < DefaultErrorStateLimit - 1; ++i) {
+            env.SetPDiskState(pdisks, ErrorStates[0]);
+        }
+        // for half of pile pdisks are expected to become FAULTY
+        env.SetPDiskState(pdisks, ErrorStates[0], EPDiskStatus::FAULTY);
+
+        env.SetPDiskState(pdisks, NKikimrBlobStorage::TPDiskState::Normal, EPDiskStatus::INACTIVE);
+        for (ui32 i = 1; i < DefaultStateLimit - 1; ++i) {
+            env.SetPDiskState(pdisks, NKikimrBlobStorage::TPDiskState::Normal);
+        }
+        env.SetPDiskState(pdisks, NKikimrBlobStorage::TPDiskState::Normal, EPDiskStatus::ACTIVE);
+    }
+
+    Y_UNIT_TEST(PDiskPileGuardFullPile) {
+        TTestEnv env(8, 4);
+        env.MockBridgeModePiles(2);
+
+        auto pdisks = env.PDisksForRandomPile();
+
+        // disks should become INACTIVE immediately after disk is broken
+        env.SetPDiskState(pdisks, ErrorStates[0], EPDiskStatus::INACTIVE);
+        for (ui32 i = 1; i < DefaultErrorStateLimit; ++i) {
+            env.SetPDiskState(pdisks, ErrorStates[0]);
+        }
+
+        // for full pile pdisks are not expected to become FAULTY, so they become ACTIVE immediatetly
+        // after pdisk becomes Normal
+        env.SetPDiskState(pdisks, NKikimrBlobStorage::TPDiskState::Normal, EPDiskStatus::ACTIVE);
+    }
+
+    Y_UNIT_TEST(PDiskPileGuardConfig) {
+        NKikimrCms::TCmsConfig config;
+        config.MutableSentinelConfig()->SetPileRatio(30);
+        TTestEnv env(8, 4, config);
+        env.MockBridgeModePiles(2);
+
+        auto pdisks = env.PDisksForRandomPile();
+
+        // erase exactly half of pile
+        std::erase_if(pdisks, [&](TPDiskID id){ return id.NodeId - env.GetFirstNodeId() <= 4; });
+
+        // disks should become INACTIVE immediately after disk is broken
+        env.SetPDiskState(pdisks, ErrorStates[0], EPDiskStatus::INACTIVE);
+        for (ui32 i = 1; i < DefaultErrorStateLimit; ++i) {
+            env.SetPDiskState(pdisks, ErrorStates[0]);
+        }
+
+        // for half of pile pdisks are not expected to become FAULTY because of config,
+        // so they become ACTIVE immediatetly after pdisk becomes Normal
+        env.SetPDiskState(pdisks, NKikimrBlobStorage::TPDiskState::Normal, EPDiskStatus::ACTIVE);
+    }
+
+    Y_UNIT_TEST(PDiskPileGuardWithoutBridgeMode) {
+        NKikimrCms::TCmsConfig config;
+        config.MutableSentinelConfig()->SetPileRatio(1); // very low ratio
+        TTestEnv env(8, 4, config);
+
+        auto pdisks = env.PDisksForRandomNode();
+
+        // disks should become INACTIVE immediately after disk is broken
+        env.SetPDiskState(pdisks, ErrorStates[0], EPDiskStatus::INACTIVE);
+        for (ui32 i = 1; i < DefaultErrorStateLimit - 1; ++i) {
+            env.SetPDiskState(pdisks, ErrorStates[0]);
+        }
+        // Without bridge mode pdisks are expected to become FAULTY
+        env.SetPDiskState(pdisks, ErrorStates[0], EPDiskStatus::FAULTY);
+
+        env.SetPDiskState(pdisks, NKikimrBlobStorage::TPDiskState::Normal, EPDiskStatus::INACTIVE);
+        for (ui32 i = 1; i < DefaultStateLimit - 1; ++i) {
+            env.SetPDiskState(pdisks, NKikimrBlobStorage::TPDiskState::Normal);
+        }
+        env.SetPDiskState(pdisks, NKikimrBlobStorage::TPDiskState::Normal, EPDiskStatus::ACTIVE);
     }
 
     Y_UNIT_TEST(PDiskFaultyGuard) {

--- a/ydb/core/cms/sentinel_ut.cpp
+++ b/ydb/core/cms/sentinel_ut.cpp
@@ -629,7 +629,7 @@ Y_UNIT_TEST_SUITE(TSentinelTests) {
             env.SetPDiskState(pdisks, ErrorStates[0]);
         }
 
-        // for full pile pdisks are not expected to become FAULTY, so they become ACTIVE immediatetly
+        // for full pile pdisks are not expected to become FAULTY, so they become ACTIVE immediately
         // after pdisk becomes Normal
         env.SetPDiskState(pdisks, NKikimrBlobStorage::TPDiskState::Normal, EPDiskStatus::ACTIVE);
     }

--- a/ydb/core/protos/cms.proto
+++ b/ydb/core/protos/cms.proto
@@ -453,6 +453,7 @@ message TCmsConfig {
         optional uint32 DataCenterRatio = 10 [default = 50];
         optional uint32 RoomRatio = 11 [default = 70];
         optional uint32 RackRatio = 12 [default = 90];
+        optional uint32 PileRatio = 18 [default = 50];
         // Similar to *Ratio settings, but specified in absolute numbers and applied per storage node.
         // This limit helps prevent cascading overreaction when many disks go offline on a single host
         // (due to disk shelf disconnection).
@@ -656,6 +657,7 @@ message TPDiskInfo {
         RATIO_BY_ROOM = 4;
         RATIO_BY_RACK = 5;
         TOO_MANY_FAULTY_PER_NODE = 6;
+        RATIO_BY_PILE = 7;
     }
 
     optional uint32 State = 1; // EPDiskState


### PR DESCRIPTION
### Changelog category <!-- remove all except one -->

* Not for changelog (changelog entry is not required)

### Description for reviewers

This PR introduces a “pile” dimension to Sentinel by adding a `PileRatio` guard along with supporting unit tests.

- Extend protobuf and config structs with `PileRatio`
- Update `TClusterMap` and `TGuardian` to enforce per-pile ratio logic
- Change `PileId` type to `TMaybe` to prevent nodes getting into the first pile when bridge mode is not enabled
- Add test helpers and new unit tests covering pile-based guard scenarios
