### PR TITLE
Move ConstFolding to kqphost optimization pipeline

### DIFF
--- a/ydb/core/kqp/host/kqp_host.cpp
+++ b/ydb/core/kqp/host/kqp_host.cpp
@@ -5,6 +5,7 @@
 #include <ydb/core/external_sources/external_source_factory.h>
 #include <ydb/core/kqp/common/kqp.h>
 #include <ydb/core/kqp/common/kqp_yql.h>
+#include <ydb/core/kqp/opt/kqp_constant_folding_transformer.h>
 #include <ydb/core/kqp/opt/kqp_query_plan.h>
 #include <ydb/core/kqp/provider/yql_kikimr_provider_impl.h>
 
@@ -1994,6 +1995,7 @@ private:
             .AddTypeAnnotation()
             .Add(TCollectParametersTransformer::Sync(SessionCtx->QueryPtr()), "CollectParameters")
             .AddPostTypeAnnotation()
+            .Add(CreateKqpConstantFoldingTransformer(*TypesCtx, Config),"ConstFolding")
             .AddOptimization(true, false)
             .Add(GetDqIntegrationPeepholeTransformer(true, TypesCtx), "DqIntegrationPeephole")
             .Add(TLogExprTransformer::Sync("Optimized expr"), "LogExpr")

--- a/ydb/core/kqp/host/kqp_runner.cpp
+++ b/ydb/core/kqp/host/kqp_runner.cpp
@@ -316,7 +316,7 @@ private:
             .Add(NOpt::CreateKqpCheckQueryTransformer(), "CheckKqlQuery")
             .AddPostTypeAnnotation(/* forSubgraph */ true)
             .AddCommonOptimization()
-            // .Add(CreateKqpConstantFoldingTransformer(*typesCtx, Config), "ConstantFolding")
+            .Add(CreateKqpConstantFoldingTransformer(*typesCtx, Config), "ConstantFolding")
             .Add(CreateKqpColumnStatisticsRequester(Config, *typesCtx, SessionCtx->Tables(), Cluster, ActorSystem), "ColumnStatisticsRequester")
             .Add(CreateKqpStatisticsTransformer(OptimizeCtx, *typesCtx, Config, Pctx), "Statistics")
             .Add(CreateKqpLogOptTransformer(OptimizeCtx, *typesCtx, Config), "LogicalOptimize")

--- a/ydb/core/kqp/host/kqp_runner.cpp
+++ b/ydb/core/kqp/host/kqp_runner.cpp
@@ -316,7 +316,7 @@ private:
             .Add(NOpt::CreateKqpCheckQueryTransformer(), "CheckKqlQuery")
             .AddPostTypeAnnotation(/* forSubgraph */ true)
             .AddCommonOptimization()
-            .Add(CreateKqpConstantFoldingTransformer(OptimizeCtx, *typesCtx, Config), "ConstantFolding")
+            // .Add(CreateKqpConstantFoldingTransformer(*typesCtx, Config), "ConstantFolding")
             .Add(CreateKqpColumnStatisticsRequester(Config, *typesCtx, SessionCtx->Tables(), Cluster, ActorSystem), "ColumnStatisticsRequester")
             .Add(CreateKqpStatisticsTransformer(OptimizeCtx, *typesCtx, Config, Pctx), "Statistics")
             .Add(CreateKqpLogOptTransformer(OptimizeCtx, *typesCtx, Config), "LogicalOptimize")

--- a/ydb/core/kqp/opt/kqp_constant_folding_transformer.cpp
+++ b/ydb/core/kqp/opt/kqp_constant_folding_transformer.cpp
@@ -116,7 +116,6 @@ IGraphTransformer::TStatus TKqpConstantFoldingTransformer::DoTransform(TExprNode
 
     if (replaces.empty()) {
         return IGraphTransformer::TStatus::Ok;
-        ;
     } else {
         TOptimizeExprSettings settings(&TypeCtx);
         settings.VisitTuples = false;
@@ -133,7 +132,7 @@ IGraphTransformer::TStatus TKqpConstantFoldingTransformer::DoTransform(TExprNode
 void TKqpConstantFoldingTransformer::Rewind() {
 }
 
-TAutoPtr<IGraphTransformer> NKikimr::NKqp::CreateKqpConstantFoldingTransformer(const TIntrusivePtr<TKqpOptimizeContext>& kqpCtx,
-    TTypeAnnotationContext& typeCtx, const TKikimrConfiguration::TPtr& config) {
-    return THolder<IGraphTransformer>(new TKqpConstantFoldingTransformer(kqpCtx, typeCtx, config));
+TAutoPtr<IGraphTransformer> NKikimr::NKqp::CreateKqpConstantFoldingTransformer(TTypeAnnotationContext& typeCtx,
+                                                                               const TKikimrConfiguration::TPtr& config) {
+    return THolder<IGraphTransformer>(new TKqpConstantFoldingTransformer(typeCtx, config));
 }

--- a/ydb/core/kqp/opt/kqp_constant_folding_transformer.h
+++ b/ydb/core/kqp/opt/kqp_constant_folding_transformer.h
@@ -23,11 +23,11 @@ using namespace NOpt;
 */
 class TKqpConstantFoldingTransformer : public TSyncTransformerBase {
     public:
-        TKqpConstantFoldingTransformer(const TIntrusivePtr<TKqpOptimizeContext>& kqpCtx, TTypeAnnotationContext& typeCtx,
-            const TKikimrConfiguration::TPtr& config) : 
+        TKqpConstantFoldingTransformer(TTypeAnnotationContext& typeCtx,
+                                       const TKikimrConfiguration::TPtr& config) :
             Config(config),
-            TypeCtx(typeCtx),
-            KqpCtx(*kqpCtx) {}
+            TypeCtx(typeCtx)
+        {}
 
         // Main method of the transformer
         IGraphTransformer::TStatus DoTransform(TExprNode::TPtr input, TExprNode::TPtr& output, TExprContext& ctx) final;
@@ -36,10 +36,9 @@ class TKqpConstantFoldingTransformer : public TSyncTransformerBase {
     private:
         const TKikimrConfiguration::TPtr& Config;
         TTypeAnnotationContext& TypeCtx;
-        const TKqpOptimizeContext& KqpCtx;
 };
 
-TAutoPtr<IGraphTransformer> CreateKqpConstantFoldingTransformer(const TIntrusivePtr<TKqpOptimizeContext>& kqpCtx, TTypeAnnotationContext& typeCtx, const TKikimrConfiguration::TPtr& config);
+TAutoPtr<IGraphTransformer> CreateKqpConstantFoldingTransformer(TTypeAnnotationContext& typeCtx, const TKikimrConfiguration::TPtr& config);
 
 }
 }


### PR DESCRIPTION
### Changelog category <!-- remove all except one -->

* Not for changelog (changelog entry is not required)

### Description for reviewers <!-- (optional) description for those who read this PR -->

Move Const Folding transformer to a kqphost optimization it allows to use folded expressions in the earlier stages