### PR TITLE
schemeshard: quick-fix, delete tenant system tablet directly in root hive

### DIFF
--- a/ydb/core/testlib/tablet_helpers.h
+++ b/ydb/core/testlib/tablet_helpers.h
@@ -126,7 +126,7 @@ namespace NKikimr {
                 : DomainKey(domainKey)
             {}
         };
-        
+
         struct TEvRequestDomainInfoReply: public TEventLocal<TEvRequestDomainInfoReply, EvRequestDomainInfoReply> {
             NHive::TDomainInfo DomainInfo;
 
@@ -137,10 +137,20 @@ namespace NKikimr {
 
     };
 
+
+    // partial mirror of NHive::ETabletState states from ydb/core/mind/hive/hive.h
+    enum class ETabletState : ui64 {
+        Unknown = 0,        // THive::ETabletState::Unknown
+        Stopped = 100,      // THive::ETabletState::Stopped
+        ReadyToWork = 200,  // THive::ETabletState::ReadyToWork
+    };
+
     struct TFakeHiveTabletInfo {
         const TTabletTypes::EType Type;
         const ui64 TabletId;
         TActorId BootstrapperActorId;
+        ETabletState State = ETabletState::Unknown;
+        TSubDomainKey ObjectDomain;  // what subdomain tablet belongs to
 
         TChannelsBindings BoundChannels;
         ui32 ChannelsProfile;

--- a/ydb/core/tx/schemeshard/schemeshard__init.cpp
+++ b/ydb/core/tx/schemeshard/schemeshard__init.cpp
@@ -674,6 +674,25 @@ struct TSchemeShard::TTxInit : public TTransactionBase<TSchemeShard> {
         return true;
     }
 
+    bool LoadSystemShardsToDelete(NIceDb::TNiceDb& db, TShardsToDeleteRows& shardsToDelete) const {
+        {
+            auto rowSet = db.Table<Schema::SystemShardsToDelete>().Range().Select();
+            if (!rowSet.IsReady()) {
+                return false;
+            }
+            while (!rowSet.EndOfSet()) {
+                const auto shardIdx = Self->MakeLocalId(rowSet.GetValue<Schema::SystemShardsToDelete::ShardIdx>());
+                shardsToDelete.emplace_back(shardIdx);
+
+                if (!rowSet.Next()) {
+                    return false;
+                }
+            }
+        }
+
+        return true;
+    }
+
     typedef std::tuple<TOperationId, TShardIdx, TTxState::ETxState> TTxShardRec;
     typedef TVector<TTxShardRec> TTxShardsRows;
 
@@ -3844,6 +3863,23 @@ struct TSchemeShard::TTxInit : public TTransactionBase<TSchemeShard> {
             }
         }
 
+        // Read system shards to delete
+        {
+            TShardsToDeleteRows shardsToDelete;
+            if (!LoadSystemShardsToDelete(db, shardsToDelete)) {
+                return false;
+            }
+
+            LOG_NOTICE_S(ctx, NKikimrServices::FLAT_TX_SCHEMESHARD,
+                         "TTxInit for SystemShardToDelete"
+                             << ", read records: " << shardsToDelete.size()
+                             << ", at schemeshard: " << Self->TabletID());
+
+            for (auto& rec: shardsToDelete) {
+                OnComplete.DeleteSystemShard(std::get<0>(rec));
+            }
+        }
+
         // Read backup settings
         {
             TBackupSettingsRows backupSettings;
@@ -5265,14 +5301,14 @@ struct TSchemeShard::TTxInit : public TTransactionBase<TSchemeShard> {
                             if (op.HasFullBackupTrimmedName()) {
                                 TString fullBackupName = op.GetFullBackupTrimmedName() + "_full";
                                 TString fullBackupPath = backupCollectionPathStr + "/" + fullBackupName;
-                                
+
                                 // Set state for each table in the full backup
                                 for (const auto& tablePath : op.GetTablePathList()) {
                                     TPath originalTablePath = TPath::Resolve(tablePath, Self);
                                     if (originalTablePath.IsResolved()) {
                                         TString tableName = originalTablePath.LeafName();
                                         TString fullBackupTablePath = fullBackupPath + "/" + tableName;
-                                        
+
                                         TPath fullBackupTableResolvedPath = TPath::Resolve(fullBackupTablePath, Self);
                                         if (fullBackupTableResolvedPath.IsResolved() && Self->PathsById.contains(fullBackupTableResolvedPath.Base()->PathId)) {
                                             auto backupTablePathElement = Self->PathsById.at(fullBackupTableResolvedPath.Base()->PathId);
@@ -5286,14 +5322,14 @@ struct TSchemeShard::TTxInit : public TTransactionBase<TSchemeShard> {
                             for (const auto& trimmedIncrName : op.GetIncrementalBackupTrimmedNames()) {
                                 TString incrBackupName = trimmedIncrName + "_incremental";
                                 TString incrBackupPath = backupCollectionPathStr + "/" + incrBackupName;
-                                
+
                                 // Set state for each table in the incremental backup
                                 for (const auto& tablePath : op.GetTablePathList()) {
                                     TPath originalTablePath = TPath::Resolve(tablePath, Self);
                                     if (originalTablePath.IsResolved()) {
                                         TString tableName = originalTablePath.LeafName();
                                         TString incrBackupTablePath = incrBackupPath + "/" + tableName;
-                                        
+
                                         TPath incrBackupTableResolvedPath = TPath::Resolve(incrBackupTablePath, Self);
                                         if (incrBackupTableResolvedPath.IsResolved() && Self->PathsById.contains(incrBackupTableResolvedPath.Base()->PathId)) {
                                             auto backupTablePathElement = Self->PathsById.at(incrBackupTableResolvedPath.Base()->PathId);

--- a/ydb/core/tx/schemeshard/schemeshard__operation_side_effects.h
+++ b/ydb/core/tx/schemeshard/schemeshard__operation_side_effects.h
@@ -56,6 +56,7 @@ private:
     THashSet<TOperationId> DoneOperations;
     THashSet<TTxId> DoneTransactions;
     THashSet<TShardIdx> ToDeleteShards;
+    THashSet<TShardIdx> ToDeleteSystemShards;  // temporary: special case for deleting tenant's system shards
     TDeque<TDependence> Dependencies;
     TDeque<TPathStateRec> ReleasePathStateRecs;
     THashSet<TPathId> TenantsToUpdate;
@@ -124,6 +125,7 @@ public:
     void PublishAndWaitPublication(TOperationId opId, TPathId pathId);
 
     void DeleteShard(TShardIdx idx);
+    void DeleteSystemShard(TShardIdx idx);
 
     void ToProgress(TIndexBuildId id);
 
@@ -153,6 +155,7 @@ private:
 
     void DoRegisterRelations(TSchemeShard* ss, const TActorContext& ctx);
     void DoTriggerDeleteShards(TSchemeShard* ss, const TActorContext &ctx);
+    void DoTriggerDeleteSystemShards(TSchemeShard *ss, const TActorContext &ctx);
 
     void DoReleasePathState(TSchemeShard* ss, const TActorContext &ctx);
     void DoDoneParts(TSchemeShard* ss, const TActorContext& ctx);
@@ -163,6 +166,7 @@ private:
     void DoActivateOps(TSchemeShard* ss, const TActorContext& ctx);
 
     void DoPersistDeleteShards(TSchemeShard* ss, NTabletFlatExecutor::TTransactionContext &txc, const TActorContext &ctx);
+    void DoPersistDeleteSystemShards(TSchemeShard* ss, NTabletFlatExecutor::TTransactionContext &txc, const TActorContext &ctx);
 
     void DoUpdateTempDirsToMakeState(TSchemeShard* ss, const TActorContext &ctx);
     void DoUpdateTempDirsToRemoveState(TSchemeShard* ss, const TActorContext &ctx);

--- a/ydb/core/tx/schemeshard/schemeshard_impl.cpp
+++ b/ydb/core/tx/schemeshard/schemeshard_impl.cpp
@@ -5255,6 +5255,9 @@ void TSchemeShard::StateWork(STFUNC_SIG) {
         HFuncTraced(TEvPrivate::TEvCleanDroppedSubDomains, Handle);
         HFuncTraced(TEvPrivate::TEvSubscribeToShardDeletion, Handle);
 
+        // Test-only notification
+        IgnoreFunc(TEvPrivate::TEvTestNotifySubdomainCleanup);
+
         HFuncTraced(TEvPrivate::TEvPersistTableStats, Handle);
         HFuncTraced(TEvPrivate::TEvPersistTopicStats, Handle);
 

--- a/ydb/core/tx/schemeshard/schemeshard_impl.h
+++ b/ydb/core/tx/schemeshard/schemeshard_impl.h
@@ -680,6 +680,7 @@ public:
     void DropPaths(const THashSet<TPathId>& paths, TStepId step, TTxId txId, NIceDb::TNiceDb& db, const TActorContext& ctx);
 
     void DoShardsDeletion(const THashSet<TShardIdx>& shardIdx, const TActorContext& ctx);
+    void DoDeleteSystemShards(const THashSet<TShardIdx>& shards, const TActorContext& ctx);
 
     void SetPartitioning(TPathId pathId, const std::vector<TShardIdx>& partitioning);
     void SetPartitioning(TPathId pathId, TOlapStoreInfo::TPtr storeInfo);
@@ -778,6 +779,7 @@ public:
     void PersistParentDomain(NIceDb::TNiceDb& db, TPathId parentDomain) const;
     void PersistParentDomainEffectiveACL(NIceDb::TNiceDb& db, const TString& owner, const TString& effectiveACL, ui64 effectiveACLVersion) const;
     void PersistShardsToDelete(NIceDb::TNiceDb& db, const THashSet<TShardIdx>& shardsIdxs);
+    void PersistSystemShardsToDelete(NIceDb::TNiceDb& db, const THashSet<TShardIdx>& shardsIdxs);
     void PersistShardDeleted(NIceDb::TNiceDb& db, TShardIdx shardIdx, const TChannelsBindings& bindedChannels);
     void PersistUnknownShardDeleted(NIceDb::TNiceDb& db, TShardIdx shardIdx);
     void PersistTxShardStatus(NIceDb::TNiceDb& db, TOperationId opId, TShardIdx shardIdx, const TTxState::TShardStatus& status);

--- a/ydb/core/tx/schemeshard/schemeshard_private.h
+++ b/ydb/core/tx/schemeshard/schemeshard_private.h
@@ -51,6 +51,7 @@ namespace TEvPrivate {
         EvVerifyPassword,
         EvLoginFinalize,
         EvContinuousBackupCleanerResult,
+        EvTestNotifySubdomainCleanup,
         EvEnd
     };
 
@@ -205,6 +206,14 @@ namespace TEvPrivate {
         { }
     };
 
+    struct TEvTestNotifySubdomainCleanup : public TEventLocal<TEvTestNotifySubdomainCleanup, EvTestNotifySubdomainCleanup> {
+        TPathId SubdomainPathId;
+
+        explicit TEvTestNotifySubdomainCleanup(const TPathId& subdomainPathId)
+            : SubdomainPathId(subdomainPathId)
+        { }
+    };
+
     struct TEvCompletePublication: public TEventLocal<TEvCompletePublication, EvCompletePublication> {
         const TOperationId OpId;
         const TPathId PathId;
@@ -284,7 +293,7 @@ namespace TEvPrivate {
 
     struct TEvProgressIncrementalRestore : public TEventLocal<TEvProgressIncrementalRestore, EvProgressIncrementalRestore> {
         ui64 OperationId;
-        
+
         explicit TEvProgressIncrementalRestore(ui64 operationId)
             : OperationId(operationId)
         {}

--- a/ydb/core/tx/schemeshard/schemeshard_schema.h
+++ b/ydb/core/tx/schemeshard/schemeshard_schema.h
@@ -2145,7 +2145,7 @@ struct Schema : NIceDb::Schema {
         struct OperationId : Column<1, NScheme::NTypeIds::Uint64> {};
         struct State : Column<2, NScheme::NTypeIds::Uint32> {};
         struct CurrentIncrementalIdx : Column<3, NScheme::NTypeIds::Uint32> {};
-        
+
         using TKey = TableKey<OperationId>;
         using TColumns = TableColumns<OperationId, State, CurrentIncrementalIdx>;
     };
@@ -2156,9 +2156,16 @@ struct Schema : NIceDb::Schema {
         struct ShardIdx : Column<2, NScheme::NTypeIds::Uint64> {};
         struct Status : Column<3, NScheme::NTypeIds::Uint32> {};
         struct LastKey : Column<4, NScheme::NTypeIds::String> {};
-        
+
         using TKey = TableKey<OperationId, ShardIdx>;
         using TColumns = TableColumns<OperationId, ShardIdx, Status, LastKey>;
+    };
+
+    struct SystemShardsToDelete : Table<124> {
+        struct ShardIdx : Column<1, NScheme::NTypeIds::Uint64> { using Type = TLocalShardIdx; };
+
+        using TKey = TableKey<ShardIdx>;
+        using TColumns = TableColumns<ShardIdx>;
     };
 
     using TTables = SchemaTables<
@@ -2282,7 +2289,8 @@ struct Schema : NIceDb::Schema {
         IncrementalRestoreOperations,
         KMeansTreeClusters,
         IncrementalRestoreState,
-        IncrementalRestoreShardProgress
+        IncrementalRestoreShardProgress,
+        SystemShardsToDelete
     >;
 
     static constexpr ui64 SysParam_NextPathId = 1;

--- a/ydb/core/tx/schemeshard/schemeshard_shard_deleter.cpp
+++ b/ydb/core/tx/schemeshard/schemeshard_shard_deleter.cpp
@@ -17,6 +17,8 @@ void TShardDeleter::SendDeleteRequests(TTabletId hiveTabletId,
         NKikimr::NSchemeShard::TShardInfo>& shardsInfos,
         const NActors::TActorContext &ctx
     ) {
+    LOG_DEBUG_S(ctx, NKikimrServices::FLAT_TX_SCHEMESHARD, "SendDeleteRequests, shardsToDelete " << shardsToDelete.size()<< ", to hive " << hiveTabletId << ", at schemeshard " << MyTabletID);
+
     if (shardsToDelete.empty())
         return;
 

--- a/ydb/core/tx/schemeshard/ut_extsubdomain/ut_extsubdomain.cpp
+++ b/ydb/core/tx/schemeshard/ut_extsubdomain/ut_extsubdomain.cpp
@@ -1,8 +1,11 @@
 #include <ydb/core/tx/schemeshard/ut_helpers/helpers.h>
 
+#include <ydb/public/lib/value/value.h>
+
 using namespace NKikimr;
 using namespace NSchemeShard;
 using namespace NSchemeShardUT_Private;
+
 
 Y_UNIT_TEST_SUITE(TSchemeShardExtSubDomainTest) {
     Y_UNIT_TEST(Fake) {
@@ -1476,6 +1479,145 @@ Y_UNIT_TEST_SUITE(TSchemeShardExtSubDomainTest) {
         // env.TestWaitTabletDeletion(runtime, xrange(TTestTxConfig::FakeHiveTablets, TTestTxConfig::FakeHiveTablets + 5));
         UNIT_ASSERT(!CheckLocalRowExists(runtime, TTestTxConfig::SchemeShard, "SubDomains", "PathId", 2));
         UNIT_ASSERT(!CheckLocalRowExists(runtime, TTestTxConfig::SchemeShard, "Paths", "Id", 2));
+    }
+
+    Y_UNIT_TEST_FLAG(DropWithDeadTenantHive, AlterDatabaseCreateHiveFirst) {
+        TTestBasicRuntime runtime;
+        TTestEnv env(runtime, TTestEnvOptions().EnableAlterDatabaseCreateHiveFirst(AlterDatabaseCreateHiveFirst));
+        ui64 txId = 100;
+
+        // EnableAlterDatabaseCreateHiveFirst = false puts extsubdomain's system tablets into the root hive control.
+        // EnableAlterDatabaseCreateHiveFirst = true puts extsubdomain's tenant hive into the root hive control
+        // and other system tablets into the tenant hive control.
+
+        TestCreateExtSubDomain(runtime, ++txId,  "/MyRoot",
+            R"(Name: "USER_0")"
+        );
+
+        TestAlterExtSubDomain(runtime, ++txId,  "/MyRoot", R"(
+            Name: "USER_0"
+            ExternalSchemeShard: true
+            PlanResolution: 50
+            Coordinators: 1
+            Mediators: 1
+            TimeCastBucketsPerMediator: 2
+            StoragePools {
+                Name: "pool-1"
+                Kind: "hdd"
+            }
+
+            ExternalHive: true
+        )");
+        env.TestWaitNotification(runtime, {txId, txId - 1});
+
+        ui64 tenantHiveId = 0;
+        TPathId subdomainPathId;
+        {
+            auto describe = DescribePath(runtime, "/MyRoot/USER_0");
+            TestDescribeResult(describe, {
+                NLs::PathExist,
+                NLs::IsExternalSubDomain("USER_0"),
+                NLs::ExtractDomainHive(&tenantHiveId),
+            });
+            TSubDomainKey subdomainKey(describe.GetPathDescription().GetDomainDescription().GetDomainKey());
+            subdomainPathId = TPathId(subdomainKey.GetSchemeShard(), subdomainKey.GetPathId());
+        }
+
+        // check that there is a new path in the root schemeshard
+        UNIT_ASSERT(CheckLocalRowExists(runtime, TTestTxConfig::SchemeShard, "Paths", "Id", subdomainPathId.LocalPathId));
+        UNIT_ASSERT(CheckLocalRowExists(runtime, TTestTxConfig::SchemeShard, "SubDomains", "PathId", subdomainPathId.LocalPathId));
+
+        // check what extsubdomain's system tablets controls root hive
+        const auto expectedTabletsInRootHive = [&]() {
+            if (AlterDatabaseCreateHiveFirst) {
+                return std::vector<ETabletType::EType>({
+                    ETabletType::Hive,
+                });
+            } else {
+                return std::vector<ETabletType::EType>{{
+                    ETabletType::Hive,
+                    ETabletType::SchemeShard,
+                    ETabletType::Coordinator,
+                    ETabletType::Mediator
+                }};
+            }
+        }();
+        {
+            const auto& expectedTypes = expectedTabletsInRootHive;
+            const auto tablets = HiveGetSubdomainTablets(runtime, TTestTxConfig::Hive, subdomainPathId);
+            UNIT_ASSERT_VALUES_EQUAL_C(tablets.size(), expectedTypes.size(), "-- unexpected tablet count in root hive for the tenant");
+            for (const auto& tablet : tablets) {
+                Cerr << "root hive, tablets for subdomain " << subdomainPathId << ", tablet type " << tablet.GetTabletType() << Endl;
+                auto found = std::find(expectedTypes.begin(), expectedTypes.end(), tablet.GetTabletType());
+                UNIT_ASSERT_C(found != expectedTypes.end(), "-- root hive holds tablet of unexpected type " << tablet.GetTabletType());
+            }
+        }
+
+        // check what extsubdomain's system tablets controls tenant hive
+        const auto expectedTabletsInTenantHive = [&]() {
+            if (AlterDatabaseCreateHiveFirst) {
+                return std::vector<ETabletType::EType>{{
+                    ETabletType::SchemeShard,
+                    ETabletType::Coordinator,
+                    ETabletType::Mediator
+                }};
+            } else {
+                return std::vector<ETabletType::EType>{};
+            }
+        }();
+        {
+            const auto& expectedTypes = expectedTabletsInTenantHive;
+            const auto tablets = HiveGetSubdomainTablets(runtime, tenantHiveId, subdomainPathId);
+            UNIT_ASSERT_VALUES_EQUAL_C(tablets.size(), expectedTypes.size(), "-- unexpected tablet count in tenant hive");
+            for (const auto& tablet : tablets) {
+                Cerr << "tenant hive, tablets for subdomain " << subdomainPathId << ", tablet type " << tablet.GetTabletType() << Endl;
+                auto found = std::find(expectedTypes.begin(), expectedTypes.end(), tablet.GetTabletType());
+                UNIT_ASSERT_C(found != expectedTypes.end(), "-- root hive holds tablet of unexpected type " << tablet.GetTabletType());
+            }
+        }
+
+        // extsubdomain drop should be independent of tenant hive's state.
+        // It must correctly remove database whether tenant nodes and tablets are alive or not.
+        //
+        // Make tenant hive inaccessible by stopping its tablet.
+        // In real life that could be, for example, due to absence of tenant nodes.
+        //
+        // Tenant hive is controlled by the root hive (running at node 0).
+        HiveStopTablet(runtime, TTestTxConfig::Hive, tenantHiveId, 0);
+
+        // drop extsubdomain
+        TestForceDropExtSubDomain(runtime, ++txId, "/MyRoot", "USER_0");
+        env.TestWaitNotification(runtime, txId);
+
+        TestDescribeResult(DescribePath(runtime, "/MyRoot/USER_0"), {NLs::PathNotExist});
+
+        TestDescribeResult(DescribePath(runtime, "/MyRoot"), {
+            NLs::PathExist,
+            NLs::PathsInsideDomain(0),
+            NLs::ShardsInsideDomain(0)
+        });
+
+        // check that extsubdomain's system tablets are deleted from the root hive
+        // and not-working state of the tenant hive is unable to hinder that
+        {
+            const auto tablets = HiveGetSubdomainTablets(runtime, TTestTxConfig::Hive, subdomainPathId);
+            UNIT_ASSERT_C(tablets.size() == 0, TStringBuilder()
+                << "-- existing subdomain's system tablets in the root hive: expected 0, got " << tablets.size()
+            );
+        }
+
+        // check that extsubdomain's path is really erased from the root schemeshard
+
+        {
+            const auto result = ReadLocalTableRecords(runtime, TTestTxConfig::SchemeShard, "SystemShardsToDelete", "ShardIdx");
+            const auto records = NKikimr::NClient::TValue::Create(result)[0]["List"];
+            //DEBUG:  Cerr << "TEST: SystemShardsToDelete: " << records.GetValueText<NKikimr::NClient::TFormatJSON>() << Endl;
+            //DEBUG:  Cerr << "TEST: " << records.DumpToString() << Endl;
+            UNIT_ASSERT_VALUES_EQUAL(records.Size(), 0);
+        }
+
+        UNIT_ASSERT(!CheckLocalRowExists(runtime, TTestTxConfig::SchemeShard, "SubDomains", "PathId", subdomainPathId.LocalPathId));
+        UNIT_ASSERT(!CheckLocalRowExists(runtime, TTestTxConfig::SchemeShard, "Paths", "Id", subdomainPathId.LocalPathId));
     }
 
     Y_UNIT_TEST_FLAG(CreateThenDropChangesParent, AlterDatabaseCreateHiveFirst) {

--- a/ydb/core/tx/schemeshard/ut_extsubdomain_reboots/ut_extsubdomain_reboots.cpp
+++ b/ydb/core/tx/schemeshard/ut_extsubdomain_reboots/ut_extsubdomain_reboots.cpp
@@ -1,9 +1,8 @@
-#include <ydb/core/protos/flat_scheme_op.pb.h>
-#include <ydb/core/testlib/actors/wait_events.h>
-#include <ydb/core/tx/datashard/datashard.h>
 #include <ydb/core/tx/schemeshard/ut_helpers/helpers.h>
+#include <ydb/core/testlib/actors/wait_events.h>
 
-#include <google/protobuf/text_format.h>
+#include <ydb/public/lib/value/value.h>
+
 
 using namespace NKikimr;
 using namespace NSchemeShard;
@@ -13,7 +12,7 @@ Y_UNIT_TEST_SUITE(TSchemeShardTestExtSubdomainReboots) {
     Y_UNIT_TEST(Fake) {
     }
 
-    Y_UNIT_TEST_FLAG(CreateExternalSubdomain, AlterDatabaseCreateHiveFirst) {
+    Y_UNIT_TEST_FLAG(CreateExtSubdomainWithHive, AlterDatabaseCreateHiveFirst) {
         TTestWithReboots t;
         t.GetTestEnvOptions()
             .EnableAlterDatabaseCreateHiveFirst(AlterDatabaseCreateHiveFirst)
@@ -101,7 +100,142 @@ Y_UNIT_TEST_SUITE(TSchemeShardTestExtSubdomainReboots) {
         });
     }
 
-    Y_UNIT_TEST_FLAG(CreateExternalSubdomainWithoutHive, AlterDatabaseCreateHiveFirst) {
+    Y_UNIT_TEST_FLAGS(DropExtSubdomain, AlterDatabaseCreateHiveFirst, ExternalHive) {
+        TTestWithReboots t;
+        t.GetTestEnvOptions()
+            .EnableAlterDatabaseCreateHiveFirst(AlterDatabaseCreateHiveFirst)
+            .EnableRealSystemViewPaths(false);
+
+        t.Run([&](TTestActorRuntime& runtime, bool& activeZone) {
+
+            TestCreateExtSubDomain(runtime, ++t.TxId,  "/MyRoot",
+                R"(Name: "USER_0")"
+            );
+            t.TestEnv->TestWaitNotification(runtime, t.TxId);
+
+            TPathId subdomainPathId;
+            {
+                TInactiveZone inactive(activeZone);
+
+                auto describe = DescribePath(runtime, "/MyRoot/USER_0");
+                TestDescribeResult(describe, {
+                    NLs::PathExist,
+                    NLs::IsExternalSubDomain("USER_0"),
+                    NLs::DomainCoordinators({}),
+                    NLs::DomainMediators({}),
+                    NLs::DomainSchemeshard(0),
+                    NLs::DomainHive(0)
+                });
+                TSubDomainKey subdomainKey = TSubDomainKey(describe.GetPathDescription().GetDomainDescription().GetDomainKey());
+                subdomainPathId = TPathId(subdomainKey.GetSchemeShard(), subdomainKey.GetPathId());
+                UNIT_ASSERT_VALUES_EQUAL(subdomainPathId.LocalPathId, 3);
+
+                TestDescribeResult(DescribePath(runtime, "/MyRoot"), {
+                    NLs::ChildrenCount(2)
+                });
+
+                UNIT_ASSERT(CheckLocalRowExists(runtime, TTestTxConfig::SchemeShard, "Paths", "Id", subdomainPathId.LocalPathId));
+                UNIT_ASSERT(CheckLocalRowExists(runtime, TTestTxConfig::SchemeShard, "SubDomains", "PathId", subdomainPathId.LocalPathId));
+
+                // Register observer for future extsubdomain cleanup notification
+                t.TestEnv->AddExtSubdomainCleanupObserver(runtime, subdomainPathId);
+            }
+
+            TestAlterExtSubDomain(runtime, ++t.TxId,  "/MyRoot",
+                Sprintf(R"(
+                        Name: "USER_0"
+
+                        StoragePools {
+                            Name: "tenant-1:hdd"
+                            Kind: "hdd"
+                        }
+                        PlanResolution: 50
+                        Coordinators: 1
+                        Mediators: 1
+                        TimeCastBucketsPerMediator: 2
+
+                        ExternalHive: %s
+                        ExternalSchemeShard: true
+                    )",
+                    ToString(ExternalHive).c_str()
+                )
+            );
+            t.TestEnv->TestWaitNotification(runtime, t.TxId);
+
+            ui64 tenantHiveId = 0;
+            {
+                TInactiveZone inactive(activeZone);
+
+                auto describe = DescribePath(runtime, "/MyRoot/USER_0");
+                TestDescribeResult(describe, {
+                    NLs::PathExist,
+                    NLs::IsExternalSubDomain("USER_0"),
+                    NLs::ExtractDomainHive(&tenantHiveId),
+                });
+
+                if (ExternalHive) {
+                    // extsubdomain drop should be independent of tenant hive's state.
+                    // It must correctly remove database whether tenant nodes and tablets are alive or not.
+                    //
+                    // Make tenant hive inaccessible by stopping its tablet.
+                    // In real life that could be, for example, due to absence of tenant nodes.
+                    //
+                    // Tenant hive is controlled by the root hive (running at node 0).
+                    HiveStopTablet(runtime, TTestTxConfig::Hive, tenantHiveId, 0);
+                }
+            }
+
+            // drop extsubdomain
+            TestForceDropExtSubDomain(runtime, ++t.TxId, "/MyRoot", "USER_0");
+            t.TestEnv->TestWaitNotification(runtime, t.TxId);
+
+            {
+                TInactiveZone inactive(activeZone);
+
+                TestDescribeResult(DescribePath(runtime, "/MyRoot/USER_0"), {
+                    NLs::PathNotExist
+                });
+
+                TestDescribeResult(DescribePath(runtime, "/MyRoot"), {
+                    NLs::PathExist,
+                    NLs::ShardsInsideDomain(0)
+                });
+
+                // wait for it to be really cleaned up
+                t.TestEnv->WaitForExtSubdomainCleanup(runtime, subdomainPathId);
+
+                // check that extsubdomain's system tablets are deleted from the root hive
+                // and not-working state of the tenant hive was unable to hinder that
+                {
+                    const auto tablets = HiveGetSubdomainTablets(runtime, TTestTxConfig::Hive, subdomainPathId);
+                    UNIT_ASSERT_C(tablets.size() == 0, TStringBuilder()
+                        << "-- existing subdomain's system tablets in the root hive: expected 0, got " << tablets.size()
+                    );
+                }
+
+                // check that extsubdomain's path is really erased from the root schemeshard
+
+                TestDescribeResult(DescribePath(runtime, "/MyRoot"), {
+                    NLs::PathExist,
+                    NLs::PathsInsideDomain(1)  // infamous /MyRoot/DirA, created in TTestWithReboots::Prepare()
+                });
+
+                {
+                    const auto result = ReadLocalTableRecords(runtime, TTestTxConfig::SchemeShard, "SystemShardsToDelete", "ShardIdx");
+                    const auto records = NKikimr::NClient::TValue::Create(result)[0]["List"];
+                    //DEBUG: Cerr << "TEST: SystemShardsToDelete: " << records.GetValueText<NKikimr::NClient::TFormatJSON>() << Endl;
+                    //DEBUG: Cerr << "TEST: " << records.DumpToString() << Endl;
+                    UNIT_ASSERT_VALUES_EQUAL(records.Size(), 0);
+                }
+
+                UNIT_ASSERT(!CheckLocalRowExists(runtime, TTestTxConfig::SchemeShard, "SubDomains", "PathId", subdomainPathId.LocalPathId));
+                UNIT_ASSERT(!CheckLocalRowExists(runtime, TTestTxConfig::SchemeShard, "Paths", "Id", subdomainPathId.LocalPathId));
+            }
+
+        });
+    }
+
+    Y_UNIT_TEST_FLAG(CreateExtSubdomainNoHive, AlterDatabaseCreateHiveFirst) {
         TTestWithReboots t;
         t.GetTestEnvOptions()
             .EnableAlterDatabaseCreateHiveFirst(AlterDatabaseCreateHiveFirst)
@@ -207,7 +341,7 @@ Y_UNIT_TEST_SUITE(TSchemeShardTestExtSubdomainReboots) {
         });
     }
 
-    Y_UNIT_TEST_FLAG(AlterForceDrop, AlterDatabaseCreateHiveFirst) {
+    Y_UNIT_TEST_FLAGS(AlterForceDrop, AlterDatabaseCreateHiveFirst, ExternalHive) {
         TTestWithReboots t;
         t.GetTestEnvOptions()
             .EnableAlterDatabaseCreateHiveFirst(AlterDatabaseCreateHiveFirst)
@@ -223,18 +357,22 @@ Y_UNIT_TEST_SUITE(TSchemeShardTestExtSubdomainReboots) {
             }
 
             AsyncAlterExtSubDomain(runtime, ++t.TxId,  "/MyRoot",
-                R"(
-                    StoragePools {
-                        Name: "tenant-1:hdd"
-                        Kind: "hdd"
-                    }
-                    PlanResolution: 50
-                    Coordinators: 3
-                    Mediators: 2
-                    TimeCastBucketsPerMediator: 2
-                    ExternalSchemeShard: true
-                    Name: "USER_0"
-                )"
+                Sprintf(R"(
+                        StoragePools {
+                            Name: "tenant-1:hdd"
+                            Kind: "hdd"
+                        }
+                        PlanResolution: 50
+                        Coordinators: 3
+                        Mediators: 2
+                        TimeCastBucketsPerMediator: 2
+                        ExternalSchemeShard: true
+                        Name: "USER_0"
+
+                        ExternalHive: %s
+                    )",
+                    ToString(ExternalHive).c_str()
+                )
             );
             t.TestEnv->ReliablePropose(runtime, ForceDropExtSubDomainRequest(++t.TxId, "/MyRoot", "USER_0"),
                                        {NKikimrScheme::StatusAccepted});
@@ -256,17 +394,18 @@ Y_UNIT_TEST_SUITE(TSchemeShardTestExtSubdomainReboots) {
     }
 
 
-    Y_UNIT_TEST_FLAG(SchemeLimits, AlterDatabaseCreateHiveFirst) {
+    Y_UNIT_TEST_FLAGS(SchemeLimits, AlterDatabaseCreateHiveFirst, ExternalHive) {
         TTestWithReboots t;
         t.GetTestEnvOptions()
             .EnableAlterDatabaseCreateHiveFirst(AlterDatabaseCreateHiveFirst)
-            .EnableRealSystemViewPaths(false);
+            .EnableRealSystemViewPaths(false)
+        ;
 
         t.Run([&](TTestActorRuntime& runtime, bool& activeZone) {
             TSchemeLimits limits;
             limits.MaxDepth = 2;
-            limits.MaxShards = 3;
             limits.MaxPaths = 2;
+            limits.MaxShards = 3 + (ExternalHive ? 1 : 0);
 
             {
                 TInactiveZone inactive(activeZone);
@@ -280,46 +419,39 @@ Y_UNIT_TEST_SUITE(TSchemeShardTestExtSubdomainReboots) {
             }
 
             TestAlterExtSubDomain(runtime, ++t.TxId,  "/MyRoot",
-                R"(
-                    StoragePools {
-                        Name: "tenant-1:hdd"
-                        Kind: "hdd"
-                    }
-                    PlanResolution: 50
-                    Coordinators: 1
-                    Mediators: 1
-                    TimeCastBucketsPerMediator: 2
-                    ExternalSchemeShard: true
-                    Name: "USER_0"
-                )"
+                Sprintf(R"(
+                        StoragePools {
+                            Name: "tenant-1:hdd"
+                            Kind: "hdd"
+                        }
+                        PlanResolution: 50
+                        Coordinators: 1
+                        Mediators: 1
+                        TimeCastBucketsPerMediator: 2
+                        ExternalSchemeShard: true
+                        Name: "USER_0"
+
+                        ExternalHive: %s
+                    )",
+                    ToString(ExternalHive).c_str()
+                )
             );
             t.TestEnv->TestWaitNotification(runtime, t.TxId);
 
             {
                 TInactiveZone inactive(activeZone);
+
+                ui64 subdomainSchemeshard;
                 TestDescribeResult(DescribePath(runtime, "/MyRoot/USER_0"),
                                    {NLs::PathExist,
                                     NLs::IsExternalSubDomain("USER_0"),
+                                    NLs::ExtractTenantSchemeshard(&subdomainSchemeshard),
+                                    NLs::ShardsInsideDomain(limits.MaxShards),
                                     NLs::DomainLimitsIs(limits.MaxPaths, limits.MaxShards)});
 
                 TestDescribeResult(DescribePath(runtime, "/MyRoot"),
                                    {NLs::ChildrenCount(2),
                                     NLs::DomainLimitsIs(limits.MaxPaths, limits.MaxShards)});
-
-                ui64 subdomainSchemeshard = TTestTxConfig::FakeHiveTablets;
-
-                TestDescribeResult(DescribePath(runtime, subdomainSchemeshard, "/MyRoot/USER_0"),
-                                   {NLs::PathExist,
-                                    NLs::IsSubDomain("MyRoot/USER_0"),
-                                    NLs::DomainKey(3, TTestTxConfig::SchemeShard),
-                                    // internal knowledge of shard declaration sequence is used here
-                                    NLs::DomainSchemeshard(subdomainSchemeshard),
-                                    NLs::DomainCoordinators({TTestTxConfig::FakeHiveTablets+1}),
-                                    NLs::DomainMediators({TTestTxConfig::FakeHiveTablets+2}),
-                                    NLs::DomainLimitsIs(limits.MaxPaths, limits.MaxShards),
-                                    NLs::ShardsInsideDomain(3),
-                                    NLs::PathsInsideDomain(0)
-                                   });
 
                 TestCreateTable(runtime, subdomainSchemeshard, ++t.TxId, "/MyRoot/USER_0", R"(
                             Name: "Table"

--- a/ydb/core/tx/schemeshard/ut_helpers/helpers.cpp
+++ b/ydb/core/tx/schemeshard/ut_helpers/helpers.cpp
@@ -44,6 +44,44 @@ namespace NSchemeShardUT_Private {
         runtime.GrabEdgeEventRethrow<NConsole::TEvConsole::TEvConfigNotificationResponse>(handle);
     }
 
+    ////////// Hive
+
+    // Stop tablet.
+    // Also see ydb/core/mind/hive/hive_ut.cpp, SendStopTablet
+    void HiveStopTablet(TTestActorRuntime &runtime, ui64 hiveTablet, ui64 tabletId, ui32 nodeIndex) {
+        TActorId senderB = runtime.AllocateEdgeActor(nodeIndex);
+        runtime.SendToPipe(hiveTablet, senderB, new TEvHive::TEvStopTablet(tabletId), 0, GetPipeConfigWithRetries());
+        TAutoPtr<IEventHandle> handle;
+        auto event = runtime.GrabEdgeEventRethrow<TEvHive::TEvStopTabletResult>(handle);
+        UNIT_ASSERT(event);
+        const auto& stopResult = event->Record;
+        UNIT_ASSERT_EQUAL_C(stopResult.GetTabletID(), tabletId, stopResult.GetTabletID() << " != " << tabletId);
+        UNIT_ASSERT_EQUAL_C(stopResult.GetStatus(), NKikimrProto::OK, (ui32)stopResult.GetStatus() << " != " << (ui32)NKikimrProto::OK);
+    }
+
+    // Retrieve tablets that belong to the given subdomain
+    std::vector<NKikimrHive::TTabletInfo> HiveGetSubdomainTablets(TTestActorRuntime &runtime, const ui64 hiveTablet, const TPathId& subdomainPathId) {
+        TActorId senderA = runtime.AllocateEdgeActor();
+        runtime.SendToPipe(hiveTablet, senderA, new TEvHive::TEvRequestHiveInfo(), 0, GetPipeConfigWithRetries());
+        TAutoPtr<IEventHandle> handle;
+        auto event = runtime.GrabEdgeEventRethrow<TEvHive::TEvResponseHiveInfo>(handle);
+        UNIT_ASSERT(event);
+        const auto& response = event->Record;
+
+        // Cerr << "TEST: HiveGetSubdomainTablets: " << response.ShortDebugString() << Endl;
+
+        std::vector<NKikimrHive::TTabletInfo> result;
+        std::copy_if(response.GetTablets().begin(), response.GetTablets().end(),
+            std::back_inserter(result),
+            [&subdomainPathId] (auto& tablet) {
+                return (tablet.GetObjectDomain().GetSchemeShard() == subdomainPathId.OwnerId
+                    && tablet.GetObjectDomain().GetPathId() == subdomainPathId.LocalPathId
+                );
+            }
+        );
+        return result;
+    }
+
     template <typename TEvResponse, typename TEvRequest, typename TStatus>
     static ui32 ReliableProposeImpl(
         NActors::TTestActorRuntime& runtime, const TActorId& proposer,
@@ -1420,6 +1458,30 @@ namespace NSchemeShardUT_Private {
         // Row missing: Value { Struct { Optional { } } } }
         return result.GetValue().GetStruct(0).GetOptional().HasOptional();
     }
+
+    // Read records from a local table by a single component key
+    NKikimrMiniKQL::TResult ReadLocalTableRecords(TTestActorRuntime& runtime, ui64 tabletId, const TString& tableName, const TString& keyColumn) {
+        const auto query = Sprintf(
+            R"(
+                (
+                    (let range '('('%s (Null) (Void))))
+                    (let fields '('%s))
+                    (return (AsList
+                        (SetResult 'Result (SelectRange '%s range fields '()))
+                    ))
+                )
+            )",
+            keyColumn.c_str(),
+            keyColumn.c_str(),
+            tableName.c_str()
+        );
+        auto result = LocalMiniKQL(runtime, tabletId, query);
+        // Result: Value { Struct { Optional { Struct { List {
+        //     Struct { Optional { Uint64: 2 } } }
+        //     ...
+        // } } } } }
+        return result;
+    };
 
     ui64 GetDatashardState(TTestActorRuntime& runtime, ui64 tabletId) {
         NKikimrMiniKQL::TResult result;

--- a/ydb/core/tx/schemeshard/ut_helpers/helpers.h
+++ b/ydb/core/tx/schemeshard/ut_helpers/helpers.h
@@ -83,6 +83,11 @@ namespace NSchemeShardUT_Private {
     NKikimrMiniKQL::TResult LocalMiniKQL(TTestActorRuntime& runtime, ui64 tabletId, const TString& query);
 
     bool CheckLocalRowExists(TTestActorRuntime& runtime, ui64 tabletId, const TString& tableName, const TString& keyColumn, ui64 keyValue);
+    NKikimrMiniKQL::TResult ReadLocalTableRecords(TTestActorRuntime& runtime, ui64 tabletId, const TString& tableName, const TString& keyColumn);
+
+    ////////// hive
+    void HiveStopTablet(TTestActorRuntime &runtime, ui64 hiveTablet, ui64 tabletId, ui32 nodeIndex);
+    std::vector<NKikimrHive::TTabletInfo> HiveGetSubdomainTablets(TTestActorRuntime &runtime, const ui64 hiveTablet, const TPathId& subdomainPathId);
 
     ////////// describe options
     struct TDescribeOptionsBuilder : public NKikimrSchemeOp::TDescribeOptions {

--- a/ydb/core/tx/schemeshard/ut_helpers/test_env.cpp
+++ b/ydb/core/tx/schemeshard/ut_helpers/test_env.cpp
@@ -956,6 +956,23 @@ void NSchemeShardUT_Private::TTestEnv::WaitForSysViewsRosterUpdate(NActors::TTes
     }
 }
 
+void NSchemeShardUT_Private::TTestEnv::AddExtSubdomainCleanupObserver(NActors::TTestActorRuntime& runtime, const TPathId& subdomainPathId) {
+    Cerr << "TESTENV: subdomain cleanup, start waiting, subdomain " << subdomainPathId << Endl;
+    ExtSubdomainCleanupComplete.erase(subdomainPathId);
+    ExtSubdomainCleanupObserver = runtime.AddObserver<TEvPrivate::TEvTestNotifySubdomainCleanup>([this](const auto& ev) {
+        ExtSubdomainCleanupComplete.insert(ev->Get()->SubdomainPathId);
+    });
+}
+
+void NSchemeShardUT_Private::TTestEnv::WaitForExtSubdomainCleanup(NActors::TTestActorRuntime& runtime, const TPathId& subdomainPathId) {
+    runtime.WaitFor("ExtSubdomainCleanup", [this, &subdomainPathId] {
+        return ExtSubdomainCleanupComplete.contains(subdomainPathId);
+    });
+    ExtSubdomainCleanupComplete.erase(subdomainPathId);
+    ExtSubdomainCleanupObserver.Remove();
+    Cerr << "TESTENV: subdomain cleanup, wait complete, subdomain " << subdomainPathId << Endl;
+}
+
 void NSchemeShardUT_Private::TTestEnv::SimulateSleep(NActors::TTestActorRuntime &runtime, TDuration duration) {
     auto sender = runtime.AllocateEdgeActor();
     runtime.Schedule(new IEventHandle(sender, sender, new TEvents::TEvWakeup()), duration);
@@ -1089,6 +1106,14 @@ NSchemeShardUT_Private::TTestWithReboots::TTestWithReboots(bool killOnCommit, NS
     TabletIds.push_back(datashard+7);
     TabletIds.push_back(datashard+8);
 
+    // Events used exclusively by test frameworks.
+    // No need for reboots on these as they aren't used in real operation mode.
+    NoRebootEventTypes.insert(TEvPrivate::EvTestNotifySubdomainCleanup);
+    NoRebootEventTypes.insert(TEvFakeHive::EvSubscribeToTabletDeletion);
+    NoRebootEventTypes.insert(TEvFakeHive::EvNotifyTabletDeleted);
+    NoRebootEventTypes.insert(TEvFakeHive::EvRequestDomainInfo);
+    NoRebootEventTypes.insert(TEvFakeHive::EvRequestDomainInfoReply);
+
     NoRebootEventTypes.insert(TEvSchemeShard::EvModifySchemeTransaction);
     NoRebootEventTypes.insert(TEvSchemeShard::EvDescribeScheme);
     NoRebootEventTypes.insert(TEvSchemeShard::EvNotifyTxCompletion);
@@ -1138,34 +1163,48 @@ struct NSchemeShardUT_Private::TTestWithReboots::TFinalizer {
 };
 
 void NSchemeShardUT_Private::TTestWithReboots::RunWithTabletReboots(std::function<void (TTestActorRuntime &, bool &)> testScenario) {
-    RunTestWithReboots(TabletIds, [&]() {
-        return [this](TTestActorRuntimeBase& runtime, TAutoPtr<IEventHandle>& event) {
-            return PassUserRequests(runtime, event);
-        };
-    },
-    [&](const TString& dispatchName, std::function<void(TTestActorRuntime&)> setup, bool& activeZone) {
-        TFinalizer finalizer(*this);
-        Prepare(dispatchName, setup, activeZone);
+    RunTestWithReboots(
+        TabletIds,
+        // filterFactory
+        [&]() {
+            return [this](TTestActorRuntimeBase& runtime, TAutoPtr<IEventHandle>& event) {
+                return PassUserRequests(runtime, event);
+            };
+        },
+        // testFunc
+        [&](const TString& dispatchName, std::function<void(TTestActorRuntime&)> setup, bool& activeZone) {
+            TFinalizer finalizer(*this);
+            Prepare(dispatchName, setup, activeZone);
 
-        activeZone = true;
-        testScenario(*Runtime, activeZone);
-    }, Max<ui32>(), Max<ui64>(), 0, 0, KillOnCommit);
+            activeZone = true;
+            testScenario(*Runtime, activeZone);
+        },
+        Max<ui32>(),
+        Max<ui64>(),
+        0,
+        0,
+        KillOnCommit
+    );
 }
 
 void NSchemeShardUT_Private::TTestWithReboots::RunWithPipeResets(std::function<void (TTestActorRuntime &, bool &)> testScenario) {
-    RunTestWithPipeResets(TabletIds,
-                          [&]() {
-        return [this](TTestActorRuntimeBase& runtime, TAutoPtr<IEventHandle>& event) {
-            return PassUserRequests(runtime, event);
-        };
-    },
-    [&](const TString& dispatchName, std::function<void(TTestActorRuntime&)> setup, bool& activeZone) {
-        TFinalizer finalizer(*this);
-        Prepare(dispatchName, setup, activeZone);
+    RunTestWithPipeResets(
+        TabletIds,
+        // filterFactory
+        [&]() {
+            return [this](TTestActorRuntimeBase& runtime, TAutoPtr<IEventHandle>& event) {
+                return PassUserRequests(runtime, event);
+            };
+        },
+        // testFunc
+        [&](const TString& dispatchName, std::function<void(TTestActorRuntime&)> setup, bool& activeZone) {
+            TFinalizer finalizer(*this);
+            Prepare(dispatchName, setup, activeZone);
 
-        activeZone = true;
-        testScenario(*Runtime, activeZone);
-    });
+            activeZone = true;
+            testScenario(*Runtime, activeZone);
+        }
+    );
 }
 
 void NSchemeShardUT_Private::TTestWithReboots::RunWithDelays(std::function<void (TTestActorRuntime &, bool &)> testScenario) {

--- a/ydb/core/tx/schemeshard/ut_helpers/test_env.h
+++ b/ydb/core/tx/schemeshard/ut_helpers/test_env.h
@@ -103,6 +103,9 @@ namespace NSchemeShardUT_Private {
         TTestActorRuntime::TEventObserverHolder SysViewsRosterUpdateObserver;
         bool SysViewsRosterUpdateFinished;
 
+        TTestActorRuntime::TEventObserverHolder ExtSubdomainCleanupObserver;
+        THashSet<TPathId> ExtSubdomainCleanupComplete;
+
     public:
         static bool ENABLE_SCHEMESHARD_LOG;
 
@@ -138,6 +141,9 @@ namespace NSchemeShardUT_Private {
         void TestWaitShardDeletion(TTestActorRuntime& runtime, TSet<ui64> localIds);
         void TestWaitShardDeletion(TTestActorRuntime& runtime, ui64 schemeShard, TSet<ui64> localIds);
         void TestWaitShardDeletion(TTestActorRuntime& runtime, ui64 schemeShard, TSet<TShardIdx> shardIds);
+
+        void AddExtSubdomainCleanupObserver(NActors::TTestActorRuntime& runtime, const TPathId& subdomainPathId);
+        void WaitForExtSubdomainCleanup(NActors::TTestActorRuntime& runtime, const TPathId& subdomainPathId);
 
         void AddSysViewsRosterUpdateObserver(TTestActorRuntime& runtime);
         void WaitForSysViewsRosterUpdate(TTestActorRuntime& runtime);

--- a/ydb/tests/functional/scheme_tests/canondata/tablet_scheme_tests.TestTabletSchemes.test_tablet_schemes_flat_schemeshard_/flat_schemeshard.schema
+++ b/ydb/tests/functional/scheme_tests/canondata/tablet_scheme_tests.TestTabletSchemes.test_tablet_schemes_flat_schemeshard_/flat_schemeshard.schema
@@ -8883,5 +8883,43 @@
                 ]
             }
         }
+    },
+    {
+        "TableId": 124,
+        "TableName": "SystemShardsToDelete",
+        "TableKey": [
+            1
+        ],
+        "ColumnsAdded": [
+            {
+                "ColumnId": 1,
+                "ColumnName": "ShardIdx",
+                "ColumnType": "Uint64"
+            }
+        ],
+        "ColumnsDropped": [],
+        "ColumnFamilies": {
+            "0": {
+                "Columns": [
+                    1
+                ],
+                "RoomID": 0,
+                "Codec": 0,
+                "InMemory": false,
+                "Cache": 0,
+                "Small": 4294967295,
+                "Large": 4294967295
+            }
+        },
+        "Rooms": {
+            "0": {
+                "Main": 1,
+                "Outer": 1,
+                "Blobs": 1,
+                "ExternalBlobs": [
+                    1
+                ]
+            }
+        }
     }
 ]


### PR DESCRIPTION
Currently, drop-extsubdomain operations may not completely remove dedicated databases from the system:
- system tablets of the tenant may remain in the root hive
- traces of database paths and subdomain objects may persist in the root schemeshard

Root cause: The cleanup procedure depends on the tenant hive's existence - delete-tablet requests are sent to the tenant hive for redirection to the root hive. This works for most databases but fails with dedicated databases, where the tenant hive cannot outlive drop-extsubdomain operations, and there's no guarantee that tenant nodes and tablets will be available during deletion.

In this PR:
- Add unit and reboot tests to verify proper extsubdomain cleanup
- Implement quick fix for subdomain cleanup by directly sending system tablets delete-tablet requests to the root hive (only for dedicated databases)

It could be easier to review PR commit by commit.

Closes #19842.

### Changelog entry

Fix issue where dedicated database deletion may leave database system tablets improperly cleaned.

### Changelog category

* Bugfix 
