### PR TITLE
Set EnableDataShardInMemoryStateMigrationAcrossGenerations = true by default

### DIFF
--- a/ydb/core/protos/feature_flags.proto
+++ b/ydb/core/protos/feature_flags.proto
@@ -182,7 +182,7 @@ message TFeatureFlags {
     optional bool EnableScaleRecommender = 157 [default = false];
     optional bool EnableVDiskThrottling = 158 [default = false];
     optional bool EnableDataShardInMemoryStateMigration = 159 [default = true];
-    optional bool EnableDataShardInMemoryStateMigrationAcrossGenerations = 160 [default = false];
+    optional bool EnableDataShardInMemoryStateMigrationAcrossGenerations = 160 [default = true];
     optional bool DisableLocalDBEraseCache = 161 [default = false];
     optional bool EnableChecksumsExport = 162 [default = false];
     optional bool EnableTopicTransfer = 163 [default = true];


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

...

### Changelog category <!-- remove all except one -->

* Not for changelog (changelog entry is not required)

### Description for reviewers <!-- (optional) description for those who read this PR -->

Since 25-1 supports in-memory migration between datashards we can enable migration across generations by default.