### PR TITLE
State storage rack priority rule

### DIFF
--- a/ydb/core/blobstorage/nodewarden/distconf_generate.cpp
+++ b/ydb/core/blobstorage/nodewarden/distconf_generate.cpp
@@ -1,7 +1,7 @@
 #include "distconf.h"
+#include "distconf_statestorage_config_generator.h"
 
 #include <ydb/core/mind/bscontroller/group_geometry_info.h>
-
 #include <ydb/library/yaml_config/yaml_config_helpers.h>
 #include <ydb/library/yaml_json/yaml_to_json.h>
 #include <library/cpp/streams/zstd/zstd.h>
@@ -573,7 +573,6 @@ namespace NKikimr::NStorage {
         std::map<std::optional<TBridgePileId>, THashMap<TString, std::vector<std::tuple<ui32, TNodeLocation>>>> nodes;
         bool goodConfig = true;
         for (const auto& node : baseConfig.GetAllNodes()) {
-
             std::optional<TBridgePileId> pileId = node.HasBridgePileId()
                 ? std::make_optional(TBridgePileId::FromProto(&node, &NKikimrBlobStorage::TNodeIdentifier::GetBridgePileId))
                 : std::nullopt;
@@ -581,104 +580,10 @@ namespace NKikimr::NStorage {
             TNodeLocation location(node.GetLocation());
             nodes[pileId][location.GetDataCenterId()].emplace_back(node.GetNodeId(), location);
         }
-
-        auto pickNodes = [&](std::vector<std::tuple<ui32, TNodeLocation>>& nodes, size_t ringsCount, size_t nodesInRing) {
-            Y_ABORT_UNLESS(ringsCount * nodesInRing <= nodes.size());
-            THashSet<ui32> disabled;
-            auto compByRack = [](const auto& x, const auto& y) {
-                return std::get<1>(x).GetRackId() < std::get<1>(y).GetRackId()
-                    || (std::get<1>(x).GetRackId() == std::get<1>(y).GetRackId() && std::get<0>(x) < std::get<0>(y));
-            };
-            auto compByState = [&](const auto& x, const auto& y) {
-                ui32 state1 = SelfHealNodesState.contains(std::get<0>(x)) ? SelfHealNodesState.at(std::get<0>(x)) : Max<ui32>();
-                ui32 state2 = SelfHealNodesState.contains(std::get<0>(y)) ? SelfHealNodesState.at(std::get<0>(y)) : Max<ui32>();
-                return state1 < state2 || (state1 == state2 && compByRack(x, y));
-            };
-            std::ranges::sort(nodes, compByState);
-            ui32 cnt = 0;
-            for (auto &[nodeId, _] : nodes) {
-                if (SelfHealNodesState[nodeId] == 0) {
-                    cnt++;
-                    continue;
-                }
-                if (cnt >= ringsCount * nodesInRing) {
-                    disabled.insert(nodeId);
-                } else {
-                    cnt++;
-                    goodConfig = false;
-                }
-            }
-            std::ranges::sort(nodes, compByRack);
-
-            std::vector<std::vector<ui32>> result;
-            result.resize(ringsCount);
-            auto iter = nodes.begin();
-            TNodeLocation location;
-            for(ui32 i : xrange(ringsCount)) {
-                std::vector<ui32> &ring = result[i];
-                while (ring.size() < nodesInRing) {
-                    ui32 nodeId = std::get<0>(*iter);
-                    location = std::get<1>(*iter);
-                    iter++;
-                    if (disabled.contains(nodeId)) {
-                        if (iter == nodes.end()) {
-                            iter = nodes.begin();
-                        }
-                        continue;
-                    }
-                    ring.push_back(nodeId);
-                    disabled.insert(nodeId);
-                }
-                while (iter != nodes.end() && std::get<1>(*iter).GetRackId() == location.GetRackId()) {
-                    ++iter;
-                }
-                if (iter == nodes.end()) {
-                    iter = nodes.begin();
-                }
-            }
-            return result;
-        };
-
         for (auto& [pileId, nodesByDataCenter] : nodes) {
-            size_t minNodesInDc = Max<size_t>();
-            for (auto& [_, v] : nodesByDataCenter) {
-                minNodesInDc = Min<size_t>(minNodesInDc, v.size());
-            }
-            const size_t datacenterCoeff = 1000 / nodesByDataCenter.size();
-            ui32 nodesInRing = minNodesInDc / datacenterCoeff + 1;
-
-            std::vector<std::vector<ui32>> rings;
-            const size_t maxNodesPerDataCenter = nodesByDataCenter.size() == 1 ? 8 : 3;
-            for (auto& [_, v] : nodesByDataCenter) {
-                size_t countToSelect = Min<size_t>(v.size(), maxNodesPerDataCenter);
-                if (v.size() < maxNodesPerDataCenter && nodesByDataCenter.size() > 1) {
-                    countToSelect = 1;
-                }
-                auto r = pickNodes(v, countToSelect, nodesInRing);
-                rings.insert(rings.end(), r.begin(), r.end());
-            }
-            auto *rg = ss->AddRingGroups();
-            if (pileId) {
-                pileId->CopyToProto(rg, &NKikimrConfig::TDomainsConfig::TStateStorage::TRing::SetBridgePileId);
-            }
-            ui32 ringsCnt = rings.size();
-            ui32 nToSelect = 1;
-            if (ringsCnt <= 2) {
-                nToSelect = 1;
-            } else if (ringsCnt < 8) {
-                nToSelect = 3;
-            } else if (ringsCnt == 8) {
-                nToSelect = 5;
-            } else if (ringsCnt > 8) {
-                nToSelect = 9;
-            }
-            rg->SetNToSelect(nToSelect);
-            for (auto &nodes : rings) {
-                auto *ring = rg->AddRing();
-                for(auto nodeId : nodes) {
-                    ring->AddNode(nodeId);
-                }
-            }
+            TStateStoragePerPileGenerator generator(nodesByDataCenter, SelfHealNodesState, pileId);
+            generator.AddRingGroup(ss);
+            goodConfig &= generator.IsGoodConfig();
         }
         return goodConfig;
     }

--- a/ydb/core/blobstorage/nodewarden/distconf_statestorage_config_generator.cpp
+++ b/ydb/core/blobstorage/nodewarden/distconf_statestorage_config_generator.cpp
@@ -1,0 +1,174 @@
+#include "distconf.h"
+#include "distconf_statestorage_config_generator.h"
+
+#include <ydb/core/mind/bscontroller/group_geometry_info.h>
+#include <ydb/library/yaml_config/yaml_config_helpers.h>
+#include <ydb/library/yaml_json/yaml_to_json.h>
+#include <library/cpp/streams/zstd/zstd.h>
+
+namespace NKikimr::NStorage {
+
+    TStateStoragePerPileGenerator::TStateStoragePerPileGenerator(THashMap<TString, std::vector<std::tuple<ui32, TNodeLocation>>>& nodes
+        , const std::unordered_map<ui32, ui32>& selfHealNodesState
+        , const std::optional<TBridgePileId>& pileId)
+        : PileId(pileId)
+        , SelfHealNodesState(selfHealNodesState)
+    {
+        FillNodeGroups(nodes);
+        CalculateRingsParameters();
+        for (auto& group : NodeGroups) {
+            PickNodes(group);
+        }
+    }
+
+    void TStateStoragePerPileGenerator::FillNodeGroups(THashMap<TString, std::vector<std::tuple<ui32, TNodeLocation>>>& nodes) {
+        NodeGroups.resize(nodes.size() < 3 ? 1 : 3);
+        for (auto& [_, dc] : nodes) {
+            for (auto& n : dc) {
+                NodeGroups[0].Nodes.emplace_back(n);
+                ui32 nodeId = std::get<0>(n);
+                if (SelfHealNodesState.contains(nodeId)) {
+                    ui32 state = SelfHealNodesState.at(nodeId);
+                    BadNodeState = Max(BadNodeState, state);
+                    auto& states = NodeGroups[0].State;
+                    states.resize(BadNodeState + 1);
+                    states[state]++;
+                }
+            }
+            for (auto& ng : NodeGroups) {
+                ng.State.resize(BadNodeState + 1);
+            }
+            std::ranges::sort(NodeGroups, [&](const auto& x, const auto& y) {
+                for (ui32 idx : xrange(BadNodeState + 1)) {
+                    if (x.State[idx] != y.State[idx]) {
+                        return x.State[idx] < y.State[idx];
+                    }
+                }
+                return x.Nodes.size() < y.Nodes.size() || (x.Nodes.size() > 0 && x.Nodes.size() == y.Nodes.size() && std::get<0>(x.Nodes[0]) < std::get<0>(y.Nodes[0]));
+            });
+        }
+        BadNodeState++;
+        Y_ABORT_UNLESS(NodeGroups.size() > 0 && NodeGroups[0].Nodes.size() > 0);
+    }
+
+    void TStateStoragePerPileGenerator::CalculateRingsParameters() {
+        ui32 minNodesInGroup = NodeGroups[0].Nodes.size();
+        if (NodeGroups.size() == 1) {
+            if (minNodesInGroup < 5) {
+                RingsInGroupCount = minNodesInGroup;
+                NToSelect = minNodesInGroup < 3 ? 1 : 3;
+            } else {
+                RingsInGroupCount = minNodesInGroup < 8 ? minNodesInGroup : 8;
+                NToSelect = 5;
+            }
+            ReplicasInRingCount = 1 + minNodesInGroup / 1000;
+        } else {
+            RingsInGroupCount = minNodesInGroup < 3 ? 1 : 3;
+            NToSelect = RingsInGroupCount < 3 ? 3 : 9;
+            ui32 nodesCnt = 0;
+            for (auto& n : NodeGroups) {
+                nodesCnt += n.Nodes.size();
+            }
+            ReplicasInRingCount = 1 + nodesCnt / 1000;
+            if (ReplicasInRingCount * RingsInGroupCount > minNodesInGroup) {
+                ReplicasInRingCount = 1;
+            }
+        }
+    }
+
+    bool TStateStoragePerPileGenerator::IsGoodConfig() const {
+        return GoodConfig;
+    }
+
+    void TStateStoragePerPileGenerator::AddRingGroup(NKikimrConfig::TDomainsConfig::TStateStorage *ss) {
+        auto *rg = ss->AddRingGroups();
+        if (PileId) {
+            PileId->CopyToProto(rg, &NKikimrConfig::TDomainsConfig::TStateStorage::TRing::SetBridgePileId);
+        }
+        rg->SetNToSelect(NToSelect);
+        for (auto &nodes : Rings) {
+            auto *ring = rg->AddRing();
+            for(auto nodeId : nodes) {
+                ring->AddNode(nodeId);
+            }
+        }
+    }
+
+    bool TStateStoragePerPileGenerator::PickNodesSimpleStrategy(TNodeGroup& group, ui32 stateLimit, bool ignoreRacks) {
+        auto iter = group.Nodes.begin();
+        TNodeLocation location;
+
+        std::vector<std::vector<ui32>> result;
+        result.resize(RingsInGroupCount);
+        for (ui32 i : xrange(RingsInGroupCount)) {
+            if (iter == group.Nodes.end()) {
+                return false;
+            }
+            std::vector<ui32> &ring = result[i];
+            while (ring.size() < ReplicasInRingCount) {
+                if (iter == group.Nodes.end()) {
+                    return false;
+                }
+                ui32 nodeId = std::get<0>(*iter);
+                location = std::get<1>(*iter);
+                ui32 state = SelfHealNodesState.contains(nodeId) ? SelfHealNodesState.at(nodeId) : BadNodeState;
+                if (state <= stateLimit) {
+                    ring.push_back(nodeId);
+                }
+                iter++;
+            }
+            if (!ignoreRacks) {
+                while (iter != group.Nodes.end() && std::get<1>(*iter).GetRackId() == location.GetRackId()) {
+                    ++iter;
+                }
+            }
+        }
+        for (auto& r : result) {
+            Rings.emplace_back(r);
+        }
+        return true;
+    }
+
+    void TStateStoragePerPileGenerator::PickNodes(TNodeGroup& group) {
+        std::unordered_map<TString, std::vector<ui32>> rackStates;
+        for (auto& n : group.Nodes) {
+            auto rack = std::get<1>(n).GetRackId();
+            auto nodeId = std::get<0>(n);
+            ui32 state = SelfHealNodesState.contains(nodeId) ? SelfHealNodesState.at(nodeId) : BadNodeState;
+            auto& rackState = rackStates[rack];
+            if (rackState.empty()) {
+                rackState.resize(BadNodeState + 1);
+            }
+            rackState[state]++;
+        }
+
+        auto compByRack = [&](const auto& x, const auto& y) {
+            auto rackX = std::get<1>(x).GetRackId();
+            auto rackY = std::get<1>(y).GetRackId();
+            if (rackX == rackY) {
+                auto nodeX = std::get<0>(x);
+                auto nodeY = std::get<0>(y);
+                ui32 state1 = SelfHealNodesState.contains(nodeX) ? SelfHealNodesState.at(nodeX) : BadNodeState;
+                ui32 state2 = SelfHealNodesState.contains(nodeY) ? SelfHealNodesState.at(nodeY) : BadNodeState;
+                return state1 < state2 || (state1 == state2 && nodeX < nodeY);
+            }
+            auto& rackStateX = rackStates[rackX];
+            auto& rackStateY = rackStates[rackY];
+            for (ui32 idx : xrange(BadNodeState + 1)) {
+                if (rackStateX[idx] != rackStateY[idx]) {
+                    return rackStateX[idx] > rackStateY[idx];
+                }
+            }
+            return rackX < rackY;
+        };
+
+        std::ranges::sort(group.Nodes, compByRack);
+        for (ui32 stateLimit : xrange(BadNodeState + 1)) {
+            if (PickNodesSimpleStrategy(group, stateLimit, rackStates.size() < RingsInGroupCount)) {
+                return;
+            }
+        }
+        Y_ABORT_UNLESS(PickNodesSimpleStrategy(group, Max<ui32>(), true));
+    }
+
+}

--- a/ydb/core/blobstorage/nodewarden/distconf_statestorage_config_generator.h
+++ b/ydb/core/blobstorage/nodewarden/distconf_statestorage_config_generator.h
@@ -1,0 +1,37 @@
+#pragma once
+
+#include "distconf.h"
+
+namespace NKikimr::NStorage {
+
+    class TStateStoragePerPileGenerator {
+    public:
+        TStateStoragePerPileGenerator(THashMap<TString, std::vector<std::tuple<ui32, TNodeLocation>>>& nodes,
+            const std::unordered_map<ui32, ui32>& selfHealNodesState,
+            const std::optional<TBridgePileId>& pileId);
+        bool IsGoodConfig() const;
+        void AddRingGroup(NKikimrConfig::TDomainsConfig::TStateStorage *ss);
+
+    private:
+        struct TNodeGroup {
+            std::vector<std::tuple<ui32, TNodeLocation>> Nodes;
+            std::vector<ui32> State;
+        };
+
+        void FillNodeGroups(THashMap<TString, std::vector<std::tuple<ui32, TNodeLocation>>>& nodes);
+        void CalculateRingsParameters();
+        bool PickNodesSimpleStrategy(TNodeGroup& group, ui32 stateLimit, bool ignoreRacks);
+        void PickNodes(TNodeGroup& group);
+
+        const std::optional<TBridgePileId> PileId;
+        const std::unordered_map<ui32, ui32>& SelfHealNodesState;
+        std::vector<TNodeGroup> NodeGroups;
+        std::unordered_map<TString, std::vector<ui32>> RackStates;
+        std::vector<std::vector<ui32>> Rings;
+        ui32 RingsInGroupCount = 1;
+        ui32 ReplicasInRingCount = 1;
+        ui32 NToSelect = 1;
+        ui32 BadNodeState = 0;
+        bool GoodConfig = true;
+    };
+}

--- a/ydb/core/blobstorage/nodewarden/distconf_ut.cpp
+++ b/ydb/core/blobstorage/nodewarden/distconf_ut.cpp
@@ -91,8 +91,11 @@ Y_UNIT_TEST_SUITE(TDistconfGenerateConfigTest) {
     }
 
     void CheckStateStorage2(const NKikimrConfig::TDomainsConfig::TStateStorage& ss, std::string expected) {
-        Cerr << "Actual: " << ss << Endl;
         TString actual = TStringBuilder() << ss;
+        if (actual != expected) {
+            Cerr << "Err Actual: " << ss << Endl;
+            Cerr << "Err Expected: " << expected << Endl;
+        }
         UNIT_ASSERT_EQUAL(actual, expected);
     }
 
@@ -102,10 +105,9 @@ Y_UNIT_TEST_SUITE(TDistconfGenerateConfigTest) {
             "Ring { Node: 7 Node: 8 } Ring { Node: 9 Node: 10 } Ring { Node: 11 Node: 12 } "
             "Ring { Node: 13 Node: 14 } Ring { Node: 15 Node: 16 } } }");
         CheckStateStorage2(GenerateDCStateStorage(1, 2, 1000), "{ RingGroups { NToSelect: 5 "
-            "Ring { Node: 1 Node: 2 Node: 3 } Ring { Node: 1001 Node: 1002 Node: 1003 } "
-            "Ring { Node: 4 Node: 5 Node: 6 } Ring { Node: 1004 Node: 1005 Node: 1006 } "
-            "Ring { Node: 7 Node: 8 Node: 9 } Ring { Node: 1007 Node: 1008 Node: 1009 } "
-            "Ring { Node: 10 Node: 11 Node: 12 } Ring { Node: 1010 Node: 1011 Node: 1012 } } }");
+            "Ring { Node: 1 Node: 2 Node: 3 } Ring { Node: 4 Node: 5 Node: 6 } Ring { Node: 7 Node: 8 Node: 9 } "
+            "Ring { Node: 10 Node: 11 Node: 12 } Ring { Node: 13 Node: 14 Node: 15 } Ring { Node: 16 Node: 17 Node: 18 } "
+            "Ring { Node: 19 Node: 20 Node: 21 } Ring { Node: 22 Node: 23 Node: 24 } } }");
         CheckStateStorage2(GenerateDCStateStorage(1, 10, 100), "{ RingGroups { NToSelect: 5 "
             "Ring { Node: 1 Node: 2 } Ring { Node: 101 Node: 102 } Ring { Node: 201 Node: 202 } "
             "Ring { Node: 301 Node: 302 } Ring { Node: 401 Node: 402 } Ring { Node: 501 Node: 502 } "
@@ -114,21 +116,35 @@ Y_UNIT_TEST_SUITE(TDistconfGenerateConfigTest) {
 
     Y_UNIT_TEST(GenerateConfig3DCBigCases) {
         CheckStateStorage2(GenerateDCStateStorage(3, 1, 300), "{ RingGroups { NToSelect: 9 "
+            "Ring { Node: 1 } Ring { Node: 2 } Ring { Node: 3 } "
             "Ring { Node: 301 } Ring { Node: 302 } Ring { Node: 303 } "
-            "Ring { Node: 601 } Ring { Node: 602 } Ring { Node: 603 } "
-            "Ring { Node: 1 } Ring { Node: 2 } Ring { Node: 3 } } }");
+            "Ring { Node: 601 } Ring { Node: 602 } Ring { Node: 603 } } }");
         CheckStateStorage2(GenerateDCStateStorage(3, 10, 100), "{ RingGroups { NToSelect: 9 "
-            "Ring { Node: 1001 Node: 1002 Node: 1003 Node: 1004 } Ring { Node: 1101 Node: 1102 Node: 1103 Node: 1104 } Ring { Node: 1201 Node: 1202 Node: 1203 Node: 1204 } "
-            "Ring { Node: 2001 Node: 2002 Node: 2003 Node: 2004 } Ring { Node: 2101 Node: 2102 Node: 2103 Node: 2104 } Ring { Node: 2201 Node: 2202 Node: 2203 Node: 2204 } "
-            "Ring { Node: 1 Node: 2 Node: 3 Node: 4 } Ring { Node: 101 Node: 102 Node: 103 Node: 104 } Ring { Node: 201 Node: 202 Node: 203 Node: 204 } } }");
+            "Ring { Node: 1 Node: 2 Node: 3 Node: 4 } Ring { Node: 101 Node: 102 Node: 103 Node: 104 } "
+            "Ring { Node: 201 Node: 202 Node: 203 Node: 204 } Ring { Node: 1001 Node: 1002 Node: 1003 Node: 1004 } "
+            "Ring { Node: 1101 Node: 1102 Node: 1103 Node: 1104 } Ring { Node: 1201 Node: 1202 Node: 1203 Node: 1204 } "
+            "Ring { Node: 2001 Node: 2002 Node: 2003 Node: 2004 } Ring { Node: 2101 Node: 2102 Node: 2103 Node: 2104 } "
+            "Ring { Node: 2201 Node: 2202 Node: 2203 Node: 2204 } } }");
     }
 
