### PR TITLE
fix: up olap workload test ram

### DIFF
--- a/ydb/tests/stress/olap_workload/tests/ya.make
+++ b/ydb/tests/stress/olap_workload/tests/ya.make
@@ -7,7 +7,7 @@ TEST_SRCS(
     test_workload.py
 )
 
-REQUIREMENTS(ram:32)
+REQUIREMENTS(ram:48)
 
 SIZE(MEDIUM)
 

--- a/ydb/tests/stress/olap_workload/tests/ya.make
+++ b/ydb/tests/stress/olap_workload/tests/ya.make
@@ -9,7 +9,7 @@ TEST_SRCS(
 
 REQUIREMENTS(ram:48)
 
-SIZE(MEDIUM)
+SIZE(LARGE)
 
 DEPENDS(
     ydb/tests/stress/olap_workload


### PR DESCRIPTION
### Changelog category <!-- remove all except one -->

* Not for changelog (changelog entry is not required)

### Description for reviewers <!-- (optional) description for those who read this PR -->

Added more RAM to olap workload test to fix [fails in A](https://nda.ya.ru/t/KWhEZe-f7JEVKT)
