### PR TITLE
Fixed temp dir owner actor id serialization

### DIFF
--- a/ydb/core/kqp/runtime/kqp_write_actor.cpp
+++ b/ydb/core/kqp/runtime/kqp_write_actor.cpp
@@ -1103,7 +1103,7 @@ public:
     void RetryShard(const ui64 shardId, const std::optional<ui64> ifCookieEqual) {
         const auto metadata = ShardedWriteController->GetMessageMetadata(shardId);
         if (!metadata || (ifCookieEqual && metadata->Cookie != ifCookieEqual)) {
-            CA_LOG_W("Retry failed: not found ShardID=" << shardId << " with Cookie=" << ifCookieEqual.value_or(0));
+            CA_LOG_I("Retry failed: not found ShardID=" << shardId << " with Cookie=" << ifCookieEqual.value_or(0));
             return;
         }
 
@@ -1119,7 +1119,7 @@ public:
     }
 
     void Handle(TEvPrivate::TEvShardRequestTimeout::TPtr& ev) {
-        CA_LOG_W("Timeout shardID=" << ev->Get()->ShardId);
+        CA_LOG_I("Timeout shardID=" << ev->Get()->ShardId);
         YQL_ENSURE(InconsistentTx);
         RetryShard(ev->Get()->ShardId, ev->Cookie);
     }

--- a/ydb/core/kqp/ut/scheme/kqp_scheme_ut.cpp
+++ b/ydb/core/kqp/ut/scheme/kqp_scheme_ut.cpp
@@ -11382,19 +11382,16 @@ Y_UNIT_TEST_SUITE(KqpScheme) {
         while (TInstant::Now() < timeout) {
             deleteResult = checkDirectory(firstDir, false);
             if (!deleteResult) {
+                Sleep(TDuration::Seconds(5));
+                const auto& result = checkDirectory(secondDir, true);
+                UNIT_ASSERT_C(result.empty(), result);
                 return;
             }
 
             Sleep(TDuration::MilliSeconds(100));
         }
+
         UNIT_FAIL("Temp dir '" << firstDir << "' still exists, last result: " << deleteResult);
-
-        Sleep(TDuration::Seconds(5));
-
-        {
-            const auto& result = checkDirectory(secondDir, true);
-            UNIT_ASSERT_C(result.empty(), result);
-        }
     }
 }
 

--- a/ydb/core/kqp/ut/scheme/kqp_scheme_ut.cpp
+++ b/ydb/core/kqp/ut/scheme/kqp_scheme_ut.cpp
@@ -11315,12 +11315,12 @@ Y_UNIT_TEST_SUITE(KqpScheme) {
         };
 
         const auto finishPromise = NThreading::NewPromise<void>();
-        const auto firstOwner = runtime.Register(new TTestTempTablesAgentActor(finishPromise));
+        const auto firstOwner = runtime.Register(new TTestTempTablesAgentActor(finishPromise), 0, 1);
         const auto firstDir = "first_dir";
         createTempDir(firstDir, firstOwner);
 
         const auto secondDir = "second_dir";
-        createTempDir(secondDir, runtime.Register(new TTestTempTablesAgentActor(NThreading::NewPromise<void>())));
+        createTempDir(secondDir, runtime.Register(new TTestTempTablesAgentActor(NThreading::NewPromise<void>()), 0, 1));
 
         // Directories succesfully created
 

--- a/ydb/core/kqp/ut/scheme/kqp_scheme_ut.cpp
+++ b/ydb/core/kqp/ut/scheme/kqp_scheme_ut.cpp
@@ -1,8 +1,12 @@
+#include <ydb/core/base/tablet_resolver.h>
+#include <ydb/core/kqp/gateway/actors/scheme.h>
 #include <ydb/core/kqp/gateway/behaviour/resource_pool_classifier/fetcher.h>
+#include <ydb/core/kqp/gateway/kqp_gateway.h>
 #include <ydb/core/kqp/ut/common/kqp_ut_common.h>
 #include <ydb/core/kqp/ut/common/columnshard.h>
 #include <ydb/core/kqp/workload_service/actors/actors.h>
 #include <ydb/core/kqp/workload_service/ut/common/kqp_workload_service_ut_common.h>
+#include <ydb/core/protos/schemeshard/operations.pb.h>
 #include <ydb/core/tx/columnshard/hooks/testing/controller.h>
 #include <ydb/core/tx/columnshard/test_helper/controllers.h>
 #include <ydb/core/formats/arrow/arrow_helpers.h>
