### PR TITLE
[Kafka API transactions] Fix several bugs

### DIFF
--- a/ydb/core/kafka_proxy/kafka_connection.cpp
+++ b/ydb/core/kafka_proxy/kafka_connection.cpp
@@ -609,6 +609,7 @@ protected:
     }
 
     void OnRequestProcessed(const Msg::TPtr& request) {
+        KAFKA_LOG_T("Request with correlationId " << request->Header.CorrelationId << " processed. Erasing it from PendingRequests and PendingRequestsQueue");
         InflightSize -= request->ExpectedSize;
         PendingRequests.erase(request->Header.CorrelationId);
         PendingRequestsQueue.pop_front();
@@ -617,7 +618,9 @@ protected:
     bool ProcessReplyQueue(const TActorContext& ctx) {
         while(!PendingRequestsQueue.empty()) {
             auto& request = PendingRequestsQueue.front();
+            KAFKA_LOG_T("Processing reply queue for request with correlationId " << request->Header.CorrelationId);
             if (request->Response.get() == nullptr) {
+                KAFKA_LOG_T("Response for request with correlationId " << request->Header.CorrelationId << " is empty.");
                 break;
             }
 
@@ -632,6 +635,7 @@ protected:
     }
 
     bool Reply(const TRequestHeaderData* header, const TApiMessage* reply, const TString method, const TInstant requestStartTime, EKafkaErrors errorCode, const TActorContext& ctx) {
+        KAFKA_LOG_T("Building reply for method " << method << " and correlationId " << header->CorrelationId << " with error code: " << errorCode);
         TKafkaVersion headerVersion = ResponseHeaderVersion(header->RequestApiKey, header->RequestApiVersion);
         TKafkaVersion version = header->RequestApiVersion;
         

--- a/ydb/core/kafka_proxy/kafka_producer_instance_id.h
+++ b/ydb/core/kafka_proxy/kafka_producer_instance_id.h
@@ -12,9 +12,15 @@ namespace NKafka {
         auto operator<=>(TProducerInstanceId const&) const = default;
     };
     inline IOutputStream& operator<<(IOutputStream& os, const TProducerInstanceId& obj) {
-        os << "{Id: " << obj.Id << ", Epoch: " << obj.Epoch;
+        os << "{Id: " << obj.Id << ", Epoch: " << obj.Epoch << "}";
         return os;
     }
 
     static const TProducerInstanceId INVALID_PRODUCER_INSTANCE_ID = {-1, -1};
+    
+    struct TProducerInstanceIdHashFn {
+        size_t operator()(const TProducerInstanceId& producerInstanceId) const {
+            return std::hash<i64>()(producerInstanceId.Id) ^ std::hash<i32>()(producerInstanceId.Epoch);
+        }
+    };
 } // namespace NKafka

--- a/ydb/core/kafka_proxy/ut/ut_produce_actor.cpp
+++ b/ydb/core/kafka_proxy/ut/ut_produce_actor.cpp
@@ -65,6 +65,7 @@ namespace {
                 Ctx->Runtime->SetLogPriority(NKikimrServices::PERSQUEUE, NLog::PRI_DEBUG);
                 TContext::TPtr kafkaContext = std::make_shared<TContext>(KafkaConfig);
                 kafkaContext->DatabasePath = "/Root/PQ";
+                kafkaContext->ConnectionId = Ctx->Edge;
                 ActorId = Ctx->Runtime->Register(CreateKafkaProduceActor(kafkaContext));
                 auto dummySchemeCacheId = Ctx->Runtime->Register(new TDummySchemeCacheActor(Ctx->TabletId));
                 Ctx->Runtime->RegisterService(MakeSchemeCacheID(), dummySchemeCacheId);
@@ -276,6 +277,28 @@ namespace {
                 return poisonPillCounter > 0;
             };
             UNIT_ASSERT(!Ctx->Runtime->DispatchEvents(options3, TDuration::Seconds(2)));
+        }
+
+        Y_UNIT_TEST(OnWriteExpiredAndWakeUp_ShouldReturnREQUEST_TIMED_OUT) {
+            auto observer = [&](TAutoPtr<IEventHandle>& input) {
+                if (auto* event = input->CastAsLocal<TEvPartitionWriter::TEvWriteRequest>()) {
+                    return TTestActorRuntimeBase::EEventAction::DROP;
+                }
+
+                return TTestActorRuntimeBase::EEventAction::PROCESS;
+            };
+            Ctx->Runtime->SetObserverFunc(observer);
+
+            SendProduce();
+
+            Ctx->Runtime->AdvanceCurrentTime(TDuration::Seconds(31));
+
+            Ctx->Runtime->SingleSys()->Send(new IEventHandle(ActorId, Ctx->Edge, new TEvKafka::TEvWakeup()));
+
+            auto response = Ctx->Runtime->GrabEdgeEvent<NKafka::TEvKafka::TEvResponse>();
+
+            UNIT_ASSERT(response != nullptr);
+            UNIT_ASSERT_VALUES_EQUAL(response->ErrorCode, NKafka::EKafkaErrors::REQUEST_TIMED_OUT);
         }
     }
 } // anonymous namespace

