### PR TITLE
Bridge Mode in CMS: testing nodes limits

### DIFF
--- a/ydb/core/cms/cms_ut.cpp
+++ b/ydb/core/cms/cms_ut.cpp
@@ -2498,18 +2498,73 @@ Y_UNIT_TEST_SUITE(TCmsTest) {
         config.MutableClusterLimits()->SetDisabledNodesLimit(1);
         env.SetCmsConfig(config);
 
-        // Pile #1: 
+        // Pile #1: We can lock one node.
         env.CheckPermissionRequest("user", true, false, true, true, MODE_KEEP_AVAILABLE, TStatus::ALLOW,
                                     MakeAction(TAction::RESTART_SERVICES, env.GetNodeId(0), 60000000, "storage"));
-        // Pile #0: 
+        // Pile #0: We can lock one node.
         env.CheckPermissionRequest("user", true, false, true, true, MODE_KEEP_AVAILABLE, TStatus::ALLOW,
                                     MakeAction(TAction::RESTART_SERVICES, env.GetNodeId(9), 60000000, "storage"));
-        // Pile #1: 
+        // Pile #1: We cannot lock more than one node.
         env.CheckPermissionRequest("user", true, false, true, true, MODE_KEEP_AVAILABLE, TStatus::DISALLOW_TEMP,
                                     MakeAction(TAction::RESTART_SERVICES, env.GetNodeId(2), 60000000, "storage"));
-        // Pile #0: 
+        // Pile #0: We cannot lock more than one node.
         env.CheckPermissionRequest("user", true, false, true, true, MODE_KEEP_AVAILABLE, TStatus::DISALLOW_TEMP,
                                     MakeAction(TAction::RESTART_SERVICES, env.GetNodeId(11), 60000000, "storage"));
+    }
+
+    Y_UNIT_TEST(BridgeModeSysTablets) {
+        TTestEnvOpts opts(12, 0);
+        TCmsTestEnv env(opts.WithBridgeMode(2, true));
+        env.EnableSysNodeChecking();
+
+        TTestActorRuntime::TEventObserver prev = env.SetObserverFunc([&](TAutoPtr<IEventHandle>& ev) {
+            if (ev->GetTypeRewrite() == TEvInterconnect::EvNodesInfo) {
+                auto *x = reinterpret_cast<TEvInterconnect::TEvNodesInfo::TPtr*>(&ev);
+                ChangePileMap(x);
+            }
+            return prev(ev);
+        });
+
+        // Locking 3 nodes in each pile
+        env.CheckPermissionRequest("user", false, false, false, true, MODE_MAX_AVAILABILITY, TStatus::ALLOW,
+                                   MakeAction(TAction::RESTART_SERVICES, env.GetNodeId(0), 60000000, "storage"));
+        env.CheckPermissionRequest("user", false, false, false, true, MODE_MAX_AVAILABILITY, TStatus::ALLOW,
+                                   MakeAction(TAction::RESTART_SERVICES, env.GetNodeId(2), 60000000, "storage"));
+        env.CheckPermissionRequest("user", false, false, false, true, MODE_MAX_AVAILABILITY, TStatus::ALLOW,
+                                   MakeAction(TAction::RESTART_SERVICES, env.GetNodeId(4), 60000000, "storage"));
+
+        env.CheckPermissionRequest("user", false, false, false, true, MODE_MAX_AVAILABILITY, TStatus::ALLOW,
+                                   MakeAction(TAction::RESTART_SERVICES, env.GetNodeId(1), 60000000, "storage"));
+        env.CheckPermissionRequest("user", false, false, false, true, MODE_MAX_AVAILABILITY, TStatus::ALLOW,
+                                   MakeAction(TAction::RESTART_SERVICES, env.GetNodeId(3), 60000000, "storage"));
+        env.CheckPermissionRequest("user", false, false, false, true, MODE_MAX_AVAILABILITY, TStatus::ALLOW,
+                                   MakeAction(TAction::RESTART_SERVICES, env.GetNodeId(5), 60000000, "storage"));
+        
+        // Pile #1: tablet 'FLAT_BS_CONTROLLER' has too many unavailable nodes. Locked: 3, down: 0, limit: 3
+        env.CheckPermissionRequest("user", false, false, false, true, MODE_MAX_AVAILABILITY, TStatus::DISALLOW_TEMP,
+                                   MakeAction(TAction::RESTART_SERVICES, env.GetNodeId(6), 60000000, "storage"));
+        // Pile #2: tablet 'FLAT_BS_CONTROLLER' has too many unavailable nodes. Locked: 3, down: 0, limit: 3
+        env.CheckPermissionRequest("user", false, false, false, true, MODE_MAX_AVAILABILITY, TStatus::DISALLOW_TEMP,
+                                   MakeAction(TAction::RESTART_SERVICES, env.GetNodeId(7), 60000000, "storage"));
+        
+        // Locking 5 nodes in each pile (MODE_KEEP_AVAILABLE)
+        env.CheckPermissionRequest("user", false, false, false, true, MODE_KEEP_AVAILABLE, TStatus::ALLOW,
+                                   MakeAction(TAction::RESTART_SERVICES, env.GetNodeId(6), 60000000, "storage"));
+        env.CheckPermissionRequest("user", false, false, false, true, MODE_KEEP_AVAILABLE, TStatus::ALLOW,
+                                   MakeAction(TAction::RESTART_SERVICES, env.GetNodeId(7), 60000000, "storage"));
+
+        env.CheckPermissionRequest("user", false, false, false, true, MODE_KEEP_AVAILABLE, TStatus::ALLOW,
+                                   MakeAction(TAction::RESTART_SERVICES, env.GetNodeId(8), 60000000, "storage"));
+        env.CheckPermissionRequest("user", false, false, false, true, MODE_KEEP_AVAILABLE, TStatus::ALLOW,
+                                   MakeAction(TAction::RESTART_SERVICES, env.GetNodeId(9), 60000000, "storage"));
+        
+        // Pile #1: tablet 'FLAT_BS_CONTROLLER' has too many unavailable nodes. Locked: 5, down: 0, limit: 5 (MODE_KEEP_AVAILABLE)
+        env.CheckPermissionRequest("user", false, false, false, true, MODE_KEEP_AVAILABLE, TStatus::DISALLOW_TEMP,
+                                   MakeAction(TAction::RESTART_SERVICES, env.GetNodeId(10), 60000000, "storage"));
+        // Pile #0: tablet 'FLAT_BS_CONTROLLER' has too many unavailable nodes. Locked: 5, down: 0, limit: 5 (MODE_KEEP_AVAILABLE)
+        env.CheckPermissionRequest("user", false, false, false, true, MODE_KEEP_AVAILABLE, TStatus::DISALLOW_TEMP,
+                                   MakeAction(TAction::RESTART_SERVICES, env.GetNodeId(11), 60000000, "storage"));
+        
     }
 }
 

