### PR TITLE
Nemesis: support 2dc config in tests

### DIFF
--- a/ydb/tests/library/harness/kikimr_cluster.py
+++ b/ydb/tests/library/harness/kikimr_cluster.py
@@ -201,7 +201,7 @@ class ExternalKiKiMRCluster(KiKiMRClusterInterface):
         if bridge_config is None:
             return None
 
-        bridge_pile_name = node.get('bridge_pile_name', None)
+        bridge_pile_name = node.get('location', {}).get('bridge_pile_name', None)
         if bridge_pile_name is None:
             return None
 
@@ -221,7 +221,7 @@ class ExternalKiKiMRCluster(KiKiMRClusterInterface):
                 host=node.get('name', node.get('host')),
                 rack=node.get('location', {}).get('rack', None),
                 datacenter=node.get('location', {}).get('data_center', None),
-                bridge_pile_name=node.get('bridge_pile_name', None),
+                bridge_pile_name=node.get('location', {}).get('bridge_pile_name', None),
                 bridge_pile_id=self._get_bridge_pile_id(node),
                 ssh_username=self.__ssh_username,
                 port=DEFAULT_GRPC_PORT,

--- a/ydb/tests/olap/load/README.md
+++ b/ydb/tests/olap/load/README.md
@@ -488,8 +488,8 @@ T+0s     | ФАЗА 1: Подготовка                         | Остан
 T+0s     | Остановка nemesis в preparation            | Nemesis останавливается на всех нодах для чистого старта
 T+0s     | ФАЗА 2: Выполнение workload                | Workload начинает выполняться на нодах
 T+15s    | Запуск nemesis                             | Nemesis стартует через 15 секунд после начала workload
-T+15s    | Подготовка конфигурации кластера           | Удаление старого cluster.yaml, копирование нового
-T+15s    | Деплой конфигурации кластера               | Файл конфигурации кластера копируется на все ноды
+T+15s    | Деплой конфигурации кластера               | Файл конфигурации кластера копируется на все ноды (если указан cluster_path)
+T+15s    | Деплой конфигурации баз данных             | Файл databases.yaml копируется на все ноды (если указан yaml-config)
 T+15s    | Начало chaos testing                       | Nemesis начинает выполнять операции согласно конфигурации
 T+15s    | Workload продолжает работу                 | Основной workload работает параллельно с nemesis
 T+15s    | Nemesis выполняет операции                 | Случайные операции: паузы, перезапуски, сетевые проблемы и т.д.
@@ -514,7 +514,10 @@ T+N      | Завершение теста                           | Тест 
 ### Параметры nemesis
 
 - `nemesis=True` - включает chaos testing
-- `cluster_path` - путь к файлу конфигурации кластера (копируется как есть, без изменений)
+- `cluster_path` - путь к файлу конфигурации кластера (копируется в `/Berkanavt/kikimr/cfg/cluster.yaml`)
+  - Если не указан, файл не копируется
+- `yaml-config` - путь к файлу конфигурации баз данных (копируется в `/Berkanavt/kikimr/cfg/databases.yaml`)
+  - Если не указан, файл не копируется
 
 ### Пример с параметризацией
 
@@ -1220,7 +1223,8 @@ ydb/tests/olap/load/
   --test-filter test_workload_simple_queue.py::TestSimpleQueue::test_workload_simple_queue[nemesis_true*] \
   --allure=./allure_tmp \
   --test-tag ya:manual \
-  --test-param cluster_path=cluster.yaml
+  --test-param cluster_path=cluster.yaml \
+  --test-param yaml-config=databases.yaml
 ```
 
 #### **Вариант 2: С выгрузкой результатов в YDB**
@@ -1240,7 +1244,8 @@ export RESULT_IAM_FILE_0=iam.json
   --test-param results-endpoint=grpcs://lb.etnvsjbk7kh1jc6bbfi8.ydb.mdb.yandexcloud.net:2135 \
   --test-param results-db=/ru-central1/b1ggceeul2pkher8vhb6/etnvsjbk7kh1jc6bbfi8 \
   --test-param results-table=nemesis/tests_results \
-  --test-param cluster_path=cluster.yaml
+  --test-param cluster_path=cluster.yaml \
+  --test-param yaml-config=databases.yaml
 ```
 
 **Параметры запуска:**
