### PR TITLE
Fix race in incremental backup that hangs operation

### DIFF
--- a/ydb/core/tx/replication/service/worker.cpp
+++ b/ydb/core/tx/replication/service/worker.cpp
@@ -88,6 +88,13 @@ TEvWorker::TEvDataEnd::TEvDataEnd(ui64 partitionId, TVector<ui64>&& adjacentPart
 {
 }
 
+TEvWorker::TEvDataEnd::TEvDataEnd(ui64 partitionId, const TVector<ui64>& adjacentPartitionsIds, const TVector<ui64>& childPartitionsIds)
+    : PartitionId(partitionId)
+    , AdjacentPartitionsIds(adjacentPartitionsIds)
+    , ChildPartitionsIds(childPartitionsIds)
+{
+}
+
 TString TEvWorker::TEvDataEnd::ToString() const {
     return TStringBuilder() << ToStringHeader() << " {"
         << " PartitionId: " << PartitionId
@@ -154,7 +161,7 @@ class TWorker: public TActorBootstrapped<TWorker> {
                 << ": sender# " << ev->Sender);
 
             Reader.Registered();
-            if (!InFlightData) {
+            if (!InFlightData && !DataEnd) {
                 Send(Reader, new TEvWorker::TEvPoll());
             }
         } else if (ev->Sender == Writer) {
@@ -164,6 +171,8 @@ class TWorker: public TActorBootstrapped<TWorker> {
             Writer.Registered();
             if (InFlightData) {
                 Send(Writer, new TEvWorker::TEvData(InFlightData->PartitionId, InFlightData->Source, InFlightData->Records));
+            } else if (DataEnd) {
+                Send(Writer, new TEvWorker::TEvDataEnd(DataEnd->PartitionId, DataEnd->AdjacentPartitionsIds, DataEnd->ChildPartitionsIds));
             }
         } else {
             LOG_W("Handshake from unknown actor"
@@ -193,6 +202,7 @@ class TWorker: public TActorBootstrapped<TWorker> {
         }
 
         InFlightData.Reset();
+        DataEnd.Reset();
         if (Reader) {
             Send(ev->Forward(Reader));
         }
@@ -237,6 +247,9 @@ class TWorker: public TActorBootstrapped<TWorker> {
                 << ": sender# " << ev->Sender);
             return;
         }
+
+        Y_ABORT_UNLESS(!DataEnd);
+        DataEnd = MakeHolder<TEvWorker::TEvDataEnd>(ev->Get()->PartitionId, ev->Get()->AdjacentPartitionsIds, ev->Get()->ChildPartitionsIds);
 
         if (Writer) {
             Send(ev->Forward(Writer));
@@ -368,6 +381,7 @@ private:
     TActorInfo Reader;
     TActorInfo Writer;
     THolder<TEvWorker::TEvData> InFlightData;
+    THolder<TEvWorker::TEvDataEnd> DataEnd;
     TDuration Lag;
 };
 

--- a/ydb/core/tx/replication/service/worker.h
+++ b/ydb/core/tx/replication/service/worker.h
@@ -86,6 +86,7 @@ struct TEvWorker {
         TVector<ui64> ChildPartitionsIds;
 
         TEvDataEnd(ui64 partitionId, TVector<ui64>&& adjacentPartitionsIds, TVector<ui64>&& childPartitionsIds);
+        TEvDataEnd(ui64 partitionId, const TVector<ui64>& adjacentPartitionsIds, const TVector<ui64>& childPartitionsIds);
         TString ToString() const override;
     };
 };

--- a/ydb/core/tx/schemeshard/ut_backup_collection/ut_backup_collection.cpp
+++ b/ydb/core/tx/schemeshard/ut_backup_collection/ut_backup_collection.cpp
@@ -1,5 +1,5 @@
-    #include <ydb/core/testlib/actors/block_events.h>
-    #include <ydb/core/tx/replication/service/worker.h>
+#include <ydb/core/testlib/actors/block_events.h>
+#include <ydb/core/tx/replication/service/worker.h>
 #include <ydb/core/tx/schemeshard/ut_helpers/helpers.h>
 #include <ydb/core/protos/schemeshard/operations.pb.h>
 #include <library/cpp/string_utils/base64/base64.h>


### PR DESCRIPTION
### Changelog category <!-- remove all except one -->

* Not for changelog (changelog entry is not required)

### Description for reviewers <!-- (optional) description for those who read this PR -->

Этот PR устраняет гонку в операции инкрементального резервного копирования, которая могла привести к зависанию операции. Исправление обеспечивает надлежащую координацию между компонентами чтения и записи в процессе установления соединения (handshake).

- Добавлена буферизация событий `TEvDataEnd`, когда компонент записи еще не готов
- Добавлен тест, воспроизводящий данную гонку