@@ -29,6 +33,7 @@ namespace NKqp {
 
 using namespace NYdb;
 using namespace NYdb::NTable;
+using namespace NYdb::NTopic;
 using namespace NYdb::NReplication;
 
 Y_UNIT_TEST_SUITE(KqpScheme) {
@@ -11253,6 +11258,142 @@ Y_UNIT_TEST_SUITE(KqpScheme) {
 
             auto result = session.ExecuteSchemeQuery(query).GetValueSync();
             UNIT_ASSERT_VALUES_EQUAL_C(result.GetStatus(), EStatus::SUCCESS, result.GetIssues().ToString());
+        }
+    }
+
+    class TTestTempTablesAgentActor : public TActorBootstrapped<TTestTempTablesAgentActor> {
+    public:
+        explicit TTestTempTablesAgentActor(NThreading::TPromise<void> finishPromise)
+            : FinishPromise(std::move(finishPromise))
+        {}
+
+        void Bootstrap() {
+            Become(&TTestTempTablesAgentActor::StateWork);
+        }
+
+        STRICT_STFUNC(StateWork,
+            IgnoreFunc(NSchemeShard::TEvSchemeShard::TEvOwnerActorAck);
+            sFunc(TEvents::TEvPoison, Finish);
+        )
+
+    private:
+        void Finish() {
+            FinishPromise.SetValue();
+            PassAway();
+        }
+
+    private:
+        NThreading::TPromise<void> FinishPromise;
+    };
+
+    Y_UNIT_TEST(CleanupTempraryTables) {
+        TKikimrRunner kikimr;
+
+        auto& runtime = *kikimr.GetTestServer().GetRuntime();
+
+        const auto createTempDir = [&](const TString& name, TActorId tempDirOwnerActorId) {
+            auto ev = std::make_unique<TEvTxUserProxy::TEvProposeTransaction>();
+            auto& record = ev->Record;
+
+            record.SetDatabaseName("/Root");
+            record.SetUserToken(NACLib::TSystemUsers::Tmp().SerializeAsString());
+
+            auto* modifyScheme = record.MutableTransaction()->MutableModifyScheme();
+            modifyScheme->SetWorkingDir("/Root");
+            modifyScheme->SetOperationType(NKikimrSchemeOp::EOperationType::ESchemeOpMkDir);
+            modifyScheme->SetAllowCreateInTempDir(false);
+
+            auto* makeDir = modifyScheme->MutableMkDir();
+            makeDir->SetName(name);
+            ActorIdToProto(tempDirOwnerActorId, modifyScheme->MutableTempDirOwnerActorId());
+
+            auto promise = NThreading::NewPromise<IKqpGateway::TGenericResult>();
+            runtime.Register(new TSchemeOpRequestHandler(ev.release(), promise, false));
+
+            const auto result = promise.GetFuture().ExtractValueSync();
+            UNIT_ASSERT_C(result.Success(), TStringBuilder() << "Temp dir '" << name << "' creation failed: " << result.Issues().ToString());
+        };
+
+        const auto finishPromise = NThreading::NewPromise<void>();
+        const auto firstOwner = runtime.Register(new TTestTempTablesAgentActor(finishPromise));
+        const auto firstDir = "first_dir";
+        createTempDir(firstDir, firstOwner);
+
+        const auto secondDir = "second_dir";
+        createTempDir(secondDir, runtime.Register(new TTestTempTablesAgentActor(NThreading::NewPromise<void>())));
+
+        // Directories succesfully created
+
+        Sleep(TDuration::Seconds(5));
+
+        const auto checkDirectory = [&](const TString& name, bool expectedExists) -> TString {
+            const auto result = Navigate(runtime, runtime.AllocateEdgeActor(), JoinPath({"/Root", name}), NSchemeCache::TSchemeCacheNavigate::EOp::OpUnknown);
+            UNIT_ASSERT_C(result, TStringBuilder() << "Empty Navigate " << name << " result");
+            UNIT_ASSERT_C(!result->ResultSet.empty(), TStringBuilder() << "Empty result sets for Navigate " << name);
+
+            const auto& tempDir = result->ResultSet.at(0);
+            if (expectedExists) {
+                if (tempDir.Status != NSchemeCache::TSchemeCacheNavigate::EStatus::Ok) {
+                    return TStringBuilder() << "Navigate temp dir '" << name << "' failed: " << tempDir.Status;
+                }
+                if (tempDir.Kind != NSchemeCache::TSchemeCacheNavigate::EKind::KindPath) {
+                    return TStringBuilder() << "Temp dir '" << name << "' has unexpected kind: " << tempDir.Kind << ", expected KindPath";
+                }
+            } else {
+                if (tempDir.Status != NSchemeCache::TSchemeCacheNavigate::EStatus::PathErrorUnknown) {
+                    return TStringBuilder() << "Navigate temp dir '" << name << "' finished with unexpected status: " << tempDir.Status << ", expected PathErrorUnknown";
+                }
+                if (tempDir.Kind != NSchemeCache::TSchemeCacheNavigate::EKind::KindUnknown) {
+                    return TStringBuilder() << "Temp dir '" << name << "' has unexpected kind: " << tempDir.Kind << ", expected KindUnknown";
+                }
+            }
+
+            return "";
+        };
+
+        {
+            const auto& result = checkDirectory(firstDir, true);
+            UNIT_ASSERT_C(result.empty(), result);
+        }
+
+        {
+            const auto& result = checkDirectory(secondDir, true);
+            UNIT_ASSERT_C(result.empty(), result);
+        }
+
+        // Delete first directory
+
+        const auto edgeActor = runtime.AllocateEdgeActor();
+        runtime.Send(firstOwner, edgeActor, new TEvents::TEvPoison());
+        finishPromise.GetFuture().GetValueSync();
+
+        runtime.Send(MakeTabletResolverID(), edgeActor, new TEvTabletResolver::TEvForward(
+            Tests::SchemeRoot,
+            new IEventHandle(TActorId(), edgeActor, new TEvents::TEvPoisonPill()),
+            {},
+            TEvTabletResolver::TEvForward::EActor::Tablet
+        ));
+        runtime.Send(MakeTabletResolverID(), TActorId(), new TEvTabletResolver::TEvTabletProblem(Tests::SchemeRoot, TActorId()));
+
+        // Check delete first directory
+
+        const auto timeout = TInstant::Now() + TDuration::Seconds(5);
+        TString deleteResult;
+        while (TInstant::Now() < timeout) {
+            deleteResult = checkDirectory(firstDir, false);
+            if (!deleteResult) {
+                return;
+            }
+
+            Sleep(TDuration::MilliSeconds(100));
+        }
+        UNIT_FAIL("Temp dir '" << firstDir << "' still exists, last result: " << deleteResult);
+
+        Sleep(TDuration::Seconds(5));
+
+        {
+            const auto& result = checkDirectory(secondDir, true);
+            UNIT_ASSERT_C(result.empty(), result);
         }
     }
 }

--- a/ydb/core/kqp/ut/scheme/kqp_scheme_ut.cpp
+++ b/ydb/core/kqp/ut/scheme/kqp_scheme_ut.cpp
@@ -11286,7 +11286,7 @@ Y_UNIT_TEST_SUITE(KqpScheme) {
         NThreading::TPromise<void> FinishPromise;
     };
 
