### PR TITLE
Support XDS protocols for client load balancing in order to request to Access Service 

### DIFF
--- a/ydb/library/grpc/actor_client/grpc_service_client.h
+++ b/ydb/library/grpc/actor_client/grpc_service_client.h
@@ -76,9 +76,11 @@ public:
         using TResponseType = decltype(typename TCallType::TResponseEventType().Response);
         const auto& requestId = ev->Get()->RequestId;
         if (!Connection) {
-            BLOG_GRPC_D(Prefix(requestId) << "Connect to "
-                        << ((Config.EnableSsl || !Config.SslCredentials.pem_root_certs.empty()) ? "grpcs://" : "grpc://")
-                        << Config.Locator);
+            TString schema;
+            if (!Config.UseXds) {
+                schema = ((Config.EnableSsl || !Config.SslCredentials.pem_root_certs.empty()) ? "grpcs://" : "grpc://");
+            }
+            BLOG_GRPC_D(Prefix(requestId) << "Connect to " << schema << Config.Locator);
             Connection = Client.CreateGRpcServiceConnection<TGrpcService>(Config);
         }
 

--- a/ydb/public/sdk/cpp/src/library/grpc/client/grpc_common.h
+++ b/ydb/public/sdk/cpp/src/library/grpc/client/grpc_common.h
@@ -22,7 +22,7 @@ struct TGRpcClientConfig {
     ui32 MaxInFlight = 0;
     bool EnableSsl = false;
     grpc::SslCredentialsOptions SslCredentials;
-    grpc_compression_algorithm CompressionAlgoritm = GRPC_COMPRESS_NONE;
+    grpc_compression_algorithm CompressionAlgorithm = GRPC_COMPRESS_NONE;
     ui64 MemQuota = 0;
     std::unordered_map<std::string, std::string> StringChannelParams;
     std::unordered_map<std::string, int> IntChannelParams;
@@ -47,7 +47,7 @@ struct TGRpcClientConfig {
         , SslCredentials{.pem_root_certs = NYdb::TStringType{caCert},
                          .pem_private_key = NYdb::TStringType{clientPrivateKey},
                          .pem_cert_chain = NYdb::TStringType{clientCert}}
-        , CompressionAlgoritm(compressionAlgorithm)
+        , CompressionAlgorithm(compressionAlgorithm)
         , UseXds((Locator.starts_with("xds:///")))
     {}
 };
@@ -56,7 +56,7 @@ inline std::shared_ptr<grpc::ChannelInterface> CreateChannelInterface(const TGRp
     grpc::ChannelArguments args;
     args.SetMaxReceiveMessageSize(config.MaxInboundMessageSize ? config.MaxInboundMessageSize : config.MaxMessageSize);
     args.SetMaxSendMessageSize(config.MaxOutboundMessageSize ? config.MaxOutboundMessageSize : config.MaxMessageSize);
-    args.SetCompressionAlgorithm(config.CompressionAlgoritm);
+    args.SetCompressionAlgorithm(config.CompressionAlgorithm);
 
     for (const auto& kvp: config.StringChannelParams) {
         args.SetString(NYdb::TStringType{kvp.first}, NYdb::TStringType{kvp.second});


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

Support XDS protocols in GRPC for client load balancing in order to request to Access Service 

### Changelog category <!-- remove all except one -->

* New feature

### Description for reviewers <!-- (optional) description for those who read this PR -->

Add using new credentials `XdsCredentials` when grpc custom channel created
