### PR TITLE
24-4: Use type-safe actor activity type

### DIFF
--- a/ydb/core/actorlib_impl/actor_activity_ut.cpp
+++ b/ydb/core/actorlib_impl/actor_activity_ut.cpp
@@ -29,7 +29,7 @@ Y_UNIT_TEST_SUITE(TActorActivity) {
 
     Y_UNIT_TEST(Basic) {
         TAutoPtr<IActor> actor = new TTestActor();
-        const ui32 activityIndex = actor->GetActivityType();
+        const ui32 activityIndex = actor->GetActivityType().GetIndex();
 
         UNIT_ASSERT_VALUES_EQUAL(TLocalProcessKeyState<TActorActivityTag>::GetInstance().GetIndexByName("ASYNC_DESTROYER"), activityIndex);
 

--- a/ydb/library/actors/core/actor.cpp
+++ b/ydb/library/actors/core/actor.cpp
@@ -497,3 +497,8 @@ namespace NActors {
         }
     }
 }
+
+template <>
+void Out<NActors::TActorActivityType>(IOutputStream& o, const NActors::TActorActivityType& x) {
+    o << x.GetName();
+}

--- a/ydb/library/actors/core/actor_bootstrapped.h
+++ b/ydb/library/actors/core/actor_bootstrapped.h
@@ -36,13 +36,9 @@ namespace NActors {
             : TActor<TDerived>(&TDerived::StateBootstrap) {
         }
 
-        template <class TEnum>
-        TActorBootstrapped(const TEnum activityType)
-            : TActor<TDerived>(&TDerived::StateBootstrap, activityType) {
-        }
-
-        TActorBootstrapped(const TString& activityName)
-            : TActor<TDerived>(&TDerived::StateBootstrap, activityName) {
+        template <typename T>
+        TActorBootstrapped(T&& activityType)
+            : TActor<TDerived>(&TDerived::StateBootstrap, std::forward<T>(activityType)) {
         }
     };
 }

