### PR TITLE
Use ordered set to preserve the relative order of splitted partitions ids

### DIFF
--- a/ydb/core/persqueue/ut/ut_with_sdk/autoscaling_ut.cpp
+++ b/ydb/core/persqueue/ut/ut_with_sdk/autoscaling_ut.cpp
@@ -1404,6 +1404,80 @@ Y_UNIT_TEST_SUITE(TopicAutoscaling) {
         ReadFromTimestamp(SdkVersion::PQv1, false);
     }
 
+    void OrderOfChildrenPartitions(SdkVersion sdk) {
+        const size_t partitionsCount = 32;
+        TTopicSdkTestSetup setup = CreateSetup();
+        setup.CreateTopicWithAutoscale(TEST_TOPIC, TEST_CONSUMER, partitionsCount, partitionsCount * 2);
+
+        TTopicClient client = setup.MakeClient();
+
+        auto readSession = CreateTestReadSession({.Name = "Session-0", .Setup = setup, .Sdk = sdk, .ExpectedMessagesCount = partitionsCount * 2, .AutoCommit = true, .Partitions = {}, .AutoPartitioningSupport = true});
+        readSession->Run();
+
+        for (ui32 p = 0; p < partitionsCount; ++p) {
+            for (ui32 sub = 1; sub <= 2; ++sub) {
+                TString name = TStringBuilder() << "producer-" << p << "-" << sub;
+                const ui64 seqNo = p * 2 + sub;
+                auto writeSession = CreateWriteSession(client, name, p, TString{TEST_TOPIC}, false);
+                writeSession->Write(Msg(name, seqNo));
+                writeSession->Close();
+            }
+        }
+        {
+            ui64 txId = 1006;
+            ::NKikimrSchemeOp::TPersQueueGroupDescription scheme;
+            scheme.SetName(TString{TEST_TOPIC});
+            for (ui32 partition = 0; partition < partitionsCount; ++partition) {
+                TString boundary(1, char(partition * (256 / partitionsCount) + (128 / partitionsCount)));
+                auto* split = scheme.AddSplit();
+                split->SetPartition(partition);
+                split->SetSplitBoundary(boundary);
+            }
+            DoRequest(setup.GetRuntime(), txId, scheme);
+        }
+
+        auto describe = client.DescribeTopic(TEST_TOPIC).GetValueSync();
+        UNIT_ASSERT_VALUES_EQUAL(describe.GetTopicDescription().GetPartitions().size(), partitionsCount * 3);
+        THashMap<ui32, const NYdb::NTopic::TPartitionInfo*> partitions;
+        for (const auto& p : describe.GetTopicDescription().GetPartitions()) {
+            partitions[p.GetPartitionId()] = &p;
+        }
+
+        readSession->WaitAllMessages();
+        std::vector<EvEndMsg> events = readSession->GetEndedPartitionEvents();
+        UNIT_ASSERT_VALUES_EQUAL(events.size(), partitionsCount);
+
+        for (const EvEndMsg& ev : events) {
+            UNIT_ASSERT_VALUES_EQUAL(ev.ChildPartitionIds.size(), 2);
+            ui32 u = ev.ChildPartitionIds.at(0);
+            ui32 v = ev.ChildPartitionIds.at(1);
+
+            const TPartitionInfo& pu = *partitions.at(u);
+            const TPartitionInfo& pv = *partitions.at(v);
+
+            auto toHex = [](const TStringBuf value) -> TString {
+                return TStringBuilder() << HexText(value);
+            };
+            auto boundToString = [&toHex](const std::optional<std::string>& b) -> TString {
+                if (b.has_value()) {
+                    return toHex(*b).Quote();
+                }
+                return "none";
+            };
+            auto partitionInfoToString = [&boundToString](const TPartitionInfo& p) -> TString {
+                return TStringBuilder() << "Partition: " << p.GetPartitionId() << "; Bounds: " << boundToString(p.GetFromBound()) << "-" << boundToString(p.GetToBound());
+            };
+
+            TString dataRepr = TStringBuilder() << "First child: #" << partitionInfoToString(pu)
+                << "; Second child: " << partitionInfoToString(pv);
+            UNIT_ASSERT_EQUAL_C(pu.GetToBound(), pv.GetFromBound(), dataRepr);
+        }
+        readSession->Close();
+    }
+
+    Y_UNIT_TEST(OrderOfChildrenPartitions_Topic) {
+        OrderOfChildrenPartitions(SdkVersion::Topic);
+    }
 }
 
 } // namespace NKikimr

--- a/ydb/core/tx/schemeshard/schemeshard_impl.cpp
+++ b/ydb/core/tx/schemeshard/schemeshard_impl.cpp
@@ -3128,8 +3128,8 @@ void TSchemeShard::PersistPersQueue(NIceDb::TNiceDb &db, TPathId pathId, TShardI
 
     Y_ABORT_UNLESS(partitionInfo.ParentPartitionIds.size() <= 2);
     auto it = partitionInfo.ParentPartitionIds.begin();
-    const auto parent = it != partitionInfo.ParentPartitionIds.end() ? (it++).cur->val : Max<ui32>();
-    const auto adjacentParent = it != partitionInfo.ParentPartitionIds.end() ? (it++).cur->val : Max<ui32>();
+    const auto parent = it != partitionInfo.ParentPartitionIds.end() ? *(it++) : Max<ui32>();
+    const auto adjacentParent = it != partitionInfo.ParentPartitionIds.end() ? *(it++) : Max<ui32>();
 
     db.Table<Schema::PersQueues>()
         .Key(pathId.LocalPathId, partitionInfo.PqId)

--- a/ydb/core/tx/schemeshard/schemeshard_info_types.h
+++ b/ydb/core/tx/schemeshard/schemeshard_info_types.h
@@ -51,6 +51,7 @@
 #include <util/generic/guid.h>
 #include <util/generic/ptr.h>
 #include <util/generic/queue.h>
+#include <util/generic/set.h>
 #include <util/generic/vector.h>
 
 namespace NKikimr {
@@ -998,8 +999,8 @@ struct TTopicTabletInfo : TSimpleRefCount<TTopicTabletInfo> {
         // Split and merge operations form the partitions graph. Each partition created in this way has a parent
         // partition. In turn, the parent partition knows about the partitions formed after the split and merge
         // operations.
-        THashSet<ui32> ParentPartitionIds;
-        THashSet<ui32> ChildPartitionIds;
+        TSet<ui32> ParentPartitionIds;
+        TSet<ui32> ChildPartitionIds;
 
         TShardIdx ShardIdx;
 


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

Since schemeshard always creates new partition IDs in ascending order, we keep this order when serializing them.

### Changelog category <!-- remove all except one -->

* Not for changelog (changelog entry is not required)

### Description for reviewers <!-- (optional) description for those who read this PR -->

[KIKIMR-23621](https://st.yandex-team.ru/KIKIMR-23621?source_from=email&source_type=notification)
