### PR TITLE
Add possibility to skip tests

### DIFF
--- a/ydb/tests/olap/scenario/helpers/__init__.py
+++ b/ydb/tests/olap/scenario/helpers/__init__.py
@@ -2,3 +2,4 @@ from .scenario_tests_helper import *  # noqa
 from .data_generators import *  # noqa
 from .drop_helper import *  # noqa
 from .table_helper import *  # noqa
+from .skip_test import *  # noqa

--- a/ydb/tests/olap/scenario/helpers/skip_test.py
+++ b/ydb/tests/olap/scenario/helpers/skip_test.py
@@ -1,0 +1,10 @@
+import pytest
+from ydb.tests.olap.scenario.helpers import TestContext
+from ydb.tests.olap.lib.utils import get_external_param
+
+
+def check_test_for_skipping(ctx: TestContext):
+    current_test = f"{ctx.suite}::{ctx.test}"
+    skipped_tests = get_external_param('olap-skip', '').split(',')
+    if current_test != '' and current_test in skipped_tests:
+        pytest.skip("marked as skipped in params")

--- a/ydb/tests/olap/scenario/helpers/ya.make
+++ b/ydb/tests/olap/scenario/helpers/ya.make
@@ -6,6 +6,7 @@ PY3_LIBRARY()
         data_generators.py
         table_helper.py
         drop_helper.py
+        skip_test.py
     )
 
     PEERDIR(

--- a/ydb/tests/olap/scenario/test_alter_tiering.py
+++ b/ydb/tests/olap/scenario/test_alter_tiering.py
@@ -6,6 +6,7 @@ from ydb.tests.olap.scenario.helpers import (
     CreateTableStore,
     DropTable,
     DropTableStore,
+    skip_test,
 )
 from ydb.tests.olap.common.thread_helper import TestThread, TestThreads
 from helpers.tiering_helper import (
@@ -299,6 +300,8 @@ class TestAlterTiering(TieringTestBase):
             sth.execute_scheme_query(AlterTableStore(store).drop_column(column_name), retries=2)
 
     def scenario_many_tables(self, ctx: TestContext):
+        skip_test.check_test_for_skipping(ctx)
+
         self._setup_tiering_test(ctx)
 
         self.test_duration = self._get_test_duration(get_external_param('test-class', 'SMALL'))


### PR DESCRIPTION
### Changelog category <!-- remove all except one -->

* Not for changelog (changelog entry is not required)

### Description for reviewers <!-- (optional) description for those who read this PR -->

Добавил возможность пропускать тесты, но пока надо в каждый дописывать 
`skip_test.check_test_for_skipping(ctx)`

Тесты для пропуска указывается следующим образом при запуске тестов:
`--test-param olap-skip="TestAlterTiering::many_tables,Another::SuperTest"`
