### PR TITLE
Extract transaction-related code from Private Cache

### DIFF
--- a/ydb/core/tablet_flat/flat_exec_seat.h
+++ b/ydb/core/tablet_flat/flat_exec_seat.h
@@ -71,7 +71,7 @@ namespace NTabletFlatExecutor {
         const TTxType TxType;
         NWilson::TSpan WaitingSpan;
         ui64 Retries = 0;
-        TPrivatePageCache::TPinned Pinned;
+        THashMap<TLogoBlobID, THashMap<TPageId, TPrivatePageCache::TPinnedPage>> Pinned;
 
         THPTimer LatencyTimer;
         THPTimer CommitTimer;

--- a/ydb/core/tablet_flat/flat_executor.cpp
+++ b/ydb/core/tablet_flat/flat_executor.cpp
@@ -731,8 +731,9 @@ void TExecutor::AddCachesOfBundle(const NTable::TPartView &partView, const THash
 
 void TExecutor::AddSingleCache(const TIntrusivePtr<TPrivatePageCache::TInfo> &info)
 {
-    PrivatePageCache->AddPageCollection(info);
+    auto sharedCacheTouches = PrivatePageCache->AddPageCollection(info);
     Send(MakeSharedPageCacheId(), new NSharedCache::TEvAttach(info->PageCollection, info->GetCacheMode()));
+    SendSharedCacheTouches(std::move(sharedCacheTouches));
 
     StickyPagesMemory += info->GetStickySize();
     TryKeepInMemoryMemory += info->GetTryKeepInMemorySize();
@@ -781,8 +782,7 @@ void TExecutor::DropSingleCache(const TLogoBlobID &label)
     Counters->Simple()[TExecutorCounters::CACHE_TOTAL_TRY_KEEP_IN_MEMORY] = TryKeepInMemoryMemory;
 }
 
-void TExecutor::TranslateCacheTouchesToSharedCache() {
-    auto touches = PrivatePageCache->GetSharedCacheTouches();
+void TExecutor::SendSharedCacheTouches(THashMap<TLogoBlobID, THashSet<TPageId>>&& touches) {
     if (touches.empty())
         return;
     Send(MakeSharedPageCacheId(), new NSharedCache::TEvTouch(std::move(touches)));
@@ -2058,8 +2058,7 @@ void TExecutor::ExecuteTransaction(TSeat* seat) {
 
     THPTimer cpuTimer;
 
-    PrivatePageCache->BeginTransaction(&seat->Pinned);
-    TPageCollectionTxEnv env(*Database, *PrivatePageCache);
+    TPageCollectionTxEnv env(*Database, *PrivatePageCache, *seat);
 
     TTransactionContext txc(Owner->TabletID(), Generation(), Step(), *Database, env, seat->CurrentTxDataLimit, seat->TaskId, seat->Self->TxSpan);
     txc.NotEnoughMemory(seat->NotEnoughMemoryCount);
@@ -2143,13 +2142,12 @@ void TExecutor::ExecuteTransaction(TSeat* seat) {
         CommitTransactionLog(RemoveTransaction(seat->UniqID), env, prod.Change, cpuTimer);
     } else {
         Y_ENSURE(!seat->CapturedMemory);
-        if (!PrivatePageCache->GetStats().ToLoadCount && !seat->RequestedMemory && !txc.IsRescheduled()) {
+        if (!env.GetStats().ToLoadCount && !seat->RequestedMemory && !txc.IsRescheduled()) {
             Y_TABLET_ERROR(NFmt::Do(*this) << " " << NFmt::Do(*seat) << " type "
                     << NFmt::Do(*seat->Self) << " postponed w/o demands");
         }
         PostponeTransaction(seat, env, prod.Change, cpuTimer);
     }
-    PrivatePageCache->EndTransaction();
 
     activeTransaction.Done();
     PlanTransactionActivation();
@@ -2159,7 +2157,6 @@ void TExecutor::UnpinTransactionPages(TSeat &seat) {
     Y_ENSURE(TransactionPagesMemory >= seat.MemoryTouched);
     TransactionPagesMemory -= seat.MemoryTouched;
 
-    PrivatePageCache->TranslatePinnedToSharedCacheTouches();
     seat.Pinned.clear();
     seat.MemoryTouched = 0;
 
@@ -2189,11 +2186,11 @@ void TExecutor::PostponeTransaction(TSeat* seat, TPageCollectionTxEnv &env,
 {
     TTxType txType = seat->TxType;
 
-    seat->MemoryTouched += PrivatePageCache->GetStats().NewlyPinnedSize;
-    TransactionPagesMemory += PrivatePageCache->GetStats().NewlyPinnedSize;
+    seat->MemoryTouched += env.GetStats().NewlyPinnedSize;
+    TransactionPagesMemory += env.GetStats().NewlyPinnedSize;
 
-    seat->MemoryTouched += PrivatePageCache->GetStats().ToLoadSize;
-    TransactionPagesMemory += PrivatePageCache->GetStats().ToLoadSize;
+    seat->MemoryTouched += env.GetStats().ToLoadSize;
+    TransactionPagesMemory += env.GetStats().ToLoadSize;
 
     if (seat->AttachedMemory)
         Memory->AttachMemory(*seat);
@@ -2204,10 +2201,10 @@ void TExecutor::PostponeTransaction(TSeat* seat, TPageCollectionTxEnv &env,
     if (auto logl = Logger->Log(ELnLev::Debug)) {
         logl
             << NFmt::Do(*this) << " " << NFmt::Do(*seat)
-            << " pin " << PrivatePageCache->GetStats().NewlyPinnedCount
-            << " (" << PrivatePageCache->GetStats().NewlyPinnedSize << " b)"
-            << " load " << PrivatePageCache->GetStats().ToLoadCount
-            << " (" << PrivatePageCache->GetStats().ToLoadSize << " b)";
+            << " pin " << env.GetStats().NewlyPinnedCount
+            << " (" << env.GetStats().NewlyPinnedSize << " b)"
+            << " load " << env.GetStats().ToLoadCount
+            << " (" << env.GetStats().ToLoadSize << " b)";
     }
 
     // Check if additional resources should be requested.
@@ -2260,7 +2257,7 @@ void TExecutor::PostponeTransaction(TSeat* seat, TPageCollectionTxEnv &env,
 
     // If memory was allocated and there is nothing to load
     // then tx may be re-activated.
-    if (!PrivatePageCache->GetStats().ToLoadCount) {
+    if (!env.GetStats().ToLoadCount) {
         EnqueueActivation(seat, CanExecuteTransaction());
         return;
     }
@@ -2270,7 +2267,7 @@ void TExecutor::PostponeTransaction(TSeat* seat, TPageCollectionTxEnv &env,
     auto waitPad = MakeIntrusive<TTransactionWaitPad>(seat);
     TransactionWaitPads[waitPad.Get()] = waitPad;
 
-    auto toLoad = PrivatePageCache->GetToLoad();
+    auto toLoad = env.ObtainToLoad();
     for (auto &[pageCollectionId, pages] : toLoad) {
         Y_DEBUG_ABORT_UNLESS(pages);
 
@@ -2294,8 +2291,8 @@ void TExecutor::PostponeTransaction(TSeat* seat, TPageCollectionTxEnv &env,
     if (auto logl = Logger->Log(ELnLev::Debug)) {
         logl
             << NFmt::Do(*this) << " " << NFmt::Do(*seat) << " postponed"
-            << ", loading " << PrivatePageCache->GetStats().ToLoadCount << " pages, " << PrivatePageCache->GetStats().ToLoadSize << " bytes"
-            << ", newly pinned " << PrivatePageCache->GetStats().NewlyPinnedCount << " pages, " << PrivatePageCache->GetStats().NewlyPinnedSize << " bytes";
+            << ", loading " << env.GetStats().ToLoadCount << " pages, " << env.GetStats().ToLoadSize << " bytes"
+            << ", newly pinned " << env.GetStats().NewlyPinnedCount << " pages, " << env.GetStats().NewlyPinnedSize << " bytes";
     }
 
     seat->CPUBookkeepingTime += bookkeepingTimer.PassedReset();
@@ -2305,17 +2302,17 @@ void TExecutor::PostponeTransaction(TSeat* seat, TPageCollectionTxEnv &env,
         AppTxCounters->TxCumulative(txType, COUNTER_TT_POSTPONED).Increment(1);
 
     // Note: previously counted non-unique cache hits for all retries
-    Counters->Cumulative()[TExecutorCounters::TX_CACHE_HITS].Increment(PrivatePageCache->GetStats().NewlyPinnedCount);
-    Counters->Cumulative()[TExecutorCounters::TX_BYTES_CACHED].Increment(PrivatePageCache->GetStats().NewlyPinnedSize);
+    Counters->Cumulative()[TExecutorCounters::TX_CACHE_HITS].Increment(env.GetStats().NewlyPinnedCount);
+    Counters->Cumulative()[TExecutorCounters::TX_BYTES_CACHED].Increment(env.GetStats().NewlyPinnedSize);
     if (seat->Retries == 1) {
         Counters->Cumulative()[TExecutorCounters::TX_RETRIED].Increment(1);
     }
 
-    Counters->Cumulative()[TExecutorCounters::TX_CACHE_MISSES].Increment(PrivatePageCache->GetStats().ToLoadCount);
-    Counters->Cumulative()[TExecutorCounters::TX_BYTES_READ].Increment(PrivatePageCache->GetStats().ToLoadSize);
+    Counters->Cumulative()[TExecutorCounters::TX_CACHE_MISSES].Increment(env.GetStats().ToLoadCount);
+    Counters->Cumulative()[TExecutorCounters::TX_BYTES_READ].Increment(env.GetStats().ToLoadSize);
     if (AppTxCounters && txType != UnknownTxType) {
-        AppTxCounters->TxCumulative(txType, COUNTER_TT_LOADED_BLOCKS).Increment(PrivatePageCache->GetStats().ToLoadCount);
-        AppTxCounters->TxCumulative(txType, COUNTER_TT_BYTES_READ).Increment(PrivatePageCache->GetStats().ToLoadSize);
+        AppTxCounters->TxCumulative(txType, COUNTER_TT_LOADED_BLOCKS).Increment(env.GetStats().ToLoadCount);
+        AppTxCounters->TxCumulative(txType, COUNTER_TT_BYTES_READ).Increment(env.GetStats().ToLoadSize);
     }
 
     Counters->Simple()[TExecutorCounters::CACHE_TOTAL_USED] = TransactionPagesMemory;
@@ -2327,15 +2324,16 @@ void TExecutor::CommitTransactionLog(std::unique_ptr<TSeat> seat, TPageCollectio
     const TTxType txType = seat->TxType;
 
     // Note: previously counted count (not size), but it requires an additional counter
-    size_t touchedBlocks = PrivatePageCache->GetStats().NewlyPinnedSize + seat->MemoryTouched;
+    size_t touchedBlocks = env.GetStats().NewlyPinnedSize + seat->MemoryTouched;
     Counters->Percentile()[TExecutorCounters::TX_PERCENTILE_TOUCHED_BLOCKS].IncrementFor(touchedBlocks);
     if (AppTxCounters && txType != UnknownTxType)
         AppTxCounters->TxCumulative(txType, COUNTER_TT_TOUCHED_BLOCKS).Increment(touchedBlocks);
 
     // Note: previously counted non-unique cache hits for all retries
-    Counters->Cumulative()[TExecutorCounters::TX_CACHE_HITS].Increment(PrivatePageCache->GetStats().NewlyPinnedCount);
-    Counters->Cumulative()[TExecutorCounters::TX_BYTES_CACHED].Increment(PrivatePageCache->GetStats().NewlyPinnedSize);
+    Counters->Cumulative()[TExecutorCounters::TX_CACHE_HITS].Increment(env.GetStats().NewlyPinnedCount);
+    Counters->Cumulative()[TExecutorCounters::TX_BYTES_CACHED].Increment(env.GetStats().NewlyPinnedSize);
 
+    SendSharedCacheTouches(env.ObtainSharedCacheTouches());
     UnpinTransactionPages(*seat);
 
     Memory->ReleaseMemory(*seat);
@@ -4365,8 +4363,6 @@ STFUNC(TExecutor::StateWork) {
     default:
         break;
     }
-
-    TranslateCacheTouchesToSharedCache();
 }
 
 STFUNC(TExecutor::StateFollower) {
@@ -4386,8 +4382,6 @@ STFUNC(TExecutor::StateFollower) {
     default:
         break;
     }
-
-    TranslateCacheTouchesToSharedCache();
 }
 
 STFUNC(TExecutor::StateFollowerBoot) {

--- a/ydb/core/tablet_flat/flat_executor.h
+++ b/ydb/core/tablet_flat/flat_executor.h
@@ -556,7 +556,7 @@ class TExecutor
     void DropCachesOfBundle(const NTable::TPart &part);
     void DropSingleCache(const TLogoBlobID&);
 
-    void TranslateCacheTouchesToSharedCache();
+    void SendSharedCacheTouches(THashMap<TLogoBlobID, THashSet<TPageId>>&& touches);
     void UpdateCacheModesForPartStore(NTable::TPartView& partView, const THashMap<NTable::TTag, ECacheMode>& cacheModes);
     void UpdateCachePagesForDatabase(bool pendingOnly = false);
     void RequestInMemPagesForPartStore(NTable::TPartView& partView, const THashSet<NTable::TTag>& stickyColumns);

--- a/ydb/core/tablet_flat/flat_executor_tx_env.h
+++ b/ydb/core/tablet_flat/flat_executor_tx_env.h
@@ -91,7 +91,7 @@ namespace NTabletFlatExecutor {
                 return &pinnedPage->PinnedBody;
             }
 
-            auto sharedBody = Cache.Lookup(pageId, info);
+            auto sharedBody = Cache.TryGetPage(pageId, info);
 
             if (!sharedBody) {
                 ToLoadPage(pageId, info);

--- a/ydb/core/tablet_flat/flat_executor_tx_env.h
+++ b/ydb/core/tablet_flat/flat_executor_tx_env.h
@@ -1,5 +1,6 @@
 #pragma once
 #include "defs.h"
+#include "flat_exec_seat.h"
 #include "flat_table_misc.h"
 #include "flat_part_store.h"
 #include "flat_store_hotdog.h"
@@ -15,9 +16,22 @@ namespace NKikimr {
 namespace NTabletFlatExecutor {
 
     struct TPageCollectionReadEnv : public NTable::IPages {
-        TPageCollectionReadEnv(TPrivatePageCache& cache)
+        TPageCollectionReadEnv(TPrivatePageCache& cache, TSeat& seat)
             : Cache(cache)
+            , Seat(seat)
         { }
+
+        using TInfo = TPrivatePageCache::TInfo;
+
+        struct TStats {
+            size_t NewlyPinnedCount = 0;
+            ui64 NewlyPinnedSize = 0;
+    
+            size_t ToLoadCount = 0;
+            ui64 ToLoadSize = 0;
+        };
+
+        const TStats& GetStats() const { return Stats; }
 
     protected: /* NTable::IPages, page collection backend implementation */
         TResult Locate(const TMemTable *memTable, ui64 ref, ui32 tag) override
@@ -29,7 +43,7 @@ namespace NTabletFlatExecutor {
         {
             auto *partStore = CheckedCast<const NTable::TPartStore*>(part);
 
-            const TSharedData* page = Lookup(partStore->Locate(lob, ref), ref);
+            const TSharedData* page = Lookup(ref, partStore->Locate(lob, ref));
 
             if (!page && ReadMissingReferences) {
                 MissingReferencesSize_ += Max<ui64>(1, part->GetPageSize(lob, ref));
@@ -42,7 +56,7 @@ namespace NTabletFlatExecutor {
         {
             auto *partStore = CheckedCast<const NTable::TPartStore*>(part);
 
-            return Lookup(partStore->PageCollections.at(groupId.Index).Get(), pageId);
+            return Lookup(pageId, partStore->PageCollections.at(groupId.Index).Get());
         }
 
         void EnableReadMissingReferences() {
@@ -60,23 +74,82 @@ namespace NTabletFlatExecutor {
         }
 
     private:
-        const TSharedData* Lookup(TPrivatePageCache::TInfo *info, TPageId pageId)
+        void ToLoadPage(TPageId pageId, TInfo *info) {
+            if (ToLoad[info->Id].insert(pageId).second) {
+                Stats.ToLoadCount++;
+                Y_ASSERT(!info->IsStickyPage(pageId));
+                Stats.ToLoadSize += info->GetPageSize(pageId);
+            }
+        }
+
+        const TSharedData* Lookup(TPageId pageId, TInfo *info)
         {
-            return Cache.Lookup(pageId, info);
+            auto& pinnedCollection = Seat.Pinned[info->Id];
+            auto* pinnedPage = pinnedCollection.FindPtr(pageId);
+            if (pinnedPage) {
+                // pinned pages do not need to be counted again
+                return &pinnedPage->PinnedBody;
+            }
+
+            auto sharedBody = Cache.Lookup(pageId, info);
+
+            if (!sharedBody) {
+                ToLoadPage(pageId, info);
+                return nullptr;
+            }
+
+            auto emplaced = pinnedCollection.emplace(pageId, TPrivatePageCache::TPinnedPage(std::move(sharedBody)));
+            Y_ENSURE(emplaced.second);
+            auto& pinnedBody = emplaced.first->second.PinnedBody;
+
+            Stats.NewlyPinnedCount++;
+            if (!info->IsStickyPage(pageId)) {
+                Stats.NewlyPinnedSize += pinnedBody.size();
+            }
+            
+            return &pinnedBody;
         }
 
     public:
-        TPrivatePageCache& Cache;
-    
-    private:
-        bool ReadMissingReferences = false;
+        auto ObtainToLoad() {
+            THashMap<TLogoBlobID, TVector<TPageId>> result;
+            for (auto& [pageCollectionId, pages_] : ToLoad) {
+                TVector<TPageId> pages(pages_.begin(), pages_.end());
+                std::sort(pages.begin(), pages.end());
+                result.emplace(pageCollectionId, std::move(pages));
+            }
+            ToLoad.clear();
+            return result;
+        }
+        
+        auto ObtainSharedCacheTouches() {
+            THashMap<TLogoBlobID, THashSet<TPageId>> result;
+            for (const auto& [pageCollectionId, pages] : Seat.Pinned) {
+                if (Cache.FindPageCollection(pageCollectionId)) {
+                    auto& touches = result[pageCollectionId];
+                    for (const auto& [pageId, pinnedPageRef] : pages) {
+                        touches.insert(pageId);
+                    }
+                }
+            }
+            return result;
+        }
 
+    private:
+        TPrivatePageCache& Cache;
+        TSeat& Seat;
+
+        THashMap<TLogoBlobID, THashSet<TPageId>> ToLoad;
+    
+        bool ReadMissingReferences = false;
         ui64 MissingReferencesSize_ = 0;
+
+        TStats Stats;
     };
 
     struct TPageCollectionTxEnv : public TPageCollectionReadEnv, public IExecuting {
-        TPageCollectionTxEnv(NTable::TDatabase& db, TPrivatePageCache& cache)
-            : TPageCollectionReadEnv(cache)
+        TPageCollectionTxEnv(NTable::TDatabase& db, TPrivatePageCache& cache, TSeat& seat)
+            : TPageCollectionReadEnv(cache, seat)
             , DB(db)
         { }
 
@@ -230,7 +303,7 @@ namespace NTabletFlatExecutor {
         NTable::TDatabase& DB;
 
     public:
-        /*_ Pending database shanshots      */
+        /*_ Pending database snapshots      */
 
         TMap<ui32, TSnapshot> MakeSnap;
 

--- a/ydb/core/tablet_flat/flat_executor_tx_env.h
+++ b/ydb/core/tablet_flat/flat_executor_tx_env.h
@@ -24,11 +24,11 @@ namespace NTabletFlatExecutor {
         using TInfo = TPrivatePageCache::TInfo;
 
         struct TStats {
-            size_t NewlyPinnedCount = 0;
-            ui64 NewlyPinnedSize = 0;
+            size_t NewlyPinnedPages = 0;
+            ui64 NewlyPinnedBytes = 0;
     
-            size_t ToLoadCount = 0;
-            ui64 ToLoadSize = 0;
+            size_t ToLoadPages = 0;
+            ui64 ToLoadBytes = 0;
         };
 
         const TStats& GetStats() const { return Stats; }
@@ -76,9 +76,9 @@ namespace NTabletFlatExecutor {
     private:
         void ToLoadPage(TPageId pageId, TInfo *info) {
             if (ToLoad[info->Id].insert(pageId).second) {
-                Stats.ToLoadCount++;
+                Stats.ToLoadPages++;
                 Y_ASSERT(!info->IsStickyPage(pageId));
-                Stats.ToLoadSize += info->GetPageSize(pageId);
+                Stats.ToLoadBytes += info->GetPageSize(pageId);
             }
         }
 
@@ -102,9 +102,9 @@ namespace NTabletFlatExecutor {
             Y_ENSURE(emplaced.second);
             auto& pinnedBody = emplaced.first->second.PinnedBody;
 
-            Stats.NewlyPinnedCount++;
+            Stats.NewlyPinnedPages++;
             if (!info->IsStickyPage(pageId)) {
-                Stats.NewlyPinnedSize += pinnedBody.size();
+                Stats.NewlyPinnedBytes += pinnedBody.size();
             }
             
             return &pinnedBody;

--- a/ydb/core/tablet_flat/flat_sausagecache.cpp
+++ b/ydb/core/tablet_flat/flat_sausagecache.cpp
@@ -81,7 +81,7 @@ void TPrivatePageCache::DropPageCollection(TInfo *info) {
     --Stats.TotalCollections;
 }
 
-TSharedPageRef TPrivatePageCache::Lookup(TPageId pageId, TInfo *info) {
+TSharedPageRef TPrivatePageCache::TryGetPage(TPageId pageId, TInfo *info) {
     auto page = info->FindPage(pageId);
     if (!page) {
         return {};

--- a/ydb/core/tablet_flat/flat_sausagecache.h
+++ b/ydb/core/tablet_flat/flat_sausagecache.h
@@ -137,7 +137,7 @@ public:
 
     const TStats& GetStats() const { return Stats; }
 
-    TSharedPageRef Lookup(TPageId pageId, TInfo *info);
+    TSharedPageRef TryGetPage(TPageId pageId, TInfo *info);
 
     void DropPage(TPageId pageId, TInfo *info);
     void AddPage(TPageId pageId, TSharedPageRef sharedBody, TInfo *info);

--- a/ydb/core/tablet_flat/flat_sausagecache.h
+++ b/ydb/core/tablet_flat/flat_sausagecache.h
@@ -23,19 +23,11 @@ public:
         {}
     };
 
-    using TPinned = THashMap<TLogoBlobID, THashMap<TPageId, TPinnedPage>>;
-
     struct TInfo;
 
     struct TStats {
         ui64 TotalCollections = 0;
         ui64 TotalSharedBody = 0;
-
-        size_t NewlyPinnedCount = 0;
-        ui64 NewlyPinnedSize = 0;
-
-        size_t ToLoadCount = 0;
-        ui64 ToLoadSize = 0;
     };
 
     struct TPage : TNonCopyable {
@@ -140,38 +132,22 @@ public:
 public:
     TInfo* FindPageCollection(const TLogoBlobID &id) const;
     TInfo* GetPageCollection(const TLogoBlobID &id) const;
-    void AddPageCollection(TIntrusivePtr<TInfo> info);
+    THashMap<TLogoBlobID, THashSet<TPageId>> AddPageCollection(TIntrusivePtr<TInfo> info);
     void DropPageCollection(TInfo *info);
 
     const TStats& GetStats() const { return Stats; }
 
-    const TSharedData* Lookup(TPageId pageId, TInfo *info);
-
-    // TODO: move this methods somewhere else (probably to TPageCollectionTxEnv)
-    // and keep page states and counters there
-    void BeginTransaction(TPinned* pinned);
-    void EndTransaction();
+    TSharedPageRef Lookup(TPageId pageId, TInfo *info);
 
     void DropPage(TPageId pageId, TInfo *info);
     void AddPage(TPageId pageId, TSharedPageRef sharedBody, TInfo *info);
 
     THashMap<TLogoBlobID, TIntrusivePtr<TInfo>> DetachPrivatePageCache();
 
-    THashMap<TLogoBlobID, TVector<TPageId>> GetToLoad();
-    void TranslatePinnedToSharedCacheTouches();
-    THashMap<TLogoBlobID, THashSet<TPageId>> GetSharedCacheTouches();
-
-private:
-    void ToLoadPage(TPageId pageId, TInfo *info);
-
 private:
     THashMap<TLogoBlobID, TIntrusivePtr<TInfo>> PageCollections;
-    THashMap<TLogoBlobID, THashSet<TPageId>> SharedCacheTouches;
 
     TStats Stats;
-
-    TPinned* Pinned;
-    THashMap<TLogoBlobID, THashSet<TPageId>> ToLoad;
 };
 
 }}

--- a/ydb/core/tablet_flat/ut/ut_shared_sausagecache.cpp
+++ b/ydb/core/tablet_flat/ut/ut_shared_sausagecache.cpp
@@ -453,7 +453,7 @@ Y_UNIT_TEST(ThreeLeveledLRU) {
     }
     LogCounters(counters);
     UNIT_ASSERT_DOUBLES_EQUAL(counters->ActiveBytes->Val(), static_cast<i64>(8_MB), static_cast<i64>(1_MB / 3));
-    UNIT_ASSERT_VALUES_EQUAL(retried, (TVector<ui32>{100, 73, 10, 1}));
+    UNIT_ASSERT_VALUES_EQUAL(retried, (TVector<ui32>{100, 73, 10}));
 
     RestartAndClearCache(env);
 


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

...

### Changelog category <!-- remove all except one -->

* Not for changelog (changelog entry is not required)

### Description for reviewers <!-- (optional) description for those who read this PR -->

Extract transaction-related code from Private Cache to `TPageCollectionReadEnv`, so it's only implement cache coherency protocol and store some additional page collection data (like cache mode and sticky pages).
