### PR TITLE
[stable-24-4] Enable tag trigger for nightly builds

### DIFF
--- a/.github/actions/test_ya/action.yml
+++ b/.github/actions/test_ya/action.yml
@@ -141,7 +141,7 @@ runs:
         RUN_ID=$(
         testmo automation:run:create --instance "$TESTMO_URL" --project-id ${{ inputs.testman_project_id }} \
           --name "$TESTMO_RUN_NAME" --source "$TESTMO_SOURCE" --resources testmo.json \
-          --tags "$BRANCH_TAG" --tags "$EXTRA_TAG"
+          --tags "${BRANCH_NAME//[^a-zA-Z0-9-]/-}" --tags "$EXTRA_TAG"
         )
         echo "runid=${RUN_ID}" >> $GITHUB_OUTPUT
         echo "TEST_HISTORY_URL=${TESTMO_URL}/automation/runs/view/${RUN_ID}" >> $GITHUB_ENV

--- a/.github/workflows/nightly_build.yml
+++ b/.github/workflows/nightly_build.yml
@@ -9,6 +9,9 @@ on:
       commit_sha:
         type: string
         default: ""
+  push:
+    tags:
+      - '[0-9]**'
 jobs:
   build_and_test:
     strategy:
@@ -35,6 +38,7 @@ jobs:
         increment: false
         run_tests: false
         put_build_results_to_cache: false
+        additional_ya_make_args: "-DDEBUGINFO_LINES_ONLY" # we don't need full symbols in CI checks
         secs: ${{ format('{{"TESTMO_TOKEN2":"{0}","AWS_KEY_ID":"{1}","AWS_KEY_VALUE":"{2}","REMOTE_CACHE_USERNAME":"{3}","REMOTE_CACHE_PASSWORD":"{4}"}}',
           secrets.TESTMO_TOKEN2, secrets.AWS_KEY_ID, secrets.AWS_KEY_VALUE, secrets.REMOTE_CACHE_USERNAME, secrets.REMOTE_CACHE_PASSWORD ) }}
         vars: ${{ format('{{"AWS_BUCKET":"{0}","AWS_ENDPOINT":"{1}","REMOTE_CACHE_URL":"{2}","TESTMO_URL":"{3}","TESTMO_PROJECT_ID":"{4}"}}',


### PR DESCRIPTION
### Changelog category
* Not for changelog (changelog entry is not required)

### Description for reviewers
cherry-pick: Enable tag event and nightly builds (https://github.com/ydb-platform/ydb/pull/19452)
Refs: https://github.com/ydb-platform/ydb/issues/19413
