### PR TITLE
Disabling shuffle elimintation by default in stable

### DIFF
--- a/ydb/core/protos/table_service_config.proto
+++ b/ydb/core/protos/table_service_config.proto
@@ -370,7 +370,7 @@ message TTableServiceConfig {
 
     optional bool AllowMultiBroadcasts = 79 [default = false];
 
-    optional bool DefaultEnableShuffleElimination = 80 [default = true];
+    optional bool DefaultEnableShuffleElimination = 80 [default = false];
 
     message TBatchOperationSettings {
         optional uint64 MaxBatchSize = 1 [ default = 10000 ];


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

Disabling shuffle elimintation by default in stable, was enabled by mistake
Its tunred on by default in main

### Changelog category <!-- remove all except one -->

* Not for changelog (changelog entry is not required)

### Description for reviewers <!-- (optional) description for those who read this PR -->

...
