### PR TITLE
Fix bridge mode connectivity checking

### DIFF
--- a/ydb/core/blobstorage/nodewarden/distconf.h
+++ b/ydb/core/blobstorage/nodewarden/distconf.h
@@ -519,6 +519,7 @@ namespace NKikimr::NStorage {
             TActorId ActorId; // originating actor id or empty if this was triggered by system
         };
         std::deque<TInvokeOperation> InvokeQ; // operations queue; first is always the being executed one
+        std::deque<TInvokeOperation> InvokePending; // collected while in ERROR_TIMEOUT state
         bool DeadActorWaitingForProposition = false;
 
         class TInvokeRequestHandlerActor;

--- a/ydb/core/blobstorage/nodewarden/distconf_invoke.h
+++ b/ydb/core/blobstorage/nodewarden/distconf_invoke.h
@@ -23,6 +23,8 @@ namespace NKikimr::NStorage {
 
         std::shared_ptr<TLifetimeToken> RequestHandlerToken = std::make_shared<TLifetimeToken>();
 
+        bool InvokedWithoutScepter = false;
+
     public: // Error handling
         struct TExError : yexception {
             bool IsCritical = false; // the one what would case Y_ABORT if in debug mode

--- a/ydb/core/blobstorage/nodewarden/distconf_scatter_gather.cpp
+++ b/ydb/core/blobstorage/nodewarden/distconf_scatter_gather.cpp
@@ -9,9 +9,6 @@ namespace NKikimr::NStorage {
         }
         STLOG(PRI_DEBUG, BS_NODE, NWDC21, "IssueScatterTask", (Request, request), (Cookie, cookie), (ActorId, actorId),
             (Binding, Binding), (Scepter, Scepter ? std::make_optional(Scepter->Id) : std::nullopt));
-        Y_ABORT_UNLESS(!actorId && Binding && !Scepter // just forwarding what we got from binding
-            || !actorId && !Binding && Scepter // initiating scatter task as a root node
-            || actorId && !Binding && Scepter); // query issued by InvokeOnRootNode machinery
         const auto [it, inserted] = ScatterTasks.try_emplace(cookie, Binding, std::move(request), ScepterCounter,
             actorId.value_or(TActorId()));
         Y_ABORT_UNLESS(inserted);


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

Fix bridge mode connectivity checking

### Changelog category <!-- remove all except one -->

* Not for changelog (changelog entry is not required)

### Description for reviewers <!-- (optional) description for those who read this PR -->

This allows fully wiped pile to connect to the rest of the cluster; also this patch fixes some issues related to config propagation checks when doing failover.
