### PR TITLE
Add a new library ini_config that only works with ini format

### DIFF
--- a/ydb/public/lib/ydb_cli/common/aws.cpp
+++ b/ydb/public/lib/ydb_cli/common/aws.cpp
@@ -15,7 +15,7 @@ const TString TCommandWithAwsCredentials::AwsCredentialsFile = "~/.aws/credentia
 const TString TCommandWithAwsCredentials::AwsDefaultProfileName = "default";
 
 TString TCommandWithAwsCredentials::ReadIniKey(const TString& iniKey) {
-    using namespace NConfig;
+    using namespace NIniConfig;
 
     const auto fileName = "AWS Credentials";
     const auto& profileName = AwsProfile.GetOrElse(AwsDefaultProfileName);

--- a/ydb/public/lib/ydb_cli/common/aws.h
+++ b/ydb/public/lib/ydb_cli/common/aws.h
@@ -1,8 +1,7 @@
 #pragma once
 
 #include "command.h"
-
-#include <library/cpp/config/config.h>
+#include "ini_config/config.h"
 
 #include <util/generic/maybe.h>
 #include <util/system/env.h>
@@ -60,7 +59,7 @@ protected:
     static const TString AwsDefaultProfileName;
 
 private:
-    TMaybe<NConfig::TConfig> Config;
+    TMaybe<NIniConfig::TConfig> Config;
     TMaybe<TString> AwsProfile;
 };
 

--- a/ydb/public/lib/ydb_cli/common/ini_config/config.cpp
+++ b/ydb/public/lib/ydb_cli/common/ini_config/config.cpp
@@ -1,0 +1,50 @@
+#include "config.h"
+
+namespace NIniConfig {
+
+    TConfig::TConfig()
+        : V_(Null())
+    {}
+
+    TConfig::TConfig(IValue* v)
+        : V_(v)
+    {}
+
+    bool TConfig::IsNull() const {
+        return V_.Get() == Null();
+    }
+
+    bool TConfig::Has(const TStringBuf& key) const {
+        return !operator[](key).IsNull();
+    }
+
+    const TConfig& TConfig::operator[](const TStringBuf& key) const {
+        return Get<TDict>().Find(key);
+    }
+
+    const TConfig& TConfig::At(const TStringBuf& key) const {
+        return Get<TDict>().At(key);
+    }
+
+    const TConfig& TConfig::Or(const TConfig& r) const {
+        return IsNull() ? r : *this;
+    }
+
+    const TConfig& TDict::Find(const TStringBuf& key) const {
+        auto it = find(TString(key));
+        if (it == end()) {
+            static TConfig nullConfig;
+            return nullConfig;
+        }
+        return it->second;
+    }
+
+    const TConfig& TDict::At(const TStringBuf& key) const {
+        auto it = find(TString(key));
+        if (it == end()) {
+            throw TConfigParseError() << "Missing key: " << key;
+        }
+        return it->second;
+    }
+
+}

--- a/ydb/public/lib/ydb_cli/common/ini_config/config.cpp
+++ b/ydb/public/lib/ydb_cli/common/ini_config/config.cpp
@@ -1,50 +1,66 @@
 #include "config.h"
