### PR TITLE
YQL-19995: Pass serialization flag

### DIFF
--- a/ydb/core/fq/libs/row_dispatcher/format_handler/format_handler.cpp
+++ b/ydb/core/fq/libs/row_dispatcher/format_handler/format_handler.cpp
@@ -261,7 +261,7 @@ private:
 
             with_lock(Self.Alloc) {
                 const auto rowType = Self.ProgramBuilder->NewMultiType(columnTypes);
-                DataPacker = std::make_unique<NKikimr::NMiniKQL::TValuePackerTransport<true>>(rowType);
+                DataPacker = std::make_unique<NKikimr::NMiniKQL::TValuePackerTransport<true>>(rowType, NKikimr::NMiniKQL::EValuePackerVersion::V0);
             }
             return TStatus::Success();
         }

--- a/ydb/core/fq/libs/row_dispatcher/format_handler/ut/common/ut_common.cpp
+++ b/ydb/core/fq/libs/row_dispatcher/format_handler/ut/common/ut_common.cpp
@@ -207,7 +207,7 @@ void TBaseFixture::CheckMessageBatch(TRope serializedBatch, const TBatch& expect
     with_lock(Alloc) {
         // Parse messages
         const auto rowType = ProgramBuilder->NewMultiType(columnTypes);
-        const auto dataUnpacker = std::make_unique<NKikimr::NMiniKQL::TValuePackerTransport<true>>(rowType);
+        const auto dataUnpacker = std::make_unique<NKikimr::NMiniKQL::TValuePackerTransport<true>>(rowType, NKikimr::NMiniKQL::EValuePackerVersion::V0);
 
         NKikimr::NMiniKQL::TUnboxedValueBatch parsedData(rowType);
         dataUnpacker->UnpackBatch(NYql::MakeChunkedBuffer(std::move(serializedBatch)), *HolderFactory, parsedData);

--- a/ydb/core/kqp/executer_actor/kqp_executer_impl.cpp
+++ b/ydb/core/kqp/executer_actor/kqp_executer_impl.cpp
@@ -42,7 +42,7 @@ void TEvKqpExecuter::TEvTxResponse::TakeResult(ui32 idx, NDq::TDqSerializedBatch
     if (rows.RowCount()) {
         NDq::TDqDataSerializer dataSerializer(
             AllocState->TypeEnv, AllocState->HolderFactory,
-            static_cast<NDqProto::EDataTransportVersion>(rows.Proto.GetTransportVersion()));
+            static_cast<NDqProto::EDataTransportVersion>(rows.Proto.GetTransportVersion()), NDq::FromProto(rows.Proto.GetValuePackerVersion()));
         dataSerializer.Deserialize(std::move(rows), result.MkqlItemType, result.Rows);
     }
 }

--- a/ydb/core/kqp/query_data/kqp_query_data.cpp
+++ b/ydb/core/kqp/query_data/kqp_query_data.cpp
@@ -439,7 +439,7 @@ NDqProto::TData TQueryData::GetShardParam(ui64 shardId, const TString& name) {
     }
 
     auto guard = TypeEnv().BindAllocator();
-    NDq::TDqDataSerializer dataSerializer{AllocState->TypeEnv, AllocState->HolderFactory, NDqProto::EDataTransportVersion::DATA_TRANSPORT_UV_PICKLE_1_0};
+    NDq::TDqDataSerializer dataSerializer{AllocState->TypeEnv, AllocState->HolderFactory, NDqProto::EDataTransportVersion::DATA_TRANSPORT_UV_PICKLE_1_0, EValuePackerVersion::V0};
     NDq::TDqSerializedBatch batch = dataSerializer.Serialize(it->second.Values.begin(), it->second.Values.end(), it->second.ItemType);
     YQL_ENSURE(!batch.IsOOB());
     return batch.Proto;

--- a/ydb/core/kqp/runtime/kqp_transport.cpp
+++ b/ydb/core/kqp/runtime/kqp_transport.cpp
@@ -70,10 +70,12 @@ void TKqpProtoBuilder::BuildYdbResultSet(
     }
 
     auto transportVersion = NDqProto::EDataTransportVersion::DATA_TRANSPORT_VERSION_UNSPECIFIED;
+    auto valuePackerVersion = NMiniKQL::EValuePackerVersion::V0;
     if (!data.empty()) {
         transportVersion = static_cast<NDqProto::EDataTransportVersion>(data.front().Proto.GetTransportVersion());
+        valuePackerVersion = NDq::FromProto(data.front().Proto.GetValuePackerVersion());
     }
-    NDq::TDqDataSerializer dataSerializer(*TypeEnv, *HolderFactory, transportVersion);
+    NDq::TDqDataSerializer dataSerializer(*TypeEnv, *HolderFactory, transportVersion, valuePackerVersion);
     for (auto& part : data) {
         if (part.ChunkCount()) {
             TUnboxedValueBatch rows(mkqlSrcRowType);

--- a/ydb/library/yql/dq/actors/compute/ut/dq_async_compute_actor_ut.cpp
+++ b/ydb/library/yql/dq/actors/compute/ut/dq_async_compute_actor_ut.cpp
@@ -386,7 +386,15 @@ struct TAsyncCATestFixture: public NUnitTest::TBaseFixture {
         // DstEndpoint
         // IsPersistent
         // EnableSpilling
-        return CreateDqInputChannel(channelId, ThisStageId, type, 10_MB, TCollectStatsLevel::None, TypeEnv, HolderFactory, TransportVersion);
+        return CreateDqInputChannel(channelId,
+                                    ThisStageId,
+                                    type,
+                                    10_MB,
+                                    TCollectStatsLevel::None,
+                                    TypeEnv,
+                                    HolderFactory,
+                                    TransportVersion,
+                                    NKikimr::NMiniKQL::EValuePackerVersion::V0);
     }
 
     auto CreateTestAsyncCA(NDqProto::TDqTask& task) {

--- a/ydb/library/yql/dq/proto/dq_tasks.proto
+++ b/ydb/library/yql/dq/proto/dq_tasks.proto
@@ -232,4 +232,5 @@ message TDqTask {
     optional uint32 ArrayBufferMinFillPercentage = 20;
     optional bool DisableMetering = 22;
     optional uint64 BufferPageAllocSize = 23;
+    EValuePackerVersion ValuePackerVersion = 24;
 }

--- a/ydb/library/yql/dq/proto/dq_transport.proto
+++ b/ydb/library/yql/dq/proto/dq_transport.proto
@@ -13,10 +13,17 @@ enum EDataTransportVersion {
     DATA_TRANSPORT_OOB_FAST_PICKLE_1_0 = 60000;
 }
 
+enum EValuePackerVersion {
+    VALUE_PACKER_VERSION_UNSPECIFIED = 0;
+    VALUE_PACKER_VERSION_V0 = 1;
+    VALUE_PACKER_VERSION_V1 = 2;
+}
+
 message TData {
     uint32 TransportVersion = 1;
     bytes Raw = 2;
     uint32 Chunks = 3;
     optional uint32 PayloadId = 4;
     uint32 Rows = 5;
+    EValuePackerVersion ValuePackerVersion = 6;
 }

--- a/ydb/library/yql/dq/runtime/dq_input_channel.cpp
+++ b/ydb/library/yql/dq/runtime/dq_input_channel.cpp
@@ -74,9 +74,9 @@ private:
 public:
     TDqInputChannel(ui64 channelId, ui32 srcStageId, NKikimr::NMiniKQL::TType* inputType, ui64 maxBufferBytes, TCollectStatsLevel level,
         const NKikimr::NMiniKQL::TTypeEnvironment& typeEnv, const NKikimr::NMiniKQL::THolderFactory& holderFactory,
-        NDqProto::EDataTransportVersion transportVersion)
+        NDqProto::EDataTransportVersion transportVersion, NKikimr::NMiniKQL::EValuePackerVersion packerVersion)
         : Impl(channelId, srcStageId, inputType, maxBufferBytes, level)
-        , DataSerializer(typeEnv, holderFactory, transportVersion) {
+        , DataSerializer(typeEnv, holderFactory, transportVersion, packerVersion) {
     }
 
     ui64 GetChannelId() const override {
@@ -165,11 +165,11 @@ private:
 };
 
 IDqInputChannel::TPtr CreateDqInputChannel(ui64 channelId, ui32 srcStageId, NKikimr::NMiniKQL::TType* inputType, ui64 maxBufferBytes,
-    TCollectStatsLevel level, const NKikimr::NMiniKQL::TTypeEnvironment& typeEnv,
-    const NKikimr::NMiniKQL::THolderFactory& holderFactory, NDqProto::EDataTransportVersion transportVersion)
+                                           TCollectStatsLevel level, const NKikimr::NMiniKQL::TTypeEnvironment& typeEnv,
+                                           const NKikimr::NMiniKQL::THolderFactory& holderFactory, NDqProto::EDataTransportVersion transportVersion, NKikimr::NMiniKQL::EValuePackerVersion packerVersion)
 {
     return new TDqInputChannel(channelId, srcStageId, inputType, maxBufferBytes, level, typeEnv, holderFactory,
-        transportVersion);
+        transportVersion, packerVersion);
 }
 
 } // namespace NYql::NDq

--- a/ydb/library/yql/dq/runtime/dq_input_channel.h
+++ b/ydb/library/yql/dq/runtime/dq_input_channel.h
@@ -30,6 +30,6 @@ public:
 
 IDqInputChannel::TPtr CreateDqInputChannel(ui64 channelId, ui32 srcStageId, NKikimr::NMiniKQL::TType* inputType, ui64 maxBufferBytes,
     TCollectStatsLevel level, const NKikimr::NMiniKQL::TTypeEnvironment& typeEnv,
-    const NKikimr::NMiniKQL::THolderFactory& holderFactory, NDqProto::EDataTransportVersion transportVersion);
+    const NKikimr::NMiniKQL::THolderFactory& holderFactory, NDqProto::EDataTransportVersion transportVersion, NKikimr::NMiniKQL::EValuePackerVersion packerVersion);
 
 } // namespace NYql::NDq

