### PR TITLE
Fix write audit log crash

### DIFF
--- a/ydb/core/audit/audit_log_impl.cpp
+++ b/ydb/core/audit/audit_log_impl.cpp
@@ -1,10 +1,10 @@
 #include <util/charset/utf8.h>
+#include <util/string/hex.h>
 
 #include <library/cpp/json/json_value.h>
 #include <library/cpp/json/json_writer.h>
 #include <library/cpp/logger/record.h>
 #include <library/cpp/logger/backend.h>
-#include <library/cpp/string_utils/base64/base64.h>
 
 #include <ydb/core/base/events.h>
 #include <ydb/library/actors/core/log.h>
@@ -222,7 +222,7 @@ THolder<NActors::IActor> CreateAuditWriter(TAuditLogBackends&& logBackends)
 
 static void EscapeNonUtf8(TString& s) {
     if (!IsUtf(s)) {
-        s = Base64Encode(s);
+        s = HexEncode(s);
     }
 }
 

--- a/ydb/core/audit/audit_log_impl.cpp
+++ b/ydb/core/audit/audit_log_impl.cpp
@@ -1,7 +1,10 @@
-#include "audit_log_impl.h"
-#include "audit_log_item_builder.h"
-#include "audit_log_service.h"
-#include "audit_log.h"
+#include <util/charset/utf8.h>
+
+#include <library/cpp/json/json_value.h>
+#include <library/cpp/json/json_writer.h>
+#include <library/cpp/logger/record.h>
+#include <library/cpp/logger/backend.h>
+#include <library/cpp/string_utils/base64/base64.h>
 
 #include <ydb/core/base/events.h>
 #include <ydb/library/actors/core/log.h>
@@ -10,13 +13,10 @@
 #include <ydb/library/actors/core/hfunc.h>
 #include <ydb/library/services/services.pb.h>
 
-#include <library/cpp/json/json_value.h>
-#include <library/cpp/json/json_writer.h>
-#include <library/cpp/logger/record.h>
-#include <library/cpp/logger/backend.h>
-#include <library/cpp/string_utils/base64/base64.h>
-
-#include <util/charset/utf8.h>
+#include "audit_log_impl.h"
+#include "audit_log_item_builder.h"
+#include "audit_log_service.h"
+#include "audit_log.h"
 
 #if defined LOG_T || \
     defined LOG_D || \

--- a/ydb/core/audit/audit_log_impl.cpp
+++ b/ydb/core/audit/audit_log_impl.cpp
@@ -72,7 +72,7 @@ void WriteLog(const TString& log, const TVector<THolder<TLogBackend>>& logBacken
                 log.data(),
                 log.length()
             ));
-        } catch (const yexception& e) {
+        } catch (const std::exception& e) {
             LOG_E("WriteLog: unable to write audit log (error: " << e.what() << ")");
         }
     }

--- a/ydb/core/audit/audit_log_impl.h
+++ b/ydb/core/audit/audit_log_impl.h
@@ -1,0 +1,8 @@
+#pragma once
+#include <ydb/core/audit/audit_log.h>
+
+namespace NKikimr::NAudit {
+
+void EscapeNonUtf8LogParts(TAuditLogParts& parts);
+
+} // namespace NKikimr::NAudit

