### PR TITLE
schemeshard ut: fix use-after-free in IndexBuildTest.RejectsOnDuplicatesUniq

### DIFF
--- a/ydb/core/tx/schemeshard/ut_index_build/ut_index_build.cpp
+++ b/ydb/core/tx/schemeshard/ut_index_build/ut_index_build.cpp
@@ -1449,6 +1449,7 @@ Y_UNIT_TEST_SUITE(IndexBuildTest) {
         const ui32 cols = 4;
         TVector<TCell> cells;
         cells.reserve(totalRows * cols);
+        TDeque<TString> storage; // appending values to deque does not invalidate references
         auto addRow = [&](ui32 key, std::optional<ui32> index1, std::optional<ui32> index2, const TString& value) {
             cells.emplace_back(TCell::Make<ui32>(key));
 
@@ -1464,7 +1465,8 @@ Y_UNIT_TEST_SUITE(IndexBuildTest) {
                 cells.emplace_back(TCell());
             }
 
-            cells.emplace_back(TCell(value.c_str(), value.size()));
+            auto& storedValue = storage.emplace_back(value);
+            cells.emplace_back(TCell(storedValue.c_str(), storedValue.size()));
 
             UNIT_ASSERT_VALUES_EQUAL(cells.size() % cols, 0);
         };


### PR DESCRIPTION
TCell stores pointers to TString that will be freed upon end-of-statement
(Noticed in asan CI error)

### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

...

### Changelog category <!-- remove all except one -->

* Not for changelog (changelog entry is not required)

### Description for reviewers <!-- (optional) description for those who read this PR -->

...
