### PR TITLE
cherry-pick: Add the ability to configure tablet boot priorities (#19702)

### DIFF
--- a/ydb/core/mind/hive/boot_queue.cpp
+++ b/ydb/core/mind/hive/boot_queue.cpp
@@ -4,9 +4,9 @@
 namespace NKikimr {
 namespace NHive {
 
-TBootQueue::TBootQueueRecord::TBootQueueRecord(const TTabletInfo& tablet, TNodeId suggestedNodeId)
+TBootQueue::TBootQueueRecord::TBootQueueRecord(const TTabletInfo& tablet, double priority, TNodeId suggestedNodeId)
     : TabletId(tablet.GetLeader().Id)
-    , Priority(GetBootPriority(tablet))
+    , Priority(priority)
     , FollowerId(tablet.IsLeader() ? 0 : tablet.AsFollower().Id)
     , SuggestedNodeId(suggestedNodeId)
 {
@@ -14,6 +14,28 @@ TBootQueue::TBootQueueRecord::TBootQueueRecord(const TTabletInfo& tablet, TNodeI
 
 void TBootQueue::AddToBootQueue(TBootQueueRecord record) {
     BootQueue.push(record);
+}
+
+void TBootQueue::AddToBootQueue(const TTabletInfo &tablet, TNodeId node) {
+    double priority = GetBootPriority(tablet);
+    BootQueue.emplace(tablet, priority, node);
+}
+
+void TBootQueue::UpdateTabletBootQueuePriorities(const NKikimrConfig::THiveConfig& hiveConfig) {
+    // Fill default priorities
+    TTabletTypeToBootPriority updated{
+        {TTabletTypes::Hive, 4},
+        {TTabletTypes::SchemeShard, 3},
+        {TTabletTypes::Mediator, 2},
+        {TTabletTypes::Coordinator, 2},
+        {TTabletTypes::BlobDepot, 2},
+        {TTabletTypes::ColumnShard, 0},
+    };
+    // Update priorities from config
+    for (const auto& entry : hiveConfig.GetTabletTypeToBootPriority()) {
+        updated.insert_or_assign(entry.GetTabletType(), entry.GetPriority());
+    }
+    TabletTypeToBootPriority = std::move(updated);
 }
 
 TBootQueue::TBootQueueRecord TBootQueue::PopFromBootQueue() {
@@ -65,6 +87,25 @@ TBootQueue::TQueue& TBootQueue::GetCurrentQueue() {
         return WaitQueue;
     }
     return BootQueue;
+}
+
+double TBootQueue::GetBootPriority(const TTabletInfo& tablet) const {
+    double priority = 0;
+
+    if (tablet.IsLeader()) {
+        priority = 1;
+        auto tabletType = tablet.GetTabletType();
+        const auto* it = TabletTypeToBootPriority.FindPtr(tabletType);
+        if (it) {
+            priority = *it;
+        }
+    }
+
+    priority += tablet.Weight;
+    if (tablet.RestartsOften()) {
+        priority -= 5;
+    }
+    return priority;
 }
 
 }

--- a/ydb/core/mind/hive/hive_impl.cpp
+++ b/ydb/core/mind/hive/hive_impl.cpp
@@ -366,7 +366,7 @@ void THive::ProcessWaitQueue() {
 void THive::AddToBootQueue(TTabletInfo* tablet, TNodeId node) {
     tablet->UpdateWeight();
     tablet->BootState = BootStateBooting;
-    BootQueue.EmplaceToBootQueue(*tablet, node);
+    BootQueue.AddToBootQueue(*tablet, node);
     UpdateCounterBootQueueSize(BootQueue.BootQueue.size());
 }
 
@@ -687,6 +687,7 @@ void THive::BuildCurrentConfig() {
         SpreadNeighbours = false;
         ObjectDistributions.Disable();
     }
+    BootQueue.UpdateTabletBootQueuePriorities(CurrentConfig);
 }
 
 void THive::Cleanup() {

--- a/ydb/core/protos/config.proto
+++ b/ydb/core/protos/config.proto
@@ -1099,7 +1099,7 @@ message TQueryServiceConfig {
     optional uint32 QueryTimeoutDefaultSeconds = 19 [default = 1800];
     optional bool EnableMatchRecognize = 20 [default = false];
     repeated string AvailableExternalDataSources = 22;                  // Ignored if AllExternalDataSourcesAreAvailable is true
-    optional bool AllExternalDataSourcesAreAvailable = 23 [default = true];   
+    optional bool AllExternalDataSourcesAreAvailable = 23 [default = true];
 }
 
 // Config describes immediate controls and allows
@@ -1726,6 +1726,11 @@ message THiveConfig {
         HIVE_BOOT_STRATEGY_FAST = 1;
     }
 
+    message TBootPriority {
+        optional NKikimrTabletBase.TTabletTypes.EType TabletType = 1;
+        optional double Priority = 2;
+    }
+
     optional uint64 MaxTabletsScheduled = 2 [default = 100];
     optional uint64 MaxResourceCounter = 3 [default = 100000000];
     optional uint64 MaxResourceCPU = 4 [default = 10000000];
@@ -1809,6 +1814,7 @@ message THiveConfig {
     optional double TargetTrackingCPUMargin = 83 [default = 0.1]; // percent
     optional double DryRunTargetTrackingCPU = 84; // percent
     optional uint64 NodeRestartsForPenalty = 85 [default = 3];
+    repeated TBootPriority TabletTypeToBootPriority = 87;
 }
 
 message THealthCheckConfig {


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

Add the ability to configure tablet boot priorities via `HiveConfig`

### Changelog category <!-- remove all except one -->

* New feature

### Description for reviewers <!-- (optional) description for those who read this PR -->

