### PR TITLE
[stable-25-1] Fix for GROUP BY emitting multiple NULL keys when block processing is enabled

### DIFF
--- a/yql/essentials/minikql/comp_nodes/mkql_block_agg.cpp
+++ b/yql/essentials/minikql/comp_nodes/mkql_block_agg.cpp
@@ -863,7 +863,7 @@ template <typename T>
 T MakeKey(TStringBuf s, ui32 keyLength) {
     Y_UNUSED(keyLength);
     Y_ASSERT(s.Size() <= sizeof(T));
-    return *(const T*)s.Data();
+    return ReadUnaligned<T>(s.Data());
 }
 
 template <>
@@ -1280,8 +1280,10 @@ public:
         }
 
         std::array<TOutputBuffer, PrefetchBatchSize> out;
-        for (ui32 i = 0; i < PrefetchBatchSize; ++i) {
-            out[i].Resize(sizeof(TKey));
+        if constexpr (!std::is_same<TKey, TSSOKey>::value && !std::is_same<TKey, TExternalFixedSizeKey>::value) {
+            for (ui32 i = 0; i < PrefetchBatchSize; ++i) {
+                out[i].Resize(sizeof(TKey));
+            }
         }
 
         std::array<TRobinHoodBatchRequestItem<TKey>, PrefetchBatchSize> insertBatch;
@@ -1374,13 +1376,18 @@ public:
             }
 
             // encode key
-            out[insertBatchLen].Rewind();
+            auto& buf = out[insertBatchLen];
+            buf.Rewind();
+            if constexpr (!std::is_same<TKey, TSSOKey>::value && !std::is_same<TKey, TExternalFixedSizeKey>::value) {
+                WriteUnaligned<TKey>(buf.Data(), TKey{});
+            }
+
             for (ui32 i = 0; i < keysDatum.size(); ++i) {
                 if (keysDatum[i].is_scalar()) {
                     // TODO: more efficient code when grouping by scalar
-                    Readers_[i]->SaveScalarItem(*keysDatum[i].scalar(), out[insertBatchLen]);
+                    Readers_[i]->SaveScalarItem(*keysDatum[i].scalar(), buf);
                 } else {
-                    Readers_[i]->SaveItem(*keysDatum[i].array(), row, out[insertBatchLen]);
+                    Readers_[i]->SaveItem(*keysDatum[i].array(), row, buf);
                 }
             }
 

--- a/yql/essentials/public/udf/arrow/block_io_buffer.h
+++ b/yql/essentials/public/udf/arrow/block_io_buffer.h
@@ -89,6 +89,10 @@ public:
         return TStringBuf(Vec_.data(), Vec_.data() + Pos_);
     }
 
+    char* Data() {
+        return Vec_.data();
+    }
+
 private:
     void Ensure(size_t delta) {
         if (Pos_ + delta > Vec_.size()) {

--- a/yql/essentials/tests/sql/minirun/part4/canondata/result.json
+++ b/yql/essentials/tests/sql/minirun/part4/canondata/result.json
@@ -314,6 +314,27 @@
             "uri": "https://{canondata_backend}/1936842/397d19bc034685a9103c63c079eb706022471c35/resource.tar.gz#test.test_blocks-agg_by_key-default.txt-Results_/results.txt"
         }
     ],
