### PR TITLE
25-1: Relax unnecessary checks for TKqpLocks proto fields

### DIFF
--- a/ydb/core/tx/datashard/datashard_kqp.cpp
+++ b/ydb/core/tx/datashard/datashard_kqp.cpp
@@ -571,38 +571,33 @@ void KqpFillOutReadSets(TOutputOpData::TOutReadSets& outReadSets, const NKikimrD
     NKikimrTx::TReadSetData::EDecision decision = NKikimrTx::TReadSetData::DECISION_COMMIT;
     TMap<std::pair<ui64, ui64>, NKikimrTx::TReadSetData> genericData;
 
-    if (kqpLocks.HasOp() && NeedValidateLocks(kqpLocks.GetOp())) {
-        bool sendLocks = SendLocks(kqpLocks, tabletId);
-        YQL_ENSURE(sendLocks == !kqpLocks.GetLocks().empty());
+    if (SendLocks(kqpLocks, tabletId) && !kqpLocks.GetReceivingShards().empty()) {
+        auto brokenLocks = ValidateLocks(kqpLocks, sysLocks, tabletId);
 
-        if (sendLocks && !kqpLocks.GetReceivingShards().empty()) {
-            auto brokenLocks = ValidateLocks(kqpLocks, sysLocks, tabletId);
+        NKikimrTxDataShard::TKqpValidateLocksResult validateLocksResult;
+        validateLocksResult.SetSuccess(brokenLocks.empty());
 
-            NKikimrTxDataShard::TKqpValidateLocksResult validateLocksResult;
-            validateLocksResult.SetSuccess(brokenLocks.empty());
+        for (auto& lock : brokenLocks) {
+            LOG_TRACE_S(*TlsActivationContext, NKikimrServices::TX_DATASHARD, "Found broken lock: " << lock.ShortDebugString());
+            if (useGenericReadSets) {
+                decision = NKikimrTx::TReadSetData::DECISION_ABORT;
+            } else {
+                validateLocksResult.AddBrokenLocks()->Swap(&lock);
+            }
+        }
 
-            for (auto& lock : brokenLocks) {
-                LOG_TRACE_S(*TlsActivationContext, NKikimrServices::TX_DATASHARD, "Found broken lock: " << lock.ShortDebugString());
-                if (useGenericReadSets) {
-                    decision = NKikimrTx::TReadSetData::DECISION_ABORT;
-                } else {
-                    validateLocksResult.AddBrokenLocks()->Swap(&lock);
-                }
+        for (auto& dstTabletId : kqpLocks.GetReceivingShards()) {
+            if (tabletId == dstTabletId) {
+                continue;
             }
 
-            for (auto& dstTabletId : kqpLocks.GetReceivingShards()) {
-                if (tabletId == dstTabletId) {
-                    continue;
-                }
+            LOG_TRACE_S(*TlsActivationContext, NKikimrServices::TX_DATASHARD, "Send locks from " << tabletId << " to " << dstTabletId << ", locks: " << validateLocksResult.ShortDebugString());
 
-                LOG_TRACE_S(*TlsActivationContext, NKikimrServices::TX_DATASHARD, "Send locks from " << tabletId << " to " << dstTabletId << ", locks: " << validateLocksResult.ShortDebugString());
-
-                auto key = std::make_pair(tabletId, dstTabletId);
-                if (useGenericReadSets) {
-                    genericData[key].SetDecision(decision);
-                } else {
-                    readsetData[key].MutableValidateLocksResult()->CopyFrom(validateLocksResult);
-                }
+            auto key = std::make_pair(tabletId, dstTabletId);
+            if (useGenericReadSets) {
+                genericData[key].SetDecision(decision);
+            } else {
+                readsetData[key].MutableValidateLocksResult()->CopyFrom(validateLocksResult);
             }
         }
     }
@@ -639,15 +634,10 @@ std::tuple<bool, TVector<NKikimrDataEvents::TLock>> KqpValidateLocks(ui64 origin
         return {true, {}};
     }
 
-    bool sendLocks = SendLocks(*kqpLocks, origin);
-    YQL_ENSURE(sendLocks == !kqpLocks->GetLocks().empty());
+    auto brokenLocks = ValidateLocks(*kqpLocks, sysLocks, origin);
 
-    if (sendLocks) {
-        auto brokenLocks = ValidateLocks(*kqpLocks, sysLocks, origin);
-
-        if (!brokenLocks.empty()) {
-            return {false, std::move(brokenLocks)};
-        }
+    if (!brokenLocks.empty()) {
+        return {false, std::move(brokenLocks)};
     }
 
     for (const auto& readSet : inReadSets) {

--- a/ydb/core/tx/datashard/datashard_ut_write.cpp
+++ b/ydb/core/tx/datashard/datashard_ut_write.cpp
@@ -1919,5 +1919,118 @@ Y_UNIT_TEST_SUITE(DataShardWrite) {
         );
     }
 
+    Y_UNIT_TEST_TWIN(DistributedInsertReadSetWithoutLocks, Volatile) {
+        TPortManager pm;
+        NKikimrConfig::TAppConfig app;
+        app.MutableTableServiceConfig()->SetEnableOltpSink(true);
+        TServerSettings serverSettings(pm.GetPort(2134));
+        serverSettings.SetDomainName("Root")
+            .SetUseRealThreads(false)
+            .SetAppConfig(app);
+
+        auto [runtime, server, sender] = TestCreateServer(serverSettings);
+
+        TDisableDataShardLogBatching disableDataShardLogBatching;
+
+        UNIT_ASSERT_VALUES_EQUAL(
+            KqpSchemeExec(runtime, R"(
+                CREATE TABLE `/Root/table` (key int, value int, PRIMARY KEY (key))
+                WITH (PARTITION_AT_KEYS = (10));
+            )"),
+            "SUCCESS"
+        );
+
+        ExecSQL(server, sender, R"(
+            UPSERT INTO `/Root/table` (key, value) VALUES
+                (1, 1001),
+                (11, 1002);
+        )");
+
+        const auto tableId = ResolveTableId(server, sender, "/Root/table");
+        const auto shards = GetTableShards(server, sender, "/Root/table");
+        UNIT_ASSERT_VALUES_EQUAL(shards.size(), 2u);
+
+        auto shard1 = shards.at(0);
+        auto shard2 = shards.at(1);
+
+        TVector<TShardedTableOptions::TColumn> columns{
+            {"key", "Int32", true, false},
+            {"value", "Int32", false, false},
+        };
+
+        const ui64 coordinator = ChangeStateStorage(Coordinator, server->GetSettings().Domain);
+
+        // Prepare an insert (readsets flow between shards)
+        ui64 txId1 = 1234567890011;
+        auto tx1sender = runtime.AllocateEdgeActor();
+        {
+            auto req1 = MakeWriteRequestOneKeyValue(
+                txId1,
+                Volatile ? NKikimrDataEvents::TEvWrite::MODE_VOLATILE_PREPARE : NKikimrDataEvents::TEvWrite::MODE_PREPARE,
+                NKikimrDataEvents::TEvWrite::TOperation::OPERATION_INSERT,
+                tableId,
+                columns,
+                2, 1003);
+            req1->Record.MutableLocks()->SetOp(NKikimrDataEvents::TKqpLocks::Commit);
+            req1->Record.MutableLocks()->AddSendingShards(shard1);
+            req1->Record.MutableLocks()->AddSendingShards(shard2);
+            req1->Record.MutableLocks()->AddReceivingShards(shard1);
+            req1->Record.MutableLocks()->AddReceivingShards(shard2);
+
+            auto req2 = MakeWriteRequestOneKeyValue(
+                txId1,
+                Volatile ? NKikimrDataEvents::TEvWrite::MODE_VOLATILE_PREPARE : NKikimrDataEvents::TEvWrite::MODE_PREPARE,
+                NKikimrDataEvents::TEvWrite::TOperation::OPERATION_INSERT,
+                tableId,
+                columns,
+                12, 1004);
+            req2->Record.MutableLocks()->SetOp(NKikimrDataEvents::TKqpLocks::Commit);
+            req2->Record.MutableLocks()->AddSendingShards(shard1);
+            req2->Record.MutableLocks()->AddSendingShards(shard2);
+            req2->Record.MutableLocks()->AddReceivingShards(shard1);
+            req2->Record.MutableLocks()->AddReceivingShards(shard2);
+
+            Cerr << "... preparing tx1 at " << shard1 << Endl;
+            auto res1 = Write(runtime, tx1sender, shard1, std::move(req1));
+            Cerr << "... preparing tx1 at " << shard2 << Endl;
+            auto res2 = Write(runtime, tx1sender, shard2, std::move(req2));
+
+            ui64 minStep = Max(res1.GetMinStep(), res2.GetMinStep());
+            ui64 maxStep = Min(res1.GetMaxStep(), res2.GetMaxStep());
+
+            Cerr << "... planning tx1 at " << coordinator << Endl;
+            SendProposeToCoordinator(
+                runtime, tx1sender, shards, {
+                    .TxId = txId1,
+                    .Coordinator = coordinator,
+                    .MinStep = minStep,
+                    .MaxStep = maxStep,
+                    .Volatile = Volatile,
+                });
+        }
+
+        // Check tx1 replies
+        {
+            auto ev1 = runtime.GrabEdgeEventRethrow<NEvents::TDataEvents::TEvWriteResult>(tx1sender);
+            auto ev2 = runtime.GrabEdgeEventRethrow<NEvents::TDataEvents::TEvWriteResult>(tx1sender);
+            UNIT_ASSERT_C(
+                ev1->Get()->Record.GetStatus() == NKikimrDataEvents::TEvWriteResult::STATUS_COMPLETED &&
+                ev2->Get()->Record.GetStatus() == NKikimrDataEvents::TEvWriteResult::STATUS_COMPLETED,
+                "Unexpected status: " << ev1->Get()->Record.GetStatus() << " and " << ev2->Get()->Record.GetStatus()
+            );
+        }
+
+        // Validate commit was fully applied
+        UNIT_ASSERT_VALUES_EQUAL(
+            KqpSimpleExec(runtime, R"(
+                SELECT key, value FROM `/Root/table` ORDER BY key;
+            )"),
+            "{ items { int32_value: 1 } items { int32_value: 1001 } }, "
+            "{ items { int32_value: 2 } items { int32_value: 1003 } }, "
+            "{ items { int32_value: 11 } items { int32_value: 1002 } }, "
+            "{ items { int32_value: 12 } items { int32_value: 1004 } }"
+        );
+    }
+
 } // Y_UNIT_TEST_SUITE(DataShardWrite)
 } // namespace NKikimr


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

...

### Changelog category <!-- remove all except one -->

* Not for changelog (changelog entry is not required)

### Description for reviewers <!-- (optional) description for those who read this PR -->

We historically used SendingShards/ReceivingShards in TKqpLocks for exchanging lock validation results. However, it has long been repurposed for generic commit/abort decision exchange. Now that we have operations (EvWrite with INSERT) which may fail due to constraint violation unrelated to locks, checking that SendingShards must have a lock is harmful. Relax these checks and decouple locks from sending/receiving shards. Now locks listed in the proto are always validated when present on commit (even when shard is not in the sending set for some reason), and readsets are always sent from shards in SendingShards.

This relaxation is safe to perform since current stable versions crash when encountering such data, and this patch doesn't change behavior otherwise. Intended for backporting into current stable versions.

Related to #19525.