### PR TITLE
Infer PDisk ExpectedSlotCount from drive size

### DIFF
--- a/ydb/core/blobstorage/nodewarden/node_warden_impl.h
+++ b/ydb/core/blobstorage/nodewarden/node_warden_impl.h
@@ -268,6 +268,7 @@ namespace NKikimr::NStorage {
         }
 
         TIntrusivePtr<TPDiskConfig> CreatePDiskConfig(const NKikimrBlobStorage::TNodeWardenServiceSet::TPDisk& pdisk);
+        static void InferPDiskSlotCount(TIntrusivePtr<TPDiskConfig> pdiskConfig, ui64 driveSize, ui64 unitSizeInBytes);
         void StartLocalPDisk(const NKikimrBlobStorage::TNodeWardenServiceSet::TPDisk& pdisk, bool temporary);
         void AskBSCToRestartPDisk(ui32 pdiskId, bool ignoreDegradedGroups, ui64 requestCookie);
         void OnPDiskRestartFinished(ui32 pdiskId, NKikimrProto::EReplyStatus status);

--- a/ydb/core/blobstorage/nodewarden/node_warden_pdisk.cpp
+++ b/ydb/core/blobstorage/nodewarden/node_warden_pdisk.cpp
@@ -16,6 +16,22 @@ namespace NKikimr::NStorage {
         {NPDisk::DEVICE_TYPE_NVME, 300000000},
     };
 
