### PR TITLE
Optimizing transactions in PQ

### DIFF
--- a/ydb/core/jaeger_tracing/request_discriminator.cpp
+++ b/ydb/core/jaeger_tracing/request_discriminator.cpp
@@ -95,6 +95,7 @@ extern const THashMap<TStringBuf, ERequestType> NameToRequestType = {
     {"Topic.DescribeConsumer", ERequestType::TOPIC_DESCRIBECONSUMER},
     {"Topic.AlterTopic", ERequestType::TOPIC_ALTERTOPIC},
     {"Topic.DropTopic", ERequestType::TOPIC_DROPTOPIC},
+    {"Topic.Transaction", ERequestType::TOPIC_PROPOSE_TRANSACTION},
 };
 
 extern const THashSet<ERequestType> NoDefaultSamplingRequestTypes = {

--- a/ydb/core/jaeger_tracing/request_discriminator.h
+++ b/ydb/core/jaeger_tracing/request_discriminator.h
@@ -111,6 +111,7 @@ enum class ERequestType: size_t {
     TOPIC_DESCRIBECONSUMER,
     TOPIC_ALTERTOPIC,
     TOPIC_DROPTOPIC,
+    TOPIC_PROPOSE_TRANSACTION,
 
     REQUEST_TYPES_CNT, // Add new types above this line
 };

--- a/ydb/core/kqp/session_actor/kqp_session_actor.cpp
+++ b/ydb/core/kqp/session_actor/kqp_session_actor.cpp
@@ -533,6 +533,17 @@ public:
     bool AreAllTheTopicsAndPartitionsKnown() const {
         if (QueryState->HasTopicOperations()) {
             const NKikimrKqp::TTopicOperationsRequest& operations = QueryState->GetTopicOperationsFromRequest();
+
+            if (operations.HasTabletId()) {
+                for (const auto& topic : operations.GetTopics()) {
+                    auto path = CanonizePath(NPersQueue::GetFullTopicPath(QueryState->GetDatabase(), topic.path()));
+                    for (const auto& partition : topic.partitions()) {
+                        QueryState->TxCtx->TopicOperations.SetTabletId(path, partition.partition_id(), operations.GetTabletId());
+                    }
+                }
+                return true;
+            }
+
             for (const auto& topic : operations.GetTopics()) {
                 auto path = CanonizePath(NPersQueue::GetFullTopicPath(QueryState->GetDatabase(), topic.path()));
 
@@ -554,6 +565,7 @@ public:
                 }
             }
         }
+
         return true;
     }
 

--- a/ydb/core/kqp/topics/kqp_topics.cpp
+++ b/ydb/core/kqp/topics/kqp_topics.cpp
@@ -302,7 +302,10 @@ bool TTopicPartitionOperations::HasTabletId() const
 
 void TTopicPartitionOperations::SetTabletId(ui64 value)
 {
-    Y_ENSURE(TabletId_.Empty());
+    if (!TabletId_.Empty()) {
+        Y_ENSURE(TabletId_ == value);
+        return;
+    }
 
     TabletId_ = value;
 }
@@ -585,6 +588,13 @@ bool TTopicOperations::HasThisPartitionAlreadyBeenAdded(const TString& topicPath
     }
 
     return false;
+}
+
+void TTopicOperations::SetTabletId(const TString& topicPath, ui32 partitionId,
+                                   ui64 tabletId)
+{
+    TTopicPartition key{topicPath, partitionId};
+    Operations_[key].SetTabletId(tabletId);
 }
 
 void TTopicOperations::CacheSchemeCacheNavigate(const NSchemeCache::TSchemeCacheNavigate::TResultSet& results)

--- a/ydb/core/kqp/topics/kqp_topics.h
+++ b/ydb/core/kqp/topics/kqp_topics.h
@@ -180,6 +180,9 @@ public:
 
     bool HasThisPartitionAlreadyBeenAdded(const TString& topic, ui32 partitionId);
 
+    void SetTabletId(const TString& topic, ui32 partition,
+                     ui64 tabletId);
+
 private:
     THashMap<TTopicPartition, TTopicPartitionOperations, TTopicPartition::THash> Operations_;
     bool HasReadOperations_ = false;

