### PR TITLE
Make TQueueInplace and TOneOneQueueInplace usable without an extra pointer

### DIFF
--- a/ydb/core/blobstorage/vdisk/skeleton/blobstorage_skeletonfront.cpp
+++ b/ydb/core/blobstorage/vdisk/skeleton/blobstorage_skeletonfront.cpp
@@ -108,8 +108,6 @@ namespace NKikimr {
             std::shared_ptr<TVDiskSkeletonTrace> Trace;
             ui64 InternalMessageId;
 
-            TRecord() = default;
-
             TRecord(std::unique_ptr<IEventHandle> ev, TInstant now, ui32 recByteSize, const NBackpressure::TMessageId &msgId,
                     ui64 cost, TInstant deadline, NKikimrBlobStorage::EVDiskQueueId extQueueId,
                     const NBackpressure::TQueueClientId& clientId, TString name, std::shared_ptr<TVDiskSkeletonTrace> &&trace,
@@ -161,7 +159,7 @@ namespace NKikimr {
 
         private:
             const TString VDiskLogPrefix;
-            std::unique_ptr<TQueueType, TQueueType::TCleanDestructor> Queue;
+            TQueueType Queue;
             ui64 InFlightCount;
             ui64 InFlightCost;
             ui64 InFlightBytes;
@@ -203,7 +201,6 @@ namespace NKikimr {
                     ui64 maxInFlightCost,
                     TIntrusivePtr<::NMonitoring::TDynamicCounters> skeletonFrontGroup)
                 : VDiskLogPrefix(logPrefix)
-                , Queue(new TQueueType())
                 , InFlightCount(0)
                 , InFlightCost(0)
                 , InFlightBytes(0)
@@ -231,7 +228,7 @@ namespace NKikimr {
             }
 
             ui64 GetSize() const {
-                return Queue->GetSize();
+                return Queue.GetSize();
             }
 
             template<typename TFront>
@@ -240,7 +237,7 @@ namespace NKikimr {
                          NKikimrBlobStorage::EVDiskQueueId extQueueId, TFront& /*front*/,
                          const NBackpressure::TQueueClientId& clientId, std::shared_ptr<TVDiskSkeletonTrace> &&trace,
                          ui64 internalMessageId) {
-                if (!Queue->Head() && CanSendToSkeleton(cost)) {
+                if (!Queue.Head() && CanSendToSkeleton(cost)) {
                     // send to Skeleton for further processing
                     ctx.Send(converted.release());
                     ++InFlightCount;
@@ -262,8 +259,8 @@ namespace NKikimr {
                     *SkeletonFrontDelayedBytes += recByteSize;
 
                     TInstant now = TAppData::TimeProvider->Now();
-                    Queue->Push(TRecord(std::move(converted), now, recByteSize, msgId, cost, deadline, extQueueId,
-                        clientId, Name, std::move(trace), internalMessageId));
+                    Queue.Emplace(std::move(converted), now, recByteSize, msgId, cost, deadline, extQueueId,
+                        clientId, Name, std::move(trace), internalMessageId);
                 }
             }
 
@@ -276,7 +273,7 @@ namespace NKikimr {
             template <class TFront>
             void ProcessNext(const TActorContext &ctx, TFront &front, bool forceError) {
                 // we can send next element to Skeleton if any
-                while (TRecord *rec = Queue->Head()) {
+                while (TRecord *rec = Queue.Head()) {
                     const ui64 cost = rec->Cost;
                     if (CanSendToSkeleton(cost) || forceError) {
                         ui32 recByteSize = rec->ByteSize;
@@ -314,7 +311,7 @@ namespace NKikimr {
                             Msgs.emplace(rec->InternalMessageId, TMsgInfo(rec->MsgId.MsgId, ctx.Now(), std::move(rec->Trace)));
                             UpdateState();
                         }
-                        Queue->Pop();
+                        Queue.Pop();
                     } else {
                         break; // stop sending requests to skeleton
                     }

--- a/ydb/core/blobstorage/vdisk/skeleton/skeleton_overload_handler.cpp
+++ b/ydb/core/blobstorage/vdisk/skeleton/skeleton_overload_handler.cpp
@@ -55,9 +55,6 @@ namespace NKikimr {
         {}
 
         ~TEmergencyQueue() {
-            while (Queue.Head()) {
-                Queue.Pop();
-            }
         }
 
         void Push(TEvBlobStorage::TEvVMovedPatch::TPtr ev) {

--- a/ydb/core/tablet/tablet_resolver.cpp
+++ b/ydb/core/tablet/tablet_resolver.cpp
@@ -11,7 +11,7 @@
 #include <ydb/library/actors/core/actor_bootstrapped.h>
 #include <ydb/library/actors/interconnect/interconnect.h>
 #include <ydb/core/util/cache.h>
-#include <ydb/core/util/queue_oneone_inplace.h>
+#include <ydb/core/util/queue_inplace.h>
 #include <util/generic/map.h>
 #include <util/generic/deque.h>
 #include <library/cpp/random_provider/random_provider.h>
@@ -94,17 +94,15 @@ class TTabletResolver : public TActorBootstrapped<TTabletResolver> {
             TInstant AddInstant;
             TEvTabletResolver::TEvForward::TPtr Ev;
 
-            TQueueEntry(TInstant instant, TEvTabletResolver::TEvForward::TPtr &ev)
+            TQueueEntry(TInstant instant, TEvTabletResolver::TEvForward::TPtr&& ev)
                 : AddInstant(instant)
-                , Ev(ev)
+                , Ev(std::move(ev))
             {}
         };
 
-        typedef TOneOneQueueInplace<TQueueEntry *, 64> TQueueType;
-
         EState State = StInit;
 
-        TAutoPtr<TQueueType, TQueueType::TPtrCleanDestructor> Queue;
+        TQueueInplace<TQueueEntry, 128> Queue;
         TActorId KnownLeader;
         TActorId KnownLeaderTablet;
 
@@ -200,9 +198,7 @@ class TTabletResolver : public TActorBootstrapped<TTabletResolver> {
     }
 
     bool PushQueue(TEvTabletResolver::TEvForward::TPtr &ev, TEntry &entry, const TActorContext &ctx) {
-        if (!entry.Queue)
-            entry.Queue.Reset(new TEntry::TQueueType());
-        entry.Queue->Push(new TEntry::TQueueEntry(ctx.Now(), ev));
+        entry.Queue.Emplace(ctx.Now(), std::move(ev));
         return true;
     }
 
@@ -324,14 +320,15 @@ class TTabletResolver : public TActorBootstrapped<TTabletResolver> {
     }
 
     void SendQueued(ui64 tabletId, TEntry &entry, const TActorContext &ctx) {
-        if (TEntry::TQueueType *queue = entry.Queue.Get()) {
-            for (TAutoPtr<TEntry::TQueueEntry> x = queue->Pop(); !!x; x.Reset(queue->Pop())) {
-                TEvTabletResolver::TEvForward *msg = x->Ev->Get();
-                if (!SendForward(x->Ev->Sender, entry, msg, ctx))
-                    ctx.Send(x->Ev->Sender, new TEvTabletResolver::TEvForwardResult(NKikimrProto::ERROR, tabletId));
+        while (TEntry::TQueueEntry* x = entry.Queue.Head()) {
+            TEvTabletResolver::TEvForward *msg = x->Ev->Get();
+            if (!SendForward(x->Ev->Sender, entry, msg, ctx)) {
+                ctx.Send(x->Ev->Sender, new TEvTabletResolver::TEvForwardResult(NKikimrProto::ERROR, tabletId));
             }
-            entry.Queue.Destroy();
+            entry.Queue.Pop();
         }
+        // Free buffer memory
+        entry.Queue.Clear();
     }
 
     void SendPing(ui64 tabletId, TEntry &entry, const TActorContext &ctx) {
@@ -359,10 +356,9 @@ class TTabletResolver : public TActorBootstrapped<TTabletResolver> {
         LOG_DEBUG(ctx, NKikimrServices::TABLET_RESOLVER,
                   "DropEntry tabletId: %" PRIu64 " followers: %" PRIu64,
                   tabletId, entry.KnownFollowers.size());
-        if (TEntry::TQueueType *queue = entry.Queue.Get()) {
-            for (TAutoPtr<TEntry::TQueueEntry> x = queue->Pop(); !!x; x.Reset(queue->Pop())) {
-                ctx.Send(x->Ev->Sender, new TEvTabletResolver::TEvForwardResult(NKikimrProto::ERROR, tabletId));
-            }
+        while (TEntry::TQueueEntry* x = entry.Queue.Head()) {
+            ctx.Send(x->Ev->Sender, new TEvTabletResolver::TEvForwardResult(NKikimrProto::ERROR, tabletId));
+            entry.Queue.Pop();
         }
         ResolvedTablets.Erase(tabletId);
         UnresolvedTablets.Erase(tabletId);
@@ -840,10 +836,10 @@ public:
             if (!value)
                 return;
 
-            if (TEntry::TQueueType *queue = value->Queue.Get()) {
-                for (TAutoPtr<TEntry::TQueueEntry> x = queue->Pop(); !!x; x.Reset(queue->Pop())) {
-                    ActorSystem->Send(x->Ev->Sender, new TEvTabletResolver::TEvForwardResult(NKikimrProto::RACE, key));
-                }
+            auto& queue = value->Queue;
+            while (TEntry::TQueueEntry* x = queue.Head()) {
+                ActorSystem->Send(x->Ev->Sender, new TEvTabletResolver::TEvForwardResult(NKikimrProto::RACE, key));
+                queue.Pop();
             }
         });
     }

--- a/ydb/core/tablet_flat/logic_redo_entry.h
+++ b/ydb/core/tablet_flat/logic_redo_entry.h
@@ -11,16 +11,16 @@ namespace NRedo {
 
     struct TEntry {
         template<typename ... Args>
-        static TEntry* Create(NTable::TTxStamp stamp, TArrayRef<const ui32> affects, Args&& ... args)
+        static std::unique_ptr<TEntry> Create(NTable::TTxStamp stamp, TArrayRef<const ui32> affects, Args&& ... args)
         {
-            auto *ptr = malloc(sizeof(TEntry) + affects.size() * sizeof(ui32));
+            void* ptr = ::operator new(sizeof(TEntry) + affects.size() * sizeof(ui32));
 
-            return ::new(ptr) TEntry(stamp, affects, std::forward<Args>(args)...);
+            return std::unique_ptr<TEntry>(::new(ptr) TEntry(stamp, affects, std::forward<Args>(args)...));
         }
 
-        void operator delete (void *p)
+        void operator delete(void* p)
         {
-            free(p);
+            ::operator delete(p);
         }
 
         void Describe(IOutputStream &out) const

--- a/ydb/core/tx/datashard/datashard_impl.h
+++ b/ydb/core/tx/datashard/datashard_impl.h
@@ -2523,7 +2523,7 @@ private:
 
     TTxProgressIdempotentScalarQueue<TEvPrivate::TEvProgressTransaction> PlanQueue;
     TTxProgressIdempotentScalarScheduleQueue<TEvPrivate::TEvCleanupTransaction> CleanupQueue;
-    TTxProgressQueue<ui64, TNoOpDestroy, TEvPrivate::TEvProgressResendReadSet> ResendReadSetQueue;
+    TTxProgressQueue<ui64, TEvPrivate::TEvProgressResendReadSet> ResendReadSetQueue;
 
     struct TPipeServerInfoOverloadSubscribersTag {};
 

--- a/ydb/core/util/queue_inplace.h
+++ b/ydb/core/util/queue_inplace.h
@@ -1,117 +1,192 @@
 #pragma once
 
 #include "defs.h"
+#include <memory>
+#include <type_traits>
 
 template<typename T, ui32 TSize>
 struct TSimpleQueueChunk {
     static const ui32 EntriesCount = (TSize - sizeof(TSimpleQueueChunk*)) / sizeof(T);
     static_assert(EntriesCount > 0, "expect EntriesCount > 0");
 
-    T Entries[EntriesCount];
-    TSimpleQueueChunk * volatile Next;
+    union {
+        T Entries[EntriesCount];
+        char Data[EntriesCount * sizeof(T)];
+    };
+    TSimpleQueueChunk* Next = nullptr;
 
-    TSimpleQueueChunk() {
-    }
+    TSimpleQueueChunk() requires (std::is_trivially_default_constructible_v<T>) = default;
+    TSimpleQueueChunk() requires (!std::is_trivially_default_constructible_v<T>) {}
+
+    ~TSimpleQueueChunk() requires (std::is_trivially_destructible_v<T>) = default;
+    ~TSimpleQueueChunk() requires (!std::is_trivially_destructible_v<T>) {}
 };
 
-
 template<typename T, ui32 TSize, typename TChunk = TSimpleQueueChunk<T, TSize>>
-class TQueueInplace : TNonCopyable {
-    TChunk * ReadFrom;
+class TQueueInplace {
+    TChunk* ReadFrom;
     ui32 ReadPosition;
     ui32 WritePosition;
-    TChunk * WriteTo;
+    TChunk* WriteTo;
     size_t Size;
 
 public:
-    TQueueInplace()
-        : ReadFrom(new TChunk())
+    TQueueInplace() noexcept
+        : ReadFrom(nullptr)
         , ReadPosition(0)
         , WritePosition(0)
-        , WriteTo(ReadFrom)
+        , WriteTo(nullptr)
         , Size(0)
     {}
 
+    TQueueInplace(TQueueInplace&& rhs) noexcept
+        : ReadFrom(rhs.ReadFrom)
+        , ReadPosition(rhs.ReadPosition)
+        , WritePosition(rhs.WritePosition)
+        , WriteTo(rhs.WriteTo)
+        , Size(rhs.Size)
+    {
+        rhs.ReadFrom = nullptr;
+        rhs.ReadPosition = 0;
+        rhs.WritePosition = 0;
+        rhs.WriteTo = nullptr;
+        rhs.Size = 0;
+    }
+
+    TQueueInplace& operator=(TQueueInplace&& rhs) noexcept {
+        if (this != &rhs) [[likely]] {
+            Clear();
+            ReadFrom = rhs.ReadFrom;
+            ReadPosition = rhs.ReadPosition;
+            WritePosition = rhs.WritePosition;
+            WriteTo = rhs.WriteTo;
+            Size = rhs.Size;
+            rhs.ReadFrom = nullptr;
+            rhs.ReadPosition = 0;
+            rhs.WritePosition = 0;
+            rhs.WriteTo = nullptr;
+            rhs.Size = 0;
+        }
+        return *this;
+    }
+
     ~TQueueInplace() {
-        Y_DEBUG_ABORT_UNLESS(Head() == nullptr && Size == 0);
-        delete ReadFrom;
+        Clear();
     }
 
-    struct TPtrCleanDestructor {
-        static inline void Destroy(TQueueInplace<T, TSize> *x) noexcept {
-            while (const T *head = x->Head()) {
-                delete *head;
-                x->Pop();
+    void Clear() noexcept {
+        TChunk* head = ReadFrom;
+        if (head) {
+            if constexpr (std::is_trivially_destructible_v<T>) {
+                do {
+                    TChunk* next = head->Next;
+                    delete head;
+                    head = next;
+                } while (head);
+            } else {
+                ui32 start = ReadPosition;
+                do {
+                    TChunk* next = head->Next;
+                    ui32 end = next ? TChunk::EntriesCount : WritePosition;
+                    for (ui32 index = start; index != end; ++index) {
+                        std::destroy_at(&head->Entries[index]);
+                    }
+                    delete head;
+                    head = next;
+                    start = 0;
+                } while (head);
             }
-            delete x;
-        }
-    };
-
-    struct TCleanDestructor {
-        static inline void Destroy(TQueueInplace<T, TSize> *x) noexcept {
-            while (x->Head()) {
-                x->Pop();
-            }
-            delete x;
-        }
-
-        void operator ()(TQueueInplace<T, TSize> *x) const noexcept {
-            Destroy(x);
-        }
-    };
-
-    void Push(const T &x) noexcept {
-        ++Size;
-        if (WritePosition != TChunk::EntriesCount) {
-            WriteTo->Entries[WritePosition] = x;
-            ++WritePosition;
-        } else {
-            TChunk *next = new TChunk();
-            next->Entries[0] = x;
-            WriteTo->Next = next;
-            WriteTo = next;
-            WritePosition = 1;
-        }
-    }
-
-    void Push(T &&x) noexcept {
-        ++Size;
-        if (WritePosition != TChunk::EntriesCount) {
-            WriteTo->Entries[WritePosition] = std::move(x);
-            ++WritePosition;
-        } else {
-            TChunk *next = new TChunk();
-            next->Entries[0] = std::move(x);
-            WriteTo->Next = next;
-            WriteTo = next;
-            WritePosition = 1;
-        }
-    }
-
-    T *Head() {
-        TChunk *head = ReadFrom;
-        if (ReadFrom == WriteTo && ReadPosition == WritePosition) {
-            return nullptr;
-        } else if (ReadPosition != TChunk::EntriesCount) {
-            return &(head->Entries[ReadPosition]);
-        } else if (TChunk *next = head->Next) {
-            ReadFrom = next;
-            delete head;
+            ReadFrom = nullptr;
             ReadPosition = 0;
-            return Head();
+            WritePosition = 0;
+            WriteTo = nullptr;
+            Size = 0;
         }
-        return nullptr;
+    }
+
+    void Push(const T& x) {
+        Grow();
+        ::new (&WriteTo->Entries[WritePosition]) T(x);
+        ++WritePosition;
+        ++Size;
+    }
+
+    void Push(T&& x) noexcept {
+        Grow();
+        ::new (&WriteTo->Entries[WritePosition]) T(std::move(x));
+        ++WritePosition;
+        ++Size;
+    }
+
+    template<class... TArgs>
+    T& Emplace(TArgs&&... args) {
+        Grow();
+        T& result = *::new (&WriteTo->Entries[WritePosition]) T(std::forward<TArgs>(args)...);
+        ++WritePosition;
+        ++Size;
+        return result;
+    }
+
+    T* Head() {
+        TChunk* head = ReadFrom;
+        if (head == WriteTo && ReadPosition == WritePosition) {
+            // Note: this also handles ReadFrom == WriteTo == nullptr
+            return nullptr;
+        }
+        if (ReadPosition == TChunk::EntriesCount) [[unlikely]] {
+            TChunk* next = head->Next;
+            if (!next) {
+                return nullptr;
+            }
+            delete head;
+            head = next;
+            ReadFrom = next;
+            ReadPosition = 0;
+        }
+        return &head->Entries[ReadPosition];
     }
 
     void Pop() {
-        const T *ret = Head();
-        if (ret) {
+        T* x = Head();
+        Y_DEBUG_ABORT_UNLESS(x);
+        std::destroy_at(x);
+        ++ReadPosition;
+        --Size;
+    }
+
+    T PopDefault() {
+        T* x = Head();
+        if (x) {
+            T result(std::move(*x));
+            std::destroy_at(x);
             ++ReadPosition;
             --Size;
+            return result;
+        } else {
+            return T{};
         }
+    }
+
+    explicit operator bool() const {
+        return Size > 0;
     }
 
     size_t GetSize() const {
         return Size;
+    }
+
+private:
+    void Grow() {
+        if (WriteTo) [[likely]] {
+            if (WritePosition == TChunk::EntriesCount) [[unlikely]] {
+                TChunk* next = new TChunk();
+                WriteTo->Next = next;
+                WriteTo = next;
+                WritePosition = 0;
+            }
+        } else {
+            // Note: ReadPosition == WritePosition == 0
+            ReadFrom = WriteTo = new TChunk();
+        }
     }
 };

--- a/ydb/core/util/queue_inplace.h
+++ b/ydb/core/util/queue_inplace.h
@@ -107,7 +107,7 @@ public:
         ++Size;
     }
 
-    void Push(T&& x) noexcept {
+    void Push(T&& x) {
         ::new (NewEntry()) T(std::move(x));
         ++WritePosition;
         ++Size;

--- a/ydb/core/util/queue_inplace.h
+++ b/ydb/core/util/queue_inplace.h
@@ -15,11 +15,8 @@ struct TSimpleQueueChunk {
     };
     TSimpleQueueChunk* Next = nullptr;
 
-    TSimpleQueueChunk() requires (std::is_trivially_default_constructible_v<T>) = default;
-    TSimpleQueueChunk() requires (!std::is_trivially_default_constructible_v<T>) {}
-
-    ~TSimpleQueueChunk() requires (std::is_trivially_destructible_v<T>) = default;
-    ~TSimpleQueueChunk() requires (!std::is_trivially_destructible_v<T>) {}
+    TSimpleQueueChunk() {}
+    ~TSimpleQueueChunk() {}
 };
 
 template<typename T, ui32 TSize, typename TChunk = TSimpleQueueChunk<T, TSize>>
@@ -179,14 +176,14 @@ private:
     void Grow() {
         if (WriteTo) [[likely]] {
             if (WritePosition == TChunk::EntriesCount) [[unlikely]] {
-                TChunk* next = new TChunk();
+                TChunk* next = new TChunk;
                 WriteTo->Next = next;
                 WriteTo = next;
                 WritePosition = 0;
             }
         } else {
             // Note: ReadPosition == WritePosition == 0
-            ReadFrom = WriteTo = new TChunk();
+            ReadFrom = WriteTo = new TChunk;
         }
     }
 };

--- a/ydb/core/util/queue_inplace_ut.cpp
+++ b/ydb/core/util/queue_inplace_ut.cpp
@@ -11,16 +11,18 @@ Y_UNIT_TEST_SUITE(TQueueInplaceTests) {
     struct TStruct {
         ui32 X;
         ui32 Y;
-        TStruct(ui32 i = 0)
+        TStruct(ui32 i)
             : X(i)
             , Y(i)
         {}
+        TStruct(TStruct&& s)
+            : X(s.X)
+            , Y(s.Y)
+        {}
+        TStruct(const TStruct&) = delete;
 
-        TStruct &operator = (const TStruct &s) {
-            X = s.X;
-            Y = s.Y;
-            return *this;
-        }
+        TStruct& operator=(TStruct&& s) = delete;
+        TStruct& operator=(const TStruct&) = delete;
 
         bool operator == (ui32 i) const {
             return X == i && Y == i;
@@ -53,23 +55,118 @@ Y_UNIT_TEST_SUITE(TQueueInplaceTests) {
         UNIT_ASSERT(queue.Head() == nullptr);
     }
 
-    Y_UNIT_TEST(CleanInDestructor) {
-        using TQueueType = TQueueInplace<std::shared_ptr<bool> *, 32>;
+    Y_UNIT_TEST(DestroyInDestructor) {
+        using TQueueType = TQueueInplace<std::shared_ptr<bool>, 32>;
 
         std::shared_ptr<bool> p(new bool(true));
         UNIT_ASSERT_VALUES_EQUAL(1u, p.use_count());
 
         {
-            TAutoPtr<TQueueType, TQueueType::TPtrCleanDestructor> queue(new TQueueType());
-            queue->Push(new std::shared_ptr<bool>(p));
-            queue->Push(new std::shared_ptr<bool>(p));
-            queue->Push(new std::shared_ptr<bool>(p));
-            queue->Push(new std::shared_ptr<bool>(p));
+            TQueueType queue;
+            queue.Push(p);
+            queue.Push(p);
+            queue.Push(p);
+            queue.Push(p);
 
             UNIT_ASSERT_VALUES_EQUAL(5u, p.use_count());
+
+            queue.Pop();
+
+            UNIT_ASSERT_VALUES_EQUAL(4u, p.use_count());
         }
 
-        UNIT_ASSERT_VALUES_EQUAL(1, p.use_count());
+        UNIT_ASSERT_VALUES_EQUAL(1u, p.use_count());
+    }
+
+    Y_UNIT_TEST(EmplacePopDefault) {
+        using TQueueType = TQueueInplace<std::unique_ptr<int>, 32>;
+
+        TQueueType queue;
+        queue.Push(std::make_unique<int>(10));
+        queue.Emplace(new int(11));
+        queue.Emplace(new int(12));
+        queue.Emplace(std::make_unique<int>(13));
+
+        auto a = queue.PopDefault();
+        UNIT_ASSERT(a && *a == 10);
+        auto b = queue.PopDefault();
+        UNIT_ASSERT(b && *b == 11);
+        auto c = queue.PopDefault();
+        UNIT_ASSERT(c && *c == 12);
+        auto d = queue.PopDefault();
+        UNIT_ASSERT(d && *d == 13);
+        auto e = queue.PopDefault();
+        UNIT_ASSERT(!e);
+    }
+
+    Y_UNIT_TEST(PopNTimes) {
+        using TQueueType = TQueueInplace<std::unique_ptr<int>, 32>;
+
+        TQueueType queue;
+        queue.Push(std::make_unique<int>(10));
+        queue.Push(std::make_unique<int>(11));
+        queue.Push(std::make_unique<int>(12));
+        queue.Push(std::make_unique<int>(13));
+        UNIT_ASSERT(queue.GetSize() == 4);
+
+        queue.Pop();
+        queue.Pop();
+        queue.Pop();
+        queue.Pop();
+        UNIT_ASSERT(queue.GetSize() == 0);
+    }
+
+    Y_UNIT_TEST(MoveConstructor) {
+        using TQueueType = TQueueInplace<ui64, 32>;
+
+        TQueueType a;
+        a.Push(10);
+        a.Push(11);
+        a.Push(12);
+        a.Push(13);
+        UNIT_ASSERT(a.GetSize() == 4);
+
+        TQueueType b(std::move(a));
+
+        UNIT_ASSERT(a.GetSize() == 0);
+        UNIT_ASSERT(a.PopDefault() == 0u);
+
+        UNIT_ASSERT(b.GetSize() == 4);
+        UNIT_ASSERT(b.PopDefault() == 10u);
+        UNIT_ASSERT(b.PopDefault() == 11u);
+        UNIT_ASSERT(b.PopDefault() == 12u);
+        UNIT_ASSERT(b.PopDefault() == 13u);
+        UNIT_ASSERT(b.PopDefault() == 0u);
+    }
+
+    Y_UNIT_TEST(MoveAssignment) {
+        using TQueueType = TQueueInplace<ui64, 32>;
+
+        TQueueType a;
+        a.Push(10);
+        a.Push(11);
+        a.Push(12);
+        a.Push(13);
+        UNIT_ASSERT(a.GetSize() == 4);
+
+        TQueueType b;
+        b.Push(20);
+        b.Push(21);
+        b.Push(22);
+        b.Push(23);
+        UNIT_ASSERT(b.GetSize() == 4);
+
+        a = std::move(b);
+
+        UNIT_ASSERT(a.GetSize() == 4);
+        UNIT_ASSERT(a.PopDefault() == 20u);
+        UNIT_ASSERT(a.PopDefault() == 21u);
+        UNIT_ASSERT(a.PopDefault() == 22u);
+        UNIT_ASSERT(a.PopDefault() == 23u);
+        UNIT_ASSERT(a.PopDefault() == 0u);
+
+        UNIT_ASSERT(b.GetSize() == 0);
+        UNIT_ASSERT(b.PopDefault() == 0u);
     }
 
 }

--- a/ydb/core/util/queue_inplace_ut.cpp
+++ b/ydb/core/util/queue_inplace_ut.cpp
@@ -99,7 +99,7 @@ Y_UNIT_TEST_SUITE(TQueueInplaceTests) {
         UNIT_ASSERT(!e);
     }
 
-    Y_UNIT_TEST(PopNTimes) {
+    Y_UNIT_TEST(PopTooManyTimes) {
         using TQueueType = TQueueInplace<std::unique_ptr<int>, 32>;
 
         TQueueType queue;
@@ -109,6 +109,7 @@ Y_UNIT_TEST_SUITE(TQueueInplaceTests) {
         queue.Push(std::make_unique<int>(13));
         UNIT_ASSERT(queue.GetSize() == 4);
 
+        queue.Pop();
         queue.Pop();
         queue.Pop();
         queue.Pop();

--- a/ydb/core/util/queue_oneone_inplace_ut.cpp
+++ b/ydb/core/util/queue_oneone_inplace_ut.cpp
@@ -52,7 +52,26 @@ Y_UNIT_TEST_SUITE(TOneOneQueueTests) {
             UNIT_ASSERT_VALUES_EQUAL(5u, p.use_count());
         }
 
-        UNIT_ASSERT_VALUES_EQUAL(1, p.use_count());
+        UNIT_ASSERT_VALUES_EQUAL(1u, p.use_count());
+    }
+
+    Y_UNIT_TEST(DeleteInDestructor) {
+        using TQueueType = TOneOneQueueInplace<std::shared_ptr<bool> *, 32, TDelete>;
+
+        std::shared_ptr<bool> p(new bool(true));
+        UNIT_ASSERT_VALUES_EQUAL(1u, p.use_count());
+
+        {
+            TQueueType queue;
+            queue.Push(new std::shared_ptr<bool>(p));
+            queue.Push(new std::shared_ptr<bool>(p));
+            queue.Push(new std::shared_ptr<bool>(p));
+            queue.Push(new std::shared_ptr<bool>(p));
+
+            UNIT_ASSERT_VALUES_EQUAL(5u, p.use_count());
+        }
+
+        UNIT_ASSERT_VALUES_EQUAL(1u, p.use_count());
     }
 
     Y_UNIT_TEST(ReadIterator) {

--- a/ydb/library/actors/testlib/test_runtime.cpp
+++ b/ydb/library/actors/testlib/test_runtime.cpp
@@ -1896,12 +1896,11 @@ namespace NActors {
 
     struct TStrandingActorDecoratorContext : public TThrRefBase {
         TStrandingActorDecoratorContext()
-            : Queue(new TQueueType)
         {
         }
 
-        typedef TOneOneQueueInplace<IEventHandle*, 32> TQueueType;
-        TAutoPtr<TQueueType, TQueueType::TPtrCleanDestructor> Queue;
+        typedef TOneOneQueueInplace<IEventHandle*, 32, TDelete> TQueueType;
+        TQueueType Queue;
     };
 
     class TStrandingActorDecorator : public TActorBootstrapped<TStrandingActorDecorator> {
@@ -1958,8 +1957,8 @@ namespace NActors {
         }
 
         STFUNC(StateFunc) {
-            bool wasEmpty = !Context->Queue->Head();
-            Context->Queue->Push(ev.Release());
+            bool wasEmpty = !Context->Queue.Head();
+            Context->Queue.Push(ev.Release());
             if (wasEmpty) {
                 SendHead(ActorContext());
             }
@@ -1967,15 +1966,15 @@ namespace NActors {
 
         STFUNC(Reply) {
             Y_ABORT_UNLESS(!HasReply);
-            IEventHandle *requestEv = Context->Queue->Head();
+            IEventHandle *requestEv = Context->Queue.Head();
             TActorId originalSender = requestEv->Sender;
             HasReply = !ReplyChecker->IsWaitingForMoreResponses(ev.Get());
             if (HasReply) {
-                delete Context->Queue->Pop();
+                delete Context->Queue.Pop();
             }
             auto ctx(ActorContext());
             ctx.Send(IEventHandle::Forward(ev, originalSender));
-            if (!IsSync && Context->Queue->Head()) {
+            if (!IsSync && Context->Queue.Head()) {
                 SendHead(ctx);
             }
         }
@@ -1985,7 +1984,7 @@ namespace NActors {
             if (!IsSync) {
                 ctx.Send(GetForwardedEvent().Release());
             } else {
-                while (Context->Queue->Head()) {
+                while (Context->Queue.Head()) {
                     ctx.Send(GetForwardedEvent().Release());
                     int count = 100;
                     while (!HasReply && count > 0) {
@@ -2003,7 +2002,7 @@ namespace NActors {
         }
 
         TAutoPtr<IEventHandle> GetForwardedEvent() {
-            IEventHandle* ev = Context->Queue->Head();
+            IEventHandle* ev = Context->Queue.Head();
             RequestType = ev->GetTypeRewrite();
             HasReply = !ReplyChecker->OnRequest(ev);
             TAutoPtr<IEventHandle> forwardedEv = ev->HasEvent()
@@ -2011,7 +2010,7 @@ namespace NActors {
                     : new IEventHandle(ev->GetTypeRewrite(), ev->Flags, Delegatee, ReplyId, ev->ReleaseChainBuffer(), ev->Cookie);
 
             if (HasReply) {
-                delete Context->Queue->Pop();
+                delete Context->Queue.Pop();
             }
             return forwardedEv;
         }

--- a/ydb/library/actors/util/queue_oneone_inplace.h
+++ b/ydb/library/actors/util/queue_oneone_inplace.h
@@ -62,17 +62,17 @@ public:
         }
     }
 
-    struct TCleanDestructor {
-        static inline void Destroy(TOneOneQueueInplace<T, TSize>* x) noexcept {
+    struct TPtrCleanDestructor {
+        static inline void Destroy(TOneOneQueueInplace* x) noexcept {
+            while (T head = x->Pop()) {
+                ::CheckedDelete(head);
+            }
             delete x;
         }
     };
 
-    struct TPtrCleanDestructor {
-        static inline void Destroy(TOneOneQueueInplace<T, TSize>* x) noexcept {
-            while (T head = x->Pop()) {
-                ::CheckedDelete(head);
-            }
+    struct TCleanDestructor {
+        static inline void Destroy(TOneOneQueueInplace* x) noexcept {
             delete x;
         }
     };

--- a/ydb/library/actors/util/queue_oneone_inplace.h
+++ b/ydb/library/actors/util/queue_oneone_inplace.h
@@ -3,16 +3,14 @@
 #include "defs.h"
 #include "queue_chunk.h"
 
-template <typename T, ui32 TSize, typename TChunk = TQueueChunk<T, TSize>>
+template <typename T, ui32 TSize, class D = TNoAction, typename TChunk = TQueueChunk<T, TSize>>
 class TOneOneQueueInplace : TNonCopyable {
-    static_assert(std::is_integral<T>::value || std::is_pointer<T>::value, "expect std::is_integral<T>::value || std::is_pointer<T>::valuer");
+    static_assert(std::is_integral<T>::value || std::is_pointer<T>::value, "expect std::is_integral<T>::value || std::is_pointer<T>::value");
 
     TChunk* ReadFrom;
     ui32 ReadPosition;
     ui32 WritePosition;
     TChunk* WriteTo;
-
-    friend class TReadIterator;
 
 public:
     class TReadIterator {
@@ -28,14 +26,15 @@ public:
 
         inline T Next() {
             TChunk* head = ReadFrom;
-            if (ReadPosition != TChunk::EntriesCount) {
-                return AtomicLoad(&head->Entries[ReadPosition++]);
-            } else if (TChunk* next = AtomicLoad(&head->Next)) {
-                ReadFrom = next;
+            if (ReadPosition == TChunk::EntriesCount) [[unlikely]] {
+                head = AtomicLoad(&head->Next);
+                if (!head) {
+                    return T{};
+                }
+                ReadFrom = head;
                 ReadPosition = 0;
-                return Next();
             }
-            return T{};
+            return AtomicLoad(&head->Entries[ReadPosition++]);
         }
     };
 
@@ -48,67 +47,68 @@ public:
     }
 
     ~TOneOneQueueInplace() {
-        Y_DEBUG_ABORT_UNLESS(Head() == 0);
-        delete ReadFrom;
-    }
-
-    struct TPtrCleanDestructor {
-        static inline void Destroy(TOneOneQueueInplace<T, TSize>* x) noexcept {
-            while (T head = x->Pop())
+        if constexpr (!std::is_same_v<D, TNoAction>) {
+            while (T x = Pop()) {
+                D::Destroy(x);
+            }
+            delete ReadFrom;
+        } else {
+            TChunk* next = ReadFrom;
+            do {
+                TChunk* head = next;
+                next = AtomicLoad(&head->Next);
                 delete head;
-            delete x;
+            } while (next);
         }
-    };
+    }
 
     struct TCleanDestructor {
         static inline void Destroy(TOneOneQueueInplace<T, TSize>* x) noexcept {
-            while (x->Pop() != nullptr)
-                continue;
             delete x;
         }
     };
 
-    struct TPtrCleanInplaceMallocDestructor {
-        template <typename TPtrVal>
-        static inline void Destroy(TOneOneQueueInplace<TPtrVal*, TSize>* x) noexcept {
-            while (TPtrVal* head = x->Pop()) {
-                head->~TPtrVal();
-                free(head);
+    struct TPtrCleanDestructor {
+        static inline void Destroy(TOneOneQueueInplace<T, TSize>* x) noexcept {
+            while (T head = x->Pop()) {
+                ::CheckedDelete(head);
             }
             delete x;
         }
     };
 
-    void Push(T x) noexcept {
-        if (WritePosition != TChunk::EntriesCount) {
-            AtomicStore(&WriteTo->Entries[WritePosition], x);
-            ++WritePosition;
-        } else {
+    void Push(T x) {
+        if (WritePosition == TChunk::EntriesCount) [[unlikely]] {
             TChunk* next = new TChunk();
-            next->Entries[0] = x;
+            AtomicStore(&next->Entries[0], x);
             AtomicStore(&WriteTo->Next, next);
             WriteTo = next;
             WritePosition = 1;
+        } else {
+            AtomicStore(&WriteTo->Entries[WritePosition++], x);
         }
     }
 
     T Head() {
         TChunk* head = ReadFrom;
-        if (ReadPosition != TChunk::EntriesCount) {
-            return AtomicLoad(&head->Entries[ReadPosition]);
-        } else if (TChunk* next = AtomicLoad(&head->Next)) {
-            ReadFrom = next;
+        if (ReadPosition == TChunk::EntriesCount) [[unlikely]] {
+            TChunk* next = AtomicLoad(&head->Next);
+            if (!next) {
+                return T{};
+            }
             delete head;
+            head = next;
+            ReadFrom = next;
             ReadPosition = 0;
-            return Head();
         }
-        return T{};
+        return AtomicLoad(&head->Entries[ReadPosition]);
     }
 
     T Pop() {
         T ret = Head();
-        if (ret)
+        if (ret) {
             ++ReadPosition;
+        }
         return ret;
     }
 

--- a/ydb/library/actors/util/queue_oneone_inplace.h
+++ b/ydb/library/actors/util/queue_oneone_inplace.h
@@ -3,7 +3,7 @@
 #include "defs.h"
 #include "queue_chunk.h"
 
-template <typename T, ui32 TSize, class D = TNoAction, typename TChunk = TQueueChunk<T, TSize>>
+template <typename T, ui32 TSize, typename D = TNoAction, typename TChunk = TQueueChunk<T, TSize>>
 class TOneOneQueueInplace : TNonCopyable {
     static_assert(std::is_integral<T>::value || std::is_pointer<T>::value, "expect std::is_integral<T>::value || std::is_pointer<T>::value");
 


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

...

### Changelog category <!-- remove all except one -->

* Not for changelog (changelog entry is not required)

### Description for reviewers <!-- (optional) description for those who read this PR -->

This PR makes it possible to specify a deleter for TOneOneQueueInplace when storing pointers, which alleviates the need for custom smart pointers. Also it makes TQueueInplace use constructors and destructors for its elements, which allows storing non-default-constructible and non-assignable types inplace, similar to standard containers.

Additionally this PR replaces indirect TOneOneQueueInplace uses with a direct TDelete specifier, and replaces single-threaded TOneOneQueueInplace with TQueueInplace.