### PR TITLE
audit log on incoming request without redirects

### DIFF
--- a/ydb/core/mon/audit/audit.h
+++ b/ydb/core/mon/audit/audit.h
@@ -10,11 +10,19 @@ namespace NMonitoring::NAudit {
 
 using TAuditParts = TVector<std::pair<TString, TString>>;
 
+enum ERequestStatus {
+    Success,
+    Process,
+    Error,
+};
+
 class TAuditCtx {
 public:
     void InitAudit(const NHttp::TEvHttpProxy::TEvHttpIncomingRequest::TPtr& ev);
     void AddAuditLogParts(const TIntrusiveConstPtr<NACLib::TUserToken>& userToken);
-    void FinishAudit(const NHttp::THttpOutgoingResponsePtr& response);
+    void LogAudit(ERequestStatus status, const TString& reason);
+    void LogOnExecute();
+    void LogOnResult(const NHttp::THttpOutgoingResponsePtr& response);
 
 private:
     void AddAuditLogPart(TStringBuf name, const TString& value);

--- a/ydb/core/mon/audit/audit.h
+++ b/ydb/core/mon/audit/audit.h
@@ -11,23 +11,23 @@ namespace NMonitoring::NAudit {
 using TAuditParts = TVector<std::pair<TString, TString>>;
 
 class TAuditCtx {
-    enum ERequestStatus {
+    enum class ERequestStatus {
         Success,
         Process,
         Error,
     };
 
-    enum EState : ui8 {
+    enum class EState : ui8 {
         Init = 0,
-        PendingExecution = 1,
-        Executing = 2,
-        Completed = 3
+        Executing,
+        Completed,
     };
 
 public:
-    void InitAudit(const NHttp::TEvHttpProxy::TEvHttpIncomingRequest::TPtr& ev);
-    void AddAuditLogParts(const TIntrusiveConstPtr<NACLib::TUserToken>& userToken);
-    void LogAudit(ERequestStatus status, const TString& reason);
+    void Init(const NActors::NMon::TEvHttpInfo::TPtr& ev);
+    void Init(const NHttp::TEvHttpProxy::TEvHttpIncomingRequest::TPtr& ev);
+    void SetUserToken(const TIntrusiveConstPtr<NACLib::TUserToken>& userToken);
+    void SetUserToken(const NACLibProto::TUserToken& userToken);
     void LogOnExecute();
     void LogOnResult(const NHttp::THttpOutgoingResponsePtr& response);
 
@@ -35,19 +35,16 @@ private:
     static ERequestStatus GetStatus(const NHttp::THttpOutgoingResponsePtr response);
     static TString ToString(const ERequestStatus value);
     static TString GetReason(const NHttp::THttpOutgoingResponsePtr& response);
+    void LogAudit(ERequestStatus status, const TString& reason);
     void AddAuditLogPart(TStringBuf name, const TString& value);
-    bool AuditableRequest(const TString& method, const TString& url, const TCgiParameters& cgiParams);
-
-    TAuditParts Parts;
-    bool Auditable = false;
-    EState State = EState::Init;
+    bool AuditableRequest(const HTTP_METHOD method, const TString& url, const TCgiParameters& cgiParams);
 
     NACLibProto::ESubjectType SubjectType = NACLibProto::SUBJECT_TYPE_ANONYMOUS;
-    TString Subject;
-    TString SanitizedToken;
+    TAuditParts Parts;
+    EState State = EState::Init;
 };
 
 bool HttpAuditEnabled(const TIntrusiveConstPtr<NACLib::TUserToken>& userToken);
-bool HttpAuditEnabled(TString serializedToken);
+// bool HttpAuditEnabled(TString serializedToken);
 
 }

--- a/ydb/core/mon/mon.cpp
+++ b/ydb/core/mon/mon.cpp
@@ -394,7 +394,7 @@ public:
     }
 
     void ReplyWith(NHttp::THttpOutgoingResponsePtr response) {
-        AuditCtx.FinishAudit(response);
+        AuditCtx.LogOnResult(response);
         Send(Event->Sender, new NHttp::TEvHttpProxy::TEvHttpOutgoingResponse(response));
     }
 
@@ -527,6 +527,7 @@ public:
             AuditCtx.AddAuditLogParts(result->UserToken);
             serializedToken = result->UserToken->GetSerializedToken();
         }
+        AuditCtx.LogOnExecute();
         Send(ActorMonPage->TargetActorId, new NMon::TEvHttpInfo(
             Container, serializedToken), IEventHandle::FlagTrackDelivery);
     }
@@ -593,9 +594,10 @@ public:
     }
 
     void ProcessRequest() {
+        AuditCtx.LogOnExecute();
         Container.Page->Output(Container);
         NHttp::THttpOutgoingResponsePtr response = Event->Get()->Request->CreateResponseString(Container.Str());
-        AuditCtx.FinishAudit(response);
+        AuditCtx.LogOnResult(response);
         Send(Event->Sender, new NHttp::TEvHttpProxy::TEvHttpOutgoingResponse(response));
         PassAway();
     }
@@ -1063,7 +1065,7 @@ public:
     }
 
     void ReplyWith(NHttp::THttpOutgoingResponsePtr response) {
-        AuditCtx.FinishAudit(response);
+        AuditCtx.LogOnResult(response);
         Send(Event->Sender, new NHttp::TEvHttpProxy::TEvHttpOutgoingResponse(response));
     }
 
@@ -1172,6 +1174,7 @@ public:
             AuditCtx.AddAuditLogParts(result->UserToken);
             Event->Get()->UserToken = result->UserToken->GetSerializedToken();
         }
+        AuditCtx.LogOnExecute();
         Send(new IEventHandle(Fields.Handler, SelfId(), Event->ReleaseBase().Release(), IEventHandle::FlagTrackDelivery, Event->Cookie));
     }
 
@@ -1206,7 +1209,7 @@ public:
 
     void Handle(NHttp::TEvHttpProxy::TEvHttpOutgoingResponse::TPtr& ev) {
         bool endOfData = ev->Get()->Response->IsDone();
-        AuditCtx.FinishAudit(ev->Get()->Response);
+        AuditCtx.LogOnResult(ev->Get()->Response);
         Forward(ev, Event->Sender);
         if (endOfData) {
             return PassAway();

--- a/ydb/core/mon/mon.cpp
+++ b/ydb/core/mon/mon.cpp
@@ -527,7 +527,9 @@ public:
             AuditCtx.AddAuditLogParts(result->UserToken);
             serializedToken = result->UserToken->GetSerializedToken();
         }
-        AuditCtx.LogOnExecute();
+        if (!ActorMonPage->AutoAudit) {
+            AuditCtx.LogOnExecute();
+        }
         Send(ActorMonPage->TargetActorId, new NMon::TEvHttpInfo(
             Container, serializedToken), IEventHandle::FlagTrackDelivery);
     }
@@ -563,11 +565,17 @@ public:
         }
     }
 
+    void Handle(NHttp::TEvHttpProxy::TEvAuditExecute::TPtr& ev) {
+        AuditCtx.LogOnExecute(true);
+        Send(ev->Sender, new NHttp::TEvHttpProxy::TEvAuditExecuteConfirmed(), 0, ev->Cookie);
+    }
+
     STATEFN(StateFunc) {
         switch (ev->GetTypeRewrite()) {
             hFunc(TEvents::TEvUndelivered, HandleUndelivered);
             hFunc(NMon::IEvHttpInfoRes, HandleResponse);
             hFunc(NKikimr::NGRpcService::TEvRequestAuthAndCheckResult, Handle);
+            hFunc(NHttp::TEvHttpProxy::TEvAuditExecute, Handle);
         }
     }
 };
@@ -1174,7 +1182,9 @@ public:
             AuditCtx.AddAuditLogParts(result->UserToken);
             Event->Get()->UserToken = result->UserToken->GetSerializedToken();
         }