@@ -1249,7 +1254,8 @@ export RESULT_IAM_FILE_0=iam.json
 - `ydb-endpoint=grpc://localhost:2135` - endpoint YDB кластера
 - `--test-filter` - фильтр для запуска конкретного теста
 - `--allure=./allure_tmp` - директория для Allure отчетов
-- `cluster_path=$CROSS` - **конфигурация кластера для nemesis (требуется для chaos testing)**
+- `cluster_path=cluster.yaml` - **конфигурация кластера для nemesis (копируется в cluster.yaml)**
+- `yaml-config=databases.yaml` - **конфигурация баз данных для nemesis (копируется в databases.yaml)**
 
 **Параметры выгрузки в YDB (только для Варианта 2):**
 - `send-results=true` - включить выгрузку результатов в YDB

--- a/ydb/tests/olap/load/lib/workload_executor.py
+++ b/ydb/tests/olap/load/lib/workload_executor.py
@@ -531,7 +531,7 @@ class WorkloadTestBase(LoadSuiteBase):
 
         # Копируем cluster.yaml (если указан cluster_path)
         cluster_result = cls._copy_single_config(
-            host, cls.cluster_path, "/Berkanavt/kikimr/cfg/cluster.yaml", 
+            host, cls.cluster_path, "/Berkanavt/kikimr/cfg/cluster.yaml",
             "cluster config", None, host_log
         )
         if not cluster_result["success"]:
@@ -549,8 +549,8 @@ class WorkloadTestBase(LoadSuiteBase):
         return {"host": host, "success": True, "log": host_log}
 
     @classmethod
-    def _copy_single_config(cls, host: str, config_path: str, remote_path: str, 
-                           config_name: str, fallback_source: str, host_log: list) -> dict:
+    def _copy_single_config(cls, host: str, config_path: str, remote_path: str,
+                            config_name: str, fallback_source: str, host_log: list) -> dict:
         """Копирует один файл конфигурации"""
         if config_path:
             # Копируем внешний файл
@@ -561,21 +561,10 @@ class WorkloadTestBase(LoadSuiteBase):
                 return {"host": host, "success": False, "error": error_msg, "log": host_log}
 
             source = config_path
-            copy_method = lambda: copy_file(
-                local_path=config_path,
-                host=host,
-                remote_path=remote_path,
-                raise_on_error=False
-            )
             success_msg = f"Copied external {config_name} from {config_path}"
         elif fallback_source:
             # Используем локальный fallback
             source = fallback_source
-            copy_method = lambda: execute_command(
-                host=host,
-                cmd=f"sudo cp {fallback_source} {remote_path}",
-                raise_on_error=False
-            )
             success_msg = f"Copied local {config_name}"
         else:
             # Ничего не копируем
@@ -583,8 +572,21 @@ class WorkloadTestBase(LoadSuiteBase):
 
         # Выполняем копирование
         host_log.append(f"Copying {config_name} from {source}")
-        result = copy_method()
-        
+
+        if config_path:
+            result = copy_file(
+                local_path=config_path,
+                host=host,
+                remote_path=remote_path,
+                raise_on_error=False
+            )
+        else:
+            result = execute_command(
+                host=host,
+                cmd=f"sudo cp {fallback_source} {remote_path}",
+                raise_on_error=False
+            )
+
         # Проверяем результат
         if config_path and not result:
             error_msg = f"Failed to copy {config_name} to {remote_path} on {host}"

--- a/ydb/tests/olap/load/lib/workload_executor.py
+++ b/ydb/tests/olap/load/lib/workload_executor.py
@@ -38,6 +38,10 @@ class WorkloadTestBase(LoadSuiteBase):
         get_external_param(
             "cluster_path",
             ""))  # Путь к кластеру
+    yaml_config: str = str(
+        get_external_param(
+            "yaml-config",
+            ""))  # Путь к yaml конфигурации
 
     @classmethod
     def setup_class(cls) -> None:
