### PR TITLE
Support atomic truncate for localdb tables

### DIFF
--- a/ydb/core/tablet_flat/flat_comp_gen.cpp
+++ b/ydb/core/tablet_flat/flat_comp_gen.cpp
@@ -307,8 +307,6 @@ void TGenCompactionStrategy::Stop() {
 
     CurrentForcedGenCompactionId = 0;
     NextForcedGenCompactionId = 0;
-    FinishedForcedGenCompactionId = 0;
-    FinishedForcedGenCompactionTs = {};
 
     // Make it possible to Start again
     Generations.clear();

--- a/ydb/core/tablet_flat/flat_database.cpp
+++ b/ydb/core/tablet_flat/flat_database.cpp
@@ -409,6 +409,26 @@ size_t TDatabase::GetOpenTxCount(ui32 table) const
     return Require(table)->GetOpenTxCount();
 }
 
+size_t TDatabase::GetTxsWithDataCount(ui32 table) const
+{
+    return Require(table)->GetTxsWithDataCount();
+}
+
+size_t TDatabase::GetTxsWithStatusCount(ui32 table) const
+{
+    return Require(table)->GetTxsWithStatusCount();
+}
+
+size_t TDatabase::GetCommittedTxCount(ui32 table) const
+{
+    return Require(table)->GetCommittedTxCount();
+}
+
+size_t TDatabase::GetRemovedTxCount(ui32 table) const
+{
+    return Require(table)->GetRemovedTxCount();
+}
+
 void TDatabase::RemoveRowVersions(ui32 table, const TRowVersion& lower, const TRowVersion& upper)
 {
     if (Y_LIKELY(lower < upper)) {

--- a/ydb/core/tablet_flat/flat_database.cpp
+++ b/ydb/core/tablet_flat/flat_database.cpp
@@ -569,6 +569,13 @@ TEpoch TDatabase::TxSnapTable(ui32 table)
     return DatabaseImpl->FlushTable(table);
 }
 
+void TDatabase::Truncate(ui32 table)
+{
+    Y_ENSURE(Redo, "Cannot Truncate outside a transaction");
+    ++Change->Snapshots;
+    DatabaseImpl->TruncateTable(table);
+}
+
 TAutoPtr<TSubset> TDatabase::CompactionSubset(ui32 table, TEpoch before, TArrayRef<const TLogoBlobID> bundle) const
 {
     return Require(table)->CompactionSubset(before, bundle);
@@ -778,6 +785,7 @@ TDatabase::TProd TDatabase::Commit(TTxStamp stamp, bool commit, TCookieAllocator
 
         Change->Garbage = std::move(DatabaseImpl->Garbage);
         Change->Deleted = std::move(DatabaseImpl->Deleted);
+        Change->Truncated = std::move(DatabaseImpl->Truncated);
         Change->Affects = DatabaseImpl->GrabAffects();
         Change->Annex = std::move(annex);
 

--- a/ydb/core/tablet_flat/flat_database.h
+++ b/ydb/core/tablet_flat/flat_database.h
@@ -174,6 +174,12 @@ public:
      */
     size_t GetOpenTxCount(ui32 table) const;
 
+    // Exposed for tests
+    size_t GetTxsWithDataCount(ui32 table) const;
+    size_t GetTxsWithStatusCount(ui32 table) const;
+    size_t GetCommittedTxCount(ui32 table) const;
+    size_t GetRemovedTxCount(ui32 table) const;
+
     /**
      * Remove row versions [lower, upper) from the given table
      *

--- a/ydb/core/tablet_flat/flat_database.h
+++ b/ydb/core/tablet_flat/flat_database.h
@@ -202,6 +202,7 @@ public:
     TAlter& Alter(); /* Begin DDL ALTER script */
 
     TEpoch TxSnapTable(ui32 table);
+    void Truncate(ui32 table);
 
     const TScheme& GetScheme() const noexcept;
 

--- a/ydb/core/tablet_flat/flat_dbase_change.h
+++ b/ydb/core/tablet_flat/flat_dbase_change.h
@@ -26,6 +26,11 @@ namespace NTable {
             TRowVersion Upper;
         };
 
+        struct TTruncate {
+            ui32 Table;
+            TAutoPtr<TSubset> Subset;
+        };
+
         TChange(TTxStamp stamp, ui64 serial)
             : Stamp(stamp), Serial(serial) { }
 
@@ -55,6 +60,8 @@ namespace NTable {
         TVector<ui32> Affects;  /* This tables touched in redo  */
         TVector<ui32> Deleted;  /* Tables deleted in some alter */
         TGarbage Garbage;       /* Wiped tables, ids in Deleted */
+
+        TVector<TTruncate> Truncated; /* Truncated tables */
 
         ui32 Snapshots = 0;
 

--- a/ydb/core/tablet_flat/flat_executor.h
+++ b/ydb/core/tablet_flat/flat_executor.h
@@ -522,6 +522,7 @@ class TExecutor
     void CheckCollectionBarrier(TIntrusivePtr<TBarrier> &barrier);
     void UtilizeSubset(const NTable::TSubset&, const NTable::NFwd::TSeen&,
         THashSet<TLogoBlobID> reusedBundles, TLogCommit *commit);
+    void UtilizeSubset(const NTable::TSubset&, TLogCommit *commit);
     bool PrepareExternalPart(TPendingPartSwitch &partSwitch, NTable::TPartComponents &&pc);
     bool PrepareExternalPart(TPendingPartSwitch &partSwitch, TPendingPartSwitch::TNewBundle &bundle);
     bool PrepareExternalTxStatus(TPendingPartSwitch &partSwitch, const NPageCollection::TLargeGlobId &dataId, NTable::TEpoch epoch, const TString &data);

--- a/ydb/core/tablet_flat/flat_executor_compaction_logic.h
+++ b/ydb/core/tablet_flat/flat_executor_compaction_logic.h
@@ -100,6 +100,7 @@ struct TCompactionLogicState {
 
         // monotonically growing, i.e. edge-like
         ui64 CurrentForcedMemCompactionId = 0;
+        ui64 LastStartedFullCompactionId = 0;
 
         bool ChangesRequested = false;
 
@@ -183,6 +184,7 @@ class TCompactionLogic {
 
     void StopTable(TCompactionLogicState::TTableInfo &table);
     void StrategyChanging(TCompactionLogicState::TTableInfo &table);
+    void ResubmitCompactions(TCompactionLogicState::TTableInfo &table);
 
     TCompactionLogicState::TTableInfo* HandleCompaction(
         ui64 compactionId,

--- a/ydb/core/tablet_flat/flat_executor_ut.cpp
+++ b/ydb/core/tablet_flat/flat_executor_ut.cpp
@@ -7917,6 +7917,279 @@ Y_UNIT_TEST_SUITE(TFlatTableExecutor_Truncate) {
         env.SendFollowerSync(new NFake::TEvExecute{ new TTxCheckRows(false, 4) });
     }
 
+    template<bool WaitForCommit = false>
+    struct TTxLambdaGeneric : public ITransaction {
+        const std::function<bool (TTransactionContext&)> Lambda;
+
+        template<class... TLambdas>
+        TTxLambdaGeneric(TLambdas&&... lambdas)
+            : Lambda([... lambdas = std::forward<TLambdas>(lambdas)](TTransactionContext& txc) {
+                return (lambdas(txc) && ...);
+            })
+        {}
+
+        bool Execute(TTransactionContext& txc, const TActorContext& ctx) override {
+            bool commit = Lambda(txc);
+            if (commit && !WaitForCommit) {
+                ctx.Send(ctx.SelfID, new NFake::TEvReturn);
+            }
+            return commit;
+        }
+
+        void Complete(const TActorContext& ctx) override {
+            if (WaitForCommit) {
+                ctx.Send(ctx.SelfID, new NFake::TEvReturn);
+            }
+        }
+    };
+
+    using TTxLambda = TTxLambdaGeneric<false>;
+    using TTxLambdaAndWaitForCommit = TTxLambdaGeneric<true>;
+
+    static auto OpWrite(i64 key, TString value, ui64 txId = 0) {
+        return [key, value, txId](TTransactionContext& txc) {
+            const auto keyCell = NScheme::TInt64::TInstance(key);
+
+            const auto valueCell = NScheme::TString::TInstance(value);
+            NTable::TUpdateOp ops{ TRowsModel::ColumnValueId, NTable::ECellOp::Set, valueCell };
+
+            if (txId == 0) {
+                txc.DB.Update(TRowsModel::TableId, NTable::ERowOp::Upsert, { keyCell }, { ops });
+            } else {
+                txc.DB.UpdateTx(TRowsModel::TableId, NTable::ERowOp::Upsert, { keyCell }, { ops }, txId);
+            }
+            return true;
+        };
+    }
+
+    static auto OpCommitTx(ui64 txId, const TRowVersion& version = TRowVersion::Min()) {
+        return [txId, version](TTransactionContext& txc) {
+            txc.DB.CommitTx(TRowsModel::TableId, txId, version);
+            return true;
+        };
+    }
+
+    static auto OpTruncate() {
+        return [](TTransactionContext& txc) {
+            txc.DB.Truncate(TRowsModel::TableId);
+            return true;
+        };
+    }
+
+    static auto OpReadRows(TString& data, ui64 txId = 0) {
+        return [&data, txId](TTransactionContext& txc) {
+            TStringBuilder builder;
+
+            TVector<NTable::TTag> tags;
+            tags.push_back(TRowsModel::ColumnKeyId);
+            tags.push_back(TRowsModel::ColumnValueId);
+
+            NTable::ITransactionMapPtr txMap;
+            if (txId != 0) {
+                txMap = MakeIntrusive<NTable::TSingleTransactionMap>(txId, TRowVersion::Min());
+            }
+
+            NTable::EReady ready;
+            auto it = txc.DB.IterateRange(TRowsModel::TableId, { }, tags, TRowVersion::Max(), txMap);
+
+            while ((ready = it->Next(NTable::ENext::All)) != NTable::EReady::Gone) {
+                if (ready == NTable::EReady::Page) {
+                    return false;
+                }
+
+                const auto& row = it->Row();
+
+                TString key;
+                DbgPrintValue(key, row.Get(0), NScheme::TTypeInfo(NScheme::TUint64::TypeId));
+
+                TString value;
+                DbgPrintValue(value, row.Get(1), NScheme::TTypeInfo(NScheme::TString::TypeId));
+
+                builder << "Key " << key << " = " << row.GetRowState()
+                    << " value = " << NTable::ECellOp(row.GetCellOp(1)) << " " << value << "\n";
+            }
+
+            data = builder;
+            return true;
+        };
+    }
+
+    Y_UNIT_TEST(PartiallyCommitThenTruncateAndWrite) {
+        TMyEnvBase env;
+        TRowsModel rows;
+
+        env->SetLogPriority(NKikimrServices::TABLET_EXECUTOR, NActors::NLog::PRI_DEBUG);
+
+        // Start the first tablet
+        env.FireTablet(env.Edge, env.Tablet, [&env](const TActorId &tablet, TTabletStorageInfo *info) {
+            return new TTestFlatTablet(env.Edge, tablet, info);
+        });
+        env.WaitForWakeUp();
+
+        // Init schema
+        {
+            TIntrusivePtr<TCompactionPolicy> policy = new TCompactionPolicy();
+            env.SendSync(rows.MakeScheme(std::move(policy)));
+        }
+
+        Cerr << "...inserting initial rows" << Endl;
+        env.SendSync(new NFake::TEvExecute{ new TTxLambda(
+            OpWrite(1, "value1", 101),
+            OpWrite(2, "value2", 102),
+            OpCommitTx(101))
+        });
+
+        Cerr << "...checking rows before compaction" << Endl;
+        {
+            TString data1, data2, data3;
+            env.SendSync(new NFake::TEvExecute{ new TTxLambda(
+                OpReadRows(data1),
+                OpReadRows(data2, 102),
+                [&](TTransactionContext& txc) {
+                    data3 = TStringBuilder()
+                        << "OpenTxCount: " << txc.DB.GetOpenTxCount(TRowsModel::TableId) << "\n"
+                        << "TxsWithDataCount: " << txc.DB.GetTxsWithDataCount(TRowsModel::TableId) << "\n"
+                        << "TxsWithStatusCount: " << txc.DB.GetTxsWithStatusCount(TRowsModel::TableId) << "\n"
+                        << "CommittedTxCount: " << txc.DB.GetCommittedTxCount(TRowsModel::TableId) << "\n"
+                        << "RemovedTxCount: " << txc.DB.GetRemovedTxCount(TRowsModel::TableId) << "\n";
+                    return true;
+                })
+            });
+            UNIT_ASSERT_VALUES_EQUAL(data1,
+                "Key 1 = Upsert value = Set value1\n");
+            UNIT_ASSERT_VALUES_EQUAL(data2,
+                "Key 1 = Upsert value = Set value1\n"
+                "Key 2 = Upsert value = Set value2\n");
+            UNIT_ASSERT_VALUES_EQUAL(data3,
+                "OpenTxCount: 1\n"
+                "TxsWithDataCount: 2\n"
+                "TxsWithStatusCount: 1\n"
+                "CommittedTxCount: 1\n"
+                "RemovedTxCount: 0\n");
+        }
+
+        Cerr << "...compacting table" << Endl;
+        env.SendSync(new NFake::TEvCompact(TRowsModel::TableId));
+        env.WaitFor<NFake::TEvCompacted>();
+
+        Cerr << "...checking rows before truncate" << Endl;
+        {
+            TString data1, data2, data3;
+            env.SendSync(new NFake::TEvExecute{ new TTxLambda(
+                OpReadRows(data1),
+                OpReadRows(data2, 102),
+                [&](TTransactionContext& txc) {
+                    data3 = TStringBuilder()
+                        << "OpenTxCount: " << txc.DB.GetOpenTxCount(TRowsModel::TableId) << "\n"
+                        << "TxsWithDataCount: " << txc.DB.GetTxsWithDataCount(TRowsModel::TableId) << "\n"
+                        << "TxsWithStatusCount: " << txc.DB.GetTxsWithStatusCount(TRowsModel::TableId) << "\n"
+                        << "CommittedTxCount: " << txc.DB.GetCommittedTxCount(TRowsModel::TableId) << "\n"
+                        << "RemovedTxCount: " << txc.DB.GetRemovedTxCount(TRowsModel::TableId) << "\n";
+                    return true;
+                })
+            });
+            UNIT_ASSERT_VALUES_EQUAL(data1,
+                "Key 1 = Upsert value = Set value1\n");
+            UNIT_ASSERT_VALUES_EQUAL(data2,
+                "Key 1 = Upsert value = Set value1\n"
+                "Key 2 = Upsert value = Set value2\n");
+            // Note: data for tx 101 was compacted as committed
+            UNIT_ASSERT_VALUES_EQUAL(data3,
+                "OpenTxCount: 1\n"
+                "TxsWithDataCount: 1\n"
+                "TxsWithStatusCount: 1\n"
+                "CommittedTxCount: 1\n"
+                "RemovedTxCount: 0\n");
+        }
+
+        Cerr << "...truncating and writing to table" << Endl;
+        {
+            TString data1, data2;
+            env.SendSync(new NFake::TEvExecute{ new TTxLambda(
+                OpTruncate(),
+                OpWrite(11, "value11", 111),
+                OpWrite(22, "value22", 122),
+                OpCommitTx(111),
+                OpReadRows(data1),
+                OpReadRows(data2, 122))
+            });
+            UNIT_ASSERT_VALUES_EQUAL(data1,
+                "Key 11 = Upsert value = Set value11\n");
+            UNIT_ASSERT_VALUES_EQUAL(data2,
+                "Key 11 = Upsert value = Set value11\n"
+                "Key 22 = Upsert value = Set value22\n");
+        }
+
+        Cerr << "...checking rows (expecting new data and no metadata for old transactions)" << Endl;
+        {
+            TString data1, data2, data3;
+            env.SendSync(new NFake::TEvExecute{ new TTxLambda(
+                OpReadRows(data1),
+                OpReadRows(data2, 122),
+                [&](TTransactionContext& txc) {
+                    data3 = TStringBuilder()
+                        << "OpenTxCount: " << txc.DB.GetOpenTxCount(TRowsModel::TableId) << "\n"
+                        << "TxsWithDataCount: " << txc.DB.GetTxsWithDataCount(TRowsModel::TableId) << "\n"
+                        << "TxsWithStatusCount: " << txc.DB.GetTxsWithStatusCount(TRowsModel::TableId) << "\n"
+                        << "CommittedTxCount: " << txc.DB.GetCommittedTxCount(TRowsModel::TableId) << "\n"
+                        << "RemovedTxCount: " << txc.DB.GetRemovedTxCount(TRowsModel::TableId) << "\n"
+                        << "Tx 101 " << (txc.DB.HasOpenTx(TRowsModel::TableId, 101) ? "is open" : "is not open") << "\n"
+                        << "Tx 101 " << (txc.DB.HasTxData(TRowsModel::TableId, 101) ? "has data" : "has no data") << "\n"
+                        << "Tx 102 " << (txc.DB.HasOpenTx(TRowsModel::TableId, 102) ? "is open" : "is not open") << "\n"
+                        << "Tx 102 " << (txc.DB.HasTxData(TRowsModel::TableId, 102) ? "has data" : "has no data") << "\n"
+                        << "Tx 111 " << (txc.DB.HasOpenTx(TRowsModel::TableId, 111) ? "is open" : "is not open") << "\n"
+                        << "Tx 111 " << (txc.DB.HasTxData(TRowsModel::TableId, 111) ? "has data" : "has no data") << "\n"
+                        << "Tx 122 " << (txc.DB.HasOpenTx(TRowsModel::TableId, 122) ? "is open" : "is not open") << "\n"
+                        << "Tx 122 " << (txc.DB.HasTxData(TRowsModel::TableId, 122) ? "has data" : "has no data") << "\n";
+                    return true;
+                })
+            });
+            UNIT_ASSERT_VALUES_EQUAL(data1,
+                "Key 11 = Upsert value = Set value11\n");
+            UNIT_ASSERT_VALUES_EQUAL(data2,
+                "Key 11 = Upsert value = Set value11\n"
+                "Key 22 = Upsert value = Set value22\n");
+            UNIT_ASSERT_VALUES_EQUAL(data3,
+                "OpenTxCount: 1\n"
+                "TxsWithDataCount: 2\n"
+                "TxsWithStatusCount: 1\n"
+                "CommittedTxCount: 1\n"
+                "RemovedTxCount: 0\n"
+                "Tx 101 is not open\n"
+                "Tx 101 has no data\n"
+                "Tx 102 is not open\n"
+                "Tx 102 has no data\n"
+                "Tx 111 is not open\n"
+                "Tx 111 has data\n"
+                "Tx 122 is open\n"
+                "Tx 122 has data\n");
+        }
+
+        for (int i = 0; i < 2; ++i) {
+            Cerr << "...restarting tablet" << Endl;
+            env.SendSync(new TEvents::TEvPoison, false, true);
+            env.WaitForGone();
+            env.FireTablet(env.Edge, env.Tablet, [&env](const TActorId &tablet, TTabletStorageInfo *info) {
+                return new TTestFlatTablet(env.Edge, tablet, info);
+            });
+            env.WaitForWakeUp();
+
+            Cerr << "...checking rows (expecting new)" << Endl;
+            {
+                TString data1, data2;
+                env.SendSync(new NFake::TEvExecute{ new TTxLambda(
+                    OpReadRows(data1),
+                    OpReadRows(data2, 122))
+                }, /* retry */ true);
+                UNIT_ASSERT_VALUES_EQUAL(data1,
+                    "Key 11 = Upsert value = Set value11\n");
+                UNIT_ASSERT_VALUES_EQUAL(data2,
+                    "Key 11 = Upsert value = Set value11\n"
+                    "Key 22 = Upsert value = Set value22\n");
+            }
+        }
+    }
+
 }
 
 }

--- a/ydb/core/tablet_flat/flat_table.cpp
+++ b/ydb/core/tablet_flat/flat_table.cpp
@@ -1168,6 +1168,11 @@ size_t TTable::GetTxsWithDataCount() const
     return TxDataRefs.size();
 }
 
+size_t TTable::GetTxsWithStatusCount() const
+{
+    return TxStatusRefs.size();
+}
+
 size_t TTable::GetCommittedTxCount() const
 {
     return CommittedTransactions.Size();

--- a/ydb/core/tablet_flat/flat_table.h
+++ b/ydb/core/tablet_flat/flat_table.h
@@ -186,6 +186,7 @@ public:
     const absl::flat_hash_set<ui64>& GetOpenTxs() const;
     size_t GetOpenTxCount() const;
     size_t GetTxsWithDataCount() const;
+    size_t GetTxsWithStatusCount() const;
     size_t GetCommittedTxCount() const;
     size_t GetRemovedTxCount() const;
 

--- a/ydb/core/tablet_flat/flat_table.h
+++ b/ydb/core/tablet_flat/flat_table.h
@@ -69,6 +69,7 @@ public:
     ~TTable();
 
     void PrepareRollback();
+    void PrepareTruncate();
     void RollbackChanges();
     void CommitChanges(TArrayRef<const TMemGlob> blobs);
     void CommitNewTable(TArrayRef<const TMemGlob> blobs);
@@ -437,6 +438,7 @@ private:
         bool MutableExisted;
         bool MutableUpdated;
         bool DisableEraseCache;
+        bool Truncated;
 
         TRollbackState(TEpoch epoch)
             : Epoch(epoch)


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

...

### Changelog category <!-- remove all except one -->

* Not for changelog (changelog entry is not required)

### Description for reviewers <!-- (optional) description for those who read this PR -->

This PR implements TDatabase::Truncate to atomically delete all table data.

Fixes #21180.