### PR TITLE
fix: change cpu requirement to 16

### DIFF
--- a/ydb/tests/compatibility/ya.make
+++ b/ydb/tests/compatibility/ya.make
@@ -25,8 +25,7 @@ TEST_SRCS(
 )
 
 SIZE(LARGE)
-REQUIREMENTS(cpu:all)
-REQUIREMENTS(ram:all)
+REQUIREMENTS(cpu:16)
 INCLUDE(${ARCADIA_ROOT}/ydb/tests/large.inc)
 INCLUDE(${ARCADIA_ROOT}/ydb/tests/tools/s3_recipe/recipe.inc)
 


### PR DESCRIPTION
### Changelog category
* Not for changelog

### Description for reviewers
Compatibility tests now require 16 CPU and none of the ram

Sped up compatibility run from [18h](https://github.com/ydb-platform/ydb/actions/runs/16012060065/job/45171674855) on relwithdebinfo to [7h](https://github.com/ydb-platform/ydb/actions/runs/16052545095/job/45298638823)
