### PR TITLE
Decimal compatibility tests

### DIFF
--- a/ydb/tests/compatibility/test_data_type.py
+++ b/ydb/tests/compatibility/test_data_type.py
@@ -39,7 +39,7 @@ class TestDataType(RestartToAnotherVersionFixture):
             self.table_names.append(f"table_{i}_{self.store_type}")
         yield from self.setup_cluster(
             extra_feature_flags={
-                "enable_parameterized_decimal": Ttue,
+                "enable_parameterized_decimal": True,
                 "enable_table_datetime64": True,
             },
             column_shard_config={

--- a/ydb/tests/compatibility/test_data_type.py
+++ b/ydb/tests/compatibility/test_data_type.py
@@ -4,13 +4,19 @@ import math
 from datetime import datetime, timedelta
 from ydb.tests.library.compatibility.fixtures import RestartToAnotherVersionFixture
 from ydb.tests.oss.ydb_sdk_import import ydb
-from ydb.tests.datashard.lib.create_table import create_table_sql_request
+from ydb.tests.datashard.lib.create_table import create_table_sql_request, create_columnshard_table_sql_request
 from ydb.tests.datashard.lib.types_of_variables import pk_types, non_pk_types, cleanup_type_name, format_sql_value
 
 
 class TestDataType(RestartToAnotherVersionFixture):
+
+    @pytest.fixture()
+    def store_type(self, request):
+        return request.param
+
     @pytest.fixture(autouse=True, scope="function")
-    def setup(self):
+    def setup(self, store_type):
+        self.store_type = store_type
         self.pk_types = []
         self.pk_types.append({"Int64": lambda i: i})
         self.count_table = 1
@@ -30,22 +36,29 @@ class TestDataType(RestartToAnotherVersionFixture):
                     "col_": self.all_types.keys(),
                 }
             )
-            self.table_names.append(f"table_{i}")
+            self.table_names.append(f"table_{i}_{self.store_type}")
         yield from self.setup_cluster(
             extra_feature_flags={
                 "enable_parameterized_decimal": True,
                 "enable_table_datetime64": True,
+            },
+            column_shard_config={
+                "disabled_on_scheme_shard": False,
             }
         )
 
     def write_data(self):
         querys = []
         for i in range(self.count_table):
