### PR TITLE
Fix vector index build crash on large tables and 3+ level indexes (25.1.2)

### DIFF
--- a/ydb/core/tx/schemeshard/schemeshard_info_types.cpp
+++ b/ydb/core/tx/schemeshard/schemeshard_info_types.cpp
@@ -2214,6 +2214,168 @@ void TIndexBuildInfo::SerializeToProto([[maybe_unused]] TSchemeShard* ss, NKikim
     }
 }
 
+ui64 TIndexBuildInfo::TKMeans::ParentEnd() const noexcept {  // included
+    return ChildBegin - 1;
+}
+ui64 TIndexBuildInfo::TKMeans::ChildEnd() const noexcept {  // included
+    return ChildBegin + ChildCount() - 1;
+}
+
+ui64 TIndexBuildInfo::TKMeans::ParentCount() const noexcept {
+    return ParentEnd() - ParentBegin + 1;
+}
+ui64 TIndexBuildInfo::TKMeans::ChildCount() const noexcept {
+    return ParentCount() * K;
+}
+
+TString TIndexBuildInfo::TKMeans::DebugString() const {
+    return TStringBuilder()
+        << "{ "
+        << "State = " << State
+        << ", Level = " << Level << " / " << Levels
+        << ", K = " << K
+        << ", Round = " << Round
+        << ", Parent = [" << ParentBegin << ".." << Parent << ".." << ParentEnd() << "]"
+        << ", Child = [" << ChildBegin << ".." << Child << ".." << ChildEnd() << "]"
+        << ", TableSize = " << TableSize
+        << " }";
+}
+
+bool TIndexBuildInfo::TKMeans::NeedsAnotherLevel() const noexcept {
+    return Level < Levels;
+}
+bool TIndexBuildInfo::TKMeans::NeedsAnotherParent() const noexcept {
+    return Parent < ParentEnd();
+}
+
+bool TIndexBuildInfo::TKMeans::NextParent() noexcept {
+    if (!NeedsAnotherParent()) {
+        return false;
+    }
+    ++Parent;
+    Child += K;
+    return true;
+}
+
+bool TIndexBuildInfo::TKMeans::NextLevel() noexcept {
+    if (!NeedsAnotherLevel()) {
+        return false;
+    }
+    NextLevel(ChildCount());
+    return true;
+}
+
+void TIndexBuildInfo::TKMeans::PrefixIndexDone(ui64 shards) {
+    Y_ENSURE(NeedsAnotherLevel());
+    // There's two worst cases, but in both one shard contains TableSize rows
+    // 1. all rows have unique prefix (*), in such case we need 1 id for each row (parent, id in prefix table)
+    // 2. all unique prefixes have size K, so we have TableSize/K parents + TableSize childs
+    // * it doesn't work now, because now prefix should have at least K embeddings, but it's bug
+    NextLevel((2 * TableSize) * shards);
+    Parent = ParentEnd();
+}
+
+void TIndexBuildInfo::TKMeans::Set(ui32 level,
+    NTableIndex::TClusterId parentBegin, NTableIndex::TClusterId parent,
+    NTableIndex::TClusterId childBegin, NTableIndex::TClusterId child,
+    ui32 state, ui64 tableSize, ui32 round) {
+    Level = level;
+    Round = round;
+    ParentBegin = parentBegin;
+    Parent = parent;
+    ChildBegin = childBegin;
+    Child = child;
+    State = static_cast<EState>(state);
+    TableSize = tableSize;
+}
+
+NKikimrTxDataShard::EKMeansState TIndexBuildInfo::TKMeans::GetUpload() const {
+    if (Level == 1) {
+        if (NeedsAnotherLevel()) {
+            return NKikimrTxDataShard::EKMeansState::UPLOAD_MAIN_TO_BUILD;
+        } else {
+            return NKikimrTxDataShard::EKMeansState::UPLOAD_MAIN_TO_POSTING;
+        }
+    } else {
+        if (NeedsAnotherLevel()) {
+            return NKikimrTxDataShard::EKMeansState::UPLOAD_BUILD_TO_BUILD;
+        } else {
+            return NKikimrTxDataShard::EKMeansState::UPLOAD_BUILD_TO_POSTING;
+        }
+    }
+}
+
+TString TIndexBuildInfo::TKMeans::WriteTo(bool needsBuildTable) const {
+    using namespace NTableIndex::NTableVectorKmeansTreeIndex;
+    TString name = PostingTable;
+    if (needsBuildTable || NeedsAnotherLevel()) {
+        name += Level % 2 != 0 ? BuildSuffix0 : BuildSuffix1;
+    }
+    return name;
+}
+
+TString TIndexBuildInfo::TKMeans::ReadFrom() const {
+    Y_ENSURE(Level > 1);
+    using namespace NTableIndex::NTableVectorKmeansTreeIndex;
+    TString name = PostingTable;
+    name += Level % 2 != 0 ? BuildSuffix1 : BuildSuffix0;
+    return name;
+}
+
+std::pair<NTableIndex::TClusterId, NTableIndex::TClusterId> TIndexBuildInfo::TKMeans::RangeToBorders(const TSerializedTableRange& range) const {
+    const NTableIndex::TClusterId minParent = ParentBegin;
+    const NTableIndex::TClusterId maxParent = ParentEnd();
+    const NTableIndex::TClusterId parentFrom = [&, from = range.From.GetCells()] {
+        if (!from.empty()) {
+            if (!from[0].IsNull()) {
+                return from[0].AsValue<NTableIndex::TClusterId>() + static_cast<NTableIndex::TClusterId>(from.size() == 1);
+            }
+        }
+        return minParent;
+    }();
+    const NTableIndex::TClusterId parentTo = [&, to = range.To.GetCells()] {
+        if (!to.empty()) {
+            if (!to[0].IsNull()) {
+                return to[0].AsValue<NTableIndex::TClusterId>() - static_cast<NTableIndex::TClusterId>(to.size() != 1 && to[1].IsNull());
+            }
+        }
+        return maxParent;
+    }();
+    Y_ENSURE(minParent <= parentFrom, "minParent(" << minParent << ") > parentFrom(" << parentFrom << ") " << DebugString());
+    Y_ENSURE(parentFrom <= parentTo, "parentFrom(" << parentFrom << ") > parentTo(" << parentTo << ") " << DebugString());
+    Y_ENSURE(parentTo <= maxParent, "parentTo(" << parentTo << ") > maxParent(" << maxParent << ") " << DebugString());
+    return {parentFrom, parentTo};
+}
+
+TString TIndexBuildInfo::TKMeans::RangeToDebugStr(const TSerializedTableRange& range) const {
+    auto toStr = [&](const TSerializedCellVec& v) -> TString {
+        const auto cells = v.GetCells();
+        if (cells.empty()) {
+            return "inf";
+        }
+        if (cells[0].IsNull()) {
+            return "-inf";
+        }
+        auto str = TStringBuilder{} << "{ count: " << cells.size();
+        if (Level > 1) {
+            str << ", parent: " << cells[0].AsValue<NTableIndex::TClusterId>();
+            if (cells.size() != 1 && cells[1].IsNull()) {
+                str << ", pk: null";
+            }
+        }
+        return str << " }";
+    };
+    return TStringBuilder{} << "{ From: " << toStr(range.From) << ", To: " << toStr(range.To) << " }";
+}
+
+void TIndexBuildInfo::TKMeans::NextLevel(ui64 childCount) noexcept {
+    ParentBegin = ChildBegin;
+    Parent = ParentBegin;
+    ChildBegin = ParentBegin + childCount;
+    Child = ChildBegin;
+    ++Level;
+}
+
 void TIndexBuildInfo::AddParent(const TSerializedTableRange& range, TShardIdx shard) {
     // For Parent == 0 only single kmeans needed, so there are two options:
     // 1. It fits entirely in the single shard => local kmeans for single shard

--- a/ydb/core/tx/schemeshard/schemeshard_info_types.h
+++ b/ydb/core/tx/schemeshard/schemeshard_info_types.h
@@ -3062,167 +3062,36 @@ struct TIndexBuildInfo: public TSimpleRefCount<TIndexBuildInfo> {
 
         ui64 TableSize = 0;
 
-        ui64 ParentEnd() const noexcept {  // included
-            return ChildBegin - 1;
-        }
-        ui64 ChildEnd() const noexcept {  // included
-            return ChildBegin + ChildCount() - 1;
-        }
+        ui64 ParentEnd() const noexcept;
+        ui64 ChildEnd() const noexcept;
 
-        ui64 ParentCount() const noexcept {
-            return ParentEnd() - ParentBegin + 1;
-        }
-        ui64 ChildCount() const noexcept {
-            return ParentCount() * K;
-        }
+        ui64 ParentCount() const noexcept;
+        ui64 ChildCount() const noexcept;
 
-        TString DebugString() const {
-            return TStringBuilder()
-                << "{ " 
-                << "State = " << State
-                << ", Level = " << Level << " / " << Levels
-                << ", K = " << K
-                << ", Round = " << Round
-                << ", Parent = [" << ParentBegin << ".." << Parent << ".." << ParentEnd() << "]"
-                << ", Child = [" << ChildBegin << ".." << Child << ".." << ChildEnd() << "]"
-                << ", TableSize = " << TableSize
-                << " }";
-        }
+        TString DebugString() const;
 
-        bool NeedsAnotherLevel() const noexcept {
-            return Level < Levels;
-        }
-        bool NeedsAnotherParent() const noexcept {
-            return Parent < ParentEnd();
-        }
+        bool NeedsAnotherLevel() const noexcept;
+        bool NeedsAnotherParent() const noexcept;
+        bool NextParent() noexcept;
+        bool NextLevel() noexcept;
+        void PrefixIndexDone(ui64 shards);
 
-        bool NextParent() noexcept {
-            if (!NeedsAnotherParent()) {
-                return false;
-            }
-            ++Parent;
-            Child += K;
-            return true;
-        }
+        void Set(ui32 level,
+            NTableIndex::TClusterId parentBegin, NTableIndex::TClusterId parent,
+            NTableIndex::TClusterId childBegin, NTableIndex::TClusterId child,
+            ui32 state, ui64 tableSize, ui32 round);
 
-        bool NextLevel() noexcept {
-            if (!NeedsAnotherLevel()) {
-                return false;
-            }
-            NextLevel(ChildCount());
-            return true;
-        }
+        NKikimrTxDataShard::EKMeansState GetUpload() const;
 
-        void PrefixIndexDone(ui64 shards) {
-            Y_ENSURE(NeedsAnotherLevel());
-            // There's two worst cases, but in both one shard contains TableSize rows
-            // 1. all rows have unique prefix (*), in such case we need 1 id for each row (parent, id in prefix table)
-            // 2. all unique prefixes have size K, so we have TableSize/K parents + TableSize childs
-            // * it doesn't work now, because now prefix should have at least K embeddings, but it's bug
-            NextLevel((2 * TableSize) * shards);
-            Parent = ParentEnd();
-        }
+        TString WriteTo(bool needsBuildTable = false) const;
+        TString ReadFrom() const;
 
-        void Set(ui32 level, 
-                 NTableIndex::TClusterId parentBegin, NTableIndex::TClusterId parent, 
-                 NTableIndex::TClusterId childBegin, NTableIndex::TClusterId child,
-                 ui32 state, ui64 tableSize, ui32 round) {
-            Level = level;
-            Round = round;
-            ParentBegin = parentBegin;
-            Parent = parent;
-            ChildBegin = childBegin;
-            Child = child;
-            State = static_cast<EState>(state);
-            TableSize = tableSize;
-        }
+        std::pair<NTableIndex::TClusterId, NTableIndex::TClusterId> RangeToBorders(const TSerializedTableRange& range) const;
 
-        NKikimrTxDataShard::EKMeansState GetUpload() const {
-            if (Level == 1) {
-                if (NeedsAnotherLevel()) {
-                    return NKikimrTxDataShard::EKMeansState::UPLOAD_MAIN_TO_BUILD;
-                } else {
-                    return NKikimrTxDataShard::EKMeansState::UPLOAD_MAIN_TO_POSTING;
-                }
-            } else {
-                if (NeedsAnotherLevel()) {
-                    return NKikimrTxDataShard::EKMeansState::UPLOAD_BUILD_TO_BUILD;
-                } else {
-                    return NKikimrTxDataShard::EKMeansState::UPLOAD_BUILD_TO_POSTING;
-                }
-            }
-        }
-
-        TString WriteTo(bool needsBuildTable = false) const {
-            using namespace NTableIndex::NTableVectorKmeansTreeIndex;
-            TString name = PostingTable;
-            if (needsBuildTable || NeedsAnotherLevel()) {
-                name += Level % 2 != 0 ? BuildSuffix0 : BuildSuffix1;
-            }
-            return name;
-        }
-        TString ReadFrom() const {
-            Y_ENSURE(Level > 1);
-            using namespace NTableIndex::NTableVectorKmeansTreeIndex;
-            TString name = PostingTable;
-            name += Level % 2 != 0 ? BuildSuffix1 : BuildSuffix0;
-            return name;
-        }
-
-        std::pair<NTableIndex::TClusterId, NTableIndex::TClusterId> RangeToBorders(const TSerializedTableRange& range) const {
-            const NTableIndex::TClusterId minParent = ParentBegin;
-            const NTableIndex::TClusterId maxParent = ParentEnd();
-            const NTableIndex::TClusterId parentFrom = [&, from = range.From.GetCells()] {
-                if (!from.empty()) {
-                    if (!from[0].IsNull()) {
-                        return from[0].AsValue<NTableIndex::TClusterId>() + static_cast<NTableIndex::TClusterId>(from.size() == 1);
-                    }
-                }
-                return minParent;
-            }();
-            const NTableIndex::TClusterId parentTo = [&, to = range.To.GetCells()] {
-                if (!to.empty()) {
-                    if (!to[0].IsNull()) {
-                        return to[0].AsValue<NTableIndex::TClusterId>() - static_cast<NTableIndex::TClusterId>(to.size() != 1 && to[1].IsNull());
-                    }
-                }
-                return maxParent;
-            }();
-            Y_ENSURE(minParent <= parentFrom, "minParent(" << minParent << ") > parentFrom(" << parentFrom << ") " << DebugString());
-            Y_ENSURE(parentFrom <= parentTo, "parentFrom(" << parentFrom << ") > parentTo(" << parentTo << ") " << DebugString());
-            Y_ENSURE(parentTo <= maxParent, "parentTo(" << parentTo << ") > maxParent(" << maxParent << ") " << DebugString());
-            return {parentFrom, parentTo};
-        }
-
-        TString RangeToDebugStr(const TSerializedTableRange& range) const {
-            auto toStr = [&](const TSerializedCellVec& v) -> TString {
-                const auto cells = v.GetCells();
-                if (cells.empty()) {
-                    return "inf";
-                }
-                if (cells[0].IsNull()) {
-                    return "-inf";
-                }
-                auto str = TStringBuilder{} << "{ count: " << cells.size();
-                if (Level > 1) {
-                    str << ", parent: " << cells[0].AsValue<NTableIndex::TClusterId>();
-                    if (cells.size() != 1 && cells[1].IsNull()) {
-                        str << ", pk: null";
-                    }
-                }
-                return str << " }";
-            };
-            return TStringBuilder{} << "{ From: " << toStr(range.From) << ", To: " << toStr(range.To) << " }";
-        }
+        TString RangeToDebugStr(const TSerializedTableRange& range) const;
 
     private:
-        void NextLevel(ui64 childCount) noexcept {
-            ParentBegin = ChildBegin;
-            Parent = ParentBegin;
-            ChildBegin = ParentBegin + childCount;
-            Child = ChildBegin;
-            ++Level;
-        }
+        void NextLevel(ui64 childCount) noexcept;
     };
     TKMeans KMeans;
 

--- a/ydb/core/tx/schemeshard/schemeshard_info_types.h
+++ b/ydb/core/tx/schemeshard/schemeshard_info_types.h
@@ -3596,7 +3596,7 @@ public:
                     indexInfo->KMeans.Rounds = NTableIndex::NTableVectorKmeansTreeIndex::DefaultKMeansRounds;
                     TString createError;
                     indexInfo->Clusters = NKikimr::NKMeans::CreateClusters(desc.settings().settings(), indexInfo->KMeans.Rounds, createError);
-                    Y_ENSURE(indexInfo->Clusters && createError == "");
+                    Y_ENSURE(indexInfo->Clusters, createError);
                     indexInfo->SpecializedIndexDescription = std::move(desc);
                 } break;
                 case NKikimrSchemeOp::TIndexCreationConfig::SPECIALIZEDINDEXDESCRIPTION_NOT_SET:

