### PR TITLE
ci: change comparision for use_default_branches

### DIFF
--- a/.github/workflows/regression_run.yml
+++ b/.github/workflows/regression_run.yml
@@ -23,6 +23,6 @@ jobs:
         build_preset: ["relwithdebinfo", "release-asan", "release-tsan", "release-msan"]
     with:
       test_targets: ydb/
-      branches: ${{ inputs.use_default_branches != true && github.ref_name || '' }}
+      branches: ${{ startsWith(inputs.use_default_branches, 'false') && github.ref_name || '' }}
       branches_config_path: '.github/config/stable_tests_branches.json'
       build_preset: ${{ matrix.build_preset }}

--- a/.github/workflows/regression_run_large.yml
+++ b/.github/workflows/regression_run_large.yml
@@ -23,6 +23,6 @@ jobs:
     with:
       test_targets: ydb/
       test_size: large
-      branches: ${{ inputs.use_default_branches != true && github.ref_name || '' }}
+      branches: ${{ startsWith(inputs.use_default_branches, 'false') && github.ref_name || '' }}
       branches_config_path: '.github/config/stable_tests_branches.json'
       build_preset: ${{ matrix.build_preset }}

--- a/.github/workflows/regression_run_small_medium.yml
+++ b/.github/workflows/regression_run_small_medium.yml
@@ -23,6 +23,6 @@ jobs:
     with:
       test_targets: ydb/
       test_size: small,medium
-      branches: ${{ inputs.use_default_branches != true && github.ref_name || '' }}
+      branches: ${{ startsWith(inputs.use_default_branches, 'false') && github.ref_name || '' }}
       branches_config_path: '.github/config/stable_tests_branches.json'
       build_preset: ${{ matrix.build_preset }}

--- a/.github/workflows/regression_run_stress.yml
+++ b/.github/workflows/regression_run_stress.yml
@@ -22,6 +22,6 @@ jobs:
         build_preset: ["relwithdebinfo", "release-asan", "release-tsan", "release-msan"]
     with:
       test_targets: ydb/tests/stress/
-      branches: ${{ inputs.use_default_branches != true && github.ref_name || '' }}
+      branches: ${{ startsWith(inputs.use_default_branches, 'false') && github.ref_name || '' }}
       branches_config_path: '.github/config/stable_tests_branches.json'
       build_preset: ${{ matrix.build_preset }}

--- a/.github/workflows/regression_whitelist_run.yml
+++ b/.github/workflows/regression_whitelist_run.yml
@@ -22,6 +22,6 @@ jobs:
         build_preset: ["relwithdebinfo", "release-asan", "release-tsan", "release-msan"]
     with:
       test_targets: ydb/tests/sql/ ydb/tests/stress ydb/tests/functional/tpc ydb/tests/functional/benchmarks_init
-      branches: ${{ inputs.use_default_branches != true && github.ref_name || '' }}
+      branches: ${{ startsWith(inputs.use_default_branches, 'false') && github.ref_name || '' }}
       branches_config_path: '.github/config/stable_tests_branches.json'
       build_preset: ${{ matrix.build_preset }}


### PR DESCRIPTION
### Changelog category <!-- remove all except one -->

* Not for changelog (changelog entry is not required)

### Description for reviewers <!-- (optional) description for those who read this PR -->

Fix comparison method for `use_default_branches` input

Now we use 
`branches: ${{ startsWith(inputs.use_default_branches, 'false') && github.ref_name || '' }}`

- `true` dispatch is used, `branches` should be empty [RUN](https://github.com/ydb-platform/ydb/actions/runs/17218799380/job/48848923862)
- `false` dispatch is used, `branches` should be github.ref_name [RUN](https://github.com/ydb-platform/ydb/actions/runs/17218803558/job/48848936189)
- `` schedule is used, `branches` should be empty [RUN](https://github.com/ydb-platform/ydb/actions/runs/17219122196/job/48849988673)


