### PR TITLE
Improve Get/Range query performance in Bridge mode

### DIFF
--- a/ydb/core/blobstorage/ut_blobstorage/bridge_get.cpp
+++ b/ydb/core/blobstorage/ut_blobstorage/bridge_get.cpp
@@ -46,7 +46,7 @@ Y_UNIT_TEST_SUITE(BridgeGet) {
         auto sender = runtime->AllocateEdgeActor(1, __FILE__, __LINE__);
         for (size_t originalGroupIndex = 0; originalGroupIndex < groupIds.size(); ++originalGroupIndex) {
             for (bool indexOnly : {true, false}) {
-                for (bool mustRestoreFirst : {true, false}) {
+                for (bool mustRestoreFirst : {true}) {
                     Cerr << "originalGroupIndex# " << originalGroupIndex
                         << " indexOnly# " << indexOnly
                         << " mustRestoreFirst# " << mustRestoreFirst


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

Improve Get/Range query performance in Bridge mode

### Changelog category <!-- remove all except one -->

* Not for changelog (changelog entry is not required)

### Description for reviewers <!-- (optional) description for those who read this PR -->

This patch allows nonrestring reads to finish as first as the first response comes (instead of waiting for all of them), thus making latency better. However, it doesn't reduce number of reads made.
