### PR TITLE
Fix multiple sequential incremental backups

### DIFF
--- a/ydb/core/protos/counters_schemeshard.proto
+++ b/ydb/core/protos/counters_schemeshard.proto
@@ -254,6 +254,9 @@ enum ESimpleCounters {
 
     COUNTER_IN_FLIGHT_OPS_TxCreateLongIncrementalRestoreOp = 199       [(CounterOpts) = {Name: "InFlightOps/CreateLongIncrementalRestoreOp"}];
     COUNTER_IN_FLIGHT_OPS_TxChangePathState = 200                     [(CounterOpts) = {Name: "InFlightOps/ChangePathState"}];
+
+    COUNTER_IN_FLIGHT_OPS_TxRotateCdcStream = 201        [(CounterOpts) = {Name: "InFlightOps/RotateCdcStream"}];
+    COUNTER_IN_FLIGHT_OPS_TxRotateCdcStreamAtTable = 202 [(CounterOpts) = {Name: "InFlightOps/RotateCdcStreamAtTable"}];
 }
 
 enum ECumulativeCounters {
@@ -410,6 +413,9 @@ enum ECumulativeCounters {
 
     COUNTER_FINISHED_OPS_TxCreateLongIncrementalRestoreOp = 121       [(CounterOpts) = {Name: "FinishedOps/CreateLongIncrementalRestoreOp"}];
     COUNTER_FINISHED_OPS_TxChangePathState = 122                     [(CounterOpts) = {Name: "FinishedOps/ChangePathState"}];
+
+    COUNTER_FINISHED_OPS_TxRotateCdcStream = 123        [(CounterOpts) = {Name: "FinishedOps/RotateCdcStream"}];
+    COUNTER_FINISHED_OPS_TxRotateCdcStreamAtTable = 124 [(CounterOpts) = {Name: "FinishedOps/RotateCdcStreamAtTable"}];
 }
 
 enum EPercentileCounters {

--- a/ydb/core/protos/flat_scheme_op.proto
+++ b/ydb/core/protos/flat_scheme_op.proto
@@ -1076,14 +1076,7 @@ message TDropCdcStream {
 message TRotateCdcStream {
     optional string TableName = 1;
     optional string OldStreamName = 2;
-
-    optional TCdcStreamDescription NewStreamDescription = 3;
-    optional uint64 NewStreamRetentionPeriodSeconds = 4 [default = 86400]; // 1d by default
-    optional uint32 NewStreamTopicPartitions = 5;
-
-    // Topic autopartitioning settings
-    optional bool NewStreamTopicAutoPartitioning = 6 [default = false]; // we always can split and merge of topic partitions
-    optional uint32 NewStreamMaxPartitionCount = 7;
+    optional TCreateCdcStream NewStream = 3;
 }
 
 message TContinuousBackupDescription {

--- a/ydb/core/protos/flat_scheme_op.proto
+++ b/ydb/core/protos/flat_scheme_op.proto
@@ -1073,7 +1073,21 @@ message TDropCdcStream {
     optional string StreamName = 2;
 }
 
+message TRotateCdcStream {
+    optional string TableName = 1;
+    optional string OldStreamName = 2;
+
+    optional TCdcStreamDescription NewStreamDescription = 3;
+    optional uint64 NewStreamRetentionPeriodSeconds = 4 [default = 86400]; // 1d by default
+    optional uint32 NewStreamTopicPartitions = 5;
+
+    // Topic autopartitioning settings
+    optional bool NewStreamTopicAutoPartitioning = 6 [default = false]; // we always can split and merge of topic partitions
+    optional uint32 NewStreamMaxPartitionCount = 7;
+}
+
 message TContinuousBackupDescription {
+    optional string StreamName = 1;
 }
 
 message TCreateContinuousBackup {
@@ -1089,6 +1103,7 @@ message TAlterContinuousBackup {
 
     message TTakeIncrementalBackup {
         optional string DstPath = 1;
+        optional string DstStreamPath = 2;
     }
 
     oneof Action {
@@ -1748,6 +1763,7 @@ message TModifyScheme {
     optional TCreateCdcStream CreateCdcStream = 45;
     optional TAlterCdcStream AlterCdcStream = 46;
     optional TDropCdcStream DropCdcStream = 47;
+    optional TRotateCdcStream RotateCdcStream = 83;
     optional TMove MoveTable = 48;
     optional TMove MoveTableIndex = 49;
     optional TSequenceDescription Sequence = 51;

--- a/ydb/core/protos/schemeshard/operations.proto
+++ b/ydb/core/protos/schemeshard/operations.proto
@@ -94,6 +94,10 @@ enum EOperationType {
     ESchemeOpDropCdcStream = 68;
     ESchemeOpDropCdcStreamImpl = 69;
     ESchemeOpDropCdcStreamAtTable = 70;
+    // Rotate
+    ESchemeOpRotateCdcStream = 120;
+    ESchemeOpRotateCdcStreamImpl = 121;
+    ESchemeOpRotateCdcStreamAtTable = 122;
 
     ESchemeOpMoveTable = 71;
     ESchemeOpMoveTableIndex = 72;

--- a/ydb/core/protos/tx_datashard.proto
+++ b/ydb/core/protos/tx_datashard.proto
@@ -437,6 +437,13 @@ message TDropCdcStreamNotice {
     optional TSnapshot DropSnapshot = 4;
 }
 
+message TRotateCdcStreamNotice {
+    optional NKikimrProto.TPathID PathId = 1;
+    optional uint64 TableSchemaVersion = 2;
+    optional NKikimrProto.TPathID OldStreamPathId = 3;
+    optional NKikimrSchemeOp.TCdcStreamDescription NewStreamDescription = 4;
+}
+
 message TAsyncIndexInfo {
 }
 
@@ -498,6 +505,7 @@ message TFlatSchemeTransaction {
     optional TCreateCdcStreamNotice CreateCdcStreamNotice = 18;
     optional TAlterCdcStreamNotice AlterCdcStreamNotice = 19;
     optional TDropCdcStreamNotice DropCdcStreamNotice = 20;
+    optional TRotateCdcStreamNotice RotateCdcStreamNotice = 24;
     optional TMoveIndex MoveIndex = 21;
 
     optional NKikimrSchemeOp.TRestoreIncrementalBackup CreateIncrementalRestoreSrc = 22;

--- a/ydb/core/tx/datashard/check_scheme_tx_unit.cpp
+++ b/ydb/core/tx/datashard/check_scheme_tx_unit.cpp
@@ -39,6 +39,7 @@ private:
     bool CheckCreateCdcStream(TActiveTransaction *activeTx);
     bool CheckAlterCdcStream(TActiveTransaction *activeTx);
     bool CheckDropCdcStream(TActiveTransaction *activeTx);
+    bool CheckRotateCdcStream(TActiveTransaction *activeTx);
     bool CheckCreateIncrementalRestoreSrc(TActiveTransaction *activeTx);
     bool CheckCreateIncrementalBackupSrc(TActiveTransaction *activeTx);
 
@@ -382,6 +383,9 @@ bool TCheckSchemeTxUnit::CheckSchemeTx(TActiveTransaction *activeTx)
         break;
     case TSchemaOperation::ETypeDropCdcStream:
         res = CheckDropCdcStream(activeTx);
+        break;
+    case TSchemaOperation::ETypeRotateCdcStream:
+        res = CheckRotateCdcStream(activeTx);
         break;
     case TSchemaOperation::ETypeCreateIncrementalRestoreSrc:
         res = CheckCreateIncrementalRestoreSrc(activeTx);
@@ -747,6 +751,19 @@ bool TCheckSchemeTxUnit::CheckDropCdcStream(TActiveTransaction *activeTx) {
 
     const auto &notice = activeTx->GetSchemeTx().GetDropCdcStreamNotice();
     if (!HasPathId(activeTx, notice, "DropCdcStream")) {
+        return false;
+    }
+
+    return CheckSchemaVersion(activeTx, notice);
+}
+
+bool TCheckSchemeTxUnit::CheckRotateCdcStream(TActiveTransaction *activeTx) {
+    if (HasDuplicate(activeTx, "RotateCdcStream", &TPipeline::HasRotateCdcStream)) {
+        return false;
+    }
+
+    const auto &notice = activeTx->GetSchemeTx().GetRotateCdcStreamNotice();
+    if (!HasPathId(activeTx, notice, "RotateCdcStream")) {
         return false;
     }
 

--- a/ydb/core/tx/datashard/datashard_active_transaction.cpp
+++ b/ydb/core/tx/datashard/datashard_active_transaction.cpp
@@ -440,6 +440,7 @@ bool TActiveTransaction::BuildSchemeTx()
         + (ui32)SchemeTx->HasCreateCdcStreamNotice()
         + (ui32)SchemeTx->HasAlterCdcStreamNotice()
         + (ui32)SchemeTx->HasDropCdcStreamNotice()
+        + (ui32)SchemeTx->HasRotateCdcStreamNotice()
         + (ui32)SchemeTx->HasMoveIndex()
         + (ui32)SchemeTx->HasCreateIncrementalRestoreSrc()
         + (ui32)SchemeTx->HasCreateIncrementalBackupSrc()
@@ -477,6 +478,8 @@ bool TActiveTransaction::BuildSchemeTx()
         SchemeTxType = TSchemaOperation::ETypeAlterCdcStream;
     else if (SchemeTx->HasDropCdcStreamNotice())
         SchemeTxType = TSchemaOperation::ETypeDropCdcStream;
+    else if (SchemeTx->HasRotateCdcStreamNotice())
+        SchemeTxType = TSchemaOperation::ETypeRotateCdcStream;
     else if (SchemeTx->HasMoveIndex())
         SchemeTxType = TSchemaOperation::ETypeMoveIndex;
     else if (SchemeTx->HasCreateIncrementalRestoreSrc())
@@ -865,6 +868,7 @@ void TActiveTransaction::BuildExecutionPlan(bool loaded)
         plan.push_back(EExecutionUnitKind::CreateCdcStream);
         plan.push_back(EExecutionUnitKind::AlterCdcStream);
         plan.push_back(EExecutionUnitKind::DropCdcStream);
+        plan.push_back(EExecutionUnitKind::RotateCdcStream);
         plan.push_back(EExecutionUnitKind::CreateIncrementalRestoreSrc);
         plan.push_back(EExecutionUnitKind::CompleteOperation);
         plan.push_back(EExecutionUnitKind::CompletedOperations);

--- a/ydb/core/tx/datashard/datashard_active_transaction.h
+++ b/ydb/core/tx/datashard/datashard_active_transaction.h
@@ -56,6 +56,7 @@ struct TSchemaOperation {
         ETypeMoveIndex = 16,
         ETypeCreateIncrementalRestoreSrc = 17,
         ETypeCreateIncrementalBackupSrc = 18,
+        ETypeRotateCdcStream = 19,
 
         ETypeUnknown = Max<ui32>()
     };
@@ -111,6 +112,7 @@ struct TSchemaOperation {
     bool IsCreateCdcStream() const { return Type == ETypeCreateCdcStream; }
     bool IsAlterCdcStream() const { return Type == ETypeAlterCdcStream; }
     bool IsDropCdcStream() const { return Type == ETypeDropCdcStream; }
+    bool IsRotateCdcStream() const { return Type == ETypeRotateCdcStream; }
     bool IsCreateIncrementalRestoreSrc() const { return Type == ETypeCreateIncrementalRestoreSrc; }
     bool IsCreateIncrementalBackupSrc() const { return Type == ETypeCreateIncrementalBackupSrc; }
 

--- a/ydb/core/tx/datashard/datashard_impl.h
+++ b/ydb/core/tx/datashard/datashard_impl.h
@@ -1942,6 +1942,12 @@ public:
         const TPathId& pathId, ui64 tableSchemaVersion,
         const TPathId& streamPathId);
 
+    TUserTable::TPtr AlterTableRotateCdcStream(
+        const TActorContext& ctx, TTransactionContext& txc,
+        const TPathId& pathId, ui64 tableSchemaVersion,
+        const TPathId& oldStreamPathId,
+        const NKikimrSchemeOp::TCdcStreamDescription& newStreamDesc);
+
     TUserTable::TPtr CreateUserTable(TTransactionContext& txc, const NKikimrSchemeOp::TTableDescription& tableScheme);
     TUserTable::TPtr AlterUserTable(const TActorContext& ctx, TTransactionContext& txc,
                                     const NKikimrSchemeOp::TTableDescription& tableScheme);

--- a/ydb/core/tx/datashard/datashard_pipeline.h
+++ b/ydb/core/tx/datashard/datashard_pipeline.h
@@ -172,6 +172,7 @@ public:
     bool HasCreateCdcStream() const { return SchemaTx && SchemaTx->IsCreateCdcStream(); }
     bool HasAlterCdcStream() const { return SchemaTx && SchemaTx->IsAlterCdcStream(); }
     bool HasDropCdcStream() const { return SchemaTx && SchemaTx->IsDropCdcStream(); }
+    bool HasRotateCdcStream() const { return SchemaTx && SchemaTx->IsRotateCdcStream(); }
     bool HasCreateIncrementalRestoreSrc() const { return SchemaTx && SchemaTx->IsCreateIncrementalRestoreSrc(); }
     bool HasCreateIncrementalBackupSrc() const { return SchemaTx && SchemaTx->IsCreateIncrementalBackupSrc(); }
 

--- a/ydb/core/tx/datashard/datashard_ut_incremental_backup.cpp
+++ b/ydb/core/tx/datashard/datashard_ut_incremental_backup.cpp
@@ -201,7 +201,7 @@ Y_UNIT_TEST_SUITE(IncrementalBackup) {
 
         ExecSQL(server, edgeActor, "DELETE FROM `/Root/Table` ON (key) VALUES (2), (6);");
 
-        WaitForContent(server, edgeActor, "/Root/Table/continuousBackupImpl", {
+        WaitForContent(server, edgeActor, "/Root/Table/0_continuousBackupImpl", {
             MakeUpsert(1, 100),
             MakeUpsert(5, 200),
             MakeUpsert(6, 300),
@@ -209,7 +209,8 @@ Y_UNIT_TEST_SUITE(IncrementalBackup) {
             MakeErase(6),
         });
 
-        WaitTxNotification(server, edgeActor, AsyncAlterTakeIncrementalBackup(server, "/Root", "Table", "IncrBackupImpl"));
+        WaitTxNotification(server, edgeActor,
+            AsyncAlterTakeIncrementalBackup(server, "/Root", "Table", "IncrBackupImpl", "1_continuousBackupImpl"));
 
         // Actions below mustn't affect the result
 
@@ -300,6 +301,166 @@ Y_UNIT_TEST_SUITE(IncrementalBackup) {
                 )"),
             "{ items { uint32_value: 1 } items { uint32_value: 10 } }, "
             "{ items { uint32_value: 3 } items { uint32_value: 30 } }");
+    }
+
+    Y_UNIT_TEST(MultiBackup) {
+        TPortManager portManager;
+        TServer::TPtr server = new TServer(TServerSettings(portManager.GetPort(2134), {}, DefaultPQConfig())
+            .SetUseRealThreads(false)
+            .SetDomainName("Root")
+            .SetEnableChangefeedInitialScan(true)
+        );
+
+        auto& runtime = *server->GetRuntime();
+        const auto edgeActor = runtime.AllocateEdgeActor();
+
+        SetupLogging(runtime);
+        InitRoot(server, edgeActor);
+        CreateShardedTable(server, edgeActor, "/Root", "Table", SimpleTable());
+
+        ExecSQL(server, edgeActor, R"(
+            UPSERT INTO `/Root/Table` (key, value) VALUES
+            (1, 10),
+            (2, 20),
+            (3, 30);
+        )");
+
+        WaitTxNotification(server, edgeActor,
+            AsyncCreateContinuousBackup(server, "/Root", "Table", "0_continuousBackupImpl"));
+
+        ExecSQL(server, edgeActor, R"(
+            UPSERT INTO `/Root/Table` (key, value) VALUES
+            (1, 100),
+            (5, 200),
+            (6, 300);
+        )");
+
+        ExecSQL(server, edgeActor, "DELETE FROM `/Root/Table` ON (key) VALUES (2), (6);");
+
+        WaitForContent(server, edgeActor, "/Root/Table/0_continuousBackupImpl", {
+            MakeUpsert(1, 100),
+            MakeUpsert(5, 200),
+            MakeUpsert(6, 300),
+            MakeErase(2),
+            MakeErase(6),
+        });
+
+        WaitTxNotification(server, edgeActor,
+            AsyncAlterTakeIncrementalBackup(server, "/Root", "Table", "1_IncrBackupImpl", "1_continuousBackupImpl"));
+
+        SimulateSleep(server, TDuration::Seconds(1));
+
+        const char* const result1 = "{ items { uint32_value: 1 } items { uint32_value: 100 } }, "
+            "{ items { uint32_value: 2 } items { null_flag_value: NULL_VALUE } }, "
+            "{ items { uint32_value: 5 } items { uint32_value: 200 } }, "
+            "{ items { uint32_value: 6 } items { null_flag_value: NULL_VALUE } }";
+
+        UNIT_ASSERT_VALUES_EQUAL(
+            KqpSimpleExec(runtime, R"(
+                SELECT key, value FROM `/Root/1_IncrBackupImpl`
+                ORDER BY key
+                )"),
+            result1);
+
+        ExecSQL(server, edgeActor, R"(
+            UPSERT INTO `/Root/Table` (key, value) VALUES
+            (2, 2000),
+            (5, 5000),
+            (7, 7000);
+        )");
+
+        ExecSQL(server, edgeActor, "DELETE FROM `/Root/Table` ON (key) VALUES (3), (5), (8);");
+
+        WaitForContent(server, edgeActor, "/Root/Table/1_continuousBackupImpl", {
+            MakeUpsert(2, 2000),
+            MakeUpsert(5, 5000),
+            MakeUpsert(7, 7000),
+            MakeErase(3),
+            MakeErase(5),
+            MakeErase(8),
+        });
+
+        WaitTxNotification(server, edgeActor,
+            AsyncAlterTakeIncrementalBackup(server, "/Root", "Table", "2_IncrBackupImpl", "2_continuousBackupImpl"));
+
+        SimulateSleep(server, TDuration::Seconds(1));
+
+        const char* const result2 = "{ items { uint32_value: 2 } items { uint32_value: 2000 } }, "
+            "{ items { uint32_value: 3 } items { null_flag_value: NULL_VALUE } }, "
+            "{ items { uint32_value: 5 } items { null_flag_value: NULL_VALUE } }, "
+            "{ items { uint32_value: 7 } items { uint32_value: 7000 } }, "
+            "{ items { uint32_value: 8 } items { null_flag_value: NULL_VALUE } }";
+
+        UNIT_ASSERT_VALUES_EQUAL(
+            KqpSimpleExec(runtime, R"(
+                SELECT key, value FROM `/Root/2_IncrBackupImpl`
+                ORDER BY key
+                )"),
+            result2);
+
+        ExecSQL(server, edgeActor, R"(
+            UPSERT INTO `/Root/Table` (key, value) VALUES
+            (20, 2000),
+            (50, 5000),
+            (70, 7000);
+        )");
+
+        ExecSQL(server, edgeActor, "DELETE FROM `/Root/Table` ON (key) VALUES (1), (2), (3);");
+
+        WaitForContent(server, edgeActor, "/Root/Table/2_continuousBackupImpl", {
+            MakeUpsert(20, 2000),
+            MakeUpsert(50, 5000),
+            MakeUpsert(70, 7000),
+            MakeErase(1),
+            MakeErase(2),
+            MakeErase(3),
+        });
+
+        WaitTxNotification(server, edgeActor,
+            AsyncAlterTakeIncrementalBackup(server, "/Root", "Table", "3_IncrBackupImpl", "3_continuousBackupImpl"));
+
+        SimulateSleep(server, TDuration::Seconds(1));
+
+        const char* const result3 = "{ items { uint32_value: 1 } items { null_flag_value: NULL_VALUE } }, "
+            "{ items { uint32_value: 2 } items { null_flag_value: NULL_VALUE } }, "
+            "{ items { uint32_value: 3 } items { null_flag_value: NULL_VALUE } }, "
+            "{ items { uint32_value: 20 } items { uint32_value: 2000 } }, "
+            "{ items { uint32_value: 50 } items { uint32_value: 5000 } }, "
+            "{ items { uint32_value: 70 } items { uint32_value: 7000 } }";
+
+        UNIT_ASSERT_VALUES_EQUAL(
+            KqpSimpleExec(runtime, R"(
+                SELECT key, value FROM `/Root/3_IncrBackupImpl`
+                ORDER BY key
+                )"),
+            result3);
+
+        // Check increments are unchanged
+
+        ExecSQL(server, edgeActor, R"(
+            UPSERT INTO `/Root/Table` (key, value) VALUES (10, 10000)
+        )");
+
+        UNIT_ASSERT_VALUES_EQUAL(
+            KqpSimpleExec(runtime, R"(
+                SELECT key, value FROM `/Root/1_IncrBackupImpl`
+                ORDER BY key
+                )"),
+            result1);
+
+        UNIT_ASSERT_VALUES_EQUAL(
+            KqpSimpleExec(runtime, R"(
+                SELECT key, value FROM `/Root/2_IncrBackupImpl`
+                ORDER BY key
+                )"),
+            result2);
+
+        UNIT_ASSERT_VALUES_EQUAL(
+            KqpSimpleExec(runtime, R"(
+                SELECT key, value FROM `/Root/3_IncrBackupImpl`
+                ORDER BY key
+                )"),
+            result3);
     }
 
     Y_UNIT_TEST(MultiRestore) {
@@ -430,7 +591,7 @@ Y_UNIT_TEST_SUITE(IncrementalBackup) {
             (3, 30);
         )");
 
-        WaitTxNotification(server, edgeActor, AsyncCreateContinuousBackup(server, "/Root", "Table"));
+        WaitTxNotification(server, edgeActor, AsyncCreateContinuousBackup(server, "/Root", "Table", "0_continuousBackupImpl"));
 
         ExecSQL(server, edgeActor, R"(
             UPSERT INTO `/Root/Table` (key, value) VALUES
@@ -443,7 +604,8 @@ Y_UNIT_TEST_SUITE(IncrementalBackup) {
 
         SimulateSleep(server, TDuration::Seconds(1));
 
-        WaitTxNotification(server, edgeActor, AsyncAlterTakeIncrementalBackup(server, "/Root", "Table", "IncrBackupImpl"));
+        WaitTxNotification(server, edgeActor,
+            AsyncAlterTakeIncrementalBackup(server, "/Root", "Table", "IncrBackupImpl", "1_continuousBackupImpl"));
 
         SimulateSleep(server, TDuration::Seconds(1));
 
@@ -532,6 +694,95 @@ Y_UNIT_TEST_SUITE(IncrementalBackup) {
                 "{ items { uint32_value: 1 } items { null_flag_value: NULL_VALUE } }, "
                 "{ items { uint32_value: 2 } items { uint32_value: 200 } }");
         }
+    }
+
+    Y_UNIT_TEST(ComplexBackupBackupCollection) {
+        TPortManager portManager;
+        TServer::TPtr server = new TServer(TServerSettings(portManager.GetPort(2134), {}, DefaultPQConfig())
+            .SetUseRealThreads(false)
+            .SetDomainName("Root")
+            .SetEnableChangefeedInitialScan(true)
+            .SetEnableBackupService(true)
+            .SetEnableRealSystemViewPaths(false)
+        );
+
+        auto& runtime = *server->GetRuntime();
+        const auto edgeActor = runtime.AllocateEdgeActor();
+
+        SetupLogging(runtime);
+        InitRoot(server, edgeActor);
+        CreateShardedTable(server, edgeActor, "/Root", "Table", SimpleTable());
+
+        ExecSQL(server, edgeActor, R"(
+            UPSERT INTO `/Root/Table` (key, value) VALUES
+                (1, 10)
+              , (2, 20)
+              , (3, 30)
+              ;
+            )");
+
+        ExecSQL(server, edgeActor, R"(
+            CREATE BACKUP COLLECTION `MyCollection`
+              ( TABLE `/Root/Table`
+              )
+            WITH
+              ( STORAGE = 'cluster'
+              , INCREMENTAL_BACKUP_ENABLED = 'true'
+              );
+            )", false);
+
+        ExecSQL(server, edgeActor, R"(BACKUP `MyCollection`;)", false);
+
+        UNIT_ASSERT_VALUES_EQUAL(
+            KqpSimpleExec(runtime, R"(
+                -- TODO: fix with navigate after proper scheme cache handling
+                SELECT key, value FROM `/Root/.backups/collections/MyCollection/19700101000001Z_full/Table`
+                ORDER BY key
+                )"),
+            KqpSimpleExec(runtime, R"(
+                SELECT key, value FROM `/Root/Table`
+                ORDER BY key
+                )"));
+
+        ExecSQL(server, edgeActor, R"(
+            UPSERT INTO `/Root/Table` (key, value) VALUES
+            (2, 200);
+        )");
+
+        ExecSQL(server, edgeActor, R"(DELETE FROM `/Root/Table` WHERE key=1;)");
+
+        ExecSQL(server, edgeActor, R"(BACKUP `MyCollection` INCREMENTAL;)", false);
+
+        SimulateSleep(server, TDuration::Seconds(1));
+
+        UNIT_ASSERT_VALUES_EQUAL(
+            KqpSimpleExec(runtime, R"(
+                -- TODO: fix with navigate after proper scheme cache handling
+                SELECT key, value FROM `/Root/.backups/collections/MyCollection/19700101000002Z_incremental/Table`
+                ORDER BY key
+                )"),
+            "{ items { uint32_value: 1 } items { null_flag_value: NULL_VALUE } }, "
+            "{ items { uint32_value: 2 } items { uint32_value: 200 } }");
+
+        ExecSQL(server, edgeActor, R"(
+            UPSERT INTO `/Root/Table` (key, value) VALUES
+            (3, 300);
+        )");
+
+        ExecSQL(server, edgeActor, R"(DELETE FROM `/Root/Table` WHERE key=2;)");
+
+        ExecSQL(server, edgeActor, R"(BACKUP `MyCollection` INCREMENTAL;)", false);
+
+        SimulateSleep(server, TDuration::Seconds(1));
+
+        UNIT_ASSERT_VALUES_EQUAL(
+            KqpSimpleExec(runtime, R"(
+                -- TODO: fix with navigate after proper scheme cache handling
+                SELECT key, value FROM `/Root/.backups/collections/MyCollection/19700101000003Z_incremental/Table`
+                ORDER BY key
+                )"),
+            "{ items { uint32_value: 2 } items { null_flag_value: NULL_VALUE } }, "
+            "{ items { uint32_value: 3 } items { uint32_value: 300 } }");
     }
 
     Y_UNIT_TEST_TWIN(SimpleRestoreBackupCollection, WithIncremental) {

--- a/ydb/core/tx/datashard/execution_unit.cpp
+++ b/ydb/core/tx/datashard/execution_unit.cpp
@@ -142,6 +142,8 @@ THolder<TExecutionUnit> CreateExecutionUnit(EExecutionUnitKind kind,
         return CreateAlterCdcStreamUnit(dataShard, pipeline);
     case EExecutionUnitKind::DropCdcStream:
         return CreateDropCdcStreamUnit(dataShard, pipeline);
+    case EExecutionUnitKind::RotateCdcStream:
+        return CreateRotateCdcStreamUnit(dataShard, pipeline);
     case EExecutionUnitKind::MoveIndex:
         return CreateMoveIndexUnit(dataShard, pipeline);
     case EExecutionUnitKind::CheckRead:

--- a/ydb/core/tx/datashard/execution_unit_ctors.h
+++ b/ydb/core/tx/datashard/execution_unit_ctors.h
@@ -73,6 +73,7 @@ THolder<TExecutionUnit> CreateMoveTableUnit(TDataShard &dataShard, TPipeline &pi
 THolder<TExecutionUnit> CreateCreateCdcStreamUnit(TDataShard &dataShard, TPipeline &pipeline);
 THolder<TExecutionUnit> CreateAlterCdcStreamUnit(TDataShard &dataShard, TPipeline &pipeline);
 THolder<TExecutionUnit> CreateDropCdcStreamUnit(TDataShard &dataShard, TPipeline &pipeline);
+THolder<TExecutionUnit> CreateRotateCdcStreamUnit(TDataShard &dataShard, TPipeline &pipeline);
 THolder<TExecutionUnit> CreateCheckReadUnit(TDataShard &dataShard, TPipeline &pipeline);
 THolder<TExecutionUnit> CreateReadUnit(TDataShard &dataShard, TPipeline &pipeline);
 THolder<TExecutionUnit> CreateIncrementalRestoreSrcUnit(TDataShard &dataShard, TPipeline &pipeline);

--- a/ydb/core/tx/datashard/execution_unit_kind.h
+++ b/ydb/core/tx/datashard/execution_unit_kind.h
@@ -74,6 +74,7 @@ enum class EExecutionUnitKind: ui32 {
     CreateCdcStream,
     AlterCdcStream,
     DropCdcStream,
+    RotateCdcStream,
     MoveIndex,
     CreateIncrementalRestoreSrc,
     Count,

--- a/ydb/core/tx/datashard/rotate_cdc_stream_unit.cpp
+++ b/ydb/core/tx/datashard/rotate_cdc_stream_unit.cpp
@@ -1,0 +1,89 @@
+#include "datashard_impl.h"
+#include "datashard_locks_db.h"
+#include "datashard_pipeline.h"
+#include "execution_unit_ctors.h"
+
+namespace NKikimr::NDataShard {
+
+class TRotateCdcStreamUnit : public TExecutionUnit {
+    THolder<TEvChangeExchange::TEvAddSender> AddSender;
+
+public:
+    TRotateCdcStreamUnit(TDataShard& self, TPipeline& pipeline)
+        : TExecutionUnit(EExecutionUnitKind::RotateCdcStream, false, self, pipeline)
+    {
+    }
+
+    bool IsReadyToExecute(TOperation::TPtr) const override {
+        return true;
+    }
+
+    EExecutionStatus Execute(TOperation::TPtr op, TTransactionContext& txc, const TActorContext& ctx) override {
+        Y_ENSURE(op->IsSchemeTx());
+
+        TActiveTransaction* tx = dynamic_cast<TActiveTransaction*>(op.Get());
+        Y_ENSURE(tx, "cannot cast operation of kind " << op->GetKind());
+
+        auto& schemeTx = tx->GetSchemeTx();
+        if (!schemeTx.HasRotateCdcStreamNotice()) {
+            return EExecutionStatus::Executed;
+        }
+
+        const auto& params = schemeTx.GetRotateCdcStreamNotice();
+        const auto& newStreamDesc = params.GetNewStreamDescription();
+        const auto oldStreamPathId = TPathId::FromProto(params.GetOldStreamPathId());
+        const auto newStreamPathId = TPathId::FromProto(newStreamDesc.GetPathId());
+
+        const auto pathId = TPathId::FromProto(params.GetPathId());
+        Y_ENSURE(pathId.OwnerId == DataShard.GetPathOwnerId());
+
+        const auto version = params.GetTableSchemaVersion();
+        Y_ENSURE(version);
+
+        auto tableInfo = DataShard.AlterTableRotateCdcStream(ctx, txc, pathId, version, oldStreamPathId, newStreamDesc);
+
+        Y_ENSURE(tableInfo);
+        TDataShardLocksDb locksDb(DataShard, txc);
+        DataShard.AddUserTable(pathId, tableInfo, &locksDb);
+
+        if (tableInfo->NeedSchemaSnapshots()) {
+            DataShard.AddSchemaSnapshot(pathId, version, op->GetStep(), op->GetTxId(), txc, ctx);
+        }
+
+        auto& scanManager = DataShard.GetCdcStreamScanManager();
+        scanManager.Forget(txc.DB, pathId, oldStreamPathId);
+        if (const auto* info = scanManager.Get(oldStreamPathId)) {
+            DataShard.CancelScan(tableInfo->LocalTid, info->ScanId);
+            scanManager.Complete(oldStreamPathId);
+        }
+
+        DataShard.GetCdcStreamHeartbeatManager().DropCdcStream(txc.DB, pathId, oldStreamPathId);
+        if (newStreamDesc.GetState() == NKikimrSchemeOp::ECdcStreamStateReady) {
+            if (const auto heartbeatInterval = TDuration::MilliSeconds(newStreamDesc.GetResolvedTimestampsIntervalMs())) {
+                DataShard.GetCdcStreamHeartbeatManager().AddCdcStream(txc.DB, pathId, newStreamPathId, heartbeatInterval);
+            }
+        }
+
+        AddSender.Reset(new TEvChangeExchange::TEvAddSender(
+            pathId, TEvChangeExchange::ESenderType::CdcStream, newStreamPathId
+        ));
+
+        BuildResult(op, NKikimrTxDataShard::TEvProposeTransactionResult::COMPLETE);
+        op->Result()->SetStepOrderId(op->GetStepOrder().ToPair());
+
+        return EExecutionStatus::DelayCompleteNoMoreRestarts;
+    }
+
+    void Complete(TOperation::TPtr, const TActorContext& ctx) override {
+        if (AddSender) {
+            ctx.Send(DataShard.GetChangeSender(), AddSender.Release());
+        }
+        DataShard.EmitHeartbeats();
+    }
+};
+
+THolder<TExecutionUnit> CreateRotateCdcStreamUnit(TDataShard& self, TPipeline& pipeline) {
+    return THolder(new TRotateCdcStreamUnit(self, pipeline));
+}
+
+} // namespace NKikimr::NDataShard

--- a/ydb/core/tx/datashard/ut_common/datashard_ut_common.cpp
+++ b/ydb/core/tx/datashard/ut_common/datashard_ut_common.cpp
@@ -1892,12 +1892,14 @@ ui64 AsyncAlterDropReplicationConfig(
 ui64 AsyncCreateContinuousBackup(
         Tests::TServer::TPtr server,
         const TString& workingDir,
-        const TString& tableName)
+        const TString& tableName,
+        const TString& streamName)
 {
     auto request = SchemeTxTemplate(NKikimrSchemeOp::ESchemeOpCreateContinuousBackup, workingDir);
 
     auto& desc = *request->Record.MutableTransaction()->MutableModifyScheme()->MutableCreateContinuousBackup();
     desc.SetTableName(tableName);
+    desc.MutableContinuousBackupDescription()->SetStreamName(streamName);
 
     return RunSchemeTx(*server->GetRuntime(), std::move(request));
 }
@@ -1906,7 +1908,8 @@ ui64 AsyncAlterTakeIncrementalBackup(
         Tests::TServer::TPtr server,
         const TString& workingDir,
         const TString& srcTableName,
-        const TString& dstTableName)
+        const TString& dstTableName,
+        const TString& dstStreamName)
 {
     auto request = SchemeTxTemplate(NKikimrSchemeOp::ESchemeOpAlterContinuousBackup, workingDir);
 
@@ -1914,6 +1917,7 @@ ui64 AsyncAlterTakeIncrementalBackup(
     desc.SetTableName(srcTableName);
     auto& incBackup = *desc.MutableTakeIncrementalBackup();
     incBackup.SetDstPath(dstTableName);
+    incBackup.SetDstStreamPath(dstStreamName);
 
     return RunSchemeTx(*server->GetRuntime(), std::move(request));
 }

--- a/ydb/core/tx/datashard/ut_common/datashard_ut_common.h
+++ b/ydb/core/tx/datashard/ut_common/datashard_ut_common.h
@@ -709,13 +709,15 @@ ui64 AsyncAlterDropReplicationConfig(
 ui64 AsyncCreateContinuousBackup(
         Tests::TServer::TPtr server,
         const TString& workingDir,
-        const TString& tableName);
+        const TString& tableName,
+        const TString& streamName = "0_continuousBackupImpl");
 
 ui64 AsyncAlterTakeIncrementalBackup(
         Tests::TServer::TPtr server,
         const TString& workingDir,
         const TString& srcTableName,
-        const TString& dstTableName);
+        const TString& dstTableName,
+        const TString& dstStreamName);
 
 ui64 AsyncAlterRestoreIncrementalBackup(
         Tests::TServer::TPtr server,

--- a/ydb/core/tx/datashard/ya.make
+++ b/ydb/core/tx/datashard/ya.make
@@ -197,6 +197,7 @@ SRCS(
     remove_locks.cpp
     remove_schema_snapshots.cpp
     restore_unit.cpp
+    rotate_cdc_stream_unit.cpp
     scan_common.cpp
     setup_sys_locks.h
     store_and_send_out_rs_unit.cpp

--- a/ydb/core/tx/schemeshard/backup/constants.h
+++ b/ydb/core/tx/schemeshard/backup/constants.h
@@ -1,7 +1,0 @@
-#pragma once
-
-namespace NKikimr::NSchemeShard::NBackup {
-
-constexpr static char const* CB_CDC_STREAM_NAME = "continuousBackupImpl";
-
-} // namespace NKikimr::NSchemeShard::NBackup

--- a/ydb/core/tx/schemeshard/backup/ya.make
+++ b/ydb/core/tx/schemeshard/backup/ya.make
@@ -1,7 +1,0 @@
-LIBRARY()
-
-SRCS(
-    constants.h
-)
-
-END()

--- a/ydb/core/tx/schemeshard/schemeshard__init.cpp
+++ b/ydb/core/tx/schemeshard/schemeshard__init.cpp
@@ -3616,6 +3616,13 @@ struct TSchemeShard::TTxInit : public TTransactionBase<TSchemeShard> {
                             txState.TargetPathTargetState = proto.GetTxCopyTableExtraData().GetTargetPathTargetState();
                         }
                     }
+                } else if (txState.TxType == TTxState::TxRotateCdcStreamAtTable) {
+                    if (!extraData.empty()) {
+                        NKikimrSchemeOp::TGenericTxInFlyExtraData proto;
+                        bool deserializeRes = ParseFromStringNoSizeLimit(proto, extraData);
+                        Y_ABORT_UNLESS(deserializeRes);
+                        txState.CdcPathId = TPathId::FromProto(proto.GetTxCopyTableExtraData().GetCdcPathId());
+                    }
                 }
 
                 Y_ABORT_UNLESS(txState.TxType != TTxState::TxInvalid);

--- a/ydb/core/tx/schemeshard/schemeshard__op_traits.cpp
+++ b/ydb/core/tx/schemeshard/schemeshard__op_traits.cpp
@@ -132,6 +132,9 @@ EOperationClass GetOperationClass(NKikimrSchemeOp::EOperationType op) {
         case NKikimrSchemeOp::EOperationType::ESchemeOpAlterCdcStreamAtTable:
         case NKikimrSchemeOp::EOperationType::ESchemeOpDropCdcStreamImpl:
         case NKikimrSchemeOp::EOperationType::ESchemeOpDropCdcStreamAtTable:
+        case NKikimrSchemeOp::EOperationType::ESchemeOpRotateCdcStream:
+        case NKikimrSchemeOp::EOperationType::ESchemeOpRotateCdcStreamImpl:
+        case NKikimrSchemeOp::EOperationType::ESchemeOpRotateCdcStreamAtTable:
         case NKikimrSchemeOp::EOperationType::ESchemeOpDropReplicationCascade:
         case NKikimrSchemeOp::EOperationType::ESchemeOpAlterExtSubDomainCreateHive:
         case NKikimrSchemeOp::EOperationType::ESchemeOpCreateColumnBuild:

--- a/ydb/core/tx/schemeshard/schemeshard__operation.cpp
+++ b/ydb/core/tx/schemeshard/schemeshard__operation.cpp
@@ -1164,6 +1164,10 @@ ISubOperation::TPtr TOperation::RestorePart(TTxState::ETxType txType, TTxState::
         return CreateDropCdcStreamAtTable(NextPartId(), txState, false);
     case TTxState::ETxType::TxDropCdcStreamAtTableDropSnapshot:
         return CreateDropCdcStreamAtTable(NextPartId(), txState, true);
+    case TTxState::ETxType::TxRotateCdcStream:
+        return CreateRotateCdcStreamImpl(NextPartId(), txState);
+    case TTxState::ETxType::TxRotateCdcStreamAtTable:
+        return CreateRotateCdcStreamAtTable(NextPartId(), txState);
 
     // Sequences
     case TTxState::ETxType::TxCreateSequence:
@@ -1468,6 +1472,11 @@ TVector<ISubOperation::TPtr> TDefaultOperationFactory::MakeOperationParts(
         return CreateDropCdcStream(op.NextPartId(), tx, context);
     case NKikimrSchemeOp::EOperationType::ESchemeOpDropCdcStreamImpl:
     case NKikimrSchemeOp::EOperationType::ESchemeOpDropCdcStreamAtTable:
+        Y_ABORT("multipart operations are handled before, also they require transaction details");
+    case NKikimrSchemeOp::EOperationType::ESchemeOpRotateCdcStream:
+        return CreateRotateCdcStream(op.NextPartId(), tx, context);
+    case NKikimrSchemeOp::EOperationType::ESchemeOpRotateCdcStreamImpl:
+    case NKikimrSchemeOp::EOperationType::ESchemeOpRotateCdcStreamAtTable:
         Y_ABORT("multipart operations are handled before, also they require transaction details");
 
     case NKikimrSchemeOp::EOperationType::ESchemeOp_DEPRECATED_35:

--- a/ydb/core/tx/schemeshard/schemeshard__operation_alter_continuous_backup.cpp
+++ b/ydb/core/tx/schemeshard/schemeshard__operation_alter_continuous_backup.cpp
@@ -1,12 +1,13 @@
+#include "schemeshard__backup_collection_common.h"
 #include "schemeshard__operation_alter_cdc_stream.h"
 #include "schemeshard__operation_common.h"
 #include "schemeshard__operation_part.h"
+#include "schemeshard__operation_rotate_cdc_stream.h"
 #include "schemeshard_impl.h"
 #include "schemeshard_utils.h"  // for TransactionTemplate
 
 #include <ydb/core/engine/mkql_proto.h>
 #include <ydb/core/scheme/scheme_types_proto.h>
-#include <ydb/core/tx/schemeshard/backup/constants.h>
 
 namespace NKikimr::NSchemeShard {
 
@@ -72,14 +73,34 @@ bool CreateAlterContinuousBackup(TOperationId opId, const TTxTransaction& tx, TO
     const auto workingDirPath = TPath::Resolve(tx.GetWorkingDir(), context.SS);
     const auto& cbOp = tx.GetAlterContinuousBackup();
     const auto& tableName = cbOp.GetTableName();
+    const auto tablePath = workingDirPath.Child(tableName, TPath::TSplitChildTag{});
 
-    const auto checksResult = NCdc::DoAlterStreamPathChecks(opId, workingDirPath, tableName, NBackup::CB_CDC_STREAM_NAME);
+    TMaybeFail<TString> lastStreamName;
+    static_assert(
+        std::is_same_v<
+            TMap<TString, TPathId>,
+            std::decay_t<decltype(tablePath.Base()->GetChildren())>> == true,
+        "Assume path children list is lexicographically sorted");
+
+    for (auto& [child, _] : tablePath.Base()->GetChildren()) {
+        if (child.EndsWith("_continuousBackupImpl")) {
+            lastStreamName = child;
+        }
+    }
+
+    if (lastStreamName.Empty()) {
+        result = {CreateReject(opId, NKikimrScheme::StatusInvalidParameter,
+            TStringBuilder() << "Last continuous backup stream is not found")};
+        return false;
+    }
+
+    const auto checksResult = NCdc::DoAlterStreamPathChecks(opId, workingDirPath, tableName, *lastStreamName);
     if (std::holds_alternative<ISubOperation::TPtr>(checksResult)) {
         result = {std::get<ISubOperation::TPtr>(checksResult)};
         return false;
     }
 
-    const auto [tablePath, streamPath] = std::get<NCdc::TStreamPaths>(checksResult);
+    const auto [_, streamPath] = std::get<NCdc::TStreamPaths>(checksResult);
     TTableInfo::TPtr table = context.SS->Tables.at(tablePath.Base()->PathId);
 
     const auto topicPath = streamPath.Child("streamImpl");
@@ -104,14 +125,9 @@ bool CreateAlterContinuousBackup(TOperationId opId, const TTxTransaction& tx, TO
         return false;
     }
 
-    NKikimrSchemeOp::TAlterCdcStream alterCdcStreamOp;
-    alterCdcStreamOp.SetTableName(tableName);
-    alterCdcStreamOp.SetStreamName(NBackup::CB_CDC_STREAM_NAME);
-
     switch (cbOp.GetActionCase()) {
     case NKikimrSchemeOp::TAlterContinuousBackup::kStop:
     case NKikimrSchemeOp::TAlterContinuousBackup::kTakeIncrementalBackup:
-        alterCdcStreamOp.MutableDisable();
         break;
     default:
         result = {CreateReject(opId, NKikimrScheme::StatusInvalidParameter, TStringBuilder()
@@ -120,11 +136,59 @@ bool CreateAlterContinuousBackup(TOperationId opId, const TTxTransaction& tx, TO
         return false;
     }
 
-    NCdc::DoAlterStream(result, alterCdcStreamOp, opId, workingDirPath, tablePath);
-
     if (cbOp.GetActionCase() == NKikimrSchemeOp::TAlterContinuousBackup::kTakeIncrementalBackup) {
+        TString newStreamName;
+        if (cbOp.GetTakeIncrementalBackup().HasDstStreamPath()) {
+            newStreamName = cbOp.GetTakeIncrementalBackup().GetDstStreamPath();
+        } else {
+            newStreamName = NBackup::ToX509String(TlsActivationContext->AsActorContext().Now()) + "_continuousBackupImpl";
+        }
+
+        const auto cdcChecksResult = NCdc::DoNewStreamPathChecks(context, opId, workingDirPath, tableName, newStreamName, false);
+        if (std::holds_alternative<ISubOperation::TPtr>(cdcChecksResult)) {
+            result = {std::get<ISubOperation::TPtr>(cdcChecksResult)};
+            return false;
+        }
+
+        const auto [_, newStreamPath] = std::get<NCdc::TStreamPaths>(cdcChecksResult);
+
+        NKikimrSchemeOp::TRotateCdcStream rotateCdcStreamOp;
+        rotateCdcStreamOp.SetTableName(tableName);
+        rotateCdcStreamOp.SetOldStreamName(*lastStreamName);
+        auto& newStreamDescription = *rotateCdcStreamOp.MutableNewStreamDescription();
+        newStreamDescription.SetName(newStreamName);
+        newStreamDescription.SetMode(NKikimrSchemeOp::ECdcStreamModeUpdate);
+        newStreamDescription.SetFormat(NKikimrSchemeOp::ECdcStreamFormatProto);
+
+        NCdc::DoRotateStream(result, rotateCdcStreamOp, opId, workingDirPath, tablePath);
         DoCreateIncrBackupTable(opId, backupTablePath, schema, result);
         DoAlterPqPart(opId, backupTablePath, topicPath, topic, result);
+
+        NKikimrSchemeOp::TCreateCdcStream createCdcStreamOp;
+        createCdcStreamOp.SetTableName(tableName);
+        auto& streamDescription = *createCdcStreamOp.MutableStreamDescription();
+        streamDescription.SetName(newStreamName);
+        streamDescription.SetMode(NKikimrSchemeOp::ECdcStreamModeUpdate);
+        streamDescription.SetFormat(NKikimrSchemeOp::ECdcStreamFormatProto);
+
+        TVector<TString> boundaries;
+        const auto& partitions = table->GetPartitions();
+        boundaries.reserve(partitions.size() - 1);
+
+        for (ui32 i = 0; i < partitions.size(); ++i) {
+            const auto& partition = partitions.at(i);
+            if (i != partitions.size() - 1) {
+                boundaries.push_back(partition.EndOfRange);
+            }
+        }
+
+        NCdc::DoCreatePqPart(result, createCdcStreamOp, opId, newStreamPath, newStreamName, table, boundaries, false);
+    } else if (cbOp.GetActionCase() == NKikimrSchemeOp::TAlterContinuousBackup::kStop) {
+        NKikimrSchemeOp::TAlterCdcStream alterCdcStreamOp;
+        alterCdcStreamOp.SetTableName(tableName);
+        alterCdcStreamOp.SetStreamName(*lastStreamName);
+        alterCdcStreamOp.MutableDisable();
+        NCdc::DoAlterStream(result, alterCdcStreamOp, opId, workingDirPath, tablePath);
     }
 
     return true;

--- a/ydb/core/tx/schemeshard/schemeshard__operation_backup_backup_collection.cpp
+++ b/ydb/core/tx/schemeshard/schemeshard__operation_backup_backup_collection.cpp
@@ -4,7 +4,6 @@
 #include "schemeshard__operation_create_cdc_stream.h"
 #include "schemeshard_impl.h"
 
-#include <ydb/core/tx/schemeshard/backup/constants.h>
 
 namespace NKikimr::NSchemeShard {
 
@@ -65,6 +64,7 @@ TVector<ISubOperation::TPtr> CreateBackupBackupCollection(TOperationId opId, con
     Y_ABORT_UNLESS(context.SS->BackupCollections.contains(bcPath->PathId));
     const auto& bc = context.SS->BackupCollections[bcPath->PathId];
     bool incrBackupEnabled = bc->Description.HasIncrementalBackupConfig();
+    TString streamName = NBackup::ToX509String(TlsActivationContext->AsActorContext().Now()) + "_continuousBackupImpl";
 
     for (const auto& item : bc->Description.GetExplicitEntryList().GetEntries()) {
         auto& desc = *copyTables.Add();
@@ -85,7 +85,7 @@ TVector<ISubOperation::TPtr> CreateBackupBackupCollection(TOperationId opId, con
             NKikimrSchemeOp::TCreateCdcStream createCdcStreamOp;
             createCdcStreamOp.SetTableName(item.GetPath());
             auto& streamDescription = *createCdcStreamOp.MutableStreamDescription();
-            streamDescription.SetName(NBackup::CB_CDC_STREAM_NAME);
+            streamDescription.SetName(streamName);
             streamDescription.SetMode(NKikimrSchemeOp::ECdcStreamModeUpdate);
             streamDescription.SetFormat(NKikimrSchemeOp::ECdcStreamFormatProto);
 
@@ -105,7 +105,7 @@ TVector<ISubOperation::TPtr> CreateBackupBackupCollection(TOperationId opId, con
             NKikimrSchemeOp::TCreateCdcStream createCdcStreamOp;
             createCdcStreamOp.SetTableName(item.GetPath());
             auto& streamDescription = *createCdcStreamOp.MutableStreamDescription();
-            streamDescription.SetName(NBackup::CB_CDC_STREAM_NAME);
+            streamDescription.SetName(streamName);
             streamDescription.SetMode(NKikimrSchemeOp::ECdcStreamModeUpdate);
             streamDescription.SetFormat(NKikimrSchemeOp::ECdcStreamFormatProto);
 
@@ -123,9 +123,9 @@ TVector<ISubOperation::TPtr> CreateBackupBackupCollection(TOperationId opId, con
                 }
             }
 
-            const auto streamPath = sPath.Child(NBackup::CB_CDC_STREAM_NAME);
+            const auto streamPath = sPath.Child(streamName);
 
-            NCdc::DoCreatePqPart(result, createCdcStreamOp, opId, streamPath, NBackup::CB_CDC_STREAM_NAME, table, boundaries, false);
+            NCdc::DoCreatePqPart(result, createCdcStreamOp, opId, streamPath, streamName, table, boundaries, false);
         }
     }
 

--- a/ydb/core/tx/schemeshard/schemeshard__operation_backup_incremental_backup_collection.cpp
+++ b/ydb/core/tx/schemeshard/schemeshard__operation_backup_incremental_backup_collection.cpp
@@ -4,7 +4,6 @@
 #include "schemeshard__operation_create_cdc_stream.h"
 #include "schemeshard_impl.h"
 
-#include <ydb/core/tx/schemeshard/backup/constants.h>
 
 namespace NKikimr::NSchemeShard {
 

--- a/ydb/core/tx/schemeshard/schemeshard__operation_common.cpp
+++ b/ydb/core/tx/schemeshard/schemeshard__operation_common.cpp
@@ -471,6 +471,9 @@ bool TDone::Process(TOperationContext& context) {
         if (srcPath->PathState == TPathElement::EPathState::EPathStateCopying) {
             context.OnComplete.ReleasePathState(OperationId, srcPath->PathId, TPathElement::EPathState::EPathStateNoChanges);
         }
+        if (txState->TxType == TTxState::TxRotateCdcStream) {
+            context.OnComplete.ReleasePathState(OperationId, srcPath->PathId, TPathElement::EPathState::EPathStateNoChanges);
+        }
     }
 
     // OlapStore tracks all tables that are under operation, make sure to unlink
@@ -795,6 +798,8 @@ void UpdatePartitioningForTableModification(TOperationId operationId, TTxState &
     } else if (txState.TxType == TTxState::TxDropCdcStreamAtTable) {
         commonShardOp = TTxState::ConfigureParts;
     } else if (txState.TxType == TTxState::TxDropCdcStreamAtTableDropSnapshot) {
+        commonShardOp = TTxState::ConfigureParts;
+    } else if (txState.TxType == TTxState::TxRotateCdcStreamAtTable) {
         commonShardOp = TTxState::ConfigureParts;
     } else if (txState.TxType == TTxState::TxRestoreIncrementalBackupAtTable) {
         commonShardOp = TTxState::ConfigureParts;

--- a/ydb/core/tx/schemeshard/schemeshard__operation_common.h
+++ b/ydb/core/tx/schemeshard/schemeshard__operation_common.h
@@ -284,7 +284,7 @@ public:
     bool ProgressState(TOperationContext& context) override;
     bool HandleReply(TEvDataShard::TEvProposeTransactionResult__HandlePtr& ev, TOperationContext& context) override;
 
-private:
+protected:
     const TOperationId OperationId;
 }; // TConfigurePartsAtTable
 

--- a/ydb/core/tx/schemeshard/schemeshard__operation_common_cdc_stream.cpp
+++ b/ydb/core/tx/schemeshard/schemeshard__operation_common_cdc_stream.cpp
@@ -17,6 +17,7 @@ bool IsExpectedTxType(TTxState::ETxType txType) {
     case TTxState::TxAlterCdcStreamAtTableDropSnapshot:
     case TTxState::TxDropCdcStreamAtTable:
     case TTxState::TxDropCdcStreamAtTableDropSnapshot:
+    case TTxState::TxRotateCdcStreamAtTable:
         return true;
     default:
         return false;

--- a/ydb/core/tx/schemeshard/schemeshard__operation_create_cdc_stream.cpp
+++ b/ydb/core/tx/schemeshard/schemeshard__operation_create_cdc_stream.cpp
@@ -879,7 +879,7 @@ std::variant<TStreamPaths, ISubOperation::TPtr> DoNewStreamPathChecks(
     bool acceptExisted,
     bool restore)
 {
-    const auto tablePath = workingDirPath.Child(tableName);
+    const auto tablePath = workingDirPath.Child(tableName, TPath::TSplitChildTag{});
     if (auto reject = RejectOnTablePathChecks(opId, tablePath, restore)) {
         return reject;
     }

--- a/ydb/core/tx/schemeshard/schemeshard__operation_create_continuous_backup.cpp
+++ b/ydb/core/tx/schemeshard/schemeshard__operation_create_continuous_backup.cpp
@@ -1,3 +1,4 @@
+#include "schemeshard__backup_collection_common.h"
 #include "schemeshard__operation_common.h"
 #include "schemeshard__operation_create_cdc_stream.h"
 #include "schemeshard__operation_part.h"
@@ -5,7 +6,6 @@
 
 #include <ydb/core/engine/mkql_proto.h>
 #include <ydb/core/scheme/scheme_types_proto.h>
-#include <ydb/core/tx/schemeshard/backup/constants.h>
 
 #define LOG_D(stream) LOG_DEBUG_S (context.Ctx, NKikimrServices::FLAT_TX_SCHEMESHARD, "[" << context.SS->TabletID() << "] " << stream)
 #define LOG_I(stream) LOG_INFO_S  (context.Ctx, NKikimrServices::FLAT_TX_SCHEMESHARD, "[" << context.SS->TabletID() << "] " << stream)
@@ -25,7 +25,14 @@ TVector<ISubOperation::TPtr> CreateNewContinuousBackup(TOperationId opId, const 
     const auto& cbOp = tx.GetCreateContinuousBackup();
     const auto& tableName = cbOp.GetTableName();
 
-    const auto checksResult = NCdc::DoNewStreamPathChecks(context, opId, workingDirPath, tableName, NBackup::CB_CDC_STREAM_NAME, acceptExisted);
+    TString streamName;
+    if (cbOp.GetContinuousBackupDescription().HasStreamName()) {
+        streamName = cbOp.GetContinuousBackupDescription().GetStreamName();
+    } else {
+        streamName = NBackup::ToX509String(TlsActivationContext->AsActorContext().Now()) + "_continuousBackupImpl";
+    }
+
+    const auto checksResult = NCdc::DoNewStreamPathChecks(context, opId, workingDirPath, tableName, streamName, acceptExisted);
     if (std::holds_alternative<ISubOperation::TPtr>(checksResult)) {
         return {std::get<ISubOperation::TPtr>(checksResult)};
     }
@@ -60,14 +67,14 @@ TVector<ISubOperation::TPtr> CreateNewContinuousBackup(TOperationId opId, const 
     NKikimrSchemeOp::TCreateCdcStream createCdcStreamOp;
     createCdcStreamOp.SetTableName(tableName);
     auto& streamDescription = *createCdcStreamOp.MutableStreamDescription();
-    streamDescription.SetName(NBackup::CB_CDC_STREAM_NAME);
+    streamDescription.SetName(streamName);
     streamDescription.SetMode(NKikimrSchemeOp::ECdcStreamModeUpdate);
     streamDescription.SetFormat(NKikimrSchemeOp::ECdcStreamFormatProto);
 
     TVector<ISubOperation::TPtr> result;
 
     NCdc::DoCreateStream(result, createCdcStreamOp, opId, workingDirPath, tablePath, acceptExisted, false);
-    NCdc::DoCreatePqPart(result, createCdcStreamOp, opId, streamPath, NBackup::CB_CDC_STREAM_NAME, table, boundaries, acceptExisted);
+    NCdc::DoCreatePqPart(result, createCdcStreamOp, opId, streamPath, streamName, table, boundaries, acceptExisted);
 
     return result;
 }

--- a/ydb/core/tx/schemeshard/schemeshard__operation_part.h
+++ b/ydb/core/tx/schemeshard/schemeshard__operation_part.h
@@ -448,6 +448,12 @@ ISubOperation::TPtr CreateDropCdcStreamImpl(TOperationId id, const TTxTransactio
 ISubOperation::TPtr CreateDropCdcStreamImpl(TOperationId id, TTxState::ETxState state);
 ISubOperation::TPtr CreateDropCdcStreamAtTable(TOperationId id, const TTxTransaction& tx, bool dropSnapshot);
 ISubOperation::TPtr CreateDropCdcStreamAtTable(TOperationId id, TTxState::ETxState state, bool dropSnapshot);
+// Rotate
+TVector<ISubOperation::TPtr> CreateRotateCdcStream(TOperationId id, const TTxTransaction& tx, TOperationContext& context);
+ISubOperation::TPtr CreateRotateCdcStreamImpl(TOperationId id, const TTxTransaction& tx);
+ISubOperation::TPtr CreateRotateCdcStreamImpl(TOperationId id, TTxState::ETxState state);
+ISubOperation::TPtr CreateRotateCdcStreamAtTable(TOperationId id, const TTxTransaction& tx);
+ISubOperation::TPtr CreateRotateCdcStreamAtTable(TOperationId id, TTxState::ETxState state);
 
 /// Continuous Backup
 // Create

--- a/ydb/core/tx/schemeshard/schemeshard__operation_rotate_cdc_stream.cpp
+++ b/ydb/core/tx/schemeshard/schemeshard__operation_rotate_cdc_stream.cpp
@@ -1,0 +1,815 @@
+#include "schemeshard__operation_rotate_cdc_stream.h"
+
+#include "schemeshard__operation_common.h"
+#include "schemeshard__operation_part.h"
+#include "schemeshard_cdc_stream_common.h"
+#include "schemeshard_utils.h"  // for TransactionTemplate
+
+#define LOG_D(stream) LOG_DEBUG_S (context.Ctx, NKikimrServices::FLAT_TX_SCHEMESHARD, "[" << context.SS->TabletID() << "] " << stream)
+#define LOG_I(stream) LOG_INFO_S  (context.Ctx, NKikimrServices::FLAT_TX_SCHEMESHARD, "[" << context.SS->TabletID() << "] " << stream)
+#define LOG_N(stream) LOG_NOTICE_S(context.Ctx, NKikimrServices::FLAT_TX_SCHEMESHARD, "[" << context.SS->TabletID() << "] " << stream)
+
+namespace NKikimr::NSchemeShard {
+
+namespace NCdc {
+
+namespace {
+
+class TPropose: public TSubOperationState {
+    TString DebugHint() const override {
+        return TStringBuilder()
+            << "RotateCdcStream TPropose"
+            << " opId# " << OperationId << " ";
+    }
+
+public:
+    explicit TPropose(TOperationId id)
+        : OperationId(id)
+    {
+        IgnoreMessages(DebugHint(), {});
+    }
+
+    bool ProgressState(TOperationContext& context) override {
+        LOG_I(DebugHint() << "ProgressState");
+
+        const auto* txState = context.SS->FindTx(OperationId);
+        Y_ABORT_UNLESS(txState);
+        Y_ABORT_UNLESS(txState->TxType == TTxState::TxRotateCdcStream);
+
+        // TODO(KIKIMR-12278): shards
+
+        context.OnComplete.ProposeToCoordinator(OperationId, txState->TargetPathId, TStepId(0));
+        return false;
+    }
+
+    bool HandleReply(TEvPrivate::TEvOperationPlan::TPtr& ev, TOperationContext& context) override {
+        const auto step = TStepId(ev->Get()->StepId);
+
+        LOG_I(DebugHint() << "HandleReply TEvOperationPlan"
+            << ": step# " << step);
+
+        const auto* txState = context.SS->FindTx(OperationId);
+        Y_ABORT_UNLESS(txState);
+        Y_ABORT_UNLESS(txState->TxType == TTxState::TxRotateCdcStream);
+        const auto& oldStreamPathId = txState->SourcePathId;
+        const auto& newStreamPathId = txState->TargetPathId;
+
+        Y_ABORT_UNLESS(context.SS->PathsById.contains(oldStreamPathId));
+        auto oldStreamPath = context.SS->PathsById.at(oldStreamPathId);
+        Y_ABORT_UNLESS(context.SS->PathsById.contains(newStreamPathId));
+        auto newStreamPath = context.SS->PathsById.at(newStreamPathId);
+
+        Y_ABORT_UNLESS(context.SS->CdcStreams.contains(oldStreamPathId));
+        auto oldStream = context.SS->CdcStreams.at(oldStreamPathId);
+        Y_ABORT_UNLESS(context.SS->CdcStreams.contains(newStreamPathId));
+        auto newStream = context.SS->CdcStreams.at(newStreamPathId);
+
+        NIceDb::TNiceDb db(context.GetDB());
+
+        newStreamPath->StepCreated = step;
+        context.SS->PersistCreateStep(db, newStreamPathId, step);
+
+        context.SS->PersistCdcStream(db, newStreamPathId);
+        context.SS->CdcStreams[newStreamPathId] = newStream->AlterData;
+        context.SS->TabletCounters->Simple()[COUNTER_CDC_STREAMS_COUNT].Add(1);
+
+        context.SS->PersistCdcStream(db, oldStreamPathId);
+        context.SS->CdcStreams[oldStreamPathId]->FinishAlter();
+
+        context.SS->ClearDescribePathCaches(oldStreamPath);
+        context.SS->ClearDescribePathCaches(newStreamPath);
+        context.OnComplete.PublishToSchemeBoard(OperationId, oldStreamPathId);
+        context.OnComplete.PublishToSchemeBoard(OperationId, newStreamPathId);
+
+        context.SS->ChangeTxState(db, OperationId, TTxState::Done);
+        return true;
+    }
+
+private:
+    const TOperationId OperationId;
+
+}; // TPropose
+
+class TRotateCdcStream: public TSubOperation {
+    static TTxState::ETxState NextState() {
+        return TTxState::Propose;
+    }
+
+    TTxState::ETxState NextState(TTxState::ETxState state) const override {
+        switch (state) {
+        case TTxState::Propose:
+            return TTxState::Done;
+        default:
+            return TTxState::Invalid;
+        }
+    }
+
+    TSubOperationState::TPtr SelectStateFunc(TTxState::ETxState state) override {
+        switch (state) {
+        case TTxState::Propose:
+            return MakeHolder<TPropose>(OperationId);
+        case TTxState::Done:
+            return MakeHolder<TDone>(OperationId);
+        default:
+            return nullptr;
+        }
+    }
+
+public:
+    using TSubOperation::TSubOperation;
+
+    THolder<TProposeResponse> Propose(const TString& owner, TOperationContext& context) override {
+        const auto& workingDir = Transaction.GetWorkingDir();
+        const auto& op = Transaction.GetRotateCdcStream();
+        const auto& oldStreamName = op.GetOldStreamName();
+        const auto& newStreamDesc = op.GetNewStreamDescription();
+        const auto& newStreamName = newStreamDesc.GetName();
+        const auto acceptExisted = !Transaction.GetFailOnExist();
+
+        LOG_N("TRotateCdcStream Propose"
+            << ": opId# " << OperationId
+            << ", oldStream# " << workingDir << "/" << oldStreamName
+            << ", newStream# " << workingDir << "/" << newStreamName);
+
+        auto result = MakeHolder<TProposeResponse>(NKikimrScheme::StatusAccepted, ui64(OperationId.GetTxId()), context.SS->TabletID());
+
+        const auto oldStreamPath = TPath::Resolve(workingDir, context.SS).Dive(oldStreamName);
+        {
+            const auto checks = oldStreamPath.Check();
+            checks
+                .NotEmpty()
+                .NotUnderDomainUpgrade()
+                .IsAtLocalSchemeShard()
+                .IsResolved()
+                .NotDeleted()
+                .IsCdcStream()
+                .NotUnderDeleting();
+
+            if (!checks) {
+                result->SetError(checks.GetStatus(), checks.GetError());
+                return result;
+            }
+        }
+
+        const auto tablePath = oldStreamPath.Parent();
+        {
+            const auto checks = tablePath.Check();
+            checks
+                .NotEmpty()
+                .NotUnderDomainUpgrade()
+                .IsAtLocalSchemeShard()
+                .IsResolved()
+                .NotDeleted()
+                .IsTable()
+                .NotAsyncReplicaTable()
+                .NotUnderDeleting();
+
+            // Allow CDC operations on tables that are under incremental backup/restore
+            if (checks && tablePath.IsUnderOperation() &&
+                !tablePath.IsUnderOutgoingIncrementalRestore()) {
+                checks.NotUnderOperation();
+            }
+
+            if (checks && !tablePath.IsInsideTableIndexPath()) {
+                checks.IsCommonSensePath();
+            }
+
+            if (!checks) {
+                result->SetError(checks.GetStatus(), checks.GetError());
+                return result;
+            }
+        }
+
+        auto newStreamPath = tablePath.Child(newStreamName);
+        {
+            const auto checks = newStreamPath.Check();
+            checks
+                .IsAtLocalSchemeShard();
+
+            if (newStreamPath.IsResolved()) {
+                checks
+                    .IsResolved()
+                    .NotUnderDeleting()
+                    .FailOnExist(TPathElement::EPathType::EPathTypeCdcStream, acceptExisted);
+            } else {
+                checks
+                    .NotEmpty()
+                    .NotResolved();
+            }
+
+            if (checks) {
+                checks
+                    .IsValidLeafName(context.UserToken.Get())
+                    .PathsLimit()
+                    .DirChildrenLimit();
+            }
+
+            if (!checks) {
+                result->SetError(checks.GetStatus(), checks.GetError());
+                if (newStreamPath.IsResolved()) {
+                    result->SetPathCreateTxId(ui64(newStreamPath.Base()->CreateTxId));
+                    result->SetPathId(newStreamPath.Base()->PathId.LocalPathId);
+                }
+                return result;
+            }
+        }
+
+
+        Y_ABORT_UNLESS(context.SS->CdcStreams.contains(oldStreamPath.Base()->PathId));
+        auto oldStream = context.SS->CdcStreams.at(oldStreamPath.Base()->PathId);
+
+        TCdcStreamInfo::EState requiredState = TCdcStreamInfo::EState::ECdcStreamStateDisabled;
+        TCdcStreamInfo::EState newState = TCdcStreamInfo::EState::ECdcStreamStateInvalid;
+
+        if (oldStream->State == TCdcStreamInfo::EState::ECdcStreamStateReady) {
+            newState = requiredState;
+        }
+
+        if (newState == TCdcStreamInfo::EState::ECdcStreamStateInvalid) {
+            result->SetError(NKikimrScheme::StatusPreconditionFailed, TStringBuilder()
+                << "Cannot switch state"
+                << ": from# " << oldStream->State
+                << ", to# " << requiredState);
+            return result;
+        }
+
+        switch (newStreamDesc.GetMode()) {
+        case NKikimrSchemeOp::ECdcStreamModeKeysOnly:
+        case NKikimrSchemeOp::ECdcStreamModeNewImage:
+        case NKikimrSchemeOp::ECdcStreamModeOldImage:
+        case NKikimrSchemeOp::ECdcStreamModeNewAndOldImages:
+        case NKikimrSchemeOp::ECdcStreamModeRestoreIncrBackup:
+            break;
+        case NKikimrSchemeOp::ECdcStreamModeUpdate:
+            if (newStreamDesc.GetFormat() == NKikimrSchemeOp::ECdcStreamFormatDynamoDBStreamsJson) {
+                result->SetError(NKikimrScheme::StatusInvalidParameter,
+                    "DYNAMODB_STREAMS_JSON format incompatible with specified stream mode");
+                return result;
+            }
+            if (newStreamDesc.GetFormat() == NKikimrSchemeOp::ECdcStreamFormatDebeziumJson) {
+                result->SetError(NKikimrScheme::StatusInvalidParameter,
+                    "DEBEZIUM_JSON format incompatible with specified stream mode");
+                return result;
+            }
+            break;
+        default:
+            result->SetError(NKikimrScheme::StatusInvalidParameter, TStringBuilder()
+                << "Invalid stream mode: " << static_cast<ui32>(newStreamDesc.GetMode()));
+            return result;
+        }
+
+        switch (newStreamDesc.GetFormat()) {
+        case NKikimrSchemeOp::ECdcStreamFormatProto:
+        case NKikimrSchemeOp::ECdcStreamFormatJson:
+            break;
+        case NKikimrSchemeOp::ECdcStreamFormatDynamoDBStreamsJson:
+            if (!AppData()->FeatureFlags.GetEnableChangefeedDynamoDBStreamsFormat()) {
+                result->SetError(NKikimrScheme::StatusPreconditionFailed,
+                    "DYNAMODB_STREAMS_JSON format is not supported yet");
+                return result;
+            }
+            if (tablePath.Base()->DocumentApiVersion < 1) {
+                result->SetError(NKikimrScheme::StatusInvalidParameter,
+                    "DYNAMODB_STREAMS_JSON format incompatible with non-document table");
+                return result;
+            }
+            break;
+        case NKikimrSchemeOp::ECdcStreamFormatDebeziumJson:
+            if (!AppData()->FeatureFlags.GetEnableChangefeedDebeziumJsonFormat()) {
+                result->SetError(NKikimrScheme::StatusPreconditionFailed,
+                    "DEBEZIUM_JSON format is not supported yet");
+                return result;
+            }
+            break;
+        default:
+            result->SetError(NKikimrScheme::StatusInvalidParameter, TStringBuilder()
+                << "Invalid stream format: " << static_cast<ui32>(newStreamDesc.GetFormat()));
+            return result;
+        }
+
+        if (!newStreamDesc.GetAwsRegion().empty()) {
+            switch (newStreamDesc.GetFormat()) {
+            case NKikimrSchemeOp::ECdcStreamFormatDynamoDBStreamsJson:
+                break;
+            default:
+                result->SetError(NKikimrScheme::StatusInvalidParameter,
+                    "AWS_REGION option incompatible with specified stream format");
+                return result;
+            }
+        }
+
+        if (newStreamDesc.GetVirtualTimestamps()) {
+            switch (newStreamDesc.GetFormat()) {
+            case NKikimrSchemeOp::ECdcStreamFormatProto:
+            case NKikimrSchemeOp::ECdcStreamFormatJson:
+                break;
+            default:
+                result->SetError(NKikimrScheme::StatusInvalidParameter,
+                    "VIRTUAL_TIMESTAMPS incompatible with specified stream format");
+                return result;
+            }
+        }
+
+        if (newStreamDesc.GetResolvedTimestampsIntervalMs()) {
+            switch (newStreamDesc.GetFormat()) {
+            case NKikimrSchemeOp::ECdcStreamFormatProto:
+            case NKikimrSchemeOp::ECdcStreamFormatJson:
+                break;
+            default:
+                result->SetError(NKikimrScheme::StatusInvalidParameter,
+                    "RESOLVED_TIMESTAMPS incompatible with specified stream format");
+                return result;
+            }
+        }
+
+        if (newStreamDesc.GetSchemaChanges()) {
+            switch (newStreamDesc.GetFormat()) {
+            case NKikimrSchemeOp::ECdcStreamFormatJson:
+                break;
+            default:
+                result->SetError(NKikimrScheme::StatusInvalidParameter,
+                    "SCHEMA_CHANGES incompatible with specified stream format");
+                return result;
+            }
+        }
+
+        TString errStr;
+        if (!context.SS->CheckLocks(tablePath.Base()->PathId, Transaction, errStr)) {
+            result->SetError(NKikimrScheme::StatusMultipleModifications, errStr);
+            return result;
+        }
+
+        TUserAttributes::TPtr userAttrs = new TUserAttributes(1);
+        if (!userAttrs->ApplyPatch(EUserAttributesOp::CreateChangefeed, newStreamDesc.GetUserAttributes(), errStr) ||
+            !userAttrs->CheckLimits(errStr))
+        {
+            result->SetError(NKikimrScheme::StatusInvalidParameter, errStr);
+            return result;
+        }
+
+        if (!AppData()->FeatureFlags.GetEnableTopicAutopartitioningForCDC() && op.GetNewStreamTopicAutoPartitioning()) {
+            result->SetError(NKikimrScheme::StatusInvalidParameter, "Topic autopartitioning for CDC is disabled");
+            return result;
+        }
+
+        auto guard = context.DbGuard();
+        context.MemChanges.GrabPath(context.SS, oldStreamPath.Base()->PathId);
+        context.MemChanges.GrabCdcStream(context.SS, oldStreamPath.Base()->PathId);
+        context.MemChanges.GrabNewTxState(context.SS, OperationId);
+
+        const auto pathId = context.SS->AllocatePathId();
+        context.MemChanges.GrabNewPath(context.SS, pathId);
+        context.MemChanges.GrabPath(context.SS, tablePath.Base()->PathId);
+        context.MemChanges.GrabNewTxState(context.SS, OperationId);
+        context.MemChanges.GrabDomain(context.SS, newStreamPath.GetPathIdForDomain());
+        context.MemChanges.GrabNewCdcStream(context.SS, pathId);
+
+        context.DbChanges.PersistPath(oldStreamPath.Base()->PathId);
+        context.DbChanges.PersistAlterCdcStream(oldStreamPath.Base()->PathId);
+        context.DbChanges.PersistTxState(OperationId);
+
+        context.DbChanges.PersistPath(pathId);
+        context.DbChanges.PersistPath(tablePath.Base()->PathId);
+        context.DbChanges.PersistApplyUserAttrs(pathId);
+        context.DbChanges.PersistAlterCdcStream(pathId);
+        context.DbChanges.PersistTxState(OperationId);
+
+        auto streamAlter = oldStream->CreateNextVersion();
+        Y_ABORT_UNLESS(streamAlter);
+        streamAlter->State = newState;
+
+        auto newStream = TCdcStreamInfo::Create(newStreamDesc);
+        Y_ABORT_UNLESS(newStream);
+        context.SS->CdcStreams[pathId] = newStream;
+
+        newStreamPath.MaterializeLeaf(owner, pathId);
+        result->SetPathId(pathId.LocalPathId);
+
+        Y_ABORT_UNLESS(!context.SS->FindTx(OperationId));
+        auto& txState = context.SS->CreateTx(OperationId, TTxState::TxRotateCdcStream,
+            newStreamPath.Base()->PathId, oldStreamPath.Base()->PathId);
+        txState.State = TTxState::Propose;
+        txState.MinStep = TStepId(1);
+
+        oldStreamPath.Base()->PathState = TPathElement::EPathState::EPathStateAlter;
+        oldStreamPath.Base()->LastTxId = OperationId.GetTxId();
+
+        newStreamPath.Base()->PathState = NKikimrSchemeOp::EPathStateCreate;
+        newStreamPath.Base()->CreateTxId = OperationId.GetTxId();
+        newStreamPath.Base()->LastTxId = OperationId.GetTxId();
+        newStreamPath.Base()->PathType = TPathElement::EPathType::EPathTypeCdcStream;
+        newStreamPath.Base()->UserAttrs->AlterData = userAttrs;
+
+        context.SS->IncrementPathDbRefCount(pathId);
+
+        newStreamPath.DomainInfo()->IncPathsInside(context.SS);
+        IncAliveChildrenSafeWithUndo(OperationId, tablePath, context); // for correct discard of ChildrenExist prop
+
+        context.OnComplete.ActivateTx(OperationId);
+
+        SetState(NextState());
+        return result;
+    }
+
+    void AbortPropose(TOperationContext& context) override {
+        LOG_N("TRotateCdcStream AbortPropose"
+            << ": opId# " << OperationId);
+    }
+
+    void AbortUnsafe(TTxId txId, TOperationContext& context) override {
+        LOG_N("TRotateCdcStream AbortUnsafe"
+            << ": opId# " << OperationId
+            << ", txId# " << txId);
+        context.OnComplete.DoneOperation(OperationId);
+    }
+
+}; // TRotateCdcStream
+
+class TConfigurePartsAtTable: public NCdcStreamState::TConfigurePartsAtTable {
+protected:
+    void FillNotice(const TPathId& pathId, NKikimrTxDataShard::TFlatSchemeTransaction& tx, TOperationContext& context) const override {
+        Y_ABORT_UNLESS(context.SS->PathsById.contains(pathId));
+        auto path = context.SS->PathsById.at(pathId);
+
+        Y_ABORT_UNLESS(context.SS->Tables.contains(pathId));
+        auto table = context.SS->Tables.at(pathId);
+
+        auto& notice = *tx.MutableRotateCdcStreamNotice();
+        pathId.ToProto(notice.MutablePathId());
+        notice.SetTableSchemaVersion(table->AlterVersion + 1);
+
+        auto* txState = context.SS->FindTx(OperationId);
+        Y_ABORT_UNLESS(txState);
+        Y_ABORT_UNLESS(txState->TxType == TTxState::TxRotateCdcStreamAtTable);
+        auto newStreamPathId = txState->CdcPathId;
+        auto oldStreamPathId = txState->SourcePathId;
+        oldStreamPathId.ToProto(notice.MutableOldStreamPathId());
+
+        Y_ABORT_UNLESS(context.SS->PathsById.contains(newStreamPathId));
+        Y_ABORT_UNLESS(context.SS->CdcStreams.contains(newStreamPathId));
+        auto newStreamPath = context.SS->PathsById.at(newStreamPathId);
+        auto newStream = context.SS->CdcStreams.at(newStreamPathId);
+
+        Y_ABORT_UNLESS(newStream->AlterData);
+        context.SS->DescribeCdcStream(newStreamPathId, newStreamPath->Name, newStream->AlterData, *notice.MutableNewStreamDescription());
+    }
+
+public:
+    using NCdcStreamState::TConfigurePartsAtTable::TConfigurePartsAtTable;
+
+}; // TConfigurePartsAtTable
+
+class TRotateCdcStreamAtTable: public TSubOperation {
+    static TTxState::ETxState NextState() {
+        return TTxState::ConfigureParts;
+    }
+
+    TTxState::ETxState NextState(TTxState::ETxState state) const override {
+        switch (state) {
+        case TTxState::Waiting:
+        case TTxState::ConfigureParts:
+            return TTxState::Propose;
+        case TTxState::Propose:
+            return TTxState::ProposedWaitParts;
+        case TTxState::ProposedWaitParts:
+            return TTxState::Done;
+        default:
+            return TTxState::Invalid;
+        }
+
+        return TTxState::Invalid;
+    }
+
+    TSubOperationState::TPtr SelectStateFunc(TTxState::ETxState state) override {
+        switch (state) {
+        case TTxState::Waiting:
+        case TTxState::ConfigureParts:
+            return MakeHolder<TConfigurePartsAtTable>(OperationId);
+        case TTxState::Propose:
+            return MakeHolder<NCdcStreamState::TProposeAtTable>(OperationId);
+        case TTxState::ProposedWaitParts:
+            return MakeHolder<NTableState::TProposedWaitParts>(OperationId);
+        case TTxState::Done:
+            return MakeHolder<TDone>(OperationId);
+        default:
+            return nullptr;
+        }
+    }
+
+public:
+    explicit TRotateCdcStreamAtTable(TOperationId id, const TTxTransaction& tx)
+        : TSubOperation(id, tx)
+    {
+    }
+
+    explicit TRotateCdcStreamAtTable(TOperationId id, TTxState::ETxState state)
+        : TSubOperation(id, state)
+    {
+    }
+
+    THolder<TProposeResponse> Propose(const TString&, TOperationContext& context) override {
+        const auto& workingDir = Transaction.GetWorkingDir();
+        const auto& op = Transaction.GetRotateCdcStream();
+        const auto& tableName = op.GetTableName();
+        const auto& oldStreamName = op.GetOldStreamName();
+        const auto& newStreamName = op.GetNewStreamDescription().GetName();
+
+        LOG_N("TRotateCdcStreamAtTable Propose"
+            << ": opId# " << OperationId
+            << ", oldStream# " << workingDir << "/" << tableName << "/" << oldStreamName
+            << ", newStream# " << workingDir << "/" << tableName << "/" << newStreamName);
+
+        auto result = MakeHolder<TProposeResponse>(NKikimrScheme::StatusAccepted, ui64(OperationId.GetTxId()), context.SS->TabletID());
+
+        const auto workingDirPath = TPath::Resolve(workingDir, context.SS);
+        {
+            const auto checks = workingDirPath.Check();
+            NCdcStreamAtTable::CheckWorkingDirOnPropose(
+                checks,
+                workingDirPath.IsTableIndex(Nothing(), false));
+        }
+
+        const auto tablePath = TPath::Resolve(workingDir, context.SS).Child(tableName, TPath::TSplitChildTag{});
+        {
+            const auto checks = tablePath.Check();
+            checks
+                .NotEmpty()
+                .NotUnderDomainUpgrade()
+                .IsAtLocalSchemeShard()
+                .IsResolved()
+                .NotDeleted()
+                .IsTable()
+                .NotAsyncReplicaTable()
+                .NotUnderDeleting();
+
+            // Allow CDC operations on tables that are under incremental backup/restore
+            if (checks && tablePath.IsUnderOperation() &&
+                !tablePath.IsUnderOutgoingIncrementalRestore()) {
+                checks.NotUnderOperation();
+            }
+
+            if (checks && !tablePath.IsInsideTableIndexPath()) {
+                checks.IsCommonSensePath();
+            }
+
+            if (!checks) {
+                result->SetError(checks.GetStatus(), checks.GetError());
+                return result;
+            }
+        }
+
+        const auto oldStreamPath = tablePath.Child(oldStreamName);
+        {
+            const auto checks = oldStreamPath.Check();
+            checks
+                .NotEmpty()
+                .NotUnderDomainUpgrade()
+                .IsAtLocalSchemeShard()
+                .IsResolved()
+                .NotDeleted()
+                .IsCdcStream()
+                .IsUnderOperation()
+                .IsUnderTheSameOperation(OperationId.GetTxId());
+
+            if (!checks) {
+                result->SetError(checks.GetStatus(), checks.GetError());
+                return result;
+            }
+        }
+
+        const auto newStreamPath = tablePath.Child(newStreamName);
+        {
+            const auto checks = newStreamPath.Check();
+            checks
+                .NotEmpty()
+                .NotUnderDomainUpgrade()
+                .IsAtLocalSchemeShard()
+                .IsResolved()
+                .NotDeleted()
+                .IsCdcStream()
+                .IsUnderOperation()
+                .IsUnderTheSameOperation(OperationId.GetTxId());
+
+            if (!checks) {
+                result->SetError(checks.GetStatus(), checks.GetError());
+                return result;
+            }
+        }
+
+        TString errStr;
+        if (!context.SS->CheckApplyIf(Transaction, errStr)) {
+            result->SetError(NKikimrScheme::StatusPreconditionFailed, errStr);
+            return result;
+        }
+
+        if (!context.SS->CheckLocks(tablePath.Base()->PathId, Transaction, errStr)) {
+            result->SetError(NKikimrScheme::StatusMultipleModifications, errStr);
+            return result;
+        }
+
+        NKikimrScheme::EStatus status;
+        if (!context.SS->CanCreateSnapshot(tablePath.Base()->PathId, OperationId.GetTxId(), status, errStr)) {
+            result->SetError(status, errStr);
+            return result;
+        }
+
+        auto guard = context.DbGuard();
+        context.MemChanges.GrabPath(context.SS, tablePath.Base()->PathId);
+        context.MemChanges.GrabNewTxState(context.SS, OperationId);
+
+        context.DbChanges.PersistPath(tablePath.Base()->PathId);
+        context.DbChanges.PersistTxState(OperationId);
+
+        Y_ABORT_UNLESS(context.SS->Tables.contains(tablePath.Base()->PathId));
+        auto table = context.SS->Tables.at(tablePath.Base()->PathId);
+
+        Y_ABORT_UNLESS(table->AlterVersion != 0);
+        Y_ABORT_UNLESS(!table->AlterData);
+
+        Y_ABORT_UNLESS(context.SS->CdcStreams.contains(oldStreamPath.Base()->PathId));
+        auto stream = context.SS->CdcStreams.at(oldStreamPath.Base()->PathId);
+
+        Y_ABORT_UNLESS(stream->AlterVersion != 0);
+        Y_ABORT_UNLESS(stream->AlterData);
+
+        const auto txType = TTxState::TxRotateCdcStreamAtTable;
+
+        Y_ABORT_UNLESS(!context.SS->FindTx(OperationId));
+        auto& txState = context.SS->CreateTx(OperationId, txType, tablePath.Base()->PathId, oldStreamPath.Base()->PathId);
+        txState.CdcPathId = newStreamPath.Base()->PathId;
+        txState.State = TTxState::ConfigureParts;
+
+        tablePath.Base()->PathState = NKikimrSchemeOp::EPathStateAlter;
+        tablePath.Base()->LastTxId = OperationId.GetTxId();
+
+        for (const auto& splitOpId : table->GetSplitOpsInFlight()) {
+            context.OnComplete.Dependence(splitOpId.GetTxId(), OperationId.GetTxId());
+        }
+
+        context.OnComplete.ActivateTx(OperationId);
+
+        SetState(NextState());
+        return result;
+    }
+
+    void AbortPropose(TOperationContext& context) override {
+        LOG_N("TRotateCdcStreamAtTable AbortPropose"
+            << ": opId# " << OperationId);
+    }
+
+    void AbortUnsafe(TTxId txId, TOperationContext& context) override {
+        LOG_N("TRotateCdcStreamAtTable AbortUnsafe"
+            << ": opId# " << OperationId
+            << ", txId# " << txId);
+        context.OnComplete.DoneOperation(OperationId);
+    }
+}; // TRotateCdcStreamAtTable
+
+} // namespace anonymous
+
+void DoRotateStream(
+        TVector<ISubOperation::TPtr>& result,
+        const NKikimrSchemeOp::TRotateCdcStream& op,
+        const TOperationId& opId,
+        const TPath& workingDirPath,
+        const TPath& tablePath)
+{
+    {
+        auto outTx = TransactionTemplate(tablePath.PathString(), NKikimrSchemeOp::EOperationType::ESchemeOpRotateCdcStreamImpl);
+        outTx.MutableRotateCdcStream()->CopyFrom(op);
+        result.push_back(CreateRotateCdcStreamImpl(NextPartId(opId, result), outTx));
+    }
+
+    {
+        auto outTx = TransactionTemplate(workingDirPath.PathString(), NKikimrSchemeOp::EOperationType::ESchemeOpRotateCdcStreamAtTable);
+        outTx.MutableRotateCdcStream()->CopyFrom(op);
+        result.push_back(CreateRotateCdcStreamAtTable(NextPartId(opId, result), outTx));
+    }
+}
+
+} // namespace NCdc
+
+using namespace NCdc;
+
+ISubOperation::TPtr CreateRotateCdcStreamImpl(TOperationId id, const TTxTransaction& tx) {
+    return MakeSubOperation<TRotateCdcStream>(id, tx);
+}
+
+ISubOperation::TPtr CreateRotateCdcStreamImpl(TOperationId id, TTxState::ETxState state) {
+    return MakeSubOperation<TRotateCdcStream>(id, state);
+}
+
+ISubOperation::TPtr CreateRotateCdcStreamAtTable(TOperationId id, const TTxTransaction& tx) {
+    return MakeSubOperation<TRotateCdcStreamAtTable>(id, tx);
+}
+
+ISubOperation::TPtr CreateRotateCdcStreamAtTable(TOperationId id, TTxState::ETxState state) {
+    return MakeSubOperation<TRotateCdcStreamAtTable>(id, state);
+}
+
+TVector<ISubOperation::TPtr> CreateRotateCdcStream(TOperationId opId, const TTxTransaction& tx, TOperationContext& context) {
+    Y_ABORT_UNLESS(tx.GetOperationType() == NKikimrSchemeOp::EOperationType::ESchemeOpRotateCdcStream);
+
+    LOG_D("CreateRotateCdcStream"
+        << ": opId# " << opId
+        << ", tx# " << tx.ShortDebugString());
+
+    const auto acceptExisted = !tx.GetFailOnExist();
+    const auto& op = tx.GetRotateCdcStream();
+    const auto& tableName = op.GetTableName();
+    const auto& oldStreamName = op.GetOldStreamName();
+    const auto& newStreamName = op.GetNewStreamDescription().GetName();
+
+    const auto workingDirPath = TPath::Resolve(tx.GetWorkingDir(), context.SS);
+
+    const auto tablePath = workingDirPath.Child(tableName);
+    {
+        const auto checks = tablePath.Check();
+        checks
+            .NotEmpty()
+            .NotUnderDomainUpgrade()
+            .IsAtLocalSchemeShard()
+            .IsResolved()
+            .NotDeleted()
+            .IsTable()
+            .NotAsyncReplicaTable()
+            .NotUnderDeleting();
+
+        // Allow CDC operations on tables that are under incremental backup/restore
+        if (checks && tablePath.IsUnderOperation() &&
+            !tablePath.IsUnderOutgoingIncrementalRestore()) {
+            checks.NotUnderOperation();
+        }
+
+        if (checks && !tablePath.IsInsideTableIndexPath()) {
+            checks.IsCommonSensePath();
+        }
+
+        if (!checks) {
+            return {CreateReject(opId, checks.GetStatus(), checks.GetError())};
+        }
+    }
+
+    const auto oldStreamPath = tablePath.Child(oldStreamName);
+    {
+        const auto checks = oldStreamPath.Check();
+        checks
+            .NotEmpty()
+            .NotUnderDomainUpgrade()
+            .IsAtLocalSchemeShard()
+            .IsResolved()
+            .NotDeleted()
+            .IsCdcStream()
+            .NotUnderDeleting();
+
+        if (!checks) {
+            return {CreateReject(opId, checks.GetStatus(), checks.GetError())};
+        }
+    }
+
+    const auto newStreamPath = tablePath.Child(newStreamName);
+    {
+        const auto checks = newStreamPath.Check();
+        checks
+            .IsAtLocalSchemeShard();
+
+        if (newStreamPath.IsResolved()) {
+            checks
+                .IsResolved()
+                .NotUnderDeleting()
+                .FailOnExist(TPathElement::EPathType::EPathTypeCdcStream, acceptExisted);
+        } else {
+            checks
+                .NotEmpty()
+                .NotResolved();
+        }
+
+        if (checks) {
+            checks
+                .IsValidLeafName(context.UserToken.Get())
+                .PathsLimit()
+                .DirChildrenLimit();
+        }
+
+        if (!checks) {
+            return {CreateReject(opId, checks.GetStatus(), checks.GetError())};
+        }
+    }
+
+    TString errStr;
+    if (!context.SS->CheckApplyIf(tx, errStr)) {
+        return {CreateReject(opId, NKikimrScheme::StatusPreconditionFailed, errStr)};
+    }
+
+    if (!context.SS->CheckLocks(tablePath.Base()->PathId, tx, errStr)) {
+        return {CreateReject(opId, NKikimrScheme::StatusMultipleModifications, errStr)};
+    }
+
+    TVector<ISubOperation::TPtr> result;
+
+    DoRotateStream(result, op, opId, workingDirPath, tablePath);
+
+    return result;
+}
+
+} // namespace NKikimr::NSchemeShard

--- a/ydb/core/tx/schemeshard/schemeshard__operation_rotate_cdc_stream.h
+++ b/ydb/core/tx/schemeshard/schemeshard__operation_rotate_cdc_stream.h
@@ -2,9 +2,6 @@
 
 #include "schemeshard__operation_part.h"
 
-#include <ydb/core/engine/mkql_proto.h>
-#include <ydb/core/scheme/scheme_types_proto.h>
-
 namespace NKikimr::NSchemeShard::NCdc {
 
 void DoRotateStream(

--- a/ydb/core/tx/schemeshard/schemeshard__operation_rotate_cdc_stream.h
+++ b/ydb/core/tx/schemeshard/schemeshard__operation_rotate_cdc_stream.h
@@ -1,0 +1,17 @@
+#pragma once
+
+#include "schemeshard__operation_part.h"
+
+#include <ydb/core/engine/mkql_proto.h>
+#include <ydb/core/scheme/scheme_types_proto.h>
+
+namespace NKikimr::NSchemeShard::NCdc {
+
+void DoRotateStream(
+    TVector<ISubOperation::TPtr>& result,
+    const NKikimrSchemeOp::TRotateCdcStream& op,
+    const TOperationId& opId,
+    const TPath& workingDirPath,
+    const TPath& tablePath);
+
+} // namespace NKikimr::NSchemesShard::NCdc

--- a/ydb/core/tx/schemeshard/schemeshard_audit_log_fragment.cpp
+++ b/ydb/core/tx/schemeshard/schemeshard_audit_log_fragment.cpp
@@ -507,11 +507,11 @@ TVector<TString> ExtractChangingPaths(const NKikimrSchemeOp::TModifyScheme& tx) 
         break;
     case NKikimrSchemeOp::EOperationType::ESchemeOpRotateCdcStream:
         result.emplace_back(NKikimr::JoinPath({tx.GetWorkingDir(), tx.GetRotateCdcStream().GetTableName(), tx.GetRotateCdcStream().GetOldStreamName()}));
-        result.emplace_back(NKikimr::JoinPath({tx.GetWorkingDir(), tx.GetRotateCdcStream().GetTableName(), tx.GetRotateCdcStream().GetNewStreamDescription().GetName()}));
+        result.emplace_back(NKikimr::JoinPath({tx.GetWorkingDir(), tx.GetRotateCdcStream().GetTableName(), tx.GetRotateCdcStream().GetNewStream().GetStreamDescription().GetName()}));
         break;
     case NKikimrSchemeOp::EOperationType::ESchemeOpRotateCdcStreamImpl:
         result.emplace_back(NKikimr::JoinPath({tx.GetWorkingDir(), tx.GetRotateCdcStream().GetOldStreamName()}));
-        result.emplace_back(NKikimr::JoinPath({tx.GetWorkingDir(), tx.GetRotateCdcStream().GetNewStreamDescription().GetName()}));
+        result.emplace_back(NKikimr::JoinPath({tx.GetWorkingDir(), tx.GetRotateCdcStream().GetNewStream().GetStreamDescription().GetName()}));
         break;
     case NKikimrSchemeOp::EOperationType::ESchemeOpRotateCdcStreamAtTable:
         result.emplace_back(NKikimr::JoinPath({tx.GetWorkingDir(), tx.GetRotateCdcStream().GetTableName()}));

--- a/ydb/core/tx/schemeshard/schemeshard_audit_log_fragment.cpp
+++ b/ydb/core/tx/schemeshard/schemeshard_audit_log_fragment.cpp
@@ -189,6 +189,10 @@ TString DefineUserOperationName(const NKikimrSchemeOp::TModifyScheme& tx) {
     case NKikimrSchemeOp::EOperationType::ESchemeOpDropCdcStreamImpl:
     case NKikimrSchemeOp::EOperationType::ESchemeOpDropCdcStreamAtTable:
         return "ALTER TABLE DROP CHANGEFEED";
+    case NKikimrSchemeOp::EOperationType::ESchemeOpRotateCdcStream:
+    case NKikimrSchemeOp::EOperationType::ESchemeOpRotateCdcStreamImpl:
+    case NKikimrSchemeOp::EOperationType::ESchemeOpRotateCdcStreamAtTable:
+        return "ALTER TABLE ROTATE CHANGEFEED";
     // sequence
     case NKikimrSchemeOp::EOperationType::ESchemeOpCreateSequence:
         return "CREATE SEQUENCE";
@@ -500,6 +504,17 @@ TVector<TString> ExtractChangingPaths(const NKikimrSchemeOp::TModifyScheme& tx) 
         break;
     case NKikimrSchemeOp::EOperationType::ESchemeOpDropCdcStreamAtTable:
         result.emplace_back(NKikimr::JoinPath({tx.GetWorkingDir(), tx.GetDropCdcStream().GetTableName()}));
+        break;
+    case NKikimrSchemeOp::EOperationType::ESchemeOpRotateCdcStream:
+        result.emplace_back(NKikimr::JoinPath({tx.GetWorkingDir(), tx.GetRotateCdcStream().GetTableName(), tx.GetRotateCdcStream().GetOldStreamName()}));
+        result.emplace_back(NKikimr::JoinPath({tx.GetWorkingDir(), tx.GetRotateCdcStream().GetTableName(), tx.GetRotateCdcStream().GetNewStreamDescription().GetName()}));
+        break;
+    case NKikimrSchemeOp::EOperationType::ESchemeOpRotateCdcStreamImpl:
+        result.emplace_back(NKikimr::JoinPath({tx.GetWorkingDir(), tx.GetRotateCdcStream().GetOldStreamName()}));
+        result.emplace_back(NKikimr::JoinPath({tx.GetWorkingDir(), tx.GetRotateCdcStream().GetNewStreamDescription().GetName()}));
+        break;
+    case NKikimrSchemeOp::EOperationType::ESchemeOpRotateCdcStreamAtTable:
+        result.emplace_back(NKikimr::JoinPath({tx.GetWorkingDir(), tx.GetRotateCdcStream().GetTableName()}));
         break;
     case NKikimrSchemeOp::EOperationType::ESchemeOpMoveTable:
         result.emplace_back(tx.GetMoveTable().GetSrcPath());

--- a/ydb/core/tx/schemeshard/schemeshard_tx_infly.h
+++ b/ydb/core/tx/schemeshard/schemeshard_tx_infly.h
@@ -151,6 +151,8 @@ struct TTxState {
         item(TxDropSysView, 104) \
         item(TxCreateLongIncrementalRestoreOp, 105) \
         item(TxChangePathState, 106) \
+        item(TxRotateCdcStream, 107) \
+        item(TxRotateCdcStreamAtTable, 108) \
 
     // TX_STATE_TYPE_ENUM
 
@@ -282,7 +284,8 @@ struct TTxState {
     TStepId MinStep = InvalidStepId;
     TStepId PlanStep = InvalidStepId;
 
-    // TxCopy: Stores path for cdc stream to create in case of ContinuousBackup; uses ExtraData through proto
+    // TxCopy or TxRotateCdcStreamAtTable: Stores path for cdc stream to create in case of ContinuousBackup;
+    // uses ExtraData through proto
     TPathId CdcPathId = InvalidPathId;
     TMaybe<NKikimrSchemeOp::EPathState> TargetPathTargetState;
 
@@ -459,6 +462,10 @@ struct TTxState {
         case TxMoveTableIndex:
         case TxMoveSequence:
             return true;
+        case TxRotateCdcStream:
+            return true;
+        case TxRotateCdcStreamAtTable:
+            return false;
         case TxInvalid:
         case TxAllocatePQ:
             Y_DEBUG_ABORT_UNLESS("UNREACHABLE");
@@ -572,6 +579,8 @@ struct TTxState {
         case TxAlterResourcePool:
         case TxAlterBackupCollection:
         case TxChangePathState:
+        case TxRotateCdcStream:
+        case TxRotateCdcStreamAtTable:
             return false;
         case TxMoveTable:
         case TxMoveTableIndex:
@@ -694,6 +703,8 @@ struct TTxState {
         case TxAlterResourcePool:
         case TxAlterBackupCollection:
         case TxChangePathState:
+        case TxRotateCdcStream:
+        case TxRotateCdcStreamAtTable:
             return false;
         case TxInvalid:
         case TxAllocatePQ:
@@ -774,6 +785,9 @@ struct TTxState {
             case NKikimrSchemeOp::ESchemeOpDropCdcStream: return TxInvalid;
             case NKikimrSchemeOp::ESchemeOpDropCdcStreamImpl: return TxDropCdcStream;
             case NKikimrSchemeOp::ESchemeOpDropCdcStreamAtTable: return TxDropCdcStreamAtTable;
+            case NKikimrSchemeOp::ESchemeOpRotateCdcStream: return TxInvalid;
+            case NKikimrSchemeOp::ESchemeOpRotateCdcStreamImpl: return TxRotateCdcStream;
+            case NKikimrSchemeOp::ESchemeOpRotateCdcStreamAtTable: return TxRotateCdcStreamAtTable;
             case NKikimrSchemeOp::ESchemeOpMoveTable: return TxMoveTable;
             case NKikimrSchemeOp::ESchemeOpMoveTableIndex: return TxMoveTableIndex;
             case NKikimrSchemeOp::ESchemeOpCreateSequence: return TxCreateSequence;

--- a/ydb/core/tx/schemeshard/ut_base/ut_base.cpp
+++ b/ydb/core/tx/schemeshard/ut_base/ut_base.cpp
@@ -11754,6 +11754,9 @@ Y_UNIT_TEST_SUITE(TSchemeShardTest) {
         // TODO: validate no stream created
 
         if (WithIncremental) {
+            // Pass time to prevent stream names clashing
+            runtime.AdvanceCurrentTime(TDuration::Seconds(1));
+
             TestBackupIncrementalBackupCollection(runtime, ++txId, "/MyRoot", R"(
                 Name: ".backups/collections/MyCollection1"
             )");

--- a/ydb/core/tx/schemeshard/ut_continuous_backup/ut_continuous_backup.cpp
+++ b/ydb/core/tx/schemeshard/ut_continuous_backup/ut_continuous_backup.cpp
@@ -30,18 +30,19 @@ Y_UNIT_TEST_SUITE(TContinuousBackupTests) {
         TestCreateContinuousBackup(runtime, ++txId, "/MyRoot", R"(
             TableName: "Table"
             ContinuousBackupDescription {
+                StreamName: "0_continuousBackupImpl"
             }
         )");
         env.TestWaitNotification(runtime, txId);
 
-        TestDescribeResult(DescribePrivatePath(runtime, "/MyRoot/Table/continuousBackupImpl"), {
+        TestDescribeResult(DescribePrivatePath(runtime, "/MyRoot/Table/0_continuousBackupImpl"), {
             NLs::PathExist,
             NLs::StreamMode(NKikimrSchemeOp::ECdcStreamModeUpdate),
             NLs::StreamFormat(NKikimrSchemeOp::ECdcStreamFormatProto),
             NLs::StreamState(NKikimrSchemeOp::ECdcStreamStateReady),
             NLs::StreamVirtualTimestamps(false),
         });
-        TestDescribeResult(DescribePrivatePath(runtime, "/MyRoot/Table/continuousBackupImpl/streamImpl"), {NLs::PathExist});
+        TestDescribeResult(DescribePrivatePath(runtime, "/MyRoot/Table/0_continuousBackupImpl/streamImpl"), {NLs::PathExist});
 
         TestAlterContinuousBackup(runtime, ++txId, "/MyRoot", R"(
             TableName: "Table"
@@ -49,7 +50,7 @@ Y_UNIT_TEST_SUITE(TContinuousBackupTests) {
         )");
         env.TestWaitNotification(runtime, txId);
 
-        TestDescribeResult(DescribePrivatePath(runtime, "/MyRoot/Table/continuousBackupImpl"), {
+        TestDescribeResult(DescribePrivatePath(runtime, "/MyRoot/Table/0_continuousBackupImpl"), {
             NLs::PathExist,
             NLs::StreamMode(NKikimrSchemeOp::ECdcStreamModeUpdate),
             NLs::StreamFormat(NKikimrSchemeOp::ECdcStreamFormatProto),
@@ -61,8 +62,8 @@ Y_UNIT_TEST_SUITE(TContinuousBackupTests) {
         )");
         env.TestWaitNotification(runtime, txId);
 
-        TestDescribeResult(DescribePrivatePath(runtime, "/MyRoot/Table/continuousBackupImpl"), {NLs::PathNotExist});
-        TestDescribeResult(DescribePrivatePath(runtime, "/MyRoot/Table/continuousBackupImpl/streamImpl"), {NLs::PathNotExist});
+        TestDescribeResult(DescribePrivatePath(runtime, "/MyRoot/Table/0_continuousBackupImpl"), {NLs::PathNotExist});
+        TestDescribeResult(DescribePrivatePath(runtime, "/MyRoot/Table/0_continuousBackupImpl/streamImpl"), {NLs::PathNotExist});
     }
 
     Y_UNIT_TEST(TakeIncrementalBackup) {
@@ -81,18 +82,19 @@ Y_UNIT_TEST_SUITE(TContinuousBackupTests) {
         TestCreateContinuousBackup(runtime, ++txId, "/MyRoot", R"(
             TableName: "Table"
             ContinuousBackupDescription {
+                StreamName: "0_continuousBackupImpl"
             }
         )");
         env.TestWaitNotification(runtime, txId);
 
-        TestDescribeResult(DescribePrivatePath(runtime, "/MyRoot/Table/continuousBackupImpl"), {
+        TestDescribeResult(DescribePrivatePath(runtime, "/MyRoot/Table/0_continuousBackupImpl"), {
             NLs::PathExist,
             NLs::StreamMode(NKikimrSchemeOp::ECdcStreamModeUpdate),
             NLs::StreamFormat(NKikimrSchemeOp::ECdcStreamFormatProto),
             NLs::StreamState(NKikimrSchemeOp::ECdcStreamStateReady),
             NLs::StreamVirtualTimestamps(false),
         });
-        TestDescribeResult(DescribePrivatePath(runtime, "/MyRoot/Table/continuousBackupImpl/streamImpl"), {
+        TestDescribeResult(DescribePrivatePath(runtime, "/MyRoot/Table/0_continuousBackupImpl/streamImpl"), {
             NLs::PathExist,
             NLs::HasNotOffloadConfig,
         });
@@ -101,6 +103,7 @@ Y_UNIT_TEST_SUITE(TContinuousBackupTests) {
             TableName: "Table"
             TakeIncrementalBackup {
                 DstPath: "IncrBackupImpl"
+                DstStreamPath: "1_continuousBackupImpl"
             }
         )");
         env.TestWaitNotification(runtime, txId);
@@ -109,7 +112,7 @@ Y_UNIT_TEST_SUITE(TContinuousBackupTests) {
         auto ownerId = pathInfo.GetPathOwnerId();
         auto localId = pathInfo.GetPathId();
 
-        TestDescribeResult(DescribePrivatePath(runtime, "/MyRoot/Table/continuousBackupImpl/streamImpl"), {
+        TestDescribeResult(DescribePrivatePath(runtime, "/MyRoot/Table/0_continuousBackupImpl/streamImpl"), {
             NLs::PathExist,
             NLs::HasOffloadConfig(Sprintf(R"(
                     IncrementalBackup: {
@@ -120,6 +123,18 @@ Y_UNIT_TEST_SUITE(TContinuousBackupTests) {
                         }
                     }
                 )", ownerId, localId)),
+        });
+
+        TestDescribeResult(DescribePrivatePath(runtime, "/MyRoot/Table/1_continuousBackupImpl"), {
+            NLs::PathExist,
+            NLs::StreamMode(NKikimrSchemeOp::ECdcStreamModeUpdate),
+            NLs::StreamFormat(NKikimrSchemeOp::ECdcStreamFormatProto),
+            NLs::StreamState(NKikimrSchemeOp::ECdcStreamStateReady),
+            NLs::StreamVirtualTimestamps(false),
+        });
+        TestDescribeResult(DescribePrivatePath(runtime, "/MyRoot/Table/1_continuousBackupImpl/streamImpl"), {
+            NLs::PathExist,
+            NLs::HasNotOffloadConfig,
         });
 
         TestDescribeResult(DescribePrivatePath(runtime, "/MyRoot/IncrBackupImpl"), {

--- a/ydb/core/tx/schemeshard/ya.make
+++ b/ydb/core/tx/schemeshard/ya.make
@@ -199,6 +199,7 @@ SRCS(
     schemeshard__operation_part.h
     schemeshard__operation_restore_backup_collection.cpp
     schemeshard__operation_rmdir.cpp
+    schemeshard__operation_rotate_cdc_stream.cpp
     schemeshard__operation_side_effects.cpp
     schemeshard__operation_side_effects.h
     schemeshard__operation_split_merge.cpp
@@ -323,7 +324,6 @@ PEERDIR(
     ydb/core/tablet_flat
     ydb/core/tx
     ydb/core/tx/datashard
-    ydb/core/tx/schemeshard/backup
     ydb/core/tx/schemeshard/common
     ydb/core/tx/schemeshard/generated
     ydb/core/tx/schemeshard/olap

--- a/ydb/core/tx/tx_proxy/schemereq.cpp
+++ b/ydb/core/tx/tx_proxy/schemereq.cpp
@@ -325,6 +325,15 @@ struct TBaseSchemeReq: public TActorBootstrapped<TDerived> {
         case NKikimrSchemeOp::ESchemeOpDropCdcStreamAtTable:
             return *modifyScheme.MutableDropCdcStream()->MutableTableName();
 
+        case NKikimrSchemeOp::ESchemeOpRotateCdcStream:
+            return *modifyScheme.MutableRotateCdcStream()->MutableTableName();
+
+        case NKikimrSchemeOp::ESchemeOpRotateCdcStreamImpl:
+            Y_ABORT("no implementation for ESchemeOpRotateCdcStreamImpl");
+
+        case NKikimrSchemeOp::ESchemeOpRotateCdcStreamAtTable:
+            return *modifyScheme.MutableRotateCdcStream()->MutableTableName();
+
         case NKikimrSchemeOp::ESchemeOpMoveTable:
             Y_ABORT("no implementation for ESchemeOpMoveTable");
 
@@ -715,6 +724,7 @@ struct TBaseSchemeReq: public TActorBootstrapped<TDerived> {
         case NKikimrSchemeOp::ESchemeOpCreateCdcStream:
         case NKikimrSchemeOp::ESchemeOpAlterCdcStream:
         case NKikimrSchemeOp::ESchemeOpDropCdcStream:
+        case NKikimrSchemeOp::ESchemeOpRotateCdcStream:
         case NKikimrSchemeOp::ESchemeOpAlterPersQueueGroup:
         case NKikimrSchemeOp::ESchemeOpAlterBlockStoreVolume:
         case NKikimrSchemeOp::ESchemeOpAssignBlockStoreVolume:
@@ -1028,6 +1038,8 @@ struct TBaseSchemeReq: public TActorBootstrapped<TDerived> {
         case NKikimrSchemeOp::ESchemeOpAlterCdcStreamAtTable:
         case NKikimrSchemeOp::ESchemeOpDropCdcStreamImpl:
         case NKikimrSchemeOp::ESchemeOpDropCdcStreamAtTable:
+        case NKikimrSchemeOp::ESchemeOpRotateCdcStreamImpl:
+        case NKikimrSchemeOp::ESchemeOpRotateCdcStreamAtTable:
         case NKikimrSchemeOp::ESchemeOpMoveTableIndex:
         case NKikimrSchemeOp::ESchemeOpAlterExtSubDomainCreateHive:
         case NKikimrSchemeOp::ESchemeOpAlterView:


### PR DESCRIPTION
### Changelog category <!-- remove all except one -->

* Not for changelog (changelog entry is not required)

### Description for reviewers <!-- (optional) description for those who read this PR -->

В этом PR реализовано переключение CDC стримов на таблице при снятии очередного инкрементального бекапа:

- Находим последний стрим в лексикографическом порядке, для этого стримы называются в формате `<timestamp>_continuousBackupImpl`
- В новой операции `RotateCdcStream` одновременно создаем новый стрим, и переводим последний стрим в disabled
- Одновременно с `RotateCdcStream` создается новая табличка инкремент, и для disabled стрима запускается offloading в эту новую табличку
