### PR TITLE
Fix DS proxy batching problem

### DIFF
--- a/ydb/core/blobstorage/dsproxy/dsproxy_impl.h
+++ b/ydb/core/blobstorage/dsproxy/dsproxy_impl.h
@@ -99,6 +99,7 @@ class TBlobStorageGroupProxy : public TActorBootstrapped<TBlobStorageGroupProxy>
     TBatchedPutQueue BatchedPuts[PutHandleClassCount][PutTacticCount];
     static constexpr ui64 PutBatchecBucketCount = PutHandleClassCount * PutTacticCount;
     TStackVec<TPutBatchedBucket, PutBatchecBucketCount> PutBatchedBucketQueue;
+    THashSet<TLogoBlobID> BatchedPutIds;
 
     TEvStopBatchingGetRequests::TPtr StopGetBatchingEvent;
     ui64 BatchedGetRequestCount = 0;


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

Fix DS proxy batching problem

### Changelog category <!-- remove all except one -->

* Bugfix 

### Description for reviewers <!-- (optional) description for those who read this PR -->

During operation of Bridge mode proxy races can occur on configuration switch leading to multiple puts sent in near time points, being batched together and leading DS proxy to assertion failure. This patch prevents batching puts with repeating blob ids in the same batch.

This fixes #23430
