### PR TITLE
Fixed the bug with S3 backups when directories in the path do not exist

### DIFF
--- a/ydb/core/tx/schemeshard/ut_restore/ut_restore.cpp
+++ b/ydb/core/tx/schemeshard/ut_restore/ut_restore.cpp
@@ -5692,13 +5692,13 @@ consumers {
               scheme: HTTP
               items {
                 source_prefix: "/Topic"
-                destination_path: "/MyRoot/Topic"
+                destination_path: "/MyRoot/Restored/Topic"
               }
             }
         )", port));
         env.TestWaitNotification(runtime, txId);
 
-        TestDescribeResult(DescribePath(runtime, "/MyRoot/Topic"), {
+        TestDescribeResult(DescribePath(runtime, "/MyRoot/Restored/Topic"), {
             NLs::PathExist,
         });
     }

--- a/ydb/services/ydb/backup_ut/encrypted_backup_ut.cpp
+++ b/ydb/services/ydb/backup_ut/encrypted_backup_ut.cpp
@@ -607,14 +607,6 @@ Y_UNIT_TEST_SUITE_F(EncryptedExportTest, TBackupEncryptionTestFixture) {
             });
         }
 
-        // Topics can't restore to a new dir
-        // Create dir
-        // TODO: remove after fix
-        {
-            auto res = YdbSchemeClient().MakeDirectory("/Root/Restored").GetValueSync();
-            UNIT_ASSERT_C(res.IsSuccess(), res.GetIssues().ToString());
-        }
-
         {
             NImport::TImportFromS3Settings importSettings = MakeImportSettings("Prefix", "/Root/Restored");
             importSettings

--- a/ydb/tests/compatibility/s3_backups/test_export_import_s3.py
+++ b/ydb/tests/compatibility/s3_backups/test_export_import_s3.py
@@ -16,7 +16,6 @@ from ydb.tests.library.compatibility.fixtures import MixedClusterFixture
 from ydb.export import ExportClient
 from ydb.export import ExportToS3Settings
 from ydb.import_client import ImportClient, ImportFromS3Settings
-from ydb.scheme import BaseSchemeClient  # TODO: remove after fix: https://github.com/ydb-platform/ydb/issues/21745
 from ydb.topic import TopicClient
 
 
@@ -176,10 +175,6 @@ class TestExportImportS3(MixedClusterFixture):
 
             if self._is_current_version():
                 if "TOPIC" in scheme_objects:
-                    # TODO: remove after fix: https://github.com/ydb-platform/ydb/issues/21745
-                    if num == 1 and "TABLE" not in scheme_objects:
-                        BaseSchemeClient(self.driver).make_directory(f"/Root/{imported_prefix}")
-
                     topic_name = f"Root/{self.prefix_topics}/sample_topic_{num}"
                     imported_topic_name = f"/Root/{imported_prefix}/sample_topic_{num}"
                     import_settings = import_settings.with_source_and_destination(topic_name, imported_topic_name)


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

...

### Changelog category <!-- remove all except one -->

* Not for changelog (changelog entry is not required)

### Description for reviewers <!-- (optional) description for those who read this PR -->

Исправлен [баг](https://github.com/ydb-platform/ydb/issues/21745). Теперь в качестве рабочей директории при создании топиков указывается корень базы. В качестве имени - полный путь до топика, исключая корень. В таком случае будут создаваться автоматически несуществующие директории.
