### PR TITLE
Create counters instance for the memory profiles

### DIFF
--- a/ydb/tests/tools/kqprun/kqprun.cpp
+++ b/ydb/tests/tools/kqprun/kqprun.cpp
@@ -21,6 +21,8 @@
 
 #ifdef PROFILE_MEMORY_ALLOCATIONS
 #include <library/cpp/lfalloc/alloc_profiler/profiler.h>
+#include <library/cpp/monlib/dynamic_counters/counters.h>
+#include <yql/essentials/minikql/mkql_buffer.h>
 #endif
 
 using namespace NKikimrRun;
@@ -977,6 +979,11 @@ private:
 
 int main(int argc, const char* argv[]) {
     SetupSignalActions();
+
+#ifdef PROFILE_MEMORY_ALLOCATIONS
+    NMonitoring::TDynamicCounterPtr memoryProfilingCounters = MakeIntrusive<NMonitoring::TDynamicCounters>();
+    NKikimr::NMiniKQL::InitializeGlobalPagedBufferCounters(memoryProfilingCounters);
+#endif
 
     try {
         NKqpRun::TMain().Run(argc, argv);


### PR DESCRIPTION
### Changelog category <!-- remove all except one -->

* Not for changelog (changelog entry is not required)

### Description for reviewers <!-- (optional) description for those who read this PR -->

kqprun was crashing when compiled with `PROFILE_MEMORY_ALLOCATIONS` due to uninitialized monitoring counters.
I've added a dedicated counters instance and a call to `InitializeGlobalPagedBufferCounters` (I've decided against using Counters from an YDB node instance since kqprun can run multiple nodes). Not sure if it should be a global var. Maybe `InitializeGlobalPagedBufferCounters` should hold a global reference to the root Counters instance to ensure it's not freed while still in use.