### PR TITLE
persqueue: SetGRpcKeepAliveTimeout(TDuration::Seconds(30)) for mirrorer

### DIFF
--- a/ydb/core/persqueue/actor_persqueue_client_iface.h
+++ b/ydb/core/persqueue/actor_persqueue_client_iface.h
@@ -30,7 +30,8 @@ public:
 
         auto driverConfig = NYdb::TDriverConfig()
             .SetMaxMessageSize(MaxMessageSize)
-            .SetNetworkThreadsNum(settings.GetThreadsCount());
+            .SetNetworkThreadsNum(settings.GetThreadsCount())
+	    .SetGRpcKeepAliveTimeout(TDuration::Seconds(30));
         Driver = std::make_shared<NYdb::TDriver>(driverConfig);
     }
 

--- a/ydb/core/persqueue/actor_persqueue_client_iface.h
+++ b/ydb/core/persqueue/actor_persqueue_client_iface.h
@@ -31,7 +31,7 @@ public:
         auto driverConfig = NYdb::TDriverConfig()
             .SetMaxMessageSize(MaxMessageSize)
             .SetNetworkThreadsNum(settings.GetThreadsCount())
-	    .SetGRpcKeepAliveTimeout(TDuration::Seconds(30));
+	    .SetGRpcKeepAliveTimeout(TDuration::Seconds(10));
         Driver = std::make_shared<NYdb::TDriver>(driverConfig);
     }
 


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

...

### Changelog category <!-- remove all except one -->

* Not for changelog (changelog entry is not required)

### Description for reviewers <!-- (optional) description for those who read this PR -->

PQ mirrorer works better with grpc keep alive.