### PR TITLE
Keep native strictness in YtMeta attrs - YDB-related changes

### DIFF
--- a/ydb/tests/fq/tools/kqprun.py
+++ b/ydb/tests/fq/tools/kqprun.py
@@ -1,5 +1,5 @@
 import os
-from typing import Optional, List
+from typing import Optional, List, Callable
 
 import pytest
 import yatest.common
@@ -27,13 +27,16 @@ class KqpRun(object):
     def __res_file_path(self, name: str) -> str:
         return os.path.join(self.res_dir, name)
 
-    def add_table(self, name: str, content: List[str], attrs: Optional[str] = None):
+    def add_table(self, name: str, content: List[str], attrs: Optional[str] = None, attrs_postprocess: Callable[str, str] = None):
         table_path = self.__res_file_path(f'table_{len(self.tables)}.yson')
         with open(table_path, 'w') as table:
             for row in content:
                 table.write(f'{row}\n')
 
         if attrs is not None:
+            if attrs_postprocess is not None:
+                attrs = attrs_postprocess(attrs)
+
             with open(f'{table_path}.attr', 'w') as table_attrs:
                 table_attrs.write(attrs)
 

--- a/ydb/tests/fq/yt/kqp_yt_import/helpers.py
+++ b/ydb/tests/fq/yt/kqp_yt_import/helpers.py
@@ -5,6 +5,8 @@ import ydb.public.api.protos.ydb_value_pb2 as ydb
 
 from ydb.tests.fq.tools.kqprun import KqpRun
 
+from yt.yql.tests.common.test_framework.test_utils import infer_yt_schema
+
 
 ValueByTypeExtractors = {
     ydb.Type.PrimitiveTypeId.INT64: lambda x: x.int64_value,
@@ -30,7 +32,7 @@ def add_sample_table(kqp_run: KqpRun, table_name: str = 'input', infer_schema: b
         '{"key"="800";"subkey"=2;"value"="ddd"};',
         '{"key"="020";"subkey"=3;"value"="q"};',
         '{"key"="150";"subkey"=4;"value"="qzz"};'
-    ], attrs)
+    ], attrs, attrs_postprocess=infer_yt_schema)
 
 
 def validate_sample_result(result: str):

--- a/ydb/tests/fq/yt/kqp_yt_import/ya.make
+++ b/ydb/tests/fq/yt/kqp_yt_import/ya.make
@@ -24,6 +24,7 @@ DATA(
 PEERDIR(
     ydb/public/api/protos
     ydb/tests/fq/tools
+    yt/yql/tests/common/test_framework
     yql/essentials/tests/common/test_framework
 )
 


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

### Changelog category <!-- remove all except one -->

* Not for changelog (changelog entry is not required)

### Description for reviewers <!-- (optional) description for those who read this PR -->

Fix `test_yt_reading.py::TestYtReading::test_block_reading` test breakage introduced by commit [Keep native strictness in YtMeta attrs & block input fix](https://github.com/ydb-platform/ydb/commit/46e4be74a9340d4152edfb8e8f739d50aaf83240) brought by YQL sync