### PR TITLE
Set account type in ticket parser response

### DIFF
--- a/ydb/core/security/ticket_parser_impl.h
+++ b/ydb/core/security/ticket_parser_impl.h
@@ -61,6 +61,7 @@ private:
             USER_ACCOUNT_TYPE,
             SERVICE_ACCOUNT_TYPE,
             ANONYMOUS_ACCOUNT_TYPE,
+            SERVICE_ACCOUNT_IMPERSONATED_FROM_USER_ACCOUNT_TYPE, // Service account credentials got from impersonation of user account
         };
 
         TString Subject;
@@ -656,14 +657,49 @@ private:
             return TPermissionRecord::TTypeCase::USER_ACCOUNT_TYPE;
         case Account::kServiceAccount:
             return TPermissionRecord::TTypeCase::SERVICE_ACCOUNT_TYPE;
+        case Account::kAnonymousAccount:
+            return TPermissionRecord::TTypeCase::ANONYMOUS_ACCOUNT_TYPE;
         default:
             return TPermissionRecord::TTypeCase::TYPE_NOT_SET;
         }
     }
 
+    typename TPermissionRecord::TTypeCase ConvertSubjectType(const nebius::iam::v1::Account::TypeCase& type, const nebius::iam::v1::ImpersonationInfo& impersonationInfo) {
+        typename TPermissionRecord::TTypeCase result = ConvertSubjectType(type);
+        if (result == TPermissionRecord::TTypeCase::SERVICE_ACCOUNT_TYPE) {
+            for (const nebius::iam::v1::ImpersonationInfo::ImpersonationAccount& impersonationAccount : impersonationInfo.chain()) {
+                for (const nebius::iam::v1::Account& account : impersonationAccount.account()) {
+                    if (ConvertSubjectType(account.GetTypeCase()) == TPermissionRecord::TTypeCase::USER_ACCOUNT_TYPE) {
+                        result = TPermissionRecord::TTypeCase::SERVICE_ACCOUNT_IMPERSONATED_FROM_USER_ACCOUNT_TYPE;
+                        break;
+                    }
+                }
+                if (result == TPermissionRecord::TTypeCase::SERVICE_ACCOUNT_IMPERSONATED_FROM_USER_ACCOUNT_TYPE) {
+                    break;
+                }
+            }
+        }
+        return result;
+    }
+
     template <>
     typename TPermissionRecord::TTypeCase ConvertSubjectType<nebius::iam::v1::AuthenticateResponse>(const nebius::iam::v1::AuthenticateResponse& response) {
         return ConvertSubjectType(response.account().type_case());
+    }
+
+    NACLibProto::ESubjectType ConvertSubjectTypeToProto(typename TPermissionRecord::TTypeCase type) {
+        switch (type) {
+        case TPermissionRecord::TTypeCase::TYPE_NOT_SET:
+            return NACLibProto::SUBJECT_TYPE_UNSPECIFIED;
+        case TPermissionRecord::TTypeCase::USER_ACCOUNT_TYPE:
+            return NACLibProto::SUBJECT_TYPE_USER;
+        case TPermissionRecord::TTypeCase::SERVICE_ACCOUNT_TYPE:
+            return NACLibProto::SUBJECT_TYPE_SERVICE;
+        case TPermissionRecord::TTypeCase::ANONYMOUS_ACCOUNT_TYPE:
+            return NACLibProto::SUBJECT_TYPE_ANONYMOUS;
+        case TPermissionRecord::TTypeCase::SERVICE_ACCOUNT_IMPERSONATED_FROM_USER_ACCOUNT_TYPE:
+            return NACLibProto::SUBJECT_TYPE_SERVICE_IMPERSONATED_FROM_USER;
+        }
     }
 
     template <typename TTokenRecord>
@@ -1198,7 +1234,7 @@ private:
                                 processingError = true;
                                 break;
                             }
-                            record.SubjectType = ConvertSubjectType(account.type_case());
+                            record.SubjectType = ConvertSubjectType(account.type_case(), result.impersonation_info());
                             for (auto& [_, permissionRecord] : record.Permissions) {
                                 if (permissionRecord.Error.empty()) {
                                     permissionRecord.Subject = record.Subject;
@@ -1758,6 +1794,7 @@ protected:
 
     template <typename TTokenRecord>
     void SetToken(const TString& key, TTokenRecord& record, TIntrusivePtr<NACLib::TUserToken> token) {
+        token->SetSubjectType(ConvertSubjectTypeToProto(record.SubjectType));
         TInstant now = TlsActivationContext->Now();
         record.Error.clear();
         EnrichUserTokenWithBuiltins(record, token);

--- a/ydb/library/aclib/aclib.h
+++ b/ydb/library/aclib/aclib.h
@@ -96,6 +96,8 @@ public:
     using NACLibProto::TUserToken::GetAuthType;
     using NACLibProto::TUserToken::GetSanitizedToken;
     using NACLibProto::TUserToken::SetSanitizedToken;
+    using NACLibProto::TUserToken::GetSubjectType;
+    using NACLibProto::TUserToken::SetSubjectType;
     TVector<TSID> GetGroupSIDs() const;
     TString GetOriginalUserToken() const;
     TString SerializeAsString() const;

--- a/ydb/library/aclib/protos/aclib.proto
+++ b/ydb/library/aclib/protos/aclib.proto
@@ -24,12 +24,21 @@ message TProtoHashTable {
     repeated TProtoHashBucket Buckets = 2;
 }
 
+enum ESubjectType {
+    SUBJECT_TYPE_UNSPECIFIED = 0;
+    SUBJECT_TYPE_USER = 1;
+    SUBJECT_TYPE_SERVICE = 2;
+    SUBJECT_TYPE_ANONYMOUS = 3;
+    SUBJECT_TYPE_SERVICE_IMPERSONATED_FROM_USER = 4;
+}
+
 message TUserToken {
     optional string UserSID = 1;
     optional TProtoHashTable GroupSIDs = 2;
     optional string OriginalUserToken = 3;
     optional string AuthType = 4;
     optional string SanitizedToken = 5; // Sanitized token that can be added to audit logs, but can not be used as token to access YDB or any other service.
+    optional ESubjectType SubjectType = 6;
 }
 
 message TSecurityObject {


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

...

### Changelog category <!-- remove all except one -->

* Not for changelog (changelog entry is not required)

### Description for reviewers <!-- (optional) description for those who read this PR -->

Set one of four types of client's account:
SUBJECT_TYPE_USER
SUBJECT_TYPE_SERVICE
SUBJECT_TYPE_ANONYMOUS
SUBJECT_TYPE_SERVICE_IMPERSONATED_FROM_USER

The last one is set when we see a service account, but it was initially done from user account. In this case audit logs should be written as if the action is made by user.