### PR TITLE
Fix mirror-3of4 data merger problem (#20674)

### DIFF
--- a/ydb/core/blobstorage/vdisk/hulldb/generic/blobstorage_hulldatamerger.h
+++ b/ydb/core/blobstorage/vdisk/hulldb/generic/blobstorage_hulldatamerger.h
@@ -166,7 +166,7 @@ namespace NKikimr {
 
                 bool producingHugeBlob = false;
 
-                if (inMemParts.Empty() && smallDiskParts.Empty()) { // we only have huge blobs, so keep it this way
+                if (inMemParts.Empty() && smallDiskParts.Empty() && !hugeDiskParts.Empty()) { // we only have huge blobs, so keep it this way
                     producingHugeBlob = true;
                 } else {
                     producingHugeBlob = targetingHugeBlob;


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

Fix mirror-3of4 data merger problem

### Changelog category <!-- remove all except one -->

* Not for changelog (changelog entry is not required)

### Description for reviewers <!-- (optional) description for those who read this PR -->

This patch fixes problem when generated huge metadata parts in mirror-3of4 were incorrectly processed by 24-4.
