### PR TITLE
ci: sync prestable with merge

### DIFF
--- a/.github/workflows/rebase_prestable.yml
+++ b/.github/workflows/rebase_prestable.yml
@@ -43,5 +43,5 @@ jobs:
       - name: Sync ${{ matrix.stable_branch }} to ${{ matrix.prestable_branch }}
         run: |
           git checkout ${{ matrix.prestable_branch }}
-          git rebase origin/${{ matrix.stable_branch }}
-          git push origin ${{ matrix.prestable_branch }} --force
+          git merge --no-ff origin/${{ matrix.stable_branch }}
+          git push origin ${{ matrix.prestable_branch }}


### PR DESCRIPTION
Refs: #20359, #21069
### Changelog category 
* Not for changelog (changelog entry is not required)

### Description for reviewers

Replaced `rebase` with `merge --no-ff` when syncing prestable branch