### PR TITLE
Bridge Mode in SB: retry undelivered messages in replica subscribers

### DIFF
--- a/ydb/core/tx/scheme_board/subscriber.cpp
+++ b/ydb/core/tx/scheme_board/subscriber.cpp
@@ -344,20 +344,6 @@ namespace {
 
     };
 
-    struct TEvPrivate {
-        enum EEv {
-            EvReplicaMissing = EventSpaceBegin(TKikimrEvents::ES_PRIVATE),
-
-            EvEnd,
-        };
-
-        static_assert(EvEnd < EventSpaceEnd(TKikimrEvents::ES_PRIVATE), "expect EvEnd < EventSpaceEnd(TKikimrEvents::ES_PRIVATE)");
-
-        struct TEvReplicaMissing : public TEventLocal<TEvReplicaMissing, EvReplicaMissing> {
-            // empty
-        };
-    };
-
 } // anonymous
 
 template <typename TPath, typename TDerived>
@@ -421,13 +407,6 @@ class TReplicaSubscriber: public TMonitorableActor<TDerived> {
         this->Send(ev->Sender, std::move(response), 0, ev->Cookie);
     }
 
-    void Handle(TEvents::TEvUndelivered::TPtr&) {
-        // We notify parent that this replica is missing, but we stay alive
-        // until the node is disconnected, in which case we assume the node
-        // may reboot and actor is launched.
-        this->Send(Parent, new TEvPrivate::TEvReplicaMissing);
-    }
-
     void PassAway() override {
         if (Replica.NodeId() != this->SelfId().NodeId()) {
             this->Send(MakeInterconnectProxyId(Replica.NodeId()), new TEvents::TEvUnsubscribe());
@@ -482,10 +461,10 @@ public:
             hFunc(NInternalEvents::TEvNotify, Handle);
             hFunc(NInternalEvents::TEvSyncVersionRequest, Handle);
             hFunc(NInternalEvents::TEvSyncVersionResponse, Handle);
-            hFunc(TEvents::TEvUndelivered, Handle);
 
             hFunc(TSchemeBoardMonEvents::TEvInfoRequest, Handle);
 
+            cFunc(TEvents::TEvUndelivered::EventType, PassAway);
             cFunc(TEvInterconnect::TEvNodeDisconnected::EventType, PassAway);
             cFunc(TEvents::TEvPoisonPill::EventType, PassAway);
         }
@@ -525,12 +504,8 @@ class TSubscriberProxy: public TMonitorableActor<TDerived> {
     }
 
     void Handle(NInternalEvents::TEvSyncVersionRequest::TPtr& ev) {
-        if (!ReplicaMissing) {
-            CurrentSyncRequest = ev->Cookie;
-            this->Send(ReplicaSubscriber, ev->Release().Release(), 0, ev->Cookie);
-        } else {
-            this->Send(Parent, new NInternalEvents::TEvSyncVersionResponse(0), 0, ev->Cookie);
-        }
+        CurrentSyncRequest = ev->Cookie;
+        this->Send(ReplicaSubscriber, ev->Release().Release(), 0, ev->Cookie);
     }
 
     void HandleSleep(NInternalEvents::TEvSyncVersionRequest::TPtr& ev) {
@@ -567,41 +542,21 @@ class TSubscriberProxy: public TMonitorableActor<TDerived> {
         this->Send(ev->Sender, std::move(response), 0, ev->Cookie);
     }
 
-    void OnReplicaFailure() {
-        if (CurrentSyncRequest) {
-            this->Send(Parent, new NInternalEvents::TEvSyncVersionResponse(0), 0, CurrentSyncRequest);
-            CurrentSyncRequest = 0;
-        }
-
-        this->Send(Parent, new NInternalEvents::TEvNotifyBuilder(Path, true));
-    }
-
     void Handle(TEvents::TEvGone::TPtr& ev) {
         if (ev->Sender != ReplicaSubscriber) {
             return;
         }
 
-        if (!ReplicaMissing) {
-            OnReplicaFailure();
+        if (CurrentSyncRequest) {
+            this->Send(Parent, new NInternalEvents::TEvSyncVersionResponse(0), 0, CurrentSyncRequest);
+            CurrentSyncRequest = 0;
         }
+        this->Send(Parent, new NInternalEvents::TEvNotifyBuilder(Path, true));
 
         ReplicaSubscriber = TActorId();
-        ReplicaMissing = false;
 
         this->Become(&TDerived::StateSleep, Delay, new TEvents::TEvWakeup());
         Delay = Min(Delay * 2, MaxDelay);
-    }
-
-    void Handle(TEvPrivate::TEvReplicaMissing::TPtr& ev) {
-        if (ev->Sender != ReplicaSubscriber) {
-            return;
-        }
-
-        if (!ReplicaMissing) {
-            OnReplicaFailure();
-
-            ReplicaMissing = true;
-        }
     }
 
     void PassAway() override {
@@ -663,7 +618,6 @@ public:
             hFunc(TSchemeBoardMonEvents::TEvInfoRequest, Handle);
 
             hFunc(TEvents::TEvGone, Handle);
-            hFunc(TEvPrivate::TEvReplicaMissing, Handle);
             cFunc(TEvents::TEvPoisonPill::EventType, PassAway);
         }
     }
@@ -693,7 +647,6 @@ private:
     TDuration Delay;
 
     ui64 CurrentSyncRequest;
-    bool ReplicaMissing = false;
 
     static constexpr TDuration DefaultDelay = TDuration::MilliSeconds(10);
     static constexpr TDuration MaxDelay = TDuration::Seconds(5);

--- a/ydb/core/tx/scheme_board/subscriber.cpp
+++ b/ydb/core/tx/scheme_board/subscriber.cpp
@@ -464,8 +464,8 @@ public:
 
             hFunc(TSchemeBoardMonEvents::TEvInfoRequest, Handle);
 
-            cFunc(TEvents::TEvUndelivered::EventType, PassAway);
             cFunc(TEvInterconnect::TEvNodeDisconnected::EventType, PassAway);
+            cFunc(TEvents::TEvUndelivered::EventType, PassAway);
             cFunc(TEvents::TEvPoisonPill::EventType, PassAway);
         }
     }
