### PR TITLE
dq/runtime/output_channel: relax requirement on double watermark

### DIFF
--- a/ydb/library/yql/dq/runtime/dq_output_channel.cpp
+++ b/ydb/library/yql/dq/runtime/dq_output_channel.cpp
@@ -226,7 +226,7 @@ public:
     }
 
     void Push(NDqProto::TWatermark&& watermark) override {
-        YQL_ENSURE(!Watermark);
+        YQL_ENSURE(!Watermark || Watermark->GetTimestampUs() <= watermark.GetTimestampUs());
         Watermark.ConstructInPlace(std::move(watermark));
     }
 

--- a/ydb/library/yql/dq/runtime/dq_output_channel.cpp
+++ b/ydb/library/yql/dq/runtime/dq_output_channel.cpp
@@ -82,6 +82,7 @@ public:
 
     EDqFillLevel GetFillLevel() const override {
         if (Checkpoints) {
+            // prevent adding data into channel that already contains untransferred checkpoint (we can tolerate multiple checkpoints without any data between)
             return EDqFillLevel::HardLimit;
         }
         return FillLevel;
@@ -229,6 +230,7 @@ public:
     }
 
     void Push(NDqProto::TWatermark&& watermark) override {
+        // if there were already watermark in-fly replace it with latest one
         YQL_ENSURE(!Watermark || Watermark->GetTimestampUs() <= watermark.GetTimestampUs());
         Watermark.ConstructInPlace(std::move(watermark));
     }


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

...

### Changelog category <!-- remove all except one -->

* Not for changelog (changelog entry is not required)

### Description for reviewers <!-- (optional) description for those who read this PR -->

Fixes YQ-4351. While two cases are similar, they are handled a bit differently.
~~In case of checkpoint, we cannot lose checkpoints, and we cannot reorder checkpoints and data. So, if channel contains any untransferred checkpoints, allow adding more checkpoints, but with no data between.~~ Upd: as fix with checkpoints basically workaround for lack of support of checkpointing ResultWriter, it should be fixed differently and separately and dropped from this PR.
In case of watermarks, we can move watermark behind new data and merge several watermarks.