--- a/ydb/core/persqueue/pq_impl.cpp
+++ b/ydb/core/persqueue/pq_impl.cpp
@@ -4637,7 +4637,8 @@ void TPersQueue::CheckTxState(const TActorContext& ctx,
 
     case NKikimrPQ::TTransaction::DELETING:
         // The PQ tablet has persisted its state. Now she can delete the transaction and take the next one.
-        DeleteWriteId(tx.WriteId);
+        TMaybe<TWriteId> writeId = tx.WriteId; // copy writeId to save for kafka transaction after erase
+        DeleteWriteId(writeId);
         PQ_LOG_D("delete TxId " << tx.TxId);
         Txs.erase(tx.TxId);
         SetTxInFlyCounter();
@@ -4646,7 +4647,7 @@ void TPersQueue::CheckTxState(const TActorContext& ctx,
         // in the status of the PQ tablet (if they came)
         TryReturnTabletStateAll(ctx);
 
-        TryContinueKafkaWrites(tx.WriteId, ctx);
+        TryContinueKafkaWrites(writeId, ctx);
         break;
     }
 }

--- a/ydb/core/persqueue/pq_impl.cpp
+++ b/ydb/core/persqueue/pq_impl.cpp
@@ -2695,7 +2695,7 @@ void TPersQueue::HandleEventForSupportivePartition(const ui64 responseCookie,
                        NPersQueue::NErrorCode::BAD_REQUEST,
                        "it is forbidden to write after a commit");
             return;
-        } else if (writeInfo.TxId.Defined() && writeId.KafkaApiTransaction) {
+        } else if (writeInfo.TxId.Defined() && writeId.IsKafkaApiTransaction()) {
             // This branch happens when previous Kafka transaction has committed and we recieve write for next one
             // before PQ has deleted supportive partition for previous transaction
             PQ_LOG_D("GetOwnership request for the next Kafka transaction while previous is being deleted. Saving it till the complete delete of the previous tx.%02");
@@ -3213,6 +3213,16 @@ void TPersQueue::ScheduleDeleteExpiredKafkaTransactions() {
         if (txnExpired(pair.second)) {
             PQ_LOG_D("Transaction for Kafka producer " << pair.first.KafkaProducerInstanceId << " is expired");
             BeginDeletePartitions(pair.second);
+        }
+    }
+}
+
+void TPersQueue::TryContinueKafkaWrites(const TMaybe<TWriteId> writeId, const TActorContext& ctx) {
+    if (writeId.Defined() && writeId->IsKafkaApiTransaction()) {
+        auto it = KafkaNextTransactionRequests.find(writeId->KafkaProducerInstanceId);
+        if (it != KafkaNextTransactionRequests.end()) {
+            Handle(it->second, ctx);
+            KafkaNextTransactionRequests.erase(it);
         }
     }
 }
@@ -4636,13 +4646,7 @@ void TPersQueue::CheckTxState(const TActorContext& ctx,
         // in the status of the PQ tablet (if they came)
         TryReturnTabletStateAll(ctx);
 
-        if (tx.WriteId->KafkaApiTransaction) {
-            auto it = KafkaNextTransactionRequests.find(tx.WriteId->KafkaProducerInstanceId);
-            if (it != KafkaNextTransactionRequests.end()) {
-                Handle(it->second, ctx);
-                KafkaNextTransactionRequests.erase(it);
-            }
-        }
+        TryContinueKafkaWrites(tx.WriteId, ctx);
         break;
     }
 }

--- a/ydb/core/persqueue/pq_impl.cpp
+++ b/ydb/core/persqueue/pq_impl.cpp
@@ -2584,8 +2584,8 @@ const TPartitionInfo& TPersQueue::GetPartitionInfo(const NKikimrClient::TPersQue
     ui32 originalPartitionId = req.GetPartition();
 
     Y_ABORT_UNLESS(TxWrites.contains(writeId) && TxWrites.at(writeId).Partitions.contains(originalPartitionId),
-                   "PQ %" PRIu64 ", WriteId {%" PRIu64 ", %" PRIu64 "}, Partition %" PRIu32,
-                   TabletID(), writeId.NodeId, writeId.KeyId, originalPartitionId);
+                   "PQ %" PRIu64 ", WriteId %s, Partition %" PRIu32,
+                   TabletID(), writeId.ToString().data(), originalPartitionId);
 
     const TPartitionId& partitionId = TxWrites.at(writeId).Partitions.at(originalPartitionId);
     Y_ABORT_UNLESS(Partitions.contains(partitionId));
