### PR TITLE
Regenerate lambda type annotations for DqHashCombine

### DIFF
--- a/ydb/library/yql/dq/opt/dq_opt_peephole.cpp
+++ b/ydb/library/yql/dq/opt/dq_opt_peephole.cpp
@@ -1046,18 +1046,14 @@ NNodes::TExprBase DqPeepholeRewriteWideCombiner([[maybe_unused]] const NNodes::T
         return node;
     }
 
-    auto cloneLambda = [&](const auto& lambdaStub) {
-        return lambdaStub.Ptr(); // we could do a deep copy via ctx.DeepCopyLambda(lambdaStub.Ref()) but we would lose types and constraints
-    };
-
     auto inputFromFlow = NNodes::TExprBase(ctx.Builder(node.Pos()).Callable("FromFlow").Add(0, wideCombiner.Input().Ptr()).Seal().Build());
     auto dqPhyCombine = Build<TDqPhyHashCombine>(ctx, node.Pos())
         .Input(inputFromFlow)
         .MemLimit(wideCombiner.MemLimit())
-        .KeyExtractor(cloneLambda(wideCombiner.KeyExtractor()))
-        .InitHandler(cloneLambda(wideCombiner.InitHandler()))
-        .UpdateHandler(cloneLambda(wideCombiner.UpdateHandler()))
-        .FinishHandler(cloneLambda(wideCombiner.FinishHandler()))
+        .KeyExtractor(wideCombiner.KeyExtractor().Ptr())
+        .InitHandler(wideCombiner.InitHandler().Ptr())
+        .UpdateHandler(wideCombiner.UpdateHandler().Ptr())
+        .FinishHandler(wideCombiner.FinishHandler().Ptr())
     .Done();
 
     return NNodes::TExprBase(

--- a/ydb/library/yql/dq/opt/dq_opt_peephole.cpp
+++ b/ydb/library/yql/dq/opt/dq_opt_peephole.cpp
@@ -1046,14 +1046,18 @@ NNodes::TExprBase DqPeepholeRewriteWideCombiner([[maybe_unused]] const NNodes::T
         return node;
     }
 
+    auto copyLambda = [&](const auto& prev) {
+        return ctx.DeepCopyLambda(prev.Ref());
+    };
+
     auto inputFromFlow = NNodes::TExprBase(ctx.Builder(node.Pos()).Callable("FromFlow").Add(0, wideCombiner.Input().Ptr()).Seal().Build());
     auto dqPhyCombine = Build<TDqPhyHashCombine>(ctx, node.Pos())
         .Input(inputFromFlow)
         .MemLimit(wideCombiner.MemLimit())
-        .KeyExtractor(wideCombiner.KeyExtractor().Ptr())
-        .InitHandler(wideCombiner.InitHandler().Ptr())
-        .UpdateHandler(wideCombiner.UpdateHandler().Ptr())
-        .FinishHandler(wideCombiner.FinishHandler().Ptr())
+        .KeyExtractor(copyLambda(wideCombiner.KeyExtractor()))
+        .InitHandler(copyLambda(wideCombiner.InitHandler()))
+        .UpdateHandler(copyLambda(wideCombiner.UpdateHandler()))
+        .FinishHandler(copyLambda(wideCombiner.FinishHandler()))
     .Done();
 
     return NNodes::TExprBase(

--- a/ydb/library/yql/dq/type_ann/dq_type_ann.cpp
+++ b/ydb/library/yql/dq/type_ann/dq_type_ann.cpp
@@ -1278,7 +1278,7 @@ TStatus AnnotateDqHashCombine(const TExprNode::TPtr& input, TExprContext& ctx) {
         return TStatus::Error;
     }
 
-    auto& inputStream = input->ChildRef(0);
+    auto& inputStream = input->ChildRef(TDqPhyHashCombine::idx_Input);
     if (!EnsureStreamType(*inputStream, ctx)) {
         return TStatus::Error;
     }
@@ -1290,7 +1290,7 @@ TStatus AnnotateDqHashCombine(const TExprNode::TPtr& input, TExprContext& ctx) {
     auto itemTypes = multiType->Cast<TMultiExprType>()->GetItems();
 
     // key extractor lambda
-    auto& keyExtractor = input->ChildRef(2);
+    auto& keyExtractor = input->ChildRef(TDqPhyHashCombine::idx_KeyExtractor);
     auto status = ConvertToLambda(keyExtractor, ctx, itemTypes.size());
     if (status.Level != TStatus::Ok) {
         return status;
@@ -1315,7 +1315,7 @@ TStatus AnnotateDqHashCombine(const TExprNode::TPtr& input, TExprContext& ctx) {
     }
 
     // state init lambda
-    auto& initHandler = input->ChildRef(3);
+    auto& initHandler = input->ChildRef(TDqPhyHashCombine::idx_InitHandler);
     TTypeAnnotationNode::TListType initArgTypes = keyTypes;
     initArgTypes.insert(initArgTypes.end(), itemTypes.begin(), itemTypes.end());
     status = ConvertToLambda(initHandler, ctx, initArgTypes.size());
@@ -1338,7 +1338,7 @@ TStatus AnnotateDqHashCombine(const TExprNode::TPtr& input, TExprContext& ctx) {
     }
 
     // state update lambda
-    auto& updateHandler = input->ChildRef(4);
+    auto& updateHandler = input->ChildRef(TDqPhyHashCombine::idx_UpdateHandler);
     TTypeAnnotationNode::TListType updateArgTypes = keyTypes;
     updateArgTypes.insert(updateArgTypes.end(), itemTypes.begin(), itemTypes.end());
     updateArgTypes.insert(updateArgTypes.end(), stateTypes.begin(), stateTypes.end());
@@ -1354,7 +1354,7 @@ TStatus AnnotateDqHashCombine(const TExprNode::TPtr& input, TExprContext& ctx) {
     }
 
     // finalize output lambda
-    auto& finishHandler = input->ChildRef(5);
+    auto& finishHandler = input->ChildRef(TDqPhyHashCombine::idx_FinishHandler);
     TTypeAnnotationNode::TListType finishArgTypes = keyTypes;
     finishArgTypes.insert(finishArgTypes.end(), stateTypes.begin(), stateTypes.end());
     status = ConvertToLambda(finishHandler, ctx, finishArgTypes.size());

--- a/ydb/library/yql/dq/type_ann/dq_type_ann.cpp
+++ b/ydb/library/yql/dq/type_ann/dq_type_ann.cpp
@@ -1278,20 +1278,104 @@ TStatus AnnotateDqHashCombine(const TExprNode::TPtr& input, TExprContext& ctx) {
         return TStatus::Error;
     }
 
-    if (!input->Child(5)->GetTypeAnn()) {
+    auto& inputStream = input->ChildRef(0);
+    if (!EnsureStreamType(*inputStream, ctx)) {
         return TStatus::Error;
     }
-
-    const auto* outputTypeAnn = input->Child(5)->GetTypeAnn();
-    if (!outputTypeAnn) {
+    auto streamType = inputStream->GetTypeAnn()->Cast<TStreamExprType>();
+    auto multiType = streamType->GetItemType();
+    if (!EnsureMultiType(inputStream->Pos(), *multiType, ctx)) {
         return TStatus::Error;
     }
-    if (outputTypeAnn->GetKind() != ETypeAnnotationKind::Multi) {
-        TTypeAnnotationNode::TListType wrapper {outputTypeAnn};
-        outputTypeAnn = ctx.MakeType<TMultiExprType>(wrapper);
-    }
-    input->SetTypeAnn(ctx.MakeType<TStreamExprType>(outputTypeAnn));
+    auto itemTypes = multiType->Cast<TMultiExprType>()->GetItems();
 
+    // key extractor lambda
+    auto& keyExtractor = input->ChildRef(2);
+    auto status = ConvertToLambda(keyExtractor, ctx, itemTypes.size());
+    if (status.Level != TStatus::Ok) {
+        return status;
+    }
+    if (!UpdateLambdaAllArgumentsTypes(keyExtractor, itemTypes, ctx)) {
+        return TStatus::Error;
+    }
+    if (!keyExtractor->GetTypeAnn()) {
+        return TStatus::Repeat;
+    }
+
+    TTypeAnnotationNode::TListType keyTypes;
+    for (ui32 i = 1; i < keyExtractor->ChildrenSize(); ++i) {
+        auto childType = keyExtractor->Child(i)->GetTypeAnn();
+        keyTypes.emplace_back(childType);
+        if (!EnsureHashableKey(keyExtractor->Child(i)->Pos(), childType, ctx)) {
+            return TStatus::Error;
+        }
+        if (!EnsureEquatableKey(keyExtractor->Child(i)->Pos(), childType, ctx)) {
+            return TStatus::Error;
+        }
+    }
+
+    // state init lambda
+    auto& initHandler = input->ChildRef(3);
+    TTypeAnnotationNode::TListType initArgTypes = keyTypes;
+    initArgTypes.insert(initArgTypes.end(), itemTypes.begin(), itemTypes.end());
+    status = ConvertToLambda(initHandler, ctx, initArgTypes.size());
+    if (status.Level != TStatus::Ok) {
+        return status;
+    }
+    if (!UpdateLambdaAllArgumentsTypes(initHandler, initArgTypes, ctx)) {
+        return TStatus::Error;
+    }
+    if (!initHandler->GetTypeAnn()) {
+        return TStatus::Repeat;
+    }
+    TTypeAnnotationNode::TListType stateTypes;
+    for (ui32 i = 1; i < initHandler->ChildrenSize(); ++i) {
+        auto childType = initHandler->Child(i)->GetTypeAnn();
+        stateTypes.emplace_back(childType);
+        if (!EnsureComputableType(initHandler->Child(i)->Pos(), *childType, ctx)) {
+            return TStatus::Error;
+        }
+    }
+
+    // state update lambda
+    auto& updateHandler = input->ChildRef(4);
+    TTypeAnnotationNode::TListType updateArgTypes = keyTypes;
+    updateArgTypes.insert(updateArgTypes.end(), itemTypes.begin(), itemTypes.end());
+    updateArgTypes.insert(updateArgTypes.end(), stateTypes.begin(), stateTypes.end());
+    status = ConvertToLambda(updateHandler, ctx, updateArgTypes.size());
+    if (status.Level != TStatus::Ok) {
+        return status;
+    }
+    if (!UpdateLambdaAllArgumentsTypes(updateHandler, updateArgTypes, ctx)) {
+        return TStatus::Error;
+    }
+    if (!updateHandler->GetTypeAnn()) {
+        return TStatus::Repeat;
+    }
+
+    // finalize output lambda
+    auto& finishHandler = input->ChildRef(5);
+    TTypeAnnotationNode::TListType finishArgTypes = keyTypes;
+    finishArgTypes.insert(finishArgTypes.end(), stateTypes.begin(), stateTypes.end());
+    status = ConvertToLambda(finishHandler, ctx, finishArgTypes.size());
+    if (status.Level != TStatus::Ok) {
+        return status;
+    }
+    if (!UpdateLambdaAllArgumentsTypes(finishHandler, finishArgTypes, ctx)) {
+        return TStatus::Error;
+    }
+    if (!finishHandler->GetTypeAnn()) {
+        return TStatus::Repeat;
+    }
+
+    // Derive the output type from the finishHandler
+    TTypeAnnotationNode::TListType finishOutputTypes;
+    for (ui32 i = 1; i < finishHandler->ChildrenSize(); ++i) {
+        finishOutputTypes.emplace_back(finishHandler->Child(i)->GetTypeAnn());
+    }
+    auto finishOutputType = ctx.MakeType<TMultiExprType>(finishOutputTypes);
+
+    input->SetTypeAnn(ctx.MakeType<TStreamExprType>(finishOutputType));
     return TStatus::Ok;
 }
 


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

...

### Changelog category <!-- remove all except one -->

* Not for changelog (changelog entry is not required)

### Description for reviewers <!-- (optional) description for those who read this PR -->

Don't reuse existing type annotations on lambdas when in-place replacing the WideCombiner. Generate a set of new lambdas with the same type annotations.