### PR TITLE
Pass audit log parts from grpc request check actor to monitoring [simple way]

### DIFF
--- a/ydb/core/grpc_services/base/base.h
+++ b/ydb/core/grpc_services/base/base.h
@@ -1676,27 +1676,31 @@ private:
 
 class TEvRequestAuthAndCheckResult : public TEventLocal<TEvRequestAuthAndCheckResult, TRpcServices::EvRequestAuthAndCheckResult> {
 public:
-    TEvRequestAuthAndCheckResult(Ydb::StatusIds::StatusCode status, const NYql::TIssues& issues)
+    TEvRequestAuthAndCheckResult(Ydb::StatusIds::StatusCode status, const NYql::TIssues& issues, const TAuditLogParts& auditLogParts)
         : Status(status)
         , Issues(issues)
+        , AuditLogParts(auditLogParts)
     {}
 
-    TEvRequestAuthAndCheckResult(Ydb::StatusIds::StatusCode status, const NYql::TIssue& issue)
+    TEvRequestAuthAndCheckResult(Ydb::StatusIds::StatusCode status, const NYql::TIssue& issue, const TAuditLogParts& auditLogParts)
         : Status(status)
+        , AuditLogParts(auditLogParts)
     {
         Issues.AddIssue(issue);
     }
 
-    TEvRequestAuthAndCheckResult(Ydb::StatusIds::StatusCode status, const TString& error)
+    TEvRequestAuthAndCheckResult(Ydb::StatusIds::StatusCode status, const TString& error, const TAuditLogParts& auditLogParts)
         : Status(status)
+        , AuditLogParts(auditLogParts)
     {
         Issues.AddIssue(error);
     }
 
-    TEvRequestAuthAndCheckResult(const TString& database, const TMaybe<TString>& ydbToken, const TIntrusiveConstPtr<NACLib::TUserToken>& userToken)
+    TEvRequestAuthAndCheckResult(const TString& database, const TMaybe<TString>& ydbToken, const TIntrusiveConstPtr<NACLib::TUserToken>& userToken, const TAuditLogParts& auditLogParts)
         : Database(database)
         , YdbToken(ydbToken)
         , UserToken(userToken)
+        , AuditLogParts(auditLogParts)
     {}
 
     Ydb::StatusIds::StatusCode Status = Ydb::StatusIds::SUCCESS;
@@ -1704,17 +1708,19 @@ public:
     TString Database;
     TMaybe<TString> YdbToken;
     TIntrusiveConstPtr<NACLib::TUserToken> UserToken;
+    TAuditLogParts AuditLogParts;
 };
 
 class TEvRequestAuthAndCheck
     : public IRequestProxyCtx
     , public TEventLocal<TEvRequestAuthAndCheck, TRpcServices::EvRequestAuthAndCheck> {
 public:
-    TEvRequestAuthAndCheck(const TString& database, const TMaybe<TString>& ydbToken, NActors::TActorId sender)
+    TEvRequestAuthAndCheck(const TString& database, const TMaybe<TString>& ydbToken, NActors::TActorId sender, TAuditMode auditMode)
         : Database(database)
         , YdbToken(ydbToken)
         , Sender(sender)
         , AuthState(true)
+        , AuditMode(auditMode)
     {}
 
     // IRequestProxyCtx
@@ -1748,14 +1754,16 @@ public:
                 new TEvRequestAuthAndCheckResult(
                     Database,
                     YdbToken,
-                    UserToken
+                    UserToken,
+                    GetAuditLogParts()
                 )
             );
         } else {
             ctx.Send(Sender,
                 new TEvRequestAuthAndCheckResult(
                     status,
-                    IssueManager.GetIssues()
+                    IssueManager.GetIssues(),
+                    GetAuditLogParts()
                 )
             );
         }
@@ -1891,6 +1899,10 @@ public:
         return {};
     }
 
+    TAuditMode GetAuditMode() const override {
+        return AuditMode;
+    }
+
     TString Database;
     TMaybe<TString> YdbToken;
     NActors::TActorId Sender;
@@ -1902,6 +1914,7 @@ public:
     NYql::TIssueManager IssueManager;
     TIntrusiveConstPtr<NACLib::TUserToken> UserToken;
     TInstant deadline = TInstant::Now() + TDuration::Seconds(10);
+    TAuditMode AuditMode;
 
     inline static const TString EmptySerializedTokenMessage;
 };