@@ -2674,7 +2674,13 @@ void TPersQueue::HandleEventForSupportivePartition(const ui64 responseCookie,
     const TWriteId writeId = GetWriteId(req);
     ui32 originalPartitionId = req.GetPartition();
 
-    if (TxWrites.contains(writeId) && TxWrites.at(writeId).Partitions.contains(originalPartitionId)) {
+    if (writeId.KafkaApiTransaction && TxWrites.contains(writeId) && !TxWrites.at(writeId).Partitions.contains(originalPartitionId)) {
+        // This branch happens when previous Kafka transaction has committed and we recieve write for next one
+        // after PQ has deleted supportive partition and before it has deleted writeId from TxWrites (tx has not transaitioned to DELETED state) 
+        PQ_LOG_D("GetOwnership request for the next Kafka transaction while previous is being deleted. Saving it till the complete delete of the previous tx.%01");
+        KafkaNextTransactionRequests[writeId.KafkaProducerInstanceId] = event;
+        return;
+    } else if (TxWrites.contains(writeId) && TxWrites.at(writeId).Partitions.contains(originalPartitionId)) {
         //
         // - вспомогательная партиция уже существует
         // - если партиция инициализирована, то
@@ -2683,11 +2689,17 @@ void TPersQueue::HandleEventForSupportivePartition(const ui64 responseCookie,
         // -     добавить сообщение в очередь для партиции
         //
         const TTxWriteInfo& writeInfo = TxWrites.at(writeId);
-        if (writeInfo.TxId.Defined()) {
+        if (writeInfo.TxId.Defined() && writeId.IsTopicApiTransaction()) {
             ReplyError(ctx,
                        responseCookie,
                        NPersQueue::NErrorCode::BAD_REQUEST,
                        "it is forbidden to write after a commit");
+            return;
+        } else if (writeInfo.TxId.Defined() && writeId.KafkaApiTransaction) {
+            // This branch happens when previous Kafka transaction has committed and we recieve write for next one
+            // before PQ has deleted supportive partition for previous transaction
+            PQ_LOG_D("GetOwnership request for the next Kafka transaction while previous is being deleted. Saving it till the complete delete of the previous tx.%02");
+            KafkaNextTransactionRequests[writeId.KafkaProducerInstanceId] = event;
             return;
         }
 
@@ -3199,6 +3211,7 @@ void TPersQueue::ScheduleDeleteExpiredKafkaTransactions() {
 
     for (auto& pair : TxWrites) {
         if (txnExpired(pair.second)) {
+            PQ_LOG_D("Transaction for Kafka producer " << pair.first.KafkaProducerInstanceId << " is expired");
             BeginDeletePartitions(pair.second);
         }
     }
@@ -4622,6 +4635,14 @@ void TPersQueue::CheckTxState(const TActorContext& ctx,
         // If this was the last transaction, then you need to send responses to messages about changes
         // in the status of the PQ tablet (if they came)
         TryReturnTabletStateAll(ctx);
+
+        if (tx.WriteId->KafkaApiTransaction) {
+            auto it = KafkaNextTransactionRequests.find(tx.WriteId->KafkaProducerInstanceId);
+            if (it != KafkaNextTransactionRequests.end()) {
+                Handle(it->second, ctx);
+                KafkaNextTransactionRequests.erase(it);
+            }
+        }
         break;
     }
 }
@@ -5196,6 +5217,7 @@ void TPersQueue::DeletePartition(const TPartitionId& partitionId, const TActorCo
     const TPartitionInfo& partition = p->second;
     ctx.Send(partition.Actor, new TEvents::TEvPoisonPill());
 
+    PQ_LOG_D("DeletePartition " << partitionId);
     Partitions.erase(partitionId);
 }
 
@@ -5229,7 +5251,7 @@ void TPersQueue::Handle(TEvPQ::TEvDeletePartitionDone::TPtr& ev, const TActorCon
                     TryExecuteTxs(ctx, *tx);
                 }
             }
-        } else if (writeInfo.KafkaTransaction) {
+        } else if (writeInfo.KafkaTransaction) { // case when kafka transaction haven't even started in KQP, but data for it was already written in partition
             DeleteWriteId(writeId);
         }
     }

--- a/ydb/core/persqueue/pq_impl.h
+++ b/ydb/core/persqueue/pq_impl.h
@@ -292,6 +292,15 @@ private:
     TMaybe<NKikimrPQ::TPQTabletConfig> TabletConfigTx;
     TMaybe<NKikimrPQ::TBootstrapConfig> BootstrapConfigTx;
     TMaybe<NKikimrPQ::TPartitions> PartitionsDataConfigTx;
+    /**
+    Requests are placed in this queue when there is a GetOwnership request with writeId that is being deleted.
+    In kafka transactions (kafka api prior to 4.0.0 version) all transactional writes in same session will have
+    same producerId+producerEpoch pairs. Thus we can't distinguish write to one transaction from the write to the next one.
+    
+    But we know for sure that all writes coming after the commit of the kafka transaction refer to the next transaction. 
+    That's why we queue them here till previous transaction is completely deleted (all supportive partitions are deleted and writeId is erased from TxWrites).
+     */
+    THashMap<NKafka::TProducerInstanceId, TEvPersQueue::TEvRequest::TPtr, NKafka::TProducerInstanceIdHashFn> KafkaNextTransactionRequests = {};
 
     // PLANNED -> CALCULATING -> CALCULATED -> WAIT_RS -> EXECUTING -> EXECUTED
     THashMap<TDistributedTransaction::EState, TDeque<ui64>> TxsOrder;

--- a/ydb/core/persqueue/pq_impl.h
+++ b/ydb/core/persqueue/pq_impl.h
@@ -300,7 +300,7 @@ private:
     But we know for sure that all writes coming after the commit of the kafka transaction refer to the next transaction. 
     That's why we queue them here till previous transaction is completely deleted (all supportive partitions are deleted and writeId is erased from TxWrites).
      */
-    THashMap<NKafka::TProducerInstanceId, TEvPersQueue::TEvRequest::TPtr, NKafka::TProducerInstanceIdHashFn> KafkaNextTransactionRequests = {};
+    THashMap<NKafka::TProducerInstanceId, TEvPersQueue::TEvRequest::TPtr, NKafka::TProducerInstanceIdHashFn> KafkaNextTransactionRequests;
 
     // PLANNED -> CALCULATING -> CALCULATED -> WAIT_RS -> EXECUTING -> EXECUTED
     THashMap<TDistributedTransaction::EState, TDeque<ui64>> TxsOrder;
@@ -466,6 +466,7 @@ private:
 
     void DeleteExpiredTransactions(const TActorContext& ctx);
     void ScheduleDeleteExpiredKafkaTransactions();
+    void TryContinueKafkaWrites(const TMaybe<TWriteId> writeId, const TActorContext& ctx);
     void Handle(TEvPersQueue::TEvCancelTransactionProposal::TPtr& ev, const TActorContext& ctx);
 
     void SetTxCounters();

--- a/ydb/core/persqueue/ut/pqtablet_ut.cpp
+++ b/ydb/core/persqueue/ut/pqtablet_ut.cpp
@@ -35,6 +35,7 @@ struct TTxOperation {
     TMaybe<ui64> End;
     TString Path;
     TMaybe<ui32> SupportivePartition;
+    bool KafkaTransaction = false;
 };
 
 struct TConfigParams {
@@ -259,6 +260,7 @@ protected:
     // returns owner cookie for this supportive partition
     TString CreateSupportivePartitionForKafka(const NKafka::TProducerInstanceId& producerInstanceId);
     void SendKafkaTxnWriteRequest(const NKafka::TProducerInstanceId& producerInstanceId, const TString& ownerCookie);
+    void CommitKafkaTransaction(NKafka::TProducerInstanceId producerInstanceId, ui64 txId);
 
     std::unique_ptr<TEvPersQueue::TEvRequest> MakeGetOwnershipRequest(const TGetOwnershipRequestParams& params,
                                                                       const TActorId& pipe) const;
@@ -383,6 +385,9 @@ void TPQTabletFixture::SendProposeTransactionRequest(const TProposeTransactionPa
             operation->SetPath(txOp.Path);
             if (txOp.SupportivePartition.Defined()) {
                 operation->SetSupportivePartition(*txOp.SupportivePartition);
+            }
+            if (txOp.KafkaTransaction) {
+                operation->SetKafkaTransaction(true);
             }
 
             partitions.insert(txOp.Partition);
@@ -828,6 +833,23 @@ void TPQTabletFixture::SendKafkaTxnWriteRequest(const NKafka::TProducerInstanceI
     UNIT_ASSERT(response != nullptr);
     UNIT_ASSERT(response->Record.GetPartitionResponse().HasCookie());
     UNIT_ASSERT_VALUES_EQUAL(123, response->Record.GetPartitionResponse().GetCookie());
+}
+
+void TPQTabletFixture::CommitKafkaTransaction(NKafka::TProducerInstanceId producerInstanceId, ui64 txId) {
+    SendProposeTransactionRequest({.TxId=txId,
+                                  .Senders={Ctx->TabletId}, .Receivers={Ctx->TabletId},
+                                  .TxOps={
+                                    {.Partition=0, .Path="/topic", .KafkaTransaction=true},
+                                  },
+                                  .WriteId=TWriteId(producerInstanceId)
+                                  });
+    WaitProposeTransactionResponse({.TxId=txId,
+                                   .Status=NKikimrPQ::TEvProposeTransactionResult::PREPARED});
+    SendPlanStep({.Step=100, .TxIds={txId}});
+    WaitPlanStepAck({.Step=100, .TxIds={txId}}); // TEvPlanStepAck для координатора
+    WaitPlanStepAccepted({.Step=100});
+    WaitProposeTransactionResponse({.TxId=txId,
+                                   .Status=NKikimrPQ::TEvProposeTransactionResult::COMPLETE});
 }
 
 void TPQTabletFixture::WaitWriteResponse(const TWriteResponseMatcher& matcher)
@@ -2397,9 +2419,7 @@ Y_UNIT_TEST_F(Kafka_Transaction_Supportive_Partitions_Should_Be_Deleted_After_Ti
 
     // wait till supportive partition for this kafka transaction is deleted
     WaitForExactSupportivePartitionsCount(0);
-    // validate that TxWrite for this transaction is deleted
-    auto txInfo2 = GetTxWritesFromKV();
-    UNIT_ASSERT_VALUES_EQUAL(txInfo2.TxWritesSize(), 0);
+    WaitForExactTxWritesCount(0);
 }
 
 Y_UNIT_TEST_F(Non_Kafka_Transaction_Supportive_Partitions_Should_Not_Be_Deleted_After_Timeout, TPQTabletFixture)
@@ -2469,6 +2489,126 @@ Y_UNIT_TEST_F(In_Kafka_Txn_Only_Supportive_Partitions_That_Exceeded_Timeout_Shou
     auto txInfo = GetTxWritesFromKV();
     UNIT_ASSERT_EQUAL(txInfo.TxWritesSize(), 1);
     UNIT_ASSERT_VALUES_EQUAL(txInfo.GetTxWrites(0).GetWriteId().GetKafkaProducerInstanceId().GetId(), producerInstanceId2.Id);
+}
+
+Y_UNIT_TEST_F(Kafka_Transaction_Incoming_Before_Previous_TEvDeletePartitionDone_Came_Should_Be_Processed_After_Previous_Complete_Erasure, TPQTabletFixture) {
+    NKafka::TProducerInstanceId producerInstanceId = {1, 0};
+    const ui64 txId = 67890;
+    PQTabletPrepare({.partitions=1}, {}, *Ctx);
+    EnsurePipeExist();
+    TString ownerCookie = CreateSupportivePartitionForKafka(producerInstanceId);
+
+    // send data to create blobs for supportive partitions
+    SendKafkaTxnWriteRequest(producerInstanceId, ownerCookie);
+    ui32 fisrtSupportivePartitionId = WaitForExactTxWritesCount(1).GetTxWrites(0).GetInternalPartitionId();
+    
+    TAutoPtr<IEventHandle> deleteDoneEvent;
+    bool seenEvent = false;
+    // add observer for TEvPQ::TEvDeletePartitionDone request and skip it
+    auto observer = [&](TAutoPtr<IEventHandle>& input) {
+        if (!seenEvent && input->CastAsLocal<TEvPQ::TEvDeletePartitionDone>()) {
+            Cout << "Dropping TEvPQ::TEvDeletePartitionDone" << Endl;
+            deleteDoneEvent = input;
+            seenEvent = true;
+            return TTestActorRuntimeBase::EEventAction::DROP;
+        }
+        
+        return TTestActorRuntimeBase::EEventAction::PROCESS;
+    };
+    Ctx->Runtime->SetObserverFunc(observer);
+
+    CommitKafkaTransaction(producerInstanceId, txId);
+
+    // wait for delete response and save it
+    TDispatchOptions options;
+    options.CustomFinalCondition = [&seenEvent]() {
+        return seenEvent;
+    };
+    UNIT_ASSERT(Ctx->Runtime->DispatchEvents(options));
+
+    // send another GetOwnership request to enforce new suportive partition creation (it imitates new transaction start for same proudcer epoch)
+    auto request = MakeGetOwnershipRequest({.Partition=0,
+                     .WriteId=TWriteId{producerInstanceId},
+                     .NeedSupportivePartition=true,
+                     .Owner=DEFAULT_OWNER,
+                     .Cookie=5}, Pipe);
+    Ctx->Runtime->SendToPipe(Pipe,
+                             Ctx->Edge,
+                             request.release(),
+                             0, 0);
+
+    // send TEvPQ::TEvDeletePartitionDone 
+    Ctx->Runtime->SendToPipe(Pipe,
+                             Ctx->Edge,
+                             deleteDoneEvent.Release()->Get<TEvPQ::TEvDeletePartitionDone>(),
+                             0, 0);
+    
+    WaitForTheTransactionToBeDeleted(txId);
+    auto txInfo = GetTxWritesFromKV();
+    UNIT_ASSERT_EQUAL(txInfo.TxWritesSize(), 1);
+    UNIT_ASSERT_VALUES_EQUAL(txInfo.GetTxWrites(0).GetWriteId().GetKafkaProducerInstanceId().GetId(), producerInstanceId.Id);
+    UNIT_ASSERT_VALUES_UNEQUAL(txInfo.GetTxWrites(0).GetInternalPartitionId(), fisrtSupportivePartitionId);
+    TString ownerCookie2 = WaitGetOwnershipResponse({.Cookie=5, .Status=NMsgBusProxy::MSTATUS_OK});
+    UNIT_ASSERT_VALUES_UNEQUAL(ownerCookie2, ownerCookie);
+}
+
+Y_UNIT_TEST_F(Kafka_Transaction_Incoming_Before_Previous_Is_In_DELETED_State_Should_Be_Processed_After_Previous_Complete_Erasure, TPQTabletFixture) {
+    NKafka::TProducerInstanceId producerInstanceId = {1, 0};
+    const ui64 txId = 67890;
+    PQTabletPrepare({.partitions=1}, {}, *Ctx);
+    EnsurePipeExist();
+    TString ownerCookie = CreateSupportivePartitionForKafka(producerInstanceId);
+
+    // send data to create blobs for supportive partitions
+    SendKafkaTxnWriteRequest(producerInstanceId, ownerCookie);
+    WaitForExactTxWritesCount(1);
+    
+    TAutoPtr<IEventHandle> keyValueResponse;
+    bool seenDeletePartitionsDoneEvent = false;
+    bool seenKeyValResponse = false;
+    // add observer for TEvPQ::TEvDeletePartitionDone request and skip it
+    auto observer = [&](TAutoPtr<IEventHandle>& input) {
+        if (!seenDeletePartitionsDoneEvent && input->CastAsLocal<TEvPQ::TEvDeletePartitionDone>()) {
+            seenDeletePartitionsDoneEvent = true;
+        } else if (seenDeletePartitionsDoneEvent && !seenKeyValResponse && input->CastAsLocal<TEvKeyValue::TEvResponse>()) {
+            // next TEvKeyValue::TEvResponse after TEvPQ::TEvDeletePartitionDone contains info about successull deletion of writeInfo from KV
+            keyValueResponse = input;
+            seenKeyValResponse = true;
+            return TTestActorRuntimeBase::EEventAction::DROP;
+        }
+        
+        return TTestActorRuntimeBase::EEventAction::PROCESS;
+    };
+    Ctx->Runtime->SetObserverFunc(observer);
+
+    CommitKafkaTransaction(producerInstanceId, txId);
+
+    // wait for delete response and save it
+    TDispatchOptions options;
+    options.CustomFinalCondition = [&seenKeyValResponse]() {
+        return seenKeyValResponse;
+    };
+    UNIT_ASSERT(Ctx->Runtime->DispatchEvents(options));
+
+    // send another GetOwnership request to enforce new suportive partition creation (it imitates new transaction start for same proudcer epoch)
+    auto request = MakeGetOwnershipRequest({.Partition=0,
+                     .WriteId=TWriteId{producerInstanceId},
+                     .NeedSupportivePartition=true,
+                     .Owner=DEFAULT_OWNER,
+                     .Cookie=5}, Pipe);
+    Ctx->Runtime->SendToPipe(Pipe,
+                             Ctx->Edge,
+                             request.release(),
+                             0, 0);
+
+    // send TEvKeyValue::TEvResponse 
+    Ctx->Runtime->SendToPipe(Pipe,
+                             Ctx->Edge,
+                             keyValueResponse.Release()->Get<TEvKeyValue::TEvResponse>(),
+                             0, 0);
+    
+    TString ownerCookie2 = WaitGetOwnershipResponse({.Cookie=5, .Status=NMsgBusProxy::MSTATUS_OK});
+    UNIT_ASSERT_VALUES_UNEQUAL(ownerCookie2, ownerCookie);
 }
 
 void TPQTabletFixture::TestSendingTEvReadSetViaApp(const TSendReadSetViaAppTestParams& params)

--- a/ydb/core/persqueue/ut/pqtablet_ut.cpp
+++ b/ydb/core/persqueue/ut/pqtablet_ut.cpp
@@ -288,6 +288,9 @@ protected:
     void WaitForAppSendRsResponse(const TAppSendReadSetMatcher& matcher);
     void TestSendingTEvReadSetViaApp(const TSendReadSetViaAppTestParams& params);
 
+    template<class EventType>
+    void AddOneTimeEventObserver(bool& seenEvent, std::function<TTestActorRuntimeBase::EEventAction(TAutoPtr<IEventHandle>&)> callback = [](){return TTestActorRuntimeBase::EEventAction::PROCESS;});
+
     //
     // TODO(abcdef): для тестирования повторных вызовов нужны примитивы Send+Wait
     //
@@ -1362,6 +1365,19 @@ void TPQTabletFixture::WaitForAppSendRsResponse(const TAppSendReadSetMatcher& ma
         const bool resultOk = value["result"].GetStringSafe() == "OK"sv;
         UNIT_ASSERT_VALUES_EQUAL(resultOk, *matcher.Status);
     }
+}
+
+template<class EventType>
+void TPQTabletFixture::AddOneTimeEventObserver(bool& seenEvent, std::function<TTestActorRuntimeBase::EEventAction(TAutoPtr<IEventHandle>&)> callback) {
+    auto observer = [&](TAutoPtr<IEventHandle>& input) {
+        if (!seenEvent && input->CastAsLocal<EventType>()) {
+            seenEvent = true;
+            return callback(input);
+        }
+        
+        return TTestActorRuntimeBase::EEventAction::PROCESS;
+    };
+    Ctx->Runtime->SetObserverFunc(observer);
 }
 
 Y_UNIT_TEST_F(Parallel_Transactions_1, TPQTabletFixture)
@@ -2505,45 +2521,31 @@ Y_UNIT_TEST_F(Kafka_Transaction_Incoming_Before_Previous_TEvDeletePartitionDone_
     TAutoPtr<IEventHandle> deleteDoneEvent;
     bool seenEvent = false;
     // add observer for TEvPQ::TEvDeletePartitionDone request and skip it
-    auto observer = [&](TAutoPtr<IEventHandle>& input) {
-        if (!seenEvent && input->CastAsLocal<TEvPQ::TEvDeletePartitionDone>()) {
-            Cout << "Dropping TEvPQ::TEvDeletePartitionDone" << Endl;
-            deleteDoneEvent = input;
-            seenEvent = true;
-            return TTestActorRuntimeBase::EEventAction::DROP;
-        }
-        
-        return TTestActorRuntimeBase::EEventAction::PROCESS;
-    };
-    Ctx->Runtime->SetObserverFunc(observer);
+    AddOneTimeEventObserver<TEvPQ::TEvDeletePartitionDone>(seenEvent, [&deleteDoneEvent](TAutoPtr<IEventHandle>& eventHandle) {
+        deleteDoneEvent = eventHandle;
+        return TTestActorRuntimeBase::EEventAction::DROP;
+    });
 
     CommitKafkaTransaction(producerInstanceId, txId);
 
     // wait for delete response and save it
     TDispatchOptions options;
-    options.CustomFinalCondition = [&seenEvent]() {
-        return seenEvent;
-    };
+    options.CustomFinalCondition = [&seenEvent]() {return seenEvent;};
     UNIT_ASSERT(Ctx->Runtime->DispatchEvents(options));
 
     // send another GetOwnership request to enforce new suportive partition creation (it imitates new transaction start for same proudcer epoch)
-    auto request = MakeGetOwnershipRequest({.Partition=0,
+    SendGetOwnershipRequest({.Partition=0,
                      .WriteId=TWriteId{producerInstanceId},
                      .NeedSupportivePartition=true,
                      .Owner=DEFAULT_OWNER,
-                     .Cookie=5}, Pipe);
-    Ctx->Runtime->SendToPipe(Pipe,
-                             Ctx->Edge,
-                             request.release(),
-                             0, 0);
-
-    // send TEvPQ::TEvDeletePartitionDone 
+                     .Cookie=5});
+    // now we can eventually send TEvPQ::TEvDeletePartitionDone 
     Ctx->Runtime->SendToPipe(Pipe,
                              Ctx->Edge,
                              deleteDoneEvent.Release()->Get<TEvPQ::TEvDeletePartitionDone>(),
                              0, 0);
-    
     WaitForTheTransactionToBeDeleted(txId);
+
     auto txInfo = GetTxWritesFromKV();
     UNIT_ASSERT_EQUAL(txInfo.TxWritesSize(), 1);
     UNIT_ASSERT_VALUES_EQUAL(txInfo.GetTxWrites(0).GetWriteId().GetKafkaProducerInstanceId().GetId(), producerInstanceId.Id);
@@ -2585,28 +2587,23 @@ Y_UNIT_TEST_F(Kafka_Transaction_Incoming_Before_Previous_Is_In_DELETED_State_Sho
 
     // wait for delete response and save it
     TDispatchOptions options;
-    options.CustomFinalCondition = [&seenKeyValResponse]() {
-        return seenKeyValResponse;
-    };
+    options.CustomFinalCondition = [&seenKeyValResponse]() {return seenKeyValResponse;};
     UNIT_ASSERT(Ctx->Runtime->DispatchEvents(options));
 
     // send another GetOwnership request to enforce new suportive partition creation (it imitates new transaction start for same proudcer epoch)
-    auto request = MakeGetOwnershipRequest({.Partition=0,
+    SendGetOwnershipRequest({.Partition=0,
                      .WriteId=TWriteId{producerInstanceId},
                      .NeedSupportivePartition=true,
                      .Owner=DEFAULT_OWNER,
-                     .Cookie=5}, Pipe);
-    Ctx->Runtime->SendToPipe(Pipe,
-                             Ctx->Edge,
-                             request.release(),
-                             0, 0);
+                     .Cookie=5});
 
-    // send TEvKeyValue::TEvResponse 
+    // eventually send TEvKeyValue::TEvResponse 
     Ctx->Runtime->SendToPipe(Pipe,
                              Ctx->Edge,
                              keyValueResponse.Release()->Get<TEvKeyValue::TEvResponse>(),
                              0, 0);
     
+    // wait for a deferred response for last GetOwnership request we sent
     TString ownerCookie2 = WaitGetOwnershipResponse({.Cookie=5, .Status=NMsgBusProxy::MSTATUS_OK});
     UNIT_ASSERT_VALUES_UNEQUAL(ownerCookie2, ownerCookie);
 }

--- a/ydb/core/persqueue/write_id.cpp
+++ b/ydb/core/persqueue/write_id.cpp
@@ -34,6 +34,12 @@ void TWriteId::ToStream(IOutputStream& s) const
     }
 }
 
+TString TWriteId::ToString() const {
+    TStringStream ss;
+    ToStream(ss);
+    return ss.Str();
+}
+
 template <class T>
 TWriteId GetWriteIdImpl(const T& m)
 {

--- a/ydb/core/persqueue/write_id.h
+++ b/ydb/core/persqueue/write_id.h
@@ -29,6 +29,7 @@ struct TWriteId {
     bool operator<(const TWriteId& rhs) const;
 
     void ToStream(IOutputStream& s) const;
+    TString ToString() const;
 
     size_t GetHash() const
     {
@@ -46,7 +47,7 @@ struct TWriteId {
     // these fields are used to identify topic api transaction
     ui64 NodeId = 0;
     ui64 KeyId = 0;
-    // Iidentifies kafka api transaction
+    // Identifies kafka api transaction
     NKafka::TProducerInstanceId KafkaProducerInstanceId;
 };
 

--- a/ydb/core/persqueue/write_id.h
+++ b/ydb/core/persqueue/write_id.h
@@ -43,6 +43,11 @@ struct TWriteId {
         return !KafkaApiTransaction;
     }
 
+    bool IsKafkaApiTransaction() const 
+    {
+        return KafkaApiTransaction;
+    }
+
     bool KafkaApiTransaction = false;
     // these fields are used to identify topic api transaction
     ui64 NodeId = 0;


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

This PR fixes:
- bug with hanging produce request when using transactions
- VERIFY on a write request to a new kafka transaction when previous has not yet deleted
- invalid memory access on write expired in kafka_produce_actor.

### Changelog category <!-- remove all except one -->

* Not for changelog (changelog entry is not required)

### Description for reviewers <!-- (optional) description for those who read this PR -->

...
