### PR TITLE
Cloud Events, YMQ: Mapper ProtoToUnifiedAgent

### DIFF
--- a/ydb/core/protos/config.proto
+++ b/ydb/core/protos/config.proto
@@ -1058,6 +1058,7 @@ message TSqsConfig {
         optional bool EnableCloudEvents = 1 [default = false];
         optional bool TenantMode = 2 [default = false];
         optional uint64 RetryTimeoutSeconds = 3;
+        optional string UnifiedAgentUri = 4;
     }
 
     optional TYcSearchEventsConfig YcSearchEventsConfig = 66;

--- a/ydb/core/ymq/actor/cloud_events/cloud_events.h
+++ b/ydb/core/ymq/actor/cloud_events/cloud_events.h
@@ -36,7 +36,9 @@ namespace NCloudEvents {
         ui64 OriginalId;
         TString Id;
         TString Type;
-        ui64 CreatedAt_ms;
+
+        TInstant CreatedAt;
+
         TString CloudId;
         TString FolderId;
         TString ResourceId;

--- a/ydb/core/ymq/actor/cloud_events/cloud_events_ut/cloud_events_ut.cpp
+++ b/ydb/core/ymq/actor/cloud_events/cloud_events_ut/cloud_events_ut.cpp
@@ -133,9 +133,7 @@ private:
         )
         {
             TStringBuilder queryBuilder;
-            ui64 createdAt = std::chrono::time_point_cast<std::chrono::milliseconds>
-                                      (std::chrono::high_resolution_clock::now())
-                                      .time_since_epoch().count();
+            auto createdAt = TInstant::Now().MilliSeconds();
 
             queryBuilder
                 << "UPSERT INTO" << "`" << FullTablePath
@@ -322,7 +320,7 @@ Y_UNIT_TEST_SUITE(ProtoTests) {
         event.OriginalId = 1234567890;
         event.Id = "e-" + eventType + "-0001";
         event.Type = eventType;
-        event.CreatedAt_ms = 1710000000000;
+        event.CreatedAt = TInstant::Now();
         event.CloudId = "cloud-12345";
         event.FolderId = "folder-67890";
         event.ResourceId = queueName;
@@ -362,7 +360,7 @@ Y_UNIT_TEST_SUITE(ProtoTests) {
 
         UNIT_ASSERT_EQUAL(ev.event_metadata().event_id(), evInfo.Id);
         UNIT_ASSERT_EQUAL(ev.event_metadata().event_type(), "yandex.cloud.events.ymq." + eventType);
-        UNIT_ASSERT_EQUAL(static_cast<ui64>(ev.event_metadata().created_at().seconds()), evInfo.CreatedAt_ms);
+        UNIT_ASSERT_EQUAL(static_cast<ui64>(ev.event_metadata().created_at().seconds()), evInfo.CreatedAt.Seconds());
         UNIT_ASSERT_EQUAL(ev.event_metadata().cloud_id(), evInfo.CloudId);
         UNIT_ASSERT_EQUAL(ev.event_metadata().folder_id(), evInfo.FolderId);
 

--- a/ydb/core/ymq/actor/cloud_events/cloud_events_ut/cloud_events_ut.cpp
+++ b/ydb/core/ymq/actor/cloud_events/cloud_events_ut/cloud_events_ut.cpp
@@ -52,7 +52,8 @@ private:
             Processor = new NCloudEvents::TProcessor(
                 SchemePath,
                 TString(),
-                retryTimeout
+                retryTimeout,
+                nullptr
             );
             ProcessorId = runtime->Register(Processor);
             runtime->EnableScheduleForActor(ProcessorId, true);
@@ -132,7 +133,7 @@ private:
         )
         {
             TStringBuilder queryBuilder;
-            ui64 createdAt = std::chrono::time_point_cast<std::chrono::microseconds>
+            ui64 createdAt = std::chrono::time_point_cast<std::chrono::milliseconds>
                                       (std::chrono::high_resolution_clock::now())
                                       .time_since_epoch().count();
 
@@ -321,7 +322,7 @@ Y_UNIT_TEST_SUITE(ProtoTests) {
         event.OriginalId = 1234567890;
         event.Id = "e-" + eventType + "-0001";
         event.Type = eventType;
-        event.CreatedAt = 1710000000;
+        event.CreatedAt_ms = 1710000000000;
         event.CloudId = "cloud-12345";
         event.FolderId = "folder-67890";
         event.ResourceId = queueName;
@@ -361,7 +362,7 @@ Y_UNIT_TEST_SUITE(ProtoTests) {
 
         UNIT_ASSERT_EQUAL(ev.event_metadata().event_id(), evInfo.Id);
         UNIT_ASSERT_EQUAL(ev.event_metadata().event_type(), "yandex.cloud.events.ymq." + eventType);
-        UNIT_ASSERT_EQUAL(static_cast<ui64>(ev.event_metadata().created_at().seconds()), evInfo.CreatedAt);
+        UNIT_ASSERT_EQUAL(static_cast<ui64>(ev.event_metadata().created_at().seconds()), evInfo.CreatedAt_ms);
         UNIT_ASSERT_EQUAL(ev.event_metadata().cloud_id(), evInfo.CloudId);
         UNIT_ASSERT_EQUAL(ev.event_metadata().folder_id(), evInfo.FolderId);
 

--- a/ydb/core/ymq/actor/cloud_events/cloud_events_ut/cloud_events_ut.cpp
+++ b/ydb/core/ymq/actor/cloud_events/cloud_events_ut/cloud_events_ut.cpp
@@ -1,13 +1,7 @@
-#include <library/cpp/testing/unittest/registar.h>
 #include <util/string/builder.h>
 #include <ydb/core/ymq/actor/cloud_events/cloud_events.h>
-#include <ydb/core/ymq/actor/queue_schema.h>
-
-
 #include <ydb/core/testlib/test_client.h>
-#include <ydb/core/ymq/actor/index_events_processor.h>
 #include <library/cpp/testing/unittest/registar.h>
-#include <util/stream/file.h>
 
 namespace NKikimr::NSQS {
 
@@ -313,4 +307,98 @@ private:
     }
 };
 UNIT_TEST_SUITE_REGISTRATION(TCloudEventsProcessorTests);
+
+Y_UNIT_TEST_SUITE(ProtoTests) {
+    NCloudEvents::TEventInfo CreateEventInfo(
+        const TString& eventType
+    ) {
+        NCloudEvents::TEventInfo event;
+        TString queueName = "queue-name-12345";
+
+        event.UserSID = "service-account-id-789";
+        event.MaskedToken = "masked_token_abc123";
+        event.AuthType = "service_account";
+        event.OriginalId = 1234567890;
+        event.Id = "e-" + eventType + "-0001";
+        event.Type = eventType;
+        event.CreatedAt = 1710000000;
+        event.CloudId = "cloud-12345";
+        event.FolderId = "folder-67890";
+        event.ResourceId = queueName;
+        event.RemoteAddress = "192.168.1.100";
+        event.RequestId = "req-" + queueName + "-001";
+        event.IdempotencyId = "idemp-" + queueName;
+        event.QueueName = queueName;
+        if (event.Type == "CreateMessageQueue") {
+            event.Permission = "ymq.queues.create";
+        } else if (event.Type == "UpdateMessageQueue") {
+            event.Permission = "ymq.queues.setAttributes";
+        } else if (event.Type == "DeleteMessageQueue") {
+            event.Permission = "ymq.queues.delete";
+        }
+        event.Labels = "{\"k1\" : \"v1\"}";
+        return event;
+    }
+
+    template <typename TEvent>
+    void TestEventFilling(const TString& eventType, const TString& expectedPermission) {
+        auto evInfo = CreateEventInfo(eventType);
+        TEvent ev;
+        NCloudEvents::TFiller<TEvent> filler(evInfo, ev);
+        filler.Fill();
+
+        UNIT_ASSERT(ev.authentication().authenticated() == true);
+        UNIT_ASSERT_EQUAL(ev.authentication().subject_id(), evInfo.UserSID);
+        UNIT_ASSERT_EQUAL(ev.authentication().subject_type(), ::yandex::cloud::events::Authentication::SERVICE_ACCOUNT);
+        UNIT_ASSERT_EQUAL(ev.authentication().token_info().masked_iam_token(), evInfo.MaskedToken);
+
+        UNIT_ASSERT(ev.authorization().authorized() == true);
+        UNIT_ASSERT_EQUAL(ev.authorization().permissions_size(), 1);
+        const auto& perm = ev.authorization().permissions(0);
+        UNIT_ASSERT_EQUAL(perm.permission(), expectedPermission);
+        UNIT_ASSERT_EQUAL(perm.resource_type(), evInfo.ResourceType);
+        UNIT_ASSERT_EQUAL(perm.resource_id(), evInfo.ResourceId);
+
+        UNIT_ASSERT_EQUAL(ev.event_metadata().event_id(), evInfo.Id);
+        UNIT_ASSERT_EQUAL(ev.event_metadata().event_type(), "yandex.cloud.events.ymq." + eventType);
+        UNIT_ASSERT_EQUAL(static_cast<ui64>(ev.event_metadata().created_at().seconds()), evInfo.CreatedAt);
+        UNIT_ASSERT_EQUAL(ev.event_metadata().cloud_id(), evInfo.CloudId);
+        UNIT_ASSERT_EQUAL(ev.event_metadata().folder_id(), evInfo.FolderId);
+
+        UNIT_ASSERT_EQUAL(ev.request_metadata().remote_address(), evInfo.RemoteAddress);
+        UNIT_ASSERT_EQUAL(ev.request_metadata().request_id(), evInfo.RequestId);
+        UNIT_ASSERT_EQUAL(ev.request_metadata().idempotency_id(), evInfo.IdempotencyId);
+
+        UNIT_ASSERT_EQUAL(ev.event_status(), yandex::cloud::events::EventStatus::DONE);
+        UNIT_ASSERT(!ev.has_error());
+
+        const auto& details = ev.details();
+        UNIT_ASSERT_EQUAL(details.name(), evInfo.QueueName);
+        UNIT_ASSERT_EQUAL(details.labels_size(), 1);
+        UNIT_ASSERT(details.labels().contains("k1"));
+        UNIT_ASSERT_EQUAL(details.labels().at("k1"), "v1");
+    }
+
+    Y_UNIT_TEST(CreateQueueFiller) {
+        TestEventFilling<NCloudEvents::TCreateQueueEvent>(
+            "CreateMessageQueue", 
+            "ymq.queues.create"
+        );
+    }
+
+    Y_UNIT_TEST(UpdateQueueFiller) {
+        TestEventFilling<NCloudEvents::TUpdateQueueEvent>(
+            "UpdateMessageQueue", 
+            "ymq.queues.setAttributes"
+        );
+    }
+
+    Y_UNIT_TEST(DeleteQueueFiller) {
+        TestEventFilling<NCloudEvents::TDeleteQueueEvent>(
+            "DeleteMessageQueue", 
+            "ymq.queues.delete"
+        );
+    }
+}
+
 } // NKikimr::NSQS

--- a/ydb/core/ymq/actor/cloud_events/proto/ya.make
+++ b/ydb/core/ymq/actor/cloud_events/proto/ya.make
@@ -1,0 +1,19 @@
+PROTO_LIBRARY()
+
+EXCLUDE_TAGS(GO_PROTO)
+
+PEERDIR(
+    ydb/public/api/client/yc_public/events
+    ydb/public/api/client/yc_public/common
+)
+
+GRPC()
+SRCS(
+    ymq.proto
+)
+
+USE_COMMON_GOOGLE_APIS(
+    api/annotations
+)
+
+END()

--- a/ydb/core/ymq/actor/cloud_events/proto/ymq.proto
+++ b/ydb/core/ymq/actor/cloud_events/proto/ymq.proto
@@ -1,0 +1,98 @@
+syntax = "proto3";
+
+package yandex.cloud.events.ymq;
+
+import "google/rpc/status.proto";
+import "ydb/public/api/client/yc_public/events/common.proto";
+import "ydb/public/api/client/yc_public/common/validation.proto";
+import "ydb/public/api/client/yc_public/events/options.proto";
+
+option go_package = "ymq";
+option java_package = "yandex.cloud.api.events.ymq";
+
+message CreateQueue {
+    option (include) = true;
+
+    Authentication authentication = 1 [(required) = true];
+    Authorization authorization = 2 [(required) = true];
+
+    EventMetadata event_metadata = 3 [(required) = true];
+    RequestMetadata request_metadata = 4 [(required) = true];
+
+    EventStatus event_status = 5 [(required) = true];
+    EventDetails details = 6 [(required) = true];
+    RequestParameters request_parameters = 7 [(required) = true];
+    google.rpc.Status error = 8;
+    Response response = 9;
+
+    message Response {
+        // empty
+    }
+
+    message EventDetails {
+        map<string, string> labels = 1;
+        string name = 2;
+    }
+
+    message RequestParameters {
+        // empty
+    }
+}
+
+message UpdateQueue {
+    option (include) = true;
+
+    Authentication authentication = 1 [(required) = true];
+    Authorization authorization = 2 [(required) = true];
+
+    EventMetadata event_metadata = 3 [(required) = true];
+    RequestMetadata request_metadata = 4 [(required) = true];
+
+    EventStatus event_status = 5 [(required) = true];
+    EventDetails details = 6 [(required) = true];
+    RequestParameters request_parameters = 7 [(required) = true];
+    google.rpc.Status error = 8;
+    Response response = 9;
+
+    message Response {
+        // empty
+    }
+
+    message EventDetails {
+        map<string, string> labels = 1;
+        string name = 2;
+    }
+
+    message RequestParameters {
+        // empty
+    }
+}
+
+message DeleteQueue {
+    option (include) = true;
+
+    Authentication authentication = 1 [(required) = true];
+    Authorization authorization = 2 [(required) = true];
+
+    EventMetadata event_metadata = 3 [(required) = true];
+    RequestMetadata request_metadata = 4 [(required) = true];
+
+    EventStatus event_status = 5 [(required) = true];
+    EventDetails details = 6 [(required) = true];
+    RequestParameters request_parameters = 7 [(required) = true];
+    google.rpc.Status error = 8;
+    Response response = 9;
+
+    message Response {
+        // empty
+    }
+
+    message EventDetails {
+        map<string, string> labels = 1;
+        string name = 2;
+    }
+
+    message RequestParameters {
+        // empty
+    }
+}

--- a/ydb/core/ymq/actor/cloud_events/ya.make
+++ b/ydb/core/ymq/actor/cloud_events/ya.make
@@ -6,6 +6,7 @@ SRCS(
 )
 
 PEERDIR(
+    ydb/core/ymq/actor/cloud_events/proto
     ydb/library/actors/core
     ydb/core/protos
     ydb/core/util

--- a/ydb/core/ymq/actor/service.cpp
+++ b/ydb/core/ymq/actor/service.cpp
@@ -1592,7 +1592,7 @@ void TSqsService::MakeAndRegisterYcEventsProcessor() {
 
     auto root = YcSearchEventsConfig.TenantMode ? TString() : Cfg().GetRoot();
 
-    auto factory = AppData()->SqsEventsWriterFactory;
+    auto factory = AppData()->SqsEventsWriterFactory; // Why is factory here? Why can't we use default methods without insane abstractions?
     Y_ABORT_UNLESS(factory);
     Register(new TSearchEventsProcessor(
             root, YcSearchEventsConfig.ReindexInterval, YcSearchEventsConfig.RescanInterval,
@@ -1607,10 +1607,14 @@ void TSqsService::MakeAndRegisterCloudEventsProcessor() {
     }
 
     auto root = CloudEventsConfig.TenantMode ? TString() : Cfg().GetRoot();
+
+    auto factory = AppData()->SqsEventsWriterFactory; // Why is factory here? Why can't we use default methods without insane abstractions?
+    Y_ABORT_UNLESS(factory);
     Register(new NCloudEvents::TProcessor(
         root,
         CloudEventsConfig.Database,
-        CloudEventsConfig.RetryTimeout
+        CloudEventsConfig.RetryTimeout,
+        factory->CreateCloudEventsWriter(Cfg(), GetSqsServiceCounters(AppData()->Counters, "yc_unified_agent"))
     ));
 }
 

--- a/ydb/core/ymq/base/events_writer.cpp
+++ b/ydb/core/ymq/base/events_writer.cpp
@@ -90,3 +90,12 @@ IEventsWriterWrapper::TPtr TSqsEventsWriterFactory::CreateEventsWriter(const NKi
     }
     return new TNullEventsWriter();
 }
+
+IEventsWriterWrapper::TPtr TSqsEventsWriterFactory::CreateCloudEventsWriter(const NKikimrConfig::TSqsConfig& config, const NMonitoring::TDynamicCounterPtr& counters) const {
+    const auto& cloudEventsCfg = config.GetCloudEventsConfig();
+    if (cloudEventsCfg.HasUnifiedAgentUri()) {
+        return new TUaEventsWriter(cloudEventsCfg.GetUnifiedAgentUri(), counters);
+    } else {
+        return new TNullEventsWriter();
+    }
+}

--- a/ydb/core/ymq/base/events_writer.h
+++ b/ydb/core/ymq/base/events_writer.h
@@ -6,4 +6,5 @@
 class TSqsEventsWriterFactory : public NKikimr::NSQS::IEventsWriterFactory {
 public:
     NKikimr::NSQS::IEventsWriterWrapper::TPtr CreateEventsWriter(const NKikimrConfig::TSqsConfig& config, const NMonitoring::TDynamicCounterPtr& counters) const override;
+    NKikimr::NSQS::IEventsWriterWrapper::TPtr CreateCloudEventsWriter(const NKikimrConfig::TSqsConfig& config, const NMonitoring::TDynamicCounterPtr& counters) const override;
 };

--- a/ydb/core/ymq/base/events_writer_iface.h
+++ b/ydb/core/ymq/base/events_writer_iface.h
@@ -23,10 +23,10 @@ private:
     bool Closed = false;
 };
 
-
 class IEventsWriterFactory {
 public:
-    virtual IEventsWriterWrapper::TPtr CreateEventsWriter(const NKikimrConfig::TSqsConfig& config,  const ::NMonitoring::TDynamicCounterPtr& counters) const = 0;
+    virtual IEventsWriterWrapper::TPtr CreateEventsWriter(const NKikimrConfig::TSqsConfig& config, const ::NMonitoring::TDynamicCounterPtr& counters) const = 0;
+    virtual IEventsWriterWrapper::TPtr CreateCloudEventsWriter(const NKikimrConfig::TSqsConfig& config, const NMonitoring::TDynamicCounterPtr& counters) const = 0;
     virtual ~IEventsWriterFactory()
     {}
 };

--- a/ydb/public/api/client/yc_public/events/common.proto
+++ b/ydb/public/api/client/yc_public/events/common.proto
@@ -50,9 +50,14 @@ message Authentication {
     FEDERATED_USER_ACCOUNT = 3;
   }
 
+  message IamTokenInfo {
+    string masked_iam_token = 1;
+  }
+
   bool authenticated = 1;
   SubjectType subject_type = 2;
   string subject_id = 3;
+  IamTokenInfo token_info = 4;
 }
 
 message Authorization {


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

In addition to https://github.com/ydb-platform/ydb/pull/18333 and https://github.com/ydb-platform/ydb/pull/20231.

There is implements the function of writing to the unified agent for cloud events in YMQ.

In addition, a mapper was implemented that turns a C++ structure into a protobuf structure in order to serialize it and send it to a unified agent.

### Changelog category <!-- remove all except one -->

* Improvement