### PR TITLE
25-1: Fix unexpected unique constraint violation errors from datashards

### DIFF
--- a/.github/config/muted_ya.txt
+++ b/.github/config/muted_ya.txt
@@ -45,8 +45,10 @@ ydb/core/kqp/ut/tx KqpSnapshotIsolation.TConflictReadWriteOltpNoSink
 ydb/core/kqp/ut/tx KqpSnapshotIsolation.TConflictWriteOlap
 ydb/core/kqp/ut/tx KqpSnapshotIsolation.TConflictWriteOltp
 ydb/core/kqp/ut/tx KqpSnapshotIsolation.TConflictWriteOltpNoSink
+ydb/core/kqp/ut/tx KqpSnapshotIsolation.TReadOnlyOlap
 ydb/core/kqp/ut/tx KqpSnapshotIsolation.TReadOnlyOltp
 ydb/core/kqp/ut/tx KqpSnapshotIsolation.TReadOnlyOltpNoSink
+ydb/core/kqp/ut/tx KqpSnapshotIsolation.TSimpleOlap
 ydb/core/kqp/ut/tx KqpSnapshotIsolation.TSimpleOltp
 ydb/core/kqp/ut/tx KqpSnapshotIsolation.TSimpleOltpNoSink
 ydb/core/persqueue/ut [*/*] chunk chunk

--- a/ydb/core/kqp/executer_actor/kqp_executer_impl.h
+++ b/ydb/core/kqp/executer_actor/kqp_executer_impl.h
@@ -1033,7 +1033,6 @@ protected:
                 ActorIdToProto(BufferActorId, settings.MutableBufferActorId());
             }
             if (!settings.GetInconsistentTx()
-                    && TasksGraph.GetMeta().LockMode == NKikimrDataEvents::OPTIMISTIC_SNAPSHOT_ISOLATION
                     && GetSnapshot().IsValid()) {
                 settings.MutableMvccSnapshot()->SetStep(GetSnapshot().Step);
                 settings.MutableMvccSnapshot()->SetTxId(GetSnapshot().TxId);

--- a/ydb/core/kqp/runtime/kqp_write_actor.cpp
+++ b/ydb/core/kqp/runtime/kqp_write_actor.cpp
@@ -137,6 +137,14 @@ namespace {
             transaction.AddReceivingShards(*prepareSettings.ArbiterColumnShard);
         }
     }
+
+    std::optional<NKikimrDataEvents::TMvccSnapshot> GetOptionalMvccSnapshot(const NKikimrKqp::TKqpTableSinkSettings& settings) {
+        if (settings.HasMvccSnapshot()) {
+            return settings.GetMvccSnapshot();
+        } else {
+            return std::nullopt;
+        }
+    }
 }
 
 
@@ -948,6 +956,9 @@ public:
 
             if (LockMode == NKikimrDataEvents::OPTIMISTIC_SNAPSHOT_ISOLATION) {
                 YQL_ENSURE(MvccSnapshot);
+            }
+
+            if (MvccSnapshot) {
                 *evWrite->Record.MutableMvccSnapshot() = *MvccSnapshot;
             }
         }
@@ -977,6 +988,20 @@ public:
         } else {
             YQL_ENSURE(!isPrepare);
             Counters->WriteActorImmediateWritesRetries->Inc();
+        }
+
+        if (isPrepare && MvccSnapshot) {
+            bool needMvccSnapshot = false;
+            for (const auto& operation : evWrite->Record.GetOperations()) {
+                if (operation.GetType() == NKikimrDataEvents::TEvWrite::TOperation::OPERATION_INSERT) {
+                    // This operation may fail with an incorrect unique constraint violation otherwise
+                    needMvccSnapshot = true;
+                    break;
+                }
+            }
+            if (needMvccSnapshot) {
+                *evWrite->Record.MutableMvccSnapshot() = *MvccSnapshot;
+            }
         }
 
         NDataIntegrity::LogIntegrityTrails("EvWriteTx", evWrite->Record.GetTxId(), shardId, TlsActivationContext->AsActorContext(), "WriteActor");
@@ -1378,7 +1403,7 @@ public:
                 Settings.GetIsOlap(),
                 std::move(keyColumnTypes),
                 Alloc,
-                Settings.GetMvccSnapshot(),
+                GetOptionalMvccSnapshot(Settings),
                 Settings.GetLockMode(),
                 nullptr,
                 TActorId{},
@@ -3090,7 +3115,7 @@ private:
                     .LockTxId = Settings.GetLockTxId(),
                     .LockNodeId = Settings.GetLockNodeId(),
                     .InconsistentTx = Settings.GetInconsistentTx(),
-                    .MvccSnapshot = Settings.GetMvccSnapshot(),
+                    .MvccSnapshot = GetOptionalMvccSnapshot(Settings),
                     .LockMode = Settings.GetLockMode(),
                 },
                 .Priority = Settings.GetPriority(),

--- a/ydb/core/tx/datashard/build_data_tx_out_rs_unit.cpp
+++ b/ydb/core/tx/datashard/build_data_tx_out_rs_unit.cpp
@@ -63,7 +63,7 @@ EExecutionStatus TBuildDataTxOutRSUnit::Execute(TOperation::TPtr op,
     TDataShardLocksDb locksDb(DataShard, txc);
     TSetupSysLocks guardLocks(op, DataShard, &locksDb);
 
-    tx->GetDataTx()->SetReadVersion(DataShard.GetReadWriteVersions(tx).ReadVersion);
+    tx->GetDataTx()->SetMvccVersion(DataShard.GetMvccVersion(tx));
     IEngineFlat *engine = tx->GetDataTx()->GetEngine();
     try {
         auto &outReadSets = op->OutReadSets();

--- a/ydb/core/tx/datashard/build_distributed_erase_tx_out_rs_unit.cpp
+++ b/ydb/core/tx/datashard/build_distributed_erase_tx_out_rs_unit.cpp
@@ -104,9 +104,9 @@ public:
 
         const auto tags = MakeTags(condition->Tags(), eraseTx->GetIndexColumnIds());
         auto now = TAppData::TimeProvider->Now();
-        auto [readVersion, writeVersion] = DataShard.GetReadWriteVersions(tx);
+        auto mvccVersion = DataShard.GetMvccVersion(tx);
         NMiniKQL::TEngineHostCounters engineHostCounters;
-        TDataShardUserDb userDb(DataShard, txc.DB, op->GetGlobalTxId(), readVersion, writeVersion, engineHostCounters, now);
+        TDataShardUserDb userDb(DataShard, txc.DB, op->GetGlobalTxId(), mvccVersion, engineHostCounters, now);
         bool pageFault = false;
 
         TDynBitMap confirmedRows;

--- a/ydb/core/tx/datashard/build_kqp_data_tx_out_rs_unit.cpp
+++ b/ydb/core/tx/datashard/build_kqp_data_tx_out_rs_unit.cpp
@@ -91,7 +91,7 @@ EExecutionStatus TBuildKqpDataTxOutRSUnit::Execute(TOperation::TPtr op, TTransac
         LOG_T("Operation " << *op << " (build_kqp_data_tx_out_rs) at " << tabletId
             << " set memory limit " << (txc.GetMemoryLimit() - dataTx->GetTxSize()));
 
-        dataTx->SetReadVersion(DataShard.GetReadWriteVersions(tx).ReadVersion);
+        dataTx->SetMvccVersion(DataShard.GetMvccVersion(tx));
 
         if (dataTx->GetKqpComputeCtx().HasPersistentChannels()) {
             auto result = KqpRunTransaction(ctx, op->GetTxId(), useGenericReadSets, tasksRunner);

--- a/ydb/core/tx/datashard/change_collector_cdc_stream.cpp
+++ b/ydb/core/tx/datashard/change_collector_cdc_stream.cpp
@@ -279,10 +279,10 @@ bool TCdcStreamChangeCollector::Collect(const TTableId& tableId, ERowOp rop,
 }
 
 TMaybe<TRowState> TCdcStreamChangeCollector::GetState(const TTableId& tableId, TArrayRef<const TRawTypeValue> key,
-        TArrayRef<const TTag> valueTags, TSelectStats& stats, const TMaybe<TRowVersion>& readVersion)
+        TArrayRef<const TTag> valueTags, TSelectStats& stats, const TMaybe<TRowVersion>& snapshot)
 {
     TRowState row;
-    const auto ready = UserDb.SelectRow(tableId, key, valueTags, row, stats, readVersion);
+    const auto ready = UserDb.SelectRow(tableId, key, valueTags, row, stats, snapshot);
 
     if (ready == EReady::Page) {
         return Nothing();
@@ -292,10 +292,10 @@ TMaybe<TRowState> TCdcStreamChangeCollector::GetState(const TTableId& tableId, T
 }
 
 TMaybe<TRowState> TCdcStreamChangeCollector::GetState(const TTableId& tableId, TArrayRef<const TRawTypeValue> key,
-        TArrayRef<const TTag> valueTags, const TMaybe<TRowVersion>& readVersion)
+        TArrayRef<const TTag> valueTags, const TMaybe<TRowVersion>& snapshot)
 {
     TSelectStats stats;
-    return GetState(tableId, key, valueTags, stats, readVersion);
+    return GetState(tableId, key, valueTags, stats, snapshot);
 }
 
 TRowState TCdcStreamChangeCollector::PatchState(const TRowState& oldState, ERowOp rop,

--- a/ydb/core/tx/datashard/change_collector_cdc_stream.h
+++ b/ydb/core/tx/datashard/change_collector_cdc_stream.h
@@ -8,9 +8,9 @@ namespace NDataShard {
 
 class TCdcStreamChangeCollector: public TBaseChangeCollector {
     TMaybe<NTable::TRowState> GetState(const TTableId& tableId, TArrayRef<const TRawTypeValue> key,
-        TArrayRef<const NTable::TTag> valueTags, NTable::TSelectStats& stats, const TMaybe<TRowVersion>& readVersion = {});
+        TArrayRef<const NTable::TTag> valueTags, NTable::TSelectStats& stats, const TMaybe<TRowVersion>& snapshot = {});
     TMaybe<NTable::TRowState> GetState(const TTableId& tableId, TArrayRef<const TRawTypeValue> key,
-        TArrayRef<const NTable::TTag> valueTags, const TMaybe<TRowVersion>& readVersion = {});
+        TArrayRef<const NTable::TTag> valueTags, const TMaybe<TRowVersion>& snapshot = {});
     static NTable::TRowState PatchState(const NTable::TRowState& oldState, NTable::ERowOp rop,
         const THashMap<NTable::TTag, NTable::TPos>& tagToPos, const THashMap<NTable::TTag, NTable::TUpdateOp>& updates);
 

--- a/ydb/core/tx/datashard/datashard__engine_host.cpp
+++ b/ydb/core/tx/datashard/datashard__engine_host.cpp
@@ -207,7 +207,7 @@ public:
                 self->GetKeyAccessSampler()))
         , Self(self)
         , EngineBay(engineBay)
-        , UserDb(*self, db, globalTxId, TRowVersion::Min(), TRowVersion::Max(), counters, now)        
+        , UserDb(*self, db, globalTxId, TRowVersion::Max(), counters, now)
     {
     }
 
@@ -217,9 +217,9 @@ public:
             TArrayRef<const NTable::TTag> tags,
             NTable::TRowState& row,
             NTable::TSelectStats& stats,
-            const TMaybe<TRowVersion>& readVersion) override
+            const TMaybe<TRowVersion>& snapshot) override
     {
-        return UserDb.SelectRow(tableId, key, tags, row, stats, readVersion);
+        return UserDb.SelectRow(tableId, key, tags, row, stats, snapshot);
     }
 
     NTable::EReady SelectRow(
@@ -227,29 +227,27 @@ public:
             TArrayRef<const TRawTypeValue> key,
             TArrayRef<const NTable::TTag> tags,
             NTable::TRowState& row,
-            const TMaybe<TRowVersion>& readVersion) override
+            const TMaybe<TRowVersion>& snapshot) override
     {
-        return UserDb.SelectRow(tableId, key, tags, row, readVersion);
+        return UserDb.SelectRow(tableId, key, tags, row, snapshot);
     }
 
-    void SetWriteVersion(TRowVersion writeVersion) {
-        UserDb.SetWriteVersion(writeVersion);
+    void SetMvccVersion(TRowVersion mvccVersion) {
+        UserDb.SetMvccVersion(mvccVersion);
     }
 
     TRowVersion GetWriteVersion(const TTableId& tableId) const override {
         Y_UNUSED(tableId);
-        Y_ABORT_UNLESS(!UserDb.GetWriteVersion().IsMax(), "Cannot perform writes without WriteVersion set");
-        return UserDb.GetWriteVersion();
-    }
-
-    void SetReadVersion(TRowVersion readVersion) {
-        UserDb.SetReadVersion(readVersion);
+        auto mvccVersion = UserDb.GetMvccVersion();
+        Y_ABORT_UNLESS(!mvccVersion.IsMax(), "Cannot perform writes without the correct MvccVersion set");
+        return mvccVersion;
     }
 
     TRowVersion GetReadVersion(const TTableId& tableId) const override {
         Y_UNUSED(tableId);
-        Y_ABORT_UNLESS(!UserDb.GetReadVersion().IsMin(), "Cannot perform reads without ReadVersion set");
-        return UserDb.GetReadVersion();
+        auto mvccVersion = UserDb.GetMvccVersion();
+        Y_ABORT_UNLESS(!mvccVersion.IsMax(), "Cannot perform reads without the correct MvccVersion set");
+        return mvccVersion;
     }
 
     void SetVolatileTxId(ui64 txId) {
@@ -276,8 +274,8 @@ public:
         return UserDb.GetChangeCollector(tableId);
     }
 
-    void CommitChanges(const TTableId& tableId, ui64 lockId, const TRowVersion& writeVersion) override {
-        UserDb.CommitChanges(tableId, lockId, writeVersion);
+    void CommitChanges(const TTableId& tableId, ui64 lockId) override {
+        UserDb.CommitChanges(tableId, lockId);
     }
 
     TVector<IDataShardChangeCollector::TChange> GetCollectedChanges() const {
@@ -596,21 +594,14 @@ TEngineBay::TSizes TEngineBay::CalcSizes(bool needsTotalKeysSize) const {
     return outSizes;
 }
 
-void TEngineBay::SetWriteVersion(TRowVersion writeVersion) {
+void TEngineBay::SetMvccVersion(TRowVersion mvccVersion) {
     Y_ABORT_UNLESS(EngineHost);
 
     auto* host = static_cast<TDataShardEngineHost*>(EngineHost.Get());
-    host->SetWriteVersion(writeVersion);
-}
-
-void TEngineBay::SetReadVersion(TRowVersion readVersion) {
-    Y_ABORT_UNLESS(EngineHost);
-
-    auto* host = static_cast<TDataShardEngineHost*>(EngineHost.Get());
-    host->SetReadVersion(readVersion);
+    host->SetMvccVersion(mvccVersion);
 
     Y_ABORT_UNLESS(ComputeCtx);
-    ComputeCtx->SetReadVersion(readVersion);
+    ComputeCtx->SetMvccVersion(mvccVersion);
 }
 
 void TEngineBay::SetVolatileTxId(ui64 txId) {

--- a/ydb/core/tx/datashard/datashard__engine_host.h
+++ b/ydb/core/tx/datashard/datashard__engine_host.h
@@ -97,8 +97,7 @@ public:
     const TValidationInfo& TxInfo() const { return KeyValidator.GetInfo(); }
     TEngineBay::TSizes CalcSizes(bool needsTotalKeysSize) const;
 
-    void SetWriteVersion(TRowVersion writeVersion);
-    void SetReadVersion(TRowVersion readVersion);
+    void SetMvccVersion(TRowVersion mvccVersion);
     void SetVolatileTxId(ui64 txId);
     void SetIsImmediateTx();
     void SetUsesMvccSnapshot();

--- a/ydb/core/tx/datashard/datashard_active_transaction.h
+++ b/ydb/core/tx/datashard/datashard_active_transaction.h
@@ -185,8 +185,7 @@ public:
     bool CanCancel();
     bool CheckCancelled(ui64 tabletId);
 
-    void SetWriteVersion(TRowVersion writeVersion) { EngineBay.SetWriteVersion(writeVersion); }
-    void SetReadVersion(TRowVersion readVersion) { EngineBay.SetReadVersion(readVersion); }
+    void SetMvccVersion(TRowVersion mvccVersion) { EngineBay.SetMvccVersion(mvccVersion); }
     void SetVolatileTxId(ui64 txId) { EngineBay.SetVolatileTxId(txId); }
 
     TVector<IDataShardChangeCollector::TChange> GetCollectedChanges() const { return EngineBay.GetCollectedChanges(); }

--- a/ydb/core/tx/datashard/datashard_change_receiving.cpp
+++ b/ydb/core/tx/datashard/datashard_change_receiving.cpp
@@ -307,18 +307,16 @@ class TDataShard::TTxApplyChangeRecords: public TTransactionBase<TDataShard> {
                 return false;
         }
 
-        if (!UseStepTxId(record) && !MvccReadWriteVersion) {
-            auto [readVersion, writeVersion] = Self->GetReadWriteVersions();
-            Y_DEBUG_ABORT_UNLESS(readVersion == writeVersion);
-            MvccReadWriteVersion = writeVersion;
-            Pipeline.AddCommittingOp(*MvccReadWriteVersion);
+        if (!UseStepTxId(record) && !MvccVersion) {
+            MvccVersion = Self->GetMvccVersion();
+            Pipeline.AddCommittingOp(*MvccVersion);
         }
 
         if (UseStepTxId(record)) {
             txc.DB.Update(tableInfo.LocalTid, rop, Key, Value, TRowVersion(record.GetStep(), record.GetTxId()));
         } else {
             Self->SysLocksTable().BreakLocks(tableId, KeyCells.GetCells()); // probably redundant, we expect target table to be locked until complete restore
-            txc.DB.Update(tableInfo.LocalTid, rop, Key, Value, *MvccReadWriteVersion);
+            txc.DB.Update(tableInfo.LocalTid, rop, Key, Value, *MvccVersion);
         }
 
         Self->GetConflictsCache().GetTableCache(tableInfo.LocalTid).RemoveUncommittedWrites(KeyCells.GetCells(), txc.DB);
@@ -408,8 +406,8 @@ public:
     void Complete(const TActorContext& ctx) override {
         Y_ABORT_UNLESS(Status);
 
-        if (MvccReadWriteVersion) {
-            Pipeline.RemoveCommittingOp(*MvccReadWriteVersion);
+        if (MvccVersion) {
+            Pipeline.RemoveCommittingOp(*MvccVersion);
         }
 
         if (Status->Record.GetStatus() == NKikimrChangeExchange::TEvStatus::STATUS_OK) {
@@ -425,7 +423,7 @@ private:
     TPipeline& Pipeline;
     TEvChangeExchange::TEvApplyRecords::TPtr Ev;
     THolder<TEvChangeExchange::TEvStatus> Status;
-    std::optional<TRowVersion> MvccReadWriteVersion;
+    std::optional<TRowVersion> MvccVersion;
 
     TSerializedCellVec KeyCells;
     TSerializedCellVec ValueCells;

--- a/ydb/core/tx/datashard/datashard_common_upload.cpp
+++ b/ydb/core/tx/datashard/datashard_common_upload.cpp
@@ -14,7 +14,7 @@ TCommonUploadOps<TEvRequest, TEvResponse>::TCommonUploadOps(typename TEvRequest:
 
 template <typename TEvRequest, typename TEvResponse>
 bool TCommonUploadOps<TEvRequest, TEvResponse>::Execute(TDataShard* self, TTransactionContext& txc,
-        const TRowVersion& readVersion, const TRowVersion& writeVersion, ui64 globalTxId,
+        const TRowVersion& mvccVersion, ui64 globalTxId,
         absl::flat_hash_set<ui64>* volatileReadDependencies)
 {
     const auto& record = Ev->Get()->Record;
@@ -75,7 +75,7 @@ bool TCommonUploadOps<TEvRequest, TEvResponse>::Execute(TDataShard* self, TTrans
         self->GetVolatileTxManager().GetTxMap());
 
     NMiniKQL::TEngineHostCounters engineHostCounters;
-    TDataShardUserDb userDb(*self, txc.DB, globalTxId, readVersion, writeVersion, engineHostCounters, TAppData::TimeProvider->Now());
+    TDataShardUserDb userDb(*self, txc.DB, globalTxId, mvccVersion, engineHostCounters, TAppData::TimeProvider->Now());
     TDataShardChangeGroupProvider groupProvider(*self, txc.DB);
 
     if (CollectChanges) {
@@ -146,7 +146,7 @@ bool TCommonUploadOps<TEvRequest, TEvResponse>::Execute(TDataShard* self, TTrans
         if (readForTableShadow) {
             rowState.Init(tagsForSelect.size());
 
-            auto ready = txc.DB.Select(localTableId, key, tagsForSelect, rowState, 0 /* readFlags */, readVersion);
+            auto ready = txc.DB.Select(localTableId, key, tagsForSelect, rowState, 0 /* readFlags */, mvccVersion);
             if (ready == NTable::EReady::Page) {
                 pageFault = true;
             }
