### PR TITLE
Rename TPrivatePageCache::TInfo to TPageCollection

### DIFF
--- a/ydb/core/tablet_flat/flat_boot_back.h
+++ b/ydb/core/tablet_flat/flat_boot_back.h
@@ -107,7 +107,7 @@ namespace NBoot {
         TDeque<TBody> TurnsLog;
         TDeque<TSwitch> Switches;
         THashMap<ui32, NTable::TSnapEdge> Edges;
-        THashMap<TLogoBlobID, TIntrusivePtr<TPrivatePageCache::TInfo>> PageCaches;
+        THashMap<TLogoBlobID, TIntrusivePtr<TPrivatePageCache::TPageCollection>> PageCollections;
         THashMap<TLogoBlobID, TSharedData> TxStatusCaches;
     };
 

--- a/ydb/core/tablet_flat/flat_boot_bundle.h
+++ b/ydb/core/tablet_flat/flat_boot_bundle.h
@@ -17,7 +17,7 @@ namespace NBoot {
 
     class TBundleLoadStep final: public NBoot::IStep {
     public:
-        using TCache = TPrivatePageCache::TInfo;
+        using TPageCollection = TPrivatePageCache::TPageCollection;
 
         static constexpr NBoot::EStep StepKind = NBoot::EStep::Bundle;
 
@@ -41,8 +41,8 @@ namespace NBoot {
             PageCollections.resize(LargeGlobIds.size());
 
             for (auto slot: xrange(LargeGlobIds.size())) {
-                if (auto *info = Back->PageCaches.FindPtr(LargeGlobIds[slot].Lead)) {
-                    PageCollections[slot] = *info;
+                if (auto *pageCollection = Back->PageCollections.FindPtr(LargeGlobIds[slot].Lead)) {
+                    PageCollections[slot] = *pageCollection;
                 } else {
                     LeftMetas += Spawn<TLoadBlobs>(LargeGlobIds[slot], slot);
                 }
@@ -85,7 +85,7 @@ namespace NBoot {
             } else {
                 auto *pack = new NPageCollection::TPageCollection(load->LargeGlobId, load->PlainData());
 
-                PageCollections[load->Cookie] = new TPrivatePageCache::TInfo(pack);
+                PageCollections[load->Cookie] = new TPageCollection(pack);
             }
 
             TryLoad();
@@ -137,11 +137,11 @@ namespace NBoot {
 
         void PropagateSideEffects(const NTable::TPartView &partView)
         {
-            for (auto &cache : partView.As<NTable::TPartStore>()->PageCollections)
-                Logic->Result().PageCaches.push_back(cache);
+            for (auto &pageCollection : partView.As<NTable::TPartStore>()->PageCollections)
+                Logic->Result().PageCollections.push_back(pageCollection);
 
-            if (auto &cache = partView.As<NTable::TPartStore>()->Pseudo)
-                Logic->Result().PageCaches.push_back(cache);
+            if (auto &pageCollection = partView.As<NTable::TPartStore>()->Pseudo)
+                Logic->Result().PageCollections.push_back(pageCollection);
         }
 
     private:
@@ -149,7 +149,7 @@ namespace NBoot {
 
         TAutoPtr<NTable::TLoader> Loader;
         TVector<NPageCollection::TLargeGlobId> LargeGlobIds;
-        TVector<TIntrusivePtr<TCache>> PageCollections;
+        TVector<TIntrusivePtr<TPrivatePageCache::TPageCollection>> PageCollections;
         TString Legacy;
         TString Opaque;
         TVector<TString> Deltas;

--- a/ydb/core/tablet_flat/flat_dbase_sz_env.h
+++ b/ydb/core/tablet_flat/flat_dbase_sz_env.h
@@ -9,7 +9,7 @@ namespace NKikimr {
 namespace NTable {
 
     struct TSizeEnv : public IPages {
-        using TInfo = NTabletFlatExecutor::TPrivatePageCache::TInfo;
+        using TPageCollection = NTabletFlatExecutor::TPrivatePageCache::TPageCollection;
 
         TSizeEnv(IPages* env)
             : Env(env)
@@ -55,7 +55,7 @@ namespace NTable {
         }
 
     private:
-        void AddPageSize(TInfo *info, TPageId pageId)
+        void AddPageSize(TPageCollection *info, TPageId pageId)
         {
             if (Touched[info].insert(pageId).second) {
                 Pages++;

--- a/ydb/core/tablet_flat/flat_executor.h
+++ b/ydb/core/tablet_flat/flat_executor.h
@@ -96,7 +96,7 @@ struct TPendingPartSwitch {
             : PartComponents(std::move(pc))
         {
             for (size_t idx = 0; idx < PartComponents.PageCollectionComponents.size(); ++idx) {
-                if (!PartComponents.PageCollectionComponents[idx].Packet) {
+                if (!PartComponents.PageCollectionComponents[idx].PageCollection) {
                     Loaders.emplace_back(idx, PartComponents.PageCollectionComponents[idx].LargeGlobId);
                 }
             }
@@ -108,7 +108,7 @@ struct TPendingPartSwitch {
 
         bool Accept(TLargeGlobLoaders::iterator it, const TLogoBlobID& id, TString body) {
             if (it->Accept(id, std::move(body))) {
-                PartComponents.PageCollectionComponents[it->Index].ParsePacket(it->Finish());
+                PartComponents.PageCollectionComponents[it->Index].ParsePageCollection(it->Finish());
                 Loaders.erase(it);
                 return !Loaders;
             }
@@ -305,7 +305,7 @@ struct TTransactionWaitPad : public NPageCollection::TPagesWaitPad {
 struct TCompactionChangesCtx;
 
 struct TExecutorCaches {
-    THashMap<TLogoBlobID, TIntrusivePtr<TPrivatePageCache::TInfo>> PageCaches;
+    THashMap<TLogoBlobID, TIntrusivePtr<TPrivatePageCache::TPageCollection>> PageCollections;
     THashMap<TLogoBlobID, TSharedData> TxStatusCaches;
 };
 
@@ -513,7 +513,7 @@ class TExecutor
     void Broken();
     void Active(const TActorContext &ctx);
     void ActivateFollower(const TActorContext &ctx);
-    void RecreatePageCollectionsCache();
+    void RecreatePrivateCache();
     void ReflectSchemeSettings();
     void OnYellowChannels(TVector<ui32> yellowMoveChannels, TVector<ui32> yellowStopChannels) override;
     void CheckYellow(TVector<ui32> &&yellowMoveChannels, TVector<ui32> &&yellowStopChannels, bool terminal = false);
@@ -546,13 +546,13 @@ class TExecutor
     void EnqueueActivation(TSeat* seat, bool activate);
     void PlanTransactionActivation();
     void MakeLogSnapshot();
-    void TryActivateWaitingTransaction(TIntrusivePtr<NPageCollection::TPagesWaitPad>&& waitPad, TVector<NSharedCache::TEvResult::TLoaded>&& pages, TPrivatePageCache::TInfo* collectionInfo);
+    void TryActivateWaitingTransaction(TIntrusivePtr<NPageCollection::TPagesWaitPad>&& waitPad, TVector<NSharedCache::TEvResult::TLoaded>&& pages, TPrivatePageCache::TPageCollection* collectionInfo);
     void ActivateWaitingTransaction(TTransactionWaitPad& transaction);
     void LogWaitingTransaction(const TTransactionWaitPad& transaction);
-    void AddCachesOfBundle(const NTable::TPartView &partView, const THashMap<NTable::TTag, ECacheMode>& cacheModes);
-    void AddSingleCache(const TIntrusivePtr<TPrivatePageCache::TInfo> &info);
-    void DropCachesOfBundle(const NTable::TPart &part);
-    void DropSingleCache(const TLogoBlobID&);
+    void AddPartStorePageCollections(const NTable::TPartView &partView, const THashMap<NTable::TTag, ECacheMode>& cacheModes);
+    void AddPageCollection(const TIntrusivePtr<TPrivatePageCache::TPageCollection> &pageCollection);
+    void DropPartStorePageCollections(const NTable::TPart &part);
+    void DropPageCollection(const TLogoBlobID& pageCollectionId);
 
     void SendSharedCacheTouches(THashMap<TLogoBlobID, THashSet<TPageId>>&& touches);
     void UpdateCacheModesForPartStore(NTable::TPartView& partView, const THashMap<NTable::TTag, ECacheMode>& cacheModes);

--- a/ydb/core/tablet_flat/flat_executor_bootlogic.cpp
+++ b/ydb/core/tablet_flat/flat_executor_bootlogic.cpp
@@ -133,7 +133,7 @@ void TExecutorBootLogic::PrepareEnv(bool follower, ui32 gen, TExecutorCaches cac
 
     State_ = new NBoot::TBack(follower, Info->TabletID, gen);
     State().Scheme = new NTable::TScheme;
-    State().PageCaches = std::move(caches.PageCaches);
+    State().PageCollections = std::move(caches.PageCollections);
     State().TxStatusCaches = std::move(caches.TxStatusCaches);
 
     Steps = new NBoot::TRoot(this, State_.Get(), logger);
@@ -321,11 +321,11 @@ void TExecutorBootLogic::FollowersSyncComplete() {
 
 TExecutorCaches TExecutorBootLogic::DetachCaches() {
     if (Result_) {
-        for (auto &x : Result().PageCaches)
-            State().PageCaches[x->Id] = x;
+        for (auto &x : Result().PageCollections)
+            State().PageCollections[x->Id] = x;
     }
     return TExecutorCaches{
-        .PageCaches = std::move(State().PageCaches),
+        .PageCollections = std::move(State().PageCollections),
         .TxStatusCaches = std::move(State().TxStatusCaches),
     };
 }

--- a/ydb/core/tablet_flat/flat_executor_bootlogic.h
+++ b/ydb/core/tablet_flat/flat_executor_bootlogic.h
@@ -37,7 +37,7 @@ namespace NBoot {
         TAutoPtr<TExecutorBorrowLogic> Loans;
         THashMap<ui32, NTable::TRowVersionRanges> RemovedRowVersions;
 
-        TVector<TIntrusivePtr<TPrivatePageCache::TInfo>> PageCaches;
+        TVector<TIntrusivePtr<TPrivatePageCache::TPageCollection>> PageCollections;
         bool ShouldSnapshotScheme = false;
     };
 }

--- a/ydb/core/tablet_flat/flat_part_outset.cpp
+++ b/ydb/core/tablet_flat/flat_part_outset.cpp
@@ -4,10 +4,10 @@
 namespace NKikimr {
 namespace NTable {
 
-void TPageCollectionComponents::ParsePacket(TSharedData meta) {
-    Y_DEBUG_ABORT_UNLESS(!Packet, "Packet is already parsed");
+void TPageCollectionComponents::ParsePageCollection(TSharedData meta) {
+    Y_DEBUG_ABORT_UNLESS(!PageCollection, "PageCollection is already parsed");
 
-    Packet = new NPageCollection::TPageCollection(LargeGlobId, std::move(meta));
+    PageCollection = new NPageCollection::TPageCollection(LargeGlobId, std::move(meta));
 }
 
 TEpoch TPartComponents::GetEpoch() const {
@@ -15,7 +15,7 @@ TEpoch TPartComponents::GetEpoch() const {
         return Epoch;
     }
 
-    Y_ENSURE(PageCollectionComponents && PageCollectionComponents[0].Packet,
+    Y_ENSURE(PageCollectionComponents && PageCollectionComponents[0].PageCollection,
         "PartComponents has neither a known epoch, nor a parsed meta packet");
 
     return TLoader::GrabEpoch(*this);

--- a/ydb/core/tablet_flat/flat_part_outset.h
+++ b/ydb/core/tablet_flat/flat_part_outset.h
@@ -10,9 +10,9 @@ namespace NTable {
         // fully identified by this LargeGlobId
         NPageCollection::TLargeGlobId LargeGlobId;
         // loaded meta page
-        TIntrusiveConstPtr<NPageCollection::TPageCollection> Packet;
+        TIntrusiveConstPtr<NPageCollection::TPageCollection> PageCollection;
 
-        void ParsePacket(TSharedData meta);
+        void ParsePageCollection(TSharedData meta);
     };
 
     struct TPartComponents {

--- a/ydb/core/tablet_flat/flat_part_store.h
+++ b/ydb/core/tablet_flat/flat_part_store.h
@@ -46,7 +46,7 @@ protected:
     { }
 
 public:
-    using TCache = NTabletFlatExecutor::TPrivatePageCache::TInfo;
+    using TPageCollection = NTabletFlatExecutor::TPrivatePageCache::TPageCollection;
 
     TPartStore(const TLogoBlobID &label, TPart::TParams egg, TStat stat)
         : TPart(label, egg, stat)
@@ -125,7 +125,7 @@ public:
         return dynamic_cast<const NPageCollection::TPageCollection*>(pageCollection);
     }
 
-    TCache* Locate(ELargeObj lob, ui64 ref) const
+    TPageCollection* Locate(ELargeObj lob, ui64 ref) const
     {
         if ((lob != ELargeObj::Extern && lob != ELargeObj::Outer) || (ref >> 32)) {
             Y_TABLET_ERROR("Invalid ref ELargeObj{" << int(lob) << ", " << ref << "}");
@@ -148,28 +148,28 @@ public:
         return pages;
     }
 
-    static TVector<TIntrusivePtr<TCache>> Construct(TVector<TPageCollectionComponents> components)
+    static TVector<TIntrusivePtr<TPageCollection>> Construct(TVector<TPageCollectionComponents> components)
     {
-        TVector<TIntrusivePtr<TCache>> caches;
+        TVector<TIntrusivePtr<TPageCollection>> pageCollections;
 
         for (auto &one: components) {
-            caches.emplace_back(new TCache(std::move(one.Packet)));
+            pageCollections.emplace_back(new TPageCollection(std::move(one.PageCollection)));
         }
 
-        return caches;
+        return pageCollections;
     }
 
-    static TArrayRef<const TIntrusivePtr<TCache>> Storages(const TPartView &partView)
+    static TArrayRef<const TIntrusivePtr<TPageCollection>> Storages(const TPartView &partView)
     {
         auto *part = partView.As<TPartStore>();
 
         Y_ENSURE(!partView || part, "Got an unexpected type of TPart part");
 
-        return part ? part->PageCollections : TArrayRef<const TIntrusivePtr<TCache>> { };
+        return part ? part->PageCollections : TArrayRef<const TIntrusivePtr<TPageCollection>> { };
     }
 
-    TVector<TIntrusivePtr<TCache>> PageCollections;
-    TIntrusivePtr<TCache> Pseudo;    /* Cache for NPage::TBlobs */
+    TVector<TIntrusivePtr<TPageCollection>> PageCollections;
+    TIntrusivePtr<TPageCollection> Pseudo;    /* Cache for NPage::TBlobs */
 };
 
 class TTxStatusPartStore : public TTxStatusPart, public IBorrowBundle {

--- a/ydb/core/tablet_flat/flat_scan_actor.h
+++ b/ydb/core/tablet_flat/flat_scan_actor.h
@@ -162,9 +162,9 @@ namespace NOps {
                 Y_ENSURE(!PageCollections[slot]);
                 auto& loader = PageCollectionLoaders[slot];
                 if (loader.Apply(msg->BlobId, std::move(msg->Body))) {
-                    TIntrusiveConstPtr<NPageCollection::IPageCollection> pack =
+                    TIntrusiveConstPtr<NPageCollection::IPageCollection> pageCollection =
                         new NPageCollection::TPageCollection(Part->LargeGlobIds[slot], loader.ExtractSharedData());
-                    PageCollections[slot] = new TPrivatePageCache::TInfo(std::move(pack));
+                    PageCollections[slot] = new TPrivatePageCache::TPageCollection(std::move(pageCollection));
                     Y_ENSURE(PageCollectionsLeft > 0);
                     if (0 == --PageCollectionsLeft) {
                         PageCollectionLoaders.clear();
@@ -239,7 +239,7 @@ namespace NOps {
             TActorId Owner;
             TIntrusiveConstPtr<TColdPartStore> Part;
             EPriority ReadPriority;
-            TVector<TIntrusivePtr<TPrivatePageCache::TInfo>> PageCollections;
+            TVector<TIntrusivePtr<TPrivatePageCache::TPageCollection>> PageCollections;
             TVector<NPageCollection::TLargeGlobIdRestoreState> PageCollectionLoaders;
             size_t PageCollectionsLeft = 0;
             std::optional<NTable::TLoader> Loader;

--- a/ydb/core/tablet_flat/flat_store_hotdog.cpp
+++ b/ydb/core/tablet_flat/flat_store_hotdog.cpp
@@ -40,7 +40,7 @@ void TPageCollectionProtoHelper::Do(TBundle *bundle, const TPartComponents &pc)
     bundle->MutablePageCollections()->Reserve(pc.PageCollectionComponents.size());
 
     for (auto &one : pc.PageCollectionComponents)
-        Bundle(bundle->AddPageCollections(), one.LargeGlobId, one.Packet.Get());
+        Bundle(bundle->AddPageCollections(), one.LargeGlobId, one.PageCollection.Get());
 
     if (auto &legacy = pc.Legacy)
         bundle->SetLegacy(legacy);
@@ -102,11 +102,11 @@ void TPageCollectionProtoHelper::Do(TBundle *bundle, const TIntrusiveConstPtr<NT
     bundle->SetEpoch(partStore->Epoch.ToProto());
 }
 
-void TPageCollectionProtoHelper::Bundle(NKikimrExecutorFlat::TPageCollection *pageCollectionProto, const TPrivatePageCache::TInfo &cache)
+void TPageCollectionProtoHelper::Bundle(NKikimrExecutorFlat::TPageCollection *pageCollectionProto, const TPrivatePageCache::TPageCollection &pageCollection_)
 {
-    auto *pack = CheckedCast<const NPageCollection::TPageCollection*>(cache.PageCollection.Get());
+    auto *pageCollection = CheckedCast<const NPageCollection::TPageCollection*>(pageCollection_.PageCollection.Get());
 
-    return Bundle(pageCollectionProto, pack->LargeGlobId, pack);
+    return Bundle(pageCollectionProto, pageCollection->LargeGlobId, pageCollection);
 }
 
 
@@ -133,7 +133,7 @@ NTable::TPartComponents TPageCollectionProtoHelper::MakePageCollectionComponents
         auto& item = components.emplace_back();
         item.LargeGlobId = TLargeGlobIdProto::Get(pageCollection.GetLargeGlobId());
         if (pageCollection.HasMeta()) {
-            item.ParsePacket(TSharedData::Copy(pageCollection.GetMeta()));
+            item.ParsePageCollection(TSharedData::Copy(pageCollection.GetMeta()));
         }
     }
 

--- a/ydb/core/tablet_flat/flat_store_hotdog.h
+++ b/ydb/core/tablet_flat/flat_store_hotdog.h
@@ -45,7 +45,7 @@ namespace NTabletFlatExecutor {
         static TPartComponents MakePageCollectionComponents(const TBundle &proto, bool unsplit = false);
 
     private:
-        void Bundle(NKikimrExecutorFlat::TPageCollection *pageCollectionProto, const TPrivatePageCache::TInfo &cache);
+        void Bundle(NKikimrExecutorFlat::TPageCollection *pageCollectionProto, const TPrivatePageCache::TPageCollection &pageCollection);
         void Bundle(
                 NKikimrExecutorFlat::TPageCollection *pageCollectionProto,
                 const TLargeGlobId &largeGlobId,

--- a/ydb/core/tablet_flat/flat_writer_blocks.h
+++ b/ydb/core/tablet_flat/flat_writer_blocks.h
@@ -16,7 +16,7 @@ namespace NWriter {
         using ECache = NTable::NPage::ECache;
         using EPage = NTable::NPage::EPage;
         using TPageId = NTable::NPage::TPageId;
-        using TCache = TPrivatePageCache::TInfo;
+        using TPageCollection = TPrivatePageCache::TPageCollection;
 
         struct TResult : TMoveOnly {
             TIntrusiveConstPtr<NPageCollection::IPageCollection> PageCollection;

--- a/ydb/core/tablet_flat/ut/ut_slice_loader.cpp
+++ b/ydb/core/tablet_flat/ut/ut_slice_loader.cpp
@@ -20,7 +20,7 @@ namespace NTable {
 
 using namespace NTest;
 using TPageCollectionProtoHelper = NTabletFlatExecutor::TPageCollectionProtoHelper;
-using TCache = NTabletFlatExecutor::TPrivatePageCache::TInfo;
+using TPageCollection = NTabletFlatExecutor::TPrivatePageCache::TPageCollection;
 
 namespace {
     NPage::TConf PageConf()
@@ -144,7 +144,7 @@ namespace {
         TCheckResult result;
 
         TIntrusiveConstPtr<NPageCollection::IPageCollection> pageCollection = new TTestPartPageCollection(part, 0);
-        NTable::TLoader::TLoaderEnv env(new TCache(pageCollection));
+        NTable::TLoader::TLoaderEnv env(new TPageCollection(pageCollection));
         env.ProvidePart(part.Get());
         TKeysLoader loader(part.Get(), &env);
 


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

...

### Changelog category <!-- remove all except one -->

* Not for changelog (changelog entry is not required)

### Description for reviewers <!-- (optional) description for those who read this PR -->

No more meaningless `TInfo` class

Yes, we do have `TPageCollection` in `NPageCollection` and some other places, but I think it's the best option