### PR TITLE
YQ-4580 fixed hash shuffle channels restore for streaming queries

### DIFF
--- a/ydb/core/kqp/executer_actor/kqp_tasks_graph.cpp
+++ b/ydb/core/kqp/executer_actor/kqp_tasks_graph.cpp
@@ -1593,6 +1593,22 @@ void RestoreTasksGraphInfo(TKqpTasksGraph& tasksGraph, const NKikimrKqp::TQueryP
                     const auto& hashInfo = outputInfo.GetHashPartition();
                     newOutput.KeyColumns.assign(hashInfo.GetKeyColumns().begin(), hashInfo.GetKeyColumns().end());
                     newOutput.PartitionsCount = hashInfo.GetPartitionsCount();
+
+                    switch (hashInfo.GetHashKindCase()) {
+                        case NDqProto::TTaskOutputHashPartition::kHashV1:
+                            newOutput.HashKind = EHashShuffleFuncType::HashV1;
+                            break;
+                        case NDqProto::TTaskOutputHashPartition::kHashV2:
+                            newOutput.HashKind = EHashShuffleFuncType::HashV2;
+                            break;
+                        case NDqProto::TTaskOutputHashPartition::kColumnShardHashV1:
+                            newOutput.HashKind = EHashShuffleFuncType::ColumnShardHashV1;
+                            break;
+                        case NDqProto::TTaskOutputHashPartition::HASHKIND_NOT_SET:
+                            YQL_ENSURE(false, "Unknown hash kind");
+                            break;
+                    }
+
                     break;
                 }
                 case NDqProto::TTaskOutput::kBroadcast: {

--- a/ydb/core/kqp/executer_actor/kqp_tasks_graph.cpp
+++ b/ydb/core/kqp/executer_actor/kqp_tasks_graph.cpp
@@ -1605,7 +1605,7 @@ void RestoreTasksGraphInfo(TKqpTasksGraph& tasksGraph, const NKikimrKqp::TQueryP
                             newOutput.HashKind = EHashShuffleFuncType::ColumnShardHashV1;
                             break;
                         case NDqProto::TTaskOutputHashPartition::HASHKIND_NOT_SET:
-                            YQL_ENSURE(false, "Unknown hash kind");
+                            YQL_ENSURE(false, "Hash kind not set");
                             break;
                     }
 

--- a/ydb/core/kqp/ut/federated_query/datastreams/datastreams_ut.cpp
+++ b/ydb/core/kqp/ut/federated_query/datastreams/datastreams_ut.cpp
@@ -26,478 +26,634 @@ using namespace NTestUtils;
 namespace {
 
 struct TScriptQuerySettings {
-    TString Query;
     bool SaveState = false;
     NKikimrKqp::TScriptExecutionRetryState::TMapping RetryMapping;
     std::optional<NKikimrKqp::TQueryPhysicalGraph> PhysicalGraph;
     TDuration Timeout = TDuration::Seconds(30);
 };
 
-std::pair<TString, TOperation::TOperationId> StartScriptQuery(TTestActorRuntime& runtime, const TScriptQuerySettings& settings) {
-    NKikimrKqp::TEvQueryRequest queryProto;
-    queryProto.SetUserToken(NACLib::TUserToken(BUILTIN_ACL_ROOT, TVector<NACLib::TSID>{runtime.GetAppData().AllAuthenticatedUsers}).SerializeAsString());
-    auto& req = *queryProto.MutableRequest();
-    req.SetDatabase("/Root");
-    req.SetQuery(settings.Query);
-    req.SetAction(NKikimrKqp::QUERY_ACTION_EXECUTE);
-    req.SetType(NKikimrKqp::QUERY_TYPE_SQL_GENERIC_SCRIPT);
+class TStreamingTestFixture : public NUnitTest::TBaseFixture {
+public:
+    // External YDB recipe
+    inline static const TString YDB_ENDPOINT = GetEnv("YDB_ENDPOINT");
+    inline static const TString YDB_DATABASE = GetEnv("YDB_DATABASE");
 
-    auto ev = MakeHolder<TEvKqp::TEvScriptRequest>();
-    ev->Record = queryProto;
-    ev->ForgetAfter = settings.Timeout;
-    ev->ResultsTtl = settings.Timeout;
-    ev->RetryMapping = {settings.RetryMapping};
-    ev->SaveQueryPhysicalGraph = settings.SaveState;
-    ev->QueryPhysicalGraph = settings.PhysicalGraph;
+    // Local kikimr test cluster
+    inline static constexpr char TEST_DATABASE[] = "/Root";
 
-    const auto edgeActor = runtime.AllocateEdgeActor();
-    runtime.Send(MakeKqpProxyID(runtime.GetNodeId()), edgeActor, ev.Release());
+    inline static constexpr TDuration TEST_OPERATION_TIMEOUT = TDuration::Seconds(10);
 
-    const auto reply = runtime.GrabEdgeEvent<TEvKqp::TEvScriptResponse>(edgeActor, settings.Timeout);
-    UNIT_ASSERT_C(reply, "CreateScript response is empty");
-    UNIT_ASSERT_VALUES_EQUAL_C(reply->Get()->Status, Ydb::StatusIds::SUCCESS, reply->Get()->Issues.ToString());
+public:
+    // Local kikimr settings
 
-    const auto& executionId = reply->Get()->ExecutionId;    
-    UNIT_ASSERT(executionId);
+    NKikimrConfig::TAppConfig& SetupAppConfig() {
+        UNIT_ASSERT_C(!AppConfig, "AppConfig is already initialized");
+        EnsureNotInitialized("AppConfig");
 
-    return {executionId, TOperation::TOperationId(ScriptExecutionOperationFromExecutionId(executionId))};
-}
+        return AppConfig.emplace();
+    }
+
+    TIntrusivePtr<IMockPqGateway> SetupMockPqGateway() {
+        UNIT_ASSERT_C(!PqGateway, "PqGateway is already initialized");
+        EnsureNotInitialized("MockPqGateway");
+
+        const auto mockPqGateway = CreateMockPqGateway();
+        PqGateway = mockPqGateway;
+
+        return mockPqGateway;
+    }
+
+    // Local kikimr test cluster
+
+    std::shared_ptr<TKikimrRunner> GetKikimrRunner() {
+        if (!Kikimr) {
+            Kikimr = MakeKikimrRunner(true, nullptr, nullptr, AppConfig, NYql::NDq::CreateS3ActorsFactory(), {
+                .PqGateway = PqGateway
+            });
+        }
+
+        return Kikimr;
+    }
+
+    TTestActorRuntime& GetRuntime() {
+        return *GetKikimrRunner()->GetTestServer().GetRuntime();
+    }
+
+    std::shared_ptr<TDriver> GetInternalDriver() {
+        if (!InternalDriver) {
+            InternalDriver = std::make_shared<TDriver>(GetKikimrRunner()->GetDriver());
+        }
+
+        return InternalDriver;
+    }
+
+    std::shared_ptr<TQueryClient> GetQueryClient() {
+        if (!QueryClient) {
+            QueryClient = std::make_shared<TQueryClient>(GetKikimrRunner()->GetQueryClient());
+        }
+
+        return QueryClient;
+    }
+
+    std::shared_ptr<NYdb::NTable::TTableClient> GetTableClient() {
+        if (!TableClient) {
+            TableClient = std::make_shared<NYdb::NTable::TTableClient>(GetKikimrRunner()->GetTableClient());
+        }
+
+        return TableClient;
+    }
+
+    std::shared_ptr<NOperation::TOperationClient> GetOperationClient() {
+        if (!OperationClient) {
+            OperationClient = std::make_shared<NOperation::TOperationClient>(*GetInternalDriver());
+        }
+
+        return OperationClient;
+    }
+
+    std::shared_ptr<NYdb::NTable::TSession> GetTableClientSession() {
+        if (!TableClientSession) {
+            TableClientSession = std::make_shared<NYdb::NTable::TSession>(
+                GetTableClient()->CreateSession().ExtractValueSync().GetSession()
+            );
+        }
+
+        return TableClientSession;
+    }
+
+    // External YDB recipe
+
+    std::shared_ptr<TDriver> GetExternalDriver() {
+        if (!ExternalDriver) {
+            ExternalDriver = std::make_shared<TDriver>(TDriverConfig()
+                .SetEndpoint(YDB_ENDPOINT)
+                .SetDatabase(YDB_DATABASE));
+        }
+
+        return ExternalDriver;
+    }
+
+    std::shared_ptr<NTopic::TTopicClient> GetTopicClient() {
+        if (!TopicClient) {
+            TopicClient = std::make_shared<NTopic::TTopicClient>(*GetExternalDriver(), NTopic::TTopicClientSettings()
+                .DiscoveryEndpoint(YDB_ENDPOINT)
+                .Database(YDB_DATABASE));
+        }
+
+        return TopicClient;
+    }
+
+    // Topic client SDK (external YDB recipe)
+
+    void CreateTopic(const TString& topicName, std::optional<NTopic::TCreateTopicSettings> settings = std::nullopt) {
+        if (!settings) {
+            settings.emplace()
+                .PartitioningSettings(1, 1);
+        }
+
+        const auto result = GetTopicClient()->CreateTopic(topicName, *settings).ExtractValueSync();
+        UNIT_ASSERT_VALUES_EQUAL_C(result.GetStatus(), EStatus::SUCCESS, result.GetIssues().ToOneLineString());
+    }
+
+    void WriteTopicMessage(const TString& topicName, const TString& message, ui64 partition = 0) {
+        auto writeSession = GetTopicClient()->CreateSimpleBlockingWriteSession(NTopic::TWriteSessionSettings()
+            .Path(topicName)
+            .PartitionId(partition));
+
+        writeSession->Write(NTopic::TWriteMessage(message));
+        writeSession->Close();
+    }
+
+    void ReadTopicMessages(const TString& topicName, const TVector<TString>& expectedMessages, TDuration disposition = TDuration::Seconds(100)) {
+        NTopic::TReadSessionSettings readSettings;
+        readSettings
+            .WithoutConsumer()
+            .AppendTopics(
+                NTopic::TTopicReadSettings(topicName).ReadFromTimestamp(TInstant::Now() - disposition)
+                    .AppendPartitionIds(0)
+            );
+
+        readSettings.EventHandlers_.StartPartitionSessionHandler(
+            [](NTopic::TReadSessionEvent::TStartPartitionSessionEvent& event) {
+                event.Confirm(0);
+            }
+        );
+
+        auto readSession = GetTopicClient()->CreateReadSession(readSettings);
+        std::vector<std::string> received;
+        WaitFor(TEST_OPERATION_TIMEOUT, "topic output messages", [&](TString& error) {
+            if (!readSession->WaitEvent().HasValue()) {
+                error = TStringBuilder() << "no event set, received #" << received.size() << " / " << expectedMessages.size() << " messages";
+                return false;
+            }
+
+            auto event = readSession->GetEvent(/* block */ true);
+            if (const auto dataEvent = std::get_if<NTopic::TReadSessionEvent::TDataReceivedEvent>(&*event)) {
+                for (const auto& message : dataEvent->GetMessages()) {
+                    received.push_back(message.GetData()); 
+                }
+
+                if (received.size() == expectedMessages.size()) {
+                    return true;
+                }
+            }
+
+            UNIT_ASSERT_GE(expectedMessages.size(), received.size());
+
+            error = TStringBuilder() << "got new event, received #" << received.size() << " / " << expectedMessages.size() << " messages";
+            return false;
+        });
+
+        UNIT_ASSERT_VALUES_EQUAL(received.size(), expectedMessages.size());
+        for (size_t i = 0; i < received.size(); ++i) {
+            UNIT_ASSERT_VALUES_EQUAL(received[i], expectedMessages[i]);
+        }
+    }
+
+    // Table client SDK
+
+    void ExecSchemeQuery(const TString& query, EStatus expectedStatus = EStatus::SUCCESS) {
+        const auto result = GetTableClientSession()->ExecuteSchemeQuery(query).ExtractValueSync();
+        UNIT_ASSERT_VALUES_EQUAL_C(result.GetStatus(), expectedStatus, result.GetIssues().ToOneLineString());
+    }
+
+    // Query client SDK
+
+    std::vector<TResultSet> ExecQuery(const TString& query, EStatus expectedStatus = EStatus::SUCCESS) {
+        auto result = GetQueryClient()->ExecuteQuery(query, TTxControl::NoTx()).ExtractValueSync();
+        UNIT_ASSERT_VALUES_EQUAL_C(result.GetStatus(), expectedStatus, result.GetIssues().ToOneLineString());
+        return result.GetResultSets();
+    }
+
+    void CreatePqSource(const TString& pqSourceName) {
+        ExecQuery(fmt::format(R"(
+            CREATE EXTERNAL DATA SOURCE `{pq_source}` WITH (
+                SOURCE_TYPE = "Ydb",
+                LOCATION = "{pq_location}",
+                DATABASE_NAME = "{pq_database_name}",
+                AUTH_METHOD = "NONE"
+            );)",
+            "pq_source"_a = pqSourceName,
+            "pq_location"_a = YDB_ENDPOINT,
+            "pq_database_name"_a = YDB_DATABASE
+        ));
+    }
+
+    void CreatePqSourceBasicAuth(const TString& pqSourceName) {
+        ExecQuery(fmt::format(R"(
+            CREATE OBJECT secret_local_password (TYPE SECRET) WITH (value = "1234");
+            CREATE EXTERNAL DATA SOURCE `{pq_source}` WITH (
+                SOURCE_TYPE = "Ydb",
+                LOCATION = "{pq_location}",
+                DATABASE_NAME = "{pq_database_name}",
+                AUTH_METHOD = "BASIC",
+                LOGIN = "root",
+                PASSWORD_SECRET_NAME = "secret_local_password"
+            );)",
+            "pq_source"_a = pqSourceName,
+            "pq_location"_a = YDB_ENDPOINT,
+            "pq_database_name"_a = YDB_DATABASE
+        ));
+    }
+
+    void CreateS3Source(const TString& bucket, const TString& s3SourceName) {
+        ExecQuery(fmt::format(R"(
+            CREATE EXTERNAL DATA SOURCE `{s3_source}` WITH (
+                SOURCE_TYPE="ObjectStorage",
+                LOCATION="{s3_location}",
+                AUTH_METHOD="NONE"
+            );)",
+            "s3_source"_a = s3SourceName,
+            "s3_location"_a = GetBucketLocation(bucket)
+        ));
+    }
+
+    // Script executions (using query client SDK)
+
+    TOperation::TOperationId ExecScript(const TString& query, std::optional<TExecuteScriptSettings> settings = std::nullopt, bool waitRunning = true) {
+        if (!settings) {
+            settings.emplace()
+                .StatsMode(EStatsMode::Profile);
+        }
+
+        const auto operation = GetQueryClient()->ExecuteScript(query, *settings).ExtractValueSync();
+        const auto& status = operation.Status();
+        UNIT_ASSERT_VALUES_EQUAL_C(status.GetStatus(), EStatus::SUCCESS, status.GetIssues().ToOneLineString());
+
+        if (waitRunning) {
+            WaitScriptExecution(operation.Id(), EExecStatus::Running);
+            Sleep(TDuration::Seconds(1));
+        }
+
+        return operation.Id();
+    }
+
+    void WaitScriptExecution(const TOperation::TOperationId& operationId, EExecStatus finalStatus = EExecStatus::Completed, bool waitRetry = false) {
+        std::optional<TScriptExecutionOperation> operation;
+        WaitFor(TEST_OPERATION_TIMEOUT, TStringBuilder() << "script execution status" << finalStatus, [&, client = GetOperationClient()](TString& error) {
+            operation = client->Get<NYdb::NQuery::TScriptExecutionOperation>(operationId).GetValueSync();
+
+            const auto execStatus = operation->Metadata().ExecStatus;
+            if (execStatus == finalStatus) {
+                return true;
+            }
+
+            const auto& status = operation->Status();
+            UNIT_ASSERT_VALUES_EQUAL_C(status.GetStatus(), EStatus::SUCCESS, status.GetIssues().ToOneLineString());
+            UNIT_ASSERT_C(!operation->Ready(), "Operation unexpectedly ready in status " << execStatus << " (expected status " << finalStatus << ")");
+
+            error = TStringBuilder() << "operation status " << execStatus;
+            return false;
+        });
+
+        const auto& status = operation->Status();
+        const auto execStatus = operation->Metadata().ExecStatus;
+        UNIT_ASSERT_VALUES_EQUAL_C(execStatus, finalStatus, status.GetIssues().ToOneLineString());
+
+        if (finalStatus != EExecStatus::Failed) {
+            UNIT_ASSERT_VALUES_EQUAL_C(status.GetStatus(), EStatus::SUCCESS, status.GetIssues().ToOneLineString());
+        }
+
+        if (!waitRetry) {
+            UNIT_ASSERT_VALUES_EQUAL(operation->Ready(), IsIn({EExecStatus::Completed, EExecStatus::Failed}, execStatus));
+        } else {
+            UNIT_ASSERT_C(!operation->Ready(), "Operation unexpectedly ready for waiting retry");
+        }
+    }
+
+    void ExecAndWaitScript(const TString& query, EExecStatus finalStatus = EExecStatus::Completed, std::optional<TExecuteScriptSettings> settings = std::nullopt) {
+        WaitScriptExecution(ExecScript(query, settings), finalStatus, false);
+    }
+
+    TResultSet FetchScriptResult(const TOperation::TOperationId& operationId, ui64 resultSetId = 0) {
+        WaitScriptExecution(operationId);
+
+        auto result = GetQueryClient()->FetchScriptResults(operationId, resultSetId).ExtractValueSync();
+        UNIT_ASSERT_VALUES_EQUAL_C(result.GetStatus(), EStatus::SUCCESS, result.GetIssues().ToOneLineString());
+
+        return result.ExtractResultSet();
+    }
+
+    void CheckScriptResult(const TResultSet& result, ui64 columnsCount, ui64 rowsCount, std::function<void(TResultSetParser&)> validator) {
+        TResultSetParser resultSet(result);
+        UNIT_ASSERT_VALUES_EQUAL(resultSet.ColumnsCount(), columnsCount);
+        UNIT_ASSERT_VALUES_EQUAL(resultSet.RowsCount(), rowsCount);
+
+        for (ui64 i = 0; i < rowsCount; ++i) {
+            UNIT_ASSERT_C(resultSet.TryNextRow(), i);
+            validator(resultSet);
+        }
+    }
+
+    void CheckScriptResult(const TOperation::TOperationId& operationId, ui64 columnsCount, ui64 rowsCount, std::function<void(TResultSetParser&)> validator, ui64 resultSetId = 0) {
+        CheckScriptResult(FetchScriptResult(operationId, resultSetId), columnsCount, rowsCount, validator);
+    }
+
+    void CancelScriptExecution(const TOperation::TOperationId& operationId) {
+        const auto& result = GetOperationClient()->Cancel(operationId).ExtractValueSync();
+        UNIT_ASSERT_VALUES_EQUAL_C(result.GetStatus(), EStatus::SUCCESS, result.GetIssues().ToOneLineString());
+    }
+
+    // Script executions (native events API)
+
+    std::pair<TString, TOperation::TOperationId> ExecScriptNative(const TString& query, const TScriptQuerySettings& settings = {}, bool waitRunning = true) {
+        auto& runtime = GetRuntime();
+
+        NKikimrKqp::TEvQueryRequest queryProto;
+        queryProto.SetUserToken(NACLib::TUserToken(BUILTIN_ACL_ROOT, TVector<NACLib::TSID>{runtime.GetAppData().AllAuthenticatedUsers}).SerializeAsString());
+
+        auto& req = *queryProto.MutableRequest();
+        req.SetDatabase(TEST_DATABASE);
+        req.SetQuery(query);
+        req.SetAction(NKikimrKqp::QUERY_ACTION_EXECUTE);
+        req.SetType(NKikimrKqp::QUERY_TYPE_SQL_GENERIC_SCRIPT);
+
+        auto ev = std::make_unique<TEvKqp::TEvScriptRequest>();
+        ev->Record = queryProto;
+        ev->ForgetAfter = settings.Timeout;
+        ev->ResultsTtl = settings.Timeout;
+        ev->RetryMapping = {settings.RetryMapping};
+        ev->SaveQueryPhysicalGraph = settings.SaveState;
+        ev->QueryPhysicalGraph = settings.PhysicalGraph;
+
+        const auto edgeActor = runtime.AllocateEdgeActor();
+        runtime.Send(MakeKqpProxyID(runtime.GetNodeId()), edgeActor, ev.release());
+
+        const auto reply = runtime.GrabEdgeEvent<TEvKqp::TEvScriptResponse>(edgeActor, settings.Timeout);
+        UNIT_ASSERT_C(reply, "CreateScript response is empty");
+        UNIT_ASSERT_VALUES_EQUAL_C(reply->Get()->Status, Ydb::StatusIds::SUCCESS, reply->Get()->Issues.ToString());
+
+        const auto& executionId = reply->Get()->ExecutionId;    
+        UNIT_ASSERT(executionId);
+        const auto& operationId = TOperation::TOperationId(ScriptExecutionOperationFromExecutionId(executionId));
+
+        if (waitRunning) {
+            WaitScriptExecution(operationId, EExecStatus::Running);
+            Sleep(TDuration::Seconds(1));
+        }
+
+        return {executionId, operationId};
+    }
+
+    NKikimrKqp::TScriptExecutionRetryState::TMapping CreateRetryMapping(const std::vector<Ydb::StatusIds::StatusCode>& statuses, TDuration backoffDuration = TDuration::Seconds(5)) {
+        NKikimrKqp::TScriptExecutionRetryState::TMapping retryMapping;
+        for (const auto status : statuses) {
+            retryMapping.AddStatusCode(status);
+        }
+
+        auto& policy = *retryMapping.MutableBackoffPolicy();
+        policy.SetRetryPeriodMs(backoffDuration.MilliSeconds());
+        policy.SetBackoffPeriodMs(backoffDuration.MilliSeconds());
+        policy.SetRetryRateLimit(1);
+
+        return retryMapping;
+    }
+
+    NKikimrKqp::TQueryPhysicalGraph LoadPhysicalGraph(const TString& executionId) {
+        auto& runtime = GetRuntime();
+        const auto edgeActor = runtime.AllocateEdgeActor();
+        runtime.Register(CreateGetScriptExecutionPhysicalGraphActor(edgeActor, TEST_DATABASE, executionId));
+
+        const auto graph = runtime.GrabEdgeEvent<TEvGetScriptPhysicalGraphResponse>(edgeActor, TDuration::Seconds(10));
+        UNIT_ASSERT_C(graph, "Empty graph response");
+        UNIT_ASSERT_VALUES_EQUAL_C(graph->Get()->Status, Ydb::StatusIds::SUCCESS, graph->Get()->Issues.ToOneLineString());
+
+        return graph->Get()->PhysicalGraph;
+    }
+
+    // Utils
+
+    static void WaitFor(TDuration timeout, const TString& description, std::function<bool(TString&)> callback) {
+        TInstant start = TInstant::Now();
+        TString errorString;
+        while (TInstant::Now() - start <= timeout) {
+            if (callback(errorString)) {
+                return;
+            }
+
+            Cerr << "Wait " << description << " " << TInstant::Now() - start << ": " << errorString << "\n";
+            Sleep(TDuration::Seconds(1));
+        }
+
+        UNIT_FAIL("Waiting " << description << " timeout. Spent time " << TInstant::Now() - start << " exceeds limit " << timeout << ", last error: " << errorString);
+    }
+
+private:
+    void EnsureNotInitialized(const TString& info) {
+        UNIT_ASSERT_C(!Kikimr, "Kikimr runner is already initialized, can not setup " << info);
+    }
+
+private:
+    std::optional<NKikimrConfig::TAppConfig> AppConfig;
+    TIntrusivePtr<NYql::IPqGateway> PqGateway;
+    std::shared_ptr<TKikimrRunner> Kikimr;
+
+    std::shared_ptr<TDriver> InternalDriver;
+    std::shared_ptr<NOperation::TOperationClient> OperationClient;
+    std::shared_ptr<TQueryClient> QueryClient;
+    std::shared_ptr<NYdb::NTable::TTableClient> TableClient;
+    std::shared_ptr<NYdb::NTable::TSession> TableClientSession;
+
+    // Attached to database from recipe (YDB_ENDPOINT / YDB_DATABASE)
+    std::shared_ptr<TDriver> ExternalDriver;
+    std::shared_ptr<NTopic::TTopicClient> TopicClient;
+};
 
 } // anonymous namespace
 
 Y_UNIT_TEST_SUITE(KqpFederatedQueryDatastreams) {
-
-    Y_UNIT_TEST(CreateExternalDataSource) {
-        auto kikimr = NFederatedQueryTest::MakeKikimrRunner(true, nullptr, nullptr, std::nullopt, NYql::NDq::CreateS3ActorsFactory());
-
-        auto query = TStringBuilder() << R"(
-            CREATE EXTERNAL DATA SOURCE `sourceName` WITH (
-                SOURCE_TYPE="Ydb",
-                LOCATION=")" << GetEnv("YDB_ENDPOINT") << R"(",
-                DATABASE_NAME=")" << GetEnv("YDB_DATABASE") << R"(",
-                AUTH_METHOD="NONE"
-            );)";
-        auto session = kikimr->GetTableClient().CreateSession().GetValueSync().GetSession();
-        auto result = session.ExecuteSchemeQuery(query).GetValueSync();
-        UNIT_ASSERT_VALUES_EQUAL_C(result.GetStatus(), EStatus::SUCCESS, result.GetIssues().ToString());
+    Y_UNIT_TEST_F(CreateExternalDataSource, TStreamingTestFixture) {
+        CreatePqSource("sourceName");
 
         // DataStreams is not allowed.
-        auto query2 = TStringBuilder() << R"(
+        ExecSchemeQuery(TStringBuilder() << R"(
             CREATE EXTERNAL DATA SOURCE `sourceName2` WITH (
                 SOURCE_TYPE="DataStreams",
-                LOCATION=")" << GetEnv("YDB_ENDPOINT") << R"(",
-                DATABASE_NAME=")" << GetEnv("YDB_DATABASE") << R"(",
+                LOCATION=")" << YDB_ENDPOINT << R"(",
+                DATABASE_NAME=")" << YDB_DATABASE << R"(",
                 AUTH_METHOD="NONE"
-            );)";
-        result = session.ExecuteSchemeQuery(query2).GetValueSync();
-        UNIT_ASSERT_VALUES_EQUAL_C(result.GetStatus(), EStatus::SCHEME_ERROR, result.GetIssues().ToString());
+            );)", EStatus::SCHEME_ERROR);
 
         // YdbTopics is not allowed.