--- a/ydb/core/audit/audit_log_service_ut.cpp
+++ b/ydb/core/audit/audit_log_service_ut.cpp
@@ -1,0 +1,162 @@
+#include "audit_log_service.h"
+#include "audit_log.h"
+
+#include <ydb/library/actors/core/actor.h>
+#include <ydb/library/actors/testlib/test_runtime.h>
+
+#include <library/cpp/logger/stream.h>
+#include <library/cpp/testing/unittest/registar.h>
+
+#include <queue>
+#include <mutex>
+#include <condition_variable>
+
+namespace NKikimr::NAudit {
+
+template <typename T>
+class TWaitableQueue {
+public:
+    void Push(const T& value) {
+        {
+            std::lock_guard<std::mutex> lock(Mutex);
+            Queue.push(value);
+        }
+        CondVar.notify_one();
+    }
+
+    T Pop() {
+        std::unique_lock<std::mutex> lock(Mutex);
+        CondVar.wait(lock, [this] { return !Queue.empty(); });
+        T value = Queue.front();
+        Queue.pop();
+        return value;
+    }
+
+    bool Empty() const {
+        std::lock_guard<std::mutex> lock(Mutex);
+        return Queue.empty();
+    }
+
+private:
+    mutable std::mutex Mutex;
+    std::condition_variable CondVar;
+    std::queue<T> Queue;
+};
+
+using TLogQueue = TWaitableQueue<TString>;
+using TLogQueuePtr = std::shared_ptr<TWaitableQueue<TString>>;
+
+class TTestLogBackend : public TLogBackend {
+public:
+    TTestLogBackend(TLogQueuePtr queue)
+        : Queue(std::move(queue))
+    {
+    }
+
+    void WriteData(const TLogRecord& rec) override {
+        Queue->Push(TString(rec.Data, rec.Len));
+    }
+
+    void ReopenLog() override {
+    }
+
+private:
+    TLogQueuePtr Queue;
+};
+
+class TExceptionLogBackend : public TLogBackend {
+public:
+    void WriteData(const TLogRecord&) override {
+        throw std::runtime_error("test");
+    }
+
+    void ReopenLog() override {
+    }
+};
+
+struct TTestAuditLogActorSystem : public NActors::TTestActorRuntimeBase {
+    TTestAuditLogActorSystem()
+        : TTestActorRuntimeBase(1, true)
+    {
+    }
+
+    void Init(TAuditLogBackends&& backends) {
+        AddLocalService(MakeAuditServiceID(), NActors::TActorSetupCmd(CreateAuditWriter(std::move(backends)).Release(), NActors::TMailboxType::Simple, 0));
+        InitNodes();
+        SetLogBackend(new TStreamLogBackend(&Cerr));
+        AppendToLogSettings(
+            NKikimrServices::EServiceKikimr_MIN,
+            NKikimrServices::EServiceKikimr_MAX,
+            NKikimrServices::EServiceKikimr_Name<NActors::NLog::EComponent>
+        );
+        SetLogPriority(NKikimrServices::AUDIT_LOG_WRITER, NActors::NLog::PRI_DEBUG);
+    }
+};
+
+class TTestAuditLogService {
+public:
+    explicit TTestAuditLogService(TAuditLogBackends&& backends) {
+        Init(std::move(backends));
+    }
+
+    explicit TTestAuditLogService(NKikimrConfig::TAuditConfig::EFormat format) {
+        Init(MakeBackends(format));
+    }
+
+    void Init(TAuditLogBackends&& backends) {
+        Runtime.Init(std::move(backends));
+    }
+
+    TAuditLogBackends MakeBackends(NKikimrConfig::TAuditConfig::EFormat format) {
+        TAuditLogBackends backends;
+        backends[format].emplace_back(MakeHolder<TTestLogBackend>(LogQueue));
+        backends[format].emplace_back(MakeHolder<TExceptionLogBackend>());
+        return backends;
+    }
+
+    TString SendAuditLog(TAuditLogParts&& parts) { // Send log and wait for result
+        NAudit::SendAuditLog(Runtime.SingleSys(), std::move(parts));
+        return LogQueue->Pop();
+    }
+
+private:
+    TLogQueuePtr LogQueue = std::make_shared<TLogQueue>();
+    TTestAuditLogActorSystem Runtime;
+};
+
+Y_UNIT_TEST_SUITE(AuditLogWriterServiceTest) {
+    Y_UNIT_TEST(LoggingTxt) {
+        TTestAuditLogService test(NKikimrConfig::TAuditConfig::TXT);
+
+        TAuditLogParts parts = {
+            {"name", "value"},
+            {"fe", "\xfe\xfe"},
+        };
+
+        UNIT_ASSERT_STRING_CONTAINS(test.SendAuditLog(std::move(parts)), "name=value, fe=/v4="); // non utf-8 is in base64
+    }
+
+    Y_UNIT_TEST(LoggingJson) {
+        TTestAuditLogService test(NKikimrConfig::TAuditConfig::JSON);
+
+        TAuditLogParts parts = {
+            {"name", "value"},
+            {"fe", "\xfe\xfe"},
+        };
+
+        UNIT_ASSERT_STRING_CONTAINS(test.SendAuditLog(std::move(parts)), R"({"name":"value","fe":"/v4="})");
+    }
+
+    Y_UNIT_TEST(LoggingJsonLog) {
+        TTestAuditLogService test(NKikimrConfig::TAuditConfig::JSON_LOG_COMPATIBLE);
+
+        TAuditLogParts parts = {
+            {"name", "value"},
+            {"fe", "\xfe\xfe"},
+        };
+
+        UNIT_ASSERT_STRING_CONTAINS(test.SendAuditLog(std::move(parts)), R"("@log_type":"audit","name":"value","fe":"\/v4="})");
+    }
+}
+
+} // namespace NKikimr::NAudit

