### PR TITLE
stable-25-3: MKQL_RUNTIME_VERSION=59U

### DIFF
--- a/yql/essentials/minikql/mkql_runtime_version.h
+++ b/yql/essentials/minikql/mkql_runtime_version.h
@@ -24,7 +24,7 @@ namespace NMiniKQL {
 // 1. Bump this version every time incompatible runtime nodes are introduced.
 // 2. Make sure you provide runtime node generation for previous runtime versions.
 #ifndef MKQL_RUNTIME_VERSION
-#define MKQL_RUNTIME_VERSION 67U
+#define MKQL_RUNTIME_VERSION 59U
 #endif
 
 // History:


### PR DESCRIPTION
Compat with 25-2

See https://github.com/ydb-platform/ydb/blob/prestable-25-2/yql/essentials/minikql/mkql_runtime_version.h#L27