+            pk_keys = self.pk_types[i].keys()
+            if self.store_type == "COLUMN":
+                pk_keys = pk_keys - {"Bool"}
+            
             values = []
             for key in range(1, self.count_rows + 1):
                 values.append(
                     f'''(
-                        {", ".join([format_sql_value(self.pk_types[i][type_name](key), type_name) for type_name in self.pk_types[i].keys()])},
+                        {", ".join([format_sql_value(self.pk_types[i][type_name](key), type_name) for type_name in pk_keys])},
                         {", ".join([format_sql_value(self.all_types[type_name](key), type_name) for type_name in self.all_types.keys()])}
                         )
                         '''
@@ -53,7 +66,7 @@ class TestDataType(RestartToAnotherVersionFixture):
             querys.append(
                 f"""
                 UPSERT INTO `{self.table_names[i]}` (
-                    {", ".join([f"pk_{cleanup_type_name(type_name)}" for type_name in self.pk_types[i].keys()])},
+                    {", ".join([f"pk_{cleanup_type_name(type_name)}" for type_name in pk_keys])},
                     {", ".join([f"col_{cleanup_type_name(type_name)}" for type_name in self.all_types.keys()])}
                 )
                 VALUES {",".join(values)};
@@ -112,28 +125,49 @@ class TestDataType(RestartToAnotherVersionFixture):
     def create_table(self):
         pk_columns = []
         for i in range(self.count_table):
+            pk_keys = self.pk_types[i].keys()
+            if self.store_type == "COLUMN":
+                pk_keys = pk_keys - {"Bool"}
+            
             pk_columns.append(
                 {
-                    "pk_": self.pk_types[i].keys(),
+                    "pk_": pk_keys,
                 }
             )
         querys = []
         for i in range(self.count_table):
-            querys.append(
-                create_table_sql_request(
-                    self.table_names[i],
-                    columns=self.columns[i],
-                    pk_columns=pk_columns[i],
-                    index_columns={},
-                    unique="",
-                    sync="",
+            if self.store_type == "COLUMN":
+                querys.append(
+                    create_columnshard_table_sql_request(
+                        self.table_names[i],
+                        columns=self.columns[i],
+                        pk_columns=pk_columns[i],
+                        index_columns={},
+                        unique="",
+                        sync="",
+                    )
                 )
-            )
+            else:
+                querys.append(
+                    create_table_sql_request(
+                        self.table_names[i],
+                        columns=self.columns[i],
+                        pk_columns=pk_columns[i],
+                        index_columns={},
+                        unique="",
+                        sync="",
+                    )
+                )
         with ydb.QuerySessionPool(self.driver) as session_pool:
             for query in querys:
                 session_pool.execute_with_retries(query)
 
+    @pytest.mark.parametrize("store_type", ["ROW", "COLUMN"], indirect=True)
     def test_data_type(self):
+        if any("Decimal" in type_name for type_name in self.all_types.keys()) and self.store_type == "COLUMN":
+            if (min(self.versions) < (25, 1)):
+                pytest.skip("Decimal types are not supported in columnshard in this version")
+
         self.create_table()
 
         self.write_data()

--- a/ydb/tests/compatibility/test_data_type.py
+++ b/ydb/tests/compatibility/test_data_type.py
@@ -50,15 +50,11 @@ class TestDataType(RestartToAnotherVersionFixture):
     def write_data(self):
         querys = []
         for i in range(self.count_table):
-            pk_keys = self.pk_types[i].keys()
-            if self.store_type == "COLUMN":
-                pk_keys = pk_keys - {"Bool"}
-            
             values = []
             for key in range(1, self.count_rows + 1):
                 values.append(
                     f'''(
-                        {", ".join([format_sql_value(self.pk_types[i][type_name](key), type_name) for type_name in pk_keys])},
+                        {", ".join([format_sql_value(self.pk_types[i][type_name](key), type_name) for type_name in self.pk_types[i].keys()])},
                         {", ".join([format_sql_value(self.all_types[type_name](key), type_name) for type_name in self.all_types.keys()])}
                         )
                         '''
@@ -66,7 +62,7 @@ class TestDataType(RestartToAnotherVersionFixture):
             querys.append(
                 f"""
                 UPSERT INTO `{self.table_names[i]}` (
-                    {", ".join([f"pk_{cleanup_type_name(type_name)}" for type_name in pk_keys])},
+                    {", ".join([f"pk_{cleanup_type_name(type_name)}" for type_name in self.pk_types[i].keys()])},
                     {", ".join([f"col_{cleanup_type_name(type_name)}" for type_name in self.all_types.keys()])}
                 )
                 VALUES {",".join(values)};
@@ -125,13 +121,9 @@ class TestDataType(RestartToAnotherVersionFixture):
     def create_table(self):
         pk_columns = []
         for i in range(self.count_table):
-            pk_keys = self.pk_types[i].keys()
-            if self.store_type == "COLUMN":
-                pk_keys = pk_keys - {"Bool"}
-            
             pk_columns.append(
                 {
-                    "pk_": pk_keys,
+                    "pk_": self.pk_types[i].keys(),
                 }
             )
         querys = []

--- a/ydb/tests/compatibility/test_data_type.py
+++ b/ydb/tests/compatibility/test_data_type.py
@@ -110,7 +110,7 @@ class TestDataType(RestartToAnotherVersionFixture):
         if data_type == "String" or data_type == "Yson":
             assert values_from_rows.decode("utf-8") == self.all_types[data_type](
                 values
-            ), f"{data_type}, expected {self.all_types[data_type](values)}, received {values_from_rows.decode("utf-8")}"
+            ), f"{data_type}, expected {self.all_types[data_type](values)}, received {values_from_rows.decode('utf-8')}"
         elif data_type == "Float" or data_type == "DyNumber":
             assert math.isclose(
                 float(values_from_rows), float(self.all_types[data_type](values)), rel_tol=1e-3
@@ -153,7 +153,7 @@ class TestDataType(RestartToAnotherVersionFixture):
                     sync="",
                     column_table=self.store_type == "COLUMN",
                 )
-             )
+            )
 
         with ydb.QuerySessionPool(self.driver) as session_pool:
             for query in querys:

--- a/ydb/tests/compatibility/test_data_type.py
+++ b/ydb/tests/compatibility/test_data_type.py
@@ -50,6 +50,9 @@ class TestDataType(RestartToAnotherVersionFixture):
             },
             column_shard_config={
                 "disabled_on_scheme_shard": False,
+            },
+            table_service_config={
+                "enable_olap_sink": True,
             }
         )
 

--- a/ydb/tests/compatibility/test_data_type.py
+++ b/ydb/tests/compatibility/test_data_type.py
@@ -5,7 +5,7 @@ from datetime import datetime, timedelta
 from ydb.tests.library.compatibility.fixtures import RestartToAnotherVersionFixture
 from ydb.tests.oss.ydb_sdk_import import ydb
 from ydb.tests.datashard.lib.create_table import create_table_sql_request
-from ydb.tests.datashard.lib.types_of_variables import pk_types, non_pk_types, cleanup_type_name, format_sql_value, types_missing_in_column_tables
+from ydb.tests.datashard.lib.types_of_variables import pk_types, non_pk_types, cleanup_type_name, format_sql_value, types_not_supported_yet_in_columnshard
 
 
 class TestDataType(RestartToAnotherVersionFixture):
@@ -21,8 +21,8 @@ class TestDataType(RestartToAnotherVersionFixture):
         self.count_rows = 30
         self.store_type = store_type
         # not all the types are supported for column tables
-        supported_pk_types = pk_types if store_type == "ROW" else {k: v for k, v in pk_types.items() if k not in types_missing_in_column_tables}
-        supported_non_pk_types = non_pk_types if store_type == "ROW" else {k: v for k, v in non_pk_types.items() if k not in types_missing_in_column_tables}
+        supported_pk_types = pk_types if store_type == "ROW" else {k: v for k, v in pk_types.items() if k not in types_not_supported_yet_in_columnshard}
+        supported_non_pk_types = non_pk_types if store_type == "ROW" else {k: v for k, v in non_pk_types.items() if k not in types_not_supported_yet_in_columnshard}
         self.all_types = {**supported_pk_types, **supported_non_pk_types}
 
         self.count_table = 0

