### PR TITLE
ci: enabled use_default_branches for test WFs

### DIFF
--- a/.github/workflows/regression_run.yml
+++ b/.github/workflows/regression_run.yml
@@ -23,6 +23,6 @@ jobs:
         build_preset: ["relwithdebinfo", "release-asan", "release-tsan", "release-msan"]
     with:
       test_targets: ydb/
-      branches: ''
+      branches: ${{ inputs.use_default_branches != true && github.ref_name || '' }}
       branches_config_path: '.github/config/stable_tests_branches.json'
       build_preset: ${{ matrix.build_preset }}

--- a/.github/workflows/regression_run_large.yml
+++ b/.github/workflows/regression_run_large.yml
@@ -23,6 +23,6 @@ jobs:
     with:
       test_targets: ydb/
       test_size: large
-      branches: ''
+      branches: ${{ inputs.use_default_branches != true && github.ref_name || '' }}
       branches_config_path: '.github/config/stable_tests_branches.json'
       build_preset: ${{ matrix.build_preset }}

--- a/.github/workflows/regression_run_small_medium.yml
+++ b/.github/workflows/regression_run_small_medium.yml
@@ -23,6 +23,6 @@ jobs:
     with:
       test_targets: ydb/
       test_size: small,medium
-      branches: ''
+      branches: ${{ inputs.use_default_branches != true && github.ref_name || '' }}
       branches_config_path: '.github/config/stable_tests_branches.json'
       build_preset: ${{ matrix.build_preset }}

--- a/.github/workflows/regression_run_stress.yml
+++ b/.github/workflows/regression_run_stress.yml
@@ -22,6 +22,6 @@ jobs:
         build_preset: ["relwithdebinfo", "release-asan", "release-tsan", "release-msan"]
     with:
       test_targets: ydb/tests/stress/
-      branches: ''
+      branches: ${{ inputs.use_default_branches != true && github.ref_name || '' }}
       branches_config_path: '.github/config/stable_tests_branches.json'
       build_preset: ${{ matrix.build_preset }}

--- a/.github/workflows/regression_whitelist_run.yml
+++ b/.github/workflows/regression_whitelist_run.yml
@@ -22,6 +22,6 @@ jobs:
         build_preset: ["relwithdebinfo", "release-asan", "release-tsan", "release-msan"]
     with:
       test_targets: ydb/tests/sql/ ydb/tests/stress ydb/tests/functional/tpc ydb/tests/functional/benchmarks_init
-      branches: ''
+      branches: ${{ inputs.use_default_branches != true && github.ref_name || '' }}
       branches_config_path: '.github/config/stable_tests_branches.json'
       build_preset: ${{ matrix.build_preset }}


### PR DESCRIPTION
### Changelog category <!-- remove all except one -->

* Not for changelog (changelog entry is not required)

### Description for reviewers <!-- (optional) description for those who read this PR -->

Flag was ignored and WFs were always run on defaults

Now we pass github ref wherever the `use_default_branches` input is deselected (see https://github.com/ydb-platform/ydb/commit/050aa8cdf9ed09c48f9edec5b3fe2c2a4d9a9533)

Run with default branches: https://github.com/ydb-platform/ydb/actions/runs/17049743749/job/48334196820

Run without default branches: https://github.com/ydb-platform/ydb/actions/runs/17049747791/job/48334210656