--- a/ydb/library/yql/dq/runtime/dq_output_channel.cpp
+++ b/ydb/library/yql/dq/runtime/dq_output_channel.cpp
@@ -1,6 +1,8 @@
 #include "dq_output_channel.h"
 #include "dq_arrow_helpers.h"
 
+#include <ydb/library/yql/dq/runtime/dq_packer_version_helper.h>
+
 #include <util/generic/buffer.h>
 #include <util/generic/size_literals.h>
 #include <util/stream/buffer.h>
@@ -32,9 +34,9 @@ public:
 
     TDqOutputChannel(ui64 channelId, ui32 dstStageId, NMiniKQL::TType* outputType,
         const NMiniKQL::THolderFactory& holderFactory, const TDqOutputChannelSettings& settings, const TLogFunc& logFunc,
-        NDqProto::EDataTransportVersion transportVersion)
+        NDqProto::EDataTransportVersion transportVersion, NKikimr::NMiniKQL::EValuePackerVersion packerVersion)
         : OutputType(outputType)
-        , Packer(OutputType, settings.BufferPageAllocSize)
+        , Packer(OutputType, packerVersion, settings.BufferPageAllocSize)
         , Width(OutputType->IsMulti() ? static_cast<NMiniKQL::TMultiType*>(OutputType)->GetElementsCount() : 1u)
         , Storage(settings.ChannelStorage)
         , HolderFactory(holderFactory)
