### PR TITLE
DeserializeSchema has been moved to conveyor insrt

### DIFF
--- a/ydb/core/tx/columnshard/operations/write_data.h
+++ b/ydb/core/tx/columnshard/operations/write_data.h
@@ -30,7 +30,7 @@ public:
 private:
     NOlap::ISnapshotSchema::TPtr IndexSchema;
     NOlap::ISnapshotSchema::TPtr BatchSchema;
-    std::shared_ptr<arrow::Schema> PayloadSchema;
+    NKikimrDataEvents::TEvWrite::TOperation Operation;
     TString IncomingData;
     NEvWrite::EModificationType ModificationType = NEvWrite::EModificationType::Upsert;
 };


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

Здесь на flame графе видно как много cpu потребляется в этом месте в самом TColumnShardActor, а должно быть в conveyor
![profdata](https://github.com/user-attachments/assets/c3db55d8-3f4c-473f-99b6-ef0ba0816ad5)


### Changelog category <!-- remove all except one -->


* Not for changelog (changelog entry is not required)

### Description for reviewers <!-- (optional) description for those who read this PR -->

...
