### PR TITLE
Add manual request approval to CMS

### DIFF
--- a/ydb/core/cms/cluster_info.h
+++ b/ydb/core/cms/cluster_info.h
@@ -903,6 +903,8 @@ public:
     }
 
     ui64 AddExternalLocks(const TNotificationInfo &notification, const TActorContext *ctx);
+    
+    TSet<TLockableItem *> FindLockedItems(const NKikimrCms::TAction &action, const TActorContext *ctx);
 
     void SetHostMarkers(const TString &hostName, const THashSet<NKikimrCms::EMarker> &markers);
     void ResetHostMarkers(const TString &hostName);
@@ -1017,8 +1019,6 @@ private:
         }
         return TPDiskID();
     }
-
-    TSet<TLockableItem *> FindLockedItems(const NKikimrCms::TAction &action, const TActorContext *ctx);
 
     TNodes Nodes;
     TTablets Tablets;

--- a/ydb/core/cms/cms.cpp
+++ b/ydb/core/cms/cms.cpp
@@ -1530,14 +1530,14 @@ void TCms::ManuallyApproveRequest(TEvCms::TEvManageRequestRequest::TPtr &ev, con
     // Create a permission for each action in the scheduled request
     TAutoPtr<TEvCms::TEvPermissionResponse> resp = new TEvCms::TEvPermissionResponse;
     resp->Record.MutableStatus()->SetCode(TStatus::ALLOW);
-    const ui32 priority = copy->Request.GetPriority();
     for (const auto& action : copy->Request.GetActions()) {
         auto items = ClusterInfo->FindLockedItems(action, &ctx);
         for (const auto& item : items) {
             TErrorInfo error;
             TDuration duration = TDuration::MicroSeconds(action.GetDuration());
             duration += TDuration::MicroSeconds(copy->Request.GetDuration());
-            item->DeactivateScheduledLocks(priority);
+            // To get permissions ASAP and not in the priority order.
+            item->DeactivateScheduledLocks(0);
             bool isLocked = item->IsLocked(error, State->Config.DefaultRetryTime, TActivationContext::Now(), duration);
             item->ReactivateScheduledLocks();
             if (isLocked) {

--- a/ydb/core/cms/cms.cpp
+++ b/ydb/core/cms/cms.cpp
@@ -1537,7 +1537,7 @@ void TCms::ManuallyApproveRequest(TEvCms::TEvManageRequestRequest::TPtr &ev, con
             TDuration duration = TDuration::MicroSeconds(action.GetDuration());
             duration += TDuration::MicroSeconds(copy->Request.GetDuration());
             // To get permissions ASAP and not in the priority order.
-            item->DeactivateScheduledLocks(0);
+            item->DeactivateScheduledLocks(Min<i32>());
             bool isLocked = item->IsLocked(error, State->Config.DefaultRetryTime, TActivationContext::Now(), duration);
             item->ReactivateScheduledLocks();
             if (isLocked) {

--- a/ydb/core/cms/cms.cpp
+++ b/ydb/core/cms/cms.cpp
@@ -1472,10 +1472,10 @@ void TCms::ManuallyApproveRequest(TEvCms::TEvManageRequestRequest::TPtr &ev, con
         const TActorId SendTo;
 
         TRequestApproveActor(TString requestId, TCmsStatePtr state, TActorId sendTo)
-        : TBase(&TRequestApproveActor::StateWork)
-        , RequestId(std::move(requestId))
-        , State(std::move(state))
-        , SendTo(sendTo)
+            : TBase(&TRequestApproveActor::StateWork)
+            , RequestId(std::move(requestId))
+            , State(std::move(state))
+            , SendTo(sendTo)
         {}
 
         void Handle(TEvCms::TEvPermissionResponse::TPtr &ev) {
@@ -1495,11 +1495,8 @@ void TCms::ManuallyApproveRequest(TEvCms::TEvManageRequestRequest::TPtr &ev, con
 
             manageResponse->Record.MutableStatus()->SetCode(TStatus::OK);
             for (auto& permission : resp->Record.permissions()) {
-                manageResponse->Record.AddManuallyApprovedPermissions(permission.GetId());
+                manageResponse->Record.AddManuallyApprovedPermissions()->CopyFrom(permission);
             }
-
-            // Remove the scheduled request
-            State->ScheduledRequests.erase(RequestId);
 
             Send(SendTo, std::move(manageResponse), 0, ev->Cookie);
 

--- a/ydb/core/cms/cms.cpp
+++ b/ydb/core/cms/cms.cpp
@@ -1525,10 +1525,10 @@ void TCms::ManuallyApproveRequest(TEvCms::TEvManageRequestRequest::TPtr &ev, con
             ev, TStatus::WRONG_REQUEST, "Unknown request for manual approval", ctx);
     }
 
-    TAutoPtr<TRequestInfo> copy = new TRequestInfo(it->second);
+    THolder<TRequestInfo> copy = MakeHolder<TRequestInfo>(it->second);
 
     // Create a permission for each action in the scheduled request
-    TAutoPtr<TEvCms::TEvPermissionResponse> resp = new TEvCms::TEvPermissionResponse;
+    THolder<TEvCms::TEvPermissionResponse> resp = MakeHolder<TEvCms::TEvPermissionResponse>();
     resp->Record.MutableStatus()->SetCode(TStatus::ALLOW);
     for (const auto& action : copy->Request.GetActions()) {
         auto items = ClusterInfo->FindLockedItems(action, &ctx);

--- a/ydb/core/cms/cms.cpp
+++ b/ydb/core/cms/cms.cpp
@@ -1543,7 +1543,8 @@ void TCms::ManuallyApproveRequest(TEvCms::TEvManageRequestRequest::TPtr &ev, con
     for (const auto& action : copy->Request.GetActions()) {
         auto* perm = resp->Record.AddPermissions();
         perm->MutableAction()->CopyFrom(action);
-        perm->SetDeadline(TInstant::Now().GetValue() + copy->Request.GetDuration());
+        TInstant deadline = TActivationContext::Now() + TDuration::MicroSeconds(copy->Request.GetDuration());
+        perm->SetDeadline(deadline.GetValue());
     }
 
     AcceptPermissions(resp->Record, rec.GetRequestId(), rec.GetUser(), ctx, true);

--- a/ydb/core/cms/cms.cpp
+++ b/ydb/core/cms/cms.cpp
@@ -1499,7 +1499,7 @@ void TCms::ManuallyApproveRequest(TEvCms::TEvManageRequestRequest::TPtr &ev, con
     };
 
     auto actor = new TRequestApproveActor(ev->Sender);
-    TActorId rrr = ctx.RegisterWithSameMailbox(actor);
+    TActorId approveActorId = ctx.RegisterWithSameMailbox(actor);
 
     auto &rec = ev->Get()->Record;
     // Manual approval: forcefully grant permission for the request
@@ -1526,7 +1526,7 @@ void TCms::ManuallyApproveRequest(TEvCms::TEvManageRequestRequest::TPtr &ev, con
 
     AcceptPermissions(resp->Record, rec.GetRequestId(), rec.GetUser(), ctx, true);
 
-    auto handle = new IEventHandle(rrr, SelfId(), resp.Release(), 0, ev->Cookie);
+    auto handle = new IEventHandle(approveActorId, SelfId(), resp.Release(), 0, ev->Cookie);
     Execute(CreateTxStorePermissions(std::move(ev->Release()), handle, rec.GetUser(), std::move(copy)), ctx);
 }
 

--- a/ydb/core/cms/cms_impl.h
+++ b/ydb/core/cms/cms_impl.h
@@ -382,6 +382,7 @@ private:
     void RemovePermission(TEvCms::TEvManagePermissionRequest::TPtr &ev, bool done, const TActorContext &ctx);
     void GetRequest(TEvCms::TEvManageRequestRequest::TPtr &ev, bool all, const TActorContext &ctx);
     void RemoveRequest(TEvCms::TEvManageRequestRequest::TPtr &ev, const TActorContext &ctx);
+    void ManuallyApproveRequest(TEvCms::TEvManageRequestRequest::TPtr &ev, const TActorContext &ctx);
     void GetNotifications(TEvCms::TEvManageNotificationRequest::TPtr &ev, bool all, const TActorContext &ctx);
     bool RemoveNotification(const TString &id, const TString &user, bool remove, TErrorInfo &error);
 

--- a/ydb/core/cms/cms_ut.cpp
+++ b/ydb/core/cms/cms_ut.cpp
@@ -521,6 +521,56 @@ Y_UNIT_TEST_SUITE(TCmsTest) {
         );
     }
 
+    Y_UNIT_TEST(ManualRequestApproval)
+    {
+        auto opts = TTestEnvOpts(8, 8).WithSentinel().WithDynamicGroups();
+        TCmsTestEnv env(opts);
+
+        auto pdiskId = env.PDiskId(0, 0);
+        TString pdiskPath = "/" + std::to_string(pdiskId.NodeId) + "/pdisk-" + std::to_string(pdiskId.DiskId) + ".data";
+
+        for (ui32 i = 0; i < 3; i++) {
+            auto& node = TFakeNodeWhiteboardService::Info[env.GetNodeId(i)];
+            node.Connected = false;
+        }
+        env.RegenerateBSConfig(TFakeNodeWhiteboardService::Config.MutableResponse()->MutableStatus(0)->MutableBaseConfig(), opts);
+
+        auto req = MakePermissionRequest(
+            TRequestOptions("user", false, false, true),
+            MakeAction(TAction::SHUTDOWN_HOST, env.GetNodeId(0), 60000000)
+        );
+        req->Record.SetAvailabilityMode(NKikimrCms::EAvailabilityMode::MODE_MAX_AVAILABILITY);
+
+        // Request that cannot be fulfilled
+        auto rec1 = env.CheckPermissionRequest(req, TStatus::DISALLOW_TEMP);
+
+        auto rid1 = rec1.GetRequestId();
+
+        // Manual approval
+        auto approveResp = env.CheckApproveRequest("user", rid1, false, TStatus::OK);
+        UNIT_ASSERT_VALUES_EQUAL(approveResp.ManuallyApprovedPermissionsSize(), 1);
+        TString permissionId = approveResp.GetManuallyApprovedPermissions(0);
+        auto rec2 = env.CheckGetPermission("user", permissionId);
+        UNIT_ASSERT_VALUES_EQUAL(rec2.PermissionsSize(), 1);
+        UNIT_ASSERT_VALUES_EQUAL(rec2.GetPermissions(0).GetId(), permissionId);
+        
+        for (ui32 i = 0; i < 3; i++) {
+            auto& node = TFakeNodeWhiteboardService::Info[env.GetNodeId(i)];
+            node.Connected = true;
+        }
+
+        {
+            // Request cannot be fulfilled, since node 0 is locked by previously approved request
+            auto req = MakePermissionRequest(
+                TRequestOptions("user", false, false, true),
+                MakeAction(TAction::SHUTDOWN_HOST, env.GetNodeId(0), 60000000)
+            );
+            req->Record.SetAvailabilityMode(NKikimrCms::EAvailabilityMode::MODE_MAX_AVAILABILITY);
+
+            env.CheckPermissionRequest(req, TStatus::DISALLOW_TEMP);
+        }
+    }
+
     Y_UNIT_TEST(RequestReplacePDiskDoesntBreakGroup)
     {
         auto opts = TTestEnvOpts(8, 2).WithSentinel().WithDynamicGroups();

--- a/ydb/core/cms/cms_ut.cpp
+++ b/ydb/core/cms/cms_ut.cpp
@@ -601,6 +601,36 @@ Y_UNIT_TEST_SUITE(TCmsTest) {
         }
     }
 
+    Y_UNIT_TEST(ManualRequestApprovalWithPartialAlreadyApproved)
+    {
+        auto opts = TTestEnvOpts(8, 8).WithSentinel().WithDynamicGroups();
+        TCmsTestEnv env(opts);
+
+        auto pdiskId = env.PDiskId(0, 0);
+        TString pdiskPath = "/" + std::to_string(pdiskId.NodeId) + "/pdisk-" + std::to_string(pdiskId.DiskId) + ".data";
+
+        auto req = MakePermissionRequest(
+            TRequestOptions("user", false, false, true),
+            MakeAction(TAction::SHUTDOWN_HOST, env.GetNodeId(0), 60000000),
+            MakeAction(TAction::SHUTDOWN_HOST, env.GetNodeId(1), 60000000),
+            MakeAction(TAction::SHUTDOWN_HOST, env.GetNodeId(2), 60000000)
+        );
+
+        req->Record.SetAvailabilityMode(NKikimrCms::EAvailabilityMode::MODE_MAX_AVAILABILITY);
+
+        auto rec1 = env.CheckPermissionRequest(req, TStatus::DISALLOW_TEMP);
+
+        auto rid1 = rec1.GetRequestId();
+        
+        // // Manual approval
+        // auto approveResp = env.CheckApproveRequest("user", rid1, false, TStatus::OK);
+        // UNIT_ASSERT_VALUES_EQUAL(approveResp.ManuallyApprovedPermissionsSize(), 1);
+        // TString permissionId = approveResp.GetManuallyApprovedPermissions(0);
+        // auto rec2 = env.CheckGetPermission("user", permissionId);
+        // UNIT_ASSERT_VALUES_EQUAL(rec2.PermissionsSize(), 1);
+        // UNIT_ASSERT_VALUES_EQUAL(rec2.GetPermissions(0).GetId(), permissionId);
+    }
+
     Y_UNIT_TEST(RequestReplacePDiskDoesntBreakGroup)
     {
         auto opts = TTestEnvOpts(8, 2).WithSentinel().WithDynamicGroups();

--- a/ydb/core/cms/cms_ut.cpp
+++ b/ydb/core/cms/cms_ut.cpp
@@ -529,6 +529,7 @@ Y_UNIT_TEST_SUITE(TCmsTest) {
         auto pdiskId = env.PDiskId(0, 0);
         TString pdiskPath = "/" + std::to_string(pdiskId.NodeId) + "/pdisk-" + std::to_string(pdiskId.DiskId) + ".data";
 
+        // Disconnect 3 nodes, in this case locking is not allowed
         for (ui32 i = 0; i < 3; i++) {
             auto& node = TFakeNodeWhiteboardService::Info[env.GetNodeId(i)];
             node.Connected = false;
@@ -553,11 +554,6 @@ Y_UNIT_TEST_SUITE(TCmsTest) {
         auto rec2 = env.CheckGetPermission("user", permissionId);
         UNIT_ASSERT_VALUES_EQUAL(rec2.PermissionsSize(), 1);
         UNIT_ASSERT_VALUES_EQUAL(rec2.GetPermissions(0).GetId(), permissionId);
-        
-        for (ui32 i = 0; i < 3; i++) {
-            auto& node = TFakeNodeWhiteboardService::Info[env.GetNodeId(i)];
-            node.Connected = true;
-        }
 
         {
             // Request cannot be fulfilled, since node 0 is locked by previously approved request
@@ -568,6 +564,40 @@ Y_UNIT_TEST_SUITE(TCmsTest) {
             req->Record.SetAvailabilityMode(NKikimrCms::EAvailabilityMode::MODE_MAX_AVAILABILITY);
 
             env.CheckPermissionRequest(req, TStatus::DISALLOW_TEMP);
+        }
+    }
+
+    Y_UNIT_TEST(ManualRequestApprovalLockingAllNodes)
+    {
+        auto opts = TTestEnvOpts(8, 8).WithSentinel().WithDynamicGroups();
+        TCmsTestEnv env(opts);
+
+        auto pdiskId = env.PDiskId(0, 0);
+        TString pdiskPath = "/" + std::to_string(pdiskId.NodeId) + "/pdisk-" + std::to_string(pdiskId.DiskId) + ".data";
+
+        auto& node = TFakeNodeWhiteboardService::Info[env.GetNodeId(0)];
+        node.Connected = false;
+        env.RegenerateBSConfig(TFakeNodeWhiteboardService::Config.MutableResponse()->MutableStatus(0)->MutableBaseConfig(), opts);
+
+        for (ui32 i = 0; i < 8; i++) {
+            auto req = MakePermissionRequest(
+                TRequestOptions("user", false, false, true),
+                MakeAction(TAction::SHUTDOWN_HOST, env.GetNodeId(i), 60000000)
+            );
+            req->Record.SetAvailabilityMode(NKikimrCms::EAvailabilityMode::MODE_MAX_AVAILABILITY);
+
+            // Request that cannot be fulfilled
+            auto rec1 = env.CheckPermissionRequest(req, TStatus::DISALLOW_TEMP);
+
+            auto rid1 = rec1.GetRequestId();
+
+            // Manual approval
+            auto approveResp = env.CheckApproveRequest("user", rid1, false, TStatus::OK);
+            UNIT_ASSERT_VALUES_EQUAL(approveResp.ManuallyApprovedPermissionsSize(), 1);
+            TString permissionId = approveResp.GetManuallyApprovedPermissions(0);
+            auto rec2 = env.CheckGetPermission("user", permissionId);
+            UNIT_ASSERT_VALUES_EQUAL(rec2.PermissionsSize(), 1);
+            UNIT_ASSERT_VALUES_EQUAL(rec2.GetPermissions(0).GetId(), permissionId);
         }
     }
 

--- a/ydb/core/cms/cms_ut.cpp
+++ b/ydb/core/cms/cms_ut.cpp
@@ -526,9 +526,6 @@ Y_UNIT_TEST_SUITE(TCmsTest) {
         auto opts = TTestEnvOpts(8, 8).WithSentinel().WithDynamicGroups();
         TCmsTestEnv env(opts);
 
-        auto pdiskId = env.PDiskId(0, 0);
-        TString pdiskPath = "/" + std::to_string(pdiskId.NodeId) + "/pdisk-" + std::to_string(pdiskId.DiskId) + ".data";
-
         // Disconnect 3 nodes, in this case locking is not allowed
         for (ui32 i = 0; i < 3; i++) {
             auto& node = TFakeNodeWhiteboardService::Info[env.GetNodeId(i)];
@@ -550,7 +547,7 @@ Y_UNIT_TEST_SUITE(TCmsTest) {
         // Manual approval
         auto approveResp = env.CheckApproveRequest("user", rid1, false, TStatus::OK);
         UNIT_ASSERT_VALUES_EQUAL(approveResp.ManuallyApprovedPermissionsSize(), 1);
-        TString permissionId = approveResp.GetManuallyApprovedPermissions(0);
+        TString permissionId = approveResp.GetManuallyApprovedPermissions(0).GetId();
         auto rec2 = env.CheckGetPermission("user", permissionId);
         UNIT_ASSERT_VALUES_EQUAL(rec2.PermissionsSize(), 1);
         UNIT_ASSERT_VALUES_EQUAL(rec2.GetPermissions(0).GetId(), permissionId);
@@ -572,9 +569,6 @@ Y_UNIT_TEST_SUITE(TCmsTest) {
         auto opts = TTestEnvOpts(8, 8).WithSentinel().WithDynamicGroups();
         TCmsTestEnv env(opts);
 
-        auto pdiskId = env.PDiskId(0, 0);
-        TString pdiskPath = "/" + std::to_string(pdiskId.NodeId) + "/pdisk-" + std::to_string(pdiskId.DiskId) + ".data";
-
         auto& node = TFakeNodeWhiteboardService::Info[env.GetNodeId(0)];
         node.Connected = false;
         env.RegenerateBSConfig(TFakeNodeWhiteboardService::Config.MutableResponse()->MutableStatus(0)->MutableBaseConfig(), opts);
@@ -594,7 +588,7 @@ Y_UNIT_TEST_SUITE(TCmsTest) {
             // Manual approval
             auto approveResp = env.CheckApproveRequest("user", rid1, false, TStatus::OK);
             UNIT_ASSERT_VALUES_EQUAL(approveResp.ManuallyApprovedPermissionsSize(), 1);
-            TString permissionId = approveResp.GetManuallyApprovedPermissions(0);
+            TString permissionId = approveResp.GetManuallyApprovedPermissions(0).GetId();
             auto rec2 = env.CheckGetPermission("user", permissionId);
             UNIT_ASSERT_VALUES_EQUAL(rec2.PermissionsSize(), 1);
             UNIT_ASSERT_VALUES_EQUAL(rec2.GetPermissions(0).GetId(), permissionId);
@@ -605,9 +599,6 @@ Y_UNIT_TEST_SUITE(TCmsTest) {
     {
         auto opts = TTestEnvOpts(8, 8).WithSentinel().WithDynamicGroups();
         TCmsTestEnv env(opts);
-
-        auto pdiskId = env.PDiskId(0, 0);
-        TString pdiskPath = "/" + std::to_string(pdiskId.NodeId) + "/pdisk-" + std::to_string(pdiskId.DiskId) + ".data";
 
         auto req = MakePermissionRequest(
             TRequestOptions("user", true, false, true),
@@ -629,7 +620,8 @@ Y_UNIT_TEST_SUITE(TCmsTest) {
         // // Manual approval
         auto approveResp = env.CheckApproveRequest("user", rid1, false, TStatus::OK);
         UNIT_ASSERT_VALUES_EQUAL(approveResp.ManuallyApprovedPermissionsSize(), 2);
-        for (const auto& permissionId : approveResp.GetManuallyApprovedPermissions()) {
+        for (const auto& permission : approveResp.GetManuallyApprovedPermissions()) {
+            auto permissionId = permission.GetId();
             auto rec3 = env.CheckGetPermission("user", permissionId);
             UNIT_ASSERT_VALUES_EQUAL(rec3.PermissionsSize(), 1);
             UNIT_ASSERT_VALUES_EQUAL(rec3.GetPermissions(0).GetId(), permissionId);
@@ -640,9 +632,6 @@ Y_UNIT_TEST_SUITE(TCmsTest) {
     {
         auto opts = TTestEnvOpts(8, 8).WithSentinel().WithDynamicGroups();
         TCmsTestEnv env(opts);
-
-        auto pdiskId = env.PDiskId(0, 0);
-        TString pdiskPath = "/" + std::to_string(pdiskId.NodeId) + "/pdisk-" + std::to_string(pdiskId.DiskId) + ".data";
 
         auto req = MakePermissionRequest(
             TRequestOptions("user", true, false, true),

--- a/ydb/core/cms/cms_ut.cpp
+++ b/ydb/core/cms/cms_ut.cpp
@@ -575,7 +575,7 @@ Y_UNIT_TEST_SUITE(TCmsTest) {
             auto list = env.CheckListRequests("user", 2);
             auto reqs = list.GetRequests();
             for (const auto& req : reqs) {
-                UNIT_ASSERT_VALUES_UNEQUAL("user-r-1", req.GetRequestId());
+                UNIT_ASSERT_VALUES_UNEQUAL(req.GetRequestId(), "user-r-1");
             }
          
             // Check that manually approved permission was cleaned up
@@ -629,7 +629,7 @@ Y_UNIT_TEST_SUITE(TCmsTest) {
         req->Record.SetAvailabilityMode(NKikimrCms::EAvailabilityMode::MODE_MAX_AVAILABILITY);
 
         auto rec1 = env.CheckPermissionRequest(req, TStatus::ALLOW_PARTIAL);
-        UNIT_ASSERT_VALUES_EQUAL(1, rec1.PermissionsSize());
+        UNIT_ASSERT_VALUES_EQUAL(rec1.PermissionsSize(), 1);
         auto rec2 = env.CheckGetPermission("user", rec1.GetPermissions(0).GetId());
         UNIT_ASSERT_VALUES_EQUAL(rec2.PermissionsSize(), 1);
         UNIT_ASSERT_VALUES_EQUAL(rec2.GetPermissions(0).GetId(), rec1.GetPermissions(0).GetId());

--- a/ydb/core/cms/cms_ut_common.cpp
+++ b/ydb/core/cms/cms_ut_common.cpp
@@ -963,6 +963,16 @@ TCmsTestEnv::CheckListRequests(const TString &user,
     return rec;
 }
 
+NKikimrCms::TManageRequestResponse
+TCmsTestEnv::CheckApproveRequest(const TString &user,
+                                 const TString &id,
+                                 bool dry,
+                                 NKikimrCms::TStatus::ECode code)
+{
+    auto req = MakeManageRequestRequest(user, TManageRequestRequest::APPROVE, id, dry);
+    return CheckManageRequestRequest(req, code);
+}
+
 NKikimrCms::TPermissionResponse
 TCmsTestEnv::CheckRequest(const TString &user,
                           TString id,

--- a/ydb/core/cms/cms_ut_common.h
+++ b/ydb/core/cms/cms_ut_common.h
@@ -336,6 +336,12 @@ public:
         bool dry = false,
         NKikimrCms::TStatus::ECode code = NKikimrCms::TStatus::OK);
     NKikimrCms::TManageRequestResponse CheckListRequests(const TString &user, ui64 count);
+    NKikimrCms::TManageRequestResponse CheckApproveRequest(
+        const TString &user,
+        const TString &id,
+        bool dry = false,
+        NKikimrCms::TStatus::ECode code = NKikimrCms::TStatus::OK
+    );
 
     NKikimrCms::TPermissionResponse CheckRequest(
         const TString &user,

--- a/ydb/core/driver_lib/cli_utils/cli_cmds_cms.cpp
+++ b/ydb/core/driver_lib/cli_utils/cli_cmds_cms.cpp
@@ -254,6 +254,16 @@ public:
     }
 };
 
+class TClientCommandApproveRequest : public TClientCommandManageRequest
+{
+public:
+    TClientCommandApproveRequest()
+        : TClientCommandManageRequest("approve", {}, "Approve scheduled request",
+                                      NKikimrCms::TManageRequestRequest::APPROVE, true)
+    {
+    }
+};
+
 class TClientCommandCheckRequest : public TCmsClientCommand
 {
 public:
@@ -589,6 +599,7 @@ public:
         AddCommand(std::make_unique<TClientCommandGetRequest>());
         AddCommand(std::make_unique<TClientCommandListRequest>());
         AddCommand(std::make_unique<TClientCommandRejectRequest>());
+        AddCommand(std::make_unique<TClientCommandApproveRequest>());
         AddCommand(std::make_unique<TClientCommandCheckRequest>());
     }
 };

--- a/ydb/core/protos/cms.proto
+++ b/ydb/core/protos/cms.proto
@@ -235,7 +235,7 @@ message TManageRequestResponse {
 
   optional TStatus           Status = 1;
   repeated TScheduledRequest Requests = 2;
-  repeated string            ManuallyApprovedPermissions = 3;
+  repeated TPermission       ManuallyApprovedPermissions = 3;
 }
 
 message TCheckRequest {

--- a/ydb/core/protos/cms.proto
+++ b/ydb/core/protos/cms.proto
@@ -213,6 +213,7 @@ message TManageRequestRequest {
     LIST = 1;
     GET = 2;
     REJECT = 3;
+    APPROVE = 4;
   }
 
   optional string   User = 1;
@@ -234,6 +235,7 @@ message TManageRequestResponse {
 
   optional TStatus           Status = 1;
   repeated TScheduledRequest Requests = 2;
+  repeated string            ManuallyApprovedPermissions = 3;
 }
 
 message TCheckRequest {


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->
Adds ability to manually approve scheduled CMS request and receive permissions. This allows, for example, locking an already failed node.

### Changelog category <!-- remove all except one -->

* Experimental feature

### Description for reviewers <!-- (optional) description for those who read this PR -->

...
