### PR TITLE
Get rid of extra actorsystem.h include.

### DIFF
--- a/ydb/apps/etcd_proxy/service/etcd_shared.h
+++ b/ydb/apps/etcd_proxy/service/etcd_shared.h
@@ -1,7 +1,7 @@
 #pragma once
 
 #include <ydb/public/sdk/cpp/include/ydb-cpp-sdk/client/query/client.h>
-#include <ydb/library/actors/core/actorsystem.h>
+#include <ydb/library/actors/core/actorsystem_fwd.h>
 
 #include <atomic>
 

--- a/ydb/apps/etcd_proxy/service/etcd_shared.h
+++ b/ydb/apps/etcd_proxy/service/etcd_shared.h
@@ -2,6 +2,7 @@
 
 #include <ydb/public/sdk/cpp/include/ydb-cpp-sdk/client/query/client.h>
 #include <ydb/library/actors/core/actorsystem_fwd.h>
+#include <ydb/library/actors/core/actorid.h>
 
 #include <atomic>
 

--- a/ydb/core/actorlib_impl/actor_tracker.cpp
+++ b/ydb/core/actorlib_impl/actor_tracker.cpp
@@ -1,5 +1,5 @@
 #include "actor_tracker.h"
-#include <ydb/library/actors/core/actorsystem.h>
+#include <ydb/library/actors/core/actor.h>
 #include <ydb/library/actors/core/executor_thread.h>
 #include <ydb/library/actors/core/hfunc.h>
 

--- a/ydb/core/base/pool_stats_collector.h
+++ b/ydb/core/base/pool_stats_collector.h
@@ -1,6 +1,5 @@
 #pragma once
 #include "defs.h"
