### PR TITLE
Remove unused fields from Whiteboard::TBSGroupStateInfo

### DIFF
--- a/ydb/core/blob_depot/group_metrics_exchange.cpp
+++ b/ydb/core/blob_depot/group_metrics_exchange.cpp
@@ -83,8 +83,6 @@ namespace NKikimr::NBlobDepot {
 
             auto *wb = record.MutableWhiteboardUpdate();
             wb->SetGroupID(Config.GetVirtualGroupId());
-            wb->SetAllocatedSize(Data->GetTotalStoredDataSize());
-            wb->SetAvailableSize(params->GetAvailableSize());
             wb->SetReadThroughput(ReadThroughput);
             wb->SetWriteThroughput(WriteThroughput);
 

--- a/ydb/core/protos/node_whiteboard.proto
+++ b/ydb/core/protos/node_whiteboard.proto
@@ -258,8 +258,8 @@ message TBSGroupStateInfo {
     optional EFlag Latency = 8 [(DefaultField) = true];
     optional uint32 Count = 13; // filled during group count
     optional string StoragePoolName = 14 [(DefaultField) = true]; // from BS_CONTROLLER
-    optional uint64 AllocatedSize = 15 [(InsignificantChangeAmount) = 100000000, (DefaultField) = true];
-    optional uint64 AvailableSize = 16 [(InsignificantChangeAmount) = 100000000,  (DefaultField) = true];
+    // optional uint64 AllocatedSize = 15 [(InsignificantChangeAmount) = 100000000, (DefaultField) = true];
+    // optional uint64 AvailableSize = 16 [(InsignificantChangeAmount) = 100000000,  (DefaultField) = true];
     optional uint64 ReadThroughput = 17 [(DefaultField) = true];
     optional uint64 WriteThroughput = 18 [(DefaultField) = true];
     optional bool Encryption = 19 [(DefaultField) = true];


### PR DESCRIPTION
### Changelog category

* Not for changelog (changelog entry is not required)

### Description for reviewers

Those values are set, but never read

Related to #21358 