--- a/ydb/tests/compatibility/test_data_type.py
+++ b/ydb/tests/compatibility/test_data_type.py
@@ -4,7 +4,7 @@ import math
 from datetime import datetime, timedelta
 from ydb.tests.library.compatibility.fixtures import RestartToAnotherVersionFixture
 from ydb.tests.oss.ydb_sdk_import import ydb
-from ydb.tests.datashard.lib.create_table import create_table_sql_request, create_columnshard_table_sql_request
+from ydb.tests.datashard.lib.create_table import create_table_sql_request
 from ydb.tests.datashard.lib.types_of_variables import pk_types, non_pk_types, cleanup_type_name, format_sql_value, types_missing_in_column_tables
 
 
@@ -142,28 +142,17 @@ class TestDataType(RestartToAnotherVersionFixture):
 
         querys = []
         for i in range(self.count_table):
-            if self.store_type == "COLUMN":
-                querys.append(
-                    create_columnshard_table_sql_request(
-                        self.table_names[i],
-                        columns=self.columns[i],
-                        pk_columns=pk_columns[i],
-                        index_columns={},
-                        unique="",
-                        sync="",
-                    )
+            querys.append(
+                create_table_sql_request(
+                    self.table_names[i],
+                    columns=self.columns[i],
+                    pk_columns=pk_columns[i],
+                    index_columns={},
+                    unique="",
+                    sync="",
+                    column_table=self.store_type == "COLUMN",
                 )
-            else:
-                querys.append(
-                    create_table_sql_request(
-                        self.table_names[i],
-                        columns=self.columns[i],
-                        pk_columns=pk_columns[i],
-                        index_columns={},
-                        unique="",
-                        sync="",
-                    )
-                )
+             )
 
         with ydb.QuerySessionPool(self.driver) as session_pool:
             for query in querys:

--- a/ydb/tests/compatibility/test_data_type.py
+++ b/ydb/tests/compatibility/test_data_type.py
@@ -101,7 +101,7 @@ class TestDataType(RestartToAnotherVersionFixture):
                 for row in rows:
                     for prefix in self.columns[table_index].keys():
                         for type_name in self.columns[table_index][prefix]:
-                            expected_value = row_num if prefix == "pk_" else row_num
+                            expected_value = row_num
                             self.assert_type(type_name, expected_value, row[f"{prefix}{cleanup_type_name(type_name)}"])
 
                 query_index += 1

--- a/ydb/tests/compatibility/test_data_type.py
+++ b/ydb/tests/compatibility/test_data_type.py
@@ -58,13 +58,14 @@ class TestDataType(RestartToAnotherVersionFixture):
 
     def write_data(self):
         querys = []
+        unwrap_after_cast = self.store_type == "COLUMN"
         for i in range(self.count_table):
             values = []
             for key in range(1, self.count_rows + 1):
                 values.append(
                     f'''(
-                        {", ".join([format_sql_value(self.pk_types[i][type_name](key), type_name) for type_name in self.pk_types[i].keys()])},
-                        {", ".join([format_sql_value(self.all_types[type_name](key), type_name) for type_name in self.all_types.keys()])}
+                        {", ".join([format_sql_value(self.pk_types[i][type_name](key), type_name, unwrap_after_cast) for type_name in self.pk_types[i].keys()])},
+                        {", ".join([format_sql_value(self.all_types[type_name](key), type_name, unwrap_after_cast) for type_name in self.all_types.keys()])}
                         )
                         '''
                 )

--- a/ydb/tests/datashard/lib/create_table.py
+++ b/ydb/tests/datashard/lib/create_table.py
@@ -29,6 +29,44 @@ def create_table_sql_request(table_name: str, columns: dict[str, dict[str]], pk_
     return sql_create
 
 
+def create_columnshard_table_sql_request(table_name: str, columns: dict[str, dict[str]], pk_columns: dict[str, dict[str]], index_columns: dict[str, dict[str]], unique: str, sync: str) -> str:
+    create_columns = []
+    for prefix in columns.keys():
+        if (prefix != "ttl_" or columns[prefix][0] != "") and len(columns[prefix]) != 0:
+            if prefix == "pk_":
+                create_columns.append(", ".join(
+                    f"{prefix}{cleanup_type_name(type_name)} {type_name} NOT NULL" for type_name in columns[prefix]))
+            else:
+                create_columns.append(", ".join(
+                    f"{prefix}{cleanup_type_name(type_name)} {type_name}" for type_name in columns[prefix]))
+    create_primary_key = []
+    for prefix in pk_columns.keys():
+        if len(pk_columns[prefix]) != 0:
+            create_primary_key.append(", ".join(
+                f"{prefix}{cleanup_type_name(type_name)}" for type_name in pk_columns[prefix]))
+    create_index = []
+    for prefix in index_columns.keys():
+        if len(index_columns[prefix]) != 0:
+            create_index.append(", ".join(
+                f"INDEX idx_{prefix}{cleanup_type_name(type_name)} GLOBAL {unique} {sync} ON ({prefix}{cleanup_type_name(type_name)})" for type_name in index_columns[prefix]))
+
+    partition_by = ", ".join([f"{prefix}{cleanup_type_name(type_name)}" for prefix in pk_columns.keys() for type_name in pk_columns[prefix]])
+
+    sql_create = f"""
+        CREATE TABLE `{table_name}` (
+            {", ".join(create_columns)},
+            PRIMARY KEY(
+                {", ".join(create_primary_key)}
+                )
+            {f", {", ".join(create_index)}" if create_index else ""}
+            )
+        PARTITION BY HASH({partition_by})
+        WITH (
+            STORE = COLUMN
+        )
+    """
+    return sql_create
+
 def create_ttl_sql_request(ttl: str, inteval: dict[str, str], time: str, table_name: str) -> str:
     create_ttl = []
     for pt in inteval.keys():

--- a/ydb/tests/datashard/lib/create_table.py
+++ b/ydb/tests/datashard/lib/create_table.py
@@ -67,6 +67,7 @@ def create_columnshard_table_sql_request(table_name: str, columns: dict[str, dic
     """
     return sql_create
 
+
 def create_ttl_sql_request(ttl: str, inteval: dict[str, str], time: str, table_name: str) -> str:
     create_ttl = []
     for pt in inteval.keys():

--- a/ydb/tests/datashard/lib/create_table.py
+++ b/ydb/tests/datashard/lib/create_table.py
@@ -51,7 +51,7 @@ def create_table_sql_request(
             PRIMARY KEY(
                 {", ".join(create_primary_key)}
                 )
-            {f", {", ".join(create_index)}" if create_index else ""}
+            {f", {', '.join(create_index)}" if create_index else ""}
             )
     """
     if column_table:
@@ -94,7 +94,7 @@ def create_vector_index_sql_request(
         ALTER TABLE {table_name}
         ADD INDEX {name_vector_index}
         GLOBAL {sync} USING vector_kmeans_tree
-        ON ({f"{prefix}, " if prefix != "" else ""}{embedding}) {f"COVER ({", ".join(cover)})" if len(cover) != 0 else ""}
+        ON ({f"{prefix}, " if prefix != "" else ""}{embedding}) {f"COVER ({', '.join(cover)})" if len(cover) != 0 else ""}
         WITH ({function}={distance}, vector_type="{vector_type}", vector_dimension={vector_dimension}, levels={levels}, clusters={clusters});
     """
     return create_vector_index

--- a/ydb/tests/datashard/lib/create_table.py
+++ b/ydb/tests/datashard/lib/create_table.py
@@ -55,7 +55,7 @@ def create_table_sql_request(
             )
     """
     if column_table:
-        sql_create += f"""
+        sql_create += """
             WITH (
                 STORE = COLUMN
             )

--- a/ydb/tests/datashard/lib/create_table.py
+++ b/ydb/tests/datashard/lib/create_table.py
@@ -63,7 +63,6 @@ def create_table_sql_request(
                 STORE = COLUMN
             )
         """
-    sql_create += ";"
     return sql_create
 
 

--- a/ydb/tests/datashard/lib/create_table.py
+++ b/ydb/tests/datashard/lib/create_table.py
@@ -55,10 +55,7 @@ def create_table_sql_request(
             )
     """
     if column_table:
-        # column tables require explicit command of how to partition them, row tables get partitioned automatically
-        partition_by = ", ".join([f"{prefix}{cleanup_type_name(type_name)}" for prefix in pk_columns.keys() for type_name in pk_columns[prefix]])
         sql_create += f"""
-            PARTITION BY HASH({partition_by})
             WITH (
                 STORE = COLUMN
             )

--- a/ydb/tests/datashard/lib/types_of_variables.py
+++ b/ydb/tests/datashard/lib/types_of_variables.py
@@ -13,8 +13,8 @@ def format_sql_value(value, type_name):
         return f"'{value}'"
     if type_name in non_pk_types.keys() or type_name == "Datetime64" or type_name == "Date32" or type_name == "Datetime" or \
             type_name == "Date" or type_name == "UUID" or type_name == "DyNumber" or type_name == "Decimal(35,10)" or type_name == "Decimal(22,9)" or type_name == "Decimal(15,0))":
-        return f"CAST('{value}' AS {type_name})"
-    return f"CAST({value} AS {type_name})"
+        return f"Unwrap(CAST('{value}' AS {type_name}))"
+    return f"Unwrap(CAST({value} AS {type_name}))"
 
 
 ttl_types = {

--- a/ydb/tests/datashard/lib/types_of_variables.py
+++ b/ydb/tests/datashard/lib/types_of_variables.py
@@ -133,24 +133,24 @@ pk_types = {
     "Uint16": lambda i: i,
     "Int8": lambda i: i,
     "Uint8": lambda i: i,
-    # "Bool": lambda i: bool(i),
+    "Bool": lambda i: bool(i),
     "Decimal(15,0)": lambda i: "{}".format(i),
     "Decimal(22,9)": lambda i: "{}.123".format(i),
     "Decimal(35,10)": lambda i: "{}.123456".format(i),
-    # "DyNumber": lambda i: float(f"{i}e1"),
+    "DyNumber": lambda i: float(f"{i}e1"),
 
     "String": lambda i: f"String {i}",
     "Utf8": lambda i: f"Utf8 {i}",
-    # "UUID": lambda i: UUID("3{:03}5678-e89b-12d3-a456-556642440000".format(i)),
+    "UUID": lambda i: UUID("3{:03}5678-e89b-12d3-a456-556642440000".format(i)),
 
     "Date": lambda i: datetime.strptime("2{:03}-01-01".format(i), "%Y-%m-%d").date(),
     "Datetime": lambda i: datetime.strptime("2{:03}-10-02T11:00:00Z".format(i), "%Y-%m-%dT%H:%M:%SZ"),
     "Timestamp": lambda i: 1696200000000000 + i * 100000000,
-    # "Interval": lambda i: i,
+    "Interval": lambda i: i,
     "Date32": lambda i: datetime.strptime("2{:03}-01-01".format(i), "%Y-%m-%d").date(),
     "Datetime64": lambda i: datetime.strptime("2{:03}-10-02T11:00:00Z".format(i), "%Y-%m-%dT%H:%M:%SZ"),
     "Timestamp64": lambda i: 1696200000000000 + i * 100000000,
-    # "Interval64": lambda i: i,
+    "Interval64": lambda i: i,
 }
 
 non_pk_types = {
@@ -159,4 +159,12 @@ non_pk_types = {
     "Json": lambda i: "{{\"another_key\": {}}}".format(i),
     "JsonDocument": lambda i: "{{\"another_doc_key\": {}}}".format(i),
     "Yson": lambda i: "[{}]".format(i),
+}
+
+types_missing_in_column_tables = {
+    "Bool",
+    "DyNumber",
+    "UUID",
+    "Interval",
+    "Interval64",
 }

--- a/ydb/tests/datashard/lib/types_of_variables.py
+++ b/ydb/tests/datashard/lib/types_of_variables.py
@@ -133,24 +133,24 @@ pk_types = {
     "Uint16": lambda i: i,
     "Int8": lambda i: i,
     "Uint8": lambda i: i,
-    "Bool": lambda i: bool(i),
+    # "Bool": lambda i: bool(i),
     "Decimal(15,0)": lambda i: "{}".format(i),
     "Decimal(22,9)": lambda i: "{}.123".format(i),
     "Decimal(35,10)": lambda i: "{}.123456".format(i),
-    "DyNumber": lambda i: float(f"{i}e1"),
+    # "DyNumber": lambda i: float(f"{i}e1"),
 
     "String": lambda i: f"String {i}",
     "Utf8": lambda i: f"Utf8 {i}",
-    "UUID": lambda i: UUID("3{:03}5678-e89b-12d3-a456-556642440000".format(i)),
+    # "UUID": lambda i: UUID("3{:03}5678-e89b-12d3-a456-556642440000".format(i)),
 
     "Date": lambda i: datetime.strptime("2{:03}-01-01".format(i), "%Y-%m-%d").date(),
     "Datetime": lambda i: datetime.strptime("2{:03}-10-02T11:00:00Z".format(i), "%Y-%m-%dT%H:%M:%SZ"),
     "Timestamp": lambda i: 1696200000000000 + i * 100000000,
-    "Interval": lambda i: i,
+    # "Interval": lambda i: i,
     "Date32": lambda i: datetime.strptime("2{:03}-01-01".format(i), "%Y-%m-%d").date(),
     "Datetime64": lambda i: datetime.strptime("2{:03}-10-02T11:00:00Z".format(i), "%Y-%m-%dT%H:%M:%SZ"),
     "Timestamp64": lambda i: 1696200000000000 + i * 100000000,
-    "Interval64": lambda i: i,
+    # "Interval64": lambda i: i,
 }
 
 non_pk_types = {
@@ -158,5 +158,5 @@ non_pk_types = {
     "Double": lambda i: i + 0.2,
     "Json": lambda i: "{{\"another_key\": {}}}".format(i),
     "JsonDocument": lambda i: "{{\"another_doc_key\": {}}}".format(i),
-    "Yson": lambda i: "[{}]".format(i)
+    "Yson": lambda i: "[{}]".format(i),
 }

--- a/ydb/tests/datashard/lib/types_of_variables.py
+++ b/ydb/tests/datashard/lib/types_of_variables.py
@@ -2,27 +2,106 @@ from uuid import UUID
 from datetime import datetime
 
 
-def cleanup_type_name(type_name):
-    return type_name.replace('(', '').replace(')', '').replace(',', '')
-
-
 def format_sql_value(value, type_name):
     if type_name == "Datetime64" or type_name == "Datetime":
         value = value.strftime("%Y-%m-%dT%H:%M:%SZ")
     if type_name == "String" or type_name == "Utf8":
         return f"'{value}'"
-    if type_name in non_pk_types.keys() or type_name == "Datetime64" or type_name == "Date32" or type_name == "Datetime" or \
-            type_name == "Date" or type_name == "UUID" or type_name == "DyNumber" or type_name == "Decimal(35,10)" or type_name == "Decimal(22,9)" or type_name == "Decimal(15,0))":
+
+    # Use quoted values for types that require string representation
+    if type_name in types_requiring_quotes_in_cast:
         return f"Unwrap(CAST('{value}' AS {type_name}))"
+
+    # Use unquoted values for numeric and other types
     return f"Unwrap(CAST({value} AS {type_name}))"
 
+
+def generate_date_value(i):
+    """
+    Generate a Date value for YDB standard Date type.
+
+    YDB Date range: 1970-01-01 to 2105-12-31 (inclusive)
+    - MIN_YEAR: 1970 (inclusive)
+    - MAX_YEAR: 2106 (non-inclusive, so max valid year is 2105)
+    - Based on YDB constants: MIN_YEAR=1970, MAX_YEAR=2106, MAX_DATE=49673
+    """
+    year = min(2000 + i, 2105)  # Clamp to YDB's standard Date range
+    return datetime.strptime(f"{year}-01-01", "%Y-%m-%d").date()
+
+
+def generate_datetime_value(i):
+    """
+    Generate a Datetime value for YDB standard Datetime type.
+
+    YDB Datetime range: 1970-01-01 to 2105-12-31 (inclusive)
+    - MIN_YEAR: 1970 (inclusive)
+    - MAX_YEAR: 2106 (non-inclusive, so max valid year is 2105)
+    - Based on YDB constants: MIN_YEAR=1970, MAX_YEAR=2106, MAX_DATETIME=86400*49673
+    """
+    year = min(2000 + i, 2105)  # Clamp to YDB's standard Datetime range
+    return datetime.strptime(f"{year}-10-02T11:00:00Z", "%Y-%m-%dT%H:%M:%SZ")
+
+
+def generate_date32_value(i):
+    """
+    Generate a Date32 value for YDB extended Date32 type.
+
+    YDB Date32 range: much larger than standard Date type
+    - MIN_YEAR32: -144169 (inclusive)
+    - MAX_YEAR32: 148108 (non-inclusive, so max valid year is 148107)
+    - MIN_DATE32: -53375809, MAX_DATE32: 53375807 (both inclusive)
+
+    For test purposes, we use a reasonable subset of this range.
+    """
+    year = min(2000 + i, 10000)  # Use reasonable range for testing (up to year 10000)
+    return datetime.strptime(f"{year}-01-01", "%Y-%m-%d").date()
+
+
+def generate_datetime64_value(i):
+    """
+    Generate a Datetime64 value for YDB extended Datetime64 type.
+
+    YDB Datetime64 range: much larger than standard Datetime type
+    - MIN_YEAR32: -144169 (inclusive)
+    - MAX_YEAR32: 148108 (non-inclusive, so max valid year is 148107)
+    - MIN_DATETIME64: -4611669897600, MAX_DATETIME64: 4611669811199
+
+    For test purposes, we use a reasonable subset of this range.
+    """
+    year = min(2000 + i, 10000)  # Use reasonable range for testing (up to year 10000)
+    return datetime.strptime(f"{year}-10-02T11:00:00Z", "%Y-%m-%dT%H:%M:%SZ")
+
+
+def cleanup_type_name(type_name):
+    return type_name.replace("(", "").replace(")", "").replace(",", "")
+
+
+# Types that require quoted values in CAST operations
+types_requiring_quotes_in_cast = {
+    # String-based types
+    "Json",
+    "JsonDocument",
+    "Yson",
+    # Date/time types that need string formatting
+    "Date",
+    "Datetime",
+    "Date32",
+    "Datetime64",
+    # Special types
+    "UUID",
+    "DyNumber",
+    # Decimal types
+    "Decimal(15,0)",
+    "Decimal(22,9)",
+    "Decimal(35,10)",
+}
 
 ttl_types = {
     "DyNumber": lambda i: float("3742656{:03}e10".format(i)),
     "Uint32": lambda i: 3742656000 + i,
     "Uint64": lambda i: 3742656000 + i,
-    "Date": lambda i: datetime.strptime("2{:03}-01-01".format(i), "%Y-%m-%d").date(),
-    "Datetime": lambda i: datetime.strptime("2{:03}-10-02T11:00:00Z".format(i), "%Y-%m-%dT%H:%M:%SZ"),
+    "Date": generate_date_value,
+    "Datetime": generate_datetime_value,
     "Timestamp": lambda i: 2696200000000000 + i * 100000000,
 }
 
@@ -43,8 +122,8 @@ index_second_sync = {
     "String": lambda i: f"String {i}",
     "Utf8": lambda i: f"Utf8 {i}",
     "UUID": lambda i: UUID("3{:03}5678-e89b-12d3-a456-556642440000".format(i)),
-    "Date": lambda i: datetime.strptime("2{:03}-01-01".format(i), "%Y-%m-%d").date(),
-    "Datetime": lambda i: datetime.strptime("2{:03}-10-02T11:00:00Z".format(i), "%Y-%m-%dT%H:%M:%SZ"),
+    "Date": generate_date_value,
+    "Datetime": generate_datetime_value,
 }
 
 index_three_sync = {
@@ -52,16 +131,16 @@ index_three_sync = {
     "Decimal(15,0)": lambda i: "{}".format(i),
     "Decimal(22,9)": lambda i: "{}.123".format(i),
     "Decimal(35,10)": lambda i: "{}.123456".format(i),
-    "Date32": lambda i: datetime.strptime("2{:03}-01-01".format(i), "%Y-%m-%d").date(),
-    "Datetime64": lambda i: datetime.strptime("2{:03}-10-02T11:00:00Z".format(i), "%Y-%m-%dT%H:%M:%SZ"),
+    "Date32": generate_date32_value,
+    "Datetime64": generate_datetime64_value,
 }
 
 index_three_sync_not_Bool = {
     "Decimal(15,0)": lambda i: "{}".format(i),
     "Decimal(22,9)": lambda i: "{}.123".format(i),
     "Decimal(35,10)": lambda i: "{}.123456".format(i),
-    "Date32": lambda i: datetime.strptime("2{:03}-01-01".format(i), "%Y-%m-%d").date(),
-    "Datetime64": lambda i: datetime.strptime("2{:03}-10-02T11:00:00Z".format(i), "%Y-%m-%dT%H:%M:%SZ"),
+    "Date32": generate_date32_value,
+    "Datetime64": generate_datetime64_value,
 }
 
 index_four_sync = {
@@ -107,12 +186,12 @@ index_second = {
     "String": lambda i: f"String {i}",
     "Utf8": lambda i: f"Utf8 {i}",
     "UUID": lambda i: UUID("3{:03}5678-e89b-12d3-a456-556642440000".format(i)),
-    "Date": lambda i: datetime.strptime("2{:03}-01-01".format(i), "%Y-%m-%d").date(),
-    "Datetime": lambda i: datetime.strptime("2{:03}-10-02T11:00:00Z".format(i), "%Y-%m-%dT%H:%M:%SZ"),
+    "Date": generate_date_value,
+    "Datetime": generate_datetime_value,
     "Timestamp": lambda i: 1696200000000000 + i * 100000000,
     "Interval": lambda i: i,
-    "Date32": lambda i: datetime.strptime("2{:03}-01-01".format(i), "%Y-%m-%d").date(),
-    "Datetime64": lambda i: datetime.strptime("2{:03}-10-02T11:00:00Z".format(i), "%Y-%m-%dT%H:%M:%SZ"),
+    "Date32": generate_date32_value,
+    "Datetime64": generate_datetime64_value,
     "Timestamp64": lambda i: 1696200000000000 + i * 100000000,
     "Interval64": lambda i: i,
 }
@@ -138,17 +217,15 @@ pk_types = {
     "Decimal(22,9)": lambda i: "{}.123".format(i),
     "Decimal(35,10)": lambda i: "{}.123456".format(i),
     "DyNumber": lambda i: float(f"{i}e1"),
-
     "String": lambda i: f"String {i}",
     "Utf8": lambda i: f"Utf8 {i}",
     "UUID": lambda i: UUID("3{:03}5678-e89b-12d3-a456-556642440000".format(i)),
-
-    "Date": lambda i: datetime.strptime("2{:03}-01-01".format(i), "%Y-%m-%d").date(),
-    "Datetime": lambda i: datetime.strptime("2{:03}-10-02T11:00:00Z".format(i), "%Y-%m-%dT%H:%M:%SZ"),
+    "Date": generate_date_value,
+    "Datetime": generate_datetime_value,
     "Timestamp": lambda i: 1696200000000000 + i * 100000000,
     "Interval": lambda i: i,
-    "Date32": lambda i: datetime.strptime("2{:03}-01-01".format(i), "%Y-%m-%d").date(),
-    "Datetime64": lambda i: datetime.strptime("2{:03}-10-02T11:00:00Z".format(i), "%Y-%m-%dT%H:%M:%SZ"),
+    "Date32": generate_date32_value,
+    "Datetime64": generate_datetime64_value,
     "Timestamp64": lambda i: 1696200000000000 + i * 100000000,
     "Interval64": lambda i: i,
 }
@@ -156,8 +233,8 @@ pk_types = {
 non_pk_types = {
     "Float": lambda i: i + 0.1,
     "Double": lambda i: i + 0.2,
-    "Json": lambda i: "{{\"another_key\": {}}}".format(i),
-    "JsonDocument": lambda i: "{{\"another_doc_key\": {}}}".format(i),
+    "Json": lambda i: '{{"another_key": {}}}'.format(i),
+    "JsonDocument": lambda i: '{{"another_doc_key": {}}}'.format(i),
     "Yson": lambda i: "[{}]".format(i),
 }
 

--- a/ydb/tests/datashard/lib/types_of_variables.py
+++ b/ydb/tests/datashard/lib/types_of_variables.py
@@ -2,18 +2,20 @@ from uuid import UUID
 from datetime import datetime
 
 
-def format_sql_value(value, type_name):
+def format_sql_value(value, type_name, unwrap_after_cast: bool = False):
     if type_name == "Datetime64" or type_name == "Datetime":
         value = value.strftime("%Y-%m-%dT%H:%M:%SZ")
     if type_name == "String" or type_name == "Utf8":
         return f"'{value}'"
 
-    # Use quoted values for types that require string representation
-    if type_name in types_requiring_quotes_in_cast:
-        return f"Unwrap(CAST('{value}' AS {type_name}))"
-
-    # Use unquoted values for numeric and other types
-    return f"Unwrap(CAST({value} AS {type_name}))"
+    casted_value = (
+        # Use quoted values for types that require string representation
+        f"CAST('{value}' AS {type_name})"
+        if type_name in types_requiring_quotes_in_cast
+        # Use unquoted values for numeric and other types
+        else f"CAST({value} AS {type_name})"
+    )
+    return f"Unwrap({casted_value})" if unwrap_after_cast else casted_value
 
 
 def generate_date_value(i):

--- a/ydb/tests/datashard/lib/types_of_variables.py
+++ b/ydb/tests/datashard/lib/types_of_variables.py
@@ -3,6 +3,14 @@ from datetime import datetime
 
 
 def format_sql_value(value, type_name, unwrap_after_cast: bool = False):
+    """
+    Format a value for SQL insertion.
+
+    Args:
+        value: The value to format.
+        type_name: The type of the value.
+        unwrap_after_cast: Whether to unwrap the value after casting. Unwrap makes the value type not nullable.
+    """
     if type_name == "Datetime64" or type_name == "Datetime":
         value = value.strftime("%Y-%m-%dT%H:%M:%SZ")
     if type_name == "String" or type_name == "Utf8":

--- a/ydb/tests/datashard/lib/types_of_variables.py
+++ b/ydb/tests/datashard/lib/types_of_variables.py
@@ -248,7 +248,7 @@ non_pk_types = {
     "Yson": lambda i: "[{}]".format(i),
 }
 
-types_missing_in_column_tables = {
+types_not_supported_yet_in_columnshard = {
     "Bool",
     "DyNumber",
     "UUID",

--- a/ydb/tests/stress/olap_workload/workload/__init__.py
+++ b/ydb/tests/stress/olap_workload/workload/__init__.py
@@ -5,39 +5,12 @@ import random
 import threading
 from enum import Enum
 
+from ydb.tests.datashard.lib.types_of_variables import non_pk_types, pk_types, types_not_supported_yet_in_columnshard
 from ydb.tests.stress.common.common import WorkloadBase
 
-supported_pk_types = [
-    # Bool https://github.com/ydb-platform/ydb/issues/13037
-    "Int8",
-    "Int16",
-    "Int32",
-    "Int64",
-    "Uint8",
-    "Uint16",
-    "Uint32",
-    "Uint64",
-    "Decimal(22,9)",
-    # "DyNumber", https://github.com/ydb-platform/ydb/issues/13048
+supported_pk_types = pk_types.keys() - types_not_supported_yet_in_columnshard
 
-    "String",
-    "Utf8",
-    # Uuid", https://github.com/ydb-platform/ydb/issues/13047
-
-    "Date",
-    "Datetime",
-    "Datetime64",
-    "Timestamp",
-    # "Interval", https://github.com/ydb-platform/ydb/issues/13050
-]
-
-supported_types = supported_pk_types + [
-    "Float",
-    "Double",
-    "Json",
-    "JsonDocument",
-    "Yson"
-]
+supported_types = (pk_types.keys() | non_pk_types.keys()) - types_not_supported_yet_in_columnshard
 
 
 class WorkloadTablesCreateDrop(WorkloadBase):

--- a/ydb/tests/stress/olap_workload/workload/__init__.py
+++ b/ydb/tests/stress/olap_workload/workload/__init__.py
@@ -8,9 +8,9 @@ from enum import Enum
 from ydb.tests.datashard.lib.types_of_variables import non_pk_types, pk_types, types_not_supported_yet_in_columnshard
 from ydb.tests.stress.common.common import WorkloadBase
 
-supported_pk_types = pk_types.keys() - types_not_supported_yet_in_columnshard
+supported_pk_types = list(pk_types.keys() - types_not_supported_yet_in_columnshard)
 
-supported_types = (pk_types.keys() | non_pk_types.keys()) - types_not_supported_yet_in_columnshard
+supported_types = list((pk_types.keys() | non_pk_types.keys()) - types_not_supported_yet_in_columnshard)
 
 
 class WorkloadTablesCreateDrop(WorkloadBase):

--- a/ydb/tests/stress/olap_workload/workload/ya.make
+++ b/ydb/tests/stress/olap_workload/workload/ya.make
@@ -8,6 +8,7 @@ PEERDIR(
     ydb/public/sdk/python
     ydb/public/sdk/python/enable_v3_new_behavior
     ydb/tests/stress/common
+    ydb/tests/datashard/lib
 )
 
 END()


### PR DESCRIPTION
It is a take-over from here https://github.com/ydb-platform/ydb/pull/22355

Extends `compatibility/test_data_type.py` to support Column Tables.

Relates to #19821 
