### PR TITLE
Enable Kafka API related feature flags

### DIFF
--- a/ydb/core/protos/feature_flags.proto
+++ b/ydb/core/protos/feature_flags.proto
@@ -198,9 +198,9 @@ message TFeatureFlags {
     optional bool EnableDataErasure = 172 [default = false];
     optional bool EnableShowCreate = 173 [default = false];
     optional bool EnableChangefeedsExport = 174 [default = false];
-    optional bool EnableKafkaNativeBalancing = 175 [default = false];
+    optional bool EnableKafkaNativeBalancing = 175 [default = true];
     optional bool EnableTabletRestartOnUnhandledExceptions = 176 [default = true];
-    optional bool EnableKafkaTransactions = 177 [default = false];
+    optional bool EnableKafkaTransactions = 177 [default = true];
     optional bool EnableLoginCache = 178 [default = false];
     optional bool SwitchToConfigV2 = 179 [default = false];
     optional bool SwitchToConfigV1 = 180 [default = false];


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

This PR sets to true by default these feature flags:
- EnableKafkaNativeBalancing - it enables kafka API users to rely on Kafka client-side consumer balancing protocol.
- EnableKafkaTransactions - it allows to use Kafka-transactions related methods

### Changelog category <!-- remove all except one -->

* Not for changelog (changelog entry is not required)

### Description for reviewers <!-- (optional) description for those who read this PR -->

...