--- a/ydb/core/audit/audit_log_service_ut.cpp
+++ b/ydb/core/audit/audit_log_service_ut.cpp
@@ -133,7 +133,7 @@ Y_UNIT_TEST_SUITE(AuditLogWriterServiceTest) {
             {"fe", "\xfe\xfe"},
         };
 
-        UNIT_ASSERT_STRING_CONTAINS(test.SendAuditLog(std::move(parts)), "name=value, fe=/v4="); // non utf-8 is in base64
+        UNIT_ASSERT_STRING_CONTAINS(test.SendAuditLog(std::move(parts)), "name=value, fe=FEFE"); // non utf-8 is in base64
     }
 
     Y_UNIT_TEST(LoggingJson) {
@@ -144,7 +144,7 @@ Y_UNIT_TEST_SUITE(AuditLogWriterServiceTest) {
             {"fe", "\xfe\xfe"},
         };
 
-        UNIT_ASSERT_STRING_CONTAINS(test.SendAuditLog(std::move(parts)), R"({"name":"value","fe":"/v4="})");
+        UNIT_ASSERT_STRING_CONTAINS(test.SendAuditLog(std::move(parts)), R"({"name":"value","fe":"FEFE"})");
     }
 
     Y_UNIT_TEST(LoggingJsonLog) {
@@ -155,7 +155,7 @@ Y_UNIT_TEST_SUITE(AuditLogWriterServiceTest) {
             {"fe", "\xfe\xfe"},
         };
 
-        UNIT_ASSERT_STRING_CONTAINS(test.SendAuditLog(std::move(parts)), R"("@log_type":"audit","name":"value","fe":"\/v4="})");
+        UNIT_ASSERT_STRING_CONTAINS(test.SendAuditLog(std::move(parts)), R"("@log_type":"audit","name":"value","fe":"FEFE"})");
     }
 }
 

--- a/ydb/core/audit/audit_log_ut.cpp
+++ b/ydb/core/audit/audit_log_ut.cpp
@@ -1,0 +1,37 @@
+#include "audit_log_impl.h"
+
+#include <library/cpp/testing/unittest/registar.h>
+
+namespace NKikimr::NAudit {
+
+Y_UNIT_TEST_SUITE(EscapeNonUtf8LogPartsTest) {
+    Y_UNIT_TEST(Escape) {
+        TAuditLogParts parts = {
+            {"name", "value"}, // utf8, OK
+            {"", ""}, // utf8, OK
+            {"valid-utf-8", "🤺 ברוך הבא"}, // nonusual, but valid utf8
+            {"\xc2non\xfeutf-8", "valid - \xfe\xfa\xf5\xc2 - valid"}, // need to be escaped
+            {"newline", "\n"},
+            {"backslash", "\\"},
+        };
+
+        EscapeNonUtf8LogParts(parts);
+
+        TAuditLogParts expectedParts = {
+            {"name", "value"},
+            {"", ""},
+            {"valid-utf-8", "🤺 ברוך הבא"},
+            {"wm5vbv51dGYtOA==", "dmFsaWQgLSD++vXCIC0gdmFsaWQ="},
+            {"newline", "\n"},
+            {"backslash", "\\"},
+        };
+
+        UNIT_ASSERT_VALUES_EQUAL(parts.size(), expectedParts.size());
+        for (size_t i = 0; i < parts.size(); ++i) {
+            UNIT_ASSERT_VALUES_EQUAL_C(parts[i].first, expectedParts[i].first, i);
+            UNIT_ASSERT_VALUES_EQUAL_C(parts[i].second, expectedParts[i].second, i);
+        }
+    }
+}
+
+} // namespace NKikimr::NAudit

