### PR TITLE
conveyor_composite: remove stray unhandled event

### DIFF
--- a/ydb/core/tx/conveyor_composite/service/service.cpp
+++ b/ydb/core/tx/conveyor_composite/service/service.cpp
@@ -26,7 +26,6 @@ void TDistributor::Bootstrap() {
     AFL_NOTICE(NKikimrServices::TX_CONVEYOR)("name", ConveyorName)("action", "conveyor_registered")("config", Config.DebugString())(
         "actor_id", SelfId())("manager", Manager->DebugString());
     Become(&TDistributor::StateMain);
-    TBase::Schedule(TDuration::Seconds(1), new NActors::TEvents::TEvWakeup(1));
 }
 
 void TDistributor::HandleMain(TEvInternal::TEvTaskProcessedResult::TPtr& evExt) {


### PR DESCRIPTION
regression by 3849a7e5cde6fbbb1a61a417b485b2c6c8dd3513
event handler was removed, but event is still emitted (once);
largely cosmetic (only nasty-looking, but harmless log message)

### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

...

### Changelog category <!-- remove all except one -->

* Not for changelog (changelog entry is not required)

### Description for reviewers <!-- (optional) description for those who read this PR -->

...
