### PR TITLE
allow network access for the kafka stress test since it loads some resources from the storage.yandexcloud.net

### DIFF
--- a/ydb/tests/stress/kafka/tests/ya.make
+++ b/ydb/tests/stress/kafka/tests/ya.make
@@ -26,5 +26,6 @@ PEERDIR(
     ydb/public/sdk/python/enable_v3_new_behavior
 )
 
+REQUIREMENTS(network:full)
 
 END()


### PR DESCRIPTION


### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

...

### Changelog category <!-- remove all except one -->


* Not for changelog (changelog entry is not required)

### Description for reviewers <!-- (optional) description for those who read this PR -->

...
