### PR TITLE
DataShard and SchemeShard: Support CacheMode in TFamilyDescription

### DIFF
--- a/ydb/core/protos/flat_scheme_op.proto
+++ b/ydb/core/protos/flat_scheme_op.proto
@@ -63,6 +63,11 @@ enum EColumnCache {
     ColumnCacheEver = 2;
 }
 
+enum EColumnCacheMode {
+    ColumnCacheModeRegular = 0;
+    ColumnCacheModeTryKeepInMemory = 1;
+}
+
 enum EColumnStorage {
     ColumnStorage1 = 0;
     ColumnStorage2 = 1;
@@ -136,6 +141,7 @@ message TFamilyDescription {
     optional EColumnStorage Storage = 8; // DEPRECATED: use StorageConfig
     optional TStorageConfig StorageConfig = 9;
     optional int32 ColumnCodecLevel = 10;
+    optional EColumnCacheMode ColumnCacheMode = 11;
 }
 
 message TFastSplitSettings {

--- a/ydb/core/tx/datashard/datashard_user_table.cpp
+++ b/ydb/core/tx/datashard/datashard_user_table.cpp
@@ -385,6 +385,7 @@ void TUserTable::AlterSchema() {
         columnFamily->SetStorage(family.Storage);
         columnFamily->SetColumnCodec(family.ColumnCodec);
         columnFamily->SetColumnCache(family.ColumnCache);
+        columnFamily->SetColumnCacheMode(family.ColumnCacheMode);
         columnFamily->SetRoom(family.GetRoomId());
     }
 
@@ -450,7 +451,7 @@ void TUserTable::DoApplyCreate(
 
         alter.AddFamily(tid, familyId, family.GetRoomId());
         alter.SetFamilyCompression(tid, familyId, family.Codec);
-        alter.SetFamilyCacheMode(tid, familyId, NTable::NPage::ECacheMode::Regular); // TODO: handle different cache modes
+        alter.SetFamilyCacheMode(tid, familyId, family.CacheMode);
         alter.SetFamilyCache(tid, familyId, family.Cache);
         alter.SetFamilyBlobs(tid, familyId, family.GetOuterThreshold(), family.GetExternalThreshold());
         if (appliedRooms.insert(family.GetRoomId()).second) {
@@ -549,7 +550,7 @@ void TUserTable::ApplyAlter(
         for (ui32 tid : tids) {
             alter.AddFamily(tid, familyId, family.GetRoomId());
             alter.SetFamilyCompression(tid, familyId, family.Codec);
-            alter.SetFamilyCacheMode(tid, familyId, NTable::NPage::ECacheMode::Regular); // TODO: handle different cache modes
+            alter.SetFamilyCacheMode(tid, familyId, family.CacheMode);
             alter.SetFamilyCache(tid, familyId, family.Cache);
             alter.SetFamilyBlobs(tid, familyId, family.GetOuterThreshold(), family.GetExternalThreshold());
         }
@@ -702,7 +703,7 @@ void TUserTable::Fix_KIKIMR_17222(NTable::TDatabase& db, ui32 tid) const
 
         db.Alter().AddFamily(tid, familyId, family.GetRoomId());
         db.Alter().SetFamilyCompression(tid, familyId, family.Codec);
-        db.Alter().SetFamilyCacheMode(tid, familyId, NTable::NPage::ECacheMode::Regular); // TODO: handle different cache modes
+        db.Alter().SetFamilyCacheMode(tid, familyId, family.CacheMode);
         db.Alter().SetFamilyCache(tid, familyId, family.Cache);
         db.Alter().SetFamilyBlobs(tid, familyId, family.GetOuterThreshold(), family.GetExternalThreshold());
     }

--- a/ydb/core/tx/datashard/datashard_user_table.h
+++ b/ydb/core/tx/datashard/datashard_user_table.h
@@ -254,7 +254,9 @@ struct TUserTable : public TThrRefBase {
                     return ECacheMode::Regular;
                 case NKikimrSchemeOp::EColumnCacheMode::ColumnCacheModeTryKeepInMemory:
                     return ECacheMode::TryKeepInMemory;
+                // keep no default
             }
+            Y_ENSURE(false, "unexpected");
         }
     };
 

--- a/ydb/core/tx/datashard/datashard_user_table.h
+++ b/ydb/core/tx/datashard/datashard_user_table.h
@@ -28,15 +28,18 @@ struct TUserTable : public TThrRefBase {
     struct TUserFamily {
         using ECodec = NTable::NPage::ECodec;
         using ECache = NTable::NPage::ECache;
+        using ECacheMode = NTable::NPage::ECacheMode;
 
         TUserFamily(const NKikimrSchemeOp::TFamilyDescription& family)
             : ColumnCodec(family.GetColumnCodec())
             , ColumnCache(family.GetColumnCache())
+            , ColumnCacheMode(family.GetColumnCacheMode())
             , OuterThreshold(SaveGetThreshold(family.GetStorageConfig().GetDataThreshold()))
             , ExternalThreshold(SaveGetThreshold(family.GetStorageConfig().GetExternalThreshold()))
             , Storage(family.GetStorage())
             , Codec(ExtractDbCodec(family))
             , Cache(ExtractDbCache(family))
+            , CacheMode(ExtractDbCacheMode(family))
             , Room(new TStorageRoom(family.GetRoom()))
             , Name(family.GetName())
         {
@@ -50,6 +53,10 @@ struct TUserTable : public TThrRefBase {
             if (family.HasColumnCache()) {
                 ColumnCache = family.GetColumnCache();
                 Cache = ToDbCache(ColumnCache);
+            }
+            if (family.HasColumnCacheMode()) {
+                ColumnCacheMode = family.GetColumnCacheMode();
+                CacheMode = ToDbCacheMode(ColumnCacheMode);
             }
             if (family.GetStorageConfig().HasDataThreshold()) {
                 OuterThreshold = SaveGetThreshold(family.GetStorageConfig().GetDataThreshold());
@@ -77,6 +84,7 @@ struct TUserTable : public TThrRefBase {
 
         NKikimrSchemeOp::EColumnCodec ColumnCodec;
         NKikimrSchemeOp::EColumnCache ColumnCache;
+        NKikimrSchemeOp::EColumnCacheMode ColumnCacheMode;
         ui32 OuterThreshold;
         ui32 ExternalThreshold;
         NKikimrSchemeOp::EColumnStorage Storage;
@@ -84,6 +92,7 @@ struct TUserTable : public TThrRefBase {
 
         ECodec Codec;
         ECache Cache;
+        ECacheMode CacheMode;
         TStorageRoom::TPtr Room;
 
         ui32 MainChannel() const {
@@ -230,6 +239,22 @@ struct TUserTable : public TThrRefBase {
                 // keep no default
             }
             Y_ENSURE(false, "unexpected");
+        }
+
+        static ECacheMode ExtractDbCacheMode(const NKikimrSchemeOp::TFamilyDescription& family) {
+            if (family.HasColumnCacheMode()) {
+                return ToDbCacheMode(family.GetColumnCacheMode());
+            }
+            return ECacheMode::Regular;
+        }
+
+        static ECacheMode ToDbCacheMode(NKikimrSchemeOp::EColumnCacheMode cacheMode) {
+            switch (cacheMode) {
+                case NKikimrSchemeOp::EColumnCacheMode::ColumnCacheModeRegular:
+                    return ECacheMode::Regular;
+                case NKikimrSchemeOp::EColumnCacheMode::ColumnCacheModeTryKeepInMemory:
+                    return ECacheMode::TryKeepInMemory;
+            }
         }
     };
 

--- a/ydb/core/tx/schemeshard/schemeshard_info_types.cpp
+++ b/ydb/core/tx/schemeshard/schemeshard_info_types.cpp
@@ -1094,6 +1094,10 @@ bool TPartitionConfigMerger::ApplyChangesInColumnFamilies(
             dstFamily.SetColumnCache(changesFamily.GetColumnCache());
         }
 
+        if (changesFamily.HasColumnCacheMode()) {
+            dstFamily.SetColumnCacheMode(changesFamily.GetColumnCacheMode());
+        }
+
         if (changesFamily.HasStorage()) {
             dstFamily.SetStorage(changesFamily.GetStorage());
         }


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

...

### Changelog category <!-- remove all except one -->

* Not for changelog (changelog entry is not required)

### Description for reviewers <!-- (optional) description for those who read this PR -->

- Add CacheMode in flat_scheme_op.proto
- Support CacheMode setting in TUserTable in DataShard
- Support CacheMode setting in SchemeShard
