### PR TITLE
[Kafka API transactions] Fix several bugs

### DIFF
--- a/ydb/core/kafka_proxy/kafka_connection.cpp
+++ b/ydb/core/kafka_proxy/kafka_connection.cpp
@@ -609,6 +609,7 @@ protected:
     }
 
     void OnRequestProcessed(const Msg::TPtr& request) {
+        KAFKA_LOG_T("Request with correlationId " << request->Header.CorrelationId << " processed. Erasing it from PendingRequests and PendingRequestsQueue");
         InflightSize -= request->ExpectedSize;
         PendingRequests.erase(request->Header.CorrelationId);
         PendingRequestsQueue.pop_front();
@@ -617,7 +618,9 @@ protected:
     bool ProcessReplyQueue(const TActorContext& ctx) {
         while(!PendingRequestsQueue.empty()) {
             auto& request = PendingRequestsQueue.front();
+            KAFKA_LOG_T("Processing reply queue for request with correlationId " << request->Header.CorrelationId);
             if (request->Response.get() == nullptr) {
+                KAFKA_LOG_T("Response for request with correlationId " << request->Header.CorrelationId << " is empty.");
                 break;
             }
 
@@ -632,6 +635,7 @@ protected:
     }
 
     bool Reply(const TRequestHeaderData* header, const TApiMessage* reply, const TString method, const TInstant requestStartTime, EKafkaErrors errorCode, const TActorContext& ctx) {
+        KAFKA_LOG_T("Building reply for method " << method << " and correlationId " << header->CorrelationId << " with error code: " << errorCode);
         TKafkaVersion headerVersion = ResponseHeaderVersion(header->RequestApiKey, header->RequestApiVersion);
         TKafkaVersion version = header->RequestApiVersion;
         

--- a/ydb/core/kafka_proxy/kafka_producer_instance_id.h
+++ b/ydb/core/kafka_proxy/kafka_producer_instance_id.h
@@ -12,9 +12,15 @@ namespace NKafka {
         auto operator<=>(TProducerInstanceId const&) const = default;
     };
     inline IOutputStream& operator<<(IOutputStream& os, const TProducerInstanceId& obj) {
-        os << "{Id: " << obj.Id << ", Epoch: " << obj.Epoch;
+        os << "{Id: " << obj.Id << ", Epoch: " << obj.Epoch << "}";
         return os;
     }
 
     static const TProducerInstanceId INVALID_PRODUCER_INSTANCE_ID = {-1, -1};
+    
+    struct TProducerInstanceIdHashFn {
+        size_t operator()(const TProducerInstanceId& producerInstanceId) const {
+            return std::hash<i64>()(producerInstanceId.Id) ^ std::hash<i32>()(producerInstanceId.Epoch);
+        }
+    };
 } // namespace NKafka

--- a/ydb/core/kafka_proxy/ut/ut_produce_actor.cpp
+++ b/ydb/core/kafka_proxy/ut/ut_produce_actor.cpp
@@ -65,6 +65,7 @@ namespace {
                 Ctx->Runtime->SetLogPriority(NKikimrServices::PQ_TX, NLog::PRI_DEBUG);
                 TContext::TPtr kafkaContext = std::make_shared<TContext>(KafkaConfig);
                 kafkaContext->DatabasePath = "/Root/PQ";
+                kafkaContext->ConnectionId = Ctx->Edge;
                 ActorId = Ctx->Runtime->Register(CreateKafkaProduceActor(kafkaContext));
                 auto dummySchemeCacheId = Ctx->Runtime->Register(new TDummySchemeCacheActor(Ctx->TabletId));
                 Ctx->Runtime->RegisterService(MakeSchemeCacheID(), dummySchemeCacheId);
@@ -276,6 +277,28 @@ namespace {
                 return poisonPillCounter > 0;
             };
             UNIT_ASSERT(!Ctx->Runtime->DispatchEvents(options3, TDuration::Seconds(2)));
+        }
+
+        Y_UNIT_TEST(OnWriteExpiredAndWakeUp_ShouldReturnREQUEST_TIMED_OUT) {
+            auto observer = [&](TAutoPtr<IEventHandle>& input) {
+                if (auto* event = input->CastAsLocal<TEvPartitionWriter::TEvWriteRequest>()) {
+                    return TTestActorRuntimeBase::EEventAction::DROP;
+                }
+
+                return TTestActorRuntimeBase::EEventAction::PROCESS;
+            };
+            Ctx->Runtime->SetObserverFunc(observer);
+
+            SendProduce();
+
+            Ctx->Runtime->AdvanceCurrentTime(TDuration::Seconds(31));
+
+            Ctx->Runtime->SingleSys()->Send(new IEventHandle(ActorId, Ctx->Edge, new TEvKafka::TEvWakeup()));
+
+            auto response = Ctx->Runtime->GrabEdgeEvent<NKafka::TEvKafka::TEvResponse>();
+
+            UNIT_ASSERT(response != nullptr);
+            UNIT_ASSERT_VALUES_EQUAL(response->ErrorCode, NKafka::EKafkaErrors::REQUEST_TIMED_OUT);
         }
     }
 } // anonymous namespace