--- a/ydb/core/persqueue/events/global.h
+++ b/ydb/core/persqueue/events/global.h
@@ -250,6 +250,7 @@ namespace TEvPersQueue {
     };
 
     struct TEvProposeTransaction : public TEventPreSerializedPB<TEvProposeTransaction, NKikimrPQ::TEvProposeTransaction, EvProposeTransaction> {
+        NWilson::TSpan ExecuteSpan;
     };
 
     struct TEvProposeTransactionBuilder: public TEvProposeTransaction {

--- a/ydb/core/persqueue/events/internal.h
+++ b/ydb/core/persqueue/events/internal.h
@@ -846,6 +846,8 @@ struct TEvPQ {
         TVector<NKikimrPQ::TPartitionOperation> Operations;
         TActorId SupportivePartitionActor;
         bool ForcePredicateFalse = false;
+
+        NWilson::TSpan Span;
     };
 
     struct TEvTxCalcPredicateResult : public TEventLocal<TEvTxCalcPredicateResult, EvTxCalcPredicateResult> {
@@ -903,6 +905,8 @@ struct TEvPQ {
         ui64 TxId;
 
         TMessageGroupsPtr ExplicitMessageGroups;
+
+        NWilson::TSpan Span;
     };
 
     struct TEvTxCommitDone : public TEventLocal<TEvTxCommitDone, EvTxCommitDone> {
@@ -916,6 +920,8 @@ struct TEvPQ {
         ui64 Step;
         ui64 TxId;
         NPQ::TPartitionId Partition;
+
+        NWilson::TSpan Span;
     };
 
     struct TEvTxRollback : public TEventLocal<TEvTxRollback, EvTxRollback> {
@@ -927,6 +933,8 @@ struct TEvPQ {
 
         ui64 Step;
         ui64 TxId;
+
+        NWilson::TSpan Span;
     };
 
     struct TEvSubDomainStatus : public TEventPB<TEvSubDomainStatus, NKikimrPQ::TEvSubDomainStatus, EvSubDomainStatus> {
@@ -1091,6 +1099,8 @@ struct TEvPQ {
 
     struct TEvGetWriteInfoRequest : public TEventLocal<TEvGetWriteInfoRequest, EvGetWriteInfoRequest> {
         TActorId OriginalPartition;
+
+        NWilson::TSpan Span;
     };
 
     struct TEvGetWriteInfoResponse : public TEventLocal<TEvGetWriteInfoResponse, EvGetWriteInfoResponse> {

--- a/ydb/core/persqueue/partition.cpp
+++ b/ydb/core/persqueue/partition.cpp
@@ -4,6 +4,7 @@
 #include "partition_util.h"
 #include "partition.h"
 #include "partition_log.h"
+#include "tracing_support.h"
 
 #include <ydb/library/wilson_ids/wilson.h>
 #include <ydb/core/base/appdata.h>
@@ -15,6 +16,7 @@
 #include <ydb/core/protos/counters_pq.pb.h>
 #include <ydb/core/protos/msgbus.pb.h>
 #include <ydb/library/persqueue/topic_parser/topic_parser.h>
+#include <ydb/library/wilson_ids/wilson.h>
 #include <ydb/public/lib/base/msgbus.h>
 #include <library/cpp/html/pcdata/pcdata.h>
 #include <library/cpp/monlib/service/pages/templates.h>
@@ -274,7 +276,9 @@ void AddCheckDiskRequest(TEvKeyValue::TEvRequest *request, ui32 numChannels) {
 TPartition::TPartition(ui64 tabletId, const TPartitionId& partition, const TActorId& tablet, ui32 tabletGeneration, const TActorId& blobCache,
                        const NPersQueue::TTopicConverterPtr& topicConverter, TString dcId, bool isServerless,
                        const NKikimrPQ::TPQTabletConfig& tabletConfig, const TTabletCountersBase& counters, bool subDomainOutOfSpace, ui32 numChannels,
-                       const TActorId& writeQuoterActorId, bool newPartition, TVector<TTransaction> distrTxs)
+                       const TActorId& writeQuoterActorId,
+                       TIntrusivePtr<NJaegerTracing::TSamplingThrottlingControl> samplingControl,
+                       bool newPartition)
     : Initializer(this)
     , TabletID(tabletId)
     , TabletGeneration(tabletGeneration)
@@ -316,24 +320,9 @@ TPartition::TPartition(ui64 tabletId, const TPartitionId& partition, const TActo
     , WriteBufferIsFullCounter(nullptr)
     , WriteLagMs(TDuration::Minutes(1), 100)
     , LastEmittedHeartbeat(TRowVersion::Min())
+    , SamplingControl(samplingControl)
 {
     TabletCounters.Populate(Counters);
-
-    if (!distrTxs.empty()) {
-        for (auto& tx : distrTxs) {
-            if (!tx.Predicate.Defined()) {
-                UserActionAndTransactionEvents.emplace_back(MakeSimpleShared<TTransaction>(std::move(tx)));
-            } else if (*tx.Predicate) {
-                auto txId = tx.GetTxId();
-                auto txPtr = MakeSimpleShared<TTransaction>(std::move(tx));
-                BatchingState = ETxBatchingState::Executing;
-                if (txId.Defined()) {
-                    TransactionsInflight.insert(std::make_pair(*txId, txPtr));
-                }
-                UserActionAndTxPendingCommit.emplace_back(std::move(txPtr));
-            }
-        }
-    }
 }
 
 void TPartition::EmplaceResponse(TMessage&& message, const TActorContext& ctx) {
@@ -1194,6 +1183,14 @@ void TPartition::Handle(TEvPQ::TEvTxCalcPredicate::TPtr& ev, const TActorContext
              " Step " << ev->Get()->Step <<
              ", TxId " << ev->Get()->TxId);
 
+    ev->Get()->Span = NWilson::TSpan(TWilsonTopic::TopicTopLevel,
+                                     std::move(ev->TraceId),
+                                     "Topic.Partition.CalcPredicate",
+                                     NWilson::EFlags::AUTO_END);
+    auto span = ev->Get()->Span.CreateChild(TWilsonTopic::TopicTopLevel,
+                                            "Topic.Partition.ProcessEvent",
+                                            NWilson::EFlags::AUTO_END);
+
     ProcessPendingEvent(ev, ctx);
 }
 
@@ -1227,6 +1224,8 @@ void TPartition::ProcessPendingEvent(std::unique_ptr<TEvPQ::TEvTxCommit> ev, con
                        "PQ: %" PRIu64 ", Partition: %" PRIu32 ", Step: %" PRIu64 ", TxId: %" PRIu64,
                        TabletID, Partition.OriginalPartitionId,
                        ev->Step, ev->TxId);
+
+        txIter->second->CommitSpan = std::move(ev->Span);
     }
     Y_ABORT_UNLESS(txIter->second->State == ECommitState::Pending);
 
@@ -1239,6 +1238,14 @@ void TPartition::Handle(TEvPQ::TEvTxCommit::TPtr& ev, const TActorContext& ctx)
     PQ_LOG_D("Handle TEvPQ::TEvTxCommit" <<
              " Step " << ev->Get()->Step <<
              ", TxId " << ev->Get()->TxId);
+
+    ev->Get()->Span = NWilson::TSpan(TWilsonTopic::TopicTopLevel,
+                                     std::move(ev->TraceId),
+                                     "Topic.Partition.Commit",
+                                     NWilson::EFlags::AUTO_END);
+    auto span = ev->Get()->Span.CreateChild(TWilsonTopic::TopicTopLevel,
+                                            "Topic.Partition.ProcessEvent",
+                                            NWilson::EFlags::AUTO_END);
 
     ProcessPendingEvent(ev, ctx);
 }
@@ -1321,6 +1328,10 @@ void TPartition::Handle(TEvPQ::TEvGetWriteInfoRequest::TPtr& ev, const TActorCon
     PQ_LOG_D("Handle TEvPQ::TEvGetWriteInfoRequest");
 
     ev->Get()->OriginalPartition = ev->Sender;
+    ev->Get()->Span = NWilson::TSpan(TWilsonTopic::TopicTopLevel,
+                                     std::move(ev->TraceId),
+                                     "Topic.Partition.GetWriteInfo",
+                                     NWilson::EFlags::AUTO_END);
 
     ProcessPendingEvent(ev, ctx);
 }
@@ -1334,6 +1345,13 @@ void TPartition::WriteInfoResponseHandler(
     Y_ABORT_UNLESS(!txIter.IsEnd());
 
     auto& tx = (*txIter->second);
+
+    PQ_LOG_TX_D("Received TEvGetWriteInfoResponse for TxId " << tx.GetTxId());
+
+    tx.GetWriteInfoSpan.End();
+    tx.GetWriteInfoSpan = {};
+
+    tx.WriteInfoResponseTimestamp = Now();
 
     std::visit(TOverloaded{
         [&tx](TAutoPtr<TEvPQ::TEvGetWriteInfoResponse>& msg) {
@@ -1372,6 +1390,7 @@ TPartition::EProcessResult TPartition::ApplyWriteInfoResponse(TTransaction& tx) 
     THashSet<TString> txSourceIds;
     for (auto& s : srcIdInfo) {
         if (TxAffectedSourcesIds.contains(s.first)) {
+            PQ_LOG_TX_D("TxAffectedSourcesIds contains SourceId " << s.first << ". TxId " << tx.GetTxId());
             ret = EProcessResult::Blocked;
             break;
         }
@@ -1379,10 +1398,12 @@ TPartition::EProcessResult TPartition::ApplyWriteInfoResponse(TTransaction& tx) 
             WriteAffectedSourcesIds.insert(s.first);
         } else {
             if (WriteAffectedSourcesIds.contains(s.first)) {
+                PQ_LOG_TX_D("WriteAffectedSourcesIds contains SourceId " << s.first << ". TxId " << tx.GetTxId());
                 ret = EProcessResult::Blocked;
                 break;
             }
             txSourceIds.insert(s.first);
+            PQ_LOG_D("Tx " << tx.GetTxId() << " affect SourceId " << s.first);
         }
 
         if (auto inFlightIter = TxInflightMaxSeqNoPerSourceId.find(s.first); !inFlightIter.IsEnd()) {
@@ -1452,8 +1473,18 @@ void TPartition::Handle(TEvPQ::TEvGetWriteInfoError::TPtr& ev, const TActorConte
 void TPartition::ReplyToProposeOrPredicate(TSimpleSharedPtr<TTransaction>& tx, bool isPredicate) {
 
     if (isPredicate) {
+        tx->CalcPredicateSpan.End();
+        tx->CalcPredicateSpan = {};
+
         auto insRes = TransactionsInflight.emplace(tx->Tx->TxId, tx);
         Y_ABORT_UNLESS(insRes.second);
+
+        if ((Now() - tx->WriteInfoResponseTimestamp) >= TDuration::Seconds(1)) {
+            PQ_LOG_TX_D("The long answer to TEvTxCalcPredicate. TxId: " << tx->GetTxId());
+        }
+
+        PQ_LOG_TX_D("Send TEvTxCalcPredicateResult. TxId: " << tx->GetTxId());
+
         Send(Tablet,
              MakeHolder<TEvPQ::TEvTxCalcPredicateResult>(tx->Tx->Step,
                                                          tx->Tx->TxId,
@@ -1462,6 +1493,7 @@ void TPartition::ReplyToProposeOrPredicate(TSimpleSharedPtr<TTransaction>& tx, b
     } else {
         auto insRes = TransactionsInflight.emplace(tx->ProposeConfig->TxId, tx);
         Y_ABORT_UNLESS(insRes.second);
+
         auto result = MakeHolder<TEvPQ::TEvProposePartitionConfigResult>(tx->ProposeConfig->Step,
                                                                 tx->ProposeConfig->TxId,
                                                                 Partition);
@@ -1948,7 +1980,10 @@ void TPartition::RequestWriteInfoIfRequired()
     auto tx = std::get<1>(UserActionAndTransactionEvents.back().Event);
     auto supportId = tx->SupportivePartitionActor;
     if (supportId) {
-        Send(supportId, new TEvPQ::TEvGetWriteInfoRequest());
+        PQ_LOG_TX_D("Send TEvGetWriteInfoRequest for TxId " << tx->GetTxId());
+        Send(supportId, new TEvPQ::TEvGetWriteInfoRequest(),
+             0, 0,
+             tx->CalcPredicateSpan.GetTraceId());
         WriteInfosToTx.insert(std::make_pair(supportId, tx));
     }
 }
@@ -2006,6 +2041,7 @@ size_t TPartition::GetUserActCount(const TString& consumer) const
 void TPartition::ProcessTxsAndUserActs(const TActorContext& ctx)
 {
     if (KVWriteInProgress) {
+        PQ_LOG_D("Can't process txs");
         return;
     }
     if (DeletePartitionState == DELETION_INITED) {
@@ -2026,13 +2062,16 @@ void TPartition::ProcessTxsAndUserActs(const TActorContext& ctx)
 
         return;
     }
+    PQ_LOG_D("Batching state before ContinueProcessTxsAndUserActs: " << (int)BatchingState);
     while (true) {
-        if (BatchingState == ETxBatchingState::PreProcessing) {
+        if (CanProcessUserActionAndTransactionEvents()) {
             ContinueProcessTxsAndUserActs(ctx);
         }
         if (BatchingState == ETxBatchingState::PreProcessing) {
+            PQ_LOG_D("Still preprocessing - waiting for something");
             return; // Still preprocessing - waiting for something;
         }
+        PQ_LOG_D("Batching state after ContinueProcessTxsAndUserActs: " << (int)BatchingState);
 
         // Preprocessing complete;
         if (CurrentBatchSize > 0) {
@@ -2049,6 +2088,7 @@ void TPartition::ProcessTxsAndUserActs(const TActorContext& ctx)
         }
         if (!UserActionAndTxPendingCommit.empty()) {
             // Still pending for come commits
+            PQ_LOG_D("Still pending for come commits");
             return;
         }
         // Commit queue processing complete. Now can either swith to persist or continue preprocessing;
@@ -2058,6 +2098,13 @@ void TPartition::ProcessTxsAndUserActs(const TActorContext& ctx)
         }
         BatchingState = ETxBatchingState::PreProcessing;
     }
+}
+
+bool TPartition::CanProcessUserActionAndTransactionEvents() const
+{
+    return
+        (BatchingState == ETxBatchingState::PreProcessing) ||
+        (BatchingState == ETxBatchingState::Executing);
 }
 
 void TPartition::ContinueProcessTxsAndUserActs(const TActorContext&)
@@ -2071,7 +2118,7 @@ void TPartition::ContinueProcessTxsAndUserActs(const TActorContext&)
     auto visitor = [this](auto& event) {
         return this->PreProcessUserActionOrTransaction(event);
     };
-    while (BatchingState == ETxBatchingState::PreProcessing && !UserActionAndTransactionEvents.empty()) {
+    while (CanProcessUserActionAndTransactionEvents() && !UserActionAndTransactionEvents.empty()) {
         if (ChangingConfig) {
             BatchingState = ETxBatchingState::Finishing;
             break;
@@ -2233,10 +2280,20 @@ void TPartition::RunPersist() {
         WriteInfosApplied.clear();
         //Done with counters.
 
+        for (auto& traceId : TxForPersistTraceIds) {
+            TxForPersistSpans.emplace_back(TWilsonTopic::TopicTopLevel,
+                                           std::move(traceId),
+                                           "Topic.Partition.TxPersistRequest",
+                                           NWilson::EFlags::AUTO_END);
+            AttachPersistRequestSpan(TxForPersistSpans.back());
+        }
+        TxForPersistTraceIds.clear();
+
         PersistRequestSpan.Attribute("bytes", static_cast<i64>(PersistRequest->Record.ByteSizeLong()));
         ctx.Send(HaveWriteMsg ? BlobCache : Tablet, PersistRequest.Release(), 0, 0, PersistRequestSpan.GetTraceId());
         CurrentPersistRequestSpan = std::move(PersistRequestSpan);
         PersistRequestSpan = NWilson::TSpan();
+
         KVWriteInProgress = true;
     } else {
         OnProcessTxsAndUserActsWriteComplete(ActorContext());
@@ -2318,13 +2375,19 @@ void TPartition::AnswerCurrentReplies(const TActorContext& ctx)
 
 TPartition::EProcessResult TPartition::PreProcessUserActionOrTransaction(TSimpleSharedPtr<TTransaction>& t)
 {
+    auto span = t->CalcPredicateSpan.CreateChild(TWilsonTopic::TopicTopLevel,
+                                                 "Topic.Partition.PreProcess",
+                                                 NWilson::EFlags::AUTO_END);
+
     auto result = EProcessResult::Continue;
     if (t->SupportivePartitionActor && !t->WriteInfo && !t->WriteInfoApplied) { // Pending for write info
+        PQ_LOG_TX_D("The Tx " << t->GetTxId() << " is waiting for TEvGetWriteInfoResponse");
         return EProcessResult::NotReady;
     }
     if (t->WriteInfo && !t->WriteInfoApplied) { //Recieved write info but not applied
         result = ApplyWriteInfoResponse(*t);
         if (!t->WriteInfoApplied) { // Tried to apply write info but couldn't - TX must be blocked.
+            PQ_LOG_TX_D("The Tx " << t->GetTxId() << " must be blocked");
             Y_ABORT_UNLESS(result != EProcessResult::Continue);
             return result;
         }
@@ -2375,6 +2438,10 @@ TPartition::EProcessResult TPartition::PreProcessUserActionOrTransaction(TSimple
 
 bool TPartition::ExecUserActionOrTransaction(TSimpleSharedPtr<TTransaction>& t, TEvKeyValue::TEvRequest*)
 {
+    auto span = t->CommitSpan.CreateChild(TWilsonTopic::TopicTopLevel,
+                                          "Topic.Partition.Process",
+                                          NWilson::EFlags::AUTO_END);
+
     if (t->ProposeTransaction) {
         ExecImmediateTx(*t);
         return true;
@@ -2418,22 +2485,24 @@ TPartition::EProcessResult TPartition::BeginTransaction(const TEvPQ::TEvTxCalcPr
     for (auto& operation : tx.Operations) {
         const TString& consumer = operation.GetConsumer();
         if (TxAffectedConsumers.contains(consumer)) {
+            PQ_LOG_TX_D("TxAffectedConsumers contains consumer " << consumer << ". TxId " << tx.TxId);
             return EProcessResult::Blocked;
         }
         if (SetOffsetAffectedConsumers.contains(consumer)) {
+            PQ_LOG_TX_D("SetOffsetAffectedConsumers contains consumer " << consumer << ". TxId " << tx.TxId);
             return EProcessResult::Blocked;
         }
 
         if (AffectedUsers.contains(consumer) && !GetPendingUserIfExists(consumer)) {
             PQ_LOG_D("Partition " << Partition <<
-                    " Consumer '" << consumer << "' has been removed");
+                     " Consumer '" << consumer << "' has been removed");
             result = false;
             break;
         }
 
         if (!UsersInfoStorage->GetIfExists(consumer)) {
             PQ_LOG_D("Partition " << Partition <<
-                        " Unknown consumer '" << consumer << "'");
+                     " Unknown consumer '" << consumer << "'");
             result = false;
             break;
         }
@@ -2448,34 +2517,34 @@ TPartition::EProcessResult TPartition::BeginTransaction(const TEvPQ::TEvTxCalcPr
         } else if (!operation.GetReadSessionId().empty() && operation.GetReadSessionId() != userInfo.Session) {
             if (IsActive() || operation.GetCommitOffsetsEnd() < EndOffset || userInfo.Offset != i64(EndOffset)) {
                 PQ_LOG_D("Partition " << Partition <<
-                    " Consumer '" << consumer << "'" <<
-                    " Bad request (session already dead) " <<
-                    " RequestSessionId '" << operation.GetReadSessionId() <<
-                    " CurrentSessionId '" << userInfo.Session <<
-                    "'");
+                         " Consumer '" << consumer << "'" <<
+                         " Bad request (session already dead) " <<
+                         " RequestSessionId '" << operation.GetReadSessionId() <<
+                         " CurrentSessionId '" << userInfo.Session <<
+                         "'");
                 result = false;
             }
         } else {
             if (!operation.GetForceCommit() && operation.GetCommitOffsetsBegin() > operation.GetCommitOffsetsEnd()) {
                 PQ_LOG_D("Partition " << Partition <<
-                            " Consumer '" << consumer << "'" <<
-                            " Bad request (invalid range) " <<
-                            " Begin " << operation.GetCommitOffsetsBegin() <<
-                            " End " << operation.GetCommitOffsetsEnd());
+                         " Consumer '" << consumer << "'" <<
+                         " Bad request (invalid range) " <<
+                         " Begin " << operation.GetCommitOffsetsBegin() <<
+                         " End " << operation.GetCommitOffsetsEnd());
                 result = false;
             } else if (!operation.GetForceCommit() && userInfo.Offset != (i64)operation.GetCommitOffsetsBegin()) {
                 PQ_LOG_D("Partition " << Partition <<
-                            " Consumer '" << consumer << "'" <<
-                            " Bad request (gap) " <<
-                            " Offset " << userInfo.Offset <<
-                            " Begin " << operation.GetCommitOffsetsBegin());
+                         " Consumer '" << consumer << "'" <<
+                         " Bad request (gap) " <<
+                         " Offset " << userInfo.Offset <<
+                         " Begin " << operation.GetCommitOffsetsBegin());
                 result = false;
             } else if (!operation.GetForceCommit() && operation.GetCommitOffsetsEnd() > EndOffset) {
                 PQ_LOG_D("Partition " << Partition <<
-                            " Consumer '" << consumer << "'" <<
-                            " Bad request (behind the last offset) " <<
-                            " EndOffset " << EndOffset <<
-                            " End " << operation.GetCommitOffsetsEnd());
+                         " Consumer '" << consumer << "'" <<
+                         " Bad request (behind the last offset) " <<
+                         " EndOffset " << EndOffset <<
+                         " End " << operation.GetCommitOffsetsEnd());
                 result = false;
             }
 
@@ -2486,6 +2555,7 @@ TPartition::EProcessResult TPartition::BeginTransaction(const TEvPQ::TEvTxCalcPr
                 break;
             }
             consumers.insert(consumer);
+            PQ_LOG_TX_D("Tx " << tx.TxId << " affect consumer " << consumer);
         }
     }
 
@@ -2696,7 +2766,7 @@ void TPartition::CommitTransaction(TSimpleSharedPtr<TTransaction>& t)
 
         CommitWriteOperations(*t);
         ChangePlanStepAndTxId(t->Tx->Step, t->Tx->TxId);
-        ScheduleReplyCommitDone(t->Tx->Step, t->Tx->TxId);
+        ScheduleReplyCommitDone(t->Tx->Step, t->Tx->TxId, std::move(t->CommitSpan));
     } else if (t->ProposeConfig) {
         Y_ABORT_UNLESS(t->Predicate.Defined() && *t->Predicate);
 
@@ -2704,7 +2774,7 @@ void TPartition::CommitTransaction(TSimpleSharedPtr<TTransaction>& t)
         ExecChangePartitionConfig();
         ChangePlanStepAndTxId(t->ProposeConfig->Step, t->ProposeConfig->TxId);
 
-        ScheduleReplyCommitDone(t->ProposeConfig->Step, t->ProposeConfig->TxId);
+        ScheduleReplyCommitDone(t->ProposeConfig->Step, t->ProposeConfig->TxId, std::move(t->CommitSpan));
     } else {
         Y_ABORT_UNLESS(t->ChangeConfig);
         ExecChangePartitionConfig();
@@ -3429,10 +3499,16 @@ void TPartition::ScheduleReplyPropose(const NKikimrPQ::TEvProposeTransaction& ev
                                           kind, reason).Release());
 }
 
-void TPartition::ScheduleReplyCommitDone(ui64 step, ui64 txId)
+void TPartition::ScheduleReplyCommitDone(ui64 step, ui64 txId, NWilson::TSpan&& commitSpan)
 {
-    Replies.emplace_back(Tablet,
-                         MakeCommitDone(step, txId).Release());
+    if (auto traceId = commitSpan.GetTraceId(); traceId) {
+        TxForPersistTraceIds.push_back(traceId);
+    }
+
+    auto event = MakeCommitDone(step, txId);
+    event->Span = std::move(commitSpan);
+
+    Replies.emplace_back(Tablet, event.Release());
 }
 
 void TPartition::ScheduleDropPartitionLabeledCounters(const TString& group)

--- a/ydb/core/persqueue/partition.h
+++ b/ydb/core/persqueue/partition.h
@@ -14,6 +14,7 @@
 #include "read_quoter.h"
 
 #include <ydb/core/keyvalue/keyvalue_events.h>
+#include <ydb/core/jaeger_tracing/sampling_throttling_control.h>
 #include <ydb/library/persqueue/counter_time_keeper/counter_time_keeper.h>
 
 #include <ydb/library/actors/core/actor.h>
@@ -57,6 +58,7 @@ struct TTransaction {
         : Tx(tx)
         , Predicate(predicate)
         , SupportivePartitionActor(tx->SupportivePartitionActor)
+        , CalcPredicateSpan(std::move(tx->Span))
     {
         Y_ABORT_UNLESS(Tx);
     }
@@ -110,6 +112,12 @@ struct TTransaction {
     bool WriteInfoApplied = false;
     TString Message;
     ECommitState State = ECommitState::Pending;
+
+    NWilson::TSpan CalcPredicateSpan;
+    NWilson::TSpan GetWriteInfoSpan;
+    NWilson::TSpan CommitSpan;
+
+    TInstant WriteInfoResponseTimestamp;
 };
 
 class TPartition : public TActorBootstrapped<TPartition> {
@@ -360,7 +368,8 @@ private:
                               NKikimrPQ::TEvProposeTransactionResult::EStatus statusCode,
                               NKikimrPQ::TError::EKind kind,
                               const TString& reason);
-    void ScheduleReplyCommitDone(ui64 step, ui64 txId);
+    void ScheduleReplyCommitDone(ui64 step, ui64 txId,
+                                 NWilson::TSpan&& commitSpan);
     void ScheduleDropPartitionLabeledCounters(const TString& group);
     void SchedulePartitionConfigChanged();
 
@@ -470,8 +479,9 @@ public:
     TPartition(ui64 tabletId, const TPartitionId& partition, const TActorId& tablet, ui32 tabletGeneration, const TActorId& blobCache,
                const NPersQueue::TTopicConverterPtr& topicConverter, TString dcId, bool isServerless,
                const NKikimrPQ::TPQTabletConfig& config, const TTabletCountersBase& counters, bool SubDomainOutOfSpace, ui32 numChannels,
-               const TActorId& writeQuoterActorId, bool newPartition = false,
-               TVector<TTransaction> distrTxs = {});
+               const TActorId& writeQuoterActorId,
+               TIntrusivePtr<NJaegerTracing::TSamplingThrottlingControl> samplingControl,
+               bool newPartition = false);
 
     void Bootstrap(const TActorContext& ctx);
 
@@ -1032,6 +1042,12 @@ private:
     void DumpKeyValueRequest(const NKikimrClient::TKeyValueRequest& request);
 
     TBlobKeyTokenPtr MakeBlobKeyToken(const TString& key);
+
+    TIntrusivePtr<NJaegerTracing::TSamplingThrottlingControl> SamplingControl;
+    TDeque<NWilson::TTraceId> TxForPersistTraceIds;
+    TDeque<NWilson::TSpan> TxForPersistSpans;
+
+    bool CanProcessUserActionAndTransactionEvents() const;
 };
 
 } // namespace NKikimr::NPQ

--- a/ydb/core/persqueue/partition_write.cpp
+++ b/ydb/core/persqueue/partition_write.cpp
@@ -504,6 +504,11 @@ void TPartition::OnHandleWriteResponse(const TActorContext& ctx)
 {
     KVWriteInProgress = false;
 
+    for (auto& span : TxForPersistSpans) {
+        span.End();
+    }
+    TxForPersistSpans.clear();
+
     if (DeletePartitionState == DELETION_IN_PROCESS) {
         // before deleting an supportive partition, it is necessary to summarize its work
         HandleWakeup(ctx);

--- a/ydb/core/persqueue/pq_impl.cpp
+++ b/ydb/core/persqueue/pq_impl.cpp
@@ -6,6 +6,7 @@
 #include "partition.h"
 #include "read.h"
 #include "utils.h"
+#include "tracing_support.h"
 #include "ydb/core/protos/config.pb.h"
 
 #include <ydb/core/base/tx_processing.h>
@@ -20,6 +21,7 @@
 #include <ydb/core/scheme/scheme_types_proto.h>
 #include <ydb/core/sys_view/service/sysview_service.h>
 #include <ydb/core/tablet/tablet_counters.h>
+#include <ydb/core/jaeger_tracing/sampling_throttling_configurator.h>
 #include <library/cpp/json/json_writer.h>
 
 #include <util/generic/strbuf.h>
@@ -712,6 +714,10 @@ void TPersQueue::HandleTransactionsReadResponse(NKikimrClient::TResponse&& resp,
         status != NKikimrProto::OK &&
         status != NKikimrProto::NODATA) {
         ok = false;
+    }
+    if (!ok) {
+        PQ_LOG_ERROR_AND_DIE("Transactions read error: " << resp.ShortDebugString());
+        return;
     }
 
     TransactionsReadResults.emplace_back(std::move(result));
@@ -2956,8 +2962,7 @@ void TPersQueue::Handle(TEvTabletPipe::TEvClientConnected::TPtr& ev, const TActo
 void TPersQueue::AckReadSetsToTablet(ui64 tabletId, const TActorContext& ctx)
 {
     THashSet<TDistributedTransaction*> txs;
-
-
+    TVector<std::pair<ui64, ui64>> bindings;
 
     for (ui64 txId : GetBindedTxs(tabletId)) {
         PQ_LOG_TX_I("Assume tablet " << tabletId << " dead, sending read set acks for tx " << txId);
@@ -2970,11 +2975,17 @@ void TPersQueue::AckReadSetsToTablet(ui64 tabletId, const TActorContext& ctx)
         tx->OnReadSetAck(tabletId);
         tx->UnbindMsgsFromPipe(tabletId);
 
+        bindings.emplace_back(tabletId, tx->TxId);
+
         txs.insert(tx);
     }
 
     if (txs.empty()) {
         return;
+    }
+
+    for (const auto& [tabletId, txId] : bindings) {
+        UnbindTxFromPipe(tabletId, txId);
     }
 
     for (auto* tx : txs) {
@@ -3037,6 +3048,13 @@ void TPersQueue::HandleDie(const TActorContext& ctx)
     NKeyValue::TKeyValueFlat::HandleDie(ctx);
 }
 
+void TPersQueue::InitPipeClientCache()
+{
+    PipeClientCacheConfig = MakeIntrusive<NTabletPipe::TBoundedClientCacheConfig>();
+    PipeClientCacheConfig->ClientPoolLimit = 2000;
+
+    PipeClientCache.Reset(NTabletPipe::CreateBoundedClientCache(PipeClientCacheConfig, GetPipeClientConfig()));
+}
 
 TPersQueue::TPersQueue(const TActorId& tablet, TTabletStorageInfo *info)
     : TKeyValueFlat(tablet, info)
@@ -3048,9 +3066,9 @@ TPersQueue::TPersQueue(const TActorId& tablet, TTabletStorageInfo *info)
     , Counters(nullptr)
     , NextResponseCookie(0)
     , ResourceMetrics(nullptr)
-    , PipeClientCacheConfig(new NTabletPipe::TBoundedClientCacheConfig())
-    , PipeClientCache(NTabletPipe::CreateBoundedClientCache(PipeClientCacheConfig, GetPipeClientConfig()))
 {
+    InitPipeClientCache();
+
     typedef TProtobufTabletCounters<
         NKeyValue::ESimpleCounters_descriptor,
         NKeyValue::ECumulativeCounters_descriptor,
@@ -3072,6 +3090,8 @@ void TPersQueue::CreatedHook(const TActorContext& ctx)
 {
     IsServerless = AppData(ctx)->FeatureFlags.GetEnableDbCounters(); //TODO: find out it via describe
     CacheActor = ctx.Register(new TPQCacheProxy(ctx.SelfID, TabletID()));
+
+    SamplingControl = AppData(ctx)->TracingConfigurator->GetControl();
 
     ctx.Send(GetNameserviceActorId(), new TEvInterconnect::TEvGetNode(ctx.SelfID.NodeId()));
     InitProcessingParams(ctx);
@@ -3220,7 +3240,7 @@ void TPersQueue::SetTxCompleteLagCounter()
 
     if (!TxQueue.empty()) {
         ui64 firstTxStep = TxQueue.front().first;
-        ui64 currentStep = TAppData::TimeProvider->Now().MilliSeconds();
+        ui64 currentStep = MediatorTimeCastEntry ? MediatorTimeCastEntry->Get(TabletID()) : TAppData::TimeProvider->Now().MilliSeconds();
 
         if (currentStep > firstTxStep) {
             lag = currentStep - firstTxStep;
@@ -3265,6 +3285,12 @@ void TPersQueue::Handle(TEvPersQueue::TEvProposeTransaction::TPtr& ev, const TAc
 
     const NKikimrPQ::TEvProposeTransaction& event = ev->Get()->GetRecord();
     PQ_LOG_TX_D("Handle TEvPersQueue::TEvProposeTransaction " << event.ShortDebugString());
+
+    auto span = GenerateSpan("Topic.Transaction", *SamplingControl);
+    span.Attribute("TxId", static_cast<i64>(event.GetTxId()));
+    span.Attribute("TabletId", static_cast<i64>(TabletID()));
+
+    ev->Get()->ExecuteSpan = std::move(span);
 
     switch (event.GetTxBodyCase()) {
     case NKikimrPQ::TEvProposeTransaction::kData:
@@ -3335,6 +3361,10 @@ bool TPersQueue::CheckTxWriteOperations(const NKikimrPQ::TDataTransaction& txBod
 void TPersQueue::HandleDataTransaction(TAutoPtr<TEvPersQueue::TEvProposeTransaction> ev,
                                        const TActorContext& ctx)
 {
+    auto span = ev->ExecuteSpan.CreateChild(TWilsonTopic::TopicTopLevel,
+                                            "Topic.Transaction.HandleDataTransaction",
+                                            NWilson::EFlags::AUTO_END);
+
     NKikimrPQ::TEvProposeTransaction& event = *ev->MutableRecord();
     Y_ABORT_UNLESS(event.GetTxBodyCase() == NKikimrPQ::TEvProposeTransaction::kData);
     Y_ABORT_UNLESS(event.HasData());
@@ -3493,6 +3523,8 @@ void TPersQueue::Handle(TEvTxProcessing::TEvReadSet::TPtr& ev, const TActorConte
     PQ_LOG_TX_I("Handle TEvTxProcessing::TEvReadSet tx " << event.GetTxId() << " tabletProducer " << event.GetTabletProducer());
 
     if (auto tx = GetTransaction(ctx, event.GetTxId()); tx && tx->PredicatesReceived.contains(event.GetTabletProducer())) {
+        tx->SetLastTabletSentByRS(event.GetTabletProducer());
+
         if ((tx->State > NKikimrPQ::TTransaction::EXECUTED) ||
             ((tx->State == NKikimrPQ::TTransaction::EXECUTED) && !tx->WriteInProgress)) {
             if (ack) {
@@ -3503,6 +3535,10 @@ void TPersQueue::Handle(TEvTxProcessing::TEvReadSet::TPtr& ev, const TActorConte
         }
 
         tx->OnReadSet(event, ev->Sender, std::move(ack));
+
+        if (tx->HaveParticipantsDecision()) {
+            tx->EndWaitRSSpan();
+        }
 
         if (tx->State == NKikimrPQ::TTransaction::WAIT_RS) {
             TryExecuteTxs(ctx, *tx);
@@ -3532,6 +3568,7 @@ void TPersQueue::Handle(TEvTxProcessing::TEvReadSetAck::TPtr& ev, const TActorCo
 
     tx->OnReadSetAck(event);
     tx->UnbindMsgsFromPipe(event.GetTabletConsumer());
+    UnbindTxFromPipe(event.GetTabletConsumer(), event.GetTxId());
 
     if (tx->State == NKikimrPQ::TTransaction::WAIT_RS_ACKS) {
         TryExecuteTxs(ctx, *tx);
@@ -3695,7 +3732,9 @@ void TPersQueue::BeginWriteTxs(const TActorContext& ctx)
     NewSupportivePartitions.clear();
 
     PQ_LOG_D("Send TEvKeyValue::TEvRequest (WRITE_TX_COOKIE)");
-    ctx.Send(ctx.SelfID, request.Release());
+    ctx.Send(ctx.SelfID, request.Release(),
+             0, 0,
+             WriteTxsSpan.GetTraceId());
 
     TryReturnTabletStateAll(ctx);
 }
@@ -3748,9 +3787,15 @@ void TPersQueue::ProcessProposeTransactionQueue(const TActorContext& ctx)
         const auto front = std::move(EvProposeTransactionQueue.front());
         EvProposeTransactionQueue.pop_front();
 
+        auto span = front->ExecuteSpan.CreateChild(TWilsonTopic::TopicTopLevel,
+                                                   "Topic.Transaction.ProcessProposeTransactionQueue",
+                                                   NWilson::EFlags::AUTO_END);
+
         const NKikimrPQ::TEvProposeTransaction& event = front->GetRecord();
         TDistributedTransaction& tx = Txs[event.GetTxId()];
         SetTxInFlyCounter();
+
+        tx.SetExecuteSpan(std::move(front->ExecuteSpan));
 
         switch (tx.State) {
         case NKikimrPQ::TTransaction::UNKNOWN:
@@ -3831,6 +3876,9 @@ void TPersQueue::ProcessPlanStepQueue(const TActorContext& ctx)
                 if (auto p = Txs.find(txId); p != Txs.end()) {
                     TDistributedTransaction& tx = p->second;
 
+                    auto span = tx.CreatePlanStepSpan(TabletID(), step);
+                    tx.BeginWaitRSSpan(TabletID());
+
                     Y_ABORT_UNLESS(tx.MaxStep >= step);
 
                     if (tx.Step == Max<ui64>()) {
@@ -3873,6 +3921,10 @@ void TPersQueue::ProcessWriteTxs(const TActorContext& ctx,
 {
     Y_ABORT_UNLESS(!WriteTxsInProgress, "PQ %" PRIu64, TabletID());
 
+    if (!WriteTxs.empty() && HasTxPersistSpan && !WriteTxsSpan) {
+        WriteTxsSpan = GenerateSpan("Topic.Transaction.WriteTxs", WriteTxsSpanVerbosity);
+    }
+
     for (auto& [txId, state] : WriteTxs) {
         // There may be cases when in one iteration of a record we change the state of a transaction and delete it
         auto tx = GetTransaction(ctx, txId);
@@ -3881,6 +3933,8 @@ void TPersQueue::ProcessWriteTxs(const TActorContext& ctx,
             tx->AddCmdWrite(request, state);
 
             ChangedTxs.emplace(tx->Step, txId);
+
+            tx->BeginPersistSpan(TabletID(), state, WriteTxsSpan.GetTraceId());
         }
     }
 
@@ -3892,12 +3946,18 @@ void TPersQueue::ProcessDeleteTxs(const TActorContext& ctx,
 {
     Y_ABORT_UNLESS(!WriteTxsInProgress, "PQ %" PRIu64, TabletID());
 
+    if (!DeleteTxs.empty() && HasTxDeleteSpan && !WriteTxsSpan) {
+        WriteTxsSpan = GenerateSpan("Topic.Transaction.WriteTxs", WriteTxsSpanVerbosity);
+    }
+
     for (ui64 txId : DeleteTxs) {
         PQ_LOG_TX_D("delete key for TxId " << txId);
         AddCmdDeleteTx(request, txId);
 
         auto tx = GetTransaction(ctx, txId);
         if (tx) {
+            tx->BeginDeleteSpan(TabletID(), WriteTxsSpan.GetTraceId());
+
             ChangedTxs.emplace(tx->Step, txId);
         }
     }
@@ -4173,7 +4233,9 @@ void TPersQueue::SendEvTxCalcPredicateToPartitions(const TActorContext& ctx,
 
         event->ForcePredicateFalse = forcePredicateFalse;
 
-        ctx.Send(partition.Actor, event.release());
+        ctx.Send(partition.Actor, event.release(),
+                 0, 0,
+                 tx.GetExecuteSpanTraceId());
     }
 
     tx.PartitionRepliesCount = 0;
@@ -4195,7 +4257,9 @@ void TPersQueue::SendEvTxCommitToPartitions(const TActorContext& ctx,
                        "PQ %" PRIu64 ", Partition %" PRIu32 ", TxId %" PRIu64,
                        TabletID(), partitionId, tx.TxId);
 
-        ctx.Send(p->second.Actor, event.release());
+        ctx.Send(p->second.Actor, event.release(),
+                 0, 0,
+                 tx.GetExecuteSpanTraceId());
     }
 
     tx.PartitionRepliesCount = 0;
@@ -4260,6 +4324,10 @@ void TPersQueue::UnbindTxFromPipe(ui64 tabletId, ui64 txId)
 {
     if (auto p = BindedTxs.find(tabletId); p != BindedTxs.end()) {
         p->second.erase(txId);
+
+        if (p->second.empty()) {
+            BindedTxs.erase(p);
+        }
     }
 }
 
@@ -4518,6 +4586,8 @@ void TPersQueue::CheckTxState(const TActorContext& ctx,
 
         TryChangeTxState(tx, NKikimrPQ::TTransaction::WAIT_RS);
 
+        tx.BeginWaitRSAcksSpan(TabletID());
+
         SendEvReadSetToReceivers(ctx, tx);
 
         if (tx.TxId != TxsOrder[tx.State].front()) {
@@ -4534,6 +4604,8 @@ void TPersQueue::CheckTxState(const TActorContext& ctx,
         PQ_LOG_TX_D("HaveParticipantsDecision " << tx.HaveParticipantsDecision());
 
         if (tx.HaveParticipantsDecision()) {
+            tx.EndWaitRSSpan();
+
             if (tx.GetDecision() == NKikimrTx::TReadSetData::DECISION_COMMIT) {
                 SendEvTxCommitToPartitions(ctx, tx);
             } else {
@@ -4564,6 +4636,8 @@ void TPersQueue::CheckTxState(const TActorContext& ctx,
                  ", Expected " << tx.PartitionRepliesExpected);
 
         if (tx.PartitionRepliesCount == tx.PartitionRepliesExpected) {
+            tx.EndExecuteSpan();
+
             SendEvProposeTransactionResult(ctx, tx);
             PQ_LOG_TX_I("complete TxId " << tx.TxId);
 
@@ -4615,6 +4689,8 @@ void TPersQueue::CheckTxState(const TActorContext& ctx,
         PQ_LOG_TX_D("HaveAllRecipientsReceive " << tx.HaveAllRecipientsReceive() <<
                  ", AllSupportivePartitionsHaveBeenDeleted " << AllSupportivePartitionsHaveBeenDeleted(tx.WriteId));
         if (tx.HaveAllRecipientsReceive() && AllSupportivePartitionsHaveBeenDeleted(tx.WriteId)) {
+            tx.EndWaitRSAcksSpan();
+
             DeleteTx(tx);
             // implicitly switch to the state DELETING
         }
@@ -4669,6 +4745,11 @@ void TPersQueue::WriteTx(TDistributedTransaction& tx, NKikimrPQ::TTransaction::E
 {
     WriteTxs[tx.TxId] = state;
 
+    if (auto traceId = tx.GetExecuteSpanTraceId(); traceId) {
+        HasTxPersistSpan = true;
+        WriteTxsSpanVerbosity = traceId.GetVerbosity();
+    }
+
     tx.WriteInProgress = true;
 }
 
@@ -4677,6 +4758,11 @@ void TPersQueue::DeleteTx(TDistributedTransaction& tx)
     PQ_LOG_TX_D("add an TxId " << tx.TxId << " to the list for deletion");
 
     DeleteTxs.insert(tx.TxId);
+
+    if (auto traceId = tx.GetExecuteSpanTraceId(); traceId) {
+        HasTxDeleteSpan = true;
+        WriteTxsSpanVerbosity = traceId.GetVerbosity();
+    }
 
     ChangeTxState(tx, NKikimrPQ::TTransaction::DELETING);
 
@@ -4702,7 +4788,18 @@ void TPersQueue::CheckChangedTxStates(const TActorContext& ctx)
 
         tx->WriteInProgress = false;
 
+        tx->EndPersistSpan();
+        tx->EndDeleteSpan();
+
         TryExecuteTxs(ctx, *tx);
+    }
+
+    HasTxPersistSpan = false;
+    HasTxDeleteSpan = false;
+
+    if (WriteTxsSpan) {
+        WriteTxsSpan.End();
+        WriteTxsSpan = {};
     }
 
     ChangedTxs.clear();
@@ -4883,6 +4980,7 @@ TPartition* TPersQueue::CreatePartitionActor(const TPartitionId& partitionId,
                           SubDomainOutOfSpace,
                           (ui32)channels,
                           GetPartitionQuoter(partitionId),
+                          SamplingControl,
                           newPartition);
 }
 

--- a/ydb/core/persqueue/pq_impl.h
+++ b/ydb/core/persqueue/pq_impl.h
@@ -8,6 +8,7 @@
 #include <ydb/core/tablet/tablet_counters.h>
 #include <ydb/core/tablet/tablet_pipe_client_cache.h>
 #include <ydb/core/base/tablet_pipe.h>
+#include <ydb/core/jaeger_tracing/sampling_throttling_control.h>
 #include <ydb/core/persqueue/events/internal.h>
 #include <ydb/core/tx/scheme_cache/scheme_cache.h>
 #include <ydb/core/tx/time_cast/time_cast.h>
@@ -583,6 +584,15 @@ private:
     void ProcessPendingEvents();
 
     void AckReadSetsToTablet(ui64 tabletId, const TActorContext& ctx);
+
+    TIntrusivePtr<NJaegerTracing::TSamplingThrottlingControl> SamplingControl;
+    NWilson::TSpan WriteTxsSpan;
+
+    void InitPipeClientCache();
+
+    bool HasTxPersistSpan = false;
+    bool HasTxDeleteSpan = false;
+    ui8 WriteTxsSpanVerbosity = 0;
 };
 
 

--- a/ydb/core/persqueue/tracing_support.cpp
+++ b/ydb/core/persqueue/tracing_support.cpp
@@ -1,0 +1,33 @@
+#include "tracing_support.h"
+
+#include <ydb/core/jaeger_tracing/request_discriminator.h>
+#include <ydb/library/wilson_ids/wilson.h>
+
+namespace NKikimr::NPQ {
+
+NWilson::TSpan GenerateSpan(const TStringBuf name, NJaegerTracing::TSamplingThrottlingControl& tracingControl)
+{
+    NJaegerTracing::TRequestDiscriminator discriminator;
+    discriminator.RequestType = NJaegerTracing::ERequestType::TOPIC_PROPOSE_TRANSACTION;
+    discriminator.Database = {};
+
+    NWilson::TTraceId traceId = tracingControl.HandleTracing(discriminator, {});
+
+    if (traceId) {
+        return {TWilsonTopic::TopicTopLevel, std::move(traceId), TString(name), NWilson::EFlags::AUTO_END};
+    }
+
+    return {};
+}
+
+NWilson::TSpan GenerateSpan(const TStringBuf name, ui8 verbosity)
+{
+    return {
+        TWilsonTopic::TopicTopLevel,
+        NWilson::TTraceId::NewTraceId(verbosity, Max<ui32>()),
+        TString(name),
+        NWilson::EFlags::AUTO_END
+    };
+}
+
+}

--- a/ydb/core/persqueue/tracing_support.h
+++ b/ydb/core/persqueue/tracing_support.h
@@ -1,0 +1,12 @@
+#pragma once
+
+#include <ydb/core/jaeger_tracing/sampling_throttling_control.h>
+#include <ydb/library/actors/wilson/wilson_span.h>
+#include <util/generic/fwd.h>
+
+namespace NKikimr::NPQ {
+
+NWilson::TSpan GenerateSpan(const TStringBuf name, NJaegerTracing::TSamplingThrottlingControl& tracingControl);
+NWilson::TSpan GenerateSpan(const TStringBuf name, ui8 verbosity);
+
+}

--- a/ydb/core/persqueue/transaction.cpp
+++ b/ydb/core/persqueue/transaction.cpp
@@ -2,6 +2,8 @@
 #include "utils.h"
 #include "partition_log.h"
 
+#include <ydb/library/wilson_ids/wilson.h>
+
 namespace NKikimr::NPQ {
 
 TDistributedTransaction::TDistributedTransaction(const NKikimrPQ::TTransaction& tx) :
@@ -60,6 +62,28 @@ TDistributedTransaction::TDistributedTransaction(const NKikimrPQ::TTransaction& 
     }
 
     PartitionsData = std::move(tx.GetPartitions());
+
+    if (tx.HasExecuteTraceId()) {
+        NWilson::TTraceId traceId(tx.GetExecuteTraceId());
+        ExecuteSpan = NWilson::TSpan(TWilsonTopic::TopicTopLevel,
+                                     std::move(traceId),
+                                     "Topic.Transaction",
+                                     NWilson::EFlags::AUTO_END);
+    }
+    if (tx.HasWaitRSTraceId()) {
+        NWilson::TTraceId traceId(tx.GetWaitRSTraceId());
+        WaitRSSpan = NWilson::TSpan(TWilsonTopic::TopicTopLevel,
+                                    std::move(traceId),
+                                    "Topic.Transaction.WaitRS",
+                                    NWilson::EFlags::AUTO_END);
+    }
+    if (tx.HasWaitRSAcksTraceId()) {
+        NWilson::TTraceId traceId(tx.GetWaitRSAcksTraceId());
+        WaitRSAcksSpan = NWilson::TSpan(TWilsonTopic::TopicTopLevel,
+                                        std::move(traceId),
+                                        "Topic.Transaction.WaitRSAcks",
+                                        NWilson::EFlags::AUTO_END);
+    }
 }
 
 TString TDistributedTransaction::LogPrefix() const
@@ -425,6 +449,16 @@ NKikimrPQ::TTransaction TDistributedTransaction::Serialize(EState state) {
 
     *tx.MutablePartitions() = PartitionsData;
 
+    if (ExecuteSpan) {
+        ExecuteSpan.GetTraceId().Serialize(tx.MutableExecuteTraceId());
+    }
+    if (WaitRSSpan) {
+        WaitRSSpan.GetTraceId().Serialize(tx.MutableWaitRSTraceId());
+    }
+    if (WaitRSAcksSpan) {
+        WaitRSAcksSpan.GetTraceId().Serialize(tx.MutableWaitRSAcksTraceId());
+    }
+
     return tx;
 }
 
@@ -473,6 +507,113 @@ const TVector<NKikimrTx::TEvReadSet>& TDistributedTransaction::GetBindedMsgs(ui6
     static TVector<NKikimrTx::TEvReadSet> empty;
 
     return empty;
+}
+
+void TDistributedTransaction::SetExecuteSpan(NWilson::TSpan&& span)
+{
+    ExecuteSpan = std::move(span);
+}
+
+void TDistributedTransaction::EndExecuteSpan()
+{
+    if (ExecuteSpan) {
+        ExecuteSpan.End();
+        ExecuteSpan = {};
+    }
+}
+
+NWilson::TSpan TDistributedTransaction::CreatePlanStepSpan(ui64 tabletId, ui64 step)
+{
+    auto span = CreateSpan("Topic.Transaction.Plan", tabletId);
+    span.Attribute("PlanStep", static_cast<i64>(step));
+    return span;
+}
+
+void TDistributedTransaction::BeginWaitRSSpan(ui64 tabletId)
+{
+    if (!WaitRSSpan) {
+        WaitRSSpan = CreateSpan("Topic.Transaction.WaitRS", tabletId);
+    }
+}
+
+void TDistributedTransaction::SetLastTabletSentByRS(ui64 tabletId)
+{
+    if (WaitRSSpan) {
+        WaitRSSpan.Attribute("LastTabletId", static_cast<i64>(tabletId));
+    }
+}
+
+void TDistributedTransaction::EndWaitRSSpan()
+{
+    if (WaitRSSpan) {
+        WaitRSSpan.End();
+        WaitRSSpan = {};
+    }
+}
+
+void TDistributedTransaction::BeginWaitRSAcksSpan(ui64 tabletId)
+{
+    WaitRSAcksSpan = CreateSpan("Topic.Transaction.WaitRSAcks", tabletId);
+}
+
+void TDistributedTransaction::EndWaitRSAcksSpan()
+{
+    if (WaitRSAcksSpan) {
+        WaitRSAcksSpan.End();
+        WaitRSAcksSpan = {};
+    }
+}
+
+void TDistributedTransaction::BeginPersistSpan(ui64 tabletId, EState state, const NWilson::TTraceId& traceId)
+{
+    PersistSpan = CreateSpan("Topic.Transaction.Persist", tabletId);
+    PersistSpan.Attribute("State", NKikimrPQ::TTransaction_EState_Name(state));
+    if (traceId) {
+        PersistSpan.Link(traceId);
+    }
+}
+
+void TDistributedTransaction::EndPersistSpan()
+{
+    if (PersistSpan) {
+        PersistSpan.End();
+        PersistSpan = {};
+    }
+}
+
+void TDistributedTransaction::BeginDeleteSpan(ui64 tabletId, const NWilson::TTraceId& traceId)
+{
+    DeleteSpan = CreateSpan("Topic.Transaction.Delete", tabletId);
+    if (traceId) {
+        DeleteSpan.Link(traceId);
+    }
+}
+
+void TDistributedTransaction::EndDeleteSpan()
+{
+    if (DeleteSpan) {
+        DeleteSpan.End();
+        DeleteSpan = {};
+    }
+}
+
+NWilson::TSpan TDistributedTransaction::CreateSpan(const char* name, ui64 tabletId)
+{
+    if (!ExecuteSpan) {
+        return {};
+    }
+
+    auto span = ExecuteSpan.CreateChild(TWilsonTopic::TopicTopLevel,
+                                        name,
+                                        NWilson::EFlags::AUTO_END);
+    span.Attribute("TxId", static_cast<i64>(TxId));
+    span.Attribute("TabletId", static_cast<i64>(tabletId));
+    return span;
+}
+
+NWilson::TTraceId TDistributedTransaction::GetExecuteSpanTraceId()
+{
+    return ExecuteSpan.GetTraceId();
 }
 
 }

--- a/ydb/core/persqueue/transaction.h
+++ b/ydb/core/persqueue/transaction.h
@@ -108,6 +108,30 @@ struct TDistributedTransaction {
     size_t PredicateAcksCount = 0;
 
     bool Pending = false;
+
+    void SetExecuteSpan(NWilson::TSpan&& span);
+    void EndExecuteSpan();
+    NWilson::TSpan CreatePlanStepSpan(ui64 tabletId, ui64 step);
+    void BeginWaitRSSpan(ui64 tabletId);
+    void SetLastTabletSentByRS(ui64 tabletId);
+    void EndWaitRSSpan();
+    void BeginWaitRSAcksSpan(ui64 tabletId);
+    void EndWaitRSAcksSpan();
+    void BeginPersistSpan(ui64 tabletId, EState state, const NWilson::TTraceId& traceId);
+    void EndPersistSpan();
+    void BeginDeleteSpan(ui64 tabletId, const NWilson::TTraceId& traceId);
+    void EndDeleteSpan();
+
+    NWilson::TTraceId GetExecuteSpanTraceId();
+
+private:
+    NWilson::TSpan CreateSpan(const char* name, ui64 tabletId);
+
+    NWilson::TSpan ExecuteSpan;
+    NWilson::TSpan PersistSpan;
+    NWilson::TSpan WaitRSSpan;
+    NWilson::TSpan WaitRSAcksSpan;
+    NWilson::TSpan DeleteSpan;
 };
 
 }

--- a/ydb/core/persqueue/ut/common/pq_ut_common.h
+++ b/ydb/core/persqueue/ut/common/pq_ut_common.h
@@ -104,6 +104,7 @@ struct TTestContext {
         NActors::NLog::EPriority otherPriority = NLog::PRI_INFO;
 
         runtime.SetLogPriority(NKikimrServices::PERSQUEUE, pqPriority);
+        runtime.SetLogPriority(NKikimrServices::PQ_TX, pqPriority);
         runtime.SetLogPriority(NKikimrServices::PERSQUEUE_READ_BALANCER, pqPriority);
 
         runtime.SetLogPriority(NKikimrServices::SYSTEM_VIEWS, pqPriority);

--- a/ydb/core/persqueue/ut/partition_ut.cpp
+++ b/ydb/core/persqueue/ut/partition_ut.cpp
@@ -3636,7 +3636,7 @@ Y_UNIT_TEST_F(TEvTxCalcPredicate_With_Conflicts, TPartitionTxTestHelper)
 
     WaitTxPredicateReply(tx1);
 
-    auto tx2 = MakeAndSendWriteTx({{"sourceid", {1, 3}}});
+    auto tx2 = MakeAndSendWriteTx({{"sourceid", {4, 6}}});
 
     WaitWriteInfoRequest(tx2);
     SendWriteInfoResponse(tx2);
@@ -3644,8 +3644,6 @@ Y_UNIT_TEST_F(TEvTxCalcPredicate_With_Conflicts, TPartitionTxTestHelper)
     ExpectNoTxPredicateReply();
 
     SendTxCommit(tx1);
-
-    EmulateKVTablet();
 
     WaitTxPredicateReply(tx2);
 }

--- a/ydb/core/persqueue/ut/pqtablet_ut.cpp
+++ b/ydb/core/persqueue/ut/pqtablet_ut.cpp
@@ -438,6 +438,61 @@ void TPQTabletFixture::WaitPlanStepAccepted(const TPlanStepAcceptedMatcher& matc
 
 void TPQTabletFixture::WaitReadSet(NHelpers::TPQTabletMock& tablet, const TReadSetMatcher& matcher)
 {
+    auto tryMatch = [](const TReadSetMatcher& matcher, const NKikimrTx::TEvReadSet& readSet) {
+        if (matcher.Step.Defined()) {
+            UNIT_ASSERT(readSet.HasStep());
+            UNIT_ASSERT_VALUES_EQUAL(*matcher.Step, readSet.GetStep());
+        }
+        if (matcher.TxId.Defined()) {
+            UNIT_ASSERT(readSet.HasTxId());
+            UNIT_ASSERT_VALUES_EQUAL(*matcher.TxId, readSet.GetTxId());
+        }
+        if (matcher.Source.Defined()) {
+            UNIT_ASSERT(readSet.HasTabletSource());
+            UNIT_ASSERT_VALUES_EQUAL(*matcher.Source, readSet.GetTabletSource());
+        }
+        if (matcher.Target.Defined()) {
+            UNIT_ASSERT(readSet.HasTabletDest());
+            UNIT_ASSERT_VALUES_EQUAL(*matcher.Target, readSet.GetTabletDest());
+        }
+        if (matcher.Decision.Defined()) {
+            UNIT_ASSERT(readSet.HasReadSet());
+
+            NKikimrTx::TReadSetData data;
+            Y_ABORT_UNLESS(data.ParseFromString(readSet.GetReadSet()));
+
+            UNIT_ASSERT_EQUAL(*matcher.Decision, data.GetDecision());
+        }
+        if (matcher.Producer.Defined()) {
+            UNIT_ASSERT(readSet.HasTabletProducer());
+            UNIT_ASSERT_VALUES_EQUAL(*matcher.Producer, readSet.GetTabletProducer());
+        }
+    };
+
+    if (matcher.Step.Defined() && matcher.TxId.Defined()) {
+        const ui64 step = *matcher.Step;
+        const ui64 txId = *matcher.TxId;
+        const auto key = std::make_pair(step, txId);
+
+        auto p = tablet.ReadSets.find(std::make_pair(step, txId));
+        if (p == tablet.ReadSets.end()) {
+            TDispatchOptions options;
+            options.CustomFinalCondition = [&]() {
+                return tablet.ReadSets.contains(key);
+            };
+            UNIT_ASSERT(Ctx->Runtime->DispatchEvents(options));
+
+            p = tablet.ReadSets.find(key);
+        }
+
+        const auto& records = p->second;
+        UNIT_ASSERT_VALUES_EQUAL(records.size(), 1);
+
+        tryMatch(matcher, records.front());
+
+        return;
+    }
+
     if (!tablet.ReadSet.Defined()) {
         TDispatchOptions options;
         options.CustomFinalCondition = [&]() {
@@ -449,34 +504,7 @@ void TPQTabletFixture::WaitReadSet(NHelpers::TPQTabletMock& tablet, const TReadS
     auto readSet = std::move(*tablet.ReadSet);
     tablet.ReadSet = Nothing();
 
-    if (matcher.Step.Defined()) {
-        UNIT_ASSERT(readSet.HasStep());
-        UNIT_ASSERT_VALUES_EQUAL(*matcher.Step, readSet.GetStep());
-    }
-    if (matcher.TxId.Defined()) {
-        UNIT_ASSERT(readSet.HasTxId());
-        UNIT_ASSERT_VALUES_EQUAL(*matcher.TxId, readSet.GetTxId());
-    }
-    if (matcher.Source.Defined()) {
-        UNIT_ASSERT(readSet.HasTabletSource());
-        UNIT_ASSERT_VALUES_EQUAL(*matcher.Source, readSet.GetTabletSource());
-    }
-    if (matcher.Target.Defined()) {
-        UNIT_ASSERT(readSet.HasTabletDest());
-        UNIT_ASSERT_VALUES_EQUAL(*matcher.Target, readSet.GetTabletDest());
-    }
-    if (matcher.Decision.Defined()) {
-        UNIT_ASSERT(readSet.HasReadSet());
-
-        NKikimrTx::TReadSetData data;
-        Y_ABORT_UNLESS(data.ParseFromString(readSet.GetReadSet()));
-
-        UNIT_ASSERT_EQUAL(*matcher.Decision, data.GetDecision());
-    }
-    if (matcher.Producer.Defined()) {
-        UNIT_ASSERT(readSet.HasTabletProducer());
-        UNIT_ASSERT_VALUES_EQUAL(*matcher.Producer, readSet.GetTabletProducer());
-    }
+    tryMatch(matcher, readSet);
 }
 
 void TPQTabletFixture::WaitReadSetEx(NHelpers::TPQTabletMock& tablet, const TReadSetMatcher& matcher)

--- a/ydb/core/persqueue/writer/writer.cpp
+++ b/ydb/core/persqueue/writer/writer.cpp
@@ -338,6 +338,7 @@ class TPartitionWriter : public TActorBootstrapped<TPartitionWriter>, private TR
 
         if (HasSupportivePartitionId()) {
             operations->SetSupportivePartition(SupportivePartitionId);
+            operations->SetTabletId(TabletId);
         }
 
         return ev;

--- a/ydb/core/persqueue/ya.make
+++ b/ydb/core/persqueue/ya.make
@@ -50,6 +50,7 @@ SRCS(
     microseconds_sliding_window.cpp
     dread_cache_service/caching_service.cpp
     write_id.cpp
+    tracing_support.cpp
 )
 
 GENERATE_ENUM_SERIALIZATION(read_balancer__balancing.h)

--- a/ydb/core/protos/kqp.proto
+++ b/ydb/core/protos/kqp.proto
@@ -71,6 +71,7 @@ message TTopicOperationsRequest {
     optional string Consumer = 1;
     repeated TopicOffsets Topics = 2;
     optional uint32 SupportivePartition = 3;
+    optional uint64 TabletId = 4;
 
     message TopicOffsets {
         // Topic path.

--- a/ydb/core/protos/pqconfig.proto
+++ b/ydb/core/protos/pqconfig.proto
@@ -1179,6 +1179,10 @@ message TTransaction {
     optional NActorsProto.TActorId SourceActor = 14;
 
     optional TWriteId WriteId = 15;
+
+    optional NActorsProto.TTraceId ExecuteTraceId = 17;
+    optional NActorsProto.TTraceId WaitRSTraceId = 18;
+    optional NActorsProto.TTraceId WaitRSAcksTraceId = 19;
 };
 
 message TTabletTxInfo {


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

Changes from #22269

Added a distributed transaction execution trace using the PQ tablet.

Optimized the operation of the PQ tablet:
- fewer Schema Cache requests
- transaction predicates are calculated in batches

### Changelog category <!-- remove all except one -->

* Improvement

### Description for reviewers <!-- (optional) description for those who read this PR -->

...