--- a/ydb/core/tx/schemeshard/ut_base/ut_info_types.cpp
+++ b/ydb/core/tx/schemeshard/ut_base/ut_info_types.cpp
@@ -239,4 +239,67 @@ ColumnFamilies {
         "{ 0 -> 0, 1 -> 1 }");
     }
 
+    Y_UNIT_TEST(IndexBuildInfoAddParent) {
+        TIndexBuildInfo info;
+
+        info.KMeans.ParentBegin = 1;
+        info.KMeans.Parent = 1;
+        info.KMeans.ChildBegin = 201;
+        info.KMeans.Child = 201;
+
+        TVector<TCell> from = {TCell::Make((ui64)1), TCell::Make(123)};
+        TVector<TCell> to = {TCell::Make((ui64)3), TCell::Make(123)};
+        auto range = TSerializedTableRange(from, true, to, true);
+        info.AddParent(range, TShardIdx(1, 1));
+
+        UNIT_ASSERT_VALUES_EQUAL(info.Cluster2Shards.size(), 1);
+        UNIT_ASSERT_VALUES_EQUAL(info.Cluster2Shards.at(3).From, 1);
+        UNIT_ASSERT_VALUES_EQUAL(info.Cluster2Shards.at(3).Shards.size(), 1);
+
+        // add an intersecting shard. it even crashed here until 02.07.2025 :)
+        from = {TCell::Make((ui64)3), TCell::Make(123)};
+        to = {TCell::Make((ui64)4), TCell::Make(123)};
+        range = TSerializedTableRange(from, true, to, true);
+        info.AddParent(range, TShardIdx(1, 2));
+
+        // Cluster2Shards is a rather stupid thing - for now, it just merges all intersecting
+        // shard ranges into a single item, thus losing the range info for individual cluster IDs
+        UNIT_ASSERT_VALUES_EQUAL(info.Cluster2Shards.size(), 1);
+        UNIT_ASSERT_VALUES_EQUAL(info.Cluster2Shards.at(4).From, 1);
+        UNIT_ASSERT_VALUES_EQUAL(info.Cluster2Shards.at(4).Shards.size(), 2);
+
+        // add a non-intersecting shard
+        from = {TCell::Make((ui64)5), TCell::Make(123)};
+        to = {TCell::Make((ui64)6), TCell::Make(123)};
+        range = TSerializedTableRange(from, true, to, true);
+        info.AddParent(range, TShardIdx(1, 3));
+
+        UNIT_ASSERT_VALUES_EQUAL(info.Cluster2Shards.size(), 2);
+        UNIT_ASSERT_VALUES_EQUAL(info.Cluster2Shards.at(4).From, 1);
+        UNIT_ASSERT_VALUES_EQUAL(info.Cluster2Shards.at(4).Shards.size(), 2);
+        UNIT_ASSERT_VALUES_EQUAL(info.Cluster2Shards.at(6).From, 5);
+        UNIT_ASSERT_VALUES_EQUAL(info.Cluster2Shards.at(6).Shards.size(), 1);
+
+        // incomplete range is "from (99, +infinity)", thus equal to "from [100]"
+        from = {TCell::Make((ui64)99)};
+        to = {TCell::Make((ui64)100), TCell::Make(123)};
+        range = TSerializedTableRange(from, true, to, true);
+        info.AddParent(range, TShardIdx(1, 4));
+
+        UNIT_ASSERT_VALUES_EQUAL(info.Cluster2Shards.size(), 3);
+        UNIT_ASSERT_VALUES_EQUAL(info.Cluster2Shards.at(100).From, 100);
+        UNIT_ASSERT_VALUES_EQUAL(info.Cluster2Shards.at(100).Shards.size(), 1);
+
+        // insert and check something before an existing item
+        from = {TCell::Make((ui64)50), TCell::Make(123)};
+        to = {TCell::Make((ui64)51), TCell::Make(123)};
+        range = TSerializedTableRange(from, true, to, true);
+        info.AddParent(range, TShardIdx(1, 5));
+
+        UNIT_ASSERT_VALUES_EQUAL(info.Cluster2Shards.size(), 4);
+        UNIT_ASSERT_VALUES_EQUAL(info.Cluster2Shards.at(51).From, 50);
+        UNIT_ASSERT_VALUES_EQUAL(info.Cluster2Shards.at(51).Shards.size(), 1);
+
+    }
+
 }

