### PR TITLE
Analytics: fix mute wf

### DIFF
--- a/.github/workflows/update_muted_ya.yml
+++ b/.github/workflows/update_muted_ya.yml
@@ -147,8 +147,18 @@ jobs:
                   TEST_COUNT=0
                   FULL_URL="${BASE_URL}"
                   while read -r test_name && [ ${TEST_COUNT} -lt ${MAX_TESTS} ]; do
-                    formatted_name=$(echo "${test_name}" | sed 's/ \//')
-                    encoded_name=$(echo "${formatted_name}" | sed 's/ /%20/g' | sed 's/[+]/%2B/g' | sed 's/[\/]/%2F/g' | sed 's/\[/%5B/g' | sed 's/\]/%5D/g')
+                    # Заменяем только первый пробел на слэш для формата suite/test
+                    formatted_name=$(echo "${test_name}" | sed 's/ /\//')
+
+                    # URL-кодируем спецсимволы: пробел, слэш, [, ], плюс, минус
+                    encoded_name=$(echo "${formatted_name}" \
+                      | sed 's/ /%20/g' \
+                      | sed 's/\//%2F/g' \
+                      | sed 's/\[/%5B/g' \
+                      | sed 's/\]/%5D/g' \
+                      | sed 's/+/%2B/g' \
+                      | sed 's/-/%2D/g')
+
                     FULL_URL="${FULL_URL}&full_name=${encoded_name}"
                     TEST_COUNT=$((TEST_COUNT+1))
                   done < mute_update/to_mute.txt


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->
### Fix: корректное формирование URL для дашборда mute-кандидатов в workflow

- Исправлена ошибка с некорректным использованием sed, из-за которой падал workflow.
- Теперь только первый пробел в имени теста заменяется на слэш (формат suite/test).
- Добавлено URL-кодирование плюса (+) и минуса (-), а также других спецсимволов.
- Улучшена читаемость и поддерживаемость блока формирования ссылки на дашборд.

Теперь ссылка на дашборд в PR всегда формируется корректно, даже если в именах тестов есть специальные символы. 

### Changelog category <!-- remove all except one -->

* Not for changelog (changelog entry is not required)

### Description for reviewers <!-- (optional) description for those who read this PR -->

...
