### PR TITLE
fq/run_actor: fix remaining normal events in finishing state

### DIFF
--- a/ydb/core/fq/libs/actors/run_actor.cpp
+++ b/ydb/core/fq/libs/actors/run_actor.cpp
@@ -447,9 +447,11 @@ private:
         hFunc(NMon::TEvHttpInfo, Handle);
 
         // Ignore tail of action events after normal work.
+        IgnoreFunc(TEvPrivate::TEvProgramFinished);
         IgnoreFunc(TEvents::TEvAsyncContinue);
         IgnoreFunc(NActors::TEvents::TEvUndelivered);
         IgnoreFunc(TEvents::TEvGraphParams);
+        IgnoreFunc(NActors::TEvents::TEvWakeup);
         IgnoreFunc(TEvents::TEvQueryActionResult);
         IgnoreFunc(TEvCheckpointCoordinator::TEvZeroCheckpointDone);
         IgnoreFunc(TEvCheckpointCoordinator::TEvRaiseTransientIssues);


### PR DESCRIPTION
```
E   ydb/core/fq/libs/actors/run_actor.cpp:456
E   FinishStateFunc(): requirement false failed
E   0. /-S/util/system/yassert.cpp:83: InternalPanicImpl @ 0xA3AA835
E   1. /-S/util/system/yassert.cpp:55: Panic @ 0xA3A3076
E   2. /tmp//-S/ydb/core/fq/libs/actors/run_actor.cpp:438: FinishStateFunc @ 0x1B8AC88D
E   3. /tmp//-S/ydb/core/fq/libs/actors/run_actor.cpp:415: ?? @ 0x1B8ABAED
E   4. /tmp//-S/ydb/library/actors/core/actor.cpp:280: Receive @ 0xB0CB8D4
E   5. /-S/ydb/library/actors/core/actor.h:810: State @ 0x1B830D90
E   6. /tmp//-S/ydb/library/actors/core/actor.cpp:280: Receive @ 0xB0CB8D4
E   7. /tmp//-S/ydb/library/actors/core/executor_thread.cpp:269: Execute @ 0xB10396B
E   8. /tmp//-S/ydb/library/actors/core/executor_thread.cpp:460: operator() @ 0xB107642
E   9. /tmp//-S/ydb/library/actors/core/executor_thread.cpp:512: ProcessExecutorPool @ 0xB107210
E   10. /tmp//-S/ydb/library/actors/core/executor_thread.cpp:538: ThreadProc @ 0xB107E7A
E   11. /-S/util/system/thread.cpp:244: ThreadProxy @ 0xA3ABC9C
E   12. ??:0: ?? @ 0x7F2AD96E8AC2
E   13. ??:0: ?? @ 0x7F2AD977A84F
```
noticed in [flacky test](https://storage.yandexcloud.net/ydb-gh-logs/ydb-platform/ydb/PR-check/16621600024/ya-x86-64/try_1/artifacts/logs/ydb/tests/fq/http_api/test-results/py3test/testing_out_stuff/test_http_api.py.TestHttpApi.test_openapi_spec.log)

### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

...

### Changelog category <!-- remove all except one -->

* Not for changelog (changelog entry is not required)

### Description for reviewers <!-- (optional) description for those who read this PR -->

...