-    Y_UNIT_TEST(CleanupTempraryTables) {
+    Y_UNIT_TEST(CleanupTemporaryTables) {
         TKikimrRunner kikimr;
 
         auto& runtime = *kikimr.GetTestServer().GetRuntime();

--- a/ydb/core/tx/schemeshard/schemeshard__background_cleaning.cpp
+++ b/ydb/core/tx/schemeshard/schemeshard__background_cleaning.cpp
@@ -39,23 +39,38 @@ namespace {
 
         return result;
     }
+
+    const TDuration& GetCurrentDelay(
+            const NKikimrConfig::TBackgroundCleaningConfig::TRetrySettings& backgroundCleaningRetrySettings,
+            TTempDirsState::TRetryState& state) {
+        if (state.CurrentDelay == TDuration::Zero()) {
+            state.CurrentDelay =
+                TDuration::MilliSeconds(backgroundCleaningRetrySettings.GetStartDelayMs());
+        }
+        return state.CurrentDelay;
+    }
+
+    TDuration GetDelay(
+        const NKikimrConfig::TBackgroundCleaningConfig::TRetrySettings& backgroundCleaningRetrySettings,
+        TTempDirsState::TRetryState& state
+    ) {
+        auto newDelay = state.CurrentDelay;
+        newDelay *= 2;
+        auto maxDelay =
+            TDuration::MilliSeconds(backgroundCleaningRetrySettings.GetMaxDelayMs());
+        if (newDelay > maxDelay) {
+            newDelay = maxDelay;
+        }
+        newDelay *= AppData()->RandomProvider->Uniform(50, 200);
+        newDelay /= 100;
+        state.CurrentDelay = newDelay;
+        return state.CurrentDelay;
+    }
 }
 
 NOperationQueue::EStartStatus TSchemeShard::StartBackgroundCleaning(const TPathId& pathId) {
     auto info = ResolveTempDirInfo(pathId);
     if (!info) {
-        return NOperationQueue::EStartStatus::EOperationRemove;
-    }
-
-    auto& TempDirsByOwner = TempDirsState.TempDirsByOwner;
-
-    auto it = TempDirsByOwner.find(info->TempDirOwnerActorId);
-    if (it == TempDirsByOwner.end()) {
-        return NOperationQueue::EStartStatus::EOperationRemove;
-    }
-
-    auto tempDirIt = it->second.find(pathId);
-    if (tempDirIt == it->second.end()) {
         return NOperationQueue::EStartStatus::EOperationRemove;
     }
 
@@ -152,7 +167,14 @@ NOperationQueue::EStartStatus TSchemeShard::StartBackgroundCleaning(const TPathI
     }
 
     if (state.ObjectsToDrop == 0) {
-        ContinueBackgroundCleaning(pathId);
+        if (state.DirsToRemove.empty()) {
+            CleanBackgroundCleaningState(pathId);
+            return NOperationQueue::EStartStatus::EOperationRemove;
+        }
+
+        if (!ContinueBackgroundCleaning(pathId)) {
+            return NOperationQueue::EStartStatus::EOperationRetry;
+        }
     }
 
     return NOperationQueue::EStartStatus::EOperationRunning;
@@ -206,6 +228,7 @@ bool TSchemeShard::ContinueBackgroundCleaning(const TPathId& pathId) {
     } else if (state.ObjectsToDrop == state.ObjectsDropped) {
         if (state.NeedToRetryLater || !processNextDir()) {
             CleanBackgroundCleaningState(pathId);
+            BackgroundCleaningQueue->OnDone(pathId);
             EnqueueBackgroundCleaning(pathId);
             return false;
         }
@@ -213,6 +236,7 @@ bool TSchemeShard::ContinueBackgroundCleaning(const TPathId& pathId) {
         ++state.ObjectsDropped;
         if (state.ObjectsToDrop == state.ObjectsDropped && (state.NeedToRetryLater || !processNextDir())) {
             CleanBackgroundCleaningState(pathId);
+            BackgroundCleaningQueue->OnDone(pathId);
             EnqueueBackgroundCleaning(pathId);
             return false;
         }
@@ -268,33 +292,6 @@ void TSchemeShard::Handle(TEvInterconnect::TEvNodeDisconnected::TPtr& ev, const 
     RetryNodeSubscribe(ev->Get()->NodeId);
 }
 
-const TDuration& GetCurrentDelay(
-        const NKikimrConfig::TBackgroundCleaningConfig::TRetrySettings& backgroundCleaningRetrySettings,
-        TTempDirsState::TRetryState& state) {
-    if (state.CurrentDelay == TDuration::Zero()) {
-        state.CurrentDelay =
-            TDuration::MilliSeconds(backgroundCleaningRetrySettings.GetStartDelayMs());
-    }
-    return state.CurrentDelay;
-}
-
-TDuration GetDelay(
-    const NKikimrConfig::TBackgroundCleaningConfig::TRetrySettings& backgroundCleaningRetrySettings,
-    TTempDirsState::TRetryState& state
-) {
-    auto newDelay = state.CurrentDelay;
-    newDelay *= 2;
-    auto maxDelay =
-        TDuration::MilliSeconds(backgroundCleaningRetrySettings.GetMaxDelayMs());
-    if (newDelay > maxDelay) {
-        newDelay = maxDelay;
-    }
-    newDelay *= AppData()->RandomProvider->Uniform(50, 200);
-    newDelay /= 100;
-    state.CurrentDelay = newDelay;
-    return state.CurrentDelay;
-}
-
 void TSchemeShard::RetryNodeSubscribe(ui32 nodeId) {
     auto& nodeStates = TempDirsState.NodeStates;
     auto it = nodeStates.find(nodeId);
@@ -319,7 +316,7 @@ void TSchemeShard::RetryNodeSubscribe(ui32 nodeId) {
         << " at schemeshard " << TabletID());
 
     if (retryState.RetryNumber > BackgroundCleaningRetrySettings.GetMaxRetryNumber()) {
-        for (const auto& ownerActorId: nodeState.Owners) {
+        for (const auto& ownerActorId : nodeState.Owners) {
             auto& tempDirsByOwner = TempDirsState.TempDirsByOwner;
 
             auto itTempDirs = tempDirsByOwner.find(ownerActorId);
@@ -328,7 +325,7 @@ void TSchemeShard::RetryNodeSubscribe(ui32 nodeId) {
             }
 
             auto& currentTempDirs = itTempDirs->second;
-            for (auto& pathId: currentTempDirs) {
+            for (auto& pathId : currentTempDirs) {
                 EnqueueBackgroundCleaning(pathId);
             }
             tempDirsByOwner.erase(itTempDirs);
@@ -348,7 +345,7 @@ void TSchemeShard::RetryNodeSubscribe(ui32 nodeId) {
         return;
     }
 
-    for (const auto& ownerActorId: nodeState.Owners) {
+    for (const auto& ownerActorId : nodeState.Owners) {
         Send(new IEventHandle(ownerActorId, SelfId(),
             new TEvSchemeShard::TEvOwnerActorAck(),
             IEventHandle::FlagTrackDelivery | IEventHandle::FlagSubscribeOnSession));
@@ -366,14 +363,20 @@ bool TSchemeShard::CheckOwnerUndelivered(TEvents::TEvUndelivered::TPtr& ev) {
         return false;
     }
 
-    auto& currentTempDirs = it->second;
     auto ctx = ActorContext();
     LOG_INFO_S(ctx, NKikimrServices::FLAT_TX_SCHEMESHARD, "Owner undelivered for BackgroundCleaning "
         "for ownerActorId# " << ownerActorId
         << ", undelivered reason# " << ev->Get()->Reason
         << " at schemeshard " << TabletID());
 
-    for (auto& pathId: currentTempDirs) {
+    if (ev->Get()->Reason != TEvents::TEvUndelivered::EReason::ReasonActorUnknown) {
+        RetryNodeSubscribe(ownerActorId.NodeId());
+        return true;
+    }
+
+    auto& currentTempDirs = it->second;
+
+    for (auto& pathId : currentTempDirs) {
         EnqueueBackgroundCleaning(pathId);
     }
     tempDirsByOwner.erase(it);

--- a/ydb/core/tx/schemeshard/schemeshard__init.cpp
+++ b/ydb/core/tx/schemeshard/schemeshard__init.cpp
@@ -94,7 +94,7 @@ struct TSchemeShard::TTxInit : public TTransactionBase<TSchemeShard> {
                        TStepId, TTxId, TStepId, TTxId,
                        TString, TTxId,
                        ui64, ui64, ui64,
-                       TActorId> TPathRec;
+                       TString, TActorId> TPathRec;
     typedef TDeque<TPathRec> TPathRows;
 
     template <typename SchemaTable, typename TRowSet>
@@ -112,7 +112,8 @@ struct TSchemeShard::TTxInit : public TTransactionBase<TSchemeShard> {
             rowSet.template GetValueOrDefault<typename SchemaTable::DirAlterVersion>(1),
             rowSet.template GetValueOrDefault<typename SchemaTable::UserAttrsAlterVersion>(1),
             rowSet.template GetValueOrDefault<typename SchemaTable::ACLVersion>(0),
-            rowSet.template GetValueOrDefault<typename SchemaTable::TempDirOwnerId>()
+            rowSet.template GetValueOrDefault<typename SchemaTable::TempDirOwnerActorId_Deprecated>(),
+            rowSet.template GetValueOrDefault<typename SchemaTable::TempDirOwnerActorId>()
         );
     }
 
@@ -138,6 +139,7 @@ struct TSchemeShard::TTxInit : public TTransactionBase<TSchemeShard> {
 
         TPathElement::TPtr path = new TPathElement(pathId, parentPathId, domainId, name, owner);
 
+        TString tempDirOwnerActorId_Deprecated;
         std::tie(
             std::ignore, //pathId
             std::ignore, //parentPathId
@@ -153,11 +155,16 @@ struct TSchemeShard::TTxInit : public TTransactionBase<TSchemeShard> {
             path->DirAlterVersion,
             path->UserAttrs->AlterVersion,
             path->ACLVersion,
+            tempDirOwnerActorId_Deprecated,
             path->TempDirOwnerActorId) = rec;
 
         path->PathState = TPathElement::EPathState::EPathStateNoChanges;
         if (path->StepDropped) {
             path->PathState = TPathElement::EPathState::EPathStateNotExist;
+        }
+
+        if (!path->TempDirOwnerActorId) {
+            path->TempDirOwnerActorId.Parse(tempDirOwnerActorId_Deprecated.c_str(), tempDirOwnerActorId_Deprecated.size());
         }
 
         return path;

--- a/ydb/core/tx/schemeshard/schemeshard__init.cpp
+++ b/ydb/core/tx/schemeshard/schemeshard__init.cpp
@@ -9,8 +9,6 @@
 #include <ydb/core/tablet_flat/flat_cxx_database.h>
 #include <ydb/core/util/pb.h>
 
-#include <library/cpp/protobuf/util/pb_io.h>
-
 namespace NKikimr {
 namespace NSchemeShard {
 

--- a/ydb/core/tx/schemeshard/schemeshard__operation_side_effects.cpp
+++ b/ydb/core/tx/schemeshard/schemeshard__operation_side_effects.cpp
@@ -784,10 +784,10 @@ void TSideEffects::DoPersistDeleteShards(TSchemeShard *ss, NTabletFlatExecutor::
 void TSideEffects::DoUpdateTempDirsToMakeState(TSchemeShard* ss, const TActorContext &ctx) {
     for (auto& [ownerActorId, tempDirs]: TempDirsToMakeState) {
 
-        auto& TempDirsByOwner = ss->TempDirsState.TempDirsByOwner;
+        auto& tempDirsByOwner = ss->TempDirsState.TempDirsByOwner;
         auto& nodeStates = ss->TempDirsState.NodeStates;
 
-        const auto it = TempDirsByOwner.find(ownerActorId);
+        const auto it = tempDirsByOwner.find(ownerActorId);
 
         const auto nodeId = ownerActorId.NodeId();
 
@@ -801,12 +801,12 @@ void TSideEffects::DoUpdateTempDirsToMakeState(TSchemeShard* ss, const TActorCon
             itNodeStates->second.Owners.insert(ownerActorId);
         }
 
-        if (it == TempDirsByOwner.end()) {
+        if (it == tempDirsByOwner.end()) {
             ctx.Send(new IEventHandle(ownerActorId, ss->SelfId(),
                 new TEvSchemeShard::TEvOwnerActorAck(),
                 IEventHandle::FlagTrackDelivery | IEventHandle::FlagSubscribeOnSession));
 
-            auto& currentDirsTables = TempDirsByOwner[ownerActorId];
+            auto& currentDirsTables = tempDirsByOwner[ownerActorId];
 
             for (auto& pathId : tempDirs) {
                 currentDirsTables.insert(std::move(pathId));
@@ -822,9 +822,9 @@ void TSideEffects::DoUpdateTempDirsToMakeState(TSchemeShard* ss, const TActorCon
 
 void TSideEffects::DoUpdateTempDirsToRemoveState(TSchemeShard* ss, const TActorContext& ctx) {
     for (auto& [ownerActorId, tempDirs]: TempDirsToRemoveState) {
-        auto& TempDirsByOwner = ss->TempDirsState.TempDirsByOwner;
-        const auto it = TempDirsByOwner.find(ownerActorId);
-        if (it == TempDirsByOwner.end()) {
+        auto& tempDirsByOwner = ss->TempDirsState.TempDirsByOwner;
+        const auto it = tempDirsByOwner.find(ownerActorId);
+        if (it == tempDirsByOwner.end()) {
             continue;
         }
 
@@ -839,7 +839,7 @@ void TSideEffects::DoUpdateTempDirsToRemoveState(TSchemeShard* ss, const TActorC
         }
 
         if (it->second.empty()) {
-            TempDirsByOwner.erase(it);
+            tempDirsByOwner.erase(it);
 
             auto& nodeStates = ss->TempDirsState.NodeStates;
 

--- a/ydb/core/tx/schemeshard/schemeshard_impl.cpp
+++ b/ydb/core/tx/schemeshard/schemeshard_impl.cpp
@@ -2111,6 +2111,10 @@ void TSchemeShard::PersistLastTxId(NIceDb::TNiceDb& db, const TPathElement::TPtr
 void TSchemeShard::PersistPath(NIceDb::TNiceDb& db, const TPathId& pathId) {
     Y_ABORT_UNLESS(PathsById.contains(pathId));
     TPathElement::TPtr elem = PathsById.at(pathId);
+
+    NActorsProto::TActorId tempDirOwnerActorIdProto;
+    ActorIdToProto(elem->TempDirOwnerActorId, &tempDirOwnerActorIdProto);
+
     if (IsLocalId(pathId)) {
         db.Table<Schema::Paths>().Key(pathId.LocalPathId).Update(
                     NIceDb::TUpdate<Schema::Paths::ParentOwnerId>(elem->ParentPathId.OwnerId),
@@ -2127,7 +2131,8 @@ void TSchemeShard::PersistPath(NIceDb::TNiceDb& db, const TPathId& pathId) {
                     NIceDb::TUpdate<Schema::Paths::DirAlterVersion>(elem->DirAlterVersion),
                     NIceDb::TUpdate<Schema::Paths::UserAttrsAlterVersion>(elem->UserAttrs->AlterVersion),
                     NIceDb::TUpdate<Schema::Paths::ACLVersion>(elem->ACLVersion),
-                    NIceDb::TUpdate<Schema::Paths::TempDirOwnerActorId>(elem->TempDirOwnerActorId.ToString())
+                    NIceDb::TUpdate<Schema::Paths::TempDirOwnerActorId>(elem->TempDirOwnerActorId.ToString()),
+                    NIceDb::TUpdate<Schema::Paths::TempDirOwnerActorIdProto>(tempDirOwnerActorIdProto.SerializeAsString())
                     );
     } else {
         db.Table<Schema::MigratedPaths>().Key(pathId.OwnerId, pathId.LocalPathId).Update(
@@ -2145,7 +2150,8 @@ void TSchemeShard::PersistPath(NIceDb::TNiceDb& db, const TPathId& pathId) {
                     NIceDb::TUpdate<Schema::MigratedPaths::DirAlterVersion>(elem->DirAlterVersion),
                     NIceDb::TUpdate<Schema::MigratedPaths::UserAttrsAlterVersion>(elem->UserAttrs->AlterVersion),
                     NIceDb::TUpdate<Schema::MigratedPaths::ACLVersion>(elem->ACLVersion),
-                    NIceDb::TUpdate<Schema::MigratedPaths::TempDirOwnerActorId>(elem->TempDirOwnerActorId.ToString())
+                    NIceDb::TUpdate<Schema::MigratedPaths::TempDirOwnerActorId>(elem->TempDirOwnerActorId.ToString()),
+                    NIceDb::TUpdate<Schema::MigratedPaths::TempDirOwnerActorIdProto>(tempDirOwnerActorIdProto.SerializeAsString())
                     );
     }
 }

--- a/ydb/core/tx/schemeshard/schemeshard_impl.cpp
+++ b/ydb/core/tx/schemeshard/schemeshard_impl.cpp
@@ -2111,10 +2111,6 @@ void TSchemeShard::PersistLastTxId(NIceDb::TNiceDb& db, const TPathElement::TPtr
 void TSchemeShard::PersistPath(NIceDb::TNiceDb& db, const TPathId& pathId) {
     Y_ABORT_UNLESS(PathsById.contains(pathId));
     TPathElement::TPtr elem = PathsById.at(pathId);
-
-    NActorsProto::TActorId tempDirOwnerActorIdProto;
-    ActorIdToProto(elem->TempDirOwnerActorId, &tempDirOwnerActorIdProto);
-
     if (IsLocalId(pathId)) {
         db.Table<Schema::Paths>().Key(pathId.LocalPathId).Update(
                     NIceDb::TUpdate<Schema::Paths::ParentOwnerId>(elem->ParentPathId.OwnerId),
@@ -2131,8 +2127,7 @@ void TSchemeShard::PersistPath(NIceDb::TNiceDb& db, const TPathId& pathId) {
                     NIceDb::TUpdate<Schema::Paths::DirAlterVersion>(elem->DirAlterVersion),
                     NIceDb::TUpdate<Schema::Paths::UserAttrsAlterVersion>(elem->UserAttrs->AlterVersion),
                     NIceDb::TUpdate<Schema::Paths::ACLVersion>(elem->ACLVersion),
-                    NIceDb::TUpdate<Schema::Paths::TempDirOwnerActorId>(elem->TempDirOwnerActorId.ToString()),
-                    NIceDb::TUpdate<Schema::Paths::TempDirOwnerActorIdProto>(tempDirOwnerActorIdProto.SerializeAsString())
+                    NIceDb::TUpdate<Schema::Paths::TempDirOwnerId>(elem->TempDirOwnerActorId)
                     );
     } else {
         db.Table<Schema::MigratedPaths>().Key(pathId.OwnerId, pathId.LocalPathId).Update(
@@ -2150,8 +2145,7 @@ void TSchemeShard::PersistPath(NIceDb::TNiceDb& db, const TPathId& pathId) {
                     NIceDb::TUpdate<Schema::MigratedPaths::DirAlterVersion>(elem->DirAlterVersion),
                     NIceDb::TUpdate<Schema::MigratedPaths::UserAttrsAlterVersion>(elem->UserAttrs->AlterVersion),
                     NIceDb::TUpdate<Schema::MigratedPaths::ACLVersion>(elem->ACLVersion),
-                    NIceDb::TUpdate<Schema::MigratedPaths::TempDirOwnerActorId>(elem->TempDirOwnerActorId.ToString()),
-                    NIceDb::TUpdate<Schema::MigratedPaths::TempDirOwnerActorIdProto>(tempDirOwnerActorIdProto.SerializeAsString())
+                    NIceDb::TUpdate<Schema::MigratedPaths::TempDirOwnerId>(elem->TempDirOwnerActorId)
                     );
     }
 }

--- a/ydb/core/tx/schemeshard/schemeshard_impl.cpp
+++ b/ydb/core/tx/schemeshard/schemeshard_impl.cpp
@@ -2127,7 +2127,7 @@ void TSchemeShard::PersistPath(NIceDb::TNiceDb& db, const TPathId& pathId) {
                     NIceDb::TUpdate<Schema::Paths::DirAlterVersion>(elem->DirAlterVersion),
                     NIceDb::TUpdate<Schema::Paths::UserAttrsAlterVersion>(elem->UserAttrs->AlterVersion),
                     NIceDb::TUpdate<Schema::Paths::ACLVersion>(elem->ACLVersion),
-                    NIceDb::TUpdate<Schema::Paths::TempDirOwnerId>(elem->TempDirOwnerActorId)
+                    NIceDb::TUpdate<Schema::Paths::TempDirOwnerActorId>(elem->TempDirOwnerActorId)
                     );
     } else {
         db.Table<Schema::MigratedPaths>().Key(pathId.OwnerId, pathId.LocalPathId).Update(
@@ -2145,7 +2145,7 @@ void TSchemeShard::PersistPath(NIceDb::TNiceDb& db, const TPathId& pathId) {
                     NIceDb::TUpdate<Schema::MigratedPaths::DirAlterVersion>(elem->DirAlterVersion),
                     NIceDb::TUpdate<Schema::MigratedPaths::UserAttrsAlterVersion>(elem->UserAttrs->AlterVersion),
                     NIceDb::TUpdate<Schema::MigratedPaths::ACLVersion>(elem->ACLVersion),
-                    NIceDb::TUpdate<Schema::MigratedPaths::TempDirOwnerId>(elem->TempDirOwnerActorId)
+                    NIceDb::TUpdate<Schema::MigratedPaths::TempDirOwnerActorId>(elem->TempDirOwnerActorId)
                     );
     }
 }

--- a/ydb/core/tx/schemeshard/schemeshard_schema.h
+++ b/ydb/core/tx/schemeshard/schemeshard_schema.h
@@ -35,15 +35,15 @@ struct Schema : NIceDb::Schema {
         struct UserAttrsAlterVersion : Column<14, NScheme::NTypeIds::Uint64> {};
         struct ACLVersion :            Column<15, NScheme::NTypeIds::Uint64> {};
         struct ParentOwnerId :         Column<16, NScheme::NTypeIds::Uint64> { using Type = TOwnerId; static constexpr Type Default = InvalidOwnerId; };
-        struct TempDirOwnerActorId :   Column<17, NScheme::NTypeIds::String> {}; // legacy
-        struct TempDirOwnerId :        Column<18, NScheme::NTypeIds::ActorId> {}; // Only for EPathType::EPathTypeDir.
+        struct TempDirOwnerActorId_Deprecated : Column<17, NScheme::NTypeIds::String> {};
+        struct TempDirOwnerActorId :   Column<18, NScheme::NTypeIds::ActorId> {}; // Only for EPathType::EPathTypeDir.
                                                                                   // Not empty if dir must be deleted after loosing connection with TempDirOwnerActorId actor.
                                                                                   // See schemeshard__background_cleaning.cpp.
 
         using TKey = TableKey<Id>;
         using TColumns = TableColumns<Id, ParentId, Name, CreateFinished, PathType, StepCreated, CreateTxId,
             StepDropped, DropTxId, Owner, ACL, LastTxId, DirAlterVersion, UserAttrsAlterVersion, ACLVersion,
-            ParentOwnerId, TempDirOwnerActorId, TempDirOwnerId>;
+            ParentOwnerId, TempDirOwnerActorId_Deprecated, TempDirOwnerActorId>;
     };
 
     struct MigratedPaths : Table<50> {
@@ -63,14 +63,15 @@ struct Schema : NIceDb::Schema {
         struct DirAlterVersion :       Column<14, NScheme::NTypeIds::Uint64> {};
         struct UserAttrsAlterVersion : Column<15, NScheme::NTypeIds::Uint64> {};
         struct ACLVersion :            Column<16, NScheme::NTypeIds::Uint64> {};
-        struct TempDirOwnerActorId :   Column<17, NScheme::NTypeIds::String> {}; // legacy
-        struct TempDirOwnerId :        Column<18, NScheme::NTypeIds::ActorId> {}; // Only for EPathType::EPathTypeDir.
+        struct TempDirOwnerActorId_Deprecated : Column<17, NScheme::NTypeIds::String> {};
+        struct TempDirOwnerActorId :   Column<18, NScheme::NTypeIds::ActorId> {}; // Only for EPathType::EPathTypeDir.
                                                                                   // Not empty if dir must be deleted after loosing connection with TempDirOwnerActorId actor.
                                                                                   // See schemeshard__background_cleaning.cpp.
 
         using TKey = TableKey<OwnerPathId, LocalPathId>;
         using TColumns = TableColumns<OwnerPathId, LocalPathId, ParentOwnerId, ParentLocalId, Name, PathType, StepCreated, CreateTxId,
-            StepDropped, DropTxId, Owner, ACL, LastTxId, DirAlterVersion, UserAttrsAlterVersion, ACLVersion, TempDirOwnerActorId, TempDirOwnerId>;
+            StepDropped, DropTxId, Owner, ACL, LastTxId, DirAlterVersion, UserAttrsAlterVersion, ACLVersion, TempDirOwnerActorId_Deprecated,
+            TempDirOwnerActorId>;
     };
 
     struct TxInFlight : Table<2> { // not in use

--- a/ydb/core/tx/schemeshard/schemeshard_schema.h
+++ b/ydb/core/tx/schemeshard/schemeshard_schema.h
@@ -36,14 +36,14 @@ struct Schema : NIceDb::Schema {
         struct ACLVersion :            Column<15, NScheme::NTypeIds::Uint64> {};
         struct ParentOwnerId :         Column<16, NScheme::NTypeIds::Uint64> { using Type = TOwnerId; static constexpr Type Default = InvalidOwnerId; };
         struct TempDirOwnerActorId :   Column<17, NScheme::NTypeIds::String> {}; // legacy
-        struct TempDirOwnerActorIdProto : Column<18, NScheme::NTypeIds::String> {}; // Only for EPathType::EPathTypeDir.
-                                                                                    // Not empty if dir must be deleted after loosing connection with TempDirOwnerActorId actor.
-                                                                                    // See schemeshard__background_cleaning.cpp.
+        struct TempDirOwnerId :        Column<18, NScheme::NTypeIds::ActorId> {}; // Only for EPathType::EPathTypeDir.
+                                                                                  // Not empty if dir must be deleted after loosing connection with TempDirOwnerActorId actor.
+                                                                                  // See schemeshard__background_cleaning.cpp.
 
         using TKey = TableKey<Id>;
         using TColumns = TableColumns<Id, ParentId, Name, CreateFinished, PathType, StepCreated, CreateTxId,
             StepDropped, DropTxId, Owner, ACL, LastTxId, DirAlterVersion, UserAttrsAlterVersion, ACLVersion,
-            ParentOwnerId, TempDirOwnerActorId, TempDirOwnerActorIdProto>;
+            ParentOwnerId, TempDirOwnerActorId, TempDirOwnerId>;
     };
 
     struct MigratedPaths : Table<50> {
@@ -64,14 +64,13 @@ struct Schema : NIceDb::Schema {
         struct UserAttrsAlterVersion : Column<15, NScheme::NTypeIds::Uint64> {};
         struct ACLVersion :            Column<16, NScheme::NTypeIds::Uint64> {};
         struct TempDirOwnerActorId :   Column<17, NScheme::NTypeIds::String> {}; // legacy
-        struct TempDirOwnerActorIdProto : Column<18, NScheme::NTypeIds::String> {}; // Only for EPathType::EPathTypeDir.
-                                                                                    // Not empty if dir must be deleted after loosing connection with TempDirOwnerActorId actor.
-                                                                                    // See schemeshard__background_cleaning.cpp.
+        struct TempDirOwnerId :        Column<18, NScheme::NTypeIds::ActorId> {}; // Only for EPathType::EPathTypeDir.
+                                                                                  // Not empty if dir must be deleted after loosing connection with TempDirOwnerActorId actor.
+                                                                                  // See schemeshard__background_cleaning.cpp.
 
         using TKey = TableKey<OwnerPathId, LocalPathId>;
         using TColumns = TableColumns<OwnerPathId, LocalPathId, ParentOwnerId, ParentLocalId, Name, PathType, StepCreated, CreateTxId,
-            StepDropped, DropTxId, Owner, ACL, LastTxId, DirAlterVersion, UserAttrsAlterVersion, ACLVersion, TempDirOwnerActorId,
-            TempDirOwnerActorIdProto>;
+            StepDropped, DropTxId, Owner, ACL, LastTxId, DirAlterVersion, UserAttrsAlterVersion, ACLVersion, TempDirOwnerActorId, TempDirOwnerId>;
     };
 
     struct TxInFlight : Table<2> { // not in use

--- a/ydb/core/tx/schemeshard/schemeshard_schema.h
+++ b/ydb/core/tx/schemeshard/schemeshard_schema.h
@@ -35,14 +35,15 @@ struct Schema : NIceDb::Schema {
         struct UserAttrsAlterVersion : Column<14, NScheme::NTypeIds::Uint64> {};
         struct ACLVersion :            Column<15, NScheme::NTypeIds::Uint64> {};
         struct ParentOwnerId :         Column<16, NScheme::NTypeIds::Uint64> { using Type = TOwnerId; static constexpr Type Default = InvalidOwnerId; };
-        struct TempDirOwnerActorId :   Column<17, NScheme::NTypeIds::String> {}; // Only for EPathType::EPathTypeDir.
-                                                                                 // Not empty if dir must be deleted after loosing connection with TempDirOwnerActorId actor.
-                                                                                 // See schemeshard__background_cleaning.cpp.
+        struct TempDirOwnerActorId :   Column<17, NScheme::NTypeIds::String> {}; // legacy
+        struct TempDirOwnerActorIdProto : Column<18, NScheme::NTypeIds::String> {}; // Only for EPathType::EPathTypeDir.
+                                                                                    // Not empty if dir must be deleted after loosing connection with TempDirOwnerActorId actor.
+                                                                                    // See schemeshard__background_cleaning.cpp.
 
         using TKey = TableKey<Id>;
         using TColumns = TableColumns<Id, ParentId, Name, CreateFinished, PathType, StepCreated, CreateTxId,
             StepDropped, DropTxId, Owner, ACL, LastTxId, DirAlterVersion, UserAttrsAlterVersion, ACLVersion,
-            ParentOwnerId, TempDirOwnerActorId>;
+            ParentOwnerId, TempDirOwnerActorId, TempDirOwnerActorIdProto>;
     };
 
     struct MigratedPaths : Table<50> {
@@ -62,13 +63,15 @@ struct Schema : NIceDb::Schema {
         struct DirAlterVersion :       Column<14, NScheme::NTypeIds::Uint64> {};
         struct UserAttrsAlterVersion : Column<15, NScheme::NTypeIds::Uint64> {};
         struct ACLVersion :            Column<16, NScheme::NTypeIds::Uint64> {};
-        struct TempDirOwnerActorId :   Column<17, NScheme::NTypeIds::String> {}; // Only for EPathType::EPathTypeDir.
-                                                                                 // Not empty if dir must be deleted after loosing connection with TempDirOwnerActorId actor.
-                                                                                 // See schemeshard__background_cleaning.cpp.
+        struct TempDirOwnerActorId :   Column<17, NScheme::NTypeIds::String> {}; // legacy
+        struct TempDirOwnerActorIdProto : Column<18, NScheme::NTypeIds::String> {}; // Only for EPathType::EPathTypeDir.
+                                                                                    // Not empty if dir must be deleted after loosing connection with TempDirOwnerActorId actor.
+                                                                                    // See schemeshard__background_cleaning.cpp.
 
         using TKey = TableKey<OwnerPathId, LocalPathId>;
         using TColumns = TableColumns<OwnerPathId, LocalPathId, ParentOwnerId, ParentLocalId, Name, PathType, StepCreated, CreateTxId,
-            StepDropped, DropTxId, Owner, ACL, LastTxId, DirAlterVersion, UserAttrsAlterVersion, ACLVersion, TempDirOwnerActorId>;
+            StepDropped, DropTxId, Owner, ACL, LastTxId, DirAlterVersion, UserAttrsAlterVersion, ACLVersion, TempDirOwnerActorId,
+            TempDirOwnerActorIdProto>;
     };
 
     struct TxInFlight : Table<2> { // not in use

--- a/ydb/tests/functional/scheme_tests/canondata/tablet_scheme_tests.TestTabletSchemes.test_tablet_schemes_flat_schemeshard_/flat_schemeshard.schema
+++ b/ydb/tests/functional/scheme_tests/canondata/tablet_scheme_tests.TestTabletSchemes.test_tablet_schemes_flat_schemeshard_/flat_schemeshard.schema
@@ -93,8 +93,8 @@
             },
             {
                 "ColumnId": 18,
-                "ColumnName": "TempDirOwnerActorIdProto",
-                "ColumnType": "String"
+                "ColumnName": "TempDirOwnerId",
+                "ColumnType": "ActorID"
             }
         ],
         "ColumnsDropped": [],
@@ -3630,8 +3630,8 @@
             },
             {
                 "ColumnId": 18,
-                "ColumnName": "TempDirOwnerActorIdProto",
-                "ColumnType": "String"
+                "ColumnName": "TempDirOwnerId",
+                "ColumnType": "ActorID"
             }
         ],
         "ColumnsDropped": [],

--- a/ydb/tests/functional/scheme_tests/canondata/tablet_scheme_tests.TestTabletSchemes.test_tablet_schemes_flat_schemeshard_/flat_schemeshard.schema
+++ b/ydb/tests/functional/scheme_tests/canondata/tablet_scheme_tests.TestTabletSchemes.test_tablet_schemes_flat_schemeshard_/flat_schemeshard.schema
@@ -7,11 +7,6 @@
         ],
         "ColumnsAdded": [
             {
-                "ColumnId": 17,
-                "ColumnName": "TempDirOwnerActorId",
-                "ColumnType": "String"
-            },
-            {
                 "ColumnId": 1,
                 "ColumnName": "Id",
                 "ColumnType": "Uint64"
@@ -90,13 +85,22 @@
                 "ColumnId": 16,
                 "ColumnName": "ParentOwnerId",
                 "ColumnType": "Uint64"
+            },
+            {
+                "ColumnId": 17,
+                "ColumnName": "TempDirOwnerActorId",
+                "ColumnType": "String"
+            },
+            {
+                "ColumnId": 18,
+                "ColumnName": "TempDirOwnerActorIdProto",
+                "ColumnType": "String"
             }
         ],
         "ColumnsDropped": [],
         "ColumnFamilies": {
             "0": {
                 "Columns": [
-                    17,
                     1,
                     2,
                     3,
@@ -112,7 +116,9 @@
                     13,
                     14,
                     15,
-                    16
+                    16,
+                    17,
+                    18
                 ],
                 "RoomID": 0,
                 "Codec": 0,
@@ -3538,11 +3544,6 @@
         ],
         "ColumnsAdded": [
             {
-                "ColumnId": 17,
-                "ColumnName": "TempDirOwnerActorId",
-                "ColumnType": "String"
-            },
-            {
                 "ColumnId": 1,
                 "ColumnName": "OwnerPathId",
                 "ColumnType": "Uint64"
@@ -3621,13 +3622,22 @@
                 "ColumnId": 16,
                 "ColumnName": "ACLVersion",
                 "ColumnType": "Uint64"
+            },
+            {
+                "ColumnId": 17,
+                "ColumnName": "TempDirOwnerActorId",
+                "ColumnType": "String"
+            },
+            {
+                "ColumnId": 18,
+                "ColumnName": "TempDirOwnerActorIdProto",
+                "ColumnType": "String"
             }
         ],
         "ColumnsDropped": [],
         "ColumnFamilies": {
             "0": {
                 "Columns": [
-                    17,
                     1,
                     2,
                     3,
@@ -3643,7 +3653,9 @@
                     13,
                     14,
                     15,
-                    16
+                    16,
+                    17,
+                    18
                 ],
                 "RoomID": 0,
                 "Codec": 0,

--- a/ydb/tests/functional/scheme_tests/canondata/tablet_scheme_tests.TestTabletSchemes.test_tablet_schemes_flat_schemeshard_/flat_schemeshard.schema
+++ b/ydb/tests/functional/scheme_tests/canondata/tablet_scheme_tests.TestTabletSchemes.test_tablet_schemes_flat_schemeshard_/flat_schemeshard.schema
@@ -88,12 +88,12 @@
             },
             {
                 "ColumnId": 17,
-                "ColumnName": "TempDirOwnerActorId",
+                "ColumnName": "TempDirOwnerActorId_Deprecated",
                 "ColumnType": "String"
             },
             {
                 "ColumnId": 18,
-                "ColumnName": "TempDirOwnerId",
+                "ColumnName": "TempDirOwnerActorId",
                 "ColumnType": "ActorID"
             }
         ],
@@ -3625,12 +3625,12 @@
             },
             {
                 "ColumnId": 17,
-                "ColumnName": "TempDirOwnerActorId",
+                "ColumnName": "TempDirOwnerActorId_Deprecated",
                 "ColumnType": "String"
             },
             {
                 "ColumnId": 18,
-                "ColumnName": "TempDirOwnerId",
+                "ColumnName": "TempDirOwnerActorId",
                 "ColumnType": "ActorID"
             }
         ],


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

Fixed temp dir owner actor id serialization

### Changelog category <!-- remove all except one -->

* Bugfix 

### Description for reviewers <!-- (optional) description for those who read this PR -->

When restarting the SS tablet, the TempDirOwnerActorId pool id is lost and the temporary tables are dropped because it is not possible to send an Ack to the actor. Fixed serialization for TempDirOwnerActorId, pool id is now saved.