--- a/ydb/core/persqueue/pq_impl.cpp
+++ b/ydb/core/persqueue/pq_impl.cpp
@@ -4646,7 +4646,8 @@ void TPersQueue::CheckTxState(const TActorContext& ctx,
 
     case NKikimrPQ::TTransaction::DELETING:
         // The PQ tablet has persisted its state. Now she can delete the transaction and take the next one.
-        DeleteWriteId(tx.WriteId);
+        TMaybe<TWriteId> writeId = tx.WriteId; // copy writeId to save for kafka transaction after erase
+        DeleteWriteId(writeId);
         PQ_LOG_TX_I("delete TxId " << tx.TxId);
         Txs.erase(tx.TxId);
         SetTxInFlyCounter();
@@ -4655,7 +4656,7 @@ void TPersQueue::CheckTxState(const TActorContext& ctx,
         // in the status of the PQ tablet (if they came)
         TryReturnTabletStateAll(ctx);
 
-        TryContinueKafkaWrites(tx.WriteId, ctx);
+        TryContinueKafkaWrites(writeId, ctx);
         break;
     }
 }

--- a/ydb/core/persqueue/pq_impl.h
+++ b/ydb/core/persqueue/pq_impl.h
@@ -299,7 +299,7 @@ private:
     But we know for sure that all writes coming after the commit of the kafka transaction refer to the next transaction. 
     That's why we queue them here till previous transaction is completely deleted (all supportive partitions are deleted and writeId is erased from TxWrites).
      */
-    THashMap<NKafka::TProducerInstanceId, TEvPersQueue::TEvRequest::TPtr, NKafka::TProducerInstanceIdHashFn> KafkaNextTransactionRequests = {};
+    THashMap<NKafka::TProducerInstanceId, TEvPersQueue::TEvRequest::TPtr, NKafka::TProducerInstanceIdHashFn> KafkaNextTransactionRequests;
 
     // PLANNED -> CALCULATING -> CALCULATED -> WAIT_RS -> EXECUTING -> EXECUTED
     THashMap<TDistributedTransaction::EState, TDeque<ui64>> TxsOrder;
@@ -465,6 +465,7 @@ private:
 
     void DeleteExpiredTransactions(const TActorContext& ctx);
     void ScheduleDeleteExpiredKafkaTransactions();
+    void TryContinueKafkaWrites(const TMaybe<TWriteId> writeId, const TActorContext& ctx);
     void Handle(TEvPersQueue::TEvCancelTransactionProposal::TPtr& ev, const TActorContext& ctx);
 
     void SetTxCounters();

