### PR TITLE
Resume throttled tasks when the pool has under-utilized fair-share

### DIFF
--- a/ydb/core/kqp/compute_actor/kqp_compute_actor_factory.cpp
+++ b/ydb/core/kqp/compute_actor/kqp_compute_actor_factory.cpp
@@ -130,11 +130,10 @@ public:
         resourcesRequest.ExecutionUnits = 1;
         resourcesRequest.Memory = memoryLimits.MkqlLightProgramMemoryLimit;
 
-        NScheduler::TSchedulableActorHelper::TOptions schedulableOptions;
-        if (args.Query) {
-            schedulableOptions.SchedulableTask = MakeHolder<NScheduler::TSchedulableTask>(args.Query);
-        }
-        schedulableOptions.IsSchedulable = args.Query && !args.TxInfo->PoolId.empty() && args.TxInfo->PoolId != NResourcePool::DEFAULT_POOL_ID;
+        NScheduler::TSchedulableActorOptions schedulableOptions {
+            .Query = args.Query,
+            .IsSchedulable = args.Query && !args.TxInfo->PoolId.empty() && args.TxInfo->PoolId != NResourcePool::DEFAULT_POOL_ID,
+        };
 
         TIntrusivePtr<NRm::TTaskState> task = MakeIntrusive<NRm::TTaskState>(args.Task->GetId(), args.TxInfo->CreatedAt);
 

--- a/ydb/core/kqp/runtime/scheduler/fwd.h
+++ b/ydb/core/kqp/runtime/scheduler/fwd.h
@@ -4,6 +4,7 @@
 #include <util/generic/ptr.h>
 #include <util/stream/output.h>
 
