### PR TITLE
Support config v2 for nemesis and stress tool

### DIFF
--- a/ydb/tests/library/harness/kikimr_cluster.py
+++ b/ydb/tests/library/harness/kikimr_cluster.py
@@ -47,11 +47,13 @@ class ExternalKiKiMRCluster(KiKiMRClusterInterface):
         self.__ssh_username = ssh_username
         self.__deploy_cluster = deploy_cluster
 
-        if self.__yaml_config is None:
+        if self.__yaml_config is not None:
+            with open(self.__yaml_config, 'r') as r:
+                config_v2 = yaml.safe_load(r.read())
+                self.__hosts = [host.get('name', host.get('host')) for host in config_v2.get('config', {}).get('hosts')]
+        else:
             # Backward compatibility for cluster.yaml
             self.__hosts = [host.get('name', host.get('host')) for host in self.__cluster_config.get('hosts')]
-        else:
-            self.__hosts = [host.get('name', host.get('host')) for host in self.__yaml_config.get('config', {}).get('hosts')]
 
         self.__slot_count = 0
         for domain in self.__cluster_config['domains']:

--- a/ydb/tests/library/harness/kikimr_cluster.py
+++ b/ydb/tests/library/harness/kikimr_cluster.py
@@ -17,6 +17,15 @@ DEFAULT_MON_PORT = 8765
 DEFAULT_GRPC_PORT = 2135
 
 
