### PR TITLE
25-1: CMS: ignore tenant and cluster unavailable nodes limits in force availability mode

### DIFF
--- a/ydb/core/cms/cms.cpp
+++ b/ydb/core/cms/cms.cpp
@@ -936,14 +936,6 @@ bool TCms::TryToLockVDisk(const TActionOptions& opts,
             }
             break;
         case MODE_FORCE_RESTART:
-            if (counters->GroupAlreadyHasLockedDisks() && !counters->GroupHasMoreThanOneDiskPerNode() && opts.PartialPermissionAllowed) {
-                TabletCounters->Cumulative()[COUNTER_PARTIAL_PERMISSIONS_OPTIMIZED].Increment(1);
-                error.Code = TStatus::DISALLOW_TEMP;
-                error.Reason = "You cannot get two or more disks from the same group at the same time"
-                               " in partial permissions allowed mode";
-                error.Deadline = defaultDeadline;
-                return false;
-            }
             // Any number of down disks is OK for this mode.
             break;
         default:

--- a/ydb/core/cms/cms_maintenance_api_ut.cpp
+++ b/ydb/core/cms/cms_maintenance_api_ut.cpp
@@ -116,6 +116,55 @@ Y_UNIT_TEST_SUITE(TMaintenanceApiTest) {
         const auto &a = response.action_group_states(0).action_states(0);
         UNIT_ASSERT_VALUES_EQUAL(a.status(), ActionState::ACTION_STATUS_PERFORMED);
     }
+
+    Y_UNIT_TEST(ForceAvailabilityMode) {
+        TCmsTestEnv env(8);
+
+        NKikimrCms::TCmsConfig config;
+        config.MutableClusterLimits()->SetDisabledNodesLimit(1);
+        config.MutableClusterLimits()->SetDisabledNodesRatioLimit(30);
+        config.MutableTenantLimits()->SetDisabledNodesLimit(1);
+        config.MutableTenantLimits()->SetDisabledNodesRatioLimit(30);
+        env.SetCmsConfig(config);
+
+        auto response = env.CheckMaintenanceTaskCreate(
+            "task-1",
+            Ydb::StatusIds::SUCCESS,
+            Ydb::Maintenance::AVAILABILITY_MODE_FORCE,
+            MakeActionGroup(
+                MakeLockAction(env.GetNodeId(0), TDuration::Minutes(10))
+            ),
+            MakeActionGroup(
+                MakeLockAction(env.GetNodeId(1), TDuration::Minutes(10))
+            ),
+            MakeActionGroup(
+                MakeLockAction(env.GetNodeId(2), TDuration::Minutes(10))
+            ),
+            MakeActionGroup(
+                MakeLockAction(env.GetNodeId(3), TDuration::Minutes(10))
+            ),
+            MakeActionGroup(
+                MakeLockAction(env.GetNodeId(4), TDuration::Minutes(10))
+            ),
+            MakeActionGroup(
+                MakeLockAction(env.GetNodeId(5), TDuration::Minutes(10))
+            ),
+            MakeActionGroup(
+                MakeLockAction(env.GetNodeId(6), TDuration::Minutes(10))
+            ),
+            MakeActionGroup(
+                MakeLockAction(env.GetNodeId(7), TDuration::Minutes(10))
+            )
+        );
+
+        // Everything is allowed to perform maintenance regardless of the failure model
+        UNIT_ASSERT_VALUES_EQUAL(response.action_group_states().size(), 8);
+        for (size_t i = 0; i < 8; ++i) {
+            UNIT_ASSERT_VALUES_EQUAL(response.action_group_states(i).action_states().size(), 1);
+            const auto& a = response.action_group_states(i).action_states(0);
+            UNIT_ASSERT_VALUES_EQUAL(a.status(), ActionState::ACTION_STATUS_PERFORMED);
+        }
+    }
 }
 
 } // namespace NKikimr::NCmsTest 

--- a/ydb/core/cms/node_checkers.cpp
+++ b/ydb/core/cms/node_checkers.cpp
@@ -91,8 +91,6 @@ bool TNodesLimitsCounterBase::TryToLockNode(ui32 nodeId, NKikimrCms::EAvailabili
     Y_ABORT_UNLESS(NodeToState.contains(nodeId));
     auto nodeState = NodeToState.at(nodeId);
 
-    bool isForceRestart = mode == NKikimrCms::MODE_FORCE_RESTART;
-
     NCH_LOG_D("Checking Node: "
             << nodeId << ", with state: " << nodeState
             << ", with limit: " << DisabledNodesLimit
@@ -114,12 +112,12 @@ bool TNodesLimitsCounterBase::TryToLockNode(ui32 nodeId, NKikimrCms::EAvailabili
             return true;
     }
 
-    // Always allow at least one node
-    if (LockedNodesCount + DownNodesCount == 0) {
+    if (mode == NKikimrCms::MODE_FORCE_RESTART) {
         return true;
     }
 
-    if (isForceRestart && !LockedNodesCount) {
+    // Always allow at least one node
+    if (LockedNodesCount + DownNodesCount == 0) {
         return true;
     }
 


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

Режим доступности Force теперь игнорирует лимиты недоступных узлов. Фиксит [#18604](https://github.com/ydb-platform/ydb/issues/18604).

### Changelog category <!-- remove all except one -->

* Bugfix 

### Description for reviewers <!-- (optional) description for those who read this PR -->

Cherry-picked from #20217
