### PR TITLE
Fix EvYardResize handling in PDisk and VDisk skeleton

### DIFF
--- a/ydb/core/blobstorage/pdisk/blobstorage_pdisk_actor.cpp
+++ b/ydb/core/blobstorage/pdisk/blobstorage_pdisk_actor.cpp
@@ -699,7 +699,9 @@ public:
     }
 
     void InitHandle(NPDisk::TEvYardResize::TPtr &ev) {
-        Y_UNUSED(ev);
+        PDisk->Mon.YardResize.CountRequest();
+        Send(ev->Sender, new NPDisk::TEvYardResizeResult(NKikimrProto::CORRUPTED, {}, StateErrorReason));
+        PDisk->Mon.YardResize.CountResponse();
     }
 
     void InitHandle(NPDisk::TEvShredPDisk::TPtr &ev) {
@@ -841,7 +843,9 @@ public:
     }
 
     void ErrorHandle(NPDisk::TEvYardResize::TPtr &ev) {
-        Y_UNUSED(ev);
+        PDisk->Mon.YardResize.CountRequest();
+        Send(ev->Sender, new NPDisk::TEvYardResizeResult(NKikimrProto::CORRUPTED, {}, StateErrorReason));
+        PDisk->Mon.YardResize.CountResponse();
     }
 
     void ErrorHandle(NPDisk::TEvChunkReserve::TPtr &ev) {
@@ -985,6 +989,7 @@ public:
     }
 
     void Handle(NPDisk::TEvYardResize::TPtr &ev) {
+        PDisk->Mon.YardResize.CountRequest();
         TYardResize* request = PDisk->ReqCreator.CreateFromEv<TYardResize>(*ev->Get(), ev->Sender);
         PDisk->InputRequest(request);
     }

