### PR TITLE
audit log on incoming request

### DIFF
--- a/ydb/core/mon/audit/audit.h
+++ b/ydb/core/mon/audit/audit.h
@@ -10,11 +10,19 @@ namespace NMonitoring::NAudit {
 
 using TAuditParts = TVector<std::pair<TString, TString>>;
 
+enum ERequestStatus {
+    Success,
+    Process,
+    Error,
+};
+
 class TAuditCtx {
 public:
     void InitAudit(const NHttp::TEvHttpProxy::TEvHttpIncomingRequest::TPtr& ev);
     void AddAuditLogParts(const TIntrusiveConstPtr<NACLib::TUserToken>& userToken);
-    void FinishAudit(const NHttp::THttpOutgoingResponsePtr& response);
+    void LogAudit(ERequestStatus status, const TString& reason);
+    void LogOnExecute();
+    void LogOnResult(const NHttp::THttpOutgoingResponsePtr& response);
 
 private:
     void AddAuditLogPart(TStringBuf name, const TString& value);

--- a/ydb/core/mon/mon.cpp
+++ b/ydb/core/mon/mon.cpp
@@ -394,7 +394,7 @@ public:
     }
 
     void ReplyWith(NHttp::THttpOutgoingResponsePtr response) {
-        AuditCtx.FinishAudit(response);
+        AuditCtx.LogOnResult(response);
         Send(Event->Sender, new NHttp::TEvHttpProxy::TEvHttpOutgoingResponse(response));
     }
 
@@ -527,6 +527,7 @@ public:
             AuditCtx.AddAuditLogParts(result->UserToken);
             serializedToken = result->UserToken->GetSerializedToken();
         }
+        AuditCtx.LogOnExecute();
         Send(ActorMonPage->TargetActorId, new NMon::TEvHttpInfo(
             Container, serializedToken), IEventHandle::FlagTrackDelivery);
     }
@@ -593,9 +594,10 @@ public:
     }
 
     void ProcessRequest() {
+        AuditCtx.LogOnExecute();
         Container.Page->Output(Container);
         NHttp::THttpOutgoingResponsePtr response = Event->Get()->Request->CreateResponseString(Container.Str());
-        AuditCtx.FinishAudit(response);
+        AuditCtx.LogOnResult(response);
         Send(Event->Sender, new NHttp::TEvHttpProxy::TEvHttpOutgoingResponse(response));
         PassAway();
     }
@@ -1063,7 +1065,7 @@ public:
     }
 
     void ReplyWith(NHttp::THttpOutgoingResponsePtr response) {
-        AuditCtx.FinishAudit(response);
+        AuditCtx.LogOnResult(response);
         Send(Event->Sender, new NHttp::TEvHttpProxy::TEvHttpOutgoingResponse(response));
     }
 
@@ -1172,6 +1174,7 @@ public:
             AuditCtx.AddAuditLogParts(result->UserToken);
             Event->Get()->UserToken = result->UserToken->GetSerializedToken();
         }
+        AuditCtx.LogOnExecute();
         Send(new IEventHandle(Fields.Handler, SelfId(), Event->ReleaseBase().Release(), IEventHandle::FlagTrackDelivery, Event->Cookie));
     }
 
@@ -1206,7 +1209,7 @@ public:
 
     void Handle(NHttp::TEvHttpProxy::TEvHttpOutgoingResponse::TPtr& ev) {
         bool endOfData = ev->Get()->Response->IsDone();
-        AuditCtx.FinishAudit(ev->Get()->Response);
+        AuditCtx.LogOnResult(ev->Get()->Response);
         Forward(ev, Event->Sender);
         if (endOfData) {
             return PassAway();

--- a/ydb/core/mon/mon.h
+++ b/ydb/core/mon/mon.h
@@ -63,6 +63,7 @@ public:
         TVector<TString> AllowedSIDs;
         bool SortPages = true;
         TString MonServiceName = "utils";
+        bool AutoAudit = true;
     };
 
     NMonitoring::IMonPage* RegisterActorPage(TRegisterActorPageFields fields);
@@ -76,6 +77,7 @@ public:
         TActorId Handler;
         bool UseAuth = true;
         TVector<TString> AllowedSIDs;
+        bool AutoAudit = true;
     };
 
     void RegisterActorHandler(const TRegisterHandlerFields& fields);

