### PR TITLE
Added tests for nullable columns in PK and changed deserialization logics

### DIFF
--- a/ydb/core/kqp/ut/olap/kqp_olap_ut.cpp
+++ b/ydb/core/kqp/ut/olap/kqp_olap_ut.cpp
@@ -4142,35 +4142,35 @@ Y_UNIT_TEST_SUITE(KqpOlap) {
             Cout << "a is null and b = 3 result: " << output5 << Endl;
             CompareYson(output5, R"([[#;[3]]])");
 
-            // Cerr << "Starting select\n";
-            // AFL_DEBUG(NKikimrServices::TX_COLUMNSHARD)("event", "Starting select a is not null");
-            // it = client.StreamExecuteQuery(R"(
-            //     SELECT
-            //         a, b
-            //     FROM `/Root/ColumnShard`
-            //     WHERE a IS NOT NULL;
-            // )", NYdb::NQuery::TTxControl::BeginTx().CommitTx()).ExtractValueSync();
-            // Cerr << "Finished select\n";
-            // UNIT_ASSERT_VALUES_EQUAL_C(it.GetStatus(), EStatus::SUCCESS, it.GetIssues().ToString());
-            // TString output6 = StreamResultToYson(it);
-            // Cerr << "Finished convert\n";
-            // Cout << output6 << Endl;
-            // CompareYson(output6, R"([[[2u];[5]];[[3u];#]])");
+            Cerr << "Starting select\n";
+            AFL_DEBUG(NKikimrServices::TX_COLUMNSHARD)("event", "Starting select a is not null");
+            it = client.StreamExecuteQuery(R"(
+                SELECT
+                    a, b
+                FROM `/Root/ColumnShard`
+                WHERE a IS NOT NULL;
+            )", NYdb::NQuery::TTxControl::BeginTx().CommitTx()).ExtractValueSync();
+            Cerr << "Finished select\n";
+            UNIT_ASSERT_VALUES_EQUAL_C(it.GetStatus(), EStatus::SUCCESS, it.GetIssues().ToString());
+            TString output6 = StreamResultToYson(it);
+            Cerr << "Finished convert\n";
+            Cout << "a is not null result: " << output6 << Endl;
+            CompareYson(output6, R"([[[2u];[5]];[[3u];#]])");
 
-            // Cerr << "Starting select\n";
-            // AFL_DEBUG(NKikimrServices::TX_COLUMNSHARD)("event", "Starting select a is not null and b = 5");
-            // it = client.StreamExecuteQuery(R"(
-            //     SELECT
-            //         a, b
-            //     FROM `/Root/ColumnShard`
-            //     WHERE a IS NOT NULL AND b = 5;
-            // )", NYdb::NQuery::TTxControl::BeginTx().CommitTx()).ExtractValueSync();
-            // Cerr << "Finished select\n";
-            // UNIT_ASSERT_VALUES_EQUAL_C(it.GetStatus(), EStatus::SUCCESS, it.GetIssues().ToString());
-            // TString output7 = StreamResultToYson(it);
-            // Cerr << "Finished convert\n";
-            // Cout << output7 << Endl;
-            // CompareYson(output7, R"([[[2u];[5]]])");
+            Cerr << "Starting select\n";
+            AFL_DEBUG(NKikimrServices::TX_COLUMNSHARD)("event", "Starting select a is not null and b = 5");
+            it = client.StreamExecuteQuery(R"(
+                SELECT
+                    a, b
+                FROM `/Root/ColumnShard`
+                WHERE a IS NOT NULL AND b = 5;
+            )", NYdb::NQuery::TTxControl::BeginTx().CommitTx()).ExtractValueSync();
+            Cerr << "Finished select\n";
+            UNIT_ASSERT_VALUES_EQUAL_C(it.GetStatus(), EStatus::SUCCESS, it.GetIssues().ToString());
+            TString output7 = StreamResultToYson(it);
+            Cerr << "Finished convert\n";
+            Cout << "a is not null and b = 5 result: " << output7 << Endl;
+            CompareYson(output7, R"([[[2u];[5]]])");
 
             // Cerr << "Starting select a!=2\n";
             // AFL_DEBUG(NKikimrServices::TX_COLUMNSHARD)("event", "Starting select a != 2");
@@ -4184,7 +4184,7 @@ Y_UNIT_TEST_SUITE(KqpOlap) {
             // UNIT_ASSERT_VALUES_EQUAL_C(it.GetStatus(), EStatus::SUCCESS, it.GetIssues().ToString());
             // TString output8 = StreamResultToYson(it);
             // Cerr << "Finished convert\n";
-            // Cout << output8 << Endl;
+            // Cout << "a != 2 result: " << output8 << Endl;
             // CompareYson(output8, R"([[[3u];#]])");
 
             Cerr << "Starting select\n";
@@ -4199,7 +4199,7 @@ Y_UNIT_TEST_SUITE(KqpOlap) {
             UNIT_ASSERT_VALUES_EQUAL_C(it.GetStatus(), EStatus::SUCCESS, it.GetIssues().ToString());
             TString output9 = StreamResultToYson(it);
             Cerr << "Finished convert\n";
-            Cout << output9 << Endl;
+            Cout << "a < 3 result: " << output9 << Endl;
             CompareYson(output9, R"([[[2u];[5]]])");
 
             Cerr << "Starting select a < 2\n";
@@ -4217,20 +4217,20 @@ Y_UNIT_TEST_SUITE(KqpOlap) {
             Cout << "a < 2 result: " << output10 << Endl;
             CompareYson(output10, R"([])");
 
-            // Cerr << "Starting select a > 2\n";
-            // AFL_DEBUG(NKikimrServices::TX_COLUMNSHARD)("event", "Starting select a > 2");
-            // it = client.StreamExecuteQuery(R"(
-            //     SELECT
-            //         a, b
-            //     FROM `/Root/ColumnShard`
-            //     WHERE a > 2;
-            // )", NYdb::NQuery::TTxControl::BeginTx().CommitTx()).ExtractValueSync();
-            // Cerr << "Finished select\n";
-            // UNIT_ASSERT_VALUES_EQUAL_C(it.GetStatus(), EStatus::SUCCESS, it.GetIssues().ToString());
-            // TString output11 = StreamResultToYson(it);
-            // Cerr << "Finished convert\n";
-            // Cout << "a > 2 result: " << output11 << Endl;
-            // CompareYson(output11, R"([[#;#];[#;[3]];[[3u];#]])");
+            Cerr << "Starting select a > 2\n";
+            AFL_DEBUG(NKikimrServices::TX_COLUMNSHARD)("event", "Starting select a > 2");
+            it = client.StreamExecuteQuery(R"(
+                SELECT
+                    a, b
+                FROM `/Root/ColumnShard`
+                WHERE a > 2;
+            )", NYdb::NQuery::TTxControl::BeginTx().CommitTx()).ExtractValueSync();
+            Cerr << "Finished select\n";
+            UNIT_ASSERT_VALUES_EQUAL_C(it.GetStatus(), EStatus::SUCCESS, it.GetIssues().ToString());
+            TString output11 = StreamResultToYson(it);
+            Cerr << "Finished convert\n";
+            Cout << "a > 2 result: " << output11 << Endl;
+            CompareYson(output11, R"([[#;#];[#;[3]];[[3u];#]])");
             
         }
     }

--- a/ydb/core/kqp/ut/olap/kqp_olap_ut.cpp
+++ b/ydb/core/kqp/ut/olap/kqp_olap_ut.cpp
@@ -3017,8 +3017,7 @@ Y_UNIT_TEST_SUITE(KqpOlap) {
 #endif
         );
     }
-*/
-
+ */
     // Unit test for https://github.com/ydb-platform/ydb/issues/7967
     Y_UNIT_TEST(PredicatePushdownNulls) {
         auto settings = TKikimrSettings()
@@ -4030,6 +4029,210 @@ Y_UNIT_TEST_SUITE(KqpOlap) {
                     NYdb::NQuery::TTxControl::BeginTx().CommitTx())
                 .GetValueSync();
         UNIT_ASSERT_VALUES_EQUAL(result.GetStatus(), EStatus::SUCCESS);
+    }
+
+    Y_UNIT_TEST(SelectNullPk) {
+        auto settings = TKikimrSettings().SetWithSampleTables(false);
+        settings.AppConfig.MutableColumnShardConfig()->SetAllowNullableColumnsInPK(true);
+
+        TKikimrRunner kikimr(settings);
+        Tests::NCommon::TLoggerInit(kikimr).Initialize();
+
+        auto session = kikimr.GetTableClient().CreateSession().GetValueSync().GetSession();
+
+        const TString query = R"(
+            CREATE TABLE `/Root/ColumnShard` (
+                a Uint64,
+                b Int64,
+                PRIMARY KEY (a, b)
+            )
+            PARTITION BY HASH(a)
+            WITH (STORE = COLUMN, AUTO_PARTITIONING_MIN_PARTITIONS_COUNT = 1);
+        )";
+
+        auto result = session.ExecuteSchemeQuery(query).GetValueSync();
+        UNIT_ASSERT_C(result.GetStatus() == NYdb::EStatus::SUCCESS, result.GetIssues().ToString());
+
+        auto client = kikimr.GetQueryClient();
+        {
+            auto prepareResult = client.ExecuteQuery(R"(
+                REPLACE INTO `/Root/ColumnShard` (a, b) VALUES
+                    (NULL, 3),
+                    (NULL, NULL),
+                    (2u, 5),
+                    (3u, NULL)
+            )", NYdb::NQuery::TTxControl::BeginTx().CommitTx()).ExtractValueSync();
+            UNIT_ASSERT(prepareResult.IsSuccess());;
+        }
+
+        {
+            kikimr.GetTestServer().GetRuntime()->SetLogPriority(NKikimrServices::TX_COLUMNSHARD, NActors::NLog::PRI_TRACE);
+            kikimr.GetTestServer().GetRuntime()->SetLogPriority(NKikimrServices::KQP_COMPUTE, NActors::NLog::PRI_TRACE);
+
+            Cerr << "Starting select\n";
+            AFL_DEBUG(NKikimrServices::TX_COLUMNSHARD)("event", "Starting select a <= 2");
+            auto it = client.StreamExecuteQuery(R"(
+                SELECT
+                    a, b
+                FROM `/Root/ColumnShard`
+                WHERE a <= 2;
+            )", NYdb::NQuery::TTxControl::BeginTx().CommitTx()).ExtractValueSync();
+            Cerr << "Finished select\n";
+            UNIT_ASSERT_VALUES_EQUAL_C(it.GetStatus(), EStatus::SUCCESS, it.GetIssues().ToString());
+            TString output1 = StreamResultToYson(it);
+            Cerr << "Finished convert\n";
+            Cout << "a <= 2 result: " << output1 << Endl;
+            CompareYson(output1, R"([[[2u];[5]]])");
+
+            Cerr << "Starting select\n";
+            AFL_DEBUG(NKikimrServices::TX_COLUMNSHARD)("event", "Starting select a is null");
+            it = client.StreamExecuteQuery(R"(
+                SELECT
+                    a, b
+                FROM `/Root/ColumnShard`
+                WHERE a IS NULL;
+            )", NYdb::NQuery::TTxControl::BeginTx().CommitTx()).ExtractValueSync();
+            Cerr << "Finished select\n";
+            UNIT_ASSERT_VALUES_EQUAL_C(it.GetStatus(), EStatus::SUCCESS, it.GetIssues().ToString());
+            TString output2 = StreamResultToYson(it);
+            Cerr << "Finished convert\n";
+            Cout << "a is null result: " << output2 << Endl;
+            CompareYson(output2, R"([[#;#];[#;[3]]])");
+
+            AFL_DEBUG(NKikimrServices::TX_COLUMNSHARD)("event", "Starting select a is null and b is null");
+            it = client.StreamExecuteQuery(R"(
+                SELECT
+                    a, b
+                FROM `/Root/ColumnShard`
+                WHERE a IS NULL AND b IS NULL;
+            )", NYdb::NQuery::TTxControl::BeginTx().CommitTx()).ExtractValueSync();
+            Cerr << "Finished select\n";
+            UNIT_ASSERT_VALUES_EQUAL_C(it.GetStatus(), EStatus::SUCCESS, it.GetIssues().ToString());
+            TString output3 = StreamResultToYson(it);
+            Cerr << "Finished convert\n";
+            Cout << "a is null and b is null result: " << output3 << Endl;
+            CompareYson(output3, R"([[#;#]])");
+
+            AFL_DEBUG(NKikimrServices::TX_COLUMNSHARD)("event", "Starting select a is null and b is not null");
+            it = client.StreamExecuteQuery(R"(
+                SELECT
+                    a, b
+                FROM `/Root/ColumnShard`
+                WHERE a IS NULL AND b IS NOT NULL;
+            )", NYdb::NQuery::TTxControl::BeginTx().CommitTx()).ExtractValueSync();
+            Cerr << "Finished select\n";
+            UNIT_ASSERT_VALUES_EQUAL_C(it.GetStatus(), EStatus::SUCCESS, it.GetIssues().ToString());
+            TString output4 = StreamResultToYson(it);
+            Cerr << "Finished convert\n";
+            Cout << "a is null and b is not null result: " << output4 << Endl;
+            CompareYson(output4, R"([[#;[3]]])");
+
+            Cerr << "Starting select\n";
+            AFL_DEBUG(NKikimrServices::TX_COLUMNSHARD)("event", "Starting select a is null and b = 3");
+            it = client.StreamExecuteQuery(R"(
+                SELECT
+                    a, b
+                FROM `/Root/ColumnShard`
+                WHERE a IS NULL AND b = 3;
+            )", NYdb::NQuery::TTxControl::BeginTx().CommitTx()).ExtractValueSync();
+            Cerr << "Finished select\n";
+            UNIT_ASSERT_VALUES_EQUAL_C(it.GetStatus(), EStatus::SUCCESS, it.GetIssues().ToString());
+            TString output5 = StreamResultToYson(it);
+            Cerr << "Finished convert\n";
+            Cout << "a is null and b = 3 result: " << output5 << Endl;
+            CompareYson(output5, R"([[#;[3]]])");
+
+            // Cerr << "Starting select\n";
+            // AFL_DEBUG(NKikimrServices::TX_COLUMNSHARD)("event", "Starting select a is not null");
+            // it = client.StreamExecuteQuery(R"(
+            //     SELECT
+            //         a, b
+            //     FROM `/Root/ColumnShard`
+            //     WHERE a IS NOT NULL;
+            // )", NYdb::NQuery::TTxControl::BeginTx().CommitTx()).ExtractValueSync();
+            // Cerr << "Finished select\n";
+            // UNIT_ASSERT_VALUES_EQUAL_C(it.GetStatus(), EStatus::SUCCESS, it.GetIssues().ToString());
+            // TString output6 = StreamResultToYson(it);
+            // Cerr << "Finished convert\n";
+            // Cout << output6 << Endl;
+            // CompareYson(output6, R"([[[2u];[5]];[[3u];#]])");
+
+            // Cerr << "Starting select\n";
+            // AFL_DEBUG(NKikimrServices::TX_COLUMNSHARD)("event", "Starting select a is not null and b = 5");
+            // it = client.StreamExecuteQuery(R"(
+            //     SELECT
+            //         a, b
+            //     FROM `/Root/ColumnShard`
+            //     WHERE a IS NOT NULL AND b = 5;
+            // )", NYdb::NQuery::TTxControl::BeginTx().CommitTx()).ExtractValueSync();
+            // Cerr << "Finished select\n";
+            // UNIT_ASSERT_VALUES_EQUAL_C(it.GetStatus(), EStatus::SUCCESS, it.GetIssues().ToString());
+            // TString output7 = StreamResultToYson(it);
+            // Cerr << "Finished convert\n";
+            // Cout << output7 << Endl;
+            // CompareYson(output7, R"([[[2u];[5]]])");
+
+            // Cerr << "Starting select a!=2\n";
+            // AFL_DEBUG(NKikimrServices::TX_COLUMNSHARD)("event", "Starting select a != 2");
+            // it = client.StreamExecuteQuery(R"(
+            //     SELECT
+            //         a, b
+            //     FROM `/Root/ColumnShard`
+            //     WHERE a != 2;
+            // )", NYdb::NQuery::TTxControl::BeginTx().CommitTx()).ExtractValueSync();
+            // Cerr << "Finished select\n";
+            // UNIT_ASSERT_VALUES_EQUAL_C(it.GetStatus(), EStatus::SUCCESS, it.GetIssues().ToString());
+            // TString output8 = StreamResultToYson(it);
+            // Cerr << "Finished convert\n";
+            // Cout << output8 << Endl;
+            // CompareYson(output8, R"([[[3u];#]])");
+
+            Cerr << "Starting select\n";
+            AFL_DEBUG(NKikimrServices::TX_COLUMNSHARD)("event", "Starting select a < 3");
+            it = client.StreamExecuteQuery(R"(
+                SELECT
+                    a, b
+                FROM `/Root/ColumnShard`
+                WHERE a < 3;
+            )", NYdb::NQuery::TTxControl::BeginTx().CommitTx()).ExtractValueSync();
+            Cerr << "Finished select\n";
+            UNIT_ASSERT_VALUES_EQUAL_C(it.GetStatus(), EStatus::SUCCESS, it.GetIssues().ToString());
+            TString output9 = StreamResultToYson(it);
+            Cerr << "Finished convert\n";
+            Cout << output9 << Endl;
+            CompareYson(output9, R"([[[2u];[5]]])");
+
+            Cerr << "Starting select a < 2\n";
+            AFL_DEBUG(NKikimrServices::TX_COLUMNSHARD)("event", "Starting select a < 2");
+            it = client.StreamExecuteQuery(R"(
+                SELECT
+                    a, b
+                FROM `/Root/ColumnShard`
+                WHERE a < 2;
+            )", NYdb::NQuery::TTxControl::BeginTx().CommitTx()).ExtractValueSync();
+            Cerr << "Finished select\n";
+            UNIT_ASSERT_VALUES_EQUAL_C(it.GetStatus(), EStatus::SUCCESS, it.GetIssues().ToString());
+            TString output10 = StreamResultToYson(it);
+            Cerr << "Finished convert\n";
+            Cout << "a < 2 result: " << output10 << Endl;
+            CompareYson(output10, R"([])");
+
+            // Cerr << "Starting select a > 2\n";
+            // AFL_DEBUG(NKikimrServices::TX_COLUMNSHARD)("event", "Starting select a > 2");
+            // it = client.StreamExecuteQuery(R"(
+            //     SELECT
+            //         a, b
+            //     FROM `/Root/ColumnShard`
+            //     WHERE a > 2;
+            // )", NYdb::NQuery::TTxControl::BeginTx().CommitTx()).ExtractValueSync();
+            // Cerr << "Finished select\n";
+            // UNIT_ASSERT_VALUES_EQUAL_C(it.GetStatus(), EStatus::SUCCESS, it.GetIssues().ToString());
+            // TString output11 = StreamResultToYson(it);
+            // Cerr << "Finished convert\n";
+            // Cout << "a > 2 result: " << output11 << Endl;
+            // CompareYson(output11, R"([[#;#];[#;[3]];[[3u];#]])");
+            
+        }
     }
 
     Y_UNIT_TEST(InsertIntoNullablePK) {

--- a/ydb/core/tx/columnshard/engines/predicate/predicate.cpp
+++ b/ydb/core/tx/columnshard/engines/predicate/predicate.cpp
@@ -65,6 +65,69 @@ TString FromCells(const TConstArrayRef<TCell>& cells, const std::vector<std::pai
     return NArrow::SerializeBatchNoCompression(batch);
 }
 
+// std::pair<NKikimr::NOlap::TPredicate, NKikimr::NOlap::TPredicate> TPredicate::DeserializePredicatesRange(
+//     const TSerializedTableRange& range, const std::vector<std::pair<TString, NScheme::TTypeInfo>>& columns) {
+//     std::vector<TCell> leftCells;
+//     std::vector<std::pair<TString, NScheme::TTypeInfo>> leftColumns;
+
+//     Cerr << "From" << Endl;
+//     for (auto& cell: range.From.GetCells()) {
+//         Cerr << cell.IsNull() << " ";
+//     }
+//     Cerr << "\nInclusive: " << range.FromInclusive << Endl;
+//     Cerr << "From end" << Endl;
+
+//     Cerr << "To" << Endl;
+//     for (auto& cell: range.To.GetCells()) {
+//         Cerr << cell.IsNull() << " ";
+//     }
+//     Cerr << "\nInclusive: " << range.ToInclusive << Endl;
+//     Cerr << "To end" << Endl;
+
+//     {
+//         TConstArrayRef<TCell> cells = range.From.GetCells();
+//         const size_t size = cells.size();
+//         Y_ASSERT(size <= columns.size());
+//         leftCells.reserve(size);
+//         leftColumns.reserve(size);
+//         for (size_t i = 0; i < size; ++i) {
+//             leftCells.push_back(cells[i]);
+//             leftColumns.push_back(columns[i]);
+//         }
+//     }
+
+//     std::vector<TCell> rightCells;
+//     std::vector<std::pair<TString, NScheme::TTypeInfo>> rightColumns;
+//     {
+//         TConstArrayRef<TCell> cells = range.To.GetCells();
+//         const size_t size = cells.size();
+//         Y_ASSERT(size <= columns.size());
+//         rightCells.reserve(size);
+//         rightColumns.reserve(size);
+//         for (size_t i = 0; i < size; ++i) {
+//             rightCells.push_back(cells[i]);
+//             rightColumns.push_back(columns[i]);
+//         }
+//     }
+
+//     const bool fromInclusive = range.FromInclusive; //|| leftTrailingNull;
+//     const bool toInclusive = range.ToInclusive;// && !rightTrailingNull;
+
+//     TString leftBorder = FromCells(leftCells, leftColumns);
+//     TString rightBorder = FromCells(rightCells, rightColumns);
+//     auto leftSchema = NArrow::MakeArrowSchema(leftColumns);
+//     Y_ASSERT(leftSchema.ok());
+//     auto rightSchema = NArrow::MakeArrowSchema(rightColumns);
+//     Y_ASSERT(rightSchema.ok());
+//     auto result = std::make_pair(
+//         TPredicate(fromInclusive ? NKernels::EOperation::GreaterEqual : NKernels::EOperation::Greater, leftBorder, leftSchema.ValueUnsafe()),
+//         TPredicate(toInclusive ? NKernels::EOperation::LessEqual : NKernels::EOperation::Less, rightBorder, rightSchema.ValueUnsafe()));
+//     Cerr << "R1: " << result.first << Endl;
+//     Cerr << "R2: " << result.second << Endl;
+
+//     return result;
+// }
+
 std::pair<NKikimr::NOlap::TPredicate, NKikimr::NOlap::TPredicate> TPredicate::DeserializePredicatesRange(
     const TSerializedTableRange& range, const std::vector<std::pair<TString, NScheme::TTypeInfo>>& columns) {
     std::vector<TCell> leftCells;


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

Added support for nullable PK columns and tests

### Changelog category <!-- remove all except one -->

* Improvement

### Description for reviewers <!-- (optional) description for those who read this PR -->

PR draft to support nullable columns in PK. Added tests, but some tests does not work because of not working logic with "> N". But the author of PR did not manage to get what is wrong with it. Maybe range generation in protobuf for yql query should support nullable PK differently.
...