+#include <list>
 #include <memory>
 
 namespace NKikimr::NKqp::NScheduler {
@@ -18,14 +19,11 @@ namespace NKikimr::NKqp::NScheduler {
         struct TStaticAttributes;
 
         namespace NDynamic {
-            struct TTreeElementBase;
-
             class TQuery;
             class TPool;
             class TDatabase;
             class TRoot;
 
-            using TTreeElementPtr = std::shared_ptr<TTreeElementBase>;
             using TQueryPtr = std::shared_ptr<TQuery>;
             using TPoolPtr = std::shared_ptr<TPool>;
             using TDatabasePtr = std::shared_ptr<TDatabase>;
@@ -33,14 +31,13 @@ namespace NKikimr::NKqp::NScheduler {
         } // namespace NDynamic
 
         namespace NSnapshot {
-            struct TTreeElementBase;
+            struct TTreeElement;
 
             class TQuery;
             class TPool;
             class TDatabase;
             class TRoot;
 
-            using TTreeElementPtr = std::shared_ptr<TTreeElementBase>;
             using TQueryPtr = std::shared_ptr<TQuery>;
             using TPoolPtr = std::shared_ptr<TPool>;
             using TDatabasePtr = std::shared_ptr<TDatabase>;
@@ -49,7 +46,8 @@ namespace NKikimr::NKqp::NScheduler {
     }
 
     struct TSchedulableTask;
-    using TSchedulableTaskPtr = THolder<TSchedulableTask>;
+    using TSchedulableTaskPtr = std::shared_ptr<TSchedulableTask>;
+    using TSchedulableTaskList = std::list<std::pair<TSchedulableTaskPtr::weak_type, std::atomic<bool> /* isThrottled */>>;
 
     // These params are used when calculating delay for schedulable task, but are taken from the scheduler configuration.
     struct TDelayParams {

--- a/ydb/core/kqp/runtime/scheduler/kqp_compute_actor.h
+++ b/ydb/core/kqp/runtime/scheduler/kqp_compute_actor.h
@@ -41,7 +41,7 @@ namespace NKikimr::NKqp::NScheduler {
         void PassAway() override {
             if (!PassedAway && IsAccountable()) {
                 PassedAway = true;
-                StopExecution();
+                StopExecution(ForcedResume);
             }
 
             TBase::PassAway();
@@ -51,6 +51,7 @@ namespace NKikimr::NKqp::NScheduler {
         void Handle(TSchedulableTask::TResumeEventType::TPtr& ev) {
             if (TSchedulableTask::IsResumeEvent(ev)) {
                 if (IsThrottled()) {
+                    ForcedResume = ev->Sender != this->SelfId();
                     TBase::DoExecute();
                 }
             } else {
@@ -70,7 +71,7 @@ namespace NKikimr::NKqp::NScheduler {
             if (StartExecution(now)) {
                 TBase::DoExecuteImpl();
                 if (!PassedAway) {
-                    StopExecution();
+                    StopExecution(ForcedResume);
                 }
                 return;
             }
@@ -80,6 +81,7 @@ namespace NKikimr::NKqp::NScheduler {
 
     private:
         bool PassedAway = false;
+        bool ForcedResume = false;
     };
 
 } // namespace NKikimr::NKqp::NScheduler

--- a/ydb/core/kqp/runtime/scheduler/kqp_compute_actor.h
+++ b/ydb/core/kqp/runtime/scheduler/kqp_compute_actor.h
@@ -1,35 +1,38 @@
 #pragma once
 
 #include "kqp_schedulable_actor.h"
+#include "kqp_schedulable_task.h"
 
 #include <ydb/library/yql/dq/actors/compute/dq_sync_compute_actor_base.h>
 
 namespace NKikimr::NKqp::NScheduler {
 
     template <class TDerived>
-    class TSchedulableComputeActorBase : public NYql::NDq::TDqSyncComputeActorBase<TDerived>, private TSchedulableActorHelper {
+    class TSchedulableComputeActorBase : public NYql::NDq::TDqSyncComputeActorBase<TDerived>, TSchedulableActorBase {
         using TBase = NYql::NDq::TDqSyncComputeActorBase<TDerived>;
-        static constexpr ui64 TAG_WAKEUP_RESUME = 201; // TODO: why this value for magic number?
 
     public:
         template<typename ... TArgs>
-        TSchedulableComputeActorBase(TOptions options, TArgs&& ... args)
+        TSchedulableComputeActorBase(const TSchedulableActorOptions& options, TArgs&& ... args)
             : TBase(std::forward<TArgs>(args) ...)
-            , TSchedulableActorHelper(std::move(options))
+            , TSchedulableActorBase(options)
         {
         }
 
     protected:
         void DoBootstrap() {
-            // TODO: implement this
+            if (IsAccountable()) {
+                RegisterForResume(this->SelfId());
+            }
         }
 
         // Magic state-function name to overload
         STATEFN(BaseStateFuncBody) {
             // TODO: account mailbox usage?
+
             // we assume that exceptions are handled in parents/descendants
             switch (ev->GetTypeRewrite()) {
-                hFunc(NActors::TEvents::TEvWakeup, TSchedulableComputeActorBase<TDerived>::Handle);
+                hFunc(TSchedulableTask::TResumeEventType, TSchedulableComputeActorBase<TDerived>::Handle);
                 default:
                     TBase::BaseStateFuncBody(ev);
             }
@@ -45,9 +48,11 @@ namespace NKikimr::NKqp::NScheduler {
         }
 
     private:
-        void Handle(NActors::TEvents::TEvWakeup::TPtr& ev) {
-            if (ev->Get()->Tag == TAG_WAKEUP_RESUME) {
-                TBase::DoExecute();
+        void Handle(TSchedulableTask::TResumeEventType::TPtr& ev) {
+            if (TSchedulableTask::IsResumeEvent(ev)) {
+                if (IsThrottled()) {
+                    TBase::DoExecute();
+                }
             } else {
                 TBase::HandleExecuteBase(ev);
             }
@@ -70,7 +75,7 @@ namespace NKikimr::NKqp::NScheduler {
                 return;
             }
 
-            this->Schedule(CalculateDelay(now), new NActors::TEvents::TEvWakeup(TAG_WAKEUP_RESUME));
+            this->Schedule(CalculateDelay(now), TSchedulableTask::GetResumeEvent().release());
         }
 
     private:

--- a/ydb/core/kqp/runtime/scheduler/kqp_schedulable_actor.h
+++ b/ydb/core/kqp/runtime/scheduler/kqp_schedulable_actor.h
@@ -36,7 +36,7 @@ protected:
     }
 
     bool StartExecution(TMonotonic now);
-    void StopExecution();
+    void StopExecution(bool& forcedResume);
 
     TDuration CalculateDelay(TMonotonic now) const;
 

--- a/ydb/core/kqp/runtime/scheduler/kqp_schedulable_task.cpp
+++ b/ydb/core/kqp/runtime/scheduler/kqp_schedulable_task.cpp
@@ -1,0 +1,108 @@
+#include "kqp_schedulable_task.h"
+
+#include <ydb/core/kqp/runtime/scheduler/tree/dynamic.h>
+
+namespace NKikimr::NKqp::NScheduler {
+
+using namespace NHdrf::NDynamic;
+
+TSchedulableTask::TSchedulableTask(const TQueryPtr& query)
+    : Query(query)
+{
+    Y_ENSURE(query);
+    ++Query->Demand;
+}
+
+TSchedulableTask::~TSchedulableTask() {
+    if (Iterator) {
+        Query->RemoveTask(*Iterator);
+    }
+    --Query->Demand;
+}
+
+void TSchedulableTask::RegisterForResume(const TActorId& actorId) {
+    Y_ENSURE(!Iterator);
+    Iterator = Query->AddTask(shared_from_this());
+    ActorId = actorId;
+}
+
+void TSchedulableTask::Resume() {
+    NActors::TActivationContext::Send(ActorId, GetResumeEvent());
+}
+
+// TODO: referring to the pool's fair-share and usage - query's fair-share is ignored.
+bool TSchedulableTask::TryIncreaseUsage() {
+    const auto snapshot = Query->GetSnapshot();
+    auto pool = Query->GetParent();
+    ui64 newUsage = pool->Usage.load();
+    bool increased = false;
+
+    while (!increased && newUsage < snapshot->GetParent()->FairShare) {
+        increased = pool->Usage.compare_exchange_weak(newUsage, newUsage + 1);
+    }
+
+    if (!increased) {
+        return false;
+    }
+
+    ++Query->Usage;
+    for (TTreeElement* parent = pool->GetParent(); parent; parent = parent->GetParent()) {
+        ++parent->Usage;
+    }
+
+    return true;
+}
+
+// TODO: referring to the pool's fair-share and usage - query's fair-share is ignored.
+void TSchedulableTask::IncreaseUsage() {
+    if (Iterator) {
+        (*Iterator)->second = false;
+    }
+    for (TTreeElement* parent = Query.get(); parent; parent = parent->GetParent()) {
+        ++parent->Usage;
+    }
+}
+
+// TODO: referring to the pool's fair-share and usage - query's fair-share is ignored.
+void TSchedulableTask::DecreaseUsage(const TDuration& burstUsage) {
+    for (TTreeElement* parent = Query.get(); parent; parent = parent->GetParent()) {
+        --parent->Usage;
+        parent->BurstUsage += burstUsage.MicroSeconds();
+    }
+}
+
+void TSchedulableTask::IncreaseExtraUsage() {
+    for (TTreeElement* parent = Query.get(); parent; parent = parent->GetParent()) {
+        ++parent->UsageExtra;
+    }
+}
+
+void TSchedulableTask::DecreaseExtraUsage(const TDuration& burstUsageExtra) {
+    for (TTreeElement* parent = Query.get(); parent; parent = parent->GetParent()) {
+        --parent->UsageExtra;
+        parent->BurstUsageExtra += burstUsageExtra.MicroSeconds();
+    }
+}
+
+void TSchedulableTask::IncreaseBurstThrottle(const TDuration& burstThrottle) {
+    for (TTreeElement* parent = Query.get(); parent; parent = parent->GetParent()) {
+        parent->BurstThrottle += burstThrottle.MicroSeconds();
+    }
+}
+
+void TSchedulableTask::IncreaseThrottle() {
+    if (Iterator) {
+        (*Iterator)->second = true;
+    }
+    for (TTreeElement* parent = Query.get(); parent; parent = parent->GetParent()) {
+        ++parent->Throttle;
+    }
+}
+
+void TSchedulableTask::DecreaseThrottle() {
+    for (TTreeElement* parent = Query.get(); parent; parent = parent->GetParent()) {
+        --parent->Throttle;
+    }
+}
+
+} // namespace NKikimr::NKqp::NScheduler

--- a/ydb/core/kqp/runtime/scheduler/kqp_schedulable_task.h
+++ b/ydb/core/kqp/runtime/scheduler/kqp_schedulable_task.h
@@ -26,7 +26,10 @@ struct TSchedulableTask : public std::enable_shared_from_this<TSchedulableTask> 
 
     bool TryIncreaseUsage();
     void IncreaseUsage();
-    void DecreaseUsage(const TDuration& burstUsage);
+    void DecreaseUsage(const TDuration& burstUsage, bool forcedResume);
+
+    // Returns parent pool's 'fair-share' - 'usage'
+    size_t GetSpareUsage() const;
 
     // Account extra usage which doesn't affect scheduling
     void IncreaseExtraUsage();

--- a/ydb/core/kqp/runtime/scheduler/kqp_schedulable_task.h
+++ b/ydb/core/kqp/runtime/scheduler/kqp_schedulable_task.h
@@ -1,0 +1,48 @@
+#pragma once
+
+#include "fwd.h"
+
+#include <ydb/library/actors/core/actorid.h>
+#include <ydb/library/actors/core/events.h>
+
+namespace NKikimr::NKqp::NScheduler {
+
+// The proxy-object between any schedulable actor and the scheduler itself
+
+struct TSchedulableTask : public std::enable_shared_from_this<TSchedulableTask> {
+    explicit TSchedulableTask(const NHdrf::NDynamic::TQueryPtr& query);
+    ~TSchedulableTask();
+
+    void RegisterForResume(const NActors::TActorId& actorId);
+    void Resume();
+
+    using TResumeEventType = NActors::TEvents::TEvWakeup;
+    static inline bool IsResumeEvent(const TResumeEventType::TPtr& ev) {
+        return ev->Get()->Tag == TAG_WAKEUP_RESUME;
+    }
+    static inline auto GetResumeEvent() {
+        return std::make_unique<TResumeEventType>(TAG_WAKEUP_RESUME);
+    }
+
+    bool TryIncreaseUsage();
+    void IncreaseUsage();
+    void DecreaseUsage(const TDuration& burstUsage);
+
+    // Account extra usage which doesn't affect scheduling
+    void IncreaseExtraUsage();
+    void DecreaseExtraUsage(const TDuration& burstUsage);
+
+    void IncreaseBurstThrottle(const TDuration& burstThrottle);
+    void IncreaseThrottle();
+    void DecreaseThrottle();
+
+    const NHdrf::NDynamic::TQueryPtr Query; // TODO: should be private
+
+private:
+    static constexpr ui64 TAG_WAKEUP_RESUME = 201; // TODO: why this value for magic number?
+
+    std::optional<TSchedulableTaskList::iterator> Iterator; // TODO: improve iterator to not allow access to adjacent values in list.
+    NActors::TActorId ActorId;
+};
+
+} // namespace NKikimr::NKqp::NScheduler

--- a/ydb/core/kqp/runtime/scheduler/tree/common.h
+++ b/ydb/core/kqp/runtime/scheduler/tree/common.h
@@ -166,10 +166,12 @@ namespace NKikimr::NKqp::NScheduler::NHdrf {
         NMonitoring::TDynamicCounters::TCounterPtr Guarantee;
         NMonitoring::TDynamicCounters::TCounterPtr Demand;
         NMonitoring::TDynamicCounters::TCounterPtr Usage;
+        NMonitoring::TDynamicCounters::TCounterPtr UsageResume;
         NMonitoring::TDynamicCounters::TCounterPtr Throttle;
         NMonitoring::TDynamicCounters::TCounterPtr FairShare;
         NMonitoring::TDynamicCounters::TCounterPtr InFlight;
         NMonitoring::TDynamicCounters::TCounterPtr Waiting;
+        NMonitoring::TDynamicCounters::TCounterPtr Satisfaction;
         NMonitoring::TDynamicCounters::TCounterPtr InFlightExtra;
         NMonitoring::TDynamicCounters::TCounterPtr UsageExtra;
         NMonitoring::THistogramPtr                 Delay;

--- a/ydb/core/kqp/runtime/scheduler/tree/common.h
+++ b/ydb/core/kqp/runtime/scheduler/tree/common.h
@@ -1,10 +1,26 @@
 #pragma once
 
+#include "../fwd.h"
+
 #include <library/cpp/monlib/dynamic_counters/counters.h>
 
-#include <util/system/types.h>
+#include <util/generic/hash.h>
 
 #include <optional>
+
+template <typename Base, typename Derived>
+concept CStaticallyDowncastable = requires(Base* b) {
+    static_cast<Derived*>(b);
+};
+
+namespace std {
+
+    // TODO: remove after switch to C++26
+    template <typename Base, typename Derived>
+    inline constexpr bool is_virtual_base_of_v =
+        std::is_base_of_v<Base, Derived> && !CStaticallyDowncastable<Base, Derived>;
+
+} // namespace std
 
 namespace NKikimr::NKqp::NScheduler::NHdrf {
 
@@ -42,6 +58,109 @@ namespace NKikimr::NKqp::NScheduler::NHdrf {
         }
     };
 
+    enum class ETreeType : ui8 {
+        DYNAMIC,
+        SNAPSHOT,
+    };
+
+    template <ETreeType>
+    struct TTreeElementBase : public TStaticAttributes {
+        using TPtr = std::shared_ptr<TTreeElementBase>;
+
+        explicit TTreeElementBase(const TId& id, const TStaticAttributes& attrs = {}) : Id(id) { Update(attrs); }
+        virtual ~TTreeElementBase() = default;
+
+        inline const TId& GetId() const {
+            return Id;
+        }
+
+        void AddChild(const TPtr& element) {
+            Y_ENSURE(Y_LIKELY(element));
+            Children.push_back(element);
+            element->Parent = this;
+        }
+
+        void RemoveChild(const TPtr& element) {
+            Y_ENSURE(Y_LIKELY(element));
+            for (auto it = Children.begin(); it != Children.end(); ++it) {
+                if (*it == element) {
+                    element->Parent = nullptr;
+                    Children.erase(it);
+                    return;
+                }
+            }
+
+            // TODO: throw exception that child not found.
+        }
+
+        inline size_t ChildrenSize() const {
+            return Children.size();
+        }
+
+        template <class T, class Fn>
+        void ForEachChild(Fn&& fn) const {
+            size_t i = 0;
+
+            for (const auto& child : Children) {
+                T* ptr;
+                if constexpr (std::is_virtual_base_of_v<TTreeElementBase, T>) {
+                    ptr = dynamic_cast<T*>(child.get());
+                    Y_ASSERT(ptr);
+                } else {
+                    ptr = static_cast<T*>(child.get());
+                }
+                if constexpr (std::is_void_v<std::invoke_result_t<Fn, T*, size_t>>) {
+                    fn(ptr, i++);
+                } else {
+                    if (fn(ptr, i++)) {
+                        break;
+                    }
+                }
+            }
+        }
+
+        // True for parentless and real root
+        virtual inline bool IsRoot() const {
+            return !Parent;
+        }
+
+        // True for everything except queries
+        virtual inline bool IsPool() const {
+            return true;
+        }
+
+        // True for queries and leaf-pools
+        virtual inline bool IsLeaf() const {
+            return Children.empty();
+        }
+
+    protected:
+        const TId Id;
+        TTreeElementBase* Parent = nullptr;
+
+    private:
+        std::vector<TPtr> Children;
+    };
+
+    template <ETreeType T>
+    struct TQuery : public virtual TTreeElementBase<T> {
+        using TBase = TTreeElementBase<T>;
+        using TPtr = std::shared_ptr<TQuery>;
+
+        explicit TQuery(const TQueryId& id, const TStaticAttributes& attrs = {}) : TBase(id, attrs) {}
+
+        void AddChild(const typename TBase::TPtr& element) = delete;
+        void RemoveChild(const typename TBase::TPtr& element) = delete;
+
+        inline bool IsRoot() const final {
+            return false;
+        }
+
+        inline bool IsPool() const final {
+            return false;
+        }
+    };
+
     struct TPoolCounters {
         NMonitoring::TDynamicCounters::TCounterPtr Limit;
         NMonitoring::TDynamicCounters::TCounterPtr Guarantee;
@@ -54,6 +173,74 @@ namespace NKikimr::NKqp::NScheduler::NHdrf {
         NMonitoring::TDynamicCounters::TCounterPtr InFlightExtra;
         NMonitoring::TDynamicCounters::TCounterPtr UsageExtra;
         NMonitoring::THistogramPtr                 Delay;
+    };
+
+    template <ETreeType T>
+    struct TPool : public virtual TTreeElementBase<T> {
+        using TBase = TTreeElementBase<T>;
+        using TPtr = std::shared_ptr<TPool>;
+
+        explicit TPool(const TPoolId& id, const TStaticAttributes& attrs = {}) : TBase(id, attrs) {}
+
+        void AddQuery(const TQuery<T>::TPtr& query) {
+            Y_ENSURE(Pools.empty());
+            Y_ENSURE(!Queries.contains(std::get<TQueryId>(query->GetId())));
+            Queries.emplace(std::get<TQueryId>(query->GetId()), query);
+            AddChild(query);
+        }
+
+        void RemoveQuery(const TQueryId& queryId) {
+            Y_ENSURE(Pools.empty());
+            auto queryIt = Queries.find(queryId);
+            Y_ENSURE(queryIt != Queries.end());
+            RemoveChild(queryIt->second);
+            Queries.erase(queryIt);
+        }
+
+        TQuery<T>::TPtr GetQuery(const TQueryId& queryId) const {
+            Y_ENSURE(Pools.empty());
+            auto it = Queries.find(queryId);
+            return it == Queries.end() ? nullptr : it->second;
+        }
+
+        void AddPool(const TPool::TPtr& pool) {
+            Y_ENSURE(Queries.empty());
+            Y_ENSURE(!Pools.contains(std::get<TPoolId>(pool->GetId())));
+            Pools.emplace(std::get<TPoolId>(pool->GetId()), pool);
+            AddChild(pool);
+        }
+
+        void RemovePool(const TPoolId& poolId) {
+            Y_ENSURE(Queries.empty());
+            auto poolIt = Pools.find(poolId);
+            Y_ENSURE(poolIt != Pools.end());
+            RemoveChild(poolIt->second);
+            Pools.erase(poolIt);
+        }
+
+        TPool::TPtr GetPool(const TPoolId& poolId) const {
+            Y_ENSURE(Queries.empty());
+            auto it = Pools.find(poolId);
+            return it == Pools.end() ? nullptr : it->second;
+        }
+
+        inline bool IsPool() const final {
+            return true;
+        }
+
+        inline bool IsLeaf() const final {
+            return this->ChildrenSize() == 0 || !Queries.empty();
+        }
+
+    protected:
+        std::optional<TPoolCounters> Counters;
+
+    private:
+        using TBase::AddChild;
+        using TBase::RemoveChild;
+
+        THashMap<TQueryId, typename TQuery<T>::TPtr> Queries;
+        THashMap<TPoolId, typename TPool::TPtr> Pools;
     };
 
 } // namespace NKikimr::NKqp::NScheduler::NHdrf

--- a/ydb/core/kqp/runtime/scheduler/tree/dynamic.cpp
+++ b/ydb/core/kqp/runtime/scheduler/tree/dynamic.cpp
@@ -1,39 +1,15 @@
 #include "dynamic.h"
 
+#include <ydb/core/kqp/runtime/scheduler/kqp_schedulable_task.h>
+
 namespace NKikimr::NKqp::NScheduler::NHdrf::NDynamic {
 
 ///////////////////////////////////////////////////////////////////////////////
-// TTreeElementBase
+// TTreeElement
 ///////////////////////////////////////////////////////////////////////////////
 
-void TTreeElementBase::AddChild(const TTreeElementPtr& element) {
-    const auto usage = element->Usage.load();
-    const auto throttle = element->Throttle.load();
-    const auto burstUsage = element->BurstUsage.load();
-    const auto burstThrottle = element->BurstThrottle.load();
-
-    Children.push_back(element);
-    element->Parent = this;
-
-    // In case of detached query we should propagate approximate values to new parents.
-    for (TTreeElementBase* parent = this; parent; parent = parent->Parent) {
-        parent->Usage += usage;
-        parent->Throttle += throttle;
-        parent->BurstUsage += burstUsage;
-        parent->BurstThrottle += burstThrottle;
-    }
-}
-
-void TTreeElementBase::RemoveChild(const TTreeElementPtr& element) {
-    for (auto it = Children.begin(); it != Children.end(); ++it) {
-        if (*it == element) {
-            element->Parent = nullptr;
-            // TODO: should we decrease usage, throttle, etc for parents here?
-            Children.erase(it);
-            return;
-        }
-    }
-    // TODO: throw exception that child not found.
+TPool* TTreeElement::GetParent() const {
+    return dynamic_cast<TPool*>(Parent);
 }
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -41,16 +17,47 @@ void TTreeElementBase::RemoveChild(const TTreeElementPtr& element) {
 ///////////////////////////////////////////////////////////////////////////////
 
 TQuery::TQuery(const TQueryId& id, const TDelayParams* delayParams, const TStaticAttributes& attrs)
-    : DelayParams(delayParams)
-    , Id(id)
+    : NHdrf::TTreeElementBase<ETreeType::DYNAMIC>(id, attrs)
+    , TTreeElement(id, attrs)
+    , NHdrf::TQuery<ETreeType::DYNAMIC>(id, attrs)
+    , DelayParams(delayParams)
 {
-    Update(attrs);
 }
 
 NSnapshot::TQuery* TQuery::TakeSnapshot() const {
     auto* newQuery = new NSnapshot::TQuery(std::get<TQueryId>(GetId()), const_cast<TQuery*>(this));
     newQuery->Demand = Demand.load();
+    newQuery->Usage = Usage.load();
     return newQuery;
+}
+
+TSchedulableTaskList::iterator TQuery::AddTask(const TSchedulableTaskPtr& task) {
+    TWriteGuard lock(TasksMutex);
+    return SchedulableTasks.emplace(SchedulableTasks.end(), task, false);
+}
+
+void TQuery::RemoveTask(const TSchedulableTaskList::iterator& it) {
+    TWriteGuard lock(TasksMutex);
+    SchedulableTasks.erase(it);
+}
+
+ui32 TQuery::ResumeTasks(ui32 count) {
+    TReadGuard lock(TasksMutex);
+    ui32 run = 0;
+
+    count = std::min<ui32>(count, SchedulableTasks.size());
+    count = std::min<ui32>(count, Throttle);
+
+    for (auto it = SchedulableTasks.begin(); run < count && it != SchedulableTasks.end(); ++it) {
+        if (it->second) {
+            if (auto task = it->first.lock()) {
+                task->Resume();
+                ++run;
+            }
+        }
+    }
+
+    return run;
 }
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -58,70 +65,61 @@ NSnapshot::TQuery* TQuery::TakeSnapshot() const {
 ///////////////////////////////////////////////////////////////////////////////
 
 TPool::TPool(const TPoolId& id, const TIntrusivePtr<TKqpCounters>& counters, const TStaticAttributes& attrs)
-    : Id(id)
+    : NHdrf::TTreeElementBase<ETreeType::DYNAMIC>(id, attrs)
+    , TTreeElement(id, attrs)
+    , NHdrf::TPool<ETreeType::DYNAMIC>(id, attrs)
 {
-    Update(attrs);
-
-    Y_ENSURE(counters);
+    if (!counters) {
+        return;
+    }
 
     auto group = counters->GetKqpCounters()->GetSubgroup("scheduler/pool", id);
 
     // TODO: since counters don't support float-point values, then use CPU * 1'000'000 to account with microsecond precision
 
-    Counters.Limit     = group->GetCounter("Limit",     false);
-    Counters.Guarantee = group->GetCounter("Guarantee", false);
-    Counters.Demand    = group->GetCounter("Demand",    false); // snapshot
-    Counters.InFlight  = group->GetCounter("InFlight",  false);
-    Counters.Waiting   = group->GetCounter("Waiting",   false);
-    Counters.Usage     = group->GetCounter("Usage",     true);
-    Counters.Throttle  = group->GetCounter("Throttle",  true);
-    Counters.FairShare = group->GetCounter("FairShare", true);  // snapshot
+    Counters = TPoolCounters();
+    Counters->Limit     = group->GetCounter("Limit",     false);
+    Counters->Guarantee = group->GetCounter("Guarantee", false);
+    Counters->Demand    = group->GetCounter("Demand",    false); // snapshot
+    Counters->InFlight  = group->GetCounter("InFlight",  false);
+    Counters->Waiting   = group->GetCounter("Waiting",   false);
+    Counters->Usage     = group->GetCounter("Usage",     true);
+    Counters->Throttle  = group->GetCounter("Throttle",  true);
+    Counters->FairShare = group->GetCounter("FairShare", true);  // snapshot
 
-    Counters.InFlightExtra = group->GetCounter("InFlightExtra",  false);
-    Counters.UsageExtra    = group->GetCounter("UsageExtra",     true);
+    Counters->InFlightExtra = group->GetCounter("InFlightExtra",  false);
+    Counters->UsageExtra    = group->GetCounter("UsageExtra",     true);
 
-    Counters.Delay     = group->GetHistogram("Delay",
+    Counters->Delay     = group->GetHistogram("Delay",
         NMonitoring::ExplicitHistogram({10, 10e2, 10e3, 10e4, 10e5, 10e6, 10e7}), true); // TODO: make from MinDelay to MaxDelay.
 }
 
 NSnapshot::TPool* TPool::TakeSnapshot() const {
     auto* newPool = new NSnapshot::TPool(std::get<TPoolId>(GetId()), Counters, *this);
 
-    Counters.Limit->Set(GetLimit() * 1'000'000);
-    Counters.Guarantee->Set(GetGuarantee() * 1'000'000);
-    Counters.InFlight->Set(Usage * 1'000'000);
-    Counters.Waiting->Set(Throttle * 1'000'000);
-    Counters.Usage->Set(BurstUsage);
-    Counters.Throttle->Set(BurstThrottle);
+    if (Counters) {
+        Counters->Limit->Set(GetLimit() * 1'000'000);
+        Counters->Guarantee->Set(GetGuarantee() * 1'000'000);
+        Counters->InFlight->Set(Usage * 1'000'000);
+        Counters->Waiting->Set(Throttle * 1'000'000);
+        Counters->Usage->Set(BurstUsage);
+        Counters->Throttle->Set(BurstThrottle);
 
-    Counters.InFlightExtra->Set(UsageExtra * 1'000'000);
-    Counters.UsageExtra->Set(BurstUsageExtra);
+        Counters->InFlightExtra->Set(UsageExtra * 1'000'000);
+        Counters->UsageExtra->Set(BurstUsageExtra);
+    }
 
-    for (const auto& child : Children) {
-        newPool->AddQuery(std::shared_ptr<NSnapshot::TQuery>(std::dynamic_pointer_cast<TQuery>(child)->TakeSnapshot()));
+    if (IsLeaf()) {
+        ForEachChild<TQuery>([&](TQuery* query, size_t) {
+            newPool->AddQuery(NSnapshot::TQueryPtr(query->TakeSnapshot()));
+        });
+    } else {
+        ForEachChild<TPool>([&](TPool* pool, size_t) {
+            newPool->AddPool(NSnapshot::TPoolPtr(pool->TakeSnapshot()));
+        });
     }
 
     return newPool;
-}
-
-void TPool::AddQuery(const TQueryPtr& query) {
-    Y_ENSURE(!Queries.contains(std::get<TQueryId>(query->GetId())));
-    Queries.emplace(std::get<TQueryId>(query->GetId()), query);
-    AddChild(query);
-
-    query->Delay = Counters.Delay;
-}
-
-void TPool::RemoveQuery(const TQueryId& queryId) {
-    auto queryIt = Queries.find(queryId);
-    Y_ENSURE(queryIt != Queries.end());
-    RemoveChild(queryIt->second);
-    Queries.erase(queryIt);
-}
-
-TQueryPtr TPool::GetQuery(const TQueryId& queryId) const {
-    auto it = Queries.find(queryId);
-    return it == Queries.end() ? nullptr : it->second;
 }
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -129,48 +127,42 @@ TQueryPtr TPool::GetQuery(const TQueryId& queryId) const {
 ///////////////////////////////////////////////////////////////////////////////
 
 TDatabase::TDatabase(const TDatabaseId& id, const TStaticAttributes& attrs)
-    : Id(id)
+    : NHdrf::TTreeElementBase<ETreeType::DYNAMIC>(id, attrs)
+    , TPool(id, {}, attrs)
 {
-    Update(attrs);
 }
 
 NSnapshot::TDatabase* TDatabase::TakeSnapshot() const {
     auto* newDatabase = new NSnapshot::TDatabase(std::get<TDatabaseId>(GetId()), *this);
-    for (const auto& child : Children) {
-        newDatabase->AddPool(std::shared_ptr<NSnapshot::TPool>(std::dynamic_pointer_cast<TPool>(child)->TakeSnapshot()));
-    }
+    ForEachChild<TPool>([&](TPool* pool, size_t) {
+        newDatabase->AddPool(NSnapshot::TPoolPtr(pool->TakeSnapshot()));
+    });
     return newDatabase;
-}
-
-void TDatabase::AddPool(const TPoolPtr& pool) {
-    Y_ENSURE(!Pools.contains(std::get<TPoolId>(pool->GetId())));
-    Pools.emplace(std::get<TPoolId>(pool->GetId()), pool);
-    AddChild(pool);
-}
-
-TPoolPtr TDatabase::GetPool(const TPoolId& id) const {
-    auto it = Pools.find(id);
-    return it == Pools.end() ? nullptr : it->second;
 }
 
 ///////////////////////////////////////////////////////////////////////////////
 // TRoot
 ///////////////////////////////////////////////////////////////////////////////
 
-TRoot::TRoot(TIntrusivePtr<TKqpCounters> counters) {
+TRoot::TRoot(TIntrusivePtr<TKqpCounters> counters)
+    : NHdrf::TTreeElementBase<ETreeType::DYNAMIC>("(ROOT)")
+    , TPool("(ROOT)", {})
+{
+    Y_ASSERT(counters);
     auto group = counters->GetKqpCounters();
     Counters.TotalLimit = group->GetCounter("scheduler/TotalLimit", false);
 }
 
 void TRoot::AddDatabase(const TDatabasePtr& database) {
-    Y_ENSURE(!Databases.contains(std::get<TDatabaseId>(database->GetId())));
-    Databases.emplace(std::get<TDatabaseId>(database->GetId()), database);
-    AddChild(database);
+    AddPool(database);
 }
 
-TDatabasePtr TRoot::GetDatabase(const TDatabaseId& id) const {
-    auto it = Databases.find(id);
-    return it == Databases.end() ? nullptr : it->second;
+void TRoot::RemoveDatabase(const TDatabaseId& databaseId) {
+    RemovePool(databaseId);
+}
+
+TDatabasePtr TRoot::GetDatabase(const TDatabaseId& databaseId) const {
+    return std::static_pointer_cast<TDatabase>(GetPool(databaseId));
 }
 
 NSnapshot::TRoot* TRoot::TakeSnapshot() const {
@@ -179,9 +171,9 @@ NSnapshot::TRoot* TRoot::TakeSnapshot() const {
     Counters.TotalLimit->Set(TotalLimit * 1'000'000);
 
     newRoot->TotalLimit = TotalLimit;
-    for (const auto& child : Children) {
-        newRoot->AddDatabase(std::shared_ptr<NSnapshot::TDatabase>(std::dynamic_pointer_cast<TDatabase>(child)->TakeSnapshot()));
-    }
+    ForEachChild<TDatabase>([&](TDatabase* database, size_t) {
+        newRoot->AddDatabase(NSnapshot::TDatabasePtr(database->TakeSnapshot()));
+    });
 
     return newRoot;
 }

--- a/ydb/core/kqp/runtime/scheduler/tree/dynamic.cpp
+++ b/ydb/core/kqp/runtime/scheduler/tree/dynamic.cpp
@@ -78,19 +78,21 @@ TPool::TPool(const TPoolId& id, const TIntrusivePtr<TKqpCounters>& counters, con
     // TODO: since counters don't support float-point values, then use CPU * 1'000'000 to account with microsecond precision
 
     Counters = TPoolCounters();
-    Counters->Limit     = group->GetCounter("Limit",     false);
-    Counters->Guarantee = group->GetCounter("Guarantee", false);
-    Counters->Demand    = group->GetCounter("Demand",    false); // snapshot
-    Counters->InFlight  = group->GetCounter("InFlight",  false);
-    Counters->Waiting   = group->GetCounter("Waiting",   false);
-    Counters->Usage     = group->GetCounter("Usage",     true);
-    Counters->Throttle  = group->GetCounter("Throttle",  true);
-    Counters->FairShare = group->GetCounter("FairShare", true);  // snapshot
+    Counters->Satisfaction = group->GetCounter("Satisfaction", false); // snapshot
+    Counters->Limit        = group->GetCounter("Limit",        false);
+    Counters->Guarantee    = group->GetCounter("Guarantee",    false);
+    Counters->Demand       = group->GetCounter("Demand",       false); // snapshot
+    Counters->InFlight     = group->GetCounter("InFlight",     false);
+    Counters->Waiting      = group->GetCounter("Waiting",      false);
+    Counters->Usage        = group->GetCounter("Usage",        true);
+    Counters->UsageResume  = group->GetCounter("UsageResume",  true);
+    Counters->Throttle     = group->GetCounter("Throttle",     true);
+    Counters->FairShare    = group->GetCounter("FairShare",    true);  // snapshot
 
-    Counters->InFlightExtra = group->GetCounter("InFlightExtra",  false);
-    Counters->UsageExtra    = group->GetCounter("UsageExtra",     true);
+    Counters->InFlightExtra = group->GetCounter("InFlightExtra", false);
+    Counters->UsageExtra    = group->GetCounter("UsageExtra",    true);
 
-    Counters->Delay     = group->GetHistogram("Delay",
+    Counters->Delay = group->GetHistogram("Delay",
         NMonitoring::ExplicitHistogram({10, 10e2, 10e3, 10e4, 10e5, 10e6, 10e7}), true); // TODO: make from MinDelay to MaxDelay.
 }
 
@@ -103,6 +105,7 @@ NSnapshot::TPool* TPool::TakeSnapshot() const {
         Counters->InFlight->Set(Usage * 1'000'000);
         Counters->Waiting->Set(Throttle * 1'000'000);
         Counters->Usage->Set(BurstUsage);
+        Counters->UsageResume->Set(BurstUsageResume);
         Counters->Throttle->Set(BurstThrottle);
 
         Counters->InFlightExtra->Set(UsageExtra * 1'000'000);

--- a/ydb/core/kqp/runtime/scheduler/tree/dynamic.h
+++ b/ydb/core/kqp/runtime/scheduler/tree/dynamic.h
@@ -34,6 +34,7 @@ namespace NKikimr::NKqp::NScheduler::NHdrf::NDynamic {
         std::atomic<ui64> Throttle = 0;
 
         std::atomic<ui64> BurstUsage = 0;
+        std::atomic<ui64> BurstUsageResume = 0;
         std::atomic<ui64> BurstUsageExtra = 0;
         std::atomic<ui64> BurstThrottle = 0;
 

--- a/ydb/core/kqp/runtime/scheduler/tree/snapshot.cpp
+++ b/ydb/core/kqp/runtime/scheduler/tree/snapshot.cpp
@@ -4,186 +4,184 @@
 
 namespace NKikimr::NKqp::NScheduler::NHdrf::NSnapshot {
 
-void TTreeElementBase::AddChild(const TTreeElementPtr& element) {
-    Children.push_back(element);
-    element->Parent = this;
+///////////////////////////////////////////////////////////////////////////////
+// TTreeElement
+///////////////////////////////////////////////////////////////////////////////
+
+TPool* TTreeElement::GetParent() const {
+    return dynamic_cast<TPool*>(Parent);
 }
 
-void TTreeElementBase::RemoveChild(const TTreeElementPtr& element) {
-    for (auto it = Children.begin(); it != Children.end(); ++it) {
-        if (*it == element) {
-            element->Parent = nullptr;
-            // TODO: should we decrease usage for parents here?
-            Children.erase(it);
-            return;
-        }
-    }
-    // TODO: throw exception that child not found.
-}
-
-void TTreeElementBase::AccountFairShare(const TDuration& period) {
-    for (auto& child : Children) {
+void TTreeElement::AccountFairShare(const TDuration& period) {
+    ForEachChild<TTreeElement>([&](TTreeElement* child, size_t) {
         child->AccountFairShare(period);
-    }
+    });
 }
 
-void TTreeElementBase::UpdateBottomUp(ui64 totalLimit) {
+void TTreeElement::UpdateBottomUp(ui64 totalLimit) {
     TotalLimit = totalLimit;
     Limit = Min<ui64>(GetLimit(), TotalLimit);
 
-    if (!IsLeaf()) {
+    if (IsPool()) {
         Demand = 0;
-        for (auto& child : Children) {
+        Usage = 0;
+        ForEachChild<TTreeElement>([&](TTreeElement* child, size_t) {
             child->UpdateBottomUp(totalLimit);
             Demand += child->Demand;
-        }
+            Usage += child->Usage;
+        });
     }
 
     Demand = Min<ui64>(Demand, GetLimit());
     Guarantee = Min<ui64>(GetGuarantee(), Demand);
 }
 
-void TTreeElementBase::UpdateTopDown() {
+TTreeElement* TTreeElement::UpdateTopDown() {
     if (IsRoot()) {
         FairShare = Demand;
     }
 
     // At this moment we know own fair-share. Need to calibrate children.
 
-    // Fair-share variant (for pools and databases)
-    if (!IsLeaf() && !Children.at(0)->IsLeaf()) {
+    TTreeElement* mostUnsatisfied = this;
+    if (FairShare >= 1'000'000) {
+        Satisfaction = Usage/float(FairShare);
+    }
+
+    if (!IsPool()) {
+        return mostUnsatisfied;
+    }
+
+    // Fair-share variant (when children are pools and databases)
+    if (!IsLeaf()) {
         ui64 totalWeightedDemand = 0;
         std::vector<ui64> weightedDemand;
 
-        weightedDemand.resize(Children.size());
-        for (size_t i = 0, s = Children.size(); i < s; ++i) {
-            const auto& child = Children.at(i);
+        weightedDemand.resize(ChildrenSize());
+        ForEachChild<TTreeElement>([&](TTreeElement* child, size_t i) {
             weightedDemand.at(i) = child->GetWeight() * child->Demand;
             totalWeightedDemand += weightedDemand.at(i);
-        }
-
-        for (size_t i = 0, s = Children.size(); i < s; ++i) {
-            const auto& child = Children.at(i);
+        });
+        ForEachChild<TTreeElement>([&](TTreeElement* child, size_t i) {
             if (totalWeightedDemand > 0) {
-                // TODO: distribute resources lost because of integer division.
+                // TODO: distribute the resources lost cause of integer division.
                 child->FairShare = weightedDemand.at(i) * FairShare / totalWeightedDemand;
             } else {
                 child->FairShare = 0;
             }
-            child->UpdateTopDown();
-        }
+
+            auto* unsatisfied = child->UpdateTopDown();
+            if (mostUnsatisfied == this || !mostUnsatisfied->Satisfaction ||
+                unsatisfied->Satisfaction && *unsatisfied->Satisfaction <= *mostUnsatisfied->Satisfaction)
+            {
+                mostUnsatisfied = unsatisfied;
+            }
+        });
     }
-    // FIFO variant (for queries)
+    // FIFO variant (when children are queries)
     else {
         // TODO: stable sort children by weight
 
         auto leftFairShare = FairShare;
 
         // Give at least 1 fair-share for each demanding child
-        for (size_t i = 0, s = Children.size(); i < s && leftFairShare > 0; ++i) {
-            const auto& child = Children.at(i);
+        ForEachChild<TTreeElement>([&](TTreeElement* child, size_t) -> bool {
+            if (leftFairShare == 0) {
+                return true;
+            }
+
             if (child->Demand > 0) {
                 child->FairShare = 1;
                 --leftFairShare;
             }
-        }
 
-        for (size_t i = 0, s = Children.size(); i < s; ++i) {
-            const auto& child = Children.at(i);
-            auto demand = child->Demand > 0 ? child->Demand - 1 : 0;
-            child->FairShare += Min(leftFairShare, demand);
+            return false;
+        });
+        ForEachChild<TQuery>([&](TQuery* query, size_t) {
+            auto demand = query->Demand > 0 ? query->Demand - 1 : 0;
+            query->FairShare += Min(leftFairShare, demand);
             leftFairShare = leftFairShare <= demand ? 0 : leftFairShare - demand;
 
-            // TODO: looks a little bit hacky.
-            if (auto query = std::dynamic_pointer_cast<TQuery>(child); query && query->Origin) {
-                query->Origin->SetSnapshot(query);
-                query->Origin = nullptr;
-            }
-        }
+            Y_ASSERT(query->Origin);
+            query->Origin->SetSnapshot(query->shared_from_this());
+        });
     }
+
+    return mostUnsatisfied;
 }
 
 ///////////////////////////////////////////////////////////////////////////////
 // TQuery
 ///////////////////////////////////////////////////////////////////////////////
 
-TQuery::TQuery(const TQueryId& id, NDynamic::TQuery* origQuery)
-    : Origin(origQuery)
-    , Id(id)
+TQuery::TQuery(const TQueryId& id, NDynamic::TQuery* query)
+    : NHdrf::TTreeElementBase<ETreeType::SNAPSHOT>(id, *query)
+    , TTreeElement(id, *query)
+    , NHdrf::TQuery<ETreeType::SNAPSHOT>(id, *query)
+    , Origin(query)
 {
-    Update(*origQuery);
 }
 
 ///////////////////////////////////////////////////////////////////////////////
 // TPool
 ///////////////////////////////////////////////////////////////////////////////
 
-TPool::TPool(const TString& id, const TPoolCounters& counters, const TStaticAttributes& attrs)
-    : Id(id)
+TPool::TPool(const TPoolId& id, const std::optional<TPoolCounters>& counters, const TStaticAttributes& attrs)
+    : NHdrf::TTreeElementBase<ETreeType::SNAPSHOT>(id, attrs)
+    , TTreeElement(id, attrs)
+    , NHdrf::TPool<ETreeType::SNAPSHOT>(id, attrs)
 {
-    Update(attrs);
-
-    Counters.Demand    = counters.Demand;
-    Counters.FairShare = counters.FairShare;
+    if (counters) {
+        Counters = TPoolCounters();
+        Counters->Demand    = counters->Demand;
+        Counters->FairShare = counters->FairShare;
+    }
 }
 
 void TPool::AccountFairShare(const TDuration& period) {
-    Counters.FairShare->Add(FairShare * period.MicroSeconds());
-    TTreeElementBase::AccountFairShare(period);
+    if (Counters) {
+        Counters->FairShare->Add(FairShare * period.MicroSeconds());
+    }
+    TTreeElement::AccountFairShare(period);
 }
 
 void TPool::UpdateBottomUp(ui64 totalLimit) {
-    TTreeElementBase::UpdateBottomUp(totalLimit);
-    Counters.Demand->Set(Demand * 1'000'000);
-}
-
-void TPool::AddQuery(const TQueryPtr& query) {
-    Y_ENSURE(!Queries.contains(query->GetId()));
-    Queries.emplace(query->GetId(), query);
-    AddChild(query);
-}
-
-void TPool::RemoveQuery(const TQueryId& queryId) {
-    auto queryIt = Queries.find(queryId);
-    Y_ENSURE(queryIt != Queries.end());
-    RemoveChild(queryIt->second);
-    Queries.erase(queryIt);
-}
-
-TQueryPtr TPool::GetQuery(const TQueryId& queryId) const {
-    auto it = Queries.find(queryId);
-    return it == Queries.end() ? nullptr : it->second;
+    TTreeElement::UpdateBottomUp(totalLimit);
+    if (Counters) {
+        Counters->Demand->Set(Demand * 1'000'000);
+    }
 }
 
 ///////////////////////////////////////////////////////////////////////////////
 // TDatabase
 ///////////////////////////////////////////////////////////////////////////////
 
-TDatabase::TDatabase(const TString& id, const TStaticAttributes& attrs)
-    : Id(id)
+TDatabase::TDatabase(const TDatabaseId& id, const TStaticAttributes& attrs)
+    : NHdrf::TTreeElementBase<ETreeType::SNAPSHOT>(id, attrs)
+    , TPool(id, {}, attrs)
 {
-    Update(attrs);
-}
-
-void TDatabase::AddPool(const TPoolPtr& pool) {
-    Y_ENSURE(!Pools.contains(pool->GetId()));
-    Pools.emplace(pool->GetId(), pool);
-    AddChild(pool);
-}
-
-TPoolPtr TDatabase::GetPool(const TString& poolId) const {
-    auto it = Pools.find(poolId);
-    return it == Pools.end() ? nullptr : it->second;
 }
 
 ///////////////////////////////////////////////////////////////////////////////
 // TRoot
 ///////////////////////////////////////////////////////////////////////////////
 
+TRoot::TRoot()
+    : NHdrf::TTreeElementBase<ETreeType::SNAPSHOT>("(ROOT)")
+    , TPool("(ROOT)", {})
+{
+}
+
 void TRoot::AddDatabase(const TDatabasePtr& database) {
-    Y_ENSURE(!Databases.contains(database->GetId()));
-    Databases.emplace(database->GetId(), database);
-    AddChild(database);
+    AddPool(database);
+}
+
+void TRoot::RemoveDatabase(const TDatabaseId& databaseId) {
+    RemovePool(databaseId);
+}
+
+TDatabasePtr TRoot::GetDatabase(const TDatabaseId& databaseId) const {
+    return std::static_pointer_cast<TDatabase>(GetPool(databaseId));
 }
 
 void TRoot::AccountFairShare(const TRootPtr& previous) {

--- a/ydb/core/kqp/runtime/scheduler/tree/snapshot.h
+++ b/ydb/core/kqp/runtime/scheduler/tree/snapshot.h
@@ -1,107 +1,66 @@
 #pragma once
 
-#include "../fwd.h"
 #include "common.h"
 
 #include <library/cpp/time_provider/monotonic.h>
 
-#include <util/datetime/base.h>
-#include <util/generic/hash.h>
-
-#include <vector>
-
 namespace NKikimr::NKqp::NScheduler::NHdrf::NSnapshot {
 
-    struct TTreeElementBase : public TStaticAttributes {
+    struct TTreeElement : public virtual TTreeElementBase<ETreeType::SNAPSHOT> {
         ui64 TotalLimit = Infinity();
         ui64 FairShare = 0;
 
         ui64 Demand = 0;
+        ui64 Usage = 0;
+        std::optional<float> Satisfaction;
 
-        TTreeElementBase* Parent = nullptr;
-        std::vector<TTreeElementPtr> Children;
+        const TMonotonic Timestamp = TMonotonic::Now();
 
-        virtual ~TTreeElementBase() = default;
+        explicit TTreeElement(const TId& id, const TStaticAttributes& attrs = {}) : TTreeElementBase(id, attrs) {}
 
-        void AddChild(const TTreeElementPtr& element);
-        void RemoveChild(const TTreeElementPtr& element);
-
-        bool IsRoot() const {
-            return !Parent;
-        }
-
-        bool IsLeaf() const {
-            return Children.empty();
-        }
+        TPool* GetParent() const;
 
         virtual void AccountFairShare(const TDuration& period);
         virtual void UpdateBottomUp(ui64 totalLimit);
-        void UpdateTopDown();
+        TTreeElement* UpdateTopDown(); // returns the most unsatisfied leaf pool
     };
 
-    class TQuery : public TTreeElementBase {
+    class TQuery : public TTreeElement, public NHdrf::TQuery<ETreeType::SNAPSHOT>, public std::enable_shared_from_this<TQuery> {
     public:
-        TQuery(const TQueryId& queryId, NDynamic::TQuery* origQuery);
+        TQuery(const TQueryId& queryId, NDynamic::TQuery* query);
 
-        const TQueryId& GetId() const {
-            return Id;
-        }
-
-        const TMonotonic Timestamp = TMonotonic::Now();
-        NDynamic::TQuery* Origin;
-
-    private:
-        const TQueryId Id;
+        NDynamic::TQuery* Origin; // TODO: why public?
     };
 
-    class TPool : public TTreeElementBase {
+    class TPool : public TTreeElement, public NHdrf::TPool<ETreeType::SNAPSHOT> {
     public:
-        TPool(const TString& id, const TPoolCounters& counters, const TStaticAttributes& attrs = {});
-
-        const TString& GetId() const {
-            return Id;
-        }
+        TPool(const TPoolId& id, const std::optional<TPoolCounters>& counters, const TStaticAttributes& attrs = {});
 
         void AccountFairShare(const TDuration& period) override;
         void UpdateBottomUp(ui64 totalLimit) override;
-
-        void AddQuery(const TQueryPtr& query);
-        void RemoveQuery(const TQueryId& queryId);
-        TQueryPtr GetQuery(const TQueryId& queryId) const;
-
-    private:
-        const TString Id;
-        THashMap<TQueryId, TQueryPtr> Queries;
-        TPoolCounters Counters;
     };
 
-    class TDatabase : public TTreeElementBase {
+    class TDatabase : public TPool {
     public:
-        explicit TDatabase(const TString& id, const TStaticAttributes& attrs = {});
+        explicit TDatabase(const TDatabaseId& id, const TStaticAttributes& attrs = {});
+    };
 
-        void AddPool(const TPoolPtr& pool);
-        TPoolPtr GetPool(const TString& poolId) const;
+    class TRoot : public TPool {
+    public:
+        TRoot();
 
-        const TString& GetId() const {
-            return Id;
+        inline bool IsRoot() const final {
+            return true;
         }
 
-    private:
-        const TString Id;
-        THashMap<TString /* poolId */, TPoolPtr> Pools;
-    };
-
-    class TRoot : public TTreeElementBase {
-    public:
         void AddDatabase(const TDatabasePtr& database);
-        TDatabasePtr GetDatabase(const TString& id) const;
+        void RemoveDatabase(const TDatabaseId& databaseId);
+        TDatabasePtr GetDatabase(const TDatabaseId& databaseId) const;
 
         void AccountFairShare(const TRootPtr& previous);
-        using TTreeElementBase::AccountFairShare;
 
     private:
-        const TMonotonic Timestamp = TMonotonic::Now();
-        THashMap<TString /* databaseId */, TDatabasePtr> Databases;
+        using TTreeElement::AccountFairShare;
     };
 
 }

--- a/ydb/core/kqp/runtime/scheduler/tree/snapshot.h
+++ b/ydb/core/kqp/runtime/scheduler/tree/snapshot.h
@@ -20,9 +20,9 @@ namespace NKikimr::NKqp::NScheduler::NHdrf::NSnapshot {
 
         TPool* GetParent() const;
 
-        virtual void AccountFairShare(const TDuration& period);
+        virtual void AccountSnapshotDuration(const TDuration& period);
         virtual void UpdateBottomUp(ui64 totalLimit);
-        TTreeElement* UpdateTopDown(); // returns the most unsatisfied leaf pool
+        void UpdateTopDown();
     };
 
     class TQuery : public TTreeElement, public NHdrf::TQuery<ETreeType::SNAPSHOT>, public std::enable_shared_from_this<TQuery> {
@@ -36,7 +36,7 @@ namespace NKikimr::NKqp::NScheduler::NHdrf::NSnapshot {
     public:
         TPool(const TPoolId& id, const std::optional<TPoolCounters>& counters, const TStaticAttributes& attrs = {});
 
-        void AccountFairShare(const TDuration& period) override;
+        void AccountSnapshotDuration(const TDuration& period) override;
         void UpdateBottomUp(ui64 totalLimit) override;
     };
 
@@ -57,10 +57,7 @@ namespace NKikimr::NKqp::NScheduler::NHdrf::NSnapshot {
         void RemoveDatabase(const TDatabaseId& databaseId);
         TDatabasePtr GetDatabase(const TDatabaseId& databaseId) const;
 
-        void AccountFairShare(const TRootPtr& previous);
-
-    private:
-        using TTreeElement::AccountFairShare;
+        void AccountPreviousSnapshot(const TRootPtr& snapshot);
     };
 
 }

--- a/ydb/core/kqp/runtime/ya.make
+++ b/ydb/core/kqp/runtime/ya.make
@@ -28,6 +28,7 @@ SRCS(
 
     scheduler/kqp_compute_scheduler_service.cpp
     scheduler/kqp_schedulable_actor.cpp
+    scheduler/kqp_schedulable_task.cpp
     scheduler/tree/dynamic.cpp
     scheduler/tree/snapshot.cpp
 )


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

The compute scheduler tries to utilize all pools fair-share by resuming throttled tasks

### Changelog category <!-- remove all except one -->

* Performance improvement