### PR TITLE
Bridge Mode in CMS: Pile name in public api

### DIFF
--- a/ydb/core/cms/api_adapters.cpp
+++ b/ydb/core/cms/api_adapters.cpp
@@ -229,14 +229,14 @@ class TListClusterNodes: public TAdapterActor<
         location.set_rack(in.Location.GetRackId());
         location.set_unit(in.Location.GetUnitId());
 
+        if (const auto bridgePileName = in.Location.GetBridgePileName(); bridgePileName) {
+            location.set_bridge_pile_name(*bridgePileName);
+        }
+
         if (in.Services & EService::DynamicNode) {
             out.mutable_dynamic()->set_tenant(in.Tenant);
         } else {
             out.mutable_storage();
-        }
-
-        if (in.PileId.Defined()) {
-            out.set_pile_id(*in.PileId);
         }
     }
 

--- a/ydb/core/cms/cms.cpp
+++ b/ydb/core/cms/cms.cpp
@@ -1253,6 +1253,9 @@ void TCms::AddHostState(const TClusterInfoPtr &clusterInfo, const TNodeInfo &nod
         host->SetPileId(*node.PileId);
     }
     node.Location.Serialize(host->MutableLocation(), false);
+    if (const auto bridgePileName = node.Location.GetBridgePileName(); bridgePileName) {
+        host->MutableLocation()->SetBridgePileName(*bridgePileName);
+    }
     for (auto marker : node.Markers) {
         host->AddMarkers(marker);
     }

--- a/ydb/core/cms/cms_ut.cpp
+++ b/ydb/core/cms/cms_ut.cpp
@@ -2361,26 +2361,17 @@ Y_UNIT_TEST_SUITE(TCmsTest) {
         for (const auto& node : *nodes) {
             pileMap->at(node.NodeId % pileMap->size()).push_back(node.NodeId);
         }
+        for (auto& node : *nodes) {
+            NActorsInterconnect::TNodeLocation pb;
+            node.Location.Serialize(&pb, true);
+            pb.SetBridgePileName("r" + ToString(node.NodeId % pileMap->size()));
+            node.Location = TNodeLocation(pb);
+        }
 
         auto newEv = IEventHandle::Downcast<TEvInterconnect::TEvNodesInfo>(
             new IEventHandle((*ev)->Recipient, (*ev)->Sender, new TEvInterconnect::TEvNodesInfo(nodes, pileMap))
         );
         ev->Swap(newEv);
-    }
-
-    ::google::protobuf::RepeatedPtrField< ::Ydb::Maintenance::Node> RequestMaintenanceState(TCmsTestEnv& env)
-    {
-        TAutoPtr<TEvCms::TEvListClusterNodesRequest> event = new TEvCms::TEvListClusterNodesRequest;
-        env.SendToPipe(env.CmsId, env.GetSender(), event.Release(), 0, GetPipeConfigWithRetries());
-
-        TAutoPtr<IEventHandle> handle;
-        auto reply = env.GrabEdgeEventRethrow<TEvCms::TEvListClusterNodesResponse>(handle);
-        UNIT_ASSERT(reply);
-
-        const auto &rec = reply->Record;
-        UNIT_ASSERT_VALUES_EQUAL(rec.GetStatus(), Ydb::StatusIds::SUCCESS);
-
-        return rec.GetResult().nodes();
     }
 
     Y_UNIT_TEST(BridgeModeCollectInfo)
@@ -2416,20 +2407,23 @@ Y_UNIT_TEST_SUITE(TCmsTest) {
             UNIT_ASSERT_EQUAL(nodeId % opts.PileCount, node->PileId);
         }
 
