### PR TITLE
Fix static PDisk config check to account InferPDsikSlotCount

### DIFF
--- a/ydb/core/mind/bscontroller/config_fit_pdisks.cpp
+++ b/ydb/core/mind/bscontroller/config_fit_pdisks.cpp
@@ -85,7 +85,10 @@ namespace NKikimr {
                 pdiskInfo->BoxId = disk.BoxId;
                 if (pdiskInfo->PDiskConfig != disk.PDiskConfig
                         || pdiskInfo->InferPDiskSlotCountFromUnitSize != disk.InferPDiskSlotCountFromUnitSize) {
-                    if (const auto id = FindStaticPDisk(disk, state); id && state.StaticPDisks.at(*id).PDiskConfig != disk.PDiskConfig) {
+                    const std::optional<TBlobStorageController::TStaticPDiskInfo> staticPDisk = FindStaticPDisk(disk, state).transform(
+                        [&](TPDiskId id) {return state.StaticPDisks.at(id);});
+                    if (staticPDisk && (staticPDisk->PDiskConfig != disk.PDiskConfig
+                            || staticPDisk->InferPDiskSlotCountFromUnitSize != disk.InferPDiskSlotCountFromUnitSize)) {
                         throw TExError() << "PDiskConfig mismatch for static disk" << TErrorParams::NodeId(disk.NodeId) << TErrorParams::Path(disk.Path);
                     } else {
                         pdiskInfo->PDiskConfig = disk.PDiskConfig;


### PR DESCRIPTION
### Changelog category

* Not for changelog (changelog entry is not required)

### Description for reviewers

- Fixup for https://github.com/ydb-platform/ydb/pull/20966#discussion_r2200697790

I suppose this code will be refactored soon in scope of #20163, but for now it's better to maintain behaviour uniform. 
