### PR TITLE
Open (u)int16 and new time types for datashard tests

### DIFF
--- a/ydb/tests/datashard/lib/dml_operations.py
+++ b/ydb/tests/datashard/lib/dml_operations.py
@@ -298,38 +298,31 @@ class DMLOperations():
 
         rows = self.query(f"select {", ".join(statements)} from {table_name}")
         count = 0
-        for data_type in all_types.keys():
-            if data_type != "Date32" and data_type != "Datetime64" and data_type != "Timestamp64" and data_type != 'Interval64':
-                for i in range(len(rows)):
-                    self.assert_type(all_types, data_type, i+1, rows[i][count])
-                count += 1
+        for data_type in all_types.keys():    
+            for i in range(len(rows)):
+                self.assert_type(all_types, data_type, i+1, rows[i][count])
+            count += 1
         for data_type in pk_types.keys():
-            if data_type != "Date32" and data_type != "Datetime64" and data_type != "Timestamp64" and data_type != 'Interval64':
-                for i in range(len(rows)):
-                    self.assert_type(pk_types, data_type, i+1, rows[i][count])
-                count += 1
+            for i in range(len(rows)):
+                self.assert_type(pk_types, data_type, i+1, rows[i][count])
+            count += 1
         for data_type in index.keys():
-            if data_type != "Date32" and data_type != "Datetime64" and data_type != "Timestamp64" and data_type != 'Interval64':
-                for i in range(len(rows)):
-                    self.assert_type(index, data_type, i+1, rows[i][count])
-                count += 1
+            for i in range(len(rows)):
+                self.assert_type(index, data_type, i+1, rows[i][count])
+            count += 1
         if ttl != "":
             for i in range(len(rows)):
                 self.assert_type(ttl_types, ttl, i+1, rows[i][count])
             count += 1
 
     def create_statements(self, pk_types, all_types, index, ttl):
-        # delete if after https://github.com/ydb-platform/ydb/issues/16930
         statements = []
         for data_type in all_types.keys():
-            if data_type != "Date32" and data_type != "Datetime64" and data_type != "Timestamp64" and data_type != 'Interval64':
-                statements.append(f"col_{cleanup_type_name(data_type)}")
+            statements.append(f"col_{cleanup_type_name(data_type)}")
         for data_type in pk_types.keys():
-            if data_type != "Date32" and data_type != "Datetime64" and data_type != "Timestamp64" and data_type != 'Interval64':
-                statements.append(f"pk_{cleanup_type_name(data_type)}")
+            statements.append(f"pk_{cleanup_type_name(data_type)}")
         for data_type in index.keys():
-            if data_type != "Date32" and data_type != "Datetime64" and data_type != "Timestamp64" and data_type != 'Interval64':
-                statements.append(f"col_index_{cleanup_type_name(data_type)}")
+            statements.append(f"col_index_{cleanup_type_name(data_type)}")
         if ttl != "":
             statements.append(f"ttl_{cleanup_type_name(ttl)}")
         return statements

--- a/ydb/tests/datashard/lib/dml_operations.py
+++ b/ydb/tests/datashard/lib/dml_operations.py
@@ -298,7 +298,7 @@ class DMLOperations():
 
         rows = self.query(f"select {", ".join(statements)} from {table_name}")
         count = 0
-        for data_type in all_types.keys():    
+        for data_type in all_types.keys():
             for i in range(len(rows)):
                 self.assert_type(all_types, data_type, i+1, rows[i][count])
             count += 1