--- a/ydb/core/audit/audit_log_ut.cpp
+++ b/ydb/core/audit/audit_log_ut.cpp
@@ -17,11 +17,12 @@ Y_UNIT_TEST_SUITE(EscapeNonUtf8LogPartsTest) {
 
         EscapeNonUtf8LogParts(parts);
 
+
         TAuditLogParts expectedParts = {
             {"name", "value"},
             {"", ""},
             {"valid-utf-8", "🤺 ברוך הבא"},
-            {"wm5vbv51dGYtOA==", "dmFsaWQgLSD++vXCIC0gdmFsaWQ="},
+            {"C26E6F6EFE7574662D38", "76616C6964202D20FEFAF5C2202D2076616C6964"},
             {"newline", "\n"},
             {"backslash", "\\"},
         };

--- a/ydb/core/audit/ut/ya.make
+++ b/ydb/core/audit/ut/ya.make
@@ -1,6 +1,11 @@
 UNITTEST_FOR(ydb/core/audit)
 
+PEERDIR(
+    ydb/library/actors/testlib
+)
+
 SRCS(
+    audit_log_service_ut.cpp
     audit_log_ut.cpp
 )
 

--- a/ydb/core/audit/ut/ya.make
+++ b/ydb/core/audit/ut/ya.make
@@ -1,0 +1,7 @@
+UNITTEST_FOR(ydb/core/audit)
+
+SRCS(
+    audit_log_ut.cpp
+)
+
+END()

--- a/ydb/core/audit/ya.make
+++ b/ydb/core/audit/ya.make
@@ -11,6 +11,7 @@ PEERDIR(
     ydb/library/actors/core
     library/cpp/json
     library/cpp/logger
+    library/cpp/string_utils/base64
     ydb/core/base
 )
 
@@ -18,4 +19,8 @@ END()
 
 RECURSE(
     audit_config
+)
+
+RECURSE_FOR_TESTS(
+    ut
 )

--- a/ydb/core/audit/ya.make
+++ b/ydb/core/audit/ya.make
@@ -11,7 +11,6 @@ PEERDIR(
     ydb/library/actors/core
     library/cpp/json
     library/cpp/logger
-    library/cpp/string_utils/base64
     ydb/core/base
 )
 

--- a/ydb/core/log_backend/log_backend.cpp
+++ b/ydb/core/log_backend/log_backend.cpp
@@ -15,11 +15,24 @@ public:
     {}
 
     void WriteData(const TLogRecord& rec) override {
-        TLogRecord record = rec;
-        TString data = JsonEnvelope.ApplyJsonEnvelope(TStringBuf(record.Data, record.Len));
-        record.Data = data.data();
-        record.Len = data.size();
-        LogBackend->WriteData(record);
+        try {
+            TLogRecord record = rec;
+            TString data = JsonEnvelope.ApplyJsonEnvelope(TStringBuf(record.Data, record.Len));
+            record.Data = data.data();
+            record.Len = data.size();
+            LogBackend->WriteData(record);
+        } catch (const std::exception& ex) {
+            try {
+                TStringBuilder error;
+                error << "Exception on writing audit log line: " << ex.what();
+                TString data = JsonEnvelope.ApplyJsonEnvelope(error);
+                TLogRecord record = rec;
+                record.Data = data.data();
+                record.Len = data.size();
+                LogBackend->WriteData(record);
+            } catch (...) {
+            }
+        }
     }
 
     void ReopenLog() override {

--- a/ydb/core/log_backend/log_backend.cpp
+++ b/ydb/core/log_backend/log_backend.cpp
@@ -24,7 +24,7 @@ public:
         } catch (const std::exception& ex) {
             try {
                 TStringBuilder error;
-                error << "Exception on writing audit log line: " << ex.what();
+                error << "Exception on writing audit log line with json envelope: " << ex.what();
                 TString data = JsonEnvelope.ApplyJsonEnvelope(error);
                 TLogRecord record = rec;
                 record.Data = data.data();
@@ -32,6 +32,7 @@ public:
                 LogBackend->WriteData(record);
             } catch (...) {
             }
+            throw;
         }
     }
 


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

...

### Changelog category <!-- remove all except one -->

* Not for changelog (changelog entry is not required)

### Description for reviewers <!-- (optional) description for those who read this PR -->

Reproduces with audit logging enabled on command `ydb-dstool -e https://cluster.endpoint:8765 --insecure cluster balance`

