### PR TITLE
[stable-25-1] Fix cpu counters for cases with stuck actors

### DIFF
--- a/ydb/library/actors/core/execution_stats.h
+++ b/ydb/library/actors/core/execution_stats.h
@@ -62,6 +62,13 @@ namespace NActors {
             }
         }
 
+        void AddOveraddedCpuUs(i64 elapsed) {
+            if (Y_LIKELY(elapsed > 0)) {
+                RelaxedStore(&Stats->OveraddedCpuUs, RelaxedLoad(&Stats->OveraddedCpuUs) + elapsed);
+                RelaxedStore(&Stats->CpuUs, (ui64)RelaxedLoad(&Stats->CpuUs) + elapsed);
+            }
+        }
+
         void IncrementSentEvents() {
             RelaxedStore(&Stats->SentEvents, RelaxedLoad(&Stats->SentEvents) + 1);
         }
@@ -137,9 +144,18 @@ namespace NActors {
         }
 
         void UpdateThreadTime() {
+            ui64 cpuUs = CpuSensor.GetDiff();
+            ui64 overaddedCpuUs = RelaxedLoad(&Stats->OveraddedCpuUs);
+            if (cpuUs < overaddedCpuUs) {
+                RelaxedStore(&Stats->OveraddedCpuUs, overaddedCpuUs - cpuUs);
+            } else if (overaddedCpuUs > 0) {
+                RelaxedStore(&Stats->OveraddedCpuUs, (ui64)0);
+                RelaxedStore(&Stats->CpuUs, (ui64)RelaxedLoad(&Stats->CpuUs) + cpuUs - overaddedCpuUs);
+            } else {
+                RelaxedStore(&Stats->CpuUs, (ui64)RelaxedLoad(&Stats->CpuUs) + cpuUs);
+            }
             RelaxedStore(&Stats->SafeElapsedTicks, (ui64)RelaxedLoad(&Stats->ElapsedTicks));
             RelaxedStore(&Stats->SafeParkedTicks, (ui64)RelaxedLoad(&Stats->ParkedTicks));
-            RelaxedStore(&Stats->CpuUs, (ui64)RelaxedLoad(&Stats->CpuUs) + CpuSensor.GetDiff());
         }
 
         void IncreaseNotEnoughCpuExecutions() {

--- a/ydb/library/actors/core/execution_stats.h
+++ b/ydb/library/actors/core/execution_stats.h
@@ -154,8 +154,7 @@ namespace NActors {
             } else {
                 RelaxedStore(&Stats->CpuUs, (ui64)RelaxedLoad(&Stats->CpuUs) + cpuUs);
             }
-            RelaxedStore(&Stats->SafeElapsedTicks, (ui64)RelaxedLoad(&Stats->ElapsedTicks));
-            RelaxedStore(&Stats->SafeParkedTicks, (ui64)RelaxedLoad(&Stats->ParkedTicks));
+            CopySafeTicks();
         }
 
         void IncreaseNotEnoughCpuExecutions() {
@@ -187,6 +186,11 @@ namespace NActors {
         void Switch(TExecutorThreadStats* stats)
         {
             Stats = stats;
+        }
+
+        void CopySafeTicks() {
+            RelaxedStore(&Stats->SafeElapsedTicks, (ui64)RelaxedLoad(&Stats->ElapsedTicks));
+            RelaxedStore(&Stats->SafeParkedTicks, (ui64)RelaxedLoad(&Stats->ParkedTicks));
         }
     };
 }

--- a/ydb/library/actors/core/executor_thread.cpp
+++ b/ydb/library/actors/core/executor_thread.cpp
@@ -556,6 +556,7 @@ namespace NActors {
             NHPTimer::STime passedTime = Max<i64>(hpnow - activationStart, 0);
             ExecutionStats.SetCurrentActivationTime(activityType, Ts2Us(passedTime));
         }