-        auto query3 = TStringBuilder() << R"(
+        ExecSchemeQuery(TStringBuilder() << R"(
             CREATE EXTERNAL DATA SOURCE `sourceName2` WITH (
                 SOURCE_TYPE=")" << ToString(NYql::EDatabaseType::YdbTopics) << R"(",
-                LOCATION=")" << GetEnv("YDB_ENDPOINT") << R"(",
-                DATABASE_NAME=")" << GetEnv("YDB_DATABASE") << R"(",
+                LOCATION=")" << YDB_ENDPOINT << R"(",
+                DATABASE_NAME=")" << YDB_DATABASE << R"(",
                 AUTH_METHOD="NONE"
-            );)";
-        result = session.ExecuteSchemeQuery(query3).GetValueSync();
-        UNIT_ASSERT_VALUES_EQUAL_C(result.GetStatus(), EStatus::SCHEME_ERROR, result.GetIssues().ToString());
+            );)", EStatus::SCHEME_ERROR);
     }
 
-    Y_UNIT_TEST(CreateExternalDataSourceBasic) {
-        auto kikimr = NFederatedQueryTest::MakeKikimrRunner(true, nullptr, nullptr, std::nullopt, NYql::NDq::CreateS3ActorsFactory());
+    Y_UNIT_TEST_F(CreateExternalDataSourceBasic, TStreamingTestFixture) {
+        CreatePqSourceBasicAuth("sourceName");
+    }
 
-        auto query = TStringBuilder() << R"(
-            CREATE OBJECT secret_local_password (TYPE SECRET) WITH (value = "password");
+    Y_UNIT_TEST_F(FailedWithoutAvailableExternalDataSourcesYdb, TStreamingTestFixture) {
+        SetupAppConfig().MutableQueryServiceConfig()->SetAllExternalDataSourcesAreAvailable(false);
+
+        ExecSchemeQuery(TStringBuilder() << R"(
             CREATE EXTERNAL DATA SOURCE `sourceName` WITH (
                 SOURCE_TYPE="Ydb",
-                LOCATION=")" << GetEnv("YDB_ENDPOINT") << R"(",
-                DATABASE_NAME=")" << GetEnv("YDB_DATABASE") << R"(",
-                AUTH_METHOD="BASIC",
-                LOGIN="root",
-                PASSWORD_SECRET_NAME="secret_local_password"
-            );)";
-        auto session = kikimr->GetTableClient().CreateSession().GetValueSync().GetSession();
-        auto result = session.ExecuteSchemeQuery(query).GetValueSync();
-        UNIT_ASSERT_VALUES_EQUAL_C(result.GetStatus(), EStatus::SUCCESS, result.GetIssues().ToString());
-    }
-
-    Y_UNIT_TEST(FailedWithoutAvailableExternalDataSourcesYdb) {
-        NKikimrConfig::TAppConfig appCfg;
-        appCfg.MutableQueryServiceConfig()->SetAllExternalDataSourcesAreAvailable(false);
-        auto kikimr = NFederatedQueryTest::MakeKikimrRunner(true, nullptr, nullptr, appCfg, NYql::NDq::CreateS3ActorsFactory());
-
-        auto query = TStringBuilder() << R"(
-            CREATE EXTERNAL DATA SOURCE `sourceName` WITH (
-                SOURCE_TYPE="Ydb",
-                LOCATION=")" << GetEnv("YDB_ENDPOINT") << R"(",
-                DATABASE_NAME=")" << GetEnv("YDB_DATABASE") << R"(",
+                LOCATION=")" << YDB_ENDPOINT << R"(",
+                DATABASE_NAME=")" << YDB_DATABASE << R"(",
                 AUTH_METHOD="NONE"
-            );)";
-        auto session = kikimr->GetTableClient().CreateSession().GetValueSync().GetSession();
-        auto result = session.ExecuteSchemeQuery(query).GetValueSync();
-        UNIT_ASSERT_VALUES_EQUAL_C(result.GetStatus(), EStatus::SCHEME_ERROR, result.GetIssues().ToString());
+            );)", EStatus::SCHEME_ERROR);
     }
 
