### PR TITLE
Bridge Mode in SB: more thorough disconnected group ignoring in subscriber

### DIFF
--- a/ydb/core/tx/scheme_board/subscriber.cpp
+++ b/ydb/core/tx/scheme_board/subscriber.cpp
@@ -1020,6 +1020,10 @@ class TSubscriber: public TMonitorableActor<TDerived> {
         MaybeRunVersionSync();
     }
 
+    static bool ShouldIgnore(const TEvStateStorage::TEvResolveReplicasList::TReplicaGroup& replicaGroup) {
+        return replicaGroup.WriteOnly || replicaGroup.State == ERingGroupState::DISCONNECTED;
+    }
+
     void Handle(TEvStateStorage::TEvResolveReplicasList::TPtr& ev) {
         SBS_LOG_D("Handle " << ev->Get()->ToString());
 
@@ -1047,7 +1051,7 @@ class TSubscriber: public TMonitorableActor<TDerived> {
 
         for (size_t groupIdx = 0; groupIdx < replicaGroups.size(); ++groupIdx) {
             const auto& replicaGroup = replicaGroups[groupIdx];
-            if (replicaGroup.WriteOnly || replicaGroup.State == ERingGroupState::DISCONNECTED) {
+            if (ShouldIgnore(replicaGroup)) {
                 continue;
             }
             auto& proxyGroup = ProxyGroups.emplace_back();

--- a/ydb/core/tx/scheme_board/subscriber.cpp
+++ b/ydb/core/tx/scheme_board/subscriber.cpp
@@ -784,7 +784,7 @@ class TSubscriber: public TMonitorableActor<TDerived> {
     }
 
     static bool ShouldIgnore(const TProxyGroup& proxyGroup) {
-        return proxyGroup.State != ERingGroupState::PRIMARY;
+        return proxyGroup.State == ERingGroupState::DISCONNECTED;
     }
 
     bool IsMajorityReached() const {

--- a/ydb/core/tx/scheme_board/subscriber.cpp
+++ b/ydb/core/tx/scheme_board/subscriber.cpp
@@ -719,7 +719,6 @@ class TSubscriber: public TMonitorableActor<TDerived> {
     };
 
     struct TProxyGroup {
-        bool WriteOnly;
         ERingGroupState State;
         TVector<TProxyInfo> Proxies;
     };
@@ -785,7 +784,7 @@ class TSubscriber: public TMonitorableActor<TDerived> {
     }
 
     static bool ShouldIgnore(const TProxyGroup& proxyGroup) {
-        return proxyGroup.WriteOnly || proxyGroup.State != ERingGroupState::PRIMARY;
+        return proxyGroup.State != ERingGroupState::PRIMARY;
     }
 
     bool IsMajorityReached() const {
@@ -1064,7 +1063,6 @@ class TSubscriber: public TMonitorableActor<TDerived> {
                 continue;
             }
             auto& proxyGroup = ProxyGroups.emplace_back();
-            proxyGroup.WriteOnly = replicaGroup.WriteOnly;
             proxyGroup.State = replicaGroup.State;
 
             proxyGroup.Proxies.reserve(replicaGroup.Replicas.size());

--- a/ydb/core/tx/scheme_board/subscriber.cpp
+++ b/ydb/core/tx/scheme_board/subscriber.cpp
@@ -989,7 +989,7 @@ class TSubscriber: public TMonitorableActor<TDerived> {
         }
         bool syncIsComplete = true;
         for (size_t groupIdx : xrange(ProxyGroups.size())) {
-            if (ProxyGroups[groupIdx].WriteOnly) {
+            if (ShouldIgnore(ProxyGroups[groupIdx])) {
                 continue;
             }
             const ui32 size = ProxyGroups[groupIdx].Proxies.size();
@@ -1059,7 +1059,7 @@ class TSubscriber: public TMonitorableActor<TDerived> {
 
         for (size_t groupIdx = 0; groupIdx < replicaGroups.size(); ++groupIdx) {
             const auto& replicaGroup = replicaGroups[groupIdx];
-            if (replicaGroup.WriteOnly) {
+            if (replicaGroup.WriteOnly || replicaGroup.State == ERingGroupState::DISCONNECTED) {
                 continue;
             }
             auto& proxyGroup = ProxyGroups.emplace_back();

--- a/ydb/core/tx/scheme_board/subscriber_ut.cpp
+++ b/ydb/core/tx/scheme_board/subscriber_ut.cpp
@@ -548,7 +548,7 @@ TVector<TActorId> GetReplicasRequiredForQuorum(const TVector<TStateStorageInfo::
 
     for (size_t i = 0; i < ringGroups.size(); ++i) {
         const auto& ringGroup = ringGroups[i];
-        if (ringGroup.WriteOnly || ringGroup.State != ERingGroupState::PRIMARY) {
+        if (ShouldIgnore(ringGroup)) {
             // not participating in the quorum
             continue;
         }

--- a/ydb/core/tx/scheme_board/subscriber_ut.cpp
+++ b/ydb/core/tx/scheme_board/subscriber_ut.cpp
@@ -644,6 +644,10 @@ Y_UNIT_TEST_SUITE(TSubscriberSinglePathUpdateTest) {
         TestSinglePathUpdate({ {.State = PRIMARY}, {.State = DISCONNECTED} });
     }
 
+    Y_UNIT_TEST(OneSynchronizedRingGroup) {
+        TestSinglePathUpdate({ {.State = PRIMARY}, {.State = SYNCHRONIZED} });
+    }
+
     Y_UNIT_TEST(OneWriteOnlyRingGroup) {
         TestSinglePathUpdate({ {.State = PRIMARY}, {.State = PRIMARY, .WriteOnly = true} });
     }


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

### Changelog category <!-- remove all except one -->

* Not for changelog (changelog entry is not required)

### Description for reviewers <!-- (optional) description for those who read this PR -->

Epic:
- https://github.com/ydb-platform/ydb/issues/19748

Issue:
- https://github.com/ydb-platform/ydb/issues/20320

Note:
- ResolveReplicaList event has DISCONNECTED piles already filtered out:
  - https://github.com/ydb-platform/ydb/blob/ff15de8c93e6378fbd39217f4ebaa380bdae778b/ydb/core/base/statestorage_proxy.cpp#L1065
  However, I don't want to verify that this invariant holds true, so I just ignore them once again just to be sure.
