### PR TITLE
merge to stable 25-1 YQ fixes for s3 provider

### DIFF
--- a/ydb/core/external_sources/external_source_factory.cpp
+++ b/ydb/core/external_sources/external_source_factory.cpp
@@ -21,7 +21,13 @@ struct TExternalSourceFactory : public IExternalSourceFactory {
         : Sources(sources)
         , AllExternalDataSourcesAreAvailable(allExternalDataSourcesAreAvailable)
         , AvailableExternalDataSources(availableExternalDataSources)
-    {}
+    {
+        for (const auto& [type, source] : sources) {
+            if (AvailableExternalDataSources.contains(type)) {
+                AvailableProviders.insert(source->GetName());
+            }
+        }
+    }
 
     IExternalSource::TPtr GetOrCreate(const TString& type) const override {
         auto it = Sources.find(type);
@@ -34,10 +40,18 @@ struct TExternalSourceFactory : public IExternalSourceFactory {
         return it->second;
     }
 
+    bool IsAvailableProvider(const TString& provider) const override {
+        if (AllExternalDataSourcesAreAvailable) {
+            return true;
+        }
+        return AvailableProviders.contains(provider);
+    }
+
 private:
     const TMap<TString, IExternalSource::TPtr> Sources;
     bool AllExternalDataSourcesAreAvailable;
     const std::set<TString> AvailableExternalDataSources;
+    std::set<TString> AvailableProviders;
 };
 
 }

