### PR TITLE
Add UT for group cache, improve SentToWarden for local messages

### DIFF
--- a/ydb/core/blobstorage/ut_blobstorage/bsc_cache.cpp
+++ b/ydb/core/blobstorage/ut_blobstorage/bsc_cache.cpp
@@ -1,0 +1,122 @@
+#include <ydb/core/blobstorage/ut_blobstorage/lib/env.h>
+#include <ydb/core/blobstorage/ut_blobstorage/lib/ut_helpers.h>
+
+Y_UNIT_TEST_SUITE(GroupConfigurationPropagation) {
+
+struct TTestCtx : public TTestCtxBase {
+    TTestCtx(const TBlobStorageGroupType& erasure)
+        : TTestCtxBase(TEnvironmentSetup::TSettings{
+            .NodeCount = erasure.BlobSubgroupSize() * 2,
+            .Erasure = erasure,
+            .ControllerNodeId = erasure.BlobSubgroupSize() * 2,
+        })
+    {}
+
+    static bool BlockBscResponses(ui32, std::unique_ptr<IEventHandle>& ev) {
+        if (ev->GetTypeRewrite() == TEvBlobStorage::TEvControllerNodeServiceSetUpdate::EventType) {
+            return false;
+        }
+        
+        return true;
+    }
+
+    void AllocateEdgeActorOnNodeWOConfig() {
+        std::set<ui32> nodesWOConfig = GetComplementNodeSet(NodesWithConfig);
+        UNIT_ASSERT(!NodesWithConfig.empty());
+        AllocateEdgeActorOnSpecificNode(*nodesWOConfig.begin());
+        NodeWithProxy = Edge.NodeId();
+    }
+
+    void CheckStatus() {
+        AllocateEdgeActorOnNodeWOConfig();
+        auto res = GetGroupStatus(GroupId, WaitTime);
+        UNIT_ASSERT(res);
+        UNIT_ASSERT_VALUES_EQUAL_C(res->Get()->Status, NKikimrProto::OK, res->Get()->ErrorReason);
+    }
+
+    void Setup() {
+        Initialize();
+        NodesWithConfig = GetNodesWithVDisks();
+        NodesWithConfig.insert(Env->Settings.ControllerNodeId);
+        AllocateEdgeActorOnNodeWOConfig();
+        UNIT_ASSERT(NodeWithProxy != Env->Settings.ControllerNodeId);
+        Env->Sim(TDuration::Minutes(10));
+        Env->Runtime->FilterFunction = BlockBscResponses;
+    }
+
+    void StopNode() {
+        Env->StopNode(NodeWithProxy);
+    }
+
+    void StartNode() {
+        Env->StartNode(NodeWithProxy);
+        AllocateEdgeActorOnNodeWOConfig();
+    }
+
+    void RestartNode() {
+        StopNode();
+        StartNode();
+    }
+
+    void UpdateGroupConfiguration() {
+        NKikimrBlobStorage::TConfigRequest request;
+        auto* reassign = request.AddCommand()->MutableReassignGroupDisk();
+        for (const auto& slot : BaseConfig.GetVSlot()) {
+            if (slot.GetGroupId() == GroupId) {
+                reassign->SetGroupId(slot.GetGroupId());
+                reassign->SetGroupGeneration(slot.GetGroupGeneration());
+                reassign->SetFailRealmIdx(slot.GetFailRealmIdx());
+                reassign->SetFailDomainIdx(slot.GetFailDomainIdx());
+                reassign->SetVDiskIdx(slot.GetVDiskIdx());
+                break;
+            }
+        }
+        auto response = Env->Invoke(request);
+        BaseConfig = Env->FetchBaseConfig();
+
+        std::set<ui32> nodesWithVDisks = GetNodesWithVDisks();
+        NodesWithConfig.insert(nodesWithVDisks.begin(), nodesWithVDisks.end());
+    }
+
+    const TDuration WaitTime = TDuration::Seconds(1);
+    ui32 NodeWithProxy;
+    std::set<ui32> NodesWithConfig;
+};
+
+Y_UNIT_TEST(Simple) {
+    TTestCtx ctx(TBlobStorageGroupType::Erasure4Plus2Block);
+    ctx.Setup();
+    ctx.CheckStatus();
+}
+
+Y_UNIT_TEST(Reassign) {
+    TTestCtx ctx(TBlobStorageGroupType::Erasure4Plus2Block);
+    ctx.Setup();
+    ctx.UpdateGroupConfiguration();
+    ctx.CheckStatus();
+}
+
+Y_UNIT_TEST(NodeRestart) {
+    TTestCtx ctx(TBlobStorageGroupType::Erasure4Plus2Block);
+    ctx.Setup();
+    ctx.RestartNode();
+    ctx.CheckStatus();
+}
+
+Y_UNIT_TEST(NodeRestartAndUpdate) {
+    TTestCtx ctx(TBlobStorageGroupType::Erasure4Plus2Block);
+    ctx.Setup();
+    ctx.StopNode();
+    ctx.UpdateGroupConfiguration();
+    ctx.StartNode();
+    ctx.CheckStatus();
+}
+
+Y_UNIT_TEST(BscRestart) {
+    TTestCtx ctx(TBlobStorageGroupType::Erasure4Plus2Block);
+    ctx.Setup();
+    ctx.Env->RestartNode(ctx.Env->Settings.ControllerNodeId);
+    ctx.CheckStatus();
+}
+
+}

