### PR TITLE
CI: support ydb qa down for test upload

### DIFF
--- a/.github/scripts/analytics/upload_tests_results.py
+++ b/.github/scripts/analytics/upload_tests_results.py
@@ -270,9 +270,11 @@ def main():
         print(f"Warning: Failed to upload test results to YDB: {e}")
         print("This is not a critical error, continuing with CI process...")
         return 0
+    
+    return 0
 
        
 
 
 if __name__ == "__main__":
-    main()
+    sys.exit(main())

--- a/.github/scripts/analytics/upload_tests_results.py
+++ b/.github/scripts/analytics/upload_tests_results.py
@@ -215,56 +215,61 @@ def main():
     test_table_name = f"{path_in_database}/test_runs_column"
     full_path = posixpath.join(DATABASE_PATH, test_table_name)
 
-    with ydb.Driver(
-        endpoint=DATABASE_ENDPOINT,
-        database=DATABASE_PATH,
-        credentials=ydb.credentials_from_env_variables(),
-    ) as driver:
-        driver.wait(timeout=10, fail_fast=True)
-        session = ydb.retry_operation_sync(
-            lambda: driver.table_client.session().create()
-        )
+    try:
+        with ydb.Driver(
+            endpoint=DATABASE_ENDPOINT,
+            database=DATABASE_PATH,
+            credentials=ydb.credentials_from_env_variables(),
+        ) as driver:
+            driver.wait(timeout=10, fail_fast=True)
+            session = ydb.retry_operation_sync(
+                lambda: driver.table_client.session().create()
+            )
 
-        # Parse and upload
-        results = parse_junit_xml(
-            test_results_file, build_type, job_name, job_id, commit, branch, pull, run_timestamp
-        )
-        result_with_owners = get_codeowners_for_tests(codeowners, results)
-        prepared_for_upload_rows = []
-        for index, row in enumerate(result_with_owners):
-            prepared_for_upload_rows.append({
-                'branch': row['branch'],
-                'build_type': row['build_type'],
-                'commit': row['commit'],
-                'duration': row['duration'],
-                'job_id': row['job_id'],
-                'job_name': row['job_name'],
-                'log': row['log'],
-                'logsdir': row['logsdir'],
-                'owners': row['owners'],
-                'pull': row['pull'],
-                'run_timestamp': row['run_timestamp'],
-                'status_description': row['status_description'],
-                'status': row['status'],
-                'stderr': row['stderr'],
-                'stdout': row['stdout'],
-                'suite_folder': row['suite_folder'],
-                'test_id': f"{row['pull']}_{row['run_timestamp']}_{index}",
-                'test_name': row['test_name'],
-            })
-        print(f'upserting runs: {len(prepared_for_upload_rows)} rows')
-        if prepared_for_upload_rows:
-            batch_rows_for_upload_size = 1000
-            with ydb.SessionPool(driver) as pool:
-                create_tables(pool, test_table_name)
-                for start in range(0, len(prepared_for_upload_rows), batch_rows_for_upload_size):
-                    batch_rows_for_upload = prepared_for_upload_rows[start:start + batch_rows_for_upload_size]     
-                    bulk_upsert(driver.table_client, full_path,
-                            batch_rows_for_upload)
-                
-            print('tests uploaded')
-        else:
-            print('nothing to upload')
+            # Parse and upload
+            results = parse_junit_xml(
+                test_results_file, build_type, job_name, job_id, commit, branch, pull, run_timestamp
+            )
+            result_with_owners = get_codeowners_for_tests(codeowners, results)
+            prepared_for_upload_rows = []
+            for index, row in enumerate(result_with_owners):
+                prepared_for_upload_rows.append({
+                    'branch': row['branch'],
+                    'build_type': row['build_type'],
+                    'commit': row['commit'],
+                    'duration': row['duration'],
+                    'job_id': row['job_id'],
+                    'job_name': row['job_name'],
+                    'log': row['log'],
+                    'logsdir': row['logsdir'],
+                    'owners': row['owners'],
+                    'pull': row['pull'],
+                    'run_timestamp': row['run_timestamp'],
+                    'status_description': row['status_description'],
+                    'status': row['status'],
+                    'stderr': row['stderr'],
+                    'stdout': row['stdout'],
+                    'suite_folder': row['suite_folder'],
+                    'test_id': f"{row['pull']}_{row['run_timestamp']}_{index}",
+                    'test_name': row['test_name'],
+                })
+            print(f'upserting runs: {len(prepared_for_upload_rows)} rows')
+            if prepared_for_upload_rows:
+                batch_rows_for_upload_size = 1000
+                with ydb.SessionPool(driver) as pool:
+                    create_tables(pool, test_table_name)
+                    for start in range(0, len(prepared_for_upload_rows), batch_rows_for_upload_size):
+                        batch_rows_for_upload = prepared_for_upload_rows[start:start + batch_rows_for_upload_size]     
+                        bulk_upsert(driver.table_client, full_path,
+                                batch_rows_for_upload)
+                    
+                print('tests uploaded')
+            else:
+                print('nothing to upload')
+    except Exception as e:
+        print(f"Warning: Failed to upload test results to YDB: {e}")
+        print("This is not a critical error, continuing with CI process...")
+        return 0
 
        
 


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

