### PR TITLE
Generate 1 empty cluster for an empty vector index

### DIFF
--- a/ydb/core/base/kmeans_clusters.cpp
+++ b/ydb/core/base/kmeans_clusters.cpp
@@ -302,6 +302,13 @@ public:
         return data.size() == 1 + sizeof(TCoord) * Dimensions;
     }
 
+    TString GetEmptyRow() const override {
+        TString str;
+        str.resize(1 + sizeof(TCoord) * Dimensions);
+        str[sizeof(TCoord) * Dimensions] = TypeByte;
+        return str;
+    }
+
 private:
     auto GetCoords(const char* coords) {
         return std::span{reinterpret_cast<const TCoord*>(coords), Dimensions};

--- a/ydb/core/base/kmeans_clusters.h
+++ b/ydb/core/base/kmeans_clusters.h
@@ -39,6 +39,8 @@ public:
     virtual void AggregateToCluster(ui32 pos, const TArrayRef<const char>& embedding, ui64 weight = 1) = 0;
 
     virtual bool IsExpectedSize(const TArrayRef<const char>& data) = 0;
+
+    virtual TString GetEmptyRow() const = 0;
 };
 
 std::unique_ptr<IClusters> CreateClusters(const Ydb::Table::VectorIndexSettings& settings, ui32 maxRounds, TString& error);

--- a/ydb/core/kqp/ut/indexes/kqp_indexes_vector_ut.cpp
+++ b/ydb/core/kqp/ut/indexes/kqp_indexes_vector_ut.cpp
@@ -175,7 +175,7 @@ Y_UNIT_TEST_SUITE(KqpVectorIndexes) {
         DoPositiveQueriesVectorIndexOrderBy(session, txSettings, "CosineSimilarity", "DESC", covered);
     }
 
