### PR TITLE
merge to stable 25-1-3 YQ-4424 Fixed temp dir owner actor id serialization

### DIFF
--- a/ydb/core/kqp/runtime/kqp_write_actor.cpp
+++ b/ydb/core/kqp/runtime/kqp_write_actor.cpp
@@ -1065,7 +1065,7 @@ public:
     }
 
     void Handle(TEvPrivate::TEvShardRequestTimeout::TPtr& ev) {
-        CA_LOG_W("Timeout shardID=" << ev->Get()->ShardId);
+        CA_LOG_I("Timeout shardID=" << ev->Get()->ShardId);
         YQL_ENSURE(InconsistentTx);
         RetryShard(ev->Get()->ShardId, ev->Cookie);
     }

--- a/ydb/core/kqp/ut/scheme/kqp_scheme_ut.cpp
+++ b/ydb/core/kqp/ut/scheme/kqp_scheme_ut.cpp
@@ -1,8 +1,12 @@
+#include <ydb/core/base/tablet_resolver.h>
+#include <ydb/core/kqp/gateway/actors/scheme.h>
 #include <ydb/core/kqp/gateway/behaviour/resource_pool_classifier/fetcher.h>
+#include <ydb/core/kqp/gateway/kqp_gateway.h>
 #include <ydb/core/kqp/ut/common/kqp_ut_common.h>
 #include <ydb/core/kqp/ut/common/columnshard.h>
 #include <ydb/core/kqp/workload_service/actors/actors.h>
 #include <ydb/core/kqp/workload_service/ut/common/kqp_workload_service_ut_common.h>
+#include <ydb/core/protos/schemeshard/operations.pb.h>
 #include <ydb/core/tx/columnshard/hooks/testing/controller.h>
 #include <ydb/core/tx/columnshard/test_helper/controllers.h>
 #include <ydb/core/formats/arrow/arrow_helpers.h>
