### PR TITLE
Fix TX proxy and add bridge mode stress test for scheme board

### DIFF
--- a/ydb/core/tx/scheme_board/subscriber.cpp
+++ b/ydb/core/tx/scheme_board/subscriber.cpp
@@ -499,6 +499,9 @@ public:
 template <typename TPath, typename TDerived, typename TReplicaDerived>
 class TSubscriberProxy: public TMonitorableActor<TDerived> {
     void Sleep() {
+        SBS_LOG_T("Sleep"
+            << ": delay# " << Delay);
+
         ReplicaSubscriber = TActorId();
         this->Send(Parent, new NInternalEvents::TEvNotifyBuilder(Path, true));
         this->Become(&TDerived::StateSleep, Delay, new TEvents::TEvWakeup());
@@ -529,10 +532,19 @@ class TSubscriberProxy: public TMonitorableActor<TDerived> {
     }
 
     void HandleSleep(NInternalEvents::TEvSyncVersionRequest::TPtr& ev) {
+        SBS_LOG_T("HandleSleep " << ev->Get()->ToString()
+            << ": sender# " << ev->Sender
+            << ", cookie# " << ev->Cookie);
+
         this->Send(Parent, new NInternalEvents::TEvSyncVersionResponse(0), 0, ev->Cookie);
     }
 
     void Handle(NInternalEvents::TEvSyncVersionResponse::TPtr& ev) {
+        SBS_LOG_T("Handle " << ev->Get()->ToString()
+            << ": sender# " << ev->Sender
+            << ", cookie# " << ev->Cookie
+            << ", current sync request# " << CurrentSyncRequest);
+
         if (ev->Sender != ReplicaSubscriber || ev->Cookie != CurrentSyncRequest) {
             return;
         }
@@ -777,6 +789,7 @@ class TSubscriber: public TMonitorableActor<TDerived> {
     }
 
     bool MaybeRunVersionSync() {
+        SBS_LOG_T("MaybeRunVersionSync, delayed sync request: " << DelayedSyncRequest);
         if (!DelayedSyncRequest) {
             return false;
         }
@@ -858,8 +871,13 @@ class TSubscriber: public TMonitorableActor<TDerived> {
 
         if (!record.GetIsDeletion()) {
             NKikimrScheme::TEvDescribeSchemeResult proto = selectedNotify->GetDescribeSchemeResult();
+            SBS_LOG_T("Send notification to the owner"
+                << ": owner# " << Owner
+                << ", proto# " << proto.ShortDebugString());
             this->Send(Owner, BuildNotify<TSchemeBoardEvents::TEvNotifyUpdate>(record, std::move(proto)));
         } else {
+            SBS_LOG_T("Send deletion notification to the owner"
+                << ": owner# " << Owner);
             this->Send(Owner, BuildNotify<TSchemeBoardEvents::TEvNotifyDelete>(record, record.GetStrong()));
         }
     }
@@ -878,7 +896,12 @@ class TSubscriber: public TMonitorableActor<TDerived> {
 
         EnqueueSyncRequest(ev);
 
-        if (PendingSync || !IsMajorityReached()) {
+        if (PendingSync) {
+            SBS_LOG_T("Pending sync");
+            return;
+        }
+        if (!IsMajorityReached()) {
+            SBS_LOG_T("Haven't reached the majority");
             return;
         }
 

--- a/ydb/core/tx/scheme_board/subscriber.cpp
+++ b/ydb/core/tx/scheme_board/subscriber.cpp
@@ -789,7 +789,8 @@ class TSubscriber: public TMonitorableActor<TDerived> {
     }
 
     bool MaybeRunVersionSync() {
-        SBS_LOG_T("MaybeRunVersionSync, delayed sync request: " << DelayedSyncRequest);
+        SBS_LOG_T("MaybeRunVersionSync"
+            << ": delayed sync request# " << DelayedSyncRequest);
         if (!DelayedSyncRequest) {
             return false;
         }

--- a/ydb/core/tx/tx_proxy/schemereq.cpp
+++ b/ydb/core/tx/tx_proxy/schemereq.cpp
@@ -1712,17 +1712,18 @@ void TFlatSchemeReq::HandleWorkingDir(TEvTxProxySchemeCache::TEvNavigateKeySetRe
     const auto& resultSet = ev->Get()->Request->ResultSet;
 
     const TVector<TString>* workingDir = nullptr;
-    bool lookupError = true;
+    bool lookupError = false;
     for (auto it = resultSet.rbegin(); it != resultSet.rend(); ++it) {
-        lookupError &= (it->Status == NSchemeCache::TSchemeCacheNavigate::EStatus::LookupError);
         if (it->Status == NSchemeCache::TSchemeCacheNavigate::EStatus::Ok) {
             workingDir = &it->Path;
             break;
+        } else if (it->Status == NSchemeCache::TSchemeCacheNavigate::EStatus::LookupError) {
+            lookupError = true;
         }
     }
 
     auto parts = GetFullPath(GetModifyScheme());
-    if (!resultSet.empty() && lookupError) {
+    if (!workingDir && lookupError) {
         const auto errText = TStringBuilder()
             << "Cannot resolve working dir, lookup error"
             << " path# " << JoinPath(parts);

--- a/ydb/tests/stress/common/common.py
+++ b/ydb/tests/stress/common/common.py
@@ -19,10 +19,10 @@ class YdbClient:
     def wait_connection(self, timeout=5):
         self.driver.wait(timeout, fail_fast=True)
 
-    def query(self, statement, is_ddl):
+    def query(self, statement, is_ddl, retry_settings=None):
         if self.use_query_service:
             try:
-                return self.session_pool.execute_with_retries(statement)
+                return self.session_pool.execute_with_retries(query=statement, retry_settings=retry_settings)
             except Exception as e:
                 logger.error(f"Error: {e} while executing query: {statement}")
                 raise e

--- a/ydb/tests/stress/scheme_board/pile_promotion/__main__.py
+++ b/ydb/tests/stress/scheme_board/pile_promotion/__main__.py
@@ -1,0 +1,30 @@
+# -*- coding: utf-8 -*-
+import argparse
+import logging
+import sys
+from ydb.tests.stress.scheme_board.pile_promotion.workload import WorkloadRunner
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(
+        description="test scheme board stability during pile promotions",
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+    )
+    parser.add_argument("--grpc_endpoint", default="localhost:2135", help="GRPC endpoint to be used")
+    parser.add_argument("--http_endpoint", default="http://localhost:8765", help="HTTP endpoint to be used")
+    parser.add_argument("--database", default="/Root", help="Database to connect to")
+    parser.add_argument("--path", default="olap_workload", help="Path prefix for tables")
+    parser.add_argument(
+        "--duration", default=180, type=lambda x: int(x), help="Duration of workload in seconds."
+    )
+    args = parser.parse_args()
+
+    logging.basicConfig(
+        level=logging.DEBUG, format="%(asctime)s - %(levelname)s - %(name)s:%(lineno)d - %(funcName)s: %(message)s"
+    )
+    logger = logging.getLogger("pile_promotion")
+
+    with WorkloadRunner(args.grpc_endpoint, args.http_endpoint, args.database, args.path, args.duration) as runner:
+        if runner.run() < 2:
+            logger.error("Test was not successful.")
+            sys.exit(1)

--- a/ydb/tests/stress/scheme_board/pile_promotion/tests/pile_promotion_test.py
+++ b/ydb/tests/stress/scheme_board/pile_promotion/tests/pile_promotion_test.py
@@ -1,0 +1,63 @@
+# -*- coding: utf-8 -*-
+import os
+import yatest
+
+from ydb.tests.library.harness.kikimr_runner import KiKiMR
+from ydb.tests.library.harness.kikimr_config import KikimrConfigGenerator
+from ydb.tests.library.common.types import Erasure
+from ydb.tests.library.harness.util import LogLevels
+
+
+class PilePromotionTest(object):
+
+    @classmethod
+    def setup_class(cls):
+        cls.cluster = KiKiMR(
+            KikimrConfigGenerator(
+                erasure=Erasure.BLOCK_4_2,
+                nodes=16,
+                use_in_memory_pdisks=False,
+                use_config_store=True,
+                metadata_section={
+                    "kind": "MainConfig",
+                    "version": 0,
+                    "cluster": "",
+                },
+                separate_node_configs=True,
+                simple_config=True,
+                use_self_management=True,
+                extra_grpc_services=["bridge"],
+                bridge_config={"piles": [{"name": "r1"}, {"name": "r2"}]},
+                additional_log_configs={
+                    "BS_NODE": LogLevels.DEBUG,
+                    "CMS_TENANTS": LogLevels.DEBUG,
+                    "FLAT_TX_SCHEMESHARD": LogLevels.DEBUG,
+                    "INTERCONNECT": LogLevels.INFO,
+                    "KQP_COMPILE_ACTOR": LogLevels.DEBUG,
+                    "KQP_GATEWAY": LogLevels.DEBUG,
+                    "KQP_SESSION": LogLevels.DEBUG,
+                    "SCHEME_BOARD_POPULATOR": LogLevels.DEBUG,
+                    "SCHEME_BOARD_REPLICA": LogLevels.DEBUG,
+                    "SCHEME_BOARD_SUBSCRIBER": LogLevels.TRACE,
+                    "TX_PROXY": LogLevels.DEBUG,
+                    "TX_PROXY_SCHEME_CACHE": LogLevels.DEBUG,
+                },
+            )
+        )
+        cls.cluster.start()
+
+    @classmethod
+    def teardown_class(cls):
+        cls.cluster.stop()
+
+    def do_test(self):
+        cmd = [
+            yatest.common.binary_path(os.getenv("STRESS_TEST_UTILITY")),
+            "--grpc_endpoint", f"grpc://{self.cluster.nodes[1].host}:{self.cluster.nodes[1].grpc_port}",
+            "--http_endpoint", f"http://{self.cluster.nodes[1].host}:{self.cluster.nodes[1].mon_port}",
+            "--database", "/Root",
+            "--path", "test",
+            "--duration", "180",
+        ]
+
+        yatest.common.execute(cmd, wait=True)

--- a/ydb/tests/stress/scheme_board/pile_promotion/tests/test_scheme_board_workload.py
+++ b/ydb/tests/stress/scheme_board/pile_promotion/tests/test_scheme_board_workload.py
@@ -1,0 +1,7 @@
+# -*- coding: utf-8 -*-
+from pile_promotion_test import PilePromotionTest
+
+
+class TestSchemeBoard(PilePromotionTest):
+    def test_scheme_board(self):
+        self.do_test()

--- a/ydb/tests/stress/scheme_board/pile_promotion/tests/ya.make
+++ b/ydb/tests/stress/scheme_board/pile_promotion/tests/ya.make
@@ -1,0 +1,30 @@
+PY3TEST()
+INCLUDE(${ARCADIA_ROOT}/ydb/tests/ydbd_dep.inc)
+ENV(STRESS_TEST_UTILITY="ydb/tests/stress/scheme_board/pile_promotion/pile_promotion_workload")
+
+TEST_SRCS(
+    pile_promotion_test.py
+    test_scheme_board_workload.py
+)
+
+REQUIREMENTS(ram:32)
+
+SIZE(MEDIUM)
+
+ENV(YDB_CLI_BINARY="ydb/apps/ydb/ydb")
+
+DEPENDS(
+    ydb/apps/ydb
+    ydb/tests/stress/scheme_board/pile_promotion
+)
+
+PEERDIR(
+    ydb/tests/library
+    ydb/tests/library/clients
+    ydb/tests/library/stress
+    ydb/tests/stress/common
+    ydb/tests/stress/scheme_board/pile_promotion/workload
+)
+
+
+END()

--- a/ydb/tests/stress/scheme_board/pile_promotion/workload/__init__.py
+++ b/ydb/tests/stress/scheme_board/pile_promotion/workload/__init__.py
@@ -152,7 +152,7 @@ class WorkloadInsertDelete(WorkloadBase):
             logger.debug(f"iteration {i}")
             self._query_with_retries(
                 f"""
-                    INSERT INTO `{table_path}` (`id`, `i64Val`)
+                    UPSERT INTO `{table_path}` (`id`, `i64Val`)
                     VALUES
                     ({i * 2}, {i * 10}),
                     ({i * 2 + 1}, {i * 10 + 1})

--- a/ydb/tests/stress/scheme_board/pile_promotion/workload/__init__.py
+++ b/ydb/tests/stress/scheme_board/pile_promotion/workload/__init__.py
@@ -1,0 +1,343 @@
+# -*- coding: utf-8 -*-
+import ydb
+import time
+import random
+import threading
+import requests
+import logging
+from enum import Enum
+from urllib.parse import urlparse
+
+from ydb.public.api.protos.ydb_bridge_common_pb2 import PileState
+from ydb.public.api.protos.ydb_status_codes_pb2 import StatusIds
+from ydb.tests.library.clients.kikimr_bridge_client import BridgeClient
+from ydb.tests.oss.ydb_sdk_import import ydb
+from ydb.tests.stress.common.common import WorkloadBase
+from ydb.tests.stress.common.common import YdbClient
+import ydb.public.api.protos.draft.ydb_bridge_pb2 as bridge
+
+logger = logging.getLogger(__name__)
+
+
+def update_cluster_state(client, updates, expected_status=StatusIds.SUCCESS):
+    response = client.update_cluster_state(updates)
+    logger.debug(f"Update cluster state response: {response}")
+    if response.operation.status != expected_status:
+        raise Exception(f"Update cluster state failed with status: {response.operation.status}")
+    if expected_status == StatusIds.SUCCESS:
+        result = bridge.UpdateClusterStateResult()
+        response.operation.result.Unpack(result)
+        return result
+    else:
+        return response
+
+
+def get_cluster_state(client):
+    response = client.get_cluster_state()
+    if response.operation.status != StatusIds.SUCCESS:
+        raise Exception(f"Get cluster state failed with status: {response.operation.status}")
+    result = bridge.GetClusterStateResult()
+    response.operation.result.Unpack(result)
+    logger.debug(f"Get cluster state result: {result}")
+    return result
+
+
+class WorkloadTablesCreateDrop(WorkloadBase):
+    class TableStatus(Enum):
+        CREATING = "Creating"
+        AVAILABLE = "Available"
+        DELETING = "Deleting"
+
+    def __init__(self, client, prefix, stop):
+        super().__init__(client, prefix, "create_drop", stop)
+        self.created = 0
+        self.deleted = 0
+        self.tables = {}
+        self.lock = threading.Lock()
+
+    def get_stat(self):
+        with self.lock:
+            return f"Created: {self.created}, Deleted: {self.deleted}, Existing: {len(self.tables)}"
+
+    def _generate_new_table_n(self):
+        with self.lock:
+            n = self.created + 1
+            while n in self.tables:
+                n += 1
+            self.tables[n] = WorkloadTablesCreateDrop.TableStatus.CREATING
+            return n
+
+    def create_table(self, table):
+        path = self.get_table_path(table)
+        stmt = f"""
+                CREATE TABLE `{path}` (
+                    key Int, value Utf8,
+                    PRIMARY KEY(key)
+                )
+            """
+        self.client.query(stmt, True)
+
+    def _create_tables_loop(self):
+        logger.debug("starting")
+        while not self.is_stop_requested():
+            n = self._generate_new_table_n()
+            self.create_table(str(n))
+            with self.lock:
+                self.tables[n] = WorkloadTablesCreateDrop.TableStatus.AVAILABLE
+                self.created += 1
+                logger.debug(f"iteration {self.created}")
+        with self.lock:
+            logger.debug(f"exiting after {self.created} iterations")
+
+    def _get_table_to_delete(self):
+        with self.lock:
+            for n, status in self.tables.items():
+                if status == WorkloadTablesCreateDrop.TableStatus.AVAILABLE:
+                    self.tables[n] = WorkloadTablesCreateDrop.TableStatus.DELETING
+                    return n
+            return None
+
+    def _delete_tables_loop(self):
+        logger.debug("starting")
+        while not self.is_stop_requested():
+            n = self._get_table_to_delete()
+            if n is None:
+                logger.info("create_drop: no tables to delete")
+                time.sleep(5)
+                continue
+            self.client.drop_table(self.get_table_path(str(n)))
+            with self.lock:
+                del self.tables[n]
+                self.deleted += 1
+                logger.debug(f"iteration {self.deleted}")
+        with self.lock:
+            logger.debug(f"exiting after {self.deleted} iterations")
+
+    def get_workload_thread_funcs(self):
+        return [self._create_tables_loop] * 3 + [self._delete_tables_loop] * 3
+
+
+class WorkloadInsertDelete(WorkloadBase):
+    def __init__(self, client, prefix, stop):
+        super().__init__(client, prefix, "insert_delete", stop)
+        self.inserted = 0
+        self.actual_rows = 0
+        self.table_name = "table"
+        self.lock = threading.Lock()
+
+    def get_stat(self):
+        with self.lock:
+            return f"Inserted: {self.inserted}, actual rows: {self.actual_rows}"
+
+    def _query_with_retries(self, query):
+        # retry undetermined
+        retry_settings = ydb.RetrySettings(idempotent=True)
+        return self.client.query(query, False, retry_settings)
+
+    def _loop(self):
+        logger.debug("starting")
+        table_path = self.get_table_path(self.table_name)
+        self.client.query(
+            f"""
+                CREATE TABLE `{table_path}` (
+                id Int64 NOT NULL,
+                i64Val Int64,
+                PRIMARY KEY(id)
+                )
+        """,
+            True,
+        )
+        i = 1
+        while not self.is_stop_requested():
+            logger.debug(f"iteration {i}")
+            self._query_with_retries(
+                f"""
+                    INSERT INTO `{table_path}` (`id`, `i64Val`)
+                    VALUES
+                    ({i * 2}, {i * 10}),
+                    ({i * 2 + 1}, {i * 10 + 1})
+                """,
+            )
+
+            self._query_with_retries(
+                f"""
+                    DELETE FROM `{table_path}`
+                    WHERE i64Val % 2 == 1
+                """,
+            )
+
+            actual = self._query_with_retries(
+                f"""
+                    SELECT COUNT(*) as cnt, SUM(i64Val) as vals, SUM(id) as ids FROM `{table_path}`
+                """,
+            )[0].rows[0]
+            expected = {"cnt": i, "vals": i * (i + 1) * 5, "ids": i * (i + 1)}
+            if actual != expected:
+                raise Exception(f"Incorrect result: expected:{expected}, actual:{actual}")
+            i += 1
+            with self.lock:
+                self.inserted += 2
+                self.actual_rows = actual["cnt"]
+        logger.debug(f"exiting after {i} iterations")
+
+    def get_workload_thread_funcs(self):
+        return [self._loop]
+
+
+class PilePromotionWorkload(WorkloadBase):
+    loop_cnt = 0
+    wait_for = 9
+
+    def __init__(self, client, grpc_endpoint, http_endpoint, prefix, stop):
+        super().__init__(client, prefix, "pile_promotion", stop)
+        self.ringGroupActorIdOffset = 1
+        self.http_endpoint = http_endpoint
+        self.lock = threading.Lock()
+        parsed = urlparse(grpc_endpoint)
+        host = parsed.hostname
+        port = parsed.port
+        self.bridge_client = BridgeClient(host, port)
+        self.bridge_client.set_auth_token("root@builtin")
+
+    def get_stat(self):
+        with self.lock:
+            return f"Pile promotions: {self.loop_cnt}"
+
+    def _loop(self):
+        logger.debug("starting")
+        while not self.is_stop_requested():
+            # Get current state
+            current_state = get_cluster_state(self.bridge_client)
+            logger.info(f"Current cluster state: {current_state}")
+            non_primary_pile = ""
+            for pile in current_state.pile_states:
+                if pile.state != PileState.PRIMARY:
+                    non_primary_pile = pile.pile_name
+                    break
+            logger.info(f"Non-primary pile: {non_primary_pile}")
+
+            # Promote non-primary pile
+            updates = [
+                PileState(pile_name=non_primary_pile, state=PileState.PROMOTED),
+            ]
+            update_cluster_state(self.bridge_client, updates)
+            logger.info(f"Promoted {non_primary_pile}")
+            time.sleep(self.wait_for)
+
+            # Verify the state change
+            new_state = get_cluster_state(self.bridge_client)
+            logger.info(f"Cluster state after the promotion: {new_state}")
+            for pile in new_state.pile_states:
+                if pile.pile_name == non_primary_pile:
+                    assert (
+                        pile.state == PileState.PRIMARY
+                    ), f"expected PRIMARY state of the {non_primary_pile}, but got: {pile.state}"
+
+            with self.lock:
+                logger.info(f"Pile promotion {self.loop_cnt} finished")
+                self.loop_cnt += 1
+                logger.debug(f"iteration {self.loop_cnt}")
+        with self.lock:
+            logger.debug(f"exiting after {self.loop_cnt} iterations")
+            self.bridge_client.close()
+
+    def get_workload_thread_funcs(self):
+        return [self._loop]
+
+
+class WorkloadDiscovery(WorkloadBase):
+
+    def __init__(self, client, grpc_endpoint, prefix, stop):
+        super().__init__(client, prefix, "discovery", stop)
+        self.grpc_endpoint = grpc_endpoint
+        self.lock = threading.Lock()
+        self.cnt = 0
+
+    def get_stat(self):
+        with self.lock:
+            return f"Discovery: {self.cnt}"
+
+    def _loop(self):
+        logger.debug("starting")
+        driver_config = ydb.DriverConfig(self.grpc_endpoint, self.client.database)
+        while not self.is_stop_requested():
+            time.sleep(3)
+            resolver = ydb.DiscoveryEndpointsResolver(driver_config)
+            result = resolver.resolve()
+            if result is None:
+                logger.info("Discovery empty")
+            else:
+                logger.info(f"Len = {len(result.endpoints)} Endpoints: {result.endpoints}")
+            with self.lock:
+                self.cnt += 1
+                logger.debug(f"iteration {self.cnt}")
+        with self.lock:
+            logger.debug(f"exiting after {self.cnt} iterations")
+
+    def get_workload_thread_funcs(self):
+        return [self._loop]
+
+
+class WorkloadRunner:
+    def __init__(self, grpc_endpoint, http_endpoint, database, path, duration):
+        self.client = YdbClient(grpc_endpoint, database, True)
+        self.client.wait_connection()
+        self.grpc_endpoint = grpc_endpoint
+        self.http_endpoint = http_endpoint
+        self.name = path
+        self.tables_prefix = "/".join([self.client.database, self.name])
+        self.duration = duration
+        ydb.interceptor.monkey_patch_event_handler()
+
+    def __enter__(self):
+        self._cleanup()
+        return self
+
+    def __exit__(self, exc_type, exc_value, traceback):
+        self._cleanup()
+
+    def _cleanup(self):
+        logger.info(f"Cleaning up {self.tables_prefix}...")
+        deleted = self.client.remove_recursively(self.tables_prefix)
+        logger.info(f"Cleaning up {self.tables_prefix}... done, {deleted} tables deleted")
+
+    def run(self):
+        stop = threading.Event()
+
+        promotionWorkload = PilePromotionWorkload(
+            self.client,
+            self.grpc_endpoint,
+            self.http_endpoint,
+            self.name,
+            stop,
+        )
+        workloads = [
+            WorkloadTablesCreateDrop(self.client, self.name, stop),
+            WorkloadInsertDelete(self.client, self.name, stop),
+            promotionWorkload,
+            WorkloadDiscovery(self.client, self.grpc_endpoint, self.name, stop),
+        ]
+        for w in workloads:
+            w.start()
+        started_at = time.time()
+        while time.time() - started_at < self.duration:
+            logger.info(f"Elapsed {(int)(time.time() - started_at)} seconds, stat:")
+            for w in workloads:
+                logger.info(f"\t{w.name}: {w.get_stat()}")
+            time.sleep(5)
+        stop.set()
+        logger.info("Waiting for stop...")
+        failed_to_stop = []
+        for w in workloads:
+            logger.debug(f"Waiting for {w.name} to stop...")
+            w.join(timeout=30)
+            if w.is_alive():
+                logger.error(f"Workload {w.name} failed to stop within 30 seconds!")
+                failed_to_stop.append(w.name)
+            else:
+                logger.debug(f"{w.name} stopped")
+
+        if failed_to_stop:
+            raise Exception(f"The following workloads failed to stop: {failed_to_stop}")
+        logger.info("Waiting for stop... stopped")
+        return promotionWorkload.loop_cnt

--- a/ydb/tests/stress/scheme_board/pile_promotion/workload/__init__.py
+++ b/ydb/tests/stress/scheme_board/pile_promotion/workload/__init__.py
@@ -1,9 +1,7 @@
 # -*- coding: utf-8 -*-
 import ydb
 import time
-import random
 import threading
-import requests
 import logging
 from enum import Enum
 from urllib.parse import urlparse
@@ -11,7 +9,6 @@ from urllib.parse import urlparse
 from ydb.public.api.protos.ydb_bridge_common_pb2 import PileState
 from ydb.public.api.protos.ydb_status_codes_pb2 import StatusIds
 from ydb.tests.library.clients.kikimr_bridge_client import BridgeClient
-from ydb.tests.oss.ydb_sdk_import import ydb
 from ydb.tests.stress.common.common import WorkloadBase
 from ydb.tests.stress.common.common import YdbClient
 import ydb.public.api.protos.draft.ydb_bridge_pb2 as bridge

--- a/ydb/tests/stress/scheme_board/pile_promotion/workload/ya.make
+++ b/ydb/tests/stress/scheme_board/pile_promotion/workload/ya.make
@@ -1,0 +1,16 @@
+PY3_LIBRARY()
+
+PY_SRCS(
+    __init__.py
+)
+
+PEERDIR(
+    contrib/python/requests
+    ydb/public/sdk/python
+    ydb/public/sdk/python/enable_v3_new_behavior
+    ydb/tests/library
+    ydb/tests/library/clients
+    ydb/tests/stress/common
+)
+
+END()

--- a/ydb/tests/stress/scheme_board/pile_promotion/ya.make
+++ b/ydb/tests/stress/scheme_board/pile_promotion/ya.make
@@ -1,0 +1,18 @@
+PY3_PROGRAM(pile_promotion_workload)
+
+PY_SRCS(
+    __main__.py
+)
+
+PEERDIR(
+    contrib/python/requests
+    contrib/python/PyHamcrest/py3
+    ydb/tests/stress/common
+    ydb/tests/stress/scheme_board/pile_promotion/workload
+)
+
+END()
+
+RECURSE_FOR_TESTS(
+    tests
+)

--- a/ydb/tests/stress/scheme_board/ya.make
+++ b/ydb/tests/stress/scheme_board/ya.make
@@ -1,0 +1,3 @@
+RECURSE(
+    pile_promotion
+)

--- a/ydb/tests/stress/ya.make
+++ b/ydb/tests/stress/ya.make
@@ -11,6 +11,7 @@ RECURSE(
     oltp_workload
     reconfig_state_storage_workload
     s3_backups
+    scheme_board
     show_create/view
     simple_queue
     statistics_workload


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

### Changelog category <!-- remove all except one -->

* Not for changelog (changelog entry is not required)

### Description for reviewers <!-- (optional) description for those who read this PR -->

Epic:
- https://github.com/ydb-platform/ydb/issues/19748

Issue:
- https://github.com/ydb-platform/ydb/issues/20646

The stress test and a fix in the TX proxy that make it stable enough.

#### TX proxy fix

TX proxy [resolves](https://github.com/ydb-platform/ydb/blob/c2d430629ddab8a78bc6d3f1640f7abf7c5532e9/ydb/core/tx/tx_proxy/schemereq.cpp#L503) working dir as follows:
1. /Root
2. /Root/db
3. /Root/db/dirA
4. /Root/db/dirA/dirB
5. /Root/db/dirA/dirB/parentDir

If the `parentDir` does not exist (which is valid), the SchemeCache resolution status for it will be "PathErrorUnknown". The code [attempts](https://github.com/ydb-platform/ydb/blob/c2d430629ddab8a78bc6d3f1640f7abf7c5532e9/ydb/core/tx/tx_proxy/schemereq.cpp#L1719) to take the grandparent (`dirB`) as the working dir in this case. However, resolution of the `dirB` might end in a LookupError and it needs to be retried:
```
node_11/logfile_lq886ruu.log:2025-08-26T14:48:20.874872Z :TX_PROXY_SCHEME_CACHE DEBUG: cache.cpp:266: Send result: self# [11:7542906179349556600:2350], recipient# [11:7542906179349556163:2348], result# { ErrorCount: 3 DatabaseName:  DomainOwnerId: 0 Instant: 0 ResultSet [{ Path: Root TableId: [18446744073709551615:18446744073709551615:0] RequestType: ByPath Operation: OpPath RedirectRequired: false ShowPrivatePath: false SyncVersion: true Status: LookupError Kind: KindUnknown DomainInfo <null> },{ Path: Root/test TableId: [18446744073709551615:18446744073709551615:0] RequestType: ByPath Operation: OpPath RedirectRequired: false ShowPrivatePath: false SyncVersion: true Status: LookupError Kind: KindUnknown DomainInfo <null> },{ Path: Root/test/create_drop TableId: [18446744073709551615:18446744073709551615:0] RequestType: ByPath Operation: OpPath RedirectRequired: false ShowPrivatePath: false SyncVersion: true Status: PathErrorUnknown Kind: KindUnknown DomainInfo <null> }] }
```

The current PR adds retries on LookupErrors of ancestors of the working dir to handle the issue.

