### PR TITLE
Fix reassign node logic in self-heal

### DIFF
--- a/ydb/core/blobstorage/nodewarden/distconf_invoke_state_storage.cpp
+++ b/ydb/core/blobstorage/nodewarden/distconf_invoke_state_storage.cpp
@@ -122,6 +122,7 @@ namespace NKikimr::NStorage {
         auto needReconfig = [&](auto clearFunc, auto ssMutableFunc, auto buildFunc) {
             auto copyCurrentConfig = currentConfig;
             auto ss = *(copyCurrentConfig.*ssMutableFunc)();
+            auto targetSS = *(targetConfig.*ssMutableFunc)();
             if (ss.RingGroupsSize() == 0) {
                 ss.MutableRing()->ClearRingGroupActorIdOffset();
             } else {
@@ -132,9 +133,11 @@ namespace NKikimr::NStorage {
             TIntrusivePtr<TStateStorageInfo> newSSInfo;
             TIntrusivePtr<TStateStorageInfo> oldSSInfo;
             oldSSInfo = (*buildFunc)(ss);
-            newSSInfo = (*buildFunc)(*(targetConfig.*ssMutableFunc)());
+            newSSInfo = (*buildFunc)(targetSS);
             if (oldSSInfo->RingGroups == newSSInfo->RingGroups) {
                 (targetConfig.*clearFunc)();
+                 STLOG(PRI_DEBUG, BS_NODE, NW104, "needReconfig clear config"
+                , (CurrentConfig, ss), (TargetConfig, targetSS), (oldSSInfo, oldSSInfo->ToString()), (newSSInfo, newSSInfo->ToString()));
                 return ReconfigType::NONE;
             }
 

--- a/ydb/core/blobstorage/nodewarden/distconf_selfheal.h
+++ b/ydb/core/blobstorage/nodewarden/distconf_selfheal.h
@@ -39,4 +39,32 @@ namespace NKikimr::NStorage {
 
         STFUNC(StateFunc);
     };
+
+    class TStateStorageReassignNodeSelfhealActor : public TActorBootstrapped<TStateStorageReassignNodeSelfhealActor> {
+        const TDuration WaitForConfigStep;
+        const TActorId Sender;
+        const ui64 Cookie;
+        bool AllowNextStep = false;
+        bool FinishReassign = false;
+        ui32 NodeFrom;
+        ui32 NodeTo;
+        bool NeedReconfigSS;
+        bool NeedReconfigSSB;
+        bool NeedReconfigSB;
+
+        using TResult = NKikimrBlobStorage::TEvNodeConfigInvokeOnRootResult;
+
+        void HandleWakeup();
+        void Finish(TResult::EStatus result, const TString& errorReason = "");
+        void RequestChangeStateStorage(bool disable);
+        void HandleResult(NStorage::TEvNodeConfigInvokeOnRootResult::TPtr& ev);
+
+    public:
+        TStateStorageReassignNodeSelfhealActor(TActorId sender, ui64 cookie, TDuration waitForConfigStep
+            , ui32 nodeFrom, ui32 nodeTo, bool needReconfigSS, bool needReconfigSSB, bool needReconfigSB);
+
+        void Bootstrap(TActorId parentId);
+
+        STFUNC(StateFunc);
+    };
 }

--- a/ydb/core/blobstorage/nodewarden/distconf_selfheal.h
+++ b/ydb/core/blobstorage/nodewarden/distconf_selfheal.h
@@ -21,6 +21,7 @@ namespace NKikimr::NStorage {
         NKikimrBlobStorage::TStateStorageConfig CurrentConfig;
         NKikimrBlobStorage::TStateStorageConfig TargetConfig;
         bool AllowNextStep = true;
+        ui32 PilesCount;
 
         using TResult = NKikimrBlobStorage::TEvNodeConfigInvokeOnRootResult;
 
@@ -33,7 +34,7 @@ namespace NKikimr::NStorage {
 
     public:
         TStateStorageSelfhealActor(TActorId sender, ui64 cookie, TDuration waitForConfigStep
-            , NKikimrBlobStorage::TStateStorageConfig&& currentConfig, NKikimrBlobStorage::TStateStorageConfig&& targetConfig);
+            , NKikimrBlobStorage::TStateStorageConfig&& currentConfig, NKikimrBlobStorage::TStateStorageConfig&& targetConfig, ui32 pilesCount);
 
         void Bootstrap(TActorId parentId);
 

--- a/ydb/core/blobstorage/nodewarden/distconf_statestorage_config_generator.cpp
+++ b/ydb/core/blobstorage/nodewarden/distconf_statestorage_config_generator.cpp
@@ -178,14 +178,6 @@ namespace NKikimr::NStorage {
         for (ui32 stateLimit : xrange(NodeStatesSize)) {
             if (PickNodesSimpleStrategy(group, stateLimit, rackStates.size() < RingsInGroupCount)) {
                 GoodConfig &= stateLimit <= 1;
-                std::string r = "disc:" + std::to_string(group.Disconnected) + " -> ";
-                for(auto n : group.Nodes) {
-                    auto& rackState = rackStates[std::get<1>(n).GetRackId()];
-                    r += std::to_string(std::get<0>(n)) + ":u" + std::to_string(UsedNodes.contains(std::get<0>(n)))
-                    + ":" + std::to_string(rackState[0]) + ":" + std::to_string(rackState[1])
-                    + ":" + std::to_string(CalcNodeState(std::get<0>(n), group.Disconnected)) + ", ";
-                }
-                STLOG(PRI_DEBUG, BS_NODE, NW102, "TStateStoragePerPileGenerator::PickNodesByState", (stateLimit, stateLimit), (Nodes, r));
                 return;
             }
         }

--- a/ydb/core/blobstorage/nodewarden/distconf_statestorage_config_generator.h
+++ b/ydb/core/blobstorage/nodewarden/distconf_statestorage_config_generator.h
@@ -20,12 +20,15 @@ namespace NKikimr::NStorage {
         struct TNodeGroup {
             std::vector<std::tuple<ui32, TNodeLocation>> Nodes;
             std::array<ui32, NodeStatesSize> State;
+            bool Disconnected;
         };
 
         void FillNodeGroups(THashMap<TString, std::vector<std::tuple<ui32, TNodeLocation>>>& nodes);
         void CalculateRingsParameters();
         bool PickNodesSimpleStrategy(TNodeGroup& group, ui32 stateLimit, bool ignoreRacks);
         void PickNodes(TNodeGroup& group);
+        void PickNodesByRack(TNodeGroup& group);
+        void PickNodesByState(TNodeGroup& group);
         ui32 CalcNodeState(ui32 nodeId);
 
         const std::optional<TBridgePileId> PileId;

--- a/ydb/core/blobstorage/nodewarden/distconf_statestorage_config_generator.h
+++ b/ydb/core/blobstorage/nodewarden/distconf_statestorage_config_generator.h
@@ -27,9 +27,7 @@ namespace NKikimr::NStorage {
         void CalculateRingsParameters();
         bool PickNodesSimpleStrategy(TNodeGroup& group, ui32 stateLimit, bool ignoreRacks);
         void PickNodes(TNodeGroup& group);
-        void PickNodesByRack(TNodeGroup& group);
-        void PickNodesByState(TNodeGroup& group);
-        ui32 CalcNodeState(ui32 nodeId);
+        ui32 CalcNodeState(ui32 nodeId, bool disconnected);
 
         const std::optional<TBridgePileId> PileId;
         const std::unordered_map<ui32, ui32>& SelfHealNodesState;

--- a/ydb/core/protos/blobstorage_distributed_config.proto
+++ b/ydb/core/protos/blobstorage_distributed_config.proto
@@ -229,6 +229,7 @@ message TEvNodeConfigInvokeOnRoot {
         bool StateStorage = 3;
         bool StateStorageBoard = 4;
         bool SchemeBoard = 5;
+        optional bool DisableRing = 6;
     }
 
     message TGetStateStorageConfig {

--- a/ydb/tests/functional/config/test_distconf_sentinel_node_status.py
+++ b/ydb/tests/functional/config/test_distconf_sentinel_node_status.py
@@ -199,4 +199,4 @@ class TestKiKiMRDistConfSelfHealDCDisconnected(KiKiMRDistConfNodeStatusTest):
         rg2 = get_ring_group(self.do_request_config(), configName)
         assert_eq(rg["NToSelect"], 9)
         assert_eq(len(rg["Ring"]), 9)
-        assert_eq(rg, rg2)
+        assert_eq(rg2, rg)

--- a/ydb/tests/functional/config/test_distconf_sentinel_node_status.py
+++ b/ydb/tests/functional/config/test_distconf_sentinel_node_status.py
@@ -144,20 +144,20 @@ class TestKiKiMRDistConfSelfHealNodeDisconnected(KiKiMRDistConfNodeStatusTest):
         assert_eq(len(rg["Ring"]), 9)
         self.validate_contains_nodes(rg, [3])
         self.cluster.nodes[3].stop()
-        for i in range(15):
-            time.sleep(2)
-            cfg = self.do_request_config()[f"{configName}Config"]
-            assert_eq(len(cfg["RingGroups"]), 1)
+        time.sleep(25)
 
         rg2 = get_ring_group(self.do_request_config(), configName)
         assert_eq(rg["NToSelect"], 9)
         assert_eq(len(rg["Ring"]), 9)
         self.validate_not_contains_nodes(rg2, [3])
+        assert_that("RingGroupActorIdOffset" not in rg2)  # reassign node api used instead adding new ring groups test
+        for ring in rg2:
+            assert_that("IsDisabled" not in rg)
         assert_that(rg != rg2)
         self.cluster.nodes[3].start()
         time.sleep(25)
         rg3 = get_ring_group(self.do_request_config(), configName)
-        assert_that(rg3 == rg2)  # Current config has no bad nodes and should not run self-heal
+        assert_eq(rg3, rg2)  # Current config has no bad nodes and should not run self-heal
 
 
 class TestKiKiMRDistConfSelfHeal2NodesDisconnected(KiKiMRDistConfNodeStatusTest):
@@ -199,4 +199,4 @@ class TestKiKiMRDistConfSelfHealDCDisconnected(KiKiMRDistConfNodeStatusTest):
         rg2 = get_ring_group(self.do_request_config(), configName)
         assert_eq(rg["NToSelect"], 9)
         assert_eq(len(rg["Ring"]), 9)
-        assert_that(rg == rg2)
+        assert_eq(rg, rg2)

--- a/ydb/tests/functional/config/test_distconf_sentinel_node_status.py
+++ b/ydb/tests/functional/config/test_distconf_sentinel_node_status.py
@@ -136,25 +136,25 @@ class KiKiMRDistConfNodeStatusTest(object):
 
 class TestKiKiMRDistConfSelfHealNodeDisconnected(KiKiMRDistConfNodeStatusTest):
     erasure = Erasure.MIRROR_3_DC
-    nodes_count = 12
+    nodes_count = 10
 
     def do_test(self, configName):
         rg = get_ring_group(self.do_request_config(), configName)
         assert_eq(rg["NToSelect"], 9)
         assert_eq(len(rg["Ring"]), 9)
-        self.validate_contains_nodes(rg, [3])
-        self.cluster.nodes[3].stop()
+        self.validate_contains_nodes(rg, [4])
+        self.cluster.nodes[4].stop()
         time.sleep(25)
 
         rg2 = get_ring_group(self.do_request_config(), configName)
         assert_eq(rg["NToSelect"], 9)
         assert_eq(len(rg["Ring"]), 9)
-        self.validate_not_contains_nodes(rg2, [3])
+        self.validate_not_contains_nodes(rg2, [4])
         assert_that("RingGroupActorIdOffset" not in rg2)  # reassign node api used instead adding new ring groups test
         for ring in rg2:
             assert_that("IsDisabled" not in rg)
         assert_that(rg != rg2)
-        self.cluster.nodes[3].start()
+        self.cluster.nodes[4].start()
         time.sleep(25)
         rg3 = get_ring_group(self.do_request_config(), configName)
         assert_eq(rg3, rg2)  # Current config has no bad nodes and should not run self-heal


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

1. Fix reassign logic in 2 steps. Disable ring and then reassign node + enable ring
2. Fix validation when reassign logic can be applyed. Disable ring can be applyed only when majority is not broken
3. Make readonly unnecessary ring groups in previous config during reconfiguration to decrease number of rings when reconfiguration was not completed before other one
4. Do not take in to account node states if the most nodes in DC are unhealthy. It means DC is mostly disconnected and we can not trust sentinel results this time. It decrease unnecessary reconfiguration.
### Changelog category <!-- remove all except one -->

* Not for changelog (changelog entry is not required)

### Description for reviewers <!-- (optional) description for those who read this PR -->

...
