### PR TITLE
Comment message_visibility/resource message options in Nebius API because of a conflict

### DIFF
--- a/ydb/public/api/client/nc_private/annotations.proto
+++ b/ydb/public/api/client/nc_private/annotations.proto
@@ -128,7 +128,7 @@ extend google.protobuf.MessageOptions {
   // It is PUBLIC if a public item depends on it, for example is returned by a public method.
   // Use `option (message_visibility) = PUBLIC;` if you want to override the result of tree shaking.
   // NOTE: tree shaking takes into account only .proto files inside the current directory.
-  Visibility message_visibility = 50001;
+  // Visibility message_visibility = 50001; // Conflicts with other options by its number
 
   // Marker extension for resource specifications. Resource type is equal to according NID type, e.g. "serviceaccount" or "project"
   string resource = 50002;
@@ -463,7 +463,7 @@ message MethodCLISettings {
 
     // must be a single character
     string shortcut = 1;
-    
+
     string flag = 2;
   }
 

--- a/ydb/public/api/client/nc_private/annotations.proto
+++ b/ydb/public/api/client/nc_private/annotations.proto
@@ -131,7 +131,7 @@ extend google.protobuf.MessageOptions {
   // Visibility message_visibility = 50001; // Conflicts with other options by its number
 
   // Marker extension for resource specifications. Resource type is equal to according NID type, e.g. "serviceaccount" or "project"
-  string resource = 50002;
+  // string resource = 50002; // Conflicts with other options by its number
 
   // @exclude 50003 is used for audit in `nebius/audit/annotations.proto`
 }

--- a/ydb/public/api/client/nc_private/common/v1/metadata.proto
+++ b/ydb/public/api/client/nc_private/common/v1/metadata.proto
@@ -12,7 +12,7 @@ option java_package = "ai.nebius.common.v1";
 
 // Common resource metadata.
 message ResourceMetadata {
-  option (message_visibility) = PUBLIC;
+  // option (message_visibility) = PUBLIC; // This option conflicts with other options by its number
 
   // Identifier for the resource, unique for its resource type.
   // @exclude Using NID is STRONGLY recommended because NID is URL- and DNS-safe and reasonably human-readable.
@@ -69,7 +69,7 @@ message ResourceMetadata {
 // if service supports uniqueness of ResourceMetadata.name within tuple (scope) <resource_type, parent_id>
 // it also must have grpc method GetByName
 message GetByNameRequest {
-  option (message_visibility) = PUBLIC;
+  // option (message_visibility) = PUBLIC; // This option conflicts with other options by its number
 
   string parent_id = 1;
   string name = 2;

--- a/ydb/public/api/client/nc_private/iam/v1/service_account.proto
+++ b/ydb/public/api/client/nc_private/iam/v1/service_account.proto
@@ -11,7 +11,7 @@ option java_outer_classname = "ServiceAccountProto";
 option java_package = "ai.nebius.iam.cpl.api.priv.v1";
 
 message ServiceAccount {
-  option (resource) = "serviceaccount";
+  // option (resource) = "serviceaccount"; // This option conflicts with other options by its number
 
   common.v1.ResourceMetadata metadata = 1 [(buf.validate.field).required = true];
   ServiceAccountSpec spec = 2 [(buf.validate.field).required = true];

--- a/ydb/public/api/client/nc_private/iam/v1/tenant_user_account.proto
+++ b/ydb/public/api/client/nc_private/iam/v1/tenant_user_account.proto
@@ -18,7 +18,7 @@ option java_package = "ai.nebius.iam.identity.v1";
 
 message TenantUserAccount {
   option (resource_behavior) = UNNAMED;
-  option (resource) = "tenantuseraccount";
+  // option (resource) = "tenantuseraccount"; // This option conflicts with other options by its number
 
   common.v1.ResourceMetadata metadata = 1 [(buf.validate.field).required = true];
   TenantUserAccountSpec spec = 2 [(buf.validate.field).required = true];

--- a/ydb/public/api/client/nc_private/iam/v1/user_account.proto
+++ b/ydb/public/api/client/nc_private/iam/v1/user_account.proto
@@ -20,7 +20,7 @@ option java_package = "ai.nebius.iam.identity.v1";
 
 message UserAccount {
   option (resource_behavior) = UNNAMED;
-  option (resource) = "useraccount";
+  // option (resource) = "useraccount"; // This option conflicts with other options by its number
 
   common.v1.ResourceMetadata metadata = 1 [(buf.validate.field).required = true];
   UserAccountSpec spec = 2 [(buf.validate.field).required = true];


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

...

### Changelog category <!-- remove all except one -->

* Not for changelog (changelog entry is not required)

### Description for reviewers <!-- (optional) description for those who read this PR -->

Conflict in one of custom builds:
```
E0000 00:00:1753293057.338177   75393 descriptor_database.cc:771] Extension conflicts with extension already in database: extend .google.protobuf.MessageOptions { message_visibility = 50001 } from:contrib/ydb/public/api/client/nc_private/annotations.proto
Terminating due to uncaught exception 0x324b3fc12410    what() -> "LogMessageFatal exception"
 of type y_absl::lts_y_20240722::log_internal::FatalException
```
