### PR TITLE
Propagate ForceGroupGeneration for all subrequests issued by DS proxy

### DIFF
--- a/ydb/core/base/blobstorage.h
+++ b/ydb/core/base/blobstorage.h
@@ -1255,7 +1255,6 @@ struct TEvBlobStorage {
 
         std::optional<TReaderTabletData> ReaderTabletData;
         std::optional<TForceBlockTabletData> ForceBlockTabletData;
-        std::optional<ui32> ForceGroupGeneration;
 
         TEvGet(TCloneEventPolicy, const TEvGet& origin)
             : QuerySize(origin.QuerySize)

--- a/ydb/core/blobstorage/dsproxy/dsproxy_blackboard.cpp
+++ b/ydb/core/blobstorage/dsproxy/dsproxy_blackboard.cpp
@@ -584,7 +584,7 @@ void TBlackboard::GetWorstPredictedDelaysNs(const TBlobStorageGroupInfo &info, T
 
 void TBlackboard::RegisterBlobForPut(const TLogoBlobID& id, size_t blobIdx) {
     const auto [it, inserted] = BlobStates.try_emplace(id);
-    Y_ABORT_UNLESS(inserted);
+    Y_VERIFY_S(inserted, "Id# " << id);
     TBlobState& state = it->second;
     state.Init(id, *Info);
     state.BlobIdx = blobIdx;

--- a/ydb/core/blobstorage/dsproxy/dsproxy_request.cpp
+++ b/ydb/core/blobstorage/dsproxy/dsproxy_request.cpp
@@ -886,6 +886,11 @@ namespace NKikimr {
     }
 
     void TBlobStorageGroupRequestActor::SendToProxy(std::unique_ptr<IEventBase> event, ui64 cookie, NWilson::TTraceId traceId) {
+        if (ForceGroupGeneration) {
+            if (auto *common = dynamic_cast<TEvBlobStorage::TEvRequestCommon*>(event.get())) {
+                common->ForceGroupGeneration = ForceGroupGeneration;
+            }
+        }
         Send(ProxyActorId, event.release(), 0, cookie, std::move(traceId));
     }
 

--- a/ydb/core/blobstorage/dsproxy/dsproxy_request.cpp
+++ b/ydb/core/blobstorage/dsproxy/dsproxy_request.cpp
@@ -1114,6 +1114,7 @@ namespace NKikimr {
             ReplyAndDie(NKikimrProto::RACE);
             return false;
         }
+        Y_VERIFY_S(!Info->Group->HasBridgeProxyGroupId() || ForceGroupGeneration, "Type# " << TypeName(*this));
         return true;
     }
 

--- a/ydb/core/blobstorage/dsproxy/dsproxy_request.cpp
+++ b/ydb/core/blobstorage/dsproxy/dsproxy_request.cpp
@@ -1114,7 +1114,7 @@ namespace NKikimr {
             ReplyAndDie(NKikimrProto::RACE);
             return false;
         }
-        Y_VERIFY_S(!Info->Group->HasBridgeProxyGroupId() || ForceGroupGeneration, "Type# " << TypeName(*this));
+        Y_VERIFY_S(!Info->Group || !Info->Group->HasBridgeProxyGroupId() || ForceGroupGeneration, "Type# " << TypeName(*this));
         return true;
     }
 

--- a/ydb/core/blobstorage/nodewarden/distconf_bridge.cpp
+++ b/ydb/core/blobstorage/nodewarden/distconf_bridge.cpp
@@ -20,8 +20,6 @@ namespace NKikimr::NStorage {
         }
 
         if (config->HasClusterStateDetails()) {
-            auto *details = config->MutableClusterStateDetails();
-
             Y_DEBUG_ABORT_UNLESS(config->HasClusterState());
             auto *clusterState = config->MutableClusterState();
 
@@ -31,49 +29,6 @@ namespace NKikimr::NStorage {
                         ConnectedUnsyncedPiles.contains(TBridgePileId::FromPileIndex(i))) {
                     clusterState->SetPerPileState(i, NKikimrBridge::TClusterState::NOT_SYNCHRONIZED_2);
                     changes = true;
-
-                    auto *state = details->AddPileSyncState();
-                    TBridgePileId::FromPileIndex(i).CopyToProto(state, &std::decay_t<decltype(*state)>::SetBridgePileId);
-                    state->SetBecameUnsyncedGeneration(clusterState->GetGeneration() + 1);
-                    state->SetUnsyncedBSC(true);
-
-                    // spin generations for all static groups and update this pile's state to BLOCKS
-                    auto *ss = config->MutableBlobStorageConfig()->MutableServiceSet();
-                    THashMap<TGroupId, NKikimrBlobStorage::TGroupInfo*> groupMap;
-                    for (auto& group : *ss->MutableGroups()) {
-                        groupMap.emplace(TGroupId::FromProto(&group, &NKikimrBlobStorage::TGroupInfo::GetGroupID), &group);
-                    }
-                    THashSet<TGroupId> changedGroupIds;
-                    for (const auto& [groupId, group] : groupMap) {
-                        if (!group->HasBridgeGroupState()) {
-                            continue;
-                        }
-                        auto *state = group->MutableBridgeGroupState();
-                        Y_ABORT_UNLESS(i < state->PileSize());
-                        auto *pile = state->MutablePile(i);
-                        pile->ClearStage();
-                        pile->SetBecameUnsyncedGeneration(clusterState->GetGeneration() + 1);
-                        group->SetGroupGeneration(group->GetGroupGeneration() + 1);
-                        for (auto& pile : *state->MutablePile()) {
-                            const auto refGroupId = TGroupId::FromProto(&pile, &NKikimrBridge::TGroupState::TPile::GetGroupId);
-                            auto *refGroup = groupMap[refGroupId];
-                            Y_ABORT_UNLESS(refGroup);
-                            Y_ABORT_UNLESS(refGroup->GetGroupGeneration() == pile.GetGroupGeneration());
-                            refGroup->SetGroupGeneration(refGroup->GetGroupGeneration() + 1);
-                            pile.SetGroupGeneration(refGroup->GetGroupGeneration());
-                            changedGroupIds.insert(refGroupId);
-                        }
-                    }
-                    for (auto& vdisk : *ss->MutableVDisks()) {
-                        auto vdiskId = VDiskIDFromVDiskID(vdisk.GetVDiskID());
-                        if (!changedGroupIds.contains(vdiskId.GroupID)) {
-                            continue;
-                        }
-                        auto *group = groupMap[vdiskId.GroupID];
-                        Y_ABORT_UNLESS(group);
-                        vdiskId.GroupGeneration = group->GetGroupGeneration();
-                        VDiskIDFromVDiskID(vdiskId, vdisk.MutableVDiskID());
-                    }
                 }
             }
         }

