### PR TITLE
Add one more good status in sentinel for nodes to eliminate blinking

### DIFF
--- a/ydb/core/cms/config.h
+++ b/ydb/core/cms/config.h
@@ -17,6 +17,7 @@ struct TCmsSentinelConfig {
         bool Enable;
         ui32 NodeBadStateLimit;
         ui32 NodeGoodStateLimit;
+        ui32 NodePrettyGoodStateLimit;
         TDuration WaitForConfigStep;
         TDuration RelaxTime;
     };
@@ -65,6 +66,7 @@ struct TCmsSentinelConfig {
         ssConfig->SetRelaxTime(StateStorageSelfHealConfig.RelaxTime.GetValue());
         ssConfig->SetNodeBadStateLimit(StateStorageSelfHealConfig.NodeBadStateLimit);
         ssConfig->SetNodeGoodStateLimit(StateStorageSelfHealConfig.NodeGoodStateLimit);
+        ssConfig->SetNodePrettyGoodStateLimit(StateStorageSelfHealConfig.NodePrettyGoodStateLimit);
 
         config.SetDataCenterRatio(DataCenterRatio);
         config.SetRoomRatio(RoomRatio);
@@ -97,6 +99,7 @@ struct TCmsSentinelConfig {
         StateStorageSelfHealConfig.Enable = ssConfig.GetEnable();
         StateStorageSelfHealConfig.NodeBadStateLimit = ssConfig.GetNodeBadStateLimit();
         StateStorageSelfHealConfig.NodeGoodStateLimit = ssConfig.GetNodeGoodStateLimit();
+        StateStorageSelfHealConfig.NodePrettyGoodStateLimit = ssConfig.GetNodePrettyGoodStateLimit();
         StateStorageSelfHealConfig.WaitForConfigStep = TDuration::MicroSeconds(ssConfig.GetWaitForConfigStep());
         StateStorageSelfHealConfig.RelaxTime = TDuration::MicroSeconds(ssConfig.GetRelaxTime());
 

--- a/ydb/core/cms/sentinel_impl.h
+++ b/ydb/core/cms/sentinel_impl.h
@@ -111,6 +111,7 @@ private:
 struct TNodeStatusComputer {
     enum ENodeState {
         GOOD = 0,
+        PRETTY_GOOD,
         MAY_BE_GOOD,
         MAY_BE_BAD,
         BAD,
@@ -121,6 +122,7 @@ struct TNodeStatusComputer {
     ui64 StateCounter = 0;
     ui32 BadStateLimit;
     ui32 GoodStateLimit;
+    ui32 PrettyGoodStateLimit;
 
     ui32 GetCurrentNodeState() const;
     bool Compute();
@@ -128,7 +130,8 @@ struct TNodeStatusComputer {
 
     bool MaybeBad() const { return CurrentState == ENodeState::BAD && StateCounter < BadStateLimit; }
     bool DefinitelyBad() const { return CurrentState == ENodeState::BAD && StateCounter >= BadStateLimit; }
-    bool MaybeGood() const { return CurrentState == ENodeState::GOOD && StateCounter < GoodStateLimit; }
+    bool MaybeGood() const { return CurrentState == ENodeState::GOOD && StateCounter < PrettyGoodStateLimit; }
+    bool PrettyGood() const { return CurrentState == ENodeState::GOOD && StateCounter >= PrettyGoodStateLimit; }
     bool DefinitelyGood() const { return CurrentState == ENodeState::GOOD && StateCounter >= GoodStateLimit; }
 };
 

--- a/ydb/core/protos/cms.proto
+++ b/ydb/core/protos/cms.proto
@@ -429,9 +429,10 @@ message TCmsConfig {
         message TStateStorageSelfHealConfig {
             optional bool Enable = 19 [default = true];
             optional uint32 NodeGoodStateLimit = 20 [default = 10];
-            optional uint32 NodeBadStateLimit = 21 [default = 10];
-            optional uint32 WaitForConfigStep = 22 [default = 60000000];
-            optional uint32 RelaxTime = 23 [default = 600000000];
+            optional uint32 NodePrettyGoodStateLimit = 21 [default = 7];
+            optional uint32 NodeBadStateLimit = 22 [default = 10];
+            optional uint32 WaitForConfigStep = 23 [default = 60000000];
+            optional uint32 RelaxTime = 24 [default = 600000000];
         }
 
         message TStateLimit {

--- a/ydb/tests/functional/config/test_distconf_sentinel_node_status.py
+++ b/ydb/tests/functional/config/test_distconf_sentinel_node_status.py
@@ -51,6 +51,7 @@ class KiKiMRDistConfNodeStatusTest(object):
         "state_storage_self_heal_config": {
             "enable": True,
             "node_good_state_limit": 3,
+            "node_pretty_good_state_limit": 2,
             "node_bad_state_limit": 3,
             "wait_for_config_step": 1000000,
             "relax_time": 10000000,


### PR DESCRIPTION
…on startup cluster

### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

Introduce one more state PRETTY_GOOD for node. 
In sort order this state has the same value as GOOD but not trigger self-heal.
This allow to eliminate not necessary self-heals when multiple nodes continuously raise up 

### Changelog category <!-- remove all except one -->

* Not for changelog (changelog entry is not required)

### Description for reviewers <!-- (optional) description for those who read this PR -->

...
