### PR TITLE
Remove NPageCollection::TFetch class

### DIFF
--- a/ydb/core/tablet_flat/flat_bio_actor.h
+++ b/ydb/core/tablet_flat/flat_bio_actor.h
@@ -24,21 +24,23 @@ namespace NBlockIO {
     private:
         void Registered(TActorSystem*, const TActorId&) override;
         void Inbox(TEventHandlePtr &eh);
-        void Bootstrap(EPriority priority, TAutoPtr<NPageCollection::TFetch>);
         void Dispatch();
         void Handle(ui32 offset, TArrayRef<TLoaded>);
         void Terminate(EStatus code);
 
     private:
-        const TActorId Service;
-        const ui64 Cookie = Max<ui64>();
+        const TActorId StatActorId;
+        const ui64 EventCookie;
         TAutoPtr<NUtil::ILogger> Logger;
 
         /*_ immutable request settings  */
 
-        TActorId Owner;
-        EPriority Priority = EPriority::None;
-        TAutoPtr<NPageCollection::TFetch> Origin;
+        TActorId Sender;
+        EPriority Priority;
+        TIntrusiveConstPtr<NPageCollection::IPageCollection> PageCollection;
+        TVector<TPageId> Pages;
+        NWilson::TTraceId TraceId;
+        ui64 RequestCookie;
 
         /*_ request operational state   */
 
@@ -59,13 +61,10 @@ namespace NBlockIO {
         NMetrics::TTabletIopsRawValue GroupOps;
     };
 
-    template<typename ... TArgs>
-    inline void Start(NActors::IActorOps *ops, TActorId service,
-                        ui64 cookie, TArgs&& ... args)
+    inline void Start(NActors::IActorOps *ops, TActorId statActorId, ui64 cookie, TEvFetch* fetch)
     {
-        auto self = ops->Register(new TBlockIO(service, cookie));
-
-        ops->Send(self, new TEvFetch(std::forward<TArgs>(args)...));
+        auto self = ops->Register(new TBlockIO(statActorId, cookie));
+        ops->Send(self, fetch);
     }
 
 }

--- a/ydb/core/tablet_flat/flat_bio_events.h
+++ b/ydb/core/tablet_flat/flat_bio_events.h
@@ -58,14 +58,6 @@ namespace NBlockIO {
                 << " " << NKikimrProto::EReplyStatus_Name(Status) << "}";
         }
 
-        ui64 Bytes() const
-        {
-            return
-                std::accumulate(Pages.begin(), Pages.end(), ui64(0),
-                    [](ui64 bytes, const NPageCollection::TLoadedPage& block)
-                        { return bytes + block.Data.size(); });
-        }
-
         const EStatus Status;
         TIntrusiveConstPtr<NPageCollection::IPageCollection> PageCollection;
         TVector<NPageCollection::TLoadedPage> Pages;

