### PR TITLE
Stress tests: endpoint and database as fixture field

### DIFF
--- a/ydb/tests/library/stress/fixtures.py
+++ b/ydb/tests/library/stress/fixtures.py
@@ -20,11 +20,13 @@ class StressFixture:
 
         self.cluster = KiKiMR(self.config)
         self.cluster.start()
+        self.database = "/Root"
         self.endpoint = "grpc://%s:%s" % ('localhost', self.cluster.nodes[1].port)
+        self.mon_endpoint = f"http://localhost:{self.cluster.nodes[1].mon_port}"
 
         self.driver = ydb.Driver(
             ydb.DriverConfig(
-                database='/Root',
+                database=self.database,
                 endpoint=self.endpoint
             )
         )

--- a/ydb/tests/stress/cdc/tests/test_workload.py
+++ b/ydb/tests/stress/cdc/tests/test_workload.py
@@ -19,8 +19,8 @@ class TestYdbWorkload(StressFixture):
     def test(self):
         cmd = [
             yatest.common.binary_path(os.getenv("YDB_TEST_PATH")),
-            "--endpoint", f"grpc://localhost:{self.cluster.nodes[1].grpc_port}",
-            "--database", "/Root",
+            "--endpoint", self.endpoint,
+            "--database", self.database,
             "--duration", "120",
         ]
         yatest.common.execute(cmd, wait=True)

