### PR TITLE
Use unique_ptr to allocate TInterconnectListenerTCP in kikimr_services_initializers.cpp to aviod memory leak on Bind() failure

### DIFF
--- a/ydb/core/driver_lib/run/kikimr_services_initializers.cpp
+++ b/ydb/core/driver_lib/run/kikimr_services_initializers.cpp
@@ -782,14 +782,14 @@ void TBasicServicesInitializer::InitializeServices(NActors::TActorSystemSetup* s
                     TString address;
                     if (node.second.first)
                         address = node.second.first;
-                    auto listener = new TInterconnectListenerTCP(
+                    auto listener = std::make_unique<TInterconnectListenerTCP>(
                         address, node.second.second, icCommon);
                     if (int err = listener->Bind()) {
                         ythrow yexception()
                             << "Failed to set up IC listener on port " << node.second.second
                             << " errno# " << err << " (" << strerror(err) << ")";
                     }
-                    setup->LocalServices.emplace_back(MakeInterconnectListenerActorId(false), TActorSetupCmd(listener,
+                    setup->LocalServices.emplace_back(MakeInterconnectListenerActorId(false), TActorSetupCmd(listener.release(),
                         TMailboxType::ReadAsFilled, interconnectPoolId));
                 }
             }
@@ -803,13 +803,13 @@ void TBasicServicesInitializer::InitializeServices(NActors::TActorSystemSetup* s
                 if (info.GetAddress()) {
                     address = info.GetAddress();
                 }
-                auto listener = new TInterconnectListenerTCP(address, info.GetPort(), icCommon);
+                auto listener = std::make_unique<TInterconnectListenerTCP>(address, info.GetPort(), icCommon);
                 if (int err = listener->Bind()) {
                     ythrow yexception()
                         << "Failed to set up IC listener on port " << info.GetPort()
                         << " errno# " << err << " (" << strerror(err) << ")";
                 }
-                setup->LocalServices.emplace_back(MakeInterconnectListenerActorId(true), TActorSetupCmd(listener,
+                setup->LocalServices.emplace_back(MakeInterconnectListenerActorId(true), TActorSetupCmd(listener.release(),
                     TMailboxType::ReadAsFilled, interconnectPoolId));
             }
 
@@ -819,13 +819,13 @@ void TBasicServicesInitializer::InitializeServices(NActors::TActorSystemSetup* s
                     if (nodesManagerConfig.GetEnabled()) {
                         TFederatedQueryInitializer::SetIcPort(nodesManagerConfig.GetPort());
                         icCommon->TechnicalSelfHostName = nodesManagerConfig.GetHost();
-                        auto listener = new TInterconnectListenerTCP({}, nodesManagerConfig.GetPort(), icCommon);
+                        auto listener = std::make_unique<TInterconnectListenerTCP>({}, nodesManagerConfig.GetPort(), icCommon);
                         if (int err = listener->Bind()) {
                             ythrow yexception()
                                 << "Failed to set up IC listener on port " << nodesManagerConfig.GetPort()
                                 << " errno# " << err << " (" << strerror(err) << ")";
                         }
-                        setup->LocalServices.emplace_back(MakeInterconnectListenerActorId(true), TActorSetupCmd(listener,
+                        setup->LocalServices.emplace_back(MakeInterconnectListenerActorId(true), TActorSetupCmd(listener.release(),
                             TMailboxType::ReadAsFilled, interconnectPoolId));
                     }
                 }

--- a/ydb/core/driver_lib/run/kikimr_services_initializers.cpp
+++ b/ydb/core/driver_lib/run/kikimr_services_initializers.cpp
@@ -819,7 +819,7 @@ void TBasicServicesInitializer::InitializeServices(NActors::TActorSystemSetup* s
                     if (nodesManagerConfig.GetEnabled()) {
                         TFederatedQueryInitializer::SetIcPort(nodesManagerConfig.GetPort());
                         icCommon->TechnicalSelfHostName = nodesManagerConfig.GetHost();
-                        auto listener = std::make_unique<TInterconnectListenerTCP>({}, nodesManagerConfig.GetPort(), icCommon);
+                        auto listener = std::make_unique<TInterconnectListenerTCP>("", nodesManagerConfig.GetPort(), icCommon);
                         if (int err = listener->Bind()) {
                             ythrow yexception()
                                 << "Failed to set up IC listener on port " << nodesManagerConfig.GetPort()


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

Use unique_ptr to allocate TInterconnectListenerTCP in kikimr_services_initializers.cpp to aviod memory leak on Bind() failure

### Changelog category <!-- remove all except one -->

* Not for changelog (changelog entry is not required)

### Description for reviewers <!-- (optional) description for those who read this PR -->

Fixes asan error observed here: https://github.com/ydb-platform/nbs/actions/runs/16562298902

```
#0 0x15510bbd in operator new(unsigned long) /actions-runner/_work/nbs/nbs/contrib/libs/clang16-rt/lib/asan/asan_new_delete.cpp:95:3
#1 0x39cf1d97 in NKikimr::NKikimrServicesInitializers::TBasicServicesInitializer::InitializeServices(NActors::TActorSystemSetup*, NKikimr::TAppData const*) /actions-runner/_work/nbs/nbs/contrib/ydb/core/driver_lib/run/kikimr_services_initializers.cpp:804:33
#2 0x39c27d42 in NKikimr::TServiceInitializersList::InitializeServices(NActors::TActorSystemSetup*, NKikimr::TAppData const*) /actions-runner/_work/nbs/nbs/contrib/ydb/core/driver_lib/run/service_initializer.cpp:13:29
#3 0x341ee243 in NKikimr::TKikimrRunner::InitializeActorSystem(NKikimr::TKikimrRunConfig const&, TIntrusivePtr<NKikimr::TServiceInitializersList, TDefaultIntrusivePtrOps<NKikimr::TServiceInitializersList>>, NKikimr::TBasicKikimrServicesMask const&) /actions-runner/_work/nbs/nbs/contrib/ydb/core/driver_lib/run/run.cpp:1232:26
#4 0x341bafbe in NCloud::NFileStore::NStorage::(anonymous namespace)::TActorSystem::Init /actions-runner/_work/nbs/nbs/cloud/filestore/libs/storage/init/actorsystem.cpp:393:5
#5 0x341bafbe in NCloud::NFileStore::NStorage::CreateActorSystem(NCloud::NFileStore::NStorage::TActorSystemArgs const&) /actions-runner/_work/nbs/nbs/cloud/filestore/libs/storage/init/actorsystem.cpp:495:18
#6 0x33de497f in NCloud::NFileStore::NDaemon::TBootstrapCommon::InitActorSystem() /actions-runner/_work/nbs/nbs/cloud/filestore/libs/daemon/common/bootstrap.cpp:302:19
#7 0x33de07b0 in NCloud::NFileStore::NDaemon::TBootstrapCommon::Init() /actions-runner/_work/nbs/nbs/cloud/filestore/libs/daemon/common/bootstrap.cpp:181:9
#8 0x15448d37 in int NCloud::DoMain<NCloud::NFileStore::NDaemon::TBootstrapServer>(NCloud::NFileStore::NDaemon::TBootstrapServer&, int, char**) /actions-runner/_work/nbs/nbs/cloud/storage/core/libs/daemon/app.h:36:23
#9 0x15448948 in main /actions-runner/_work/nbs/nbs/cloud/filestore/apps/server/main.cpp:17:12
#10 0x7ff42ce0bd8f  (/lib/x86_64-linux-gnu/libc.so.6+0x29d8f) (BuildId: d5197096f709801829b118af1b7cf6631efa2dcd)
```