### PR TITLE
Add TMessage::GetBrokenData method

### DIFF
--- a/ydb/public/sdk/cpp/include/ydb-cpp-sdk/client/topic/read_events.h
+++ b/ydb/public/sdk/cpp/include/ydb-cpp-sdk/client/topic/read_events.h
@@ -102,6 +102,7 @@ struct TReadSessionEvent {
             virtual ~TMessageBase() = default;
 
             virtual const std::string& GetData() const;
+            virtual const std::string& GetBrokenData() const;
 
             virtual void Commit() = 0;
 
@@ -144,6 +145,8 @@ struct TReadSessionEvent {
             //! User data.
             //! Throws decompressor exception if decompression failed.
             const std::string& GetData() const override;
+            //! Throws exception if decompression succeeded.
+            const std::string& GetBrokenData() const override;
 
             //! Commits single message.
             void Commit() override;

--- a/ydb/public/sdk/cpp/src/client/topic/impl/read_session_event.cpp
+++ b/ydb/public/sdk/cpp/src/client/topic/impl/read_session_event.cpp
@@ -88,6 +88,10 @@ const std::string& TMessageBase::GetData() const {
     return Data;
 }
 
+const std::string& TMessageBase::GetBrokenData() const {
+    return Data;
+}
+
 uint64_t TMessageBase::GetOffset() const {
     return Information.Offset;
 }
@@ -173,6 +177,13 @@ const std::string& TMessage::GetData() const {
         std::rethrow_exception(DecompressionException);
     }
     return TMessageBase::GetData();
+}
+
+const std::string& TMessage::GetBrokenData() const {
+    if (DecompressionException) {
+        return TMessageBase::GetData();
+    }
+    ythrow yexception() << "Can not get broken data after succesful decompression";
 }
 
 bool TMessage::HasException() const {

--- a/ydb/public/sdk/cpp/src/client/topic/impl/read_session_event.cpp
+++ b/ydb/public/sdk/cpp/src/client/topic/impl/read_session_event.cpp
@@ -183,7 +183,7 @@ const std::string& TMessage::GetBrokenData() const {
     if (DecompressionException) {
         return TMessageBase::GetData();
     }
-    ythrow yexception() << "Can not get broken data after succesful decompression";
+    ythrow yexception() << "Can not get broken data after successful decompression";
 }
 
 bool TMessage::HasException() const {

--- a/ydb/public/sdk/cpp/src/client/topic/impl/read_session_impl.ipp
+++ b/ydb/public/sdk/cpp/src/client/topic/impl/read_session_impl.ipp
@@ -1361,7 +1361,6 @@ inline void TSingleClusterReadSessionImpl<false>::StopPartitionSessionImpl(
 
     if (graceful) {
         auto committedOffset = partitionStream->GetMaxCommittedOffset();
-        LOG_LAZY(Log, TLOG_DEBUG, GetLogPrefix() << "XXXXX PushEvent 1422 TStopPartitionSessionEvent");
         pushRes = EventsQueue->PushEvent(
             partitionStream,
             // TODO(qyryq) Is it safe to use GetMaxCommittedOffset here instead of StopPartitionSessionRequest.commmitted_offset?
@@ -1374,7 +1373,6 @@ inline void TSingleClusterReadSessionImpl<false>::StopPartitionSessionImpl(
         released.set_partition_session_id(partitionStream->GetAssignId());
         WriteToProcessorImpl(std::move(req));
         PartitionStreams.erase(partitionSessionId);
-        LOG_LAZY(Log, TLOG_DEBUG, GetLogPrefix() << "XXXXX PushEvent 1435 TPartitionSessionClosedEvent");
         pushRes = EventsQueue->PushEvent(
             partitionStream,
             TReadSessionEvent::TPartitionSessionClosedEvent(partitionStream, TReadSessionEvent::TPartitionSessionClosedEvent::EReason::Lost),

--- a/ydb/public/sdk/cpp/src/client/topic/impl/read_session_impl.ipp
+++ b/ydb/public/sdk/cpp/src/client/topic/impl/read_session_impl.ipp
@@ -3040,8 +3040,6 @@ void TDataDecompressionInfo<UseMigrationProtocol>::TDecompressionTask::operator(
             minOffset = Min(minOffset, static_cast<i64>(data.offset()));
             maxOffset = Max(maxOffset, static_cast<i64>(data.offset()));
 
-            DecompressedSize += data.data().size();
-
             try {
                 if constexpr (UseMigrationProtocol) {
                     if (parent->DoDecompress
@@ -3070,6 +3068,8 @@ void TDataDecompressionInfo<UseMigrationProtocol>::TDecompressionTask::operator(
                     session->GetLog() << TLOG_INFO << "Error decompressing data: " << CurrentExceptionMessage();
                 }
             }
+
+            DecompressedSize += data.data().size();
         }
     }
 

--- a/ydb/public/sdk/cpp/src/client/topic/impl/read_session_impl.ipp
+++ b/ydb/public/sdk/cpp/src/client/topic/impl/read_session_impl.ipp
@@ -3042,6 +3042,8 @@ void TDataDecompressionInfo<UseMigrationProtocol>::TDecompressionTask::operator(
             minOffset = Min(minOffset, static_cast<i64>(data.offset()));
             maxOffset = Max(maxOffset, static_cast<i64>(data.offset()));
 
+            DecompressedSize += data.data().size();
+
             try {
                 if constexpr (UseMigrationProtocol) {
                     if (parent->DoDecompress
@@ -3063,11 +3065,8 @@ void TDataDecompressionInfo<UseMigrationProtocol>::TDecompressionTask::operator(
                         data.set_data(TStringType{decompressed});
                     }
                 }
-
-                DecompressedSize += data.data().size();
             } catch (...) {
                 parent->PutDecompressionError(std::current_exception(), messages.Batch, i);
-                data.clear_data(); // Free memory, because we don't count it.
 
                 if (auto session = parent->CbContext->LockShared()) {
                     session->GetLog() << TLOG_INFO << "Error decompressing data: " << CurrentExceptionMessage();

--- a/ydb/public/sdk/cpp/tests/integration/topic/basic_usage.cpp
+++ b/ydb/public/sdk/cpp/tests/integration/topic/basic_usage.cpp
@@ -747,6 +747,113 @@ TEST_F(BasicUsage, TEST_NAME(TWriteSession_WriteEncoded)) {
     }
 }
 
+TEST_F(BasicUsage, TEST_NAME(TWriteSession_WriteEncoded_Broken)) {
+    // Write a broken compressed message.
+    // GetData should throw an exception.
+    // GetBrokenData should return the broken data.
+
+    // Write a correct compressed message.
+    // GetData should return the correct data.
+    // GetBrokenData should throw an exception.
+
+    auto driver = MakeDriver();
+
+    TTopicClient client(driver);
+
+    auto settings = TWriteSessionSettings()
+        .Path(GetTopicPath())
+        .MessageGroupId(TEST_MESSAGE_GROUP_ID);
+
+    auto writer = client.CreateWriteSession(settings);
+    std::string brokenPacked = "some broken data";
+
+    {
+        auto event = *writer->GetEvent(true);
+        ASSERT_TRUE(std::holds_alternative<TWriteSessionEvent::TReadyToAcceptEvent>(event));
+        writer->WriteEncoded(
+            std::move(std::get<TWriteSessionEvent::TReadyToAcceptEvent>(event).ContinuationToken),
+            TWriteMessage::CompressedMessage(brokenPacked, ECodec::GZIP, 100)
+        );
+    }
+
+    std::string correctMessage = "message";
+    TString packed;
+    {
+        TStringOutput so(packed);
+        TZLibCompress oss(&so, ZLib::GZip, 6);
+        oss << correctMessage;
+    }
+    {
+        auto event = *writer->GetEvent(true);
+        ASSERT_TRUE(std::holds_alternative<TWriteSessionEvent::TReadyToAcceptEvent>(event));
+        writer->WriteEncoded(
+            std::move(std::get<TWriteSessionEvent::TReadyToAcceptEvent>(event).ContinuationToken),
+            TWriteMessage::CompressedMessage(packed, ECodec::GZIP, correctMessage.size())
+        );
+    }
+
+    std::uint32_t acks = 0;
+    while (acks < 2)  {
+        auto event = *writer->GetEvent(true);
+        if (auto e = std::get_if<TWriteSessionEvent::TAcksEvent>(&event)) {
+            acks += e->Acks.size();
+        } else {
+            continue;
+        }
+    }
+
+    ASSERT_EQ(acks, 2u);
+
+    auto readSettings = TReadSessionSettings()
+        .ConsumerName(GetConsumerName())
+        .AppendTopics(GetTopicPath())
+        // .DirectRead(EnableDirectRead)
+        ;
+    std::shared_ptr<IReadSession> readSession = client.CreateReadSession(readSettings);
+    std::uint32_t readMessageCount = 0;
+    while (readMessageCount < 2) {
+        std::cerr << "Get event on client\n";
+        auto event = *readSession->GetEvent(true);
+        std::visit(TOverloaded {
+            [&](TReadSessionEvent::TDataReceivedEvent& event) {
+                for (auto& message: event.GetMessages()) {
+                    if (readMessageCount == 0) {
+                        ASSERT_THROW(message.GetData(), std::exception);
+                        std::string data = message.GetBrokenData();
+                        ASSERT_TRUE(brokenPacked == data);
+                    } else {
+                        ASSERT_THROW(message.GetBrokenData(), std::exception);
+                        std::string data = message.GetData();
+                        ASSERT_TRUE(correctMessage == data);
+                    }
+                    ++readMessageCount;
+                }
+            },
+            [&](TReadSessionEvent::TCommitOffsetAcknowledgementEvent&) {
+                FAIL();
+            },
+            [&](TReadSessionEvent::TStartPartitionSessionEvent& event) {
+                event.Confirm();
+            },
+            [&](TReadSessionEvent::TStopPartitionSessionEvent& event) {
+                event.Confirm();
+            },
+            [&](TReadSessionEvent::TEndPartitionSessionEvent& event) {
+                event.Confirm();
+            },
+            [&](TReadSessionEvent::TPartitionSessionStatusEvent&) {
+                FAIL() << "Test does not support lock sessions yet";
+            },
+            [&](TReadSessionEvent::TPartitionSessionClosedEvent&) {
+                FAIL() << "Test does not support lock sessions yet";
+            },
+            [&](TSessionClosedEvent&) {
+                FAIL() << "Session closed";
+            }
+        }, event);
+    }
+}
+
 namespace {
     enum class EExpectedTestResult {
         SUCCESS,


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

Topic SDK: Add TDataReceivedEvent::TMessage::GetBrokenData method to retrieve original data that caused an error on decompression

### Changelog category <!-- remove all except one -->

* New feature

### Description for reviewers <!-- (optional) description for those who read this PR -->

LOGBROKER-9807