### PR TITLE
Batch of operations

### DIFF
--- a/ydb/core/persqueue/ut/partition_ut.cpp
+++ b/ydb/core/persqueue/ut/partition_ut.cpp
@@ -2230,16 +2230,19 @@ Y_UNIT_TEST_F(CorrectRange_Multiple_Transactions, TPartitionFixture)
 
     SendCommitTx(step, txId_1);
 
+    WaitCmdWrite({.Count=1, .PlanStep=step, .TxId=txId_1, .UserInfos={{1, {.Session=session, .Offset=1}}}});
+    SendCmdWriteResponse(NMsgBusProxy::MSTATUS_OK);
+
+    WaitCommitTxDone({.TxId=txId_1, .Partition=TPartitionId(partition)});
+
     WaitCalcPredicateResult({.Step=step, .TxId=txId_2, .Partition=TPartitionId(partition), .Predicate=false});
     SendRollbackTx(step, txId_2);
 
     WaitCalcPredicateResult({.Step=step, .TxId=txId_3, .Partition=TPartitionId(partition), .Predicate=false});
     SendRollbackTx(step, txId_3);
 
-    WaitCmdWrite({.Count=3, .PlanStep=step, .TxId=txId_3, .UserInfos={{1, {.Session=session, .Offset=1}}}});
+    WaitCmdWrite({.Count=1, .PlanStep=step, .TxId=txId_3, .UserInfos={{1, {.Session=session, .Offset=1}}}});
     SendCmdWriteResponse(NMsgBusProxy::MSTATUS_OK);
-
-    WaitCommitTxDone({.TxId=txId_1, .Partition=TPartitionId(partition)});
 }
 
 Y_UNIT_TEST_F(CorrectRange_Multiple_Consumers, TPartitionFixture)
@@ -2344,6 +2347,9 @@ Y_UNIT_TEST_F(CorrectRange_Rollback, TPartitionFixture)
 
     SendCalcPredicate(step, txId_2, client, 0, 5);
     SendRollbackTx(step, txId_1);
+
+    WaitCmdWrite({.Count=1, .PlanStep=step, .TxId=txId_1, .UserInfos={{1, {.Consumer="client", .Session="session", .Offset=0}}}});
+    SendCmdWriteResponse(NMsgBusProxy::MSTATUS_OK);
 
     WaitCalcPredicateResult({.Step=step, .TxId=txId_2, .Partition=TPartitionId(partition), .Predicate=true});
 }
@@ -2902,27 +2908,31 @@ Y_UNIT_TEST_F(ConflictingActsInSeveralBatches, TPartitionTxTestHelper) {
 
     SendTxCommit(tx1);
     SendTxRollback(tx2);
-    ExpectNoKvRequest();
+    WaitKvRequest();
+    SendKvResponse();
 
     WaitTxPredicateReply(tx3);
     WaitBatchCompletion(1);
     SendTxCommit(tx3);
 
     //2 Normal writes with src1 & src4
-    WaitBatchCompletion(6 + 2); // Normal writes produce 1 act for each message
     ExpectNoTxPredicateReply();
     WaitKvRequest();
     SendKvResponse();
     WaitCommitDone(tx1);
     WaitCommitDone(tx3);
     WaitTxPredicateReply(tx5);
-    WaitBatchCompletion(1);
+    WaitBatchCompletion(6 + 2); // Normal writes produce 1 act for each message
     SendTxCommit(tx5);
-    WaitBatchCompletion(1 + 6); //Normal write & immTx for src4;
+    WaitBatchCompletion(1);
 
     WaitKvRequest();
     SendKvResponse();
     WaitCommitDone(tx5);
+
+    WaitBatchCompletion(1 + 6); //Normal write & immTx for src4;
+    WaitKvRequest();
+    SendKvResponse();
     WaitImmediateTxComplete(immTx1, true);
 }
 