+#include "ini.h"
+
+#include <util/stream/mem.h>
 
 namespace NIniConfig {
 
-    TConfig::TConfig()
-        : V_(Null())
-    {}
+TConfig TConfig::ReadIni(TStringBuf in) {
+    TMemoryInput mi(in.data(), in.size());
 
-    TConfig::TConfig(IValue* v)
-        : V_(v)
-    {}
+    return ParseIni(mi);
+}
 
-    bool TConfig::IsNull() const {
-        return V_.Get() == Null();
+bool TConfig::Has(const TStringBuf& key) const {
+    return !operator[](key).IsNull();
+}
+
+const TConfig& TConfig::operator[](const TStringBuf& key) const {
+    return Get<TDict>().Find(key);
+}
+
+const TConfig& TConfig::At(const TStringBuf& key) const {
+    return Get<TDict>().At(key);
+}
+
+const TConfig& TConfig::operator[](size_t index) const {
+    return Get<TArray>().Index(index);
+}
+
+size_t TConfig::GetArraySize() const {
+    return Get<TArray>().size();
+}
+
+const TConfig& TDict::Find(const TStringBuf& key) const {
+    const_iterator it = find(key);
+
+    if (it == end()) {
+        return Default<TConfig>();
     }
 
-    bool TConfig::Has(const TStringBuf& key) const {
-        return !operator[](key).IsNull();
+    return it->second;
+}
+
+const TConfig& TDict::At(const TStringBuf& key) const {
+    const_iterator it = find(key);
+
+    Y_ENSURE_BT(it != end(), "missing key '" << key << "'");
+
+    return it->second;
+}
+
+const TConfig& TArray::Index(size_t index) const {
+    if (index < size()) {
+        return (*this)[index];
     }
 
-    const TConfig& TConfig::operator[](const TStringBuf& key) const {
-        return Get<TDict>().Find(key);
-    }
+    return Default<TConfig>();
+}
 
-    const TConfig& TConfig::At(const TStringBuf& key) const {
-        return Get<TDict>().At(key);
-    }
+const TConfig& TArray::At(size_t index) const {
+    Y_ENSURE_BT(index < size(), "index " << index << " is out of bounds");
 
-    const TConfig& TConfig::Or(const TConfig& r) const {
-        return IsNull() ? r : *this;
-    }
-
-    const TConfig& TDict::Find(const TStringBuf& key) const {
-        auto it = find(TString(key));
-        if (it == end()) {
-            static TConfig nullConfig;
-            return nullConfig;
-        }
-        return it->second;
-    }
-
-    const TConfig& TDict::At(const TStringBuf& key) const {
-        auto it = find(TString(key));
-        if (it == end()) {
-            throw TConfigParseError() << "Missing key: " << key;
-        }
-        return it->second;
-    }
+    return (*this)[index];
+}
 
 }

--- a/ydb/public/lib/ydb_cli/common/ini_config/config.h
+++ b/ydb/public/lib/ydb_cli/common/ini_config/config.h
@@ -1,0 +1,71 @@
+#pragma once
+
+#include "value.h"
+
+#include <util/generic/hash.h>
+#include <util/generic/ptr.h>
+#include <util/generic/deque.h>
+#include <util/generic/string.h>
+#include <util/generic/vector.h>
+#include <util/generic/yexception.h>
+#include <util/stream/input.h>
+
+namespace NIniConfig {
+
+    class TConfigError : public yexception {};
+    class TConfigParseError : public TConfigError {};
+    class TTypeMismatch : public TConfigError {};
+
+    // This is a copy of the original TConfig class from the library/cpp/config with only ini-specific functionality
+
+    class TConfig {
+    public:
+        TConfig();
+        TConfig(const TConfig& other) = default;
+        TConfig& operator=(const TConfig& other) = default;
+
+        explicit TConfig(IValue* v);
+
+        template <typename T>
+        bool IsA() const {
+            return V_ && V_->IsA(typeid(T));
+        }
+
+        template <typename T>
+        const T& Get() const {
+            return *static_cast<const T*>(V_->Ptr());
+        }
+
+        template <typename T>
+        T& GetNonConstant() const {
+            return *static_cast<T*>(V_->Ptr());
+        }
+
+        template <typename T>
+        T As() const {
+            return ValueAs<T>(V_.Get());
+        }
+
+        template <typename T>
+        T As(T def) const {
+            return IsNull() ? def : As<T>();
+        }
+
+        bool IsNull() const;
+        bool Has(const TStringBuf& key) const;
+        const TConfig& operator[](const TStringBuf& key) const;
+        const TConfig& At(const TStringBuf& key) const;
+        const TConfig& Or(const TConfig& r) const;
+
+        static TConfig ReadIni(TStringBuf content);
+
+    private:
+        TIntrusivePtr<IValue> V_;
+    };
+
+    struct TArray : public TVector<TConfig> {};
+    struct TDict : public THashMap<TString, TConfig> {
+        const TConfig& Find(const TStringBuf& key) const;
+        const TConfig& At(const TStringBuf& key) const;
+    };
+}

--- a/ydb/public/lib/ydb_cli/common/ini_config/config.h
+++ b/ydb/public/lib/ydb_cli/common/ini_config/config.h
@@ -11,51 +11,90 @@
 #include <util/stream/input.h>
 
 namespace NIniConfig {
+    class TConfigError: public TWithBackTrace<yexception> {
+    };
 
-    class TConfigError : public yexception {};
-    class TConfigParseError : public TConfigError {};
-    class TTypeMismatch : public TConfigError {};
+    class TConfigParseError: public TConfigError {
+    };
 
-    // This is a copy of the original TConfig class from the library/cpp/config with only ini-specific functionality
+    class TTypeMismatch: public TConfigError {
+    };
+
+    struct TArray;
+    struct TDict;
 
     class TConfig {
     public:
-        TConfig();
-        TConfig(const TConfig& other) = default;
-        TConfig& operator=(const TConfig& other) = default;
-
-        explicit TConfig(IValue* v);
-
-        template <typename T>
-        bool IsA() const {
-            return V_ && V_->IsA(typeid(T));
+        inline TConfig()
+            : V_(Null())
+        {
         }
 
-        template <typename T>
-        const T& Get() const {
-            return *static_cast<const T*>(V_->Ptr());
+        inline TConfig(IValue* v)
+            : V_(v)
+        {
         }
 
-        template <typename T>
-        T& GetNonConstant() const {
-            return *static_cast<T*>(V_->Ptr());
+        TConfig(const TConfig& config) = default;
+        TConfig& operator=(const TConfig& config) = default;
+
+        template <class T>
+        inline bool IsA() const {
+            return V_->IsA(typeid(T));
         }
 
-        template <typename T>
-        T As() const {
+        inline bool IsNumeric() const {
+            return IsA<double>() || IsA<i64>() || IsA<ui64>();
+        }
+
+        template <class T>
+        inline const T& Get() const {
+            return GetNonConstant<T>();
+        }
+
+        template <class T>
+        inline T& GetNonConstant() const {
+            if (this->IsA<T>()) {
+                return *(T*)V_->Ptr();
+            }
+
+            if constexpr (std::is_same_v<T, ::NIniConfig::TArray>) {
+                NCfgPrivate::ReportTypeMismatch(V_->TypeName(), "array");
+            } else if constexpr (std::is_same_v<T, ::NIniConfig::TDict>) {
+                NCfgPrivate::ReportTypeMismatch(V_->TypeName(), "dict");
+            } else if constexpr (std::is_same_v<T, TString>) {
+                NCfgPrivate::ReportTypeMismatch(V_->TypeName(), "string");
+            } else {
+                NCfgPrivate::ReportTypeMismatch(V_->TypeName(), ::TypeName<T>());
+            }
+        }
+
+        template <class T>
+        inline T As() const {
             return ValueAs<T>(V_.Get());
         }
 
-        template <typename T>
-        T As(T def) const {
+        template <class T>
+        inline T As(T def) const {
             return IsNull() ? def : As<T>();
         }
 
-        bool IsNull() const;
+        inline bool IsNull() const noexcept {
+            return V_.Get() == Null();
+        }
+
+        const TConfig& Or(const TConfig& r) const {
+            return IsNull() ? r : *this;
+        }
+
+        //assume value is dict
         bool Has(const TStringBuf& key) const;
         const TConfig& operator[](const TStringBuf& key) const;
         const TConfig& At(const TStringBuf& key) const;
-        const TConfig& Or(const TConfig& r) const;
+
+        //assume value is array
+        const TConfig& operator[](size_t index) const;
+        size_t GetArraySize() const;
 
         static TConfig ReadIni(TStringBuf content);
 
@@ -63,8 +102,12 @@ namespace NIniConfig {
         TIntrusivePtr<IValue> V_;
     };
 
-    struct TArray : public TVector<TConfig> {};
-    struct TDict : public THashMap<TString, TConfig> {
+    struct TArray: public TDeque<TConfig> {
+        const TConfig& Index(size_t index) const;
+        const TConfig& At(size_t index) const;
+    };
+
+    struct TDict: public THashMap<TString, TConfig> {
         const TConfig& Find(const TStringBuf& key) const;
         const TConfig& At(const TStringBuf& key) const;
     };

--- a/ydb/public/lib/ydb_cli/common/ini_config/config_ut.cpp
+++ b/ydb/public/lib/ydb_cli/common/ini_config/config_ut.cpp
@@ -1,0 +1,172 @@
+#include "config.h"
+
+#include <library/cpp/testing/unittest/registar.h>
+
+using namespace NIniConfig;
+
+Y_UNIT_TEST_SUITE(IniConfigBasicTests) {
+
+    Y_UNIT_TEST(SimpleKeyValue) {
+        const TString ini = R"ini(
+            key1 = value1
+            key2=value2
+        )ini";
+
+        TConfig cfg = TConfig::ReadIni(ini);
+        UNIT_ASSERT_VALUES_EQUAL(cfg["key1"].As<TString>(), "value1");
+        UNIT_ASSERT_VALUES_EQUAL(cfg["key2"].As<TString>(), "value2");
+    }
+
+    Y_UNIT_TEST(CommentsAndWhitespace) {
+        const TString ini = R"ini(
+            # This is a comment
+            ; This is a semicolon comment
+            key = value   # inline comment
+        )ini";
+
+        TConfig cfg = TConfig::ReadIni(ini);
+        UNIT_ASSERT_VALUES_EQUAL(cfg["key"].As<TString>(), "value");
+    }
+
+    Y_UNIT_TEST(SimpleSection) {
+        const TString ini = R"ini(
+            [section]
+            name = John
+        )ini";
+
+        TConfig cfg = TConfig::ReadIni(ini);
+        UNIT_ASSERT_VALUES_EQUAL(cfg["section"]["name"].As<TString>(), "John");
+    }
+
+    Y_UNIT_TEST(VeryDeepSection) {
+        const TString ini = R"ini(
+            [a.b.c.d.e]
+            nested = ok
+        )ini";
+
+        TConfig cfg = TConfig::ReadIni(ini);
+        UNIT_ASSERT_VALUES_EQUAL(cfg["a"]["b"]["c"]["d"]["e"]["nested"].As<TString>(), "ok");
+    }
+
+    Y_UNIT_TEST(SectionOverridesRoot) {
+        const TString ini = R"ini(
+            name = root
+
+            [sec]
+            name = section
+        )ini";
+
+        TConfig cfg = TConfig::ReadIni(ini);
+        UNIT_ASSERT_VALUES_EQUAL(cfg["name"].As<TString>(), "root");
+        UNIT_ASSERT_VALUES_EQUAL(cfg["sec"]["name"].As<TString>(), "section");
+    }
+
+    Y_UNIT_TEST(NotExistingKey) {
+        const TString ini = R"ini(
+            key = value
+        )ini";
+
+        TConfig cfg = TConfig::ReadIni(ini);
+
+        UNIT_ASSERT(cfg.Has("key"));
+        UNIT_ASSERT(!cfg.Has("missing"));
+
+        UNIT_ASSERT_EXCEPTION_CONTAINS(cfg.At("missing"), TConfigParseError, "Missing key: missing");
+
+        UNIT_ASSERT(cfg["missing"].IsNull());
+    }
+
+    Y_UNIT_TEST(NotExistingProfile) {
+        const TString ini = R"ini(
+            [profile default]
+            name = root
+        )ini";
+
+        TConfig cfg = TConfig::ReadIni(ini);
+        auto& section = cfg["profile default"];
+        UNIT_ASSERT_VALUES_EQUAL(section["name"].As<TString>(), "root");
+
+        UNIT_ASSERT(!cfg.Has("profile xyz"));
+        UNIT_ASSERT(cfg["profile xyz"].IsNull());
+    }
+
+    Y_UNIT_TEST(IncorrectSectionFormat) {
+        const TString ini = R"ini(
+            [unclosed
+            key = val
+        )ini";
+
+        UNIT_ASSERT_EXCEPTION_CONTAINS(TConfig::ReadIni(ini), TConfigParseError, "malformed section");
+    }
+
+    Y_UNIT_TEST(LineWithoutEquals) {
+        const TString ini = R"ini(
+            key=val
+            broken_line
+        )ini";
+
+        UNIT_ASSERT_EXCEPTION_CONTAINS(TConfig::ReadIni(ini), TConfigParseError, "no '='");
+    }
+
+    Y_UNIT_TEST(QuotedValuesPlaceholder) {
+        const TString ini = R"ini(
+            path = "/usr/bin"
+            port = 8080
+            debug = true
+        )ini";
+
+        TConfig cfg = TConfig::ReadIni(ini);
+        UNIT_ASSERT_VALUES_EQUAL(cfg["path"].As<TString>(), "/usr/bin");
+        UNIT_ASSERT_EQUAL(cfg["port"].As<i64>(), 8080);
+        UNIT_ASSERT_EQUAL(cfg["debug"].As<bool>(), true);
+    }
+
+    Y_UNIT_TEST(AsWithDefaults) {
+        const TString ini = R"ini(
+            key = true
+        )ini";
+
+        TConfig cfg = TConfig::ReadIni(ini);
+
+        bool flag = cfg["key"].As<bool>();
+        bool fallback = cfg["missing"].As<bool>(false);
+
+        UNIT_ASSERT_EQUAL(flag, true);
+        UNIT_ASSERT_EQUAL(fallback, false);
+    }
+
+    Y_UNIT_TEST(EmptyContentReturnsEmptyDict) {
+        const TString ini = "";
+
+        TConfig cfg = TConfig::ReadIni(ini);
+        UNIT_ASSERT(cfg.IsA<TDict>());
+        UNIT_ASSERT_EQUAL(cfg.Get<TDict>().size(), 0);
+    }
+
+    Y_UNIT_TEST(SectionWithDotInName) {
+        const TString ini = R"ini(
+            [service.local]
+            port = 1234
+        )ini";
+
+        TConfig cfg = TConfig::ReadIni(ini);
+        UNIT_ASSERT(cfg["service"]["local"].Has("port"));
+        UNIT_ASSERT_EQUAL(cfg["service"]["local"]["port"].As<int>(), 1234);
+    }
+
+    Y_UNIT_TEST(SectionBeforeAndAfterRootKeys) {
+        const TString ini = R"ini(
+            key1 = root1
+
+            [group]
+            key2 = group2
+
+            key3 = root3
+        )ini";
+
+        TConfig cfg = TConfig::ReadIni(ini);
+        UNIT_ASSERT_VALUES_EQUAL(cfg["key1"].As<TString>(), "root1");
+        UNIT_ASSERT_VALUES_EQUAL(cfg["group"]["key2"].As<TString>(), "group2");
+        UNIT_ASSERT_VALUES_EQUAL(cfg["key3"].As<TString>(), "root3");
+    }
+}

