### PR TITLE
Set default storage type as `column` (was `row`) and default datetime mode as `datetime32` (was `datetime64`) in `ydb workload * init` commands.

### DIFF
--- a/ydb/apps/ydb/CHANGELOG.md
+++ b/ydb/apps/ydb/CHANGELOG.md
@@ -1,4 +1,4 @@
-* Set default storage type as `column` (was `raw`) and default datetime mode as `datetime32` (was `datetime64`) in `ydb workload * init` commands.
+* Set default storage type as `column` (was `row`) and default datetime mode as `datetime32` (was `datetime64`) in `ydb workload * init` commands.
 * Added ability of `ydb workload tpch` and `ydb workload tpcds` commands to use fraction `--scale` option.
 * Added `ydb workload tpcc check` subcommand, which checks TPC-C data consistency.
 

--- a/ydb/apps/ydb/CHANGELOG.md
+++ b/ydb/apps/ydb/CHANGELOG.md
@@ -1,3 +1,4 @@
+* Set default storage type as `column` (was `raw`) and default datetime mode as `datetime32` (was `datetime64`) in `ydb workload * init` commands.
 * Added ability of `ydb workload tpch` and `ydb workload tpcds` commands to use fraction `--scale` option.
 * Added `ydb workload tpcc check` subcommand, which checks TPC-C data consistency.
 

--- a/ydb/library/workload/benchmark_base/workload.h
+++ b/ydb/library/workload/benchmark_base/workload.h
@@ -22,7 +22,7 @@ public:
         YQL /* "yql" */,
         PG /* "pg"*/
     };
-    enum class EDatetimeMode {
+    enum class EDatetimeTypes {
         DateTime32 /* "dt32" */,
         DateTime64 /* "dt64" */
     };
@@ -35,7 +35,7 @@ public:
     YDB_READONLY_DEF(TString, S3Endpoint);
     YDB_READONLY_DEF(TString, S3Prefix);
     YDB_READONLY(TString, StringType, "Utf8");
-    YDB_READONLY(EDatetimeMode, DatetimeMode, EDatetimeMode::DateTime32);
+    YDB_READONLY(EDatetimeTypes, DatetimeTypes, EDatetimeTypes::DateTime32);
     YDB_READONLY(ui64, PartitionSizeMb, 2000);
     YDB_READONLY_PROTECT(bool, CheckCanonical, false);
 };

--- a/ydb/library/workload/benchmark_base/workload.h
+++ b/ydb/library/workload/benchmark_base/workload.h
@@ -16,24 +16,26 @@ public:
     enum class EStoreType {
         Row     /* "row"    */,
         Column  /* "column" */,
-        ExternalS3      /* "external-s3"     */
+        ExternalS3      /* "external-s3" */
     };
     enum class EQuerySyntax {
         YQL /* "yql" */,
         PG /* "pg"*/
+    };
+    enum class EDatetimeMode {
+        DateTime32 /* "dt32" */,
+        DateTime64 /* "dt64" */
     };
     void ConfigureOpts(NLastGetopt::TOpts& opts, const ECommandType commandType, int workloadType) override;
     void Validate(const ECommandType commandType, int workloadType) override;
     TString GetFullTableName(const char* table) const;
     static TString GetTablePathQuote(EQuerySyntax syntax);
     YDB_ACCESSOR_DEF(TString, Path);
-    YDB_READONLY(EStoreType, StoreType, EStoreType::Row);
+    YDB_READONLY(EStoreType, StoreType, EStoreType::Column);
     YDB_READONLY_DEF(TString, S3Endpoint);
     YDB_READONLY_DEF(TString, S3Prefix);
     YDB_READONLY(TString, StringType, "Utf8");
-    YDB_READONLY(TString, DateType, "Date32");
-    YDB_READONLY(TString, DatetimeType, "Datetime64");
-    YDB_READONLY(TString, TimestampType, "Timestamp64");
+    YDB_READONLY(EDatetimeMode, DatetimeMode, EDatetimeMode::DateTime32);
     YDB_READONLY(ui64, PartitionSizeMb, 2000);
     YDB_READONLY_PROTECT(bool, CheckCanonical, false);
 };