--- a/ydb/tests/datashard/lib/types_of_variables.py
+++ b/ydb/tests/datashard/lib/types_of_variables.py
@@ -118,13 +118,13 @@ ttl_types = {
 index_zero_sync = {
     "Int64": lambda i: i,
     "Int32": lambda i: i,
-    # "Int16": lambda i: i, https://github.com/ydb-platform/ydb/issues/15842
+    "Int16": lambda i: i,
 }
 
 index_first_sync = {
     "Uint64": lambda i: i,
     "Uint32": lambda i: i,
-    # "Uint16": lambda i: i,  https://github.com/ydb-platform/ydb/issues/15842
+    "Uint16": lambda i: i,
 }
 
 index_second_sync = {
@@ -167,8 +167,8 @@ index_first_not_Bool = {
     "Uint64": lambda i: i,
     "Int32": lambda i: i,
     "Uint32": lambda i: i,
-    # "Int16": lambda i: i, https://github.com/ydb-platform/ydb/issues/15842
-    # "Uint16": lambda i: i, https://github.com/ydb-platform/ydb/issues/15842
+    "Int16": lambda i: i,
+    "Uint16": lambda i: i,
     "Int8": lambda i: i,
     "Uint8": lambda i: i,
     "Decimal(15,0)": lambda i: "{}".format(i),
@@ -181,8 +181,8 @@ index_first = {
     "Uint64": lambda i: i,
     "Int32": lambda i: i,
     "Uint32": lambda i: i,
-    # "Int16": lambda i: i, https://github.com/ydb-platform/ydb/issues/15842
-    # "Uint16": lambda i: i, https://github.com/ydb-platform/ydb/issues/15842
+    "Int16": lambda i: i,
+    "Uint16": lambda i: i,
     "Int8": lambda i: i,
     "Uint8": lambda i: i,
     "Bool": lambda i: bool(i),

--- a/ydb/tests/datashard/parametrized_queries/test_parametrized_queries.py
+++ b/ydb/tests/datashard/parametrized_queries/test_parametrized_queries.py
@@ -24,10 +24,6 @@ unsupported_types = [
     "Decimal(15,0)",
     "Decimal(22,9)",
     "Decimal(35,10)",
-    "Date32",
-    "Datetime64",
-    "Timestamp64",
-    "Interval64",
 ]
 
 
@@ -58,6 +54,10 @@ primitive_type = {
     "Json": ydb.PrimitiveType.Json,
     "JsonDocument": ydb.PrimitiveType.JsonDocument,
     "Yson": ydb.PrimitiveType.Yson,
+    "Date32": ydb.PrimitiveType.Date32,
+    "Datetime64": ydb.PrimitiveType.Datetime64,
+    "Timestamp64": ydb.PrimitiveType.Timestamp64,
+    "Interval64": ydb.PrimitiveType.Interval64,
 }
 
 

--- a/ydb/tests/datashard/partitioning/test_partitioning.py
+++ b/ydb/tests/datashard/partitioning/test_partitioning.py
@@ -54,13 +54,11 @@ class TestPartitionong(TestBase):
         [
             ("table_Int64", {"Int64": lambda i: i}, {**pk_types, **non_pk_types}, {}),
             ("table_Int32", {"Int32": lambda i: i}, {**pk_types, **non_pk_types}, {}),
-            # ("table_Int16", {"Int16": lambda i: i},
-            # {**pk_types, **non_pk_types}, {}), https://github.com/ydb-platform/ydb/issues/15842
+            ("table_Int16", {"Int16": lambda i: i}, {**pk_types, **non_pk_types}, {}),
             ("table_Int8", {"Int8": lambda i: i}, {**pk_types, **non_pk_types}, {}),
             ("table_Uint64", {"Uint64": lambda i: i}, {**pk_types, **non_pk_types}, {}),
             ("table_Uint32", {"Uint32": lambda i: i}, {**pk_types, **non_pk_types}, {}),
-            # ("table_Uint16", {"Uint16": lambda i: i},
-            # {**pk_types, **non_pk_types}, {}), https://github.com/ydb-platform/ydb/issues/15842
+            ("table_Uint16", {"Uint16": lambda i: i}, {**pk_types, **non_pk_types}, {}),
             ("table_Uint8", {"Uint8": lambda i: i}, {**pk_types, **non_pk_types}, {}),
             ("table_String", {"String": lambda i: f"{i}"}, {**pk_types, **non_pk_types}, {}),
             ("table_Utf8", {"Utf8": lambda i: f"{i}"}, {**pk_types, **non_pk_types}, {}),

--- a/ydb/tests/datashard/secondary_index/test_secondary_index.py
+++ b/ydb/tests/datashard/secondary_index/test_secondary_index.py
@@ -165,15 +165,9 @@ class TestSecondaryIndex(TestBase):
         rows = dml.query(f"select count(*) as count from {table_name}")
         count_col = rows[0].count
         statements = []
-        # delete if after https://github.com/ydb-platform/ydb/issues/16930
+
         for data_type in all_types.keys():
-            if (
-                data_type != "Date32"
-                and data_type != "Datetime64"
-                and data_type != "Timestamp64"
-                and data_type != 'Interval64'
-            ):
-                statements.append(f"col_{cleanup_type_name(data_type)}")
+            statements.append(f"col_{cleanup_type_name(data_type)}")
 
         for type_name in index.keys():
             if type_name != "Bool":
@@ -188,14 +182,8 @@ class TestSecondaryIndex(TestBase):
                         rows = self.query(select_sql, tx=session.transaction(tx_mode=ydb.QueryStaleReadOnly()))
                         count = 0
                         for data_type in all_types.keys():
-                            if (
-                                data_type != "Date32"
-                                and data_type != "Datetime64"
-                                and data_type != "Timestamp64"
-                                and data_type != 'Interval64'
-                            ):
-                                dml.assert_type(all_types, data_type, i, rows[0][count])
-                                count += 1
+                            dml.assert_type(all_types, data_type, i, rows[0][count])
+                            count += 1
 
                     dml.transactional(process)
             else:
@@ -209,15 +197,9 @@ class TestSecondaryIndex(TestBase):
                     rows = self.query(select_sql, tx=session.transaction(tx_mode=ydb.QueryStaleReadOnly()))
                     count = 0
                     for data_type in all_types.keys():
-                        if (
-                            data_type != "Date32"
-                            and data_type != "Datetime64"
-                            and data_type != "Timestamp64"
-                            and data_type != 'Interval64'
-                        ):
-                            for i in range(len(rows)):
-                                dml.assert_type(all_types, data_type, i + 1, rows[i][count])
-                            count += 1
+                        for i in range(len(rows)):
+                            dml.assert_type(all_types, data_type, i + 1, rows[i][count])
+                        count += 1
 
                 dml.transactional(process)
 

--- a/ydb/tests/datashard/select/test_select.py
+++ b/ydb/tests/datashard/select/test_select.py
@@ -69,7 +69,6 @@ class TestDML(TestBase):
         self.from_select(table_name, all_types, pk_types, index, ttl, dml)
         self.distinct(table_name, all_types, pk_types, index, ttl, dml)
         self.union(table_name, all_types, pk_types, index, ttl, dml)
-        self.without(table_name, all_types, pk_types, index, ttl)
         self.tablesample_sample(table_name, all_types, pk_types, index, ttl, dml)
 
     def limit(
@@ -252,31 +251,6 @@ class TestDML(TestBase):
             rows = dml.query(select_with_sql_request)
             for i, row in enumerate(rows):
                 self.assert_type_after_select(i + 1, row, all_types, pk_types, index, ttl, dml)
-
-    def without(
-        self, table_name: str, all_types: dict[str, str], pk_types: dict[str, str], index: dict[str, str], ttl: str
-    ):
-        selected_columns_without = []
-        for type_name in all_types.keys():
-            selected_columns_without.append(f"col_{cleanup_type_name(type_name)}")
-        for type_name in pk_types.keys():
-            selected_columns_without.append(f"pk_{cleanup_type_name(type_name)}")
-        for type_name in index.keys():
-            selected_columns_without.append(f"col_index_{cleanup_type_name(type_name)}")
-
-        for type_name in all_types.keys():
-            self.create_without(table_name, selected_columns_without, f"col_{cleanup_type_name(type_name)}")
-        for type_name in pk_types.keys():
-            self.create_without(table_name, selected_columns_without, f"pk_{cleanup_type_name(type_name)}")
-        for type_name in index.keys():
-            self.create_without(table_name, selected_columns_without, f"col_index_{cleanup_type_name(type_name)}")
-        if ttl != "":
-            self.create_without(table_name, selected_columns_without, f"ttl_{cleanup_type_name(ttl)}")
-
-    def create_without(self, table_name, selected_columns_without, without):
-        rows = self.query(f"select * without {", ".join(selected_columns_without)}, {without} from {table_name}")
-        for col_name in rows[0].keys():
-            assert col_name != without, f"a column {without} in the table {table_name} was not excluded"
 
     def tablesample_sample(
         self,

--- a/ydb/tests/datashard/select/test_select.py
+++ b/ydb/tests/datashard/select/test_select.py
@@ -18,12 +18,6 @@ from ydb.tests.datashard.lib.types_of_variables import (
     index_zero_sync,
 )
 
-unsuppored_time_types = [
-    "Date32",
-    "Datetime64",
-    "Timestamp64",
-    "Interval64",
-]  # https://github.com/ydb-platform/ydb/issues/16930
 unsuppored_distinct_types = [
     "DyNumber",
     "UUID",  # https://github.com/ydb-platform/ydb/issues/17484
@@ -100,14 +94,11 @@ class TestDML(TestBase):
     ):
         selected_columns = []
         for type in all_types.keys():
-            if type not in unsuppored_time_types:
-                selected_columns.append(f"col_{cleanup_type_name(type)}")
+            selected_columns.append(f"col_{cleanup_type_name(type)}")
         for type in pk_types.keys():
-            if type not in unsuppored_time_types:
-                selected_columns.append(f"pk_{cleanup_type_name(type)}")
+            selected_columns.append(f"pk_{cleanup_type_name(type)}")
         for type in index.keys():
-            if type not in unsuppored_time_types:
-                selected_columns.append(f"col_index_{cleanup_type_name(type)}")
+            selected_columns.append(f"col_index_{cleanup_type_name(type)}")
         if ttl != "":
             selected_columns.append(f"ttl_{cleanup_type_name(ttl)}")
         return selected_columns
@@ -124,17 +115,14 @@ class TestDML(TestBase):
     ):
         col_idx = 0
         for type in all_types.keys():
-            if type not in unsuppored_time_types:
-                dml.assert_type(all_types, type, value, row[col_idx])
-                col_idx += 1
+            dml.assert_type(all_types, type, value, row[col_idx])
+            col_idx += 1
         for type in pk_types.keys():
-            if type not in unsuppored_time_types:
-                dml.assert_type(pk_types, type, value, row[col_idx])
-                col_idx += 1
+            dml.assert_type(pk_types, type, value, row[col_idx])
+            col_idx += 1
         for type in index.keys():
-            if type not in unsuppored_time_types:
-                dml.assert_type(index, type, value, row[col_idx])
-                col_idx += 1
+            dml.assert_type(index, type, value, row[col_idx])
+            col_idx += 1
         if ttl != "":
             dml.assert_type(ttl_types, ttl, value, row[col_idx])
             col_idx += 1
@@ -165,20 +153,19 @@ class TestDML(TestBase):
     ):
         for type in all_types.keys():
             if (
-                type not in unsuppored_time_types
-                and type not in unsuppored_distinct_types
+                type not in unsuppored_distinct_types
                 and type not in uncomparable_types
             ):
                 rows_distinct = self.query(f"SELECT DISTINCT col_{cleanup_type_name(type)} from {table_name}")
                 for i in range(len(rows_distinct)):
                     dml.assert_type(all_types, type, i + 1, rows_distinct[i][0])
         for type in pk_types.keys():
-            if type not in unsuppored_time_types and type not in unsuppored_distinct_types:
+            if type not in unsuppored_distinct_types:
                 rows_distinct = self.query(f"SELECT DISTINCT pk_{cleanup_type_name(type)} from {table_name}")
                 for i in range(len(rows_distinct)):
                     dml.assert_type(pk_types, type, i + 1, rows_distinct[i][0])
         for type in index.keys():
-            if type not in unsuppored_time_types and type not in unsuppored_distinct_types:
+            if type not in unsuppored_distinct_types:
                 rows_distinct = self.query(f"SELECT DISTINCT col_index_{cleanup_type_name(type)} from {table_name}")
                 for i in range(len(rows_distinct)):
                     dml.assert_type(index, type, i + 1, rows_distinct[i][0])
@@ -199,16 +186,15 @@ class TestDML(TestBase):
         selected_columns = []
         for type in all_types.keys():
             if (
-                type not in unsuppored_time_types
-                and type not in unsuppored_distinct_types
+                type not in unsuppored_distinct_types
                 and type not in uncomparable_types
             ):
                 selected_columns.append(f"col_{cleanup_type_name(type)}")
         for type in pk_types.keys():
-            if type not in unsuppored_time_types and type not in unsuppored_distinct_types:
+            if type not in unsuppored_distinct_types:
                 selected_columns.append(f"pk_{cleanup_type_name(type)}")
         for type in index.keys():
-            if type not in unsuppored_time_types and type not in unsuppored_distinct_types:
+            if type not in unsuppored_distinct_types:
                 selected_columns.append(f"col_index_{cleanup_type_name(type)}")
         if ttl != "" and ttl != "DyNumber":
             selected_columns.append(f"ttl_{cleanup_type_name(ttl)}")
@@ -221,18 +207,17 @@ class TestDML(TestBase):
         )
         for type in all_types.keys():
             if (
-                type not in unsuppored_time_types
-                and type not in unsuppored_distinct_types
+                type not in unsuppored_distinct_types
                 and type not in uncomparable_types
             ):
                 for line in range(len(rows)):
                     dml.assert_type(all_types, type, line + 1, rows[line][f"col_{cleanup_type_name(type)}"])
         for type in pk_types.keys():
-            if type not in unsuppored_time_types and type not in unsuppored_distinct_types:
+            if type not in unsuppored_distinct_types:
                 for line in range(len(rows)):
                     dml.assert_type(pk_types, type, line + 1, rows[line][f"pk_{cleanup_type_name(type)}"])
         for type in index.keys():
-            if type not in unsuppored_time_types and type not in unsuppored_distinct_types:
+            if type not in unsuppored_distinct_types:
                 for line in range(len(rows)):
                     dml.assert_type(index, type, line + 1, rows[line][f"col_index_{cleanup_type_name(type)}"])
         if ttl != "" and ttl != "DyNumber":
@@ -273,24 +258,18 @@ class TestDML(TestBase):
     ):
         selected_columns_without = []
         for type_name in all_types.keys():
-            if type_name in unsuppored_time_types:
-                selected_columns_without.append(f"col_{cleanup_type_name(type_name)}")
+            selected_columns_without.append(f"col_{cleanup_type_name(type_name)}")
         for type_name in pk_types.keys():
-            if type_name in unsuppored_time_types:
-                selected_columns_without.append(f"pk_{cleanup_type_name(type_name)}")
+            selected_columns_without.append(f"pk_{cleanup_type_name(type_name)}")
         for type_name in index.keys():
-            if type_name in unsuppored_time_types:
-                selected_columns_without.append(f"col_index_{cleanup_type_name(type_name)}")
+            selected_columns_without.append(f"col_index_{cleanup_type_name(type_name)}")
 
         for type_name in all_types.keys():
-            if type_name not in unsuppored_time_types:
-                self.create_without(table_name, selected_columns_without, f"col_{cleanup_type_name(type_name)}")
+            self.create_without(table_name, selected_columns_without, f"col_{cleanup_type_name(type_name)}")
         for type_name in pk_types.keys():
-            if type_name not in unsuppored_time_types:
-                self.create_without(table_name, selected_columns_without, f"pk_{cleanup_type_name(type_name)}")
+            self.create_without(table_name, selected_columns_without, f"pk_{cleanup_type_name(type_name)}")
         for type_name in index.keys():
-            if type_name not in unsuppored_time_types:
-                self.create_without(table_name, selected_columns_without, f"col_index_{cleanup_type_name(type_name)}")
+            self.create_without(table_name, selected_columns_without, f"col_index_{cleanup_type_name(type_name)}")
         if ttl != "":
             self.create_without(table_name, selected_columns_without, f"ttl_{cleanup_type_name(ttl)}")
 
@@ -378,10 +357,9 @@ class TestDML(TestBase):
         all_types = {**pk_types, **non_pk_types}
         statements = []
         for type_name in all_types.keys():
-            if type_name not in unsuppored_time_types:
-                statements.append(
-                    f"{format_sql_value(all_types[type_name](1), type_name)} AS pk_{cleanup_type_name(type_name)}"
-                )
+            statements.append(
+                f"{format_sql_value(all_types[type_name](1), type_name)} AS pk_{cleanup_type_name(type_name)}"
+            )
         list_sql = f"""
             $data = AsList(
                 AsStruct({", ".join(statements)})
@@ -394,15 +372,9 @@ class TestDML(TestBase):
                    """
         )
         for type_name in all_types.keys():
-            if (
-                type_name != "Date32"
-                and type_name != "Datetime64"
-                and type_name != "Timestamp64"
-                and type_name != 'Interval64'
-            ):
-                if type_name == "Utf8":
-                    dml.assert_type(
-                        all_types, type_name, 1, rows[0][f"pk_{cleanup_type_name(type_name)}"].decode("utf-8")
-                    )
-                else:
-                    dml.assert_type(all_types, type_name, 1, rows[0][f"pk_{cleanup_type_name(type_name)}"])
+            if type_name == "Utf8":
+                dml.assert_type(
+                    all_types, type_name, 1, rows[0][f"pk_{cleanup_type_name(type_name)}"].decode("utf-8")
+                )
+            else:
+                dml.assert_type(all_types, type_name, 1, rows[0][f"pk_{cleanup_type_name(type_name)}"])

--- a/ydb/tests/datashard/select/test_select.py
+++ b/ydb/tests/datashard/select/test_select.py
@@ -69,6 +69,7 @@ class TestDML(TestBase):
         self.from_select(table_name, all_types, pk_types, index, ttl, dml)
         self.distinct(table_name, all_types, pk_types, index, ttl, dml)
         self.union(table_name, all_types, pk_types, index, ttl, dml)
+        self.without(table_name, all_types, pk_types, index, ttl)
         self.tablesample_sample(table_name, all_types, pk_types, index, ttl, dml)
 
     def limit(
@@ -251,6 +252,23 @@ class TestDML(TestBase):
             rows = dml.query(select_with_sql_request)
             for i, row in enumerate(rows):
                 self.assert_type_after_select(i + 1, row, all_types, pk_types, index, ttl, dml)
+
+    def without(
+        self, table_name: str, all_types: dict[str, str], pk_types: dict[str, str], index: dict[str, str], ttl: str
+    ):
+        for type_name in all_types.keys():
+            self.create_without(table_name, f"col_{cleanup_type_name(type_name)}")
+        for type_name in pk_types.keys():
+            self.create_without(table_name, f"pk_{cleanup_type_name(type_name)}")
+        for type_name in index.keys():
+            self.create_without(table_name, f"col_index_{cleanup_type_name(type_name)}")
+        if ttl != "":
+            self.create_without(table_name, f"ttl_{cleanup_type_name(ttl)}")
+
+    def create_without(self, table_name, without):
+        rows = self.query(f"select * without {without} from {table_name}")
+        for col_name in rows[0].keys():
+            assert col_name != without, f"a column {without} in the table {table_name} was not excluded"
 
     def tablesample_sample(
         self,

--- a/ydb/tests/datashard/split_merge/test_split_merge.py
+++ b/ydb/tests/datashard/split_merge/test_split_merge.py
@@ -47,16 +47,16 @@ class TestSplitMerge(TestBase):
              {**pk_types, **non_pk_types}, {}, "", "", ""),
             ("table_Int32", {"Int32": lambda i: i},
              {**pk_types, **non_pk_types}, {}, "", "", ""),
-            # ("table_Int16", {"Int16": lambda i: i},
-            # {**pk_types, **non_pk_types}, {}, "", "", ""), https://github.com/ydb-platform/ydb/issues/15842
+            ("table_Int16", {"Int16": lambda i: i},
+             {**pk_types, **non_pk_types}, {}, "", "", ""),
             ("table_Int8", {"Int8": lambda i: i}, {
              **pk_types, **non_pk_types}, {}, "", "", ""),
             ("table_Uint64", {"Uint64": lambda i: i},
              {**pk_types, **non_pk_types}, {}, "", "", ""),
             ("table_Uint32", {"Uint32": lambda i: i},
              {**pk_types, **non_pk_types}, {}, "", "", ""),
-            # ("table_Uint16", {"Uint16": lambda i: i},
-            # {**pk_types, **non_pk_types}, {}, "", "", ""), https://github.com/ydb-platform/ydb/issues/15842
+            ("table_Uint16", {"Uint16": lambda i: i},
+             {**pk_types, **non_pk_types}, {}, "", "", ""),
             ("table_Uint8", {"Uint8": lambda i: i},
              {**pk_types, **non_pk_types}, {}, "", "", ""),
             ("table_Decimal150", {

--- a/ydb/tests/datashard/vector_index/medium/test_vector_index.py
+++ b/ydb/tests/datashard/vector_index/medium/test_vector_index.py
@@ -182,36 +182,18 @@ class TestVectorIndex(VectorBase):
             rows.reverse()
         count = 0
         for data_type in all_types.keys():
-            if (
-                data_type != "Date32"
-                and data_type != "Datetime64"
-                and data_type != "Timestamp64"
-                and data_type != 'Interval64'
-                and data_type != 'String'
-            ):
+            if data_type != 'String':
                 for i in range(len(rows)):
                     dml.assert_type(all_types, data_type, i + 1, rows[i][count])
                 count += 1
         for data_type in pk_types.keys():
-            if (
-                data_type != "Date32"
-                and data_type != "Datetime64"
-                and data_type != "Timestamp64"
-                and data_type != 'Interval64'
-            ):
-                for i in range(len(rows)):
-                    dml.assert_type(pk_types, data_type, i + 1, rows[i][count])
-                count += 1
+            for i in range(len(rows)):
+                dml.assert_type(pk_types, data_type, i + 1, rows[i][count])
+            count += 1
         for data_type in index.keys():
-            if (
-                data_type != "Date32"
-                and data_type != "Datetime64"
-                and data_type != "Timestamp64"
-                and data_type != 'Interval64'
-            ):
-                for i in range(len(rows)):
-                    dml.assert_type(index, data_type, i + 1, rows[i][count])
-                count += 1
+            for i in range(len(rows)):
+                dml.assert_type(index, data_type, i + 1, rows[i][count])
+            count += 1
         if ttl != "":
             for i in range(len(rows)):
                 dml.assert_type(ttl_types, ttl, i + 1, rows[i][count])
@@ -389,34 +371,16 @@ class TestVectorIndex(VectorBase):
                 rows.reverse()
             count = 0
             for data_type in all_types.keys():
-                if (
-                    data_type != "Date32"
-                    and data_type != "Datetime64"
-                    and data_type != "Timestamp64"
-                    and data_type != 'Interval64'
-                    and data_type != 'String'
-                ):
+                if data_type != 'String':
                     for j in range(len(rows)):
                         dml.assert_type(all_types, data_type, i + j * 5, rows[j][count])
                     count += 1
             for data_type in pk_types.keys():
-                if (
-                    data_type != "Date32"
-                    and data_type != "Datetime64"
-                    and data_type != "Timestamp64"
-                    and data_type != 'Interval64'
-                ):
-                    for j in range(len(rows)):
-                        dml.assert_type(pk_types, data_type, i + j * 5, rows[j][count])
-                    count += 1
+                for j in range(len(rows)):
+                    dml.assert_type(pk_types, data_type, i + j * 5, rows[j][count])
+                count += 1
             for data_type in index.keys():
-                if (
-                    data_type != "Date32"
-                    and data_type != "Datetime64"
-                    and data_type != "Timestamp64"
-                    and data_type != 'Interval64'
-                    and data_type != 'String'
-                ):
+                if data_type != 'String':
                     for j in range(len(rows)):
                         dml.assert_type(index, data_type, i + j * 5, rows[j][count])
                     count += 1


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

...

### Changelog category <!-- remove all except one -->

* Not for changelog (changelog entry is not required)

### Description for reviewers <!-- (optional) description for those who read this PR -->

I found these issues in datashard tests when I was writing new checks for `ALTER TABLE ADD COLUMN`:
* #15842
* #16930
* #17178

1. I've already fixed (u)int16 issue for `ALTER TABLE ADD COLUMN DEFAULT`: #20887
2. Date32, Datetime64, Timestamp64, Interval64 are supported in Python SDK supports: https://github.com/ydb-platform/ydb-python-sdk/blob/main/ydb/types.py#L139

This is an attempt to support the new time types and (u)int16 in datashard tests and close the issues above.

...
