### PR TITLE
Add scheme operations for secrets

### DIFF
--- a/ydb/core/protos/counters_schemeshard.proto
+++ b/ydb/core/protos/counters_schemeshard.proto
@@ -260,6 +260,11 @@ enum ESimpleCounters {
 
     COUNTER_IN_FLIGHT_OPS_TxIncrementalRestoreFinalize = 203 [(CounterOpts) = {Name: "InFlightOps/IncrementalRestoreFinalize"}];
     COUNTER_IN_FLIGHT_OPS_TxCreateLongIncrementalBackupOp = 204 [(CounterOpts) = {Name: "InFlightOps/CreateLongIncrementalBackupOp"}];
+
+    COUNTER_SECRET_COUNT = 205 [(CounterOpts) = {Name: "SecretCount"}];
+    COUNTER_IN_FLIGHT_OPS_TxCreateSecret = 206 [(CounterOpts) = {Name: "InFlightOps/CreateSecret"}];
+    COUNTER_IN_FLIGHT_OPS_TxAlterSecret = 207 [(CounterOpts) = {Name: "InFlightOps/AlterSecret"}];
+    COUNTER_IN_FLIGHT_OPS_TxDropSecret = 208 [(CounterOpts) = {Name: "InFlightOps/DropSecret"}];
 }
 
 enum ECumulativeCounters {
@@ -422,6 +427,10 @@ enum ECumulativeCounters {
 
     COUNTER_FINISHED_OPS_TxIncrementalRestoreFinalize = 125 [(CounterOpts) = {Name: "FinishedOps/IncrementalRestoreFinalize"}];
     COUNTER_FINISHED_OPS_TxCreateLongIncrementalBackupOp = 126 [(CounterOpts) = {Name: "FinishedOps/CreateLongIncrementalBackupOp"}];
+
+    COUNTER_FINISHED_OPS_TxCreateSecret = 127 [(CounterOpts) = {Name: "FinishedOps/CreateSecret"}];
+    COUNTER_FINISHED_OPS_TxAlterSecret = 128 [(CounterOpts) = {Name: "FinishedOps/AlterSecret"}];
+    COUNTER_FINISHED_OPS_TxDropSecret = 129 [(CounterOpts) = {Name: "FinishedOps/DropSecret"}];
 }
 
 enum EPercentileCounters {

--- a/ydb/core/protos/flat_scheme_op.proto
+++ b/ydb/core/protos/flat_scheme_op.proto
@@ -1896,6 +1896,10 @@ message TModifyScheme {
 
     optional TSetColumnConstraintsInitiate SetColumnConstraintsInitiate = 87;
 
+    // Secret
+    optional TSecretSchemaOp CreateSecret = 88;
+    optional TSecretSchemaOp AlterSecret = 89;
+
     // Some entries are grouped by semantics, so are out of order
 }
 
@@ -1965,6 +1969,7 @@ enum EPathType {
     EPathTypeBackupCollection = 22;
     EPathTypeTransfer = 23;
     EPathTypeSysView = 24;
+    EPathTypeSecret = 25;
 }
 
 enum EPathSubType {
@@ -2025,6 +2030,7 @@ message TPathVersion {
     optional uint64 ResourcePoolVersion = 30;
     optional uint64 BackupCollectionVersion = 31;
     optional uint64 SysViewVersion = 32;
+    optional uint64 SecretVersion = 33;
 }
 
 // Describes single path
@@ -2117,6 +2123,7 @@ message TPathDescription {
     optional TResourcePoolDescription ResourcePoolDescription = 30;
     optional TBackupCollectionDescription BackupCollectionDescription = 31;
     optional TSysViewDescription SysViewDescription = 32;
+    optional TSecretDescription SecretDescription = 33;
 }
 
 // For persisting AlterTable Tx description in Schemeshard internal DB
@@ -2349,4 +2356,16 @@ message TLongIncrementalRestoreOp {
 message TChangePathState {
     optional string Path = 1;
     optional EPathState TargetState = 2;
+}
+
+message TSecretDescription {
+    optional string Name = 1;
+    optional string Value = 2; // original, unencrypted value
+    optional uint64 Version = 3;
+}
+
+message TSecretSchemaOp {
+    optional string Name = 1;
+    optional string Value = 2; // original, unencrypted value
+    optional bool InheritPermissions = 3;
 }

--- a/ydb/core/protos/schemeshard/operations.proto
+++ b/ydb/core/protos/schemeshard/operations.proto
@@ -198,5 +198,10 @@ enum EOperationType {
     // Alter Table Alter Column Set
     ESchemeOpCreateSetConstraintInitiate = 126;
 
+    // Secret
+    ESchemeOpCreateSecret = 127;
+    ESchemeOpAlterSecret = 128;
+    ESchemeOpDropSecret = 129;
+
     // Some entries are grouped by semantics, so are out of order
 }

--- a/ydb/core/tx/scheme_board/cache.cpp
+++ b/ydb/core/tx/scheme_board/cache.cpp
@@ -242,6 +242,7 @@ namespace {
             entry.FileStoreInfo.Drop();
             entry.BackupCollectionInfo.Drop();
             entry.SysViewInfo.Drop();
+            entry.SecretInfo.Drop();
         }
 
         static void SetErrorAndClear(TResolveContext* context, TResolve::TEntry& entry, const bool isDescribeDenied) {
@@ -1647,6 +1648,10 @@ class TSchemeCache: public TMonitorableActor<TSchemeCache> {
                 }
                 FillInfo(Kind, SysViewInfo, std::move(*pathDesc.MutableSysViewDescription()));
                 break;
+            case NKikimrSchemeOp::EPathTypeSecret:
+                Kind = TNavigate::KindSecret;
+                FillInfo(Kind, SecretInfo, std::move(*pathDesc.MutableSecretDescription()));
+                break;
             case NKikimrSchemeOp::EPathTypeInvalid:
                 Y_DEBUG_ABORT("Invalid path type");
                 break;
@@ -1728,6 +1733,9 @@ class TSchemeCache: public TMonitorableActor<TSchemeCache> {
                         break;
                     case NKikimrSchemeOp::EPathTypeSysView:
                         ListNodeEntry->Children.emplace_back(name, pathId, TNavigate::KindSysView);
+                        break;
+                    case NKikimrSchemeOp::EPathTypeSecret:
+                        ListNodeEntry->Children.emplace_back(name, pathId, TNavigate::KindSecret);
                         break;
                     case NKikimrSchemeOp::EPathTypeTableIndex:
                     case NKikimrSchemeOp::EPathTypeInvalid:
@@ -1960,6 +1968,7 @@ class TSchemeCache: public TMonitorableActor<TSchemeCache> {
             entry.ResourcePoolInfo = ResourcePoolInfo;
             entry.BackupCollectionInfo = BackupCollectionInfo;
             entry.SysViewInfo = SysViewInfo;
+            entry.SecretInfo = SecretInfo;
             entry.TableKind = TableKind;
         }
 
@@ -2266,6 +2275,9 @@ class TSchemeCache: public TMonitorableActor<TSchemeCache> {
 
         // SysView specific
         TIntrusivePtr<TNavigate::TSysViewInfo> SysViewInfo;
+
+        // Secret specific
+        TIntrusivePtr<TNavigate::TSecretInfo> SecretInfo;
 
     }; // TCacheItem
 

--- a/ydb/core/tx/scheme_board/cache.cpp
+++ b/ydb/core/tx/scheme_board/cache.cpp
@@ -763,6 +763,7 @@ class TSchemeCache: public TMonitorableActor<TSchemeCache> {
             ResourcePoolInfo.Drop();
             BackupCollectionInfo.Drop();
             SysViewInfo.Drop();
+            SecretInfo.Drop();
         }
 
         void FillTableInfo(const NKikimrSchemeOp::TPathDescription& pathDesc) {
@@ -1300,6 +1301,7 @@ class TSchemeCache: public TMonitorableActor<TSchemeCache> {
             DESCRIPTION_PART(ResourcePoolInfo);
             DESCRIPTION_PART(BackupCollectionInfo);
             DESCRIPTION_PART(SysViewInfo);
+            DESCRIPTION_PART(SecretInfo);
 
             #undef DESCRIPTION_PART
 

--- a/ydb/core/tx/scheme_cache/scheme_cache.h
+++ b/ydb/core/tx/scheme_cache/scheme_cache.h
@@ -203,6 +203,7 @@ struct TSchemeCacheNavigate {
         KindBackupCollection = 23,
         KindTransfer = 24,
         KindSysView = 25,
+        KindSecret = 26,
     };
 
     struct TListNodeEntry : public TAtomicRefCount<TListNodeEntry> {
@@ -329,6 +330,11 @@ struct TSchemeCacheNavigate {
         NKikimrSchemeOp::TSysViewDescription Description;
     };
 
+    struct TSecretInfo : public TAtomicRefCount<TSecretInfo> {
+        EKind Kind = KindUnknown;
+        NKikimrSchemeOp::TSecretDescription Description;
+    };
+
     struct TEntry {
         enum class ERequestType : ui8 {
             ByPath,
@@ -385,6 +391,7 @@ struct TSchemeCacheNavigate {
         TIntrusiveConstPtr<TResourcePoolInfo> ResourcePoolInfo;
         TIntrusiveConstPtr<TBackupCollectionInfo> BackupCollectionInfo;
         TIntrusiveConstPtr<TSysViewInfo> SysViewInfo;
+        TIntrusiveConstPtr<TSecretInfo> SecretInfo;
 
         TString ToString() const;
         TString ToString(const NScheme::TTypeRegistry& typeRegistry) const;

--- a/ydb/core/tx/schemeshard/schemeshard__op_traits.cpp
+++ b/ydb/core/tx/schemeshard/schemeshard__op_traits.cpp
@@ -46,6 +46,7 @@ EOperationClass GetOperationClass(NKikimrSchemeOp::EOperationType op) {
         case NKikimrSchemeOp::EOperationType::ESchemeOpMoveSequence:
         case NKikimrSchemeOp::EOperationType::ESchemeOpCreateTransfer:
         case NKikimrSchemeOp::EOperationType::ESchemeOpCreateSysView:
+        case NKikimrSchemeOp::EOperationType::ESchemeOpCreateSecret:
             return EOperationClass::Create;
 
         // Simple operations that drop paths
@@ -79,6 +80,7 @@ EOperationClass GetOperationClass(NKikimrSchemeOp::EOperationType op) {
         case NKikimrSchemeOp::EOperationType::ESchemeOpDropTransfer:
         case NKikimrSchemeOp::EOperationType::ESchemeOpDropTransferCascade:
         case NKikimrSchemeOp::EOperationType::ESchemeOpDropSysView:
+        case NKikimrSchemeOp::EOperationType::ESchemeOpDropSecret:
             return EOperationClass::Drop;
 
         // Simple operations that alter paths
@@ -106,6 +108,7 @@ EOperationClass GetOperationClass(NKikimrSchemeOp::EOperationType op) {
         case NKikimrSchemeOp::EOperationType::ESchemeOpAlterContinuousBackup:
         case NKikimrSchemeOp::EOperationType::ESchemeOpAlterBackupCollection:
         case NKikimrSchemeOp::EOperationType::ESchemeOpAlterTransfer:
+        case NKikimrSchemeOp::EOperationType::ESchemeOpAlterSecret:
             return EOperationClass::Alter;
 
         // Compound or special operations

--- a/ydb/core/tx/schemeshard/schemeshard__op_traits.h
+++ b/ydb/core/tx/schemeshard/schemeshard__op_traits.h
@@ -187,6 +187,13 @@ struct TSchemeTxTraits<NKikimrSchemeOp::EOperationType::ESchemeOpCreateReplicati
     constexpr inline static bool CreateDirsFromName = true;
 };
 
+template <>
+struct TSchemeTxTraits<NKikimrSchemeOp::EOperationType::ESchemeOpCreateSecret>
+    : public TSchemeTxTraitsFallback
+{
+    constexpr inline static bool CreateDirsFromName = true;
+};
+
 namespace NOperation {
 
 template <class TTraits>

--- a/ydb/core/tx/schemeshard/schemeshard__operation.cpp
+++ b/ydb/core/tx/schemeshard/schemeshard__operation.cpp
@@ -1284,6 +1284,14 @@ ISubOperation::TPtr TOperation::RestorePart(TTxState::ETxType txType, TTxState::
     case TTxState::ETxType::TxCreateLongIncrementalBackupOp:
         return CreateLongIncrementalBackupOp(NextPartId(), txState);
 
+    // Secret
+    case TTxState::ETxType::TxCreateSecret:
+        return CreateNewSecret(NextPartId(), txState);
+    case TTxState::ETxType::TxAlterSecret:
+        return CreateAlterSecret(NextPartId(), txState);
+    case TTxState::ETxType::TxDropSecret:
+        return CreateDropSecret(NextPartId(), txState);
+
     case TTxState::ETxType::TxInvalid:
         Y_UNREACHABLE();
     }
@@ -1609,6 +1617,14 @@ TVector<ISubOperation::TPtr> TDefaultOperationFactory::MakeOperationParts(
     // Incremental Restore Finalization
     case NKikimrSchemeOp::EOperationType::ESchemeOpIncrementalRestoreFinalize:
         return {CreateIncrementalRestoreFinalize(op.NextPartId(), tx)};
+
+    // Secret
+    case NKikimrSchemeOp::EOperationType::ESchemeOpCreateSecret:
+        return {CreateNewSecret(op.NextPartId(), tx)};
+    case NKikimrSchemeOp::EOperationType::ESchemeOpAlterSecret:
+        return {CreateAlterSecret(op.NextPartId(), tx)};
+    case NKikimrSchemeOp::EOperationType::ESchemeOpDropSecret:
+        return {CreateDropSecret(op.NextPartId(), tx)};
     }
 
     Y_UNREACHABLE();

--- a/ydb/core/tx/schemeshard/schemeshard__operation_alter_secret.cpp
+++ b/ydb/core/tx/schemeshard/schemeshard__operation_alter_secret.cpp
@@ -177,6 +177,14 @@ public:
             return result;
         }
 
+        context.MemChanges.GrabPath(context.SS, secretPath.Base()->PathId);
+        context.MemChanges.GrabSecret(context.SS, secretPath.Base()->PathId);
+        context.MemChanges.GrabNewTxState(context.SS, OperationId);
+
+        context.DbChanges.PersistPath(secretPath.Base()->PathId);
+        context.DbChanges.PersistAlterSecret(secretPath.Base()->PathId);
+        context.DbChanges.PersistTxState(OperationId);
+
         auto alterData = secretInfo->CreateNextVersion();
         alterData->Description.SetValue(alterSecretProto.GetValue());
         alterData->Description.SetVersion(secretInfo->AlterVersion);

--- a/ydb/core/tx/schemeshard/schemeshard__operation_alter_secret.cpp
+++ b/ydb/core/tx/schemeshard/schemeshard__operation_alter_secret.cpp
@@ -1,0 +1,230 @@
+#include "schemeshard__operation_common.h"
+#include "schemeshard__operation_part.h"
+#include "schemeshard_impl.h"
+
+#define LOG_N(stream) LOG_NOTICE_S(context.Ctx, NKikimrServices::FLAT_TX_SCHEMESHARD, "[" << context.SS->SelfTabletId() << "] " << stream)
+#define LOG_I(stream) LOG_INFO_S  (context.Ctx, NKikimrServices::FLAT_TX_SCHEMESHARD, "[" << context.SS->SelfTabletId() << "] " << stream)
+#define LOG_D(stream) LOG_DEBUG_S (context.Ctx, NKikimrServices::FLAT_TX_SCHEMESHARD, "[" << context.SS->SelfTabletId() << "] " << stream)
+
+namespace {
+
+using namespace NKikimr;
+using namespace NSchemeShard;
+
+class TPropose: public TSubOperationState {
+private:
+    TOperationId OperationId;
+
+    TString DebugHint() const override {
+        return TStringBuilder()
+            << "TAlterSecret TPropose"
+            << " operationId# " << OperationId;
+    }
+
+public:
+    explicit TPropose(TOperationId id)
+        : OperationId(id)
+    {
+    }
+
+    bool ProgressState(TOperationContext& context) override {
+        LOG_I(DebugHint() << " ProgressState");
+
+        const auto* txState = context.SS->FindTx(OperationId);
+        Y_ABORT_UNLESS(txState);
+        Y_ABORT_UNLESS(txState->TxType == TTxState::TxAlterSecret);
+
+        context.OnComplete.ProposeToCoordinator(OperationId, txState->TargetPathId, TStepId(0));
+        return false;
+    }
+
+    bool HandleReply(TEvPrivate::TEvOperationPlan::TPtr& ev, TOperationContext& context) override {
+        const auto step = TStepId(ev->Get()->StepId);
+
+        LOG_I(DebugHint() << "HandleReply TEvOperationPlan" << ": step# " << step);
+
+        const auto* txState = context.SS->FindTx(OperationId);
+        Y_ABORT_UNLESS(txState);
+        Y_ABORT_UNLESS(txState->TxType == TTxState::TxAlterSecret);
+        const auto& secretPathId = txState->TargetPathId;
+
+        Y_ABORT_UNLESS(context.SS->PathsById.contains(secretPathId));
+        auto secretPath = context.SS->PathsById.at(secretPathId);
+
+        Y_ABORT_UNLESS(context.SS->Secrets.contains(secretPathId));
+        const auto secretInfo = context.SS->Secrets.at(secretPathId);
+
+        auto alterData = secretInfo->AlterData;
+        Y_ABORT_UNLESS(alterData);
+        Y_ABORT_UNLESS(secretInfo->Description.GetVersion() + 1 == alterData->Description.GetVersion());
+
+        NIceDb::TNiceDb db(context.GetDB());
+        context.SS->Secrets[secretPathId] = alterData;
+        context.SS->PersistSecretAlterRemove(db, secretPathId);
+        context.SS->PersistSecret(db, secretPathId, *alterData);
+
+        context.SS->ClearDescribePathCaches(secretPath);
+        context.OnComplete.PublishToSchemeBoard(OperationId, secretPathId);
+
+        context.SS->ChangeTxState(db, OperationId, TTxState::Done);
+        return true;
+    }
+};
+
+class TAlterSecret: public TSubOperation {
+    static TTxState::ETxState NextState() {
+        return TTxState::Propose;
+    }
+
+    TTxState::ETxState NextState(TTxState::ETxState state) const override {
+        switch (state) {
+        case TTxState::Propose:
+            return TTxState::Done;
+        default:
+            return TTxState::Invalid;
+        }
+    }
+
+    TSubOperationState::TPtr SelectStateFunc(TTxState::ETxState state) override {
+        switch (state) {
+        case TTxState::Propose:
+            return MakeHolder<TPropose>(OperationId);
+        case TTxState::Done:
+            return MakeHolder<TDone>(OperationId);
+        default:
+            return nullptr;
+        }
+    }
+
+public:
+    using TSubOperation::TSubOperation;
+
+    THolder<TProposeResponse> Propose(const TString&, TOperationContext& context) override {
+        const TTabletId ssId = context.SS->SelfTabletId();
+
+        const auto& alterSecretProto = Transaction.GetAlterSecret();
+
+        const TString& parentPathStr = Transaction.GetWorkingDir();
+        const TString& secretName = alterSecretProto.GetName();
+
+        LOG_N("TAlterSecret Propose"
+            << ", path: " << parentPathStr << "/" << secretName
+            << ", opId: " << OperationId
+        );
+
+        auto result = MakeHolder<TProposeResponse>(NKikimrScheme::StatusAccepted, ui64(OperationId.GetTxId()), ui64(ssId));
+
+        if (!Transaction.HasAlterSecret()) {
+            result->SetError(NKikimrScheme::StatusInvalidParameter, "AlterSecret is not present");
+            return result;
+        }
+
+        NSchemeShard::TPath parentPath = NSchemeShard::TPath::Resolve(parentPathStr, context.SS);
+        NSchemeShard::TPath secretPath = parentPath.Child(secretName);
+        {
+            NSchemeShard::TPath::TChecker checks = parentPath.Check();
+            checks
+                .NotUnderDomainUpgrade()
+                .IsAtLocalSchemeShard()
+                .IsResolved()
+                .NotDeleted()
+                .NotUnderDeleting()
+                .IsCommonSensePath()
+                .IsDirectory();
+
+            if (!checks) {
+                result->SetError(checks.GetStatus(), checks.GetError());
+                return result;
+            }
+        }
+
+        {
+            NSchemeShard::TPath::TChecker checks = secretPath.Check();
+            checks
+                .IsResolved()
+                .NotDeleted()
+                .NotUnderDeleting()
+                .IsSecret();
+
+            if (!checks) {
+                result->SetError(checks.GetStatus(), checks.GetError());
+                if (secretPath.IsResolved()) {
+                    result->SetPathCreateTxId(ui64(secretPath.Base()->CreateTxId));
+                    result->SetPathId(secretPath.Base()->PathId.LocalPathId);
+                }
+                return result;
+            }
+        }
+
+        result->SetPathId(secretPath.Base()->PathId.LocalPathId);
+
+        TString errStr;
+        if (!context.SS->CheckLocks(parentPath.Base()->PathId, Transaction, errStr)) {
+            result->SetError(NKikimrScheme::StatusMultipleModifications, errStr);
+            return result;
+        }
+
+        Y_ABORT_UNLESS(context.SS->Secrets.contains(secretPath.Base()->PathId));
+        auto secretInfo = context.SS->Secrets.at(secretPath.Base()->PathId);
+
+        if (secretInfo->AlterVersion == 0) {
+            result->SetError(NKikimrScheme::StatusMultipleModifications, "Secret is not created yet");
+            return result;
+        }
+
+        if (secretInfo->AlterData) {
+            result->SetError(NKikimrScheme::StatusMultipleModifications, "There's another Alter in flight");
+            return result;
+        }
+
+        auto alterData = secretInfo->CreateNextVersion();
+        alterData->Description.SetValue(alterSecretProto.GetValue());
+        alterData->Description.SetVersion(secretInfo->AlterVersion);
+
+        Y_ABORT_UNLESS(!context.SS->FindTx(OperationId));
+        TTxState& txState = context.SS->CreateTx(OperationId, TTxState::TxAlterSecret, secretPath.Base()->PathId);
+        txState.State = TTxState::Propose;
+
+        secretPath.Base()->PathState = NKikimrSchemeOp::EPathStateAlter;
+        secretPath.Base()->LastTxId = OperationId.GetTxId();
+
+        NIceDb::TNiceDb db(context.GetDB());
+        context.SS->PersistSecretAlter(db, secretPath.Base()->PathId, *secretInfo->AlterData);
+        context.SS->PersistTxState(db, OperationId);
+
+        context.OnComplete.ActivateTx(OperationId);
+
+        SetState(NextState());
+        return result;
+    }
+
+    void AbortPropose(TOperationContext& context) override {
+        LOG_N("TAlterSecret AbortPropose"
+            << ", opId: " << OperationId
+        );
+    }
+
+    void AbortUnsafe(TTxId forceDropTxId, TOperationContext& context) override {
+        LOG_N("TAlterSecret AbortUnsafe"
+            << ", opId: " << OperationId
+            << ", forceDropId: " << forceDropTxId
+        );
+
+        context.OnComplete.DoneOperation(OperationId);
+    }
+};
+
+}
+
+namespace NKikimr::NSchemeShard {
+
+ISubOperation::TPtr CreateAlterSecret(TOperationId id, const TTxTransaction& tx) {
+    return MakeSubOperation<TAlterSecret>(id, tx);
+}
+
+ISubOperation::TPtr CreateAlterSecret(TOperationId id, TTxState::ETxState state) {
+    Y_ABORT_UNLESS(state != TTxState::Invalid);
+    return MakeSubOperation<TAlterSecret>(id, state);
+}
+
+}

--- a/ydb/core/tx/schemeshard/schemeshard__operation_create_secret.cpp
+++ b/ydb/core/tx/schemeshard/schemeshard__operation_create_secret.cpp
@@ -1,0 +1,297 @@
+#include "schemeshard__op_traits.h"
+#include "schemeshard__operation_common.h"
+#include "schemeshard__operation_part.h"
+#include "schemeshard_impl.h"
+
+#define LOG_N(stream) LOG_NOTICE_S(context.Ctx, NKikimrServices::FLAT_TX_SCHEMESHARD, "[" << context.SS->SelfTabletId() << "] " << stream)
+#define LOG_I(stream) LOG_INFO_S  (context.Ctx, NKikimrServices::FLAT_TX_SCHEMESHARD, "[" << context.SS->SelfTabletId() << "] " << stream)
+#define LOG_D(stream) LOG_DEBUG_S (context.Ctx, NKikimrServices::FLAT_TX_SCHEMESHARD, "[" << context.SS->SelfTabletId() << "] " << stream)
+
+namespace {
+
+using namespace NKikimr;
+using namespace NSchemeShard;
+
+class TPropose : public TSubOperationState {
+private:
+    const TOperationId OperationId;
+
+    TString DebugHint() const override {
+        return TStringBuilder()
+            << "TCreateSecret::TPropose"
+            << ", opId: " << OperationId;
+    }
+
+public:
+    explicit TPropose(TOperationId id)
+        : OperationId(id)
+    {
+    }
+
+    bool ProgressState(TOperationContext& context) override {
+        LOG_I(DebugHint() << " ProgressState");
+
+        const auto* txState = context.SS->FindTx(OperationId);
+        Y_ABORT_UNLESS(txState);
+        Y_ABORT_UNLESS(txState->TxType == TTxState::TxCreateSecret);
+
+        context.OnComplete.ProposeToCoordinator(OperationId, txState->TargetPathId, TStepId(0));
+        return false;
+    }
+
+    bool HandleReply(TEvPrivate::TEvOperationPlan::TPtr& ev, TOperationContext& context) override {
+        const auto step = TStepId(ev->Get()->StepId);
+
+        LOG_I(DebugHint() << "HandleReply TEvOperationPlan"
+            << ": step# " << step);
+
+        const auto* txState = context.SS->FindTx(OperationId);
+        Y_ABORT_UNLESS(txState);
+        Y_ABORT_UNLESS(txState->TxType == TTxState::TxCreateSecret);
+
+        context.SS->TabletCounters->Simple()[COUNTER_SECRET_COUNT].Add(1);
+
+        const auto& secretPathId = txState->TargetPathId;
+        Y_ABORT_UNLESS(context.SS->PathsById.contains(secretPathId));
+        auto secretPath = context.SS->PathsById.at(secretPathId);
+
+        Y_ABORT_UNLESS(context.SS->Secrets.contains(secretPathId));
+        auto secretInfo = context.SS->Secrets.at(secretPathId);
+
+        auto alterData = secretInfo->AlterData;
+        Y_ABORT_UNLESS(alterData);
+
+        NIceDb::TNiceDb db(context.GetDB());
+
+        secretPath->StepCreated = step;
+        context.SS->PersistCreateStep(db, secretPathId, step);
+
+        context.SS->Secrets[secretPathId] = alterData;
+        context.SS->PersistSecretAlterRemove(db, secretPathId);
+        context.SS->PersistSecret(db, secretPathId, *alterData);
+
+        Y_ABORT_UNLESS(context.SS->PathsById.contains(secretPath->ParentPathId));
+        auto parentPath = context.SS->PathsById.at(secretPath->ParentPathId);
+
+        ++parentPath->DirAlterVersion;
+        context.SS->PersistPathDirAlterVersion(db, parentPath);
+
+        context.SS->ClearDescribePathCaches(parentPath);
+        context.OnComplete.PublishToSchemeBoard(OperationId, parentPath->PathId);
+
+        context.SS->ClearDescribePathCaches(secretPath);
+        context.OnComplete.PublishToSchemeBoard(OperationId, secretPathId);
+
+        context.SS->ChangeTxState(db, OperationId, TTxState::Done);
+        return true;
+    }
+};
+
+class TCreateSecret : public TSubOperation {
+    static TTxState::ETxState NextState() {
+        return TTxState::Propose;
+    }
+
+    TTxState::ETxState NextState(TTxState::ETxState state) const override {
+        switch (state) {
+            case TTxState::Waiting:
+            case TTxState::Propose:
+                return TTxState::Done;
+            default:
+                return TTxState::Invalid;
+        }
+    }
+
+    TSubOperationState::TPtr SelectStateFunc(TTxState::ETxState state) override {
+        switch (state) {
+            case TTxState::Waiting:
+            case TTxState::Propose:
+                return MakeHolder<TPropose>(OperationId);
+            case TTxState::Done:
+                return MakeHolder<TDone>(OperationId);
+            default:
+                return nullptr;
+        }
+    }
+
+public:
+    using TSubOperation::TSubOperation;
+
+    THolder<TProposeResponse> Propose(const TString& owner, TOperationContext& context) override {
+        const TTabletId ssId = context.SS->SelfTabletId();
+
+        const auto acceptExisting = !Transaction.GetFailOnExist();
+        const TString& parentPathStr = Transaction.GetWorkingDir();
+        const auto& createSecretProto = Transaction.GetCreateSecret();
+
+        const TString& secretName = createSecretProto.GetName();
+
+        LOG_N("TCreateSecret Propose"
+            << ", path: " << parentPathStr << "/" << secretName
+            << ", opId: " << OperationId
+        );
+
+        auto secretDescrWithoutSecretParts = createSecretProto;
+        secretDescrWithoutSecretParts.ClearValue();
+        LOG_D("TCreateSecret Propose"
+            << ", path: " << parentPathStr << "/" << secretName
+            << ", opId: " << OperationId
+            << ", secretDescription (without secret parts): " << secretDescrWithoutSecretParts.ShortDebugString()
+        );
+
+        auto result = MakeHolder<TProposeResponse>(NKikimrScheme::StatusAccepted, ui64(OperationId.GetTxId()), ui64(ssId));
+
+        const auto parentPath = NSchemeShard::TPath::Resolve(parentPathStr, context.SS);
+        {
+            const auto checks = parentPath.Check();
+            checks
+                .NotUnderDomainUpgrade()
+                .IsAtLocalSchemeShard()
+                .IsResolved()
+                .NotDeleted()
+                .NotUnderDeleting()
+                .IsCommonSensePath()
+                .IsDirectory()
+                .IsValidLeafName(context.UserToken.Get());
+
+            if (!checks) {
+                result->SetError(checks.GetStatus(), checks.GetError());
+                return result;
+            }
+        }
+
+        // TODO(yurikiselev): Support inherit_permissions mode [issue:23460]
+        const TString acl = Transaction.GetModifyACL().GetDiffACL();
+
+        NSchemeShard::TPath dstPath = parentPath.Child(secretName);
+        {
+            const auto checks = dstPath.Check();
+            checks.IsAtLocalSchemeShard();
+            if (dstPath.IsResolved()) {
+                checks
+                    .NotUnderDeleting()
+                    .FailOnExist(TPathElement::EPathType::EPathTypeSecret, acceptExisting);
+            } else {
+                checks
+                    .NotEmpty();
+            }
+
+            if (checks) {
+                checks
+                    .IsValidLeafName(context.UserToken.Get())
+                    .DepthLimit()
+                    .PathsLimit()
+                    .DirChildrenLimit()
+                    .IsValidACL(acl);
+            }
+
+            if (!checks) {
+                result->SetError(checks.GetStatus(), checks.GetError());
+                if (dstPath.IsResolved()) {
+                    result->SetPathCreateTxId(ui64(dstPath.Base()->CreateTxId));
+                    result->SetPathId(dstPath.Base()->PathId.LocalPathId);
+                }
+                return result;
+            }
+        }
+
+        TString errStr;
+        if (!context.SS->CheckApplyIf(Transaction, errStr)) {
+            result->SetError(NKikimrScheme::StatusPreconditionFailed, errStr);
+            return result;
+        }
+
+        const auto secretPathId = context.SS->AllocatePathId();
+        context.MemChanges.GrabNewPath(context.SS, secretPathId);
+        context.MemChanges.GrabPath(context.SS, parentPath->PathId);
+        context.MemChanges.GrabNewSecret(context.SS, secretPathId);
+        context.MemChanges.GrabNewTxState(context.SS, OperationId);
+
+        context.DbChanges.PersistPath(secretPathId);
+        context.DbChanges.PersistPath(parentPath->PathId);
+        context.DbChanges.PersistSecret(secretPathId);
+        context.DbChanges.PersistTxState(OperationId);
+
+        dstPath.MaterializeLeaf(owner, secretPathId);
+        dstPath.DomainInfo()->IncPathsInside(context.SS);
+        IncAliveChildrenSafeWithUndo(OperationId, parentPath, context); // for correct discard of ChildrenExist prop
+
+        result->SetPathId(secretPathId.LocalPathId);
+
+        TPathElement::TPtr secretPath = dstPath.Base();
+        secretPath->PathState = TPathElement::EPathState::EPathStateCreate;
+        secretPath->PathType = TPathElement::EPathType::EPathTypeSecret;
+        secretPath->CreateTxId = OperationId.GetTxId();
+        secretPath->LastTxId = OperationId.GetTxId();
+        if (!acl.empty()) {
+            secretPath->ApplyACL(acl);
+        }
+
+        NKikimrSchemeOp::TSecretDescription secretDescription;
+        secretDescription.SetName(createSecretProto.GetName());
+        secretDescription.SetValue(createSecretProto.GetValue());
+
+        const auto secretInfo = TSecretInfo::Create(std::move(secretDescription));
+        context.SS->Secrets[secretPathId] = secretInfo;
+
+        NIceDb::TNiceDb db(context.GetDB());
+        context.SS->PersistPath(db, dstPath->PathId);
+        context.SS->PersistSecret(db, dstPath->PathId, *secretInfo);
+        context.SS->PersistSecretAlter(db, dstPath->PathId, *secretInfo->AlterData);
+        context.SS->IncrementPathDbRefCount(dstPath->PathId);
+
+        TTxState& txState = context.SS->CreateTx(OperationId, TTxState::TxCreateSecret, secretPathId);
+        txState.State = TTxState::Propose;
+        context.OnComplete.ActivateTx(OperationId);
+
+        if (parentPath.Base()->HasActiveChanges()) {
+            TTxId parentTxId = parentPath.Base()->PlannedToCreate() ? parentPath.Base()->CreateTxId : parentPath.Base()->LastTxId;
+            context.OnComplete.Dependence(parentTxId, OperationId.GetTxId());
+        }
+
+        SetState(NextState());
+        return result;
+    }
+
+    void AbortPropose(TOperationContext& context) override {
+        LOG_N("TCreateSecret AbortPropose" << ", opId: " << OperationId);
+    }
+
+    void AbortUnsafe(TTxId forceDropTxId, TOperationContext& context) override {
+        LOG_N("TCreateSecret AbortUnsafe" << ", opId: " << OperationId << ", forceDropId: " << forceDropTxId);
+
+        context.OnComplete.DoneOperation(OperationId);
+    }
+};
+
+}
+
+namespace NKikimr::NSchemeShard {
+
+using TTag = TSchemeTxTraits<NKikimrSchemeOp::EOperationType::ESchemeOpCreateSecret>;
+
+namespace NOperation {
+
+template <>
+std::optional<TString> GetTargetName<TTag>(TTag, const TTxTransaction& tx) {
+    return tx.GetCreateSecret().GetName();
+}
+
+template <>
+bool SetName<TTag>(TTag, TTxTransaction& tx, const TString& name) {
+    tx.MutableCreateSecret()->SetName(name);
+    return true;
+}
+
+}
+
+ISubOperation::TPtr CreateNewSecret(TOperationId id, const TTxTransaction& tx) {
+    return MakeSubOperation<TCreateSecret>(id, tx);
+}
+
+ISubOperation::TPtr CreateNewSecret(TOperationId id, TTxState::ETxState state) {
+    Y_ABORT_UNLESS(state != TTxState::Invalid);
+    return MakeSubOperation<TCreateSecret>(id, state);
+}
+
+}

--- a/ydb/core/tx/schemeshard/schemeshard__operation_create_secret.cpp
+++ b/ydb/core/tx/schemeshard/schemeshard__operation_create_secret.cpp
@@ -151,8 +151,7 @@ public:
                 .NotDeleted()
                 .NotUnderDeleting()
                 .IsCommonSensePath()
-                .IsDirectory()
-                .IsValidLeafName(context.UserToken.Get());
+                .IsDirectory();
 
             if (!checks) {
                 result->SetError(checks.GetStatus(), checks.GetError());

--- a/ydb/core/tx/schemeshard/schemeshard__operation_db_changes.cpp
+++ b/ydb/core/tx/schemeshard/schemeshard__operation_db_changes.cpp
@@ -33,6 +33,14 @@ void TStorageChanges::Apply(TSchemeShard* ss, NTabletFlatExecutor::TTransactionC
         ss->PersistSequenceAlter(db, pId);
     }
 
+    for (const auto& pathId : Secrets) {
+        ss->PersistSecret(db, pathId);
+    }
+
+    for (const auto& pathId : AlterSecrets) {
+        ss->PersistSecretAlter(db, pathId);
+    }
+
     for (const auto& pId : ApplyIndexes) {
         ss->PersistTableIndex(db, pId);
     }

--- a/ydb/core/tx/schemeshard/schemeshard__operation_db_changes.h
+++ b/ydb/core/tx/schemeshard/schemeshard__operation_db_changes.h
@@ -40,6 +40,9 @@ class TStorageChanges: public TSimpleRefCount<TStorageChanges> {
     TDeque<TPathId> Sequences;
     TDeque<TPathId> AlterSequences;
 
+    TDeque<TPathId> Secrets;
+    TDeque<TPathId> AlterSecrets;
+
     TDeque<TPathId> SysViews;
 
     // Can we have multiple long incremental restore operations?
@@ -133,6 +136,14 @@ public:
 
     void PersistSequence(const TPathId& pathId) {
         Sequences.push_back(pathId);
+    }
+
+    void PersistAlterSecret(const TPathId& pathId) {
+        AlterSecrets.emplace_back(pathId);
+    }
+
+    void PersistSecret(const TPathId& pathId) {
+        Secrets.emplace_back(pathId);
     }
 
     void PersistSysView(const TPathId& pathId) {

--- a/ydb/core/tx/schemeshard/schemeshard__operation_drop_secret.cpp
+++ b/ydb/core/tx/schemeshard/schemeshard__operation_drop_secret.cpp
@@ -149,8 +149,7 @@ public:
             }
         }
 
-        TSecretInfo::TPtr secret = context.SS->Secrets.Value(path->PathId, nullptr);
-        Y_ABORT_UNLESS(secret);
+        Y_ABORT_UNLESS(context.SS->Secrets.contains(path->PathId));
 
         TString errStr;
         if (!context.SS->CheckApplyIf(Transaction, errStr)) {

--- a/ydb/core/tx/schemeshard/schemeshard__operation_drop_secret.cpp
+++ b/ydb/core/tx/schemeshard/schemeshard__operation_drop_secret.cpp
@@ -1,0 +1,216 @@
+#include "schemeshard__operation_common.h"
+#include "schemeshard__operation_part.h"
+#include "schemeshard_impl.h"
+
+#define LOG_N(stream) LOG_NOTICE_S(context.Ctx, NKikimrServices::FLAT_TX_SCHEMESHARD, "[" << context.SS->SelfTabletId() << "] " << stream)
+#define LOG_I(stream) LOG_INFO_S  (context.Ctx, NKikimrServices::FLAT_TX_SCHEMESHARD, "[" << context.SS->SelfTabletId() << "] " << stream)
+
+namespace {
+
+using namespace NKikimr;
+using namespace NSchemeShard;
+
+class TPropose : public TSubOperationState {
+    const TOperationId OperationId;
+
+    TString DebugHint() const override {
+        return TStringBuilder()
+            << "TDropSecret TPropose"
+            << ", opId: " << OperationId;
+    }
+
+public:
+    explicit TPropose(TOperationId id)
+        : OperationId(id)
+    {
+    }
+
+    bool ProgressState(TOperationContext& context) override {
+        LOG_I(DebugHint() << " ProgressState");
+
+        const auto* txState = context.SS->FindTx(OperationId);
+        Y_ABORT_UNLESS(txState);
+        Y_ABORT_UNLESS(txState->TxType == TTxState::TxDropSecret);
+
+        context.OnComplete.ProposeToCoordinator(OperationId, txState->TargetPathId, TStepId(0));
+        return false;
+    }
+
+    bool HandleReply(TEvPrivate::TEvOperationPlan::TPtr& ev, TOperationContext& context) override {
+        const auto step = TStepId(ev->Get()->StepId);
+
+        LOG_I(DebugHint() << " HandleReply TEvOperationPlan"
+            << ", step: " << step
+        );
+
+        TTxState* txState = context.SS->FindTx(OperationId);
+        Y_ABORT_UNLESS(txState);
+        Y_ABORT_UNLESS(txState->TxType == TTxState::TxDropSecret);
+
+        TPathId pathId = txState->TargetPathId;
+        auto secretPath = context.SS->PathsById.at(pathId);
+        auto parentDir = context.SS->PathsById.at(secretPath->ParentPathId);
+
+        NIceDb::TNiceDb db(context.GetDB());
+
+        Y_ABORT_UNLESS(!secretPath->Dropped());
+        secretPath->SetDropped(step, OperationId.GetTxId());
+        context.SS->PersistDropStep(db, pathId, step, OperationId);
+        auto domainInfo = context.SS->ResolveDomainInfo(pathId);
+        domainInfo->DecPathsInside(context.SS);
+        DecAliveChildrenDirect(OperationId, parentDir, context); // for correct discard of ChildrenExist prop
+
+        context.SS->TabletCounters->Simple()[COUNTER_SECRET_COUNT].Sub(1);
+        context.SS->PersistSecretRemove(db, pathId);
+
+        ++parentDir->DirAlterVersion;
+        context.SS->PersistPathDirAlterVersion(db, parentDir);
+        context.SS->ClearDescribePathCaches(parentDir);
+        context.SS->ClearDescribePathCaches(secretPath);
+
+        if (!context.SS->DisablePublicationsOfDropping) {
+            context.OnComplete.PublishToSchemeBoard(OperationId, parentDir->PathId);
+            context.OnComplete.PublishToSchemeBoard(OperationId, pathId);
+        }
+
+        context.SS->ChangeTxState(db, OperationId, TTxState::Done);
+
+        return true;
+    }
+};
+
+class TDropSecret : public TSubOperation {
+    TTxState::ETxState NextState() const {
+        return TTxState::Propose;
+    }
+
+    TTxState::ETxState NextState(TTxState::ETxState state) const override {
+        switch (state) {
+        case TTxState::Propose:
+            return TTxState::Done;
+        default:
+            return TTxState::Invalid;
+        }
+    }
+
+    TSubOperationState::TPtr SelectStateFunc(TTxState::ETxState state) override {
+        switch (state) {
+        case TTxState::Propose:
+            return MakeHolder<TPropose>(OperationId);
+        case TTxState::Done:
+            return MakeHolder<TDone>(OperationId);
+        default:
+            return nullptr;
+        }
+    }
+
+public:
+    using TSubOperation::TSubOperation;
+
+    THolder<TProposeResponse> Propose(const TString&, TOperationContext& context) override {
+        const ui64 ssId = context.SS->TabletID();
+        const auto& drop = Transaction.GetDrop();
+
+        const TString& workingDir = Transaction.GetWorkingDir();
+        const TString& name = drop.GetName();
+
+        LOG_N("TDropSecret Propose"
+            << ", opId: " << OperationId
+            << ", path: " << workingDir << "/" << name
+        );
+
+        auto result = MakeHolder<TProposeResponse>(NKikimrScheme::StatusAccepted, ui64(OperationId.GetTxId()), ssId);
+
+        TPath path = drop.HasId()
+            ? TPath::Init(context.SS->MakeLocalId(drop.GetId()), context.SS)
+            : TPath::Resolve(workingDir, context.SS).Dive(name);
+        {
+            auto checks = path.Check();
+            checks
+                .NotEmpty()
+                .NotUnderDomainUpgrade()
+                .IsAtLocalSchemeShard()
+                .IsResolved()
+                .NotDeleted()
+                .NotUnderDeleting()
+                .IsSecret()
+                .NotUnderOperation();
+
+            if (!checks) {
+                result->SetError(checks.GetStatus(), checks.GetError());
+                if (path.IsResolved() &&
+                    path.Base()->IsSecret() &&
+                    (path.Base()->PlannedToDrop() || path.Base()->Dropped())
+                ) {
+                    result->SetPathDropTxId(ui64(path.Base()->DropTxId));
+                    result->SetPathId(path.Base()->PathId.LocalPathId);
+                }
+                return result;
+            }
+        }
+
+        TSecretInfo::TPtr secret = context.SS->Secrets.Value(path->PathId, nullptr);
+        Y_ABORT_UNLESS(secret);
+
+        TString errStr;
+        if (!context.SS->CheckApplyIf(Transaction, errStr)) {
+            result->SetError(NKikimrScheme::StatusPreconditionFailed, errStr);
+            return result;
+        }
+
+        const auto pathId = path.Base()->PathId;
+        result->SetPathId(pathId.LocalPathId);
+
+        auto guard = context.DbGuard();
+        context.MemChanges.GrabNewTxState(context.SS, OperationId);
+        context.MemChanges.GrabPath(context.SS, pathId);
+        context.MemChanges.GrabPath(context.SS, path->ParentPathId);
+
+        context.DbChanges.PersistPath(pathId);
+        context.DbChanges.PersistPath(path->ParentPathId);
+        context.DbChanges.PersistTxState(OperationId);
+
+        path.Base()->PathState = TPathElement::EPathState::EPathStateDrop;
+        path.Base()->DropTxId = OperationId.GetTxId();
+        path.Base()->LastTxId = OperationId.GetTxId();
+
+        TTxState& txState = context.SS->CreateTx(OperationId, TTxState::TxDropSecret, path.Base()->PathId);
+        txState.State = TTxState::Propose;
+        txState.MinStep = TStepId(1);
+
+        context.OnComplete.ActivateTx(OperationId);
+
+        SetState(NextState());
+        return result;
+    }
+
+    void AbortPropose(TOperationContext& context) override {
+        LOG_N("TDropSecret AbortPropose"
+            << ", opId: " << OperationId
+        );
+    }
+
+    void AbortUnsafe(TTxId forceDropTxId, TOperationContext& context) override {
+        LOG_N("TDropSecret AbortUnsafe"
+            << ", opId: " << OperationId
+            << ", txId: " << forceDropTxId
+        );
+
+        context.OnComplete.DoneOperation(OperationId);
+    }
+};
+
+}
+
+namespace NKikimr::NSchemeShard {
+
+ISubOperation::TPtr CreateDropSecret(TOperationId id, const TTxTransaction& tx) {
+    return MakeSubOperation<TDropSecret>(id, tx);
+}
+
+ISubOperation::TPtr CreateDropSecret(TOperationId id, TTxState::ETxState state) {
+    Y_ABORT_UNLESS(state != TTxState::Invalid);
+    return MakeSubOperation<TDropSecret>(id, state);
+}
+
+}

--- a/ydb/core/tx/schemeshard/schemeshard__operation_memory_changes.cpp
+++ b/ydb/core/tx/schemeshard/schemeshard__operation_memory_changes.cpp
@@ -144,6 +144,14 @@ void TMemoryChanges::GrabNewLongIncrementalBackupOp(TSchemeShard* ss, ui64 id) {
     IncrementalBackups.emplace(id, nullptr);
 }
 
+void TMemoryChanges::GrabNewSecret(TSchemeShard* ss, const TPathId& pathId) {
+    GrabNew(pathId, ss->Secrets, Secrets);
+}
+
+void TMemoryChanges::GrabSecret(TSchemeShard* ss, const TPathId& pathId) {
+    Grab<TSecretInfo>(pathId, ss->Secrets, Secrets);
+}
+
 void TMemoryChanges::UnDo(TSchemeShard* ss) {
     // be aware of the order of grab & undo ops
     // stack is the best way to manage it right
@@ -323,6 +331,16 @@ void TMemoryChanges::UnDo(TSchemeShard* ss) {
             ss->IncrementalBackups.erase(id);
         }
         IncrementalBackups.pop();
+    }
+
+    while (Secrets) {
+        const auto& [id, elem] = Secrets.top();
+        if (elem) {
+            ss->Secrets[id] = elem;
+        } else {
+            ss->Secrets.erase(id);
+        }
+        Secrets.pop();
     }
 }
 

--- a/ydb/core/tx/schemeshard/schemeshard__operation_memory_changes.h
+++ b/ydb/core/tx/schemeshard/schemeshard__operation_memory_changes.h
@@ -72,6 +72,9 @@ class TMemoryChanges: public TSimpleRefCount<TMemoryChanges> {
     using TIncrementalBackupState = std::pair<ui64, TIncrementalBackupInfo::TPtr>;
     TStack<TIncrementalBackupState> IncrementalBackups;
 
+    using TSecretState = std::pair<TPathId, TSecretInfo::TPtr>;
+    TStack<TSecretState> Secrets;
+
 public:
     ~TMemoryChanges() = default;
 
@@ -120,6 +123,9 @@ public:
     void GrabLongIncrementalRestoreOp(TSchemeShard* ss, const TOperationId& opId);
 
     void GrabNewLongIncrementalBackupOp(TSchemeShard* ss, ui64 id);
+
+    void GrabNewSecret(TSchemeShard* ss, const TPathId& pathId);
+    void GrabSecret(TSchemeShard* ss, const TPathId& pathId);
 
     void UnDo(TSchemeShard* ss);
 };

--- a/ydb/core/tx/schemeshard/schemeshard__operation_part.h
+++ b/ydb/core/tx/schemeshard/schemeshard__operation_part.h
@@ -731,5 +731,15 @@ ISubOperation::TPtr CreateNewSysView(TOperationId id, TTxState::ETxState state);
 ISubOperation::TPtr CreateDropSysView(TOperationId id, const TTxTransaction& tx);
 ISubOperation::TPtr CreateDropSysView(TOperationId id, TTxState::ETxState state);
 
+// Secret
+// Create
+ISubOperation::TPtr CreateNewSecret(TOperationId id, const TTxTransaction& tx);
+ISubOperation::TPtr CreateNewSecret(TOperationId id, TTxState::ETxState state);
+// Alter
+ISubOperation::TPtr CreateAlterSecret(TOperationId id, const TTxTransaction& tx);
+ISubOperation::TPtr CreateAlterSecret(TOperationId id, TTxState::ETxState state);
+// Drop
+ISubOperation::TPtr CreateDropSecret(TOperationId id, const TTxTransaction& tx);
+ISubOperation::TPtr CreateDropSecret(TOperationId id, TTxState::ETxState state);
 }
 }

--- a/ydb/core/tx/schemeshard/schemeshard__operation_upgrade_subdomain.cpp
+++ b/ydb/core/tx/schemeshard/schemeshard__operation_upgrade_subdomain.cpp
@@ -310,6 +310,7 @@ public:
             case NKikimrSchemeOp::EPathType::EPathTypeView:
             case NKikimrSchemeOp::EPathType::EPathTypeResourcePool:
             case NKikimrSchemeOp::EPathType::EPathTypeSysView:
+            case NKikimrSchemeOp::EPathType::EPathTypeSecret:
                 Y_ABORT_UNLESS(!path.Base()->IsRoot());
                 //no shards
                 break;

--- a/ydb/core/tx/schemeshard/schemeshard_audit_log_fragment.cpp
+++ b/ydb/core/tx/schemeshard/schemeshard_audit_log_fragment.cpp
@@ -294,6 +294,13 @@ TString DefineUserOperationName(const NKikimrSchemeOp::TModifyScheme& tx) {
         return "RESTORE INCREMENTAL FINALIZE";
     case NKikimrSchemeOp::EOperationType::ESchemeOpCreateSetConstraintInitiate:
         return "SET CONSTRAINT";
+    // secret
+    case NKikimrSchemeOp::EOperationType::ESchemeOpCreateSecret:
+        return "CREATE SECRET";
+    case NKikimrSchemeOp::EOperationType::ESchemeOpAlterSecret:
+        return "ALTER SECRET";
+    case NKikimrSchemeOp::EOperationType::ESchemeOpDropSecret:
+        return "DROP SECRET";
     }
     Y_ABORT("switch should cover all operation types");
 }
@@ -673,6 +680,14 @@ TVector<TString> ExtractChangingPaths(const NKikimrSchemeOp::TModifyScheme& tx) 
         break;
     case NKikimrSchemeOp::EOperationType::ESchemeOpCreateSetConstraintInitiate:
         result.emplace_back(NKikimr::JoinPath({tx.GetWorkingDir(), tx.GetSetColumnConstraintsInitiate().GetTableName()}));
+    case NKikimrSchemeOp::EOperationType::ESchemeOpCreateSecret:
+        result.emplace_back(NKikimr::JoinPath({tx.GetWorkingDir(), tx.GetCreateSecret().GetName()}));
+        break;
+    case NKikimrSchemeOp::EOperationType::ESchemeOpAlterSecret:
+        result.emplace_back(NKikimr::JoinPath({tx.GetWorkingDir(), tx.GetAlterSecret().GetName()}));
+        break;
+    case NKikimrSchemeOp::EOperationType::ESchemeOpDropSecret:
+        result.emplace_back(NKikimr::JoinPath({tx.GetWorkingDir(), tx.GetDrop().GetName()}));
         break;
     }
 

--- a/ydb/core/tx/schemeshard/schemeshard_impl.cpp
+++ b/ydb/core/tx/schemeshard/schemeshard_impl.cpp
@@ -546,6 +546,7 @@ void TSchemeShard::Clear() {
     ExternalDataSources.clear();
     Views.clear();
     SysViews.clear();
+    Secrets.clear();
 
     ColumnTables = { };
     BackgroundSessionsManager = std::make_shared<NKikimr::NOlap::NBackground::TSessionsManager>(
@@ -1470,6 +1471,9 @@ bool TSchemeShard::CheckApplyIf(const NKikimrSchemeOp::TModifyScheme& scheme, TS
                         case NKikimrSchemeOp::EPathType::EPathTypeSysView:
                             actualVersion = pathVersion.GetSysViewVersion();
                             break;
+                        case NKikimrSchemeOp::EPathType::EPathTypeSecret:
+                            actualVersion = pathVersion.GetSecretVersion();
+                            break;
                         default:
                             actualVersion = pathVersion.GetGeneralVersion();
                             break;
@@ -1735,6 +1739,7 @@ TPathElement::EPathState TSchemeShard::CalcPathState(TTxState::ETxType txType, T
     case TTxState::TxCreateBackupCollection:
     case TTxState::TxCreateSysView:
     case TTxState::TxCreateLongIncrementalBackupOp:
+    case TTxState::TxCreateSecret:
         return TPathElement::EPathState::EPathStateCreate;
     case TTxState::TxAlterPQGroup:
     case TTxState::TxAlterTable:
@@ -1774,6 +1779,7 @@ TPathElement::EPathState TSchemeShard::CalcPathState(TTxState::ETxType txType, T
     case TTxState::TxAlterResourcePool:
     case TTxState::TxAlterBackupCollection:
     case TTxState::TxChangePathState:
+    case TTxState::TxAlterSecret:
         return TPathElement::EPathState::EPathStateAlter;
     case TTxState::TxDropTable:
     case TTxState::TxDropPQGroup:
@@ -1802,6 +1808,7 @@ TPathElement::EPathState TSchemeShard::CalcPathState(TTxState::ETxType txType, T
     case TTxState::TxDropResourcePool:
     case TTxState::TxDropBackupCollection:
     case TTxState::TxDropSysView:
+    case TTxState::TxDropSecret:
         return TPathElement::EPathState::EPathStateDrop;
     case TTxState::TxBackup:
         return TPathElement::EPathState::EPathStateBackup;
@@ -3369,6 +3376,81 @@ void TSchemeShard::PersistRemoveBackupCollection(NIceDb::TNiceDb& db, TPathId pa
     db.Table<Schema::BackupCollection>().Key(pathId.OwnerId, pathId.LocalPathId).Delete();
 }
 
+void TSchemeShard::PersistSecret(NIceDb::TNiceDb& db, TPathId pathId, const TSecretInfo& secretInfo) {
+    Y_ABORT_UNLESS(IsLocalId(pathId));
+
+    TString serializedDescription;
+    Y_ABORT_UNLESS(secretInfo.Description.SerializeToString(&serializedDescription));
+
+    db.Table<Schema::Secrets>().Key(pathId.LocalPathId).Update(
+        NIceDb::TUpdate<Schema::Secrets::AlterVersion>(secretInfo.AlterVersion),
+        NIceDb::TUpdate<Schema::Secrets::Description>(serializedDescription));
+}
+
+void TSchemeShard::PersistSecret(NIceDb::TNiceDb& db, TPathId pathId) {
+    Y_ABORT_UNLESS(PathsById.contains(pathId));
+    TPathElement::TPtr elem = PathsById.at(pathId);
+
+    Y_ABORT_UNLESS(Secrets.contains(pathId));
+    TSecretInfo::TPtr secretInfo = Secrets.at(pathId);
+
+    Y_ABORT_UNLESS(elem->IsSecret());
+
+    Y_ABORT_UNLESS(secretInfo);
+
+    PersistSecret(db, pathId, *secretInfo);
+}
+
+void TSchemeShard::PersistSecretRemove(NIceDb::TNiceDb& db, TPathId pathId) {
+    Y_ABORT_UNLESS(IsLocalId(pathId));
+
+    if (!Secrets.contains(pathId)) {
+        return;
+    }
+
+    auto secretInfo = Secrets.at(pathId);
+    if (secretInfo->AlterData) {
+        secretInfo->AlterData = nullptr;
+        PersistSecretAlterRemove(db, pathId);
+    }
+
+    Secrets.erase(pathId);
+    DecrementPathDbRefCount(pathId);
+    db.Table<Schema::Secrets>().Key(pathId.LocalPathId).Delete();
+}
+
+void TSchemeShard::PersistSecretAlter(NIceDb::TNiceDb& db, TPathId pathId, const TSecretInfo& secretInfo) {
+    Y_ABORT_UNLESS(IsLocalId(pathId));
+
+    TString serializedDescription;
+    Y_ABORT_UNLESS(secretInfo.Description.SerializeToString(&serializedDescription));
+
+    db.Table<Schema::SecretsAlterData>().Key(pathId.LocalPathId).Update(
+        NIceDb::TUpdate<Schema::SecretsAlterData::AlterVersion>(secretInfo.AlterVersion),
+        NIceDb::TUpdate<Schema::SecretsAlterData::Description>(serializedDescription));
+}
+
+void TSchemeShard::PersistSecretAlter(NIceDb::TNiceDb& db, TPathId pathId) {
+    Y_ABORT_UNLESS(PathsById.contains(pathId));
+    TPathElement::TPtr elem = PathsById.at(pathId);
+
+    Y_ABORT_UNLESS(Secrets.contains(pathId));
+    TSecretInfo::TPtr secretInfo = Secrets.at(pathId);
+
+    Y_ABORT_UNLESS(elem->IsSecret());
+
+    TSecretInfo::TPtr alterData = secretInfo->AlterData;
+    Y_ABORT_UNLESS(alterData);
+
+    PersistSecretAlter(db, pathId, *alterData);
+}
+
+void TSchemeShard::PersistSecretAlterRemove(NIceDb::TNiceDb& db, TPathId pathId) {
+    Y_ABORT_UNLESS(IsLocalId(pathId));
+
+    db.Table<Schema::SecretsAlterData>().Key(pathId.LocalPathId).Delete();
+}
+
 void TSchemeShard::PersistRemoveRtmrVolume(NIceDb::TNiceDb &db, TPathId pathId) {
     Y_ABORT_UNLESS(IsLocalId(pathId));
 
@@ -4010,7 +4092,6 @@ void TSchemeShard::PersistSequence(NIceDb::TNiceDb& db, TPathId pathId)
     Y_ABORT_UNLESS(sequenceInfo);
 
     PersistSequence(db, pathId, *sequenceInfo);
-
 }
 
 void TSchemeShard::PersistSequenceRemove(NIceDb::TNiceDb& db, TPathId pathId)
@@ -4706,6 +4787,14 @@ NKikimrSchemeOp::TPathVersion TSchemeShard::GetPathVersion(const TPath& path) co
                 Y_ABORT_UNLESS(it != SysViews.end());
                 result.SetSysViewVersion(it->second->AlterVersion);
                 generalVersion += result.GetSysViewVersion();
+                break;
+            }
+
+            case NKikimrSchemeOp::EPathType::EPathTypeSecret: {
+                auto it = Secrets.find(pathId);
+                Y_ABORT_UNLESS(it != Secrets.end());
+                result.SetSecretVersion(it->second->AlterVersion);
+                generalVersion += result.GetSecretVersion();
                 break;
             }
 
@@ -5621,6 +5710,9 @@ void TSchemeShard::UncountNode(TPathElement::TPtr node) {
         break;
     case TPathElement::EPathType::EPathTypeSysView:
         TabletCounters->Simple()[COUNTER_SYS_VIEW_COUNT].Sub(1);
+        break;
+    case TPathElement::EPathType::EPathTypeSecret:
+        TabletCounters->Simple()[COUNTER_SECRET_COUNT].Sub(1);
         break;
     case TPathElement::EPathType::EPathTypeInvalid:
         Y_ABORT("impossible path type");

--- a/ydb/core/tx/schemeshard/schemeshard_impl.h
+++ b/ydb/core/tx/schemeshard/schemeshard_impl.h
@@ -272,6 +272,7 @@ public:
     THashMap<TPathId, TResourcePoolInfo::TPtr> ResourcePools;
     THashMap<TPathId, TBackupCollectionInfo::TPtr> BackupCollections;
     THashMap<TPathId, TSysViewInfo::TPtr> SysViews;
+    THashMap<TPathId, TSecretInfo::TPtr> Secrets;
 
     TTempDirsState TempDirsState;
 
@@ -895,6 +896,14 @@ public:
     void PersistRemoveSysView(NIceDb::TNiceDb& db, TPathId pathId);
 
     void PersistLongIncrementalRestoreOp(NIceDb::TNiceDb& db, const NKikimrSchemeOp::TLongIncrementalRestoreOp& op);
+
+    // Secret
+    void PersistSecret(NIceDb::TNiceDb& db, TPathId pathId, const TSecretInfo& secretInfo);
+    void PersistSecret(NIceDb::TNiceDb& db, TPathId pathId);
+    void PersistSecretRemove(NIceDb::TNiceDb& db, TPathId pathId);
+    void PersistSecretAlter(NIceDb::TNiceDb& db, TPathId pathId, const TSecretInfo& secretInfo);
+    void PersistSecretAlter(NIceDb::TNiceDb& db, TPathId pathId);
+    void PersistSecretAlterRemove(NIceDb::TNiceDb& db, TPathId pathId);
 
     TTabletId GetGlobalHive() const;
 

--- a/ydb/core/tx/schemeshard/schemeshard_path.cpp
+++ b/ydb/core/tx/schemeshard/schemeshard_path.cpp
@@ -1169,6 +1169,20 @@ const TPath::TChecker& TPath::TChecker::IsSysView(EStatus status) const {
     );
 }
 
+const TPath::TChecker& TPath::TChecker::IsSecret(EStatus status) const {
+    if (Failed) {
+        return *this;
+    }
+
+    if (Path.Base()->IsSecret()) {
+        return *this;
+    }
+
+    return Fail(status, TStringBuilder() << "path is not a secret"
+        << " (" << BasicPathInfo(Path.Base()) << ")"
+    );
+}
+
 TString TPath::TChecker::BasicPathInfo(TPathElement::TPtr element) const {
     return TStringBuilder()
         << "id: " << element->PathId << ", "

--- a/ydb/core/tx/schemeshard/schemeshard_path.h
+++ b/ydb/core/tx/schemeshard/schemeshard_path.h
@@ -114,6 +114,7 @@ public:
         const TChecker& IsBackupCollection(EStatus status = EStatus::StatusNameConflict) const;
         const TChecker& IsSupportedInExports(EStatus status = EStatus::StatusNameConflict) const;
         const TChecker& IsSysView(EStatus status = EStatus::StatusNameConflict) const;
+        const TChecker& IsSecret(EStatus status = EStatus::StatusNameConflict) const;
     };
 
 public:

--- a/ydb/core/tx/schemeshard/schemeshard_path_describer.h
+++ b/ydb/core/tx/schemeshard/schemeshard_path_describer.h
@@ -49,6 +49,7 @@ class TPathDescriber {
     void DescribeResourcePool(TPathId pathId, TPathElement::TPtr pathEl);
     void DescribeBackupCollection(TPathId pathId, TPathElement::TPtr pathEl);
     void DescribeSysView(const TActorContext&, TPathId pathId, TPathElement::TPtr pathEl);
+    void DescribeSecret(const TActorContext&, TPathId pathId, TPathElement::TPtr pathEl);
 
 public:
     explicit TPathDescriber(TSchemeShard* self, NKikimrSchemeOp::TDescribePath&& params)

--- a/ydb/core/tx/schemeshard/schemeshard_path_element.cpp
+++ b/ydb/core/tx/schemeshard/schemeshard_path_element.cpp
@@ -243,6 +243,10 @@ bool TPathElement::IsBackupCollection() const {
     return PathType == EPathType::EPathTypeBackupCollection;
 }
 
+bool TPathElement::IsSecret() const {
+    return PathType == EPathType::EPathTypeSecret;
+}
+
 void TPathElement::SetDropped(TStepId step, TTxId txId) {
     PathState = EPathState::EPathStateNotExist;
     StepDropped = step;

--- a/ydb/core/tx/schemeshard/schemeshard_path_element.h
+++ b/ydb/core/tx/schemeshard/schemeshard_path_element.h
@@ -141,6 +141,7 @@ public:
     bool IsTemporary() const;
     bool IsResourcePool() const;
     bool IsBackupCollection() const;
+    bool IsSecret() const;
     TVirtualTimestamp GetCreateTS() const;
     TVirtualTimestamp GetDropTS() const;
     void SetDropped(TStepId step, TTxId txId);

--- a/ydb/core/tx/schemeshard/schemeshard_schema.h
+++ b/ydb/core/tx/schemeshard/schemeshard_schema.h
@@ -2219,6 +2219,24 @@ struct Schema : NIceDb::Schema {
         >;
     };
 
+    struct Secrets : Table<127> {
+        struct PathId : Column<1, NScheme::NTypeIds::Uint64> { using Type = TLocalPathId; };
+        struct AlterVersion : Column<2, NScheme::NTypeIds::Uint64> {};
+        struct Description : Column<3, NScheme::NTypeIds::String> {};
+
+        using TKey = TableKey<PathId>;
+        using TColumns = TableColumns<PathId, AlterVersion, Description>;
+    };
+
+    struct SecretsAlterData : Table<128> {
+        struct PathId : Column<1, NScheme::NTypeIds::Uint64> { using Type = TLocalPathId; };
+        struct AlterVersion : Column<2, NScheme::NTypeIds::Uint64> {};
+        struct Description : Column<3, NScheme::NTypeIds::String> {};
+
+        using TKey = TableKey<PathId>;
+        using TColumns = TableColumns<PathId, AlterVersion, Description>;
+    };
+
     using TTables = SchemaTables<
         Paths,
         TxInFlight,
@@ -2343,7 +2361,9 @@ struct Schema : NIceDb::Schema {
         IncrementalRestoreShardProgress,
         SystemShardsToDelete,
         IncrementalBackups,
-        IncrementalBackupItems
+        IncrementalBackupItems,
+        Secrets,
+        SecretsAlterData
     >;
 
     static constexpr ui64 SysParam_NextPathId = 1;

--- a/ydb/core/tx/schemeshard/schemeshard_subop_types.cpp
+++ b/ydb/core/tx/schemeshard/schemeshard_subop_types.cpp
@@ -82,16 +82,17 @@ bool IsCreate(ETxType t) {
         case TxCreateSysView:
         case TxCreateLongIncrementalRestoreOp:
         case TxCreateLongIncrementalBackupOp:
-            return true;
+        case TxCreateSecret:
+            return true; // IsCreate
         case TxIncrementalRestoreFinalize:
-            return false;
+            return false; // IsCreate
         case TxInitializeBuildIndex: //this is more like alter
         case TxCreateCdcStreamAtTable:
         case TxCreateCdcStreamAtTableWithInitialScan:
-            return false;
+            return false; // IsCreate
         case TxCreateLock: //this is more like alter
         case TxDropLock: //this is more like alter
-            return false;
+            return false; // IsCreate
         case TxDropTable:
         case TxDropOlapStore:
         case TxDropColumnTable:
@@ -124,7 +125,8 @@ bool IsCreate(ETxType t) {
         case TxDropResourcePool:
         case TxDropBackupCollection:
         case TxDropSysView:
-            return false;
+        case TxDropSecret:
+            return false; // IsCreate
         case TxAlterPQGroup:
         case TxAlterTable:
         case TxAlterOlapStore:
@@ -161,15 +163,16 @@ bool IsCreate(ETxType t) {
         case TxRestoreIncrementalBackupAtTable:
         case TxAlterBackupCollection:
         case TxChangePathState:
-            return false;
+        case TxAlterSecret:
+            return false; // IsCreate
         case TxMoveTable:
         case TxMoveTableIndex:
         case TxMoveSequence:
-            return true;
+            return true; // IsCreate
         case TxRotateCdcStream:
-            return true;
+            return true; // IsCreate
         case TxRotateCdcStreamAtTable:
-            return false;
+            return false; // IsCreate
         case TxInvalid:
         case TxAllocatePQ:
             Y_DEBUG_ABORT_UNLESS("UNREACHABLE");
@@ -208,9 +211,10 @@ bool IsDrop(ETxType t) {
         case TxDropResourcePool:
         case TxDropBackupCollection:
         case TxDropSysView:
-            return true;
+        case TxDropSecret:
+            return true; // IsDrop
         case TxIncrementalRestoreFinalize:
-            return false;
+            return false; // IsDrop
         case TxMkDir:
         case TxCreateTable:
         case TxCopyTable:
@@ -252,7 +256,8 @@ bool IsDrop(ETxType t) {
         case TxCreateSysView:
         case TxCreateLongIncrementalRestoreOp:
         case TxCreateLongIncrementalBackupOp:
-            return false;
+        case TxCreateSecret:
+            return false; // IsDrop
         case TxAlterPQGroup:
         case TxAlterTable:
         case TxAlterOlapStore:
@@ -288,14 +293,15 @@ bool IsDrop(ETxType t) {
         case TxAlterResourcePool:
         case TxAlterBackupCollection:
         case TxChangePathState:
-            return false;
+        case TxAlterSecret:
+            return false; // IsDrop
         case TxRotateCdcStream:
         case TxRotateCdcStreamAtTable:
-            return false;
+            return false; // IsDrop
         case TxMoveTable:
         case TxMoveTableIndex:
         case TxMoveSequence:
-            return false;
+            return false; // IsDrop
         case TxInvalid:
         case TxAllocatePQ:
             Y_DEBUG_ABORT_UNLESS("UNREACHABLE");
@@ -329,7 +335,7 @@ bool CanDeleteParts(ETxType t) {
         case TxDropBlobDepot:
         case TxDropContinuousBackup:
         case TxDropBackupCollection:
-            return true;
+            return true; // CanDeleteParts
         case TxDropTableIndex:
         case TxRmDir:
         case TxFinalizeBuildIndex:
@@ -340,7 +346,7 @@ bool CanDeleteParts(ETxType t) {
         case TxDropSysView:
         case TxCreateLongIncrementalRestoreOp:
         case TxCreateLongIncrementalBackupOp:
-            return false;
+            return false; // CanDeleteParts
         case TxMkDir:
         case TxCreateTable:
         case TxCreateOlapStore:
@@ -378,7 +384,9 @@ bool CanDeleteParts(ETxType t) {
         case TxRestoreIncrementalBackupAtTable:
         case TxCreateBackupCollection:
         case TxCreateSysView:
-            return false;
+        case TxCreateSecret:
+        case TxDropSecret:
+            return false; // CanDeleteParts
         case TxAlterPQGroup:
         case TxAlterTable:
         case TxAlterOlapStore:
@@ -418,9 +426,10 @@ bool CanDeleteParts(ETxType t) {
         case TxChangePathState:
         case TxRotateCdcStream:
         case TxRotateCdcStreamAtTable:
-            return false;
+        case TxAlterSecret:
+            return false; // CanDeleteParts
         case TxIncrementalRestoreFinalize:
-            return false;
+            return false; // CanDeleteParts
         case TxInvalid:
         case TxAllocatePQ:
             Y_DEBUG_ABORT_UNLESS("UNREACHABLE");
@@ -539,7 +548,7 @@ ETxType ConvertToTxType(NKikimrSchemeOp::EOperationType opType) {
         case NKikimrSchemeOp::ESchemeOpCreateLongIncrementalRestoreOp: return TxCreateLongIncrementalRestoreOp;
         case NKikimrSchemeOp::ESchemeOpChangePathState: return TxChangePathState;
         case NKikimrSchemeOp::ESchemeOpIncrementalRestoreFinalize: return TxIncrementalRestoreFinalize;
-            case NKikimrSchemeOp::ESchemeOpCreateLongIncrementalBackupOp: return TxCreateLongIncrementalBackupOp;
+        case NKikimrSchemeOp::ESchemeOpCreateLongIncrementalBackupOp: return TxCreateLongIncrementalBackupOp;
         case NKikimrSchemeOp::ESchemeOpAlterExtSubDomainCreateHive: return TxAlterExtSubDomainCreateHive;
         case NKikimrSchemeOp::ESchemeOpDropExternalTable: return TxDropExternalTable;
         case NKikimrSchemeOp::ESchemeOpDropExternalDataSource: return TxDropExternalDataSource;
@@ -549,6 +558,9 @@ ETxType ConvertToTxType(NKikimrSchemeOp::EOperationType opType) {
         case NKikimrSchemeOp::ESchemeOpMoveIndex: return TxMoveTableIndex;
         case NKikimrSchemeOp::ESchemeOpMoveSequence: return TxMoveSequence;
         case NKikimrSchemeOp::ESchemeOpRestoreIncrementalBackupAtTable: return TxRestoreIncrementalBackupAtTable;
+        case NKikimrSchemeOp::ESchemeOpCreateSecret: return TxCreateSecret;
+        case NKikimrSchemeOp::ESchemeOpAlterSecret: return TxAlterSecret;
+        case NKikimrSchemeOp::ESchemeOpDropSecret: return TxDropSecret;
 
         // no matching tx-type
         case NKikimrSchemeOp::ESchemeOpBackupBackupCollection:

--- a/ydb/core/tx/schemeshard/schemeshard_subop_types.h
+++ b/ydb/core/tx/schemeshard/schemeshard_subop_types.h
@@ -125,6 +125,9 @@ enum ESimpleCounters : int;
     item(TxRotateCdcStreamAtTable, 108) \
     item(TxIncrementalRestoreFinalize, 109) \
     item(TxCreateLongIncrementalBackupOp, 110) \
+    item(TxCreateSecret, 111) \
+    item(TxAlterSecret, 112) \
+    item(TxDropSecret, 113) \
 
 // TX_STATE_TYPE_ENUM
 

--- a/ydb/core/tx/schemeshard/ut_helpers/helpers.cpp
+++ b/ydb/core/tx/schemeshard/ut_helpers/helpers.cpp
@@ -1047,6 +1047,12 @@ namespace NSchemeShardUT_Private {
     GENERIC_HELPERS(DropSysView, NKikimrSchemeOp::EOperationType::ESchemeOpDropSysView, &NKikimrSchemeOp::TModifyScheme::MutableDrop)
     DROP_BY_PATH_ID_HELPERS(DropSysView, NKikimrSchemeOp::EOperationType::ESchemeOpDropSysView)
 
+    // secret
+    GENERIC_HELPERS(CreateSecret, NKikimrSchemeOp::EOperationType::ESchemeOpCreateSecret, &NKikimrSchemeOp::TModifyScheme::MutableCreateSecret)
+    GENERIC_HELPERS(AlterSecret, NKikimrSchemeOp::EOperationType::ESchemeOpAlterSecret, &NKikimrSchemeOp::TModifyScheme::MutableAlterSecret)
+    GENERIC_HELPERS(DropSecret, NKikimrSchemeOp::EOperationType::ESchemeOpDropSecret, &NKikimrSchemeOp::TModifyScheme::MutableDrop)
+    DROP_BY_PATH_ID_HELPERS(DropSecret, NKikimrSchemeOp::EOperationType::ESchemeOpDropSecret)
+
     #undef DROP_BY_PATH_ID_HELPERS
     #undef GENERIC_WITH_ATTRS_HELPERS
     #undef GENERIC_HELPERS

--- a/ydb/core/tx/schemeshard/ut_helpers/helpers.h
+++ b/ydb/core/tx/schemeshard/ut_helpers/helpers.h
@@ -326,6 +326,12 @@ namespace NSchemeShardUT_Private {
     GENERIC_HELPERS(DropSysView);
     DROP_BY_PATH_ID_HELPERS(DropSysView);
 
+    // secret
+    GENERIC_HELPERS(CreateSecret);
+    GENERIC_HELPERS(AlterSecret);
+    GENERIC_HELPERS(DropSecret);
+    DROP_BY_PATH_ID_HELPERS(DropSecret);
+
     #undef DROP_BY_PATH_ID_HELPERS
     #undef GENERIC_WITH_ATTRS_HELPERS
     #undef GENERIC_HELPERS

--- a/ydb/core/tx/schemeshard/ut_helpers/ls_checks.cpp
+++ b/ydb/core/tx/schemeshard/ut_helpers/ls_checks.cpp
@@ -496,6 +496,13 @@ void IsSysView(const NKikimrScheme::TEvDescribeSchemeResult& record) {
     UNIT_ASSERT_VALUES_EQUAL(selfPath.GetPathType(), NKikimrSchemeOp::EPathTypeSysView);
 }
 
+void IsSecret(const NKikimrScheme::TEvDescribeSchemeResult& record) {
+    UNIT_ASSERT_VALUES_EQUAL(record.GetStatus(), NKikimrScheme::StatusSuccess);
+    const auto& pathDescr = record.GetPathDescription();
+    const auto& selfPath = pathDescr.GetSelf();
+    UNIT_ASSERT_VALUES_EQUAL(selfPath.GetPathType(), NKikimrSchemeOp::EPathTypeSecret);
+}
+
 TCheckFunc CheckColumns(const TString& name, const TSet<TString>& columns, const TSet<TString>& droppedColumns, const TSet<TString> keyColumns, bool strictCount) {
     return [=] (const NKikimrScheme::TEvDescribeSchemeResult& record) {
         UNIT_ASSERT(record.HasPathDescription());

--- a/ydb/core/tx/schemeshard/ut_helpers/ls_checks.h
+++ b/ydb/core/tx/schemeshard/ut_helpers/ls_checks.h
@@ -116,6 +116,7 @@ namespace NLs {
     void IsResourcePool(const NKikimrScheme::TEvDescribeSchemeResult& record);
     void IsBackupCollection(const NKikimrScheme::TEvDescribeSchemeResult& record);
     void IsSysView(const NKikimrScheme::TEvDescribeSchemeResult& record);
+    void IsSecret(const NKikimrScheme::TEvDescribeSchemeResult& record);
     TCheckFunc CheckColumns(const TString& name, const TSet<TString>& columns, const TSet<TString>& droppedColumns, const TSet<TString> keyColumns, bool strictCount = false);
     TCheckFunc CheckColumnType(const ui64 columnIndex, const TString& columnTypename);
     void CheckBoundaries(const NKikimrScheme::TEvDescribeSchemeResult& record);

--- a/ydb/core/tx/schemeshard/ut_secret/ut_secret.cpp
+++ b/ydb/core/tx/schemeshard/ut_secret/ut_secret.cpp
@@ -52,6 +52,26 @@ Y_UNIT_TEST_SUITE(TSchemeShardSecretTest) {
         }
     }
 
+    Y_UNIT_TEST(CreateSecretAndIntermediateDirs) {
+        TTestBasicRuntime runtime;
+        TTestEnv env(runtime);
+        ui64 txId = 100;
+
+        TestCreateSecret(runtime, ++txId, "/MyRoot",
+            R"(
+                Name: "dir1/dir2/test-secret"
+                Value: "test-value"
+            )"
+        );
+        env.TestWaitNotification(runtime, txId);
+
+        {
+            const auto describeResult = DescribePath(runtime, "/MyRoot/dir1/dir2/test-secret");
+            TestDescribeResult(describeResult, {NLs::Finished, NLs::IsSecret});
+            ExpectEqualSecretDescription(describeResult, "test-secret", "test-value", 0);
+        }
+    }
+
     Y_UNIT_TEST(CreateExistingSecret) {
         TTestBasicRuntime runtime;
         TTestEnv env(runtime);

--- a/ydb/core/tx/schemeshard/ut_secret/ut_secret.cpp
+++ b/ydb/core/tx/schemeshard/ut_secret/ut_secret.cpp
@@ -1,0 +1,396 @@
+#include <ydb/core/tx/schemeshard/ut_helpers/helpers.h>
+
+namespace {
+    using namespace NSchemeShardUT_Private;
+    using NKikimrScheme::EStatus;
+
+    void ExpectEqualSecretDescription(
+        const NKikimrScheme::TEvDescribeSchemeResult& describeResult,
+        const TString& name,
+        const TString& value,
+        const ui64 version
+    ) {
+        UNIT_ASSERT(describeResult.HasPathDescription());
+        UNIT_ASSERT(describeResult.GetPathDescription().HasSecretDescription());
+        const auto& secretDescription = describeResult.GetPathDescription().GetSecretDescription();
+        UNIT_ASSERT_VALUES_EQUAL(secretDescription.GetName(), name);
+        UNIT_ASSERT_VALUES_EQUAL(secretDescription.GetValue(), value);
+        UNIT_ASSERT_VALUES_EQUAL(secretDescription.GetVersion(), version);
+    }
+}
+
+Y_UNIT_TEST_SUITE(TSchemeShardSecretTest) {
+    Y_UNIT_TEST(CreateSecret) {
+        TTestBasicRuntime runtime;
+        TTestEnv env(runtime);
+        ui64 txId = 100;
+
+        TestMkDir(runtime, ++txId, "/MyRoot", "dir");
+        env.TestWaitNotification(runtime, txId);
+
+        TestCreateSecret(runtime, ++txId, "/MyRoot/dir",
+            R"(
+                Name: "test-secret"
+                Value: "test-value"
+            )"
+        );
+        env.TestWaitNotification(runtime, txId);
+
+        {
+            const auto describeResult = DescribePath(runtime, "/MyRoot/dir/test-secret");
+            TestDescribeResult(describeResult, {NLs::Finished, NLs::IsSecret});
+            ExpectEqualSecretDescription(describeResult, "test-secret", "test-value", 0);
+        }
+
+        TActorId sender = runtime.AllocateEdgeActor();
+        RebootTablet(runtime, TTestTxConfig::SchemeShard, sender);
+
+        {
+            const auto describeResult = DescribePath(runtime, "/MyRoot/dir/test-secret");
+            TestDescribeResult(describeResult, {NLs::Finished, NLs::IsSecret});
+            ExpectEqualSecretDescription(describeResult, "test-secret", "test-value", 0);
+        }
+    }
+
+    Y_UNIT_TEST(CreateExistingSecret) {
+        TTestBasicRuntime runtime;
+        TTestEnv env(runtime);
+        ui64 txId = 100;
+
+        TestMkDir(runtime, ++txId, "/MyRoot", "dir");
+        env.TestWaitNotification(runtime, txId);
+
+        TestCreateSecret(runtime, ++txId, "/MyRoot/dir",
+            R"(
+                Name: "test-secret"
+                Value: "test-value-init"
+            )"
+        );
+        env.TestWaitNotification(runtime, txId);
+        TestLs(runtime, "/MyRoot/dir/test-secret", false, NLs::PathExist);
+
+        TestCreateSecret(runtime, ++txId, "/MyRoot/dir",
+            R"(
+                Name: "test-secret"
+                Value: "test-value-new"
+            )",
+            {EStatus::StatusSchemeError, EStatus::StatusAlreadyExists}
+        );
+        env.TestWaitNotification(runtime, txId);
+        const auto describeResult = DescribePath(runtime, "/MyRoot/dir/test-secret");
+        TestDescribeResult(describeResult, {NLs::Finished, NLs::IsSecret});
+        ExpectEqualSecretDescription(describeResult, "test-secret", "test-value-init", 0);
+    }
+
+    Y_UNIT_TEST(AsyncCreateDifferentSecrets) {
+        TTestBasicRuntime runtime;
+        TTestEnv env(runtime);
+        ui64 txId = 100;
+
+        TestMkDir(runtime, ++txId, "/MyRoot", "dir");
+        env.TestWaitNotification(runtime, txId);
+
+        AsyncCreateSecret(runtime, ++txId, "/MyRoot/dir",
+            R"(
+                Name: "test-secret-1"
+                Value: "test-value-1"
+            )"
+        );
+        AsyncCreateSecret(runtime, ++txId, "/MyRoot/dir",
+            R"(
+                Name: "test-secret-2"
+                Value: "test-value-2"
+            )"
+        );
+
+        TestModificationResult(runtime, txId - 1);
+        TestModificationResult(runtime, txId);
+        env.TestWaitNotification(runtime, {txId - 1, txId});
+
+        for (int i = 1; i <= 2; ++i){
+            const auto describeResult = DescribePath(runtime, "/MyRoot/dir/test-secret-" + ToString(i));
+            TestDescribeResult(describeResult, {NLs::Finished, NLs::IsSecret});
+            ExpectEqualSecretDescription(
+                describeResult,
+                "test-secret-" + ToString(i),
+                "test-value-" + ToString(i),
+                0
+            );
+        }
+    }
+
+    Y_UNIT_TEST(AsyncCreateSameSecret) {
+        TTestBasicRuntime runtime;
+        TTestEnv env(runtime);
+        ui64 txId = 100;
+
+        TestMkDir(runtime, ++txId, "/MyRoot", "dir");
+        env.TestWaitNotification(runtime, txId);
+
+        for (int i = 0; i < 2; ++i) {
+            AsyncCreateSecret(runtime, ++txId, "/MyRoot/dir",
+                R"(
+                    Name: "test-secret"
+                    Value: "test-value"
+                )"
+            );
+        }
+        const TVector<TExpectedResult> expectedResults = {EStatus::StatusAccepted,
+                                                          EStatus::StatusMultipleModifications,
+                                                          EStatus::StatusAlreadyExists};
+        TestModificationResults(runtime, txId - 1, expectedResults);
+        TestModificationResults(runtime, txId, expectedResults);
+        env.TestWaitNotification(runtime, {txId - 1, txId});
+
+        const auto describeResult = DescribePath(runtime, "/MyRoot/dir/test-secret");
+        TestDescribeResult(describeResult, {NLs::Finished, NLs::IsSecret});
+        ExpectEqualSecretDescription(describeResult, "test-secret", "test-value", 0);
+    }
+
+    Y_UNIT_TEST(ReadOnlyMode) {
+        TTestBasicRuntime runtime;
+        TTestEnv env(runtime);
+        ui64 txId = 100;
+
+        TestMkDir(runtime, ++txId, "/MyRoot", "dir");
+        env.TestWaitNotification(runtime, txId);
+        SetSchemeshardReadOnlyMode(runtime, true);
+        TActorId sender = runtime.AllocateEdgeActor();
+        RebootTablet(runtime, TTestTxConfig::SchemeShard, sender);
+
+        TestCreateSecret(runtime, ++txId, "/MyRoot/dir",
+            R"(
+                Name: "test-name"
+                Value: "test-value"
+            )",
+            {{EStatus::StatusReadOnly}}
+        );
+        env.TestWaitNotification(runtime, txId);
+        TestLs(runtime, "/MyRoot/dir/test-name", false, NLs::PathNotExist);
+
+        SetSchemeshardReadOnlyMode(runtime, false);
+        sender = runtime.AllocateEdgeActor();
+        RebootTablet(runtime, TTestTxConfig::SchemeShard, sender);
+
+        TestCreateSecret(runtime, ++txId, "/MyRoot/dir",
+            R"(
+                Name: "test-name"
+                Value: "test-value"
+            )"
+        );
+        env.TestWaitNotification(runtime, txId);
+        TestLs(runtime, "/MyRoot/dir/test-name", false, NLs::PathExist);
+    }
+
+    Y_UNIT_TEST(EmptySecretName) {
+        TTestBasicRuntime runtime;
+        TTestEnv env(runtime);
+        ui64 txId = 100;
+
+        TestMkDir(runtime, ++txId, "/MyRoot", "dir");
+        env.TestWaitNotification(runtime, txId);
+
+        TestCreateSecret(runtime, ++txId, "/MyRoot/dir",
+            R"(
+                Name: ""
+                Value: "test-value"
+            )",
+            {{EStatus::StatusSchemeError, "error: path part shouldn't be empty"}}
+        );
+        env.TestWaitNotification(runtime, txId);
+    }
+
+    Y_UNIT_TEST(CreateNotInDatabase) {
+        TTestBasicRuntime runtime;
+        TTestEnv env(runtime);
+        ui64 txId = 100;
+
+        TestCreateSecret(runtime, ++txId, "/MyRoot",
+            R"(
+                Name: "test-name"
+                Value: "test-value"
+            )"
+        );
+        env.TestWaitNotification(runtime, txId);
+        TestLs(runtime, "/MyRoot/test-name", false, NLs::PathExist);
+    }
+
+    Y_UNIT_TEST(DropSecret) {
+        TTestBasicRuntime runtime;
+        TTestEnv env(runtime);
+        ui64 txId = 100;
+
+        TestMkDir(runtime, ++txId, "/MyRoot", "dir");
+        env.TestWaitNotification(runtime, txId);
+
+        TestCreateSecret(runtime, ++txId, "/MyRoot/dir",
+            R"(
+                Name: "test-secret"
+                Value: "test-value"
+            )"
+        );
+        env.TestWaitNotification(runtime, txId);
+
+        TestLs(runtime, "/MyRoot/dir/test-secret", false, NLs::PathExist);
+
+        TestDropSecret(runtime, ++txId, "/MyRoot/dir", "test-secret");
+        env.TestWaitNotification(runtime, txId);
+        TestLs(runtime, "/MyRoot/dir/test-secret", false, NLs::PathNotExist);
+
+        TActorId sender = runtime.AllocateEdgeActor();
+        RebootTablet(runtime, TTestTxConfig::SchemeShard, sender);
+        TestLs(runtime, "/MyRoot/dir/test-secret", false, NLs::PathNotExist);
+    }
+
+    Y_UNIT_TEST(DropUnexistingSecret) {
+        TTestBasicRuntime runtime;
+        TTestEnv env(runtime);
+        ui64 txId = 100;
+
+        TestLs(runtime, "/MyRoot/test-secret", false, NLs::PathNotExist);
+
+        TestDropSecret(
+            runtime,
+            ++txId,
+            "/MyRoot",
+            "test-secret",
+            {EStatus::StatusPathDoesNotExist}
+        );
+        env.TestWaitNotification(runtime, txId);
+    }
+
+    Y_UNIT_TEST(AsyncDropSameSecret) {
+        TTestBasicRuntime runtime;
+        TTestEnv env(runtime);
+        ui64 txId = 100;
+
+        TestMkDir(runtime, ++txId, "/MyRoot", "dir");
+        env.TestWaitNotification(runtime, txId);
+
+        TestCreateSecret(runtime, ++txId, "/MyRoot/dir",
+            R"(
+                Name: "test-secret"
+                Value: "test-value"
+            )"
+        );
+        env.TestWaitNotification(runtime, txId);
+
+        TestLs(runtime, "/MyRoot/dir/test-secret", false, NLs::PathExist);
+
+        for (int i = 0; i < 2; ++i) {
+            AsyncDropSecret(runtime, ++txId, "/MyRoot/dir", "test-secret");
+            AsyncDropSecret(runtime, ++txId, "/MyRoot/dir", "test-secret");
+        }
+        const TVector<TExpectedResult> expectedResults = {EStatus::StatusAccepted,
+                                                          EStatus::StatusMultipleModifications,
+                                                          EStatus::StatusPathDoesNotExist};
+        TestModificationResults(runtime, txId - 1, expectedResults);
+        TestModificationResults(runtime, txId, expectedResults);
+        env.TestWaitNotification(runtime, {txId - 1, txId});
+
+        TestLs(runtime, "/MyRoot/dir/test-secret", false, NLs::PathNotExist);
+    }
+
+    Y_UNIT_TEST(AlterExistingSecretMultipleTImes) {
+        TTestBasicRuntime runtime;
+        TTestEnv env(runtime);
+        ui64 txId = 100;
+
+        TestMkDir(runtime, ++txId, "/MyRoot", "dir");
+        env.TestWaitNotification(runtime, txId);
+
+        TestCreateSecret(runtime, ++txId, "/MyRoot/dir",
+            R"(
+                Name: "test-secret"
+                Value: "test-value-0"
+            )"
+        );
+        env.TestWaitNotification(runtime, txId);
+        TestLs(runtime, "/MyRoot/dir/test-secret", false, NLs::PathExist);
+
+        TestAlterSecret(runtime, ++txId, "/MyRoot/dir",
+            R"(
+                Name: "test-secret"
+                Value: "test-value-1"
+            )"
+        );
+        env.TestWaitNotification(runtime, txId);
+        auto describeResult = DescribePath(runtime, "/MyRoot/dir/test-secret");
+        TestDescribeResult(describeResult, {NLs::Finished, NLs::IsSecret});
+        ExpectEqualSecretDescription(describeResult, "test-secret", "test-value-1", 1);
+
+        TestAlterSecret(runtime, ++txId, "/MyRoot/dir",
+            R"(
+                Name: "test-secret"
+                Value: "test-value-2"
+            )"
+        );
+        env.TestWaitNotification(runtime, txId);
+        describeResult = DescribePath(runtime, "/MyRoot/dir/test-secret");
+        TestDescribeResult(describeResult, {NLs::Finished, NLs::IsSecret});
+        ExpectEqualSecretDescription(describeResult, "test-secret", "test-value-2", 2);
+
+        TActorId sender = runtime.AllocateEdgeActor();
+        RebootTablet(runtime, TTestTxConfig::SchemeShard, sender);
+        describeResult = DescribePath(runtime, "/MyRoot/dir/test-secret");
+        TestDescribeResult(describeResult, {NLs::Finished, NLs::IsSecret});
+        ExpectEqualSecretDescription(describeResult, "test-secret", "test-value-2", 2);
+    }
+
+    Y_UNIT_TEST(AlterUnexistingSecret) {
+        TTestBasicRuntime runtime;
+        TTestEnv env(runtime);
+        ui64 txId = 100;
+
+        TestMkDir(runtime, ++txId, "/MyRoot", "dir");
+        env.TestWaitNotification(runtime, txId);
+
+        TestLs(runtime, "/MyRoot/dir/test-secret", false, NLs::PathNotExist);
+
+        TestAlterSecret(runtime, ++txId, "/MyRoot/dir",
+            R"(
+                 Name: "test-secret"
+                Value: "test-value"
+            )",
+             {EStatus::StatusPathDoesNotExist}
+        );
+        env.TestWaitNotification(runtime, txId);
+
+        TestLs(runtime, "/MyRoot/dir/test-secret", false, NLs::PathNotExist);
+    }
+
+    Y_UNIT_TEST(AsyncAlterSameSecret) {
+        TTestBasicRuntime runtime;
+        TTestEnv env(runtime);
+        ui64 txId = 100;
+
+        TestMkDir(runtime, ++txId, "/MyRoot", "dir");
+        env.TestWaitNotification(runtime, txId);
+
+        TestCreateSecret(runtime, ++txId, "/MyRoot/dir",
+            R"(
+                Name: "test-secret"
+                Value: "test-value-init"
+            )"
+        );
+        env.TestWaitNotification(runtime, txId);
+
+        for (int i = 0; i < 2; ++i) {
+            AsyncAlterSecret(runtime, ++txId, "/MyRoot/dir",
+                R"(
+                    Name: "test-secret"
+                    Value: "test-value-new"
+                )"
+            );
+        }
+        const TVector<TExpectedResult> expectedResults = {EStatus::StatusAccepted,
+                                                          EStatus::StatusMultipleModifications};
+        TestModificationResults(runtime, txId - 1, expectedResults);
+        TestModificationResults(runtime, txId, expectedResults);
+        env.TestWaitNotification(runtime, {txId - 1, txId});
+
+        const auto describeResult = DescribePath(runtime, "/MyRoot/dir/test-secret");
+        TestDescribeResult(describeResult, {NLs::Finished, NLs::IsSecret});
+        ExpectEqualSecretDescription(describeResult, "test-secret", "test-value-new", 1);
+    }
+}

--- a/ydb/core/tx/schemeshard/ut_secret/ya.make
+++ b/ydb/core/tx/schemeshard/ut_secret/ya.make
@@ -1,0 +1,18 @@
+UNITTEST_FOR(ydb/core/tx/schemeshard)
+
+FORK_SUBTESTS()
+
+SIZE(MEDIUM)
+
+PEERDIR(
+    ydb/core/testlib/basics/default
+    ydb/core/tx/schemeshard/ut_helpers
+)
+
+SRCS(
+    ut_secret.cpp
+)
+
+YQL_LAST_ABI_VERSION()
+
+END()

--- a/ydb/core/tx/schemeshard/ut_secret_reboots/ut_secret_reboots.cpp
+++ b/ydb/core/tx/schemeshard/ut_secret_reboots/ut_secret_reboots.cpp
@@ -19,7 +19,7 @@ namespace {
 }
 
 Y_UNIT_TEST_SUITE(TSchemeShardSecretTestReboots) {
-    Y_UNIT_TEST(CreateSecretWithReboots) {
+    Y_UNIT_TEST(CreateSecret) {
         TTestWithReboots t;
         t.Run([&](TTestActorRuntime& runtime, bool& activeZone) {
             {
@@ -44,7 +44,7 @@ Y_UNIT_TEST_SUITE(TSchemeShardSecretTestReboots) {
         });
     }
 
-    Y_UNIT_TEST(AlterSecretWithReboots) {
+    Y_UNIT_TEST(AlterSecret) {
         TTestWithReboots t;
         t.Run([&](TTestActorRuntime& runtime, bool& activeZone) {
             {
@@ -78,7 +78,7 @@ Y_UNIT_TEST_SUITE(TSchemeShardSecretTestReboots) {
         });
     }
 
-    Y_UNIT_TEST(DropSecretWithReboots) {
+    Y_UNIT_TEST(DropSecret) {
         TTestWithReboots t;
         t.Run([&](TTestActorRuntime& runtime, bool& activeZone) {
             {

--- a/ydb/core/tx/schemeshard/ut_secret_reboots/ut_secret_reboots.cpp
+++ b/ydb/core/tx/schemeshard/ut_secret_reboots/ut_secret_reboots.cpp
@@ -1,0 +1,107 @@
+#include <ydb/core/tx/schemeshard/ut_helpers/helpers.h>
+
+namespace {
+    using namespace NSchemeShardUT_Private;
+
+    void ExpectEqualSecretDescription(
+        const NKikimrScheme::TEvDescribeSchemeResult& describeResult,
+        const TString& name,
+        const TString& value,
+        const ui64 version
+    ) {
+        UNIT_ASSERT(describeResult.HasPathDescription());
+        UNIT_ASSERT(describeResult.GetPathDescription().HasSecretDescription());
+        const auto& secretDescription = describeResult.GetPathDescription().GetSecretDescription();
+        UNIT_ASSERT_VALUES_EQUAL(secretDescription.GetName(), name);
+        UNIT_ASSERT_VALUES_EQUAL(secretDescription.GetValue(), value);
+        UNIT_ASSERT_VALUES_EQUAL(secretDescription.GetVersion(), version);
+    }
+}
+
+Y_UNIT_TEST_SUITE(TSchemeShardSecretTestReboots) {
+    Y_UNIT_TEST(CreateSecretWithReboots) {
+        TTestWithReboots t;
+        t.Run([&](TTestActorRuntime& runtime, bool& activeZone) {
+            {
+                TInactiveZone inactive(activeZone);
+                TestMkDir(runtime, ++t.TxId, "/MyRoot", "dir");
+                t.TestEnv->TestWaitNotification(runtime, t.TxId);
+            }
+
+            TestCreateSecret(runtime, ++t.TxId, "/MyRoot/dir",
+                R"(
+                    Name: "test-secret"
+                    Value: "test-value"
+                )"
+            );
+            t.TestEnv->TestWaitNotification(runtime, t.TxId);
+
+            {
+                TInactiveZone inactive(activeZone);
+                const auto describeResult = DescribePath(runtime, "/MyRoot/dir/test-secret");
+                TestDescribeResult(describeResult, {NLs::Finished, NLs::IsSecret});
+            }
+        });
+    }
+
+    Y_UNIT_TEST(AlterSecretWithReboots) {
+        TTestWithReboots t;
+        t.Run([&](TTestActorRuntime& runtime, bool& activeZone) {
+            {
+                TInactiveZone inactive(activeZone);
+                TestMkDir(runtime, ++t.TxId, "/MyRoot", "dir");
+                t.TestEnv->TestWaitNotification(runtime, t.TxId);
+
+                TestCreateSecret(runtime, ++t.TxId, "/MyRoot/dir",
+                    R"(
+                        Name: "test-secret"
+                        Value: "test-value-0"
+                    )"
+                );
+                t.TestEnv->TestWaitNotification(runtime, t.TxId);
+            }
+
+            TestAlterSecret(runtime, ++t.TxId, "/MyRoot/dir",
+                R"(
+                    Name: "test-secret"
+                    Value: "test-value-1"
+                )"
+            );
+            t.TestEnv->TestWaitNotification(runtime, t.TxId);
+
+            {
+                TInactiveZone inactive(activeZone);
+                const auto describeResult = DescribePath(runtime, "/MyRoot/dir/test-secret");
+                TestDescribeResult(describeResult, {NLs::Finished, NLs::IsSecret});
+                ExpectEqualSecretDescription(describeResult, "test-secret", "test-value-1", 1);
+            }
+        });
+    }
+
+    Y_UNIT_TEST(DropSecretWithReboots) {
+        TTestWithReboots t;
+        t.Run([&](TTestActorRuntime& runtime, bool& activeZone) {
+            {
+                TInactiveZone inactive(activeZone);
+                TestMkDir(runtime, ++t.TxId, "/MyRoot", "dir");
+                t.TestEnv->TestWaitNotification(runtime, t.TxId);
+                TestCreateSecret(runtime, ++t.TxId, "/MyRoot/dir",
+                    R"(
+                        Name: "test-secret"
+                        Value: "test-value"
+                    )"
+                );
+                t.TestEnv->TestWaitNotification(runtime, t.TxId);
+                TestLs(runtime, "/MyRoot/dir/test-secret", false, NLs::PathExist);
+            }
+
+            TestDropSecret(runtime, ++t.TxId, "/MyRoot/dir", "test-secret");
+            t.TestEnv->TestWaitNotification(runtime, t.TxId);
+
+            {
+                TInactiveZone inactive(activeZone);
+                TestLs(runtime, "/MyRoot/dir/test-secret", false, NLs::PathNotExist);
+            }
+        });
+    }
+}

--- a/ydb/core/tx/schemeshard/ut_secret_reboots/ya.make
+++ b/ydb/core/tx/schemeshard/ut_secret_reboots/ya.make
@@ -1,0 +1,31 @@
+IF (NOT WITH_VALGRIND)
+    UNITTEST_FOR(ydb/core/tx/schemeshard)
+
+    FORK_SUBTESTS()
+
+    SPLIT_FACTOR(60)
+
+    IF (SANITIZER_TYPE OR WITH_VALGRIND)
+        SIZE(LARGE)
+        INCLUDE(${ARCADIA_ROOT}/ydb/tests/large.inc)
+        REQUIREMENTS(ram:12)
+    ELSE()
+        SIZE(MEDIUM)
+    ENDIF()
+
+    PEERDIR(
+        ydb/core/testlib/default
+        ydb/core/tx
+        ydb/core/tx/schemeshard/ut_helpers
+        yql/essentials/public/udf/service/exception_policy
+    )
+
+    YQL_LAST_ABI_VERSION()
+
+    SRCS(
+        ut_secret_reboots.cpp
+    )
+
+
+END()
+ENDIF()

--- a/ydb/core/tx/schemeshard/ut_system_names/ut_system_names.cpp
+++ b/ydb/core/tx/schemeshard/ut_system_names/ut_system_names.cpp
@@ -474,17 +474,15 @@ const std::vector<TCreatePathOp> CreatePathOperations({
     },
     {
         .Type = NKikimrSchemeOp::EOperationType::ESchemeOpCreateSecret,
-        //TODO: proper check
-        .CreateRequest = nullptr,
-        // .CreateRequest = [](const TString& workingDir, const TString& path) {
-        //     const TString modifyScheme = Sprintf(
-        //         R"(
-        //             Name: "%s"
-        //         )",
-        //         path.c_str()
-        //     );
-        //     return CreateSecretRequest(0 /* txId */, workingDir, modifyScheme);
-        // }
+        .CreateRequest = [](const TString& workingDir, const TString& path) {
+            const TString modifyScheme = Sprintf(
+                R"(
+                    Name: "%s"
+                )",
+                path.c_str()
+            );
+            return CreateSecretRequest(0 /* txId */, workingDir, modifyScheme);
+        }
     },
 
     //NOTE: ADD NEW ENTRY ABOVE THIS LINE

--- a/ydb/core/tx/schemeshard/ut_system_names/ut_system_names.cpp
+++ b/ydb/core/tx/schemeshard/ut_system_names/ut_system_names.cpp
@@ -472,6 +472,20 @@ const std::vector<TCreatePathOp> CreatePathOperations({
         //     return CreateSysViewRequest(0 /* txId */, workingDir, modifyScheme);
         // }
     },
+    {
+        .Type = NKikimrSchemeOp::EOperationType::ESchemeOpCreateSecret,
+        //TODO: proper check
+        .CreateRequest = nullptr,
+        // .CreateRequest = [](const TString& workingDir, const TString& path) {
+        //     const TString modifyScheme = Sprintf(
+        //         R"(
+        //             Name: "%s"
+        //         )",
+        //         path.c_str()
+        //     );
+        //     return CreateSecretRequest(0 /* txId */, workingDir, modifyScheme);
+        // }
+    },
 
     //NOTE: ADD NEW ENTRY ABOVE THIS LINE
 });

--- a/ydb/core/tx/schemeshard/ya.make
+++ b/ydb/core/tx/schemeshard/ya.make
@@ -51,6 +51,8 @@ RECURSE_FOR_TESTS(
     ut_serverless_reboots
     ut_split_merge
     ut_split_merge_reboots
+    ut_secret
+    ut_secret_reboots
     ut_stats
     ut_subdomain
     ut_subdomain_reboots
@@ -111,6 +113,7 @@ SRCS(
     schemeshard__operation_alter_pq.cpp
     schemeshard__operation_alter_replication.cpp
     schemeshard__operation_alter_resource_pool.cpp
+    schemeshard__operation_alter_secret.cpp
     schemeshard__operation_alter_sequence.cpp
     schemeshard__operation_alter_solomon.cpp
     schemeshard__operation_alter_subdomain.cpp
@@ -154,6 +157,7 @@ SRCS(
     schemeshard__operation_create_replication.cpp
     schemeshard__operation_create_resource_pool.cpp
     schemeshard__operation_create_restore.cpp
+    schemeshard__operation_create_secret.cpp
     schemeshard__operation_create_restore_incremental_backup.cpp
     schemeshard__operation_incremental_restore_finalize.cpp
     schemeshard__operation_create_rtmr.cpp
@@ -179,6 +183,7 @@ SRCS(
     schemeshard__operation_drop_pq.cpp
     schemeshard__operation_drop_replication.cpp
     schemeshard__operation_drop_resource_pool.cpp
+    schemeshard__operation_drop_secret.cpp
     schemeshard__operation_drop_sequence.cpp
     schemeshard__operation_drop_solomon.cpp
     schemeshard__operation_drop_subdomain.cpp

--- a/ydb/core/tx/tx_proxy/schemereq.cpp
+++ b/ydb/core/tx/tx_proxy/schemereq.cpp
@@ -473,6 +473,7 @@ struct TBaseSchemeReq: public TActorBootstrapped<TDerived> {
         case NKikimrSchemeOp::ESchemeOpCreateResourcePool:
         case NKikimrSchemeOp::ESchemeOpCreateBackupCollection:
         case NKikimrSchemeOp::ESchemeOpCreateSysView:
+        case NKikimrSchemeOp::ESchemeOpCreateSecret:
             return true;
         default:
             return false;

--- a/ydb/core/tx/tx_proxy/schemereq.cpp
+++ b/ydb/core/tx/tx_proxy/schemereq.cpp
@@ -168,6 +168,7 @@ struct TBaseSchemeReq: public TActorBootstrapped<TDerived> {
         case NKikimrSchemeOp::ESchemeOpDropView:
         case NKikimrSchemeOp::ESchemeOpDropResourcePool:
         case NKikimrSchemeOp::ESchemeOpDropSysView:
+        case NKikimrSchemeOp::ESchemeOpDropSecret:
             return *modifyScheme.MutableDrop()->MutableName();
 
         case NKikimrSchemeOp::ESchemeOpAlterTable:
@@ -392,6 +393,12 @@ struct TBaseSchemeReq: public TActorBootstrapped<TDerived> {
 
         case NKikimrSchemeOp::ESchemeOpDropContinuousBackup:
             return *modifyScheme.MutableDropContinuousBackup()->MutableTableName();
+
+        case NKikimrSchemeOp::ESchemeOpCreateSecret:
+            return *modifyScheme.MutableCreateSecret()->MutableName();
+
+        case NKikimrSchemeOp::ESchemeOpAlterSecret:
+            return *modifyScheme.MutableAlterSecret()->MutableName();
 
         case NKikimrSchemeOp::ESchemeOpCreateResourcePool:
             return *modifyScheme.MutableCreateResourcePool()->MutableName();
@@ -756,7 +763,10 @@ struct TBaseSchemeReq: public TActorBootstrapped<TDerived> {
         case NKikimrSchemeOp::ESchemeOpDropContinuousBackup:
         case NKikimrSchemeOp::ESchemeOpAlterResourcePool:
         case NKikimrSchemeOp::ESchemeOpAlterBackupCollection:
+        case NKikimrSchemeOp::ESchemeOpAlterSecret:
+        case NKikimrSchemeOp::ESchemeOpCreateSecret:
         {
+            // TODO(yurikiselev): Change grants according to discussed [issue:23460]
             auto toResolve = TPathToResolve(pbModifyScheme);
             toResolve.Path = Merge(workingDir, SplitPath(GetPathNameForScheme(pbModifyScheme)));
             toResolve.RequireAccess = NACLib::EAccessRights::AlterSchema | accessToUserAttrs;
@@ -818,6 +828,7 @@ struct TBaseSchemeReq: public TActorBootstrapped<TDerived> {
         case NKikimrSchemeOp::ESchemeOpDropView:
         case NKikimrSchemeOp::ESchemeOpDropResourcePool:
         case NKikimrSchemeOp::ESchemeOpDropBackupCollection:
+        case NKikimrSchemeOp::ESchemeOpDropSecret:
         {
             auto toResolve = TPathToResolve(pbModifyScheme);
             toResolve.Path = Merge(workingDir, SplitPath(GetPathNameForScheme(pbModifyScheme)));

--- a/ydb/core/viewer/browse.h
+++ b/ydb/core/viewer/browse.h
@@ -100,6 +100,8 @@ public:
             return NKikimrViewer::EObjectType::ResourcePool;
         case NKikimrSchemeOp::EPathType::EPathTypeSysView:
             return NKikimrViewer::EObjectType::SysView;
+        case NKikimrSchemeOp::EPathType::EPathTypeSecret:
+            return NKikimrViewer::EObjectType::Secret;
         case NKikimrSchemeOp::EPathType::EPathTypeExtSubDomain:
         case NKikimrSchemeOp::EPathType::EPathTypeTableIndex:
         case NKikimrSchemeOp::EPathType::EPathTypeInvalid:

--- a/ydb/core/viewer/protos/viewer.proto
+++ b/ydb/core/viewer/protos/viewer.proto
@@ -45,6 +45,7 @@ enum EObjectType {
     View = 26;
     ResourcePool = 27;
     SysView = 28;
+    Secret = 29;
 }
 
 message TBrowseInfo {

--- a/ydb/public/lib/deprecated/kicli/kicli.h
+++ b/ydb/public/lib/deprecated/kicli/kicli.h
@@ -591,6 +591,7 @@ public:
         BackupCollection,
         Transfer,
         SysView,
+        Secret,
     };
 
     TSchemaObject(TSchemaObject&&) = default;

--- a/ydb/public/lib/deprecated/kicli/schema.cpp
+++ b/ydb/public/lib/deprecated/kicli/schema.cpp
@@ -140,6 +140,9 @@ void TSchemaObject::Drop() {
     case EPathType::ResourcePool:
         drop.SetOperationType(NKikimrSchemeOp::EOperationType::ESchemeOpDropResourcePool);
         break;
+    case EPathType::Secret:
+        drop.SetOperationType(NKikimrSchemeOp::EOperationType::ESchemeOpDropSecret);
+        break;
     case EPathType::BackupCollection:
         // FIXME(+active)
         // drop.SetOperationType(NKikimrSchemeOp::EOperationType::ESchemeOpDropBackupCollection);
@@ -244,6 +247,8 @@ static TSchemaObject::EPathType GetType(const NKikimrSchemeOp::TDirEntry& entry)
         return TSchemaObject::EPathType::BackupCollection;
     case NKikimrSchemeOp::EPathTypeSysView:
         return TSchemaObject::EPathType::SysView;
+    case NKikimrSchemeOp::EPathTypeSecret:
+        return TSchemaObject::EPathType::Secret;
     case NKikimrSchemeOp::EPathTypeTableIndex:
     case NKikimrSchemeOp::EPathTypeExtSubDomain:
     case NKikimrSchemeOp::EPathTypeCdcStream:

--- a/ydb/services/ydb/backup_ut/ydb_backup_ut.cpp
+++ b/ydb/services/ydb/backup_ut/ydb_backup_ut.cpp
@@ -2203,6 +2203,8 @@ Y_UNIT_TEST_SUITE(BackupRestore) {
             case EPathTypeColumnStore:
             case EPathTypeColumnTable:
                 break; // https://github.com/ydb-platform/ydb/issues/10459
+            case EPathTypeSecret:
+                break; // TODO(yurikiselev): Support backups [issue:23489]
             case EPathTypeInvalid:
             case EPathTypeBackupCollection:
             case EPathTypeBlobDepot:
@@ -3005,6 +3007,8 @@ Y_UNIT_TEST_SUITE(BackupRestoreS3) {
             case EPathTypeColumnStore:
             case EPathTypeColumnTable:
                 break; // https://github.com/ydb-platform/ydb/issues/10459
+            case EPathTypeSecret:
+                break; // TODO(yurikiselev): Support backups [issue:23489]
             case EPathTypeInvalid:
             case EPathTypeBackupCollection:
             case EPathTypeBlobDepot:

--- a/ydb/tests/functional/scheme_tests/canondata/tablet_scheme_tests.TestTabletSchemes.test_tablet_schemes_flat_schemeshard_/flat_schemeshard.schema
+++ b/ydb/tests/functional/scheme_tests/canondata/tablet_scheme_tests.TestTabletSchemes.test_tablet_schemes_flat_schemeshard_/flat_schemeshard.schema
@@ -9089,5 +9089,105 @@
                 ]
             }
         }
+    },
+    {
+        "TableId": 127,
+        "TableName": "Secrets",
+        "TableKey": [
+            1
+        ],
+        "ColumnsAdded": [
+            {
+                "ColumnId": 1,
+                "ColumnName": "PathId",
+                "ColumnType": "Uint64"
+            },
+            {
+                "ColumnId": 2,
+                "ColumnName": "AlterVersion",
+                "ColumnType": "Uint64"
+            },
+            {
+                "ColumnId": 3,
+                "ColumnName": "Description",
+                "ColumnType": "String"
+            }
+        ],
+        "ColumnsDropped": [],
+        "ColumnFamilies": {
+            "0": {
+                "Columns": [
+                    1,
+                    2,
+                    3
+                ],
+                "RoomID": 0,
+                "Codec": 0,
+                "InMemory": false,
+                "Cache": 0,
+                "Small": 4294967295,
+                "Large": 4294967295
+            }
+        },
+        "Rooms": {
+            "0": {
+                "Main": 1,
+                "Outer": 1,
+                "Blobs": 1,
+                "ExternalBlobs": [
+                    1
+                ]
+            }
+        }
+    },
+    {
+        "TableId": 128,
+        "TableName": "SecretsAlterData",
+        "TableKey": [
+            1
+        ],
+        "ColumnsAdded": [
+            {
+                "ColumnId": 1,
+                "ColumnName": "PathId",
+                "ColumnType": "Uint64"
+            },
+            {
+                "ColumnId": 2,
+                "ColumnName": "AlterVersion",
+                "ColumnType": "Uint64"
+            },
+            {
+                "ColumnId": 3,
+                "ColumnName": "Description",
+                "ColumnType": "String"
+            }
+        ],
+        "ColumnsDropped": [],
+        "ColumnFamilies": {
+            "0": {
+                "Columns": [
+                    1,
+                    2,
+                    3
+                ],
+                "RoomID": 0,
+                "Codec": 0,
+                "InMemory": false,
+                "Cache": 0,
+                "Small": 4294967295,
+                "Large": 4294967295
+            }
+        },
+        "Rooms": {
+            "0": {
+                "Main": 1,
+                "Outer": 1,
+                "Blobs": 1,
+                "ExternalBlobs": [
+                    1
+                ]
+            }
+        }
     }
 ]


### PR DESCRIPTION
### Changelog category
* Not for changelog

### Description for reviewers
Added basic schema operations support. For now secrets values are stored in SchemaCache. It will be changed separately.