-        AuditCtx.LogOnExecute();
+        if (!Fields.AutoAudit) {
+            AuditCtx.LogOnExecute();
+        }
         Send(new IEventHandle(Fields.Handler, SelfId(), Event->ReleaseBase().Release(), IEventHandle::FlagTrackDelivery, Event->Cookie));
     }
 
@@ -1228,6 +1238,11 @@ public:
         CancelSubscriber = std::move(ev);
     }
 
+    void Handle(NHttp::TEvHttpProxy::TEvAuditExecute::TPtr& ev) {
+        AuditCtx.LogOnExecute(true);
+        Send(ev->Sender, new NHttp::TEvHttpProxy::TEvAuditExecuteConfirmed(), 0, ev->Cookie);
+    }
+
     STATEFN(StateWork) {
         switch (ev->GetTypeRewrite()) {
             hFunc(TEvents::TEvUndelivered, HandleUndelivered);
@@ -1235,6 +1250,7 @@ public:
             hFunc(NHttp::TEvHttpProxy::TEvHttpOutgoingResponse, Handle);
             hFunc(NHttp::TEvHttpProxy::TEvHttpOutgoingDataChunk, Handle);
             hFunc(NHttp::TEvHttpProxy::TEvSubscribeForCancel, Handle);
+            hFunc(NHttp::TEvHttpProxy::TEvAuditExecute, Handle);
             cFunc(NHttp::TEvHttpProxy::EvRequestCancelled, Cancelled);
         }
     }
@@ -1499,7 +1515,9 @@ NMonitoring::IMonPage* TMon::RegisterActorPage(TRegisterActorPageFields fields) 
         fields.ActorId,
         fields.AllowedSIDs ? fields.AllowedSIDs : Config.AllowedSIDs,
         fields.UseAuth ? Config.Authorizer : TRequestAuthorizer(),
-        fields.MonServiceName);
+        fields.MonServiceName,
+        fields.AutoAudit
+    );
     if (fields.Index) {
         fields.Index->Register(page);
         if (fields.SortPages) {

--- a/ydb/core/mon/mon.h
+++ b/ydb/core/mon/mon.h
@@ -63,7 +63,7 @@ public:
         TVector<TString> AllowedSIDs;
         bool SortPages = true;
         TString MonServiceName = "utils";
-        bool AutoAudit = true;
+        bool AutoAuditStart = true;
     };
 
     NMonitoring::IMonPage* RegisterActorPage(TRegisterActorPageFields fields);
@@ -77,7 +77,7 @@ public:
         TActorId Handler;
         bool UseAuth = true;
         TVector<TString> AllowedSIDs;
-        bool AutoAudit = true;
+        bool AutoAuditStart = true;
     };
 
     void RegisterActorHandler(const TRegisterHandlerFields& fields);

--- a/ydb/core/mon/mon.h
+++ b/ydb/core/mon/mon.h
@@ -63,6 +63,7 @@ public:
         TVector<TString> AllowedSIDs;
         bool SortPages = true;
         TString MonServiceName = "utils";
+        bool AutoAudit = true;
     };
 
     NMonitoring::IMonPage* RegisterActorPage(TRegisterActorPageFields fields);
@@ -76,6 +77,7 @@ public:
         TActorId Handler;
         bool UseAuth = true;
         TVector<TString> AllowedSIDs;
+        bool AutoAudit = true;
     };
 
     void RegisterActorHandler(const TRegisterHandlerFields& fields);

--- a/ydb/core/mon/mon_impl.h
+++ b/ydb/core/mon/mon_impl.h
@@ -142,7 +142,8 @@ class TActorMonPage: public IMonPage {
 public:
     TActorMonPage(const TString &path, const TString &title, const TString &host, bool preTag,
                     TActorSystem *actorSystem, const TActorId &actorId, const TVector<TString> &sids,
-                    TMon::TRequestAuthorizer authorizer, TString monServiceName = "utils")
+                    TMon::TRequestAuthorizer authorizer, TString monServiceName = "utils",
+                    bool autoAudit = false)
         : IMonPage(path, title)
         , Host(host)
         , PreTag(preTag)
@@ -151,6 +152,7 @@ public:
         , AllowedSIDs(sids)
         , Authorizer(std::move(authorizer))
         , MonServiceName(monServiceName)
+        , AutoAudit(autoAudit)
     {
     }
 
@@ -165,6 +167,7 @@ public:
     const TVector<TString> AllowedSIDs;
     TMon::TRequestAuthorizer Authorizer;
     TString MonServiceName;
+    bool AutoAudit;
 };
 
 inline TString GetPageFullPath(const NMonitoring::IMonPage* page) {

--- a/ydb/core/mon/mon_impl.h
+++ b/ydb/core/mon/mon_impl.h
@@ -143,7 +143,7 @@ public:
     TActorMonPage(const TString &path, const TString &title, const TString &host, bool preTag,
                     TActorSystem *actorSystem, const TActorId &actorId, const TVector<TString> &sids,
                     TMon::TRequestAuthorizer authorizer, TString monServiceName = "utils",
-                    bool autoAudit = false)
+                    bool AutoAuditStart = false)
         : IMonPage(path, title)
         , Host(host)
         , PreTag(preTag)
@@ -152,7 +152,7 @@ public:
         , AllowedSIDs(sids)
         , Authorizer(std::move(authorizer))
         , MonServiceName(monServiceName)
-        , AutoAudit(autoAudit)
+        , AutoAuditStart(AutoAuditStart)
     {
     }
 
@@ -167,7 +167,7 @@ public:
     const TVector<TString> AllowedSIDs;
     TMon::TRequestAuthorizer Authorizer;
     TString MonServiceName;
