### PR TITLE
Fix exception safety when invoking actor event handler

### DIFF
--- a/ydb/library/actors/testlib/test_runtime.cpp
+++ b/ydb/library/actors/testlib/test_runtime.cpp
@@ -403,8 +403,10 @@ namespace NActors {
                             TActorContext ctx(*mailbox, *node->ExecutorThread, GetCycleCountFast(), ev->GetRecipientRewrite());
                             TActivationContext *prevTlsActivationContext = TlsActivationContext;
                             TlsActivationContext = &ctx;
+                            Y_DEFER {
+                                TlsActivationContext = prevTlsActivationContext;
+                            };
                             recipientActor->Receive(ev);
-                            TlsActivationContext = prevTlsActivationContext;
                             // we expect the logger to never die in tests
                         }
                     }
@@ -1693,6 +1695,10 @@ namespace NActors {
             TActivationContext *prevTlsActivationContext = TlsActivationContext;
             TlsActivationContext = &ctx;
             CurrentRecipient = actorId;
+            Y_DEFER {
+                CurrentRecipient = TActorId();
+                TlsActivationContext = prevTlsActivationContext;
+            };
             {
                 TInverseGuard<TMutex> inverseGuard(Mutex);
 #ifdef USE_ACTOR_CALLSTACK
@@ -1702,8 +1708,6 @@ namespace NActors {
                 recipientActor->Receive(ev);
                 node->ExecutorThread->DropUnregistered();
             }
-            CurrentRecipient = TActorId();
-            TlsActivationContext = prevTlsActivationContext;
         } else {
             if (VERBOSE) {
                 Cerr << "Failed to find actor with local id: " << recipientLocalId << "\n";


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

Fix exception safety when invoking actor event handler

### Changelog category <!-- remove all except one -->

* Not for changelog (changelog entry is not required)

### Description for reviewers <!-- (optional) description for those who read this PR -->

This fixes testlib's behaviour on calling Receive() and not handling exceptions, leaving TlsActivationContext in incorrect state.