to avoid errors like
```
.github/scripts/analytics/upload_tests_results.py --test-results-file /home/runner/actions_runner/_work/ydb/ydb/tmp/results/try_1/junit.xml --run-timestamp 1752599766 --commit f4859e23fc124bf54654449244cb986ac7deda49 --build-type release-asan --pull 16296686146_PR_#20651 --job-name PR-check --job-id 16296686146 --branch main
Traceback (most recent call last):
  File "/home/runner/actions_runner/_work/ydb/ydb/.github/scripts/analytics/upload_tests_results.py", line 273, in <module>
    main()
  File "/home/runner/actions_runner/_work/ydb/ydb/.github/scripts/analytics/upload_tests_results.py", line 262, in main
    bulk_upsert(driver.table_client, full_path,
  File "/home/runner/actions_runner/_work/ydb/ydb/.github/scripts/analytics/upload_tests_results.py", line 80, in bulk_upsert
    table_client.bulk_upsert(table_path, rows, column_types)
  File "/home/runner/.local/lib/python3.10/site-packages/ydb/table.py", line 1225, in bulk_upsert
    return self._driver(
  File "/home/runner/.local/lib/python3.10/site-packages/ydb/tracing.py", line 70, in wrapper
    return f(self, *args, **kwargs)
  File "/home/runner/.local/lib/python3.10/site-packages/ydb/pool.py", line 464, in __call__
    res = connection(
  File "/home/runner/.local/lib/python3.10/site-packages/ydb/connection.py", line 469, in __call__
    return response if wrap_result is None else wrap_result(rpc_state, response, *wrap_args)
  File "/home/runner/.local/lib/python3.10/site-packages/ydb/_session_impl.py", line 232, in wrap_operation_bulk_upsert
    return operation.Operation(rpc_state, response_pb, driver)
  File "/home/runner/.local/lib/python3.10/site-packages/ydb/operation.py", line 57, in __init__
    issues._process_response(response.operation)
  File "/home/runner/.local/lib/python3.10/site-packages/ydb/issues.py", line 238, in _process_response
    raise exc_obj(_format_response(response_proto), response_proto.issues)
ydb.issues.Unavailable: message: "Shard 72075186449855097 is not available after 10 retries" severity: 1 (server_code: 400050)
+ result='upserting runs: 16438 rows
> create table if not exists:'\''test_results/test_runs_column'\''
> bulk upsert: /ru-central1/b1ggceeul2pkher8vhb6/etnvsjbk7kh1jc6bbfi8/test_results/test_runs_column'
Error: Process completed with exit code 1.
```

### Changelog category <!-- remove all except one -->


* Not for changelog (changelog entry is not required)

### Description for reviewers <!-- (optional) description for those who read this PR -->

...
