### PR TITLE
[stable-25-1-1] Enable tag trigger for nightly builds

### DIFF
--- a/.github/actions/test_ya/action.yml
+++ b/.github/actions/test_ya/action.yml
@@ -287,7 +287,7 @@ runs:
         echo "BRANCH_NAME=$BRANCH_NAME" >> $GITHUB_ENV
         echo "BRANCH_NAME is set to $BRANCH_NAME"
 
-        TESTMO_BRANCH_TAG="$BRANCH_NAME"
+        TESTMO_BRANCH_TAG="${BRANCH_NAME//[^a-zA-Z0-9-]/-}"
         TESTMO_ARCH="${{ runner.arch == 'X64' && 'x86-64' || runner.arch == 'ARM64' && 'arm64' || 'unknown' }}"
         TESTMO_PR_NUMBER=${{ github.event.number }}
 

--- a/.github/workflows/nightly_build.yml
+++ b/.github/workflows/nightly_build.yml
@@ -9,6 +9,9 @@ on:
       commit_sha:
         type: string
         default: ""
+  push:
+    tags:
+      - '[0-9]**'
 jobs:
   build_and_test:
     strategy:


### PR DESCRIPTION
### Changelog category
* Not for changelog (changelog entry is not required)

### Description for reviewers
cherry-pick: Enable tag event and nightly builds (#19452)

Refs: #19413