### PR TITLE
Improve text output of integrity check

### DIFF
--- a/ydb/core/base/blobstorage.h
+++ b/ydb/core/base/blobstorage.h
@@ -1449,6 +1449,7 @@ struct TEvBlobStorage {
         TLogoBlobID Id;
         TInstant Deadline;
         NKikimrBlobStorage::EGetHandleClass GetHandleClass;
+        bool SingleLine;    // Print DataInfo in single line
 
         TEvCheckIntegrity(TCloneEventPolicy, const TEvCheckIntegrity& origin)
             : Id(origin.Id)
@@ -1459,10 +1460,12 @@ struct TEvBlobStorage {
         TEvCheckIntegrity(
                 const TLogoBlobID& id,
                 TInstant deadline,
-                NKikimrBlobStorage::EGetHandleClass getHandleClass)
+                NKikimrBlobStorage::EGetHandleClass getHandleClass,
+                bool singleLine = false)
             : Id(id)
             , Deadline(deadline)
             , GetHandleClass(getHandleClass)
+            , SingleLine(singleLine)
         {}
 
         TString Print(bool /*isFull*/) const {
@@ -1505,13 +1508,44 @@ struct TEvBlobStorage {
             PS_BLOB_IS_RECOVERABLE = 4,     // blob parts are definitely placed incorrectly or there are missing parts but blob may be recovered
             PS_BLOB_IS_LOST = 5,            // blob is lost/unrecoverable
         };
-        EPlacementStatus PlacementStatus = PS_OK;
+
+        static TString PlacementStatusToString(EPlacementStatus status) {
+            switch (status) {
+                case PS_OK:
+                    return "PS_OK";
+                case PS_REPLICATION_IN_PROGRESS:
+                    return "PS_REPLICATION_IN_PROGRESS";
+                case PS_UNKNOWN:
+                    return "PS_UNKNOWN";
+                case PS_BLOB_IS_RECOVERABLE:
+                    return "PS_BLOB_IS_RECOVERABLE";
+                case PS_BLOB_IS_LOST:
+                    return "PS_BLOB_IS_LOST";
+                default:
+                    return "BAD_PLACEMENT_STATUS";
+            }
+        }
 
         enum EDataStatus {
             DS_OK = 1,      // all data parts contain valid data
             DS_UNKNOWN = 2, // status is unknown because of missing disks or network problems
             DS_ERROR = 3,   // some parts definitely contain invalid data
         };
+
+        static TString DataStatusToString(EDataStatus status) {
+            switch (status) {
+                case DS_OK:
+                    return "DS_OK";
+                case DS_UNKNOWN:
+                    return "DS_UNKNOWN";
+                case DS_ERROR:
+                    return "DS_ERROR";
+                default:
+                    return "BAD_DATA_STATUS";
+            }
+        }
+
+        EPlacementStatus PlacementStatus = PS_OK;
         EDataStatus DataStatus = DS_OK;
         TString DataInfo; // textual info about checks in blob data
 
@@ -1527,8 +1561,8 @@ struct TEvBlobStorage {
                 << " Id# " << Id
                 << " Status# " << NKikimrProto::EReplyStatus_Name(Status)
                 << " ErrorReason# " << ErrorReason
-                << " PlacementStatus# " << (int)PlacementStatus
-                << " DataStatus# " << (int)DataStatus
+                << " PlacementStatus# " << PlacementStatusToString(PlacementStatus)
+                << " DataStatus# " << DataStatusToString(DataStatus)
                 << " DataInfo# " << DataInfo
                 << " }";
             return str.Str();

--- a/ydb/core/blobstorage/groupinfo/blobstorage_groupinfo.h
+++ b/ydb/core/blobstorage/groupinfo/blobstorage_groupinfo.h
@@ -172,7 +172,7 @@ public:
             TString DataInfo;
         };
 
-        virtual TPartsState GetDataState(const TLogoBlobID& id, const TPartsData& partsData) const = 0;
+        virtual TPartsState GetDataState(const TLogoBlobID& id, const TPartsData& partsData, char separator) const = 0;
     };
 
     ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////

--- a/ydb/core/blobstorage/groupinfo/blobstorage_groupinfo_data_check.h
+++ b/ydb/core/blobstorage/groupinfo/blobstorage_groupinfo_data_check.h
@@ -16,9 +16,10 @@ class TDataIntegrityCheckerTrivial : public TDataIntegrityCheckerBase {
 public:
     using TDataIntegrityCheckerBase::TDataIntegrityCheckerBase;
 
-    TPartsState GetDataState(const TLogoBlobID& id, const TPartsData& partsData) const override {
+    TPartsState GetDataState(const TLogoBlobID& id, const TPartsData& partsData, char separator) const override {
         Y_UNUSED(id);
         Y_UNUSED(partsData);
+        Y_UNUSED(separator);
         return {};
     }
 };
@@ -27,7 +28,7 @@ class TDataIntegrityCheckerBlock42 : public TDataIntegrityCheckerBase {
 public:
     using TDataIntegrityCheckerBase::TDataIntegrityCheckerBase;
 
-    TPartsState GetDataState(const TLogoBlobID& id, const TPartsData& partsData) const override {
+    TPartsState GetDataState(const TLogoBlobID& id, const TPartsData& partsData, char separator) const override {
         Y_ABORT_UNLESS(partsData.Parts.size() == 6);
 
         TPartsState partsState;
@@ -58,7 +59,7 @@ public:
 
         // checking layout
         TStringStream layoutReport;
-        layoutReport << "Layout info:" << Endl;
+        layoutReport << "Layout info:" << separator;
 
         TStringStream str;
         bool hasUnequalParts = false;
@@ -80,19 +81,19 @@ public:
                 str << "]";
                 ++ver;
             }
-            str << Endl;
+            str << separator;
         }
 
         layoutReport << str.Str();
         if (hasUnequalParts) {
             partsState.IsOk = false;
-            layoutReport << "ERROR: There are unequal parts" << Endl;
+            layoutReport << "ERROR: There are unequal parts" << separator;
         }
         partsState.DataInfo = layoutReport.Str();
 
         // checking erasure
         TStringStream erasureReport;
-        erasureReport << "Erasure info:" << Endl;
+        erasureReport << "Erasure info:" << separator;
 
         std::vector<ui32> partIds;
         partIds.reserve(6);
@@ -144,7 +145,7 @@ public:
                         if (cmp) {
                             erasureError = true;
                         } else {
-                            str << "OK" << Endl;
+                            str << "OK" << separator;
                             erasureReport << str.Str(); // report only succesful restore
                         }
                     }
@@ -199,7 +200,7 @@ public:
 
         if (erasureError) {
             partsState.IsOk = false;
-            erasureReport << "ERROR: There are erasure restore fails" << Endl;
+            erasureReport << "ERROR: There are erasure restore fails" << separator;
         }
 
         partsState.DataInfo += erasureReport.Str();
@@ -214,7 +215,7 @@ private:
 public:
     using TDataIntegrityCheckerBase::TDataIntegrityCheckerBase;
 
-    TPartsState GetDataState(const TLogoBlobID& id, const TPartsData& partsData) const override {
+    TPartsState GetDataState(const TLogoBlobID& id, const TPartsData& partsData, char separator) const override {
         Y_UNUSED(id);
         Y_ABORT_UNLESS(partsData.Parts.size() == 3);
 
@@ -244,7 +245,7 @@ public:
         }
 
         TStringStream layoutReport;
-        layoutReport << "Layout info:" << Endl;
+        layoutReport << "Layout info:" << separator;
 
         TStringStream str;
         bool hasUnequalParts = (seenParts.size() > 1);
@@ -260,12 +261,12 @@ public:
             str << "]";
             ++ver;
         }
-        str << Endl;
+        str << separator;
         layoutReport << str.Str();
 
         if (hasUnequalParts) {
             partsState.IsOk = false;
-            layoutReport << "ERROR: There are unequal parts" << Endl;
+            layoutReport << "ERROR: There are unequal parts" << separator;
         }
         partsState.DataInfo = layoutReport.Str();
 


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

Now there is an option to display DataInfo in a single line and fields DataStatus and PlacementStatus are displayed as strings, not integers.

### Changelog category <!-- remove all except one -->

* Not for changelog (changelog entry is not required)
