### PR TITLE
Fix data races on CurrentSettings field

### DIFF
--- a/ydb/core/jaeger_tracing/sampling_throttling_configurator.h
+++ b/ydb/core/jaeger_tracing/sampling_throttling_configurator.h
@@ -35,12 +35,12 @@ public:
 
 private:
     TSettings<double, TIntrusivePtr<TThrottler>> GenerateThrottlers(
-        TSettings<double, TWithTag<TThrottlingSettings>> settings);
+        TSettings<double, TWithTag<TThrottlingSettings>> settings) const;
 
     std::unique_ptr<TSamplingThrottlingControl::TSamplingThrottlingImpl> GenerateSetup();
 
     TVector<TIntrusivePtr<TSamplingThrottlingControl>> IssuedControls;
-    TIntrusivePtr<ITimeProvider> TimeProvider;
+    const TIntrusivePtr<ITimeProvider> TimeProvider;
     TFastRng64 Rng;
     TSettings<double, TIntrusivePtr<TThrottler>> CurrentSettings;
     TMutex ControlMutex;


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

Fix data race which occured during reconfiguration of TSamplingThrottlingControl, https://github.com/ydb-platform/ydb/issues/20741

### Changelog category <!-- remove all except one -->

* Bugfix