### PR TITLE
fixed memory travel when PartitionGraph was changed

### DIFF
--- a/ydb/core/kafka_proxy/actors/kafka_read_session_actor.cpp
+++ b/ydb/core/kafka_proxy/actors/kafka_read_session_actor.cpp
@@ -476,7 +476,7 @@ void TKafkaReadSessionActor::HandleAuthOk(NGRpcProxy::V1::TEvPQProxy::TEvAuthRes
 
     for (const auto& [name, t] : ev->Get()->TopicAndTablets) {
         auto internalName = t.TopicNameConverter->GetInternalName();
-        TopicsInfo[internalName] = NGRpcProxy::TTopicHolder::FromTopicInfo(t);
+        TopicsInfo[internalName] = NKikimr::NGRpcProxy::TTopicHolder(t);
         FullPathToConverter[t.TopicNameConverter->GetPrimaryPath()] = t.TopicNameConverter;
         FullPathToConverter[t.TopicNameConverter->GetSecondaryPath()] = t.TopicNameConverter;
     }

--- a/ydb/core/persqueue/partition.cpp
+++ b/ydb/core/persqueue/partition.cpp
@@ -3263,9 +3263,7 @@ void TPartition::EmulatePostProcessUserAct(const TEvPQ::TEvSetClientInfo& act,
         );
 
         userInfo.Offset = offset;
-        if (userInfo.Offset <= (i64)StartOffset) {
-            userInfo.AnyCommits = false;
-        }
+        userInfo.AnyCommits = userInfo.Offset > (i64)StartOffset;
 
         if (LastOffsetHasBeenCommited(userInfo)) {
             SendReadingFinished(user);

--- a/ydb/core/persqueue/partition_init.h
+++ b/ydb/core/persqueue/partition_init.h
@@ -140,6 +140,8 @@ public:
 
     void Execute(const TActorContext& ctx) override;
     void Handle(TEvKeyValue::TEvResponse::TPtr& ev, const TActorContext& ctx) override;
+
+    void PostProcessing(const TActorContext& ctx);
 };
 
 class TInitDataRangeStep: public TBaseKVStep {

--- a/ydb/core/persqueue/ut/common/autoscaling_ut_common.cpp
+++ b/ydb/core/persqueue/ut/common/autoscaling_ut_common.cpp
@@ -113,6 +113,7 @@ TTopicSdkTestSetup CreateSetup() {
     setup.GetRuntime().GetAppData().PQConfig.SetTopicsAreFirstClassCitizen(true);
     setup.GetRuntime().GetAppData().PQConfig.SetUseSrcIdMetaMappingInFirstClass(true);
     setup.GetRuntime().GetAppData().PQConfig.SetBalancerWakeupIntervalSec(1);
+    setup.GetRuntime().GetAppData().PQConfig.SetACLRetryTimeoutSec(1);
 
     return setup;
 }

--- a/ydb/core/persqueue/ut/ut_with_sdk/commitoffset_ut.cpp
+++ b/ydb/core/persqueue/ut/ut_with_sdk/commitoffset_ut.cpp
@@ -618,6 +618,49 @@ Y_UNIT_TEST_SUITE(CommitOffset) {
             return true;
         });
     }
+
+    Y_UNIT_TEST(DistributedTxCommit_LongReadSession) {
+        TTopicSdkTestSetup setup = CreateSetup();
+        PrepareAutopartitionedTopic(setup);
+
+        std::vector<NYdb::NTopic::TReadSessionEvent::TDataReceivedEvent> messages;
+
+        auto result = setup.Read(TEST_TOPIC, TEST_CONSUMER, [&](auto& x) {
+            messages.push_back(x);
+            return true;
+        });
+
+        {
+            Cerr << ">>>>> Alter topic" << Endl << Flush;
+            TTopicClient client(setup.MakeDriver());
+            TAlterTopicSettings settings;
+            settings.SetRetentionPeriod(TDuration::Hours(1));
+            client.AlterTopic(TEST_TOPIC, settings).GetValueSync();
+        }
+
+        // Wait recheck acl happened
+        messages[0].GetMessages()[0].Commit(); // trigger recheck
+        Sleep(TDuration::Seconds(5));
+
+        Cerr << ">>>>> Commit message" << Endl << Flush;
+
+        bool first = true;
+        for (auto& e : messages) {
+            for (auto& m :e.GetMessages()) {
+                if (first) {
+                    first = false;
+                    continue;
+                }
+                m.Commit();
+            }
+        }
+
+        // Wait commit happened
+        Sleep(TDuration::Seconds(5));
+
+        result.Reader->Close();
+    }
+
 }
 
 } // namespace NKikimr

--- a/ydb/services/deprecated/persqueue_v0/grpc_pq_actor.h
+++ b/ydb/services/deprecated/persqueue_v0/grpc_pq_actor.h
@@ -804,7 +804,7 @@ private:
     THashMap<std::pair<TString, ui32>, TPartitionActorInfo> Partitions; //topic[ClientSideName!]:partition -> info
 
     THashMap<TString, NPersQueue::TTopicConverterPtr> FullPathToConverter; // PrimaryFullPath -> Converter, for balancer replies matching
-    THashMap<TString, TTopicHolder> Topics; // PrimaryName ->topic info
+    THashMap<TString, TTopicHolder::TPtr> Topics; // PrimaryName ->topic info
 
     TVector<ui32> Groups;
     bool ReadOnlyLocal;

