### PR TITLE
Fix cluster permissions check under grpc

### DIFF
--- a/ydb/core/grpc_services/grpc_request_check_actor.h
+++ b/ydb/core/grpc_services/grpc_request_check_actor.h
@@ -141,8 +141,8 @@ public:
         }
 
         if constexpr (std::is_same_v<TEvent, TEvRequestAuthAndCheck>) {
-            TVector<TEvTicketParser::TEvAuthorizeTicket::TEntry> e = GetEntriesForAuthAndCheckRequest(Request_);
-            entries.insert(entries.end(), e.begin(), e.end());
+            TVector<TEvTicketParser::TEvAuthorizeTicket::TEntry> authCheckRequestEntries = GetEntriesForAuthAndCheckRequest(Request_);
+            entries.insert(entries.end(), authCheckRequestEntries.begin(), authCheckRequestEntries.end());
         }
 
         TVector<TEvTicketParser::TEvAuthorizeTicket::TEntry> clusterAccessCheckEntries = GetEntriesForClusterAccessCheck(rootAttributes);

--- a/ydb/core/grpc_services/grpc_request_check_actor.h
+++ b/ydb/core/grpc_services/grpc_request_check_actor.h
@@ -39,11 +39,12 @@ bool TGRpcRequestProxyHandleMethods::ValidateAndReplyOnError(TCtx* ctx) {
     }
 }
 
-inline TVector<TEvTicketParser::TEvAuthorizeTicket::TEntry> GetEntriesForAuthAndCheckRequest(TEvRequestAuthAndCheck::TPtr& ev, const TVector<std::pair<TString, TString>>& rootAttributes) {
+inline TVector<TEvTicketParser::TEvAuthorizeTicket::TEntry> GetEntriesForAuthAndCheckRequest(TEvRequestAuthAndCheck::TPtr& ev) {
     const bool isBearerToken = ev->Get()->YdbToken && ev->Get()->YdbToken->StartsWith("Bearer");
     const bool useAccessService = AppData()->AuthConfig.GetUseAccessService();
     const bool needClusterAccessResourceCheck = AppData()->DomainsConfig.GetSecurityConfig().ViewerAllowedSIDsSize() > 0 ||
-                                AppData()->DomainsConfig.GetSecurityConfig().MonitoringAllowedSIDsSize() > 0;
+                                AppData()->DomainsConfig.GetSecurityConfig().MonitoringAllowedSIDsSize() > 0 ||
+                                AppData()->DomainsConfig.GetSecurityConfig().AdministrationAllowedSIDsSize() > 0;
 
     if (!isBearerToken || !useAccessService || !needClusterAccessResourceCheck) {
         return {};
@@ -56,7 +57,23 @@ inline TVector<TEvTicketParser::TEvAuthorizeTicket::TEntry> GetEntriesForAuthAnd
             {NKikimr::TEvTicketParser::TEvAuthorizeTicket::ToPermissions({"ydb.developerApi.get", "ydb.developerApi.update"}), {{"gizmo_id", "gizmo"}}}
         };
         return entries;
-    } else if (accessServiceType == "Nebius_v1") {
+    } else {
+        return {};
+    }
+}
+
+inline TVector<TEvTicketParser::TEvAuthorizeTicket::TEntry> GetEntriesForClusterAccessCheck(const TVector<std::pair<TString, TString>>& rootAttributes) {
+    const bool useAccessService = AppData()->AuthConfig.GetUseAccessService();
+    const bool needClusterAccessResourceCheck = AppData()->DomainsConfig.GetSecurityConfig().ViewerAllowedSIDsSize() > 0 ||
+                                AppData()->DomainsConfig.GetSecurityConfig().MonitoringAllowedSIDsSize() > 0 ||
+                                AppData()->DomainsConfig.GetSecurityConfig().AdministrationAllowedSIDsSize() > 0;
+
+    if (!useAccessService || !needClusterAccessResourceCheck) {
+        return {};
+    }
+
+    const TString& accessServiceType = AppData()->AuthConfig.GetAccessServiceType();
+    if (accessServiceType == "Nebius_v1") {
         static const auto permissions = NKikimr::TEvTicketParser::TEvAuthorizeTicket::ToPermissions({
             "ydb.clusters.get", "ydb.clusters.monitor", "ydb.clusters.manage"
         });
@@ -124,7 +141,11 @@ public:
         }
 
         if constexpr (std::is_same_v<TEvent, TEvRequestAuthAndCheck>) {
-            const auto& e = GetEntriesForAuthAndCheckRequest(Request_, rootAttributes);
+            TVector<TEvTicketParser::TEvAuthorizeTicket::TEntry> e = GetEntriesForAuthAndCheckRequest(Request_);
+            entries.insert(entries.end(), e.begin(), e.end());
+        }
+
+        if (TVector<TEvTicketParser::TEvAuthorizeTicket::TEntry> e = GetEntriesForClusterAccessCheck(rootAttributes)) {
             entries.insert(entries.end(), e.begin(), e.end());
         }
 

--- a/ydb/core/grpc_services/grpc_request_check_actor.h
+++ b/ydb/core/grpc_services/grpc_request_check_actor.h
@@ -145,9 +145,8 @@ public:
             entries.insert(entries.end(), e.begin(), e.end());
         }
 
-        if (TVector<TEvTicketParser::TEvAuthorizeTicket::TEntry> e = GetEntriesForClusterAccessCheck(rootAttributes)) {
-            entries.insert(entries.end(), e.begin(), e.end());
-        }
+        TVector<TEvTicketParser::TEvAuthorizeTicket::TEntry> clusterAccessCheckEntries = GetEntriesForClusterAccessCheck(rootAttributes);
+        entries.insert(entries.end(), clusterAccessCheckEntries.begin(), clusterAccessCheckEntries.end());
 
         if (!entries.empty()) {
             SetEntries(entries);


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

...

### Changelog category <!-- remove all except one -->

* Not for changelog (changelog entry is not required)

### Description for reviewers <!-- (optional) description for those who read this PR -->

The new Nebius scheme for checking permissions for cluster root container worked only for http requests (because TEvRequestAuthAndCheck works only in case of http requests). This PR fixes grpc methods (like getting/setting cluster config), if we use AdministrationAllowedSIDs together with folder_id cluster attribute.
