### PR TITLE
retry replica notifications with mismatched cluster state

### DIFF
--- a/ydb/core/tx/scheme_board/subscriber.cpp
+++ b/ydb/core/tx/scheme_board/subscriber.cpp
@@ -490,7 +490,6 @@ public:
 
 template <typename TPath, typename TDerived, typename TReplicaDerived>
 class TSubscriberProxy: public TMonitorableActor<TDerived> {
-
     void Sleep() {
         ReplicaSubscriber = TActorId();
         this->Send(Parent, new NInternalEvents::TEvNotifyBuilder(Path, true));

--- a/ydb/core/tx/scheme_board/subscriber.cpp
+++ b/ydb/core/tx/scheme_board/subscriber.cpp
@@ -52,7 +52,7 @@ namespace {
     }
 
     template <typename TPath>
-    bool IsValidNotification(const TPath& path, const NKikimrSchemeBoard::TEvNotify& record, const TClusterState* clusterState = nullptr) {
+    bool IsValidNotification(const TPath& path, const NKikimrSchemeBoard::TEvNotify& record) {
         bool valid = false;
 
         if (record.HasPath()) {
@@ -61,10 +61,6 @@ namespace {
 
         if (!valid && (record.HasPathOwnerId() && record.HasLocalPathId())) {
             valid = IsSame(path, TPathId(record.GetPathOwnerId(), record.GetLocalPathId()));
-        }
-
-        if (valid && clusterState && record.HasClusterState()) {
-            valid = (*clusterState == TClusterState(record.GetClusterState()));
         }
 
         return valid;
@@ -494,9 +490,26 @@ public:
 
 template <typename TPath, typename TDerived, typename TReplicaDerived>
 class TSubscriberProxy: public TMonitorableActor<TDerived> {
+
+    void Sleep() {
+        ReplicaSubscriber = TActorId();
+        this->Send(Parent, new NInternalEvents::TEvNotifyBuilder(Path, true));
+        this->Become(&TDerived::StateSleep, Delay, new TEvents::TEvWakeup());
+        Delay = Min(Delay * 2, MaxDelay);
+    }
+
     void Handle(NInternalEvents::TEvNotify::TPtr& ev) {
         if (ev->Sender != ReplicaSubscriber) {
             return;
+        }
+        if (const auto& record = ev->Get()->GetRecord(); record.HasClusterState() && TClusterState(record.GetClusterState()) != ClusterState) {
+            SBS_LOG_D("Cluster state mismatch in replica notification"
+                << ": sender# " << ev->Sender
+                << ", subscriber cluster state# " << ClusterState
+                << ", replica cluster state# {" << record.GetClusterState().ShortDebugString() << "}"
+            );
+            this->Send(ReplicaSubscriber, new TEvents::TEvPoisonPill());
+            return Sleep();
         }
 
         this->Send(Parent, ev->Release().Release(), 0, ev->Cookie);
@@ -552,10 +565,7 @@ class TSubscriberProxy: public TMonitorableActor<TDerived> {
             CurrentSyncRequest = 0;
         }
 
-        ReplicaSubscriber = TActorId();
-        this->Send(Parent, new NInternalEvents::TEvNotifyBuilder(Path, true));
-        this->Become(&TDerived::StateSleep, Delay, new TEvents::TEvWakeup());
-        Delay = Min(Delay * 2, MaxDelay);
+        Sleep();
     }
 
     void PassAway() override {
@@ -589,13 +599,15 @@ public:
             const ui32 totalReplicas,
             const TActorId& replica,
             const TPath& path,
-            const ui64 domainOwnerId)
+            const ui64 domainOwnerId,
+            const TClusterState& clusterState)
         : Parent(parent)
         , ReplicaIndex(replicaIndex)
         , TotalReplicas(totalReplicas)
         , Replica(replica)
         , Path(path)
         , DomainOwnerId(domainOwnerId)
+        , ClusterState(clusterState)
         , Delay(DefaultDelay)
         , CurrentSyncRequest(0)
     {
@@ -641,6 +653,7 @@ private:
     TActorId Replica;
     const TPath Path;
     const ui64 DomainOwnerId;
+    TClusterState ClusterState;
 
     TActorId ReplicaSubscriber;
     TDuration Delay;
@@ -779,7 +792,7 @@ class TSubscriber: public TMonitorableActor<TDerived> {
         SBS_LOG_D("Handle " << ev->Get()->ToString()
             << ": sender# " << ev->Sender);
 
-        if (!IsValidNotification(Path, ev->Get()->GetRecord(), &ClusterState)) {
+        if (!IsValidNotification(Path, ev->Get()->GetRecord())) {
             SBS_LOG_E("Suspicious " << ev->Get()->ToString()
                 << ": sender# " << ev->Sender);
             return;
@@ -865,8 +878,7 @@ class TSubscriber: public TMonitorableActor<TDerived> {
         Y_ABORT_UNLESS(MaybeRunVersionSync());
     }
 
-    static bool IsSyncFinished(ui32 successes, ui32 failures, ui32 expectedTotal) {
-        const auto half = expectedTotal;
+    static bool IsSyncFinished(ui32 successes, ui32 failures, ui32 expectedTotal, ui32 half) {
         return successes > half || failures > half || successes + failures >= expectedTotal;
     }
 
@@ -933,7 +945,7 @@ class TSubscriber: public TMonitorableActor<TDerived> {
         for (size_t groupIdx : xrange(ProxyGroups.size())) {
             const ui32 size = ProxyGroups[groupIdx].Proxies.size();
             const ui32 half = size / 2;
-            if (!IsSyncFinished(successesByGroup[groupIdx], failuresByGroup[groupIdx], size)) {
+            if (!IsSyncFinished(successesByGroup[groupIdx], failuresByGroup[groupIdx], size, half)) {
                 SBS_LOG_D("Sync is in progress"
                     << ": cookie# " << ev->Cookie
                     << ", ring group# " << groupIdx
@@ -1007,6 +1019,9 @@ class TSubscriber: public TMonitorableActor<TDerived> {
         PendingSync.clear();
         ReceivedSync.clear();
 
+        ClusterState.Generation = ev->Get()->ClusterStateGeneration;
+        ClusterState.Guid = ev->Get()->ClusterStateGuid;
+
         for (size_t groupIdx = 0; groupIdx < replicaGroups.size(); ++groupIdx) {
             const auto& replicaGroup = replicaGroups[groupIdx];
             if (ShouldIgnore(replicaGroup)) {
@@ -1024,15 +1039,13 @@ class TSubscriber: public TMonitorableActor<TDerived> {
                         replicaGroup.Replicas.size(),
                         replicaGroup.Replicas[i],
                         Path,
-                        DomainOwnerId
+                        DomainOwnerId,
+                        ClusterState
                     )
                 );
                 ProxyToGroupMap[proxy.Proxy] = ProxyGroups.size() - 1;
             }
         }
-
-        ClusterState.Generation = ev->Get()->ClusterStateGeneration;
-        ClusterState.Guid = ev->Get()->ClusterStateGuid;
 
         this->Become(&TDerived::StateWork);
     }


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

### Changelog category <!-- remove all except one -->

* Not for changelog (changelog entry is not required)

### Description for reviewers <!-- (optional) description for those who read this PR -->

Epic:
- https://github.com/ydb-platform/ydb/issues/19748

Issue:
- https://github.com/ydb-platform/ydb/issues/23387

Replica notifications with mismatched cluster state were previously ignored. This could prevent the main subscriber from ever reaching the majority of notifications from the replicas, because the notifications are not retried by the replicas. In this initializing state the main subscriber does not process sync requests, so the queries were timing out.
