### PR TITLE
Fix uninitialized FollowerId field

### DIFF
--- a/ydb/core/tablet/tablet_sys.cpp
+++ b/ydb/core/tablet/tablet_sys.cpp
@@ -791,7 +791,7 @@ void TTablet::HandleByLeader(TEvTablet::TEvFollowerAttach::TPtr &ev) {
         auto followerItPair = LeaderInfo.emplace(
             std::piecewise_construct,
             std::forward_as_tuple(ev->Sender),
-            std::forward_as_tuple(EFollowerSyncState::Pending));
+            std::forward_as_tuple(ev->Sender, EFollowerSyncState::Pending));
         Y_ABORT_UNLESS(followerItPair.second);
 
         followerIt = followerItPair.first;
@@ -799,7 +799,6 @@ void TTablet::HandleByLeader(TEvTablet::TEvFollowerAttach::TPtr &ev) {
 
     TLeaderInfo &followerInfo = followerIt->second;
 
-    followerInfo.FollowerId = followerId;
     followerInfo.InterconnectSession = ev->InterconnectSession;
     followerInfo.FollowerAttempt = record.GetFollowerAttempt();
     followerInfo.StreamCounter = 0;
@@ -940,7 +939,7 @@ void TTablet::HandleStateStorageInfoUpgrade(TEvStateStorage::TEvInfo::TPtr &ev) 
                 auto itPair = LeaderInfo.emplace(
                     std::piecewise_construct,
                     std::forward_as_tuple(xpair.first),
-                    std::forward_as_tuple(EFollowerSyncState::NeedSync));
+                    std::forward_as_tuple(xpair.first, EFollowerSyncState::NeedSync));
                 // some followers could be already present by active TEvFollowerAttach
                 if (itPair.second)
                     TrySyncToFollower(itPair.first);

--- a/ydb/core/tablet/tablet_sys.h
+++ b/ydb/core/tablet/tablet_sys.h
@@ -179,7 +179,7 @@ class TTablet : public TActor<TTablet> {
     };
 
     struct TLeaderInfo : public TIntrusiveListItem<TLeaderInfo> {
-        TActorId FollowerId;
+        const TActorId FollowerId;
         TActorId InterconnectSession;
         ui32 FollowerAttempt;
         ui64 StreamCounter;
@@ -194,8 +194,9 @@ class TTablet : public TActor<TTablet> {
         ui32 ConfirmedGCStep;
         bool PresentInList;
 
-        TLeaderInfo(EFollowerSyncState syncState = EFollowerSyncState::Pending)
-            : FollowerAttempt(Max<ui32>())
+        explicit TLeaderInfo(const TActorId& followerId, EFollowerSyncState syncState)
+            : FollowerId(followerId)
+            , FollowerAttempt(Max<ui32>())
             , StreamCounter(0)
             , SyncState(syncState)
             , LastSyncAttempt(TInstant::Zero())


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

...

### Changelog category <!-- remove all except one -->

* Not for changelog (changelog entry is not required)

### Description for reviewers <!-- (optional) description for those who read this PR -->

The new FollowerId field was left uninitialized when leader discovers followers before those followers are connected, which could later lead to Y_ENSURE triggering on disconnections.

Fixes #21779.