### PR TITLE
Independent limits of unavailable nodes for each piles

### DIFF
--- a/ydb/core/cms/cluster_info.h
+++ b/ydb/core/cms/cluster_info.h
@@ -655,13 +655,15 @@ public:
     using TPDisks = THashMap<TPDiskID, TPDiskInfoPtr, TPDiskIDHash>;
     using TVDisks = THashMap<TVDiskID, TVDiskInfoPtr>;
     using TBSGroups = THashMap<ui32, TBSGroupInfo>;
+    using TPileId = ui32;
 
-    using TenantNodesCheckers = THashMap<TString, TSimpleSharedPtr<TNodesLimitsCounterBase>>;
+    using TTenantNodesCheckers = THashMap<TString, TSimpleSharedPtr<TNodesLimitsCounterBase>>;
+    using TClusterPilesNodesCheckers = THashMap<TPileId, TSimpleSharedPtr<TClusterLimitsCounter>>;
 
     friend TOperationLogManager;
 
-    TenantNodesCheckers TenantNodesChecker;
-    TSimpleSharedPtr<TClusterLimitsCounter> ClusterNodes = MakeSimpleShared<TClusterLimitsCounter>(0u, 0u);
+    THashMap<TPileId, TTenantNodesCheckers> TenantNodesChecker;
+    TClusterPilesNodesCheckers ClusterNodes = {{0, MakeSimpleShared<TClusterLimitsCounter>(0u, 0u)}};
 
     TOperationLogManager LogManager;
     TOperationLogManager ScheduledLogManager;
@@ -1036,11 +1038,12 @@ private:
     THashMap<ui32, ui32> StateStorageNodeToRingId;
 
 public:
+    using TSysNodesCheckers = THashMap<NKikimrConfig::TBootstrap::ETabletType, TSimpleSharedPtr<TSysTabletsNodesCounter>>;
     bool IsLocalBootConfDiffersFromConsole = false;
     NKikimrConfig::TBootstrap BootstrapConfig;
     THashMap<ui32, TVector<NKikimrConfig::TBootstrap::ETabletType>> NodeToTabletTypes;
 
-    THashMap<NKikimrConfig::TBootstrap::ETabletType, TSimpleSharedPtr<TSysTabletsNodesCounter>> SysNodesCheckers;
+    THashMap<TPileId, TSysNodesCheckers> SysNodesCheckers;
 
     TIntrusiveConstPtr<TStateStorageInfo> StateStorageInfo;
     TVector<TVector<TStateStorageRingInfoPtr>> StateStorageRings;

--- a/ydb/core/cms/cluster_info.h
+++ b/ydb/core/cms/cluster_info.h
@@ -663,7 +663,7 @@ public:
     friend TOperationLogManager;
 
     THashMap<TPileId, TTenantNodesCheckers> TenantNodesChecker;
-    TClusterPilesNodesCheckers ClusterNodes = {{0, MakeSimpleShared<TClusterLimitsCounter>(0u, 0u)}};
+    TClusterPilesNodesCheckers ClusterNodes;
 
     TOperationLogManager LogManager;
     TOperationLogManager ScheduledLogManager;
@@ -682,6 +682,7 @@ public:
 
     void GenerateTenantNodesCheckers();
     void GenerateSysTabletsNodesCheckers();
+    void GenerateClusterNodesCheckers();
 
     bool IsStateStorageReplicaNode(ui32 nodeId) {
         return StateStorageReplicas.contains(nodeId);
@@ -1048,7 +1049,6 @@ public:
     TIntrusiveConstPtr<TStateStorageInfo> StateStorageInfo;
     TVector<TVector<TStateStorageRingInfoPtr>> StateStorageRings;
 
-    std::vector<NKikimr::TBridgeInfo::TPile> Piles;
     THashMap<ui32, ui32> NodeIdToPileId;
     bool IsBridgeMode = false;
 };