@@ -26,6 +30,7 @@ namespace NKqp {
 
 using namespace NYdb;
 using namespace NYdb::NTable;
+using namespace NYdb::NTopic;
 using namespace NYdb::NReplication;
 
 Y_UNIT_TEST_SUITE(KqpScheme) {
@@ -10661,6 +10666,139 @@ Y_UNIT_TEST_SUITE(KqpScheme) {
             auto result = session.ExecuteSchemeQuery(query).GetValueSync();
             UNIT_ASSERT_VALUES_EQUAL_C(result.GetStatus(), EStatus::SUCCESS, result.GetIssues().ToString());
         }
+    }
+
+    class TTestTempTablesAgentActor : public TActorBootstrapped<TTestTempTablesAgentActor> {
+    public:
+        explicit TTestTempTablesAgentActor(NThreading::TPromise<void> finishPromise)
+            : FinishPromise(std::move(finishPromise))
+        {}
+
+        void Bootstrap() {
+            Become(&TTestTempTablesAgentActor::StateWork);
+        }
+
+        STRICT_STFUNC(StateWork,
+            IgnoreFunc(NSchemeShard::TEvSchemeShard::TEvOwnerActorAck);
+            sFunc(TEvents::TEvPoison, Finish);
+        )
+
+    private:
+        void Finish() {
+            FinishPromise.SetValue();
+            PassAway();
+        }
+
+    private:
+        NThreading::TPromise<void> FinishPromise;
+    };
+
+    Y_UNIT_TEST(CleanupTemporaryTables) {
+        TKikimrRunner kikimr;
+
+        auto& runtime = *kikimr.GetTestServer().GetRuntime();
+
+        const auto createTempDir = [&](const TString& name, TActorId tempDirOwnerActorId) {
+            auto ev = std::make_unique<TEvTxUserProxy::TEvProposeTransaction>();
+            auto& record = ev->Record;
+
+            record.SetDatabaseName("/Root");
+            record.SetUserToken(NACLib::TSystemUsers::Tmp().SerializeAsString());
+
+            auto* modifyScheme = record.MutableTransaction()->MutableModifyScheme();
+            modifyScheme->SetWorkingDir("/Root");
+            modifyScheme->SetOperationType(NKikimrSchemeOp::EOperationType::ESchemeOpMkDir);
+            modifyScheme->SetAllowCreateInTempDir(false);
+
+            auto* makeDir = modifyScheme->MutableMkDir();
+            makeDir->SetName(name);
+            ActorIdToProto(tempDirOwnerActorId, modifyScheme->MutableTempDirOwnerActorId());
+
+            auto promise = NThreading::NewPromise<IKqpGateway::TGenericResult>();
+            runtime.Register(new TSchemeOpRequestHandler(ev.release(), promise, false));
+
+            const auto result = promise.GetFuture().ExtractValueSync();
+            UNIT_ASSERT_C(result.Success(), TStringBuilder() << "Temp dir '" << name << "' creation failed: " << result.Issues().ToString());
+        };
+
+        const auto finishPromise = NThreading::NewPromise<void>();
+        const auto firstOwner = runtime.Register(new TTestTempTablesAgentActor(finishPromise), 0, 1);
+        const auto firstDir = "first_dir";
+        createTempDir(firstDir, firstOwner);
+
+        const auto secondDir = "second_dir";
+        createTempDir(secondDir, runtime.Register(new TTestTempTablesAgentActor(NThreading::NewPromise<void>()), 0, 1));
+
+        // Directories succesfully created
+
+        Sleep(TDuration::Seconds(5));
+
+        const auto checkDirectory = [&](const TString& name, bool expectedExists) -> TString {
+            const auto result = Navigate(runtime, runtime.AllocateEdgeActor(), JoinPath({"/Root", name}), NSchemeCache::TSchemeCacheNavigate::EOp::OpUnknown);
+            UNIT_ASSERT_C(result, TStringBuilder() << "Empty Navigate " << name << " result");
+            UNIT_ASSERT_C(!result->ResultSet.empty(), TStringBuilder() << "Empty result sets for Navigate " << name);
+
+            const auto& tempDir = result->ResultSet.at(0);
+            if (expectedExists) {
+                if (tempDir.Status != NSchemeCache::TSchemeCacheNavigate::EStatus::Ok) {
+                    return TStringBuilder() << "Navigate temp dir '" << name << "' failed: " << tempDir.Status;
+                }
+                if (tempDir.Kind != NSchemeCache::TSchemeCacheNavigate::EKind::KindPath) {
+                    return TStringBuilder() << "Temp dir '" << name << "' has unexpected kind: " << tempDir.Kind << ", expected KindPath";
+                }
+            } else {
+                if (tempDir.Status != NSchemeCache::TSchemeCacheNavigate::EStatus::PathErrorUnknown) {
+                    return TStringBuilder() << "Navigate temp dir '" << name << "' finished with unexpected status: " << tempDir.Status << ", expected PathErrorUnknown";
+                }
+                if (tempDir.Kind != NSchemeCache::TSchemeCacheNavigate::EKind::KindUnknown) {
+                    return TStringBuilder() << "Temp dir '" << name << "' has unexpected kind: " << tempDir.Kind << ", expected KindUnknown";
+                }
+            }
+
+            return "";
+        };
+
+        {
+            const auto& result = checkDirectory(firstDir, true);
+            UNIT_ASSERT_C(result.empty(), result);
+        }
+
+        {
+            const auto& result = checkDirectory(secondDir, true);
+            UNIT_ASSERT_C(result.empty(), result);
+        }
+
+        // Delete first directory
+
+        const auto edgeActor = runtime.AllocateEdgeActor();
+        runtime.Send(firstOwner, edgeActor, new TEvents::TEvPoison());
+        finishPromise.GetFuture().GetValueSync();
+
+        runtime.Send(MakeTabletResolverID(), edgeActor, new TEvTabletResolver::TEvForward(
+            Tests::SchemeRoot,
+            new IEventHandle(TActorId(), edgeActor, new TEvents::TEvPoisonPill()),
+            {},
+            TEvTabletResolver::TEvForward::EActor::Tablet
+        ));
+        runtime.Send(MakeTabletResolverID(), TActorId(), new TEvTabletResolver::TEvTabletProblem(Tests::SchemeRoot, TActorId()));
+
+        // Check delete first directory
+
+        const auto timeout = TInstant::Now() + TDuration::Seconds(5);
+        TString deleteResult;
+        while (TInstant::Now() < timeout) {
+            deleteResult = checkDirectory(firstDir, false);
+            if (!deleteResult) {
+                Sleep(TDuration::Seconds(5));
+                const auto& result = checkDirectory(secondDir, true);
+                UNIT_ASSERT_C(result.empty(), result);
+                return;
+            }
+
+            Sleep(TDuration::MilliSeconds(100));
+        }
+
+        UNIT_FAIL("Temp dir '" << firstDir << "' still exists, last result: " << deleteResult);
     }
 }
 