--- a/ydb/tests/stress/kv/tests/test_workload.py
+++ b/ydb/tests/stress/kv/tests/test_workload.py
@@ -18,8 +18,8 @@ class TestYdbWorkload(StressFixture):
         init_command = [
             yatest.common.binary_path(os.getenv("YDB_CLI_BINARY")),
             "--verbose",
-            "--endpoint", "grpc://localhost:%d" % self.cluster.nodes[1].grpc_port,
-            "--database=/Root",
+            "--endpoint", self.endpoint,
+            "--database={}".format(self.database),
             "workload", "kv", "init",
             "--min-partitions", "1",
             "--partition-size", "10",

--- a/ydb/tests/stress/log/tests/test_workload.py
+++ b/ydb/tests/stress/log/tests/test_workload.py
@@ -15,8 +15,8 @@ class TestYdbLogWorkload(StressFixture):
         return [
             yatest.common.binary_path(os.getenv('YDB_CLI_BINARY')),
             '--verbose',
-            '--endpoint', 'grpc://localhost:%d' % self.cluster.nodes[1].grpc_port,
-            '--database=/Root',
+            '--endpoint', self.endpoint,
+            '--database={}'.format(self.database),
             'workload', 'log'
         ] + subcmds + [
             '--path', path

--- a/ydb/tests/stress/mixedpy/test_mixed.py
+++ b/ydb/tests/stress/mixedpy/test_mixed.py
@@ -70,8 +70,8 @@ class TestYdbWorkload(StressFixture):
     @pytest.mark.parametrize('store_type', ['row', 'column'])
     def test(self, store_type):
         duration = get_external_param('duration', '120')
-        self.endpoint = get_external_param('endpoint', 'grpc://localhost:%d' % self.cluster.nodes[1].grpc_port)
-        self.database = get_external_param('database', '/Root')
+        self.endpoint = get_external_param('endpoint', self.endpoint)
+        self.database = get_external_param('database', self.database)
         yatest.common.execute(
             self.get_command_prefix(subcmds=['clean']))
 

--- a/ydb/tests/stress/node_broker/tests/test_workload.py
+++ b/ydb/tests/stress/node_broker/tests/test_workload.py
@@ -24,9 +24,9 @@ class TestYdbWorkload(StressFixture):
     def test(self):
         cmd = [
             yatest.common.binary_path(os.getenv("YDB_TEST_PATH")),
-            "--endpoint", f"grpc://localhost:{self.cluster.nodes[1].grpc_port}",
-            "--mon-endpoint", f"http://localhost:{self.cluster.nodes[1].mon_port}",
-            "--database", "/Root",
+            "--endpoint", self.endpoint,
+            "--mon-endpoint", self.mon_endpoint,
+            "--database", self.database,
             "--duration", "120",
         ]
         yatest.common.execute(cmd, wait=True)

--- a/ydb/tests/stress/olap_workload/tests/test_workload.py
+++ b/ydb/tests/stress/olap_workload/tests/test_workload.py
@@ -19,6 +19,6 @@ class TestYdbWorkload(StressFixture):
         yatest.common.execute([
             yatest.common.binary_path(os.environ["YDB_WORKLOAD_PATH"]),
             "--endpoint", self.endpoint,
-            "--database", "/Root",
+            "--database", self.database,
             "--duration", "120",
         ])

--- a/ydb/tests/stress/oltp_workload/tests/test_workload.py
+++ b/ydb/tests/stress/oltp_workload/tests/test_workload.py
@@ -18,7 +18,7 @@ class TestYdbWorkload(StressFixture):
         )
 
     def test(self):
-        client = YdbClient(f'grpc://localhost:{self.cluster.nodes[1].grpc_port}', '/Root', True)
+        client = YdbClient(self.endpoint, self.database, True)
         client.wait_connection()
         with WorkloadRunner(client, 'oltp_workload', 120) as runner:
             runner.run()

--- a/ydb/tests/stress/s3_backups/tests/test_workload.py
+++ b/ydb/tests/stress/s3_backups/tests/test_workload.py
@@ -19,8 +19,8 @@ class TestYdbWorkload(StressFixture):
     def test(self):
         cmd = [
             yatest.common.binary_path(os.getenv("YDB_TEST_PATH")),
-            "--endpoint", f"grpc://localhost:{self.cluster.nodes[1].grpc_port}",
-            "--database", "/Root",
+            "--endpoint", self.endpoint,
+            "--database", self.database,
             "--duration", "120",
         ]
         yatest.common.execute(cmd, wait=True)

--- a/ydb/tests/stress/show_create/view/tests/test_workload.py
+++ b/ydb/tests/stress/show_create/view/tests/test_workload.py
@@ -25,8 +25,8 @@ class TestYdbWorkload(StressFixture):
     def test_show_create_view_workload(self, duration, path_prefix):
         cmd = [
             yatest.common.binary_path(os.getenv("STRESS_TEST_UTILITY")),
-            "--endpoint", f"grpc://localhost:{self.cluster.nodes[1].grpc_port}",
-            "--database", "/Root",
+            "--endpoint", self.endpoint,
+            "--database", self.database,
             "--duration", str(duration),
         ]
 

--- a/ydb/tests/stress/simple_queue/tests/test_workload.py
+++ b/ydb/tests/stress/simple_queue/tests/test_workload.py
@@ -18,5 +18,5 @@ class TestYdbWorkload(StressFixture):
 
     @pytest.mark.parametrize('mode', ['row', 'column'])
     def test(self, mode: str):
-        with Workload(f'grpc://localhost:{self.cluster.nodes[1].grpc_port}', '/Root', 60, mode) as workload:
+        with Workload(self.endpoint, self.database, 60, mode) as workload:
             workload.start()

--- a/ydb/tests/stress/transfer/tests/test_workload.py
+++ b/ydb/tests/stress/transfer/tests/test_workload.py
@@ -21,8 +21,8 @@ class TestYdbWorkload(StressFixture):
     def test(self, store_type):
         cmd = [
             yatest.common.binary_path(os.getenv("YDB_TEST_PATH")),
-            "--endpoint", f'grpc://localhost:{self.cluster.nodes[1].grpc_port}',
-            "--database", "/Root",
+            "--endpoint", self.endpoint,
+            "--database", self.database,
             "--duration", "60",
             "--mode", store_type
         ]


### PR DESCRIPTION
This PR refactors stress test files to use fixture fields for endpoint and database configuration instead of hardcoded values. The changes centralize connection parameters in the base fixture class and reference them consistently across all stress test modules.

- Introduces self.database, self.endpoint, and self.mon_endpoint as fixture fields in the base class
- Replaces hardcoded endpoint and database strings with references to these fixture fields
- Updates all stress test modules to use the centralized configuration approach
