### PR TITLE
Add epoch version & nodes count sensors in NodeBroker & DynamicNameserver

### DIFF
--- a/ydb/core/mind/dynamic_nameserver.cpp
+++ b/ydb/core/mind/dynamic_nameserver.cpp
@@ -556,13 +556,15 @@ void TDynamicNameserver::OnPipeDestroyed(ui32 domain, const TActorContext &ctx)
 }
 
 void TDynamicNameserver::UpdateCounters() {
-    ui32 domain = AppData()->DomainsInfo->GetDomain()->DomainUid;
-    const auto &config = DynamicConfigs[domain];
+    auto info = AppData()->DomainsInfo;
+    if (info->Domain) {
+        const auto &config = DynamicConfigs[info->Domain->DomainUid];
 
-    *EpochVersionCounter = config->Epoch.Version;
-    *ActiveDynamicNodesCounter = config->DynamicNodes.size();
-    *ExpiredDynamicNodesCounter = config->ExpiredNodes.size();
-    *StaticNodesCounter = StaticConfig->StaticNodeTable.size();
+        *EpochVersionCounter = config->Epoch.Version;
+        *ActiveDynamicNodesCounter = config->DynamicNodes.size();
+        *ExpiredDynamicNodesCounter = config->ExpiredNodes.size();
+        *StaticNodesCounter = StaticConfig->StaticNodeTable.size();
+    }
 }
 
 void TDynamicNameserver::Handle(TEvInterconnect::TEvResolveNode::TPtr &ev,

--- a/ydb/core/mind/dynamic_nameserver.cpp
+++ b/ydb/core/mind/dynamic_nameserver.cpp
@@ -1,6 +1,7 @@
 #include "dynamic_nameserver_impl.h"
 
 #include <ydb/core/base/appdata.h>
+#include <ydb/core/base/counters.h>
 #include <ydb/core/base/nameservice.h>
 #include <ydb/core/mon/mon.h>
 #include <ydb/library/services/services.pb.h>
@@ -91,6 +92,7 @@ private:
                 ResetInterconnectProxyConfig(NodeId, ctx);
                 ListNodesCache->Invalidate(); // node was erased
             }
+            Owner->UpdateCounters();
             OnError(rec.GetStatus().GetReason(), ctx);
             return;
         }
@@ -105,6 +107,7 @@ private:
             ResetInterconnectProxyConfig(NodeId, ctx);
         Config->DynamicNodes.emplace(NodeId, node);
 
+        Owner->UpdateCounters();
         OnSuccess(ctx);
     }
 
@@ -240,6 +243,13 @@ void TDynamicNameserver::Bootstrap(const TActorContext &ctx)
         OpenPipe(domain->DomainUid);
     }
 
+    auto counters = GetServiceCounters(AppData(ctx)->Counters, "utils")->GetSubgroup("component", "nameserver");
+    ActiveDynamicNodesCounter = counters->GetCounter("ActiveDynamicNodes");
+    ExpiredDynamicNodesCounter = counters->GetCounter("ExpireDynamicNodes");
+    StaticNodesCounter = counters->GetCounter("StaticNodes");
+    EpochVersionCounter = counters->GetCounter("EpochVersion");
+    UpdateCounters();
+
     Send(MakeBlobStorageNodeWardenID(SelfId().NodeId()), new TEvNodeWardenQueryStorageConfig(true));
 
     Become(&TDynamicNameserver::StateFunc);
@@ -282,6 +292,7 @@ void TDynamicNameserver::ReplaceNameserverSetup(TIntrusivePtr<TTableNameserverSe
         for (const auto& subscriber : StaticNodeChangeSubscribers) {
             TActivationContext::Send(new IEventHandle(SelfId(), subscriber, new TEvInterconnect::TEvListNodes));
         }
+        UpdateCounters();
     }
 }
 
@@ -518,6 +529,8 @@ void TDynamicNameserver::UpdateState(const NKikimrNodeBroker::TNodesInfo &rec,
         }
         config->Epoch = rec.GetEpoch();
     }
+
+    UpdateCounters();
 }
 
 void TDynamicNameserver::OnPipeDestroyed(ui32 domain, const TActorContext &ctx)
@@ -540,6 +553,16 @@ void TDynamicNameserver::OnPipeDestroyed(ui32 domain, const TActorContext &ctx)
     SyncInProgress = false;
 
     OpenPipe(DynamicConfigs[domain]->NodeBrokerPipe);
+}
+
+void TDynamicNameserver::UpdateCounters() {
+    ui32 domain = AppData()->DomainsInfo->GetDomain()->DomainUid;
+    const auto &config = DynamicConfigs[domain];
+
+    *EpochVersionCounter = config->Epoch.Version;
+    *ActiveDynamicNodesCounter = config->DynamicNodes.size();
+    *ExpiredDynamicNodesCounter = config->ExpiredNodes.size();
+    *StaticNodesCounter = StaticConfig->StaticNodeTable.size();
 }
 
 void TDynamicNameserver::Handle(TEvInterconnect::TEvResolveNode::TPtr &ev,
@@ -805,6 +828,8 @@ void TDynamicNameserver::Handle(TEvNodeBroker::TEvUpdateNodes::TPtr &ev, const T
                 break;
         }
     }