--- a/ydb/tests/compatibility/test_compatibility.py
+++ b/ydb/tests/compatibility/test_compatibility.py
@@ -89,9 +89,9 @@ class TestCompatibility(RestartToAnotherVersionFixture):
         assert self.execute_scan_query('select count(*) as row_count from `sample_table`')[0]['row_count'] == 500, 'Expected 500 rows: update 100-200 rows and added 300 rows'
 
     @pytest.mark.parametrize("store_type, date_args", [
-        pytest.param("row",    ["--datetime-mode=dt32"], id="row"),
-        pytest.param("column", ["--datetime-mode=dt32"], id="column"),
-        pytest.param("column", ["--datetime-mode=dt64"], id="column-date64")
+        pytest.param("row",    ["--datetime-types=dt32"], id="row"),
+        pytest.param("column", ["--datetime-types=dt32"], id="column"),
+        pytest.param("column", ["--datetime-types=dt64"], id="column-date64")
     ])
     def test_tpch1(self, store_type, date_args):
         result_json_path = os.path.join(yatest.common.test_output_path(), "result.json")

--- a/ydb/tests/compatibility/test_compatibility.py
+++ b/ydb/tests/compatibility/test_compatibility.py
@@ -89,9 +89,9 @@ class TestCompatibility(RestartToAnotherVersionFixture):
         assert self.execute_scan_query('select count(*) as row_count from `sample_table`')[0]['row_count'] == 500, 'Expected 500 rows: update 100-200 rows and added 300 rows'
 
     @pytest.mark.parametrize("store_type, date_args", [
-        pytest.param("row",    ["--datetime"], id="row"),
-        pytest.param("column", ["--datetime"], id="column"),
-        pytest.param("column", []            , id="column-date64")
+        pytest.param("row",    ["--datetime-mode=dt32"], id="row"),
+        pytest.param("column", ["--datetime-mode=dt32"], id="column"),
+        pytest.param("column", ["--datetime-mode=dt64"], id="column-date64")
     ])
     def test_tpch1(self, store_type, date_args):
         result_json_path = os.path.join(yatest.common.test_output_path(), "result.json")

