### PR TITLE
Fix use-after-free in CMS remove permission

### DIFF
--- a/ydb/core/cms/cms_tx_remove_permissions.cpp
+++ b/ydb/core/cms/cms_tx_remove_permissions.cpp
@@ -41,13 +41,14 @@ public:
 
             auto it = Self->State->ScheduledRequests.find(requestId);
             if (it != Self->State->ScheduledRequests.end()) {
+                bool evictVDisks = it->second.Request.GetEvictVDisks();
                 if (Expired) {
                     RemoveRequest(db, requestId, ctx, TStringBuilder() << "Remove request"
                         << ": id# " << requestId
                         << ", reason# " << "permission " << id << " has expired");
                 }
                 
-                if (it->second.Request.GetEvictVDisks()) {
+                if (evictVDisks) {
                     auto ret = Self->ResetHostMarkers(host, txc, ctx);
                     std::move(ret.begin(), ret.end(), std::back_inserter(UpdateMarkers));
 


### PR DESCRIPTION
(cherry picked from commit 49247d97856cf3595ca6073951fd264f196cedc6)