### PR TITLE
Use tablet state subscriptions in tablet resolver

### DIFF
--- a/ydb/core/base/statestorage_proxy.cpp
+++ b/ydb/core/base/statestorage_proxy.cpp
@@ -39,6 +39,7 @@ class TStateStorageProxyRequest : public TActor<TStateStorageProxyRequest> {
     TActorId SuggestedLeader;
     TActorId SuggestedLeaderTablet;
     TActorId Source;
+    ui64 SourceCookie = 0;
 
     ui32 Replicas;
     THolder<TStateStorageInfo::TSelection> ReplicaSelection;
@@ -91,12 +92,12 @@ class TStateStorageProxyRequest : public TActor<TStateStorageProxyRequest> {
             }
         }
         if (NotifyRingGroupProxy)
-            Send(Source, new TEvStateStorage::TEvRingGroupPassAway());
+            Send(Source, new TEvStateStorage::TEvRingGroupPassAway(), 0, SourceCookie);
         TActor::PassAway();
     }
 
     void Reply(NKikimrProto::EReplyStatus status) {
-        Send(Source, new TEvStateStorage::TEvInfo(status, TabletID, Cookie, ReplyLeader, ReplyLeaderTablet, ReplyGeneration, ReplyStep, ReplyLocked, ReplyLockedFor, Signature, Followers));
+        Send(Source, new TEvStateStorage::TEvInfo(status, TabletID, Cookie, ReplyLeader, ReplyLeaderTablet, ReplyGeneration, ReplyStep, ReplyLocked, ReplyLockedFor, Signature, Followers), 0, SourceCookie);
     }
 
     void ReplyAndDie(NKikimrProto::EReplyStatus status) {
@@ -193,7 +194,7 @@ class TStateStorageProxyRequest : public TActor<TStateStorageProxyRequest> {
             (Info->ClusterStateGeneration == clusterStateGeneration && Info->ClusterStateGuid != clusterStateGuid)) {
             BLOG_D("StateStorageProxy TEvNodeWardenNotifyConfigMismatch: Info->ClusterStateGeneration=" << Info->ClusterStateGeneration << " clusterStateGeneration=" << clusterStateGeneration <<" Info->ClusterStateGuid=" << Info->ClusterStateGuid << " clusterStateGuid=" << clusterStateGuid);
             if (NotifyRingGroupProxy) {
-                Send(Source, new TEvStateStorage::TEvConfigVersionInfo(clusterStateGeneration, clusterStateGuid));
+                Send(Source, new TEvStateStorage::TEvConfigVersionInfo(clusterStateGeneration, clusterStateGuid), 0, SourceCookie);
             }
             Send(MakeBlobStorageNodeWardenID(SelfId().NodeId()),
                 new NStorage::TEvNodeWardenNotifyConfigMismatch(sender.NodeId(), clusterStateGeneration, clusterStateGuid));
@@ -285,6 +286,7 @@ class TStateStorageProxyRequest : public TActor<TStateStorageProxyRequest> {
         TEvStateStorage::TEvLookup *msg = ev->Get();
         BLOG_D("ProxyRequest::HandleInit ringGroup:" << RingGroupIndex << " ev: " << msg->ToString());
         Source = ev->Sender;
+        SourceCookie = ev->Cookie;
 
         PrepareInit(msg);
         SendRequest([this](ui64 cookie, TActorId /*replica*/) { return new TEvStateStorage::TEvReplicaLookup(TabletID, cookie, Info->ClusterStateGeneration, Info->ClusterStateGuid); });
@@ -296,6 +298,7 @@ class TStateStorageProxyRequest : public TActor<TStateStorageProxyRequest> {
         TEvStateStorage::TEvUpdate *msg = ev->Get();
         BLOG_D("ProxyRequest::HandleInit ringGroup:" << RingGroupIndex << " ev: " << msg->ToString());
         Source = ev->Sender;
+        SourceCookie = ev->Cookie;
 
         PrepareInit(msg);
 
@@ -313,6 +316,7 @@ class TStateStorageProxyRequest : public TActor<TStateStorageProxyRequest> {
         TEvStateStorage::TEvLock *msg = ev->Get();
         BLOG_D("ProxyRequest::HandleInit ringGroup:" << RingGroupIndex << " ev: " << msg->ToString());
         Source = ev->Sender;
+        SourceCookie = ev->Cookie;
 
         PrepareInit(msg);
 
@@ -496,7 +500,7 @@ class TStateStorageProxyRequest : public TActor<TStateStorageProxyRequest> {
             ++SignaturesMerged;
 
             if (RepliesMerged + RepliesAfterReply == Replicas) {
-                Send(Source, new TEvStateStorage::TEvUpdateSignature(TabletID, Signature));
+                Send(Source, new TEvStateStorage::TEvUpdateSignature(TabletID, Signature), 0, SourceCookie);
                 return PassAway();
             }
         }
@@ -514,7 +518,7 @@ class TStateStorageProxyRequest : public TActor<TStateStorageProxyRequest> {
         MergeSigNodeError(node);
 
         if (RepliesMerged + RepliesAfterReply == Replicas) {
-            Send(Source, new TEvStateStorage::TEvUpdateSignature(TabletID, Signature));
+            Send(Source, new TEvStateStorage::TEvUpdateSignature(TabletID, Signature), 0, SourceCookie);
             return PassAway();
         }
     }
@@ -543,7 +547,7 @@ class TStateStorageProxyRequest : public TActor<TStateStorageProxyRequest> {
     void HandleUpdateSigTimeout() {
         BLOG_D("ProxyRequest::HandleUpdateSigTimeout ringGroup:" << RingGroupIndex << " RepliesAfterReply# " << (ui32)RepliesAfterReply);
         if (RepliesAfterReply > 0)
-            Send(Source, new TEvStateStorage::TEvUpdateSignature(TabletID, Signature));
+            Send(Source, new TEvStateStorage::TEvUpdateSignature(TabletID, Signature), 0, SourceCookie);
         PassAway();
     }
 
@@ -646,6 +650,7 @@ class TStateStorageRingGroupProxyRequest : public TActorBootstrapped<TStateStora
     THashMap<ui32, TActorId> RingGroupActorsByIndex;
 
     TActorId Source;
+    ui64 SourceCookie = 0;
     THashSet<TActorId> Replies;
     ui32 RingGroupPassAwayCounter;
     bool WaitAllReplies;
@@ -666,6 +671,7 @@ class TStateStorageRingGroupProxyRequest : public TActorBootstrapped<TStateStora
     void HandleInit(TEvStateStorage::TEvLookup::TPtr &ev) {
         TEvStateStorage::TEvLookup *msg = ev->Get();
         Source = ev->Sender;
+        SourceCookie = ev->Cookie;
         WaitAllReplies = msg->ProxyOptions.SigWaitMode != msg->ProxyOptions.SigNone;
         BLOG_D("RingGroupProxyRequest::HandleInit ev: " << msg->ToString());
         for (ui32 ringGroupIndex = 0; ringGroupIndex < Info->RingGroups.size(); ++ringGroupIndex) {
@@ -685,6 +691,7 @@ class TStateStorageRingGroupProxyRequest : public TActorBootstrapped<TStateStora
     void HandleInit(T::TPtr &ev) {
         T *msg = ev->Get();
         Source = ev->Sender;
+        SourceCookie = ev->Cookie;
         WaitAllReplies = true;
         BLOG_D("RingGroupProxyRequest::HandleInit ev: " << msg->ToString());
         for (ui32 ringGroupIndex = 0; ringGroupIndex < Info->RingGroups.size(); ++ringGroupIndex) {
@@ -720,7 +727,7 @@ class TStateStorageRingGroupProxyRequest : public TActorBootstrapped<TStateStora
     void Reply(NKikimrProto::EReplyStatus status) {
         auto* msg = new TEvStateStorage::TEvInfo(status, TabletID, Cookie, CurrentLeader, CurrentLeaderTablet, CurrentGeneration, CurrentStep, Locked, LockedFor, Signature, Followers);
         BLOG_D("RingGroupProxyRequest::Reply ev: " << msg->ToString());
-        Send(Source, msg);
+        Send(Source, msg, 0, SourceCookie);
     }
 
     bool ShouldReply() {
@@ -750,7 +757,7 @@ class TStateStorageRingGroupProxyRequest : public TActorBootstrapped<TStateStora
     void HandleResult(TEvStateStorage::TEvUpdateSignature::TPtr &ev) {
         TEvStateStorage::TEvUpdateSignature *msg = ev->Get();
         Signature.Merge(msg->Signature);
-        Send(Source, new TEvStateStorage::TEvUpdateSignature(msg->TabletID, Signature));
+        Send(Source, new TEvStateStorage::TEvUpdateSignature(msg->TabletID, Signature), 0, SourceCookie);
     }
 
     void HandleConfigVersion(TEvStateStorage::TEvConfigVersionInfo::TPtr &ev) {
@@ -806,6 +813,7 @@ public:
 class TStateStorageDumpRequest : public TActorBootstrapped<TStateStorageDumpRequest> {
 protected:
     const TActorId Sender;
+    const ui64 Cookie;
     TIntrusivePtr<TStateStorageInfo> Info;
     TList<TActorId> AllReplicas;
     TAutoPtr<TEvStateStorage::TEvResponseReplicasDumps> Response;
@@ -816,14 +824,15 @@ public:
         return NKikimrServices::TActivity::TABLET_FORWARDING_ACTOR;
     }
 
-    TStateStorageDumpRequest(const TActorId &sender, const TIntrusivePtr<TStateStorageInfo> &info)
+    TStateStorageDumpRequest(const TActorId &sender, ui64 cookie, const TIntrusivePtr<TStateStorageInfo> &info)
         : Sender(sender)
+        , Cookie(cookie)
         , Info(info)
         , UndeliveredCount(0)
     {}
 
     void SendResponse() {
-        Send(Sender, Response.Release());
+        Send(Sender, Response.Release(), 0, Cookie);
         PassAway();
     }
 
@@ -873,6 +882,7 @@ public:
 class TStateStorageDeleteRequest : public TActorBootstrapped<TStateStorageDeleteRequest> {
 protected:
     const TActorId Sender;
+    const ui64 Cookie;
     TIntrusivePtr<TStateStorageInfo> Info;
     TList<TActorId> AllReplicas;
     ui32 Count;
@@ -884,8 +894,9 @@ public:
         return NKikimrServices::TActivity::TABLET_FORWARDING_ACTOR;
     }
 
-    TStateStorageDeleteRequest(const TActorId &sender, const TIntrusivePtr<TStateStorageInfo> &info, ui64 tabletId)
+    TStateStorageDeleteRequest(const TActorId &sender, ui64 cookie, const TIntrusivePtr<TStateStorageInfo> &info, ui64 tabletId)
         : Sender(sender)
+        , Cookie(cookie)
         , Info(info)
         , Count(0)
         , UndeliveredCount(0)
@@ -893,7 +904,7 @@ public:
     {}
 
     void SendResponse() {
-        Send(Sender, new TEvStateStorage::TEvDeleteResult(TabletID, Count > AllReplicas.size() / 2 ? NKikimrProto::OK : NKikimrProto::ERROR));
+        Send(Sender, new TEvStateStorage::TEvDeleteResult(TabletID, Count > AllReplicas.size() / 2 ? NKikimrProto::OK : NKikimrProto::ERROR), 0, Cookie);
         PassAway();
     }
 
@@ -957,11 +968,11 @@ class TStateStorageProxy : public TActor<TStateStorageProxy> {
     THashSet<std::tuple<TActorId, ui64>> SchemeBoardSubscriptions;
 
     void Handle(TEvStateStorage::TEvRequestReplicasDumps::TPtr &ev) {
-        TActivationContext::Register(new TStateStorageDumpRequest(ev->Sender, Info));
+        TActivationContext::Register(new TStateStorageDumpRequest(ev->Sender, ev->Cookie, Info));
     }
 
     void Handle(TEvStateStorage::TEvDelete::TPtr &ev) {
-        TActivationContext::Register(new TStateStorageDeleteRequest(ev->Sender, Info, ev->Get()->TabletID));
+        TActivationContext::Register(new TStateStorageDeleteRequest(ev->Sender, ev->Cookie, Info, ev->Get()->TabletID));
     }
 
     void SpreadCleanupRequest(const TStateStorageInfo::TSelection &selection, ui64 tabletId, TActorId proposedLeader) {

--- a/ydb/core/cms/cms_ut.cpp
+++ b/ydb/core/cms/cms_ut.cpp
@@ -2484,7 +2484,7 @@ Y_UNIT_TEST_SUITE(TCmsTest) {
         // Pile #1: There are 0 rings locked on this pile => it is possible to lock.
         env.CheckPermissionRequest("user", true, false, true, true, MODE_MAX_AVAILABILITY, TStatus::ALLOW,
                                     MakeAction(TAction::RESTART_SERVICES, env.GetNodeId(0), 60000000, "storage"));
-        // Pile #0: There are 0 rings locked on this pile => it is possible to lock.                            
+        // Pile #0: There are 0 rings locked on this pile => it is possible to lock.
         env.CheckPermissionRequest("user", true, false, true, true, MODE_MAX_AVAILABILITY, TStatus::ALLOW,
                                     MakeAction(TAction::RESTART_SERVICES, env.GetNodeId(1), 60000000, "storage"));
         // Pile #1: There is already one ring locked on this pile => it is not possible to lock.

--- a/ydb/core/cms/cms_ut_common.cpp
+++ b/ydb/core/cms/cms_ut_common.cpp
@@ -586,10 +586,12 @@ static void SetupServices(TTestBasicRuntime &runtime, const TTestEnvOpts &option
     runtime.GetAppData().BootstrapConfig = TFakeNodeWhiteboardService::BootstrapConfig;
     
     if (options.IsBridgeMode) {
-        for (ui32 pileId = 0; pileId < options.PileCount; ++pileId) {
-            runtime.GetAppData().BridgeConfig.AddPiles()->SetName("r" + ToString(pileId));
+        for (ui32 nodeIndex = 0; nodeIndex < runtime.GetNodeCount(); ++nodeIndex) {
+            for (ui32 pileId = 0; pileId < options.PileCount; ++pileId) {
+                runtime.GetAppData(nodeIndex).BridgeConfig.AddPiles()->SetName("r" + ToString(pileId));
+            }
+            runtime.GetAppData(nodeIndex).BridgeModeEnabled = true;
         }
-        runtime.GetAppData().BridgeModeEnabled = true;
     }
 
     NKikimrCms::TCmsConfig cmsConfig;
@@ -679,6 +681,9 @@ TCmsTestEnv::TCmsTestEnv(const TTestEnvOpts &options)
 
     Sender = AllocateEdgeActor();
     ClientId = TActorId();
+
+    // Make sure default empty configs are handled first
+    SimulateSleep(TDuration::MilliSeconds(100));
 
     NKikimrCms::TCmsConfig cmsConfig;
     cmsConfig.MutableTenantLimits()->SetDisabledNodesRatioLimit(0);

--- a/ydb/core/cms/console/immediate_controls_configurator_ut.cpp
+++ b/ydb/core/cms/console/immediate_controls_configurator_ut.cpp
@@ -149,35 +149,46 @@ void InitImmediateControlsConfigurator(TTenantTestRuntime &runtime)
     }
 }
 
-void WaitForUpdate(TTenantTestRuntime &runtime)
-{
-    struct TIsConfigNotificationProcessed {
-        bool operator()(IEventHandle& ev)
-        {
-            if (ev.GetTypeRewrite() == NConsole::TEvConsole::EvConfigNotificationResponse) {
-                auto &rec = ev.Get<NConsole::TEvConsole::TEvConfigNotificationResponse>()->Record;
-                if (rec.GetConfigId().ItemIdsSize() != 1 || rec.GetConfigId().GetItemIds(0).GetId())
-                    return true;
-            }
+class TConfigUpdatesObserver {
+public:
+    TConfigUpdatesObserver(TTestActorRuntime& runtime)
+        : Runtime(runtime)
+        , Holder(Runtime.AddObserver<NConsole::TEvConsole::TEvConfigNotificationResponse>(
+            [this](auto& ev) {
+                auto& rec = ev->Get()->Record;
+                if (rec.GetConfigId().ItemIdsSize() != 1 || rec.GetConfigId().GetItemIds(0).GetId()) {
+                    ++Count;
+                }
+            }))
+    {}
 
-            return false;
-        }
-    };
+    void Clear() {
+        Count = 0;
+    }
 
-    TDispatchOptions options;
-    options.FinalEvents.emplace_back(TIsConfigNotificationProcessed(), 1);
-    runtime.DispatchEvents(options);
-}
+    void Wait() {
+        Runtime.WaitFor("config update", [this]{ return this->Count > 0; });
+        --Count;
+    }
+
+private:
+    TTestActorRuntime& Runtime;
+    TTestActorRuntime::TEventObserverHolder Holder;
+    size_t Count = 0;
+};
 
 template <typename ...Ts>
-void ConfigureAndWaitUpdate(TTenantTestRuntime &runtime,
+void ConfigureAndWaitUpdate(TTenantTestRuntime &runtime, TConfigUpdatesObserver &updates,
                             Ts... args)
 {
     auto *event = new TEvConsole::TEvConfigureRequest;
     CollectActions(event->Record, args...);
 
+    updates.Clear();
     runtime.SendToConsole(event);
-    WaitForUpdate(runtime);
+    auto ev = runtime.GrabEdgeEventRethrow<TEvConsole::TEvConfigureResponse>(runtime.Sender);
+    UNIT_ASSERT_VALUES_EQUAL(ev->Get()->Record.GetStatus().GetCode(), Ydb::StatusIds::SUCCESS);
+    updates.Wait();
 }
 
 void CompareControls(TTenantTestRuntime &runtime,
@@ -210,8 +221,11 @@ Y_UNIT_TEST_SUITE(TImmediateControlsConfiguratorTests)
     Y_UNIT_TEST(TestControlsInitialization)
     {
         TTenantTestRuntime runtime(DefaultConsoleTestConfig());
+        runtime.SimulateSleep(TDuration::MilliSeconds(100)); // settle down
+        TConfigUpdatesObserver updates(runtime);
+
         InitImmediateControlsConfigurator(runtime);
-        WaitForUpdate(runtime); // initial update
+        updates.Wait(); // initial update
 
         CompareControls(runtime, ITEM_CONTROLS_DEFAULT.GetConfig().GetImmediateControlsConfig());
     }
@@ -219,10 +233,13 @@ Y_UNIT_TEST_SUITE(TImmediateControlsConfiguratorTests)
     Y_UNIT_TEST(TestModifiedControls)
     {
         TTenantTestRuntime runtime(DefaultConsoleTestConfig());
-        InitImmediateControlsConfigurator(runtime);
-        WaitForUpdate(runtime); // initial update
+        runtime.SimulateSleep(TDuration::MilliSeconds(100)); // settle down
+        TConfigUpdatesObserver updates(runtime);
 
-        ConfigureAndWaitUpdate(runtime,
+        InitImmediateControlsConfigurator(runtime);
+        updates.Wait(); // initial update
+
+        ConfigureAndWaitUpdate(runtime, updates,
                                MakeAddAction(ITEM_CONTROLS1));
         CompareControls(runtime, ITEM_CONTROLS1.GetConfig().GetImmediateControlsConfig());
     }
@@ -230,18 +247,21 @@ Y_UNIT_TEST_SUITE(TImmediateControlsConfiguratorTests)
     Y_UNIT_TEST(TestResetToDefault)
     {
         TTenantTestRuntime runtime(DefaultConsoleTestConfig());
-        InitImmediateControlsConfigurator(runtime);
-        WaitForUpdate(runtime); // initial update
+        runtime.SimulateSleep(TDuration::MilliSeconds(100)); // settle down
+        TConfigUpdatesObserver updates(runtime);
 
-        ConfigureAndWaitUpdate(runtime,
+        InitImmediateControlsConfigurator(runtime);
+        updates.Wait(); // initial update
+
+        ConfigureAndWaitUpdate(runtime, updates,
                                MakeAddAction(ITEM_CONTROLS1));
         CompareControls(runtime, ITEM_CONTROLS1.GetConfig().GetImmediateControlsConfig());
 
-        ConfigureAndWaitUpdate(runtime,
+        ConfigureAndWaitUpdate(runtime, updates,
                                MakeAddAction(ITEM_CONTROLS2));
         CompareControls(runtime, ITEM_CONTROLS2_RES.GetConfig().GetImmediateControlsConfig());
 
-        ConfigureAndWaitUpdate(runtime,
+        ConfigureAndWaitUpdate(runtime, updates,
                                MakeRemoveAction(1, 1),
                                MakeRemoveAction(2, 1));
 
@@ -251,10 +271,13 @@ Y_UNIT_TEST_SUITE(TImmediateControlsConfiguratorTests)
     Y_UNIT_TEST(TestMaxLimit)
     {
         TTenantTestRuntime runtime(DefaultConsoleTestConfig());
-        InitImmediateControlsConfigurator(runtime);
-        WaitForUpdate(runtime); // initial update
+        runtime.SimulateSleep(TDuration::MilliSeconds(100)); // settle down
+        TConfigUpdatesObserver updates(runtime);
 
-        ConfigureAndWaitUpdate(runtime,
+        InitImmediateControlsConfigurator(runtime);
+        updates.Wait(); // initial update
+
+        ConfigureAndWaitUpdate(runtime, updates,
                                MakeAddAction(ITEM_CONTROLS_EXCEED_MAX));
         CompareControls(runtime, ITEM_CONTROLS_MAX.GetConfig().GetImmediateControlsConfig());
     }
@@ -262,8 +285,11 @@ Y_UNIT_TEST_SUITE(TImmediateControlsConfiguratorTests)
     Y_UNIT_TEST(TestDynamicMap)
     {
         TTenantTestRuntime runtime(DefaultConsoleTestConfig());
+        runtime.SimulateSleep(TDuration::MilliSeconds(100)); // settle down
+        TConfigUpdatesObserver updates(runtime);
+
         InitImmediateControlsConfigurator(runtime);
-        WaitForUpdate(runtime); // initial update
+        updates.Wait(); // initial update
 
         NKikimrConsole::TConfigItem dynamicMapValue;
         {
@@ -275,7 +301,7 @@ Y_UNIT_TEST_SUITE(TImmediateControlsConfiguratorTests)
             r.SetMaxInFlight(10);
         }
 
-        ConfigureAndWaitUpdate(runtime, MakeAddAction(dynamicMapValue));
+        ConfigureAndWaitUpdate(runtime, updates, MakeAddAction(dynamicMapValue));
 
         auto icb = runtime.GetAppData().Icb;
 

--- a/ydb/core/mind/hive/hive_ut.cpp
+++ b/ydb/core/mind/hive/hive_ut.cpp
@@ -1488,6 +1488,7 @@ Y_UNIT_TEST_SUITE(THiveTest) {
 
         ui32 nodeId = runtime.GetNodeId(0);
         {
+            runtime.SimulateSleep(TDuration::MilliSeconds(100));
             runtime.SendToPipe(hiveTablet, sender, new TEvHive::TEvDrainNode(nodeId));
             {
                 TDispatchOptions options;
@@ -1502,9 +1503,7 @@ Y_UNIT_TEST_SUITE(THiveTest) {
                     wasDedup = true;
                 }
             });
-            while (!wasDedup) {
-                runtime.DispatchEvents({});
-            }
+            runtime.WaitFor("dedup", [&]{ return wasDedup; }, TDuration::Seconds(1));
         }
     }
 

--- a/ydb/core/mind/node_broker_ut.cpp
+++ b/ydb/core/mind/node_broker_ut.cpp
@@ -905,6 +905,7 @@ void CheckAsyncResolveNode(TTestActorRuntime &runtime, ui32 nodeId, const TStrin
     UNIT_ASSERT(reply);
 
     UNIT_ASSERT_VALUES_EQUAL(reply->NodeId, nodeId);
+    UNIT_ASSERT(!reply->Addresses.empty());
     UNIT_ASSERT_VALUES_EQUAL(reply->Addresses[0].GetAddress(), addr);
 }
 
@@ -4778,6 +4779,10 @@ Y_UNIT_TEST_SUITE(TDynamicNameserverTest) {
         runtime.WaitFor("cache miss", [&]{return resolveBlock.size() >= 1 || syncBlock.size() >= 1; });
 
         // Reboot NodeBroker to break pipe
+        TBlockEvents<TEvTabletPipe::TEvClientConnected> connectBlock(runtime,
+            [&](auto& ev) {
+                return runtime.FindActorName(ev->GetRecipientRewrite()) == "NAMESERVICE";
+            });
         RebootTablet(runtime, MakeNodeBrokerID(), sender);
 
         // Resolve request is failed, because pipe was broken
@@ -4787,6 +4792,7 @@ Y_UNIT_TEST_SUITE(TDynamicNameserverTest) {
         resolveBlock.Stop();
         syncBlock.Stop();
         deltaBlock.Stop();
+        connectBlock.Stop().Unblock();
 
         // The following requests should be OK
         CheckResolveNode(runtime, sender, NODE1, "1.2.3.4");

--- a/ydb/core/quoter/kesus_quoter_ut.cpp
+++ b/ydb/core/quoter/kesus_quoter_ut.cpp
@@ -109,7 +109,7 @@ Y_UNIT_TEST_SUITE(QuoterWithKesusTest) {
         setup.GetQuota(TKesusQuoterTestSetup::DEFAULT_KESUS_PATH, TKesusQuoterTestSetup::DEFAULT_KESUS_RESOURCE);
 
         setup.GetClient().DeleteKesus(TKesusQuoterTestSetup::DEFAULT_KESUS_PARENT_PATH, TKesusQuoterTestSetup::DEFAULT_KESUS_NAME);
-        Sleep(TDuration::MilliSeconds(500)); // Wait for pipe disconnection, reconnection and passing info that old kesus was destroyed
+        Sleep(TDuration::MilliSeconds(2000)); // Wait for pipe disconnection, reconnection and passing info that old kesus was destroyed
         setup.GetClient().RefreshPathCache(setup.GetServer().GetRuntime(), TKesusQuoterTestSetup::DEFAULT_KESUS_PATH);
 
         setup.CreateDefaultKesusAndResource();

--- a/ydb/core/tablet/tablet_resolver.cpp
+++ b/ydb/core/tablet/tablet_resolver.cpp
@@ -329,18 +329,12 @@ class TTabletResolver : public TActorBootstrapped<TTabletResolver> {
             // Don't overload state storage when leader is inaccessible
             if (entry.CurrentLeaderSuspect && entry.CurrentLeaderProblem) {
                 switch (++retryNumber) {
-                    case 1: {
-                        retryDelay = {};
-                        break;
-                    }
-                    case 2: {
+                    case 1:
                         retryDelay = TDuration::MilliSeconds(1);
                         break;
-                    }
-                    default: {
+                    default:
                         retryDelay = Min(retryDelay * 2, TDuration::MilliSeconds(300));
                         break;
-                    }
                 }
             } else {
                 retryNumber = 0;

--- a/ydb/core/tablet/tablet_resolver.cpp
+++ b/ydb/core/tablet/tablet_resolver.cpp
@@ -5,6 +5,11 @@
 #include <ydb/core/base/tabletid.h>
 #include <ydb/core/base/tablet.h>
 #include <ydb/core/base/appdata.h>
+#include <ydb/library/actors/async/async.h>
+#include <ydb/library/actors/async/cancellation.h>
+#include <ydb/library/actors/async/event.h>
+#include <ydb/library/actors/async/sleep.h>
+#include <ydb/library/actors/async/wait_for_event.h>
 #include <ydb/library/actors/core/hfunc.h>
 #include <ydb/library/actors/core/log.h>
 #include <ydb/library/actors/core/interconnect.h>
@@ -22,6 +27,12 @@ namespace NKikimr {
 const TDuration TabletResolverNegativeCacheTimeout = TDuration::MilliSeconds(300);
 const TDuration TabletResolverRefreshNodesPeriod = TDuration::Seconds(60);
 
+#define BLOG_TRACE(stream) LOG_TRACE_S(*TlsActivationContext, NKikimrServices::TABLET_RESOLVER, stream)
+#define BLOG_DEBUG(stream) LOG_DEBUG_S(*TlsActivationContext, NKikimrServices::TABLET_RESOLVER, stream)
+#define BLOG_INFO(stream) LOG_INFO_S(*TlsActivationContext, NKikimrServices::TABLET_RESOLVER, stream)
+#define BLOG_WARN(stream) LOG_WARN_S(*TlsActivationContext, NKikimrServices::TABLET_RESOLVER, stream)
+#define BLOG_ERROR(stream) LOG_ERROR_S(*TlsActivationContext, NKikimrServices::TABLET_RESOLVER, stream)
+
 class TTabletResolver : public TActorBootstrapped<TTabletResolver> {
     struct TEvPrivate {
         enum EEv {
@@ -35,7 +46,7 @@ class TTabletResolver : public TActorBootstrapped<TTabletResolver> {
             const ui64 TabletID;
             TSchedulerCookieHolder Cookie;
 
-            TEvPingTimeout(ui64 tabletId, ISchedulerCookie *cookie)
+            TEvPingTimeout(ui64 tabletId, ISchedulerCookie* cookie)
                 : TabletID(tabletId)
                 , Cookie(cookie)
             {}
@@ -69,24 +80,17 @@ class TTabletResolver : public TActorBootstrapped<TTabletResolver> {
     };
 
     struct TEntry {
-        enum EState {
-            StInit,
-            StInitResolve,
+        enum EState : ui8 {
+            StResolve,
             StNormal,
-            StProblemResolve,
-            StProblemPing,
-            StFollowerUpdate,
+            StRemove,
         };
 
         static const char* StateToString(EState state) {
             switch (state) {
-            case StInit: return "StInit";
-            case StInitResolve: return "StInitResolve";
+            case StResolve: return "StResolve";
             case StNormal: return "StNormal";
-            case StProblemResolve: return "StProblemResolve";
-            case StProblemPing: return "StProblemPing";
-            case StFollowerUpdate: return "StFollowerUpdate";
-            default: return "Unknown";
+            case StRemove: return "StRemove";
             }
         }
 
@@ -100,23 +104,29 @@ class TTabletResolver : public TActorBootstrapped<TTabletResolver> {
             {}
         };
 
-        EState State = StInit;
+        const ui64 TabletId;
+        EState State = StResolve;
+
+        bool InCache : 1 = false;
+        bool CurrentLeaderProblem : 1 = false;
+        bool CurrentLeaderProblemPermanent : 1 = false;
 
         TQueueInplace<TQueueEntry, 128> Queue;
         TActorId KnownLeader;
         TActorId KnownLeaderTablet;
 
         TInstant LastResolved;
-        TInstant LastPing;
-
-        TSchedulerCookieHolder Cookie;
 
         TVector<std::pair<TActorId, TActorId>> KnownFollowers;
 
         ui64 CacheEpoch = 0;
         ui64 LastCheckEpoch = 0;
 
-        TEntry() {}
+        TAsyncEvent Wakeup;
+
+        explicit TEntry(ui64 tabletId)
+            : TabletId(tabletId)
+        {}
     };
 
     struct TResolveInfo {
@@ -126,9 +136,9 @@ class TTabletResolver : public TActorBootstrapped<TTabletResolver> {
         ui32 NumLocal;
         ui32 NumLocalDc;
         ui32 NumOtherDc;
-        bool * NeedFollowerUpdate;
+        bool* NeedFollowerUpdate;
 
-        TResolveInfo(const TEvTabletResolver::TEvForward& msg, const TDuration& sinceResolve, bool * needFollowerUpdate)
+        TResolveInfo(const TEvTabletResolver::TEvForward& msg, const TDuration& sinceResolve, bool* needFollowerUpdate)
             : ResFlags(msg.ResolveFlags)
             , SinceLastResolve(sinceResolve)
             , NumLocal(0)
@@ -158,13 +168,73 @@ class TTabletResolver : public TActorBootstrapped<TTabletResolver> {
         }
     };
 
-    typedef NCache::TUnboundedCacheOnMap<ui64, TAutoPtr<TEntry>> TUnresolvedTablets;
-    typedef NCache::T2QCache<ui64, TAutoPtr<TEntry>> TResolvedTablets;
+    class TEventStream : public TIntrusiveListItem<TEventStream> {
+    public:
+        TEventStream(TTabletResolver* self, ui64 cookie)
+            : Self(self)
+            , Cookie(cookie)
+        {
+            Self->EventStreams[Cookie] = this;
+        }
+
+        ~TEventStream() {
+            Self->EventStreams.erase(Cookie);
+        }
+
+        async<IEventHandle::TPtr> Next() {
+            Y_ABORT_UNLESS(!NextEvent, "Unexpected event pending before Next()");
+            co_await ReceivedEvent.Wait();
+            // Note: NextEvent is nullptr on TEvNodeDisconnected
+            co_return std::move(NextEvent);
+        }
+
+        void OnConnect() {
+            Connected = true;
+        }
+
+        void OnEvent(IEventHandle::TPtr ev) {
+            Y_ABORT_UNLESS(ReceivedEvent.HasAwaiters(), "Nobody is waiting");
+            NextEvent = std::move(ev);
+            ReceivedEvent.NotifyOne();
+        }
+
+        void OnDisconnect() {
+            Y_ABORT_UNLESS(ReceivedEvent.HasAwaiters(), "Nobody is waiting");
+            Y_ABORT_UNLESS(!NextEvent, "Unexpected event pending in OnDisconnect()");
+            ReceivedEvent.NotifyOne();
+        }
+
+        bool HadConnect() const {
+            return Connected;
+        }
+
+    private:
+        TTabletResolver* const Self;
+        const ui64 Cookie;
+        IEventHandle::TPtr NextEvent;
+        TAsyncEvent ReceivedEvent;
+        bool Connected = false;
+    };
+
+    absl::flat_hash_map<ui64, TEventStream*> EventStreams;
+
+    struct TTabletStateSubscription {
+        TActorId ActorId;
+        ui64 TabletId = 0;
+        ui64 SeqNo = 0;
+        NKikimrTabletBase::TEvTabletStateUpdate::EState State = NKikimrTabletBase::TEvTabletStateUpdate::StateUnknown;
+        TAsyncCancellationScope Scope;
+    };
+
+    struct TInterconnectSession {
+        TIntrusiveList<TEventStream> EventStreams;
+    };
+
+    typedef NCache::T2QCache<ui64, TEntry*> TTabletCache;
 
     TIntrusivePtr<TTabletResolverConfig> Config;
-    TActorSystem* ActorSystem;
-    TUnresolvedTablets UnresolvedTablets;
-    TResolvedTablets ResolvedTablets;
+    THashMap<ui64, TEntry> Tablets;
+    TTabletCache TabletCache;
     THashSet<ui64> TabletsOnStopList;
     THashMap<ui32, TString> NodeToDcMapping;
 
@@ -172,6 +242,10 @@ class TTabletResolver : public TActorBootstrapped<TTabletResolver> {
     ui64 LastNodeProblemsUpdateEpoch = 0;
 
     ui64 LastCacheEpoch = 0;
+
+    THashMap<TActorId, TTabletStateSubscription> TabletStateSubscriptions;
+    THashMap<TActorId, TInterconnectSession> InterconnectSessions;
+    ui64 LastSeqNo = 0;
 
     ::NMonitoring::TDynamicCounters::TCounterPtr SelectedLeaderLocal;
     ::NMonitoring::TDynamicCounters::TCounterPtr SelectedLeaderLocalDc;
@@ -190,21 +264,310 @@ class TTabletResolver : public TActorBootstrapped<TTabletResolver> {
         return it != NodeToDcMapping.end() ? std::make_optional(it->second) : std::nullopt;
     }
 
-    void ResolveRequest(ui64 tabletId, const TActorContext &ctx) {
-        const TActorId ssproxy = MakeStateStorageProxyID();
-        ctx.Send(ssproxy, new TEvStateStorage::TEvLookup(tabletId, 0), IEventHandle::FlagTrackDelivery, tabletId);
+    async<TEvStateStorage::TEvInfo::TPtr> AsyncLookupTablet(ui64 tabletId) {
+        const ui64 cookie = ++LastSeqNo;
+        const TActorId proxy = MakeStateStorageProxyID();
+        Send(proxy, new TEvStateStorage::TEvLookup(tabletId, 0), IEventHandle::FlagTrackDelivery, cookie);
 
         InFlyResolveCounter->Inc();
+        Y_DEFER { InFlyResolveCounter->Dec(); };
+
+        // We may receive either TEvStateStorage::TEvInfo or TEvUndelivered
+        auto ev = co_await ActorWaitForEvent<IEventHandle>(cookie);
+        switch (ev->GetTypeRewrite()) {
+            case TEvStateStorage::TEvInfo::EventType:
+                co_return std::move(reinterpret_cast<TEvStateStorage::TEvInfo::TPtr&>(ev));
+
+            case TEvents::TEvUndelivered::EventType:
+                co_return nullptr;
+
+            default:
+                Y_ABORT_S("Unexpected resolve reply " << Hex(ev->GetTypeRewrite()) << " " << ev->ToString());
+        }
     }
 
-    bool PushQueue(TEvTabletResolver::TEvForward::TPtr &ev, TEntry &entry, const TActorContext &ctx) {
-        entry.Queue.Emplace(ctx.Now(), std::move(ev));
-        return true;
+    void AddTabletToStopList(ui64 tabletId) {
+        if (TabletResolverNegativeCacheTimeout) {
+            if (TabletsOnStopList.emplace(tabletId).second) {
+                Schedule(TabletResolverNegativeCacheTimeout, new TEvPrivate::TEvStopListRemoval(tabletId));
+            }
+        }
     }
 
-    std::pair<TActorId, TActorId> SelectForward(const TActorContext& ctx, const TEntry& entry, TResolveInfo& info, ui64 tabletId)
-    {
-        const ui32 selfNode = ctx.SelfID.NodeId();
+    void TabletResolveLoop(ui64 tabletId) {
+        TEntry& entry = Tablets.at(tabletId);
+        Y_ABORT_UNLESS(entry.State == TEntry::StResolve);
+
+        Y_DEFER {
+            TabletCache.Erase(tabletId);
+            Tablets.erase(tabletId);
+        };
+
+        for (;;) {
+            // On every iteration we make a new resolve request
+            Y_ABORT_UNLESS(entry.State == TEntry::StResolve,
+                "Unexpected entry.State: %s", TEntry::StateToString(entry.State));
+            {
+                BLOG_TRACE("TabletResolveLoop tabletId: " << tabletId
+                        << " sending TEvLookup");
+                auto ev = co_await AsyncLookupTablet(tabletId);
+                if (!ev) {
+                    // StateStorage proxy is not configured on this node
+                    BLOG_INFO("TabletResolveLoop tabletId: " << tabletId
+                            << " StateStorage proxy not configured");
+                    SendQueuedError(tabletId, entry, NKikimrProto::ERROR);
+                    break;
+                }
+
+                auto* msg = ev->Get();
+                const bool success = (msg->Status == NKikimrProto::OK); // TODO: handle 'locked' state?
+
+                BLOG_TRACE("TabletResolveLoop tabletId: " << tabletId
+                    << " received TEvInfo Status: " << msg->Status
+                    << " event: " << msg->ToString());
+
+                if (!success) {
+                    SendQueuedError(tabletId, entry, NKikimrProto::ERROR);
+                    AddTabletToStopList(tabletId);
+                    break;
+                }
+
+                // This will also send replies to all enqueued requests
+                ApplyEntryInfo(entry, *msg);
+            }
+
+            if (!entry.InCache) {
+                // This entry was evicted while resolving, stop processing
+                BLOG_TRACE("TabletResolveLoop tabletId: " << tabletId
+                    << " processing stopped for an evicted entry");
+                break;
+            }
+
+            if (entry.CurrentLeaderProblem && entry.CurrentLeaderProblemPermanent && entry.KnownFollowers.empty()) {
+                // Don't cache a known bad leader without followers
+                BLOG_TRACE("TabletResolveLoop tabletId: " << tabletId
+                    << " resolved to a known problem leader " << entry.KnownLeader
+                    << " processing stopped with negative caching");
+                AddTabletToStopList(tabletId);
+                break;
+            }
+
+            entry.State = TEntry::StNormal;
+
+            // Wait until the next iteration
+            co_await entry.Wakeup.Wait();
+
+            if (!entry.InCache || entry.State == TEntry::StRemove) {
+                BLOG_TRACE("TabletResolveLoop tabletId: " << tabletId
+                    << " processing stopped for an evicted entry");
+                break;
+            }
+        }
+
+        if (entry.KnownLeader) {
+            UnsubscribeTabletState(entry.KnownLeader);
+        }
+    }
+
+    void OnTabletActive(ui64 tabletId, const TActorId& actorId, const TActorId& userActorId) {
+        auto it = Tablets.find(tabletId);
+        if (it == Tablets.end()) {
+            return;
+        }
+
+        TEntry& entry = it->second;
+        if (entry.KnownLeader == actorId) {
+            if (!entry.KnownLeaderTablet) {
+                entry.KnownLeaderTablet = userActorId;
+            }
+            // We just confirmed this leader is active
+            entry.CurrentLeaderProblem = false;
+            entry.CurrentLeaderProblemPermanent = false;
+            return;
+        }
+
+        for (auto& pr : entry.KnownFollowers) {
+            if (pr.first == actorId) {
+                if (!pr.second) {
+                    pr.second = userActorId;
+                }
+                break;
+            }
+        }
+    }
+
+    void OnTabletProblem(ui64 tabletId, const TActorId& actorId, bool permanent = false) {
+        auto it = Tablets.find(tabletId);
+        if (it == Tablets.end()) {
+            return;
+        }
+
+        TEntry& entry = it->second;
+        BLOG_TRACE("OnTabletProblem tabletId: " << tabletId << " actorId: " << actorId
+            << " entry.State: " << TEntry::StateToString(entry.State));
+
+        if (!actorId) {
+            // TEvTabletProblem without actorId is used for forced eviction
+            if (entry.State == TEntry::StNormal) {
+                entry.State = TEntry::StRemove;
+                entry.Wakeup.NotifyOne();
+            }
+            return;
+        }
+
+        if (entry.KnownLeader == actorId || entry.KnownLeaderTablet == actorId) {
+            BLOG_TRACE("OnTabletProblem tabletId: " << tabletId
+                << " marking leader " << entry.KnownLeader
+                << " with a" << (permanent ? " permanent" : "") << " problem");
+            entry.CurrentLeaderProblem = true;
+            if (permanent) {
+                entry.CurrentLeaderProblemPermanent = true;
+            }
+            // Note: we want to delay resolve until the next request
+            return;
+        }
+
+        for (auto it = entry.KnownFollowers.begin(), end = entry.KnownFollowers.end(); it != end; ++it) {
+            if (it->first == actorId || it->second == actorId) {
+                BLOG_TRACE("OnTabletProblem tabletId: " << tabletId
+                    << " removing follower " << it->first);
+                entry.KnownFollowers.erase(it);
+                if (entry.State == TEntry::StNormal) {
+                    entry.State = TEntry::StResolve;
+                    entry.Wakeup.NotifyOne();
+                }
+                break;
+            }
+        }
+    }
+
+    void TabletStateSubscriptionLoop(ui64 tabletId, TActorId actorId) {
+        Y_ABORT_UNLESS(!TabletStateSubscriptions.contains(actorId));
+        auto& subscription = TabletStateSubscriptions[actorId];
+        subscription.ActorId = actorId;
+        subscription.TabletId = tabletId;
+        Y_DEFER { TabletStateSubscriptions.erase(actorId); };
+
+        subscription.Scope = co_await TAsyncCancellationScope::WithCurrentHandler();
+
+        unsigned retryNumber = 0;
+        TDuration retryDelay;
+        for (;;) {
+            subscription.SeqNo = -1;
+            subscription.State = NKikimrTabletBase::TEvTabletStateUpdate::StateUnknown;
+
+            // Note: this also checks for cancellation
+            if (retryDelay) {
+                BLOG_TRACE("TabletStateSubscriptionLoop tabletId: " << tabletId << " actor: " << actorId
+                    << " sleeping for " << retryDelay);
+            }
+            co_await AsyncSleepFor(retryDelay);
+
+            const ui64 seqNo = ++LastSeqNo;
+            subscription.SeqNo = seqNo;
+            ui32 flags = IEventHandle::FlagTrackDelivery;
+            if (actorId.NodeId() != SelfId().NodeId()) {
+                flags |= IEventHandle::FlagSubscribeOnSession;
+            }
+            BLOG_TRACE("TabletStateSubscriptionLoop tabletId: " << tabletId << " actor: " << actorId
+                    << " sending TEvTabletStateSubscribe seqNo=" << seqNo);
+            Send(actorId, new TEvTablet::TEvTabletStateSubscribe(tabletId, seqNo), flags, seqNo);
+
+            bool subscribed = true;
+            auto unsubscribe = [&]() {
+                if (subscribed) {
+                    BLOG_TRACE("TabletStateSubscriptionLoop tabletId: " << tabletId << " actor: " << actorId
+                        << " sending TEvTabletStateUnsubscribe seqNo=" << seqNo);
+                    Send(actorId, new TEvTablet::TEvTabletStateUnsubscribe(tabletId, seqNo));
+                    subscribed = false;
+                }
+            };
+
+            Y_DEFER {
+                // Note: don't unsubscribe during actor system shutdown
+                if (TlsActivationContext) {
+                    unsubscribe();
+                }
+            };
+
+            TEventStream stream(this, seqNo);
+            while (subscribed) {
+                auto ev = co_await stream.Next();
+                if (!ev) {
+                    // Node disconnected, start a new iteration
+                    subscribed = false;
+                    BLOG_TRACE("TabletStateSubscriptionLoop tabletId: " << tabletId << " actor: " << actorId
+                        << " node disconnected");
+                    OnTabletProblem(tabletId, actorId);
+                    break;
+                }
+
+                switch (ev->GetTypeRewrite()) {
+                    case TEvents::TEvUndelivered::EventType: {
+                        // Tablet actor doesn't exist (note: this will not be delivered after a disconnect)
+                        subscribed = false;
+                        BLOG_TRACE("TabletStateSubscriptionLoop tabletId: " << tabletId << " actor: " << actorId
+                            << " undelivered, assuming actor permanently unavailable");
+                        OnTabletProblem(tabletId, actorId, /* permanent */ true);
+                        co_return;
+                    }
+                    case TEvTablet::TEvTabletStateUpdate::EventType: {
+                        retryNumber = 0;
+                        auto* msg = ev->Get<TEvTablet::TEvTabletStateUpdate>();
+                        BLOG_TRACE("TabletStateSubscriptionLoop tabletId: " << tabletId << " actor: " << actorId
+                            << " received state update: " << msg->ToString());
+                        subscription.State = msg->Record.GetState();
+                        if (subscription.State == NKikimrTabletBase::TEvTabletStateUpdate::StateActive) {
+                            if (auto userActorId = msg->GetUserActorId()) {
+                                OnTabletActive(tabletId, actorId, userActorId);
+                            }
+                        }
+                        if (subscription.State == NKikimrTabletBase::TEvTabletStateUpdate::StateTerminating ||
+                            subscription.State == NKikimrTabletBase::TEvTabletStateUpdate::StateDead)
+                        {
+                            OnTabletProblem(tabletId, actorId, /* permanent */ true);
+                            unsubscribe();
+                            co_return;
+                        }
+                        break;
+                    }
+                    default: {
+                        Y_ABORT_S("Unexpected tablet state notification " << Hex(ev->GetTypeRewrite()) << " " << ev->ToString());
+                    }
+                }
+            }
+
+            // A small exponential backoff on retries: 0ms, 1ms, 2ms, 4ms, 8ms, 10ms
+            switch (++retryNumber) {
+                case 1:
+                    retryDelay = TDuration::Zero();
+                    break;
+                case 2:
+                    retryDelay = TDuration::MilliSeconds(1);
+                    break;
+                default:
+                    retryDelay = Min(retryDelay * 2, TDuration::MilliSeconds(10));
+                    break;
+            }
+        }
+    }
+
+    void SubscribeTabletState(ui64 tabletId, const TActorId& actorId) {
+        if (!TabletStateSubscriptions.contains(actorId)) {
+            TabletStateSubscriptionLoop(tabletId, actorId);
+            Y_DEBUG_ABORT_UNLESS(TabletStateSubscriptions.contains(actorId));
+        }
+    }
+
+    void UnsubscribeTabletState(const TActorId& actorId) {
+        auto it = TabletStateSubscriptions.find(actorId);
+        if (it != TabletStateSubscriptions.end()) {
+            it->second.Scope.Cancel();
+        }
+    }
+
+    std::pair<TActorId, TActorId> SelectForward(const TEntry& entry, TResolveInfo& info, ui64 tabletId) {
+        const ui32 selfNode = SelfId().NodeId();
         const std::optional<TString> selfDc = FindNodeDc(selfNode);
         const std::optional<TString> leaderDc = FindNodeDc(entry.KnownLeader.NodeId());
 
@@ -231,7 +594,7 @@ class TTabletResolver : public TActorBootstrapped<TTabletResolver> {
             }
         };
 
-        bool countLeader = (entry.State == TEntry::StNormal || entry.State == TEntry::StFollowerUpdate);
+        bool countLeader = (entry.KnownLeader && !entry.CurrentLeaderProblem);
         if (countLeader) {
             bool isLocal = (entry.KnownLeader.NodeId() == selfNode);
             bool isLocalDc = selfDc && leaderDc == selfDc;
@@ -245,7 +608,7 @@ class TTabletResolver : public TActorBootstrapped<TTabletResolver> {
         }
 
         if (info.ResFlags.AllowFollower()) {
-            for (const auto &x : entry.KnownFollowers) {
+            for (const auto& x : entry.KnownFollowers) {
                 bool isLocal = (x.first.NodeId() == selfNode);
                 bool isLocalDc = selfDc && FindNodeDc(x.first.NodeId()) == selfDc;
                 info.Count(isLocal, isLocalDc);
@@ -261,18 +624,21 @@ class TTabletResolver : public TActorBootstrapped<TTabletResolver> {
         auto dcName = [](const std::optional<TString>& x) { return x ? x->data() : "<none>"; };
 
         if (!winners.empty()) {
-            size_t winnerIndex = (winners.size() == 1 ? 0 : (AppData(ctx)->RandomProvider->GenRand64() % winners.size()));
+            size_t winnerIndex = (winners.size() == 1 ? 0 : (AppData()->RandomProvider->GenRand64() % winners.size()));
             const TCandidate& winner = winners[winnerIndex];
 
-            LOG_DEBUG(ctx, NKikimrServices::TABLET_RESOLVER,
-                "SelectForward node %" PRIu32 " selfDC %s leaderDC %s %s"
-                " local %" PRIu32 " localDc %" PRIu32 " other %" PRIu32 " disallowed %" PRIu32
-                " tabletId: %" PRIu64 " followers: %" PRIu64 " countLeader %" PRIu32
-                " allowFollowers %" PRIu32 " winner: %s",
-                selfNode, dcName(selfDc), dcName(leaderDc), info.ResFlags.ToString().data(),
-                info.NumLocal, info.NumLocalDc, info.NumOtherDc, disallowed,
-                tabletId, entry.KnownFollowers.size(), countLeader, info.ResFlags.AllowFollower(),
-                winner.KnownLeader.ToString().c_str());
+            BLOG_DEBUG("SelectForward"
+                << " node " << selfNode
+                << " selfDC " << dcName(selfDc)
+                << " leaderDC " << dcName(leaderDc)
+                << " " << info.ResFlags.ToString()
+                << " local " << info.NumLocal << " localDc " << info.NumLocalDc << " other " << info.NumOtherDc
+                << " disallowed " << disallowed
+                << " tabletId: " << tabletId
+                << " followers: " << entry.KnownFollowers.size()
+                << " countLeader " << countLeader
+                << " allowFollowers " << info.ResFlags.AllowFollower()
+                << " winner: " << winner.KnownLeader);
 
             if (winner.IsLeader) {
                 if (winner.IsLocal)
@@ -293,25 +659,29 @@ class TTabletResolver : public TActorBootstrapped<TTabletResolver> {
             return std::make_pair(winner.KnownLeader, winner.KnownLeaderTablet);
         }
 
-        LOG_INFO(ctx, NKikimrServices::TABLET_RESOLVER,
-            "No candidates for SelectForward, node %" PRIu32 " selfDC %s leaderDC %s %s"
-            " local %" PRIu32 " localDc %" PRIu32 " other %" PRIu32 " disallowed %" PRIu32,
-            selfNode, dcName(selfDc), dcName(leaderDc), info.ResFlags.ToString().data(),
-            info.NumLocal, info.NumLocalDc, info.NumOtherDc, disallowed);
+        BLOG_INFO("No candidates for SelectForward,"
+            << " node " << selfNode
+            << " selfDC " << dcName(selfDc)
+            << " leaderDC " << dcName(leaderDc)
+            << " " << info.ResFlags.ToString()
+            << " local " << info.NumLocal
+            << " localDc " << info.NumLocalDc
+            << " other " << info.NumOtherDc
+            << " disallowed " << disallowed);
 
         SelectedNone->Inc();
 
         return std::make_pair(TActorId(), TActorId());
     }
 
-    bool SendForward(const TActorId &sender, const TEntry &entry, TEvTabletResolver::TEvForward *msg,
-                     const TActorContext &ctx, bool * needFollowerUpdate = nullptr) {
-        TResolveInfo info(*msg, ctx.Now() - entry.LastResolved, needFollowerUpdate); // fills needFollowerUpdate in dtor
-        const std::pair<TActorId, TActorId> endpoint = SelectForward(ctx, entry, info, msg->TabletID);
+    bool SendForward(const TActorId& sender, const TEntry& entry, TEvTabletResolver::TEvForward* msg,
+                     bool* needFollowerUpdate = nullptr) {
+        TResolveInfo info(*msg, TActivationContext::Now() - entry.LastResolved, needFollowerUpdate); // fills needFollowerUpdate in dtor
+        const std::pair<TActorId, TActorId> endpoint = SelectForward(entry, info, msg->TabletID);
         if (endpoint.first) {
-            ctx.Send(sender, new TEvTabletResolver::TEvForwardResult(msg->TabletID, endpoint.second, endpoint.first, LastCacheEpoch));
+            Send(sender, new TEvTabletResolver::TEvForwardResult(msg->TabletID, endpoint.second, endpoint.first, LastCacheEpoch));
             if (!!msg->Ev) {
-                ctx.Send(IEventHandle::Forward(std::move(msg->Ev), msg->SelectActor(endpoint.second, endpoint.first)));
+                Send(IEventHandle::Forward(std::move(msg->Ev), msg->SelectActor(endpoint.second, endpoint.first)));
             }
             return true;
         } else {
@@ -319,11 +689,16 @@ class TTabletResolver : public TActorBootstrapped<TTabletResolver> {
         }
     }
 
-    void SendQueued(ui64 tabletId, TEntry &entry, const TActorContext &ctx) {
+    bool PushQueue(TEntry& entry, TEvTabletResolver::TEvForward::TPtr& ev) {
+        entry.Queue.Emplace(TActivationContext::Now(), std::move(ev));
+        return true;
+    }
+
+    void SendQueued(TEntry& entry) {
         while (TEntry::TQueueEntry* x = entry.Queue.Head()) {
-            TEvTabletResolver::TEvForward *msg = x->Ev->Get();
-            if (!SendForward(x->Ev->Sender, entry, msg, ctx)) {
-                ctx.Send(x->Ev->Sender, new TEvTabletResolver::TEvForwardResult(NKikimrProto::ERROR, tabletId));
+            TEvTabletResolver::TEvForward* msg = x->Ev->Get();
+            if (!SendForward(x->Ev->Sender, entry, msg)) {
+                Send(x->Ev->Sender, new TEvTabletResolver::TEvForwardResult(NKikimrProto::ERROR, entry.TabletId));
             }
             entry.Queue.Pop();
         }
@@ -331,146 +706,125 @@ class TTabletResolver : public TActorBootstrapped<TTabletResolver> {
         entry.Queue.Clear();
     }
 
-    void SendPing(ui64 tabletId, TEntry &entry, const TActorContext &ctx) {
-        ctx.Send(entry.KnownLeader, new TEvTablet::TEvPing(tabletId, 0), IEventHandle::FlagTrackDelivery, tabletId); // no subscribe for reason
-        entry.Cookie.Reset(ISchedulerCookie::Make3Way());
-
-        const TDuration timeout = TDuration::MilliSeconds(500);
-        ctx.Schedule(timeout, new TEvPrivate::TEvPingTimeout(tabletId, entry.Cookie.Get()), entry.Cookie.Get());
-    }
-
-    void ApplyEntryInfo(TEvStateStorage::TEvInfo& msg, TEntry &entry, const TActorContext &ctx) {
-        entry.KnownLeader = msg.CurrentLeader;
-        entry.KnownLeaderTablet = msg.CurrentLeaderTablet;
-        entry.LastResolved = ctx.Now();
-        entry.KnownFollowers = std::move(msg.Followers);
-        entry.CacheEpoch = ++LastCacheEpoch;
-
-        LOG_DEBUG(ctx, NKikimrServices::TABLET_RESOLVER,
-                  "ApplyEntry leader tabletId: %" PRIu64 " followers: %" PRIu64,
-                  msg.TabletID, entry.KnownFollowers.size());
-        SendQueued(msg.TabletID, entry, ctx);
-    }
-
-    void DropEntry(ui64 tabletId, TEntry& entry, bool cacheNegative, const TActorContext &ctx) {
-        LOG_DEBUG(ctx, NKikimrServices::TABLET_RESOLVER,
-                  "DropEntry tabletId: %" PRIu64 " followers: %" PRIu64,
-                  tabletId, entry.KnownFollowers.size());
+    void SendQueuedError(ui64 tabletId, TEntry& entry, NKikimrProto::EReplyStatus status) {
         while (TEntry::TQueueEntry* x = entry.Queue.Head()) {
-            ctx.Send(x->Ev->Sender, new TEvTabletResolver::TEvForwardResult(NKikimrProto::ERROR, tabletId));
+            Send(x->Ev->Sender, new TEvTabletResolver::TEvForwardResult(status, tabletId));
             entry.Queue.Pop();
         }
-        ResolvedTablets.Erase(tabletId);
-        UnresolvedTablets.Erase(tabletId);
-
-        if (TabletResolverNegativeCacheTimeout && cacheNegative) {
-            if (TabletsOnStopList.emplace(tabletId).second)
-                Schedule(TabletResolverNegativeCacheTimeout, new TEvPrivate::TEvStopListRemoval(tabletId));
-        }
+        // Free buffer memory
+        entry.Queue.Clear();
     }
 
-    void DropEntry(ui64 tabletId, TEntry& entry, const TActorContext &ctx) {
-        DropEntry(tabletId, entry, true, ctx);
-    }
-
-    TAutoPtr<TEntry>& GetEntry(ui64 tabletId, const TActorContext &ctx) {
-        TAutoPtr<TEntry>* entryPtr;
-        if (!ResolvedTablets.Find(tabletId, entryPtr)) {
-            if (!UnresolvedTablets.Find(tabletId, entryPtr)) {
-                ActorSystem = ctx.ActorSystem();
-                UnresolvedTablets.Insert(tabletId, TAutoPtr<TEntry>(new TEntry()), entryPtr);
+    void ApplyEntryInfo(TEntry& entry, TEvStateStorage::TEvInfo& msg) {
+        if (entry.KnownLeader != msg.CurrentLeader) {
+            if (entry.KnownLeader) {
+                UnsubscribeTabletState(entry.KnownLeader);
+            }
+            entry.KnownLeader = msg.CurrentLeader;
+            entry.KnownLeaderTablet = msg.CurrentLeaderTablet;
+            entry.CurrentLeaderProblem = false;
+            entry.CurrentLeaderProblemPermanent = false;
+            if (entry.InCache && entry.KnownLeader) {
+                SubscribeTabletState(entry.TabletId, entry.KnownLeader);
+            }
+        } else {
+            if (!entry.CurrentLeaderProblemPermanent) {
+                entry.CurrentLeaderProblem = false;
+            }
+            if (msg.CurrentLeaderTablet) {
+                entry.KnownLeaderTablet = msg.CurrentLeaderTablet;
             }
         }
 
-        return *entryPtr;
+        entry.KnownFollowers = std::move(msg.Followers);
+
+        entry.LastResolved = TActivationContext::Now();
+        entry.CacheEpoch = ++LastCacheEpoch;
+
+        BLOG_DEBUG("ApplyEntry tabletId: " << msg.TabletID
+            << " leader: " << entry.KnownLeader
+            << " followers: " << entry.KnownFollowers.size());
+        SendQueued(entry);
     }
 
-    TAutoPtr<TEntry>* FindEntry(ui64 tabletId) {
-        TAutoPtr<TEntry>* entryPtr;
-        if (!ResolvedTablets.Find(tabletId, entryPtr)) {
-            if (!UnresolvedTablets.Find(tabletId, entryPtr)) {
-                return nullptr;
-            }
+    TEntry& GetEntry(ui64 tabletId) {
+        bool created = false;
+        auto it = Tablets.find(tabletId);
+        if (it == Tablets.end()) {
+            auto res = Tablets.emplace(
+                std::piecewise_construct,
+                std::forward_as_tuple(tabletId),
+                std::forward_as_tuple(tabletId));
+            it = res.first;
+            created = true;
         }
 
-        return entryPtr;
+        TEntry& entry = it->second;
+        if (created) {
+            TabletResolveLoop(tabletId);
+        }
+
+        // Entry may be evicted while resolving, reinsert back into cache on additional hits
+        TEntry** ignored;
+        if (!entry.InCache) {
+            bool ok = TabletCache.Insert(tabletId, &entry, ignored);
+            Y_DEBUG_ABORT_UNLESS(ok, "Unexpected failure to reinsert previously evicted tablet");
+            entry.InCache = true;
+        } else {
+            bool ok = TabletCache.Find(tabletId, ignored);
+            Y_DEBUG_ABORT_UNLESS(ok, "Unexpected failure to find an unevicted tablet");
+        }
+
+        return entry;
     }
 
-    void MoveEntryToResolved(ui64 tabletId, TAutoPtr<TEntry>& entry) {
-        TAutoPtr<TEntry>* resolvedEntryPtr;
-        Y_ABORT_UNLESS(ResolvedTablets.Insert(tabletId, entry, resolvedEntryPtr));
-        Y_ABORT_UNLESS(UnresolvedTablets.Erase(tabletId));
-    }
-
-    void MoveEntryToUnresolved(ui64 tabletId, TAutoPtr<TEntry>& entry) {
-        TAutoPtr<TEntry>* unresolvedEntryPtr;
-        Y_ABORT_UNLESS(UnresolvedTablets.Insert(tabletId, entry, unresolvedEntryPtr));
-        Y_ABORT_UNLESS(ResolvedTablets.Erase(tabletId));
-    }
-
-    void CheckDelayedNodeProblem(ui64 tabletId, const TActorContext &ctx) {
-        TAutoPtr<TEntry>* entryHolder = FindEntry(tabletId);
-        if (!entryHolder) {
+    void CheckDelayedNodeProblem(ui64 tabletId) {
+        auto it = Tablets.find(tabletId);
+        if (it == Tablets.end()) {
             return;
         }
 
-        TEntry &entry = *entryHolder->Get();
+        TEntry& entry = it->second;
+        if (entry.CacheEpoch < LastNodeProblemsUpdateEpoch && entry.LastCheckEpoch < LastNodeProblemsUpdateEpoch) {
+            entry.LastCheckEpoch = LastCacheEpoch;
 
-        switch (entry.State) {
-        case TEntry::StNormal:
-        case TEntry::StFollowerUpdate:
-            if (entry.CacheEpoch < LastNodeProblemsUpdateEpoch && entry.LastCheckEpoch < LastNodeProblemsUpdateEpoch) {
-                entry.LastCheckEpoch = LastCacheEpoch;
-
-                auto *pMaxProblemEpoch = NodeProblems.FindPtr(entry.KnownLeader.NodeId());
+            if (entry.State == TEntry::StNormal) {
+                auto* pMaxProblemEpoch = NodeProblems.FindPtr(entry.KnownLeader.NodeId());
                 if (pMaxProblemEpoch && entry.CacheEpoch <= *pMaxProblemEpoch) {
-                    LOG_DEBUG(ctx, NKikimrServices::TABLET_RESOLVER,
-                            "Delayed invalidation of tabletId: %" PRIu64
-                            " leader: %s by NodeId", tabletId, entry.KnownLeader.ToString().c_str());
-                    if (entry.KnownFollowers.empty()) {
-                        // Avoid resolving preemptively until the next request
-                        DropEntry(tabletId, entry, /* cacheNegative */ false, ctx);
-                        return;
-                    }
-                    ResolveRequest(tabletId, ctx);
-                    entry.State = TEntry::StProblemResolve;
-                    MoveEntryToUnresolved(tabletId, *entryHolder);
-                    return;
-                }
-
-                auto itDst = entry.KnownFollowers.begin();
-                auto itSrc = entry.KnownFollowers.begin();
-                while (itSrc != entry.KnownFollowers.end()) {
-                    pMaxProblemEpoch = NodeProblems.FindPtr(itSrc->first.NodeId());
-                    if (pMaxProblemEpoch && entry.CacheEpoch <= *pMaxProblemEpoch) {
-                        LOG_DEBUG(ctx, NKikimrServices::TABLET_RESOLVER,
-                            "Delayed invalidation of tabletId: %" PRIu64
-                            " follower: %s by nodeId", tabletId, itSrc->first.ToString().c_str());
-                        ++itSrc;
-                        continue;
-                    }
-                    if (itDst != itSrc) {
-                        *itDst = *itSrc;
-                    }
-                    ++itDst;
-                    ++itSrc;
-                }
-
-                if (itDst != itSrc) {
-                    entry.KnownFollowers.erase(itDst, itSrc);
-                    ResolveRequest(tabletId, ctx);
-                    entry.State = TEntry::StFollowerUpdate;
+                    BLOG_DEBUG("Delayed invalidation of tabletId: " << tabletId
+                        << " leader: " << entry.KnownLeader << " by nodeId");
+                    entry.CurrentLeaderProblem = true;
                 }
             }
-            break;
 
-        default:
-            break;
+            auto itDst = entry.KnownFollowers.begin();
+            auto itSrc = entry.KnownFollowers.begin();
+            while (itSrc != entry.KnownFollowers.end()) {
+                auto* pMaxProblemEpoch = NodeProblems.FindPtr(itSrc->first.NodeId());
+                if (pMaxProblemEpoch && entry.CacheEpoch <= *pMaxProblemEpoch) {
+                    BLOG_DEBUG("Delayed invalidation of tabletId: " << tabletId
+                        << " follower: " << itSrc->first << " by nodeId");
+                    ++itSrc;
+                    continue;
+                }
+                if (itDst != itSrc) {
+                    *itDst = *itSrc;
+                }
+                ++itDst;
+                ++itSrc;
+            }
+            if (itDst != itSrc) {
+                entry.KnownFollowers.erase(itDst, itSrc);
+                if (entry.State == TEntry::StNormal) {
+                    entry.State = TEntry::StResolve;
+                    entry.Wakeup.NotifyOne();
+                }
+            }
         }
     }
 
-    void Handle(TEvTabletResolver::TEvForward::TPtr &ev, const TActorContext &ctx) {
-        TEvTabletResolver::TEvForward *msg = ev->Get();
+    void Handle(TEvTabletResolver::TEvForward::TPtr& ev) {
+        TEvTabletResolver::TEvForward* msg = ev->Get();
         const ui64 tabletId = msg->TabletID;
 
         // allow some requests to bypass negative caching in low-load case
@@ -479,328 +833,120 @@ class TTabletResolver : public TActorBootstrapped<TTabletResolver> {
             return;
         }
 
-        CheckDelayedNodeProblem(tabletId, ctx);
+        CheckDelayedNodeProblem(tabletId);
 
-        TAutoPtr<TEntry> &entryHolder = GetEntry(tabletId, ctx);
-        TEntry& entry = *entryHolder.Get();
-
-        LOG_DEBUG(ctx, NKikimrServices::TABLET_RESOLVER,
-                  "Handle TEvForward tabletId: %" PRIu64 " entry.State: %s ev: %s",
-                  tabletId, TEntry::StateToString(entry.State), msg->ToString().data());
-
-        switch (entry.State) {
-        case TEntry::StInit:
-            {
-                PushQueue(ev, entry, ctx);
-                ResolveRequest(tabletId, ctx);
-                entry.State = TEntry::StInitResolve;
-            }
-            break;
-        case TEntry::StInitResolve:
-            PushQueue(ev, entry, ctx);
-            break;
-        case TEntry::StNormal: {
-            bool needFollowerUpdate = false;
-            if (!SendForward(ev->Sender, entry, msg, ctx, &needFollowerUpdate)) {
-                PushQueue(ev, entry, ctx);
-                ResolveRequest(tabletId, ctx);
-                entry.State = TEntry::StFollowerUpdate;
-            }
-            if (needFollowerUpdate) {
-                ResolveRequest(tabletId, ctx);
-                entry.State = TEntry::StFollowerUpdate;
-            }
-            break;
-        }
-        case TEntry::StProblemResolve:
-        case TEntry::StProblemPing:
-            PushQueue(ev, entry, ctx);
-            break;
-        case TEntry::StFollowerUpdate:
-            if (!SendForward(ev->Sender, entry, msg, ctx))
-                PushQueue(ev, entry, ctx);
-            break;
-        default:
-            Y_ABORT();
-        }
-    }
-
-    void Handle(TEvTabletResolver::TEvTabletProblem::TPtr &ev, const TActorContext &ctx) {
-        TEvTabletResolver::TEvTabletProblem *msg = ev->Get();
-        const ui64 tabletId = msg->TabletID;
-
-        TAutoPtr<TEntry>* entryHolder = FindEntry(tabletId);
-        if (!entryHolder) {
-            LOG_DEBUG(ctx, NKikimrServices::TABLET_RESOLVER, "Handle TEvTabletProblem tabletId: %" PRIu64
-                " no entyHolder", tabletId);
-            return;
-        }
-        TEntry &entry = *entryHolder->Get();
-
-        LOG_DEBUG(ctx, NKikimrServices::TABLET_RESOLVER, "Handle TEvTabletProblem tabletId: %" PRIu64
-            " entry.State: %s", tabletId, TEntry::StateToString(entry.State));
+        TEntry& entry = GetEntry(tabletId);
+        BLOG_DEBUG("Handle TEvForward tabletId: " << tabletId
+                << " entry.State: " << TEntry::StateToString(entry.State)
+                << " leader: " << entry.KnownLeader
+                << (entry.CurrentLeaderProblem ? " (known problem)" : "")
+                << " followers: " << entry.KnownFollowers.size()
+                << " ev: " << msg->ToString());
 
         switch (entry.State) {
-        case TEntry::StInit:
-        case TEntry::StInitResolve:
-            break;
-        case TEntry::StNormal:
-            if (!msg->Actor || entry.KnownLeader == msg->Actor || entry.KnownLeaderTablet == msg->Actor) {
-                if (entry.KnownFollowers.empty()) {
-                    // Avoid resolving preemptively until the next request
-                    DropEntry(tabletId, entry, /* cacheNegative */ false, ctx);
-                    return;
+            case TEntry::StNormal: {
+                bool needUpdate = false;
+                if (!SendForward(ev->Sender, entry, msg, &needUpdate)) {
+                    PushQueue(entry, ev);
+                    needUpdate = true;
                 }
-                ResolveRequest(tabletId, ctx);
-                entry.State = TEntry::StProblemResolve;
-                MoveEntryToUnresolved(tabletId, *entryHolder);
-            } else {
-                // find in follower list
-                for (auto it = entry.KnownFollowers.begin(), end = entry.KnownFollowers.end(); it != end; ++it) {
-                    if (it->first == msg->Actor || it->second == msg->Actor) {
-                        entry.KnownFollowers.erase(it);
-                        ResolveRequest(tabletId, ctx);
-                        entry.State = TEntry::StFollowerUpdate;
-                        break;
-                    }
+                if (needUpdate) {
+                    entry.State = TEntry::StResolve;
+                    entry.Wakeup.NotifyOne();
                 }
-            }
-            break;
-        case TEntry::StFollowerUpdate:
-            if (!msg->Actor || entry.KnownLeader == msg->Actor || entry.KnownLeaderTablet == msg->Actor) {
-                // Reuse previously sent resolve request for StProblemResolve
-                entry.State = TEntry::StProblemResolve;
-                MoveEntryToUnresolved(tabletId, *entryHolder);
                 break;
             }
-            [[fallthrough]];
-        case TEntry::StProblemResolve:
-        case TEntry::StProblemPing:
-            for (auto it = entry.KnownFollowers.begin(), end = entry.KnownFollowers.end(); it != end; ++it) {
-                if (it->first == msg->Actor || it->second == msg->Actor) {
-                    entry.KnownFollowers.erase(it);
-                    break;
+            case TEntry::StResolve: {
+                // Try to handle requests even while resolving
+                if (entry.CacheEpoch == 0 || !SendForward(ev->Sender, entry, msg)) {
+                    PushQueue(entry, ev);
                 }
+                break;
             }
-            break;
-        default:
-            Y_ABORT();
+            case TEntry::StRemove: {
+                Y_ABORT("Unexpected StRemove state");
+            }
         }
     }
 
-    void Handle(TEvTabletResolver::TEvNodeProblem::TPtr &ev, const TActorContext &ctx) {
-        TEvTabletResolver::TEvNodeProblem *msg = ev->Get();
+    void Handle(TEvTabletResolver::TEvTabletProblem::TPtr& ev) {
+        TEvTabletResolver::TEvTabletProblem* msg = ev->Get();
+        const ui64 tabletId = msg->TabletID;
+
+        // Note: avoid promoting tablet entry in the cache
+        auto it = Tablets.find(tabletId);
+        if (it == Tablets.end()) {
+            BLOG_DEBUG("Handle TEvTabletProblem tabletId: " << tabletId << " not cached");
+            return;
+        }
+
+        TEntry& entry = it->second;
+        BLOG_DEBUG("Handle TEvTabletProblem tabletId: " << tabletId << " actor: " << msg->Actor
+            << " entry.State: " << TEntry::StateToString(entry.State));
+
+        OnTabletProblem(tabletId, msg->Actor, /* permanent */ false);
+    }
+
+    void Handle(TEvTabletResolver::TEvNodeProblem::TPtr& ev) {
+        TEvTabletResolver::TEvNodeProblem* msg = ev->Get();
         const ui32 nodeId = msg->NodeId;
         const ui64 problemEpoch = msg->CacheEpoch;
 
-        ui64 &maxProblemEpoch = NodeProblems[nodeId];
+        ui64& maxProblemEpoch = NodeProblems[nodeId];
         if (maxProblemEpoch < problemEpoch) {
-            LOG_DEBUG(ctx, NKikimrServices::TABLET_RESOLVER, "Handle TEvNodeProblem nodeId: %" PRIu32
-                " max(problemEpoch): %" PRIu64, nodeId, problemEpoch);
+            BLOG_DEBUG("Handle TEvNodeProblem nodeId: " << nodeId
+                << " max(problemEpoch): " << problemEpoch);
             maxProblemEpoch = problemEpoch;
             LastNodeProblemsUpdateEpoch = ++LastCacheEpoch;
         } else {
-            LOG_DEBUG(ctx, NKikimrServices::TABLET_RESOLVER, "Handle TEvNodeProblem nodeId: %" PRIu32
-                " problemEpoch: %" PRIu64 " <= max(problemEpoch): %" PRIu64,
-                nodeId, problemEpoch, maxProblemEpoch);
+            BLOG_DEBUG("Handle TEvNodeProblem nodeId: " << nodeId
+                << " problemEpoch: " << problemEpoch << " <= max(problemEpoch): " << maxProblemEpoch);
         }
     }
 
-    void Handle(TEvStateStorage::TEvInfo::TPtr &ev, const TActorContext &ctx) {
-        InFlyResolveCounter->Dec();
+    void Handle(TEvInterconnect::TEvNodeConnected::TPtr& ev) {
+        auto& session = InterconnectSessions[ev->Sender];
 
-        TEvStateStorage::TEvInfo *msg = ev->Get();
-        const ui64 tabletId = msg->TabletID;
-        const bool success = (msg->Status == NKikimrProto::OK); // todo: handle 'locked' state
-
-        TAutoPtr<TEntry>* entryHolder = FindEntry(tabletId);
-        if (!entryHolder) {
-            LOG_DEBUG(ctx, NKikimrServices::TABLET_RESOLVER, "Handle TEvInfo tabletId: %" PRIu64 " no entryHolder",
-                tabletId);
-            return;
-        }
-        TEntry &entry = *entryHolder->Get();
-
-        LOG_DEBUG(ctx, NKikimrServices::TABLET_RESOLVER, "Handle TEvInfo tabletId: %" PRIu64
-            " entry.State: %s success: %s ev: %s", tabletId, TEntry::StateToString(entry.State),
-            (success ? "true" : "false"), ev->GetBase()->ToString().data());
-
-        switch (entry.State) {
-        case TEntry::StInit:
-            Y_ABORT("must not happens");
-        case TEntry::StInitResolve:
-            if (success) {
-                if (msg->CurrentLeaderTablet) {
-                    entry.State = TEntry::StNormal;
-                    ApplyEntryInfo(*msg, entry, ctx);
-                    MoveEntryToResolved(tabletId, *entryHolder);
-                } else {
-                    // HACK: Don't cache invalid CurrentLeaderTablet
-                    // FIXME: Use subscription + cache here to reduce the workload
-                    ApplyEntryInfo(*msg, entry, ctx);
-                    DropEntry(tabletId, entry, ctx);
-                }
-            } else {
-                DropEntry(tabletId, entry, ctx);
-            }
-            break;
-        case TEntry::StFollowerUpdate:
-            if (success) {
-                if (msg->CurrentLeaderTablet) {
-                    entry.State = TEntry::StNormal;
-                    ApplyEntryInfo(*msg, entry, ctx);
-                } else {
-                    // HACK: Don't cache invalid CurrentLeaderTablet
-                    // FIXME: Use subscription + cache here to reduce the workload
-                    ApplyEntryInfo(*msg, entry, ctx);
-                    DropEntry(tabletId, entry, ctx);
-                }
-            } else {
-                DropEntry(tabletId, entry, ctx);
-            }
-            break;
-        case TEntry::StProblemResolve:
-            if (success) {
-                if (entry.KnownLeader == msg->CurrentLeader) {
-                    if (!(entry.KnownLeaderTablet == msg->CurrentLeaderTablet || !entry.KnownLeaderTablet)) {
-                        DropEntry(tabletId, entry, ctx); // got info but not full, occurs on transitional cluster states
-                    } else {
-                        entry.State = TEntry::StProblemPing;
-                        entry.KnownLeaderTablet = msg->CurrentLeaderTablet;
-                        entry.KnownFollowers = std::move(msg->Followers);
-                        SendPing(tabletId, entry, ctx);
-                    }
-                } else {
-                    if (msg->CurrentLeaderTablet) {
-                        entry.State = TEntry::StNormal;
-                        ApplyEntryInfo(*msg, entry, ctx);
-                        MoveEntryToResolved(tabletId, *entryHolder);
-                    } else {
-                        ApplyEntryInfo(*msg, entry, ctx);
-                        DropEntry(tabletId, entry, ctx);
-                    }
-                }
-            } else {
-                DropEntry(tabletId, entry, ctx);
-            }
-            break;
-        case TEntry::StProblemPing:
-        case TEntry::StNormal:
-            break;
-        default:
-            Y_ABORT();
+        auto it = EventStreams.find(ev->Cookie);
+        if (it != EventStreams.end()) {
+            session.EventStreams.PushBack(it->second);
+            it->second->OnConnect();
         }
     }
 
-    void Handle(TEvTablet::TEvPong::TPtr &ev, const TActorContext &ctx) {
-        NKikimrTabletBase::TEvPong &record = ev->Get()->Record;
-        const ui64 tabletId = record.GetTabletID();
-
-        TAutoPtr<TEntry>* entryHolder = FindEntry(tabletId);
-        if (!entryHolder) {
-            LOG_DEBUG(ctx, NKikimrServices::TABLET_RESOLVER, "Handle TEvPong tabletId: %" PRIu64 " no entryHolder",
-                tabletId);
-            return;
-        }
-        TEntry &entry = *entryHolder->Get();
-
-        LOG_DEBUG(ctx, NKikimrServices::TABLET_RESOLVER, "Handle TEvPong tabletId: %" PRIu64 " entry.State: %s",
-            tabletId, TEntry::StateToString(entry.State));
-
-        switch (entry.State) {
-        case TEntry::StInit:
-        case TEntry::StInitResolve:
-        case TEntry::StNormal:
-        case TEntry::StProblemResolve:
-        case TEntry::StFollowerUpdate:
-            break;
-        case TEntry::StProblemPing:
-            if (ev->Sender == entry.KnownLeader) {
-                entry.Cookie.Detach();
-                entry.State = TEntry::StNormal;
-                SendQueued(tabletId, entry, ctx);
-                MoveEntryToResolved(tabletId, *entryHolder);
+    void Handle(TEvInterconnect::TEvNodeDisconnected::TPtr& ev) {
+        auto itSession = InterconnectSessions.find(ev->Sender);
+        if (itSession != InterconnectSessions.end()) {
+            auto& session = itSession->second;
+            while (!session.EventStreams.Empty()) {
+                auto* stream = session.EventStreams.PopFront();
+                stream->OnDisconnect();
             }
-            break;
-        default:
-            Y_ABORT();
+            InterconnectSessions.erase(itSession);
+        }
+
+        auto it = EventStreams.find(ev->Cookie);
+        if (it != EventStreams.end() && !it->second->HadConnect()) {
+            it->second->OnDisconnect();
         }
     }
 
-    void Handle(TEvents::TEvUndelivered::TPtr &ev, const TActorContext &ctx) {
-        // cold be Ping or Initial Statestorage resolve
-        const ui64 tabletId = ev->Cookie;
-        TAutoPtr<TEntry>* entryHolder = FindEntry(tabletId);
-        if (!entryHolder)
-            return;
-
-        TEntry &entry = *entryHolder->Get();
-        if (ev->Get()->SourceType == TEvStateStorage::TEvLookup::EventType) {
-            InFlyResolveCounter->Dec();
-            DropEntry(tabletId, entry, ctx);
-            return;
-        }
-
-        switch (entry.State) {
-        case TEntry::StInit:
-        case TEntry::StInitResolve:
-        case TEntry::StNormal:
-        case TEntry::StProblemResolve:
-        case TEntry::StFollowerUpdate:
-            break;
-        case TEntry::StProblemPing:
-            if (ev->Sender == entry.KnownLeader) {
-                DropEntry(tabletId, entry, ctx);
-            }
-            break;
-        default:
-            Y_ABORT();
+    void HandleStream(IEventHandle::TPtr& ev) {
+        auto it = EventStreams.find(ev->Cookie);
+        if (it != EventStreams.end()) {
+            it->second->OnEvent(std::move(ev));
         }
     }
 
-    void Handle(TEvPrivate::TEvPingTimeout::TPtr &ev, const TActorContext &ctx) {
-        TEvPrivate::TEvPingTimeout *msg = ev->Get();
-        const ui64 tabletId = msg->TabletID;
-
-        TAutoPtr<TEntry>* entryHolder = FindEntry(tabletId);
-        if (!entryHolder) {
-            LOG_DEBUG(ctx, NKikimrServices::TABLET_RESOLVER, "Handle TEvPingTimeout tabletId: %" PRIu64
-                " no entryHolder", tabletId);
-            return;
-        }
-        TEntry &entry = *entryHolder->Get();
-
-        LOG_DEBUG(ctx, NKikimrServices::TABLET_RESOLVER, "Handle TEvPingTimeout tabletId: %" PRIu64 " entry.State: %s",
-            tabletId, TEntry::StateToString(entry.State));
-
-        switch (entry.State) {
-        case TEntry::StInit:
-        case TEntry::StInitResolve:
-        case TEntry::StNormal:
-        case TEntry::StProblemResolve:
-        case TEntry::StFollowerUpdate:
-            break;
-        case TEntry::StProblemPing:
-            if (msg->Cookie.DetachEvent()) {
-                DropEntry(tabletId, entry, ctx);
-            }
-            break;
-        default:
-            Y_ABORT();
-        }
-    }
-
-    void Handle(TEvPrivate::TEvStopListRemoval::TPtr &ev, const TActorContext &) {
-        TEvPrivate::TEvStopListRemoval *msg = ev->Get();
+    void Handle(TEvPrivate::TEvStopListRemoval::TPtr& ev) {
+        TEvPrivate::TEvStopListRemoval* msg = ev->Get();
         TabletsOnStopList.erase(msg->TabletID);
     }
 
-    void Handle(TEvInterconnect::TEvNodesInfo::TPtr &ev, const TActorContext &ctx) {
-        Y_UNUSED(ctx);
-
-        const TEvInterconnect::TEvNodesInfo *msg = ev->Get();
+    void Handle(TEvInterconnect::TEvNodesInfo::TPtr& ev) {
+        const TEvInterconnect::TEvNodesInfo* msg = ev->Get();
         bool distinct = false;
-        for (const auto &nodeInfo : msg->Nodes) {
+        for (const auto& nodeInfo : msg->Nodes) {
             if (nodeInfo.Location.GetDataCenterId() != msg->Nodes[0].Location.GetDataCenterId())
                 distinct = true;
             NodeToDcMapping[nodeInfo.NodeId] = nodeInfo.Location.GetDataCenterId();
@@ -809,15 +955,23 @@ class TTabletResolver : public TActorBootstrapped<TTabletResolver> {
         if (!distinct)
             NodeToDcMapping.clear();
 
-        ctx.Schedule(TabletResolverRefreshNodesPeriod, new TEvPrivate::TEvRefreshNodes);
+        Schedule(TabletResolverRefreshNodesPeriod, new TEvPrivate::TEvRefreshNodes);
     }
 
-    void Handle(TEvPrivate::TEvRefreshNodes::TPtr &, const TActorContext &ctx) {
-        RefreshNodes(ctx);
+    void Handle(TEvPrivate::TEvRefreshNodes::TPtr&) {
+        RefreshNodes();
     }
 
-    void RefreshNodes(const TActorContext &ctx) {
-        ctx.Send(GetNameserviceActorId(), new TEvInterconnect::TEvListNodes());
+    void RefreshNodes() {
+        Send(GetNameserviceActorId(), new TEvInterconnect::TEvListNodes());
+    }
+
+    void OnEvictEntry(TEntry& entry) {
+        entry.InCache = false;
+        if (entry.State == TEntry::StNormal) {
+            entry.State = TEntry::StRemove;
+            entry.Wakeup.NotifyOne();
+        }
     }
 
 public:
@@ -825,35 +979,34 @@ public:
         return NKikimrServices::TActivity::TABLET_RESOLVER_ACTOR;
     }
 
-    TTabletResolver(const TIntrusivePtr<TTabletResolverConfig> &config)
+    TTabletResolver(const TIntrusivePtr<TTabletResolverConfig>& config)
         : Config(config)
-        , ActorSystem(nullptr)
-        , ResolvedTablets(new NCache::T2QCacheConfig())
+        , TabletCache(new NCache::T2QCacheConfig())
     {
-        ResolvedTablets.SetOverflowCallback([=, this](const NCache::ICache<ui64, TAutoPtr<TEntry>>& cache) {
+        TabletCache.SetOverflowCallback([this](const NCache::ICache<ui64, TEntry*>& cache) {
             return cache.GetUsedSize() >= Config->TabletCacheLimit;
         });
 
-        ResolvedTablets.SetEvictionCallback([&](const ui64& key, TAutoPtr<TEntry>& value, ui64 size) {
+        TabletCache.SetEvictionCallback([this](const ui64& key, TEntry*& value, ui64 size) {
+            Y_UNUSED(key);
             Y_UNUSED(size);
 
-            if (!value)
+            if (!value) {
+                // Moved from, but not erased?
                 return;
-
-            auto& queue = value->Queue;
-            while (TEntry::TQueueEntry* x = queue.Head()) {
-                ActorSystem->Send(x->Ev->Sender, new TEvTabletResolver::TEvForwardResult(NKikimrProto::RACE, key));
-                queue.Pop();
             }
+
+            OnEvictEntry(*value);
         });
     }
 
     ~TTabletResolver() {
-        ResolvedTablets.SetEvictionCallback(&TResolvedTablets::DefaultEvictionCallback);
+        TabletCache.SetEvictionCallback(&TTabletCache::DefaultEvictionCallback);
+        TabletCache.SetOverflowCallback(&TTabletCache::DefaultOverflowCallback);
     }
 
-    void Bootstrap(const TActorContext &ctx) {
-        RefreshNodes(ctx);
+    void Bootstrap() {
+        RefreshNodes();
         Become(&TThis::StateWork);
 
         auto tablets = GetServiceCounters(AppData()->Counters, "tablets");
@@ -871,25 +1024,25 @@ public:
 
     STFUNC(StateWork) {
         switch (ev->GetTypeRewrite()) {
-            HFunc(TEvTabletResolver::TEvForward, Handle);
-            HFunc(TEvTabletResolver::TEvTabletProblem, Handle);
-            HFunc(TEvTabletResolver::TEvNodeProblem, Handle);
-            HFunc(TEvStateStorage::TEvInfo, Handle);
-            HFunc(TEvTablet::TEvPong, Handle);
-            HFunc(TEvPrivate::TEvPingTimeout, Handle);
-            HFunc(TEvPrivate::TEvStopListRemoval, Handle);
-            HFunc(TEvInterconnect::TEvNodesInfo, Handle);
-            HFunc(TEvPrivate::TEvRefreshNodes, Handle);
-            HFunc(TEvents::TEvUndelivered, Handle);
+            hFunc(TEvTabletResolver::TEvForward, Handle);
+            hFunc(TEvTabletResolver::TEvTabletProblem, Handle);
+            hFunc(TEvTabletResolver::TEvNodeProblem, Handle);
+            IgnoreFunc(TEvStateStorage::TEvInfo);
+            hFunc(TEvInterconnect::TEvNodeConnected, Handle);
+            hFunc(TEvInterconnect::TEvNodeDisconnected, Handle);
+            fFunc(TEvTablet::TEvTabletStateUpdate::EventType, HandleStream);
+            fFunc(TEvents::TEvUndelivered::EventType, HandleStream);
+            hFunc(TEvInterconnect::TEvNodesInfo, Handle);
+            hFunc(TEvPrivate::TEvRefreshNodes, Handle);
+            hFunc(TEvPrivate::TEvStopListRemoval, Handle);
             default:
-                LOG_WARN(*TlsActivationContext, NKikimrServices::TABLET_RESOLVER, "TTabletResolver::StateWork unexpected event type: %" PRIx32
-                    " event: %s", ev->GetTypeRewrite(), ev->ToString().data());
+                BLOG_WARN("TTabletResolver::StateWork unexpected event type: " << Hex(ev->GetTypeRewrite()) << " event: " << ev->ToString());
                 break;
         }
     }
 };
 
-IActor* CreateTabletResolver(const TIntrusivePtr<TTabletResolverConfig> &config) {
+IActor* CreateTabletResolver(const TIntrusivePtr<TTabletResolverConfig>& config) {
     return new TTabletResolver(config);
 }
 

--- a/ydb/core/tablet/tablet_sys.cpp
+++ b/ydb/core/tablet/tablet_sys.cpp
@@ -305,13 +305,13 @@ void TTablet::HandlePingBoot(TEvTablet::TEvPing::TPtr &ev) {
     // todo: handle wait-boot flag
     NKikimrTabletBase::TEvPing &record = ev->Get()->Record;
     Y_ABORT_UNLESS(record.GetTabletID() == TabletID());
-    Send(ev->Sender, new TEvTablet::TEvPong(TabletID(), TEvTablet::TEvPong::FlagBoot | TEvTablet::TEvPong::FlagLeader));
+    Send(ev->Sender, new TEvTablet::TEvPong(TabletID(), TEvTablet::TEvPong::FlagBoot | TEvTablet::TEvPong::FlagLeader), 0, ev->Cookie);
 }
 
 void TTablet::HandlePingFollower(TEvTablet::TEvPing::TPtr &ev) {
     NKikimrTabletBase::TEvPing &record = ev->Get()->Record;
     Y_ABORT_UNLESS(record.GetTabletID() == TabletID());
-    Send(ev->Sender, new TEvTablet::TEvPong(TabletID(), TEvTablet::TEvPong::FlagFollower));
+    Send(ev->Sender, new TEvTablet::TEvPong(TabletID(), TEvTablet::TEvPong::FlagFollower), 0, ev->Cookie);
 }
 
 void TTablet::HandleStateStorageLeaderResolve(TEvStateStorage::TEvInfo::TPtr &ev) {
@@ -1063,7 +1063,7 @@ void TTablet::HandleWriteZeroEntry(TEvTabletBase::TEvWriteLogResult::TPtr &ev) {
 void TTablet::Handle(TEvTablet::TEvPing::TPtr &ev) {
     NKikimrTabletBase::TEvPing &record = ev->Get()->Record;
     Y_ABORT_UNLESS(record.GetTabletID() == TabletID());
-    Send(ev->Sender, new TEvTablet::TEvPong(TabletID(), TEvTablet::TEvPong::FlagLeader));
+    Send(ev->Sender, new TEvTablet::TEvPong(TabletID(), TEvTablet::TEvPong::FlagLeader), 0, ev->Cookie);
 }
 
 void TTablet::HandleByLeader(TEvTablet::TEvTabletActive::TPtr &ev) {

--- a/ydb/core/tablet/ya.make
+++ b/ydb/core/tablet/ya.make
@@ -58,6 +58,7 @@ SRCS(
 )
 
 PEERDIR(
+    ydb/library/actors/async
     ydb/library/actors/core
     ydb/library/actors/helpers
     ydb/library/actors/protos

--- a/ydb/core/testlib/actors/test_runtime.cpp
+++ b/ydb/core/testlib/actors/test_runtime.cpp
@@ -243,7 +243,8 @@ namespace NActors {
                 MonPorts.push_back(port);
             }
 
-            node->ActorSystem->Start();
+            StartActorSystem(nodeIndex, node);
+
             if (nodeAppData->Mon) {
                 nodeAppData->Mon->Start(node->ActorSystem.Get());
             }

--- a/ydb/core/testlib/basics/services.cpp
+++ b/ydb/core/testlib/basics/services.cpp
@@ -86,6 +86,9 @@ namespace NPDisk {
         IActor* tabletResolver = CreateTabletResolver(tabletResolverConfig);
         runtime.AddLocalService(MakeTabletResolverID(),
             TActorSetupCmd(tabletResolver, TMailboxType::Revolving, 0), nodeIndex);
+
+        // TabletResolver needs timers for retries
+        runtime.EnableScheduleForActor(MakeTabletResolverID());
     }
 
     void SetupTabletPipePerNodeCaches(TTestActorRuntime& runtime, ui32 nodeIndex, bool forceFollowers)
@@ -503,11 +506,6 @@ namespace NPDisk {
                 NSysView::MakeSysViewServiceID(runtime.GetNodeId(nodeIndex)), nodeIndex);
             Y_ABORT_UNLESS(sysViewServiceId, "Missing SysView Service on node %" PRIu32, nodeIndex);
             runtime.EnableScheduleForActor(sysViewServiceId);
-
-            // TabletResolver needs timers for retries
-            auto tabletResolverActorId = runtime.GetLocalServiceId(MakeTabletResolverID(), nodeIndex);
-            Y_ABORT_UNLESS(tabletResolverActorId, "Missing TabletResolver on node %" PRIu32, nodeIndex);
-            runtime.EnableScheduleForActor(tabletResolverActorId);
         }
 
 

--- a/ydb/core/testlib/basics/services.cpp
+++ b/ydb/core/testlib/basics/services.cpp
@@ -503,6 +503,11 @@ namespace NPDisk {
                 NSysView::MakeSysViewServiceID(runtime.GetNodeId(nodeIndex)), nodeIndex);
             Y_ABORT_UNLESS(sysViewServiceId, "Missing SysView Service on node %" PRIu32, nodeIndex);
             runtime.EnableScheduleForActor(sysViewServiceId);
+
+            // TabletResolver needs timers for retries
+            auto tabletResolverActorId = runtime.GetLocalServiceId(MakeTabletResolverID(), nodeIndex);
+            Y_ABORT_UNLESS(tabletResolverActorId, "Missing TabletResolver on node %" PRIu32, nodeIndex);
+            runtime.EnableScheduleForActor(tabletResolverActorId);
         }
 
 

--- a/ydb/library/actors/testlib/test_runtime.h
+++ b/ydb/library/actors/testlib/test_runtime.h
@@ -679,6 +679,7 @@ namespace NActors {
 
         THolder<TActorSystemSetup> MakeActorSystemSetup(ui32 nodeIndex, TNodeDataBase* node);
         THolder<TActorSystem> MakeActorSystem(ui32 nodeIndex, TNodeDataBase* node);
+        void StartActorSystem(ui32 nodeIndex, TNodeDataBase* node);
         virtual void InitActorSystemSetup(TActorSystemSetup& setup, TNodeDataBase* node) {
             Y_UNUSED(setup, node);
         }


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

...

### Changelog category <!-- remove all except one -->

* Not for changelog (changelog entry is not required)

### Description for reviewers <!-- (optional) description for those who read this PR -->

This PR rewrites tablet resolver to use tablet state subscriptions for cache invalidation.

Fixes #21053.