--- a/ydb/core/blobstorage/ut_blobstorage/bridge_get.cpp
+++ b/ydb/core/blobstorage/ut_blobstorage/bridge_get.cpp
@@ -19,6 +19,12 @@ namespace {
         return TNodeLocation(location);
     }
 
+    template<typename T>
+    T *FillInGroupGeneration(T *ev) {
+        ev->ForceGroupGeneration = 1;
+        return ev;
+    }
+
 }
 
 Y_UNIT_TEST_SUITE(BridgeGet) {
@@ -55,7 +61,8 @@ Y_UNIT_TEST_SUITE(BridgeGet) {
                     TString data = "hello";
                     TLogoBlobID id(100500, 1, step++, 0, data.size(), 0);
                     runtime->WrapInActorContext(sender, [&] {
-                        SendToBSProxy(sender, groupIds[originalGroupIndex], new TEvBlobStorage::TEvPut(id, data, TInstant::Max()));
+                        SendToBSProxy(sender, groupIds[originalGroupIndex], FillInGroupGeneration(
+                            new TEvBlobStorage::TEvPut(id, data, TInstant::Max())));
                     });
                     auto res = env.WaitForEdgeActorEvent<TEvBlobStorage::TEvPutResult>(sender, false);
                     UNIT_ASSERT_VALUES_EQUAL(res->Get()->Status, NKikimrProto::OK);
@@ -63,8 +70,8 @@ Y_UNIT_TEST_SUITE(BridgeGet) {
                     for (size_t i = 0; i < groupIds.size(); ++i) {
                         Cerr << "*** reading from i# " << i << Endl;
                         runtime->WrapInActorContext(sender, [&] {
-                            SendToBSProxy(sender, groupIds[i], new TEvBlobStorage::TEvGet(id, 0, 0,
-                                TInstant::Max(), NKikimrBlobStorage::FastRead));
+                            SendToBSProxy(sender, groupIds[i], FillInGroupGeneration(new TEvBlobStorage::TEvGet(id, 0, 0,
+                                TInstant::Max(), NKikimrBlobStorage::FastRead)));
                         });
                         auto res = env.WaitForEdgeActorEvent<TEvBlobStorage::TEvGetResult>(sender, false);
                         auto& m = *res->Get();
@@ -90,8 +97,8 @@ Y_UNIT_TEST_SUITE(BridgeGet) {
                     for (size_t i = 0; i < groupIds.size(); ++i) {
                         Cerr << "*** reading from i# " << i << Endl;
                         runtime->WrapInActorContext(sender, [&] {
-                            SendToBSProxy(sender, groupIds[i], new TEvBlobStorage::TEvGet(id, 0, 0,
-                                TInstant::Max(), NKikimrBlobStorage::FastRead));
+                            SendToBSProxy(sender, groupIds[i], FillInGroupGeneration(new TEvBlobStorage::TEvGet(id, 0, 0,
+                                TInstant::Max(), NKikimrBlobStorage::FastRead)));
                         });
                         auto res = env.WaitForEdgeActorEvent<TEvBlobStorage::TEvGetResult>(sender, false);
                         auto& m = *res->Get();
@@ -145,7 +152,8 @@ Y_UNIT_TEST_SUITE(BridgeGet) {
                     if (mask[i] & 1 << k) {
                         TLogoBlobID id(tabletId, k + 1, 1, 0, data.size(), 0);
                         runtime->WrapInActorContext(sender, [&] {
-                            SendToBSProxy(sender, groupIds[i], new TEvBlobStorage::TEvPut(id, data, TInstant::Max()));
+                            SendToBSProxy(sender, groupIds[i], FillInGroupGeneration(
+                                new TEvBlobStorage::TEvPut(id, data, TInstant::Max())));
                         });
                         auto res = env.WaitForEdgeActorEvent<TEvBlobStorage::TEvPutResult>(sender, false);
                         UNIT_ASSERT_VALUES_EQUAL(res->Get()->Status, NKikimrProto::OK);
@@ -170,8 +178,8 @@ Y_UNIT_TEST_SUITE(BridgeGet) {
             for (size_t i = 0; maxId && i < groupIds.size(); ++i) {
                 Cerr << "*** reading from i# " << i << Endl;
                 runtime->WrapInActorContext(sender, [&] {
-                    SendToBSProxy(sender, groupIds[i], new TEvBlobStorage::TEvGet(m.Id, 0, 0,
-                        TInstant::Max(), NKikimrBlobStorage::FastRead));
+                    SendToBSProxy(sender, groupIds[i], FillInGroupGeneration(new TEvBlobStorage::TEvGet(m.Id, 0, 0,
+                        TInstant::Max(), NKikimrBlobStorage::FastRead)));
                 });
                 auto res = env.WaitForEdgeActorEvent<TEvBlobStorage::TEvGetResult>(sender, false);
                 auto& m = *res->Get();
@@ -227,7 +235,8 @@ Y_UNIT_TEST_SUITE(BridgeGet) {
                     if (mask[i] & 1 << k) {
                         TLogoBlobID id(tabletId, gen, k + 1, 0, data.size(), 0);
                         runtime->WrapInActorContext(sender, [&] {
-                            SendToBSProxy(sender, groupIds[i], new TEvBlobStorage::TEvPut(id, data, TInstant::Max()));
+                            SendToBSProxy(sender, groupIds[i], FillInGroupGeneration(new TEvBlobStorage::TEvPut(
+                                id, data, TInstant::Max())));
                         });
                         auto res = env.WaitForEdgeActorEvent<TEvBlobStorage::TEvPutResult>(sender, false);
                         UNIT_ASSERT_VALUES_EQUAL(res->Get()->Status, NKikimrProto::OK);
@@ -266,8 +275,8 @@ Y_UNIT_TEST_SUITE(BridgeGet) {
                 Cerr << "*** reading from i# " << i << Endl;
                 for (size_t j = 0; j < blobs.size(); ++j) {
                     runtime->WrapInActorContext(sender, [&] {
-                        SendToBSProxy(sender, groupIds[i], new TEvBlobStorage::TEvGet(blobs[j], 0, 0,
-                            TInstant::Max(), NKikimrBlobStorage::FastRead));
+                        SendToBSProxy(sender, groupIds[i], FillInGroupGeneration(new TEvBlobStorage::TEvGet(blobs[j], 0, 0,
+                            TInstant::Max(), NKikimrBlobStorage::FastRead)));
                     });
                     auto res = env.WaitForEdgeActorEvent<TEvBlobStorage::TEvGetResult>(sender, false);
                     auto& m = *res->Get();

--- a/ydb/core/mind/bscontroller/bridge.cpp
+++ b/ydb/core/mind/bscontroller/bridge.cpp
@@ -372,7 +372,11 @@ void TBlobStorageController::StartRequiredSyncers() {
             return;
         }
         const auto& state = bridgeGroupInfo->GetBridgeGroupState();
-        for (const auto& pile : state.GetPile()) {
+        for (size_t pileIndex = 0; pileIndex < state.PileSize(); ++pileIndex) {
+            if (BridgeInfo->GetPile(TBridgePileId::FromPileIndex(pileIndex))->State != NKikimrBridge::TClusterState::NOT_SYNCHRONIZED_2) {
+                continue; // can't start syncing yet
+            }
+            const auto& pile = state.GetPile(pileIndex);
             if (pile.GetStage() == NKikimrBridge::TGroupState::SYNCED) {
                 continue; // this group is synced
             }


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

Propagate ForceGroupGeneration for all subrequests issued by DS proxy

### Changelog category <!-- remove all except one -->

* Not for changelog (changelog entry is not required)

### Description for reviewers <!-- (optional) description for those who read this PR -->

This patch ensures correct ForceGroupGeneration on all subrequests generated by DS proxy request processing actor to ensure correct handling of all responses when executing bridged queries.
