### PR TITLE
25-1: User-defined Certificate Authority (CA) in asynchronous replication

### DIFF
--- a/ydb/core/kqp/host/kqp_gateway_proxy.cpp
+++ b/ydb/core/kqp/host/kqp_gateway_proxy.cpp
@@ -2424,6 +2424,9 @@ public:
             if (const auto& staticCreds = settings.Settings.StaticCredentials) {
                 staticCreds->Serialize(*params.MutableStaticCredentials());
             }
+            if (const auto& caCert = settings.Settings.CaCert) {
+                params.SetCaCert(*caCert);
+            }
             if (settings.Settings.RowConsistency) {
                 config.MutableConsistencySettings()->MutableRow();
             }
@@ -2491,14 +2494,20 @@ public:
                 state.MutableStandBy();
             }
 
-            if (settings.Settings.ConnectionString || settings.Settings.Endpoint || settings.Settings.Database ||
-                    settings.Settings.OAuthToken || settings.Settings.StaticCredentials) {
+            if (settings.Settings.ConnectionString
+                || settings.Settings.Endpoint
+                || settings.Settings.Database
+                || settings.Settings.OAuthToken
+                || settings.Settings.StaticCredentials
+                || settings.Settings.CaCert
+            ) {
                 auto& config = *op.MutableConfig();
                 auto& params = *config.MutableSrcConnectionParams();
                 if (const auto& connectionString = settings.Settings.ConnectionString) {
                     const auto parseResult = NYdb::ParseConnectionString(*connectionString);
                     params.SetEndpoint(TString{parseResult.Endpoint});
                     params.SetDatabase(TString{parseResult.Database});
+                    params.SetEnableSsl(parseResult.EnableSsl);
                 }
                 if (const auto& endpoint = settings.Settings.Endpoint) {
                     params.SetEndpoint(*endpoint);
@@ -2511,6 +2520,9 @@ public:
                 }
                 if (const auto& staticCreds = settings.Settings.StaticCredentials) {
                     staticCreds->Serialize(*params.MutableStaticCredentials());
+                }
+                if (const auto& caCert = settings.Settings.CaCert) {
+                    params.SetCaCert(*caCert);
                 }
             }
 
@@ -2599,8 +2611,6 @@ public:
             op.SetName(pathPair.second);
 
             auto& config = *op.MutableConfig();
-
-
             auto& params = *config.MutableSrcConnectionParams();
             if (const auto& connectionString = settings.Settings.ConnectionString) {
                 const auto parseResult = NYdb::ParseConnectionString(*connectionString);
@@ -2619,6 +2629,9 @@ public:
             }
             if (const auto& staticCreds = settings.Settings.StaticCredentials) {
                 staticCreds->Serialize(*params.MutableStaticCredentials());
+            }
+            if (const auto& caCert = settings.Settings.CaCert) {
+                params.SetCaCert(*caCert);
             }
 
             {
@@ -2709,14 +2722,20 @@ public:
                 state.MutableStandBy();
             }
 
-            if (settings.Settings.ConnectionString || settings.Settings.Endpoint || settings.Settings.Database ||
-                    settings.Settings.OAuthToken || settings.Settings.StaticCredentials) {
+            if (settings.Settings.ConnectionString
+                || settings.Settings.Endpoint
+                || settings.Settings.Database
+                || settings.Settings.OAuthToken
+                || settings.Settings.StaticCredentials
+                || settings.Settings.CaCert
+            ) {
                 auto& config = *op.MutableConfig();
                 auto& params = *config.MutableSrcConnectionParams();
                 if (const auto& connectionString = settings.Settings.ConnectionString) {
                     const auto parseResult = NYdb::ParseConnectionString(*connectionString);
                     params.SetEndpoint(TString{parseResult.Endpoint});
                     params.SetDatabase(TString{parseResult.Database});
+                    params.SetEnableSsl(parseResult.EnableSsl);
                 }
                 if (const auto& endpoint = settings.Settings.Endpoint) {
                     params.SetEndpoint(*endpoint);
@@ -2729,6 +2748,9 @@ public:
                 }
                 if (const auto& staticCreds = settings.Settings.StaticCredentials) {
                     staticCreds->Serialize(*params.MutableStaticCredentials());
+                }
+                if (const auto& caCert = settings.Settings.CaCert) {
+                    params.SetCaCert(*caCert);
                 }
             }
 

--- a/ydb/core/kqp/provider/yql_kikimr_exec.cpp
+++ b/ydb/core/kqp/provider/yql_kikimr_exec.cpp
@@ -726,6 +726,8 @@ namespace {
             } else if (name == "password_secret_name") {
                 dstSettings.EnsureStaticCredentials().PasswordSecretName =
                     setting.Value().Cast<TCoDataCtor>().Literal().Cast<TCoAtom>().Value();
+            } else if (name == "ca_cert") {
+                dstSettings.CaCert = setting.Value().Cast<TCoDataCtor>().Literal().Cast<TCoAtom>().Value();
             } else if (name == "state") {
                 auto value = ToString(setting.Value().Cast<TCoDataCtor>().Literal().Cast<TCoAtom>().Value());
                 if (to_lower(value) == "done") {

--- a/ydb/core/kqp/provider/yql_kikimr_gateway.h
+++ b/ydb/core/kqp/provider/yql_kikimr_gateway.h
@@ -837,6 +837,7 @@ struct TReplicationSettingsBase {
     TMaybe<TString> Database;
     TMaybe<TOAuthToken> OAuthToken;
     TMaybe<TStaticCredentials> StaticCredentials;
+    TMaybe<TString> CaCert;
     TMaybe<TStateDone> StateDone;
     bool StatePaused = false;
     bool StateStandBy = false;

--- a/ydb/core/kqp/provider/yql_kikimr_type_ann.cpp
+++ b/ydb/core/kqp/provider/yql_kikimr_type_ann.cpp
@@ -1778,6 +1778,7 @@ virtual TStatus HandleCreateTable(TKiCreateTable create, TExprContext& ctx) over
             "user",
             "password",
             "password_secret_name",
+            "ca_cert",
             "consistency_level",
             "commit_interval",
         };
@@ -1805,6 +1806,7 @@ virtual TStatus HandleCreateTable(TKiCreateTable create, TExprContext& ctx) over
             "user",
             "password",
             "password_secret_name",
+            "ca_cert",
             "state",
             "failover_mode",
         };
@@ -1837,6 +1839,7 @@ virtual TStatus HandleCreateTable(TKiCreateTable create, TExprContext& ctx) over
             "user",
             "password",
             "password_secret_name",
+            "ca_cert",
             "commit_interval",
             "flush_interval",
             "batch_size_bytes",
@@ -1867,6 +1870,7 @@ virtual TStatus HandleCreateTable(TKiCreateTable create, TExprContext& ctx) over
             "user",
             "password",
             "password_secret_name",
+            "ca_cert",
             "state",
             "failover_mode",
             "flush_interval",

--- a/ydb/core/kqp/ut/scheme/kqp_scheme_ut.cpp
+++ b/ydb/core/kqp/ut/scheme/kqp_scheme_ut.cpp
@@ -7774,7 +7774,7 @@ Y_UNIT_TEST_SUITE(KqpScheme) {
             )", kikimr.GetEndpoint().c_str());
 
             const auto result = session.ExecuteSchemeQuery(query).GetValueSync();
-            UNIT_ASSERT_VALUES_EQUAL_C(result.GetStatus(), EStatus::BAD_REQUEST, result.GetIssues().ToString());
+            UNIT_ASSERT_VALUES_EQUAL_C(result.GetStatus(), EStatus::GENERIC_ERROR, result.GetIssues().ToString());
             UNIT_ASSERT_STRING_CONTAINS_C(result.GetIssues().ToOneLineString(), "CA_CERT has no effect in non-secure mode", result.GetIssues().ToOneLineString());
         }
 

--- a/ydb/core/kqp/ut/scheme/kqp_scheme_ut.cpp
+++ b/ydb/core/kqp/ut/scheme/kqp_scheme_ut.cpp
@@ -7754,6 +7754,49 @@ Y_UNIT_TEST_SUITE(KqpScheme) {
         }
     }
 
+    Y_UNIT_TEST(CreateAsyncReplicationWithCaCert) {
+        TKikimrRunner kikimr;
+        auto db = kikimr.GetTableClient();
+        auto session = db.CreateSession().GetValueSync().GetSession();
+
+        // invalid, non-secure mode
+        {
+            auto query = Sprintf(R"(
+                --!syntax_v1
+                CREATE ASYNC REPLICATION `/Root/replication` FOR
+                    `/Root/table` AS `/Root/replica`
+                WITH (
+                    CONNECTION_STRING = "grpc://localhost:2135/?database=/Root",
+                    USER = "user",
+                    PASSWORD = "password",
+                    CA_CERT = "-----BEGIN CERTIFICATE-----"
+                );
+            )", kikimr.GetEndpoint().c_str());
+
+            const auto result = session.ExecuteSchemeQuery(query).GetValueSync();
+            UNIT_ASSERT_VALUES_EQUAL_C(result.GetStatus(), EStatus::BAD_REQUEST, result.GetIssues().ToString());
+            UNIT_ASSERT_STRING_CONTAINS_C(result.GetIssues().ToOneLineString(), "CA_CERT has no effect in non-secure mode", result.GetIssues().ToOneLineString());
+        }
+
+        // ok
+        {
+            auto query = Sprintf(R"(
+                --!syntax_v1
+                CREATE ASYNC REPLICATION `/Root/replication` FOR
+                    `/Root/table` AS `/Root/replica`
+                WITH (
+                    CONNECTION_STRING = "grpcs://localhost:2135/?database=/Root",
+                    USER = "user",
+                    PASSWORD = "password",
+                    CA_CERT = "-----BEGIN CERTIFICATE-----"
+                );
+            )", kikimr.GetEndpoint().c_str());
+
+            const auto result = session.ExecuteSchemeQuery(query).GetValueSync();
+            UNIT_ASSERT_VALUES_EQUAL_C(result.GetStatus(), EStatus::SUCCESS, result.GetIssues().ToString());
+        }
+    }
+
     Y_UNIT_TEST_TWIN(AsyncReplicationCommitInterval, UseQueryService) {
         TKikimrRunner kikimr;
         auto queryClient = kikimr.GetQueryClient();

--- a/ydb/core/kqp/ut/scheme/kqp_scheme_ut.cpp
+++ b/ydb/core/kqp/ut/scheme/kqp_scheme_ut.cpp
@@ -7774,7 +7774,7 @@ Y_UNIT_TEST_SUITE(KqpScheme) {
             )", kikimr.GetEndpoint().c_str());
 
             const auto result = session.ExecuteSchemeQuery(query).GetValueSync();
-            UNIT_ASSERT_VALUES_EQUAL_C(result.GetStatus(), EStatus::GENERIC_ERROR, result.GetIssues().ToString());
+            UNIT_ASSERT_VALUES_EQUAL_C(result.GetStatus(), EStatus::BAD_REQUEST, result.GetIssues().ToString());
             UNIT_ASSERT_STRING_CONTAINS_C(result.GetIssues().ToOneLineString(), "CA_CERT has no effect in non-secure mode", result.GetIssues().ToOneLineString());
         }
 

--- a/ydb/core/protos/replication.proto
+++ b/ydb/core/protos/replication.proto
@@ -31,6 +31,7 @@ message TConnectionParams {
     optional string Endpoint = 1;
     optional string Database = 2;
     optional bool EnableSsl = 5;
+    optional string CaCert = 6;
     // credentials
     oneof Credentials {
         TStaticCredentials StaticCredentials = 3;

--- a/ydb/core/tx/replication/controller/replication.cpp
+++ b/ydb/core/tx/replication/controller/replication.cpp
@@ -145,6 +145,7 @@ public:
             const auto& endpoint = params.GetEndpoint();
             const auto& database = params.GetDatabase();
             const bool ssl = params.GetEnableSsl();
+            const auto& caCert = params.GetCaCert();
 
             if (endpoint.empty()) {
                 ydbProxy.Reset(CreateLocalYdbProxy(Database));
@@ -154,13 +155,13 @@ public:
                     if (!params.GetStaticCredentials().HasPassword()) {
                         return ResolveSecret(params.GetStaticCredentials().GetPasswordSecretName(), ctx);
                     }
-                    ydbProxy.Reset(CreateYdbProxy(endpoint, database, ssl, params.GetStaticCredentials()));
+                    ydbProxy.Reset(CreateYdbProxy(endpoint, database, ssl, caCert, params.GetStaticCredentials()));
                     break;
                 case NKikimrReplication::TConnectionParams::kOAuthToken:
                     if (!params.GetOAuthToken().HasToken()) {
                         return ResolveSecret(params.GetOAuthToken().GetTokenSecretName(), ctx);
                     }
-                    ydbProxy.Reset(CreateYdbProxy(endpoint, database, ssl, params.GetOAuthToken().GetToken()));
+                    ydbProxy.Reset(CreateYdbProxy(endpoint, database, ssl, caCert, params.GetOAuthToken().GetToken()));
                     break;
                 default:
                     ErrorState(TStringBuilder() << "Unexpected credentials: " << params.GetCredentialsCase());

--- a/ydb/core/tx/replication/controller/target_discoverer_ut.cpp
+++ b/ydb/core/tx/replication/controller/target_discoverer_ut.cpp
@@ -203,7 +203,7 @@ Y_UNIT_TEST_SUITE(TargetDiscoverer) {
         staticCreds.SetUser("user");
         staticCreds.SetPassword("password");
         const auto ydbProxy = env.GetRuntime().Register(CreateYdbProxy(
-            env.GetEndpoint(), env.GetDatabase(), false /* ssl */, staticCreds));
+            env.GetEndpoint(), env.GetDatabase(), false /* ssl */, "" /* cert */, staticCreds));
 
         env.GetRuntime().Register(CreateTargetDiscoverer(env.GetSender(), 1, ydbProxy,
             CreateConfig(TVector<std::pair<TString, TString>>{

--- a/ydb/core/tx/replication/ut_helpers/test_env.h
+++ b/ydb/core/tx/replication/ut_helpers/test_env.h
@@ -35,7 +35,7 @@ class TEnv {
         Database = "/" + ToString(DomainName);
 
         YdbProxy = Server.GetRuntime()->Register(CreateYdbProxy(
-            Endpoint, UseDatabase ? Database : "", false /* ssl */, std::forward<Args>(args)...));
+            Endpoint, UseDatabase ? Database : "", false /* ssl */, "" /* cert */, std::forward<Args>(args)...));
         Sender = Server.GetRuntime()->AllocateEdgeActor();
     }
 

--- a/ydb/core/tx/replication/ydb_proxy/ydb_proxy.cpp
+++ b/ydb/core/tx/replication/ydb_proxy/ydb_proxy.cpp
@@ -309,6 +309,9 @@ class TYdbProxy: public TBaseProxyActor<TYdbProxy> {
         if (base.CredentialsProviderFactory_) {
             derived.CredentialsProviderFactory(*base.CredentialsProviderFactory_);
         }
+        if (base.SslCredentials_) {
+            derived.SslCredentials_ = base.SslCredentials_;
+        }
 
         return derived;
     }
@@ -446,22 +449,24 @@ class TYdbProxy: public TBaseProxyActor<TYdbProxy> {
         Call<TEvYdbProxy::TEvCommitOffsetResponse>(ev, &TTopicClient::CommitOffset);
     }
 
-    static TCommonClientSettings MakeSettings(const TString& endpoint, const TString& database, bool ssl) {
+    static TCommonClientSettings BaseSettings(const TString& endpoint, const TString& database, bool ssl, const TString& caCert) {
         return TCommonClientSettings()
             .DiscoveryEndpoint(endpoint)
             .DiscoveryMode(EDiscoveryMode::Async)
             .Database(database)
-            .SslCredentials(ssl);
+            .SslCredentials(TSslCredentials(ssl, caCert));
     }
 
-    static TCommonClientSettings MakeSettings(const TString& endpoint, const TString& database, bool ssl, const TString& token) {
-        return MakeSettings(endpoint, database, ssl)
-            .AuthToken(token);
+    static TCommonClientSettings MakeSettings(TCommonClientSettings&& settings) {
+        return settings;
     }
 
-    static TCommonClientSettings MakeSettings(const TString& endpoint, const TString& database, bool ssl, const TStaticCredentials& credentials) {
-        return MakeSettings(endpoint, database, ssl)
-            .CredentialsProviderFactory(CreateLoginCredentialsProviderFactory({
+    static TCommonClientSettings MakeSettings(TCommonClientSettings&& settings, const TString& token) {
+        return settings.AuthToken(token);
+    }
+
+    static TCommonClientSettings MakeSettings(TCommonClientSettings&& settings, const TStaticCredentials& credentials) {
+        return settings.CredentialsProviderFactory(CreateLoginCredentialsProviderFactory({
                 .User = credentials.GetUser(),
                 .Password = credentials.GetPassword(),
             }));
@@ -469,9 +474,9 @@ class TYdbProxy: public TBaseProxyActor<TYdbProxy> {
 
 public:
     template <typename... Args>
-    explicit TYdbProxy(Args&&... args)
+    explicit TYdbProxy(const TString& endpoint, const TString& database, bool ssl, const TString& caCert, Args&&... args)
         : TBaseProxyActor(&TThis::StateWork)
-        , CommonSettings(MakeSettings(std::forward<Args>(args)...))
+        , CommonSettings(MakeSettings(BaseSettings(endpoint, database, ssl, caCert), std::forward<Args>(args)...))
     {
     }
 
@@ -513,16 +518,16 @@ private:
 
 }; // TYdbProxy
 
-IActor* CreateYdbProxy(const TString& endpoint, const TString& database, bool ssl) {
-    return new TYdbProxy(endpoint, database, ssl);
+IActor* CreateYdbProxy(const TString& endpoint, const TString& database, bool ssl, const TString& caCert) {
+    return new TYdbProxy(endpoint, database, ssl, caCert);
 }
 
-IActor* CreateYdbProxy(const TString& endpoint, const TString& database, bool ssl, const TString& token) {
-    return new TYdbProxy(endpoint, database, ssl, token);
+IActor* CreateYdbProxy(const TString& endpoint, const TString& database, bool ssl, const TString& caCert, const TString& token) {
+    return new TYdbProxy(endpoint, database, ssl, caCert, token);
 }
 
-IActor* CreateYdbProxy(const TString& endpoint, const TString& database, bool ssl, const TStaticCredentials& credentials) {
-    return new TYdbProxy(endpoint, database, ssl, credentials);
+IActor* CreateYdbProxy(const TString& endpoint, const TString& database, bool ssl, const TString& caCert, const TStaticCredentials& credentials) {
+    return new TYdbProxy(endpoint, database, ssl, caCert, credentials);
 }
 
 }

--- a/ydb/core/tx/replication/ydb_proxy/ydb_proxy.h
+++ b/ydb/core/tx/replication/ydb_proxy/ydb_proxy.h
@@ -287,9 +287,9 @@ struct TEvYdbProxy {
 
 #pragma pop_macro("RemoveDirectory")
 
-IActor* CreateYdbProxy(const TString& endpoint, const TString& database, bool ssl);
-IActor* CreateYdbProxy(const TString& endpoint, const TString& database, bool ssl, const TString& token);
-IActor* CreateYdbProxy(const TString& endpoint, const TString& database, bool ssl,
+IActor* CreateYdbProxy(const TString& endpoint, const TString& database, bool ssl = false, const TString& caCert = {});
+IActor* CreateYdbProxy(const TString& endpoint, const TString& database, bool ssl, const TString& caCert, const TString& token);
+IActor* CreateYdbProxy(const TString& endpoint, const TString& database, bool ssl, const TString& caCert,
     const NKikimrReplication::TStaticCredentials& credentials);
 
 IActor* CreateLocalYdbProxy(const TString& database);

--- a/ydb/core/tx/schemeshard/schemeshard__operation_create_replication.cpp
+++ b/ydb/core/tx/schemeshard/schemeshard__operation_create_replication.cpp
@@ -432,6 +432,12 @@ public:
                 "Unable to construct channel binding for replication controller with the storage pool");
             return result;
         }
+ 
+        const auto& connectionParams = desc.GetConfig().GetSrcConnectionParams();
+        if (connectionParams.HasCaCert() && !connectionParams.GetEnableSsl()) {
+            result->SetError(NKikimrScheme::StatusInvalidParameter, "CA_CERT has no effect in non-secure mode");
+            return result;
+        }
 
         path.MaterializeLeaf(owner);
         path->CreateTxId = OperationId.GetTxId();
@@ -444,7 +450,7 @@ public:
         IncAliveChildrenDirect(OperationId, parentPath, context); // for correct discard of ChildrenExist prop
         parentPath.DomainInfo()->IncPathsInside(context.SS);
 
-        if (desc.GetConfig().GetSrcConnectionParams().GetCredentialsCase() == NKikimrReplication::TConnectionParams::CREDENTIALS_NOT_SET) {
+        if (connectionParams.GetCredentialsCase() == NKikimrReplication::TConnectionParams::CREDENTIALS_NOT_SET) {
             desc.MutableConfig()->MutableSrcConnectionParams()->MutableOAuthToken()->SetToken(BUILTIN_ACL_ROOT);
         }
 

--- a/ydb/core/tx/schemeshard/ut_replication/ut_replication.cpp
+++ b/ydb/core/tx/schemeshard/ut_replication/ut_replication.cpp
@@ -293,6 +293,90 @@ Y_UNIT_TEST_SUITE(TReplicationTests) {
         }
     }
 
+    Y_UNIT_TEST(SecureMode) {
+        TTestBasicRuntime runtime;
+        TTestEnv env(runtime, TTestEnvOptions().InitYdbDriver(true));
+        ui64 txId = 100;
+
+        SetupLogging(runtime);
+
+        TestCreateReplication(runtime, ++txId, "/MyRoot", R"(
+            Name: "Replication"
+            Config {
+              SrcConnectionParams {
+                CaCert: "-----BEGIN CERTIFICATE-----"
+              }
+              Specific {
+                Targets {
+                  SrcPath: "/MyRoot1/Table"
+                  DstPath: "/MyRoot2/Table"
+                }
+              }
+            }
+        )", {NKikimrScheme::StatusInvalidParameter});
+
+        TestCreateReplication(runtime, ++txId, "/MyRoot", R"(
+            Name: "Replication"
+            Config {
+              SrcConnectionParams {
+                EnableSsl: false
+                CaCert: "-----BEGIN CERTIFICATE-----"
+              }
+              Specific {
+                Targets {
+                  SrcPath: "/MyRoot1/Table"
+                  DstPath: "/MyRoot2/Table"
+                }
+              }
+            }
+        )", {NKikimrScheme::StatusInvalidParameter});
+
+        TestCreateReplication(runtime, ++txId, "/MyRoot", R"(
+            Name: "Replication1"
+            Config {
+              SrcConnectionParams {
+                EnableSsl: true
+                CaCert: "-----BEGIN CERTIFICATE-----"
+              }
+              Specific {
+                Targets {
+                  SrcPath: "/MyRoot1/Table"
+                  DstPath: "/MyRoot2/Table"
+                }
+              }
+            }
+        )");
+        env.TestWaitNotification(runtime, txId);
+        {
+            const auto desc = DescribePath(runtime, "/MyRoot/Replication1");
+            const auto& params = desc.GetPathDescription().GetReplicationDescription().GetConfig().GetSrcConnectionParams();
+            UNIT_ASSERT(params.GetEnableSsl());
+            UNIT_ASSERT_VALUES_EQUAL(params.GetCaCert(), "-----BEGIN CERTIFICATE-----");
+        }
+
+        TestCreateReplication(runtime, ++txId, "/MyRoot", R"(
+            Name: "Replication2"
+            Config {
+              SrcConnectionParams {
+                EnableSsl: true
+              }
+              Specific {
+                Targets {
+                  SrcPath: "/MyRoot1/Table"
+                  DstPath: "/MyRoot2/Table"
+                }
+              }
+            }
+        )");
+        env.TestWaitNotification(runtime, txId);
+        {
+            const auto desc = DescribePath(runtime, "/MyRoot/Replication2");
+            const auto& params = desc.GetPathDescription().GetReplicationDescription().GetConfig().GetSrcConnectionParams();
+            UNIT_ASSERT(params.GetEnableSsl());
+            UNIT_ASSERT(!params.HasCaCert());
+        }
+    }
+
     Y_UNIT_TEST(Alter) {
         TTestBasicRuntime runtime;
         TTestEnv env(runtime, TTestEnvOptions().InitYdbDriver(true));

--- a/yql/essentials/sql/v1/sql_query.cpp
+++ b/yql/essentials/sql/v1/sql_query.cpp
@@ -64,6 +64,7 @@ static bool AsyncReplicationSettingsEntry(std::map<TString, TNodePtr>& out,
         "user",
         "password",
         "password_secret_name",
+        "ca_cert",
     };
 
     TSet<TString> modeSettings = {
@@ -163,6 +164,7 @@ static bool TransferSettingsEntry(std::map<TString, TNodePtr>& out,
         "user",
         "password",
         "password_secret_name",
+        "ca_cert",
         "flush_interval",
         "batch_size_bytes",
         "directory",

--- a/yql/essentials/sql/v1/sql_ut.cpp
+++ b/yql/essentials/sql/v1/sql_ut.cpp
@@ -3141,7 +3141,8 @@ Y_UNIT_TEST_SUITE(SqlParsingOnly) {
             WITH (
                 CONNECTION_STRING = "grpc://localhost:2135/?database=/MyDatabase",
                 ENDPOINT = "localhost:2135",
-                DATABASE = "/MyDatabase"
+                DATABASE = "/MyDatabase",
+                CA_CERT = "-----BEGIN CERTIFICATE-----"
             );
         )";
         auto res = SqlToYql(req);
@@ -3161,6 +3162,8 @@ Y_UNIT_TEST_SUITE(SqlParsingOnly) {
                 UNIT_ASSERT_VALUES_UNEQUAL(TString::npos, line.find("localhost:2135"));
                 UNIT_ASSERT_VALUES_UNEQUAL(TString::npos, line.find("database"));
                 UNIT_ASSERT_VALUES_UNEQUAL(TString::npos, line.find("/MyDatabase"));
+                UNIT_ASSERT_VALUES_UNEQUAL(TString::npos, line.find("ca_cert"));
+                UNIT_ASSERT_VALUES_UNEQUAL(TString::npos, line.find("-----BEGIN CERTIFICATE-----"));
             }
         };
 
@@ -3255,6 +3258,7 @@ Y_UNIT_TEST_SUITE(SqlParsingOnly) {
             {"user", "user"},
             {"password", "bar"},
             {"password_secret_name", "bar_secret_name"},
+            {"ca_cert", "-----BEGIN CERTIFICATE-----"},
         };
 
         for (const auto& [k, v] : settings) {


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

Added support for a user-defined Certificate Authority (CA) in asynchronous replication.

### Changelog category <!-- remove all except one -->

* New feature

### Description for reviewers <!-- (optional) description for those who read this PR -->

issue: https://github.com/ydb-platform/ydb/issues/21353