@@ -497,10 +499,10 @@ IDqOutputChannel::TPtr CreateDqOutputChannel(ui64 channelId, ui32 dstStageId, NK
             [[fallthrough]];
         case NDqProto::EDataTransportVersion::DATA_TRANSPORT_UV_PICKLE_1_0:
         case NDqProto::EDataTransportVersion::DATA_TRANSPORT_OOB_PICKLE_1_0:
-            return new TDqOutputChannel<false>(channelId, dstStageId, outputType, holderFactory, settings, logFunc, transportVersion);
+            return new TDqOutputChannel<false>(channelId, dstStageId, outputType, holderFactory, settings, logFunc, transportVersion, FromProto(settings.ValuePackerVersion));
         case NDqProto::EDataTransportVersion::DATA_TRANSPORT_UV_FAST_PICKLE_1_0:
         case NDqProto::EDataTransportVersion::DATA_TRANSPORT_OOB_FAST_PICKLE_1_0:
-            return new TDqOutputChannel<true>(channelId, dstStageId, outputType, holderFactory, settings, logFunc, transportVersion);
+            return new TDqOutputChannel<true>(channelId, dstStageId, outputType, holderFactory, settings, logFunc, transportVersion, FromProto(settings.ValuePackerVersion));
         default:
             YQL_ENSURE(false, "Unsupported transport version " << (ui32)transportVersion);
     }

