### PR TITLE
Support for tablet state subscriptions

### DIFF
--- a/ydb/core/base/tablet.h
+++ b/ydb/core/base/tablet.h
@@ -91,6 +91,11 @@ struct TEvTablet {
         EvReserved_00,
         EvFollowerGcAck, // from follower to leader
 
+        // between tablet resolver and sys tablet
+        EvTabletStateSubscribe = EvBoot + 2064,
+        EvTabletStateUnsubscribe,
+        EvTabletStateUpdate,
+
         // from leader to follower
         EvFollowerUpdate = EvBoot + 2560,
         EvFollowerAuxUpdate,
@@ -910,6 +915,43 @@ struct TEvTablet {
             , Status(status)
             , ErrorReason(std::move(errorReason))
         {}
+    };
+
+    struct TEvTabletStateSubscribe : TEventPB<TEvTabletStateSubscribe, NKikimrTabletBase::TEvTabletStateSubscribe, EvTabletStateSubscribe> {
+        TEvTabletStateSubscribe() = default;
+
+        TEvTabletStateSubscribe(ui64 tabletId, ui64 seqNo) {
+            Record.SetTabletId(tabletId);
+            Record.SetSeqNo(seqNo);
+        }
+    };
+
+    struct TEvTabletStateUnsubscribe : TEventPB<TEvTabletStateUnsubscribe, NKikimrTabletBase::TEvTabletStateUnsubscribe, EvTabletStateUnsubscribe> {
+        TEvTabletStateUnsubscribe() = default;
+
+        TEvTabletStateUnsubscribe(ui64 tabletId, ui64 seqNo) {
+            Record.SetTabletId(tabletId);
+            Record.SetSeqNo(seqNo);
+        }
+    };
+
+    struct TEvTabletStateUpdate : TEventPB<TEvTabletStateUpdate, NKikimrTabletBase::TEvTabletStateUpdate, EvTabletStateUpdate> {
+        using EState = NKikimrTabletBase::TEvTabletStateUpdate::EState;
+
+        TEvTabletStateUpdate() = default;
+
+        TEvTabletStateUpdate(ui64 tabletId, ui64 seqNo, EState state, const TActorId& userActorId = {}) {
+            Record.SetTabletId(tabletId);
+            Record.SetSeqNo(seqNo);
+            Record.SetState(state);
+            if (userActorId) {
+                ActorIdToProto(userActorId, Record.MutableUserActorId());
+            }
+        }
+
+        TActorId GetUserActorId() const {
+            return ActorIdFromProto(Record.GetUserActorId());
+        }
     };
 };
 