--- a/ydb/core/persqueue/ut/pqtablet_ut.cpp
+++ b/ydb/core/persqueue/ut/pqtablet_ut.cpp
@@ -2459,11 +2459,11 @@ Y_UNIT_TEST_F(Kafka_Transaction_Incoming_Before_Previous_TEvDeletePartitionDone_
     SendKafkaTxnWriteRequest(producerInstanceId, ownerCookie);
     ui32 fisrtSupportivePartitionId = WaitForExactTxWritesCount(1).GetTxWrites(0).GetInternalPartitionId();
     
-    TAutoPtr<IEventHandle> deleteDoneEvent;
+    TAutoPtr<TEvPQ::TEvDeletePartitionDone> deleteDoneEvent;
     bool seenEvent = false;
     // add observer for TEvPQ::TEvDeletePartitionDone request and skip it
     AddOneTimeEventObserver<TEvPQ::TEvDeletePartitionDone>(seenEvent, [&deleteDoneEvent](TAutoPtr<IEventHandle>& eventHandle) {
-        deleteDoneEvent = eventHandle;
+        deleteDoneEvent = eventHandle->Release<TEvPQ::TEvDeletePartitionDone>();
         return TTestActorRuntimeBase::EEventAction::DROP;
     });
 
@@ -2483,7 +2483,7 @@ Y_UNIT_TEST_F(Kafka_Transaction_Incoming_Before_Previous_TEvDeletePartitionDone_
     // now we can eventually send TEvPQ::TEvDeletePartitionDone 
     Ctx->Runtime->SendToPipe(Pipe,
                              Ctx->Edge,
-                             deleteDoneEvent.Release()->Get<TEvPQ::TEvDeletePartitionDone>(),
+                             deleteDoneEvent.Release(),
                              0, 0);
     WaitForTheTransactionToBeDeleted(txId);
 
@@ -2506,7 +2506,7 @@ Y_UNIT_TEST_F(Kafka_Transaction_Incoming_Before_Previous_Is_In_DELETED_State_Sho
     SendKafkaTxnWriteRequest(producerInstanceId, ownerCookie);
     WaitForExactTxWritesCount(1);
     
-    TAutoPtr<IEventHandle> keyValueResponse;
+    TAutoPtr<TEvKeyValue::TEvResponse> keyValueResponse;
     bool seenDeletePartitionsDoneEvent = false;
     bool seenKeyValResponse = false;
     // add observer for TEvPQ::TEvDeletePartitionDone request and skip it
@@ -2515,7 +2515,7 @@ Y_UNIT_TEST_F(Kafka_Transaction_Incoming_Before_Previous_Is_In_DELETED_State_Sho
             seenDeletePartitionsDoneEvent = true;
         } else if (seenDeletePartitionsDoneEvent && !seenKeyValResponse && input->CastAsLocal<TEvKeyValue::TEvResponse>()) {
             // next TEvKeyValue::TEvResponse after TEvPQ::TEvDeletePartitionDone contains info about successull deletion of writeInfo from KV
-            keyValueResponse = input;
+            keyValueResponse = input->Release<TEvKeyValue::TEvResponse>();
             seenKeyValResponse = true;
             return TTestActorRuntimeBase::EEventAction::DROP;
         }
@@ -2541,7 +2541,7 @@ Y_UNIT_TEST_F(Kafka_Transaction_Incoming_Before_Previous_Is_In_DELETED_State_Sho
     // eventually send TEvKeyValue::TEvResponse 
     Ctx->Runtime->SendToPipe(Pipe,
                              Ctx->Edge,
-                             keyValueResponse.Release()->Get<TEvKeyValue::TEvResponse>(),
+                             keyValueResponse.Release(),
                              0, 0);
     
     // wait for a deferred response for last GetOwnership request we sent

--- a/ydb/core/persqueue/write_id.cpp
+++ b/ydb/core/persqueue/write_id.cpp
@@ -34,6 +34,12 @@ void TWriteId::ToStream(IOutputStream& s) const
     }
 }
 
+TString TWriteId::ToString() const {
+    TStringStream ss;
+    ToStream(ss);
+    return ss.Str();
+}
+
 template <class T>
 TWriteId GetWriteIdImpl(const T& m)
 {

--- a/ydb/core/persqueue/write_id.h
+++ b/ydb/core/persqueue/write_id.h
@@ -29,6 +29,7 @@ struct TWriteId {
     bool operator<(const TWriteId& rhs) const;
 
     void ToStream(IOutputStream& s) const;
+    TString ToString() const;
 
     size_t GetHash() const
     {
@@ -46,7 +47,7 @@ struct TWriteId {
     // these fields are used to identify topic api transaction
     ui64 NodeId = 0;
     ui64 KeyId = 0;
-    // Iidentifies kafka api transaction
+    // Identifies kafka api transaction
     NKafka::TProducerInstanceId KafkaProducerInstanceId;
 };
 

--- a/ydb/core/persqueue/write_id.h
+++ b/ydb/core/persqueue/write_id.h
@@ -43,6 +43,11 @@ struct TWriteId {
         return !KafkaApiTransaction;
     }
 
+    bool IsKafkaApiTransaction() const 
+    {
+        return KafkaApiTransaction;
+    }
+
     bool KafkaApiTransaction = false;
     // these fields are used to identify topic api transaction
     ui64 NodeId = 0;


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

PR to main: https://github.com/ydb-platform/ydb/pull/21927

This PR fixes:
- bug with hanging produce request when using transactions
- VERIFY on a write request to a new kafka transaction when previous has not yet deleted
- invalid memory access on write expired in kafka_produce_actor.

### Changelog category <!-- remove all except one -->

* Not for changelog (changelog entry is not required)

### Description for reviewers <!-- (optional) description for those who read this PR -->

...
