### PR TITLE
YMQ: Do not send x-amz-crc32 HTTP header (AWS does not do it) (25-1)

### DIFF
--- a/ydb/core/http_proxy/http_req.cpp
+++ b/ydb/core/http_proxy/http_req.cpp
@@ -181,7 +181,6 @@ namespace NKikimr::NHttpProxy {
     constexpr TStringBuf REQUEST_FORWARDED_FOR = "x-forwarded-for";
     constexpr TStringBuf REQUEST_TARGET_HEADER = "x-amz-target";
     constexpr TStringBuf REQUEST_CONTENT_TYPE_HEADER = "content-type";
-    constexpr TStringBuf CRC32_HEADER = "x-amz-crc32";
     constexpr TStringBuf CREDENTIAL_PARAM = "Credential";
 
 
@@ -1173,7 +1172,6 @@ namespace NKikimr::NHttpProxy {
             response->Set<&NHttp::THttpResponse::Connection>(request->GetConnection());
             response->Set(REQUEST_ID_HEADER_EXT, RequestId);
             if (!contentType.empty() && !body.empty()) {
-                response->Set(CRC32_HEADER, ToString(crc32(body.data(), body.size())));
                 response->Set<&NHttp::THttpResponse::ContentType>(contentType);
                 if (!request->Endpoint->CompressContentTypes.empty()) {
                     contentType = NHttp::Trim(contentType.Before(';'), ' ');


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

YMQ: Do not send x-amz-crc32 HTTP header (AWS does not do it)

### Changelog category <!-- remove all except one -->

* Improvement

### Description for reviewers <!-- (optional) description for those who read this PR -->

https://github.com/ydb-platform/ydb/pull/20525
