### PR TITLE
Account GroupSizeInUnits in JSON Viewer

### DIFF
--- a/ydb/core/viewer/storage_groups.h
+++ b/ydb/core/viewer/storage_groups.h
@@ -479,9 +479,9 @@ public:
             DiskSpace = NKikimrViewer::EFlag::Grey;
             DiskSpaceUsage = 0;
             for (const TVDisk& vdisk : VDisks) {
+                available += vdisk.AvailableSize;
                 auto itPDisk = pDisks.find(vdisk.VSlotId);
                 if (itPDisk != pDisks.end()) {
-                    available += std::min(itPDisk->second.GetSlotTotalSize() - vdisk.AllocatedSize, vdisk.AvailableSize);
                     DiskSpace = std::max(DiskSpace, vdisk.DiskSpace);
                     DiskSpaceUsage = std::max(DiskSpaceUsage, itPDisk->second.GetDiskSpaceUsage());
                 }


### PR DESCRIPTION
### Changelog category

* Not for changelog (changelog entry is not required)

### Description for reviewers

Fix `Group.AvailableSize` reporting in JSON Viewer (account `GroupSizeInUnits`)

- Follow-up for #21875 
- Part of #16959