### PR TITLE
Fix create_mute_test_issue

### DIFF
--- a/.github/scripts/tests/create_new_muted_ya.py
+++ b/.github/scripts/tests/create_new_muted_ya.py
@@ -313,8 +313,9 @@ def create_mute_issues(all_tests, file_path, close_issues=True):
     
     # Check and close issues if needed
     closed_issues = []
+    partially_unmuted_issues = []
     if close_issues:
-        closed_issues = close_unmuted_issues(muted_tests_set)
+        closed_issues, partially_unmuted_issues = close_unmuted_issues(muted_tests_set)
     
     # First, collect all tests into temporary dictionary
     for test in all_tests:
@@ -380,25 +381,60 @@ def create_mute_issues(all_tests, file_path, close_issues=True):
     
     # Add closed issues section if any
     if closed_issues:
-        formatted_results.append("CLOSED ISSUES:")
-        for issue in closed_issues:
-            formatted_results.append(f"Closed {issue['url']}")
-            formatted_results.append("Unmuted tests:")
-            for test in issue['tests']:
-                formatted_results.append(f"  - {test}")
+        formatted_results.append("🔒 **CLOSED ISSUES**")
+        formatted_results.append("─────────────────────────────")
         formatted_results.append("")
-        formatted_results.append("CREATED ISSUES:")
+        for issue in closed_issues:
+            formatted_results.append(f"✅ **Closed** {issue['url']}")
+            formatted_results.append("   📝 **Unmuted tests:**")
+            for test in issue['tests']:
+                formatted_results.append(f"   • `{test}`")
+            formatted_results.append("")
     
-    # Add created issues
-    current_owner = None
-    for result in results:
-        if current_owner != result['owner']:
-            if formatted_results and formatted_results[-1] != "":  # Add blank line between owner groups if last line is not empty
-                formatted_results.append('')
-            current_owner = result['owner']
-            # Add owner header with team URL
-            formatted_results.append(f"TEAM:@ydb-platform/{current_owner} @https://github.com/orgs/ydb-platform/teams/{current_owner}")
-        formatted_results.append(result['message'])
+    # Add partially unmuted issues section if any
+    if partially_unmuted_issues:
+        if closed_issues:
+            formatted_results.append("─────────────────────────────")
+            formatted_results.append("")
+        formatted_results.append("🔓 **PARTIALLY UNMUTED ISSUES**")
+        formatted_results.append("─────────────────────────────")
+        formatted_results.append("")
+        for issue in partially_unmuted_issues:
+            formatted_results.append(f"⚠️ **Partially unmuted** {issue['url']}")
+            formatted_results.append("   📝 **Unmuted tests:**")
+            for test in issue['unmuted_tests']:
+                formatted_results.append(f"   • `{test}`")
+            formatted_results.append("   🔒 **Still muted tests:**")
+            for test in issue['still_muted_tests']:
+                formatted_results.append(f"   • `{test}`")
+            formatted_results.append("")
+    
+    # Add created issues section if any
+    if results:
+        if closed_issues or partially_unmuted_issues:
+            formatted_results.append("─────────────────────────────")
+            formatted_results.append("")
+        formatted_results.append("🆕 **CREATED ISSUES**")
+        formatted_results.append("─────────────────────────────")
+        formatted_results.append("")
+    
+        # Add created issues
+        current_owner = None
+        for result in results:
+            if current_owner != result['owner']:
+                if formatted_results and formatted_results[-1] != "":
+                    formatted_results.append('')
+                    formatted_results.append('')
+                current_owner = result['owner']
+                # Add owner header with team URL
+                formatted_results.append(f"👥 **TEAM** @ydb-platform/{current_owner}")
+                formatted_results.append(f"   https://github.com/orgs/ydb-platform/teams/{current_owner}")
+                formatted_results.append("   ┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄")
+            
+            # Extract issue URL and title
+            issue_url = result['message'].split('url ')[-1]
+            title = result['message'].split("'")[1]
+            formatted_results.append(f"   🎯 {issue_url} - `{title}`")
 
     print("\n\n")
     print("\n".join(formatted_results))


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->


- fixed bug 
```

Traceback (most recent call last):
  File "/home/runner/work/ydb/ydb/.github/scripts/tests/create_new_muted_ya.py", line 478, in <module>
    mute_worker(args)
  File "/home/runner/work/ydb/ydb/.github/scripts/tests/create_new_muted_ya.py", line 454, in mute_worker
    create_mute_issues(all_tests, file_path, close_issues=args.close_issues)
  File "/home/runner/work/ydb/ydb/.github/scripts/tests/create_new_muted_ya.py", line 317, in create_mute_issues
    closed_issues = close_unmuted_issues(muted_tests_set)
                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/runner/work/ydb/ydb/.github/scripts/tests/update_mute_issues.py", line 787, in close_unmuted_issues
    if not has_unmute_comment(existing_comments, unmuted_tests):
                              ^^^^^^^^^^^^^^^^^
UnboundLocalError: cannot access local variable 'existing_comments' where it is not associated with a value
```
- Comment format improved

#### Comment before

![telegram-cloud-photo-size-2-5431526156781351731-y](https://github.com/user-attachments/assets/49acd2f7-9a64-4707-9b0f-96bea873423f)

### Comment after

<img width="679" alt="image" src="https://github.com/user-attachments/assets/a0bc9fe3-af8c-4ee5-b6eb-d56d92c2df50" />

### Changelog category <!-- remove all except one -->


* Not for changelog (changelog entry is not required)

### Description for reviewers <!-- (optional) description for those who read this PR -->

...
