### PR TITLE
25-1-2: Fix KesusQuoterService reconnect

### DIFF
--- a/ydb/core/quoter/kesus_quoter_proxy.cpp
+++ b/ydb/core/quoter/kesus_quoter_proxy.cpp
@@ -43,6 +43,8 @@ namespace NQuoter {
 
 namespace TEvKesus = NKesus::TEvKesus;
 
+const ui64 KesusReconnectLimit = 5;
+
 class TKesusQuoterProxy : public TActorBootstrapped<TKesusQuoterProxy> {
     struct TResourceState {
         const TString Resource;
@@ -797,6 +799,7 @@ private:
         if (ev->Get()->Status == NKikimrProto::OK) {
             KESUS_PROXY_LOG_DEBUG("Successfully connected to tablet");
             Connected = true;
+            KesusReconnectCount = 0;
             SubscribeToAllResources();
         } else {
             if (ev->Get()->Dead) {
@@ -804,8 +807,10 @@ private:
                 SendToService(CreateUpdateEvent(TEvQuota::EUpdateState::Broken));
             } else {
                 KESUS_PROXY_LOG_WARN("Failed to connect to tablet. Status: " << ev->Get()->Status);
-                if (!ConnectToKesus(true)) {
-                    KESUS_PROXY_LOG_WARN("Too many reconnect attempts, assuming kesus dead");
+                if (++KesusReconnectCount <= KesusReconnectLimit) {
+                    ConnectToKesus(true);
+                } else {
+                    KESUS_PROXY_LOG_WARN("Too many reconnect attempts in a row, assuming kesus dead");
                     SendToService(CreateUpdateEvent(TEvQuota::EUpdateState::Broken));
                     KesusReconnectCount = 0;
                 }
@@ -1122,7 +1127,7 @@ public:
         return KesusInfo->Description.GetKesusTabletId();
     }
 
-    NTabletPipe::TClientConfig GetPipeConnectionOptions(bool reconnection) {
+    static NTabletPipe::TClientConfig GetPipeConnectionOptions(bool reconnection) {
         NTabletPipe::TClientConfig cfg;
         cfg.RetryPolicy = {
             .RetryLimitCount = 3u,
@@ -1138,13 +1143,9 @@ public:
         CookieToResourcePath.clear(); // we will resend all requests with new cookies
     }
 
-    bool ConnectToKesus(bool reconnection) {
+    void ConnectToKesus(bool reconnection) {
         if (reconnection) {
             KESUS_PROXY_LOG_INFO("Reconnecting to kesus");
-            ++KesusReconnectCount;
-            if (KesusReconnectCount > 5) {
-                return false;
-            }
         } else {
             KESUS_PROXY_LOG_DEBUG("Connecting to kesus");
         }
@@ -1157,7 +1158,6 @@ public:
                     GetKesusTabletId(),
                     GetPipeConnectionOptions(reconnection)));
         Connected = false;
-        return true;
     }
 
     void PassAway() override {

--- a/ydb/core/quoter/kesus_quoter_proxy.h
+++ b/ydb/core/quoter/kesus_quoter_proxy.h
@@ -22,6 +22,8 @@ struct ITabletPipeFactory {
     static THolder<ITabletPipeFactory> GetDefaultFactory();
 };
 
+extern const ui64 KesusReconnectLimit;
+
 NActors::IActor* CreateKesusQuoterProxy(ui64 quoterId, const NSchemeCache::TSchemeCacheNavigate::TEntry& navEntry, const NActors::TActorId& quoterServiceId, THolder<ITabletPipeFactory> tabletPipeFactory = ITabletPipeFactory::GetDefaultFactory());
 
 class TKesusResourceAllocationStatistics {


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

Fixed the [KesusQuoterService freeze](https://github.com/ydb-platform/ydb/issues/20747) in case of several unsuccessful attempts to connect to the Kesus tablet.

### Changelog category <!-- remove all except one -->

* Bugfix

### Description for reviewers <!-- (optional) description for those who read this PR -->

issue: https://github.com/ydb-platform/ydb/issues/20747
main: https://github.com/ydb-platform/ydb/pull/20748