+    void TNodeWarden::InferPDiskSlotCount(TIntrusivePtr<TPDiskConfig> pdiskConfig, ui64 driveSize, ui64 unitSizeInBytes) {
+        Y_ABORT_UNLESS(driveSize);
+        Y_ABORT_UNLESS(unitSizeInBytes);
+
+        const double slotCount = lround(double(driveSize) / unitSizeInBytes);
+        ui32 slotSizeInUnits = 1u;
+
+        constexpr long MaxSlots = 16;
+        while (lround(slotCount/slotSizeInUnits) > MaxSlots) {
+            slotSizeInUnits *= 2;
+        }
+
+        pdiskConfig->ExpectedSlotCount = lround(slotCount/slotSizeInUnits);
+        pdiskConfig->SlotSizeInUnits = slotSizeInUnits;
+    }
+
     TIntrusivePtr<TPDiskConfig> TNodeWarden::CreatePDiskConfig(const NKikimrBlobStorage::TNodeWardenServiceSet::TPDisk& pdisk)  {
         const TString& path = pdisk.GetPath();
         const ui64 pdiskGuid = pdisk.GetPDiskGuid();
@@ -119,6 +135,24 @@ namespace NKikimr::NStorage {
         if (auto it = Cfg->SectorMaps.find(path); it != Cfg->SectorMaps.end()) {
             pdiskConfig->SectorMap = it->second;
             pdiskConfig->EnableSectorEncryption = !pdiskConfig->SectorMap;
+        }
+
+        if (ui64 unitSizeInBytes = pdisk.GetInferPDiskSlotCountFromUnitSize()) {
+            ui64 driveSize = 0;
+            TStringStream outDetails;
+            if (pdiskConfig->SectorMap) {
+                driveSize = pdiskConfig->SectorMap->DeviceSize;
+                outDetails << "drive size obtained from SectorMap";
+            } else if (std::optional<NPDisk::TDriveData> data = NPDisk::GetDriveData(path, &outDetails)) {
+                driveSize = data->Size;
+            }
+
+            if (!driveSize) {
+                STLOG(PRI_ERROR, BS_NODE, NW91, "Unable to determine drive size for inferring PDisk slot count",
+                    (Path, path), (Details, outDetails.Str()));
+            } else {
+                InferPDiskSlotCount(pdiskConfig, driveSize, unitSizeInBytes);
+            }
         }
 
         const NPDisk::TMainKey& pdiskKey = Cfg->PDiskKey;

--- a/ydb/core/blobstorage/pdisk/blobstorage_pdisk_config.h
+++ b/ydb/core/blobstorage/pdisk/blobstorage_pdisk_config.h
@@ -136,6 +136,7 @@ struct TPDiskConfig : public TThrRefBase {
     ui32 MaxQueuedCompletionActions;
     bool UseSpdkNvmeDriver;
 
+    // Next 2 are either user-defined or inferred from drive size
     ui64 ExpectedSlotCount = 0;
     ui32 SlotSizeInUnits = 0;
 

--- a/ydb/core/mind/bscontroller/cmds_host_config.cpp
+++ b/ydb/core/mind/bscontroller/cmds_host_config.cpp
@@ -23,6 +23,7 @@ namespace NKikimr::NBsController {
             driveInfo.SharedWithOs = drive.GetSharedWithOs();
             driveInfo.ReadCentric = drive.GetReadCentric();
             driveInfo.Kind = drive.GetKind();
+            driveInfo.InferPDiskSlotCountFromUnitSize = drive.GetInferPDiskSlotCountFromUnitSize();
 
             if (drive.HasPDiskConfig()) {
                 TString config;
@@ -46,6 +47,7 @@ namespace NKikimr::NBsController {
             driveInfo.SharedWithOs = false;
             driveInfo.ReadCentric = false;
             driveInfo.Kind = 0;
+            driveInfo.InferPDiskSlotCountFromUnitSize = 0;
             driveInfo.PDiskConfig = defaultPDiskConfig;
 
             for (const auto& path : field) {

--- a/ydb/core/mind/bscontroller/cmds_storage_pool.cpp
+++ b/ydb/core/mind/bscontroller/cmds_storage_pool.cpp
@@ -597,6 +597,7 @@ namespace NKikimr::NBsController {
                 x->SetDriveStatus(NKikimrBlobStorage::EDriveStatus::ACTIVE);
                 x->SetExpectedSlotCount(pdisk.ExpectedSlotCount);
                 x->SetDecommitStatus(NKikimrBlobStorage::EDecommitStatus::DECOMMIT_NONE);
+                x->SetInferPDiskSlotCountFromUnitSize(pdisk.InferPDiskSlotCountFromUnitSize);
                 if (pdisk.PDiskMetrics) {
                     x->MutablePDiskMetrics()->CopyFrom(*pdisk.PDiskMetrics);
                     x->MutablePDiskMetrics()->ClearPDiskId();

--- a/ydb/core/mind/bscontroller/config.cpp
+++ b/ydb/core/mind/bscontroller/config.cpp
@@ -115,6 +115,7 @@ namespace NKikimr::NBsController {
                 pdisk->SetPDiskCategory(pdiskInfo.Kind.GetRaw());
                 pdisk->SetExpectedSerial(pdiskInfo.ExpectedSerial);
                 pdisk->SetManagementStage(Self->SerialManagementStage);
+                pdisk->SetInferPDiskSlotCountFromUnitSize(pdiskInfo.InferPDiskSlotCountFromUnitSize);
                 if (pdiskInfo.PDiskConfig && !pdisk->MutablePDiskConfig()->ParseFromString(pdiskInfo.PDiskConfig)) {
                     // TODO(alexvru): report this somehow
                 }
@@ -908,6 +909,7 @@ namespace NKikimr::NBsController {
                 drive.SetSharedWithOs(value.SharedWithOs);
                 drive.SetReadCentric(value.ReadCentric);
                 drive.SetKind(value.Kind);
+                drive.SetInferPDiskSlotCountFromUnitSize(value.InferPDiskSlotCountFromUnitSize);
 
                 if (const auto& config = value.PDiskConfig) {
                     NKikimrBlobStorage::TPDiskConfig& pb = *drive.MutablePDiskConfig();
@@ -1044,6 +1046,7 @@ namespace NKikimr::NBsController {
             pb->SetLastSeenSerial(pdisk.LastSeenSerial);
             pb->SetReadOnly(pdisk.Mood == TPDiskMood::ReadOnly);
             pb->SetMaintenanceStatus(pdisk.MaintenanceStatus);
+            pb->SetInferPDiskSlotCountFromUnitSize(pdisk.InferPDiskSlotCountFromUnitSize);
         }
 
         void TBlobStorageController::Serialize(NKikimrBlobStorage::TVSlotId *pb, TVSlotId id) {

--- a/ydb/core/mind/bscontroller/config_fit_pdisks.cpp
+++ b/ydb/core/mind/bscontroller/config_fit_pdisks.cpp
@@ -25,6 +25,7 @@ namespace NKikimr {
             bool ReadCentric = false;
             TPDiskCategory PDiskCategory = {};
             TString PDiskConfig;
+            ui64 InferPDiskSlotCountFromUnitSize = 0;
 
             TDiskId GetId() const {
                 return {NodeId, Path};
@@ -72,7 +73,8 @@ namespace NKikimr {
                 pdiskInfo->SharedWithOs != disk.SharedWithOs ||
                 pdiskInfo->ReadCentric != disk.ReadCentric ||
                 pdiskInfo->BoxId != disk.BoxId ||
-                pdiskInfo->PDiskConfig != disk.PDiskConfig)
+                pdiskInfo->PDiskConfig != disk.PDiskConfig ||
+                pdiskInfo->InferPDiskSlotCountFromUnitSize != disk.InferPDiskSlotCountFromUnitSize)
             {
                 // update PDisk configuration
                 auto pdiskInfo = state.PDisks.FindForUpdate(pdiskId);
@@ -81,11 +83,13 @@ namespace NKikimr {
                 pdiskInfo->SharedWithOs = disk.SharedWithOs;
                 pdiskInfo->ReadCentric = disk.ReadCentric;
                 pdiskInfo->BoxId = disk.BoxId;
-                if (pdiskInfo->PDiskConfig != disk.PDiskConfig) {
+                if (pdiskInfo->PDiskConfig != disk.PDiskConfig
+                        || pdiskInfo->InferPDiskSlotCountFromUnitSize != disk.InferPDiskSlotCountFromUnitSize) {
                     if (const auto id = FindStaticPDisk(disk, state); id && state.StaticPDisks.at(*id).PDiskConfig != disk.PDiskConfig) {
                         throw TExError() << "PDiskConfig mismatch for static disk" << TErrorParams::NodeId(disk.NodeId) << TErrorParams::Path(disk.Path);
                     } else {
                         pdiskInfo->PDiskConfig = disk.PDiskConfig;
+                        pdiskInfo->InferPDiskSlotCountFromUnitSize = disk.InferPDiskSlotCountFromUnitSize;
                     }
                 }
                 // run ExtractConfig as the very last step
@@ -178,6 +182,7 @@ namespace NKikimr {
                         disk.ReadCentric = driveInfo.ReadCentric;
                         disk.Serial = serial;
                         disk.SharedWithOs = driveInfo.SharedWithOs;
+                        disk.InferPDiskSlotCountFromUnitSize = driveInfo.InferPDiskSlotCountFromUnitSize;
 
                         auto diskId = disk.GetId();
                         auto [_, inserted] = disks.try_emplace(diskId, std::move(disk));
@@ -329,7 +334,8 @@ namespace NKikimr {
                             NKikimrBlobStorage::EDecommitStatus::DECOMMIT_NONE, NBsController::TPDiskMood::Normal,
                             disk.Serial, disk.LastSeenSerial, disk.LastSeenPath, staticSlotUsage,
                             true /* assume shred completed for this disk */,
-                            NKikimrBlobStorage::TMaintenanceStatus::NO_REQUEST);
+                            NKikimrBlobStorage::TMaintenanceStatus::NO_REQUEST,
+                            disk.InferPDiskSlotCountFromUnitSize);
 
                     // Set PDiskId and Guid in DrivesSerials
                     if (auto info = state.DrivesSerials.FindForUpdate(disk.Serial)) {

--- a/ydb/core/mind/bscontroller/impl.h
+++ b/ydb/core/mind/bscontroller/impl.h
@@ -344,6 +344,7 @@ public:
         bool HasExpectedSlotCount = false;
         ui32 NumActiveSlots = 0; // sum of owners weights allocated on this PDisk
         ui32 SlotSizeInUnits = 0;
+        ui64 InferPDiskSlotCountFromUnitSize = 0;
         TMap<Schema::VSlot::VSlotID::Type, TIndirectReferable<TVSlotInfo>::TPtr> VSlotsOnPDisk; // vslots over this PDisk
 
         bool Operational = false; // set to true when both containing node is connected and Operational is reported in Metrics
@@ -382,7 +383,8 @@ public:
                     Table::LastSeenPath,
                     Table::DecommitStatus,
                     Table::ShredComplete,
-                    Table::MaintenanceStatus
+                    Table::MaintenanceStatus,
+                    Table::InferPDiskSlotCountFromUnitSize
                 > adapter(
                     &TPDiskInfo::Path,
                     &TPDiskInfo::Kind,
@@ -399,7 +401,8 @@ public:
                     &TPDiskInfo::LastSeenPath,
                     &TPDiskInfo::DecommitStatus,
                     &TPDiskInfo::ShredComplete,
-                    &TPDiskInfo::MaintenanceStatus
+                    &TPDiskInfo::MaintenanceStatus,
+                    &TPDiskInfo::InferPDiskSlotCountFromUnitSize
                 );
             callback(&adapter);
         }
@@ -423,7 +426,8 @@ public:
                    const TString& lastSeenPath,
                    ui32 staticSlotUsage,
                    bool shredComplete,
-                   NKikimrBlobStorage::TMaintenanceStatus::E maintenanceStatus)
+                   NKikimrBlobStorage::TMaintenanceStatus::E maintenanceStatus,
+                   ui64 inferPDiskSlotCountFromUnitSize)
             : HostId(hostId)
             , Path(path)
             , Kind(kind)
@@ -434,6 +438,7 @@ public:
             , PDiskConfig(std::move(pdiskConfig))
             , ShredComplete(shredComplete)
             , BoxId(boxId)
+            , InferPDiskSlotCountFromUnitSize(inferPDiskSlotCountFromUnitSize)
             , Status(status)
             , StatusTimestamp(statusTimestamp)
             , DecommitStatus(decommitStatus)
@@ -994,6 +999,7 @@ public:
             Table::ReadCentric::Type ReadCentric;
             Table::Kind::Type Kind;
             TMaybe<Table::PDiskConfig::Type> PDiskConfig;
+            Table::InferPDiskSlotCountFromUnitSize::Type InferPDiskSlotCountFromUnitSize;
 
             template<typename T>
             static void Apply(TBlobStorageController* /*controller*/, T&& callback) {
@@ -1002,13 +1008,15 @@ public:
                         Table::SharedWithOs,
                         Table::ReadCentric,
                         Table::Kind,
-                        Table::PDiskConfig
+                        Table::PDiskConfig,
+                        Table::InferPDiskSlotCountFromUnitSize
                     > adapter(
                         &TDriveInfo::Type,
                         &TDriveInfo::SharedWithOs,
                         &TDriveInfo::ReadCentric,
                         &TDriveInfo::Kind,
-                        &TDriveInfo::PDiskConfig
+                        &TDriveInfo::PDiskConfig,
+                        &TDriveInfo::InferPDiskSlotCountFromUnitSize
                     );
                 callback(&adapter);
             }
@@ -2430,6 +2438,7 @@ public:
         const Schema::PDisk::Guid::Type Guid;
         Schema::PDisk::PDiskConfig::Type PDiskConfig;
         ui32 ExpectedSlotCount = 0;
+        ui64 InferPDiskSlotCountFromUnitSize = 0;
 
         // runtime info
         ui32 StaticSlotUsage = 0;
@@ -2442,6 +2451,7 @@ public:
             , Path(pdisk.GetPath())
             , Category(pdisk.GetPDiskCategory())
             , Guid(pdisk.GetPDiskGuid())
+            , InferPDiskSlotCountFromUnitSize(pdisk.GetInferPDiskSlotCountFromUnitSize())
         {
             if (pdisk.HasPDiskConfig()) {
                 const auto& cfg = pdisk.GetPDiskConfig();

--- a/ydb/core/mind/bscontroller/load_everything.cpp
+++ b/ydb/core/mind/bscontroller/load_everything.cpp
@@ -348,7 +348,8 @@ public:
                     Self->DefaultMaxSlots, disks.GetValue<T::Status>(), disks.GetValue<T::Timestamp>(),
                     disks.GetValue<T::DecommitStatus>(), disks.GetValue<T::Mood>(), disks.GetValue<T::ExpectedSerial>(),
                     disks.GetValue<T::LastSeenSerial>(), disks.GetValue<T::LastSeenPath>(), staticSlotUsage,
-                    disks.GetValueOrDefault<T::ShredComplete>(), disks.GetValueOrDefault<T::MaintenanceStatus>());
+                    disks.GetValueOrDefault<T::ShredComplete>(), disks.GetValueOrDefault<T::MaintenanceStatus>(),
+                    disks.GetValueOrDefault<T::InferPDiskSlotCountFromUnitSize>());
 
                 if (!disks.Next())
                     return false;

--- a/ydb/core/mind/bscontroller/register_node.cpp
+++ b/ydb/core/mind/bscontroller/register_node.cpp
@@ -484,6 +484,9 @@ void TBlobStorageController::ReadPDisk(const TPDiskId& pdiskId, const TPDiskInfo
             STLOG(PRI_CRIT, BS_CONTROLLER, BSCTXRN02, "PDiskConfig invalid", (NodeId, pdiskId.NodeId),
                 (PDiskId, pdiskId.PDiskId));
         }
+        if (pdisk.InferPDiskSlotCountFromUnitSize) {
+            pDisk->SetInferPDiskSlotCountFromUnitSize(pdisk.InferPDiskSlotCountFromUnitSize);
+        }
     }
     pDisk->SetExpectedSerial(pdisk.ExpectedSerial);
     pDisk->SetManagementStage(SerialManagementStage);
@@ -684,4 +687,3 @@ void TBlobStorageController::SendInReply(const IEventHandle& query, std::unique_
 }
 
 } // NKikimr::NBsController
-

--- a/ydb/core/mind/bscontroller/scheme.h
+++ b/ydb/core/mind/bscontroller/scheme.h
@@ -44,11 +44,12 @@ struct Schema : NIceDb::Schema {
         struct Mood : Column<18, NScheme::NTypeIds::Uint8> { using Type = TPDiskMood::EValue; static constexpr Type Default = Type::Normal; };
         struct ShredComplete : Column<19, NScheme::NTypeIds::Bool> { static constexpr Type Default = true; };
         struct MaintenanceStatus : Column<20, NScheme::NTypeIds::Uint8> { using Type = NKikimrBlobStorage::TMaintenanceStatus::E; static constexpr Type Default = NKikimrBlobStorage::TMaintenanceStatus::NO_REQUEST; };
+        struct InferPDiskSlotCountFromUnitSize : Column<21, NScheme::NTypeIds::Uint64> { static constexpr Type Default = 0; };
 
         using TKey = TableKey<NodeID, PDiskID>; // order is important
         using TColumns = TableColumns<NodeID, PDiskID, Path, Category, Guid, SharedWithOs, ReadCentric, NextVSlotId,
               Status, Timestamp, PDiskConfig, ExpectedSerial, LastSeenSerial, LastSeenPath, DecommitStatus, Mood,
-              ShredComplete, MaintenanceStatus>;
+              ShredComplete, MaintenanceStatus, InferPDiskSlotCountFromUnitSize>;
     };
 
     struct Group : Table<4> {
@@ -245,9 +246,10 @@ struct Schema : NIceDb::Schema {
         struct ReadCentric : Column<5, NScheme::NTypeIds::Bool> {};
         struct Kind : Column<6, NScheme::NTypeIds::Uint64> {};
         struct PDiskConfig : Column<7, NScheme::NTypeIds::String> {};
+        struct InferPDiskSlotCountFromUnitSize : Column<8, NScheme::NTypeIds::Uint64> { static constexpr Type Default = 0; };
 
         using TKey = TableKey<HostConfigId, Path>;
-        using TColumns = TableColumns<HostConfigId, Path, TypeCol, SharedWithOs, ReadCentric, Kind, PDiskConfig>;
+        using TColumns = TableColumns<HostConfigId, Path, TypeCol, SharedWithOs, ReadCentric, Kind, PDiskConfig, InferPDiskSlotCountFromUnitSize>;
     };
 
     struct BoxHostV2 : Table<105> {

--- a/ydb/core/protos/blobstorage.proto
+++ b/ydb/core/protos/blobstorage.proto
@@ -1038,6 +1038,10 @@ message TNodeWardenServiceSet {
         optional TPDiskSpaceColor.E SpaceColorBorder = 13;
         optional bool ReadOnly = 14;
         optional bool Stop = 15;
+
+        // If not zero, NodeWarded infers PDiskConfig ExpectedSlotCount and SlotSizeInUnits (if unset)
+        // from drive size and this value
+        optional uint64 InferPDiskSlotCountFromUnitSize = 16;
     }
 
     message TVDisk {

--- a/ydb/core/protos/blobstorage_config.proto
+++ b/ydb/core/protos/blobstorage_config.proto
@@ -23,6 +23,7 @@ message THostConfigDrive {
 
     // optional PDisk config for these drives; if not set, default configuration is applied; overrides host-wide default
     NKikimrBlobStorage.TPDiskConfig PDiskConfig = 6;
+    uint64 InferPDiskSlotCountFromUnitSize = 7;
 }
 
 // Command used to define typical host configuration. It it used while defining new typical host configurations and as
@@ -681,6 +682,7 @@ message TBaseConfig {
         string LastSeenSerial = 18;
         bool ReadOnly = 19;
         TMaintenanceStatus.E MaintenanceStatus = 20;
+        uint64 InferPDiskSlotCountFromUnitSize = 21;
     }
     message TVSlot {
         message TDonorDisk {

--- a/ydb/library/yaml_config/protos/config.proto
+++ b/ydb/library/yaml_config/protos/config.proto
@@ -74,6 +74,12 @@ message TExtendedHostConfigDrive {
     optional NKikimrBlobStorage.TPDiskConfig PDiskConfig = 6 [(NMarkers.CopyTo) = "THostConfigDrive"];
     optional uint64 ExpectedSlotCount = 7;
     optional uint32 SlotSizeInUnits = 8;
+    optional uint64 InferPDiskSlotCountFromUnitSize = 9 [(NMarkers.CopyTo) = "THostConfigDrive"];
+}
+
+message TInferPDiskSlotCountFromUnitSize {
+    optional uint64 Rot = 1;
+    optional uint64 Ssd = 2; // Implies both ssd and nvme
 }
 
 message THosts {
@@ -140,6 +146,8 @@ message TExtendedDefineHostConfig {
     repeated string Rot = 5 [(NMarkers.CopyTo) = "TDefineHostConfig"];
     repeated string Ssd = 6 [(NMarkers.CopyTo) = "TDefineHostConfig"];
     repeated string Nvme = 7 [(NMarkers.CopyTo) = "TDefineHostConfig"];
+
+    optional TInferPDiskSlotCountFromUnitSize InferPDiskSlotCountFromUnitSize = 8;
 
     optional uint64 ItemConfigGeneration = 100 [(NMarkers.CopyTo) = "TDefineHostConfig"];
 }

--- a/ydb/library/yaml_config/ut_transform/canondata/test_transform.TestYamlConfigTransformations.test_domains_config_dump_/multinode-missing-all.yaml.result.json
+++ b/ydb/library/yaml_config/ut_transform/canondata/test_transform.TestYamlConfigTransformations.test_domains_config_dump_/multinode-missing-all.yaml.result.json
@@ -1,1 +1,1 @@
-{"error": true, "stderr": "Terminating due to uncaught exception REDACTED    what() -> \"ydb/library/yaml_config/yaml_config_parser.cpp:884: Erasure species is not specified for storage pool type, id 0\"\n of type TWithBackTrace<yexception>\n"}
+{"error": true, "stderr": "Terminating due to uncaught exception REDACTED    what() -> \"ydb/library/yaml_config/yaml_config_parser.cpp:898: Erasure species is not specified for storage pool type, id 0\"\n of type TWithBackTrace<yexception>\n"}

--- a/ydb/library/yaml_config/ut_transform/canondata/test_transform.TestYamlConfigTransformations.test_domains_config_dump_/multinode-unmatched-types.yaml.result.json
+++ b/ydb/library/yaml_config/ut_transform/canondata/test_transform.TestYamlConfigTransformations.test_domains_config_dump_/multinode-unmatched-types.yaml.result.json
@@ -1,1 +1,1 @@
-{"error": true, "stderr": "Terminating due to uncaught exception REDACTED    what() -> \"ydb/library/yaml_config/yaml_config_parser.cpp:888: Disk type is not specified for storage pool type, id 0\"\n of type TWithBackTrace<yexception>\n"}
+{"error": true, "stderr": "Terminating due to uncaught exception REDACTED    what() -> \"ydb/library/yaml_config/yaml_config_parser.cpp:902: Disk type is not specified for storage pool type, id 0\"\n of type TWithBackTrace<yexception>\n"}

--- a/ydb/library/yaml_config/yaml_config_parser.cpp
+++ b/ydb/library/yaml_config/yaml_config_parser.cpp
@@ -351,14 +351,14 @@ namespace NKikimr::NYaml {
             }
             if (typesCount == 1) {
                 TString currentDiskType = hasRot ? "ROT" : (hasSsd ? "SSD" : "NVME");
-                if (diskType.empty()) { 
+                if (diskType.empty()) {
                     diskType = currentDiskType;
                 } else if (diskType != currentDiskType) {
                     return TString();
                 }
             }
         }
-        return diskType; 
+        return diskType;
     }
 
     void PrepareActorSystemConfig(NKikimrConfig::TAppConfig& config) {
@@ -639,6 +639,20 @@ namespace NKikimr::NYaml {
                     }
                     if (drive.HasSlotSizeInUnits()) {
                         drive.MutablePDiskConfig()->SetSlotSizeInUnits(drive.GetSlotSizeInUnits());
+                    }
+                }
+
+                if (hostConfig.HasInferPDiskSlotCountFromUnitSize()) {
+                    auto unitSizeByType = hostConfig.GetInferPDiskSlotCountFromUnitSize();
+                    for(auto& drive : *hostConfig.MutableDrive()) {
+                        if (drive.HasInferPDiskSlotCountFromUnitSize()) {
+                            continue;
+                        }
+                        if (drive.GetType() == "ROT" && unitSizeByType.HasRot()) {
+                            drive.SetInferPDiskSlotCountFromUnitSize(unitSizeByType.GetRot());
+                        } else if (auto& type = drive.GetType(); (type == "SSD" || type == "NVME") && unitSizeByType.HasSsd()) {
+                            drive.SetInferPDiskSlotCountFromUnitSize(unitSizeByType.GetSsd());
+                        }
                     }
                 }
             }

--- a/ydb/tests/functional/scheme_tests/canondata/tablet_scheme_tests.TestTabletSchemes.test_tablet_schemes_flat_bs_controller_/flat_bs_controller.schema
+++ b/ydb/tests/functional/scheme_tests/canondata/tablet_scheme_tests.TestTabletSchemes.test_tablet_schemes_flat_bs_controller_/flat_bs_controller.schema
@@ -346,6 +346,11 @@
                 "ColumnId": 20,
                 "ColumnName": "MaintenanceStatus",
                 "ColumnType": "Byte"
+            },
+            {
+                "ColumnId": 21,
+                "ColumnName": "InferPDiskSlotCountFromUnitSize",
+                "ColumnType": "Uint64"
             }
         ],
         "ColumnsDropped": [],
@@ -369,7 +374,8 @@
                     17,
                     18,
                     19,
-                    20
+                    20,
+                    21
                 ],
                 "RoomID": 0,
                 "Codec": 0,
@@ -1828,11 +1834,6 @@
         ],
         "ColumnsAdded": [
             {
-                "ColumnId": 7,
-                "ColumnName": "PDiskConfig",
-                "ColumnType": "String"
-            },
-            {
                 "ColumnId": 1,
                 "ColumnName": "HostConfigId",
                 "ColumnType": "Uint64"
@@ -1861,19 +1862,30 @@
                 "ColumnId": 6,
                 "ColumnName": "Kind",
                 "ColumnType": "Uint64"
+            },
+            {
+                "ColumnId": 7,
+                "ColumnName": "PDiskConfig",
+                "ColumnType": "String"
+            },
+            {
+                "ColumnId": 8,
+                "ColumnName": "InferPDiskSlotCountFromUnitSize",
+                "ColumnType": "Uint64"
             }
         ],
         "ColumnsDropped": [],
         "ColumnFamilies": {
             "0": {
                 "Columns": [
-                    7,
                     1,
                     2,
                     3,
                     4,
                     5,
-                    6
+                    6,
+                    7,
+                    8
                 ],
                 "RoomID": 0,
                 "Codec": 0,


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

- Introduced new Distributed Storage parameter `InferPDiskSlotCountFromUnitSize` that infers `ExpectedSlotCount` and `SlotSizeInUnits` from this value and drive size.

### Changelog category <!-- remove all except one -->

* New feature

### Description for reviewers 

Close #19709 