### PR TITLE
Fix codeowners for CHANGELOG.md

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,5 +1,5 @@
-/CHANGELOG.md @ydb-platform/changelog-reviewers
 /*.md @ydb-platform/docs
+/CHANGELOG.md @ydb-platform/changelog-reviewers
 
 /build @ydb-platform/ci
 /certs @ydb-platform/ci


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

Fix codeowners for CHANGELOG.md

### Changelog category <!-- remove all except one -->

* Not for changelog (changelog entry is not required)

### Description for reviewers <!-- (optional) description for those who read this PR -->

...
