### PR TITLE
25-1: Invalidate tablet resolver cache on tablet pipe disconnect

### DIFF
--- a/ydb/core/tablet/tablet_resolver.cpp
+++ b/ydb/core/tablet/tablet_resolver.cpp
@@ -427,6 +427,11 @@ class TTabletResolver : public TActorBootstrapped<TTabletResolver> {
                     LOG_DEBUG(ctx, NKikimrServices::TABLET_RESOLVER,
                             "Delayed invalidation of tabletId: %" PRIu64
                             " leader: %s by NodeId", tabletId, entry.KnownLeader.ToString().c_str());
+                    if (entry.KnownFollowers.empty()) {
+                        // Avoid resolving preemptively until the next request
+                        DropEntry(tabletId, entry, ctx);
+                        return;
+                    }
                     ResolveRequest(tabletId, ctx);
                     entry.State = TEntry::StProblemResolve;
                     MoveEntryToUnresolved(tabletId, *entryHolder);
@@ -541,6 +546,11 @@ class TTabletResolver : public TActorBootstrapped<TTabletResolver> {
             break;
         case TEntry::StNormal:
             if (!msg->Actor || entry.KnownLeader == msg->Actor || entry.KnownLeaderTablet == msg->Actor) {
+                if (entry.KnownFollowers.empty()) {
+                    // Avoid resolving preemptively until the next request
+                    DropEntry(tabletId, entry, ctx);
+                    return;
+                }
                 ResolveRequest(tabletId, ctx);
                 entry.State = TEntry::StProblemResolve;
                 MoveEntryToUnresolved(tabletId, *entryHolder);
@@ -555,11 +565,17 @@ class TTabletResolver : public TActorBootstrapped<TTabletResolver> {
                     }
                 }
             }
-
             break;
+        case TEntry::StFollowerUpdate:
+            if (!msg->Actor || entry.KnownLeader == msg->Actor || entry.KnownLeaderTablet == msg->Actor) {
+                // Reuse previously sent resolve request for StProblemResolve
+                entry.State = TEntry::StProblemResolve;
+                MoveEntryToUnresolved(tabletId, *entryHolder);
+                break;
+            }
+            [[fallthrough]];
         case TEntry::StProblemResolve:
         case TEntry::StProblemPing:
-        case TEntry::StFollowerUpdate:
             for (auto it = entry.KnownFollowers.begin(), end = entry.KnownFollowers.end(); it != end; ++it) {
                 if (it->first == msg->Actor || it->second == msg->Actor) {
                     entry.KnownFollowers.erase(it);


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

...

### Changelog category <!-- remove all except one -->

* Not for changelog (changelog entry is not required)

### Description for reviewers <!-- (optional) description for those who read this PR -->

When tablets restart gracefully, e.g. during version upgrades, we may leave old leader addresses cached for a long time, and connecting to those addresses for the first time may take 10s of seconds after a corresponding VM is destroyed. Invalidate addresses when disconnect is initiated from the tablet, which covers most system pipe cache use cases.

Fixes #20931.