### PR TITLE
limit deduplication filter cache memory

### DIFF
--- a/ydb/core/tx/columnshard/engines/reader/simple_reader/duplicates/manager.h
+++ b/ydb/core/tx/columnshard/engines/reader/simple_reader/duplicates/manager.h
@@ -29,8 +29,15 @@ class TDuplicateManager: public NActors::TActor<TDuplicateManager> {
 private:
     class TPortionsSlice;
 
+    class TFilterSizeProvider {
+    public:
+        size_t operator()(const NArrow::TColumnFilter& filter) {
+            return filter.GetDataSize();
+        }
+    };
+
 private:
-    inline static const ui64 FILTER_CACHE_SIZE_CNT = 100;
+    inline static const ui64 FILTER_CACHE_SIZE = 10000000;  // 10 MiB
 
     inline static TAtomicCounter NextRequestId = 0;
 
@@ -43,7 +50,7 @@ private:
     const std::shared_ptr<NDataAccessorControl::IDataAccessorsManager> DataAccessorsManager;
     const std::shared_ptr<NColumnFetching::TColumnDataManager> ColumnDataManager;
 
-    TLRUCache<TDuplicateMapInfo, NArrow::TColumnFilter> FiltersCache;
+    TLRUCache<TDuplicateMapInfo, NArrow::TColumnFilter, TNoopDelete, TFilterSizeProvider> FiltersCache;
     THashMap<TDuplicateMapInfo, std::vector<std::shared_ptr<TInternalFilterConstructor>>> BuildingFilters;
     ui64 ExpectedIntersectionCount = 0;
 


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

...

### Changelog category <!-- remove all except one -->

* Not for changelog (changelog entry is not required)

### Description for reviewers <!-- (optional) description for those who read this PR -->

- ограничение объёма кэша фильтров по занимаемой памяти
- сортировка порций по PK при включенной дедупликации