-#include <ydb/library/actors/core/actorsystem.h>
 #include <library/cpp/monlib/dynamic_counters/counters.h>
 
 namespace NActors {

--- a/ydb/core/client/server/msgbus_server.h
+++ b/ydb/core/client/server/msgbus_server.h
@@ -1,5 +1,4 @@
 #pragma once
-#include <ydb/library/actors/core/actorsystem.h>
 #include <ydb/library/actors/core/actor_bootstrapped.h>
 #include <ydb/public/lib/base/defs.h>
 #include <ydb/public/lib/base/msgbus.h>

--- a/ydb/core/driver_lib/run/factories.h
+++ b/ydb/core/driver_lib/run/factories.h
@@ -22,7 +22,6 @@
 
 #include <ydb/library/yaml_config/yaml_config.h>
 
-#include <ydb/library/actors/core/actorsystem.h>
 #include <ydb/library/actors/wilson/wilson_uploader.h>
 
 #include <functional>

--- a/ydb/core/driver_lib/run/kikimr_services_initializers.h
+++ b/ydb/core/driver_lib/run/kikimr_services_initializers.h
@@ -19,7 +19,6 @@
 #include <ydb/core/fq/libs/shared_resources/interface/shared_resources.h>
 
 #include <ydb/library/actors/core/defs.h>
-#include <ydb/library/actors/core/actorsystem.h>
 #include <ydb/library/actors/core/log_settings.h>
 #include <ydb/library/actors/core/scheduler_actor.h>
 #include <ydb/library/actors/core/scheduler_basic.h>

--- a/ydb/core/driver_lib/run/service_initializer.h
+++ b/ydb/core/driver_lib/run/service_initializer.h
@@ -1,6 +1,5 @@
 #pragma once
 
-#include <ydb/library/actors/core/actorsystem.h>
 #include <ydb/core/base/appdata.h>
 
 #include <util/generic/list.h>

--- a/ydb/core/external_sources/external_source.h
+++ b/ydb/core/external_sources/external_source.h
@@ -5,7 +5,6 @@
 #include <util/generic/string.h>
 
 #include <ydb/core/protos/external_sources.pb.h>
-#include <ydb/library/actors/core/actorsystem.h>
 #include <yql/essentials/public/issue/yql_issue.h>
 
 namespace NKikimr::NExternalSource {

--- a/ydb/core/external_sources/external_source_factory.h
+++ b/ydb/core/external_sources/external_source_factory.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "external_source.h"
+#include <ydb/library/actors/core/actorsystem_fwd.h>
 #include <ydb/library/yql/providers/common/token_accessor/client/factory.h>
 #include <ydb/library/yql/providers/common/db_id_async_resolver/database_type.h>
 

--- a/ydb/core/external_sources/object_storage.h
+++ b/ydb/core/external_sources/object_storage.h
@@ -6,6 +6,7 @@
 
 #include <ydb/library/yql/providers/common/token_accessor/client/factory.h>
 #include <ydb/public/api/protos/draft/fq.pb.h>
+#include <ydb/library/actors/core/actorsystem_fwd.h>
 
 namespace NKikimr::NExternalSource {
 

--- a/ydb/core/fq/libs/actors/nodes_manager.h
+++ b/ydb/core/fq/libs/actors/nodes_manager.h
@@ -10,7 +10,6 @@
 #include <ydb/library/yql/providers/dq/actors/proto_builder.h>
 #include <ydb/library/yql/providers/common/http_gateway/yql_http_gateway.h>
 
-#include <ydb/library/actors/core/actorsystem.h>
 #include <library/cpp/time_provider/time_provider.h>
 #include <library/cpp/random_provider/random_provider.h>
 

--- a/ydb/core/fq/libs/actors/proxy.h
+++ b/ydb/core/fq/libs/actors/proxy.h
@@ -21,7 +21,6 @@
 
 #include <ydb/public/lib/fq/scope.h>
 
-#include <ydb/library/actors/core/actorsystem.h>
 #include <library/cpp/random_provider/random_provider.h>
 #include <library/cpp/time_provider/time_provider.h>
 

--- a/ydb/core/fq/libs/actors/proxy_private.h
+++ b/ydb/core/fq/libs/actors/proxy_private.h
@@ -9,7 +9,6 @@
 #include <ydb/library/yql/providers/dq/worker_manager/interface/counters.h>
 #include <ydb/library/yql/providers/dq/actors/proto_builder.h>
 
-#include <ydb/library/actors/core/actorsystem.h>
 #include <library/cpp/time_provider/time_provider.h>
 #include <library/cpp/random_provider/random_provider.h>
 #include <library/cpp/monlib/metrics/histogram_collector.h>

--- a/ydb/core/fq/libs/compute/common/pinger.h
+++ b/ydb/core/fq/libs/compute/common/pinger.h
@@ -1,6 +1,6 @@
 #pragma once
 
-#include <ydb/library/actors/core/actorsystem.h>
+#include <ydb/library/actors/core/actor.h>
 #include <ydb/core/fq/libs/config/protos/pinger.pb.h>
 #include <yql/essentials/providers/common/metrics/service_counters.h>
 #include <ydb/public/lib/fq/scope.h>

--- a/ydb/core/fq/libs/compute/common/run_actor_params.h
+++ b/ydb/core/fq/libs/compute/common/run_actor_params.h
@@ -19,7 +19,6 @@
 
 #include <ydb/public/lib/fq/scope.h>
 
-#include <ydb/library/actors/core/actorsystem.h>
 #include <library/cpp/random_provider/random_provider.h>
 #include <library/cpp/time_provider/time_provider.h>
 

--- a/ydb/core/fq/libs/compute/ydb/control_plane/compute_database_control_plane_service.cpp
+++ b/ydb/core/fq/libs/compute/ydb/control_plane/compute_database_control_plane_service.cpp
@@ -16,7 +16,6 @@
 
 #include <ydb/library/actors/core/actor.h>
 #include <ydb/library/actors/core/actor_bootstrapped.h>
-#include <ydb/library/actors/core/actorsystem.h>
 #include <ydb/library/actors/core/hfunc.h>
 #include <ydb/library/actors/core/log.h>
 

--- a/ydb/core/fq/libs/compute/ydb/executer_actor.cpp
+++ b/ydb/core/fq/libs/compute/ydb/executer_actor.cpp
@@ -13,7 +13,6 @@
 
 #include <ydb/library/actors/core/actor.h>
 #include <ydb/library/actors/core/actor_bootstrapped.h>
-#include <ydb/library/actors/core/actorsystem.h>
 #include <ydb/library/actors/core/hfunc.h>
 #include <ydb/library/actors/core/log.h>
 

--- a/ydb/core/fq/libs/compute/ydb/finalizer_actor.cpp
+++ b/ydb/core/fq/libs/compute/ydb/finalizer_actor.cpp
@@ -14,7 +14,6 @@
 
 #include <ydb/library/actors/core/actor.h>
 #include <ydb/library/actors/core/actor_bootstrapped.h>
-#include <ydb/library/actors/core/actorsystem.h>
 #include <ydb/library/actors/core/hfunc.h>
 #include <ydb/library/actors/core/log.h>
 

--- a/ydb/core/fq/libs/compute/ydb/initializer_actor.cpp
+++ b/ydb/core/fq/libs/compute/ydb/initializer_actor.cpp
@@ -15,7 +15,6 @@
 
 #include <ydb/library/actors/core/actor.h>
 #include <ydb/library/actors/core/actor_bootstrapped.h>
-#include <ydb/library/actors/core/actorsystem.h>
 #include <ydb/library/actors/core/hfunc.h>
 #include <ydb/library/actors/core/log.h>
 

--- a/ydb/core/fq/libs/compute/ydb/resources_cleaner_actor.cpp
+++ b/ydb/core/fq/libs/compute/ydb/resources_cleaner_actor.cpp
@@ -15,7 +15,6 @@
 
 #include <ydb/library/actors/core/actor.h>
 #include <ydb/library/actors/core/actor_bootstrapped.h>
-#include <ydb/library/actors/core/actorsystem.h>
 #include <ydb/library/actors/core/hfunc.h>
 #include <ydb/library/actors/core/log.h>
 

--- a/ydb/core/fq/libs/compute/ydb/result_writer_actor.cpp
+++ b/ydb/core/fq/libs/compute/ydb/result_writer_actor.cpp
@@ -18,7 +18,6 @@
 
 #include <ydb/library/actors/core/actor.h>
 #include <ydb/library/actors/core/actor_bootstrapped.h>
-#include <ydb/library/actors/core/actorsystem.h>
 #include <ydb/library/actors/core/hfunc.h>
 #include <ydb/library/actors/core/log.h>
 #include <library/cpp/protobuf/interop/cast.h>

--- a/ydb/core/fq/libs/compute/ydb/status_tracker_actor.cpp
+++ b/ydb/core/fq/libs/compute/ydb/status_tracker_actor.cpp
@@ -19,7 +19,6 @@
 
 #include <ydb/library/actors/core/actor.h>
 #include <ydb/library/actors/core/actor_bootstrapped.h>
-#include <ydb/library/actors/core/actorsystem.h>
 #include <ydb/library/actors/core/hfunc.h>
 #include <ydb/library/actors/core/log.h>
 

--- a/ydb/core/fq/libs/compute/ydb/stopper_actor.cpp
+++ b/ydb/core/fq/libs/compute/ydb/stopper_actor.cpp
@@ -18,7 +18,6 @@
 
 #include <ydb/library/actors/core/actor.h>
 #include <ydb/library/actors/core/actor_bootstrapped.h>
-#include <ydb/library/actors/core/actorsystem.h>
 #include <ydb/library/actors/core/hfunc.h>
 #include <ydb/library/actors/core/log.h>
 

--- a/ydb/core/fq/libs/compute/ydb/ydb_run_actor.h
+++ b/ydb/core/fq/libs/compute/ydb/ydb_run_actor.h
@@ -21,7 +21,6 @@
 
 #include <ydb/public/lib/fq/scope.h>
 
-#include <ydb/library/actors/core/actorsystem.h>
 #include <library/cpp/random_provider/random_provider.h>
 #include <library/cpp/time_provider/time_provider.h>
 

--- a/ydb/core/fq/libs/gateway/empty_gateway.h
+++ b/ydb/core/fq/libs/gateway/empty_gateway.h
@@ -1,7 +1,7 @@
 #pragma once
 #include <ydb/library/yql/providers/dq/provider/yql_dq_gateway.h>
 
-#include <ydb/library/actors/core/actorsystem.h>
+#include <ydb/library/actors/core/actorid.h>
 
 namespace NFq {
 

--- a/ydb/core/fq/libs/mock/yql_mock.h
+++ b/ydb/core/fq/libs/mock/yql_mock.h
@@ -3,8 +3,6 @@
 #include <ydb/core/testlib/actors/test_runtime.h>
 #include <ydb/core/fq/libs/shared_resources/interface/shared_resources.h>
 
-#include <ydb/library/actors/core/actorsystem.h>
-
 namespace NFq {
 
 NActors::IActor* CreateYqlMockActor(int grpcPort);

--- a/ydb/core/fq/libs/shared_resources/interface/shared_resources.h
+++ b/ydb/core/fq/libs/shared_resources/interface/shared_resources.h
@@ -1,7 +1,7 @@
 #pragma once
-#include <ydb/library/actors/core/actorsystem.h>
 
 #include <util/generic/ptr.h>
+#include <ydb/library/actors/core/actorsystem_fwd.h>
 
 namespace NFq {
 

--- a/ydb/core/fq/libs/shared_resources/shared_resources.h
+++ b/ydb/core/fq/libs/shared_resources/shared_resources.h
@@ -7,8 +7,6 @@
 
 #include <ydb/library/security/ydb_credentials_provider_factory.h>
 
-#include <ydb/library/actors/core/actorsystem.h>
-
 namespace NFq {
 
 struct TYqSharedResources : public IYqSharedResources {

--- a/ydb/core/http_proxy/http_req.h
+++ b/ydb/core/http_proxy/http_req.h
@@ -10,7 +10,6 @@
 #include <ydb/library/http_proxy/authorization/signature.h>
 #include <ydb/public/api/grpc/draft/ydb_datastreams_v1.grpc.pb.h>
 
-#include <ydb/library/actors/core/actorsystem.h>
 #include <ydb/library/actors/http/http.h>
 #include <ydb/public/sdk/cpp/src/library/grpc/client/grpc_client_low.h>
 #include <library/cpp/http/server/http.h>

--- a/ydb/core/kafka_proxy/kafka_log.h
+++ b/ydb/core/kafka_proxy/kafka_log.h
@@ -1,6 +1,5 @@
 #pragma once
 
-#include <ydb/library/actors/core/actorsystem.h>
 #include <ydb/library/actors/core/log.h>
 #include <ydb/library/services/services.pb.h>
 

--- a/ydb/core/kesus/tablet/rate_accounting.h
+++ b/ydb/core/kesus/tablet/rate_accounting.h
@@ -3,7 +3,6 @@
 #include <ydb/core/protos/kesus.pb.h>
 #include <ydb/library/time_series_vec/time_series_vec.h>
 
-#include <ydb/library/actors/core/actorsystem.h>
 #include <ydb/library/actors/core/actor.h>
 #include <library/cpp/monlib/dynamic_counters/counters.h>
 

--- a/ydb/core/kqp/common/kqp.cpp
+++ b/ydb/core/kqp/common/kqp.cpp
@@ -1,6 +1,6 @@
 #include "kqp.h"
 
-#include <ydb/library/actors/core/actorsystem.h>
+#include <ydb/library/actors/core/actorid.h>
 
 #include <util/datetime/base.h>
 

--- a/ydb/core/kqp/common/shutdown/controller.cpp
+++ b/ydb/core/kqp/common/shutdown/controller.cpp
@@ -1,6 +1,8 @@
 #include "controller.h"
 #include "events.h"
 
+#include <ydb/library/actors/core/actorsystem.h>
+
 namespace NKikimr::NKqp {
 
 TKqpShutdownController::TKqpShutdownController(NActors::TActorId kqpProxyActorId, const NKikimrConfig::TTableServiceConfig& tableServiceConfig, bool enableGraceful)

--- a/ydb/core/kqp/common/shutdown/controller.h
+++ b/ydb/core/kqp/common/shutdown/controller.h
@@ -1,7 +1,7 @@
 #pragma once
 #include "state.h"
+#include <ydb/library/actors/core/actorsystem_fwd.h>
 #include <ydb/library/actors/core/actorid.h>
-#include <ydb/library/actors/core/actorsystem.h>
 #include <ydb/core/protos/config.pb.h>
 #include <ydb/core/protos/table_service_config.pb.h>
 

--- a/ydb/core/kqp/compute_actor/kqp_scan_common.h
+++ b/ydb/core/kqp/compute_actor/kqp_scan_common.h
@@ -1,8 +1,9 @@
 #pragma once
 #include "kqp_compute_state.h"
 
-#include <ydb/library/actors/core/actorsystem.h>
 #include <ydb/library/actors/core/log_iface.h>
+#include <ydb/library/actors/core/actorsystem_fwd.h>
+
 
 namespace NKikimr::NKqp::NScanPrivate {
 

--- a/ydb/core/local_pgwire/log_impl.h
+++ b/ydb/core/local_pgwire/log_impl.h
@@ -1,6 +1,5 @@
 #pragma once
 
-#include <ydb/library/actors/core/actorsystem.h>
 #include <ydb/library/actors/core/log.h>
 #include <ydb/library/services/services.pb.h>
 

--- a/ydb/core/mon_alloc/profiler.cpp
+++ b/ydb/core/mon_alloc/profiler.cpp
@@ -3,7 +3,6 @@
 
 #include <ydb/library/services/services.pb.h>
 
-#include <ydb/library/actors/core/actorsystem.h>
 #include <ydb/library/actors/core/hfunc.h>
 #include <ydb/library/actors/core/mon.h>
 #include <ydb/library/actors/core/log.h>

--- a/ydb/core/persqueue/pqrb/partition_scale_manager.h
+++ b/ydb/core/persqueue/pqrb/partition_scale_manager.h
@@ -9,7 +9,6 @@
 #include <ydb/core/tx/schemeshard/schemeshard.h>
 #include <ydb/core/tx/schemeshard/schemeshard_info_types.h>
 #include <ydb/library/actors/core/actor_bootstrapped.h>
-#include <ydb/library/actors/core/actorsystem.h>
 
 #include <util/system/types.h>
 #include <util/generic/fwd.h>

--- a/ydb/core/persqueue/pqrb/partition_scale_request.h
+++ b/ydb/core/persqueue/pqrb/partition_scale_request.h
@@ -6,7 +6,6 @@
 #include <ydb/core/tx/schemeshard/schemeshard.h>
 #include <ydb/core/tx/tx_proxy/proxy.h>
 #include <ydb/library/actors/core/actor_bootstrapped.h>
-#include <ydb/library/actors/core/actorsystem.h>
 
 #include <util/generic/string.h>
 

--- a/ydb/core/pgproxy/pg_log.h
+++ b/ydb/core/pgproxy/pg_log.h
@@ -1,6 +1,5 @@
 #pragma once
 
-#include <ydb/library/actors/core/actorsystem.h>
 #include <ydb/library/actors/core/log.h>
 #include <ydb/library/services/services.pb.h>
 

--- a/ydb/core/public_http/http_req.h
+++ b/ydb/core/public_http/http_req.h
@@ -1,8 +1,8 @@
 #pragma once
 
 #include <ydb/public/api/protos/ydb_status_codes.pb.h>
-#include <ydb/library/actors/core/actorsystem.h>
 #include <ydb/library/actors/http/http.h>
+#include <ydb/library/actors/core/actorsystem_fwd.h>
 
 namespace NKikimr::NPublicHttp {
 

--- a/ydb/core/security/login_page.h
+++ b/ydb/core/security/login_page.h
@@ -1,5 +1,5 @@
 #include <library/cpp/monlib/service/pages/mon_page.h>
-#include <ydb/library/actors/core/actorsystem.h>
+#include <ydb/library/actors/core/actor.h>
 
 namespace NKikimr {
 

--- a/ydb/core/tablet/private/labeled_db_counters.cpp
+++ b/ydb/core/tablet/private/labeled_db_counters.cpp
@@ -1,6 +1,5 @@
 #include "labeled_db_counters.h"
 
-#include <ydb/library/actors/core/actorsystem.h>
 #include <util/string/split.h>
 #include <ydb/core/sys_view/service/sysview_service.h>
 

--- a/ydb/core/tablet_flat/util_fmt_logger.h
+++ b/ydb/core/tablet_flat/util_fmt_logger.h
@@ -5,7 +5,6 @@
 
 #include <ydb/core/base/appdata.h>
 #include <library/cpp/time_provider/time_provider.h>
-#include <ydb/library/actors/core/actorsystem.h>
 #include <ydb/library/actors/core/log_iface.h>
 
 namespace NKikimr {

--- a/ydb/core/ymq/actor/cleanup_queue_data.h
+++ b/ydb/core/ymq/actor/cleanup_queue_data.h
@@ -8,7 +8,6 @@
 
 #include <ydb/library/actors/core/actor_bootstrapped.h>
 #include <ydb/library/actors/core/hfunc.h>
-#include <ydb/library/actors/core/actorsystem.h>
 #include <ydb/library/actors/core/log.h>
 
 namespace NKikimr::NSQS {

--- a/ydb/core/ymq/actor/cloud_events/cloud_events.h
+++ b/ydb/core/ymq/actor/cloud_events/cloud_events.h
@@ -6,7 +6,6 @@
 #include <ydb/public/sdk/cpp/include/ydb-cpp-sdk/client/table/table.h>
 #include <ydb/library/actors/core/actor_bootstrapped.h>
 #include <ydb/library/actors/core/hfunc.h>
-#include <ydb/library/actors/core/actorsystem.h>
 #include <ydb/library/aclib/aclib.h>
 #include <util/random/mersenne64.h>
 #include <util/random/entropy.h>

--- a/ydb/core/ymq/actor/monitoring.h
+++ b/ydb/core/ymq/actor/monitoring.h
@@ -6,7 +6,6 @@
 
 #include <ydb/library/actors/core/actor_bootstrapped.h>
 #include <ydb/library/actors/core/hfunc.h>
-#include <ydb/library/actors/core/actorsystem.h>
 #include <ydb/library/actors/core/log.h>
 
 

--- a/ydb/library/actors/core/actorsystem_fwd.h
+++ b/ydb/library/actors/core/actorsystem_fwd.h
@@ -1,0 +1,9 @@
+#pragma once
+
+namespace NActors {
+
+class TActorSystem;
+class IActor;
+struct TActorId;
+
+}

--- a/ydb/library/grpc/actor_client/grpc_service_cache.h
+++ b/ydb/library/grpc/actor_client/grpc_service_cache.h
@@ -1,7 +1,6 @@
 #pragma once
 
 #include <variant>
-#include <ydb/library/actors/core/actorsystem.h>
 #include <ydb/library/actors/core/actor_bootstrapped.h>
 #include <ydb/library/actors/core/mailbox.h>
 #include <ydb/core/util/simple_cache.h>

--- a/ydb/library/grpc/server/actors/logger.h
+++ b/ydb/library/grpc/server/actors/logger.h
@@ -1,6 +1,5 @@
 #pragma once
 
-#include <ydb/library/actors/core/actorsystem.h>
 #include <ydb/library/actors/core/log.h>
 #include <ydb/library/grpc/server/logger.h>
 

--- a/ydb/library/logger/actor.h
+++ b/ydb/library/logger/actor.h
@@ -1,6 +1,6 @@
 #pragma once
 
-#include <ydb/library/actors/core/actorsystem.h>
+#include <ydb/library/actors/core/actorsystem_fwd.h>
 #include <ydb/library/actors/core/log.h>
 #include <library/cpp/logger/backend.h>
 #include <library/cpp/logger/record.h>

--- a/ydb/services/bridge/grpc_service.h
+++ b/ydb/services/bridge/grpc_service.h
@@ -3,7 +3,8 @@
 #include <ydb/public/api/grpc/draft/ydb_bridge_v1.grpc.pb.h>
 
 #include <ydb/library/grpc/server/grpc_server.h>
-#include <ydb/library/actors/core/actorsystem.h>
+#include <ydb/library/actors/core/actorid.h>
+#include <ydb/library/actors/core/actorsystem_fwd.h>
 
 
 namespace NKikimr::NGRpcService {

--- a/ydb/services/cms/grpc_service.h
+++ b/ydb/services/cms/grpc_service.h
@@ -1,6 +1,5 @@
 #pragma once
 
-#include <ydb/library/actors/core/actorsystem.h>
 #include <ydb/library/grpc/server/grpc_server.h>
 #include <ydb/public/api/grpc/ydb_cms_v1.grpc.pb.h>
 #include <ydb/core/grpc_services/base/base_service.h>

--- a/ydb/services/config/grpc_service.h
+++ b/ydb/services/config/grpc_service.h
@@ -1,9 +1,9 @@
 #pragma once
 
 #include <ydb/public/api/grpc/ydb_config_v1.grpc.pb.h>
-
 #include <ydb/library/grpc/server/grpc_server.h>
-#include <ydb/library/actors/core/actorsystem.h>
+#include <ydb/library/actors/core/actorsystem_fwd.h>
+#include <ydb/library/actors/core/actorid.h>
 
 
 namespace NKikimr::NGRpcService {

--- a/ydb/services/datastreams/datastreams_proxy.h
+++ b/ydb/services/datastreams/datastreams_proxy.h
@@ -8,8 +8,6 @@
 #include <ydb/core/grpc_services/rpc_calls.h>
 
 #include <ydb/library/grpc/server/grpc_server.h>
-#include <ydb/library/actors/core/actor_bootstrapped.h>
-#include <ydb/library/actors/core/actorsystem.h>
 
 
 namespace NKikimr {

--- a/ydb/services/datastreams/events.h
+++ b/ydb/services/datastreams/events.h
@@ -2,8 +2,6 @@
 
 #include <ydb/public/api/protos/draft/persqueue_error_codes.pb.h>
 
-#include <ydb/library/actors/core/actor_bootstrapped.h>
-#include <ydb/library/actors/core/actorsystem.h>
 #include <ydb/library/actors/core/event_local.h>
 
 namespace NKikimr::NDataStreams::V1 {

--- a/ydb/services/datastreams/grpc_service.h
+++ b/ydb/services/datastreams/grpc_service.h
@@ -1,6 +1,5 @@
 #pragma once
 
-#include <ydb/library/actors/core/actorsystem.h>
 #include <ydb/library/grpc/server/grpc_server.h>
 #include <ydb/public/api/grpc/draft/ydb_datastreams_v1.grpc.pb.h>
 #include <ydb/core/grpc_services/base/base_service.h>

--- a/ydb/services/deprecated/persqueue_v0/grpc_pq_read.h
+++ b/ydb/services/deprecated/persqueue_v0/grpc_pq_read.h
@@ -8,7 +8,7 @@
 #include <ydb/library/persqueue/topic_parser/topic_parser.h>
 
 #include <ydb/library/grpc/server/grpc_request.h>
-#include <ydb/library/actors/core/actorsystem.h>
+#include <ydb/library/actors/core/actorsystem_fwd.h>
 
 #include <util/generic/hash.h>
 #include <util/system/mutex.h>

--- a/ydb/services/deprecated/persqueue_v0/grpc_pq_write.h
+++ b/ydb/services/deprecated/persqueue_v0/grpc_pq_write.h
@@ -7,7 +7,7 @@
 
 #include <ydb/services/deprecated/persqueue_v0/api/grpc/persqueue.grpc.pb.h>
 
-#include <ydb/library/actors/core/actorsystem.h>
+#include <ydb/library/actors/core/actorsystem_fwd.h>
 
 #include <util/generic/hash.h>
 #include <util/generic/maybe.h>

--- a/ydb/services/deprecated/persqueue_v0/persqueue.h
+++ b/ydb/services/deprecated/persqueue_v0/persqueue.h
@@ -1,6 +1,7 @@
 #pragma once
 
-#include <ydb/library/actors/core/actorsystem.h>
+#include <ydb/library/actors/core/actorsystem_fwd.h>
+#include <ydb/library/actors/core/actorid.h>
 
 #include <ydb/services/deprecated/persqueue_v0/api/grpc/persqueue.grpc.pb.h>
 

--- a/ydb/services/discovery/grpc_service.h
+++ b/ydb/services/discovery/grpc_service.h
@@ -1,6 +1,6 @@
 #pragma once
 
-#include <ydb/library/actors/core/actorsystem.h>
+#include <ydb/library/actors/core/actorsystem_fwd.h>
 
 #include <ydb/public/api/grpc/ydb_discovery_v1.grpc.pb.h>
 

--- a/ydb/services/dynamic_config/grpc_service.h
+++ b/ydb/services/dynamic_config/grpc_service.h
@@ -1,6 +1,5 @@
 #pragma once
 
-#include <ydb/library/actors/core/actorsystem.h>
 #include <ydb/library/grpc/server/grpc_server.h>
 #include <ydb/public/api/grpc/draft/ydb_dynamic_config_v1.grpc.pb.h>
 #include <ydb/core/grpc_services/base/base_service.h>

--- a/ydb/services/fq/grpc_service.cpp
+++ b/ydb/services/fq/grpc_service.cpp
@@ -1,5 +1,6 @@
 #include "grpc_service.h"
 
+#include <ydb/library/actors/core/actorsystem.h>
 #include <ydb/core/grpc_services/grpc_helper.h>
 #include <ydb/core/grpc_services/grpc_request_proxy.h>
 #include <ydb/core/grpc_services/rpc_calls.h>

--- a/ydb/services/fq/grpc_service.h
+++ b/ydb/services/fq/grpc_service.h
@@ -1,6 +1,7 @@
 #pragma once
 
-#include <ydb/library/actors/core/actorsystem.h>
+#include <ydb/library/actors/core/actorsystem_fwd.h>
+#include <ydb/library/actors/core/actorid.h>
 
 #include <ydb/library/grpc/server/grpc_server.h>
 

--- a/ydb/services/fq/private_grpc.h
+++ b/ydb/services/fq/private_grpc.h
@@ -1,6 +1,7 @@
 #pragma once
 
-#include <ydb/library/actors/core/actorsystem.h>
+#include <ydb/library/actors/core/actorsystem_fwd.h>
+#include <ydb/library/actors/core/actorid.h>
 #include <ydb/library/grpc/server/grpc_server.h>
 #include <ydb/core/fq/libs/grpc/fq_private_v1.grpc.pb.h>
 

--- a/ydb/services/fq/ydb_over_fq.h
+++ b/ydb/services/fq/ydb_over_fq.h
@@ -1,6 +1,7 @@
 #pragma once
 
-#include <ydb/library/actors/core/actorsystem.h>
+#include <ydb/library/actors/core/actorsystem_fwd.h>
+#include <ydb/library/actors/core/actorid.h>
 
 #include <ydb/library/grpc/server/grpc_server.h>
 

--- a/ydb/services/kesus/grpc_service.h
+++ b/ydb/services/kesus/grpc_service.h
@@ -4,7 +4,7 @@
 
 #include <ydb/library/grpc/server/grpc_server.h>
 
-#include <ydb/library/actors/core/actorsystem.h>
+#include <ydb/library/actors/core/actorsystem_fwd.h>
 
 #include <util/generic/hash_set.h>
 

--- a/ydb/services/keyvalue/grpc_service.h
+++ b/ydb/services/keyvalue/grpc_service.h
@@ -3,7 +3,8 @@
 #include <ydb/public/api/grpc/ydb_keyvalue_v1.grpc.pb.h>
 
 #include <ydb/library/grpc/server/grpc_server.h>
-#include <ydb/library/actors/core/actorsystem.h>
+#include <ydb/library/actors/core/actorsystem_fwd.h>
+#include <ydb/library/actors/core/actorid.h>
 
 
 namespace NKikimr::NGRpcService {

--- a/ydb/services/local_discovery/grpc_service.h
+++ b/ydb/services/local_discovery/grpc_service.h
@@ -1,6 +1,6 @@
 #pragma once
 
-#include <ydb/library/actors/core/actorsystem.h>
+#include <ydb/library/actors/core/actorsystem_fwd.h>
 
 #include <ydb/core/protos/config.pb.h>
 #include <ydb/public/api/grpc/ydb_discovery_v1.grpc.pb.h>

--- a/ydb/services/maintenance/grpc_service.h
+++ b/ydb/services/maintenance/grpc_service.h
@@ -3,7 +3,7 @@
 #include <ydb/core/grpc_services/base/base_service.h>
 #include <ydb/public/api/grpc/draft/ydb_maintenance_v1.grpc.pb.h>
 
-#include <ydb/library/actors/core/actorsystem.h>
+#include <ydb/library/actors/core/actorsystem_fwd.h>
 #include <ydb/library/grpc/server/grpc_server.h>
 
 namespace NKikimr::NGRpcService {

--- a/ydb/services/metadata/abstract/common.h
+++ b/ydb/services/metadata/abstract/common.h
@@ -6,7 +6,6 @@
 #include <ydb/library/actors/core/actorid.h>
 #include <ydb/library/actors/core/events.h>
 #include <ydb/library/actors/core/actor_virtual.h>
-#include <ydb/library/actors/core/actorsystem.h>
 #include <ydb/library/actors/core/actor_bootstrapped.h>
 #include <library/cpp/object_factory/object_factory.h>
 #include <ydb/core/base/events.h>

--- a/ydb/services/metadata/abstract/fetcher.h
+++ b/ydb/services/metadata/abstract/fetcher.h
@@ -3,7 +3,6 @@
 #include <ydb/library/actors/core/actorid.h>
 #include <ydb/library/actors/core/events.h>
 #include <ydb/library/actors/core/actor_virtual.h>
-#include <ydb/library/actors/core/actorsystem.h>
 #include <ydb/library/actors/core/actor_bootstrapped.h>
 #include <library/cpp/object_factory/object_factory.h>
 #include <ydb/core/base/events.h>

--- a/ydb/services/metadata/manager/abstract.h
+++ b/ydb/services/metadata/manager/abstract.h
@@ -7,7 +7,7 @@
 
 #include <ydb/library/accessor/accessor.h>
 #include <ydb/library/aclib/aclib.h>
-#include <ydb/library/actors/core/actorsystem.h>
+#include <ydb/library/actors/core/actorsystem_fwd.h>
 #include <ydb/library/conclusion/result.h>
 #include <ydb/library/conclusion/status.h>
 #include <ydb/services/metadata/abstract/kqp_common.h>

--- a/ydb/services/metadata/request/common.h
+++ b/ydb/services/metadata/request/common.h
@@ -3,7 +3,6 @@
 #include <ydb/library/actors/core/actorid.h>
 #include <ydb/library/actors/core/events.h>
 #include <ydb/library/actors/core/actor_virtual.h>
-#include <ydb/library/actors/core/actorsystem.h>
 #include <ydb/library/actors/core/actor_bootstrapped.h>
 #include <ydb/library/accessor/accessor.h>
 #include <ydb/public/api/protos/ydb_table.pb.h>

--- a/ydb/services/monitoring/grpc_service.h
+++ b/ydb/services/monitoring/grpc_service.h
@@ -1,7 +1,5 @@
 #pragma once
 
-#include <ydb/library/actors/core/actorsystem.h>
-
 #include <ydb/public/api/grpc/ydb_monitoring_v1.grpc.pb.h>
 
 #include <ydb/library/grpc/server/grpc_server.h>

--- a/ydb/services/persqueue_cluster_discovery/grpc_service.h
+++ b/ydb/services/persqueue_cluster_discovery/grpc_service.h
@@ -1,6 +1,7 @@
 #pragma once
 
-#include <ydb/library/actors/core/actorsystem.h>
+#include <ydb/library/actors/core/actorsystem_fwd.h>
+#include <ydb/library/actors/core/actorid.h>
 #include <ydb/public/api/grpc/draft/ydb_persqueue_v1.grpc.pb.h>
 #include <ydb/library/grpc/server/grpc_server.h>
 

--- a/ydb/services/persqueue_v1/grpc_pq_read.h
+++ b/ydb/services/persqueue_v1/grpc_pq_read.h
@@ -7,7 +7,7 @@
 #include <ydb/core/persqueue/cluster_tracker.h>
 #include <ydb/core/mind/address_classification/net_classifier.h>
 
-#include <ydb/library/actors/core/actorsystem.h>
+#include <ydb/library/actors/core/actorid.h>
 
 #include <util/generic/hash.h>
 #include <util/system/mutex.h>

--- a/ydb/services/persqueue_v1/grpc_pq_write.h
+++ b/ydb/services/persqueue_v1/grpc_pq_write.h
@@ -6,7 +6,7 @@
 #include <ydb/core/persqueue/cluster_tracker.h>
 #include <ydb/core/mind/address_classification/net_classifier.h>
 
-#include <ydb/library/actors/core/actorsystem.h>
+#include <ydb/library/actors/core/actorid.h>
 
 #include <util/generic/hash.h>
 #include <util/generic/maybe.h>

--- a/ydb/services/persqueue_v1/persqueue.h
+++ b/ydb/services/persqueue_v1/persqueue.h
@@ -1,6 +1,6 @@
 #pragma once
 
-#include <ydb/library/actors/core/actorsystem.h>
+#include <ydb/library/actors/core/actorsystem_fwd.h>
 
 #include <ydb/public/api/grpc/draft/ydb_persqueue_v1.grpc.pb.h>
 

--- a/ydb/services/persqueue_v1/services_initializer.h
+++ b/ydb/services/persqueue_v1/services_initializer.h
@@ -1,6 +1,8 @@
 #pragma once
 
-#include <ydb/library/actors/core/actorsystem.h>
+#include <ydb/library/actors/core/actorsystem_fwd.h>
+#include <ydb/library/actors/core/actorid.h>
+#include <library/cpp/monlib/dynamic_counters/counters.h>
 
 namespace NKikimr {
 

--- a/ydb/services/persqueue_v1/topic.h
+++ b/ydb/services/persqueue_v1/topic.h
@@ -1,6 +1,7 @@
 #pragma once
 
-#include <ydb/library/actors/core/actorsystem.h>
+#include <ydb/library/actors/core/actorsystem_fwd.h>
+#include <ydb/library/actors/core/actorid.h>
 
 #include <ydb/public/api/grpc/ydb_topic_v1.grpc.pb.h>
 

--- a/ydb/services/rate_limiter/grpc_service.h
+++ b/ydb/services/rate_limiter/grpc_service.h
@@ -1,6 +1,7 @@
 #pragma once
 
-#include <ydb/library/actors/core/actorsystem.h>
+#include <ydb/library/actors/core/actorsystem_fwd.h>
+#include <ydb/library/actors/core/actorid.h>
 #include <ydb/library/grpc/server/grpc_server.h>
 #include <ydb/public/api/grpc/ydb_rate_limiter_v1.grpc.pb.h>
 

--- a/ydb/services/replication/grpc_service.h
+++ b/ydb/services/replication/grpc_service.h
@@ -3,7 +3,6 @@
 #include <ydb/core/grpc_services/base/base_service.h>
 #include <ydb/public/api/grpc/draft/ydb_replication_v1.grpc.pb.h>
 
-#include <ydb/library/actors/core/actorsystem.h>
 #include <ydb/library/grpc/server/grpc_server.h>
 
 namespace NKikimr::NGRpcService {

--- a/ydb/services/tablet/ydb_tablet.h
+++ b/ydb/services/tablet/ydb_tablet.h
@@ -1,6 +1,6 @@
 #pragma once
 
-#include <ydb/library/actors/core/actorsystem.h>
+#include <ydb/library/actors/core/actorsystem_fwd.h>
 #include <ydb/library/grpc/server/grpc_server.h>
 #include <ydb/core/grpc_services/base/base_service.h>
 

--- a/ydb/services/ydb/ydb_clickhouse_internal.h
+++ b/ydb/services/ydb/ydb_clickhouse_internal.h
@@ -5,7 +5,7 @@
 #include <ydb/core/grpc_services/grpc_helper.h>
 #include <ydb/library/grpc/server/grpc_server.h>
 
-#include <ydb/library/actors/core/actorsystem.h>
+#include <ydb/library/actors/core/actorsystem_fwd.h>
 
 #include <ydb/core/grpc_services/base/base_service.h>
 

--- a/ydb/services/ydb/ydb_dummy.cpp
+++ b/ydb/services/ydb/ydb_dummy.cpp
@@ -6,6 +6,7 @@
 #include <ydb/core/grpc_services/rpc_deferrable.h>
 
 #include <ydb/core/grpc_streaming/grpc_streaming.h>
+#include <ydb/library/actors/core/actorsystem.h>
 
 #include <ydb/public/api/grpc/draft/dummy.grpc.pb.h>
 

--- a/ydb/services/ydb/ydb_dummy.h
+++ b/ydb/services/ydb/ydb_dummy.h
@@ -1,7 +1,8 @@
 #pragma once
 
+#include <ydb/library/actors/core/actorid.h>
 #include <ydb/library/grpc/server/grpc_server.h>
-#include <ydb/library/actors/core/actorsystem.h>
+#include <ydb/library/actors/core/actorsystem_fwd.h>
 #include <library/cpp/monlib/counters/counters.h>
 #include <ydb/public/api/grpc/draft/dummy.grpc.pb.h>
 

--- a/ydb/services/ydb/ydb_export.h
+++ b/ydb/services/ydb/ydb_export.h
@@ -1,6 +1,5 @@
 #pragma once
 
-#include <ydb/library/actors/core/actorsystem.h>
 #include <ydb/library/grpc/server/grpc_server.h>
 #include <ydb/public/api/grpc/ydb_export_v1.grpc.pb.h>
 #include <ydb/core/grpc_services/base/base_service.h>

--- a/ydb/services/ydb/ydb_import.h
+++ b/ydb/services/ydb/ydb_import.h
@@ -1,6 +1,5 @@
 #pragma once
 
-#include <ydb/library/actors/core/actorsystem.h>
 #include <ydb/library/grpc/server/grpc_server.h>
 #include <ydb/public/api/grpc/ydb_import_v1.grpc.pb.h>
 #include <ydb/core/grpc_services/base/base_service.h>

--- a/ydb/services/ydb/ydb_logstore.h
+++ b/ydb/services/ydb/ydb_logstore.h
@@ -3,7 +3,6 @@
 #include <ydb/public/api/grpc/draft/ydb_logstore_v1.grpc.pb.h>
 #include <ydb/core/grpc_services/grpc_helper.h>
 #include <ydb/library/grpc/server/grpc_server.h>
-#include <ydb/library/actors/core/actorsystem.h>
 
 #include <ydb/core/grpc_services/base/base_service.h>
 

--- a/ydb/services/ydb/ydb_object_storage.h
+++ b/ydb/services/ydb/ydb_object_storage.h
@@ -1,6 +1,5 @@
 #pragma once
 
-#include <ydb/library/actors/core/actorsystem.h>
 #include <ydb/library/grpc/server/grpc_server.h>
 #include <ydb/public/api/grpc/draft/ydb_object_storage_v1.grpc.pb.h>
 #include <ydb/core/grpc_services/base/base_service.h>

--- a/ydb/services/ydb/ydb_operation.h
+++ b/ydb/services/ydb/ydb_operation.h
@@ -1,6 +1,5 @@
 #pragma once
 
-#include <ydb/library/actors/core/actorsystem.h>
 #include <ydb/public/api/grpc/ydb_operation_v1.grpc.pb.h>
 #include <ydb/library/grpc/server/grpc_server.h>
 #include <ydb/core/grpc_services/base/base_service.h>

--- a/ydb/services/ydb/ydb_scheme.h
+++ b/ydb/services/ydb/ydb_scheme.h
@@ -1,6 +1,5 @@
 #pragma once
 
-#include <ydb/library/actors/core/actorsystem.h>
 #include <ydb/library/grpc/server/grpc_server.h>
 #include <ydb/public/api/grpc/ydb_scheme_v1.grpc.pb.h>
 #include <ydb/core/grpc_services/base/base_service.h>

--- a/ydb/services/ydb/ydb_scripting.h
+++ b/ydb/services/ydb/ydb_scripting.h
@@ -1,6 +1,5 @@
 #pragma once
 
-#include <ydb/library/actors/core/actorsystem.h>
 #include <ydb/library/grpc/server/grpc_server.h>
 #include <ydb/public/api/grpc/ydb_scripting_v1.grpc.pb.h>
 #include <ydb/core/grpc_services/base/base_service.h>

--- a/ydb/services/ydb/ydb_table.h
+++ b/ydb/services/ydb/ydb_table.h
@@ -1,6 +1,6 @@
 #pragma once
 
-#include <ydb/library/actors/core/actorsystem.h>
+#include <ydb/library/actors/core/actorsystem_fwd.h>
 #include <ydb/library/grpc/server/grpc_server.h>
 #include <ydb/public/api/grpc/ydb_table_v1.grpc.pb.h>
 #include <ydb/core/grpc_services/base/base_service.h>

--- a/ydb/services/ymq/grpc_service.h
+++ b/ydb/services/ymq/grpc_service.h
@@ -1,7 +1,6 @@
 #pragma once
 
 #include "ydb/public/api/grpc/draft/ydb_ymq_v1.grpc.pb.h"
-#include <ydb/library/actors/core/actorsystem.h>
 #include <ydb/library/grpc/server/grpc_server.h>
 #include <ydb/core/grpc_services/base/base_service.h>
 

--- a/ydb/services/ymq/ymq_proxy.h
+++ b/ydb/services/ymq/ymq_proxy.h
@@ -7,7 +7,6 @@
 
 #include <ydb/library/grpc/server/grpc_server.h>
 #include <ydb/library/actors/core/actor_bootstrapped.h>
-#include <ydb/library/actors/core/actorsystem.h>
 
 
 namespace NKikimr {


### PR DESCRIPTION

### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

actorsystem.h mainly used to send events in to the actorsystem outside actor context.


### Changelog category <!-- remove all except one -->


* Not for changelog (changelog entry is not required)

### Description for reviewers <!-- (optional) description for those who read this PR -->

Just to reduce number of files to be recompiled after actorsystem.h modifications..
...