-    Y_UNIT_TEST(CheckAvailableExternalDataSourcesYdb) {
-        NKikimrConfig::TAppConfig appCfg;
-        appCfg.MutableQueryServiceConfig()->AddAvailableExternalDataSources("Ydb");
-        appCfg.MutableQueryServiceConfig()->SetAllExternalDataSourcesAreAvailable(false);
-        auto kikimr = NFederatedQueryTest::MakeKikimrRunner(true, nullptr, nullptr, appCfg, NYql::NDq::CreateS3ActorsFactory());
+    Y_UNIT_TEST_F(CheckAvailableExternalDataSourcesYdb, TStreamingTestFixture) {
+        auto& cfg = *SetupAppConfig().MutableQueryServiceConfig();
+        cfg.AddAvailableExternalDataSources("Ydb");
+        cfg.SetAllExternalDataSourcesAreAvailable(false);
 
-        auto query = TStringBuilder() << R"(
-            CREATE EXTERNAL DATA SOURCE `sourceName` WITH (
-                SOURCE_TYPE="Ydb",
-                LOCATION=")" << GetEnv("YDB_ENDPOINT") << R"(",
-                DATABASE_NAME=")" << GetEnv("YDB_DATABASE") << R"(",
-                AUTH_METHOD="NONE"
-            );)";
-        auto session = kikimr->GetTableClient().CreateSession().GetValueSync().GetSession();
-        auto result = session.ExecuteSchemeQuery(query).GetValueSync();
-        UNIT_ASSERT_VALUES_EQUAL_C(result.GetStatus(), EStatus::SUCCESS, result.GetIssues().ToString());
+        CreatePqSource("sourceName");
     }
 
