### PR TITLE
always uses block engine reader for olap tables

### DIFF
--- a/.github/config/muted_ya.txt
+++ b/.github/config/muted_ya.txt
@@ -43,6 +43,18 @@ ydb/core/kqp/ut/federated_query/s3 sole chunk chunk
 ydb/core/kqp/ut/indexes KqpMultishardIndex.WriteIntoRenamingAsyncIndex
 ydb/core/kqp/ut/indexes KqpMultishardIndex.WriteIntoRenamingSyncIndex
 ydb/core/kqp/ut/olap [*/*] chunk chunk
+ydb/core/kqp/ut/olap KqpDecimalColumnShard.TestAggregation
+ydb/core/kqp/ut/olap KqpDecimalColumnShard.TestFilterCompare
+ydb/core/kqp/ut/olap KqpDecimalColumnShard.TestFilterEqual
+ydb/core/kqp/ut/olap KqpDecimalColumnShard.TestFilterNulls
+ydb/core/kqp/ut/olap KqpDecimalColumnShard.TestJoinByDecimal
+ydb/core/kqp/ut/olap KqpDecimalColumnShard.TestJoinById
+ydb/core/kqp/ut/olap KqpDecimalColumnShard.TestOrderByDecimal
+ydb/core/kqp/ut/olap KqpDecimalColumnShard.TestSimpleQueries
+ydb/core/kqp/ut/scheme KqpOlapScheme.AddPgColumnWithStore
+ydb/core/kqp/ut/scheme KqpOlapTypes.Decimal
+ydb/core/kqp/ut/scheme KqpOlapTypes.Decimal35
+ydb/core/kqp/ut/scheme KqpOlapTypes.DecimalCsv
 ydb/core/kqp/ut/opt KqpKv.ReadRows_TimeoutCancelsReads
 ydb/core/kqp/ut/query KqpAnalyze.AnalyzeTable+ColumnStore
 ydb/core/kqp/ut/query KqpAnalyze.AnalyzeTable-ColumnStore


### PR DESCRIPTION
### Changelog entry 

always uses block engine reader for olap tables

### Changelog category 

* Not for changelog (changelog entry is not required)

### Description for reviewers <!-- (optional) description for those who read this PR -->

...
