### PR TITLE
[asan] core/kqp/ut/tx/kqp_locks_tricky_ut: fix out-of-scope use

### DIFF
--- a/ydb/core/kqp/ut/tx/kqp_locks_tricky_ut.cpp
+++ b/ydb/core/kqp/ut/tx/kqp_locks_tricky_ut.cpp
@@ -17,6 +17,7 @@
 #include <library/cpp/json/json_reader.h>
 
 #include <util/string/printf.h>
+#include <util/generic/scope.h>
 
 
 namespace NKikimr::NKqp {
@@ -78,6 +79,9 @@ Y_UNIT_TEST_SUITE(KqpLocksTricky) {
             });
 
             auto saveObserver = runtime.SetObserverFunc(grab);
+            Y_DEFER {
+                runtime.SetObserverFunc(saveObserver);
+            }
 
             auto future = kikimr.RunInThreadPool([&]{
                 auto txc = TTxControl::BeginTx(TTxSettings::SerializableRW()).CommitTx();
@@ -125,7 +129,6 @@ Y_UNIT_TEST_SUITE(KqpLocksTricky) {
             UNIT_ASSERT_C(result.IsSuccess(), result.GetIssues().ToString());
             auto& stats = NYdb::TProtoAccessor::GetProto(*result.GetStats());
             UNIT_ASSERT_VALUES_EQUAL(stats.query_phases().size(), 2);
-            runtime.SetObserverFunc(saveObserver);
         }
     }
 
@@ -183,6 +186,9 @@ Y_UNIT_TEST_SUITE(KqpLocksTricky) {
             };
 
             auto saveObserver = runtime.SetObserverFunc(grab);
+            Y_DEFER {
+                runtime.SetObserverFunc(saveObserver);
+            }
 
             std::optional<TTransaction> tx;
 
@@ -246,7 +252,6 @@ Y_UNIT_TEST_SUITE(KqpLocksTricky) {
             auto resultSecond = runtime.WaitFuture(future);
             // select must be successful. no transaction locks invalidated issues.
             UNIT_ASSERT_C(result.IsSuccess(), result.GetIssues().ToString());
-            runtime.SetObserverFunc(saveObserver);
         }
     }
 
@@ -298,6 +303,9 @@ Y_UNIT_TEST_SUITE(KqpLocksTricky) {
             });
 
             auto saveObserver = runtime.SetObserverFunc(grab);
+            Y_DEFER {
+                runtime.SetObserverFunc(saveObserver);
+            }
 
             auto future = kikimr.RunInThreadPool([&]{
                 auto txc = TTxControl::BeginTx(TTxSettings::SerializableRW()).CommitTx();
@@ -326,7 +334,6 @@ Y_UNIT_TEST_SUITE(KqpLocksTricky) {
 
             auto result = runtime.WaitFuture(future);
             UNIT_ASSERT_VALUES_EQUAL_C(result.GetStatus(), EStatus::ABORTED, result.GetIssues().ToString());        
-            runtime.SetObserverFunc(saveObserver);
         }
     }
 }

