### PR TITLE
DataShard: use volatile commits for non-volatile distributed writes

### DIFF
--- a/ydb/core/protos/feature_flags.proto
+++ b/ydb/core/protos/feature_flags.proto
@@ -222,4 +222,5 @@ message TFeatureFlags {
     optional bool EnableTopicCompactificationByKey = 196 [default = false];
     optional bool EnableCompactionOverloadDetection = 197 [default = true];
     optional bool DisableColumnShardBulkUpsertRequireAllColumns = 198 [default = false];
+    optional bool EnableDataShardWriteAlwaysVolatile = 199 [default = true];
 }

--- a/ydb/core/testlib/basics/feature_flags.h
+++ b/ydb/core/testlib/basics/feature_flags.h
@@ -81,6 +81,7 @@ public:
     FEATURE_FLAG_SETTER(EnableSharedMetadataAccessorCache)
     FEATURE_FLAG_SETTER(EnableSystemNamesProtection)
     FEATURE_FLAG_SETTER(EnableRealSystemViewPaths)
+    FEATURE_FLAG_SETTER(EnableDataShardWriteAlwaysVolatile)
 
     #undef FEATURE_FLAG_SETTER
 };

--- a/ydb/core/tx/datashard/block_fail_point_unit.cpp
+++ b/ydb/core/tx/datashard/block_fail_point_unit.cpp
@@ -1,0 +1,79 @@
+#include "datashard_impl.h"
+#include "datashard_pipeline.h"
+#include "execution_unit_ctors.h"
+#include "datashard_failpoints.h"
+
+namespace NKikimr {
+namespace NDataShard {
+
+class TBlockFailPointUnit : public TExecutionUnit {
+public:
+    TBlockFailPointUnit(TDataShard &dataShard,
+                         TPipeline &pipeline);
+    ~TBlockFailPointUnit() override;
+
+    bool IsReadyToExecute(TOperation::TPtr op) const override;
+    EExecutionStatus Execute(TOperation::TPtr op,
+                             TTransactionContext &txc,
+                             const TActorContext &ctx) override;
+    void Complete(TOperation::TPtr op,
+                  const TActorContext &ctx) override;
+
+private:
+};
+
+TBlockFailPointUnit::TBlockFailPointUnit(TDataShard &dataShard,
+                                           TPipeline &pipeline)
+    : TExecutionUnit(EExecutionUnitKind::BlockFailPoint, false, dataShard, pipeline)
+{
+}
+
+TBlockFailPointUnit::~TBlockFailPointUnit()
+{
+}
+
+bool TBlockFailPointUnit::IsReadyToExecute(TOperation::TPtr op) const
+{
+    if (!op->HasFlag(TTxFlags::BlockFailPointWaiting)) {
+        return true;
+    }
+    if (op->HasFlag(TTxFlags::BlockFailPointUnblocked)) {
+        return true;
+    }
+    return false;
+}
+
+EExecutionStatus TBlockFailPointUnit::Execute(TOperation::TPtr op,
+                                               TTransactionContext &,
+                                               const TActorContext &)
+{
+    if (!op->HasFlag(TTxFlags::BlockFailPointWaiting)) {
+        auto future = gBlockOperationsFailPoint.Block(DataShard.TabletID(), op->GetTxId());
+        if (future.Initialized() && !future.IsReady()) {
+            op->SetFlag(TTxFlags::BlockFailPointWaiting);
+            TActorId selfId = DataShard.SelfId();
+            future.Subscribe([actorSystem = TActivationContext::ActorSystem(), selfId = selfId, txId = op->GetTxId()](auto&) {
+                actorSystem->Send(new IEventHandle(selfId, selfId, new TDataShard::TEvPrivate::TEvBlockFailPointUnblock(txId)));
+            });
+            return EExecutionStatus::Continue;
+        }
+    }
+
+    op->ResetFlag(TTxFlags::BlockFailPointWaiting);
+    op->ResetFlag(TTxFlags::BlockFailPointUnblocked);
+    return EExecutionStatus::Executed;
+}
+
+void TBlockFailPointUnit::Complete(TOperation::TPtr,
+                                    const TActorContext &)
+{
+}
+
+THolder<TExecutionUnit> CreateBlockFailPointUnit(TDataShard &dataShard,
+                                                  TPipeline &pipeline)
+{
+    return THolder(new TBlockFailPointUnit(dataShard, pipeline));
+}
+
+} // namespace NDataShard
+} // namespace NKikimr

--- a/ydb/core/tx/datashard/complete_write_unit.cpp
+++ b/ydb/core/tx/datashard/complete_write_unit.cpp
@@ -103,7 +103,7 @@ void TCompleteWriteUnit::Complete(TOperation::TPtr op, const TActorContext &ctx)
     Pipeline.RemoveCommittingOp(op);
     Pipeline.RemoveTx(op->GetStepOrder());
     DataShard.IncCounter(COUNTER_WRITE_SUCCESS);
-    
+
     CompleteWrite(op, ctx);
 
     DataShard.SendDelayedAcks(ctx, op->DelayedAcks());

--- a/ydb/core/tx/datashard/datashard.cpp
+++ b/ydb/core/tx/datashard/datashard.cpp
@@ -4548,6 +4548,18 @@ void TDataShard::Handle(TEvPrivate::TEvRestartOperation::TPtr &ev, const TActorC
     PlanQueue.Progress(ctx);
 }
 
+void TDataShard::Handle(TEvPrivate::TEvBlockFailPointUnblock::TPtr& ev, const TActorContext& ctx) {
+    const auto txId = ev->Get()->TxId;
+
+    if (auto op = Pipeline.FindOp(txId)) {
+        if (op->HasFlag(TTxFlags::BlockFailPointWaiting)) {
+            op->SetFlag(TTxFlags::BlockFailPointUnblocked);
+            Pipeline.AddCandidateOp(op);
+            PlanQueue.Progress(ctx);
+        }
+    }
+}
+
 bool TDataShard::ReassignChannelsEnabled() const {
     return true;
 }

--- a/ydb/core/tx/datashard/datashard.h
+++ b/ydb/core/tx/datashard/datashard.h
@@ -132,8 +132,11 @@ namespace NDataShard {
             WaitingForRestart = 1ULL << 46,
             // Operation has write keys registered in the cache
             DistributedWritesRegistered = 1ULL << 47,
+            // Operation was blocked and is waiting for explicit unblock
+            BlockFailPointWaiting = 1ULL << 48,
+            BlockFailPointUnblocked = 1ULL << 49,
 
-            LastFlag = DistributedWritesRegistered,
+            LastFlag = BlockFailPointUnblocked,
 
             PrivateFlagsMask = 0xFFFFFFFFFFFF0000ULL,
             PreservedPrivateFlagsMask = ReadOnly | ProposeBlocker | NeedDiagnostics | GlobalReader

--- a/ydb/core/tx/datashard/datashard_active_transaction.cpp
+++ b/ydb/core/tx/datashard/datashard_active_transaction.cpp
@@ -682,12 +682,14 @@ void TActiveTransaction::FinalizeDataTxPlan()
         plan.push_back(EExecutionUnitKind::StoreAndSendOutRS);
         plan.push_back(EExecutionUnitKind::PrepareKqpDataTxInRS);
         plan.push_back(EExecutionUnitKind::LoadAndWaitInRS);
+        plan.push_back(EExecutionUnitKind::BlockFailPoint);
         plan.push_back(EExecutionUnitKind::ExecuteKqpDataTx);
     } else {
         plan.push_back(EExecutionUnitKind::BuildDataTxOutRS);
         plan.push_back(EExecutionUnitKind::StoreAndSendOutRS);
         plan.push_back(EExecutionUnitKind::PrepareDataTxInRS);
         plan.push_back(EExecutionUnitKind::LoadAndWaitInRS);
+        plan.push_back(EExecutionUnitKind::BlockFailPoint);
         plan.push_back(EExecutionUnitKind::ExecuteDataTx);
     }
     plan.push_back(EExecutionUnitKind::CompleteOperation);
