### PR TITLE
Fix unexpected unique constraint violation errors from datashards

### DIFF
--- a/ydb/core/kqp/executer_actor/kqp_executer_impl.h
+++ b/ydb/core/kqp/executer_actor/kqp_executer_impl.h
@@ -1001,7 +1001,6 @@ protected:
                 ActorIdToProto(BufferActorId, settings.MutableBufferActorId());
             }
             if (!settings.GetInconsistentTx()
-                    && TasksGraph.GetMeta().LockMode == NKikimrDataEvents::OPTIMISTIC_SNAPSHOT_ISOLATION
                     && GetSnapshot().IsValid()) {
                 settings.MutableMvccSnapshot()->SetStep(GetSnapshot().Step);
                 settings.MutableMvccSnapshot()->SetTxId(GetSnapshot().TxId);

--- a/ydb/core/kqp/runtime/kqp_write_actor.cpp
+++ b/ydb/core/kqp/runtime/kqp_write_actor.cpp
@@ -137,6 +137,14 @@ namespace {
             transaction.AddReceivingShards(*prepareSettings.ArbiterColumnShard);
         }
     }
+
+    std::optional<NKikimrDataEvents::TMvccSnapshot> GetOptionalMvccSnapshot(const NKikimrKqp::TKqpTableSinkSettings& settings) {
+        if (settings.HasMvccSnapshot()) {
+            return settings.GetMvccSnapshot();
+        } else {
+            return std::nullopt;
+        }
+    }
 }
 
 
@@ -1417,7 +1425,7 @@ public:
                 Settings.GetIsOlap(),
                 std::move(keyColumnTypes),
                 Alloc,
-                Settings.GetMvccSnapshot(),
+                GetOptionalMvccSnapshot(Settings),
                 Settings.GetLockMode(),
                 nullptr,
                 TActorId{},
@@ -3244,7 +3252,7 @@ private:
                     .LockTxId = Settings.GetLockTxId(),
                     .LockNodeId = Settings.GetLockNodeId(),
                     .InconsistentTx = Settings.GetInconsistentTx(),
-                    .MvccSnapshot = Settings.GetMvccSnapshot(),
+                    .MvccSnapshot = GetOptionalMvccSnapshot(Settings),
                     .LockMode = Settings.GetLockMode(),
                 },
                 .Priority = Settings.GetPriority(),

