### PR TITLE
ydb/core/wrappers/events: remove unnecessary dependency

### DIFF
--- a/ydb/core/wrappers/events/ya.make
+++ b/ydb/core/wrappers/events/ya.make
@@ -17,7 +17,6 @@ ELSE()
         contrib/libs/curl
         ydb/core/base
         ydb/core/protos
-        ydb/core/wrappers/ut_helpers
         ydb/library/actors/core
     )
 ENDIF()


### PR DESCRIPTION
on ydb/core/wrappers/ut_helpers; it is only used in various ut

### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

...

### Changelog category <!-- remove all except one -->

* Not for changelog (changelog entry is not required)

### Description for reviewers <!-- (optional) description for those who read this PR -->

arcadia ci passed;
only purpose of this patch is to reduce list of deps on libxml
