### PR TITLE
Fix test_data_type.py

### DIFF
--- a/ydb/tests/compatibility/test_data_type.py
+++ b/ydb/tests/compatibility/test_data_type.py
@@ -50,6 +50,9 @@ class TestDataType(RestartToAnotherVersionFixture):
             },
             column_shard_config={
                 "disabled_on_scheme_shard": False,
+                "compaction_enabled": True,
+                "deduplication_enabled": True,
+                "reader_class_name": "SIMPLE",
             },
             table_service_config={
                 "enable_olap_sink": True,


### PR DESCRIPTION
Closes #23139

Most probably the problem was that the effective config params for column shards looked like these:
column_shard_config={
    "compaction_enabled": True,
    "deduplication_enabled": False,
}

That sometimes led to duplicates in the test (if the compaction did not managed to clean the table).

Explicit setting these params in the test makes the test stable.

The question, why "deduplication_enabled" was False (when the default value is True) is still open.