--- a/ydb/tests/compatibility/test_stress.py
+++ b/ydb/tests/compatibility/test_stress.py
@@ -180,9 +180,9 @@ class TestStress(MixedClusterFixture):
         yatest.common.execute(run_command, wait=True, stdout=self.output_f, stderr=self.output_f)
 
     @pytest.mark.parametrize("store_type, date_args", [
-        pytest.param("row",    ["--datetime"], id="row"),
-        pytest.param("column", ["--datetime"], id="column"),
-        pytest.param("column", []            , id="column-date64")
+        pytest.param("row",    ["--datetime-mode=dt32"], id="row"),
+        pytest.param("column", ["--datetime-mode=dt32"], id="column"),
+        pytest.param("column", ["--datetime-mode=dt64"], id="column-date64")
     ])
     def test_tpch1(self, store_type, date_args):
         init_command = [
@@ -236,9 +236,9 @@ class TestStress(MixedClusterFixture):
 
     @pytest.mark.skip(reason="Not stabilized yet")
     @pytest.mark.parametrize("store_type, date_args", [
-        pytest.param("row",    ["--datetime"], id="row"),
-        pytest.param("column", ["--datetime"], id="column"),
-        pytest.param("column", []            , id="column-date64")
+        pytest.param("row",    ["--datetime-mode=dt32"], id="row"),
+        pytest.param("column", ["--datetime-mode=dt32"], id="column"),
+        pytest.param("column", ["--datetime-mode=dt64"], id="column-date64")
     ])
     def test_tpcds1(self, store_type, date_args):
         init_command = [

--- a/ydb/tests/compatibility/test_stress.py
+++ b/ydb/tests/compatibility/test_stress.py
@@ -180,9 +180,9 @@ class TestStress(MixedClusterFixture):
         yatest.common.execute(run_command, wait=True, stdout=self.output_f, stderr=self.output_f)
 
     @pytest.mark.parametrize("store_type, date_args", [
-        pytest.param("row",    ["--datetime-mode=dt32"], id="row"),
-        pytest.param("column", ["--datetime-mode=dt32"], id="column"),
-        pytest.param("column", ["--datetime-mode=dt64"], id="column-date64")
+        pytest.param("row",    ["--datetime-types=dt32"], id="row"),
+        pytest.param("column", ["--datetime-types=dt32"], id="column"),
+        pytest.param("column", ["--datetime-types=dt64"], id="column-date64")
     ])
     def test_tpch1(self, store_type, date_args):
         init_command = [
@@ -236,9 +236,9 @@ class TestStress(MixedClusterFixture):
 
     @pytest.mark.skip(reason="Not stabilized yet")
     @pytest.mark.parametrize("store_type, date_args", [
-        pytest.param("row",    ["--datetime-mode=dt32"], id="row"),
-        pytest.param("column", ["--datetime-mode=dt32"], id="column"),
-        pytest.param("column", ["--datetime-mode=dt64"], id="column-date64")
+        pytest.param("row",    ["--datetime-types=dt32"], id="row"),
+        pytest.param("column", ["--datetime-types=dt32"], id="column"),
+        pytest.param("column", ["--datetime-types=dt64"], id="column-date64")
     ])
     def test_tpcds1(self, store_type, date_args):
         init_command = [

--- a/ydb/tests/functional/benchmarks_init/test_init.py
+++ b/ydb/tests/functional/benchmarks_init/test_init.py
@@ -30,7 +30,7 @@ class InitBase(object):
                 '--endpoint', 'grpc://localhost',
                 '--database', '/Root/db',
                 'workload', cls.workload, '-p', f'/Root/db/{cls.workload}/s{scale}',
-                'init', '--dry-run'
+                'init', '--dry-run', '--datetime-mode=dt64'
             ]
             + [str(arg) for arg in args]
         ).stdout.decode('utf8')

--- a/ydb/tests/functional/benchmarks_init/test_init.py
+++ b/ydb/tests/functional/benchmarks_init/test_init.py
@@ -30,7 +30,7 @@ class InitBase(object):
                 '--endpoint', 'grpc://localhost',
                 '--database', '/Root/db',
                 'workload', cls.workload, '-p', f'/Root/db/{cls.workload}/s{scale}',
-                'init', '--dry-run', '--datetime-mode=dt64'
+                'init', '--dry-run', '--datetime-types=dt64'
             ]
             + [str(arg) for arg in args]
         ).stdout.decode('utf8')

--- a/ydb/tests/functional/clickbench/test.py
+++ b/ydb/tests/functional/clickbench/test.py
@@ -129,7 +129,7 @@ def save_canonical_data(data, fname):
 @pytest.mark.parametrize("store", ["row", "column"])
 def test_run_benchmark(store):
     path = "clickbench/benchmark/{}/hits".format(store)
