### PR TITLE
async ca: fix VERIFY when Start is called too soon

### DIFF
--- a/ydb/library/yql/dq/actors/compute/dq_async_compute_actor.cpp
+++ b/ydb/library/yql/dq/actors/compute/dq_async_compute_actor.cpp
@@ -780,9 +780,6 @@ private:
         if (DeferredRestoreFromCheckpointEvent) {
             ForwardToCheckpoints(std::move(DeferredRestoreFromCheckpointEvent));
         }
-        if (DeferredStart) {
-            Start();
-        }
 
         ContinueExecute(EResumeSource::CATaskRunnerCreated);
     }
@@ -875,14 +872,6 @@ private:
         if (--ProcessSourcesState.Inflight == 0) {
             CA_LOG_T("Send TEvContinueRun on OnAsyncInputPushFinished");
             AskContinueRun(Nothing(), false);
-        }
-    }
-
-    void Start() override {
-        if (TypeEnv) { // Got answer from TaskRunner
-            TBase::Start();
-        } else {
-            DeferredStart = true;
         }
     }
 
@@ -1292,7 +1281,6 @@ private:
     NMonitoring::TDynamicCounters::TCounterPtr CpuTime;
     NDqProto::TEvComputeActorState ComputeActorState;
     TMaybe<EResumeSource> LastPollResult;
-    bool DeferredStart = false;
 };
 
 

--- a/ydb/library/yql/dq/actors/compute/dq_async_compute_actor.cpp
+++ b/ydb/library/yql/dq/actors/compute/dq_async_compute_actor.cpp
@@ -783,6 +783,7 @@ private:
         }
         if (DeferredRunEvent) {
             HandleExecuteBase(DeferredRunEvent);
+            DeferredRunEvent.Reset();
         }
 
         ContinueExecute(EResumeSource::CATaskRunnerCreated);

--- a/ydb/library/yql/dq/actors/compute/dq_async_compute_actor.cpp
+++ b/ydb/library/yql/dq/actors/compute/dq_async_compute_actor.cpp
@@ -780,6 +780,9 @@ private:
         if (DeferredRestoreFromCheckpointEvent) {
             ForwardToCheckpoints(std::move(DeferredRestoreFromCheckpointEvent));
         }
+        if (DeferredStart) {
+            Start();
+        }
 
         ContinueExecute(EResumeSource::CATaskRunnerCreated);
     }
@@ -872,6 +875,14 @@ private:
         if (--ProcessSourcesState.Inflight == 0) {
             CA_LOG_T("Send TEvContinueRun on OnAsyncInputPushFinished");
             AskContinueRun(Nothing(), false);
+        }
+    }
+
+    void Start() override {
+        if (TypeEnv) { // Got answer from TaskRunner
+            TBase::Start();
+        } else {
+            DeferredStart = true;
         }
     }
 
@@ -1281,6 +1292,7 @@ private:
     NMonitoring::TDynamicCounters::TCounterPtr CpuTime;
     NDqProto::TEvComputeActorState ComputeActorState;
     TMaybe<EResumeSource> LastPollResult;
+    bool DeferredStart = false;
 };
 
 

--- a/ydb/library/yql/dq/actors/compute/dq_compute_actor_impl.h
+++ b/ydb/library/yql/dq/actors/compute/dq_compute_actor_impl.h
@@ -821,7 +821,7 @@ protected:
         }
     }
 
-    void Start() override {
+    void Start() override final {
         Running = true;
         State = NDqProto::COMPUTE_STATE_EXECUTING;
         ContinueExecute(EResumeSource::CAStart);

--- a/ydb/library/yql/dq/actors/compute/dq_compute_actor_impl.h
+++ b/ydb/library/yql/dq/actors/compute/dq_compute_actor_impl.h
@@ -821,7 +821,7 @@ protected:
         }
     }
 
-    void Start() override final {
+    void Start() override {
         Running = true;
         State = NDqProto::COMPUTE_STATE_EXECUTING;
         ContinueExecute(EResumeSource::CAStart);


### PR DESCRIPTION
When `TEvRun` received before we got `TEvTaskRunnerCreateFinished` from `TaskRunnerActor`, it may lead to `DoExecute`, which calls not-yet-assigned `AsyncInput` and VERIFY `PollAsyncInput(): requirement AsyncInput failed` (this bug was exposed by #1113)
There were similar fix before: 735d9c3127b2fd3472830948c1f4a0d9be1fdab3

### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

...

### Changelog category <!-- remove all except one -->

* Not for changelog (changelog entry is not required)

### Description for reviewers <!-- (optional) description for those who read this PR -->

...