### PR TITLE
Fix BSC group status reporting for Bridge mode

### DIFF
--- a/ydb/core/mind/bscontroller/bsc.cpp
+++ b/ydb/core/mind/bscontroller/bsc.cpp
@@ -271,7 +271,7 @@ void TBlobStorageController::Handle(TEvNodeWardenStorageConfig::TPtr ev) {
     Y_DEBUG_ABORT_UNLESS(!isFirstStorageConfig || CurrentStateFunc() == &TThis::StateInit);
 
     StorageConfig = std::move(ev->Get()->Config);
-    BridgeInfo = std::move(ev->Get()->BridgeInfo);
+    auto prevBridgeInfo = std::exchange(BridgeInfo, std::move(ev->Get()->BridgeInfo));
     SelfManagementEnabled = ev->Get()->SelfManagementEnabled;
 
     auto prevStaticPDisks = std::exchange(StaticPDisks, {});
@@ -309,6 +309,27 @@ void TBlobStorageController::Handle(TEvNodeWardenStorageConfig::TPtr ev) {
             }
         } else {
             Y_FAIL("no storage configuration provided");
+        }
+    }
+
+    // if bridge info has changed, then add any dynamic groups to sys view changed list
+    if (BridgeInfo) {
+        bool changed = false;
+        if (!prevBridgeInfo) {
+            changed = true;
+        } else {
+            Y_ABORT_UNLESS(std::size(prevBridgeInfo->Piles) == std::size(BridgeInfo->Piles));
+            for (size_t k = 0; k < std::size(BridgeInfo->Piles); ++k) {
+                if (prevBridgeInfo->Piles[k].State != BridgeInfo->Piles[k].State) {
+                    changed = true;
+                    break;
+                }
+            }
+        }
+        if (changed) {
+            for (const auto& [groupId, group] : GroupMap) {
+                SysViewChangedGroups.insert(groupId);
+            }
         }
     }
 