--- a/ydb/core/cms/cms_ut_common.cpp
+++ b/ydb/core/cms/cms_ut_common.cpp
@@ -654,10 +654,9 @@ TCmsTestEnv::TCmsTestEnv(const TTestEnvOpts &options)
             options.PileCount - 1,
             TStateStorageInfo::TRingGroup{.State = SYNCHRONIZED, .NToSelect = options.NToSelect}
         );
-
         THashMap<ui32, TVector<ui32>> ringGroupIdToNodeIds;
-        for (ui32 i = 0; i < GetNodeCount(); ++i) {
-            ringGroupIdToNodeIds[(i + 1) % options.PileCount].push_back(i);
+        for (ui32 i = 1; i <= GetNodeCount(); ++i) {
+            ringGroupIdToNodeIds[i % options.PileCount].push_back(i - 1);
         }
         auto setuper = options.EnableSimpleStateStorageConfig 
                                               ? CreateCustomStateStorageSetupper(ringGroups, 3) 

--- a/ydb/core/cms/cms_ut_common.cpp
+++ b/ydb/core/cms/cms_ut_common.cpp
@@ -655,11 +655,13 @@ TCmsTestEnv::TCmsTestEnv(const TTestEnvOpts &options)
             TStateStorageInfo::TRingGroup{.State = SYNCHRONIZED, .NToSelect = options.NToSelect}
         );
 