-    bool AutoAudit;
+    bool AutoAuditStart;
 };
 
 inline TString GetPageFullPath(const NMonitoring::IMonPage* page) {

--- a/ydb/core/viewer/json_local_rpc.h
+++ b/ydb/core/viewer/json_local_rpc.h
@@ -157,6 +157,10 @@ public:
         if (TBase::NeedToRedirect()) {
             return;
         }
+        static const THashSet<HTTP_METHOD> MODIFYING_METHODS = {HTTP_METHOD_POST, HTTP_METHOD_PUT, HTTP_METHOD_DELETE, HTTP_METHOD_EXTENSION};
+        if (std::find(MODIFYING_METHODS.begin(), MODIFYING_METHODS.end(), Event->Get()->Request.GetMethod()) == MODIFYING_METHODS.end() && TBase::NeedToWriteAuditLog()) {
+            return;
+        }
         TRequestProtoType request;
         if (!Params2Proto(request)) {
             return;

--- a/ydb/core/viewer/json_pipe_req.cpp
+++ b/ydb/core/viewer/json_pipe_req.cpp
@@ -1,6 +1,5 @@
 #include "json_pipe_req.h"
 #include "log.h"
-#include <ydb/core/mon/audit/audit.h>
 #include <library/cpp/json/json_reader.h>
 #include <library/cpp/json/json_writer.h>
 
@@ -129,6 +128,36 @@ TViewerPipeClient::TViewerPipeClient(NWilson::TTraceId traceId) {
     if (traceId) {
         Span = {TComponentTracingLevels::THttp::TopLevel, std::move(traceId), "viewer", NWilson::EFlags::AUTO_END};
     }
+}
+
+void TViewerPipeClient::WriteAuditLog() {
+    auto request = GetRequest();
+    if (TString tokenString = request.GetUserTokenObject()) {
+        NACLibProto::TUserToken userToken;
+        if (userToken.ParseFromString(tokenString)) {
+            NMonitoring::NAudit::TAuditCtx auditCtx;
+            if (Event) {
+                auditCtx.Init(Event);
+            } else if (HttpEvent) {
+                auditCtx.Init(HttpEvent);
+            }
+            auditCtx.SetUserToken(userToken);
+            auditCtx.LogOnExecute();
+        }
+    }
+}
+
+void TViewerPipeClient::Bootstrap() {
+    BootstrapPre();
+    if (RunOnDynnode && NeedToRedirect()) {
+        return;
+    }
+
+    if (NeedAudit) {
+        NeedAudit = false;
+        WriteAuditLog();
+    }
+    BootstrapEx();
 }
 
 void TViewerPipeClient::BuildParamsFromJson(TStringBuf data) {
@@ -1203,13 +1232,6 @@ STATEFN(TViewerPipeClient::StateResolveResource) {
     }
 }
 
-STATEFN(TViewerPipeClient::StateAudit) {
-    switch (ev->GetTypeRewrite()) {
-        cFunc(NHttp::TEvHttpProxy::EvAuditExecuteConfirmed, Bootstrap);
-        cFunc(TEvents::TEvWakeup::EventType, HandleTimeout);
-    }
-}
-
 void TViewerPipeClient::RedirectToDatabase(const TString& database) {
     DatabaseNavigateResponse = MakeRequestSchemeCacheNavigate(database);
     --DataRequests; // don't count this request
@@ -1230,27 +1252,6 @@ bool TViewerPipeClient::NeedToRedirect() {
             ReplyAndPassAway(GetHTTPFORBIDDEN("text/html", "<html><body><h1>403 Forbidden</h1></body></html>"), "Access denied");
             return true;
         }
-    }
-    return false;
-}
-
-bool TViewerPipeClient::NeedToWriteAuditLog() {
-    if (Event && !NMonitoring::NAudit::HttpAuditEnabled(Event->Get()->UserToken)) {
-        return false;
-    }
-    if (HttpEvent && !NMonitoring::NAudit::HttpAuditEnabled(HttpEvent->Get()->UserToken)) {
-        return false;
-    }
-    if (NeedAuditLog) {
-        NeedAuditLog = false;
-        auto event = std::make_unique<NHttp::TEvHttpProxy::TEvAuditExecute>();
-        if (Event) {
-            Send(Event->Sender, event.release(), IEventHandle::FlagTrackDelivery);
-        } else if (HttpEvent) {
-            Send(HttpEvent->Sender, event.release(), IEventHandle::FlagTrackDelivery);
-        }
-        Become(&TViewerPipeClient::StateAudit);
-        return true;
     }
     return false;
 }

--- a/ydb/core/viewer/json_pipe_req.h
+++ b/ydb/core/viewer/json_pipe_req.h
@@ -44,6 +44,7 @@ protected:
     TString SharedDatabase;
     bool Direct = false;
     bool NeedRedirect = true;
+    bool NeedAuditLog = true;
     i32 DataRequests = 0; // how many requests we wait to process data
     bool PassedAway = false;
     bool ReplySent = false;
@@ -389,9 +390,12 @@ protected:
     void HandleResolve(TEvStateStorage::TEvBoardInfo::TPtr& ev);
     STATEFN(StateResolveDatabase);
     STATEFN(StateResolveResource);
+    STATEFN(StateAudit);
     void RedirectToDatabase(const TString& database);
     bool NeedToRedirect();
+    bool NeedToWriteAuditLog();
     void HandleTimeout();
+    virtual void Execute() {};
     void PassAway() override;
 };
 

--- a/ydb/core/viewer/json_storage_base.h
+++ b/ydb/core/viewer/json_storage_base.h
@@ -139,7 +139,7 @@ protected:
     }
 
 public:
