### PR TITLE
Remove legacy split to read and write versions, execute operations at a single mvcc version

### DIFF
--- a/ydb/core/tx/datashard/build_data_tx_out_rs_unit.cpp
+++ b/ydb/core/tx/datashard/build_data_tx_out_rs_unit.cpp
@@ -63,7 +63,7 @@ EExecutionStatus TBuildDataTxOutRSUnit::Execute(TOperation::TPtr op,
     TDataShardLocksDb locksDb(DataShard, txc);
     TSetupSysLocks guardLocks(op, DataShard, &locksDb);
 
-    tx->GetDataTx()->SetReadVersion(DataShard.GetReadWriteVersions(tx).ReadVersion);
+    tx->GetDataTx()->SetMvccVersion(DataShard.GetMvccVersion(tx));
     IEngineFlat *engine = tx->GetDataTx()->GetEngine();
     try {
         auto &outReadSets = op->OutReadSets();

--- a/ydb/core/tx/datashard/build_distributed_erase_tx_out_rs_unit.cpp
+++ b/ydb/core/tx/datashard/build_distributed_erase_tx_out_rs_unit.cpp
@@ -104,9 +104,9 @@ public:
 
         const auto tags = MakeTags(condition->Tags(), eraseTx->GetIndexColumnIds());
         auto now = TAppData::TimeProvider->Now();
-        auto [readVersion, writeVersion] = DataShard.GetReadWriteVersions(tx);
+        auto mvccVersion = DataShard.GetMvccVersion(tx);
         NMiniKQL::TEngineHostCounters engineHostCounters;
-        TDataShardUserDb userDb(DataShard, txc.DB, op->GetGlobalTxId(), readVersion, writeVersion, engineHostCounters, now);
+        TDataShardUserDb userDb(DataShard, txc.DB, op->GetGlobalTxId(), mvccVersion, engineHostCounters, now);
         bool pageFault = false;
 
         TDynBitMap confirmedRows;

--- a/ydb/core/tx/datashard/build_kqp_data_tx_out_rs_unit.cpp
+++ b/ydb/core/tx/datashard/build_kqp_data_tx_out_rs_unit.cpp
@@ -91,7 +91,7 @@ EExecutionStatus TBuildKqpDataTxOutRSUnit::Execute(TOperation::TPtr op, TTransac
         LOG_T("Operation " << *op << " (build_kqp_data_tx_out_rs) at " << tabletId
             << " set memory limit " << (txc.GetMemoryLimit() - dataTx->GetTxSize()));
 
-        dataTx->SetReadVersion(DataShard.GetReadWriteVersions(tx).ReadVersion);
+        dataTx->SetMvccVersion(DataShard.GetMvccVersion(tx));
 
         if (dataTx->GetKqpComputeCtx().HasPersistentChannels()) {
             auto result = KqpRunTransaction(ctx, op->GetTxId(), useGenericReadSets, tasksRunner);

--- a/ydb/core/tx/datashard/change_collector_cdc_stream.cpp
+++ b/ydb/core/tx/datashard/change_collector_cdc_stream.cpp
@@ -279,10 +279,10 @@ bool TCdcStreamChangeCollector::Collect(const TTableId& tableId, ERowOp rop,
 }
 
 TMaybe<TRowState> TCdcStreamChangeCollector::GetState(const TTableId& tableId, TArrayRef<const TRawTypeValue> key,
-        TArrayRef<const TTag> valueTags, TSelectStats& stats, const TMaybe<TRowVersion>& readVersion)
+        TArrayRef<const TTag> valueTags, TSelectStats& stats, const TMaybe<TRowVersion>& snapshot)
 {
     TRowState row;
-    const auto ready = UserDb.SelectRow(tableId, key, valueTags, row, stats, readVersion);
+    const auto ready = UserDb.SelectRow(tableId, key, valueTags, row, stats, snapshot);
 
     if (ready == EReady::Page) {
         return Nothing();
@@ -292,10 +292,10 @@ TMaybe<TRowState> TCdcStreamChangeCollector::GetState(const TTableId& tableId, T
 }
 
 TMaybe<TRowState> TCdcStreamChangeCollector::GetState(const TTableId& tableId, TArrayRef<const TRawTypeValue> key,
-        TArrayRef<const TTag> valueTags, const TMaybe<TRowVersion>& readVersion)
+        TArrayRef<const TTag> valueTags, const TMaybe<TRowVersion>& snapshot)
 {
     TSelectStats stats;
-    return GetState(tableId, key, valueTags, stats, readVersion);
+    return GetState(tableId, key, valueTags, stats, snapshot);
 }
 
 TRowState TCdcStreamChangeCollector::PatchState(const TRowState& oldState, ERowOp rop,

--- a/ydb/core/tx/datashard/change_collector_cdc_stream.h
+++ b/ydb/core/tx/datashard/change_collector_cdc_stream.h
@@ -8,9 +8,9 @@ namespace NDataShard {
 
 class TCdcStreamChangeCollector: public TBaseChangeCollector {
     TMaybe<NTable::TRowState> GetState(const TTableId& tableId, TArrayRef<const TRawTypeValue> key,
-        TArrayRef<const NTable::TTag> valueTags, NTable::TSelectStats& stats, const TMaybe<TRowVersion>& readVersion = {});
+        TArrayRef<const NTable::TTag> valueTags, NTable::TSelectStats& stats, const TMaybe<TRowVersion>& snapshot = {});
     TMaybe<NTable::TRowState> GetState(const TTableId& tableId, TArrayRef<const TRawTypeValue> key,
-        TArrayRef<const NTable::TTag> valueTags, const TMaybe<TRowVersion>& readVersion = {});
+        TArrayRef<const NTable::TTag> valueTags, const TMaybe<TRowVersion>& snapshot = {});
     static NTable::TRowState PatchState(const NTable::TRowState& oldState, NTable::ERowOp rop,
         const THashMap<NTable::TTag, NTable::TPos>& tagToPos, const THashMap<NTable::TTag, NTable::TUpdateOp>& updates);
 

--- a/ydb/core/tx/datashard/datashard.cpp
+++ b/ydb/core/tx/datashard/datashard.cpp
@@ -67,7 +67,7 @@ public:
         }
 
         // Write user tables with a minimal safe version (avoiding snapshots)
-        return Self->GetLocalReadWriteVersions().WriteVersion;
+        return Self->GetLocalMvccVersion();
     }
 
     TRowVersion GetReadVersion(const TTableId& tableId) const override {
@@ -83,7 +83,7 @@ public:
             return TRowVersion::Max();
         }
 
-        return Self->GetLocalReadWriteVersions().ReadVersion;
+        return TRowVersion::Max();
     }
 
 private:
@@ -2327,23 +2327,8 @@ bool TDataShard::AllowCancelROwithReadsets() const {
     return CanCancelROWithReadSets;
 }
 
-TReadWriteVersions TDataShard::GetLocalReadWriteVersions() const {
-    if (IsFollower())
-        return {TRowVersion::Max(), TRowVersion::Max()};
-
-    TRowVersion edge = Max(
-            SnapshotManager.GetCompleteEdge(),
-            SnapshotManager.GetIncompleteEdge(),
-            SnapshotManager.GetUnprotectedReadEdge());
-
-    if (auto nextOp = Pipeline.GetNextPlannedOp(edge.Step, edge.TxId))
-        return TRowVersion(nextOp->GetStep(), nextOp->GetTxId());
-
-    TRowVersion maxEdge(edge.Step, ::Max<ui64>());
-
-    TRowVersion writeVersion = Max(maxEdge, edge.Next(), SnapshotManager.GetImmediateWriteEdge());
-
-    return {TRowVersion::Max(), writeVersion};
+TRowVersion TDataShard::GetLocalMvccVersion() const {
+    return GetMvccVersion();
 }
 
 TRowVersion TDataShard::GetMvccTxVersion(EMvccTxMode mode, TOperation* op) const {
@@ -2438,17 +2423,17 @@ TRowVersion TDataShard::GetMvccTxVersion(EMvccTxMode mode, TOperation* op) const
     Y_ENSURE(false, "unreachable");
 }
 
-TReadWriteVersions TDataShard::GetReadWriteVersions(TOperation* op) const {
+TRowVersion TDataShard::GetMvccVersion(TOperation* op) const {
     if (IsFollower()) {
-        return {TRowVersion::Max(), TRowVersion::Max()};
+        return TRowVersion::Max();
     }
 
     if (op) {
-        if (!op->MvccReadWriteVersion) {
-            op->MvccReadWriteVersion = GetMvccTxVersion(op->IsReadOnly() ? EMvccTxMode::ReadOnly : EMvccTxMode::ReadWrite, op);
+        if (!op->CachedMvccVersion) {
+            op->CachedMvccVersion = GetMvccTxVersion(op->IsReadOnly() ? EMvccTxMode::ReadOnly : EMvccTxMode::ReadWrite, op);
         }
 
-        return *op->MvccReadWriteVersion;
+        return *op->CachedMvccVersion;
     }
 
     return GetMvccTxVersion(EMvccTxMode::ReadWrite, nullptr);

--- a/ydb/core/tx/datashard/datashard__engine_host.h
+++ b/ydb/core/tx/datashard/datashard__engine_host.h
@@ -97,8 +97,7 @@ public:
     const TValidationInfo& TxInfo() const { return KeyValidator.GetInfo(); }
     TEngineBay::TSizes CalcSizes(bool needsTotalKeysSize) const;
 
-    void SetWriteVersion(TRowVersion writeVersion);
-    void SetReadVersion(TRowVersion readVersion);
+    void SetMvccVersion(TRowVersion mvccVersion);
     void SetVolatileTxId(ui64 txId);
     void SetIsImmediateTx();
     void SetUsesMvccSnapshot();

--- a/ydb/core/tx/datashard/datashard_active_transaction.h
+++ b/ydb/core/tx/datashard/datashard_active_transaction.h
@@ -185,8 +185,7 @@ public:
     bool CanCancel();
     bool CheckCancelled(ui64 tabletId);
 
-    void SetWriteVersion(TRowVersion writeVersion) { EngineBay.SetWriteVersion(writeVersion); }
-    void SetReadVersion(TRowVersion readVersion) { EngineBay.SetReadVersion(readVersion); }
+    void SetMvccVersion(TRowVersion mvccVersion) { EngineBay.SetMvccVersion(mvccVersion); }
     void SetVolatileTxId(ui64 txId) { EngineBay.SetVolatileTxId(txId); }
 
     TVector<IDataShardChangeCollector::TChange> GetCollectedChanges() const { return EngineBay.GetCollectedChanges(); }

--- a/ydb/core/tx/datashard/datashard_common_upload.cpp
+++ b/ydb/core/tx/datashard/datashard_common_upload.cpp
@@ -14,7 +14,7 @@ TCommonUploadOps<TEvRequest, TEvResponse>::TCommonUploadOps(typename TEvRequest:
 
 template <typename TEvRequest, typename TEvResponse>
 bool TCommonUploadOps<TEvRequest, TEvResponse>::Execute(TDataShard* self, TTransactionContext& txc,
-        const TRowVersion& readVersion, const TRowVersion& writeVersion, ui64 globalTxId,
+        const TRowVersion& mvccVersion, ui64 globalTxId,
         absl::flat_hash_set<ui64>* volatileReadDependencies)
 {
     const auto& record = Ev->Get()->Record;
@@ -75,7 +75,7 @@ bool TCommonUploadOps<TEvRequest, TEvResponse>::Execute(TDataShard* self, TTrans
         self->GetVolatileTxManager().GetTxMap());
 
     NMiniKQL::TEngineHostCounters engineHostCounters;
-    TDataShardUserDb userDb(*self, txc.DB, globalTxId, readVersion, writeVersion, engineHostCounters, TAppData::TimeProvider->Now());
+    TDataShardUserDb userDb(*self, txc.DB, globalTxId, mvccVersion, engineHostCounters, TAppData::TimeProvider->Now());
     TDataShardChangeGroupProvider groupProvider(*self, txc.DB);
 
     if (CollectChanges) {
@@ -146,7 +146,7 @@ bool TCommonUploadOps<TEvRequest, TEvResponse>::Execute(TDataShard* self, TTrans
         if (readForTableShadow) {
             rowState.Init(tagsForSelect.size());
 
-            auto ready = txc.DB.Select(localTableId, key, tagsForSelect, rowState, 0 /* readFlags */, readVersion);
+            auto ready = txc.DB.Select(localTableId, key, tagsForSelect, rowState, 0 /* readFlags */, mvccVersion);
             if (ready == NTable::EReady::Page) {
                 pageFault = true;
             }
@@ -232,7 +232,7 @@ bool TCommonUploadOps<TEvRequest, TEvResponse>::Execute(TDataShard* self, TTrans
                         pageFault = true;
                     }
                 } else {
-                    if (!ChangeCollector->OnUpdate(fullTableId, writeTableId, NTable::ERowOp::Upsert, key, value, writeVersion)) {
+                    if (!ChangeCollector->OnUpdate(fullTableId, writeTableId, NTable::ERowOp::Upsert, key, value, mvccVersion)) {
                         pageFault = true;
                     }
                 }
@@ -251,11 +251,11 @@ bool TCommonUploadOps<TEvRequest, TEvResponse>::Execute(TDataShard* self, TTrans
             self->GetConflictsCache().GetTableCache(writeTableId).AddUncommittedWrite(keyCells.GetCells(), globalTxId, txc.DB);
             if (!commitAdded) {
                 // Make sure we see our own changes on further iterations
-                userDb.AddCommitTxId(fullTableId, globalTxId, writeVersion);
+                userDb.AddCommitTxId(fullTableId, globalTxId);
                 commitAdded = true;
             }
         } else {
-            txc.DB.Update(writeTableId, NTable::ERowOp::Upsert, key, value, writeVersion);
+            txc.DB.Update(writeTableId, NTable::ERowOp::Upsert, key, value, mvccVersion);
             self->GetConflictsCache().GetTableCache(writeTableId).RemoveUncommittedWrites(keyCells.GetCells(), txc.DB);
         }
     }
@@ -277,7 +277,7 @@ bool TCommonUploadOps<TEvRequest, TEvResponse>::Execute(TDataShard* self, TTrans
     if (!volatileDependencies.empty()) {
         self->GetVolatileTxManager().PersistAddVolatileTx(
             globalTxId,
-            writeVersion,
+            mvccVersion,
             /* commitTxIds */ { globalTxId },
             volatileDependencies,
             /* participants */ { },

--- a/ydb/core/tx/datashard/datashard_common_upload.h
+++ b/ydb/core/tx/datashard/datashard_common_upload.h
@@ -21,8 +21,7 @@ public:
     explicit TCommonUploadOps(typename TEvRequest::TPtr& ev, bool breakLocks, bool collectChanges);
 
 protected:
-    bool Execute(TDataShard* self, TTransactionContext& txc, const TRowVersion& readVersion,
-        const TRowVersion& writeVersion, ui64 globalTxId,
+    bool Execute(TDataShard* self, TTransactionContext& txc, const TRowVersion& mvccVersion, ui64 globalTxId,
         absl::flat_hash_set<ui64>* volatileReadDependencies);
     void GetResult(TDataShard* self, TActorId& target, THolder<IEventBase>& event, ui64& cookie);
     const TEvRequest* GetRequest() const;

--- a/ydb/core/tx/datashard/datashard_direct_erase.h
+++ b/ydb/core/tx/datashard/datashard_direct_erase.h
@@ -20,19 +20,17 @@ class TDirectTxErase : public IDirectTx {
     struct TExecuteParams {
         TDirectTxErase* const Tx;
         TTransactionContext* const Txc;
-        const TRowVersion ReadVersion;
-        const TRowVersion WriteVersion;
+        const TRowVersion MvccVersion;
         const ui64 GlobalTxId;
         absl::flat_hash_set<ui64>* const VolatileReadDependencies;
 
     private:
         explicit TExecuteParams(TDirectTxErase* tx, TTransactionContext* txc,
-                const TRowVersion& readVersion, const TRowVersion& writeVersion,
-                ui64 globalTxId, absl::flat_hash_set<ui64>* volatileReadDependencies)
+                const TRowVersion& mvccVersion, ui64 globalTxId,
+                absl::flat_hash_set<ui64>* volatileReadDependencies)
             : Tx(tx)
             , Txc(txc)
-            , ReadVersion(readVersion)
-            , WriteVersion(writeVersion)
+            , MvccVersion(mvccVersion)
             , GlobalTxId(globalTxId)
             , VolatileReadDependencies(volatileReadDependencies)
         {
@@ -40,7 +38,7 @@ class TDirectTxErase : public IDirectTx {
 
     public:
         static TExecuteParams ForCheck() {
-            return TExecuteParams(nullptr, nullptr, TRowVersion(), TRowVersion(), 0, nullptr);
+            return TExecuteParams(nullptr, nullptr, TRowVersion(), 0, nullptr);
         }
 
         template <typename... Args>
@@ -74,8 +72,8 @@ public:
         NKikimrTxDataShard::TEvEraseRowsResponse::EStatus& status, TString& error);
 
     bool Execute(TDataShard* self, TTransactionContext& txc,
-        const TRowVersion& readVersion, const TRowVersion& writeVersion,
-        ui64 globalTxId, absl::flat_hash_set<ui64>& volatileReadDependencies) override;
+        const TRowVersion& mvccVersion, ui64 globalTxId,
+        absl::flat_hash_set<ui64>& volatileReadDependencies) override;
     TDirectTxResult GetResult(TDataShard* self) override;
     TVector<IDataShardChangeCollector::TChange> GetCollectedChanges() const override;
 };

--- a/ydb/core/tx/datashard/datashard_direct_transaction.h
+++ b/ydb/core/tx/datashard/datashard_direct_transaction.h
@@ -21,8 +21,8 @@ class IDirectTx {
 public:
     virtual ~IDirectTx() = default;
     virtual bool Execute(TDataShard* self, TTransactionContext& txc,
-        const TRowVersion& readVersion, const TRowVersion& writeVersion,
-        ui64 globalTxId, absl::flat_hash_set<ui64>& volatileReadDependencies) = 0;
+        const TRowVersion& mvccVersion, ui64 globalTxId,
+        absl::flat_hash_set<ui64>& volatileReadDependencies) = 0;
     virtual TDirectTxResult GetResult(TDataShard* self) = 0;
     virtual TVector<IDataShardChangeCollector::TChange> GetCollectedChanges() const = 0;
 };

--- a/ydb/core/tx/datashard/datashard_direct_upload.cpp
+++ b/ydb/core/tx/datashard/datashard_direct_upload.cpp
@@ -9,11 +9,11 @@ TDirectTxUpload::TDirectTxUpload(TEvDataShard::TEvUploadRowsRequest::TPtr& ev)
 }
 
 bool TDirectTxUpload::Execute(TDataShard* self, TTransactionContext& txc,
-        const TRowVersion& readVersion, const TRowVersion& writeVersion,
-        ui64 globalTxId, absl::flat_hash_set<ui64>& volatileReadDependencies)
+        const TRowVersion& mvccVersion, ui64 globalTxId,
+        absl::flat_hash_set<ui64>& volatileReadDependencies)
 {
-    return TCommonUploadOps::Execute(self, txc, readVersion, writeVersion,
-        globalTxId, &volatileReadDependencies);
+    return TCommonUploadOps::Execute(self, txc, mvccVersion, globalTxId,
+            &volatileReadDependencies);
 }
 
 TDirectTxResult TDirectTxUpload::GetResult(TDataShard* self) {

--- a/ydb/core/tx/datashard/datashard_direct_upload.h
+++ b/ydb/core/tx/datashard/datashard_direct_upload.h
@@ -15,8 +15,8 @@ public:
     explicit TDirectTxUpload(TEvDataShard::TEvUploadRowsRequest::TPtr& ev);
 
     bool Execute(TDataShard* self, TTransactionContext& txc,
-        const TRowVersion& readVersion, const TRowVersion& writeVersion,
-        ui64 globalTxId, absl::flat_hash_set<ui64>& volatileReadDependencies) override;
+        const TRowVersion& mvccVersion, ui64 globalTxId,
+        absl::flat_hash_set<ui64>& volatileReadDependencies) override;
     TDirectTxResult GetResult(TDataShard* self) override;
     TVector<IDataShardChangeCollector::TChange> GetCollectedChanges() const override;
 };

--- a/ydb/core/tx/datashard/datashard_impl.h
+++ b/ydb/core/tx/datashard/datashard_impl.h
@@ -137,21 +137,6 @@ public:
     virtual void OnFinished(TDataShard* self) = 0;
 };
 
-struct TReadWriteVersions {
-    TReadWriteVersions(const TRowVersion& readVersion, const TRowVersion& writeVersion)
-        : ReadVersion(readVersion)
-        , WriteVersion(writeVersion)
-    {}
-
-    TReadWriteVersions(const TRowVersion& version)
-        : ReadVersion(version)
-        , WriteVersion(version)
-    {}
-
-    const TRowVersion ReadVersion;
-    const TRowVersion WriteVersion;
-};
-
 class TDataShardEngineHost;
 struct TSetupSysLocks;
 
@@ -1489,7 +1474,7 @@ class TDataShard
     NTabletFlatExecutor::ITransaction* CreateTxCheckInReadSets();
     NTabletFlatExecutor::ITransaction* CreateTxRemoveOldInReadSets();
 
-    TReadWriteVersions GetLocalReadWriteVersions() const;
+    TRowVersion GetLocalMvccVersion() const;
 
 public:
     static constexpr NKikimrServices::TActivity::EType ActorActivityType() {
@@ -2058,7 +2043,7 @@ public:
         bool WaitCompletion = false;
     };
 
-    TReadWriteVersions GetReadWriteVersions(TOperation* op = nullptr) const;
+    TRowVersion GetMvccVersion(TOperation* op = nullptr) const;
     TPromotePostExecuteEdges PromoteImmediatePostExecuteEdges(
             const TRowVersion& version, EPromotePostExecuteEdges mode, TTransactionContext& txc);
     ui64 GetMaxObservedStep() const;

--- a/ydb/core/tx/datashard/datashard_kqp.cpp
+++ b/ydb/core/tx/datashard/datashard_kqp.cpp
@@ -791,7 +791,7 @@ void KqpEraseLocks(ui64 origin, const NKikimrDataEvents::TKqpLocks* kqpLocks, TS
     }
 }
 
-void KqpCommitLocks(ui64 origin, const NKikimrDataEvents::TKqpLocks* kqpLocks, TSysLocks& sysLocks, const TRowVersion& writeVersion, IDataShardUserDb& userDb) {
+void KqpCommitLocks(ui64 origin, const NKikimrDataEvents::TKqpLocks* kqpLocks, TSysLocks& sysLocks, IDataShardUserDb& userDb) {
     if (kqpLocks == nullptr) {
         return;
     }
@@ -811,7 +811,7 @@ void KqpCommitLocks(ui64 origin, const NKikimrDataEvents::TKqpLocks* kqpLocks, T
             TTableId tableId(lockProto.GetSchemeShard(), lockProto.GetPathId());
             auto txId = lockProto.GetLockId();
 
-            userDb.CommitChanges(tableId, txId, writeVersion);
+            userDb.CommitChanges(tableId, txId);
         }
     } else {
         KqpEraseLocks(origin, kqpLocks, sysLocks);

--- a/ydb/core/tx/datashard/datashard_kqp.h
+++ b/ydb/core/tx/datashard/datashard_kqp.h
@@ -47,7 +47,7 @@ bool KqpLocksHasArbiter(const NKikimrDataEvents::TKqpLocks* kqpLocks);
 bool KqpLocksIsArbiter(ui64 tabletId, const NKikimrDataEvents::TKqpLocks* kqpLocks);
 
 void KqpEraseLocks(ui64 tabletId, const NKikimrDataEvents::TKqpLocks* kqpLocks, TSysLocks& sysLocks);
-void KqpCommitLocks(ui64 tabletId, const NKikimrDataEvents::TKqpLocks* kqpLocks, TSysLocks& sysLocks, const TRowVersion& writeVersion, IDataShardUserDb& userDb);
+void KqpCommitLocks(ui64 tabletId, const NKikimrDataEvents::TKqpLocks* kqpLocks, TSysLocks& sysLocks, IDataShardUserDb& userDb);
 
 void KqpUpdateDataShardStatCounters(TDataShard& dataShard, const NMiniKQL::TEngineHostCounters& counters);
 

--- a/ydb/core/tx/datashard/datashard_kqp_compute.cpp
+++ b/ydb/core/tx/datashard/datashard_kqp_compute.cpp
@@ -134,14 +134,14 @@ void TKqpDatashardComputeContext::SetLockTxId(ui64 lockTxId, ui32 lockNodeId) {
     UserDb.SetLockNodeId(lockNodeId);
 }
 
-void TKqpDatashardComputeContext::SetReadVersion(TRowVersion readVersion) {
-    UserDb.SetReadVersion(readVersion);
+void TKqpDatashardComputeContext::SetMvccVersion(TRowVersion mvccVersion) {
+    UserDb.SetMvccVersion(mvccVersion);
 }
 
-TRowVersion TKqpDatashardComputeContext::GetReadVersion() const {
-    Y_ENSURE(!UserDb.GetReadVersion().IsMin(), "Cannot perform reads without ReadVersion set");
+TRowVersion TKqpDatashardComputeContext::GetMvccVersion() const {
+    Y_ENSURE(!UserDb.GetMvccVersion().IsMin(), "Cannot perform reads without ReadVersion set");
 
-    return UserDb.GetReadVersion();
+    return UserDb.GetMvccVersion();
 }
 
 TEngineHostCounters& TKqpDatashardComputeContext::GetDatashardCounters() {
@@ -240,7 +240,7 @@ bool TKqpDatashardComputeContext::PinPages(const TVector<IEngineFlat::TValidated
                                          adjustLimit(key.RangeLimits.ItemsLimit),
                                          adjustLimit(key.RangeLimits.BytesLimit),
                                          key.Reverse ? NTable::EDirection::Reverse : NTable::EDirection::Forward,
-                                         GetReadVersion());
+                                         GetMvccVersion());
 
         LOG_TRACE_S(*TlsActivationContext, NKikimrServices::TX_DATASHARD, "Run precharge on table " << tableInfo->Name
             << ", columns: [" << JoinSeq(", ", columnTags) << "]"

--- a/ydb/core/tx/datashard/datashard_kqp_compute.h
+++ b/ydb/core/tx/datashard/datashard_kqp_compute.h
@@ -46,8 +46,8 @@ public:
 
     void Clear();
 
-    void SetReadVersion(TRowVersion readVersion);
-    TRowVersion GetReadVersion() const;
+    void SetMvccVersion(TRowVersion readVersion);
+    TRowVersion GetMvccVersion() const;
 
     TEngineHostCounters& GetTaskCounters(ui64 taskId) { return TaskCounters[taskId]; }
     TEngineHostCounters& GetDatashardCounters();

--- a/ydb/core/tx/datashard/datashard_pipeline.cpp
+++ b/ydb/core/tx/datashard/datashard_pipeline.cpp
@@ -2282,7 +2282,7 @@ void TPipeline::AddCommittingOp(const TOperation::TPtr& op) {
     Y_ENSURE(!op->GetCommittingOpsVersion(),
         "Trying to AddCommittingOp " << *op << " more than once");
 
-    TRowVersion version = Self->GetReadWriteVersions(op.Get()).WriteVersion;
+    TRowVersion version = Self->GetMvccVersion(op.Get());
     if (op->IsImmediate())
         CommittingOps.Add(op->GetTxId(), version);
     else

--- a/ydb/core/tx/datashard/datashard_user_db.cpp
+++ b/ydb/core/tx/datashard/datashard_user_db.cpp
@@ -6,15 +6,14 @@
 
 namespace NKikimr::NDataShard {
 
-TDataShardUserDb::TDataShardUserDb(TDataShard& self, NTable::TDatabase& db, ui64 globalTxId, const TRowVersion& readVersion, const TRowVersion& writeVersion, NMiniKQL::TEngineHostCounters& counters, TInstant now)
+TDataShardUserDb::TDataShardUserDb(TDataShard& self, NTable::TDatabase& db, ui64 globalTxId, const TRowVersion& mvccVersion, NMiniKQL::TEngineHostCounters& counters, TInstant now)
     : Self(self)
     , Db(db)
     , ChangeGroupProvider(self, db)
     , GlobalTxId(globalTxId)
     , LockTxId(0)
     , LockNodeId(0)
-    , ReadVersion(readVersion)
-    , WriteVersion(writeVersion)
+    , MvccVersion(mvccVersion)
     , Now(now)
     , Counters(counters)
 {
@@ -26,15 +25,21 @@ NTable::EReady TDataShardUserDb::SelectRow(
         TArrayRef<const NTable::TTag> tags,
         NTable::TRowState& row,
         NTable::TSelectStats& stats,
-        const TMaybe<TRowVersion>& readVersion)
+        const TMaybe<TRowVersion>& snapshot)
 {
     auto tid = Self.GetLocalTableId(tableId);
     Y_ENSURE(tid != 0, "Unexpected SelectRow for an unknown table");
 
+    if (snapshot) {
+        // Note: snapshot is used by change collector to check scan snapshot state
+        // We don't want to apply any tx map or observer to reproduce whatever scan observes
+        return Db.Select(tid, key, tags, row, stats, /* readFlags */ 0, *snapshot);
+    }
+
     SetPerformedUserReads(true);
 
     return Db.Select(tid, key, tags, row, stats, /* readFlags */ 0,
-        readVersion.GetOrElse(ReadVersion),
+        MvccVersion,
         GetReadTxMap(tableId),
         GetReadTxObserver(tableId));
 }
@@ -44,10 +49,10 @@ NTable::EReady TDataShardUserDb::SelectRow(
         TArrayRef<const TRawTypeValue> key,
         TArrayRef<const NTable::TTag> tags,
         NTable::TRowState& row,
-        const TMaybe<TRowVersion>& readVersion)
+        const TMaybe<TRowVersion>& snapshot)
 {
     NTable::TSelectStats stats;
-    return SelectRow(tableId, key, tags, row, stats, readVersion);
+    return SelectRow(tableId, key, tags, row, stats, snapshot);
 }
 
 ui64 CalculateKeyBytes(const TArrayRef<const TRawTypeValue> key) {
@@ -301,10 +306,10 @@ void TDataShardUserDb::UpsertRowInt(
 
     const ui64 writeTxId = GetWriteTxId(tableId);
     if (writeTxId == 0) {
-        if (collector && !collector->OnUpdate(tableId, localTableId, rowOp, key, ops, WriteVersion))
+        if (collector && !collector->OnUpdate(tableId, localTableId, rowOp, key, ops, MvccVersion))
             throw TNotReadyTabletException();
 
-        Db.Update(localTableId, rowOp, key, ops, WriteVersion);
+        Db.Update(localTableId, rowOp, key, ops, MvccVersion);
     } else {
         if (collector && !collector->OnUpdateTx(tableId, localTableId, rowOp, key, ops, writeTxId))
             throw TNotReadyTabletException();
@@ -427,7 +432,7 @@ ui64 TDataShardUserDb::GetChangeGroup() {
     return ChangeGroupProvider.GetChangeGroup();
 }
 
-void TDataShardUserDb::CommitChanges(const TTableId& tableId, ui64 lockId, const TRowVersion& writeVersion) {
+void TDataShardUserDb::CommitChanges(const TTableId& tableId, ui64 lockId) {
     auto localTid = Self.GetLocalTableId(tableId);
     Y_ENSURE(localTid, "Unexpected failure to find table " << tableId << " in datashard " << Self.TabletID());
 
@@ -460,27 +465,27 @@ void TDataShardUserDb::CommitChanges(const TTableId& tableId, ui64 lockId, const
             // Update TxMap to include the new commit
             auto it = TxMaps.find(tableId.PathId);
             if (it != TxMaps.end()) {
-                it->second->Add(lockId, WriteVersion);
+                it->second->Add(lockId, MvccVersion);
             }
         }
         return;
     }
 
     LOG_TRACE_S(*TlsActivationContext, NKikimrServices::TX_DATASHARD, "Committing changes lockId# " << lockId << " in localTid# " << localTid << " shard# " << Self.TabletID());
-    Db.CommitTx(localTid, lockId, writeVersion);
+    Db.CommitTx(localTid, lockId, MvccVersion);
     Self.GetConflictsCache().GetTableCache(localTid).RemoveUncommittedWrites(lockId, Db);
 
     if (!CommittedLockChanges.contains(lockId) && Self.HasLockChangeRecords(lockId)) {
         if (auto* collector = GetChangeCollector(tableId)) {
-            collector->CommitLockChanges(lockId, WriteVersion);
+            collector->CommitLockChanges(lockId, MvccVersion);
             CommittedLockChanges.insert(lockId);
         }
     }
 }
 
-void TDataShardUserDb::AddCommitTxId(const TTableId& tableId, ui64 txId, const TRowVersion& commitVersion) {
+void TDataShardUserDb::AddCommitTxId(const TTableId& tableId, ui64 txId) {
     auto* dynamicTxMap = static_cast<NTable::TDynamicTransactionMap*>(GetReadTxMap(tableId).Get());
-    dynamicTxMap->Add(txId, commitVersion);
+    dynamicTxMap->Add(txId, MvccVersion);
 }
 
 class TLockedReadTxObserver: public NTable::ITransactionObserver {
@@ -791,7 +796,7 @@ ui64 TDataShardUserDb::GetWriteTxId(const TTableId& tableId) {
             // Update TxMap to include the new commit
             auto it = TxMaps.find(tableId.PathId);
             if (it != TxMaps.end()) {
-                it->second->Add(VolatileTxId, WriteVersion);
+                it->second->Add(VolatileTxId, MvccVersion);
             }
         }
         return VolatileTxId;
@@ -829,7 +834,7 @@ NTable::ITransactionMapPtr TDataShardUserDb::GetReadTxMap(const TTableId& tableI
         } else if (VolatileTxId) {
             // We want committed volatile changes to be visible at the write version
             for (ui64 commitTxId : VolatileCommitTxIds) {
-                txMap->Add(commitTxId, WriteVersion);
+                txMap->Add(commitTxId, MvccVersion);
             }
         }
     }
@@ -867,7 +872,7 @@ NTable::ITransactionObserverPtr TDataShardUserDb::GetReadTxObserver(const TTable
     return ptr;
 }
 
-void TDataShardUserDb::AddReadConflict(ui64 txId) const {
+void TDataShardUserDb::AddReadConflict(ui64 txId) {
     Y_ENSURE(LockTxId);
 
     // We have detected uncommitted changes in txId that could affect
@@ -876,11 +881,11 @@ void TDataShardUserDb::AddReadConflict(ui64 txId) const {
     Self.SysLocksTable().AddReadConflict(txId);
 }
 
-void TDataShardUserDb::CheckReadConflict(const TRowVersion& rowVersion) const {
+void TDataShardUserDb::CheckReadConflict(const TRowVersion& rowVersion) {
     Y_ENSURE(LockTxId);
 
-    if (rowVersion > ReadVersion) {
-        // We are reading from snapshot at ReadVersion and should not normally
+    if (rowVersion > MvccVersion) {
+        // We are reading from snapshot at MvccVersion and should not normally
         // observe changes with a version above that. However, if we have an
         // uncommitted change, that we fake as committed for our own changes
         // visibility, we might shadow some change that happened after a

--- a/ydb/core/tx/datashard/datashard_user_db.h
+++ b/ydb/core/tx/datashard/datashard_user_db.h
@@ -28,14 +28,14 @@ public:
             TArrayRef<const NTable::TTag> tags,
             NTable::TRowState& row,
             NTable::TSelectStats& stats,
-            const TMaybe<TRowVersion>& readVersion = {}) = 0;
+            const TMaybe<TRowVersion>& snapshot = {}) = 0;
 
     virtual NTable::EReady SelectRow(
             const TTableId& tableId,
             TArrayRef<const TRawTypeValue> key,
             TArrayRef<const NTable::TTag> tags,
             NTable::TRowState& row,
-            const TMaybe<TRowVersion>& readVersion = {}) = 0;
+            const TMaybe<TRowVersion>& snapshot = {}) = 0;
 
     virtual void UpsertRow(
             const TTableId& tableId,
@@ -74,16 +74,15 @@ public:
 
     virtual void CommitChanges(
             const TTableId& tableId,
-            ui64 lockId,
-            const TRowVersion& writeVersion) = 0;
+            ui64 lockId) = 0;
 };
 
 class IDataShardConflictChecker {
 protected:
     ~IDataShardConflictChecker() = default;
 public:
-    virtual void AddReadConflict(ui64 txId) const = 0;
-    virtual void CheckReadConflict(const TRowVersion& rowVersion) const = 0;
+    virtual void AddReadConflict(ui64 txId) = 0;
+    virtual void CheckReadConflict(const TRowVersion& rowVersion) = 0;
     virtual void CheckReadDependency(ui64 txId) = 0;
 
     virtual void CheckWriteConflicts(const TTableId& tableId, TArrayRef<const TCell> keyCells) = 0;
@@ -100,8 +99,7 @@ public:
             TDataShard& self,
             NTable::TDatabase& db,
             ui64 globalTxId,
-            const TRowVersion& readVersion,
-            const TRowVersion& writeVersion,
+            const TRowVersion& mvccVersion,
             NMiniKQL::TEngineHostCounters& counters, 
             TInstant now
     );
@@ -114,14 +112,14 @@ public:
             TArrayRef<const NTable::TTag> tags,
             NTable::TRowState& row,
             NTable::TSelectStats& stats,
-            const TMaybe<TRowVersion>& readVersion = {}) override;
+            const TMaybe<TRowVersion>& snapshot = {}) override;
 
     NTable::EReady SelectRow(
             const TTableId& tableId,
             TArrayRef<const TRawTypeValue> key,
             TArrayRef<const NTable::TTag> tags,
             NTable::TRowState& row,
-            const TMaybe<TRowVersion>& readVersion = {}) override;
+            const TMaybe<TRowVersion>& snapshot = {}) override;
 
     void UpsertRow(
             const TTableId& tableId,
@@ -160,8 +158,7 @@ public:
 
     void CommitChanges(
             const TTableId& tableId, 
-            ui64 lockId, 
-            const TRowVersion& writeVersion) override;
+            ui64 lockId) override;
 
 //IDataShardChangeGroupProvider
 public:  
@@ -170,8 +167,8 @@ public:
 
 //IDataShardConflictChecker
 public:  
-    void AddReadConflict(ui64 txId) const override;
-    void CheckReadConflict(const TRowVersion& rowVersion) const override;
+    void AddReadConflict(ui64 txId) override;
+    void CheckReadConflict(const TRowVersion& rowVersion) override;
     void CheckReadDependency(ui64 txId) override;
 
     void CheckWriteConflicts(const TTableId& tableId, TArrayRef<const TCell> keyCells) override;
@@ -185,7 +182,7 @@ public:
 
 public:
     bool NeedToReadBeforeWrite(const TTableId& tableId);
-    void AddCommitTxId(const TTableId& tableId, ui64 txId, const TRowVersion& commitVersion);
+    void AddCommitTxId(const TTableId& tableId, ui64 txId);
     ui64 GetWriteTxId(const TTableId& tableId);
 
     absl::flat_hash_set<ui64>& GetVolatileReadDependencies();
@@ -229,8 +226,7 @@ private:
     YDB_ACCESSOR_DEF(bool, IsWriteTx);
     YDB_ACCESSOR_DEF(bool, UsesMvccSnapshot);
 
-    YDB_ACCESSOR_DEF(TRowVersion, ReadVersion);
-    YDB_ACCESSOR_DEF(TRowVersion, WriteVersion);
+    YDB_ACCESSOR_DEF(TRowVersion, MvccVersion);
 
     YDB_READONLY_DEF(TInstant, Now);
 

--- a/ydb/core/tx/datashard/direct_tx_unit.cpp
+++ b/ydb/core/tx/datashard/direct_tx_unit.cpp
@@ -31,7 +31,7 @@ public:
 
         if (op->IsImmediate()) {
             // Every time we execute immediate transaction we may choose a new mvcc version
-            op->MvccReadWriteVersion.reset();
+            op->CachedMvccVersion.reset();
         }
 
         TDataShardLocksDb locksDb(DataShard, txc);

--- a/ydb/core/tx/datashard/execute_commit_writes_tx_unit.cpp
+++ b/ydb/core/tx/datashard/execute_commit_writes_tx_unit.cpp
@@ -34,7 +34,7 @@ public:
         TSetupSysLocks guardLocks(op, DataShard, &locksDb);
 
         const auto& commitTx = tx->GetCommitWritesTx()->GetBody();
-        const auto versions = DataShard.GetReadWriteVersions(op.Get());
+        const auto mvccVersion = DataShard.GetMvccVersion(op.Get());
 
         const auto& tableId = commitTx.GetTableId();
         const auto& tableInfo = *DataShard.GetUserTables().at(tableId.GetTableId());
@@ -44,7 +44,7 @@ public:
 
         // FIXME: temporary break all locks, but we want to be smarter about which locks we break
         DataShard.SysLocksTable().BreakAllLocks(fullTableId);
-        txc.DB.CommitTx(tableInfo.LocalTid, writeTxId, versions.WriteVersion);
+        txc.DB.CommitTx(tableInfo.LocalTid, writeTxId, mvccVersion);
         DataShard.GetConflictsCache().GetTableCache(tableInfo.LocalTid).RemoveUncommittedWrites(writeTxId, txc.DB);
 
         if (Pipeline.AddLockDependencies(op, guardLocks)) {

--- a/ydb/core/tx/datashard/execute_data_tx_unit.cpp
+++ b/ydb/core/tx/datashard/execute_data_tx_unit.cpp
@@ -68,7 +68,7 @@ EExecutionStatus TExecuteDataTxUnit::Execute(TOperation::TPtr op,
 
     if (op->IsImmediate()) {
         // Every time we execute immediate transaction we may choose a new mvcc version
-        op->MvccReadWriteVersion.reset();
+        op->CachedMvccVersion.reset();
     }
 
     TActiveTransaction* tx = dynamic_cast<TActiveTransaction*>(op.Get());
@@ -233,9 +233,8 @@ void TExecuteDataTxUnit::ExecuteDataTx(TOperation::TPtr op,
     DataShard.ReleaseCache(*tx);
     tx->GetDataTx()->ResetCounters();
 
-    auto [readVersion, writeVersion] = DataShard.GetReadWriteVersions(tx);
-    tx->GetDataTx()->SetReadVersion(readVersion);
-    tx->GetDataTx()->SetWriteVersion(writeVersion);
+    auto mvccVersion = DataShard.GetMvccVersion(tx);
+    tx->GetDataTx()->SetMvccVersion(mvccVersion);
 
     // TODO: is it required to always prepare outgoing read sets?
     if (!engine->IsAfterOutgoingReadsetsExtracted()) {
@@ -326,7 +325,7 @@ void TExecuteDataTxUnit::ExecuteDataTx(TOperation::TPtr op,
         TVector<ui64> participants; // empty participants
         DataShard.GetVolatileTxManager().PersistAddVolatileTx(
             tx->GetTxId(),
-            writeVersion,
+            mvccVersion,
             commitTxIds,
             tx->GetDataTx()->GetVolatileDependencies(),
             participants,
@@ -343,7 +342,7 @@ void TExecuteDataTxUnit::ExecuteDataTx(TOperation::TPtr op,
     AddLocksToResult(op, ctx);
 
     if (!guardLocks.LockTxId) {
-        writeVersion.ToProto(op->Result()->Record.MutableCommitVersion());
+        mvccVersion.ToProto(op->Result()->Record.MutableCommitVersion());
     }
 
     Pipeline.AddCommittingOp(op);

--- a/ydb/core/tx/datashard/execute_distributed_erase_tx_unit.cpp
+++ b/ydb/core/tx/datashard/execute_distributed_erase_tx_unit.cpp
@@ -42,16 +42,16 @@ public:
 
         const auto& eraseTx = tx->GetDistributedEraseTx();
         const auto& request = eraseTx->GetRequest();
-        auto [readVersion, writeVersion] = DataShard.GetReadWriteVersions(op.Get());
+        auto mvccVersion = DataShard.GetMvccVersion(op.Get());
 
         if (eraseTx->HasDependents()) {
             NMiniKQL::TEngineHostCounters engineHostCounters;
-            TDataShardUserDb userDb(DataShard, txc.DB, op->GetGlobalTxId(), readVersion, writeVersion, engineHostCounters, TAppData::TimeProvider->Now());
+            TDataShardUserDb userDb(DataShard, txc.DB, op->GetGlobalTxId(), mvccVersion, engineHostCounters, TAppData::TimeProvider->Now());
             TDataShardChangeGroupProvider groupProvider(DataShard, txc.DB, /* distributed tx group */ 0);
             THolder<IDataShardChangeCollector> changeCollector{CreateChangeCollector(DataShard, userDb, groupProvider, txc.DB, request.GetTableId())};
 
             auto presentRows = TDynBitMap().Set(0, request.KeyColumnsSize());
-            if (!Execute(txc, request, presentRows, eraseTx->GetConfirmedRows(), writeVersion, op->GetGlobalTxId(),
+            if (!Execute(txc, request, presentRows, eraseTx->GetConfirmedRows(), mvccVersion, op->GetGlobalTxId(),
                     &userDb, &groupProvider, changeCollector.Get()))
             {
                 return EExecutionStatus::Restart;
@@ -94,7 +94,7 @@ public:
                     Y_ENSURE(presentRows.contains(rs.Origin));
 
                     auto confirmedRows = DeserializeBitMap<TDynBitMap>(body.GetConfirmedRows());
-                    if (!Execute(txc, request, presentRows.at(rs.Origin), confirmedRows, writeVersion, op->GetGlobalTxId())) {
+                    if (!Execute(txc, request, presentRows.at(rs.Origin), confirmedRows, mvccVersion, op->GetGlobalTxId())) {
                         return EExecutionStatus::Restart;
                     }
                 }
@@ -119,7 +119,7 @@ public:
     }
 
     bool Execute(TTransactionContext& txc, const NKikimrTxDataShard::TEvEraseRowsRequest& request,
-            const TDynBitMap& presentRows, const TDynBitMap& confirmedRows, const TRowVersion& writeVersion,
+            const TDynBitMap& presentRows, const TDynBitMap& confirmedRows, const TRowVersion& mvccVersion,
             ui64 globalTxId,
             TDataShardUserDb* userDb = nullptr,
             TDataShardChangeGroupProvider* groupProvider = nullptr,
@@ -176,7 +176,7 @@ public:
                         pageFault = true;
                     }
                 } else {
-                    if (!changeCollector->OnUpdate(fullTableId, tableInfo.LocalTid, NTable::ERowOp::Erase, key, {}, writeVersion)) {
+                    if (!changeCollector->OnUpdate(fullTableId, tableInfo.LocalTid, NTable::ERowOp::Erase, key, {}, mvccVersion)) {
                         pageFault = true;
                     }
                 }
@@ -193,11 +193,11 @@ public:
                 DataShard.GetConflictsCache().GetTableCache(tableInfo.LocalTid).AddUncommittedWrite(keyCells.GetCells(), globalTxId, txc.DB);
                 if (!commitAdded && userDb) {
                     // Make sure we see our own changes on further iterations
-                    userDb->AddCommitTxId(fullTableId, globalTxId, writeVersion);
+                    userDb->AddCommitTxId(fullTableId, globalTxId);
                     commitAdded = true;
                 }
             } else {
-                txc.DB.Update(tableInfo.LocalTid, NTable::ERowOp::Erase, key, {}, writeVersion);
+                txc.DB.Update(tableInfo.LocalTid, NTable::ERowOp::Erase, key, {}, mvccVersion);
                 DataShard.GetConflictsCache().GetTableCache(tableInfo.LocalTid).RemoveUncommittedWrites(keyCells.GetCells(), txc.DB);
             }
         }
@@ -209,7 +209,7 @@ public:
         if (!volatileDependencies.empty() || volatileOrdered) {
             DataShard.GetVolatileTxManager().PersistAddVolatileTx(
                 globalTxId,
-                writeVersion,
+                mvccVersion,
                 /* commitTxIds */ { globalTxId },
                 volatileDependencies,
                 /* participants */ { },

--- a/ydb/core/tx/datashard/execute_kqp_data_tx_unit.cpp
+++ b/ydb/core/tx/datashard/execute_kqp_data_tx_unit.cpp
@@ -70,7 +70,7 @@ EExecutionStatus TExecuteKqpDataTxUnit::Execute(TOperation::TPtr op, TTransactio
 
     if (op->IsImmediate()) {
         // Every time we execute immediate transaction we may choose a new mvcc version
-        op->MvccReadWriteVersion.reset();
+        op->CachedMvccVersion.reset();
     }
 
     TActiveTransaction* tx = dynamic_cast<TActiveTransaction*>(op.Get());
@@ -238,9 +238,8 @@ EExecutionStatus TExecuteKqpDataTxUnit::Execute(TOperation::TPtr op, TTransactio
         auto execCtx = DefaultKqpExecutionContext();
         tasksRunner.Prepare(DefaultKqpDataReqMemoryLimits(), *execCtx);
 
-        auto [readVersion, writeVersion] = DataShard.GetReadWriteVersions(tx);
-        dataTx->SetReadVersion(readVersion);
-        dataTx->SetWriteVersion(writeVersion);
+        auto mvccVersion = DataShard.GetMvccVersion(tx);
+        dataTx->SetMvccVersion(mvccVersion);
 
         if (op->HasVolatilePrepareFlag()) {
             dataTx->SetVolatileTxId(txId);
@@ -250,7 +249,7 @@ EExecutionStatus TExecuteKqpDataTxUnit::Execute(TOperation::TPtr op, TTransactio
 
         const bool isArbiter = op->HasVolatilePrepareFlag() && KqpLocksIsArbiter(tabletId, kqpLocks);
 
-        KqpCommitLocks(tabletId, kqpLocks, sysLocks, writeVersion, tx->GetDataTx()->GetUserDb());
+        KqpCommitLocks(tabletId, kqpLocks, sysLocks, tx->GetDataTx()->GetUserDb());
 
         auto& computeCtx = tx->GetDataTx()->GetKqpComputeCtx();
 
@@ -354,7 +353,7 @@ EExecutionStatus TExecuteKqpDataTxUnit::Execute(TOperation::TPtr op, TTransactio
             TVector<ui64> participants(awaitingDecisions.begin(), awaitingDecisions.end());
             DataShard.GetVolatileTxManager().PersistAddVolatileTx(
                 txId,
-                writeVersion,
+                mvccVersion,
                 commitTxIds,
                 dataTx->GetVolatileDependencies(),
                 participants,
@@ -387,7 +386,7 @@ EExecutionStatus TExecuteKqpDataTxUnit::Execute(TOperation::TPtr op, TTransactio
         AddLocksToResult(op, ctx);
 
         if (!guardLocks.LockTxId) {
-            writeVersion.ToProto(op->Result()->Record.MutableCommitVersion());
+            mvccVersion.ToProto(op->Result()->Record.MutableCommitVersion());
         }
 
         if (auto changes = std::move(dataTx->GetCollectedChanges())) {

--- a/ydb/core/tx/datashard/finish_propose_unit.cpp
+++ b/ydb/core/tx/datashard/finish_propose_unit.cpp
@@ -57,11 +57,11 @@ TDataShard::TPromotePostExecuteEdges TFinishProposeUnit::PromoteImmediatePostExe
         } else {
             return DataShard.PromoteImmediatePostExecuteEdges(op->GetMvccSnapshot(), TDataShard::EPromotePostExecuteEdges::ReadOnly, txc);
         }
-    } else if (op->MvccReadWriteVersion) {
+    } else if (op->CachedMvccVersion) {
         if (op->IsReadOnly() || op->LockTxId()) {
-            return DataShard.PromoteImmediatePostExecuteEdges(*op->MvccReadWriteVersion, TDataShard::EPromotePostExecuteEdges::ReadOnly, txc);
+            return DataShard.PromoteImmediatePostExecuteEdges(*op->CachedMvccVersion, TDataShard::EPromotePostExecuteEdges::ReadOnly, txc);
         } else {
-            return DataShard.PromoteImmediatePostExecuteEdges(*op->MvccReadWriteVersion, TDataShard::EPromotePostExecuteEdges::ReadWrite, txc);
+            return DataShard.PromoteImmediatePostExecuteEdges(*op->CachedMvccVersion, TDataShard::EPromotePostExecuteEdges::ReadWrite, txc);
         }
     } else {
         return { };
@@ -198,8 +198,8 @@ void TFinishProposeUnit::CompleteRequest(TOperation::TPtr op,
             LWTRACK(ProposeTransactionSendResult, op->Orbit);
             res->Orbit = std::move(op->Orbit);
         }
-        if (op->IsImmediate() && !op->IsReadOnly() && !op->IsAborted() && op->MvccReadWriteVersion) {
-            DataShard.SendImmediateWriteResult(*op->MvccReadWriteVersion, op->GetTarget(), res.Release(), op->GetCookie(), {}, op->GetTraceId());
+        if (op->IsImmediate() && !op->IsReadOnly() && !op->IsAborted() && op->CachedMvccVersion) {
+            DataShard.SendImmediateWriteResult(*op->CachedMvccVersion, op->GetTarget(), res.Release(), op->GetCookie(), {}, op->GetTraceId());
         } else if (op->IsImmediate() && op->IsReadOnly() && !op->IsAborted()) {
             // TODO: we should actually measure a read timestamp and use it here
             DataShard.SendImmediateReadResult(op->GetTarget(), res.Release(), op->GetCookie(), {}, op->GetTraceId());

--- a/ydb/core/tx/datashard/operation.h
+++ b/ydb/core/tx/datashard/operation.h
@@ -965,7 +965,7 @@ private:
     std::optional<TRowVersion> CommittingOpsVersion;
 
 public:
-    std::optional<TRowVersion> MvccReadWriteVersion;
+    std::optional<TRowVersion> CachedMvccVersion;
 
 public:
     // Orbit used for tracking operation progress

--- a/ydb/core/tx/datashard/read_table_scan_unit.cpp
+++ b/ydb/core/tx/datashard/read_table_scan_unit.cpp
@@ -133,7 +133,7 @@ EExecutionStatus TReadTableScanUnit::Execute(TOperation::TPtr op,
         } else {
             // Note: this mode is only used in legacy tests and may not work with volatile transactions
             // With mvcc we have to mark all preceding transactions as logically complete
-            auto readVersion = DataShard.GetReadWriteVersions(tx).ReadVersion;
+            auto readVersion = DataShard.GetMvccVersion(tx);
             hadWrites |= Pipeline.MarkPlannedLogicallyCompleteUpTo(readVersion, txc);
             if (op->IsMvccSnapshotRepeatable() || !op->IsImmediate()) {
                 hadWrites |= DataShard.PromoteCompleteEdge(op.Get(), txc);

--- a/ydb/core/tx/datashard/setup_sys_locks.h
+++ b/ydb/core/tx/datashard/setup_sys_locks.h
@@ -34,17 +34,17 @@ struct TSetupSysLocks
         LockTxId = op->LockTxId();
         LockNodeId = op->LockNodeId();
 
-        auto [readVersion, writeVersion] = self.GetReadWriteVersions(op.Get());
+        auto mvccVersion = self.GetMvccVersion(op.Get());
 
         // check whether the current operation is a part of an out-of-order Tx
         bool outOfOrder = false;
         if (auto &activeOps = self.Pipeline.GetActivePlannedOps()) {
-            if (auto it = activeOps.begin(); writeVersion != TRowVersion(it->first.Step, it->first.TxId))
+            if (auto it = activeOps.begin(); mvccVersion != TRowVersion(it->first.Step, it->first.TxId))
                 outOfOrder = true;
         }
 
-        CheckVersion = readVersion;
-        BreakVersion = outOfOrder ? writeVersion : TRowVersion::Min();
+        CheckVersion = mvccVersion;
+        BreakVersion = outOfOrder ? mvccVersion : TRowVersion::Min();
 
         if (!op->LocksCache().Locks.empty())
             SysLocksTable.SetCache(&op->LocksCache());


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

...

### Changelog category <!-- remove all except one -->

* Not for changelog (changelog entry is not required)

### Description for reviewers <!-- (optional) description for those who read this PR -->

When transitioning to mvcc we used to have legacy operations which performed reads at the maximum possible version and writes at a version just above the last persistent snapshot. Datashard doesn't support these legacy modes anymore, and splitting to read and write versions no longer makes sense and introduces confusion. Operations are supposed to execute at a single consistent mvcc version.

Fixes #20429.