### PR TITLE
[docs] build.sh only builds, add run.sh for build+serve via HTTP

### DIFF
--- a/ydb/docs/README.md
+++ b/ydb/docs/README.md
@@ -1,0 +1,62 @@
+# YDB Documentation
+
+This folder contains the source code for YDB documentation built using the [Diplodoc](https://diplodoc.com/) documentation platform.
+
+## Contributing to Documentation 📖
+
+YDB follows the "Documentation as Code" approach. For comprehensive information about contributing to YDB documentation, including review process, style guide, and structure guidelines, visit:
+
+- **[Contributing to YDB Documentation](https://ydb.tech/docs/en/contributor/documentation/?version=main)** — Overview
+- **[Review process](https://ydb.tech/docs/en/contributor/documentation/review/?version=main)** - Documentation review workflow and requirements
+- **[Style guide](https://ydb.tech/docs/en/contributor/documentation/style-guide/?version=main)** - Writing standards and conventions for YDB documentation
+- **[Structure](https://ydb.tech/docs/en/contributor/documentation/structure/?version=main)** - Organization and hierarchy of documentation content
+- **[Genres](https://ydb.tech/docs/en/contributor/documentation/genres/?version=main)** - Different types of documentation and their purposes
+
+## Quick Start
+
+This folder provides two scripts to help you work with the documentation locally:
+
+### `build.sh` - Build Documentation Only
+
+Builds the YDB documentation and outputs it to a specified directory.
+
+```bash
+# Build to a temporary directory
+./build.sh
+
+# Build to a specific directory
+./build.sh /path/to/output
+```
+
+**Requirements:**
+- [YFM builder](https://diplodoc.com/docs/en/tools/docs/) (`yfm` command)
+
+**Returns:**
+- Exit code 0 on successful build
+- Exit code 1 on build failure
+
+### `run.sh` - Build and Serve Documentation
+
+Builds the documentation and starts a local HTTP server to preview the results.
+
+```bash
+# Build and serve from a temporary directory
+./run.sh
+
+# Build and serve from a specific directory
+./run.sh /path/to/output
+```
+
+**Requirements:**
+- [YFM builder](https://diplodoc.com/docs/en/tools/docs/) (`yfm` command)
+- Python 3 (for the HTTP server)
+
+**Access the documentation:**
+- English: http://localhost:8888/en
+- Russian: http://localhost:8888/ru
+
+Press `Ctrl+C` to stop the server.
+
+## File Structure
+
+The documentation source files are organized as Markdown files with YAML configuration, following the Diplodoc documentation format. The built documentation includes both English (`en`) and Russian (`ru`) versions.

--- a/ydb/docs/README.md
+++ b/ydb/docs/README.md
@@ -1,6 +1,6 @@
 # YDB Documentation
 
-This folder contains the source code for YDB documentation built using the [Diplodoc](https://diplodoc.com/) documentation platform.
+This folder contains the source code for [YDB documentation](https://ydb.tech/docs/en/) built using the [Diplodoc](https://diplodoc.com/) documentation platform.
 
 ## Contributing to Documentation 📖
 

--- a/ydb/docs/build.sh
+++ b/ydb/docs/build.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-# Use this script to build YDB docs with open-source tools and start an HTTP server
+# Use this script to build YDB docs with open-source tools
 # You may specify the output directory as a parameter. If omitted, the docs will be generated to a TEMP subdirectory
 
 set -e
@@ -14,27 +14,14 @@ check_dependency() {
   fi
 }
 
-start_server() {
-  echo
-  echo "Starting HTTP server, open the links in your browser:"
-  echo
-  echo "- http://localhost:8888/en (English)"
-  echo "- http://localhost:8888/ru (Russian)"
-  echo
-  echo "Press Ctrl+C in this window to stop the HTTP server."
-  echo
-  python3 -m http.server 8888 -d $1
-}
-
 DIR=${1:-"$TMPDIR"docs}
 
 check_dependency "yfm" "YFM builder" "https://diplodoc.com/docs/en/tools/docs/"
-check_dependency "python3" "Python3" "https://www.python.org/downloads/"
 
 echo "Starting YFM builder"
 echo "Output directory: $DIR"
 
-if ! yfm -s -i . -o $DIR --allowHTML  --apply-presets; then
+if ! yfm -s -i . -o $DIR --allowHTML --apply-presets; then
   echo
   echo '================================'
   echo 'YFM build completed with ERRORS!'
@@ -43,5 +30,8 @@ if ! yfm -s -i . -o $DIR --allowHTML  --apply-presets; then
   exit 1
 fi
 
-start_server $DIR
+echo
+echo "Build completed successfully!"
+echo "Output directory: $DIR"
+exit 0
 

--- a/ydb/docs/run.sh
+++ b/ydb/docs/run.sh
@@ -1,0 +1,44 @@
+#!/bin/bash
+
+# Use this script to build YDB docs and start an HTTP server
+# You may specify the output directory as a parameter. If omitted, the docs will be generated to a TEMP subdirectory
+
+set -e
+
+check_dependency() {
+  if ! command -v $1 &> /dev/null; then
+    echo
+    echo "You need to have $2 installed to run this script, exiting"
+    echo "Installation instructions: $3"
+    exit 1
+  fi
+}
+
+start_server() {
+  echo
+  echo "Starting HTTP server, open the links in your browser:"
+  echo
+  echo "- http://localhost:8888/en (English)"
+  echo "- http://localhost:8888/ru (Russian)"
+  echo
+  echo "Press Ctrl+C in this window to stop the HTTP server."
+  echo
+  python3 -m http.server 8888 -d $1
+}
+
+DIR=${1:-"$TMPDIR"docs}
+
+# Check for python3 dependency needed for the server
+check_dependency "python3" "Python3" "https://www.python.org/downloads/"
+
+# Build the documentation
+echo "Building documentation..."
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+if ! "$SCRIPT_DIR/build.sh" "$DIR"; then
+  echo
+  echo "Build failed! Cannot start server."
+  exit 1
+fi
+
+# Start the HTTP server if build was successful
+start_server "$DIR"


### PR DESCRIPTION
### Changelog category <!-- remove all except one -->

* Documentation (changelog entry is not required)

### Description for reviewers <!-- (optional) description for those who read this PR -->

Serving via HTTP makes the script hang if you're just using grepping output to see if there're any errors.