-    TSession DoOnlyCreateTableForVectorIndex(TTableClient& db, bool nullable, const TString& dataCol = "data") {
+    TSession DoOnlyCreateTableForVectorIndex(TTableClient& db, bool nullable, const TString& dataCol = "data", bool partitioned = true) {
         auto session = db.CreateSession().GetValueSync().GetSession();
 
         {
@@ -192,13 +192,15 @@ Y_UNIT_TEST_SUITE(KqpVectorIndexes) {
                     .AddNonNullableColumn(dataCol, EPrimitiveType::String);
             }
             tableBuilder.SetPrimaryKeyColumns({"pk"});
-            tableBuilder.BeginPartitioningSettings()
-                .SetMinPartitionsCount(3)
-            .EndPartitioningSettings();
-            auto partitions = TExplicitPartitions{}
-                .AppendSplitPoints(TValueBuilder{}.BeginTuple().AddElement().OptionalInt64(4).EndTuple().Build())
-                .AppendSplitPoints(TValueBuilder{}.BeginTuple().AddElement().OptionalInt64(6).EndTuple().Build());
-            tableBuilder.SetPartitionAtKeys(partitions);
+            if (partitioned) {
+                tableBuilder.BeginPartitioningSettings()
+                    .SetMinPartitionsCount(3)
+                .EndPartitioningSettings();
+                auto partitions = TExplicitPartitions{}
+                    .AppendSplitPoints(TValueBuilder{}.BeginTuple().AddElement().OptionalInt64(4).EndTuple().Build())
+                    .AppendSplitPoints(TValueBuilder{}.BeginTuple().AddElement().OptionalInt64(6).EndTuple().Build());
+                tableBuilder.SetPartitionAtKeys(partitions);
+            }
             auto result = session.CreateTable("/Root/TestTable", tableBuilder.Build()).ExtractValueSync();
             UNIT_ASSERT_VALUES_EQUAL(result.IsTransportError(), false);
             UNIT_ASSERT_VALUES_EQUAL_C(result.GetStatus(), EStatus::SUCCESS, result.GetIssues().ToString());
@@ -517,55 +519,6 @@ Y_UNIT_TEST_SUITE(KqpVectorIndexes) {
         UNIT_ASSERT_STRINGS_EQUAL(originalPostingTable, postingTable1_bulk);
     }
 
-    Y_UNIT_TEST(VectorIndexNoEmptyUpdate) {
-        NKikimrConfig::TFeatureFlags featureFlags;
-        featureFlags.SetEnableVectorIndex(true);
-        auto setting = NKikimrKqp::TKqpSetting();
-        auto serverSettings = TKikimrSettings()
-            .SetFeatureFlags(featureFlags)
-            .SetKqpSettings({setting});
-
-        TKikimrRunner kikimr(serverSettings);
-        kikimr.GetTestServer().GetRuntime()->SetLogPriority(NKikimrServices::BUILD_INDEX, NActors::NLog::PRI_TRACE);
-
-        auto db = kikimr.GetTableClient();
-        auto session = DoOnlyCreateTableForVectorIndex(db, true);
-        DoCreateVectorIndex(session, false);
-
-        const TString originalPostingTable = ReadTablePartToYson(session, "/Root/TestTable/index1/indexImplPostingTable");
-
-        // Insert to the table with index should succeed, but without updating the index
-        {
-            TString query1(Q_(R"(
-                INSERT INTO `/Root/TestTable` (pk, emb, data) VALUES
-                (10, "\x11\x62\x03", "10"),
-                (11, "\x77\x75\x03", "11");
-            )"));
-            auto result = session.ExecuteDataQuery(query1, TTxControl::BeginTx(TTxSettings::SerializableRW()).CommitTx())
-                .ExtractValueSync();
-            UNIT_ASSERT(result.IsSuccess());
-        }
-        UNIT_ASSERT_STRINGS_EQUAL(originalPostingTable, ReadTablePartToYson(session, "/Root/TestTable/index1/indexImplPostingTable"));
-
-        // Update to the table with index should succeed, but without updating the index
-        {
-            TString query1(Q_("UPDATE `/Root/TestTable` SET data=\"20\" WHERE pk=10;"));
-            auto result = session.ExecuteDataQuery(query1, TTxControl::BeginTx(TTxSettings::SerializableRW()).CommitTx())
-                .ExtractValueSync();
-            UNIT_ASSERT(result.IsSuccess());
-        }
-        UNIT_ASSERT_STRINGS_EQUAL(originalPostingTable, ReadTablePartToYson(session, "/Root/TestTable/index1/indexImplPostingTable"));
-
-        // Delete from the table with index should succeed, but without updating the index
-        {
-            TString query1(Q_("DELETE FROM `/Root/TestTable`"));
-            auto result = session.ExecuteDataQuery(query1, TTxControl::BeginTx(TTxSettings::SerializableRW()).CommitTx())
-                .ExtractValueSync();
-            UNIT_ASSERT(result.IsSuccess());
-        }
-        UNIT_ASSERT_STRINGS_EQUAL(originalPostingTable, ReadTablePartToYson(session, "/Root/TestTable/index1/indexImplPostingTable"));
-    }
-
     void DoTestVectorIndexDelete(const TString& deleteQuery, bool returning, bool covered) {
         NKikimrConfig::TFeatureFlags featureFlags;
         featureFlags.SetEnableVectorIndex(true);
@@ -837,6 +790,67 @@ Y_UNIT_TEST_SUITE(KqpVectorIndexes) {
 
     Y_UNIT_TEST_TWIN(VectorIndexUpsertClusterChangeReturning, Covered) {
         DoTestVectorIndexUpdateClusterChange(Q_(R"(UPSERT INTO `/Root/TestTable` (`pk`, `emb`, `data`) VALUES (9, "\x03\x31\x03", "9") RETURNING `data`, `emb`, `pk`;)"), true, Covered);
+    }
+
+    // First index level build is processed differently when table has 1 and >1 partitions so we check both cases
+    Y_UNIT_TEST_TWIN(EmptyVectorIndexUpdate, Partitioned) {
+        NKikimrConfig::TFeatureFlags featureFlags;
+        featureFlags.SetEnableVectorIndex(true);
+        auto setting = NKikimrKqp::TKqpSetting();
+        auto serverSettings = TKikimrSettings()
+            .SetFeatureFlags(featureFlags)
+            .SetKqpSettings({setting});
+
+        TKikimrRunner kikimr(serverSettings);
+        kikimr.GetTestServer().GetRuntime()->SetLogPriority(NKikimrServices::BUILD_INDEX, NActors::NLog::PRI_TRACE);
+        kikimr.GetTestServer().GetRuntime()->SetLogPriority(NKikimrServices::FLAT_TX_SCHEMESHARD, NActors::NLog::PRI_TRACE);
+
+        auto db = kikimr.GetTableClient();
+        auto session = DoOnlyCreateTableForVectorIndex(db, false, "data", Partitioned);
+        DoCreateVectorIndex(session, false);
+
+        // Check that the index has 1 empty leaf cluster
+        {
+            const TString query1(Q_(R"(
+                SELECT COUNT(*), UNWRAP(SUM(CASE WHEN (__ydb_id & 0x8000000000000000) != 0 THEN 1 ELSE 0 END)) FROM `/Root/TestTable/index1/indexImplLevelTable`;
+            )"));
+            auto result = session.ExecuteDataQuery(query1, TTxControl::BeginTx(TTxSettings::SerializableRW()).CommitTx())
+                .ExtractValueSync();
+            UNIT_ASSERT(result.IsSuccess());
+            UNIT_ASSERT_VALUES_EQUAL(NYdb::FormatResultSetYson(result.GetResultSet(0)), "[[1u;1]]");
+        }
+        {
+            const TString query1(Q_(R"(
+                SELECT COUNT(*) FROM `/Root/TestTable/index1/indexImplPostingTable`;
+            )"));
+            auto result = session.ExecuteDataQuery(query1, TTxControl::BeginTx(TTxSettings::SerializableRW()).CommitTx())
+                .ExtractValueSync();
+            UNIT_ASSERT(result.IsSuccess());
+            UNIT_ASSERT_VALUES_EQUAL(NYdb::FormatResultSetYson(result.GetResultSet(0)), "[[0u]]");
+        }
+
+        // Insert to the table with index should succeed
+        {
+            TString query1(Q_(R"(
+                INSERT INTO `/Root/TestTable` (pk, emb, data) VALUES
+                (10, "\x11\x62\x03", "10");
+            )"));
+
+            auto result = session.ExecuteDataQuery(query1, TTxControl::BeginTx(TTxSettings::SerializableRW()).CommitTx())
+                .ExtractValueSync();
+            UNIT_ASSERT(result.IsSuccess());
+        }
+
+        // Posting table should be updated
+        {
+            const TString query1(Q_(R"(
+                SELECT COUNT(*) FROM `/Root/TestTable/index1/indexImplPostingTable`;
+            )"));
+            auto result = session.ExecuteDataQuery(query1, TTxControl::BeginTx(TTxSettings::SerializableRW()).CommitTx())
+                .ExtractValueSync();
+            UNIT_ASSERT(result.IsSuccess());
+            UNIT_ASSERT_VALUES_EQUAL(NYdb::FormatResultSetYson(result.GetResultSet(0)), "[[1u]]");
+        }
     }
 
     Y_UNIT_TEST_TWIN(SimpleVectorIndexOrderByCosineDistanceWithCover, Nullable) {

--- a/ydb/core/protos/tx_datashard.proto
+++ b/ydb/core/protos/tx_datashard.proto
@@ -1607,8 +1607,6 @@ message TEvLocalKMeansRequest {
     repeated string DataColumns = 20;
 
     optional NKikimrIndexBuilder.TIndexBuildScanSettings ScanSettings = 22;
-
-    optional bool MakeOneEmptyCluster = 23;
 }
 
 message TEvLocalKMeansResponse {
@@ -1625,7 +1623,7 @@ message TEvLocalKMeansResponse {
 
     reserved 8 to 11;
     optional NKikimrIndexBuilder.TMeteringStats MeteringStats = 12;
-    optional bool IsLastLevel = 13;
+    optional bool IsEmpty = 13;
 }
 
 message TEvReshuffleKMeansRequest {

--- a/ydb/core/protos/tx_datashard.proto
+++ b/ydb/core/protos/tx_datashard.proto
@@ -1607,6 +1607,8 @@ message TEvLocalKMeansRequest {
     repeated string DataColumns = 20;
 
     optional NKikimrIndexBuilder.TIndexBuildScanSettings ScanSettings = 22;
+
+    optional bool MakeOneEmptyCluster = 23;
 }
 
 message TEvLocalKMeansResponse {
@@ -1623,6 +1625,7 @@ message TEvLocalKMeansResponse {
 
     reserved 8 to 11;
     optional NKikimrIndexBuilder.TMeteringStats MeteringStats = 12;
+    optional bool IsLastLevel = 13;
 }
 
 message TEvReshuffleKMeansRequest {

--- a/ydb/core/tx/schemeshard/schemeshard__init.cpp
+++ b/ydb/core/tx/schemeshard/schemeshard__init.cpp
@@ -4715,7 +4715,8 @@ struct TSchemeShard::TTxInit : public TTransactionBase<TSchemeShard> {
                             rowset.GetValue<Schema::KMeansTreeProgress::Child>(),
                             rowset.GetValue<Schema::KMeansTreeProgress::State>(),
                             rowset.GetValue<Schema::KMeansTreeProgress::TableSize>(),
-                            rowset.GetValue<Schema::KMeansTreeProgress::Round>()
+                            rowset.GetValue<Schema::KMeansTreeProgress::Round>(),
+                            rowset.GetValue<Schema::KMeansTreeProgress::IsEmpty>()
                         );
                         buildInfo.Sample.Rows.reserve(buildInfo.KMeans.K * 2);
                         if (buildInfo.KMeans.State == TIndexBuildInfo::TKMeans::Recompute) {

--- a/ydb/core/tx/schemeshard/schemeshard_build_index.cpp
+++ b/ydb/core/tx/schemeshard/schemeshard_build_index.cpp
@@ -321,6 +321,19 @@ void TSchemeShard::PersistBuildIndexShardStatusReset(NIceDb::TNiceDb& db, TIndex
     info.Shards.clear();
 }
 
+void TSchemeShard::PersistBuildIndexKMeansState(NIceDb::TNiceDb& db, const TIndexBuildInfo& buildInfo) {
+    db.Table<Schema::KMeansTreeProgress>().Key(buildInfo.Id).Update(
+        NIceDb::TUpdate<Schema::KMeansTreeProgress::Level>(buildInfo.KMeans.Level),
+        NIceDb::TUpdate<Schema::KMeansTreeProgress::State>(buildInfo.KMeans.State),
+        NIceDb::TUpdate<Schema::KMeansTreeProgress::Parent>(buildInfo.KMeans.Parent),
+        NIceDb::TUpdate<Schema::KMeansTreeProgress::ParentBegin>(buildInfo.KMeans.ParentBegin),
+        NIceDb::TUpdate<Schema::KMeansTreeProgress::Child>(buildInfo.KMeans.Child),
+        NIceDb::TUpdate<Schema::KMeansTreeProgress::ChildBegin>(buildInfo.KMeans.ChildBegin),
+        NIceDb::TUpdate<Schema::KMeansTreeProgress::TableSize>(buildInfo.KMeans.TableSize),
+        NIceDb::TUpdate<Schema::KMeansTreeProgress::Round>(buildInfo.KMeans.Round)
+    );
+}
+
 void TSchemeShard::PersistBuildIndexSampleForget(NIceDb::TNiceDb& db, const TIndexBuildInfo& info) {
     Y_ASSERT(info.IsBuildVectorIndex());
     for (ui32 row = 0; row < info.KMeans.K * 2; ++row) {

--- a/ydb/core/tx/schemeshard/schemeshard_build_index.cpp
+++ b/ydb/core/tx/schemeshard/schemeshard_build_index.cpp
@@ -330,7 +330,8 @@ void TSchemeShard::PersistBuildIndexKMeansState(NIceDb::TNiceDb& db, const TInde
         NIceDb::TUpdate<Schema::KMeansTreeProgress::Child>(buildInfo.KMeans.Child),
         NIceDb::TUpdate<Schema::KMeansTreeProgress::ChildBegin>(buildInfo.KMeans.ChildBegin),
         NIceDb::TUpdate<Schema::KMeansTreeProgress::TableSize>(buildInfo.KMeans.TableSize),
-        NIceDb::TUpdate<Schema::KMeansTreeProgress::Round>(buildInfo.KMeans.Round)
+        NIceDb::TUpdate<Schema::KMeansTreeProgress::Round>(buildInfo.KMeans.Round),
+        NIceDb::TUpdate<Schema::KMeansTreeProgress::IsEmpty>(buildInfo.KMeans.IsEmpty)
     );
 }
 

--- a/ydb/core/tx/schemeshard/schemeshard_impl.h
+++ b/ydb/core/tx/schemeshard/schemeshard_impl.h
@@ -1517,6 +1517,7 @@ public:
     void PersistBuildIndexProcessed(NIceDb::TNiceDb& db, const TIndexBuildInfo& indexInfo);
     void PersistBuildIndexBilled(NIceDb::TNiceDb& db, const TIndexBuildInfo& indexInfo);
 
+    void PersistBuildIndexKMeansState(NIceDb::TNiceDb& db, const TIndexBuildInfo& buildInfo);
     void PersistBuildIndexSampleForget(NIceDb::TNiceDb& db, const TIndexBuildInfo& indexInfo);
     void PersistBuildIndexSampleToClusters(NIceDb::TNiceDb& db, TIndexBuildInfo& indexInfo);
     void PersistBuildIndexClustersToSample(NIceDb::TNiceDb& db, TIndexBuildInfo& indexInfo);

--- a/ydb/core/tx/schemeshard/schemeshard_info_types.cpp
+++ b/ydb/core/tx/schemeshard/schemeshard_info_types.cpp
@@ -2280,6 +2280,7 @@ TString TIndexBuildInfo::TKMeans::DebugString() const {
         << ", Level = " << Level << " / " << Levels
         << ", K = " << K
         << ", Round = " << Round
+        << (IsEmpty ? ", IsEmpty = true" : "")
         << ", Parent = [" << ParentBegin << ".." << Parent << ".." << ParentEnd() << "]"
         << ", Child = [" << ChildBegin << ".." << Child << ".." << ChildEnd() << "]"
         << ", TableSize = " << TableSize
@@ -2323,9 +2324,10 @@ void TIndexBuildInfo::TKMeans::PrefixIndexDone(ui64 shards) {
 void TIndexBuildInfo::TKMeans::Set(ui32 level,
     NTableIndex::TClusterId parentBegin, NTableIndex::TClusterId parent,
     NTableIndex::TClusterId childBegin, NTableIndex::TClusterId child,
-    ui32 state, ui64 tableSize, ui32 round) {
+    ui32 state, ui64 tableSize, ui32 round, bool isEmpty) {
     Level = level;
     Round = round;
+    IsEmpty = isEmpty;
     ParentBegin = parentBegin;
     Parent = parent;
     ChildBegin = childBegin;

--- a/ydb/core/tx/schemeshard/schemeshard_info_types.h
+++ b/ydb/core/tx/schemeshard/schemeshard_info_types.h
@@ -3153,6 +3153,7 @@ struct TIndexBuildInfo: public TSimpleRefCount<TIndexBuildInfo> {
         };
         ui32 Level = 1;
         ui32 Round = 0;
+        bool IsEmpty = false;
 
         EState State = Sample;
 
@@ -3181,7 +3182,7 @@ struct TIndexBuildInfo: public TSimpleRefCount<TIndexBuildInfo> {
         void Set(ui32 level,
             NTableIndex::TClusterId parentBegin, NTableIndex::TClusterId parent,
             NTableIndex::TClusterId childBegin, NTableIndex::TClusterId child,
-            ui32 state, ui64 tableSize, ui32 round);
+            ui32 state, ui64 tableSize, ui32 round, bool isEmpty);
 
         NKikimrTxDataShard::EKMeansState GetUpload() const;
 

--- a/ydb/core/tx/schemeshard/schemeshard_schema.h
+++ b/ydb/core/tx/schemeshard/schemeshard_schema.h
@@ -2021,6 +2021,7 @@ struct Schema : NIceDb::Schema {
         struct TableSize : Column<8, NScheme::NTypeIds::Uint64> {};
         // Also for "auto" settings will needs to save K
         struct Round : Column<9, NScheme::NTypeIds::Uint32> {};
+        struct IsEmpty : Column<10, NScheme::NTypeIds::Bool> {};
 
         using TKey = TableKey<Id>;
         using TColumns = TableColumns<
@@ -2032,7 +2033,8 @@ struct Schema : NIceDb::Schema {
             Child,
             ChildBegin,
             TableSize,
-            Round
+            Round,
+            IsEmpty
         >;
     };
 

--- a/ydb/tests/functional/scheme_tests/canondata/tablet_scheme_tests.TestTabletSchemes.test_tablet_schemes_flat_schemeshard_/flat_schemeshard.schema
+++ b/ydb/tests/functional/scheme_tests/canondata/tablet_scheme_tests.TestTabletSchemes.test_tablet_schemes_flat_schemeshard_/flat_schemeshard.schema
@@ -8413,6 +8413,11 @@
                 "ColumnId": 9,
                 "ColumnName": "Round",
                 "ColumnType": "Uint32"
+            },
+            {
+                "ColumnId": 10,
+                "ColumnName": "IsEmpty",
+                "ColumnType": "Bool"
             }
         ],
         "ColumnsDropped": [],
@@ -8427,7 +8432,8 @@
                     6,
                     7,
                     8,
-                    9
+                    9,
+                    10
                 ],
                 "RoomID": 0,
                 "Codec": 0,


### PR DESCRIPTION
### Changelog category

* Not for changelog (changelog entry is not required)

### Description for reviewers

This is required to enable updates of an empty vector index without making the level table mutable.