@@ -708,6 +710,7 @@ void TActiveTransaction::BuildExecutionPlan(bool loaded)
             Y_ENSURE(!loaded);
             plan.push_back(EExecutionUnitKind::CheckDataTx);
             plan.push_back(EExecutionUnitKind::BuildAndWaitDependencies);
+            plan.push_back(EExecutionUnitKind::BlockFailPoint);
             if (IsKqpDataTransaction()) {
                 plan.push_back(EExecutionUnitKind::ExecuteKqpDataTx);
             } else {
@@ -727,6 +730,7 @@ void TActiveTransaction::BuildExecutionPlan(bool loaded)
             plan.push_back(EExecutionUnitKind::BuildAndWaitDependencies);
             Y_ENSURE(IsKqpDataTransaction());
             // Note: execute will also prepare and send readsets
+            plan.push_back(EExecutionUnitKind::BlockFailPoint);
             plan.push_back(EExecutionUnitKind::ExecuteKqpDataTx);
             // Note: it is important that plan here is the same as regular
             // distributed tx, since normal tx may decide to commit in a

--- a/ydb/core/tx/datashard/datashard_common_upload.cpp
+++ b/ydb/core/tx/datashard/datashard_common_upload.cpp
@@ -284,6 +284,7 @@ bool TCommonUploadOps<TEvRequest, TEvResponse>::Execute(TDataShard* self, TTrans
             groupProvider.GetCurrentChangeGroup(),
             /* ordered */ false,
             /* arbiter */ false,
+            /* disable expectations */ false,
             txc);
         // Note: transaction is already committed, no additional waiting needed
     }

--- a/ydb/core/tx/datashard/datashard_direct_erase.cpp
+++ b/ydb/core/tx/datashard/datashard_direct_erase.cpp
@@ -208,6 +208,7 @@ TDirectTxErase::EStatus TDirectTxErase::CheckedExecute(
             groupProvider ? groupProvider->GetCurrentChangeGroup() : std::nullopt,
             /* ordered */ false,
             /* arbiter */ false,
+            /* disable expectations */ false,
             *params.Txc);
         // Note: transaction is already committed, no additional waiting needed
     }

--- a/ydb/core/tx/datashard/datashard_failpoints.cpp
+++ b/ydb/core/tx/datashard/datashard_failpoints.cpp
@@ -6,5 +6,21 @@ namespace NDataShard {
 TCancelTxFailPoint gCancelTxFailPoint;
 TSkipRepliesFailPoint gSkipRepliesFailPoint;
 TSkipReadIteratorResultFailPoint gSkipReadIteratorResultFailPoint;
+TBlockOperationsFailPoint gBlockOperationsFailPoint;
+
+TBlockOperationsFailPoint::TGuard::TGuard()
+    : Prev(gBlockOperationsFailPoint.Chain.exchange(this, std::memory_order_acq_rel))
+{}
+
+TBlockOperationsFailPoint::TGuard::TGuard(std::function<bool(ui64, ui64)> callback)
+    : Callback(std::move(callback))
+    , Prev(gBlockOperationsFailPoint.Chain.exchange(this, std::memory_order_acq_rel))
+{}
+
+TBlockOperationsFailPoint::TGuard::~TGuard() {
+    IBlockOperations* expected = this;
+    bool success = gBlockOperationsFailPoint.Chain.compare_exchange_strong(expected, Prev, std::memory_order_release);
+    Y_ABORT_UNLESS(success, "TBlockOperationsFailPoint::TGuard construction/destruction order mismatch");
+}
 
 }}

--- a/ydb/core/tx/datashard/datashard_kqp.h
+++ b/ydb/core/tx/datashard/datashard_kqp.h
@@ -31,7 +31,7 @@ THolder<TEvDataShard::TEvProposeTransactionResult> KqpCompleteTransaction(const 
     ui64 tabletId, ui64 txId, const TInputOpData::TInReadSets* inReadSets, bool useGenericReadSets, NKqp::TKqpTasksRunner& tasksRunner,
     const NMiniKQL::TKqpDatashardComputeContext& computeCtx);
 
