### PR TITLE
patch contrib/grpc:  Fix bug in Tx0cp code path in posix endpoint.

### DIFF
--- a/contrib/libs/grpc/patches/pr37696_code_path_in_posix_endpoint.patch
+++ b/contrib/libs/grpc/patches/pr37696_code_path_in_posix_endpoint.patch
@@ -1,0 +1,13 @@
+diff --git a/src/core/lib/event_engine/posix_engine/posix_endpoint.cc b/src/core/lib/event_engine/posix_engine/posix_endpoint.cc
+index 7634bb1334b81..c5708db02c57a 100644
+--- a/src/core/lib/event_engine/posix_engine/posix_endpoint.cc
++++ b/src/core/lib/event_engine/posix_engine/posix_endpoint.cc
+@@ -236,7 +236,7 @@ msg_iovlen_type TcpZerocopySendRecord::PopulateIovs(size_t* unwind_slice_idx,
+        iov_size++) {
+     MutableSlice& slice = internal::SliceCast<MutableSlice>(
+         buf_.MutableSliceAt(out_offset_.slice_idx));
+-    iov[iov_size].iov_base = slice.begin();
++    iov[iov_size].iov_base = slice.begin() + out_offset_.byte_idx;
+     iov[iov_size].iov_len = slice.length() - out_offset_.byte_idx;
+     *sending_length += iov[iov_size].iov_len;
+     ++(out_offset_.slice_idx);

--- a/contrib/libs/grpc/src/core/lib/event_engine/posix_engine/posix_endpoint.cc
+++ b/contrib/libs/grpc/src/core/lib/event_engine/posix_engine/posix_endpoint.cc
@@ -238,7 +238,7 @@ msg_iovlen_type TcpZerocopySendRecord::PopulateIovs(size_t* unwind_slice_idx,
        iov_size++) {
     MutableSlice& slice = internal::SliceCast<MutableSlice>(
         buf_.MutableSliceAt(out_offset_.slice_idx));
-    iov[iov_size].iov_base = slice.begin();
+    iov[iov_size].iov_base = slice.begin() + out_offset_.byte_idx;
     iov[iov_size].iov_len = slice.length() - out_offset_.byte_idx;
     *sending_length += iov[iov_size].iov_len;
     ++(out_offset_.slice_idx);


### PR DESCRIPTION
Backporting commit from upstream https://github.com/grpc/grpc/pull/37696

KIKIMR-23576
commit_hash:70b894f6a164019d8febd081d12402de1a9fc07a

### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->
  
 Backporting commit from upstream https://github.com/grpc/grpc/pull/37696


### Changelog category <!-- remove all except one -->

* Not for changelog (changelog entry is not required)

### Description for reviewers <!-- (optional) description for those who read this PR -->
 
KIKIMR-23576
commit in the ydb-platform/ydb rightlib branch: https://github.com/ydb-platform/ydb/commit/73574c2ed2aa5b5e98e4a83202e9708a60746559