--- a/ydb/core/kqp/ut/scheme/kqp_scheme_ut.cpp
+++ b/ydb/core/kqp/ut/scheme/kqp_scheme_ut.cpp
@@ -10694,7 +10694,12 @@ Y_UNIT_TEST_SUITE(KqpScheme) {
     };
 
     Y_UNIT_TEST(CleanupTemporaryTables) {
-        TKikimrRunner kikimr;
+        NKikimrConfig::TAppConfig appConfig;
+        appConfig.MutableFeatureFlags()->SetEnableTempTables(true);
+
+        TKikimrRunner kikimr(TKikimrSettings()
+            .SetFeatureFlags(appConfig.GetFeatureFlags())
+            .SetAppConfig(appConfig));
 
         auto& runtime = *kikimr.GetTestServer().GetRuntime();
 

--- a/ydb/core/tx/schemeshard/schemeshard__init.cpp
+++ b/ydb/core/tx/schemeshard/schemeshard__init.cpp
@@ -94,7 +94,7 @@ struct TSchemeShard::TTxInit : public TTransactionBase<TSchemeShard> {
                        TStepId, TTxId, TStepId, TTxId,
                        TString, TTxId,
                        ui64, ui64, ui64,
-                       TString> TPathRec;
+                       TString, TActorId> TPathRec;
     typedef TDeque<TPathRec> TPathRows;
 
     template <typename SchemaTable, typename TRowSet>
@@ -112,6 +112,7 @@ struct TSchemeShard::TTxInit : public TTransactionBase<TSchemeShard> {
             rowSet.template GetValueOrDefault<typename SchemaTable::DirAlterVersion>(1),
             rowSet.template GetValueOrDefault<typename SchemaTable::UserAttrsAlterVersion>(1),
             rowSet.template GetValueOrDefault<typename SchemaTable::ACLVersion>(0),
+            rowSet.template GetValueOrDefault<typename SchemaTable::TempDirOwnerActorId_Deprecated>(),
             rowSet.template GetValueOrDefault<typename SchemaTable::TempDirOwnerActorId>()
         );
     }
@@ -138,7 +139,7 @@ struct TSchemeShard::TTxInit : public TTransactionBase<TSchemeShard> {
 
         TPathElement::TPtr path = new TPathElement(pathId, parentPathId, domainId, name, owner);
 
-        TString tempDirOwnerActorId;
+        TString tempDirOwnerActorId_Deprecated;
         std::tie(
             std::ignore, //pathId
             std::ignore, //parentPathId
@@ -154,14 +155,17 @@ struct TSchemeShard::TTxInit : public TTransactionBase<TSchemeShard> {
             path->DirAlterVersion,
             path->UserAttrs->AlterVersion,
             path->ACLVersion,
-            tempDirOwnerActorId) = rec;
+            tempDirOwnerActorId_Deprecated,
+            path->TempDirOwnerActorId) = rec;
 
         path->PathState = TPathElement::EPathState::EPathStateNoChanges;
         if (path->StepDropped) {
             path->PathState = TPathElement::EPathState::EPathStateNotExist;
         }
 
-        path->TempDirOwnerActorId.Parse(tempDirOwnerActorId.c_str(), tempDirOwnerActorId.size());
+        if (!path->TempDirOwnerActorId) {
+            path->TempDirOwnerActorId.Parse(tempDirOwnerActorId_Deprecated.c_str(), tempDirOwnerActorId_Deprecated.size());
+        }
 
         return path;
     }

--- a/ydb/core/tx/schemeshard/schemeshard__init.cpp
+++ b/ydb/core/tx/schemeshard/schemeshard__init.cpp
@@ -113,7 +113,7 @@ struct TSchemeShard::TTxInit : public TTransactionBase<TSchemeShard> {
             rowSet.template GetValueOrDefault<typename SchemaTable::UserAttrsAlterVersion>(1),
             rowSet.template GetValueOrDefault<typename SchemaTable::ACLVersion>(0),
             rowSet.template GetValueOrDefault<typename SchemaTable::TempDirOwnerActorId_Deprecated>(),
-            rowSet.template GetValueOrDefault<typename SchemaTable::TempDirOwnerActorId>()
+            rowSet.template GetValueOrDefault<typename SchemaTable::TempDirOwnerActorIdRaw>()
         );
     }
 

