### PR TITLE
Add --non-indexed parameter to vector workload to allow testing non-indexed search

### DIFF
--- a/ydb/library/workload/vector/vector_workload_params.cpp
+++ b/ydb/library/workload/vector/vector_workload_params.cpp
@@ -52,6 +52,8 @@ void TVectorWorkloadParams::ConfigureOpts(NLastGetopt::TOpts& opts, const EComma
             .DefaultValue(10).StoreResult(&RecallThreads);
         opts.AddLongOption( "recall", "Measure recall metrics. It trains on 'targets' vector by bruce-force search.")
             .StoreTrue(&Recall);
+        opts.AddLongOption( "non-indexed", "Take vector settings from the index, but search without the index.")
+            .StoreTrue(&NonIndexedSearch);
     };
 
     switch (commandType) {
@@ -146,6 +148,10 @@ void TVectorWorkloadParams::Init() {
         Y_ABORT_UNLESS(tableDescription.GetPrimaryKeyColumns().size() == 1,
             "Only single key is supported. But table %s has %d key columns", QueryTableName.c_str(), tableDescription.GetPrimaryKeyColumns().size());
         QueryTableKeyColumn = tableDescription.GetPrimaryKeyColumns().at(0);
+    }
+
+    if (NonIndexedSearch) {
+        IndexName = "";
     }
 }
 

--- a/ydb/library/workload/vector/vector_workload_params.h
+++ b/ydb/library/workload/vector/vector_workload_params.h
@@ -44,6 +44,7 @@ public:
     size_t RecallThreads = 0;
     ui64 TableRowCount = 0;
     bool Recall = false;
+    bool NonIndexedSearch = false;
     bool KeyIsInt = false;
 };
 


### PR DESCRIPTION
### Changelog category

* Not for changelog (changelog entry is not required)

### Description for reviewers

Мотивация:

Я в экспериментах по полноте сейчас также тестирую скорость поиска без индекса, но без подобной доработки workload этого не умеет, а хочется сделать, чтобы тесты были воспроизводимы внешними клиентами.

`--index idx_prefix --non-indexed` - самый простой способ сделать это, т.к. для поиска нужны параметры, которые сейчас берутся из индекса - название префиксной колонки, название векторной колонки и функция близости. То есть альтернативно вместо non-indexed пришлось бы задавать 3 параметра. Но мне кажется, оно того не стоит, и проще сделать non-indexed, поэтому закидываю вот такой ПР.