### PR TITLE
Bridge Mode in SB: verify config between replicas and the main subscriber

### DIFF
--- a/ydb/core/base/statestorage.h
+++ b/ydb/core/base/statestorage.h
@@ -104,7 +104,7 @@ struct TEvStateStorage {
             , ProxyOptions(proxyOptions)
         {}
 
-        TEvLookup(const TEvLookup& ev)            
+        TEvLookup(const TEvLookup& ev)
             : TabletID(ev.TabletID)
             , Cookie(ev.Cookie)
             , ProxyOptions(ev.ProxyOptions)
@@ -154,7 +154,7 @@ struct TEvStateStorage {
         {
         }
 
-        TEvUpdate(const TEvUpdate& ev) 
+        TEvUpdate(const TEvUpdate& ev)
             : TabletID(ev.TabletID)
             , Cookie(ev.Cookie)
             , ProposedLeader(ev.ProposedLeader)
@@ -162,7 +162,7 @@ struct TEvStateStorage {
             , ProposedGeneration(ev.ProposedGeneration)
             , ProposedStep(ev.ProposedStep)
             , Signature(ev.Signature)
-            , ProxyOptions(ev.ProxyOptions) 
+            , ProxyOptions(ev.ProxyOptions)
         {
         }
 
@@ -251,7 +251,7 @@ struct TEvStateStorage {
             , ProposedLeader(ev.ProposedLeader)
             , ProposedGeneration(ev.ProposedGeneration)
             , Signature(ev.Signature)
-            , ProxyOptions(ev.ProxyOptions) 
+            , ProxyOptions(ev.ProxyOptions)
         {
         }
 
@@ -486,7 +486,7 @@ struct TStateStorageInfo : public TThrRefBase {
             StatusOutdated,
             StatusUnavailable,
         };
- 
+
         ui32 Sz;
         TArrayHolder<TActorId> SelectedReplicas;
         TArrayHolder<EStatus> Status;
@@ -579,7 +579,7 @@ IActor* CreateStateStorageMonitoringActor(ui64 targetTablet, const TActorId &sen
 IActor* CreateStateStorageTabletGuardian(ui64 tabletId, const TActorId &leader, const TActorId &tabletLeader, ui32 generation);
 IActor* CreateStateStorageFollowerGuardian(ui64 tabletId, const TActorId &follower); // created as followerCandidate
 IActor* CreateStateStorageBoardReplica(const TIntrusivePtr<TStateStorageInfo> &, ui32);
-IActor* CreateSchemeBoardReplica(const TIntrusivePtr<TStateStorageInfo>&, ui32);
+IActor* CreateSchemeBoardReplica(const TIntrusivePtr<TStateStorageInfo>& info, ui32);
 IActor* CreateBoardLookupActor(
     const TString &path, const TActorId &owner, EBoardLookupMode mode,
     TBoardRetrySettings boardRetrySettings = {}, ui64 cookie = 0);

--- a/ydb/core/base/statestorage.h
+++ b/ydb/core/base/statestorage.h
@@ -104,7 +104,7 @@ struct TEvStateStorage {
             , ProxyOptions(proxyOptions)
         {}
 
-        TEvLookup(const TEvLookup& ev)
+        TEvLookup(const TEvLookup& ev)            
             : TabletID(ev.TabletID)
             , Cookie(ev.Cookie)
             , ProxyOptions(ev.ProxyOptions)
@@ -154,7 +154,7 @@ struct TEvStateStorage {
         {
         }
 
-        TEvUpdate(const TEvUpdate& ev)
+        TEvUpdate(const TEvUpdate& ev) 
             : TabletID(ev.TabletID)
             , Cookie(ev.Cookie)
             , ProposedLeader(ev.ProposedLeader)
@@ -162,7 +162,7 @@ struct TEvStateStorage {
             , ProposedGeneration(ev.ProposedGeneration)
             , ProposedStep(ev.ProposedStep)
             , Signature(ev.Signature)
-            , ProxyOptions(ev.ProxyOptions)
+            , ProxyOptions(ev.ProxyOptions) 
         {
         }
 
@@ -251,7 +251,7 @@ struct TEvStateStorage {
             , ProposedLeader(ev.ProposedLeader)
             , ProposedGeneration(ev.ProposedGeneration)
             , Signature(ev.Signature)
-            , ProxyOptions(ev.ProxyOptions)
+            , ProxyOptions(ev.ProxyOptions) 
         {
         }
 
@@ -486,7 +486,7 @@ struct TStateStorageInfo : public TThrRefBase {
             StatusOutdated,
             StatusUnavailable,
         };
-
+ 
         ui32 Sz;
         TArrayHolder<TActorId> SelectedReplicas;
         TArrayHolder<EStatus> Status;
@@ -579,7 +579,7 @@ IActor* CreateStateStorageMonitoringActor(ui64 targetTablet, const TActorId &sen
 IActor* CreateStateStorageTabletGuardian(ui64 tabletId, const TActorId &leader, const TActorId &tabletLeader, ui32 generation);
 IActor* CreateStateStorageFollowerGuardian(ui64 tabletId, const TActorId &follower); // created as followerCandidate
 IActor* CreateStateStorageBoardReplica(const TIntrusivePtr<TStateStorageInfo> &, ui32);
-IActor* CreateSchemeBoardReplica(const TIntrusivePtr<TStateStorageInfo>& info, ui32);
+IActor* CreateSchemeBoardReplica(const TIntrusivePtr<TStateStorageInfo>&, ui32);
 IActor* CreateBoardLookupActor(
     const TString &path, const TActorId &owner, EBoardLookupMode mode,
     TBoardRetrySettings boardRetrySettings = {}, ui64 cookie = 0);

--- a/ydb/core/blobstorage/nodewarden/node_warden_resource.cpp
+++ b/ydb/core/blobstorage/nodewarden/node_warden_resource.cpp
@@ -174,7 +174,7 @@ void TNodeWarden::ApplyStateStorageConfig(const NKikimrBlobStorage::TStorageConf
     FETCH_CONFIG(stateStorage, StateStorage)
     FETCH_CONFIG(board, StateStorageBoard)
     FETCH_CONFIG(schemeBoard, SchemeBoard)
-    
+
     STLOG(PRI_DEBUG, BS_NODE, NW55, "ApplyStateStorageConfig",
         (StateStorageConfig, StorageConfig->GetStateStorageConfig()),
         (NewStateStorageInfo, *stateStorageInfo),
@@ -209,7 +209,7 @@ void TNodeWarden::ApplyStateStorageConfig(const NKikimrBlobStorage::TStorageConf
             || !std::equal(prev.CompatibleVersions.begin(), prev.CompatibleVersions.end(), cur.CompatibleVersions.begin());
     };
 
-    
+
     TActorSystem *as = TActivationContext::ActorSystem();
     const bool changedStateStorage = !StateStorageProxyConfigured || changed(*StateStorageInfo, *stateStorageInfo);
     const bool changedBoard = !StateStorageProxyConfigured || changed(*BoardInfo, *boardInfo);
@@ -249,8 +249,8 @@ void TNodeWarden::ApplyStateStorageConfig(const NKikimrBlobStorage::TStorageConf
                             Send(replicaId, new TEvStateStorage::TEvUpdateGroupConfig(info, nullptr, nullptr));
                         } else if (which == &BoardInfo && !newActorIds.contains(replicaId)) {
                             Send(replicaId, new TEvStateStorage::TEvUpdateGroupConfig(nullptr, info, nullptr));
-                        } else {
-                            // TODO(alexvru): update other kinds of replicas
+                        } else if (which == &SchemeBoardInfo && !newActorIds.contains(replicaId)) {
+                            Send(replicaId, new TEvStateStorage::TEvUpdateGroupConfig(nullptr, nullptr, info));
                         }
                         newActorIds.insert(replicaId);
                     }
@@ -334,7 +334,7 @@ void TNodeWarden::HandleIncrHugeInit(NIncrHuge::TEvIncrHugeInit::TPtr ev) {
 void TNodeWarden::Handle(TEvNodeWardenNotifyConfigMismatch::TPtr ev) {
     //TODO: config mismatch with node
     auto *msg = ev->Get();
-    STLOG(PRI_INFO, BS_NODE, NW51, "TEvNodeWardenNotifyConfigMismatch: NodeId: " << msg->NodeId 
+    STLOG(PRI_INFO, BS_NODE, NW51, "TEvNodeWardenNotifyConfigMismatch: NodeId: " << msg->NodeId
         << " ClusterStateGeneration: " << msg->ClusterStateGeneration << " ClusterStateGuid: " << msg->ClusterStateGuid);
 }
 

--- a/ydb/core/protos/scheme_board.proto
+++ b/ydb/core/protos/scheme_board.proto
@@ -119,6 +119,11 @@ message TEvUnsubscribe {
     optional uint64 LocalPathId = 3;
 }
 
+message TClusterState {
+    optional uint64 Generation = 1;
+    optional fixed64 Guid = 2;
+}
+
  // See comments for TEvUpdate.
 message TEvNotify {
     optional string Path = 1;
@@ -136,8 +141,7 @@ message TEvNotify {
     optional NKikimrProto.TPathID PathSubdomainPathId = 8;
     repeated uint64 PathAbandonedTenantsSchemeShards = 9;
 
-    optional uint64 ClusterStateGeneration = 10;
-    optional fixed64 ClusterStateGuid = 11;
+    optional TClusterState ClusterState = 10;
 }
 
 message TEvNotifyAck {
@@ -154,6 +158,5 @@ message TEvSyncVersionRequest {
 message TEvSyncVersionResponse {
     optional uint64 Version = 1;
     optional bool Partial = 2;
-    optional uint64 ClusterStateGeneration = 3;
-    optional fixed64 ClusterStateGuid = 4;
+    optional TClusterState ClusterState = 3;
 }

--- a/ydb/core/protos/scheme_board.proto
+++ b/ydb/core/protos/scheme_board.proto
@@ -151,4 +151,6 @@ message TEvSyncVersionRequest {
 message TEvSyncVersionResponse {
     optional uint64 Version = 1;
     optional bool Partial = 2;
+    optional uint64 ClusterStateGeneration = 3;
+    optional fixed64 ClusterStateGuid = 4;
 }

--- a/ydb/core/protos/scheme_board.proto
+++ b/ydb/core/protos/scheme_board.proto
@@ -135,6 +135,9 @@ message TEvNotify {
 
     optional NKikimrProto.TPathID PathSubdomainPathId = 8;
     repeated uint64 PathAbandonedTenantsSchemeShards = 9;
+
+    optional uint64 ClusterStateGeneration = 10;
+    optional fixed64 ClusterStateGuid = 11;
 }
 
 message TEvNotifyAck {

--- a/ydb/core/tx/scheme_board/events_internal.h
+++ b/ydb/core/tx/scheme_board/events_internal.h
@@ -312,7 +312,7 @@ struct TEvNotify: public TEventPreSerializedPB<TEvNotify, NKikimrSchemeBoard::TE
     TEvNotify() = default;
     explicit TEvNotify(const TClusterState& clusterState) {
         if (clusterState) {
-            *Record.MutableClusterState() = clusterState.ToProto();
+            clusterState.ToProto(*Record.MutableClusterState());
         }
     }
 
@@ -367,11 +367,16 @@ struct TEvSyncVersionRequest: public TEventPB<TEvSyncVersionRequest, NKikimrSche
 struct TEvSyncVersionResponse: public TEventPB<TEvSyncVersionResponse, NKikimrSchemeBoard::TEvSyncVersionResponse, TSchemeBoardEvents::EvSyncVersionResponse> {
     TEvSyncVersionResponse() = default;
 
-    explicit TEvSyncVersionResponse(const ui64 version, const bool partial = false, const TClusterState& clusterState = {}) {
+    explicit TEvSyncVersionResponse(const ui64 version) {
         Record.SetVersion(version);
-        Record.SetPartial(partial);
+        Record.SetPartial(true);
+    }
+
+    explicit TEvSyncVersionResponse(const ui64 version, const TClusterState& clusterState) {
+        Record.SetVersion(version);
+        Record.SetPartial(false);
         if (clusterState) {
-            *Record.MutableClusterState() = clusterState.ToProto();
+            clusterState.ToProto(*Record.MutableClusterState());
         }
     }
 

--- a/ydb/core/tx/scheme_board/events_internal.h
+++ b/ydb/core/tx/scheme_board/events_internal.h
@@ -310,6 +310,10 @@ TString PrintPath(const IEventBase* ev, const NKikimrSchemeBoard::TEvNotify& rec
 
 struct TEvNotify: public TEventPreSerializedPB<TEvNotify, NKikimrSchemeBoard::TEvNotify, TSchemeBoardEvents::EvNotify> {
     TEvNotify() = default;
+    TEvNotify(ui64 clusterStateGeneration, ui64 clusterStateGuid) {
+        Record.SetClusterStateGeneration(clusterStateGeneration);
+        Record.SetClusterStateGuid(clusterStateGuid);
+    }
 
     TString ToString() const override {
         return PrintPath(this, Record);

--- a/ydb/core/tx/scheme_board/events_internal.h
+++ b/ydb/core/tx/scheme_board/events_internal.h
@@ -362,15 +362,23 @@ struct TEvSyncVersionRequest: public TEventPB<TEvSyncVersionRequest, NKikimrSche
 struct TEvSyncVersionResponse: public TEventPB<TEvSyncVersionResponse, NKikimrSchemeBoard::TEvSyncVersionResponse, TSchemeBoardEvents::EvSyncVersionResponse> {
     TEvSyncVersionResponse() = default;
 
-    explicit TEvSyncVersionResponse(const ui64 version, const bool partial = false) {
+    explicit TEvSyncVersionResponse(const ui64 version, const bool partial = false, TMaybe<ui64> clusterStateGeneration = Nothing(), TMaybe<ui64> clusterStateGuid = Nothing()) {
         Record.SetVersion(version);
         Record.SetPartial(partial);
+        if (clusterStateGeneration) {
+            Record.SetClusterStateGeneration(*clusterStateGeneration);
+        }
+        if (clusterStateGuid) {
+            Record.SetClusterStateGuid(*clusterStateGuid);
+        }
     }
 
     TString ToString() const override {
         return TStringBuilder() << ToStringHeader() << " {"
             << " Version: " << Record.GetVersion()
             << " Partial: " << Record.GetPartial()
+            << " Cluster State Generation: " << Record.GetClusterStateGeneration()
+            << " Cluster State GUID: " << Record.GetClusterStateGuid()
         << " }";
     }
 };

--- a/ydb/core/tx/scheme_board/helpers.cpp
+++ b/ydb/core/tx/scheme_board/helpers.cpp
@@ -180,5 +180,30 @@ bool ShouldIgnore(const TStateStorageInfo::TRingGroup& ringGroup) {
     return ringGroup.WriteOnly || ringGroup.State == ERingGroupState::DISCONNECTED;
 }
 
+TClusterState::TClusterState(const NKikimrSchemeBoard::TClusterState& proto)
+    : Generation(proto.GetGeneration())
+    , Guid(proto.GetGuid())
+{}
+
+TClusterState::TClusterState(const TStateStorageInfo* info)
+    : Generation(info ? info->ClusterStateGeneration : 0)
+    , Guid(info ? info->ClusterStateGuid : 0)
+{}
+
+NKikimrSchemeBoard::TClusterState TClusterState::ToProto() const {
+    NKikimrSchemeBoard::TClusterState proto;
+    proto.SetGeneration(Generation);
+    proto.SetGuid(Guid);
+    return proto;
+}
+
+TClusterState::operator bool() const {
+    return Generation || Guid;
+}
+
+void TClusterState::Out(IOutputStream& out) const {
+    out << std::format("(Generation: {}, GUID: {})", Generation, Guid);
+}
+
 } // NSchemeBoard
 } // NKikimr

--- a/ydb/core/tx/scheme_board/helpers.cpp
+++ b/ydb/core/tx/scheme_board/helpers.cpp
@@ -190,11 +190,9 @@ TClusterState::TClusterState(const TStateStorageInfo* info)
     , Guid(info ? info->ClusterStateGuid : 0)
 {}
 
-NKikimrSchemeBoard::TClusterState TClusterState::ToProto() const {
-    NKikimrSchemeBoard::TClusterState proto;
+void TClusterState::ToProto(NKikimrSchemeBoard::TClusterState& proto) const {
     proto.SetGeneration(Generation);
     proto.SetGuid(Guid);
-    return proto;
 }
 
 TClusterState::operator bool() const {
@@ -202,7 +200,12 @@ TClusterState::operator bool() const {
 }
 
 void TClusterState::Out(IOutputStream& out) const {
-    out << std::format("(Generation: {}, GUID: {})", Generation, Guid);
+    out << std::format("{{Generation: {}, GUID: {}}}", Generation, Guid);
+}
+
+bool TClusterState::operator==(const TClusterState& other) const {
+    return Generation == other.Generation
+        && Guid == other.Guid;
 }
 
 } // NSchemeBoard

--- a/ydb/core/tx/scheme_board/helpers.h
+++ b/ydb/core/tx/scheme_board/helpers.h
@@ -65,5 +65,22 @@ TString JsonFromDescribeSchemeResult(const TString& serialized);
 
 bool ShouldIgnore(const TStateStorageInfo::TRingGroup& ringGroup);
 
+struct TClusterState {
+    ui64 Generation = 0;
+    ui64 Guid = 0;
+
+    TClusterState() = default;
+    explicit TClusterState(const TStateStorageInfo* info);
+    explicit TClusterState(const NKikimrSchemeBoard::TClusterState& proto);
+    NKikimrSchemeBoard::TClusterState ToProto() const;
+
+    operator bool() const;
+    void Out(IOutputStream& out) const;
+};
+
 } // NSchemeBoard
 } // NKikimr
+
+Y_DECLARE_OUT_SPEC(inline, NKikimr::NSchemeBoard::TClusterState, o, x) {
+    return x.Out(o);
+}

--- a/ydb/core/tx/scheme_board/helpers.h
+++ b/ydb/core/tx/scheme_board/helpers.h
@@ -72,9 +72,10 @@ struct TClusterState {
     TClusterState() = default;
     explicit TClusterState(const TStateStorageInfo* info);
     explicit TClusterState(const NKikimrSchemeBoard::TClusterState& proto);
-    NKikimrSchemeBoard::TClusterState ToProto() const;
+    void ToProto(NKikimrSchemeBoard::TClusterState& proto) const;
 
-    operator bool() const;
+    explicit operator bool() const;
+    bool operator==(const TClusterState& other) const;
     void Out(IOutputStream& out) const;
 };
 

--- a/ydb/core/tx/scheme_board/replica.cpp
+++ b/ydb/core/tx/scheme_board/replica.cpp
@@ -440,7 +440,7 @@ public:
             notify->Record.SetVersion(GetVersion());
             Y_ABORT_UNLESS(Owner);
             if (Owner->Info) {
-                *notify->Record.MutableClusterState() = TClusterState(Owner->Info.Get()).ToProto();
+                TClusterState(Owner->Info.Get()).ToProto(*notify->Record.MutableClusterState());
             }
 
             if (!IsEmpty() || IsExplicitlyDeleted() || forceStrong) {
@@ -1125,7 +1125,7 @@ private:
         }
 
         if (auto cookie = info.ProcessSyncRequest()) {
-            Send(ev->Sender, new NInternalEvents::TEvSyncVersionResponse(desc->GetVersion(), false, TClusterState(Info.Get())), 0, *cookie);
+            Send(ev->Sender, new NInternalEvents::TEvSyncVersionResponse(desc->GetVersion(), TClusterState(Info.Get())), 0, *cookie);
         }
     }
 
@@ -1147,7 +1147,7 @@ private:
                 version = GetVersion(TPathId(record.GetPathOwnerId(), record.GetLocalPathId()));
             }
 
-            Send(ev->Sender, new NInternalEvents::TEvSyncVersionResponse(version, false, TClusterState(Info.Get())), 0, ev->Cookie);
+            Send(ev->Sender, new NInternalEvents::TEvSyncVersionResponse(version, TClusterState(Info.Get())), 0, ev->Cookie);
             return;
         }
 
@@ -1169,7 +1169,7 @@ private:
         auto cookie = info.ProcessSyncRequest();
         Y_ABORT_UNLESS(cookie && *cookie == ev->Cookie);
 
-        Send(ev->Sender, new NInternalEvents::TEvSyncVersionResponse(desc->GetVersion(), false, TClusterState(Info.Get())), 0, *cookie);
+        Send(ev->Sender, new NInternalEvents::TEvSyncVersionResponse(desc->GetVersion(), TClusterState(Info.Get())), 0, *cookie);
     }
 
     void Handle(TSchemeBoardMonEvents::TEvInfoRequest::TPtr& ev) {

--- a/ydb/core/tx/scheme_board/replica.cpp
+++ b/ydb/core/tx/scheme_board/replica.cpp
@@ -438,6 +438,9 @@ public:
             }
 
             notify->Record.SetVersion(GetVersion());
+            Y_ABORT_UNLESS(Owner);
+            notify->Record.SetClusterStateGeneration(Owner->ClusterStateGeneration);
+            notify->Record.SetClusterStateGuid(Owner->ClusterStateGuid);
 
             if (!IsEmpty() || IsExplicitlyDeleted() || forceStrong) {
                 notify->Record.SetStrong(true);

--- a/ydb/core/tx/scheme_board/replica.cpp
+++ b/ydb/core/tx/scheme_board/replica.cpp
@@ -66,7 +66,7 @@ class TReplica: public TMonitorableActor<TReplica> {
     };
 
 public:
-    TReplica(const TIntrusivePtr<TStateStorageInfo>& info)
+    explicit TReplica(const TIntrusivePtr<TStateStorageInfo>& info)
         : ClusterStateGeneration(info->ClusterStateGeneration)
         , ClusterStateGuid(info->ClusterStateGuid)
     {}

--- a/ydb/core/tx/scheme_board/replica.cpp
+++ b/ydb/core/tx/scheme_board/replica.cpp
@@ -66,6 +66,11 @@ class TReplica: public TMonitorableActor<TReplica> {
     };
 
 public:
+    TReplica(const TIntrusivePtr<TStateStorageInfo>& info)
+        : ClusterStateGeneration(info->ClusterStateGeneration)
+        , ClusterStateGuid(info->ClusterStateGuid)
+    {}
+
     enum ESubscriptionType {
         SUBSCRIPTION_UNSPECIFIED, // for filtration
         SUBSCRIPTION_BY_PATH,
@@ -1300,13 +1305,15 @@ private:
     TDoubleIndexedMap<TString, TPathId, TDescription, TMerger, THashMap, TMap> Descriptions;
     TMap<TActorId, std::variant<TString, TPathId>, TActorId::TOrderedCmp> Subscribers;
     THashMap<ui64, TSet<TActorId>> WaitStrongNotifications;
+    ui64 ClusterStateGeneration = 0;
+    ui64 ClusterStateGuid = 0;
 
 }; // TReplica
 
 } // NSchemeBoard
 
-IActor* CreateSchemeBoardReplica(const TIntrusivePtr<TStateStorageInfo>&, ui32) {
-    return new NSchemeBoard::TReplica();
+IActor* CreateSchemeBoardReplica(const TIntrusivePtr<TStateStorageInfo>& info, ui32) {
+    return new NSchemeBoard::TReplica(info);
 }
 
 } // NKikimr

--- a/ydb/core/tx/scheme_board/replica.cpp
+++ b/ydb/core/tx/scheme_board/replica.cpp
@@ -1121,7 +1121,7 @@ private:
         }
 
         if (auto cookie = info.ProcessSyncRequest()) {
-            Send(ev->Sender, new NInternalEvents::TEvSyncVersionResponse(desc->GetVersion()), 0, *cookie);
+            Send(ev->Sender, new NInternalEvents::TEvSyncVersionResponse(desc->GetVersion(), false, ClusterStateGeneration, ClusterStateGuid), 0, *cookie);
         }
     }
 
@@ -1143,7 +1143,7 @@ private:
                 version = GetVersion(TPathId(record.GetPathOwnerId(), record.GetLocalPathId()));
             }
 
-            Send(ev->Sender, new NInternalEvents::TEvSyncVersionResponse(version), 0, ev->Cookie);
+            Send(ev->Sender, new NInternalEvents::TEvSyncVersionResponse(version, false, ClusterStateGeneration, ClusterStateGuid), 0, ev->Cookie);
             return;
         }
 
@@ -1165,7 +1165,7 @@ private:
         auto cookie = info.ProcessSyncRequest();
         Y_ABORT_UNLESS(cookie && *cookie == ev->Cookie);
 
-        Send(ev->Sender, new NInternalEvents::TEvSyncVersionResponse(desc->GetVersion()), 0, *cookie);
+        Send(ev->Sender, new NInternalEvents::TEvSyncVersionResponse(desc->GetVersion(), false, ClusterStateGeneration, ClusterStateGuid), 0, *cookie);
     }
 
     void Handle(TSchemeBoardMonEvents::TEvInfoRequest::TPtr& ev) {

--- a/ydb/core/tx/scheme_board/subscriber.cpp
+++ b/ydb/core/tx/scheme_board/subscriber.cpp
@@ -1065,6 +1065,9 @@ class TSubscriber: public TMonitorableActor<TDerived> {
             }
         }
 
+        ClusterStateGeneration = ev->Get()->ClusterStateGeneration;
+        ClusterStateGuid = ev->Get()->ClusterStateGuid;
+
         this->Become(&TDerived::StateWork);
     }
 
@@ -1220,6 +1223,9 @@ private:
     ui64 CurrentSyncRequest;
     TSet<TActorId> PendingSync;
     TMap<TActorId, bool> ReceivedSync;
+
+    ui64 ClusterStateGeneration = 0;
+    ui64 ClusterStateGuid = 0;
 
 }; // TSubscriber
 


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

### Changelog category <!-- remove all except one -->

* Not for changelog (changelog entry is not required)

### Description for reviewers <!-- (optional) description for those who read this PR -->

Epic:
- https://github.com/ydb-platform/ydb/issues/19748

Issue:
- https://github.com/ydb-platform/ydb/issues/19828

We ignore messages sent from replicas whose config version does not match ours. It would prevent achieving quorum of replicas on Sync Requests and on the initial replicas querying by the main subscriber. Users won't get inconsistent result on Sync Requests from Scheme Cache.
