### PR TITLE
25-1-3: schemeshard: quick-fix tenant system tablets deletion

### DIFF
--- a/ydb/core/testlib/tablet_helpers.h
+++ b/ydb/core/testlib/tablet_helpers.h
@@ -126,7 +126,7 @@ namespace NKikimr {
                 : DomainKey(domainKey)
             {}
         };
-        
+
         struct TEvRequestDomainInfoReply: public TEventLocal<TEvRequestDomainInfoReply, EvRequestDomainInfoReply> {
             NHive::TDomainInfo DomainInfo;
 
@@ -137,10 +137,20 @@ namespace NKikimr {
 
     };
 
+
+    // partial mirror of NHive::ETabletState states from ydb/core/mind/hive/hive.h
+    enum class ETabletState : ui64 {
+        Unknown = 0,        // THive::ETabletState::Unknown
+        Stopped = 100,      // THive::ETabletState::Stopped
+        ReadyToWork = 200,  // THive::ETabletState::ReadyToWork
+    };
+
     struct TFakeHiveTabletInfo {
         const TTabletTypes::EType Type;
         const ui64 TabletId;
         TActorId BootstrapperActorId;
+        ETabletState State = ETabletState::Unknown;
+        TSubDomainKey ObjectDomain;  // what subdomain tablet belongs to
 
         TChannelsBindings BoundChannels;
         ui32 ChannelsProfile;

--- a/ydb/core/tx/schemeshard/schemeshard__init.cpp
+++ b/ydb/core/tx/schemeshard/schemeshard__init.cpp
@@ -674,6 +674,25 @@ struct TSchemeShard::TTxInit : public TTransactionBase<TSchemeShard> {
         return true;
     }
 
+    bool LoadSystemShardsToDelete(NIceDb::TNiceDb& db, TShardsToDeleteRows& shardsToDelete) const {
+        {
+            auto rowSet = db.Table<Schema::SystemShardsToDelete>().Range().Select();
+            if (!rowSet.IsReady()) {
+                return false;
+            }
+            while (!rowSet.EndOfSet()) {
+                const auto shardIdx = Self->MakeLocalId(rowSet.GetValue<Schema::SystemShardsToDelete::ShardIdx>());
+                shardsToDelete.emplace_back(shardIdx);
+
+                if (!rowSet.Next()) {
+                    return false;
+                }
+            }
+        }
+
+        return true;
+    }
+
     typedef std::tuple<TOperationId, TShardIdx, TTxState::ETxState> TTxShardRec;
     typedef TVector<TTxShardRec> TTxShardsRows;
 
@@ -3790,6 +3809,23 @@ struct TSchemeShard::TTxInit : public TTransactionBase<TSchemeShard> {
             }
         }
 
+        // Read system shards to delete
+        {
+            TShardsToDeleteRows shardsToDelete;
+            if (!LoadSystemShardsToDelete(db, shardsToDelete)) {
+                return false;
+            }
+
+            LOG_NOTICE_S(ctx, NKikimrServices::FLAT_TX_SCHEMESHARD,
+                         "TTxInit for SystemShardToDelete"
+                             << ", read records: " << shardsToDelete.size()
+                             << ", at schemeshard: " << Self->TabletID());
+
+            for (auto& rec: shardsToDelete) {
+                OnComplete.DeleteSystemShard(std::get<0>(rec));
+            }
+        }
+
         // Read backup settings
         {
             TBackupSettingsRows backupSettings;
@@ -3845,7 +3881,7 @@ struct TSchemeShard::TTxInit : public TTransactionBase<TSchemeShard> {
                     auto desc = tableInfo->BackupSettings.MutableTable();
                     Y_ABORT_UNLESS(ParseFromStringNoSizeLimit(*desc, tableDesc));
                 }
-                
+
                 if (changefeedUnderlyingTopics) {
                     NKikimrSchemeOp::TChangefeedUnderlyingTopics wrapperOverTopics;
                     Y_ABORT_UNLESS(ParseFromStringNoSizeLimit(wrapperOverTopics, changefeedUnderlyingTopics));
@@ -4525,12 +4561,12 @@ struct TSchemeShard::TTxInit : public TTransactionBase<TSchemeShard> {
                 try {
                     fill(buildInfo);
                 } catch (const std::exception& exc) {
-                    LOG_ERROR_S(ctx, NKikimrServices::BUILD_INDEX, 
+                    LOG_ERROR_S(ctx, NKikimrServices::BUILD_INDEX,
                         "Init " << stepName << " unhandled exception, id#" << buildInfo.Id
                         << " " << TypeName(exc) << ": " << exc.what() << Endl
                         << TBackTrace::FromCurrentException().PrintToString()
                         << ", TIndexBuildInfo: " << buildInfo);
-        
+
                     // in-memory volatile state:
                     buildInfo.IsBroken = true;
                     buildInfo.AddIssue(TStringBuilder() << "Init " << stepName << " unhandled exception " << exc.what());
@@ -4541,7 +4577,7 @@ struct TSchemeShard::TTxInit : public TTransactionBase<TSchemeShard> {
                 const auto* buildInfoPtr = Self->IndexBuilds.FindPtr(id);
                 Y_ASSERT(buildInfoPtr);
                 if (!buildInfoPtr) {
-                    LOG_ERROR_S(ctx, NKikimrServices::BUILD_INDEX, 
+                    LOG_ERROR_S(ctx, NKikimrServices::BUILD_INDEX,
                         "Init " << stepName << " BuildInfo not found: id#" << id);
                     return;
                 }

--- a/ydb/core/tx/schemeshard/schemeshard__operation_side_effects.cpp
+++ b/ydb/core/tx/schemeshard/schemeshard__operation_side_effects.cpp
@@ -139,6 +139,13 @@ void TSideEffects::DeleteShard(TShardIdx idx) {
     ToDeleteShards.insert(idx);
 }
 
+void TSideEffects::DeleteSystemShard(TShardIdx idx) {
+    if (!idx) {
+        return; //KIKIMR-8507
+    }
+    ToDeleteSystemShards.insert(idx);
+}
+
 void TSideEffects::ToProgress(TIndexBuildId id) {
     IndexToProgress.push_back(id);
 }
@@ -186,6 +193,7 @@ void TSideEffects::ApplyOnExecute(TSchemeShard* ss, NTabletFlatExecutor::TTransa
     DoPersistDependencies(ss,txc, ctx);
 
     DoPersistDeleteShards(ss, txc, ctx);
+    DoPersistDeleteSystemShards(ss, txc, ctx);
 
     SetupRoutingLongOps(ss, ctx);
 }
@@ -225,6 +233,7 @@ void TSideEffects::ApplyOnComplete(TSchemeShard* ss, const TActorContext& ctx) {
     DoRegisterRelations(ss, ctx);
 
     DoTriggerDeleteShards(ss, ctx);
+    DoTriggerDeleteSystemShards(ss, ctx);
 
     ResumeLongOps(ss, ctx);
 }
@@ -753,6 +762,10 @@ void TSideEffects::DoTriggerDeleteShards(TSchemeShard *ss, const TActorContext &
     ss->DoShardsDeletion(ToDeleteShards, ctx);
 }
 
+void TSideEffects::DoTriggerDeleteSystemShards(TSchemeShard *ss, const TActorContext &ctx) {
+    ss->DoDeleteSystemShards(ToDeleteSystemShards, ctx);
+}
+
 void TSideEffects::DoReleasePathState(TSchemeShard *ss, const TActorContext &) {
     for (auto& rec: ReleasePathStateRecs) {
         TOperationId opId = InvalidOperationId;
@@ -777,6 +790,11 @@ void TSideEffects::DoReleasePathState(TSchemeShard *ss, const TActorContext &) {
 void TSideEffects::DoPersistDeleteShards(TSchemeShard *ss, NTabletFlatExecutor::TTransactionContext &txc, const TActorContext &) {
     NIceDb::TNiceDb db(txc.DB);
     ss->PersistShardsToDelete(db, ToDeleteShards);
+}
+
+void TSideEffects::DoPersistDeleteSystemShards(TSchemeShard *ss, NTabletFlatExecutor::TTransactionContext &txc, const TActorContext &) {
+    NIceDb::TNiceDb db(txc.DB);
+    ss->PersistSystemShardsToDelete(db, ToDeleteSystemShards);
 }
 
 void TSideEffects::DoUpdateTempDirsToMakeState(TSchemeShard* ss, const TActorContext &ctx) {

--- a/ydb/core/tx/schemeshard/schemeshard__operation_side_effects.h
+++ b/ydb/core/tx/schemeshard/schemeshard__operation_side_effects.h
@@ -56,6 +56,7 @@ private:
     THashSet<TOperationId> DoneOperations;
     THashSet<TTxId> DoneTransactions;
     THashSet<TShardIdx> ToDeleteShards;
+    THashSet<TShardIdx> ToDeleteSystemShards;  // temporary: special case for deleting tenant's system shards
     TDeque<TDependence> Dependencies;
     TDeque<TPathStateRec> ReleasePathStateRecs;
     THashSet<TPathId> TenantsToUpdate;
@@ -124,6 +125,7 @@ public:
     void PublishAndWaitPublication(TOperationId opId, TPathId pathId);
 
     void DeleteShard(TShardIdx idx);
+    void DeleteSystemShard(TShardIdx idx);
 
     void ToProgress(TIndexBuildId id);
 
@@ -153,6 +155,7 @@ private:
 
     void DoRegisterRelations(TSchemeShard* ss, const TActorContext& ctx);
     void DoTriggerDeleteShards(TSchemeShard* ss, const TActorContext &ctx);
+    void DoTriggerDeleteSystemShards(TSchemeShard *ss, const TActorContext &ctx);
 
     void DoReleasePathState(TSchemeShard* ss, const TActorContext &ctx);
     void DoDoneParts(TSchemeShard* ss, const TActorContext& ctx);
@@ -163,6 +166,7 @@ private:
     void DoActivateOps(TSchemeShard* ss, const TActorContext& ctx);
 
     void DoPersistDeleteShards(TSchemeShard* ss, NTabletFlatExecutor::TTransactionContext &txc, const TActorContext &ctx);
+    void DoPersistDeleteSystemShards(TSchemeShard* ss, NTabletFlatExecutor::TTransactionContext &txc, const TActorContext &ctx);
 
     void DoUpdateTempDirsToMakeState(TSchemeShard* ss, const TActorContext &ctx);
     void DoUpdateTempDirsToRemoveState(TSchemeShard* ss, const TActorContext &ctx);

--- a/ydb/core/tx/schemeshard/schemeshard_impl.cpp
+++ b/ydb/core/tx/schemeshard/schemeshard_impl.cpp
@@ -3354,9 +3354,17 @@ void TSchemeShard::PersistShardsToDelete(NIceDb::TNiceDb& db, const THashSet<TSh
     }
 }
 
+void TSchemeShard::PersistSystemShardsToDelete(NIceDb::TNiceDb& db, const THashSet<TShardIdx>& shardsIdxs) {
+    for (auto& shardIdx : shardsIdxs) {
+        Y_ABORT_UNLESS(IsLocalId(shardIdx));
+        db.Table<Schema::SystemShardsToDelete>().Key(shardIdx.GetLocalId()).Update();
+    }
+}
+
 void TSchemeShard::PersistShardDeleted(NIceDb::TNiceDb& db, TShardIdx shardIdx, const TChannelsBindings& bindedChannels) {
     if (shardIdx.GetOwnerId() == TabletID()) {
         db.Table<Schema::ShardsToDelete>().Key(shardIdx.GetLocalId()).Delete();
+        db.Table<Schema::SystemShardsToDelete>().Key(shardIdx.GetLocalId()).Delete();
         db.Table<Schema::Shards>().Key(shardIdx.GetLocalId()).Delete();
         for (ui32 channelId = 0; channelId < bindedChannels.size(); ++channelId) {
             db.Table<Schema::ChannelsBinding>().Key(shardIdx.GetLocalId(), channelId).Delete();
@@ -3375,6 +3383,7 @@ void TSchemeShard::PersistShardDeleted(NIceDb::TNiceDb& db, TShardIdx shardIdx, 
 void TSchemeShard::PersistUnknownShardDeleted(NIceDb::TNiceDb& db, TShardIdx shardIdx) {
     if (shardIdx.GetOwnerId() == TabletID()) {
         db.Table<Schema::ShardsToDelete>().Key(shardIdx.GetLocalId()).Delete();
+        db.Table<Schema::SystemShardsToDelete>().Key(shardIdx.GetLocalId()).Delete();
     }
 
     db.Table<Schema::MigratedShardsToDelete>().Key(shardIdx.GetOwnerId(), shardIdx.GetLocalId()).Delete();
@@ -4272,6 +4281,12 @@ void TSchemeShard::DoShardsDeletion(const THashSet<TShardIdx>& shardIdxs, const 
     }
 }
 
+void TSchemeShard::DoDeleteSystemShards(const THashSet<TShardIdx>& shards, const TActorContext& ctx) {
+    if (!shards.empty()) {
+        ShardDeleter.SendDeleteRequests(GetGlobalHive(ctx), shards, ShardInfos, ctx);
+    }
+}
+
 NKikimrSchemeOp::TPathVersion TSchemeShard::GetPathVersion(const TPath& path) const {
     NKikimrSchemeOp::TPathVersion result;
 
@@ -4982,6 +4997,9 @@ void TSchemeShard::StateWork(STFUNC_SIG) {
         HFuncTraced(TEvPrivate::TEvCleanDroppedPaths, Handle);
         HFuncTraced(TEvPrivate::TEvCleanDroppedSubDomains, Handle);
         HFuncTraced(TEvPrivate::TEvSubscribeToShardDeletion, Handle);
+
+        // Test-only notification
+        IgnoreFunc(TEvPrivate::TEvTestNotifySubdomainCleanup);
 
         HFuncTraced(TEvPrivate::TEvPersistTableStats, Handle);
         HFuncTraced(TEvPrivate::TEvPersistTopicStats, Handle);
@@ -5734,14 +5752,29 @@ void TSchemeShard::Handle(TEvTabletPipe::TEvServerDisconnected::TPtr &, const TA
 
 void TSchemeShard::Handle(TEvSchemeShard::TEvSyncTenantSchemeShard::TPtr& ev, const TActorContext& ctx) {
     const auto& record = ev->Get()->Record;
-    LOG_INFO_S(ctx, NKikimrServices::FLAT_TX_SCHEMESHARD,
-               "Handle TEvSyncTenantSchemeShard"
-                   << ", at schemeshard: " << TabletID()
-                   << ", msg: " << record.DebugString());
+    LOG_DEBUG_S(ctx, NKikimrServices::FLAT_TX_SCHEMESHARD, "Handle TEvSyncTenantSchemeShard, at schemeshard: " << TabletID()
+        << ", msg: " << record.ShortDebugString()
+    );
     Y_VERIFY_S(IsDomainSchemeShard, "unexpected message: schemeshard: " << TabletID() << " mgs: " << record.DebugString());
 
+    const TPathId pathId(record.GetDomainSchemeShard(), record.GetDomainPathId());
+
+    if (!SubDomains.contains(pathId)) {
+        LOG_WARN_S(ctx, NKikimrServices::FLAT_TX_SCHEMESHARD, "Handle TEvSyncTenantSchemeShard, at schemeshard: " << TabletID()
+            << ", ignore spurious message from dropped subdomain's schemeshard (partial cleanup)" << pathId
+        );
+        return;
+    }
+
+    if (!PathsById.contains(pathId)) {
+        LOG_WARN_S(ctx, NKikimrServices::FLAT_TX_SCHEMESHARD, "Handle TEvSyncTenantSchemeShard, at schemeshard: " << TabletID()
+            << ", ignore spurious message from dropped subdomain's schemeshard (full cleanup)" << pathId
+        );
+        return;
+    }
+
     if (SubDomainsLinks.Sync(ev, ctx)) {
-        Execute(CreateTxSyncTenant(TPathId(record.GetDomainSchemeShard(), record.GetDomainPathId())), ctx);
+        Execute(CreateTxSyncTenant(pathId), ctx);
     }
 }
 

--- a/ydb/core/tx/schemeshard/schemeshard_impl.cpp
+++ b/ydb/core/tx/schemeshard/schemeshard_impl.cpp
@@ -5773,6 +5773,17 @@ void TSchemeShard::Handle(TEvSchemeShard::TEvSyncTenantSchemeShard::TPtr& ev, co
         return;
     }
 
+    if (PathsById.at(pathId)->Dropped()) {
+        // This could happen when root schemeshard reboots just after marking subdomain's path as dropped
+        // but before being able to begin subdomain cleanup. Then, if tenant schemeshard tablet is still alive,
+        // it will detect disconnect error in pipe-to-parent, re-establish connection and send TEvSyncTenantSchemeShard.
+        // Root schemeshard should ignore it and should not register dropped subdomain in subdomain links again.
+        LOG_WARN_S(ctx, NKikimrServices::FLAT_TX_SCHEMESHARD, "Handle TEvSyncTenantSchemeShard, at schemeshard: " << TabletID()
+            << ", ignore spurious message from dropped subdomain's schemeshard (pre cleanup)" << pathId
+        );
+        return;
+    }
+
     if (SubDomainsLinks.Sync(ev, ctx)) {
         Execute(CreateTxSyncTenant(pathId), ctx);
     }

--- a/ydb/core/tx/schemeshard/schemeshard_impl.h
+++ b/ydb/core/tx/schemeshard/schemeshard_impl.h
@@ -663,6 +663,7 @@ public:
     void DropPaths(const THashSet<TPathId>& paths, TStepId step, TTxId txId, NIceDb::TNiceDb& db, const TActorContext& ctx);
 
     void DoShardsDeletion(const THashSet<TShardIdx>& shardIdx, const TActorContext& ctx);
+    void DoDeleteSystemShards(const THashSet<TShardIdx>& shards, const TActorContext& ctx);
 
     void SetPartitioning(TPathId pathId, const std::vector<TShardIdx>& partitioning);
     void SetPartitioning(TPathId pathId, TOlapStoreInfo::TPtr storeInfo);
@@ -761,6 +762,7 @@ public:
     void PersistParentDomain(NIceDb::TNiceDb& db, TPathId parentDomain) const;
     void PersistParentDomainEffectiveACL(NIceDb::TNiceDb& db, const TString& owner, const TString& effectiveACL, ui64 effectiveACLVersion) const;
     void PersistShardsToDelete(NIceDb::TNiceDb& db, const THashSet<TShardIdx>& shardsIdxs);
+    void PersistSystemShardsToDelete(NIceDb::TNiceDb& db, const THashSet<TShardIdx>& shardsIdxs);
     void PersistShardDeleted(NIceDb::TNiceDb& db, TShardIdx shardIdx, const TChannelsBindings& bindedChannels);
     void PersistUnknownShardDeleted(NIceDb::TNiceDb& db, TShardIdx shardIdx);
     void PersistTxShardStatus(NIceDb::TNiceDb& db, TOperationId opId, TShardIdx shardIdx, const TTxState::TShardStatus& status);

--- a/ydb/core/tx/schemeshard/schemeshard_private.h
+++ b/ydb/core/tx/schemeshard/schemeshard_private.h
@@ -41,6 +41,7 @@ namespace TEvPrivate {
         EvRunDataErasure,
         EvRunTenantDataErasure,
         EvAddNewShardToDataErasure,
+        EvTestNotifySubdomainCleanup,
         EvEnd
     };
 
@@ -168,6 +169,14 @@ namespace TEvPrivate {
 
         explicit TEvNotifyShardDeleted(const TShardIdx& shardIdx)
             : ShardIdx(shardIdx)
+        { }
+    };
+
+    struct TEvTestNotifySubdomainCleanup : public TEventLocal<TEvTestNotifySubdomainCleanup, EvTestNotifySubdomainCleanup> {
+        TPathId SubdomainPathId;
+
+        explicit TEvTestNotifySubdomainCleanup(const TPathId& subdomainPathId)
+            : SubdomainPathId(subdomainPathId)
         { }
     };
 

--- a/ydb/core/tx/schemeshard/schemeshard_schema.h
+++ b/ydb/core/tx/schemeshard/schemeshard_schema.h
@@ -2058,6 +2058,13 @@ struct Schema : NIceDb::Schema {
         >;
     };
 
+    struct SystemShardsToDelete : Table<124> {
+        struct ShardIdx : Column<1, NScheme::NTypeIds::Uint64> { using Type = TLocalShardIdx; };
+
+        using TKey = TableKey<ShardIdx>;
+        using TColumns = TableColumns<ShardIdx>;
+    };
+
     using TTables = SchemaTables<
         Paths,
         TxInFlight,
@@ -2175,7 +2182,8 @@ struct Schema : NIceDb::Schema {
         WaitingDataErasureTenants,
         TenantDataErasureGenerations,
         WaitingDataErasureShards,
-        KMeansTreeClusters
+        KMeansTreeClusters,
+        SystemShardsToDelete
     >;
 
     static constexpr ui64 SysParam_NextPathId = 1;

--- a/ydb/core/tx/schemeshard/schemeshard_shard_deleter.cpp
+++ b/ydb/core/tx/schemeshard/schemeshard_shard_deleter.cpp
@@ -12,9 +12,13 @@ void TShardDeleter::Shutdown(const NActors::TActorContext &ctx) {
 }
 
 void TShardDeleter::SendDeleteRequests(TTabletId hiveTabletId,
-                                       const THashSet<TShardIdx> &shardsToDelete,
-                                       const THashMap<NKikimr::NSchemeShard::TShardIdx, NKikimr::NSchemeShard::TShardInfo>& shardsInfos,
-                                       const NActors::TActorContext &ctx) {
+        const THashSet<TShardIdx> &shardsToDelete,
+        const THashMap<NKikimr::NSchemeShard::TShardIdx,
+        NKikimr::NSchemeShard::TShardInfo>& shardsInfos,
+        const NActors::TActorContext &ctx
+    ) {
+    LOG_DEBUG_S(ctx, NKikimrServices::FLAT_TX_SCHEMESHARD, "SendDeleteRequests, shardsToDelete " << shardsToDelete.size()<< ", to hive " << hiveTabletId << ", at schemeshard " << MyTabletID);
+
     if (shardsToDelete.empty())
         return;
 

--- a/ydb/core/tx/schemeshard/ut_extsubdomain/ut_extsubdomain.cpp
+++ b/ydb/core/tx/schemeshard/ut_extsubdomain/ut_extsubdomain.cpp
@@ -1,8 +1,11 @@
 #include <ydb/core/tx/schemeshard/ut_helpers/helpers.h>
 
+#include <ydb/public/lib/value/value.h>
+
 using namespace NKikimr;
 using namespace NSchemeShard;
 using namespace NSchemeShardUT_Private;
+
 
 Y_UNIT_TEST_SUITE(TSchemeShardExtSubDomainTest) {
     Y_UNIT_TEST(Fake) {
@@ -1458,6 +1461,145 @@ Y_UNIT_TEST_SUITE(TSchemeShardExtSubDomainTest) {
         // env.TestWaitTabletDeletion(runtime, xrange(TTestTxConfig::FakeHiveTablets, TTestTxConfig::FakeHiveTablets + 5));
         UNIT_ASSERT(!CheckLocalRowExists(runtime, TTestTxConfig::SchemeShard, "SubDomains", "PathId", 2));
         UNIT_ASSERT(!CheckLocalRowExists(runtime, TTestTxConfig::SchemeShard, "Paths", "Id", 2));
+    }
+
+    Y_UNIT_TEST_FLAG(DropWithDeadTenantHive, AlterDatabaseCreateHiveFirst) {
+        TTestBasicRuntime runtime;
+        TTestEnv env(runtime, TTestEnvOptions().EnableAlterDatabaseCreateHiveFirst(AlterDatabaseCreateHiveFirst));
+        ui64 txId = 100;
+
+        // EnableAlterDatabaseCreateHiveFirst = false puts extsubdomain's system tablets into the root hive control.
+        // EnableAlterDatabaseCreateHiveFirst = true puts extsubdomain's tenant hive into the root hive control
+        // and other system tablets into the tenant hive control.
+
+        TestCreateExtSubDomain(runtime, ++txId,  "/MyRoot",
+            R"(Name: "USER_0")"
+        );
+
+        TestAlterExtSubDomain(runtime, ++txId,  "/MyRoot", R"(
+            Name: "USER_0"
+            ExternalSchemeShard: true
+            PlanResolution: 50
+            Coordinators: 1
+            Mediators: 1
+            TimeCastBucketsPerMediator: 2
+            StoragePools {
+                Name: "pool-1"
+                Kind: "hdd"
+            }
+
+            ExternalHive: true
+        )");
+        env.TestWaitNotification(runtime, {txId, txId - 1});
+
+        ui64 tenantHiveId = 0;
+        TPathId subdomainPathId;
+        {
+            auto describe = DescribePath(runtime, "/MyRoot/USER_0");
+            TestDescribeResult(describe, {
+                NLs::PathExist,
+                NLs::IsExternalSubDomain("USER_0"),
+                NLs::ExtractDomainHive(&tenantHiveId),
+            });
+            TSubDomainKey subdomainKey(describe.GetPathDescription().GetDomainDescription().GetDomainKey());
+            subdomainPathId = TPathId(subdomainKey.GetSchemeShard(), subdomainKey.GetPathId());
+        }
+
+        // check that there is a new path in the root schemeshard
+        UNIT_ASSERT(CheckLocalRowExists(runtime, TTestTxConfig::SchemeShard, "Paths", "Id", subdomainPathId.LocalPathId));
+        UNIT_ASSERT(CheckLocalRowExists(runtime, TTestTxConfig::SchemeShard, "SubDomains", "PathId", subdomainPathId.LocalPathId));
+
+        // check what extsubdomain's system tablets controls root hive
+        const auto expectedTabletsInRootHive = [&]() {
+            if (AlterDatabaseCreateHiveFirst) {
+                return std::vector<ETabletType::EType>({
+                    ETabletType::Hive,
+                });
+            } else {
+                return std::vector<ETabletType::EType>{{
+                    ETabletType::Hive,
+                    ETabletType::SchemeShard,
+                    ETabletType::Coordinator,
+                    ETabletType::Mediator
+                }};
+            }
+        }();
+        {
+            const auto& expectedTypes = expectedTabletsInRootHive;
+            const auto tablets = HiveGetSubdomainTablets(runtime, TTestTxConfig::Hive, subdomainPathId);
+            UNIT_ASSERT_VALUES_EQUAL_C(tablets.size(), expectedTypes.size(), "-- unexpected tablet count in root hive for the tenant");
+            for (const auto& tablet : tablets) {
+                Cerr << "root hive, tablets for subdomain " << subdomainPathId << ", tablet type " << tablet.GetTabletType() << Endl;
+                auto found = std::find(expectedTypes.begin(), expectedTypes.end(), tablet.GetTabletType());
+                UNIT_ASSERT_C(found != expectedTypes.end(), "-- root hive holds tablet of unexpected type " << tablet.GetTabletType());
+            }
+        }
+
+        // check what extsubdomain's system tablets controls tenant hive
+        const auto expectedTabletsInTenantHive = [&]() {
+            if (AlterDatabaseCreateHiveFirst) {
+                return std::vector<ETabletType::EType>{{
+                    ETabletType::SchemeShard,
+                    ETabletType::Coordinator,
+                    ETabletType::Mediator
+                }};
+            } else {
+                return std::vector<ETabletType::EType>{};
+            }
+        }();
+        {
+            const auto& expectedTypes = expectedTabletsInTenantHive;
+            const auto tablets = HiveGetSubdomainTablets(runtime, tenantHiveId, subdomainPathId);
+            UNIT_ASSERT_VALUES_EQUAL_C(tablets.size(), expectedTypes.size(), "-- unexpected tablet count in tenant hive");
+            for (const auto& tablet : tablets) {
+                Cerr << "tenant hive, tablets for subdomain " << subdomainPathId << ", tablet type " << tablet.GetTabletType() << Endl;
+                auto found = std::find(expectedTypes.begin(), expectedTypes.end(), tablet.GetTabletType());
+                UNIT_ASSERT_C(found != expectedTypes.end(), "-- root hive holds tablet of unexpected type " << tablet.GetTabletType());
+            }
+        }
+
+        // extsubdomain drop should be independent of tenant hive's state.
+        // It must correctly remove database whether tenant nodes and tablets are alive or not.
+        //
+        // Make tenant hive inaccessible by stopping its tablet.
+        // In real life that could be, for example, due to absence of tenant nodes.
+        //
+        // Tenant hive is controlled by the root hive (running at node 0).
+        HiveStopTablet(runtime, TTestTxConfig::Hive, tenantHiveId, 0);
+
+        // drop extsubdomain
+        TestForceDropExtSubDomain(runtime, ++txId, "/MyRoot", "USER_0");
+        env.TestWaitNotification(runtime, txId);
+
+        TestDescribeResult(DescribePath(runtime, "/MyRoot/USER_0"), {NLs::PathNotExist});
+
+        TestDescribeResult(DescribePath(runtime, "/MyRoot"), {
+            NLs::PathExist,
+            NLs::PathsInsideDomain(0),
+            NLs::ShardsInsideDomain(0)
+        });
+
+        // check that extsubdomain's system tablets are deleted from the root hive
+        // and not-working state of the tenant hive is unable to hinder that
+        {
+            const auto tablets = HiveGetSubdomainTablets(runtime, TTestTxConfig::Hive, subdomainPathId);
+            UNIT_ASSERT_C(tablets.size() == 0, TStringBuilder()
+                << "-- existing subdomain's system tablets in the root hive: expected 0, got " << tablets.size()
+            );
+        }
+
+        // check that extsubdomain's path is really erased from the root schemeshard
+
+        {
+            const auto result = ReadLocalTableRecords(runtime, TTestTxConfig::SchemeShard, "SystemShardsToDelete", "ShardIdx");
+            const auto records = NKikimr::NClient::TValue::Create(result)[0]["List"];
+            //DEBUG:  Cerr << "TEST: SystemShardsToDelete: " << records.GetValueText<NKikimr::NClient::TFormatJSON>() << Endl;
+            //DEBUG:  Cerr << "TEST: " << records.DumpToString() << Endl;
+            UNIT_ASSERT_VALUES_EQUAL(records.Size(), 0);
+        }
+
+        UNIT_ASSERT(!CheckLocalRowExists(runtime, TTestTxConfig::SchemeShard, "SubDomains", "PathId", subdomainPathId.LocalPathId));
+        UNIT_ASSERT(!CheckLocalRowExists(runtime, TTestTxConfig::SchemeShard, "Paths", "Id", subdomainPathId.LocalPathId));
     }
 
     Y_UNIT_TEST_FLAG(CreateThenDropChangesParent, AlterDatabaseCreateHiveFirst) {

--- a/ydb/core/tx/schemeshard/ut_extsubdomain_reboots/ut_extsubdomain_reboots.cpp
+++ b/ydb/core/tx/schemeshard/ut_extsubdomain_reboots/ut_extsubdomain_reboots.cpp
@@ -1,9 +1,8 @@
 #include <ydb/core/tx/schemeshard/ut_helpers/helpers.h>
+#include <ydb/core/testlib/actors/wait_events.h>
 
-#include <ydb/core/tx/datashard/datashard.h>
-#include <ydb/core/protos/flat_scheme_op.pb.h>
+#include <ydb/public/lib/value/value.h>
 
-#include <google/protobuf/text_format.h>
 
 using namespace NKikimr;
 using namespace NSchemeShard;
@@ -13,7 +12,7 @@ Y_UNIT_TEST_SUITE(TSchemeShardTestExtSubdomainReboots) {
     Y_UNIT_TEST(Fake) {
     }
 
-    Y_UNIT_TEST_FLAG(CreateExternalSubdomain, AlterDatabaseCreateHiveFirst) {
+    Y_UNIT_TEST_FLAG(CreateExtSubdomainWithHive, AlterDatabaseCreateHiveFirst) {
         TTestWithReboots t;
         t.GetTestEnvOptions().EnableAlterDatabaseCreateHiveFirst(AlterDatabaseCreateHiveFirst);
         t.Run([&](TTestActorRuntime& runtime, bool& activeZone) {
@@ -98,7 +97,140 @@ Y_UNIT_TEST_SUITE(TSchemeShardTestExtSubdomainReboots) {
         });
     }
 
-    Y_UNIT_TEST_FLAG(CreateExternalSubdomainWithoutHive, AlterDatabaseCreateHiveFirst) {
+    Y_UNIT_TEST_FLAGS(DropExtSubdomain, AlterDatabaseCreateHiveFirst, ExternalHive) {
+        TTestWithReboots t;
+        t.GetTestEnvOptions().EnableAlterDatabaseCreateHiveFirst(AlterDatabaseCreateHiveFirst);
+
+        t.Run([&](TTestActorRuntime& runtime, bool& activeZone) {
+
+            TestCreateExtSubDomain(runtime, ++t.TxId,  "/MyRoot",
+                R"(Name: "USER_0")"
+            );
+            t.TestEnv->TestWaitNotification(runtime, t.TxId);
+
+            TPathId subdomainPathId;
+            {
+                TInactiveZone inactive(activeZone);
+
+                auto describe = DescribePath(runtime, "/MyRoot/USER_0");
+                TestDescribeResult(describe, {
+                    NLs::PathExist,
+                    NLs::IsExternalSubDomain("USER_0"),
+                    NLs::DomainCoordinators({}),
+                    NLs::DomainMediators({}),
+                    NLs::DomainSchemeshard(0),
+                    NLs::DomainHive(0)
+                });
+                TSubDomainKey subdomainKey = TSubDomainKey(describe.GetPathDescription().GetDomainDescription().GetDomainKey());
+                subdomainPathId = TPathId(subdomainKey.GetSchemeShard(), subdomainKey.GetPathId());
+                UNIT_ASSERT_VALUES_EQUAL(subdomainPathId.LocalPathId, 3);
+
+                TestDescribeResult(DescribePath(runtime, "/MyRoot"), {
+                    NLs::ChildrenCount(2)
+                });
+
+                UNIT_ASSERT(CheckLocalRowExists(runtime, TTestTxConfig::SchemeShard, "Paths", "Id", subdomainPathId.LocalPathId));
+                UNIT_ASSERT(CheckLocalRowExists(runtime, TTestTxConfig::SchemeShard, "SubDomains", "PathId", subdomainPathId.LocalPathId));
+
+                // Register observer for future extsubdomain cleanup notification
+                t.TestEnv->AddExtSubdomainCleanupObserver(runtime, subdomainPathId);
+            }
+
+            TestAlterExtSubDomain(runtime, ++t.TxId,  "/MyRoot",
+                Sprintf(R"(
+                        Name: "USER_0"
+
+                        StoragePools {
+                            Name: "tenant-1:hdd"
+                            Kind: "hdd"
+                        }
+                        PlanResolution: 50
+                        Coordinators: 1
+                        Mediators: 1
+                        TimeCastBucketsPerMediator: 2
+
+                        ExternalHive: %s
+                        ExternalSchemeShard: true
+                    )",
+                    ToString(ExternalHive).c_str()
+                )
+            );
+            t.TestEnv->TestWaitNotification(runtime, t.TxId);
+
+            ui64 tenantHiveId = 0;
+            {
+                TInactiveZone inactive(activeZone);
+
+                auto describe = DescribePath(runtime, "/MyRoot/USER_0");
+                TestDescribeResult(describe, {
+                    NLs::PathExist,
+                    NLs::IsExternalSubDomain("USER_0"),
+                    NLs::ExtractDomainHive(&tenantHiveId),
+                });
+
+                if (ExternalHive) {
+                    // extsubdomain drop should be independent of tenant hive's state.
+                    // It must correctly remove database whether tenant nodes and tablets are alive or not.
+                    //
+                    // Make tenant hive inaccessible by stopping its tablet.
+                    // In real life that could be, for example, due to absence of tenant nodes.
+                    //
+                    // Tenant hive is controlled by the root hive (running at node 0).
+                    HiveStopTablet(runtime, TTestTxConfig::Hive, tenantHiveId, 0);
+                }
+            }
+
+            // drop extsubdomain
+            TestForceDropExtSubDomain(runtime, ++t.TxId, "/MyRoot", "USER_0");
+            t.TestEnv->TestWaitNotification(runtime, t.TxId);
+
+            {
+                TInactiveZone inactive(activeZone);
+
+                TestDescribeResult(DescribePath(runtime, "/MyRoot/USER_0"), {
+                    NLs::PathNotExist
+                });
+
+                TestDescribeResult(DescribePath(runtime, "/MyRoot"), {
+                    NLs::PathExist,
+                    NLs::ShardsInsideDomain(0)
+                });
+
+                // wait for it to be really cleaned up
+                t.TestEnv->WaitForExtSubdomainCleanup(runtime, subdomainPathId);
+
+                // check that extsubdomain's system tablets are deleted from the root hive
+                // and not-working state of the tenant hive was unable to hinder that
+                {
+                    const auto tablets = HiveGetSubdomainTablets(runtime, TTestTxConfig::Hive, subdomainPathId);
+                    UNIT_ASSERT_C(tablets.size() == 0, TStringBuilder()
+                        << "-- existing subdomain's system tablets in the root hive: expected 0, got " << tablets.size()
+                    );
+                }
+
+                // check that extsubdomain's path is really erased from the root schemeshard
+
+                TestDescribeResult(DescribePath(runtime, "/MyRoot"), {
+                    NLs::PathExist,
+                    NLs::PathsInsideDomain(1)  // infamous /MyRoot/DirA, created in TTestWithReboots::Prepare()
+                });
+
+                {
+                    const auto result = ReadLocalTableRecords(runtime, TTestTxConfig::SchemeShard, "SystemShardsToDelete", "ShardIdx");
+                    const auto records = NKikimr::NClient::TValue::Create(result)[0]["List"];
+                    //DEBUG: Cerr << "TEST: SystemShardsToDelete: " << records.GetValueText<NKikimr::NClient::TFormatJSON>() << Endl;
+                    //DEBUG: Cerr << "TEST: " << records.DumpToString() << Endl;
+                    UNIT_ASSERT_VALUES_EQUAL(records.Size(), 0);
+                }
+
+                UNIT_ASSERT(!CheckLocalRowExists(runtime, TTestTxConfig::SchemeShard, "SubDomains", "PathId", subdomainPathId.LocalPathId));
+                UNIT_ASSERT(!CheckLocalRowExists(runtime, TTestTxConfig::SchemeShard, "Paths", "Id", subdomainPathId.LocalPathId));
+            }
+
+        });
+    }
+
+    Y_UNIT_TEST_FLAG(CreateExtSubdomainNoHive, AlterDatabaseCreateHiveFirst) {
         TTestWithReboots t;
         t.GetTestEnvOptions().EnableAlterDatabaseCreateHiveFirst(AlterDatabaseCreateHiveFirst);
         t.Run([&](TTestActorRuntime& runtime, bool& activeZone) {
@@ -198,7 +330,7 @@ Y_UNIT_TEST_SUITE(TSchemeShardTestExtSubdomainReboots) {
         });
     }
 
-    Y_UNIT_TEST_FLAG(AlterForceDrop, AlterDatabaseCreateHiveFirst) {
+    Y_UNIT_TEST_FLAGS(AlterForceDrop, AlterDatabaseCreateHiveFirst, ExternalHive) {
         TTestWithReboots t;
         t.GetTestEnvOptions().EnableAlterDatabaseCreateHiveFirst(AlterDatabaseCreateHiveFirst);
         t.Run([&](TTestActorRuntime& runtime, bool& activeZone) {
@@ -211,18 +343,22 @@ Y_UNIT_TEST_SUITE(TSchemeShardTestExtSubdomainReboots) {
             }
 
             AsyncAlterExtSubDomain(runtime, ++t.TxId,  "/MyRoot",
-                R"(
-                    StoragePools {
-                        Name: "tenant-1:hdd"
-                        Kind: "hdd"
-                    }
-                    PlanResolution: 50
-                    Coordinators: 3
-                    Mediators: 2
-                    TimeCastBucketsPerMediator: 2
-                    ExternalSchemeShard: true
-                    Name: "USER_0"
-                )"
+                Sprintf(R"(
+                        StoragePools {
+                            Name: "tenant-1:hdd"
+                            Kind: "hdd"
+                        }
+                        PlanResolution: 50
+                        Coordinators: 3
+                        Mediators: 2
+                        TimeCastBucketsPerMediator: 2
+                        ExternalSchemeShard: true
+                        Name: "USER_0"
+
+                        ExternalHive: %s
+                    )",
+                    ToString(ExternalHive).c_str()
+                )
             );
             t.TestEnv->ReliablePropose(runtime, ForceDropExtSubDomainRequest(++t.TxId, "/MyRoot", "USER_0"),
                                        {NKikimrScheme::StatusAccepted});
@@ -244,14 +380,14 @@ Y_UNIT_TEST_SUITE(TSchemeShardTestExtSubdomainReboots) {
     }
 
 
-    Y_UNIT_TEST_FLAG(SchemeLimits, AlterDatabaseCreateHiveFirst) {
+    Y_UNIT_TEST_FLAGS(SchemeLimits, AlterDatabaseCreateHiveFirst, ExternalHive) {
         TTestWithReboots t;
         t.GetTestEnvOptions().EnableAlterDatabaseCreateHiveFirst(AlterDatabaseCreateHiveFirst);
         t.Run([&](TTestActorRuntime& runtime, bool& activeZone) {
             TSchemeLimits limits;
             limits.MaxDepth = 2;
-            limits.MaxShards = 3;
             limits.MaxPaths = 2;
+            limits.MaxShards = 3 + (ExternalHive ? 1 : 0);
 
             {
                 TInactiveZone inactive(activeZone);
@@ -265,46 +401,39 @@ Y_UNIT_TEST_SUITE(TSchemeShardTestExtSubdomainReboots) {
             }
 
             TestAlterExtSubDomain(runtime, ++t.TxId,  "/MyRoot",
-                R"(
-                    StoragePools {
-                        Name: "tenant-1:hdd"
-                        Kind: "hdd"
-                    }
-                    PlanResolution: 50
-                    Coordinators: 1
-                    Mediators: 1
-                    TimeCastBucketsPerMediator: 2
-                    ExternalSchemeShard: true
-                    Name: "USER_0"
-                )"
+                Sprintf(R"(
+                        StoragePools {
+                            Name: "tenant-1:hdd"
+                            Kind: "hdd"
+                        }
+                        PlanResolution: 50
+                        Coordinators: 1
+                        Mediators: 1
+                        TimeCastBucketsPerMediator: 2
+                        ExternalSchemeShard: true
+                        Name: "USER_0"
+
+                        ExternalHive: %s
+                    )",
+                    ToString(ExternalHive).c_str()
+                )
             );
             t.TestEnv->TestWaitNotification(runtime, t.TxId);
 
             {
                 TInactiveZone inactive(activeZone);
+
+                ui64 subdomainSchemeshard;
                 TestDescribeResult(DescribePath(runtime, "/MyRoot/USER_0"),
                                    {NLs::PathExist,
                                     NLs::IsExternalSubDomain("USER_0"),
+                                    NLs::ExtractTenantSchemeshard(&subdomainSchemeshard),
+                                    NLs::ShardsInsideDomain(limits.MaxShards),
                                     NLs::DomainLimitsIs(limits.MaxPaths, limits.MaxShards)});
 
                 TestDescribeResult(DescribePath(runtime, "/MyRoot"),
                                    {NLs::ChildrenCount(2),
                                     NLs::DomainLimitsIs(limits.MaxPaths, limits.MaxShards)});
-
-                ui64 subdomainSchemeshard = TTestTxConfig::FakeHiveTablets;
-
-                TestDescribeResult(DescribePath(runtime, subdomainSchemeshard, "/MyRoot/USER_0"),
-                                   {NLs::PathExist,
-                                    NLs::IsSubDomain("MyRoot/USER_0"),
-                                    NLs::DomainKey(3, TTestTxConfig::SchemeShard),
-                                    // internal knowledge of shard declaration sequence is used here
-                                    NLs::DomainSchemeshard(subdomainSchemeshard),
-                                    NLs::DomainCoordinators({TTestTxConfig::FakeHiveTablets+1}),
-                                    NLs::DomainMediators({TTestTxConfig::FakeHiveTablets+2}),
-                                    NLs::DomainLimitsIs(limits.MaxPaths, limits.MaxShards),
-                                    NLs::ShardsInsideDomain(3),
-                                    NLs::PathsInsideDomain(0)
-                                   });
 
                 TestCreateTable(runtime, subdomainSchemeshard, ++t.TxId, "/MyRoot/USER_0", R"(
                             Name: "Table"

--- a/ydb/core/tx/schemeshard/ut_helpers/helpers.cpp
+++ b/ydb/core/tx/schemeshard/ut_helpers/helpers.cpp
@@ -44,6 +44,44 @@ namespace NSchemeShardUT_Private {
         runtime.GrabEdgeEventRethrow<NConsole::TEvConsole::TEvConfigNotificationResponse>(handle);
     }
 
+    ////////// Hive
+
+    // Stop tablet.
+    // Also see ydb/core/mind/hive/hive_ut.cpp, SendStopTablet
+    void HiveStopTablet(TTestActorRuntime &runtime, ui64 hiveTablet, ui64 tabletId, ui32 nodeIndex) {
+        TActorId senderB = runtime.AllocateEdgeActor(nodeIndex);
+        runtime.SendToPipe(hiveTablet, senderB, new TEvHive::TEvStopTablet(tabletId), 0, GetPipeConfigWithRetries());
+        TAutoPtr<IEventHandle> handle;
+        auto event = runtime.GrabEdgeEventRethrow<TEvHive::TEvStopTabletResult>(handle);
+        UNIT_ASSERT(event);
+        const auto& stopResult = event->Record;
+        UNIT_ASSERT_EQUAL_C(stopResult.GetTabletID(), tabletId, stopResult.GetTabletID() << " != " << tabletId);
+        UNIT_ASSERT_EQUAL_C(stopResult.GetStatus(), NKikimrProto::OK, (ui32)stopResult.GetStatus() << " != " << (ui32)NKikimrProto::OK);
+    }
+
+    // Retrieve tablets that belong to the given subdomain
+    std::vector<NKikimrHive::TTabletInfo> HiveGetSubdomainTablets(TTestActorRuntime &runtime, const ui64 hiveTablet, const TPathId& subdomainPathId) {
+        TActorId senderA = runtime.AllocateEdgeActor();
+        runtime.SendToPipe(hiveTablet, senderA, new TEvHive::TEvRequestHiveInfo(), 0, GetPipeConfigWithRetries());
+        TAutoPtr<IEventHandle> handle;
+        auto event = runtime.GrabEdgeEventRethrow<TEvHive::TEvResponseHiveInfo>(handle);
+        UNIT_ASSERT(event);
+        const auto& response = event->Record;
+
+        // Cerr << "TEST: HiveGetSubdomainTablets: " << response.ShortDebugString() << Endl;
+
+        std::vector<NKikimrHive::TTabletInfo> result;
+        std::copy_if(response.GetTablets().begin(), response.GetTablets().end(),
+            std::back_inserter(result),
+            [&subdomainPathId] (auto& tablet) {
+                return (tablet.GetObjectDomain().GetSchemeShard() == subdomainPathId.OwnerId
+                    && tablet.GetObjectDomain().GetPathId() == subdomainPathId.LocalPathId
+                );
+            }
+        );
+        return result;
+    }
+
     template <typename TEvResponse, typename TEvRequest, typename TStatus>
     static ui32 ReliableProposeImpl(
         NActors::TTestActorRuntime& runtime, const TActorId& proposer,
@@ -1331,6 +1369,30 @@ namespace NSchemeShardUT_Private {
         // Row missing: Value { Struct { Optional { } } } }
         return result.GetValue().GetStruct(0).GetOptional().HasOptional();
     }
+
+    // Read records from a local table by a single component key
+    NKikimrMiniKQL::TResult ReadLocalTableRecords(TTestActorRuntime& runtime, ui64 tabletId, const TString& tableName, const TString& keyColumn) {
+        const auto query = Sprintf(
+            R"(
+                (
+                    (let range '('('%s (Null) (Void))))
+                    (let fields '('%s))
+                    (return (AsList
+                        (SetResult 'Result (SelectRange '%s range fields '()))
+                    ))
+                )
+            )",
+            keyColumn.c_str(),
+            keyColumn.c_str(),
+            tableName.c_str()
+        );
+        auto result = LocalMiniKQL(runtime, tabletId, query);
+        // Result: Value { Struct { Optional { Struct { List {
+        //     Struct { Optional { Uint64: 2 } } }
+        //     ...
+        // } } } } }
+        return result;
+    };
 
     ui64 GetDatashardState(TTestActorRuntime& runtime, ui64 tabletId) {
         NKikimrMiniKQL::TResult result;

--- a/ydb/core/tx/schemeshard/ut_helpers/helpers.h
+++ b/ydb/core/tx/schemeshard/ut_helpers/helpers.h
@@ -82,6 +82,11 @@ namespace NSchemeShardUT_Private {
     NKikimrMiniKQL::TResult LocalMiniKQL(TTestActorRuntime& runtime, ui64 tabletId, const TString& query);
 
     bool CheckLocalRowExists(TTestActorRuntime& runtime, ui64 tabletId, const TString& tableName, const TString& keyColumn, ui64 keyValue);
+    NKikimrMiniKQL::TResult ReadLocalTableRecords(TTestActorRuntime& runtime, ui64 tabletId, const TString& tableName, const TString& keyColumn);
+
+    ////////// hive
+    void HiveStopTablet(TTestActorRuntime &runtime, ui64 hiveTablet, ui64 tabletId, ui32 nodeIndex);
+    std::vector<NKikimrHive::TTabletInfo> HiveGetSubdomainTablets(TTestActorRuntime &runtime, const ui64 hiveTablet, const TPathId& subdomainPathId);
 
     ////////// describe options
     struct TDescribeOptionsBuilder : public NKikimrSchemeOp::TDescribeOptions {

--- a/ydb/core/tx/schemeshard/ut_helpers/test_env.cpp
+++ b/ydb/core/tx/schemeshard/ut_helpers/test_env.cpp
@@ -593,7 +593,7 @@ NSchemeShardUT_Private::TTestEnv::TTestEnv(TTestActorRuntime& runtime, const TTe
     app.FeatureFlags.SetEnableTableDatetime64(true);
     app.FeatureFlags.SetEnableVectorIndex(true);
     app.FeatureFlags.SetEnableColumnStore(true);
-    app.FeatureFlags.SetEnableStrictAclCheck(opts.EnableStrictAclCheck_);    
+    app.FeatureFlags.SetEnableStrictAclCheck(opts.EnableStrictAclCheck_);
     app.SetEnableMoveIndex(opts.EnableMoveIndex_);
     app.SetEnableChangefeedInitialScan(opts.EnableChangefeedInitialScan_);
     app.SetEnableNotNullDataColumns(opts.EnableNotNullDataColumns_);
@@ -924,6 +924,23 @@ void NSchemeShardUT_Private::TTestEnv::TestWaitShardDeletion(NActors::TTestActor
     TestWaitShardDeletion(runtime, TTestTxConfig::SchemeShard, std::move(localIds));
 }
 
+void NSchemeShardUT_Private::TTestEnv::AddExtSubdomainCleanupObserver(NActors::TTestActorRuntime& runtime, const TPathId& subdomainPathId) {
+    Cerr << "TESTENV: subdomain cleanup, start waiting, subdomain " << subdomainPathId << Endl;
+    ExtSubdomainCleanupComplete.erase(subdomainPathId);
+    ExtSubdomainCleanupObserver = runtime.AddObserver<TEvPrivate::TEvTestNotifySubdomainCleanup>([this](const auto& ev) {
+        ExtSubdomainCleanupComplete.insert(ev->Get()->SubdomainPathId);
+    });
+}
+
+void NSchemeShardUT_Private::TTestEnv::WaitForExtSubdomainCleanup(NActors::TTestActorRuntime& runtime, const TPathId& subdomainPathId) {
+    runtime.WaitFor("ExtSubdomainCleanup", [this, &subdomainPathId] {
+        return ExtSubdomainCleanupComplete.contains(subdomainPathId);
+    });
+    ExtSubdomainCleanupComplete.erase(subdomainPathId);
+    ExtSubdomainCleanupObserver.Remove();
+    Cerr << "TESTENV: subdomain cleanup, wait complete, subdomain " << subdomainPathId << Endl;
+}
+
 void NSchemeShardUT_Private::TTestEnv::SimulateSleep(NActors::TTestActorRuntime &runtime, TDuration duration) {
     auto sender = runtime.AllocateEdgeActor();
     runtime.Schedule(new IEventHandle(sender, sender, new TEvents::TEvWakeup()), duration);
@@ -1057,6 +1074,14 @@ NSchemeShardUT_Private::TTestWithReboots::TTestWithReboots(bool killOnCommit, NS
     TabletIds.push_back(datashard+7);
     TabletIds.push_back(datashard+8);
 
+    // Events used exclusively by test frameworks.
+    // No need for reboots on these as they aren't used in real operation mode.
+    NoRebootEventTypes.insert(TEvPrivate::EvTestNotifySubdomainCleanup);
+    NoRebootEventTypes.insert(TEvFakeHive::EvSubscribeToTabletDeletion);
+    NoRebootEventTypes.insert(TEvFakeHive::EvNotifyTabletDeleted);
+    NoRebootEventTypes.insert(TEvFakeHive::EvRequestDomainInfo);
+    NoRebootEventTypes.insert(TEvFakeHive::EvRequestDomainInfoReply);
+
     NoRebootEventTypes.insert(TEvSchemeShard::EvModifySchemeTransaction);
     NoRebootEventTypes.insert(TEvSchemeShard::EvDescribeScheme);
     NoRebootEventTypes.insert(TEvSchemeShard::EvNotifyTxCompletion);
@@ -1106,34 +1131,48 @@ struct NSchemeShardUT_Private::TTestWithReboots::TFinalizer {
 };
 
 void NSchemeShardUT_Private::TTestWithReboots::RunWithTabletReboots(std::function<void (TTestActorRuntime &, bool &)> testScenario) {
-    RunTestWithReboots(TabletIds, [&]() {
-        return [this](TTestActorRuntimeBase& runtime, TAutoPtr<IEventHandle>& event) {
-            return PassUserRequests(runtime, event);
-        };
-    },
-    [&](const TString& dispatchName, std::function<void(TTestActorRuntime&)> setup, bool& activeZone) {
-        TFinalizer finalizer(*this);
-        Prepare(dispatchName, setup, activeZone);
+    RunTestWithReboots(
+        TabletIds,
+        // filterFactory
+        [&]() {
+            return [this](TTestActorRuntimeBase& runtime, TAutoPtr<IEventHandle>& event) {
+                return PassUserRequests(runtime, event);
+            };
+        },
+        // testFunc
+        [&](const TString& dispatchName, std::function<void(TTestActorRuntime&)> setup, bool& activeZone) {
+            TFinalizer finalizer(*this);
+            Prepare(dispatchName, setup, activeZone);
 
-        activeZone = true;
-        testScenario(*Runtime, activeZone);
-    }, Max<ui32>(), Max<ui64>(), 0, 0, KillOnCommit);
+            activeZone = true;
+            testScenario(*Runtime, activeZone);
+        },
+        Max<ui32>(),
+        Max<ui64>(),
+        0,
+        0,
+        KillOnCommit
+    );
 }
 
 void NSchemeShardUT_Private::TTestWithReboots::RunWithPipeResets(std::function<void (TTestActorRuntime &, bool &)> testScenario) {
-    RunTestWithPipeResets(TabletIds,
-                          [&]() {
-        return [this](TTestActorRuntimeBase& runtime, TAutoPtr<IEventHandle>& event) {
-            return PassUserRequests(runtime, event);
-        };
-    },
-    [&](const TString& dispatchName, std::function<void(TTestActorRuntime&)> setup, bool& activeZone) {
-        TFinalizer finalizer(*this);
-        Prepare(dispatchName, setup, activeZone);
+    RunTestWithPipeResets(
+        TabletIds,
+        // filterFactory
+        [&]() {
+            return [this](TTestActorRuntimeBase& runtime, TAutoPtr<IEventHandle>& event) {
+                return PassUserRequests(runtime, event);
+            };
+        },
+        // testFunc
+        [&](const TString& dispatchName, std::function<void(TTestActorRuntime&)> setup, bool& activeZone) {
+            TFinalizer finalizer(*this);
+            Prepare(dispatchName, setup, activeZone);
 
-        activeZone = true;
-        testScenario(*Runtime, activeZone);
-    });
+            activeZone = true;
+            testScenario(*Runtime, activeZone);
+        }
+    );
 }
 
 void NSchemeShardUT_Private::TTestWithReboots::RunWithDelays(std::function<void (TTestActorRuntime &, bool &)> testScenario) {

--- a/ydb/core/tx/schemeshard/ut_helpers/test_env.h
+++ b/ydb/core/tx/schemeshard/ut_helpers/test_env.h
@@ -98,6 +98,9 @@ namespace NSchemeShardUT_Private {
         TActorId MeteringFake;
         THolder<NYdb::TDriver> YdbDriver;
 
+        TTestActorRuntime::TEventObserverHolder ExtSubdomainCleanupObserver;
+        THashSet<TPathId> ExtSubdomainCleanupComplete;
+
     public:
         static bool ENABLE_SCHEMESHARD_LOG;
 
@@ -133,6 +136,9 @@ namespace NSchemeShardUT_Private {
         void TestWaitShardDeletion(TTestActorRuntime& runtime, TSet<ui64> localIds);
         void TestWaitShardDeletion(TTestActorRuntime& runtime, ui64 schemeShard, TSet<ui64> localIds);
         void TestWaitShardDeletion(TTestActorRuntime& runtime, ui64 schemeShard, TSet<TShardIdx> shardIds);
+
+        void AddExtSubdomainCleanupObserver(NActors::TTestActorRuntime& runtime, const TPathId& subdomainPathId);
+        void WaitForExtSubdomainCleanup(NActors::TTestActorRuntime& runtime, const TPathId& subdomainPathId);
 
         void SimulateSleep(TTestActorRuntime& runtime, TDuration duration);
 

--- a/ydb/tests/functional/scheme_tests/canondata/tablet_scheme_tests.TestTabletSchemes.test_tablet_schemes_flat_schemeshard_/flat_schemeshard.schema
+++ b/ydb/tests/functional/scheme_tests/canondata/tablet_scheme_tests.TestTabletSchemes.test_tablet_schemes_flat_schemeshard_/flat_schemeshard.schema
@@ -8532,5 +8532,43 @@
                 ]
             }
         }
+    },
+    {
+        "TableId": 124,
+        "TableName": "SystemShardsToDelete",
+        "TableKey": [
+            1
+        ],
+        "ColumnsAdded": [
+            {
+                "ColumnId": 1,
+                "ColumnName": "ShardIdx",
+                "ColumnType": "Uint64"
+            }
+        ],
+        "ColumnsDropped": [],
+        "ColumnFamilies": {
+            "0": {
+                "Columns": [
+                    1
+                ],
+                "RoomID": 0,
+                "Codec": 0,
+                "InMemory": false,
+                "Cache": 0,
+                "Small": 4294967295,
+                "Large": 4294967295
+            }
+        },
+        "Rooms": {
+            "0": {
+                "Main": 1,
+                "Outer": 1,
+                "Blobs": 1,
+                "ExternalBlobs": [
+                    1
+                ]
+            }
+        }
     }
 ]


### PR DESCRIPTION
Merge from `main`:
- a721d56 -- https://github.com/ydb-platform/ydb/pull/21377
- 1f8359c -- https://github.com/ydb-platform/ydb/pull/22360

Currently, drop-extsubdomain operations may not completely remove dedicated databases from the system:
- system tablets of the tenant may remain in the root hive
- traces of database paths and subdomain objects may persist in the root schemeshard

Root cause: The cleanup procedure depends on the tenant hive's existence - delete-tablet requests are sent to the tenant hive for redirection to the root hive. This works for most databases but fails with dedicated databases, where the tenant hive cannot outlive drop-extsubdomain operations, and there's no guarantee that tenant nodes and tablets will be available during deletion.

Changes:
- Implement quick fix for subdomain cleanup by directly sending system tablets delete-tablet requests to the root hive (only for dedicated databases)
- Add unit and reboot tests to verify proper extsubdomain cleanup
- Fix aggressive reconnect loop in coordinator's mediator_queue
- Fix handling of TEvSchemeShard::TEvSyncTenantSchemeShard in schemeshard

Closes #19842.

### Changelog entry

Fix issue where dedicated database deletion may leave database system tablets improperly cleaned.

### Changelog category

* Bugfix 
