### PR TITLE
stop using TFsPath in backup / restore for db paths

### DIFF
--- a/ydb/library/backup/backup.cpp
+++ b/ydb/library/backup/backup.cpp
@@ -483,11 +483,14 @@ void DropTable(TDriver driver, const TString& path) {
     VerifyStatus(status, TStringBuilder() << "Drop table " << path.Quote() << " failed");
 }
 
-TFsPath CreateDirectory(const TFsPath& folderPath, const TString& name) {
-    TFsPath childFolderPath = folderPath.Child(name);
-    LOG_D("Process " << childFolderPath.GetPath().Quote());
-    childFolderPath.MkDir();
-    return childFolderPath;
+TFsPath CreateDirectory(const TFsPath& fsParentPath, const TString& dbRelativePath) {
+    const TPathSplitUnix dbRelativePathSplit(dbRelativePath);
+    TPathSplit fsPathSplit(fsParentPath.PathSplit());
+    fsPathSplit.AppendMany(dbRelativePathSplit.begin(), dbRelativePathSplit.end());
+    TFsPath fsPath(fsPathSplit.Reconstruct());
+    LOG_D("Process " << fsPath.GetPath().Quote());
+    fsPath.MkDirs();
+    return fsPath;
 }
 
 void WriteProtoToFile(const google::protobuf::Message& proto, const TFsPath& folderPath, const NDump::NFiles::TFileInfo& fileInfo) {
@@ -689,17 +692,20 @@ void BackupDependentResources(TDriver driver, const std::string& coordinationNod
     NRateLimiter::TRateLimiterClient client(driver);
     const auto rateLimiters = ListRateLimiters(client, coordinationNodePath);
 
-    for (const auto& rateLimiterPath : rateLimiters) {
-        const auto desc = DescribeRateLimiter(client, coordinationNodePath, rateLimiterPath);
+    for (const auto& dbRateLimiterPath : rateLimiters) {
+        const auto desc = DescribeRateLimiter(client, coordinationNodePath, dbRateLimiterPath);
         Ydb::RateLimiter::CreateResourceRequest request;
         desc.GetHierarchicalDrrProps().SerializeTo(*request.mutable_resource()->mutable_hierarchical_drr());
         if (const auto& meteringConfig = desc.GetMeteringConfig()) {
             meteringConfig->SerializeTo(*request.mutable_resource()->mutable_metering_config());
         }
 
-        TFsPath childFolderPath = fsBackupFolder.Child(TString{rateLimiterPath});
-        childFolderPath.MkDirs();
-        WriteProtoToFile(request, childFolderPath, NDump::NFiles::CreateRateLimiter());
+        const TPathSplitUnix dbRateLimiterPathSplit(dbRateLimiterPath);
+        TPathSplit fsRateLimiterPathSplit = fsBackupFolder.PathSplit();
+        fsRateLimiterPathSplit.AppendMany(dbRateLimiterPathSplit.begin(), dbRateLimiterPathSplit.end());
+        TFsPath fsRateLimiterPath(fsRateLimiterPathSplit.Reconstruct());
+        fsRateLimiterPath.MkDirs();
+        WriteProtoToFile(request, fsRateLimiterPath, NDump::NFiles::CreateRateLimiter());
     }
 }
 

--- a/ydb/library/backup/backup.cpp
+++ b/ydb/library/backup/backup.cpp
@@ -703,7 +703,7 @@ void BackupDependentResources(TDriver driver, const std::string& coordinationNod
         const TPathSplitUnix dbRateLimiterPathSplit(dbRateLimiterPath);
         TPathSplit fsRateLimiterPathSplit = fsBackupFolder.PathSplit();
         fsRateLimiterPathSplit.AppendMany(dbRateLimiterPathSplit.begin(), dbRateLimiterPathSplit.end());
-        TFsPath fsRateLimiterPath(fsRateLimiterPathSplit.Reconstruct());
+        const TFsPath fsRateLimiterPath(fsRateLimiterPathSplit.Reconstruct());
         fsRateLimiterPath.MkDirs();
         WriteProtoToFile(request, fsRateLimiterPath, NDump::NFiles::CreateRateLimiter());
     }

--- a/ydb/library/backup/backup.cpp
+++ b/ydb/library/backup/backup.cpp
@@ -628,7 +628,7 @@ void BackupView(TDriver driver, const TString& dbBackupRoot, const TString& dbPa
     const auto viewDescription = DescribeView(driver, dbPath);
 
     const auto creationQuery = NDump::BuildCreateViewQuery(
-        TFsPath(dbPathRelativeToBackupRoot).GetName(),
+        TString(TPathSplitUnix(dbPathRelativeToBackupRoot).back()),
         dbPath,
         TString(viewDescription.GetQueryText()),
         dbBackupRoot,

--- a/ydb/public/lib/ydb_cli/dump/restore_impl.cpp
+++ b/ydb/public/lib/ydb_cli/dump/restore_impl.cpp
@@ -1526,9 +1526,10 @@ TRestoreResult TRestoreClient::RestoreDependentResources(const TFsPath& fsPath, 
 
         if (path.IsDirectory()) {
             if (IsFileExists(path.Child(NFiles::CreateRateLimiter().FileName))) {
-                const auto& pathSplit = path.RelativeTo(fsPath).PathSplit();
+                auto resourcePath = path.RelativeTo(fsPath);
+                const auto& resourcePathSplit = resourcePath.PathSplit();
                 TPathSplitUnix canonicalPathSplit;
-                canonicalPathSplit.AppendMany(pathSplit.begin(), pathSplit.end());
+                canonicalPathSplit.AppendMany(resourcePathSplit.begin(), resourcePathSplit.end());
                 const auto result = RestoreRateLimiter(path, dbPath, canonicalPathSplit.Reconstruct());
                 if (!result.IsSuccess()) {
                     return result;

--- a/ydb/public/lib/ydb_cli/dump/restore_impl.cpp
+++ b/ydb/public/lib/ydb_cli/dump/restore_impl.cpp
@@ -1526,7 +1526,10 @@ TRestoreResult TRestoreClient::RestoreDependentResources(const TFsPath& fsPath, 
 
         if (path.IsDirectory()) {
             if (IsFileExists(path.Child(NFiles::CreateRateLimiter().FileName))) {
-                const auto result = RestoreRateLimiter(path, dbPath, path.RelativeTo(fsPath).GetPath());
+                const auto& pathSplit = path.RelativeTo(fsPath).PathSplit();
+                TPathSplitUnix canonicalPathSplit;
+                canonicalPathSplit.AppendMany(pathSplit.begin(), pathSplit.end());
+                const auto result = RestoreRateLimiter(path, dbPath, canonicalPathSplit.Reconstruct());
                 if (!result.IsSuccess()) {
                     return result;
                 }


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

### Changelog category <!-- remove all except one -->

* Not for changelog (changelog entry is not required)

### Description for reviewers <!-- (optional) description for those who read this PR -->

This particular usage was harmless, but we must be very careful, because TFsPath works differently on Windows.

Issue:
- https://github.com/ydb-platform/ydb/issues/22688
