### PR TITLE
Added local backup support for system views

### DIFF
--- a/ydb/library/backup/db_iterator.h
+++ b/ydb/library/backup/db_iterator.h
@@ -47,6 +47,7 @@ private:
             NScheme::ESchemeEntryType::Topic,
             NScheme::ESchemeEntryType::CoordinationNode,
             NScheme::ESchemeEntryType::Replication,
+            NScheme::ESchemeEntryType::SysView,
         };
 
         return values;
@@ -157,6 +158,10 @@ public:
         return GetCurrentNode()->Type == NScheme::ESchemeEntryType::Directory;
     }
 
+    bool IsSystemDir() const {
+        return NConsoleClient::IsSystemDir(*GetCurrentNode());
+    }
+
     bool IsReplication() const {
         return GetCurrentNode()->Type == NScheme::ESchemeEntryType::Replication;
     }
@@ -169,6 +174,10 @@ public:
         return GetCurrentNode()->Type == NScheme::ESchemeEntryType::ExternalTable;
     }
 
+    bool IsSystemView() const {
+        return GetCurrentNode()->Type == NScheme::ESchemeEntryType::SysView;
+    }
+
     bool IsListed() const {
         return NextNodes.front().IsListed;
     }
@@ -177,8 +186,27 @@ public:
         return bool{NextNodes};
     }
 
