### PR TITLE
fixed loop on retryable error on target discovery

### DIFF
--- a/ydb/core/transfer/uploader.h
+++ b/ydb/core/transfer/uploader.h
@@ -14,7 +14,6 @@ class TTableUploader : public TActorBootstrapped<TTableUploader<TData>> {
     using TThis = TTableUploader<TData>;
     using TBase = TActorBootstrapped<TTableUploader<TData>>;
 
-protected:
     static constexpr size_t MaxSchemeRetries = 3;
 
 public:

--- a/ydb/core/tx/replication/common/backoff.h
+++ b/ydb/core/tx/replication/common/backoff.h
@@ -7,16 +7,18 @@ namespace NKikimr::NReplication {
 
 struct TBackoff {
 
+    static constexpr TDuration MinDelay = TDuration::MilliSeconds(5);
+
     TBackoff(size_t maxRetries = 10, TDuration initialDelay = TDuration::Seconds(1), TDuration maxDelay = TDuration::Minutes(15))
         : MaxRetries(maxRetries)
-        , InitialDelay(initialDelay)
+        , InitialDelay(std::max(initialDelay, MinDelay))
         , MaxDelay(maxDelay)
         , Iteration(0) {
     }
 
     TDuration Next() {
         TDuration delay = TDuration::MilliSeconds(InitialDelay.MilliSeconds() << Iteration++);
-        delay = std::min(MaxDelay, delay);
+        delay = delay == TDuration::Zero() ? MaxDelay : std::min(MaxDelay, delay);
         delay += TDuration::MilliSeconds(RandomNumber<size_t>(delay.MilliSeconds() / 4));
         return delay;
     }

--- a/ydb/core/tx/replication/common/backoff.h
+++ b/ydb/core/tx/replication/common/backoff.h
@@ -1,0 +1,37 @@
+#pragma once
+
+#include <util/datetime/base.h>
+#include <util/random/random.h>
+
+namespace NKikimr::NReplication {
+
+struct TBackoff {
+
+    TBackoff(size_t maxRetries = 10, TDuration initialDelay = TDuration::Seconds(1), TDuration maxDelay = TDuration::Minutes(15))
+        : MaxRetries(maxRetries)
+        , InitialDelay(initialDelay)
+        , MaxDelay(maxDelay)
+        , Iteration(0) {
+    }
+
+    TDuration Next() {
+        TDuration delay = TDuration::MilliSeconds(InitialDelay.MilliSeconds() << Iteration++);
+        delay = std::min(MaxDelay, delay);
+        delay += TDuration::MilliSeconds(RandomNumber<size_t>(delay.MilliSeconds() / 4));
+        return delay;
+    }
+
+    bool HasMore() const {
+        return Iteration < MaxRetries;
+    }
+
+    operator bool() const {
+        return HasMore();
+    }
+
+    const size_t MaxRetries;
+    const TDuration InitialDelay;
+    const TDuration MaxDelay;
+    size_t Iteration;
+};
+}

--- a/ydb/core/tx/replication/common/backoff.h
+++ b/ydb/core/tx/replication/common/backoff.h
@@ -13,7 +13,8 @@ struct TBackoff {
         : MaxRetries(maxRetries)
         , InitialDelay(std::max(initialDelay, MinDelay))
         , MaxDelay(maxDelay)
-        , Iteration(0) {
+        , Iteration(0)
+    {
     }
 
     TDuration Next() {
@@ -27,7 +28,7 @@ struct TBackoff {
         return Iteration < MaxRetries;
     }
 
-    operator bool() const {
+    explicit operator bool() const {
         return HasMore();
     }
 
@@ -36,4 +37,5 @@ struct TBackoff {
     const TDuration MaxDelay;
     size_t Iteration;
 };
+
 }

--- a/ydb/core/tx/replication/controller/target_discoverer.cpp
+++ b/ydb/core/tx/replication/controller/target_discoverer.cpp
@@ -398,7 +398,6 @@ private:
     TVector<TEvPrivate::TEvDiscoveryTargetsResult::TFailedEntry> Failed;
 
     TBackoff Backoff;
-
 }; // TTargetDiscoverer
 
 IActor* CreateTargetDiscoverer(const TActorId& parent, ui64 rid, const TActorId& proxy,

--- a/ydb/core/tx/replication/controller/target_discoverer.cpp
+++ b/ydb/core/tx/replication/controller/target_discoverer.cpp
@@ -7,6 +7,7 @@
 
 #include <ydb/core/base/path.h>
 #include <ydb/core/protos/replication.pb.h>
+#include <ydb/core/tx/replication/common/backoff.h>
 #include <ydb/core/tx/replication/ydb_proxy/ydb_proxy.h>
 #include <ydb/library/actors/core/actor_bootstrapped.h>
 #include <ydb/library/actors/core/hfunc.h>
@@ -75,9 +76,10 @@ class TTargetDiscoverer: public TActorBootstrapped<TTargetDiscoverer> {
             LOG_E("Describe path failed"
                 << ": path# " << path.first
                 << ", status# " << result.GetStatus()
-                << ", issues# " << result.GetIssues().ToOneLineString());
+                << ", issues# " << result.GetIssues().ToOneLineString()
+                << ", iteration# " << Backoff.Iteration);
 
-            if (IsRetryableError(result)) {
+            if (IsRetryableError(result) && Backoff.HasMore()) {
                 return RetryDescribe(*it);
             } else {
                 Failed.emplace_back(path.first, result);
@@ -145,7 +147,7 @@ class TTargetDiscoverer: public TActorBootstrapped<TTargetDiscoverer> {
                 << ", status# " << result.GetStatus()
                 << ", issues# " << result.GetIssues().ToOneLineString());
 
-            if (IsRetryableError(result)) {
+            if (IsRetryableError(result) && Backoff.HasMore()) {
                 return RetryDescribe(*it);
             } else {
                 Failed.emplace_back(path.first, result);
@@ -195,7 +197,7 @@ class TTargetDiscoverer: public TActorBootstrapped<TTargetDiscoverer> {
                 << ", status# " << result.GetStatus()
                 << ", issues# " << result.GetIssues().ToOneLineString());
 
-            if (IsRetryableError(result)) {
+            if (IsRetryableError(result) && Backoff.HasMore()) {
                 return RetryDescribe(*it);
             } else {
                 Failed.emplace_back(path.first, result);
@@ -285,7 +287,7 @@ class TTargetDiscoverer: public TActorBootstrapped<TTargetDiscoverer> {
                 << ", status# " << result.GetStatus()
                 << ", issues# " << result.GetIssues().ToOneLineString());
 
-            if (IsRetryableError(result)) {
+            if (IsRetryableError(result) && Backoff.HasMore()) {
                 return RetryListing(it->first);
             } else {
                 Failed.emplace_back(path.first, result);
@@ -298,7 +300,7 @@ class TTargetDiscoverer: public TActorBootstrapped<TTargetDiscoverer> {
 
     void ScheduleRetry() {
         if (DescribeRetries.empty() && ListingRetries.empty()) {
-            Schedule(TDuration::Seconds(10), new TEvents::TEvWakeup);
+            Schedule(Backoff.Next(), new TEvents::TEvWakeup);
         }
     }
 
@@ -345,6 +347,7 @@ public:
         , YdbProxy(proxy)
         , Config(config)
         , LogPrefix("TargetDiscoverer", ReplicationId)
+        , Backoff(5)
     {
         if (Config.HasSpecific()) {
             for (const auto& target : Config.GetSpecific().GetTargets()) {
@@ -393,6 +396,8 @@ private:
     THashSet<ui64> ListingRetries;
     TVector<TEvPrivate::TEvDiscoveryTargetsResult::TAddEntry> ToAdd;
     TVector<TEvPrivate::TEvDiscoveryTargetsResult::TFailedEntry> Failed;
+
+    TBackoff Backoff;
 
 }; // TTargetDiscoverer
 

--- a/ydb/core/tx/replication/controller/target_discoverer_ut.cpp
+++ b/ydb/core/tx/replication/controller/target_discoverer_ut.cpp
@@ -233,7 +233,9 @@ Y_UNIT_TEST_SUITE(TargetDiscoverer) {
         ));
 
         for (size_t i = 0; i <= 5; ++i) {
-            NYdb::TStatus status(NYdb::EStatus::UNAVAILABLE, NYdb::NIssue::TIssues());
+            NYdb::NIssue::TIssues issues;
+            issues.AddIssue(TStringBuilder() << "iteration-" << i);
+            NYdb::TStatus status(NYdb::EStatus::UNAVAILABLE, std::move(issues));
             env.SendAsync(discoveryActorId, new TEvYdbProxy::TEvDescribePathResponse(std::move(status), NYdb::NScheme::TSchemeEntry()));
 
             env.SendAsync(discoveryActorId, new TEvents::TEvWakeup());
@@ -245,6 +247,7 @@ Y_UNIT_TEST_SUITE(TargetDiscoverer) {
         const auto& failed = ev->Get()->Failed;
         UNIT_ASSERT_VALUES_EQUAL(failed.size(), 1);
         UNIT_ASSERT_VALUES_EQUAL(failed.at(0).Error.GetStatus(), NYdb::EStatus::UNAVAILABLE);
+        UNIT_ASSERT_VALUES_EQUAL(failed.at(0).Error.GetIssues().ToOneLineString(), "{ <main>: Error: iteration-5 }");
     }
 }
 


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

...

### Changelog category <!-- remove all except one -->

* Not for changelog (changelog entry is not required)

### Description for reviewers <!-- (optional) description for those who read this PR -->

Добавил ограничение по кол-ву ретраев для ошибок во время target_discovery. Это позволяет показать пользователю ошибку из-за чего не работает репликация/трансфер. До этого понять причину можно было только по логам сервера.