+    "test.test[blocks-agg_with_long_keys-default.txt-Debug]": [
+        {
+            "checksum": "7c4a660fbbc90bdd8f4dd41a3c661bf5",
+            "size": 1144,
+            "uri": "https://{canondata_backend}/1942173/aec80438f8fc63ab8d93cee4a56261df6843c1f3/resource.tar.gz#test.test_blocks-agg_with_long_keys-default.txt-Debug_/opt.yql"
+        }
+    ],
+    "test.test[blocks-agg_with_long_keys-default.txt-Peephole]": [
+        {
+            "checksum": "c8f494b293f588852db9bb9a43439a45",
+            "size": 1738,
+            "uri": "https://{canondata_backend}/1942173/aec80438f8fc63ab8d93cee4a56261df6843c1f3/resource.tar.gz#test.test_blocks-agg_with_long_keys-default.txt-Peephole_/opt.yql"
+        }
+    ],
+    "test.test[blocks-agg_with_long_keys-default.txt-Results]": [
+        {
+            "checksum": "57c5aab96cb792f5f669cfb9a119550a",
+            "size": 84929,
+            "uri": "https://{canondata_backend}/1942173/aec80438f8fc63ab8d93cee4a56261df6843c1f3/resource.tar.gz#test.test_blocks-agg_with_long_keys-default.txt-Results_/results.txt"
+        }
+    ],
     "test.test[blocks-or_opt_scalar-default.txt-Debug]": [
         {
             "checksum": "48438c52974cf1f5de5ed35df99e54b5",

--- a/yql/essentials/tests/sql/minirun/part6/canondata/result.json
+++ b/yql/essentials/tests/sql/minirun/part6/canondata/result.json
@@ -296,6 +296,27 @@
             "uri": "file://test.test_bitcast_implicit-mod_bitcast-default.txt-Results_/extracted"
         }
     ],
+    "test.test[blocks-agg_with_optional_string_keys-default.txt-Debug]": [
+        {
+            "checksum": "c4c01814bb43ce233a32b92dbde44870",
+            "size": 1114,
+            "uri": "https://{canondata_backend}/1881367/91257b77defd2cabf8041b14bff63c8d29b9acc0/resource.tar.gz#test.test_blocks-agg_with_optional_string_keys-default.txt-Debug_/opt.yql"
+        }
+    ],
+    "test.test[blocks-agg_with_optional_string_keys-default.txt-Peephole]": [
+        {
+            "checksum": "746a1d389eb41491e1275c5323df00bf",
+            "size": 1547,
+            "uri": "https://{canondata_backend}/1881367/91257b77defd2cabf8041b14bff63c8d29b9acc0/resource.tar.gz#test.test_blocks-agg_with_optional_string_keys-default.txt-Peephole_/opt.yql"
+        }
+    ],
+    "test.test[blocks-agg_with_optional_string_keys-default.txt-Results]": [
+        {
+            "checksum": "bddaea9e12611287fc78163411a25cdc",
+            "size": 73787,
+            "uri": "https://{canondata_backend}/1881367/91257b77defd2cabf8041b14bff63c8d29b9acc0/resource.tar.gz#test.test_blocks-agg_with_optional_string_keys-default.txt-Results_/results.txt"
+        }
+    ],
     "test.test[blocks-coalesce_scalar-default.txt-Debug]": [
         {
             "checksum": "5ee084040bec68362ce741c283ddead6",

--- a/yql/essentials/tests/sql/minirun/part8/canondata/result.json
+++ b/yql/essentials/tests/sql/minirun/part8/canondata/result.json
@@ -394,6 +394,27 @@
             "uri": "https://{canondata_backend}/1130705/a25045513209436069d9f9a29831b732c13e1675/resource.tar.gz#test.test_blocks-agg_singular_type_value-default.txt-Results_/results.txt"
         }
     ],
+    "test.test[blocks-agg_with_optional_short_keys-default.txt-Debug]": [
+        {
+            "checksum": "169d1c9b335c178ff63d1f4858a7b237",
+            "size": 1067,
+            "uri": "https://{canondata_backend}/1937367/01b34a497b7b8ca6a58c91f8a4e3d26eac6fc1dd/resource.tar.gz#test.test_blocks-agg_with_optional_short_keys-default.txt-Debug_/opt.yql"
+        }
+    ],
+    "test.test[blocks-agg_with_optional_short_keys-default.txt-Peephole]": [
+        {
+            "checksum": "922eb78f0602be1324327c4e1d615df7",
+            "size": 1500,
+            "uri": "https://{canondata_backend}/1937367/01b34a497b7b8ca6a58c91f8a4e3d26eac6fc1dd/resource.tar.gz#test.test_blocks-agg_with_optional_short_keys-default.txt-Peephole_/opt.yql"
+        }
+    ],
+    "test.test[blocks-agg_with_optional_short_keys-default.txt-Results]": [
+        {
+            "checksum": "8bc94ce2c4b3fae8ee00c3d9b1f1a922",
+            "size": 73786,
+            "uri": "https://{canondata_backend}/1937367/01b34a497b7b8ca6a58c91f8a4e3d26eac6fc1dd/resource.tar.gz#test.test_blocks-agg_with_optional_short_keys-default.txt-Results_/results.txt"
+        }
+    ],
     "test.test[blocks-and_scalar-default.txt-Debug]": [
         {
             "checksum": "e5ccc5c53756e09ded8e82b6d662e5e9",

--- a/yql/essentials/tests/sql/sql2yql/canondata/result.json
+++ b/yql/essentials/tests/sql/sql2yql/canondata/result.json
@@ -1420,6 +1420,27 @@
             "uri": "https://{canondata_backend}/1781765/0dce37dc71c65fe553d73ed7cf98a62bdee9ddee/resource.tar.gz#test_sql2yql.test_blocks-agg_singular_type_value_optional_/sql.yql"
         }
     ],