--- a/ydb/core/external_sources/external_source_factory.h
+++ b/ydb/core/external_sources/external_source_factory.h
@@ -10,6 +10,8 @@ struct IExternalSourceFactory : public TThrRefBase {
     using TPtr = TIntrusivePtr<IExternalSourceFactory>;
 
     virtual IExternalSource::TPtr GetOrCreate(const TString& type) const = 0;
+
+    virtual bool IsAvailableProvider(const TString& provider) const = 0;
 };
 
 IExternalSourceFactory::TPtr CreateExternalSourceFactory(const std::vector<TString>& hostnamePatterns,

--- a/ydb/core/kqp/host/kqp_host.cpp
+++ b/ydb/core/kqp/host/kqp_host.cpp
@@ -1824,6 +1824,10 @@ private:
     }
 
     void InitS3Provider(EKikimrQueryType queryType) {
+        if (!ExternalSourceFactory->IsAvailableProvider(TString(NYql::S3ProviderName))) {
+            return;
+        }
+
         auto state = MakeIntrusive<NYql::TS3State>();
         state->Types = TypesCtx.Get();
         state->FunctionRegistry = FuncRegistry;
@@ -1844,6 +1848,10 @@ private:
     }
 
     void InitGenericProvider() {
+        if (!ExternalSourceFactory->IsAvailableProvider(TString(NYql::GenericProviderName))) {
+            return;
+        }
+
         if (!FederatedQuerySetup->ConnectorClient) {
             return;
         }
@@ -1862,6 +1870,10 @@ private:
     }
 
     void InitYtProvider() {
+        if (!ExternalSourceFactory->IsAvailableProvider(TString(NYql::YtProviderName))) {
+            return;
+        }
+
         TString userName = CreateGuidAsString();
         if (SessionCtx->GetUserToken() && SessionCtx->GetUserToken()->GetUserSID()) {
             userName = SessionCtx->GetUserToken()->GetUserSID();
@@ -1897,6 +1909,10 @@ private:
     }
 
     void InitSolomonProvider() {
+        if (!ExternalSourceFactory->IsAvailableProvider(TString(NYql::SolomonProviderName))) {
+            return;
+        }
+
         auto solomonState = MakeIntrusive<TSolomonState>();
 
         solomonState->Types = TypesCtx.Get();

--- a/ydb/library/yql/providers/s3/actors/yql_arrow_column_converters.h
+++ b/ydb/library/yql/providers/s3/actors/yql_arrow_column_converters.h
@@ -5,6 +5,7 @@
 
 namespace NDB {
 
+// forward declaration for <ydb/library/yql/udfs/common/clickhouse/client/src/Formats/FormatSettings.h>
 struct FormatSettings;
 
 } // namespace NDB

--- a/ydb/library/yql/providers/s3/actors/yql_s3_actors_factory_impl.cpp
+++ b/ydb/library/yql/providers/s3/actors/yql_s3_actors_factory_impl.cpp
@@ -2,14 +2,13 @@
 #include "yql_s3_write_actor.h"
 #include "yql_s3_applicator_actor.h"
 
+#include <ydb/library/yql/dq/actors/compute/dq_compute_actor_async_io.h>
+
 #include <util/system/platform.h>
 #if defined(_linux_) || defined(_darwin_)
 #include "yql_s3_read_actor.h"
 #include <ydb/library/yql/udfs/common/clickhouse/client/src/Formats/registerFormats.h>
 #endif
-
-#include <ydb/library/yql/dq/actors/compute/dq_compute_actor_async_io.h>
-
 
 namespace NYql::NDq {
 

--- a/ydb/library/yql/providers/s3/actors/yql_s3_read_actor.cpp
+++ b/ydb/library/yql/providers/s3/actors/yql_s3_read_actor.cpp
@@ -1,41 +1,3 @@
-#include <util/system/platform.h>
-#if defined(_linux_) || defined(_darwin_)
-#include <ydb/library/yql/udfs/common/clickhouse/client/src/DataTypes/DataTypeArray.h>
-#include <ydb/library/yql/udfs/common/clickhouse/client/src/DataTypes/DataTypeDate.h>
-#include <ydb/library/yql/udfs/common/clickhouse/client/src/DataTypes/DataTypeDateTime64.h>
-#include <ydb/library/yql/udfs/common/clickhouse/client/src/DataTypes/DataTypesDecimal.h>
-#include <ydb/library/yql/udfs/common/clickhouse/client/src/DataTypes/DataTypeEnum.h>
-#include <ydb/library/yql/udfs/common/clickhouse/client/src/DataTypes/DataTypeFactory.h>
-#include <ydb/library/yql/udfs/common/clickhouse/client/src/DataTypes/DataTypeInterval.h>
-#include <ydb/library/yql/udfs/common/clickhouse/client/src/DataTypes/DataTypeNothing.h>
-#include <ydb/library/yql/udfs/common/clickhouse/client/src/DataTypes/DataTypeNullable.h>
-#include <ydb/library/yql/udfs/common/clickhouse/client/src/DataTypes/DataTypeString.h>
-#include <ydb/library/yql/udfs/common/clickhouse/client/src/DataTypes/DataTypeTuple.h>
-#include <ydb/library/yql/udfs/common/clickhouse/client/src/DataTypes/DataTypeUUID.h>
-#include <ydb/library/yql/udfs/common/clickhouse/client/src/DataTypes/DataTypesNumber.h>
-
-#include <ydb/library/yql/udfs/common/clickhouse/client/src/IO/ReadBuffer.h>
-#include <ydb/library/yql/udfs/common/clickhouse/client/src/IO/ReadBufferFromFile.h>
-#include <ydb/library/yql/udfs/common/clickhouse/client/src/Core/Block.h>
-#include <ydb/library/yql/udfs/common/clickhouse/client/src/Core/ColumnsWithTypeAndName.h>
-
-#include <ydb/library/yql/udfs/common/clickhouse/client/src/Formats/FormatFactory.h>
-#include <ydb/library/yql/udfs/common/clickhouse/client/src/Processors/Formats/InputStreamFromInputFormat.h>
-#include <ydb/library/yql/udfs/common/clickhouse/client/src/Processors/Formats/Impl/ArrowBufferedStreams.h>
-
-#include <arrow/api.h>
-#include <arrow/io/api.h>
-#include <arrow/compute/cast.h>
-#include <arrow/status.h>
-#include <arrow/util/future.h>
-#include <parquet/arrow/reader.h>
-#include <parquet/file_reader.h>
-
-#include <library/cpp/protobuf/util/pb_io.h>
-#include <google/protobuf/text_format.h>
-
-#endif
-
 #include "yql_arrow_column_converters.h"
 #include "yql_arrow_push_down.h"
 #include "yql_s3_decompressor_actor.h"
@@ -98,6 +60,47 @@
 #endif
 #include <library/cpp/string_utils/quote/quote.h>
 #include <library/cpp/xml/document/xml-document.h>
+
+#include <util/system/platform.h>
+#if defined(_linux_) || defined(_darwin_)
+
+#include <arrow/api.h>
+#include <arrow/io/api.h>
+#include <arrow/compute/cast.h>
+#include <arrow/status.h>
+#include <arrow/util/future.h>
+#include <parquet/arrow/reader.h>
+#include <parquet/file_reader.h>
+
+#include <library/cpp/protobuf/util/pb_io.h>
+#include <google/protobuf/text_format.h>
+
+#undef NO_SANITIZE_THREAD
+
+#include <ydb/library/yql/udfs/common/clickhouse/client/src/DataTypes/DataTypeArray.h>
+#include <ydb/library/yql/udfs/common/clickhouse/client/src/DataTypes/DataTypeDate.h>
+#include <ydb/library/yql/udfs/common/clickhouse/client/src/DataTypes/DataTypeDateTime64.h>
+#include <ydb/library/yql/udfs/common/clickhouse/client/src/DataTypes/DataTypesDecimal.h>
+#include <ydb/library/yql/udfs/common/clickhouse/client/src/DataTypes/DataTypeEnum.h>
+#include <ydb/library/yql/udfs/common/clickhouse/client/src/DataTypes/DataTypeFactory.h>
+#include <ydb/library/yql/udfs/common/clickhouse/client/src/DataTypes/DataTypeInterval.h>
+#include <ydb/library/yql/udfs/common/clickhouse/client/src/DataTypes/DataTypeNothing.h>
+#include <ydb/library/yql/udfs/common/clickhouse/client/src/DataTypes/DataTypeNullable.h>
+#include <ydb/library/yql/udfs/common/clickhouse/client/src/DataTypes/DataTypeString.h>
+#include <ydb/library/yql/udfs/common/clickhouse/client/src/DataTypes/DataTypeTuple.h>
+#include <ydb/library/yql/udfs/common/clickhouse/client/src/DataTypes/DataTypeUUID.h>
+#include <ydb/library/yql/udfs/common/clickhouse/client/src/DataTypes/DataTypesNumber.h>
+
+#include <ydb/library/yql/udfs/common/clickhouse/client/src/IO/ReadBuffer.h>
+#include <ydb/library/yql/udfs/common/clickhouse/client/src/IO/ReadBufferFromFile.h>
+#include <ydb/library/yql/udfs/common/clickhouse/client/src/Core/Block.h>
+#include <ydb/library/yql/udfs/common/clickhouse/client/src/Core/ColumnsWithTypeAndName.h>
+
+#include <ydb/library/yql/udfs/common/clickhouse/client/src/Formats/FormatFactory.h>
+#include <ydb/library/yql/udfs/common/clickhouse/client/src/Processors/Formats/InputStreamFromInputFormat.h>
+#include <ydb/library/yql/udfs/common/clickhouse/client/src/Processors/Formats/Impl/ArrowBufferedStreams.h>
+
+#endif
 
 #define LOG_E(name, stream) \
     LOG_ERROR_S(*TlsActivationContext, NKikimrServices::KQP_COMPUTE, name << ": " << this->SelfId() << ", TxId: " << TxId << ". " << stream)
@@ -1557,8 +1560,19 @@ private:
 
     class TReadyBlock {
     public:
-        TReadyBlock(TEvS3Provider::TEvNextBlock::TPtr& event) : PathInd(event->Get()->PathIndex) { Block.swap(event->Get()->Block); }
-        TReadyBlock(TEvS3Provider::TEvNextRecordBatch::TPtr& event) : Batch(event->Get()->Batch), PathInd(event->Get()->PathIndex) {}
+        TReadyBlock(TEvS3Provider::TEvNextBlock::TPtr& event)
+            : PathInd(event->Get()->PathIndex)
+        {
+            const auto& block = event->Get()->Block;
+            YQL_ENSURE(block);
+            Block.swap(*block);
+        }
+
+        TReadyBlock(TEvS3Provider::TEvNextRecordBatch::TPtr& event)
+            : Batch(event->Get()->Batch)
+            , PathInd(event->Get()->PathIndex)
+        {}
+
         NDB::Block Block;
         std::shared_ptr<arrow::RecordBatch> Batch;
         size_t PathInd;
@@ -1742,7 +1756,9 @@ private:
 
     void HandleNextBlock(TEvS3Provider::TEvNextBlock::TPtr& next) {
         YQL_ENSURE(!ReadSpec->Arrow);
-        auto rows = next->Get()->Block.rows();
+        const auto& block = next->Get()->Block;
+        YQL_ENSURE(block);
+        auto rows = block->rows();
         IngressStats.Bytes += next->Get()->IngressDelta;
         IngressStats.DecompressedBytes += next->Get()->IngressDecompressedDelta;
         IngressStats.Rows += rows;

--- a/ydb/library/yql/providers/s3/actors/yql_s3_source_queue.cpp
+++ b/ydb/library/yql/providers/s3/actors/yql_s3_source_queue.cpp
@@ -1,43 +1,3 @@
-#include <util/system/platform.h>
-#if defined(_linux_) || defined(_darwin_)
-#include <ydb/library/yql/udfs/common/clickhouse/client/src/DataTypes/DataTypeArray.h>
-#include <ydb/library/yql/udfs/common/clickhouse/client/src/DataTypes/DataTypeDate.h>
-#include <ydb/library/yql/udfs/common/clickhouse/client/src/DataTypes/DataTypeDateTime64.h>
-#include <ydb/library/yql/udfs/common/clickhouse/client/src/DataTypes/DataTypesDecimal.h>
-#include <ydb/library/yql/udfs/common/clickhouse/client/src/DataTypes/DataTypeEnum.h>
-#include <ydb/library/yql/udfs/common/clickhouse/client/src/DataTypes/DataTypeFactory.h>
-#include <ydb/library/yql/udfs/common/clickhouse/client/src/DataTypes/DataTypeInterval.h>
-#include <ydb/library/yql/udfs/common/clickhouse/client/src/DataTypes/DataTypeNothing.h>
-#include <ydb/library/yql/udfs/common/clickhouse/client/src/DataTypes/DataTypeNullable.h>
-#include <ydb/library/yql/udfs/common/clickhouse/client/src/DataTypes/DataTypeString.h>
-#include <ydb/library/yql/udfs/common/clickhouse/client/src/DataTypes/DataTypeTuple.h>
-#include <ydb/library/yql/udfs/common/clickhouse/client/src/DataTypes/DataTypeUUID.h>
-#include <ydb/library/yql/udfs/common/clickhouse/client/src/DataTypes/DataTypesNumber.h>
-
-#include <ydb/library/yql/udfs/common/clickhouse/client/src/IO/ReadBuffer.h>
-#include <ydb/library/yql/udfs/common/clickhouse/client/src/IO/ReadBufferFromFile.h>
-#include <ydb/library/yql/udfs/common/clickhouse/client/src/Core/Block.h>
-#include <ydb/library/yql/udfs/common/clickhouse/client/src/Core/ColumnsWithTypeAndName.h>
-
-#include <ydb/library/yql/udfs/common/clickhouse/client/src/Formats/FormatFactory.h>
-#include <ydb/library/yql/udfs/common/clickhouse/client/src/Processors/Formats/InputStreamFromInputFormat.h>
-#include <ydb/library/yql/udfs/common/clickhouse/client/src/Processors/Formats/Impl/ArrowBufferedStreams.h>
-
-#include <arrow/api.h>
-#include <arrow/io/api.h>
-#include <arrow/compute/cast.h>
-#include <arrow/status.h>
-#include <arrow/util/future.h>
-#include <parquet/arrow/reader.h>
-#include <parquet/file_reader.h>
-
-#include <library/cpp/protobuf/util/pb_io.h>
-#include <google/protobuf/text_format.h>
-
-#endif
-
-#include "yql_arrow_column_converters.h"
-#include "yql_s3_actors_util.h"
 #include "yql_s3_read_actor.h"
 #include "yql_s3_source_queue.h"
 
@@ -87,13 +47,53 @@
 #include <util/system/fstat.h>
 
 #include <algorithm>
-#include <queue>
 
 #ifdef THROW
 #undef THROW
 #endif
 #include <library/cpp/string_utils/quote/quote.h>
 #include <library/cpp/xml/document/xml-document.h>
+
+#include <util/system/platform.h>
+#if defined(_linux_) || defined(_darwin_)
+
+#include <arrow/api.h>
+#include <arrow/io/api.h>
+#include <arrow/compute/cast.h>
+#include <arrow/status.h>
+#include <arrow/util/future.h>
+#include <parquet/arrow/reader.h>
+#include <parquet/file_reader.h>
+
+#include <library/cpp/protobuf/util/pb_io.h>
+#include <google/protobuf/text_format.h>
+
+#undef NO_SANITIZE_THREAD
+
+#include <ydb/library/yql/udfs/common/clickhouse/client/src/DataTypes/DataTypeArray.h>
+#include <ydb/library/yql/udfs/common/clickhouse/client/src/DataTypes/DataTypeDate.h>
+#include <ydb/library/yql/udfs/common/clickhouse/client/src/DataTypes/DataTypeDateTime64.h>
+#include <ydb/library/yql/udfs/common/clickhouse/client/src/DataTypes/DataTypesDecimal.h>
+#include <ydb/library/yql/udfs/common/clickhouse/client/src/DataTypes/DataTypeEnum.h>
+#include <ydb/library/yql/udfs/common/clickhouse/client/src/DataTypes/DataTypeFactory.h>
+#include <ydb/library/yql/udfs/common/clickhouse/client/src/DataTypes/DataTypeInterval.h>
+#include <ydb/library/yql/udfs/common/clickhouse/client/src/DataTypes/DataTypeNothing.h>
+#include <ydb/library/yql/udfs/common/clickhouse/client/src/DataTypes/DataTypeNullable.h>
+#include <ydb/library/yql/udfs/common/clickhouse/client/src/DataTypes/DataTypeString.h>
+#include <ydb/library/yql/udfs/common/clickhouse/client/src/DataTypes/DataTypeTuple.h>
+#include <ydb/library/yql/udfs/common/clickhouse/client/src/DataTypes/DataTypeUUID.h>
+#include <ydb/library/yql/udfs/common/clickhouse/client/src/DataTypes/DataTypesNumber.h>
+
+#include <ydb/library/yql/udfs/common/clickhouse/client/src/IO/ReadBuffer.h>
+#include <ydb/library/yql/udfs/common/clickhouse/client/src/IO/ReadBufferFromFile.h>
+#include <ydb/library/yql/udfs/common/clickhouse/client/src/Core/Block.h>
+#include <ydb/library/yql/udfs/common/clickhouse/client/src/Core/ColumnsWithTypeAndName.h>
+
+#include <ydb/library/yql/udfs/common/clickhouse/client/src/Formats/FormatFactory.h>
+#include <ydb/library/yql/udfs/common/clickhouse/client/src/Processors/Formats/InputStreamFromInputFormat.h>
+#include <ydb/library/yql/udfs/common/clickhouse/client/src/Processors/Formats/Impl/ArrowBufferedStreams.h>
+
+#endif
 
 #define LOG_E(name, stream) \
     LOG_ERROR_S(*NActors::TlsActivationContext, NKikimrServices::KQP_COMPUTE, name << ": " << this->SelfId() << ", TxId: " << TxId << ". " << stream)

--- a/ydb/library/yql/providers/s3/actors/yql_s3_write_actor.cpp
+++ b/ydb/library/yql/providers/s3/actors/yql_s3_write_actor.cpp
@@ -11,8 +11,6 @@
 #include <parquet/arrow/writer.h>
 #include <util/generic/size_literals.h>
 
-#include <ydb/library/yql/providers/s3/compressors/factory.h>  // defines NO_SANITIZE_THREAD
-
 #include <ydb/library/actors/core/actor_bootstrapped.h>
 #include <ydb/library/actors/core/events.h>
 #include <ydb/library/actors/core/event_local.h>
@@ -22,6 +20,7 @@
 #include <ydb/library/services/services.pb.h>
 #include <ydb/library/yql/providers/common/http_gateway/yql_http_default_retry_policy.h>
 #include <ydb/library/yql/providers/s3/common/util.h>
+#include <ydb/library/yql/providers/s3/compressors/factory.h>
 #include <ydb/library/yql/providers/s3/credentials/credentials.h>
 
 #include <yql/essentials/minikql/mkql_program_builder.h>

--- a/ydb/library/yql/providers/s3/common/source_context.h
+++ b/ydb/library/yql/providers/s3/common/source_context.h
@@ -4,13 +4,10 @@
 #include <memory>
 #include <mutex>
 
-#include <ydb/library/yql/udfs/common/clickhouse/client/src/Formats/FormatSettings.h>
-#include <ydb/library/yql/providers/s3/events/events.h>
-
 #include <ydb/library/actors/core/actorsystem.h>
-
 #include <ydb/library/yql/providers/common/http_gateway/yql_http_gateway.h>
 #include <ydb/library/yql/providers/common/http_gateway/yql_http_default_retry_policy.h>
+#include <ydb/library/yql/providers/s3/events/events.h>
 
 namespace NYql::NDq {
 

--- a/ydb/library/yql/providers/s3/compressors/brotli.cpp
+++ b/ydb/library/yql/providers/s3/compressors/brotli.cpp
@@ -1,28 +1,52 @@
 #include "brotli.h"
 #include "output_queue_impl.h"
 
-#include <util/generic/size_literals.h>
-#include <yql/essentials/utils/exceptions.h>
-#include <yql/essentials/utils/yql_panic.h>
+#include <contrib/libs/brotli/include/brotli/decode.h>
 #include <contrib/libs/brotli/include/brotli/encode.h>
+
+#include <util/generic/size_literals.h>
+
 #include <ydb/library/yql/dq/actors/protos/dq_status_codes.pb.h>
 
-namespace NYql {
+#include <yql/essentials/utils/exceptions.h>
+#include <yql/essentials/utils/yql_panic.h>
 
-namespace NBrotli {
+#include <ydb/library/yql/udfs/common/clickhouse/client/src/IO/ReadBuffer.h>
+
+namespace NYql::NBrotli {
 
 namespace {
-    struct TAllocator {
-        static void* Allocate(void* /* opaque */, size_t size) {
-            return ::operator new(size);
-        }
 
-        static void Deallocate(void* /* opaque */, void* ptr) noexcept {
-            ::operator delete(ptr);
-        }
-    };
+struct TAllocator {
+    static void* Allocate(void* /* opaque */, size_t size) {
+        return ::operator new(size);
+    }
 
-}
+    static void Deallocate(void* /* opaque */, void* ptr) noexcept {
+        ::operator delete(ptr);
+    }
+};
+
+class TReadBuffer : public NDB::ReadBuffer {
+public:
+    TReadBuffer(NDB::ReadBuffer& source);
+    ~TReadBuffer();
+private:
+    bool nextImpl() final;
+
+    NDB::ReadBuffer& Source_;
+    std::vector<char> InBuffer, OutBuffer;
+
+    BrotliDecoderState* DecoderState_;
+
+    bool SubstreamFinished_ = false;
+    bool InputExhausted_ = false;
+    size_t InputAvailable_ = 0;
+    size_t InputSize_ = 0;
+
+    void InitDecoder();
+    void FreeDecoder();
+};
 
 TReadBuffer::TReadBuffer(NDB::ReadBuffer& source)
     : NDB::ReadBuffer(nullptr, 0ULL), Source_(source)
@@ -107,8 +131,6 @@ void TReadBuffer::FreeDecoder() {
     BrotliDecoderDestroyInstance(DecoderState_);
 }
 
-namespace {
-
 class TCompressor : public TOutputQueue<> {
 public:
     TCompressor(int quiality)
@@ -188,11 +210,14 @@ private:
     bool IsFirstBlock = true;
 };
 
+} // anonymous namespace
+
+std::unique_ptr<NDB::ReadBuffer> MakeDecompressor(NDB::ReadBuffer& source) {
+    return std::make_unique<TReadBuffer>(source);
 }
+
 IOutputQueue::TPtr MakeCompressor(std::optional<int> cLevel) {
     return std::make_unique<TCompressor>(cLevel.value_or(BROTLI_DEFAULT_QUALITY));
 }
 
-}
-
-}
+} // namespace NYql::NBrotli

--- a/ydb/library/yql/providers/s3/compressors/brotli.h
+++ b/ydb/library/yql/providers/s3/compressors/brotli.h
@@ -1,36 +1,18 @@
 #pragma once
 
-#include <ydb/library/yql/udfs/common/clickhouse/client/src/IO/ReadBuffer.h>
-#include <contrib/libs/brotli/include/brotli/decode.h>
 #include "output_queue.h"
 
-namespace NYql {
+namespace NDB {
 
-namespace NBrotli {
+// forward declaration for <ydb/library/yql/udfs/common/clickhouse/client/src/IO/ReadBuffer.h>
+class ReadBuffer;
 
-class TReadBuffer : public NDB::ReadBuffer {
-public:
-    TReadBuffer(NDB::ReadBuffer& source);
-    ~TReadBuffer();
-private:
-    bool nextImpl() final;
+} // namespace NDB
 
-    NDB::ReadBuffer& Source_;
-    std::vector<char> InBuffer, OutBuffer;
+namespace NYql::NBrotli {
 
-    BrotliDecoderState* DecoderState_;
-
-    bool SubstreamFinished_ = false;
-    bool InputExhausted_ = false;
-    size_t InputAvailable_ = 0;
-    size_t InputSize_ = 0;
-
-    void InitDecoder();
-    void FreeDecoder();
-};
+std::unique_ptr<NDB::ReadBuffer> MakeDecompressor(NDB::ReadBuffer& source);
 
 IOutputQueue::TPtr MakeCompressor(std::optional<int> cLevel = {});
 
-}
-
-}
+} // namespace NYql::NBrotli

--- a/ydb/library/yql/providers/s3/compressors/bzip2.cpp
+++ b/ydb/library/yql/providers/s3/compressors/bzip2.cpp
@@ -1,14 +1,36 @@
 #include "bzip2.h"
-
-#include <util/generic/size_literals.h>
-#include <yql/essentials/utils/exceptions.h>
-#include <yql/essentials/utils/yql_panic.h>
-#include <ydb/library/yql/dq/actors/protos/dq_status_codes.pb.h>
 #include "output_queue_impl.h"
 
-namespace NYql {
+#include <contrib/libs/libbz2/bzlib.h>
 
-namespace NBzip2 {
+#include <util/generic/size_literals.h>
+
+#include <ydb/library/yql/dq/actors/protos/dq_status_codes.pb.h>
+
+#include <yql/essentials/utils/exceptions.h>
+#include <yql/essentials/utils/yql_panic.h>
+
+#include <ydb/library/yql/udfs/common/clickhouse/client/src/IO/ReadBuffer.h>
+
+namespace NYql::NBzip2 {
+
+namespace {
+
+class TReadBuffer : public NDB::ReadBuffer {
+public:
+    TReadBuffer(NDB::ReadBuffer& source);
+    ~TReadBuffer();
+private:
+    bool nextImpl() final;
+
+    NDB::ReadBuffer& Source_;
+    std::vector<char> InBuffer, OutBuffer;
+
+    bz_stream BzStream_;
+
+    void InitDecoder();
+    void FreeDecoder();
+};
 
 TReadBuffer::TReadBuffer(NDB::ReadBuffer& source)
     : NDB::ReadBuffer(nullptr, 0ULL), Source_(source)
@@ -63,8 +85,6 @@ bool TReadBuffer::nextImpl() {
         }
     }
 }
-
-namespace {
 
 class TCompressor : public TOutputQueue<> {
 public:
@@ -134,12 +154,14 @@ private:
     TOutputQueue<0> InputQueue;
 };
 
+} // anonymous namespace
+
+std::unique_ptr<NDB::ReadBuffer> MakeDecompressor(NDB::ReadBuffer& source) {
+    return std::make_unique<TReadBuffer>(source);
 }
 
 IOutputQueue::TPtr MakeCompressor(std::optional<int> blockSize100k) {
     return std::make_unique<TCompressor>(blockSize100k.value_or(9));
 }
 
-}
-
-}
+} // namespace NYql::NBzip2

--- a/ydb/library/yql/providers/s3/compressors/bzip2.h
+++ b/ydb/library/yql/providers/s3/compressors/bzip2.h
@@ -1,32 +1,18 @@
 #pragma once
 
-#include <ydb/library/yql/udfs/common/clickhouse/client/src/IO/ReadBuffer.h>
-#include <contrib/libs/libbz2/bzlib.h>
 #include "output_queue.h"
 
-namespace NYql {
+namespace NDB {
 
-namespace NBzip2 {
+// forward declaration for <ydb/library/yql/udfs/common/clickhouse/client/src/IO/ReadBuffer.h>
+class ReadBuffer;
 
-class TReadBuffer : public NDB::ReadBuffer {
-public:
-    TReadBuffer(NDB::ReadBuffer& source);
-    ~TReadBuffer();
-private:
-    bool nextImpl() final;
+} // namespace NDB
 
-    NDB::ReadBuffer& Source_;
-    std::vector<char> InBuffer, OutBuffer;
+namespace NYql::NBzip2 {
 
-    bz_stream BzStream_;
-
-    void InitDecoder();
-    void FreeDecoder();
-};
+std::unique_ptr<NDB::ReadBuffer> MakeDecompressor(NDB::ReadBuffer& source);
 
 IOutputQueue::TPtr MakeCompressor(std::optional<int> blockSize100k = {});
 
-}
-
-}
-
+} // namespace NYql::NBzip2

--- a/ydb/library/yql/providers/s3/compressors/factory.cpp
+++ b/ydb/library/yql/providers/s3/compressors/factory.cpp
@@ -1,13 +1,15 @@
 #include "factory.h"
 
 #if defined(_win_)
+
 namespace NYql {
 
 IOutputQueue::TPtr MakeCompressorQueue(const std::string_view& /*compression*/) {
     return {};
 }
 
-}
+} // namespace NYql
+
 #else
 
 #include "lz4io.h"
@@ -18,44 +20,59 @@ IOutputQueue::TPtr MakeCompressorQueue(const std::string_view& /*compression*/) 
 #include "gz.h"
 #include "output_queue_impl.h"
 
+#include <ydb/library/yql/udfs/common/clickhouse/client/src/IO/ReadBuffer.h>
+
 namespace NYql {
 
 std::unique_ptr<NDB::ReadBuffer> MakeDecompressor(NDB::ReadBuffer& input, const std::string_view& compression) {
-    if ("lz4" == compression)
-        return std::make_unique<NLz4::TReadBuffer>(input);
-    if ("brotli" == compression)
-        return std::make_unique<NBrotli::TReadBuffer>(input);
-    if ("zstd" == compression)
-        return std::make_unique<NZstd::TReadBuffer>(input);
-    if ("bzip2" == compression)
-        return std::make_unique<NBzip2::TReadBuffer>(input);
-    if ("xz" == compression)
-        return std::make_unique<NXz::TReadBuffer>(input);
-    if ("gzip" == compression)
-        return std::make_unique<NGz::TReadBuffer>(input);
+    if ("lz4" == compression) {
+        return NLz4::MakeDecompressor(input);
+    }
+    if ("brotli" == compression) {
+        return NBrotli::MakeDecompressor(input);
+    }
+    if ("zstd" == compression) {
+        return NZstd::MakeDecompressor(input);
+    }
+    if ("bzip2" == compression) {
+        return NBzip2::MakeDecompressor(input);
+    }
+    if ("xz" == compression) {
+        return NXz::MakeDecompressor(input);
+    }
+    if ("gzip" == compression) {
+        return NGz::MakeDecompressor(input);
+    }
 
     return nullptr;
 }
 
 IOutputQueue::TPtr MakeCompressorQueue(const std::string_view& compression) {
-    if ("lz4" == compression)
+    if ("lz4" == compression) {
         return NLz4::MakeCompressor();
-    if ("brotli" == compression)
+    }
+    if ("brotli" == compression) {
         return NBrotli::MakeCompressor();
-    if ("zstd" == compression)
+    }
+    if ("zstd" == compression) {
         return  NZstd::MakeCompressor();
-    if ("bzip2" == compression)
+    }
+    if ("bzip2" == compression) {
         return  NBzip2::MakeCompressor();
-    if ("xz" == compression)
+    }
+    if ("xz" == compression) {
         return NXz::MakeCompressor();
-    if ("gzip" == compression)
+    }
+    if ("gzip" == compression) {
         return NGz::MakeCompressor();
-
-    if (compression.empty())
+    }
+    if (compression.empty()) {
         return std::make_unique<TOutputQueue<5_MB>>();
+    }
 
     return {};
 }
 
-}
+} // namespace NYql
+
 #endif

--- a/ydb/library/yql/providers/s3/compressors/factory.h
+++ b/ydb/library/yql/providers/s3/compressors/factory.h
@@ -1,15 +1,23 @@
 #pragma once
+
 #include "output_queue.h"
 
 #if defined(_win_)
+
 namespace NYql {
 
 IOutputQueue::TPtr MakeCompressorQueue(const std::string_view& compression);
 
-}
+} // namespace NYql
+
 #else
 
-#include <ydb/library/yql/udfs/common/clickhouse/client/src/IO/ReadBuffer.h>
+namespace NDB {
+
+// forward declaration for <ydb/library/yql/udfs/common/clickhouse/client/src/IO/ReadBuffer.h>
+class ReadBuffer;
+
+} // namespace NDB
 
 namespace NYql {
 
@@ -17,5 +25,6 @@ std::unique_ptr<NDB::ReadBuffer> MakeDecompressor(NDB::ReadBuffer& input, const 
 
 IOutputQueue::TPtr MakeCompressorQueue(const std::string_view& compression);
 
-}
+} // namespace NYql
+
 #endif

--- a/ydb/library/yql/providers/s3/compressors/gz.h
+++ b/ydb/library/yql/providers/s3/compressors/gz.h
@@ -1,29 +1,18 @@
 #pragma once
 
-#include <ydb/library/yql/udfs/common/clickhouse/client/src/IO/ReadBuffer.h>
-#include <zlib.h>
 #include "output_queue.h"
 
-namespace NYql {
+namespace NDB {
 
-namespace NGz {
+// forward declaration for <ydb/library/yql/udfs/common/clickhouse/client/src/IO/ReadBuffer.h>
+class ReadBuffer;
 
-class TReadBuffer : public NDB::ReadBuffer {
-public:
-    TReadBuffer(NDB::ReadBuffer& source);
-    ~TReadBuffer();
-private:
-    bool nextImpl() final;
+} // namespace NDB
 
-    NDB::ReadBuffer& Source_;
-    std::vector<char> InBuffer, OutBuffer;
+namespace NYql::NGz {
 
-    z_stream Z_;
-};
+std::unique_ptr<NDB::ReadBuffer> MakeDecompressor(NDB::ReadBuffer& source);
 
 IOutputQueue::TPtr MakeCompressor(std::optional<int> cLevel = {});
 
-}
-
-}
-
+} // namespace NYql::NGz

--- a/ydb/library/yql/providers/s3/compressors/lz4io.h
+++ b/ydb/library/yql/providers/s3/compressors/lz4io.h
@@ -1,42 +1,18 @@
 #pragma once
 
-#include <ydb/library/yql/udfs/common/clickhouse/client/src/IO/ReadBuffer.h>
-#define LZ4F_STATIC_LINKING_ONLY
-#include <contrib/libs/lz4/lz4frame.h>
-
 #include "output_queue.h"
 
-namespace NYql {
+namespace NDB {
 
-namespace NLz4 {
+// forward declaration for <ydb/library/yql/udfs/common/clickhouse/client/src/IO/ReadBuffer.h>
+class ReadBuffer;
 
-enum class EStreamType {
-    Unknown = 0,
-    Frame,
-    Legacy
-};
+} // namespace NDB
 
-class TReadBuffer : public NDB::ReadBuffer {
-public:
-    TReadBuffer(NDB::ReadBuffer& source);
-    ~TReadBuffer();
-private:
-    bool nextImpl() final;
+namespace NYql::NLz4 {
 
-    size_t DecompressFrame();
-    size_t DecompressLegacy();
-
-    NDB::ReadBuffer& Source;
-    const EStreamType StreamType;
-    std::vector<char> InBuffer, OutBuffer;
-
-    LZ4F_decompressionContext_t Ctx;
-    LZ4F_errorCode_t NextToLoad;
-    size_t Pos, Remaining;
-};
+std::unique_ptr<NDB::ReadBuffer> MakeDecompressor(NDB::ReadBuffer& source);
 
 IOutputQueue::TPtr MakeCompressor(std::optional<int> cLevel = {});
 
-}
-
-}
+} // namespace NYql::NLz4

--- a/ydb/library/yql/providers/s3/compressors/ut/decompressor_ut.cpp
+++ b/ydb/library/yql/providers/s3/compressors/ut/decompressor_ut.cpp
@@ -1,9 +1,10 @@
 #include <ydb/library/yql/providers/s3/compressors/lz4io.h>
-#include <ydb/library/yql/udfs/common/clickhouse/client/src/IO/ReadBufferFromFile.h>
 
 #include <library/cpp/scheme/scheme.h>
 #include <library/cpp/testing/common/env.h>
 #include <library/cpp/testing/unittest/registar.h>
+
+#include <ydb/library/yql/udfs/common/clickhouse/client/src/IO/ReadBufferFromFile.h>
 
 namespace NYql::NCompressors {
 
@@ -16,7 +17,7 @@ namespace {
 Y_UNIT_TEST_SUITE(TCompressorTests) {
     Y_UNIT_TEST(SuccessLz4) {
         NDB::ReadBufferFromFile buffer(GetResourcePath("test.json.lz4"));
-        auto decompressorBuffer = std::make_unique<NLz4::TReadBuffer>(buffer);
+        auto decompressorBuffer = NLz4::MakeDecompressor(buffer);
 
         char str[256] = {};
         decompressorBuffer->read(str, 256);
@@ -31,12 +32,12 @@ Y_UNIT_TEST_SUITE(TCompressorTests) {
 
     Y_UNIT_TEST(WrongMagicLz4) {
         NDB::ReadBufferFromFile buffer(GetResourcePath("test.json"));
-        UNIT_ASSERT_EXCEPTION_CONTAINS(std::make_unique<NLz4::TReadBuffer>(buffer), yexception, "Wrong magic.");
+        UNIT_ASSERT_EXCEPTION_CONTAINS(NLz4::MakeDecompressor(buffer), yexception, "Wrong magic.");
     }
 
     Y_UNIT_TEST(ErrorLz4) {
         NDB::ReadBufferFromFile buffer(GetResourcePath("test.broken.lz4"));
-        auto decompressorBuffer = std::make_unique<NLz4::TReadBuffer>(buffer);
+        auto decompressorBuffer = NLz4::MakeDecompressor(buffer);
         char str[256] = {};
         UNIT_ASSERT_EXCEPTION_CONTAINS(decompressorBuffer->read(str, 256), yexception, "Decompression error: ERROR_reservedFlag_set");
     }

--- a/ydb/library/yql/providers/s3/compressors/xz.h
+++ b/ydb/library/yql/providers/s3/compressors/xz.h
@@ -1,32 +1,18 @@
 #pragma once
 
-#include <ydb/library/yql/udfs/common/clickhouse/client/src/IO/ReadBuffer.h>
-#include <contrib/libs/lzma/liblzma/api/lzma.h>
 #include "output_queue.h"
 
-namespace NYql {
+namespace NDB {
 
-namespace NXz {
+// forward declaration for <ydb/library/yql/udfs/common/clickhouse/client/src/IO/ReadBuffer.h>
+class ReadBuffer;
 
-class TReadBuffer : public NDB::ReadBuffer {
-public:
-    TReadBuffer(NDB::ReadBuffer& source);
-    ~TReadBuffer();
-private:
-    bool nextImpl() final;
+} // namespace NDB
 
-    NDB::ReadBuffer& Source_;
-    std::vector<char> InBuffer, OutBuffer;
+namespace NYql::NXz {
 
-    lzma_stream Strm_;
-
-    bool IsInFinished_ = false;
-    bool IsOutFinished_ = false;
-};
+std::unique_ptr<NDB::ReadBuffer> MakeDecompressor(NDB::ReadBuffer& source);
 
 IOutputQueue::TPtr MakeCompressor(std::optional<int> cLevel = {});
 
-}
-
-}
-
+} // namespace NYql::NXz

--- a/ydb/library/yql/providers/s3/compressors/ya.make
+++ b/ydb/library/yql/providers/s3/compressors/ya.make
@@ -1,4 +1,5 @@
 LIBRARY()
+
 PEERDIR(
     contrib/libs/fmt
     contrib/libs/poco/Util

--- a/ydb/library/yql/providers/s3/compressors/zstd.h
+++ b/ydb/library/yql/providers/s3/compressors/zstd.h
@@ -1,31 +1,18 @@
 #pragma once
 
-#include <ydb/library/yql/udfs/common/clickhouse/client/src/IO/ReadBuffer.h>
-#define ZSTD_STATIC_LINKING_ONLY
-#include <contrib/libs/zstd/include/zstd.h>
 #include "output_queue.h"
 
-namespace NYql {
+namespace NDB {
 
-namespace NZstd {
+// forward declaration for <ydb/library/yql/udfs/common/clickhouse/client/src/IO/ReadBuffer.h>
+class ReadBuffer;
 
-class TReadBuffer : public NDB::ReadBuffer {
-public:
-    TReadBuffer(NDB::ReadBuffer& source);
-    ~TReadBuffer();
-private:
-    bool nextImpl() final;
+} // namespace NDB
 
-    NDB::ReadBuffer& Source_;
-    std::vector<char> InBuffer, OutBuffer;
-    ::ZSTD_DStream *const ZCtx_;
-    size_t Offset_;
-    size_t Size_;
-    bool Finished_ = false;
-};
+namespace NYql::NZstd {
+
+std::unique_ptr<NDB::ReadBuffer> MakeDecompressor(NDB::ReadBuffer& source);
 
 IOutputQueue::TPtr MakeCompressor(std::optional<int> cLevel = {});
 
-}
-
-}
+} // namespace NYql::NZstd

--- a/ydb/library/yql/providers/s3/events/events.cpp
+++ b/ydb/library/yql/providers/s3/events/events.cpp
@@ -1,1 +1,17 @@
 #include "events.h"
+
+#include <ydb/library/yql/udfs/common/clickhouse/client/src/Core/Block.h>
+
+namespace NYql::NDq {
+
+TEvS3Provider::TEvNextBlock::TEvNextBlock(NDB::Block& block, size_t pathInd, ui64 ingressDelta, TDuration cpuTimeDelta, ui64 ingressDecompressedDelta)
+    : Block(std::make_unique<NDB::Block>())
+    , PathIndex(pathInd)
+    , IngressDelta(ingressDelta)
+    , CpuTimeDelta(cpuTimeDelta)
+    , IngressDecompressedDelta(ingressDecompressedDelta)
+{
+    Block->swap(block);
+}
+
+} // namespace NYql::NDq

--- a/ydb/library/yql/providers/s3/events/events.h
+++ b/ydb/library/yql/providers/s3/events/events.h
@@ -10,9 +10,14 @@
 #include <yql/essentials/public/issue/yql_issue_message.h>
 #include <ydb/library/yql/providers/common/http_gateway/yql_http_gateway.h>
 
-#include <ydb/library/yql/udfs/common/clickhouse/client/src/Core/Block.h>
-
 #include <arrow/api.h>
+
+namespace NDB {
+
+// forward declaration for <ydb/library/yql/udfs/common/clickhouse/client/src/Core/Block.h>
+class Block;
+
+} // namespace NDB
 
 namespace NYql::NDq {
 
@@ -176,11 +181,9 @@ struct TEvS3Provider {
     };
 
     struct TEvNextBlock : public NActors::TEventLocal<TEvNextBlock, EvNextBlock> {
-        TEvNextBlock(NDB::Block& block, size_t pathInd, ui64 ingressDelta, TDuration cpuTimeDelta, ui64 ingressDecompressedDelta = 0)
-            : PathIndex(pathInd), IngressDelta(ingressDelta), CpuTimeDelta(cpuTimeDelta), IngressDecompressedDelta(ingressDecompressedDelta) {
-            Block.swap(block);
-        }
-        NDB::Block Block;
+        TEvNextBlock(NDB::Block& block, size_t pathInd, ui64 ingressDelta, TDuration cpuTimeDelta, ui64 ingressDecompressedDelta = 0);
+
+        std::unique_ptr<NDB::Block> Block;
         const size_t PathIndex;
         const ui64 IngressDelta;
         const TDuration CpuTimeDelta;

--- a/ydb/library/yql/providers/s3/provider/yql_s3_settings.cpp
+++ b/ydb/library/yql/providers/s3/provider/yql_s3_settings.cpp
@@ -65,7 +65,7 @@ void TS3Configuration::Init(const TS3GatewayConfig& config, TIntrusivePtr<TTypeA
         config.HasMaxInflightListsPerQuery() ? config.GetMaxInflightListsPerQuery() : 1;
     ListingCallbackThreadCount = config.HasListingCallbackThreadCount()
                                      ? config.GetListingCallbackThreadCount()
-                                     : 1;
+                                     : 0;
     ListingCallbackPerThreadQueueSize = config.HasListingCallbackPerThreadQueueSize()
                                             ? config.GetListingCallbackPerThreadQueueSize()
                                             : 100;

--- a/ydb/library/yql/providers/s3/serializations/serialization_interval.cpp
+++ b/ydb/library/yql/providers/s3/serializations/serialization_interval.cpp
@@ -1,13 +1,13 @@
 #include "serialization_interval.h"
 
+#include <util/generic/serialized_enum.h>
+
 #include <ydb/library/yql/udfs/common/clickhouse/client/src/DataTypes/DataTypeFactory.h>
 #include <ydb/library/yql/udfs/common/clickhouse/client/src/DataTypes/DataTypeInterval.h>
 #include <ydb/library/yql/udfs/common/clickhouse/client/src/DataTypes/Serializations/SerializationNumber.h>
 
 #include <ydb/library/yql/udfs/common/clickhouse/client/src/IO/ReadHelpers.h>
 #include <ydb/library/yql/udfs/common/clickhouse/client/src/IO/WriteHelpers.h>
-
-#include <util/generic/serialized_enum.h>
 
 namespace NYql::NSerialization {
 

--- a/ydb/library/yql/udfs/common/clickhouse/client/base/common/defines.h
+++ b/ydb/library/yql/udfs/common/clickhouse/client/base/common/defines.h
@@ -46,45 +46,45 @@
 #endif
 
 /// Check for presence of address sanitizer
-#if !defined(ADDRESS_SANITIZER)
-#    if defined(ch_has_feature)
-#        if ch_has_feature(address_sanitizer)
-#            define ADDRESS_SANITIZER 1
-#        endif
-#    elif defined(__SANITIZE_ADDRESS__)
-#        define ADDRESS_SANITIZER 1
-#    endif
-#endif
+// #if !defined(ADDRESS_SANITIZER)
+// #    if defined(ch_has_feature)
+// #        if ch_has_feature(address_sanitizer)
+// #            define ADDRESS_SANITIZER 1
+// #        endif
+// #    elif defined(__SANITIZE_ADDRESS__)
+// #        define ADDRESS_SANITIZER 1
+// #    endif
+// #endif
 
-#if !defined(THREAD_SANITIZER)
-#    if defined(ch_has_feature)
-#        if ch_has_feature(thread_sanitizer)
-#            define THREAD_SANITIZER 1
-#        endif
-#    elif defined(__SANITIZE_THREAD__)
-#        define THREAD_SANITIZER 1
-#    endif
-#endif
+// #if !defined(THREAD_SANITIZER)
+// #    if defined(ch_has_feature)
+// #        if ch_has_feature(thread_sanitizer)
+// #            define THREAD_SANITIZER 1
+// #        endif
+// #    elif defined(__SANITIZE_THREAD__)
+// #        define THREAD_SANITIZER 1
+// #    endif
+// #endif
 
-#if !defined(MEMORY_SANITIZER)
-#    if defined(ch_has_feature)
-#        if ch_has_feature(memory_sanitizer)
-#            define MEMORY_SANITIZER 1
-#        endif
-#    elif defined(__MEMORY_SANITIZER__)
-#        define MEMORY_SANITIZER 1
-#    endif
-#endif
+// #if !defined(MEMORY_SANITIZER)
+// #    if defined(ch_has_feature)
+// #        if ch_has_feature(memory_sanitizer)
+// #            define MEMORY_SANITIZER 1
+// #        endif
+// #    elif defined(__MEMORY_SANITIZER__)
+// #        define MEMORY_SANITIZER 1
+// #    endif
+// #endif
 
-#if !defined(UNDEFINED_BEHAVIOR_SANITIZER)
-#    if defined(__has_feature)
-#        if __has_feature(undefined_behavior_sanitizer)
-#            define UNDEFINED_BEHAVIOR_SANITIZER 1
-#        endif
-#    elif defined(__UNDEFINED_BEHAVIOR_SANITIZER__)
-#        define UNDEFINED_BEHAVIOR_SANITIZER 1
-#    endif
-#endif
+// #if !defined(UNDEFINED_BEHAVIOR_SANITIZER)
+// #    if defined(__has_feature)
+// #        if __has_feature(undefined_behavior_sanitizer)
+// #            define UNDEFINED_BEHAVIOR_SANITIZER 1
+// #        endif
+// #    elif defined(__UNDEFINED_BEHAVIOR_SANITIZER__)
+// #        define UNDEFINED_BEHAVIOR_SANITIZER 1
+// #    endif
+// #endif
 
 #if defined(ADDRESS_SANITIZER)
 #    define BOOST_USE_ASAN 1


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

Fixes for s3 provider (already merged in stable-25-1-3)

* [YQ-4478 added provider name validation in kqp host (](https://github.com/ydb-platform/ydb/commit/4c59f7eacef7b8c120951dcfaefc476f848001e7)https://github.com/ydb-platform/ydb/pull/22141[)](https://github.com/ydb-platform/ydb/commit/4c59f7eacef7b8c120951dcfaefc476f848001e7)
* [YQ-4447 disabled thread pool in s3 by default (](https://github.com/ydb-platform/ydb/commit/fd6815515d355e74e52f0e120b4f5c04618a2f95)https://github.com/ydb-platform/ydb/pull/22160[)](https://github.com/ydb-platform/ydb/commit/fd6815515d355e74e52f0e120b4f5c04618a2f95)
* [YQ-4454 fixed clickhouse udf includes (](https://github.com/ydb-platform/ydb/commit/8f1967d12d5546b2e20eceef3e586841c6f67523)https://github.com/ydb-platform/ydb/pull/21698[)](https://github.com/ydb-platform/ydb/commit/8f1967d12d5546b2e20eceef3e586841c6f67523)

### Changelog category <!-- remove all except one -->

* Bugfix 

### Description for reviewers <!-- (optional) description for those who read this PR -->