-    Y_UNIT_TEST(ReadTopicFailedWithoutAvailableExternalDataSourcesYdbTopics) {
-        NKikimrConfig::TAppConfig appCfg;
-        appCfg.MutableQueryServiceConfig()->AddAvailableExternalDataSources("Ydb");
-        appCfg.MutableQueryServiceConfig()->SetAllExternalDataSourcesAreAvailable(false);
-        auto kikimr = NFederatedQueryTest::MakeKikimrRunner(true, nullptr, nullptr, appCfg, NYql::NDq::CreateS3ActorsFactory());
+    Y_UNIT_TEST_F(ReadTopicFailedWithoutAvailableExternalDataSourcesYdbTopics, TStreamingTestFixture) {
+        auto& cfg = *SetupAppConfig().MutableQueryServiceConfig();
+        cfg.AddAvailableExternalDataSources("Ydb");
+        cfg.SetAllExternalDataSourcesAreAvailable(false);
 
         TString sourceName = "sourceName";
+        CreatePqSource(sourceName);
+
         TString topicName = "topicName";
-        TString tableName = "tableName";
+        CreateTopic(topicName);
 
-        NYdb::NTopic::TTopicClientSettings opts;
-        opts.DiscoveryEndpoint(GetEnv("YDB_ENDPOINT"))
-            .Database(GetEnv("YDB_DATABASE"));
-
-        auto driver = TDriver(TDriverConfig());
-        NYdb::NTopic::TTopicClient topicClient(driver, opts);
-
-        auto topicSettings = NYdb::NTopic::TCreateTopicSettings().PartitioningSettings(1, 1);
-        auto status = topicClient.CreateTopic(topicName, topicSettings).GetValueSync();
-        UNIT_ASSERT_C(status.IsSuccess(), status.GetIssues().ToString());
-
-        auto query = TStringBuilder() << R"(
-            CREATE EXTERNAL DATA SOURCE `)" << sourceName << R"(` WITH (
-                SOURCE_TYPE="Ydb",
-                LOCATION=")" << GetEnv("YDB_ENDPOINT") << R"(",
-                DATABASE_NAME=")" << GetEnv("YDB_DATABASE") << R"(",
-                AUTH_METHOD="NONE"
-            );)";
-
-        auto db = kikimr->GetTableClient();
-        auto session = db.CreateSession().GetValueSync().GetSession();
-
-        auto result = session.ExecuteSchemeQuery(query).GetValueSync();
-        UNIT_ASSERT_VALUES_EQUAL_C(result.GetStatus(), EStatus::SUCCESS, result.GetIssues().ToString());
-        auto settings = TExecuteScriptSettings().StatsMode(EStatsMode::Basic);
-
-        const TString sql = fmt::format(R"(
-                SELECT * FROM `{source}`.`{topic}`
-                    WITH (
-                        FORMAT="json_each_row",
-                        SCHEMA=(
-                            key String NOT NULL,
-                            value String NOT NULL
-                        ))
-                    LIMIT 1;
-            )", "source"_a=sourceName, "topic"_a=topicName);
-
-        auto queryClient = kikimr->GetQueryClient();
-        auto scriptExecutionOperation = queryClient.ExecuteScript(sql, settings).ExtractValueSync();
-        UNIT_ASSERT_VALUES_EQUAL_C(scriptExecutionOperation.Status().GetStatus(), EStatus::SUCCESS, scriptExecutionOperation.Status().GetIssues().ToString());
-
-        NYdb::NQuery::TScriptExecutionOperation readyOp = WaitScriptExecutionOperation(scriptExecutionOperation.Id(), kikimr->GetDriver());
-        UNIT_ASSERT_EQUAL_C(readyOp.Metadata().ExecStatus, EExecStatus::Failed, readyOp.Status().GetIssues().ToString());
+        ExecAndWaitScript(fmt::format(R"(
+            SELECT * FROM `{source}`.`{topic}`
+                WITH (
+                    FORMAT="json_each_row",
+                    SCHEMA=(
+                        key String NOT NULL,
+                        value String NOT NULL
+                    ))
+                LIMIT 1;
+            )",
+            "source"_a=sourceName,
+            "topic"_a=topicName
+        ), EExecStatus::Failed);
     }
 