-    void Bootstrap() override {
+    void BootstrapEx() override {
         TIntrusivePtr<TDomainsInfo> domains = AppData()->DomainsInfo;
 
         if (FilterTenant.empty()) {

--- a/ydb/core/viewer/json_vdisk_req.h
+++ b/ydb/core/viewer/json_vdisk_req.h
@@ -62,7 +62,7 @@ public:
         , Event(ev)
     {}
 
-    void Bootstrap() override {
+    void BootstrapEx() override {
         const auto& params(Event->Get()->Request.GetParams());
         NodeId = FromStringWithDefault<ui32>(params.Get("node_id"), 0);
         PDiskId = FromStringWithDefault<ui32>(params.Get("pdisk_id"), Max<ui32>());

--- a/ydb/core/viewer/json_wb_req.h
+++ b/ydb/core/viewer/json_wb_req.h
@@ -36,7 +36,7 @@ public:
         : TBase(viewer, ev)
     {}
 
-    void Bootstrap() override {
+    void BootstrapEx() override {
         const auto& params(Event->Get()->Request.GetParams());
         std::vector<TNodeId> nodeIds;
         SplitIds(params.Get("node_id"), ',', nodeIds);
@@ -87,7 +87,7 @@ public:
             }
         }
         TBase::RequestSettings.Format = params.Get("format");
-        TBase::Bootstrap();
+        TBase::BootstrapEx();
     }
 
     virtual void FilterResponse(TResponseType& response) {

--- a/ydb/core/viewer/pdisk_info.h
+++ b/ydb/core/viewer/pdisk_info.h
@@ -40,7 +40,7 @@ public:
         : TBase(viewer, ev)
     {}
 
-    void Bootstrap() override {
+    void BootstrapEx() override {
         TString pDiskId = Params.Get("pdisk_id");
         if (pDiskId.Contains('-')) {
             PDiskId = FromStringWithDefault<ui32>(TStringBuf(pDiskId).Before('-'), Max<ui32>());

--- a/ydb/core/viewer/pdisk_restart.h
+++ b/ydb/core/viewer/pdisk_restart.h
@@ -38,6 +38,9 @@ public:
     {}
 
     void Bootstrap() override {
+        if (NeedToWriteAuditLog()) {
+            return;
+        }
         ui32 nodeId = FromStringWithDefault<ui32>(Params.Get("node_id"), 0);
         ui32 pDiskId = FromStringWithDefault<ui32>(Params.Get("pdisk_id"), Max<ui32>());
         bool force = FromStringWithDefault<bool>(Params.Get("force"), false);

--- a/ydb/core/viewer/pdisk_restart.h
+++ b/ydb/core/viewer/pdisk_restart.h
@@ -37,10 +37,7 @@ public:
         : TViewerPipeClient(viewer, ev)
     {}
 
-    void Bootstrap() override {
-        if (NeedToWriteAuditLog()) {
-            return;
-        }
+    void BootstrapEx() override {
         ui32 nodeId = FromStringWithDefault<ui32>(Params.Get("node_id"), 0);
         ui32 pDiskId = FromStringWithDefault<ui32>(Params.Get("pdisk_id"), Max<ui32>());
         bool force = FromStringWithDefault<bool>(Params.Get("force"), false);

--- a/ydb/core/viewer/pdisk_status.h
+++ b/ydb/core/viewer/pdisk_status.h
@@ -26,10 +26,7 @@ public:
         : TViewerPipeClient(viewer, ev)
     {}
 
-    void Bootstrap() override {
-        if (NeedToWriteAuditLog()) {
-            return;
-        }
+    void BootstrapEx() override {
         if (!PostData.IsDefined()) {
             return ReplyAndPassAway(GetHTTPBADREQUEST("text/plain", "Only POST method is allowed"));
         }

--- a/ydb/core/viewer/pdisk_status.h
+++ b/ydb/core/viewer/pdisk_status.h
@@ -27,6 +27,9 @@ public:
     {}
 
     void Bootstrap() override {
+        if (NeedToWriteAuditLog()) {
+            return;
+        }
         if (!PostData.IsDefined()) {
             return ReplyAndPassAway(GetHTTPBADREQUEST("text/plain", "Only POST method is allowed"));
         }

--- a/ydb/core/viewer/storage_groups.h
+++ b/ydb/core/viewer/storage_groups.h
@@ -118,6 +118,8 @@ public:
     using TThis = TStorageGroups;
     using TFieldsType = std::bitset<+EGroupFields::COUNT>;
 
+    static constexpr bool RunOnDynnode = true;
+
     // Common
     std::unordered_map<TPathId, TRequestResponse<TEvTxProxySchemeCache::TEvNavigateKeySetResult>> NavigateKeySetResult;
     ui64 NavigateKeySetInFlight = 0;
@@ -871,10 +873,7 @@ public:
     }
 
 public:
-    void Bootstrap() override {
-        if (NeedToRedirect()) {
-            return;
-        }
+    void BootstrapEx() override {
         if (Database) {
             if (!DatabaseNavigateResponse) {
                 DatabaseNavigateResponse = MakeRequestSchemeCacheNavigate(Database, 0);

--- a/ydb/core/viewer/vdisk_evict.h
+++ b/ydb/core/viewer/vdisk_evict.h
@@ -41,10 +41,7 @@ public:
         return true;
     }
 
-    void Bootstrap() override {
-        if (NeedToWriteAuditLog()) {
-            return;
-        }
+    void BootstrapEx() override {
         ui32 groupId = 0;
         ui32 groupGeneration = 0;
         ui32 failRealmIdx = 0;

--- a/ydb/core/viewer/vdisk_evict.h
+++ b/ydb/core/viewer/vdisk_evict.h
@@ -42,6 +42,9 @@ public:
     }
 
     void Bootstrap() override {
+        if (NeedToWriteAuditLog()) {
+            return;
+        }
         ui32 groupId = 0;
         ui32 groupGeneration = 0;
         ui32 failRealmIdx = 0;

--- a/ydb/core/viewer/viewer.cpp
+++ b/ydb/core/viewer/viewer.cpp
@@ -103,18 +103,21 @@ public:
                 .ActorId = ctx.SelfID,
                 .UseAuth = true,
                 .AllowedSIDs = databaseAllowedSIDs,
+                .AutoAudit = false,
             });
             mon->RegisterActorPage({
                 .RelPath = "viewer/capabilities",
                 .ActorSystem = ctx.ActorSystem(),
                 .ActorId = ctx.SelfID,
                 .UseAuth = false,
+                .AutoAudit = false,
             });
             mon->RegisterActorPage({
                 .Title = "Viewer",
                 .RelPath = "viewer/v2",
                 .ActorSystem = ctx.ActorSystem(),
                 .ActorId = ctx.SelfID,
+                .AutoAudit = false,
             });
             mon->RegisterActorPage({
                 .Title = "Monitoring",
@@ -122,18 +125,21 @@ public:
                 .ActorSystem = ctx.ActorSystem(),
                 .ActorId = ctx.SelfID,
                 .UseAuth = false,
+                .AutoAudit = false,
             });
             mon->RegisterActorPage({
                 .RelPath = "counters/hosts",
                 .ActorSystem = ctx.ActorSystem(),
                 .ActorId = ctx.SelfID,
                 .UseAuth = false,
+                .AutoAudit = false,
             });
             mon->RegisterActorPage({
                 .RelPath = "healthcheck",
                 .ActorSystem = ctx.ActorSystem(),
                 .ActorId = ctx.SelfID,
                 .UseAuth = false,
+                .AutoAudit = false,
             });
             mon->RegisterActorPage({
                 .RelPath = "vdisk",
@@ -141,6 +147,7 @@ public:
                 .ActorId = ctx.SelfID,
                 .UseAuth = true,
                 .AllowedSIDs = databaseAllowedSIDs,
+                .AutoAudit = false,
             });
             mon->RegisterActorPage({
                 .RelPath = "pdisk",
@@ -148,6 +155,7 @@ public:
                 .ActorId = ctx.SelfID,
                 .UseAuth = true,
                 .AllowedSIDs = monitoringAllowedSIDs,
+                .AutoAudit = false,
             });
             mon->RegisterActorPage({
                 .RelPath = "operation",
@@ -155,6 +163,7 @@ public:
                 .ActorId = ctx.SelfID,
                 .UseAuth = true,
                 .AllowedSIDs = databaseAllowedSIDs,
+                .AutoAudit = false,
             });
             mon->RegisterActorPage({
                 .RelPath = "query",
@@ -162,6 +171,7 @@ public:
                 .ActorId = ctx.SelfID,
                 .UseAuth = true,
                 .AllowedSIDs = databaseAllowedSIDs,
+                .AutoAudit = false,
             });
             mon->RegisterActorPage({
                 .RelPath = "scheme",
@@ -169,6 +179,7 @@ public:
                 .ActorId = ctx.SelfID,
                 .UseAuth = true,
                 .AllowedSIDs = databaseAllowedSIDs,
+                .AutoAudit = false,
             });
             mon->RegisterActorPage({
                 .RelPath = "storage",
@@ -176,6 +187,7 @@ public:
                 .ActorId = ctx.SelfID,
                 .UseAuth = true,
                 .AllowedSIDs = databaseAllowedSIDs,
+                .AutoAudit = false,
             });
             if (!KikimrRunConfig.AppConfig.GetMonitoringConfig().GetHideHttpEndpoint()) {
                 auto whiteboardServiceId = NNodeWhiteboard::MakeNodeWhiteboardServiceId(ctx.SelfID.NodeId());
@@ -219,6 +231,7 @@ public:
                         .Handler = ctx.SelfID,
                         .UseAuth = true,
                         .AllowedSIDs = databaseAllowedSIDs,
+                        .AutoAudit = false,
                     });
                 }
             }

--- a/ydb/core/viewer/viewer.cpp
+++ b/ydb/core/viewer/viewer.cpp
@@ -103,21 +103,21 @@ public:
                 .ActorId = ctx.SelfID,
                 .UseAuth = true,
                 .AllowedSIDs = databaseAllowedSIDs,
-                .AutoAudit = false,
+                .AutoAuditStart = false,
             });
             mon->RegisterActorPage({
                 .RelPath = "viewer/capabilities",
                 .ActorSystem = ctx.ActorSystem(),
                 .ActorId = ctx.SelfID,
                 .UseAuth = false,
-                .AutoAudit = false,
+                .AutoAuditStart = false,
             });
             mon->RegisterActorPage({
                 .Title = "Viewer",
                 .RelPath = "viewer/v2",
                 .ActorSystem = ctx.ActorSystem(),
                 .ActorId = ctx.SelfID,
-                .AutoAudit = false,
+                .AutoAuditStart = false,
             });
             mon->RegisterActorPage({
                 .Title = "Monitoring",
@@ -125,21 +125,21 @@ public:
                 .ActorSystem = ctx.ActorSystem(),
                 .ActorId = ctx.SelfID,
                 .UseAuth = false,
-                .AutoAudit = false,
+                .AutoAuditStart = false,
             });
             mon->RegisterActorPage({
                 .RelPath = "counters/hosts",
                 .ActorSystem = ctx.ActorSystem(),
                 .ActorId = ctx.SelfID,
                 .UseAuth = false,
-                .AutoAudit = false,
+                .AutoAuditStart = false,
             });
             mon->RegisterActorPage({
                 .RelPath = "healthcheck",
                 .ActorSystem = ctx.ActorSystem(),
                 .ActorId = ctx.SelfID,
                 .UseAuth = false,
-                .AutoAudit = false,
+                .AutoAuditStart = false,
             });
             mon->RegisterActorPage({
                 .RelPath = "vdisk",
@@ -147,7 +147,7 @@ public:
                 .ActorId = ctx.SelfID,
                 .UseAuth = true,
                 .AllowedSIDs = databaseAllowedSIDs,
-                .AutoAudit = false,
+                .AutoAuditStart = false,
             });
             mon->RegisterActorPage({
                 .RelPath = "pdisk",
@@ -155,7 +155,7 @@ public:
                 .ActorId = ctx.SelfID,
                 .UseAuth = true,
                 .AllowedSIDs = monitoringAllowedSIDs,
-                .AutoAudit = false,
+                .AutoAuditStart = false,
             });
             mon->RegisterActorPage({
                 .RelPath = "operation",
@@ -163,7 +163,7 @@ public:
                 .ActorId = ctx.SelfID,
                 .UseAuth = true,
                 .AllowedSIDs = databaseAllowedSIDs,
-                .AutoAudit = false,
+                .AutoAuditStart = false,
             });
             mon->RegisterActorPage({
                 .RelPath = "query",
@@ -171,7 +171,7 @@ public:
                 .ActorId = ctx.SelfID,
                 .UseAuth = true,
                 .AllowedSIDs = databaseAllowedSIDs,
-                .AutoAudit = false,
+                .AutoAuditStart = false,
             });
             mon->RegisterActorPage({
                 .RelPath = "scheme",
@@ -179,7 +179,7 @@ public:
                 .ActorId = ctx.SelfID,
                 .UseAuth = true,
                 .AllowedSIDs = databaseAllowedSIDs,
-                .AutoAudit = false,
+                .AutoAuditStart = false,
             });
             mon->RegisterActorPage({
                 .RelPath = "storage",
@@ -187,7 +187,7 @@ public:
                 .ActorId = ctx.SelfID,
                 .UseAuth = true,
                 .AllowedSIDs = databaseAllowedSIDs,
-                .AutoAudit = false,
+                .AutoAuditStart = false,
             });
             if (!KikimrRunConfig.AppConfig.GetMonitoringConfig().GetHideHttpEndpoint()) {
                 auto whiteboardServiceId = NNodeWhiteboard::MakeNodeWhiteboardServiceId(ctx.SelfID.NodeId());
@@ -231,7 +231,7 @@ public:
                         .Handler = ctx.SelfID,
                         .UseAuth = true,
                         .AllowedSIDs = databaseAllowedSIDs,
-                        .AutoAudit = false,
+                        .AutoAuditStart = false,
                     });
                 }
             }

--- a/ydb/core/viewer/viewer_acl.h
+++ b/ydb/core/viewer/viewer_acl.h
@@ -10,6 +10,8 @@ class TJsonACL : public TViewerPipeClient {
     using TThis = TJsonACL;
     using TBase = TViewerPipeClient;
     using TBase::ReplyAndPassAway;
+    static constexpr bool RunOnDynnode = true;
+
     TRequestResponse<TEvTxProxySchemeCache::TEvNavigateKeySetResult> CacheResult;
     TRequestResponse<TEvTxUserProxy::TEvProposeTransactionStatus> ProposeStatus;
     TRequestResponse<NSchemeShard::TEvSchemeShard::TEvNotifyTxCompletionResult> NotifyTxCompletionResult;
@@ -213,13 +215,7 @@ public:
         : TViewerPipeClient(viewer, ev)
     {}
 
-    void Bootstrap() override {
-        if (NeedToRedirect()) {
-            return;
-        }
-        if (PostData.IsDefined() && NeedToWriteAuditLog()) {
-            return;
-        }
+    void BootstrapEx() override {
         MergeRules = FromStringWithDefault<bool>(Params.Get("merge_rules"), MergeRules);
         if (Params.Has("dialect")) {
             static const std::unordered_map<TString, const TDialect*> dialects = {

--- a/ydb/core/viewer/viewer_acl.h
+++ b/ydb/core/viewer/viewer_acl.h
@@ -217,6 +217,9 @@ public:
         if (NeedToRedirect()) {
             return;
         }
+        if (PostData.IsDefined() && NeedToWriteAuditLog()) {
+            return;
+        }
         MergeRules = FromStringWithDefault<bool>(Params.Get("merge_rules"), MergeRules);
         if (Params.Has("dialect")) {
             static const std::unordered_map<TString, const TDialect*> dialects = {

--- a/ydb/core/viewer/viewer_autocomplete.h
+++ b/ydb/core/viewer/viewer_autocomplete.h
@@ -16,6 +16,8 @@ class TJsonAutocomplete : public TViewerPipeClient {
     using TThis = TJsonAutocomplete;
     using TBase = TViewerPipeClient;
 
+    static constexpr bool RunOnDynnode = true;
+
     std::optional<TRequestResponse<NConsole::TEvConsole::TEvListTenantsResponse>> ConsoleResult;
     std::optional<TRequestResponse<TEvTxProxySchemeCache::TEvNavigateKeySetResult>> CacheResult;
 
@@ -107,10 +109,7 @@ public:
             new TEvTxProxySchemeCache::TEvNavigateKeySet(request.release()));
     }
 
-    void Bootstrap() override {
-        if (NeedToRedirect()) {
-            return;
-        }
+    void BootstrapEx() override {
         ParseCgiParameters(Params);
         PrepareParameters();
         if (Database) {

--- a/ydb/core/viewer/viewer_bscontrollerinfo.h
+++ b/ydb/core/viewer/viewer_bscontrollerinfo.h
@@ -20,7 +20,7 @@ public:
         : TViewerPipeClient(viewer, ev)
     {}
 
-    void Bootstrap() override {
+    void BootstrapEx() override {
         const auto& params(Event->Get()->Request.GetParams());
         JsonSettings.EnumAsNumbers = !FromStringWithDefault<bool>(params.Get("enums"), false);
         JsonSettings.UI64AsString = !FromStringWithDefault<bool>(params.Get("ui64"), false);

--- a/ydb/core/viewer/viewer_capabilities.h
+++ b/ydb/core/viewer/viewer_capabilities.h
@@ -10,14 +10,13 @@ public:
     using TThis = TViewerCapabilities;
     using TBase = TViewerPipeClient;
 
+    static constexpr bool RunOnDynnode = true;
+
     TViewerCapabilities(IViewer* viewer, NMon::TEvHttpInfo::TPtr& ev)
         : TBase(viewer, ev)
     {}
 
-    void Bootstrap() override {
-        if (TBase::NeedToRedirect()) {
-            return;
-        }
+    void BootstrapEx() override {
         ReplyAndPassAway();
     }
 

--- a/ydb/core/viewer/viewer_check_access.h
+++ b/ydb/core/viewer/viewer_check_access.h
@@ -13,6 +13,8 @@ class TCheckAccess : public TViewerPipeClient {
     using TThis = TCheckAccess;
     using TBase = TViewerPipeClient;
     using TBase::ReplyAndPassAway;
+    static constexpr bool RunOnDynnode = true;
+
     TAutoPtr<TEvTxProxySchemeCache::TEvNavigateKeySetResult> CacheResult;
     TVector<TString> Permissions;
 
@@ -21,10 +23,7 @@ public:
         : TViewerPipeClient(viewer, ev)
     {}
 
-    void Bootstrap() override {
-        if (NeedToRedirect()) {
-            return;
-        }
+    void BootstrapEx() override {
         const auto& params(Event->Get()->Request.GetParams());
         ui32 timeout = FromStringWithDefault<ui32>(params.Get("timeout"), 10000);
         if (params.Has("permissions")) {

--- a/ydb/core/viewer/viewer_cluster.h
+++ b/ydb/core/viewer/viewer_cluster.h
@@ -106,7 +106,7 @@ public:
         OffloadMergeAttempts = FromStringWithDefault<bool>(params.Get("offload_merge_attempts"), OffloadMergeAttempts);
     }
 
-    void Bootstrap() override {
+    void BootstrapEx() override {
         NodesInfoResponse = MakeRequest<TEvInterconnect::TEvNodesInfo>(GetNameserviceActorId(), new TEvInterconnect::TEvListNodes());
         if (AppData()->BridgeModeEnabled) {
             NodeWardenStorageConfigResponse = MakeRequest<TEvNodeWardenStorageConfig>(MakeBlobStorageNodeWardenID(SelfId().NodeId()),

--- a/ydb/core/viewer/viewer_compute.h
+++ b/ydb/core/viewer/viewer_compute.h
@@ -94,7 +94,7 @@ public:
         return false;
     }
 
-    void Bootstrap() override {
+    void BootstrapEx() override {
         const auto& params(Event->Get()->Request.GetParams());
         JsonSettings.EnumAsNumbers = !FromStringWithDefault<bool>(params.Get("enums"), true);
         JsonSettings.UI64AsString = !FromStringWithDefault<bool>(params.Get("ui64"), false);

--- a/ydb/core/viewer/viewer_describe.h
+++ b/ydb/core/viewer/viewer_describe.h
@@ -15,6 +15,8 @@ class TJsonDescribe : public TViewerPipeClient {
     using TThis = TJsonDescribe;
     using TBase = TViewerPipeClient;
     using TBase::ReplyAndPassAway;
+    static constexpr bool RunOnDynnode = true;
+
     TRequestResponse<TEvSchemeShard::TEvDescribeSchemeResult> SchemeShardResult;
     TRequestResponse<TEvTxProxySchemeCache::TEvNavigateKeySetResult> CacheResult;
     TAutoPtr<NKikimrViewer::TEvDescribeSchemeInfo> DescribeResult;
@@ -44,10 +46,7 @@ public:
         record->MutableOptions()->SetReturnPartitioningInfo(FromStringWithDefault<bool>(params.Get("partitioning_info"), true));
     }
 
-    void Bootstrap() override {
-        if (NeedToRedirect()) {
-            return;
-        }
+    void BootstrapEx() override {
         if (Params.Has("path_id") && !Params.Has("schemeshard_id")) {
             // path_id is not enough to describe path, we need schemeshard_id
             ReplyAndPassAway(GetHTTPBADREQUEST("text/plain", "schemeshard_id is required when path_id is specified"));

--- a/ydb/core/viewer/viewer_describe_consumer.h
+++ b/ydb/core/viewer/viewer_describe_consumer.h
@@ -22,12 +22,12 @@ public:
         AllowedMethods = {HTTP_METHOD_GET};
     }
 
-    void Bootstrap() override {
+    void BootstrapEx() override {
         const auto& params(Event->Get()->Request.GetParams());
         if (params.Has("database_path")) {
             Database = params.Get("database_path");
         }
-        TBase::Bootstrap();
+        TBase::BootstrapEx();
     }
 
     static YAML::Node GetSwagger() {

--- a/ydb/core/viewer/viewer_describe_topic.h
+++ b/ydb/core/viewer/viewer_describe_topic.h
@@ -21,12 +21,12 @@ public:
         AllowedMethods = {HTTP_METHOD_GET};
     }
 
-    void Bootstrap() override {
+    void BootstrapEx() override {
         const auto& params(Event->Get()->Request.GetParams());
         if (params.Has("database_path")) {
             Database = params.Get("database_path");
         }
-        TBase::Bootstrap();
+        TBase::BootstrapEx();
     }
 
     static YAML::Node GetSwagger() {

--- a/ydb/core/viewer/viewer_feature_flags.h
+++ b/ydb/core/viewer/viewer_feature_flags.h
@@ -10,6 +10,8 @@ using namespace NActors;
 class TJsonFeatureFlags : public TViewerPipeClient {
     using TThis = TJsonFeatureFlags;
     using TBase = TViewerPipeClient;
+    static constexpr bool RunOnDynnode = true;
+
     THashSet<TString> FilterFeatures;
     bool ChangedOnly = false;
 
@@ -18,10 +20,7 @@ public:
         : TViewerPipeClient(viewer, ev)
     {}
 
-    void Bootstrap() override {
-        if (NeedToRedirect()) {
-            return;
-        }
+    void BootstrapEx() override {
         StringSplitter(Params.Get("features")).Split(',').SkipEmpty().Collect(&FilterFeatures);
         ChangedOnly = FromStringWithDefault<bool>(Params.Get("changed"), ChangedOnly);
         ReplyAndPassAway();

--- a/ydb/core/viewer/viewer_graph.h
+++ b/ydb/core/viewer/viewer_graph.h
@@ -21,7 +21,7 @@ public:
         : TViewerPipeClient(viewer, ev)
     {}
 
-    void Bootstrap() override {
+    void BootstrapEx() override {
         BLOG_TRACE("Graph received request for " << Event->Get()->Request.GetUri());
         const auto& params(Event->Get()->Request.GetParams());
         NKikimrGraph::TEvGetMetrics getRequest;

--- a/ydb/core/viewer/viewer_healthcheck.h
+++ b/ydb/core/viewer/viewer_healthcheck.h
@@ -19,6 +19,7 @@ enum HealthCheckResponseFormat {
 class TJsonHealthCheck : public TViewerPipeClient {
     using TThis = TJsonHealthCheck;
     using TBase = TViewerPipeClient;
+    static constexpr bool RunOnDynnode = true;
     static const bool WithRetry = false;
     TJsonSettings JsonSettings;
     ui32 Timeout = 0;
@@ -63,10 +64,7 @@ public:
         SelfCheckResult = MakeRequest<NHealthCheck::TEvSelfCheckResult>(NHealthCheck::MakeHealthCheckID(), MakeSelfCheckRequest().Release());
     }
 
-    void Bootstrap() override {
-        if (NeedToRedirect()) {
-            return;
-        }
+    void BootstrapEx() override {
         const auto& params(Event->Get()->Request.GetParams());
         Format = HealthCheckResponseFormat::JSON;
         if (params.Has("format")) {

--- a/ydb/core/viewer/viewer_hiveinfo.h
+++ b/ydb/core/viewer/viewer_hiveinfo.h
@@ -21,7 +21,7 @@ public:
         : TViewerPipeClient(viewer, ev)
     {}
 
-    void Bootstrap() override {
+    void BootstrapEx() override {
         const auto& params(Event->Get()->Request.GetParams());
         ui64 hiveId = FromStringWithDefault<ui64>(params.Get("hive_id"), 0);
         JsonSettings.EnumAsNumbers = !FromStringWithDefault<bool>(params.Get("enums"), false);

--- a/ydb/core/viewer/viewer_hivestats.h
+++ b/ydb/core/viewer/viewer_hivestats.h
@@ -21,7 +21,7 @@ public:
         , Event(ev)
     {}
 
-    void Bootstrap() override {
+    void BootstrapEx() override {
         const auto& params(Event->Get()->Request.GetParams());
         ui64 hiveId = FromStringWithDefault<ui64>(params.Get("hive_id"), 0);
         JsonSettings.EnumAsNumbers = !FromStringWithDefault<bool>(params.Get("enums"), true);

--- a/ydb/core/viewer/viewer_hotkeys.h
+++ b/ydb/core/viewer/viewer_hotkeys.h
@@ -39,7 +39,7 @@ public:
         record->MutableOptions()->SetReturnPartitionStats(true);
     }
 
-    void Bootstrap() override {
+    void BootstrapEx() override {
         const auto& params(Event->Get()->Request.GetParams());
         Timeout = FromStringWithDefault<ui32>(params.Get("timeout"), 10000);
         Limit = FromStringWithDefault<ui32>(params.Get("limit"), 10);

--- a/ydb/core/viewer/viewer_multipart_counter.h
+++ b/ydb/core/viewer/viewer_multipart_counter.h
@@ -10,6 +10,7 @@ class TViewerMultipartCounter : public TViewerPipeClient {
 public:
     using TThis = TViewerMultipartCounter;
     using TBase = TViewerPipeClient;
+    static constexpr bool RunOnDynnode = true;
 
     TViewerMultipartCounter(IViewer* viewer, NHttp::TEvHttpProxy::TEvHttpIncomingRequest::TPtr& ev)
         : TBase(viewer, ev)
@@ -26,10 +27,7 @@ public:
         return "MULTIPART_COUNTER ";
     }
 
-    void Bootstrap() override {
-        if (TBase::NeedToRedirect()) {
-            return;
-        }
+    void BootstrapEx() override {
         NHttp::TUrlParameters params(HttpEvent->Get()->Request->GetParameters());
         MaxCounter = std::clamp<ui32>(FromStringWithDefault(params.Get("max_counter"), MaxCounter), 1, 100000);
         Period = std::clamp<ui32>(FromStringWithDefault(params.Get("period"), Period), 1, 100000);

--- a/ydb/core/viewer/viewer_netinfo.h
+++ b/ydb/core/viewer/viewer_netinfo.h
@@ -33,7 +33,7 @@ public:
         , Event(ev)
     {}
 
-    void Bootstrap() override {
+    void BootstrapEx() override {
         const auto& params(Event->Get()->Request.GetParams());
         JsonSettings.EnumAsNumbers = !FromStringWithDefault<bool>(params.Get("enums"), true);
         JsonSettings.UI64AsString = !FromStringWithDefault<bool>(params.Get("ui64"), false);

--- a/ydb/core/viewer/viewer_nodes.h
+++ b/ydb/core/viewer/viewer_nodes.h
@@ -59,6 +59,7 @@ class TJsonNodes : public TViewerPipeClient {
     using TNodeId = ui32;
     using TPDiskId = std::pair<TNodeId, ui32>;
     using TFieldsType = std::bitset<+ENodeFields::COUNT>;
+    static constexpr bool RunOnDynnode = true;
 
     enum ENavigateRequest {
         ENavigateRequestDatabase,
@@ -1091,11 +1092,7 @@ public:
         }
     }
 
-    void Bootstrap() override {
-        if (TBase::NeedToRedirect()) {
-            return;
-        }
-
+    void BootstrapEx() override {
         NodesInfoResponse = MakeRequest<TEvInterconnect::TEvNodesInfo>(GetNameserviceActorId(), new TEvInterconnect::TEvListNodes());
         {
             auto request = std::make_unique<TEvWhiteboard::TEvNodeStateRequest>();

--- a/ydb/core/viewer/viewer_query.h
+++ b/ydb/core/viewer/viewer_query.h
@@ -339,6 +339,10 @@ public:
         if (NeedToRedirect()) {
             return;
         }
+        if (NeedToWriteAuditLog()) {
+            return;
+        }
+
         if (Query.empty() && Action != "cancel-query" && Action != "fetch-long-query") {
             return TBase::ReplyAndPassAway(GetHTTPBADREQUEST("text/plain", "Query is empty"), "EmptyQuery");
         }

--- a/ydb/core/viewer/viewer_query.h
+++ b/ydb/core/viewer/viewer_query.h
@@ -17,6 +17,8 @@ using namespace NActors;
 class TJsonQuery : public TViewerPipeClient {
     using TThis = TJsonQuery;
     using TBase = TViewerPipeClient;
+    static constexpr bool RunOnDynnode = true;
+
     std::vector<std::vector<Ydb::ResultSet>> ResultSets;
     TString Query;
     TString Action;
@@ -335,14 +337,7 @@ public:
         InitConfig(Params);
     }
 
-    void Bootstrap() override {
-        if (NeedToRedirect()) {
-            return;
-        }
-        if (NeedToWriteAuditLog()) {
-            return;
-        }
-
+    void BootstrapEx() override {
         if (Query.empty() && Action != "cancel-query" && Action != "fetch-long-query") {
             return TBase::ReplyAndPassAway(GetHTTPBADREQUEST("text/plain", "Query is empty"), "EmptyQuery");
         }

--- a/ydb/core/viewer/viewer_render.h
+++ b/ydb/core/viewer/viewer_render.h
@@ -15,6 +15,8 @@ class TJsonRender : public TViewerPipeClient {
     using TThis = TJsonRender;
     using TBase = TViewerPipeClient;
     using TBase::ReplyAndPassAway;
+    static constexpr bool RunOnDynnode = true;
+
     std::vector<TString> Metrics;
 
 public:
@@ -23,10 +25,7 @@ public:
     {
     }
 
-    void Bootstrap() override {
-        if (NeedToRedirect()) {
-            return;
-        }
+    void BootstrapEx() override {
         NKikimrGraph::TEvGetMetrics getRequest;
         if (Params.Has("target")) {
             TString metric;

--- a/ydb/core/viewer/viewer_request.cpp
+++ b/ydb/core/viewer/viewer_request.cpp
@@ -35,13 +35,13 @@ public:
     {
     }
 
-    void Bootstrap() override {
+    void BootstrapEx() override {
         TBase::RequestSettings.MergeFields = Event->Get()->Record.GetMergeFields();
         TBase::RequestSettings.Timeout = Event->Get()->Record.GetTimeout();
         for (TNodeId nodeId : Event->Get()->Record.GetLocation().GetNodeId()) {
             TBase::RequestSettings.FilterNodeIds.push_back(nodeId);
         }
-        TBase::Bootstrap();
+        TBase::BootstrapEx();
     }
 
     THolder<TRequestEventType> BuildRequest() override;

--- a/ydb/core/viewer/viewer_simple_counter.h
+++ b/ydb/core/viewer/viewer_simple_counter.h
@@ -10,6 +10,7 @@ class TViewerSimpleCounter : public TViewerPipeClient {
 public:
     using TThis = TViewerSimpleCounter;
     using TBase = TViewerPipeClient;
+    static constexpr bool RunOnDynnode = true;
 
     TViewerSimpleCounter(IViewer* viewer, NHttp::TEvHttpProxy::TEvHttpIncomingRequest::TPtr& ev)
         : TBase(viewer, ev)
@@ -25,10 +26,7 @@ public:
         return "SIMPLE_COUNTER ";
     }
 
-    void Bootstrap() override {
-        if (TBase::NeedToRedirect()) {
-            return;
-        }
+    void BootstrapEx() override {
         NHttp::TUrlParameters params(HttpEvent->Get()->Request->GetParameters());
         MaxCounter = std::clamp<ui32>(FromStringWithDefault(params.Get("max_counter"), MaxCounter), 1, 100000);
         Period = std::clamp<ui32>(FromStringWithDefault(params.Get("period"), Period), 1, 100000);

--- a/ydb/core/viewer/viewer_storage.h
+++ b/ydb/core/viewer/viewer_storage.h
@@ -122,7 +122,7 @@ public:
         }
     }
 
-    void Bootstrap() override {
+    void BootstrapEx() override {
         if (UsagePace == 0) {
             Send(Initiator, new NMon::TEvHttpInfoRes(Viewer->GetHTTPBADREQUEST(Event->Get(), {}, "Bad Request"), 0, NMon::IEvHttpInfoRes::EContentType::Custom));
             return PassAway();
@@ -132,7 +132,7 @@ public:
         if (hiveId != TDomainsInfo::BadTabletId) {
             RequestHiveStorageStats(hiveId);
         }
-        TBase::Bootstrap();
+        TBase::BootstrapEx();
     }
 
     void Handle(TEvTxProxySchemeCache::TEvNavigateKeySetResult::TPtr& ev) {

--- a/ydb/core/viewer/viewer_tenantinfo.h
+++ b/ydb/core/viewer/viewer_tenantinfo.h
@@ -19,6 +19,8 @@ class TJsonTenantInfo : public TViewerPipeClient {
     using TThis = TJsonTenantInfo;
     using TBase = TViewerPipeClient;
     using TBase::ReplyAndPassAway;
+    static constexpr bool RunOnDynnode = true;
+
     std::optional<TRequestResponse<NConsole::TEvConsole::TEvListTenantsResponse>> ListTenantsResponse;
     std::unordered_map<TString, TRequestResponse<NConsole::TEvConsole::TEvGetTenantStatusResponse>> TenantStatusResponses;
     std::unordered_map<TString, TRequestResponse<TEvTxProxySchemeCache::TEvNavigateKeySetResult>> NavigateKeySetResult;
@@ -110,10 +112,7 @@ public:
         return TBase::MakeRequestSchemeShardDescribe(schemeShardId, path, options);
     }
 
-    void Bootstrap() override {
-        if (NeedToRedirect()) {
-            return;
-        }
+    void BootstrapEx() override {
         const auto& params(Event->Get()->Request.GetParams());
         JsonSettings.EnumAsNumbers = !FromStringWithDefault<bool>(params.Get("enums"), true);
         JsonSettings.UI64AsString = !FromStringWithDefault<bool>(params.Get("ui64"), false);

--- a/ydb/core/viewer/viewer_tenants.h
+++ b/ydb/core/viewer/viewer_tenants.h
@@ -24,7 +24,7 @@ public:
         , Event(ev)
     {}
 
-    void Bootstrap() override {
+    void BootstrapEx() override {
         const auto& params(Event->Get()->Request.GetParams());
         JsonSettings.EnumAsNumbers = !FromStringWithDefault<bool>(params.Get("enums"), true);
         JsonSettings.UI64AsString = !FromStringWithDefault<bool>(params.Get("ui64"), false);

--- a/ydb/core/viewer/viewer_topic_data.cpp
+++ b/ydb/core/viewer/viewer_topic_data.cpp
@@ -239,10 +239,7 @@ void TTopicData::StateRequestedDescribe(TAutoPtr<::NActors::IEventHandle>& ev) {
     }
 }
 
-void TTopicData::Bootstrap() {
-    if (!Database.empty() && TBase::NeedToRedirect()) {
-        return;
-    }
+void TTopicData::BootstrapEx() {
     const auto& params(Event->Get()->Request.GetParams());
     Timeout = TDuration::Seconds(std::min((ui32)Timeout.Seconds(), 30u));
 

--- a/ydb/core/viewer/viewer_topic_data.h
+++ b/ydb/core/viewer/viewer_topic_data.h
@@ -34,6 +34,7 @@ class TTopicData : public TViewerPipeClient {
     using TThis = TTopicData;
     using TBase::ReplyAndPassAway;
     using TBase::GetHTTPBADREQUEST;
+    static constexpr bool RunOnDynnode = true;
 
 private:
     void HandleDescribe(TEvTxProxySchemeCache::TEvNavigateKeySetResult::TPtr& ev);
@@ -50,7 +51,7 @@ public:
         : TViewerPipeClient(viewer, ev)
     {}
 
-    void Bootstrap() override;
+    void BootstrapEx() override;
     void ReplyAndPassAway() override;
 
 private:

--- a/ydb/core/viewer/viewer_whoami.h
+++ b/ydb/core/viewer/viewer_whoami.h
@@ -15,6 +15,7 @@ using namespace NActors;
 
 class TJsonWhoAmI : public TViewerPipeClient {
     using TBase = TViewerPipeClient;
+    static constexpr bool RunOnDynnode = true;
 public:
     static constexpr NKikimrServices::TActivity::EType ActorActivityType() {
         return NKikimrServices::TActivity::VIEWER_HANDLER;
@@ -24,14 +25,11 @@ public:
         : TViewerPipeClient(viewer, ev)
     {}
 
-    void Bootstrap() {
-        if (NeedToRedirect()) {
-            return;
-        }
+    void BootstrapEx() override {
         ReplyAndPassAway();
     }
 
-    void ReplyAndPassAway() {
+    void ReplyAndPassAway() override {
         NACLibProto::TUserToken userToken;
         Y_PROTOBUF_SUPPRESS_NODISCARD userToken.ParseFromString(Event->Get()->UserToken);
         NJson::TJsonValue json(NJson::JSON_MAP);

--- a/ydb/core/viewer/wb_req.h
+++ b/ydb/core/viewer/wb_req.h
@@ -93,7 +93,7 @@ public:
         }
     }
 
-    void Bootstrap() override {
+    void BootstrapEx() override {
         std::replace(RequestSettings.FilterNodeIds.begin(),
                      RequestSettings.FilterNodeIds.end(),
                      (ui32)0,

--- a/ydb/library/actors/http/http_proxy.h
+++ b/ydb/library/actors/http/http_proxy.h
@@ -58,6 +58,8 @@ struct TEvHttpProxy {
         EvHttpOutgoingDataChunk,
         EvSubscribeForCancel,
         EvRequestCancelled,
+        EvAuditExecute,
+        EvAuditExecuteConfirmed,
         EvEnd
     };
 
@@ -294,6 +296,8 @@ struct TEvHttpProxy {
 
     struct TEvSubscribeForCancel : NActors::TEventLocal<TEvSubscribeForCancel, EvSubscribeForCancel> {};
     struct TEvRequestCancelled : NActors::TEventLocal<TEvRequestCancelled, EvRequestCancelled> {};
+    struct TEvAuditExecute : NActors::TEventLocal<TEvAuditExecute, EvAuditExecute> {};
+    struct TEvAuditExecuteConfirmed : NActors::TEventLocal<TEvAuditExecuteConfirmed, EvAuditExecuteConfirmed> {};
 };
 
 struct TRateLimiter {

--- a/ydb/library/actors/http/http_proxy.h
+++ b/ydb/library/actors/http/http_proxy.h
@@ -58,8 +58,6 @@ struct TEvHttpProxy {
         EvHttpOutgoingDataChunk,
         EvSubscribeForCancel,
         EvRequestCancelled,
-        EvAuditExecute,
-        EvAuditExecuteConfirmed,
         EvEnd
     };
 
@@ -296,8 +294,6 @@ struct TEvHttpProxy {
 
     struct TEvSubscribeForCancel : NActors::TEventLocal<TEvSubscribeForCancel, EvSubscribeForCancel> {};
     struct TEvRequestCancelled : NActors::TEventLocal<TEvRequestCancelled, EvRequestCancelled> {};
-    struct TEvAuditExecute : NActors::TEventLocal<TEvAuditExecute, EvAuditExecute> {};
-    struct TEvAuditExecuteConfirmed : NActors::TEventLocal<TEvAuditExecuteConfirmed, EvAuditExecuteConfirmed> {};
 };
 
 struct TRateLimiter {


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

An audit log entry is required upon request reception, EXCLUDING redirect cases.

### Changelog category <!-- remove all except one -->

* Improvement

### Description for reviewers <!-- (optional) description for those who read this PR -->

Audit logging should happen twice for each request:
- **On request receipt** - to record the start of processing.
- **When the result is known** - to record the final status.

Logging of redirects must be excluded.

When registering a http handler, you can choose one of two audit logging strategies:
- **AutoAuditStart = true** - Audit logging is triggered automatically when the handler is called. 
- **AutoAuditStart = false** - The handler explicitly controls when audit logging starts.

The monitoring service request actor records a final entry with the request outcome.

In this PR, `AuditDirectedStart` is added to YDB Viewer. It is set for all modifying handlers immediately after a redirect attempt, to avoid logging requests that return a redirect as unnecessary.

An audit log for a single user operation might look like this now:
```
2025-08-07T13:36:51.053111Z: {"status":"IN-PROCESS", "reason":"Execute", "operation":"HTTP REQUEST","url":"/viewer/query","component":"monitoring", ...}
2025-08-07T13:36:51.053433Z: {"status":"SUCCESS", "operation":"HTTP REQUEST","url":"/viewer/query","component":"monitoring" ...}
```
Requests with a redirect in the response will be skipped.