+
+    UpdateCounters();
 }
 
 void TDynamicNameserver::Handle(TEvNodeBroker::TEvSyncNodesResponse::TPtr &ev, const TActorContext &ctx)

--- a/ydb/core/mind/dynamic_nameserver_impl.h
+++ b/ydb/core/mind/dynamic_nameserver_impl.h
@@ -261,6 +261,8 @@ private:
     void OnPipeDestroyed(ui32 domain,
                          const TActorContext &ctx);
 
+    void UpdateCounters();
+
     void Handle(TEvInterconnect::TEvResolveNode::TPtr &ev, const TActorContext &ctx);
     void Handle(TEvResolveAddress::TPtr &ev, const TActorContext &ctx);
     void Handle(TEvInterconnect::TEvListNodes::TPtr &ev, const TActorContext &ctx);
@@ -305,6 +307,11 @@ private:
     bool SyncInProgress = false;
     ui64 SyncCookie = 0;
     ui64 SeqNo = 0;
+
+    ::NMonitoring::TDynamicCounters::TCounterPtr StaticNodesCounter;
+    ::NMonitoring::TDynamicCounters::TCounterPtr ActiveDynamicNodesCounter;
+    ::NMonitoring::TDynamicCounters::TCounterPtr ExpiredDynamicNodesCounter;
+    ::NMonitoring::TDynamicCounters::TCounterPtr EpochVersionCounter;
 };
 
 } // NNodeBroker

--- a/ydb/core/mind/dynamic_nameserver_mon.cpp
+++ b/ydb/core/mind/dynamic_nameserver_mon.cpp
@@ -21,6 +21,19 @@ TString ToString(TInstant t)
     return t.FormatLocalTime("%d %b %Y %H:%M:%S %Z");
 }
 
+TString ToString(EProtocolState s)
+{
+    switch (s) {
+        case EProtocolState::Connecting:
+            return "Connecting";
+        case EProtocolState::UseEpochProtocol:
+            return "EpochProtocol";
+        case EProtocolState::UseDeltaProtocol:
+            return "DeltaProtocol";
+    }
+    return "Unknown";
+}
+
 void OutputStaticContent(IOutputStream &str)
 {
     str << R"__(
@@ -193,6 +206,10 @@ void TDynamicNameserver::Handle(NMon::TEvHttpInfo::TPtr &ev, const TActorContext
                 << "    <tr>" << Endl
                 << "      <td class='right-align'>Max dynamic node ID:</td>" << Endl
                 << "      <td>" << config->MaxDynamicNodeId << "</td>" << Endl
+                << "    </tr>" << Endl
+                << "    <tr>" << Endl
+                << "      <td class='right-align'>Protocol state:</td>" << Endl
+                << "      <td>" << ToString(ProtocolState) << "</td>" << Endl
                 << "    </tr>" << Endl
                 << "  </tbody>" << Endl
                 << "</table></div>" << Endl;

--- a/ydb/core/mind/node_broker.cpp
+++ b/ydb/core/mind/node_broker.cpp
@@ -786,6 +786,13 @@ bool TNodeBroker::HasOutdatedSubscription(TActorId subscriber, ui64 newSeqNo) co
     return false;
 }
 
+void TNodeBroker::UpdateCommittedStateCounters() {
+    TabletCounters->Simple()[COUNTER_ACTIVE_NODES].Set(Committed.Nodes.size());
+    TabletCounters->Simple()[COUNTER_EXPIRED_NODES].Set(Committed.ExpiredNodes.size());
+    TabletCounters->Simple()[COUNTER_REMOVED_NODES].Set(Committed.RemovedNodes.size());
+    TabletCounters->Simple()[COUNTER_EPOCH_VERSION].Set(Committed.Epoch.Version);
+}
+
 void TNodeBroker::TState::LoadConfigFromProto(const NKikimrNodeBroker::TConfig &config)
 {
     Config = config;

--- a/ydb/core/mind/node_broker__extend_lease.cpp
+++ b/ydb/core/mind/node_broker__extend_lease.cpp
@@ -90,6 +90,8 @@ public:
             Self->AddNodeToUpdateNodesLog(node);
             Self->ScheduleProcessSubscribersQueue(ctx);
         }
+
+        Self->UpdateCommittedStateCounters();
     }
 
 private:

