### PR TITLE
[NOT-FOR-MERGE] grace join: process buckets consecutively

### DIFF
--- a/yql/essentials/minikql/comp_nodes/mkql_grace_join_imp.cpp
+++ b/yql/essentials/minikql/comp_nodes/mkql_grace_join_imp.cpp
@@ -167,6 +167,7 @@ TTable::EAddTupleResult TTable::AddTuple(ui64* intColumns, char** stringColumns,
 
 void TTable::ResetIterator() {
     CurrIterIndex = 0;
+    CurrIterBucket = 0;
     if (IsTableJoined) {
         JoinTable1->ResetIterator();
         JoinTable2->ResetIterator();
@@ -869,6 +870,7 @@ inline bool TTable::AddKeysToHashTable(KeysHashTable& t, ui64* keys, NYql::NUdf:
 
 
 bool TTable::NextJoinedData(TupleData& td1, TupleData& td2) {
+    Y_DEBUG_ABORT_UNLESS(IsTableJoined);
         if (auto& joinIds = JoinIds; CurrIterIndex != joinIds.size()) {
             Y_DEBUG_ABORT_UNLESS(JoinKind == EJoinKind::Inner || JoinKind == EJoinKind::Left || JoinKind == EJoinKind::Right || JoinKind == EJoinKind::Full);
             auto ids = joinIds[CurrIterIndex++];
@@ -914,23 +916,17 @@ void TTable::Clear() {
 void TTable::ClearResults() {
     JoinIds.clear();
     LeftIds.clear();
-    if (JoinTable1) {
+    if (IsTableJoined) {
         JoinTable1->ClearResults();
-    }
-    if (JoinTable2) {
         JoinTable2->ClearResults();
     }
-    ResetIterator();
-    CurrIterBucket = NumberOfBuckets;
 }
 
 void TTable::ShrinkResults() {
     JoinIds.shrink_to_fit();
     LeftIds.shrink_to_fit();
-    if (JoinTable1) {
+    if (IsTableJoined) {
         JoinTable1->ShrinkResults();
-    }
-    if (JoinTable2) {
         JoinTable2->ShrinkResults();
     }
 }

--- a/yql/essentials/minikql/comp_nodes/mkql_grace_join_imp.cpp
+++ b/yql/essentials/minikql/comp_nodes/mkql_grace_join_imp.cpp
@@ -945,6 +945,21 @@ void TTable::ShrinkBucket(ui64 bucket) {
     tb.JoinSlots.shrink_to_fit();
 }
 
+void TTable::BorrowPreviousBucket(ui32 bucket) {
+    BorrowBucket (bucket, (bucket == 0 ? NumberOfBuckets : bucket) - 1);
+}
+
+void TTable::BorrowBucket(ui32 bucket, ui32 previousBucket) {
+    if (JoinTable1) {
+        JoinTable1->BorrowBucket(bucket, previousBucket);
+    }
+    if (JoinTable2) {
+        JoinTable2->BorrowBucket(bucket, previousBucket);
+    }
+    std::swap(TableBuckets[bucket].LeftIds, TableBuckets[previousBucket].LeftIds);
+    std::swap(TableBuckets[bucket].JoinIds, TableBuckets[previousBucket].JoinIds);
+}
+
 void TTable::InitializeBucketSpillers(ISpiller::TPtr spiller) {
     for (size_t i = 0; i < NumberOfBuckets; ++i) {
         TableBucketsSpillers.emplace_back(spiller, 5_MB);

--- a/yql/essentials/minikql/comp_nodes/mkql_grace_join_imp.cpp
+++ b/yql/essentials/minikql/comp_nodes/mkql_grace_join_imp.cpp
@@ -167,7 +167,6 @@ TTable::EAddTupleResult TTable::AddTuple(ui64* intColumns, char** stringColumns,
 
 void TTable::ResetIterator() {
     CurrIterIndex = 0;
-    CurrIterBucket = 0;
     if (IsTableJoined) {
         JoinTable1->ResetIterator();
         JoinTable2->ResetIterator();
@@ -389,8 +388,8 @@ bool TTable::TryToPreallocateMemoryForJoin(TTable& t1, TTable& t2, EJoinKind /* 
 
 // Joins two tables and returns join result in joined table. Tuples of joined table could be received by
 // joined table iterator
-void TTable::Join(TTable& t1, TTable& t2, EJoinKind joinKind, bool hasMoreLeftTuples, bool hasMoreRightTuples, ui32 fromBucket, ui32 toBucket) {
-    if (hasMoreLeftTuples) {
+void TTable::Join(ui32 bucket, TTable& t1, TTable& t2, EJoinKind joinKind, bool hasMoreLeftTuples, bool hasMoreRightTuples) {
+    if ( hasMoreLeftTuples )
         LeftTableBatch_ = true;
     }
 
@@ -406,6 +405,8 @@ void TTable::Join(TTable& t1, TTable& t2, EJoinKind joinKind, bool hasMoreLeftTu
 
     JoinKind = joinKind;
 
+    CurrIterBucket = bucket;
+
     IsTableJoined = true;
 
     MKQL_ENSURE(joinKind != EJoinKind::Cross, "Cross Join is not allowed in Grace Join");
@@ -414,9 +415,11 @@ void TTable::Join(TTable& t1, TTable& t2, EJoinKind joinKind, bool hasMoreLeftTu
 
     ui64 tuplesFound = 0;
 
-    for (ui64 bucket = fromBucket; bucket < toBucket; bucket++) {
-        auto& joinResults = TableBuckets[bucket].JoinIds;
+    do { // XXX
+        auto& joinResults = JoinIds;
         joinResults.clear();
+        auto joinTable1 = JoinTable1;
+        auto joinTable2 = JoinTable2;
         TTableBucket* bucket1 = &JoinTable1->TableBuckets[bucket];
         TTableBucket* bucket2 = &JoinTable2->TableBuckets[bucket];
         TTableBucketStats* bucketStats1 = &JoinTable1->TableBucketsStats[bucket];
@@ -439,6 +442,7 @@ void TTable::Join(TTable& t1, TTable& t2, EJoinKind joinKind, bool hasMoreLeftTu
 
         if (swapTables) {
             std::swap(bucket1, bucket2);
+            std::swap(joinTable1, joinTable2);
             std::swap(bucketStats1, bucketStats2);
             std::swap(headerSize1, headerSize2);
             std::swap(nullsSize1, nullsSize2);
@@ -448,8 +452,10 @@ void TTable::Join(TTable& t1, TTable& t2, EJoinKind joinKind, bool hasMoreLeftTu
             std::swap(tuplesNum1, tuplesNum2);
         }
 
-        auto& leftIds = bucket1->LeftIds;
+        auto& leftIds = joinTable1->LeftIds;
         leftIds.clear();
+        auto& leftIds2 = joinTable2->LeftIds;
+        leftIds2.clear();
 
         const bool selfJoinSameKeys = (JoinTable1 == JoinTable2);
         const bool needLeftIds = ((swapTables ? (JoinKind == EJoinKind::Right || JoinKind == EJoinKind::RightOnly) : (JoinKind == EJoinKind::Left || JoinKind == EJoinKind::LeftOnly)) || JoinKind == EJoinKind::Full || JoinKind == EJoinKind::Exclusion) && !selfJoinSameKeys;
@@ -662,7 +668,6 @@ void TTable::Join(TTable& t1, TTable& t2, EJoinKind joinKind, bool hasMoreLeftTu
                 auto slotIt = joinSlots.cbegin();
                 auto end = joinSlots.cend();
                 auto isSemi = JoinKind == EJoinKind::LeftSemi || JoinKind == EJoinKind::RightSemi;
-                auto& leftIds2 = bucket2->LeftIds;
 
                 for (; slotIt != end; slotIt += slotSize) {
                     if ((*(slotIt + HashSize) & 1) == isSemi && *slotIt != 0) {
@@ -687,7 +692,7 @@ void TTable::Join(TTable& t1, TTable& t2, EJoinKind joinKind, bool hasMoreLeftTu
         BloomLookups_ += bloomLookups;
 
         UDF_LOG(Logger_, LogComponent_, GRACEJOIN_TRACE, TStringBuilder() << (const void*)this << '#' << bucket << " Table1 " << JoinTable1->TableBucketsStats[bucket].TuplesNum << " Table2 " << JoinTable2->TableBucketsStats[bucket].TuplesNum << " LeftTableBatch " << LeftTableBatch_ << " RightTableBatch " << RightTableBatch_ << " leftIds " << leftIds.size() << " joinIds " << joinResults.size() << " joinKind " << (int)JoinKind << " swapTables " << swapTables << " initHashTable " << initHashTable);
-    }
+    } while(false);
 
     HasMoreLeftTuples_ = hasMoreLeftTuples;
     HasMoreRightTuples_ = hasMoreRightTuples;
@@ -862,9 +867,9 @@ inline bool TTable::AddKeysToHashTable(KeysHashTable& t, ui64* keys, NYql::NUdf:
     return true;
 }
 
-bool TTable::NextJoinedData(TupleData& td1, TupleData& td2, ui64 bucketLimit) {
-    while (CurrIterBucket < bucketLimit) {
-        if (auto& joinIds = TableBuckets[CurrIterBucket].JoinIds; CurrIterIndex != joinIds.size()) {
+
+bool TTable::NextJoinedData(TupleData& td1, TupleData& td2) {
+        if (auto& joinIds = JoinIds; CurrIterIndex != joinIds.size()) {
             Y_DEBUG_ABORT_UNLESS(JoinKind == EJoinKind::Inner || JoinKind == EJoinKind::Left || JoinKind == EJoinKind::Right || JoinKind == EJoinKind::Full);
             auto ids = joinIds[CurrIterIndex++];
 
@@ -875,9 +880,8 @@ bool TTable::NextJoinedData(TupleData& td1, TupleData& td2, ui64 bucketLimit) {
         }
 
         auto leftSide = [this](auto sideTable, auto& tdL, auto& tdR) {
-            const auto& bucket = sideTable->TableBuckets[CurrIterBucket];
             auto& currIterIndex = sideTable->CurrIterIndex;
-            const auto& leftIds = bucket.LeftIds;
+            const auto& leftIds = sideTable->LeftIds;
 
             if (currIterIndex != leftIds.size()) {
                 auto id = leftIds[currIterIndex++];
@@ -898,12 +902,6 @@ bool TTable::NextJoinedData(TupleData& td1, TupleData& td2, ui64 bucketLimit) {
             return true;
         }
 
-        ++CurrIterBucket;
-        CurrIterIndex = 0;
-        JoinTable1->CurrIterIndex = 0;
-        JoinTable2->CurrIterIndex = 0;
-    }
-
     return false;
 }
 
@@ -913,7 +911,33 @@ void TTable::Clear() {
     }
 }
 
+void TTable::ClearResults() {
+    JoinIds.clear();
+    LeftIds.clear();
+    if (JoinTable1) {
+        JoinTable1->ClearResults();
+    }
+    if (JoinTable2) {
+        JoinTable2->ClearResults();
+    }
+    ResetIterator();
+    CurrIterBucket = NumberOfBuckets;
+}
+
+void TTable::ShrinkResults() {
+    JoinIds.shrink_to_fit();
+    LeftIds.shrink_to_fit();
+    if (JoinTable1) {
+        JoinTable1->ShrinkResults();
+    }
+    if (JoinTable2) {
+        JoinTable2->ShrinkResults();
+    }
+}
+
 void TTable::ClearBucket(ui64 bucket) {
+    JoinIds.clear();
+    LeftIds.clear();
     TTableBucket& tb = TableBuckets[bucket];
     tb.KeyIntVals.clear();
     tb.DataIntVals.clear();
@@ -921,8 +945,6 @@ void TTable::ClearBucket(ui64 bucket) {
     tb.StringsValues.clear();
     tb.InterfaceValues.clear();
     tb.InterfaceOffsets.clear();
-    tb.JoinIds.clear();
-    tb.LeftIds.clear();
     tb.JoinSlots.clear();
     tb.NSlots = 0;
 
@@ -933,6 +955,9 @@ void TTable::ClearBucket(ui64 bucket) {
 }
 
 void TTable::ShrinkBucket(ui64 bucket) {
+
+    JoinIds.shrink_to_fit();
+    LeftIds.shrink_to_fit();
     TTableBucket& tb = TableBuckets[bucket];
     tb.KeyIntVals.shrink_to_fit();
     tb.DataIntVals.shrink_to_fit();
@@ -940,24 +965,7 @@ void TTable::ShrinkBucket(ui64 bucket) {
     tb.StringsValues.shrink_to_fit();
     tb.InterfaceValues.shrink_to_fit();
     tb.InterfaceOffsets.shrink_to_fit();
-    tb.JoinIds.shrink_to_fit();
-    tb.LeftIds.shrink_to_fit();
     tb.JoinSlots.shrink_to_fit();
-}
-
-void TTable::BorrowPreviousBucket(ui32 bucket) {
-    BorrowBucket (bucket, (bucket == 0 ? NumberOfBuckets : bucket) - 1);
-}
-
-void TTable::BorrowBucket(ui32 bucket, ui32 previousBucket) {
-    if (JoinTable1) {
-        JoinTable1->BorrowBucket(bucket, previousBucket);
-    }
-    if (JoinTable2) {
-        JoinTable2->BorrowBucket(bucket, previousBucket);
-    }
-    std::swap(TableBuckets[bucket].LeftIds, TableBuckets[previousBucket].LeftIds);
-    std::swap(TableBuckets[bucket].JoinIds, TableBuckets[previousBucket].JoinIds);
 }
 
 void TTable::InitializeBucketSpillers(ISpiller::TPtr spiller) {

--- a/yql/essentials/minikql/comp_nodes/mkql_grace_join_imp.h
+++ b/yql/essentials/minikql/comp_nodes/mkql_grace_join_imp.h
@@ -412,6 +412,10 @@ public:
         return NextJoinedData(td1, td2, JoinTable1->TableBucketsStats.size());
     }
 
+    ui32 GetCurrentBucketIterator() const {
+        return CurrIterBucket;
+    }
+
     // Creates buckets that support spilling.
     void InitializeBucketSpillers(ISpiller::TPtr spiller);
 
@@ -453,6 +457,10 @@ public:
 
     // Forces bucket to release the space used for underlying containers.
     void ShrinkBucket(ui64 bucket);
+
+    // Borrows result memory from previous bucket
+    void BorrowPreviousBucket(ui32 bucket);
+    void BorrowBucket(ui32 bucket, ui32 previousBucket);
 
     // Clears table content
     void Clear();

--- a/yql/essentials/minikql/comp_nodes/mkql_grace_join_imp.h
+++ b/yql/essentials/minikql/comp_nodes/mkql_grace_join_imp.h
@@ -411,11 +411,6 @@ public:
     // Returns next jointed tuple data. Returs true if there are more tuples
     bool NextJoinedData(TupleData& td1, TupleData& td2);
 
-    // Returns currently joined bucket (or NumberOfBuckets if there are none)
-    ui32 GetCurrentBucket() const {
-        return CurrIterBucket;
-    }
-
     // Creates buckets that support spilling.
     void InitializeBucketSpillers(ISpiller::TPtr spiller);
 


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

...

### Changelog category <!-- remove all except one -->

* New feature
* Experimental feature
* Improvement
* Performance improvement
* User Interface
* Bugfix 
* Backward incompatible change
* Documentation (changelog entry is not required)
* Not for changelog (changelog entry is not required)

### Description for reviewers <!-- (optional) description for those who read this PR -->

GraceJoin first makes matches list for all buckets, then walks over all lists and return answers.
It would be better to return answers for each bucket immediately after generating matches list (hence keeping matches list for one bucket at a time).