### PR TITLE
`COMMIT_INTERVAL` default value

### DIFF
--- a/ydb/core/kqp/provider/yql_kikimr_gateway.cpp
+++ b/ydb/core/kqp/provider/yql_kikimr_gateway.cpp
@@ -77,7 +77,9 @@ void TReplicationSettings::TStaticCredentials::Serialize(NKikimrReplication::TSt
 }
 
 void TReplicationSettings::TGlobalConsistency::Serialize(NKikimrReplication::TConsistencySettings_TGlobalConsistency& proto) const {
-    proto.SetCommitIntervalMilliSeconds(CommitInterval.MilliSeconds());
+    if (CommitInterval) {
+        proto.SetCommitIntervalMilliSeconds(CommitInterval.MilliSeconds());
+    }
 }
 
 TFuture<IKikimrGateway::TGenericResult> IKikimrGateway::CreatePath(const TString& path, TCreateDirFunc createDir) {

--- a/ydb/core/protos/replication.proto
+++ b/ydb/core/protos/replication.proto
@@ -44,7 +44,7 @@ message TConsistencySettings {
     }
 
     message TGlobalConsistency {
-        optional uint64 CommitIntervalMilliSeconds = 1;
+        optional uint64 CommitIntervalMilliSeconds = 1 [default = 10000]; // 10s
     }
 
     oneof Level {


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

Fixed an [issue](https://github.com/ydb-platform/ydb/issues/21814) where a replication instance with an unspecified `COMMIT_INTERVAL` option caused the process to crash.

### Changelog category <!-- remove all except one -->

* Bugfix

### Description for reviewers <!-- (optional) description for those who read this PR -->

...
