### PR TITLE
Introduce distconf cache for group info propagation (#19315)

### DIFF
--- a/ydb/core/base/blobstorage.h
+++ b/ydb/core/base/blobstorage.h
@@ -919,6 +919,10 @@ struct TEvBlobStorage {
         EvNodeWardenReadMetadataResult,
         EvNodeWardenWriteMetadata,
         EvNodeWardenWriteMetadataResult,
+        EvNodeWardenUpdateCache,
+        EvNodeWardenQueryCache,
+        EvNodeWardenQueryCacheResult,
+        EvNodeWardenUnsubscribeFromCache,
 
         // Other
         EvRunActor = EvPut + 15 * 512,

--- a/ydb/core/blobstorage/base/blobstorage_events.cpp
+++ b/ydb/core/blobstorage/base/blobstorage_events.cpp
@@ -3,12 +3,10 @@
 
 namespace NKikimr {
 
-    TEvNodeWardenStorageConfig::TEvNodeWardenStorageConfig(const NKikimrBlobStorage::TStorageConfig& config,
-            const NKikimrBlobStorage::TStorageConfig *proposedConfig, bool selfManagementEnabled)
-        : Config(std::make_unique<NKikimrBlobStorage::TStorageConfig>(config))
-        , ProposedConfig(proposedConfig
-            ? std::make_unique<NKikimrBlobStorage::TStorageConfig>(*proposedConfig)
-            : nullptr)
+    TEvNodeWardenStorageConfig::TEvNodeWardenStorageConfig(std::shared_ptr<const NKikimrBlobStorage::TStorageConfig> config,
+            std::shared_ptr<const NKikimrBlobStorage::TStorageConfig> proposedConfig, bool selfManagementEnabled)
+        : Config(std::move(config))
+        , ProposedConfig(std::move(proposedConfig))
         , SelfManagementEnabled(selfManagementEnabled)
     {}
 

--- a/ydb/core/blobstorage/base/blobstorage_events.h
+++ b/ydb/core/blobstorage/base/blobstorage_events.h
@@ -580,12 +580,12 @@ namespace NKikimr {
     struct TEvNodeWardenStorageConfig
         : TEventLocal<TEvNodeWardenStorageConfig, TEvBlobStorage::EvNodeWardenStorageConfig>
     {
-        std::unique_ptr<NKikimrBlobStorage::TStorageConfig> Config;
-        std::unique_ptr<NKikimrBlobStorage::TStorageConfig> ProposedConfig;
+        std::shared_ptr<const NKikimrBlobStorage::TStorageConfig> Config;
+        std::shared_ptr<const NKikimrBlobStorage::TStorageConfig> ProposedConfig;
         bool SelfManagementEnabled;
 
-        TEvNodeWardenStorageConfig(const NKikimrBlobStorage::TStorageConfig& config,
-                const NKikimrBlobStorage::TStorageConfig *proposedConfig, bool selfManagementEnabled);
+        TEvNodeWardenStorageConfig(std::shared_ptr<const NKikimrBlobStorage::TStorageConfig> config,
+            std::shared_ptr<const NKikimrBlobStorage::TStorageConfig> proposedConfig, bool selfManagementEnabled);
         ~TEvNodeWardenStorageConfig();
     };
 

--- a/ydb/core/blobstorage/nodewarden/distconf.cpp
+++ b/ydb/core/blobstorage/nodewarden/distconf.cpp
@@ -341,6 +341,9 @@ namespace NKikimr::NStorage {
             hFunc(TEvBlobStorage::TEvControllerValidateConfigResponse, Handle);
             hFunc(TEvBlobStorage::TEvControllerProposeConfigResponse, Handle);
             hFunc(TEvBlobStorage::TEvControllerConsoleCommitResponse, Handle);
+            hFunc(TEvNodeWardenUpdateCache, Handle);
+            hFunc(TEvNodeWardenQueryCache, Handle);
+            hFunc(TEvNodeWardenUnsubscribeFromCache, Handle);
         )
         for (ui32 nodeId : std::exchange(UnsubscribeQueue, {})) {
             UnsubscribeInterconnect(nodeId);

--- a/ydb/core/blobstorage/nodewarden/distconf.cpp
+++ b/ydb/core/blobstorage/nodewarden/distconf.cpp
@@ -8,15 +8,12 @@
 namespace NKikimr::NStorage {
 
     TDistributedConfigKeeper::TDistributedConfigKeeper(TIntrusivePtr<TNodeWardenConfig> cfg,
-            const NKikimrBlobStorage::TStorageConfig& baseConfig, bool isSelfStatic)
+            std::shared_ptr<const NKikimrBlobStorage::TStorageConfig> baseConfig, bool isSelfStatic)
         : IsSelfStatic(isSelfStatic)
         , Cfg(std::move(cfg))
         , BaseConfig(baseConfig)
-        , InitialConfig(baseConfig)
-    {
-        UpdateFingerprint(&BaseConfig);
-        InitialConfig.SetFingerprint(BaseConfig.GetFingerprint());
-    }
+        , InitialConfig(std::move(baseConfig))
+    {}
 
     void TDistributedConfigKeeper::Bootstrap() {
         STLOG(PRI_DEBUG, BS_NODE, NWDC00, "Bootstrap");
@@ -34,9 +31,9 @@ namespace NKikimr::NStorage {
 
         // generate initial drive set and query stored configuration
         if (IsSelfStatic) {
-            if (BaseConfig.GetSelfManagementConfig().GetEnabled()) {
+            if (BaseConfig->GetSelfManagementConfig().GetEnabled()) {
                 // read this only if it is possibly enabled
-                EnumerateConfigDrives(InitialConfig, SelfId().NodeId(), [&](const auto& /*node*/, const auto& drive) {
+                EnumerateConfigDrives(*InitialConfig, SelfId().NodeId(), [&](const auto& /*node*/, const auto& drive) {
                     DrivesToRead.push_back(drive.GetPath());
                 });
                 std::sort(DrivesToRead.begin(), DrivesToRead.end());
@@ -97,11 +94,11 @@ namespace NKikimr::NStorage {
                 }
             }
 
-            SelfManagementEnabled = (!IsSelfStatic || BaseConfig.GetSelfManagementConfig().GetEnabled()) &&
+            SelfManagementEnabled = (!IsSelfStatic || BaseConfig->GetSelfManagementConfig().GetEnabled()) &&
                 config.GetSelfManagementConfig().GetEnabled() &&
                 config.GetGeneration();
 
-            StorageConfig.emplace(config);
+            StorageConfig = std::make_shared<NKikimrBlobStorage::TStorageConfig>(config);
             if (ProposedStorageConfig && ProposedStorageConfig->GetGeneration() <= StorageConfig->GetGeneration()) {
                 ProposedStorageConfig.reset();
             }
@@ -232,8 +229,8 @@ namespace NKikimr::NStorage {
 
         Y_ABORT_UNLESS(!StorageConfig || CheckFingerprint(*StorageConfig));
         Y_ABORT_UNLESS(!ProposedStorageConfig || CheckFingerprint(*ProposedStorageConfig));
-        Y_ABORT_UNLESS(CheckFingerprint(BaseConfig));
-        Y_ABORT_UNLESS(!InitialConfig.GetFingerprint() || CheckFingerprint(InitialConfig));
+        Y_ABORT_UNLESS(CheckFingerprint(*BaseConfig));
+        Y_ABORT_UNLESS(!InitialConfig->GetFingerprint() || CheckFingerprint(*InitialConfig));
 
         if (Scepter) {
             Y_ABORT_UNLESS(HasQuorum());
@@ -302,13 +299,11 @@ namespace NKikimr::NStorage {
     void TDistributedConfigKeeper::ReportStorageConfigToNodeWarden(ui64 cookie) {
         Y_ABORT_UNLESS(StorageConfig);
         const TActorId wardenId = MakeBlobStorageNodeWardenID(SelfId().NodeId());
-        const NKikimrBlobStorage::TStorageConfig *config = SelfManagementEnabled
-            ? &StorageConfig.value()
-            : &BaseConfig;
-        const NKikimrBlobStorage::TStorageConfig *proposedConfig = ProposedStorageConfig && SelfManagementEnabled
-            ? &ProposedStorageConfig.value()
+        const auto& config = SelfManagementEnabled ? StorageConfig : BaseConfig;
+        auto proposedConfig = ProposedStorageConfig && SelfManagementEnabled
+            ? std::make_shared<NKikimrBlobStorage::TStorageConfig>(*ProposedStorageConfig)
             : nullptr;
-        auto ev = std::make_unique<TEvNodeWardenStorageConfig>(*config, proposedConfig, SelfManagementEnabled);
+        auto ev = std::make_unique<TEvNodeWardenStorageConfig>(config, std::move(proposedConfig), SelfManagementEnabled);
         Send(wardenId, ev.release(), 0, cookie);
     }
 

--- a/ydb/core/blobstorage/nodewarden/distconf.h
+++ b/ydb/core/blobstorage/nodewarden/distconf.h
@@ -279,6 +279,14 @@ namespace NKikimr::NStorage {
         std::optional<std::tuple<ui64, ui32>> ProposedConfigHashVersion;
         std::vector<std::tuple<TActorId, TString, ui64>> ConsoleConfigValidationQ;
 
+        // cache subsystem
+        struct TCacheItem {
+            ui32 Generation; // item generation
+            std::optional<TString> Value; // item binary value
+        };
+        THashMap<TString, TCacheItem> Cache;
+        std::set<std::tuple<TString, TActorId>> CacheSubscriptions;
+
         friend void ::Out<ERootState>(IOutputStream&, ERootState);
 
     public:
@@ -430,7 +438,7 @@ namespace NKikimr::NStorage {
         void ApplyConfigUpdateToDynamicNodes(bool drop);
         void OnDynamicNodeDisconnected(ui32 nodeId, TActorId sessionId);
         void HandleDynamicConfigSubscribe(STATEFN_SIG);
-        void PushConfigToDynamicNode(TActorId actorId, TActorId sessionId);
+        void PushConfigToDynamicNode(TActorId actorId, TActorId sessionId, bool addCache);
 
         ////////////////////////////////////////////////////////////////////////////////////////////////////////////////
         // Event delivery
@@ -444,6 +452,18 @@ namespace NKikimr::NStorage {
         // Monitoring
 
         void Handle(NMon::TEvHttpInfo::TPtr ev);
+
+        ////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+        // Cache update
+
+        void ApplyCacheUpdates(NKikimrBlobStorage::TCacheUpdate *cacheUpdate, ui32 senderNodeId);
+
+        void AddCacheUpdate(NKikimrBlobStorage::TCacheUpdate *cacheUpdate, THashMap<TString, TCacheItem>::const_iterator it,
+            bool addValue);
+
+        void Handle(TEvNodeWardenUpdateCache::TPtr ev);
+        void Handle(TEvNodeWardenQueryCache::TPtr ev);
+        void Handle(TEvNodeWardenUnsubscribeFromCache::TPtr ev);
 
         ////////////////////////////////////////////////////////////////////////////////////////////////////////////////
         // Console interaction

--- a/ydb/core/blobstorage/nodewarden/distconf.h
+++ b/ydb/core/blobstorage/nodewarden/distconf.h
@@ -177,7 +177,7 @@ namespace NKikimr::NStorage {
         bool SelfManagementEnabled = false;
 
         // currently active storage config
-        std::optional<NKikimrBlobStorage::TStorageConfig> StorageConfig;
+        std::shared_ptr<const NKikimrBlobStorage::TStorageConfig> StorageConfig;
         TString MainConfigYaml; // the part we have to push (unless this is storage-only) to console
         std::optional<ui64> MainConfigYamlVersion;
         TString MainConfigFetchYaml; // the part we would get is we fetch from console
@@ -185,10 +185,10 @@ namespace NKikimr::NStorage {
         std::optional<TString> StorageConfigYaml; // set if dedicated storage yaml is enabled; otherwise nullopt
 
         // base config from config file
-        NKikimrBlobStorage::TStorageConfig BaseConfig;
+        std::shared_ptr<const NKikimrBlobStorage::TStorageConfig> BaseConfig;
 
         // initial config based on config file and stored committed configs
-        NKikimrBlobStorage::TStorageConfig InitialConfig;
+        std::shared_ptr<const NKikimrBlobStorage::TStorageConfig> InitialConfig;
         std::vector<TString> DrivesToRead;
 
         // proposed storage configuration of the cluster
@@ -286,8 +286,8 @@ namespace NKikimr::NStorage {
             return NKikimrServices::TActivity::NODEWARDEN_DISTRIBUTED_CONFIG;
         }
 
-        TDistributedConfigKeeper(TIntrusivePtr<TNodeWardenConfig> cfg, const NKikimrBlobStorage::TStorageConfig& baseConfig,
-            bool isSelfStatic);
+        TDistributedConfigKeeper(TIntrusivePtr<TNodeWardenConfig> cfg,
+            std::shared_ptr<const NKikimrBlobStorage::TStorageConfig> baseConfig, bool isSelfStatic);
 
         void Bootstrap();
         void PassAway() override;

--- a/ydb/core/blobstorage/nodewarden/distconf_binding.cpp
+++ b/ydb/core/blobstorage/nodewarden/distconf_binding.cpp
@@ -313,7 +313,7 @@ namespace NKikimr::NStorage {
             } else if (prevRootNodeId != GetRootNodeId() || configUpdate) {
                 STLOG(PRI_DEBUG, BS_NODE, NWDC13, "Binding updated", (Binding, Binding), (PrevRootNodeId, prevRootNodeId),
                     (ConfigUpdate, configUpdate));
-                FanOutReversePush(configUpdate ? &StorageConfig.value() : nullptr, record.GetRecurseConfigUpdate());
+                FanOutReversePush(configUpdate ? StorageConfig.get() : nullptr, record.GetRecurseConfigUpdate());
             }
         }
     }
@@ -426,7 +426,7 @@ namespace NKikimr::NStorage {
         TBoundNode& info = it->second;
         if (inserted) {
             SendEvent(senderNodeId, info, std::make_unique<TEvNodeConfigReversePush>(GetRootNodeId(),
-                StorageConfig ? &StorageConfig.value() : nullptr, false));
+                StorageConfig.get(), false));
             for (auto& [cookie, task] : ScatterTasks) {
                 IssueScatterTaskForNode(senderNodeId, info, cookie, task);
             }

--- a/ydb/core/blobstorage/nodewarden/distconf_binding.cpp
+++ b/ydb/core/blobstorage/nodewarden/distconf_binding.cpp
@@ -103,6 +103,10 @@ namespace NKikimr::NStorage {
             boundNode->MutableMeta()->CopyFrom(node.Configs.back());
         }
 
+        for (auto it = Cache.begin(); it != Cache.end(); ++it) {
+            AddCacheUpdate(record.MutableCacheUpdate(), it, false);
+        }
+
         SendEvent(*Binding, std::move(ev));
     }
 
@@ -316,6 +320,22 @@ namespace NKikimr::NStorage {
                 FanOutReversePush(configUpdate ? StorageConfig.get() : nullptr, record.GetRecurseConfigUpdate());
             }
         }
+
+        // process cache updates, if needed
+        if (record.HasCacheUpdate()) {
+            auto *cacheUpdate = record.MutableCacheUpdate();
+            ApplyCacheUpdates(cacheUpdate, senderNodeId);
+
+            if (cacheUpdate->RequestedKeysSize()) {
+                auto ev = std::make_unique<TEvNodeConfigPush>();
+                for (const TString& key : cacheUpdate->GetRequestedKeys()) {
+                    if (const auto it = Cache.find(key); it != Cache.end()) {
+                        AddCacheUpdate(ev->Record.MutableCacheUpdate(), it, true);
+                    }
+                }
+                SendEvent(*Binding, std::move(ev));
+            }
+        }
     }
 
     void TDistributedConfigKeeper::UpdateBound(ui32 refererNodeId, TNodeIdentifier nodeId, const TStorageConfigMeta& meta, TEvNodeConfigPush *msg) {
@@ -425,8 +445,32 @@ namespace NKikimr::NStorage {
         const auto [it, inserted] = DirectBoundNodes.try_emplace(senderNodeId, ev->Cookie, ev->InterconnectSession);
         TBoundNode& info = it->second;
         if (inserted) {
-            SendEvent(senderNodeId, info, std::make_unique<TEvNodeConfigReversePush>(GetRootNodeId(),
-                StorageConfig.get(), false));
+            auto response = std::make_unique<TEvNodeConfigReversePush>(GetRootNodeId(), StorageConfig.get(), false);
+            if (record.GetInitial() && record.HasCacheUpdate()) {
+                auto *cache = record.MutableCacheUpdate();
+
+                // scan existing cache keys to find the ones we need to ask and to report others
+                THashSet<TString> keysToReport;
+                for (const auto& [key, value] : Cache) {
+                    keysToReport.insert(key);
+                }
+                for (const auto& item : cache->GetKeyValuePairs()) {
+                    keysToReport.erase(item.GetKey());
+                    const auto it = Cache.find(item.GetKey());
+                    if (it == Cache.end() || it->second.Generation < item.GetGeneration()) {
+                        response->Record.MutableCacheUpdate()->AddRequestedKeys(item.GetKey());
+                    } else if (item.GetGeneration() < it->second.Generation) {
+                        AddCacheUpdate(response->Record.MutableCacheUpdate(), it, true);
+                    }
+                }
+                for (const TString& key : keysToReport) {
+                    const auto it = Cache.find(key);
+                    Y_ABORT_UNLESS(it != Cache.end());
+                    AddCacheUpdate(response->Record.MutableCacheUpdate(), it, true);
+                }
+            }
+
+            SendEvent(senderNodeId, info, std::move(response));
             for (auto& [cookie, task] : ScatterTasks) {
                 IssueScatterTaskForNode(senderNodeId, info, cookie, task);
             }
@@ -463,6 +507,11 @@ namespace NKikimr::NStorage {
                     (NodeId, nodeId));
                 Y_DEBUG_ABORT();
             }
+        }
+
+        // process cache items
+        if (!record.GetInitial() && record.HasCacheUpdate()) {
+            ApplyCacheUpdates(record.MutableCacheUpdate(), senderNodeId);
         }
 
         if (pushEv && pushEv->IsUseful()) {

--- a/ydb/core/blobstorage/nodewarden/distconf_binding.cpp
+++ b/ydb/core/blobstorage/nodewarden/distconf_binding.cpp
@@ -446,7 +446,7 @@ namespace NKikimr::NStorage {
         TBoundNode& info = it->second;
         if (inserted) {
             auto response = std::make_unique<TEvNodeConfigReversePush>(GetRootNodeId(), StorageConfig.get(), false);
-            if (record.GetInitial() && record.HasCacheUpdate()) {
+            if (record.GetInitial()) {
                 auto *cache = record.MutableCacheUpdate();
 
                 // scan existing cache keys to find the ones we need to ask and to report others

--- a/ydb/core/blobstorage/nodewarden/distconf_cache.cpp
+++ b/ydb/core/blobstorage/nodewarden/distconf_cache.cpp
@@ -1,0 +1,85 @@
+#include "distconf.h"
+
+namespace NKikimr::NStorage {
+
+    void TDistributedConfigKeeper::ApplyCacheUpdates(NKikimrBlobStorage::TCacheUpdate *cacheUpdate, ui32 senderNodeId) {
+        NKikimrBlobStorage::TCacheUpdate updates;
+
+        for (const auto& item : cacheUpdate->GetKeyValuePairs()) {
+            const auto [it, inserted] = Cache.try_emplace(item.GetKey());
+            TCacheItem& cacheItem = it->second;
+            auto newValue = item.HasValue() ? std::make_optional(item.GetValue()) : std::nullopt;
+            if (inserted || cacheItem.Generation < item.GetGeneration()) {
+                cacheItem.Generation = item.GetGeneration();
+                cacheItem.Value = std::move(newValue);
+                AddCacheUpdate(&updates, it, true);
+
+                // notify subscribers
+                for (auto pos = CacheSubscriptions.lower_bound(std::make_tuple(it->first, TActorId()));
+                        pos != CacheSubscriptions.end() && std::get<0>(*pos) == it->first; ++pos) {
+                    const auto& [key, actorId] = *pos;
+                    Send(actorId, new TEvNodeWardenQueryCacheResult(item.GetKey(), item.HasValue()
+                        ? std::make_optional(std::make_tuple(item.GetGeneration(), item.GetValue()))
+                        : std::nullopt));
+                }
+            } else if (cacheItem.Generation == item.GetGeneration()) {
+                Y_DEBUG_ABORT_UNLESS(cacheItem.Value == newValue);
+            }
+        }
+
+        if (!IsSelfStatic) {
+            return; // nothing to do for dynamic nodes
+        }
+
+        // propagate forward, if bound
+        if (Binding && Binding->SessionId && Binding->NodeId != senderNodeId) {
+            auto ev = std::make_unique<TEvNodeConfigPush>();
+            ev->Record.MutableCacheUpdate()->CopyFrom(updates);
+            SendEvent(*Binding, std::move(ev));
+        }
+        // propagate backwards
+        for (const auto& [nodeId, info] : DirectBoundNodes) {
+            auto ev = std::make_unique<TEvNodeConfigReversePush>(GetRootNodeId(), nullptr, false);
+            ev->Record.MutableCacheUpdate()->CopyFrom(updates);
+            SendEvent(nodeId, info, std::move(ev));
+        }
+        // propagate to connected dynamic nodes
+        for (const auto& [sessionId, actorId] : DynamicConfigSubscribers) {
+            auto ev = std::make_unique<TEvNodeWardenDynamicConfigPush>();
+            ev->Record.MutableCacheUpdate()->CopyFrom(updates);
+            auto handle = std::make_unique<IEventHandle>(actorId, SelfId(), ev.release());
+            handle->Rewrite(TEvInterconnect::EvForward, sessionId);
+            TActivationContext::Send(handle.release());
+        }
+    }
+
+    void TDistributedConfigKeeper::AddCacheUpdate(NKikimrBlobStorage::TCacheUpdate *cacheUpdate,
+            THashMap<TString, TCacheItem>::const_iterator it, bool addValue) {
+        auto *kvp = cacheUpdate->AddKeyValuePairs();
+        kvp->SetKey(it->first);
+        kvp->SetGeneration(it->second.Generation);
+        if (const auto& value = it->second.Value; value && addValue) {
+            kvp->SetValue(*value);
+        }
+    }
+
+    void TDistributedConfigKeeper::Handle(TEvNodeWardenUpdateCache::TPtr ev) {
+        ApplyCacheUpdates(&ev->Get()->CacheUpdate, 0);
+    }
+
+    void TDistributedConfigKeeper::Handle(TEvNodeWardenQueryCache::TPtr ev) {
+        auto& msg = *ev->Get();
+        if (msg.Subscribe) {
+            CacheSubscriptions.emplace(msg.Key, ev->Sender);
+        }
+        const auto it = Cache.find(msg.Key);
+        Send(ev->Sender, new TEvNodeWardenQueryCacheResult(msg.Key, it != Cache.end() && it->second.Value
+            ? std::make_optional(std::make_tuple(it->second.Generation, *it->second.Value))
+            : std::nullopt));
+    }
+
+    void TDistributedConfigKeeper::Handle(TEvNodeWardenUnsubscribeFromCache::TPtr ev) {
+        CacheSubscriptions.erase(std::make_tuple(ev->Get()->Key, ev->Sender));
+    }
+
+} // NKikimr::NStorage

--- a/ydb/core/blobstorage/nodewarden/distconf_console.cpp
+++ b/ydb/core/blobstorage/nodewarden/distconf_console.cpp
@@ -103,7 +103,7 @@ namespace NKikimr::NStorage {
                 if (!StorageConfig || !StorageConfig->HasConfigComposite() || ProposedConfigHashVersion !=
                         std::make_tuple(MainConfigFetchYamlHash, *MainConfigYamlVersion)) {
                     const char *err = "proposed config, but something has gone awfully wrong";
-                    STLOG(PRI_CRIT, BS_NODE, NWDC69, err, (StorageConfig, StorageConfig),
+                    STLOG(PRI_CRIT, BS_NODE, NWDC69, err, (StorageConfig, StorageConfig.get()),
                         (ProposedConfigHashVersion, ProposedConfigHashVersion),
                         (MainConfigFetchYamlHash, MainConfigFetchYamlHash),
                         (MainConfigYamlVersion, MainConfigYamlVersion));

--- a/ydb/core/blobstorage/nodewarden/distconf_dynamic.cpp
+++ b/ydb/core/blobstorage/nodewarden/distconf_dynamic.cpp
@@ -63,11 +63,14 @@ namespace NKikimr::NStorage {
             StaticNodeSessionId = {};
             ConnectToStaticNode();
         }
+        if (record.HasCacheUpdate()) {
+            ApplyCacheUpdates(record.MutableCacheUpdate(), 0);
+        }
     }
 
     void TDistributedConfigKeeper::ApplyConfigUpdateToDynamicNodes(bool drop) {
         for (const auto& [sessionId, actorId] : DynamicConfigSubscribers) {
-            PushConfigToDynamicNode(actorId, sessionId);
+            PushConfigToDynamicNode(actorId, sessionId, false);
         }
         if (drop) {
             Y_ABORT_UNLESS(!PartOfNodeQuorum());
@@ -89,7 +92,7 @@ namespace NKikimr::NStorage {
 
         const bool partOfNodeQuorum = PartOfNodeQuorum();
         if (!partOfNodeQuorum || StorageConfig) {
-            PushConfigToDynamicNode(ev->Sender, sessionId);
+            PushConfigToDynamicNode(ev->Sender, sessionId, true);
         }
         if (!partOfNodeQuorum) {
             return;
@@ -102,7 +105,7 @@ namespace NKikimr::NStorage {
         Y_ABORT_UNLESS(inserted);
     }
 
-    void TDistributedConfigKeeper::PushConfigToDynamicNode(TActorId actorId, TActorId sessionId) {
+    void TDistributedConfigKeeper::PushConfigToDynamicNode(TActorId actorId, TActorId sessionId, bool addCache) {
         auto ev = std::make_unique<TEvNodeWardenDynamicConfigPush>();
         auto& record = ev->Record;
         if (!PartOfNodeQuorum()) { // this configuration is not reliable, don't push anything
@@ -113,6 +116,12 @@ namespace NKikimr::NStorage {
             target->CopyFrom(*StorageConfig);
         } else {
             target->CopyFrom(*BaseConfig);
+        }
+        if (addCache) {
+            // push full cache to the dynamic node
+            for (auto it = Cache.begin(); it != Cache.end(); ++it) {
+                AddCacheUpdate(record.MutableCacheUpdate(), it, true);
+            }
         }
         auto handle = std::make_unique<IEventHandle>(actorId, SelfId(), ev.release());
         handle->Rewrite(TEvInterconnect::EvForward, sessionId);

--- a/ydb/core/blobstorage/nodewarden/distconf_dynamic.cpp
+++ b/ydb/core/blobstorage/nodewarden/distconf_dynamic.cpp
@@ -112,7 +112,7 @@ namespace NKikimr::NStorage {
         } else if (auto *target = record.MutableConfig(); SelfManagementEnabled) {
             target->CopyFrom(*StorageConfig);
         } else {
-            target->CopyFrom(BaseConfig);
+            target->CopyFrom(*BaseConfig);
         }
         auto handle = std::make_unique<IEventHandle>(actorId, SelfId(), ev.release());
         handle->Rewrite(TEvInterconnect::EvForward, sessionId);

--- a/ydb/core/blobstorage/nodewarden/distconf_fsm.cpp
+++ b/ydb/core/blobstorage/nodewarden/distconf_fsm.cpp
@@ -344,7 +344,7 @@ namespace NKikimr::NStorage {
 
         if (persistedConfig) { // we have a committed config, apply and spread it
             ApplyStorageConfig(*persistedConfig);
-            FanOutReversePush(&StorageConfig.value(), true /*recurseConfigUpdate*/);
+            FanOutReversePush(StorageConfig.get(), true /*recurseConfigUpdate*/);
         }
 
         NKikimrBlobStorage::TStorageConfig tempConfig;
@@ -443,7 +443,7 @@ namespace NKikimr::NStorage {
         } else if (HasConfigQuorum(*CurrentProposedStorageConfig, generateSuccessful, *Cfg)) {
             // apply configuration and spread it
             ApplyStorageConfig(*CurrentProposedStorageConfig);
-            FanOutReversePush(&StorageConfig.value(), true /*recurseConfigUpdate*/);
+            FanOutReversePush(StorageConfig.get(), true /*recurseConfigUpdate*/);
             CurrentProposedStorageConfig.reset();
         } else {
             STLOG(PRI_DEBUG, BS_NODE, NWDC47, "no quorum for ProposedStorageConfig", (Record, *res),
@@ -486,7 +486,7 @@ namespace NKikimr::NStorage {
                     SelfNode.Serialize(status->MutableNodeId());
                     status->SetStatus(TEvGather::TProposeStorageConfig::ERROR);
                     STLOG(PRI_ERROR, BS_NODE, NWDC49, "ProposedStorageConfig generation/fingerprint mismatch",
-                        (StorageConfig, StorageConfig), (Request, task.Request), (RootNodeId, GetRootNodeId()));
+                        (StorageConfig, StorageConfig.get()), (Request, task.Request), (RootNodeId, GetRootNodeId()));
                     Y_DEBUG_ABORT();
                 } else {
                     ProposedStorageConfigCookie = cookie;
@@ -561,9 +561,9 @@ namespace NKikimr::NStorage {
         THashSet<TNodeIdentifier> nodesAlreadyReplied{SelfNode};
 
         auto *ptr = response->AddNodes();
-        ptr->MutableBaseConfig()->CopyFrom(BaseConfig);
+        ptr->MutableBaseConfig()->CopyFrom(*BaseConfig);
         SelfNode.Serialize(ptr->AddNodeIds());
-        baseConfigs.emplace(BaseConfig, ptr);
+        baseConfigs.emplace(*BaseConfig, ptr);
 
         THashMap<TStorageConfigMeta, TEvGather::TCollectConfigs::TPersistentConfig*> committedConfigs;
         THashMap<TStorageConfigMeta, TEvGather::TCollectConfigs::TPersistentConfig*> proposedConfigs;

--- a/ydb/core/blobstorage/nodewarden/distconf_mon.cpp
+++ b/ydb/core/blobstorage/nodewarden/distconf_mon.cpp
@@ -284,6 +284,38 @@ namespace NKikimr::NStorage {
                         }
                     }
                 }
+
+                DIV_CLASS("panel panel-info") {
+                    DIV_CLASS("panel-heading") {
+                        out << "Cache";
+                    }
+                    DIV_CLASS("panel-body") {
+                        TABLE_CLASS("table table-condensed") {
+                            TABLEHEAD() {
+                                TABLER() {
+                                    TABLEH() { out << "Key"; }
+                                    TABLEH() { out << "Generation"; }
+                                    TABLEH() { out << "Value size"; }
+                                }
+                            }
+                            TABLEBODY() {
+                                std::vector<TString> keys;
+                                for (const auto& [key, value] : Cache) {
+                                    keys.push_back(key);
+                                }
+                                std::ranges::sort(keys);
+                                for (const TString& key : keys) {
+                                    const TCacheItem& value = Cache.at(key);
+                                    TABLER() {
+                                        TABLED() { out << key; }
+                                        TABLED() { out << value.Generation; }
+                                        TABLED() { out << (value.Value ? value.Value->size() : 0); }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
             }
 
             contentType = NMon::TEvHttpInfoRes::Html;

--- a/ydb/core/blobstorage/nodewarden/distconf_mon.cpp
+++ b/ydb/core/blobstorage/nodewarden/distconf_mon.cpp
@@ -179,9 +179,9 @@ namespace NKikimr::NStorage {
                         }
                     }
                 };
-                outputConfig("StorageConfig", StorageConfig ? &StorageConfig.value() : nullptr);
-                outputConfig("BaseConfig", &BaseConfig);
-                outputConfig("InitialConfig", &InitialConfig);
+                outputConfig("StorageConfig", StorageConfig.get());
+                outputConfig("BaseConfig", BaseConfig.get());
+                outputConfig("InitialConfig", InitialConfig.get());
                 outputConfig("ProposedStorageConfig", ProposedStorageConfig ? &ProposedStorageConfig.value() : nullptr);
 
                 DIV_CLASS("panel panel-info") {

--- a/ydb/core/blobstorage/nodewarden/distconf_persistent_storage.cpp
+++ b/ydb/core/blobstorage/nodewarden/distconf_persistent_storage.cpp
@@ -274,17 +274,17 @@ namespace NKikimr::NStorage {
             for (const auto& [path, m, guid] : msg.MetadataPerPath) {
                 if (m.HasCommittedStorageConfig()) {
                     const auto& config = m.GetCommittedStorageConfig();
-                    if (InitialConfig.GetGeneration() < config.GetGeneration()) {
-                        InitialConfig.CopyFrom(config);
-                    } else if (InitialConfig.GetGeneration() && InitialConfig.GetGeneration() == config.GetGeneration() &&
-                            InitialConfig.GetFingerprint() != config.GetFingerprint()) {
+                    if (InitialConfig->GetGeneration() < config.GetGeneration()) {
+                        InitialConfig = std::make_shared<NKikimrBlobStorage::TStorageConfig>(config);
+                    } else if (InitialConfig->GetGeneration() && InitialConfig->GetGeneration() == config.GetGeneration() &&
+                            InitialConfig->GetFingerprint() != config.GetFingerprint()) {
                         // TODO: error
                     }
                 }
                 if (m.HasProposedStorageConfig()) {
                     const auto& proposed = m.GetProposedStorageConfig();
                     // TODO: more checks
-                    if (InitialConfig.GetGeneration() < proposed.GetGeneration() && (
+                    if (InitialConfig->GetGeneration() < proposed.GetGeneration() && (
                             !ProposedStorageConfig || ProposedStorageConfig->GetGeneration() < proposed.GetGeneration())) {
                         ProposedStorageConfig.emplace(proposed);
                     }
@@ -293,8 +293,8 @@ namespace NKikimr::NStorage {
 
             // generate new list of drives to acquire
             std::vector<TString> drivesToRead;
-            if (BaseConfig.GetSelfManagementConfig().GetEnabled()) {
-                EnumerateConfigDrives(InitialConfig, SelfId().NodeId(), [&](const auto& /*node*/, const auto& drive) {
+            if (BaseConfig->GetSelfManagementConfig().GetEnabled()) {
+                EnumerateConfigDrives(*InitialConfig, SelfId().NodeId(), [&](const auto& /*node*/, const auto& drive) {
                     drivesToRead.push_back(drive.GetPath());
                 });
                 std::sort(drivesToRead.begin(), drivesToRead.end());
@@ -304,9 +304,9 @@ namespace NKikimr::NStorage {
                 DrivesToRead = std::move(drivesToRead);
                 ReadConfig();
             } else {
-                ApplyStorageConfig(InitialConfig);
+                ApplyStorageConfig(*InitialConfig);
                 Y_ABORT_UNLESS(DirectBoundNodes.empty()); // ensure we don't have to spread this config
-                InitialConfig.Clear();
+                InitialConfig = std::make_shared<NKikimrBlobStorage::TStorageConfig>();
                 StorageConfigLoaded = true;
             }
         }

--- a/ydb/core/blobstorage/nodewarden/distconf_ut.cpp
+++ b/ydb/core/blobstorage/nodewarden/distconf_ut.cpp
@@ -24,13 +24,13 @@ namespace NBlobStorageNodeWardenTest{
 Y_UNIT_TEST_SUITE(TDistconfGenerateConfigTest) {
 
     NKikimrConfig::TDomainsConfig::TStateStorage GenerateSimpleStateStorage(ui32 nodes) {
+        NKikimr::NStorage::TDistributedConfigKeeper keeper(nullptr, nullptr, true);
         NKikimrConfig::TDomainsConfig::TStateStorage ss;
         NKikimrBlobStorage::TStorageConfig config;
         for (ui32 i : xrange(nodes)) {
             auto *node = config.AddAllNodes();
             node->SetNodeId(i + 1);
         }
-        NKikimr::NStorage::TDistributedConfigKeeper keeper(nullptr, config, true);
         keeper.GenerateStateStorageConfig(&ss, config);
         return ss;
     }
@@ -38,6 +38,7 @@ Y_UNIT_TEST_SUITE(TDistconfGenerateConfigTest) {
     NKikimrConfig::TDomainsConfig::TStateStorage GenerateDCStateStorage(ui32 dcCnt, ui32 racksCnt,  ui32 nodesInRack) {
         NKikimrBlobStorage::TStorageConfig config;
         ui32 nodeId = 1;
+        NKikimr::NStorage::TDistributedConfigKeeper keeper(nullptr, nullptr, true);
         for (ui32 dc : xrange(dcCnt)) {
             for (ui32 rack : xrange(racksCnt)) {
                 for (auto _ : xrange(nodesInRack)) {
@@ -49,7 +50,6 @@ Y_UNIT_TEST_SUITE(TDistconfGenerateConfigTest) {
             }
         }
         NKikimrConfig::TDomainsConfig::TStateStorage ss;
-        NKikimr::NStorage::TDistributedConfigKeeper keeper(nullptr, config, true);
         keeper.GenerateStateStorageConfig(&ss, config);
         return ss;
     }

--- a/ydb/core/blobstorage/nodewarden/node_warden_events.h
+++ b/ydb/core/blobstorage/nodewarden/node_warden_events.h
@@ -13,7 +13,7 @@ namespace NKikimr::NStorage {
         TEvNodeConfigPush() = default;
 
         bool IsUseful() const {
-            return Record.BoundNodesSize() || Record.DeletedBoundNodeIdsSize();
+            return Record.BoundNodesSize() || Record.DeletedBoundNodeIdsSize() || Record.HasCacheUpdate();
         }
     };
 
@@ -114,6 +114,42 @@ namespace NKikimr::NStorage {
         TEvNodeWardenWriteMetadataResult(std::optional<ui64> guid, NPDisk::EPDiskMetadataOutcome outcome)
             : Guid(guid)
             , Outcome(outcome)
+        {}
+    };
+
+    struct TEvNodeWardenUpdateCache : TEventLocal<TEvNodeWardenUpdateCache, TEvBlobStorage::EvNodeWardenUpdateCache> {
+        NKikimrBlobStorage::TCacheUpdate CacheUpdate;
+
+        TEvNodeWardenUpdateCache(NKikimrBlobStorage::TCacheUpdate&& cacheUpdate)
+            : CacheUpdate(std::move(cacheUpdate))
+        {}
+    };
+
+    struct TEvNodeWardenQueryCache : TEventLocal<TEvNodeWardenQueryCache, TEvBlobStorage::EvNodeWardenQueryCache> {
+        TString Key;
+        bool Subscribe;
+
+        TEvNodeWardenQueryCache(TString key, bool subscribe)
+            : Key(std::move(key))
+            , Subscribe(subscribe)
+        {}
+    };
+
+    struct TEvNodeWardenQueryCacheResult : TEventLocal<TEvNodeWardenQueryCacheResult, TEvBlobStorage::EvNodeWardenQueryCacheResult> {
+        TString Key;
+        std::optional<std::tuple<ui32, TString>> GenerationValue;
+
+        TEvNodeWardenQueryCacheResult(TString key, std::optional<std::tuple<ui32, TString>> generationValue)
+            : Key(std::move(key))
+            , GenerationValue(std::move(generationValue))
+        {}
+    };
+
+    struct TEvNodeWardenUnsubscribeFromCache : TEventLocal<TEvNodeWardenUnsubscribeFromCache, TEvBlobStorage::EvNodeWardenUnsubscribeFromCache> {
+        TString Key;
+
+        TEvNodeWardenUnsubscribeFromCache(TString key)
+            : Key(std::move(key))
         {}
     };
 

--- a/ydb/core/blobstorage/nodewarden/node_warden_group.cpp
+++ b/ydb/core/blobstorage/nodewarden/node_warden_group.cpp
@@ -1,5 +1,6 @@
 #include "node_warden.h"
 #include "node_warden_impl.h"
+#include "node_warden_events.h"
 
 #include <ydb/core/blob_depot/agent/agent.h>
 
@@ -289,6 +290,7 @@ namespace NKikimr::NStorage {
                         TActivationContext::Send(new IEventHandle(TEvents::TSystem::Poison, 0, group.GroupResolver, {}, nullptr, 0));
                     }
                     Groups.erase(groupId);
+                    Send(SelfId(), new TEvNodeWardenUnsubscribeFromCache(Sprintf("G%08" PRIx32, groupId)));
 
                     // report group deletion to whiteboard
                     Send(WhiteboardId, new NNodeWhiteboard::TEvWhiteboard::TEvBSGroupStateDelete(groupId));

--- a/ydb/core/blobstorage/nodewarden/node_warden_group.cpp
+++ b/ydb/core/blobstorage/nodewarden/node_warden_group.cpp
@@ -115,16 +115,9 @@ namespace NKikimr::NStorage {
 
         // forget pending queries
         if (fromController) {
-            group.GetGroupRequestPending = false;
             group.ProposeRequestPending = false;
-        } else if (fromResolver) {
-            group.GetGroupRequestPending = false;
         }
-
-        if (group.GroupResolver && !group.GetGroupRequestPending) {
-            TActivationContext::Send(new IEventHandle(TEvents::TSystem::Poison, 0, group.GroupResolver, {}, nullptr, 0));
-            group.GroupResolver = {};
-        }
+        group.GetGroupRequestPending = false;
 
         // update group content and encryption stuff
         bool groupChanged = false; // did the 'Group' field change somehow?
@@ -260,6 +253,11 @@ namespace NKikimr::NStorage {
                 GroupPendingQueue.erase(it);
             }
         }
+
+        if (group.GroupResolver && group.Info) {
+            TActivationContext::Send(new IEventHandle(TEvents::TSystem::Poison, 0, group.GroupResolver, {}, nullptr, 0));
+            group.GroupResolver = {};
+        }
     }
 
     void TNodeWarden::RequestGroupConfig(ui32 groupId, TGroupRecord& group) {
@@ -273,6 +271,7 @@ namespace NKikimr::NStorage {
             SendToController(std::make_unique<TEvBlobStorage::TEvControllerGetGroup>(LocalNodeId, &groupId, &groupId + 1));
             group.GroupResolver = RegisterWithSameMailbox(CreateGroupResolverActor(groupId));
             group.GetGroupRequestPending = true;
+            Send(SelfId(), new TEvNodeWardenQueryCache(Sprintf("G%08" PRIx32, groupId), true));
         }
     }
 

--- a/ydb/core/blobstorage/nodewarden/node_warden_impl.cpp
+++ b/ydb/core/blobstorage/nodewarden/node_warden_impl.cpp
@@ -160,6 +160,9 @@ STATEFN(TNodeWarden::StateOnline) {
         fFunc(TEvBlobStorage::EvNodeConfigInvokeOnRoot, ForwardToDistributedConfigKeeper);
         fFunc(TEvBlobStorage::EvNodeWardenDynamicConfigSubscribe, ForwardToDistributedConfigKeeper);
         fFunc(TEvBlobStorage::EvNodeWardenDynamicConfigPush, ForwardToDistributedConfigKeeper);
+        fFunc(TEvBlobStorage::EvNodeWardenUpdateCache, ForwardToDistributedConfigKeeper);
+        fFunc(TEvBlobStorage::EvNodeWardenQueryCache, ForwardToDistributedConfigKeeper);
+        fFunc(TEvBlobStorage::EvNodeWardenUnsubscribeFromCache, ForwardToDistributedConfigKeeper);
 
         hFunc(TEvNodeWardenQueryBaseConfig, Handle);
         hFunc(TEvNodeConfigInvokeOnRootResult, Handle);
@@ -169,6 +172,8 @@ STATEFN(TNodeWarden::StateOnline) {
         hFunc(TEvNodeWardenReadMetadata, Handle);
         hFunc(TEvNodeWardenWriteMetadata, Handle);
         hFunc(TEvPrivate::TEvDereferencePDisk, Handle);
+
+        hFunc(TEvNodeWardenQueryCacheResult, Handle);
 
         default:
             EnqueuePendingMessage(ev);

--- a/ydb/core/blobstorage/nodewarden/node_warden_impl.cpp
+++ b/ydb/core/blobstorage/nodewarden/node_warden_impl.cpp
@@ -1,6 +1,7 @@
 #include "node_warden.h"
 #include "node_warden_events.h"
 #include "node_warden_impl.h"
+#include "distconf.h"
 
 #include <google/protobuf/util/message_differencer.h>
 #include <ydb/core/blobstorage/common/immediate_control_defaults.h>
@@ -449,8 +450,11 @@ void TNodeWarden::Bootstrap() {
         appConfig.MutableSelfManagementConfig()->CopyFrom(*Cfg->SelfManagementConfig);
     }
     TString errorReason;
-    const bool success = DeriveStorageConfig(appConfig, &StorageConfig, &errorReason);
+    auto config = std::make_shared<NKikimrBlobStorage::TStorageConfig>();
+    const bool success = DeriveStorageConfig(appConfig, config.get(), &errorReason);
     Y_VERIFY_S(success, "failed to generate initial TStorageConfig: " << errorReason);
+    TDistributedConfigKeeper::UpdateFingerprint(config.get());
+    StorageConfig = std::move(config);
 
     YamlConfig = std::move(Cfg->YamlConfig);
 
@@ -899,7 +903,7 @@ void TNodeWarden::SendDropDonorQuery(ui32 nodeId, ui32 pdiskId, ui32 vslotId, co
         }
         InvokeCallbacks.emplace(cookie, [=](TEvNodeConfigInvokeOnRootResult& msg) {
             if (msg.Record.GetStatus() != NKikimrBlobStorage::TEvNodeConfigInvokeOnRootResult::OK) {
-                for (const auto& vdisk : StorageConfig.GetBlobStorageConfig().GetServiceSet().GetVDisks()) {
+                for (const auto& vdisk : StorageConfig->GetBlobStorageConfig().GetServiceSet().GetVDisks()) {
                     const TVDiskID currentVDiskId = VDiskIDFromVDiskID(vdisk.GetVDiskID());
                     const auto& loc = vdisk.GetVDiskLocation();
                     if (currentVDiskId.SameExceptGeneration(vdiskId) &&
@@ -948,7 +952,7 @@ void TNodeWarden::SendVDiskReport(TVSlotId vslotId, const TVDiskID &vDiskId,
         }
         InvokeCallbacks.emplace(cookie, [=](TEvNodeConfigInvokeOnRootResult& msg) {
             if (msg.Record.GetStatus() != NKikimrBlobStorage::TEvNodeConfigInvokeOnRootResult::OK) {
-                for (const auto& vdisk : StorageConfig.GetBlobStorageConfig().GetServiceSet().GetVDisks()) {
+                for (const auto& vdisk : StorageConfig->GetBlobStorageConfig().GetServiceSet().GetVDisks()) {
                     const TVDiskID currentVDiskId = VDiskIDFromVDiskID(vdisk.GetVDiskID());
                     const auto& loc = vdisk.GetVDiskLocation();
                     if (currentVDiskId == vDiskId && loc.GetNodeID() == vslotId.NodeId &&
@@ -1154,7 +1158,7 @@ void TNodeWarden::Handle(TEvStatusUpdate::TPtr ev) {
             const auto& info = r->GroupInfo;
 
             if (const ui32 groupId = info->GroupID.GetRawId(); TGroupID(groupId).ConfigurationType() == EGroupConfigurationType::Static) {
-                for (const auto& item : StorageConfig.GetBlobStorageConfig().GetServiceSet().GetVDisks()) {
+                for (const auto& item : StorageConfig->GetBlobStorageConfig().GetServiceSet().GetVDisks()) {
                     const TVDiskID vdiskId = VDiskIDFromVDiskID(item.GetVDiskID());
                     if (vdiskId.GroupID.GetRawId() == groupId && info->GetTopology().GetOrderNumber(vdiskId) == r->OrderNumber &&
                             item.HasDonorMode() && item.GetEntityStatus() != NKikimrBlobStorage::EEntityStatus::DESTROY) {

--- a/ydb/core/blobstorage/nodewarden/node_warden_impl.h
+++ b/ydb/core/blobstorage/nodewarden/node_warden_impl.h
@@ -21,6 +21,7 @@ namespace NKikimr::NStorage {
     struct TEvNodeConfigInvokeOnRootResult;
     struct TEvNodeWardenQueryBaseConfig;
     struct TEvNodeWardenWriteMetadata;
+    struct TEvNodeWardenQueryCacheResult;
 
     constexpr ui32 ProxyConfigurationTimeoutMilliseconds = 200;
     constexpr TDuration BackoffMin = TDuration::MilliSeconds(20);
@@ -557,6 +558,8 @@ namespace NKikimr::NStorage {
 
         // process group information obtained by one of managed entities
         void Handle(TEvBlobStorage::TEvUpdateGroupInfo::TPtr ev);
+
+        void Handle(TAutoPtr<TEventHandle<TEvNodeWardenQueryCacheResult>> ev);
 
         void HandleGetGroup(TAutoPtr<IEventHandle> ev);
 

--- a/ydb/core/blobstorage/nodewarden/node_warden_impl.h
+++ b/ydb/core/blobstorage/nodewarden/node_warden_impl.h
@@ -639,7 +639,7 @@ namespace NKikimr::NStorage {
         void StartDistributedConfigKeeper();
         void ForwardToDistributedConfigKeeper(STATEFN_SIG);
 
-        NKikimrBlobStorage::TStorageConfig StorageConfig;
+        std::shared_ptr<const NKikimrBlobStorage::TStorageConfig> StorageConfig;
         bool SelfManagementEnabled = false;
         THashSet<TActorId> StorageConfigSubscribers;
 

--- a/ydb/core/blobstorage/nodewarden/node_warden_mon.cpp
+++ b/ydb/core/blobstorage/nodewarden/node_warden_mon.cpp
@@ -107,7 +107,7 @@ void TNodeWarden::RenderWholePage(IOutputStream& out) {
         DIV() {
             out << "<p>Self-management enabled: " << (SelfManagementEnabled ? "yes" : "no") << "</p>";
             out << "<pre>";
-            OutputPrettyMessage(out, StorageConfig);
+            OutputPrettyMessage(out, *StorageConfig);
             out << "</pre>";
         }
 

--- a/ydb/core/blobstorage/nodewarden/node_warden_proxy.cpp
+++ b/ydb/core/blobstorage/nodewarden/node_warden_proxy.cpp
@@ -1,5 +1,6 @@
 #include "node_warden.h"
 #include "node_warden_impl.h"
+#include "node_warden_events.h"
 
 #include <ydb/core/blobstorage/dsproxy/dsproxy.h>
 #include <ydb/core/blobstorage/dsproxy/mock/dsproxy_mock.h>
@@ -95,6 +96,9 @@ void TNodeWarden::StartLocalProxy(ui32 groupId) {
             }
         }));
     }
+
+    // subscribe for group information changes through distconf cache
+    Send(SelfId(), new TEvNodeWardenQueryCache(Sprintf("G%08" PRIx32, groupId), true));
 
     group.ProxyId = as->Register(proxy.release(), TMailboxType::ReadAsFilled, AppData()->SystemPoolId);
     as->RegisterLocalService(MakeBlobStorageProxyID(groupId), group.ProxyId);
@@ -194,6 +198,21 @@ void TNodeWarden::Handle(NNodeWhiteboard::TEvWhiteboard::TEvBSGroupStateUpdate::
     const ui32 groupId = record.GetGroupID();
     if (const auto it = Groups.find(groupId); it != Groups.end() && it->second.ProxyId) {
         TActivationContext::Send(ev->Forward(WhiteboardId));
+    }
+}
+
+void TNodeWarden::Handle(TEvNodeWardenQueryCacheResult::TPtr ev) {
+    auto& msg = *ev->Get();
+    ui32 groupId;
+    if (msg.Key.StartsWith("G") && TryIntFromString<16>(msg.Key.substr(1), groupId) && msg.GenerationValue) {
+        auto& [generation, value] = *msg.GenerationValue;
+        NKikimrBlobStorage::TGroupInfo groupInfo;
+        const bool success = groupInfo.ParseFromString(value);
+        Y_DEBUG_ABORT_UNLESS(success);
+        if (success) {
+            Y_DEBUG_ABORT_UNLESS(groupInfo.GetGroupGeneration() == generation);
+            ApplyGroupInfo(groupId, generation, &groupInfo, false, false);
+        }
     }
 }
 

--- a/ydb/core/blobstorage/nodewarden/node_warden_resource.cpp
+++ b/ydb/core/blobstorage/nodewarden/node_warden_resource.cpp
@@ -166,20 +166,14 @@ void TNodeWarden::ApplyStateStorageConfig(const NKikimrBlobStorage::TStorageConf
     }
 
     // apply updates for the state storage proxy
-<<<<<<< HEAD
 #define FETCH_CONFIG(PART, PREFIX, PROTO) \
-    Y_ABORT_UNLESS(StorageConfig.Has##PROTO##Config()); \
+    Y_ABORT_UNLESS(StorageConfig->Has##PROTO##Config()); \
     char PART##Prefix[TActorId::MaxServiceIDLength] = PREFIX; \
-    TIntrusivePtr<TStateStorageInfo> PART##Info = BuildStateStorageInfo(PART##Prefix, StorageConfig.Get##PROTO##Config());
+    TIntrusivePtr<TStateStorageInfo> PART##Info = BuildStateStorageInfo(PART##Prefix, StorageConfig->Get##PROTO##Config());
 
     FETCH_CONFIG(stateStorage, "ssr", StateStorage)
     FETCH_CONFIG(board, "ssb", StateStorageBoard)
     FETCH_CONFIG(schemeBoard, "sbr", SchemeBoard)
-=======
-#define FETCH_CONFIG(PART, PROTO) \
-    Y_ABORT_UNLESS(StorageConfig->Has##PROTO##Config()); \
-    TIntrusivePtr<TStateStorageInfo> PART##Info = Build##PROTO##Info(StorageConfig->Get##PROTO##Config());
->>>>>>> a3fdda7cfea (Pass TStorageConfig through pointer to prevent copying when doing subscription fan-out (#18765))
 
     STLOG(PRI_DEBUG, BS_NODE, NW52, "ApplyStateStorageConfig",
         (StateStorageConfig, StorageConfig->GetStateStorageConfig()),

--- a/ydb/core/blobstorage/nodewarden/node_warden_resource.cpp
+++ b/ydb/core/blobstorage/nodewarden/node_warden_resource.cpp
@@ -84,15 +84,16 @@ void TNodeWarden::Handle(TEvNodeWardenQueryStorageConfig::TPtr ev) {
 }
 
 void TNodeWarden::Handle(TEvNodeWardenStorageConfig::TPtr ev) {
-    ev->Get()->Config->Swap(&StorageConfig);
-    SelfManagementEnabled = ev->Get()->SelfManagementEnabled;
+    auto *msg = ev->Get();
+    StorageConfig = std::move(msg->Config);
+    SelfManagementEnabled = msg->SelfManagementEnabled;
 
-    if (StorageConfig.HasBlobStorageConfig()) {
-        if (const auto& bsConfig = StorageConfig.GetBlobStorageConfig(); bsConfig.HasServiceSet()) {
+    if (StorageConfig->HasBlobStorageConfig()) {
+        if (const auto& bsConfig = StorageConfig->GetBlobStorageConfig(); bsConfig.HasServiceSet()) {
             const NKikimrBlobStorage::TNodeWardenServiceSet *proposed = nullptr;
             if (const auto& proposedConfig = ev->Get()->ProposedConfig) {
-                Y_VERIFY_S(StorageConfig.GetGeneration() < proposedConfig->GetGeneration(),
-                    "StorageConfig.Generation# " << StorageConfig.GetGeneration()
+                Y_VERIFY_S(StorageConfig->GetGeneration() < proposedConfig->GetGeneration(),
+                    "StorageConfig.Generation# " << StorageConfig->GetGeneration()
                     << " ProposedConfig.Generation# " << proposedConfig->GetGeneration());
                 Y_ABORT_UNLESS(proposedConfig->HasBlobStorageConfig()); // must have the BlobStorageConfig and the ServiceSet
                 const auto& proposedBsConfig = proposedConfig->GetBlobStorageConfig();
@@ -103,29 +104,29 @@ void TNodeWarden::Handle(TEvNodeWardenStorageConfig::TPtr ev) {
         }
     }
 
-    if (StorageConfig.HasStateStorageConfig() && StorageConfig.HasStateStorageBoardConfig() && StorageConfig.HasSchemeBoardConfig()) {
+    if (StorageConfig->HasStateStorageConfig() && StorageConfig->HasStateStorageBoardConfig() && StorageConfig->HasSchemeBoardConfig()) {
         ApplyStateStorageConfig(ev->Get()->ProposedConfig.get());
     } else {
-        Y_ABORT_UNLESS(!StorageConfig.HasStateStorageConfig() && !StorageConfig.HasStateStorageBoardConfig() &&
-            !StorageConfig.HasSchemeBoardConfig());
+        Y_ABORT_UNLESS(!StorageConfig->HasStateStorageConfig() && !StorageConfig->HasStateStorageBoardConfig() &&
+            !StorageConfig->HasSchemeBoardConfig());
     }
 
     for (const TActorId& subscriber : StorageConfigSubscribers) {
         Send(subscriber, new TEvNodeWardenStorageConfig(StorageConfig, nullptr, SelfManagementEnabled));
     }
 
-    if (StorageConfig.HasConfigComposite()) {
+    if (StorageConfig->HasConfigComposite()) {
         TString mainConfigYaml;
         ui64 mainConfigYamlVersion;
-        auto error = DecomposeConfig(StorageConfig.GetConfigComposite(), &mainConfigYaml, &mainConfigYamlVersion, nullptr);
+        auto error = DecomposeConfig(StorageConfig->GetConfigComposite(), &mainConfigYaml, &mainConfigYamlVersion, nullptr);
         if (error) {
             STLOG_DEBUG_FAIL(BS_NODE, NW49, "failed to decompose yaml configuration", (Error, error));
         } else if (mainConfigYaml) {
             std::optional<TString> storageConfigYaml;
             std::optional<ui64> storageConfigYamlVersion;
-            if (StorageConfig.HasCompressedStorageYaml()) {
+            if (StorageConfig->HasCompressedStorageYaml()) {
                 try {
-                    TStringInput s(StorageConfig.GetCompressedStorageYaml());
+                    TStringInput s(StorageConfig->GetCompressedStorageYaml());
                     storageConfigYaml.emplace(TZstdDecompress(&s).ReadAll());
                     storageConfigYamlVersion.emplace(NYamlConfig::GetStorageMetadata(*storageConfigYaml).Version.value_or(0));
                 } catch (const std::exception& ex) {
@@ -138,7 +139,7 @@ void TNodeWarden::Handle(TEvNodeWardenStorageConfig::TPtr ev) {
                 storageConfigYamlVersion);
         }
     } else {
-        Y_DEBUG_ABORT_UNLESS(!StorageConfig.HasCompressedStorageYaml());
+        Y_DEBUG_ABORT_UNLESS(!StorageConfig->HasCompressedStorageYaml());
     }
 
     TActivationContext::Send(new IEventHandle(TEvBlobStorage::EvNodeWardenStorageConfigConfirm, 0, ev->Sender, SelfId(),
@@ -165,6 +166,7 @@ void TNodeWarden::ApplyStateStorageConfig(const NKikimrBlobStorage::TStorageConf
     }
 
     // apply updates for the state storage proxy
+<<<<<<< HEAD
 #define FETCH_CONFIG(PART, PREFIX, PROTO) \
     Y_ABORT_UNLESS(StorageConfig.Has##PROTO##Config()); \
     char PART##Prefix[TActorId::MaxServiceIDLength] = PREFIX; \
@@ -173,15 +175,20 @@ void TNodeWarden::ApplyStateStorageConfig(const NKikimrBlobStorage::TStorageConf
     FETCH_CONFIG(stateStorage, "ssr", StateStorage)
     FETCH_CONFIG(board, "ssb", StateStorageBoard)
     FETCH_CONFIG(schemeBoard, "sbr", SchemeBoard)
+=======
+#define FETCH_CONFIG(PART, PROTO) \
+    Y_ABORT_UNLESS(StorageConfig->Has##PROTO##Config()); \
+    TIntrusivePtr<TStateStorageInfo> PART##Info = Build##PROTO##Info(StorageConfig->Get##PROTO##Config());
+>>>>>>> a3fdda7cfea (Pass TStorageConfig through pointer to prevent copying when doing subscription fan-out (#18765))
 
     STLOG(PRI_DEBUG, BS_NODE, NW52, "ApplyStateStorageConfig",
-        (StateStorageConfig, StorageConfig.GetStateStorageConfig()),
+        (StateStorageConfig, StorageConfig->GetStateStorageConfig()),
         (NewStateStorageInfo, *stateStorageInfo),
         (CurrentStateStorageInfo, StateStorageInfo.Get()),
-        (StateStorageBoardConfig, StorageConfig.GetStateStorageBoardConfig()),
+        (StateStorageBoardConfig, StorageConfig->GetStateStorageBoardConfig()),
         (NewStateStorageBoardInfo, *boardInfo),
         (CurrentStateStorageBoardInfo, BoardInfo.Get()),
-        (SchemeBoardConfig, StorageConfig.GetSchemeBoardConfig()),
+        (SchemeBoardConfig, StorageConfig->GetSchemeBoardConfig()),
         (NewSchemeBoardInfo, *schemeBoardInfo),
         (CurrentSchemeBoardInfo, SchemeBoardInfo.Get()));
 

--- a/ydb/core/blobstorage/nodewarden/node_warden_vdisk.cpp
+++ b/ydb/core/blobstorage/nodewarden/node_warden_vdisk.cpp
@@ -218,8 +218,8 @@ namespace NKikimr::NStorage {
 
         vdiskConfig->FeatureFlags = Cfg->FeatureFlags;
 
-        if (StorageConfig.HasBlobStorageConfig() && StorageConfig.GetBlobStorageConfig().HasVDiskPerformanceSettings()) {
-            for (auto &type : StorageConfig.GetBlobStorageConfig().GetVDiskPerformanceSettings().GetVDiskTypes()) {
+        if (StorageConfig->HasBlobStorageConfig() && StorageConfig->GetBlobStorageConfig().HasVDiskPerformanceSettings()) {
+            for (auto &type : StorageConfig->GetBlobStorageConfig().GetVDiskPerformanceSettings().GetVDiskTypes()) {
                 if (type.HasPDiskType() && deviceType == PDiskTypeToPDiskType(type.GetPDiskType())) {
                     if (type.HasMinHugeBlobSizeInBytes()) {
                         vdiskConfig->MinHugeBlobInBytes = type.GetMinHugeBlobSizeInBytes();

--- a/ydb/core/blobstorage/nodewarden/ya.make
+++ b/ydb/core/blobstorage/nodewarden/ya.make
@@ -6,6 +6,7 @@ SRCS(
     distconf.cpp
     distconf.h
     distconf_binding.cpp
+    distconf_cache.cpp
     distconf_console.cpp
     distconf_dynamic.cpp
     distconf_generate.cpp

--- a/ydb/core/blobstorage/ut_blobstorage/bsc_cache.cpp
+++ b/ydb/core/blobstorage/ut_blobstorage/bsc_cache.cpp
@@ -76,6 +76,7 @@ struct TTestCtx : public TTestCtxBase {
 
         std::set<ui32> nodesWithVDisks = GetNodesWithVDisks();
         NodesWithConfig.insert(nodesWithVDisks.begin(), nodesWithVDisks.end());
+        Env->Sim(TDuration::Seconds(1));
     }
 
     const TDuration WaitTime = TDuration::Seconds(1);

--- a/ydb/core/blobstorage/ut_blobstorage/bsc_cache.cpp
+++ b/ydb/core/blobstorage/ut_blobstorage/bsc_cache.cpp
@@ -51,6 +51,7 @@ struct TTestCtx : public TTestCtxBase {
     void StartNode() {
         Env->StartNode(NodeWithProxy);
         AllocateEdgeActorOnNodeWOConfig();
+        Env->Sim(TDuration::Seconds(1));
     }
 
     void RestartNode() {

--- a/ydb/core/blobstorage/ut_blobstorage/bsc_cache.cpp
+++ b/ydb/core/blobstorage/ut_blobstorage/bsc_cache.cpp
@@ -1,0 +1,122 @@
+#include <ydb/core/blobstorage/ut_blobstorage/lib/env.h>
+#include <ydb/core/blobstorage/ut_blobstorage/ut_helpers.h>
+
+Y_UNIT_TEST_SUITE(GroupConfigurationPropagation) {
+
+struct TTestCtx : public TTestCtxBase {
+    TTestCtx(const TBlobStorageGroupType& erasure)
+        : TTestCtxBase(TEnvironmentSetup::TSettings{
+            .NodeCount = erasure.BlobSubgroupSize() * 2,
+            .Erasure = erasure,
+            .ControllerNodeId = erasure.BlobSubgroupSize() * 2,
+        })
+    {}
+
+    static bool BlockBscResponses(ui32, std::unique_ptr<IEventHandle>& ev) {
+        if (ev->GetTypeRewrite() == TEvBlobStorage::TEvControllerNodeServiceSetUpdate::EventType) {
+            return false;
+        }
+        
+        return true;
+    }
+
+    void AllocateEdgeActorOnNodeWOConfig() {
+        std::set<ui32> nodesWOConfig = GetComplementNodeSet(NodesWithConfig);
+        UNIT_ASSERT(!NodesWithConfig.empty());
+        AllocateEdgeActorOnSpecificNode(*nodesWOConfig.begin());
+        NodeWithProxy = Edge.NodeId();
+    }
+
+    void CheckStatus() {
+        AllocateEdgeActorOnNodeWOConfig();
+        auto res = GetGroupStatus(GroupId, WaitTime);
+        UNIT_ASSERT(res);
+        UNIT_ASSERT_VALUES_EQUAL_C(res->Get()->Status, NKikimrProto::OK, res->Get()->ErrorReason);
+    }
+
+    void Setup() {
+        Initialize();
+        NodesWithConfig = GetNodesWithVDisks();
+        NodesWithConfig.insert(Env->Settings.ControllerNodeId);
+        AllocateEdgeActorOnNodeWOConfig();
+        UNIT_ASSERT(NodeWithProxy != Env->Settings.ControllerNodeId);
+        Env->Sim(TDuration::Minutes(10));
+        Env->Runtime->FilterFunction = BlockBscResponses;
+    }
+
+    void StopNode() {
+        Env->StopNode(NodeWithProxy);
+    }
+
+    void StartNode() {
+        Env->StartNode(NodeWithProxy);
+        AllocateEdgeActorOnNodeWOConfig();
+    }
+
+    void RestartNode() {
+        StopNode();
+        StartNode();
+    }
+
+    void UpdateGroupConfiguration() {
+        NKikimrBlobStorage::TConfigRequest request;
+        auto* reassign = request.AddCommand()->MutableReassignGroupDisk();
+        for (const auto& slot : BaseConfig.GetVSlot()) {
+            if (slot.GetGroupId() == GroupId) {
+                reassign->SetGroupId(slot.GetGroupId());
+                reassign->SetGroupGeneration(slot.GetGroupGeneration());
+                reassign->SetFailRealmIdx(slot.GetFailRealmIdx());
+                reassign->SetFailDomainIdx(slot.GetFailDomainIdx());
+                reassign->SetVDiskIdx(slot.GetVDiskIdx());
+                break;
+            }
+        }
+        auto response = Env->Invoke(request);
+        BaseConfig = Env->FetchBaseConfig();
+
+        std::set<ui32> nodesWithVDisks = GetNodesWithVDisks();
+        NodesWithConfig.insert(nodesWithVDisks.begin(), nodesWithVDisks.end());
+    }
+
+    const TDuration WaitTime = TDuration::Seconds(1);
+    ui32 NodeWithProxy;
+    std::set<ui32> NodesWithConfig;
+};
+
+Y_UNIT_TEST(Simple) {
+    TTestCtx ctx(TBlobStorageGroupType::Erasure4Plus2Block);
+    ctx.Setup();
+    ctx.CheckStatus();
+}
+
+Y_UNIT_TEST(Reassign) {
+    TTestCtx ctx(TBlobStorageGroupType::Erasure4Plus2Block);
+    ctx.Setup();
+    ctx.UpdateGroupConfiguration();
+    ctx.CheckStatus();
+}
+
+Y_UNIT_TEST(NodeRestart) {
+    TTestCtx ctx(TBlobStorageGroupType::Erasure4Plus2Block);
+    ctx.Setup();
+    ctx.RestartNode();
+    ctx.CheckStatus();
+}
+
+Y_UNIT_TEST(NodeRestartAndUpdate) {
+    TTestCtx ctx(TBlobStorageGroupType::Erasure4Plus2Block);
+    ctx.Setup();
+    ctx.StopNode();
+    ctx.UpdateGroupConfiguration();
+    ctx.StartNode();
+    ctx.CheckStatus();
+}
+
+Y_UNIT_TEST(BscRestart) {
+    TTestCtx ctx(TBlobStorageGroupType::Erasure4Plus2Block);
+    ctx.Setup();
+    ctx.Env->RestartNode(ctx.Env->Settings.ControllerNodeId);
+    ctx.CheckStatus();
+}
+
+}

--- a/ydb/core/blobstorage/ut_blobstorage/bsc_cache.cpp
+++ b/ydb/core/blobstorage/ut_blobstorage/bsc_cache.cpp
@@ -1,5 +1,5 @@
 #include <ydb/core/blobstorage/ut_blobstorage/lib/env.h>
-#include <ydb/core/blobstorage/ut_blobstorage/ut_helpers.h>
+#include <ydb/core/blobstorage/ut_blobstorage/lib/ut_helpers.h>
 
 Y_UNIT_TEST_SUITE(GroupConfigurationPropagation) {
 

--- a/ydb/core/blobstorage/ut_blobstorage/lib/defs.h
+++ b/ydb/core/blobstorage/ut_blobstorage/lib/defs.h
@@ -9,6 +9,7 @@
 #include <ydb/core/blobstorage/pdisk/mock/pdisk_mock.h>
 #include <ydb/core/blobstorage/backpressure/queue_backpressure_client.h>
 #include <ydb/core/blobstorage/nodewarden/node_warden.h>
+#include <ydb/core/blobstorage/nodewarden/node_warden_events.h>
 #include <ydb/core/blobstorage/vdisk/common/vdisk_private_events.h>
 #include <ydb/core/node_whiteboard/node_whiteboard.h>
 #include <ydb/core/mind/bscontroller/bsc.h>

--- a/ydb/core/blobstorage/ut_blobstorage/lib/env.h
+++ b/ydb/core/blobstorage/ut_blobstorage/lib/env.h
@@ -381,7 +381,7 @@ struct TEnvironmentSetup {
 //            NKikimrServices::BS_VDISK_PATCH,
 //            NKikimrServices::BS_VDISK_PUT,
 //            NKikimrServices::BS_VDISK_OTHER,
-            NKikimrServices::BS_VDISK_SCRUB,
+//            NKikimrServices::BS_VDISK_SCRUB,
 //            NKikimrServices::BS_PROXY,
 //            NKikimrServices::BS_PROXY_RANGE,
 //            NKikimrServices::BS_PROXY_GET,

--- a/ydb/core/blobstorage/ut_blobstorage/lib/node_warden_mock.h
+++ b/ydb/core/blobstorage/ut_blobstorage/lib/node_warden_mock.h
@@ -128,5 +128,8 @@ public:
         IgnoreFunc(NNodeWhiteboard::TEvWhiteboard::TEvBSGroupStateUpdate);
         hFunc(TEvNodeWardenQueryStorageConfig, Handle);
         fFunc(TEvents::TSystem::Unsubscribe, HandleUnsubscribe);
+        IgnoreFunc(NStorage::TEvNodeWardenUpdateCache);
+        IgnoreFunc(NStorage::TEvNodeWardenQueryCache);
+        IgnoreFunc(NStorage::TEvNodeWardenUnsubscribeFromCache);
     )
 };

--- a/ydb/core/blobstorage/ut_blobstorage/lib/node_warden_mock_bsc.cpp
+++ b/ydb/core/blobstorage/ut_blobstorage/lib/node_warden_mock_bsc.cpp
@@ -226,7 +226,8 @@ void TNodeWardenMockActor::Handle(TEvBlobStorage::TEvControllerNodeServiceSetUpd
 }
 
 void TNodeWardenMockActor::Handle(TEvNodeWardenQueryStorageConfig::TPtr ev) {
-    Send(ev->Sender, new TEvNodeWardenStorageConfig(NKikimrBlobStorage::TStorageConfig(), nullptr, false));
+    Send(ev->Sender, new TEvNodeWardenStorageConfig(std::make_shared<NKikimrBlobStorage::TStorageConfig>(),
+        nullptr, false));
 }
 
 void TNodeWardenMockActor::HandleUnsubscribe(STATEFN_SIG) {

--- a/ydb/core/blobstorage/ut_blobstorage/lib/ut_helpers.h
+++ b/ydb/core/blobstorage/ut_blobstorage/lib/ut_helpers.h
@@ -283,33 +283,29 @@ public:
         if (!findNodeWithoutVDisks) {
             chosenNodeId = NodeCount;
         } else {
-            std::set<ui32> nodesWithoutVDisks;
-            for (ui32 nodeId = 1; nodeId <= NodeCount; ++nodeId) {
-                nodesWithoutVDisks.insert(nodeId);
-            }
-    
-            for (const auto& vslot : BaseConfig.GetVSlot()) {
-                nodesWithoutVDisks.erase(vslot.GetVSlotId().GetNodeId());
-            }
-
-            if (!nodesWithoutVDisks.empty()) {
-                chosenNodeId = *nodesWithoutVDisks.begin();
-            }
+            std::set<ui32> nodesWOVDisks = GetComplementNodeSet(GetNodesWithVDisks());
+            chosenNodeId = *nodesWOVDisks.begin();
         }
 
         Y_VERIFY_S(chosenNodeId != 0, "No available nodes to allocate");
-        Edge = Env->Runtime->AllocateEdgeActor(NodeCount);
+        Edge = Env->Runtime->AllocateEdgeActor(chosenNodeId);
+    }
+
+    void AllocateEdgeActorOnSpecificNode(ui32 nodeId) {
+        Edge = Env->Runtime->AllocateEdgeActor(nodeId);
     }
 
     void FetchBaseConfig() {
         BaseConfig = Env->FetchBaseConfig();
     }
 
-    TAutoPtr<TEventHandle<TEvBlobStorage::TEvStatusResult>> GetGroupStatus(ui32 groupId) {
+    TAutoPtr<TEventHandle<TEvBlobStorage::TEvStatusResult>> GetGroupStatus(ui32 groupId,
+            TDuration waitTime = TDuration::Max()) {
+        TInstant ts = (waitTime == TDuration::Max()) ? TInstant::Max() : Env->Now() + waitTime;
         Env->Runtime->WrapInActorContext(Edge, [&] {
-            SendToBSProxy(Edge, groupId, new TEvBlobStorage::TEvStatus(TInstant::Max()));
+            SendToBSProxy(Edge, groupId, new TEvBlobStorage::TEvStatus(ts));
         });
-        return Env->WaitForEdgeActorEvent<TEvBlobStorage::TEvStatusResult>(Edge, false, TInstant::Max());
+        return Env->WaitForEdgeActorEvent<TEvBlobStorage::TEvStatusResult>(Edge, false, ts);
     }
 
     virtual void Initialize() {
@@ -406,6 +402,24 @@ public:
             }
         }
         return blobs;
+    }
+
+    std::set<ui32> GetNodesWithVDisks() {
+        std::set<ui32> res;
+        for (const auto& vslot : BaseConfig.GetVSlot()) {
+            res.insert(vslot.GetVSlotId().GetNodeId());
+        }
+        return res;
+    }
+
+    std::set<ui32> GetComplementNodeSet(std::set<ui32> nodes) {
+        std::set<ui32> res;
+        for (ui32 nodeId = 1; nodeId <= NodeCount; ++nodeId) {
+            if (!nodes.contains(nodeId)) {
+                res.insert(nodeId);
+            }
+        }
+        return res;
     }
 
 public:

--- a/ydb/core/blobstorage/ut_blobstorage/ya.make
+++ b/ydb/core/blobstorage/ut_blobstorage/ya.make
@@ -17,6 +17,7 @@ SRCS(
     acceleration.cpp
     assimilation.cpp
     block_race.cpp
+    bsc_cache.cpp
     counting_events.cpp
     deadlines.cpp
     decommit_3dc.cpp

--- a/ydb/core/mind/bscontroller/cmds_storage_pool.cpp
+++ b/ydb/core/mind/bscontroller/cmds_storage_pool.cpp
@@ -560,8 +560,8 @@ namespace NKikimr::NBsController {
                 x->SetStatus(NKikimrBlobStorage::EVDiskStatus_Name(vslot.VDiskStatus.value_or(NKikimrBlobStorage::EVDiskStatus::ERROR)));
                 x->SetReady(vslot.ReadySince <= mono);
             }
-            if (const auto& s = Self.StorageConfig; s.HasBlobStorageConfig()) {
-                if (const auto& bsConfig = s.GetBlobStorageConfig(); bsConfig.HasServiceSet()) {
+            if (const auto& s = Self.StorageConfig; s && s->HasBlobStorageConfig()) {
+                if (const auto& bsConfig = s->GetBlobStorageConfig(); bsConfig.HasServiceSet()) {
                     const auto& ss = bsConfig.GetServiceSet();
                     for (const auto& group : ss.GetGroups()) {
                         auto *x = pb->AddGroup();

--- a/ydb/core/mind/bscontroller/commit_config.cpp
+++ b/ydb/core/mind/bscontroller/commit_config.cpp
@@ -43,8 +43,8 @@ namespace NKikimr::NBsController {
         bool Execute(TTransactionContext& txc, const TActorContext&) override {
             NIceDb::TNiceDb db(txc.DB);
             auto& conf = Self->StorageConfig;
-            GenerationOnStart = conf.GetGeneration();
-            FingerprintOnStart = conf.GetFingerprint();
+            GenerationOnStart = conf->GetGeneration();
+            FingerprintOnStart = conf->GetFingerprint();
             auto row = db.Table<Schema::State>().Key(true);
             if (YamlConfig) {
                 row.Update<Schema::State::YamlConfig>(CompressYamlConfig(*YamlConfig));
@@ -67,7 +67,7 @@ namespace NKikimr::NBsController {
 
         void Complete(const TActorContext& ctx) override {
             auto& conf = Self->StorageConfig;
-            if (conf.GetGeneration() != GenerationOnStart || conf.GetFingerprint() != FingerprintOnStart) {
+            if (conf->GetGeneration() != GenerationOnStart || conf->GetFingerprint() != FingerprintOnStart) {
                 LOG_ALERT_S(ctx, NKikimrServices::BS_CONTROLLER, "Storage config changed");
                 Y_DEBUG_ABORT("Storage config changed");
             }
@@ -100,7 +100,7 @@ namespace NKikimr::NBsController {
             }
 
             if (StorageConfig) {
-                Self->StorageConfig = std::move(*StorageConfig);
+                Self->StorageConfig = std::make_shared<NKikimrBlobStorage::TStorageConfig>(*StorageConfig);
                 Self->ApplyStorageConfig(true);
             }
 

--- a/ydb/core/mind/bscontroller/config.cpp
+++ b/ydb/core/mind/bscontroller/config.cpp
@@ -3,6 +3,8 @@
 #include "diff.h"
 #include "table_merger.h"
 
+#include <ydb/core/blobstorage/nodewarden/node_warden_events.h>
+
 namespace NKikimr::NBsController {
 
         class TBlobStorageController::TNodeWardenUpdateNotifier {
@@ -10,6 +12,7 @@ namespace NKikimr::NBsController {
             TConfigState &State;
             THashMap<TNodeId, NKikimrBlobStorage::TEvControllerNodeServiceSetUpdate> Services;
             THashSet<TPDiskId> DeletedPDiskIds;
+            NKikimrBlobStorage::TCacheUpdate CacheUpdate;
 
         public:
             TNodeWardenUpdateNotifier(TBlobStorageController *self, TConfigState &state)
@@ -33,6 +36,11 @@ namespace NKikimr::NBsController {
                         record.SetAvailDomain(AppData()->DomainsInfo->GetDomain()->DomainUid);
                         State.Outbox.emplace_back(nodeId, std::move(event), 0);
                     }
+                }
+
+                if (CacheUpdate.KeyValuePairsSize()) {
+                    State.Outbox.emplace_back(Self->SelfId().NodeId(), std::make_unique<NStorage::TEvNodeWardenUpdateCache>(
+                        std::move(CacheUpdate)), 0);
                 }
             }
 
@@ -258,9 +266,11 @@ namespace NKikimr::NBsController {
                 const TString storagePoolName = info.Name;
 
                 // push group information to each node that will receive VDisk status update
+                NKikimrBlobStorage::TGroupInfo proto;
+                SerializeGroupInfo(&proto, groupInfo, storagePoolName, scopeId);
                 for (TNodeId nodeId : nodes) {
                     NKikimrBlobStorage::TNodeWardenServiceSet *service = Services[nodeId].MutableServiceSet();
-                    SerializeGroupInfo(service->AddGroups(), groupInfo, storagePoolName, scopeId);
+                    service->AddGroups()->CopyFrom(proto);
                 }
 
                 // push group state notification to NodeWhiteboard (for virtual groups only)
@@ -274,6 +284,12 @@ namespace NKikimr::NBsController {
                         MakeIntrusive<TBlobStorageGroupInfo>(groupInfo.Topology, std::move(dynInfo), storagePoolName,
                         scopeId, NPDisk::DEVICE_TYPE_UNKNOWN)));
                 }
+
+                auto *kvp = CacheUpdate.AddKeyValuePairs();
+                kvp->SetKey(Sprintf("G%08" PRIx32, groupId));
+                kvp->SetGeneration(groupInfo.Generation);
+                const bool success = proto.SerializeToString(kvp->MutableValue());
+                Y_DEBUG_ABORT_UNLESS(success);
             }
 
             void ApplyGroupDeleted(const TGroupId &groupId, const TGroupInfo& /*groupInfo*/) {
@@ -284,6 +300,10 @@ namespace NKikimr::NBsController {
                     item.SetGroupID(groupId.GetRawId());
                     item.SetEntityStatus(NKikimrBlobStorage::DESTROY);
                 }
+
+                auto *kvp = CacheUpdate.AddKeyValuePairs();
+                kvp->SetKey(Sprintf("G%08" PRIx32, groupId));
+                kvp->SetGeneration(Max<ui32>());
             }
 
             void ApplyGroupDiff(const TGroupId &groupId, const TGroupInfo &prev, const TGroupInfo &cur) {

--- a/ydb/core/mind/bscontroller/config.cpp
+++ b/ydb/core/mind/bscontroller/config.cpp
@@ -40,7 +40,7 @@ namespace NKikimr::NBsController {
 
                 if (CacheUpdate.KeyValuePairsSize()) {
                     State.Outbox.emplace_back(Self->SelfId().NodeId(), std::make_unique<NStorage::TEvNodeWardenUpdateCache>(
-                        std::move(CacheUpdate)), 0);
+                        std::move(CacheUpdate)), 0, true);
                 }
             }
 
@@ -708,8 +708,12 @@ namespace NKikimr::NBsController {
         }
 
         ui64 TBlobStorageController::TConfigState::ApplyConfigUpdates() {
-            for (auto& [nodeId, ev, cookie] : Outbox) {
-                Self.SendToWarden(nodeId, std::move(ev), cookie);
+            for (TOutgoingMessage& msg : Outbox) {
+                if (msg.ToLocalWarden) {
+                    Self.Send(MakeBlobStorageNodeWardenID(Self.SelfId().NodeId()), std::move(msg.Event), 0, msg.Cookie);
+                } else {
+                    Self.SendToWarden(msg.NodeId, std::move(msg.Event), msg.Cookie);
+                }
             }
             for (auto& ev : StatProcessorOutbox) {
                 Self.SelfId().Send(Self.StatProcessorActorId, ev.release());

--- a/ydb/core/mind/bscontroller/config.h
+++ b/ydb/core/mind/bscontroller/config.h
@@ -91,7 +91,22 @@ namespace NKikimr {
             THashSet<TPDiskId> PDisksToRemove;
 
             // outgoing messages
-            std::deque<std::tuple<TNodeId, std::unique_ptr<IEventBase>, ui64>> Outbox;
+            struct TOutgoingMessage {
+                TNodeId NodeId;
+                std::unique_ptr<IEventBase> Event;
+                ui64 Cookie;
+                bool ToLocalWarden;
+
+                TOutgoingMessage(TNodeId nodeId, std::unique_ptr<IEventBase>&& event,
+                        ui64 cookie, bool toLocalWarden = false)
+                    : NodeId(nodeId)
+                    , Event(std::forward<std::unique_ptr<IEventBase>>(event))
+                    , Cookie(cookie)
+                    , ToLocalWarden(toLocalWarden)
+                {}
+            };
+
+            std::deque<TOutgoingMessage> Outbox;
             std::deque<std::unique_ptr<IEventBase>> StatProcessorOutbox;
             std::deque<std::unique_ptr<IEventBase>> NodeWhiteboardOutbox;
             THolder<TEvControllerUpdateSelfHealInfo> UpdateSelfHealInfoMsg;

--- a/ydb/core/mind/bscontroller/impl.h
+++ b/ydb/core/mind/bscontroller/impl.h
@@ -1554,7 +1554,7 @@ private:
     bool TryToRelocateBrokenDisksLocallyFirst = false;
     bool DonorMode = false;
     TDuration ScrubPeriodicity;
-    NKikimrBlobStorage::TStorageConfig StorageConfig;
+    std::shared_ptr<const NKikimrBlobStorage::TStorageConfig> StorageConfig;
     bool SelfManagementEnabled = false;
     std::optional<TYamlConfig> YamlConfig;
     ui64 YamlConfigHash = 0;

--- a/ydb/core/mind/bscontroller/load_everything.cpp
+++ b/ydb/core/mind/bscontroller/load_everything.cpp
@@ -2,6 +2,8 @@
 #include "console_interaction.h"
 #include "group_geometry_info.h"
 
+#include <ydb/core/blobstorage/nodewarden/node_warden_events.h>
+
 #include <ydb/library/yaml_config/yaml_config.h>
 
 namespace NKikimr {
@@ -537,6 +539,31 @@ public:
         }
         for (const auto& key : vdiskMetricsToDelete) {
             db.Table<Schema::VDiskMetrics>().Key(key).Delete();
+        }
+
+        // send notification to node warden about new groups
+        {
+            NKikimrBlobStorage::TCacheUpdate m;
+            for (const auto& [groupId, groupInfo] : Self->GroupMap) {
+                auto *kvp = m.AddKeyValuePairs();
+                kvp->SetKey(Sprintf("G%08" PRIx32, groupId));
+                kvp->SetGeneration(groupInfo->Generation);
+
+                TMaybe<TKikimrScopeId> scopeId;
+                const TStoragePoolInfo& info = Self->StoragePools.at(groupInfo->StoragePoolId);
+                if (info.SchemeshardId && info.PathItemId) {
+                    scopeId = TKikimrScopeId(*info.SchemeshardId, *info.PathItemId);
+                } else {
+                    Y_ABORT_UNLESS(!info.SchemeshardId && !info.PathItemId);
+                }
+
+                NKikimrBlobStorage::TGroupInfo proto;
+                SerializeGroupInfo(&proto, *groupInfo, info.Name, scopeId);
+                const bool success = proto.SerializeToString(kvp->MutableValue());
+                Y_DEBUG_ABORT_UNLESS(success);
+            }
+            const auto& selfId = Self->SelfId();
+            selfId.Send(MakeBlobStorageNodeWardenID(selfId.NodeId()), new NStorage::TEvNodeWardenUpdateCache(std::move(m)));
         }
 
         return true;

--- a/ydb/core/mind/bscontroller/register_node.cpp
+++ b/ydb/core/mind/bscontroller/register_node.cpp
@@ -663,7 +663,7 @@ void TBlobStorageController::EraseKnownDrivesOnDisconnected(TNodeInfo *nodeInfo)
 
 void TBlobStorageController::SendToWarden(TNodeId nodeId, std::unique_ptr<IEventBase> ev, ui64 cookie) {
     Y_ABORT_UNLESS(nodeId);
-    if (auto *node = FindNode(nodeId); node && node->ConnectedServerId) {
+    if (TNodeInfo* node = FindNode(nodeId); node && node->ConnectedServerId) {
         auto h = std::make_unique<IEventHandle>(MakeBlobStorageNodeWardenID(nodeId), SelfId(), ev.release(), 0, cookie);
         if (node->InterconnectSessionId) {
             h->Rewrite(TEvInterconnect::EvForward, node->InterconnectSessionId);

--- a/ydb/core/mind/bscontroller/self_heal.cpp
+++ b/ydb/core/mind/bscontroller/self_heal.cpp
@@ -1035,15 +1035,15 @@ namespace NKikimr::NBsController {
     }
 
     void TBlobStorageController::PushStaticGroupsToSelfHeal() {
-        if (!SelfHealId || !StorageConfigObtained || !StorageConfig.HasBlobStorageConfig() || !SelfManagementEnabled) {
+        if (!SelfHealId || !StorageConfigObtained || !StorageConfig->HasBlobStorageConfig() || !SelfManagementEnabled) {
             return;
         }
 
         auto sh = std::make_unique<TEvControllerUpdateSelfHealInfo>();
 
-        if (const auto& bsConfig = StorageConfig.GetBlobStorageConfig(); bsConfig.HasServiceSet()) {
+        if (const auto& bsConfig = StorageConfig->GetBlobStorageConfig(); bsConfig.HasServiceSet()) {
             const auto& ss = bsConfig.GetServiceSet();
-            const auto& smConfig = StorageConfig.GetSelfManagementConfig();
+            const auto& smConfig = StorageConfig->GetSelfManagementConfig();
             for (const auto& group : ss.GetGroups()) {
                 auto& content = sh->GroupsToUpdate[TGroupId::FromProto(&group, &NKikimrBlobStorage::TGroupInfo::GetGroupID)];
                 const TBlobStorageGroupType gtype(static_cast<TBlobStorageGroupType::EErasureSpecies>(group.GetErasureSpecies()));

--- a/ydb/core/mind/bscontroller/sys_view.cpp
+++ b/ydb/core/mind/bscontroller/sys_view.cpp
@@ -504,8 +504,8 @@ void TBlobStorageController::UpdateSystemViews() {
                     vslot.VDiskStatus, vslot.VDiskKind, false);
             }
         }
-        if (StorageConfig.HasBlobStorageConfig()) {
-            if (const auto& bsConfig = StorageConfig.GetBlobStorageConfig(); bsConfig.HasServiceSet()) {
+        if (StorageConfig && StorageConfig->HasBlobStorageConfig()) {
+            if (const auto& bsConfig = StorageConfig->GetBlobStorageConfig(); bsConfig.HasServiceSet()) {
                 const auto& ss = bsConfig.GetServiceSet();
                 for (const auto& group : ss.GetGroups()) {
                     if (!SysViewChangedGroups.count(TGroupId::FromProto(&group, &NKikimrBlobStorage::TGroupInfo::GetGroupID))) {
@@ -546,7 +546,7 @@ void TBlobStorageController::UpdateSystemViews() {
                         NLayoutChecker::TGroupLayout layout(groupInfo->GetTopology());
                         NLayoutChecker::TDomainMapper mapper;
                         TGroupGeometryInfo geom(groupInfo->Type, SelfManagementEnabled
-                            ? StorageConfig.GetSelfManagementConfig().GetGeometry()
+                            ? StorageConfig->GetSelfManagementConfig().GetGeometry()
                             : NKikimrBlobStorage::TGroupGeometry());
 
                         Y_DEBUG_ABORT_UNLESS(pdiskIds.size() == groupInfo->GetTotalVDisksNum());

--- a/ydb/core/mind/bscontroller/ut_bscontroller/main.cpp
+++ b/ydb/core/mind/bscontroller/ut_bscontroller/main.cpp
@@ -243,7 +243,8 @@ struct TEnvironmentSetup {
             {}
 
             void Handle(TEvNodeWardenQueryStorageConfig::TPtr ev) {
-                Send(ev->Sender, new TEvNodeWardenStorageConfig(NKikimrBlobStorage::TStorageConfig(), nullptr, false));
+                Send(ev->Sender, new TEvNodeWardenStorageConfig(std::make_shared<NKikimrBlobStorage::TStorageConfig>(),
+                    nullptr, false));
             }
 
             STATEFN(StateFunc) {

--- a/ydb/core/mind/bscontroller/ut_selfheal/defs.h
+++ b/ydb/core/mind/bscontroller/ut_selfheal/defs.h
@@ -3,6 +3,7 @@
 #include <ydb/core/mind/bscontroller/defs.h>
 #include <ydb/core/blobstorage/dsproxy/mock/dsproxy_mock.h>
 #include <ydb/core/blobstorage/pdisk/mock/pdisk_mock.h>
+#include <ydb/core/blobstorage/nodewarden/node_warden_events.h>
 
 #include <ydb/core/mind/bscontroller/bsc.h>
 #include <ydb/core/mind/bscontroller/types.h>

--- a/ydb/core/mind/bscontroller/ut_selfheal/node_warden_mock.h
+++ b/ydb/core/mind/bscontroller/ut_selfheal/node_warden_mock.h
@@ -192,5 +192,8 @@ public:
         cFunc(EvUpdateDriveStatus, UpdateDriveStatus);
         cFunc(TEvents::TSystem::Wakeup, Connect);
         hFunc(TEvNodeWardenQueryStorageConfig, Handle);
+        IgnoreFunc(NStorage::TEvNodeWardenUpdateCache);
+        IgnoreFunc(NStorage::TEvNodeWardenQueryCache);
+        IgnoreFunc(NStorage::TEvNodeWardenUnsubscribeFromCache);
     })
 };

--- a/ydb/core/mind/bscontroller/ut_selfheal/node_warden_mock.h
+++ b/ydb/core/mind/bscontroller/ut_selfheal/node_warden_mock.h
@@ -180,7 +180,8 @@ public:
     }
 
     void Handle(TEvNodeWardenQueryStorageConfig::TPtr ev) {
-        Send(ev->Sender, new TEvNodeWardenStorageConfig(NKikimrBlobStorage::TStorageConfig(), nullptr, false));
+        Send(ev->Sender, new TEvNodeWardenStorageConfig(std::make_shared<NKikimrBlobStorage::TStorageConfig>(),
+            nullptr, false));
     }
 
     STRICT_STFUNC(StateFunc, {

--- a/ydb/core/protos/blobstorage_distributed_config.proto
+++ b/ydb/core/protos/blobstorage_distributed_config.proto
@@ -53,6 +53,17 @@ message TStorageFileContent {
     repeated TRecord Record = 1;
 }
 
+message TCacheUpdate {
+    message TKeyValuePair {
+        string Key = 1; // unique cache item key
+        uint32 Generation = 2; // generation of the key: Value may only change with increasing generation
+        optional bytes Value = 3; // updated value; when not set, this item is considered to be deleted
+    }
+
+    repeated TKeyValuePair KeyValuePairs = 1;
+    repeated string RequestedKeys = 2;
+}
+
 // Attach sender node to the recipient one; if already bound, then just update configuration.
 message TEvNodeConfigPush {
     message TBoundNode {
@@ -62,6 +73,7 @@ message TEvNodeConfigPush {
     bool Initial = 1; // set to true if this push is initial connection establishment
     repeated TBoundNode BoundNodes = 2; // a list of bound node updates (including itself)
     repeated TNodeIdentifier DeletedBoundNodeIds = 3; // a list of detached nodes
+    TCacheUpdate CacheUpdate = 4;
 }
 
 // Used to reverse-propagate configuration and to confirm/reject initial TEvNodePushBinding query.
@@ -70,6 +82,7 @@ message TEvNodeConfigReversePush {
     bool Rejected = 2; // is the request rejected due to cyclic graph?
     TStorageConfig CommittedStorageConfig = 3; // last known committed storage configuration
     bool RecurseConfigUpdate = 4;
+    TCacheUpdate CacheUpdate = 5;
 }
 
 // Remove node from bound list.
@@ -270,4 +283,5 @@ message TEvNodeConfigInvokeOnRootResult {
 message TEvNodeWardenDynamicConfigPush {
     TStorageConfig Config = 1;
     bool NoQuorum = 2;
+    TCacheUpdate CacheUpdate = 3;
 }


### PR DESCRIPTION
- **Pass TStorageConfig through pointer to prevent copying when doing subscription fan-out (#18765)**
- **Introduce distconf cache for group info propagation (#19315)**
- **Add UT for group cache, improve SentToWarden for local messages (#22541)**
- **Fix GroupConfigurationPropagation::Reassign unit test (#22829)**
- **Cherry-pick specific changes from 7dac338db3e4**

### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

Cherry-pick multiple commits for Distconf group configuration cache 

### Changelog category <!-- remove all except one -->

* New feature