### PR TITLE
Fix unnecessary tablet resolver negative caching on pipe disconnects

### DIFF
--- a/ydb/core/tablet/tablet_pipe_ut.cpp
+++ b/ydb/core/tablet/tablet_pipe_ut.cpp
@@ -1366,6 +1366,11 @@ Y_UNIT_TEST_SUITE(TTabletPipeTest) {
         }
 
         auto sender2 = runtime.AllocateEdgeActor();
+        for (int i = 0; i < 30; ++i) {
+            // overload tablet resolver with unrelated queries
+            runtime.Send(new IEventHandle(MakeTabletResolverID(), TActorId(),
+                new TEvTabletResolver::TEvForward(TTestTxConfig::TxTablet0 + 1 + i, nullptr, {})));
+        }
         auto client2 = runtime.Register(NTabletPipe::CreateClient(sender2, TTestTxConfig::TxTablet0, NTabletPipe::TClientConfig{
             .ExpectShutdown = true,
             .RetryPolicy = NTabletPipe::TClientRetryPolicy::WithoutRetries(),
@@ -1442,6 +1447,11 @@ Y_UNIT_TEST_SUITE(TTabletPipeTest) {
         }
 
         auto sender2 = runtime.AllocateEdgeActor();
+        for (int i = 0; i < 30; ++i) {
+            // overload tablet resolver with unrelated queries
+            runtime.Send(new IEventHandle(MakeTabletResolverID(), TActorId(),
+                new TEvTabletResolver::TEvForward(TTestTxConfig::TxTablet0 + 1 + i, nullptr, {})));
+        }
         auto client2 = runtime.Register(NTabletPipe::CreateClient(sender2, TTestTxConfig::TxTablet0, NTabletPipe::TClientConfig{
             .RetryPolicy = NTabletPipe::TClientRetryPolicy::WithoutRetries(),
         }));


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

...

### Changelog category <!-- remove all except one -->

* Not for changelog (changelog entry is not required)

### Description for reviewers <!-- (optional) description for those who read this PR -->

Fix in #20931 introduced a subtle bug with negative caching for tablets after a disconnect. This bug is subtle because this negative caching only triggers under heavy load and not observable otherwise. Avoid negative caching unless we got definitely negative/outdated response from state storage.

Support for #21053.