@@ -232,7 +232,7 @@ bool TCommonUploadOps<TEvRequest, TEvResponse>::Execute(TDataShard* self, TTrans
                         pageFault = true;
                     }
                 } else {
-                    if (!ChangeCollector->OnUpdate(fullTableId, writeTableId, NTable::ERowOp::Upsert, key, value, writeVersion)) {
+                    if (!ChangeCollector->OnUpdate(fullTableId, writeTableId, NTable::ERowOp::Upsert, key, value, mvccVersion)) {
                         pageFault = true;
                     }
                 }
@@ -251,11 +251,11 @@ bool TCommonUploadOps<TEvRequest, TEvResponse>::Execute(TDataShard* self, TTrans
             self->GetConflictsCache().GetTableCache(writeTableId).AddUncommittedWrite(keyCells.GetCells(), globalTxId, txc.DB);
             if (!commitAdded) {
                 // Make sure we see our own changes on further iterations
-                userDb.AddCommitTxId(fullTableId, globalTxId, writeVersion);
+                userDb.AddCommitTxId(fullTableId, globalTxId);
                 commitAdded = true;
             }
         } else {
-            txc.DB.Update(writeTableId, NTable::ERowOp::Upsert, key, value, writeVersion);
+            txc.DB.Update(writeTableId, NTable::ERowOp::Upsert, key, value, mvccVersion);
             self->GetConflictsCache().GetTableCache(writeTableId).RemoveUncommittedWrites(keyCells.GetCells(), txc.DB);
         }
     }
