### PR TITLE
Move bridge pile name to node location for convenience

### DIFF
--- a/ydb/core/blobstorage/nodewarden/node_warden_impl.cpp
+++ b/ydb/core/blobstorage/nodewarden/node_warden_impl.cpp
@@ -1550,18 +1550,19 @@ bool NKikimr::NStorage::DeriveStorageConfig(const NKikimrConfig::TAppConfig& app
         } else if (node.HasWalleLocation()) {
             r->MutableLocation()->CopyFrom(node.GetWalleLocation());
         }
+        const auto& bridgePileName = TNodeLocation(r->GetLocation()).GetBridgePileName();
         if (!piles.empty()) {
-            if (!node.HasBridgePileName()) {
+            if (!bridgePileName) {
                 *errorReason = TStringBuilder() << "mandatory pile name is missing for node " << r->GetNodeId();
                 return false;
             }
-            const auto it = piles.find(node.GetBridgePileName());
+            const auto it = piles.find(*bridgePileName);
             if (it == piles.end()) {
-                *errorReason = TStringBuilder() << "incorrect pile name " << node.GetBridgePileName();
+                *errorReason = TStringBuilder() << "incorrect pile name " << *bridgePileName;
                 return false;
             }
             it->second.CopyToProto(r, &NKikimrBlobStorage::TNodeIdentifier::SetBridgePileId);
-        } else if (node.HasBridgePileName()) {
+        } else if (bridgePileName) {
             *errorReason = "pile name can't be specified when Bridge mode is not enabled";
             return false;
         }

--- a/ydb/core/config/init/init.cpp
+++ b/ydb/core/config/init/init.cpp
@@ -168,9 +168,6 @@ class TDefaultNodeBrokerClient
                         nodeInfo.SetName(TString{result.GetNodeName()});
                         outNodeName = result.GetNodeName();
                     }
-                    if (node.BridgePileId) {
-                        nodeInfo.SetBridgePileId(*node.BridgePileId);
-                    }
                 } else {
                     auto &info = *nsConfig.AddNode();
                     info.SetNodeId(node.NodeId);
@@ -179,9 +176,6 @@ class TDefaultNodeBrokerClient
                     info.SetHost(TString{node.Host});
                     info.SetInterconnectHost(TString{node.ResolveHost});
                     NConfig::CopyNodeLocation(info.MutableLocation(), node.Location);
-                    if (node.BridgePileId && appConfig.HasBridgeConfig()) {
-                        info.SetBridgePileName(appConfig.GetBridgeConfig().GetPiles(*node.BridgePileId).GetName());
-                    }
                 }
             }
         }
@@ -262,9 +256,6 @@ class TDefaultNodeBrokerClient
         result.FixedNodeId(settings.FixedNodeID);
         if (settings.Path) {
             result.Path(*settings.Path);
-        }
-        if (settings.BridgePileName) {
-            result.BridgePileName(*settings.BridgePileName);
         }
 
         auto loc = settings.Location;
