### PR TITLE
Add new options to the "ydb workload topic read/write" scenarios

### DIFF
--- a/ydb/public/lib/ydb_cli/commands/topic_operations_scenario.cpp
+++ b/ydb/public/lib/ydb_cli/commands/topic_operations_scenario.cpp
@@ -286,7 +286,10 @@ void TTopicOperationsScenario::StartProducerThreads(std::vector<std::future<void
             .UseAutoPartitioning = useAutoPartitioning,
             .CommitIntervalMs = TxCommitIntervalMs != 0 ? TxCommitIntervalMs : CommitPeriodSeconds * 1000, // seconds to ms conversion
             .CommitMessages = CommitMessages,
-            .UseCpuTimestamp = UseCpuTimestamp
+            .UseCpuTimestamp = UseCpuTimestamp,
+            .KeyPrefix = KeyPrefix,
+            .KeyCount = KeyCount,
+            .KeySeed = writerIdx,
         };
 
         threads.push_back(std::async([writerParams = std::move(writerParams)]() { TTopicWorkloadWriterWorker::RetryableWriterLoop(writerParams); }));

--- a/ydb/public/lib/ydb_cli/commands/topic_operations_scenario.cpp
+++ b/ydb/public/lib/ydb_cli/commands/topic_operations_scenario.cpp
@@ -240,6 +240,8 @@ void TTopicOperationsScenario::StartConsumerThreads(std::vector<std::future<void
                 .UseTopicCommit = OnlyTopicInTx,
                 .UseTableSelect = UseTableSelect && !OnlyTopicInTx,
                 .UseTableUpsert = !OnlyTopicInTx,
+                .RestartInterval = RestartInterval,
+                .ReadWithoutCommit = ReadWithoutCommit,
                 .ReadWithoutConsumer = ReadWithoutConsumer,
                 .CommitPeriodMs = TxCommitIntervalMs != 0 ? TxCommitIntervalMs : CommitPeriodSeconds * 1000, // seconds to ms conversion,
                 .CommitMessages = CommitMessages

--- a/ydb/public/lib/ydb_cli/commands/topic_operations_scenario.cpp
+++ b/ydb/public/lib/ydb_cli/commands/topic_operations_scenario.cpp
@@ -44,6 +44,12 @@ void TTopicOperationsScenario::EnsureWarmupSecIsValid() const
     }
 }
 
