### PR TITLE
Fix Roaring UDF tests

### DIFF
--- a/ydb/library/yql/udfs/common/roaring/test/cases/aggregation.sql
+++ b/ydb/library/yql/udfs/common/roaring/test/cases/aggregation.sql
@@ -17,7 +17,7 @@ $filter_lambda = ($search, $doc_ids) -> {
 };
 
 $udaf = AggregationFactory("UDAF",
-    ($item, $parent) -> (Roaring::FromUint32List(AsList(UNWRAP(CAST($item AS Uint32))), $parent)),
+    ($item, $parent) -> (Roaring::FromUint32List(AsList(UNWRAP(CAST($item AS Uint32))))),
     ($state, $item, $_) -> (Roaring::Add($state, UNWRAP(CAST($item AS Uint32)))),
     ($state1, $state2) -> (Roaring::Or($state1, $state2)),
     ($state) -> (Roaring::Uint32List($state)),


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

Fix incorrect `$parent` usage across UDAF factory in Roaring UDF `aggregation` test

### Changelog category <!-- remove all except one -->

* Bugfix 

### Description for reviewers <!-- (optional) description for those who read this PR -->

`Roaring::FromUint32List` expects `$parent` to have some specific type, which is incorrect usage
Moreover, `$parent` dependency in `FromUint32List` is redundant as long as it depends on `$item`