-        THashMap<ui32, TVector<ui32>> ringGroupIdToNodeIds;
-        for (ui32 i = 1; i <= GetNodeCount(); ++i) {
-            ringGroupIdToNodeIds[i % options.PileCount].push_back(i - 1);
+        THashMap<ui32, TVector<ui32>> pileIdToNodeIds;
+        for (ui32 i = 0; i < GetNodeCount(); ++i) {
+            pileIdToNodeIds[(i + 1) % options.PileCount].push_back(i);
         }
-        auto setuper = CreateCustomStateStorageSetupper(ringGroups, ringGroupIdToNodeIds);
+        auto setuper = options.EnableSimpleStateStorageConfig 
+                                              ? CreateCustomStateStorageSetupper(ringGroups, 3) 
+                                              : CreateCustomStateStorageSetupper(ringGroups, pileIdToNodeIds);
 
         for (ui32 nodeIndex = 0; nodeIndex < GetNodeCount(); ++nodeIndex) {
             setuper(*this, nodeIndex);

--- a/ydb/core/cms/cms_ut_common.cpp
+++ b/ydb/core/cms/cms_ut_common.cpp
@@ -655,13 +655,13 @@ TCmsTestEnv::TCmsTestEnv(const TTestEnvOpts &options)
             TStateStorageInfo::TRingGroup{.State = SYNCHRONIZED, .NToSelect = options.NToSelect}
         );
 
-        THashMap<ui32, TVector<ui32>> pileIdToNodeIds;
+        THashMap<ui32, TVector<ui32>> ringGroupIdToNodeIds;
         for (ui32 i = 0; i < GetNodeCount(); ++i) {
-            pileIdToNodeIds[(i + 1) % options.PileCount].push_back(i);
+            ringGroupIdToNodeIds[(i + 1) % options.PileCount].push_back(i);
         }
         auto setuper = options.EnableSimpleStateStorageConfig 
                                               ? CreateCustomStateStorageSetupper(ringGroups, 3) 
-                                              : CreateCustomStateStorageSetupper(ringGroups, pileIdToNodeIds);
+                                              : CreateCustomStateStorageSetupper(ringGroups, ringGroupIdToNodeIds);
 
         for (ui32 nodeIndex = 0; nodeIndex < GetNodeCount(); ++nodeIndex) {
             setuper(*this, nodeIndex);

--- a/ydb/core/cms/cms_ut_common.cpp
+++ b/ydb/core/cms/cms_ut_common.cpp
@@ -654,6 +654,7 @@ TCmsTestEnv::TCmsTestEnv(const TTestEnvOpts &options)
             options.PileCount - 1,
             TStateStorageInfo::TRingGroup{.State = SYNCHRONIZED, .NToSelect = options.NToSelect}
         );
+
         THashMap<ui32, TVector<ui32>> ringGroupIdToNodeIds;
         for (ui32 i = 1; i <= GetNodeCount(); ++i) {
             ringGroupIdToNodeIds[i % options.PileCount].push_back(i - 1);

--- a/ydb/core/cms/cms_ut_common.h
+++ b/ydb/core/cms/cms_ut_common.h
@@ -94,6 +94,7 @@ struct TTestEnvOpts {
     bool EnableSingleCompositeActionGroup;
     bool EnableDynamicGroups;
     bool IsBridgeMode;
+    bool EnableSimpleStateStorageConfig;
 
     using TNodeLocationCallback = std::function<TNodeLocation(ui32)>;
     TNodeLocationCallback NodeLocationCallback;
@@ -118,6 +119,7 @@ struct TTestEnvOpts {
         , EnableSingleCompositeActionGroup(true)
         , EnableDynamicGroups(false)
         , IsBridgeMode(false)
+        , EnableSimpleStateStorageConfig(false)
     {
     }
 
@@ -146,9 +148,10 @@ struct TTestEnvOpts {
         return *this;
     }
 
-    TTestEnvOpts& WithBridgeMode(ui32 pileCount = 2) {
+    TTestEnvOpts& WithBridgeMode(ui32 pileCount = 2, bool enableSimpleStateStorageConfig = false) {
         IsBridgeMode = true;
         PileCount = pileCount;
+        EnableSimpleStateStorageConfig = enableSimpleStateStorageConfig;
         return *this;
     }
 };

--- a/ydb/core/testlib/basics/services.cpp
+++ b/ydb/core/testlib/basics/services.cpp
@@ -320,7 +320,7 @@ namespace NPDisk {
     namespace {
 
         void AddReplicas(TStateStorageInfo::TRingGroup& group, const TVector<TActorId>& replicas) {
-            group.NToSelect = group.NToSelect ?: replicas.size();
+            group.NToSelect = group.NToSelect ? group.NToSelect : replicas.size();
             group.Rings.resize(replicas.size());
             for (size_t i = 0; i < replicas.size(); ++i) {
                 // one replica per ring


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

...

### Changelog category <!-- remove all except one -->

* Not for changelog (changelog entry is not required)

### Description for reviewers <!-- (optional) description for those who read this PR -->

- Добавил тест `BridgeModeNodeLimit` - проверяется корректная обработка лимитов недоступных нод для двух pile'ов независимо;
- Добавил тест `BridgeModeSysTablets` - проверяется корректная обработка лимитов недоступных нод под системными таблетками для двух pile'ов независимо;
- Добавил флаг `EnableSimpleStateStorageConfig` для конфигурации state storage в bridge mode, при которой только одна нода входит в ring'и, тем самым проверки доходят до лимитов системных таблеток, а не обрубаются на state storage, так как заблокировано слишком много ring'ов;
- Исправлен комментарий из предыдущего PR: https://github.com/ydb-platform/ydb/pull/21018#discussion_r2206795775