@@ -277,7 +277,7 @@ bool TCommonUploadOps<TEvRequest, TEvResponse>::Execute(TDataShard* self, TTrans
     if (!volatileDependencies.empty()) {
         self->GetVolatileTxManager().PersistAddVolatileTx(
             globalTxId,
-            writeVersion,
+            mvccVersion,
             /* commitTxIds */ { globalTxId },
             volatileDependencies,
             /* participants */ { },

--- a/ydb/core/tx/datashard/datashard_common_upload.h
+++ b/ydb/core/tx/datashard/datashard_common_upload.h
@@ -21,8 +21,7 @@ public:
     explicit TCommonUploadOps(typename TEvRequest::TPtr& ev, bool breakLocks, bool collectChanges);
 
 protected:
-    bool Execute(TDataShard* self, TTransactionContext& txc, const TRowVersion& readVersion,
-        const TRowVersion& writeVersion, ui64 globalTxId,
+    bool Execute(TDataShard* self, TTransactionContext& txc, const TRowVersion& mvccVersion, ui64 globalTxId,
         absl::flat_hash_set<ui64>* volatileReadDependencies);
     void GetResult(TDataShard* self, TActorId& target, THolder<IEventBase>& event, ui64& cookie);
     const TEvRequest* GetRequest() const;

--- a/ydb/core/tx/datashard/datashard_direct_erase.h
+++ b/ydb/core/tx/datashard/datashard_direct_erase.h
@@ -20,19 +20,17 @@ class TDirectTxErase : public IDirectTx {
     struct TExecuteParams {
         TDirectTxErase* const Tx;
         TTransactionContext* const Txc;
-        const TRowVersion ReadVersion;
-        const TRowVersion WriteVersion;
+        const TRowVersion MvccVersion;
         const ui64 GlobalTxId;
         absl::flat_hash_set<ui64>* const VolatileReadDependencies;
 
     private:
         explicit TExecuteParams(TDirectTxErase* tx, TTransactionContext* txc,
-                const TRowVersion& readVersion, const TRowVersion& writeVersion,
-                ui64 globalTxId, absl::flat_hash_set<ui64>* volatileReadDependencies)
+                const TRowVersion& mvccVersion, ui64 globalTxId,
+                absl::flat_hash_set<ui64>* volatileReadDependencies)
             : Tx(tx)
             , Txc(txc)
-            , ReadVersion(readVersion)
-            , WriteVersion(writeVersion)
+            , MvccVersion(mvccVersion)
             , GlobalTxId(globalTxId)
             , VolatileReadDependencies(volatileReadDependencies)
         {
@@ -40,7 +38,7 @@ class TDirectTxErase : public IDirectTx {
 
     public:
         static TExecuteParams ForCheck() {
-            return TExecuteParams(nullptr, nullptr, TRowVersion(), TRowVersion(), 0, nullptr);
+            return TExecuteParams(nullptr, nullptr, TRowVersion(), 0, nullptr);
         }
 
         template <typename... Args>
@@ -74,8 +72,8 @@ public:
         NKikimrTxDataShard::TEvEraseRowsResponse::EStatus& status, TString& error);
 
     bool Execute(TDataShard* self, TTransactionContext& txc,
-        const TRowVersion& readVersion, const TRowVersion& writeVersion,
-        ui64 globalTxId, absl::flat_hash_set<ui64>& volatileReadDependencies) override;
+        const TRowVersion& mvccVersion, ui64 globalTxId,
+        absl::flat_hash_set<ui64>& volatileReadDependencies) override;
     TDirectTxResult GetResult(TDataShard* self) override;
     TVector<IDataShardChangeCollector::TChange> GetCollectedChanges() const override;
 };

--- a/ydb/core/tx/datashard/datashard_direct_transaction.h
+++ b/ydb/core/tx/datashard/datashard_direct_transaction.h
@@ -21,8 +21,8 @@ class IDirectTx {
 public:
     virtual ~IDirectTx() = default;
     virtual bool Execute(TDataShard* self, TTransactionContext& txc,
-        const TRowVersion& readVersion, const TRowVersion& writeVersion,
-        ui64 globalTxId, absl::flat_hash_set<ui64>& volatileReadDependencies) = 0;
+        const TRowVersion& mvccVersion, ui64 globalTxId,
+        absl::flat_hash_set<ui64>& volatileReadDependencies) = 0;
     virtual TDirectTxResult GetResult(TDataShard* self) = 0;
     virtual TVector<IDataShardChangeCollector::TChange> GetCollectedChanges() const = 0;
 };

--- a/ydb/core/tx/datashard/datashard_direct_upload.cpp
+++ b/ydb/core/tx/datashard/datashard_direct_upload.cpp
@@ -9,11 +9,11 @@ TDirectTxUpload::TDirectTxUpload(TEvDataShard::TEvUploadRowsRequest::TPtr& ev)
 }
 
 bool TDirectTxUpload::Execute(TDataShard* self, TTransactionContext& txc,
-        const TRowVersion& readVersion, const TRowVersion& writeVersion,
-        ui64 globalTxId, absl::flat_hash_set<ui64>& volatileReadDependencies)
+        const TRowVersion& mvccVersion, ui64 globalTxId,
+        absl::flat_hash_set<ui64>& volatileReadDependencies)
 {
-    return TCommonUploadOps::Execute(self, txc, readVersion, writeVersion,
-        globalTxId, &volatileReadDependencies);
+    return TCommonUploadOps::Execute(self, txc, mvccVersion, globalTxId,
+            &volatileReadDependencies);
 }
 
 TDirectTxResult TDirectTxUpload::GetResult(TDataShard* self) {

--- a/ydb/core/tx/datashard/datashard_direct_upload.h
+++ b/ydb/core/tx/datashard/datashard_direct_upload.h
@@ -15,8 +15,8 @@ public:
     explicit TDirectTxUpload(TEvDataShard::TEvUploadRowsRequest::TPtr& ev);
 
     bool Execute(TDataShard* self, TTransactionContext& txc,
-        const TRowVersion& readVersion, const TRowVersion& writeVersion,
-        ui64 globalTxId, absl::flat_hash_set<ui64>& volatileReadDependencies) override;
+        const TRowVersion& mvccVersion, ui64 globalTxId,
+        absl::flat_hash_set<ui64>& volatileReadDependencies) override;
     TDirectTxResult GetResult(TDataShard* self) override;
     TVector<IDataShardChangeCollector::TChange> GetCollectedChanges() const override;
 };

