### PR TITLE
Fix VDisk compaction race

### DIFF
--- a/ydb/core/blobstorage/vdisk/hulldb/generic/hullds_idx.cpp
+++ b/ydb/core/blobstorage/vdisk/hulldb/generic/hullds_idx.cpp
@@ -17,6 +17,7 @@ namespace NKikimr {
             case StateCompPolicyAtWork: return "Policy At Work";
             case StateCompInProgress:   return "Compaction In Progress";
             case StateWaitCommit:       return "Committing";
+            case StateWaitPreCompact:   return "Waiting Huge Blob Pre-compaction";
             default:                    return "UNKNOWN";
         }
     }

--- a/ydb/core/blobstorage/vdisk/hulldb/generic/hullds_idx.h
+++ b/ydb/core/blobstorage/vdisk/hulldb/generic/hullds_idx.h
@@ -21,7 +21,8 @@ namespace NKikimr {
             StateNoComp = 0,        // default initial state
             StateCompPolicyAtWork,  // compaction policy is working
             StateCompInProgress,    // level compaction
-            StateWaitCommit         // wait for commit to disk
+            StateWaitCommit,        // wait for commit to disk
+            StateWaitPreCompact,    // wait for huge blob precompaction
         };
 
         static const char *LevelCompStateToStr(ELevelCompState s);

--- a/ydb/core/blobstorage/vdisk/hullop/blobstorage_hullactor.cpp
+++ b/ydb/core/blobstorage/vdisk/hullop/blobstorage_hullactor.cpp
@@ -276,11 +276,18 @@ namespace NKikimr {
                     if (CompactionTask->GetHugeBlobsToDelete().Empty()) {
                         ApplyCompactionResult(ctx, {}, {}, 0);
                     } else {
+                        // switch compaction state to pre-compaction to block any attempts of concurrent compaction
+                        RTCtx->LevelIndex->SetCompState(TLevelIndexBase::StateWaitPreCompact);
+
                         const ui64 cookie = NextPreCompactCookie++;
                         LOG_DEBUG_S(ctx, NKikimrServices::BS_HULLCOMP, HullDs->HullCtx->VCtx->VDiskLogPrefix
                             << "requesting PreCompact for ActDeleteSsts");
                         ctx.Send(HullLogCtx->HugeKeeperId, new TEvHugePreCompact, 0, cookie);
                         PreCompactCallbacks.emplace(cookie, [this, ev](ui64 wId, const TActorContext& ctx) mutable {
+                            Y_VERIFY_S(RTCtx->LevelIndex->GetCompState() == TLevelIndexBase::StateWaitPreCompact,
+                                HullDs->HullCtx->VCtx->VDiskLogPrefix);
+                            RTCtx->LevelIndex->SetCompState(TLevelIndexBase::StateNoComp);
+
                             Y_VERIFY_S(wId, HullDs->HullCtx->VCtx->VDiskLogPrefix);
                             LOG_DEBUG_S(ctx, NKikimrServices::BS_HULLCOMP, HullDs->HullCtx->VCtx->VDiskLogPrefix
                                 << "got PreCompactResult for ActDeleteSsts, wId# " << wId);


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

Fix VDisk compaction race

### Changelog category <!-- remove all except one -->

* Not for changelog (changelog entry is not required)

### Description for reviewers <!-- (optional) description for those who read this PR -->

This patch fixes vdisk compaction race leading to possible data corruption when two compactions are started concurrently.
