### PR TITLE
Change the default logging level to `WARN` from `EMERG` for CLI commands that support multiple verbosity levels

### DIFF
--- a/ydb/apps/ydb/CHANGELOG.md
+++ b/ydb/apps/ydb/CHANGELOG.md
@@ -1,4 +1,5 @@
 * Fixed decimal type comparison in `ydb workload * run` commands.
+* Changed the default logging level from `EMERGENCY` to `ERROR` for commands that support multiple verbosity levels.
 * Added a new paths approach in the `ydb export s3` and `ydb import s3` commands with the new `--include` option instead of the `--item` option. 
 * Added support for encryption features in the `ydb export s3` and `ydb import s3` commands.
 

--- a/ydb/library/backup/backup.cpp
+++ b/ydb/library/backup/backup.cpp
@@ -1026,7 +1026,7 @@ void BackupFolderImpl(TDriver driver, const TString& database, const TString& db
             } else if (dbIt.IsExternalTable()) {
                 BackupExternalTable(driver, dbIt.GetFullPath(), childFolderPath);
             } else if (!dbIt.IsTable() && !dbIt.IsDir()) {
-                LOG_E("Skipping " << dbIt.GetFullPath().Quote() << ": dumping objects of type " << dbIt.GetCurrentNode()->Type << " is not supported");
+                LOG_W("Skipping " << dbIt.GetFullPath().Quote() << ": dumping objects of type " << dbIt.GetCurrentNode()->Type << " is not supported");
                 childFolderPath.Child(NDump::NFiles::Incomplete().FileName).DeleteIfExists();
                 childFolderPath.DeleteIfExists();
             }

--- a/ydb/public/lib/ydb_cli/commands/topic_operations_scenario.cpp
+++ b/ydb/public/lib/ydb_cli/commands/topic_operations_scenario.cpp
@@ -59,7 +59,7 @@ ui32 TTopicOperationsScenario::GetTopicMaxPartitionCount() const
     return TopicMaxPartitionCount >= TopicPartitionCount ? TopicMaxPartitionCount : (TopicPartitionCount << 3);
 }
 
