### PR TITLE
Bridge Mode in CMS: testing storage groups

### DIFF
--- a/ydb/core/cms/cms_ut.cpp
+++ b/ydb/core/cms/cms_ut.cpp
@@ -2401,6 +2401,7 @@ Y_UNIT_TEST_SUITE(TCmsTest) {
     Y_UNIT_TEST(BridgeModeGroups)
     {
         TTestEnvOpts opts(16, 4);
+        opts.NToSelect = 8;
         TCmsTestEnv env(opts.WithBridgeMode());
         TTestActorRuntime::TEventObserver prev = env.SetObserverFunc([&](TAutoPtr<IEventHandle>& ev) {
             if (ev->GetTypeRewrite() == TEvInterconnect::EvNodesInfo) {

--- a/ydb/core/cms/cms_ut.cpp
+++ b/ydb/core/cms/cms_ut.cpp
@@ -2389,18 +2389,18 @@ Y_UNIT_TEST_SUITE(TCmsTest) {
         UNIT_ASSERT_EQUAL(info.NodeIdToPileId.size(), 16);
         UNIT_ASSERT_EQUAL(info.BSGroupsCount(), 8);
         for (const auto& [_, group] : info.AllBSGroups()) {
+            // Checking (group.VDisks.size() > 0) means there are no proxy groups.
             UNIT_ASSERT(group.VDisks.size() > 0);
         }
-
         for (const auto [nodeId, pileId] : info.NodeIdToPileId) {
+            // In ChangePileMap, nodes are distributed among piles based on the parity.
             UNIT_ASSERT(nodeId % opts.PileCount == pileId);
         }
-
     }
 
-    Y_UNIT_TEST(BridgeModeGroupsTest)
+    Y_UNIT_TEST(BridgeModeGroups)
     {
-        TTestEnvOpts opts(16);
+        TTestEnvOpts opts(16, 4);
         TCmsTestEnv env(opts.WithBridgeMode());
         TTestActorRuntime::TEventObserver prev = env.SetObserverFunc([&](TAutoPtr<IEventHandle>& ev) {
             if (ev->GetTypeRewrite() == TEvInterconnect::EvNodesInfo) {
@@ -2410,14 +2410,71 @@ Y_UNIT_TEST_SUITE(TCmsTest) {
             return prev(ev);
         });
 
+        // Pile #1.
         env.CheckPermissionRequest("user", true, false, true, true, MODE_MAX_AVAILABILITY, TStatus::ALLOW,
                                     MakeAction(TAction::RESTART_SERVICES, env.GetNodeId(0), 60000000, "storage"));
+        // Pile #0: there are no vdisks that are the same as on the node with index 0.
         env.CheckPermissionRequest("user", true, false, true, true, MODE_MAX_AVAILABILITY, TStatus::ALLOW,
-                                    MakeAction(TAction::RESTART_SERVICES, env.GetNodeId(8), 60000000, "storage"));
-        env.CheckPermissionRequest("user", true, false, true, true, MODE_MAX_AVAILABILITY, TStatus::DISALLOW_TEMP,
-                                    MakeAction(TAction::RESTART_SERVICES, env.GetNodeId(1), 60000000, "storage"));
-        env.CheckPermissionRequest("user", true, false, true, true, MODE_MAX_AVAILABILITY, TStatus::DISALLOW_TEMP,
                                     MakeAction(TAction::RESTART_SERVICES, env.GetNodeId(9), 60000000, "storage"));
+        // Pile #1: the vdisk from this pile is already locked.
+        env.CheckPermissionRequest("user", true, false, true, true, MODE_MAX_AVAILABILITY, TStatus::DISALLOW_TEMP,
+                                    MakeAction(TAction::RESTART_SERVICES, env.GetNodeId(2), 60000000, "storage"));
+        // Pile #0: the vdisk from this pile is already locked.
+        env.CheckPermissionRequest("user", true, false, true, true, MODE_MAX_AVAILABILITY, TStatus::DISALLOW_TEMP,
+                                    MakeAction(TAction::RESTART_SERVICES, env.GetNodeId(11), 60000000, "storage"));
+        // Pile #1: in MODE_KEEP_AVAILABLE mode, two vdisks can be locked in a pile.
+        env.CheckPermissionRequest("user", true, false, true, true, MODE_KEEP_AVAILABLE, TStatus::ALLOW,
+                                    MakeAction(TAction::RESTART_SERVICES, env.GetNodeId(2), 60000000, "storage"));
+        // Pile #2: in MODE_KEEP_AVAILABLE mode, two vdisks can be locked in a pile.
+        env.CheckPermissionRequest("user", true, false, true, true, MODE_KEEP_AVAILABLE, TStatus::ALLOW,
+                                    MakeAction(TAction::RESTART_SERVICES, env.GetNodeId(11), 60000000, "storage"));
+        // Pile #1: in MODE_KEEP_AVAILABLE mode, no more than two vdisks can be locked in a pile.
+        env.CheckPermissionRequest("user", true, false, true, true, MODE_KEEP_AVAILABLE, TStatus::DISALLOW_TEMP,
+                                    MakeAction(TAction::RESTART_SERVICES, env.GetNodeId(4), 60000000, "storage"));
+        // Pile #2: in MODE_KEEP_AVAILABLE mode, no more than two vdisks can be locked in a pile.
+        env.CheckPermissionRequest("user", true, false, true, true, MODE_KEEP_AVAILABLE, TStatus::DISALLOW_TEMP,
+                                    MakeAction(TAction::RESTART_SERVICES, env.GetNodeId(13), 60000000, "storage"));
+    }
+
+    Y_UNIT_TEST(BridgeModeStateStorage)
+    {
+        TTestEnvOpts opts(16);
+        opts.VDisks = 0;
+        opts.NToSelect = 5;
+        TCmsTestEnv env(opts.WithBridgeMode());
+
+        TTestActorRuntime::TEventObserver prev = env.SetObserverFunc([&](TAutoPtr<IEventHandle>& ev) {
+            if (ev->GetTypeRewrite() == TEvInterconnect::EvNodesInfo) {
+                auto *x = reinterpret_cast<TEvInterconnect::TEvNodesInfo::TPtr*>(&ev);
+                ChangePileMap(x);
+            }
+            return prev(ev);
+        });
+
+        // Pile #1: There are 0 rings locked on this pile => it is possible to lock.
+        env.CheckPermissionRequest("user", true, false, true, true, MODE_MAX_AVAILABILITY, TStatus::ALLOW,
+                                    MakeAction(TAction::RESTART_SERVICES, env.GetNodeId(0), 60000000, "storage"));
+        // Pile #0: There are 0 rings locked on this pile => it is possible to lock.                            
+        env.CheckPermissionRequest("user", true, false, true, true, MODE_MAX_AVAILABILITY, TStatus::ALLOW,
+                                    MakeAction(TAction::RESTART_SERVICES, env.GetNodeId(1), 60000000, "storage"));
+        // Pile #1: There is already one ring locked on this pile => it is not possible to lock.
+        env.CheckPermissionRequest("user", true, false, true, true, MODE_MAX_AVAILABILITY, TStatus::DISALLOW_TEMP,
+                                    MakeAction(TAction::RESTART_SERVICES, env.GetNodeId(2), 60000000, "storage"));
+        // Pile #0: There is already one ring locked on this pile => it is not possible to lock.
+        env.CheckPermissionRequest("user", true, false, true, true, MODE_MAX_AVAILABILITY, TStatus::DISALLOW_TEMP,
+                                    MakeAction(TAction::RESTART_SERVICES, env.GetNodeId(3), 60000000, "storage"));
+        // Pile #1: On a pile in MODE_KEEP_AVAILABLE mode, it is possible to lock <= 2 rings => it is possible to lock
+        env.CheckPermissionRequest("user", true, false, true, true, MODE_KEEP_AVAILABLE, TStatus::ALLOW,
+                                    MakeAction(TAction::RESTART_SERVICES, env.GetNodeId(2), 60000000, "storage"));
+        // Pile #0: On a pile in MODE_KEEP_AVAILABLE mode, it is possible to lock <= 2 rings => it is possible to lock
+        env.CheckPermissionRequest("user", true, false, true, true, MODE_KEEP_AVAILABLE, TStatus::ALLOW,
+                                    MakeAction(TAction::RESTART_SERVICES, env.GetNodeId(3), 60000000, "storage"));
+        // Pile #1: On a pile in MODE_KEEP_AVAILABLE mode, it is possible to lock <= 2 rings — the limit has been exhausted => it is not possible to lock.
+        env.CheckPermissionRequest("user", true, false, true, true, MODE_KEEP_AVAILABLE, TStatus::DISALLOW_TEMP,
+                                    MakeAction(TAction::RESTART_SERVICES, env.GetNodeId(4), 60000000, "storage"));
+        // Pile #0: On a pile in MODE_KEEP_AVAILABLE mode, it is possible to lock <= 2 rings — the limit has been exhausted => it is not possible to lock.
+        env.CheckPermissionRequest("user", true, false, true, true, MODE_KEEP_AVAILABLE, TStatus::DISALLOW_TEMP,
+                                    MakeAction(TAction::RESTART_SERVICES, env.GetNodeId(5), 60000000, "storage"));
     }
 }
 

--- a/ydb/core/cms/cms_ut_common.cpp
+++ b/ydb/core/cms/cms_ut_common.cpp
@@ -654,13 +654,11 @@ TCmsTestEnv::TCmsTestEnv(const TTestEnvOpts &options)
             options.PileCount - 1,
             TStateStorageInfo::TRingGroup{.State = SYNCHRONIZED, .NToSelect = options.NToSelect}
         );
-        Y_ABORT_UNLESS(GetNodeCount() >= 16);
-        auto setuper = CreateCustomStateStorageSetupper(ringGroups, 
-            {
-                {0, {1, 3, 5, 7, 9, 11, 13, 15}},
-                {1, {0, 2, 4, 6, 8, 10, 12, 14}}
-            }
-        );
+        THashMap<ui32, TVector<ui32>> ringGroupIdToNodeIds;
+        for (ui32 i = 1; i <= GetNodeCount(); ++i) {
+            ringGroupIdToNodeIds[i % options.PileCount].push_back(i - 1);
+        }
+        auto setuper = CreateCustomStateStorageSetupper(ringGroups, ringGroupIdToNodeIds);
 
         for (ui32 nodeIndex = 0; nodeIndex < GetNodeCount(); ++nodeIndex) {
             setuper(*this, nodeIndex);

--- a/ydb/core/cms/cms_ut_common.cpp
+++ b/ydb/core/cms/cms_ut_common.cpp
@@ -654,7 +654,13 @@ TCmsTestEnv::TCmsTestEnv(const TTestEnvOpts &options)
             options.PileCount - 1,
             TStateStorageInfo::TRingGroup{.State = SYNCHRONIZED, .NToSelect = options.NToSelect}
         );
-        auto setuper = CreateCustomStateStorageSetupper(ringGroups, options.NRings * options.RingSize);
+        Y_ABORT_UNLESS(GetNodeCount() >= 16);
+        auto setuper = CreateCustomStateStorageSetupper(ringGroups, 
+            {
+                {0, {1, 3, 5, 7, 9, 11, 13, 15}},
+                {1, {0, 2, 4, 6, 8, 10, 12, 14}}
+            }
+        );
 
         for (ui32 nodeIndex = 0; nodeIndex < GetNodeCount(); ++nodeIndex) {
             setuper(*this, nodeIndex);

--- a/ydb/core/testlib/basics/helpers.h
+++ b/ydb/core/testlib/basics/helpers.h
@@ -45,6 +45,8 @@ namespace NFake {
                            bool replicasOnFirstNode = false);
     void SetupCustomStateStorage(TTestActorRuntime &runtime, ui32 NToSelect, ui32 nrings, ui32 ringSize);
     TStateStorageSetupper CreateCustomStateStorageSetupper(const TVector<TStateStorageInfo::TRingGroup>& ringGroups, int replicasInRingGroup);
+    TStateStorageSetupper CreateCustomStateStorageSetupper(const TVector<TStateStorageInfo::TRingGroup>& ringGroups,
+                                                           const THashMap<ui32, TVector<ui32>>& pileIdToNodeIds);
     TStateStorageSetupper CreateDefaultStateStorageSetupper();
     void SetupBSNodeWarden(TTestActorRuntime& runtime, ui32 nodeIndex, TIntrusivePtr<TNodeWardenConfig> nodeWardenConfig);
     void SetupTabletResolver(TTestActorRuntime& runtime, ui32 nodeIndex);


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

...

### Changelog category <!-- remove all except one -->

* Not for changelog (changelog entry is not required)

### Description for reviewers <!-- (optional) description for those who read this PR -->

- Добавил поясняющие комментарии к тестам `Bridge Mode` в `CMS`;
- `BridgeModeGroupsTest` -> `BridgeModeGroups`: т.к такой суффикс не используется в этих тестах;
- В предыдущих тестах настройки piles и ring groups были рассинхронизированы: `pileId` ноды определялся по четности `nodeId,` а в ring group указывалась одна нода в репликах. Теперь pile и ring group определяются в зависимости от четности `nodeId`;
- В тест `BridgeModeGroups` добавлены vdisks (+3);
- Добавлен тест `BridgeModeStateStorage`. 