-    Y_UNIT_TEST(GenerateConfigIgnoreNodes) {
+    Y_UNIT_TEST(IgnoreNodes) {
         CheckStateStorage(GenerateDCStateStorage(1, 1, 20, { {3, 1} }), 5, {1, 2, 4, 5, 6, 7, 8, 9});
         CheckStateStorage(GenerateDCStateStorage(1, 1, 20, { {3, 1}, {7, 3}, {10, 2} }), 5, {1, 2, 4, 5, 6, 8, 9, 11});
         CheckStateStorage(GenerateDCStateStorage(1, 1, 10, { {3, 1}, {7, 3}, {10, 2} }), 5, {1, 2, 3, 4, 5, 6, 8, 9});
         CheckStateStorage(GenerateDCStateStorage(1, 1, 10, { {3, 2}, {7, 3}, {10, 1} }), 5, {1, 2, 4, 5, 6, 8, 9, 10});
         CheckStateStorage(GenerateDCStateStorage(3, 3, 3, { {13, 1} }), 9, {1, 4, 7, 10, 14, 16, 19, 22, 25});
+    }
+
+    Y_UNIT_TEST(BadRack) {
+        CheckStateStorage(GenerateDCStateStorage(3, 3, 3, { {13, 5}, {14, 3}, {15, 4} }), 9, {1, 4, 7, 10, 14, 16, 19, 22, 25});
+        CheckStateStorage(GenerateDCStateStorage(3, 3, 3, { {13, 2}, {14, 3}, {15, 4} }), 9, {1, 4, 7, 10, 13, 16, 19, 22, 25});
+        CheckStateStorage(GenerateDCStateStorage(3, 3, 3, { {13, 2}, {14, 3}, {15, 1} }), 9, {1, 4, 7, 10, 15, 16, 19, 22, 25});
+    }
+
+    Y_UNIT_TEST(ExtraDCHelp) {
+        CheckStateStorage(GenerateDCStateStorage(4, 3, 1, { {3, 1} }), 9, {1, 2, 4, 5, 6, 7, 8, 9, 10});
+        CheckStateStorage(GenerateDCStateStorage(4, 3, 1, { {6, 1} }), 9, {1, 2, 3, 4, 5, 7, 8, 9, 10});
+        CheckStateStorage(GenerateDCStateStorage(4, 3, 1, { {9, 1}, {8, 4} }), 9, {1, 2, 3, 4, 5, 6, 7, 10, 11});
     }
 }
 }

--- a/ydb/core/blobstorage/nodewarden/ya.make
+++ b/ydb/core/blobstorage/nodewarden/ya.make
@@ -25,6 +25,8 @@ SRCS(
     distconf_scatter_gather.cpp
     distconf_selfheal.h
     distconf_selfheal.cpp
+    distconf_statestorage_config_generator.h
+    distconf_statestorage_config_generator.cpp
     distconf_validate.cpp
     node_warden.h
     node_warden_cache.cpp


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

When generate config for state storage:
1. Cases with more than 3 DC. Extra DC nodes should be merged with one of other DC to replace bad nodes. The case intermediate of migration ydb from one to other DC.
2. Exact number of racks should be used in DC. The cases when rack is down we can not put replicas of different rings in one rack.

### Changelog category <!-- remove all except one -->

* Not for changelog (changelog entry is not required)

### Description for reviewers <!-- (optional) description for those who read this PR -->

...