-    bool IsSkipped() const {
-        return NConsoleClient::IsSystemObject(*GetCurrentNode());
+    bool IsMaterializedSysDir() {
+        const auto& entry = *GetCurrentNode();
+        if (IsDir() && entry.Name == ".sys") {
+            // TODO(n00bcracker): drop this check after removing EnableRealSystemViewPaths flag
+            const TString& fullPath = GetFullPath();
+            NScheme::TListDirectoryResult listResult = Client.ListDirectory(GetFullPath()).GetValueSync();
+            Y_ENSURE(listResult.IsSuccess(), "Can't list '.sys' directory, maybe it doesn't exist, dbPath# "
+                << fullPath.Quote());
+
+            for (const auto& child : listResult.GetChildren()) {
+                if (child.Type == NScheme::ESchemeEntryType::SysView) {
+                    return true;
+                }
+            }
+        }
+
+        return false;
+    }
+
+    bool IsSkipped() {
+        return IsSystemDir() && !IsMaterializedSysDir();
     }
 
     void Next() {

--- a/ydb/public/lib/ydb_cli/commands/ydb_tools.cpp
+++ b/ydb/public/lib/ydb_cli/commands/ydb_tools.cpp
@@ -154,6 +154,9 @@ void TCommandRestore::Config(TConfig& config) {
     config.Opts->AddLongOption("restore-acl", "Whether to restore ACL and owner or not.")
         .DefaultValue(defaults.RestoreACL_).StoreResult(&RestoreACL);
 
+    config.Opts->AddLongOption("replace-sys-acl", "Whether to restore ACL for system objects or not.")
+        .DefaultValue(defaults.ReplaceSysACL_).StoreResult(&ReplaceSysACL);
+
     config.Opts->AddLongOption("skip-document-tables", "Skip Document API tables.")
         .DefaultValue(defaults.SkipDocumentTables_).StoreResult(&SkipDocumentTables)
         .Hidden(); // Deprecated
@@ -239,6 +242,7 @@ int TCommandRestore::Run(TConfig& config) {
         .RestoreData(RestoreData)
         .RestoreIndexes(RestoreIndexes)
         .RestoreACL(RestoreACL)
+        .ReplaceSysACL(ReplaceSysACL)
         .SkipDocumentTables(SkipDocumentTables)
         .SavePartialResult(SavePartialResult)
         .RowsPerRequest(NYdb::SizeFromString(RowsPerRequest))

--- a/ydb/public/lib/ydb_cli/commands/ydb_tools.h
+++ b/ydb/public/lib/ydb_cli/commands/ydb_tools.h
@@ -59,6 +59,7 @@ private:
     bool RestoreData = true;
     bool RestoreIndexes = true;
     bool RestoreACL = true;
+    bool ReplaceSysACL = true;
     bool SkipDocumentTables = false;
     bool SavePartialResult = false;
     bool Replace = false;

--- a/ydb/public/lib/ydb_cli/common/sys.h
+++ b/ydb/public/lib/ydb_cli/common/sys.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <util/generic/fwd.h>
 namespace NYdb {
 
 inline namespace Dev {
@@ -9,6 +10,10 @@ namespace NScheme {
 }
 
 namespace NConsoleClient {
+
+bool IsSystemName(const TStringBuf name);
+
+bool IsSystemDir(const NScheme::TSchemeEntry& entry);
 
 bool IsSystemObject(const NScheme::TSchemeEntry& entry);
 

--- a/ydb/public/lib/ydb_cli/dump/dump.h
+++ b/ydb/public/lib/ydb_cli/dump/dump.h
@@ -99,6 +99,7 @@ struct TRestoreSettings: public TOperationRequestSettings<TRestoreSettings> {
     FLUENT_SETTING_DEFAULT(bool, RestoreIndexes, true);
     FLUENT_SETTING_DEFAULT(bool, RestoreChangefeeds, true);
     FLUENT_SETTING_DEFAULT(bool, RestoreACL, true);
+    FLUENT_SETTING_DEFAULT(bool, ReplaceSysACL, true);
     FLUENT_SETTING_DEFAULT(bool, SkipDocumentTables, false);
     FLUENT_SETTING_DEFAULT(bool, SavePartialResult, false);
     FLUENT_SETTING_DEFAULT(bool, Replace, false);

--- a/ydb/public/lib/ydb_cli/dump/files/files.cpp
+++ b/ydb/public/lib/ydb_cli/dump/files/files.cpp
@@ -21,6 +21,7 @@ enum EFilesType {
     CREATE_ASYNC_REPLICATION,
     CREATE_EXTERNAL_DATA_SOURCE,
     CREATE_EXTERNAL_TABLE,
+    SYSTEM_VIEW,
 };
 
 static constexpr TFileInfo FILES_INFO[] = {
@@ -42,6 +43,7 @@ static constexpr TFileInfo FILES_INFO[] = {
     {"create_async_replication.sql", "async replication"},
     {"create_external_data_source.sql", "external data source"},
     {"create_external_table.sql", "external table"},
+    {"system_view.pb", "system view"},
 };
 
 const TFileInfo& TableScheme() {
@@ -114,6 +116,10 @@ const TFileInfo& CreateExternalDataSource() {
 
 const TFileInfo& CreateExternalTable() {
     return FILES_INFO[CREATE_EXTERNAL_TABLE];
+}
+
+const TFileInfo& SystemView() {
+    return FILES_INFO[SYSTEM_VIEW];
 }
 
 } // NYdb::NDump::NFiles

--- a/ydb/public/lib/ydb_cli/dump/files/files.h
+++ b/ydb/public/lib/ydb_cli/dump/files/files.h
@@ -25,5 +25,6 @@ const TFileInfo& AlterGroup();
 const TFileInfo& CreateAsyncReplication();
 const TFileInfo& CreateExternalDataSource();
 const TFileInfo& CreateExternalTable();
+const TFileInfo& SystemView();
 
 } // NYdb::NDump:NFiles

--- a/ydb/public/lib/ydb_cli/dump/restore_impl.cpp
+++ b/ydb/public/lib/ydb_cli/dump/restore_impl.cpp
@@ -4,12 +4,14 @@
 
 #include <ydb/public/sdk/cpp/include/ydb-cpp-sdk/client/discovery/discovery.h>
 #include <ydb/public/sdk/cpp/include/ydb-cpp-sdk/client/proto/accessor.h>
+#include <ydb/public/sdk/cpp/include/ydb-cpp-sdk/client/value/value.h>
 #include <ydb/public/api/protos/ydb_cms.pb.h>
 #include <ydb/public/api/protos/ydb_rate_limiter.pb.h>
 #include <ydb/public/api/protos/ydb_table.pb.h>
 #include <ydb/public/lib/ydb_cli/common/recursive_list.h>
 #include <ydb/public/lib/ydb_cli/common/recursive_remove.h>
 #include <ydb/public/lib/ydb_cli/common/retry_func.h>
+#include <ydb/public/lib/ydb_cli/common/sys.h>
 #include <ydb/public/lib/ydb_cli/dump/files/files.h>
 #include <ydb/public/lib/ydb_cli/dump/util/log.h>
 #include <ydb/public/lib/ydb_cli/dump/util/query_utils.h>
@@ -119,8 +121,82 @@ Ydb::Cms::CreateDatabaseRequest ReadDatabaseDescription(const TFsPath& fsDirPath
     return ReadProtoFromFile<Ydb::Cms::CreateDatabaseRequest>(fsDirPath, log, NFiles::Database());
 }
 
+Ydb::Table::DescribeSystemViewResult ReadSystemViewDescription(const TFsPath& fsDirPath, const TLog* log) {
+    return ReadProtoFromFile<Ydb::Table::DescribeSystemViewResult>(fsDirPath, log, NFiles::SystemView());
+}
+
 TTableDescription TableDescriptionFromProto(const Ydb::Table::CreateTableRequest& proto) {
     return TProtoAccessor::FromProto(proto);
+}
+
+TRestoreResult CheckSysViewCompatibility(
+    const Ydb::Table::DescribeSystemViewResult& dumpedProto,
+    const Ydb::Table::DescribeSystemViewResult& actualProto)
+{
+    if (dumpedProto.sys_view_id() != actualProto.sys_view_id()) {
+        return Result<TRestoreResult>(EStatus::SCHEME_ERROR, TStringBuilder()
+            << "System view ID mismatch: dumped=" << dumpedProto.sys_view_id()
+            << ", actual=" << actualProto.sys_view_id());
+    }
+
+    const auto& dumpedColumns = dumpedProto.columns();
+    const auto& actualColumns = actualProto.columns();
+
+    THashMap<TString, const Ydb::Table::ColumnMeta*> actualColumnsMap;
+    for (const auto& col : actualColumns) {
+        actualColumnsMap.emplace(col.name(), &col);
+    }
+
+    for (const auto& dumpedCol : dumpedColumns) {
+        auto it = actualColumnsMap.find(dumpedCol.name());
+        if (it == actualColumnsMap.end()) {
+            return Result<TRestoreResult>(EStatus::SCHEME_ERROR, TStringBuilder()
+                << "Column " << TString(dumpedCol.name()).Quote() << " from dump is missing in actual system view");
+        }
+
+        const auto& actualCol = *it->second;
+
+        TType dumpedType(dumpedCol.type());
+        TType actualType(actualCol.type());
+        if (!TypesEqual(dumpedType, actualType)) {
+            // Add detailed logging for type comparison failures
+            TString dumpedTypeStr = dumpedCol.type().ShortUtf8DebugString();
+            TString actualTypeStr = actualCol.type().ShortUtf8DebugString();
+
+            return Result<TRestoreResult>(EStatus::SCHEME_ERROR, TStringBuilder()
+                << "Column type mismatch for " << TString(dumpedCol.name()).Quote()
+                << ": dumped type: " << dumpedTypeStr
+                << ", actual type: " << actualTypeStr);
+        }
+
+        bool dumpedNotNull = dumpedCol.has_not_null() ? dumpedCol.not_null() : false;
+        bool actualNotNull = actualCol.has_not_null() ? actualCol.not_null() : false;
+        if (dumpedNotNull != actualNotNull) {
+            return Result<TRestoreResult>(EStatus::SCHEME_ERROR, TStringBuilder()
+                << "Column not_null property mismatch for " << TString(dumpedCol.name()).Quote()
+                << ": dumped not_null=" << (dumpedNotNull ? "true" : "false")
+                << ", actual not_null=" << (actualNotNull ? "true" : "false"));
+        }
+    }
+
+    const auto& dumpedPrimaryKeys = dumpedProto.primary_key();
+    const auto& actualPrimaryKeys = actualProto.primary_key();
+    if (dumpedPrimaryKeys.size() > actualPrimaryKeys.size()) {
+        return Result<TRestoreResult>(EStatus::SCHEME_ERROR, TStringBuilder()
+            << "Primary key count mismatch: dumped has more keys (" << dumpedPrimaryKeys.size()
+            << ") than actual (" << actualPrimaryKeys.size() << ")");
+    }
+
+    for (int i = 0; i < dumpedPrimaryKeys.size(); ++i) {
+        if (dumpedPrimaryKeys[i] != actualPrimaryKeys[i]) {
+            return Result<TRestoreResult>(EStatus::SCHEME_ERROR, TStringBuilder()
+                << "Primary key order mismatch at position " << i
+                << ": dumped=" << TString(dumpedPrimaryKeys[i]).Quote()
+                << ", actual=" << TString(actualPrimaryKeys[i]).Quote());
+        }
+    }
+
+    return Result<TRestoreResult>();
 }
 
 TChangefeedDescription ChangefeedDescriptionFromProto(const Ydb::Table::ChangefeedDescription& proto) {
@@ -200,20 +276,6 @@ TMaybe<TRestoreResult> ErrorOnIncomplete(const TFsPath& fsPath) {
         );
     }
     return Nothing();
-}
-
-TRestoreResult CheckExistenceAndType(TSchemeClient& client, const TString& dbPath, ESchemeEntryType expectedType) {
-    auto pathDescription = DescribePath(client, dbPath);
-    if (!pathDescription.IsSuccess()) {
-        return Result<TRestoreResult>(dbPath, std::move(pathDescription));
-    }
-    if (pathDescription.GetEntry().Type != expectedType) {
-        return Result<TRestoreResult>(dbPath, EStatus::SCHEME_ERROR,
-            TStringBuilder() << "Expected a " << expectedType << ", but got: " << pathDescription.GetEntry().Type
-        );
-    }
-
-    return Result<TRestoreResult>();
 }
 
 TStatus CreateTopic(TTopicClient& client, const TString& dbPath, const Ydb::Topic::CreateTopicRequest& request) {
@@ -308,14 +370,12 @@ TDelayedRestoreCall::TDelayedRestoreCall(
     ESchemeEntryType type,
     TFsPath fsPath,
     TString dbPath,
-    TRestoreSettings settings,
-    bool isAlreadyExisting
+    TRestoreSettings settings
 )
     : Type(type)
     , FsPath(fsPath)
     , DbPath(dbPath)
     , Settings(settings)
-    , IsAlreadyExisting(isAlreadyExisting)
 {}
 
 TDelayedRestoreCall::TDelayedRestoreCall(
@@ -323,14 +383,12 @@ TDelayedRestoreCall::TDelayedRestoreCall(
     TFsPath fsPath,
     TString dbRestoreRoot,
     TString dbPathRelativeToRestoreRoot,
-    TRestoreSettings settings,
-    bool isAlreadyExisting
+    TRestoreSettings settings
 )
     : Type(type)
     , FsPath(fsPath)
     , DbPath(TTwoComponentPath(dbRestoreRoot, dbPathRelativeToRestoreRoot))
     , Settings(settings)
-    , IsAlreadyExisting(isAlreadyExisting)
 {}
 
 int TDelayedRestoreCall::GetOrder() const {
@@ -350,15 +408,15 @@ TRestoreResult TDelayedRestoreManager::Restore(const TDelayedRestoreCall& call) 
     switch (call.Type) {
         case ESchemeEntryType::View: {
             const auto& [dbRestoreRoot, dbPathRelativeToRestoreRoot] = std::get<TDelayedRestoreCall::TTwoComponentPath>(call.DbPath);
-            return Client->RestoreView(call.FsPath, dbRestoreRoot, dbPathRelativeToRestoreRoot, call.Settings, call.IsAlreadyExisting);
+            return Client->RestoreView(call.FsPath, dbRestoreRoot, dbPathRelativeToRestoreRoot, call.Settings);
         }
         case ESchemeEntryType::ExternalTable: {
             const auto& dbPath = std::get<TDelayedRestoreCall::TSimplePath>(call.DbPath);
-            return Client->RestoreExternalTable(call.FsPath, dbPath, call.Settings, call.IsAlreadyExisting);
+            return Client->RestoreExternalTable(call.FsPath, dbPath, call.Settings);
         }
         case ESchemeEntryType::Replication: {
             const auto& [dbRestoreRoot, dbPathRelativeToRestoreRoot] = std::get<TDelayedRestoreCall::TTwoComponentPath>(call.DbPath);
-            return Client->RestoreReplication(call.FsPath, dbRestoreRoot, dbPathRelativeToRestoreRoot, call.Settings, call.IsAlreadyExisting);
+            return Client->RestoreReplication(call.FsPath, dbRestoreRoot, dbPathRelativeToRestoreRoot, call.Settings);
         }
         default:
             ythrow TBadArgumentException() << "Attempting to restore an unexpected object from: " << call.FsPath;
@@ -462,23 +520,22 @@ TRestoreResult TRestoreClient::Restore(const TString& fsPath, const TString& dbP
     const TString dbBasePath = dbPathSplit.Reconstruct();
     LOG_D("Resolved db base path: " << dbBasePath.Quote());
 
-    auto oldDirectoryList = RecursiveList(SchemeClient, dbBasePath);
+    auto oldDirectoryList = RecursiveList(SchemeClient, dbBasePath, TRecursiveListSettings().SkipSys(false));
     if (const auto& status = oldDirectoryList.Status; !status.IsSuccess()) {
         LOG_E("Error listing db base path: " << dbBasePath.Quote() << ": " << status.GetIssues().ToOneLineString());
         return Result<TRestoreResult>(dbBasePath, EStatus::SCHEME_ERROR, "Can not list existing directory");
     }
 
-    THashMap<TString, ESchemeEntryType> oldEntries;
     for (const auto& entry : oldDirectoryList.Entries) {
-        oldEntries.emplace(TString{entry.Name}, entry.Type);
+        ExistingEntries.emplace(TString{entry.Name}, entry.Type);
     }
 
     // restore
     auto restoreResult = Result<TRestoreResult>();
     if (settings.Replace_) {
-        restoreResult = DropAndRestore(fsPath, dbPath, settings, oldEntries);
+        restoreResult = DropAndRestore(fsPath, dbPath, settings);
     } else {
-        restoreResult = RestoreFolder(fsPath, dbPath, settings, oldEntries);
+        restoreResult = RestoreFolder(fsPath, dbPath, settings);
     }
     if (auto result = DelayedRestoreManager.RestoreDelayed(); !result.IsSuccess()) {
         restoreResult = result;
@@ -497,7 +554,7 @@ TRestoreResult TRestoreClient::Restore(const TString& fsPath, const TString& dbP
 
     LOG_I("Cleanup");
 
-    auto newListing = RecursiveList(SchemeClient, dbBasePath);
+    auto newListing = RecursiveList(SchemeClient, dbBasePath, TRecursiveListSettings().SkipSys(false));
     if (!newListing.Status.IsSuccess()) {
         return restoreResult;
     }
@@ -505,8 +562,8 @@ TRestoreResult TRestoreClient::Restore(const TString& fsPath, const TString& dbP
     // Why don't we use the built-in RecursiveList filter?
     // TSchemeEntry::Name is rewritten in the RecursiveList to become the full path to the object.
     // Until it is rewritten, we can only use the entry name to filter it out, which is not enough.
-    std::erase_if(newListing.Entries, [&oldEntries](const TSchemeEntry& entry) {
-        return oldEntries.contains(entry.Name);
+    std::erase_if(newListing.Entries, [&](const TSchemeEntry& entry) {
+        return ExistingEntries.contains(entry.Name);
     });
 
     // Why do we reverse the list?
@@ -809,7 +866,8 @@ TRestoreResult TRestoreClient::RestoreDatabaseImpl(const TString& fsPath, const 
     }
 
     if (settings.WithContent_) {
-        auto restoreResult = RestoreFolder(fsPath, dbPath, {}, { { dbPath, ESchemeEntryType::SubDomain } });
+        ExistingEntries.emplace(dbPath, ESchemeEntryType::SubDomain);
+        auto restoreResult = RestoreFolder(fsPath, dbPath, {});
         if (auto result = DelayedRestoreManager.RestoreDelayed(); !result.IsSuccess()) {
             restoreResult = result;
         }
@@ -932,6 +990,10 @@ namespace {
 
         if (IsFileExists(path.Child(NFiles::CreateExternalTable().FileName))) {
             types.emplace_back(ESchemeEntryType::ExternalTable);
+        }
+
+        if (IsFileExists(path.Child(NFiles::SystemView().FileName))) {
+            types.emplace_back(ESchemeEntryType::SysView);
         }
 
         if (IsFileExists(path.Child(NFiles::Empty().FileName))) {
@@ -1057,8 +1119,7 @@ namespace {
 TRestoreResult TRestoreClient::RestoreFolder(
         const TFsPath& fsBackupRoot,
         const TString& dbRestoreRoot,
-        const TRestoreSettings& settings,
-        const THashMap<TString, ESchemeEntryType>& oldEntries)
+        const TRestoreSettings& settings)
 {
     TVector<TFsBackupEntry> backupEntries;
     if (auto result = ListBackupEntries(fsBackupRoot, dbRestoreRoot, backupEntries); !result.IsSuccess()) {
@@ -1071,14 +1132,11 @@ TRestoreResult TRestoreClient::RestoreFolder(
     LOG_D("List of entries in the backup: " << NJson::WriteJson(ConvertToJson(backupEntries), false));
 
     for (const auto& [fsPath, dbPath, type] : backupEntries) {
-        if (type == ESchemeEntryType::Directory && oldEntries.contains(dbPath)) {
-            continue;
-        }
         Y_ENSURE(dbPath.StartsWith(dbRestoreRoot),
             "Implementation error, dbPath: " << dbPath.Quote()
                 << " must be built by appending a relative path to dbRestoreRoot: " << dbRestoreRoot.Quote()
         );
-        if (auto result = Restore(type, fsPath, dbRestoreRoot, dbPath.substr(dbRestoreRoot.size()), settings, oldEntries.contains(dbPath), true); !result.IsSuccess()) {
+        if (auto result = Restore(type, fsPath, dbRestoreRoot, dbPath.substr(dbRestoreRoot.size()), settings, true); !result.IsSuccess()) {
             return result;
         }
     }
@@ -1100,53 +1158,56 @@ TRestoreResult TRestoreClient::Drop(ESchemeEntryType type, const TString& path, 
 
     if (result.IsSuccess()) {
         LOG_D("Dropped " << path.Quote());
+        ExistingEntries.erase(path);
         return Result<TRestoreResult>();
     }
     LOG_E("Failed to drop " << path.Quote());
     return Result<TRestoreResult>(path, std::move(result));
 }
 
-TRestoreResult TRestoreClient::Restore(NScheme::ESchemeEntryType type, const TFsPath& fsPath, const TString& dbRestoreRoot, const TString& dbPathRelativeToRestoreRoot, const TRestoreSettings& settings, bool isAlreadyExisting, bool delay) {
+TRestoreResult TRestoreClient::Restore(NScheme::ESchemeEntryType type, const TFsPath& fsPath, const TString& dbRestoreRoot, const TString& dbPathRelativeToRestoreRoot, const TRestoreSettings& settings, bool delay) {
     const auto dbPath = dbRestoreRoot + dbPathRelativeToRestoreRoot;
     switch (type) {
         case ESchemeEntryType::Directory:
-            return RestoreEmptyDir(fsPath, dbPath, settings, isAlreadyExisting);
+            return RestoreDir(fsPath, dbPath, settings);
         case ESchemeEntryType::Table:
-            return RestoreTable(fsPath, dbPath, settings, isAlreadyExisting);
+            return RestoreTable(fsPath, dbPath, settings);
         case ESchemeEntryType::Topic:
-            return RestoreTopic(fsPath, dbPath, settings, isAlreadyExisting);
+            return RestoreTopic(fsPath, dbPath, settings);
         case ESchemeEntryType::View:
             if (delay) {
-                DelayedRestoreManager.Add(ESchemeEntryType::View, fsPath, dbRestoreRoot, dbPathRelativeToRestoreRoot, settings, isAlreadyExisting);
+                DelayedRestoreManager.Add(ESchemeEntryType::View, fsPath, dbRestoreRoot, dbPathRelativeToRestoreRoot, settings);
                 return Result<TRestoreResult>();
             }
-            return RestoreView(fsPath, dbRestoreRoot, dbPathRelativeToRestoreRoot, settings, isAlreadyExisting);
+            return RestoreView(fsPath, dbRestoreRoot, dbPathRelativeToRestoreRoot, settings);
         case ESchemeEntryType::CoordinationNode:
-            return RestoreCoordinationNode(fsPath, dbPath, settings, isAlreadyExisting);
+            return RestoreCoordinationNode(fsPath, dbPath, settings);
         case ESchemeEntryType::ExternalTable:
             if (delay) {
-                DelayedRestoreManager.Add(ESchemeEntryType::ExternalTable, fsPath, dbPath, settings, isAlreadyExisting);
+                DelayedRestoreManager.Add(ESchemeEntryType::ExternalTable, fsPath, dbPath, settings);
                 return Result<TRestoreResult>();
             }
-            return RestoreExternalTable(fsPath, dbPath, settings, isAlreadyExisting);
+            return RestoreExternalTable(fsPath, dbPath, settings);
         case ESchemeEntryType::ExternalDataSource:
-            return RestoreExternalDataSource(fsPath, dbPath, settings, isAlreadyExisting);
+            return RestoreExternalDataSource(fsPath, dbPath, settings);
         case ESchemeEntryType::Replication:
             if (delay) {
-                DelayedRestoreManager.Add(ESchemeEntryType::Replication, fsPath, dbRestoreRoot, dbPathRelativeToRestoreRoot, settings, isAlreadyExisting);
+                DelayedRestoreManager.Add(ESchemeEntryType::Replication, fsPath, dbRestoreRoot, dbPathRelativeToRestoreRoot, settings);
                 return Result<TRestoreResult>();
             }
-            return RestoreReplication(fsPath, dbRestoreRoot, dbPathRelativeToRestoreRoot, settings, isAlreadyExisting);
+            return RestoreReplication(fsPath, dbRestoreRoot, dbPathRelativeToRestoreRoot, settings);
+        case ESchemeEntryType::SysView:
+            return RestoreSysView(fsPath, dbPath, settings);
         default:
             ythrow TBadArgumentException() << "Attempting to restore an unexpected object from: " << fsPath << ", type: " << type;
     }
 
 }
 
-TRestoreResult TRestoreClient::DropAndRestoreExternals(const TVector<TFsBackupEntry>& backupEntries, const TVector<size_t>& externalDataSources, const THashMap<TString, size_t>& externalTables, const TRestoreSettings& settings, const THashMap<TString, ESchemeEntryType>& existingEntries) {
+TRestoreResult TRestoreClient::DropAndRestoreExternals(const TVector<TFsBackupEntry>& backupEntries, const TVector<size_t>& externalDataSources, const THashMap<TString, size_t>& externalTables, const TRestoreSettings& settings) {
     for (size_t i : externalDataSources) {
         const auto& [fsPath, dbPath, type] = backupEntries[i];
-        if (!existingEntries.contains(dbPath)) {
+        if (!ExistingEntries.contains(dbPath)) {
             continue;
         }
         TVector<TString> references;
@@ -1163,27 +1224,26 @@ TRestoreResult TRestoreClient::DropAndRestoreExternals(const TVector<TFsBackupEn
     }
 
     for (const auto& [dbPath, i] : externalTables) {
-        if (existingEntries.contains(dbPath)) {
-            auto result = Drop(ESchemeEntryType::ExternalTable, dbPath, settings);
-            if (!result.IsSuccess()) {
+        if (ExistingEntries.contains(dbPath)) {
+            if (auto result = Drop(ESchemeEntryType::ExternalTable, dbPath, settings); !result.IsSuccess()) {
                 return result;
             }
         }
     }
     for (size_t i : externalDataSources) {
         const auto& [fsPath, dbPath, type] = backupEntries[i];
-        if (existingEntries.contains(dbPath)) {
+        if (ExistingEntries.contains(dbPath)) {
             if (auto result = Drop(type, dbPath, settings); !result.IsSuccess()) {
                 return result;
             }
         }
-        if (auto result = RestoreExternalDataSource(fsPath, dbPath, settings, false); !result.IsSuccess()) {
+        if (auto result = RestoreExternalDataSource(fsPath, dbPath, settings); !result.IsSuccess()) {
             return result;
         }
     }
     for (const auto& [dbPath, i] : externalTables) {
         const auto& fsPath = backupEntries[i].FsPath;
-        auto result = RestoreExternalTable(fsPath, dbPath, settings, false /* already exists */);
+        auto result = RestoreExternalTable(fsPath, dbPath, settings);
         if (!result.IsSuccess()) {
             return result;
         }
@@ -1192,9 +1252,9 @@ TRestoreResult TRestoreClient::DropAndRestoreExternals(const TVector<TFsBackupEn
     return Result<TRestoreResult>();
 }
 
-TRestoreResult TRestoreClient::DropAndRestoreTablesAndDependents(const TVector<TFsBackupEntry>& backupEntries, const THashMap<TString, size_t>& tables, const TVector<size_t>& views, const THashMap<TString, size_t>& replications, const TString& dbRestoreRoot, const TRestoreSettings& settings, const THashMap<TString, ESchemeEntryType>& existingEntries) {
+TRestoreResult TRestoreClient::DropAndRestoreTablesAndDependents(const TVector<TFsBackupEntry>& backupEntries, const THashMap<TString, size_t>& tables, const TVector<size_t>& views, const THashMap<TString, size_t>& replications, const TString& dbRestoreRoot, const TRestoreSettings& settings) {
     // to do: verify that no replication in the entire database (not just the restore root!) depends on the tables we are going to drop
-    for (const auto& [dbPath, type] : existingEntries) {
+    for (const auto& [dbPath, type] : ExistingEntries) {
         if (type == ESchemeEntryType::Replication && !replications.contains(dbPath)) {
             // a replication that is not present in the backup, but present in the database
             TVector<TString> sources;
@@ -1213,7 +1273,7 @@ TRestoreResult TRestoreClient::DropAndRestoreTablesAndDependents(const TVector<T
 
     for (size_t i : views) {
         const auto& [fsPath, dbPath, type] = backupEntries[i];
-        if (existingEntries.contains(dbPath)) {
+        if (ExistingEntries.contains(dbPath)) {
             if (auto result = Drop(type, dbPath, settings); !result.IsSuccess()) {
                 return result;
             }
@@ -1221,7 +1281,7 @@ TRestoreResult TRestoreClient::DropAndRestoreTablesAndDependents(const TVector<T
     }
 
     for (const auto& [dbPath, i] : replications) {
-        if (existingEntries.contains(dbPath)) {
+        if (ExistingEntries.contains(dbPath)) {
             if (auto result = Drop(ESchemeEntryType::Replication, dbPath, settings); !result.IsSuccess()) {
                 return result;
             }
@@ -1231,19 +1291,19 @@ TRestoreResult TRestoreClient::DropAndRestoreTablesAndDependents(const TVector<T
     // the main loop: tables are restored here
     for (const auto& [_, i] : tables) {
         const auto& [fsPath, dbPath, type] = backupEntries[i];
-        if (existingEntries.contains(dbPath)) {
+        if (ExistingEntries.contains(dbPath)) {
             if (auto result = Drop(type, dbPath, settings); !result.IsSuccess()) {
                 return result;
             }
         }
-        if (auto result = RestoreTable(fsPath, dbPath, settings, false); !result.IsSuccess()) {
+        if (auto result = RestoreTable(fsPath, dbPath, settings); !result.IsSuccess()) {
             return result;
         }
     }
 
     for (const auto& [dbPath, i] : replications) {
         const auto& fsPath = backupEntries[i].FsPath;
-        if (auto result = RestoreReplication(fsPath, dbRestoreRoot, dbPath.substr(dbRestoreRoot.size()), settings, false); !result.IsSuccess()) {
+        if (auto result = RestoreReplication(fsPath, dbRestoreRoot, dbPath.substr(dbRestoreRoot.size()), settings); !result.IsSuccess()) {
             return result;
         }
     }
@@ -1252,13 +1312,13 @@ TRestoreResult TRestoreClient::DropAndRestoreTablesAndDependents(const TVector<T
         const auto& [fsPath, dbPath, type] = backupEntries[i];
         Y_ENSURE(dbPath.StartsWith(dbRestoreRoot), "dbPath must be built by appending a relative path to dbRestoreRoot");
         // views might depend on other views, so we restore them with the help of a dedicated manager
-        DelayedRestoreManager.Add(type, fsPath, dbRestoreRoot, dbPath.substr(dbRestoreRoot.size()), settings, false);
+        DelayedRestoreManager.Add(type, fsPath, dbRestoreRoot, dbPath.substr(dbRestoreRoot.size()), settings);
     }
 
     return Result<TRestoreResult>();
 }
 
-TRestoreResult TRestoreClient::DropAndRestore(const TFsPath& fsBackupRoot, const TString& dbRestoreRoot, const TRestoreSettings& settings, const THashMap<TString, ESchemeEntryType>& existingEntries) {
+TRestoreResult TRestoreClient::DropAndRestore(const TFsPath& fsBackupRoot, const TString& dbRestoreRoot, const TRestoreSettings& settings) {
     TVector<TFsBackupEntry> backupEntries;
     if (auto result = ListBackupEntries(fsBackupRoot, dbRestoreRoot, backupEntries); !result.IsSuccess()) {
         return result;
@@ -1266,7 +1326,7 @@ TRestoreResult TRestoreClient::DropAndRestore(const TFsPath& fsBackupRoot, const
     LOG_D("List of entries in the backup: " << NJson::WriteJson(ConvertToJson(backupEntries), false));
 
     for (const auto& [fsPath, dbPath, type] : backupEntries) {
-        const auto* existingType = existingEntries.FindPtr(dbPath);
+        const auto* existingType = ExistingEntries.FindPtr(dbPath);
 
         // verify that types are matching
         if (existingType && !TypesAreMatching(*existingType, type)) {
@@ -1287,6 +1347,7 @@ TRestoreResult TRestoreClient::DropAndRestore(const TFsPath& fsBackupRoot, const
     TVector<size_t> directories;
     THashMap<TString, size_t> tables;
     TVector<size_t> views;
+    TVector<size_t> systemViews;
     THashMap<TString, size_t> replications;
     TVector<size_t> externalDataSources;
     THashMap<TString, size_t> externalTables;
@@ -1315,6 +1376,9 @@ TRestoreResult TRestoreClient::DropAndRestore(const TFsPath& fsBackupRoot, const
             case ESchemeEntryType::View:
                 views.emplace_back(i);
                 break;
+            case ESchemeEntryType::SysView:
+                systemViews.emplace_back(i);
+                break;
             default:
                 regular.emplace_back(i);
                 break;
@@ -1323,29 +1387,34 @@ TRestoreResult TRestoreClient::DropAndRestore(const TFsPath& fsBackupRoot, const
 
     for (size_t i : directories) {
         const auto& [fsPath, dbPath, type] = backupEntries[i];
-        if (!existingEntries.contains(dbPath)) {
-            if (auto result = RestoreEmptyDir(fsPath, dbPath, settings, false); !result.IsSuccess()) {
-                return result;
-            }
+        if (auto result = RestoreDir(fsPath, dbPath, settings); !result.IsSuccess()) {
+            return result;
         }
     }
 
-    if (auto result = DropAndRestoreExternals(backupEntries, externalDataSources, externalTables, settings, existingEntries); !result.IsSuccess()) {
+    for (size_t i : systemViews) {
+        const auto& [fsPath, dbPath, type] = backupEntries[i];
+        if (auto result = RestoreSysView(fsPath, dbPath, settings); !result.IsSuccess()) {
+            return result;
+        }
+    }
+
+    if (auto result = DropAndRestoreExternals(backupEntries, externalDataSources, externalTables, settings); !result.IsSuccess()) {
         return result;
     }
-    if (auto result = DropAndRestoreTablesAndDependents(backupEntries, tables, views, replications, dbRestoreRoot, settings, existingEntries); !result.IsSuccess()) {
+    if (auto result = DropAndRestoreTablesAndDependents(backupEntries, tables, views, replications, dbRestoreRoot, settings); !result.IsSuccess()) {
         return result;
     }
 
     for (size_t i : regular) {
         const auto& [fsPath, dbPath, type] = backupEntries[i];
-        if (existingEntries.contains(dbPath)) {
+        if (ExistingEntries.contains(dbPath)) {
             if (auto result = Drop(type, dbPath, settings); !result.IsSuccess()) {
                 return result;
             }
         }
         Y_ENSURE(dbPath.StartsWith(dbRestoreRoot), "dbPath must be built by appending a relative path to dbRestoreRoot");
-        if (auto result = Restore(type, fsPath, dbRestoreRoot, dbPath.substr(dbRestoreRoot.size()), settings, false, false); !result.IsSuccess()) {
+        if (auto result = Restore(type, fsPath, dbRestoreRoot, dbPath.substr(dbRestoreRoot.size()), settings, false); !result.IsSuccess()) {
             return result;
         }
     }
@@ -1357,8 +1426,7 @@ TRestoreResult TRestoreClient::RestoreView(
     const TFsPath& fsPath,
     const TString& dbRestoreRoot,
     const TString& dbPathRelativeToRestoreRoot,
-    const TRestoreSettings& settings,
-    bool isAlreadyExisting)
+    const TRestoreSettings& settings)
 {
     LOG_D("Process " << fsPath.GetPath().Quote());
 
@@ -1366,7 +1434,7 @@ TRestoreResult TRestoreClient::RestoreView(
     LOG_I("Restore view " << fsPath.GetPath().Quote() << " to " << dbPath.Quote());
 
     if (settings.DryRun_) {
-        return CheckExistenceAndType(SchemeClient, dbPath, ESchemeEntryType::View);
+        return CheckExistenceAndType(dbPath, ESchemeEntryType::View);
     }
 
     TString query = ReadViewQuery(fsPath, Log.get());
@@ -1383,7 +1451,7 @@ TRestoreResult TRestoreClient::RestoreView(
 
     if (result.IsSuccess()) {
         LOG_D("Created " << dbPath.Quote());
-        return RestorePermissions(fsPath, dbPath, settings, isAlreadyExisting);
+        return RestorePermissions(fsPath, dbPath, settings, ExistingEntries.contains(dbPath), false);
     }
 
     if (result.GetStatus() == EStatus::SCHEME_ERROR) {
@@ -1398,22 +1466,21 @@ TRestoreResult TRestoreClient::RestoreView(
 TRestoreResult TRestoreClient::RestoreTopic(
     const TFsPath& fsPath,
     const TString& dbPath,
-    const TRestoreSettings& settings,
-    bool isAlreadyExisting)
+    const TRestoreSettings& settings)
 {
     LOG_D("Process " << fsPath.GetPath().Quote());
 
     LOG_I("Restore topic " << fsPath.GetPath().Quote() << " to " << dbPath.Quote());
 
     if (settings.DryRun_) {
-        return CheckExistenceAndType(SchemeClient, dbPath, ESchemeEntryType::Topic);
+        return CheckExistenceAndType(dbPath, ESchemeEntryType::Topic);
     }
 
     const auto request = ReadTopicCreationRequest(fsPath, Log.get());
     auto result = CreateTopic(TopicClient, dbPath, request);
     if (result.IsSuccess()) {
         LOG_D("Created " << dbPath.Quote());
-        return RestorePermissions(fsPath, dbPath, settings, isAlreadyExisting);
+        return RestorePermissions(fsPath, dbPath, settings, ExistingEntries.contains(dbPath), false);
     }
 
     LOG_E("Failed to create " << dbPath.Quote());
@@ -1450,8 +1517,7 @@ TRestoreResult TRestoreClient::RestoreReplication(
     const TFsPath& fsPath,
     const TString& dbRestoreRoot,
     const TString& dbPathRelativeToRestoreRoot,
-    const TRestoreSettings& settings,
-    bool isAlreadyExisting)
+    const TRestoreSettings& settings)
 {
     LOG_D("Process " << fsPath.GetPath().Quote());
 
@@ -1459,7 +1525,7 @@ TRestoreResult TRestoreClient::RestoreReplication(
     LOG_I("Restore async replication " << fsPath.GetPath().Quote() << " to " << dbPath.Quote());
 
     if (settings.DryRun_) {
-        return CheckExistenceAndType(SchemeClient, dbPath, ESchemeEntryType::Replication);
+        return CheckExistenceAndType(dbPath, ESchemeEntryType::Replication);
     }
 
     auto query = ReadAsyncReplicationQuery(fsPath, Log.get());
@@ -1483,7 +1549,7 @@ TRestoreResult TRestoreClient::RestoreReplication(
 
     if (result.IsSuccess()) {
         LOG_D("Created " << dbPath.Quote());
-        return RestorePermissions(fsPath, dbPath, settings, isAlreadyExisting);
+        return RestorePermissions(fsPath, dbPath, settings, ExistingEntries.contains(dbPath), false);
     }
 
     LOG_E("Failed to create " << dbPath.Quote());
@@ -1549,15 +1615,14 @@ TRestoreResult TRestoreClient::RestoreDependentResources(const TFsPath& fsPath, 
 TRestoreResult TRestoreClient::RestoreCoordinationNode(
     const TFsPath& fsPath,
     const TString& dbPath,
-    const TRestoreSettings& settings,
-    bool isAlreadyExisting)
+    const TRestoreSettings& settings)
 {
     LOG_D("Process " << fsPath.GetPath().Quote());
 
     LOG_I("Restore coordination node " << fsPath.GetPath().Quote() << " to " << dbPath.Quote());
 
     if (settings.DryRun_) {
-        return CheckExistenceAndType(SchemeClient, dbPath, ESchemeEntryType::CoordinationNode);
+        return CheckExistenceAndType(dbPath, ESchemeEntryType::CoordinationNode);
     }
 
     const auto request = ReadCoordinationNodeCreationRequest(fsPath, Log.get());
@@ -1569,7 +1634,7 @@ TRestoreResult TRestoreClient::RestoreCoordinationNode(
         }
 
         LOG_D("Created " << dbPath.Quote());
-        return RestorePermissions(fsPath, dbPath, settings, isAlreadyExisting);
+        return RestorePermissions(fsPath, dbPath, settings, ExistingEntries.contains(dbPath), false);
     }
 
     LOG_E("Failed to create " << dbPath.Quote());
@@ -1579,15 +1644,14 @@ TRestoreResult TRestoreClient::RestoreCoordinationNode(
 TRestoreResult TRestoreClient::RestoreExternalDataSource(
     const TFsPath& fsPath,
     const TString& dbPath,
-    const TRestoreSettings& settings,
-    bool isAlreadyExisting)
+    const TRestoreSettings& settings)
 {
     LOG_D("Process " << fsPath.GetPath().Quote());
 
     LOG_I("Restore external data source " << fsPath.GetPath().Quote() << " to " << dbPath.Quote());
 
     if (settings.DryRun_) {
-        return CheckExistenceAndType(SchemeClient, dbPath, ESchemeEntryType::ExternalDataSource);
+        return CheckExistenceAndType(dbPath, ESchemeEntryType::ExternalDataSource);
     }
 
     TString query = ReadExternalDataSourceQuery(fsPath, Log.get());
@@ -1608,7 +1672,7 @@ TRestoreResult TRestoreClient::RestoreExternalDataSource(
 
     if (result.IsSuccess()) {
         LOG_D("Created " << dbPath.Quote());
-        return RestorePermissions(fsPath, dbPath, settings, isAlreadyExisting);
+        return RestorePermissions(fsPath, dbPath, settings, ExistingEntries.contains(dbPath), false);
     }
 
     LOG_E("Failed to create " << dbPath.Quote());
@@ -1618,15 +1682,14 @@ TRestoreResult TRestoreClient::RestoreExternalDataSource(
 TRestoreResult TRestoreClient::RestoreExternalTable(
     const TFsPath& fsPath,
     const TString& dbPath,
-    const TRestoreSettings& settings,
-    bool isAlreadyExisting)
+    const TRestoreSettings& settings)
 {
     LOG_D("Process " << fsPath.GetPath().Quote());
 
     LOG_I("Restore external table " << fsPath.GetPath().Quote() << " to " << dbPath.Quote());
 
     if (settings.DryRun_) {
-        return CheckExistenceAndType(SchemeClient, dbPath, ESchemeEntryType::ExternalTable);
+        return CheckExistenceAndType(dbPath, ESchemeEntryType::ExternalTable);
     }
 
     TString query = ReadExternalTableQuery(fsPath, Log.get());
@@ -1642,18 +1705,61 @@ TRestoreResult TRestoreClient::RestoreExternalTable(
 
     if (result.IsSuccess()) {
         LOG_D("Created " << dbPath.Quote());
-        return RestorePermissions(fsPath, dbPath, settings, isAlreadyExisting);
+        return RestorePermissions(fsPath, dbPath, settings, ExistingEntries.contains(dbPath), false);
     }
 
     LOG_E("Failed to create " << dbPath.Quote());
     return Result<TRestoreResult>(dbPath, std::move(result));
 }
 
+TRestoreResult TRestoreClient::RestoreSysView(
+    const TFsPath& fsPath,
+    const TString& dbPath,
+    const TRestoreSettings& settings)
+{
+    LOG_D("Process " << fsPath.GetPath().Quote());
+
+    LOG_I("Restore system view " << fsPath.GetPath().Quote() << " to " << dbPath.Quote());
+
+    auto existenceResult = CheckExistenceAndType(dbPath, ESchemeEntryType::SysView);
+
+    if (settings.DryRun_) {
+        if (!existenceResult.IsSuccess()) {
+            return existenceResult;
+        }
+
+        auto dumpedProto = ReadSystemViewDescription(fsPath, Log.get());
+
+        Ydb::Table::DescribeSystemViewResult actualProto;
+        auto describeStatus = DescribeSystemView(TableClient, dbPath, actualProto);
+        if (!describeStatus.IsSuccess()) {
+            LOG_E("Failed to describe system view " << dbPath.Quote());
+            return Result<TRestoreResult>(dbPath, std::move(describeStatus));
+        }
+
+        auto compatibilityStatus = CheckSysViewCompatibility(dumpedProto, actualProto);
+        if (!compatibilityStatus.IsSuccess()) {
+            LOG_E("System view compatibility check failed for " << dbPath.Quote()
+                  << ": " << compatibilityStatus.GetIssues().ToOneLineString());
+            return Result<TRestoreResult>(dbPath, std::move(compatibilityStatus));
+        }
+
+        LOG_D("System view " << dbPath.Quote() << " is compatible");
+        return Result<TRestoreResult>();
+    }
+
+    if (!existenceResult.IsSuccess()) {
+        LOG_D("System view " << dbPath.Quote() << " does not exist, skipping");
+        return Result<TRestoreResult>();
+    }
+
+    return RestorePermissions(fsPath, dbPath, settings, true, true);
+}
+
 TRestoreResult TRestoreClient::RestoreTable(
         const TFsPath& fsPath,
         const TString& dbPath,
-        const TRestoreSettings& settings,
-        bool isAlreadyExisting)
+        const TRestoreSettings& settings)
 {
     LOG_D("Process " << fsPath.GetPath().Quote());
 
@@ -1718,7 +1824,24 @@ TRestoreResult TRestoreClient::RestoreTable(
         LOG_D("Skip restoring changefeeds of " << dbPath.Quote());
     }
 
-    return RestorePermissions(fsPath, dbPath, settings, isAlreadyExisting);
+    return RestorePermissions(fsPath, dbPath, settings, ExistingEntries.contains(dbPath), false);
+}
+
+TRestoreResult TRestoreClient::CheckExistenceAndType(const TString& dbPath, ESchemeEntryType expectedType) const {
+    const auto entry = ExistingEntries.find(dbPath);
+    if (entry == ExistingEntries.end()) {
+        return Result<TRestoreResult>(dbPath, EStatus::SCHEME_ERROR, "Entry doesn't exist");
+    }
+
+    const auto& [path, type] = *entry;
+
+    if (!TypesAreMatching(type, expectedType)) {
+        return Result<TRestoreResult>(dbPath, EStatus::SCHEME_ERROR,
+            TStringBuilder() << "Expected a " << expectedType << ", but got: " << type
+        );
+    }
+
+    return Result<TRestoreResult>();
 }
 
 TRestoreResult TRestoreClient::CheckSchema(const TString& dbPath, const TTableDescription& desc) {
@@ -2063,6 +2186,7 @@ TRestoreResult TRestoreClient::RestorePermissionsImpl(
     LOG_D("Restore ACL " << fsPath.GetPath().Quote() << " to " << dbPath.Quote());
 
     auto permissions = ReadPermissions(fsPath, Log.get());
+    permissions.set_clear_permissions(true);
     auto result = ModifyPermissions(client, dbPath, TModifyPermissionsSettings(permissions));
 
     if (result.GetStatus() == EStatus::UNAUTHORIZED) {
@@ -2077,35 +2201,53 @@ TRestoreResult TRestoreClient::RestorePermissions(
         const TFsPath& fsPath,
         const TString& dbPath,
         const TRestoreSettings& settings,
-        bool isAlreadyExisting)
+        bool isAlreadyExisting,
+        bool isSystemObject)
 {
-    if (!settings.RestoreACL_) {
-        return Result<TRestoreResult>();
-    }
-
-    if (isAlreadyExisting) {
-        return Result<TRestoreResult>();
+    if (isSystemObject) {
+        if (!isAlreadyExisting || !settings.ReplaceSysACL_) {
+            return Result<TRestoreResult>();
+        }
+    } else {
+        if (isAlreadyExisting || !settings.RestoreACL_) {
+            return Result<TRestoreResult>();
+        }
     }
 
     return RestorePermissionsImpl(SchemeClient, fsPath, dbPath);
 }
 
-TRestoreResult TRestoreClient::RestoreEmptyDir(
+TRestoreResult TRestoreClient::RestoreDir(
         const TFsPath& fsPath,
         const TString& dbPath,
-        const TRestoreSettings& settings,
-        bool isAlreadyExisting)
+        const TRestoreSettings& settings)
 {
     LOG_D("Process " << fsPath.GetPath().Quote());
 
-    LOG_I("Restore empty directory " << fsPath.GetPath().Quote() << " to " << dbPath.Quote());
+    LOG_I("Restore directory " << fsPath.GetPath().Quote() << " to " << dbPath.Quote());
 
-    auto result = MakeDirectory(SchemeClient, dbPath);
-    if (!result.IsSuccess()) {
-        return result;
+    if (settings.DryRun_) {
+        return CheckExistenceAndType(dbPath, ESchemeEntryType::Directory);
     }
 
-    return RestorePermissions(fsPath, dbPath, settings, isAlreadyExisting);
+    TPathSplitUnix dbPathSplit(dbPath);
+    if (IsSystemName(dbPathSplit.back())) {
+        if (auto result = CheckExistenceAndType(dbPath, ESchemeEntryType::Directory); !result.IsSuccess()) {
+            LOG_D("System dir " << dbPath.Quote() << " does not exist, skipping");
+            return Result<TRestoreResult>();
+        }
+
+        return RestorePermissions(fsPath, dbPath, settings, true, true);
+    } else {
+        bool isAlreadyExisting = ExistingEntries.contains(dbPath);
+        if (!isAlreadyExisting) {
+            if (auto result = MakeDirectory(SchemeClient, dbPath); !result.IsSuccess()) {
+                return result;
+            }
+        }
+
+        return RestorePermissions(fsPath, dbPath, settings, isAlreadyExisting, false);
+    }
 }
 
 } // NYdb::NDump
@@ -2113,3 +2255,5 @@ TRestoreResult TRestoreClient::RestoreEmptyDir(
 Y_DECLARE_OUT_SPEC(, NYdb::NDump::NPrivate::TLocation, o, x) {
     return x.Out(o);
 }
+
+

--- a/ydb/public/lib/ydb_cli/dump/restore_impl.h
+++ b/ydb/public/lib/ydb_cli/dump/restore_impl.h
@@ -138,14 +138,12 @@ struct TDelayedRestoreCall {
     TFsPath FsPath;
     std::variant<TSimplePath, TTwoComponentPath> DbPath;
     TRestoreSettings Settings;
-    bool IsAlreadyExisting;
 
     TDelayedRestoreCall(
         NScheme::ESchemeEntryType type,
         TFsPath fsPath,
         TString dbPath,
-        TRestoreSettings settings,
-        bool isAlreadyExisting
+        TRestoreSettings settings
     );
 
     TDelayedRestoreCall(
@@ -153,8 +151,7 @@ struct TDelayedRestoreCall {
         TFsPath fsPath,
         TString dbRestoreRoot,
         TString dbPathRelativeToRestoreRoot,
-        TRestoreSettings settings,
-        bool isAlreadyExisting
+        TRestoreSettings settings
     );
 
     int GetOrder() const;
@@ -194,23 +191,25 @@ struct TFsBackupEntry {
 } // NPrivate
 
 class TRestoreClient {
-    TRestoreResult RestoreFolder(const TFsPath& fsBackupRoot, const TString& dbRestoreRoot, const TRestoreSettings& settings, const THashMap<TString, NScheme::ESchemeEntryType>& oldEntries);
-    TRestoreResult RestoreEmptyDir(const TFsPath& fsPath, const TString& dbPath, const TRestoreSettings& settings, bool isAlreadyExisting);
-    TRestoreResult RestoreTable(const TFsPath& fsPath, const TString& dbPath, const TRestoreSettings& settings, bool isAlreadyExisting);
-    TRestoreResult RestoreView(const TFsPath& fsPath, const TString& dbRestoreRoot, const TString& dbPathRelativeToRestoreRoot, const TRestoreSettings& settings, bool isAlreadyExisting);
-    TRestoreResult RestoreTopic(const TFsPath& fsPath, const TString& dbPath, const TRestoreSettings& settings, bool isAlreadyExisting);
-    TRestoreResult RestoreReplication(const TFsPath& fsPath, const TString& dbRestoreRoot, const TString& dbPathRelativeToRestoreRoot, const TRestoreSettings& settings, bool isAlreadyExisting);
-    TRestoreResult RestoreCoordinationNode(const TFsPath& fsPath, const TString& dbPath, const TRestoreSettings& settings, bool isAlreadyExisting);
+    TRestoreResult RestoreFolder(const TFsPath& fsBackupRoot, const TString& dbRestoreRoot, const TRestoreSettings& settings);
+    TRestoreResult RestoreDir(const TFsPath& fsPath, const TString& dbPath, const TRestoreSettings& settings);
+    TRestoreResult RestoreTable(const TFsPath& fsPath, const TString& dbPath, const TRestoreSettings& settings);
+    TRestoreResult RestoreView(const TFsPath& fsPath, const TString& dbRestoreRoot, const TString& dbPathRelativeToRestoreRoot, const TRestoreSettings& settings);
+    TRestoreResult RestoreTopic(const TFsPath& fsPath, const TString& dbPath, const TRestoreSettings& settings);
+    TRestoreResult RestoreReplication(const TFsPath& fsPath, const TString& dbRestoreRoot, const TString& dbPathRelativeToRestoreRoot, const TRestoreSettings& settings);
+    TRestoreResult RestoreCoordinationNode(const TFsPath& fsPath, const TString& dbPath, const TRestoreSettings& settings);
     TRestoreResult RestoreDependentResources(const TFsPath& fsPath, const TString& dbPath);
     TRestoreResult RestoreRateLimiter(const TFsPath& fsPath, const TString& coordinationNodePath, const TString& resourcePath);
-    TRestoreResult RestoreExternalDataSource(const TFsPath& fsPath, const TString& dbPath, const TRestoreSettings& settings, bool isAlreadyExisting);
-    TRestoreResult RestoreExternalTable(const TFsPath& fsPath, const TString& dbPath, const TRestoreSettings& settings, bool isAlreadyExisting);
+    TRestoreResult RestoreExternalDataSource(const TFsPath& fsPath, const TString& dbPath, const TRestoreSettings& settings);
+    TRestoreResult RestoreExternalTable(const TFsPath& fsPath, const TString& dbPath, const TRestoreSettings& settings);
+    TRestoreResult RestoreSysView(const TFsPath& fsPath, const TString& dbPath, const TRestoreSettings& settings);
 
+    TRestoreResult CheckExistenceAndType(const TString& dbPath, NScheme::ESchemeEntryType expectedType) const;
     TRestoreResult CheckSchema(const TString& dbPath, const NTable::TTableDescription& desc);
     TRestoreResult RestoreData(const TFsPath& fsPath, const TString& dbPath, const TRestoreSettings& settings, const NTable::TTableDescription& desc, ui32 partitionCount);
     TRestoreResult RestoreIndexes(const TString& dbPath, const NTable::TTableDescription& desc);
     TRestoreResult RestoreChangefeeds(const TFsPath& path, const TString& dbPath);
-    TRestoreResult RestorePermissions(const TFsPath& fsPath, const TString& dbPath, const TRestoreSettings& settings, bool isAlreadyExisting);
+    TRestoreResult RestorePermissions(const TFsPath& fsPath, const TString& dbPath, const TRestoreSettings& settings, bool isAlreadyExisting, bool isSystemObject);
     TRestoreResult RestoreConsumers(const TString& topicPath, const std::vector<NTopic::TConsumer>& consumers);
 
     TRestoreResult FindClusterRootPath();
@@ -235,10 +234,10 @@ class TRestoreClient {
 
     TRestoreResult CheckSecretExistence(const TString& secretName);
     TRestoreResult Drop(NScheme::ESchemeEntryType type, const TString& path, const TRestoreSettings& settings);
-    TRestoreResult Restore(NScheme::ESchemeEntryType type, const TFsPath& fsPath, const TString& dbRestoreRoot, const TString& dbPathRelativeToRestoreRoot, const TRestoreSettings& settings, bool isAlreadyExisting, bool delay);
-    TRestoreResult DropAndRestore(const TFsPath& fsPath, const TString& dbRestoreRoot, const TRestoreSettings& settings, const THashMap<TString, NScheme::ESchemeEntryType>& existingEntries);
-    TRestoreResult DropAndRestoreExternals(const TVector<NPrivate::TFsBackupEntry>& backupEntries, const TVector<size_t>& externalDataSources, const THashMap<TString, size_t>& externalTables, const TRestoreSettings& settings, const THashMap<TString, NScheme::ESchemeEntryType>& existingEntries);
-    TRestoreResult DropAndRestoreTablesAndDependents(const TVector<NPrivate::TFsBackupEntry>& backupEntries, const THashMap<TString, size_t>& tables, const TVector<size_t>& views, const THashMap<TString, size_t>& replications, const TString& dbRestoreRoot, const TRestoreSettings& settings, const THashMap<TString, NScheme::ESchemeEntryType>& existingEntries);
+    TRestoreResult Restore(NScheme::ESchemeEntryType type, const TFsPath& fsPath, const TString& dbRestoreRoot, const TString& dbPathRelativeToRestoreRoot, const TRestoreSettings& settings, bool delay);
+    TRestoreResult DropAndRestore(const TFsPath& fsPath, const TString& dbRestoreRoot, const TRestoreSettings& settings);
+    TRestoreResult DropAndRestoreExternals(const TVector<NPrivate::TFsBackupEntry>& backupEntries, const TVector<size_t>& externalDataSources, const THashMap<TString, size_t>& externalTables, const TRestoreSettings& settings);
+    TRestoreResult DropAndRestoreTablesAndDependents(const TVector<NPrivate::TFsBackupEntry>& backupEntries, const THashMap<TString, size_t>& tables, const TVector<size_t>& views, const THashMap<TString, size_t>& replications, const TString& dbRestoreRoot, const TRestoreSettings& settings);
 
 public:
     explicit TRestoreClient(const TDriver& driver, const std::shared_ptr<TLog>& log);
@@ -263,6 +262,7 @@ private:
     TDriverConfig DriverConfig;
     TString ClusterRootPath;
     NPrivate::TDelayedRestoreManager DelayedRestoreManager;
+    THashMap<TString, NScheme::ESchemeEntryType> ExistingEntries;
 
     friend class NPrivate::TDelayedRestoreManager;
 }; // TRestoreClient

--- a/ydb/public/lib/ydb_cli/dump/util/util.cpp
+++ b/ydb/public/lib/ydb_cli/dump/util/util.cpp
@@ -39,6 +39,17 @@ TStatus DescribeExternalDataSource(TTableClient& client, const TString& path, Yd
     return status;
 }
 
+TStatus DescribeSystemView(TTableClient& client, const TString& path, Ydb::Table::DescribeSystemViewResult& out) {
+    auto status = client.RetryOperationSync([&](NTable::TSession session) {
+        auto result = session.DescribeSystemView(path).ExtractValueSync();
+        if (result.IsSuccess()) {
+            out = TProtoAccessor::GetProto(result.GetSystemViewDescription());
+        }
+        return result;
+    });
+    return status;
+}
+
 TStatus DescribeReplication(NReplication::TReplicationClient& client, const TString& path, TMaybe<NReplication::TReplicationDescription>& out) {
     out.Clear();
 

--- a/ydb/public/lib/ydb_cli/dump/util/util.h
+++ b/ydb/public/lib/ydb_cli/dump/util/util.h
@@ -43,6 +43,7 @@ inline TResult Result(const TString& path, TStatus&& status) {
 
 TStatus DescribeTable(NTable::TTableClient& tableClient, const TString& path, TMaybe<NTable::TTableDescription>& out);
 TStatus DescribeExternalDataSource(NTable::TTableClient& tableClient, const TString& path, Ydb::Table::DescribeExternalDataSourceResult& out);
+TStatus DescribeSystemView(NTable::TTableClient& tableClient, const TString& path, Ydb::Table::DescribeSystemViewResult& out);
 TStatus DescribeReplication(NReplication::TReplicationClient& replicationClient, const TString& path, TMaybe<NReplication::TReplicationDescription>& out);
 TStatus DescribeViewQuery(const NYdb::TDriver& driver, const TString& path, TString& out);
 

--- a/ydb/public/sdk/cpp/src/client/scheme/scheme.cpp
+++ b/ydb/public/sdk/cpp/src/client/scheme/scheme.cpp
@@ -146,6 +146,10 @@ void TSchemeEntry::SerializeTo(::Ydb::Scheme::ModifyPermissionsRequest& request)
 }
 
 TModifyPermissionsSettings::TModifyPermissionsSettings(const ::Ydb::Scheme::ModifyPermissionsRequest& request) {
+    if (request.clear_permissions()) {
+        AddClearAcl();
+    }
+
     for (const auto& action : request.actions()) {
         switch (action.action_case()) {
             case Ydb::Scheme::PermissionsAction::kGrant:

--- a/ydb/services/ydb/backup_ut/ya.make
+++ b/ydb/services/ydb/backup_ut/ya.make
@@ -19,7 +19,7 @@ SRCS(
 PEERDIR(
     contrib/libs/fmt
     library/cpp/streams/zstd
-    ydb/core/testlib/default
+    ydb/core/testlib/pg
     ydb/core/util
     ydb/core/wrappers/ut_helpers
     ydb/public/lib/ydb_cli/dump


### PR DESCRIPTION
# Add Local Backup Support for System Views

This PR implements backup and restore functionality for system views (`.sys` directory contents) in YDB. 

**Key Changes:**
- Extended backup infrastructure to handle system directories alongside regular directories
- Added `--replace-sys-acl` CLI option to control whether system object permissions are restored from backup or preserved from target
- Added comprehensive test coverage for system view backup/restore scenarios with ACL management
- Maintains backward compatibility - existing backups continue to work without changes

The feature enables complete database backup/restore including system dirs with configurable permission handling.