### PR TITLE
Avoid unnecessary activations before reclaiming free mailboxes

### DIFF
--- a/ydb/library/actors/core/executor_thread.cpp
+++ b/ydb/library/actors/core/executor_thread.cpp
@@ -212,7 +212,6 @@ namespace NActors {
 
         ThreadCtx.ResetOverwrittenEventsPerMailbox();
         ThreadCtx.ResetOverwrittenTimePerMailboxTs();
-        bool drained = false;
         for (; execCtx.ExecutedEvents < ThreadCtx.OverwrittenEventsPerMailbox(); execCtx.ExecutedEvents++) {
             if (TAutoPtr<IEventHandle> evExt = mailbox->Pop()) {
                 EXECUTOR_THREAD_DEBUG(EDebugLevel::Event, "mailbox->Pop()");
@@ -387,7 +386,6 @@ namespace NActors {
                         ThreadCtx.WorkerId(),
                         recipient.ToString(),
                         SafeTypeName(actor));
-                drained = true;
                 break; // empty queue, leave
             }
         }
@@ -412,7 +410,7 @@ namespace NActors {
 
         NProfiling::TMemoryTagScope::Reset(0);
         TlsActivationContext = nullptr;
-        if (mailbox->IsEmpty() && drained) {
+        if (mailbox->IsEmpty() && mailbox->CanReclaim()) {
             ThreadCtx.FreeMailbox(mailbox);
         } else {
             mailbox->Unlock(ThreadCtx.Pool(), hpnow, RevolvingWriteCounter);

--- a/ydb/library/actors/core/mailbox_lockfree.h
+++ b/ydb/library/actors/core/mailbox_lockfree.h
@@ -186,6 +186,14 @@ namespace NActors {
          */
         void Unlock(IExecutorPool* pool, NHPTimer::STime now, ui64& revolvingCounter);
 
+        /**
+         * Returns true when a free mailbox can be reclaimed
+         */
+        bool CanReclaim() const {
+            Y_DEBUG_ABORT_UNLESS(IsFree());
+            return !EventHead;
+        }
+
     private:
         void EnsureActorMap();
         void OnPreProcessed(IEventHandle* head, IEventHandle* tail) noexcept;


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

...

### Changelog category <!-- remove all except one -->

* Not for changelog (changelog entry is not required)

### Description for reviewers <!-- (optional) description for those who read this PR -->

When mailbox processed the last event after unregistering the last actor the loop could finish early due to preemption, which caused unnecessary empty activation before reclaiming free mailboxes back to the pool. Check the mailbox whether it can be reclaimed instead of a local variable.