### PR TITLE
Fix infinite retries for TEvCollectGarbage on deleted tablets when doing Bridge sync

### DIFF
--- a/ydb/core/blobstorage/bridge/syncer/syncer.cpp
+++ b/ydb/core/blobstorage/bridge/syncer/syncer.cpp
@@ -234,9 +234,9 @@ namespace NKikimr::NBridge {
                 }
                 auto kv = std::make_unique<TVector<TLogoBlobID>>();
                 std::ranges::set_difference(tempKeep, *dkv, std::back_inserter(*kv)); // do not keep flag overrides keep
-                IssueQuery(true, std::make_unique<TEvBlobStorage::TEvCollectGarbage>(tabletId, Max<ui32>(),
-                    0u, false, 0u, 0u, kv->empty() ? nullptr : kv.release(), dkv->empty() ? nullptr : dkv.release(),
-                    TInstant::Max()));
+                IssueQuery(true, std::make_unique<TEvBlobStorage::TEvCollectGarbage>(tabletId, Max<ui32>(), 0u, 0u,
+                    false, 0u, 0u, kv->empty() ? nullptr : kv.release(), dkv->empty() ? nullptr : dkv.release(),
+                    TInstant::Max(), true, false, true));
             }
         };
 


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

Fix infinite retries for TEvCollectGarbage on deleted tablets when doing Bridge sync

### Changelog category <!-- remove all except one -->

* Not for changelog (changelog entry is not required)

### Description for reviewers <!-- (optional) description for those who read this PR -->

This patch fixes incorrect syncer behaviour when it issues CollectGarbage command with keep flags only with maximum generation set and without setting IgnoreBlock flag, thus leading to impossibility of this command execution when tablet gets deleted and maximum generation is blocked. In the case of failure command gets retried infinitely, leading to impossibility to get in SYNCHRONIZED state.
