### PR TITLE
Make BridgePileId natural number

### DIFF
--- a/ydb/core/base/blobstorage.cpp
+++ b/ydb/core/base/blobstorage.cpp
@@ -269,3 +269,8 @@ template<>
 void Out<NKikimr::TPDiskCategory>(IOutputStream &str, const NKikimr::TPDiskCategory &value) {
     str << value.ToString();
 }
+
+template<>
+void Out<NKikimr::TBridgePileId>(IOutputStream& str, const NKikimr::TBridgePileId& bridgePileId) {
+    str << bridgePileId.ToString();
+}

--- a/ydb/core/base/blobstorage_common.h
+++ b/ydb/core/base/blobstorage_common.h
@@ -2,17 +2,69 @@
 
 #include <ydb/core/base/id_wrapper.h>
 
-namespace NKikimr{
+namespace NKikimr {
 
     struct TGroupIdTag;
     using TGroupId = TIdWrapper<ui32, TGroupIdTag>;
 
     struct TBridgePileTag;
-    using TBridgePileId = TIdWrapper<ui32, TBridgePileTag>;
+    struct TBridgePileId : TIdWrapper<ui32, TBridgePileTag> {
+        TBridgePileId() = default;
+        TBridgePileId(const TBridgePileId&) = default;
+
+        TBridgePileId& operator =(const TBridgePileId&) = default;
+
+        using TIdWrapper::ToString;
+
+        static constexpr TBridgePileId Min() { return FromValue(::Min<Type>()); }
+        static constexpr TBridgePileId Max() { return FromValue(::Max<Type>()); }
+
+        friend std::strong_ordering operator <=>(const TBridgePileId&, const TBridgePileId&) = default;
+
+        template<typename TProto>
+        void CopyToProto(TProto *message, void (TProto::*pfn)(Type value)) const {
+            if (*this) {
+                std::invoke(pfn, message, GetRawId());
+            }
+        }
+
+        template<typename TType, typename TProto>
+        static constexpr TBridgePileId FromProto(const TType *message, TProto (TType::*pfn)() const) {
+            return FromValue(std::invoke(pfn, message));
+        }
+
+        static constexpr TBridgePileId FromPileIndex(size_t index) noexcept { return FromValue(index + 1); }
+        static constexpr TBridgePileId FromLocalDb(ui32 value) noexcept { return FromValue(value); }
+
+        explicit operator bool() const { return GetRawId() != 0; }
+
+        size_t GetPileIndex() const {
+            Y_DEBUG_ABORT_UNLESS(*this);
+            return GetRawId() - 1;
+        }
+
+        ui32 GetLocalDb() const { return GetRawId(); }
+        size_t Hash() const { return GetRawId(); }
+
+    private:
+        explicit constexpr TBridgePileId(Type value) : TIdWrapper(TIdWrapper::FromValue(value)) {}
+
+        Type GetRawId() const {
+            return TIdWrapper::GetRawId();
+        }
+
+        static constexpr TBridgePileId FromValue(Type value) noexcept {
+            return TBridgePileId(value);
+        }
+    };
     
     inline bool IsDynamicGroup(TGroupId groupId) {
         return groupId.GetRawId() & 0x80000000;
     }
 }
 
+template<>
+struct std::hash<NKikimr::TBridgePileId> { size_t operator()(NKikimr::TBridgePileId id) const { return id.Hash(); } };
 
+template<>
+struct THash<NKikimr::TBridgePileId> : std::hash<NKikimr::TBridgePileId> {};

--- a/ydb/core/base/bridge.h
+++ b/ydb/core/base/bridge.h
@@ -31,8 +31,8 @@ namespace NKikimr {
         TBridgeInfo(TBridgeInfo&&) = default;
 
         const TPile *GetPile(TBridgePileId bridgePileId) const {
-            Y_ABORT_UNLESS(bridgePileId.GetRawId() < Piles.size());
-            return &Piles[bridgePileId.GetRawId()];
+            Y_ABORT_UNLESS(bridgePileId.GetPileIndex() < Piles.size());
+            return &Piles[bridgePileId.GetPileIndex()];
         }
 
         const TPile *GetPileForNode(ui32 nodeId) const {
@@ -43,7 +43,7 @@ namespace NKikimr {
         template<typename T>
         void ForEachPile(T&& callback) const {
             for (size_t i = 0; i < Piles.size(); ++i) {
-                callback(TBridgePileId::FromValue(i));
+                callback(TBridgePileId::FromPileIndex(i));
             }
         }
     };

--- a/ydb/core/blobstorage/bridge/syncer/syncer.cpp
+++ b/ydb/core/blobstorage/bridge/syncer/syncer.cpp
@@ -79,8 +79,8 @@ namespace NKikimr::NBridge {
         SourcePileId = BridgeInfo->PrimaryPile->BridgePileId;
         const auto& groups = Info->GetBridgeGroupIds();
         Y_ABORT_UNLESS(groups.size() == std::size(BridgeInfo->Piles));
-        SourceGroupId = groups[SourcePileId.GetRawId()];
-        TargetGroupId = groups[TargetPileId.GetRawId()];
+        SourceGroupId = groups[SourcePileId.GetPileIndex()];
+        TargetGroupId = groups[TargetPileId.GetPileIndex()];
         LogId = TStringBuilder() << LogId << '{' << SourceGroupId << "->" << TargetGroupId << '}';
         STLOG(PRI_DEBUG, BS_BRIDGE_SYNC, BRSS01, "initiating sync", (LogId, LogId));
         SourceState = &GroupAssimilateState[false];

--- a/ydb/core/blobstorage/dsproxy/bridge/bridge.cpp
+++ b/ydb/core/blobstorage/dsproxy/bridge/bridge.cpp
@@ -251,7 +251,7 @@ namespace NKikimr {
 
             const auto& bridgeGroupIds = Info->GetBridgeGroupIds();
             for (size_t i = 0; i < bridgeGroupIds.size(); ++i) {
-                const auto bridgePileId = TBridgePileId::FromValue(i);
+                const auto bridgePileId = TBridgePileId::FromPileIndex(i);
                 const TBridgeInfo::TPile *pile = BridgeInfo->GetPile(bridgePileId);
                 if (!NBridge::PileStateTraits(pile->State).AllowsConnection) {
                     continue; // ignore this pile, it is disconnected

--- a/ydb/core/blobstorage/groupinfo/blobstorage_groupinfo.cpp
+++ b/ydb/core/blobstorage/groupinfo/blobstorage_groupinfo.cpp
@@ -801,9 +801,7 @@ TIntrusivePtr<TBlobStorageGroupInfo> TBlobStorageGroupInfo::Parse(const NKikimrB
     if (group.HasBridgeProxyGroupId()) {
         res->BridgeProxyGroupId.emplace(TGroupId::FromProto(&group, &NKikimrBlobStorage::TGroupInfo::GetBridgeProxyGroupId));
     }
-    if (group.HasBridgePileId()) {
-        res->BridgePileId.emplace(TBridgePileId::FromProto(&group, &NKikimrBlobStorage::TGroupInfo::GetBridgePileId));
-    }
+    res->BridgePileId = TBridgePileId::FromProto(&group, &NKikimrBlobStorage::TGroupInfo::GetBridgePileId);
 
     // store original group protobuf it was parsed from
     res->Group.emplace(group);

--- a/ydb/core/blobstorage/groupinfo/blobstorage_groupinfo.h
+++ b/ydb/core/blobstorage/groupinfo/blobstorage_groupinfo.h
@@ -338,7 +338,7 @@ public:
     const std::vector<TGroupId>& GetBridgeGroupIds() const { return BridgeGroupIds; }
     bool IsBridged() const { return !BridgeGroupIds.empty(); }
     std::optional<TGroupId> GetBridgeProxyGroupId() const { return BridgeProxyGroupId; }
-    std::optional<TBridgePileId> GetBridgePileId() const { return BridgePileId; }
+    TBridgePileId GetBridgePileId() const { return BridgePileId; }
 
     // for testing purposes; numFailDomains = 0 automatically selects possible minimum for provided erasure; groupId=0
     // and groupGen=1 for constructed group
@@ -485,7 +485,7 @@ private:
     // bridge mode fields
     std::vector<TGroupId> BridgeGroupIds;
     std::optional<TGroupId> BridgeProxyGroupId;
-    std::optional<TBridgePileId> BridgePileId;
+    TBridgePileId BridgePileId;
 };
 
 // physical fail domain description

--- a/ydb/core/blobstorage/nodewarden/distconf.cpp
+++ b/ydb/core/blobstorage/nodewarden/distconf.cpp
@@ -18,7 +18,7 @@ namespace NKikimr::NStorage {
         if (Cfg && Cfg->BridgeConfig) {
             const auto& piles = Cfg->BridgeConfig->GetPiles();
             for (int i = 0; i < piles.size(); ++i) {
-                const auto [it, inserted] = BridgePileNameMap.emplace(piles[i].GetName(), TBridgePileId::FromValue(i));
+                const auto [it, inserted] = BridgePileNameMap.emplace(piles[i].GetName(), TBridgePileId::FromPileIndex(i));
                 Y_ABORT_UNLESS(inserted);
             }
         }
@@ -120,7 +120,7 @@ namespace NKikimr::NStorage {
                 config.GetGeneration();
 
             if (Cfg->BridgeConfig) {
-                BridgeInfo = GenerateBridgeInfo(config, Cfg.Get(), SelfNode.NodeId());
+                BridgeInfo = GenerateBridgeInfo(config);
             } else {
                 Y_ABORT_UNLESS(!BridgeInfo);
             }
@@ -503,17 +503,18 @@ namespace NKikimr::NStorage {
                     auto *group = groups->Mutable(i);
                     if (!group->HasBridgePileId()) {
                         return "bridge pile id is not set for a ring group";
-                    } else if (ui32 pileId = group->GetBridgePileId(); pileId < clusterState.PerPileStateSize()) {
+                    } else if (const auto pileId = TBridgePileId::FromProto(group, &std::decay_t<decltype(*group)>::GetBridgePileId);
+                            pileId.GetPileIndex() < clusterState.PerPileStateSize()) {
                         using T = NKikimrConfig::TDomainsConfig::TStateStorage;
                         std::optional<T::EPileState> state;
-                        if (pileId == clusterState.GetPrimaryPile()) {
-                            state = pileId == clusterState.GetPromotedPile()
+                        if (pileId == TBridgePileId::FromProto(&clusterState, &NKikimrBridge::TClusterState::GetPrimaryPile)) {
+                            state = pileId == TBridgePileId::FromProto(&clusterState, &NKikimrBridge::TClusterState::GetPromotedPile)
                                 ? T::PRIMARY
                                 : T::DEMOTED;
-                        } else if (pileId == clusterState.GetPromotedPile()) {
+                        } else if (pileId == TBridgePileId::FromProto(&clusterState, &NKikimrBridge::TClusterState::GetPromotedPile)) {
                             state = T::PROMOTED;
                         } else {
-                            switch (clusterState.GetPerPileState(pileId)) {
+                            switch (clusterState.GetPerPileState(pileId.GetPileIndex())) {
                                 case NKikimrBridge::TClusterState::DISCONNECTED:
                                     state = T::DISCONNECTED;
                                     break;
@@ -559,43 +560,26 @@ namespace NKikimr::NStorage {
         return std::nullopt;
     }
 
-    TBridgeInfo::TPtr GenerateBridgeInfo(const NKikimrBlobStorage::TStorageConfig& config, const TNodeWardenConfig *cfg,
-            ui32 selfNodeId) {
+    TBridgeInfo::TPtr TDistributedConfigKeeper::GenerateBridgeInfo(const NKikimrBlobStorage::TStorageConfig& config) {
         // prepare empty structure
         auto bridgeInfo = std::make_shared<TBridgeInfo>();
-        bridgeInfo->Piles.resize(cfg->BridgeConfig->PilesSize());
-
-        THashMap<TString, TBridgePileId> names;
-        if (cfg->BridgeConfig) {
-            for (size_t i = 0; i < cfg->BridgeConfig->PilesSize(); ++i) {
-                names.emplace(cfg->BridgeConfig->GetPiles(i).GetName(), TBridgePileId::FromValue(i));
-            }
-        }
+        const size_t numPiles = Cfg->BridgeConfig->PilesSize();
+        bridgeInfo->Piles.resize(numPiles);
 
         for (const auto& node : config.GetAllNodes()) {
-            std::optional<TBridgePileId> bridgePileId;
-            const TNodeLocation location(node.GetLocation());
-            if (const auto& bridgePileName = location.GetBridgePileName()) {
-                if (const auto it = names.find(*bridgePileName); it != names.end()) {
-                    bridgePileId.emplace(it->second);
-                } else {
-                    Y_ABORT("BridgePileName is incorrect");
-                }
-            } else if (names) {
-                Y_ABORT("missing BridgePileName for node");
-            }
+            const TBridgePileId bridgePileId = ResolveNodePileId(TNodeLocation(node.GetLocation()));
             Y_ABORT_UNLESS(bridgePileId);
+            auto& pile = bridgeInfo->Piles[bridgePileId.GetPileIndex()];
             const ui32 nodeId = node.GetNodeId();
-            auto& pile = bridgeInfo->Piles[bridgePileId->GetRawId()];
             pile.StaticNodeIds.push_back(node.GetNodeId());
             bridgeInfo->StaticNodeIdToPile[nodeId] = &pile;
-            if (nodeId == selfNodeId) {
+            if (nodeId == SelfNode.NodeId()) {
                 bridgeInfo->SelfNodePile = &pile;
             }
         }
 
-        if (cfg->DynamicNodeConfig && cfg->DynamicNodeConfig->HasNodeInfo()) {
-            const auto& nodeInfo = cfg->DynamicNodeConfig->GetNodeInfo();
+        if (Cfg->DynamicNodeConfig && Cfg->DynamicNodeConfig->HasNodeInfo()) {
+            const auto& nodeInfo = Cfg->DynamicNodeConfig->GetNodeInfo();
             if (!nodeInfo.HasLocation()) {
                 Y_ABORT("missing Location in dynamic TNodeInfo");
             }
@@ -603,43 +587,36 @@ namespace NKikimr::NStorage {
             if (!bridgePileName) {
                 Y_ABORT("missing BridgePileName in dynamic TNodeLocation");
             }
-            const auto& bridge = AppData()->BridgeConfig;
-            for (ui32 pileId = 0; pileId < bridge.PilesSize(); ++pileId) {
-                if (bridge.GetPiles(pileId).GetName() == bridgePileName) {
-                    bridgeInfo->SelfNodePile = &bridgeInfo->Piles[pileId];
-                    break;
-                }
-            }
-            if (!bridgeInfo->SelfNodePile) {
-                Y_ABORT("incorrect bridge pile name in dynamic TNodeLocation: %s", bridgePileName->c_str());
-            }
+            const auto it = BridgePileNameMap.find(*bridgePileName);
+            Y_ABORT_UNLESS(it != BridgePileNameMap.end(), "incorrect bridge pile name in dynamic TNodeLocation: %s",
+                bridgePileName->c_str());
+            bridgeInfo->SelfNodePile = &bridgeInfo->Piles[it->second.GetPileIndex()];
         }
 
-        Y_VERIFY_S(bridgeInfo->SelfNodePile, "SelfNodeId# " << selfNodeId << " Config# " << SingleLineProto(config));
+        Y_VERIFY_S(bridgeInfo->SelfNodePile, "SelfNodeId# " << SelfNode.NodeId() << " Config# " << SingleLineProto(config));
 
-        const NKikimrBridge::TClusterState *state = config.HasClusterState()
-            ? &config.GetClusterState()
-            : nullptr;
-        Y_VERIFY_S(state, SingleLineProto(config));
+        Y_ABORT_UNLESS(config.HasClusterState());
+        const NKikimrBridge::TClusterState& state = config.GetClusterState();
 
-        const size_t numPiles = cfg->BridgeConfig->PilesSize();
-        Y_ABORT_UNLESS(!state || state->PerPileStateSize() == numPiles);
+        Y_ABORT_UNLESS(state.PerPileStateSize() == numPiles);
         for (size_t i = 0; i < numPiles; ++i) {
             auto& pile = bridgeInfo->Piles[i];
-            pile.BridgePileId = TBridgePileId::FromValue(i);
-            pile.Name = cfg->BridgeConfig->GetPiles(i).GetName();
-            pile.State = state ? state->GetPerPileState(i) : NKikimrBridge::TClusterState::SYNCHRONIZED;
+            pile.BridgePileId = TBridgePileId::FromPileIndex(i);
+            pile.Name = Cfg->BridgeConfig->GetPiles(i).GetName();
+            pile.State = state.GetPerPileState(i);
             std::ranges::sort(pile.StaticNodeIds);
         }
 
-        const ui32 primary = state ? state->GetPrimaryPile() : 0;
-        Y_ABORT_UNLESS(primary < cfg->BridgeConfig->PilesSize());
-        bridgeInfo->Piles[primary].IsPrimary = true;
-        bridgeInfo->PrimaryPile = &bridgeInfo->Piles[primary];
+        const TBridgePileId primary = TBridgePileId::FromProto(&state, &NKikimrBridge::TClusterState::GetPrimaryPile);
+        Y_ABORT_UNLESS(primary.GetPileIndex() < numPiles);
+        auto& pile = bridgeInfo->Piles[primary.GetPileIndex()];
+        pile.IsPrimary = true;
+        bridgeInfo->PrimaryPile = &pile;
 
-        if (const ui32 promoted = state ? state->GetPromotedPile() : primary; promoted != primary) {
-            Y_ABORT_UNLESS(promoted < cfg->BridgeConfig->PilesSize());
-            auto& pile = bridgeInfo->Piles[promoted];
+        const TBridgePileId promoted = TBridgePileId::FromProto(&state, &NKikimrBridge::TClusterState::GetPromotedPile);
+        if (promoted != primary) {
+            Y_ABORT_UNLESS(promoted.GetPileIndex() < numPiles);
+            auto& pile = bridgeInfo->Piles[promoted.GetPileIndex()];
             Y_ABORT_UNLESS(pile.State == NKikimrBridge::TClusterState::SYNCHRONIZED);
             pile.IsBeingPromoted = true;
             bridgeInfo->BeingPromotedPile = &pile;

--- a/ydb/core/blobstorage/nodewarden/distconf.h
+++ b/ydb/core/blobstorage/nodewarden/distconf.h
@@ -377,7 +377,7 @@ namespace NKikimr::NStorage {
 
         void ApplyNewNodeList(std::span<std::tuple<TNodeIdentifier, TNodeLocation>> newNodeList);
 
-        std::optional<TBridgePileId> ResolveNodePileId(const TNodeLocation& location);
+        TBridgePileId ResolveNodePileId(const TNodeLocation& location);
 
         ////////////////////////////////////////////////////////////////////////////////////////////////////////////////
         // Binding to peer nodes
@@ -441,8 +441,8 @@ namespace NKikimr::NStorage {
             THashMap<TVDiskIdShort, NBsController::TPDiskId> replacedDisks,
             const NBsController::TGroupMapper::TForbiddenPDisks& forbid,
             i64 requiredSpace, NKikimrBlobStorage::TBaseConfig *baseConfig,
-            bool convertToDonor, bool ignoreVSlotQuotaCheck, bool isSelfHealReasonDecommit,
-            std::optional<TBridgePileId> bridgePileId, std::optional<TGroupId> bridgeProxyGroupId);
+            bool convertToDonor, bool ignoreVSlotQuotaCheck, bool isSelfHealReasonDecommit, TBridgePileId bridgePileId,
+            std::optional<TGroupId> bridgeProxyGroupId);
 
         bool UpdateConfig(NKikimrBlobStorage::TStorageConfig *config, bool& checkSyncersAfterCommit);
 
@@ -492,6 +492,8 @@ namespace NKikimr::NStorage {
         static void GenerateBridgeInitialState(const TNodeWardenConfig& cfg, NKikimrBlobStorage::TStorageConfig *config);
 
         bool CheckBridgePeerRevPush(const NKikimrBlobStorage::TStorageConfig& peerConfig, ui32 senderNodeId);
+
+        TBridgeInfo::TPtr GenerateBridgeInfo(const NKikimrBlobStorage::TStorageConfig& config);
 
         ////////////////////////////////////////////////////////////////////////////////////////////////////////////////
         // Scatter/gather logic
@@ -701,9 +703,6 @@ namespace NKikimr::NStorage {
         ui64 *mainConfigVersion, TString *mainConfigFetchYaml);
 
     std::optional<TString> UpdateClusterState(NKikimrBlobStorage::TStorageConfig *config);
-
-    TBridgeInfo::TPtr GenerateBridgeInfo(const NKikimrBlobStorage::TStorageConfig& config,
-        const TNodeWardenConfig *cfg, ui32 selfNodeId);
 
 } // NKikimr::NStorage
 

--- a/ydb/core/blobstorage/nodewarden/distconf_binding.cpp
+++ b/ydb/core/blobstorage/nodewarden/distconf_binding.cpp
@@ -114,7 +114,7 @@ namespace NKikimr::NStorage {
         PrimaryPileBindQueue.Update(NodeIdsForPrimaryPileOutgoingBinding);
     }
 
-    std::optional<TBridgePileId> TDistributedConfigKeeper::ResolveNodePileId(const TNodeLocation& location) {
+    TBridgePileId TDistributedConfigKeeper::ResolveNodePileId(const TNodeLocation& location) {
         if (const auto& bridgePileName = location.GetBridgePileName()) {
             if (const auto it = BridgePileNameMap.find(*bridgePileName); it != BridgePileNameMap.end()) {
                 return it->second;
@@ -124,7 +124,7 @@ namespace NKikimr::NStorage {
         } else if (BridgePileNameMap) {
             Y_DEBUG_ABORT_S("missing bridge pile name for node Location# " << location.ToString());
         }
-        return std::nullopt;
+        return TBridgePileId();
     }
 
     void TDistributedConfigKeeper::IssueNextBindRequest() {

--- a/ydb/core/blobstorage/nodewarden/distconf_fsm.cpp
+++ b/ydb/core/blobstorage/nodewarden/distconf_fsm.cpp
@@ -26,7 +26,7 @@ namespace NKikimr::NStorage {
             LocalPileQuorum = BridgeInfo && HasNodeQuorum(*StorageConfig, connected, BridgePileNameMap,
                 BridgeInfo->SelfNodePile->BridgePileId, nullptr);
             GlobalQuorum = (!BridgeInfo || BridgeInfo->SelfNodePile->IsPrimary) && HasNodeQuorum(*StorageConfig,
-                connected, BridgePileNameMap, std::nullopt, nullptr);
+                connected, BridgePileNameMap, TBridgePileId(), nullptr);
 
             // recalculate unsynced piles' quorum too
             if (BridgeInfo) {
@@ -179,7 +179,7 @@ namespace NKikimr::NStorage {
             connected.push_back(nodeId);
         }
         return HasNodeQuorum(config, connected, BridgePileNameMap, local && BridgeInfo ?
-            std::make_optional(BridgeInfo->SelfNodePile->BridgePileId) : std::nullopt, nullptr);
+            BridgeInfo->SelfNodePile->BridgePileId : TBridgePileId(), nullptr);
     }
 
     TDistributedConfigKeeper::TProcessCollectConfigsResult TDistributedConfigKeeper::ProcessCollectConfigs(
@@ -195,7 +195,7 @@ namespace NKikimr::NStorage {
                 successfulNodes.emplace_back(node);
             }
         }
-        const bool nodeQuorum = HasNodeQuorum(*StorageConfig, successfulNodes, BridgePileNameMap, std::nullopt, &err);
+        const bool nodeQuorum = HasNodeQuorum(*StorageConfig, successfulNodes, BridgePileNameMap, TBridgePileId(), &err);
 
         ////////////////////////////////////////////////////////////////////////////////////////////////////////////////
         // Calculate configuration quorum
@@ -234,7 +234,7 @@ namespace NKikimr::NStorage {
                     nodesWithoutDistconf.emplace_back(node);
                 }
             }
-            if (HasNodeQuorum(*StorageConfig, nodesWithoutDistconf, BridgePileNameMap, std::nullopt, nullptr)) {
+            if (HasNodeQuorum(*StorageConfig, nodesWithoutDistconf, BridgePileNameMap, TBridgePileId(), nullptr)) {
                 // yes, distconf is disabled on the majority of the nodes, so we can't do anything about it
                 return {.IsDistconfDisabledQuorum = true};
             }
@@ -275,7 +275,7 @@ namespace NKikimr::NStorage {
         }
         for (auto it = baseConfigs.begin(); it != baseConfigs.end(); ) { // filter out configs not having node quorum
             TBaseConfigInfo& r = it->second;
-            if (HasNodeQuorum(r.Config, r.HavingNodeIds, BridgePileNameMap, std::nullopt, nullptr)) {
+            if (HasNodeQuorum(r.Config, r.HavingNodeIds, BridgePileNameMap, TBridgePileId(), nullptr)) {
                 ++it;
             } else {
                 baseConfigs.erase(it++);

--- a/ydb/core/blobstorage/nodewarden/distconf_invoke_bridge.cpp
+++ b/ydb/core/blobstorage/nodewarden/distconf_invoke_bridge.cpp
@@ -21,15 +21,17 @@ namespace NKikimr::NStorage {
 
         // check new config alone
         const ui32 numPiles = Self->Cfg->BridgeConfig->PilesSize();
+        const auto primaryPileId = TBridgePileId::FromProto(&newClusterState, &NKikimrBridge::TClusterState::GetPrimaryPile);
+        const auto promotedPileId = TBridgePileId::FromProto(&newClusterState, &NKikimrBridge::TClusterState::GetPromotedPile);
         if (newClusterState.PerPileStateSize() != numPiles) {
             throw TExError() << "Incorrect number of per-pile states in new config";
-        } else if (newClusterState.GetPrimaryPile() >= numPiles) {
+        } else if (primaryPileId.GetPileIndex() >= numPiles) {
             throw TExError() << "Incorrect primary pile";
-        } else if (newClusterState.GetPromotedPile() >= numPiles) {
+        } else if (promotedPileId.GetPileIndex() >= numPiles) {
             throw TExError() << "Incorrect promoted pile";
-        } else if (newClusterState.GetPerPileState(newClusterState.GetPrimaryPile()) != NKikimrBridge::TClusterState::SYNCHRONIZED) {
+        } else if (newClusterState.GetPerPileState(primaryPileId.GetPileIndex()) != NKikimrBridge::TClusterState::SYNCHRONIZED) {
             throw TExError() << "Incorrect primary pile state";
-        } else if (newClusterState.GetPerPileState(newClusterState.GetPromotedPile()) != NKikimrBridge::TClusterState::SYNCHRONIZED) {
+        } else if (newClusterState.GetPerPileState(promotedPileId.GetPileIndex()) != NKikimrBridge::TClusterState::SYNCHRONIZED) {
             throw TExError() << "Incorrect promoted pile state";
         }
 
@@ -94,7 +96,9 @@ namespace NKikimr::NStorage {
 
         if (changedPileIndex != Max<size_t>()) {
             for (size_t i = 0; i < details->PileSyncStateSize(); ++i) {
-                if (const auto& state = details->GetPileSyncState(i); state.GetBridgePileId() == changedPileIndex) {
+                const auto& state = details->GetPileSyncState(i);
+                const auto bridgePileId = TBridgePileId::FromProto(&state, &std::decay_t<decltype(state)>::GetBridgePileId);
+                if (bridgePileId.GetPileIndex() == changedPileIndex) {
                     details->MutablePileSyncState()->DeleteSubrange(i, 1);
                     break;
                 }
@@ -105,7 +109,8 @@ namespace NKikimr::NStorage {
                     // this pile is not disconnected, there is no reason to synchronize it anymore
                     for (size_t i = 0; i < details->PileSyncStateSize(); ++i) {
                         const auto& item = details->GetPileSyncState(i);
-                        if (item.GetBridgePileId() != changedPileIndex) {
+                        const auto bridgePileId = TBridgePileId::FromProto(&item, &std::decay_t<decltype(item)>::GetBridgePileId);
+                        if (bridgePileId.GetPileIndex() != changedPileIndex) {
                             break;
                         }
                         details->MutablePileSyncState()->DeleteSubrange(i, 1);
@@ -131,9 +136,12 @@ namespace NKikimr::NStorage {
 
     void TInvokeRequestHandlerActor::NotifyBridgeSyncFinished(const TQuery::TNotifyBridgeSyncFinished& cmd) {
         RunCommonChecks();
+
+        const auto bridgePileId = TBridgePileId::FromProto(&cmd, &TQuery::TNotifyBridgeSyncFinished::GetBridgePileId);
+
         if (!Self->Cfg->BridgeConfig) {
             throw TExError() << "Bridge mode is not enabled";
-        } else if (Self->Cfg->BridgeConfig->PilesSize() <= cmd.GetBridgePileId()) {
+        } else if (Self->Cfg->BridgeConfig->PilesSize() <= bridgePileId.GetPileIndex()) {
             throw TExError() << "BridgePileId out of bounds";
         } else if (Self->StorageConfig->GetClusterState().GetGeneration() != cmd.GetGeneration()) {
             throw TExError() << "Generation mismatch";
@@ -148,7 +156,7 @@ namespace NKikimr::NStorage {
         NKikimrBridge::TClusterStateDetails::TPileSyncState *state = nullptr;
         for (stateIndex = 0; stateIndex < details->PileSyncStateSize(); ++stateIndex) {
             state = details->MutablePileSyncState(stateIndex);
-            if (state->GetBridgePileId() == cmd.GetBridgePileId()) {
+            if (TBridgePileId::FromProto(state, &std::decay_t<decltype(*state)>::GetBridgePileId) == bridgePileId) {
                 break;
             } else {
                 state = nullptr;
@@ -192,7 +200,7 @@ namespace NKikimr::NStorage {
                 if (!state->GetUnsyncedBSC() && !state->UnsyncedGroupIdsSize()) {
                     // fully synced, can switch to SYNCHRONIZED
                     details->MutablePileSyncState()->DeleteSubrange(stateIndex, 1);
-                    clusterState->SetPerPileState(cmd.GetBridgePileId(), NKikimrBridge::TClusterState::SYNCHRONIZED);
+                    clusterState->SetPerPileState(bridgePileId.GetPileIndex(), NKikimrBridge::TClusterState::SYNCHRONIZED);
                     clusterState->SetGeneration(clusterState->GetGeneration() + 1);
                     auto *entry = details->AddUnsyncedHistory();
                     entry->MutableClusterState()->CopyFrom(*clusterState);

--- a/ydb/core/blobstorage/nodewarden/distconf_invoke_static_group.cpp
+++ b/ydb/core/blobstorage/nodewarden/distconf_invoke_static_group.cpp
@@ -192,9 +192,7 @@ namespace NKikimr::NStorage {
         for (const auto& group : ss.GetGroups()) {
             if (group.GetGroupID() == vdiskId.GroupID.GetRawId()) {
                 try {
-                    std::optional<TBridgePileId> bridgePileId = group.HasBridgePileId()
-                        ? std::make_optional(TBridgePileId::FromProto(&group, &NKikimrBlobStorage::TGroupInfo::GetBridgePileId))
-                        : std::nullopt;
+                    const auto bridgePileId = TBridgePileId::FromProto(&group, &NKikimrBlobStorage::TGroupInfo::GetBridgePileId);
                     std::optional<TGroupId> bridgeProxyGroupId = group.HasBridgeProxyGroupId()
                         ? std::make_optional(TGroupId::FromProto(&group, &NKikimrBlobStorage::TGroupInfo::GetBridgeProxyGroupId))
                         : std::nullopt;

--- a/ydb/core/blobstorage/nodewarden/distconf_quorum.cpp
+++ b/ydb/core/blobstorage/nodewarden/distconf_quorum.cpp
@@ -12,7 +12,7 @@ namespace NKikimr::NStorage {
             const auto& clusterState = config.GetClusterState();
             for (size_t i = 0; i < clusterState.PerPileStateSize(); ++i) {
                 if (NBridge::PileStateTraits(clusterState.GetPerPileState(i)).RequiresConfigQuorum) {
-                    mandatoryPileIds.insert(TBridgePileId::FromValue(i));
+                    mandatoryPileIds.insert(TBridgePileId::FromPileIndex(i));
                 }
             }
         }
@@ -49,7 +49,7 @@ namespace NKikimr::NStorage {
             for (size_t i = 0; i < cs.PerPileStateSize(); ++i) {
                 if (NBridge::PileStateTraits(cs.GetPerPileState(i)).RequiresConfigQuorum) {
                     // this pile is part of config quorum, we need it to be connected
-                    res.try_emplace(TBridgePileId::FromValue(i));
+                    res.try_emplace(TBridgePileId::FromPileIndex(i));
                 }
             }
         } else {
@@ -61,11 +61,11 @@ namespace NKikimr::NStorage {
     }
 
     bool HasNodeQuorum(const NKikimrBlobStorage::TStorageConfig& config, std::span<TNodeIdentifier> successful,
-            const THashMap<TString, TBridgePileId>& bridgePileNameMap, std::optional<TBridgePileId> singleBridgePileId,
+            const THashMap<TString, TBridgePileId>& bridgePileNameMap, TBridgePileId singleBridgePileId,
             TStringStream *out) {
         // prepare list of piles we want to examine
         auto status = singleBridgePileId
-            ? THashMap<TBridgePileId, THashMap<TString, std::tuple<ui32, ui32>>>{{*singleBridgePileId, {}}}
+            ? THashMap<TBridgePileId, THashMap<TString, std::tuple<ui32, ui32>>>{{singleBridgePileId, {}}}
             : PrepareStatusMap(config);
 
         // generate set of all nodes

--- a/ydb/core/blobstorage/nodewarden/distconf_quorum.h
+++ b/ydb/core/blobstorage/nodewarden/distconf_quorum.h
@@ -9,8 +9,7 @@ namespace NKikimr::NStorage {
             const THashSet<TBridgePileId>& pileIdQuorumOverride);
 
     bool HasNodeQuorum(const NKikimrBlobStorage::TStorageConfig& config, std::span<TNodeIdentifier> successful,
-        const THashMap<TString, TBridgePileId>& bridgePileNameMap, std::optional<TBridgePileId> singleBridgePileId,
-        TStringStream *out);
+        const THashMap<TString, TBridgePileId>& bridgePileNameMap, TBridgePileId singleBridgePileId, TStringStream *out);
 
     using TSuccessfulDisk = std::tuple<TNodeIdentifier, TString, std::optional<ui64>>;
 

--- a/ydb/core/blobstorage/nodewarden/distconf_statestorage_config_generator.cpp
+++ b/ydb/core/blobstorage/nodewarden/distconf_statestorage_config_generator.cpp
@@ -10,7 +10,7 @@ namespace NKikimr::NStorage {
 
     TStateStoragePerPileGenerator::TStateStoragePerPileGenerator(THashMap<TString, std::vector<std::tuple<ui32, TNodeLocation>>>& nodes
         , const std::unordered_map<ui32, ui32>& selfHealNodesState
-        , const std::optional<TBridgePileId>& pileId
+        , TBridgePileId pileId
         , std::unordered_set<ui32>& usedNodes
     )
         : PileId(pileId)
@@ -80,9 +80,7 @@ namespace NKikimr::NStorage {
 
     void TStateStoragePerPileGenerator::AddRingGroup(NKikimrConfig::TDomainsConfig::TStateStorage *ss) {
         auto *rg = ss->AddRingGroups();
-        if (PileId) {
-            PileId->CopyToProto(rg, &NKikimrConfig::TDomainsConfig::TStateStorage::TRing::SetBridgePileId);
-        }
+        PileId.CopyToProto(rg, &NKikimrConfig::TDomainsConfig::TStateStorage::TRing::SetBridgePileId);
         rg->SetNToSelect(NToSelect);
         for (auto &nodes : Rings) {
             std::ranges::sort(nodes, [&](const auto& x, const auto& y) {

--- a/ydb/core/blobstorage/nodewarden/distconf_statestorage_config_generator.h
+++ b/ydb/core/blobstorage/nodewarden/distconf_statestorage_config_generator.h
@@ -9,7 +9,7 @@ namespace NKikimr::NStorage {
     public:
         TStateStoragePerPileGenerator(THashMap<TString, std::vector<std::tuple<ui32, TNodeLocation>>>& nodes,
             const std::unordered_map<ui32, ui32>& selfHealNodesState,
-            const std::optional<TBridgePileId>& pileId,
+            TBridgePileId pileId,
             std::unordered_set<ui32>& usedNodes);
         bool IsGoodConfig() const;
         void AddRingGroup(NKikimrConfig::TDomainsConfig::TStateStorage *ss);
@@ -29,7 +29,7 @@ namespace NKikimr::NStorage {
         void PickNodes(TNodeGroup& group);
         ui32 CalcNodeState(ui32 nodeId, bool disconnected);
 
-        const std::optional<TBridgePileId> PileId;
+        const TBridgePileId PileId;
         const std::unordered_map<ui32, ui32>& SelfHealNodesState;
         std::vector<TNodeGroup> NodeGroups;
         std::unordered_set<ui32>& UsedNodes;

--- a/ydb/core/blobstorage/nodewarden/node_warden_impl.cpp
+++ b/ydb/core/blobstorage/nodewarden/node_warden_impl.cpp
@@ -1527,7 +1527,7 @@ bool NKikimr::NStorage::DeriveStorageConfig(const NKikimrConfig::TAppConfig& app
                 *errorReason = "missing pile name";
                 return false;
             }
-            const auto [it, inserted] = piles.try_emplace(p[i].GetName(), TBridgePileId::FromValue(i));
+            const auto [it, inserted] = piles.try_emplace(p[i].GetName(), TBridgePileId::FromPileIndex(i));
             if (!inserted) {
                 *errorReason = TStringBuilder() << "duplicate pile name " << p[i].GetName();
                 return false;

--- a/ydb/core/driver_lib/run/kikimr_services_initializers.cpp
+++ b/ydb/core/driver_lib/run/kikimr_services_initializers.cpp
@@ -754,7 +754,7 @@ void TBasicServicesInitializer::InitializeServices(NActors::TActorSystemSetup* s
                     }
                 }
                 Y_ABORT_UNLESS(i != bridge.PilesSize());
-                const auto selfBridgePileId = TBridgePileId::FromValue(i);
+                const auto selfBridgePileId = TBridgePileId::FromPileIndex(i);
 
                 const TActorId actorId = MakeDistconfBridgeConnectionCheckerActorId();
                 setup->LocalServices.emplace_back(actorId, TActorSetupCmd(

--- a/ydb/core/mind/bscontroller/bsc.cpp
+++ b/ydb/core/mind/bscontroller/bsc.cpp
@@ -120,10 +120,11 @@ void TBlobStorageController::TGroupInfo::FillInGroupParameters(
     if (GroupMetrics) {
         params->MergeFrom(GroupMetrics->GetGroupParameters());
     } else if (BridgeGroupInfo) {
+        Y_ABORT_UNLESS(self->BridgeInfo);
         for (const auto& groupId : BridgeGroupInfo->GetBridgeGroupIds()) {
             if (TGroupInfo *groupInfo = self->FindGroup(TGroupId::FromValue(groupId))) {
-                if (self->BridgeInfo && groupInfo->BridgePileId &&
-                        self->BridgeInfo->GetPile(*groupInfo->BridgePileId)->State == NKikimrBridge::TClusterState::DISCONNECTED) {
+                Y_ABORT_UNLESS(groupInfo->BridgePileId);
+                if (!NBridge::PileStateTraits(self->BridgeInfo->GetPile(groupInfo->BridgePileId)->State).AllowsConnection) {
                     continue; // ignore groups from disconnected piles
                 }
                 groupInfo->FillInGroupParameters(params, self);

--- a/ydb/core/mind/bscontroller/config.cpp
+++ b/ydb/core/mind/bscontroller/config.cpp
@@ -1247,9 +1247,7 @@ namespace NKikimr::NBsController {
             if (groupInfo.BridgeProxyGroupId) {
                 groupInfo.BridgeProxyGroupId->CopyToProto(group, &NKikimrBlobStorage::TGroupInfo::SetBridgeProxyGroupId);
             }
-            if (groupInfo.BridgePileId) {
-                groupInfo.BridgePileId->CopyToProto(group, &NKikimrBlobStorage::TGroupInfo::SetBridgePileId);
-            }
+            groupInfo.BridgePileId.CopyToProto(group, &NKikimrBlobStorage::TGroupInfo::SetBridgePileId);
         }
 
         void TBlobStorageController::SerializeSettings(NKikimrBlobStorage::TUpdateSettings *settings) {

--- a/ydb/core/mind/bscontroller/config_fit_groups.cpp
+++ b/ydb/core/mind/bscontroller/config_fit_groups.cpp
@@ -108,7 +108,7 @@ namespace NKikimr {
                         false, /* down */
                         false, /* seenOperational */
                         0, /* groupSizeInUnits */
-                        std::nullopt, /* bridgePileId */
+                        TBridgePileId(), /* bridgePileId */
                         StoragePoolId, /* storagePoolId */
                         0, /* numFailRealms */
                         0, /* numFailDomainsPerFailRealm */
@@ -129,11 +129,11 @@ namespace NKikimr {
                         groupId.CopyToProto(&mainGroup, &NKikimrBlobStorage::TGroupInfo::AddBridgeGroupIds);
                     });
                 } else {
-                    CreateGroup(std::nullopt, std::nullopt); // regular single group
+                    CreateGroup(TBridgePileId(), std::nullopt); // regular single group
                 }
             }
 
-            TGroupId CreateGroup(std::optional<TBridgePileId> bridgePileId, std::optional<TGroupId> bridgeProxyGroupId) {
+            TGroupId CreateGroup(TBridgePileId bridgePileId, std::optional<TGroupId> bridgeProxyGroupId) {
                 ////////////////////////////////////////////////////////////////////////////////////////////
                 // ALLOCATE GROUP ID FOR THE NEW GROUP
                 ////////////////////////////////////////////////////////////////////////////////////////////
@@ -523,7 +523,7 @@ namespace NKikimr {
                 TGroupMapper::TForbiddenPDisks,
                 ui32,
                 i64,
-                std::optional<TBridgePileId>>;
+                TBridgePileId>;
 
             template<typename T>
             TAllocateOrSanitizeGroupResult<T> AllocateOrSanitizeGroup(
@@ -535,7 +535,7 @@ namespace NKikimr {
                     ui32 groupSizeInUnits,
                     i64 requiredSpace,
                     bool addExistingDisks,
-                    std::optional<TBridgePileId> bridgePileId,
+                    TBridgePileId bridgePileId,
                     T&& func) {
                 if (!Mapper) {
                     Mapper.emplace(Geometry, StoragePool.RandomizeGroupMapping);
@@ -577,7 +577,7 @@ namespace NKikimr {
                     ui32 groupSizeInUnits,
                     i64 requiredSpace,
                     bool addExistingDisks,
-                    std::optional<TBridgePileId> bridgePileId,
+                    TBridgePileId bridgePileId,
                     T&& func) {
                 TGroupMapper::TGroupConstraintsDefinition emptyConstraints;
                 return AllocateOrSanitizeGroup(groupId, group, emptyConstraints, replacedDisks, forbid, groupSizeInUnits, requiredSpace,
@@ -661,7 +661,7 @@ namespace NKikimr {
                     whyUnusable.append('D');
                 }
 
-                std::optional<TBridgePileId> bridgePileId;
+                TBridgePileId bridgePileId;
                 if (const auto& bridgeInfo = State.BridgeInfo) {
                     if (const TBridgeInfo::TPile *pile = bridgeInfo->GetPileForNode(id.NodeId)) {
                         bridgePileId = pile->BridgePileId;

--- a/ydb/core/mind/bscontroller/group_geometry_info.h
+++ b/ydb/core/mind/bscontroller/group_geometry_info.h
@@ -86,7 +86,7 @@ namespace NKikimr::NBsController {
         void AllocateGroup(TGroupMapper &mapper, TGroupId groupId, TGroupMapper::TGroupDefinition &group,
                 TGroupMapper::TGroupConstraintsDefinition& constrainsts,
                 const THashMap<TVDiskIdShort, TPDiskId>& replacedDisks, TGroupMapper::TForbiddenPDisks forbid,
-                ui32 groupSizeInUnits, i64 requiredSpace, std::optional<TBridgePileId> bridgePileId) const {
+                ui32 groupSizeInUnits, i64 requiredSpace, TBridgePileId bridgePileId) const {
             TString error;
             for (const bool requireOperational : {true, false}) {
                 if (mapper.AllocateGroup(groupId.GetRawId(), group, constrainsts, replacedDisks, forbid, groupSizeInUnits, requiredSpace,
@@ -101,7 +101,7 @@ namespace NKikimr::NBsController {
         std::pair<TVDiskIdShort, TPDiskId> SanitizeGroup(TGroupMapper &mapper, TGroupId groupId,
                 TGroupMapper::TGroupDefinition &group, TGroupMapper::TGroupConstraintsDefinition&,
                 const THashMap<TVDiskIdShort, TPDiskId>& /*replacedDisks*/, TGroupMapper::TForbiddenPDisks forbid,
-                ui32 groupSizeInUnits, i64 requiredSpace, std::optional<TBridgePileId> bridgePileId) const {
+                ui32 groupSizeInUnits, i64 requiredSpace, TBridgePileId bridgePileId) const {
             TString error;
             auto misplacedVDisks = mapper.FindMisplacedVDisks(group, groupSizeInUnits);
             if (misplacedVDisks.Disks.size() == 0) {

--- a/ydb/core/mind/bscontroller/group_mapper.h
+++ b/ydb/core/mind/bscontroller/group_mapper.h
@@ -63,7 +63,7 @@ namespace NKikimr {
                 const bool Operational;
                 const bool Decommitted;
                 TString WhyUnusable;
-                std::optional<TBridgePileId> BridgePileId;
+                TBridgePileId BridgePileId;
             };
 
         public:
@@ -101,9 +101,9 @@ namespace NKikimr {
             // prefix+infix part gives us distinct fail realms we can use while generating groups.
             bool AllocateGroup(ui32 groupId, TGroupDefinition& group, TGroupMapper::TGroupConstraintsDefinition& constraints,
                 const THashMap<TVDiskIdShort, TPDiskId>& replacedDisks, TForbiddenPDisks forbid, ui32 groupSizeInUnits, i64 requiredSpace,
-                bool requireOperational, std::optional<TBridgePileId> bridgePileId, TString& error);
+                bool requireOperational, TBridgePileId bridgePileId, TString& error);
             bool AllocateGroup(ui32 groupId, TGroupDefinition& group, const THashMap<TVDiskIdShort, TPDiskId>& replacedDisks,
-                TForbiddenPDisks forbid, ui32 groupSizeInUnits, i64 requiredSpace, bool requireOperational, std::optional<TBridgePileId> bridgePileId,
+                TForbiddenPDisks forbid, ui32 groupSizeInUnits, i64 requiredSpace, bool requireOperational, TBridgePileId bridgePileId,
                 TString& error);
 
             struct TMisplacedVDisks {
@@ -135,7 +135,7 @@ namespace NKikimr {
             TMisplacedVDisks FindMisplacedVDisks(const TGroupDefinition& group, ui32 groupSizeInUnits);
 
             std::optional<TPDiskId> TargetMisplacedVDisk(TGroupId groupId, TGroupDefinition& group, TVDiskIdShort vdisk,
-                TForbiddenPDisks forbid, ui32 groupSizeInUnits, i64 requiredSpace, bool requireOperational, std::optional<TBridgePileId> bridgePileId,
+                TForbiddenPDisks forbid, ui32 groupSizeInUnits, i64 requiredSpace, bool requireOperational, TBridgePileId bridgePileId,
                 TString& error);
         };
 

--- a/ydb/core/mind/bscontroller/group_mapper_ut.cpp
+++ b/ydb/core/mind/bscontroller/group_mapper_ut.cpp
@@ -195,7 +195,7 @@ public:
     ui32 AllocateGroup(TGroupMapper& mapper, TGroupMapper::TGroupDefinition& group, ui32 groupSizeInUnits = 0u, bool allowFailure = false) {
         ui32 groupId = NextGroupId++;
         TString error;
-        bool success = mapper.AllocateGroup(groupId, group, {}, {}, groupSizeInUnits, 0, false, std::nullopt, error);
+        bool success = mapper.AllocateGroup(groupId, group, {}, {}, groupSizeInUnits, 0, false, TBridgePileId(), error);
         if (!success && allowFailure) {
             Ctest << "error# " << error << Endl;
             return 0;
@@ -244,7 +244,7 @@ public:
 
         TString error;
         bool success = mapper.AllocateGroup(groupId, group.Group, replacedDisks, std::move(forbid), group.GroupSizeInUnits, 0,
-            requireOperational, std::nullopt, error);
+            requireOperational, TBridgePileId(), error);
         if (!success) {
             Ctest << "error# " << error << Endl;
             if (allowError) {
@@ -330,7 +330,7 @@ public:
             status = ESanitizeResult::FAIL;
             for (auto vdisk : result.Disks) {
                 auto target = mapper.TargetMisplacedVDisk(TGroupId::FromValue(groupId), group.Group, vdisk,
-                    std::move(forbid), 0, requireOperational, group.GroupSizeInUnits, std::nullopt, error);
+                    std::move(forbid), 0, requireOperational, group.GroupSizeInUnits, TBridgePileId(), error);
                 if (target) {
                     status = ESanitizeResult::SUCCESS;
                     if (movedDisk) {

--- a/ydb/core/mind/bscontroller/impl.h
+++ b/ydb/core/mind/bscontroller/impl.h
@@ -612,7 +612,7 @@ public:
 
         Table::GroupSizeInUnits::Type GroupSizeInUnits;
 
-        std::optional<Table::BridgePileId::Type> BridgePileId;
+        Table::BridgePileId::Type BridgePileId;
 
         TMaybe<Table::VirtualGroupName::Type> VirtualGroupName;
         TMaybe<Table::VirtualGroupState::Type> VirtualGroupState;
@@ -750,7 +750,7 @@ public:
                    Schema::Group::Down::Type down,
                    Schema::Group::SeenOperational::Type seenOperational,
                    Schema::Group::GroupSizeInUnits::Type groupSizeInUnits,
-                   std::optional<Schema::Group::BridgePileId::Type> bridgePileId,
+                   Schema::Group::BridgePileId::Type bridgePileId,
                    TBoxStoragePoolId storagePoolId,
                    ui32 numFailRealms,
                    ui32 numFailDomainsPerFailRealm,

--- a/ydb/core/mind/bscontroller/load_everything.cpp
+++ b/ydb/core/mind/bscontroller/load_everything.cpp
@@ -222,9 +222,7 @@ public:
                                                    groups.GetValueOrDefault<T::Down>(),
                                                    groups.GetValueOrDefault<T::SeenOperational>(),
                                                    groups.GetValueOrDefault<T::GroupSizeInUnits>(),
-                                                   groups.HaveValue<T::BridgePileId>()
-                                                       ? std::make_optional(groups.GetValue<T::BridgePileId>())
-                                                       : std::nullopt,
+                                                   groups.GetValueOrDefault<T::BridgePileId>(),
                                                    storagePoolId,
                                                    std::get<0>(geom),
                                                    std::get<1>(geom),
@@ -531,7 +529,7 @@ public:
                 for (size_t i = 0; i < proxyGroup->BridgeGroupInfo->BridgeGroupIdsSize(); ++i) {
                     auto *group = Self->FindGroup(TGroupId::FromValue(proxyGroup->BridgeGroupInfo->GetBridgeGroupIds(i)));
                     Y_ABORT_UNLESS(group);
-                    Y_ABORT_UNLESS(group->BridgePileId == TBridgePileId::FromValue(i));
+                    Y_ABORT_UNLESS(group->BridgePileId == TBridgePileId::FromPileIndex(i));
                     Y_ABORT_UNLESS(!group->BridgeProxyGroupId);
                     group->BridgeProxyGroupId = proxyGroupId;
                 }

--- a/ydb/core/mind/bscontroller/scheme.h
+++ b/ydb/core/mind/bscontroller/scheme.h
@@ -4,6 +4,7 @@
 #include "mood.h"
 
 namespace NKikimr {
+
 namespace NBsController {
 
 struct Schema : NIceDb::Schema {
@@ -69,7 +70,7 @@ struct Schema : NIceDb::Schema {
         struct SeenOperational : Column<14, NScheme::NTypeIds::Bool> { static constexpr Type Default = false; };
         struct DecommitStatus : Column<15, NScheme::NTypeIds::Uint32> { using Type = NKikimrBlobStorage::TGroupDecommitStatus::E; };
         struct GroupSizeInUnits : Column<16, NScheme::NTypeIds::Uint32> { static constexpr Type Default = 0; };
-        struct BridgePileId : Column<17, NScheme::NTypeIds::Uint32> { using Type = TBridgePileId; };
+        struct BridgePileId : Column<17, NScheme::NTypeIds::Uint32> { using Type = TBridgePileId; static constexpr Type Default = TBridgePileId(); };
 
         // VirtualGroup management code
         struct VirtualGroupName  : Column<112, NScheme::NTypeIds::Utf8>   {}; // unique name of the virtual group

--- a/ydb/core/mind/bscontroller/virtual_group.cpp
+++ b/ydb/core/mind/bscontroller/virtual_group.cpp
@@ -70,7 +70,7 @@ namespace NKikimr::NBsController {
         auto *group = Groups.ConstructInplaceNewEntry(TGroupId::FromValue(groupId.GetRaw()), TGroupId::FromValue(groupId.GetRaw()), 0u, 0u,
             TBlobStorageGroupType::ErasureNone, 0u, NKikimrBlobStorage::TVDiskKind::Default,
             pool.EncryptionMode.GetOrElse(TBlobStorageGroupInfo::EEM_NONE), TBlobStorageGroupInfo::ELCP_INITIAL,
-            TString(), TString(), 0u, 0u, false, false, 0u, std::nullopt, storagePoolId, 0u, 0u, 0u);
+            TString(), TString(), 0u, 0u, false, false, 0u, TBridgePileId(), storagePoolId, 0u, 0u, 0u);
 
         // bind group to storage pool
         ++pool.NumGroups;

--- a/ydb/core/mind/dynamic_nameserver.cpp
+++ b/ydb/core/mind/dynamic_nameserver.cpp
@@ -423,7 +423,7 @@ void TDynamicNameserver::SendNodesList(TActorId recipient, const TActorContext &
                                    pr.second.Port, pr.second.Location, true);
             if (newPileMap && BridgeInfo) {
                 if (const auto *pile = BridgeInfo->GetPileForNode(pr.first)) {
-                    newPileMap->at(pile->BridgePileId.GetRawId()).push_back(pr.first);
+                    newPileMap->at(pile->BridgePileId.GetPileIndex()).push_back(pr.first);
                 }
             }
         }

--- a/ydb/core/mind/hive/bridge_pile_info.h
+++ b/ydb/core/mind/hive/bridge_pile_info.h
@@ -30,7 +30,7 @@ struct TBridgePileInfo {
     }
 
     ui32 GetId() const {
-        return Id.GetRawId();
+        return Id.GetLocalDb();
     }
 };
 } // namespace NKikimr::NHive

--- a/ydb/core/mind/hive/hive_ut.cpp
+++ b/ydb/core/mind/hive/hive_ut.cpp
@@ -7825,13 +7825,13 @@ Y_UNIT_TEST_SUITE(THiveTest) {
             for (ui32 pile = 0; pile < 2; ++pile) {
                 BridgeInfos[pile] = std::make_shared<TBridgeInfo>();
                 BridgeInfos[pile]->Piles.push_back(TBridgeInfo::TPile{
-                    .BridgePileId = TBridgePileId::FromValue(0),
+                    .BridgePileId = TBridgePileId::FromPileIndex(0),
                     .State = NKikimrBridge::TClusterState::SYNCHRONIZED,
                     .IsPrimary = true,
                     .IsBeingPromoted = false,
                 });
                 BridgeInfos[pile]->Piles.push_back(TBridgeInfo::TPile{
-                    .BridgePileId = TBridgePileId::FromValue(1),
+                    .BridgePileId = TBridgePileId::FromPileIndex(1),
                     .State = NKikimrBridge::TClusterState::SYNCHRONIZED,
                     .IsPrimary = false,
                     .IsBeingPromoted = false,

--- a/ydb/core/mind/hive/node_info.h
+++ b/ydb/core/mind/hive/node_info.h
@@ -99,7 +99,7 @@ public:
     TString Name;
     ui64 DrainSeqNo = 0;
     std::optional<TLastScheduledTablet> LastScheduledTablet; // remembered for a limited time
-    TBridgePileId BridgePileId = TBridgePileId::FromValue(0);
+    TBridgePileId BridgePileId;
 
     TNodeInfo(TNodeId nodeId, THive& hive);
     TNodeInfo(const TNodeInfo&) = delete;

--- a/ydb/core/mind/hive/tx__load_everything.cpp
+++ b/ydb/core/mind/hive/tx__load_everything.cpp
@@ -314,7 +314,7 @@ public:
             }
             while (!bridgePileRowset.EndOfSet()) {
                 ++numPiles;
-                TBridgePileId pileId = TBridgePileId::FromValue(bridgePileRowset.GetValue<Schema::BridgePile::Id>());
+                TBridgePileId pileId = TBridgePileId::FromLocalDb(bridgePileRowset.GetValue<Schema::BridgePile::Id>());
                 auto& pileInfo = Self->GetPile(pileId);
                 pileInfo.State = bridgePileRowset.GetValue<Schema::BridgePile::State>();
                 pileInfo.IsPrimary = bridgePileRowset.GetValue<Schema::BridgePile::IsPrimary>();
@@ -360,7 +360,7 @@ public:
                     }
                 }
                 node.DrainSeqNo = nodeRowset.GetValueOrDefault<Schema::Node::DrainSeqNo>();
-                node.BridgePileId = TBridgePileId::FromValue(nodeRowset.GetValueOrDefault<Schema::Node::BridgePileId>());
+                node.BridgePileId = TBridgePileId::FromLocalDb(nodeRowset.GetValueOrDefault<Schema::Node::BridgePileId>());
                 if (!node.ServicedDomains) {
                     node.ServicedDomains = { Self->RootDomainKey };
                 }

--- a/ydb/core/mind/hive/tx__register_node.cpp
+++ b/ydb/core/mind/hive/tx__register_node.cpp
@@ -67,10 +67,9 @@ public:
             node.LastSeenServicedDomains = node.ServicedDomains;
             node.Name = name;
             if (Record.HasBridgePileId()) {
-                ui32 pileId = Record.GetBridgePileId();
-                node.BridgePileId = TBridgePileId::FromValue(pileId);
+                node.BridgePileId = TBridgePileId::FromProto(&Record, &decltype(Record)::GetBridgePileId);
                 Self->GetPile(node.BridgePileId).Nodes.insert(nodeId);
-                db.Table<Schema::Node>().Key(nodeId).Update<Schema::Node::BridgePileId>(pileId);
+                db.Table<Schema::Node>().Key(nodeId).Update<Schema::Node::BridgePileId>(node.BridgePileId.GetLocalDb());
             } else {
                 Y_ENSURE(!Self->BridgeInfo, "Running in bridge mode, but node " << nodeId << " has no pile");
             }

--- a/ydb/core/mind/hive/tx__update_pile.cpp
+++ b/ydb/core/mind/hive/tx__update_pile.cpp
@@ -45,7 +45,7 @@ public:
             pileInfo.State = wardenPileInfo.State;
             pileInfo.IsPrimary = wardenPileInfo.IsPrimary;
             pileInfo.IsPromoted = wardenPileInfo.IsBeingPromoted;
-            db.Table<Schema::BridgePile>().Key(pileId.GetRawId()).Update(
+            db.Table<Schema::BridgePile>().Key(pileId.GetLocalDb()).Update(
                 NIceDb::TUpdate<Schema::BridgePile::State>(pileInfo.State),
                 NIceDb::TUpdate<Schema::BridgePile::IsPrimary>(pileInfo.IsPrimary),
                 NIceDb::TUpdate<Schema::BridgePile::IsPromoted>(pileInfo.IsPromoted)

--- a/ydb/core/mind/local.cpp
+++ b/ydb/core/mind/local.cpp
@@ -84,7 +84,7 @@ class TLocalNodeRegistrar : public TActorBootstrapped<TLocalNodeRegistrar> {
     const TActorId Owner;
     const ui64 HiveId;
     TVector<TSubDomainKey> ServicedDomains;
-    std::optional<TBridgePileId> BridgePileId;
+    TBridgePileId BridgePileId;
 
     TActorId HivePipeClient;
     bool Connected;
@@ -209,9 +209,7 @@ class TLocalNodeRegistrar : public TActorBootstrapped<TLocalNodeRegistrar> {
         if (const TString& nodeName = AppData(ctx)->NodeName; !nodeName.empty()) {
             request->Record.SetName(nodeName);
         }
-        if (BridgePileId) {
-            request->Record.SetBridgePileId(BridgePileId->GetRawId());
-        }
+        BridgePileId.CopyToProto(&request->Record, &decltype(request->Record)::SetBridgePileId);
 
         NTabletPipe::SendData(ctx, HivePipeClient, request.Release());
 

--- a/ydb/core/node_whiteboard/node_whiteboard.h
+++ b/ydb/core/node_whiteboard/node_whiteboard.h
@@ -334,9 +334,7 @@ struct TEvWhiteboard {
             if (const auto& bridgeProxyGroupId = groupInfo->GetBridgeProxyGroupId()) {
                 bridgeProxyGroupId->CopyToProto(&Record, &decltype(Record)::SetBridgeProxyGroupId);
             }
-            if (const auto& bridgePileId = groupInfo->GetBridgePileId()) {
-                bridgePileId->CopyToProto(&Record, &decltype(Record)::SetBridgePileId);
-            }
+            groupInfo->GetBridgePileId().CopyToProto(&Record, &decltype(Record)::SetBridgePileId);
         }
     };
 

--- a/ydb/core/tablet_flat/flat_cxx_database.h
+++ b/ydb/core/tablet_flat/flat_cxx_database.h
@@ -390,6 +390,37 @@ struct TConvertValue<TColumnType, TIdWrapper<T, Tag>, TRawTypeValue> {
     operator TIdWrapper<T, Tag>() const { return TIdWrapper<T, Tag>::FromValue(static_cast<T>(Value)); }
 };
 
+////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+// TBridgePileId conversion
+
+template<typename TColumnType>
+struct TConvertValue<TColumnType, TRawTypeValue, TBridgePileId> {
+    static_assert(TColumnType::ColumnType == NScheme::NTypeIds::Uint32);
+
+    ui32 Storage;
+    TTypeValue Value;
+
+    TConvertValue(TBridgePileId value)
+        : Storage(value.GetLocalDb())
+        , Value(value ? TTypeValue(Storage) : TTypeValue())
+    {}
+
+    operator const TRawTypeValue&() const { return Value; }
+};
+
+template<typename TColumnType>
+struct TConvertValue<TColumnType, TBridgePileId, TRawTypeValue> {
+    TTypeValue Value;
+
+    TConvertValue(const TRawTypeValue& value)
+        : Value(value)
+    {}
+
+    operator TBridgePileId() const {
+        return Value.HaveValue() ? TBridgePileId::FromLocalDb(static_cast<ui32>(Value)) : TBridgePileId();
+    }
+};
+
 template <typename TColumnType, typename SourceType>
 struct TConvertValue<TColumnType, TRawTypeValue, SourceType> {
     TTypeValue Value;

--- a/ydb/core/viewer/storage_groups.h
+++ b/ydb/core/viewer/storage_groups.h
@@ -630,7 +630,7 @@ public:
     std::unordered_map<TVSlotId, const NKikimrSysView::TVSlotInfo*> VSlotsByVSlotId;
     std::unordered_map<TVSlotId, const NKikimrWhiteboard::TVDiskStateInfo*> VDisksByVSlotId;
     std::unordered_map<TPDiskId, const NKikimrWhiteboard::TPDiskStateInfo*> PDisksByPDiskId;
-    std::unordered_map<ui32, TString> PileNames;
+    std::unordered_map<TBridgePileId, TString> PileNames;
 
     TFieldsType FieldsRequested; // fields that were requested by user
     TFieldsType FieldsRequired; // fields that are required to calculate the response
@@ -1317,7 +1317,7 @@ public:
                     if (NodeWardenStorageConfigResponse->Get()->BridgeInfo) {
                         const auto& srcBridgeInfo = *NodeWardenStorageConfigResponse->Get()->BridgeInfo.get();
                         for (const auto& pile : srcBridgeInfo.Piles) {
-                            PileNames[pile.BridgePileId.GetRawId()] = pile.Name;
+                            PileNames[pile.BridgePileId] = pile.Name;
                         }
                     } else {
                         AddProblem("empty-node-warden-bridge-info");
@@ -1347,7 +1347,8 @@ public:
                     group.PutUserDataLatency = info.GetPutUserDataLatency();
                     group.GetFastLatency = info.GetGetFastLatency();
                     if (info.HasBridgePileId() && !PileNames.empty()) {
-                        group.PileName = PileNames[info.GetBridgePileId()];
+                        const auto bridgePileId = TBridgePileId::FromProto(&info, &NKikimrSysView::TGroupInfo::GetBridgePileId);
+                        group.PileName = PileNames[bridgePileId];
                         FieldsAvailable.set(+EGroupFields::PileName);
                     }
                 }

--- a/ydb/core/viewer/viewer_cluster.h
+++ b/ydb/core/viewer/viewer_cluster.h
@@ -358,7 +358,7 @@ private:
                     std::unordered_map<ui32, ui32> pileNodes;
                     for (const auto& pile : srcBridgeInfo.Piles) {
                         auto& pbBridgePileInfo = *pbBridgeInfo.AddPiles();
-                        pbBridgePileInfo.SetPileId(pile.BridgePileId.GetRawId());
+                        pile.BridgePileId.CopyToProto(&pbBridgePileInfo, &std::decay_t<decltype(pbBridgePileInfo)>::SetPileId);
                         pbBridgePileInfo.SetName(pile.Name);
                         pbBridgePileInfo.SetState(pile.State);
                         pbBridgePileInfo.SetIsPrimary(pile.IsPrimary);


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

Make BridgePileId natural number

### Changelog category <!-- remove all except one -->

* Not for changelog (changelog entry is not required)

### Description for reviewers <!-- (optional) description for those who read this PR -->

This patch makes bridge pile ids starting from 1, thus making zero value marked as unused/incorrect and allowing to drop optional around TBridgePileId.