### PR TITLE
Add option to commit or abort transactions from the administrator's UI

### DIFF
--- a/ydb/core/persqueue/pq_impl.h
+++ b/ydb/core/persqueue/pq_impl.h
@@ -94,6 +94,7 @@ class TPersQueue : public NKeyValue::TKeyValueFlat {
 
     bool OnRenderAppHtmlPage(NMon::TEvRemoteHttpInfo::TPtr ev, const TActorContext& ctx) override;
     bool OnRenderAppHtmlPageTx(NMon::TEvRemoteHttpInfo::TPtr ev, const TActorContext& ctx);
+    bool OnSendReadSetToYourself(NMon::TEvRemoteHttpInfo::TPtr& ev, const TActorContext& ctx);
 
     void HandleDie(const TActorContext& ctx) override;
 

--- a/ydb/core/persqueue/pq_impl.h
+++ b/ydb/core/persqueue/pq_impl.h
@@ -95,6 +95,7 @@ class TPersQueue : public NKeyValue::TKeyValueFlat {
     bool OnRenderAppHtmlPage(NMon::TEvRemoteHttpInfo::TPtr ev, const TActorContext& ctx) override;
     bool OnRenderAppHtmlPageTx(NMon::TEvRemoteHttpInfo::TPtr ev, const TActorContext& ctx);
     bool OnSendReadSetToYourself(NMon::TEvRemoteHttpInfo::TPtr& ev, const TActorContext& ctx);
+    TString RenderSendReadSetHtmlForms(const TDistributedTransaction& tx, ui64 tabletSource) const;
 
     void HandleDie(const TActorContext& ctx) override;
 

--- a/ydb/core/persqueue/pq_impl.h
+++ b/ydb/core/persqueue/pq_impl.h
@@ -95,7 +95,7 @@ class TPersQueue : public NKeyValue::TKeyValueFlat {
     bool OnRenderAppHtmlPage(NMon::TEvRemoteHttpInfo::TPtr ev, const TActorContext& ctx) override;
     bool OnRenderAppHtmlPageTx(NMon::TEvRemoteHttpInfo::TPtr ev, const TActorContext& ctx);
     bool OnSendReadSetToYourself(NMon::TEvRemoteHttpInfo::TPtr& ev, const TActorContext& ctx);
-    TString RenderSendReadSetHtmlForms(const TDistributedTransaction& tx, ui64 tabletSource) const;
+    TString RenderSendReadSetHtmlForms(const TDistributedTransaction& tx, const TMaybe<TConstArrayRef<ui64>> tabletSourcesFilter) const;
 
     void HandleDie(const TActorContext& ctx) override;
 

--- a/ydb/core/persqueue/pq_impl_app.cpp
+++ b/ydb/core/persqueue/pq_impl_app.cpp
@@ -228,6 +228,10 @@ bool TPersQueue::OnRenderAppHtmlPage(NMon::TEvRemoteHttpInfo::TPtr ev, const TAc
         return true;
     }
 
+    if (ev->Get()->Cgi().Has("SendReadSet")) {
+        return OnSendReadSetToYourself(ev, ctx);
+    }
+
     if (ev->Get()->Cgi().Has("kv")) {
         return TKeyValueFlat::OnRenderAppHtmlPage(ev, ctx);
     }

--- a/ydb/core/persqueue/pq_impl_app.cpp
+++ b/ydb/core/persqueue/pq_impl_app.cpp
@@ -212,6 +212,28 @@ bool TPersQueue::OnRenderAppHtmlPageTx(NMon::TEvRemoteHttpInfo::TPtr ev, const T
                 PRE() {
                     str << SecureDebugStringMultiline(tx->Serialize());
                 }
+                TAG(TH2) {str << "Tablets";}
+                TABLE_SORTABLE_CLASS("table") {
+                    TABLEHEAD() {
+                        TABLER() {
+                            TABLEH() {str << "Idx";}
+                            TABLEH() {str << "Predicate";}
+                        }
+                    }
+                    TABLEBODY() {
+                        for (const auto& [idx, predicate] : tx->PredicatesReceived) {
+                            TABLER() {
+                                TABLED() {str << idx;}
+                                const TStringBuf cls = predicate.HasPredicate() ? (predicate.GetPredicate() ? "success"sv : "danger"sv) : ""sv;
+                                TABLED_CLASS(cls) {
+                                    if (predicate.HasPredicate()) {
+                                        str << (predicate.GetPredicate() ? "TRUE"sv : "FALSE"sv);
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
             }
         } else {
             str << "Transaction " << txId << " not found";

--- a/ydb/core/persqueue/pq_impl_app.cpp
+++ b/ydb/core/persqueue/pq_impl_app.cpp
@@ -212,18 +212,22 @@ bool TPersQueue::OnRenderAppHtmlPageTx(NMon::TEvRemoteHttpInfo::TPtr ev, const T
                 PRE() {
                     str << SecureDebugStringMultiline(tx->Serialize());
                 }
-                TAG(TH2) {str << "Tablets";}
+                TAG(TH2) {str << "Predicates";}
                 TABLE_SORTABLE_CLASS("table") {
                     TABLEHEAD() {
                         TABLER() {
-                            TABLEH() {str << "Idx";}
-                            TABLEH() {str << "Predicate";}
+                            TABLEH() {str << "Tablet ID";}
+                            TABLEH() {str << "Predicate value";}
                         }
                     }
                     TABLEBODY() {
-                        for (const auto& [idx, predicate] : tx->PredicatesReceived) {
+                        for (const auto& [tabletID, predicate] : tx->PredicatesReceived) {
                             TABLER() {
-                                TABLED() {str << idx;}
+                                TABLED() {
+                                    HREF(TStringBuilder() << "?TabletID=" << tabletID << "&TxId=" << txId) {
+                                        str << tabletID;
+                                    }
+                                }
                                 const TStringBuf cls = predicate.HasPredicate() ? (predicate.GetPredicate() ? "success"sv : "danger"sv) : ""sv;
                                 TABLED_CLASS(cls) {
                                     if (predicate.HasPredicate()) {

--- a/ydb/core/persqueue/pq_impl_app_sendreadset.cpp
+++ b/ydb/core/persqueue/pq_impl_app_sendreadset.cpp
@@ -1,0 +1,61 @@
+#include "pq_impl.h"
+
+namespace NKikimr::NPQ {
+
+TString MakeReadSetData(bool commit)
+{
+    NKikimrTx::TReadSetData data;
+    data.SetDecision(commit ? NKikimrTx::TReadSetData::DECISION_COMMIT : NKikimrTx::TReadSetData::DECISION_ABORT);
+
+    TString encoded;
+    Y_ABORT_UNLESS(data.SerializeToString(&encoded));
+
+    return encoded;
+}
+
+template <class T>
+TMaybe<T> GetParameter(NMon::TEvRemoteHttpInfo::TPtr& ev, const TString& name)
+{
+    if (!ev->Get()->Cgi().Has(name)) {
+        return Nothing();
+    }
+    return FromString<T>(ev->Get()->Cgi().Get(name));
+}
+
+bool TPersQueue::OnSendReadSetToYourself(NMon::TEvRemoteHttpInfo::TPtr& ev, const TActorContext& ctx)
+{
+    auto step = GetParameter<ui64>(ev, "step");
+    auto txId = GetParameter<ui64>(ev, "txId");
+    auto senderTablet = GetParameter<ui64>(ev, "senderTablet");
+    auto decision = GetParameter<TString>(ev, "decision");
+
+    if (!step.Defined() || !txId.Defined() || !senderTablet.Defined() || !decision.Defined()) {
+        ctx.Send(ev->Sender, new NMon::TEvRemoteJsonInfoRes(R"({"result":"expected step, txId, senderTablet and decision"})"));
+        return true;
+    }
+
+    auto* tx = GetTransaction(ctx, *txId);
+    if (!tx) {
+        ctx.Send(ev->Sender, new NMon::TEvRemoteJsonInfoRes(R"({"result":"unknown tx"})"));
+        return true;
+    }
+    if (tx->Step != *step) {
+        ctx.Send(ev->Sender, new NMon::TEvRemoteJsonInfoRes(R"({"result":"invalid step"})"));
+        return true;
+    }
+
+    auto event = std::make_unique<TEvTxProcessing::TEvReadSet>(*step,
+                                                               *txId,
+                                                               *senderTablet,
+                                                               TabletID(),
+                                                               *senderTablet,
+                                                               MakeReadSetData(*decision == "commit"),
+                                                               0);
+    ctx.Send(ctx.SelfID, std::move(event));
+
+    ctx.Send(ev->Sender, new NMon::TEvRemoteJsonInfoRes(R"({"result":"OK"})"));
+
+    return true;
+}
+
+}

--- a/ydb/core/persqueue/pq_impl_app_sendreadset.cpp
+++ b/ydb/core/persqueue/pq_impl_app_sendreadset.cpp
@@ -5,7 +5,7 @@
 
 namespace NKikimr::NPQ {
 
-TString MakeReadSetData(bool commit)
+static TString MakeReadSetData(bool commit)
 {
     NKikimrTx::TReadSetData data;
     data.SetDecision(commit ? NKikimrTx::TReadSetData::DECISION_COMMIT : NKikimrTx::TReadSetData::DECISION_ABORT);
@@ -17,15 +17,27 @@ TString MakeReadSetData(bool commit)
 }
 
 template <class T>
-TMaybe<T> GetParameter(NMon::TEvRemoteHttpInfo::TPtr& ev, const TString& name)
+static TMaybe<T> GetParameter(const TCgiParameters& cgi, const TStringBuf name)
 {
-    if (!ev->Get()->Cgi().Has(name)) {
+    if (!cgi.Has(name)) {
         return Nothing();
     }
-    return FromString<T>(ev->Get()->Cgi().Get(name));
+    return FromString<T>(cgi.Get(name));
 }
 
-TString TPersQueue::RenderSendReadSetHtmlForms(const TDistributedTransaction& tx, ui64 tabletSource) const
+template <class T>
+static TVector<T> GetParameters(const TCgiParameters& cgi, const TStringBuf name)
+{
+    const auto [first, last] = cgi.equal_range(name);
+    TVector<T> result;
+    for (auto it = first; it != last; ++it) {
+        result.push_back(FromString<T>(it->second));
+    }
+    return result;
+}
+
+
+TString TPersQueue::RenderSendReadSetHtmlForms(const TDistributedTransaction& tx, const TMaybe<TConstArrayRef<ui64>> tabletSourcesFilter) const
 {
     struct TOption {
         const char* Decision;
@@ -33,23 +45,31 @@ TString TPersQueue::RenderSendReadSetHtmlForms(const TDistributedTransaction& tx
         const char* BtnClass;
     };
     static constexpr TOption options[] = {
-        {"commit", "Send commit to {txId}", "btn btn-warning btn-sm"},
-        {"abort", "Send abort to {txId}", "btn btn-danger btn-sm"},
+        {"commit", "Send \"COMMIT\" to {txId}", "btn btn-warning btn-sm"},
+        {"abort", "Send \"ABORT\" to {txId}", "btn btn-danger btn-sm"},
     };
 
     TStringStream str;
     HTML(str) {
-        for (const TOption& option : options) {
-            LAYOUT_COLUMN() {
-                FORM_CLASS("form-horizontal") {
-                    DIV_CLASS("control-group") {
-                        DIV_CLASS("controls") {
-                            str << "<input type='hidden' name='step' value='" << tx.Step << "'/>";
-                            str << "<input type='hidden' name='txId' value='" << tx.TxId << "'/>";
-                            str << "<input type='hidden' name='senderTablet' value='" << tabletSource << "'/>";
-                            str << "<input type='hidden' name='decision' value='" << option.Decision << "'/>";
-                            str << "<input type='hidden' name='TabletID' value='" << TabletID() << "'/>";
-                            str << "<button type='submit' name='SendReadSet' class='" << option.BtnClass << "'>" << fmt::format(fmt::runtime(option.Text), fmt::arg("txId", tx.TxId)) << "</button>";
+        LAYOUT_ROW() {
+            for (const TOption& option : options) {
+                LAYOUT_COLUMN() {
+                    FORM_CLASS("form-horizontal") {
+                        DIV_CLASS("control-group") {
+                            DIV_CLASS("controls") {
+                                if (tabletSourcesFilter.Defined()) {
+                                    for (const ui64 tabletSource : *tabletSourcesFilter) {
+                                        str << "<input type='hidden' name='senderTablet' value='" << tabletSource << "'/>";
+                                    }
+                                } else {
+                                    str << "<input type='hidden' name='allSenderTablets' value='1'/>";
+                                }
+                                str << "<input type='hidden' name='TabletID' value='" << TabletID() << "'/>";
+                                str << "<input type='hidden' name='step' value='" << tx.Step << "'/>";
+                                str << "<input type='hidden' name='txId' value='" << tx.TxId << "'/>";
+                                str << "<input type='hidden' name='decision' value='" << option.Decision << "'/>";
+                                str << "<button type='submit' name='SendReadSet' class='" << option.BtnClass << "'>" << fmt::format(fmt::runtime(option.Text), fmt::arg("txId", tx.TxId)) << "</button>";
+                            }
                         }
                     }
                 }
@@ -59,15 +79,40 @@ TString TPersQueue::RenderSendReadSetHtmlForms(const TDistributedTransaction& tx
     return std::move(str).Str();
 }
 
+static TVector<ui64> GetSenderTablets(const TCgiParameters& cgi, const TDistributedTransaction& tx)
+{
+    if (cgi.Has("allSenderTablets")) {
+        TVector<ui64> senderTablets;
+        for (const auto& [tabletID, predicate] : tx.PredicatesReceived) {
+            if (!predicate.HasPredicate()) {
+                senderTablets.push_back(tabletID);
+            }
+        }
+        return senderTablets;
+    } else {
+        return GetParameters<ui64>(cgi, "senderTablet");
+    }
+}
+
+
 bool TPersQueue::OnSendReadSetToYourself(NMon::TEvRemoteHttpInfo::TPtr& ev, const TActorContext& ctx)
 {
-    auto step = GetParameter<ui64>(ev, "step");
-    auto txId = GetParameter<ui64>(ev, "txId");
-    auto senderTablet = GetParameter<ui64>(ev, "senderTablet");
-    auto decision = GetParameter<TString>(ev, "decision");
+    const TCgiParameters& cgi = ev->Get()->Cgi();
+    const auto step = GetParameter<ui64>(cgi, "step");
+    const auto txId = GetParameter<ui64>(cgi, "txId");
+    const auto decision = GetParameter<TString>(cgi, "decision");
+    const bool hasAllSenderTablets = cgi.Has("allSenderTablets");
+    const bool hasSenderTablet = cgi.Has("senderTablet");
 
-    if (!step.Defined() || !txId.Defined() || !senderTablet.Defined() || !decision.Defined()) {
-        ctx.Send(ev->Sender, new NMon::TEvRemoteJsonInfoRes(R"({"result":"expected step, txId, senderTablet and decision"})"));
+    if (!step.Defined() || !txId.Defined() || !decision.Defined()) {
+        ctx.Send(ev->Sender, new NMon::TEvRemoteJsonInfoRes(R"({"result":"expected step, txId and decision"})"));
+        return true;
+    }
+    if (!hasAllSenderTablets && !hasSenderTablet) {
+        ctx.Send(ev->Sender, new NMon::TEvRemoteJsonInfoRes(R"({"result":"expected senderTablet parameter or allSenderTablets flag"})"));
+        return true;
+    } else if (hasAllSenderTablets && hasSenderTablet) {
+        ctx.Send(ev->Sender, new NMon::TEvRemoteJsonInfoRes(R"({"result":"senderTablet parameter and allSenderTablets flag are mutually exclusive"})"));
         return true;
     }
 
@@ -80,15 +125,22 @@ bool TPersQueue::OnSendReadSetToYourself(NMon::TEvRemoteHttpInfo::TPtr& ev, cons
         ctx.Send(ev->Sender, new NMon::TEvRemoteJsonInfoRes(R"({"result":"invalid step"})"));
         return true;
     }
+    const auto senderTablets = GetSenderTablets(cgi, *tx);
+    if (senderTablets.empty()) {
+        ctx.Send(ev->Sender, new NMon::TEvRemoteJsonInfoRes(R"({"result":"empty senderTablets array"})"));
+        return true;
+    }
 
-    auto event = std::make_unique<TEvTxProcessing::TEvReadSet>(*step,
-                                                               *txId,
-                                                               *senderTablet,
-                                                               TabletID(),
-                                                               *senderTablet,
-                                                               MakeReadSetData(*decision == "commit"),
-                                                               0);
-    ctx.Send(ctx.SelfID, std::move(event));
+    for (const auto senderTablet : senderTablets) {
+        auto event = std::make_unique<TEvTxProcessing::TEvReadSet>(*step,
+                                                                   *txId,
+                                                                   senderTablet,
+                                                                   TabletID(),
+                                                                   senderTablet,
+                                                                   MakeReadSetData(decision == "commit"),
+                                                                   0);
+        ctx.Send(ctx.SelfID, std::move(event));
+    }
 
     ctx.Send(ev->Sender, new NMon::TEvRemoteJsonInfoRes(R"({"result":"OK"})"));
 

--- a/ydb/core/persqueue/ut/pqtablet_ut.cpp
+++ b/ydb/core/persqueue/ut/pqtablet_ut.cpp
@@ -253,7 +253,7 @@ protected:
     void SendSaveTxState(TAutoPtr<IEventHandle>& event);
 
     void WaitForTheTransactionToBeDeleted(ui64 txId);
-    
+
     TVector<TString> WaitForExactSupportivePartitionsCount(ui32 expectedCount);
     TVector<TString> GetSupportivePartitionsKeysFromKV();
     NKikimrPQ::TTabletTxInfo WaitForExactTxWritesCount(ui32 expectedCount);
@@ -2331,7 +2331,7 @@ Y_UNIT_TEST_F(Kafka_Transaction_Supportive_Partitions_Should_Be_Deleted_After_Ti
     UNIT_ASSERT_VALUES_EQUAL(txInfo.GetTxWrites(0).GetKafkaTransaction(), true);
 
     // increment time till after kafka txn timeout
-    ui64 kafkaTxnTimeoutMs = Ctx->Runtime->GetAppData(0).KafkaProxyConfig.GetTransactionTimeoutMs() 
+    ui64 kafkaTxnTimeoutMs = Ctx->Runtime->GetAppData(0).KafkaProxyConfig.GetTransactionTimeoutMs()
         + KAFKA_TRANSACTION_DELETE_DELAY_MS;
     Ctx->Runtime->AdvanceCurrentTime(TDuration::MilliSeconds(kafkaTxnTimeoutMs + 1));
     SendToPipe(Ctx->Edge, MakeHolder<TEvents::TEvWakeup>().Release());
@@ -2365,7 +2365,7 @@ Y_UNIT_TEST_F(Non_Kafka_Transaction_Supportive_Partitions_Should_Not_Be_Deleted_
     UNIT_ASSERT_VALUES_EQUAL(txInfo2.TxWritesSize(), 2);
 
     // increment time till after kafka txn timeout
-    ui64 kafkaTxnTimeoutMs = Ctx->Runtime->GetAppData(0).KafkaProxyConfig.GetTransactionTimeoutMs() 
+    ui64 kafkaTxnTimeoutMs = Ctx->Runtime->GetAppData(0).KafkaProxyConfig.GetTransactionTimeoutMs()
         + KAFKA_TRANSACTION_DELETE_DELAY_MS;
     Ctx->Runtime->AdvanceCurrentTime(TDuration::MilliSeconds(kafkaTxnTimeoutMs + 1));
     SendToPipe(Ctx->Edge, MakeHolder<TEvents::TEvWakeup>().Release());
@@ -2381,7 +2381,7 @@ Y_UNIT_TEST_F(In_Kafka_Txn_Only_Supportive_Partitions_That_Exceeded_Timeout_Shou
     NKafka::TProducerInstanceId producerInstanceId2 = {2, 0};
     PQTabletPrepare({.partitions=1}, {}, *Ctx);
     EnsurePipeExist();
-    
+
     // create first kafka-transacition and write data to it
     TString ownerCookie1 = CreateSupportivePartitionForKafka(producerInstanceId1);
     SendKafkaTxnWriteRequest(producerInstanceId1, ownerCookie1);
@@ -2391,7 +2391,7 @@ Y_UNIT_TEST_F(In_Kafka_Txn_Only_Supportive_Partitions_That_Exceeded_Timeout_Shou
     // advance time to value strictly less then kafka transaction timeout
     ui64 testTimeAdvanceMs = KAFKA_TRANSACTION_DELETE_DELAY_MS / 2;
     Ctx->Runtime->AdvanceCurrentTime(TDuration::MilliSeconds(testTimeAdvanceMs));
-    
+
     // create second kafka-transacition and write data to it
     EnsurePipeExist();
     TString ownerCookie2 = CreateSupportivePartitionForKafka(producerInstanceId2);

--- a/ydb/core/persqueue/ut/ya.make
+++ b/ydb/core/persqueue/ut/ya.make
@@ -17,6 +17,7 @@ ENDIF()
 
 PEERDIR(
     library/cpp/getopt
+    library/cpp/json
     library/cpp/regex/pcre
     library/cpp/svnversion
     ydb/core/persqueue/ut/common

--- a/ydb/core/persqueue/ya.make
+++ b/ydb/core/persqueue/ya.make
@@ -30,6 +30,7 @@ SRCS(
     pq.cpp
     pq_database.cpp
     pq_impl_app.cpp
+    pq_impl_app_sendreadset.cpp
     pq_impl.cpp
     pq_l2_cache.cpp
     pq_rl_helpers.cpp

--- a/ydb/core/persqueue/ya.make
+++ b/ydb/core/persqueue/ya.make
@@ -58,6 +58,7 @@ GENERATE_ENUM_SERIALIZATION(read_balancer__balancing.h)
 GENERATE_ENUM_SERIALIZATION(sourceid_info.h)
 
 PEERDIR(
+    contrib/libs/fmt
     ydb/library/actors/core
     library/cpp/html/pcdata
     library/cpp/json


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

The administrative UI now contains buttons that allow to simulate the tablet receiving a TEvReadSet PQ message.

### Changelog category <!-- remove all except one -->

* Not for changelog (changelog entry is not required)

### Description for reviewers <!-- (optional) description for those who read this PR -->

LOGBROKER-9735
