### PR TITLE
stable-25-1:  Remove obsolete version of the zstd06 codec

### DIFF
--- a/library/cpp/blockcodecs/codecs/legacy_zstd06/ya.make
+++ b/library/cpp/blockcodecs/codecs/legacy_zstd06/ya.make
@@ -9,4 +9,8 @@ SRCS(
     GLOBAL legacy_zstd06.cpp
 )
 
+IF (DONT_LINK_LEGACY_ZSTD06_BLOCKCODEC)
+    MESSAGE(FATAL_ERROR "Library disabled with the -D DONT_LINK_LEGACY_ZSTD06_BLOCKCODEC flag")
+ENDIF()
+
 END()

--- a/library/cpp/blockcodecs/ya.make
+++ b/library/cpp/blockcodecs/ya.make
@@ -5,13 +5,18 @@ PEERDIR(
     library/cpp/blockcodecs/codecs/brotli
     library/cpp/blockcodecs/codecs/bzip
     library/cpp/blockcodecs/codecs/fastlz
-    library/cpp/blockcodecs/codecs/legacy_zstd06
     library/cpp/blockcodecs/codecs/lz4
     library/cpp/blockcodecs/codecs/lzma
     library/cpp/blockcodecs/codecs/snappy
     library/cpp/blockcodecs/codecs/zlib
     library/cpp/blockcodecs/codecs/zstd
 )
+
+IF (NOT DONT_LINK_LEGACY_ZSTD06_BLOCKCODEC)
+PEERDIR(
+    library/cpp/blockcodecs/codecs/legacy_zstd06
+)
+ENDIF()
 
 SRCS(
     codecs.cpp


### PR DESCRIPTION
 ### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

Remove obsolete library 

### Changelog category <!-- remove all except one -->

* Not for changelog (changelog entry is not required)

### Description for reviewers <!-- (optional) description for those who read this PR -->
KIKIMR-23622