### PR TITLE
restrict database nodes for databases whiteboard queries

### DIFF
--- a/ydb/core/viewer/wb_req.h
+++ b/ydb/core/viewer/wb_req.h
@@ -98,7 +98,6 @@ public:
                      RequestSettings.FilterNodeIds.end(),
                      (ui32)0,
                      TlsActivationContext->ActorSystem()->NodeId);
-
         TBase::InitConfig(RequestSettings);
         Request = BuildRequest();
         if (RequestSettings.FilterNodeIds.empty()) {


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

restrict database nodes for databases whiteboard queries
it's needed so databases users couldn't get information about storage nodes, for example

### Changelog category <!-- remove all except one -->

* Not for changelog (changelog entry is not required)

### Description for reviewers <!-- (optional) description for those who read this PR -->

...