-    Y_UNIT_TEST(ReadTopic) {
-        NKikimrConfig::TAppConfig appCfg;
-        appCfg.MutableQueryServiceConfig()->AddAvailableExternalDataSources("Ydb");
-        appCfg.MutableQueryServiceConfig()->AddAvailableExternalDataSources("YdbTopics");
-        appCfg.MutableQueryServiceConfig()->SetAllExternalDataSourcesAreAvailable(false);
-        auto kikimr = NFederatedQueryTest::MakeKikimrRunner(true, nullptr, nullptr, appCfg, NYql::NDq::CreateS3ActorsFactory());
+    Y_UNIT_TEST_F(ReadTopic, TStreamingTestFixture) {
+        auto& cfg = *SetupAppConfig().MutableQueryServiceConfig();
+        cfg.AddAvailableExternalDataSources("Ydb");
+        cfg.AddAvailableExternalDataSources("YdbTopics");
+        cfg.SetAllExternalDataSourcesAreAvailable(false);
 
         TString sourceName = "sourceName";
         TString topicName = "topicName";
         TString tableName = "tableName";
         ui32 partitionCount = 10;
 
-        NYdb::NTopic::TTopicClientSettings opts;
-        opts.DiscoveryEndpoint(GetEnv("YDB_ENDPOINT"))
-            .Database(GetEnv("YDB_DATABASE"));
-        auto driver = TDriver(TDriverConfig());
-        NYdb::NTopic::TTopicClient topicClient(driver, opts);
+        CreateTopic(topicName, NTopic::TCreateTopicSettings()
+            .PartitioningSettings(partitionCount, partitionCount));
 
-        auto topicSettings = NYdb::NTopic::TCreateTopicSettings().PartitioningSettings(partitionCount, partitionCount);
-        auto status = topicClient.CreateTopic(topicName, topicSettings).GetValueSync();
-        UNIT_ASSERT_C(status.IsSuccess(), status.GetIssues().ToString());
+        CreatePqSource(sourceName);
 
-        auto query = TStringBuilder() << R"(
-            CREATE EXTERNAL DATA SOURCE `)" << sourceName << R"(` WITH (
-                SOURCE_TYPE="Ydb",
-                LOCATION=")" << GetEnv("YDB_ENDPOINT") << R"(",
-                DATABASE_NAME=")" << GetEnv("YDB_DATABASE") << R"(",
-                AUTH_METHOD="NONE"
-            );)";
-
-        auto db = kikimr->GetTableClient();
-        auto session = db.CreateSession().GetValueSync().GetSession();
-
-        auto result = session.ExecuteSchemeQuery(query).GetValueSync();
-        UNIT_ASSERT_VALUES_EQUAL_C(result.GetStatus(), EStatus::SUCCESS, result.GetIssues().ToString());
-        auto settings = TExecuteScriptSettings().StatsMode(EStatsMode::Basic);
-
-        const TString sql = fmt::format(R"(
-                SELECT * FROM `{source}`.`{topic}`
-                    WITH (
-                        FORMAT="json_each_row",
-                        SCHEMA=(
-                            key String NOT NULL,
-                            value String NOT NULL
-                        ))
-                    LIMIT {partition_count};
-            )", "source"_a=sourceName, "topic"_a=topicName, "partition_count"_a=partitionCount);
-
-        auto queryClient = kikimr->GetQueryClient();
-        auto scriptExecutionOperation = queryClient.ExecuteScript(sql, settings).ExtractValueSync();
-        UNIT_ASSERT_VALUES_EQUAL_C(scriptExecutionOperation.Status().GetStatus(), EStatus::SUCCESS, scriptExecutionOperation.Status().GetIssues().ToString());
-        
-        std::this_thread::sleep_for(std::chrono::milliseconds(1000));
+        const auto scriptExecutionOperation = ExecScript(fmt::format(R"(
+            SELECT * FROM `{source}`.`{topic}`
+                WITH (
+                    FORMAT="json_each_row",
+                    SCHEMA=(
+                        key String NOT NULL,
+                        value String NOT NULL
+                    ))
+                LIMIT {partition_count};
+            )",
+            "source"_a=sourceName,
+            "topic"_a=topicName,
+            "partition_count"_a=partitionCount
+        ));
 
         for (ui32 i = 0; i < partitionCount; ++i) {
-            auto writeSettings = NYdb::NTopic::TWriteSessionSettings().Path(topicName).PartitionId(i);
-            auto topicSession = topicClient.CreateSimpleBlockingWriteSession(writeSettings);
-            topicSession->Write(NYdb::NTopic::TWriteMessage(R"({"key":"key1", "value": "value1"})"));
-            topicSession->Close();
+            WriteTopicMessage(topicName, R"({"key":"key1", "value": "value1"})", i);
         }
 
-        NYdb::NQuery::TScriptExecutionOperation readyOp = WaitScriptExecutionOperation(scriptExecutionOperation.Id(), kikimr->GetDriver());
-        UNIT_ASSERT_EQUAL_C(readyOp.Metadata().ExecStatus, EExecStatus::Completed, readyOp.Status().GetIssues().ToString());
-        TFetchScriptResultsResult results = queryClient.FetchScriptResults(scriptExecutionOperation.Id(), 0).ExtractValueSync();
-        UNIT_ASSERT_C(results.IsSuccess(), results.GetIssues().ToString());
-
-        TResultSetParser resultSet(results.ExtractResultSet());
-        UNIT_ASSERT_VALUES_EQUAL(resultSet.ColumnsCount(), 2);
-        UNIT_ASSERT_VALUES_EQUAL(resultSet.RowsCount(), partitionCount);
-        UNIT_ASSERT(resultSet.TryNextRow());
-        UNIT_ASSERT_VALUES_EQUAL(resultSet.ColumnParser(0).GetString(), "key1");
-        UNIT_ASSERT_VALUES_EQUAL(resultSet.ColumnParser(1).GetString(), "value1");
+        CheckScriptResult(scriptExecutionOperation, 2, partitionCount, [](TResultSetParser& result) {
+            UNIT_ASSERT_VALUES_EQUAL(result.ColumnParser(0).GetString(), "key1");
+            UNIT_ASSERT_VALUES_EQUAL(result.ColumnParser(1).GetString(), "value1");
+        });
     }
 
-    Y_UNIT_TEST(ReadTopicBasic) {
-        auto kikimr = NFederatedQueryTest::MakeKikimrRunner(true, nullptr, nullptr, std::nullopt, NYql::NDq::CreateS3ActorsFactory());
-
+    Y_UNIT_TEST_F(ReadTopicBasic, TStreamingTestFixture) {
         TString sourceName = "sourceName";
         TString topicName = "topicName";
         TString tableName = "tableName";
 
-        NYdb::NTopic::TTopicClientSettings opts;
-        opts.DiscoveryEndpoint(GetEnv("YDB_ENDPOINT"))
-            .Database(GetEnv("YDB_DATABASE"));
-        auto driver = TDriver(TDriverConfig());
-        NYdb::NTopic::TTopicClient topicClient(driver, opts);
+        CreateTopic(topicName);
 
-        auto topicSettings = NYdb::NTopic::TCreateTopicSettings().PartitioningSettings(1, 1);
-        auto status = topicClient.CreateTopic(topicName, topicSettings).GetValueSync();
-        UNIT_ASSERT_C(status.IsSuccess(), status.GetIssues().ToString());
+        CreatePqSourceBasicAuth(sourceName);
 
-        auto query = TStringBuilder() << R"(
-            CREATE OBJECT secret_local_password (TYPE SECRET) WITH (value = "1234");
-            CREATE EXTERNAL DATA SOURCE `)" << sourceName << R"(` WITH (
-                SOURCE_TYPE="Ydb",
-                LOCATION=")" << GetEnv("YDB_ENDPOINT") << R"(",
-                DATABASE_NAME=")" << GetEnv("YDB_DATABASE") << R"(",
-                AUTH_METHOD="BASIC",
-                LOGIN="root",
-                PASSWORD_SECRET_NAME="secret_local_password"
-            );)";
+        const auto scriptExecutionOperation = ExecScript(fmt::format(R"(
+            SELECT * FROM `{source}`.`{topic}`
+                WITH (
+                    FORMAT="json_each_row",
+                    SCHEMA=(
+                        key String NOT NULL,
+                        value String NOT NULL
+                    ))
+                LIMIT 1;
+            )",
+            "source"_a=sourceName,
+            "topic"_a=topicName
+        ));
 
