### PR TITLE
Enable Kafka API related feature flags

### DIFF
--- a/ydb/core/kafka_proxy/ut/ut_protocol.cpp
+++ b/ydb/core/kafka_proxy/ut/ut_protocol.cpp
@@ -58,7 +58,7 @@ class TTestServer {
 public:
     TIpPort Port;
 
-    TTestServer(const TString& kafkaApiMode = "1", bool serverless = false, bool enableNativeKafkaBalancing = false) {
+    TTestServer(const TString& kafkaApiMode = "1", bool serverless = false, bool enableNativeKafkaBalancing = true) {
         TPortManager portManager;
         Port = portManager.GetTcpPort();
 
@@ -137,8 +137,8 @@ public:
         KikimrServer->GetRuntime()->SetLogPriority(NKikimrServices::GRPC_CLIENT, NLog::PRI_TRACE);
         KikimrServer->GetRuntime()->SetLogPriority(NKikimrServices::GRPC_PROXY_NO_CONNECT_ACCESS, NLog::PRI_TRACE);
 
-        if (enableNativeKafkaBalancing) {
-            KikimrServer->GetRuntime()->GetAppData().FeatureFlags.SetEnableKafkaNativeBalancing(true);
+        if (!enableNativeKafkaBalancing) {
+            KikimrServer->GetRuntime()->GetAppData().FeatureFlags.SetEnableKafkaNativeBalancing(false);
         }
         KikimrServer->GetRuntime()->GetAppData().FeatureFlags.SetEnableKafkaTransactions(true);
 
@@ -1183,7 +1183,7 @@ Y_UNIT_TEST_SUITE(KafkaProtocol) {
 
     void RunBalanceScenarionTest(bool forFederation) {
         TString protocolName = "roundrobin";
-        TInsecureTestServer testServer("2");
+        TInsecureTestServer testServer("2", false, false);
 
         TString topicName = "/Root/topic-0-test";
         TString shortTopicName = "topic-0-test";
@@ -1411,7 +1411,7 @@ Y_UNIT_TEST_SUITE(KafkaProtocol) {
     Y_UNIT_TEST(BalanceScenarioCdc) {
 
         TString protocolName = "roundrobin";
-        TInsecureTestServer testServer("2");
+        TInsecureTestServer testServer("2", false, false);
 
 
         TString tableName = "/Root/table-0-test";

--- a/ydb/core/protos/feature_flags.proto
+++ b/ydb/core/protos/feature_flags.proto
@@ -197,8 +197,8 @@ message TFeatureFlags {
     optional bool EnablePermissionsExport = 171 [default = false];
     optional bool EnableDataErasure = 172 [default = false];
     optional bool EnableChangefeedsExport = 174 [default = true];
-    optional bool EnableKafkaNativeBalancing = 175 [default = false];
-    optional bool EnableKafkaTransactions = 177 [default = false];
+    optional bool EnableKafkaNativeBalancing = 175 [default = true];
+    optional bool EnableKafkaTransactions = 177 [default = true];
     optional bool SwitchToConfigV2 = 179 [default = false];
     optional bool SwitchToConfigV1 = 180 [default = false];
     optional bool EnableExportAutoDropping = 183 [default = true];


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

This PR sets to true by default these feature flags:

* EnableKafkaNativeBalancing - it enables kafka API users to rely on Kafka client-side consumer balancing protocol.
* EnableKafkaTransactions - it allows to use Kafka-transactions related methods

### Changelog category <!-- remove all except one -->

* Not for changelog (changelog entry is not required)

### Description for reviewers <!-- (optional) description for those who read this PR -->

...