### PR TITLE
schemeshard: fix SyncTenant handling for dropped extsubdomains

### DIFF
--- a/ydb/core/tx/schemeshard/schemeshard_impl.cpp
+++ b/ydb/core/tx/schemeshard/schemeshard_impl.cpp
@@ -6045,6 +6045,17 @@ void TSchemeShard::Handle(TEvSchemeShard::TEvSyncTenantSchemeShard::TPtr& ev, co
         return;
     }
 
+    if (PathsById.at(pathId)->Dropped()) {
+        // This could happen when root schemeshard reboots just after marking subdomain's path as dropped
+        // but before being able to begin subdomain cleanup. Then, if tenant schemeshard tablet is still alive,
+        // it will detect disconnect error in pipe-to-parent, re-establish connection and send TEvSyncTenantSchemeShard.
+        // Root schemeshard should ignore it and should not register dropped subdomain in subdomain links again.
+        LOG_WARN_S(ctx, NKikimrServices::FLAT_TX_SCHEMESHARD, "Handle TEvSyncTenantSchemeShard, at schemeshard: " << TabletID()
+            << ", ignore spurious message from dropped subdomain's schemeshard (pre cleanup)" << pathId
+        );
+        return;
+    }
+
     if (SubDomainsLinks.Sync(ev, ctx)) {
         Execute(CreateTxSyncTenant(pathId), ctx);
     }


### PR DESCRIPTION
Fix possible crash in handling of spurious `TEvSchemeShard::TEvSyncTenantSchemeShard`:
- in root schemeshard
- sent from tenant schemeshard of an extsubdomain
- during extsubdomain drop process
- triggered by root schemeshard reboot

Follow-up to:
- https://github.com/ydb-platform/ydb/pull/21377

Issue #19842