--- a/ydb/core/tx/datashard/datashard_pipeline.cpp
+++ b/ydb/core/tx/datashard/datashard_pipeline.cpp
@@ -1685,7 +1685,8 @@ TOperation::TPtr TPipeline::BuildOperation(NEvents::TDataEvents::TEvWrite::TPtr&
 {
     const auto& rec = ev->Get()->Record;
     TBasicOpInfo info(rec.GetTxId(), EOperationKind::WriteTx, NEvWrite::TConvertor::GetProposeFlags(rec.GetTxMode()), 0, receivedAt, tieBreakerIndex);
-    if (rec.HasMvccSnapshot()) {
+    // Uncommitted writes are performed over a consistent mvcc snapshot
+    if (rec.HasMvccSnapshot() && rec.GetLockTxId()) {
         info.SetMvccSnapshot(TRowVersion(rec.GetMvccSnapshot().GetStep(), rec.GetMvccSnapshot().GetTxId()),
             rec.GetMvccSnapshot().GetRepeatableRead());
     }
@@ -1699,9 +1700,9 @@ TOperation::TPtr TPipeline::BuildOperation(NEvents::TDataEvents::TEvWrite::TPtr&
         LOG_ERROR_S(TActivationContext::AsActorContext(), NKikimrServices::TX_DATASHARD, error);
     };
 
-    if (rec.HasMvccSnapshot() && !rec.GetLockTxId()) {
+    if (rec.GetLockMode() != NKikimrDataEvents::OPTIMISTIC) {
         badRequest(NKikimrDataEvents::TEvWriteResult::STATUS_BAD_REQUEST,
-            "MvccSnapshot without LockTxId is not implemented");
+            "Only OPTIMISTIC lock mode is currently implemented");
         return writeOp;
     }
 

--- a/ydb/core/tx/datashard/datashard_user_db.h
+++ b/ydb/core/tx/datashard/datashard_user_db.h
@@ -241,6 +241,25 @@ private:
 
     YDB_ACCESSOR_DEF(bool, PerformedUserReads);
 
+    // Becomes true when user-visible reads detect changes over MvccVersion, i.e.
+    // if we would have performed this read under a lock, it would have been broken.
+    YDB_READONLY(bool, MvccReadConflict, false);
+
+    // At commit time we have MvccVersion equal to the commit version, however
+    // when transaction has a snapshot it should behave as if all reads are
+    // performed at the snapshot version. This snapshot version is not used
+    // for reads (we optimistically read from commit version at commit time to
+    // minimize conflicts), however encountering errors which prevent the
+    // transaction from committing having conflicts with the snapshot indicate
+    // it should behave as if an imaginary lock was broken instread.
+    YDB_ACCESSOR(TRowVersion, SnapshotVersion, TRowVersion::Max());
+    // Becomes true when reads detect there have been committed changes between
+    // the snapshot version and the commit version.
+    YDB_READONLY(bool, SnapshotReadConflict, false);
+    // Becomes true when writes detect there have been committed changes between
+    // the snapshot version and the commit version.
+    YDB_READONLY(bool, SnapshotWriteConflict, false);
+
     NMiniKQL::TEngineHostCounters& Counters;
 };
 

--- a/ydb/core/tx/datashard/datashard_ut_common_kqp.h
+++ b/ydb/core/tx/datashard/datashard_ut_common_kqp.h
@@ -228,8 +228,8 @@ namespace NKqpHelpers {
         return SendRequest(runtime, MakeSimpleRequestRPC(query, sessionId, txId, true /* commitTx */));
     }
 
-    inline TString KqpSimpleCommit(TTestActorRuntime& runtime, const TString& sessionId, const TString& txId, const TString& query) {
-        auto response = AwaitResponse(runtime, KqpSimpleSendCommit(runtime, sessionId, txId, query));
+    inline TString KqpSimpleWaitCommit(TTestActorRuntime& runtime, NThreading::TFuture<Ydb::Table::ExecuteDataQueryResponse> future) {
+        auto response = AwaitResponse(runtime, std::move(future));
         if (response.operation().status() != Ydb::StatusIds::SUCCESS) {
             return TStringBuilder() << "ERROR: " << response.operation().status();
         }
@@ -237,6 +237,10 @@ namespace NKqpHelpers {
         response.operation().result().UnpackTo(&result);
         Y_ENSURE(result.tx_meta().id().empty(), "must be empty transaction");
         return FormatResult(result);
+    }
+
+    inline TString KqpSimpleCommit(TTestActorRuntime& runtime, const TString& sessionId, const TString& txId, const TString& query) {
+        return KqpSimpleWaitCommit(runtime, KqpSimpleSendCommit(runtime, sessionId, txId, query));
     }
 
     inline Ydb::Table::ExecuteSchemeQueryRequest MakeSchemeRequestRPC(

--- a/ydb/core/tx/datashard/datashard_write_operation.cpp
+++ b/ydb/core/tx/datashard/datashard_write_operation.cpp
@@ -57,6 +57,10 @@ TValidatedWriteTx::TValidatedWriteTx(TDataShard* self, ui64 globalTxId, TInstant
         LockNodeId = record.GetLockNodeId();
     }
 
+    if (record.HasMvccSnapshot()) {
+        MvccSnapshot.emplace(record.GetMvccSnapshot().GetStep(), record.GetMvccSnapshot().GetTxId());
+    }
+
     OverloadSubscribe = record.HasOverloadSubscribe() ? record.GetOverloadSubscribe() : std::optional<ui64>{};
 
     NKikimrTxDataShard::TKqpTransaction::TDataTaskMeta meta;

--- a/ydb/core/tx/datashard/datashard_write_operation.h
+++ b/ydb/core/tx/datashard/datashard_write_operation.h
@@ -132,6 +132,7 @@ private:
     YDB_READONLY_DEF(TInstant, ReceivedAt);
     YDB_READONLY_DEF(std::optional<ui64>, OverloadSubscribe);
     YDB_READONLY_DEF(bool, MvccSnapshotRead);
+    YDB_READONLY_DEF(std::optional<TRowVersion>, MvccSnapshot);
 
     YDB_READONLY_DEF(ui64, TxSize);
 

--- a/ydb/core/tx/datashard/execute_write_unit.cpp
+++ b/ydb/core/tx/datashard/execute_write_unit.cpp
@@ -157,9 +157,17 @@ public:
     }
 
     EExecutionStatus OnUniqueConstrainException(TDataShardUserDb& userDb, TWriteOperation& writeOp, TTransactionContext& txc, const TActorContext& ctx) {
-        if (CheckForVolatileReadDependencies(userDb, writeOp, txc, ctx)) 
+        if (CheckForVolatileReadDependencies(userDb, writeOp, txc, ctx)) {
             return EExecutionStatus::Continue;
-        
+        }
+
+        if (userDb.GetSnapshotReadConflict()) {
+            LOG_TRACE_S(ctx, NKikimrServices::TX_DATASHARD, "Operation " << writeOp << " at " << DataShard.TabletID() << " aborting. Conflict with another transaction.");
+            writeOp.SetError(NKikimrDataEvents::TEvWriteResult::STATUS_LOCKS_BROKEN, "Read conflict with concurrent transaction.");
+            ResetChanges(userDb, writeOp, txc);
+            return EExecutionStatus::Executed;
+        }
+
         LOG_TRACE_S(ctx, NKikimrServices::TX_DATASHARD, "Operation " << writeOp << " at " << DataShard.TabletID() << " aborting. Conflict with existing key.");
         writeOp.SetError(NKikimrDataEvents::TEvWriteResult::STATUS_CONSTRAINT_VIOLATION, "Conflict with existing key.");
         ResetChanges(userDb, writeOp, txc);
@@ -310,7 +318,7 @@ public:
         NMiniKQL::TEngineHostCounters engineHostCounters;
         const ui64 txId = writeTx->GetTxId();
         const auto mvccVersion = DataShard.GetMvccVersion(writeOp);
-        
+
         TDataShardUserDb userDb(DataShard, txc.DB, op->GetGlobalTxId(), mvccVersion, engineHostCounters, TAppData::TimeProvider->Now());
         userDb.SetIsWriteTx(true);
         userDb.SetIsImmediateTx(op->IsImmediate());
@@ -319,6 +327,11 @@ public:
 
         if (op->HasVolatilePrepareFlag()) {
             userDb.SetVolatileTxId(txId);
+        }
+
+        auto mvccSnapshot = writeTx->GetMvccSnapshot();
+        if (mvccSnapshot && !writeTx->GetLockTxId()) {
+            userDb.SetSnapshotVersion(*mvccSnapshot);
         }
 
         try {


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

...

### Changelog category <!-- remove all except one -->

* Not for changelog (changelog entry is not required)

### Description for reviewers <!-- (optional) description for those who read this PR -->

This patch fixes unexpected unique constraint errors when duplicate key is committed after a transaction acquires its read snapshot. A couple of tests are added: one ensures transaction fails with an ABORTED error when INSERT is performed before the commit, another when INSERT is performed together with the commit (behavior changes when KQP doesn't force flush INSERT before the commit).

To work correctly datashards need MvccSnapshot specified now, so it can make sure writes are performed over the correct version. I found out that EvWrite didn't work correctly when writing over a snapshot (which is chosen by datashard even when MvccSnapshot is not specified), and could produce inconsistent results when more recent changes are present. This could affect CDC and async index correctness.

I'm marking this as "not for changelog" since EvWrite is not enabled in production yet.

Fixes #19531.