### PR TITLE
Revert "[KQP] Add ShuffleEliminated flag"

### DIFF
--- a/ydb/core/kqp/compute_actor/kqp_compute_actor_factory.cpp
+++ b/ydb/core/kqp/compute_actor/kqp_compute_actor_factory.cpp
@@ -227,7 +227,7 @@ public:
 
         if (tableKind == ETableKind::Datashard || tableKind == ETableKind::Olap) {
             YQL_ENSURE(args.ComputesByStages);
-            auto& info = args.ComputesByStages->UpsertTaskWithScan(*args.Task, meta);
+            auto& info = args.ComputesByStages->UpsertTaskWithScan(*args.Task, meta, !AppData()->FeatureFlags.GetEnableSeparationComputeActorsFromRead());
             IActor* computeActor = CreateKqpScanComputeActor(
                 args.ExecuterId, args.TxId,
                 args.Task, AsyncIoFactory, runtimeSettings, memoryLimits,

--- a/ydb/core/kqp/compute_actor/kqp_compute_actor_factory.h
+++ b/ydb/core/kqp/compute_actor/kqp_compute_actor_factory.h
@@ -42,9 +42,9 @@ public:
         return true;
     }
 
-    TMetaScan& MergeMetaReads(const NYql::NDqProto::TDqTask& task, const NKikimrTxDataShard::TKqpTransaction::TScanTaskMeta& meta) {
+    TMetaScan& MergeMetaReads(const NYql::NDqProto::TDqTask& task, const NKikimrTxDataShard::TKqpTransaction::TScanTaskMeta& meta, const bool forceOneToMany) {
         YQL_ENSURE(meta.ReadsSize(), "unexpected merge with no reads");
-        if (!task.HasMetaId()) {
+        if (forceOneToMany || !task.HasMetaId()) {
             MetaInfo.emplace_back(TMetaScan(meta));
             return MetaInfo.back();
         } else {
@@ -83,12 +83,12 @@ public:
         }
     }
 
-    TMetaScan& UpsertTaskWithScan(const NYql::NDqProto::TDqTask& dqTask, const NKikimrTxDataShard::TKqpTransaction::TScanTaskMeta& meta) {
+    TMetaScan& UpsertTaskWithScan(const NYql::NDqProto::TDqTask& dqTask, const NKikimrTxDataShard::TKqpTransaction::TScanTaskMeta& meta, const bool forceOneToMany) {
         auto it = Stages.find(dqTask.GetStageId());
         if (it == Stages.end()) {
             it = Stages.emplace(dqTask.GetStageId(), TComputeStageInfo()).first;
         }
-        return it->second.MergeMetaReads(dqTask, meta);
+        return it->second.MergeMetaReads(dqTask, meta, forceOneToMany);
     }
 };
 

--- a/ydb/core/kqp/executer_actor/kqp_executer_impl.h
+++ b/ydb/core/kqp/executer_actor/kqp_executer_impl.h
@@ -1727,8 +1727,7 @@ protected:
         auto& stage = stageInfo.Meta.GetStage(stageInfo.Id);
 
         auto& columnShardHashV1Params = stageInfo.Meta.ColumnShardHashV1Params;
-        bool shuffleEliminated = enableShuffleElimination && stage.GetIsShuffleEliminated();
-        if (shuffleEliminated && stageInfo.Meta.ColumnTableInfoPtr) {
+        if (enableShuffleElimination && stage.GetIsShuffleEliminated() && stageInfo.Meta.ColumnTableInfoPtr) {
             const auto& tableDesc = stageInfo.Meta.ColumnTableInfoPtr->Description;
             columnShardHashV1Params.SourceShardCount = tableDesc.GetColumnShardCount();
             columnShardHashV1Params.SourceTableKeyColumnTypes = std::make_shared<TVector<NScheme::TTypeInfo>>();
@@ -1774,7 +1773,7 @@ protected:
                 }
             }
 
-            if (!AppData()->FeatureFlags.GetEnableSeparationComputeActorsFromRead() && !shuffleEliminated || (!isOlapScan && readSettings.IsSorted())) {
+            if (!AppData()->FeatureFlags.GetEnableSeparationComputeActorsFromRead() || (!isOlapScan && readSettings.IsSorted())) {
                 for (auto&& pair : nodeShards) {
                     auto& shardsInfo = pair.second;
                     for (auto&& shardInfo : shardsInfo) {
@@ -1793,7 +1792,7 @@ protected:
                     }
                 }
 
-            } else if (shuffleEliminated /* save partitioning for shuffle elimination */) {
+            } else if (enableShuffleElimination && stage.GetIsShuffleEliminated() /* save partitioning for shuffle elimination */) {
                 std::size_t stageInternalTaskId = 0;
                 columnShardHashV1Params.TaskIndexByHash = std::make_shared<TVector<ui64>>();
                 columnShardHashV1Params.TaskIndexByHash->resize(columnShardHashV1Params.SourceShardCount);


### PR DESCRIPTION
Reverts ydb-platform/ydb#20175
```
error: undefined symbol: NYql::NDq::RegisterDqPqReadActorFactory(NYql::NDq::TDqAsyncIoFactory&, NYdb::Dev::TDriver, std::__y1::shared_ptr<NYql::ISecuredServiceAccountCredentialsFactory>, TIntrusivePtr<NYql::IPqGateway, TDefaultIntrusivePtrOps<NYql::IPqGateway>> const&, TIntrusivePtr<NMonitoring::TDynamicCounters, TDefaultIntrusivePtrOps<NMonitoring::TDynamicCounters>> const&, TBasicString<char, std::__y1::char_traits<char>> const&)
>>> referenced by kqp_compute_actor.cpp:92 (/-S/ydb/core/kqp/compute_actor/kqp_compute_actor.cpp:92)
```