### PR TITLE
Add X-Forwarded-For http header to keep source address

### DIFF
--- a/ydb/mvp/oidc_proxy/oidc_proxy_ut.cpp
+++ b/ydb/mvp/oidc_proxy/oidc_proxy_ut.cpp
@@ -1747,4 +1747,13 @@ Y_UNIT_TEST_SUITE(Mvp) {
         UNIT_ASSERT(!json.Has(EXTENDED_INFO));
         UNIT_ASSERT(!json.Has(EXTENDED_ERRORS));
     }
+
+    Y_UNIT_TEST(GetAddressWithoutPort) {
+        UNIT_ASSERT_VALUES_EQUAL(GetAddressWithoutPort("[2001:db8::1]:8080"), "2001:db8::1");
+        UNIT_ASSERT_VALUES_EQUAL(GetAddressWithoutPort("2001:db8::1:8080"), "2001:db8::1:8080"); // raw IPv6
+        UNIT_ASSERT_VALUES_EQUAL(GetAddressWithoutPort("192.168.1.1:8080"), "192.168.1.1");
+        UNIT_ASSERT_VALUES_EQUAL(GetAddressWithoutPort("192.168.1.1"), "192.168.1.1");
+        UNIT_ASSERT_VALUES_EQUAL(GetAddressWithoutPort("localhost:9090"), "localhost");
+        UNIT_ASSERT_VALUES_EQUAL(GetAddressWithoutPort("localhost"), "localhost");
+    }
 }

--- a/ydb/mvp/oidc_proxy/oidc_proxy_ut.cpp
+++ b/ydb/mvp/oidc_proxy/oidc_proxy_ut.cpp
@@ -1755,5 +1755,7 @@ Y_UNIT_TEST_SUITE(Mvp) {
         UNIT_ASSERT_VALUES_EQUAL(GetAddressWithoutPort("192.168.1.1"), "192.168.1.1");
         UNIT_ASSERT_VALUES_EQUAL(GetAddressWithoutPort("localhost:9090"), "localhost");
         UNIT_ASSERT_VALUES_EQUAL(GetAddressWithoutPort("localhost"), "localhost");
+        UNIT_ASSERT_VALUES_EQUAL(GetAddressWithoutPort("some.domain.name:1234"), "some.domain.name");
+        UNIT_ASSERT_VALUES_EQUAL(GetAddressWithoutPort("some.domain.name"), "some.domain.name");
     }
 }

--- a/ydb/mvp/oidc_proxy/openid_connect.cpp
+++ b/ydb/mvp/oidc_proxy/openid_connect.cpp
@@ -262,9 +262,51 @@ TStringBuf GetCookie(const NHttp::TCookies& cookies, const TString& cookieName) 
     return cookieValue;
 }
 
+TString GetAddressWithoutPort(const TString& address) {
+    // IPv6 with brackets: [addr]:port -> addr
+    if (address.StartsWith('[')) {
+        auto end = address.find(']');
+        if (end != TString::npos) {
+            return address.substr(1, end - 1);
+        }
+    }
+
+    // IPv6 without brackets - leave unchanged just in case
+    if (std::count(address.begin(), address.end(), ':') > 1) {
+        return address;
+    }
+
+    // IPv4 with port: addr:port → addr
+    auto pos = address.rfind(':');
+    if (pos != TString::npos) {
+        return address.substr(0, pos);
+    }
+
+    return address;
+}
+
+// Append request address to X-Forwarded-For header
+// Useful for logging and audit
+TStringBuilder MakeXForwardedFor(const TProxiedRequestParams& params) {
+    NHttp::THeaders headers(params.Request->Headers);
+
+    TStringBuilder forwarded;
+    forwarded << headers.Get(X_FORWARDED_FOR_HEADER);
+    if (params.Request->Address) {
+        auto address = GetAddressWithoutPort(params.Request->Address->ToString());
+        if (!address.empty()) {
+            if (!forwarded.empty()) {
+                forwarded << ", ";
+            }
+            forwarded << address;
+        }
+    }
+    return forwarded;
+}
+
 NHttp::THttpOutgoingRequestPtr CreateProxiedRequest(const TProxiedRequestParams& params) {
     auto outRequest = NHttp::THttpOutgoingRequest::CreateRequest(params.Request->Method, params.ProtectedPage.Url);
-    NHttp::THeadersBuilder headers(params.Request->Headers);
+    NHttp::THeaders headers(params.Request->Headers);
     for (const auto& header : params.Settings.REQUEST_HEADERS_WHITE_LIST) {
         if (headers.Has(header)) {
             outRequest->Set(header, headers.Get(header));
@@ -275,6 +317,9 @@ NHttp::THttpOutgoingRequestPtr CreateProxiedRequest(const TProxiedRequestParams&
     if (!params.AuthHeader.empty()) {
         outRequest->Set(AUTHORIZATION_HEADER, params.AuthHeader);
     }
+
+    outRequest->Set(X_FORWARDED_FOR_HEADER, MakeXForwardedFor(params));
+
     if (params.Request->HaveBody()) {
         outRequest->SetBody(params.Request->Body);
     }

--- a/ydb/mvp/oidc_proxy/openid_connect.cpp
+++ b/ydb/mvp/oidc_proxy/openid_connect.cpp
@@ -287,7 +287,7 @@ TString GetAddressWithoutPort(const TString& address) {
 
 // Append request address to X-Forwarded-For header
 // Useful for logging and audit
-TStringBuilder MakeXForwardedFor(const TProxiedRequestParams& params) {
+TString MakeXForwardedFor(const TProxiedRequestParams& params) {
     NHttp::THeaders headers(params.Request->Headers);
 
     TStringBuilder forwarded;
@@ -301,7 +301,7 @@ TStringBuilder MakeXForwardedFor(const TProxiedRequestParams& params) {
             forwarded << address;
         }
     }
-    return forwarded;
+    return std::move(forwarded);
 }
 
 NHttp::THttpOutgoingRequestPtr CreateProxiedRequest(const TProxiedRequestParams& params) {

--- a/ydb/mvp/oidc_proxy/openid_connect.h
+++ b/ydb/mvp/oidc_proxy/openid_connect.h
@@ -20,6 +20,7 @@ struct TOpenIdConnectSettings;
 constexpr TStringBuf IAM_TOKEN_SCHEME = "Bearer ";
 constexpr TStringBuf IAM_TOKEN_SCHEME_LOWER = "bearer ";
 constexpr TStringBuf AUTHORIZATION_HEADER = "Authorization";
+constexpr TStringBuf X_FORWARDED_FOR_HEADER = "X-Forwarded-For";
 constexpr TStringBuf LOCATION_HEADER = "Location";
 
 constexpr TStringBuf USER_SID = "UserSID";
@@ -66,6 +67,7 @@ TRestoreOidcContextResult RestoreOidcContext(const NHttp::TCookies& cookies, con
 TCheckStateResult CheckState(const TString& state, const TString& key);
 TString DecodeToken(const TStringBuf& cookie);
 TStringBuf GetCookie(const NHttp::TCookies& cookies, const TString& cookieName);
+TString GetAddressWithoutPort(const TString& address);
 
 
 struct TProxiedRequestParams {


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

Add X-Forwarded-For http header to keep source address

### Changelog category <!-- remove all except one -->

* Improvement

### Description for reviewers <!-- (optional) description for those who read this PR -->

To support audit logging, it is necessary to provide a remote_addr field that contains the address of the user making the HTTP request.
Currently, the HTTP library does not supply the originator's address.

I’m goint to add the X-Forwarded-For header in the oidc_proxy. This header can then be used to populate the audit log.
