### PR TITLE
GetRpcMethodName() in context

### DIFF
--- a/ydb/apps/etcd_proxy/service/etcd_grpc.cpp
+++ b/ydb/apps/etcd_proxy/service/etcd_grpc.cpp
@@ -40,6 +40,10 @@ private:
         return ExtractDatabaseName(Ctx_->GetPeerMetaValues(NYdb::YDB_DATABASE_HEADER));
     }
 
+    TString GetRpcMethodName() const override {
+        return Ctx_->GetRpcMethodName();
+    }
+
     void UpdateAuthState(NYdbGrpc::TAuthState::EAuthState state) override {
         Ctx_->GetAuthState().State = state;
     }

--- a/ydb/core/grpc_services/base/base.h
+++ b/ydb/core/grpc_services/base/base.h
@@ -477,6 +477,8 @@ public:
 
     virtual void Reply(NProtoBuf::Message* resp, ui32 status = 0) = 0;
 
+    virtual TString GetRpcMethodName() const = 0;
+
 protected:
     virtual void FinishRequest() = 0;
 };
@@ -1155,6 +1157,10 @@ public:
 
     const TMaybe<TString> GetDatabaseName() const override {
         return ExtractDatabaseName(Ctx_->GetPeerMetaValues(NYdb::YDB_DATABASE_HEADER));
+    }
+
+    TString GetRpcMethodName() const override {
+        return Ctx_->GetRpcMethodName();
     }
 
     void UpdateAuthState(NYdbGrpc::TAuthState::EAuthState state) override {

--- a/ydb/core/grpc_services/local_rpc/local_rpc.h
+++ b/ydb/core/grpc_services/local_rpc/local_rpc.h
@@ -290,6 +290,11 @@ public:
         Y_ABORT("unimplemented for local rpc");
     }
 
+    TString GetRpcMethodName() const override {
+        // We have no grpc method, but the closest analog is protobuf name
+        return TRpc::TRequest::descriptor()->name();
+    }
+
 private:
     void Reply(NProtoBuf::Message *r, ui32) override {
         TResp* resp = dynamic_cast<TResp*>(r);
@@ -491,6 +496,14 @@ protected:
             return;
         }
         DoPushResponse(std::move(response), ctrl);
+    }
+
+    TString GetRpcMethodName() const override {
+        // We have no grpc method, but the closest analog is protobuf name
+        if (const NProtoBuf::Message* req = GetRequest()) {
+            return req->GetDescriptor()->name();
+        }
+        return {};
     }
 
 private:

--- a/ydb/core/grpc_services/ydb_over_fq/fq_local_grpc_events.h
+++ b/ydb/core/grpc_services/ydb_over_fq/fq_local_grpc_events.h
@@ -32,6 +32,14 @@ public:
         return TBase::GetBaseRequest().GetPeerName();
     }
 
+    TString GetRpcMethodName() const override {
+        // We have no grpc method, but the closest analog is protobuf name
+        if (const NProtoBuf::Message* req = TBase::GetRequest()) {
+            return req->GetDescriptor()->name();
+        }
+        return {};
+    }
+
 private:
     TString Scope_;
 };

--- a/ydb/core/kafka_proxy/actors/control_plane_common.h
+++ b/ydb/core/kafka_proxy/actors/control_plane_common.h
@@ -205,6 +205,14 @@ public:
         return DatabaseName;
     }
 
+    TString GetRpcMethodName() const override {
+        // We have no grpc method, but the closest analog is protobuf name
+        if (const NProtoBuf::Message* req = GetRequest()) {
+            return req->GetDescriptor()->name();
+        }
+        return {};
+    }
+
     const TIntrusiveConstPtr<NACLib::TUserToken>& GetInternalToken() const override {
         return UserToken;
     }

