### PR TITLE
remove newline cluster.txt

### DIFF
--- a/ydb/tools/cfg/utils.py
+++ b/ydb/tools/cfg/utils.py
@@ -43,7 +43,8 @@ def write_to_file(file_path, value):
 
     with open(file_path, 'w') as writer:
         writer.write(value)
-        writer.write('\n')
+        if os.path.basename(file_path) != "cluster.txt":
+            writer.write('\n')
 
 
 def write_proto_to_file(file_path, proto):


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

...

### Changelog category <!-- remove all except one -->

* Not for changelog (changelog entry is not required)

### Description for reviewers <!-- (optional) description for those who read this PR -->

Remove newline for cluster.txt 
hotfix problem with unified-agent which read newline character for metrics and logs labels