### PR TITLE
meta forward authorize header

### DIFF
--- a/ydb/mvp/meta/mvp.cpp
+++ b/ydb/mvp/meta/mvp.cpp
@@ -136,6 +136,8 @@ TString TMVP::GetAppropriateEndpoint(const NHttp::THttpIncomingRequestPtr& req) 
 NMvp::TTokensConfig TMVP::TokensConfig;
 TString TMVP::MetaDatabaseTokenName;
 
+bool TMVP::DbUserTokenSource = false;
+
 TMVP::TMVP(int argc, char** argv)
     : ActorSystemStoppingLock()
     , ActorSystemStopping(false)
@@ -177,6 +179,7 @@ void TMVP::TryGetMetaOptionsFromConfig(const YAML::Node& config) {
     MetaDatabase = meta["meta_database"].as<std::string>("");
     MetaCache = meta["meta_cache"].as<bool>(false);
     MetaDatabaseTokenName = meta["meta_database_token_name"].as<std::string>("");
+    DbUserTokenSource = meta["db_user_token_access"].as<bool>(false);
 }
 
 void TMVP::TryGetGenericOptionsFromConfig(

--- a/ydb/mvp/meta/mvp.h
+++ b/ydb/mvp/meta/mvp.h
@@ -38,6 +38,7 @@ public:
     TString MetaDatabase;
     bool MetaCache = false;
     static TString MetaDatabaseTokenName;
+    static bool DbUserTokenSource;
 
     TMVP(int argc, char** argv);
     int Init();


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

meta forward authorize header

### Changelog category <!-- remove all except one -->

* Improvement

### Description for reviewers <!-- (optional) description for those who read this PR -->

- added new field in meta config named `db_user_token_access`, default value is `false`. If `db_user_token_access=true`, database handlers start forwarding the request Authorization header  when asking YDB Viewer for info.
- added CORS headers to `/meta/cp_databases` handler