### PR TITLE
Clear hints when exiting interactive mode in YDB CLI

### DIFF
--- a/ydb/public/lib/ydb_cli/commands/interactive/interactive_cli.cpp
+++ b/ydb/public/lib/ydb_cli/commands/interactive/interactive_cli.cpp
@@ -247,7 +247,8 @@ int TInteractiveCLI::Run(TClientCommand::TConfig& config) {
         }
     }
 
-    std::cout << std::endl << "Bye" << std::endl;
+    // Clear line (hints can be still present) and print "Bye"
+    std::cout << std::endl << "\r\033[2KBye" << std::endl;
     return EXIT_SUCCESS;
 }
 

--- a/ydb/public/lib/ydb_cli/commands/interactive/interactive_cli.cpp
+++ b/ydb/public/lib/ydb_cli/commands/interactive/interactive_cli.cpp
@@ -247,8 +247,9 @@ int TInteractiveCLI::Run(TClientCommand::TConfig& config) {
         }
     }
 
-    // Clear line (hints can be still present) and print "Bye"
-    std::cout << std::endl << "\r\033[2KBye" << std::endl;
+    // Clear line (hints can be still present)
+    lineReader->ClearHints();
+    std::cout << "Bye" << std::endl;
     return EXIT_SUCCESS;
 }
 

--- a/ydb/public/lib/ydb_cli/commands/interactive/line_reader.cpp
+++ b/ydb/public/lib/ydb_cli/commands/interactive/line_reader.cpp
@@ -46,6 +46,7 @@ public:
     TLineReader(std::string prompt, std::string historyFilePath, TClientCommand::TConfig& config);
 
     std::optional<std::string> ReadLine() override;
+    void ClearHints() override;
 
 private:
     void AddToHistory(const std::string& line);
@@ -120,6 +121,11 @@ TLineReader::TLineReader(std::string prompt, std::string historyFilePath, TClien
     if (!Rx.history_load(HistoryFilePath)) {
         Rx.print("Loading history failed: %s\n", strerror(errno));
     }
+}
+
+void TLineReader::ClearHints() {
+    std::cout << std::endl;
+    Rx.invoke(replxx::Replxx::ACTION::CLEAR_SELF, 0);
 }
 
 std::optional<std::string> TLineReader::ReadLine() {

--- a/ydb/public/lib/ydb_cli/commands/interactive/line_reader.h
+++ b/ydb/public/lib/ydb_cli/commands/interactive/line_reader.h
@@ -11,6 +11,7 @@ namespace NYdb::NConsoleClient {
 class ILineReader {
 public:
     virtual std::optional<std::string> ReadLine() = 0;
+    virtual void ClearHints() = 0;
 
     virtual ~ILineReader() = default;
 };


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

### Changelog category <!-- remove all except one -->

* Not for changelog (changelog entry is not required)

### Description for reviewers <!-- (optional) description for those who read this PR -->

Before:

```
ydb>
Bye  SELECT
>
        FROM
        USE
```

After:

```
ydb>
Bye
>
```