--- a/ydb/core/tx/datashard/datashard_impl.h
+++ b/ydb/core/tx/datashard/datashard_impl.h
@@ -137,21 +137,6 @@ public:
     virtual void OnFinished(TDataShard* self) = 0;
 };
 
-struct TReadWriteVersions {
-    TReadWriteVersions(const TRowVersion& readVersion, const TRowVersion& writeVersion)
-        : ReadVersion(readVersion)
-        , WriteVersion(writeVersion)
-    {}
-
-    TReadWriteVersions(const TRowVersion& version)
-        : ReadVersion(version)
-        , WriteVersion(version)
-    {}
-
-    const TRowVersion ReadVersion;
-    const TRowVersion WriteVersion;
-};
-
 class TDataShardEngineHost;
 struct TSetupSysLocks;
 
@@ -1488,7 +1473,7 @@ class TDataShard
     NTabletFlatExecutor::ITransaction* CreateTxCheckInReadSets();
     NTabletFlatExecutor::ITransaction* CreateTxRemoveOldInReadSets();
 
-    TReadWriteVersions GetLocalReadWriteVersions() const;
+    TRowVersion GetLocalMvccVersion() const;
 
 public:
     static constexpr NKikimrServices::TActivity::EType ActorActivityType() {
@@ -2052,7 +2037,7 @@ public:
         bool WaitCompletion = false;
     };
 
-    TReadWriteVersions GetReadWriteVersions(TOperation* op = nullptr) const;
+    TRowVersion GetMvccVersion(TOperation* op = nullptr) const;
     TPromotePostExecuteEdges PromoteImmediatePostExecuteEdges(
             const TRowVersion& version, EPromotePostExecuteEdges mode, TTransactionContext& txc);
     ui64 GetMaxObservedStep() const;

--- a/ydb/core/tx/datashard/datashard_kqp.cpp
+++ b/ydb/core/tx/datashard/datashard_kqp.cpp
@@ -828,7 +828,7 @@ void KqpEraseLocks(ui64 origin, const NKikimrDataEvents::TKqpLocks* kqpLocks, TS
     }
 }
 
