### PR TITLE
Add topic consumer autocreation

### DIFF
--- a/ydb/core/kafka_proxy/actors/kafka_create_topics_actor.cpp
+++ b/ydb/core/kafka_proxy/actors/kafka_create_topics_actor.cpp
@@ -116,6 +116,7 @@ public:
                 workingDir,
                 proposal.Record.GetDatabaseName()
         );
+        KAFKA_LOG_D("Topic creation finished. Name: " << name << ". ErrorCode: " << codes.YdbCode << "\n");
         if (codes.YdbCode != Ydb::StatusIds::SUCCESS) {
             return ReplyWithError(codes.YdbCode, codes.PQCode, error);
         }
@@ -268,6 +269,7 @@ void TKafkaCreateTopicsActor::Handle(const TEvKafka::TEvTopicModificationRespons
 };
 
 void TKafkaCreateTopicsActor::Reply(const TActorContext& ctx) {
+    KAFKA_LOG_D("Replying for topics to " << Context->ConnectionId << "\n");
     TCreateTopicsResponseData::TPtr response = std::make_shared<TCreateTopicsResponseData>();
     EKafkaErrors responseStatus = NONE_ERROR;
 

--- a/ydb/core/kafka_proxy/actors/kafka_create_topics_actor.cpp
+++ b/ydb/core/kafka_proxy/actors/kafka_create_topics_actor.cpp
@@ -116,7 +116,6 @@ public:
                 workingDir,
                 proposal.Record.GetDatabaseName()
         );
-        KAFKA_LOG_D("Topic creation finished. Name: " << name << ". ErrorCode: " << codes.YdbCode << "\n");
         if (codes.YdbCode != Ydb::StatusIds::SUCCESS) {
             return ReplyWithError(codes.YdbCode, codes.PQCode, error);
         }