+        ExecutionStats.CopySafeTicks();
     }
 
     void TExecutorThread::GetCurrentStats(TExecutorThreadStats& statsCopy) {

--- a/ydb/library/actors/core/executor_thread.cpp
+++ b/ydb/library/actors/core/executor_thread.cpp
@@ -551,6 +551,7 @@ namespace NActors {
             ExecutionStats.SetCurrentActivationTime(0, 0);
         } else {
             ExecutionStats.AddElapsedCycles(activityType, hpnow - hpprev);
+            ExecutionStats.AddOveraddedCpuUs(Ts2Us(hpnow - hpprev));
             NHPTimer::STime activationStart = ThreadCtx.ActivityContext.ActivationStartTS.load(std::memory_order_acquire);
             NHPTimer::STime passedTime = Max<i64>(hpnow - activationStart, 0);
             ExecutionStats.SetCurrentActivationTime(activityType, Ts2Us(passedTime));
@@ -569,6 +570,7 @@ namespace NActors {
     }
 
     void TExecutorThread::GetCurrentStatsForHarmonizer(TExecutorThreadStats& statsCopy) {
+        UpdateThreadStats();
         statsCopy.SafeElapsedTicks = RelaxedLoad(&ExecutionStats.Stats->SafeElapsedTicks);
         statsCopy.SafeParkedTicks = RelaxedLoad(&ExecutionStats.Stats->SafeParkedTicks);
         statsCopy.CpuUs = RelaxedLoad(&ExecutionStats.Stats->CpuUs);
@@ -576,6 +578,7 @@ namespace NActors {
     }
 
     void TExecutorThread::GetSharedStatsForHarmonizer(i16 poolId, TExecutorThreadStats &stats) {
+        UpdateThreadStats();
         stats.SafeElapsedTicks = RelaxedLoad(&Stats[poolId].SafeElapsedTicks);
         stats.SafeParkedTicks = RelaxedLoad(&Stats[poolId].SafeParkedTicks);
         stats.CpuUs = RelaxedLoad(&Stats[poolId].CpuUs);

--- a/ydb/library/actors/core/mon_stats.h
+++ b/ydb/library/actors/core/mon_stats.h
@@ -103,6 +103,7 @@ namespace NActors {
         ui64 SafeElapsedTicks = 0;
         ui64 SafeParkedTicks = 0;
         ui64 WorstActivationTimeUs = 0;
+        ui64 OveraddedCpuUs = 0;
 
         TActivationTime CurrentActivationTime;
 

--- a/ydb/library/actors/core/ut/actor_ut.cpp
+++ b/ydb/library/actors/core/ut/actor_ut.cpp
@@ -24,6 +24,96 @@ Y_UNIT_TEST_SUITE(ActorBenchmark) {
     using TSettings = TActorBenchmark::TSettings;
     using TSendReceiveActorParams = TActorBenchmark::TSendReceiveActorParams;
 
+    class TLongRunningActor : public TActorBootstrapped<TLongRunningActor> {
+        public:
+            TLongRunningActor(std::atomic<bool>& stop, ui64 seconds, TThreadParkPad* startPad)
+                : Seconds(seconds)
+                , StartPad(startPad)
+                , StopFlag(stop)
+            {}
+
+            void Bootstrap() {
+                Cerr << "Unpark startPad" << Endl;
+                StartPad->Unpark();
+                constexpr ui64 BufferSize = 10000;
+                TInstant start = TActivationContext::Now();
+                ui64 counter = 0;
+                Buffer.resize(BufferSize);
+                while (!StopFlag && TActivationContext::Now() - start < TDuration::Seconds(Seconds)) {
+                    counter++;
+                    ui64 sum = counter;
+                    for (ui64 i = 0; i < BufferSize; i++) {
+                        sum += Buffer[i];
+                    }
+                    Buffer[counter % BufferSize] = sum;
+                }
+                PassAway();
+            }
+        private:
+            TVector<ui64> Buffer;
+            ui64 Seconds;
+            TThreadParkPad* StartPad;
+            std::atomic<bool>& StopFlag;
+    };
+
+    Y_UNIT_TEST(GetStatisticsWithLongRunningActor) {
+        THolder<TActorSystemSetup> setup =  TActorBenchmark::GetActorSystemSetup();
+        TActorBenchmark::AddBasicPool(setup, 1, true, false);
+
+        TActorSystem actorSystem(setup);
+        actorSystem.Start();
+
+        TThreadParkPad startPad;
+        TThreadParkPad stopPad;
+        TAtomic actorsAlive = 0;
+        std::atomic<bool> stop = false;
+
+        THolder<IActor> longRunningActor{
+            new TTestEndDecorator(THolder(new TLongRunningActor(stop, 1, &startPad)), &stopPad, &actorsAlive)
+        };
+        actorSystem.Register(longRunningActor.Release(), TMailboxType::HTSwap, 0);
+
+        Cerr << "Park startPad" << Endl;
+        startPad.Park();
+
+        ui64 CpuUs = 0;
+        ui64 ElapsedUs = 0;
+        ui64 SafeElapsedUs= 0;
+        for (ui32 i = 0; i < 10; ++i) {
+            NanoSleep(1'000'000);
+            TVector<TExecutorThreadStats> executorThreadStats;
+            TExecutorPoolStats poolStats;
+            actorSystem.GetPoolStats(0, poolStats, executorThreadStats);
+
+            ui64 newCpuUs = 0;
+            ui64 newElapsedUs = 0;
+            ui64 newSafeElapsedUs = 0;
+            for (auto &thread : executorThreadStats) {
+                newCpuUs += thread.CpuUs;
+                newElapsedUs += Ts2Us(thread.ElapsedTicks);
+                newSafeElapsedUs += Ts2Us(thread.SafeElapsedTicks);
+            }
+
+            Cerr << "Iteration " << i << " completed" << Endl;
+            Cerr << "CpuUs: " << CpuUs << " new: " << newCpuUs << Endl;
+            Cerr << "ElapsedUs: " << ElapsedUs << " new: " << newElapsedUs << Endl;
+            Cerr << "SafeElapsedUs: " << SafeElapsedUs << " new: " << newSafeElapsedUs << Endl;
+
+            UNIT_ASSERT_VALUES_UNEQUAL(CpuUs, newCpuUs);
+            UNIT_ASSERT_VALUES_UNEQUAL(ElapsedUs, newElapsedUs);
+            UNIT_ASSERT_VALUES_UNEQUAL(SafeElapsedUs, newSafeElapsedUs);
+
+            CpuUs = newCpuUs;
+            ElapsedUs = newElapsedUs;
+            SafeElapsedUs = newSafeElapsedUs;
+        }
+        stop = true;
+
+        Cerr << "Park stopPad" << Endl;
+        stopPad.Park();
+        actorSystem.Stop();
+    }
+
     Y_UNIT_TEST(WithOnlyOneSharedExecutors) {
         THolder<TActorSystemSetup> setup =  TActorBenchmark::GetActorSystemSetup();
         TActorBenchmark::AddBasicPool(setup, 1, 1, true);


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

When an actor started taking too long to process, the ElapsedMicrosec and CpuMicrosec metrics wouldn't update. As a result, the harmonizer could behave incorrectly and, even under CPU shortage, reduce the number of threads.

### Changelog category <!-- remove all except one -->

* Not for changelog (changelog entry is not required)

### Description for reviewers <!-- (optional) description for those who read this PR -->

...
