### PR TITLE
Nemesis: fix stucking perform_checks 

### DIFF
--- a/ydb/tests/library/nemesis/remote_execution.py
+++ b/ydb/tests/library/nemesis/remote_execution.py
@@ -54,23 +54,23 @@ def wait_timeout(process, timeout):
 def execute_command_with_output_on_hosts(list_of_hosts, command, per_host_timeout=60, username=None):
     full_output = []
     full_retcode = 0
-    pool = futures.ProcessPoolExecutor(8)
-    fs = []
-    for host in list_of_hosts:
-        fs.append(
-            pool.submit(
-                execute_command_with_output_single_host,
-                host, command,
-                timeout=per_host_timeout,
-                username=username
+    with futures.ProcessPoolExecutor(8) as pool:
+        fs = []
+        for host in list_of_hosts:
+            fs.append(
+                pool.submit(
+                    execute_command_with_output_single_host,
+                    host, command,
+                    timeout=per_host_timeout,
+                    username=username
+                )
             )
-        )
 
-    for f in fs:
-        retcode, output = f.result()
-        if retcode:
-            full_retcode = retcode
-        full_output.extend(output)
+        for f in fs:
+            retcode, output = f.result()
+            if retcode:
+                full_retcode = retcode
+            full_output.extend(output)
     return full_retcode, full_output
 
 


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

- Before, Пулы не освобождались
```
Active threads after minidumps_search_results(): [<_MainThread(MainThread, started 140687397700416)>, <_ExecutorManagerThread(Thread-14, started 140681796384512)>]
SAFETY WARDEN:
Active threads after print safety violations(): [<_MainThread(MainThread, started 140687397700416)>, <_ExecutorManagerThread(Thread-14, started 140681796384512)>]
LIVENESS WARDEN:
Active threads after print liveness violations(): [<_MainThread(MainThread, started 140687397700416)>, <_ExecutorManagerThread(Thread-14, started 140681796384512)>]
SAFETY WARDEN (total: 0)
LIVENESS WARDEN (total: 0)
COREDUMPS:
    host-1: 0
    host-2: 0
MINIDUMPS:
    host-1: 0
    host-2: 0
Active threads after main(): [<_MainThread(MainThread, started 140687397700416)>, <_ExecutorManagerThread(Thread-14, started 140681796384512)>]
Active threads after main(): [<_MainThread(MainThread, started 140687397700416)>, <_ExecutorManagerThread(Thread-14, started 140681796384512)>]
```

- After
```
Active threads after minidumps_search_results(): [<_MainThread(MainThread, started 140353785328448)>]
SAFETY WARDEN:
Active threads after print safety violations(): [<_MainThread(MainThread, started 140353785328448)>]
LIVENESS WARDEN:
Active threads after print liveness violations(): [<_MainThread(MainThread, started 140353785328448)>]
SAFETY WARDEN (total: 0)
LIVENESS WARDEN (total: 0)
COREDUMPS:
     host-1: 0
     host-2: 0
MINIDUMPS:
     host-1: 0
     host-2: 0
Active threads after main(): [<_MainThread(MainThread, started 140353785328448)>]
Active threads after main(): [<_MainThread(MainThread, started 140353785328448)>]
```

### Changelog category <!-- remove all except one -->


* Not for changelog (changelog entry is not required)

### Description for reviewers <!-- (optional) description for those who read this PR -->

...