-        auto db = kikimr->GetTableClient();
-        auto session = db.CreateSession().GetValueSync().GetSession();
+        WriteTopicMessage(topicName, R"({"key":"key1", "value": "value1"})");
 
-        auto result = session.ExecuteSchemeQuery(query).GetValueSync();
-        UNIT_ASSERT_VALUES_EQUAL_C(result.GetStatus(), EStatus::SUCCESS, result.GetIssues().ToString());
-        auto settings = TExecuteScriptSettings().StatsMode(EStatsMode::Basic);
-
-        const TString sql = fmt::format(R"(
-                SELECT * FROM `{source}`.`{topic}`
-                    WITH (
-                        FORMAT="json_each_row",
-                        SCHEMA=(
-                            key String NOT NULL,
-                            value String NOT NULL
-                        ))
-                    LIMIT 1;
-            )", "source"_a=sourceName, "topic"_a=topicName);
-
-        auto queryClient = kikimr->GetQueryClient();
-        auto scriptExecutionOperation = queryClient.ExecuteScript(sql, settings).ExtractValueSync();
-        UNIT_ASSERT_VALUES_EQUAL_C(scriptExecutionOperation.Status().GetStatus(), EStatus::SUCCESS, scriptExecutionOperation.Status().GetIssues().ToString());
-        
-        std::this_thread::sleep_for(std::chrono::milliseconds(1000));
-
-        auto writeSettings = NYdb::NTopic::TWriteSessionSettings().Path(topicName);
-        auto topicSession = topicClient.CreateSimpleBlockingWriteSession(writeSettings);
-        topicSession->Write(NYdb::NTopic::TWriteMessage(R"({"key":"key1", "value": "value1"})"));
-        topicSession->Close();
-
-        NYdb::NQuery::TScriptExecutionOperation readyOp = WaitScriptExecutionOperation(scriptExecutionOperation.Id(), kikimr->GetDriver());
-        UNIT_ASSERT_EQUAL_C(readyOp.Metadata().ExecStatus, EExecStatus::Completed, readyOp.Status().GetIssues().ToString());
-        TFetchScriptResultsResult results = queryClient.FetchScriptResults(scriptExecutionOperation.Id(), 0).ExtractValueSync();
-        UNIT_ASSERT_C(results.IsSuccess(), results.GetIssues().ToString());
-
-        TResultSetParser resultSet(results.ExtractResultSet());
-        UNIT_ASSERT_VALUES_EQUAL(resultSet.ColumnsCount(), 2);
-        UNIT_ASSERT_VALUES_EQUAL(resultSet.RowsCount(), 1);
-        UNIT_ASSERT(resultSet.TryNextRow());
-        UNIT_ASSERT_VALUES_EQUAL(resultSet.ColumnParser(0).GetString(), "key1");
-        UNIT_ASSERT_VALUES_EQUAL(resultSet.ColumnParser(1).GetString(), "value1");
+        CheckScriptResult(scriptExecutionOperation, 2, 1, [](TResultSetParser& result) {
+            UNIT_ASSERT_VALUES_EQUAL(result.ColumnParser(0).GetString(), "key1");
+            UNIT_ASSERT_VALUES_EQUAL(result.ColumnParser(1).GetString(), "value1");
+        });
     }
 
-    Y_UNIT_TEST(InsertTopicBasic) {
-        auto kikimr = NFederatedQueryTest::MakeKikimrRunner(true, nullptr, nullptr, std::nullopt, NYql::NDq::CreateS3ActorsFactory());
-
+    Y_UNIT_TEST_F(InsertTopicBasic, TStreamingTestFixture) {
         TString sourceName = "sourceName";
         TString inputTopicName = "inputTopicName";
         TString outputTopicName = "outputTopicName";
         TString tableName = "tableName";
 
-        NYdb::NTopic::TTopicClientSettings opts;
-        opts.DiscoveryEndpoint(GetEnv("YDB_ENDPOINT"))
-            .Database(GetEnv("YDB_DATABASE"));
-        auto driver = TDriver(TDriverConfig());
-        NYdb::NTopic::TTopicClient topicClient(driver, opts);
+        CreateTopic(outputTopicName);
+        CreateTopic(inputTopicName);
 
-        auto topicSettings = NYdb::NTopic::TCreateTopicSettings().PartitioningSettings(1, 1);
-        auto status = topicClient.CreateTopic(outputTopicName, topicSettings).GetValueSync();
-        
-        UNIT_ASSERT_C(status.IsSuccess(), status.GetIssues().ToString());
-        std::this_thread::sleep_for(std::chrono::milliseconds(1000));
+        CreatePqSourceBasicAuth(sourceName);
 
-        status = topicClient.CreateTopic(inputTopicName, topicSettings).GetValueSync();
-        UNIT_ASSERT_C(status.IsSuccess(), status.GetIssues().ToString());
+        const auto scriptExecutionOperation = ExecScript(fmt::format(R"(
+            $input = SELECT key, value FROM `{source}`.`{input_topic}`
+                WITH (
+                    FORMAT="json_each_row",
+                    SCHEMA=(
+                        key String NOT NULL,
+                        value String  NOT NULL
+                    ));
+            INSERT INTO `{source}`.`{output_topic}`
+                SELECT key || value FROM $input;
+            )",
+            "source"_a=sourceName,
+            "input_topic"_a=inputTopicName,
+            "output_topic"_a=outputTopicName
+        ));
 
-        auto query = TStringBuilder() << R"(
-            CREATE OBJECT secret_local_password (TYPE SECRET) WITH (value = "1234");
-            CREATE EXTERNAL DATA SOURCE `)" << sourceName << R"(` WITH (
-                SOURCE_TYPE="Ydb",
-                LOCATION=")" << GetEnv("YDB_ENDPOINT") << R"(",
-                DATABASE_NAME=")" << GetEnv("YDB_DATABASE") << R"(",
-                AUTH_METHOD="BASIC",
-                LOGIN="root",
-                PASSWORD_SECRET_NAME="secret_local_password"
-            );)";
+        WriteTopicMessage(inputTopicName, R"({"key":"key1", "value": "value1"})");
+        ReadTopicMessages(outputTopicName, {"key1value1"});
 
-        auto db = kikimr->GetTableClient();
-        auto session = db.CreateSession().GetValueSync().GetSession();
-        auto result = session.ExecuteSchemeQuery(query).GetValueSync();
-        UNIT_ASSERT_VALUES_EQUAL_C(result.GetStatus(), EStatus::SUCCESS, result.GetIssues().ToString());
-
-        const TString sql = fmt::format(R"(
-                $input = SELECT key, value FROM `{source}`.`{input_topic}`
-                    WITH (
-                        FORMAT="json_each_row",
-                        SCHEMA=(
-                            key String NOT NULL,
-                            value String  NOT NULL
-                        ));
-                INSERT INTO `{source}`.`{output_topic}`
-                    SELECT key || value FROM $input;
-            )", "source"_a=sourceName, "input_topic"_a=inputTopicName, "output_topic"_a=outputTopicName);
-
-        auto queryClient = kikimr->GetQueryClient();
-        auto settings = TExecuteScriptSettings().StatsMode(EStatsMode::Basic);
-        auto scriptExecutionOperation = queryClient.ExecuteScript(sql, settings).ExtractValueSync();
-        UNIT_ASSERT_VALUES_EQUAL_C(scriptExecutionOperation.Status().GetStatus(), EStatus::SUCCESS, scriptExecutionOperation.Status().GetIssues().ToString());
-
-        std::this_thread::sleep_for(std::chrono::milliseconds(1000));
-
-        auto writeSettings = NYdb::NTopic::TWriteSessionSettings().Path(inputTopicName);
-        auto topicSession = topicClient.CreateSimpleBlockingWriteSession(writeSettings);
-        topicSession->Write(NYdb::NTopic::TWriteMessage(R"({"key":"key1", "value":"value1"})"));
-        topicSession->Close();
-
-        NYdb::NTopic::TReadSessionSettings readSettings;
-        readSettings
-            .WithoutConsumer()
-            .AppendTopics(
-                NTopic::TTopicReadSettings(outputTopicName).ReadFromTimestamp(TInstant::Now() - TDuration::Seconds(146))
-                    .AppendPartitionIds(0));
-
-        readSettings.EventHandlers_.StartPartitionSessionHandler(
-            [](NYdb::NTopic::TReadSessionEvent::TStartPartitionSessionEvent& event) {
-                event.Confirm(0);
-            }
-        );
-
-        auto readSession = topicClient.CreateReadSession(readSettings);
-        std::vector<std::string> received;
-        while (true) {
-            auto event = readSession->GetEvent(/*block = */true);
-            if (auto dataEvent = std::get_if<NYdb::NTopic::TReadSessionEvent::TDataReceivedEvent>(&*event)) {
-                for (const auto& message : dataEvent->GetMessages()) {
-                    received.push_back(message.GetData());
-                }
-                break;
-            }
-        }
-        UNIT_ASSERT_EQUAL(received.size(), 1);
-        UNIT_ASSERT_EQUAL(received[0], "key1value1");
-
-        NYdb::NOperation::TOperationClient client(kikimr->GetDriver());
-        status = client.Cancel(scriptExecutionOperation.Id()).ExtractValueSync();
-        UNIT_ASSERT_C(status.IsSuccess(), status.GetIssues().ToString());
+        CancelScriptExecution(scriptExecutionOperation);
     }
 