@@ -2972,7 +2982,6 @@ Y_UNIT_TEST_F(ConflictingTxProceedAfterRollback, TPartitionTxTestHelper) {
     WaitBatchCompletion(1);
 
     SendTxRollback(tx1);
-    ExpectNoKvRequest();
 
     WaitTxPredicateReply(tx2);
     WaitBatchCompletion(2);
@@ -3002,26 +3011,27 @@ Y_UNIT_TEST_F(ConflictingSrcIdForTxInDifferentBatches, TPartitionTxTestHelper) {
     Cerr << "Wait batch of 1 completion\n";
     SendTxCommit(tx1);
     WaitBatchCompletion(1);
-    Cerr << "Expect no KV request\n";
-    ExpectNoKvRequest();
+    Cerr << "Expect KV request\n";
+    WaitKvRequest();
+    SendKvResponse();
     WaitTxPredicateReply(tx2);
     SendTxCommit(tx2);
 
-    Cerr << "Waif or tx 3 predicate failure\n";
+    Cerr << "Wait for tx 3 predicate failure\n";
     WaitTxPredicateFailure(tx3);
-    Cerr << "Waif or tx 4 predicate failure\n";
+    Cerr << "Wait for tx 4 predicate failure\n";
     WaitTxPredicateFailure(tx4);
 
 
     Cerr << "Wait batch of 3 completion\n";
     WaitBatchCompletion(1); // Immediate Tx 2 - 4.
-    Cerr << "Expect no KV request\n";
-    ExpectNoKvRequest();
+    Cerr << "Expect KV request\n";
+    WaitKvRequest();
+    SendKvResponse();
     SendTxRollback(tx3);
     SendTxRollback(tx4);
     WaitBatchCompletion(2); // Immediate Tx 2 - 4.
 
-    ExpectNoCommitDone();
     WaitKvRequest();
     SendKvResponse();
     Cerr << "Wait for commits\n";
@@ -3049,16 +3059,18 @@ Y_UNIT_TEST_F(ConflictingSrcIdTxAndWritesDifferentBatches, TPartitionTxTestHelpe
     SendTxCommit(tx1);
     WaitBatchCompletion(1);
 
-    ExpectNoKvRequest();
+    WaitKvRequest();
+    SendKvResponse();
+
+    WaitCommitDone(tx1);
+
     WaitTxPredicateFailure(tx2);
     WaitTxPredicateReply(tx3);
     SendTxRollback(tx2);
     SendTxCommit(tx3);
     WaitBatchCompletion(2); // Tx 2 & 3.
-    ExpectNoCommitDone();
     WaitKvRequest();
     SendKvResponse();
-    WaitCommitDone(tx1);
     WaitCommitDone(tx3);
     WaitBatchCompletion(3);
     WaitKvRequest();
@@ -3208,9 +3220,10 @@ Y_UNIT_TEST_F(DifferentWriteTxBatchingOptions, TPartitionTxTestHelper) {
     WaitBatchCompletion(1+1);
     ExpectNoKvRequest();
     SendTxCommit(tx);
-    WaitBatchCompletion(1);
     EmulateKVTablet();
     WaitCommitDone(tx);
+    WaitBatchCompletion(1);
+    EmulateKVTablet();
     }
     {
     // 5. WriteTx -> ImmTx = 2 batches
@@ -3224,13 +3237,13 @@ Y_UNIT_TEST_F(DifferentWriteTxBatchingOptions, TPartitionTxTestHelper) {
     WaitBatchCompletion(1+1);
     WaitTxPredicateReply(tx);
     SendTxCommit(tx);
-    WaitBatchCompletion(1);
     ExpectNoCommitDone();
     EmulateKVTablet();
+    WaitBatchCompletion(1);
     WaitCommitDone(tx);
+    EmulateKVTablet();
     WaitImmediateTxComplete(immTx, true);
     }
-
 }
 Y_UNIT_TEST_F(FailedTxsDontBlock, TPartitionTxTestHelper) {
     Init({.WriterSessions={"src1", "src2"}, .EndOffset = 1});
@@ -3325,16 +3338,16 @@ Y_UNIT_TEST_F(ConflictingCommitsInSeveralBatches, TPartitionTxTestHelper) {
     //Just block processing so every message arrives before batching starts
     auto txTmp = MakeAndSendWriteTx({});
 
-    MakeAndSendNormalOffsetCommit(1, 2);
+    MakeAndSendNormalOffsetCommit(1, 2); // act-1
     auto tx1 = MakeAndSendTxOffsetCommit(1, 2, 5);
     auto tx2 = MakeAndSendTxOffsetCommit(1, 5, 10);
-    MakeAndSendNormalOffsetCommit(1, 20);
+    MakeAndSendNormalOffsetCommit(1, 20); // act-2
     ResetBatchCompletion();
 
     WaitWriteInfoRequest(txTmp, true);
     WaitTxPredicateReply(txTmp);
 
-    WaitBatchCompletion(2);
+    WaitBatchCompletion(2); // txTmp + act-1
     SendTxRollback(txTmp);
 
     ExpectNoTxPredicateReply();
@@ -3342,22 +3355,22 @@ Y_UNIT_TEST_F(ConflictingCommitsInSeveralBatches, TPartitionTxTestHelper) {
     SendKvResponse();
 
     WaitTxPredicateReply(tx1);
-    WaitBatchCompletion(1);
+    WaitBatchCompletion(1); // tx1
     ExpectNoTxPredicateReply();
     SendTxCommit(tx1);
-    ExpectNoKvRequest();
 
     WaitTxPredicateReply(tx2);
-    WaitBatchCompletion(1);
     SendTxCommit(tx2);
-    WaitBatchCompletion(1);
+    WaitBatchCompletion(1); // tx2
 
     WaitKvRequest();
     SendKvResponse();
     WaitCommitDone(tx1);
     WaitCommitDone(tx2);
 
-
+    WaitBatchCompletion(1); // act-2
+    WaitKvRequest();
+    SendKvResponse();
 
     txTmp = MakeAndSendWriteTx({});
     auto immTx1 = MakeAndSendImmediateTxOffsetCommit(2, 0, 5);
@@ -3366,7 +3379,7 @@ Y_UNIT_TEST_F(ConflictingCommitsInSeveralBatches, TPartitionTxTestHelper) {
     WaitTxPredicateReply(txTmp);
     SendTxRollback(txTmp);
 
-    WaitBatchCompletion(2 + 1);
+    WaitBatchCompletion(3);
     WaitKvRequest();
     SendKvResponse();
     WaitImmediateTxComplete(immTx1, true);
@@ -3454,7 +3467,8 @@ Y_UNIT_TEST_F(ConflictingCommitProccesAfterRollback, TPartitionTxTestHelper) {
     WaitBatchCompletion(1);
 
     SendTxRollback(tx1);
-    ExpectNoKvRequest();
+    WaitKvRequest();
+    SendKvResponse();
 
     WaitTxPredicateReply(tx2);
     WaitBatchCompletion(1);
@@ -3629,19 +3643,27 @@ Y_UNIT_TEST_F(TEvTxCalcPredicate_Without_Conflicts, TPartitionTxTestHelper)
 {
     Init();
 
-    auto tx1 = MakeAndSendWriteTx({{"sourceid", {1, 3}}});
+    auto tx1 = MakeAndSendWriteTx({{"sourceid-1", {1, 3}}});
 
     WaitWriteInfoRequest(tx1);
     SendWriteInfoResponse(tx1);
 
     WaitTxPredicateReply(tx1);
 
-    auto tx2 = MakeAndSendWriteTx({{"another-sourceid", {1, 3}}});
+    SendTxCommit(tx1);
+    EmulateKVTablet();
+
+    auto tx2 = MakeAndSendWriteTx({{"sourceid-2", {1, 3}}});
+    auto tx3 = MakeAndSendWriteTx({{"sourceid-3", {1, 3}}});
 
     WaitWriteInfoRequest(tx2);
+    WaitWriteInfoRequest(tx3);
+
+    SendWriteInfoResponse(tx3);
     SendWriteInfoResponse(tx2);
 
     WaitTxPredicateReply(tx2);
+    WaitTxPredicateReply(tx3);
 }
 
 Y_UNIT_TEST_F(TEvTxCalcPredicate_With_Conflicts, TPartitionTxTestHelper)


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

The program can add transactions to the batch until it reaches the request size in KV.
As a result, transactions may be delayed. They will wait for predicates and commits.

### Changelog category <!-- remove all except one -->

* Performance improvement

### Description for reviewers <!-- (optional) description for those who read this PR -->

...