@@ -636,6 +627,9 @@ void CopyNodeLocation(NActorsInterconnect::TNodeLocation* dst, const NYdb::NDisc
     if (src.Body) {
         dst->SetBody(src.Body.value());
     }
+    if (src.BridgePileName) {
+        dst->SetBridgePileName(TString{src.BridgePileName.value()});
+    }
     if (src.DataCenter) {
         dst->SetDataCenter(TString{src.DataCenter.value()});
     }
@@ -665,6 +659,9 @@ void CopyNodeLocation(NYdb::NDiscovery::TNodeLocation* dst, const NActorsInterco
     }
     if (src.HasBody()) {
         dst->Body = src.GetBody();
+    }
+    if (src.HasBridgePileName()) {
+        dst->BridgePileName = src.GetBridgePileName();
     }
     if (src.HasDataCenter()) {
         dst->DataCenter = src.GetDataCenter();

--- a/ydb/core/config/init/init.h
+++ b/ydb/core/config/init/init.h
@@ -119,7 +119,6 @@ struct TNodeRegistrationSettings {
     ui32 InterconnectPort;
     NActors::TNodeLocation Location;
     TString NodeRegistrationToken;
-    std::optional<TString> BridgePileName;
 };
 
 class INodeRegistrationResult {

--- a/ydb/core/config/init/init_impl.h
+++ b/ydb/core/config/init/init_impl.h
@@ -790,6 +790,9 @@ struct TCommonAppOptions {
 
     NActors::TNodeLocation CreateNodeLocation() const {
         NActorsInterconnect::TNodeLocation location;
+        if (BridgePileName) {
+            location.SetBridgePileName(BridgePileName);
+        }
         location.SetDataCenter(DataCenter ? DataCenter.GetRef() : TString(""));
         location.SetRack(Rack);
         location.SetUnit(ToString(Body));
@@ -1325,7 +1328,6 @@ public:
             cf.InterconnectPort,
             cf.CreateNodeLocation(),
             AppConfig.GetAuthConfig().GetNodeRegistrationToken(),
-            cf.BridgePileName ? std::make_optional(cf.BridgePileName) : std::nullopt,
         };
 
         auto result = NodeBrokerClient.RegisterDynamicNode(cf.GrpcSslSettings, addrs, settings, Env, Logger);

--- a/ydb/core/mind/dynamic_nameserver_impl.h
+++ b/ydb/core/mind/dynamic_nameserver_impl.h
@@ -85,11 +85,9 @@ struct TDynamicConfig : public TThrRefBase {
                          const TString &resolveHost,
                          ui16 port,
                          const TNodeLocation &location,
-                         TInstant expire,
-                         std::optional<TBridgePileId> bridgePileId)
+                         TInstant expire)
             : TNodeInfo(address, host, resolveHost, port, location)
             , Expire(expire)
-            , BridgePileId(bridgePileId)
         {
         }
 
@@ -99,10 +97,7 @@ struct TDynamicConfig : public TThrRefBase {
                                info.GetResolveHost(),
                                (ui16)info.GetPort(),
                                TNodeLocation(info.GetLocation()),
-                               TInstant::MicroSeconds(info.GetExpire()),
-                               info.HasBridgePileId()
-                                   ? std::make_optional(TBridgePileId::FromProto(&info, &NKikimrNodeBroker::TNodeInfo::GetBridgePileId))
-                                   : std::nullopt)
+                               TInstant::MicroSeconds(info.GetExpire()))
         {
         }
 
@@ -119,7 +114,6 @@ struct TDynamicConfig : public TThrRefBase {
         }
 
         TInstant Expire;
-        std::optional<TBridgePileId> BridgePileId;
     };
 
     THashMap<ui32, TDynamicNodeInfo> DynamicNodes;

--- a/ydb/core/mind/node_broker.cpp
+++ b/ydb/core/mind/node_broker.cpp
@@ -171,9 +171,6 @@ bool TNodeBroker::OnRenderAppHtmlPage(NMon::TEvRemoteHttpInfo::TPtr ev,
                     << "   AuthorizedByCertificate: " << (node.AuthorizedByCertificate ? "true" : "false") << Endl
                     << "   ServicedSubDomain: " << node.ServicedSubDomain << Endl
                     << "   SlotIndex: " << node.SlotIndex << Endl;
-                if (node.BridgePileId) {
-                    str << "   BridgePileId: " << *node.BridgePileId << Endl;
-                }
             }
             str << Endl;
 
@@ -479,9 +476,6 @@ void TNodeBroker::FillNodeInfo(const TNodeInfo &node,
     info.SetExpire(node.Expire.GetValue());
     node.Location.Serialize(info.MutableLocation(), false);
     FillNodeName(node.SlotIndex, info);
-    if (const auto& id = node.BridgePileId) {
-        id->CopyToProto(&info, &NKikimrNodeBroker::TNodeInfo::SetBridgePileId);
-    }
 }
 
 void TNodeBroker::FillNodeName(const std::optional<ui32> &slotIndex,
@@ -866,8 +860,7 @@ void TNodeBroker::TDirtyState::DbAddNode(const TNodeInfo &node,
                 << " expire=" << node.ExpirationString()
                 << " servicedsubdomain=" << node.ServicedSubDomain
                 << " slotindex=" << node.SlotIndex
-                << " authorizedbycertificate=" << (node.AuthorizedByCertificate ? "true" : "false")
-                << " bridgePileId=" << (node.BridgePileId ? TString(TStringBuilder() << *node.BridgePileId) : "<none>"));
+                << " authorizedbycertificate=" << (node.AuthorizedByCertificate ? "true" : "false"));
 
     NIceDb::TNiceDb db(txc.DB);
 
@@ -888,11 +881,6 @@ void TNodeBroker::TDirtyState::DbAddNode(const TNodeInfo &node,
         .Update<T::Location>(node.Location.GetSerializedLocation())
         .Update<T::ServicedSubDomain>(node.ServicedSubDomain)
         .Update<T::AuthorizedByCertificate>(node.AuthorizedByCertificate);
-
-    if (node.BridgePileId) {
-        db.Table<T>().Key(node.NodeId)
-            .Update<T::BridgePileId>(node.BridgePileId->GetRawId());
-    }
 
     if (node.SlotIndex.has_value()) {
         db.Table<T>().Key(node.NodeId)
@@ -1126,9 +1114,6 @@ TNodeBroker::TDbChanges TNodeBroker::TDirtyState::DbLoadNodes(auto &nodesRowset,
             }
             info.AuthorizedByCertificate = nodesRowset.template GetValue<Schema::Nodes::AuthorizedByCertificate>();
             info.State = expire > Epoch.Start ? ENodeState::Active : ENodeState::Expired;
-            if (nodesRowset.template HaveValue<Schema::Nodes::BridgePileId>()) {
-                info.BridgePileId.emplace(TBridgePileId::FromValue(nodesRowset.template GetValue<Schema::Nodes::BridgePileId>()));
-            }
             AddNode(info);
 
             LOG_DEBUG_S(ctx, NKikimrServices::NODE_BROKER,
@@ -1514,7 +1499,6 @@ void TNodeBroker::Handle(TEvNodeBroker::TEvRegistrationRequest::TPtr &ev,
         TActorId ReplyTo;
         NActors::TScopeId ScopeId;
         TSubDomainKey ServicedSubDomain;
-        std::optional<TBridgePileId> BridgePileId;
         TString Error;
 
     public:
@@ -1532,19 +1516,19 @@ void TNodeBroker::Handle(TEvNodeBroker::TEvRegistrationRequest::TPtr &ev,
 
             auto& record = Ev->Get()->Record;
 
-            if (record.HasBridgePileName()) {
+            if (const auto& bridgePileName = TNodeLocation(record.GetLocation()).GetBridgePileName()) {
                 if (AppData()->BridgeConfig && AppData()->BridgeConfig->PilesSize()) {
-                    const TString& name = record.GetBridgePileName();
                     const auto& bridge = *AppData()->BridgeConfig;
                     const auto& piles = bridge.GetPiles();
+                    bool found = false;
                     for (int i = 0; i < piles.size(); ++i) {
-                        if (piles[i].GetName() == name) {
-                            BridgePileId.emplace(TBridgePileId::FromValue(i));
+                        if (piles[i].GetName() == *bridgePileName) {
+                            found = true;
                             break;
                         }
                     }
-                    if (!BridgePileId) {
-                        Error = TStringBuilder() << "Incorrect bridge pile name " << name;
+                    if (!found) {
+                        Error = TStringBuilder() << "Incorrect bridge pile name " << *bridgePileName;
                     }
                 } else {
                     Error = "Bridge pile specified while bridge mode is disabled";
@@ -1602,8 +1586,7 @@ void TNodeBroker::Handle(TEvNodeBroker::TEvRegistrationRequest::TPtr &ev,
                 << ": scope id# " << ScopeIdToString(ScopeId)
                 << ": serviced subdomain# " << ServicedSubDomain);
 
-            Send(ReplyTo, new TEvPrivate::TEvResolvedRegistrationRequest(Ev, ScopeId, ServicedSubDomain, BridgePileId,
-                std::move(Error)));
+            Send(ReplyTo, new TEvPrivate::TEvResolvedRegistrationRequest(Ev, ScopeId, ServicedSubDomain, std::move(Error)));
             Die(ctx);
         }
 
@@ -1777,9 +1760,6 @@ TNodeBroker::TNodeInfo::TNodeInfo(ui32 nodeId, ENodeState state, ui64 version, c
     , ServicedSubDomain(schema.GetServicedSubDomain())
     , State(state)
     , Version(version)
-    , BridgePileId(schema.HasBridgePileId()
-        ? std::make_optional(TBridgePileId::FromProto(&schema, &TNodeInfoSchema::GetBridgePileId))
-        : std::nullopt)
 {}
 
 TNodeBroker::TNodeInfo::TNodeInfo(ui32 nodeId, ENodeState state, ui64 version)
@@ -1803,8 +1783,7 @@ bool TNodeBroker::TNodeInfo::EqualExceptVersion(const TNodeInfo &other) const
         && AuthorizedByCertificate == other.AuthorizedByCertificate
         && SlotIndex == other.SlotIndex
         && ServicedSubDomain == other.ServicedSubDomain
-        && State == other.State
-        && BridgePileId == other.BridgePileId;
+        && State == other.State;
 }
 
 TString TNodeBroker::TNodeInfo::IdString() const
@@ -1832,7 +1811,6 @@ TString TNodeBroker::TNodeInfo::ToString() const
         << ", Expire: " << ExpirationString()
         << ", Location: " << Location.ToString()
         << ", AuthorizedByCertificate: " << AuthorizedByCertificate
-        << ", BridgePileId: " << (BridgePileId ? TString(TStringBuilder() << *BridgePileId) : "<none>")
         << ", SlotIndex: " << SlotIndex
         << ", ServicedSubDomain: " << ServicedSubDomain
     << " }";
@@ -1853,9 +1831,6 @@ TNodeInfoSchema TNodeBroker::TNodeInfo::SerializeToSchema() const {
         serialized.SetSlotIndex(*SlotIndex);
     }
     serialized.SetAuthorizedByCertificate(AuthorizedByCertificate);
-    if (BridgePileId) {
-        BridgePileId->CopyToProto(&serialized, &TNodeInfoSchema::SetBridgePileId);
-    }
     return serialized;
 }
 

--- a/ydb/core/mind/node_broker__scheme.h
+++ b/ydb/core/mind/node_broker__scheme.h
@@ -37,7 +37,7 @@ struct Schema : NIceDb::Schema {
         struct ServicedSubDomain : Column<13, NScheme::NTypeIds::String> { using Type = NKikimrSubDomains::TDomainKey; };
         struct SlotIndex : Column<14, NScheme::NTypeIds::Uint32> {};
         struct AuthorizedByCertificate : Column<15, NScheme::NTypeIds::Bool> {};
-        struct BridgePileId : Column<16, NScheme::NTypeIds::Uint32> {};
+        //struct BridgePileId : Column<16, NScheme::NTypeIds::Uint32> {};
 
         using TKey = TableKey<ID>;
         using TColumns = TableColumns<
@@ -51,8 +51,7 @@ struct Schema : NIceDb::Schema {
             Location,
             ServicedSubDomain,
             SlotIndex,
-            AuthorizedByCertificate,
-            BridgePileId
+            AuthorizedByCertificate
         >;
     };
 

--- a/ydb/core/mind/node_broker_impl.h
+++ b/ydb/core/mind/node_broker_impl.h
@@ -67,19 +67,16 @@ public:
                     TEvNodeBroker::TEvRegistrationRequest::TPtr request,
                     NActors::TScopeId scopeId,
                     TSubDomainKey servicedSubDomain,
-                    std::optional<TBridgePileId> bridgePileId,
                     TString error)
                 : Request(request)
                 , ScopeId(scopeId)
                 , ServicedSubDomain(servicedSubDomain)
-                , BridgePileId(bridgePileId)
                 , Error(std::move(error))
             {}
 
             TEvNodeBroker::TEvRegistrationRequest::TPtr Request;
             NActors::TScopeId ScopeId;
             TSubDomainKey ServicedSubDomain;
-            std::optional<TBridgePileId> BridgePileId;
             TString Error;
         };
 
@@ -144,7 +141,6 @@ private:
         TSubDomainKey ServicedSubDomain;
         ENodeState State = ENodeState::Removed;
         ui64 Version = 0;
-        std::optional<TBridgePileId> BridgePileId;
     };
 
     // State changes to apply while moving to the next epoch.

--- a/ydb/core/protos/config.proto
+++ b/ydb/core/protos/config.proto
@@ -165,8 +165,6 @@ message TStaticNameserviceConfig {
         repeated TEndpoint Endpoint = 7;
 
         optional NActorsInterconnect.TNodeLocation WalleLocation = 8 [deprecated=true];
-
-        optional string BridgePileName = 9; // realm name for bridged installations (starting from 0)
     }
 
     repeated TNode Node = 1;

--- a/ydb/core/protos/node_broker.proto
+++ b/ydb/core/protos/node_broker.proto
@@ -22,7 +22,6 @@ message TNodeInfo {
     optional NActorsInterconnect.TNodeLocation Location = 6;
     optional uint64 Expire = 7;
     optional string Name = 8;
-    optional uint32 BridgePileId = 9;
 }
 
 message TNodeInfoSchema {
@@ -36,7 +35,6 @@ message TNodeInfoSchema {
     optional NKikimrSubDomains.TDomainKey ServicedSubDomain = 8;
     optional uint32 SlotIndex = 9;
     optional bool AuthorizedByCertificate = 10;
-    optional uint32 BridgePileId = 11;
 }
 
 message TVersionInfo {
@@ -90,7 +88,6 @@ message TRegistrationRequest {
   optional bool FixedNodeId = 6;
   optional string Path = 7;
   optional bool AuthorizedByCertificate = 8;
-  optional string BridgePileName = 9;
 }
 
 message TRegistrationResponse {

--- a/ydb/library/actors/core/interconnect.cpp
+++ b/ydb/library/actors/core/interconnect.cpp
@@ -147,6 +147,10 @@ namespace NActors {
 
         for (const auto& [key, value] : Items) {
             switch (key) {
+                case TKeys::BridgePileName:
+                    // just ignore it
+                    break;
+
                 case TKeys::DataCenter:
                     memcpy(&dataCenterId, value.data(), Min<size_t>(sizeof(dataCenterId), value.length()));
                     break;

--- a/ydb/library/actors/core/interconnect.h
+++ b/ydb/library/actors/core/interconnect.h
@@ -12,6 +12,7 @@ namespace NActors {
     public:
         struct TKeys {
             enum E : int {
+                BridgePileName = 5,
                 DataCenter = 10,
                 Module = 20,
                 Rack = 30,
@@ -88,6 +89,17 @@ namespace NActors {
         TLegacyValue GetLegacyValue() const;
 
         const std::vector<std::pair<TKeys::E, TString>>& GetItems() const { return Items; }
+
+        const std::optional<TString> GetBridgePileName() const {
+            if (Items.empty()) {
+                return std::nullopt;
+            }
+
+            auto& [key, value] = Items.front();
+            return key == TKeys::BridgePileName
+                ? std::make_optional(value)
+                : std::nullopt;
+        }
 
         bool HasKey(TKeys::E key) const {
             auto comp = [](const auto& p, TKeys::E value) { return p.first < value; };

--- a/ydb/library/actors/protos/interconnect.proto
+++ b/ydb/library/actors/protos/interconnect.proto
@@ -27,6 +27,7 @@ message TNodeLocation {
     optional uint32 BodyNum = 4 [deprecated=true];
     optional uint32 Body = 100500 [deprecated=true]; // for compatibility with WalleLocation
 
+    optional string BridgePileName = 5 [(PrintName) = "P"];
     optional string DataCenter = 10 [(PrintName) = "DC"];
     optional string Module = 20 [(PrintName) = "M"];
     optional string Rack = 30 [(PrintName) = "R"];

--- a/ydb/library/yaml_config/yaml_config_parser.cpp
+++ b/ydb/library/yaml_config/yaml_config_parser.cpp
@@ -1022,10 +1022,6 @@ endDiskTypeCheck:   ;
             } else {
                 node->SetInterconnectHost(host.GetHost());
             }
-
-            if (host.HasBridgePileName()) {
-                node->SetBridgePileName(host.GetBridgePileName());
-            }
         }
     }
 

--- a/ydb/public/api/protos/ydb_discovery.proto
+++ b/ydb/public/api/protos/ydb_discovery.proto
@@ -69,6 +69,7 @@ message NodeLocation {
     optional uint32 body_num = 4 [deprecated=true];
     optional uint32 body = 100500 [deprecated=true]; // for compatibility with WalleLocation
 
+    optional string bridge_pile_name = 5;
     optional string data_center = 10;
     optional string module = 20;
     optional string rack = 30;
@@ -83,7 +84,6 @@ message NodeInfo {
     optional string address = 5;
     optional NodeLocation location = 6;
     optional uint64 expire = 7;
-    optional uint32 bridge_pile_id = 8;
 }
 
 message NodeRegistrationRequest {
@@ -95,7 +95,6 @@ message NodeRegistrationRequest {
     optional string domain_path = 6;
     optional bool fixed_node_id = 7;
     optional string path = 8;
-    optional string bridge_pile_name = 9;
 }
 
 message NodeRegistrationResult {

--- a/ydb/public/sdk/cpp/include/ydb-cpp-sdk/client/discovery/discovery.h
+++ b/ydb/public/sdk/cpp/include/ydb-cpp-sdk/client/discovery/discovery.h
@@ -33,6 +33,7 @@ struct TNodeLocation {
     std::optional<uint32_t> BodyNum;
     std::optional<uint32_t> Body;
 
+    std::optional<std::string> BridgePileName;
     std::optional<std::string> DataCenter;
     std::optional<std::string> Module;
     std::optional<std::string> Rack;
@@ -48,7 +49,6 @@ struct TNodeRegistrationSettings : public TSimpleRequestSettings<TNodeRegistrati
     FLUENT_SETTING(std::string, DomainPath);
     FLUENT_SETTING_DEFAULT(bool, FixedNodeId, false);
     FLUENT_SETTING(std::string, Path);
-    FLUENT_SETTING(std::string, BridgePileName);
 };
 
 struct TEndpointInfo {
@@ -97,7 +97,6 @@ struct TNodeInfo {
     std::string Address;
     TNodeLocation Location;
     uint64_t Expire;
-    std::optional<uint32_t> BridgePileId;
 };
 
 class TNodeRegistrationResult : public TStatus {

--- a/ydb/public/sdk/cpp/src/client/discovery/discovery.cpp
+++ b/ydb/public/sdk/cpp/src/client/discovery/discovery.cpp
@@ -63,11 +63,12 @@ TNodeLocation::TNodeLocation(const Ydb::Discovery::NodeLocation& location)
     , RackNum(location.has_rack_num() ? std::make_optional(location.rack_num()) : std::nullopt)
     , BodyNum(location.has_body_num() ? std::make_optional(location.body_num()) : std::nullopt)
     , Body(location.has_body() ? std::make_optional(location.body()) : std::nullopt)
+    , BridgePileName(location.has_bridge_pile_name() ? std::make_optional(location.bridge_pile_name()) : std::nullopt)
     , DataCenter(location.has_data_center() ? std::make_optional(location.data_center()) : std::nullopt)
     , Module(location.has_module() ? std::make_optional(location.module()) : std::nullopt)
     , Rack(location.has_rack() ? std::make_optional(location.rack()) : std::nullopt)
     , Unit(location.has_unit() ? std::make_optional(location.unit()) : std::nullopt)
-    {}
+{}
 
 TNodeInfo::TNodeInfo(const Ydb::Discovery::NodeInfo& info)
     : NodeId(info.node_id())
@@ -77,7 +78,6 @@ TNodeInfo::TNodeInfo(const Ydb::Discovery::NodeInfo& info)
     , Address(info.address())
     , Location(info.location())
     , Expire(info.expire())
-    , BridgePileId(info.has_bridge_pile_id() ? std::make_optional(info.bridge_pile_id()) : std::nullopt)
 {}
 
 TNodeRegistrationResult::TNodeRegistrationResult(TStatus&& status, const Ydb::Discovery::NodeRegistrationResult& proto)
@@ -209,13 +209,13 @@ public:
         if (!settings.Path_.empty()) {
             request.set_path(TStringType{settings.Path_});
         }
-        if (!settings.BridgePileName_.empty()) {
-            request.set_bridge_pile_name(TStringType{settings.BridgePileName_});
-        }
 
         auto requestLocation = request.mutable_location();
         const auto& location = settings.Location_;
 
+        if (location.BridgePileName) {
+            requestLocation->set_bridge_pile_name(TStringType{location.BridgePileName.value()});
+        }
         if (location.DataCenter) {
             requestLocation->set_data_center(TStringType{location.DataCenter.value()});
         }

--- a/ydb/tests/library/harness/kikimr_config.py
+++ b/ydb/tests/library/harness/kikimr_config.py
@@ -785,7 +785,7 @@ class KikimrConfigGenerator(object):
                 "host_config_id": host_config_id,
             }
             if self.bridge_config:
-                host_dict["bridge_pile_name"] = self.bridge_config.get("piles", [])[node_id % len(self.bridge_config.get("piles", []))].get("name")
+                host_dict["location"] = {"bridge_pile_name": self.bridge_config.get("piles", [])[node_id % len(self.bridge_config.get("piles", []))].get("name")}
             elif self.static_erasure == Erasure.MIRROR_3_DC:
                 host_dict["location"] = {"data_center": "zone-%d" % (node_id % 3)}
             hosts.append(host_dict)

--- a/ydb/tools/ydbd_slice/yaml_configurator.py
+++ b/ydb/tools/ydbd_slice/yaml_configurator.py
@@ -174,7 +174,7 @@ class YamlConfigurator(object):
 
     @property
     def hosts_bridge_piles(self):
-        return {host.get('host'): host.get('bridge_pile_name') for host in self.static_config_dict.get('hosts', [])}
+        return {host.get('host'): host.get('location', {}).get('bridge_pile_name') for host in self.static_config_dict.get('hosts', [])}
 
     @property
     def group_hosts_by_datacenter(self):


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

Move bridge pile name to node location for convenience

### Changelog category <!-- remove all except one -->

* Not for changelog (changelog entry is not required)

### Description for reviewers <!-- (optional) description for those who read this PR -->

This moves bridge pile name into Location structure, removing it as a separate field and removing bridge pile id from public interfaces.