@@ -269,7 +268,6 @@ void TKafkaCreateTopicsActor::Handle(const TEvKafka::TEvTopicModificationRespons
 };
 
 void TKafkaCreateTopicsActor::Reply(const TActorContext& ctx) {
-    KAFKA_LOG_D("Replying for topics to " << Context->ConnectionId << "\n");
     TCreateTopicsResponseData::TPtr response = std::make_shared<TCreateTopicsResponseData>();
     EKafkaErrors responseStatus = NONE_ERROR;
 

--- a/ydb/core/kafka_proxy/actors/kafka_metadata_actor.cpp
+++ b/ydb/core/kafka_proxy/actors/kafka_metadata_actor.cpp
@@ -297,7 +297,7 @@ void TKafkaMetadataActor::SendCreateTopicsRequest(const TString& topicName, ui32
     auto message = std::make_shared<NKafka::TCreateTopicsRequestData>();
     TCreateTopicsRequestData::TCreatableTopic topicToCreate;
     topicToCreate.Name = topicName;
-    topicToCreate.NumPartitions = Context->Config.GetDefaultNumOfPartitions();
+    topicToCreate.NumPartitions = Context->Config.GetTopicCreationDefaultPartitions();
     message->Topics.push_back(topicToCreate);
     TContext::TPtr ContextForTopicCreation;
     ContextForTopicCreation = std::make_shared<TContext>(TContext(Context->Config));

--- a/ydb/core/kafka_proxy/actors/kafka_metadata_actor.cpp
+++ b/ydb/core/kafka_proxy/actors/kafka_metadata_actor.cpp
@@ -260,7 +260,8 @@ void TKafkaMetadataActor::HandleLocationResponse(TEvLocationResponse::TPtr ev, c
             PendingTopicResponses.emplace(index, locationResponse);
         } else {
             if (!Context->Config.GetAutoCreateTopicsEnable() || TopicСreationAttempts.find(*topic.Name) != TopicСreationAttempts.end()) {
-                KAFKA_LOG_ERROR("Describe topic '" << topic.Name << "' location finishied with error: Code=" << locationResponse->Status << ", Issues=" << locationResponse->Issues.ToOneLineString());
+                KAFKA_LOG_ERROR("Describe topic '" << topic.Name << "' location finishied with error: Code="
+                    << locationResponse->Status << ", Issues=" << locationResponse->Issues.ToOneLineString());
                 AddTopicError(topic, ConvertErrorCode(locationResponse->Status));
             } else {
                 if (TopicСreationAttempts.find(*topic.Name) == TopicСreationAttempts.end()) {

--- a/ydb/core/kafka_proxy/actors/kafka_metadata_actor.cpp
+++ b/ydb/core/kafka_proxy/actors/kafka_metadata_actor.cpp
@@ -274,8 +274,9 @@ void TKafkaMetadataActor::HandleLocationResponse(TEvLocationResponse::TPtr ev, c
 }
 
 void TKafkaMetadataActor::Handle(const TEvKafka::TEvResponse::TPtr& ev, const TActorContext& ctx) {
+    // can be recieved only from TCreateTopicActor
     TActorId& creatorActorId = ev->Sender;
-    const TopicNameToIndex& topicNameToIndex = CreateTopicRequests[creatorActorId];
+    const TTopicNameToIndex& topicNameToIndex = CreateTopicRequests[creatorActorId];
     const TString& topicName = topicNameToIndex.TopicName;
     const ui32& topicIndex = topicNameToIndex.TopicIndex;
     InflyCreateTopics--;
@@ -283,8 +284,11 @@ void TKafkaMetadataActor::Handle(const TEvKafka::TEvResponse::TPtr& ev, const TA
     if (errorCode == EKafkaErrors::NONE_ERROR) {
         TActorId child = SendTopicRequest(topicName);
         TopicIndexes[child].push_back(topicIndex);
-    } else if (InflyCreateTopics == 0) {
-        RespondIfRequired(ctx);
+    } else {
+        Response->Topics[topicIndex].ErrorCode = errorCode;
+        if (InflyCreateTopics == 0) {
+            RespondIfRequired(ctx);
+        }
     }
 }
 
@@ -304,7 +308,7 @@ void TKafkaMetadataActor::SendCreateTopicsRequest(const TString& topicName, ui32
         1,
         TMessagePtr<NKafka::TCreateTopicsRequestData>({}, message)
     ));
-    CreateTopicRequests[actorId] = TopicNameToIndex{topicName, index};
+    CreateTopicRequests[actorId] = TTopicNameToIndex{topicName, index};
 }
 
 void TKafkaMetadataActor::AddBroker(ui64 nodeId, const TString& host, ui64 port) {

--- a/ydb/core/kafka_proxy/actors/kafka_metadata_actor.h
+++ b/ydb/core/kafka_proxy/actors/kafka_metadata_actor.h
@@ -65,6 +65,7 @@ private:
             hFunc(NKikimr::TEvDiscovery::TEvDiscoveryData, HandleDiscoveryData);
             hFunc(NKikimr::TEvDiscovery::TEvError, HandleDiscoveryError);
             hFunc(NKikimr::TEvPQ::TEvListAllTopicsResponse, HandleListTopics);
+            HFunc(TEvKafka::TEvTopicModificationResponse, Handle);
         }
     }
 
@@ -88,6 +89,8 @@ private:
     bool HaveError = false;
     bool FallbackToIcDiscovery = false;
     TMap<ui64, TSimpleSharedPtr<TEvLocationResponse>> PendingTopicResponses;
+
+    void Handle(const TEvKafka::TEvTopicModificationResponse::TPtr& ev, const TActorContext& ctx);
 
     THashMap<ui64, TNodeInfo> Nodes;
     THashMap<TString, TActorId> PartitionActors;

--- a/ydb/core/kafka_proxy/actors/kafka_metadata_actor.h
+++ b/ydb/core/kafka_proxy/actors/kafka_metadata_actor.h
@@ -65,7 +65,7 @@ private:
             hFunc(NKikimr::TEvDiscovery::TEvDiscoveryData, HandleDiscoveryData);
             hFunc(NKikimr::TEvDiscovery::TEvError, HandleDiscoveryError);
             hFunc(NKikimr::TEvPQ::TEvListAllTopicsResponse, HandleListTopics);
-            HFunc(TEvKafka::TEvTopicModificationResponse, Handle);
+            HFunc(TEvKafka::TEvResponse, Handle);
         }
     }
 
@@ -73,11 +73,13 @@ private:
 
 private:
     const TContext::TPtr Context;
+    TContext::TPtr ContextForTopicCreation;
     const ui64 CorrelationId;
     const TMessagePtr<TMetadataRequestData> Message;
     const bool WithProxy;
 
     ui64 PendingResponses = 0;
+    ui64 InflyCreateTopics = 0;
 
     TMetadataResponseData::TPtr Response;
     THashMap<TActorId, TVector<ui64>> TopicIndexes;
@@ -89,8 +91,10 @@ private:
     bool HaveError = false;
     bool FallbackToIcDiscovery = false;
     TMap<ui64, TSimpleSharedPtr<TEvLocationResponse>> PendingTopicResponses;
+    TSet<TString> TopicСreationAttempts;
+    TMap<TActorId, std::pair<TString, ui32>> CreateTopicRequests;
 
-    void Handle(const TEvKafka::TEvTopicModificationResponse::TPtr& ev, const TActorContext& ctx);
+    void Handle(const TEvKafka::TEvResponse::TPtr& ev, const TActorContext& ctx);
 
     THashMap<ui64, TNodeInfo> Nodes;
     THashMap<TString, TActorId> PartitionActors;

--- a/ydb/core/kafka_proxy/actors/kafka_metadata_actor.h
+++ b/ydb/core/kafka_proxy/actors/kafka_metadata_actor.h
@@ -12,7 +12,7 @@
 
 namespace NKafka {
 
-    struct TopicNameToIndex {
+    struct TTopicNameToIndex {
         TString TopicName;
         ui32 TopicIndex;
     };
@@ -97,7 +97,7 @@ private:
     bool FallbackToIcDiscovery = false;
     TMap<ui64, TSimpleSharedPtr<TEvLocationResponse>> PendingTopicResponses;
     TSet<TString> TopicСreationAttempts;
-    TMap<TActorId, TopicNameToIndex> CreateTopicRequests;
+    TMap<TActorId, TTopicNameToIndex> CreateTopicRequests;
 
     void Handle(const TEvKafka::TEvResponse::TPtr& ev, const TActorContext& ctx);
     void SendCreateTopicsRequest(const TString& topicName, ui32 index, const TActorContext& ctx);

--- a/ydb/core/kafka_proxy/actors/kafka_metadata_actor.h
+++ b/ydb/core/kafka_proxy/actors/kafka_metadata_actor.h
@@ -12,6 +12,11 @@
 
 namespace NKafka {
 
+    struct TopicNameToIndex {
+        TString TopicName;
+        ui32 TopicIndex;
+    };
+
 TActorId MakeKafkaDiscoveryCacheID();
 
 class TKafkaMetadataActor: public NActors::TActorBootstrapped<TKafkaMetadataActor> {
@@ -92,9 +97,10 @@ private:
     bool FallbackToIcDiscovery = false;
     TMap<ui64, TSimpleSharedPtr<TEvLocationResponse>> PendingTopicResponses;
     TSet<TString> TopicСreationAttempts;
-    TMap<TActorId, std::pair<TString, ui32>> CreateTopicRequests;
+    TMap<TActorId, TopicNameToIndex> CreateTopicRequests;
 
     void Handle(const TEvKafka::TEvResponse::TPtr& ev, const TActorContext& ctx);
+    void SendCreateTopicsRequest(const TString& topicName, ui32 index, const TActorContext& ctx);
 
     THashMap<ui64, TNodeInfo> Nodes;
     THashMap<TString, TActorId> PartitionActors;

--- a/ydb/core/kafka_proxy/actors/kafka_offset_fetch_actor.cpp
+++ b/ydb/core/kafka_proxy/actors/kafka_offset_fetch_actor.cpp
@@ -439,7 +439,6 @@ void TKafkaOffsetFetchActor::CreateConsumerGroupIfNecessary(const TString& topic
                                     const TString& originalTopicName,
                                     const TString& groupId,
                                     const std::vector<TOffsetFetchResponsePartitions>& topicPartitions) {
-    // consumer is not added to the topic case
     TopicGroupIdAndPath consumerTopicRequest = TopicGroupIdAndPath{groupId, topicPath};
     if (ConsumerTopicAlterRequestAttempts.find(consumerTopicRequest) == ConsumerTopicAlterRequestAttempts.end()) {
         ConsumerTopicAlterRequestAttempts.insert(consumerTopicRequest);

--- a/ydb/core/kafka_proxy/actors/kafka_offset_fetch_actor.cpp
+++ b/ydb/core/kafka_proxy/actors/kafka_offset_fetch_actor.cpp
@@ -273,13 +273,16 @@ void TKafkaOffsetFetchActor::Handle(TEvKafka::TEvCommitedOffsetsResponse::TPtr& 
                             alteredTopicInfo.Entities.Consumers->insert(*consumerGroup.GroupId);
                             alteredTopicInfo.Entities.Partitions->insert(topicPartition.PartitionIndex);
                             AlterTopicInf[AlterTopicCookie] = alteredTopicInfo;
-                            auto callback = [replyTo = SelfId(), cookie = AlterTopicCookie, path = groupTopic.Name, this](Ydb::StatusIds::StatusCode statusCode, const google::protobuf::Message*) {
+                            auto callback = [replyTo = SelfId(), cookie = AlterTopicCookie, path = groupTopic.Name, this]
+                                (Ydb::StatusIds::StatusCode statusCode, const google::protobuf::Message*) {
                                 NYdb::NIssue::TIssues issues;
                                 NYdb::TStatus status(static_cast<NYdb::EStatus>(statusCode), std::move(issues));
                                 Send(replyTo, new NKikimr::NReplication::TEvYdbProxy::TEvAlterTopicResponse(std::move(status)), 0, cookie);
                             };
                             NKikimr::NReplication::TLocalProxyActor* actor = new NKikimr::NReplication::TLocalProxyActor(DatabasePath);
-                            NKikimr::NGRpcService::DoAlterTopicRequest(std::make_unique<NKikimr::NReplication::TLocalProxyRequest>(*groupTopic.Name, DatabasePath, std::move(request), callback), *actor);
+                            NKikimr::NGRpcService::DoAlterTopicRequest(std::make_unique<NKikimr::NReplication::TLocalProxyRequest>(
+                                *groupTopic.Name, DatabasePath, std::move(request), callback),
+                                *actor);
                             break;
                         } else if (topicPartition.ErrorCode == EKafkaErrors::UNKNOWN_TOPIC_OR_PARTITION) {
                             // topic does not exist case

--- a/ydb/core/kafka_proxy/actors/kafka_offset_fetch_actor.cpp
+++ b/ydb/core/kafka_proxy/actors/kafka_offset_fetch_actor.cpp
@@ -234,6 +234,7 @@ void TKafkaOffsetFetchActor::Bootstrap(const NActors::TActorContext& ctx) {
 }
 
 void TKafkaOffsetFetchActor::Handle(TEvKafka::TEvCommitedOffsetsResponse::TPtr& ev, const TActorContext& ctx) {
+    KAFKA_LOG_D("Entered Handle:TEvCommitedOffsetsResponse. InflyTopics=" << InflyTopics << "\n");
     InflyTopics--;
 
     auto eventPtr = ev->Release();
@@ -241,27 +242,34 @@ void TKafkaOffsetFetchActor::Handle(TEvKafka::TEvCommitedOffsetsResponse::TPtr& 
 
     if (InflyTopics == 0) {
         auto response = GetOffsetFetchResponse();
-        KAFKA_LOG_D("Sending response to user " << GetUsernameOrAnonymous(Context));
+        KAFKA_LOG_D("Checking correctness of response for user " << GetUsernameOrAnonymous(Context));
         if (Context->Config.GetAutoCreateTopicsEnable()) {
             for (const auto& consumerGroup : response->Groups) {
                 for (const auto& groupTopic : consumerGroup.Topics) {
                     for (const auto& topicPartition : groupTopic.Partitions) {
                         if (topicPartition.ErrorCode == EKafkaErrors::RESOURCE_NOT_FOUND) {
                             // consumer is not added to the topic case
+                            if (topicPartition.PartitionIndex != 0 && TopicCreateRequestAttempts.find(*groupTopic.Name) != TopicCreateRequestAttempts.end()) {
+                                break;
+                            }
                             InflyTopics++;
                             std::pair<TString, TString> consumerTopicRequest = {*consumerGroup.GroupId, *groupTopic.Name};
-                            if (ConsumerTopicRequestAttempts.find(consumerTopicRequest) == ConsumerTopicRequestAttempts.end()) {
-                                ConsumerTopicRequestAttempts.insert(consumerTopicRequest);
+                            if (ConsumerTopicAlterRequestAttempts.find(consumerTopicRequest) == ConsumerTopicAlterRequestAttempts.end()) {
+                                ConsumerTopicAlterRequestAttempts.insert(consumerTopicRequest);
                             } else {
                                 break;
                             }
+                            KAFKA_LOG_D("Entered ConsumerNotExist case for topic " << *groupTopic.Name << " and consumer " <<  *consumerGroup.GroupId << ". InflyTopics: " << InflyTopics << ". Sending request from: " << ContextForTopicCreation->ConnectionId << "\n");
 
                             auto topicSettings = NYdb::NTopic::TAlterTopicSettings();
                             topicSettings.BeginAddConsumer(*consumerGroup.GroupId).EndAddConsumer();
 
                             auto request = std::make_unique<Ydb::Topic::AlterTopicRequest>();
-                            TString p = TStringBuilder() << "/" << DatabasePath << groupTopic.Name;
-                            request.get()->set_path(TStringBuilder() << DatabasePath << "/" << groupTopic.Name);
+                            // TString p = TStringBuilder() << "/" << DatabasePath << groupTopic.Name;
+                            // TString p1 = TStringBuilder() << DatabasePath << "/" << groupTopic.Name;
+                            // TString p2 = DatabasePath + "/" + *groupTopic.Name;
+                            // TString p3 = *groupTopic.Name;
+                            request.get()->set_path(DatabasePath + "/" + *groupTopic.Name);
                             for (auto& c : topicSettings.AddConsumers_) {
                                 auto* consumer = request.get()->add_add_consumers();
                                 consumer->set_name(c.ConsumerName_);
@@ -279,22 +287,27 @@ void TKafkaOffsetFetchActor::Handle(TEvKafka::TEvCommitedOffsetsResponse::TPtr& 
                                 NYdb::TStatus status(static_cast<NYdb::EStatus>(statusCode), std::move(issues));
                                 Send(replyTo, new NKikimr::NReplication::TEvYdbProxy::TEvAlterTopicResponse(std::move(status)), 0, cookie);
                             };
-                            NKikimr::NReplication::TLocalProxyActor* actor = new NKikimr::NReplication::TLocalProxyActor(DatabasePath);
+                            std::shared_ptr<NKikimr::NReplication::TLocalProxyActor> actor(new NKikimr::NReplication::TLocalProxyActor(DatabasePath));
                             NKikimr::NGRpcService::DoAlterTopicRequest(std::make_unique<NKikimr::NReplication::TLocalProxyRequest>(
                                 *groupTopic.Name, DatabasePath, std::move(request), callback),
                                 *actor);
                             break;
                         } else if (topicPartition.ErrorCode == EKafkaErrors::UNKNOWN_TOPIC_OR_PARTITION) {
                             // topic does not exist case
+                            if (TopicCreateRequestAttempts.find(*groupTopic.Name) != TopicCreateRequestAttempts.end()) {
+                                break;
+                            }
+                            TopicCreateRequestAttempts.insert(*groupTopic.Name);
                             InflyTopics++;
                             auto message = std::make_shared<NKafka::TCreateTopicsRequestData>();
                             TCreateTopicsRequestData::TCreatableTopic topicToCreate;
                             topicToCreate.Name = *groupTopic.Name;
+                            topicToCreate.NumPartitions = 1;
                             message->Topics.push_back(topicToCreate);
                             TActorId actorId = ctx.Register(new TKafkaCreateTopicsActor(ContextForTopicCreation,
                                 1,
                                 TMessagePtr<NKafka::TCreateTopicsRequestData>({}, message)));
-
+                            KAFKA_LOG_D("Entered TopicNotExist case for topic " << *groupTopic.Name << ". InflyTopics: " << InflyTopics << ". Sending request from: " << ContextForTopicCreation->ConnectionId << ". CreatorActorId: " << actorId << "\n");
                             ModifiedTopicInfo createdTopicInfo;
                             createdTopicInfo.TopicName = *groupTopic.Name;
                             createdTopicInfo.Entities.Consumers->insert(*consumerGroup.GroupId);
@@ -306,6 +319,7 @@ void TKafkaOffsetFetchActor::Handle(TEvKafka::TEvCommitedOffsetsResponse::TPtr& 
             }
         }
         if (InflyTopics == 0) {
+            KAFKA_LOG_D("Sending OffsetFetchResponse\n");
             Send(Context->ConnectionId, new TEvKafka::TEvResponse(CorrelationId, response, static_cast<EKafkaErrors>(response->ErrorCode)));
             Die(ctx);
         }
@@ -313,8 +327,14 @@ void TKafkaOffsetFetchActor::Handle(TEvKafka::TEvCommitedOffsetsResponse::TPtr& 
 }
 
 void TKafkaOffsetFetchActor::Handle(const TEvKafka::TEvResponse::TPtr& ev, const TActorContext& ctx) {
-    KAFKA_LOG_D("Entered TEvResponse from CreateTopicsActor");
-    auto& errorCode = ev->Release()->ErrorCode;
+    TActorId& creatorActorId = ev->Sender;
+    KAFKA_LOG_D("Entered TEvResponse from CreateTopicsActor1. CreatorActorId: " << creatorActorId << "\n");
+    const ModifiedTopicInfo& createdTopicInformation = CreateTopicInf[creatorActorId];
+    KAFKA_LOG_D("Entered TEvResponse from CreateTopicsActor2.\n");
+    // auto eventPtr = ev->Release();
+    KAFKA_LOG_D("Entered TEvResponse from CreateTopicsActor3 for topic " << createdTopicInformation.TopicName << "\n");
+    auto errorCode = ev->Release()->ErrorCode;
+    KAFKA_LOG_D("Entered TEvResponse from CreateTopicsActor3 for topic " << createdTopicInformation.TopicName << ". ErrorCode: " << errorCode << "\n");
     if (errorCode != EKafkaErrors::NONE_ERROR) {
         InflyTopics--;
         if (InflyTopics == 0) {
@@ -324,8 +344,6 @@ void TKafkaOffsetFetchActor::Handle(const TEvKafka::TEvResponse::TPtr& ev, const
         }
         return;
     }
-    TActorId& creatorActorId = ev->Sender;
-    const ModifiedTopicInfo& createdTopicInformation = CreateTopicInf[creatorActorId];
 
     NKikimr::NGRpcProxy::V1::TLocalRequestBase locationRequest{
         NormalizePath(Context->DatabasePath, createdTopicInformation.TopicName),
@@ -343,8 +361,8 @@ void TKafkaOffsetFetchActor::Handle(const TEvKafka::TEvResponse::TPtr& ev, const
 }
 
 void TKafkaOffsetFetchActor::Handle(NKikimr::NReplication::TEvYdbProxy::TEvAlterTopicResponse::TPtr& ev, const TActorContext& ctx) {
-    KAFKA_LOG_D("Handling TEvAlterTopicResponse");
     NYdb::TStatus& result = ev->Get()->Result;
+    KAFKA_LOG_D("Handling TEvAlterTopicResponse. Status: " << result.GetStatus() << "\n");
     if (result.GetStatus() != NYdb::EStatus::SUCCESS) {
         InflyTopics--;
         if (InflyTopics == 0) {

--- a/ydb/core/kafka_proxy/actors/kafka_offset_fetch_actor.cpp
+++ b/ydb/core/kafka_proxy/actors/kafka_offset_fetch_actor.cpp
@@ -255,7 +255,7 @@ void TKafkaOffsetFetchActor::Handle(TEvKafka::TEvCommitedOffsetsResponse::TPtr& 
                                                                         topicResponse.Partitions);
                 break;
             } else if (topicPartition.ErrorCode == EKafkaErrors::UNKNOWN_TOPIC_OR_PARTITION) {
-                // topic does not exist case
+                // topic or partition does not exist case
                 bool continueChecking = CreateTopicIfNecessary(topicName, *topicGroupRequest.TopicRequest.Name, topicGroupRequest.GroupId, ctx);
                 if (!continueChecking) {
                     break;
@@ -273,7 +273,7 @@ void TKafkaOffsetFetchActor::Handle(TEvKafka::TEvCommitedOffsetsResponse::TPtr& 
 void TKafkaOffsetFetchActor::Handle(const TEvKafka::TEvResponse::TPtr& ev, const TActorContext& ctx) {
     // TKafkaOffsetFetchActor can receive TEvResponse only from TKafkaCreateTopicsActor actor
     TActorId& creatorActorId = ev->Sender;
-    const ModifiedTopicInfo& createdTopicInformation = CreateTopicInfo[creatorActorId];
+    const TModifiedTopicInfo& createdTopicInformation = CreateTopicInfo[creatorActorId];
     auto errorCode = ev->Release()->ErrorCode;
     DependantActors.erase(creatorActorId);
     if (errorCode != EKafkaErrors::NONE_ERROR) {
@@ -314,7 +314,7 @@ void TKafkaOffsetFetchActor::Handle(NKikimr::NReplication::TEvYdbProxy::TEvAlter
         return;
     }
 
-    const ModifiedTopicInfo& alteredTopicInfo = AlterTopicInfo[ev->Cookie];
+    const TModifiedTopicInfo& alteredTopicInfo = AlterTopicInfo[ev->Cookie];
     NKikimr::NGRpcProxy::V1::TLocalRequestBase locationRequest{
         NormalizePath(Context->DatabasePath, alteredTopicInfo.TopicName),
         Context->DatabasePath,
@@ -394,10 +394,10 @@ void NKafka::TKafkaOffsetFetchActor::Handle(NKqp::TEvKqp::TEvQueryResponse::TPtr
 void TKafkaOffsetFetchActor::ExtractPartitions(const TString& group, const NKafka::TOffsetFetchRequestData::TOffsetFetchRequestGroup::TOffsetFetchRequestTopics& topic) {
     TString topicName = topic.Name.value();
     if (!TopicToEntities.contains(topicName)) {
-        TopicEntities newEntities;
+        TTopicEntities newEntities;
         TopicToEntities[topicName] = newEntities;
     }
-    TopicEntities& entities = TopicToEntities[topicName];
+    TTopicEntities& entities = TopicToEntities[topicName];
     entities.Consumers->insert(group);
     for (auto partition: topic.PartitionIndexes) {
         entities.Partitions->insert(partition);
@@ -439,7 +439,7 @@ void TKafkaOffsetFetchActor::CreateConsumerGroupIfNecessary(const TString& topic
                                     const TString& originalTopicName,
                                     const TString& groupId,
                                     const std::vector<TOffsetFetchResponsePartitions>& topicPartitions) {
-    TopicGroupIdAndPath consumerTopicRequest = TopicGroupIdAndPath{groupId, topicPath};
+    TTopicGroupIdAndPath consumerTopicRequest = TTopicGroupIdAndPath{groupId, topicPath};
     if (ConsumerTopicAlterRequestAttempts.find(consumerTopicRequest) == ConsumerTopicAlterRequestAttempts.end()) {
         ConsumerTopicAlterRequestAttempts.insert(consumerTopicRequest);
     } else {
@@ -457,7 +457,7 @@ void TKafkaOffsetFetchActor::CreateConsumerGroupIfNecessary(const TString& topic
         consumer->set_name(c.ConsumerName_);
     }
     AlterTopicCookie++;
-    ModifiedTopicInfo alteredTopicInfo;
+    TModifiedTopicInfo alteredTopicInfo;
     alteredTopicInfo.TopicName = originalTopicName;
     alteredTopicInfo.Entities.Consumers->insert(groupId);
     for (const auto& topicPartition : topicPartitions) {
@@ -506,7 +506,7 @@ bool TKafkaOffsetFetchActor::CreateTopicIfNecessary(const TString& topicName,
         1,
         TMessagePtr<NKafka::TCreateTopicsRequestData>({}, message)));
     DependantActors.insert(actorId);
-    ModifiedTopicInfo createdTopicInfo;
+    TModifiedTopicInfo createdTopicInfo;
     createdTopicInfo.TopicName = originalTopicName;
     createdTopicInfo.Entities.Consumers->insert(groupId);
     for (int partitionIndex = 0; partitionIndex < topicToCreate.NumPartitions; partitionIndex++) {
@@ -601,7 +601,7 @@ NYdb::TParamsBuilder TKafkaOffsetFetchActor::BuildFetchAssignmentsParams(const s
 void TKafkaOffsetFetchActor::FillMapWithGroupRequests() {
     for (const auto& groupRequest : Message->Groups) {
         for (auto& topicRequest : groupRequest.Topics) {
-            GroupRequests[*topicRequest.Name] = TopicGroupRequest{topicRequest, *groupRequest.GroupId};
+            GroupRequests[*topicRequest.Name] = TTopicGroupRequest{topicRequest, *groupRequest.GroupId};
         }
     }
 }

--- a/ydb/core/kafka_proxy/actors/kafka_offset_fetch_actor.cpp
+++ b/ydb/core/kafka_proxy/actors/kafka_offset_fetch_actor.cpp
@@ -493,7 +493,7 @@ bool TKafkaOffsetFetchActor::CreateTopicIfNecessary(const TString& topicName,
     auto message = std::make_shared<NKafka::TCreateTopicsRequestData>();
     TCreateTopicsRequestData::TCreatableTopic topicToCreate;
     topicToCreate.Name = topicName;
-    topicToCreate.NumPartitions = Context->Config.GetDefaultNumOfPartitions();
+    topicToCreate.NumPartitions = Context->Config.GetTopicCreationDefaultPartitions();
     message->Topics.push_back(topicToCreate);
 
     TContext::TPtr ContextForTopicCreation;

--- a/ydb/core/kafka_proxy/actors/kafka_offset_fetch_actor.cpp
+++ b/ydb/core/kafka_proxy/actors/kafka_offset_fetch_actor.cpp
@@ -260,7 +260,7 @@ void TKafkaOffsetFetchActor::Handle(TEvKafka::TEvCommitedOffsetsResponse::TPtr& 
                                 break;
                             }
                             InflyTopics++;
-                            
+
                             auto topicSettings = NYdb::NTopic::TAlterTopicSettings();
                             topicSettings.BeginAddConsumer(*consumerGroup.GroupId).EndAddConsumer();
                             auto request = std::make_unique<Ydb::Topic::AlterTopicRequest>();
@@ -279,10 +279,15 @@ void TKafkaOffsetFetchActor::Handle(TEvKafka::TEvCommitedOffsetsResponse::TPtr& 
                                 (Ydb::StatusIds::StatusCode statusCode, const google::protobuf::Message*) {
                                 NYdb::NIssue::TIssues issues;
                                 NYdb::TStatus status(static_cast<NYdb::EStatus>(statusCode), std::move(issues));
-                                Send(replyTo, new NKikimr::NReplication::TEvYdbProxy::TEvAlterTopicResponse(std::move(status)), 0, cookie);
+                                Send(replyTo,
+                                    new NKikimr::NReplication::TEvYdbProxy::TEvAlterTopicResponse(std::move(status)),
+                                    0,
+                                    cookie);
                             };
-                            std::shared_ptr<NKikimr::NReplication::TLocalProxyActor> actor(new NKikimr::NReplication::TLocalProxyActor(DatabasePath));
-                            NKikimr::NGRpcService::DoAlterTopicRequest(std::make_unique<NKikimr::NReplication::TLocalProxyRequest>(
+                            std::shared_ptr<NKikimr::NReplication::TLocalProxyActor> actor(
+                                new NKikimr::NReplication::TLocalProxyActor(DatabasePath));
+                            NKikimr::NGRpcService::DoAlterTopicRequest(
+                                std::make_unique<NKikimr::NReplication::TLocalProxyRequest>(
                                 topicName, DatabasePath, std::move(request), callback),
                                 *actor);
                             break;

--- a/ydb/core/kafka_proxy/actors/kafka_offset_fetch_actor.cpp
+++ b/ydb/core/kafka_proxy/actors/kafka_offset_fetch_actor.cpp
@@ -213,6 +213,7 @@ void TKafkaOffsetFetchActor::Bootstrap(const NActors::TActorContext& ctx) {
         Kqp->SendCreateSessionRequest(ctx);
         KAFKA_LOG_D("Creating KQP Session");
     } else {
+        FillMapWithGroupRequests();
         for (const auto& topicToEntities : TopicToEntities) {
             NKikimr::NGRpcProxy::V1::TLocalRequestBase locationRequest{
                 NormalizePath(Context->DatabasePath, topicToEntities.first),
@@ -237,99 +238,44 @@ void TKafkaOffsetFetchActor::Handle(TEvKafka::TEvCommitedOffsetsResponse::TPtr& 
     InflyTopics--;
 
     auto eventPtr = ev->Release();
-    TopicsToResponses[eventPtr->TopicName] = eventPtr;
-
-    if (InflyTopics == 0) {
-        auto response = GetOffsetFetchResponse();
-        if (Context->Config.GetAutoCreateTopicsEnable()) {
-            for (const auto& consumerGroup : response->Groups) {
-                for (const auto& groupTopic : consumerGroup.Topics) {
-                    for (const auto& topicPartition : groupTopic.Partitions) {
-                        TString topicName = GetTopicNameWithoutDb(DatabasePath, *groupTopic.Name);
-                        TString topicPath = NormalizePath(DatabasePath, *groupTopic.Name);
-                        if (topicPartition.ErrorCode == EKafkaErrors::RESOURCE_NOT_FOUND) {
-                            // consumer is not added to the topic case
-                            if (topicPartition.PartitionIndex != 0 &&
-                                TopicCreateRequestAttempts.find(topicName) != TopicCreateRequestAttempts.end()) {
-                                break;
-                            }
-                            std::pair<TString, TString> consumerTopicRequest = {*consumerGroup.GroupId, topicPath};
-                            if (ConsumerTopicAlterRequestAttempts.find(consumerTopicRequest) == ConsumerTopicAlterRequestAttempts.end()) {
-                                ConsumerTopicAlterRequestAttempts.insert(consumerTopicRequest);
-                            } else {
-                                break;
-                            }
-                            InflyTopics++;
-
-                            auto topicSettings = NYdb::NTopic::TAlterTopicSettings();
-                            topicSettings.BeginAddConsumer(*consumerGroup.GroupId).EndAddConsumer();
-                            auto request = std::make_unique<Ydb::Topic::AlterTopicRequest>();
-                            request.get()->set_path(topicPath);
-                            for (auto& c : topicSettings.AddConsumers_) {
-                                auto* consumer = request.get()->add_add_consumers();
-                                consumer->set_name(c.ConsumerName_);
-                            }
-                            AlterTopicCookie++;
-                            ModifiedTopicInfo alteredTopicInfo;
-                            alteredTopicInfo.TopicName = *groupTopic.Name;
-                            alteredTopicInfo.Entities.Consumers->insert(*consumerGroup.GroupId);
-                            alteredTopicInfo.Entities.Partitions->insert(topicPartition.PartitionIndex);
-                            AlterTopicInf[AlterTopicCookie] = alteredTopicInfo;
-                            auto callback = [replyTo = SelfId(), cookie = AlterTopicCookie, path = topicName, this]
-                                (Ydb::StatusIds::StatusCode statusCode, const google::protobuf::Message*) {
-                                NYdb::NIssue::TIssues issues;
-                                NYdb::TStatus status(static_cast<NYdb::EStatus>(statusCode), std::move(issues));
-                                Send(replyTo,
-                                    new NKikimr::NReplication::TEvYdbProxy::TEvAlterTopicResponse(std::move(status)),
-                                    0,
-                                    cookie);
-                            };
-                            std::shared_ptr<NKikimr::NReplication::TLocalProxyActor> actor(
-                                new NKikimr::NReplication::TLocalProxyActor(DatabasePath));
-                            NKikimr::NGRpcService::DoAlterTopicRequest(
-                                std::make_unique<NKikimr::NReplication::TLocalProxyRequest>(
-                                topicName, DatabasePath, std::move(request), callback),
-                                *actor);
-                            break;
-                        } else if (topicPartition.ErrorCode == EKafkaErrors::UNKNOWN_TOPIC_OR_PARTITION) {
-                            // topic does not exist case
-                            if (TopicCreateRequestAttempts.find(topicName) != TopicCreateRequestAttempts.end()) {
-                                break;
-                            }
-                            TopicCreateRequestAttempts.insert(topicName);
-                            InflyTopics++;
-
-                            auto message = std::make_shared<NKafka::TCreateTopicsRequestData>();
-                            TCreateTopicsRequestData::TCreatableTopic topicToCreate;
-                            topicToCreate.Name = topicName;
-                            topicToCreate.NumPartitions = 1;
-                            message->Topics.push_back(topicToCreate);
-                            TActorId actorId = ctx.Register(new TKafkaCreateTopicsActor(ContextForTopicCreation,
-                                1,
-                                TMessagePtr<NKafka::TCreateTopicsRequestData>({}, message)));
-
-                            ModifiedTopicInfo createdTopicInfo;
-                            createdTopicInfo.TopicName = *groupTopic.Name;
-                            createdTopicInfo.Entities.Consumers->insert(*consumerGroup.GroupId);
-                            createdTopicInfo.Entities.Partitions->insert(0); // default number of partitions is 1
-                            CreateTopicInf[actorId] = createdTopicInfo;
-                        }
-                    }
+    TString topicName = eventPtr->TopicName;
+    TopicsToResponses[topicName] = eventPtr;
+    if (Context->Config.GetAutoCreateTopicsEnable()) {
+        auto& topicGroupRequest = GroupRequests[topicName];
+        auto topicResponse = GetOffsetResponseForTopic(topicGroupRequest.TopicRequest, topicGroupRequest.GroupId);
+        for (const auto& topicPartition : topicResponse.Partitions) {
+            TString topicName = GetTopicNameWithoutDb(DatabasePath, *topicGroupRequest.TopicRequest.Name);
+            TString topicPath = NormalizePath(DatabasePath, topicName);
+            if (topicPartition.ErrorCode == EKafkaErrors::RESOURCE_NOT_FOUND) {
+                // consumer is not assigned to the topic case
+                TKafkaOffsetFetchActor::CreateConsumerGroupIfNecessary(topicName,
+                                                                        topicPath,
+                                                                        topicName,
+                                                                        topicGroupRequest.GroupId,
+                                                                        topicResponse.Partitions);
+                break;
+            } else if (topicPartition.ErrorCode == EKafkaErrors::UNKNOWN_TOPIC_OR_PARTITION) {
+                // topic does not exist case
+                bool continueChecking = CreateTopicIfNecessary(topicName, *topicGroupRequest.TopicRequest.Name, topicGroupRequest.GroupId, ctx);
+                if (!continueChecking) {
+                    break;
                 }
             }
         }
-        if (InflyTopics == 0) {
-            Send(Context->ConnectionId, new TEvKafka::TEvResponse(CorrelationId, response, static_cast<EKafkaErrors>(response->ErrorCode)));
-            Die(ctx);
-        }
+    }
+    if (InflyTopics == 0) {
+        auto response = GetOffsetFetchResponse();
+        Send(Context->ConnectionId, new TEvKafka::TEvResponse(CorrelationId, response, static_cast<EKafkaErrors>(response->ErrorCode)));
+        Die(ctx);
     }
 }
 
 void TKafkaOffsetFetchActor::Handle(const TEvKafka::TEvResponse::TPtr& ev, const TActorContext& ctx) {
+    // TKafkaOffsetFetchActor can receive TEvResponse only from TKafkaCreateTopicsActor actor
     TActorId& creatorActorId = ev->Sender;
-    KAFKA_LOG_D("Entered TEvResponse from CreateTopicsActor1. CreatorActorId: " << creatorActorId << "\n");
-    const ModifiedTopicInfo& createdTopicInformation = CreateTopicInf[creatorActorId];
+    const ModifiedTopicInfo& createdTopicInformation = CreateTopicInfo[creatorActorId];
     auto errorCode = ev->Release()->ErrorCode;
+    DependantActors.erase(creatorActorId);
     if (errorCode != EKafkaErrors::NONE_ERROR) {
         InflyTopics--;
         if (InflyTopics == 0) {
@@ -368,7 +314,7 @@ void TKafkaOffsetFetchActor::Handle(NKikimr::NReplication::TEvYdbProxy::TEvAlter
         return;
     }
 
-    const ModifiedTopicInfo& alteredTopicInfo = AlterTopicInf[ev->Cookie];
+    const ModifiedTopicInfo& alteredTopicInfo = AlterTopicInfo[ev->Cookie];
     NKikimr::NGRpcProxy::V1::TLocalRequestBase locationRequest{
         NormalizePath(Context->DatabasePath, alteredTopicInfo.TopicName),
         Context->DatabasePath,
@@ -425,6 +371,8 @@ void NKafka::TKafkaOffsetFetchActor::Handle(NKqp::TEvKqp::TEvQueryResponse::TPtr
         }
     }
 
+    FillMapWithGroupRequests();
+
     for (const auto& topicToEntities : TopicToEntities) {
         NKikimr::NGRpcProxy::V1::TLocalRequestBase locationRequest{
             NormalizePath(Context->DatabasePath, topicToEntities.first),
@@ -456,8 +404,9 @@ void TKafkaOffsetFetchActor::ExtractPartitions(const TString& group, const NKafk
     }
 };
 
-void TKafkaOffsetFetchActor::ParseGroupsAssignments(NKqp::TEvKqp::TEvQueryResponse::TPtr ev, std::vector<std::pair<std::optional<TString>, TConsumerProtocolAssignment>>& assignments)
-{
+void TKafkaOffsetFetchActor::ParseGroupsAssignments(NKqp::TEvKqp::TEvQueryResponse::TPtr ev,
+                                                    std::vector<std::pair<std::optional<TString>,
+                                                    TConsumerProtocolAssignment>>& assignments) {
     if (!ev) {
         return;
     }
@@ -472,7 +421,6 @@ void TKafkaOffsetFetchActor::ParseGroupsAssignments(NKqp::TEvKqp::TEvQueryRespon
     while (parser.TryNextRow()) {
         TString assignmentStr = parser.ColumnParser("assignment").GetOptionalString().value_or("");
         TString groupId = parser.ColumnParser("consumer_group").GetUtf8().c_str();
-        KAFKA_LOG_D("assignmentStr: " << assignmentStr);
         if (!assignmentStr.empty()) {
             TKafkaBytes assignment = assignmentStr;
             TKafkaVersion version = *(TKafkaVersion*)(assignment.value().data() + sizeof(TKafkaVersion));
@@ -486,45 +434,97 @@ void TKafkaOffsetFetchActor::ParseGroupsAssignments(NKqp::TEvKqp::TEvQueryRespon
     }
 }
 
+void TKafkaOffsetFetchActor::CreateConsumerGroupIfNecessary(const TString& topicName,
+                                    const TString& topicPath,
+                                    const TString& originalTopicName,
+                                    const TString& groupId,
+                                    const std::vector<TOffsetFetchResponsePartitions>& topicPartitions) {
+    // consumer is not added to the topic case
+    TopicGroupIdAndPath consumerTopicRequest = TopicGroupIdAndPath{groupId, topicPath};
+    if (ConsumerTopicAlterRequestAttempts.find(consumerTopicRequest) == ConsumerTopicAlterRequestAttempts.end()) {
+        ConsumerTopicAlterRequestAttempts.insert(consumerTopicRequest);
+    } else {
+        // it is enough to send a consumer addition request only once for a particular topic
+        return;
+    }
+    InflyTopics++;
+
+    auto topicSettings = NYdb::NTopic::TAlterTopicSettings();
+    topicSettings.BeginAddConsumer(groupId).EndAddConsumer();
+    auto request = std::make_unique<Ydb::Topic::AlterTopicRequest>();
+    request.get()->set_path(topicPath);
+    for (auto& c : topicSettings.AddConsumers_) {
+        auto* consumer = request.get()->add_add_consumers();
+        consumer->set_name(c.ConsumerName_);
+    }
+    AlterTopicCookie++;
+    ModifiedTopicInfo alteredTopicInfo;
+    alteredTopicInfo.TopicName = originalTopicName;
+    alteredTopicInfo.Entities.Consumers->insert(groupId);
+    for (const auto& topicPartition : topicPartitions) {
+        alteredTopicInfo.Entities.Partitions->insert(topicPartition.PartitionIndex);
+    }
+    AlterTopicInfo[AlterTopicCookie] = alteredTopicInfo;
+    auto callback = [replyTo = SelfId(), cookie = AlterTopicCookie, path = topicName, this]
+        (Ydb::StatusIds::StatusCode statusCode, const google::protobuf::Message*) {
+        NYdb::NIssue::TIssues issues;
+        NYdb::TStatus status(static_cast<NYdb::EStatus>(statusCode), std::move(issues));
+        Send(replyTo,
+            new NKikimr::NReplication::TEvYdbProxy::TEvAlterTopicResponse(std::move(status)),
+            0,
+            cookie);
+    };
+    NKikimr::NGRpcService::DoAlterTopicRequest(
+        std::make_unique<NKikimr::NReplication::TLocalProxyRequest>(
+        topicName, DatabasePath, std::move(request), callback),
+        NKikimr::NReplication::TLocalProxyActor(DatabasePath));
+
+}
+
+bool TKafkaOffsetFetchActor::CreateTopicIfNecessary(const TString& topicName,
+                                                    const TString& originalTopicName,
+                                                    const TString& groupId,
+                                                    const TActorContext& ctx) {
+    if (TopicCreateRequestAttempts.find(topicName) != TopicCreateRequestAttempts.end()) {
+        return false;
+    }
+    TopicCreateRequestAttempts.insert(topicName);
+    InflyTopics++;
+
+    auto message = std::make_shared<NKafka::TCreateTopicsRequestData>();
+    TCreateTopicsRequestData::TCreatableTopic topicToCreate;
+    topicToCreate.Name = topicName;
+    topicToCreate.NumPartitions = Context->Config.GetDefaultNumOfPartitions();
+    message->Topics.push_back(topicToCreate);
+
+    TContext::TPtr ContextForTopicCreation;
+    ContextForTopicCreation = std::make_shared<TContext>(TContext(Context->Config));
+    ContextForTopicCreation->ConnectionId = ctx.SelfID;
+    ContextForTopicCreation->UserToken = Context->UserToken;
+    ContextForTopicCreation->DatabasePath = Context->DatabasePath;
+
+    TActorId actorId = ctx.Register(new TKafkaCreateTopicsActor(ContextForTopicCreation,
+        1,
+        TMessagePtr<NKafka::TCreateTopicsRequestData>({}, message)));
+    DependantActors.insert(actorId);
+    ModifiedTopicInfo createdTopicInfo;
+    createdTopicInfo.TopicName = originalTopicName;
+    createdTopicInfo.Entities.Consumers->insert(groupId);
+    for (int partitionIndex = 0; partitionIndex < topicToCreate.NumPartitions; partitionIndex++) {
+        createdTopicInfo.Entities.Partitions->insert(partitionIndex);
+    }
+    CreateTopicInfo[actorId] = createdTopicInfo;
+    return false;
+}
+
 TOffsetFetchResponseData::TPtr TKafkaOffsetFetchActor::GetOffsetFetchResponse() {
     TOffsetFetchResponseData::TPtr response = std::make_shared<TOffsetFetchResponseData>();
     for (const auto& requestGroup : Message->Groups) {
         TOffsetFetchResponseData::TOffsetFetchResponseGroup group;
         group.GroupId = requestGroup.GroupId.value();
         for (const auto& requestTopic: requestGroup.Topics) {
-            TOffsetFetchResponseData::TOffsetFetchResponseGroup::TOffsetFetchResponseTopics topic;
-            TString topicName = requestTopic.Name.value();
-            topic.Name = topicName;
-            if (TopicsToResponses[topicName]->Status == NONE_ERROR) {
-                auto partitionsToOffsets = TopicsToResponses[topicName]->PartitionIdToOffsets;
-                for (auto requestPartition: requestTopic.PartitionIndexes) {
-                    TOffsetFetchResponseData::TOffsetFetchResponseGroup::TOffsetFetchResponseTopics::TOffsetFetchResponsePartitions partition;
-                    partition.PartitionIndex = requestPartition;
-                    if (partitionsToOffsets.get() != nullptr
-                            && partitionsToOffsets->contains(requestPartition)) {
-                        auto groupPartitionToOffset = (*partitionsToOffsets)[requestPartition].find(requestGroup.GroupId.value());
-                        if (groupPartitionToOffset != (*partitionsToOffsets)[requestPartition].end()) {
-                            partition.CommittedOffset = groupPartitionToOffset->second.Offset;
-                            partition.Metadata = groupPartitionToOffset->second.Metadata;
-                            partition.ErrorCode = NONE_ERROR;
-                        } else {
-                            partition.ErrorCode = RESOURCE_NOT_FOUND;
-                            KAFKA_LOG_ERROR("Group " << requestGroup.GroupId.value() << " not found for topic " << topicName);
-                        }
-                    } else {
-                        partition.ErrorCode = RESOURCE_NOT_FOUND;
-                        KAFKA_LOG_ERROR("Partition " << requestPartition << " not found for topic " << topicName);
-                    }
-                    topic.Partitions.push_back(partition);
-                }
-            } else {
-                for (auto requestPartition: requestTopic.PartitionIndexes) {
-                    TOffsetFetchResponseData::TOffsetFetchResponseGroup::TOffsetFetchResponseTopics::TOffsetFetchResponsePartitions partition;
-                    partition.PartitionIndex = requestPartition;
-                    partition.ErrorCode = TopicsToResponses[topicName]->Status;
-                    topic.Partitions.push_back(partition);
-                }
-            }
+            TOffsetFetchResponseData::TOffsetFetchResponseGroup::TOffsetFetchResponseTopics topic
+                                    = GetOffsetResponseForTopic(requestTopic, *requestGroup.GroupId);
             group.Topics.push_back(topic);
         }
         response->Groups.push_back(group);
@@ -547,11 +547,48 @@ TOffsetFetchResponseData::TPtr TKafkaOffsetFetchActor::GetOffsetFetchResponse() 
     return response;
 }
 
+TOffsetFetchResponseData::TOffsetFetchResponseGroup::TOffsetFetchResponseTopics TKafkaOffsetFetchActor::GetOffsetResponseForTopic(
+                                    TOffsetFetchRequestData::TOffsetFetchRequestGroup::TOffsetFetchRequestTopics const &requestTopic,
+                                    TString groupId) {
+    TOffsetFetchResponseData::TOffsetFetchResponseGroup::TOffsetFetchResponseTopics topic;
+    TString topicName = requestTopic.Name.value();
+    topic.Name = topicName;
+    if (TopicsToResponses[topicName]->Status == NONE_ERROR) {
+        auto partitionsToOffsets = TopicsToResponses[topicName]->PartitionIdToOffsets;
+        for (auto requestPartition: requestTopic.PartitionIndexes) {
+            TOffsetFetchResponseData::TOffsetFetchResponseGroup::TOffsetFetchResponseTopics::TOffsetFetchResponsePartitions partition;
+            partition.PartitionIndex = requestPartition;
+            if (partitionsToOffsets.get() != nullptr
+                    && partitionsToOffsets->contains(requestPartition)) {
+                auto groupPartitionToOffset = (*partitionsToOffsets)[requestPartition].find(groupId);
+                if (groupPartitionToOffset != (*partitionsToOffsets)[requestPartition].end()) {
+                    partition.CommittedOffset = groupPartitionToOffset->second.Offset;
+                    partition.Metadata = groupPartitionToOffset->second.Metadata;
+                    partition.ErrorCode = NONE_ERROR;
+                } else {
+                    partition.ErrorCode = RESOURCE_NOT_FOUND;
+                    KAFKA_LOG_ERROR("Group " << groupId << " not found for topic " << topicName);
+                }
+            } else {
+                partition.ErrorCode = RESOURCE_NOT_FOUND;
+                KAFKA_LOG_ERROR("Partition " << requestPartition << " not found for topic " << topicName);
+            }
+            topic.Partitions.push_back(partition);
+        }
+    } else {
+        for (auto requestPartition: requestTopic.PartitionIndexes) {
+            TOffsetFetchResponseData::TOffsetFetchResponseGroup::TOffsetFetchResponseTopics::TOffsetFetchResponsePartitions partition;
+            partition.PartitionIndex = requestPartition;
+            partition.ErrorCode = TopicsToResponses[topicName]->Status;
+            topic.Partitions.push_back(partition);
+        }
+    }
+    return topic;
+}
 NYdb::TParamsBuilder TKafkaOffsetFetchActor::BuildFetchAssignmentsParams(const std::vector<std::optional<TString>>& groupIds) {
     NYdb::TParamsBuilder params;
 
     params.AddParam("$Database").Utf8(DatabasePath).Build();
-    KAFKA_LOG_D(TStringBuilder() << "Groups count: " << groupIds.size());
     auto& consumerGroups = params.AddParam("$ConsumerGroups").BeginList();
 
     for (auto& groupId: groupIds) {
@@ -562,8 +599,19 @@ NYdb::TParamsBuilder TKafkaOffsetFetchActor::BuildFetchAssignmentsParams(const s
     return params;
 }
 
+void TKafkaOffsetFetchActor::FillMapWithGroupRequests() {
+    for (const auto& groupRequest : Message->Groups) {
+        for (auto& topicRequest : groupRequest.Topics) {
+            GroupRequests[*topicRequest.Name] = TopicGroupRequest{topicRequest, *groupRequest.GroupId};
+        }
+    }
+}
+
 void NKafka::TKafkaOffsetFetchActor::Die(const TActorContext &ctx) {
     KAFKA_LOG_D("Dying.");
+    for (const TActorId& actorId : DependantActors) {
+        Send(actorId, new TEvents::TEvPoisonPill());
+    }
     if (Kqp) {
         Kqp->CloseKqpSession(ctx);
     }

--- a/ydb/core/kafka_proxy/actors/kafka_offset_fetch_actor.h
+++ b/ydb/core/kafka_proxy/actors/kafka_offset_fetch_actor.h
@@ -94,7 +94,8 @@ private:
     std::unordered_map<ui32, TString> CookieToGroupId;
     std::unordered_map<ui32, ModifiedTopicInfo> AlterTopicInf;
     std::unordered_map<TActorId, ModifiedTopicInfo> CreateTopicInf;
-    std::unordered_set<std::pair<TString, TString>, TPairHash> ConsumerTopicRequestAttempts;
+    std::unordered_set<std::pair<TString, TString>, TPairHash> ConsumerTopicAlterRequestAttempts;
+    std::unordered_set<TString> TopicCreateRequestAttempts;
     std::unique_ptr<NKafka::TKqpTxHelper> Kqp;
 
     ui32 InflyTopics = 0;

--- a/ydb/core/kafka_proxy/actors/kafka_offset_fetch_actor.h
+++ b/ydb/core/kafka_proxy/actors/kafka_offset_fetch_actor.h
@@ -40,6 +40,9 @@ struct AlterTopicInfo {
     TopicEntities Entities;
 };
 
+struct TPairHash { size_t operator()(const std::pair<TString, TString>& p) const { return CombineHashes(std::hash<TString>()(p.first), std::hash<TString>()(p.second)); } };
+
+
 class TKafkaOffsetFetchActor: public NActors::TActorBootstrapped<TKafkaOffsetFetchActor> {
 
     using TBase = NActors::TActor<TKafkaOffsetFetchActor>;
@@ -87,6 +90,7 @@ private:
     std::unordered_map<TString, ui32> GroupIdToIndex;
     std::unordered_map<ui32, TString> CookieToGroupId;
     std::unordered_map<ui32, AlterTopicInfo> AlterTopicInf;
+    std::unordered_map<std::pair<TString, TString>, ui32, TPairHash> ConsumerTopicRequestsLimit;
     std::unique_ptr<NKafka::TKqpTxHelper> Kqp;
 
     ui32 InflyTopics = 0;

--- a/ydb/core/kafka_proxy/actors/kafka_offset_fetch_actor.h
+++ b/ydb/core/kafka_proxy/actors/kafka_offset_fetch_actor.h
@@ -83,24 +83,24 @@ public:
 
     void Handle(TEvKafka::TEvCommitedOffsetsResponse::TPtr& ev, const TActorContext& ctx);
     void Handle(NKqp::TEvKqp::TEvCreateSessionResponse::TPtr& ev, const TActorContext& ctx);
-    void Handle(NKqp::TEvKqp::TEvQueryResponse::TPtr ev, const TActorContext& ctx);
+    void Handle(NKqp::TEvKqp::TEvQueryResponse::TPtr& ev, const TActorContext& ctx);
     void Handle(NKikimr::NReplication::TEvYdbProxy::TEvAlterTopicResponse::TPtr& ev, const TActorContext& ctx);
     void Handle(const TEvKafka::TEvResponse::TPtr& ev, const TActorContext& ctx);
-    void ExtractPartitions(const TString& group, const NKafka::TOffsetFetchRequestData::TOffsetFetchRequestGroup::TOffsetFetchRequestTopics& topic);
-    void ParseGroupsAssignments(NKqp::TEvKqp::TEvQueryResponse::TPtr ev, std::vector<std::pair<std::optional<TString>, TConsumerProtocolAssignment>>& assignments);
+    void ExtractPartitions(const TString& group,
+                           const NKafka::TOffsetFetchRequestData::TOffsetFetchRequestGroup::TOffsetFetchRequestTopics& topic);
+    void ParseGroupsAssignments(const NKqp::TEvKqp::TEvQueryResponse::TPtr& ev,
+                                std::vector<std::pair<std::optional<TString>, TConsumerProtocolAssignment>>& assignments);
     void CreateConsumerGroupIfNecessary(const TString& topicName,
                                     const TString& topicPath,
                                     const TString& originalTopicName,
-                                    const TString& groupId,
-                                    const std::vector<TOffsetFetchResponsePartitions>& topicPartitions);
-    bool CreateTopicIfNecessary(const TString& topicName,
+                                    const TString& groupId);
+    void CreateTopicIfNecessary(const TString& topicName,
                                 const TString& originalTopicName,
-                                const TString& groupId,
                                 const TActorContext& ctx);
     TOffsetFetchResponseData::TPtr GetOffsetFetchResponse();
     TOffsetFetchResponseData::TOffsetFetchResponseGroup::TOffsetFetchResponseTopics GetOffsetResponseForTopic(
                                     TOffsetFetchRequestData::TOffsetFetchRequestGroup::TOffsetFetchRequestTopics const &requestTopic,
-                                    TString groupId);
+                                    const TString& groupId);
     NYdb::TParamsBuilder BuildFetchAssignmentsParams(const std::vector<std::optional<TString>>& groupIds);
     void FillMapWithGroupRequests();
     void ReplyError(const TActorContext& ctx);
@@ -119,9 +119,9 @@ private:
     std::unordered_map<TString, TAutoPtr<TEvKafka::TEvCommitedOffsetsResponse>> TopicsToResponses;
     std::unordered_map<TString, ui32> GroupIdToIndex;
     std::unordered_map<ui32, TString> CookieToGroupId;
-    std::unordered_map<ui32, TModifiedTopicInfo> AlterTopicInfo;
-    std::unordered_map<TString, TTopicGroupRequest> GroupRequests;
-    std::unordered_map<TActorId, TModifiedTopicInfo> CreateTopicInfo;
+    std::unordered_map<ui32, TString> AlterTopicCookieToName;
+    std::unordered_map<TString, std::vector<TTopicGroupRequest>> GroupRequests;
+    std::unordered_map<TActorId, TString> CreateTopicActorIdToName;
     std::unordered_set<TTopicGroupIdAndPath, TStructHash> ConsumerTopicAlterRequestAttempts;
     std::unordered_set<TString> TopicCreateRequestAttempts;
     std::unordered_set<TActorId> DependantActors;

--- a/ydb/core/kafka_proxy/actors/kafka_offset_fetch_actor.h
+++ b/ydb/core/kafka_proxy/actors/kafka_offset_fetch_actor.h
@@ -40,7 +40,21 @@ struct ModifiedTopicInfo {
     TopicEntities Entities;
 };
 
-struct TPairHash { size_t operator()(const std::pair<TString, TString>& p) const { return CombineHashes(std::hash<TString>()(p.first), std::hash<TString>()(p.second)); } };
+struct TopicGroupRequest {
+    TOffsetFetchRequestData::TOffsetFetchRequestGroup::TOffsetFetchRequestTopics TopicRequest;
+    TString GroupId;
+};
+
+struct TopicGroupIdAndPath {
+    TString GroupId;
+    TString TopicPath;
+
+    bool operator==(const TopicGroupIdAndPath& topicGroupIdAndPath) const {
+        return GroupId == topicGroupIdAndPath.GroupId && TopicPath == topicGroupIdAndPath.TopicPath;
+    }
+};
+
+struct TStructHash { size_t operator()(const TopicGroupIdAndPath& alterTopicRequest) const { return CombineHashes(std::hash<TString>()(alterTopicRequest.GroupId), std::hash<TString>()(alterTopicRequest.TopicPath)); } };
 
 
 class TKafkaOffsetFetchActor: public NActors::TActorBootstrapped<TKafkaOffsetFetchActor> {
@@ -74,8 +88,21 @@ public:
     void Handle(const TEvKafka::TEvResponse::TPtr& ev, const TActorContext& ctx);
     void ExtractPartitions(const TString& group, const NKafka::TOffsetFetchRequestData::TOffsetFetchRequestGroup::TOffsetFetchRequestTopics& topic);
     void ParseGroupsAssignments(NKqp::TEvKqp::TEvQueryResponse::TPtr ev, std::vector<std::pair<std::optional<TString>, TConsumerProtocolAssignment>>& assignments);
+    void CreateConsumerGroupIfNecessary(const TString& topicName,
+                                    const TString& topicPath,
+                                    const TString& originalTopicName,
+                                    const TString& groupId,
+                                    const std::vector<TOffsetFetchResponsePartitions>& topicPartitions);
+    bool CreateTopicIfNecessary(const TString& topicName,
+                                const TString& originalTopicName,
+                                const TString& groupId,
+                                const TActorContext& ctx);
     TOffsetFetchResponseData::TPtr GetOffsetFetchResponse();
+    TOffsetFetchResponseData::TOffsetFetchResponseGroup::TOffsetFetchResponseTopics GetOffsetResponseForTopic(
+                                    TOffsetFetchRequestData::TOffsetFetchRequestGroup::TOffsetFetchRequestTopics const &requestTopic,
+                                    TString groupId);
     NYdb::TParamsBuilder BuildFetchAssignmentsParams(const std::vector<std::optional<TString>>& groupIds);
+    void FillMapWithGroupRequests();
     void ReplyError(const TActorContext& ctx);
     void Die(const TActorContext &ctx);
 
@@ -92,10 +119,12 @@ private:
     std::unordered_map<TString, TAutoPtr<TEvKafka::TEvCommitedOffsetsResponse>> TopicsToResponses;
     std::unordered_map<TString, ui32> GroupIdToIndex;
     std::unordered_map<ui32, TString> CookieToGroupId;
-    std::unordered_map<ui32, ModifiedTopicInfo> AlterTopicInf;
-    std::unordered_map<TActorId, ModifiedTopicInfo> CreateTopicInf;
-    std::unordered_set<std::pair<TString, TString>, TPairHash> ConsumerTopicAlterRequestAttempts;
+    std::unordered_map<ui32, ModifiedTopicInfo> AlterTopicInfo;
+    std::unordered_map<TString, TopicGroupRequest> GroupRequests;
+    std::unordered_map<TActorId, ModifiedTopicInfo> CreateTopicInfo;
+    std::unordered_set<TopicGroupIdAndPath, TStructHash> ConsumerTopicAlterRequestAttempts;
     std::unordered_set<TString> TopicCreateRequestAttempts;
+    std::unordered_set<TActorId> DependantActors;
     std::unique_ptr<NKafka::TKqpTxHelper> Kqp;
 
     ui32 InflyTopics = 0;

--- a/ydb/core/kafka_proxy/actors/kafka_offset_fetch_actor.h
+++ b/ydb/core/kafka_proxy/actors/kafka_offset_fetch_actor.h
@@ -30,31 +30,31 @@ const TString FETCH_ASSIGNMENTS = R"sql(
       AND consumer_group IN $ConsumerGroups
 )sql";
 
-struct TopicEntities {
+struct TTopicEntities {
     std::shared_ptr<TSet<TString>> Consumers = std::make_shared<TSet<TString>>();
     std::shared_ptr<TSet<ui32>> Partitions = std::make_shared<TSet<ui32>>();
 };
 
-struct ModifiedTopicInfo {
+struct TModifiedTopicInfo {
     TString TopicName;
-    TopicEntities Entities;
+    TTopicEntities Entities;
 };
 
-struct TopicGroupRequest {
+struct TTopicGroupRequest {
     TOffsetFetchRequestData::TOffsetFetchRequestGroup::TOffsetFetchRequestTopics TopicRequest;
     TString GroupId;
 };
 
-struct TopicGroupIdAndPath {
+struct TTopicGroupIdAndPath {
     TString GroupId;
     TString TopicPath;
 
-    bool operator==(const TopicGroupIdAndPath& topicGroupIdAndPath) const {
+    bool operator==(const TTopicGroupIdAndPath& topicGroupIdAndPath) const {
         return GroupId == topicGroupIdAndPath.GroupId && TopicPath == topicGroupIdAndPath.TopicPath;
     }
 };
 
-struct TStructHash { size_t operator()(const TopicGroupIdAndPath& alterTopicRequest) const { return CombineHashes(std::hash<TString>()(alterTopicRequest.GroupId), std::hash<TString>()(alterTopicRequest.TopicPath)); } };
+struct TStructHash { size_t operator()(const TTopicGroupIdAndPath& alterTopicRequest) const { return CombineHashes(std::hash<TString>()(alterTopicRequest.GroupId), std::hash<TString>()(alterTopicRequest.TopicPath)); } };
 
 
 class TKafkaOffsetFetchActor: public NActors::TActorBootstrapped<TKafkaOffsetFetchActor> {
@@ -115,14 +115,14 @@ private:
     TContext::TPtr ContextForTopicCreation;
     const ui64 CorrelationId;
     const TMessagePtr<TOffsetFetchRequestData> Message;
-    std::unordered_map<TString, TopicEntities> TopicToEntities;
+    std::unordered_map<TString, TTopicEntities> TopicToEntities;
     std::unordered_map<TString, TAutoPtr<TEvKafka::TEvCommitedOffsetsResponse>> TopicsToResponses;
     std::unordered_map<TString, ui32> GroupIdToIndex;
     std::unordered_map<ui32, TString> CookieToGroupId;
-    std::unordered_map<ui32, ModifiedTopicInfo> AlterTopicInfo;
-    std::unordered_map<TString, TopicGroupRequest> GroupRequests;
-    std::unordered_map<TActorId, ModifiedTopicInfo> CreateTopicInfo;
-    std::unordered_set<TopicGroupIdAndPath, TStructHash> ConsumerTopicAlterRequestAttempts;
+    std::unordered_map<ui32, TModifiedTopicInfo> AlterTopicInfo;
+    std::unordered_map<TString, TTopicGroupRequest> GroupRequests;
+    std::unordered_map<TActorId, TModifiedTopicInfo> CreateTopicInfo;
+    std::unordered_set<TTopicGroupIdAndPath, TStructHash> ConsumerTopicAlterRequestAttempts;
     std::unordered_set<TString> TopicCreateRequestAttempts;
     std::unordered_set<TActorId> DependantActors;
     std::unique_ptr<NKafka::TKqpTxHelper> Kqp;

--- a/ydb/core/kafka_proxy/actors/kafka_offset_fetch_actor.h
+++ b/ydb/core/kafka_proxy/actors/kafka_offset_fetch_actor.h
@@ -35,7 +35,7 @@ struct TopicEntities {
     std::shared_ptr<TSet<ui32>> Partitions = std::make_shared<TSet<ui32>>();
 };
 
-struct AlterTopicInfo {
+struct ModifiedTopicInfo {
     TString TopicName;
     TopicEntities Entities;
 };
@@ -63,6 +63,7 @@ public:
             HFunc(NKqp::TEvKqp::TEvQueryResponse, Handle);
             HFunc(NKqp::TEvKqp::TEvCreateSessionResponse, Handle);
             HFunc(NKikimr::NReplication::TEvYdbProxy::TEvAlterTopicResponse, Handle);
+            HFunc(TEvKafka::TEvResponse, Handle);
         }
     }
 
@@ -70,6 +71,7 @@ public:
     void Handle(NKqp::TEvKqp::TEvCreateSessionResponse::TPtr& ev, const TActorContext& ctx);
     void Handle(NKqp::TEvKqp::TEvQueryResponse::TPtr ev, const TActorContext& ctx);
     void Handle(NKikimr::NReplication::TEvYdbProxy::TEvAlterTopicResponse::TPtr& ev, const TActorContext& ctx);
+    void Handle(const TEvKafka::TEvResponse::TPtr& ev, const TActorContext& ctx);
     void ExtractPartitions(const TString& group, const NKafka::TOffsetFetchRequestData::TOffsetFetchRequestGroup::TOffsetFetchRequestTopics& topic);
     void ParseGroupsAssignments(NKqp::TEvKqp::TEvQueryResponse::TPtr ev, std::vector<std::pair<std::optional<TString>, TConsumerProtocolAssignment>>& assignments);
     TOffsetFetchResponseData::TPtr GetOffsetFetchResponse();
@@ -83,19 +85,22 @@ public:
 
 private:
     const TContext::TPtr Context;
+    TContext::TPtr ContextForTopicCreation;
     const ui64 CorrelationId;
     const TMessagePtr<TOffsetFetchRequestData> Message;
     std::unordered_map<TString, TopicEntities> TopicToEntities;
     std::unordered_map<TString, TAutoPtr<TEvKafka::TEvCommitedOffsetsResponse>> TopicsToResponses;
     std::unordered_map<TString, ui32> GroupIdToIndex;
     std::unordered_map<ui32, TString> CookieToGroupId;
-    std::unordered_map<ui32, AlterTopicInfo> AlterTopicInf;
-    std::unordered_map<std::pair<TString, TString>, ui32, TPairHash> ConsumerTopicRequestsLimit;
+    std::unordered_map<ui32, ModifiedTopicInfo> AlterTopicInf;
+    std::unordered_map<TActorId, ModifiedTopicInfo> CreateTopicInf;
+    std::unordered_set<std::pair<TString, TString>, TPairHash> ConsumerTopicRequestAttempts;
     std::unique_ptr<NKafka::TKqpTxHelper> Kqp;
 
     ui32 InflyTopics = 0;
     ui32 WaitingGroupTopicsInfo = 0;
     ui32 KqpCookie = 0;
+    ui32 AlterTopicCookie = 0;
     std::vector<std::optional<TString>> GroupsToFetch;
     const TString DatabasePath;
     bool KqpSessionCreated = false;

--- a/ydb/core/kafka_proxy/ut/kafka_test_client.cpp
+++ b/ydb/core/kafka_proxy/ut/kafka_test_client.cpp
@@ -424,7 +424,7 @@ TMessagePtr<TOffsetFetchResponseData> TKafkaTestClient::OffsetFetch(TString grou
     return WriteAndRead<TOffsetFetchResponseData>(header, request);
 }
 
-TMessagePtr<TOffsetFetchResponseData> TKafkaTestClient::OffsetFetch(TOffsetFetchRequestData request) {
+TMessagePtr<TOffsetFetchResponseData> TKafkaTestClient::OffsetFetch(TOffsetFetchRequestData& request) {
     Cerr << ">>>>> TOffsetFetchRequestData\n";
     TRequestHeaderData header = Header(NKafka::EApiKey::OFFSET_FETCH, 8);
     return WriteAndRead<TOffsetFetchResponseData>(header, request);

--- a/ydb/core/kafka_proxy/ut/kafka_test_client.cpp
+++ b/ydb/core/kafka_proxy/ut/kafka_test_client.cpp
@@ -711,7 +711,7 @@ void TKafkaTestClient::UnknownApiKey() {
 }
 
 void TKafkaTestClient::AuthenticateToKafka() {
-{
+    {
         auto msg = ApiVersions();
 
         UNIT_ASSERT_VALUES_EQUAL(msg->ErrorCode, static_cast<TKafkaInt16>(EKafkaErrors::NONE_ERROR));
@@ -732,6 +732,28 @@ void TKafkaTestClient::AuthenticateToKafka() {
     }
 }
 
+void TKafkaTestClient::AuthenticateToKafka(const TString& userName, const TString& userPassword) {
+    {
+        auto msg = ApiVersions();
+
+        UNIT_ASSERT_VALUES_EQUAL(msg->ErrorCode, static_cast<TKafkaInt16>(EKafkaErrors::NONE_ERROR));
+        UNIT_ASSERT_VALUES_EQUAL(msg->ApiKeys.size(), EXPECTED_API_KEYS_COUNT);
+    }
+
+    {
+        auto msg = SaslHandshake();
+
+        UNIT_ASSERT_VALUES_EQUAL(msg->ErrorCode, static_cast<TKafkaInt16>(EKafkaErrors::NONE_ERROR));
+        UNIT_ASSERT_VALUES_EQUAL(msg->Mechanisms.size(), 1u);
+        UNIT_ASSERT_VALUES_EQUAL(*msg->Mechanisms[0], "PLAIN");
+    }
+
+    {
+        auto msg = SaslAuthenticate(userName, userPassword);
+        UNIT_ASSERT_VALUES_EQUAL(msg->ErrorCode, static_cast<TKafkaInt16>(EKafkaErrors::NONE_ERROR));
+    }
+
+}
 
 TRequestHeaderData TKafkaTestClient::Header(NKafka::EApiKey apiKey, TKafkaVersion version) {
     TRequestHeaderData header;

--- a/ydb/core/kafka_proxy/ut/kafka_test_client.h
+++ b/ydb/core/kafka_proxy/ut/kafka_test_client.h
@@ -137,6 +137,8 @@ class TKafkaTestClient {
 
         void AuthenticateToKafka();
 
+        void AuthenticateToKafka(const TString& userName, const TString& userPassword);
+
         TRequestHeaderData Header(NKafka::EApiKey apiKey, TKafkaVersion version);
 
     protected:

--- a/ydb/core/kafka_proxy/ut/kafka_test_client.h
+++ b/ydb/core/kafka_proxy/ut/kafka_test_client.h
@@ -103,7 +103,7 @@ class TKafkaTestClient {
 
         TMessagePtr<TOffsetFetchResponseData> OffsetFetch(TString groupId, std::map<TString, std::vector<i32>> topicsToPartions);
 
-        TMessagePtr<TOffsetFetchResponseData> OffsetFetch(TOffsetFetchRequestData request);
+        TMessagePtr<TOffsetFetchResponseData> OffsetFetch(TOffsetFetchRequestData& request);
 
         TMessagePtr<TListGroupsResponseData> ListGroups(TListGroupsRequestData request);
 

--- a/ydb/core/kafka_proxy/ut/metarequest_ut.cpp
+++ b/ydb/core/kafka_proxy/ut/metarequest_ut.cpp
@@ -24,7 +24,8 @@ Y_UNIT_TEST_SUITE(TMetadataActorTests) {
             Config.MutableProxy()->SetHostname(proxyHost);
             Config.MutableProxy()->SetPort(9097);
         }
-
+        Config.SetAutoCreateTopicsEnable(false);
+        Config.SetAutoCreateConsumersEnable(false);
         auto* runtime = server.CleverServer->GetRuntime();
         auto request = GetMetadataRequest(topics);
 

--- a/ydb/core/kafka_proxy/ut/ut_protocol.cpp
+++ b/ydb/core/kafka_proxy/ut/ut_protocol.cpp
@@ -59,7 +59,7 @@ public:
     TIpPort Port;
 
     TTestServer(const TString& kafkaApiMode = "1", bool serverless = false, bool enableNativeKafkaBalancing = true, bool enableAutoTopicCreation = false,
-                                                                                                                    bool enableAutoConsumerCreation = false) {
+                                                                                                                    bool enableAutoConsumerCreation = true) {
         TPortManager portManager;
         Port = portManager.GetTcpPort();
 
@@ -94,8 +94,8 @@ public:
             appConfig.MutableKafkaProxyConfig()->SetAutoCreateTopicsEnable(true);
         }
         appConfig.MutableKafkaProxyConfig()->SetTopicCreationDefaultPartitions(2);
-        if (enableAutoConsumerCreation) {
-            appConfig.MutableKafkaProxyConfig()->SetAutoCreateConsumersEnable(true);
+        if (!enableAutoConsumerCreation) {
+            appConfig.MutableKafkaProxyConfig()->SetAutoCreateConsumersEnable(false);
         }
         if (serverless) {
             appConfig.MutableKafkaProxyConfig()->MutableProxy()->SetHostname("localhost");
@@ -1571,7 +1571,7 @@ Y_UNIT_TEST_SUITE(KafkaProtocol) {
     } // Y_UNIT_TEST(BalanceScenarioCdc)
 
     Y_UNIT_TEST(OffsetCommitAndFetchScenario) {
-        TInsecureTestServer testServer("2");
+        TInsecureTestServer testServer("2", false, true, false, false);
         testServer.KikimrServer->GetRuntime()->SetLogPriority(NKikimrServices::PQ_WRITE_PROXY, NActors::NLog::PRI_TRACE);
         testServer.KikimrServer->GetRuntime()->SetLogPriority(NKikimrServices::PERSQUEUE, NActors::NLog::PRI_TRACE);
 

--- a/ydb/core/kafka_proxy/ut/ut_protocol.cpp
+++ b/ydb/core/kafka_proxy/ut/ut_protocol.cpp
@@ -89,7 +89,10 @@ public:
         appConfig.MutableKafkaProxyConfig()->SetListeningPort(Port);
         appConfig.MutableKafkaProxyConfig()->SetMaxMessageSize(1024);
         appConfig.MutableKafkaProxyConfig()->SetMaxInflightSize(2048);
-        appConfig.MutableKafkaProxyConfig()->SetAutoCreateTopicsEnable(true);
+        if (enableAutoTopicCreation) {
+            appConfig.MutableKafkaProxyConfig()->SetAutoCreateTopicsEnable(true);
+        }
+        appConfig.MutableKafkaProxyConfig()->SetDefaultNumOfPartitions(2);
 
         if (serverless) {
             appConfig.MutableKafkaProxyConfig()->MutableProxy()->SetHostname("localhost");
@@ -1834,6 +1837,7 @@ Y_UNIT_TEST_SUITE(KafkaProtocol) {
         }
     } // Y_UNIT_TEST(OffsetFetchScenario)
 
+
     void RunCreateTopicsScenario(TInsecureTestServer& testServer, TKafkaTestClient& client) {
         NYdb::NTopic::TTopicClient pqClient(*testServer.Driver);
 
@@ -2540,66 +2544,154 @@ Y_UNIT_TEST_SUITE(KafkaProtocol) {
         UNIT_ASSERT_VALUES_EQUAL(metadataResponse->Brokers[0].Port, FAKE_SERVERLESS_KAFKA_PROXY_PORT);
     }
 
-    Y_UNIT_TEST(ConsumerTopicAutocreationScenario) {
-        TInsecureTestServer testServer;
+    Y_UNIT_TEST(OffsetFetchConsumerTopicAutocreationScenario) {
+        TInsecureTestServer testServer("1", false, false, true);
 
         TString nonExistedTopicName1 = "non-existent-topic-1";
         TString nonExistedTopicName2 = "non-existent-topic-2";
+        TString nonExistedTopicName3 = "non-existent-topic-3";
+        TString existedTopicName = "existent-topic";
         TString newConsumer = "new-consumer";
+        TString consumerName = "my-consumer";
 
-        if (testServer.KikimrServer.get()->ServerSettings->AppConfig->GetKafkaProxyConfig().GetAutoCreateTopicsEnable()) {
-            Cout << "AutoCreateTopicsEnable is set true\n";
+        ui32 defaultPartitionsCount = testServer.KikimrServer.get()->ServerSettings->AppConfig->GetKafkaProxyConfig().GetDefaultNumOfPartitions();
+
+        {
+            NYdb::NTopic::TTopicClient pqClient(*testServer.Driver);
+            // create input and output topics
+            CreateTopic(pqClient, existedTopicName, 3, {consumerName});
+        }
+
+        { TKafkaTestClient client(testServer.Port);
+            // аутентифицируемся как пользователь с правами на чтение и запись
+            TString userName = "user123@/Root";
+            TString userPassword = "UsErPassword";
+            client.AuthenticateToKafka(userName, userPassword);
             {
-                TKafkaTestClient client(testServer.Port);
-                // аутентифицируемся как пользователь с правами на чтение и запись
-                TString userName = "user123@/Root";
-                TString userPassword = "UsErPassword";
-                client.AuthenticateToKafka(userName, userPassword);
-
+                // existent topic with existent consumer
                 std::map<TString, std::vector<i32>> topicsToPartions;
-                topicsToPartions[nonExistedTopicName1] = std::vector<i32>{0};
-                auto msg = client.OffsetFetch(newConsumer, topicsToPartions);
+                topicsToPartions[existedTopicName] = std::vector<i32>{0, 1, 2};
+                auto msg = client.OffsetFetch(consumerName, topicsToPartions);
                 UNIT_ASSERT_VALUES_EQUAL(msg->Groups.size(), 1);
                 UNIT_ASSERT_VALUES_EQUAL(msg->Groups[0].ErrorCode, 0);
                 UNIT_ASSERT_VALUES_EQUAL(msg->Groups[0].Topics.size(), 1);
-                UNIT_ASSERT_VALUES_EQUAL(msg->Groups[0].Topics[0].Name, nonExistedTopicName1);
-                UNIT_ASSERT_VALUES_EQUAL(msg->Groups[0].Topics[0].Partitions.size(), 1);
+                UNIT_ASSERT_VALUES_EQUAL(msg->Groups[0].Topics[0].Name, existedTopicName);
+                UNIT_ASSERT_VALUES_EQUAL(msg->Groups[0].Topics[0].Partitions.size(), 3);
                 UNIT_ASSERT_VALUES_EQUAL(msg->Groups[0].Topics[0].Partitions[0].PartitionIndex, 0);
                 UNIT_ASSERT_VALUES_EQUAL(msg->Groups[0].Topics[0].Partitions[0].ErrorCode, EKafkaErrors::NONE_ERROR);
             }
 
             {
-                TKafkaTestClient client(testServer.Port);
-                // аутентифицируемся как пользователь без прав на запись
-                TString userName = "usernorights@/Root";
-                TString userPassword = "dummyPass";
-                client.AuthenticateToKafka(userName, userPassword);
+                // existent topic with non-existent consumer
                 std::map<TString, std::vector<i32>> topicsToPartions;
-                topicsToPartions[nonExistedTopicName2] = std::vector<i32>{0};
-                auto msg = client.OffsetFetch(newConsumer, topicsToPartions);
-                UNIT_ASSERT_VALUES_EQUAL(msg->Groups.size(), 1);
-                UNIT_ASSERT_VALUES_EQUAL(msg->Groups[0].Topics.size(), 1);
-                UNIT_ASSERT_VALUES_EQUAL(msg->Groups[0].Topics[0].Partitions[0].ErrorCode, EKafkaErrors::UNKNOWN_TOPIC_OR_PARTITION);
-            }
-        } else {
-            Cout << "AutoCreateTopicsEnable is set false\n";
-            {
-                TKafkaTestClient client(testServer.Port);
-                // аутентифицируемся как пользователь с правами на чтение и запись
-                TString userName = "user123@/Root";
-                TString userPassword = "UsErPassword";
-                client.AuthenticateToKafka(userName, userPassword);
-
-                std::map<TString, std::vector<i32>> topicsToPartions;
-                topicsToPartions[nonExistedTopicName1] = std::vector<i32>{0};
+                topicsToPartions[existedTopicName] = std::vector<i32>{0, 1, 2};
                 auto msg = client.OffsetFetch(newConsumer, topicsToPartions);
                 UNIT_ASSERT_VALUES_EQUAL(msg->Groups.size(), 1);
                 UNIT_ASSERT_VALUES_EQUAL(msg->Groups[0].ErrorCode, 0);
                 UNIT_ASSERT_VALUES_EQUAL(msg->Groups[0].Topics.size(), 1);
-                UNIT_ASSERT_VALUES_EQUAL(msg->Groups[0].Topics[0].Name, nonExistedTopicName1);
+                UNIT_ASSERT_VALUES_EQUAL(msg->Groups[0].Topics[0].Name, existedTopicName);
+                UNIT_ASSERT_VALUES_EQUAL(msg->Groups[0].Topics[0].Partitions.size(), 3);
+                UNIT_ASSERT_VALUES_EQUAL(msg->Groups[0].Topics[0].Partitions[0].PartitionIndex, 0);
+                UNIT_ASSERT_VALUES_EQUAL(msg->Groups[0].Topics[0].Partitions[0].ErrorCode, EKafkaErrors::NONE_ERROR);
+            }
+
+            {
+                // an offset fetch request for both existent topic and non-existent topic
+                std::map<TString, std::vector<i32>> topicsToPartions;
+                topicsToPartions[existedTopicName] = std::vector<i32>{0, 1, 2};
+                topicsToPartions[nonExistedTopicName1] = std::vector<i32>{0, 1};
+                auto msg = client.OffsetFetch(newConsumer, topicsToPartions);
+                UNIT_ASSERT_VALUES_EQUAL(msg->Groups.size(), 1);
+                UNIT_ASSERT_VALUES_EQUAL(msg->Groups[0].ErrorCode, 0);
+                UNIT_ASSERT_VALUES_EQUAL(msg->Groups[0].Topics.size(), 2);
+                UNIT_ASSERT_VALUES_EQUAL(msg->Groups[0].Topics[0].Name, existedTopicName);
+                UNIT_ASSERT_VALUES_EQUAL(msg->Groups[0].Topics[0].Partitions.size(), 3);
+                for (const auto& partition : msg->Groups[0].Topics[0].Partitions) {
+                    UNIT_ASSERT_VALUES_EQUAL(partition.ErrorCode, EKafkaErrors::NONE_ERROR);
+                }
+                UNIT_ASSERT_VALUES_EQUAL(msg->Groups[0].Topics[1].Name, nonExistedTopicName1);
+                UNIT_ASSERT_VALUES_EQUAL(msg->Groups[0].Topics[1].Partitions.size(), defaultPartitionsCount);
+                for (const auto& partition : msg->Groups[0].Topics[1].Partitions) {
+                    UNIT_ASSERT_VALUES_EQUAL(partition.ErrorCode, EKafkaErrors::NONE_ERROR);
+                }
+            }
+
+            {
+                // non-existent topic with non-existent consumer
+                std::map<TString, std::vector<i32>> topicsToPartions;
+                topicsToPartions[nonExistedTopicName2] = std::vector<i32>{0};
+                auto msg = client.OffsetFetch(newConsumer, topicsToPartions);
+                UNIT_ASSERT_VALUES_EQUAL(msg->Groups.size(), 1);
+                UNIT_ASSERT_VALUES_EQUAL(msg->Groups[0].ErrorCode, 0);
+                UNIT_ASSERT_VALUES_EQUAL(msg->Groups[0].Topics.size(), 1);
+                UNIT_ASSERT_VALUES_EQUAL(msg->Groups[0].Topics[0].Name, nonExistedTopicName2);
                 UNIT_ASSERT_VALUES_EQUAL(msg->Groups[0].Topics[0].Partitions.size(), 1);
                 UNIT_ASSERT_VALUES_EQUAL(msg->Groups[0].Topics[0].Partitions[0].PartitionIndex, 0);
-                UNIT_ASSERT_VALUES_EQUAL(msg->Groups[0].Topics[0].Partitions[0].ErrorCode, EKafkaErrors::UNKNOWN_TOPIC_OR_PARTITION);
+                UNIT_ASSERT_VALUES_EQUAL(msg->Groups[0].Topics[0].Partitions[0].ErrorCode, EKafkaErrors::NONE_ERROR);
+            }
+        }
+
+        {
+            TKafkaTestClient client(testServer.Port);
+            // аутентифицируемся как пользователь без прав на запись
+            TString userName = "usernorights@/Root";
+            TString userPassword = "dummyPass";
+            client.AuthenticateToKafka(userName, userPassword);
+
+            std::map<TString, std::vector<i32>> topicsToPartions;
+            topicsToPartions[nonExistedTopicName3] = std::vector<i32>{0};
+            auto msg = client.OffsetFetch(newConsumer, topicsToPartions);
+            UNIT_ASSERT_VALUES_EQUAL(msg->Groups.size(), 1);
+            UNIT_ASSERT_VALUES_EQUAL(msg->Groups[0].Topics.size(), 1);
+            UNIT_ASSERT_VALUES_EQUAL(msg->Groups[0].Topics[0].Partitions[0].ErrorCode, EKafkaErrors::UNKNOWN_TOPIC_OR_PARTITION);
+        }
+    }
+
+    Y_UNIT_TEST(MetadataTopicAutocreationEnabledScenario) {
+        TInsecureTestServer testServer("1", false, false, true);
+
+        TString nonExistedTopicName1 = "non-existent-topic-1";
+        TString nonExistedTopicName2 = "non-existent-topic-2";
+        TString existedTopicName = "existent-topic";
+        TString consumerName = "my-consumer";
+        ui32 existedTopicPartitionsNum = 3;
+
+        ui32 defaultPartitionsCount = testServer.KikimrServer.get()->ServerSettings->AppConfig->GetKafkaProxyConfig().GetDefaultNumOfPartitions();
+
+        {
+            NYdb::NTopic::TTopicClient pqClient(*testServer.Driver);
+            // create input and output topics
+            CreateTopic(pqClient, existedTopicName, existedTopicPartitionsNum, {consumerName});
+        }
+
+        {
+            TKafkaTestClient client(testServer.Port);
+            TString userName = "user123@/Root";
+            TString userPassword = "UsErPassword";
+            client.AuthenticateToKafka(userName, userPassword);
+            TVector<TString> nonExistentTopics = {nonExistedTopicName1};
+            auto msg = client.Metadata(nonExistentTopics);
+            UNIT_ASSERT_VALUES_EQUAL(msg->Topics.size(), 1);
+            UNIT_ASSERT_VALUES_EQUAL(msg->Topics[0].Partitions.size(), defaultPartitionsCount);
+            for (const auto &partitionInfo : msg->Topics[0].Partitions) {
+                UNIT_ASSERT_VALUES_EQUAL(partitionInfo.ErrorCode, EKafkaErrors::NONE_ERROR);
+            }
+        }
+
+        {
+            TKafkaTestClient client(testServer.Port);
+            TString userName = "user123@/Root";
+            TString userPassword = "UsErPassword";
+            client.AuthenticateToKafka(userName, userPassword);
+            TVector<TString> nonExistentTopics = {nonExistedTopicName2, existedTopicName};
+            auto msg = client.Metadata(nonExistentTopics);
+            UNIT_ASSERT_VALUES_EQUAL(msg->Topics.size(), 2);
+            UNIT_ASSERT_VALUES_EQUAL(msg->Topics[0].Partitions.size(), defaultPartitionsCount);
+            UNIT_ASSERT_VALUES_EQUAL(msg->Topics[1].Partitions.size(), existedTopicPartitionsNum);
+            for (int i = 0; i < 2; i++) {
+                for (const auto &partitionInfo : msg->Topics[0].Partitions) {
+                    UNIT_ASSERT_VALUES_EQUAL(partitionInfo.ErrorCode, EKafkaErrors::NONE_ERROR);
+                }
             }
         }
     }
@@ -3301,7 +3393,7 @@ Y_UNIT_TEST_SUITE(KafkaProtocol) {
         TKafkaTestClient kafkaClient(testServer.Port);
         // use random transactional id for each request to avoid parallel execution problems
         auto transactionalId = TStringBuilder() << "my-tx-producer-" << RandomNumber<ui64>();
-        
+
         // this first request will init table
         auto resp1 = kafkaClient.InitProducerId(transactionalId);
         // update epoch to be last available
@@ -3319,7 +3411,7 @@ Y_UNIT_TEST_SUITE(KafkaProtocol) {
         rows.EndList();
         auto upsertResult = tableClient.BulkUpsert("//Root/.metadata/kafka_transactional_producers", rows.Build()).GetValueSync();
         UNIT_ASSERT_EQUAL(upsertResult.GetStatus(), EStatus::SUCCESS);
-        
+
         auto resp2 = kafkaClient.InitProducerId(transactionalId);
 
         // validate first response

--- a/ydb/core/kafka_proxy/ut/ut_protocol.cpp
+++ b/ydb/core/kafka_proxy/ut/ut_protocol.cpp
@@ -58,7 +58,7 @@ class TTestServer {
 public:
     TIpPort Port;
 
-    TTestServer(const TString& kafkaApiMode = "1", bool serverless = false, bool enableNativeKafkaBalancing = true, bool enableAutoTopicCreation = false,
+    TTestServer(const TString& kafkaApiMode = "1", bool serverless = false, bool enableNativeKafkaBalancing = true, bool enableAutoTopicCreation = true,
                                                                                                                     bool enableAutoConsumerCreation = true) {
         TPortManager portManager;
         Port = portManager.GetTcpPort();
@@ -90,8 +90,8 @@ public:
         appConfig.MutableKafkaProxyConfig()->SetListeningPort(Port);
         appConfig.MutableKafkaProxyConfig()->SetMaxMessageSize(1024);
         appConfig.MutableKafkaProxyConfig()->SetMaxInflightSize(2048);
-        if (enableAutoTopicCreation) {
-            appConfig.MutableKafkaProxyConfig()->SetAutoCreateTopicsEnable(true);
+        if (!enableAutoTopicCreation) {
+            appConfig.MutableKafkaProxyConfig()->SetAutoCreateTopicsEnable(false);
         }
         appConfig.MutableKafkaProxyConfig()->SetTopicCreationDefaultPartitions(2);
         if (!enableAutoConsumerCreation) {

--- a/ydb/core/kafka_proxy/ut/ut_protocol.cpp
+++ b/ydb/core/kafka_proxy/ut/ut_protocol.cpp
@@ -2676,6 +2676,19 @@ Y_UNIT_TEST_SUITE(KafkaProtocol) {
             }
         }
 
+         {
+            // check that if user has no rights, topic is not created
+            TKafkaTestClient client(testServer.Port);
+            TString userName = "usernorights@/Root";
+            TString userPassword = "dummyPass";
+            client.AuthenticateToKafka(userName, userPassword);
+            TVector<TString> nonExistentTopic = {nonExistedTopicName2};
+            auto msg = client.Metadata(nonExistentTopic);
+            UNIT_ASSERT_VALUES_EQUAL(msg->Topics.size(), 1);
+            UNIT_ASSERT_VALUES_EQUAL(msg->Topics[0].Partitions.size(), 0);
+            UNIT_ASSERT_VALUES_EQUAL(msg->Topics[0].ErrorCode, EKafkaErrors::TOPIC_AUTHORIZATION_FAILED);
+        }
+
         {
             TKafkaTestClient client(testServer.Port);
             TString userName = "user123@/Root";
@@ -2692,6 +2705,7 @@ Y_UNIT_TEST_SUITE(KafkaProtocol) {
                 }
             }
         }
+
     }
 
     Y_UNIT_TEST(DescribeGroupsScenario) {

--- a/ydb/core/kafka_proxy/ut/ut_protocol.cpp
+++ b/ydb/core/kafka_proxy/ut/ut_protocol.cpp
@@ -58,7 +58,8 @@ class TTestServer {
 public:
     TIpPort Port;
 
-    TTestServer(const TString& kafkaApiMode = "1", bool serverless = false, bool enableNativeKafkaBalancing = false) {
+    TTestServer(const TString& kafkaApiMode = "1", bool serverless = false, bool enableNativeKafkaBalancing = true, bool enableAutoTopicCreation = false,
+                                                                                                                    bool enableAutoConsumerCreation = false) {
         TPortManager portManager;
         Port = portManager.GetTcpPort();
 
@@ -93,7 +94,9 @@ public:
             appConfig.MutableKafkaProxyConfig()->SetAutoCreateTopicsEnable(true);
         }
         appConfig.MutableKafkaProxyConfig()->SetTopicCreationDefaultPartitions(2);
-
+        if (enableAutoConsumerCreation) {
+            appConfig.MutableKafkaProxyConfig()->SetAutoCreateConsumersEnable(true);
+        }
         if (serverless) {
             appConfig.MutableKafkaProxyConfig()->MutableProxy()->SetHostname("localhost");
             appConfig.MutableKafkaProxyConfig()->MutableProxy()->SetPort(FAKE_SERVERLESS_KAFKA_PROXY_PORT);
@@ -211,7 +214,7 @@ public:
             UNIT_ASSERT_VALUES_EQUAL(status, NMsgBusProxy::MSTATUS_OK);
 
             NYdb::NScheme::TSchemeClient schemeClient(*Driver);
-            NYdb::NScheme::TPermissions permissions("user-no-rights", {"ydb.generic.read"});
+            NYdb::NScheme::TPermissions permissions("user-no-rights", {});
 
             auto result = schemeClient
                               .ModifyPermissions(
@@ -2544,8 +2547,58 @@ Y_UNIT_TEST_SUITE(KafkaProtocol) {
         UNIT_ASSERT_VALUES_EQUAL(metadataResponse->Brokers[0].Port, FAKE_SERVERLESS_KAFKA_PROXY_PORT);
     }
 
-    Y_UNIT_TEST(OffsetFetchConsumerTopicAutocreationScenario) {
-        TInsecureTestServer testServer("1", false, false, true);
+    Y_UNIT_TEST(OffsetFetchConsumerAutocreationScenario) {
+        TInsecureTestServer testServer("1", false, false, false, true);
+
+        TString nonExistedTopicName = "non-existent-topic";
+        TString existedTopicName = "existent-topic";
+        TString consumerName = "my-consumer";
+        TString newConsumer1 = "new-consumer-1";
+
+        {
+            NYdb::NTopic::TTopicClient pqClient(*testServer.Driver);
+            CreateTopic(pqClient, existedTopicName, 3, {consumerName});
+        }
+
+        { TKafkaTestClient client(testServer.Port);
+            // authenticating as user with read and write rights
+            TString userName = "user123@/Root";
+            TString userPassword = "UsErPassword";
+            client.AuthenticateToKafka(userName, userPassword);
+            {
+                // checking consumer autocreation for existing topic
+                std::map<TString, std::vector<i32>> topicsToPartions;
+                topicsToPartions[existedTopicName] = std::vector<i32>{0, 1};
+                auto msg = client.OffsetFetch(newConsumer1, topicsToPartions);
+                UNIT_ASSERT_VALUES_EQUAL(msg->Groups.size(), 1);
+                UNIT_ASSERT_VALUES_EQUAL(msg->Groups[0].ErrorCode, 0);
+                UNIT_ASSERT_VALUES_EQUAL(msg->Groups[0].Topics.size(), 1);
+                UNIT_ASSERT_VALUES_EQUAL(msg->Groups[0].Topics[0].Name, existedTopicName);
+                UNIT_ASSERT_VALUES_EQUAL(msg->Groups[0].Topics[0].Partitions.size(), 2);
+                UNIT_ASSERT_VALUES_EQUAL(msg->Groups[0].Topics[0].Partitions[0].PartitionIndex, 0);
+                UNIT_ASSERT_VALUES_EQUAL(msg->Groups[0].Topics[0].Partitions[0].ErrorCode, EKafkaErrors::NONE_ERROR);
+                UNIT_ASSERT_VALUES_EQUAL(msg->Groups[0].Topics[0].Partitions[1].PartitionIndex, 1);
+                UNIT_ASSERT_VALUES_EQUAL(msg->Groups[0].Topics[0].Partitions[1].ErrorCode, EKafkaErrors::NONE_ERROR);
+            }
+
+            {
+                // non-existent topic with non-existent consumer should return an error for unexistent topic
+                std::map<TString, std::vector<i32>> topicsToPartions;
+                topicsToPartions[nonExistedTopicName] = std::vector<i32>{0};
+                auto msg = client.OffsetFetch(newConsumer1, topicsToPartions);
+                UNIT_ASSERT_VALUES_EQUAL(msg->Groups.size(), 1);
+                UNIT_ASSERT_VALUES_EQUAL(msg->Groups[0].ErrorCode, 0);
+                UNIT_ASSERT_VALUES_EQUAL(msg->Groups[0].Topics.size(), 1);
+                UNIT_ASSERT_VALUES_EQUAL(msg->Groups[0].Topics[0].Name, nonExistedTopicName);
+                UNIT_ASSERT_VALUES_EQUAL(msg->Groups[0].Topics[0].Partitions.size(), 1);
+                UNIT_ASSERT_VALUES_EQUAL(msg->Groups[0].Topics[0].Partitions[0].PartitionIndex, 0);
+                UNIT_ASSERT_VALUES_EQUAL(msg->Groups[0].Topics[0].Partitions[0].ErrorCode, EKafkaErrors::UNKNOWN_TOPIC_OR_PARTITION);
+            }
+        }
+    }
+
+    Y_UNIT_TEST(OffsetFetchTopicConsumerAutocreationScenario) {
+        TInsecureTestServer testServer("1", false, false, true, true);
 
         TString nonExistedTopicName1 = "non-existent-topic-1";
         TString nonExistedTopicName2 = "non-existent-topic-2";

--- a/ydb/core/kafka_proxy/ut/ut_protocol.cpp
+++ b/ydb/core/kafka_proxy/ut/ut_protocol.cpp
@@ -92,7 +92,7 @@ public:
         if (enableAutoTopicCreation) {
             appConfig.MutableKafkaProxyConfig()->SetAutoCreateTopicsEnable(true);
         }
-        appConfig.MutableKafkaProxyConfig()->SetDefaultNumOfPartitions(2);
+        appConfig.MutableKafkaProxyConfig()->SetTopicCreationDefaultPartitions(2);
 
         if (serverless) {
             appConfig.MutableKafkaProxyConfig()->MutableProxy()->SetHostname("localhost");
@@ -2551,10 +2551,11 @@ Y_UNIT_TEST_SUITE(KafkaProtocol) {
         TString nonExistedTopicName2 = "non-existent-topic-2";
         TString nonExistedTopicName3 = "non-existent-topic-3";
         TString existedTopicName = "existent-topic";
-        TString newConsumer = "new-consumer";
         TString consumerName = "my-consumer";
+        TString newConsumer1 = "new-consumer-1";
+        TString newConsumer2 = "new-consumer-2";
 
-        ui32 defaultPartitionsCount = testServer.KikimrServer.get()->ServerSettings->AppConfig->GetKafkaProxyConfig().GetDefaultNumOfPartitions();
+        ui32 defaultPartitionsCount = testServer.KikimrServer.get()->ServerSettings->AppConfig->GetKafkaProxyConfig().GetTopicCreationDefaultPartitions();
 
         {
             NYdb::NTopic::TTopicClient pqClient(*testServer.Driver);
@@ -2584,14 +2585,47 @@ Y_UNIT_TEST_SUITE(KafkaProtocol) {
                 // existent topic with non-existent consumer
                 std::map<TString, std::vector<i32>> topicsToPartions;
                 topicsToPartions[existedTopicName] = std::vector<i32>{0, 1, 2};
-                auto msg = client.OffsetFetch(newConsumer, topicsToPartions);
+                auto msg = client.OffsetFetch(newConsumer1, topicsToPartions);
                 UNIT_ASSERT_VALUES_EQUAL(msg->Groups.size(), 1);
                 UNIT_ASSERT_VALUES_EQUAL(msg->Groups[0].ErrorCode, 0);
                 UNIT_ASSERT_VALUES_EQUAL(msg->Groups[0].Topics.size(), 1);
                 UNIT_ASSERT_VALUES_EQUAL(msg->Groups[0].Topics[0].Name, existedTopicName);
                 UNIT_ASSERT_VALUES_EQUAL(msg->Groups[0].Topics[0].Partitions.size(), 3);
-                UNIT_ASSERT_VALUES_EQUAL(msg->Groups[0].Topics[0].Partitions[0].PartitionIndex, 0);
-                UNIT_ASSERT_VALUES_EQUAL(msg->Groups[0].Topics[0].Partitions[0].ErrorCode, EKafkaErrors::NONE_ERROR);
+                for (size_t i = 0; i < msg->Groups[0].Topics[0].Partitions.size(); i++) {
+                    UNIT_ASSERT_VALUES_EQUAL(msg->Groups[0].Topics[0].Partitions[0].PartitionIndex, 0);
+                    UNIT_ASSERT_VALUES_EQUAL(msg->Groups[0].Topics[0].Partitions[0].ErrorCode, EKafkaErrors::NONE_ERROR);
+                }
+            }
+
+            {
+                // existent topic with existent consumer but non-existent partition should return an error
+                std::map<TString, std::vector<i32>> topicsToPartions;
+                i32 tooBigpartitionIndex = 100;
+                topicsToPartions[existedTopicName] = std::vector<i32>{tooBigpartitionIndex};
+                auto msg = client.OffsetFetch(newConsumer1, topicsToPartions);
+                UNIT_ASSERT_VALUES_EQUAL(msg->Groups.size(), 1);
+                UNIT_ASSERT_VALUES_EQUAL(msg->Groups[0].ErrorCode, 0);
+                UNIT_ASSERT_VALUES_EQUAL(msg->Groups[0].Topics.size(), 1);
+                UNIT_ASSERT_VALUES_EQUAL(msg->Groups[0].Topics[0].Name, existedTopicName);
+                UNIT_ASSERT_VALUES_EQUAL(msg->Groups[0].Topics[0].Partitions.size(), 1);
+                UNIT_ASSERT_VALUES_EQUAL(msg->Groups[0].Topics[0].Partitions[0].PartitionIndex, tooBigpartitionIndex);
+                UNIT_ASSERT_VALUES_EQUAL(msg->Groups[0].Topics[0].Partitions[0].ErrorCode, EKafkaErrors::RESOURCE_NOT_FOUND);
+            }
+
+            {
+                // existent topic with non-existent consumer and non-existent partition should return an error
+                std::map<TString, std::vector<i32>> topicsToPartions;
+                i32 tooBigpartitionIndex = 100;
+                topicsToPartions[existedTopicName] = std::vector<i32>{tooBigpartitionIndex};
+                auto msg = client.OffsetFetch(newConsumer2, topicsToPartions);
+                UNIT_ASSERT_VALUES_EQUAL(msg->Groups.size(), 1);
+                UNIT_ASSERT_VALUES_EQUAL(msg->Groups[0].ErrorCode, 0);
+                UNIT_ASSERT_VALUES_EQUAL(msg->Groups[0].Topics.size(), 1);
+                UNIT_ASSERT_VALUES_EQUAL(msg->Groups[0].Topics[0].Name, existedTopicName);
+                UNIT_ASSERT_VALUES_EQUAL(msg->Groups[0].ErrorCode, EKafkaErrors::NONE_ERROR);
+                UNIT_ASSERT_VALUES_EQUAL(msg->Groups[0].Topics[0].Partitions.size(), 1);
+                UNIT_ASSERT_VALUES_EQUAL(msg->Groups[0].Topics[0].Partitions[0].PartitionIndex, tooBigpartitionIndex);
+                UNIT_ASSERT_VALUES_EQUAL(msg->Groups[0].Topics[0].Partitions[0].ErrorCode, EKafkaErrors::RESOURCE_NOT_FOUND);
             }
 
             {
@@ -2599,7 +2633,7 @@ Y_UNIT_TEST_SUITE(KafkaProtocol) {
                 std::map<TString, std::vector<i32>> topicsToPartions;
                 topicsToPartions[existedTopicName] = std::vector<i32>{0, 1, 2};
                 topicsToPartions[nonExistedTopicName1] = std::vector<i32>{0, 1};
-                auto msg = client.OffsetFetch(newConsumer, topicsToPartions);
+                auto msg = client.OffsetFetch(newConsumer1, topicsToPartions);
                 UNIT_ASSERT_VALUES_EQUAL(msg->Groups.size(), 1);
                 UNIT_ASSERT_VALUES_EQUAL(msg->Groups[0].ErrorCode, 0);
                 UNIT_ASSERT_VALUES_EQUAL(msg->Groups[0].Topics.size(), 2);
@@ -2619,7 +2653,7 @@ Y_UNIT_TEST_SUITE(KafkaProtocol) {
                 // non-existent topic with non-existent consumer
                 std::map<TString, std::vector<i32>> topicsToPartions;
                 topicsToPartions[nonExistedTopicName2] = std::vector<i32>{0};
-                auto msg = client.OffsetFetch(newConsumer, topicsToPartions);
+                auto msg = client.OffsetFetch(newConsumer1, topicsToPartions);
                 UNIT_ASSERT_VALUES_EQUAL(msg->Groups.size(), 1);
                 UNIT_ASSERT_VALUES_EQUAL(msg->Groups[0].ErrorCode, 0);
                 UNIT_ASSERT_VALUES_EQUAL(msg->Groups[0].Topics.size(), 1);
@@ -2639,7 +2673,7 @@ Y_UNIT_TEST_SUITE(KafkaProtocol) {
 
             std::map<TString, std::vector<i32>> topicsToPartions;
             topicsToPartions[nonExistedTopicName3] = std::vector<i32>{0};
-            auto msg = client.OffsetFetch(newConsumer, topicsToPartions);
+            auto msg = client.OffsetFetch(newConsumer1, topicsToPartions);
             UNIT_ASSERT_VALUES_EQUAL(msg->Groups.size(), 1);
             UNIT_ASSERT_VALUES_EQUAL(msg->Groups[0].Topics.size(), 1);
             UNIT_ASSERT_VALUES_EQUAL(msg->Groups[0].Topics[0].Partitions[0].ErrorCode, EKafkaErrors::UNKNOWN_TOPIC_OR_PARTITION);
@@ -2655,7 +2689,7 @@ Y_UNIT_TEST_SUITE(KafkaProtocol) {
         TString consumerName = "my-consumer";
         ui32 existedTopicPartitionsNum = 3;
 
-        ui32 defaultPartitionsCount = testServer.KikimrServer.get()->ServerSettings->AppConfig->GetKafkaProxyConfig().GetDefaultNumOfPartitions();
+        ui32 defaultPartitionsCount = testServer.KikimrServer.get()->ServerSettings->AppConfig->GetKafkaProxyConfig().GetTopicCreationDefaultPartitions();
 
         {
             NYdb::NTopic::TTopicClient pqClient(*testServer.Driver);

--- a/ydb/core/kafka_proxy/ut/ut_protocol.cpp
+++ b/ydb/core/kafka_proxy/ut/ut_protocol.cpp
@@ -2558,12 +2558,11 @@ Y_UNIT_TEST_SUITE(KafkaProtocol) {
 
         {
             NYdb::NTopic::TTopicClient pqClient(*testServer.Driver);
-            // create input and output topics
             CreateTopic(pqClient, existedTopicName, 3, {consumerName});
         }
 
         { TKafkaTestClient client(testServer.Port);
-            // аутентифицируемся как пользователь с правами на чтение и запись
+            // authenticating as user with read and write rights
             TString userName = "user123@/Root";
             TString userPassword = "UsErPassword";
             client.AuthenticateToKafka(userName, userPassword);
@@ -2633,7 +2632,7 @@ Y_UNIT_TEST_SUITE(KafkaProtocol) {
 
         {
             TKafkaTestClient client(testServer.Port);
-            // аутентифицируемся как пользователь без прав на запись
+            // authenticating as a user with no write rights
             TString userName = "usernorights@/Root";
             TString userPassword = "dummyPass";
             client.AuthenticateToKafka(userName, userPassword);
@@ -2660,7 +2659,6 @@ Y_UNIT_TEST_SUITE(KafkaProtocol) {
 
         {
             NYdb::NTopic::TTopicClient pqClient(*testServer.Driver);
-            // create input and output topics
             CreateTopic(pqClient, existedTopicName, existedTopicPartitionsNum, {consumerName});
         }
 

--- a/ydb/core/kafka_proxy/ut/ut_protocol.cpp
+++ b/ydb/core/kafka_proxy/ut/ut_protocol.cpp
@@ -1572,7 +1572,7 @@ Y_UNIT_TEST_SUITE(KafkaProtocol) {
         TString firstTopicName = "/Root/topic-0-test";
         TString secondTopicName = "/Root/topic-1-test";
         TString shortTopicName = "topic-1-test";
-        TString notExistsTopicName = "/Root/not-exists";
+        TString notExistsTopicName = "not-exists";
         ui64 minActivePartitions = 10;
 
         TString firstConsumerName = "consumer-0";
@@ -1716,16 +1716,19 @@ Y_UNIT_TEST_SUITE(KafkaProtocol) {
     }
         {
             // Check fetch offsets with nonexistent topic
+            std::map<TString, std::vector<i32>> topicsToPartions;
+            topicsToPartions[notExistsTopicName] = std::vector<i32>{0, 1};
+            auto msg = client.OffsetFetch(firstConsumerName, topicsToPartions);
+            UNIT_ASSERT_VALUES_EQUAL(msg->Groups.size(), 1);
+            UNIT_ASSERT_VALUES_EQUAL(msg->Groups[0].Topics.size(), 1);
+            UNIT_ASSERT_VALUES_EQUAL(msg->Groups[0].Topics[0].Partitions.size(), 2);
             if (!testServer.KikimrServer.get()->ServerSettings->AppConfig->GetKafkaProxyConfig().GetAutoCreateTopicsEnable()) {
-                std::map<TString, std::vector<i32>> topicsToPartions;
-                topicsToPartions[notExistsTopicName] = std::vector<i32>{0, 1};
-                auto msg = client.OffsetFetch(firstConsumerName, topicsToPartions);
-                UNIT_ASSERT_VALUES_EQUAL(msg->Groups.size(), 1);
-                UNIT_ASSERT_VALUES_EQUAL(msg->Groups[0].Topics.size(), 1);
-                UNIT_ASSERT_VALUES_EQUAL(msg->Groups[0].Topics[0].Partitions.size(), 2);
                 for (const auto& partition : msg->Groups[0].Topics[0].Partitions) {
                     UNIT_ASSERT_VALUES_EQUAL(partition.ErrorCode, UNKNOWN_TOPIC_OR_PARTITION);
                 }
+            } else {
+                UNIT_ASSERT_VALUES_EQUAL(msg->Groups[0].Topics[0].Partitions[0].ErrorCode, NONE_ERROR);
+                UNIT_ASSERT_VALUES_EQUAL(msg->Groups[0].Topics[0].Partitions[1].ErrorCode, RESOURCE_NOT_FOUND);
             }
         }
 

--- a/ydb/core/kafka_proxy/ut/ut_protocol.cpp
+++ b/ydb/core/kafka_proxy/ut/ut_protocol.cpp
@@ -1716,66 +1716,74 @@ Y_UNIT_TEST_SUITE(KafkaProtocol) {
     }
         {
             // Check fetch offsets with nonexistent topic
-            std::map<TString, std::vector<i32>> topicsToPartions;
-            topicsToPartions[notExistsTopicName] = std::vector<i32>{0, 1};
-            auto msg = client.OffsetFetch(firstConsumerName, topicsToPartions);
-            UNIT_ASSERT_VALUES_EQUAL(msg->Groups.size(), 1);
-            UNIT_ASSERT_VALUES_EQUAL(msg->Groups[0].Topics.size(), 1);
-            UNIT_ASSERT_VALUES_EQUAL(msg->Groups[0].Topics[0].Partitions.size(), 2);
-            for (const auto& partition : msg->Groups[0].Topics[0].Partitions) {
-                UNIT_ASSERT_VALUES_EQUAL(partition.ErrorCode, UNKNOWN_TOPIC_OR_PARTITION);
+            if (!testServer.KikimrServer.get()->ServerSettings->AppConfig->GetKafkaProxyConfig().GetAutoCreateTopicsEnable()) {
+                std::map<TString, std::vector<i32>> topicsToPartions;
+                topicsToPartions[notExistsTopicName] = std::vector<i32>{0, 1};
+                auto msg = client.OffsetFetch(firstConsumerName, topicsToPartions);
+                UNIT_ASSERT_VALUES_EQUAL(msg->Groups.size(), 1);
+                UNIT_ASSERT_VALUES_EQUAL(msg->Groups[0].Topics.size(), 1);
+                UNIT_ASSERT_VALUES_EQUAL(msg->Groups[0].Topics[0].Partitions.size(), 2);
+                for (const auto& partition : msg->Groups[0].Topics[0].Partitions) {
+                    UNIT_ASSERT_VALUES_EQUAL(partition.ErrorCode, UNKNOWN_TOPIC_OR_PARTITION);
+                }
             }
         }
 
         {
             // Check commit with nonexistent topic
 
-            std::unordered_map<TString, std::vector<NKafka::TEvKafka::PartitionConsumerOffset>> offsets;
-            std::vector<NKafka::TEvKafka::PartitionConsumerOffset> partitionsAndOffsets;
-            for (ui64 i = 0; i < minActivePartitions; ++i) {
-                partitionsAndOffsets.emplace_back(i, static_cast<ui64>(recordsCount), commitedMetaData);
-            }
-            offsets[firstTopicName] = partitionsAndOffsets;
-            offsets[notExistsTopicName] = partitionsAndOffsets;
+            if (!testServer.KikimrServer.get()->ServerSettings->AppConfig->GetKafkaProxyConfig().GetAutoCreateTopicsEnable()) {
+                std::unordered_map<TString, std::vector<NKafka::TEvKafka::PartitionConsumerOffset>> offsets;
+                std::vector<NKafka::TEvKafka::PartitionConsumerOffset> partitionsAndOffsets;
+                for (ui64 i = 0; i < minActivePartitions; ++i) {
+                    partitionsAndOffsets.emplace_back(i, static_cast<ui64>(recordsCount), commitedMetaData);
+                }
+                offsets[firstTopicName] = partitionsAndOffsets;
+                offsets[notExistsTopicName] = partitionsAndOffsets;
 
-            auto msg = client.OffsetCommit(notExistsConsumerName, offsets);
-            UNIT_ASSERT_VALUES_EQUAL(msg->Topics.size(), 2);
-            UNIT_ASSERT_VALUES_EQUAL(msg->Topics.back().Partitions.size(), minActivePartitions);
-            for (const auto& topic : msg->Topics) {
-                for (const auto& partition : topic.Partitions) {
-                   UNIT_ASSERT_VALUES_EQUAL(partition.ErrorCode, static_cast<TKafkaInt16>(EKafkaErrors::GROUP_ID_NOT_FOUND));
+                auto msg = client.OffsetCommit(notExistsConsumerName, offsets);
+                UNIT_ASSERT_VALUES_EQUAL(msg->Topics.size(), 2);
+                UNIT_ASSERT_VALUES_EQUAL(msg->Topics.back().Partitions.size(), minActivePartitions);
+                for (const auto& topic : msg->Topics) {
+                    for (const auto& partition : topic.Partitions) {
+                    UNIT_ASSERT_VALUES_EQUAL(partition.ErrorCode, static_cast<TKafkaInt16>(EKafkaErrors::GROUP_ID_NOT_FOUND));
+                    }
                 }
             }
         }
 
         {
-            // Check fetch offsets nonexistent consumer
-            std::map<TString, std::vector<i32>> topicsToPartions;
-            topicsToPartions[firstTopicName] = std::vector<i32>{0, 1};
-            auto msg = client.OffsetFetch(notExistsConsumerName, topicsToPartions);
-            UNIT_ASSERT_VALUES_EQUAL(msg->Groups.size(), 1);
-            UNIT_ASSERT_VALUES_EQUAL(msg->Groups[0].Topics.size(), 1);
-            UNIT_ASSERT_VALUES_EQUAL(msg->Groups[0].Topics[0].Partitions.size(), 2);
-            for (const auto& partition : msg->Groups[0].Topics[0].Partitions) {
-                UNIT_ASSERT_VALUES_EQUAL(partition.ErrorCode, RESOURCE_NOT_FOUND);
+            if (!testServer.KikimrServer.get()->ServerSettings->AppConfig->GetKafkaProxyConfig().GetAutoCreateTopicsEnable()) {
+                // Check fetch offsets nonexistent consumer
+                std::map<TString, std::vector<i32>> topicsToPartions;
+                topicsToPartions[firstTopicName] = std::vector<i32>{0, 1};
+                auto msg = client.OffsetFetch(notExistsConsumerName, topicsToPartions);
+                UNIT_ASSERT_VALUES_EQUAL(msg->Groups.size(), 1);
+                UNIT_ASSERT_VALUES_EQUAL(msg->Groups[0].Topics.size(), 1);
+                UNIT_ASSERT_VALUES_EQUAL(msg->Groups[0].Topics[0].Partitions.size(), 2);
+                for (const auto& partition : msg->Groups[0].Topics[0].Partitions) {
+                    UNIT_ASSERT_VALUES_EQUAL(partition.ErrorCode, RESOURCE_NOT_FOUND);
+                }
             }
         }
 
         {
-            // Check commit with nonexistent consumer
-            std::unordered_map<TString, std::vector<NKafka::TEvKafka::PartitionConsumerOffset>> offsets;
-            std::vector<NKafka::TEvKafka::PartitionConsumerOffset> partitionsAndOffsets;
-            for (ui64 i = 0; i < minActivePartitions; ++i) {
-                partitionsAndOffsets.emplace_back(i, static_cast<ui64>(recordsCount), commitedMetaData);
-            }
-            offsets[firstTopicName] = partitionsAndOffsets;
+            if (!testServer.KikimrServer.get()->ServerSettings->AppConfig->GetKafkaProxyConfig().GetAutoCreateTopicsEnable()) {
+                // Check commit with nonexistent consumer
+                std::unordered_map<TString, std::vector<NKafka::TEvKafka::PartitionConsumerOffset>> offsets;
+                std::vector<NKafka::TEvKafka::PartitionConsumerOffset> partitionsAndOffsets;
+                for (ui64 i = 0; i < minActivePartitions; ++i) {
+                    partitionsAndOffsets.emplace_back(i, static_cast<ui64>(recordsCount), commitedMetaData);
+                }
+                offsets[firstTopicName] = partitionsAndOffsets;
 
-            auto msg = client.OffsetCommit(notExistsConsumerName, offsets);
-            UNIT_ASSERT_VALUES_EQUAL(msg->Topics.size(), 1);
-            UNIT_ASSERT_VALUES_EQUAL(msg->Topics.back().Partitions.size(), minActivePartitions);
-            for (const auto& topic : msg->Topics) {
-                for (const auto& partition : topic.Partitions) {
-                   UNIT_ASSERT_VALUES_EQUAL(partition.ErrorCode, static_cast<TKafkaInt16>(EKafkaErrors::GROUP_ID_NOT_FOUND));
+                auto msg = client.OffsetCommit(notExistsConsumerName, offsets);
+                UNIT_ASSERT_VALUES_EQUAL(msg->Topics.size(), 1);
+                UNIT_ASSERT_VALUES_EQUAL(msg->Topics.back().Partitions.size(), minActivePartitions);
+                for (const auto& topic : msg->Topics) {
+                    for (const auto& partition : topic.Partitions) {
+                    UNIT_ASSERT_VALUES_EQUAL(partition.ErrorCode, static_cast<TKafkaInt16>(EKafkaErrors::GROUP_ID_NOT_FOUND));
+                    }
                 }
             }
         }

--- a/ydb/core/kafka_proxy/ut/ut_protocol.cpp
+++ b/ydb/core/kafka_proxy/ut/ut_protocol.cpp
@@ -187,6 +187,21 @@ public:
         }
 
         {
+            auto status = client.CreateUser("/Root", "user123", "UsErPassword");
+            UNIT_ASSERT_VALUES_EQUAL(status, NMsgBusProxy::MSTATUS_OK);
+
+            NYdb::NScheme::TSchemeClient schemeClient(*Driver);
+            NYdb::NScheme::TPermissions permissions("ouruser", {"ydb.generic.read", "ydb.generic.write", "ydb.generic.full"});
+
+            auto result = schemeClient
+                              .ModifyPermissions(
+                                  "/Root", NYdb::NScheme::TModifyPermissionsSettings().AddGrantPermissions(permissions))
+                              .ExtractValueSync();
+            Cerr << result.GetIssues().ToString() << "\n";
+            UNIT_ASSERT(result.IsSuccess());
+        }
+
+        {
             // Access Server Mock
             grpc::ServerBuilder builder;
             builder.AddListeningPort(accessServiceEndpoint, grpc::InsecureServerCredentials()).RegisterService(&accessServiceMock);
@@ -2493,6 +2508,24 @@ Y_UNIT_TEST_SUITE(KafkaProtocol) {
         UNIT_ASSERT_VALUES_EQUAL(metadataResponse->Brokers[0].Port, FAKE_SERVERLESS_KAFKA_PROXY_PORT);
     }
 
+    Y_UNIT_TEST(ConsumerTopicAutocreationScenario) {
+        TInsecureTestServer testServer;
+        // TInsecureTestServer testServer("1", false, true);
+        // TKafkaTestClient client(testServer.Port, "ClientA");
+        TClient client(*(testServer.KikimrServer->ServerSettings));
+
+        // NYdb::NScheme::TSchemeClient schemeClient(*testServer->Driver);
+        // NYdb::NScheme::TPermissions permissions("ouruser", {"ydb.generic.read", "ydb.generic.write", "ydb.generic.full"});
+
+        // auto result = schemeClient
+        //                     .ModifyPermissions(
+        //                         "/Root", NYdb::NScheme::TModifyPermissionsSettings().AddGrantPermissions(permissions))
+        //                     .ExtractValueSync();
+        // Cerr << result.GetIssues().ToString() << "\n";
+        // UNIT_ASSERT(result.IsSuccess());
+        // client.DeleteUser("/Root", const TModifyUserOption &options)
+
+    }
 
     Y_UNIT_TEST(DescribeGroupsScenario) {
         TInsecureTestServer testServer("1", false, true);

--- a/ydb/core/kafka_proxy/ut/ut_protocol.cpp
+++ b/ydb/core/kafka_proxy/ut/ut_protocol.cpp
@@ -1255,7 +1255,7 @@ Y_UNIT_TEST_SUITE(KafkaProtocol) {
 
     void RunBalanceScenarionTest(bool forFederation) {
         TString protocolName = "roundrobin";
-        TInsecureTestServer testServer("2");
+        TInsecureTestServer testServer("2", false, false);
 
         TString topicName = "/Root/topic-0-test";
         TString shortTopicName = "topic-0-test";
@@ -1483,7 +1483,7 @@ Y_UNIT_TEST_SUITE(KafkaProtocol) {
     Y_UNIT_TEST(BalanceScenarioCdc) {
 
         TString protocolName = "roundrobin";
-        TInsecureTestServer testServer("2");
+        TInsecureTestServer testServer("2", false, false);
 
 
         TString tableName = "/Root/table-0-test";
@@ -1728,35 +1728,27 @@ Y_UNIT_TEST_SUITE(KafkaProtocol) {
             UNIT_ASSERT_VALUES_EQUAL(msg->Groups.size(), 1);
             UNIT_ASSERT_VALUES_EQUAL(msg->Groups[0].Topics.size(), 1);
             UNIT_ASSERT_VALUES_EQUAL(msg->Groups[0].Topics[0].Partitions.size(), 2);
-            if (!testServer.KikimrServer.get()->ServerSettings->AppConfig->GetKafkaProxyConfig().GetAutoCreateTopicsEnable()) {
-                for (const auto& partition : msg->Groups[0].Topics[0].Partitions) {
-                    UNIT_ASSERT_VALUES_EQUAL(partition.ErrorCode, UNKNOWN_TOPIC_OR_PARTITION);
-                }
-            } else {
-                UNIT_ASSERT_VALUES_EQUAL(msg->Groups[0].Topics[0].Partitions[0].ErrorCode, NONE_ERROR);
-                UNIT_ASSERT_VALUES_EQUAL(msg->Groups[0].Topics[0].Partitions[1].ErrorCode, RESOURCE_NOT_FOUND);
+            for (const auto& partition : msg->Groups[0].Topics[0].Partitions) {
+                UNIT_ASSERT_VALUES_EQUAL(partition.ErrorCode, UNKNOWN_TOPIC_OR_PARTITION);
             }
         }
 
         {
             // Check commit with nonexistent topic
+            std::unordered_map<TString, std::vector<NKafka::TEvKafka::PartitionConsumerOffset>> offsets;
+            std::vector<NKafka::TEvKafka::PartitionConsumerOffset> partitionsAndOffsets;
+            for (ui64 i = 0; i < minActivePartitions; ++i) {
+                partitionsAndOffsets.emplace_back(i, static_cast<ui64>(recordsCount), commitedMetaData);
+            }
+            offsets[firstTopicName] = partitionsAndOffsets;
+            offsets[notExistsTopicName] = partitionsAndOffsets;
 
-            if (!testServer.KikimrServer.get()->ServerSettings->AppConfig->GetKafkaProxyConfig().GetAutoCreateTopicsEnable()) {
-                std::unordered_map<TString, std::vector<NKafka::TEvKafka::PartitionConsumerOffset>> offsets;
-                std::vector<NKafka::TEvKafka::PartitionConsumerOffset> partitionsAndOffsets;
-                for (ui64 i = 0; i < minActivePartitions; ++i) {
-                    partitionsAndOffsets.emplace_back(i, static_cast<ui64>(recordsCount), commitedMetaData);
-                }
-                offsets[firstTopicName] = partitionsAndOffsets;
-                offsets[notExistsTopicName] = partitionsAndOffsets;
-
-                auto msg = client.OffsetCommit(notExistsConsumerName, offsets);
-                UNIT_ASSERT_VALUES_EQUAL(msg->Topics.size(), 2);
-                UNIT_ASSERT_VALUES_EQUAL(msg->Topics.back().Partitions.size(), minActivePartitions);
-                for (const auto& topic : msg->Topics) {
-                    for (const auto& partition : topic.Partitions) {
-                    UNIT_ASSERT_VALUES_EQUAL(partition.ErrorCode, static_cast<TKafkaInt16>(EKafkaErrors::GROUP_ID_NOT_FOUND));
-                    }
+            auto msg = client.OffsetCommit(notExistsConsumerName, offsets);
+            UNIT_ASSERT_VALUES_EQUAL(msg->Topics.size(), 2);
+            UNIT_ASSERT_VALUES_EQUAL(msg->Topics.back().Partitions.size(), minActivePartitions);
+            for (const auto& topic : msg->Topics) {
+                for (const auto& partition : topic.Partitions) {
+                UNIT_ASSERT_VALUES_EQUAL(partition.ErrorCode, static_cast<TKafkaInt16>(EKafkaErrors::GROUP_ID_NOT_FOUND));
                 }
             }
         }
@@ -1769,34 +1761,26 @@ Y_UNIT_TEST_SUITE(KafkaProtocol) {
             UNIT_ASSERT_VALUES_EQUAL(msg->Groups.size(), 1);
             UNIT_ASSERT_VALUES_EQUAL(msg->Groups[0].Topics.size(), 1);
             UNIT_ASSERT_VALUES_EQUAL(msg->Groups[0].Topics[0].Partitions.size(), 2);
-            if (!testServer.KikimrServer.get()->ServerSettings->AppConfig->GetKafkaProxyConfig().GetAutoCreateTopicsEnable()) {
-                for (const auto& partition : msg->Groups[0].Topics[0].Partitions) {
-                    UNIT_ASSERT_VALUES_EQUAL(partition.ErrorCode, RESOURCE_NOT_FOUND);
-                }
-            } else {
-                for (const auto& partition : msg->Groups[0].Topics[0].Partitions) {
-                    UNIT_ASSERT_VALUES_EQUAL(partition.ErrorCode, NONE_ERROR);
-                }
+            for (const auto& partition : msg->Groups[0].Topics[0].Partitions) {
+                UNIT_ASSERT_VALUES_EQUAL(partition.ErrorCode, RESOURCE_NOT_FOUND);
             }
         }
 
         {
-            if (!testServer.KikimrServer.get()->ServerSettings->AppConfig->GetKafkaProxyConfig().GetAutoCreateTopicsEnable()) {
-                // Check commit with nonexistent consumer
-                std::unordered_map<TString, std::vector<NKafka::TEvKafka::PartitionConsumerOffset>> offsets;
-                std::vector<NKafka::TEvKafka::PartitionConsumerOffset> partitionsAndOffsets;
-                for (ui64 i = 0; i < minActivePartitions; ++i) {
-                    partitionsAndOffsets.emplace_back(i, static_cast<ui64>(recordsCount), commitedMetaData);
-                }
-                offsets[firstTopicName] = partitionsAndOffsets;
+            // Check commit with nonexistent consumer
+            std::unordered_map<TString, std::vector<NKafka::TEvKafka::PartitionConsumerOffset>> offsets;
+            std::vector<NKafka::TEvKafka::PartitionConsumerOffset> partitionsAndOffsets;
+            for (ui64 i = 0; i < minActivePartitions; ++i) {
+                partitionsAndOffsets.emplace_back(i, static_cast<ui64>(recordsCount), commitedMetaData);
+            }
+            offsets[firstTopicName] = partitionsAndOffsets;
 
-                auto msg = client.OffsetCommit(notExistsConsumerName, offsets);
-                UNIT_ASSERT_VALUES_EQUAL(msg->Topics.size(), 1);
-                UNIT_ASSERT_VALUES_EQUAL(msg->Topics.back().Partitions.size(), minActivePartitions);
-                for (const auto& topic : msg->Topics) {
-                    for (const auto& partition : topic.Partitions) {
-                    UNIT_ASSERT_VALUES_EQUAL(partition.ErrorCode, static_cast<TKafkaInt16>(EKafkaErrors::GROUP_ID_NOT_FOUND));
-                    }
+            auto msg = client.OffsetCommit(notExistsConsumerName, offsets);
+            UNIT_ASSERT_VALUES_EQUAL(msg->Topics.size(), 1);
+            UNIT_ASSERT_VALUES_EQUAL(msg->Topics.back().Partitions.size(), minActivePartitions);
+            for (const auto& topic : msg->Topics) {
+                for (const auto& partition : topic.Partitions) {
+                UNIT_ASSERT_VALUES_EQUAL(partition.ErrorCode, static_cast<TKafkaInt16>(EKafkaErrors::GROUP_ID_NOT_FOUND));
                 }
             }
         }

--- a/ydb/core/protos/config.proto
+++ b/ydb/core/protos/config.proto
@@ -2268,7 +2268,7 @@ message TKafkaProxyConfig {
     optional bool AuthViaApiKey = 11 [default = true];
     optional uint32 TransactionTimeoutMs = 12 [default = 300000]; // 5 minutes (same as in kafka)
     optional bool AutoCreateTopicsEnable = 13 [default = false];
-    optional uint32 DefaultNumOfPartitions = 14 [default = 1];
+    optional uint32 TopicCreationDefaultPartitions = 14 [default = 1];
 }
 
 message TAwsCompatibilityConfig {

--- a/ydb/core/protos/config.proto
+++ b/ydb/core/protos/config.proto
@@ -2267,6 +2267,7 @@ message TKafkaProxyConfig {
     optional bool MeteringV2Enabled = 10 [default = true];
     optional bool AuthViaApiKey = 11 [default = true];
     optional uint32 TransactionTimeoutMs = 12 [default = 300000]; // 5 minutes (same as in kafka)
+    optional bool AutoCreateTopicsEnable = 13 [default = false];
 }
 
 message TAwsCompatibilityConfig {

--- a/ydb/core/protos/config.proto
+++ b/ydb/core/protos/config.proto
@@ -2267,7 +2267,7 @@ message TKafkaProxyConfig {
     optional bool MeteringV2Enabled = 10 [default = true];
     optional bool AuthViaApiKey = 11 [default = true];
     optional uint32 TransactionTimeoutMs = 12 [default = 300000]; // 5 minutes (same as in kafka)
-    optional bool AutoCreateTopicsEnable = 13 [default = false];
+    optional bool AutoCreateTopicsEnable = 13 [default = true];
     optional uint32 TopicCreationDefaultPartitions = 14 [default = 1];
     optional bool AutoCreateConsumersEnable = 15 [default = true];
 }

--- a/ydb/core/protos/config.proto
+++ b/ydb/core/protos/config.proto
@@ -2269,7 +2269,7 @@ message TKafkaProxyConfig {
     optional uint32 TransactionTimeoutMs = 12 [default = 300000]; // 5 minutes (same as in kafka)
     optional bool AutoCreateTopicsEnable = 13 [default = false];
     optional uint32 TopicCreationDefaultPartitions = 14 [default = 1];
-    optional bool AutoCreateConsumersEnable = 15 [default = false];
+    optional bool AutoCreateConsumersEnable = 15 [default = true];
 }
 
 message TAwsCompatibilityConfig {

--- a/ydb/core/protos/config.proto
+++ b/ydb/core/protos/config.proto
@@ -2268,6 +2268,7 @@ message TKafkaProxyConfig {
     optional bool AuthViaApiKey = 11 [default = true];
     optional uint32 TransactionTimeoutMs = 12 [default = 300000]; // 5 minutes (same as in kafka)
     optional bool AutoCreateTopicsEnable = 13 [default = false];
+    optional uint32 DefaultNumOfPartitions = 14 [default = 1];
 }
 
 message TAwsCompatibilityConfig {

--- a/ydb/core/protos/config.proto
+++ b/ydb/core/protos/config.proto
@@ -2269,6 +2269,7 @@ message TKafkaProxyConfig {
     optional uint32 TransactionTimeoutMs = 12 [default = 300000]; // 5 minutes (same as in kafka)
     optional bool AutoCreateTopicsEnable = 13 [default = false];
     optional uint32 TopicCreationDefaultPartitions = 14 [default = 1];
+    optional bool AutoCreateConsumersEnable = 15 [default = false];
 }
 
 message TAwsCompatibilityConfig {


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

Add topic  autocreation when auto_create_topics_enable flag is enabled in config and consumer autocreation when auto_create_topics_enable or auto_create_consumers_enable flags are true.

### Changelog category <!-- remove all except one -->

* Not for changelog (changelog entry is not required)

### Description for reviewers <!-- (optional) description for those who read this PR -->

...
