### PR TITLE
Replace pages pinning with TSharedPageRef

### DIFF
--- a/ydb/core/tablet_flat/flat_exec_seat.h
+++ b/ydb/core/tablet_flat/flat_exec_seat.h
@@ -24,8 +24,6 @@ namespace NTabletFlatExecutor {
     };
 
     struct TSeat : public TIntrusiveListItem<TSeat> {
-        using TPinned = THashMap<TLogoBlobID, THashMap<ui32, TIntrusivePtr<TPrivatePageCachePinPad>>>;
-
         TSeat(const TSeat&) = delete;
 
         TSeat(ui32 uniqId, TAutoPtr<ITransaction> self)
@@ -73,7 +71,7 @@ namespace NTabletFlatExecutor {
         const TTxType TxType;
         NWilson::TSpan WaitingSpan;
         ui64 Retries = 0;
-        TPinned Pinned;
+        TPrivatePageCache::TPinned Pinned;
 
         THPTimer LatencyTimer;
         THPTimer CommitTimer;

--- a/ydb/core/tablet_flat/flat_executor.cpp
+++ b/ydb/core/tablet_flat/flat_executor.cpp
@@ -771,7 +771,7 @@ void TExecutor::DropSingleCache(const TLogoBlobID &label)
 }
 
 void TExecutor::TranslateCacheTouchesToSharedCache() {
-    auto touches = PrivatePageCache->GetPrepareSharedTouched();
+    auto touches = PrivatePageCache->GetSharedCacheTouches();
     if (touches.empty())
         return;
     Send(MakeSharedPageCacheId(), new NSharedCache::TEvTouch(std::move(touches)));
@@ -2085,6 +2085,7 @@ void TExecutor::UnpinTransactionPages(TSeat &seat) {
     Y_ENSURE(TransactionPagesMemory >= seat.MemoryTouched);
     TransactionPagesMemory -= seat.MemoryTouched;
 
+    PrivatePageCache->TouchSharedCache(seat.Pinned);
     seat.Pinned.clear();
     seat.MemoryTouched = 0;
 

--- a/ydb/core/tablet_flat/flat_executor.cpp
+++ b/ydb/core/tablet_flat/flat_executor.cpp
@@ -3048,7 +3048,6 @@ void TExecutor::Handle(NSharedCache::TEvResult::TPtr &ev) {
                 PrivatePageCache->ProvideBlock(loaded.PageId, loaded.Page, collectionInfo);
             }
             if (requestType == ESharedCacheRequestType::Transaction) {
-                Y_ASSERT(msg->Pages);
                 TryActivateWaitingTransaction(std::move(msg->WaitPad), std::move(msg->Pages), collectionInfo);
             }
         }

--- a/ydb/core/tablet_flat/flat_executor.h
+++ b/ydb/core/tablet_flat/flat_executor.h
@@ -547,9 +547,9 @@ class TExecutor
     void EnqueueActivation(TSeat* seat, bool activate);
     void PlanTransactionActivation();
     void MakeLogSnapshot();
-    void TryActivateWaitingTransaction(TIntrusivePtr<NPageCollection::TPagesWaitPad>&& waitPad);
-    void ActivateWaitingTransaction(TIntrusivePtr<NPageCollection::TPagesWaitPad>&& waitPad);
-    void LogWaitingTransaction(TIntrusivePtr<NPageCollection::TPagesWaitPad>&& waitPad);
+    void TryActivateWaitingTransaction(TIntrusivePtr<NPageCollection::TPagesWaitPad>&& waitPad, TVector<NSharedCache::TEvResult::TLoaded>&& pages, TPrivatePageCache::TInfo* collectionInfo);
+    void ActivateWaitingTransaction(TTransactionWaitPad& transaction);
+    void LogWaitingTransaction(const TTransactionWaitPad& transaction);
     void AddCachesOfBundle(const NTable::TPartView &partView);
     void AddSingleCache(const TIntrusivePtr<TPrivatePageCache::TInfo> &info);
     void DropCachesOfBundle(const NTable::TPart &part);

--- a/ydb/core/tablet_flat/flat_sausagecache.cpp
+++ b/ydb/core/tablet_flat/flat_sausagecache.cpp
@@ -306,6 +306,14 @@ THashMap<TLogoBlobID, TIntrusivePtr<TPrivatePageCache::TInfo>> TPrivatePageCache
 }
 
 void TPrivatePageCache::TouchSharedCache(const TPinned &pinned) {
+    // report all touched pages:
+    
+    // 1. these that were touched on this transaction retry
+    for (auto &page : Touches) {
+        SharedCacheTouches[page.Info->Id].insert(page.Id);
+    }
+
+    // 2. and these that were touched on previous transaction retries
     for (const auto& [pageCollectionId, pages] : pinned) {
         if (auto *info = Info(pageCollectionId)) {
             auto& touches = SharedCacheTouches[pageCollectionId];

--- a/ydb/core/tablet_flat/flat_sausagecache.h
+++ b/ydb/core/tablet_flat/flat_sausagecache.h
@@ -161,11 +161,13 @@ public:
 
     void ProvideBlock(TPageId pageId, TSharedPageRef sharedBody, TInfo *info);
     THashMap<TLogoBlobID, TIntrusivePtr<TInfo>> DetachPrivatePageCache();
-    THashMap<TLogoBlobID, THashSet<TPageId>> GetPrepareSharedTouched();
+
+    void TouchSharedCache(const TPinned &pinned);
+    THashMap<TLogoBlobID, THashSet<TPageId>> GetSharedCacheTouches();
 
 private:
     THashMap<TLogoBlobID, TIntrusivePtr<TInfo>> PageCollections;
-    THashMap<TLogoBlobID, THashSet<TPageId>> ToTouchShared;
+    THashMap<TLogoBlobID, THashSet<TPageId>> SharedCacheTouches;
 
     TStats Stats;
 

--- a/ydb/core/tablet_flat/flat_sausagecache.h
+++ b/ydb/core/tablet_flat/flat_sausagecache.h
@@ -1,5 +1,4 @@
 #pragma once
-#include "flat_page_iface.h"
 #include "flat_sausage_gut.h"
 #include "shared_handle.h"
 #include "shared_cache_events.h"
@@ -11,16 +10,10 @@ namespace NTabletFlatExecutor {
 
 using namespace NSharedCache;
 
-struct TPrivatePageCachePinPad : public TAtomicRefCount<TPrivatePageCachePinPad> {
-    // no internal state
-};
-
 class TPrivatePageCache {
-    using TPageId = NTable::NPage::TPageId;
-    using TPinned = THashMap<TLogoBlobID, THashMap<TPageId, TIntrusivePtr<TPrivatePageCachePinPad>>>;
-    using EPage = NTable::NPage::EPage;
-
 public:
+    using TPinned = THashMap<TLogoBlobID, THashMap<TPageId, TSharedPageRef>>;
+
     struct TInfo;
 
     struct TStats {
@@ -28,8 +21,6 @@ public:
         ui64 TotalSharedBody = 0; // total number of bytes currently referenced from shared cache
         ui64 TotalPinnedBody = 0; // total number of bytes currently pinned in memory
         ui64 TotalExclusive = 0; // total number of bytes exclusive to this cache (not from shared cache)
-        ui64 PinnedSetSize = 0; // number of bytes pinned by transactions (even those not currently loaded)
-        ui64 PinnedLoadSize = 0; // number of bytes pinned by transactions (which are currently being loaded)
         size_t CurrentCacheHits = 0; // = Touches.Size()
         ui64 CurrentCacheHitSize = 0; // = Touches.Where(t => !t.Sticky).Sum(t => t.Size)
         size_t CurrentCacheMisses = 0; // = ToLoad.Size()
@@ -47,7 +38,6 @@ public:
         const size_t Size;
 
         TInfo* const Info;
-        TIntrusivePtr<TPrivatePageCachePinPad> PinPad;
         TSharedPageRef SharedBody;
         TSharedData PinnedBody;
 
@@ -59,7 +49,6 @@ public:
         bool IsUnnecessary() const noexcept {
             return (
                 LoadState == LoadStateNo &&
-                !PinPad &&
                 !SharedBody);
         }
 
@@ -160,16 +149,17 @@ public:
 
     const TSharedData* Lookup(TPageId pageId, TInfo *collection);
 
-    void CountTouches(TPinned &pinned, ui32 &newPages, ui64 &newMemory, ui64 &pinnedMemory);
+    void CountTouches(TPinned &pinned, ui32 &touchedUnpinnedPages, ui64 &touchedUnpinnedMemory, ui64 &touchedPinnedMemory);
     void PinTouches(TPinned &pinned, ui32 &touchedPages, ui32 &pinnedPages, ui64 &pinnedMemory);
-    void PinToLoad(TPinned &pinned, ui32 &pinnedPages, ui64 &pinnedMemory);
-    void UnpinPages(TPinned &pinned, size_t &unpinnedPages);
+
+    void CountToLoad(TPinned &pinned, ui32 &toLoadPages, ui64 &toLoadMemory);
     THashMap<TPrivatePageCache::TInfo*, TVector<TPageId>> GetToLoad() const;
+
     void ResetTouchesAndToLoad(bool verifyEmpty);
 
     void DropSharedBody(TInfo *collectionInfo, TPageId pageId);
 
-    void ProvideBlock(NSharedCache::TEvResult::TLoaded&& loaded, TInfo *collectionInfo);
+    void ProvideBlock(TPageId pageId, TSharedPageRef sharedBody, TInfo *info);
     THashMap<TLogoBlobID, TIntrusivePtr<TInfo>> DetachPrivatePageCache();
     THashMap<TLogoBlobID, THashSet<TPageId>> GetPrepareSharedTouched();
 
@@ -181,9 +171,6 @@ private:
 
     TIntrusiveList<TPage> Touches;
     TIntrusiveList<TPage> ToLoad;
-
-    TIntrusivePtr<TPrivatePageCachePinPad> Pin(TPage *page);
-    void Unpin(TPage *page, TPrivatePageCachePinPad *pad);
 
     void TryLoad(TPage *page);
     void TryUnload(TPage *page);

--- a/ydb/core/tablet_flat/shared_cache_events.h
+++ b/ydb/core/tablet_flat/shared_cache_events.h
@@ -125,12 +125,12 @@ namespace NKikimr::NSharedCache {
         }
 
         struct TLoaded {
-            TLoaded(ui32 pageId, TSharedPageRef page)
+            TLoaded(TPageId pageId, TSharedPageRef page)
                 : PageId(pageId)
                 , Page(std::move(page))
             { }
 
-            ui32 PageId;
+            TPageId PageId;
             TSharedPageRef Page;
         };
 

--- a/ydb/core/tablet_flat/shared_page.h
+++ b/ydb/core/tablet_flat/shared_page.h
@@ -7,6 +7,7 @@
 namespace NKikimr::NSharedCache {
 
 using TPageId = NTable::NPage::TPageId;
+using EPage = NTable::NPage::EPage;
 
 struct TCollection;
 

--- a/ydb/core/tablet_flat/ut/ut_shared_sausagecache.cpp
+++ b/ydb/core/tablet_flat/ut/ut_shared_sausagecache.cpp
@@ -1091,7 +1091,7 @@ Y_UNIT_TEST(ZeroCache_FlatIndex) {
 
 }
 
-Y_UNIT_TEST_SUITE(TSharedPageCache_WaitPads) {
+Y_UNIT_TEST_SUITE(TSharedPageCache_Transactions) {
 
 void BasicSetup(TMyEnvBase& env) {
     env->SetLogPriority(NKikimrServices::TABLET_SAUSAGECACHE, NActors::NLog::PRI_TRACE);


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

...

### Changelog category <!-- remove all except one -->

* Not for changelog (changelog entry is not required)

### Description for reviewers <!-- (optional) description for those who read this PR -->

Instead of keeping `TPrivatePageCachePinPad` on pinned pages, keep used `TSharedPageRef` in transaction `TSeat`
