### PR TITLE
Add huge blob checker

### DIFF
--- a/ydb/core/blobstorage/vdisk/hullop/huge_blob_checker.h
+++ b/ydb/core/blobstorage/vdisk/hullop/huge_blob_checker.h
@@ -1,0 +1,38 @@
+#pragma once
+
+#include "defs.h"
+
+namespace NKikimr {
+
+    class THugeBlobLayoutChecker {
+        THashMap<TChunkIdx, std::map<ui32, std::tuple<ui32, TLogoBlobID>>> ChunkCoverage;
+
+    public:
+        void AddHugeBlob(TLogoBlobID id, TDiskPart location) {
+            Y_ABORT_UNLESS(location.ChunkIdx);
+            Y_ABORT_UNLESS(location.Size);
+            auto& coverage = ChunkCoverage[location.ChunkIdx];
+            auto [it, inserted] = coverage.emplace(location.Offset, std::make_tuple(location.Size, id));
+            Y_VERIFY_S(inserted, "duplicate HugeBlob entity: id# " << id << " location# " << location.ToString()
+                << " existing Offset# " << it->first << " Size# " << std::get<0>(it->second)
+                << " BlobId# " << std::get<1>(it->second));
+            if (it != coverage.begin()) {
+                auto prevIt = std::prev(it);
+                const ui32 prevOffset = prevIt->first;
+                const auto& [prevSize, prevId] = prevIt->second;
+                Y_VERIFY_S(prevOffset + prevSize <= location.Offset, "overlapping HugeBlob entity: id# " << id
+                    << " location# " << location.ToString() << " previous Offset# " << prevOffset << " Size# " << prevSize
+                    << " BlobId# " << prevId);
+            }
+            if (std::next(it) != coverage.end()) {
+                auto nextIt = std::next(it);
+                const ui32 nextOffset = nextIt->first;
+                const auto& [nextSize, nextId] = nextIt->second;
+                Y_VERIFY_S(location.Offset + location.Size <= nextOffset, "overlapping HugeBlob entity: id# " << id
+                    << " location " << location.ToString() << " next Offset# " << nextOffset << " nextSize# " << nextSize
+                    << " BlobId# " << nextId);
+            }
+        }
+    };
+
+} // NKikimr

--- a/ydb/core/blobstorage/vdisk/localrecovery/localrecovery_logreplay.h
+++ b/ydb/core/blobstorage/vdisk/localrecovery/localrecovery_logreplay.h
@@ -22,6 +22,8 @@ namespace NKikimr {
     class TPDiskCtx;
     class TLocalRecoveryInfo;
 
+    class THugeBlobLayoutChecker;
+
     ////////////////////////////////////////////////////////////////////////////
     // TLocalRecoveryContext
     ////////////////////////////////////////////////////////////////////////////
@@ -65,6 +67,7 @@ namespace NKikimr {
     ////////////////////////////////////////////////////////////////////////////
     // CreateRecoveryLogReplayer
     ////////////////////////////////////////////////////////////////////////////
-    IActor* CreateRecoveryLogReplayer(TActorId parentId, std::shared_ptr<TLocalRecoveryContext> locRecCtx);
+    IActor* CreateRecoveryLogReplayer(TActorId parentId, std::shared_ptr<TLocalRecoveryContext> locRecCtx,
+        THugeBlobLayoutChecker&& hugeBlobLayoutChecker);
 
 } // NKikimr


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

Add huge blob checker

### Changelog category <!-- remove all except one -->

* Not for changelog (changelog entry is not required)

### Description for reviewers <!-- (optional) description for those who read this PR -->

This patch add validation code on VDisk load stage that prevents multiple references to the same huge blob that may lead to silent data corruption. Such references may occur only as a result of a bug.
