### PR TITLE
YQ-4556 fixed PartitionedTaskParams type (repeated string -> repeated bytes)

### DIFF
--- a/ydb/core/protos/kqp_physical.proto
+++ b/ydb/core/protos/kqp_physical.proto
@@ -380,8 +380,7 @@ message TKqpExternalSource {
 
     // Partitioning
     string TaskParamKey = 3;
-    reserved 4;
-    repeated bytes PartitionedTaskParams = 8;
+    repeated bytes PartitionedTaskParams = 4;
 
     string SourceName = 5;
     string AuthInfo = 6;

--- a/ydb/core/protos/kqp_physical.proto
+++ b/ydb/core/protos/kqp_physical.proto
@@ -380,7 +380,8 @@ message TKqpExternalSource {
 
     // Partitioning
     string TaskParamKey = 3;
-    repeated string PartitionedTaskParams = 4;
+    reserved 4;
+    repeated bytes PartitionedTaskParams = 8;
 
     string SourceName = 5;
     string AuthInfo = 6;


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

Fixed PartitionedTaskParams type (repeated string -> repeated bytes). PartitionedTaskParams contains serialized protobufs

### Changelog category <!-- remove all except one -->

* Bugfix 

### Description for reviewers <!-- (optional) description for those who read this PR -->

There should be no problem with compatibility, since the `TKqpExternalSource` protobuff only goes between compile actor <-> executer actor within a single node and is cached only in memory in session actor.