-    Y_UNIT_TEST(RestoreScriptPhysicalGraphBasic) {
+    Y_UNIT_TEST_F(RestoreScriptPhysicalGraphBasic, TStreamingTestFixture) {
         constexpr char writeBucket[] = "test_bucket_restore_script_physical_graph";
         CreateBucket(writeBucket);
 
-        auto kikimr = NFederatedQueryTest::MakeKikimrRunner(true, nullptr, nullptr, std::nullopt, NYql::NDq::CreateS3ActorsFactory());
-        auto db = kikimr->GetQueryClient();
-
-        const auto topicDriver = TDriver(TDriverConfig());
-        NTopic::TTopicClient topicClient(topicDriver, NTopic::TTopicClientSettings()
-            .DiscoveryEndpoint(GetEnv("YDB_ENDPOINT"))
-            .Database(GetEnv("YDB_DATABASE")));
-
         constexpr char topicName[] = "restoreScriptTopic";
-        {
-            const auto status = topicClient.CreateTopic(topicName).ExtractValueSync();
-            UNIT_ASSERT_C(status.IsSuccess(), status.GetIssues().ToString());
-        }
+        CreateTopic(topicName);
 
         constexpr char pqSourceName[] = "sourceName";
-        constexpr char s3SinkName[] = "s3Sink";
-        {
-            const auto query = fmt::format(R"(
-                CREATE EXTERNAL DATA SOURCE `{s3_sink}` WITH (
-                    SOURCE_TYPE="ObjectStorage",
-                    LOCATION="{s3_location}",
-                    AUTH_METHOD="NONE"
-                );
-                CREATE EXTERNAL DATA SOURCE `{pq_source}` WITH (
-                    SOURCE_TYPE = "Ydb",
-                    LOCATION = "{pq_location}",
-                    DATABASE_NAME = "{pq_database_name}",
-                    AUTH_METHOD = "NONE"
-                );)",
-                "s3_sink"_a = s3SinkName,
-                "s3_location"_a = GetBucketLocation(writeBucket),
-                "pq_source"_a = pqSourceName,
-                "pq_location"_a = GetEnv("YDB_ENDPOINT"),
-                "pq_database_name"_a = GetEnv("YDB_DATABASE")
-            );
-            const auto result = db.ExecuteQuery(query, TTxControl::NoTx()).ExtractValueSync();
-            UNIT_ASSERT_VALUES_EQUAL_C(result.GetStatus(), EStatus::SUCCESS, result.GetIssues().ToString());
-        }
+        CreatePqSource(pqSourceName);
 
-        auto& runtime = *kikimr->GetTestServer().GetRuntime();
+        constexpr char s3SinkName[] = "s3Sink";
+        CreateS3Source(writeBucket, s3SinkName);
 
         const auto executeQuery = [&](TScriptQuerySettings settings) {
-            settings.Query = fmt::format(R"(
+            const auto& [executionId, operationId] = ExecScriptNative(fmt::format(R"(
                 INSERT INTO `{s3_sink}`.`folder/` WITH (FORMAT = "json_each_row")
                 SELECT * FROM `{source}`.`{topic}` WITH (
                     FORMAT = "json_each_row",
@@ -509,17 +665,10 @@ Y_UNIT_TEST_SUITE(KqpFederatedQueryDatastreams) {
                 "s3_sink"_a = s3SinkName,
                 "source"_a = pqSourceName,
                 "topic"_a = topicName
-            );
+            ), settings);
 
-            const auto [executionId, operationId] = StartScriptQuery(runtime, settings);
-            const auto readyOp = WaitScriptExecutionOperation(operationId, kikimr->GetDriver(), [&]() {
-                Sleep(TDuration::Seconds(1));
-                auto topicSession = topicClient.CreateSimpleBlockingWriteSession(NTopic::TWriteSessionSettings().Path(topicName));
-                topicSession->Write(NTopic::TWriteMessage(R"({"key":"key1", "value": "value1"})"));
-                topicSession->Close();
-            });
-            UNIT_ASSERT_VALUES_EQUAL_C(readyOp.Status().GetStatus(), EStatus::SUCCESS, readyOp.Status().GetIssues().ToString());
-            UNIT_ASSERT_VALUES_EQUAL_C(readyOp.Metadata().ExecStatus, EExecStatus::Completed, readyOp.Status().GetIssues().ToString());
+            WriteTopicMessage(topicName, R"({"key":"key1", "value": "value1"})");
+            WaitScriptExecution(operationId);
 
             return executionId;
         };
@@ -528,34 +677,86 @@ Y_UNIT_TEST_SUITE(KqpFederatedQueryDatastreams) {
         const TString sampleResult = "{\"key\":\"key1\",\"value\":\"value1\"}\n";
         UNIT_ASSERT_VALUES_EQUAL(GetAllObjects(writeBucket), sampleResult);
 
-        const auto edgeActor = runtime.AllocateEdgeActor();
-        runtime.Register(CreateGetScriptExecutionPhysicalGraphActor(edgeActor, "/Root", executionId));
-        const auto graph = runtime.GrabEdgeEvent<TEvGetScriptPhysicalGraphResponse>(edgeActor, TDuration::Seconds(10));
-        UNIT_ASSERT_C(graph, "Empty graph response");
-        UNIT_ASSERT_VALUES_EQUAL_C(graph->Get()->Status, Ydb::StatusIds::SUCCESS, graph->Get()->Issues.ToString());
+        ExecQuery(fmt::format(R"(
+            DROP EXTERNAL DATA SOURCE `{s3_sink}`;
+            DROP EXTERNAL DATA SOURCE `{pq_source}`;)",
+            "s3_sink"_a = s3SinkName,
+            "pq_source"_a = pqSourceName
+        ));
 
-        {
-            const auto query = fmt::format(R"(
-                DROP EXTERNAL DATA SOURCE `{s3_sink}`;
-                DROP EXTERNAL DATA SOURCE `{pq_source}`;)",
-                "s3_sink"_a = s3SinkName,
-                "pq_source"_a = pqSourceName
-            );
-            const auto result = db.ExecuteQuery(query, TTxControl::NoTx()).ExtractValueSync();
-            UNIT_ASSERT_VALUES_EQUAL_C(result.GetStatus(), EStatus::SUCCESS, result.GetIssues().ToString());
-        }
-
-        executeQuery({.PhysicalGraph = graph->Get()->PhysicalGraph});
+        executeQuery({.PhysicalGraph = LoadPhysicalGraph(executionId)});
         UNIT_ASSERT_VALUES_EQUAL(GetAllObjects(writeBucket), TStringBuilder() << sampleResult << sampleResult);
     }
 
-    Y_UNIT_TEST(RestoreScriptPhysicalGraphOnRetry) {
+    Y_UNIT_TEST_F(RestoreScriptPhysicalGraphGroupByHop, TStreamingTestFixture) {
+        constexpr char sourceTopicName[] = "restoreScriptGroupByHopTopicSource";
+        constexpr char sinkTopicName[] = "restoreScriptGroupByHopTopicSink";
+        CreateTopic(sourceTopicName);
+        CreateTopic(sinkTopicName);
+
+        constexpr char pqSourceName[] = "sourceName";
+        CreatePqSource(pqSourceName);
+
+        TVector<TString> expectedMessages;
+        const auto executeQuery = [&](TScriptQuerySettings settings) {
+            const auto& [executionId, operationId] = ExecScriptNative(fmt::format(R"(
+                $input = SELECT * FROM `{source}`.`{source_topic}` WITH (
+                    FORMAT = "json_each_row",
+                    SCHEMA (
+                        time String,
+                        event String NOT NULL
+                    )
+                );
+
+                INSERT INTO `{source}`.`{sink_topic}`
+                SELECT
+                    event
+                FROM $input
+                GROUP BY
+                    HOP (CAST(time AS Timestamp), "PT1H", "PT1H", "PT0H"),
+                    event
+                LIMIT 1;)",
+                "source_topic"_a = sourceTopicName,
+                "sink_topic"_a = sinkTopicName,
+                "source"_a = pqSourceName
+            ), settings);
+
+            WriteTopicMessage(sourceTopicName, R"({"time": "2025-08-24T00:00:00.000000Z", "event": "A"})");
+            WriteTopicMessage(sourceTopicName, R"({"time": "2025-08-25T00:00:00.000000Z", "event": "B"})");
+
+            expectedMessages.emplace_back("A");
+            ReadTopicMessages(sinkTopicName, expectedMessages);
+
+            WaitScriptExecution(operationId);
+
+            return executionId;
+        };
+
+        const auto executionId = executeQuery({.SaveState = true});
+
+        ExecQuery(fmt::format(R"(
+            DROP EXTERNAL DATA SOURCE `{source}`;)",
+            "source"_a = pqSourceName
+        ));
+
+        executeQuery({.PhysicalGraph = LoadPhysicalGraph(executionId)});
+    }
+
+    Y_UNIT_TEST_F(RestoreScriptPhysicalGraphOnRetry, TStreamingTestFixture) {
+        const auto pqGateway = SetupMockPqGateway();
+
         constexpr char writeBucket[] = "test_bucket_restore_script_physical_graph_on_retry";
         CreateBucket(writeBucket);
 
-        const auto pqGateway = CreateMockPqGateway();
-
         constexpr char topicName[] = "restoreScriptTopicOnRetry";
+        CreateTopic(topicName);
+
+        constexpr char pqSourceName[] = "sourceName";
+        CreatePqSource(pqSourceName);
+
+        constexpr char s3SinkName[] = "s3Sink";
+        CreateS3Source(writeBucket, s3SinkName);
+
         size_t numberEvents = 0;
         pqGateway->AddEventProvider(topicName, [&](TMockPqSession meta) -> NTopic::TReadSessionEvent::TEvent {
             numberEvents++;
@@ -567,114 +768,36 @@ Y_UNIT_TEST_SUITE(KqpFederatedQueryDatastreams) {
             return MakePqMessage(numberEvents, R"({"key":"key1", "value": "value1"})", meta);
         });
 
-        auto kikimr = NFederatedQueryTest::MakeKikimrRunner(true, nullptr, nullptr, std::nullopt, NYql::NDq::CreateS3ActorsFactory(), {
-            .PqGateway = pqGateway
-        });
-        auto db = kikimr->GetQueryClient();
+        const auto& [_, operationId] = ExecScriptNative(fmt::format(R"(
+            PRAGMA s3.AtomicUploadCommit = "true";
 
-        const auto topicDriver = TDriver(TDriverConfig());
-        NTopic::TTopicClient topicClient(topicDriver, NTopic::TTopicClientSettings()
-            .DiscoveryEndpoint(GetEnv("YDB_ENDPOINT"))
-            .Database(GetEnv("YDB_DATABASE")));
+            INSERT INTO `{s3_sink}`.`folder/` WITH (FORMAT = "json_each_row")
+            SELECT * FROM `{source}`.`{topic}` WITH (
+                FORMAT = "json_each_row",
+                SCHEMA = (
+                    key String NOT NULL,
+                    value String NOT NULL
+                )
+            ) LIMIT 1;)",
+            "s3_sink"_a = s3SinkName,
+            "source"_a = pqSourceName,
+            "topic"_a = topicName
+        ), {
+            .SaveState = true,
+            .RetryMapping = CreateRetryMapping({Ydb::StatusIds::BAD_REQUEST})
+        }, false);
 
-        {
-            const auto status = topicClient.CreateTopic(topicName).ExtractValueSync();
-            UNIT_ASSERT_C(status.IsSuccess(), status.GetIssues().ToString());
-        }
+        WaitScriptExecution(operationId, EExecStatus::Failed, true);
 
-        constexpr char s3SinkName[] = "s3Sink";
-        constexpr char pqSourceName[] = "sourceName";
-        {
-            const auto query = fmt::format(R"(
-                CREATE EXTERNAL DATA SOURCE `{s3_sink}` WITH (
-                    SOURCE_TYPE="ObjectStorage",
-                    LOCATION="{s3_location}",
-                    AUTH_METHOD="NONE"
-                );
-                CREATE EXTERNAL DATA SOURCE `{pq_source}` WITH (
-                    SOURCE_TYPE = "Ydb",
-                    LOCATION = "{pq_location}",
-                    DATABASE_NAME = "{pq_database_name}",
-                    AUTH_METHOD = "NONE"
-                );)",
-                "s3_sink"_a = s3SinkName,
-                "s3_location"_a = GetBucketLocation(writeBucket),
-                "pq_source"_a = pqSourceName,
-                "pq_location"_a = GetEnv("YDB_ENDPOINT"),
-                "pq_database_name"_a = GetEnv("YDB_DATABASE")
-            );
-            const auto result = db.ExecuteQuery(query, TTxControl::NoTx()).ExtractValueSync();
-            UNIT_ASSERT_VALUES_EQUAL_C(result.GetStatus(), EStatus::SUCCESS, result.GetIssues().ToString());
-        }
+        ExecQuery(fmt::format(R"(
+            DROP EXTERNAL DATA SOURCE `{s3_sink}`;
+            DROP EXTERNAL DATA SOURCE `{pq_source}`;)",
+            "s3_sink"_a = s3SinkName,
+            "pq_source"_a = pqSourceName
+        ));
 