--- a/ydb/core/cms/cms.cpp
+++ b/ydb/core/cms/cms.cpp
@@ -1777,6 +1777,8 @@ void TCms::Handle(TEvPrivate::TEvClusterInfo::TPtr &ev, const TActorContext &ctx
     if (!AppData(ctx)->DisableCheckingSysNodesCms)
         info->GenerateSysTabletsNodesCheckers();
 
+    info->GenerateClusterNodesCheckers();
+
     AdjustInfo(info, ctx);
 
     State->ClusterInfo = info;

--- a/ydb/core/cms/cms.cpp
+++ b/ydb/core/cms/cms.cpp
@@ -155,7 +155,6 @@ void TCms::GenerateNodeState(IOutputStream& out)
         totalVDisksRestart += nodeVDisksStatusMap[node.first].Restart;
     }
 
-    const auto& nodeState = ClusterInfo->ClusterNodes->GetNodeToState();
     HTML(out) {
         TAG(TH3) {
             out << "Nodes with state";
@@ -198,6 +197,7 @@ void TCms::GenerateNodeState(IOutputStream& out)
             TABLEBODY() {
                 for (const auto& node : ClusterInfo->AllNodes()) {
                     auto currentInMemoryState = INodesChecker::NODE_STATE_UNSPECIFIED;
+                    const auto& nodeState = ClusterInfo->ClusterNodes[node.second->PileId.GetOrElse(0)]->GetNodeToState();
                     if (nodeState.contains(node.first)) {
                         currentInMemoryState = nodeState.at(node.first);
                     }
@@ -821,7 +821,7 @@ bool TCms::CheckSysTabletsNode(const TActionOptions &opts,
     }
 
     for (auto &tabletType : ClusterInfo->NodeToTabletTypes[node.NodeId]) {
-        if (!ClusterInfo->SysNodesCheckers[tabletType]->TryToLockNode(node.NodeId, opts.AvailabilityMode, error.Reason)) {
+        if (!ClusterInfo->SysNodesCheckers[node.PileId.GetOrElse(0)][tabletType]->TryToLockNode(node.NodeId, opts.AvailabilityMode, error.Reason)) {
             error.Code = TStatus::DISALLOW_TEMP;
             error.Deadline = TActivationContext::Now() + State->Config.DefaultRetryTime;
             return false;
@@ -839,7 +839,7 @@ bool TCms::TryToLockNode(const TAction& action,
     TDuration duration = TDuration::MicroSeconds(action.GetDuration());
     duration += opts.PermissionDuration;
 
-    if (!ClusterInfo->ClusterNodes->TryToLockNode(node.NodeId, opts.AvailabilityMode, error.Reason)) {
+    if (!ClusterInfo->ClusterNodes[node.PileId.GetOrElse(0)]->TryToLockNode(node.NodeId, opts.AvailabilityMode, error.Reason)) {
         error.Code = TStatus::DISALLOW_TEMP;
         error.Deadline = TActivationContext::Now() + State->Config.DefaultRetryTime;
         return false;
@@ -847,7 +847,7 @@ bool TCms::TryToLockNode(const TAction& action,
 
     if (node.Tenant
         && opts.TenantPolicy != NONE
-        && !ClusterInfo->TenantNodesChecker[node.Tenant]->TryToLockNode(node.NodeId, opts.AvailabilityMode, error.Reason))
+        && !ClusterInfo->TenantNodesChecker[node.PileId.GetOrElse(0)][node.Tenant]->TryToLockNode(node.NodeId, opts.AvailabilityMode, error.Reason))
     {
         error.Code = TStatus::DISALLOW_TEMP;
         error.Deadline = TActivationContext::Now() + State->Config.DefaultRetryTime;


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

...

### Changelog category <!-- remove all except one -->

* Not for changelog (changelog entry is not required)

### Description for reviewers <!-- (optional) description for those who read this PR -->

- Реализация этого комментария: https://github.com/ydb-platform/ydb/pull/20327#issuecomment-3024274025
В этом pr ноды в счетчиках изолируются от других pile'ов за счет оборачивания всех счетчиков в `THashMap<TPileId, ...>`. В предыдущем - прокидывал `NodeIdToPileId` во все счетчики и уже внутри методов делал проверку в каком pile находится нода
- Убрал запрос в `NodeWarden` - оказался ненужным
