### PR TITLE
25-1: Use type-safe actor activity type

### DIFF
--- a/ydb/core/actorlib_impl/actor_activity_ut.cpp
+++ b/ydb/core/actorlib_impl/actor_activity_ut.cpp
@@ -29,7 +29,7 @@ Y_UNIT_TEST_SUITE(TActorActivity) {
 
     Y_UNIT_TEST(Basic) {
         TAutoPtr<IActor> actor = new TTestActor();
-        const ui32 activityIndex = actor->GetActivityType();
+        const ui32 activityIndex = actor->GetActivityType().GetIndex();
 
         UNIT_ASSERT_VALUES_EQUAL(TLocalProcessKeyState<TActorActivityTag>::GetInstance().GetIndexByName("ASYNC_DESTROYER"), activityIndex);
 

--- a/ydb/library/actors/core/actor.cpp
+++ b/ydb/library/actors/core/actor.cpp
@@ -542,3 +542,8 @@ namespace NActors {
         TlsActivationContext->ExecutorThread.SetOverwrittenTimePerMailboxTs(value);
     }
 }
+
+template <>
+void Out<NActors::TActorActivityType>(IOutputStream& o, const NActors::TActorActivityType& x) {
+    o << x.GetName();
+}

--- a/ydb/library/actors/core/actor.h
+++ b/ydb/library/actors/core/actor.h
@@ -353,6 +353,60 @@ namespace NActors {
         void DoActorInit() { LastUsageTimestamp = GetCycleCountFast(); }
     };
 
+    class TActorActivityType {
+    public:
+        TActorActivityType()
+            : TActorActivityType(FromEnum(EInternalActorType::OTHER))
+        {}
+
+        template <typename EEnum>
+        static TActorActivityType FromEnum(EEnum activityType) requires (std::is_enum_v<EEnum>) {
+            return FromIndex(TEnumProcessKey<TActorActivityTag, EEnum>::GetIndex(activityType));
+        }
+
+        static TActorActivityType FromName(TStringBuf activityName) {
+            return FromIndex(TLocalProcessKeyState<TActorActivityTag>::GetInstance().Register(activityName));
+        }
+
+        template <const char* Name>
+        static TActorActivityType FromStaticName() {
+            return FromIndex(TLocalProcessKey<TActorActivityTag, Name>::GetIndex());
+        }
+
+        template <typename T>
+        static TActorActivityType FromTypeName() {
+            // 200 characters is limit for solomon metric tag length
+            return FromIndex(TLocalProcessExtKey<TActorActivityTag, T, 200>::GetIndex());
+        }
+
+        static constexpr TActorActivityType FromIndex(size_t index) {
+            return TActorActivityType(index);
+        }
+
+        constexpr ui32 GetIndex() const {
+            return Index;
+        }
+
+        TStringBuf GetName() const {
+            return TLocalProcessKeyState<TActorActivityTag>::GetInstance().GetNameByIndex(Index);
+        }
+
+        friend constexpr bool operator==(TActorActivityType a, TActorActivityType b) = default;
+
+        template <typename EEnum>
+        friend bool operator==(TActorActivityType a, EEnum b) requires (std::is_enum_v<EEnum>) {
+            return a == FromEnum(b);
+        }
+
+    private:
+        explicit constexpr TActorActivityType(ui32 index)
+            : Index(index)
+        {}
+
+    private:
+        ui32 Index;
+    };
+
     class IActor
         : protected IActorOps
         , public TActorUsageImpl<ActorLibCollectUsageStats>
@@ -374,13 +428,6 @@ namespace NActors {
         friend class TExecutorPoolBaseMailboxed;
         friend class TExecutorThread;
 
-        IActor(const ui32 activityType)
-            : SelfActorId(TActorId())
-            , ElapsedTicks(0)
-            , ActivityType(activityType)
-            , HandledEvents(0) {
-        }
-
     protected:
         TActorCallbackBehaviour CImpl;
     public:
@@ -389,29 +436,34 @@ namespace NActors {
         /// @sa services.proto NKikimrServices::TActivity::EType
         using EActorActivity = EInternalActorType;
         using EActivityType = EActorActivity;
-        ui32 ActivityType;
+        TActorActivityType ActivityType;
 
     protected:
         ui64 HandledEvents;
 
-        template <typename EEnum = EActivityType, typename std::enable_if<std::is_enum<EEnum>::value, bool>::type v = true>
-        IActor(const EEnum activityEnumType = EActivityType::OTHER)
-            : IActor(TEnumProcessKey<TActorActivityTag, EEnum>::GetIndex(activityEnumType)) {
-        }
+        IActor(TActorActivityType activityType = {})
+            : SelfActorId(TActorId())
+            , ElapsedTicks(0)
+            , ActivityType(activityType)
+            , HandledEvents(0)
+        {}
 
-        IActor(TActorCallbackBehaviour&& cImpl, const ui32 activityType)
+        IActor(TActorCallbackBehaviour&& cImpl, TActorActivityType activityType = {})
             : SelfActorId(TActorId())
             , ElapsedTicks(0)
             , CImpl(std::move(cImpl))
             , ActivityType(activityType)
             , HandledEvents(0)
-        {
-        }
+        {}
 
-        template <typename EEnum = EActivityType, typename std::enable_if<std::is_enum<EEnum>::value, bool>::type v = true>
-        IActor(TActorCallbackBehaviour&& cImpl, const EEnum activityEnumType = EActivityType::OTHER)
-            : IActor(std::move(cImpl), TEnumProcessKey<TActorActivityTag, EEnum>::GetIndex(activityEnumType)) {
-        }
+        template <typename EEnum>
+        IActor(TActorCallbackBehaviour&& cImpl, EEnum activityType) requires (std::is_enum_v<EEnum>)
+            : IActor(std::move(cImpl), TActorActivityType::FromEnum(activityType))
+        {}
+
+        IActor(TActorCallbackBehaviour&& cImpl, TStringBuf activityName)
+            : IActor(std::move(cImpl), TActorActivityType::FromName(activityName))
+        {}
 
     public:
         template <class TEventBase>
@@ -463,8 +515,17 @@ namespace NActors {
         virtual void PassAway();
 
     protected:
-        void SetActivityType(ui32 activityType) {
+        void SetActivityType(TActorActivityType activityType) {
             ActivityType = activityType;
+        }
+
+        template <typename EEnum>
+        void SetActivityType(EEnum activityType) requires (std::is_enum_v<EEnum>) {
+            ActivityType = TActorActivityType::FromEnum(activityType);
+        }
+
+        void SetActivityType(TStringBuf activityName) {
+            ActivityType = TActorActivityType::FromName(activityName);
         }
 
     public:
@@ -531,7 +592,7 @@ namespace NActors {
         void AddElapsedTicks(i64 ticks) {
             ElapsedTicks += ticks;
         }
-        ui32 GetActivityType() const {
+        TActorActivityType GetActivityType() const {
             return ActivityType;
         }
         ui64 GetHandledEvents() const {
@@ -639,18 +700,20 @@ namespace NActors {
         return TLocalProcessKeyState<TActorActivityTag>::GetInstance().GetNameByIndex(index);
     }
 
+    inline TStringBuf GetActivityTypeName(TActorActivityType activityType) {
+        return activityType.GetName();
+    }
+
     class IActorCallback: public IActor {
     protected:
-        template <class TEnum = IActor::EActivityType>
-        IActorCallback(TReceiveFunc stateFunc, const TEnum activityType = IActor::EActivityType::OTHER)
-            : IActor(TActorCallbackBehaviour(stateFunc), activityType) {
+        IActorCallback(TReceiveFunc stateFunc)
+            : IActor(TActorCallbackBehaviour(stateFunc))
+        {}
 
-        }
-
-        IActorCallback(TReceiveFunc stateFunc, const ui32 activityType)
-            : IActor(TActorCallbackBehaviour(stateFunc), activityType) {
-
-        }
+        template <typename T>
+        IActorCallback(TReceiveFunc stateFunc, T&& activityType)
+            : IActor(TActorCallbackBehaviour(stateFunc), std::forward<T>(activityType))
+        {}
 
     public:
         template <typename T>
@@ -679,31 +742,18 @@ namespace NActors {
     private:
         using TDerivedReceiveFunc = void (TDerived::*)(TAutoPtr<IEventHandle>& ev);
 
-        template <typename T, typename = const char*>
-        struct HasActorName: std::false_type {};
-        template <typename T>
-        struct HasActorName<T, decltype((void)T::ActorName, (const char*)nullptr)>: std::true_type {};
-
-        template <typename T, typename = const char*>
-        struct HasActorActivityType: std::false_type {};
-        template <typename T>
-        struct HasActorActivityType<T, decltype((void)T::ActorActivityType, (const char*)nullptr)>: std::true_type {};
-
-        static ui32 GetActivityTypeIndexImpl() {
-            if constexpr(HasActorName<TDerived>::value) {
-                return TLocalProcessKey<TActorActivityTag, TDerived::ActorName>::GetIndex();
-            } else if constexpr (HasActorActivityType<TDerived>::value) {
-                using TActorActivity = decltype(((TDerived*)nullptr)->ActorActivityType());
-                static_assert(std::is_enum<TActorActivity>::value);
-                return TEnumProcessKey<TActorActivityTag, TActorActivity>::GetIndex(TDerived::ActorActivityType());
+        static TActorActivityType GetDefaultActivityTypeImpl() {
+            if constexpr (requires { TDerived::ActorName; }) {
+                return TActorActivityType::FromStaticName<TDerived::ActorName>();
+            } else if constexpr (requires { TDerived::ActorActivityType; }) {
+                return TActorActivityType::FromEnum(TDerived::ActorActivityType());
             } else {
-                // 200 characters is limit for solomon metric tag length
-                return TLocalProcessExtKey<TActorActivityTag, TDerived, 200>::GetIndex();
+                return TActorActivityType::FromTypeName<TDerived>();
             }
         }
 
-        static ui32 GetActivityTypeIndex() {
-            static const ui32 result = GetActivityTypeIndexImpl();
+        static TActorActivityType GetDefaultActivityType() {
+            static const TActorActivityType result = GetDefaultActivityTypeImpl();
             return result;
         }
 
@@ -711,17 +761,13 @@ namespace NActors {
         // static constexpr char ActorName[] = "UNNAMED";
 
         TActor(TDerivedReceiveFunc func)
-            : IActorCallback(static_cast<TReceiveFunc>(func), GetActivityTypeIndex()) {
-        }
+            : IActorCallback(static_cast<TReceiveFunc>(func), GetDefaultActivityType())
+        {}
 
-        template <class TEnum = EActivityType>
-        TActor(TDerivedReceiveFunc func, const TEnum activityEnumType = EActivityType::OTHER)
-            : IActorCallback(static_cast<TReceiveFunc>(func), activityEnumType) {
-        }
-
-        TActor(TDerivedReceiveFunc func, const TString& actorName)
-            : IActorCallback(static_cast<TReceiveFunc>(func), TLocalProcessKeyState<TActorActivityTag>::GetInstance().Register(actorName)) {
-        }
+        template <typename T>
+        TActor(TDerivedReceiveFunc func, T&& activityType)
+            : IActorCallback(static_cast<TReceiveFunc>(func), std::forward<T>(activityType))
+        {}
 
     public:
         typedef TDerived TThis;

--- a/ydb/library/actors/core/actor_bootstrapped.h
+++ b/ydb/library/actors/core/actor_bootstrapped.h
@@ -35,13 +35,9 @@ namespace NActors {
             : TActor<TDerived>(&TDerived::StateBootstrap) {
         }
 
-        template <class TEnum>
-        TActorBootstrapped(const TEnum activityType)
-            : TActor<TDerived>(&TDerived::StateBootstrap, activityType) {
-        }
-
-        TActorBootstrapped(const TString& activityName)
-            : TActor<TDerived>(&TDerived::StateBootstrap, activityName) {
+        template <typename T>
+        TActorBootstrapped(T&& activityType)
+            : TActor<TDerived>(&TDerived::StateBootstrap, std::forward<T>(activityType)) {
         }
     };
 }

--- a/ydb/library/actors/core/executor_pool_base.cpp
+++ b/ydb/library/actors/core/executor_pool_base.cpp
@@ -56,9 +56,9 @@ namespace NActors {
                 Y_ABORT_UNLESS(actor->StuckIndex == i);
                 const TDuration delta = now - actor->LastReceiveTimestamp;
                 if (delta > TDuration::Seconds(30)) {
-                    ++stats.StuckActorsByActivity[actor->GetActivityType()];
+                    ++stats.StuckActorsByActivity[actor->GetActivityType().GetIndex()];
                 }
-                accountUsage(actor->GetActivityType(), actor->GetUsage(GetCycleCountFast()));
+                accountUsage(actor->GetActivityType().GetIndex(), actor->GetUsage(GetCycleCountFast()));
             }
             for (const auto& [activityType, usage] : DeadActorsUsage) {
                 accountUsage(activityType, usage);
@@ -188,7 +188,7 @@ namespace NActors {
         NHPTimer::STime hpstart = GetCycleCountFast();
         TInternalActorTypeGuard<EInternalActorSystemActivity::ACTOR_SYSTEM_REGISTER, false> activityGuard(hpstart);
 #ifdef ACTORSLIB_COLLECT_EXEC_STATS
-        ui32 at = actor->GetActivityType();
+        ui32 at = actor->GetActivityType().GetIndex();
         Y_DEBUG_ABORT_UNLESS(at < Stats.ActorsAliveByActivity.size());
         if (at >= Stats.MaxActivityType()) {
             at = TActorTypeOperator::GetActorActivityIncorrectIndex();
@@ -236,7 +236,7 @@ namespace NActors {
         NHPTimer::STime hpstart = GetCycleCountFast();
         TInternalActorTypeGuard<EInternalActorSystemActivity::ACTOR_SYSTEM_REGISTER, false> activityGuard(hpstart);
 #ifdef ACTORSLIB_COLLECT_EXEC_STATS
-        ui32 at = actor->GetActivityType();
+        ui32 at = actor->GetActivityType().GetIndex();
         if (at >= Stats.MaxActivityType())
             at = 0;
         AtomicIncrement(Stats.ActorsAliveByActivity[at]);

--- a/ydb/library/actors/core/executor_thread.cpp
+++ b/ydb/library/actors/core/executor_thread.cpp
@@ -88,7 +88,7 @@ namespace NActors {
     void TExecutorThread::UnregisterActor(TMailbox* mailbox, TActorId actorId) {
         Y_DEBUG_ABORT_UNLESS(actorId.PoolID() == ThreadCtx.PoolId() && ThreadCtx.Pool()->ResolveMailbox(actorId.Hint()) == mailbox);
         IActor* actor = mailbox->DetachActor(actorId.LocalId());
-        ExecutionStats.DecrementActorsAliveByActivity(actor->GetActivityType());
+        ExecutionStats.DecrementActorsAliveByActivity(actor->GetActivityType().GetIndex());
         DyingActors.push_back(THolder(actor));
     }
 
@@ -103,7 +103,7 @@ namespace NActors {
                         actorPtr = pool->Actors.back();
                         actorPtr->StuckIndex = i;
                         pool->Actors.pop_back();
-                        pool->DeadActorsUsage.emplace_back(actor->GetActivityType(), actor->GetUsage(GetCycleCountFast()));
+                        pool->DeadActorsUsage.emplace_back(actor->GetActivityType().GetIndex(), actor->GetUsage(GetCycleCountFast()));
                     }
                 }
             }
@@ -259,7 +259,7 @@ namespace NActors {
 
                     ui32 evTypeForTracing = ev->Type;
 
-                    ui32 activityType = actor->GetActivityType();
+                    ui32 activityType = actor->GetActivityType().GetIndex();
                     if (activityType != prevActivityType) {
                         prevActivityType = activityType;
                         NProfiling::TMemoryTagScope::Reset(activityType);

--- a/ydb/library/actors/core/ut/actor_ut.cpp
+++ b/ydb/library/actors/core/ut/actor_ut.cpp
@@ -570,7 +570,7 @@ Y_UNIT_TEST_SUITE(TestDecorator) {
 
         void Bootstrap()
         {
-            const auto& activityTypeIndex = GetActivityType();
+            auto activityTypeIndex = GetActivityType().GetIndex();
             Y_ENSURE(activityTypeIndex < GetActivityTypeCount());
             Y_ENSURE(GetActivityTypeName(activityTypeIndex) == "TestActor");
             PassAway();

--- a/ydb/library/actors/testlib/test_runtime.cpp
+++ b/ydb/library/actors/testlib/test_runtime.cpp
@@ -1599,7 +1599,7 @@ namespace NActors {
         if (!actor) {
             return {};
         }
-        return TLocalProcessKeyState<TActorActivityTag>::GetInstance().GetNameByIndex(actor->GetActivityType());
+        return actor->GetActivityType().GetName();
     }
 
     void TTestActorRuntimeBase::EnableScheduleForActor(const TActorId& actorId, bool allow) {

--- a/ydb/library/yql/dq/actors/compute/dq_compute_actor_channels.cpp
+++ b/ydb/library/yql/dq/actors/compute/dq_compute_actor_channels.cpp
@@ -40,7 +40,7 @@ TString InFlightMessagesStr(const TCollection& inFlight) {
 } // anonymous namespace
 
 TDqComputeActorChannels::TDqComputeActorChannels(TActorId owner, const TTxId& txId, const TDqTaskSettings& task,
-    bool retryOnUndelivery, NDqProto::EDqStatsMode statsMode, ui64 channelBufferSize, ICallbacks* cbs, ui32 actorActivityType)
+    bool retryOnUndelivery, NDqProto::EDqStatsMode statsMode, ui64 channelBufferSize, ICallbacks* cbs, NActors::TActorActivityType actorActivityType)
     : TActor(&TDqComputeActorChannels::WorkState, actorActivityType)
     , Owner(owner)
     , TxId(txId)

--- a/ydb/library/yql/dq/actors/compute/dq_compute_actor_channels.h
+++ b/ydb/library/yql/dq/actors/compute/dq_compute_actor_channels.h
@@ -83,7 +83,7 @@ public:
 
 public:
     TDqComputeActorChannels(NActors::TActorId owner, const TTxId& txId, const TDqTaskSettings& task, bool retryOnUndelivery,
-        NDqProto::EDqStatsMode statsMode, ui64 channelBufferSize, ICallbacks* cbs, ui32 actorActivityType);
+        NDqProto::EDqStatsMode statsMode, ui64 channelBufferSize, ICallbacks* cbs, NActors::TActorActivityType actorActivityType);
 
 private:
     STATEFN(WorkState);

--- a/ydb/library/yql/dq/actors/compute/ut/dq_compute_actor_ut.cpp
+++ b/ydb/library/yql/dq/actors/compute/ut/dq_compute_actor_ut.cpp
@@ -68,7 +68,7 @@ struct TChannelsTestFixture: public NUnitTest::TBaseFixture
             NYql::NDqProto::EDqStatsMode::DQ_STATS_MODE_NONE,
             /*channelBufferSize = */ 1000000,
             /*callbacks = */ &Callbacks,
-            /*activityType = */ 0
+            /*activityType = */ {}
         ));
         channels->InputChannelsMap.emplace((ui64)0, TDqComputeActorChannels::TInputChannelState {});
         InputChannel = &channels->InCh(0);


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

...

### Changelog category <!-- remove all except one -->

* Not for changelog (changelog entry is not required)

### Description for reviewers <!-- (optional) description for those who read this PR -->

We often use protobuf enums as actor activity types, while using dynamically generated array indexes internally. Unfortunately we still accepted raw indexes in SetActivityType, with protobuf enums silently converting into these array indexes, causing incorrect activity attribution (since protobuf value does not equal its activity array index). Start using a type-safe class which wraps array indexes, and correctly convert from enums and/or strings where it's allowed.

Fixes #18286.
Merges #18291.