--- a/ydb/core/blobstorage/pdisk/blobstorage_pdisk_impl.cpp
+++ b/ydb/core/blobstorage/pdisk/blobstorage_pdisk_impl.cpp
@@ -2075,6 +2075,7 @@ void TPDisk::YardResize(TYardResize &ev) {
     TStringStream errorReason;
     NKikimrProto::EReplyStatus errStatus = CheckOwnerAndRound(&ev, errorReason);
     if (errStatus != NKikimrProto::OK) {
+        Mon.YardResize.CountResponse();
         PCtx->ActorSystem->Send(ev.Sender, new NPDisk::TEvYardResizeResult(errStatus, {}, errorReason.Str()));
         return;
     }
@@ -2087,9 +2088,10 @@ void TPDisk::YardResize(TYardResize &ev) {
 
     auto result = std::make_unique<NPDisk::TEvYardResizeResult>(NKikimrProto::OK, GetStatusFlags(ev.Owner, ev.OwnerGroupType), TString());
     if (Cfg->ReadOnly) {
+        Mon.YardResize.CountResponse();
         PCtx->ActorSystem->Send(ev.Sender, result.release());
     } else {
-        WriteSysLogRestorePoint(new TCompletionEventSender(this, ev.Sender, result.release()),
+        WriteSysLogRestorePoint(new TCompletionEventSender(this, ev.Sender, result.release(), Mon.YardResize.Results),
             TReqId(TReqId::YardResize, 0), {});
     }
 }

--- a/ydb/core/blobstorage/pdisk/blobstorage_pdisk_mon.h
+++ b/ydb/core/blobstorage/pdisk/blobstorage_pdisk_mon.h
@@ -470,6 +470,7 @@ struct TPDiskMon {
     TReqCounters Harakiri;
     TReqCounters YardSlay;
     TReqCounters YardControl;
+    TReqCounters YardResize;
 
     TReqCounters ShredPDisk;
     TReqCounters PreShredCompactVDisk;

--- a/ydb/core/blobstorage/vdisk/skeleton/blobstorage_skeleton.cpp
+++ b/ydb/core/blobstorage/vdisk/skeleton/blobstorage_skeleton.cpp
@@ -900,7 +900,7 @@ namespace NKikimr {
             // prepare TLoggedRecVPutHuge
             auto traceId = ev->TraceId.Clone();
             bool confirmSyncLogAlso = static_cast<bool>(syncLogMsg);
-            intptr_t loggedRecId = LoggedRecsVault.Put(new TLoggedRecVPutHuge(seg, confirmSyncLogAlso, Db->HugeKeeperID, ev, 
+            intptr_t loggedRecId = LoggedRecsVault.Put(new TLoggedRecVPutHuge(seg, confirmSyncLogAlso, Db->HugeKeeperID, ev,
                     SelfVDiskId, Config, VCtx));
             void *loggedRecCookie = reinterpret_cast<void *>(loggedRecId);
             // create log msg
@@ -2551,6 +2551,10 @@ namespace NKikimr {
             CHECK_PDISK_RESPONSE(VCtx, ev, TActivationContext::AsActorContext());
         }
 
+        void Handle(NPDisk::TEvYardResizeResult::TPtr &ev, const TActorContext &ctx) {
+            CHECK_PDISK_RESPONSE(VCtx, ev, ctx);
+        }
+
         void Handle(TEvBlobStorage::TEvVTakeSnapshot::TPtr ev, const TActorContext& ctx) {
             const auto& record = ev->Get()->Record;
             if (!SelfVDiskId.SameDisk(record.GetVDiskID())) {
@@ -2813,7 +2817,7 @@ namespace NKikimr {
             CFunc(TEvBlobStorage::EvTimeToUpdateWhiteboard, UpdateWhiteboard)
             HFunc(NPDisk::TEvCutLog, Handle)
             HFunc(TEvVGenerationChange, Handle)
-            IgnoreFunc(NPDisk::TEvYardResizeResult)
+            HFunc(NPDisk::TEvYardResizeResult, Handle)
             HFunc(TEvents::TEvPoisonPill, HandlePoison)
             HFunc(TEvents::TEvGone, Handle)
             CFunc(TEvBlobStorage::EvCommenceRepl, HandleCommenceRepl)
@@ -2866,7 +2870,7 @@ namespace NKikimr {
             HFunc(NPDisk::TEvCutLog, Handle)
             HFunc(NPDisk::TEvConfigureSchedulerResult, Handle)
             HFunc(TEvVGenerationChange, Handle)
-            IgnoreFunc(NPDisk::TEvYardResizeResult)
+            HFunc(NPDisk::TEvYardResizeResult, Handle)
             HFunc(TEvents::TEvPoisonPill, HandlePoison)
             HFunc(TEvents::TEvGone, Handle)
             CFunc(TEvBlobStorage::EvCommenceRepl, HandleCommenceRepl)
@@ -2938,7 +2942,7 @@ namespace NKikimr {
             HFunc(NPDisk::TEvCutLog, Handle)
             HFunc(NPDisk::TEvConfigureSchedulerResult, Handle)
             HFunc(TEvVGenerationChange, Handle)
-            IgnoreFunc(NPDisk::TEvYardResizeResult)
+            HFunc(NPDisk::TEvYardResizeResult, Handle)
             HFunc(TEvents::TEvPoisonPill, HandlePoison)
             HFunc(TEvents::TEvGone, Handle)
             fFunc(TEvBlobStorage::EvReplDone, HandleReplDone)
@@ -2970,7 +2974,7 @@ namespace NKikimr {
             HFunc(TEvents::TEvPoisonPill, HandlePoison)
             HFunc(TEvents::TEvGone, Handle)
             HFunc(TEvVGenerationChange, Handle)
-            IgnoreFunc(NPDisk::TEvYardResizeResult)
+            HFunc(NPDisk::TEvYardResizeResult, Handle)
             CFunc(TEvBlobStorage::EvReplDone, Ignore)
             CFunc(TEvBlobStorage::EvCommenceRepl, HandleCommenceRepl)
             fFunc(TEvBlobStorage::EvControllerScrubStartQuantum, ForwardToScrubActor)


### PR DESCRIPTION
### Changelog category

* Not for changelog (changelog entry is not required)

### Description for reviewers

- Close #19852
- Close #19373 

Notice https://github.com/ydb-platform/ydb/blob/5cd7630bd4df521fdd26911d910dab19412bab58/ydb/core/blobstorage/vdisk/common/vdisk_context.h#L214-L221