--- a/ydb/core/base/tablet.h
+++ b/ydb/core/base/tablet.h
@@ -91,11 +91,6 @@ struct TEvTablet {
         EvReserved_00,
         EvFollowerGcAck, // from follower to leader
 
-        // between tablet resolver and sys tablet
-        EvTabletStateSubscribe = EvBoot + 2064,
-        EvTabletStateUnsubscribe,
-        EvTabletStateUpdate,
-
         // from leader to follower
         EvFollowerUpdate = EvBoot + 2560,
         EvFollowerAuxUpdate,
@@ -108,6 +103,11 @@ struct TEvTablet {
         EvResetTabletResult,
         EvGcForStepAckRequest, // from executer to sys tablet
         EvGcForStepAckResponse, // from sys tablet to executer
+
+        // between tablet resolver and sys tablet
+        EvTabletStateSubscribe = EvBoot + 3328,
+        EvTabletStateUnsubscribe,
+        EvTabletStateUpdate,
 
         EvEnd
     };

--- a/ydb/core/protos/node_whiteboard.proto
+++ b/ydb/core/protos/node_whiteboard.proto
@@ -38,9 +38,10 @@ message TTabletStateInfo {
         ResolveLeader = 11;
         Deleted = 12;
         Stopped = 13;
-        Reserved14 = 14;
+        Stopping = 14;
         Reserved15 = 15;
         Reserved16 = 16;
+        Reserved17 = 17;
     }
 
     optional uint64 TabletId = 1 [(DefaultField) = true];

--- a/ydb/core/protos/node_whiteboard.proto
+++ b/ydb/core/protos/node_whiteboard.proto
@@ -38,7 +38,7 @@ message TTabletStateInfo {
         ResolveLeader = 11;
         Deleted = 12;
         Stopped = 13;
-        Stopping = 14;
+        Terminating = 14;
         Reserved15 = 15;
         Reserved16 = 16;
         Reserved17 = 17;

--- a/ydb/core/protos/out/out_tablet.cpp
+++ b/ydb/core/protos/out/out_tablet.cpp
@@ -1,0 +1,7 @@
+#include <ydb/core/protos/tablet.pb.h>
+
+#include <util/stream/output.h>
+
+Y_DECLARE_OUT_SPEC(, NKikimrTabletBase::TEvTabletStateUpdate::EState, stream, value) {
+    stream << NKikimrTabletBase::TEvTabletStateUpdate::EState_Name(value);
+}

--- a/ydb/core/protos/out/ya.make
+++ b/ydb/core/protos/out/ya.make
@@ -5,6 +5,7 @@ SRCS(
     out_cms.cpp
     out_long_tx_service.cpp
     out_sequenceshard.cpp
+    out_tablet.cpp
 )
 
 PEERDIR(

--- a/ydb/core/protos/tablet.proto
+++ b/ydb/core/protos/tablet.proto
@@ -273,7 +273,7 @@ message TEvTabletStateUpdate {
         StateUnknown = 0;
         StateBooting = 1;
         StateActive = 2;
-        StateStopping = 3;
+        StateTerminating = 3;
         StateDead = 4;
     }
 

--- a/ydb/core/protos/tablet.proto
+++ b/ydb/core/protos/tablet.proto
@@ -1,5 +1,6 @@
 import "ydb/core/protos/base.proto";
 import "ydb/core/protos/tablet_counters.proto";
+import "ydb/library/actors/protos/actors.proto";
 
 package NKikimrTabletBase;
 option java_package = "ru.yandex.kikimr.proto";
@@ -255,4 +256,29 @@ message TEvDropLease {
 
 message TEvLeaseDropped {
     optional uint64 TabletID = 1;
+}
+
+message TEvTabletStateSubscribe {
+    optional fixed64 TabletId = 1;
+    optional uint64 SeqNo = 2;
+}
+
+message TEvTabletStateUnsubscribe {
+    optional fixed64 TabletId = 1;
+    optional uint64 SeqNo = 2;
+}
+
+message TEvTabletStateUpdate {
+    enum EState {
+        StateUnknown = 0;
+        StateBooting = 1;
+        StateActive = 2;
+        StateStopping = 3;
+        StateDead = 4;
+    }
+
+    optional fixed64 TabletId = 1;
+    optional uint64 SeqNo = 2;
+    optional EState State = 3;
+    optional NActorsProto.TActorId UserActorId = 4;
 }

--- a/ydb/core/tablet/tablet_state_ut.cpp
+++ b/ydb/core/tablet/tablet_state_ut.cpp
@@ -96,13 +96,13 @@ Y_UNIT_TEST_SUITE(TabletState) {
             });
         Y_UNUSED(tablet2);
 
-        // We should receive a stopping notification (which implies new pipes will not connect)
+        // We should receive a terminating notification (which implies new pipes will not connect)
         {
             auto ev = runtime.GrabEdgeEvent<TEvTablet::TEvTabletStateUpdate>(sender);
             auto* msg = ev->Get();
             UNIT_ASSERT_VALUES_EQUAL(msg->Record.GetTabletId(), tabletId);
             UNIT_ASSERT_VALUES_EQUAL(msg->Record.GetSeqNo(), 1u);
-            UNIT_ASSERT_VALUES_EQUAL(msg->Record.GetState(), NKikimrTabletBase::TEvTabletStateUpdate::StateStopping);
+            UNIT_ASSERT_VALUES_EQUAL(msg->Record.GetState(), NKikimrTabletBase::TEvTabletStateUpdate::StateTerminating);
             UNIT_ASSERT_VALUES_UNEQUAL(msg->GetUserActorId(), TActorId());
             UNIT_ASSERT_VALUES_EQUAL(ev->Cookie, 123u);
         }

--- a/ydb/core/tablet/tablet_state_ut.cpp
+++ b/ydb/core/tablet/tablet_state_ut.cpp
@@ -1,0 +1,284 @@
+#include <ydb/core/testlib/tablet_helpers.h>
+
+#include <ydb/core/tablet_flat/tablet_flat_executed.h>
+#include <ydb/library/actors/core/hfunc.h>
+#include <ydb/library/actors/core/interconnect.h>
+#include <ydb/library/actors/interconnect/interconnect_impl.h>
+
+#include <library/cpp/testing/unittest/registar.h>
+
+namespace NKikimr {
+
+Y_UNIT_TEST_SUITE(TabletState) {
+
+    class TSimpleTablet
+        : public TActor<TSimpleTablet>
+        , public NTabletFlatExecutor::TTabletExecutedFlat
+    {
+    public:
+        TSimpleTablet(const TActorId& tablet, TTabletStorageInfo* info)
+            : TActor(&TThis::StateInit)
+            , TTabletExecutedFlat(info, tablet, nullptr)
+        {}
+
+    private:
+        void DefaultSignalTabletActive(const TActorContext&) override {
+            // must be empty
+        }
+
+        void OnActivateExecutor(const TActorContext& ctx) override {
+            Become(&TThis::StateWork);
+            SignalTabletActive(ctx);
+        }
+
+        void OnDetach(const TActorContext& ctx) override {
+            return Die(ctx);
+        }
+
+        void OnTabletDead(TEvTablet::TEvTabletDead::TPtr&, const TActorContext& ctx) override {
+            return Die(ctx);
+        }
+
+        STFUNC(StateInit) {
+            StateInitImpl(ev, SelfId());
+        }
+
+        STFUNC(StateWork) {
+            switch (ev->GetTypeRewrite()) {
+            default:
+                HandleDefaultEvents(ev, SelfId());
+            }
+        }
+    };
+
+    Y_UNIT_TEST(NormalLifecycle) {
+        TTestBasicRuntime runtime(1);
+        SetupTabletServices(runtime);
+
+        auto sender = runtime.AllocateEdgeActor();
+        ui64 tabletId = TTestTxConfig::TxTablet0;
+
+        auto tablet1 = StartTestTablet(runtime,
+            CreateTestTabletInfo(tabletId, TTabletTypes::Dummy),
+            [](const TActorId& tablet, TTabletStorageInfo* info) {
+                return new TSimpleTablet(tablet, info);
+            });
+
+        runtime.Send(new IEventHandle(tablet1, sender, new TEvTablet::TEvTabletStateSubscribe(tabletId, /* seqNo */ 1), /* flags */ 0, /* cookie */ 123), 0, true);
+
+        // We should receive a booting state immediately after subscription
+        {
+            auto ev = runtime.GrabEdgeEvent<TEvTablet::TEvTabletStateUpdate>(sender);
+            auto* msg = ev->Get();
+            UNIT_ASSERT_VALUES_EQUAL(msg->Record.GetTabletId(), tabletId);
+            UNIT_ASSERT_VALUES_EQUAL(msg->Record.GetSeqNo(), 1u);
+            UNIT_ASSERT_VALUES_EQUAL(msg->Record.GetState(), NKikimrTabletBase::TEvTabletStateUpdate::StateBooting);
+            UNIT_ASSERT_VALUES_EQUAL(msg->GetUserActorId(), TActorId());
+            UNIT_ASSERT_VALUES_EQUAL(ev->Cookie, 123u);
+        }
+
+        // Next we should receive an active state with the user tablet
+        {
+            auto ev = runtime.GrabEdgeEvent<TEvTablet::TEvTabletStateUpdate>(sender);
+            auto* msg = ev->Get();
+            UNIT_ASSERT_VALUES_EQUAL(msg->Record.GetTabletId(), tabletId);
+            UNIT_ASSERT_VALUES_EQUAL(msg->Record.GetSeqNo(), 1u);
+            UNIT_ASSERT_VALUES_EQUAL(msg->Record.GetState(), NKikimrTabletBase::TEvTabletStateUpdate::StateActive);
+            UNIT_ASSERT_VALUES_UNEQUAL(msg->GetUserActorId(), TActorId());
+            UNIT_ASSERT_VALUES_EQUAL(ev->Cookie, 123u);
+        }
+
+        // Start a new tablet instance, which will cause the first instance to shutdown
+        auto tablet2 = StartTestTablet(runtime,
+            CreateTestTabletInfo(tabletId, TTabletTypes::Dummy),
+            [](const TActorId& tablet, TTabletStorageInfo* info) {
+                return new TSimpleTablet(tablet, info);
+            });
+        Y_UNUSED(tablet2);
+
+        // We should receive a stopping notification (which implies new pipes will not connect)
+        {
+            auto ev = runtime.GrabEdgeEvent<TEvTablet::TEvTabletStateUpdate>(sender);
+            auto* msg = ev->Get();
+            UNIT_ASSERT_VALUES_EQUAL(msg->Record.GetTabletId(), tabletId);
+            UNIT_ASSERT_VALUES_EQUAL(msg->Record.GetSeqNo(), 1u);
+            UNIT_ASSERT_VALUES_EQUAL(msg->Record.GetState(), NKikimrTabletBase::TEvTabletStateUpdate::StateStopping);
+            UNIT_ASSERT_VALUES_UNEQUAL(msg->GetUserActorId(), TActorId());
+            UNIT_ASSERT_VALUES_EQUAL(ev->Cookie, 123u);
+        }
+
+        // Eventually the tablet dies and we should receive another notification
+        {
+            auto ev = runtime.GrabEdgeEvent<TEvTablet::TEvTabletStateUpdate>(sender);
+            auto* msg = ev->Get();
+            UNIT_ASSERT_VALUES_EQUAL(msg->Record.GetTabletId(), tabletId);
+            UNIT_ASSERT_VALUES_EQUAL(msg->Record.GetSeqNo(), 1u);
+            UNIT_ASSERT_VALUES_EQUAL(msg->Record.GetState(), NKikimrTabletBase::TEvTabletStateUpdate::StateDead);
+            UNIT_ASSERT_VALUES_UNEQUAL(msg->GetUserActorId(), TActorId());
+            UNIT_ASSERT_VALUES_EQUAL(ev->Cookie, 123u);
+        }
+    }
+
+    Y_UNIT_TEST(SeqNoSubscriptionReplace) {
+        TTestBasicRuntime runtime(1);
+        SetupTabletServices(runtime);
+
+        auto sender = runtime.AllocateEdgeActor();
+        ui64 tabletId = TTestTxConfig::TxTablet0;
+
+        auto tablet1 = StartTestTablet(runtime,
+            CreateTestTabletInfo(tabletId, TTabletTypes::Dummy),
+            [](const TActorId& tablet, TTabletStorageInfo* info) {
+                return new TSimpleTablet(tablet, info);
+            });
+
+        runtime.Send(new IEventHandle(tablet1, sender, new TEvTablet::TEvTabletStateSubscribe(tabletId, /* seqNo */ 1), /* flags */ 0, /* cookie */ 123), 0, true);
+        runtime.Send(new IEventHandle(tablet1, sender, new TEvTablet::TEvTabletStateSubscribe(tabletId, /* seqNo */ 2), /* flags */ 0, /* cookie */ 234), 0, true);
+
+        // We should receive a booting state immediately after subscription
+        {
+            auto ev = runtime.GrabEdgeEvent<TEvTablet::TEvTabletStateUpdate>(sender);
+            auto* msg = ev->Get();
+            UNIT_ASSERT_VALUES_EQUAL(msg->Record.GetTabletId(), tabletId);
+            UNIT_ASSERT_VALUES_EQUAL(msg->Record.GetSeqNo(), 1u);
+            UNIT_ASSERT_VALUES_EQUAL(msg->Record.GetState(), NKikimrTabletBase::TEvTabletStateUpdate::StateBooting);
+            UNIT_ASSERT_VALUES_EQUAL(msg->GetUserActorId(), TActorId());
+            UNIT_ASSERT_VALUES_EQUAL(ev->Cookie, 123u);
+        }
+
+        // Same for the second SeqNo (which replaces subscription)
+        {
+            auto ev = runtime.GrabEdgeEvent<TEvTablet::TEvTabletStateUpdate>(sender);
+            auto* msg = ev->Get();
+            UNIT_ASSERT_VALUES_EQUAL(msg->Record.GetTabletId(), tabletId);
+            UNIT_ASSERT_VALUES_EQUAL(msg->Record.GetSeqNo(), 2u);
+            UNIT_ASSERT_VALUES_EQUAL(msg->Record.GetState(), NKikimrTabletBase::TEvTabletStateUpdate::StateBooting);
+            UNIT_ASSERT_VALUES_EQUAL(msg->GetUserActorId(), TActorId());
+            UNIT_ASSERT_VALUES_EQUAL(ev->Cookie, 234u);
+        }
+
+        // Next we should receive an active state with the user tablet for the second SeqNo
+        {
+            auto ev = runtime.GrabEdgeEvent<TEvTablet::TEvTabletStateUpdate>(sender);
+            auto* msg = ev->Get();
+            UNIT_ASSERT_VALUES_EQUAL(msg->Record.GetTabletId(), tabletId);
+            UNIT_ASSERT_VALUES_EQUAL(msg->Record.GetSeqNo(), 2u);
+            UNIT_ASSERT_VALUES_EQUAL(msg->Record.GetState(), NKikimrTabletBase::TEvTabletStateUpdate::StateActive);
+            UNIT_ASSERT_VALUES_UNEQUAL(msg->GetUserActorId(), TActorId());
+            UNIT_ASSERT_VALUES_EQUAL(ev->Cookie, 234u);
+        }
+    }
+
+    Y_UNIT_TEST(SeqNoSubscribeOutOfOrder) {
+        TTestBasicRuntime runtime(1);
+        SetupTabletServices(runtime);
+
+        auto sender = runtime.AllocateEdgeActor();
+        ui64 tabletId = TTestTxConfig::TxTablet0;
+
+        auto tablet1 = StartTestTablet(runtime,
+            CreateTestTabletInfo(tabletId, TTabletTypes::Dummy),
+            [](const TActorId& tablet, TTabletStorageInfo* info) {
+                return new TSimpleTablet(tablet, info);
+            });
+
+        runtime.Send(new IEventHandle(tablet1, sender, new TEvTablet::TEvTabletStateSubscribe(tabletId, /* seqNo */ 2), /* flags */ 0, /* cookie */ 234), 0, true);
+        runtime.Send(new IEventHandle(tablet1, sender, new TEvTablet::TEvTabletStateSubscribe(tabletId, /* seqNo */ 1), /* flags */ 0, /* cookie */ 123), 0, true);
+
+        // We should receive reply for the second SeqNo, the first out-of-order one should be ignored
+        {
+            auto ev = runtime.GrabEdgeEvent<TEvTablet::TEvTabletStateUpdate>(sender);
+            auto* msg = ev->Get();
+            UNIT_ASSERT_VALUES_EQUAL(msg->Record.GetTabletId(), tabletId);
+            UNIT_ASSERT_VALUES_EQUAL(msg->Record.GetSeqNo(), 2u);
+            UNIT_ASSERT_VALUES_EQUAL(msg->Record.GetState(), NKikimrTabletBase::TEvTabletStateUpdate::StateBooting);
+            UNIT_ASSERT_VALUES_EQUAL(msg->GetUserActorId(), TActorId());
+            UNIT_ASSERT_VALUES_EQUAL(ev->Cookie, 234u);
+        }
+
+        // Next we should receive an active state with the user tablet for the second SeqNo
+        {
+            auto ev = runtime.GrabEdgeEvent<TEvTablet::TEvTabletStateUpdate>(sender);
+            auto* msg = ev->Get();
+            UNIT_ASSERT_VALUES_EQUAL(msg->Record.GetTabletId(), tabletId);
+            UNIT_ASSERT_VALUES_EQUAL(msg->Record.GetSeqNo(), 2u);
+            UNIT_ASSERT_VALUES_EQUAL(msg->Record.GetState(), NKikimrTabletBase::TEvTabletStateUpdate::StateActive);
+            UNIT_ASSERT_VALUES_UNEQUAL(msg->GetUserActorId(), TActorId());
+            UNIT_ASSERT_VALUES_EQUAL(ev->Cookie, 234u);
+        }
+    }
+
+    Y_UNIT_TEST(ImplicitUnsubscribeOnDisconnect) {
+        TTestBasicRuntime runtime(2);
+        SetupTabletServices(runtime);
+
+        auto sender = runtime.AllocateEdgeActor();
+        ui64 tabletId = TTestTxConfig::TxTablet0;
+
+        auto tablet1 = StartTestTablet(runtime,
+            CreateTestTabletInfo(tabletId, TTabletTypes::Dummy),
+            [](const TActorId& tablet, TTabletStorageInfo* info) {
+                return new TSimpleTablet(tablet, info);
+            }, /* nodeIdx */ 1);
+
+        runtime.Send(new IEventHandle(tablet1, sender, new TEvTablet::TEvTabletStateSubscribe(tabletId, /* seqNo */ 2), /* flags */ IEventHandle::FlagSubscribeOnSession, /* cookie */ 234), 0, true);
+
+        // Connect notification for FlagSubscribeOnSession
+        {
+            auto ev = runtime.GrabEdgeEvent<TEvInterconnect::TEvNodeConnected>(sender);
+        }
+
+        // We should receive reply for the second SeqNo, the first out-of-order one should be ignored
+        {
+            auto ev = runtime.GrabEdgeEvent<TEvTablet::TEvTabletStateUpdate>(sender);
+            auto* msg = ev->Get();
+            UNIT_ASSERT_VALUES_EQUAL(msg->Record.GetTabletId(), tabletId);
+            UNIT_ASSERT_VALUES_EQUAL(msg->Record.GetSeqNo(), 2u);
+            UNIT_ASSERT_VALUES_EQUAL(msg->Record.GetState(), NKikimrTabletBase::TEvTabletStateUpdate::StateBooting);
+            UNIT_ASSERT_VALUES_EQUAL(msg->GetUserActorId(), TActorId());
+            UNIT_ASSERT_VALUES_EQUAL(ev->Cookie, 234u);
+        }
+
+        // Next we should receive an active state with the user tablet for the second SeqNo
+        {
+            auto ev = runtime.GrabEdgeEvent<TEvTablet::TEvTabletStateUpdate>(sender);
+            auto* msg = ev->Get();
+            UNIT_ASSERT_VALUES_EQUAL(msg->Record.GetTabletId(), tabletId);
+            UNIT_ASSERT_VALUES_EQUAL(msg->Record.GetSeqNo(), 2u);
+            UNIT_ASSERT_VALUES_EQUAL(msg->Record.GetState(), NKikimrTabletBase::TEvTabletStateUpdate::StateActive);
+            UNIT_ASSERT_VALUES_UNEQUAL(msg->GetUserActorId(), TActorId());
+            UNIT_ASSERT_VALUES_EQUAL(ev->Cookie, 234u);
+        }
+
+        // Disconnect nodes
+        runtime.Send(new IEventHandle(runtime.GetInterconnectProxy(0, 1), TActorId(), new TEvInterconnect::TEvDisconnect()), 0, true);
+
+        // Disconnect notification for FlagSubscribeOnSession
+        {
+            auto ev = runtime.GrabEdgeEvent<TEvInterconnect::TEvNodeDisconnected>(sender);
+        }
+
+        // There should be no more events in the queue
+        {
+            auto ev = runtime.GrabEdgeEvent<IEventHandle>(sender, TDuration::MilliSeconds(1));
+            UNIT_ASSERT_C(!ev, "Unexpected event received");
+        }
+
+        // Start a new tablet instance, which will cause the first instance to shutdown
+        auto tablet2 = StartTestTablet(runtime,
+            CreateTestTabletInfo(tabletId, TTabletTypes::Dummy),
+            [](const TActorId& tablet, TTabletStorageInfo* info) {
+                return new TSimpleTablet(tablet, info);
+            }, /* nodeIdx */ 1);
+        Y_UNUSED(tablet2);
+
+        // There should be no events for the subscription
+        {
+            auto ev = runtime.GrabEdgeEvent<IEventHandle>(sender, TDuration::Seconds(1));
+            UNIT_ASSERT_C(!ev, "Unexpected envet received");
+        }
+    }
+
+} // Y_UNIT_TEST_SUITE(TabletState)
+
+} // namespace NKikimr

--- a/ydb/core/tablet/tablet_sys.cpp
+++ b/ydb/core/tablet/tablet_sys.cpp
@@ -46,11 +46,6 @@ ui64 TTablet::TabletID() const {
 }
 
 void TTablet::NextFollowerAttempt() {
-    const ui32 node = FollowerInfo.KnownLeaderID.NodeId();
-    if (node && node != SelfId().NodeId()) {
-        const TActorId proxy = TActivationContext::InterconnectProxy(node);
-        Send(proxy, new TEvents::TEvUnsubscribe);
-    }
     FollowerInfo.NextAttempt();
 }
 
@@ -315,9 +310,16 @@ void TTablet::HandleStateStorageLeaderResolve(TEvStateStorage::TEvInfo::TPtr &ev
 
     if (msg->Status == NKikimrProto::OK && msg->CurrentLeader) {
         FollowerInfo.KnownLeaderID = msg->CurrentLeader;
+        FollowerInfo.LastCookie = ++LastInterconnectSubscribeCookie;
         Send(FollowerInfo.KnownLeaderID,
                 new TEvTablet::TEvFollowerAttach(TabletID(), FollowerInfo.FollowerAttempt),
-                IEventHandle::FlagTrackDelivery | IEventHandle::FlagSubscribeOnSession);
+                IEventHandle::FlagTrackDelivery | IEventHandle::FlagSubscribeOnSession,
+                FollowerInfo.LastCookie);
+
+        if (ui32 nodeId = FollowerInfo.KnownLeaderID.NodeId(); nodeId != SelfId().NodeId()) {
+            InterconnectPending[nodeId].LastCookie = FollowerInfo.LastCookie;
+        }
+
         Become(&TThis::StateFollowerSubscribe);
     } else { // something goes weird, try again a bit later
         NextFollowerAttempt();
@@ -394,24 +396,46 @@ bool TTablet::CheckFollowerUpdate(const TActorId &sender, ui32 attempt, ui64 cou
 }
 
 void TTablet::HandleByFollower(TEvents::TEvUndelivered::TPtr &ev) {
-    if (ev->Sender == FollowerInfo.KnownLeaderID) {
+    if (ev->Get()->SourceType == TEvents::TSystem::Subscribe) {
+        InterconnectSessionDisconnected(ev->Sender);
+        return;
+    }
+
+    if (ev->Get()->SourceType == TEvTablet::EvTabletStateUpdate) {
+        TabletStateUndelivered(ev->Sender, ev->Cookie);
+        return;
+    }
+
+    if (ev->Get()->SourceType == TEvTablet::TEvTabletStop::EventType) {
+        if (ev->Sender == UserTablet) {
+            return HandleStopped();
+        }
+        return;
+    }
+
+    if (ev->Sender == FollowerInfo.KnownLeaderID && ev->Cookie == FollowerInfo.LastCookie) {
+        FollowerInfo.LastCookie = -1;
         NextFollowerAttempt();
         RetryFollowerBootstrapOrWait();
         return;
     }
+}
 
-    if (ev->Sender == UserTablet && ev->Get()->SourceType == TEvTablet::TEvTabletStop::EventType) {
-        return HandleStopped();
-    }
+void TTablet::HandleByFollower(TEvInterconnect::TEvNodeConnected::TPtr &ev) {
+    InterconnectSessionConnected(ev->Sender, ev->Get()->NodeId, ev->Cookie);
 }
 
 void TTablet::HandleByFollower(TEvInterconnect::TEvNodeDisconnected::TPtr &ev) {
-    if (ev->Get()->NodeId != FollowerInfo.KnownLeaderID.NodeId())
-        return;
+    // Only handle notification matching the last subscription attempt
+    if (ev->Get()->NodeId == FollowerInfo.KnownLeaderID.NodeId() && ev->Cookie == FollowerInfo.LastCookie) {
+        FollowerInfo.LastCookie = -1;
 
-    BLOG_TRACE("Follower got TEvNodeDisconnected NodeId# " << ev->Get()->NodeId, "TSYS06");
-    NextFollowerAttempt();
-    RetryFollowerBootstrapOrWait();
+        BLOG_TRACE("Follower got TEvNodeDisconnected NodeId# " << ev->Get()->NodeId, "TSYS06");
+        NextFollowerAttempt();
+        RetryFollowerBootstrapOrWait();
+    }
+
+    InterconnectSessionDisconnected(ev->Sender);
 }
 
 void TTablet::HandleByFollower(TEvTablet::TEvFollowerDisconnect::TPtr &ev) {
@@ -435,9 +459,15 @@ void TTablet::HandleByFollower(TEvTablet::TEvFollowerRefresh::TPtr &ev) {
     NextFollowerAttempt();
 
     FollowerInfo.KnownLeaderID = ev->Sender;
+    FollowerInfo.LastCookie = ++LastInterconnectSubscribeCookie;
     Send(FollowerInfo.KnownLeaderID,
         new TEvTablet::TEvFollowerAttach(TabletID(), FollowerInfo.FollowerAttempt),
-        IEventHandle::FlagTrackDelivery | IEventHandle::FlagSubscribeOnSession);
+        IEventHandle::FlagTrackDelivery | IEventHandle::FlagSubscribeOnSession,
+        FollowerInfo.LastCookie);
+
+    if (ui32 nodeId = FollowerInfo.KnownLeaderID.NodeId(); nodeId != SelfId().NodeId()) {
+        InterconnectPending[nodeId].LastCookie = FollowerInfo.LastCookie;
+    }
 
     Become(&TThis::StateFollowerSubscribe);
 }
@@ -555,8 +585,6 @@ void TTablet::HandleByFollower(TEvTablet::TEvFGcAck::TPtr &ev) {
 
 TMap<TActorId, TTablet::TLeaderInfo>::iterator
 TTablet::EraseFollowerInfo(TMap<TActorId, TLeaderInfo>::iterator followerIt) {
-    const ui32 followerNode = followerIt->first.NodeId();
-
     auto retIt = LeaderInfo.erase(followerIt);
 
     if (UserTablet) {
@@ -566,25 +594,16 @@ TTablet::EraseFollowerInfo(TMap<TActorId, TLeaderInfo>::iterator followerIt) {
     TryPumpWaitingForGc();
     TryFinishFollowerSync();
 
-    if (followerNode != SelfId().NodeId()) {
-        bool noMoreFollowersOnNode = true;
-        for (const auto &xpair : LeaderInfo) {
-            if (xpair.first.NodeId() == followerNode) {
-                noMoreFollowersOnNode = false;
-                break;
-            }
-        }
-
-        if (noMoreFollowersOnNode)
-            Send(TActivationContext::InterconnectProxy(followerNode), new TEvents::TEvUnsubscribe);
-    }
-
     return retIt;
 }
 
 TMap<TActorId, TTablet::TLeaderInfo>::iterator TTablet::HandleFollowerConnectionProblem(TMap<TActorId, TLeaderInfo>::iterator followerIt) {
     TLeaderInfo &followerInfo = followerIt->second;
     bool shouldEraseEntry = false;
+
+    followerInfo.InterconnectSession = {};
+    followerInfo.LastCookie = -1;
+    followerInfo.Unlink();
 
     switch (followerInfo.SyncState) {
     case EFollowerSyncState::Pending:
@@ -620,6 +639,12 @@ TMap<TActorId, TTablet::TLeaderInfo>::iterator TTablet::HandleFollowerConnection
     return followerIt;
 }
 
+void TTablet::HandleFollowerDisconnect(TLeaderInfo* follower) {
+    auto it = LeaderInfo.find(follower->FollowerId);
+    Y_ENSURE(it != LeaderInfo.end());
+    HandleFollowerConnectionProblem(it);
+}
+
 void TTablet::TrySyncToFollower(TMap<TActorId, TLeaderInfo>::iterator followerIt) {
     TLeaderInfo &followerInfo = followerIt->second;
     if (followerInfo.SyncCookieHolder) // already awaiting
@@ -633,36 +658,57 @@ void TTablet::TrySyncToFollower(TMap<TActorId, TLeaderInfo>::iterator followerIt
 
 void TTablet::DoSyncToFollower(TMap<TActorId, TLeaderInfo>::iterator followerIt) {
     TLeaderInfo &followerInfo = followerIt->second;
+    followerInfo.InterconnectSession = {};
+    followerInfo.LastCookie = ++LastInterconnectSubscribeCookie;
+    followerInfo.Unlink();
 
-    Send(followerIt->first, new TEvTablet::TEvFollowerRefresh(TabletID(), StateStorageInfo.KnownGeneration), IEventHandle::FlagTrackDelivery | IEventHandle::FlagSubscribeOnSession);
+    Send(followerIt->first,
+        new TEvTablet::TEvFollowerRefresh(TabletID(), StateStorageInfo.KnownGeneration),
+        IEventHandle::FlagTrackDelivery | IEventHandle::FlagSubscribeOnSession,
+        followerInfo.LastCookie);
+
+    if (ui32 nodeId = followerIt->first.NodeId(); nodeId != SelfId().NodeId()) {
+        auto& pending = InterconnectPending[nodeId];
+        pending.LastCookie = followerInfo.LastCookie;
+        pending.Followers.PushBack(&followerInfo);
+    }
 
     ++followerInfo.SyncAttempt;
     followerInfo.LastSyncAttempt = TActivationContext::Now();
 }
 
-
 void TTablet::HandleByLeader(TEvents::TEvUndelivered::TPtr &ev) {
-    auto followerIt = LeaderInfo.find(ev->Sender);
-    if (followerIt != LeaderInfo.end()) {
-        HandleFollowerConnectionProblem(followerIt);
+    if (ev->Get()->SourceType == TEvents::TSystem::Subscribe) {
+        InterconnectSessionDisconnected(ev->Sender);
         return;
     }
 
-    if (ev->Sender == UserTablet && ev->Get()->SourceType == TEvTablet::TEvTabletStop::EventType) {
-        return HandleStopped();
+    if (ev->Get()->SourceType == TEvTablet::EvTabletStateUpdate) {
+        TabletStateUndelivered(ev->Sender, ev->Cookie);
+        return;
+    }
+
+    if (ev->Get()->SourceType == TEvTablet::TEvTabletStop::EventType) {
+        if (ev->Sender == UserTablet) {
+            return HandleStopped();
+        }
+        return;
+    }
+
+    auto followerIt = LeaderInfo.find(ev->Sender);
+    if (followerIt != LeaderInfo.end() && followerIt->second.LastCookie == ev->Cookie) {
+        HandleFollowerConnectionProblem(followerIt);
+        return;
     }
 }
 
+void TTablet::HandleByLeader(TEvInterconnect::TEvNodeConnected::TPtr &ev) {
+    InterconnectSessionConnected(ev->Sender, ev->Get()->NodeId, ev->Cookie);
+}
+
 void TTablet::HandleByLeader(TEvInterconnect::TEvNodeDisconnected::TPtr &ev) {
-    // typical number if followers on one node is one. so we don't bother with batched check for unsubscribe
-    // and we still need to unsubscribe 'cuz of possible races
-    const TEvInterconnect::TEvNodeDisconnected *msg = ev->Get();
-    for (auto it = LeaderInfo.begin(); it != LeaderInfo.end(); ) {
-        if (it->first.NodeId() == msg->NodeId)
-            it = HandleFollowerConnectionProblem(it);
-        else
-            ++it;
-    }
+    // This will also call HandleFollowerConnectionProblem for all attached followers
+    InterconnectSessionDisconnected(ev->Sender);
 }
 
 void TTablet::HandleByLeader(TEvTablet::TEvFollowerListRefresh::TPtr &ev) {
@@ -733,7 +779,10 @@ void TTablet::HandleByLeader(TEvTablet::TEvFollowerAttach::TPtr &ev) {
             // Consider sending follower updates starting with the next commit
             Graph.MinFollowerUpdate = Graph.NextEntry;
         }
-        auto followerItPair = LeaderInfo.insert(decltype(LeaderInfo)::value_type(ev->Sender, TLeaderInfo(EFollowerSyncState::Pending)));
+        auto followerItPair = LeaderInfo.emplace(
+            std::piecewise_construct,
+            std::forward_as_tuple(ev->Sender),
+            std::forward_as_tuple(EFollowerSyncState::Pending));
         Y_ABORT_UNLESS(followerItPair.second);
 
         followerIt = followerItPair.first;
@@ -741,10 +790,18 @@ void TTablet::HandleByLeader(TEvTablet::TEvFollowerAttach::TPtr &ev) {
 
     TLeaderInfo &followerInfo = followerIt->second;
 
+    followerInfo.FollowerId = followerId;
+    followerInfo.InterconnectSession = ev->InterconnectSession;
     followerInfo.FollowerAttempt = record.GetFollowerAttempt();
     followerInfo.StreamCounter = 0;
     followerInfo.SyncAttempt = 0;
     followerInfo.SyncCookieHolder.Destroy();
+    followerInfo.LastCookie = ++LastInterconnectSubscribeCookie;
+
+    if (followerInfo.InterconnectSession) {
+        auto& session = SubscribeInterconnectSession(followerInfo.InterconnectSession);
+        session.Followers.PushBack(&followerInfo);
+    }
 
     if (UserTablet)
         Send(UserTablet, new TEvTablet::TEvNewFollowerAttached(LeaderInfo.size()));
@@ -871,7 +928,10 @@ void TTablet::HandleStateStorageInfoUpgrade(TEvStateStorage::TEvInfo::TPtr &ev) 
                     // Consider sending follower updates starting with the next commit
                     Graph.MinFollowerUpdate = Graph.NextEntry;
                 }
-                auto itPair = LeaderInfo.insert(decltype(LeaderInfo)::value_type(xpair.first, TLeaderInfo(EFollowerSyncState::NeedSync)));
+                auto itPair = LeaderInfo.emplace(
+                    std::piecewise_construct,
+                    std::forward_as_tuple(xpair.first),
+                    std::forward_as_tuple(EFollowerSyncState::NeedSync));
                 // some followers could be already present by active TEvFollowerAttach
                 if (itPair.second)
                     TrySyncToFollower(itPair.first);
@@ -1009,6 +1069,7 @@ void TTablet::HandleByLeader(TEvTablet::TEvTabletActive::TPtr &ev) {
             <<  " started in " << (ActivateTime-BoostrapTime).MilliSeconds() << "msec", "TSYS24");
 
     PipeConnectAcceptor->Activate(SelfId(), UserTablet, true, StateStorageInfo.KnownGeneration, TabletVersionInfo);
+    SendTabletStateUpdates(NKikimrTabletBase::TEvTabletStateUpdate::StateActive);
 }
 
 void TTablet::HandleByFollower(TEvTablet::TEvTabletActive::TPtr &ev) {
@@ -1020,6 +1081,7 @@ void TTablet::HandleByFollower(TEvTablet::TEvTabletActive::TPtr &ev) {
 
     Send(FollowerStStGuardian, new TEvTablet::TEvFollowerUpdateState(false, SelfId(), UserTablet));
     ReportTabletStateChange(TTabletStateInfo::Active);
+    SendTabletStateUpdates(NKikimrTabletBase::TEvTabletStateUpdate::StateActive);
 }
 
 TTablet::TLogEntry* TTablet::MakeLogEntry(TEvTablet::TCommitInfo &commitInfo, NKikimrTabletBase::TTabletLogEntry *commitEv) {
@@ -1451,7 +1513,7 @@ void TTablet::SendFollowerAuxUpdate(TLeaderInfo& info, const TActorId& follower,
     auto notify = MakeHolder<TEvTablet::TEvFollowerAuxUpdate>(tabletId, info.FollowerAttempt, info.StreamCounter);
     notify->Record.SetAuxPayload(auxUpdate);
 
-    Send(follower, notify.Release(), 0, IEventHandle::FlagTrackDelivery);
+    SendViaSession(info.InterconnectSession, follower, notify.Release(), IEventHandle::FlagTrackDelivery, info.LastCookie);
     ++info.StreamCounter;
 }
 
@@ -1550,8 +1612,7 @@ void TTablet::ProgressFollowerQueue() {
                     followerInfo.SyncState = EFollowerSyncState::Active;
                 }
 
-                const ui32 subscFlag = (followerInfo.StreamCounter == 0) ? IEventHandle::FlagSubscribeOnSession : 0;
-                Send(xpair.first, notify.Release(), IEventHandle::FlagTrackDelivery | subscFlag);
+                SendViaSession(followerInfo.InterconnectSession, xpair.first, notify.Release(), IEventHandle::FlagTrackDelivery, followerInfo.LastCookie);
 
                 ++xpair.second.StreamCounter;
             }
@@ -1796,6 +1857,9 @@ bool TTablet::StopTablet(
                 Send(FollowerStStGuardian, new TEvents::TEvPoisonPill());
                 FollowerStStGuardian = { };
             }
+
+            ReportTabletStateChange(TTabletStateInfo::Stopping);
+            SendTabletStateUpdates(NKikimrTabletBase::TEvTabletStateUpdate::StateStopping);
         }
 
         if (!DelayedCancelTablet) {
@@ -1885,12 +1949,8 @@ void TTablet::CancelTablet(TEvTablet::TEvTabletDead::EReason reason, const TStri
     if (RebuildGraphRequest)
         Send(RebuildGraphRequest, new TEvents::TEvPoisonPill());
 
-    TSet<ui32> nodesToUnsubsribe;
     for (auto &xpair : LeaderInfo) {
         Send(xpair.first, new TEvTablet::TEvFollowerDisconnect(TabletID(), xpair.second.FollowerAttempt));
-        const ui32 followerNode = xpair.first.NodeId();
-        if (followerNode && followerNode != SelfId().NodeId())
-            nodesToUnsubsribe.emplace(followerNode);
     }
     LeaderInfo.clear();
 
@@ -1901,14 +1961,18 @@ void TTablet::CancelTablet(TEvTablet::TEvTabletDead::EReason reason, const TStri
         Send(StateStorageInfo.ProxyID, new TEvStateStorage::TEvCleanup(TabletID(), SelfId()));
 
     ReportTabletStateChange(TTabletStateInfo::Dead);
+    SendTabletStateUpdates(NKikimrTabletBase::TEvTabletStateUpdate::StateDead);
+    TabletStateSubscribers.clear();
 
-    const ui32 leaderNode = FollowerInfo.KnownLeaderID.NodeId();
-    if (leaderNode && leaderNode != SelfId().NodeId())
-        nodesToUnsubsribe.emplace(leaderNode);
-
-    for (ui32 x : nodesToUnsubsribe) {
-        Send(TActivationContext::InterconnectProxy(x), new TEvents::TEvUnsubscribe());
+    for (auto& pr : InterconnectSessions) {
+        Send(pr.first, new TEvents::TEvUnsubscribe());
     }
+    InterconnectSessions.clear();
+
+    for (auto& pr : InterconnectPending) {
+        Send(TActivationContext::InterconnectProxy(pr.first), new TEvents::TEvUnsubscribe());
+    }
+    InterconnectPending.clear();
 
     PassAway();
 }
@@ -1917,6 +1981,129 @@ void TTablet::Handle(TEvTablet::TEvUpdateConfig::TPtr &ev) {
     ResourceProfiles = ev->Get()->ResourceProfiles;
     if (UserTablet)
         TActivationContext::Send(ev->Forward(UserTablet));
+}
+
+void TTablet::Handle(TEvTablet::TEvTabletStateSubscribe::TPtr& ev) {
+    auto* msg = ev->Get();
+
+    TTabletStateSubscriber& subscriber = TabletStateSubscribers[ev->Sender];
+    if (subscriber.ActorId) {
+        if (msg->Record.GetSeqNo() < subscriber.SeqNo) {
+            // ignore outdated requests
+            return;
+        }
+    } else {
+        subscriber.ActorId = ev->Sender;
+    }
+    subscriber.Cookie = ev->Cookie;
+    subscriber.SeqNo = msg->Record.GetSeqNo();
+    subscriber.InterconnectSession = ev->InterconnectSession;
+
+    if (subscriber.InterconnectSession) {
+        auto& session = SubscribeInterconnectSession(subscriber.InterconnectSession);
+        session.TabletStateSubscribers.PushBack(&subscriber);
+    }
+
+    NKikimrTabletBase::TEvTabletStateUpdate::EState state;
+    if (PipeConnectAcceptor->IsStopped()) {
+        state = NKikimrTabletBase::TEvTabletStateUpdate::StateStopping;
+    } else if (PipeConnectAcceptor->IsActive()) {
+        state = NKikimrTabletBase::TEvTabletStateUpdate::StateActive;
+    } else {
+        state = NKikimrTabletBase::TEvTabletStateUpdate::StateBooting;
+    }
+
+    SendTabletStateUpdate(subscriber, state);
+}
+
+void TTablet::Handle(TEvTablet::TEvTabletStateUnsubscribe::TPtr& ev) {
+    auto* msg = ev->Get();
+
+    auto it = TabletStateSubscribers.find(ev->Sender);
+    if (it != TabletStateSubscribers.end() && it->second.SeqNo == msg->Record.GetSeqNo()) {
+        TabletStateSubscribers.erase(it);
+    }
+}
+
+void TTablet::SendTabletStateUpdate(const TTabletStateSubscriber& subscriber, NKikimrTabletBase::TEvTabletStateUpdate::EState state) {
+    auto replyMsg = MakeHolder<TEvTablet::TEvTabletStateUpdate>(TabletID(), subscriber.SeqNo, state, UserTablet);
+
+    SendViaSession(
+        subscriber.InterconnectSession,
+        subscriber.ActorId,
+        replyMsg.Release(),
+        IEventHandle::FlagTrackDelivery,
+        subscriber.Cookie);
+}
+
+void TTablet::SendTabletStateUpdates(NKikimrTabletBase::TEvTabletStateUpdate::EState state) {
+    for (const auto& pr : TabletStateSubscribers) {
+        SendTabletStateUpdate(pr.second, state);
+    }
+}
+
+TTablet::TInterconnectSession& TTablet::SubscribeInterconnectSession(const TActorId& sessionId) {
+    auto& session = InterconnectSessions[sessionId];
+    if (!session.ActorId) {
+        session.ActorId = sessionId;
+        Send(sessionId, new TEvents::TEvSubscribe(), IEventHandle::FlagTrackDelivery);
+    }
+    return session;
+}
+
+void TTablet::InterconnectSessionConnected(const TActorId& sessionId, ui32 nodeId, ui64 cookie) {
+    auto& session = InterconnectSessions[sessionId];
+    session.ActorId = sessionId;
+    session.Connected = true;
+
+    auto it = InterconnectPending.find(nodeId);
+    if (it != InterconnectPending.end()) {
+        while (!it->second.Followers.Empty()) {
+            TLeaderInfo* follower = it->second.Followers.Front();
+            if (cookie < follower->LastCookie) {
+                break;
+            }
+            // We have matched FlagSubscribeOnSession to the specific session
+            session.Followers.PushBack(follower);
+        }
+
+        if (it->second.LastCookie == cookie) {
+            // This was the last known FlagSubscribeOnSession request
+            InterconnectPending.erase(it);
+        }
+    }
+}
+
+void TTablet::InterconnectSessionDisconnected(const TActorId& sessionId) {
+    if (auto it = InterconnectSessions.find(sessionId); it != InterconnectSessions.end()) {
+        while (!it->second.Followers.Empty()) {
+            TLeaderInfo* follower = it->second.Followers.PopFront();
+            HandleFollowerDisconnect(follower);
+        }
+        while (!it->second.TabletStateSubscribers.Empty()) {
+            TTabletStateSubscriber* subscriber = it->second.TabletStateSubscribers.PopFront();
+            TActorId actorId = subscriber->ActorId;
+            TabletStateSubscribers.erase(actorId);
+        }
+        InterconnectSessions.erase(it);
+    }
+}
+
+void TTablet::TabletStateUndelivered(const TActorId& actorId, ui64 cookie) {
+    auto it = TabletStateSubscribers.find(actorId);
+    if (it != TabletStateSubscribers.end() && it->second.Cookie == cookie) {
+        TabletStateSubscribers.erase(it);
+    }
+}
+
+void TTablet::SendViaSession(const TActorId& sessionId, const TActorId& target, IEventBase* event, ui32 flags, ui64 cookie) {
+    THolder<IEventHandle> ev = MakeHolder<IEventHandle>(target, SelfId(), event, flags, cookie);
+
+    if (sessionId) {
+        ev->Rewrite(TEvInterconnect::EvForward, sessionId);
+    }
+
+    TActivationContext::Send(ev.Release());
 }
 
 void TTablet::LockedInitializationPath() {
@@ -2032,6 +2219,7 @@ void TTablet::Bootstrap() {
     }
     // todo: handle "proxy unknown" case (normal timeouts are handled by proxy)
     PipeConnectAcceptor->Detach(SelfId());
+    SendTabletStateUpdates(NKikimrTabletBase::TEvTabletStateUpdate::StateBooting);
     Become(&TThis::StateResolveStateStorage);
     ReportTabletStateChange(TTabletStateInfo::ResolveStateStorage);
 }

--- a/ydb/core/tablet/tablet_sys.cpp
+++ b/ydb/core/tablet/tablet_sys.cpp
@@ -1858,8 +1858,8 @@ bool TTablet::StopTablet(
                 FollowerStStGuardian = { };
             }
 
-            ReportTabletStateChange(TTabletStateInfo::Stopping);
-            SendTabletStateUpdates(NKikimrTabletBase::TEvTabletStateUpdate::StateStopping);
+            ReportTabletStateChange(TTabletStateInfo::Terminating);
+            SendTabletStateUpdates(NKikimrTabletBase::TEvTabletStateUpdate::StateTerminating);
         }
 
         if (!DelayedCancelTablet) {
@@ -2006,7 +2006,7 @@ void TTablet::Handle(TEvTablet::TEvTabletStateSubscribe::TPtr& ev) {
 
     NKikimrTabletBase::TEvTabletStateUpdate::EState state;
     if (PipeConnectAcceptor->IsStopped()) {
-        state = NKikimrTabletBase::TEvTabletStateUpdate::StateStopping;
+        state = NKikimrTabletBase::TEvTabletStateUpdate::StateTerminating;
     } else if (PipeConnectAcceptor->IsActive()) {
         state = NKikimrTabletBase::TEvTabletStateUpdate::StateActive;
     } else {

--- a/ydb/core/tablet/tablet_sys.h
+++ b/ydb/core/tablet/tablet_sys.h
@@ -369,7 +369,7 @@ class TTablet : public TActor<TTablet> {
 
     // next funcs return next correct iterator
     TMap<TActorId, TLeaderInfo>::iterator EraseFollowerInfo(TMap<TActorId, TLeaderInfo>::iterator followerIt);
-    TMap<TActorId, TLeaderInfo>::iterator HandleFollowerConnectionProblem(TMap<TActorId, TLeaderInfo>::iterator followerIt);
+    TMap<TActorId, TLeaderInfo>::iterator HandleFollowerConnectionProblem(TMap<TActorId, TLeaderInfo>::iterator followerIt, bool permanent = false);
     void HandleFollowerDisconnect(TLeaderInfo* follower);
 
     void TrySyncToFollower(TMap<TActorId, TLeaderInfo>::iterator followerIt);
@@ -418,6 +418,7 @@ class TTablet : public TActor<TTablet> {
     TInterconnectSession& SubscribeInterconnectSession(const TActorId& sessionId);
     void InterconnectSessionConnected(const TActorId& sessionId, ui32 nodeId, ui64 cookie);
     void InterconnectSessionDisconnected(const TActorId& sessionId);
+    void InterconnectSessionDisconnected(const TActorId& sessionId, ui32 nodeId, ui64 cookie);
     void TabletStateUndelivered(const TActorId& actorId, ui64 cookie);
     void SendViaSession(const TActorId& sessionId, const TActorId& target, IEventBase* event, ui32 flags = 0, ui64 cookie = 0);
 

--- a/ydb/core/tablet/tablet_sys.h
+++ b/ydb/core/tablet/tablet_sys.h
@@ -169,6 +169,7 @@ class TTablet : public TActor<TTablet> {
     } FollowerInfo;
 
     void NextFollowerAttempt();
+    void SendFollowerAttach(const TActorId& leader);
 
     enum class EFollowerSyncState {
         NeedSync, // follower known but not connected, blocks gc

--- a/ydb/core/tablet/ut/ya.make
+++ b/ydb/core/tablet/ut/ya.make
@@ -26,6 +26,7 @@ SRCS(
     tablet_pipecache_ut.cpp
     tablet_req_blockbs_ut.cpp
     tablet_resolver_ut.cpp
+    tablet_state_ut.cpp
 )
 
 END()

--- a/ydb/library/actors/testlib/test_runtime.h
+++ b/ydb/library/actors/testlib/test_runtime.h
@@ -564,7 +564,7 @@ namespace NActors {
             try {
                 return GrabEdgeEvent<TEvent>(handle, simTimeout);
             } catch (...) {
-                ythrow TWithBackTrace<yexception>() << "Exception occured while waiting for " << TypeName<TEvent>() << ": " << CurrentExceptionMessage();
+                ythrow TWithBackTrace<yexception>() << "Exception occured while waiting for " << TypeName<TEvent>() << ": " << FormatCurrentException();
             }
         }
 
@@ -573,7 +573,7 @@ namespace NActors {
             try {
                 return GrabEdgeEvent<TEvent>(edgeFilter, simTimeout);
             } catch (...) {
-                ythrow TWithBackTrace<yexception>() << "Exception occured while waiting for " << TypeName<TEvent>() << ": " << CurrentExceptionMessage();
+                ythrow TWithBackTrace<yexception>() << "Exception occured while waiting for " << TypeName<TEvent>() << ": " << FormatCurrentException();
             }
         }
 
@@ -582,7 +582,7 @@ namespace NActors {
             try {
                 return GrabEdgeEvent<TEvent>(edgeActor, simTimeout);
             } catch (...) {
-                ythrow TWithBackTrace<yexception>() << "Exception occured while waiting for " << TypeName<TEvent>() << ": " << CurrentExceptionMessage();
+                ythrow TWithBackTrace<yexception>() << "Exception occured while waiting for " << TypeName<TEvent>() << ": " << FormatCurrentException();
             }
         }
 
@@ -609,7 +609,7 @@ namespace NActors {
             try {
                 return GrabEdgeEvents<TEvents...>(handle, simTimeout);
             } catch (...) {
-                ythrow TWithBackTrace<yexception>() << "Exception occured while waiting for " << TypeNames<TEvents...>() << ": " << CurrentExceptionMessage();
+                ythrow TWithBackTrace<yexception>() << "Exception occured while waiting for " << TypeNames<TEvents...>() << ": " << FormatCurrentException();
             }
         }
 


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

...

### Changelog category <!-- remove all except one -->

* Not for changelog (changelog entry is not required)

### Description for reviewers <!-- (optional) description for those who read this PR -->

Add tablet state subscriptions which would be used by tablet resolver to invalidate cache entries on tablet restarts.

Support for #21053