### PR TITLE
remove extra timeout handler call (#21746)

### DIFF
--- a/ydb/core/viewer/viewer_tenantinfo.h
+++ b/ydb/core/viewer/viewer_tenantinfo.h
@@ -1030,7 +1030,6 @@ public:
             request.Error(error);
         }
         ReplyAndPassAway();
-        TBase::HandleTimeout();
     }
 
     static YAML::Node GetSwagger() {


### PR DESCRIPTION
fixes crash, described in https://github.com/ydb-platform/ydb/issues/21744
* Bugfix 

