### PR TITLE
Propagate ForceGroupGeneration for all subrequests issued by DS proxy

### DIFF
--- a/ydb/core/base/blobstorage.h
+++ b/ydb/core/base/blobstorage.h
@@ -1224,7 +1224,6 @@ struct TEvBlobStorage {
 
         std::optional<TReaderTabletData> ReaderTabletData;
         std::optional<TForceBlockTabletData> ForceBlockTabletData;
-        std::optional<ui32> ForceGroupGeneration;
 
         TEvGet(TCloneEventPolicy, const TEvGet& origin)
             : QuerySize(origin.QuerySize)

--- a/ydb/core/blobstorage/dsproxy/dsproxy_request.cpp
+++ b/ydb/core/blobstorage/dsproxy/dsproxy_request.cpp
@@ -886,6 +886,11 @@ namespace NKikimr {
     }
 
     void TBlobStorageGroupRequestActor::SendToProxy(std::unique_ptr<IEventBase> event, ui64 cookie, NWilson::TTraceId traceId) {
+        if (ForceGroupGeneration) {
+            if (auto *common = dynamic_cast<TEvBlobStorage::TEvRequestCommon*>(event.get())) {
+                common->ForceGroupGeneration = ForceGroupGeneration;
+            }
+        }
         Send(ProxyActorId, event.release(), 0, cookie, std::move(traceId));
     }
 

--- a/ydb/core/blobstorage/dsproxy/dsproxy_request.cpp
+++ b/ydb/core/blobstorage/dsproxy/dsproxy_request.cpp
@@ -1114,6 +1114,7 @@ namespace NKikimr {
             ReplyAndDie(NKikimrProto::RACE);
             return false;
         }
+        Y_VERIFY_S(!Info->Group->HasBridgeProxyGroupId() || ForceGroupGeneration, "Type# " << TypeName(*this));
         return true;
     }
 

--- a/ydb/core/blobstorage/nodewarden/distconf_bridge.cpp
+++ b/ydb/core/blobstorage/nodewarden/distconf_bridge.cpp
@@ -20,8 +20,6 @@ namespace NKikimr::NStorage {
         }
 
         if (config->HasClusterStateDetails()) {
-            auto *details = config->MutableClusterStateDetails();
-
             Y_DEBUG_ABORT_UNLESS(config->HasClusterState());
             auto *clusterState = config->MutableClusterState();
 
@@ -31,49 +29,6 @@ namespace NKikimr::NStorage {
                         ConnectedUnsyncedPiles.contains(TBridgePileId::FromPileIndex(i))) {
                     clusterState->SetPerPileState(i, NKikimrBridge::TClusterState::NOT_SYNCHRONIZED_2);
                     changes = true;
-
-                    auto *state = details->AddPileSyncState();
-                    TBridgePileId::FromPileIndex(i).CopyToProto(state, &std::decay_t<decltype(*state)>::SetBridgePileId);
-                    state->SetBecameUnsyncedGeneration(clusterState->GetGeneration() + 1);
-                    state->SetUnsyncedBSC(true);
-
-                    // spin generations for all static groups and update this pile's state to BLOCKS
-                    auto *ss = config->MutableBlobStorageConfig()->MutableServiceSet();
-                    THashMap<TGroupId, NKikimrBlobStorage::TGroupInfo*> groupMap;
-                    for (auto& group : *ss->MutableGroups()) {
-                        groupMap.emplace(TGroupId::FromProto(&group, &NKikimrBlobStorage::TGroupInfo::GetGroupID), &group);
-                    }
-                    THashSet<TGroupId> changedGroupIds;
-                    for (const auto& [groupId, group] : groupMap) {
-                        if (!group->HasBridgeGroupState()) {
-                            continue;
-                        }
-                        auto *state = group->MutableBridgeGroupState();
-                        Y_ABORT_UNLESS(i < state->PileSize());
-                        auto *pile = state->MutablePile(i);
-                        pile->ClearStage();
-                        pile->SetBecameUnsyncedGeneration(clusterState->GetGeneration() + 1);
-                        group->SetGroupGeneration(group->GetGroupGeneration() + 1);
-                        for (auto& pile : *state->MutablePile()) {
-                            const auto refGroupId = TGroupId::FromProto(&pile, &NKikimrBridge::TGroupState::TPile::GetGroupId);
-                            auto *refGroup = groupMap[refGroupId];
-                            Y_ABORT_UNLESS(refGroup);
-                            Y_ABORT_UNLESS(refGroup->GetGroupGeneration() == pile.GetGroupGeneration());
-                            refGroup->SetGroupGeneration(refGroup->GetGroupGeneration() + 1);
-                            pile.SetGroupGeneration(refGroup->GetGroupGeneration());
-                            changedGroupIds.insert(refGroupId);
-                        }
-                    }
-                    for (auto& vdisk : *ss->MutableVDisks()) {
-                        auto vdiskId = VDiskIDFromVDiskID(vdisk.GetVDiskID());
-                        if (!changedGroupIds.contains(vdiskId.GroupID)) {
-                            continue;
-                        }
-                        auto *group = groupMap[vdiskId.GroupID];
-                        Y_ABORT_UNLESS(group);
-                        vdiskId.GroupGeneration = group->GetGroupGeneration();
-                        VDiskIDFromVDiskID(vdiskId, vdisk.MutableVDiskID());
-                    }
                 }
             }
         }

--- a/ydb/core/mind/bscontroller/bridge.cpp
+++ b/ydb/core/mind/bscontroller/bridge.cpp
@@ -352,7 +352,11 @@ void TBlobStorageController::StartRequiredSyncers() {
             return;
         }
         const auto& state = bridgeGroupInfo->GetBridgeGroupState();
-        for (const auto& pile : state.GetPile()) {
+        for (size_t pileIndex = 0; pileIndex < state.PileSize(); ++pileIndex) {
+            if (BridgeInfo->GetPile(TBridgePileId::FromPileIndex(pileIndex))->State != NKikimrBridge::TClusterState::NOT_SYNCHRONIZED_2) {
+                continue; // can't start syncing yet
+            }
+            const auto& pile = state.GetPile(pileIndex);
             if (pile.GetStage() == NKikimrBridge::TGroupState::SYNCED) {
                 continue; // this group is synced
             }


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

Propagate ForceGroupGeneration for all subrequests issued by DS proxy

### Changelog category <!-- remove all except one -->

* Not for changelog (changelog entry is not required)

### Description for reviewers <!-- (optional) description for those who read this PR -->

This patch ensures correct ForceGroupGeneration on all subrequests generated by DS proxy request processing actor to ensure correct handling of all responses when executing bridged queries.
