### PR TITLE
Invoke TRope::Compact in OnVGetResult only when occupied memory exceeds threshold

### DIFF
--- a/ydb/core/blobstorage/dsproxy/dsproxy_get_impl.h
+++ b/ydb/core/blobstorage/dsproxy/dsproxy_get_impl.h
@@ -223,11 +223,8 @@ public:
             if (replyStatus == NKikimrProto::OK) {
                 // TODO(cthulhu): Verify shift and response size, and cookie
                 DSP_LOG_DEBUG_SX(logCtx, "BPG58", "Got# OK orderNumber# " << orderNumber << " vDiskId# " << vdisk.ToString());
-                resultBuffer.Compact();
                 if (resultBuffer.GetOccupiedMemorySize() > resultBuffer.size() * 2) {
-                    auto temp = TRcBuf::Uninitialized(resultBuffer.size());
-                    resultBuffer.ExtractFrontPlain(temp.GetDataMut(), temp.size());
-                    resultBuffer.Insert(resultBuffer.End(), std::move(temp));
+                    resultBuffer.Compact();
                 }
                 Blackboard.AddResponseData(blobId, orderNumber, resultShift, std::move(resultBuffer));
             } else if (replyStatus == NKikimrProto::NODATA) {


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

Invoke TRope::Compact in OnVGetResult only when occupied memory exceeds threshold

### Changelog category <!-- remove all except one -->

* Performance improvement

### Description for reviewers <!-- (optional) description for those who read this PR -->

This change prevents unnecessary TRope::Compact call by invoking it only when the occupied memory exceeds a threshold. Current code inside of the if statement is redundant as  it is applying the same logic as TRope::Compact.

https://github.com/ydb-platform/nbs/issues/4040

...