--- a/ydb/library/actors/core/actor_ut.cpp
+++ b/ydb/library/actors/core/actor_ut.cpp
@@ -483,7 +483,7 @@ Y_UNIT_TEST_SUITE(TestDecorator) {
 
         void Bootstrap()
         {
-            const auto& activityTypeIndex = GetActivityType();
+            auto activityTypeIndex = GetActivityType().GetIndex();
             Y_ENSURE(activityTypeIndex < GetActivityTypeCount());
             Y_ENSURE(GetActivityTypeName(activityTypeIndex) == "TestActor");
             PassAway();

--- a/ydb/library/actors/core/executor_pool_base.cpp
+++ b/ydb/library/actors/core/executor_pool_base.cpp
@@ -53,9 +53,9 @@ namespace NActors {
                 Y_ABORT_UNLESS(actor->StuckIndex == i);
                 const TDuration delta = now - actor->LastReceiveTimestamp;
                 if (delta > TDuration::Seconds(30)) {
-                    ++stats.StuckActorsByActivity[actor->GetActivityType()];
+                    ++stats.StuckActorsByActivity[actor->GetActivityType().GetIndex()];
                 }
-                accountUsage(actor->GetActivityType(), actor->GetUsage(GetCycleCountFast()));
+                accountUsage(actor->GetActivityType().GetIndex(), actor->GetUsage(GetCycleCountFast()));
             }
             for (const auto& [activityType, usage] : DeadActorsUsage) {
                 accountUsage(activityType, usage);
@@ -154,7 +154,7 @@ namespace NActors {
         NHPTimer::STime hpstart = GetCycleCountFast();
         TInternalActorTypeGuard<EInternalActorSystemActivity::ACTOR_SYSTEM_REGISTER, false> activityGuard(hpstart);
 #ifdef ACTORSLIB_COLLECT_EXEC_STATS
-        ui32 at = actor->GetActivityType();
+        ui32 at = actor->GetActivityType().GetIndex();
         Y_DEBUG_ABORT_UNLESS(at < Stats.ActorsAliveByActivity.size());
         if (at >= Stats.MaxActivityType()) {
             at = TActorTypeOperator::GetActorActivityIncorrectIndex();
@@ -242,7 +242,7 @@ namespace NActors {
         NHPTimer::STime hpstart = GetCycleCountFast();
         TInternalActorTypeGuard<EInternalActorSystemActivity::ACTOR_SYSTEM_REGISTER, false> activityGuard(hpstart);
 #ifdef ACTORSLIB_COLLECT_EXEC_STATS
-        ui32 at = actor->GetActivityType();
+        ui32 at = actor->GetActivityType().GetIndex();
         if (at >= Stats.MaxActivityType())
             at = 0;
         AtomicIncrement(Stats.ActorsAliveByActivity[at]);

--- a/ydb/library/actors/core/executor_thread.cpp
+++ b/ydb/library/actors/core/executor_thread.cpp
@@ -107,7 +107,7 @@ namespace NActors {
     void TGenericExecutorThread::UnregisterActor(TMailboxHeader* mailbox, TActorId actorId) {
         Y_DEBUG_ABORT_UNLESS(actorId.PoolID() == ExecutorPool->PoolId && ExecutorPool->ResolveMailbox(actorId.Hint()) == mailbox);
         IActor* actor = mailbox->DetachActor(actorId.LocalId());
-        Ctx.DecrementActorsAliveByActivity(actor->GetActivityType());
+        Ctx.DecrementActorsAliveByActivity(actor->GetActivityType().GetIndex());
         DyingActors.push_back(THolder(actor));
     }
 
@@ -122,7 +122,7 @@ namespace NActors {
                         actorPtr = pool->Actors.back();
                         actorPtr->StuckIndex = i;
                         pool->Actors.pop_back();
-                        pool->DeadActorsUsage.emplace_back(actor->GetActivityType(), actor->GetUsage(GetCycleCountFast()));
+                        pool->DeadActorsUsage.emplace_back(actor->GetActivityType().GetIndex(), actor->GetUsage(GetCycleCountFast()));
                     }
                 }
             }
@@ -241,7 +241,7 @@ namespace NActors {
 
                     ui32 evTypeForTracing = ev->Type;
 
-                    ui32 activityType = actor->GetActivityType();
+                    ui32 activityType = actor->GetActivityType().GetIndex();
                     if (activityType != prevActivityType) {
                         prevActivityType = activityType;
                         NProfiling::TMemoryTagScope::Reset(activityType);

--- a/ydb/library/actors/helpers/flow_controlled_queue.cpp
+++ b/ydb/library/actors/helpers/flow_controlled_queue.cpp
@@ -23,7 +23,7 @@ public:
     const ui32 Flags;
     const ui64 StartCounter;
 
-    TFlowControlledRequestActor(ui32 activity, TFlowControlledRequestQueue *queue, TActorId source, ui64 cookie, ui32 flags)
+    TFlowControlledRequestActor(TActorActivityType activity, TFlowControlledRequestQueue *queue, TActorId source, ui64 cookie, ui32 flags)
         : IActorCallback(static_cast<TReceiveFunc>(&TFlowControlledRequestActor::StateWait), activity)
         , QueueActor(queue)
         , Source(source)

--- a/ydb/library/actors/testlib/test_runtime.cpp
+++ b/ydb/library/actors/testlib/test_runtime.cpp
@@ -1591,7 +1591,7 @@ namespace NActors {
         if (!actor) {
             return {};
         }
-        return TLocalProcessKeyState<TActorActivityTag>::GetInstance().GetNameByIndex(actor->GetActivityType());
+        return actor->GetActivityType().GetName();
     }
 
     void TTestActorRuntimeBase::EnableScheduleForActor(const TActorId& actorId, bool allow) {

--- a/ydb/library/yql/dq/actors/compute/dq_compute_actor_channels.cpp
+++ b/ydb/library/yql/dq/actors/compute/dq_compute_actor_channels.cpp
@@ -39,7 +39,7 @@ TString InFlightMessagesStr(const TCollection& inFlight) {
 } // anonymous namespace
 
 TDqComputeActorChannels::TDqComputeActorChannels(TActorId owner, const TTxId& txId, const TDqTaskSettings& task,
-    bool retryOnUndelivery, NDqProto::EDqStatsMode statsMode, ui64 channelBufferSize, ICallbacks* cbs, ui32 actorActivityType)
+    bool retryOnUndelivery, NDqProto::EDqStatsMode statsMode, ui64 channelBufferSize, ICallbacks* cbs, NActors::TActorActivityType actorActivityType)
     : TActor(&TDqComputeActorChannels::WorkState, actorActivityType)
     , Owner(owner)
     , TxId(txId)

--- a/ydb/library/yql/dq/actors/compute/dq_compute_actor_channels.h
+++ b/ydb/library/yql/dq/actors/compute/dq_compute_actor_channels.h
@@ -83,7 +83,7 @@ public:
 
 public:
     TDqComputeActorChannels(NActors::TActorId owner, const TTxId& txId, const TDqTaskSettings& task, bool retryOnUndelivery,
-        NDqProto::EDqStatsMode statsMode, ui64 channelBufferSize, ICallbacks* cbs, ui32 actorActivityType);
+        NDqProto::EDqStatsMode statsMode, ui64 channelBufferSize, ICallbacks* cbs, NActors::TActorActivityType actorActivityType);
 
 private:
     STATEFN(WorkState);

--- a/ydb/library/yql/dq/actors/compute/ut/dq_compute_actor_ut.cpp
+++ b/ydb/library/yql/dq/actors/compute/ut/dq_compute_actor_ut.cpp
@@ -68,7 +68,7 @@ struct TChannelsTestFixture: public NUnitTest::TBaseFixture
             NYql::NDqProto::EDqStatsMode::DQ_STATS_MODE_NONE,
             /*channelBufferSize = */ 1000000,
             /*callbacks = */ &Callbacks,
-            /*activityType = */ 0
+            /*activityType = */ {}
         ));
         channels->InputChannelsMap.emplace((ui64)0, TDqComputeActorChannels::TInputChannelState {});
         InputChannel = &channels->InCh(0);


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

...

### Changelog category <!-- remove all except one -->

* Not for changelog (changelog entry is not required)

### Description for reviewers <!-- (optional) description for those who read this PR -->

We often use protobuf enums as actor activity types, while using dynamically generated array indexes internally. Unfortunately we still accepted raw indexes in SetActivityType, with protobuf enums silently converting into these array indexes, causing incorrect activity attribution (since protobuf value does not equal its activity array index). Start using a type-safe class which wraps array indexes, and correctly convert from enums and/or strings where it's allowed.

Fixes #18286.
Merges #18291.