--- a/ydb/core/mind/node_broker__graceful_shutdown.cpp
+++ b/ydb/core/mind/node_broker__graceful_shutdown.cpp
@@ -52,6 +52,8 @@ public:
             Self->Committed.ReleaseSlotIndex(Self->Committed.Nodes.at(Event->Get()->Record.GetNodeId()));
         }
         ctx.Send(Event->Sender, Response.Release());
+
+        Self->UpdateCommittedStateCounters();
     }
 
 private:

--- a/ydb/core/mind/node_broker__migrate_state.cpp
+++ b/ydb/core/mind/node_broker__migrate_state.cpp
@@ -106,6 +106,8 @@ public:
             NKikimrNodeBroker::TVersionInfo versionInfo;
             versionInfo.SetSupportDeltaProtocol(true);
             Self->SignalTabletActive(ctx, versionInfo.SerializeAsString());
+
+            Self->UpdateCommittedStateCounters();
         } else {
             Self->Execute(Self->CreateTxMigrateState(std::move(DbChanges)));
         }

--- a/ydb/core/mind/node_broker__register_node.cpp
+++ b/ydb/core/mind/node_broker__register_node.cpp
@@ -235,6 +235,8 @@ public:
         }
 
         Reply(ctx);
+
+        Self->UpdateCommittedStateCounters();
     }
 
 private:

--- a/ydb/core/mind/node_broker__update_config.cpp
+++ b/ydb/core/mind/node_broker__update_config.cpp
@@ -92,6 +92,8 @@ public:
                         "TTxUpdateConfig reply with: " << Response->ToString());
             ctx.Send(Response);
         }
+
+        Self->UpdateCommittedStateCounters();
     }
 
 private:

--- a/ydb/core/mind/node_broker__update_config_subscription.cpp
+++ b/ydb/core/mind/node_broker__update_config_subscription.cpp
@@ -41,6 +41,8 @@ public:
                     "Using new subscription id=" << SubscriptionId);
 
         Self->Committed.ConfigSubscriptionId = SubscriptionId;
+
+        Self->UpdateCommittedStateCounters();
     }
 
 private:

--- a/ydb/core/mind/node_broker__update_epoch.cpp
+++ b/ydb/core/mind/node_broker__update_epoch.cpp
@@ -36,6 +36,8 @@ public:
         Self->PrepareUpdateNodesLog();
         Self->ProcessDelayedListNodesRequests();
         Self->ScheduleProcessSubscribersQueue(ctx);
+
+        Self->UpdateCommittedStateCounters();
     }
 
 private:

--- a/ydb/core/mind/node_broker_impl.h
+++ b/ydb/core/mind/node_broker_impl.h
@@ -305,6 +305,8 @@ private:
     void RemoveSubscriber(TActorId subscriber, const TActorContext &ctx);
     bool HasOutdatedSubscription(TActorId subscriber, ui64 newSeqNo) const;
 
+    void UpdateCommittedStateCounters();
+
     void Handle(TEvConsole::TEvConfigNotificationRequest::TPtr &ev,
                 const TActorContext &ctx);
     void Handle(TEvConsole::TEvReplaceConfigSubscriptionsResponse::TPtr &ev,

--- a/ydb/core/protos/counters_node_broker.proto
+++ b/ydb/core/protos/counters_node_broker.proto
@@ -10,6 +10,10 @@ enum ESimpleCounters {
     COUNTER_EPOCH_SIZE_BYTES = 0            [(CounterOpts) = {Name: "EpochSizeBytes"}];
     COUNTER_EPOCH_DELTAS_SIZE_BYTES = 1     [(CounterOpts) = {Name: "EpochDeltasSizeBytes"}];
     COUNTER_UPDATE_NODES_LOG_SIZE_BYTES = 2 [(CounterOpts) = {Name: "UpdateNodesLogSizeBytes"}];
+    COUNTER_EPOCH_VERSION = 3               [(CounterOpts) = {Name: "EpochVersion"}];
+    COUNTER_ACTIVE_NODES = 4                [(CounterOpts) = {Name: "ActiveNodes"}];
+    COUNTER_EXPIRED_NODES = 5               [(CounterOpts) = {Name: "ExpiredNodes"}];
+    COUNTER_REMOVED_NODES = 6               [(CounterOpts) = {Name: "RemovedNodes"}];
 }
 
 enum ECumulativeCounters {


### PR DESCRIPTION
### Changelog category <!-- remove all except one -->

* Not for changelog (changelog entry is not required)

### Description for reviewers

Этот PR добавляет в компоненты `NodeBroker` и `DynamicNameserver` новые метрики:
- Версию эпохи
- Количество active/expired/removed динамических узлов
- Количество статических узлов

Основные изменения:
- Расширен файл `counters_node_broker.proto` четырьмя новыми простыми счетчиками
- Добавлен метод `UpdateCommittedStateCounters` в `TNodeBroker`, который вызывается после транзакций, изменяющих состояние
- Добавлен метод `UpdateCounters` в `TDynamicNameserver`, который вызывается после изменения состояния
