### PR TITLE
workaround for dumping bad requests with very long url

### DIFF
--- a/ydb/library/actors/http/http.h
+++ b/ydb/library/actors/http/http.h
@@ -370,6 +370,9 @@ public:
     void ConnectionClosed();
 
     size_t GetHeadersSize() const { // including request line
+        if (HeaderType::Headers.empty()) {
+            return TSocketBuffer::Size();
+        }
         return HeaderType::Headers.end() - TSocketBuffer::Data();
     }
 
@@ -623,6 +626,9 @@ public:
     }
 
     size_t GetHeadersSize() const { // including request line
+        if (HeaderType::Headers.empty()) {
+            return TSocketBuffer::Size();
+        }
         return HeaderType::Headers.end() - TSocketBuffer::Data();
     }
 


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

fixes crash when request was made with URL longer than 2048 bytes and DEBUG level for logging HTTP is active
closes #20859

### Changelog category <!-- remove all except one -->

* Bugfix 

### Description for reviewers <!-- (optional) description for those who read this PR -->

...
