### PR TITLE
Global vector index update support

### DIFF
--- a/ydb/core/base/kmeans_clusters.cpp
+++ b/ydb/core/base/kmeans_clusters.cpp
@@ -266,13 +266,10 @@ public:
         return false;
     }
 
-    std::optional<ui32> FindCluster(TArrayRef<const TCell> row, ui32 embeddingPos) override {
-        Y_ENSURE(embeddingPos < row.size());
-        const auto embedding = row.at(embeddingPos).AsRef();
+    std::optional<ui32> FindCluster(TArrayRef<const char> embedding) override {
         if (!IsExpectedSize(embedding)) {
             return {};
         }
-
         auto min = TMetric::Init();
         std::optional<ui32> closest = {};
         for (size_t i = 0; const auto& cluster : Clusters) {
@@ -284,6 +281,11 @@ public:
             ++i;
         }
         return closest;
+    }
+
+    std::optional<ui32> FindCluster(TArrayRef<const TCell> row, ui32 embeddingPos) override {
+        Y_ENSURE(embeddingPos < row.size());
+        return FindCluster(row.at(embeddingPos).AsRef());
     }
 
     void AggregateToCluster(ui32 pos, const TArrayRef<const char>& embedding, ui64 weight) override {

--- a/ydb/core/base/kmeans_clusters.h
+++ b/ydb/core/base/kmeans_clusters.h
@@ -32,6 +32,8 @@ public:
 
     virtual void RemoveEmptyClusters() = 0;
 
+    virtual std::optional<ui32> FindCluster(TArrayRef<const char> embedding) = 0;
+
     virtual std::optional<ui32> FindCluster(TArrayRef<const TCell> row, ui32 embeddingPos) = 0;
 
     virtual void AggregateToCluster(ui32 pos, const TArrayRef<const char>& embedding, ui64 weight = 1) = 0;

--- a/ydb/core/base/table_index.cpp
+++ b/ydb/core/base/table_index.cpp
@@ -190,8 +190,6 @@ bool IsBuildImplTable(std::string_view tableName) {
         || tableName.ends_with(NTableVectorKmeansTreeIndex::BuildSuffix1);
 }
 
-static constexpr TClusterId PostingParentFlag = (1ull << 63ull);
-
 // Note: if cluster id is too big, something is wrong with cluster enumeration
 void EnsureNoPostingParentFlag(TClusterId parent) {
     Y_ENSURE((parent & PostingParentFlag) == 0);

--- a/ydb/core/base/table_index.h
+++ b/ydb/core/base/table_index.h
@@ -49,6 +49,8 @@ using TClusterId = ui64;
 inline constexpr auto ClusterIdType = Ydb::Type::UINT64;
 inline constexpr const char* ClusterIdTypeName = "Uint64";
 
+inline constexpr TClusterId PostingParentFlag = (1ull << 63ull);
+
 void EnsureNoPostingParentFlag(TClusterId parent);
 
 TClusterId SetPostingParentFlag(TClusterId parent);

--- a/ydb/core/kqp/common/kqp_tx.cpp
+++ b/ydb/core/kqp/common/kqp_tx.cpp
@@ -175,6 +175,7 @@ bool NeedSnapshot(const TKqpTransactionContext& txCtx, const NYql::TKikimrConfig
     bool hasStreamLookup = false;
     bool hasSinkWrite = false;
     bool hasSinkInsert = false;
+    bool hasVectorResolve = false;
 
     for (const auto &tx : physicalQuery.GetTransactions()) {
         switch (tx.GetType()) {
@@ -208,6 +209,7 @@ bool NeedSnapshot(const TKqpTransactionContext& txCtx, const NYql::TKikimrConfig
 
             for (const auto &input : stage.GetInputs()) {
                 hasStreamLookup |= input.GetTypeCase() == NKqpProto::TKqpPhyConnection::kStreamLookup;
+                hasVectorResolve |= input.GetTypeCase() == NKqpProto::TKqpPhyConnection::kVectorResolve;
             }
 
             for (const auto &tableOp : stage.GetTableOps()) {
@@ -226,7 +228,7 @@ bool NeedSnapshot(const TKqpTransactionContext& txCtx, const NYql::TKikimrConfig
     YQL_ENSURE(!hasSinkWrite || hasEffects);
 
     // We need snapshot for stream lookup, besause it's used for dependent reads
-    if (hasStreamLookup) {
+    if (hasStreamLookup || hasVectorResolve) {
         return true;
     }
 
@@ -379,6 +381,7 @@ bool HasUncommittedChangesRead(THashSet<NKikimr::TTableId>& modifiedTables, cons
                     break;
                 case NKqpProto::TKqpPhyConnection::kSequencer:
                     return true;
+                case NKqpProto::TKqpPhyConnection::kVectorResolve: // FIXME: Maybe, when prefix tables are enabled
                 case NKqpProto::TKqpPhyConnection::kUnionAll:
                 case NKqpProto::TKqpPhyConnection::kParallelUnionAll:
                 case NKqpProto::TKqpPhyConnection::kMap:

--- a/ydb/core/kqp/common/kqp_yql.cpp
+++ b/ydb/core/kqp/common/kqp_yql.cpp
@@ -623,4 +623,33 @@ TKqpStreamLookupSettings TKqpStreamLookupSettings::Parse(const NNodes::TKqpCnStr
     return TKqpStreamLookupSettings::Parse(node.Settings());
 }
 
+NNodes::TCoNameValueTupleList TKqpDeleteRowsIndexSettings::BuildNode(TExprContext& ctx, TPositionHandle pos) const {
+    TVector<TCoNameValueTuple> settings;
+
+    if (SkipLookup) {
+        settings.emplace_back(
+            Build<TCoNameValueTuple>(ctx, pos)
+                .Name().Build(SkipLookupSettingName)
+            .Done()
+        );
+    }
+
+    return Build<TCoNameValueTupleList>(ctx, pos)
+        .Add(settings)
+        .Done();
+}
+
+TKqpDeleteRowsIndexSettings TKqpDeleteRowsIndexSettings::Parse(const NNodes::TKqlDeleteRowsIndex& del) {
+    TKqpDeleteRowsIndexSettings settings;
+    if (del.Settings()) {
+        for (const auto& tuple: del.Settings().Cast()) {
+            auto name = tuple.Name().Value();
+            if (name == SkipLookupSettingName) {
+                settings.SkipLookup = true;
+            }
+        }
+    }
+    return settings;
+}
+
 } // namespace NYql

--- a/ydb/core/kqp/common/kqp_yql.h
+++ b/ydb/core/kqp/common/kqp_yql.h
@@ -72,6 +72,14 @@ struct TKqpStreamLookupSettings {
     static TKqpStreamLookupSettings Parse(const NNodes::TCoNameValueTupleList& node);
 };
 
+struct TKqpDeleteRowsIndexSettings {
+    bool SkipLookup = false;
+    static constexpr TStringBuf SkipLookupSettingName = "SkipLookup";
+
+    NNodes::TCoNameValueTupleList BuildNode(TExprContext& ctx, TPositionHandle pos) const;
+    static TKqpDeleteRowsIndexSettings Parse(const NNodes::TKqlDeleteRowsIndex& node);
+};
+
 enum class ERequestSorting {
     NONE = 0,
     ASC,

--- a/ydb/core/kqp/compute_actor/kqp_compute_actor.cpp
+++ b/ydb/core/kqp/compute_actor/kqp_compute_actor.cpp
@@ -10,6 +10,7 @@
 #include <ydb/core/kqp/runtime/kqp_read_table.h>
 #include <ydb/core/kqp/runtime/kqp_sequencer_factory.h>
 #include <ydb/core/kqp/runtime/kqp_stream_lookup_factory.h>
+#include <ydb/core/kqp/runtime/kqp_vector_actor.h>
 #include <ydb/library/yql/providers/generic/actors/yql_generic_provider_factories.h>
 #include <ydb/library/formats/arrow/protos/ssa.pb.h>
 #include <ydb/library/yql/dq/proto/dq_tasks.pb.h>
@@ -88,6 +89,7 @@ NYql::NDq::IDqAsyncIoFactory::TPtr CreateKqpAsyncIoFactory(
     RegisterKqpReadActor(*factory, counters);
     RegisterKqpWriteActor(*factory, counters);
     RegisterSequencerActorFactory(*factory, counters);
+    RegisterKqpVectorResolveActor(*factory, counters);
 
     if (federatedQuerySetup) {
         auto s3HttpRetryPolicy = NYql::GetHTTPDefaultRetryPolicy(NYql::THttpRetryPolicyOptions{.RetriedCurlCodes = NYql::FqRetriedCurlCodes()});

--- a/ydb/core/kqp/executer_actor/kqp_executer_impl.h
+++ b/ydb/core/kqp/executer_actor/kqp_executer_impl.h
@@ -1515,6 +1515,7 @@ protected:
                     case NKqpProto::TKqpPhyConnection::kStreamLookup:
                     case NKqpProto::TKqpPhyConnection::kMap:
                     case NKqpProto::TKqpPhyConnection::kParallelUnionAll:
+                    case NKqpProto::TKqpPhyConnection::kVectorResolve:
                         break;
                     default:
                         YQL_ENSURE(false, "Unexpected connection type: " << (ui32)input.GetTypeCase() << Endl
@@ -1546,6 +1547,12 @@ protected:
                 case NKqpProto::TKqpPhyConnection::kParallelUnionAll: {
                     inputTasks += originStageInfo.Tasks.size();
                     isParallelUnionAll = true;
+                    break;
+                }
+                case NKqpProto::TKqpPhyConnection::kVectorResolve: {
+                    partitionsCount = originStageInfo.Tasks.size();
+                    UnknownAffectedShardCount = true;
+                    intros.push_back("Resetting compute tasks count because input " + ToString(inputIndex) + " is VectorResolve - " + ToString(partitionsCount));
                     break;
                 }
                 default:

--- a/ydb/core/kqp/executer_actor/kqp_tasks_graph.h
+++ b/ydb/core/kqp/executer_actor/kqp_tasks_graph.h
@@ -212,10 +212,11 @@ struct TGraphMeta {
 };
 
 struct TTaskInputMeta {
-    // these message are allocated using the protubuf arena.
+    // these message are allocated using the protobuf arena.
     NKikimrTxDataShard::TKqpReadRangesSourceSettings* SourceSettings = nullptr;
     NKikimrKqp::TKqpStreamLookupSettings* StreamLookupSettings = nullptr;
     NKikimrKqp::TKqpSequencerSettings* SequencerSettings = nullptr;
+    NKikimrTxDataShard::TKqpVectorResolveSettings* VectorResolveSettings = nullptr;
 };
 
 struct TTaskOutputMeta {

--- a/ydb/core/kqp/expr_nodes/kqp_expr_nodes.json
+++ b/ydb/core/kqp/expr_nodes/kqp_expr_nodes.json
@@ -456,6 +456,16 @@
             ]
         },
         {
+            "Name": "TKqpCnVectorResolve",
+            "Base": "TKqpConnection",
+            "Match": {"Type": "Callable", "Name": "KqpCnVectorResolve"},
+            "Children": [
+                {"Index": 1, "Name": "Table", "Type": "TKqpTable"},
+                {"Index": 2, "Name": "InputType", "Type": "TExprBase"},
+                {"Index": 3, "Name": "Index", "Type": "TCoAtom"}
+            ]
+        },
+        {
             "Name": "TKqlIndexLookupJoinBase",
             "Base": "TCallable",
             "Match": {"Type": "CallableBase"},

--- a/ydb/core/kqp/opt/kqp_opt.cpp
+++ b/ydb/core/kqp/opt/kqp_opt.cpp
@@ -122,6 +122,10 @@ TExprBase ProjectColumns(const TExprBase& input, const TVector<TString>& columnN
     return ProjectColumnsInternal(input, columnNames, ctx);
 }
 
+TExprBase ProjectColumns(const TExprBase& input, const TVector<TStringBuf>& columnNames, TExprContext& ctx) {
+    return ProjectColumnsInternal(input, columnNames, ctx);
+}
+
 TExprBase ProjectColumns(const TExprBase& input, const THashSet<TStringBuf>& columnNames, TExprContext& ctx) {
     return ProjectColumnsInternal(input, columnNames, ctx);
 }

--- a/ydb/core/kqp/opt/kqp_opt_impl.h
+++ b/ydb/core/kqp/opt/kqp_opt_impl.h
@@ -18,6 +18,8 @@ const NYql::TKikimrTableDescription& GetTableData(const NYql::TKikimrTablesData&
 
 NYql::NNodes::TExprBase ProjectColumns(const NYql::NNodes::TExprBase& input, const TVector<TString>& columnNames,
     NYql::TExprContext& ctx);
+NYql::NNodes::TExprBase ProjectColumns(const NYql::NNodes::TExprBase& input, const TVector<TStringBuf>& columnNames,
+    NYql::TExprContext& ctx);
 NYql::NNodes::TExprBase ProjectColumns(const NYql::NNodes::TExprBase& input, const THashSet<TStringBuf>& columnNames,
     NYql::TExprContext& ctx);
 

--- a/ydb/core/kqp/opt/kqp_opt_kql.cpp
+++ b/ydb/core/kqp/opt/kqp_opt_kql.cpp
@@ -574,7 +574,7 @@ TExprBase BuildDeleteTableWithIndex(const TKiDeleteTable& del, const TKikimrTabl
 {
     auto rowsToDelete = BuildRowsToDelete(tableData, withSystemColumns, del.Filter(), del.IsBatch(), del.Pos(), ctx);
 
-    auto indexes = BuildSecondaryIndexVector(tableData, del.Pos(), ctx, nullptr,
+    auto indexes = BuildSecondaryIndexVector(tableData, del.Pos(), ctx, nullptr, false,
         [] (const TKikimrTableMetadata& meta, TPositionHandle pos, TExprContext& ctx) -> TExprBase {
             return BuildTableMeta(meta, pos, ctx);
         });

--- a/ydb/core/kqp/opt/kqp_opt_kql.cpp
+++ b/ydb/core/kqp/opt/kqp_opt_kql.cpp
@@ -709,7 +709,7 @@ TExprBase BuildUpdateTableWithIndex(const TKiUpdateTable& update, const TKikimrT
 
     // For unique or vector index rewrite UPDATE to UPDATE ON
     if (needsKqpEffect) {
-        auto effect = Build<TKqlUpdateRowsIndex>(ctx, update.Pos())
+        return Build<TKqlUpdateRowsIndex>(ctx, update.Pos())
             .Table(BuildTableMeta(tableData, update.Pos(), ctx))
             .Input<TKqpWriteConstraint>()
                 .Input(updatedRows)
@@ -721,9 +721,6 @@ TExprBase BuildUpdateTableWithIndex(const TKiUpdateTable& update, const TKikimrT
                 .Build()
             .Settings(IsConditionalUpdateSetting(ctx, update.Pos()))
             .Done();
-
-        effects.emplace_back(effect);
-        return Build<TExprList>(ctx, update.Pos()).Add(effects).Done();
     }
 
     const auto& pk = tableData.Metadata->KeyColumnNames;

--- a/ydb/core/kqp/opt/kqp_opt_kql.cpp
+++ b/ydb/core/kqp/opt/kqp_opt_kql.cpp
@@ -572,18 +572,19 @@ TExprBase BuildDeleteTable(const TKiDeleteTable& del, const TKikimrTableDescript
 TExprBase BuildDeleteTableWithIndex(const TKiDeleteTable& del, const TKikimrTableDescription& tableData,
     bool withSystemColumns, TExprContext& ctx)
 {
-    auto rowsToDelete = BuildRowsToDelete(tableData, withSystemColumns, del.Filter(), del.IsBatch(), del.Pos(), ctx);
-
-    auto indexes = BuildSecondaryIndexVector(tableData, del.Pos(), ctx, nullptr, false,
+    auto indexes = BuildSecondaryIndexVector(tableData, del.Pos(), ctx, nullptr, true,
         [] (const TKikimrTableMetadata& meta, TPositionHandle pos, TExprContext& ctx) -> TExprBase {
             return BuildTableMeta(meta, pos, ctx);
         });
     YQL_ENSURE(indexes);
 
+    auto rowsToDelete = BuildRowsToDelete(tableData, withSystemColumns, del.Filter(), del.IsBatch(), del.Pos(), ctx);
+
     const auto& pk = tableData.Metadata->KeyColumnNames;
 
+    auto tableMeta = BuildTableMeta(tableData, del.Pos(), ctx);
     auto tableDelete = Build<TKqlDeleteRows>(ctx, del.Pos())
-        .Table(BuildTableMeta(tableData, del.Pos(), ctx))
+        .Table(tableMeta)
         .Input(ProjectColumns(rowsToDelete, pk, ctx))
         .ReturningColumns<TCoAtomList>().Build()
         .IsBatch(del.IsBatch())
@@ -593,30 +594,96 @@ TExprBase BuildDeleteTableWithIndex(const TKiDeleteTable& del, const TKikimrTabl
     TVector<TExprBase> effects;
     effects.push_back(tableDelete);
 
-    for (const auto& [indexMeta, indexDesc] : indexes) {
-        THashSet<TStringBuf> indexTableColumns;
-
+    for (const auto& [tableNode, indexDesc] : indexes) {
+        TVector<TString> indexTableColumns;
         THashSet<TString> keyColumns;
         for (const auto& column : indexDesc->KeyColumns) {
             YQL_ENSURE(keyColumns.emplace(column).second);
-            indexTableColumns.emplace(column);
+            indexTableColumns.push_back(column);
         }
 
         for (const auto& column : pk) {
             if (keyColumns.insert(column).second) {
-                indexTableColumns.emplace(column);
+                indexTableColumns.push_back(column);
             }
         }
 
-        auto indexDelete = Build<TKqlDeleteRows>(ctx, del.Pos())
-            .Table(indexMeta)
-            .Input(ProjectColumns(rowsToDelete, indexTableColumns, ctx))
-            .ReturningColumns<TCoAtomList>().Build()
-            .IsBatch(del.IsBatch())
-            .Settings(IsConditionalDeleteSetting(ctx, del.Pos()))
-            .Done();
+        auto projectedInput = ProjectColumns(rowsToDelete, indexTableColumns, ctx);
 
-        effects.push_back(indexDelete);
+        if (indexDesc->Type == TIndexDescription::EType::GlobalSyncVectorKMeansTree) {
+            // Generate input type for vector resolve
+            TVector<const TItemExprType*> rowItems;
+            for (const auto& column : indexTableColumns) {
+                auto type = tableData.GetColumnType(column);
+                YQL_ENSURE(type, "No key column: " << column);
+                auto itemType = ctx.MakeType<TItemExprType>(column, type);
+                YQL_ENSURE(itemType->Validate(del.Pos(), ctx));
+                rowItems.push_back(itemType);
+            }
+            auto rowType = ctx.MakeType<TStructExprType>(rowItems);
+            YQL_ENSURE(rowType->Validate(del.Pos(), ctx));
+            const TTypeAnnotationNode* resolveInputType = ctx.MakeType<TListExprType>(rowType);
+
+            auto deleteIndexKeys = Build<TKqpCnVectorResolve>(ctx, del.Pos())
+                // NB: Output() is a bad name, it's actually TakeOutputFrom()
+                .Output()
+                    .Stage<TDqStage>()
+                        .Inputs()
+                            .Build()
+                        .Program()
+                            .Args({})
+                            .Body<TCoToStream>()
+                                .Input(projectedInput)
+                                .Build()
+                            .Build()
+                        .Settings().Build()
+                        .Build()
+                    .Index().Build(0)
+                    .Build()
+                .Table(tableMeta)
+                .InputType(ExpandType(del.Pos(), *resolveInputType, ctx))
+                .Index(ctx.NewAtom(del.Pos(), indexDesc->Name))
+                .Done();
+
+            auto deleteIndexStage = Build<TDqStage>(ctx, del.Pos())
+                .Inputs()
+                    .Add(deleteIndexKeys)
+                    .Build()
+                .Program()
+                    .Args({"rows"})
+                    .Body<TCoToStream>()
+                        .Input("rows")
+                        .Build()
+                    .Build()
+                .Settings().Build()
+                .Done();
+
+            auto deleteUnion = Build<TDqCnUnionAll>(ctx, del.Pos())
+                .Output()
+                    .Stage(deleteIndexStage)
+                    .Index().Build("0")
+                    .Build()
+                .Done();
+
+            auto indexDelete = Build<TKqlDeleteRows>(ctx, del.Pos())
+                .Table(tableNode)
+                .Input(deleteUnion)
+                .ReturningColumns<TCoAtomList>().Build()
+                .IsBatch(ctx.NewAtom(del.Pos(), "false"))
+                .Done();
+
+            effects.emplace_back(indexDelete);
+        } else {
+            auto indexDelete = Build<TKqlDeleteRows>(ctx, del.Pos())
+                .Table(tableNode)
+                .Input(projectedInput)
+                .ReturningColumns<TCoAtomList>().Build()
+                .IsBatch(del.IsBatch())
+                .Settings(IsConditionalDeleteSetting(ctx, del.Pos()))
+                .Done();
+
+            effects.push_back(indexDelete);
+        }
     }
 
     return Build<TExprList>(ctx, del.Pos()).Add(effects).Done();

--- a/ydb/core/kqp/opt/physical/effects/kqp_opt_phy_effects_impl.h
+++ b/ydb/core/kqp/opt/physical/effects/kqp_opt_phy_effects_impl.h
@@ -95,8 +95,12 @@ struct TDictAndKeysResult {
 TDictAndKeysResult PrecomputeDictAndKeys(const TCondenseInputResult& condenseResult, NYql::TPositionHandle pos,
     NYql::TExprContext& ctx);
 
-NYql::NNodes::TKqpCnStreamLookup BuildStreamLookupOverPrecompute(const NYql::TKikimrTableDescription & table,  NYql::NNodes::TDqPhyPrecompute& precompute,
+NYql::NNodes::TKqpCnStreamLookup BuildStreamLookupOverPrecompute(const NYql::TKikimrTableDescription & table, NYql::NNodes::TDqPhyPrecompute& precompute,
     NYql::NNodes::TExprBase input,
     const NYql::NNodes::TKqpTable& kqpTableNode, const NYql::TPositionHandle& pos, NYql::TExprContext& ctx, const TVector<TString>& extraColumnsToRead = {});
+
+NYql::NNodes::TKqpCnVectorResolve BuildVectorResolveOverPrecompute(const NYql::NNodes::TDqPhyPrecompute& rowsPrecompute,
+    const NYql::NNodes::TExprBase& originalInput, const NYql::NNodes::TKqpTable& kqpTableNode,
+    const TString& kqpIndexName, const NYql::TPositionHandle& pos, NYql::TExprContext& ctx);
 
 } // NKikimr::NKqp::NOpt

--- a/ydb/core/kqp/opt/physical/effects/kqp_opt_phy_effects_impl.h
+++ b/ydb/core/kqp/opt/physical/effects/kqp_opt_phy_effects_impl.h
@@ -103,4 +103,11 @@ NYql::NNodes::TKqpCnVectorResolve BuildVectorResolveOverPrecompute(const NYql::N
     const NYql::NNodes::TExprBase& originalInput, const NYql::NNodes::TKqpTable& kqpTableNode,
     const TString& kqpIndexName, const NYql::TPositionHandle& pos, NYql::TExprContext& ctx);
 
+NYql::NNodes::TExprBase BuildVectorIndexPostingRows(const NYql::TKikimrTableDescription& table,
+    const NYql::NNodes::TKqpTable& tableNode,
+    const TString& indexName,
+    const TVector<TStringBuf>& indexTableColumns,
+    const NYql::NNodes::TExprBase& deleteIndexKeys,
+    NYql::TPositionHandle pos, NYql::TExprContext& ctx);
+
 } // NKikimr::NKqp::NOpt

--- a/ydb/core/kqp/opt/physical/effects/kqp_opt_phy_effects_impl.h
+++ b/ydb/core/kqp/opt/physical/effects/kqp_opt_phy_effects_impl.h
@@ -99,15 +99,14 @@ NYql::NNodes::TKqpCnStreamLookup BuildStreamLookupOverPrecompute(const NYql::TKi
     NYql::NNodes::TExprBase input,
     const NYql::NNodes::TKqpTable& kqpTableNode, const NYql::TPositionHandle& pos, NYql::TExprContext& ctx, const TVector<TString>& extraColumnsToRead = {});
 
-NYql::NNodes::TKqpCnVectorResolve BuildVectorResolveOverPrecompute(const NYql::NNodes::TDqPhyPrecompute& rowsPrecompute,
-    const NYql::NNodes::TExprBase& originalInput, const NYql::NNodes::TKqpTable& kqpTableNode,
-    const TString& kqpIndexName, const NYql::TPositionHandle& pos, NYql::TExprContext& ctx);
-
 NYql::NNodes::TExprBase BuildVectorIndexPostingRows(const NYql::TKikimrTableDescription& table,
     const NYql::NNodes::TKqpTable& tableNode,
     const TString& indexName,
     const TVector<TStringBuf>& indexTableColumns,
     const NYql::NNodes::TExprBase& deleteIndexKeys,
     NYql::TPositionHandle pos, NYql::TExprContext& ctx);
+
+TVector<TStringBuf> BuildVectorIndexPostingColumns(const NYql::TKikimrTableDescription& table,
+    const NYql::TIndexDescription* indexDesc);
 
 } // NKikimr::NKqp::NOpt

--- a/ydb/core/kqp/opt/physical/effects/kqp_opt_phy_indexes.cpp
+++ b/ydb/core/kqp/opt/physical/effects/kqp_opt_phy_indexes.cpp
@@ -1,3 +1,4 @@
+#include <ydb/core/base/table_vector_index.h>
 #include "kqp_opt_phy_effects_impl.h"
 
 namespace NKikimr::NKqp::NOpt {
@@ -111,9 +112,17 @@ TVector<std::pair<TExprNode::TPtr, const TIndexDescription*>> BuildSecondaryInde
 
         if (index.KeyColumns && addIndex) {
             auto& implTable = table.Metadata->ImplTables[i];
-            YQL_ENSURE(!implTable->Next);
-            auto indexTable = tableBuilder(*implTable, pos, ctx).Ptr();
-            secondaryIndexes.emplace_back(indexTable, &index);
+            if (index.Type == TIndexDescription::EType::GlobalSyncVectorKMeansTree) {
+                YQL_ENSURE(implTable->Next && !implTable->Next->Next);
+                auto postingTable = implTable->Next;
+                YQL_ENSURE(postingTable->Name.EndsWith(NTableIndex::NTableVectorKmeansTreeIndex::PostingTable));
+                auto indexTable = tableBuilder(*postingTable, pos, ctx).Ptr();
+                secondaryIndexes.emplace_back(indexTable, &index);
+            } else {
+                YQL_ENSURE(!implTable->Next);
+                auto indexTable = tableBuilder(*implTable, pos, ctx).Ptr();
+                secondaryIndexes.emplace_back(indexTable, &index);
+            }
         }
     }
     return secondaryIndexes;

--- a/ydb/core/kqp/opt/physical/effects/kqp_opt_phy_insert_index.cpp
+++ b/ydb/core/kqp/opt/physical/effects/kqp_opt_phy_insert_index.cpp
@@ -88,8 +88,10 @@ TExprBase MakeInsertIndexRows(const NYql::NNodes::TExprBase& inputRows, const TK
         .Done();
 }
 
-TKqpCnVectorResolve BuildVectorResolveOverPrecompute(NYql::NNodes::TDqPhyPrecompute& rowsPrecompute,
-    NYql::NNodes::TExprBase originalInput, const TKqpTable& kqpTableNode,
+} // namespace
+
+TKqpCnVectorResolve BuildVectorResolveOverPrecompute(const NYql::NNodes::TDqPhyPrecompute& rowsPrecompute,
+    const NYql::NNodes::TExprBase& originalInput, const TKqpTable& kqpTableNode,
     const TString& kqpIndexName, const TPositionHandle& pos, TExprContext& ctx)
 {
     const TTypeAnnotationNode* originalAnnotation = originalInput.Ptr()->GetTypeAnn();
@@ -130,8 +132,6 @@ TKqpCnVectorResolve BuildVectorResolveOverPrecompute(NYql::NNodes::TDqPhyPrecomp
         .Index(ctx.NewAtom(pos, kqpIndexName))
         .Done();
 }
-
-} // namespace
 
 TExprBase KqpBuildInsertIndexStages(TExprBase node, TExprContext& ctx, const TKqpOptimizeContext& kqpCtx) {
     if (!node.Maybe<TKqlInsertRowsIndex>()) {

--- a/ydb/core/kqp/provider/yql_kikimr_gateway.h
+++ b/ydb/core/kqp/provider/yql_kikimr_gateway.h
@@ -205,7 +205,8 @@ struct TIndexDescription {
             case EType::GlobalAsync:
                 return false;
             case EType::GlobalSyncVectorKMeansTree:
-                return false;
+                // FIXME: Support updating prefixed vector indexes
+                return KeyColumns.size() == 1;
         }
     }
 

--- a/ydb/core/kqp/provider/yql_kikimr_opt_build.cpp
+++ b/ydb/core/kqp/provider/yql_kikimr_opt_build.cpp
@@ -1,6 +1,7 @@
 #include "yql_kikimr_provider_impl.h"
 #include "yql_kikimr_gateway.h"
 
+#include <ydb/core/base/table_vector_index.h>
 #include <ydb/core/kqp/common/kqp_yql.h>
 #include <ydb/core/kqp/gateway/utils/scheme_helpers.h>
 #include <yql/essentials/core/yql_opt_utils.h>
@@ -185,11 +186,18 @@ struct TKiExploreTxResults {
                 continue;
             }
 
-            const auto indexTables = NKikimr::NKqp::NSchemeHelpers::CreateIndexTablePath(name, index);
-            //YQL_ENSURE(indexTables.size() == 1, "Only index with one impl table is supported");
-            const auto indexTable = indexTables[0];
-
             ops[name] |= TPrimitiveYdbOperation::Read;
+
+            const auto indexTables = NKikimr::NKqp::NSchemeHelpers::CreateIndexTablePath(name, index);
+            TString indexTable;
+            if (index.Type == TIndexDescription::EType::GlobalSyncVectorKMeansTree) {
+                YQL_ENSURE(index.KeyColumns.size() == 1, "Prefixed vector index is not supported");
+                indexTable = indexTables[1];
+                YQL_ENSURE(indexTable.EndsWith(NKikimr::NTableIndex::NTableVectorKmeansTreeIndex::PostingTable));
+            } else {
+                YQL_ENSURE(indexTables.size() == 1, "Only index with one impl table is supported");
+                indexTable = indexTables[0];
+            }
             ops[indexTable] = TPrimitiveYdbOperation::Write;
         }
 
@@ -208,8 +216,15 @@ struct TKiExploreTxResults {
             }
 
             const auto indexTables = NKikimr::NKqp::NSchemeHelpers::CreateIndexTablePath(name, index);
-            YQL_ENSURE(indexTables.size() == 1, "Only index with one impl table is supported");
-            const auto indexTable = indexTables[0];
+            TString indexTable;
+            if (index.Type == TIndexDescription::EType::GlobalSyncVectorKMeansTree) {
+                YQL_ENSURE(index.KeyColumns.size() == 1, "Prefixed vector index is not supported");
+                indexTable = indexTables[1];
+                YQL_ENSURE(indexTable.EndsWith(NKikimr::NTableIndex::NTableVectorKmeansTreeIndex::PostingTable));
+            } else {
+                YQL_ENSURE(indexTables.size() == 1, "Only index with one impl table is supported");
+                indexTable = indexTables[0];
+            }
 
             for (const auto& column : index.KeyColumns) {
                 if (updateColumns.contains(column)) {

--- a/ydb/core/kqp/provider/yql_kikimr_opt_build.cpp
+++ b/ydb/core/kqp/provider/yql_kikimr_opt_build.cpp
@@ -186,7 +186,7 @@ struct TKiExploreTxResults {
             }
 
             const auto indexTables = NKikimr::NKqp::NSchemeHelpers::CreateIndexTablePath(name, index);
-            YQL_ENSURE(indexTables.size() == 1, "Only index with one impl table is supported");
+            //YQL_ENSURE(indexTables.size() == 1, "Only index with one impl table is supported");
             const auto indexTable = indexTables[0];
 
             ops[name] |= TPrimitiveYdbOperation::Read;

--- a/ydb/core/kqp/provider/yql_kikimr_provider.cpp
+++ b/ydb/core/kqp/provider/yql_kikimr_provider.cpp
@@ -2,6 +2,7 @@
 
 #include <yql/essentials/providers/common/proto/gateways_config.pb.h>
 #include <ydb/core/base/path.h>
+#include <ydb/core/base/table_vector_index.h>
 #include <ydb/core/scheme/scheme_tabledefs.h>
 
 #include <yql/essentials/parser/pg_wrapper/interface/type_desc.h>
@@ -225,20 +226,20 @@ TKikimrTableDescription& TKikimrTablesData::GetTable(const TString& cluster, con
 bool TKikimrTablesData::IsTableImmutable(const TStringBuf& cluster, const TStringBuf& path) {
     auto mainTableImpl = GetMainTableIfTableIsImplTableOfIndex(cluster, path);
     if (mainTableImpl) {
-
-        for(const auto& index: mainTableImpl->Metadata->Indexes) {
+        for (const auto& index: mainTableImpl->Metadata->Indexes) {
             if (index.Type != TIndexDescription::EType::GlobalSyncVectorKMeansTree) {
                 continue;
             }
-
-            for(const auto& implTable: index.GetImplTables()) {
-                TString implTablePath = TStringBuilder() << mainTableImpl->Metadata->Name << "/" << index.Name << "/" << implTable;
-                if (path == implTablePath)
-                    return true;
+            if (index.KeyColumns.size() > 1) {
+                // prefixed index update is not supported yet
+                return true;
+            }
+            auto levelTablePath = TStringBuilder() << mainTableImpl->Metadata->Name << "/" << index.Name << "/" << NKikimr::NTableIndex::NTableVectorKmeansTreeIndex::LevelTable;
+            if (path == levelTablePath) {
+                return true;
             }
         }
     }
-
     return false;
 }
 

--- a/ydb/core/kqp/provider/yql_kikimr_provider.cpp
+++ b/ydb/core/kqp/provider/yql_kikimr_provider.cpp
@@ -906,17 +906,16 @@ void TableDescriptionToTableInfoImpl(const TKikimrTableDescription& desc, TYdbOp
                 continue;
             }
 
-            const auto& implTable = *desc.Metadata->ImplTables[idxNo];
-            YQL_ENSURE(!implTable.Next);
+            for (auto implTable = desc.Metadata->ImplTables[idxNo]; implTable; implTable = implTable->Next) {
+                auto info = NKqpProto::TKqpTableInfo();
+                info.SetTableName(implTable->Name);
+                info.MutableTableId()->SetOwnerId(implTable->PathId.OwnerId());
+                info.MutableTableId()->SetTableId(implTable->PathId.TableId());
+                info.SetSchemaVersion(implTable->SchemaVersion);
 
-            auto info = NKqpProto::TKqpTableInfo();
-            info.SetTableName(implTable.Name);
-            info.MutableTableId()->SetOwnerId(implTable.PathId.OwnerId());
-            info.MutableTableId()->SetTableId(implTable.PathId.TableId());
-            info.SetSchemaVersion(implTable.SchemaVersion);
-
-            back_inserter = std::move(info);
-            ++back_inserter;
+                back_inserter = std::move(info);
+                ++back_inserter;
+            }
         }
     }
 }

--- a/ydb/core/kqp/query_compiler/kqp_query_compiler.cpp
+++ b/ydb/core/kqp/query_compiler/kqp_query_compiler.cpp
@@ -10,6 +10,7 @@
 #include <ydb/core/kqp/query_data/kqp_request_predictor.h>
 #include <ydb/core/ydb_convert/ydb_convert.h>
 
+#include <ydb/core/base/table_vector_index.h>
 #include <ydb/core/scheme/scheme_tabledefs.h>
 #include <ydb/library/mkql_proto/mkql_proto.h>
 
@@ -1691,6 +1692,100 @@ private:
                 }
                 default:
                     YQL_ENSURE(false, "Unexpected lookup strategy for stream lookup: " << settings.Strategy);
+            }
+
+
+            return;
+        }
+
+        if (auto maybeVectorResolve = connection.Maybe<TKqpCnVectorResolve>()) {
+            TProgramBuilder pgmBuilder(TypeEnv, FuncRegistry);
+            auto& vectorResolveProto = *connectionProto.MutableVectorResolve();
+            auto vectorResolve = maybeVectorResolve.Cast();
+
+            auto tableMeta = TablesData->ExistingTable(Cluster, vectorResolve.Table().Path()).Metadata;
+            YQL_ENSURE(tableMeta);
+
+            TIndexDescription *indexDesc = nullptr;
+            for (auto& index: tableMeta->Indexes) {
+                if (index.Name == vectorResolve.Index().Value()) {
+                    indexDesc = &index;
+                }
+            }
+            YQL_ENSURE(indexDesc);
+
+            // Index settings
+            auto& kmeansDesc = std::get<NKikimrKqp::TVectorIndexKmeansTreeDescription>(indexDesc->SpecializedIndexDescription);
+            *vectorResolveProto.MutableIndexSettings() = kmeansDesc.GetSettings().Getsettings();
+
+            // Main table
+            FillTablesMap(vectorResolve.Table(), tablesMap);
+            FillTableId(vectorResolve.Table(), *vectorResolveProto.MutableTable());
+
+            // Index level table
+            TString levelTablePath = TStringBuilder()
+                << vectorResolve.Table().Path().Value()
+                << "/" << vectorResolve.Index().Value()
+                << "/" << NTableIndex::NTableVectorKmeansTreeIndex::LevelTable;
+            auto levelTableMeta = TablesData->ExistingTable(Cluster, levelTablePath).Metadata;
+            YQL_ENSURE(levelTableMeta);
+
+            tablesMap.emplace(levelTablePath, THashSet<TStringBuf>{});
+            tablesMap[levelTablePath].emplace(NTableIndex::NTableVectorKmeansTreeIndex::ParentColumn);
+            tablesMap[levelTablePath].emplace(NTableIndex::NTableVectorKmeansTreeIndex::IdColumn);
+            tablesMap[levelTablePath].emplace(NTableIndex::NTableVectorKmeansTreeIndex::CentroidColumn);
+
+            vectorResolveProto.MutableLevelTable()->SetPath(levelTablePath);
+            vectorResolveProto.MutableLevelTable()->SetOwnerId(levelTableMeta->PathId.OwnerId());
+            vectorResolveProto.MutableLevelTable()->SetTableId(levelTableMeta->PathId.TableId());
+            vectorResolveProto.MutableLevelTable()->SetVersion(levelTableMeta->SchemaVersion);
+
+            // Input and output types
+
+            const auto inputType = vectorResolve.InputType().Ref().GetTypeAnn()->Cast<TTypeExprType>()->GetType();
+            YQL_ENSURE(inputType, "Empty vector resolve input type");
+            YQL_ENSURE(inputType->GetKind() == ETypeAnnotationKind::List, "Unexpected vector resolve input type");
+            const auto inputItemType = inputType->Cast<TListExprType>()->GetItemType();
+            vectorResolveProto.SetInputType(NMiniKQL::SerializeNode(CompileType(pgmBuilder, *inputItemType), TypeEnv));
+
+            const auto outputType = vectorResolve.Ref().GetTypeAnn();
+            YQL_ENSURE(outputType, "Empty vector resolve output type");
+            YQL_ENSURE(outputType->GetKind() == ETypeAnnotationKind::Stream, "Unexpected vector resolve output type");
+            const auto outputItemType = outputType->Cast<TStreamExprType>()->GetItemType();
+            vectorResolveProto.SetOutputType(NMiniKQL::SerializeNode(CompileType(pgmBuilder, *outputItemType), TypeEnv));
+
+            // Input columns. Input is strictly mapped to main table's columns to ease passing their types through PhyCnVectorResolve
+
+            TMap<TString, ui32> columnIndexes;
+            YQL_ENSURE(inputItemType->GetKind() == ETypeAnnotationKind::Struct);
+            const auto& inputColumns = inputItemType->Cast<TStructExprType>()->GetItems();
+            ui32 n = 0;
+            for (const auto inputColumn : inputColumns) {
+                auto name = TString(inputColumn->GetName());
+                YQL_ENSURE(tableMeta->Columns.FindPtr(name), "Unknown column: " << name);
+                vectorResolveProto.AddColumns(name);
+                tablesMap[vectorResolve.Table().Path()].emplace(name);
+                columnIndexes[name] = n++;
+            }
+
+            // Copy columns & vector column index
+
+            auto vectorColumn = indexDesc->KeyColumns.back();
+            YQL_ENSURE(columnIndexes.contains(vectorColumn));
+            vectorResolveProto.SetVectorColumnIndex(columnIndexes.at(vectorColumn));
+
+            TSet<TString> copyColumns;
+            for (const auto& keyColumn : tableMeta->KeyColumnNames) {
+                YQL_ENSURE(columnIndexes.contains(keyColumn));
+                vectorResolveProto.AddCopyColumnIndexes(columnIndexes.at(keyColumn));
+                copyColumns.insert(keyColumn);
+            }
+            for (const auto& dataColumn : indexDesc->DataColumns) {
+                if (!copyColumns.contains(dataColumn)) {
+                    YQL_ENSURE(columnIndexes.contains(dataColumn));
+                    vectorResolveProto.AddCopyColumnIndexes(columnIndexes.at(dataColumn));
+                    copyColumns.insert(dataColumn);
+                }
             }
 
             return;

--- a/ydb/core/kqp/runtime/kqp_read_actor.h
+++ b/ydb/core/kqp/runtime/kqp_read_actor.h
@@ -4,14 +4,29 @@
 
 #include <ydb/library/yql/dq/actors/compute/dq_compute_actor_async_io_factory.h>
 
+#include <util/generic/ptr.h>
+
 namespace NKikimrTxDataShard {
 class TEvRead;
 class TEvReadAck;
+class TKqpReadRangesSourceSettings;
 }
 
 namespace NKikimr {
 namespace NKqp {
 
+std::pair<NYql::NDq::IDqComputeActorAsyncInput*, IActor*> CreateKqpReadActor(const NKikimrTxDataShard::TKqpReadRangesSourceSettings* settings,
+    TIntrusivePtr<NActors::TProtoArenaHolder> arena, // Arena for settings
+    const NActors::TActorId& computeActorId,
+    ui64 inputIndex,
+    NYql::NDq::TCollectStatsLevel statsLevel,
+    NYql::NDq::TTxId txId,
+    ui64 taskId,
+    const NKikimr::NMiniKQL::TTypeEnvironment& typeEnv,
+    const NKikimr::NMiniKQL::THolderFactory& holderFactory,
+    std::shared_ptr<NKikimr::NMiniKQL::TScopedAlloc> alloc,
+    const NWilson::TTraceId& traceId,
+    TIntrusivePtr<TKqpCounters> counters);
 void RegisterKqpReadActor(NYql::NDq::TDqAsyncIoFactory&, TIntrusivePtr<TKqpCounters>);
 void InterceptReadActorPipeCache(NActors::TActorId);
 

--- a/ydb/core/kqp/runtime/kqp_vector_actor.cpp
+++ b/ydb/core/kqp/runtime/kqp_vector_actor.cpp
@@ -1,0 +1,557 @@
+#include "kqp_vector_actor.h"
+#include "kqp_read_actor.h"
+
+#include <ydb/core/kqp/runtime/kqp_scan_data.h>
+#include <ydb/core/base/kmeans_clusters.h>
+#include <ydb/core/base/table_index.h>
+#include <ydb/core/base/table_vector_index.h>
+#include <ydb/core/engine/minikql/minikql_engine_host.h>
+
+#include <ydb/core/kqp/gateway/kqp_gateway.h>
+#include <ydb/core/kqp/common/kqp_yql.h>
+
+#include <ydb/library/yql/dq/actors/compute/dq_compute_actor_impl.h>
+
+#include <util/string/vector.h>
+
+namespace NKikimr {
+namespace NKqp {
+
+using namespace NYql;
+using namespace NYql::NDq;
+using namespace NKikimr;
+using namespace NKikimr::NDataShard;
+
+class TKqpVectorResolveActor : public NActors::TActorBootstrapped<TKqpVectorResolveActor>, public NYql::NDq::IDqComputeActorAsyncInput {
+
+public:
+    TKqpVectorResolveActor(
+        NKikimrTxDataShard::TKqpVectorResolveSettings&& settings,
+        ui64 inputIndex,
+        const NUdf::TUnboxedValue& input,
+        NYql::NDq::TCollectStatsLevel statsLevel,
+        NYql::NDq::TTxId txId,
+        ui64 taskId,
+        const NActors::TActorId& computeActorId,
+        const NMiniKQL::TTypeEnvironment& typeEnv,
+        const NMiniKQL::THolderFactory& holderFactory,
+        std::shared_ptr<NMiniKQL::TScopedAlloc>& alloc,
+        const NWilson::TTraceId& traceId,
+        TIntrusivePtr<TKqpCounters> counters)
+        : Settings(std::move(settings))
+        , LogPrefix(TStringBuilder() << "VectorResolveActor, inputIndex: " << inputIndex << ", CA Id " << computeActorId)
+        , InputIndex(inputIndex)
+        , Input(input)
+        , TxId(txId)
+        , TaskId(taskId)
+        , ComputeActorId(computeActorId)
+        , TypeEnv(typeEnv)
+        , HolderFactory(holderFactory)
+        , Alloc(alloc)
+        , Counters(counters)
+        , TraceId(traceId)
+        , MySpan(TWilsonKqp::VectorResolveActor, NWilson::TTraceId(traceId), "VectorResolveActor")
+    {
+        IngressStats.Level = statsLevel;
+
+        Snapshot = IKqpGateway::TKqpSnapshot(Settings.GetSnapshot().GetStep(), Settings.GetSnapshot().GetTxId());
+
+        InitResultColumns();
+    }
+
+    virtual ~TKqpVectorResolveActor() {
+        if (Input.HasValue() && Alloc) {
+            TGuard<NMiniKQL::TScopedAlloc> allocGuard(*Alloc);
+            Input.Clear();
+
+            NKikimr::NMiniKQL::TUnboxedValueDeque emptyList;
+            emptyList.swap(PendingRows);
+        }
+    }
+
+    void Bootstrap() {
+        //Counters->VectorResolveActorsCount->Inc();
+
+        CA_LOG_D("Start vector resolve actor");
+        Become(&TKqpVectorResolveActor::StateFunc);
+    }
+
+private:
+    void SaveState(const NYql::NDqProto::TCheckpoint&, NYql::NDq::TSourceState&) override {}
+    void LoadState(const NYql::NDq::TSourceState&) override {}
+    void CommitState(const NYql::NDqProto::TCheckpoint&) override {}
+
+    STFUNC(StateFunc) {
+        try {
+            switch (ev->GetTypeRewrite()) {
+                hFunc(TEvNewAsyncInputDataArrived, HandleRead);
+                hFunc(IDqComputeActorAsyncInput::TEvAsyncInputError, OnAsyncInputError);
+            }
+        } catch (const yexception& e) {
+            RuntimeError(e.what(), NYql::NDqProto::StatusIds::INTERNAL_ERROR);
+        }
+    }
+
+    ui64 GetInputIndex() const override {
+        return InputIndex;
+    }
+
+    const NYql::NDq::TDqAsyncStats& GetIngressStats() const override {
+        return IngressStats;
+    }
+
+    void PassAway() final {
+        //Counters->VectorResolveActorsCount->Dec();
+
+        if (ReadActorId) {
+            Send(ReadActorId, new TEvents::TEvPoison);
+            ReadActorId = {};
+        }
+
+        {
+            auto guard = BindAllocator();
+            Input.Clear();
+            NKikimr::NMiniKQL::TUnboxedValueDeque emptyList;
+            emptyList.swap(PendingRows);
+        }
+
+        MySpan.End();
+
+        TActorBootstrapped<TKqpVectorResolveActor>::PassAway();
+    }
+
+    i64 GetAsyncInputData(NKikimr::NMiniKQL::TUnboxedValueBatch& batch, TMaybe<TInstant>&, bool& finished, i64 freeSpace) final {
+        YQL_ENSURE(!batch.IsWide(), "Wide stream is not supported");
+
+        i64 totalDataSize = LevelsFinished ? ReplyResult(batch, freeSpace) : 0;
+        finished = false;
+        if (!PendingRows.size()) {
+            auto status = FetchRows();
+            if (PendingRows.size()) {
+                LevelsFinished = false;
+                ResolvedLevel = 0;
+                PrevClusters.clear();
+                ContinueResolveClusters();
+                Send(ComputeActorId, new TEvNewAsyncInputDataArrived(InputIndex));
+            } else {
+                finished = (status == NUdf::EFetchStatus::Finish);
+            }
+        }
+
+        CA_LOG_D("Returned " << totalDataSize << " bytes, finished: " << finished);
+        return totalDataSize;
+    }
+
+    TMaybe<google::protobuf::Any> ExtraData() override {
+        google::protobuf::Any result;
+        NKikimrTxDataShard::TEvKqpInputActorResultInfo resultInfo;
+        for (auto& lock : Locks) {
+            resultInfo.AddLocks()->CopyFrom(lock);
+        }
+        result.PackFrom(resultInfo);
+        return result;
+    }
+
+    NUdf::EFetchStatus FetchRows() {
+        auto guard = BindAllocator();
+
+        NUdf::EFetchStatus status;
+        NUdf::TUnboxedValue currentValue;
+
+        while ((status = Input.Fetch(currentValue)) == NUdf::EFetchStatus::Ok) {
+            PendingRows.push_back(std::move(currentValue));
+        }
+
+        return status;
+    }
+
+    void ContinueResolveClusters() {
+        if (Failed) {
+            return;
+        }
+        if (!Settings.HasIndexSettings()) {
+            RuntimeError("Index settings are required", NYql::NDqProto::StatusIds::INTERNAL_ERROR);
+            return;
+        }
+        while (!LevelsFinished) {
+            if (!LevelClusters.size()) {
+                LevelClusters.clear();
+                if (!ResolvedLevel) {
+                    LevelClusters.insert(0);
+                } else {
+                    for (auto cluster: PrevClusters) {
+                        if (!(cluster & NKikimr::NTableIndex::PostingParentFlag)) {
+                            LevelClusters.insert(cluster);
+                        }
+                    }
+                }
+                if (!LevelClusters.size()) {
+                    // All clusters are invalid (0) or already leaf (PostingParentFlag is set)
+                    LevelsFinished = true;
+                    break;
+                }
+                NextClusters.clear();
+                NextClusters.resize(PendingRows.size());
+                CurClusters.reset();
+            }
+            while (LevelClusters.size() > 0) {
+                auto cluster = *LevelClusters.begin();
+                if (ResolvedLevel > 0 ? !CurClusters : !RootClusters) {
+                    ReadChildClusters(cluster);
+                    return;
+                }
+                auto & clusters = (ResolvedLevel > 0 ? CurClusters : RootClusters);
+                auto & clusterIds = (ResolvedLevel > 0 ? CurClusterIds : RootClusterIds);
+                for (size_t i = 0; i < PendingRows.size(); i++) {
+                    if (ResolvedLevel > 0 && PrevClusters[i] != cluster) {
+                        continue;
+                    }
+                    auto embedding = PendingRows[i].GetElement(Settings.GetVectorColumnIndex());
+                    auto cluster = clusters->FindCluster(embedding.AsStringRef());
+                    if (!cluster.has_value()) {
+                        // embedding is invalid
+                        NextClusters[i] = 0;
+                    } else {
+                        NextClusters[i] = clusterIds[*cluster];
+                    }
+                }
+                CurClusters.reset();
+                LevelClusters.erase(cluster);
+            }
+            PrevClusters = std::move(NextClusters);
+            ResolvedLevel++;
+        }
+        if (!Failed) {
+            NotifyCA();
+        }
+    }
+
+    TGuard<NKikimr::NMiniKQL::TScopedAlloc> BindAllocator() {
+        return TypeEnv.BindAllocator();
+    }
+
+    static TTableRange RawParentRange(NTableIndex::TClusterId parent) {
+        auto from = parent > 0 ? TCell::Make(parent - 1) : TCell(); // null is -infinity
+        auto to = TCell::Make(parent); // missing key suffix is +infinity
+        return TTableRange({&from, 1}, false, {&to, 1}, true);
+    }
+
+    static TSerializedTableRange ParentRange(NTableIndex::TClusterId parent) {
+        auto from = parent > 0 ? TCell::Make(parent - 1) : TCell(); // null is -infinity
+        auto to = TCell::Make(parent); // missing key suffix is +infinity
+        return TSerializedTableRange({&from, 1}, false, {&to, 1}, true);
+    }
+
+    void ReadChildClusters(NTableIndex::TClusterId parent) {
+        if (ReadingChildClusters) {
+            return;
+        }
+        ReadingChildClusters = true;
+        ReadingChildClustersOf = parent;
+        ReadUsingActor(parent);
+    }
+
+    void ReadUsingActor(NTableIndex::TClusterId parent) {
+        auto range = ParentRange(parent);
+        auto arena = MakeIntrusive<NActors::TProtoArenaHolder>();
+        auto src = arena->Allocate<NKikimrTxDataShard::TKqpReadRangesSourceSettings>();
+        *src->MutableTable() = Settings.GetLevelTable();
+        range.Serialize(*src->MutableFullRange());
+        src->SetDataFormat(NKikimrDataEvents::FORMAT_CELLVEC);
+        if (Snapshot.IsValid()) {
+            src->MutableSnapshot()->SetTxId(Snapshot.TxId);
+            src->MutableSnapshot()->SetStep(Snapshot.Step);
+        }
+        if (Settings.HasLockTxId()) {
+            src->SetLockTxId(Settings.GetLockTxId());
+            if (Settings.HasLockMode()) {
+                src->SetLockMode(Settings.GetLockMode());
+            }
+        }
+        if (Settings.HasLockNodeId()) {
+            src->SetLockNodeId(Settings.GetLockNodeId());
+        }
+
+        // Level table key is parent+id
+        auto ui64Type = NScheme::ProtoColumnTypeFromTypeInfoMod(NScheme::TTypeInfo(NScheme::NTypeIds::Uint64), "");
+        src->AddKeyColumnTypes(ui64Type.TypeId);
+        src->AddKeyColumnTypes(ui64Type.TypeId);
+        *src->AddKeyColumnTypeInfos() = NKikimrProto::TTypeInfo();
+        *src->AddKeyColumnTypeInfos() = NKikimrProto::TTypeInfo();
+
+        auto* meta = src->AddColumns();
+        meta->SetId(Settings.GetLevelTableParentColumnId());
+        meta->SetName(NTableIndex::NTableVectorKmeansTreeIndex::ParentColumn);
+        meta->SetType(ui64Type.TypeId);
+        *meta->MutableTypeInfo() = NKikimrProto::TTypeInfo();
+        meta->SetNotNull(true);
+
+        meta = src->AddColumns();
+        meta->SetId(Settings.GetLevelTableClusterColumnId());
+        meta->SetName(NTableIndex::NTableVectorKmeansTreeIndex::IdColumn);
+        meta->SetType(ui64Type.TypeId);
+        *meta->MutableTypeInfo() = NKikimrProto::TTypeInfo();
+        meta->SetNotNull(true);
+
+        auto stringType = NScheme::ProtoColumnTypeFromTypeInfoMod(NScheme::TTypeInfo(NScheme::NTypeIds::String), "");
+        meta = src->AddColumns();
+        meta->SetId(Settings.GetLevelTableCentroidColumnId());
+        meta->SetName(NTableIndex::NTableVectorKmeansTreeIndex::CentroidColumn);
+        meta->SetType(stringType.TypeId);
+        *meta->MutableTypeInfo() = NKikimrProto::TTypeInfo();
+        meta->SetNotNull(true);
+
+        auto [ readActorInput, readActor ] = CreateKqpReadActor(src, arena, this->SelfId(),
+            0, IngressStats.Level, TxId, TaskId, TypeEnv, HolderFactory, Alloc, TraceId, Counters);
+
+        ReadActorInput = readActorInput;
+        ReadActorId = RegisterWithSameMailbox(readActor);
+
+        HandleRead(nullptr);
+    }
+
+    void HandleRead(TEvNewAsyncInputDataArrived::TPtr) {
+        TMaybe<TInstant> watermark;
+        ui64 freeSpace = 32*1024*1024; // FIXME The value doesn't really matter, but where to take it from?
+        NKikimr::NMiniKQL::TUnboxedValueBatch rows;
+        bool finished = false;
+        {
+            auto guard = BindAllocator();
+            ReadActorInput->GetAsyncInputData(rows, watermark, finished, freeSpace);
+            rows.ForEachRow([&](NUdf::TUnboxedValue& value) {
+                NTableIndex::TClusterId parent = value.GetElement(0).Get<ui64>();
+                if (parent != ReadingChildClustersOf) {
+                    RuntimeError("Returned clusters for invalid parent", NYql::NDqProto::StatusIds::INTERNAL_ERROR);
+                    return;
+                }
+                NTableIndex::TClusterId child = value.GetElement(1).Get<ui64>();
+                auto centroid = value.GetElement(2);
+                FetchedClusters[child] = TString(centroid.AsStringRef());
+            });
+        }
+        if (finished) {
+            auto extra = ReadActorInput->ExtraData();
+            if (extra) {
+                NKikimrTxDataShard::TEvKqpInputActorResultInfo resultInfo;
+                YQL_ENSURE(extra->UnpackTo(&resultInfo));
+                for (size_t i = 0; i < resultInfo.LocksSize(); i++) {
+                    Locks.push_back(resultInfo.GetLocks(i));
+                }
+            }
+            Send(ReadActorId, new TEvents::TEvPoison);
+            ReadActorId = {};
+            ReadActorInput = nullptr;
+            ReadingChildClusters = false;
+            // Convert to NKikimr::NKMeans::TClusters
+            if (!Failed) {
+                ParseFetchedClusters();
+            }
+        }
+        {
+            auto guard = BindAllocator();
+            rows.clear();
+        }
+    }
+
+    void NotifyCA() {
+        Send(ComputeActorId, new TEvNewAsyncInputDataArrived(InputIndex));
+    }
+
+    void OnAsyncInputError(const IDqComputeActorAsyncInput::TEvAsyncInputError::TPtr& ev) {
+        RuntimeError("Error reading from level table", ev->Get()->FatalCode, ev->Get()->Issues);
+    }
+
+    void ParseFetchedClusters() {
+        TString error;
+        auto clusters = NKikimr::NKMeans::CreateClusters(Settings.GetIndexSettings(), 0, error);
+        if (!clusters) {
+            // Index settings are invalid for some reason
+            RuntimeError(error, NYql::NDqProto::StatusIds::INTERNAL_ERROR);
+            return;
+        }
+        TVector<ui64> clusterIds;
+        TVector<TString> clusterRows;
+        for (auto & pp: FetchedClusters) {
+            clusterIds.push_back(pp.first);
+            clusterRows.push_back(std::move(pp.second));
+        }
+        if (!clusters->SetClusters(std::move(clusterRows))) {
+            // Clusters are invalid for some reason
+            RuntimeError("Child clusters of "+std::to_string(ReadingChildClustersOf)+" are invalid", NYql::NDqProto::StatusIds::INTERNAL_ERROR);
+            return;
+        }
+        FetchedClusters.clear();
+        if (!ReadingChildClustersOf) {
+            // Cache root clusters in RootClusters for future batches
+            RootClusters = std::move(clusters);
+            RootClusterIds = std::move(clusterIds);
+        } else {
+            CurClusters = std::move(clusters);
+            CurClusterIds = std::move(clusterIds);
+        }
+        ContinueResolveClusters();
+    }
+
+    i64 ReplyResult(NKikimr::NMiniKQL::TUnboxedValueBatch& batch, i64 freeSpace) {
+        auto guard = BindAllocator();
+
+        i64 totalSize = 0;
+
+        while (PendingRows.size() > 0 && freeSpace > 0) {
+            i64 rowSize = 0;
+            NUdf::TUnboxedValue currentValue = std::move(PendingRows.back());
+            PendingRows.pop_back();
+
+            NUdf::TUnboxedValue* rowItems = nullptr;
+            // Output columns: Cluster ID + Source table PK [ + Data Columns ]
+            auto newValue = HolderFactory.CreateDirectArrayHolder(1 + Settings.CopyColumnIndexesSize(), rowItems);
+
+            *rowItems++ = NUdf::TUnboxedValuePod((ui64)PrevClusters[PendingRows.size()]);
+            rowSize += sizeof(NUdf::TUnboxedValuePod);
+
+            for (size_t i = 0; i < Settings.CopyColumnIndexesSize(); i++) {
+                auto colIdx = Settings.GetCopyColumnIndexes(i);
+                *rowItems++ = currentValue.GetElement(colIdx);
+                rowSize += NMiniKQL::GetUnboxedValueSize(currentValue.GetElement(colIdx), ColumnTypeInfos[colIdx]).AllocatedBytes;
+            }
+
+            totalSize += rowSize;
+            freeSpace -= rowSize;
+            SentBytes += rowSize;
+            SentRows++;
+
+            batch.emplace_back(std::move(newValue));
+        }
+
+        return totalSize;
+    }
+
+    void FillExtraStats(NDqProto::TDqTaskStats* stats, bool last, const NYql::NDq::TDqMeteringStats* mstats) override {
+        if (last) {
+            NDqProto::TDqTableStats* tableStats = nullptr;
+            for (size_t i = 0; i < stats->TablesSize(); ++i) {
+                auto* table = stats->MutableTables(i);
+                if (table->GetTablePath() == Settings.GetLevelTable().GetTablePath()) {
+                    tableStats = table;
+                }
+            }
+            if (!tableStats) {
+                tableStats = stats->AddTables();
+                tableStats->SetTablePath(Settings.GetLevelTable().GetTablePath());
+            }
+
+            auto consumedRows = mstats ? mstats->Inputs[InputIndex]->RowsConsumed : SentRows;
+
+            tableStats->SetReadRows(tableStats->GetReadRows() + consumedRows);
+            tableStats->SetReadBytes(tableStats->GetReadBytes() + (mstats ? mstats->Inputs[InputIndex]->BytesConsumed : SentBytes));
+            // No idea how many partitions were affected by all ReadActors (they may overlap)
+            //tableStats->SetAffectedPartitions(tableStats->GetAffectedPartitions() + AffectedShards);
+        }
+    }
+
+    void RuntimeError(const TString& message, NYql::NDqProto::StatusIds::StatusCode statusCode, const NYql::TIssues& subIssues = {}) {
+        Failed = true;
+
+        NYql::TIssue issue(message);
+        for (const auto& i : subIssues) {
+            issue.AddSubIssue(MakeIntrusive<NYql::TIssue>(i));
+        }
+
+        NYql::TIssues issues;
+        issues.AddIssue(std::move(issue));
+
+        if (MySpan) {
+            MySpan.EndError(issues.ToOneLineString());
+        }
+
+        Send(ComputeActorId, new TEvAsyncInputError(InputIndex, std::move(issues), statusCode));
+    }
+
+    void InitResultColumns() {
+        YQL_ENSURE(Settings.InputColumnTypesSize() > 0);
+        YQL_ENSURE(Settings.InputColumnTypesSize() == Settings.InputColumnTypeInfosSize());
+        ColumnTypeInfos.reserve(Settings.InputColumnTypesSize());
+        for (size_t i = 0; i < Settings.InputColumnTypesSize(); i++) {
+            ColumnTypeInfos.push_back(NScheme::TypeInfoFromProto(Settings.GetInputColumnTypes(i), Settings.GetInputColumnTypeInfos(i)));
+        }
+    }
+
+private:
+    // Parameters
+
+    const NKikimrTxDataShard::TKqpVectorResolveSettings Settings;
+    const TString LogPrefix;
+    const ui64 InputIndex;
+    NUdf::TUnboxedValue Input;
+    NYql::NDq::TDqAsyncStats IngressStats;
+    NYql::NDq::TTxId TxId;
+    ui64 TaskId;
+    const NActors::TActorId ComputeActorId;
+    const NMiniKQL::TTypeEnvironment& TypeEnv;
+    const NMiniKQL::THolderFactory& HolderFactory;
+    std::shared_ptr<NKikimr::NMiniKQL::TScopedAlloc> Alloc;
+    TIntrusivePtr<TKqpCounters> Counters;
+    NWilson::TTraceId TraceId;
+
+    IKqpGateway::TKqpSnapshot Snapshot;
+    TVector<NScheme::TTypeInfo> ColumnTypeInfos;
+
+    // State
+
+    NKikimr::NMiniKQL::TUnboxedValueDeque PendingRows;
+    bool ReadingChildClusters = false;
+    NTableIndex::TClusterId ReadingChildClustersOf = {};
+
+    NYql::NDq::IDqComputeActorAsyncInput* ReadActorInput = nullptr;
+    TActorId ReadActorId = {};
+    bool Failed = false;
+
+    TMap<NTableIndex::TClusterId, TString> FetchedClusters;
+    ui32 ResolvedLevel = 0;
+    bool LevelsFinished = false;
+    TVector<NTableIndex::TClusterId> PrevClusters;
+    TVector<NTableIndex::TClusterId> NextClusters;
+    TSet<NTableIndex::TClusterId> LevelClusters;
+    std::unique_ptr<NKikimr::NKMeans::IClusters> RootClusters;
+    TVector<NTableIndex::TClusterId> RootClusterIds;
+    std::unique_ptr<NKikimr::NKMeans::IClusters> CurClusters;
+    TVector<NTableIndex::TClusterId> CurClusterIds;
+
+    TVector<NKikimrDataEvents::TLock> Locks;
+
+    ui64 SentRows = 0;
+    ui64 SentBytes = 0;
+
+    NWilson::TSpan MySpan;
+};
+
+std::pair<NYql::NDq::IDqComputeActorAsyncInput*, IActor*> CreateKqpVectorResolveActor(
+    NKikimrTxDataShard::TKqpVectorResolveSettings&& settings,
+    ui64 inputIndex,
+    const NUdf::TUnboxedValue& input,
+    NYql::NDq::TCollectStatsLevel statsLevel,
+    NYql::NDq::TTxId txId,
+    ui64 taskId,
+    const NActors::TActorId& computeActorId,
+    const NMiniKQL::TTypeEnvironment& typeEnv,
+    const NMiniKQL::THolderFactory& holderFactory,
+    std::shared_ptr<NMiniKQL::TScopedAlloc>& alloc,
+    const NWilson::TTraceId& traceId,
+    TIntrusivePtr<TKqpCounters> counters) {
+    auto actor = new TKqpVectorResolveActor(std::move(settings), inputIndex, input, statsLevel, txId,
+        taskId, computeActorId, typeEnv, holderFactory, alloc, traceId, counters);
+    return {actor, actor};
+}
+
+void RegisterKqpVectorResolveActor(NYql::NDq::TDqAsyncIoFactory& factory, TIntrusivePtr<TKqpCounters> counters) {
+    factory.RegisterInputTransform<NKikimrTxDataShard::TKqpVectorResolveSettings>(
+        "VectorResolveInputTransformer", [counters](NKikimrTxDataShard::TKqpVectorResolveSettings&& settings,
+            NYql::NDq::TDqAsyncIoFactory::TInputTransformArguments&& args) -> std::pair<NYql::NDq::IDqComputeActorAsyncInput*, IActor*> {
+            return CreateKqpVectorResolveActor(std::move(settings),
+                args.InputIndex, args.TransformInput, args.StatsLevel, args.TxId, args.TaskId, args.ComputeActorId,
+                args.TypeEnv, args.HolderFactory, args.Alloc, args.TraceId, counters);
+        });
+}
+
+} // namespace NKqp
+} // namespace NKikimr

--- a/ydb/core/kqp/runtime/kqp_vector_actor.h
+++ b/ydb/core/kqp/runtime/kqp_vector_actor.h
@@ -1,0 +1,34 @@
+#pragma once
+
+#include <ydb/core/protos/tx_datashard.pb.h>
+
+#include <ydb/core/kqp/counters/kqp_counters.h>
+
+#include <ydb/library/yql/dq/actors/compute/dq_compute_actor_async_io_factory.h>
+
+namespace NKikimrTxDataShard {
+class TEvRead;
+class TEvReadAck;
+}
+
+namespace NKikimr {
+namespace NKqp {
+
+std::pair<NYql::NDq::IDqComputeActorAsyncInput*, IActor*> CreateKqpVectorResolveActor(
+    NKikimrTxDataShard::TKqpVectorResolveSettings&& settings,
+    ui64 inputIndex,
+    const NUdf::TUnboxedValue& input,
+    NYql::NDq::TCollectStatsLevel statsLevel,
+    NYql::NDq::TTxId txId,
+    ui64 taskId,
+    const NActors::TActorId& computeActorId,
+    const NMiniKQL::TTypeEnvironment& typeEnv,
+    const NMiniKQL::THolderFactory& holderFactory,
+    std::shared_ptr<NMiniKQL::TScopedAlloc>& alloc,
+    const NWilson::TTraceId& traceId,
+    TIntrusivePtr<TKqpCounters> counters);
+
+void RegisterKqpVectorResolveActor(NYql::NDq::TDqAsyncIoFactory&, TIntrusivePtr<TKqpCounters>);
+
+} // namespace NKqp
+} // namespace NKikimr

--- a/ydb/core/kqp/runtime/ya.make
+++ b/ydb/core/kqp/runtime/ya.make
@@ -22,6 +22,7 @@ SRCS(
     kqp_stream_lookup_worker.h
     kqp_tasks_runner.cpp
     kqp_transport.cpp
+    kqp_vector_actor.cpp
     kqp_write_actor_settings.cpp
     kqp_write_actor.cpp
     kqp_write_table.cpp

--- a/ydb/core/kqp/ut/indexes/kqp_indexes_ut.cpp
+++ b/ydb/core/kqp/ut/indexes/kqp_indexes_ut.cpp
@@ -5699,7 +5699,7 @@ R"([[#;#;["Primary1"];[41u]];[["Secondary2"];[2u];["Primary2"];[42u]];[["Seconda
         NKikimrConfig::TFeatureFlags featureFlags;
         featureFlags.SetEnableAccessToIndexImplTables(true);
         auto settings = TKikimrSettings().SetFeatureFlags(featureFlags);
-        TKikimrRunner kikimr(settings);        
+        TKikimrRunner kikimr(settings);
         auto db = kikimr.GetTableClient();
         kikimr.GetTestClient().GrantConnect("user@builtin");
         kikimr.GetTestServer().GetRuntime()->GetAppData().AdministrationAllowedSIDs.emplace_back("root@builtin");
@@ -5731,7 +5731,7 @@ R"([[#;#;["Primary1"];[41u]];[["Secondary2"];[2u];["Primary2"];[42u]];[["Seconda
                 UPSERT INTO `%s` (Key, Fk, Value) VALUES
                     (9,    9,    "Payload9");
             )", tablePath), TTxControl::BeginTx(TTxSettings::SerializableRW()).CommitTx()).ExtractValueSync();
-        };        
+        };
         auto upsertImplTableQuery = [&]() {
             return userSession.ExecuteDataQuery(Sprintf(R"(
                 UPSERT INTO `%s` (Fk, Key) VALUES
@@ -5914,7 +5914,7 @@ R"([[#;#;["Primary1"];[41u]];[["Secondary2"];[2u];["Primary2"];[42u]];[["Seconda
                 result.GetIssues().ToString()
             );
         }
-    }    
+    }
 }
 
 }

--- a/ydb/core/kqp/ut/indexes/kqp_indexes_vector_ut.cpp
+++ b/ydb/core/kqp/ut/indexes/kqp_indexes_vector_ut.cpp
@@ -412,7 +412,7 @@ Y_UNIT_TEST_SUITE(KqpVectorIndexes) {
         }
     }
 
-    Y_UNIT_TEST(VectorIndexIsNotUpdatable) {
+    Y_UNIT_TEST(VectorIndexIsUpdatable) {
         NKikimrConfig::TFeatureFlags featureFlags;
         featureFlags.SetEnableVectorIndex(true);
         auto setting = NKikimrKqp::TKqpSetting();
@@ -445,10 +445,10 @@ Y_UNIT_TEST_SUITE(KqpVectorIndexes) {
 
         // Insert to the table with index should succeed
         {
-            //, (11, "\x77\x75\x03", "11")
             const TString query1(Q_(R"(
                 INSERT INTO `/Root/TestTable` (pk, emb, data) VALUES
-                (10, "\x76\x77\x03", "10");
+                (10, "\x76\x77\x03", "10"),
+                (11, "\x77\x75\x03", "11");
             )"));
 
             auto result = session.ExecuteDataQuery(
@@ -496,9 +496,10 @@ Y_UNIT_TEST_SUITE(KqpVectorIndexes) {
         }
 
         const TString postingTable1_del = ReadTablePartToYson(session, "/Root/TestTable/index1/indexImplPostingTable");
+        UNIT_ASSERT_STRINGS_UNEQUAL(originalPostingTable, postingTable1_del);
+        UNIT_ASSERT_STRINGS_UNEQUAL(postingTable1_ins, postingTable1_del);
 
-/*
-        // Normal delete from the table with index should succeed (it uses a different code path)
+        // Normal delete from the table with index should succeed too (it uses a different code path)
         {
             const TString query1(Q_(R"(
                 DELETE FROM `/Root/TestTable` WHERE pk=11;
@@ -511,11 +512,10 @@ Y_UNIT_TEST_SUITE(KqpVectorIndexes) {
             UNIT_ASSERT(result.IsSuccess());
         }
 
-        const TString postingTable1_del = ReadTablePartToYson(session, "/Root/TestTable/index1/indexImplPostingTable");
-*/
+        const TString postingTable2_del = ReadTablePartToYson(session, "/Root/TestTable/index1/indexImplPostingTable");
 
         // First index is updated
-        UNIT_ASSERT_STRINGS_EQUAL(originalPostingTable, postingTable1_del);
+        UNIT_ASSERT_STRINGS_EQUAL(originalPostingTable, postingTable2_del);
     }
 
     Y_UNIT_TEST_TWIN(SimpleVectorIndexOrderByCosineDistanceWithCover, Nullable) {

--- a/ydb/core/kqp/ut/indexes/kqp_indexes_vector_ut.cpp
+++ b/ydb/core/kqp/ut/indexes/kqp_indexes_vector_ut.cpp
@@ -443,10 +443,10 @@ Y_UNIT_TEST_SUITE(KqpVectorIndexes) {
 
         const TString originalPostingTable = ReadTablePartToYson(session, "/Root/TestTable/index1/indexImplPostingTable");
 
-        // Upsert to the table with index should succeed
+        // Insert to the table with index should succeed
         {
             const TString query1(Q_(R"(
-                UPSERT INTO `/Root/TestTable` (pk, emb, data) VALUES)"
+                INSERT INTO `/Root/TestTable` (pk, emb, data) VALUES)"
                 "(10, \"\x76\x76\x03\", \"10\");"
             ));
 
@@ -475,29 +475,9 @@ Y_UNIT_TEST_SUITE(KqpVectorIndexes) {
         }
 
         const TString postingTable1 = ReadTablePartToYson(session, "/Root/TestTable/index1/indexImplPostingTable");
-        
-        // First index is not updated
-        UNIT_ASSERT_STRINGS_EQUAL(originalPostingTable, postingTable1);
 
-        // Add second index
-        {
-            const TString createIndex(Q_(R"(
-                ALTER TABLE `/Root/TestTable`
-                    ADD INDEX index2
-                    GLOBAL USING vector_kmeans_tree
-                    ON (emb)
-                    WITH (similarity=cosine, vector_type="uint8", vector_dimension=2, levels=2, clusters=2);
-            )"));
-
-            auto result = session.ExecuteSchemeQuery(createIndex).ExtractValueSync();
-
-            UNIT_ASSERT_C(result.IsSuccess(), result.GetIssues().ToString());
-        }     
-        
-        const TString postingTable2 = ReadTablePartToYson(session, "/Root/TestTable/index2/indexImplPostingTable");
-        
-        // Second index is different
-        UNIT_ASSERT_STRINGS_UNEQUAL(originalPostingTable, postingTable2);
+        // First index is updated
+        UNIT_ASSERT_STRINGS_UNEQUAL(originalPostingTable, postingTable1);
     }
 
     Y_UNIT_TEST_TWIN(SimpleVectorIndexOrderByCosineDistanceWithCover, Nullable) {

--- a/ydb/core/protos/kqp_physical.proto
+++ b/ydb/core/protos/kqp_physical.proto
@@ -8,6 +8,7 @@ import "google/protobuf/any.proto";
 import "ydb/core/protos/flat_scheme_op.proto";
 import "ydb/library/mkql_proto/protos/minikql.proto";
 import "ydb/library/yql/dq/proto/dq_tasks.proto";
+import "ydb/public/api/protos/ydb_table.proto";
 import "ydb/public/api/protos/ydb_value.proto";
 import "ydb/core/protos/index_builder.proto";
 import "ydb/core/protos/sys_view_types.proto";
@@ -313,6 +314,17 @@ message TKqpPhyCnStreamLookup {
     bool IsTableImmutable = 10;
 }
 
+message TKqpPhyCnVectorResolve {
+    optional Ydb.Table.VectorIndexSettings IndexSettings = 1;
+    TKqpPhyTableId Table = 2;
+    TKqpPhyTableId LevelTable = 3;
+    repeated string Columns = 4;
+    uint32 VectorColumnIndex = 5;
+    repeated uint32 CopyColumnIndexes = 6;
+    bytes InputType = 7;
+    bytes OutputType = 8;
+}
+
 message TKqpPhyCnSequencer {
     TKqpPhyTableId Table = 1;
     repeated string Columns = 2;
@@ -339,6 +351,7 @@ message TKqpPhyConnection {
         TKqpPhyCnStreamLookup StreamLookup = 12;
         TKqpPhyCnSequencer Sequencer = 14;
         TKqpPhyCnParallelUnionAll ParallelUnionAll = 15;
+        TKqpPhyCnVectorResolve VectorResolve = 16;
     };
 }
 

--- a/ydb/core/protos/tx_datashard.proto
+++ b/ydb/core/protos/tx_datashard.proto
@@ -275,6 +275,36 @@ message TKqpReadRangesSourceSettings {
     optional bool IsTableImmutable = 23 [default = false];
 }
 
+// Takes input rows with a vector column, resolves the leaf cluster ID using the given
+// vector index level and prefix tables for each of them and returns rows for the posting table.
+// Primary key and data columns are copied to the posting table row and a cluster ID column is added.
+message TKqpVectorResolveSettings {
+    // Index settings
+    optional Ydb.Table.VectorIndexSettings IndexSettings = 1;
+    optional uint32 IndexLevels = 2;
+
+    // Level table and its column IDs
+    optional TKqpTransaction.TTableMeta LevelTable = 3;
+    optional uint32 LevelTableParentColumnId = 4;
+    optional uint32 LevelTableClusterColumnId = 5;
+    optional uint32 LevelTableCentroidColumnId = 6;
+
+    //optional TKqpTransaction.TTableMeta PrefixTable = ?;
+
+    // Input columns (columns of the source table)
+    repeated uint32 InputColumnTypes = 7;
+    repeated NKikimrProto.TTypeInfo InputColumnTypeInfos = 8;
+    //repeated uint32 PrefixColumnIds = ?;
+    repeated uint32 CopyColumnIndexes = 9;
+    optional uint32 VectorColumnIndex = 10;
+
+    // Transaction parameters
+    optional NKikimrProto.TRowVersion Snapshot = 11;
+    optional uint64 LockTxId = 12;
+    optional uint32 LockNodeId = 13;
+    optional NKikimrDataEvents.ELockMode LockMode = 14;
+}
+
 message TKqpTaskInfo {
     optional uint64 TaskId = 1;
     optional NActorsProto.TActorId ComputeActor = 2;

--- a/ydb/library/wilson_ids/wilson.h
+++ b/ydb/library/wilson_ids/wilson.h
@@ -88,6 +88,8 @@ namespace NKikimr {
                     BufferWriteActorState = TComponentTracingLevels::TQueryProcessor::Detailed,
                     TableWriteActor = TComponentTracingLevels::TQueryProcessor::Detailed,
 
+                VectorResolveActor = TComponentTracingLevels::TQueryProcessor::Basic,
+
             BulkUpsertActor = TComponentTracingLevels::TQueryProcessor::TopLevel,
         };
     };


### PR DESCRIPTION
### Changelog entry

Implement basic update support for global vector indexes. Clusters are not recalculated, rows are just reclassified according to the existing clusters.

### Changelog category

* New feature

### Description for reviewers

INSERT, DELETE in two forms (DELETE WHERE and DELETE ON), UPDATE and UPSERT queries are now supported.