+    "test_sql2yql.test[blocks-agg_with_long_keys]": [
+        {
+            "checksum": "9e33943a7d53d564dcd74254699f5e40",
+            "size": 2268,
+            "uri": "https://{canondata_backend}/1881367/d038dca8eefe1a3deb4de9ce8bf77e4ff93a0ee8/resource.tar.gz#test_sql2yql.test_blocks-agg_with_long_keys_/sql.yql"
+        }
+    ],
+    "test_sql2yql.test[blocks-agg_with_optional_short_keys]": [
+        {
+            "checksum": "d86c09153425549662c29e059055313a",
+            "size": 1833,
+            "uri": "https://{canondata_backend}/1917492/6861dabe163fc1019f5ab349e6b1256e5319ed13/resource.tar.gz#test_sql2yql.test_blocks-agg_with_optional_short_keys_/sql.yql"
+        }
+    ],
+    "test_sql2yql.test[blocks-agg_with_optional_string_keys]": [
+        {
+            "checksum": "bb039e048c5409c0403a0fad71eb7fc5",
+            "size": 1863,
+            "uri": "https://{canondata_backend}/1881367/d038dca8eefe1a3deb4de9ce8bf77e4ff93a0ee8/resource.tar.gz#test_sql2yql.test_blocks-agg_with_optional_string_keys_/sql.yql"
+        }
+    ],
     "test_sql2yql.test[blocks-and]": [
         {
             "checksum": "e22a52b51ef20174c3b832acb09df01b",
@@ -8369,6 +8390,21 @@
     "test_sql_format.test[blocks-agg_singular_type_value_optional]": [
         {
             "uri": "file://test_sql_format.test_blocks-agg_singular_type_value_optional_/formatted.sql"
+        }
+    ],
+    "test_sql_format.test[blocks-agg_with_long_keys]": [
+        {
+            "uri": "file://test_sql_format.test_blocks-agg_with_long_keys_/formatted.sql"
+        }
+    ],
+    "test_sql_format.test[blocks-agg_with_optional_short_keys]": [
+        {
+            "uri": "file://test_sql_format.test_blocks-agg_with_optional_short_keys_/formatted.sql"
+        }
+    ],
+    "test_sql_format.test[blocks-agg_with_optional_string_keys]": [
+        {
+            "uri": "file://test_sql_format.test_blocks-agg_with_optional_string_keys_/formatted.sql"
         }
     ],
     "test_sql_format.test[blocks-and]": [

--- a/yql/essentials/tests/sql/sql2yql/canondata/test_sql_format.test_blocks-agg_with_long_keys_/formatted.sql
+++ b/yql/essentials/tests/sql/sql2yql/canondata/test_sql_format.test_blocks-agg_with_long_keys_/formatted.sql
@@ -1,0 +1,30 @@
+PRAGMA config.flags('PeepholeFlags', 'UseAggPhases');
+
+$src = ListMap(
+    ListFromRange(CAST(0 AS Int64), CAST(500 AS Int64)), ($keyVal) -> {
+        RETURN <|
+            k1: $keyVal,
+            k2: $keyVal + 1,
+            k3: $keyVal + 2,
+            v: $keyVal
+        |>;
+    }
+);
+
+SELECT
+    k1,
+    k2,
+    k3,
+    sum(v) AS s
+FROM
+    as_table($src)
+GROUP BY
+    k1,
+    k2,
+    k3
+ORDER BY
+    k1,
+    k2,
+    k3,
+    s
+;

--- a/yql/essentials/tests/sql/sql2yql/canondata/test_sql_format.test_blocks-agg_with_optional_short_keys_/formatted.sql
+++ b/yql/essentials/tests/sql/sql2yql/canondata/test_sql_format.test_blocks-agg_with_optional_short_keys_/formatted.sql
@@ -1,0 +1,22 @@
+PRAGMA config.flags('PeepholeFlags', 'UseAggPhases');
+
+$src = ListMap(
+    ListFromRange(CAST(0 AS Int64), CAST(500 AS Int64)), ($x) -> {
+        RETURN <|
+            k: if($x % 10 == 0, NULL, $x),
+            v: $x
+        |>;
+    }
+);
+
+SELECT
+    k,
+    sum(v) AS s
+FROM
+    as_table($src)
+GROUP BY
+    k
+ORDER BY
+    k,
+    s
+;

--- a/yql/essentials/tests/sql/sql2yql/canondata/test_sql_format.test_blocks-agg_with_optional_string_keys_/formatted.sql
+++ b/yql/essentials/tests/sql/sql2yql/canondata/test_sql_format.test_blocks-agg_with_optional_string_keys_/formatted.sql
@@ -1,0 +1,22 @@
+PRAGMA config.flags('PeepholeFlags', 'UseAggPhases');
+
+$src = ListMap(
+    ListFromRange(CAST(0 AS Int64), CAST(500 AS Int64)), ($x) -> {
+        RETURN <|
+            k: if($x % 10 == 0, NULL, CAST($x AS String)),
+            v: $x
+        |>;
+    }
+);
+
+SELECT
+    k,
+    sum(v) AS s
+FROM
+    as_table($src)
+GROUP BY
+    k
+ORDER BY
+    k,
+    s
+;

--- a/yql/essentials/tests/sql/suites/blocks/agg_with_long_keys.sql
+++ b/yql/essentials/tests/sql/suites/blocks/agg_with_long_keys.sql
@@ -1,0 +1,13 @@
+pragma config.flags("PeepholeFlags","UseAggPhases");
+
+$src = ListMap(ListFromRange(cast (0 as Int64), cast(500 as Int64)), ($keyVal) -> {
+    return <|
+        k1: $keyVal,
+        k2: $keyVal + 1,
+        k3: $keyVal + 2,
+        v: $keyVal
+    |>;
+});
+
+select k1, k2, k3, sum(v) as s from as_table($src) group by k1, k2, k3 order by k1, k2, k3, s;
+

--- a/yql/essentials/tests/sql/suites/blocks/agg_with_optional_short_keys.sql
+++ b/yql/essentials/tests/sql/suites/blocks/agg_with_optional_short_keys.sql
@@ -1,0 +1,11 @@
+pragma config.flags("PeepholeFlags","UseAggPhases");
+
+$src = ListMap(ListFromRange(cast (0 as Int64), cast(500 as Int64)), ($x) -> {
+    return <|
+        k: if ($x % 10 == 0, NULL, $x),
+        v: $x
+    |>;
+});
+
+select k, sum(v) as s from as_table($src) group by k order by k, s;
+

--- a/yql/essentials/tests/sql/suites/blocks/agg_with_optional_string_keys.sql
+++ b/yql/essentials/tests/sql/suites/blocks/agg_with_optional_string_keys.sql
@@ -1,0 +1,11 @@
+pragma config.flags("PeepholeFlags","UseAggPhases");
+
+$src = ListMap(ListFromRange(cast (0 as Int64), cast(500 as Int64)), ($x) -> {
+    return <|
+        k: if ($x % 10 == 0, NULL, cast ($x as String)),
+        v: $x
+    |>;
+});
+
+select k, sum(v) as s from as_table($src) group by k order by k, s;
+


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

Fix for GROUP BY emitting multiple NULL keys when block processing is enabled

### Changelog category <!-- remove all except one -->

* Bugfix 

### Description for reviewers <!-- (optional) description for those who read this PR -->

Closes #20717