@@ -551,10 +551,9 @@ class TSubscriberProxy: public TMonitorableActor<TDerived> {
             this->Send(Parent, new NInternalEvents::TEvSyncVersionResponse(0), 0, CurrentSyncRequest);
             CurrentSyncRequest = 0;
         }
-        this->Send(Parent, new NInternalEvents::TEvNotifyBuilder(Path, true));
 
         ReplicaSubscriber = TActorId();
-
+        this->Send(Parent, new NInternalEvents::TEvNotifyBuilder(Path, true));
         this->Become(&TDerived::StateSleep, Delay, new TEvents::TEvWakeup());
         Delay = Min(Delay * 2, MaxDelay);
     }


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

### Changelog category <!-- remove all except one -->

* Not for changelog (changelog entry is not required)

### Description for reviewers <!-- (optional) description for those who read this PR -->

This PR essentially reverts the changes introduced in the Scheme Board Subscriber here:
- https://github.com/ydb-platform/ydb/commit/3780b3ba900496e3e5dc49b1fd6dff3eb9a942a0

This is a major update in the handling of undelivered messages sent from the replica subscribers to the replicas.

Undelivered was previously a final verdict, there was no sense in trying to deliver those messages again. The replica could have become available after an unsuccessful attempt to communicate with it only in case the node restarts. This is no longer the case. Replicas can be dynamically created when the configuration changes. That's why undelivered is no longer a terminal state and needs to be retried.

Moreover, previously we have used the non-retriable reaction on undelivered as a way to reconfigure scheme board replicas. There is no need for this workaround anymore, because we have ring groups that allow replicas reconfiguration. Scheme Board reconfiguration happens without replicas unavailability. No message is expected to be undelivered on reconfiguration.

Epic:
- https://github.com/ydb-platform/ydb/issues/19748

Issue:
- https://github.com/ydb-platform/ydb/issues/21004

Ещё немного о безопасности данного фикса:

При реконфигурации мы заводим ещё одну ring group'у с новым набором реплик и потихоньку переползаем на неё. Подписчики [перестанут общаться](https://github.com/ydb-platform/ydb/blob/main/ydb/core/tx/scheme_board/subscriber.cpp#L1060) со старыми репликами как только до них дойдёт конфиг, где они помечены write only. Сами реплики при этом ещё какое-то время должны жить. Идеальная картинка, по-моему, должна выглядить так (как по факту сейчас я не знаю): 
- distconf доставляет до всех нод обновлённый конфиг, где старые реплики помечены write only
- state storage убивает старые реплики и сообщения к ним начинают порождать undelivered

Ни одного undelivered не должно быть порождено, потому что к моменту физического уничтожения старых реплик, все подписчики уже перестали с ними общаться.
