### PR TITLE
Fix config reading sequence

### DIFF
--- a/ydb/core/blobstorage/nodewarden/distconf.cpp
+++ b/ydb/core/blobstorage/nodewarden/distconf.cpp
@@ -64,14 +64,7 @@ namespace NKikimr::NStorage {
 
         // generate initial drive set and query stored configuration
         if (IsSelfStatic) {
-            if (BaseConfig->GetSelfManagementConfig().GetEnabled()) {
-                // read this only if it is possibly enabled
-                EnumerateConfigDrives(*InitialConfig, SelfId().NodeId(), [&](const auto& /*node*/, const auto& drive) {
-                    DrivesToRead.push_back(drive.GetPath());
-                });
-                std::sort(DrivesToRead.begin(), DrivesToRead.end());
-            }
-            ReadConfig();
+            ReadConfig(GetDrivesToRead(true));
         } else {
             StorageConfigLoaded = true;
         }

--- a/ydb/core/blobstorage/nodewarden/distconf.h
+++ b/ydb/core/blobstorage/nodewarden/distconf.h
@@ -212,7 +212,6 @@ namespace NKikimr::NStorage {
 
         // initial config based on config file and stored committed configs
         std::shared_ptr<const NKikimrBlobStorage::TStorageConfig> InitialConfig;
-        std::vector<TString> DrivesToRead;
 
         // proposed storage configuration of the cluster
         std::optional<NKikimrBlobStorage::TStorageConfig> ProposedStorageConfig; // proposed one
@@ -359,11 +358,13 @@ namespace NKikimr::NStorage {
         ////////////////////////////////////////////////////////////////////////////////////////////////////////////////
         // PDisk configuration retrieval and storing
 
-        void ReadConfig(ui64 cookie = 0);
+        void ReadConfig(std::vector<TString> paths, ui64 cookie = 0);
         void WriteConfig(std::vector<TString> drives, NKikimrBlobStorage::TPDiskMetadataRecord record);
         void PersistConfig(TPersistCallback callback);
         void Handle(TEvPrivate::TEvStorageConfigStored::TPtr ev);
         void Handle(TEvPrivate::TEvStorageConfigLoaded::TPtr ev);
+
+        std::vector<TString> GetDrivesToRead(bool initial) const;
 
         static TString CalculateFingerprint(const NKikimrBlobStorage::TStorageConfig& config);
         static void UpdateFingerprint(NKikimrBlobStorage::TStorageConfig *config);

--- a/ydb/core/blobstorage/nodewarden/distconf_fsm.cpp
+++ b/ydb/core/blobstorage/nodewarden/distconf_fsm.cpp
@@ -544,17 +544,7 @@ namespace NKikimr::NStorage {
     void TDistributedConfigKeeper::PrepareScatterTask(ui64 cookie, TScatterTask& task) {
         switch (task.Request.GetRequestCase()) {
             case TEvScatter::kCollectConfigs: {
-                std::vector<TString> drives;
-                auto callback = [&](const auto& /*node*/, const auto& drive) {
-                    drives.push_back(drive.GetPath());
-                };
-                EnumerateConfigDrives(*StorageConfig, SelfId().NodeId(), callback);
-                if (ProposedStorageConfig) {
-                    EnumerateConfigDrives(*ProposedStorageConfig, SelfId().NodeId(), callback);
-                }
-                std::sort(drives.begin(), drives.end());
-                drives.erase(std::unique(drives.begin(), drives.end()), drives.end());
-                ReadConfig(cookie);
+                ReadConfig(GetDrivesToRead(false), cookie);
                 ++task.AsyncOperationsPending;
                 break;
             }

--- a/ydb/core/blobstorage/nodewarden/distconf_persistent_storage.cpp
+++ b/ydb/core/blobstorage/nodewarden/distconf_persistent_storage.cpp
@@ -5,7 +5,7 @@
 
 namespace NKikimr::NStorage {
 
-    void TDistributedConfigKeeper::ReadConfig(ui64 cookie) {
+    void TDistributedConfigKeeper::ReadConfig(std::vector<TString> paths, ui64 cookie) {
         class TReaderActor : public TActorBootstrapped<TReaderActor> {
             const std::vector<TString> Paths;
             const ui64 Cookie;
@@ -80,7 +80,7 @@ namespace NKikimr::NStorage {
                 hFunc(TEvNodeWardenReadMetadataResult, Handle);
             )
         };
-        Register(new TReaderActor(DrivesToRead, cookie));
+        Register(new TReaderActor(std::move(paths), cookie));
     }
 
     void TDistributedConfigKeeper::WriteConfig(std::vector<TString> drives, NKikimrBlobStorage::TPDiskMetadataRecord record) {
@@ -270,12 +270,16 @@ namespace NKikimr::NStorage {
 
                 FinishAsyncOperation(it->first);
             }
-        } else { // just loaded the initial config, try to acquire newer configuration
+        } else {
+            // just loaded the initial config, try to acquire newer configuration
+            bool changes = false;
+
             for (const auto& [path, m, guid] : msg.MetadataPerPath) {
                 if (m.HasCommittedStorageConfig()) {
                     const auto& config = m.GetCommittedStorageConfig();
                     if (InitialConfig->GetGeneration() < config.GetGeneration()) {
                         InitialConfig = std::make_shared<NKikimrBlobStorage::TStorageConfig>(config);
+                        changes = true;
                     } else if (InitialConfig->GetGeneration() && InitialConfig->GetGeneration() == config.GetGeneration() &&
                             InitialConfig->GetFingerprint() != config.GetFingerprint()) {
                         // TODO: error
@@ -287,22 +291,14 @@ namespace NKikimr::NStorage {
                     if (InitialConfig->GetGeneration() < proposed.GetGeneration() && (
                             !ProposedStorageConfig || ProposedStorageConfig->GetGeneration() < proposed.GetGeneration())) {
                         ProposedStorageConfig.emplace(proposed);
+                        changes = true;
                     }
                 }
             }
 
-            // generate new list of drives to acquire
-            std::vector<TString> drivesToRead;
-            if (BaseConfig->GetSelfManagementConfig().GetEnabled()) {
-                EnumerateConfigDrives(*InitialConfig, SelfId().NodeId(), [&](const auto& /*node*/, const auto& drive) {
-                    drivesToRead.push_back(drive.GetPath());
-                });
-                std::sort(drivesToRead.begin(), drivesToRead.end());
-            }
-
-            if (DrivesToRead != drivesToRead) { // re-read configuration as it may cover additional drives
-                DrivesToRead = std::move(drivesToRead);
-                ReadConfig();
+            // read if got something new
+            if (changes) {
+                ReadConfig(GetDrivesToRead(true));
             } else {
                 ApplyStorageConfig(*InitialConfig);
                 Y_ABORT_UNLESS(DirectBoundNodes.empty()); // ensure we don't have to spread this config
@@ -310,6 +306,21 @@ namespace NKikimr::NStorage {
                 StorageConfigLoaded = true;
             }
         }
+    }
+
+    std::vector<TString> TDistributedConfigKeeper::GetDrivesToRead(bool initial) const {
+        std::vector<TString> drivesToRead;
+        if (BaseConfig->GetSelfManagementConfig().GetEnabled()) {
+            auto callback = [&](const auto& /*node*/, const auto& drive) { drivesToRead.push_back(drive.GetPath()); };
+            EnumerateConfigDrives(*(initial ? InitialConfig : StorageConfig), SelfId().NodeId(), callback);
+            if (ProposedStorageConfig) {
+                EnumerateConfigDrives(*ProposedStorageConfig, SelfId().NodeId(), callback);
+            }
+            std::ranges::sort(drivesToRead);
+            const auto [begin, end] = std::ranges::unique(drivesToRead);
+            drivesToRead.erase(begin, end);
+        }
+        return drivesToRead;
     }
 
 } // NKikimr::NStorage


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

Fix config reading sequence

### Changelog category <!-- remove all except one -->

* Not for changelog (changelog entry is not required)

### Description for reviewers <!-- (optional) description for those who read this PR -->

This patch fixes how configs from distconf are fetched from disk in order to prevent theoretical infinite cycles.