--- a/ydb/core/blobstorage/ut_blobstorage/lib/ut_helpers.h
+++ b/ydb/core/blobstorage/ut_blobstorage/lib/ut_helpers.h
@@ -304,13 +304,12 @@ public:
     }
 
     TAutoPtr<TEventHandle<TEvBlobStorage::TEvStatusResult>> GetGroupStatus(ui32 groupId,
-            TDuration waitTime = TDuration::Max(), TActorId actorId = {}) {
+            TDuration waitTime = TDuration::Max()) {
         TInstant ts = (waitTime == TDuration::Max()) ? TInstant::Max() : Env->Now() + waitTime;
-        TActorId edge = (actorId == TActorId{}) ? Edge : actorId; 
-        Env->Runtime->WrapInActorContext(edge, [&] {
-            SendToBSProxy(edge, groupId, new TEvBlobStorage::TEvStatus(ts));
+        Env->Runtime->WrapInActorContext(Edge, [&] {
+            SendToBSProxy(Edge, groupId, new TEvBlobStorage::TEvStatus(ts));
         });
-        return Env->WaitForEdgeActorEvent<TEvBlobStorage::TEvStatusResult>(edge, false, ts);
+        return Env->WaitForEdgeActorEvent<TEvBlobStorage::TEvStatusResult>(Edge, false, ts);
     }
 
     virtual void Initialize() {

--- a/ydb/core/blobstorage/ut_blobstorage/ya.make
+++ b/ydb/core/blobstorage/ut_blobstorage/ya.make
@@ -18,6 +18,7 @@ SRCS(
     assimilation.cpp
     backpressure.cpp
     block_race.cpp
+    bsc_cache.cpp
     counting_events.cpp
     deadlines.cpp
     decommit_3dc.cpp

--- a/ydb/core/mind/bscontroller/config.h
+++ b/ydb/core/mind/bscontroller/config.h
@@ -92,7 +92,22 @@ namespace NKikimr {
             THashSet<TPDiskId> PDisksToRemove;
 
             // outgoing messages
-            std::deque<std::tuple<TNodeId, std::unique_ptr<IEventBase>, ui64>> Outbox;
+            struct TOutgoingMessage {
+                TNodeId NodeId;
+                std::unique_ptr<IEventBase> Event;
+                ui64 Cookie;
+                bool ToLocalWarden;
+
+                TOutgoingMessage(TNodeId nodeId, std::unique_ptr<IEventBase>&& event,
+                        ui64 cookie, bool toLocalWarden = false)
+                    : NodeId(nodeId)
+                    , Event(std::forward<std::unique_ptr<IEventBase>>(event))
+                    , Cookie(cookie)
+                    , ToLocalWarden(toLocalWarden)
+                {}
+            };
+
+            std::deque<TOutgoingMessage> Outbox;
             std::deque<std::unique_ptr<IEventBase>> StatProcessorOutbox;
             std::deque<std::unique_ptr<IEventBase>> NodeWhiteboardOutbox;
             THolder<TEvControllerUpdateSelfHealInfo> UpdateSelfHealInfoMsg;

--- a/ydb/core/mind/bscontroller/register_node.cpp
+++ b/ydb/core/mind/bscontroller/register_node.cpp
@@ -667,12 +667,9 @@ void TBlobStorageController::EraseKnownDrivesOnDisconnected(TNodeInfo *nodeInfo)
 
 void TBlobStorageController::SendToWarden(TNodeId nodeId, std::unique_ptr<IEventBase> ev, ui64 cookie) {
     Y_ABORT_UNLESS(nodeId);
-    bool isLocal = nodeId == SelfId().NodeId();
-    TNodeInfo* node = FindNode(nodeId);
-
-    if (isLocal || (node && node->ConnectedServerId)) {
+    if (TNodeInfo* node = FindNode(nodeId); node && node->ConnectedServerId) {
         auto h = std::make_unique<IEventHandle>(MakeBlobStorageNodeWardenID(nodeId), SelfId(), ev.release(), 0, cookie);
-        if (!isLocal && node->InterconnectSessionId) {
+        if (node->InterconnectSessionId) {
             h->Rewrite(TEvInterconnect::EvForward, node->InterconnectSessionId);
         }
         TActivationContext::Send(h.release());

--- a/ydb/core/mind/bscontroller/register_node.cpp
+++ b/ydb/core/mind/bscontroller/register_node.cpp
@@ -667,9 +667,12 @@ void TBlobStorageController::EraseKnownDrivesOnDisconnected(TNodeInfo *nodeInfo)
 
 void TBlobStorageController::SendToWarden(TNodeId nodeId, std::unique_ptr<IEventBase> ev, ui64 cookie) {
     Y_ABORT_UNLESS(nodeId);
-    if (auto *node = FindNode(nodeId); node && node->ConnectedServerId) {
+    bool isLocal = nodeId == SelfId().NodeId();
+    TNodeInfo* node = FindNode(nodeId);
+
+    if (isLocal || (node && node->ConnectedServerId)) {
         auto h = std::make_unique<IEventHandle>(MakeBlobStorageNodeWardenID(nodeId), SelfId(), ev.release(), 0, cookie);
-        if (node->InterconnectSessionId) {
+        if (!isLocal && node->InterconnectSessionId) {
             h->Rewrite(TEvInterconnect::EvForward, node->InterconnectSessionId);
         }
         TActivationContext::Send(h.release());


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

Add unit tests for storage group configuration propagation via DistConf cache. Improve BSC's SendToWarden method, send message directly to local warden.

### Changelog category <!-- remove all except one -->

* Improvement