-    ret = run_cli(["workload", "clickbench", "--path", path, "init", "--store", store, "--datetime"])
+    ret = run_cli(["workload", "clickbench", "--path", path, "init", "--store", store, "--datetime-mode=dt32"])
     assert_that(ret.exit_code, is_(0))
 
     ret = run_cli(
@@ -149,7 +149,7 @@ def test_run_benchmark(store):
 @pytest.mark.parametrize("store", ["row", "column"])
 def test_run_determentistic(store):
     path = "clickbench/determentistic/{}/hits".format(store)
-    ret = run_cli(["workload", "clickbench", "--path", path, "init", "--store", store, "--datetime"])
+    ret = run_cli(["workload", "clickbench", "--path", path, "init", "--store", store, "--datetime-mode=dt32"])
     assert_that(ret.exit_code, is_(0))
     ret = run_cli(
         [
@@ -179,7 +179,7 @@ def test_run_determentistic(store):
 @pytest.mark.parametrize("store", ["row", "column"])
 def test_plans(store):
     ret = run_cli(
-        ["workload", "clickbench", "--path", "clickbench/plans/{}/hits".format(store), "init", "--store", store, "--datetime"]
+        ["workload", "clickbench", "--path", "clickbench/plans/{}/hits".format(store), "init", "--store", store, "--datetime-mode=dt32"]
     )
     assert_that(ret.exit_code, is_(0))
 

--- a/ydb/tests/functional/clickbench/test.py
+++ b/ydb/tests/functional/clickbench/test.py
@@ -129,7 +129,7 @@ def save_canonical_data(data, fname):
 @pytest.mark.parametrize("store", ["row", "column"])
 def test_run_benchmark(store):
     path = "clickbench/benchmark/{}/hits".format(store)
-    ret = run_cli(["workload", "clickbench", "--path", path, "init", "--store", store, "--datetime-mode=dt32"])
+    ret = run_cli(["workload", "clickbench", "--path", path, "init", "--store", store, "--datetime-types=dt32"])
     assert_that(ret.exit_code, is_(0))
 
     ret = run_cli(
@@ -149,7 +149,7 @@ def test_run_benchmark(store):
 @pytest.mark.parametrize("store", ["row", "column"])
 def test_run_determentistic(store):
     path = "clickbench/determentistic/{}/hits".format(store)
-    ret = run_cli(["workload", "clickbench", "--path", path, "init", "--store", store, "--datetime-mode=dt32"])
+    ret = run_cli(["workload", "clickbench", "--path", path, "init", "--store", store, "--datetime-types=dt32"])
     assert_that(ret.exit_code, is_(0))
     ret = run_cli(
         [
@@ -179,7 +179,7 @@ def test_run_determentistic(store):
 @pytest.mark.parametrize("store", ["row", "column"])
 def test_plans(store):
     ret = run_cli(
-        ["workload", "clickbench", "--path", "clickbench/plans/{}/hits".format(store), "init", "--store", store, "--datetime-mode=dt32"]
+        ["workload", "clickbench", "--path", "clickbench/plans/{}/hits".format(store), "init", "--store", store, "--datetime-types=dt32"]
     )
     assert_that(ret.exit_code, is_(0))
 

--- a/ydb/tests/functional/tpc/large/test_tpcds.py
+++ b/ydb/tests/functional/tpc/large/test_tpcds.py
@@ -12,7 +12,7 @@ class TestTpcdsS1(tpcds.TestTpcds1, FunctionalTestBase):
     @classmethod
     def setup_class(cls) -> None:
         cls.setup_cluster(memory_controller_config=cls.memory_controller_config)
-        cls.run_cli(['workload', 'tpcds', '-p', f'olap_yatests/{cls._get_path()}', 'init', '--store=column', '--datetime-mode=dt64'])
+        cls.run_cli(['workload', 'tpcds', '-p', f'olap_yatests/{cls._get_path()}', 'init', '--store=column', '--datetime-types=dt64'])
         cls.run_cli(['workload', 'tpcds', '-p', f'olap_yatests/{cls._get_path()}', 'import', 'generator', f'--scale={cls.scale}'])
         super().setup_class()
 

--- a/ydb/tests/functional/tpc/large/test_tpcds.py
+++ b/ydb/tests/functional/tpc/large/test_tpcds.py
@@ -12,7 +12,7 @@ class TestTpcdsS1(tpcds.TestTpcds1, FunctionalTestBase):
     @classmethod
     def setup_class(cls) -> None:
         cls.setup_cluster(memory_controller_config=cls.memory_controller_config)
-        cls.run_cli(['workload', 'tpcds', '-p', f'olap_yatests/{cls._get_path()}', 'init', '--store=column'])
+        cls.run_cli(['workload', 'tpcds', '-p', f'olap_yatests/{cls._get_path()}', 'init', '--store=column', '--datetime-mode=dt64'])
         cls.run_cli(['workload', 'tpcds', '-p', f'olap_yatests/{cls._get_path()}', 'import', 'generator', f'--scale={cls.scale}'])
         super().setup_class()
 

--- a/ydb/tests/functional/tpc/large/test_tpch_spilling.py
+++ b/ydb/tests/functional/tpc/large/test_tpch_spilling.py
@@ -31,7 +31,7 @@ class TestTpchSpillingS10(tpch.TestTpch10, FunctionalTestBase):
     @classmethod
     def setup_class(cls) -> None:
         cls.setup_cluster(table_service_config=cls.table_service_config, memory_controller_config=cls.memory_controller_config)
-        cls.run_cli(['workload', 'tpch', '-p', 'olap_yatests/tpch/s10', 'init', '--store=column'])
+        cls.run_cli(['workload', 'tpch', '-p', 'olap_yatests/tpch/s10', 'init', '--store=column', '--datetime-mode=dt64'])
         cls.run_cli(['workload', 'tpch', '-p', 'olap_yatests/tpch/s10', 'import', 'generator', '--scale=10'])
 
         tpch.TestTpch10.setup_class()

--- a/ydb/tests/functional/tpc/large/test_tpch_spilling.py
+++ b/ydb/tests/functional/tpc/large/test_tpch_spilling.py
@@ -31,7 +31,7 @@ class TestTpchSpillingS10(tpch.TestTpch10, FunctionalTestBase):
     @classmethod
     def setup_class(cls) -> None:
         cls.setup_cluster(table_service_config=cls.table_service_config, memory_controller_config=cls.memory_controller_config)
-        cls.run_cli(['workload', 'tpch', '-p', 'olap_yatests/tpch/s10', 'init', '--store=column', '--datetime-mode=dt64'])
+        cls.run_cli(['workload', 'tpch', '-p', 'olap_yatests/tpch/s10', 'init', '--store=column', '--datetime-types=dt64'])
         cls.run_cli(['workload', 'tpch', '-p', 'olap_yatests/tpch/s10', 'import', 'generator', '--scale=10'])
 
         tpch.TestTpch10.setup_class()

--- a/ydb/tests/functional/tpc/medium/test_clickbench.py
+++ b/ydb/tests/functional/tpc/medium/test_clickbench.py
@@ -10,7 +10,7 @@ class TestClickbench(clickbench.TestClickbench, FunctionalTestBase):
     @classmethod
     def setup_class(cls) -> None:
         cls.setup_cluster()
-        cls.run_cli(['workload', 'clickbench', '-p', 'olap_yatests/clickbench/hits', 'init', '--store=column'])
+        cls.run_cli(['workload', 'clickbench', '-p', 'olap_yatests/clickbench/hits', 'init', '--store=column', '--datetime-mode=dt64'])
         cls.run_cli(['workload', 'clickbench', '-p', 'olap_yatests/clickbench/hits', 'import', 'files', '--input', yatest.common.source_path("ydb/tests/functional/clickbench/data/hits.csv")])
         super().setup_class()
 
@@ -22,7 +22,7 @@ class TestClickbenchParallel(clickbench.TestClickbenchParallel8, FunctionalTestB
     @classmethod
     def setup_class(cls) -> None:
         cls.setup_cluster()
-        cls.run_cli(['workload', 'clickbench', '-p', 'olap_yatests/clickbench/hits', 'init', '--store=column'])
+        cls.run_cli(['workload', 'clickbench', '-p', 'olap_yatests/clickbench/hits', 'init', '--store=column', '--datetime-mode=dt64'])
         cls.run_cli(['workload', 'clickbench', '-p', 'olap_yatests/clickbench/hits', 'import', 'files', '--input', yatest.common.source_path("ydb/tests/functional/clickbench/data/hits.csv")])
         super().setup_class()
 
@@ -34,6 +34,6 @@ class TestClickbenchPg(clickbench.TestClickbenchPg, FunctionalTestBase):
     @classmethod
     def setup_class(cls) -> None:
         cls.setup_cluster()
-        cls.run_cli(['workload', 'clickbench', '-p', 'olap_yatests/clickbench/hits', 'init', '--store=column'])
+        cls.run_cli(['workload', 'clickbench', '-p', 'olap_yatests/clickbench/hits', 'init', '--store=column', '--datetime-mode=dt64'])
         cls.run_cli(['workload', 'clickbench', '-p', 'olap_yatests/clickbench/hits', 'import', 'files', '--input', yatest.common.source_path("ydb/tests/functional/clickbench/data/hits.csv")])
         super().setup_class()

--- a/ydb/tests/functional/tpc/medium/test_clickbench.py
+++ b/ydb/tests/functional/tpc/medium/test_clickbench.py
@@ -10,7 +10,7 @@ class TestClickbench(clickbench.TestClickbench, FunctionalTestBase):
     @classmethod
     def setup_class(cls) -> None:
         cls.setup_cluster()
-        cls.run_cli(['workload', 'clickbench', '-p', 'olap_yatests/clickbench/hits', 'init', '--store=column', '--datetime-mode=dt64'])
+        cls.run_cli(['workload', 'clickbench', '-p', 'olap_yatests/clickbench/hits', 'init', '--store=column', '--datetime-types=dt64'])
         cls.run_cli(['workload', 'clickbench', '-p', 'olap_yatests/clickbench/hits', 'import', 'files', '--input', yatest.common.source_path("ydb/tests/functional/clickbench/data/hits.csv")])
         super().setup_class()
 
@@ -22,7 +22,7 @@ class TestClickbenchParallel(clickbench.TestClickbenchParallel8, FunctionalTestB
     @classmethod
     def setup_class(cls) -> None:
         cls.setup_cluster()
-        cls.run_cli(['workload', 'clickbench', '-p', 'olap_yatests/clickbench/hits', 'init', '--store=column', '--datetime-mode=dt64'])
+        cls.run_cli(['workload', 'clickbench', '-p', 'olap_yatests/clickbench/hits', 'init', '--store=column', '--datetime-types=dt64'])
         cls.run_cli(['workload', 'clickbench', '-p', 'olap_yatests/clickbench/hits', 'import', 'files', '--input', yatest.common.source_path("ydb/tests/functional/clickbench/data/hits.csv")])
         super().setup_class()
 
@@ -34,6 +34,6 @@ class TestClickbenchPg(clickbench.TestClickbenchPg, FunctionalTestBase):
     @classmethod
     def setup_class(cls) -> None:
         cls.setup_cluster()
-        cls.run_cli(['workload', 'clickbench', '-p', 'olap_yatests/clickbench/hits', 'init', '--store=column', '--datetime-mode=dt64'])
+        cls.run_cli(['workload', 'clickbench', '-p', 'olap_yatests/clickbench/hits', 'init', '--store=column', '--datetime-types=dt64'])
         cls.run_cli(['workload', 'clickbench', '-p', 'olap_yatests/clickbench/hits', 'import', 'files', '--input', yatest.common.source_path("ydb/tests/functional/clickbench/data/hits.csv")])
         super().setup_class()

--- a/ydb/tests/functional/tpc/medium/tpch/test_s1.py
+++ b/ydb/tests/functional/tpc/medium/tpch/test_s1.py
@@ -14,6 +14,6 @@ class TestTpchS1(tpch.TestTpch1, FunctionalTestBase):
     @classmethod
     def setup_class(cls) -> None:
         cls.setup_cluster()
-        cls.run_cli(['workload', 'tpch', '-p', f'olap_yatests/{cls._get_path()}', 'init', '--store=column'] + cls.addition_init_params())
+        cls.run_cli(['workload', 'tpch', '-p', f'olap_yatests/{cls._get_path()}', 'init', '--store=column', '--datetime-mode=dt64'] + cls.addition_init_params())
         cls.run_cli(['workload', 'tpch', '-p', f'olap_yatests/{cls._get_path()}', 'import', 'generator', f'--scale={cls.scale}'])
         super().setup_class()

--- a/ydb/tests/functional/tpc/medium/tpch/test_s1.py
+++ b/ydb/tests/functional/tpc/medium/tpch/test_s1.py
@@ -14,6 +14,6 @@ class TestTpchS1(tpch.TestTpch1, FunctionalTestBase):
     @classmethod
     def setup_class(cls) -> None:
         cls.setup_cluster()
-        cls.run_cli(['workload', 'tpch', '-p', f'olap_yatests/{cls._get_path()}', 'init', '--store=column', '--datetime-mode=dt64'] + cls.addition_init_params())
+        cls.run_cli(['workload', 'tpch', '-p', f'olap_yatests/{cls._get_path()}', 'init', '--store=column', '--datetime-types=dt64'] + cls.addition_init_params())
         cls.run_cli(['workload', 'tpch', '-p', f'olap_yatests/{cls._get_path()}', 'import', 'generator', f'--scale={cls.scale}'])
         super().setup_class()

--- a/ydb/tests/olap/s3_import/test_tpch_import.py
+++ b/ydb/tests/olap/s3_import/test_tpch_import.py
@@ -90,7 +90,7 @@ class TestS3TpchImport(S3ImportTestBase):
         """)
 
         logger.info("Creating tpc-h tables...")
-        self.ydb_client.run_cli_comand(["workload", "tpch", "init", "--datetime-mode=dt32", "--store", "column"])
+        self.ydb_client.run_cli_comand(["workload", "tpch", "init", "--datetime-types=dt32", "--store", "column"])
         self.ydb_client.run_cli_comand(["workload", "tpch", "import", "generator", "--scale", "1"])
 
         logger.info("Exporting into s3...")

--- a/ydb/tests/olap/s3_import/test_tpch_import.py
+++ b/ydb/tests/olap/s3_import/test_tpch_import.py
@@ -90,7 +90,7 @@ class TestS3TpchImport(S3ImportTestBase):
         """)
 
         logger.info("Creating tpc-h tables...")
-        self.ydb_client.run_cli_comand(["workload", "tpch", "init", "--datetime", "--store", "column"])
+        self.ydb_client.run_cli_comand(["workload", "tpch", "init", "--datetime-mode=dt32", "--store", "column"])
         self.ydb_client.run_cli_comand(["workload", "tpch", "import", "generator", "--scale", "1"])
 
         logger.info("Exporting into s3...")

--- a/ydb/tests/sql/lib/test_base.py
+++ b/ydb/tests/sql/lib/test_base.py
@@ -109,7 +109,7 @@ class TpchTestBaseH1(TestBase):
         cls.teardown_tpch()
 
     def setup_tpch(cls):
-        cls.run_cli(['workload', 'tpch', '-p', cls.tpch_default_path()+'/', 'init', '--store=column', '--datetime'])
+        cls.run_cli(['workload', 'tpch', '-p', cls.tpch_default_path()+'/', 'init', '--store=column', '--datetime-mode=dt32'])
         cls.run_cli(['workload', 'tpch', '-p', cls.tpch_default_path()+'/', 'import', 'generator', '--scale=1'])
 
     def teardown_tpch(cls):

--- a/ydb/tests/sql/lib/test_base.py
+++ b/ydb/tests/sql/lib/test_base.py
@@ -109,7 +109,7 @@ class TpchTestBaseH1(TestBase):
         cls.teardown_tpch()
 
     def setup_tpch(cls):
-        cls.run_cli(['workload', 'tpch', '-p', cls.tpch_default_path()+'/', 'init', '--store=column', '--datetime-mode=dt32'])
+        cls.run_cli(['workload', 'tpch', '-p', cls.tpch_default_path()+'/', 'init', '--store=column', '--datetime-types=dt32'])
         cls.run_cli(['workload', 'tpch', '-p', cls.tpch_default_path()+'/', 'import', 'generator', '--scale=1'])
 
     def teardown_tpch(cls):


### PR DESCRIPTION
https://github.com/ydb-platform/ydb/issues/21402
https://github.com/ydb-platform/ydb/issues/21403

### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

...

### Changelog category <!-- remove all except one -->

* Not for changelog (changelog entry is not required)

### Description for reviewers <!-- (optional) description for those who read this PR -->

...
