### PR TITLE
Fixes in s3_backups compatibility tests

### DIFF
--- a/ydb/tests/compatibility/s3_backups/test_export_import_s3.py
+++ b/ydb/tests/compatibility/s3_backups/test_export_import_s3.py
@@ -224,7 +224,7 @@ class TestExportImportS3(MixedClusterFixture):
             self._export_check_topic()
             self._import_check_topic()
 
-    def test_full_pipeline(self):
+    def test_all_scheme_objects(self):
         self._create_items()
         self._export_check()
         self._import_check()


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

...

### Changelog category <!-- remove all except one -->

* Not for changelog (changelog entry is not required)

### Description for reviewers <!-- (optional) description for those who read this PR -->

Поправил замечания в тестах на совместимость для бэкапов s3:
- [Первое](https://github.com/ydb-platform/ydb/pull/20075#discussion_r2224959436);
- [Второе](https://github.com/ydb-platform/ydb/pull/20075#discussion_r2224959436) - добавил отдельные тесты на экспорт / импорт таблиц и топиков, но общий тест для всех схемных объектов удалять не стал, т.к. он полезный (например, могут случиться какие-то конфликты при экспорте / импорте директории с различными схемными объектами).

При разделении теста на таблицы / топики вспомнился [баг](https://github.com/ydb-platform/ydb/issues/21745) из-за которого перед экспортом топиков нужно создать несуществующую директорию.