+def kikimr_cluster_factory(configurator=None, config_path=None):
+    # TODO: remove current function, use explicit KiKiMR/ExternalKiKiMRCluster
+    logger.info("Starting standalone YDB cluster")
+    if config_path is not None:
+        return ExternalKiKiMRCluster(config_path)
+    else:
+        return KiKiMR(configurator)
+
+
 class ExternalKiKiMRCluster(KiKiMRClusterInterface):
     def __init__(
             self,

--- a/ydb/tests/library/harness/kikimr_runner.py
+++ b/ydb/tests/library/harness/kikimr_runner.py
@@ -1014,8 +1014,9 @@ mon={mon}""".format(
         self.update_binary_links()
 
     def prepare_artifacts(self, cluster_yml):
-        self.copy_file_or_dir(
-            self.__kikimr_configure_binary_path, self.kikimr_configure_binary_deploy_path)
+        if self.__kikimr_configure_binary_path is not None:
+            self.copy_file_or_dir(
+                self.__kikimr_configure_binary_path, self.kikimr_configure_binary_deploy_path)
 
         for version, local_driver in zip(self.versions, self.local_drivers_path):
             self.ssh_command("sudo rm -rf %s" % version)
@@ -1025,14 +1026,15 @@ mon={mon}""".format(
                 self.ssh_command("sudo /sbin/setcap 'CAP_SYS_RAWIO,CAP_SYS_NICE=ep' %s" % version)
 
         self.update_binary_links()
-        self.ssh_command("sudo mkdir -p %s" % self.kikimr_configuration_deploy_path)
-        self.copy_file_or_dir(cluster_yml, self.kikimr_cluster_yaml_deploy_path)
-        self.ssh_command(self.__generate_configs_cmd())
-        self.ssh_command(
-            self.__generate_configs_cmd(
-                "--dynamic"
+        if self.__kikimr_configure_binary_path is not None:
+            self.ssh_command("sudo mkdir -p %s" % self.kikimr_configuration_deploy_path)
+            self.copy_file_or_dir(cluster_yml, self.kikimr_cluster_yaml_deploy_path)
+            self.ssh_command(self.__generate_configs_cmd())
+            self.ssh_command(
+                self.__generate_configs_cmd(
+                    "--dynamic"
+                )
             )
-        )
 
     def format_pdisk(self, pdisk_id):
         pass

--- a/ydb/tests/stability/tool/__main__.py
+++ b/ydb/tests/stability/tool/__main__.py
@@ -247,7 +247,7 @@ class StabilityCluster:
 
         if self.yaml_config is None:
             self.kikimr_cluster = ExternalKiKiMRCluster(
-                config_path=self.slice_directory,
+                cluster_template=self.slice_directory,
                 kikimr_configure_binary_path=self._unpack_resource("cfg"),
                 kikimr_path=self.ydbd_path,
                 kikimr_next_path=self.ydbd_next_path,
@@ -256,7 +256,7 @@ class StabilityCluster:
             )
         else:
             self.kikimr_cluster = ExternalKiKiMRCluster(
-                config_path=self.slice_directory,
+                cluster_template=self.slice_directory,
                 kikimr_configure_binary_path=None,
                 kikimr_path=self.ydbd_path,
                 kikimr_next_path=self.ydbd_next_path,

--- a/ydb/tests/stability/tool/__main__.py
+++ b/ydb/tests/stability/tool/__main__.py
@@ -224,13 +224,14 @@ class bcolors:
 
 
 class StabilityCluster:
-    def __init__(self, ssh_username, cluster_path, ydbd_path=None, ydbd_next_path=None):
+    def __init__(self, ssh_username, cluster_path, ydbd_path=None, ydbd_next_path=None, yaml_config=None):
         self.working_dir = os.path.join(tempfile.gettempdir(), "ydb_stability")
         os.makedirs(self.working_dir, exist_ok=True)
         self.ssh_username = ssh_username
         self.slice_directory = cluster_path
         self.ydbd_path = ydbd_path
         self.ydbd_next_path = ydbd_next_path
+        self.yaml_config = yaml_config
 
         self.artifacts = (
             self._unpack_resource('nemesis'),
@@ -244,14 +245,23 @@ class StabilityCluster:
             self._unpack_resource('ydb_cli'),
         )
 
-        self.kikimr_cluster = ExternalKiKiMRCluster(
-            config_path=self.slice_directory,
-            kikimr_configure_binary_path=self._unpack_resource("cfg"),
-            kikimr_path=self.ydbd_path,
-            kikimr_next_path=self.ydbd_next_path,
-            ssh_username=self.ssh_username,
-            deploy_cluster=True,
-        )
+        if yaml_config is None:
+            self.kikimr_cluster = ExternalKiKiMRCluster(
+                config_path=self.slice_directory,
+                kikimr_configure_binary_path=self._unpack_resource("cfg"),
+                kikimr_path=self.ydbd_path,
+                kikimr_next_path=self.ydbd_next_path,
+                ssh_username=self.ssh_username,
+                deploy_cluster=True,
+            )
+        else:
+            self.kikimr_cluster = ExternalKiKiMRCluster(
+                config_path=self.slice_directory,
+                kikimr_path=self.ydbd_path,
+                kikimr_next_path=self.ydbd_next_path,
+                ssh_username=self.ssh_username,
+                yaml_config=self.yaml_config,
+            )
 
     def _unpack_resource(self, name):
         res = resource.find(name)
@@ -1041,6 +1051,12 @@ Common usage scenarios:
         help="Path to next ydbd version binary (for cross-version testing)",
     )
     parser.add_argument(
+        "--yaml_config",
+        required=False,
+        type=path_type,
+        help="Path to Yandex DB configuration v2",
+    )
+    parser.add_argument(
         "--ssh_user",
         required=False,
         default=getpass.getuser(),
@@ -1190,6 +1206,7 @@ def main():
         cluster_path=args.cluster_path,
         ydbd_path=args.ydbd_path,
         ydbd_next_path=args.next_ydbd_path,
+        yaml_config=args.yaml_config,
     )
 
     for action in args.actions:

--- a/ydb/tests/stability/tool/__main__.py
+++ b/ydb/tests/stability/tool/__main__.py
@@ -245,7 +245,7 @@ class StabilityCluster:
             self._unpack_resource('ydb_cli'),
         )
 
-        if yaml_config is None:
+        if self.yaml_config is None:
             self.kikimr_cluster = ExternalKiKiMRCluster(
                 config_path=self.slice_directory,
                 kikimr_configure_binary_path=self._unpack_resource("cfg"),
@@ -1054,6 +1054,7 @@ Common usage scenarios:
     parser.add_argument(
         "--yaml_config",
         required=False,
+        default=None,
         type=path_type,
         help="Path to Yandex DB configuration v2",
     )
@@ -1201,13 +1202,14 @@ Common usage scenarios:
 def main():
     args = parse_args()
     ssh_username = args.ssh_user
+    yaml_config = args.yaml_config
     print('Initing cluster info')
     stability_cluster = StabilityCluster(
         ssh_username=ssh_username,
         cluster_path=args.cluster_path,
         ydbd_path=args.ydbd_path,
         ydbd_next_path=args.next_ydbd_path,
-        yaml_config=args.yaml_config,
+        yaml_config=yaml_config,
     )
 
     for action in args.actions:

--- a/ydb/tests/stability/tool/__main__.py
+++ b/ydb/tests/stability/tool/__main__.py
@@ -257,6 +257,7 @@ class StabilityCluster:
         else:
             self.kikimr_cluster = ExternalKiKiMRCluster(
                 config_path=self.slice_directory,
+                kikimr_configure_binary_path=None,
                 kikimr_path=self.ydbd_path,
                 kikimr_next_path=self.ydbd_next_path,
                 ssh_username=self.ssh_username,

--- a/ydb/tests/stability/tool/__main__.py
+++ b/ydb/tests/stability/tool/__main__.py
@@ -1052,7 +1052,7 @@ Common usage scenarios:
         help="Path to next ydbd version binary (for cross-version testing)",
     )
     parser.add_argument(
-        "--yaml_config",
+        "--yaml-config",
         required=False,
         default=None,
         type=path_type,

--- a/ydb/tests/tools/nemesis/driver/__main__.py
+++ b/ydb/tests/tools/nemesis/driver/__main__.py
@@ -132,7 +132,7 @@ def nemesis_logic(arguments):
     if yaml_config is not None:
         nemesis = catalog.nemesis_factory(
             ExternalKiKiMRCluster(
-                cluster_path=arguments.ydb_cluster_template,
+                cluster_template=arguments.ydb_cluster_template,
                 kikimr_configure_binary_path=None,
                 kikimr_path=arguments.ydb_binary_path,
                 ssh_username=ssh_username,
@@ -144,7 +144,7 @@ def nemesis_logic(arguments):
     else:
         nemesis = catalog.nemesis_factory(
             ExternalKiKiMRCluster(
-                cluster_path=arguments.ydb_cluster_template,
+                cluster_template=arguments.ydb_cluster_template,
                 kikimr_configure_binary_path=None,
                 kikimr_path=arguments.ydb_binary_path,
                 ssh_username=ssh_username,

--- a/ydb/tests/tools/nemesis/driver/__main__.py
+++ b/ydb/tests/tools/nemesis/driver/__main__.py
@@ -160,7 +160,7 @@ def main():
     parser = argparse.ArgumentParser(formatter_class=argparse.RawDescriptionHelpFormatter)
     parser.add_argument('--ydb-cluster-template', required=True, help='Path to the Yandex DB cluster template')
     parser.add_argument('--ydb-binary-path', required=True, help='Path to the Yandex DB binary')
-    parser.add_argument('--yaml-config', required=True, help='Path to the Yandex DB configuration v2')
+    parser.add_argument('--yaml-config', help='Path to the Yandex DB configuration v2')
     parser.add_argument('--private-key-file', default='')
     parser.add_argument('--log-file', default=None)
     parser.add_argument('--mon-port', default=8666, type=lambda x: int(x))

--- a/ydb/tests/tools/nemesis/driver/__main__.py
+++ b/ydb/tests/tools/nemesis/driver/__main__.py
@@ -159,9 +159,9 @@ def nemesis_logic(arguments):
 
 def main():
     parser = argparse.ArgumentParser(formatter_class=argparse.RawDescriptionHelpFormatter)
-    parser.add_argument('--ydb-cluster-template', required=True, help='Path to the Yandex DB cluster template')
-    parser.add_argument('--ydb-binary-path', required=True, help='Path to the Yandex DB binary')
-    parser.add_argument('--yaml-config', required=False, default=None, help='Path to the Yandex DB configuration v2')
+    parser.add_argument('--ydb-cluster-template', required=True, help='Path to the YDB cluster template')
+    parser.add_argument('--ydb-binary-path', required=True, help='Path to the YDB binary')
+    parser.add_argument('--yaml-config', required=False, default=None, help='Path to the YDB configuration v2')
     parser.add_argument('--private-key-file', default='')
     parser.add_argument('--log-file', default=None)
     parser.add_argument('--mon-port', default=8666, type=lambda x: int(x))

--- a/ydb/tests/tools/nemesis/driver/__main__.py
+++ b/ydb/tests/tools/nemesis/driver/__main__.py
@@ -128,16 +128,29 @@ class Key(object):
 def nemesis_logic(arguments):
     logging.config.dictConfig(setup_logging_config(arguments.log_file))
     ssh_username = os.getenv('NEMESIS_USER', 'robot-nemesis')
-    nemesis = catalog.nemesis_factory(
-        ExternalKiKiMRCluster(
-            arguments.ydb_cluster_template,
-            kikimr_configure_binary_path=None,
-            kikimr_path=arguments.ydb_binary_path,
+    if arguments.yaml_config is not None:
+        nemesis = catalog.nemesis_factory(
+            ExternalKiKiMRCluster(
+                arguments.ydb_cluster_template,
+                kikimr_configure_binary_path=None,
+                kikimr_path=arguments.ydb_binary_path,
+                ssh_username=ssh_username,
+                yaml_config=arguments.yaml_config,
+            ),
             ssh_username=ssh_username,
-        ),
-        ssh_username=ssh_username,
-        enable_nemesis_list_filter_by_hostname=arguments.enable_nemesis_list_filter_by_hostname,
-    )
+            enable_nemesis_list_filter_by_hostname=arguments.enable_nemesis_list_filter_by_hostname,
+        )
+    else:
+        nemesis = catalog.nemesis_factory(
+            ExternalKiKiMRCluster(
+                arguments.ydb_cluster_template,
+                kikimr_configure_binary_path=None,
+                kikimr_path=arguments.ydb_binary_path,
+                ssh_username=ssh_username,
+            ),
+            ssh_username=ssh_username,
+            enable_nemesis_list_filter_by_hostname=arguments.enable_nemesis_list_filter_by_hostname,
+        )
     nemesis.start()
     monitor.setup_page(arguments.mon_host, arguments.mon_port)
     nemesis.stop()
@@ -147,6 +160,7 @@ def main():
     parser = argparse.ArgumentParser(formatter_class=argparse.RawDescriptionHelpFormatter)
     parser.add_argument('--ydb-cluster-template', required=True, help='Path to the Yandex DB cluster template')
     parser.add_argument('--ydb-binary-path', required=True, help='Path to the Yandex DB binary')
+    parser.add_argument('--yaml-config', required=True, help='Path to the Yandex DB configuration v2')
     parser.add_argument('--private-key-file', default='')
     parser.add_argument('--log-file', default=None)
     parser.add_argument('--mon-port', default=8666, type=lambda x: int(x))

--- a/ydb/tests/tools/nemesis/driver/__main__.py
+++ b/ydb/tests/tools/nemesis/driver/__main__.py
@@ -128,14 +128,15 @@ class Key(object):
 def nemesis_logic(arguments):
     logging.config.dictConfig(setup_logging_config(arguments.log_file))
     ssh_username = os.getenv('NEMESIS_USER', 'robot-nemesis')
-    if arguments.yaml_config is not None:
+    yaml_config = arguments.yaml_config
+    if yaml_config is not None:
         nemesis = catalog.nemesis_factory(
             ExternalKiKiMRCluster(
-                arguments.ydb_cluster_template,
+                cluster_path=arguments.ydb_cluster_template,
                 kikimr_configure_binary_path=None,
                 kikimr_path=arguments.ydb_binary_path,
                 ssh_username=ssh_username,
-                yaml_config=arguments.yaml_config,
+                yaml_config=yaml_config,
             ),
             ssh_username=ssh_username,
             enable_nemesis_list_filter_by_hostname=arguments.enable_nemesis_list_filter_by_hostname,
@@ -143,7 +144,7 @@ def nemesis_logic(arguments):
     else:
         nemesis = catalog.nemesis_factory(
             ExternalKiKiMRCluster(
-                arguments.ydb_cluster_template,
+                cluster_path=arguments.ydb_cluster_template,
                 kikimr_configure_binary_path=None,
                 kikimr_path=arguments.ydb_binary_path,
                 ssh_username=ssh_username,
@@ -160,7 +161,7 @@ def main():
     parser = argparse.ArgumentParser(formatter_class=argparse.RawDescriptionHelpFormatter)
     parser.add_argument('--ydb-cluster-template', required=True, help='Path to the Yandex DB cluster template')
     parser.add_argument('--ydb-binary-path', required=True, help='Path to the Yandex DB binary')
-    parser.add_argument('--yaml-config', help='Path to the Yandex DB configuration v2')
+    parser.add_argument('--yaml-config', required=False, default=None, help='Path to the Yandex DB configuration v2')
     parser.add_argument('--private-key-file', default='')
     parser.add_argument('--log-file', default=None)
     parser.add_argument('--mon-port', default=8666, type=lambda x: int(x))


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

Support config v2 for nemesis and stress tool via `--yaml-config` argument to path

### Changelog category <!-- remove all except one -->

* Not for changelog (changelog entry is not required)

### Description for reviewers <!-- (optional) description for those who read this PR -->

How to run

```
sudo ./tool deploy_tools --cluster_path=/home/apkobzev/nemesis-2dc/databases.yaml --ydbd_path=/home/apkobzev/ydb/ydb/apps/ydbd/ydbd --yaml-config=/home/apkobzev/nemesis-2dc/config.yaml
```

```
sudo ./tool start_nemesis --cluster_path=/home/apkobzev/nemesis-2dc/databases.yaml --ydbd_path=/home/apkobzev/ydb/ydb/apps/ydbd/ydbd --yaml-config=/home/apkobzev/nemesis-2dc/config.yaml
```

<details>
<summary>config.yaml</summary>

```
metadata:
  kind: MainConfig
  cluster: ""
  version: 0

config:
  erasure: block-4-2 # default for static and dynamic groups
  default_disk_type: SSD # default disk type used for group creation of both kinds

  self_management_config:
    enabled: true # automatic management of static resources (static group, state storage, etc)

  bridge_config:
    piles:
    - name: r1
    - name: r2

  host_configs: # like host flavours in kube
  - drive:
    - path: /dev/disk/by-partlabel/kikimr_ssd_01
      type: SSD
    - path: /dev/disk/by-partlabel/kikimr_ssd_02
      type: SSD
    - path: /dev/disk/by-partlabel/kikimr_ssd_03
      type: SSD
    - path: /dev/disk/by-partlabel/kikimr_ssd_04
      type: SSD
    - path: /dev/disk/by-partlabel/kikimr_ssd_05
      type: SSD
    - path: /dev/disk/by-partlabel/kikimr_ssd_06
      type: SSD
    host_config_id: 1
  hosts:
  - {host: myt0-7691.search.yandex.net, location: {data_center: 'zone-a', rack:  1}, host_config_id: 1, bridge_pile_name: r1}
  - {host: myt0-7619.search.yandex.net, location: {data_center: 'zone-a', rack:  2}, host_config_id: 1, bridge_pile_name: r1}
  - {host: myt0-7612.search.yandex.net, location: {data_center: 'zone-a', rack:  3}, host_config_id: 1, bridge_pile_name: r1}
  - {host: myt0-7610.search.yandex.net, location: {data_center: 'zone-a', rack:  4}, host_config_id: 1, bridge_pile_name: r1}
  - {host: myt0-7564.search.yandex.net, location: {data_center: 'zone-a', rack:  5}, host_config_id: 1, bridge_pile_name: r1}
  - {host: myt0-7551.search.yandex.net, location: {data_center: 'zone-a', rack:  6}, host_config_id: 1, bridge_pile_name: r1}
  - {host: myt0-7548.search.yandex.net, location: {data_center: 'zone-a', rack:  7}, host_config_id: 1, bridge_pile_name: r1}
  - {host: myt0-7545.search.yandex.net, location: {data_center: 'zone-a', rack:  8}, host_config_id: 1, bridge_pile_name: r1}

  - {host: myt0-7542.search.yandex.net, location: {data_center: 'zone-b', rack:  1}, host_config_id: 1, bridge_pile_name: r2}
    #  - {host: myt0-7531.search.yandex.net, location: {data_center: 'zone-b', rack:  2}, host_config_id: 1, bridge_pile_name: r2}
  - {host: myt0-7635.search.yandex.net, location: {data_center: 'zone-b', rack:  2}, host_config_id: 1, bridge_pile_name: r2}
  - {host: myt0-7513.search.yandex.net, location: {data_center: 'zone-b', rack:  3}, host_config_id: 1, bridge_pile_name: r2}
  - {host: myt0-7512.search.yandex.net, location: {data_center: 'zone-b', rack:  4}, host_config_id: 1, bridge_pile_name: r2}
  - {host: myt0-7501.search.yandex.net, location: {data_center: 'zone-b', rack:  5}, host_config_id: 1, bridge_pile_name: r2}
  - {host: myt0-7461.search.yandex.net, location: {data_center: 'zone-b', rack:  6}, host_config_id: 1, bridge_pile_name: r2}
  - {host: myt0-7448.search.yandex.net, location: {data_center: 'zone-b', rack:  7}, host_config_id: 1, bridge_pile_name: r2}
  - {host: myt0-7442.search.yandex.net, location: {data_center: 'zone-b', rack:  8}, host_config_id: 1, bridge_pile_name: r2}
```

</details>

<details>
<summary>databases.yaml</summary>

```
domains:
  - domain_name: Root
    dynamic_slots: 16
    databases:
      - name: "testdb"
        storage_units:
          - count: 4
            kind: ssd
        compute_units:
          - count: 10
            kind: slot
            zone: any
```

</details>

<details>
<summary>nemesis.service systemd unit</summary>

```
[Unit]
Description=Nemesis
After=network-online.target
Wants=nemesis-autoconf.service
StartLimitInterval=10
StartLimitBurst=15

[Service]
Restart=always
RestartSec=1
User=kikimr
Environment=NEMESIS_USER=robot-nemesis
ExecStart=/Berkanavt/nemesis/bin/nemesis --ydb-cluster-template /Berkanavt/kikimr/cfg/databases.yaml --yaml-config /Berkanavt/kikimr/cfg/config.yaml --ydb-binary-path /Berkanavt/kikimr/bin/kikimr --enable-nemesis-list-filter-by-hostname --private-key-file /Berkanavt/nemesis/cfg/id_rsa
StandardOutput=syslog
StandardError=syslog
SyslogIdentifier=nemesis
SyslogFacility=daemon
SyslogLevel=err
LimitNOFILE=65536
LimitCORE=0
LimitMEMLOCK=32212254720

[Install]
WantedBy=multi-user.target
```

</details>