--- a/ydb/core/mon/mon_impl.h
+++ b/ydb/core/mon/mon_impl.h
@@ -142,7 +142,8 @@ class TActorMonPage: public IMonPage {
 public:
     TActorMonPage(const TString &path, const TString &title, const TString &host, bool preTag,
                     TActorSystem *actorSystem, const TActorId &actorId, const TVector<TString> &sids,
-                    TMon::TRequestAuthorizer authorizer, TString monServiceName = "utils")
+                    TMon::TRequestAuthorizer authorizer, TString monServiceName = "utils",
+                    bool autoAudit = false)
         : IMonPage(path, title)
         , Host(host)
         , PreTag(preTag)
@@ -151,6 +152,7 @@ public:
         , AllowedSIDs(sids)
         , Authorizer(std::move(authorizer))
         , MonServiceName(monServiceName)
+        , AutoAudit(autoAudit)
     {
     }
 
@@ -165,6 +167,7 @@ public:
     const TVector<TString> AllowedSIDs;
     TMon::TRequestAuthorizer Authorizer;
     TString MonServiceName;
+    bool AutoAudit;
 };
 
 inline TString GetPageFullPath(const NMonitoring::IMonPage* page) {

--- a/ydb/core/viewer/json_local_rpc.h
+++ b/ydb/core/viewer/json_local_rpc.h
@@ -157,6 +157,10 @@ public:
         if (TBase::NeedToRedirect()) {
             return;
         }
+        static const THashSet<HTTP_METHOD> MODIFYING_METHODS = {HTTP_METHOD_POST, HTTP_METHOD_PUT, HTTP_METHOD_DELETE, HTTP_METHOD_EXTENSION};
+        if (std::find(MODIFYING_METHODS.begin(), MODIFYING_METHODS.end(), Event->Get()->Request.GetMethod()) == MODIFYING_METHODS.end() && TBase::NeedToWriteAuditLog()) {
+            return;
+        }
         TRequestProtoType request;
         if (!Params2Proto(request)) {
             return;

--- a/ydb/core/viewer/json_pipe_req.h
+++ b/ydb/core/viewer/json_pipe_req.h
@@ -44,6 +44,7 @@ protected:
     TString SharedDatabase;
     bool Direct = false;
     bool NeedRedirect = true;
+    bool NeedAuditLog = true;
     i32 DataRequests = 0; // how many requests we wait to process data
     bool PassedAway = false;
     bool ReplySent = false;
@@ -389,9 +390,12 @@ protected:
     void HandleResolve(TEvStateStorage::TEvBoardInfo::TPtr& ev);
     STATEFN(StateResolveDatabase);
     STATEFN(StateResolveResource);
+    STATEFN(StateAudit);
     void RedirectToDatabase(const TString& database);
     bool NeedToRedirect();
+    bool NeedToWriteAuditLog();
     void HandleTimeout();
+    virtual void Execute() {};
     void PassAway() override;
 };
 

--- a/ydb/core/viewer/pdisk_restart.h
+++ b/ydb/core/viewer/pdisk_restart.h
@@ -38,6 +38,9 @@ public:
     {}
 
     void Bootstrap() override {
+        if (NeedToWriteAuditLog()) {
+            return;
+        }
         ui32 nodeId = FromStringWithDefault<ui32>(Params.Get("node_id"), 0);
         ui32 pDiskId = FromStringWithDefault<ui32>(Params.Get("pdisk_id"), Max<ui32>());
         bool force = FromStringWithDefault<bool>(Params.Get("force"), false);

--- a/ydb/core/viewer/pdisk_status.h
+++ b/ydb/core/viewer/pdisk_status.h
@@ -27,6 +27,9 @@ public:
     {}
 
     void Bootstrap() override {
+        if (NeedToWriteAuditLog()) {
+            return;
+        }
         if (!PostData.IsDefined()) {
             return ReplyAndPassAway(GetHTTPBADREQUEST("text/plain", "Only POST method is allowed"));
         }

--- a/ydb/core/viewer/vdisk_evict.h
+++ b/ydb/core/viewer/vdisk_evict.h
@@ -42,6 +42,9 @@ public:
     }
 
     void Bootstrap() override {
+        if (NeedToWriteAuditLog()) {
+            return;
+        }
         ui32 groupId = 0;
         ui32 groupGeneration = 0;
         ui32 failRealmIdx = 0;

--- a/ydb/core/viewer/viewer.cpp
+++ b/ydb/core/viewer/viewer.cpp
@@ -103,18 +103,21 @@ public:
                 .ActorId = ctx.SelfID,
                 .UseAuth = true,
                 .AllowedSIDs = databaseAllowedSIDs,
+                .AutoAudit = false,
             });
             mon->RegisterActorPage({
                 .RelPath = "viewer/capabilities",
                 .ActorSystem = ctx.ActorSystem(),
                 .ActorId = ctx.SelfID,
                 .UseAuth = false,
+                .AutoAudit = false,
             });
             mon->RegisterActorPage({
                 .Title = "Viewer",
                 .RelPath = "viewer/v2",
                 .ActorSystem = ctx.ActorSystem(),
                 .ActorId = ctx.SelfID,
+                .AutoAudit = false,
             });
             mon->RegisterActorPage({
                 .Title = "Monitoring",
@@ -122,18 +125,21 @@ public:
                 .ActorSystem = ctx.ActorSystem(),
                 .ActorId = ctx.SelfID,
                 .UseAuth = false,
+                .AutoAudit = false,
             });
             mon->RegisterActorPage({
                 .RelPath = "counters/hosts",
                 .ActorSystem = ctx.ActorSystem(),
                 .ActorId = ctx.SelfID,
                 .UseAuth = false,
+                .AutoAudit = false,
             });
             mon->RegisterActorPage({
                 .RelPath = "healthcheck",
                 .ActorSystem = ctx.ActorSystem(),
                 .ActorId = ctx.SelfID,
                 .UseAuth = false,
+                .AutoAudit = false,
             });
             mon->RegisterActorPage({
                 .RelPath = "vdisk",
@@ -141,6 +147,7 @@ public:
                 .ActorId = ctx.SelfID,
                 .UseAuth = true,
                 .AllowedSIDs = databaseAllowedSIDs,
+                .AutoAudit = false,
             });
             mon->RegisterActorPage({
                 .RelPath = "pdisk",
@@ -148,6 +155,7 @@ public:
                 .ActorId = ctx.SelfID,
                 .UseAuth = true,
                 .AllowedSIDs = monitoringAllowedSIDs,
+                .AutoAudit = false,
             });
             mon->RegisterActorPage({
                 .RelPath = "operation",
@@ -155,6 +163,7 @@ public:
                 .ActorId = ctx.SelfID,
                 .UseAuth = true,
                 .AllowedSIDs = databaseAllowedSIDs,
+                .AutoAudit = false,
             });
             mon->RegisterActorPage({
                 .RelPath = "query",
@@ -162,6 +171,7 @@ public:
                 .ActorId = ctx.SelfID,
                 .UseAuth = true,
                 .AllowedSIDs = databaseAllowedSIDs,
+                .AutoAudit = false,
             });
             mon->RegisterActorPage({
                 .RelPath = "scheme",
@@ -169,6 +179,7 @@ public:
                 .ActorId = ctx.SelfID,
                 .UseAuth = true,
                 .AllowedSIDs = databaseAllowedSIDs,
+                .AutoAudit = false,
             });
             mon->RegisterActorPage({
                 .RelPath = "storage",
@@ -176,6 +187,7 @@ public:
                 .ActorId = ctx.SelfID,
                 .UseAuth = true,
                 .AllowedSIDs = databaseAllowedSIDs,
+                .AutoAudit = false,
             });
             if (!KikimrRunConfig.AppConfig.GetMonitoringConfig().GetHideHttpEndpoint()) {
                 auto whiteboardServiceId = NNodeWhiteboard::MakeNodeWhiteboardServiceId(ctx.SelfID.NodeId());
@@ -219,6 +231,7 @@ public:
                         .Handler = ctx.SelfID,
                         .UseAuth = true,
                         .AllowedSIDs = databaseAllowedSIDs,
+                        .AutoAudit = false,
                     });
                 }
             }

