### PR TITLE
Analytics: Fix chunks determinition for test 

### DIFF
--- a/.github/scripts/analytics/data_mart_queries/test_history_fast_mart.sql
+++ b/.github/scripts/analytics/data_mart_queries/test_history_fast_mart.sql
@@ -19,7 +19,7 @@ SELECT
     run_timestamp >= CurrentUtcDate() - Interval("P1D")
     and String::Contains(test_name, '.flake8')  = FALSE
     and (CASE 
-        WHEN String::Contains(test_name, 'chunk chunk') OR String::Contains(test_name, 'chunk+chunk') THEN TRUE
+        WHEN String::Contains(all_data.test_name, 'sole chunk') OR String::Contains(all_data.test_name, 'chunk+chunk')  OR String::Contains(all_data.test_name, '] chunk') THEN TRUE
         ELSE FALSE
         END) = FALSE
     and (branch = 'main' or branch like 'stable-%')

--- a/.github/scripts/analytics/data_mart_queries/test_history_fast_mart.sql
+++ b/.github/scripts/analytics/data_mart_queries/test_history_fast_mart.sql
@@ -19,7 +19,7 @@ SELECT
     run_timestamp >= CurrentUtcDate() - Interval("P1D")
     and String::Contains(test_name, '.flake8')  = FALSE
     and (CASE 
-        WHEN String::Contains(all_data.test_name, 'sole chunk') OR String::Contains(all_data.test_name, 'chunk+chunk')  OR String::Contains(all_data.test_name, '] chunk') THEN TRUE
+        WHEN String::Contains(test_name, 'sole chunk') OR String::Contains(test_name, 'chunk+chunk')  OR String::Contains(test_name, '] chunk') THEN TRUE
         ELSE FALSE
         END) = FALSE
     and (branch = 'main' or branch like 'stable-%')

--- a/.github/scripts/analytics/data_mart_queries/test_history_mart.sql
+++ b/.github/scripts/analytics/data_mart_queries/test_history_mart.sql
@@ -19,7 +19,7 @@ SELECT
     cast(COALESCE(String::SplitToList(pull,'_A')[1],"1") as Uint16) as attempt,
     (cast(pull as String) || '_' || SUBSTRING(cast(commit as String), 1, 8)) as pull_commit,
     CASE 
-        WHEN String::Contains(test_name, 'chunk chunk') OR String::Contains(test_name, 'chunk+chunk') THEN TRUE
+        WHEN String::Contains(all_data.test_name, 'sole chunk') OR String::Contains(all_data.test_name, 'chunk+chunk')  OR String::Contains(all_data.test_name, '] chunk') THEN TRUE
         ELSE FALSE
     END as with_cunks
    
@@ -29,6 +29,6 @@ WHERE
     run_timestamp >= CurrentUtcDate() - 1*Interval("P1D")
     and String::Contains(test_name, '.flake8')  = FALSE
     and (CASE 
-        WHEN String::Contains(test_name, 'chunk chunk') OR String::Contains(test_name, 'chunk+chunk') THEN TRUE
+        WHEN String::Contains(all_data.test_name, 'sole chunk') OR String::Contains(all_data.test_name, 'chunk+chunk')  OR String::Contains(all_data.test_name, '] chunk') THEN TRUE
         ELSE FALSE
         END) = FALSE

--- a/.github/scripts/analytics/data_mart_queries/test_history_mart.sql
+++ b/.github/scripts/analytics/data_mart_queries/test_history_mart.sql
@@ -19,7 +19,7 @@ SELECT
     cast(COALESCE(String::SplitToList(pull,'_A')[1],"1") as Uint16) as attempt,
     (cast(pull as String) || '_' || SUBSTRING(cast(commit as String), 1, 8)) as pull_commit,
     CASE 
-        WHEN String::Contains(all_data.test_name, 'sole chunk') OR String::Contains(all_data.test_name, 'chunk+chunk')  OR String::Contains(all_data.test_name, '] chunk') THEN TRUE
+        WHEN String::Contains(test_name, 'sole chunk') OR String::Contains(test_name, 'chunk+chunk')  OR String::Contains(test_name, '] chunk') THEN TRUE
         ELSE FALSE
     END as with_cunks
    
