### PR TITLE
Add GroupSizeInUnits info to Hive

### DIFF
--- a/ydb/core/mind/bscontroller/bsc.cpp
+++ b/ydb/core/mind/bscontroller/bsc.cpp
@@ -131,6 +131,7 @@ void TBlobStorageController::TGroupInfo::FillInGroupParameters(
         FillInResources(params->MutableAssuredResources(), true);
         FillInResources(params->MutableCurrentResources(), false);
         FillInVDiskResources(params);
+        params->SetGroupSizeInUnits(GroupSizeInUnits);
     }
 }
 

--- a/ydb/core/mind/hive/hive_impl.cpp
+++ b/ydb/core/mind/hive/hive_impl.cpp
@@ -2195,6 +2195,7 @@ void THive::Handle(TEvHive::TEvRequestHiveStorageStats::TPtr& ev) {
             pbGroup.SetMaximumSize(group.MaximumResources.Size);
             pbGroup.SetAllocatedSize(group.GroupParameters.GetAllocatedSize());
             pbGroup.SetAvailableSize(group.GroupParameters.GetAvailableSize());
+            pbGroup.SetGroupSizeInUnits(group.GroupParameters.GetGroupSizeInUnits());
         }
     }
     Send(ev->Sender, response.Release(), 0, ev->Cookie);

--- a/ydb/core/protos/blobstorage.proto
+++ b/ydb/core/protos/blobstorage.proto
@@ -1317,6 +1317,7 @@ message TEvControllerSelectGroupsResult {
         optional uint64 AvailableSize = 9; // bytes as reported by VDisk metrics (pessimistic case)
         optional uint64 AllocatedSize = 10; // the same basis
         optional NKikimrBlobStorage.TPDiskSpaceColor.E SpaceColor = 11;
+        optional uint32 GroupSizeInUnits = 14;
     }
     message TMatchingGroupList {
         repeated TGroupParameters Groups = 1;

--- a/ydb/core/protos/hive.proto
+++ b/ydb/core/protos/hive.proto
@@ -355,6 +355,7 @@ message THiveStorageGroupStats {
     optional uint64 MaximumSize = 9;
     optional uint64 AllocatedSize = 10;
     optional uint64 AvailableSize = 11;
+    optional uint32 GroupSizeInUnits = 12;
 }
 
 message THiveStoragePoolStats {

--- a/ydb/core/viewer/viewer_storage.h
+++ b/ydb/core/viewer/viewer_storage.h
@@ -301,6 +301,7 @@ public:
                     stats.SetMaximumIOPS(stats.GetMaximumIOPS() + pbGroup.GetMaximumIOPS());
                     stats.SetMaximumThroughput(stats.GetMaximumThroughput() + pbGroup.GetMaximumThroughput());
                     stats.SetMaximumSize(stats.GetMaximumSize() + pbGroup.GetMaximumSize());
+                    stats.SetGroupSizeInUnits(pbGroup.GetGroupSizeInUnits());
                 }
             }
         }


### PR DESCRIPTION
### Changelog category

* Not for changelog (changelog entry is not required)

### Description for reviewers

Though it isn't used for anything except monitoring. See the existing relationships on the Miro diagram: [pdf](https://github.com/user-attachments/files/21494572/PDiskSlotSizeUnits.-.2025-07-23.pdf), [link](https://miro.com/app/board/uXjVIILlPOQ=/?moveToWidget=3458764630770574041&cot=14)


- Close #19385  