### PR TITLE
KIKIMR-23837 Lower base table statistics propagation intervals for dedicated databases

### DIFF
--- a/ydb/core/base/appdata.cpp
+++ b/ydb/core/base/appdata.cpp
@@ -77,6 +77,7 @@ struct TAppData::TImpl {
     NKikimrConfig::TWorkloadManagerConfig WorkloadManagerConfig;
     NKikimrConfig::TQueryServiceConfig QueryServiceConfig;
     NKikimrConfig::TBridgeConfig BridgeConfig;
+    NKikimrConfig::TStatisticsConfig StatisticsConfig;
 };
 
 TAppData::TAppData(
@@ -139,6 +140,7 @@ TAppData::TAppData(
     , WorkloadManagerConfig(Impl->WorkloadManagerConfig)
     , QueryServiceConfig(Impl->QueryServiceConfig)
     , BridgeConfig(Impl->BridgeConfig)
+    , StatisticsConfig(Impl->StatisticsConfig)
     , KikimrShouldContinue(kikimrShouldContinue)
     , TracingConfigurator(MakeIntrusive<NJaegerTracing::TSamplingThrottlingConfigurator>(TimeProvider, RandomProvider))
 {}

--- a/ydb/core/base/appdata_fwd.h
+++ b/ydb/core/base/appdata_fwd.h
@@ -79,6 +79,7 @@ namespace NKikimrConfig {
     class TWorkloadManagerConfig;
     class TQueryServiceConfig;
     class TBridgeConfig;
+    class TStatisticsConfig;
 }
 
 namespace NKikimrReplication {
@@ -262,6 +263,7 @@ struct TAppData {
     NKikimrConfig::TWorkloadManagerConfig& WorkloadManagerConfig;
     NKikimrConfig::TQueryServiceConfig& QueryServiceConfig;
     NKikimrConfig::TBridgeConfig& BridgeConfig;
+    NKikimrConfig::TStatisticsConfig& StatisticsConfig;
     bool EnforceUserTokenRequirement = false;
     bool EnforceUserTokenCheckRequirement = false; // check token if it was specified
     bool AllowHugeKeyValueDeletes = true; // delete when all clients limit deletes per request

--- a/ydb/core/driver_lib/run/run.cpp
+++ b/ydb/core/driver_lib/run/run.cpp
@@ -1299,6 +1299,10 @@ void TKikimrRunner::InitializeAppData(const TKikimrRunConfig& runConfig)
         AppData->BridgeModeEnabled = true;
     }
 
+    if (runConfig.AppConfig.HasStatisticsConfig()) {
+        AppData->StatisticsConfig = runConfig.AppConfig.GetStatisticsConfig();
+    }
+
     // setup resource profiles
     AppData->ResourceProfiles = new TResourceProfiles;
     if (runConfig.AppConfig.GetBootstrapConfig().ResourceProfilesSize())

--- a/ydb/core/protos/config.proto
+++ b/ydb/core/protos/config.proto
@@ -2420,6 +2420,19 @@ message TGeneralCacheConfig {
     optional uint64 DirectInflightGlobalLimit = 3;
 }
 
+message TStatisticsConfig {
+    // Interval for base statistics send requests from SchemeShard to StatisticsAggregator.
+    // Serverless interval should be higher because many SchemeShards send data to one aggregator.
+    optional uint32 BaseStatsSendIntervalSecondsDedicated = 1 [default = 5];
+    optional uint32 BaseStatsSendIntervalSecondsServerless = 2 [default = 240];
+
+    // Interval for base statistics propagate requests from StatisticsAggregator to StatisticsService.
+    // Serverless interval should be higher because in each iteration we need to propagate more data
+    // from many SchemeShards.
+    optional uint32 BaseStatsPropagateIntervalSecondsDedicated = 3 [default = 5];
+    optional uint32 BaseStatsPropagateIntervalSecondsServerless = 4 [default = 180];
+};
+
 message TAppConfig {
     option (NMarkers.Root) = true;
     optional TActorSystemConfig ActorSystemConfig = 1;
@@ -2524,6 +2537,7 @@ message TAppConfig {
     optional TGeneralCacheConfig PortionsMetadataCache = 110;
     optional TGeneralCacheConfig ColumnDataCache = 111;
     optional TGroupedMemoryLimiterConfig DeduplicationGroupedMemoryLimiterConfig = 112;
+    optional TStatisticsConfig StatisticsConfig = 113;
 }
 
 message TYdbVersion {

--- a/ydb/core/statistics/aggregator/aggregator.cpp
+++ b/ydb/core/statistics/aggregator/aggregator.cpp
@@ -5,11 +5,11 @@
 namespace NKikimr::NStat {
 
 IActor* CreateStatisticsAggregator(const NActors::TActorId& tablet, TTabletStorageInfo* info) {
-    return new TStatisticsAggregator(tablet, info, false);
+    return new TStatisticsAggregator(tablet, info);
 }
 
 IActor* CreateStatisticsAggregatorForTests(const NActors::TActorId& tablet, TTabletStorageInfo* info) {
-    return new TStatisticsAggregator(tablet, info, true);
+    return new TStatisticsAggregator(tablet, info);
 }
 
 } // NKikimr::NStat

--- a/ydb/core/statistics/aggregator/aggregator.cpp
+++ b/ydb/core/statistics/aggregator/aggregator.cpp
@@ -8,8 +8,4 @@ IActor* CreateStatisticsAggregator(const NActors::TActorId& tablet, TTabletStora
     return new TStatisticsAggregator(tablet, info);
 }
 
-IActor* CreateStatisticsAggregatorForTests(const NActors::TActorId& tablet, TTabletStorageInfo* info) {
-    return new TStatisticsAggregator(tablet, info);
-}
-
 } // NKikimr::NStat

--- a/ydb/core/statistics/aggregator/aggregator.h
+++ b/ydb/core/statistics/aggregator/aggregator.h
@@ -7,6 +7,4 @@ namespace NKikimr::NStat {
 
 IActor* CreateStatisticsAggregator(const NActors::TActorId& tablet, TTabletStorageInfo* info);
 
-IActor* CreateStatisticsAggregatorForTests(const NActors::TActorId& tablet, TTabletStorageInfo* info);
-
 } // NKikimr::NStat

--- a/ydb/core/statistics/aggregator/aggregator_impl.h
+++ b/ydb/core/statistics/aggregator/aggregator_impl.h
@@ -130,7 +130,7 @@ private:
     void PropagateStatistics();
     void PropagateFastStatistics();
     size_t PropagatePart(const std::vector<TNodeId>& nodeIds, const std::vector<TSSId>& ssIds,
-        size_t lastSSIndex, bool useSizeLimit);
+        size_t lastSSIndex, bool useSizeLimit, ui64 cookie);
 
     void Handle(TEvStatistics::TEvAnalyze::TPtr& ev);
     void Handle(TEvTxProxySchemeCache::TEvNavigateKeySetResult::TPtr& ev);
@@ -261,6 +261,8 @@ private:
     std::unordered_set<TNodeId> FastNodes; // nodes for fast propagation
     std::unordered_set<TSSId> FastSchemeShards; // schemeshards for fast propagation
 
+    ui64 CurPropagationSeq = 0;
+    static constexpr ui64 InvalidPropagationSeq = -1; // used as request cookie for fast propagation requests
     bool PropagationInFlight = false;
     std::vector<TNodeId> PropagationNodes;
     std::vector<TSSId> PropagationSchemeShards;

--- a/ydb/core/statistics/aggregator/aggregator_impl.h
+++ b/ydb/core/statistics/aggregator/aggregator_impl.h
@@ -33,7 +33,7 @@ public:
         return NKikimrServices::TActivity::STATISTICS_AGGREGATOR;
     }
 
-    TStatisticsAggregator(const NActors::TActorId& tablet, TTabletStorageInfo* info, bool forTests);
+    TStatisticsAggregator(const NActors::TActorId& tablet, TTabletStorageInfo* info);
 
 private:
     using TSSId = ui64;
@@ -242,8 +242,10 @@ private:
     static constexpr size_t StatsOptimizeFirstNodesCount = 3; // optimize first nodes - fast propagation
     static constexpr size_t StatsSizeLimitBytes = 2 << 20; // limit for stats size in one message
 
-    TDuration PropagateInterval;
-    TDuration PropagateTimeout;
+    TDuration PropagateIntervalDedicated;
+    TDuration PropagateIntervalServerless;
+    TDuration PropagateInterval = TDuration::Seconds(5);
+
     static constexpr TDuration FastCheckInterval = TDuration::MilliSeconds(50);
 
     std::unordered_map<TSSId, TString> BaseStatistics; // schemeshard id -> serialized stats for all paths

--- a/ydb/core/statistics/service/service_impl.cpp
+++ b/ydb/core/statistics/service/service_impl.cpp
@@ -934,9 +934,10 @@ private:
     }
 
     void Handle(TEvStatistics::TEvPropagateStatistics::TPtr& ev) {
-        SA_LOG_D("EvPropagateStatistics, node id = " << SelfId().NodeId());
+        SA_LOG_D("EvPropagateStatistics, node id: " << SelfId().NodeId()
+            << " cookie: " << ev->Cookie);
 
-        Send(ev->Sender, new TEvStatistics::TEvPropagateStatisticsResponse);
+        Send(ev->Sender, new TEvStatistics::TEvPropagateStatisticsResponse, 0, ev->Cookie);
 
         IsStatisticsDisabledInSA = false;
 

--- a/ydb/core/statistics/service/ut/ut_basic_statistics.cpp
+++ b/ydb/core/statistics/service/ut/ut_basic_statistics.cpp
@@ -241,13 +241,13 @@ Y_UNIT_TEST_SUITE(BasicStatistics) {
         });
         runtime.WaitFor("TEvSchemeShardStats 2", [&]{ return secondStatsToSA; });
 
-        bool propagate = false;
+        size_t propagateCount = 0;
         auto propagateObserver = runtime.AddObserver<TEvStatistics::TEvPropagateStatistics>([&](auto&){
-            propagate = true;
+            ++propagateCount;
         });
-        runtime.WaitFor("TEvPropagateStatistics", [&]{ return propagate; });
+        runtime.WaitFor("TEvPropagateStatistics", [&]{ return propagateCount >= runtime.GetNodeCount(); });
 
-        UNIT_ASSERT(GetRowCount(runtime, 1, pathId) == expectedRowCount);
+        UNIT_ASSERT_VALUES_EQUAL(GetRowCount(runtime, 1, pathId), expectedRowCount);
     }
 
     Y_UNIT_TEST(NotFullStatisticsDatashard) {

--- a/ydb/core/statistics/service/ut/ut_basic_statistics.cpp
+++ b/ydb/core/statistics/service/ut/ut_basic_statistics.cpp
@@ -167,6 +167,41 @@ Y_UNIT_TEST_SUITE(BasicStatistics) {
         ValidateRowCount(runtime, 1, pathId2, 6);
     }
 
+    Y_UNIT_TEST(DedicatedTimeIntervals) {
+        // Test that time intervals set in config for the serverless environment are honored.
+        auto modifyConfig = [](Tests::TServerSettings& settings) {
+            settings.AppConfig->MutableStatisticsConfig()->SetBaseStatsSendIntervalSecondsDedicated(3);
+            settings.AppConfig->MutableStatisticsConfig()->SetBaseStatsPropagateIntervalSecondsDedicated(3);
+        };
+        TTestEnv env(1, 2, false, modifyConfig);
+
+        auto& runtime = *env.GetServer().GetRuntime();
+
+        CreateDatabase(env, "Database1", 1, false, "hdd1");
+        CreateDatabase(env, "Database2", 1, false, "hdd2");
+        CreateTable(env, "Database1", "Table1", 5);
+        CreateTable(env, "Database2", "Table2", 6);
+
+        auto pathId1 = ResolvePathId(runtime, "/Root/Database1/Table1");
+        auto pathId2 = ResolvePathId(runtime, "/Root/Database2/Table2");
+        ValidateRowCount(runtime, 2, pathId1, 5);
+        ValidateRowCount(runtime, 1, pathId2, 6);
+
+        size_t sendCount = 0;
+        auto sendObserver = runtime.AddObserver<TEvStatistics::TEvSchemeShardStats>([&](auto&){
+            ++sendCount;
+        });
+
+        size_t propagateCount = 0;
+        auto propagateObserver = runtime.AddObserver<TEvStatistics::TEvPropagateStatistics>([&](auto&){
+            ++propagateCount;
+        });
+
+        runtime.SimulateSleep(TDuration::Seconds(4));
+        UNIT_ASSERT_GE(sendCount, 2); // at least one event from each tenant schemeshard
+        UNIT_ASSERT_GE(propagateCount, 2); // at least one propagate event to each node
+    }
+
     Y_UNIT_TEST(Serverless) {
         TTestEnv env(1, 1);
 
@@ -335,6 +370,10 @@ Y_UNIT_TEST_SUITE(BasicStatistics) {
         runtime.SimulateSleep(TDuration::Seconds(15));
         UNIT_ASSERT_VALUES_EQUAL(sendCount, 0);
         UNIT_ASSERT_VALUES_EQUAL(propagateCount, 0);
+
+        runtime.SimulateSleep(TDuration::Seconds(20));
+        UNIT_ASSERT_VALUES_EQUAL(sendCount, 2); // events from 2 serverless schemeshards
+        UNIT_ASSERT_VALUES_EQUAL(propagateCount, 2); // SA -> node1 and node1 -> node2
     }
 }
 

--- a/ydb/core/statistics/service/ut/ut_basic_statistics.cpp
+++ b/ydb/core/statistics/service/ut/ut_basic_statistics.cpp
@@ -290,6 +290,52 @@ Y_UNIT_TEST_SUITE(BasicStatistics) {
         auto pathId = ResolvePathId(runtime, "/Root/Serverless/Table/ValueIndex/indexImplTable");
         ValidateRowCount(runtime, 1, pathId, 5);
     }
+
+    Y_UNIT_TEST(ServerlessTimeIntervals) {
+        // Test that time intervals set in config for the serverless environment are honored.
+        auto modifyConfig = [](Tests::TServerSettings& settings) {
+            settings.AppConfig->MutableStatisticsConfig()->SetBaseStatsSendIntervalSecondsServerless(30);
+            settings.AppConfig->MutableStatisticsConfig()->SetBaseStatsPropagateIntervalSecondsServerless(30);
+        };
+        TTestEnv env(1, 1, false, modifyConfig);
+
+        CreateDatabase(env, "Shared", 1, true);
+        CreateServerlessDatabase(env, "Serverless1", "/Root/Shared");
+        CreateServerlessDatabase(env, "Serverless2", "/Root/Shared");
+        CreateTable(env, "Serverless1", "Table1", 5);
+        CreateTable(env, "Serverless2", "Table2", 6);
+
+        // Wait until reported row counts are correct.
+        auto& runtime = *env.GetServer().GetRuntime();
+        auto pathId1 = ResolvePathId(runtime, "/Root/Serverless1/Table1");
+        auto pathId2 = ResolvePathId(runtime, "/Root/Serverless2/Table2");
+        ValidateRowCount(runtime, 1, pathId1, 5);
+        ValidateRowCount(runtime, 1, pathId2, 6);
+
+        // Subsequent events renewing base statistics should not be sent out for a long time.
+
+        size_t sendCount = 0;
+        auto sendObserver = runtime.AddObserver<TEvStatistics::TEvSchemeShardStats>([&](auto& ev){
+            // Count only events from serverless schemeshards.
+            NKikimrStat::TSchemeShardStats stats;
+            UNIT_ASSERT(stats.ParseFromString(ev->Get()->Record.GetStats()));
+            if (stats.GetEntries().size() == 1) {
+                auto ownerId = stats.GetEntries()[0].GetPathId().GetOwnerId();
+                if (ownerId == pathId1.OwnerId || ownerId == pathId2.OwnerId) {
+                    ++sendCount;
+                }
+            }
+        });
+
+        size_t propagateCount = 0;
+        auto propagateObserver = runtime.AddObserver<TEvStatistics::TEvPropagateStatistics>([&](auto&){
+            ++propagateCount;
+        });
+
+        runtime.SimulateSleep(TDuration::Seconds(15));
+        UNIT_ASSERT_VALUES_EQUAL(sendCount, 0);
+        UNIT_ASSERT_VALUES_EQUAL(propagateCount, 0);
+    }
 }
 
 } // NSysView

