### PR TITLE
Report inferred PDisk SlotCount in metrics

### DIFF
--- a/ydb/apps/dstool/lib/dstool_cmd_pdisk_list.py
+++ b/ydb/apps/dstool/lib/dstool_cmd_pdisk_list.py
@@ -90,8 +90,15 @@ def do(args):
         row['Kind'] = pdisk.Kind
         row['Guid'] = pdisk.Guid
         row['NumStaticSlots'] = pdisk.NumStaticSlots
-        row['ExpectedSlotCount'] = pdisk.ExpectedSlotCount
-        row['SlotSizeInUnits'] = pdisk.PDiskConfig.SlotSizeInUnits
+        if (pdisk.PDiskMetrics.HasField('SlotCount')):
+            row['ExpectedSlotCount'] = pdisk.PDiskMetrics.SlotCount
+            row['SlotSizeInUnits'] = pdisk.PDiskMetrics.SlotSizeInUnits
+        elif (pdisk.InferPDiskSlotCountFromUnitSize != 0):
+            row['ExpectedSlotCount'] = 0
+            row['SlotSizeInUnits'] = 0
+        else:
+            row['ExpectedSlotCount'] = pdisk.ExpectedSlotCount
+            row['SlotSizeInUnits'] = pdisk.PDiskConfig.SlotSizeInUnits
         row['PDiskConfig'] = text_format.MessageToString(pdisk.PDiskConfig, as_one_line=True)
         row['AvailableSize'] = pdisk.PDiskMetrics.AvailableSize
         row['TotalSize'] = pdisk.PDiskMetrics.TotalSize

--- a/ydb/core/blobstorage/nodewarden/node_warden_pdisk.cpp
+++ b/ydb/core/blobstorage/nodewarden/node_warden_pdisk.cpp
@@ -137,7 +137,9 @@ namespace NKikimr::NStorage {
             pdiskConfig->EnableSectorEncryption = !pdiskConfig->SectorMap;
         }
 