-void KqpFillOutReadSets(TOutputOpData::TOutReadSets& outReadSets, const NKikimrDataEvents::TKqpLocks& kqpLocks, 
+void KqpFillOutReadSets(TOutputOpData::TOutReadSets& outReadSets, const NKikimrDataEvents::TKqpLocks& kqpLocks,
     bool useGenericReadSets, NKqp::TKqpTasksRunner* tasksRunner, TSysLocks& sysLocks, ui64 tabletId);
 
 void KqpPrepareInReadsets(TInputOpData::TInReadSets& inReadSets,
@@ -42,6 +42,8 @@ std::tuple<bool, TVector<NKikimrDataEvents::TLock>> KqpValidateLocks(ui64 tablet
 std::tuple<bool, TVector<NKikimrDataEvents::TLock>> KqpValidateVolatileTx(ui64 tabletId, TSysLocks& sysLocks, 
     const NKikimrDataEvents::TKqpLocks* kqpLocks, bool useGenericReadSets, ui64 txId, const TVector<NKikimrTx::TEvReadSet>& delayedInReadSets, 
     TInputOpData::TAwaitingDecisions& awaitingDecisions, TOutputOpData::TOutReadSets& outReadSets);
+void KqpFillOutReadSets(TOutputOpData::TOutReadSets& outReadSets, const NKikimrDataEvents::TKqpLocks* kqpLocks,
+    NKikimrTx::TReadSetData::EDecision decision, ui64 origin);
 
 bool KqpLocksHasArbiter(const NKikimrDataEvents::TKqpLocks* kqpLocks);
 bool KqpLocksIsArbiter(ui64 tabletId, const NKikimrDataEvents::TKqpLocks* kqpLocks);

--- a/ydb/core/tx/datashard/datashard_ut_order.cpp
+++ b/ydb/core/tx/datashard/datashard_ut_order.cpp
@@ -2969,7 +2969,8 @@ Y_UNIT_TEST_TWIN(TestShardRestartPlannedCommitShouldSucceed, EvWrite) {
         .SetAppConfig(app)
         // Note: currently volatile transactions don't survive tablet reboots,
         // and reply with UNDETERMINED similar to immediate transactions.
-        .SetEnableDataShardVolatileTransactions(false);
+        .SetEnableDataShardVolatileTransactions(false)
+        .SetEnableDataShardWriteAlwaysVolatile(false);
 
     Tests::TServer::TPtr server = new TServer(serverSettings);
     auto &runtime = *server->GetRuntime();

--- a/ydb/core/tx/datashard/datashard_ut_read_iterator.cpp
+++ b/ydb/core/tx/datashard/datashard_ut_read_iterator.cpp
@@ -2582,6 +2582,7 @@ Y_UNIT_TEST_SUITE(DataShardReadIterator) {
             .SetUseRealThreads(false)
             // Blocked volatile transactions block reads, disable
             .SetEnableDataShardVolatileTransactions(false)
+            .SetEnableDataShardWriteAlwaysVolatile(false)
             .SetAppConfig(app);
 
         const ui64 shardCount = 1;

--- a/ydb/core/tx/datashard/datashard_ut_snapshot.cpp
+++ b/ydb/core/tx/datashard/datashard_ut_snapshot.cpp
@@ -2681,6 +2681,7 @@ Y_UNIT_TEST_SUITE(DataShardSnapshots) {
         // Note: disable volatile transactions, since this test verifies lock
         // freezing and volatile transactions work without them.
         runtime.GetAppData(0).FeatureFlags.SetEnableDataShardVolatileTransactions(false);
+        runtime.GetAppData(0).FeatureFlags.SetEnableDataShardWriteAlwaysVolatile(false);
 
         // Commit changes in tx 123
         observer.BlockReadSets = true;
@@ -2835,6 +2836,7 @@ Y_UNIT_TEST_SUITE(DataShardSnapshots) {
         // until readsets arrive, and this test relies on tx cross blocking,
         // which doesn't happen with volatile transactions.
         runtime.GetAppData(0).FeatureFlags.SetEnableDataShardVolatileTransactions(false);
+        runtime.GetAppData(0).FeatureFlags.SetEnableDataShardWriteAlwaysVolatile(false);
 
         // Commit changes in tx 123 (we expect locks to be ready for sending)
         observer.BlockReadSets = true;
@@ -4986,7 +4988,8 @@ Y_UNIT_TEST_SUITE(DataShardSnapshots) {
         serverSettings.SetDomainName("Root")
             .SetUseRealThreads(false)
             .SetDomainPlanResolution(100)
-            .SetEnableDataShardVolatileTransactions(false);
+            .SetEnableDataShardVolatileTransactions(false)
+            .SetEnableDataShardWriteAlwaysVolatile(false);
 
         Tests::TServer::TPtr server = new TServer(serverSettings);
         auto &runtime = *server->GetRuntime();

--- a/ydb/core/tx/datashard/datashard_ut_trace.cpp
+++ b/ydb/core/tx/datashard/datashard_ut_trace.cpp
@@ -257,7 +257,7 @@ Y_UNIT_TEST_SUITE(TDataShardTrace) {
 
                 auto progress = tabletTxs[1];
                 CheckTxHasWriteLog(progress);
-                CheckTxHasDatashardUnits(progress, usesVolatileTxs ? 6 : 11);
+                CheckTxHasDatashardUnits(progress, usesVolatileTxs ? 7 : 12);
             }
 
             std::string canon = ExpectedSpan("Session.query.QUERY_ACTION_EXECUTE",
@@ -277,7 +277,7 @@ Y_UNIT_TEST_SUITE(TDataShardTrace) {
                             Conditional(usesVolatileTxs, "Datashard.SendWithConfirmedReadOnlyLease"),
                             ExpectedSpan("Tablet.Transaction",
                                 ExpectedSpan("Tablet.Transaction.Execute",
-                                    Repeat("Datashard.Unit", usesVolatileTxs ? 6 : 11)),
+                                    Repeat("Datashard.Unit", usesVolatileTxs ? 7 : 12)),
                                 ExpectedSpan("Tablet.WriteLog",
                                     "Tablet.WriteLog.LogEntry"),
                                 "Tablet.Transaction.Complete"),
@@ -305,7 +305,7 @@ Y_UNIT_TEST_SUITE(TDataShardTrace) {
 
                 auto progress = tabletTxs[1];
                 CheckTxHasWriteLog(progress);
-                CheckTxHasDatashardUnits(progress, usesVolatileTxs ? 6 : 11);
+                CheckTxHasDatashardUnits(progress, usesVolatileTxs ? 7 : 12);
             }
 
             std::string canon = ExpectedSpan("Session.query.QUERY_ACTION_EXECUTE",
@@ -330,7 +330,7 @@ Y_UNIT_TEST_SUITE(TDataShardTrace) {
                                 Conditional(usesVolatileTxs, "Datashard.SendWithConfirmedReadOnlyLease"),
                                 ExpectedSpan("Tablet.Transaction",
                                     ExpectedSpan("Tablet.Transaction.Execute",
-                                        Repeat("Datashard.Unit", usesVolatileTxs ? 6 : 11)),
+                                        Repeat("Datashard.Unit", usesVolatileTxs ? 7 : 12)),
                                     ExpectedSpan("Tablet.WriteLog",
                                         "Tablet.WriteLog.LogEntry"),
                                     "Tablet.Transaction.Complete"),
@@ -552,12 +552,12 @@ Y_UNIT_TEST_SUITE(TDataShardTrace) {
         auto writeTx = tabletTxs[0];
 
         CheckTxHasWriteLog(writeTx);
-        CheckTxHasDatashardUnits(writeTx, 5);
+        CheckTxHasDatashardUnits(writeTx, 6);
 
         std::string canon = ExpectedSpan("Datashard.WriteTransaction",
             ExpectedSpan("Tablet.Transaction",
                 ExpectedSpan("Tablet.Transaction.Execute",
-                    Repeat("Datashard.Unit", 5)),
+                    Repeat("Datashard.Unit", 6)),
                 ExpectedSpan("Tablet.WriteLog", "Tablet.WriteLog.LogEntry"),
                 "Tablet.Transaction.Complete"),
             "Datashard.SendImmediateWriteResult")

--- a/ydb/core/tx/datashard/datashard_ut_volatile.cpp
+++ b/ydb/core/tx/datashard/datashard_ut_volatile.cpp
@@ -3062,7 +3062,8 @@ Y_UNIT_TEST_SUITE(DataShardVolatile) {
 
         // arbiter will send 3 expectations
         // two shards will send 1 commit decision + 1 expectation
-        size_t expectedReadSets = 3 + 2 * 2;
+        // one shard will send 1 abort decision
+        size_t expectedReadSets = 3 + 2 * 2 + 1;
         runtime.SimulateSleep(TDuration::Seconds(1));
         UNIT_ASSERT_VALUES_EQUAL(blockedReadSets.size(), expectedReadSets);
 
@@ -3078,9 +3079,8 @@ Y_UNIT_TEST_SUITE(DataShardVolatile) {
         TCountReadSets countReadSets(runtime);
         runtime.SimulateSleep(TDuration::Seconds(1));
 
-        // arbiter will send 3 additional commit decisions
-        // the last shard sends a nodata readset to answer expectation
-        UNIT_ASSERT_VALUES_EQUAL(countReadSets.Count, expectedReadSets + 4);
+        // arbiter will send 3 additional commit (abort) decisions
+        UNIT_ASSERT_VALUES_EQUAL(countReadSets.Count, expectedReadSets + 3);
 
         Cerr << "========= Checking table =========" << Endl;
         UNIT_ASSERT_VALUES_EQUAL(

--- a/ydb/core/tx/datashard/datashard_ut_write.cpp
+++ b/ydb/core/tx/datashard/datashard_ut_write.cpp
@@ -1863,7 +1863,10 @@ Y_UNIT_TEST_SUITE(DataShardWrite) {
             .SetUseRealThreads(false)
             // It's easier to reproduce without volatile transactions, since
             // then we can block pipeline by blocking readsets
-            .SetEnableDataShardVolatileTransactions(false);
+            .SetEnableDataShardVolatileTransactions(false)
+            // We need to block transaction post validation, which is
+            // impossible with volatile execution.
+            .SetEnableDataShardWriteAlwaysVolatile(false);
 
         auto [runtime, server, sender] = TestCreateServer(serverSettings);
 
@@ -2140,7 +2143,8 @@ Y_UNIT_TEST_SUITE(DataShardWrite) {
         // Wait for some time and make sure there have been no unexpected
         // commits, which would indicate the upsert is blocked by tx1.
         runtime.SimulateSleep(TDuration::MilliSeconds(1));
-        UNIT_ASSERT_VALUES_EQUAL_C(blockedCommits.size(), 0u,
+        size_t commitsBeforeTx2 = blockedCommits.size();
+        UNIT_ASSERT_VALUES_EQUAL_C(commitsBeforeTx2, 0u,
             "The uncommitted upsert didn't block. Something may have changed and the test needs to be revised.");
 
         // Now, while blocking commits, unblock progress and let tx2 to execute,
@@ -2149,7 +2153,7 @@ Y_UNIT_TEST_SUITE(DataShardWrite) {
         blockedProgress.Stop();
 
         runtime.SimulateSleep(TDuration::MilliSeconds(1));
-        size_t commitsAfterTx2 = blockedCommits.size();
+        size_t commitsAfterTx2 = blockedCommits.size() - commitsBeforeTx2;
         Cerr << "... observed " << commitsAfterTx2 << " commits after tx2 unblock" << Endl;
         UNIT_ASSERT_C(commitsAfterTx2 >= 2,
             "Expected tx2 to produce at least 2 commits (store out rs + abort tx)"
@@ -2161,7 +2165,7 @@ Y_UNIT_TEST_SUITE(DataShardWrite) {
         blockedReadSets.Stop();
 
         runtime.SimulateSleep(TDuration::MilliSeconds(1));
-        size_t commitsAfterTx3 = blockedCommits.size() - commitsAfterTx2;
+        size_t commitsAfterTx3 = blockedCommits.size() - commitsAfterTx2 - commitsBeforeTx2;
         Cerr << "... observed " << commitsAfterTx3 << " more commits after readset unblock" << Endl;
         UNIT_ASSERT_C(commitsAfterTx3 >= 2,
             "Expected at least 2 commits after readset unblock (tx1, tx3), but only "
@@ -2868,6 +2872,299 @@ Y_UNIT_TEST_SUITE(DataShardWrite) {
             "{ items { int32_value: 2 } items { int32_value: 1003 } }, "
             "{ items { int32_value: 11 } items { int32_value: 1002 } }, "
             "{ items { int32_value: 12 } items { int32_value: 1004 } }"
+        );
+    }
+
+    Y_UNIT_TEST_TWIN(DistributedInsertWithoutLocks, Volatile) {
+        TPortManager pm;
+        NKikimrConfig::TAppConfig app;
+        app.MutableTableServiceConfig()->SetEnableOltpSink(true);
+        TServerSettings serverSettings(pm.GetPort(2134));
+        serverSettings.SetDomainName("Root")
+            .SetUseRealThreads(false)
+            .SetAppConfig(app);
+
+        auto [runtime, server, sender] = TestCreateServer(serverSettings);
+
+        TDisableDataShardLogBatching disableDataShardLogBatching;
+
+        UNIT_ASSERT_VALUES_EQUAL(
+            KqpSchemeExec(runtime, R"(
+                CREATE TABLE `/Root/table` (key int, value int, PRIMARY KEY (key))
+                WITH (PARTITION_AT_KEYS = (10));
+            )"),
+            "SUCCESS"
+        );
+
+        ExecSQL(server, sender, R"(
+            UPSERT INTO `/Root/table` (key, value) VALUES
+                (1, 1001),
+                (11, 1002);
+        )");
+
+        const auto tableId = ResolveTableId(server, sender, "/Root/table");
+        const auto shards = GetTableShards(server, sender, "/Root/table");
+        UNIT_ASSERT_VALUES_EQUAL(shards.size(), 2u);
+
+        auto shard1 = shards.at(0);
+        auto shard2 = shards.at(1);
+
+        TVector<TShardedTableOptions::TColumn> columns{
+            {"key", "Int32", true, false},
+            {"value", "Int32", false, false},
+        };
+
+        const ui64 coordinator = ChangeStateStorage(Coordinator, server->GetSettings().Domain);
+
+        // Prepare an insert (readsets flow between shards)
+        ui64 txId1 = 1234567890011;
+        auto tx1sender = runtime.AllocateEdgeActor();
+        {
+            auto req1 = MakeWriteRequestOneKeyValue(
+                txId1,
+                Volatile ? NKikimrDataEvents::TEvWrite::MODE_VOLATILE_PREPARE : NKikimrDataEvents::TEvWrite::MODE_PREPARE,
+                NKikimrDataEvents::TEvWrite::TOperation::OPERATION_INSERT,
+                tableId,
+                columns,
+                2, 1003);
+            req1->Record.MutableLocks()->SetOp(NKikimrDataEvents::TKqpLocks::Commit);
+            req1->Record.MutableLocks()->AddSendingShards(shard1);
+            req1->Record.MutableLocks()->AddSendingShards(shard2);
+            req1->Record.MutableLocks()->AddReceivingShards(shard1);
+            req1->Record.MutableLocks()->AddReceivingShards(shard2);
+
+            auto req2 = MakeWriteRequestOneKeyValue(
+                txId1,
+                Volatile ? NKikimrDataEvents::TEvWrite::MODE_VOLATILE_PREPARE : NKikimrDataEvents::TEvWrite::MODE_PREPARE,
+                NKikimrDataEvents::TEvWrite::TOperation::OPERATION_INSERT,
+                tableId,
+                columns,
+                12, 1004);
+            req2->Record.MutableLocks()->SetOp(NKikimrDataEvents::TKqpLocks::Commit);
+            req2->Record.MutableLocks()->AddSendingShards(shard1);
+            req2->Record.MutableLocks()->AddSendingShards(shard2);
+            req2->Record.MutableLocks()->AddReceivingShards(shard1);
+            req2->Record.MutableLocks()->AddReceivingShards(shard2);
+
+            Cerr << "... preparing tx1 at " << shard1 << Endl;
+            auto res1 = Write(runtime, tx1sender, shard1, std::move(req1));
+            Cerr << "... preparing tx1 at " << shard2 << Endl;
+            auto res2 = Write(runtime, tx1sender, shard2, std::move(req2));
+
+            ui64 minStep = Max(res1.GetMinStep(), res2.GetMinStep());
+            ui64 maxStep = Min(res1.GetMaxStep(), res2.GetMaxStep());
+
+            Cerr << "... planning tx1 at " << coordinator << Endl;
+            SendProposeToCoordinator(
+                runtime, tx1sender, shards, {
+                    .TxId = txId1,
+                    .Coordinator = coordinator,
+                    .MinStep = minStep,
+                    .MaxStep = maxStep,
+                    .Volatile = Volatile,
+                });
+        }
+
+        // Check tx1 replies
+        {
+            auto ev1 = runtime.GrabEdgeEventRethrow<NEvents::TDataEvents::TEvWriteResult>(tx1sender);
+            auto ev2 = runtime.GrabEdgeEventRethrow<NEvents::TDataEvents::TEvWriteResult>(tx1sender);
+            UNIT_ASSERT_C(
+                ev1->Get()->Record.GetStatus() == NKikimrDataEvents::TEvWriteResult::STATUS_COMPLETED &&
+                ev2->Get()->Record.GetStatus() == NKikimrDataEvents::TEvWriteResult::STATUS_COMPLETED,
+                "Unexpected status: " << ev1->Get()->Record.GetStatus() << " and " << ev2->Get()->Record.GetStatus()
+            );
+        }
+
+        // Validate commit was not partially applied
+        UNIT_ASSERT_VALUES_EQUAL(
+            KqpSimpleExec(runtime, R"(
+                SELECT key, value FROM `/Root/table` ORDER BY key;
+            )"),
+            "{ items { int32_value: 1 } items { int32_value: 1001 } }, "
+            "{ items { int32_value: 2 } items { int32_value: 1003 } }, "
+            "{ items { int32_value: 11 } items { int32_value: 1002 } }, "
+            "{ items { int32_value: 12 } items { int32_value: 1004 } }"
+        );
+    }
+
+    Y_UNIT_TEST_TWIN(DistributedInsertDuplicateWithLocks, Volatile) {
+        TPortManager pm;
+        NKikimrConfig::TAppConfig app;
+        app.MutableTableServiceConfig()->SetEnableOltpSink(true);
+        TServerSettings serverSettings(pm.GetPort(2134));
+        serverSettings.SetDomainName("Root")
+            .SetUseRealThreads(false)
+            .SetAppConfig(app);
+
+        auto [runtime, server, sender] = TestCreateServer(serverSettings);
+
+        TDisableDataShardLogBatching disableDataShardLogBatching;
+
+        UNIT_ASSERT_VALUES_EQUAL(
+            KqpSchemeExec(runtime, R"(
+                CREATE TABLE `/Root/table` (key int, value int, PRIMARY KEY (key))
+                WITH (PARTITION_AT_KEYS = (10));
+            )"),
+            "SUCCESS"
+        );
+
+        ExecSQL(server, sender, R"(
+            UPSERT INTO `/Root/table` (key, value) VALUES
+                (1, 1001),
+                (11, 1002);
+        )");
+
+        const auto tableId = ResolveTableId(server, sender, "/Root/table");
+        const auto shards = GetTableShards(server, sender, "/Root/table");
+        UNIT_ASSERT_VALUES_EQUAL(shards.size(), 2u);
+
+        auto shard1 = shards.at(0);
+        auto shard2 = shards.at(1);
+
+        TVector<TShardedTableOptions::TColumn> columns{
+            {"key", "Int32", true, false},
+            {"value", "Int32", false, false},
+        };
+
+        const ui64 coordinator = ChangeStateStorage(Coordinator, server->GetSettings().Domain);
+
+        const ui64 lockTxId1 = 1234567890001;
+        const ui64 lockNodeId = runtime.GetNodeId(0);
+        NLongTxService::TLockHandle lockHandle1(lockTxId1, runtime.GetActorSystem(0));
+
+        NKikimrDataEvents::TLock lock1shard1;
+        NKikimrDataEvents::TLock lock1shard2;
+
+        // Make a read (lock1 shard1)
+        auto read1sender = runtime.AllocateEdgeActor();
+        {
+            Cerr << "... making a read from " << shard1 << Endl;
+            auto req = std::make_unique<TEvDataShard::TEvRead>();
+            {
+                auto& record = req->Record;
+                record.SetReadId(1);
+                record.MutableTableId()->SetOwnerId(tableId.PathId.OwnerId);
+                record.MutableTableId()->SetTableId(tableId.PathId.LocalPathId);
+                record.AddColumns(1);
+                record.AddColumns(2);
+                record.SetLockTxId(lockTxId1);
+                record.SetLockNodeId(lockNodeId);
+                record.SetResultFormat(NKikimrDataEvents::FORMAT_CELLVEC);
+                i32 key = 1;
+                TVector<TCell> keys;
+                keys.push_back(TCell::Make(key));
+                req->Keys.push_back(TSerializedCellVec(TSerializedCellVec::Serialize(keys)));
+            }
+            ForwardToTablet(runtime, shard1, read1sender, req.release());
+            auto ev = runtime.GrabEdgeEventRethrow<TEvDataShard::TEvReadResult>(read1sender);
+            auto* res = ev->Get();
+            UNIT_ASSERT_VALUES_EQUAL(res->Record.GetStatus().GetCode(), Ydb::StatusIds::SUCCESS);
+            UNIT_ASSERT_VALUES_EQUAL(res->Record.GetFinished(), true);
+            UNIT_ASSERT_VALUES_EQUAL(res->Record.GetTxLocks().size(), 1u);
+            lock1shard1 = res->Record.GetTxLocks().at(0);
+            UNIT_ASSERT_C(lock1shard1.GetCounter() < 1000, "Unexpected lock in the result: " << lock1shard1.ShortDebugString());
+        }
+
+        // Make a read (lock1 shard2)
+        auto read2sender = runtime.AllocateEdgeActor();
+        {
+            Cerr << "... making a read from " << shard2 << Endl;
+            auto req = std::make_unique<TEvDataShard::TEvRead>();
+            {
+                auto& record = req->Record;
+                record.SetReadId(1);
+                record.MutableTableId()->SetOwnerId(tableId.PathId.OwnerId);
+                record.MutableTableId()->SetTableId(tableId.PathId.LocalPathId);
+                record.AddColumns(1);
+                record.AddColumns(2);
+                record.SetLockTxId(lockTxId1);
+                record.SetLockNodeId(lockNodeId);
+                record.SetResultFormat(NKikimrDataEvents::FORMAT_CELLVEC);
+                i32 key = 11;
+                TVector<TCell> keys;
+                keys.push_back(TCell::Make(key));
+                req->Keys.push_back(TSerializedCellVec(TSerializedCellVec::Serialize(keys)));
+            }
+            ForwardToTablet(runtime, shard2, read2sender, req.release());
+            auto ev = runtime.GrabEdgeEventRethrow<TEvDataShard::TEvReadResult>(read2sender);
+            auto* res = ev->Get();
+            UNIT_ASSERT_VALUES_EQUAL(res->Record.GetStatus().GetCode(), Ydb::StatusIds::SUCCESS);
+            UNIT_ASSERT_VALUES_EQUAL(res->Record.GetFinished(), true);
+            UNIT_ASSERT_VALUES_EQUAL(res->Record.GetTxLocks().size(), 1u);
+            lock1shard2 = res->Record.GetTxLocks().at(0);
+            UNIT_ASSERT_C(lock1shard2.GetCounter() < 1000, "Unexpected lock in the result: " << lock1shard2.ShortDebugString());
+        }
+
+        // Prepare an insert (readsets flow between shards)
+        ui64 txId1 = 1234567890011;
+        auto tx1sender = runtime.AllocateEdgeActor();
+        {
+            auto req1 = MakeWriteRequestOneKeyValue(
+                txId1,
+                Volatile ? NKikimrDataEvents::TEvWrite::MODE_VOLATILE_PREPARE : NKikimrDataEvents::TEvWrite::MODE_PREPARE,
+                NKikimrDataEvents::TEvWrite::TOperation::OPERATION_INSERT,
+                tableId,
+                columns,
+                1, 1003);
+            req1->Record.MutableLocks()->SetOp(NKikimrDataEvents::TKqpLocks::Commit);
+            req1->Record.MutableLocks()->AddSendingShards(shard1);
+            req1->Record.MutableLocks()->AddSendingShards(shard2);
+            req1->Record.MutableLocks()->AddReceivingShards(shard1);
+            req1->Record.MutableLocks()->AddReceivingShards(shard2);
+            *req1->Record.MutableLocks()->AddLocks() = lock1shard1;
+
+            auto req2 = MakeWriteRequestOneKeyValue(
+                txId1,
+                Volatile ? NKikimrDataEvents::TEvWrite::MODE_VOLATILE_PREPARE : NKikimrDataEvents::TEvWrite::MODE_PREPARE,
+                NKikimrDataEvents::TEvWrite::TOperation::OPERATION_INSERT,
+                tableId,
+                columns,
+                12, 1004);
+            req2->Record.MutableLocks()->SetOp(NKikimrDataEvents::TKqpLocks::Commit);
+            req2->Record.MutableLocks()->AddSendingShards(shard1);
+            req2->Record.MutableLocks()->AddSendingShards(shard2);
+            req2->Record.MutableLocks()->AddReceivingShards(shard1);
+            req2->Record.MutableLocks()->AddReceivingShards(shard2);
+            *req2->Record.MutableLocks()->AddLocks() = lock1shard2;
+
+            Cerr << "... preparing tx1 at " << shard1 << Endl;
+            auto res1 = Write(runtime, tx1sender, shard1, std::move(req1));
+            Cerr << "... preparing tx1 at " << shard2 << Endl;
+            auto res2 = Write(runtime, tx1sender, shard2, std::move(req2));
+
+            ui64 minStep = Max(res1.GetMinStep(), res2.GetMinStep());
+            ui64 maxStep = Min(res1.GetMaxStep(), res2.GetMaxStep());
+
+            Cerr << "... planning tx1 at " << coordinator << Endl;
+            SendProposeToCoordinator(
+                runtime, tx1sender, shards, {
+                    .TxId = txId1,
+                    .Coordinator = coordinator,
+                    .MinStep = minStep,
+                    .MaxStep = maxStep,
+                    .Volatile = Volatile,
+                });
+        }
+
+        // Check tx1 replies
+        {
+            auto ev1 = runtime.GrabEdgeEventRethrow<NEvents::TDataEvents::TEvWriteResult>(tx1sender);
+            auto ev2 = runtime.GrabEdgeEventRethrow<NEvents::TDataEvents::TEvWriteResult>(tx1sender);
+            UNIT_ASSERT_C(
+                ev1->Get()->Record.GetStatus() == NKikimrDataEvents::TEvWriteResult::STATUS_CONSTRAINT_VIOLATION ||
+                ev2->Get()->Record.GetStatus() == NKikimrDataEvents::TEvWriteResult::STATUS_CONSTRAINT_VIOLATION,
+                "Unexpected status: " << ev1->Get()->Record.GetStatus() << " and " << ev2->Get()->Record.GetStatus()
+            );
+        }
+
+        // Validate commit was not partially applied
+        UNIT_ASSERT_VALUES_EQUAL(
+            KqpSimpleExec(runtime, R"(
+                SELECT key, value FROM `/Root/table` ORDER BY key;
+            )"),
+            "{ items { int32_value: 1 } items { int32_value: 1001 } }, "
+            "{ items { int32_value: 11 } items { int32_value: 1002 } }"
         );
     }
 

--- a/ydb/core/tx/datashard/execute_data_tx_unit.cpp
+++ b/ydb/core/tx/datashard/execute_data_tx_unit.cpp
@@ -332,6 +332,7 @@ void TExecuteDataTxUnit::ExecuteDataTx(TOperation::TPtr op,
             tx->GetDataTx()->GetVolatileChangeGroup(),
             tx->GetDataTx()->GetVolatileCommitOrdered(),
             /* arbiter */ false,
+            /* disable expectations */ false,
             txc);
     }
 

--- a/ydb/core/tx/datashard/execute_distributed_erase_tx_unit.cpp
+++ b/ydb/core/tx/datashard/execute_distributed_erase_tx_unit.cpp
@@ -216,6 +216,7 @@ public:
                 groupProvider ? groupProvider->GetCurrentChangeGroup() : std::nullopt,
                 volatileOrdered,
                 /* arbiter */ false,
+                /* disable expectations */ false,
                 txc);
             // Note: transaction is already committed, no additional waiting needed
         }

--- a/ydb/core/tx/datashard/execute_write_unit.cpp
+++ b/ydb/core/tx/datashard/execute_write_unit.cpp
@@ -57,13 +57,12 @@ public:
         DataShard.SubscribeNewLocks(ctx);
     }
 
-    void ResetChanges(TDataShardUserDb& userDb, TWriteOperation& writeOp, TTransactionContext& txc) {
+    void ResetChanges(TDataShardUserDb& userDb, TTransactionContext& txc) {
         userDb.ResetCollectedChanges();
 
-        writeOp.ReleaseTxData(txc);
-
-        if (txc.DB.HasChanges())
+        if (txc.DB.HasChanges()) {
             txc.DB.RollbackChanges();
+        }
     }
 
     bool CheckForVolatileReadDependencies(TDataShardUserDb& userDb, TWriteOperation& writeOp, TTransactionContext& txc, const TActorContext& ctx) {
@@ -76,7 +75,8 @@ public:
                 Y_ENSURE(ok, "Unexpected failure to attach TxId# " << writeOp.GetTxId() << " to volatile tx " << txId);
             }
 
-            ResetChanges(userDb, writeOp, txc);
+            ResetChanges(userDb, txc);
+            writeOp.ReleaseTxData(txc);
 
             return true;
         }
@@ -152,26 +152,26 @@ public:
 
         DataShard.IncCounter(COUNTER_TX_TABLET_NOT_READY);
 
-        ResetChanges(userDb, writeOp, txc);
+        ResetChanges(userDb, txc);
+        writeOp.ReleaseTxData(txc);
         return EExecutionStatus::Restart;
     }
 
-    EExecutionStatus OnUniqueConstrainException(TDataShardUserDb& userDb, TWriteOperation& writeOp, TTransactionContext& txc, const TActorContext& ctx) {
+    bool OnUniqueConstrainException(TDataShardUserDb& userDb, TWriteOperation& writeOp, TTransactionContext& txc, const TActorContext& ctx) {
         if (CheckForVolatileReadDependencies(userDb, writeOp, txc, ctx)) {
-            return EExecutionStatus::Continue;
+            return false;
         }
 
         if (userDb.GetSnapshotReadConflict()) {
             LOG_TRACE_S(ctx, NKikimrServices::TX_DATASHARD, "Operation " << writeOp << " at " << DataShard.TabletID() << " aborting. Conflict with another transaction.");
             writeOp.SetError(NKikimrDataEvents::TEvWriteResult::STATUS_LOCKS_BROKEN, "Read conflict with concurrent transaction.");
-            ResetChanges(userDb, writeOp, txc);
-            return EExecutionStatus::Executed;
+        } else {
+            LOG_TRACE_S(ctx, NKikimrServices::TX_DATASHARD, "Operation " << writeOp << " at " << DataShard.TabletID() << " aborting. Conflict with existing key.");
+            writeOp.SetError(NKikimrDataEvents::TEvWriteResult::STATUS_CONSTRAINT_VIOLATION, "Conflict with existing key.");
         }
 
-        LOG_TRACE_S(ctx, NKikimrServices::TX_DATASHARD, "Operation " << writeOp << " at " << DataShard.TabletID() << " aborting. Conflict with existing key.");
-        writeOp.SetError(NKikimrDataEvents::TEvWriteResult::STATUS_CONSTRAINT_VIOLATION, "Conflict with existing key.");
-        ResetChanges(userDb, writeOp, txc);
-        return EExecutionStatus::Executed;
+        ResetChanges(userDb, txc);
+        return true;
     }
 
     void DoUpdateToUserDb(TDataShardUserDb& userDb, const TValidatedWriteTxOperation& validatedOperation, TTransactionContext& txc) {
@@ -309,9 +309,9 @@ public:
         }
 
         if (writeTx->CheckCancelled()) {
-            writeOp->ReleaseTxData(txc);
             writeOp->SetError(NKikimrDataEvents::TEvWriteResult::STATUS_CANCELLED, "Tx was cancelled");
             DataShard.IncCounter(COUNTER_WRITE_CANCELLED);
+            writeOp->ReleaseTxData(txc);
             return EExecutionStatus::Executed;
         }
 
@@ -325,7 +325,7 @@ public:
         userDb.SetLockTxId(writeTx->GetLockTxId());
         userDb.SetLockNodeId(writeTx->GetLockNodeId());
 
-        if (op->HasVolatilePrepareFlag()) {
+        if (op->HasVolatilePrepareFlag() || op->GetRemainReadSets()) {
             userDb.SetVolatileTxId(txId);
         }
 
@@ -334,8 +334,32 @@ public:
             userDb.SetSnapshotVersion(*mvccSnapshot);
         }
 
+        bool preparedOutReadSets = false;
+        bool keepOutReadSets = writeOp->IsOutRSStored();
+
+        const auto* kqpLocks = writeTx->GetKqpLocks() ? &writeTx->GetKqpLocks().value() : nullptr;
+
+        auto ensureAbortOutReadSets = [&]() -> std::optional<EExecutionStatus> {
+            if (!op->IsImmediate() && !keepOutReadSets) {
+                op->OutReadSets().clear();
+                op->AwaitingDecisions().clear();
+                KqpFillOutReadSets(op->OutReadSets(), kqpLocks, NKikimrTx::TReadSetData::DECISION_ABORT, tabletId);
+                if (!op->OutReadSets().empty()) {
+                    DataShard.PrepareAndSaveOutReadSets(op->GetStep(), op->GetTxId(), op->OutReadSets(), op->PreparedOutReadSets(), txc, ctx);
+                    preparedOutReadSets = true;
+                }
+                keepOutReadSets = true;
+
+                if (preparedOutReadSets && !op->PreparedOutReadSets().empty()) {
+                    op->SetWaitCompletionFlag(true);
+                    return EExecutionStatus::DelayCompleteNoMoreRestarts;
+                }
+            }
+
+            return std::nullopt;
+        };
+
         try {
-            const auto* kqpLocks = writeTx->GetKqpLocks() ? &writeTx->GetKqpLocks().value() : nullptr;
             const auto& inReadSets = op->InReadSets();
             auto& awaitingDecisions = op->AwaitingDecisions();
             auto& outReadSets = op->OutReadSets();
@@ -385,8 +409,6 @@ public:
                 }
             }
 
-            bool keepOutReadSets = !op->HasVolatilePrepareFlag();
-
             Y_DEFER {
                 // We need to clear OutReadSets and AwaitingDecisions for
                 // volatile transactions, except when we commit them.
@@ -412,6 +434,11 @@ public:
                 auto [_, locksBrokenByTx] = sysLocks.ApplyLocks();
                 NDataIntegrity::LogIntegrityTrailsLocks(ctx, tabletId, txId, locksBrokenByTx);
                 DataShard.SubscribeNewLocks(ctx);
+
+                if (auto status = ensureAbortOutReadSets()) {
+                    return *status;
+                }
+
                 if (locksDb.HasChanges()) {
                     op->SetWaitCompletionFlag(true);
                     return EExecutionStatus::ExecutedNoMoreRestarts;
@@ -446,10 +473,10 @@ public:
 
             if (Pipeline.AddLockDependencies(op, guardLocks)) {
                 userDb.ResetCollectedChanges();
-                writeOp->ReleaseTxData(txc);
                 if (txc.DB.HasChanges()) {
                     txc.DB.RollbackChanges();
                 }
+                writeOp->ReleaseTxData(txc);
                 return EExecutionStatus::Continue;
             }
 
@@ -457,6 +484,13 @@ public:
             // Such transactions would have no participants and become immediately committed
             auto commitTxIds = userDb.GetVolatileCommitTxIds();
             if (commitTxIds || isArbiter) {
+                if (op->GetRemainReadSets()) {
+                    for (const auto& [key, received] : inReadSets) {
+                        if (received.empty()) {
+                            awaitingDecisions.insert(key.first);
+                        }
+                    }
+                }
                 TVector<ui64> participants(awaitingDecisions.begin(), awaitingDecisions.end());
                 DataShard.GetVolatileTxManager().PersistAddVolatileTx(
                     userDb.GetVolatileTxId(),
@@ -467,6 +501,7 @@ public:
                     userDb.GetChangeGroup(),
                     userDb.GetVolatileCommitOrdered(),
                     isArbiter,
+                    /* disable expectations */ !participants.empty() && !op->HasVolatilePrepareFlag(),
                     txc
                 );
             } else {
@@ -484,8 +519,15 @@ public:
                         DataShard.SendReadSetExpectation(ctx, op->GetStep(), op->GetTxId(), tabletId, target);
                     }
                 }
+            }
+
+            if (!op->IsImmediate() && !keepOutReadSets) {
+                if (op->OutReadSets().empty() && !op->HasVolatilePrepareFlag()) {
+                    KqpFillOutReadSets(outReadSets, kqpLocks, NKikimrTx::TReadSetData::DECISION_COMMIT, tabletId);
+                }
                 if (!op->OutReadSets().empty()) {
                     DataShard.PrepareAndSaveOutReadSets(op->GetStep(), op->GetTxId(), op->OutReadSets(), op->PreparedOutReadSets(), txc, ctx);
+                    preparedOutReadSets = true;
                 }
                 keepOutReadSets = true;
             }
@@ -540,21 +582,38 @@ public:
                 );
             }
 
-            writeOp->ReleaseTxData(txc);
-
             // Transaction may have made some changes before it hit the limit,
             // so we need to roll them back.
             if (txc.DB.HasChanges()) {
                 txc.DB.RollbackChanges();
             }
+
+            if (auto status = ensureAbortOutReadSets()) {
+                return *status;
+            }
+
+            writeOp->ReleaseTxData(txc);
             return EExecutionStatus::Executed;
         } catch (const TUniqueConstrainException&) {
-            return OnUniqueConstrainException(userDb, *writeOp, txc, ctx);
+            if (!OnUniqueConstrainException(userDb, *writeOp, txc, ctx)) {
+                return EExecutionStatus::Continue;
+            }
+
+            if (auto status = ensureAbortOutReadSets()) {
+                return *status;
+            }
+
+            writeOp->ReleaseTxData(txc);
+            return EExecutionStatus::Executed;
         } catch (const TKeySizeConstraintException&) {
             writeOp->SetError(NKikimrDataEvents::TEvWriteResult::STATUS_CONSTRAINT_VIOLATION, TStringBuilder() << "Size of key in secondary index is more than " << NLimits::MaxWriteKeySize);
             txc.DB.RollbackChanges();
             LOG_ERROR_S(ctx, NKikimrDataEvents::TEvWriteResult::STATUS_CONSTRAINT_VIOLATION, "Operation " << *writeOp << " at " << DataShard.TabletID() << " aborting. Size of key of secondary index is too big.");
-                
+
+            if (auto status = ensureAbortOutReadSets()) {
+                return *status;
+            }
+
             return EExecutionStatus::Executed;
         }
 
@@ -566,7 +625,7 @@ public:
             op->SetWaitCompletionFlag(true);
         }
 
-        if (op->HasVolatilePrepareFlag() && !op->PreparedOutReadSets().empty()) {
+        if (preparedOutReadSets && !op->PreparedOutReadSets().empty()) {
             return EExecutionStatus::DelayCompleteNoMoreRestarts;
         }
 
@@ -574,7 +633,7 @@ public:
     }
 
     void Complete(TOperation::TPtr op, const TActorContext& ctx) override {
-        if (op->HasVolatilePrepareFlag() && !op->PreparedOutReadSets().empty()) {
+        if (!op->PreparedOutReadSets().empty()) {
             DataShard.SendReadSets(ctx, std::move(op->PreparedOutReadSets()));
         }
     }

--- a/ydb/core/tx/datashard/execution_unit.cpp
+++ b/ydb/core/tx/datashard/execution_unit.cpp
@@ -76,6 +76,10 @@ THolder<TExecutionUnit> CreateExecutionUnit(EExecutionUnitKind kind,
         return CreatePrepareDistributedEraseTxInRSUnit(dataShard, pipeline);
     case EExecutionUnitKind::LoadAndWaitInRS:
         return CreateLoadAndWaitInRSUnit(dataShard, pipeline);
+    case EExecutionUnitKind::LoadInRS:
+        return CreateLoadInRSUnit(dataShard, pipeline);
+    case EExecutionUnitKind::BlockFailPoint:
+        return CreateBlockFailPointUnit(dataShard, pipeline);
     case EExecutionUnitKind::ExecuteDataTx:
         return CreateExecuteDataTxUnit(dataShard, pipeline);
     case EExecutionUnitKind::ExecuteKqpDataTx:

--- a/ydb/core/tx/datashard/execution_unit_ctors.h
+++ b/ydb/core/tx/datashard/execution_unit_ctors.h
@@ -38,6 +38,8 @@ THolder<TExecutionUnit> CreatePrepareKqpDataTxInRSUnit(TDataShard &dataShard, TP
 THolder<TExecutionUnit> CreatePrepareWriteTxInRSUnit(TDataShard& dataShard, TPipeline& pipeline);
 THolder<TExecutionUnit> CreatePrepareDistributedEraseTxInRSUnit(TDataShard& dataShard, TPipeline& pipeline);
 THolder<TExecutionUnit> CreateLoadAndWaitInRSUnit(TDataShard &dataShard, TPipeline &pipeline);
+THolder<TExecutionUnit> CreateLoadInRSUnit(TDataShard &dataShard, TPipeline &pipeline);
+THolder<TExecutionUnit> CreateBlockFailPointUnit(TDataShard &dataShard, TPipeline &pipeline);
 THolder<TExecutionUnit> CreateExecuteDataTxUnit(TDataShard &dataShard, TPipeline &pipeline);
 THolder<TExecutionUnit> CreateExecuteWriteUnit(TDataShard& dataShard, TPipeline& pipeline);
 THolder<TExecutionUnit> CreateExecuteKqpDataTxUnit(TDataShard& dataShard, TPipeline& pipeline);

--- a/ydb/core/tx/datashard/execution_unit_kind.h
+++ b/ydb/core/tx/datashard/execution_unit_kind.h
@@ -39,6 +39,8 @@ enum class EExecutionUnitKind: ui32 {
     PrepareWriteTxInRS,
     PrepareDistributedEraseTxInRS,
     LoadAndWaitInRS,
+    LoadInRS,
+    BlockFailPoint,
     ExecuteDataTx,
     ExecuteKqpDataTx,
     ExecuteDistributedEraseTx,

--- a/ydb/core/tx/datashard/load_in_rs_unit.cpp
+++ b/ydb/core/tx/datashard/load_in_rs_unit.cpp
@@ -1,0 +1,71 @@
+#include "datashard_impl.h"
+#include "datashard_pipeline.h"
+#include "execution_unit_ctors.h"
+
+namespace NKikimr {
+namespace NDataShard {
+
+using namespace NMiniKQL;
+
+class TLoadInRSUnit : public TExecutionUnit {
+public:
+    TLoadInRSUnit(TDataShard &dataShard,
+                         TPipeline &pipeline);
+    ~TLoadInRSUnit() override;
+
+    bool IsReadyToExecute(TOperation::TPtr op) const override;
+    EExecutionStatus Execute(TOperation::TPtr op,
+                             TTransactionContext &txc,
+                             const TActorContext &ctx) override;
+    void Complete(TOperation::TPtr op,
+                  const TActorContext &ctx) override;
+
+private:
+};
+
+TLoadInRSUnit::TLoadInRSUnit(TDataShard &dataShard,
+                                           TPipeline &pipeline)
+    : TExecutionUnit(EExecutionUnitKind::LoadInRS, true, dataShard, pipeline)
+{
+}
+
+TLoadInRSUnit::~TLoadInRSUnit()
+{
+}
+
+bool TLoadInRSUnit::IsReadyToExecute(TOperation::TPtr) const
+{
+    return true;
+}
+
+EExecutionStatus TLoadInRSUnit::Execute(TOperation::TPtr op,
+                                               TTransactionContext &txc,
+                                               const TActorContext &ctx)
+{
+    if (op->InReadSets().empty())
+        return EExecutionStatus::Executed;
+
+    // Load read sets from local database.
+    if (!op->HasLoadedInRSFlag()) {
+        if (!Pipeline.LoadInReadSets(op, txc, ctx))
+            return EExecutionStatus::Restart;
+
+        Y_ENSURE(op->HasLoadedInRSFlag());
+    }
+
+    return EExecutionStatus::Executed;
+}
+
+void TLoadInRSUnit::Complete(TOperation::TPtr,
+                                    const TActorContext &)
+{
+}
+
+THolder<TExecutionUnit> CreateLoadInRSUnit(TDataShard &dataShard,
+                                                  TPipeline &pipeline)
+{
+    return THolder(new TLoadInRSUnit(dataShard, pipeline));
+}
+
+} // namespace NDataShard
+} // namespace NKikimr

--- a/ydb/core/tx/datashard/operation.cpp
+++ b/ydb/core/tx/datashard/operation.cpp
@@ -65,7 +65,7 @@ void TOperation::AddInReadSet(const TReadSetKey &rsKey,
             LOG_TRACE_S(TActivationContext::AsActorContext(), NKikimrServices::TX_DATASHARD,
                         "Filled readset for " << *this << " from=" << rsKey.From
                         << " to=" << rsKey.To << "origin=" << rsKey.Origin);
-            InReadSets()[it->first].emplace_back(TRSData(readSet, rsKey.Origin));
+            InReadSets()[it->first].emplace_back(TRSData{ std::move(readSet), rsKey.Origin });
             if (it->second->IsComplete()) {
                 Y_ENSURE(InputDataRef().RemainReadSets > 0, "RemainReadSets counter underflow");
                 --InputDataRef().RemainReadSets;

--- a/ydb/core/tx/datashard/operation.h
+++ b/ydb/core/tx/datashard/operation.h
@@ -452,12 +452,6 @@ private:
 struct TRSData {
     TString Body;
     ui64 Origin = 0;
-
-    explicit TRSData(const TString &body = TString(),
-                     ui64 origin = 0)
-        : Body(body)
-        , Origin(origin)
-    {}
 };
 
 struct TInputOpData {

--- a/ydb/core/tx/datashard/volatile_tx.cpp
+++ b/ydb/core/tx/datashard/volatile_tx.cpp
@@ -518,6 +518,7 @@ namespace NKikimr::NDataShard {
             std::optional<ui64> changeGroup,
             bool commitOrdered,
             bool isArbiter,
+            bool disableExpectations,
             TTransactionContext& txc)
     {
         using Schema = TDataShard::Schema;
@@ -540,6 +541,7 @@ namespace NKikimr::NDataShard {
         info->CommitOrder = NextCommitOrder++;
         info->CommitOrdered = commitOrdered;
         info->IsArbiter = isArbiter;
+        info->DisableExpectations = disableExpectations;
 
         if (info->Participants.empty()) {
             // Transaction is committed when we don't have to wait for other participants

--- a/ydb/core/tx/datashard/volatile_tx.h
+++ b/ydb/core/tx/datashard/volatile_tx.h
@@ -232,6 +232,7 @@ namespace NKikimr::NDataShard {
             std::optional<ui64> changeGroup,
             bool commitOrdered,
             bool isArbiter,
+            bool disableExpectations,
             TTransactionContext& txc);
 
         bool AttachVolatileTxCallback(

--- a/ydb/core/tx/datashard/ya.make
+++ b/ydb/core/tx/datashard/ya.make
@@ -43,6 +43,7 @@ SRCS(
     create_incremental_restore_src_unit.cpp
     create_table_unit.cpp
     create_volatile_snapshot_unit.cpp
+    block_fail_point_unit.cpp
     datashard.cpp
     datashard.h
     datashard__cancel_tx_proposal.cpp
@@ -167,6 +168,7 @@ SRCS(
     key_conflicts.h
     key_validator.cpp
     load_and_wait_in_rs_unit.cpp
+    load_in_rs_unit.cpp
     load_tx_details_unit.cpp
     load_write_details_unit.cpp
     make_scan_snapshot_unit.cpp


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

...

### Changelog category <!-- remove all except one -->

* Not for changelog (changelog entry is not required)

### Description for reviewers <!-- (optional) description for those who read this PR -->

Currently non-volatile distributed write transactions may be used when OLTP tables are used with topics and/or OLAP tables. However such transactions are not resilient to aborts caused by non-lock related errors (e.g. duplicate keys and other data validation errors), because lock validation decides the transaction outcome too early.

Always use volatile execution for such distributed transactions in DataShards, which makes sure lock validation and decision calculation is atomic with regards to an actual execution. This doesn't change how transaction protocol works for other participants, this change is strictly local to datashards.

Additionally stop persisting small (up to 8 bytes) incoming readsets on disk, and make sure volatile transactions generate outgoing readsets on aborts (this was mostly an accident, since writes started to generate OutReadSets on abort, which showed that volatile transactions may have been unnecessarily delayed on abort before this change).

Fixes #19525.