-void KqpCommitLocks(ui64 origin, const NKikimrDataEvents::TKqpLocks* kqpLocks, TSysLocks& sysLocks, const TRowVersion& writeVersion, IDataShardUserDb& userDb) {
+void KqpCommitLocks(ui64 origin, const NKikimrDataEvents::TKqpLocks* kqpLocks, TSysLocks& sysLocks, IDataShardUserDb& userDb) {
     if (kqpLocks == nullptr) {
         return;
     }
@@ -848,7 +848,7 @@ void KqpCommitLocks(ui64 origin, const NKikimrDataEvents::TKqpLocks* kqpLocks, T
             TTableId tableId(lockProto.GetSchemeShard(), lockProto.GetPathId());
             auto txId = lockProto.GetLockId();
 
-            userDb.CommitChanges(tableId, txId, writeVersion);
+            userDb.CommitChanges(tableId, txId);
         }
     } else {
         KqpEraseLocks(origin, kqpLocks, sysLocks);

--- a/ydb/core/tx/datashard/datashard_kqp.h
+++ b/ydb/core/tx/datashard/datashard_kqp.h
@@ -47,7 +47,7 @@ bool KqpLocksHasArbiter(const NKikimrDataEvents::TKqpLocks* kqpLocks);
 bool KqpLocksIsArbiter(ui64 tabletId, const NKikimrDataEvents::TKqpLocks* kqpLocks);
 
 void KqpEraseLocks(ui64 tabletId, const NKikimrDataEvents::TKqpLocks* kqpLocks, TSysLocks& sysLocks);
-void KqpCommitLocks(ui64 tabletId, const NKikimrDataEvents::TKqpLocks* kqpLocks, TSysLocks& sysLocks, const TRowVersion& writeVersion, IDataShardUserDb& userDb);
+void KqpCommitLocks(ui64 tabletId, const NKikimrDataEvents::TKqpLocks* kqpLocks, TSysLocks& sysLocks, IDataShardUserDb& userDb);
 
 void KqpUpdateDataShardStatCounters(TDataShard& dataShard, const NMiniKQL::TEngineHostCounters& counters);
 

--- a/ydb/core/tx/datashard/datashard_kqp_compute.h
+++ b/ydb/core/tx/datashard/datashard_kqp_compute.h
@@ -45,8 +45,8 @@ public:
 
     void Clear();
 
-    void SetReadVersion(TRowVersion readVersion);
-    TRowVersion GetReadVersion() const;
+    void SetMvccVersion(TRowVersion readVersion);
+    TRowVersion GetMvccVersion() const;
 
     TEngineHostCounters& GetTaskCounters(ui64 taskId) { return TaskCounters[taskId]; }
     TEngineHostCounters& GetDatashardCounters();

--- a/ydb/core/tx/datashard/datashard_pipeline.cpp
+++ b/ydb/core/tx/datashard/datashard_pipeline.cpp
@@ -1686,7 +1686,8 @@ TOperation::TPtr TPipeline::BuildOperation(NEvents::TDataEvents::TEvWrite::TPtr&
 {
     const auto& rec = ev->Get()->Record;
     TBasicOpInfo info(rec.GetTxId(), EOperationKind::WriteTx, NEvWrite::TConvertor::GetProposeFlags(rec.GetTxMode()), 0, receivedAt, tieBreakerIndex);
-    if (rec.HasMvccSnapshot()) {
+    // Uncommitted writes are performed over a consistent mvcc snapshot
+    if (rec.HasMvccSnapshot() && rec.GetLockTxId()) {
         info.SetMvccSnapshot(TRowVersion(rec.GetMvccSnapshot().GetStep(), rec.GetMvccSnapshot().GetTxId()),
             rec.GetMvccSnapshot().GetRepeatableRead());
     }
@@ -1700,9 +1701,9 @@ TOperation::TPtr TPipeline::BuildOperation(NEvents::TDataEvents::TEvWrite::TPtr&
         LOG_ERROR_S(TActivationContext::AsActorContext(), NKikimrServices::TX_DATASHARD, error);
     };
 
-    if (rec.HasMvccSnapshot() && !rec.GetLockTxId()) {
+    if (rec.GetLockMode() != NKikimrDataEvents::OPTIMISTIC) {
         badRequest(NKikimrDataEvents::TEvWriteResult::STATUS_BAD_REQUEST,
-            "MvccSnapshot without LockTxId is not implemented");
+            "Only OPTIMISTIC lock mode is currently implemented");
         return writeOp;
     }
 

--- a/ydb/core/tx/datashard/datashard_pipeline.cpp
+++ b/ydb/core/tx/datashard/datashard_pipeline.cpp
@@ -2283,7 +2283,7 @@ void TPipeline::AddCommittingOp(const TOperation::TPtr& op) {
     Y_VERIFY_S(!op->GetCommittingOpsVersion(),
         "Trying to AddCommittingOp " << *op << " more than once");
 
-    TRowVersion version = Self->GetReadWriteVersions(op.Get()).WriteVersion;
+    TRowVersion version = Self->GetMvccVersion(op.Get());
     if (op->IsImmediate())
         CommittingOps.Add(op->GetTxId(), version);
     else

--- a/ydb/core/tx/datashard/datashard_repl_apply.cpp
+++ b/ydb/core/tx/datashard/datashard_repl_apply.cpp
@@ -88,9 +88,9 @@ public:
             }
         }
 
-        if (MvccReadWriteVersion) {
-            Self->PromoteImmediatePostExecuteEdges(*MvccReadWriteVersion, TDataShard::EPromotePostExecuteEdges::ReadWrite, txc);
-            Pipeline.AddCommittingOp(*MvccReadWriteVersion);
+        if (MvccVersion) {
+            Self->PromoteImmediatePostExecuteEdges(*MvccVersion, TDataShard::EPromotePostExecuteEdges::ReadWrite, txc);
+            Pipeline.AddCommittingOp(*MvccVersion);
         }
 
         if (!Result) {
@@ -195,14 +195,12 @@ public:
             txc.DB.UpdateTx(userTable.LocalTid, rop, key, update, writeTxId);
             Self->GetConflictsCache().GetTableCache(userTable.LocalTid).AddUncommittedWrite(keyCellVec.GetCells(), writeTxId, txc.DB);
         } else {
-            if (!MvccReadWriteVersion) {
-                auto [readVersion, writeVersion] = Self->GetReadWriteVersions();
-                Y_DEBUG_ABORT_UNLESS(readVersion == writeVersion);
-                MvccReadWriteVersion = writeVersion;
+            if (!MvccVersion) {
+                MvccVersion = Self->GetMvccVersion();
             }
 
             Self->SysLocksTable().BreakLocks(tableId, keyCellVec.GetCells());
-            txc.DB.Update(userTable.LocalTid, rop, key, update, *MvccReadWriteVersion);
+            txc.DB.Update(userTable.LocalTid, rop, key, update, *MvccVersion);
             Self->GetConflictsCache().GetTableCache(userTable.LocalTid).RemoveUncommittedWrites(keyCellVec.GetCells(), txc.DB);
         }
 
@@ -254,9 +252,9 @@ public:
         Y_ABORT_UNLESS(Ev);
         Y_ABORT_UNLESS(Result);
 
-        if (MvccReadWriteVersion) {
-            Pipeline.RemoveCommittingOp(*MvccReadWriteVersion);
-            Self->SendImmediateWriteResult(*MvccReadWriteVersion, Ev->Sender, Result.Release(), Ev->Cookie);
+        if (MvccVersion) {
+            Pipeline.RemoveCommittingOp(*MvccVersion);
+            Self->SendImmediateWriteResult(*MvccVersion, Ev->Sender, Result.Release(), Ev->Cookie);
         } else {
             ctx.Send(Ev->Sender, Result.Release(), 0, Ev->Cookie);
         }
@@ -266,7 +264,7 @@ private:
     TPipeline& Pipeline;
     TEvDataShard::TEvApplyReplicationChanges::TPtr Ev;
     THolder<TEvDataShard::TEvApplyReplicationChangesResult> Result;
-    std::optional<TRowVersion> MvccReadWriteVersion;
+    std::optional<TRowVersion> MvccVersion;
 }; // TTxApplyReplicationChanges
 
 void TDataShard::Handle(TEvDataShard::TEvApplyReplicationChanges::TPtr& ev, const TActorContext& ctx) {

--- a/ydb/core/tx/datashard/datashard_user_db.cpp
+++ b/ydb/core/tx/datashard/datashard_user_db.cpp
@@ -36,10 +36,19 @@ NTable::EReady TDataShardUserDb::SelectRow(
 
     SetPerformedUserReads(true);
 
-    return Db.Select(tid, key, tags, row, stats, /* readFlags */ 0,
+    NTable::EReady ready = Db.Select(tid, key, tags, row, stats, /* readFlags */ 0,
         MvccVersion,
         GetReadTxMap(tableId),
         GetReadTxObserver(tableId));
+
+    if (stats.InvisibleRowSkips > 0) {
+        if (LockTxId) {
+            Self.SysLocksTable().BreakSetLocks();
+        }
+        MvccReadConflict = true;
+    }
+
+    return ready;
 }
 
 NTable::EReady TDataShardUserDb::SelectRow(
@@ -439,11 +448,12 @@ public:
         // We already use InvisibleRowSkips for these
     }
 
-    void OnApplyCommitted(const TRowVersion&) override {
-        // Not needed
+    void OnApplyCommitted(const TRowVersion& rowVersion) override {
+        ConflictChecker.CheckReadConflict(rowVersion);
     }
 
-    void OnApplyCommitted(const TRowVersion&, ui64 txId) override {
+    void OnApplyCommitted(const TRowVersion& rowVersion, ui64 txId) override {
+        ConflictChecker.CheckReadConflict(rowVersion);
         ConflictChecker.CheckReadDependency(txId);
     }
 
@@ -756,6 +766,7 @@ NTable::ITransactionObserverPtr TDataShardUserDb::GetReadTxObserver(const TTable
     Y_ABORT_UNLESS(localTableId != 0, "Unexpected GetReadTxObserver for an unknown table");
 
     bool needObserver = (
+        SnapshotVersion < MvccVersion ||
         // We need observer when there are waiting changes in the tx map
         Self.GetVolatileTxManager().GetTxMap() ||
         // We need observer for locked reads when there are active write locks
@@ -789,8 +800,6 @@ void TDataShardUserDb::AddReadConflict(ui64 txId) {
 }
 
 void TDataShardUserDb::CheckReadConflict(const TRowVersion& rowVersion) {
-    Y_ABORT_UNLESS(LockTxId);
-
     if (rowVersion > MvccVersion) {
         // We are reading from snapshot at MvccVersion and should not normally
         // observe changes with a version above that. However, if we have an
@@ -798,7 +807,16 @@ void TDataShardUserDb::CheckReadConflict(const TRowVersion& rowVersion) {
         // visibility, we might shadow some change that happened after a
         // snapshot. This is a clear indication of a conflict between read
         // and that future conflict, hence we must break locks and abort.
-        Self.SysLocksTable().BreakSetLocks();
+        if (LockTxId) {
+            Self.SysLocksTable().BreakSetLocks();
+        }
+        MvccReadConflict = true;
+    } else if (rowVersion > SnapshotVersion) {
+        // During commit we read at the current mvcc version, however we may
+        // notice there have been changes between the snapshot and current
+        // commit version. This is not necessarily an error, but indicates
+        // if this read was performed under a lock it would have been broken.
+        SnapshotReadConflict = true;
     }
 }
 

--- a/ydb/core/tx/datashard/datashard_user_db.h
+++ b/ydb/core/tx/datashard/datashard_user_db.h
@@ -28,14 +28,14 @@ public:
             TArrayRef<const NTable::TTag> tags,
             NTable::TRowState& row,
             NTable::TSelectStats& stats,
-            const TMaybe<TRowVersion>& readVersion = {}) = 0;
+            const TMaybe<TRowVersion>& snapshot = {}) = 0;
 
     virtual NTable::EReady SelectRow(
             const TTableId& tableId,
             TArrayRef<const TRawTypeValue> key,
             TArrayRef<const NTable::TTag> tags,
             NTable::TRowState& row,
-            const TMaybe<TRowVersion>& readVersion = {}) = 0;
+            const TMaybe<TRowVersion>& snapshot = {}) = 0;
 
     virtual void UpsertRow(
             const TTableId& tableId,
@@ -63,16 +63,15 @@ public:
 
     virtual void CommitChanges(
             const TTableId& tableId,
-            ui64 lockId,
-            const TRowVersion& writeVersion) = 0;
+            ui64 lockId) = 0;
 };
 
 class IDataShardConflictChecker {
 protected:
     ~IDataShardConflictChecker() = default;
 public:
-    virtual void AddReadConflict(ui64 txId) const = 0;
-    virtual void CheckReadConflict(const TRowVersion& rowVersion) const = 0;
+    virtual void AddReadConflict(ui64 txId) = 0;
+    virtual void CheckReadConflict(const TRowVersion& rowVersion) = 0;
     virtual void CheckReadDependency(ui64 txId) = 0;
 
     virtual void CheckWriteConflicts(const TTableId& tableId, TArrayRef<const TCell> keyCells) = 0;
@@ -89,8 +88,7 @@ public:
             TDataShard& self,
             NTable::TDatabase& db,
             ui64 globalTxId,
-            const TRowVersion& readVersion,
-            const TRowVersion& writeVersion,
+            const TRowVersion& mvccVersion,
             NMiniKQL::TEngineHostCounters& counters, 
             TInstant now
     );
@@ -103,14 +101,14 @@ public:
             TArrayRef<const NTable::TTag> tags,
             NTable::TRowState& row,
             NTable::TSelectStats& stats,
-            const TMaybe<TRowVersion>& readVersion = {}) override;
+            const TMaybe<TRowVersion>& snapshot = {}) override;
 
     NTable::EReady SelectRow(
             const TTableId& tableId,
             TArrayRef<const TRawTypeValue> key,
             TArrayRef<const NTable::TTag> tags,
             NTable::TRowState& row,
-            const TMaybe<TRowVersion>& readVersion = {}) override;
+            const TMaybe<TRowVersion>& snapshot = {}) override;
 
     void UpsertRow(
             const TTableId& tableId,
@@ -138,8 +136,7 @@ public:
 
     void CommitChanges(
             const TTableId& tableId, 
-            ui64 lockId, 
-            const TRowVersion& writeVersion) override;
+            ui64 lockId) override;
 
 //IDataShardChangeGroupProvider
 public:  
@@ -148,8 +145,8 @@ public:
 
 //IDataShardConflictChecker
 public:  
-    void AddReadConflict(ui64 txId) const override;
-    void CheckReadConflict(const TRowVersion& rowVersion) const override;
+    void AddReadConflict(ui64 txId) override;
+    void CheckReadConflict(const TRowVersion& rowVersion) override;
     void CheckReadDependency(ui64 txId) override;
 
     void CheckWriteConflicts(const TTableId& tableId, TArrayRef<const TCell> keyCells) override;
@@ -163,7 +160,7 @@ public:
 
 public:
     bool NeedToReadBeforeWrite(const TTableId& tableId);
-    void AddCommitTxId(const TTableId& tableId, ui64 txId, const TRowVersion& commitVersion);
+    void AddCommitTxId(const TTableId& tableId, ui64 txId);
     ui64 GetWriteTxId(const TTableId& tableId);
 
     absl::flat_hash_set<ui64>& GetVolatileReadDependencies();
@@ -203,8 +200,7 @@ private:
     YDB_ACCESSOR_DEF(bool, IsWriteTx);
     YDB_ACCESSOR_DEF(bool, UsesMvccSnapshot);
 
-    YDB_ACCESSOR_DEF(TRowVersion, ReadVersion);
-    YDB_ACCESSOR_DEF(TRowVersion, WriteVersion);
+    YDB_ACCESSOR_DEF(TRowVersion, MvccVersion);
 
     YDB_READONLY_DEF(TInstant, Now);
 

--- a/ydb/core/tx/datashard/datashard_user_db.h
+++ b/ydb/core/tx/datashard/datashard_user_db.h
@@ -216,6 +216,25 @@ private:
 
     YDB_ACCESSOR_DEF(bool, PerformedUserReads);
 
+    // Becomes true when user-visible reads detect changes over MvccVersion, i.e.
+    // if we would have performed this read under a lock, it would have been broken.
+    YDB_READONLY(bool, MvccReadConflict, false);
+
+    // At commit time we have MvccVersion equal to the commit version, however
+    // when transaction has a snapshot it should behave as if all reads are
+    // performed at the snapshot version. This snapshot version is not used
+    // for reads (we optimistically read from commit version at commit time to
+    // minimize conflicts), however encountering errors which prevent the
+    // transaction from committing having conflicts with the snapshot indicate
+    // it should behave as if an imaginary lock was broken instread.
+    YDB_ACCESSOR(TRowVersion, SnapshotVersion, TRowVersion::Max());
+    // Becomes true when reads detect there have been committed changes between
+    // the snapshot version and the commit version.
+    YDB_READONLY(bool, SnapshotReadConflict, false);
+    // Becomes true when writes detect there have been committed changes between
+    // the snapshot version and the commit version.
+    YDB_READONLY(bool, SnapshotWriteConflict, false);
+
     NMiniKQL::TEngineHostCounters& Counters;
 };
 

--- a/ydb/core/tx/datashard/datashard_ut_common_kqp.h
+++ b/ydb/core/tx/datashard/datashard_ut_common_kqp.h
@@ -224,8 +224,8 @@ namespace NKqpHelpers {
         return SendRequest(runtime, MakeSimpleRequestRPC(query, sessionId, txId, true /* commitTx */));
     }
 
-    inline TString KqpSimpleCommit(TTestActorRuntime& runtime, const TString& sessionId, const TString& txId, const TString& query) {
-        auto response = AwaitResponse(runtime, KqpSimpleSendCommit(runtime, sessionId, txId, query));
+    inline TString KqpSimpleWaitCommit(TTestActorRuntime& runtime, NThreading::TFuture<Ydb::Table::ExecuteDataQueryResponse> future) {
+        auto response = AwaitResponse(runtime, std::move(future));
         if (response.operation().status() != Ydb::StatusIds::SUCCESS) {
             return TStringBuilder() << "ERROR: " << response.operation().status();
         }
@@ -233,6 +233,10 @@ namespace NKqpHelpers {
         response.operation().result().UnpackTo(&result);
         Y_ABORT_UNLESS(result.tx_meta().id().empty(), "must be empty transaction");
         return FormatResult(result);
+    }
+
+    inline TString KqpSimpleCommit(TTestActorRuntime& runtime, const TString& sessionId, const TString& txId, const TString& query) {
+        return KqpSimpleWaitCommit(runtime, KqpSimpleSendCommit(runtime, sessionId, txId, query));
     }
 
     inline Ydb::Table::ExecuteSchemeQueryRequest MakeSchemeRequestRPC(

--- a/ydb/core/tx/datashard/datashard_ut_write.cpp
+++ b/ydb/core/tx/datashard/datashard_ut_write.cpp
@@ -1778,5 +1778,146 @@ Y_UNIT_TEST_SUITE(DataShardWrite) {
             "{ items { int32_value: 11 } items { int32_value: 12 } items { int32_value: 12 } items { int32_value: 12 } }");
     }
 
+    Y_UNIT_TEST(WriteUniqueRowsInsertDuplicateBeforeCommit) {
+        TPortManager pm;
+        NKikimrConfig::TAppConfig app;
+        app.MutableTableServiceConfig()->SetEnableOltpSink(true);
+        TServerSettings serverSettings(pm.GetPort(2134));
+        serverSettings.SetDomainName("Root")
+            .SetUseRealThreads(false)
+            .SetAppConfig(app);
+
+        auto [runtime, server, sender] = TestCreateServer(serverSettings);
+
+        TDisableDataShardLogBatching disableDataShardLogBatching;
+
+        UNIT_ASSERT_VALUES_EQUAL(
+            KqpSchemeExec(runtime, R"(
+                CREATE TABLE `/Root/counts` (key int, rows int, PRIMARY KEY (key));
+                CREATE TABLE `/Root/rows` (key int, subkey int, value int, PRIMARY KEY (key, subkey));
+            )"),
+            "SUCCESS"
+        );
+
+        ExecSQL(server, sender, R"(
+            UPSERT INTO `/Root/counts` (key, rows) VALUES
+                (42, 2);
+            UPSERT INTO `/Root/rows` (key, subkey, value) VALUES
+                (42, 1, 101),
+                (42, 2, 102);
+        )");
+
+        TString sessionId1, txId1;
+        UNIT_ASSERT_VALUES_EQUAL(
+            KqpSimpleBegin(runtime, sessionId1, txId1, R"(
+                UPDATE `/Root/counts` SET rows = rows + 1 WHERE key = 42;
+                SELECT rows FROM `/Root/counts` WHERE key = 42;
+            )"),
+            "{ items { int32_value: 3 } }"
+        );
+
+        TString sessionId2, txId2;
+        UNIT_ASSERT_VALUES_EQUAL(
+            KqpSimpleBegin(runtime, sessionId2, txId2, R"(
+                UPDATE `/Root/counts` SET rows = rows + 1 WHERE key = 42;
+                SELECT rows FROM `/Root/counts` WHERE key = 42;
+            )"),
+            "{ items { int32_value: 3 } }"
+        );
+
+        UNIT_ASSERT_VALUES_EQUAL(
+            KqpSimpleCommit(runtime, sessionId2, txId2, R"(
+                INSERT INTO `/Root/rows` (key, subkey, value) VALUES
+                    (42, 3, 203);
+            )"),
+            "<empty>"
+        );
+
+        UNIT_ASSERT_VALUES_EQUAL(
+            KqpSimpleContinue(runtime, sessionId1, txId1, R"(
+                INSERT INTO `/Root/rows` (key, subkey, value) VALUES
+                    (42, 3, 303);
+            )"),
+            "ERROR: ABORTED"
+        );
+    }
+
+    Y_UNIT_TEST(WriteUniqueRowsInsertDuplicateAtCommit) {
+        TPortManager pm;
+        NKikimrConfig::TAppConfig app;
+        app.MutableTableServiceConfig()->SetEnableOltpSink(true);
+        TServerSettings serverSettings(pm.GetPort(2134));
+        serverSettings.SetDomainName("Root")
+            .SetUseRealThreads(false)
+            .SetAppConfig(app);
+
+        auto [runtime, server, sender] = TestCreateServer(serverSettings);
+
+        TDisableDataShardLogBatching disableDataShardLogBatching;
+
+        UNIT_ASSERT_VALUES_EQUAL(
+            KqpSchemeExec(runtime, R"(
+                CREATE TABLE `/Root/counts` (key int, rows int, PRIMARY KEY (key));
+                CREATE TABLE `/Root/rows` (key int, subkey int, value int, PRIMARY KEY (key, subkey));
+            )"),
+            "SUCCESS"
+        );
+
+        ExecSQL(server, sender, R"(
+            UPSERT INTO `/Root/counts` (key, rows) VALUES
+                (42, 2);
+            UPSERT INTO `/Root/rows` (key, subkey, value) VALUES
+                (42, 1, 101),
+                (42, 2, 102);
+        )");
+
+        TString sessionId1, txId1;
+        UNIT_ASSERT_VALUES_EQUAL(
+            KqpSimpleBegin(runtime, sessionId1, txId1, R"(
+                UPDATE `/Root/counts` SET rows = rows + 1 WHERE key = 42;
+                SELECT rows FROM `/Root/counts` WHERE key = 42;
+            )"),
+            "{ items { int32_value: 3 } }"
+        );
+
+        TString sessionId2, txId2;
+        UNIT_ASSERT_VALUES_EQUAL(
+            KqpSimpleBegin(runtime, sessionId2, txId2, R"(
+                UPDATE `/Root/counts` SET rows = rows + 1 WHERE key = 42;
+                SELECT rows FROM `/Root/counts` WHERE key = 42;
+            )"),
+            "{ items { int32_value: 3 } }"
+        );
+
+        UNIT_ASSERT_VALUES_EQUAL(
+            KqpSimpleCommit(runtime, sessionId2, txId2, R"(
+                INSERT INTO `/Root/rows` (key, subkey, value) VALUES
+                    (42, 3, 203);
+            )"),
+            "<empty>"
+        );
+
+        TBlockEvents<NEvents::TDataEvents::TEvWriteResult> blockedLocksBroken(runtime, [&](auto& ev) {
+            auto* msg = ev->Get();
+            if (msg->Record.GetStatus() == NKikimrDataEvents::TEvWriteResult::STATUS_LOCKS_BROKEN) {
+                return true;
+            }
+            return false;
+        });
+
+        auto commitFuture = KqpSimpleSendCommit(runtime, sessionId1, txId1, R"(
+            INSERT INTO `/Root/rows` (key, subkey, value) VALUES
+                (42, 3, 303);
+        )");
+
+        runtime.SimulateSleep(TDuration::MilliSeconds(1));
+        blockedLocksBroken.Stop().Unblock();
+
+        UNIT_ASSERT_VALUES_EQUAL(
+            KqpSimpleWaitCommit(runtime, std::move(commitFuture)),
+            "ERROR: ABORTED"
+        );
+    }
+
 } // Y_UNIT_TEST_SUITE(DataShardWrite)
 } // namespace NKikimr

--- a/ydb/core/tx/datashard/datashard_write_operation.cpp
+++ b/ydb/core/tx/datashard/datashard_write_operation.cpp
@@ -57,6 +57,10 @@ TValidatedWriteTx::TValidatedWriteTx(TDataShard* self, ui64 globalTxId, TInstant
         LockNodeId = record.GetLockNodeId();
     }
 
+    if (record.HasMvccSnapshot()) {
+        MvccSnapshot.emplace(record.GetMvccSnapshot().GetStep(), record.GetMvccSnapshot().GetTxId());
+    }
+
     OverloadSubscribe = record.HasOverloadSubscribe() ? record.GetOverloadSubscribe() : std::optional<ui64>{};
 
     NKikimrTxDataShard::TKqpTransaction::TDataTaskMeta meta;

--- a/ydb/core/tx/datashard/datashard_write_operation.h
+++ b/ydb/core/tx/datashard/datashard_write_operation.h
@@ -131,6 +131,7 @@ private:
     YDB_READONLY_DEF(TInstant, ReceivedAt);
     YDB_READONLY_DEF(std::optional<ui64>, OverloadSubscribe);
     YDB_READONLY_DEF(bool, MvccSnapshotRead);
+    YDB_READONLY_DEF(std::optional<TRowVersion>, MvccSnapshot);
 
     YDB_READONLY_DEF(ui64, TxSize);
 

--- a/ydb/core/tx/datashard/direct_tx_unit.cpp
+++ b/ydb/core/tx/datashard/direct_tx_unit.cpp
@@ -31,7 +31,7 @@ public:
 
         if (op->IsImmediate()) {
             // Every time we execute immediate transaction we may choose a new mvcc version
-            op->MvccReadWriteVersion.reset();
+            op->CachedMvccVersion.reset();
         }
 
         TDataShardLocksDb locksDb(DataShard, txc);

--- a/ydb/core/tx/datashard/execute_commit_writes_tx_unit.cpp
+++ b/ydb/core/tx/datashard/execute_commit_writes_tx_unit.cpp
@@ -34,7 +34,7 @@ public:
         TSetupSysLocks guardLocks(op, DataShard, &locksDb);
 
         const auto& commitTx = tx->GetCommitWritesTx()->GetBody();
-        const auto versions = DataShard.GetReadWriteVersions(op.Get());
+        const auto mvccVersion = DataShard.GetMvccVersion(op.Get());
 
         const auto& tableId = commitTx.GetTableId();
         const auto& tableInfo = *DataShard.GetUserTables().at(tableId.GetTableId());
@@ -44,7 +44,7 @@ public:
 
         // FIXME: temporary break all locks, but we want to be smarter about which locks we break
         DataShard.SysLocksTable().BreakAllLocks(fullTableId);
-        txc.DB.CommitTx(tableInfo.LocalTid, writeTxId, versions.WriteVersion);
+        txc.DB.CommitTx(tableInfo.LocalTid, writeTxId, mvccVersion);
         DataShard.GetConflictsCache().GetTableCache(tableInfo.LocalTid).RemoveUncommittedWrites(writeTxId, txc.DB);
 
         if (Pipeline.AddLockDependencies(op, guardLocks)) {

--- a/ydb/core/tx/datashard/execute_write_unit.cpp
+++ b/ydb/core/tx/datashard/execute_write_unit.cpp
@@ -254,7 +254,7 @@ public:
 
         if (op->IsImmediate()) {
             // Every time we execute immediate transaction we may choose a new mvcc version
-            op->MvccReadWriteVersion.reset();
+            op->CachedMvccVersion.reset();
         }
 
         const TValidatedWriteTx::TPtr& writeTx = writeOp->GetWriteTx();
@@ -302,9 +302,9 @@ public:
 
         NMiniKQL::TEngineHostCounters engineHostCounters;
         const ui64 txId = writeTx->GetTxId();
-        const auto [readVersion, writeVersion] = DataShard.GetReadWriteVersions(writeOp);
+        const auto mvccVersion = DataShard.GetMvccVersion(writeOp);
         
-        TDataShardUserDb userDb(DataShard, txc.DB, op->GetGlobalTxId(), readVersion, writeVersion, engineHostCounters, TAppData::TimeProvider->Now());
+        TDataShardUserDb userDb(DataShard, txc.DB, op->GetGlobalTxId(), mvccVersion, engineHostCounters, TAppData::TimeProvider->Now());
         userDb.SetIsWriteTx(true);
         userDb.SetIsImmediateTx(op->IsImmediate());
         userDb.SetLockTxId(writeTx->GetLockTxId());
@@ -401,7 +401,7 @@ public:
 
             const bool isArbiter = op->HasVolatilePrepareFlag() && KqpLocksIsArbiter(tabletId, kqpLocks);
 
-            KqpCommitLocks(tabletId, kqpLocks, sysLocks, writeVersion, userDb);
+            KqpCommitLocks(tabletId, kqpLocks, sysLocks, userDb);
 
             if (writeTx->HasOperations()) {
                 for (validatedOperationIndex = 0; validatedOperationIndex < writeTx->GetOperations().size(); ++validatedOperationIndex) {
@@ -440,7 +440,7 @@ public:
                 TVector<ui64> participants(awaitingDecisions.begin(), awaitingDecisions.end());
                 DataShard.GetVolatileTxManager().PersistAddVolatileTx(
                     userDb.GetVolatileTxId(),
-                    writeVersion,
+                    mvccVersion,
                     commitTxIds,
                     userDb.GetVolatileDependencies(),
                     participants,

--- a/ydb/core/tx/datashard/finish_propose_unit.cpp
+++ b/ydb/core/tx/datashard/finish_propose_unit.cpp
@@ -57,11 +57,11 @@ TDataShard::TPromotePostExecuteEdges TFinishProposeUnit::PromoteImmediatePostExe
         } else {
             return DataShard.PromoteImmediatePostExecuteEdges(op->GetMvccSnapshot(), TDataShard::EPromotePostExecuteEdges::ReadOnly, txc);
         }
-    } else if (op->MvccReadWriteVersion) {
+    } else if (op->CachedMvccVersion) {
         if (op->IsReadOnly() || op->LockTxId()) {
-            return DataShard.PromoteImmediatePostExecuteEdges(*op->MvccReadWriteVersion, TDataShard::EPromotePostExecuteEdges::ReadOnly, txc);
+            return DataShard.PromoteImmediatePostExecuteEdges(*op->CachedMvccVersion, TDataShard::EPromotePostExecuteEdges::ReadOnly, txc);
         } else {
-            return DataShard.PromoteImmediatePostExecuteEdges(*op->MvccReadWriteVersion, TDataShard::EPromotePostExecuteEdges::ReadWrite, txc);
+            return DataShard.PromoteImmediatePostExecuteEdges(*op->CachedMvccVersion, TDataShard::EPromotePostExecuteEdges::ReadWrite, txc);
         }
     } else {
         return { };
@@ -198,8 +198,8 @@ void TFinishProposeUnit::CompleteRequest(TOperation::TPtr op,
             LWTRACK(ProposeTransactionSendResult, op->Orbit);
             res->Orbit = std::move(op->Orbit);
         }
-        if (op->IsImmediate() && !op->IsReadOnly() && !op->IsAborted() && op->MvccReadWriteVersion) {
-            DataShard.SendImmediateWriteResult(*op->MvccReadWriteVersion, op->GetTarget(), res.Release(), op->GetCookie(), {}, op->GetTraceId());
+        if (op->IsImmediate() && !op->IsReadOnly() && !op->IsAborted() && op->CachedMvccVersion) {
+            DataShard.SendImmediateWriteResult(*op->CachedMvccVersion, op->GetTarget(), res.Release(), op->GetCookie(), {}, op->GetTraceId());
         } else if (op->IsImmediate() && op->IsReadOnly() && !op->IsAborted()) {
             // TODO: we should actually measure a read timestamp and use it here
             DataShard.SendImmediateReadResult(op->GetTarget(), res.Release(), op->GetCookie(), {}, op->GetTraceId());

--- a/ydb/core/tx/datashard/operation.h
+++ b/ydb/core/tx/datashard/operation.h
@@ -965,7 +965,7 @@ private:
     std::optional<TRowVersion> CommittingOpsVersion;
 
 public:
-    std::optional<TRowVersion> MvccReadWriteVersion;
+    std::optional<TRowVersion> CachedMvccVersion;
 
 public:
     // Orbit used for tracking operation progress

--- a/ydb/core/tx/datashard/read_table_scan_unit.cpp
+++ b/ydb/core/tx/datashard/read_table_scan_unit.cpp
@@ -133,7 +133,7 @@ EExecutionStatus TReadTableScanUnit::Execute(TOperation::TPtr op,
         } else {
             // Note: this mode is only used in legacy tests and may not work with volatile transactions
             // With mvcc we have to mark all preceding transactions as logically complete
-            auto readVersion = DataShard.GetReadWriteVersions(tx).ReadVersion;
+            auto readVersion = DataShard.GetMvccVersion(tx);
             hadWrites |= Pipeline.MarkPlannedLogicallyCompleteUpTo(readVersion, txc);
             if (op->IsMvccSnapshotRepeatable() || !op->IsImmediate()) {
                 hadWrites |= DataShard.PromoteCompleteEdge(op.Get(), txc);

--- a/ydb/core/tx/datashard/setup_sys_locks.h
+++ b/ydb/core/tx/datashard/setup_sys_locks.h
@@ -34,17 +34,17 @@ struct TSetupSysLocks
         LockTxId = op->LockTxId();
         LockNodeId = op->LockNodeId();
 
-        auto [readVersion, writeVersion] = self.GetReadWriteVersions(op.Get());
+        auto mvccVersion = self.GetMvccVersion(op.Get());
 
         // check whether the current operation is a part of an out-of-order Tx
         bool outOfOrder = false;
         if (auto &activeOps = self.Pipeline.GetActivePlannedOps()) {
-            if (auto it = activeOps.begin(); writeVersion != TRowVersion(it->first.Step, it->first.TxId))
+            if (auto it = activeOps.begin(); mvccVersion != TRowVersion(it->first.Step, it->first.TxId))
                 outOfOrder = true;
         }
 
-        CheckVersion = readVersion;
-        BreakVersion = outOfOrder ? writeVersion : TRowVersion::Min();
+        CheckVersion = mvccVersion;
+        BreakVersion = outOfOrder ? mvccVersion : TRowVersion::Min();
 
         if (!op->LocksCache().Locks.empty())
             SysLocksTable.SetCache(&op->LocksCache());


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

...

### Changelog category <!-- remove all except one -->

* Not for changelog (changelog entry is not required)

### Description for reviewers <!-- (optional) description for those who read this PR -->

This patch fixes unexpected unique constraint errors when duplicate key is committed after a transaction acquires its read snapshot. A couple of tests are added: one ensures transaction fails with an ABORTED error when INSERT is performed before the commit, another when INSERT is performed together with the commit (behavior changes when KQP doesn't force flush INSERT before the commit).

To work correctly datashards need MvccSnapshot specified now, so it can make sure writes are performed over the correct version. I found out that EvWrite didn't work correctly when writing over a snapshot (which is chosen by datashard even when MvccSnapshot is not specified), and could produce inconsistent results when more recent changes are present. This could affect CDC and async index correctness.

I'm marking this as "not for changelog" since EvWrite is not enabled in production yet.

Fixes #19531.
Merges #20448, #20514, #20545.