--- a/ydb/services/deprecated/persqueue_v0/grpc_pq_read_actor.cpp
+++ b/ydb/services/deprecated/persqueue_v0/grpc_pq_read_actor.cpp
@@ -146,7 +146,7 @@ class TPartitionActor : public NActors::TActorBootstrapped<TPartitionActor> {
 public:
      TPartitionActor(const TActorId& parentId, const TString& clientId, const ui64 cookie, const TString& session, const ui32 generation,
                         const ui32 step, const NPersQueue::TTopicConverterPtr& topic, const TString& database, const ui32 partition, const ui64 tabletID,
-                        const TReadSessionActor::TTopicCounters& counters, const TString& clientDC, std::set<NPQ::TPartitionGraph::Node*> parents);
+                        const TReadSessionActor::TTopicCounters& counters, const TString& clientDC, const TTopicHolder::TPtr& topicHolder);
     ~TPartitionActor();
 
     void Bootstrap(const NActors::TActorContext& ctx);
@@ -212,6 +212,7 @@ private:
     void CommitDone(ui64 cookie, const TActorContext& ctx);
     void SendPartitionReady(const TActorContext& ctx);
 
+    const std::set<NPQ::TPartitionGraph::Node*>& GetParents() const;
 private:
     const TActorId ParentId;
     const TString InternalClientId;
@@ -267,7 +268,7 @@ private:
     bool ReadingFinishedSent;
 
     std::unordered_map<ui64, std::shared_ptr<NKikimr::NGRpcProxy::V1::TDistributedCommitHelper>> Kqps;
-    std::set<NPQ::TPartitionGraph::Node*> Parents;
+    const TTopicHolder::TPtr TopicHolder;
 };
 
 
@@ -347,8 +348,8 @@ void TReadSessionActor::Die(const TActorContext& ctx) {
     }
 
     for (auto& t : Topics) {
-        if (t.second.PipeClient)
-            NTabletPipe::CloseClient(ctx, t.second.PipeClient);
+        if (t.second->PipeClient)
+            NTabletPipe::CloseClient(ctx, t.second->PipeClient);
     }
     LOG_INFO_S(ctx, NKikimrServices::PQ_READ_PROXY, PQ_LOG_PREFIX << " is DEAD");
 
@@ -844,7 +845,7 @@ void TReadSessionActor::RegisterSessions(const TActorContext& ctx) {
 
     for (auto& t : Topics) {
         auto& topic = t.first;
-        RegisterSession(t.second.PipeClient, topic, ctx);
+        RegisterSession(t.second->PipeClient, topic, ctx);
         NumPartitionsFromTopic[topic] = 0;
     }
 }
@@ -978,14 +979,14 @@ void TReadSessionActor::Handle(V1::TEvPQProxy::TEvAuthResultOk::TPtr& ev, const 
 
         for (auto& [name, t] : ev->Get()->TopicAndTablets) {
             auto& topicHolder = Topics[t.TopicNameConverter->GetInternalName()];
-            topicHolder.TabletID = t.TabletID;
-            topicHolder.CloudId = t.CloudId;
-            topicHolder.DbId = t.DbId;
-            topicHolder.DbPath = t.DbPath;
-            topicHolder.IsServerless = t.IsServerless;
-            topicHolder.FolderId = t.FolderId;
-            topicHolder.FullConverter = t.TopicNameConverter;
-            topicHolder.PartitionGraph = t.PartitionGraph;
+            topicHolder->TabletID = t.TabletID;
+            topicHolder->CloudId = t.CloudId;
+            topicHolder->DbId = t.DbId;
+            topicHolder->DbPath = t.DbPath;
+            topicHolder->IsServerless = t.IsServerless;
+            topicHolder->FolderId = t.FolderId;
+            topicHolder->FullConverter = t.TopicNameConverter;
+            topicHolder->PartitionGraph = t.PartitionGraph;
             FullPathToConverter[t.TopicNameConverter->GetPrimaryPath()] = t.TopicNameConverter;
             const auto& second = t.TopicNameConverter->GetSecondaryPath();
             if (!second.empty()) {
@@ -999,7 +1000,7 @@ void TReadSessionActor::Handle(V1::TEvPQProxy::TEvAuthResultOk::TPtr& ev, const 
             clientConfig.CheckAliveness = false;
 
             clientConfig.RetryPolicy = RetryPolicyForPipes;
-            t.second.PipeClient = ctx.RegisterWithSameMailbox(NTabletPipe::CreateClient(ctx.SelfID, t.second.TabletID, clientConfig));
+            t.second->PipeClient = ctx.RegisterWithSameMailbox(NTabletPipe::CreateClient(ctx.SelfID, t.second->TabletID, clientConfig));
         }
 
         RegisterSessions(ctx);
@@ -1014,7 +1015,7 @@ void TReadSessionActor::Handle(V1::TEvPQProxy::TEvAuthResultOk::TPtr& ev, const 
                              NPersQueue::NErrorCode::BAD_REQUEST, ctx);
                 return;
             }
-            it->second.PartitionGraph = t.PartitionGraph;
+            it->second->PartitionGraph = t.PartitionGraph;
         }
     }
 
