### PR TITLE
25-1: Support `reset` (in addition to `update` & `erase`) change records

### DIFF
--- a/ydb/core/tx/replication/controller/replication.h
+++ b/ydb/core/tx/replication/controller/replication.h
@@ -96,6 +96,7 @@ public:
 
         virtual void AddWorker(ui64 id) = 0;
         virtual void RemoveWorker(ui64 id) = 0;
+        virtual TVector<ui64> GetWorkers() const = 0;
         virtual void UpdateLag(ui64 workerId, TDuration lag) = 0;
         virtual const TMaybe<TDuration> GetLag() const = 0;
 

--- a/ydb/core/tx/replication/controller/target_base.cpp
+++ b/ydb/core/tx/replication/controller/target_base.cpp
@@ -144,8 +144,16 @@ void TTargetBase::RemoveWorker(ui64 id) {
     Workers.erase(id);
 }
 
-const THashMap<ui64, TTargetBase::TWorker>& TTargetBase::GetWorkers() const {
-    return Workers;
+TVector<ui64> TTargetBase::GetWorkers() const {
+    TVector<ui64> result(::Reserve(Workers.size()));
+    for (const auto& [id, _] : Workers) {
+        result.push_back(id);
+    }
+    return result;
+}
+
+bool TTargetBase::HasWorkers() const {
+    return !Workers.empty();
 }
 
 void TTargetBase::RemoveWorkers(const TActorContext& ctx) {

--- a/ydb/core/tx/replication/controller/target_base.h
+++ b/ydb/core/tx/replication/controller/target_base.h
@@ -19,7 +19,7 @@ protected:
         return Replication;
     }
 
-    const THashMap<ui64, TWorker>& GetWorkers() const;
+    bool HasWorkers() const;
     void RemoveWorkers(const TActorContext& ctx);
 
 public:
@@ -67,6 +67,7 @@ public:
 
     void AddWorker(ui64 id) override;
     void RemoveWorker(ui64 id) override;
+    TVector<ui64> GetWorkers() const override;
     void UpdateLag(ui64 workerId, TDuration lag) override;
     const TMaybe<TDuration> GetLag() const override;
 

--- a/ydb/core/tx/replication/controller/target_transfer.cpp
+++ b/ydb/core/tx/replication/controller/target_transfer.cpp
@@ -26,7 +26,7 @@ void TTargetTransfer::Progress(const TActorContext& ctx) {
 
     switch (GetStreamState()) {
     case EStreamState::Removing:
-        if (GetWorkers()) {
+        if (HasWorkers()) {
             RemoveWorkers(ctx);
         } else if (!StreamConsumerRemover) {
             StreamConsumerRemover = ctx.Register(CreateStreamConsumerRemover(replication, GetId(), ctx));

--- a/ydb/core/tx/replication/controller/target_with_stream.cpp
+++ b/ydb/core/tx/replication/controller/target_with_stream.cpp
@@ -128,7 +128,7 @@ void TTargetWithStream::Progress(const TActorContext& ctx) {
         }
         return;
     case EStreamState::Removing:
-        if (GetWorkers()) {
+        if (HasWorkers()) {
             RemoveWorkers(ctx);
         } else if (!StreamRemover) {
             StreamRemover = ctx.Register(CreateStreamRemover(replication, GetId(), ctx));

--- a/ydb/core/tx/replication/controller/tx_drop_dst_result.cpp
+++ b/ydb/core/tx/replication/controller/tx_drop_dst_result.cpp
@@ -61,6 +61,9 @@ public:
         NIceDb::TNiceDb db(txc.DB);
         db.Table<Schema::Targets>().Key(rid, tid).Delete();
         db.Table<Schema::SrcStreams>().Key(rid, tid).Delete();
+        for (const auto wid : target->GetWorkers()) {
+            db.Table<Schema::Workers>().Key(rid, tid, wid).Delete();
+        }
         Replication->RemoveTarget(tid);
 
         return true;

--- a/ydb/core/tx/replication/controller/tx_drop_stream_result.cpp
+++ b/ydb/core/tx/replication/controller/tx_drop_stream_result.cpp
@@ -66,6 +66,9 @@ public:
         } else {
             db.Table<Schema::Targets>().Key(rid, tid).Delete();
             db.Table<Schema::SrcStreams>().Key(rid, tid).Delete();
+            for (const auto wid : target->GetWorkers()) {
+                db.Table<Schema::Workers>().Key(rid, tid, wid).Delete();
+            }
             Replication->RemoveTarget(tid);
         }
 

--- a/ydb/core/tx/replication/service/service.cpp
+++ b/ydb/core/tx/replication/service/service.cpp
@@ -26,7 +26,7 @@ namespace NKikimr::NReplication::NService {
 class TSessionInfo {
     struct TWorkerInfo {
         const TActorId ActorId;
-        TRowVersion Heartbeat;
+        TRowVersion Heartbeat = TRowVersion::Min();
 
         explicit TWorkerInfo(const TActorId& actorId)
             : ActorId(actorId)

--- a/ydb/core/tx/replication/service/table_writer_ut.cpp
+++ b/ydb/core/tx/replication/service/table_writer_ut.cpp
@@ -37,8 +37,8 @@ Y_UNIT_TEST_SUITE(LocalTableWriter) {
 
         env.Send<TEvWorker::TEvPoll>(writer, new TEvWorker::TEvData(0, "TestSource", {
             TRecord(1, R"({"key":[1], "update":{"value":"10"}})"),
-            TRecord(2, R"({"key":[2], "update":{"value":"20"}})"),
-            TRecord(3, R"({"key":[3], "update":{"value":"30"}})"),
+            TRecord(2, R"({"key":[2], "reset":{"value":"20"}})"),
+            TRecord(3, R"({"key":[3], "erase":{}})"),
         }));
     }
 


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

Support in asynchronous replication new kind of change record — `reset` record (in addition to `update` & `erase` records).

### Changelog category <!-- remove all except one -->

* Bugfix

### Description for reviewers <!-- (optional) description for those who read this PR -->

issue: https://github.com/ydb-platform/ydb/issues/21884
main: https://github.com/ydb-platform/ydb/pull/21883