--- a/ydb/library/yql/dq/runtime/dq_output_channel.h
+++ b/ydb/library/yql/dq/runtime/dq_output_channel.h
@@ -34,6 +34,7 @@ struct TDqOutputChannelSettings {
     ui64 MaxChunkBytes = 2_MB;
     ui64 ChunkSizeLimit = 48_MB;
     NDqProto::EDataTransportVersion TransportVersion = NDqProto::EDataTransportVersion::DATA_TRANSPORT_UV_PICKLE_1_0;
+    NDqProto::EValuePackerVersion ValuePackerVersion = NDqProto::EValuePackerVersion::VALUE_PACKER_VERSION_V0;
     IDqChannelStorage::TPtr ChannelStorage;
     TCollectStatsLevel Level = TCollectStatsLevel::None;
     TMaybe<ui8> ArrayBufferMinFillPercentage;

--- a/ydb/library/yql/dq/runtime/dq_output_channel_ut.cpp
+++ b/ydb/library/yql/dq/runtime/dq_output_channel_ut.cpp
@@ -58,7 +58,7 @@ struct TTestContext {
         , Vb(HolderFactory)
         , TransportVersion(transportVersion)
         , IsWide(width == WIDE_CHANNEL)
-        , Ds(TypeEnv, HolderFactory, TransportVersion)
+        , Ds(TypeEnv, HolderFactory, TransportVersion, EValuePackerVersion::V0)
     {
         //TMultiType::Create(ui32 elementsCount, TType *const *elements, const TTypeEnvironment &env)
         if (bigRows) {

--- a/ydb/library/yql/dq/runtime/dq_packer_version_helper.h
+++ b/ydb/library/yql/dq/runtime/dq_packer_version_helper.h
@@ -1,0 +1,32 @@
+#pragma once
+
+#include <ydb/library/yql/dq/proto/dq_transport.pb.h>
+
+#include <yql/essentials/minikql/computation/mkql_computation_node_pack.h>
+
+namespace NYql::NDq {
+
+inline NKikimr::NMiniKQL::EValuePackerVersion FromProto(NYql::NDqProto::EValuePackerVersion packerVersion) {
+    switch (packerVersion) {
+        case NDqProto::VALUE_PACKER_VERSION_UNSPECIFIED:
+            return NKikimr::NMiniKQL::EValuePackerVersion::V0;
+        case NDqProto::VALUE_PACKER_VERSION_V0:
+            return NKikimr::NMiniKQL::EValuePackerVersion::V0;
+        case NDqProto::VALUE_PACKER_VERSION_V1:
+            return NKikimr::NMiniKQL::EValuePackerVersion::V1;
+        default:
+            Y_ENSURE(false, "This packer version is not supported for current binary.");
+            break;
+    }
+}
+
+inline NYql::NDqProto::EValuePackerVersion ToProto(NKikimr::NMiniKQL::EValuePackerVersion packerVersion) {
+    switch (packerVersion) {
+        case NKikimr::NMiniKQL::EValuePackerVersion::V0:
+            return NYql::NDqProto::EValuePackerVersion::VALUE_PACKER_VERSION_V0;
+        case NKikimr::NMiniKQL::EValuePackerVersion::V1:
+            return NYql::NDqProto::EValuePackerVersion::VALUE_PACKER_VERSION_V1;
+    }
+}
+
+} // namespace NYql::NDq

--- a/ydb/library/yql/dq/runtime/dq_tasks_runner.cpp
+++ b/ydb/library/yql/dq/runtime/dq_tasks_runner.cpp
@@ -618,7 +618,7 @@ public:
                     ui64 channelId = inputChannelDesc.GetId();
                     auto inputChannel = CreateDqInputChannel(channelId, inputChannelDesc.GetSrcStageId(), *inputType,
                         memoryLimits.ChannelBufferSize, StatsModeToCollectStatsLevel(Settings.StatsMode), typeEnv, holderFactory,
-                        inputChannelDesc.GetTransportVersion());
+                        inputChannelDesc.GetTransportVersion(), FromProto(task.GetValuePackerVersion()));
                     auto ret = AllocatedHolder->InputChannels.emplace(channelId, inputChannel);
                     YQL_ENSURE(ret.second, "task: " << TaskId << ", duplicated input channelId: " << channelId);
                     inputs.emplace_back(inputChannel);
@@ -697,6 +697,7 @@ public:
                     settings.BufferPageAllocSize = memoryLimits.BufferPageAllocSize;
                     settings.TransportVersion = outputChannelDesc.GetTransportVersion();
                     settings.Level = StatsModeToCollectStatsLevel(Settings.StatsMode);
+                    settings.ValuePackerVersion = task.GetValuePackerVersion();
 
                     if (!outputChannelDesc.GetInMemory()) {
                         settings.ChannelStorage = execCtx.CreateChannelStorage(channelId, outputChannelDesc.GetEnableSpilling());

--- a/ydb/library/yql/dq/runtime/dq_tasks_runner.h
+++ b/ydb/library/yql/dq/runtime/dq_tasks_runner.h
@@ -400,6 +400,10 @@ public:
         return Task_->HasEnableSpilling() && Task_->GetEnableSpilling();
     }
 
+    NYql::NDqProto::EValuePackerVersion GetValuePackerVersion() const {
+        return Task_->GetValuePackerVersion();
+    }
+
 private:
 
     // external callback to retrieve parameter value.

--- a/ydb/library/yql/providers/dq/common/yql_dq_settings.cpp
+++ b/ydb/library/yql/providers/dq/common/yql_dq_settings.cpp
@@ -92,6 +92,10 @@ TDqConfiguration::TDqConfiguration() {
                 EnableDqReplicate = true;
             }
         });
+    REGISTER_SETTING(*this, ValuePackerVersion).Parser([](const TString& v) {
+            return FromString<TDqSettings::EValuePackerVersion>(v);
+        });
+
     REGISTER_SETTING(*this, DisableLLVMForBlockStages);
     REGISTER_SETTING(*this, SplitStageOnDqReplicate)
         .ValueSetter([this](const TString&, bool value) {

--- a/ydb/library/yql/providers/dq/common/yql_dq_settings.h
+++ b/ydb/library/yql/providers/dq/common/yql_dq_settings.h
@@ -29,6 +29,11 @@ struct TDqSettings {
         File        /* "file" */,
     };
 
+    enum class EValuePackerVersion {
+        V0,
+        V1,
+    };
+
     struct TDefault {
         static constexpr ui32 MaxTasksPerStage = 20U;
         static constexpr ui32 MaxTasksPerOperation = 70U;
@@ -63,6 +68,7 @@ struct TDqSettings {
         static constexpr bool SplitStageOnDqReplicate = true;
         static constexpr ui64 EnableSpillingNodes = 0;
         static constexpr bool EnableSpillingInChannels = false;
+        static constexpr EValuePackerVersion ValuePackerVersion = EValuePackerVersion::V0;
     };
 
     using TPtr = std::shared_ptr<TDqSettings>;
@@ -143,6 +149,7 @@ public:
 
     NCommon::TConfSetting<ui64, Static> EnableSpillingNodes;
     NCommon::TConfSetting<bool, Static> EnableSpillingInChannels;
+    NCommon::TConfSetting<EValuePackerVersion, Static> ValuePackerVersion;
 
     NCommon::TConfSetting<ui64, Static> _MaxAttachmentsSize;
     NCommon::TConfSetting<bool, Static> DisableCheckpoints;
@@ -202,6 +209,7 @@ public:
         SAVE_SETTING(TaskRunnerStats);
         SAVE_SETTING(SpillingEngine);
         SAVE_SETTING(EnableSpillingInChannels);
+        SAVE_SETTING(ValuePackerVersion);
         SAVE_SETTING(DisableCheckpoints);
         SAVE_SETTING(Scheduler);
 #undef SAVE_SETTING
@@ -245,6 +253,15 @@ public:
     bool IsSpillingInChannelsEnabled() const {
         if (!IsSpillingEngineEnabled()) return false;
         return EnableSpillingInChannels.Get().GetOrElse(TDqSettings::TDefault::EnableSpillingInChannels) != false;
+    }
+
+    NYql::NDqProto::EValuePackerVersion GetValuePackerVersion() const {
+        switch (ValuePackerVersion.Get().GetOrElse(TDqSettings::TDefault::ValuePackerVersion)) {
+            case EValuePackerVersion::V0:
+                return NYql::NDqProto::EValuePackerVersion::VALUE_PACKER_VERSION_V0;
+            case EValuePackerVersion::V1:
+                return NYql::NDqProto::EValuePackerVersion::VALUE_PACKER_VERSION_V1;
+        }
     }
 
     ui64 GetEnabledSpillingNodes() const {

--- a/ydb/library/yql/providers/dq/planner/execution_planner.cpp
+++ b/ydb/library/yql/providers/dq/planner/execution_planner.cpp
@@ -459,6 +459,7 @@ namespace NYql::NDqs {
             taskDesc.MutableMeta()->PackFrom(taskMeta);
             taskDesc.SetStageId(stageId);
             taskDesc.SetEnableSpilling(Settings->GetEnabledSpillingNodes());
+            taskDesc.SetValuePackerVersion(Settings->GetValuePackerVersion());
 
             if (Settings->DisableLLVMForBlockStages.Get().GetOrElse(true)) {
                 auto& stage = TasksGraph.GetStageInfo(task.StageId).Meta.Stage;

--- a/ydb/library/yql/providers/dq/runtime/task_command_executor.cpp
+++ b/ydb/library/yql/providers/dq/runtime/task_command_executor.cpp
@@ -377,9 +377,9 @@ public:
                 if (batch.IsOOB()) {
                     LoadRopeFromPipe(input, batch.Payload);
                 }
-                NDq::TDqDataSerializer dataSerializer(Runner->GetTypeEnv(), Runner->GetHolderFactory(),
-                    (NDqProto::EDataTransportVersion)batch.Proto.GetTransportVersion());
-                dataSerializer.Deserialize(std::move(batch), source->GetInputType(), buffer);
+                NDq::TDqDataSerializer dataDeserializer(Runner->GetTypeEnv(), Runner->GetHolderFactory(),
+                                                        (NDqProto::EDataTransportVersion)batch.Proto.GetTransportVersion(), NDq::FromProto(batch.Proto.GetValuePackerVersion()));
+                dataDeserializer.Deserialize(std::move(batch), source->GetInputType(), buffer);
 
                 source->Push(std::move(buffer), request.GetSpace());
                 break;
@@ -624,7 +624,8 @@ public:
                 NDq::TDqDataSerializer dataSerializer(
                     Runner->GetTypeEnv(),
                     Runner->GetHolderFactory(),
-                    DataTransportVersion);
+                    DataTransportVersion,
+                    PackerVersion);
                 NDq::TDqSerializedBatch serialized = dataSerializer.Serialize(batch, outputType);
                 bool isOOB = serialized.IsOOB();
                 *response.MutableData() = std::move(serialized.Proto);
@@ -676,6 +677,7 @@ public:
             DontCollectDumps();
         }
         DataTransportVersion = DqConfiguration->GetDataTransportVersion();
+        PackerVersion = NDq::FromProto(DqConfiguration->GetValuePackerVersion());
         // TODO: Maybe use taskParams from task.GetTask().GetParameters()
         THashMap<TString, TString> taskParams;
         for (const auto& x: taskMeta.GetTaskParams()) {
@@ -805,6 +807,7 @@ private:
     TTaskCounters PrevStat;
     TDqConfiguration::TPtr DqConfiguration = MakeIntrusive<TDqConfiguration>();
     NDqProto::EDataTransportVersion DataTransportVersion = NDqProto::EDataTransportVersion::DATA_TRANSPORT_VERSION_UNSPECIFIED;
+    NKikimr::NMiniKQL::EValuePackerVersion PackerVersion = NKikimr::NMiniKQL::EValuePackerVersion::V0;
     TIntrusivePtr<NKikimr::NMiniKQL::IMutableFunctionRegistry> FunctionRegistry;
     NDq::TDqTaskRunnerContext Ctx;
     const NKikimr::NMiniKQL::TUdfModuleRemappings EmptyRemappings;

--- a/ydb/library/yql/providers/dq/task_runner_actor/task_runner_actor.cpp
+++ b/ydb/library/yql/providers/dq/task_runner_actor/task_runner_actor.cpp
@@ -425,7 +425,7 @@ private:
         YQL_ENSURE(!batch.IsWide());
 
         auto* source = TaskRunner->GetSource(index);
-        TDqDataSerializer dataSerializer(TaskRunner->GetTypeEnv(), TaskRunner->GetHolderFactory(), DataTransportVersion);
+        TDqDataSerializer dataSerializer(TaskRunner->GetTypeEnv(), TaskRunner->GetHolderFactory(), DataTransportVersion, ValuePackerVersion);
         TDqSerializedBatch serialized = dataSerializer.Serialize(batch, source->GetInputType());
 
         Invoker->Invoke([serialized=std::move(serialized), taskRunner=TaskRunner, actorSystem, selfId, cookie, parentId=ParentId, space, finish, index, settings=Settings, stageId=StageId]() mutable {
@@ -511,7 +511,10 @@ private:
         auto guard = TaskRunner->BindAllocator();
         NKikimr::NMiniKQL::TUnboxedValueBatch batch;
         auto sink = TaskRunner->GetSink(ev->Get()->Index);
-        TDqDataSerializer dataSerializer(TaskRunner->GetTypeEnv(), TaskRunner->GetHolderFactory(), (NDqProto::EDataTransportVersion)ev->Get()->Batch.Proto.GetTransportVersion());
+        TDqDataSerializer dataSerializer(TaskRunner->GetTypeEnv(),
+                                         TaskRunner->GetHolderFactory(),
+                                         (NDqProto::EDataTransportVersion)ev->Get()->Batch.Proto.GetTransportVersion(),
+                                         FromProto(ev->Get()->Batch.Proto.GetValuePackerVersion()));
         dataSerializer.Deserialize(std::move(ev->Get()->Batch), sink->GetOutputType(), batch);
 
         Parent->SinkSend(
@@ -612,6 +615,7 @@ private:
             Settings->Dispatch(taskMeta.GetSettings());
             Settings->FreezeDefaults();
             DataTransportVersion = Settings->GetDataTransportVersion();
+            ValuePackerVersion = FromProto(Settings->GetValuePackerVersion());
             StageId = taskMeta.GetStageId();
 
             NDq::TDqTaskSettings settings(&ev->Get()->Task);
@@ -760,6 +764,7 @@ private:
     THashSet<ui32> Sources;
     TIntrusivePtr<TDqConfiguration> Settings;
     NDqProto::EDataTransportVersion DataTransportVersion;
+    NKikimr::NMiniKQL::EValuePackerVersion ValuePackerVersion;
     ui64 StageId;
     TWorkerRuntimeData* RuntimeData;
     TString ClusterName;

--- a/ydb/library/yql/providers/pq/async_io/dq_pq_rd_read_actor.cpp
+++ b/ydb/library/yql/providers/pq/async_io/dq_pq_rd_read_actor.cpp
@@ -552,7 +552,7 @@ TDqPqRdReadActor::TDqPqRdReadActor(
         ColumnIndexes[index] = i;
     }
     InputDataType = programBuilder->NewMultiType(inputTypeParts);
-    DataUnpacker = std::make_unique<NKikimr::NMiniKQL::TValuePackerTransport<true>>(InputDataType);
+    DataUnpacker = std::make_unique<NKikimr::NMiniKQL::TValuePackerTransport<true>>(InputDataType, NKikimr::NMiniKQL::EValuePackerVersion::V0);
 
     IngressStats.Level = statsLevel;
 }

--- a/ydb/tests/fq/pq_async_io/ut/dq_pq_rd_read_actor_ut.cpp
+++ b/ydb/tests/fq/pq_async_io/ut/dq_pq_rd_read_actor_ut.cpp
@@ -163,7 +163,7 @@ struct TFixture : public TPqIoTestFixture {
         });
         UNIT_ASSERT_C(typeMkql, "Failed to create multi type");
 
-        NKikimr::NMiniKQL::TValuePackerTransport<true> packer(typeMkql);
+        NKikimr::NMiniKQL::TValuePackerTransport<true> packer(typeMkql, NKikimr::NMiniKQL::EValuePackerVersion::V0);
 
         TVector<NUdf::TUnboxedValue> values = {
             NUdf::TUnboxedValuePod(intValue),


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

This CL adds the ability to pass a flag that specifies the |TValuePackerTransport| serializer version. In the new serializer version V1, a bug related to the serialization of block data types (specifically, the serialization of offsets) has been fixed.
Pass flag from the DQ Settings to the |TValuePackerTransport| for the DQ component.
Set the V0 version for other occurrences.

### Changelog category <!-- remove all except one -->

* Not for changelog (changelog entry is not required)

### Description for reviewers <!-- (optional) description for those who read this PR -->

...
