### PR TITLE
Fix DS proxy batching problem

### DIFF
--- a/ydb/core/blobstorage/dsproxy/dsproxy_impl.h
+++ b/ydb/core/blobstorage/dsproxy/dsproxy_impl.h
@@ -99,6 +99,7 @@ class TBlobStorageGroupProxy : public TActorBootstrapped<TBlobStorageGroupProxy>
     TBatchedPutQueue BatchedPuts[PutHandleClassCount][PutTacticCount];
     static constexpr ui64 PutBatchecBucketCount = PutHandleClassCount * PutTacticCount;
     TStackVec<TPutBatchedBucket, PutBatchecBucketCount> PutBatchedBucketQueue;
+    THashSet<TLogoBlobID> BatchedPutIds;
 
     TEvStopBatchingGetRequests::TPtr StopGetBatchingEvent;
     ui64 BatchedGetRequestCount = 0;

--- a/ydb/core/blobstorage/dsproxy/dsproxy_request.cpp
+++ b/ydb/core/blobstorage/dsproxy/dsproxy_request.cpp
@@ -202,8 +202,8 @@ namespace NKikimr {
 
         TInstant now = TActivationContext::Now();
 
-        if (Controls.EnablePutBatching.Update(now) && partSize < MinHugeBlobInBytes &&
-                partSize <= MaxBatchedPutSize) {
+        if (Controls.EnablePutBatching.Update(now) && partSize < MinHugeBlobInBytes && partSize <= MaxBatchedPutSize &&
+                BatchedPutIds.contains(ev->Get()->Id)) {
             NKikimrBlobStorage::EPutHandleClass handleClass = ev->Get()->HandleClass;
             TEvBlobStorage::TEvPut::ETactic tactic = ev->Get()->Tactic;
             Y_ABORT_UNLESS((ui64)handleClass <= PutHandleClassCount);
@@ -220,6 +220,7 @@ namespace NKikimr {
                 ProcessBatchedPutRequests(batchedPuts, handleClass, tactic);
             }
 
+            BatchedPutIds.insert(ev->Get()->Id);
             batchedPuts.Queue.push_back(ev.Release());
             batchedPuts.Bytes += partSize;
         } else {
@@ -552,6 +553,11 @@ namespace NKikimr {
     void TBlobStorageGroupProxy::ProcessBatchedPutRequests(TBatchedPutQueue &batchedPuts,
             NKikimrBlobStorage::EPutHandleClass handleClass, TEvBlobStorage::TEvPut::ETactic tactic) {
         TMaybe<TGroupStat::EKind> kind = PutHandleClassToGroupStatKind(handleClass);
+
+        for (auto& ev : batchedPuts.Queue) {
+            const size_t n = BatchedPutIds.erase(ev->Get()->Id);
+            Y_ABORT_UNLESS(n == 1);
+        }
 
         if (Info) {
             if (CurrentStateFunc() == &TThis::StateWork) {


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

Fix DS proxy batching problem

### Changelog category <!-- remove all except one -->

* Bugfix 

### Description for reviewers <!-- (optional) description for those who read this PR -->

During operation of Bridge mode proxy races can occur on configuration switch leading to multiple puts sent in near time points, being batched together and leading DS proxy to assertion failure. This patch prevents batching puts with repeating blob ids in the same batch.

This fixes #23430