+void TTopicOperationsScenario::EnsureRatesIsValid() const
+{
+    Y_ENSURE_EX(MessagesPerSec >= 0, TMisuseException() << "--messages-per-sec should be non negative.");
+    Y_ENSURE_EX(BytesPerSec >= 0, TMisuseException() << "--bytes-per-sec should be non negative.");
+}
+
 TString TTopicOperationsScenario::GetReadOnlyTableName() const
 {
     return TableName + "-ro";

--- a/ydb/public/lib/ydb_cli/commands/topic_operations_scenario.h
+++ b/ydb/public/lib/ydb_cli/commands/topic_operations_scenario.h
@@ -41,6 +41,7 @@ public:
 
     void EnsurePercentileIsValid() const;
     void EnsureWarmupSecIsValid() const;
+    void EnsureRatesIsValid() const;
 
     TString GetReadOnlyTableName() const;
     TString GetWriteOnlyTableName() const;
@@ -66,8 +67,8 @@ public:
     bool Direct = false;
     TString ConsumerPrefix;
     size_t MessageSizeBytes;
-    size_t MessagesPerSec;
-    size_t BytesPerSec;
+    double MessagesPerSec;
+    double BytesPerSec;
     ui32 Codec;
     TString TableName;
     ui32 TablePartitionCount = 1;

--- a/ydb/public/lib/ydb_cli/commands/topic_operations_scenario.h
+++ b/ydb/public/lib/ydb_cli/commands/topic_operations_scenario.h
@@ -79,6 +79,8 @@ public:
     bool OnlyTopicInTx = true;
     bool OnlyTableInTx = false;
     bool UseTableSelect = false;
+    TDuration RestartInterval = TDuration::Max();
+    bool ReadWithoutCommit = false;
     bool ReadWithoutConsumer = false;
     bool UseCpuTimestamp = false;
     TMaybe<TString> KeyPrefix;

--- a/ydb/public/lib/ydb_cli/commands/topic_operations_scenario.h
+++ b/ydb/public/lib/ydb_cli/commands/topic_operations_scenario.h
@@ -80,6 +80,8 @@ public:
     bool UseTableSelect = false;
     bool ReadWithoutConsumer = false;
     bool UseCpuTimestamp = false;
+    TMaybe<TString> KeyPrefix;
+    ui32 KeyCount = 0;
 
 protected:
     void CreateTopic(const TString& database,

--- a/ydb/public/lib/ydb_cli/commands/topic_workload/topic_workload_reader.h
+++ b/ydb/public/lib/ydb_cli/commands/topic_workload/topic_workload_reader.h
@@ -30,6 +30,8 @@ namespace NYdb {
             bool UseTopicCommit = false;
             bool UseTableSelect = false;
             bool UseTableUpsert = false;
+            TDuration RestartInterval = TDuration::Max();
+            bool ReadWithoutCommit = false;
             bool ReadWithoutConsumer = false;
             size_t CommitPeriodMs = 15'000;
             size_t CommitMessages = 1'000'000;

--- a/ydb/public/lib/ydb_cli/commands/topic_workload/topic_workload_run_full.cpp
+++ b/ydb/public/lib/ydb_cli/commands/topic_workload/topic_workload_run_full.cpp
@@ -114,6 +114,7 @@ void TCommandWorkloadTopicRunFull::Parse(TConfig& config)
 
     Scenario.EnsurePercentileIsValid();
     Scenario.EnsureWarmupSecIsValid();
+    Scenario.EnsureRatesIsValid();
 }
 
 int TCommandWorkloadTopicRunFull::Run(TConfig& config)

--- a/ydb/public/lib/ydb_cli/commands/topic_workload/topic_workload_run_full.cpp
+++ b/ydb/public/lib/ydb_cli/commands/topic_workload/topic_workload_run_full.cpp
@@ -81,6 +81,15 @@ void TCommandWorkloadTopicRunFull::Config(TConfig& config)
     config.Opts->AddLongOption("no-consumer", "Read without consumer")
         .Hidden()
         .StoreTrue(&Scenario.ReadWithoutConsumer);
+    config.Opts->AddLongOption("key-prefix", "Generate keys with this prefix. Put pair '__key':'{key-prefix}.{key-index}' in the message metadata.")
+        .Optional()
+        .Hidden()
+        .StoreResult(&Scenario.KeyPrefix);
+    config.Opts->AddLongOption("key-count", "The number of different keys to generate. The --key-prefix parameter must be set.")
+        .Optional()
+        .Hidden()
+        .DefaultValue(1)
+        .StoreResult(&Scenario.KeyCount);
 
     config.Opts->MutuallyExclusive("message-rate", "byte-rate");
 

--- a/ydb/public/lib/ydb_cli/commands/topic_workload/topic_workload_run_read.cpp
+++ b/ydb/public/lib/ydb_cli/commands/topic_workload/topic_workload_run_read.cpp
@@ -37,6 +37,12 @@ void TCommandWorkloadTopicRunRead::Config(TConfig& config)
     config.Opts->AddLongOption("no-consumer", "Read without consumer")
         .Hidden()
         .StoreTrue(&Scenario.ReadWithoutConsumer);
+    config.Opts->AddLongOption("no-commit", "Read without committing topic offsets")
+        .Hidden()
+        .StoreTrue(&Scenario.ReadWithoutCommit);
+    config.Opts->AddLongOption("restart-interval", "Recreate reader session period (ex. '100s', '3m')")
+        .Hidden()
+        .StoreMappedResult(&Scenario.RestartInterval, TDuration::Parse);
 
     // Specific params
     config.Opts->AddLongOption("consumer-prefix", "Use consumers with names '<consumer-prefix>-0' ... '<consumer-prefix>-<n-1>' where n is set in the '--consumers' option.")

--- a/ydb/public/lib/ydb_cli/commands/topic_workload/topic_workload_run_write.cpp
+++ b/ydb/public/lib/ydb_cli/commands/topic_workload/topic_workload_run_write.cpp
@@ -69,6 +69,15 @@ void TCommandWorkloadTopicRunWrite::Config(TConfig& config)
     config.Opts->AddLongOption("direct", "Direct write to a partition node.")
         .Hidden()
         .StoreTrue(&Scenario.Direct);
+    config.Opts->AddLongOption("key-prefix", "Generate keys with this prefix. Put pair '__key':'{key-prefix}.{key-index}' in the message metadata.")
+        .Optional()
+        .Hidden()
+        .StoreResult(&Scenario.KeyPrefix);
+    config.Opts->AddLongOption("key-count", "The number of different keys to generate. The --key-prefix parameter must be set.")
+        .Optional()
+        .Hidden()
+        .DefaultValue(1)
+        .StoreResult(&Scenario.KeyCount);
 
     config.Opts->MutuallyExclusive("message-rate", "byte-rate");
 

--- a/ydb/public/lib/ydb_cli/commands/topic_workload/topic_workload_run_write.cpp
+++ b/ydb/public/lib/ydb_cli/commands/topic_workload/topic_workload_run_write.cpp
@@ -114,6 +114,7 @@ void TCommandWorkloadTopicRunWrite::Parse(TConfig& config)
 
     Scenario.EnsurePercentileIsValid();
     Scenario.EnsureWarmupSecIsValid();
+    Scenario.EnsureRatesIsValid();
 }
 
 int TCommandWorkloadTopicRunWrite::Run(TConfig& config)

--- a/ydb/public/lib/ydb_cli/commands/topic_workload/topic_workload_writer.h
+++ b/ydb/public/lib/ydb_cli/commands/topic_workload/topic_workload_writer.h
@@ -38,6 +38,9 @@ namespace NYdb {
             size_t CommitIntervalMs = 15'000;
             size_t CommitMessages = 1'000'000;
             bool UseCpuTimestamp = false;
+            TMaybe<TString> KeyPrefix;
+            ui32 KeyCount = 0;
+            ui32 KeySeed = 0;
         };
 
         class TTopicWorkloadWriterProducer;

--- a/ydb/public/lib/ydb_cli/commands/topic_workload/topic_workload_writer.h
+++ b/ydb/public/lib/ydb_cli/commands/topic_workload/topic_workload_writer.h
@@ -23,7 +23,7 @@ namespace NYdb {
             const std::vector<TString>& GeneratedMessages;
             TString Database;
             TString TopicName;
-            size_t BytesPerSec;
+            double BytesPerSec;
             size_t MessageSize;
             ui32 ProducerThreadCount;
             ui32 WriterIdx;

--- a/ydb/public/lib/ydb_cli/commands/topic_workload/topic_workload_writer_producer.h
+++ b/ydb/public/lib/ydb_cli/commands/topic_workload/topic_workload_writer_producer.h
@@ -18,9 +18,9 @@ namespace NYdb::NConsoleClient {
                 const NUnifiedAgent::TClock& clock
                 );
         void Close();
-        
+
         void SetWriteSession(std::shared_ptr<NYdb::NTopic::IWriteSession> writeSession);
-        
+
         bool WaitForInitSeqNo();
 
         void WaitForContinuationToken(const TDuration& timeout);
@@ -41,6 +41,7 @@ namespace NYdb::NConsoleClient {
         void HandleSessionClosed(const NYdb::NTopic::TSessionClosedEvent& event);
     private:
         TString GetGeneratedMessage() const;
+        NTopic::TWriteMessage::TMessageMeta GenerateMessageMeta() const;
 
         std::shared_ptr<NYdb::NTopic::IWriteSession> WriteSession_;
         ui64 MessageId_ = 0;

--- a/ydb/public/lib/ydb_cli/commands/topic_workload/ut/topic_workload_writer_producer_ut.cpp
+++ b/ydb/public/lib/ydb_cli/commands/topic_workload/ut/topic_workload_writer_producer_ut.cpp
@@ -45,8 +45,8 @@ namespace NTests {
 
 
         class TFixture : public NUnitTest::TBaseFixture {
-        protected: 
-            TFixture() : 
+        protected:
+            TFixture() :
                 WriteSession(std::make_shared<MockWriteSession>()),
                 Clock(CreateClock()),
                 Log(CreateLogger()),
@@ -55,7 +55,7 @@ namespace NTests {
             std::shared_ptr<TTopicWorkloadStatsCollector> StatsCollector = std::make_shared<TTopicWorkloadStatsCollector>(
                 // we need error flag = true, cause without it, stats collector will go into the infinite loop
                 // during the call to PrintWindowStatsLoop. And this call is the only way to deque write events to
-                // statisitcs. 
+                // statisitcs.
                 1, 1, false, false, 5, 60, 0, 99, std::make_shared<std::atomic_bool>(true), false
             );
             std::shared_ptr<MockWriteSession> WriteSession;
@@ -108,7 +108,7 @@ namespace NTests {
                     }}};
         }
 
-        TTopicWorkloadWriterParams TFixture::CreateParams() {   
+        TTopicWorkloadWriterParams TFixture::CreateParams() {
             size_t messageSize = 100'000;
 
             return TTopicWorkloadWriterParams{
@@ -153,8 +153,8 @@ namespace NTests {
         void TFixture::InitContinuationToken(TTopicWorkloadWriterProducer& producer) {
             auto continuationToken = MockContinuationTokenIssuer::IssueContinuationToken();
             std::optional<TWriteSessionEvent::TEvent> event = std::variant<
-                    TWriteSessionEvent::TAcksEvent, 
-                    TWriteSessionEvent::TReadyToAcceptEvent, 
+                    TWriteSessionEvent::TAcksEvent,
+                    TWriteSessionEvent::TReadyToAcceptEvent,
                     TSessionClosedEvent
                     >(TWriteSessionEvent::TReadyToAcceptEvent(std::move(continuationToken)));
 
@@ -172,7 +172,7 @@ namespace NTests {
             auto createTime = TInstant::MilliSeconds(1730111050000);
             producer.Send(createTime, {});
             UNIT_ASSERT_EQUAL(0, StatsCollector->GetTotalWriteMessages());
-            // We need this call, cause only this call initializes StatsCollector.WarmupTime. 
+            // We need this call, cause only this call initializes StatsCollector.WarmupTime.
             // If it is not initialized, no events will be accepted.
             // Both here and below it will not go into the loop, cause we provided errorFlag into the constructor above.
             StatsCollector->PrintWindowStatsLoop();
@@ -180,7 +180,7 @@ namespace NTests {
             auto ackEvent = CreateAckEvent(1);
             producer.HandleAckEvent(ackEvent);
 
-            // We need this call, cause only this way collector will deque wrtie events to statisitcs. 
+            // We need this call, cause only this way collector will deque wrtie events to statisitcs.
             StatsCollector->PrintWindowStatsLoop();
             UNIT_ASSERT_VALUES_EQUAL(1, StatsCollector->GetTotalWriteMessages());
         }
@@ -196,13 +196,13 @@ namespace NTests {
 
             // assert
             EXPECT_CALL(*WriteSession, Write(
-                _, 
+                _,
                 testing::AllOf(
                     // first message id is initSeqNo + 1
-                    testing::Field(&TWriteMessage::Data, GeneratedMessages[initSeqNo + 1]), 
+                    testing::Field(&TWriteMessage::Data, GeneratedMessages[initSeqNo + 1]),
                     testing::Field(&TWriteMessage::SeqNo_, initSeqNo + 1),
                     testing::Field(&TWriteMessage::CreateTimestamp_, createTs)
-                ), 
+                ),
                 _
                 ));
 
@@ -213,17 +213,17 @@ namespace NTests {
         Y_UNIT_TEST_F(WaitForContinuationToken_ShouldExtractContinuationTokenFromEvent, TFixture) {
             auto producer = CreateProducer();
             UNIT_ASSERT(!producer.ContinuationTokenDefined());
-            
+
             InitContinuationToken(producer);
 
             UNIT_ASSERT(producer.ContinuationTokenDefined());
         }
-        
+
         Y_UNIT_TEST_F(WaitForContinuationToken_ShouldThrowExceptionIfEventOfTheWrongType, TFixture) {
             auto producer = CreateProducer();
             std::optional<TWriteSessionEvent::TEvent> event = std::variant<
-                    TWriteSessionEvent::TAcksEvent, 
-                    TWriteSessionEvent::TReadyToAcceptEvent, 
+                    TWriteSessionEvent::TAcksEvent,
+                    TWriteSessionEvent::TReadyToAcceptEvent,
                     TSessionClosedEvent
                     >(CreateAckEvent(123));
             ON_CALL(*WriteSession, GetEvent(_)).WillByDefault(testing::Return(event));

--- a/ydb/public/lib/ydb_cli/commands/transfer_workload/transfer_workload_topic_to_table_run.cpp
+++ b/ydb/public/lib/ydb_cli/commands/transfer_workload/transfer_workload_topic_to_table_run.cpp
@@ -123,6 +123,7 @@ void TCommandWorkloadTransferTopicToTableRun::Parse(TConfig& config)
 
     Scenario.EnsurePercentileIsValid();
     Scenario.EnsureWarmupSecIsValid();
+    Scenario.EnsureRatesIsValid();
 }
 
 int TCommandWorkloadTransferTopicToTableRun::Run(TConfig& config)


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

Generate `__key` keys in the "ydb workload topic run write" scenario. 

Support write rate with less than 1 RPS.

Add options to read without committing offsets and to restart reading sessions periodically.


### Changelog category <!-- remove all except one -->

* Not for changelog (changelog entry is not required)

### Description for reviewers <!-- (optional) description for those who read this PR -->
[
KIKIMR-23824