--- a/ydb/core/tx/schemeshard/schemeshard__operation_side_effects.cpp
+++ b/ydb/core/tx/schemeshard/schemeshard__operation_side_effects.cpp
@@ -782,10 +782,10 @@ void TSideEffects::DoPersistDeleteShards(TSchemeShard *ss, NTabletFlatExecutor::
 void TSideEffects::DoUpdateTempDirsToMakeState(TSchemeShard* ss, const TActorContext &ctx) {
     for (auto& [ownerActorId, tempDirs]: TempDirsToMakeState) {
 
-        auto& TempDirsByOwner = ss->TempDirsState.TempDirsByOwner;
+        auto& tempDirsByOwner = ss->TempDirsState.TempDirsByOwner;
         auto& nodeStates = ss->TempDirsState.NodeStates;
 
-        const auto it = TempDirsByOwner.find(ownerActorId);
+        const auto it = tempDirsByOwner.find(ownerActorId);
 
         const auto nodeId = ownerActorId.NodeId();
 
@@ -799,12 +799,12 @@ void TSideEffects::DoUpdateTempDirsToMakeState(TSchemeShard* ss, const TActorCon
             itNodeStates->second.Owners.insert(ownerActorId);
         }
 
-        if (it == TempDirsByOwner.end()) {
+        if (it == tempDirsByOwner.end()) {
             ctx.Send(new IEventHandle(ownerActorId, ss->SelfId(),
                 new TEvSchemeShard::TEvOwnerActorAck(),
                 IEventHandle::FlagTrackDelivery | IEventHandle::FlagSubscribeOnSession));
 
-            auto& currentDirsTables = TempDirsByOwner[ownerActorId];
+            auto& currentDirsTables = tempDirsByOwner[ownerActorId];
 
             for (auto& pathId : tempDirs) {
                 currentDirsTables.insert(std::move(pathId));
@@ -820,9 +820,9 @@ void TSideEffects::DoUpdateTempDirsToMakeState(TSchemeShard* ss, const TActorCon
 
 void TSideEffects::DoUpdateTempDirsToRemoveState(TSchemeShard* ss, const TActorContext& ctx) {
     for (auto& [ownerActorId, tempDirs]: TempDirsToRemoveState) {
-        auto& TempDirsByOwner = ss->TempDirsState.TempDirsByOwner;
-        const auto it = TempDirsByOwner.find(ownerActorId);
-        if (it == TempDirsByOwner.end()) {
+        auto& tempDirsByOwner = ss->TempDirsState.TempDirsByOwner;
+        const auto it = tempDirsByOwner.find(ownerActorId);
+        if (it == tempDirsByOwner.end()) {
             continue;
         }
 
@@ -837,7 +837,7 @@ void TSideEffects::DoUpdateTempDirsToRemoveState(TSchemeShard* ss, const TActorC
         }
 
         if (it->second.empty()) {
-            TempDirsByOwner.erase(it);
+            tempDirsByOwner.erase(it);
 
             auto& nodeStates = ss->TempDirsState.NodeStates;
 

--- a/ydb/core/tx/schemeshard/schemeshard_impl.cpp
+++ b/ydb/core/tx/schemeshard/schemeshard_impl.cpp
@@ -1982,7 +1982,7 @@ void TSchemeShard::PersistPath(NIceDb::TNiceDb& db, const TPathId& pathId) {
                     NIceDb::TUpdate<Schema::Paths::DirAlterVersion>(elem->DirAlterVersion),
                     NIceDb::TUpdate<Schema::Paths::UserAttrsAlterVersion>(elem->UserAttrs->AlterVersion),
                     NIceDb::TUpdate<Schema::Paths::ACLVersion>(elem->ACLVersion),
-                    NIceDb::TUpdate<Schema::Paths::TempDirOwnerActorId>(elem->TempDirOwnerActorId)
+                    NIceDb::TUpdate<Schema::Paths::TempDirOwnerActorIdRaw>(elem->TempDirOwnerActorId)
                     );
     } else {
         db.Table<Schema::MigratedPaths>().Key(pathId.OwnerId, pathId.LocalPathId).Update(
@@ -2000,7 +2000,7 @@ void TSchemeShard::PersistPath(NIceDb::TNiceDb& db, const TPathId& pathId) {
                     NIceDb::TUpdate<Schema::MigratedPaths::DirAlterVersion>(elem->DirAlterVersion),
                     NIceDb::TUpdate<Schema::MigratedPaths::UserAttrsAlterVersion>(elem->UserAttrs->AlterVersion),
                     NIceDb::TUpdate<Schema::MigratedPaths::ACLVersion>(elem->ACLVersion),
-                    NIceDb::TUpdate<Schema::MigratedPaths::TempDirOwnerActorId>(elem->TempDirOwnerActorId)
+                    NIceDb::TUpdate<Schema::MigratedPaths::TempDirOwnerActorIdRaw>(elem->TempDirOwnerActorId)
                     );
     }
 }

--- a/ydb/core/tx/schemeshard/schemeshard_impl.cpp
+++ b/ydb/core/tx/schemeshard/schemeshard_impl.cpp
@@ -1982,7 +1982,7 @@ void TSchemeShard::PersistPath(NIceDb::TNiceDb& db, const TPathId& pathId) {
                     NIceDb::TUpdate<Schema::Paths::DirAlterVersion>(elem->DirAlterVersion),
                     NIceDb::TUpdate<Schema::Paths::UserAttrsAlterVersion>(elem->UserAttrs->AlterVersion),
                     NIceDb::TUpdate<Schema::Paths::ACLVersion>(elem->ACLVersion),
-                    NIceDb::TUpdate<Schema::Paths::TempDirOwnerActorId>(elem->TempDirOwnerActorId.ToString())
+                    NIceDb::TUpdate<Schema::Paths::TempDirOwnerActorId>(elem->TempDirOwnerActorId)
                     );
     } else {
         db.Table<Schema::MigratedPaths>().Key(pathId.OwnerId, pathId.LocalPathId).Update(
@@ -2000,7 +2000,7 @@ void TSchemeShard::PersistPath(NIceDb::TNiceDb& db, const TPathId& pathId) {
                     NIceDb::TUpdate<Schema::MigratedPaths::DirAlterVersion>(elem->DirAlterVersion),
                     NIceDb::TUpdate<Schema::MigratedPaths::UserAttrsAlterVersion>(elem->UserAttrs->AlterVersion),
                     NIceDb::TUpdate<Schema::MigratedPaths::ACLVersion>(elem->ACLVersion),
-                    NIceDb::TUpdate<Schema::MigratedPaths::TempDirOwnerActorId>(elem->TempDirOwnerActorId.ToString())
+                    NIceDb::TUpdate<Schema::MigratedPaths::TempDirOwnerActorId>(elem->TempDirOwnerActorId)
                     );
     }
 }

--- a/ydb/core/tx/schemeshard/schemeshard_schema.h
+++ b/ydb/core/tx/schemeshard/schemeshard_schema.h
@@ -33,14 +33,14 @@ struct Schema : NIceDb::Schema {
         struct ACLVersion :            Column<15, NScheme::NTypeIds::Uint64> {};
         struct ParentOwnerId :         Column<16, NScheme::NTypeIds::Uint64> { using Type = TOwnerId; static constexpr Type Default = InvalidOwnerId; };
         struct TempDirOwnerActorId_Deprecated : Column<17, NScheme::NTypeIds::String> {};
-        struct TempDirOwnerActorId :   Column<18, NScheme::NTypeIds::ActorId> {}; // Only for EPathType::EPathTypeDir.
-                                                                                  // Not empty if dir must be deleted after loosing connection with TempDirOwnerActorId actor.
-                                                                                  // See schemeshard__background_cleaning.cpp.
+        struct TempDirOwnerActorIdRaw : Column<18, NScheme::NTypeIds::ActorId> {}; // Only for EPathType::EPathTypeDir.
+                                                                                   // Not empty if dir must be deleted after loosing connection with TempDirOwnerActorId actor.
+                                                                                   // See schemeshard__background_cleaning.cpp.
 
         using TKey = TableKey<Id>;
         using TColumns = TableColumns<Id, ParentId, Name, CreateFinished, PathType, StepCreated, CreateTxId,
             StepDropped, DropTxId, Owner, ACL, LastTxId, DirAlterVersion, UserAttrsAlterVersion, ACLVersion,
-            ParentOwnerId, TempDirOwnerActorId_Deprecated, TempDirOwnerActorId>;
+            ParentOwnerId, TempDirOwnerActorId_Deprecated, TempDirOwnerActorIdRaw>;
     };
 
     struct MigratedPaths : Table<50> {
@@ -61,14 +61,14 @@ struct Schema : NIceDb::Schema {
         struct UserAttrsAlterVersion : Column<15, NScheme::NTypeIds::Uint64> {};
         struct ACLVersion :            Column<16, NScheme::NTypeIds::Uint64> {};
         struct TempDirOwnerActorId_Deprecated : Column<17, NScheme::NTypeIds::String> {};
-        struct TempDirOwnerActorId :   Column<18, NScheme::NTypeIds::ActorId> {}; // Only for EPathType::EPathTypeDir.
-                                                                                  // Not empty if dir must be deleted after loosing connection with TempDirOwnerActorId actor.
-                                                                                  // See schemeshard__background_cleaning.cpp.
+        struct TempDirOwnerActorIdRaw : Column<18, NScheme::NTypeIds::ActorId> {}; // Only for EPathType::EPathTypeDir.
+                                                                                   // Not empty if dir must be deleted after loosing connection with TempDirOwnerActorId actor.
+                                                                                   // See schemeshard__background_cleaning.cpp.
 
         using TKey = TableKey<OwnerPathId, LocalPathId>;
         using TColumns = TableColumns<OwnerPathId, LocalPathId, ParentOwnerId, ParentLocalId, Name, PathType, StepCreated, CreateTxId,
             StepDropped, DropTxId, Owner, ACL, LastTxId, DirAlterVersion, UserAttrsAlterVersion, ACLVersion, TempDirOwnerActorId_Deprecated,
-            TempDirOwnerActorId>;
+            TempDirOwnerActorIdRaw>;
     };
 
     struct TxInFlight : Table<2> { // not in use

--- a/ydb/core/tx/schemeshard/schemeshard_schema.h
+++ b/ydb/core/tx/schemeshard/schemeshard_schema.h
@@ -32,14 +32,15 @@ struct Schema : NIceDb::Schema {
         struct UserAttrsAlterVersion : Column<14, NScheme::NTypeIds::Uint64> {};
         struct ACLVersion :            Column<15, NScheme::NTypeIds::Uint64> {};
         struct ParentOwnerId :         Column<16, NScheme::NTypeIds::Uint64> { using Type = TOwnerId; static constexpr Type Default = InvalidOwnerId; };
-        struct TempDirOwnerActorId :   Column<17, NScheme::NTypeIds::String> {}; // Only for EPathType::EPathTypeDir.
-                                                                                 // Not empty if dir must be deleted after loosing connection with TempDirOwnerActorId actor.
-                                                                                 // See schemeshard__background_cleaning.cpp.
+        struct TempDirOwnerActorId_Deprecated : Column<17, NScheme::NTypeIds::String> {};
+        struct TempDirOwnerActorId :   Column<18, NScheme::NTypeIds::ActorId> {}; // Only for EPathType::EPathTypeDir.
+                                                                                  // Not empty if dir must be deleted after loosing connection with TempDirOwnerActorId actor.
+                                                                                  // See schemeshard__background_cleaning.cpp.
 
         using TKey = TableKey<Id>;
         using TColumns = TableColumns<Id, ParentId, Name, CreateFinished, PathType, StepCreated, CreateTxId,
             StepDropped, DropTxId, Owner, ACL, LastTxId, DirAlterVersion, UserAttrsAlterVersion, ACLVersion,
-            ParentOwnerId, TempDirOwnerActorId>;
+            ParentOwnerId, TempDirOwnerActorId_Deprecated, TempDirOwnerActorId>;
     };
 
     struct MigratedPaths : Table<50> {
@@ -59,13 +60,15 @@ struct Schema : NIceDb::Schema {
         struct DirAlterVersion :       Column<14, NScheme::NTypeIds::Uint64> {};
         struct UserAttrsAlterVersion : Column<15, NScheme::NTypeIds::Uint64> {};
         struct ACLVersion :            Column<16, NScheme::NTypeIds::Uint64> {};
-        struct TempDirOwnerActorId :   Column<17, NScheme::NTypeIds::String> {}; // Only for EPathType::EPathTypeDir.
-                                                                                 // Not empty if dir must be deleted after loosing connection with TempDirOwnerActorId actor.
-                                                                                 // See schemeshard__background_cleaning.cpp.
+        struct TempDirOwnerActorId_Deprecated : Column<17, NScheme::NTypeIds::String> {};
+        struct TempDirOwnerActorId :   Column<18, NScheme::NTypeIds::ActorId> {}; // Only for EPathType::EPathTypeDir.
+                                                                                  // Not empty if dir must be deleted after loosing connection with TempDirOwnerActorId actor.
+                                                                                  // See schemeshard__background_cleaning.cpp.
 
         using TKey = TableKey<OwnerPathId, LocalPathId>;
         using TColumns = TableColumns<OwnerPathId, LocalPathId, ParentOwnerId, ParentLocalId, Name, PathType, StepCreated, CreateTxId,
-            StepDropped, DropTxId, Owner, ACL, LastTxId, DirAlterVersion, UserAttrsAlterVersion, ACLVersion, TempDirOwnerActorId>;
+            StepDropped, DropTxId, Owner, ACL, LastTxId, DirAlterVersion, UserAttrsAlterVersion, ACLVersion, TempDirOwnerActorId_Deprecated,
+            TempDirOwnerActorId>;
     };
 
     struct TxInFlight : Table<2> { // not in use

--- a/ydb/tests/functional/scheme_tests/canondata/tablet_scheme_tests.TestTabletSchemes.test_tablet_schemes_flat_schemeshard_/flat_schemeshard.schema
+++ b/ydb/tests/functional/scheme_tests/canondata/tablet_scheme_tests.TestTabletSchemes.test_tablet_schemes_flat_schemeshard_/flat_schemeshard.schema
@@ -93,7 +93,7 @@
             },
             {
                 "ColumnId": 18,
-                "ColumnName": "TempDirOwnerActorId",
+                "ColumnName": "TempDirOwnerActorIdRaw",
                 "ColumnType": "ActorID"
             }
         ],
@@ -3516,7 +3516,7 @@
             },
             {
                 "ColumnId": 18,
-                "ColumnName": "TempDirOwnerActorId",
+                "ColumnName": "TempDirOwnerActorIdRaw",
                 "ColumnType": "ActorID"
             }
         ],

--- a/ydb/tests/functional/scheme_tests/canondata/tablet_scheme_tests.TestTabletSchemes.test_tablet_schemes_flat_schemeshard_/flat_schemeshard.schema
+++ b/ydb/tests/functional/scheme_tests/canondata/tablet_scheme_tests.TestTabletSchemes.test_tablet_schemes_flat_schemeshard_/flat_schemeshard.schema
@@ -7,11 +7,6 @@
         ],
         "ColumnsAdded": [
             {
-                "ColumnId": 17,
-                "ColumnName": "TempDirOwnerActorId",
-                "ColumnType": "String"
-            },
-            {
                 "ColumnId": 1,
                 "ColumnName": "Id",
                 "ColumnType": "Uint64"
@@ -90,13 +85,22 @@
                 "ColumnId": 16,
                 "ColumnName": "ParentOwnerId",
                 "ColumnType": "Uint64"
+            },
+            {
+                "ColumnId": 17,
+                "ColumnName": "TempDirOwnerActorId_Deprecated",
+                "ColumnType": "String"
+            },
+            {
+                "ColumnId": 18,
+                "ColumnName": "TempDirOwnerActorId",
+                "ColumnType": "ActorID"
             }
         ],
         "ColumnsDropped": [],
         "ColumnFamilies": {
             "0": {
                 "Columns": [
-                    17,
                     1,
                     2,
                     3,
@@ -112,7 +116,9 @@
                     13,
                     14,
                     15,
-                    16
+                    16,
+                    17,
+                    18
                 ],
                 "RoomID": 0,
                 "Codec": 0,
@@ -3424,11 +3430,6 @@
         ],
         "ColumnsAdded": [
             {
-                "ColumnId": 17,
-                "ColumnName": "TempDirOwnerActorId",
-                "ColumnType": "String"
-            },
-            {
                 "ColumnId": 1,
                 "ColumnName": "OwnerPathId",
                 "ColumnType": "Uint64"
@@ -3507,13 +3508,22 @@
                 "ColumnId": 16,
                 "ColumnName": "ACLVersion",
                 "ColumnType": "Uint64"
+            },
+            {
+                "ColumnId": 17,
+                "ColumnName": "TempDirOwnerActorId_Deprecated",
+                "ColumnType": "String"
+            },
+            {
+                "ColumnId": 18,
+                "ColumnName": "TempDirOwnerActorId",
+                "ColumnType": "ActorID"
             }
         ],
         "ColumnsDropped": [],
         "ColumnFamilies": {
             "0": {
                 "Columns": [
-                    17,
                     1,
                     2,
                     3,
@@ -3529,7 +3539,9 @@
                     13,
                     14,
                     15,
-                    16
+                    16,
+                    17,
+                    18
                 ],
                 "RoomID": 0,
                 "Codec": 0,


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

Fixed temp dir owner actor id serialization

### Changelog category <!-- remove all except one -->

* Bugfix 

### Description for reviewers <!-- (optional) description for those who read this PR -->

When restarting the SS tablet, the TempDirOwnerActorId pool id is lost and the temporary tables are dropped because it is not possible to send an Ack to the actor. Fixed serialization for TempDirOwnerActorId, pool id is now saved.