--- a/ydb/core/viewer/viewer_acl.h
+++ b/ydb/core/viewer/viewer_acl.h
@@ -217,6 +217,9 @@ public:
         if (NeedToRedirect()) {
             return;
         }
+        if (PostData.IsDefined() && NeedToWriteAuditLog()) {
+            return;
+        }
         MergeRules = FromStringWithDefault<bool>(Params.Get("merge_rules"), MergeRules);
         if (Params.Has("dialect")) {
             static const std::unordered_map<TString, const TDialect*> dialects = {

--- a/ydb/core/viewer/viewer_query.h
+++ b/ydb/core/viewer/viewer_query.h
@@ -339,6 +339,10 @@ public:
         if (NeedToRedirect()) {
             return;
         }
+        if (NeedToWriteAuditLog()) {
+            return;
+        }
+
         if (Query.empty() && Action != "cancel-query" && Action != "fetch-long-query") {
             return TBase::ReplyAndPassAway(GetHTTPBADREQUEST("text/plain", "Query is empty"), "EmptyQuery");
         }

--- a/ydb/library/actors/http/http_proxy.h
+++ b/ydb/library/actors/http/http_proxy.h
@@ -58,6 +58,8 @@ struct TEvHttpProxy {
         EvHttpOutgoingDataChunk,
         EvSubscribeForCancel,
         EvRequestCancelled,
+        EvAuditExecute,
+        EvAuditExecuteConfirmed,
         EvEnd
     };
 
@@ -294,6 +296,8 @@ struct TEvHttpProxy {
 
     struct TEvSubscribeForCancel : NActors::TEventLocal<TEvSubscribeForCancel, EvSubscribeForCancel> {};
     struct TEvRequestCancelled : NActors::TEventLocal<TEvRequestCancelled, EvRequestCancelled> {};
+    struct TEvAuditExecute : NActors::TEventLocal<TEvAuditExecute, EvAuditExecute> {};
+    struct TEvAuditExecuteConfirmed : NActors::TEventLocal<TEvAuditExecuteConfirmed, EvAuditExecuteConfirmed> {};
 };
 
 struct TRateLimiter {


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

An audit log entry is required upon request reception (without waiting for the response)

### Changelog category <!-- remove all except one -->

* Improvement

### Description for reviewers <!-- (optional) description for those who read this PR -->

Audit logging should happen twice for each request:
- **On request receipt** - to record the start of processing.
- **When the result is known** - to record the final status.

When registering a http handler, you can choose one of two audit logging strategies:
- **AutoAudit = true** - Audit logging is triggered automatically when the handler is called. The monitoring service determines when to log based on the request method and URL.
- **AutoAudit = false** - The handler explicitly controls when audit logging starts. To initiate logging, it sends a `TEvAuditExecute` message to the monitoring service request actor. The actor replies with `TEvAuditExecuteConfirmed`, ensuring the start log entry is written before request processing begins.

If audit logging was started, the monitoring service request actor records a final entry with the request outcome.

In this PR, `AuditDirectedStart` is added to YDB Viewer. It is set for all modifying handlers immediately after a redirect attempt, to avoid logging requests that return a redirect as unnecessary.

An audit log for a single user operation might look like this now:
```
2025-08-07T13:36:51.053111Z: {"status":"IN-PROCESS", "reason":"Execute", "operation":"HTTP REQUEST","url":"/viewer/query","component":"monitoring", ...}
2025-08-07T13:36:51.053433Z: {"status":"SUCCESS", "operation":"HTTP REQUEST","url":"/viewer/query","component":"monitoring" ...}
```
Requests with a redirect in the response will be skipped.