@@ -297,116 +301,11 @@ class WorkloadTestBase(LoadSuiteBase):
                             host_log.append("Deleted cluster.yaml")
 
                         # 3. Копируем config.yaml в cluster.yaml
-                        cluster_path = get_external_param("cluster_path", "")
-                        logging.info(
-                            f"Cluster path for {host}: {cluster_path}")
+                        copy_result = cls._copy_cluster_config(host, host_log)
+                        if not copy_result["success"]:
+                            return copy_result
 
-                        if cluster_path:
-                            # Если указан cluster_path, используем его как есть
-                            local_config_path = cluster_path
-                            host_log.append(
-                                f"Copying from {local_config_path}")
-                            logging.info(
-                                f"Copying config file from {local_config_path} to {host}"
-                            )
-
-                            # Проверяем, существует ли файл
-                            if not os.path.exists(local_config_path):
-                                error_msg = (
-                                    f"Config file does not exist: {local_config_path}"
-                                )
-                                host_log.append(error_msg)
-                                logging.error(error_msg)
-                                return {
-                                    "host": host,
-                                    "success": False,
-                                    "error": error_msg,
-                                    "log": host_log,
-                                }
-
-                            # Используем готовую функцию copy_file
-                            copy_result = copy_file(
-                                local_path=local_config_path,
-                                host=host,
-                                remote_path="/Berkanavt/kikimr/cfg/cluster.yaml",
-                                raise_on_error=False,
-                            )
-
-                            if copy_result is None or copy_result == "":
-                                error_msg = f"Failed to copy config file to cluster.yaml on {host} - copy_file returned: {copy_result}"
-                                host_log.append(error_msg)
-                                logging.error(error_msg)
-                                # Попробуем получить больше информации об
-                                # ошибке
-                                try:
-                                    # Проверим размер файла
-                                    file_size = os.path.getsize(
-                                        local_config_path)
-                                    logging.info(
-                                        f"Local config file size: {file_size} bytes"
-                                    )
-
-                                    # Проверим права доступа
-                                    file_mode = oct(os.stat(local_config_path).st_mode)[
-                                        -3:
-                                    ]
-                                    logging.info(
-                                        f"Local config file permissions: {file_mode}"
-                                    )
-
-                                except Exception as e:
-                                    logging.error(
-                                        f"Error checking file properties: {e}"
-                                    )
-
-                                return {
-                                    "host": host,
-                                    "success": False,
-                                    "error": error_msg,
-                                    "log": host_log,
-                                }
-                            else:
-                                host_log.append(
-                                    f"Copied config file to cluster.yaml: {copy_result}"
-                                )
-                                logging.info(
-                                    f"Successfully copied config file to {host}: {copy_result}"
-                                )
-                        else:
-                            # Если cluster_path не указан, используем локальное
-                            # копирование
-                            copy_cmd = "sudo cp /Berkanavt/kikimr/cfg/config.yaml /Berkanavt/kikimr/cfg/cluster.yaml"
-                            host_log.append("Using local cp command")
-                            logging.info(
-                                f"Using local cp command on {host}: {copy_cmd}"
-                            )
-
-                            copy_result = execute_command(
-                                host=host, cmd=copy_cmd, raise_on_error=False
-                            )
-
-                            copy_stderr = (
-                                copy_result.stderr if copy_result.stderr else ""
-                            )
-                            if copy_stderr and "error" in copy_stderr.lower():
-                                error_msg = f"Error copying config.yaml to cluster.yaml on {host}: {copy_stderr}"
-                                host_log.append(error_msg)
-                                logging.error(error_msg)
-                                return {
-                                    "host": host,
-                                    "success": False,
-                                    "error": error_msg,
-                                    "log": host_log,
-                                }
-                            else:
-                                host_log.append(
-                                    "Copied config.yaml to cluster.yaml")
-                                logging.info(
-                                    f"Successfully copied config.yaml on {host} using local cp"
-                                )
-
-                        logging.info(
-                            f"Completed nemesis config preparation for {host}")
+                        logging.info(f"Completed nemesis config preparation for {host}")
                         return {"host": host, "success": True, "log": host_log}
 
                     except Exception as e:
