### PR TITLE
prevent resync after a successful sync and reconfiguration

### DIFF
--- a/ydb/core/tx/scheme_board/subscriber.cpp
+++ b/ydb/core/tx/scheme_board/subscriber.cpp
@@ -984,6 +984,7 @@ class TSubscriber: public TMonitorableActor<TDerived> {
 
         this->Send(Owner, new NInternalEvents::TEvSyncResponse(Path, !syncIsComplete), 0, ev->Cookie);
 
+        CurrentSyncRequest = 0;
         PendingSync.clear();
         ReceivedSync.clear();
 


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

### Changelog category <!-- remove all except one -->

* Not for changelog (changelog entry is not required)

### Description for reviewers <!-- (optional) description for those who read this PR -->

Epic:
- https://github.com/ydb-platform/ydb/issues/19748

Issue:
- https://github.com/ydb-platform/ydb/issues/23528

Previously, it multiple successful sync requests with the same cookie were possible, because Scheme Board reconfiguration has led to a restart of the current sync request. We need to reset the current sync request data member after a successful sync to prevent resync with this cookie.