--- a/ydb/public/lib/ydb_cli/common/ini_config/ini.cpp
+++ b/ydb/public/lib/ydb_cli/common/ini_config/ini.cpp
@@ -1,0 +1,57 @@
+#include "ini.h"
+
+#include <util/string/strip.h>
+#include <util/stream/input.h>
+#include <util/stream/mem.h>
+#include <util/string/split.h>
+
+namespace NIniConfig {
+
+    namespace {
+        TStringBuf StripComment(TStringBuf line) {
+            return line.Before('#').Before(';');
+        }
+    }
+
+    TConfig ParseIni(IInputStream& in) {
+        TConfig ret(ConstructValue(TDict()));
+        TConfig* cur = &ret;
+        TString line;
+
+        while (in.ReadLine(line)) {
+            TStringBuf tmp = StripComment(line);
+            TStringBuf stmp = StripString(tmp);
+
+            if (stmp.empty()) {
+                continue;
+            }
+
+            if (stmp.StartsWith('[') && stmp.EndsWith(']')) {
+                stmp = TStringBuf(stmp.data() + 1, stmp.Size() - 2);
+                cur = &ret;
+
+                while (!!stmp) {
+                    TStringBuf sectionPart;
+                    stmp.Split('.', sectionPart, stmp);
+                    cur = &cur->GetNonConstant<TDict>()[sectionPart];
+                    if (!cur->IsA<TDict>()) {
+                        *cur = TConfig(ConstructValue(TDict()));
+                    }
+                }
+            } else {
+                TStringBuf key, value;
+                tmp.Split('=', key, value);
+                auto& dict = cur->GetNonConstant<TDict>();
+                dict[StripString(key)] = TConfig(ConstructValue(TString(StripString(value))));
+            }
+        }
+
+        return ret;
+    }
+
+    TConfig TConfig::ReadIni(TStringBuf content) {
+        TMemoryInput memIn(content.data(), content.size());
+        return ParseIni(memIn);
+    }
+
+}