--- a/ydb/core/statistics/ut_common/ut_common.cpp
+++ b/ydb/core/statistics/ut_common/ut_common.cpp
@@ -37,6 +37,8 @@ TTestEnv::TTestEnv(ui32 staticNodes, ui32 dynamicNodes, bool useRealThreads)
     Settings->AddStoragePoolType("hdd1");
     Settings->AddStoragePoolType("hdd2");
     Settings->SetColumnShardAlterObjectEnabled(true);
+    Settings->AppConfig->MutableStatisticsConfig()->SetBaseStatsSendIntervalSecondsServerless(6);
+    Settings->AppConfig->MutableStatisticsConfig()->SetBaseStatsPropagateIntervalSecondsServerless(6);
 
     NKikimrConfig::TFeatureFlags featureFlags;
     featureFlags.SetEnableStatistics(true);

--- a/ydb/core/statistics/ut_common/ut_common.cpp
+++ b/ydb/core/statistics/ut_common/ut_common.cpp
@@ -23,7 +23,8 @@ using namespace NYdb::NScheme;
 namespace NKikimr {
 namespace NStat {
 
-TTestEnv::TTestEnv(ui32 staticNodes, ui32 dynamicNodes, bool useRealThreads)
+TTestEnv::TTestEnv(ui32 staticNodes, ui32 dynamicNodes, bool useRealThreads,
+    std::function<void(Tests::TServerSettings&)> modifySettings)
     : CSController(NYDBTest::TControllers::RegisterCSControllerGuard<NYDBTest::NColumnShard::TController>())
 {
     auto mbusPort = PortManager.GetPort();
@@ -44,6 +45,8 @@ TTestEnv::TTestEnv(ui32 staticNodes, ui32 dynamicNodes, bool useRealThreads)
     featureFlags.SetEnableStatistics(true);
     featureFlags.SetEnableColumnStatistics(true);
     Settings->SetFeatureFlags(featureFlags);
+
+    modifySettings(*Settings);
 
     Server = new Tests::TServer(*Settings);
     Server->EnableGRpc(grpcPort);

--- a/ydb/core/statistics/ut_common/ut_common.h
+++ b/ydb/core/statistics/ut_common/ut_common.h
@@ -18,7 +18,8 @@ static constexpr ui32 ColumnTableRowsNumber = 1000;
 
 class TTestEnv {
 public:
-    TTestEnv(ui32 staticNodes = 1, ui32 dynamicNodes = 1, bool useRealThreads = false);
+    TTestEnv(ui32 staticNodes = 1, ui32 dynamicNodes = 1, bool useRealThreads = false,
+        std::function<void(Tests::TServerSettings&)> modifySettings = [](Tests::TServerSettings&) {});
     ~TTestEnv();
 
     Tests::TServer& GetServer() const {

--- a/ydb/core/testlib/test_client.cpp
+++ b/ydb/core/testlib/test_client.cpp
@@ -561,6 +561,7 @@ namespace Tests {
             if (appData.BridgeConfig.PilesSize() > 0) {
                 appData.BridgeModeEnabled = true;
             }
+            appData.StatisticsConfig.MergeFrom(Settings->AppConfig->GetStatisticsConfig());
 
             appData.DynamicNameserviceConfig = new TDynamicNameserviceConfig;
             auto dnConfig = appData.DynamicNameserviceConfig;

--- a/ydb/core/testlib/test_client.cpp
+++ b/ydb/core/testlib/test_client.cpp
@@ -1137,7 +1137,7 @@ namespace Tests {
                 TMailboxType::Revolving, appData.SystemPoolId));
         localConfig.TabletClassInfo[TTabletTypes::StatisticsAggregator] =
             TLocalConfig::TTabletClassInfo(new TTabletSetupInfo(
-                &NStat::CreateStatisticsAggregatorForTests, TMailboxType::Revolving, appData.UserPoolId,
+                &NStat::CreateStatisticsAggregator, TMailboxType::Revolving, appData.UserPoolId,
                 TMailboxType::Revolving, appData.SystemPoolId));
     }
 

--- a/ydb/core/tx/schemeshard/schemeshard_impl.cpp
+++ b/ydb/core/tx/schemeshard/schemeshard_impl.cpp
@@ -4961,6 +4961,9 @@ void TSchemeShard::OnActivateExecutor(const TActorContext &ctx) {
     MaxCdcInitialScanShardsInFlight = appData->SchemeShardConfig.GetMaxCdcInitialScanShardsInFlight();
     MaxRestoreBuildIndexShardsInFlight = appData->SchemeShardConfig.GetMaxRestoreBuildIndexShardsInFlight();
 
+    SendStatsIntervalSecondsDedicated = appData->StatisticsConfig.GetBaseStatsSendIntervalSecondsDedicated();
+    SendStatsIntervalSecondsServerless = appData->StatisticsConfig.GetBaseStatsSendIntervalSecondsServerless();
+
     ConfigureBackgroundCleaningQueue(appData->BackgroundCleaningConfig, ctx);
     ConfigureShredManager(appData->ShredConfig);
     ConfigureExternalSources(appData->QueryServiceConfig, ctx);
@@ -8264,8 +8267,17 @@ TDuration TSchemeShard::SendBaseStatsToSA() {
         << ", path count: " << count
         << ", at schemeshard: " << TabletID());
 
-    return TDuration::Seconds(SendStatsIntervalMinSeconds
-        + RandomNumber<ui64>(SendStatsIntervalMaxSeconds - SendStatsIntervalMinSeconds));
+    if (IsServerlessDomain(SubDomains.at(RootPathId()))) {
+        // In serverless subdomains several schemeshards send stats to a single SA
+        // so we use a bigger interval with jitter.
+        const auto max = TDuration::Seconds(SendStatsIntervalSecondsServerless);
+        const auto min = max * 3 / 4;
+        return min + TDuration::MilliSeconds(
+            RandomNumber<ui64>(max.MilliSeconds() - min.MilliSeconds()));
+    } else {
+        // Dedicated subdomains can use a smaller interval.
+        return TDuration::Seconds(SendStatsIntervalSecondsDedicated);
+    }
 }
 
 THolder<TShredManager> TSchemeShard::CreateShredManager(const NKikimrConfig::TDataErasureConfig& config) {

--- a/ydb/core/tx/schemeshard/schemeshard_impl.h
+++ b/ydb/core/tx/schemeshard/schemeshard_impl.h
@@ -1610,8 +1610,8 @@ public:
     // statistics
     TTabletId StatisticsAggregatorId;
     TActorId SAPipeClientId;
-    static constexpr ui64 SendStatsIntervalMinSeconds = 180;
-    static constexpr ui64 SendStatsIntervalMaxSeconds = 240;
+    ui64 SendStatsIntervalSecondsDedicated = 5;
+    ui64 SendStatsIntervalSecondsServerless = 240;
 
     void Handle(TEvTxProxySchemeCache::TEvNavigateKeySetResult::TPtr&, const TActorContext& ctx);
     void Handle(TEvPrivate::TEvSendBaseStatsToSA::TPtr& ev, const TActorContext& ctx);


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

Lower base table statistics propagation intervals for dedicated databases.

### Changelog category <!-- remove all except one -->

* Improvement

### Description for reviewers <!-- (optional) description for those who read this PR -->

1. Add `statistics_config` config section
2. Detect in SchemeShard if this instance serves serverless subdomain and adjust statistics send interval accordingly
3. StatisticsAggregator: use cookies to disambiguate PropagateStatistics responses
4. Switch to serverless propagation interval in StatisticsAggregator if this instance serves more than one SchemeShard (i.e. is in the shared database).
