### PR TITLE
Change grants for secondary index creation

### DIFF
--- a/ydb/core/kqp/executer_actor/kqp_scheme_executer.cpp
+++ b/ydb/core/kqp/executer_actor/kqp_scheme_executer.cpp
@@ -20,7 +20,7 @@ using namespace NThreading;
 
 namespace {
 
-bool CheckAddIndexAccess(const NACLib::TUserToken& userToken, const NSchemeCache::TSchemeCacheNavigate* navigate) {
+bool CheckAlterAccess(const NACLib::TUserToken& userToken, const NSchemeCache::TSchemeCacheNavigate* navigate) {
     bool isDatabaseEntry = true; // first entry is always database
 
     using TEntry = NSchemeCache::TSchemeCacheNavigate::TEntry;
@@ -710,7 +710,7 @@ public:
             return ReplyErrorAndDie(Ydb::StatusIds::SCHEME_ERROR, NYql::TIssue(error));
         }
 
-        if (UserToken && !UserToken->GetSerializedToken().empty() && !CheckAddIndexAccess(*UserToken, resp)) {
+        if (UserToken && !UserToken->GetSerializedToken().empty() && !CheckAlterAccess(*UserToken, resp)) {
             LOG_E("Access check failed");
             return ReplyErrorAndDie(Ydb::StatusIds::UNAUTHORIZED, NYql::TIssue("Unauthorized"));
         }

--- a/ydb/tests/functional/security/test_grants.py
+++ b/ydb/tests/functional/security/test_grants.py
@@ -18,6 +18,7 @@ CREATE_TABLE_GRANTS = ['ydb.granular.create_table']
 ALTER_TABLE_ADD_COLUMN_GRANTS = ['ydb.granular.alter_schema', 'ydb.granular.describe_schema']
 ALTER_TABLE_DROP_COLUMN_GRANTS = ['ydb.granular.alter_schema', 'ydb.granular.describe_schema']
 ERASE_ROW_GRANTS = ['ydb.granular.describe_schema', 'ydb.granular.select_row', 'ydb.granular.erase_row']
+ALTER_TABLE_CREATE_INDEX_GRANTS = ['ydb.granular.alter_schema', 'ydb.granular.describe_schema']
 ALTER_TABLE_ALTER_INDEX_GRANTS = ['ydb.granular.alter_schema', 'ydb.granular.describe_schema']
 ALTER_TABLE_DROP_INDEX_GRANTS = ['ydb.granular.alter_schema', 'ydb.granular.describe_schema']
 DROP_TABLE_GRANTS = ['ydb.granular.remove_schema', 'ydb.granular.describe_schema']
@@ -32,6 +33,7 @@ ALL_USED_GRANS = set(
     + ALTER_TABLE_ADD_COLUMN_GRANTS
     + ALTER_TABLE_DROP_COLUMN_GRANTS
     + ERASE_ROW_GRANTS
+    + ALTER_TABLE_CREATE_INDEX_GRANTS
     + ALTER_TABLE_ALTER_INDEX_GRANTS
     + ALTER_TABLE_DROP_INDEX_GRANTS
     + DROP_TABLE_GRANTS
@@ -164,12 +166,12 @@ def test_granular_grants_for_tables(ydb_cluster):
     create_index_query = f"ALTER TABLE `{TABLE_PATH}` ADD INDEX `b_column_index` GLOBAL ON (`b`);"
     _test_grants(
         tenant_admin_config,
-        user1_config,
-        'user1',
+        user2_config,
+        'user2',
         create_index_query,
         TABLE_PATH,
-        [],  # user1 is the owner of a table
-        "",
+        ALTER_TABLE_CREATE_INDEX_GRANTS,
+        "you do not have access permissions",
     )
 
     # ALTER TABLE ... ALTER INDEX


### PR DESCRIPTION
### Changelog entry
Secondary index creation will require `ydb.granular.describe_schema` and `ydb.granular.alter_schema` grants instead of `ydb.generic.read` and `ydb.generic.write`

### Changelog category
* Improvement

### Description for reviewers
To create indexes, one must have the `alter` and `describe` permissions.