@@ -623,6 +522,82 @@ class WorkloadTestBase(LoadSuiteBase):
                 str(e), "Nemesis Error", attachment_type=allure.attachment_type.TEXT
             )
             return nemesis_log + [error_msg]
+
+    @classmethod
+    def _copy_cluster_config(cls, host: str, host_log: list) -> dict:
+        """Копирует конфигурацию кластера на хост"""
+        logging.info(f"Cluster path for {host}: {cls.cluster_path}")
+        logging.info(f"YAML config for {host}: {cls.yaml_config}")
+
+        # Копируем cluster.yaml (если указан cluster_path)
+        cluster_result = cls._copy_single_config(
+            host, cls.cluster_path, "/Berkanavt/kikimr/cfg/cluster.yaml", 
+            "cluster config", None, host_log
+        )
+        if not cluster_result["success"]:
+            return cluster_result
+
+        # Копируем databases.yaml (если указан yaml_config)
+        if cls.yaml_config:
+            databases_result = cls._copy_single_config(
+                host, cls.yaml_config, "/Berkanavt/kikimr/cfg/databases.yaml",
+                "databases config", None, host_log
+            )
+            if not databases_result["success"]:
+                return databases_result
+
+        return {"host": host, "success": True, "log": host_log}
+
+    @classmethod
+    def _copy_single_config(cls, host: str, config_path: str, remote_path: str, 
+                           config_name: str, fallback_source: str, host_log: list) -> dict:
+        """Копирует один файл конфигурации"""
+        if config_path:
+            # Копируем внешний файл
+            if not os.path.exists(config_path):
+                error_msg = f"{config_name} file does not exist: {config_path}"
+                host_log.append(error_msg)
+                logging.error(error_msg)
+                return {"host": host, "success": False, "error": error_msg, "log": host_log}
+
+            source = config_path
+            copy_method = lambda: copy_file(
+                local_path=config_path,
+                host=host,
+                remote_path=remote_path,
+                raise_on_error=False
+            )
+            success_msg = f"Copied external {config_name} from {config_path}"
+        elif fallback_source:
+            # Используем локальный fallback
+            source = fallback_source
+            copy_method = lambda: execute_command(
+                host=host,
+                cmd=f"sudo cp {fallback_source} {remote_path}",
+                raise_on_error=False
+            )
+            success_msg = f"Copied local {config_name}"
+        else:
+            # Ничего не копируем
+            return {"host": host, "success": True, "log": host_log}
+
+        # Выполняем копирование
+        host_log.append(f"Copying {config_name} from {source}")
+        result = copy_method()
+        
+        # Проверяем результат
+        if config_path and not result:
+            error_msg = f"Failed to copy {config_name} to {remote_path} on {host}"
+            host_log.append(error_msg)
+            return {"host": host, "success": False, "error": error_msg, "log": host_log}
+        elif not config_path and result.stderr and "error" in result.stderr.lower():
+            error_msg = f"Error copying {config_name} on {host}: {result.stderr}"
+            host_log.append(error_msg)
+            return {"host": host, "success": False, "error": error_msg, "log": host_log}
+
+        host_log.append(success_msg)
+        logging.info(f"Successfully copied {config_name} to {host}")
+        return {"host": host, "success": True, "log": host_log}
 
     def create_workload_result(
         self,

--- a/ydb/tests/tools/nemesis/library/bridge_pile.py
+++ b/ydb/tests/tools/nemesis/library/bridge_pile.py
@@ -36,11 +36,18 @@ class AbstractBridgePileNemesis(Nemesis, AbstractMonitoredNemesis):
 
     def _validate_bridge_piles(self, cluster):
         bridge_pile_to_nodes = collections.defaultdict(list)
-        for node in cluster.nodes.values():
+        self.logger.info("Validating bridge piles for %d nodes", len(cluster.nodes))
+        
+        for node_id, node in cluster.nodes.items():
+            self.logger.info("Node %d: host=%s, bridge_pile_name=%s, bridge_pile_id=%s", 
+                           node_id, node.host, node.bridge_pile_name, node.bridge_pile_id)
             if node.bridge_pile_id is not None:
                 bridge_pile_to_nodes[node.bridge_pile_id].append(node)
 
         bridge_piles = list(bridge_pile_to_nodes.keys())
+        self.logger.info("Found bridge piles: %s", bridge_piles)
+        self.logger.info("Bridge pile to nodes mapping: %s", 
+                        {pile_id: [node.host for node in nodes] for pile_id, nodes in bridge_pile_to_nodes.items()})
         return bridge_pile_to_nodes, bridge_piles
 
     def _create_bridge_pile_cycle(self):
@@ -62,6 +69,7 @@ class AbstractBridgePileNemesis(Nemesis, AbstractMonitoredNemesis):
     def prepare_state(self):
         self._bridge_pile_to_nodes, self._bridge_piles = self._validate_bridge_piles(self._cluster)
         if len(self._bridge_piles) < 2:
+            self.logger.error("Bridge piles: %s", self._bridge_piles)
             self.logger.error("No bridge piles found in cluster or only one bridge pile found")
             raise Exception("No bridge piles found in cluster or only one bridge pile found")
 

--- a/ydb/tests/tools/nemesis/library/bridge_pile.py
+++ b/ydb/tests/tools/nemesis/library/bridge_pile.py
@@ -37,17 +37,17 @@ class AbstractBridgePileNemesis(Nemesis, AbstractMonitoredNemesis):
     def _validate_bridge_piles(self, cluster):
         bridge_pile_to_nodes = collections.defaultdict(list)
         self.logger.info("Validating bridge piles for %d nodes", len(cluster.nodes))
-        
+
         for node_id, node in cluster.nodes.items():
-            self.logger.info("Node %d: host=%s, bridge_pile_name=%s, bridge_pile_id=%s", 
-                           node_id, node.host, node.bridge_pile_name, node.bridge_pile_id)
+            self.logger.info("Node %d: host=%s, bridge_pile_name=%s, bridge_pile_id=%s",
+                             node_id, node.host, node.bridge_pile_name, node.bridge_pile_id)
             if node.bridge_pile_id is not None:
                 bridge_pile_to_nodes[node.bridge_pile_id].append(node)
 
         bridge_piles = list(bridge_pile_to_nodes.keys())
         self.logger.info("Found bridge piles: %s", bridge_piles)
-        self.logger.info("Bridge pile to nodes mapping: %s", 
-                        {pile_id: [node.host for node in nodes] for pile_id, nodes in bridge_pile_to_nodes.items()})
+        self.logger.info("Bridge pile to nodes mapping: %s",
+                         {pile_id: [node.host for node in nodes] for pile_id, nodes in bridge_pile_to_nodes.items()})
         return bridge_pile_to_nodes, bridge_piles
 
     def _create_bridge_pile_cycle(self):


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

## ydb/tests/olap/load/lib/workload_executor.py

- Добавлена поддержка второго конфига (`yaml-config`) для копирования на все ноды при запуске nemesis-тестов.
- Вынесена логика копирования конфигов в отдельные методы — стало проще и чище добавлять новые типы файлов.
- Теперь оба параметра (`cluster_path`, `yaml-config`) опциональны.
- Улучшена логика и обработка ошибок при копировании файлов.

## ydb/tests/olap/load/README.md

- Описано, как использовать новые параметры (`cluster_path` и `yaml-config`) в запуске тестов.
- Добавлены примеры команд с этими параметрами.
- Уточнено, куда копируются соответствующие файлы.

## ydb/tests/library/harness/kikimr_cluster.py

- Исправлено получение `bridge_pile_name` — теперь берётся из `node['location']['bridge_pile_name']`, если есть.
- Соответственно, корректно формируется информация о bridge pile для каждой ноды.
- Это нужно для корректной работы nemesis и bridge pile logic в 2dc кластерах.

## ydb/tests/tools/nemesis/library/bridge_pile.py

- Добавлен подробный логгинг по bridge pile: теперь видно, как назначаются bridge pile'ы и какие ноды к ним привязаны.
- В случае ошибок (меньше двух bridge pile'ов) в логах выводится подробная диагностика.


### Changelog category <!-- remove all except one -->
* Not for changelog (changelog entry is not required)

### Description for reviewers <!-- (optional) description for those who read this PR -->

...