--- a/ydb/core/grpc_services/grpc_request_check_actor.h
+++ b/ydb/core/grpc_services/grpc_request_check_actor.h
@@ -559,6 +559,12 @@ private:
     }
 
     void HandleAndDie(TEvRequestAuthAndCheck::TPtr& ev) {
+        // Request audit happen after successful authentication
+        // and authorization check against the database
+        // TODO: refactor: http monitoring authentication/authorization scheme must pass the same
+        // way as for grpc API
+        AuditRequest(GrpcRequestBaseCtx_, CheckedDatabaseName_);
+
         GrpcRequestBaseCtx_->FinishSpan();
         ev->Get()->ReplyWithYdbStatus(Ydb::StatusIds::SUCCESS);
         PassAway();

--- a/ydb/core/mon/audit/audit.h
+++ b/ydb/core/mon/audit/audit.h
@@ -21,10 +21,11 @@ enum ERequestStatus {
 class TAuditCtx {
 public:
     void InitAudit(const NHttp::TEvHttpProxy::TEvHttpIncomingRequest::TPtr& ev);
-    void AddAuditLogParts(const TIntrusiveConstPtr<NACLib::TUserToken>& userToken);
+    void AddAuditLogParts(const TAuditParts& parts); // TODO: pass request context instead of audit log parts
     void LogAudit(ERequestStatus status, const TString& reason, NKikimrConfig::TAuditConfig::TLogClassConfig::ELogPhase logPhase);
     void LogOnReceived();
     void LogOnCompleted(const NHttp::THttpOutgoingResponsePtr& response);
+    void SetSubjectType(NACLibProto::ESubjectType subjectType);
 
 private:
     void AddAuditLogPart(TStringBuf name, const TString& value);
@@ -33,8 +34,6 @@ private:
     TAuditParts Parts;
     bool Auditable = false;
     NACLibProto::ESubjectType SubjectType = NACLibProto::SUBJECT_TYPE_ANONYMOUS;
-    TString Subject;
-    TString SanitizedToken;
 };
 
 }

--- a/ydb/core/mon/mon.cpp
+++ b/ydb/core/mon/mon.cpp
@@ -108,7 +108,8 @@ IEventHandle* GetRequestAuthAndCheckHandle(const NActors::TActorId& owner, const
         new NKikimr::NGRpcService::TEvRequestAuthAndCheck(
             database,
             ticket ? TMaybe<TString>(ticket) : Nothing(),
-            owner),
+            owner,
+            NGRpcService::TAuditMode::Modifying(NGRpcService::TAuditMode::TLogClassConfig::ClusterAdmin)),
         IEventHandle::FlagTrackDelivery
     );
 }
@@ -136,7 +137,8 @@ NActors::IEventHandle* GetAuthorizeTicketResult(const NActors::TActorId& owner) 
             owner,
             new NKikimr::NGRpcService::TEvRequestAuthAndCheckResult(
                 Ydb::StatusIds::UNAUTHORIZED,
-                "No security credentials were provided")
+                "No security credentials were provided",
+                {})
         );
     } else if (!NKikimr::AppData()->DefaultUserSIDs.empty()) {
         TIntrusivePtr<NACLib::TUserToken> token = new NACLib::TUserToken(NKikimr::AppData()->DefaultUserSIDs);
@@ -146,7 +148,8 @@ NActors::IEventHandle* GetAuthorizeTicketResult(const NActors::TActorId& owner) 
             new NKikimr::NGRpcService::TEvRequestAuthAndCheckResult(
                 {},
                 {},
-                token
+                token,
+                {}
             )
         );
     } else {
@@ -523,9 +526,12 @@ public:
                 << " " << request->URL);
         }
         TString serializedToken;
-        if (result && result->UserToken) {
-            AuditCtx.AddAuditLogParts(result->UserToken);
-            serializedToken = result->UserToken->GetSerializedToken();
+        if (result) {
+            AuditCtx.AddAuditLogParts(result->AuditLogParts);
+            if (result->UserToken) {
+                AuditCtx.SetSubjectType(result->UserToken->GetSubjectType());
+                serializedToken = result->UserToken->GetSerializedToken();
+            }
         }
         AuditCtx.LogOnReceived();
         Send(ActorMonPage->TargetActorId, new NMon::TEvHttpInfo(
@@ -1170,9 +1176,12 @@ public:
                 << " " << request->Method
                 << " " << request->URL);
         }
-        if (result && result->UserToken) {
-            AuditCtx.AddAuditLogParts(result->UserToken);
-            Event->Get()->UserToken = result->UserToken->GetSerializedToken();
+        if (result) {
+            AuditCtx.AddAuditLogParts(result->AuditLogParts);
+            if (result->UserToken) {
+                AuditCtx.SetSubjectType(result->UserToken->GetSubjectType());
+                Event->Get()->UserToken = result->UserToken->GetSerializedToken();
+            }
         }
         AuditCtx.LogOnReceived();
         Send(new IEventHandle(Fields.Handler, SelfId(), Event->ReleaseBase().Release(), IEventHandle::FlagTrackDelivery, Event->Cookie));


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

...

### Changelog category <!-- remove all except one -->

* Not for changelog (changelog entry is not required)

### Description for reviewers <!-- (optional) description for those who read this PR -->

This PR allows to pass folder_id/cloud_id/resource_id parameters from the actor that performs authentication step to the monitoring subsystem. Then monitoring uses them in audit logging.

I passed audit log parts to monitoring. In the future it should be done in more common way: the same as for request through grpc API: instead of passing audit log parts separately, the request context should be passed. Then this context should be used (as in grpc subsystem) in audit logging directly. It enables to use one audit context filled in one place in both http and grpc.