### PR TITLE
Use lower tpch scales in compatibility tests

### DIFF
--- a/ydb/tests/compatibility/test_compatibility.py
+++ b/ydb/tests/compatibility/test_compatibility.py
@@ -123,7 +123,7 @@ class TestCompatibility(RestartToAnotherVersionFixture):
             "tpch",
             "import",
             "generator",
-            "--scale=1",
+            "--scale=0.1",
         ]
         run_command = [
             yatest.common.binary_path(os.getenv("YDB_CLI_BINARY")),
@@ -136,9 +136,7 @@ class TestCompatibility(RestartToAnotherVersionFixture):
             "-p",
             "tpch",
             "run",
-            "--scale=1",
-            "--exclude",
-            "17",  # not working for row tables
+            "--scale=0.1",
             "--check-canonical",
             "--retries",
             "5",  # in row tables we have to retry query by design

--- a/ydb/tests/compatibility/test_stress.py
+++ b/ydb/tests/compatibility/test_stress.py
@@ -211,7 +211,7 @@ class TestStress(MixedClusterFixture):
             "tpch",
             "import",
             "generator",
-            "--scale=1",
+            "--scale=0.2",
         ]
         run_command = [
             yatest.common.binary_path(os.getenv("YDB_CLI_BINARY")),
@@ -224,9 +224,7 @@ class TestStress(MixedClusterFixture):
             "-p",
             "tpch",
             "run",
-            "--scale=1",
-            "--exclude",
-            "17",  # not working for row tables
+            "--scale=0.2",
             "--check-canonical",
             "--retries",
             "5",  # in row tables we have to retry query by design


### PR DESCRIPTION
Use lower tpch scales in compatibility tests, because:
- 1gb scale is too slow 
- row tables are not working properly in 1gb scale