-        // auto state = env.RequestState();
-        // for (const auto& host : state.GetHosts()) {
-        //     const ui32 correctPileId = host.GetNodeId() % opts.PileCount;
-        //     // UNIT_ASSERT(host.GetPileId());
-        //     // UNIT_ASSERT_EQUAL(correctPileId, host.GetPileId());
-        //     // UNIT_ASSERT(host.GetLocation().GetBridgePileName());
-        //     // UNIT_ASSERT_EQUAL(correctPileId, static_cast<ui32>(host.GetLocation().GetBridgePileName()[1] - '0'));
-        // }
+        auto state = env.RequestState();
+        for (const auto& host : state.GetHosts()) {
+            const ui32 correctPileId = host.GetNodeId() % opts.PileCount;
+            if (correctPileId != 0) {
+                UNIT_ASSERT(host.GetPileId());
+                UNIT_ASSERT_EQUAL(correctPileId, host.GetPileId());
+            }
+            const auto bridgePileName = host.GetLocation().GetBridgePileName();
+            UNIT_ASSERT(bridgePileName);
+            UNIT_ASSERT_EQUAL(correctPileId, static_cast<ui32>(bridgePileName[1] - '0'));
+        }
 
-        auto listNodes = RequestMaintenanceState(env);
-
+        auto listNodes = env.RequestListNodes();
         for (const auto& node : listNodes) {
-            Cerr << "NodeId: " << node.node_id() << Endl;
-            // UNIT_ASSERT(node.location().bridge_pile_name());
+            const auto bridgePileName = node.location().bridge_pile_name();
+            UNIT_ASSERT(bridgePileName);
+            UNIT_ASSERT_EQUAL(node.node_id() % opts.PileCount, static_cast<ui32>(bridgePileName[1] - '0'));
         }
     }
 

--- a/ydb/core/cms/cms_ut_common.cpp
+++ b/ydb/core/cms/cms_ut_common.cpp
@@ -825,6 +825,22 @@ TCmsTestEnv::RequestState(const NKikimrCms::TClusterStateRequest &request,
     return rec.GetState();
 }
 
+TCmsTestEnv::TListNodes
+TCmsTestEnv::RequestListNodes()
+{
+    TAutoPtr<TEvCms::TEvListClusterNodesRequest> event = new TEvCms::TEvListClusterNodesRequest;
+    SendToPipe(CmsId, GetSender(), event.Release(), 0, GetPipeConfigWithRetries());
+
+    TAutoPtr<IEventHandle> handle;
+    auto reply = GrabEdgeEventRethrow<TEvCms::TEvListClusterNodesResponse>(handle);
+    UNIT_ASSERT(reply);
+
+    const auto &rec = reply->Record;
+    UNIT_ASSERT_VALUES_EQUAL(rec.GetStatus(), Ydb::StatusIds::SUCCESS);
+
+    return rec.GetResult().nodes();
+}
+
 std::pair<TString, TVector<TString>>
 TCmsTestEnv::ExtractPermissions(const NKikimrCms::TPermissionResponse &response)
 {

--- a/ydb/core/cms/cms_ut_common.h
+++ b/ydb/core/cms/cms_ut_common.h
@@ -187,6 +187,9 @@ public:
 
     NKikimrCms::TClusterState RequestState(const NKikimrCms::TClusterStateRequest &request = {},
         NKikimrCms::TStatus::ECode code = NKikimrCms::TStatus::OK);
+    
+    using TListNodes = ::google::protobuf::RepeatedPtrField< ::Ydb::Maintenance::Node>;
+    TListNodes RequestListNodes();
 
     std::pair<TString, TVector<TString>> ExtractPermissions(const NKikimrCms::TPermissionResponse &response);
 

--- a/ydb/public/api/protos/draft/ydb_maintenance.proto
+++ b/ydb/public/api/protos/draft/ydb_maintenance.proto
@@ -46,7 +46,6 @@ message Node {
     // version defines YDB version for current Node.
     // For example, 'ydb-stable-24-1'.
     string version = 9;
-    uint32 pile_id = 10;
 }
 
 message ListClusterNodesRequest {


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

...

### Changelog category <!-- remove all except one -->

* Not for changelog (changelog entry is not required)

### Description for reviewers <!-- (optional) description for those who read this PR -->

- Удалил поле `pile_id` из maintenance API (не стал удалять из `THostState`, т.к. в коде удобнее использовать id);
- В конвертерах для  `THostState` и для `Node` в `Location` устанавливаю `BridgePileName`;
- Написал тесты на получение состояния через `TEvCms::TEvClusterStateRequest` и `TEvCms::TEvListClusterNodesRequest`.
