### PR TITLE
Report fair VDisk AvailableSize

### DIFF
--- a/ydb/core/blobstorage/pdisk/blobstorage_pdisk_chunk_tracker.h
+++ b/ydb/core/blobstorage/pdisk/blobstorage_pdisk_chunk_tracker.h
@@ -99,6 +99,10 @@ public:
         RedistributeQuotas();
     }
 
+    ui32 GetOwnerWeight(TOwner id) {
+        return QuotaForOwner[id].GetWeight();
+    }
+
     void RemoveOwner(TOwner id) {
         bool isFound = false;
         for (ui64 idx = 0; idx < ActiveOwnerIds.size(); ++idx) {
@@ -380,6 +384,11 @@ public:
         OwnerQuota->RemoveOwner(owner);
     }
 
+    ui32 GetOwnerWeight(TOwner owner) {
+        Y_VERIFY(IsOwnerUser(owner));
+        return OwnerQuota->GetOwnerWeight(owner);
+    }
+
     ui32 GetNumActiveSlots() const {
         return OwnerQuota->GetNumActiveSlots();
     }
@@ -429,10 +438,10 @@ public:
     }
     /////////////////////////////////////////////////////
 
-    i64 GetOwnerFree(TOwner owner) const {
+    i64 GetOwnerFree(TOwner owner, bool personal) const {
         if (IsOwnerUser(owner)) {
-            // fix for CLOUDINC-1822: remove OwnerQuota->GetFree(owner) since it broke group balancing in Hive
-            return SharedQuota->GetFree();
+            // See CLOUDINC-1822: OwnerQuota->GetFree(owner) broke group balancing in Hive and was replaced by SharedQuota
+            return personal ? OwnerQuota->GetFree(owner) : SharedQuota->GetFree();
         } else {
             switch (owner) {
                 case OwnerCommonStaticLog:

--- a/ydb/core/blobstorage/pdisk/blobstorage_pdisk_keeper.h
+++ b/ydb/core/blobstorage/pdisk/blobstorage_pdisk_keeper.h
@@ -85,12 +85,16 @@ public:
         return ChunkTracker.GetOwnerHardLimit(owner);
     }
 
-    i64 GetOwnerFree(TOwner owner) const {
-        return ChunkTracker.GetOwnerFree(owner);
+    i64 GetOwnerFree(TOwner owner, bool personal) const {
+        return ChunkTracker.GetOwnerFree(owner, personal);
     }
 
     i64 GetOwnerUsed(TOwner owner) const {
         return ChunkTracker.GetOwnerUsed(owner);
+    }
+
+    ui32 GetOwnerWeight(TOwner owner) {
+        return ChunkTracker.GetOwnerWeight(owner);
     }
 
     i64 GetLogChunkCount() const {

--- a/ydb/core/protos/blobstorage.proto
+++ b/ydb/core/protos/blobstorage.proto
@@ -1307,7 +1307,7 @@ message TEvControllerSelectGroupsResult {
             optional double IOPS = 2; // operations per second
             optional uint64 ReadThroughput = 3; // bytes per second
             optional uint64 WriteThroughput = 4; // bytes per second
-            optional double Occupancy = 5; // part of full slot size of the worst VDisk of group
+            optional double Occupancy = 5; // the worst occupancy among all VDisks in group
         }
 
         // assured part of group metrics -- when the underlying PDisks have all possible VSlots created; these metrics


### PR DESCRIPTION
### Changelog category

* Not for changelog (changelog entry is not required)

### Description for reviewers

This patch affects:
- `NKikimrWhiteboard::TVDiskStateInfo.AvailableSize` almost unused, except for `core/viewer` 
- `NKikimrBlobStorage::TVDiskMetrics.AvailableSize` broadly used in BSController, Hive, Sysview, and beyond
- `NKikimrBlobStorage::TPDiskMetrics.EnforcedDynamicSlotSize` playing secondary role in BSController and Hive

See the existing relationships on the Miro diagram: [pdf](https://github.com/user-attachments/files/21494572/PDiskSlotSizeUnits.-.2025-07-23.pdf), [link](https://miro.com/app/board/uXjVIILlPOQ=/?moveToWidget=3458764630770574041&cot=14)

- Close #21358 

