### PR TITLE
[NBS] Add an empty field for nbs configs in Console to TAppConfig

### DIFF
--- a/ydb/core/protos/config.proto
+++ b/ydb/core/protos/config.proto
@@ -35,6 +35,7 @@ import "ydb/core/protos/table_service_config.proto";
 import "ydb/core/protos/tablet.proto";
 import "ydb/core/protos/tenant_pool.proto";
 import "ydb/core/protos/tenant_slot_broker.proto";
+import "ydb/core/protos/nbs/blockstore.proto";
 import "ydb/library/actors/protos/interconnect.proto";
 import "yql/essentials/core/file_storage/proto/file_storage.proto";
 import "yql/essentials/providers/common/proto/gateways_config.proto";
@@ -2367,6 +2368,7 @@ message TAppConfig {
     optional TDataErasureConfig DataErasureConfig = 88;
     optional THealthCheckConfig HealthCheckConfig = 89;
     optional TGroupedMemoryLimiterConfig CompGroupedMemoryLimiterConfig = 92;
+    optional TBlockstoreConfig BlockstoreConfig = 93;
 
     repeated TNamedConfig NamedConfigs = 100;
     optional string ClusterYamlConfig = 101;

--- a/ydb/core/protos/nbs/blockstore.proto
+++ b/ydb/core/protos/nbs/blockstore.proto
@@ -1,0 +1,4 @@
+package NKikimrConfig;
+
+// This is a message that is used for config overrides in Console for https://github.com/ydb-platform/nbs, where it's not empty
+message TBlockstoreConfig {}

--- a/ydb/core/protos/nbs/ya.make
+++ b/ydb/core/protos/nbs/ya.make
@@ -1,0 +1,19 @@
+PROTO_LIBRARY()
+
+SET(PROTOC_TRANSITIVE_HEADERS "no")
+
+GRPC()
+
+IF (OS_WINDOWS)
+    NO_OPTIMIZE_PY_PROTOS()
+ENDIF()
+
+SRCS(
+    blockstore.proto
+)
+
+CPP_PROTO_PLUGIN0(config_proto_plugin ydb/core/config/tools/protobuf_plugin)
+
+EXCLUDE_TAGS(GO_PROTO)
+
+END()

--- a/ydb/core/protos/ya.make
+++ b/ydb/core/protos/ya.make
@@ -163,6 +163,7 @@ GENERATE_ENUM_SERIALIZATION(shared_cache.pb.h)
 PEERDIR(
     ydb/core/config/protos
     ydb/core/fq/libs/config/protos
+    ydb/core/protos/nbs
     ydb/core/protos/schemeshard
     ydb/core/scheme/protos
     ydb/core/tx/columnshard/common/protos


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

Add an empty field for nbs configs in Console to TAppConfig

### Changelog category <!-- remove all except one -->

* Not for changelog (changelog entry is not required)

### Description for reviewers <!-- (optional) description for those who read this PR -->

This would allow to place blockstore configs in yaml format