### PR TITLE
[stable-25-1] Enable tag trigger for nightly builds

### DIFF
--- a/.github/actions/test_ya/action.yml
+++ b/.github/actions/test_ya/action.yml
@@ -287,7 +287,7 @@ runs:
         echo "BRANCH_NAME=$BRANCH_NAME" >> $GITHUB_ENV
         echo "BRANCH_NAME is set to $BRANCH_NAME"
 
-        TESTMO_BRANCH_TAG="$BRANCH_NAME"
+        TESTMO_BRANCH_TAG="${BRANCH_NAME//[^a-zA-Z0-9-]/-}"
         TESTMO_ARCH="${{ runner.arch == 'X64' && 'x86-64' || runner.arch == 'ARM64' && 'arm64' || 'unknown' }}"
         TESTMO_PR_NUMBER=${{ github.event.number }}
 

--- a/.github/workflows/nightly_build.yml
+++ b/.github/workflows/nightly_build.yml
@@ -9,7 +9,9 @@ on:
         type: boolean
         required: false
         default: true
-
+  push:
+    tags:
+      - '[0-9]**'
 jobs:
   determine_branches:
     runs-on: ubuntu-latest
@@ -18,7 +20,7 @@ jobs:
     steps:
       - id: set-branches
         run: |
-          if [[ "${{ github.event_name }}" == "schedule" || "${{ inputs.use_default_branches }}" == "true" ]]; then
+          if [[ "${{ github.event_name }}" == "schedule" || ("${{ inputs.use_default_branches }}" == "true"  && "${{ github.ref_type }}" != "tag") ]]; then
             echo "branches=['main', 'stable-25-1', 'stable-24-4', 'stable-25-1-1', 'stable-25-1-analytics']" >> $GITHUB_OUTPUT
           else
             echo "branches=['${{ github.ref_name }}']" >> $GITHUB_OUTPUT


### PR DESCRIPTION
### Changelog category 
* Not for changelog (changelog entry is not required)

### Description for reviewers
cherry-pick: Enable tag event and nightly builds (#19452)
Refs: #19413