Crash log:
```
0. /-S/ydb/core/driver_lib/run/main.cpp:180: KikimrTerminateHandler() @ 0x1538C512
1. /-S/contrib/libs/cxxsupp/libcxxrt/exception.cc:0: std::terminate() @ 0xA61EBC8
2. /-S/contrib/libs/cxxsupp/libcxxrt/exception.cc:821: report_failure(_Unwind_Reason_Code, __cxxabiv1::__cxa_exception*) @ 0xA61F7C0
3. /-S/contrib/libs/cxxsupp/libcxxrt/exception.cc:0: __cxa_rethrow @ 0xA61F7C0
4. /-S/ydb/library/actors/core/actor.cpp:410: NActors::IActor::Receive(TAutoPtr<NActors::IEventHandle, TDelete>&) @ 0xB50D196
5. /-S/ydb/library/actors/core/executor_thread.cpp:268: NActors::TExecutorThread::Execute(NActors::TMailbox*, bool) @ 0xB547013
6. /-S/ydb/library/actors/core/executor_thread.cpp:458: NActors::TExecutorThread::ProcessExecutorPool()::$_0::operator()(NActors::TMailbox*, bool) const @ 0xB54AB21
7. /-S/ydb/library/actors/core/executor_thread.cpp:510: NActors::TExecutorThread::ProcessExecutorPool() @ 0xB54A770
8. /-S/ydb/library/actors/core/executor_thread.cpp:536: NActors::TExecutorThread::ThreadProc() @ 0xB54B31A
9. /-S/util/system/thread.cpp:245: (anonymous namespace)::TPosixThread::ThreadProxy(void*) @ 0xA6BBFFC
10. ./nptl/pthread_create.c:442: start_thread @ 0x7FCFE0F98AC2
11. ../sysdeps/unix/sysv/linux/x86_64/clone3.S:81: ?? @ 0x7FCFE102A84F
======== exception call stack =========
0. /-S/contrib/libs/cxxsupp/libcxxrt/exception.cc:839: throw_exception(__cxxabiv1::__cxa_exception*) @ 0xA61F093
1. /-S/contrib/libs/cxxsupp/libcxxrt/exception.cc:882: __cxa_throw @ 0xA61F093
2. /-S/ydb/core/log_backend/json_envelope.cpp:75: NKikimr::TJsonEnvelope::ApplyJsonEnvelope(TBasicStringBuf<char, std::__y1::char_traits<char>> const&) const @ 0x1988A8CF
3. /-S/ydb/core/log_backend/log_backend.cpp:19: NKikimr::TLogBackendWithJsonEnvelope::WriteData(TLogRecord const&) @ 0x19888378
4. /-S/ydb/core/audit/audit_log_impl.cpp:70: NKikimr::NAudit::WriteLog(TBasicString<char, std::__y1::char_traits<char>> const&, TVector<THolder<TLogBackend, TDelete>, std::__y1::allocator<THolder<TLogBackend, TDelete>>> const&) @ 0xD3E81BD
5. /-S/ydb/core/audit/audit_log_impl.cpp:183: NKikimr::NAudit::TAuditLogActor::HandleWriteAuditLog(TAutoPtr<NActors::TEventHandle<NKikimr::NAudit::TEvAuditLog::TEvWriteAuditLog>, TDelete> const&, NActors::TActorContext const&) @ 0xD3E9552
6. /-S/ydb/core/audit/audit_log_impl.cpp:160: NKikimr::NAudit::TAuditLogActor::StateWork(TAutoPtr<NActors::IEventHandle, TDelete>&) @ 0xD3E9398
7. /-S/ydb/library/actors/core/actor.cpp:406: NActors::IActor::Receive(TAutoPtr<NActors::IEventHandle, TDelete>&) @ 0xB50D077
8. /-S/contrib/libs/cxxsupp/libcxxrt/exception.cc:1008: __cxa_rethrow @ 0xA61F710
9. /-S/ydb/library/actors/core/actor.cpp:410: NActors::IActor::Receive(TAutoPtr<NActors::IEventHandle, TDelete>&) @ 0xB50D196
10. /-S/ydb/library/actors/core/executor_thread.cpp:268: NActors::TExecutorThread::Execute(NActors::TMailbox*, bool) @ 0xB547013
11. /-S/ydb/library/actors/core/executor_thread.cpp:458: NActors::TExecutorThread::ProcessExecutorPool()::$_0::operator()(NActors::TMailbox*, bool) const @ 0xB54AB21
12. /-S/ydb/library/actors/core/executor_thread.cpp:510: NActors::TExecutorThread::ProcessExecutorPool() @ 0xB54A770
13. /-S/ydb/library/actors/core/executor_thread.cpp:536: NActors::TExecutorThread::ThreadProc() @ 0xB54B31A
14. /-S/util/system/thread.cpp:245: (anonymous namespace)::TPosixThread::ThreadProxy(void*) @ 0xA6BBFFC
15. ./nptl/pthread_create.c:442: start_thread @ 0x7FCFE0F98AC2
16. ../sysdeps/unix/sysv/linux/x86_64/clone3.S:81: ?? @ 0x7FCFE102A84F
=======================================
Terminating due to uncaught exception 0x52cce89f9a10    what() -> "Attempt to write non utf-8 string"
 of type std::runtime_error
```