### PR TITLE
return mon cors headers on 403

### DIFF
--- a/ydb/core/mon/mon.cpp
+++ b/ydb/core/mon/mon.cpp
@@ -507,7 +507,7 @@ public:
     void ReplyForbiddenAndPassAway(const TString& error = {}) {
         NYql::TIssues issues;
         issues.AddIssue(error);
-        ReplyErrorAndPassAway(Ydb::StatusIds::UNAUTHORIZED, issues, false);
+        ReplyErrorAndPassAway(Ydb::StatusIds::UNAUTHORIZED, issues, true);
     }
 
     void SendRequest(const NKikimr::NGRpcService::TEvRequestAuthAndCheckResult* result = nullptr) {
@@ -1143,7 +1143,7 @@ public:
     void ReplyForbiddenAndPassAway(const TString& error = {}) {
         NYql::TIssues issues;
         issues.AddIssue(error);
-        ReplyErrorAndPassAway(Ydb::StatusIds::UNAUTHORIZED, issues, false);
+        ReplyErrorAndPassAway(Ydb::StatusIds::UNAUTHORIZED, issues, true);
     }
 
     void SendRequest(const NKikimr::NGRpcService::TEvRequestAuthAndCheckResult& result) {


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

https://github.com/ydb-platform/ydb/issues/20767 
Return CORS headers on 403, mon. Pages show Network Error without CORS; we need CORS so the client can interpret the received response

### Changelog category <!-- remove all except one -->

* Improvement

### Description for reviewers <!-- (optional) description for those who read this PR -->

...
