### PR TITLE
Retain RACE responses in bridge proxy

### DIFF
--- a/ydb/core/base/blobstorage.h
+++ b/ydb/core/base/blobstorage.h
@@ -982,6 +982,17 @@ struct TEvBlobStorage {
         std::optional<ui32> ForceGroupGeneration;
     };
 
+    struct TEvResultCommon {
+        NKikimrProto::EReplyStatus Status;
+        TString ErrorReason;
+        std::shared_ptr<TExecutionRelay> ExecutionRelay;
+        ui32 RacingGeneration = 0;
+
+        TEvResultCommon(NKikimrProto::EReplyStatus status)
+            : Status(status)
+        {}
+    };
+
     struct TEvPut
         : TEventLocal<TEvPut, EvPut>
         , TEvRequestCommon
@@ -1097,21 +1108,21 @@ struct TEvBlobStorage {
             TGroupId groupId);
     };
 
-    struct TEvPutResult : public TEventLocal<TEvPutResult, EvPutResult> {
-        NKikimrProto::EReplyStatus Status;
+    struct TEvPutResult
+        : TEventLocal<TEvPutResult, EvPutResult>
+        , TEvResultCommon
+    {
         const TLogoBlobID Id;
         const TStorageStatusFlags StatusFlags;
         const ui32 GroupId;
         const float ApproximateFreeSpaceShare; // 0.f has special meaning 'data could not be obtained'
-        TString ErrorReason;
         bool WrittenBeyondBarrier = false; // was this blob written beyond the barrier?
         mutable NLWTrace::TOrbit Orbit;
-        std::shared_ptr<TExecutionRelay> ExecutionRelay;
         const TString StorageId;
 
         TEvPutResult(NKikimrProto::EReplyStatus status, const TLogoBlobID &id, const TStorageStatusFlags statusFlags,
                 TGroupId groupId, float approximateFreeSpaceShare, const TString& storageId = Default<TString>())
-            : Status(status)
+            : TEvResultCommon(status)
             , Id(id)
             , StatusFlags(statusFlags)
             , GroupId(groupId.GetRawId())
@@ -1121,7 +1132,7 @@ struct TEvBlobStorage {
 
         TEvPutResult(NKikimrProto::EReplyStatus status, const TLogoBlobID &id, const TStorageStatusFlags statusFlags,
                 ui32 groupId, float approximateFreeSpaceShare, const TString& storageId = Default<TString>())
-            : Status(status)
+            : TEvResultCommon(status)
             , Id(id)
             , StatusFlags(statusFlags)
             , GroupId(groupId)
@@ -1332,7 +1343,10 @@ struct TEvBlobStorage {
         }
     };
 
-    struct TEvGetResult : public TEventLocal<TEvGetResult, EvGetResult> {
+    struct TEvGetResult
+        : TEventLocal<TEvGetResult, EvGetResult>
+        , TEvResultCommon
+    {
         struct TPartMapItem {
             ui32 DiskOrderNumber;
             ui32 PartIdRequested;
@@ -1359,37 +1373,33 @@ struct TEvBlobStorage {
             {}
         };
 
-        NKikimrProto::EReplyStatus Status;
-
         // todo: replace with queue-like thing
         ui32 ResponseSz;
         TArrayHolder<TResponse> Responses;
         const ui32 GroupId;
         ui32 BlockedGeneration = 0; // valid only for requests with non-zero TabletId and true AcquireBlockedGeneration.
         TString DebugInfo;
-        TString ErrorReason;
         mutable NLWTrace::TOrbit Orbit;
-        std::shared_ptr<TExecutionRelay> ExecutionRelay;
 
         // to measure blobstorage->client hop
         TInstant Sent;
 
         TEvGetResult(NKikimrProto::EReplyStatus status, ui32 sz, TGroupId groupId)
-            : Status(status)
+            : TEvResultCommon(status)
             , ResponseSz(sz)
             , Responses(sz == 0 ? nullptr : new TResponse[sz])
             , GroupId(groupId.GetRawId())
         {}
 
         TEvGetResult(NKikimrProto::EReplyStatus status, ui32 sz, ui32 groupId)
-            : Status(status)
+            : TEvResultCommon(status)
             , ResponseSz(sz)
             , Responses(sz == 0 ? nullptr : new TResponse[sz])
             , GroupId(groupId)
         {}
 
         TEvGetResult(NKikimrProto::EReplyStatus status, ui32 sz, TArrayHolder<TResponse> responses, TGroupId groupId)
-            : Status(status)
+            : TEvResultCommon(status)
             , ResponseSz(sz)
             , Responses(std::move(responses))
             , GroupId(groupId.GetRawId())
@@ -1494,14 +1504,15 @@ struct TEvBlobStorage {
             NKikimrProto::EReplyStatus status, const TString& errorReason, TGroupId groupId);
     };
 
-    struct TEvCheckIntegrityResult : public TEventLocal<TEvCheckIntegrityResult, EvCheckIntegrityResult> {
+    struct TEvCheckIntegrityResult
+        : TEventLocal<TEvCheckIntegrityResult, EvCheckIntegrityResult>
+        , TEvResultCommon
+    {
         TLogoBlobID Id;
-        NKikimrProto::EReplyStatus Status;
-        // OK - we were able to check the integrity
+
+        // Status=OK - we were able to check the integrity
         // any other status - some problem prevents the check, ErrorReason contains detailed info
         // for example if the group is disintegrated, the status is ERROR
-
-        TString ErrorReason;
 
         enum EPlacementStatus {
             PS_OK = 1,                      // blob parts are placed according to fail model
@@ -1554,7 +1565,7 @@ struct TEvBlobStorage {
         std::shared_ptr<TExecutionRelay> ExecutionRelay;
 
         TEvCheckIntegrityResult(NKikimrProto::EReplyStatus status)
-            : Status(status)
+            : TEvResultCommon(status)
         {}
 
         TString Print(bool /*isFull*/) const {
@@ -1614,15 +1625,15 @@ struct TEvBlobStorage {
             TGroupId groupId);
     };
 
-    struct TEvGetBlockResult : public TEventLocal<TEvGetBlockResult, EvGetBlockResult> {
-        NKikimrProto::EReplyStatus Status;
+    struct TEvGetBlockResult
+        : TEventLocal<TEvGetBlockResult, EvGetBlockResult>
+        , TEvResultCommon
+    {
         ui64 TabletId;
         ui32 BlockedGeneration;
-        TString ErrorReason;
-        std::shared_ptr<TExecutionRelay> ExecutionRelay;
 
         TEvGetBlockResult(NKikimrProto::EReplyStatus status, ui64 tabletId, ui32 blockedGeneration)
-            : Status(status)
+            : TEvResultCommon(status)
             , TabletId(tabletId)
             , BlockedGeneration(blockedGeneration)
         {}
@@ -1699,13 +1710,12 @@ struct TEvBlobStorage {
             TGroupId groupId);
     };
 
-    struct TEvBlockResult : public TEventLocal<TEvBlockResult, EvBlockResult> {
-        NKikimrProto::EReplyStatus Status;
-        TString ErrorReason;
-        std::shared_ptr<TExecutionRelay> ExecutionRelay;
-
+    struct TEvBlockResult
+        : TEventLocal<TEvBlockResult, EvBlockResult>
+        , TEvResultCommon
+    {
         TEvBlockResult(NKikimrProto::EReplyStatus status)
-            : Status(status)
+            : TEvResultCommon(status)
         {}
 
         TString Print(bool isFull) const {
@@ -1915,19 +1925,19 @@ struct TEvBlobStorage {
                 const TString& errorReason, TGroupId groupId);
     };
 
-    struct TEvPatchResult : public TEventLocal<TEvPatchResult, EvPatchResult> {
-        NKikimrProto::EReplyStatus Status;
+    struct TEvPatchResult
+        : TEventLocal<TEvPatchResult, EvPatchResult>
+        , TEvResultCommon
+    {
         const TLogoBlobID Id;
         const TStorageStatusFlags StatusFlags;
         const TGroupId GroupId;
         const float ApproximateFreeSpaceShare; // 0.f has special meaning 'data could not be obtained'
-        TString ErrorReason;
         mutable NLWTrace::TOrbit Orbit;
-        std::shared_ptr<TExecutionRelay> ExecutionRelay;
 
         TEvPatchResult(NKikimrProto::EReplyStatus status, const TLogoBlobID &id, TStorageStatusFlags statusFlags,
                 TGroupId groupId, float approximateFreeSpaceShare)
-            : Status(status)
+            : TEvResultCommon(status)
             , Id(id)
             , StatusFlags(statusFlags)
             , GroupId(groupId)
@@ -2109,18 +2119,17 @@ struct TEvBlobStorage {
             TGroupId groupId);
     };
 
-    struct TEvDiscoverResult : public TEventLocal<TEvDiscoverResult, EvDiscoverResult> {
-        NKikimrProto::EReplyStatus Status;
-
+    struct TEvDiscoverResult
+        : TEventLocal<TEvDiscoverResult, EvDiscoverResult>
+        , TEvResultCommon
+    {
         TLogoBlobID Id;
         ui32 MinGeneration;
         TString Buffer;
         ui32 BlockedGeneration;
-        TString ErrorReason;
-        std::shared_ptr<TExecutionRelay> ExecutionRelay;
 
         TEvDiscoverResult(NKikimrProto::EReplyStatus status, ui32 minGeneration, ui32 blockedGeneration)
-            : Status(status)
+            : TEvResultCommon(status)
             , MinGeneration(minGeneration)
             , BlockedGeneration(blockedGeneration)
         {
@@ -2128,7 +2137,7 @@ struct TEvBlobStorage {
         }
 
         TEvDiscoverResult(const TLogoBlobID &id, ui32 minGeneration, const TString &buffer)
-            : Status(NKikimrProto::OK)
+            : TEvResultCommon(NKikimrProto::OK)
             , Id(id)
             , MinGeneration(minGeneration)
             , Buffer(buffer)
@@ -2136,7 +2145,7 @@ struct TEvBlobStorage {
         {}
 
         TEvDiscoverResult(const TLogoBlobID &id, ui32 minGeneration, const TString &buffer, ui32 blockedGeneration)
-            : Status(NKikimrProto::OK)
+            : TEvResultCommon(NKikimrProto::OK)
             , Id(id)
             , MinGeneration(minGeneration)
             , Buffer(buffer)
@@ -2228,7 +2237,10 @@ struct TEvBlobStorage {
             TGroupId groupId);
     };
 
-    struct TEvRangeResult : public TEventLocal<TEvRangeResult, EvRangeResult> {
+    struct TEvRangeResult
+        : TEventLocal<TEvRangeResult, EvRangeResult>
+        , TEvResultCommon
+    {
         struct TResponse {
             TLogoBlobID Id;
             TString Buffer;
@@ -2246,24 +2258,21 @@ struct TEvBlobStorage {
             {}
         };
 
-        NKikimrProto::EReplyStatus Status;
         TLogoBlobID From;
         TLogoBlobID To;
 
         TVector<TResponse> Responses;
         const ui32 GroupId;
-        TString ErrorReason;
-        std::shared_ptr<TExecutionRelay> ExecutionRelay;
 
         TEvRangeResult(NKikimrProto::EReplyStatus status, const TLogoBlobID &from, const TLogoBlobID &to, TGroupId groupId)
-            : Status(status)
+            : TEvResultCommon(status)
             , From(from)
             , To(to)
             , GroupId(groupId.GetRawId())
         {}
 
         TEvRangeResult(NKikimrProto::EReplyStatus status, const TLogoBlobID &from, const TLogoBlobID &to, ui32 groupId)
-            : Status(status)
+            : TEvResultCommon(status)
             , From(from)
             , To(to)
             , GroupId(groupId)
@@ -2446,19 +2455,18 @@ struct TEvBlobStorage {
             TGroupId groupId);
     };
 
-    struct TEvCollectGarbageResult : public TEventLocal<TEvCollectGarbageResult, EvCollectGarbageResult> {
-        NKikimrProto::EReplyStatus Status;
-
+    struct TEvCollectGarbageResult
+        : TEventLocal<TEvCollectGarbageResult, EvCollectGarbageResult>
+        , TEvResultCommon
+    {
         ui64 TabletId;
         ui32 RecordGeneration;
         ui32 PerGenerationCounter;
         ui32 Channel;
-        TString ErrorReason;
-        std::shared_ptr<TExecutionRelay> ExecutionRelay;
 
         TEvCollectGarbageResult(NKikimrProto::EReplyStatus status, ui64 tabletId,
                 ui32 recordGeneration, ui32 perGenerationCounter, ui32 channel)
-            : Status(status)
+            : TEvResultCommon(status)
             , TabletId(tabletId)
             , RecordGeneration(recordGeneration)
             , PerGenerationCounter(perGenerationCounter)
@@ -2521,20 +2529,15 @@ struct TEvBlobStorage {
             TGroupId groupId);
     };
 
-    struct TEvStatusResult : public TEventLocal<TEvStatusResult, EvStatusResult> {
-        NKikimrProto::EReplyStatus Status;
+    struct TEvStatusResult
+        : TEventLocal<TEvStatusResult, EvStatusResult>
+        , TEvResultCommon
+    {
         TStorageStatusFlags StatusFlags;
         float ApproximateFreeSpaceShare = 0.0f; // zero means absence of correct data
-        TString ErrorReason;
-        std::shared_ptr<TExecutionRelay> ExecutionRelay;
 
-        TEvStatusResult(NKikimrProto::EReplyStatus status, TStorageStatusFlags statusFlags)
-            : Status(status)
-            , StatusFlags(statusFlags)
-        {}
-
-        TEvStatusResult(NKikimrProto::EReplyStatus status, TStorageStatusFlags statusFlags, float approximateFreeSpaceShare)
-            : Status(status)
+        TEvStatusResult(NKikimrProto::EReplyStatus status, TStorageStatusFlags statusFlags, float approximateFreeSpaceShare = 0.0f)
+            : TEvResultCommon(status)
             , StatusFlags(statusFlags)
             , ApproximateFreeSpaceShare(approximateFreeSpaceShare)
         {}
@@ -2615,7 +2618,10 @@ struct TEvBlobStorage {
             TGroupId groupId);
     };
 
-    struct TEvAssimilateResult : TEventLocal<TEvAssimilateResult, EvAssimilateResult> {
+    struct TEvAssimilateResult
+        : TEventLocal<TEvAssimilateResult, EvAssimilateResult>
+        , TEvResultCommon
+    {
         struct TBlock {
             ui64 TabletId = 0;
             ui32 BlockedGeneration = 0;
@@ -2700,17 +2706,15 @@ struct TEvBlobStorage {
             }
         };
 
-        NKikimrProto::EReplyStatus Status;
-        TString ErrorReason;
         std::deque<TBlock> Blocks;
         std::deque<TBarrier> Barriers;
         std::deque<TBlob> Blobs;
-        std::shared_ptr<TExecutionRelay> ExecutionRelay;
 
         TEvAssimilateResult(NKikimrProto::EReplyStatus status, TString errorReason = {})
-            : Status(status)
-            , ErrorReason(std::move(errorReason))
-        {}
+            : TEvResultCommon(status)
+        {
+            ErrorReason = std::move(errorReason);
+        }
 
         TString Print(bool isFull) const {
             TStringStream str;

--- a/ydb/core/blobstorage/backpressure/ut_client/skeleton_front_mock.h
+++ b/ydb/core/blobstorage/backpressure/ut_client/skeleton_front_mock.h
@@ -62,7 +62,7 @@ public:
         auto& record = ev->Get()->Record;
 
         if (!Ready) {
-            Reply(*ev, new TEvBlobStorage::TEvVStatusResult(NKikimrProto::NOTREADY, record.GetVDiskID()));
+            Reply(*ev, new TEvBlobStorage::TEvVStatusResult(NKikimrProto::NOTREADY, VDiskIDFromVDiskID(record.GetVDiskID())));
             if (record.GetNotifyIfNotReady()) {
                 Notify.insert(ev->Sender);
             }

--- a/ydb/core/blobstorage/base/blobstorage_events.h
+++ b/ydb/core/blobstorage/base/blobstorage_events.h
@@ -312,12 +312,12 @@ namespace NKikimr {
             }
         }
 
-        TEvVStatusResult(NKikimrProto::EReplyStatus status, const NKikimrBlobStorage::TVDiskID &vdisk) {
+        TEvVStatusResult(NKikimrProto::EReplyStatus status, const TVDiskID &vdisk) {
             Y_ABORT_UNLESS(status != NKikimrProto::OK);
             Record.SetStatus(status);
             Record.SetJoinedGroup(false);
             Record.SetReplicated(false);
-            Record.MutableVDiskID()->CopyFrom(vdisk);
+            VDiskIDFromVDiskID(vdisk, Record.MutableVDiskID());
         }
     };
 

--- a/ydb/core/blobstorage/bridge/proxy/bridge_proxy.cpp
+++ b/ydb/core/blobstorage/bridge/proxy/bridge_proxy.cpp
@@ -35,11 +35,13 @@ namespace NKikimr {
             TActorId Sender;
             ui64 Cookie;
             TIntrusivePtr<TBlobStorageGroupInfo> Info;
+            std::unique_ptr<IEventBase> OriginalRequest;
             ui32 ResponsesPending = 0;
             TStorageStatusFlags StatusFlags;
             float ApproximateFreeSpaceShare = 0;
             std::unique_ptr<IEventBase> CombinedResponse;
             bool Finished = false;
+            THashSet<ui64> CookiesInFlight;
 
             struct TDiscoverState {
                 TLogoBlobID Id;
@@ -85,7 +87,7 @@ namespace NKikimr {
             TState State;
 
             template<typename TEvRequest>
-            TRequest(TActorId sender, ui64 cookie, const TEvRequest& request, TIntrusivePtr<TBlobStorageGroupInfo> info)
+            TRequest(TActorId sender, ui64 cookie, std::unique_ptr<TEvRequest>&& request, TIntrusivePtr<TBlobStorageGroupInfo> info)
                 : Sender(sender)
                 , Cookie(cookie)
                 , Info(std::move(info))
@@ -93,29 +95,32 @@ namespace NKikimr {
                 Y_ABORT_UNLESS(Info);
                 Y_ABORT_UNLESS(Info->Group);
                 Y_ABORT_UNLESS(Info->Group->HasBridgeGroupState());
+
                 if constexpr (std::is_same_v<TEvRequest, TEvBlobStorage::TEvGet>) {
-                    Y_ABORT_UNLESS(!request.PhantomCheck);
+                    Y_ABORT_UNLESS(!request->PhantomCheck);
                     State = TGetState{
-                        .GetHandleClass = request.GetHandleClass,
-                        .NumResponses = request.QuerySize,
-                        .IsIndexOnly = request.IsIndexOnly,
-                        .MustRestoreFirst = request.MustRestoreFirst,
-                        .RestoreQueue{request.QuerySize},
-                        .RestoreIndex = request.QuerySize,
+                        .GetHandleClass = request->GetHandleClass,
+                        .NumResponses = request->QuerySize,
+                        .IsIndexOnly = request->IsIndexOnly,
+                        .MustRestoreFirst = request->MustRestoreFirst,
+                        .RestoreQueue{request->QuerySize},
+                        .RestoreIndex = request->QuerySize,
                     };
                 } else if constexpr (std::is_same_v<TEvRequest, TEvBlobStorage::TEvRange>) {
                     State = TRangeState{
-                        .From = request.From,
-                        .To = request.To,
+                        .From = request->From,
+                        .To = request->To,
                     };
                 } else if constexpr (std::is_same_v<TEvRequest, TEvBlobStorage::TEvDiscover>) {
                     State = TDiscoverState{
-                        .MinGeneration = request.MinGeneration,
+                        .MinGeneration = request->MinGeneration,
                     };
                 } else if constexpr (std::is_same_v<TEvRequest, TEvBlobStorage::TEvPut>) {
                     State = TPutState{
                     };
                 }
+
+                OriginalRequest = std::move(request);
             }
 
             template<typename TEvent, typename... TArgs>
@@ -497,6 +502,7 @@ namespace NKikimr {
         TBridgeInfo::TPtr BridgeInfo;
 
         std::deque<std::unique_ptr<IEventHandle>> PendingQ;
+        std::map<ui32, std::deque<std::unique_ptr<IEventHandle>>> PendingByGeneration;
 
     public:
         TBridgedBlobStorageProxyActor(TIntrusivePtr<TBlobStorageGroupInfo> info)
@@ -524,12 +530,12 @@ namespace NKikimr {
         void HandleProxyRequest(TAutoPtr<TEventHandle<TEvent>>& ev) {
             Y_ABORT_UNLESS(BridgeInfo);
 
-            auto request = std::make_shared<TRequest>(ev->Sender, ev->Cookie, *ev->Get(), Info);
-
             std::unique_ptr<TEvent> evPtr(ev->Release().Release());
+            const TEvent& originalRequest = *evPtr;
+            auto request = std::make_shared<TRequest>(ev->Sender, ev->Cookie, std::move(evPtr), Info);
 
             STLOG(PRI_DEBUG, BS_PROXY_BRIDGE, BPB00, "new request", (RequestId, request->MakeRequestId()),
-                (GroupId, GroupId), (Request, evPtr->ToString()));
+                (GroupId, GroupId), (Request, originalRequest.ToString()));
 
             Y_ABORT_UNLESS(Info->Group);
             const auto& state = Info->Group->GetBridgeGroupState();
@@ -542,7 +548,7 @@ namespace NKikimr {
 
                 // check the sync state for this group
                 const auto& groupPileInfo = state.GetPile(i);
-                if (auto eventToSend = PrepareEvent(groupPileInfo, evPtr, i + 1 == state.PileSize())) {
+                if (auto eventToSend = PrepareEvent(groupPileInfo, originalRequest)) {
                     SendQuery(request, pile->BridgePileId, std::move(eventToSend));
                 }
             }
@@ -564,6 +570,8 @@ namespace NKikimr {
             const auto [it, inserted] = RequestsInFlight.try_emplace(cookie, request, BridgeInfo,
                 BridgeInfo->GetPile(bridgePileId), groupId);
             Y_DEBUG_ABORT_UNLESS(inserted);
+            const auto [it1, inserted1] = request->CookiesInFlight.insert(cookie);
+            Y_DEBUG_ABORT_UNLESS(inserted1);
 
             // send event
             SendToBSProxy(SelfId(), groupId, ev.release(), cookie);
@@ -571,20 +579,19 @@ namespace NKikimr {
         }
 
         template<typename TEvent>
-        std::unique_ptr<IEventBase> PrepareEvent(const NKikimrBridge::TGroupState::TPile& pile,
-                std::unique_ptr<TEvent>& ev, bool last) {
+        std::unique_ptr<IEventBase> PrepareEvent(const NKikimrBridge::TGroupState::TPile& pile, const TEvent& ev) {
             std::unique_ptr<TEvent> res;
 
             switch (pile.GetStage()) {
                 case NKikimrBridge::TGroupState::WRITE_KEEP:
                     if constexpr (std::is_same_v<TEvent, TEvBlobStorage::TEvCollectGarbage>) {
-                        if (!ev->Keep) {
+                        if (!ev.Keep) {
                             return nullptr;
                         }
                         // allow only keep flags to be sent
-                        res = std::make_unique<TEvBlobStorage::TEvCollectGarbage>(ev->TabletId, ev->RecordGeneration,
-                            ev->PerGenerationCounter, ev->Channel, false, 0, 0, ev->Keep.Release(), nullptr, ev->Deadline,
-                            true, false, false);
+                        res = std::make_unique<TEvBlobStorage::TEvCollectGarbage>(ev.TabletId, ev.RecordGeneration,
+                            ev.PerGenerationCounter, ev.Channel, false, 0, 0, new TVector<TLogoBlobID>(*ev.Keep),
+                            nullptr, ev.Deadline, true, false, false);
                     }
                     [[fallthrough]];
                 case NKikimrBridge::TGroupState::WRITE_KEEP_BARRIER_DONOTKEEP:
@@ -608,25 +615,20 @@ namespace NKikimr {
             }
 
             if (!res) {
-                res.reset(last ? ev.release() : new TEvent(TEvBlobStorage::CloneEventPolicy, *ev));
+                res = std::make_unique<TEvent>(TEvBlobStorage::CloneEventPolicy, ev);
             }
-            res->ForceGroupGeneration.emplace(pile.GetGroupGeneration());
             return res;
         }
 
         template<typename TEvent>
         void HandleProxyResult(TAutoPtr<TEventHandle<TEvent>>& ev) {
-            ////////////////////////////////////////////////////////////////////////////////////////////////////////////
-            // TODO(alexvru): handle RACE properly!
-            ////////////////////////////////////////////////////////////////////////////////////////////////////////////
-
             const auto it = RequestsInFlight.find(ev->Cookie);
             if (it == RequestsInFlight.end()) {
                 return; // request has already been completed
             }
             auto& item = it->second;
             auto& pile = *item.Pile;
-            auto& request = item.Request;
+            std::shared_ptr<TRequest> request = item.Request;
 
             const bool isError = ev->Get()->Status != NKikimrProto::OK
                 && ev->Get()->Status != NKikimrProto::NODATA
@@ -657,22 +659,61 @@ namespace NKikimr {
                     }
                 }
 
-                std::unique_ptr<TEvent> ptr(ev->Release().Release());
-                if (auto response = request->ProcessResponse(*this, std::move(ptr), pile)) {
-                    STLOG(PRI_DEBUG, BS_PROXY_BRIDGE, BPB01, "request finished", (RequestId, request->MakeRequestId()),
-                        (Response, response->ToString()));
-                    Send(request->Sender, response.release(), 0, request->Cookie);
+                if (msg->Status == NKikimrProto::RACE) {
+                    // route repeated request through node warden to ensure group info propagation before request gets restarted
+                    auto& ev = request->OriginalRequest;
+                    auto *common = dynamic_cast<TEvBlobStorage::TEvRequestCommon*>(ev.get());
+                    Y_ABORT_UNLESS(common);
+                    ++common->RestartCounter;
+                    Y_DEBUG_ABORT_UNLESS(common->RestartCounter < 100); // too often restarts do not make sense
+                    auto handle = std::make_unique<IEventHandle>(SelfId(), request->Sender, ev.release(), 0, request->Cookie);
+                    if (Info->Group->GetBridgeGroupState().GetPile(pile.BridgePileId.GetPileIndex()).GetGroupGeneration() <
+                            msg->RacingGeneration) {
+                        PendingByGeneration[Info->GroupGeneration + 1].push_back(std::move(handle));
+                    } else {
+                        TActivationContext::Send(handle.release());
+                    }
                     request->Finished = true;
+                } else {
+                    std::unique_ptr<TEvent> ptr(ev->Release().Release());
+                    if (auto response = request->ProcessResponse(*this, std::move(ptr), pile)) {
+                        STLOG(PRI_DEBUG, BS_PROXY_BRIDGE, BPB01, "request finished", (RequestId, request->MakeRequestId()),
+                            (Response, response->ToString()));
+                        auto *common = dynamic_cast<TEvBlobStorage::TEvResultCommon*>(response.get());
+                        Y_ABORT_UNLESS(common);
+                        Y_DEBUG_ABORT_UNLESS(common->Status != NKikimrProto::RACE);
+                        Send(request->Sender, response.release(), 0, request->Cookie);
+                        request->Finished = true;
+                    }
                 }
             }
 
             Y_ABORT_UNLESS(request->ResponsesPending || request->Finished);
 
+            request->CookiesInFlight.erase(it->first);
             RequestsInFlight.erase(it);
+
+            if (request->Finished) {
+                for (ui64 cookie : request->CookiesInFlight) {
+                    RequestsInFlight.erase(cookie);
+                }
+            }
         }
 
         void Handle(TEvBlobStorage::TEvConfigureProxy::TPtr ev) {
             Info = std::move(ev->Get()->Info);
+            while (!PendingByGeneration.empty()) {
+                auto it = PendingByGeneration.begin();
+                auto& [requiredGeneration, events] = *it;
+                if (Info->GroupGeneration < requiredGeneration) {
+                    break;
+                }
+                for (auto& ev : events) {
+                    TActivationContext::Send(ev.release());
+                }
+                PendingByGeneration.erase(it);
+            }
+
         }
 
 #define HANDLE_REQUEST(NAME) hFunc(NAME, HandleProxyRequest)

--- a/ydb/core/blobstorage/dsproxy/dsproxy.h
+++ b/ydb/core/blobstorage/dsproxy/dsproxy.h
@@ -327,6 +327,7 @@ private:
     bool ExecutionRelayUsed = false;
     bool FirstResponse = true;
     std::optional<ui32> ForceGroupGeneration;
+    ui32 RacingGeneration = 0;
 };
 
 void Encrypt(char *destination, const char *source, size_t shift, size_t sizeBytes, const TLogoBlobID &id,

--- a/ydb/core/blobstorage/dsproxy/dsproxy_request.cpp
+++ b/ydb/core/blobstorage/dsproxy/dsproxy_request.cpp
@@ -743,6 +743,7 @@ namespace NKikimr {
             << " Response# " << SingleLineProto(record));
 
         // process the RACE status
+        Y_ABORT_UNLESS(status == NKikimrProto::RACE);
         const TActorId& nodeWardenId = MakeBlobStorageNodeWardenID(SelfId().NodeId());
         if (vdiskId.GroupGeneration < Info->GroupGeneration) { // vdisk is older than our group
             RacingDomains |= {&Info->GetTopology(), vdiskId};
@@ -754,14 +755,19 @@ namespace NKikimr {
             if (group && (group->GetGroupID() != Info->GroupID.GetRawId() || group->GetGroupGeneration() != vdiskId.GroupGeneration)) {
                 return done(NKikimrProto::ERROR, "incorrect RecentGroup for RACE response");
             }
+            RacingGeneration = Max(RacingGeneration, vdiskId.GroupGeneration);
             Send(nodeWardenId, new TEvBlobStorage::TEvUpdateGroupInfo(vdiskId.GroupID, vdiskId.GroupGeneration,
                 group ? std::make_optional(*group) : std::nullopt));
         }
 
         // make NodeWarden restart the query just after proxy reconfiguration
         if (ForceGroupGeneration) {
-            Y_DEBUG_ABORT_UNLESS(*ForceGroupGeneration == Info->GroupGeneration);
-            Y_DEBUG_ABORT_UNLESS(*ForceGroupGeneration != vdiskId.GroupGeneration);
+            Y_VERIFY_DEBUG_S(*ForceGroupGeneration == Info->GroupGeneration && *ForceGroupGeneration != vdiskId.GroupGeneration,
+                "ForceGroupGeneration# " << *ForceGroupGeneration
+                << " Info->GroupGeneration# " << Info->GroupGeneration
+                << " VDiskId# " << vdiskId.ToString()
+                << " Record# " << SingleLineProto(record)
+                << " Type# " << type);
             return done(NKikimrProto::RACE, "forced group generation mismatch");
         } else {
             Y_DEBUG_ABORT_UNLESS(RestartCounter < 100);
@@ -937,6 +943,10 @@ namespace NKikimr {
                 Y_ABORT();
 #undef XX
         }
+
+        auto *common = dynamic_cast<TEvBlobStorage::TEvResultCommon*>(ev.get());
+        Y_ABORT_UNLESS(common);
+        common->RacingGeneration = RacingGeneration;
 
         if (ExecutionRelay) {
             SetExecutionRelay(*ev, std::exchange(ExecutionRelay, {}));

--- a/ydb/core/blobstorage/ut_blobstorage/lib/node_warden_mock_vdisk.h
+++ b/ydb/core/blobstorage/ut_blobstorage/lib/node_warden_mock_vdisk.h
@@ -62,7 +62,7 @@ public:
             }
             Send(ev->Sender, response.release(), 0, ev->Cookie);
         } else {
-            Send(ev->Sender, new TEvBlobStorage::TEvVStatusResult(NKikimrProto::ERROR, record.GetVDiskID()), 0, ev->Cookie);
+            Send(ev->Sender, new TEvBlobStorage::TEvVStatusResult(NKikimrProto::ERROR, VDiskIDFromVDiskID(record.GetVDiskID())), 0, ev->Cookie);
         }
     }
 

--- a/ydb/core/blobstorage/vdisk/skeleton/blobstorage_skeletonfront.cpp
+++ b/ydb/core/blobstorage/vdisk/skeleton/blobstorage_skeletonfront.cpp
@@ -1639,8 +1639,9 @@ namespace NKikimr {
         void Reply(TEvBlobStorage::TEvVStatus::TPtr &ev, const TActorContext &ctx,
                 NKikimrProto::EReplyStatus status, const TString& /*errorReason*/, TInstant /*now*/) {
             const ui32 flags = IEventHandle::MakeFlags(ev->GetChannel(), 0);
-            ctx.Send(ev->Sender, new TEvBlobStorage::TEvVStatusResult(status, ev->Get()->Record.GetVDiskID()),
-                flags, ev->Cookie);
+            auto response = std::make_unique<TEvBlobStorage::TEvVStatusResult>(status, SelfVDiskId);
+            SetRacingGroupInfo(ev->Get()->Record, response->Record, GInfo);
+            ctx.Send(ev->Sender, response.release(), flags, ev->Cookie);
         }
         // FIXME: don't forget about counters
 


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

Retain RACE responses in bridge proxy

### Changelog category <!-- remove all except one -->

* Not for changelog (changelog entry is not required)

### Description for reviewers <!-- (optional) description for those who read this PR -->

This patch correctly handles RACE responses from proxies in Bridge mode to allow automatic handling of reconfiguration without reporting faulty statuses to tablets leading to their restart.