-THolder<TLogBackend> TTopicOperationsScenario::MakeLogBackend(TConfig::EVerbosityLevel level)
+THolder<TLogBackend> TTopicOperationsScenario::MakeLogBackend(ui32 level)
 {
     return CreateLogBackend("cerr",
                             TConfig::VerbosityLevelToELogPriority(level));

--- a/ydb/public/lib/ydb_cli/commands/topic_operations_scenario.h
+++ b/ydb/public/lib/ydb_cli/commands/topic_operations_scenario.h
@@ -132,7 +132,7 @@ private:
 
     static NTable::TSession GetSession(NTable::TTableClient& client);
 
-    static THolder<TLogBackend> MakeLogBackend(TClientCommand::TConfig::EVerbosityLevel level);
+    static THolder<TLogBackend> MakeLogBackend(ui32 level);
 
     void InitLog(TClientCommand::TConfig& config);
     void InitDriver(TClientCommand::TConfig& config);

--- a/ydb/public/lib/ydb_cli/commands/ydb_root_common.cpp
+++ b/ydb/public/lib/ydb_cli/commands/ydb_root_common.cpp
@@ -420,7 +420,7 @@ void TClientCommandRootCommon::Config(TConfig& config) {
 
 void TClientCommandRootCommon::Parse(TConfig& config) {
     TClientCommandRootBase::Parse(config);
-    config.VerbosityLevel = std::min(static_cast<TConfig::EVerbosityLevel>(VerbosityLevel), TConfig::EVerbosityLevel::DEBUG);
+    config.VerbosityLevel = VerbosityLevel;
 }
 
 void TClientCommandRootCommon::ExtractParams(TConfig& config) {

--- a/ydb/public/lib/ydb_cli/common/command.cpp
+++ b/ydb/public/lib/ydb_cli/common/command.cpp
@@ -51,28 +51,25 @@ TClientCommand::TClientCommand(
     Opts.GetOpts().SetWrap(Max(Opts.GetOpts().Wrap_, static_cast<ui32>(lineLength)));
 }
 
-ELogPriority TClientCommand::TConfig::VerbosityLevelToELogPriority(TClientCommand::TConfig::EVerbosityLevel lvl) {
+ELogPriority TClientCommand::TConfig::VerbosityLevelToELogPriority(ui32 lvl) {
     switch (lvl) {
-        case TClientCommand::TConfig::EVerbosityLevel::NONE:
-            return ELogPriority::TLOG_EMERG;
-        case TClientCommand::TConfig::EVerbosityLevel::DEBUG:
-            return ELogPriority::TLOG_DEBUG;
-        case TClientCommand::TConfig::EVerbosityLevel::INFO:
-            return ELogPriority::TLOG_INFO;
-        case TClientCommand::TConfig::EVerbosityLevel::WARN:
+        case 0:
             return ELogPriority::TLOG_WARNING;
+        case 1:
+            return ELogPriority::TLOG_NOTICE;
+        case 2:
+            return ELogPriority::TLOG_INFO;
+        case 3:
         default:
-            return ELogPriority::TLOG_ERR;
+            return ELogPriority::TLOG_DEBUG;
     }
 }
 
-ELogPriority TClientCommand::TConfig::VerbosityLevelToELogPriorityChatty(TClientCommand::TConfig::EVerbosityLevel lvl) {
+ELogPriority TClientCommand::TConfig::VerbosityLevelToELogPriorityChatty(ui32 lvl) {
     switch (lvl) {
-        case TClientCommand::TConfig::EVerbosityLevel::NONE:
+        case 0:
             return ELogPriority::TLOG_INFO;
-        case TClientCommand::TConfig::EVerbosityLevel::DEBUG:
-        case TClientCommand::TConfig::EVerbosityLevel::INFO:
-        case TClientCommand::TConfig::EVerbosityLevel::WARN:
+        default:
             return ELogPriority::TLOG_DEBUG;
     }
     return ELogPriority::TLOG_INFO;

--- a/ydb/public/lib/ydb_cli/common/command.cpp
+++ b/ydb/public/lib/ydb_cli/common/command.cpp
@@ -72,7 +72,6 @@ ELogPriority TClientCommand::TConfig::VerbosityLevelToELogPriorityChatty(ui32 lv
         default:
             return ELogPriority::TLOG_DEBUG;
     }
-    return ELogPriority::TLOG_INFO;
 }
 
 size_t TClientCommand::TConfig::ParseHelpCommandVerbosilty(int argc, char** argv) {

--- a/ydb/public/lib/ydb_cli/common/command.h
+++ b/ydb/public/lib/ydb_cli/common/command.h
@@ -88,15 +88,8 @@ public:
             TArgSetting Max;
         };
 
-        enum EVerbosityLevel : ui32 {
-            NONE = 0,
-            WARN = 1,
-            INFO = 2,
-            DEBUG = 3,
-        };
-
-        static ELogPriority VerbosityLevelToELogPriority(EVerbosityLevel lvl);
-        static ELogPriority VerbosityLevelToELogPriorityChatty(EVerbosityLevel lvl);
+        static ELogPriority VerbosityLevelToELogPriority(ui32 lvl);
+        static ELogPriority VerbosityLevelToELogPriorityChatty(ui32 lvl);
 
         int ArgC;
         char** ArgV;
@@ -135,7 +128,7 @@ public:
         TString Oauth2KeyFile;
         TString Oauth2KeyParams;
 
-        EVerbosityLevel VerbosityLevel = EVerbosityLevel::NONE;
+        ui32 VerbosityLevel = 0;
         size_t HelpCommandVerbosiltyLevel = 1; // No options -h or one - 1, -hh - 2, -hhh - 3 etc
 
         bool JsonUi64AsText = false;
@@ -207,7 +200,7 @@ public:
         static size_t ParseHelpCommandVerbosilty(int argc, char** argv);
 
         bool IsVerbose() const {
-            return VerbosityLevel != EVerbosityLevel::NONE;
+            return VerbosityLevel > 0;
         }
 
         void SetFreeArgsMin(size_t value) {


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

### Changelog category <!-- remove all except one -->

* Not for changelog (changelog entry is not required)

### Description for reviewers <!-- (optional) description for those who read this PR -->