-        auto& runtime = *kikimr->GetTestServer().GetRuntime();
-        TString executionId;
-        TOperation::TOperationId operationId;
+        WaitScriptExecution(operationId);
 
-        constexpr TDuration backoffDuration = TDuration::Seconds(5);
-        {
-            NKikimrKqp::TScriptExecutionRetryState::TMapping retryMapping;
-            retryMapping.AddStatusCode(Ydb::StatusIds::BAD_REQUEST);
-            auto& policy = *retryMapping.MutableBackoffPolicy();
-            policy.SetRetryPeriodMs(backoffDuration.MilliSeconds());
-            policy.SetBackoffPeriodMs(backoffDuration.MilliSeconds());
-            policy.SetRetryRateLimit(1);
-
-            const TScriptQuerySettings settings = {
-                .Query = fmt::format(R"(
-                    PRAGMA s3.AtomicUploadCommit = "true";
-
-                    INSERT INTO `{s3_sink}`.`folder/` WITH (FORMAT = "json_each_row")
-                    SELECT * FROM `{source}`.`{topic}` WITH (
-                        FORMAT = "json_each_row",
-                        SCHEMA = (
-                            key String NOT NULL,
-                            value String NOT NULL
-                        )
-                    ) LIMIT 1;)",
-                    "s3_sink"_a = s3SinkName,
-                    "source"_a = pqSourceName,
-                    "topic"_a = topicName
-                ),
-                .SaveState = true,
-                .RetryMapping = retryMapping
-            };
-
-            std::tie(executionId, operationId) = StartScriptQuery(runtime, settings);
-        }
-
-        NOperation::TOperationClient opClient(kikimr->GetDriver());
-
-        const auto timeout = TInstant::Now() + TDuration::Seconds(10);
-        while (true) {
-            const auto op = opClient.Get<TScriptExecutionOperation>(operationId).ExtractValueSync();
-            UNIT_ASSERT_VALUES_EQUAL_C(op.Status().GetStatus(), EStatus::SUCCESS, op.Status().GetIssues().ToString());
-            UNIT_ASSERT_C(!op.Ready(), "Operation unexpectedly finished");
-            if (op.Metadata().ExecStatus == EExecStatus::Failed) {
-                break;
-            }
-
-            if (TInstant::Now() > timeout) {
-                UNIT_FAIL("Failed to wait for query to finish (before retry)");
-            }
-
-            Sleep(TDuration::MilliSeconds(100));
-        }
-
-        {
-            const auto query = fmt::format(R"(
-                DROP EXTERNAL DATA SOURCE `{s3_sink}`;
-                DROP EXTERNAL DATA SOURCE `{pq_source}`;)",
-                "s3_sink"_a = s3SinkName,
-                "pq_source"_a = pqSourceName
-            );
-            const auto result = db.ExecuteQuery(query, TTxControl::NoTx()).ExtractValueSync();
-            UNIT_ASSERT_VALUES_EQUAL_C(result.GetStatus(), EStatus::SUCCESS, result.GetIssues().ToString());
-        }
-
-        const auto readyOp = WaitScriptExecutionOperation(operationId, kikimr->GetDriver());
-        UNIT_ASSERT_VALUES_EQUAL_C(readyOp.Status().GetStatus(), EStatus::SUCCESS, readyOp.Status().GetIssues().ToString());
-        UNIT_ASSERT_VALUES_EQUAL_C(readyOp.Metadata().ExecStatus, EExecStatus::Completed, readyOp.Status().GetIssues().ToString());
         UNIT_ASSERT_VALUES_EQUAL(GetAllObjects(writeBucket), "{\"key\":\"key1\",\"value\":\"value1\"}\n");
         UNIT_ASSERT_VALUES_EQUAL(GetUncommittedUploadsCount(writeBucket), 0);
     }


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

Fixed hash shuffle channels restore for streaming queries

### Changelog category <!-- remove all except one -->

* Bugfix 

### Description for reviewers <!-- (optional) description for those who read this PR -->