--- a/ydb/core/kqp/ut/tx/kqp_locks_tricky_ut.cpp
+++ b/ydb/core/kqp/ut/tx/kqp_locks_tricky_ut.cpp
@@ -81,7 +81,7 @@ Y_UNIT_TEST_SUITE(KqpLocksTricky) {
             auto saveObserver = runtime.SetObserverFunc(grab);
             Y_DEFER {
                 runtime.SetObserverFunc(saveObserver);
-            }
+            };
 
             auto future = kikimr.RunInThreadPool([&]{
                 auto txc = TTxControl::BeginTx(TTxSettings::SerializableRW()).CommitTx();
@@ -188,7 +188,7 @@ Y_UNIT_TEST_SUITE(KqpLocksTricky) {
             auto saveObserver = runtime.SetObserverFunc(grab);
             Y_DEFER {
                 runtime.SetObserverFunc(saveObserver);
-            }
+            };
 
             std::optional<TTransaction> tx;
 
@@ -305,7 +305,7 @@ Y_UNIT_TEST_SUITE(KqpLocksTricky) {
             auto saveObserver = runtime.SetObserverFunc(grab);
             Y_DEFER {
                 runtime.SetObserverFunc(saveObserver);
-            }
+            };
 
             auto future = kikimr.RunInThreadPool([&]{
                 auto txc = TTxControl::BeginTx(TTxSettings::SerializableRW()).CommitTx();


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

...

### Changelog category <!-- remove all except one -->

* Not for changelog (changelog entry is not required)

### Description for reviewers <!-- (optional) description for those who read this PR -->

Triggers asan error when `grab` is called right after going out of scope

```
    #0 0x18722dd4 in NKikimr::NKqp::NTestSuiteKqpLocksTricky::TTestCaseTestNoLocksIssue<false>::Execute_(NUnitTest::TTestContext&)::'lambda'(TAutoPtr<NActors::IEventHandle, TDelete>&)::operator()(TAutoPtr<NActors::IEventHandle, TDelete>&) const /-S/contrib/ydb/core/kqp/ut/tx/kqp_locks_tricky_ut.cpp:64:21
    #1 0x3f95fa26 in std::__y1::__function::__value_func<NActors::TTestActorRuntimeBase::EEventAction (TAutoPtr<NActors::IEventHandle, TDelete> &)>::operator() /-S/contrib/libs/cxxsupp/libcxx/include/__functional/function.h:519:16
    #2 0x3f95fa26 in std::__y1::function<NActors::TTestActorRuntimeBase::EEventAction (TAutoPtr<NActors::IEventHandle, TDelete> &)>::operator() /-S/contrib/libs/cxxsupp/libcxx/include/__functional/function.h:1170:12
    #3 0x3f95fa26 in NActors::TTestActorRuntimeBase::DispatchEventsInternal(NActors::TDispatchOptions const&, TInstant) /-S/contrib/ydb/library/actors/testlib/test_runtime.cpp:1278:54
    #4 0x3f95cbd6 in NActors::TTestActorRuntimeBase::DispatchEvents /-S/contrib/ydb/library/actors/testlib/test_runtime.cpp:1083:16
    #5 0x3f95cbd6 in NActors::TTestActorRuntimeBase::DispatchEvents(NActors::TDispatchOptions const&, TDuration) /-S/contrib/ydb/library/actors/testlib/test_runtime.cpp:1078:16
    #6 0x187020f0 in bool NActors::TTestActorRuntime::WaitFuture<bool>(NThreading::TFuture<bool>, TDuration) /-S/contrib/ydb/core/testlib/actors/test_runtime.h:80:23
    #7 0x18712568 in TCallableTraits<NKikimr::NKqp::TKikimrRunner::~TKikimrRunner()::'lambda'()>::TResult NKikimr::NKqp::TKikimrRunner::RunCall<NKikimr::NKqp::TKikimrRunner::~TKikimrRunner()::'lambda'()>(NKikimr::NKqp::TKikimrRunner::~TKikimrRunner()::'lambda'()&&) /-S/contrib/ydb/core/kqp/ut/common/kqp_ut_common.h:184:46
    #8 0x186f6a60 in NKikimr::NKqp::TKikimrRunner::~TKikimrRunner() /-S/contrib/ydb/core/kqp/ut/common/kqp_ut_common.h:141:9
    #9 0x18718379 in NKikimr::NKqp::NTestSuiteKqpLocksTricky::TTestCaseTestNoLocksIssue<false>::Execute_(NUnitTest::TTestContext&) /-S/contrib/ydb/core/kqp/ut/tx/kqp_locks_tricky_ut.cpp:128:5
    #10 0x186ebcc8 in NKikimr::NKqp::NTestSuiteKqpLocksTricky::TCurrentTest::Execute()::(anonymous class)::operator() /-S/contrib/ydb/core/kqp/ut/tx/kqp_locks_tricky_ut.cpp:30:1
    #11 0x186ebcc8 in std::__y1::__invoke<(lambda at /-S/contrib/ydb/core/kqp/ut/tx/kqp_locks_tricky_ut.cpp:30:1) &> /-S/contrib/libs/cxxsupp/libcxx/include/__type_traits/invoke.h:344:25
    #12 0x186ebcc8 in std::__y1::__invoke_void_return_wrapper<void, true>::__call<(lambda at /-S/contrib/ydb/core/kqp/ut/tx/kqp_locks_tricky_ut.cpp:30:1) &> /-S/contrib/libs/cxxsupp/libcxx/include/__type_traits/invoke.h:419:5
    #13 0x186ebcc8 in std::__y1::__function::__alloc_func<(lambda at /-S/contrib/ydb/core/kqp/ut/tx/kqp_locks_tricky_ut.cpp:30:1), std::__y1::allocator<(lambda at /-S/contrib/ydb/core/kqp/ut/tx/kqp_locks_tricky_ut.cpp:30:1)>, void ()>::operator() /-S/contrib/libs/cxxsupp/libcxx/include/__functional/function.h:195:16
    #14 0x186ebcc8 in std::__y1::__function::__func<NKikimr::NKqp::NTestSuiteKqpLocksTricky::TCurrentTest::Execute()::'lambda'(), std::__y1::allocator<NKikimr::NKqp::NTestSuiteKqpLocksTricky::TCurrentTest::Execute()::'lambda'()>, void ()>::operator()() /-S/contrib/libs/cxxsupp/libcxx/include/__functional/function.h:366:12
    #15 0x190ef3fa in std::__y1::__function::__value_func<void ()>::operator() /-S/contrib/libs/cxxsupp/libcxx/include/__functional/function.h:519:16
    #16 0x190ef3fa in std::__y1::function<void ()>::operator() /-S/contrib/libs/cxxsupp/libcxx/include/__functional/function.h:1170:12
    #17 0x190ef3fa in TColoredProcessor::Run(std::__y1::function<void ()>, TBasicString<char, std::__y1::char_traits<char>> const&, char const*, bool) /-S/library/cpp/testing/unittest/utmain.cpp:525:20
    #18 0x190af6a5 in NUnitTest::TTestBase::Run(std::__y1::function<void ()>, TBasicString<char, std::__y1::char_traits<char>> const&, char const*, bool) /-S/library/cpp/testing/unittest/registar.cpp:374:18
    #19 0x186ea5f3 in NKikimr::NKqp::NTestSuiteKqpLocksTricky::TCurrentTest::Execute() /-S/contrib/ydb/core/kqp/ut/tx/kqp_locks_tricky_ut.cpp:30:1
    #20 0x190b13e9 in NUnitTest::TTestFactory::Execute() /-S/library/cpp/testing/unittest/registar.cpp:495:19
    #21 0x190e786c in NUnitTest::RunMain(int, char**) /-S/library/cpp/testing/unittest/utmain.cpp:872:44
    #22 0x7f07b779a082 in __libc_start_main /build/glibc-LcI20x/glibc-2.31/csu/../csu/libc-start.c:308:16
    #23 0x15f3a028 in _start (/storage/d/b/4246e557-53b0b568-9a3a4781-9cccb-0/0e/test-14738688063944032560-2AC/2f74/contrib/ydb/core/kqp/ut/tx/contrib-ydb-core-kqp-ut-tx+0x15f3a028) (BuildId: 8a0f23a41fd82bdcac39c65756d388d5ef0acb67)
Address 0x7f07b5546de0 is located in stack of thread T0 at offset 3552 in frame
    #0 0x1871488f in NKikimr::NKqp::NTestSuiteKqpLocksTricky::TTestCaseTestNoLocksIssue<false>::Execute_(NUnitTest::TTestContext&) /-S/contrib/ydb/core/kqp/ut/tx/kqp_locks_tricky_ut.cpp:32
```