### PR TITLE
Finish LocalRecovery with error if ChunkReadResult is erroneous

### DIFF
--- a/ydb/core/blobstorage/ut_blobstorage/recovery.cpp
+++ b/ydb/core/blobstorage/ut_blobstorage/recovery.cpp
@@ -3,7 +3,7 @@
 #include <ydb/core/driver_lib/version/version.h>
 #include <ydb/core/driver_lib/version/ut/ut_helpers.h>
 
-#include "ut_helpers.h"
+#include <ydb/core/blobstorage/ut_blobstorage/env/ut_helpers.h>
 
 #include <library/cpp/testing/unittest/registar.h>
 

--- a/ydb/core/blobstorage/ut_blobstorage/recovery.cpp
+++ b/ydb/core/blobstorage/ut_blobstorage/recovery.cpp
@@ -3,9 +3,13 @@
 #include <ydb/core/driver_lib/version/version.h>
 #include <ydb/core/driver_lib/version/ut/ut_helpers.h>
 
+#include "ut_helpers.h"
+
 #include <library/cpp/testing/unittest/registar.h>
 
 #include <google/protobuf/text_format.h>
+
+using namespace NKikimr;
 
 Y_UNIT_TEST_SUITE(CompatibilityInfo) {
     using EComponentId = NKikimrConfig::TCompatibilityRule::EComponentId;
@@ -230,5 +234,82 @@ Y_UNIT_TEST_SUITE(CompatibilityInfo) {
     Y_UNIT_TEST(BSControllerMigration) {
         TestMigration(TVersion{ 23, 3, 13, 0 }, TVersion{ 23, 4, 1, 0 }, TVersion{ 23, 5, 1, 0 }, componentBSController, ValidateForBSController);
     }
+}
 
+
+Y_UNIT_TEST_SUITE(VDiskRecovery) {
+    struct TTestCtx : public TTestCtxBase {
+        TTestCtx()
+            : TTestCtxBase(TEnvironmentSetup::TSettings{
+                .NodeCount = 8,
+                .Erasure = TBlobStorageGroupType::Erasure4Plus2Block,
+                .ControllerNodeId = 1,
+            })
+        {}
+
+        void RestartNode() {
+            Env->StopNode(NodeToRestart);
+            Env->Sim(TDuration::Minutes(1));
+            Env->StartNode(NodeToRestart);
+        }
+
+        ui32 NodeToRestart = 2;
+    };
+
+    void TestVDiskRecovery() {
+        TTestCtx ctx;
+        ctx.Initialize();
+        TVDiskID vdiskId;
+        for (const auto& vslot : ctx.BaseConfig.GetVSlot()) {
+            if (vslot.GetVSlotId().GetNodeId() == ctx.NodeToRestart) {
+                vdiskId = TVDiskID(vslot.GetGroupId(), vslot.GetGroupGeneration(), vslot.GetFailRealmIdx(),
+                        vslot.GetFailDomainIdx(), vslot.GetVDiskIdx());
+                break;
+            } 
+        }
+
+        ctx.WriteCompressedData(TTestCtxBase::TDataProfile{
+            .GroupId = ctx.GroupId,
+            .TotalSize = 10_MB,
+            .BlobSize = 100,
+        });
+
+        ctx.WriteCompressedData(TTestCtxBase::TDataProfile{
+            .GroupId = ctx.GroupId,
+            .TotalBlobs = 100,
+            .BlobSize = 4_MB,
+        });
+
+        ctx.Env->Runtime->FilterFunction = [&](ui32 nodeId, std::unique_ptr<IEventHandle>& ev) {
+            if (nodeId == ctx.NodeToRestart) {
+                if (ev->GetTypeRewrite() == NPDisk::TEvChunkReadResult::EventType) {
+                    NPDisk::TEvChunkReadResult* result = ev->Get<NPDisk::TEvChunkReadResult>();
+                    result->Status = NKikimrProto::ERROR;
+                }
+            }
+
+            return true;
+        };
+
+        ctx.RestartNode();
+
+        ctx.Env->Sim(TDuration::Minutes(5));
+
+        NKikimrBlobStorage::EVDiskQueueId queueId = NKikimrBlobStorage::GetFastRead;
+
+        TAutoPtr<TEventHandle<TEvBlobStorage::TEvVStatusResult>> res;
+        ctx.Env->WithQueueId(vdiskId, queueId, [&](const TActorId& actorId) {
+            ctx.Env->Runtime->Send(new IEventHandle(actorId, ctx.Edge, new TEvBlobStorage::TEvVStatus()), actorId.NodeId());
+            res = ctx.Env->WaitForEdgeActorEvent<TEvBlobStorage::TEvVStatusResult>(ctx.Edge, false, ctx.Env->Now() + TDuration::Seconds(10));
+        });
+
+        UNIT_ASSERT(res);
+        Cerr << res->Get()->ToString() << Endl;
+        NKikimrProto::EReplyStatus status = res->Get()->Record.GetStatus();
+        UNIT_ASSERT_C(status == NKikimrProto::VDISK_ERROR_STATE, res->Get()->ToString());
+    }
+
+    Y_UNIT_TEST(ChunkReadErrorOnVDiskRecovery) {
+        TestVDiskRecovery();
+    }
 }

--- a/ydb/core/blobstorage/vdisk/hullop/blobstorage_hullload.h
+++ b/ydb/core/blobstorage/vdisk/hullop/blobstorage_hullload.h
@@ -399,7 +399,7 @@ namespace NKikimr {
             this->PassAway();
         }
 
-        void Handle(const TEvents::TEvActorDied::TPtr& ev) {
+        void Handle(const TEvents::TEvActorDied::TPtr&) {
             // One LevelSegmentLoader termintaed unsuccessfully
             // send TEvActorDied to the parent and Die
             // This actor only has one child actor at a time, no need to clear ActiveActors
@@ -486,7 +486,7 @@ namespace NKikimr {
             this->PassAway();
         }
 
-        void Handle(const TEvents::TEvActorDied::TPtr& ev) {
+        void Handle(const TEvents::TEvActorDied::TPtr&) {
             // One LevelSegmentLoader termintaed unsuccessfully, kill all other actors,
             // send TEvActorDied to the parent and Die
             // This actor only has one child actor at a time, no need to clear ActiveActors
@@ -586,7 +586,7 @@ namespace NKikimr {
             this->PassAway();
         }
 
-        void Handle(const TEvents::TEvActorDied::TPtr& ev) {
+        void Handle(const TEvents::TEvActorDied::TPtr&) {
             // One LevelSegmentLoader termintaed unsuccessfully, kill all other actors,
             // send TEvActorDied to the parent and Die
             // This actor only has one child actor at a time, no need to clear ActiveActors

--- a/ydb/core/blobstorage/vdisk/hullop/blobstorage_hullload.h
+++ b/ydb/core/blobstorage/vdisk/hullop/blobstorage_hullload.h
@@ -224,7 +224,14 @@ namespace NKikimr {
 
         void Handle(NPDisk::TEvChunkReadResult::TPtr &ev, const TActorContext &ctx) {
             auto *msg = ev->Get();
-            CHECK_PDISK_RESPONSE_READABLE_MSG(VCtx, ev, ctx, TStringBuilder() << "{Origin# '" << Origin << "'}");
+
+            TString errorString = TStringBuilder() << "{Origin# '" << Origin << "'}";
+            if (!VCtx->CheckPDiskResponse(ctx, *ev->Get(), errorString) ||
+                !VCtx->CheckPDiskResponseReadable(ctx, *ev->Get(), errorString)) {
+                this->Send(Recipient, new TEvents::TEvActorDied);
+                this->PassAway();
+                return;
+            }
 
             const TBufferWithGaps &data = msg->Data;
             LevelSegment->IndexParts.push_back({msg->ChunkIdx, msg->Offset, msg->Data.Size()});
@@ -387,15 +394,23 @@ namespace NKikimr {
             Process(ctx);
         }
 
-        void HandlePoison(TEvents::TEvPoisonPill::TPtr &ev, const TActorContext &ctx) {
-            Y_UNUSED(ev);
-            ActiveActors.KillAndClear(ctx);
-            TThis::Die(ctx);
+        void HandlePoison() {
+            ActiveActors.KillAndClear(TActivationContext::AsActorContext());
+            this->PassAway();
+        }
+
+        void Handle(const TEvents::TEvActorDied::TPtr& ev) {
+            // One LevelSegmentLoader termintaed unsuccessfully
+            // send TEvActorDied to the parent and Die
+            // This actor only has one child actor at a time, no need to clear ActiveActors
+            this->Send(Recipient, new TEvents::TEvActorDied);
+            this->PassAway();
         }
 
         STRICT_STFUNC(StateFunc,
             HTemplFunc(THullSegLoaded, Handle)
-            HFunc(TEvents::TEvPoisonPill, HandlePoison)
+            hFunc(TEvents::TEvActorDied, Handle)
+            cFunc(TEvents::TEvPoisonPill::EventType, HandlePoison)
         )
 
     public:
@@ -466,15 +481,23 @@ namespace NKikimr {
             Process(ctx);
         }
 
-        void HandlePoison(TEvents::TEvPoisonPill::TPtr &ev, const TActorContext &ctx) {
-            Y_UNUSED(ev);
-            ActiveActors.KillAndClear(ctx);
-            TThis::Die(ctx);
+        void HandlePoison() {
+            ActiveActors.KillAndClear(TActivationContext::AsActorContext());
+            this->PassAway();
+        }
+
+        void Handle(const TEvents::TEvActorDied::TPtr& ev) {
+            // One LevelSegmentLoader termintaed unsuccessfully, kill all other actors,
+            // send TEvActorDied to the parent and Die
+            // This actor only has one child actor at a time, no need to clear ActiveActors
+            this->Send(Recipient, new TEvents::TEvActorDied);
+            this->PassAway();
         }
 
         STRICT_STFUNC(StateFunc,
             HTemplFunc(THullSegLoaded, Handle)
-            HFunc(TEvents::TEvPoisonPill, HandlePoison)
+            hFunc(TEvents::TEvActorDied, Handle)
+            cFunc(TEvents::TEvPoisonPill::EventType, HandlePoison)
         )
 
     public:
@@ -558,15 +581,23 @@ namespace NKikimr {
             Process(ctx);
         }
 
-        void HandlePoison(TEvents::TEvPoisonPill::TPtr &ev, const TActorContext &ctx) {
-            Y_UNUSED(ev);
-            ActiveActors.KillAndClear(ctx);
-            TThis::Die(ctx);
+        void HandlePoison() {
+            ActiveActors.KillAndClear(TActivationContext::AsActorContext());
+            this->PassAway();
+        }
+
+        void Handle(const TEvents::TEvActorDied::TPtr& ev) {
+            // One LevelSegmentLoader termintaed unsuccessfully, kill all other actors,
+            // send TEvActorDied to the parent and Die
+            // This actor only has one child actor at a time, no need to clear ActiveActors
+            this->Send(Recipient, new TEvents::TEvActorDied);
+            this->PassAway();
         }
 
         STRICT_STFUNC(StateFunc,
             HTemplFunc(THullSegLoaded, Handle)
-            HFunc(TEvents::TEvPoisonPill, HandlePoison)
+            hFunc(TEvents::TEvActorDied, Handle)
+            cFunc(TEvents::TEvPoisonPill::EventType, HandlePoison)
         )
 
     public:

--- a/ydb/core/blobstorage/vdisk/localrecovery/localrecovery_readbulksst.cpp
+++ b/ydb/core/blobstorage/vdisk/localrecovery/localrecovery_readbulksst.cpp
@@ -62,7 +62,7 @@ namespace NKikimr {
             this->PassAway();
         }
 
-        void Handle(const TEvents::TEvActorDied::TPtr& ev) {
+        void Handle(const TEvents::TEvActorDied::TPtr&) {
             // One LevelSegmentLoader termintaed unsuccessfully
             // send TEvActorDied to the parent and Die
             // This actor only has one child actor at a time, no need to clear ActiveActors

--- a/ydb/core/blobstorage/vdisk/localrecovery/localrecovery_readbulksst.cpp
+++ b/ydb/core/blobstorage/vdisk/localrecovery/localrecovery_readbulksst.cpp
@@ -57,15 +57,23 @@ namespace NKikimr {
             Process(ctx);
         }
 
-        void HandlePoison(TEvents::TEvPoisonPill::TPtr &ev, const TActorContext &ctx) {
-            Y_UNUSED(ev);
-            ActiveActors.KillAndClear(ctx);
-            TThis::Die(ctx);
+        void HandlePoison() {
+            ActiveActors.KillAndClear(TActivationContext::AsActorContext());
+            this->PassAway();
+        }
+
+        void Handle(const TEvents::TEvActorDied::TPtr& ev) {
+            // One LevelSegmentLoader termintaed unsuccessfully
+            // send TEvActorDied to the parent and Die
+            // This actor only has one child actor at a time, no need to clear ActiveActors
+            this->Send(Recipient, new TEvents::TEvActorDied);
+            this->PassAway();
         }
 
         STRICT_STFUNC(StateFunc,
             HTemplFunc(THullSegLoaded, Handle)
-            HFunc(TEvents::TEvPoisonPill, HandlePoison)
+            hFunc(TEvents::TEvActorDied, Handle)
+            cFunc(TEvents::TEvPoisonPill::EventType, HandlePoison)
         )
 
     public:


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

We have issue when VDisk hangs in endless local recovery if ChunkRead request fails, because it causes Loader actor to switch to terminate state without notifying its parents. This change will allow loader actor to terminate properly on PDisk errors, and LocalRecovery to get notified about this error and to finish with proper status.
https://github.com/ydb-platform/ydb/issues/20520

### Changelog category <!-- remove all except one -->

* Bugfix 

