### PR TITLE
Per API audit logging settings

### DIFF
--- a/ydb/core/protos/config.proto
+++ b/ydb/core/protos/config.proto
@@ -1564,7 +1564,7 @@ message TImmediateControlsConfig {
             MinValue: 1,
             MaxValue: 1000,
             DefaultValue: 10 }];
-        
+
         optional uint64 HullCompMaxInFlightWrites = 31 [(ControlOptions) = {
             Description: "Max writes inflight for level compaction",
             MinValue: 1,
@@ -1576,7 +1576,7 @@ message TImmediateControlsConfig {
             MinValue: 1,
             MaxValue: 1000,
             DefaultValue: 20 }];
-            
+
         optional uint64 EnableDeepScrubbing = 33 [(ControlOptions) = {
             Description: "Run CheckIntegrity requests during Scrub process instead of usual scrubbing",
             MinValue: 0,
@@ -1779,9 +1779,25 @@ message TAuditConfig {
         optional string LogJsonEnvelope = 3; // Json template with text field containing %message% placeholder. For example {"my_enveloped_message": "%message%"}. %message% will be replaced with real audit log message
     }
 
+    message TApiAuditSettings {
+        enum EApiType {
+            UNSPECIFIED = 0;
+            HTTP = 1; // HTTP API
+            GRPC = 2; // gRPC API
+        }
+
+        optional EApiType ApiType = 1;
+
+        optional bool EnableModifyingMethodsAudit = 2; // Write modifying API calls to audit logs:
+                                                       // - from cluster API that modifies cluster state;
+                                                       // - from database API that modifies database state and is performed by a user account or
+                                                       //     a service account that contains a user account in its impersonation chain.
+    }
+
     optional TStderrBackend StderrBackend = 1;
     optional TFileBackend FileBackend = 2;
     optional TUnifiedAgentBackend UnifiedAgentBackend = 3;
+    repeated TApiAuditSettings ApiAuditSettings = 4;
 };
 
 message THiveTabletLimit {

--- a/ydb/core/protos/config.proto
+++ b/ydb/core/protos/config.proto
@@ -1788,10 +1788,12 @@ message TAuditConfig {
 
         optional EApiType ApiType = 1;
 
-        optional bool EnableModifyingMethodsAudit = 2; // Write modifying API calls to audit logs:
-                                                       // - from cluster API that modifies cluster state;
-                                                       // - from database API that modifies database state and is performed by a user account or
-                                                       //     a service account that contains a user account in its impersonation chain.
+        optional bool WriteApiCalls = 2; // Write modifying API calls to audit logs
+                                         // in the same way as DML audit, but for all databases and out of database admin APIs.
+                                         //
+                                         // - from cluster admin API that modifies cluster state (public and private API);
+                                         // - from database API that modifies database state and is performed by a user account or
+                                         //     a service account that contains a user account in its impersonation chain.
     }
 
     optional TStderrBackend StderrBackend = 1;


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

...

### Changelog category <!-- remove all except one -->

* Not for changelog (changelog entry is not required)

### Description for reviewers <!-- (optional) description for those who read this PR -->

I introduce here new settings that can describe API specific modes for audit logs. I plan to implement them in GRPC and HTTP APIs. 
In HTTP API it will be implemented from scratch as we don't have audit logging there.
In GRPC API we already have logging in DML Audit logging feature, but we want to add new conditions for such logging. For example, add logging to every modifying cluster API call (such as modifying cluster config or registering a new dynamic node in cluster), or modifying usual user API call such as altering rate limiter resource or writing to topic.