### PR TITLE
precisely allocate intervals memory in deduplication

### DIFF
--- a/ydb/core/tx/columnshard/engines/reader/simple_reader/duplicates/manager.h
+++ b/ydb/core/tx/columnshard/engines/reader/simple_reader/duplicates/manager.h
@@ -52,7 +52,6 @@ private:
 
     TLRUCache<TDuplicateMapInfo, NArrow::TColumnFilter, TNoopDelete, TFilterSizeProvider> FiltersCache;
     THashMap<TDuplicateMapInfo, std::vector<std::shared_ptr<TInternalFilterConstructor>>> BuildingFilters;
-    ui64 ExpectedIntersectionCount = 0;
 
 private:
     static TPortionIntervalTree MakeIntervalTree(const std::deque<NSimple::TSourceConstructor>& portions) {

--- a/ydb/core/tx/limiter/grouped_memory/usage/stage_features.h
+++ b/ydb/core/tx/limiter/grouped_memory/usage/stage_features.h
@@ -8,13 +8,13 @@
 
 namespace NKikimr::NOlap::NGroupedMemoryManager {
 
-class TStageFeatures {
+class TStageFeatures: TMoveOnly {
 private:
     YDB_READONLY_DEF(TString, Name);
     YDB_READONLY(ui64, Limit, 0);
     YDB_READONLY_DEF(std::optional<ui64>, HardLimit);
-    YDB_ACCESSOR_DEF(TPositiveControlInteger, Usage);
-    YDB_ACCESSOR_DEF(TPositiveControlInteger, Waiting);
+    YDB_READONLY_DEF(TPositiveControlInteger, Usage);
+    YDB_READONLY_DEF(TPositiveControlInteger, Waiting);
     std::shared_ptr<TStageFeatures> Owner;
     std::shared_ptr<TStageCounters> Counters;
     std::function<void(ui64)> MemoryConsumptionUpdate;


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

...

### Changelog category <!-- remove all except one -->

* Not for changelog (changelog entry is not required)

### Description for reviewers <!-- (optional) description for those who read this PR -->

...
