### PR TITLE
Explicit timeout in driver.wait

### DIFF
--- a/ydb/tests/example/test_example.py
+++ b/ydb/tests/example/test_example.py
@@ -28,7 +28,7 @@ class TestExample:
                 endpoint=self.cluster.nodes[1].endpoint,
             )
         )
-        self.driver.wait()
+        self.driver.wait(timeout=60)
 
         yield
 

--- a/ydb/tests/library/compatibility/fixtures.py
+++ b/ydb/tests/library/compatibility/fixtures.py
@@ -102,7 +102,7 @@ class RestartToAnotherVersionFixture:
                 endpoint=self.endpoint
             )
         )
-        self.driver.wait()
+        self.driver.wait(timeout=60)
         yield
         self.cluster.stop()
 
@@ -117,7 +117,7 @@ class RestartToAnotherVersionFixture:
                 endpoint=self.endpoint
             )
         )
-        self.driver.wait()
+        self.driver.wait(timeout=60)
         # TODO: remove sleep
         # without sleep there are errors like
         # ydb.issues.Unavailable: message: "Failed to resolve tablet: 72075186224037909 after several retries." severity: 1 (server_code: 400050)
@@ -161,7 +161,7 @@ class MixedClusterFixture:
                 endpoint=self.endpoint
             )
         )
-        self.driver.wait()
+        self.driver.wait(timeout=60)
         yield
         self.cluster.stop()
 
@@ -192,7 +192,7 @@ class RollingUpgradeAndDowngradeFixture:
                     endpoint=self.endpoints[0]
                 )
             )
-            self.driver.wait()
+            self.driver.wait(timeout=60)
 
         query = """
             CREATE TABLE `test_readiness` (
@@ -247,7 +247,7 @@ class RollingUpgradeAndDowngradeFixture:
                 database='/Root'
             )
         )
-        self.driver.wait()
+        self.driver.wait(timeout=60)
         yield
         self.cluster.stop()
 

--- a/ydb/tests/library/stress/fixtures.py
+++ b/ydb/tests/library/stress/fixtures.py
@@ -30,6 +30,6 @@ class StressFixture:
                 endpoint=self.endpoint
             )
         )
-        self.driver.wait()
+        self.driver.wait(timeout=60)
         yield
         self.cluster.stop()


### PR DESCRIPTION
Отсутствие таймаута приводило к тому, что если ydbd не может подняться (например верифайка/ошибка в конфиге), то тест тупо зависал 