### PR TITLE
Enable feature flags by default: EnableTopicAutopartitioningForCDC, E…

### DIFF
--- a/ydb/core/protos/feature_flags.proto
+++ b/ydb/core/protos/feature_flags.proto
@@ -170,10 +170,10 @@ message TFeatureFlags {
     optional bool EnableParameterizedDecimal = 145 [default = true];
     optional bool EnableImmediateWritingOnBulkUpsert = 146 [default = true, deprecated = true];
     optional bool EnableInsertWriteIdSpecialColumnCompatibility = 147 [default = false];
-    optional bool EnableTopicAutopartitioningForCDC = 148 [default = false];
+    optional bool EnableTopicAutopartitioningForCDC = 148 [default = true];
     optional bool EnableWritePortionsOnInsert = 149 [default = true, deprecated = true];
     optional bool EnableFollowerStats = 150 [default = true];
-    optional bool EnableTopicAutopartitioningForReplication = 151 [default = false];
+    optional bool EnableTopicAutopartitioningForReplication = 151 [default = true];
     optional bool EnableDriveSerialsDiscovery = 152 [default = false];
     optional bool EnableSeparateDiskSpaceQuotas = 153 [default = false];
     optional bool EnableAntlr4Parser = 154 [default = true];
@@ -185,7 +185,7 @@ message TFeatureFlags {
     optional bool EnableDataShardInMemoryStateMigrationAcrossGenerations = 160 [default = false];
     optional bool DisableLocalDBEraseCache = 161 [default = false];
     optional bool EnableChecksumsExport = 162 [default = false];
-    optional bool EnableTopicTransfer = 163 [default = false];
+    optional bool EnableTopicTransfer = 163 [default = true];
     optional bool EnableViewExport = 164 [default = false];
     optional bool EnableColumnStore = 165 [default = false];
     optional bool EnableStrictAclCheck = 166 [default = false];


### PR DESCRIPTION
…nableTopicAutopartitioningForReplication, EnableTopicTransfer

### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

Enable feature flags by default: EnableTopicAutopartitioningForCDC, EnableTopicAutopartitioningForReplication, EnableTopicTransfer

### Changelog category <!-- remove all except one -->

* New feature

### Description for reviewers <!-- (optional) description for those who read this PR -->

...
