### PR TITLE
Add PileupReplicas option for state storage config generation

### DIFF
--- a/ydb/core/blobstorage/nodewarden/distconf_invoke.h
+++ b/ydb/core/blobstorage/nodewarden/distconf_invoke.h
@@ -105,12 +105,12 @@ namespace NKikimr::NStorage {
         void ReassignStateStorageNode(const TQuery::TReassignStateStorageNode& cmd);
         void ReconfigStateStorage(const NKikimrBlobStorage::TStateStorageConfig& cmd);
         void SelfHealStateStorage(const TQuery::TSelfHealStateStorage& cmd);
-        void SelfHealStateStorage(ui32 waitForConfigStep, bool forceHeal);
+        void SelfHealStateStorage(ui32 waitForConfigStep, bool forceHeal, bool pileupReplicas);
         void SelfHealNodesStateUpdate(const TQuery::TSelfHealNodesStateUpdate& cmd);
         void GetStateStorageConfig(const TQuery::TGetStateStorageConfig& cmd);
 
         void GetCurrentStateStorageConfig(NKikimrBlobStorage::TStateStorageConfig* currentConfig);
-        bool GetRecommendedStateStorageConfig(NKikimrBlobStorage::TStateStorageConfig* currentConfig);
+        bool GetRecommendedStateStorageConfig(NKikimrBlobStorage::TStateStorageConfig* currentConfig, bool pileupReplicas);
         void AdjustRingGroupActorIdOffsetInRecommendedStateStorageConfig(NKikimrBlobStorage::TStateStorageConfig* currentConfig);
         ////////////////////////////////////////////////////////////////////////////////////////////////////////////////
         // Storage configuration YAML manipulation

--- a/ydb/core/blobstorage/nodewarden/distconf_invoke_state_storage.cpp
+++ b/ydb/core/blobstorage/nodewarden/distconf_invoke_state_storage.cpp
@@ -6,12 +6,18 @@ namespace NKikimr::NStorage {
 
     using TInvokeRequestHandlerActor = TDistributedConfigKeeper::TInvokeRequestHandlerActor;
 
-    bool TInvokeRequestHandlerActor::GetRecommendedStateStorageConfig(NKikimrBlobStorage::TStateStorageConfig* currentConfig) {
+    bool TInvokeRequestHandlerActor::GetRecommendedStateStorageConfig(NKikimrBlobStorage::TStateStorageConfig* currentConfig, bool pileupReplicas) {
         const NKikimrBlobStorage::TStorageConfig& config = *Self->StorageConfig;
         bool result = true;
         std::unordered_set<ui32> usedNodes;
         result &= Self->GenerateStateStorageConfig(currentConfig->MutableStateStorageConfig(), config, usedNodes, config.GetStateStorageConfig());
+        if (pileupReplicas) {
+            usedNodes.clear();
+        }
         result &= Self->GenerateStateStorageConfig(currentConfig->MutableStateStorageBoardConfig(), config, usedNodes, config.GetStateStorageBoardConfig());
+        if (pileupReplicas) {
+            usedNodes.clear();
+        }
         result &= Self->GenerateStateStorageConfig(currentConfig->MutableSchemeBoardConfig(), config, usedNodes, config.GetSchemeBoardConfig());
         return result;
     }
@@ -76,7 +82,7 @@ namespace NKikimr::NStorage {
             auto* currentConfig = record->MutableStateStorageConfig();
 
             if (cmd.GetRecommended()) {
-                GetRecommendedStateStorageConfig(currentConfig);
+                GetRecommendedStateStorageConfig(currentConfig, cmd.GetPileupReplicas());
                 AdjustRingGroupActorIdOffsetInRecommendedStateStorageConfig(currentConfig);
             } else {
                 GetCurrentStateStorageConfig(currentConfig);
@@ -91,18 +97,19 @@ namespace NKikimr::NStorage {
             Self->SelfHealNodesState[node.GetNodeId()] = node.GetState();
         }
         if (cmd.GetEnableSelfHealStateStorage()) {
-            SelfHealStateStorage(cmd.GetWaitForConfigStep(), true);
+            SelfHealStateStorage(cmd.GetWaitForConfigStep(), true, cmd.GetPileupReplicas());
         }
     }
 
     void TInvokeRequestHandlerActor::SelfHealStateStorage(const TQuery::TSelfHealStateStorage& cmd) {
-        SelfHealStateStorage(cmd.GetWaitForConfigStep(), cmd.GetForceHeal());
+        SelfHealStateStorage(cmd.GetWaitForConfigStep(), cmd.GetForceHeal(), cmd.GetPileupReplicas());
     }
 
-    void TInvokeRequestHandlerActor::SelfHealStateStorage(ui32 waitForConfigStep, bool forceHeal) {
+    void TInvokeRequestHandlerActor::SelfHealStateStorage(ui32 waitForConfigStep, bool forceHeal, bool pileupReplicas) {
         RunCommonChecks();
+        STLOG(PRI_DEBUG, BS_NODE, NW105, "TInvokeRequestHandlerActor::SelfHealStateStorage", (waitForConfigStep, waitForConfigStep), (forceHeal, forceHeal), (pileupReplicas, pileupReplicas));
         NKikimrBlobStorage::TStateStorageConfig targetConfig;
-        if (!GetRecommendedStateStorageConfig(&targetConfig) && !forceHeal) {
+        if (!GetRecommendedStateStorageConfig(&targetConfig, pileupReplicas) && !forceHeal) {
             throw TExError() << "Recommended configuration has faulty nodes and can not be applyed";
         }
 
@@ -167,7 +174,7 @@ namespace NKikimr::NStorage {
                     }
                 }
             }
-            if (!hasBadNodes) {
+            if (!hasBadNodes && !pileupReplicas) {
                 return ReconfigType::NONE; // Current config is optimal and all nodes are good
             }
 
@@ -436,8 +443,10 @@ namespace NKikimr::NStorage {
                             found = true;
                             if (!cmd.GetDisableRing()) {
                                 ring->MutableNode()->Set(i, cmd.GetTo());
+                                ring->ClearIsDisabled();
+                            } else {
+                                ring->SetIsDisabled(true);
                             }
-                            ring->SetIsDisabled(cmd.GetDisableRing());
                         }
                     }
                 };

--- a/ydb/core/cms/config.h
+++ b/ydb/core/cms/config.h
@@ -20,6 +20,27 @@ struct TCmsSentinelConfig {
         ui32 NodePrettyGoodStateLimit;
         TDuration WaitForConfigStep;
         TDuration RelaxTime;
+        bool PileupReplicas;
+
+        void Serialize(NKikimrCms::TCmsConfig::TSentinelConfig::TStateStorageSelfHealConfig &config) const {
+            config.SetEnable(Enable);
+            config.SetNodeBadStateLimit(NodeBadStateLimit);
+            config.SetNodeGoodStateLimit(NodeGoodStateLimit);
+            config.SetNodePrettyGoodStateLimit(NodePrettyGoodStateLimit);
+            config.SetWaitForConfigStep(WaitForConfigStep.GetValue());
+            config.SetRelaxTime(RelaxTime.GetValue());
+            config.SetPileupReplicas(PileupReplicas);
+        }
+
+        void Deserialize(const NKikimrCms::TCmsConfig::TSentinelConfig::TStateStorageSelfHealConfig &config) {
+            Enable = config.GetEnable();
+            NodeBadStateLimit = config.GetNodeBadStateLimit();
+            NodeGoodStateLimit = config.GetNodeGoodStateLimit();
+            NodePrettyGoodStateLimit = config.GetNodePrettyGoodStateLimit();
+            WaitForConfigStep = TDuration::MicroSeconds(config.GetWaitForConfigStep());
+            RelaxTime = TDuration::MicroSeconds(config.GetRelaxTime());
+            PileupReplicas = config.GetPileupReplicas();
+        }
     };
 
     bool Enable = true;
@@ -60,13 +81,7 @@ struct TCmsSentinelConfig {
         config.SetDefaultStateLimit(DefaultStateLimit);
         config.SetGoodStateLimit(GoodStateLimit);
 
-        auto* ssConfig = config.MutableStateStorageSelfHealConfig();
-        ssConfig->SetEnable(StateStorageSelfHealConfig.Enable);
-        ssConfig->SetWaitForConfigStep(StateStorageSelfHealConfig.WaitForConfigStep.GetValue());
-        ssConfig->SetRelaxTime(StateStorageSelfHealConfig.RelaxTime.GetValue());
-        ssConfig->SetNodeBadStateLimit(StateStorageSelfHealConfig.NodeBadStateLimit);
-        ssConfig->SetNodeGoodStateLimit(StateStorageSelfHealConfig.NodeGoodStateLimit);
-        ssConfig->SetNodePrettyGoodStateLimit(StateStorageSelfHealConfig.NodePrettyGoodStateLimit);
+        StateStorageSelfHealConfig.Serialize(*config.MutableStateStorageSelfHealConfig());
 
         config.SetDataCenterRatio(DataCenterRatio);
         config.SetRoomRatio(RoomRatio);
@@ -95,13 +110,7 @@ struct TCmsSentinelConfig {
         PileRatio = config.GetPileRatio();
         FaultyPDisksThresholdPerNode = config.GetFaultyPDisksThresholdPerNode();
 
-        auto& ssConfig = config.GetStateStorageSelfHealConfig();
-        StateStorageSelfHealConfig.Enable = ssConfig.GetEnable();
-        StateStorageSelfHealConfig.NodeBadStateLimit = ssConfig.GetNodeBadStateLimit();
-        StateStorageSelfHealConfig.NodeGoodStateLimit = ssConfig.GetNodeGoodStateLimit();
-        StateStorageSelfHealConfig.NodePrettyGoodStateLimit = ssConfig.GetNodePrettyGoodStateLimit();
-        StateStorageSelfHealConfig.WaitForConfigStep = TDuration::MicroSeconds(ssConfig.GetWaitForConfigStep());
-        StateStorageSelfHealConfig.RelaxTime = TDuration::MicroSeconds(ssConfig.GetRelaxTime());
+        StateStorageSelfHealConfig.Deserialize(config.GetStateStorageSelfHealConfig());
 
         auto newStateLimits = LoadStateLimits(config);
         StateLimits.swap(newStateLimits);

--- a/ydb/core/cms/sentinel.cpp
+++ b/ydb/core/cms/sentinel.cpp
@@ -1150,6 +1150,7 @@ class TSentinel: public TActorBootstrapped<TSentinel> {
         auto* updateRequest = request->Record.MutableSelfHealNodesStateUpdate();
         updateRequest->SetWaitForConfigStep(Config.StateStorageSelfHealConfig.WaitForConfigStep.GetValue() / 1000000); // milliseconds -> seconds
         updateRequest->SetEnableSelfHealStateStorage(Config.StateStorageSelfHealConfig.Enable);
+        updateRequest->SetPileupReplicas(Config.StateStorageSelfHealConfig.PileupReplicas);
         for (auto& [nodeId, node] : SentinelState->Nodes) {
             SentinelState->NeedSelfHealStateStorage |= node.Compute();
             auto* nodeState = updateRequest->AddNodesState();

--- a/ydb/core/protos/blobstorage_distributed_config.proto
+++ b/ydb/core/protos/blobstorage_distributed_config.proto
@@ -234,11 +234,13 @@ message TEvNodeConfigInvokeOnRoot {
 
     message TGetStateStorageConfig {
         optional bool Recommended = 1;
+        optional bool PileupReplicas = 2;
     }
 
     message TSelfHealStateStorage {
         optional uint32 WaitForConfigStep = 1;
         optional bool ForceHeal = 2;
+        optional bool PileupReplicas = 3;
     }
 
     message TSelfHealNodesStateUpdate {
@@ -249,6 +251,7 @@ message TEvNodeConfigInvokeOnRoot {
         optional bool EnableSelfHealStateStorage = 1;
         optional uint32 WaitForConfigStep = 2;
         repeated TNodeState NodesState = 3;
+        optional bool PileupReplicas = 4;
     }
 
     message TAdvanceGeneration

--- a/ydb/core/protos/cms.proto
+++ b/ydb/core/protos/cms.proto
@@ -427,12 +427,13 @@ message TCmsConfig {
 
     message TSentinelConfig {
         message TStateStorageSelfHealConfig {
-            optional bool Enable = 19 [default = true];
-            optional uint32 NodeGoodStateLimit = 20 [default = 10];
-            optional uint32 NodePrettyGoodStateLimit = 21 [default = 7];
-            optional uint32 NodeBadStateLimit = 22 [default = 10];
-            optional uint32 WaitForConfigStep = 23 [default = 60000000];
-            optional uint32 RelaxTime = 24 [default = 600000000];
+            optional bool Enable = 1 [default = true];
+            optional uint32 NodeGoodStateLimit = 2 [default = 10];
+            optional uint32 NodePrettyGoodStateLimit = 3 [default = 7];
+            optional uint32 NodeBadStateLimit = 4 [default = 10];
+            optional uint32 WaitForConfigStep = 5 [default = 60000000];
+            optional uint32 RelaxTime = 6 [default = 600000000];
+            optional bool PileupReplicas = 7 [default = false];
         }
 
         message TStateLimit {


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

PileupReplicas option introduced. It will helps to rollback to config V1 if needed.

### Changelog category <!-- remove all except one -->

* Not for changelog (changelog entry is not required)

### Description for reviewers <!-- (optional) description for those who read this PR -->

...
