### PR TITLE
Fixed redirects from 24.4 to 25.1

### DIFF
--- a/ydb/docs/redirects.yaml
+++ b/ydb/docs/redirects.yaml
@@ -86,9 +86,15 @@ common:
   - from: /deploy/configuration/config.md
     to: /reference/configuration/index.md
   - from: /deploy/manual/connector.md
-    to: /devops/manual/federated-queries/connector-deployment.md
+    to: /devops/deployment-options/manual/federated-queries/connector-deployment.md
   - from: /deploy/manual/deploy-ydb-federated-query.md
-    to: /devops/manual/federated-queries/index.md
+    to: /devops/deployment-options/manual/federated-queries/index.md
+  - from: /devops/manual/federated-queries/connector-deployment.md
+    to: /devops/deployment-options/manual/federated-queries/connector-deployment.md
+  - from: /devops/manual/federated-queries/index.md
+    to: /devops/deployment-options/manual/federated-queries/index.md
+
+
 
   # Redirects for Deployment Options
 
@@ -120,6 +126,18 @@ common:
     to: /devops/deployment-options/manual/index.md
   - from: /devops/manual/initial-deployment.md
     to: /devops/deployment-options/manual/initial-deployment.md
+
+  - from: /maintenance/manual/cms.md
+    to: /devops/configuration-management/configuration-v1/cms.md
+  - from: /maintenance/manual/dynamic-config.md
+    to: /devops/configuration-management/configuration-v1/dynamic-config.md
+  - from: /maintenance/manual/cluster_expansion.md
+    to: /devops/configuration-management/configuration-v1/cluster_expansion.md
+  - from: /maintenance/manual/config-overview.md
+    to: /devops/configuration-management/configuration-v1/config-overview.md
+  - from: /maintenance/manual/change_actorsystem_configs.md
+    to: /devops/configuration-management/configuration-v1/change_actorsystem_configs.md
+
 
   # Redirects for Observability
   - from: /devops/manual/monitoring.md
@@ -459,25 +477,23 @@ ru:
     to: /dev/terraform.md
   - from: /postgresql/docker-connect.md
     to: /postgresql/connect.md
+  - from: /maintenance/manual/replacing_nodes.md
+    to: /devops/configuration-management/configuration-v1/replacing_nodes.md
+  - from: /maintenance/manual/dynamic-config-selectors.md
+    to: /devops/configuration-management/configuration-v1/dynamic-config-selectors.md
+  - from: /maintenance/manual/dynamic-config-volatile-config.md
+    to: /devops/configuration-management/configuration-v1/dynamic-config-volatile-config.md
+
 
 en:
   - from: /cluster/system-requirements.md
     to: /devops/system-requirements.md
   - from: /devops/observability/initial-deployment.md
     to: /devops/deployment-options/manual/initial-deployment.md
-  - from: /maintenance/manual/dynamic-config.md
-    to: /devops/deployment-options/manual/dynamic-config.md
-  - from: /maintenance/manual/config-overview.md
-    to: /devops/deployment-options/manual/config-overview.md
-  - from: /maintenance/manual/node_restarting.md
-    to: /devops/deployment-options/manual/node-restarting.md
   - from: /maintenance/manual/cluster_expansion.md
     to: /devops/deployment-options/manual/cluster-expansion.md
-  - from: /maintenance/manual/selfheal.md
-    to: /devops/deployment-options/manual/selfheal.md
   - from: /maintenance/manual/index.md
     to: /devops/deployment-options/manual/index.md
-  - from: /maintenance/manual/change_actorsystem_configs.md
-    to: /devops/deployment-options/manual/change-actorsystem-configs.md
-  - from: /maintenance/manual/cms.md
-    to: /devops/deployment-options/manual/cms.md
+  - from: /reference/ydbops/scenarios.md
+    to: /reference/ydbops/rolling-restart-scenario.md
+


### PR DESCRIPTION
### Changelog category

* Documentation

### Description for reviewers

The following links from v24.4 do not open in v25.1:

https://ydb.tech/docs/ru/devops/manual/federated-queries/index.html
https://ydb.tech/docs/ru/devops/manual/federated-queries/connector-deployment.html
https://ydb.tech/docs/ru/maintenance/manual/replacing_nodes.html
https://ydb.tech/docs/ru/maintenance/manual/cms.html
https://ydb.tech/docs/ru/maintenance/manual/dynamic-config-selectors.html
https://ydb.tech/docs/ru/maintenance/manual/cluster_expansion.html
https://ydb.tech/docs/ru/maintenance/manual/dynamic-config.html
https://ydb.tech/docs/ru/maintenance/manual/dynamic-config-volatile-config.html
https://ydb.tech/docs/ru/maintenance/manual/config-overview.html
https://ydb.tech/docs/ru/maintenance/manual/change_actorsystem_configs.html
https://ydb.tech/docs/en/devops/manual/federated-queries/index.html
https://ydb.tech/docs/en/devops/manual/federated-queries/connector-deployment.html
https://ydb.tech/docs/en/maintenance/manual/selfheal.html
https://ydb.tech/docs/en/maintenance/manual/cms.html
https://ydb.tech/docs/en/maintenance/manual/node_restarting.html
https://ydb.tech/docs/en/maintenance/manual/cluster_expansion.html
https://ydb.tech/docs/en/maintenance/manual/dynamic-config.html
https://ydb.tech/docs/en/maintenance/manual/config-overview.html
https://ydb.tech/docs/en/maintenance/manual/change_actorsystem_configs.html
https://ydb.tech/docs/en/reference/ydbops/scenarios.html

