### PR TITLE
25-1-2: Support volatile transactions without expectations

### DIFF
--- a/ydb/core/protos/tx_datashard.proto
+++ b/ydb/core/protos/tx_datashard.proto
@@ -2219,6 +2219,12 @@ message TTxVolatileDetails {
     // When true marks an arbiter for other participants
     // Arbiters hold outgoing readsets until the transaction is decided
     optional bool IsArbiter = 9;
+
+    // When true readset expectations are disabled
+    // This is used when converting non-volatile distributed transactions to
+    // optimistic volatile execution for compatibility with shards which don't
+    // support readset flags.
+    optional bool DisableExpectations = 10;
 }
 
 // Sent by datashard when some overload reason stopped being relevant

--- a/ydb/core/tx/datashard/volatile_tx.cpp
+++ b/ydb/core/tx/datashard/volatile_tx.cpp
@@ -295,9 +295,11 @@ namespace NKikimr::NDataShard {
         for (auto& pr : VolatileTxs) {
             switch (pr.second->State) {
                 case EVolatileTxState::Waiting:
-                    for (ui64 target : pr.second->Participants) {
-                        if (Self->AddExpectation(target, pr.second->Version.Step, pr.second->TxId)) {
-                            Self->SendReadSetExpectation(ctx, pr.second->Version.Step, pr.second->TxId, Self->TabletID(), target);
+                    if (!pr.second->DisableExpectations) {
+                        for (ui64 target : pr.second->Participants) {
+                            if (Self->AddExpectation(target, pr.second->Version.Step, pr.second->TxId)) {
+                                Self->SendReadSetExpectation(ctx, pr.second->Version.Step, pr.second->TxId, Self->TabletID(), target);
+                            }
                         }
                     }
                     break;
@@ -356,6 +358,7 @@ namespace NKikimr::NDataShard {
             info->CommitOrder = details.GetCommitOrder();
             info->CommitOrdered = details.GetCommitOrdered();
             info->IsArbiter = details.GetIsArbiter();
+            info->DisableExpectations = details.GetDisableExpectations();
 
             maxCommitOrder = Max(maxCommitOrder, info->CommitOrder);
 
@@ -594,6 +597,9 @@ namespace NKikimr::NDataShard {
         if (info->IsArbiter) {
             details.SetIsArbiter(true);
         }
+        if (info->DisableExpectations) {
+            details.SetDisableExpectations(true);
+        }
 
         db.Table<Schema::TxVolatileDetails>().Key(info->TxId).Update(
             NIceDb::TUpdate<Schema::TxVolatileDetails::State>(info->State),
@@ -663,7 +669,9 @@ namespace NKikimr::NDataShard {
         }
         for (ui64 shardId : info->Participants) {
             db.Table<Schema::TxVolatileParticipants>().Key(info->TxId, shardId).Delete();
-            Self->RemoveExpectation(shardId, info->TxId);
+            if (!info->DisableExpectations) {
+                Self->RemoveExpectation(shardId, info->TxId);
+            }
         }
         db.Table<Schema::TxVolatileDetails>().Key(info->TxId).Delete();
     }
@@ -899,7 +907,9 @@ namespace NKikimr::NDataShard {
         info->DelayedAcks.push_back(std::move(ack));
         info->DelayedConfirmations.insert(srcTabletId);
 
-        Self->RemoveExpectation(srcTabletId, txId);
+        if (!info->DisableExpectations) {
+            Self->RemoveExpectation(srcTabletId, txId);
+        }
 
         if (info->Participants.empty()) {
             // Move tx to committed.

--- a/ydb/core/tx/datashard/volatile_tx.h
+++ b/ydb/core/tx/datashard/volatile_tx.h
@@ -52,10 +52,11 @@ namespace NKikimr::NDataShard {
         ui64 CommitOrder;
         ui64 TxId;
         EVolatileTxState State = EVolatileTxState::Waiting;
-        bool AddCommitted = false;
-        bool CommitOrdered = false;
-        bool IsArbiter = false;
-        bool IsArbiterOnHold = false;
+        ui32 AddCommitted : 1 = false;
+        ui32 CommitOrdered : 1 = false;
+        ui32 IsArbiter : 1 = false;
+        ui32 IsArbiterOnHold : 1 = false;
+        ui32 DisableExpectations : 1 = false;
         TRowVersion Version;
         absl::flat_hash_set<ui64> CommitTxIds;
         absl::flat_hash_set<ui64> Dependencies;


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

...

### Changelog category <!-- remove all except one -->

* Not for changelog (changelog entry is not required)

### Description for reviewers <!-- (optional) description for those who read this PR -->

We want to convert persistent distributed transactions to optimistic volatile execution when possible, however persistent transactions don't have any concept of readset expectations (and don't need it), and non-datashard participants might break when receiving them.

This patch doesn't change existing behavior in any way, but will support persistent behavior change in the future. Intended for backporting into current stable versions.

Related to #19525.