@@ -1054,7 +1055,7 @@ void TReadSessionActor::Handle(TEvPersQueue::TEvLockPartition::TPtr& ev, const T
     Y_ABORT_UNLESS(!intName.empty());
     auto jt = Topics.find(intName);
 
-    if (jt == Topics.end() || pipe != jt->second.PipeClient) { //this is message from old version of pipe
+    if (jt == Topics.end() || pipe != jt->second->PipeClient) { //this is message from old version of pipe
         LOG_DEBUG_S(
                 ctx, NKikimrServices::PQ_READ_PROXY,
                 PQ_LOG_PREFIX << " ignored ev lock for topic = " << converterIter->second->GetPrintableString()
@@ -1063,7 +1064,7 @@ void TReadSessionActor::Handle(TEvPersQueue::TEvLockPartition::TPtr& ev, const T
         return;
     }
 
-    auto* partitionNode = jt->second.PartitionGraph->GetPartition(record.GetPartition());
+    auto* partitionNode = jt->second->PartitionGraph->GetPartition(record.GetPartition());
     if (!partitionNode) {
         LOG_DEBUG_S(
             ctx, NKikimrServices::PQ_READ_PROXY,
@@ -1079,7 +1080,7 @@ void TReadSessionActor::Handle(TEvPersQueue::TEvLockPartition::TPtr& ev, const T
     // ToDo[counters]
     if (NumPartitionsFromTopic[intName]++ == 0) {
         if (AppData(ctx)->PQConfig.GetTopicsAreFirstClassCitizen()) {
-            SetupTopicCounters(converterIter->second, jt->second.CloudId, jt->second.DbId, jt->second.DbPath, jt->second.IsServerless, jt->second.FolderId);
+            SetupTopicCounters(converterIter->second, jt->second->CloudId, jt->second->DbId, jt->second->DbPath, jt->second->IsServerless, jt->second->FolderId);
         } else {
             SetupTopicCounters(converterIter->second);
         }
@@ -1088,11 +1089,11 @@ void TReadSessionActor::Handle(TEvPersQueue::TEvLockPartition::TPtr& ev, const T
     auto it = TopicCounters.find(intName);
     Y_ABORT_UNLESS(it != TopicCounters.end());
 
-    auto database = jt->second.DbPath;
+    auto database = jt->second->DbPath;
     IActor* partitionActor = new TPartitionActor(
             ctx.SelfID, InternalClientId, Cookie, Session, record.GetGeneration(),
-            record.GetStep(), jt->second.FullConverter, database, record.GetPartition(), record.GetTabletId(), it->second,
-            ClientDC, jt->second.PartitionGraph->GetPartition(record.GetPartition())->AllParents
+            record.GetStep(), jt->second->FullConverter, database, record.GetPartition(), record.GetTabletId(), it->second,
+            ClientDC, jt->second
     );
 
     TActorId actorId = ctx.Register(partitionActor);
@@ -1102,8 +1103,8 @@ void TReadSessionActor::Handle(TEvPersQueue::TEvLockPartition::TPtr& ev, const T
     Y_ABORT_UNLESS(record.GetGeneration() > 0);
     //Partitions use clientside name !
     auto pp = Partitions.insert({
-        std::make_pair(jt->second.FullConverter->GetClientsideName(), record.GetPartition()),
-        TPartitionActorInfo{actorId, (((ui64)record.GetGeneration()) << 32) + record.GetStep(), jt->second.FullConverter}
+        std::make_pair(jt->second->FullConverter->GetClientsideName(), record.GetPartition()),
+        TPartitionActorInfo{actorId, (((ui64)record.GetGeneration()) << 32) + record.GetStep(), jt->second->FullConverter}
     });
     Y_ABORT_UNLESS(pp.second);
     if (SessionsActive) {
@@ -1142,7 +1143,7 @@ void TReadSessionActor::Handle(TEvPQProxy::TEvPartitionStatus::TPtr& ev, const T
         Y_ABORT_UNLESS(ClientsideLocksAllowed);
         TReadResponse result;
         auto lock = result.MutableLock();
-        lock->SetTopic(topicIter->second.FullConverter->GetClientsideName());
+        lock->SetTopic(topicIter->second->FullConverter->GetClientsideName());
         lock->SetPartition(ev->Get()->Partition);
         lock->SetReadOffset(ev->Get()->Offset);
         lock->SetEndOffset(ev->Get()->EndOffset);
@@ -1211,7 +1212,7 @@ void TReadSessionActor::Handle(TEvPersQueue::TEvReleasePartition::TPtr& ev, cons
 
     TActorId pipe = ActorIdFromProto(record.GetPipeClient());
 
-    if (pipe != it->second.PipeClient) { //this is message from old version of pipe
+    if (pipe != it->second->PipeClient) { //this is message from old version of pipe
         return;
     }
 
@@ -1286,14 +1287,14 @@ void TReadSessionActor::InformBalancerAboutRelease(const THashMap<std::pair<TStr
     Y_ABORT_UNLESS(jt != Topics.end());
 
     req.SetSession(Session);
-    ActorIdToProto(jt->second.PipeClient, req.MutablePipeClient());
+    ActorIdToProto(jt->second->PipeClient, req.MutablePipeClient());
     req.SetClientId(InternalClientId);
     req.SetTopic(it->first.first);
     req.SetPartition(it->first.second);
 
     LOG_INFO_S(ctx, NKikimrServices::PQ_READ_PROXY, PQ_LOG_PREFIX << " released: " << it->first.first << ":" << it->first.second);
 
-    NTabletPipe::SendData(ctx, jt->second.PipeClient, request.Release());
+    NTabletPipe::SendData(ctx, jt->second->PipeClient, request.Release());
 }
 
 
@@ -1428,7 +1429,7 @@ bool TReadSessionActor::ProcessReleasePartition(const THashMap<std::pair<TString
 
 bool TReadSessionActor::ProcessBalancerDead(const ui64 tablet, const TActorContext& ctx) {
     for (auto& t : Topics) {
-        if (t.second.TabletID == tablet) {
+        if (t.second->TabletID == tablet) {
             LOG_INFO_S(ctx, NKikimrServices::PQ_READ_PROXY, PQ_LOG_PREFIX << " balancer for topic " << t.first << " is dead, restarting all from this topic");
 
             //Drop all partitions from this topic
@@ -1451,14 +1452,14 @@ bool TReadSessionActor::ProcessBalancerDead(const ui64 tablet, const TActorConte
             NTabletPipe::TClientConfig clientConfig;
             clientConfig.CheckAliveness = false;
             clientConfig.RetryPolicy = RetryPolicyForPipes;
-            t.second.PipeClient = ctx.RegisterWithSameMailbox(NTabletPipe::CreateClient(ctx.SelfID, t.second.TabletID, clientConfig));
+            t.second->PipeClient = ctx.RegisterWithSameMailbox(NTabletPipe::CreateClient(ctx.SelfID, t.second->TabletID, clientConfig));
             if (InitDone) {
                 if (PipeReconnects) {
                     ++(*PipeReconnects);
                     ++(*Errors);
                 }
 
-                RegisterSession(t.second.PipeClient, t.first, ctx);
+                RegisterSession(t.second->PipeClient, t.first, ctx);
             }
         }
     }
@@ -1833,7 +1834,7 @@ void TReadSessionActor::Handle(TEvPQProxy::TEvReadingStarted::TPtr& ev, const TA
     }
 
     auto& topic = it->second;
-    NTabletPipe::SendData(ctx, topic.PipeClient, new TEvPersQueue::TEvReadingPartitionStartedRequest(InternalClientId, msg->PartitionId));
+    NTabletPipe::SendData(ctx, topic->PipeClient, new TEvPersQueue::TEvReadingPartitionStartedRequest(InternalClientId, msg->PartitionId));
 }
 
 void TReadSessionActor::Handle(TEvPQProxy::TEvReadingFinished::TPtr& ev, const TActorContext& ctx) {
@@ -1845,7 +1846,7 @@ void TReadSessionActor::Handle(TEvPQProxy::TEvReadingFinished::TPtr& ev, const T
     }
 
     auto& topic = it->second;
-    NTabletPipe::SendData(ctx, topic.PipeClient, new TEvPersQueue::TEvReadingPartitionFinishedRequest(InternalClientId, msg->PartitionId, false, msg->FirstMessage));
+    NTabletPipe::SendData(ctx, topic->PipeClient, new TEvPersQueue::TEvReadingPartitionFinishedRequest(InternalClientId, msg->PartitionId, false, msg->FirstMessage));
 }
 
 
@@ -1854,7 +1855,7 @@ void TReadSessionActor::Handle(TEvPQProxy::TEvReadingFinished::TPtr& ev, const T
 TPartitionActor::TPartitionActor(
         const TActorId& parentId, const TString& internalClientId, const ui64 cookie, const TString& session,
         const ui32 generation, const ui32 step, const NPersQueue::TTopicConverterPtr& topic, const TString& database, const ui32 partition,
-        const ui64 tabletID, const TReadSessionActor::TTopicCounters& counters, const TString& clientDC, std::set<NPQ::TPartitionGraph::Node*> parents
+        const ui64 tabletID, const TReadSessionActor::TTopicCounters& counters, const TString& clientDC, const TTopicHolder::TPtr& topicHolder
 )
     : ParentId(parentId)
     , InternalClientId(internalClientId)
@@ -1891,7 +1892,7 @@ TPartitionActor::TPartitionActor(
     , Counters(counters)
     , FirstRead(true)
     , ReadingFinishedSent(false)
-    , Parents(parents)
+    , TopicHolder(topicHolder)
 {
 }
 
@@ -1922,11 +1923,21 @@ void TPartitionActor::CheckRelease(const TActorContext& ctx) {
     }
 }
 
+const std::set<NPQ::TPartitionGraph::Node*>& TPartitionActor::GetParents() const {
+    const auto* partition = TopicHolder->PartitionGraph->GetPartition(Partition);
+    if (partition) {
+        return partition->AllParents;
+    }
+
+    static std::set<NPQ::TPartitionGraph::Node*> empty;
+    return empty;
+}
 
 void TPartitionActor::SendCommit(const ui64 readId, const ui64 offset, const TActorContext& ctx) {
-    if (!ClientHasAnyCommits && Parents.size() != 0) {
+    const auto& parents = GetParents();
+    if (!ClientHasAnyCommits && parents.size() != 0) {
         std::vector<NKikimr::NGRpcProxy::V1::TDistributedCommitHelper::TCommitInfo> commits;
-        for (auto& parent: Parents) {
+        for (auto& parent: parents) {
             NKikimr::NGRpcProxy::V1::TDistributedCommitHelper::TCommitInfo commit {.PartitionId = parent->Id, .Offset = Max<i64>(), .KillReadSession = false, .OnlyCheckCommitedToFinish = true, .ReadSessionId = Session};
             commits.push_back(commit);
         }

--- a/ydb/services/lib/actors/type_definitions.h
+++ b/ydb/services/lib/actors/type_definitions.h
@@ -32,6 +32,8 @@ struct TTopicInitInfo {
 using TTopicInitInfoMap = THashMap<TString, TTopicInitInfo>;
 
 struct TTopicHolder {
+    using TPtr = std::shared_ptr<TTopicHolder>;
+
     ui64 TabletID = 0;
     TActorId PipeClient;
     bool ACLRequestInfly = false;
@@ -49,21 +51,25 @@ struct TTopicHolder {
     THashMap<ui32, TPartitionInfo> Partitions;
     std::shared_ptr<NPQ::TPartitionGraph> PartitionGraph;
 
+    TTopicHolder() {
+    }
 
-    inline static TTopicHolder FromTopicInfo(const TTopicInitInfo& info) {
-        return TTopicHolder{
-            .TabletID = info.TabletID,
-            .ACLRequestInfly = false,
-            .CloudId = info.CloudId,
-            .DbId = info.DbId,
-            .DbPath = info.DbPath,
-            .IsServerless = info.IsServerless,
-            .FolderId = info.FolderId,
-            .MeteringMode = info.MeteringMode,
-            .FullConverter = info.TopicNameConverter,
-            .Partitions = info.Partitions,
-            .PartitionGraph = info.PartitionGraph
-        };
+    explicit TTopicHolder(const TTopicInitInfo& info) {
+        TabletID = info.TabletID;
+        ACLRequestInfly = false;
+        CloudId = info.CloudId;
+        DbId = info.DbId;
+        DbPath = info.DbPath;
+        IsServerless = info.IsServerless;
+        FolderId = info.FolderId;
+        MeteringMode = info.MeteringMode;
+        FullConverter = info.TopicNameConverter;
+        Partitions = info.Partitions;
+        PartitionGraph = info.PartitionGraph;
+    }
+
+    inline static TTopicHolder::TPtr FromTopicInfo(const TTopicInitInfo& info) {
+        return std::make_shared<TTopicHolder>(info);
     }
 };
 

--- a/ydb/services/persqueue_v1/actors/partition_actor.cpp
+++ b/ydb/services/persqueue_v1/actors/partition_actor.cpp
@@ -26,7 +26,7 @@ TPartitionActor::TPartitionActor(
         const TString& session, const TPartitionId& partition, const ui32 generation, const ui32 step,
         const ui64 tabletID, const TTopicCounters& counters, bool commitsDisabled,
         const TString& clientDC, bool rangesMode, const NPersQueue::TTopicConverterPtr& topic, const TString& database,
-        bool directRead, bool useMigrationProtocol, ui32 maxTimeLagMs, ui64 readTimestampMs, const std::set<NPQ::TPartitionGraph::Node*>& parents,
+        bool directRead, bool useMigrationProtocol, ui32 maxTimeLagMs, ui64 readTimestampMs, const TTopicHolder::TPtr& topicHolder,
         const std::unordered_set<ui64>& notCommitedToFinishParents
 )
     : ParentId(parentId)
@@ -65,7 +65,7 @@ TPartitionActor::TPartitionActor(
     , WaitDataCookie(0)
     , WaitForData(false)
     , LockCounted(false)
-    , Parents(parents)
+    , TopicHolder(topicHolder)
     , Counters(counters)
     , CommitsDisabled(commitsDisabled)
     , CommitCookie(1)
@@ -159,10 +159,21 @@ void TPartitionActor::Bootstrap(const TActorContext& ctx) {
     ctx.Schedule(PREWAIT_DATA, new TEvents::TEvWakeup());
 }
 
+const std::set<NPQ::TPartitionGraph::Node*>& TPartitionActor::GetParents() const {
+    const auto* partition = TopicHolder->PartitionGraph->GetPartition(Partition.Partition);
+    if (partition) {
+        return partition->AllParents;
+    }
+
+    static std::set<NPQ::TPartitionGraph::Node*> empty;
+    return empty;
+}
+
 void TPartitionActor::SendCommit(const ui64 readId, const ui64 offset, const TActorContext& ctx) {
-    if (!ClientHasAnyCommits && Parents.size() != 0) {
+    const auto& parents = GetParents();
+    if (!ClientHasAnyCommits && parents.size() != 0) {
         std::vector<TDistributedCommitHelper::TCommitInfo> commits;
-        for (auto& parent: Parents) {
+        for (auto& parent: parents) {
             TDistributedCommitHelper::TCommitInfo commit {.PartitionId = parent->Id, .Offset = Max<i64>(), .KillReadSession = false, .OnlyCheckCommitedToFinish = true, .ReadSessionId = Session};
             commits.push_back(commit);
         }

--- a/ydb/services/persqueue_v1/actors/partition_actor.h
+++ b/ydb/services/persqueue_v1/actors/partition_actor.h
@@ -76,7 +76,7 @@ public:
                      const TString& session, const TPartitionId& partition, ui32 generation, ui32 step,
                      const ui64 tabletID, const TTopicCounters& counters, const bool commitsDisabled,
                      const TString& clientDC, bool rangesMode, const NPersQueue::TTopicConverterPtr& topic, const TString& database, bool directRead,
-                     bool useMigrationProtocol, ui32 maxTimeLagMs, ui64 readTimestampMs, const std::set<NPQ::TPartitionGraph::Node*>& parents,
+                     bool useMigrationProtocol, ui32 maxTimeLagMs, ui64 readTimestampMs, const TTopicHolder::TPtr& topicHolder,
                      const std::unordered_set<ui64>& notCommitedToFinishParents);
     ~TPartitionActor();
 
@@ -163,6 +163,7 @@ private:
                                                                       ui64 maxSize, ui64 maxTimeLagMs, ui64 readTimestampMs,
                                                                       ui64 directReadId, ui64 sizeEstimate = 0) const;
 
+    const std::set<NPQ::TPartitionGraph::Node*>& GetParents() const;
 
 private:
     const TActorId ParentId;
@@ -229,7 +230,7 @@ private:
     std::deque<std::pair<ui64, TCommitInfo>> CommitsInfly; //ReadId, Offset
     std::unordered_map<ui64, std::shared_ptr<TDistributedCommitHelper>> Kqps;
 
-    std::set<NPQ::TPartitionGraph::Node*> Parents;
+    const TTopicHolder::TPtr TopicHolder;
 
     TTopicCounters Counters;
 

--- a/ydb/services/persqueue_v1/actors/read_session_actor.cpp
+++ b/ydb/services/persqueue_v1/actors/read_session_actor.cpp
@@ -359,8 +359,8 @@ void TReadSessionActor<UseMigrationProtocol>::Die(const TActorContext& ctx) {
     }
 
     for (const auto& [_, holder] : Topics) {
-        if (holder.PipeClient) {
-            NTabletPipe::CloseClient(ctx, holder.PipeClient);
+        if (holder->PipeClient) {
+            NTabletPipe::CloseClient(ctx, holder->PipeClient);
         }
     }
 
@@ -701,7 +701,7 @@ void TReadSessionActor<UseMigrationProtocol>::NotifyChildren(const TPartitionAct
         }
 
         const auto& topic = topicIt->second;
-        const auto& directChildren = topic.PartitionGraph->GetPartition(partition.Partition.Partition)->DirectChildren;
+        const auto& directChildren = topic->PartitionGraph->GetPartition(partition.Partition.Partition)->DirectChildren;
         if (!directChildren.empty()) {
             for (auto& [_, actorInfo]: Partitions) {
                 for (auto& child: directChildren) {
@@ -1107,7 +1107,7 @@ void TReadSessionActor<UseMigrationProtocol>::Handle(TEvPQProxy::TEvAuthResultOk
                 return CloseSession(PersQueue::ErrorCode::OVERLOAD, TStringBuilder()
                     << "metering mode of topic: " << name << " has been changed", ctx);
             }
-            it->second.PartitionGraph = t.PartitionGraph;
+            it->second->PartitionGraph = t.PartitionGraph;
         }
     }
 
@@ -1133,13 +1133,13 @@ void TReadSessionActor<UseMigrationProtocol>::InitSession(const TActorContext& c
 
     for (auto& [_, holder] : Topics) {
         if (!ReadWithoutConsumer) {
-            holder.PipeClient = CreatePipeClient(holder.TabletID, ctx);
+            holder->PipeClient = CreatePipeClient(holder->TabletID, ctx);
         }
 
-        Y_ABORT_UNLESS(holder.FullConverter);
-        auto it = TopicGroups.find(holder.FullConverter->GetInternalName());
+        Y_ABORT_UNLESS(holder->FullConverter);
+        auto it = TopicGroups.find(holder->FullConverter->GetInternalName());
         if (it != TopicGroups.end()) {
-            holder.Groups = it->second;
+            holder->Groups = it->second;
         }
     }
 
@@ -1147,33 +1147,33 @@ void TReadSessionActor<UseMigrationProtocol>::InitSession(const TActorContext& c
 
     for (const auto& [topicName, topic] : Topics) {
         if (ReadWithoutConsumer) {
-            if (topic.Groups.size() == 0) {
+            if (topic->Groups.size() == 0) {
                 return CloseSession(PersQueue::ErrorCode::BAD_REQUEST, "explicitly specify the partitions when reading without a consumer", ctx);
             }
-            for (auto group : topic.Groups) {
+            for (auto group : topic->Groups) {
                 SendLockPartitionToSelf(group-1, topicName, topic, ctx);
             }
         } else {
-            RegisterSession(topic.FullConverter->GetInternalName(), topic.PipeClient, topic.Groups, ctx);
+            RegisterSession(topic->FullConverter->GetInternalName(), topic->PipeClient, topic->Groups, ctx);
         }
 
-        NumPartitionsFromTopic[topic.FullConverter->GetInternalName()] = 0;
+        NumPartitionsFromTopic[topic->FullConverter->GetInternalName()] = 0;
     }
 
     ctx.Schedule(TDuration::Seconds(AppData(ctx)->PQConfig.GetACLRetryTimeoutSec()), new TEvents::TEvWakeup(EWakeupTag::RecheckAcl));
 }
 
 template <bool UseMigrationProtocol>
-void TReadSessionActor<UseMigrationProtocol>::SendLockPartitionToSelf(ui32 partitionId, TString topicName, TTopicHolder topic, const TActorContext& ctx) {
-    auto partitionIt = topic.Partitions.find(partitionId);
-    if (partitionIt == topic.Partitions.end()) {
+void TReadSessionActor<UseMigrationProtocol>::SendLockPartitionToSelf(ui32 partitionId, TString topicName, const TTopicHolder::TPtr& topic, const TActorContext& ctx) {
+    auto partitionIt = topic->Partitions.find(partitionId);
+    if (partitionIt == topic->Partitions.end()) {
         return CloseSession(PersQueue::ErrorCode::BAD_REQUEST, TStringBuilder() << "no partition " << partitionId << " in topic " << topicName, ctx);
     }
     THolder<TEvPersQueue::TEvLockPartition> res{new TEvPersQueue::TEvLockPartition};
     res->Record.SetSession(Session);
     res->Record.SetPartition(partitionId);
     res->Record.SetTopic(topicName);
-    res->Record.SetPath(topic.FullConverter->GetPrimaryPath());
+    res->Record.SetPath(topic->FullConverter->GetPrimaryPath());
     res->Record.SetGeneration(1);
     res->Record.SetStep(1);
     res->Record.SetClientId(ClientId);
@@ -1224,7 +1224,7 @@ void TReadSessionActor<UseMigrationProtocol>::Handle(TEvPersQueue::TEvLockPartit
     const auto name = converter->GetInternalName();
 
     auto topicIt = Topics.find(name);
-    if (topicIt == Topics.end() || (!ReadWithoutConsumer && topicIt->second.PipeClient != ActorIdFromProto(record.GetPipeClient()))) {
+    if (topicIt == Topics.end() || (!ReadWithoutConsumer && topicIt->second->PipeClient != ActorIdFromProto(record.GetPipeClient()))) {
         LOG_ALERT_S(ctx, NKikimrServices::PQ_READ_PROXY, PQ_LOG_PREFIX << " ignored ev lock"
             << ": path# " << name
             << ", reason# " << "topic is unknown");
@@ -1233,7 +1233,7 @@ void TReadSessionActor<UseMigrationProtocol>::Handle(TEvPersQueue::TEvLockPartit
 
     auto& topic = topicIt->second;
 
-    auto* partitionNode = topic.PartitionGraph->GetPartition(record.GetPartition());
+    auto* partitionNode = topic->PartitionGraph->GetPartition(record.GetPartition());
     if (!partitionNode) {
         Locks.push_back(ev->Release());
         if (!AuthInitActor) {
@@ -1245,13 +1245,13 @@ void TReadSessionActor<UseMigrationProtocol>::Handle(TEvPersQueue::TEvLockPartit
     // TODO: counters
     if (NumPartitionsFromTopic[name]++ == 0) {
         if (AppData(ctx)->PQConfig.GetTopicsAreFirstClassCitizen()) {
-            SetupTopicCounters(converter, topic.CloudId, topic.DbId, topic.DbPath, topic.IsServerless, topic.FolderId);
+            SetupTopicCounters(converter, topic->CloudId, topic->DbId, topic->DbPath, topic->IsServerless, topic->FolderId);
         } else {
             SetupTopicCounters(converter);
         }
     }
 
-    topic.Partitions.emplace(record.GetPartition(), NGRpcProxy::TPartitionInfo{record.GetTabletId()});
+    topic->Partitions.emplace(record.GetPartition(), NGRpcProxy::TPartitionInfo{record.GetTabletId()});
 
     // TODO: counters
     auto it = TopicCounters.find(name);
@@ -1277,13 +1277,12 @@ void TReadSessionActor<UseMigrationProtocol>::Handle(TEvPersQueue::TEvLockPartit
         }
     }
 
-    const auto& parentPartitions = partitionNode->AllParents;
-    const auto database = topic.DbPath;
+    const auto database = topic->DbPath;
     const TActorId actorId = ctx.Register(new TPartitionActor(
         ctx.SelfID, ClientId, ClientPath, Cookie, Session, partitionId, record.GetGeneration(),
         record.GetStep(), record.GetTabletId(), it->second, CommitsDisabled, ClientDC, RangesMode,
         converterIter->second, database, DirectRead, UseMigrationProtocol, maxLag, readTimestampMs,
-        parentPartitions, notCommitedToFinishParents));
+        topic, notCommitedToFinishParents));
 
     if (SessionsActive) {
         PartsPerSession.DecFor(Partitions.size(), 1);
@@ -1511,11 +1510,11 @@ void TReadSessionActor<UseMigrationProtocol>::Handle(TEvPersQueue::TEvReleasePar
     auto it = Topics.find(pathIter->second->GetInternalName());
     Y_ABORT_UNLESS(it != Topics.end());
 
-    if (it->second.PipeClient != ActorIdFromProto(record.GetPipeClient())) {
+    if (it->second->PipeClient != ActorIdFromProto(record.GetPipeClient())) {
         return;
     }
 
-    auto& converter = it->second.FullConverter;
+    auto& converter = it->second->FullConverter;
 
     auto tit = TopicCounters.find(converter->GetInternalName());
     Y_ABORT_UNLESS(tit != TopicCounters.end());
@@ -1600,14 +1599,14 @@ void TReadSessionActor<UseMigrationProtocol>::InformBalancerAboutRelease(typenam
 
     auto& req = request->Record;
     req.SetSession(Session);
-    ActorIdToProto(topicInfo.PipeClient, req.MutablePipeClient());
+    ActorIdToProto(topicInfo->PipeClient, req.MutablePipeClient());
     req.SetClientId(ClientId);
     req.SetTopic(converter->GetPrimaryPath());
     req.SetPartition(partitionInfo.Partition.Partition);
 
     LOG_INFO_S(ctx, NKikimrServices::PQ_READ_PROXY, PQ_LOG_PREFIX << " released"
         << ": partition# " << partitionInfo.Partition);
-    NTabletPipe::SendData(ctx, topicInfo.PipeClient, request.Release());
+    NTabletPipe::SendData(ctx, topicInfo->PipeClient, request.Release());
 }
 
 template <bool UseMigrationProtocol>
@@ -1730,9 +1729,9 @@ TActorId TReadSessionActor<UseMigrationProtocol>::CreatePipeClient(ui64 tabletId
 template <bool UseMigrationProtocol>
 void TReadSessionActor<UseMigrationProtocol>::ProcessBalancerDead(ui64 tabletId, const TActorContext& ctx) {
     for (auto& [topicName, topic] : Topics) {
-        if (topic.TabletID == tabletId) {
+        if (topic->TabletID == tabletId) {
             LOG_INFO_S(ctx, NKikimrServices::PQ_READ_PROXY, PQ_LOG_PREFIX << " balancer dead, restarting all from topic"
-                << ": topic# " << topic.FullConverter->GetPrintableString());
+                << ": topic# " << topic->FullConverter->GetPrintableString());
 
             // Drop all partitions from this topic
             for (auto it = Partitions.begin(); it != Partitions.end();) {
@@ -1753,7 +1752,7 @@ void TReadSessionActor<UseMigrationProtocol>::ProcessBalancerDead(ui64 tabletId,
                 }
             }
 
-            topic.PipeClient = CreatePipeClient(topic.TabletID, ctx);
+            topic->PipeClient = CreatePipeClient(topic->TabletID, ctx);
 
             if (InitDone) {
                 if (PipeReconnects) {
@@ -1764,7 +1763,7 @@ void TReadSessionActor<UseMigrationProtocol>::ProcessBalancerDead(ui64 tabletId,
                     ++(*Errors);
                 }
 
-                RegisterSession(topicName, topic.PipeClient, topic.Groups, ctx);
+                RegisterSession(topicName, topic->PipeClient, topic->Groups, ctx);
             }
         }
     }
@@ -2387,7 +2386,7 @@ void TReadSessionActor<UseMigrationProtocol>::Handle(TEvPQProxy::TEvReadingStart
     }
 
     auto& topic = it->second;
-    NTabletPipe::SendData(ctx, topic.PipeClient, new TEvPersQueue::TEvReadingPartitionStartedRequest(ClientId, msg->PartitionId));
+    NTabletPipe::SendData(ctx, topic->PipeClient, new TEvPersQueue::TEvReadingPartitionStartedRequest(ClientId, msg->PartitionId));
 }
 
 template <bool UseMigrationProtocol>
@@ -2400,7 +2399,7 @@ void TReadSessionActor<UseMigrationProtocol>::Handle(TEvPQProxy::TEvReadingFinis
     }
 
     auto& topic = it->second;
-    NTabletPipe::SendData(ctx, topic.PipeClient, new TEvPersQueue::TEvReadingPartitionFinishedRequest(ClientId, msg->PartitionId, AutoPartitioningSupport, msg->FirstMessage));
+    NTabletPipe::SendData(ctx, topic->PipeClient, new TEvPersQueue::TEvReadingPartitionFinishedRequest(ClientId, msg->PartitionId, AutoPartitioningSupport, msg->FirstMessage));
 
     if constexpr (!UseMigrationProtocol) {
         if (AutoPartitioningSupport) {

--- a/ydb/services/persqueue_v1/actors/read_session_actor.h
+++ b/ydb/services/persqueue_v1/actors/read_session_actor.h
@@ -327,7 +327,7 @@ private:
     void InitSession(const TActorContext& ctx);
     void RegisterSession(const TString& topic, const TActorId& pipe, const TVector<ui32>& groups, const TActorContext& ctx);
     void CloseSession(PersQueue::ErrorCode::ErrorCode code, const TString& reason, const TActorContext& ctx);
-    void SendLockPartitionToSelf(ui32 partitionId, TString topicName, TTopicHolder topic, const TActorContext& ctx);
+    void SendLockPartitionToSelf(ui32 partitionId, TString topicName, const TTopicHolder::TPtr& topic, const TActorContext& ctx);
 
     void SetupBytesReadByUserAgentCounter();
     void SetupCounters();
@@ -393,7 +393,7 @@ private:
     ui64 NextAssignId;
     TPartitionsMap Partitions; // assignId -> info
 
-    THashMap<TString, TTopicHolder> Topics; // topic -> info
+    THashMap<TString, TTopicHolder::TPtr> Topics; // topic -> info
     THashMap<TString, NPersQueue::TTopicConverterPtr> FullPathToConverter; // PrimaryFullPath -> Converter, for balancer replies matching
     THashSet<TString> TopicsToResolve;
     THashMap<TString, TVector<ui32>> TopicGroups;


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

Fixed memory travel when consumer commit offset to the topic with autopartitioning enabled

### Changelog category <!-- remove all except one -->

* Bugfix 

### Description for reviewers <!-- (optional) description for those who read this PR -->

LOGBROKER-9744