--- a/ydb/core/public_http/grpc_request_context_wrapper.cpp
+++ b/ydb/core/public_http/grpc_request_context_wrapper.cpp
@@ -82,4 +82,12 @@ namespace NKikimr::NPublicHttp {
 
     TString TGrpcRequestContextWrapper::GetEndpointId() const { return {}; }
 
+    TString TGrpcRequestContextWrapper::GetRpcMethodName() const {
+        // We have no grpc method, but the closest analog is protobuf name
+        if (Request) {
+            return Request->GetDescriptor()->name();
+        }
+        return {};
+    }
+
 } // namespace NKikimr::NPublicHttp

--- a/ydb/core/public_http/grpc_request_context_wrapper.h
+++ b/ydb/core/public_http/grpc_request_context_wrapper.h
@@ -49,7 +49,7 @@ public:
     virtual TString GetPeer() const;
     virtual bool SslServer() const { return false; }
     virtual bool IsStreamCall() const { return false; }
+    virtual TString GetRpcMethodName() const;
 };
 
 } // namespace NKikimr::NPublicHttp
-

--- a/ydb/core/tx/replication/ydb_proxy/local_proxy/local_proxy_request.h
+++ b/ydb/core/tx/replication/ydb_proxy/local_proxy/local_proxy_request.h
@@ -34,6 +34,14 @@ public:
         return DatabaseName;
     }
 
+    TString GetRpcMethodName() const override {
+        // We have no grpc method, but the closest analog is protobuf name
+        if (const NProtoBuf::Message* req = GetRequest()) {
+            return req->GetDescriptor()->name();
+        }
+        return {};
+    }
+
     const TIntrusiveConstPtr<NACLib::TUserToken>& GetInternalToken() const override {
         return UserToken;
     }

--- a/ydb/library/grpc/server/grpc_request.h
+++ b/ydb/library/grpc/server/grpc_request.h
@@ -16,6 +16,7 @@
 #include "grpc_server.h"
 #include "logger.h"
 
+#include <util/string/builder.h>
 #include <util/system/hp_timer.h>
 
 #include <grpc++/server.h>
@@ -122,6 +123,10 @@ public:
 
     bool SslServer() const override {
         return Server_->SslServer();
+    }
+
+    TString GetRpcMethodName() const override {
+        return TStringBuilder() << TService::TCurrentGRpcService::service_full_name() << '/' << Name_;
     }
 
     void Run() {

--- a/ydb/library/grpc/server/grpc_request_base.h
+++ b/ydb/library/grpc/server/grpc_request_base.h
@@ -127,6 +127,8 @@ public:
     virtual bool IsClientLost() const = 0;
 
     virtual TString GetEndpointId() const = 0;
+
+    virtual TString GetRpcMethodName() const = 0;
 };
 
 } // namespace NYdbGrpc


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

...

### Changelog category <!-- remove all except one -->

* Not for changelog (changelog entry is not required)

### Description for reviewers <!-- (optional) description for those who read this PR -->

I supported method name in rpc contexts. Then I plan to use it in audit logging.

Currently Audit logging already has an "operation" field, but it is filled with input protobuf message type name.

For example, for CreateTable API we have the following method in TableService:
```
rpc CreateTable(Table.CreateTableRequest) returns (Table.CreateTableResponse);
```

It results in audit log record:
```
{..."operation": "CreateTableRequest"...}
```

But this approach leads to two problems:
1. if we have two rpc methods with the same input protobuf message type, we can not distinguish them in audit logs
2. we already have methods in our API that have input message types that say nothing about called method:
```
service TopicService {
    rpc StreamWrite(stream StreamWriteMessage.FromClient) returns (stream StreamWriteMessage.FromServer);
    rpc StreamRead(stream StreamReadMessage.FromClient) returns (stream StreamReadMessage.FromServer);
    rpc StreamDirectRead(stream StreamDirectReadMessage.FromClient) returns (stream StreamDirectReadMessage.FromServer);
}
```

If we will use the new `GetRpcMethodName()` functionality for audit logging, it will show more clear info:
```
{..."operation2": "Ydb.Topic.V1.TopicService/StreamWrite"...}
```

instead of current records:
```
{..."operation": "FromClient"...}
```