--- a/ydb/core/tablet_flat/flat_boot_bundle.h
+++ b/ydb/core/tablet_flat/flat_boot_bundle.h
@@ -58,7 +58,8 @@ namespace NBoot {
             LeftReads -= 1;
 
             if (msg.Status == NKikimrProto::OK) {
-                Loader->Save(msg.Cookie, msg.Pages);
+                Y_ENSURE(msg.Cookie == 0);
+                Loader->Save(std::move(msg.Pages));
 
                 TryFinalize();
 
@@ -108,8 +109,8 @@ namespace NBoot {
         void TryFinalize()
         {
             if (!LeftReads) {
-                for (auto req : Loader->Run({.PreloadIndex = true, .PreloadData = false})) {
-                    LeftReads += Logic->LoadPages(this, req);
+                if (auto fetch = Loader->Run({.PreloadIndex = true, .PreloadData = false})) {
+                    LeftReads += Logic->LoadPages(this, std::move(fetch));
                 }
             }
 

--- a/ydb/core/tablet_flat/flat_executor.h
+++ b/ydb/core/tablet_flat/flat_executor.h
@@ -559,8 +559,6 @@ class TExecutor
     void RequestInMemPagesForPartStore(ui32 tableId, const NTable::TPartView &partView, const THashSet<NTable::TTag> &stickyColumns);
     void StickInMemPages(NSharedCache::TEvResult *msg);
     THashSet<NTable::TTag> GetStickyColumns(ui32 tableId);
-    void RequestFromSharedCache(TAutoPtr<NPageCollection::TFetch> fetch,
-        NBlockIO::EPriority way, ESharedCacheRequestType requestCategory);
     THolder<TScanSnapshot> PrepareScanSnapshot(ui32 table,
         const NTable::TCompactionParams* params, TRowVersion snapshot = TRowVersion::Max());
     void ReleaseScanLocks(TIntrusivePtr<TBarrier>, const NTable::TSubset&);

--- a/ydb/core/tablet_flat/flat_executor_bootlogic.cpp
+++ b/ydb/core/tablet_flat/flat_executor_bootlogic.cpp
@@ -176,8 +176,8 @@ void TExecutorBootLogic::LoadEntry(TIntrusivePtr<NBoot::TLoadBlobs> entry) {
     }
 }
 
-NBoot::TSpawned TExecutorBootLogic::LoadPages(NBoot::IStep *step, TAutoPtr<NPageCollection::TFetch> req) {
-    auto success = Loads.insert(std::make_pair(req->PageCollection.Get(), step)).second;
+NBoot::TSpawned TExecutorBootLogic::LoadPages(NBoot::IStep *step, NTable::TLoader::TFetch&& fetch) {
+    auto success = Loads.insert(std::make_pair(fetch.PageCollection.Get(), step)).second;
 
     Y_ENSURE(success, "IPageCollection queued twice for loading");
 
@@ -185,7 +185,8 @@ NBoot::TSpawned TExecutorBootLogic::LoadPages(NBoot::IStep *step, TAutoPtr<NPage
         NSharedCache::MakeSharedPageCacheId(),
         new NSharedCache::TEvRequest(
             NBlockIO::EPriority::Fast,
-            req),
+            std::move(fetch.PageCollection),
+            std::move(fetch.Pages)),
         0, (ui64)ESharedCacheRequestType::BootLogic);
 
     return NBoot::TSpawned(true);

--- a/ydb/core/tablet_flat/flat_executor_bootlogic.h
+++ b/ydb/core/tablet_flat/flat_executor_bootlogic.h
@@ -4,6 +4,7 @@
 #include "flat_boot_cookie.h"
 #include "flat_boot_util.h"
 #include "flat_load_blob_queue.h"
+#include "flat_part_loader.h"
 
 namespace NKikimr {
 namespace NTabletFlatExecutor {
@@ -97,7 +98,7 @@ private:
     ui32 GetBSGroupFor(const TLogoBlobID &logo) const;
     ui32 GetBSGroupID(ui32 channel, ui32 generation);
     void LoadEntry(TIntrusivePtr<NBoot::TLoadBlobs>);
-    NBoot::TSpawned LoadPages(NBoot::IStep*, TAutoPtr<NPageCollection::TFetch> req);
+    NBoot::TSpawned LoadPages(NBoot::IStep*, NTable::TLoader::TFetch&& fetch);
 
     void OnBlobLoaded(const TLogoBlobID& id, TString body, uintptr_t cookie) override;
 

--- a/ydb/core/tablet_flat/flat_ops_compact.h
+++ b/ydb/core/tablet_flat/flat_ops_compact.h
@@ -377,9 +377,9 @@ namespace NTabletFlatExecutor {
 
                 if (Y_UNLIKELY(fetch)) {
                     TStringBuilder error;
-                    error << "Just compacted part needs to load pages";
-                    for (auto collection : fetch) {
-                        error << " " << collection->DebugString(true);
+                    error << "Just compacted part needs to load page collection " << fetch.PageCollection->Label() << " pages";
+                    for (auto page : fetch.Pages) {
+                        error << " " << page;
                     }
                     Y_TABLET_ERROR(error);
                 }

--- a/ydb/core/tablet_flat/flat_part_loader.cpp
+++ b/ydb/core/tablet_flat/flat_part_loader.cpp
@@ -149,7 +149,7 @@ void TLoader::StageParseMeta()
     }
 }
 
-TAutoPtr<NPageCollection::TFetch> TLoader::StageCreatePartView(bool preloadIndex)
+TLoader::TFetch TLoader::StageCreatePartView(bool preloadIndex)
 {
     Y_ENSURE(!PartView, "PartView already initialized in CreatePartView stage");
     Y_ENSURE(Packs && Packs.front());
@@ -272,16 +272,16 @@ TAutoPtr<NPageCollection::TFetch> TLoader::StageCreatePartView(bool preloadIndex
 
     LoaderEnv->ProvidePart(PartView.Part.Get());
 
-    return nullptr;
+    return {};
 }
 
-TAutoPtr<NPageCollection::TFetch> TLoader::StageSliceBounds()
+TLoader::TFetch TLoader::StageSliceBounds()
 {
     Y_ENSURE(PartView, "Cannot generate bounds for a missing part");
 
     if (PartView.Slices) {
         TOverlay{ PartView.Screen, PartView.Slices }.Validate();
-        return nullptr;
+        return {};
     }
 
     LoaderEnv->EnsureNoNeedPages();
@@ -293,7 +293,7 @@ TAutoPtr<NPageCollection::TFetch> TLoader::StageSliceBounds()
         PartView.Slices = std::move(run);
         TOverlay{ PartView.Screen, PartView.Slices }.Validate();
 
-        return nullptr;
+        return {};
     } else if (auto fetches = LoaderEnv->GetFetch()) {
         return fetches;
     } else {
@@ -316,7 +316,7 @@ void TLoader::StageDeltas()
     }
 }
 
-TAutoPtr<NPageCollection::TFetch> TLoader::StagePreloadData()
+TLoader::TFetch TLoader::StagePreloadData()
 {
     auto partStore = PartView.As<TPartStore>();
 
@@ -331,13 +331,11 @@ TAutoPtr<NPageCollection::TFetch> TLoader::StagePreloadData()
     return LoaderEnv->GetFetch();
 }
 
-void TLoader::Save(ui64 cookie, TArrayRef<NSharedCache::TEvResult::TLoaded> loadedPages)
+void TLoader::Save(TVector<NSharedCache::TEvResult::TLoaded>&& pages)
 {
-    Y_ENSURE(cookie == 0, "Only the leader pack is used on load");
-
     if (Stage == EStage::PartView || Stage == EStage::Slice || Stage == EStage::PreloadData) {
-        for (auto& loaded : loadedPages) {
-            LoaderEnv->Save(cookie, std::move(loaded));
+        for (auto& page : pages) {
+            LoaderEnv->Save(std::move(page));
         }
     } else {
         Y_TABLET_ERROR("Unexpected pages save on stage " << int(Stage));

--- a/ydb/core/tablet_flat/flat_part_loader.h
+++ b/ydb/core/tablet_flat/flat_part_loader.h
@@ -26,6 +26,15 @@ namespace NTable {
 
         using TCache = NTabletFlatExecutor::TPrivatePageCache::TInfo;
 
+        struct TFetch : TMoveOnly {
+            TIntrusiveConstPtr<NPageCollection::IPageCollection> PageCollection;
+            TVector<TPageId> Pages;
+
+            explicit operator bool() const {
+                return bool(Pages);
+            }
+        };
+
         struct TLoaderEnv : public IPages {
             TLoaderEnv(TIntrusivePtr<TCache> cache)
                 : Cache(std::move(cache))
@@ -78,25 +87,30 @@ namespace NTable {
                 Y_ENSURE(!NeedPages);
             }
 
-            TAutoPtr<NPageCollection::TFetch> GetFetch()
+            TFetch GetFetch()
             {
                 if (NeedPages) {
                     TVector<TPageId> pages(NeedPages.begin(), NeedPages.end());
                     std::sort(pages.begin(), pages.end());
-                    return new NPageCollection::TFetch{ 0, Cache->PageCollection, std::move(pages) };
+                    return {
+                        .PageCollection = Cache->PageCollection,
+                        .Pages = std::move(pages)
+                    };
                 } else {
-                    return nullptr;
+                    return {};
                 }
             }
 
-            void Save(ui32 cookie, NSharedCache::TEvResult::TLoaded&& loaded)
+            void Save(NSharedCache::TEvResult::TLoaded&& loaded)
             {
-                if (cookie == 0 && NeedPages.erase(loaded.PageId)) {
-                    auto pageType = Cache->GetPageType(loaded.PageId);
-                    bool sticky = NeedIn(pageType) || pageType == EPage::FlatIndex;
-                    AddSavedPage(loaded.PageId, loaded.Page);
-                    Cache->Fill(loaded.PageId, std::move(loaded.Page), sticky);
-                }
+                auto pageType = Cache->GetPageType(loaded.PageId);
+
+                auto needed = NeedPages.erase(loaded.PageId);
+                Y_ENSURE(needed, "Got uknown " << pageType << " page " << loaded.PageId);
+                
+                bool sticky = NeedIn(pageType) || pageType == EPage::FlatIndex;
+                AddSavedPage(loaded.PageId, loaded.Page);
+                Cache->Fill(loaded.PageId, std::move(loaded.Page), sticky);
             }
 
         private:
@@ -138,10 +152,10 @@ namespace NTable {
                 TEpoch epoch = NTable::TEpoch::Max());
         ~TLoader();
 
-        TVector<TAutoPtr<NPageCollection::TFetch>> Run(TRunOptions options)
+        TFetch Run(TRunOptions options)
         {
             while (Stage < EStage::Result) {
-                TAutoPtr<NPageCollection::TFetch> fetch;
+                TFetch fetch;
 
                 switch (Stage) {
                     case EStage::Meta:
@@ -166,10 +180,7 @@ namespace NTable {
                 }
 
                 if (fetch) {
-                    if (!fetch->Pages) {
-                        Y_TABLET_ERROR("TLoader is trying to fetch 0 pages");
-                    }
-                    return { fetch };
+                    return fetch;
                 }
 
                 Stage = EStage(ui8(Stage) + 1);
@@ -178,7 +189,7 @@ namespace NTable {
             return { };
         }
 
-        void Save(ui64 cookie, TArrayRef<NSharedCache::TEvResult::TLoaded>);
+        void Save(TVector<NSharedCache::TEvResult::TLoaded>&& pages);
 
         constexpr static bool NeedIn(EPage page) noexcept
         {
@@ -251,10 +262,10 @@ namespace NTable {
         }
 
         void StageParseMeta();
-        TAutoPtr<NPageCollection::TFetch> StageCreatePartView(bool preloadIndex);
-        TAutoPtr<NPageCollection::TFetch> StageSliceBounds();
+        TFetch StageCreatePartView(bool preloadIndex);
+        TFetch StageSliceBounds();
         void StageDeltas();
-        TAutoPtr<NPageCollection::TFetch> StagePreloadData();
+        TFetch StagePreloadData();
 
     private:
         TVector<TIntrusivePtr<TCache>> Packs;

--- a/ydb/core/tablet_flat/flat_part_store.h
+++ b/ydb/core/tablet_flat/flat_part_store.h
@@ -134,7 +134,7 @@ public:
         return (lob == ELargeObj::Extern ? Pseudo : PageCollections.at(GroupsCount)).Get();
     }
 
-    TAutoPtr<NPageCollection::TFetch> GetPages(ui32 room) const
+    TVector<TPageId> GetPages(ui32 room) const
     {
         Y_ENSURE(room < PageCollections.size());
 
@@ -145,7 +145,7 @@ public:
             pages[i] = i;
         }
 
-        return new NPageCollection::TFetch{ 0, PageCollections[room]->PageCollection, std::move(pages) };
+        return pages;
     }
 
     static TVector<TIntrusivePtr<TCache>> Construct(TVector<TPageCollectionComponents> components)

--- a/ydb/core/tablet_flat/flat_sausage_fetch.h
+++ b/ydb/core/tablet_flat/flat_sausage_fetch.h
@@ -1,6 +1,6 @@
 #pragma once
 
-#include "flat_sausage_gut.h"
+#include "flat_sausage_solid.h"
 
 #include <util/generic/xrange.h>
 #include <ydb/library/actors/util/shared_data.h>
@@ -10,38 +10,6 @@ namespace NPageCollection {
 
     struct TPagesWaitPad : public TThrRefBase {
         ui64 PendingRequests = 0;
-    };
-
-    struct TFetch {
-        TFetch(ui64 cookie, TIntrusiveConstPtr<IPageCollection> pageCollection, TVector<TPageId> pages)
-            : Cookie(cookie)
-            , PageCollection(std::move(pageCollection))
-            , Pages(std::move(pages))
-        {
-        }
-
-        TString DebugString(bool detailed = false) const
-        {
-            TStringBuilder str;
-            str << "PageCollection: " << PageCollection->Label();
-            if (detailed) {
-                str << " Pages: [";
-                for (const auto& pageId : Pages) {
-                    str << " " << pageId;
-                }
-                str << " ]";
-            } else {
-                str << " Pages: " << Pages.size();
-            }
-            if (Cookie != Max<ui64>()) str << " Cookie: " << Cookie;
-            return str;
-        }
-
-        ui64 Cookie = Max<ui64>();
-        TIntrusiveConstPtr<IPageCollection> PageCollection;
-        TVector<TPageId> Pages;
-        TIntrusivePtr<TPagesWaitPad> WaitPad;
-        NWilson::TTraceId TraceId;
     };
 
     struct TLoadedPage {

--- a/ydb/core/tablet_flat/shared_cache_events.h
+++ b/ydb/core/tablet_flat/shared_cache_events.h
@@ -83,23 +83,28 @@ namespace NKikimr::NSharedCache {
     };
 
     struct TEvRequest : public TEventLocal<TEvRequest, EvRequest> {
-        const EPriority Priority;
-        TAutoPtr<NPageCollection::TFetch> Fetch;
-
-        TEvRequest(EPriority priority, TAutoPtr<NPageCollection::TFetch> fetch)
+        TEvRequest(EPriority priority, TIntrusiveConstPtr<NPageCollection::IPageCollection> pageCollection, TVector<TPageId> pages, ui64 cookie = 0)
             : Priority(priority)
-            , Fetch(fetch)
-        {
-        }
+            , PageCollection(std::move(pageCollection))
+            , Pages(std::move(pages))
+            , Cookie(cookie)
+        { }
+
+        const EPriority Priority;
+        TIntrusiveConstPtr<NPageCollection::IPageCollection> PageCollection;
+        TVector<TPageId> Pages;
+        TIntrusivePtr<NPageCollection::TPagesWaitPad> WaitPad;
+        NWilson::TTraceId TraceId;
+        const ui64 Cookie;
     };
 
     struct TEvResult : public TEventLocal<TEvResult, EvResult> {
         using EStatus = NKikimrProto::EReplyStatus;
 
-        TEvResult(TIntrusiveConstPtr<NPageCollection::IPageCollection> pageCollection, ui64 cookie, EStatus status)
+        TEvResult(TIntrusiveConstPtr<NPageCollection::IPageCollection> pageCollection, EStatus status, ui64 cookie)
             : Status(status)
+            , PageCollection(std::move(pageCollection))
             , Cookie(cookie)
-            , PageCollection(pageCollection)
         { }
 
         void Describe(IOutputStream &out) const
@@ -130,10 +135,10 @@ namespace NKikimr::NSharedCache {
         };
 
         const EStatus Status;
-        const ui64 Cookie;
         const TIntrusiveConstPtr<NPageCollection::IPageCollection> PageCollection;
         TVector<TLoaded> Pages;
         TIntrusivePtr<NPageCollection::TPagesWaitPad> WaitPad;
+        const ui64 Cookie;
     };
 
     struct TEvUpdated : public TEventLocal<TEvUpdated, EvUpdated> {

--- a/ydb/core/tablet_flat/ut/ut_slice_loader.cpp
+++ b/ydb/core/tablet_flat/ut/ut_slice_loader.cpp
@@ -150,16 +150,15 @@ namespace {
 
         while (!(result.Run = loader.Do(screen))) {
             if (auto fetch = env.GetFetch()) {
-                UNIT_ASSERT_C(fetch->PageCollection.Get() == pageCollection.Get(),
+                UNIT_ASSERT_C(fetch.PageCollection.Get() == pageCollection.Get(),
                     "TLoader wants to fetch from an unexpected pageCollection");
-                UNIT_ASSERT_C(fetch->Pages, "TLoader wants a fetch, but there are no pages");
-                result.Pages += fetch->Pages.size();
+                UNIT_ASSERT_C(fetch.Pages, "TLoader wants a fetch, but there are no pages");
+                result.Pages += fetch.Pages.size();
 
-                for (auto pageId : fetch->Pages) {
+                for (auto pageId : fetch.Pages) {
                     auto* page = part->Store->GetPage(0, pageId);
                     UNIT_ASSERT_C(page, "TLoader wants a missing page " << pageId);
-
-                    env.Save(fetch->Cookie, { pageId, NSharedCache::TSharedPageRef::MakePrivate(*page) });
+                    env.Save({ pageId, NSharedCache::TSharedPageRef::MakePrivate(*page) });
                 }
             } else {
                 UNIT_ASSERT_C(false, "TKeysLoader was stalled");

--- a/ydb/core/tx/datashard/datashard__stats.cpp
+++ b/ydb/core/tx/datashard/datashard__stats.cpp
@@ -102,9 +102,8 @@ public:
             return page;
         }
 
-        auto fetchEv = new NPageCollection::TFetch{ {}, info->PageCollection, TVector<TPageId>{ pageId } };
         PagesSize += info->GetPageSize(pageId);
-        Send(MakeSharedPageCacheId(), new NSharedCache::TEvRequest(NSharedCache::EPriority::Bkgr, fetchEv));
+        Send(MakeSharedPageCacheId(), new NSharedCache::TEvRequest(NSharedCache::EPriority::Bkgr, info->PageCollection, { pageId }));
 
         Spent->Alter(false); // pause measurement
         ReleaseResources();

--- a/ydb/core/tx/datashard/datashard_ut_followers.cpp
+++ b/ydb/core/tx/datashard/datashard_ut_followers.cpp
@@ -424,8 +424,8 @@ Y_UNIT_TEST_SUITE(DataShardFollowers) {
         auto observer = runtime.AddObserver<NSharedCache::TEvRequest>([&](NSharedCache::TEvRequest::TPtr& ev) {
             NSharedCache::TEvRequest *msg = ev->Get();
             Cerr << "Captured pages request" << Endl;
-            for (auto pageId : msg->Fetch->Pages) {
-                auto type = NTable::NPage::EPage(msg->Fetch->PageCollection->Page(pageId).Type);
+            for (auto pageId : msg->Pages) {
+                auto type = NTable::NPage::EPage(msg->PageCollection->Page(pageId).Type);
                 UNIT_ASSERT_C(type != NTable::EPage::BTreeIndex && type != NTable::EPage::FlatIndex, "Index pages should be preload during a part switch");
             }
         });
@@ -503,8 +503,8 @@ Y_UNIT_TEST_SUITE(DataShardFollowers) {
         TVector<THolder<IEventHandle>> blockedReads;
         auto observer = runtime.AddObserver<NSharedCache::TEvRequest>([&](NSharedCache::TEvRequest::TPtr& ev) {
             NSharedCache::TEvRequest *msg = ev->Get();
-            for (auto pageId : msg->Fetch->Pages) {
-                auto type = NTable::NPage::EPage(msg->Fetch->PageCollection->Page(pageId).Type);
+            for (auto pageId : msg->Pages) {
+                auto type = NTable::NPage::EPage(msg->PageCollection->Page(pageId).Type);
                 if (type == NTable::NPage::EPage::Schem2) {
                     Cerr << "... blocking part load read" << Endl;
                     blockedReads.emplace_back(ev.Release());
@@ -545,8 +545,8 @@ Y_UNIT_TEST_SUITE(DataShardFollowers) {
         ui32 readDataPages = 0;
         observer = runtime.AddObserver<NSharedCache::TEvRequest>([&](NSharedCache::TEvRequest::TPtr& ev) {
             NSharedCache::TEvRequest *msg = ev->Get();
-            for (auto pageId : msg->Fetch->Pages) {
-                auto type = NTable::NPage::EPage(msg->Fetch->PageCollection->Page(pageId).Type);
+            for (auto pageId : msg->Pages) {
+                auto type = NTable::NPage::EPage(msg->PageCollection->Page(pageId).Type);
                 readDataPages += type == NTable::NPage::EPage::DataPage;
             }
         });
@@ -632,8 +632,8 @@ Y_UNIT_TEST_SUITE(DataShardFollowers) {
         TVector<THolder<IEventHandle>> blockedReads;
         auto observer = runtime.AddObserver<NSharedCache::TEvRequest>([&](NSharedCache::TEvRequest::TPtr& ev) {
             NSharedCache::TEvRequest *msg = ev->Get();
-            for (auto pageId : msg->Fetch->Pages) {
-                auto type = NTable::NPage::EPage(msg->Fetch->PageCollection->Page(pageId).Type);
+            for (auto pageId : msg->Pages) {
+                auto type = NTable::NPage::EPage(msg->PageCollection->Page(pageId).Type);
                 if (type == NTable::NPage::EPage::Schem2) {
                     Cerr << "... blocking part load read" << Endl;
                     blockedReads.emplace_back(ev.Release());
@@ -673,8 +673,8 @@ Y_UNIT_TEST_SUITE(DataShardFollowers) {
         ui32 readDataPages = 0;
         observer = runtime.AddObserver<NSharedCache::TEvRequest>([&](NSharedCache::TEvRequest::TPtr& ev) {
             NSharedCache::TEvRequest *msg = ev->Get();
-            for (auto pageId : msg->Fetch->Pages) {
-                auto type = NTable::NPage::EPage(msg->Fetch->PageCollection->Page(pageId).Type);
+            for (auto pageId : msg->Pages) {
+                auto type = NTable::NPage::EPage(msg->PageCollection->Page(pageId).Type);
                 readDataPages += type == NTable::NPage::EPage::DataPage;
             }
         });
@@ -703,8 +703,8 @@ Y_UNIT_TEST_SUITE(DataShardFollowers) {
 
         observer = runtime.AddObserver<NSharedCache::TEvRequest>([&](NSharedCache::TEvRequest::TPtr& ev) {
             NSharedCache::TEvRequest *msg = ev->Get();
-            for (auto pageId : msg->Fetch->Pages) {
-                auto type = NTable::NPage::EPage(msg->Fetch->PageCollection->Page(pageId).Type);
+            for (auto pageId : msg->Pages) {
+                auto type = NTable::NPage::EPage(msg->PageCollection->Page(pageId).Type);
                 UNIT_ASSERT_C(type != NTable::NPage::EPage::DataPage, "Shouldn't read any data");
             }
         });

--- a/ydb/core/tx/schemeshard/ut_export/ut_export.cpp
+++ b/ydb/core/tx/schemeshard/ut_export/ut_export.cpp
@@ -1470,7 +1470,7 @@ partitioning_settings {
                 const auto* msg = ev->Get<NSharedCache::TEvResult>();
                 UNIT_ASSERT_VALUES_EQUAL(msg->Status, NKikimrProto::OK);
 
-                auto result = MakeHolder<NSharedCache::TEvResult>(msg->PageCollection, msg->Cookie, NKikimrProto::ERROR);
+                auto result = MakeHolder<NSharedCache::TEvResult>(msg->PageCollection, NKikimrProto::ERROR, msg->Cookie);
                 std::move(msg->Pages.begin(), msg->Pages.end(), std::back_inserter(result->Pages));
 
                 injectResult = MakeHolder<IEventHandle>(ev->Recipient, ev->Sender, result.Release(), ev->Flags, ev->Cookie);


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

...

### Changelog category <!-- remove all except one -->

* Not for changelog (changelog entry is not required)

### Description for reviewers <!-- (optional) description for those who read this PR -->

I don't like `NPageCollection::TFetch` class because it was used everywhere like scans and loader, where most of its fields are irrelevant (cookie, trace id, wait pad)

Refactored it into separate classes which are relevant to place where they are used (mostly page collection + page list)

Also now Shared Cache and Block IO have simple Request/Response interface without nested classes in them
