### PR TITLE
Correct config propagation in distconf

### DIFF
--- a/ydb/core/blobstorage/nodewarden/distconf.cpp
+++ b/ydb/core/blobstorage/nodewarden/distconf.cpp
@@ -83,7 +83,7 @@ namespace NKikimr::NStorage {
         // TODO: implement
     }
 
-    bool TDistributedConfigKeeper::ApplyStorageConfig(const NKikimrBlobStorage::TStorageConfig& config) {
+    bool TDistributedConfigKeeper::ApplyStorageConfig(const NKikimrBlobStorage::TStorageConfig& config, bool fromBinding) {
         if (!StorageConfig || StorageConfig->GetGeneration() < config.GetGeneration() ||
                 (!IsSelfStatic && !config.GetGeneration() && !config.GetSelfManagementConfig().GetEnabled())) {
             // extract the main config from newly applied section
@@ -152,6 +152,20 @@ namespace NKikimr::NStorage {
 
             if (BridgeInfo && !BridgeInfo->SelfNodePile->IsPrimary) {
                 UnbindNodesFromOtherPiles("not primary pile anymore");
+            }
+
+            // update configuration to the root
+            if (IsSelfStatic && !fromBinding) {
+                auto ev = std::make_unique<TEvNodeConfigPush>();
+                UpdateBound(SelfNode.NodeId(), SelfNode, *StorageConfig, ev.get());
+                if (Binding) {
+                    SendEvent(*Binding, std::move(ev));
+                }
+            }
+
+            // update configuration to bound nodes
+            if (IsSelfStatic) {
+                FanOutReversePush();
             }
 
             return true;

--- a/ydb/core/blobstorage/nodewarden/distconf.h
+++ b/ydb/core/blobstorage/nodewarden/distconf.h
@@ -154,10 +154,12 @@ namespace NKikimr::NStorage {
             TActorId SessionId; // interconnect session for this peer
             THashSet<ui64> ScatterTasks; // unanswered scatter queries
             THashSet<TNodeIdentifier> BoundNodeIds; // a set of provided bound nodes by this peer (not including itself)
+            ui32 LastReportedRootNodeId;
 
-            TBoundNode(ui64 cookie, TActorId sessionId)
+            TBoundNode(ui64 cookie, TActorId sessionId, ui32 lastReportedRootNodeId)
                 : Cookie(cookie)
                 , SessionId(sessionId)
+                , LastReportedRootNodeId(lastReportedRootNodeId)
             {}
 
             bool Expected(IEventHandle& ev) const {
@@ -344,7 +346,7 @@ namespace NKikimr::NStorage {
         void Bootstrap();
         void PassAway() override;
         void Halt(); // cease any distconf activity, unbind and reject any bindings
-        bool ApplyStorageConfig(const NKikimrBlobStorage::TStorageConfig& config);
+        bool ApplyStorageConfig(const NKikimrBlobStorage::TStorageConfig& config, bool fromBinding = false);
         void HandleConfigConfirm(STATEFN_SIG);
         void ReportStorageConfigToNodeWarden(ui64 cookie);
 
@@ -386,7 +388,7 @@ namespace NKikimr::NStorage {
         void AbortBinding(const char *reason, bool sendUnbindMessage = true, bool sendUpdate = true);
         void HandleWakeup();
         void Handle(TEvNodeConfigReversePush::TPtr ev);
-        void FanOutReversePush(const NKikimrBlobStorage::TStorageConfig *config, bool recurseConfigUpdate = false);
+        void FanOutReversePush();
         void UnbindNodesFromOtherPiles(const char *reason);
 
         ////////////////////////////////////////////////////////////////////////////////////////////////////////////////

--- a/ydb/core/blobstorage/nodewarden/distconf_binding.cpp
+++ b/ydb/core/blobstorage/nodewarden/distconf_binding.cpp
@@ -379,7 +379,7 @@ namespace NKikimr::NStorage {
             ApplyConfigUpdateToDynamicNodes(true);
 
             if (sendUpdate) {
-                FanOutReversePush(nullptr);
+                FanOutReversePush();
             }
 
             UnsubscribeQueue.insert(binding.NodeId);
@@ -406,31 +406,30 @@ namespace NKikimr::NStorage {
         Y_ABORT_UNLESS(Binding->RootNodeId || ScatterTasks.empty());
 
         // check if this binding was accepted and if it is acceptable from our point of view
+        bool bindingUpdate = false;
         if (record.GetRejected()) {
-            AbortBinding("binding rejected by peer", false);
+            AbortBinding("binding rejected by peer", false, false);
             if (const ui32 rootNodeId = record.GetRootNodeId()) {
                 StartBinding(rootNodeId);
             }
+            bindingUpdate = true;
         } else {
-            const bool configUpdate = record.HasCommittedStorageConfig() &&
-                (ApplyStorageConfig(record.GetCommittedStorageConfig()) || record.GetRecurseConfigUpdate());
-
-            const bool bindingUpdate = !Binding || Binding->RootNodeId != record.GetRootNodeId();
-            if (Binding) {
-                if (record.GetRootNodeId() == SelfId().NodeId()) {
-                    AbortBinding("binding cycle", /*sendUnbindMessage=*/ true, /*sendUpdate=*/ false);
-                } else {
-                    Binding->RootNodeId = record.GetRootNodeId();
-                }
+            if (record.GetRootNodeId() == SelfId().NodeId()) {
+                AbortBinding("binding cycle", /*sendUnbindMessage=*/ true, /*sendUpdate=*/ false);
+                bindingUpdate = true;
+            } else if (record.GetRootNodeId() != Binding->RootNodeId) {
+                Binding->RootNodeId = record.GetRootNodeId();
+                bindingUpdate = true;
             }
 
             Y_ABORT_UNLESS(!Binding || Binding->RootNodeId != SelfId().NodeId());
+        }
 
-            if (bindingUpdate || configUpdate) {
-                STLOG(PRI_DEBUG, BS_NODE, NWDC13, "Binding updated", (Binding, Binding), (BindingUpdate, bindingUpdate),
-                    (ConfigUpdate, configUpdate));
-                FanOutReversePush(configUpdate ? StorageConfig.get() : nullptr, record.GetRecurseConfigUpdate());
-            }
+        // update config if needed, or just fan-out binding changes
+        if (record.HasCommittedStorageConfig()) {
+            ApplyStorageConfig(record.GetCommittedStorageConfig(), true);
+        } else if (bindingUpdate) {
+            FanOutReversePush();
         }
 
         // process cache updates, if needed
@@ -527,9 +526,22 @@ namespace NKikimr::NStorage {
             (SessionId, ev->InterconnectSession), (Binding, Binding), (Record, record),
             (RootNodeId, GetRootNodeId()));
 
+        // check if we have to send our current config to the peer
+        const NKikimrBlobStorage::TStorageConfig *configToPeer = nullptr;
+        if (record.GetInitial()) {
+            for (const auto& item : record.GetBoundNodes()) {
+                if (item.GetNodeId().GetNodeId() == senderNodeId) {
+                    if (StorageConfig && item.GetMeta().GetGeneration() < StorageConfig->GetGeneration()) {
+                        configToPeer = StorageConfig.get();
+                    }
+                    break;
+                }
+            }
+        }
+
         if (!AllNodeIds.contains(senderNodeId)) {
             // node has been already deleted from the config, but new subscription is coming through -- ignoring it
-            SendEvent(*ev, TEvNodeConfigReversePush::MakeRejected());
+            SendEvent(*ev, TEvNodeConfigReversePush::MakeRejected(configToPeer));
             return;
         }
 
@@ -538,7 +550,7 @@ namespace NKikimr::NStorage {
             STLOG(PRI_DEBUG, BS_NODE, NWDC28, "TEvNodeConfigPush rejected", (NodeId, senderNodeId),
                 (Cookie, ev->Cookie), (SessionId, ev->InterconnectSession), (Binding, Binding),
                 (Record, record));
-            SendEvent(*ev, TEvNodeConfigReversePush::MakeRejected());
+            SendEvent(*ev, TEvNodeConfigReversePush::MakeRejected(configToPeer));
             return;
         }
 
@@ -550,7 +562,7 @@ namespace NKikimr::NStorage {
                 // nodes AND this is the root one
             } else {
                 // this is either not the root node, or no quorum for connection
-                auto response = TEvNodeConfigReversePush::MakeRejected();
+                auto response = TEvNodeConfigReversePush::MakeRejected(configToPeer);
                 if (Binding && Binding->RootNodeId) {
                     // command peer to join this specific node
                     response->Record.SetRootNodeId(Binding->RootNodeId);
@@ -581,10 +593,11 @@ namespace NKikimr::NStorage {
         };
 
         // insert new connection into map (if there is none)
-        const auto [it, inserted] = DirectBoundNodes.try_emplace(senderNodeId, ev->Cookie, ev->InterconnectSession);
+        const auto [it, inserted] = DirectBoundNodes.try_emplace(senderNodeId, ev->Cookie, ev->InterconnectSession,
+            GetRootNodeId());
         TBoundNode& info = it->second;
         if (inserted) {
-            auto response = std::make_unique<TEvNodeConfigReversePush>(GetRootNodeId(), StorageConfig.get(), false);
+            auto response = std::make_unique<TEvNodeConfigReversePush>(GetRootNodeId(), configToPeer);
             if (record.GetInitial()) {
                 auto *cache = record.MutableCacheUpdate();
 
@@ -715,10 +728,22 @@ namespace NKikimr::NStorage {
         if (!BridgeInfo) {
             return;
         }
+
+        THashSet<ui32> nodesToUpdate;
+        for (auto& [nodeId, node] : AllBoundNodes) {
+            if (!node.Configs.empty()) {
+                auto& last = node.Configs.back();
+                if (last.GetGeneration() < StorageConfig->GetGeneration()) {
+                    nodesToUpdate.insert(nodeId.NodeId());
+                }
+            }
+        }
+
         std::vector<ui32> goingToUnbind;
         for (const auto& [nodeId, info] : DirectBoundNodes) {
             if (BridgeInfo->GetPileForNode(nodeId) != BridgeInfo->SelfNodePile) {
-                SendEvent(nodeId, info, TEvNodeConfigReversePush::MakeRejected());
+                SendEvent(nodeId, info, TEvNodeConfigReversePush::MakeRejected(nodesToUpdate.contains(nodeId)
+                    ? StorageConfig.get() : nullptr));
                 goingToUnbind.push_back(nodeId);
             }
         }

--- a/ydb/core/blobstorage/nodewarden/distconf_cache.cpp
+++ b/ydb/core/blobstorage/nodewarden/distconf_cache.cpp
@@ -47,8 +47,9 @@ namespace NKikimr::NStorage {
             SendEvent(*Binding, std::move(ev));
         }
         // propagate backwards
-        for (const auto& [nodeId, info] : DirectBoundNodes) {
-            auto ev = std::make_unique<TEvNodeConfigReversePush>(GetRootNodeId(), nullptr, false);
+        for (auto& [nodeId, info] : DirectBoundNodes) {
+            auto ev = std::make_unique<TEvNodeConfigReversePush>(GetRootNodeId(), nullptr);
+            info.LastReportedRootNodeId = GetRootNodeId();
             ev->Record.MutableCacheUpdate()->CopyFrom(updates);
             SendEvent(nodeId, info, std::move(ev));
         }

--- a/ydb/core/blobstorage/nodewarden/distconf_fsm.cpp
+++ b/ydb/core/blobstorage/nodewarden/distconf_fsm.cpp
@@ -390,7 +390,6 @@ namespace NKikimr::NStorage {
 
         if (persistedConfig) { // we have a committed config, apply and spread it
             ApplyStorageConfig(*persistedConfig);
-            FanOutReversePush(StorageConfig.get(), true /*recurseConfigUpdate*/);
         }
 
         NKikimrBlobStorage::TStorageConfig tempConfig;
@@ -471,7 +470,6 @@ namespace NKikimr::NStorage {
                 *Cfg, proposition.MindPrev, &err)) {
             // apply configuration and spread it
             ApplyStorageConfig(proposition.StorageConfig);
-            FanOutReversePush(StorageConfig.get(), true /*recurseConfigUpdate*/);
 
             // this proposition came from actor -- we notify that actor and finish operation
             Y_ABORT_UNLESS(proposition.ActorId);
@@ -691,11 +689,28 @@ namespace NKikimr::NStorage {
         }
     }
 
-    void TDistributedConfigKeeper::FanOutReversePush(const NKikimrBlobStorage::TStorageConfig *config,
-            bool recurseConfigUpdate) {
-        for (const auto& [nodeId, info] : DirectBoundNodes) {
-            SendEvent(nodeId, info, std::make_unique<TEvNodeConfigReversePush>(GetRootNodeId(), config,
-                recurseConfigUpdate));
+    void TDistributedConfigKeeper::FanOutReversePush() {
+        Y_ABORT_UNLESS(StorageConfig);
+        THashSet<ui32> nodeIdsToUpdate;
+        if (StorageConfig) {
+            for (auto& [nodeId, node] : AllBoundNodes) { // assume this gets to all bound nodes
+                for (auto& meta : node.Configs) {
+                    if (meta.GetGeneration() < StorageConfig->GetGeneration()) {
+                        // this node has a chance of holding obsolete configuration: update it
+                        nodeIdsToUpdate.insert(nodeId.NodeId());
+                        meta = *StorageConfig;
+                    }
+                }
+            }
+        }
+        const ui32 rootNodeId = GetRootNodeId();
+        for (auto& [nodeId, info] : DirectBoundNodes) {
+            const bool needToUpdateConfig = nodeIdsToUpdate.contains(nodeId);
+            if (needToUpdateConfig || info.LastReportedRootNodeId != rootNodeId) {
+                SendEvent(nodeId, info, std::make_unique<TEvNodeConfigReversePush>(rootNodeId,
+                    needToUpdateConfig ? StorageConfig.get() : nullptr));
+                info.LastReportedRootNodeId = GetRootNodeId();
+            }
         }
     }
 

--- a/ydb/core/blobstorage/nodewarden/distconf_mon.cpp
+++ b/ydb/core/blobstorage/nodewarden/distconf_mon.cpp
@@ -134,9 +134,36 @@ namespace NKikimr::NStorage {
                 return res;
             };
 
+            auto getAllBoundNodes = [&] {
+                NJson::TJsonValue res(NJson::JSON_ARRAY);
+
+                for (const auto& [nodeId, node] : AllBoundNodes) {
+                    NJson::TJsonValue item(NJson::JSON_MAP);
+                    item["node_id"] = NJson::TJsonMap{
+                        {"host", std::get<0>(nodeId)},
+                        {"port", std::get<1>(nodeId)},
+                        {"node_id", std::get<2>(nodeId)},
+                    };
+
+                    NJson::TJsonValue refs(NJson::JSON_MAP);
+                    for (const auto& [refererNodeId, it] : node.Refs) {
+                        refs[ToString(refererNodeId)] = NJson::TJsonMap{
+                            {"generation", it->GetGeneration()},
+                            {"fingerprint", HexEncode(it->GetFingerprint())},
+                        };
+                    }
+                    item["refs"] = std::move(refs);
+
+                    res.AppendValue(std::move(item));
+                }
+
+                return res;
+            };
+
             NJson::TJsonValue root = NJson::TJsonMap{
                 {"binding", getBinding()},
                 {"direct_bound_nodes", getDirectBoundNodes()},
+                {"all_bound_nodes", getAllBoundNodes()},
                 {"root_state", TString(TStringBuilder() << RootState)},
                 {"error_reason", ErrorReason},
                 {"has_quorum", GlobalQuorum},
@@ -310,6 +337,46 @@ namespace NKikimr::NStorage {
                                         TABLED() { out << info.SessionId; }
                                         TABLED() { out << makeBoundNodeIds(); }
                                         TABLED() { out << FormatList(info.ScatterTasks); }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+
+                DIV_CLASS("panel panel-info") {
+                    DIV_CLASS("panel-heading") {
+                        out << "Bound nodes";
+                    }
+                    DIV_CLASS("panel-body") {
+                        TABLE_CLASS("table table-condensed") {
+                            TABLEHEAD() {
+                                TABLER() {
+                                    TABLEH() { out << "NodeId"; }
+                                    TABLEH() { out << "FQDN:IcPort"; }
+                                    TABLEH() { out << "RefererNodeId"; }
+                                    TABLEH() { out << "Generation"; }
+                                    TABLEH() { out << "Fingerprint"; }
+                                }
+                            }
+                            TABLEBODY() {
+                                auto r = AllBoundNodes | std::views::keys;
+                                std::vector<TNodeIdentifier> nodeIds(r.begin(), r.end());
+                                std::ranges::sort(nodeIds);
+                                for (const auto& nodeId : nodeIds) {
+                                    auto& node = AllBoundNodes.at(nodeId);
+                                    auto r = node.Refs | std::views::keys;
+                                    std::vector<ui32> refererNodeIds(r.begin(), r.end());
+                                    std::ranges::sort(refererNodeIds);
+                                    for (ui32 refererNodeId : refererNodeIds) {
+                                        const auto& it = node.Refs.at(refererNodeId);
+                                        TABLER() {
+                                            TABLED() { out << nodeId.NodeId(); }
+                                            TABLED() { out << std::get<0>(nodeId) << ':' << std::get<1>(nodeId); }
+                                            TABLED() { out << refererNodeId; }
+                                            TABLED() { out << it->GetGeneration(); }
+                                            TABLED() { out << HexEncode(it->GetFingerprint()); }
+                                        }
                                     }
                                 }
                             }

--- a/ydb/core/blobstorage/nodewarden/node_warden_events.h
+++ b/ydb/core/blobstorage/nodewarden/node_warden_events.h
@@ -22,20 +22,19 @@ namespace NKikimr::NStorage {
     {
         TEvNodeConfigReversePush() = default;
 
-        TEvNodeConfigReversePush(ui32 rootNodeId, const NKikimrBlobStorage::TStorageConfig *committedConfig,
-                bool recurseConfigUpdate) {
+        TEvNodeConfigReversePush(ui32 rootNodeId, const NKikimrBlobStorage::TStorageConfig *committedConfig) {
             Record.SetRootNodeId(rootNodeId);
             if (committedConfig) {
                 Record.MutableCommittedStorageConfig()->CopyFrom(*committedConfig);
             }
-            if (recurseConfigUpdate) {
-                Record.SetRecurseConfigUpdate(recurseConfigUpdate);
-            }
         }
 
-        static std::unique_ptr<TEvNodeConfigReversePush> MakeRejected() {
+        static std::unique_ptr<TEvNodeConfigReversePush> MakeRejected(const NKikimrBlobStorage::TStorageConfig *config) {
             auto res = std::make_unique<TEvNodeConfigReversePush>();
             res->Record.SetRejected(true);
+            if (config) {
+                res->Record.MutableCommittedStorageConfig()->CopyFrom(*config);
+            }
             return res;
         }
     };


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

Correct config propagation in distconf

### Changelog category <!-- remove all except one -->

* Not for changelog (changelog entry is not required)

### Description for reviewers <!-- (optional) description for those who read this PR -->

This fixes distconf propagation mechanism to ensure that configuration is delivered properly when primary pile gets disconnected.
