### PR TITLE
Implement counters related to SlotSizeInUnits

### DIFF
--- a/ydb/core/blobstorage/pdisk/blobstorage_pdisk.h
+++ b/ydb/core/blobstorage/pdisk/blobstorage_pdisk.h
@@ -188,7 +188,7 @@ struct TEvYardInitResult : TEventLocal<TEvYardInitResult, TEvBlobStorage::EvYard
     TEvYardInitResult(const NKikimrProto::EReplyStatus status, TString errorReason)
         : Status(status)
         , StatusFlags(0)
-        , PDiskParams(new TPDiskParams(0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, DEVICE_TYPE_ROT, false))
+        , PDiskParams(new TPDiskParams(0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, DEVICE_TYPE_ROT, false))
         , ErrorReason(std::move(errorReason))
     {
         Y_VERIFY(status != NKikimrProto::OK, "Single-parameter constructor is for error responses only");
@@ -197,7 +197,7 @@ struct TEvYardInitResult : TEventLocal<TEvYardInitResult, TEvBlobStorage::EvYard
     TEvYardInitResult(NKikimrProto::EReplyStatus status, ui64 seekTimeUs, ui64 readSpeedBps,
             ui64 writeSpeedBps, ui64 readBlockSize, ui64 writeBlockSize,
             ui64 bulkWriteBlockSize, ui32 chunkSize, ui32 appendBlockSize,
-            TOwner owner, TOwnerRound ownerRound, ui32 ownerWeight, ui32 slotSizeInUnits,
+            TOwner owner, TOwnerRound ownerRound, ui32 slotSizeInUnits,
             TStatusFlags statusFlags, TVector<TChunkIdx> ownedChunks,
             EDeviceType trueMediaType, bool isTinyDisk, TString errorReason)
         : Status(status)
@@ -205,7 +205,6 @@ struct TEvYardInitResult : TEventLocal<TEvYardInitResult, TEvBlobStorage::EvYard
         , PDiskParams(new TPDiskParams(
                     owner,
                     ownerRound,
-                    ownerWeight,
                     slotSizeInUnits,
                     chunkSize,
                     appendBlockSize,

--- a/ydb/core/blobstorage/pdisk/blobstorage_pdisk_impl.cpp
+++ b/ydb/core/blobstorage/pdisk/blobstorage_pdisk_impl.cpp
@@ -1843,7 +1843,7 @@ void TPDisk::ReplyErrorYardInitResult(TYardInit &evYardInit, const TString &str,
         DriveModel.Speed(TDriveModel::OP_TYPE_WRITE), readBlockSize, writeBlockSize,
         DriveModel.BulkWriteBlockSize(),
         Format.GetUserAccessibleChunkSize(), Format.GetAppendBlockSize(), OwnerSystem, 0,
-        0, Cfg->SlotSizeInUnits,
+        Cfg->SlotSizeInUnits,
         GetStatusFlags(OwnerSystem, evYardInit.OwnerGroupType), TVector<TChunkIdx>(),
         Cfg->RetrieveDeviceType(), isTinyDisk, error.Str()));
     Mon.YardInit.CountResponse();
@@ -1899,7 +1899,7 @@ bool TPDisk::YardInitForKnownVDisk(TYardInit &evYardInit, TOwner owner) {
                 DriveModel.SeekTimeNs() / 1000ull, DriveModel.Speed(TDriveModel::OP_TYPE_READ),
                 DriveModel.Speed(TDriveModel::OP_TYPE_WRITE), readBlockSize, writeBlockSize,
                 DriveModel.BulkWriteBlockSize(), Format.GetUserAccessibleChunkSize(), Format.GetAppendBlockSize(), owner,
-                ownerRound, ownerWeight, Cfg->SlotSizeInUnits,
+                ownerRound, Cfg->SlotSizeInUnits,
                 GetStatusFlags(OwnerSystem, evYardInit.OwnerGroupType), ownedChunks,
                 Cfg->RetrieveDeviceType(), isTinyDisk, ""));
 
@@ -2064,7 +2064,7 @@ void TPDisk::YardInitFinish(TYardInit &evYardInit) {
         DriveModel.SeekTimeNs() / 1000ull, DriveModel.Speed(TDriveModel::OP_TYPE_READ),
         DriveModel.Speed(TDriveModel::OP_TYPE_WRITE), readBlockSize, writeBlockSize,
         DriveModel.BulkWriteBlockSize(), Format.GetUserAccessibleChunkSize(), Format.GetAppendBlockSize(), owner, ownerRound,
-        Cfg->GetOwnerWeight(evYardInit.GroupSizeInUnits), Cfg->SlotSizeInUnits,
+        Cfg->SlotSizeInUnits,
         GetStatusFlags(OwnerSystem, evYardInit.OwnerGroupType) | ui32(NKikimrBlobStorage::StatusNewOwner), TVector<TChunkIdx>(),
         Cfg->RetrieveDeviceType(), isTinyDisk, ""));
 