@@ -29,6 +29,6 @@ WHERE
     run_timestamp >= CurrentUtcDate() - 1*Interval("P1D")
     and String::Contains(test_name, '.flake8')  = FALSE
     and (CASE 
-        WHEN String::Contains(all_data.test_name, 'sole chunk') OR String::Contains(all_data.test_name, 'chunk+chunk')  OR String::Contains(all_data.test_name, '] chunk') THEN TRUE
+        WHEN String::Contains(test_name, 'sole chunk') OR String::Contains(test_name, 'chunk+chunk')  OR String::Contains(test_name, '] chunk') THEN TRUE
         ELSE FALSE
         END) = FALSE

--- a/.github/scripts/analytics/test_history_fast.py
+++ b/.github/scripts/analytics/test_history_fast.py
@@ -121,7 +121,7 @@ def get_missed_data_for_upload(driver, full_table_path):
         all_data.run_timestamp >= CurrentUtcDate() - 6*Interval("P1D")
         and String::Contains(all_data.test_name, '.flake8')  = FALSE
         and (CASE 
-            WHEN String::Contains(all_data.test_name, 'chunk chunk') OR String::Contains(all_data.test_name, 'chunk+chunk') THEN TRUE
+            WHEN String::Contains(all_data.test_name, 'sole chunk') OR String::Contains(all_data.test_name, 'chunk+chunk')  OR String::Contains(all_data.test_name, '] chunk') THEN TRUE
             ELSE FALSE
             END) = FALSE
         and (all_data.branch = 'main' or all_data.branch like 'stable-%')

--- a/.github/scripts/analytics/tests_monitor.py
+++ b/.github/scripts/analytics/tests_monitor.py
@@ -586,7 +586,7 @@ def main():
         df['success_rate'] = df.apply(calculate_success_rate, axis=1).astype(int)
         df['summary'] = df.apply(calculate_summary, axis=1)
         df['owner'] = df['owners'].apply(compute_owner)
-        df['is_test_chunk'] = df['full_name'].str.contains('chunk chunk|chunk\+chunk', regex=True).astype(int)
+        df['is_test_chunk'] = df['full_name'].str.contains('] chunk|sole chunk|chunk chunk|chunk\+chunk', regex=True).astype(int)
         df['is_muted'] = df['is_muted'].fillna(0).astype(int)
         df['success_rate'].astype(int)
         df['state'] = df.apply(determine_state, axis=1)

--- a/.github/scripts/analytics/tests_monitor.py
+++ b/.github/scripts/analytics/tests_monitor.py
@@ -586,7 +586,7 @@ def main():
         df['success_rate'] = df.apply(calculate_success_rate, axis=1).astype(int)
         df['summary'] = df.apply(calculate_summary, axis=1)
         df['owner'] = df['owners'].apply(compute_owner)
-        df['is_test_chunk'] = df['full_name'].str.contains('] chunk|sole chunk|chunk chunk|chunk\+chunk', regex=True).astype(int)
+        df['is_test_chunk'] = df['full_name'].str.contains(']? chunk|sole chunk|chunk chunk|chunk\+chunk', regex=True).astype(int)
         df['is_muted'] = df['is_muted'].fillna(0).astype(int)
         df['success_rate'].astype(int)
         df['state'] = df.apply(determine_state, axis=1)


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

**Что изменилось:**

- В фильтрах для chunk-тестов добавили новые паттерны: теперь ищутся еще и `sole chunk` и `] chunk` (раньше были только `chunk chunk` и `chunk+chunk`).
- Обновили SQL-запросы и скрипты аналитики, чтобы эти тесты корректно фильтровались и не попадали в отчёты.

**Зачем:**  
Чтобы chunk-тесты с новыми именами тоже учитывались при анализе данных.

Затронуты: SQL-запросы и аналитические скрипты.

### Changelog category <!-- remove all except one -->


* Not for changelog (changelog entry is not required)

### Description for reviewers <!-- (optional) description for those who read this PR -->

...