--- a/ydb/public/lib/ydb_cli/common/ini_config/ini.cpp
+++ b/ydb/public/lib/ydb_cli/common/ini_config/ini.cpp
@@ -50,9 +50,9 @@ namespace NIniConfig {
                 } else {
                     //value
                     TStringBuf key, value;
-    
-                    tmp.Split('=', key, value);
-    
+                    if (!tmp.TrySplit('=', key, value)) {
+                        ythrow TConfigParseError() << "invalid line: " << tmp;
+                    }
                     auto& dict = cur->GetNonConstant<TDict>();
                     auto strippedValue = TString(StripString(value));
                     dict[StripString(key)] = ConstructValue(strippedValue);

--- a/ydb/public/lib/ydb_cli/common/ini_config/ini.cpp
+++ b/ydb/public/lib/ydb_cli/common/ini_config/ini.cpp
@@ -14,44 +14,53 @@ namespace NIniConfig {
     }
 
     TConfig ParseIni(IInputStream& in) {
-        TConfig ret(ConstructValue(TDict()));
-        TConfig* cur = &ret;
-        TString line;
-
-        while (in.ReadLine(line)) {
-            TStringBuf tmp = StripComment(line);
-            TStringBuf stmp = StripString(tmp);
-
-            if (stmp.empty()) {
-                continue;
-            }
-
-            if (stmp.StartsWith('[') && stmp.EndsWith(']')) {
-                stmp = TStringBuf(stmp.data() + 1, stmp.Size() - 2);
-                cur = &ret;
-
-                while (!!stmp) {
-                    TStringBuf sectionPart;
-                    stmp.Split('.', sectionPart, stmp);
-                    cur = &cur->GetNonConstant<TDict>()[sectionPart];
-                    if (!cur->IsA<TDict>()) {
-                        *cur = TConfig(ConstructValue(TDict()));
-                    }
+        TConfig ret = ConstructValue(TDict());
+    
+        {
+            TConfig* cur = &ret;
+            TString line;
+    
+            while (in.ReadLine(line)) {
+                TStringBuf tmp = StripComment(line);
+                TStringBuf stmp = StripString(tmp);
+    
+                if (stmp.empty()) {
+                    continue;
                 }
-            } else {
-                TStringBuf key, value;
-                tmp.Split('=', key, value);
-                auto& dict = cur->GetNonConstant<TDict>();
-                dict[StripString(key)] = TConfig(ConstructValue(TString(StripString(value))));
+    
+                if (stmp[0] == '[') {
+                    //start section
+                    if (*(stmp.end() - 1) != ']') {
+                        ythrow TConfigParseError() << "malformed section " << stmp;
+                    }
+    
+                    stmp = TStringBuf(stmp.data() + 1, stmp.end() - 1);
+                    cur = &ret;
+    
+                    while (!!stmp) {
+                        TStringBuf section;
+    
+                        stmp.Split('.', section, stmp);
+    
+                        cur = &cur->GetNonConstant<TDict>()[section];
+                        if (!cur->IsA<TDict>()) {
+                            *cur = ConstructValue(TDict());
+                        }
+                    }
+                } else {
+                    //value
+                    TStringBuf key, value;
+    
+                    tmp.Split('=', key, value);
+    
+                    auto& dict = cur->GetNonConstant<TDict>();
+                    auto strippedValue = TString(StripString(value));
+                    dict[StripString(key)] = ConstructValue(strippedValue);
+                }
             }
         }
-
+    
         return ret;
-    }
-
-    TConfig TConfig::ReadIni(TStringBuf content) {
-        TMemoryInput memIn(content.data(), content.size());
-        return ParseIni(memIn);
     }
 
 }

--- a/ydb/public/lib/ydb_cli/common/ini_config/ini.h
+++ b/ydb/public/lib/ydb_cli/common/ini_config/ini.h
@@ -1,0 +1,7 @@
+#pragma once
+
+#include "config.h"
+
+namespace NIniConfig {
+    TConfig ParseIni(IInputStream& in);
+}

--- a/ydb/public/lib/ydb_cli/common/ini_config/ut/ya.make
+++ b/ydb/public/lib/ydb_cli/common/ini_config/ut/ya.make
@@ -1,0 +1,7 @@
+UNITTEST_FOR(ydb/public/lib/ydb_cli/common/ini_config)
+
+SRCS(
+    config_ut.cpp
+)
+
+END()

--- a/ydb/public/lib/ydb_cli/common/ini_config/value.cpp
+++ b/ydb/public/lib/ydb_cli/common/ini_config/value.cpp
@@ -1,0 +1,237 @@
+#include "value.h"
+#include "config.h"
+
+#include <util/generic/algorithm.h>
+#include <util/system/type_name.h>
+#include <util/generic/singleton.h>
+#include <util/string/cast.h>
+#include <util/string/strip.h>
+#include <util/string/type.h>
+
+using namespace NIniConfig;
+
+namespace {
+    template <class T>
+    class TValue: public IValue {
+    public:
+        inline TValue(const T& t)
+            : T_(t)
+        {
+        }
+
+        bool IsA(const std::type_info& info) const override {
+            return info == typeid(T);
+        }
+
+        TString TypeName() const override {
+            return ::TypeName<T>();
+        }
+
+        void* Ptr() const override {
+            return (void*)&T_;
+        }
+
+        bool AsBool() const override {
+            return (bool)AsDouble();
+        }
+
+    protected:
+        T T_;
+    };
+
+    class TNullValue: public TValue<TNull> {
+    public:
+        inline TNullValue()
+            : TValue<TNull>(TNull())
+        {
+            Ref();
+        }
+
+        double AsDouble() const override {
+            return 0;
+        }
+
+        ui64 AsUInt() const override {
+            return 0;
+        }
+
+        i64 AsInt() const override {
+            return 0;
+        }
+
+        TString AsString() const override {
+            return TString();
+        }
+
+        TString TypeName() const override {
+            return "null";
+        }
+    };
+
+    template <class T>
+    class TNumericValue: public TValue<T> {
+    public:
+        inline TNumericValue(const T& t)
+            : TValue<T>(t)
+        {
+        }
+
+        double AsDouble() const override {
+            return this->T_;
+        }
+
+        ui64 AsUInt() const override {
+            return this->T_;
+        }
+
+        i64 AsInt() const override {
+            return this->T_;
+        }
+    };
+
+    class TBoolValue: public TNumericValue<bool> {
+    public:
+        inline TBoolValue(bool v)
+            : TNumericValue<bool>(v)
+        {
+        }
+
+        TString AsString() const override {
+            return T_ ? "true" : "false";
+        }
+    };
+
+    template <class T>
+    class TArithmeticValue: public TNumericValue<T> {
+    public:
+        inline TArithmeticValue(T v)
+            : TNumericValue<T>(v)
+        {
+        }
+
+        TString AsString() const override {
+            return ToString(this->T_);
+        }
+    };
+
+    class TStringValue: public TValue<TString> {
+    public:
+        inline TStringValue(const TString& v)
+            : TValue<TString>(v)
+        {
+        }
+
+        template <class T>
+        inline T AsT() const {
+            const TStringBuf s = StripString(TStringBuf(T_));
+
+            if (IsTrue(s)) {
+                return true;
+            }
+
+            if (IsFalse(s)) {
+                return false;
+            }
+
+            return FromString<T>(s);
+        }
+
+        double AsDouble() const override {
+            return AsT<double>();
+        }
+
+        ui64 AsUInt() const override {
+            return AsT<ui64>();
+        }
+
+        i64 AsInt() const override {
+            return AsT<i64>();
+        }
+
+        TString AsString() const override {
+            return T_;
+        }
+
+        TString TypeName() const override {
+            return "string";
+        }
+    };
+
+    template <class T>
+    class TContainer: public TValue<T> {
+    public:
+        inline TContainer(const T& t)
+            : TValue<T>(t)
+        {
+        }
+
+        double AsDouble() const override {
+            NCfgPrivate::ReportTypeMismatch(this->TypeName(), "double");
+        }
+
+        ui64 AsUInt() const override {
+            NCfgPrivate::ReportTypeMismatch(this->TypeName(), "uint");
+        }
+
+        i64 AsInt() const override {
+            NCfgPrivate::ReportTypeMismatch(this->TypeName(), "int");
+        }
+
+        bool AsBool() const override {
+            NCfgPrivate::ReportTypeMismatch(this->TypeName(), "bool");
+        }
+
+        TString AsString() const override {
+            NCfgPrivate::ReportTypeMismatch(this->TypeName(), "string");
+        }
+    };
+
+    class TArrayValue: public TContainer<TArray> {
+    public:
+        inline TArrayValue(const TArray& v)
+            : TContainer<TArray>(v)
+        {
+        }
+
+        TString TypeName() const override {
+            return "array";
+        }
+    };
+
+    class TDictValue: public TContainer<TDict> {
+    public:
+        inline TDictValue(const TDict& v)
+            : TContainer<TDict>(v)
+        {
+        }
+
+        TString TypeName() const override {
+            return "dict";
+        }
+    };
+}
+
+#define DECLARE(type1, type2)                    \
+    IValue* ConstructValueImpl(const type2& t) { \
+        return new type1(t);                     \
+    }
+
+namespace NIniConfig {
+    namespace NCfgPrivate {
+        DECLARE(TBoolValue, bool)
+        DECLARE(TArithmeticValue<double>, double)
+        DECLARE(TArithmeticValue<i64>, i64)
+        DECLARE(TArithmeticValue<ui64>, ui64)
+        DECLARE(TStringValue, TString)
+        DECLARE(TArrayValue, TArray)
+        DECLARE(TDictValue, TDict)
+    }
+
+    IValue* Null() {
+        return Singleton<TNullValue>();
+    }
+
+    [[noreturn]] void NCfgPrivate::ReportTypeMismatch(TStringBuf realType, TStringBuf expectedType) {
+        ythrow TTypeMismatch() << "type mismatch (real: " << realType << ", expected: " << expectedType << ')';
+    }
+}

--- a/ydb/public/lib/ydb_cli/common/ini_config/value.h
+++ b/ydb/public/lib/ydb_cli/common/ini_config/value.h
@@ -32,12 +32,14 @@ namespace NIniConfig {
         template <class T>
         inline IValue* ConstructValueImpl(const T& t, ...) {
             extern IValue* ConstructValueImpl(const T& t);
+
             return ConstructValueImpl(t);
         }
 
         template <class T, std::enable_if_t<std::is_floating_point<T>::value>* = nullptr>
         inline IValue* ConstructValueImpl(const T& t, TDummy) {
             extern IValue* ConstructValueImpl(const double& t);
+
             return ConstructValueImpl(t);
         }
 
@@ -45,17 +47,20 @@ namespace NIniConfig {
         inline IValue* ConstructValueImpl(const T& t, TDummy) {
             typedef std::conditional_t<std::is_signed<T>::value, i64, ui64> Type;
             extern IValue* ConstructValueImpl(const Type& t);
+
             return ConstructValueImpl(t);
         }
 
         template <class T, std::enable_if_t<std::is_convertible<T, TString>::value>* = nullptr>
         inline IValue* ConstructValueImpl(const T& t, TDummy) {
             extern IValue* ConstructValueImpl(const TString& t);
+
             return ConstructValueImpl(t);
         }
 
         inline IValue* ConstructValueImpl(const bool& t, TDummy) {
             extern IValue* ConstructValueImpl(const bool& t);
+
             return ConstructValueImpl(t);
         }
     }
@@ -88,6 +93,7 @@ namespace NIniConfig {
     template <class T>
     inline T ValueAs(const IValue* val) {
         typedef NCfgPrivate::TSelector<std::is_unsigned<T>::value> TCvt;
+
         return SafeIntegerCast<T>(TCvt::Cvt(val));
     }
 

--- a/ydb/public/lib/ydb_cli/common/ini_config/value.h
+++ b/ydb/public/lib/ydb_cli/common/ini_config/value.h
@@ -1,0 +1,113 @@
+#pragma once
+
+#include <typeinfo>
+
+#include <util/generic/ptr.h>
+#include <util/generic/cast.h>
+#include <util/generic/string.h>
+#include <util/generic/typetraits.h>
+
+class IOutputStream;
+
+namespace NIniConfig {
+    class IValue: public TAtomicRefCount<IValue> {
+    public:
+        virtual ~IValue() = default;
+
+        virtual bool IsA(const std::type_info& info) const = 0;
+        virtual TString TypeName() const = 0;
+        virtual void* Ptr() const = 0;
+
+        virtual ui64 AsUInt() const = 0;
+        virtual i64 AsInt() const = 0;
+        virtual double AsDouble() const = 0;
+        virtual bool AsBool() const = 0;
+        virtual TString AsString() const = 0;
+    };
+
+    namespace NCfgPrivate {
+        struct TDummy {
+        };
+
+        template <class T>
+        inline IValue* ConstructValueImpl(const T& t, ...) {
+            extern IValue* ConstructValueImpl(const T& t);
+            return ConstructValueImpl(t);
+        }
+
+        template <class T, std::enable_if_t<std::is_floating_point<T>::value>* = nullptr>
+        inline IValue* ConstructValueImpl(const T& t, TDummy) {
+            extern IValue* ConstructValueImpl(const double& t);
+            return ConstructValueImpl(t);
+        }
+
+        template <class T, std::enable_if_t<std::is_integral<T>::value>* = nullptr>
+        inline IValue* ConstructValueImpl(const T& t, TDummy) {
+            typedef std::conditional_t<std::is_signed<T>::value, i64, ui64> Type;
+            extern IValue* ConstructValueImpl(const Type& t);
+            return ConstructValueImpl(t);
+        }
+
+        template <class T, std::enable_if_t<std::is_convertible<T, TString>::value>* = nullptr>
+        inline IValue* ConstructValueImpl(const T& t, TDummy) {
+            extern IValue* ConstructValueImpl(const TString& t);
+            return ConstructValueImpl(t);
+        }
+
+        inline IValue* ConstructValueImpl(const bool& t, TDummy) {
+            extern IValue* ConstructValueImpl(const bool& t);
+            return ConstructValueImpl(t);
+        }
+    }
+
+    template <class T>
+    inline IValue* ConstructValue(const T& t) {
+        return NCfgPrivate::ConstructValueImpl(t, NCfgPrivate::TDummy());
+    }
+
+    IValue* Null();
+
+    namespace NCfgPrivate {
+        template <bool Unsigned>
+        struct TSelector {
+            static inline ui64 Cvt(const IValue* v) {
+                return v->AsUInt();
+            }
+        };
+
+        template <>
+        struct TSelector<false> {
+            static inline i64 Cvt(const IValue* v) {
+                return v->AsInt();
+            }
+        };
+
+        [[noreturn]] void ReportTypeMismatch(TStringBuf realType, TStringBuf expectedType);
+    }
+
+    template <class T>
+    inline T ValueAs(const IValue* val) {
+        typedef NCfgPrivate::TSelector<std::is_unsigned<T>::value> TCvt;
+        return SafeIntegerCast<T>(TCvt::Cvt(val));
+    }
+
+    template <>
+    inline double ValueAs(const IValue* val) {
+        return val->AsDouble();
+    }
+
+    template <>
+    inline float ValueAs(const IValue* val) {
+        return (float)val->AsDouble();
+    }
+
+    template <>
+    inline bool ValueAs(const IValue* val) {
+        return val->AsBool();
+    }
+
+    template <>
+    inline TString ValueAs(const IValue* val) {
+        return val->AsString();
+    }
+}

--- a/ydb/public/lib/ydb_cli/common/ini_config/ya.make
+++ b/ydb/public/lib/ydb_cli/common/ini_config/ya.make
@@ -1,0 +1,13 @@
+LIBRARY(ini_config)
+
+SRCS(
+    config.cpp
+    ini.cpp
+    value.cpp
+)
+
+END()
+
+RECURSE_FOR_TESTS(
+    ut
+)

--- a/ydb/public/lib/ydb_cli/common/ya.make
+++ b/ydb/public/lib/ydb_cli/common/ya.make
@@ -39,7 +39,6 @@ SRCS(
 PEERDIR(
     contrib/libs/aws-sdk-cpp/aws-cpp-sdk-s3
     contrib/libs/openssl
-    library/cpp/config
     library/cpp/getopt
     library/cpp/json/writer
     library/cpp/yaml/as
@@ -58,6 +57,7 @@ PEERDIR(
     ydb/public/sdk/cpp/src/client/types/credentials
     ydb/public/sdk/cpp/src/client/types/credentials/oauth2_token_exchange
     ydb/library/arrow_parquet
+    ydb/public/lib/ydb_cli/common/ini_config
     ydb/public/lib/ydb_cli/common/yql_parser
 )
 
@@ -67,6 +67,7 @@ GENERATE_ENUM_SERIALIZATION(parameters.h)
 END()
 
 RECURSE(
+    ini_config
     yql_parser
 )
 


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

### Changelog category <!-- remove all except one -->

* Not for changelog (changelog entry is not required)

### Description for reviewers <!-- (optional) description for those who read this PR -->
Add a new library that is a copy of library/cpp/config, but only with INI format.
To avoid dependency on Lua:
```
Library (Include): $B/contrib/ydb/public/lib/ydb_cli/dump/util/libydb_cli-dump-util.a ->
Library (Include): $B/contrib/ydb/public/lib/ydb_cli/common/libcommon.a ->
Library (Include): $B/library/cpp/config/liblibrary-cpp-config.a ->
Library (Include): $B/library/cpp/lua/liblibrary-cpp-lua.a ->
Directory (Include): $S/contrib/libs/lua
```