--- a/ydb/core/tx/schemeshard/ut_base/ut_info_types.cpp
+++ b/ydb/core/tx/schemeshard/ut_base/ut_info_types.cpp
@@ -247,58 +247,98 @@ ColumnFamilies {
         info.KMeans.ChildBegin = 201;
         info.KMeans.Child = 201;
 
-        TVector<TCell> from = {TCell::Make((ui64)1), TCell::Make(123)};
-        TVector<TCell> to = {TCell::Make((ui64)3), TCell::Make(123)};
-        auto range = TSerializedTableRange(from, true, to, true);
-        info.AddParent(range, TShardIdx(1, 1));
+        auto addShard = [&](ui64 fromCluster, ui64 toCluster, ui32 shard, bool partialFrom = false) {
+            TVector<TCell> from = {TCell::Make(fromCluster), TCell::Make(123)};
+            if (partialFrom) {
+                from.pop_back();
+            }
+            TVector<TCell> to = {TCell::Make(toCluster), TCell::Make(123)};
+            auto range = TSerializedTableRange(from, true, to, true);
+            info.AddParent(range, TShardIdx(1, shard));
+        };
+        auto checkShards = [&](ui64 from, ui64 to, std::vector<ui32> shards) {
+            auto rng = info.Cluster2Shards.at(to);
+            if (rng.From != from || rng.Shards.size() != shards.size()) {
+                return false;
+            }
+            for (size_t i = 0; i < shards.size(); i++) {
+                if (rng.Shards[i] != TShardIdx(1, shards[i])) {
+                    return false;
+                }
+            }
+            return true;
+        };
 
+        // no intersection + empty list
+        addShard(1, 3, 1);
         UNIT_ASSERT_VALUES_EQUAL(info.Cluster2Shards.size(), 1);
-        UNIT_ASSERT_VALUES_EQUAL(info.Cluster2Shards.at(3).From, 1);
-        UNIT_ASSERT_VALUES_EQUAL(info.Cluster2Shards.at(3).Shards.size(), 1);
+        UNIT_ASSERT(checkShards(1, 3, {1}));
 
         // add an intersecting shard. it even crashed here until 02.07.2025 :)
-        from = {TCell::Make((ui64)3), TCell::Make(123)};
-        to = {TCell::Make((ui64)4), TCell::Make(123)};
-        range = TSerializedTableRange(from, true, to, true);
-        info.AddParent(range, TShardIdx(1, 2));
-
-        // Cluster2Shards is a rather stupid thing - for now, it just merges all intersecting
-        // shard ranges into a single item, thus losing the range info for individual cluster IDs
-        UNIT_ASSERT_VALUES_EQUAL(info.Cluster2Shards.size(), 1);
-        UNIT_ASSERT_VALUES_EQUAL(info.Cluster2Shards.at(4).From, 1);
-        UNIT_ASSERT_VALUES_EQUAL(info.Cluster2Shards.at(4).Shards.size(), 2);
-
-        // add a non-intersecting shard
-        from = {TCell::Make((ui64)5), TCell::Make(123)};
-        to = {TCell::Make((ui64)6), TCell::Make(123)};
-        range = TSerializedTableRange(from, true, to, true);
-        info.AddParent(range, TShardIdx(1, 3));
-
-        UNIT_ASSERT_VALUES_EQUAL(info.Cluster2Shards.size(), 2);
-        UNIT_ASSERT_VALUES_EQUAL(info.Cluster2Shards.at(4).From, 1);
-        UNIT_ASSERT_VALUES_EQUAL(info.Cluster2Shards.at(4).Shards.size(), 2);
-        UNIT_ASSERT_VALUES_EQUAL(info.Cluster2Shards.at(6).From, 5);
-        UNIT_ASSERT_VALUES_EQUAL(info.Cluster2Shards.at(6).Shards.size(), 1);
-
-        // incomplete range is "from (99, +infinity)", thus equal to "from [100]"
-        from = {TCell::Make((ui64)99)};
-        to = {TCell::Make((ui64)100), TCell::Make(123)};
-        range = TSerializedTableRange(from, true, to, true);
-        info.AddParent(range, TShardIdx(1, 4));
-
+        // intersection by start + both larger than 1
+        addShard(3, 4, 2);
         UNIT_ASSERT_VALUES_EQUAL(info.Cluster2Shards.size(), 3);
-        UNIT_ASSERT_VALUES_EQUAL(info.Cluster2Shards.at(100).From, 100);
-        UNIT_ASSERT_VALUES_EQUAL(info.Cluster2Shards.at(100).Shards.size(), 1);
+        UNIT_ASSERT(checkShards(1, 2, {1}));
+        UNIT_ASSERT(checkShards(3, 3, {1, 2}));
+        UNIT_ASSERT(checkShards(4, 4, {2}));
 
-        // insert and check something before an existing item
-        from = {TCell::Make((ui64)50), TCell::Make(123)};
-        to = {TCell::Make((ui64)51), TCell::Make(123)};
-        range = TSerializedTableRange(from, true, to, true);
-        info.AddParent(range, TShardIdx(1, 5));
+        // intersection by start + both 1 (duplicate range)
+        // incomplete range is "from (3, +infinity)", thus equal to "from 4"
+        addShard(3, 4, 3, true);
+        UNIT_ASSERT_VALUES_EQUAL(info.Cluster2Shards.size(), 3);
+        UNIT_ASSERT(checkShards(4, 4, {2, 3}));
 
+        // intersection by start + old 1 + new larger than 1
+        addShard(4, 6, 4);
         UNIT_ASSERT_VALUES_EQUAL(info.Cluster2Shards.size(), 4);
-        UNIT_ASSERT_VALUES_EQUAL(info.Cluster2Shards.at(51).From, 50);
-        UNIT_ASSERT_VALUES_EQUAL(info.Cluster2Shards.at(51).Shards.size(), 1);
+        UNIT_ASSERT(checkShards(4, 4, {2, 3, 4}));
+        UNIT_ASSERT(checkShards(5, 6, {4}));
+
+        // intersection by start + old larger than 1 + new 1
+        addShard(6, 6, 5);
+        UNIT_ASSERT_VALUES_EQUAL(info.Cluster2Shards.size(), 5);
+        UNIT_ASSERT(checkShards(5, 5, {4}));
+        UNIT_ASSERT(checkShards(6, 6, {4, 5}));
+
+        // no intersection + after non-empty list
+        addShard(19, 20, 6);
+        UNIT_ASSERT_VALUES_EQUAL(info.Cluster2Shards.size(), 6);
+        UNIT_ASSERT(checkShards(19, 20, {6}));
+
+        // intersection by end + both larger than 1
+        addShard(18, 19, 7);
+        UNIT_ASSERT_VALUES_EQUAL(info.Cluster2Shards.size(), 8);
+        UNIT_ASSERT(checkShards(18, 18, {7}));
+        UNIT_ASSERT(checkShards(19, 19, {6, 7}));
+        UNIT_ASSERT(checkShards(20, 20, {6}));
+
+        // intersection by end + both 1 (duplicate range)
+        addShard(18, 18, 8);
+        UNIT_ASSERT_VALUES_EQUAL(info.Cluster2Shards.size(), 8);
+        UNIT_ASSERT(checkShards(18, 18, {7, 8}));
+
+        // intersection by end + old 1 + new larger than 1
+        addShard(16, 18, 9);
+        UNIT_ASSERT_VALUES_EQUAL(info.Cluster2Shards.size(), 9);
+        UNIT_ASSERT(checkShards(16, 17, {9}));
+        UNIT_ASSERT(checkShards(18, 18, {7, 8, 9}));
+
+        // intersection by end + old larger than 1 + new 1
+        addShard(16, 16, 10);
+        UNIT_ASSERT_VALUES_EQUAL(info.Cluster2Shards.size(), 10);
+        UNIT_ASSERT(checkShards(16, 16, {9, 10}));
+        UNIT_ASSERT(checkShards(17, 17, {9}));
+
+        // intersection by both
+        addShard(7, 9, 11);
+        addShard(13, 15, 12);
+        addShard(9, 13, 13);
+        UNIT_ASSERT_VALUES_EQUAL(info.Cluster2Shards.size(), 15);
+        UNIT_ASSERT(checkShards(7, 8, {11}));
+        UNIT_ASSERT(checkShards(9, 9, {11, 13}));
+        UNIT_ASSERT(checkShards(10, 12, {13}));
+        UNIT_ASSERT(checkShards(13, 13, {12, 13}));
+        UNIT_ASSERT(checkShards(14, 15, {12}));
 
     }
 


### PR DESCRIPTION
### Changelog category

* Not for changelog (changelog entry is not required)

### Description for reviewers

Cherry-picked from commits 22ac88436d70d1a9a2b18f355f358932d251b186, 395c88887eecd4cc821fe7dec739956ce1b2f74c, 8c3459708e645356c97adf117780ac239ec710f2