### PR TITLE
Unify Private Cache counters behaviour

### DIFF
--- a/ydb/core/tablet_flat/flat_executor.cpp
+++ b/ydb/core/tablet_flat/flat_executor.cpp
@@ -229,8 +229,6 @@ void TExecutor::Broken() {
 void TExecutor::RecreatePageCollectionsCache()
 {
     PrivatePageCache = MakeHolder<TPrivatePageCache>();
-    StickyPagesMemory = 0;
-    TryKeepInMemoryMemory = 0;
 
     Stats->PacksMetaBytes = 0;
 
@@ -720,7 +718,7 @@ void TExecutor::AddCachesOfBundle(const NTable::TPartView &partView, const THash
     for (size_t collectionsIndex : xrange( partStore->PageCollections.size())) {
         auto& cache = partStore->PageCollections[collectionsIndex];
         if (collectionsIndex < partView->GroupsCount) {
-            cache->UpdateCacheMode(GetCacheMode(partView->Scheme->Groups[collectionsIndex].Columns, cacheModes));
+            cache->SetCacheMode(GetCacheMode(partView->Scheme->Groups[collectionsIndex].Columns, cacheModes));
         }
         AddSingleCache(cache);
     }
@@ -734,12 +732,6 @@ void TExecutor::AddSingleCache(const TIntrusivePtr<TPrivatePageCache::TInfo> &in
     auto sharedCacheTouches = PrivatePageCache->AddPageCollection(info);
     Send(MakeSharedPageCacheId(), new NSharedCache::TEvAttach(info->PageCollection, info->GetCacheMode()));
     SendSharedCacheTouches(std::move(sharedCacheTouches));
-
-    StickyPagesMemory += info->GetStickySize();
-    TryKeepInMemoryMemory += info->GetTryKeepInMemorySize();
-
-    Counters->Simple()[TExecutorCounters::CACHE_TOTAL_STICKY] = StickyPagesMemory;
-    Counters->Simple()[TExecutorCounters::CACHE_TOTAL_TRY_KEEP_IN_MEMORY] = TryKeepInMemoryMemory;
 }
 
 void TExecutor::DropCachesOfBundle(const NTable::TPart &part)
@@ -764,22 +756,11 @@ void TExecutor::DropSingleCache(const TLogoBlobID &label)
 {
     auto pageCollection = PrivatePageCache->GetPageCollection(label);
 
-    ui64 stickySize = pageCollection->GetStickySize();
-    Y_ENSURE(StickyPagesMemory >= stickySize);
-    StickyPagesMemory -= stickySize;
-
-    ui64 tryKeepInMemorySize = pageCollection->GetTryKeepInMemorySize();
-    Y_ENSURE(TryKeepInMemoryMemory >= tryKeepInMemorySize);
-    TryKeepInMemoryMemory -= tryKeepInMemorySize;
-
     PrivatePageCache->DropPageCollection(pageCollection);
 
     // Note: Shared Cache will send TEvResult with NKikimrProto::RACE status
     // it activates all transactions that are waiting for being dropped page collection
     Send(MakeSharedPageCacheId(), new NSharedCache::TEvDetach(label));
-
-    Counters->Simple()[TExecutorCounters::CACHE_TOTAL_STICKY] = StickyPagesMemory;
-    Counters->Simple()[TExecutorCounters::CACHE_TOTAL_TRY_KEEP_IN_MEMORY] = TryKeepInMemoryMemory;
 }
 
 void TExecutor::SendSharedCacheTouches(THashMap<TLogoBlobID, THashSet<TPageId>>&& touches) {
@@ -814,29 +795,6 @@ void TExecutor::UpdateCachePagesForDatabase(bool pendingOnly) {
         table.PendingCacheEnable = false;
         table.PendingCacheModeChange = false;
     }
-}
-
-void TExecutor::StickInMemPages(NSharedCache::TEvResult *msg) {
-    const auto& scheme = Scheme();
-    for (auto& pr : scheme.Tables) {
-        const ui32 tid = pr.first;
-        auto subset = Database->Subset(tid, NTable::TEpoch::Max(), { } , { });
-        for (auto &partView : subset->Flatten) {
-            auto partStore = partView.As<NTable::TPartStore>();
-            for (auto &pageCollection : partStore->PageCollections) {
-                // Note: page collection search optimization seems useless
-                if (pageCollection->PageCollection == msg->PageCollection) {
-                    ui64 stickySizeBefore = pageCollection->GetStickySize();
-                    for (auto& loaded : msg->Pages) {
-                        pageCollection->AddStickyPage(loaded.PageId, loaded.Page);
-                    }
-                    StickyPagesMemory += pageCollection->GetStickySize() - stickySizeBefore;
-                }
-            }
-        }
-    }
-    Counters->Simple()[TExecutorCounters::CACHE_TOTAL_STICKY] = StickyPagesMemory;
-    // Note: the next call of ProvideBlock will also fill pages bodies
 }
 
 TExecutorCaches TExecutor::CleanupState() {
@@ -1511,24 +1469,12 @@ void TExecutor::UpdateCacheModesForPartStore(NTable::TPartView& partView, const 
 
     for (size_t groupIndex : xrange(partView->GroupsCount)) {
         ECacheMode cacheMode = GetCacheMode(partView->Scheme->Groups[groupIndex].Columns, cacheModes);
+        auto* pageCollection = partView.As<NTable::TPartStore>()->PageCollections[groupIndex].Get();
 
-        auto& cacheInfo = partView.As<NTable::TPartStore>()->PageCollections[groupIndex];
-        ui64 tryKeepInMemorySizeBefore = cacheInfo->GetTryKeepInMemorySize();
-
-        if (cacheInfo->UpdateCacheMode(cacheMode)) {
-            Send(MakeSharedPageCacheId(), new NSharedCache::TEvAttach(cacheInfo->PageCollection, cacheInfo->GetCacheMode()));
-            switch (cacheMode) {
-            case ECacheMode::Regular:
-                Y_ENSURE(TryKeepInMemoryMemory >= tryKeepInMemorySizeBefore);
-                TryKeepInMemoryMemory -= tryKeepInMemorySizeBefore;
-                break;
-            case ECacheMode::TryKeepInMemory:
-                TryKeepInMemoryMemory += cacheInfo->GetTryKeepInMemorySize();
-                break;
-            }
+        if (PrivatePageCache->UpdateCacheMode(cacheMode, pageCollection)) {
+            Send(MakeSharedPageCacheId(), new NSharedCache::TEvAttach(pageCollection->PageCollection, pageCollection->GetCacheMode()));
         }
     }
-    Counters->Simple()[TExecutorCounters::CACHE_TOTAL_TRY_KEEP_IN_MEMORY] = TryKeepInMemoryMemory;
 }
 
 void TExecutor::RequestInMemPagesForPartStore(NTable::TPartView& partView, const THashSet<NTable::TTag>& stickyColumns) {
@@ -3094,12 +3040,13 @@ void TExecutor::Handle(NSharedCache::TEvResult::TPtr &ev) {
             }
 
             if (requestType == ESharedCacheRequestType::InMemPages) {
-                StickInMemPages(msg);
-            }
-            for (auto& loaded : msg->Pages) {
-                PrivatePageCache->AddPage(loaded.PageId, loaded.Page, pageCollection);
-            }
-            if (requestType == ESharedCacheRequestType::Transaction) {
+                for (auto& loaded : msg->Pages) {
+                    PrivatePageCache->AddStickyPage(loaded.PageId, std::move(loaded.Page), pageCollection);
+                }
+            } else { // requestType == ESharedCacheRequestType::Transaction
+                for (auto& loaded : msg->Pages) {
+                    PrivatePageCache->AddPage(loaded.PageId, loaded.Page, pageCollection);
+                }
                 TryActivateWaitingTransaction(std::move(msg->WaitPad), std::move(msg->Pages), pageCollection);
             }
         }
@@ -3925,8 +3872,11 @@ void TExecutor::UpdateUsedTabletMemory() {
     UsedTabletMemory = 50_KB;
 
     // Count the number of bytes that can't be offloaded right now:
-    UsedTabletMemory += StickyPagesMemory;
-    UsedTabletMemory += TryKeepInMemoryMemory;
+    if (PrivatePageCache) {
+        const auto &stats = PrivatePageCache->GetStats();
+        UsedTabletMemory += stats.StickyBytes;
+        UsedTabletMemory += stats.TryKeepInMemoryBytes;
+    }
     UsedTabletMemory += TransactionPagesMemory;
 
     // Estimate memory used by internal database structures:
@@ -4026,11 +3976,12 @@ void TExecutor::UpdateCounters(const TActorContext &ctx) {
 
             if (PrivatePageCache) {
                 const auto &stats = PrivatePageCache->GetStats();
-                Counters->Simple()[TExecutorCounters::CACHE_TOTAL_COLLECTIONS].Set(stats.TotalCollections);
-                Counters->Simple()[TExecutorCounters::CACHE_TOTAL_SHARED_BODY].Set(stats.TotalSharedBody);
+                Counters->Simple()[TExecutorCounters::CACHE_TOTAL_COLLECTIONS].Set(stats.PageCollections);
+                Counters->Simple()[TExecutorCounters::CACHE_TOTAL_SHARED_BODY].Set(stats.SharedBodyBytes);
+                Counters->Simple()[TExecutorCounters::CACHE_TOTAL_STICKY].Set(stats.StickyBytes);
+                Counters->Simple()[TExecutorCounters::CACHE_TOTAL_TRY_KEEP_IN_MEMORY].Set(stats.TryKeepInMemoryBytes);
             }
-            Counters->Simple()[TExecutorCounters::CACHE_TOTAL_STICKY].Set(StickyPagesMemory);
-            Counters->Simple()[TExecutorCounters::CACHE_TOTAL_TRY_KEEP_IN_MEMORY].Set(TryKeepInMemoryMemory);
+            
             Counters->Simple()[TExecutorCounters::CACHE_TOTAL_USED].Set(TransactionPagesMemory);
 
             const auto &memory = Memory->Stats();
@@ -4558,10 +4509,10 @@ void TExecutor::RenderHtmlPage(NMon::TEvRemoteHttpInfo::TPtr &ev) const {
                 CompactionLogic->OutputHtml(str, *scheme, cgi);
 
             TAG(TH3) {str << "Page collection cache:";}
-            DIV_CLASS("row") {str << "Total collections: " << PrivatePageCache->GetStats().TotalCollections; }
-            DIV_CLASS("row") {str << "Total bytes in shared cache: " << PrivatePageCache->GetStats().TotalSharedBody; }
-            DIV_CLASS("row") {str << "Total bytes marked as sticky: " << StickyPagesMemory; }
-            DIV_CLASS("row") {str << "Total bytes for try-keep-in-memory Mode: " << TryKeepInMemoryMemory; }
+            DIV_CLASS("row") {str << "Total collections: " << PrivatePageCache->GetStats().PageCollections; }
+            DIV_CLASS("row") {str << "Total bytes in shared cache: " << PrivatePageCache->GetStats().SharedBodyBytes; }
+            DIV_CLASS("row") {str << "Total bytes marked as sticky: " << PrivatePageCache->GetStats().StickyBytes; }
+            DIV_CLASS("row") {str << "Total bytes for try-keep-in-memory Mode: " << PrivatePageCache->GetStats().TryKeepInMemoryBytes; }
             DIV_CLASS("row") {str << "Total bytes currently in use: " << TransactionPagesMemory; }
 
             if (GcLogic) {

--- a/ydb/core/tablet_flat/flat_executor.cpp
+++ b/ydb/core/tablet_flat/flat_executor.cpp
@@ -715,11 +715,13 @@ void TExecutor::AddCachesOfBundle(const NTable::TPartView &partView, const THash
             Stats->PacksMetaBytes += pack->Meta.Raw.size();
     }
 
-    for (size_t collectionsIndex : xrange( partStore->PageCollections.size())) {
-        auto& cache = partStore->PageCollections[collectionsIndex];
-        if (collectionsIndex < partView->GroupsCount) {
-            cache->SetCacheMode(GetCacheMode(partView->Scheme->Groups[collectionsIndex].Columns, cacheModes));
-        }
+    for (size_t groupIndex : xrange(partView->GroupsCount)) {
+        partStore->PageCollections[groupIndex]->SetCacheMode(
+            GetCacheMode(partView->Scheme->Groups[groupIndex].Columns, cacheModes)
+        );
+    }
+
+    for (auto &cache : partStore->PageCollections) {
         AddSingleCache(cache);
     }
 

--- a/ydb/core/tablet_flat/flat_executor.h
+++ b/ydb/core/tablet_flat/flat_executor.h
@@ -499,8 +499,6 @@ class TExecutor
     size_t ReadyPartSwitches = 0;
 
     ui64 UsedTabletMemory = 0;
-    ui64 StickyPagesMemory = 0;
-    ui64 TryKeepInMemoryMemory = 0;
     ui64 TransactionPagesMemory = 0;
 
     TActorContext SelfCtx() const;
@@ -560,7 +558,6 @@ class TExecutor
     void UpdateCacheModesForPartStore(NTable::TPartView& partView, const THashMap<NTable::TTag, ECacheMode>& cacheModes);
     void UpdateCachePagesForDatabase(bool pendingOnly = false);
     void RequestInMemPagesForPartStore(NTable::TPartView& partView, const THashSet<NTable::TTag>& stickyColumns);
-    void StickInMemPages(NSharedCache::TEvResult *msg);
     THashSet<NTable::TTag> GetStickyColumns(ui32 tableId);
     THashMap<NTable::TTag, ECacheMode> GetCacheModes(ui32 tableId);
     ECacheMode GetCacheMode(const TVector<NTable::TPartScheme::TColumn>& columns, const THashMap<NTable::TTag, ECacheMode>& cacheModes);

--- a/ydb/core/tablet_flat/flat_sausagecache.cpp
+++ b/ydb/core/tablet_flat/flat_sausagecache.cpp
@@ -67,6 +67,10 @@ THashMap<TLogoBlobID, THashSet<TPageId>> TPrivatePageCache::AddPageCollection(TI
         sharedCacheTouches[page->Info->Id].insert(page->Id);
     }
 
+    if (info->GetCacheMode() == ECacheMode::TryKeepInMemory) {
+        Stats.TryKeepInMemoryBytes += info->PageCollection->BackingSize();
+    }
+
     return sharedCacheTouches;
 }
 
@@ -78,6 +82,10 @@ void TPrivatePageCache::DropPageCollection(TInfo *info) {
         if (info->IsStickyPage(pageId)) {
             Stats.StickyBytes -= page->Size;
         }
+    }
+
+    if (info->GetCacheMode() == ECacheMode::TryKeepInMemory) {
+        Stats.TryKeepInMemoryBytes -= info->PageCollection->BackingSize();
     }
 
     info->Clear();

--- a/ydb/core/tablet_flat/flat_sausagecache.cpp
+++ b/ydb/core/tablet_flat/flat_sausagecache.cpp
@@ -29,7 +29,6 @@ TPrivatePageCache::TInfo::TInfo(const TInfo &info)
     : Id(info.Id)
     , PageCollection(info.PageCollection)
     , StickyPages(info.StickyPages)
-    , StickyPagesSize(info.StickyPagesSize)
     , CacheMode(info.CacheMode)
 {
     PageMap.resize(info.PageMap.size());
@@ -53,13 +52,16 @@ TPrivatePageCache::TInfo* TPrivatePageCache::GetPageCollection(const TLogoBlobID
 THashMap<TLogoBlobID, THashSet<TPageId>> TPrivatePageCache::AddPageCollection(TIntrusivePtr<TInfo> info) {
     auto inserted = PageCollections.insert(decltype(PageCollections)::value_type(info->Id, info));
     Y_ENSURE(inserted.second, "double registration of page collection is forbidden");
-    ++Stats.TotalCollections;
+    ++Stats.PageCollections;
 
     THashMap<TLogoBlobID, THashSet<TPageId>> sharedCacheTouches;
     for (const auto& [pageId, page] : info->GetPageMap()) {
         Y_ASSERT(page);
         
-        Stats.TotalSharedBody += page->Size;
+        Stats.SharedBodyBytes += page->Size;
+        if (info->IsStickyPage(pageId)) {
+            Stats.StickyBytes += page->Size;
+        }
 
         // notify shared cache that we have a page handle
         sharedCacheTouches[page->Info->Id].insert(page->Id);
@@ -72,13 +74,16 @@ void TPrivatePageCache::DropPageCollection(TInfo *info) {
     for (const auto& [pageId, page] : info->GetPageMap()) {
         Y_ASSERT(page);
 
-        Stats.TotalSharedBody -= page->Size;
+        Stats.SharedBodyBytes -= page->Size;
+        if (info->IsStickyPage(pageId)) {
+            Stats.StickyBytes -= page->Size;
+        }
     }
 
     info->Clear();
 
     PageCollections.erase(info->Id);
-    --Stats.TotalCollections;
+    --Stats.PageCollections;
 }
 
 TSharedPageRef TPrivatePageCache::TryGetPage(TPageId pageId, TInfo *info) {
@@ -98,16 +103,46 @@ TSharedPageRef TPrivatePageCache::TryGetPage(TPageId pageId, TInfo *info) {
 
 void TPrivatePageCache::DropPage(TPageId pageId, TInfo *info) {
     if (info->DropPage(pageId)) {
-        Stats.TotalSharedBody -= info->GetPageSize(pageId);
+        Y_ENSURE(!info->IsStickyPage(pageId));
+        Stats.SharedBodyBytes -= info->GetPageSize(pageId);
     }
 }
 
 void TPrivatePageCache::AddPage(TPageId pageId, TSharedPageRef sharedBody, TInfo *info)
 {
     if (info->AddPage(pageId, std::move(sharedBody))) {
-        Stats.TotalSharedBody += info->GetPageSize(pageId);
+        Stats.SharedBodyBytes += info->GetPageSize(pageId);
     }
 }
+
+void TPrivatePageCache::AddStickyPage(TPageId pageId, TSharedPageRef sharedBody, TInfo *info)
+{
+    AddPage(pageId, sharedBody, info);
+    if (info->AddStickyPage(pageId, std::move(sharedBody))) {
+        Stats.StickyBytes += info->GetPageSize(pageId);
+    }
+}
+
+bool TPrivatePageCache::UpdateCacheMode(ECacheMode newCacheMode, TInfo *info)
+{
+    auto oldCacheMode = info->GetCacheMode();
+    if (oldCacheMode == newCacheMode) {
+        return false;
+    }
+
+    auto tryKeepInMemoryBytesDelta = info->PageCollection->BackingSize();
+    if (oldCacheMode == ECacheMode::TryKeepInMemory) {
+        Stats.TryKeepInMemoryBytes -= tryKeepInMemoryBytesDelta;
+    }
+
+    info->SetCacheMode(newCacheMode);
+
+    if (newCacheMode == ECacheMode::TryKeepInMemory) {
+        Stats.TryKeepInMemoryBytes += tryKeepInMemoryBytesDelta;
+    }
+
+    return true;
+};
 
 THashMap<TLogoBlobID, TIntrusivePtr<TPrivatePageCache::TInfo>> TPrivatePageCache::DetachPrivatePageCache() {
     THashMap<TLogoBlobID, TIntrusivePtr<TPrivatePageCache::TInfo>> ret;

--- a/ydb/core/tablet_flat/flat_sausagecache.h
+++ b/ydb/core/tablet_flat/flat_sausagecache.h
@@ -69,8 +69,12 @@ public:
             return StickyPages.contains(pageId);
         }
 
-        // Mutable methods can be only called on a construction stage or from Private Cache
-        // Otherwise Stats counters would be out of sync
+        ECacheMode GetCacheMode() const noexcept {
+            return CacheMode;
+        }
+
+        // Mutable methods can be only called on a construction stage or from a Private Cache
+        // Otherwise stat counters would be out of sync
 
         bool AddPage(TPageId pageId, TSharedPageRef sharedBody) {
             return PageMap.emplace(pageId, MakeHolder<TPage>(
@@ -97,10 +101,6 @@ public:
 
         void SetCacheMode(ECacheMode cacheMode) {
             CacheMode = cacheMode;
-        }
-
-        ECacheMode GetCacheMode() const noexcept {
-            return CacheMode;
         }
 
         const TLogoBlobID Id;


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

...

### Changelog category <!-- remove all except one -->

* Not for changelog (changelog entry is not required)

### Description for reviewers <!-- (optional) description for those who read this PR -->

Make all Private Cache counters work the same: change TInfo counters during construction/load stage, and modify them via Private Cache only otherwise 