@@ -1130,7 +1151,7 @@ void TBlobStorageController::TStaticGroupInfo::UpdateStatus(TMonotonic mono, TBl
         if (const auto it = controller->StaticVSlots.find(vslotId); it != controller->StaticVSlots.end()) {
             if (mono <= it->second.ReadySince) { // VDisk can't be treated as READY one
                 failed |= {topology, vdiskId};
-            } else if (const TPDiskInfo *pdisk = controller->FindPDisk(vslotId.ComprisingPDiskId()); !pdisk || !pdisk->HasGoodExpectedStatus()) {
+            } else if (const TPDiskInfo *pdisk = controller->FindPDisk(vslotId.ComprisingPDiskId()); pdisk && !pdisk->HasGoodExpectedStatus()) {
                 failedByPDisk |= {topology, vdiskId};
             }
         } else {
@@ -1164,25 +1185,64 @@ void TBlobStorageController::TStaticGroupInfo::UpdateLayoutCorrect(TBlobStorageC
     LayoutCorrect = layout.IsCorrect();
 }
 
-TBlobStorageController::TGroupInfo::TGroupStatus TBlobStorageController::TStaticGroupInfo::GetStatus(
-        const TStaticGroupFinder& finder) const {
-    if (Info && Info->IsBridged()) {
-        std::optional<TGroupInfo::TGroupStatus> res;
-        for (TGroupId groupId : Info->GetBridgeGroupIds()) {
-            if (TStaticGroupInfo *g = finder(groupId)) {
-                if (const auto& s = g->GetStatus(finder); res) {
-                    res->MakeWorst(s.OperatingStatus, s.ExpectedStatus);
-                } else {
-                    res.emplace(s);
-                }
-            } else {
-                Y_DEBUG_ABORT();
-            }
+namespace {
+
+    template<typename T, typename TFinder>
+    TBlobStorageController::TGroupInfo::TGroupStatus GetGroupStatus(const T& entity, TFinder&& finder,
+            const TBridgeInfo *bridgeInfo) {
+        const NKikimrBlobStorage::TGroupInfo *groupInfo = nullptr;
+        if constexpr (std::is_same_v<T, TBlobStorageController::TGroupInfo>) {
+            groupInfo = entity.BridgeGroupInfo
+                ? &entity.BridgeGroupInfo.value()
+                : nullptr;
+        } else {
+            Y_DEBUG_ABORT_UNLESS(entity.Info);
+            Y_DEBUG_ABORT_UNLESS(entity.Info->Group);
+            groupInfo = entity.Info && entity.Info->Group && entity.Info->Group->HasBridgeGroupState()
+                ? &entity.Info->Group.value()
+                : nullptr;
         }
-        return res.value_or(TGroupInfo::TGroupStatus());
-    } else {
-        return Status;
+
+        if (groupInfo) {
+            Y_ABORT_UNLESS(bridgeInfo);
+            Y_ABORT_UNLESS(groupInfo->HasBridgeGroupState());
+
+            std::optional<TBlobStorageController::TGroupInfo::TGroupStatus> res;
+            const auto& bridgeGroupState = groupInfo->GetBridgeGroupState();
+            const auto& piles = bridgeGroupState.GetPile();
+
+            for (int pileIndex = 0; pileIndex < piles.size(); ++pileIndex) {
+                const TBridgePileId bridgePileId = TBridgePileId::FromPileIndex(pileIndex);
+                if (NBridge::PileStateTraits(bridgeInfo->GetPile(bridgePileId)->State).RequiresDataQuorum) {
+                    const auto& pile = piles[pileIndex];
+                    const auto groupId = TGroupId::FromProto(&pile, &NKikimrBridge::TGroupState::TPile::GetGroupId);
+                    if (const auto *group = finder(groupId)) {
+                        const auto& s = group->GetStatus(finder, bridgeInfo);
+                        if (res) {
+                            res->MakeWorst(s.OperatingStatus, s.ExpectedStatus);
+                        } else {
+                            res.emplace(s);
+                        }
+                    }
+                }
+            }
+
+            return res.value_or(TBlobStorageController::TGroupInfo::TGroupStatus());
+        } else {
+            return entity.Status;
+        }
     }
+
+}
+
+TBlobStorageController::TGroupInfo::TGroupStatus TBlobStorageController::TGroupInfo::GetStatus(
+        const TGroupFinder& finder, const TBridgeInfo *bridgeInfo) const {
+    return GetGroupStatus(*this, finder, bridgeInfo);
+}
+
+TBlobStorageController::TGroupInfo::TGroupStatus TBlobStorageController::TStaticGroupInfo::GetStatus(
+        const TStaticGroupFinder& finder, const TBridgeInfo *bridgeInfo) const {
+    return GetGroupStatus(*this, finder, bridgeInfo);
 }
 
 bool TBlobStorageController::TStaticGroupInfo::IsLayoutCorrect(const TStaticGroupFinder& finder) const {

--- a/ydb/core/mind/bscontroller/cmds_storage_pool.cpp
+++ b/ydb/core/mind/bscontroller/cmds_storage_pool.cpp
@@ -575,7 +575,7 @@ namespace NKikimr::NBsController {
 
         Groups.ForEach([&](TGroupId groupId, const TGroupInfo& groupInfo) {
             if (!virtualGroupsOnly || groupFilter.contains(groupId)) {
-               Serialize(pb->AddGroup(), groupInfo, finder);
+               Serialize(pb->AddGroup(), groupInfo, finder, BridgeInfo.get());
             }
         });
 
@@ -641,7 +641,7 @@ namespace NKikimr::NBsController {
                         const TVSlotId vslotId(nodeId, pdiskId, vdiskSlotId);
                         vslotId.Serialize(x->AddVSlotId());
                     }
-                    const auto& status = group.GetStatus(finder);
+                    const auto& status = group.GetStatus(finder, BridgeInfo.get());
                     x->SetOperatingStatus(status.OperatingStatus);
                     x->SetExpectedStatus(status.ExpectedStatus);
                 }

--- a/ydb/core/mind/bscontroller/config.cpp
+++ b/ydb/core/mind/bscontroller/config.cpp
@@ -1147,7 +1147,7 @@ namespace NKikimr::NBsController {
         }
 
         void TBlobStorageController::Serialize(NKikimrBlobStorage::TBaseConfig::TGroup *pb, const TGroupInfo &group,
-                const TGroupInfo::TGroupFinder& finder) {
+                const TGroupInfo::TGroupFinder& finder, const TBridgeInfo *bridgeInfo) {
             pb->SetGroupId(group.ID.GetRawId());
             pb->SetGroupGeneration(group.Generation);
             pb->SetErasureSpecies(TBlobStorageGroupType::ErasureSpeciesName(group.ErasureSpecies));
@@ -1159,7 +1159,7 @@ namespace NKikimr::NBsController {
             pb->SetSeenOperational(group.SeenOperational);
             pb->SetGroupSizeInUnits(group.GroupSizeInUnits);
 
-            const auto& status = group.GetStatus(finder);
+            const auto& status = group.GetStatus(finder, bridgeInfo);
             pb->SetOperatingStatus(status.OperatingStatus);
             pb->SetExpectedStatus(status.ExpectedStatus);
 

--- a/ydb/core/mind/bscontroller/disk_metrics.cpp
+++ b/ydb/core/mind/bscontroller/disk_metrics.cpp
@@ -33,20 +33,19 @@ public:
                 value.ClearVDiskId();
                 db.Table<Schema::VDiskMetrics>().Key(key).Update<Schema::VDiskMetrics::Metrics>(value);
                 Self->SysViewChangedVSlots.insert(vslotId);
-                Self->SysViewChangedGroups.insert(v->GroupId);
+                Self->SysViewChangedGroups.insert(v->GroupId); // TODO(alexvru): really necessary?
             }
         }
 
         for (auto& [vslotId, v] : Self->StaticVSlots) {
             if (std::exchange(v.MetricsDirty, false)) {
-                Self->SysViewChangedVSlots.insert(vslotId);
                 auto vdiskId = v.VDiskId;
                 auto groupId = vdiskId.GroupID.GetRawId();
                 auto&& key = std::tie(groupId, vdiskId.GroupGeneration, vdiskId.FailRealm, vdiskId.FailDomain, vdiskId.VDisk);
                 auto value = v.VDiskMetrics;
                 value->ClearVDiskId();
                 db.Table<Schema::VDiskMetrics>().Key(key).Update<Schema::VDiskMetrics::Metrics>(*value);
-                Self->SysViewChangedGroups.insert(vdiskId.GroupID);
+                Self->SysViewChangedVSlots.insert(vslotId);
             }
         }
         return true;

--- a/ydb/core/mind/bscontroller/impl.h
+++ b/ydb/core/mind/bscontroller/impl.h
@@ -887,24 +887,7 @@ public:
             }
         }
 
-        TGroupStatus GetStatus(const TGroupFinder& finder) const {
-            if (BridgeGroupInfo) {
-                std::optional<TGroupStatus> res;
-                for (const auto& pile : BridgeGroupInfo->GetBridgeGroupState().GetPile()) {
-                    const TGroupInfo *group = finder(TGroupId::FromProto(&pile, &NKikimrBridge::TGroupState::TPile::GetGroupId));
-                    if (group) {
-                        if (const TGroupStatus& s = group->GetStatus(finder); res) {
-                            res->MakeWorst(s.OperatingStatus, s.ExpectedStatus);
-                        } else {
-                            res.emplace(s);
-                        }
-                    }
-                }
-                return res.value_or(TGroupStatus());
-            } else {
-                return Status;
-            }
-        }
+        TGroupStatus GetStatus(const TGroupFinder& finder, const TBridgeInfo *bridgeInfo) const;
 
         void OnCommit();
     };
@@ -2411,7 +2394,7 @@ public:
         void UpdateStatus(TMonotonic mono, TBlobStorageController *controller);
         void UpdateLayoutCorrect(TBlobStorageController *controller);
 
-        TGroupInfo::TGroupStatus GetStatus(const TStaticGroupFinder& finder) const;
+        TGroupInfo::TGroupStatus GetStatus(const TStaticGroupFinder& finder, const TBridgeInfo *bridgeInfo) const;
         bool IsLayoutCorrect(const TStaticGroupFinder& finder) const;
     };
 
@@ -2529,7 +2512,7 @@ public:
     static void Serialize(NKikimrBlobStorage::TVDiskLocation *pb, const TVSlotId& vslotId);
     static void Serialize(NKikimrBlobStorage::TBaseConfig::TVSlot *pb, const TVSlotInfo &vslot, const TVSlotFinder& finder);
     static void Serialize(NKikimrBlobStorage::TBaseConfig::TGroup *pb, const TGroupInfo &group,
-        const TGroupInfo::TGroupFinder& finder);
+        const TGroupInfo::TGroupFinder& finder, const TBridgeInfo *bridgeInfo);
     static void SerializeDonors(NKikimrBlobStorage::TNodeWardenServiceSet::TVDisk *vdisk, const TVSlotInfo& vslot,
         const TGroupInfo& group, const TVSlotFinder& finder);
     static void SerializeGroupInfo(NKikimrBlobStorage::TGroupInfo *group, const TGroupInfo& groupInfo,

--- a/ydb/core/mind/bscontroller/monitoring.cpp
+++ b/ydb/core/mind/bscontroller/monitoring.cpp
@@ -1493,7 +1493,7 @@ void TBlobStorageController::RenderGroupRow(IOutputStream& out, const TGroupInfo
             TABLED() { out << (group.SeenOperational ? "YES" : ""); }
             TABLED() { out << (group.IsLayoutCorrect(finder) ? "" : "NO"); }
 
-            const auto& status = group.GetStatus(finder);
+            const auto& status = group.GetStatus(finder, BridgeInfo.get());
             TABLED() { out << NKikimrBlobStorage::TGroupStatus::E_Name(status.OperatingStatus); }
             TABLED() { out << NKikimrBlobStorage::TGroupStatus::E_Name(status.ExpectedStatus); }
             TABLED() {

--- a/ydb/core/mind/bscontroller/self_heal.cpp
+++ b/ydb/core/mind/bscontroller/self_heal.cpp
@@ -1144,7 +1144,8 @@ namespace NKikimr::NBsController {
                     }
                 }
             }
-            if (const auto it = StaticVSlots.find(vslotId); it != StaticVSlots.end() && it->second.VDiskId == vdiskId) {
+            if (const auto it = StaticVSlots.find(vslotId); it != StaticVSlots.end() &&
+                    vdiskId.SameExceptGeneration(it->second.VDiskId)) {
                 auto& vslot = it->second;
                 vslot.VDiskStatus = m.GetStatus();
                 if (vslot.VDiskStatus == NKikimrBlobStorage::EVDiskStatus::READY) {


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

Fix BSC group status reporting for Bridge mode

### Changelog category <!-- remove all except one -->

* Not for changelog (changelog entry is not required)

### Description for reviewers <!-- (optional) description for those who read this PR -->

This patch makes correct BSC group status reporting when switching pile states.