-        if (ui64 unitSizeInBytes = pdisk.GetInferPDiskSlotCountFromUnitSize()) {
+        if (pdisk.GetPDiskConfig().GetExpectedSlotCount() != 0) {
+            // Skip inferring PDisk SlotCount
+        } else if (ui64 unitSizeInBytes = pdisk.GetInferPDiskSlotCountFromUnitSize()) {
             ui64 driveSize = 0;
             TStringStream outDetails;
             if (pdiskConfig->SectorMap) {

--- a/ydb/core/blobstorage/pdisk/blobstorage_pdisk_impl.cpp
+++ b/ydb/core/blobstorage/pdisk/blobstorage_pdisk_impl.cpp
@@ -1630,6 +1630,10 @@ void TPDisk::WhiteboardReport(TWhiteboardReport &whiteboardReport) {
             pdiskState.SetEnforcedDynamicSlotSize(minSlotSize);
         }
         pDiskMetrics.SetState(state);
+        pDiskMetrics.SetSlotSizeInUnits(Cfg->SlotSizeInUnits);
+        if (ExpectedSlotCount) {
+            pDiskMetrics.SetSlotCount(ExpectedSlotCount);
+        }
     }
 
     PCtx->ActorSystem->Send(whiteboardReport.Sender, reportResult);
@@ -2330,7 +2334,7 @@ void TPDisk::Slay(TSlay &evSlay) {
         TVDiskID vDiskId = evSlay.VDiskId;
         vDiskId.GroupGeneration = -1;
         auto it = VDiskOwners.find(vDiskId);
-        
+
         for (auto& pendingInit : PendingYardInits) {
             if (vDiskId == pendingInit->VDiskIdWOGeneration()) {
                 TStringStream str;
@@ -2999,7 +3003,7 @@ NKikimrProto::EReplyStatus TPDisk::CheckOwnerAndRound(TRequestBase* req, TString
 
     if (!IsOwnerUser(req->Owner)) {
         if (req->Owner == OwnerUnallocated && req->OwnerRound == 0) {
-            return NKikimrProto::OK; 
+            return NKikimrProto::OK;
         }
         err << "  ownerId# " << req->Owner << " < Begin# " << (ui32)OwnerBeginUser
             << " or >= End# " << (ui32)OwnerEndUser << " Marker# BPD72";
@@ -4343,7 +4347,7 @@ void TPDisk::ProgressShredState() {
                     << " ShredGeneration# " << ShredGeneration
                     << " ShredState# " << (ui32)ShredState);
                 // Send/schedule a request to retry
-                THolder<TCompletionEventSender> completion(new TCompletionEventSender(this, PCtx->PDiskActor, new NPDisk::TEvContinueShred())); 
+                THolder<TCompletionEventSender> completion(new TCompletionEventSender(this, PCtx->PDiskActor, new NPDisk::TEvContinueShred()));
                 if (ReleaseUnusedLogChunks(completion.Get())) {
                     ContinueShredsInFlight++;
                     WriteSysLogRestorePoint(completion.Release(), TReqId(TReqId::ShredPDisk, 0), {});
@@ -4367,7 +4371,7 @@ void TPDisk::ProgressShredState() {
             }
         }
         // Looks good, but there still can be chunks that need to be shredded still int transition between states.
-        // For example, log chunks are removed from the log chunk list on log cut but added to free chunk list on log cut 
+        // For example, log chunks are removed from the log chunk list on log cut but added to free chunk list on log cut
         // write operation completion. So, walk through the whole chunk list and check.
         for (ui32 chunkIdx = Format.SystemChunkCount; chunkIdx < ChunkState.size(); ++chunkIdx) {
             TChunkState &state = ChunkState[chunkIdx];
@@ -4382,7 +4386,7 @@ void TPDisk::ProgressShredState() {
                         << ", there are already ContinueShredsInFlight# " << ContinueShredsInFlight.load()
                         << " so just wait for it to arrive. "
                         << " ShredGeneration# " << ShredGeneration);
-                    return; 
+                    return;
                 } else {
                     LOG_DEBUG_S(*PCtx->ActorSystem, NKikimrServices::BS_PDISK_SHRED,
                         "PDisk# " << PCtx->PDiskId

--- a/ydb/core/mind/bscontroller/config_fit_groups.cpp
+++ b/ydb/core/mind/bscontroller/config_fit_groups.cpp
@@ -678,14 +678,28 @@ namespace NKikimr {
                     }
                 }
 
+                ui32 maxSlots = 0;
+                ui32 slotSizeInUnits = 0;
+                if (info.Metrics.HasSlotCount()) {
+                    maxSlots = info.Metrics.GetSlotCount();
+                    slotSizeInUnits = info.Metrics.GetSlotSizeInUnits();
+                } else if (info.InferPDiskSlotCountFromUnitSize != 0) {
+                    // inferred values are unknown yet
+                    maxSlots = 0;
+                    slotSizeInUnits = 0;
+                } else {
+                    maxSlots = info.ExpectedSlotCount;
+                    slotSizeInUnits = info.SlotSizeInUnits;
+                }
+
                 // register PDisk in the mapper
                 return Mapper->RegisterPDisk({
                     .PDiskId = id,
                     .Location = State.HostRecords->GetLocation(id.NodeId),
                     .Usable = usable,
                     .NumSlots = numSlots,
-                    .MaxSlots = info.ExpectedSlotCount,
-                    .SlotSizeInUnits = info.SlotSizeInUnits,
+                    .MaxSlots = maxSlots,
+                    .SlotSizeInUnits = slotSizeInUnits,
                     .Groups = std::move(groups),
                     .SpaceAvailable = availableSpace,
                     .Operational = info.Operational,

--- a/ydb/core/mind/bscontroller/group_mapper.cpp
+++ b/ydb/core/mind/bscontroller/group_mapper.cpp
@@ -55,7 +55,11 @@ namespace NKikimr::NBsController {
                     // single-unit vdisk occupies double-unit pdisk slot (storage waste)
                     penalty += 20;
                 }
-                return double(NumSlots) / MaxSlots + penalty;
+                if (!MaxSlots) {
+                    return NumSlots + penalty;
+                } else {
+                    return double(NumSlots) / MaxSlots + penalty;
+                }
             }
         };
 

--- a/ydb/core/protos/blobstorage_disk.proto
+++ b/ydb/core/protos/blobstorage_disk.proto
@@ -80,7 +80,7 @@ message TPDiskMetrics {
     optional uint64 NonRealTimeMs = 6; // ms per second of non-realtime, [0..1000]
     optional uint64 SlowDeviceMs = 7; // ms per second of slow device, [0..1000]
     optional uint32 MaxIOPS = 8; // number of IOPS this device can carry out
-    
+
     // maximum expected slot size; if set, then it is guaranteed that EnforcedDynamicSlotSize bytes of space are
     // available for every slot over this PDisk; if not set, then no space enforcement assumed
     optional uint64 EnforcedDynamicSlotSize = 9;
@@ -88,4 +88,6 @@ message TPDiskMetrics {
     optional TPDiskState.E State = 10;
 
     optional uint64 UpdateTimestamp = 11; // TInstant::GetValue()
+    optional uint64 SlotCount = 12;
+    optional uint32 SlotSizeInUnits = 13;
 }


### PR DESCRIPTION
### Changelog category <!-- remove all except one -->

* Not for changelog (changelog entry is not required)

### Description for reviewers <!-- (optional) description for those who read this PR -->

This PR includes several changes:
1. Add inferred PDisk settings (`SlotCount` and `SlotSizeInUnits`) to PDiskMetrics so it can be inspected with `dstool` and test it
2. Respect explicit values provided in `PDiskConfig` (don't override them with inferred values) and test it
3. Account reported metrics in `TGroupFitter` when creating new groups
4. Fix scoring formula to account the case `MaxSlots = 0`

Follow-up for #20966