### PR TITLE
Add WorkingSyncers HTTP monitoring (merge from main #23378)

### DIFF
--- a/ydb/core/blobstorage/nodewarden/node_warden_impl.h
+++ b/ydb/core/blobstorage/nodewarden/node_warden_impl.h
@@ -652,6 +652,11 @@ namespace NKikimr::NStorage {
             TActorId ActorId;
             bool Finished = false;
             std::optional<TString> ErrorReason;
+            ui32 NumStart = 0;
+            ui32 NumStop = 0;
+            ui32 NumFinishOK = 0;
+            ui32 NumFinishError = 0;
+            std::optional<TString> LastErrorReason;
 
             friend std::strong_ordering operator <=>(const TWorkingSyncer& x, const TWorkingSyncer& y) {
                 return std::tie(x.BridgeProxyGroupId, x.SourceGroupId, x.TargetGroupId) <=>

--- a/ydb/core/blobstorage/nodewarden/node_warden_mon.cpp
+++ b/ydb/core/blobstorage/nodewarden/node_warden_mon.cpp
@@ -214,6 +214,43 @@ void TNodeWarden::RenderWholePage(IOutputStream& out) {
             }
         }
 
+        TAG(TH3) { out << "Bridge syncers"; }
+        TABLE_CLASS("table oddgray") {
+            TABLEHEAD() {
+                TABLER() {
+                    TABLEH() { out << "BridgeProxyGroupId"; }
+                    TABLEH() { out << "BridgeProxyGroupGeneration"; }
+                    TABLEH() { out << "SourceGroupId"; }
+                    TABLEH() { out << "TargetGroupId"; }
+                    TABLEH() { out << "ActorId"; }
+                    TABLEH() { out << "Finished"; }
+                    TABLEH() { out << "ErrorReason"; }
+                    TABLEH() { out << "Start/Stop/OK/Error"; }
+                    TABLEH() { out << "LastErrorReason"; }
+                }
+            }
+            TABLEBODY() {
+                for (const auto& syncer : WorkingSyncers) {
+                    out << "<a name='syncer-" << syncer.TargetGroupId << "'>";
+                    TABLER() {
+                        TABLED() { out << syncer.BridgeProxyGroupId; }
+                        TABLED() { out << syncer.BridgeProxyGroupGeneration; }
+                        TABLED() { out << syncer.SourceGroupId; }
+                        TABLED() { out << syncer.TargetGroupId; }
+                        TABLED() { out << syncer.ActorId; }
+                        TABLED() { out << syncer.Finished; }
+                        TABLED() { out << syncer.ErrorReason; }
+                        TABLED() {
+                            out << syncer.NumStart << '/' << syncer.NumStop << '/' << syncer.NumFinishOK << '/'
+                                << syncer.NumFinishError;
+                        }
+                        TABLED() { out << syncer.LastErrorReason; }
+                    }
+                    out << "</a>";
+                }
+            }
+        }
+
         RenderDSProxies(out);
     }
 }

--- a/ydb/core/mind/bscontroller/impl.h
+++ b/ydb/core/mind/bscontroller/impl.h
@@ -1790,6 +1790,7 @@ private:
     void RenderHeader(IOutputStream& out);
     void RenderFooter(IOutputStream& out);
     void RenderMonPage(IOutputStream& out);
+    void RenderBridge(IOutputStream& out);
     void RenderInternalTables(IOutputStream& out, const TString& table);
     void RenderVirtualGroups(IOutputStream& out);
     void RenderGroupDetail(IOutputStream &out, TGroupId groupId);

--- a/ydb/core/mind/bscontroller/monitoring.cpp
+++ b/ydb/core/mind/bscontroller/monitoring.cpp
@@ -962,6 +962,8 @@ bool TBlobStorageController::OnRenderAppHtmlPage(NMon::TEvRemoteHttpInfo::TPtr e
         } else if (page == "InternalTables") {
             const TString table = cgi.Has("table") ? cgi.Get("table") : "pdisks";
             RenderInternalTables(str, table);
+        } else if (page == "Bridge") {
+            RenderBridge(str);
         } else if (page == "VirtualGroups") {
             RenderVirtualGroups(str);
         } else if (page == "StopGivingGroups") {
@@ -1016,6 +1018,7 @@ void TBlobStorageController::RenderMonPage(IOutputStream& out) {
     out << "<a href='app?TabletID=" << TabletID() << "&page=HealthEvents'>Health events</a><br>";
     out << "<a href='app?TabletID=" << TabletID() << "&page=Scrub'>Scrub state</a><br>";
     out << "<a href='app?TabletID=" << TabletID() << "&page=Shred'>Shred state</a><br>";
+    out << "<a href='app?TabletID=" << TabletID() << "&page=Bridge'>Bridge state</a><br>";
     out << "<a href='app?TabletID=" << TabletID() << "&page=VirtualGroups'>Virtual groups</a><br>";
     out << "<a href='app?TabletID=" << TabletID() << "&page=InternalTables'>Internal tables</a><br>";
 


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

Add WorkingSyncers HTTP monitoring

### Changelog category <!-- remove all except one -->

* Not for changelog (changelog entry is not required)

### Description for reviewers <!-- (optional) description for those who read this PR -->

This patch adds base web monitoring for running bridge syncer in NodeWarden and BS controller.