--- a/ydb/core/blobstorage/pdisk/blobstorage_pdisk_params.cpp
+++ b/ydb/core/blobstorage/pdisk/blobstorage_pdisk_params.cpp
@@ -9,14 +9,13 @@ namespace NKikimr {
     ////////////////////////////////////////////////////////////////////////////
     // TPDiskParams
     ////////////////////////////////////////////////////////////////////////////
-    TPDiskParams::TPDiskParams(NPDisk::TOwner owner, ui64 ownerRound, ui32 OwnerWeight, ui32 slotSizeInUnits,
+    TPDiskParams::TPDiskParams(NPDisk::TOwner owner, ui64 ownerRound, ui32 slotSizeInUnits,
                                ui32 chunkSize, ui32 appendBlockSize,
                                ui64 seekTimeUs, ui64 readSpeedBps, ui64 writeSpeedBps, ui64 readBlockSize,
                                ui64 writeBlockSize, ui64 bulkWriteBlockSize, NPDisk::EDeviceType trueMediaType,
                                bool isTinyDisk)
         : Owner(owner)
         , OwnerRound(ownerRound)
-        , OwnerWeight(OwnerWeight)
         , SlotSizeInUnits(slotSizeInUnits)
         , ChunkSize(chunkSize)
         , AppendBlockSize(appendBlockSize)
@@ -63,7 +62,6 @@ namespace NKikimr {
         TStringStream str;
         str << "{TPDiskParams ownerId# " << Owner;
         str << " ownerRound# " << OwnerRound;
-        str << " OwnerWeight# " << OwnerWeight;
         str << " SlotSizeInUnits# " << SlotSizeInUnits;
         str << " ChunkSize# " << ChunkSize;
         str << " AppendBlockSize# " << AppendBlockSize;
@@ -94,10 +92,6 @@ namespace NKikimr {
                     TABLER() {
                         TABLED() {str << "Owner";}
                         TABLED() {str << Owner;}
-                    }
-                    TABLER() {
-                        TABLED() {str << "OwnerWeight";}
-                        TABLED() {str << OwnerWeight;}
                     }
                     TABLER() {
                         TABLED() {str << "SlotSizeInUnits";}

--- a/ydb/core/blobstorage/pdisk/blobstorage_pdisk_params.h
+++ b/ydb/core/blobstorage/pdisk/blobstorage_pdisk_params.h
@@ -12,7 +12,6 @@ namespace NKikimr {
     struct TPDiskParams : public TThrRefBase {
         const NPDisk::TOwner Owner;
         const ui64 OwnerRound;
-        const ui32 OwnerWeight;
         const ui32 SlotSizeInUnits;
         const ui64 ChunkSize;
         const ui32 AppendBlockSize;
@@ -37,7 +36,7 @@ namespace NKikimr {
         static ui64 CalculatePrefetchSizeBytes(ui64 seekTimeUs, ui64 readSpeedBps);
         static ui64 CalculateGlueRequestDistanceBytes(ui64 seekTimeUs, ui64 readSpeedBps);
 
-        TPDiskParams(NPDisk::TOwner owner, ui64 ownerRound, ui32 ownerWeight, ui32 slotSizeInUnits,
+        TPDiskParams(NPDisk::TOwner owner, ui64 ownerRound, ui32 slotSizeInUnits,
                      ui32 chunkSize, ui32 appendBlockSize,
                      ui64 seekTimeUs, ui64 readSpeedBps, ui64 writeSpeedBps, ui64 readBlockSize,
                      ui64 writeBlockSize, ui64 bulkWriteBlockSize, NPDisk::EDeviceType trueMediaType,

--- a/ydb/core/blobstorage/pdisk/mock/pdisk_mock.cpp
+++ b/ydb/core/blobstorage/pdisk/mock/pdisk_mock.cpp
@@ -491,7 +491,7 @@ public:
             const ui64 bulkWriteBlockSize = 65536;
             res = std::make_unique<NPDisk::TEvYardInitResult>(NKikimrProto::OK, seekTimeUs, readSpeedBps, writeSpeedBps,
                 readBlockSize, writeBlockSize, bulkWriteBlockSize, Impl.ChunkSize, Impl.AppendBlockSize, ownerId,
-                owner->OwnerRound, owner->Weight, 0u, GetStatusFlags(), std::move(ownedChunks), NPDisk::DEVICE_TYPE_NVME, false, TString());
+                owner->OwnerRound, 0u, GetStatusFlags(), std::move(ownedChunks), NPDisk::DEVICE_TYPE_NVME, false, TString());
             res->StartingPoints = owner->StartingPoints;
         } else {
             res = std::make_unique<NPDisk::TEvYardInitResult>(NKikimrProto::INVALID_ROUND, "invalid owner round");

--- a/ydb/core/blobstorage/vdisk/repl/blobstorage_hullreplwritesst_ut.cpp
+++ b/ydb/core/blobstorage/vdisk/repl/blobstorage_hullreplwritesst_ut.cpp
@@ -15,7 +15,7 @@ std::shared_ptr<TReplCtx> CreateReplCtx(TVector<TVDiskID>& vdisks, const TIntrus
     auto vctx = MakeIntrusive<TVDiskContext>(TActorId(), info->PickTopology(), counters, TVDiskID(0, 1, 0, 0, 0),
         nullptr, NPDisk::DEVICE_TYPE_UNKNOWN);
     auto hugeBlobCtx = std::make_shared<THugeBlobCtx>("", nullptr, true);
-    auto dsk = MakeIntrusive<TPDiskParams>(ui8(1), 1u, 1u, 0u, 128u << 20, 4096u, 0u, 1000000000u, 1000000000u, 65536u, 65536u, 65536u,
+    auto dsk = MakeIntrusive<TPDiskParams>(ui8(1), 1u, 0u, 128u << 20, 4096u, 0u, 1000000000u, 1000000000u, 65536u, 65536u, 65536u,
             NPDisk::DEVICE_TYPE_UNKNOWN, false);
     auto pdiskCtx = std::make_shared<TPDiskCtx>(dsk, TActorId(), TString());
     auto replCtx = std::make_shared<TReplCtx>(

--- a/ydb/core/protos/counters_bs_controller.proto
+++ b/ydb/core/protos/counters_bs_controller.proto
@@ -29,6 +29,10 @@ enum ESimpleCounters {
     COUNTER_DISK_SCRUB_CUR_GROUPS = 19 [(CounterOpts) = {Name: "CurrentlyScrubbedGroups"}];
     COUNTER_SELF_HEAL_UNREASSIGNABLE_GROUPS = 20 [(CounterOpts) = {Name: "SelfHealUnreassignableGroups"}];
     COUNTER_GROUP_LAYOUT_SANITIZER_INVALID_GROUPS = 21 [(CounterOpts) = {Name: "GroupLayoutSanitizerInvlaidGroups"}];
+    COUNTER_PDISKS_WITHOUT_INFERRED_SETTINGS = 22 [(CounterOpts) = {Name: "PDisksWithoutInferredSettings"}];
+    COUNTER_PDISKS_WITH_INFERRED_SETTINGS_UNKNOWN = 23 [(CounterOpts) = {Name: "PDisksWithInferredSettingsUnknown"}];
+    COUNTER_VDISKS_WITH_SMALL_SIZE_IN_UNITS_OCCUPYING_LARGER_VSLOT = 24 [(CounterOpts) = {Name: "VDisksWithSmallSizeInUnitsOccupyingLargerVSlot"}];
+    COUNTER_VDISKS_WITH_LARGE_SIZE_IN_UNITS_OCCUPYING_MULTIPLE_SMALLER_VSLOTS = 25 [(CounterOpts) = {Name: "VDisksWithLargeSizeInUnitsOccupyingMultipleSmallerVSlots"}];
 }
 
 enum ECumulativeCounters {

--- a/ydb/core/tablet/tablet_counters.cpp
+++ b/ydb/core/tablet/tablet_counters.cpp
@@ -85,13 +85,12 @@ void TTabletPercentileCounter::OutputHtml(IOutputStream &os, const char* name) c
     }
 }
 
-void TTabletCountersBase::OutputHtml(IOutputStream &os) const {
+void TTabletCountersBase::OutputHtml(IOutputStream &os, const char* counterClass) const {
     HTML(os) {
         DIV_CLASS("row") {
-            DIV_CLASS("col-md-12") {OutputHtml(os, "Simple", SimpleCountersMetaInfo, "col-md-3", SimpleCounters);}
-            DIV_CLASS("col-md-12") {OutputHtml(os, "Cumulative", CumulativeCountersMetaInfo, "col-md-3", CumulativeCounters);}
+            DIV_CLASS("col-md-12") {OutputHtml(os, "Simple", SimpleCountersMetaInfo, counterClass, SimpleCounters);}
+            DIV_CLASS("col-md-12") {OutputHtml(os, "Cumulative", CumulativeCountersMetaInfo, counterClass, CumulativeCounters);}
             DIV_CLASS("col-md-12") {OutputHtml(os, "Percentile", PercentileCountersMetaInfo, "col-md-12", PercentileCounters);}
-
         }
     }
 }

--- a/ydb/core/tablet/tablet_counters.h
+++ b/ydb/core/tablet/tablet_counters.h
@@ -505,7 +505,7 @@ public:
     void RememberCurrentStateAsBaseline(/*out*/ TTabletCountersBase& baseLine) const;
 
     //
-    void OutputHtml(IOutputStream &os) const;
+    void OutputHtml(IOutputStream &os, const char* counterClass) const;
     void OutputProto(NKikimrTabletBase::TTabletCountersBase& op) const;
 
     //

--- a/ydb/core/tablet_flat/flat_executor.cpp
+++ b/ydb/core/tablet_flat/flat_executor.cpp
@@ -1349,9 +1349,9 @@ bool TExecutor::PrepareExternalPart(TPendingPartSwitch &partSwitch, TPendingPart
     }
 
     if (auto* stage = bundle.GetStage<TPendingPartSwitch::TLoaderStage>()) {
-        if (auto fetch = stage->Loader.Run({.PreloadIndex = true, .PreloadData = PreloadTablesData.contains(partSwitch.TableId)})) {            
+        if (auto fetch = stage->Loader.Run({.PreloadIndex = true, .PreloadData = PreloadTablesData.contains(partSwitch.TableId)})) {
             stage->Fetching = fetch.PageCollection.Get();
-            
+
             Send(MakeSharedPageCacheId(), new NSharedCache::TEvRequest(
                 NBlockIO::EPriority::Fast, std::move(fetch.PageCollection), std::move(fetch.Pages)),
                 0, ui64(ESharedCacheRequestType::PendingInit));
@@ -4439,12 +4439,12 @@ void TExecutor::RenderHtmlCounters(NMon::TEvRemoteHttpInfo::TPtr &ev) const {
             str << "</style>";
             if (Counters) {
                 TAG(TH3) {str << "Executor counters";}
-                Counters->OutputHtml(str);
+                Counters->OutputHtml(str, "col-md-3");
             }
 
             if (AppCounters) {
                 TAG(TH3) {str << "App counters";}
-                AppCounters->OutputHtml(str);
+                AppCounters->OutputHtml(str, "col-md-6");
             }
 
             if (ResourceMetrics) {


### PR DESCRIPTION
### Changelog category

* Not for changelog (changelog entry is not required)

### Description for reviewers

- Close https://github.com/ydb-platform/ydb/issues/19372
- Part of #16959
 
Besides counters this PR includes 2 other minor changes:

<details><summary>Fix squeezed tablet counters in Developer UI html</summary>
<p>
Before:

<img width="1803" height="954" alt="Screenshot from 2025-08-07 17-17-59" src="https://github.com/user-attachments/assets/c89a54a7-080a-463d-a158-62ad23af17a8" />

After:

<img width="1803" height="954" alt="Screenshot from 2025-08-07 18-33-30" src="https://github.com/user-attachments/assets/6d613da4-0d12-4e2a-8978-3ee0512bcc81" />

</p>
</details>

<details><summary>Remove redundant OwnerWeight from YardInitResult</summary>
<p>

During VDisk initialization PDisk replies to Skeleton with `TYardInitResult` event containing `TPDiskParams` and Skeleton saves it in its context. In #19337 it was extended with `SlotSizeInUnits` and `OwnerWeight` field. Now `OwnerWeight` is removed from there for two reasons. It's actually isn't used anywhere but in html rendering. And, what is more important, `OwnerWeight` can be changed with ChangeGroupSizeInUnits command, but PDiskParams in skeleton context is a constant field.

</p>
</details> 
