### PR TITLE
Support quorum of specific bridge pile ids when changing cluster state in Bridge mode

### DIFF
--- a/ydb/core/blobstorage/nodewarden/distconf.cpp
+++ b/ydb/core/blobstorage/nodewarden/distconf.cpp
@@ -260,7 +260,7 @@ namespace NKikimr::NStorage {
         Y_ABORT_UNLESS(!InitialConfig->GetFingerprint() || CheckFingerprint(*InitialConfig));
 
         if (Scepter) {
-            Y_ABORT_UNLESS(StorageConfig && HasQuorum(*StorageConfig));
+            Y_ABORT_UNLESS(StorageConfig && HasConnectedNodeQuorum(*StorageConfig));
             Y_ABORT_UNLESS(RootState != ERootState::INITIAL && RootState != ERootState::ERROR_TIMEOUT);
             Y_ABORT_UNLESS(!Binding);
         } else {

--- a/ydb/core/blobstorage/nodewarden/distconf.h
+++ b/ydb/core/blobstorage/nodewarden/distconf.h
@@ -379,7 +379,8 @@ namespace NKikimr::NStorage {
         void CheckIfDone();
         void HandleErrorTimeout();
         void ProcessGather(TEvGather *res);
-        bool HasQuorum(const NKikimrBlobStorage::TStorageConfig& config) const;
+        bool HasConnectedNodeQuorum(const NKikimrBlobStorage::TStorageConfig& config,
+            const THashSet<TBridgePileId>& specificBridgePileIds = {}) const;
         void ProcessCollectConfigs(TEvGather::TCollectConfigs *res);
 
         struct TProcessCollectConfigsResult {
@@ -389,7 +390,8 @@ namespace NKikimr::NStorage {
         TProcessCollectConfigsResult ProcessCollectConfigs(TEvGather::TCollectConfigs *res,
             std::optional<TStringBuf> selfAssemblyUUID);
 
-        std::optional<TString> ProcessProposeStorageConfig(TEvGather::TProposeStorageConfig *res);
+        std::optional<TString> ProcessProposeStorageConfig(TEvGather::TProposeStorageConfig *res,
+            const THashSet<TBridgePileId>& specificBridgePileIds);
 
         struct TExConfigError : yexception {};
 

--- a/ydb/core/blobstorage/nodewarden/distconf_bridge.cpp
+++ b/ydb/core/blobstorage/nodewarden/distconf_bridge.cpp
@@ -184,7 +184,7 @@ namespace NKikimr::NStorage {
     }
 
     void TDistributedConfigKeeper::IssueQuerySyncers() {
-        if (!Cfg->BridgeConfig) {
+        if (!Cfg->BridgeConfig || !Scepter) {
             return;
         }
         if (!SyncerArrangeInFlight) {

--- a/ydb/core/blobstorage/nodewarden/distconf_connectivity.cpp
+++ b/ydb/core/blobstorage/nodewarden/distconf_connectivity.cpp
@@ -50,6 +50,9 @@ namespace NKikimr::NStorage {
                         if (pile.State != NKikimrBridge::TClusterState::DISCONNECTED) {
                             continue;
                         }
+                        if (pile.BridgePileId == BridgeInfo->SelfNodePile->BridgePileId) {
+                            continue; // do not disconnect from the same pile
+                        }
                         for (const ui32 nodeId : pile.StaticNodeIds) {
                             STLOG(PRI_DEBUG, BS_NODE, NWDCC00, "disconnecting", (PeerNodeId, nodeId),
                                 (BridgePileId, pile.BridgePileId));
@@ -100,10 +103,9 @@ namespace NKikimr::NStorage {
                 std::optional<TString> error;
 
                 if (BridgeInfo) {
-                    if (const auto *pile = BridgeInfo->GetPileForNode(ev->Get()->PeerNodeId)) {
-                        if (pile->State == NKikimrBridge::TClusterState::DISCONNECTED) {
-                            error = "can't establish connection to node belonging to disconnected pile";
-                        }
+                    if (const auto *pile = BridgeInfo->GetPileForNode(ev->Get()->PeerNodeId); pile &&
+                            pile != BridgeInfo->SelfNodePile && pile->State == NKikimrBridge::TClusterState::DISCONNECTED) {
+                        error = "can't establish connection to node belonging to disconnected pile";
                     } else {
                         // dynamic node?
                     }
@@ -194,7 +196,7 @@ namespace NKikimr::NStorage {
             std::optional<TString> CheckPeerConfig(TBridgePileId peerBridgePileId,
                     const NKikimrBlobStorage::TStorageConfig& config) {
                 const auto *peerPile = BridgeInfo->GetPile(peerBridgePileId);
-                if (peerPile->State == NKikimrBridge::TClusterState::DISCONNECTED) {
+                if (peerPile->State == NKikimrBridge::TClusterState::DISCONNECTED && peerPile != BridgeInfo->SelfNodePile) {
                     // peer pile is considered disconnected according to our config; this is incoming connection and we
                     // should definitely drop it
                     return "can't establish connection to node belonging to disconnected pile -- remote disconnected";

--- a/ydb/core/blobstorage/nodewarden/distconf_invoke.h
+++ b/ydb/core/blobstorage/nodewarden/distconf_invoke.h
@@ -29,6 +29,9 @@ namespace NKikimr::NStorage {
 
         std::shared_ptr<TLifetimeToken> RequestHandlerToken = std::make_shared<TLifetimeToken>();
 
+        THashSet<TBridgePileId> SpecificBridgePileIds;
+        std::optional<NKikimrBlobStorage::TStorageConfig> SwitchBridgeNewConfig;
+
     public:
         TInvokeRequestHandlerActor(TDistributedConfigKeeper *self, std::unique_ptr<TEventHandle<TEvNodeConfigInvokeOnRoot>>&& ev);
 
@@ -126,9 +129,9 @@ namespace NKikimr::NStorage {
         ////////////////////////////////////////////////////////////////////////////////////////////////////////////////
         // Bridge mode
 
-        void SwitchBridgeClusterState(const NKikimrBridge::TClusterState& newClusterState);
+        std::optional<TString> ValidateSwitchBridgeClusterState(const NKikimrBridge::TClusterState& newClusterState);
+        void SwitchBridgeClusterState();
         NKikimrBlobStorage::TStorageConfig GetSwitchBridgeNewConfig(const NKikimrBridge::TClusterState& newClusterState);
-        bool CheckSwitchBridgeCommand();
 
         void NotifyBridgeSyncFinished(const TQuery::TNotifyBridgeSyncFinished& cmd);
 

--- a/ydb/core/blobstorage/nodewarden/distconf_mon.cpp
+++ b/ydb/core/blobstorage/nodewarden/distconf_mon.cpp
@@ -139,7 +139,7 @@ namespace NKikimr::NStorage {
                 {"direct_bound_nodes", getDirectBoundNodes()},
                 {"root_state", TString(TStringBuilder() << RootState)},
                 {"error_reason", ErrorReason},
-                {"has_quorum", StorageConfig && HasQuorum(*StorageConfig)},
+                {"has_quorum", StorageConfig && HasConnectedNodeQuorum(*StorageConfig)},
                 {"scepter", Scepter ? NJson::TJsonMap{
                     {"id", Scepter->Id},
                 } : NJson::TJsonValue{NJson::JSON_NULL}},
@@ -231,7 +231,7 @@ namespace NKikimr::NStorage {
                         if (ErrorReason) {
                            out << "ErrorReason: " << ErrorReason << "<br/>";
                         }
-                        out << "Quorum: " << (StorageConfig && HasQuorum(*StorageConfig) ? "yes" : "no") << "<br/>";
+                        out << "Quorum: " << (StorageConfig && HasConnectedNodeQuorum(*StorageConfig) ? "yes" : "no") << "<br/>";
                         out << "Scepter: " << (Scepter ? ToString(Scepter->Id) : "null") << "<br/>";
                     }
                 }

--- a/ydb/core/grpc_services/rpc_bridge.cpp
+++ b/ydb/core/grpc_services/rpc_bridge.cpp
@@ -207,7 +207,11 @@ public:
         newClusterState.SetGeneration(currentClusterState.GetGeneration() + 1);
 
         auto request = std::make_unique<NStorage::TEvNodeConfigInvokeOnRoot>();
-        request->Record.MutableSwitchBridgeClusterState()->MutableNewClusterState()->CopyFrom(newClusterState);
+        auto *cmd = request->Record.MutableSwitchBridgeClusterState();
+        cmd->MutableNewClusterState()->CopyFrom(newClusterState);
+        for (ui32 specificBridgePileId : GetProtoRequest()->specific_pile_ids()) {
+            cmd->AddSpecificBridgePileIds(specificBridgePileId);
+        }
 
         self->ActorContext().Send(MakeBlobStorageNodeWardenID(self->SelfId().NodeId()), request.release());
         self->Become(&TThis::StateWaitForPropose);

--- a/ydb/core/protos/blobstorage_distributed_config.proto
+++ b/ydb/core/protos/blobstorage_distributed_config.proto
@@ -262,6 +262,7 @@ message TEvNodeConfigInvokeOnRoot {
 
     message TSwitchBridgeClusterState {
         NKikimrBridge.TClusterState NewClusterState = 1;
+        repeated uint32 SpecificBridgePileIds = 2; // obtain quorum only for specific pile set
     }
 
     message TNotifyBridgeSyncFinished {

--- a/ydb/public/api/protos/draft/ydb_bridge.proto
+++ b/ydb/public/api/protos/draft/ydb_bridge.proto
@@ -41,6 +41,8 @@ message UpdateClusterStateRequest {
     Ydb.Operations.OperationParams operation_params = 1;
     // List of desired pile states to update
     repeated PileStateUpdate updates = 2;
+    // If set, acquire quorum only for specific pile(s)
+    repeated uint32 specific_pile_ids = 3;
 }
 
 message UpdateClusterStateResponse {

--- a/ydb/public/lib/ydb_cli/commands/ydb_bridge.cpp
+++ b/ydb/public/lib/ydb_cli/commands/ydb_bridge.cpp
@@ -69,6 +69,10 @@ void TCommandBridgeUpdate::Config(TConfig& config) {
         .RequiredArgument("ID:STATE").Handler([this](const TString& value) {
             PileStateUpdates.push_back(value);
         });
+    config.Opts->AddLongOption("specific-pile-id", "Acquire quorum only for specific set of piles. Can be used multiple times.")
+        .RequiredArgument("ID").Handler([this](const TString& value) {
+            SpecificPileIds.push_back(FromString(value));
+        });
     config.Opts->AddLongOption('f', "file", "Path to a JSON file with state updates.")
         .RequiredArgument("PATH").StoreResult(&FilePath);
     config.Opts->MutuallyExclusive("set", "file");
@@ -124,7 +128,7 @@ int TCommandBridgeUpdate::Run(TConfig& config) {
     auto driver = std::make_unique<TDriver>(CreateDriver(config));
     auto client = NYdb::NBridge::TBridgeClient(*driver);
 
-    auto result = client.UpdateClusterState(Updates).GetValueSync();
+    auto result = client.UpdateClusterState(Updates, SpecificPileIds).GetValueSync();
     NStatusHelpers::ThrowOnErrorOrPrintIssues(result);
 
     Cout << "Cluster state updated successfully." << Endl;

--- a/ydb/public/lib/ydb_cli/commands/ydb_bridge.h
+++ b/ydb/public/lib/ydb_cli/commands/ydb_bridge.h
@@ -29,6 +29,7 @@ private:
     TString FilePath;
 
     std::vector<NYdb::NBridge::TPileStateUpdate> Updates;
+    std::vector<std::uint32_t> SpecificPileIds;
 };
 
 class TCommandBridgeGet : public TYdbReadOnlyCommand, public TCommandWithOutput {

--- a/ydb/public/sdk/cpp/include/ydb-cpp-sdk/client/draft/ydb_bridge.h
+++ b/ydb/public/sdk/cpp/include/ydb-cpp-sdk/client/draft/ydb_bridge.h
@@ -51,7 +51,8 @@ public:
     explicit TBridgeClient(const TDriver& driver, const TCommonClientSettings& settings = {});
     ~TBridgeClient();
 
-    TAsyncStatus UpdateClusterState(const std::vector<TPileStateUpdate>& updates, const TUpdateClusterStateSettings& settings = {});
+    TAsyncStatus UpdateClusterState(const std::vector<TPileStateUpdate>& updates,
+        const std::vector<std::uint32_t>& specificPileIds, const TUpdateClusterStateSettings& settings = {});
 
     TAsyncGetClusterStateResult GetClusterState(const TGetClusterStateSettings& settings = {});
 

--- a/ydb/public/sdk/cpp/src/client/draft/ydb_bridge.cpp
+++ b/ydb/public/sdk/cpp/src/client/draft/ydb_bridge.cpp
@@ -37,9 +37,13 @@ public:
         : TClientImplCommon(std::move(connections), settings)
     {}
 
-    TAsyncStatus UpdateClusterState(const std::vector<TPileStateUpdate>& updates, const TUpdateClusterStateSettings& settings) {
+    TAsyncStatus UpdateClusterState(const std::vector<TPileStateUpdate>& updates,
+            const std::vector<std::uint32_t>& specificPileIds, const TUpdateClusterStateSettings& settings) {
         auto request = MakeOperationRequest<Ydb::Bridge::UpdateClusterStateRequest>(settings);
         UpdatesToProto(updates, &request);
+        for (auto specificPileId : specificPileIds) {
+            request.add_specific_pile_ids(specificPileId);
+        }
 
         return RunSimple<Ydb::Bridge::V1::BridgeService, Ydb::Bridge::UpdateClusterStateRequest, Ydb::Bridge::UpdateClusterStateResponse>(
             std::move(request),
@@ -81,8 +85,9 @@ TBridgeClient::TBridgeClient(const TDriver& driver, const TCommonClientSettings&
 
 TBridgeClient::~TBridgeClient() = default;
 
-TAsyncStatus TBridgeClient::UpdateClusterState(const std::vector<TPileStateUpdate>& updates, const TUpdateClusterStateSettings& settings) {
-    return Impl_->UpdateClusterState(updates, settings);
+TAsyncStatus TBridgeClient::UpdateClusterState(const std::vector<TPileStateUpdate>& updates,
+        const std::vector<std::uint32_t>& specificPileIds, const TUpdateClusterStateSettings& settings) {
+    return Impl_->UpdateClusterState(updates, specificPileIds, settings);
 }
 
 TAsyncGetClusterStateResult TBridgeClient::GetClusterState(const TGetClusterStateSettings& settings) {


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

Support quorum of specific bridge pile ids when changing cluster state in Bridge mode

### Changelog category <!-- remove all except one -->

* Not for changelog (changelog entry is not required)

### Description for reviewers <!-- (optional) description for those who read this PR -->

This patch allows specifying explicit set of piles to make up quorum when applying cluster state change command.
